### PR TITLE
kernel: reformat src/vec{8bit,gf2}.{c,h}

### DIFF
--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -39,17 +39,16 @@
 **  The 1st 4 bytes  stores the actual vector length (in field elements)
 **  as a C integer. The 2nd component stores the field size as a C integer
 **  The data bytes begin at the 3rd component.
-**  
+**
 **  In addition, this file defines format and access for the fieldinfo
 **  objects which contain the meat-axe tables for the arithmetics.
 **
 **  There is a special representation for matrices, all of whose rows
 **  are immutable packed GFQ vectors over the same q, which is a positional
-**  representation Is8BitMatrixRep. Some special methods for such matrices 
+**  representation Is8BitMatrixRep. Some special methods for such matrices
 **  are included here.
-** 
+**
 */
-
 
 
 /****************************************************************************
@@ -62,7 +61,6 @@
 Obj IsVec8bitRep;
 
 
-
 /****************************************************************************
 **
 *V  FieldInfo8Bit . .  . . . . . . . . .plain list (length 256) of field info
@@ -71,9 +69,6 @@ Obj IsVec8bitRep;
 */
 
 static Obj FieldInfo8Bit;
-
-
-
 
 
 /****************************************************************************
@@ -91,34 +86,35 @@ Obj TYPES_VEC8BIT;
 Obj TYPE_VEC8BIT;
 Obj TYPE_VEC8BIT_LOCKED;
 
-Obj TypeVec8Bit( UInt q, UInt mut)
+Obj TypeVec8Bit(UInt q, UInt mut)
 {
-  UInt col = mut ? 1 : 2;
-  Obj type;
+    UInt col = mut ? 1 : 2;
+    Obj  type;
 #ifdef HPCGAP
-  type = ELM0_LIST(ELM_PLIST(TYPES_VEC8BIT, col),q);
+    type = ELM0_LIST(ELM_PLIST(TYPES_VEC8BIT, col), q);
 #else
-  type = ELM_PLIST(ELM_PLIST(TYPES_VEC8BIT, col),q);
+    type = ELM_PLIST(ELM_PLIST(TYPES_VEC8BIT, col), q);
 #endif
-  if (type == 0)
-    return CALL_2ARGS(TYPE_VEC8BIT, INTOBJ_INT(q), mut ? True: False);
-  else
-    return type;
+    if (type == 0)
+        return CALL_2ARGS(TYPE_VEC8BIT, INTOBJ_INT(q), mut ? True : False);
+    else
+        return type;
 }
 
-Obj TypeVec8BitLocked( UInt q, UInt mut)
+Obj TypeVec8BitLocked(UInt q, UInt mut)
 {
-  UInt col = mut ? 3 : 4;
-  Obj type;
+    UInt col = mut ? 3 : 4;
+    Obj  type;
 #ifdef HPCGAP
-  type = ELM0_LIST(ELM_PLIST(TYPES_VEC8BIT, col),q);
+    type = ELM0_LIST(ELM_PLIST(TYPES_VEC8BIT, col), q);
 #else
-  type = ELM_PLIST(ELM_PLIST(TYPES_VEC8BIT, col),q);
+    type = ELM_PLIST(ELM_PLIST(TYPES_VEC8BIT, col), q);
 #endif
-  if (type == 0)
-    return CALL_2ARGS(TYPE_VEC8BIT_LOCKED, INTOBJ_INT(q), mut ? True : False);
-  else
-    return type;
+    if (type == 0)
+        return CALL_2ARGS(TYPE_VEC8BIT_LOCKED, INTOBJ_INT(q),
+                          mut ? True : False);
+    else
+        return type;
 }
 
 /****************************************************************************
@@ -129,19 +125,19 @@ Obj TypeVec8BitLocked( UInt q, UInt mut)
 Obj TYPES_MAT8BIT;
 Obj TYPE_MAT8BIT;
 
-Obj TypeMat8Bit( UInt q, UInt mut)
+Obj TypeMat8Bit(UInt q, UInt mut)
 {
-  UInt col = mut ? 1 : 2;
-  Obj type;
+    UInt col = mut ? 1 : 2;
+    Obj  type;
 #ifdef HPCGAP
-  type = ELM0_LIST(ELM0_LIST(TYPES_MAT8BIT, col),q);
+    type = ELM0_LIST(ELM0_LIST(TYPES_MAT8BIT, col), q);
 #else
-  type = ELM_PLIST(ELM_PLIST(TYPES_MAT8BIT, col),q);
+    type = ELM_PLIST(ELM_PLIST(TYPES_MAT8BIT, col), q);
 #endif
-  if (type == 0)
-    return CALL_2ARGS(TYPE_MAT8BIT, INTOBJ_INT(q), mut ? True: False);
-  else
-    return type;
+    if (type == 0)
+        return CALL_2ARGS(TYPE_MAT8BIT, INTOBJ_INT(q), mut ? True : False);
+    else
+        return type;
 }
 
 
@@ -150,16 +146,17 @@ Obj TypeMat8Bit( UInt q, UInt mut)
 *V  TYPE_FIELDINFO_8BIT
 **
 **  A type of data object with essentially no GAP visible semantics at all
-**  
+**
 */
 
 Obj TYPE_FIELDINFO_8BIT;
 
 
-#define SIZE_VEC8BIT(len,elts) (3*sizeof(UInt)+((len)+(elts)-1)/(elts))
+#define SIZE_VEC8BIT(len, elts)                                              \
+    (3 * sizeof(UInt) + ((len) + (elts)-1) / (elts))
 
 /****************************************************************************
-**                    
+**
 *V  GetFieldInfo( <q> ) . .make or recover the meataxe table for a field
 **                         always call this, as the tables are lost by
 **                         save/restore. It's very cheap if the table already
@@ -168,110 +165,116 @@ Obj TYPE_FIELDINFO_8BIT;
 */
 
 
-static const UInt1 GF4Lookup[] =  {0,2,1,3};
-static const UInt1 GF8Lookup[] =  {0, 4, 2, 1, 6, 3, 7, 5};
+static const UInt1 GF4Lookup[] = { 0, 2, 1, 3 };
+static const UInt1 GF8Lookup[] = { 0, 4, 2, 1, 6, 3, 7, 5 };
 
-static const UInt1 GF16Lookup[] = {0, 8, 4, 2, 1, 12, 6, 3, 13, 10, 5,
-14, 7, 15, 11, 9};
+static const UInt1 GF16Lookup[] = { 0,  8,  4, 2,  1, 12, 6,  3,
+                                    13, 10, 5, 14, 7, 15, 11, 9 };
 
-static const UInt1 GF32Lookup[] = {0, 16, 8, 4, 2, 1, 20, 10, 5, 22,
-11, 17, 28, 14, 7, 23, 31, 27, 25, 24, 12, 6, 3, 21, 30, 15, 19, 29,
-26, 13, 18, 9};
+static const UInt1 GF32Lookup[] = { 0,  16, 8,  4,  2,  1,  20, 10,
+                                    5,  22, 11, 17, 28, 14, 7,  23,
+                                    31, 27, 25, 24, 12, 6,  3,  21,
+                                    30, 15, 19, 29, 26, 13, 18, 9 };
 
-static const UInt1 GF64Lookup[] = { 0, 32, 16, 8, 4, 2, 1, 54, 27, 59,
-43, 35, 39, 37, 36, 18, 9, 50, 25, 58, 29, 56, 28, 14, 7, 53, 44, 22,
-11, 51, 47, 33, 38, 19, 63, 41, 34, 17, 62, 31, 57, 42, 21, 60, 30,
-15, 49, 46, 23, 61, 40, 20, 10, 5, 52, 26, 13, 48, 24, 12, 6, 3, 55,
-45 };
+static const UInt1 GF64Lookup[] = {
+    0,  32, 16, 8,  4,  2,  1,  54, 27, 59, 43, 35, 39, 37, 36, 18,
+    9,  50, 25, 58, 29, 56, 28, 14, 7,  53, 44, 22, 11, 51, 47, 33,
+    38, 19, 63, 41, 34, 17, 62, 31, 57, 42, 21, 60, 30, 15, 49, 46,
+    23, 61, 40, 20, 10, 5,  52, 26, 13, 48, 24, 12, 6,  3,  55, 45
+};
 
-static const UInt1 GF128Lookup[] = { 0, 64, 32, 16, 8, 4, 2, 1, 96,
-48, 24, 12, 6, 3, 97, 80, 40, 20, 10, 5, 98, 49, 120, 60, 30, 15, 103,
-83, 73, 68, 34, 17, 104, 52, 26, 13, 102, 51, 121, 92, 46, 23, 107,
-85, 74, 37, 114, 57, 124, 62, 31, 111, 87, 75, 69, 66, 33, 112, 56,
-28, 14, 7, 99, 81, 72, 36, 18, 9, 100, 50, 25, 108, 54, 27, 109, 86,
-43, 117, 90, 45, 118, 59, 125, 94, 47, 119, 91, 77, 70, 35, 113, 88,
-44, 22, 11, 101, 82, 41, 116, 58, 29, 110, 55, 123, 93, 78, 39, 115,
-89, 76, 38, 19, 105, 84, 42, 21, 106, 53, 122, 61, 126, 63, 127, 95,
-79, 71, 67, 65 };
+static const UInt1 GF128Lookup[] = {
+    0,   64,  32,  16,  8,  4,   2,   1,   96,  48, 24,  12,  6,   3,   97,
+    80,  40,  20,  10,  5,  98,  49,  120, 60,  30, 15,  103, 83,  73,  68,
+    34,  17,  104, 52,  26, 13,  102, 51,  121, 92, 46,  23,  107, 85,  74,
+    37,  114, 57,  124, 62, 31,  111, 87,  75,  69, 66,  33,  112, 56,  28,
+    14,  7,   99,  81,  72, 36,  18,  9,   100, 50, 25,  108, 54,  27,  109,
+    86,  43,  117, 90,  45, 118, 59,  125, 94,  47, 119, 91,  77,  70,  35,
+    113, 88,  44,  22,  11, 101, 82,  41,  116, 58, 29,  110, 55,  123, 93,
+    78,  39,  115, 89,  76, 38,  19,  105, 84,  42, 21,  106, 53,  122, 61,
+    126, 63,  127, 95,  79, 71,  67,  65
+};
 
-static const UInt1 GF256Lookup[] = { 0, 128, 64, 32, 16, 8, 4, 2, 1,
-184, 92, 46, 23, 179, 225, 200, 100, 50, 25, 180, 90, 45, 174, 87,
-147, 241, 192, 96, 48, 24, 12, 6, 3, 185, 228, 114, 57, 164, 82, 41,
-172, 86, 43, 173, 238, 119, 131, 249, 196, 98, 49, 160, 80, 40, 20,
-10, 5, 186, 93, 150, 75, 157, 246, 123, 133, 250, 125, 134, 67, 153,
-244, 122, 61, 166, 83, 145, 240, 120, 60, 30, 15, 191, 231, 203, 221,
-214, 107, 141, 254, 127, 135, 251, 197, 218, 109, 142, 71, 155, 245,
-194, 97, 136, 68, 34, 17, 176, 88, 44, 22, 11, 189, 230, 115, 129,
-248, 124, 62, 31, 183, 227, 201, 220, 110, 55, 163, 233, 204, 102, 51,
-161, 232, 116, 58, 29, 182, 91, 149, 242, 121, 132, 66, 33, 168, 84,
-42, 21, 178, 89, 148, 74, 37, 170, 85, 146, 73, 156, 78, 39, 171, 237,
-206, 103, 139, 253, 198, 99, 137, 252, 126, 63, 167, 235, 205, 222,
-111, 143, 255, 199, 219, 213, 210, 105, 140, 70, 35, 169, 236, 118,
-59, 165, 234, 117, 130, 65, 152, 76, 38, 19, 177, 224, 112, 56, 28,
-14, 7, 187, 229, 202, 101, 138, 69, 154, 77, 158, 79, 159, 247, 195,
-217, 212, 106, 53, 162, 81, 144, 72, 36, 18, 9, 188, 94, 47, 175, 239,
-207, 223, 215, 211, 209, 208, 104, 52, 26, 13, 190, 95, 151, 243, 193,
-216, 108, 54, 27, 181, 226, 113};
+static const UInt1 GF256Lookup[] = {
+    0,   128, 64,  32,  16,  8,   4,   2,   1,   184, 92,  46,  23,  179, 225,
+    200, 100, 50,  25,  180, 90,  45,  174, 87,  147, 241, 192, 96,  48,  24,
+    12,  6,   3,   185, 228, 114, 57,  164, 82,  41,  172, 86,  43,  173, 238,
+    119, 131, 249, 196, 98,  49,  160, 80,  40,  20,  10,  5,   186, 93,  150,
+    75,  157, 246, 123, 133, 250, 125, 134, 67,  153, 244, 122, 61,  166, 83,
+    145, 240, 120, 60,  30,  15,  191, 231, 203, 221, 214, 107, 141, 254, 127,
+    135, 251, 197, 218, 109, 142, 71,  155, 245, 194, 97,  136, 68,  34,  17,
+    176, 88,  44,  22,  11,  189, 230, 115, 129, 248, 124, 62,  31,  183, 227,
+    201, 220, 110, 55,  163, 233, 204, 102, 51,  161, 232, 116, 58,  29,  182,
+    91,  149, 242, 121, 132, 66,  33,  168, 84,  42,  21,  178, 89,  148, 74,
+    37,  170, 85,  146, 73,  156, 78,  39,  171, 237, 206, 103, 139, 253, 198,
+    99,  137, 252, 126, 63,  167, 235, 205, 222, 111, 143, 255, 199, 219, 213,
+    210, 105, 140, 70,  35,  169, 236, 118, 59,  165, 234, 117, 130, 65,  152,
+    76,  38,  19,  177, 224, 112, 56,  28,  14,  7,   187, 229, 202, 101, 138,
+    69,  154, 77,  158, 79,  159, 247, 195, 217, 212, 106, 53,  162, 81,  144,
+    72,  36,  18,  9,   188, 94,  47,  175, 239, 207, 223, 215, 211, 209, 208,
+    104, 52,  26,  13,  190, 95,  151, 243, 193, 216, 108, 54,  27,  181, 226,
+    113
+};
 
-static const UInt1 PbyQ[] = { 0, 1, 2, 3, 2, 5, 0, 7, 2, 3, 0, 11, 0,
-13, 0, 0, 2, 17, 0, 19, 0, 0, 0, 23, 0, 5, 0, 3, 0, 29, 0, 31, 2, 0,
-0, 0, 0, 37, 0, 0, 0, 41, 0, 43, 0, 0, 0, 47, 0, 7, 0, 0, 0, 53, 0, 0,
-0, 0, 0, 59, 0, 61, 0, 0, 2, 0, 0, 67, 0, 0, 0, 71, 0, 73, 0, 0, 0, 0,
-0, 79, 0, 3, 0, 83, 0, 0, 0, 0, 0, 89, 0, 0, 0, 0, 0, 0, 0, 97, 0, 0,
-0, 101, 0, 103, 0, 0, 0, 107, 0, 109, 0, 0, 0, 113, 0, 0, 0, 0, 0, 0,
-0, 11, 0, 0, 0, 5, 0, 127, 2, 0, 0, 131, 0, 0, 0, 0, 0, 137, 0, 139,
-0, 0, 0, 0, 0, 0, 0, 0, 0, 149, 0, 151, 0, 0, 0, 0, 0, 157, 0, 0, 0,
-0, 0, 163, 0, 0, 0, 167, 0, 13, 0, 0, 0, 173, 0, 0, 0, 0, 0, 179, 0,
-181, 0, 0, 0, 0, 0, 0, 0, 0, 0, 191, 0, 193, 0, 0, 0, 197, 0, 199, 0,
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 211, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-223, 0, 0, 0, 227, 0, 229, 0, 0, 0, 233, 0, 0, 0, 0, 0, 239, 0, 241,
-0, 3, 0, 0, 0, 0, 0, 0, 0, 251, 0, 0, 0, 0, 2 };
+static const UInt1 PbyQ[] = {
+    0, 1,   2, 3, 2, 5,   0, 7,   2, 3, 0, 11,  0, 13,  0, 0, 2, 17,
+    0, 19,  0, 0, 0, 23,  0, 5,   0, 3, 0, 29,  0, 31,  2, 0, 0, 0,
+    0, 37,  0, 0, 0, 41,  0, 43,  0, 0, 0, 47,  0, 7,   0, 0, 0, 53,
+    0, 0,   0, 0, 0, 59,  0, 61,  0, 0, 2, 0,   0, 67,  0, 0, 0, 71,
+    0, 73,  0, 0, 0, 0,   0, 79,  0, 3, 0, 83,  0, 0,   0, 0, 0, 89,
+    0, 0,   0, 0, 0, 0,   0, 97,  0, 0, 0, 101, 0, 103, 0, 0, 0, 107,
+    0, 109, 0, 0, 0, 113, 0, 0,   0, 0, 0, 0,   0, 11,  0, 0, 0, 5,
+    0, 127, 2, 0, 0, 131, 0, 0,   0, 0, 0, 137, 0, 139, 0, 0, 0, 0,
+    0, 0,   0, 0, 0, 149, 0, 151, 0, 0, 0, 0,   0, 157, 0, 0, 0, 0,
+    0, 163, 0, 0, 0, 167, 0, 13,  0, 0, 0, 173, 0, 0,   0, 0, 0, 179,
+    0, 181, 0, 0, 0, 0,   0, 0,   0, 0, 0, 191, 0, 193, 0, 0, 0, 197,
+    0, 199, 0, 0, 0, 0,   0, 0,   0, 0, 0, 0,   0, 211, 0, 0, 0, 0,
+    0, 0,   0, 0, 0, 0,   0, 223, 0, 0, 0, 227, 0, 229, 0, 0, 0, 233,
+    0, 0,   0, 0, 0, 239, 0, 241, 0, 3, 0, 0,   0, 0,   0, 0, 0, 251,
+    0, 0,   0, 0, 2
+};
 
-static const UInt1 DbyQ[] = { 0, 1, 1, 1, 2, 1, 0, 1, 3, 2, 0, 1, 0,
-1, 0, 0, 4, 1, 0, 1, 0, 0, 0, 1, 0, 2, 0, 3, 0, 1, 0, 1, 5, 0, 0, 0,
-0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0,
-1, 0, 1, 0, 0, 6, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 4,
-0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0,
-0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 1,
-7, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
-1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0, 0, 0, 1,
-0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0,
-1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0,
-5, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 8};
-
+static const UInt1 DbyQ[] = {
+    0, 1, 1, 1, 2, 1, 0, 1, 3, 2, 0, 1, 0, 1, 0, 0, 4, 1, 0, 1, 0, 0, 0, 1,
+    0, 2, 0, 3, 0, 1, 0, 1, 5, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1,
+    0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 6, 0, 0, 1, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 0, 0, 1, 0, 4, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+    0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+    0, 2, 0, 0, 0, 3, 0, 1, 7, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1,
+    0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1,
+    0, 1, 0, 5, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 8
+};
 
 
 static const UInt1 * Char2Lookup[9] = {
-  0L, 0L,
-  GF4Lookup,
-  GF8Lookup,
-  GF16Lookup,
-  GF32Lookup,
-  GF64Lookup,
-  GF128Lookup,
-  GF256Lookup};
+    0L,         0L,         GF4Lookup,   GF8Lookup,  GF16Lookup,
+    GF32Lookup, GF64Lookup, GF128Lookup, GF256Lookup
+};
 
 
-void MakeFieldInfo8Bit( UInt q)
+void MakeFieldInfo8Bit(UInt q)
 {
-    FF   gfq;     // the field 
-    UInt p;     // characteristic 
-    UInt d;     // degree 
-    UInt i, j, k, l;  // loop variables 
-    UInt e;     // number of elements per byte 
-    UInt size;      // data structure size 
-    UInt pows[7];     // table of powers of q for packing and unpacking bytes
-    Obj info;     // The table being constructed 
-    FFV mult;     // multiplier for scalar product 
-    FFV prod;     // used in scalar product 
-    UInt val;                     // used to build up some answers 
+    FF   gfq;           // the field
+    UInt p;             // characteristic
+    UInt d;             // degree
+    UInt i, j, k, l;    // loop variables
+    UInt e;             // number of elements per byte
+    UInt size;          // data structure size
+    UInt pows[7];    // table of powers of q for packing and unpacking bytes
+    Obj  info;       // The table being constructed
+    FFV  mult;       // multiplier for scalar product
+    FFV  prod;       // used in scalar product
+    UInt val;        // used to build up some answers
     UInt val0;
-    UInt elt, el1, el2;           // used to build up some answers 
-    const FFV *succ;
-    UInt1* setelt_info; // Cache a value, mainly to get around a bug in xcode 5.0 
-    UInt1* getelt_info; // ditto 
-    Int iej_cache;      // ditto 
+    UInt elt, el1, el2;    // used to build up some answers
+    const FFV * succ;
+    UInt1 * setelt_info;    // Cache a value, mainly to get around a bug in
+                            // xcode 5.0
+    UInt1 * getelt_info;    // ditto
+    Int     iej_cache;      // ditto
 
 
     p = (UInt)PbyQ[q];
@@ -280,30 +283,31 @@ void MakeFieldInfo8Bit( UInt q)
     e = 0;
     for (i = 1; i <= 256; i *= q)
         pows[e++] = i;
-    pows[e] = i;    // simplifies things to have one more 
+    pows[e] = i;    // simplifies things to have one more
     e--;
 
-    size = sizeof(Obj) +   // type 
-          sizeof(Obj) +   // q 
-          sizeof(Obj) +   // p 
-          sizeof(Obj) +   // d 
-          sizeof(Obj) +   // els per byte 
-          q * sizeof(Obj) +           // position in GAP < order  by number 
-          q * sizeof(Obj) +           // numbering from FFV 
-          q * sizeof(Obj) + // immediate FFE by number 
-          256 * q * e + // set element lookup 
-          256 * e +   // get element lookup 
-          256 * q +   // scalar multiply 
-          2 * 256 * 256 + // inner product, 1 lot of polynomial multiply data 
-          ((e == 1) ? 0 : (256 * 256)) + // the other lot of polynomial data 
-          ((p == 2) ? 0 : (256 * 256)); // add byte 
+    size =
+        sizeof(Obj) +        // type
+        sizeof(Obj) +        // q
+        sizeof(Obj) +        // p
+        sizeof(Obj) +        // d
+        sizeof(Obj) +        // els per byte
+        q * sizeof(Obj) +    // position in GAP < order  by number
+        q * sizeof(Obj) +    // numbering from FFV
+        q * sizeof(Obj) +    // immediate FFE by number
+        256 * q * e +        // set element lookup
+        256 * e +            // get element lookup
+        256 * q +            // scalar multiply
+        2 * 256 * 256 +    // inner product, 1 lot of polynomial multiply data
+        ((e == 1) ? 0 : (256 * 256)) +    // the other lot of polynomial data
+        ((p == 2) ? 0 : (256 * 256));     // add byte
 
     info = NewWordSizedBag(T_DATOBJ, size);
     SetTypeDatObj(info, TYPE_FIELDINFO_8BIT);
 
     succ = SUCC_FF(gfq);
 
-    // from here to the end, no garbage collections should happen 
+    // from here to the end, no garbage collections should happen
     SET_Q_FIELDINFO_8BIT(info, q);
     SET_P_FIELDINFO_8BIT(info, p);
     SET_D_FIELDINFO_8BIT(info, d);
@@ -321,40 +325,41 @@ void MakeFieldInfo8Bit( UInt q)
         for (i = 0; i < q; i++)
             FELT_FFE_FIELDINFO_8BIT(info)[i] = Char2Lookup[d][i];
 
-    // simply invert the permutation to get the other one 
+    // simply invert the permutation to get the other one
     for (i = 0; i < q; i++) {
         j = FELT_FFE_FIELDINFO_8BIT(info)[i];
         SET_FFE_FELT_FIELDINFO_8BIT(info, j, NEW_FFE(gfq, i));
     }
 
-    // Now we need to store the position in Elements(GF(q)) of each field element
-    // for the sake of NumberFFVector
-    // 
+    // Now we need to store the position in Elements(GF(q)) of each field
+    // element for the sake of NumberFFVector
+    //
     // The rules for < between finite field elements make this a bit
     // complex for non-prime fields
 
-    // deal with zero and one 
+    // deal with zero and one
     SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, 0, INTOBJ_INT(0));
     SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, FELT_FFE_FIELDINFO_8BIT(info)[1],
-        INTOBJ_INT(1));
+                                   INTOBJ_INT(1));
 
     if (q != 2) {
         if (d == 1)
             for (i = 2; i < q; i++)
                 SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, i, INTOBJ_INT(i));
         else {
-            // run through subfields, filling in entry for all the new elements
-            // of each field in turn
+            // run through subfields, filling in entry for all the new
+            // elements of each field in turn
             UInt q1 = 1;
             UInt pos = 2;
             for (i = 1; i <= d; i++) {
                 q1 *= p;
                 if (d % i == 0) {
                     for (j = 2; j < q1; j++) {
-                        UInt place = FELT_FFE_FIELDINFO_8BIT(info)[1 + (j - 1) * (q - 1) / (q1 - 1)];
+                        UInt place = FELT_FFE_FIELDINFO_8BIT(
+                            info)[1 + (j - 1) * (q - 1) / (q1 - 1)];
                         if (GAPSEQ_FELT_FIELDINFO_8BIT(info)[place] == 0) {
                             SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, place,
-                                INTOBJ_INT(pos));
+                                                           INTOBJ_INT(pos));
                             pos++;
                         }
                     }
@@ -369,12 +374,12 @@ void MakeFieldInfo8Bit( UInt q)
     // entry setting table SETELT...[(i*e+j)*256 +k] is the result
     // of overwriting the jth element with i in the byte k
     for (i = 0; i < q; i++)
-        for (j = 0; j < e; j++)
-        {
+        for (j = 0; j < e; j++) {
             iej_cache = (i * e + j) * 256;
             for (k = 0; k < 256; k++)
-                setelt_info[iej_cache + k] = (UInt1)
-                        ((k / pows[j + 1]) * pows[j + 1] + i*pows[j] + (k % pows[j]));
+                setelt_info[iej_cache + k] =
+                    (UInt1)((k / pows[j + 1]) * pows[j + 1] + i * pows[j] +
+                            (k % pows[j]));
         }
 
     // entry access GETELT...[i*256+j] recovers the ith entry from the
@@ -389,9 +394,9 @@ void MakeFieldInfo8Bit( UInt q)
         mult = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)[i]);
         for (j = 0; j < 256; j++) {
             val = 0;
-            for (k  = 0; k < e; k++) {
-                elt = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                              [getelt_info[k * 256 + j]]);
+            for (k = 0; k < e; k++) {
+                elt = VAL_FFE(
+                    FFE_FELT_FIELDINFO_8BIT(info)[getelt_info[k * 256 + j]]);
                 prod = PROD_FFV(elt, mult, succ);
                 val += pows[k] * FELT_FFE_FIELDINFO_8BIT(info)[prod];
             }
@@ -399,16 +404,16 @@ void MakeFieldInfo8Bit( UInt q)
         }
     }
 
-    // inner product INNER...[i+256*j] is a byte whose LS entry is the contribution
-    // to the inner product of bytes i and j
+    // inner product INNER...[i+256*j] is a byte whose LS entry is the
+    // contribution to the inner product of bytes i and j
     for (i = 0; i < 256; i++)
         for (j = i; j < 256; j++) {
             val = 0;
             for (k = 0; k < e; k++) {
-                el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                              [getelt_info[k * 256 + i]]);
-                el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                              [getelt_info[k * 256 + j]]);
+                el1 = VAL_FFE(
+                    FFE_FELT_FIELDINFO_8BIT(info)[getelt_info[k * 256 + i]]);
+                el2 = VAL_FFE(
+                    FFE_FELT_FIELDINFO_8BIT(info)[getelt_info[k * 256 + j]]);
                 elt = PROD_FFV(el1, el2, succ);
                 val = SUM_FFV(val, elt, succ);
             }
@@ -425,10 +430,10 @@ void MakeFieldInfo8Bit( UInt q)
             for (k = 0; k < e; k++) {
                 val = 0;
                 for (l = 0; l <= k; l++) {
-                    el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                                  [getelt_info[l * 256 + i]]);
-                    el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                                  [getelt_info[(k - l) * 256 + j]]);
+                    el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(
+                        info)[getelt_info[l * 256 + i]]);
+                    el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(
+                        info)[getelt_info[(k - l) * 256 + j]]);
                     elt = PROD_FFV(el1, el2, succ);
                     val = SUM_FFV(val, elt, succ);
                 }
@@ -437,16 +442,17 @@ void MakeFieldInfo8Bit( UInt q)
             PMULL_FIELDINFO_8BIT(info)[i + 256 * j] = val0;
             PMULL_FIELDINFO_8BIT(info)[j + 256 * i] = val0;
 
-            // if there is just one entry per byte then we don't need the upper half 
+            // if there is just one entry per byte then we don't need the
+            // upper half
             if (ELS_BYTE_FIELDINFO_8BIT(info) > 1) {
                 val0 = 0;
                 for (k = e; k < 2 * e - 1; k++) {
                     val = 0;
                     for (l = k - e + 1; l < e; l++) {
-                        el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                                      [getelt_info[l * 256 + i]]);
-                        el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                                      [getelt_info[(k - l) * 256 + j]]);
+                        el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(
+                            info)[getelt_info[l * 256 + i]]);
+                        el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(
+                            info)[getelt_info[(k - l) * 256 + j]]);
                         elt = PROD_FFV(el1, el2, succ);
                         val = SUM_FFV(val, elt, succ);
                     }
@@ -465,12 +471,12 @@ void MakeFieldInfo8Bit( UInt q)
             for (j = i; j < 256; j++) {
                 val = 0;
                 for (k = 0; k < e; k++) {
-                    el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                                  [getelt_info[k * 256 + i]]);
-                    el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)
-                                  [getelt_info[k * 256 + j]]);
-                    val += pows[k] *
-                           FELT_FFE_FIELDINFO_8BIT(info)[SUM_FFV(el1, el2, succ)];
+                    el1 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(
+                        info)[getelt_info[k * 256 + i]]);
+                    el2 = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(
+                        info)[getelt_info[k * 256 + j]]);
+                    val += pows[k] * FELT_FFE_FIELDINFO_8BIT(
+                                         info)[SUM_FFV(el1, el2, succ)];
                 }
                 ADD_FIELDINFO_8BIT(info)[i + 256 * j] = val;
                 ADD_FIELDINFO_8BIT(info)[j + 256 * i] = val;
@@ -481,7 +487,7 @@ void MakeFieldInfo8Bit( UInt q)
 #ifdef HPCGAP
     MakeBagReadOnly(info);
 #endif
-    // remember the result 
+    // remember the result
 #ifdef HPCGAP
     ATOMIC_SET_ELM_PLIST_ONCE(FieldInfo8Bit, q, info);
 #else
@@ -489,8 +495,8 @@ void MakeFieldInfo8Bit( UInt q)
 #endif
     CHANGED_BAG(FieldInfo8Bit);
 }
-     
-Obj GetFieldInfo8Bit( UInt q)
+
+Obj GetFieldInfo8Bit(UInt q)
 {
     Obj info;
     assert(2 < q && q <= 256);
@@ -509,33 +515,33 @@ Obj GetFieldInfo8Bit( UInt q)
 #endif
     return info;
 }
-  
+
 
 /****************************************************************************
 **
 *F  RewriteVec8Bit( <vec>, <q> ) . . . . . . . . . . rewrite <vec> over GF(q)
 **
 ** <vec> should be an 8 bit vector over a smaller field of the same
-** characteristic 
+** characteristic
 */
 
 static Obj IsLockedRepresentationVector;
 
-void RewriteVec8Bit( Obj vec, UInt q)
+void RewriteVec8Bit(Obj vec, UInt q)
 {
     UInt q1 = FIELD_VEC8BIT(vec);
-    Obj info, info1;
+    Obj  info, info1;
     UInt len;
     UInt els, els1;
-    //UInt mut = IS_MUTABLE_OBJ(vec); 
+    // UInt mut = IS_MUTABLE_OBJ(vec);
     UInt mult;
 
-    UInt1 *gettab1, byte1;
-    const UInt1 *ptr1;
-    UInt1 *settab, *ptr, byte;
-    UInt1 * convtab;
-    const Obj *convtab1;
-    FFV val;
+    UInt1 *       gettab1, byte1;
+    const UInt1 * ptr1;
+    UInt1 *       settab, *ptr, byte;
+    UInt1 *       convtab;
+    const Obj *   convtab1;
+    FFV           val;
 
     Int i;
 
@@ -544,12 +550,13 @@ void RewriteVec8Bit( Obj vec, UInt q)
     assert(q > q1);
 
     if (DoFilter(IsLockedRepresentationVector, vec) == True) {
-        ErrorMayQuit("You cannot convert a locked vector compressed over GF(%i) to GF(%i)",
-        q1, q);
+        ErrorMayQuit("You cannot convert a locked vector compressed over "
+                     "GF(%i) to GF(%i)",
+                     q1, q);
         return;
     }
 
-    // extract the required info 
+    // extract the required info
     len = LEN_VEC8BIT(vec);
     info = GetFieldInfo8Bit(q);
     info1 = GetFieldInfo8Bit(q1);
@@ -563,7 +570,7 @@ void RewriteVec8Bit( Obj vec, UInt q)
         return;
     }
 
-    // enlarge the bag 
+    // enlarge the bag
     ResizeWordSizedBag(vec, SIZE_VEC8BIT(len, els));
 
     gettab1 = GETELT_FIELDINFO_8BIT(info1);
@@ -579,10 +586,10 @@ void RewriteVec8Bit( Obj vec, UInt q)
     assert(((q - 1) % (q1 - 1)) == 0);
     mult = (q - 1) / (q1 - 1);
     while (i >= 0) {
-        val = VAL_FFE(convtab1[ gettab1[byte1 + 256 * (i % els1)]]);
+        val = VAL_FFE(convtab1[gettab1[byte1 + 256 * (i % els1)]]);
         if (val != 0)
             val = 1 + (val - 1) * mult;
-        byte = settab[ byte + 256 * (i % els + els * convtab[ val ])];
+        byte = settab[byte + 256 * (i % els + els * convtab[val])];
         if (0 == i % els) {
             *ptr-- = byte;
             byte = 0;
@@ -603,34 +610,35 @@ void RewriteVec8Bit( Obj vec, UInt q)
 ** This function uses the interface in vecgf2.h
 */
 
-void RewriteGF2Vec( Obj vec, UInt q )
+void RewriteGF2Vec(Obj vec, UInt q)
 {
-    Obj info;
-    UInt len;
-    UInt els;
-    UInt mut = IS_MUTABLE_OBJ(vec);
-    const UInt *ptr1;
-    UInt block;
-    UInt1 *settab, *ptr, byte;
-    UInt1 *convtab;
-    UInt1 zero, one;
-    Int i;
-    Obj type;
+    Obj          info;
+    UInt         len;
+    UInt         els;
+    UInt         mut = IS_MUTABLE_OBJ(vec);
+    const UInt * ptr1;
+    UInt         block;
+    UInt1 *      settab, *ptr, byte;
+    UInt1 *      convtab;
+    UInt1        zero, one;
+    Int          i;
+    Obj          type;
 
     assert(q % 2 == 0);
 
     if (DoFilter(IsLockedRepresentationVector, vec) == True) {
-        ErrorMayQuit("You cannot convert a locked vector compressed over GF(2) to GF(%i)",
-        q, 0);
+        ErrorMayQuit("You cannot convert a locked vector compressed over "
+                     "GF(2) to GF(%i)",
+                     q, 0);
         return;
     }
 
-    // extract the required info 
+    // extract the required info
     len = LEN_GF2VEC(vec);
     info = GetFieldInfo8Bit(q);
     els = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    // enlarge the bag 
+    // enlarge the bag
     ResizeWordSizedBag(vec, SIZE_VEC8BIT(len, els));
 
     settab = SETELT_FIELDINFO_8BIT(info);
@@ -644,7 +652,10 @@ void RewriteGF2Vec( Obj vec, UInt q )
     i = len - 1;
 
     while (i >= 0) {
-        byte = settab[ byte + 256 * (i % els + els * ((block & MASK_POS_GF2VEC(i + 1)) ? one : zero))];
+        byte = settab[byte +
+                      256 * (i % els + els * ((block & MASK_POS_GF2VEC(i + 1))
+                                                  ? one
+                                                  : zero))];
         if (0 == i % els) {
             *ptr-- = byte;
             byte = 0;
@@ -665,35 +676,33 @@ void RewriteGF2Vec( Obj vec, UInt q )
 *F  ConvVec8Bit( <list>, <q> )  . . .  convert a list into 8bit vector object
 */
 
-void ConvVec8Bit (
-    Obj                 list,
-    UInt                q)
+void ConvVec8Bit(Obj list, UInt q)
 {
-    Int                 len;            // logical length of the vector    
-    Int                 i;              // loop variable                   
-    UInt                p;  // char 
-    UInt                d;  // degree 
-    FF                  f;  // field 
-    Obj                 info; // field info object 
-    UInt                elts; // elements per byte 
-    UInt1 *             settab; // element setting table 
-    UInt1 *             convtab; // FFE -> FELT conversion table 
-    Obj                 firstthree[3]; // the first three entries may get clobbered my the early bytes
-    UInt                e;  // loop variable 
-    UInt1               byte; // byte under construction 
-    UInt1*              ptr;  // place to put byte 
-    Obj                elt;
-    UInt               val;
-    UInt               nsize;
-    Obj                type;
+    Int     len;          // logical length of the vector
+    Int     i;            // loop variable
+    UInt    p;            // char
+    UInt    d;            // degree
+    FF      f;            // field
+    Obj     info;         // field info object
+    UInt    elts;         // elements per byte
+    UInt1 * settab;       // element setting table
+    UInt1 * convtab;      // FFE -> FELT conversion table
+    Obj firstthree[3];    // the first three entries may get clobbered my the
+                          // early bytes
+    UInt    e;            // loop variable
+    UInt1   byte;         // byte under construction
+    UInt1 * ptr;          // place to put byte
+    Obj     elt;
+    UInt    val;
+    UInt    nsize;
+    Obj     type;
 
     if (q > 256)
-        ErrorQuit("Field size %d is too much for 8 bits\n",
-        q, 0L);
+        ErrorQuit("Field size %d is too much for 8 bits\n", q, 0L);
     if (q == 2)
         ErrorQuit("GF2 has its own representation\n", 0L, 0L);
 
-    // already in the correct representation                               
+    // already in the correct representation
     if (IS_VEC8BIT_REP(list)) {
         if (FIELD_VEC8BIT(list) == q)
             return;
@@ -703,15 +712,15 @@ void ConvVec8Bit (
         }
         // remaining case is list is written over too large a field
         // pass through to the generic code
-
-    } else if (IS_GF2VEC_REP(list)) {
+    }
+    else if (IS_GF2VEC_REP(list)) {
         RewriteGF2Vec(list, q);
         return;
     }
 
     len = LEN_LIST(list);
 
-    // OK, so now we know which field we want, set up data 
+    // OK, so now we know which field we want, set up data
     info = GetFieldInfo8Bit(q);
     p = P_FIELDINFO_8BIT(info);
     d = D_FIELDINFO_8BIT(info);
@@ -732,11 +741,11 @@ void ConvVec8Bit (
     firstthree[1] = ELM0_LIST(list, 2);
     firstthree[2] = ELM0_LIST(list, 3);
 
-    // main loop -- e is the element within byte 
+    // main loop -- e is the element within byte
     e = 0;
     byte = 0;
     ptr = BYTES_VEC8BIT(list);
-    for (i = 1;  i <= len;  i++) {
+    for (i = 1; i <= len; i++) {
         elt = (i <= 3) ? firstthree[i - 1] : ELM_LIST(list, i);
         assert(CHAR_FF(FLD_FFE(elt)) == p);
         assert(d % DegreeFFE(elt) == 0);
@@ -760,13 +769,13 @@ void ConvVec8Bit (
     // not zero, because they had data in them in the old version of the list
     // In most cases this doesn't matter, but in characteristic 2, we must
     // clear up to the end of the word, so that AddCoeffs behaves correctly.
-    // 
+    //
     // SL -- lets do this in all characteristics, it can never hurt
 
     while ((ptr - BYTES_VEC8BIT(list)) % sizeof(UInt))
         *ptr++ = 0;
 
-    // retype and resize bag 
+    // retype and resize bag
     if (nsize != SIZE_OBJ(list))
         ResizeWordSizedBag(list, nsize);
     SET_LEN_VEC8BIT(list, len);
@@ -782,7 +791,7 @@ void ConvVec8Bit (
 **
 */
 
-UInt LcmDegree( UInt d, UInt d1)
+UInt LcmDegree(UInt d, UInt d1)
 {
     UInt x, y, g;
     x = d;
@@ -797,17 +806,14 @@ UInt LcmDegree( UInt d, UInt d1)
         g = y;
     else
         g = x;
-    return (d*d1) / g;
+    return (d * d1) / g;
 }
 
 /****************************************************************************
 **
 *F  FuncCONV_VEC8BIT( <self>, <list> ) . . . . . convert into 8bit vector rep
 */
-Obj FuncCONV_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 q)
+Obj FuncCONV_VEC8BIT(Obj self, Obj list, Obj q)
 {
     RequirePositiveSmallInt("CONV_VEC8BIT", q, "q");
     ConvVec8Bit(list, INT_INTOBJ(q));
@@ -821,114 +827,105 @@ Obj FuncCONV_VEC8BIT (
 **  This is a non-destructive counterpart of ConvVec8Bit
 */
 
-Obj NewVec8Bit (
-    Obj                 list,
-    UInt                q)
+Obj NewVec8Bit(Obj list, UInt q)
 {
-    Int                 len;            // logical length of the vector    
-    Int                 i;              // loop variable                   
-    UInt                p;	// char 
-    UInt                d;	// degree 
-    FF                  f;	// field 
- // Obj                 x;	/ an element 
-    Obj                 info;	// field info object 
-    UInt                elts;	// elements per byte 
-    UInt1 *             settab;	// element setting table 
-    UInt1 *             convtab; // FFE -> FELT conversion table 
-    UInt                e;	// loop varibale 
-    UInt1               byte;	// byte under construction 
-    UInt1*              ptr;	// place to put byte 
-    Obj                 elt;
-    UInt                val;
-    UInt                nsize;
-    Obj                 type;
-    Obj                 res;            // resulting 8bit vector object     
+    Int  len;           // logical length of the vector
+    Int  i;             // loop variable
+    UInt p;             // char
+    UInt d;             // degree
+    FF   f;             // field
+                        // Obj                 x;	/ an element
+    Obj     info;       // field info object
+    UInt    elts;       // elements per byte
+    UInt1 * settab;     // element setting table
+    UInt1 * convtab;    // FFE -> FELT conversion table
+    UInt    e;          // loop varibale
+    UInt1   byte;       // byte under construction
+    UInt1 * ptr;        // place to put byte
+    Obj     elt;
+    UInt    val;
+    UInt    nsize;
+    Obj     type;
+    Obj     res;    // resulting 8bit vector object
 
-        
+
     if (q > 256)
-      ErrorQuit("Field size %d is too much for 8 bits\n", q, 0L);
+        ErrorQuit("Field size %d is too much for 8 bits\n", q, 0L);
     if (q == 2)
-      ErrorQuit("GF2 has its own representation\n", 0L, 0L);
+        ErrorQuit("GF2 has its own representation\n", 0L, 0L);
 
-    // already in the correct representation                               
-    if ( IS_VEC8BIT_REP(list) )
-      {
-	if( FIELD_VEC8BIT(list) == q ) 
-	  {
-	    res = CopyVec8Bit(list,1); 
-        if (!IS_MUTABLE_OBJ(list))
-          // index 0 is for immutable vectors    
-	  SetTypeDatObj( res, TypeVec8Bit( q, 0 ) );
-        return res;
-      }
-	else if ( FIELD_VEC8BIT(list) < q )
-	  {
-	    // rewriting to a larger field    
-        res = CopyVec8Bit(list,1);
-        RewriteVec8Bit(res,q);
-        // TODO: rework RewriteVec8Bit and avoid calling CopyVec8Bit 
-        if (!IS_MUTABLE_OBJ(list))
-          SetTypeDatObj( res, TypeVec8Bit( q, 0 ) );
-	    return res;
-	  }
-	// remaining case is list is written over too large a field
-	// pass through to the generic code
-
+    // already in the correct representation
+    if (IS_VEC8BIT_REP(list)) {
+        if (FIELD_VEC8BIT(list) == q) {
+            res = CopyVec8Bit(list, 1);
+            if (!IS_MUTABLE_OBJ(list))
+                // index 0 is for immutable vectors
+                SetTypeDatObj(res, TypeVec8Bit(q, 0));
+            return res;
+        }
+        else if (FIELD_VEC8BIT(list) < q) {
+            // rewriting to a larger field
+            res = CopyVec8Bit(list, 1);
+            RewriteVec8Bit(res, q);
+            // TODO: rework RewriteVec8Bit and avoid calling CopyVec8Bit
+            if (!IS_MUTABLE_OBJ(list))
+                SetTypeDatObj(res, TypeVec8Bit(q, 0));
+            return res;
+        }
+        // remaining case is list is written over too large a field
+        // pass through to the generic code
     }
-    else if ( IS_GF2VEC_REP(list) )
-      {
-        res = ShallowCopyVecGF2(list);  
+    else if (IS_GF2VEC_REP(list)) {
+        res = ShallowCopyVecGF2(list);
         RewriteGF2Vec(res, q);
-        // TODO: rework RewriteGF2Vec and avoid calling ShallowCopyVecGF2 
+        // TODO: rework RewriteGF2Vec and avoid calling ShallowCopyVecGF2
         if (!IS_MUTABLE_OBJ(list))
-          SetTypeDatObj( res, TypeVec8Bit( q, 0 ) );
-	    return res;
-      }
-    
-    // OK, so now we know which field we want, set up data 
+            SetTypeDatObj(res, TypeVec8Bit(q, 0));
+        return res;
+    }
+
+    // OK, so now we know which field we want, set up data
     info = GetFieldInfo8Bit(q);
     p = P_FIELDINFO_8BIT(info);
     d = D_FIELDINFO_8BIT(info);
-    f = FiniteField(p,d);
+    f = FiniteField(p, d);
 
-    // determine the size and create a new bag     
+    // determine the size and create a new bag
     len = LEN_LIST(list);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
-    nsize = SIZE_VEC8BIT(len,elts);
-    res = NewWordSizedBag( T_DATOBJ, nsize );
-    
-    // main loop -- e is the element within byte 
+    nsize = SIZE_VEC8BIT(len, elts);
+    res = NewWordSizedBag(T_DATOBJ, nsize);
+
+    // main loop -- e is the element within byte
     e = 0;
     byte = 0;
     ptr = BYTES_VEC8BIT(res);
-    for ( i = 1;  i <= len;  i++ ) {
-      elt = ELM_LIST(list,i);
-      assert(CHAR_FF(FLD_FFE(elt)) == p);
-      assert( d % DegreeFFE(elt) == 0);
-      val = VAL_FFE(elt);
-      if (val != 0 && FLD_FFE(elt) != f)
-	{
-	  val = 1+(val-1)*(q-1)/(SIZE_FF(FLD_FFE(elt))-1);
-	}
-      // Must get these afresh after every list access, just in case this is
-      // a virtual list whose accesses might cause a garbage collection
-      settab = SETELT_FIELDINFO_8BIT(info);
-      convtab = FELT_FFE_FIELDINFO_8BIT(info);
-      byte = settab[(e + elts*convtab[val])*256 + byte];
-      if (++e == elts || i == len)
-	{
-	  *ptr++ = byte;
-	  byte = 0;
-	  e = 0;
-	}
+    for (i = 1; i <= len; i++) {
+        elt = ELM_LIST(list, i);
+        assert(CHAR_FF(FLD_FFE(elt)) == p);
+        assert(d % DegreeFFE(elt) == 0);
+        val = VAL_FFE(elt);
+        if (val != 0 && FLD_FFE(elt) != f) {
+            val = 1 + (val - 1) * (q - 1) / (SIZE_FF(FLD_FFE(elt)) - 1);
+        }
+        // Must get these afresh after every list access, just in case this is
+        // a virtual list whose accesses might cause a garbage collection
+        settab = SETELT_FIELDINFO_8BIT(info);
+        convtab = FELT_FFE_FIELDINFO_8BIT(info);
+        byte = settab[(e + elts * convtab[val]) * 256 + byte];
+        if (++e == elts || i == len) {
+            *ptr++ = byte;
+            byte = 0;
+            e = 0;
+        }
     }
-    
-    // retype bag 
-    SET_LEN_VEC8BIT( res, len );
-    SET_FIELD_VEC8BIT( res, q );
-    type = TypeVec8Bit( q, IS_MUTABLE_OBJ( list ) );
-    SetTypeDatObj( res, type );
-    
+
+    // retype bag
+    SET_LEN_VEC8BIT(res, len);
+    SET_FIELD_VEC8BIT(res, q);
+    type = TypeVec8Bit(q, IS_MUTABLE_OBJ(list));
+    SetTypeDatObj(res, type);
+
     return res;
 }
 
@@ -938,10 +935,7 @@ Obj NewVec8Bit (
 **
 **  This is a non-destructive counterpart of FuncCOPY_GF2VEC
 */
-Obj FuncCOPY_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 q)
+Obj FuncCOPY_VEC8BIT(Obj self, Obj list, Obj q)
 {
     RequirePositiveSmallInt("COPY_VEC8BIT", q, "q");
     return NewVec8Bit(list, INT_INTOBJ(q));
@@ -953,26 +947,27 @@ Obj FuncCOPY_VEC8BIT (
 **
 **  'PlainVec8Bit' converts the  vector <list> to a plain list.
 */
-    
-void PlainVec8Bit (
-    Obj                 list )
-{
-    Int                 len;            // length of <list>                
-    UInt                i;              // loop variable                   
-    Obj                 first;          // first entry                     
-    Obj                 second = 0;
-    UInt                q;
-    UInt                elts;
-    Obj                 info;
-    UInt1              *gettab;
-    UInt                tnum;
-    Obj                 fieldobj;
-    Char *              startblank;
-    Char *              endblank;
 
-    // resize the list and retype it, in this order                        
+void PlainVec8Bit(Obj list)
+{
+    Int     len;      // length of <list>
+    UInt    i;        // loop variable
+    Obj     first;    // first entry
+    Obj     second = 0;
+    UInt    q;
+    UInt    elts;
+    Obj     info;
+    UInt1 * gettab;
+    UInt    tnum;
+    Obj     fieldobj;
+    Char *  startblank;
+    Char *  endblank;
+
+    // resize the list and retype it, in this order
     if (True == DoFilter(IsLockedRepresentationVector, list)) {
-        ErrorMayQuit("Attempt to convert locked compressed vector to plain list", 0, 0);
+        ErrorMayQuit(
+            "Attempt to convert locked compressed vector to plain list", 0,
+            0);
         return;
     }
 
@@ -998,17 +993,19 @@ void PlainVec8Bit (
         // keep the first two entries
         // because setting the third destroys them
 
-        first = FFE_FELT_FIELDINFO_8BIT(info)[gettab[CONST_BYTES_VEC8BIT(list)[0]]];
+        first = FFE_FELT_FIELDINFO_8BIT(
+            info)[gettab[CONST_BYTES_VEC8BIT(list)[0]]];
         if (len > 1)
-            second =
-            FFE_FELT_FIELDINFO_8BIT(info)
-            [gettab[256 * (1 % elts) + CONST_BYTES_VEC8BIT(list)[1 / elts]]];
+            second = FFE_FELT_FIELDINFO_8BIT(
+                info)[gettab[256 * (1 % elts) +
+                             CONST_BYTES_VEC8BIT(list)[1 / elts]]];
 
-        // replace the bits by FF elts as the case may be        
-        // this must of course be done from the end of the list backwards      
+        // replace the bits by FF elts as the case may be
+        // this must of course be done from the end of the list backwards
         for (i = len; 2 < i; i--) {
-            fieldobj = FFE_FELT_FIELDINFO_8BIT(info)
-            [gettab[256 * ((i - 1) % elts) + CONST_BYTES_VEC8BIT(list)[(i - 1) / elts]]];
+            fieldobj = FFE_FELT_FIELDINFO_8BIT(
+                info)[gettab[256 * ((i - 1) % elts) +
+                             CONST_BYTES_VEC8BIT(list)[(i - 1) / elts]]];
             SET_ELM_PLIST(list, i, fieldobj);
         }
         if (len > 1)
@@ -1029,39 +1026,39 @@ void PlainVec8Bit (
 **
 *F  FuncPLAIN_VEC8BIT( <self>, <list> ) . . . .  convert back into plain list
 */
-Obj FuncPLAIN_VEC8BIT (
-    Obj                 self,
-    Obj                 list )
+Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
 {
-    // check whether <list> is an 8bit vector                                
-    while (! IS_VEC8BIT_REP(list)) {
+    // check whether <list> is an 8bit vector
+    while (!IS_VEC8BIT_REP(list)) {
         list = ErrorReturnObj(
             "PLAIN_VEC8BIT: <list> must be an 8bit vector (not a %s)",
             (Int)TNAM_OBJ(list), 0L,
             "you can replace <list> via 'return <list>;'");
     }
     if (DoFilter(IsLockedRepresentationVector, list) == True) {
-        ErrorMayQuit("You cannot convert a locked vector compressed over GF(%i) to a plain list",
-        FIELD_VEC8BIT(list) , 0);
+        ErrorMayQuit("You cannot convert a locked vector compressed over "
+                     "GF(%i) to a plain list",
+                     FIELD_VEC8BIT(list), 0);
         return 0;
     }
     PlainVec8Bit(list);
 
-    // return nothing                                                      
+    // return nothing
     return 0;
 }
 
 
-/****************************************************************************
-**
-*F * * * * * * * * * * * * arithmetic operations  * * * * * * * * * * * * * *
-*/
+    /****************************************************************************
+    **
+    *F * * * * * * * * * * * * arithmetic operations  * * * * * * * * * * * *
+    ** *
+    */
 
-#define NUMBLOCKS_VEC8BIT(len,elts) \
-        (((len) + sizeof(UInt)*(elts)-1)/(sizeof(UInt)*(elts)))
+#define NUMBLOCKS_VEC8BIT(len, elts)                                         \
+    (((len) + sizeof(UInt) * (elts)-1) / (sizeof(UInt) * (elts)))
 
-#define BLOCKS_VEC8BIT(vec) ((UInt *)BYTES_VEC8BIT(vec))     
-#define CONST_BLOCKS_VEC8BIT(vec) ((const UInt *)CONST_BYTES_VEC8BIT(vec))     
+#define BLOCKS_VEC8BIT(vec) ((UInt *)BYTES_VEC8BIT(vec))
+#define CONST_BLOCKS_VEC8BIT(vec) ((const UInt *)CONST_BYTES_VEC8BIT(vec))
 
 
 /****************************************************************************
@@ -1071,12 +1068,12 @@ Obj FuncPLAIN_VEC8BIT (
 */
 
 
-Obj CopyVec8Bit( Obj list, UInt mut )
+Obj CopyVec8Bit(Obj list, UInt mut)
 {
-    Obj copy;
+    Obj  copy;
     UInt size;
     UInt q;
-    Obj type;
+    Obj  type;
 
     size = SIZE_BAG(list);
     copy = NewWordSizedBag(T_DATOBJ, size);
@@ -1086,10 +1083,10 @@ Obj CopyVec8Bit( Obj list, UInt mut )
     CHANGED_BAG(copy);
     SET_LEN_VEC8BIT(copy, LEN_VEC8BIT(list));
     SET_FIELD_VEC8BIT(copy, q);
-    memcpy(BYTES_VEC8BIT(copy), CONST_BYTES_VEC8BIT(list), size - 3 * sizeof(UInt));
+    memcpy(BYTES_VEC8BIT(copy), CONST_BYTES_VEC8BIT(list),
+           size - 3 * sizeof(UInt));
     return copy;
 }
-
 
 
 /****************************************************************************
@@ -1106,17 +1103,13 @@ Obj CopyVec8Bit( Obj list, UInt mut )
 **
 */
 
-void  AddVec8BitVec8BitInner( Obj sum,
-  Obj vl,
-  Obj vr,
-  UInt start,
-  UInt stop )
+void AddVec8BitVec8BitInner(Obj sum, Obj vl, Obj vr, UInt start, UInt stop)
 {
-    Obj info;
+    Obj  info;
     UInt p;
     UInt elts;
 
-    // Maybe there's nothing to do 
+    // Maybe there's nothing to do
     if (!stop)
         return;
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(sum));
@@ -1127,19 +1120,19 @@ void  AddVec8BitVec8BitInner( Obj sum,
     assert(LEN_VEC8BIT(vr) >= stop);
     p = P_FIELDINFO_8BIT(info);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
-    // Convert from 1 based to zero based addressing 
-    start --;
-    stop --;
+    // Convert from 1 based to zero based addressing
+    start--;
+    stop--;
     if (p == 2) {
-        UInt *ptrL2;
-        UInt *ptrR2;
-        UInt *ptrS2;
-        UInt *endS2;
+        UInt * ptrL2;
+        UInt * ptrR2;
+        UInt * ptrS2;
+        UInt * endS2;
         // HPCGAP: Make sure to only check read guards for vl & vr.
         ptrL2 = (UInt *)(CONST_BLOCKS_VEC8BIT(vl) +
-                start / (sizeof(UInt) * elts));
+                         start / (sizeof(UInt) * elts));
         ptrR2 = (UInt *)(CONST_BLOCKS_VEC8BIT(vr) +
-                start / (sizeof(UInt) * elts));
+                         start / (sizeof(UInt) * elts));
         ptrS2 = BLOCKS_VEC8BIT(sum) + start / (sizeof(UInt) * elts);
         endS2 = BLOCKS_VEC8BIT(sum) + stop / (sizeof(UInt) * elts) + 1;
         if (sum == vl) {
@@ -1148,23 +1141,25 @@ void  AddVec8BitVec8BitInner( Obj sum,
                 ptrL2++;
                 ptrR2++;
             }
-        } else if (sum == vr) {
+        }
+        else if (sum == vr) {
             while (ptrR2 < endS2) {
-                *ptrR2 ^=  *ptrL2;
+                *ptrR2 ^= *ptrL2;
                 ptrL2++;
                 ptrR2++;
             }
-
-        } else
+        }
+        else
             while (ptrS2 < endS2)
                 *ptrS2++ = *ptrL2++ ^ *ptrR2++;
-    } else {
-        UInt1 *ptrL;
-        UInt1 *ptrR;
-        UInt1 *ptrS;
-        UInt1 *endS;
-        UInt x;
-        UInt1 *addtab = ADD_FIELDINFO_8BIT(info);
+    }
+    else {
+        UInt1 * ptrL;
+        UInt1 * ptrR;
+        UInt1 * ptrS;
+        UInt1 * endS;
+        UInt    x;
+        UInt1 * addtab = ADD_FIELDINFO_8BIT(info);
         // HPCGAP: Make sure to only check read guards for vl & vr.
         ptrL = (UInt1 *)(CONST_BYTES_VEC8BIT(vl) + start / elts);
         ptrR = (UInt1 *)(CONST_BYTES_VEC8BIT(vr) + start / elts);
@@ -1173,18 +1168,20 @@ void  AddVec8BitVec8BitInner( Obj sum,
         if (vl == sum) {
             while (ptrL < endS) {
                 if ((x = *ptrR) != 0)
-                    * ptrL = addtab[256 * (*ptrL) + x];
+                    *ptrL = addtab[256 * (*ptrL) + x];
                 ptrR++;
                 ptrL++;
             }
-        } else if (vr == sum) {
+        }
+        else if (vr == sum) {
             while (ptrR < endS) {
                 if ((x = *ptrL) != 0)
-                    * ptrR = addtab[256 * (x) + *ptrR];
+                    *ptrR = addtab[256 * (x) + *ptrR];
                 ptrR++;
                 ptrL++;
             }
-        } else
+        }
+        else
             while (ptrS < endS)
                 *ptrS++ = addtab[256 * (*ptrL++) + *ptrR++];
     }
@@ -1200,14 +1197,14 @@ void  AddVec8BitVec8BitInner( Obj sum,
 **  (mutable if either argument is).
 */
 
-Obj SumVec8BitVec8Bit( Obj vl, Obj vr )
+Obj SumVec8BitVec8Bit(Obj vl, Obj vr)
 {
-    Obj sum;
-    Obj info;
+    Obj  sum;
+    Obj  info;
     UInt elts;
     UInt q;
     UInt len;
-    Obj type;
+    Obj  type;
 
     q = FIELD_VEC8BIT(vl);
     len = LEN_VEC8BIT(vl);
@@ -1233,16 +1230,17 @@ Obj SumVec8BitVec8Bit( Obj vl, Obj vr )
 **
 */
 
-static Obj ConvertToVectorRep;  // BH: changed to static 
+static Obj ConvertToVectorRep;    // BH: changed to static
 
 
-Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
+Obj FuncSUM_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     Obj sum;
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr)) {
         UInt ql = FIELD_VEC8BIT(vl), qr = FIELD_VEC8BIT(vr);
-        Obj infol = GetFieldInfo8Bit(ql), infor = GetFieldInfo8Bit(qr);
-        UInt newd = LcmDegree(D_FIELDINFO_8BIT(infol), D_FIELDINFO_8BIT(infor));
+        Obj  infol = GetFieldInfo8Bit(ql), infor = GetFieldInfo8Bit(qr);
+        UInt newd =
+            LcmDegree(D_FIELDINFO_8BIT(infol), D_FIELDINFO_8BIT(infor));
         UInt p, newq;
         UInt i;
         p = P_FIELDINFO_8BIT(infol);
@@ -1251,13 +1249,16 @@ Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         for (i = 0; i < newd; i++)
             newq *= p;
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (newd > 8 || newq > 256 ||
-            (ql != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vl)) ||
-            (qr != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vr))) {
+            (ql != newq &&
+             True == CALL_1ARGS(IsLockedRepresentationVector, vl)) ||
+            (qr != newq &&
+             True == CALL_1ARGS(IsLockedRepresentationVector, vr))) {
             sum = SumListList(vl, vr);
             return sum;
-        } else {
+        }
+        else {
             RewriteVec8Bit(vl, newq);
             RewriteVec8Bit(vr, newq);
         }
@@ -1272,7 +1273,8 @@ Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
     else if (LEN_VEC8BIT(vl) > LEN_VEC8BIT(vr)) {
         sum = CopyVec8Bit(vl, IS_MUTABLE_OBJ(vl) || IS_MUTABLE_OBJ(vr));
         AddVec8BitVec8BitInner(sum, sum, vr, 1, LEN_VEC8BIT(vr));
-    } else {
+    }
+    else {
         sum = CopyVec8Bit(vr, IS_MUTABLE_OBJ(vl) || IS_MUTABLE_OBJ(vr));
         AddVec8BitVec8BitInner(sum, sum, vl, 1, LEN_VEC8BIT(vl));
     }
@@ -1289,25 +1291,21 @@ Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
 **  one.
 **  Multiplication is done from THE BLOCK containing <start> to the one
 **  containing <stop> INCLUSIVE. The remainder of <prod> is unchanged.
-**  <prod> may be the same vector as <vec> 
+**  <prod> may be the same vector as <vec>
 **  <scal> must be written over the field of <vec> and
 **  <prod> must be
 **  initialized as a vector over this field of length at least <stop>.
 **
 */
 
-void MultVec8BitFFEInner( Obj prod,
-        Obj vec,
-        Obj scal,
-        UInt start,
-        UInt stop )
+void MultVec8BitFFEInner(Obj prod, Obj vec, Obj scal, UInt start, UInt stop)
 {
-    Obj info;
-    UInt elts;
-    const UInt1 *ptrV;
-    UInt1 *ptrS;
-    UInt1 *endS;
-    UInt1 *tab;
+    Obj           info;
+    UInt          elts;
+    const UInt1 * ptrV;
+    UInt1 *       ptrS;
+    UInt1 *       endS;
+    UInt1 *       tab;
 
     if (!stop)
         return;
@@ -1320,11 +1318,11 @@ void MultVec8BitFFEInner( Obj prod,
     assert(Q_FIELDINFO_8BIT(info) == SIZE_FF(FLD_FFE(scal)));
 
 
-    // convert to 0 based addressing 
+    // convert to 0 based addressing
     start--;
     stop--;
     tab = SCALAR_FIELDINFO_8BIT(info) +
-    256 * FELT_FFE_FIELDINFO_8BIT(info)[VAL_FFE(scal)];
+          256 * FELT_FFE_FIELDINFO_8BIT(info)[VAL_FFE(scal)];
     ptrV = CONST_BYTES_VEC8BIT(vec) + start / elts;
     ptrS = BYTES_VEC8BIT(prod) + start / elts;
     endS = BYTES_VEC8BIT(prod) + stop / elts + 1;
@@ -1342,15 +1340,15 @@ void MultVec8BitFFEInner( Obj prod,
 **
 */
 
-Obj MultVec8BitFFE( Obj vec, Obj scal )
+Obj MultVec8BitFFE(Obj vec, Obj scal)
 {
-    Obj prod;
-    Obj info;
+    Obj  prod;
+    Obj  info;
     UInt elts;
     UInt q;
     UInt len;
     UInt v;
-    Obj type;
+    Obj  type;
 
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
@@ -1366,8 +1364,8 @@ Obj MultVec8BitFFE( Obj vec, Obj scal )
         v = VAL_FFE(scal);
         if (v != 0)
             v = 1 + (v - 1) * (q - 1) / (SIZE_FF(FLD_FFE(scal)) - 1);
-        scal = NEW_FFE(FiniteField(P_FIELDINFO_8BIT(info),
-        D_FIELDINFO_8BIT(info)), v);
+        scal = NEW_FFE(
+            FiniteField(P_FIELDINFO_8BIT(info), D_FIELDINFO_8BIT(info)), v);
     }
     MultVec8BitFFEInner(prod, vec, scal, 1, len);
     return prod;
@@ -1380,12 +1378,12 @@ Obj MultVec8BitFFE( Obj vec, Obj scal )
 **
 */
 
-Obj ZeroVec8Bit ( UInt q, UInt len, UInt mut )
+Obj ZeroVec8Bit(UInt q, UInt len, UInt mut)
 {
-    Obj zerov;
+    Obj  zerov;
     UInt size;
-    Obj info;
-    Obj type;
+    Obj  info;
+    Obj  type;
     info = GetFieldInfo8Bit(q);
     size = SIZE_VEC8BIT(len, ELS_BYTE_FIELDINFO_8BIT(info));
     zerov = NewWordSizedBag(T_DATOBJ, size);
@@ -1408,31 +1406,33 @@ Obj ZeroVec8Bit ( UInt q, UInt len, UInt mut )
 **
 */
 
-Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
+Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
 {
-    Obj prod;
-    Obj info;
+    Obj  prod;
+    Obj  info;
     UInt d;
 
-    if (VAL_FFE(ffe) == 1) { // ffe is the one 
+    if (VAL_FFE(ffe) == 1) {    // ffe is the one
         prod = CopyVec8Bit(vec, IS_MUTABLE_OBJ(vec));
-    } else if (VAL_FFE(ffe) == 0)
-        return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec), IS_MUTABLE_OBJ(vec));
+    }
+    else if (VAL_FFE(ffe) == 0)
+        return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec),
+                           IS_MUTABLE_OBJ(vec));
 
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(vec));
     d = D_FIELDINFO_8BIT(info);
 
-    // family predicate should have handled this 
+    // family predicate should have handled this
     assert(CHAR_FF(FLD_FFE(ffe)) == P_FIELDINFO_8BIT(info));
 
-    // check for field compatibility 
+    // check for field compatibility
     if (d % DEGR_FF(FLD_FFE(ffe))) {
         prod = ProdListScl(vec, ffe);
         CALL_1ARGS(ConvertToVectorRep, prod);
         return prod;
     }
 
-    // Finally the main line 
+    // Finally the main line
     return MultVec8BitFFE(vec, ffe);
 }
 
@@ -1442,11 +1442,9 @@ Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
 **
 */
 
-Obj FuncZERO_VEC8BIT( Obj self, Obj vec )
+Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 {
-    return ZeroVec8Bit(FIELD_VEC8BIT(vec),
-                       LEN_VEC8BIT(vec),
-                       1);
+    return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec), 1);
 }
 
 /****************************************************************************
@@ -1455,14 +1453,13 @@ Obj FuncZERO_VEC8BIT( Obj self, Obj vec )
 **
 */
 
-Obj FuncZERO_VEC8BIT_2( Obj self, Obj q, Obj len )
+Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
 {
     if (!ARE_INTOBJS(q, len))
-        ErrorQuit("ZERO_VEC8BIT_2: arguments must be small integers, not a %s and a %s",
-        (Int)TNAM_OBJ(q), (Int)TNAM_OBJ(len));
-    return ZeroVec8Bit(INT_INTOBJ(q),
-                       INT_INTOBJ(len),
-                       1L);
+        ErrorQuit("ZERO_VEC8BIT_2: arguments must be small integers, not a "
+                  "%s and a %s",
+                  (Int)TNAM_OBJ(q), (Int)TNAM_OBJ(len));
+    return ZeroVec8Bit(INT_INTOBJ(q), INT_INTOBJ(len), 1L);
 }
 
 /****************************************************************************
@@ -1476,7 +1473,7 @@ Obj FuncZERO_VEC8BIT_2( Obj self, Obj q, Obj len )
 ** Here we can fall back on the method above.
 */
 
-Obj FuncPROD_FFE_VEC8BIT( Obj self, Obj ffe, Obj vec)
+Obj FuncPROD_FFE_VEC8BIT(Obj self, Obj ffe, Obj vec)
 {
     return FuncPROD_VEC8BIT_FFE(self, vec, ffe);
 }
@@ -1490,43 +1487,42 @@ Obj FuncPROD_FFE_VEC8BIT( Obj self, Obj ffe, Obj vec)
 
 Obj AInvVec8Bit(Obj vec, UInt mut)
 {
-    Obj info;
+    Obj  info;
     UInt p;
-    //UInt d; 
+    // UInt d;
     UInt minusOne;
-    Obj neg;
-    FF f;
+    Obj  neg;
+    FF   f;
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(vec));
     p = P_FIELDINFO_8BIT(info);
 
     neg = CopyVec8Bit(vec, mut);
-    // characteristic 2 case 
+    // characteristic 2 case
     if (2 == p) {
         return neg;
     }
 
-    // Otherwise 
+    // Otherwise
     f = FiniteField(p, D_FIELDINFO_8BIT(info));
     minusOne = NEG_FFV(1, SUCC_FF(f));
     MultVec8BitFFEInner(neg, neg, NEW_FFE(f, minusOne), 1, LEN_VEC8BIT(neg));
     return neg;
 }
 
-Obj FuncAINV_VEC8BIT_MUTABLE( Obj self, Obj vec )
+Obj FuncAINV_VEC8BIT_MUTABLE(Obj self, Obj vec)
 {
     return AInvVec8Bit(vec, 1);
 }
 
-Obj FuncAINV_VEC8BIT_SAME_MUTABILITY( Obj self, Obj vec )
+Obj FuncAINV_VEC8BIT_SAME_MUTABILITY(Obj self, Obj vec)
 {
     return AInvVec8Bit(vec, IS_MUTABLE_OBJ(vec));
 }
 
-Obj FuncAINV_VEC8BIT_IMMUTABLE( Obj self, Obj vec )
+Obj FuncAINV_VEC8BIT_IMMUTABLE(Obj self, Obj vec)
 {
     return AInvVec8Bit(vec, 0);
 }
-
 
 
 /****************************************************************************
@@ -1535,7 +1531,7 @@ Obj FuncAINV_VEC8BIT_IMMUTABLE( Obj self, Obj vec )
 **
 **  This is the real vector add multiple routine. Others are all calls to
 **  this one. It adds <mult>*<vr> to <vl> leaving the result in <sum>
-** 
+**
 **  Addition is done from THE BLOCK containing <start> to the one
 **  containing <stop> INCLUSIVE. The remainder of <sum> is unchanged.
 **  <sum> may be the same vector as <vl> or
@@ -1546,28 +1542,24 @@ Obj FuncAINV_VEC8BIT_IMMUTABLE( Obj self, Obj vec )
 **
 */
 
-void  AddVec8BitVec8BitMultInner( Obj sum,
-          Obj vl,
-          Obj vr,
-          Obj mult,
-          UInt start,
-          UInt stop )
+void AddVec8BitVec8BitMultInner(
+    Obj sum, Obj vl, Obj vr, Obj mult, UInt start, UInt stop)
 {
-    Obj info;
-    UInt p;
-    UInt elts;
-    UInt1 *ptrL;
-    UInt1 *ptrR;
-    UInt1 *ptrS;
-    UInt1 *endS;
-    UInt1 *addtab = 0;
-    UInt1 *multab;
-    UInt x;
+    Obj     info;
+    UInt    p;
+    UInt    elts;
+    UInt1 * ptrL;
+    UInt1 * ptrR;
+    UInt1 * ptrS;
+    UInt1 * endS;
+    UInt1 * addtab = 0;
+    UInt1 * multab;
+    UInt    x;
 
     if (!stop)
         return;
 
-    // Handle special cases of <mult> 
+    // Handle special cases of <mult>
     if (VAL_FFE(mult) == 0 && sum == vl)
         return;
 
@@ -1576,49 +1568,52 @@ void  AddVec8BitVec8BitMultInner( Obj sum,
         return;
     }
 
-    //  so we have some work. get the tables 
+    //  so we have some work. get the tables
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(sum));
 
     p = P_FIELDINFO_8BIT(info);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    // Convert from 1 based to zero based addressing 
-    start --;
-    stop --;
+    // Convert from 1 based to zero based addressing
+    start--;
+    stop--;
     if (p != 2)
         addtab = ADD_FIELDINFO_8BIT(info);
 
     multab = SCALAR_FIELDINFO_8BIT(info) +
-    256 * FELT_FFE_FIELDINFO_8BIT(info)[VAL_FFE(mult)];
+             256 * FELT_FFE_FIELDINFO_8BIT(info)[VAL_FFE(mult)];
 
     // HPCGAP: cast + CONST_BYTES_VEC8BIT() ensures that only
     // read guards are checked for vl & vr.
-    ptrL = (UInt1 *) (CONST_BYTES_VEC8BIT(vl) + start / elts);
-    ptrR = (UInt1 *) (CONST_BYTES_VEC8BIT(vr) + start / elts);
+    ptrL = (UInt1 *)(CONST_BYTES_VEC8BIT(vl) + start / elts);
+    ptrR = (UInt1 *)(CONST_BYTES_VEC8BIT(vr) + start / elts);
     ptrS = BYTES_VEC8BIT(sum) + start / elts;
     endS = BYTES_VEC8BIT(sum) + stop / elts + 1;
     if (p != 2) {
         if (sum == vl) {
-            const UInt1* endS1 = endS;
-            const UInt1* addtab1 = addtab;
-            const UInt1* multab1 = multab;
+            const UInt1 * endS1 = endS;
+            const UInt1 * addtab1 = addtab;
+            const UInt1 * multab1 = multab;
             while (ptrL < endS1) {
                 if ((x = *ptrR) != 0)
-                    * ptrL = addtab1[256 * (*ptrL) + multab1[x]];
+                    *ptrL = addtab1[256 * (*ptrL) + multab1[x]];
                 ptrL++;
                 ptrR++;
             }
-        } else
+        }
+        else
             while (ptrS < endS)
                 *ptrS++ = addtab[256 * (*ptrL++) + multab[*ptrR++]];
-    } else if (sum == vl) {
+    }
+    else if (sum == vl) {
         while (ptrL < endS) {
             if ((x = *ptrR) != 0)
-                * ptrL = *ptrL ^ multab[x];
+                *ptrL = *ptrL ^ multab[x];
             ptrR++;
             ptrL++;
         }
-    } else
+    }
+    else
         while (ptrS < endS)
             *ptrS++ = *ptrL++ ^ multab[*ptrR++];
 }
@@ -1630,7 +1625,7 @@ void  AddVec8BitVec8BitMultInner( Obj sum,
 **  In-place scalar multiply
 */
 
-Obj FuncMULT_VECTOR_VEC8BITS( Obj self, Obj vec, Obj mul)
+Obj FuncMULT_VECTOR_VEC8BITS(Obj self, Obj vec, Obj mul)
 {
     UInt q;
     q = FIELD_VEC8BIT(vec);
@@ -1638,11 +1633,11 @@ Obj FuncMULT_VECTOR_VEC8BITS( Obj self, Obj vec, Obj mul)
     if (VAL_FFE(mul) == 1)
         return (Obj)0;
 
-    // Now check the field of <mul> 
+    // Now check the field of <mul>
     if (q != SIZE_FF(FLD_FFE(mul))) {
-        Obj info;
+        Obj  info;
         UInt d, d1;
-        FFV val;
+        FFV  val;
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         d1 = DegreeFFE(mul);
@@ -1667,41 +1662,44 @@ Obj FuncMULT_VECTOR_VEC8BITS( Obj self, Obj vec, Obj mul)
 
 Obj AddRowVector;
 
-Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, Obj to)
+Obj FuncADD_ROWVECTOR_VEC8BITS_5(
+    Obj self, Obj vl, Obj vr, Obj mul, Obj from, Obj to)
 {
     UInt q;
     UInt len;
     len = LEN_VEC8BIT(vl);
-    // There may be nothing to do 
+    // There may be nothing to do
     if (LT(to, from))
-        return (Obj) 0;
+        return (Obj)0;
 
     if (len != LEN_VEC8BIT(vr)) {
-        vr = ErrorReturnObj("AddRowVector: <left> and <right> must be vectors of the same length",
+        vr = ErrorReturnObj("AddRowVector: <left> and <right> must be "
+                            "vectors of the same length",
                             0L, 0L,
                             "you can replace <right> via 'return <right>;'");
 
-        // Now redispatch, because vr could be anything 
+        // Now redispatch, because vr could be anything
         return CALL_3ARGS(AddRowVector, vl, vr, mul);
     }
     while (LT(INTOBJ_INT(len), to)) {
-        to = ErrorReturnObj("AddRowVector: <to> (%d) is greater than the length of the vectors (%d)",
+        to = ErrorReturnObj("AddRowVector: <to> (%d) is greater than the "
+                            "length of the vectors (%d)",
                             INT_INTOBJ(to), len,
                             "you can replace <to> via 'return <to>;'");
     }
     if (LT(to, from))
-        return (Obj) 0;
+        return (Obj)0;
 
-    // Now we know that the characteristics must match, but not the fields 
+    // Now we know that the characteristics must match, but not the fields
     q = FIELD_VEC8BIT(vl);
 
-    // fix up fields if necessary 
+    // fix up fields if necessary
     if (q != FIELD_VEC8BIT(vr) || q != SIZE_FF(FLD_FFE(mul))) {
-        Obj info, info1;
+        Obj  info, info1;
         UInt d, d1, q1, d2, d0, q0, p, i;
-        FFV val;
+        FFV  val;
 
-        // find a common field 
+        // find a common field
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -1717,11 +1715,11 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && DoFilter(IsLockedRepresentationVector, vl) == True) ||
-        (q0 > q1 && DoFilter(IsLockedRepresentationVector, vr) == True))
+            (q0 > q1 && DoFilter(IsLockedRepresentationVector, vr) == True))
             return TRY_NEXT_METHOD;
         RewriteVec8Bit(vl, q0);
         RewriteVec8Bit(vr, q0);
@@ -1732,7 +1730,8 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
         q = q0;
     }
 
-    AddVec8BitVec8BitMultInner(vl, vl, vr, mul, INT_INTOBJ(from), INT_INTOBJ(to));
+    AddVec8BitVec8BitMultInner(vl, vl, vr, mul, INT_INTOBJ(from),
+                               INT_INTOBJ(to));
     return (Obj)0;
 }
 
@@ -1744,26 +1743,26 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
 **
 */
 
-Obj FuncADD_ROWVECTOR_VEC8BITS_3( Obj self, Obj vl, Obj vr, Obj mul)
+Obj FuncADD_ROWVECTOR_VEC8BITS_3(Obj self, Obj vl, Obj vr, Obj mul)
 {
     UInt q;
     if (LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr)) {
-        vr = ErrorReturnObj("SUM: <left> and <right> must be vectors of the same length",
-                            0L, 0L,
-                            "you can replace <right> via 'return <right>;'");
+        vr = ErrorReturnObj(
+            "SUM: <left> and <right> must be vectors of the same length", 0L,
+            0L, "you can replace <right> via 'return <right>;'");
 
-        // Now redispatch, because vr could be anything 
+        // Now redispatch, because vr could be anything
         return CALL_3ARGS(AddRowVector, vl, vr, mul);
     }
-    // Now we know that the characteristics must match, but not the fields 
+    // Now we know that the characteristics must match, but not the fields
     q = FIELD_VEC8BIT(vl);
 
-    // fix up fields if necessary 
+    // fix up fields if necessary
     if (q != FIELD_VEC8BIT(vr) || q != SIZE_FF(FLD_FFE(mul))) {
-        Obj info, info1;
+        Obj  info, info1;
         UInt d, d1, q1, d2, d0, q0, p, i;
-        FFV val;
-        // find a common field 
+        FFV  val;
+        // find a common field
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -1779,11 +1778,12 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_3( Obj self, Obj vl, Obj vr, Obj mul)
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
-        if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
-        (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vr) == True))
+        if ((q0 > q &&
+             CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
+            (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vr) == True))
             return TRY_NEXT_METHOD;
         RewriteVec8Bit(vl, q0);
         RewriteVec8Bit(vr, q0);
@@ -1805,25 +1805,25 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_3( Obj self, Obj vl, Obj vr, Obj mul)
 **
 */
 
-Obj FuncADD_ROWVECTOR_VEC8BITS_2( Obj self, Obj vl, Obj vr)
+Obj FuncADD_ROWVECTOR_VEC8BITS_2(Obj self, Obj vl, Obj vr)
 {
     UInt q;
     if (LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr)) {
-        vr = ErrorReturnObj("SUM: <left> and <right> must be vectors of the same length",
-                            0L, 0L,
-                            "you can replace <right> via 'return <right>;'");
+        vr = ErrorReturnObj(
+            "SUM: <left> and <right> must be vectors of the same length", 0L,
+            0L, "you can replace <right> via 'return <right>;'");
 
-        // Now redispatch, because vr could be anything 
+        // Now redispatch, because vr could be anything
         return CALL_2ARGS(AddRowVector, vl, vr);
     }
-    // Now we know that the characteristics must match, but not the fields 
+    // Now we know that the characteristics must match, but not the fields
     q = FIELD_VEC8BIT(vl);
-    // fix up fields if necessary 
+    // fix up fields if necessary
     if (q != FIELD_VEC8BIT(vr)) {
-        Obj info1;
-        Obj info;
+        Obj  info1;
+        Obj  info;
         UInt d, d1, q1, d0, q0, p, i;
-        // find a common field 
+        // find a common field
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -1836,11 +1836,12 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_2( Obj self, Obj vl, Obj vr)
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
-        if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
-        (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vr) == True))
+        if ((q0 > q &&
+             CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
+            (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vr) == True))
             return TRY_NEXT_METHOD;
         RewriteVec8Bit(vl, q0);
         RewriteVec8Bit(vr, q0);
@@ -1862,15 +1863,15 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_2( Obj self, Obj vl, Obj vr)
 **  (mutable if either argument is).
 */
 
-Obj SumVec8BitVec8BitMult( Obj vl, Obj vr, Obj mult )
+Obj SumVec8BitVec8BitMult(Obj vl, Obj vr, Obj mult)
 {
-    Obj sum;
-    Obj info;
+    Obj  sum;
+    Obj  info;
     UInt elts;
     UInt q;
     UInt len;
-    FFV v;
-    Obj type;
+    FFV  v;
+    Obj  type;
 
     q = FIELD_VEC8BIT(vl);
     len = LEN_VEC8BIT(vl);
@@ -1886,8 +1887,8 @@ Obj SumVec8BitVec8BitMult( Obj vl, Obj vr, Obj mult )
         v = VAL_FFE(mult);
         if (v != 0)
             v = 1 + (v - 1) * (q - 1) / (SIZE_FF(FLD_FFE(mult)) - 1);
-        mult = NEW_FFE(FiniteField(P_FIELDINFO_8BIT(info),
-        D_FIELDINFO_8BIT(info)), v);
+        mult = NEW_FFE(
+            FiniteField(P_FIELDINFO_8BIT(info), D_FIELDINFO_8BIT(info)), v);
     }
     AddVec8BitVec8BitMultInner(sum, vl, vr, mult, 1, len);
     return sum;
@@ -1899,10 +1900,10 @@ Obj SumVec8BitVec8BitMult( Obj vl, Obj vr, Obj mult )
 **
 */
 
-Obj DiffVec8BitVec8Bit( Obj vl, Obj vr)
+Obj DiffVec8BitVec8Bit(Obj vl, Obj vr)
 {
     Obj info;
-    FF f;
+    FF  f;
     FFV minusOne;
     Obj MinusOne;
     Obj dif;
@@ -1923,9 +1924,11 @@ Obj DiffVec8BitVec8Bit( Obj vl, Obj vr)
             SetTypeDatObj(dif, type);
         }
         return dif;
-    } else {
+    }
+    else {
         dif = CopyVec8Bit(vl, IS_MUTABLE_OBJ(vl) || IS_MUTABLE_OBJ(vr));
-        AddVec8BitVec8BitMultInner(dif, dif, vr, MinusOne, 1, LEN_VEC8BIT(vr));
+        AddVec8BitVec8BitMultInner(dif, dif, vr, MinusOne, 1,
+                                   LEN_VEC8BIT(vr));
         return dif;
     }
 }
@@ -1937,16 +1940,17 @@ Obj DiffVec8BitVec8Bit( Obj vl, Obj vr)
 **
 **  GAP callable method for binary -
 */
-Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
+Obj FuncDIFF_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     Obj diff;
-    //UInt p; 
+    // UInt p;
 
 
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr)) {
         UInt ql = FIELD_VEC8BIT(vl), qr = FIELD_VEC8BIT(vr);
-        Obj infol = GetFieldInfo8Bit(ql), infor = GetFieldInfo8Bit(qr);
-        UInt newd = LcmDegree(D_FIELDINFO_8BIT(infol), D_FIELDINFO_8BIT(infor));
+        Obj  infol = GetFieldInfo8Bit(ql), infor = GetFieldInfo8Bit(qr);
+        UInt newd =
+            LcmDegree(D_FIELDINFO_8BIT(infol), D_FIELDINFO_8BIT(infor));
         UInt p, newq;
         UInt i;
         p = P_FIELDINFO_8BIT(infol);
@@ -1954,20 +1958,23 @@ Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         newq = 1;
         for (i = 0; i < newd; i++)
             newq *= p;
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (newd > 8 || newq > 256 ||
-        (ql != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vl)) ||
-        (qr != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vr))) {
+            (ql != newq &&
+             True == CALL_1ARGS(IsLockedRepresentationVector, vl)) ||
+            (qr != newq &&
+             True == CALL_1ARGS(IsLockedRepresentationVector, vr))) {
             diff = DiffListList(vl, vr);
             CALL_1ARGS(ConvertToVectorRep, diff);
             return diff;
-        } else {
+        }
+        else {
             RewriteVec8Bit(vl, newq);
             RewriteVec8Bit(vr, newq);
         }
     }
 
-    // Finally the main line 
+    // Finally the main line
     return DiffVec8BitVec8Bit(vl, vr);
 }
 
@@ -1979,22 +1986,22 @@ Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
 **  deal with length variations
 */
 
-Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
+Int CmpVec8BitVec8Bit(Obj vl, Obj vr)
 {
-    Obj info;
-    UInt q;
-    UInt lenl;
-    UInt lenr;
-    const UInt1 *ptrL;
-    const UInt1 *ptrR;
-    const UInt1 *endL;
-    const UInt1 *endR;
-    UInt elts;
-    UInt vall, valr;
-    UInt e;
-    UInt1 *gettab;
-    const Obj *ffe_elt;
-    UInt len;
+    Obj           info;
+    UInt          q;
+    UInt          lenl;
+    UInt          lenr;
+    const UInt1 * ptrL;
+    const UInt1 * ptrR;
+    const UInt1 * endL;
+    const UInt1 * endR;
+    UInt          elts;
+    UInt          vall, valr;
+    UInt          e;
+    UInt1 *       gettab;
+    const Obj *   ffe_elt;
+    UInt          len;
     assert(FIELD_VEC8BIT(vl) == FIELD_VEC8BIT(vr));
     q = FIELD_VEC8BIT(vl);
     info = GetFieldInfo8Bit(q);
@@ -2013,7 +2020,8 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
         if (*ptrL == *ptrR) {
             ptrL++;
             ptrR++;
-        } else {
+        }
+        else {
             for (e = 0; e < elts; e++) {
                 vall = gettab[*ptrL + 256 * e];
                 valr = gettab[*ptrR + 256 * e];
@@ -2024,17 +2032,17 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
                         return 1;
                 }
             }
-            ErrorQuit("panic: bytes differed but all entries the same",
-                      0L, 0L);
+            ErrorQuit("panic: bytes differed but all entries the same", 0L,
+                      0L);
         }
     }
-    // now the final byte 
+    // now the final byte
     if (lenl < lenr)
         len = lenl;
     else
         len = lenr;
 
-    // look first at the shared part 
+    // look first at the shared part
     for (e = 0; e < (len % elts); e++) {
         vall = gettab[*ptrL + 256 * e];
         valr = gettab[*ptrR + 256 * e];
@@ -2045,7 +2053,7 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
                 return 1;
         }
     }
-    // if that didn't decide then the longer list is bigger 
+    // if that didn't decide then the longer list is bigger
     if (lenr > lenl)
         return -1;
     else if (lenr == lenl)
@@ -2062,19 +2070,19 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
 **
 */
 
-Obj ScalarProductVec8Bits( Obj vl, Obj vr )
+Obj ScalarProductVec8Bits(Obj vl, Obj vr)
 {
-    Obj info;
-    UInt1 acc;
-    const UInt1 *ptrL;
-    const UInt1 *ptrR;
-    const UInt1 *endL;
-    UInt len;
-    UInt q;
-    UInt elts;
-    UInt1 contrib;
-    UInt1 *inntab;
-    UInt1 *addtab;
+    Obj           info;
+    UInt1         acc;
+    const UInt1 * ptrL;
+    const UInt1 * ptrR;
+    const UInt1 * endL;
+    UInt          len;
+    UInt          q;
+    UInt          elts;
+    UInt1         contrib;
+    UInt1 *       inntab;
+    UInt1 *       addtab;
     len = LEN_VEC8BIT(vl);
     if (len > LEN_VEC8BIT(vr))
         len = LEN_VEC8BIT(vr);
@@ -2090,19 +2098,18 @@ Obj ScalarProductVec8Bits( Obj vl, Obj vr )
     inntab = INNER_FIELDINFO_8BIT(info);
     if (P_FIELDINFO_8BIT(info) == 2) {
         while (ptrL < endL) {
-            contrib = inntab [*ptrL++ + 256 * *ptrR++];
+            contrib = inntab[*ptrL++ + 256 * *ptrR++];
             acc ^= contrib;
         }
-    } else {
+    }
+    else {
         addtab = ADD_FIELDINFO_8BIT(info);
         while (ptrL < endL) {
-            contrib = inntab [*ptrL++ + 256 * *ptrR++];
+            contrib = inntab[*ptrL++ + 256 * *ptrR++];
             acc = addtab[256 * acc + contrib];
         }
-
     }
     return FFE_FELT_FIELDINFO_8BIT(info)[GETELT_FIELDINFO_8BIT(info)[acc]];
-
 }
 
 /****************************************************************************
@@ -2110,7 +2117,7 @@ Obj ScalarProductVec8Bits( Obj vl, Obj vr )
 *F  FuncPROD_VEC8BIT_VEC8BIT( <self>, <vl>, <vr> )
 */
 
-Obj FuncPROD_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
+Obj FuncPROD_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return ProdListList(vl, vr);
@@ -2126,18 +2133,18 @@ Obj FuncPROD_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
 **
 */
 
-UInt DistanceVec8Bits( Obj vl, Obj vr )
+UInt DistanceVec8Bits(Obj vl, Obj vr)
 {
-    Obj info;
-    const UInt1 *ptrL;
-    const UInt1 *ptrR;
-    const UInt1 *endL;
-    UInt len;
-    UInt q;
-    UInt elts;
-    UInt acc;
-    UInt i;
-    UInt1 *gettab;
+    Obj           info;
+    const UInt1 * ptrL;
+    const UInt1 * ptrR;
+    const UInt1 * endL;
+    UInt          len;
+    UInt          q;
+    UInt          elts;
+    UInt          acc;
+    UInt          i;
+    UInt1 *       gettab;
 
     len = LEN_VEC8BIT(vl);
     q = FIELD_VEC8BIT(vl);
@@ -2170,15 +2177,14 @@ UInt DistanceVec8Bits( Obj vl, Obj vr )
 *F  FuncDISTANCE_VEC8BIT_VEC8BIT( <self>, <vl>, <vr> )
 */
 
-Obj FuncDISTANCE_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
+Obj FuncDISTANCE_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr) ||
-    LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr))
+        LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr))
         return TRY_NEXT_METHOD;
 
     return INTOBJ_INT(DistanceVec8Bits(vl, vr));
 }
-
 
 
 /****************************************************************************
@@ -2187,22 +2193,22 @@ Obj FuncDISTANCE_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
 **
 */
 void DistDistrib8Bits(
-  Obj   veclis, // pointers to matrix vectors and their multiples 
-  Obj           vec,    // vector we compute distance to 
-  Obj   d,  // distances list 
-  Obj           sum,  // position of the sum vector 
-  UInt    pos,  // recursion depth 
-  UInt    l // length of basis 
-  ) 
+    Obj  veclis,    // pointers to matrix vectors and their multiples
+    Obj  vec,       // vector we compute distance to
+    Obj  d,         // distances list
+    Obj  sum,       // position of the sum vector
+    UInt pos,       // recursion depth
+    UInt l          // length of basis
+)
 {
-    UInt    i;
-    UInt    di;
-    Obj   cnt;
-    Obj   vp;
-    Obj           one;
-    Obj           tmp;
-    UInt          len;
-    UInt          q;
+    UInt i;
+    UInt di;
+    Obj  cnt;
+    Obj  vp;
+    Obj  one;
+    Obj  tmp;
+    UInt len;
+    UInt q;
 
     vp = ELM_PLIST(veclis, pos);
     one = INTOBJ_INT(1);
@@ -2212,13 +2218,15 @@ void DistDistrib8Bits(
     for (i = 0; i < q; i++) {
         if (pos < l) {
             DistDistrib8Bits(veclis, vec, d, sum, pos + 1, l);
-        } else {
+        }
+        else {
             di = DistanceVec8Bits(sum, vec);
             cnt = ELM_PLIST(d, di + 1);
             if (IS_INTOBJ(cnt) && SUM_INTOBJS(tmp, cnt, one)) {
                 cnt = tmp;
                 SET_ELM_PLIST(d, di + 1, cnt);
-            } else {
+            }
+            else {
                 cnt = SumInt(cnt, one);
                 SET_ELM_PLIST(d, di + 1, cnt);
                 CHANGED_BAG(d);
@@ -2230,25 +2238,25 @@ void DistDistrib8Bits(
 }
 
 Obj FuncDISTANCE_DISTRIB_VEC8BITS(
-  Obj   self,
-  Obj   veclis, // pointers to matrix vectors and their multiples 
-  Obj   vec,    // vector we compute distance to 
-  Obj   d ) // distances list 
+    Obj self,
+    Obj veclis,    // pointers to matrix vectors and their multiples
+    Obj vec,       // vector we compute distance to
+    Obj d)         // distances list
 
 {
-    Obj   sum; // sum vector 
-    UInt    len;
-    UInt           q;
+    Obj  sum;    // sum vector
+    UInt len;
+    UInt q;
 
     len = LEN_VEC8BIT(vec);
     q = FIELD_VEC8BIT(vec);
 
-    // get space for sum vector and zero out 
+    // get space for sum vector and zero out
     sum = ZeroVec8Bit(q, len, 0);
-    // do the recursive work 
+    // do the recursive work
     DistDistrib8Bits(veclis, vec, d, sum, 1, LEN_PLIST(veclis));
 
-    return (Obj) 0;
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -2256,12 +2264,12 @@ Obj FuncDISTANCE_DISTRIB_VEC8BITS(
 *F
 */
 
-void OverwriteVec8Bit( Obj dst, Obj src)
+void OverwriteVec8Bit(Obj dst, Obj src)
 {
-    const UInt1 *ptrS;
-    UInt1 *ptrD;
-    UInt size;
-    UInt n;
+    const UInt1 * ptrS;
+    UInt1 *       ptrD;
+    UInt          size;
+    UInt          n;
     size = SIZE_BAG(src);
     ptrS = CONST_BYTES_VEC8BIT(src);
     ptrD = BYTES_VEC8BIT(dst);
@@ -2269,30 +2277,30 @@ void OverwriteVec8Bit( Obj dst, Obj src)
         *ptrD++ = *ptrS++;
 }
 
-UInt AClosVec8Bit( 
-      Obj   veclis, // pointers to matrix vectors and their multiples 
-      Obj           vec,    // vector we compute distance to 
-      Obj           sum,  // position of the sum vector 
-      UInt    pos,  // recursion depth 
-      UInt    l,  // length of basis 
-      UInt    cnt,  // number of vectors used already 
-      UInt    stop, // stop value 
-      UInt    bd, // best distance so far 
-      Obj   bv, // best vector so far 
-      Obj           coords,
-      Obj           bcoords
-      )
+UInt AClosVec8Bit(
+    Obj  veclis,    // pointers to matrix vectors and their multiples
+    Obj  vec,       // vector we compute distance to
+    Obj  sum,       // position of the sum vector
+    UInt pos,       // recursion depth
+    UInt l,         // length of basis
+    UInt cnt,       // number of vectors used already
+    UInt stop,      // stop value
+    UInt bd,        // best distance so far
+    Obj  bv,        // best vector so far
+    Obj  coords,
+    Obj  bcoords)
 {
-    UInt    i, j;
-    UInt    di;
-    Obj   vp;
+    UInt i, j;
+    UInt di;
+    Obj  vp;
     UInt q;
     UInt len;
 
     // This is the case where we do not add any multiple of
     // the current basis vector
     if (pos + cnt < l) {
-        bd = AClosVec8Bit(veclis, vec, sum, pos + 1, l, cnt, stop, bd, bv, coords, bcoords);
+        bd = AClosVec8Bit(veclis, vec, sum, pos + 1, l, cnt, stop, bd, bv,
+                          coords, bcoords);
         if (bd <= stop) {
             return bd;
         }
@@ -2301,13 +2309,13 @@ UInt AClosVec8Bit(
     len = LEN_VEC8BIT(vec);
     vp = ELM_PLIST(veclis, pos);
 
-    // we need to add each scalar multiple and recurse 
-    for (i = 1; i <  q ; i++) {
+    // we need to add each scalar multiple and recurse
+    for (i = 1; i < q; i++) {
         AddVec8BitVec8BitInner(sum, sum, ELM_PLIST(vp, i), 1, len);
         if (coords)
             SET_ELM_PLIST(coords, pos, INTOBJ_INT(i));
         if (cnt == 0) {
-            // do we have a new best case 
+            // do we have a new best case
             di = DistanceVec8Bits(sum, vec);
             if (di < bd) {
                 bd = di;
@@ -2321,14 +2329,16 @@ UInt AClosVec8Bit(
                 if (bd <= stop)
                     return bd;
             }
-        } else if (pos < l) {
-            bd = AClosVec8Bit(veclis, vec, sum, pos + 1, l, cnt - 1, stop, bd, bv, coords, bcoords);
+        }
+        else if (pos < l) {
+            bd = AClosVec8Bit(veclis, vec, sum, pos + 1, l, cnt - 1, stop, bd,
+                              bv, coords, bcoords);
             if (bd <= stop) {
                 return bd;
             }
         }
     }
-    // reset component 
+    // reset component
     AddVec8BitVec8BitInner(sum, sum, ELM_PLIST(vp, q), 1, len);
     if (coords)
         SET_ELM_PLIST(coords, pos, INTOBJ_INT(0));
@@ -2339,37 +2349,38 @@ UInt AClosVec8Bit(
 
 /****************************************************************************
 **
-*F  
+*F
 */
 
 Obj FuncA_CLOSEST_VEC8BIT(
-          Obj   self,
-          Obj   veclis, // pointers to matrix vectors and their multiples 
-          Obj   vec,    // vector we compute distance to 
-          Obj   cnt,  // distances list 
-          Obj   stop) // distances list 
+    Obj self,
+    Obj veclis,    // pointers to matrix vectors and their multiples
+    Obj vec,       // vector we compute distance to
+    Obj cnt,       // distances list
+    Obj stop)      // distances list
 {
-    Obj   sum; // sum vector 
-    Obj   best; // best vector 
-    UInt  len;
+    Obj  sum;     // sum vector
+    Obj  best;    // best vector
+    UInt len;
     UInt q;
 
     if (!ARE_INTOBJS(cnt, stop))
-        ErrorQuit("A_CLOSEST_VEC8BIT: cnt and stop must be small integers, not a %s and a %s",
+        ErrorQuit("A_CLOSEST_VEC8BIT: cnt and stop must be small integers, "
+                  "not a %s and a %s",
                   (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
 
 
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
 
-    // get space for sum vector and zero out 
+    // get space for sum vector and zero out
 
     sum = ZeroVec8Bit(q, len, 1);
     best = ZeroVec8Bit(q, len, 1);
 
-    // do the recursive work 
-    AClosVec8Bit(veclis, vec, sum, 1, LEN_PLIST(veclis),
-                 INT_INTOBJ(cnt), INT_INTOBJ(stop), len + 1, // maximal value +1 
+    // do the recursive work
+    AClosVec8Bit(veclis, vec, sum, 1, LEN_PLIST(veclis), INT_INTOBJ(cnt),
+                 INT_INTOBJ(stop), len + 1,    // maximal value +1
                  best, (Obj)0, (Obj)0);
 
     return best;
@@ -2377,33 +2388,34 @@ Obj FuncA_CLOSEST_VEC8BIT(
 
 /****************************************************************************
 **
-*F  
+*F
 */
 
 Obj FuncA_CLOSEST_VEC8BIT_COORDS(
-          Obj   self,
-          Obj   veclis, // pointers to matrix vectors and their multiples 
-          Obj   vec,    // vector we compute distance to 
-          Obj   cnt,  // distances list 
-          Obj   stop) // distances list     
+    Obj self,
+    Obj veclis,    // pointers to matrix vectors and their multiples
+    Obj vec,       // vector we compute distance to
+    Obj cnt,       // distances list
+    Obj stop)      // distances list
 {
-    Obj   sum; // sum vector 
-    Obj   best; // best vector 
-    UInt    len, len2, i;
+    Obj  sum;     // sum vector
+    Obj  best;    // best vector
+    UInt len, len2, i;
     UInt q;
-    Obj coords;
-    Obj bcoords;
-    Obj res;
+    Obj  coords;
+    Obj  bcoords;
+    Obj  res;
 
     if (!ARE_INTOBJS(cnt, stop))
-        ErrorQuit("A_CLOSEST_VEC8BIT: cnt and stop must be small integers, not a %s and a %s",
-        (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
+        ErrorQuit("A_CLOSEST_VEC8BIT: cnt and stop must be small integers, "
+                  "not a %s and a %s",
+                  (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
 
 
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
 
-    // get space for sum vector and zero out 
+    // get space for sum vector and zero out
 
     sum = ZeroVec8Bit(q, len, 1);
     best = ZeroVec8Bit(q, len, 1);
@@ -2417,10 +2429,10 @@ Obj FuncA_CLOSEST_VEC8BIT_COORDS(
         SET_ELM_PLIST(bcoords, i, INTOBJ_INT(0));
     }
 
-    // do the recursive work 
-    AClosVec8Bit(veclis, vec, sum, 1, LEN_PLIST(veclis),
-    INT_INTOBJ(cnt), INT_INTOBJ(stop), len + 1, // maximal value +1 
-    best, coords, bcoords);
+    // do the recursive work
+    AClosVec8Bit(veclis, vec, sum, 1, LEN_PLIST(veclis), INT_INTOBJ(cnt),
+                 INT_INTOBJ(stop), len + 1,    // maximal value +1
+                 best, coords, bcoords);
 
     res = NEW_PLIST(T_PLIST_DENSE_NHOM, 2);
     SET_LEN_PLIST(res, 2);
@@ -2437,19 +2449,19 @@ Obj FuncA_CLOSEST_VEC8BIT_COORDS(
 **
 */
 
-Obj FuncNUMBER_VEC8BIT (Obj self, Obj vec)
+Obj FuncNUMBER_VEC8BIT(Obj self, Obj vec)
 {
-    Obj     info;
-    UInt    elts;
-    UInt    len;
-    UInt    i;
-    Obj     elt;
-    UInt1   *gettab;
-    const UInt1   *ptrS;
-    const Obj     *convtab;
+    Obj           info;
+    UInt          elts;
+    UInt          len;
+    UInt          i;
+    Obj           elt;
+    UInt1 *       gettab;
+    const UInt1 * ptrS;
+    const Obj *   convtab;
 
-    Obj     res;
-    Obj     f;
+    Obj res;
+    Obj f;
 
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(vec));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
@@ -2458,17 +2470,17 @@ Obj FuncNUMBER_VEC8BIT (Obj self, Obj vec)
     ptrS = CONST_BYTES_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
     res = INTOBJ_INT(0);
-    f = INTOBJ_INT(FIELD_VEC8BIT(vec)); // Field size as GAP integer 
+    f = INTOBJ_INT(FIELD_VEC8BIT(vec));    // Field size as GAP integer
 
     if (len == 0)
-      return INTOBJ_INT(1);
+        return INTOBJ_INT(1);
 
     for (i = 0; i < len; i++) {
         elt = convtab[gettab[ptrS[i / elts] + 256 * (i % elts)]];
-        res = ProdInt(res, f); // ``shift'' 
+        res = ProdInt(res, f);    // ``shift''
         res = SumInt(res, elt);
         if (!IS_INTOBJ(res)) {
-            // a garbage collection might have moved the pointers 
+            // a garbage collection might have moved the pointers
             gettab = GETELT_FIELDINFO_8BIT(info);
             convtab = GAPSEQ_FELT_FIELDINFO_8BIT(info);
             ptrS = CONST_BYTES_VEC8BIT(vec);
@@ -2486,31 +2498,31 @@ Obj FuncNUMBER_VEC8BIT (Obj self, Obj vec)
 ** Search for new coset leaders of weight <weight>
 */
 
-UInt CosetLeadersInner8Bits( Obj veclis,
-         Obj v,
-         Obj w,
-         UInt weight,
-         UInt pos,
-         Obj leaders,
-         UInt tofind,
-         Obj felts)
+UInt CosetLeadersInner8Bits(Obj  veclis,
+                            Obj  v,
+                            Obj  w,
+                            UInt weight,
+                            UInt pos,
+                            Obj  leaders,
+                            UInt tofind,
+                            Obj  felts)
 {
-    UInt found = 0;
-    UInt len = LEN_VEC8BIT(v);
-    UInt lenw = LEN_VEC8BIT(w);
-    UInt sy;
-    Obj u;
-    Obj vc;
-    UInt i, j;
-    UInt q;
-    Obj info;
-    UInt1 *settab;
-    UInt elts;
-    UInt1 *ptr, *ptrw;
-    UInt1 *gettab;
-    UInt1 *feltffe;
-    Obj x;
-    Obj vp;
+    UInt    found = 0;
+    UInt    len = LEN_VEC8BIT(v);
+    UInt    lenw = LEN_VEC8BIT(w);
+    UInt    sy;
+    Obj     u;
+    Obj     vc;
+    UInt    i, j;
+    UInt    q;
+    Obj     info;
+    UInt1 * settab;
+    UInt    elts;
+    UInt1 * ptr, *ptrw;
+    UInt1 * gettab;
+    UInt1 * feltffe;
+    Obj     x;
+    Obj     vp;
 
     q = FIELD_VEC8BIT(v);
     info = GetFieldInfo8Bit(q);
@@ -2532,14 +2544,14 @@ UInt CosetLeadersInner8Bits( Obj veclis,
                 xxxx = gettab[ptrw[j / elts] + 256 * (j % elts)];
                 sy += xxxx;
             }
-            if ((Obj) 0 == ELM_PLIST(leaders, sy + 1)) {
+            if ((Obj)0 == ELM_PLIST(leaders, sy + 1)) {
                 UInt k;
-                Obj qk;
-                Obj wc;
+                Obj  qk;
+                Obj  wc;
                 vc = CopyVec8Bit(v, 0);
                 SET_ELM_PLIST(leaders, sy + 1, vc);
                 CHANGED_BAG(leaders);
-                // Also record all the multiples here 
+                // Also record all the multiples here
                 wc = ZeroVec8Bit(q, lenw, 1);
                 settab = SETELT_FIELDINFO_8BIT(info);
                 gettab = GETELT_FIELDINFO_8BIT(info);
@@ -2573,9 +2585,11 @@ UInt CosetLeadersInner8Bits( Obj veclis,
             AddVec8BitVec8BitInner(w, w, u, 1, lenw);
             *ptr = settab[*ptr + 256 * ((i - 1) % elts)];
         }
-    } else {
+    }
+    else {
         if (pos + weight <= len) {
-            found += CosetLeadersInner8Bits(veclis, v, w, weight, pos + 1, leaders, tofind, felts);
+            found += CosetLeadersInner8Bits(veclis, v, w, weight, pos + 1,
+                                            leaders, tofind, felts);
             if (found == tofind)
                 return found;
         }
@@ -2588,8 +2602,10 @@ UInt CosetLeadersInner8Bits( Obj veclis,
             x = ELM_PLIST(felts, i + 1);
             settab = SETELT_FIELDINFO_8BIT(info);
             feltffe = FELT_FFE_FIELDINFO_8BIT(info);
-            *ptr = settab[*ptr + 256 * (elts * feltffe[VAL_FFE(x)] + ((pos - 1) % elts))];
-            found += CosetLeadersInner8Bits(veclis, v, w, weight - 1, pos + 1, leaders, tofind - found, felts);
+            *ptr = settab[*ptr + 256 * (elts * feltffe[VAL_FFE(x)] +
+                                        ((pos - 1) % elts))];
+            found += CosetLeadersInner8Bits(veclis, v, w, weight - 1, pos + 1,
+                                            leaders, tofind - found, felts);
             if (found == tofind)
                 return found;
         }
@@ -2600,28 +2616,29 @@ UInt CosetLeadersInner8Bits( Obj veclis,
 
         ptr = BYTES_VEC8BIT(v) + (pos - 1) / elts;
         *ptr = settab[*ptr + 256 * ((pos - 1) % elts)];
-
     }
     TakeInterrupt();
     return found;
 }
 
 
-
-
-Obj FuncCOSET_LEADERS_INNER_8BITS( Obj self, Obj veclis, Obj weight, Obj tofind, Obj leaders, Obj felts)
+Obj FuncCOSET_LEADERS_INNER_8BITS(
+    Obj self, Obj veclis, Obj weight, Obj tofind, Obj leaders, Obj felts)
 {
-    Obj v, w;
+    Obj  v, w;
     UInt lenv, lenw, q;
     if (!ARE_INTOBJS(weight, tofind))
-        ErrorQuit("COSET_LEADERS_INNER_8BITS: weight and tofind must be small integers, not a %s and a %s",
-        (Int)TNAM_OBJ(weight), (Int)TNAM_OBJ(tofind));
+        ErrorQuit("COSET_LEADERS_INNER_8BITS: weight and tofind must be "
+                  "small integers, not a %s and a %s",
+                  (Int)TNAM_OBJ(weight), (Int)TNAM_OBJ(tofind));
     lenv = LEN_PLIST(veclis);
     q = LEN_PLIST(felts);
     v = ZeroVec8Bit(q, lenv, 1);
     lenw = LEN_VEC8BIT(ELM_PLIST(ELM_PLIST(veclis, 1), 1));
     w = ZeroVec8Bit(q, lenw, 1);
-    return INTOBJ_INT(CosetLeadersInner8Bits(veclis, v, w, INT_INTOBJ(weight), 1, leaders, INT_INTOBJ(tofind), felts));
+    return INTOBJ_INT(CosetLeadersInner8Bits(veclis, v, w, INT_INTOBJ(weight),
+                                             1, leaders, INT_INTOBJ(tofind),
+                                             felts));
 }
 
 
@@ -2631,7 +2648,7 @@ Obj FuncCOSET_LEADERS_INNER_8BITS( Obj self, Obj veclis, Obj weight, Obj tofind,
 **
 */
 
-Obj FuncEQ_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
+Obj FuncEQ_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return EqListList(vl, vr) ? True : False;
@@ -2648,7 +2665,7 @@ Obj FuncEQ_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
 **
 */
 
-Obj FuncLT_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
+Obj FuncLT_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return LtListList(vl, vr) ? True : False;
@@ -2668,7 +2685,7 @@ Obj FuncLT_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
 */
 
 
-Obj FuncSHALLOWCOPY_VEC8BIT( Obj self, Obj list )
+Obj FuncSHALLOWCOPY_VEC8BIT(Obj self, Obj list)
 {
     return CopyVec8Bit(list, 1);
 }
@@ -2678,9 +2695,7 @@ Obj FuncSHALLOWCOPY_VEC8BIT( Obj self, Obj list )
 **
 *F  FuncLEN_VEC8BIT( <self>, <list> )  . . . . . . . .  length of a vector
 */
-Obj FuncLEN_VEC8BIT (
-    Obj                 self,
-    Obj                 list )
+Obj FuncLEN_VEC8BIT(Obj self, Obj list)
 {
     return INTOBJ_INT(LEN_VEC8BIT(list));
 }
@@ -2689,9 +2704,7 @@ Obj FuncLEN_VEC8BIT (
 **
 *F  FuncQ_VEC8BIT( <self>, <list> )  . . . . . . . .  length of a vector
 */
-Obj FuncQ_VEC8BIT (
-    Obj                 self,
-    Obj                 list )
+Obj FuncQ_VEC8BIT(Obj self, Obj list)
 {
     return INTOBJ_INT(FIELD_VEC8BIT(list));
 }
@@ -2707,25 +2720,23 @@ Obj FuncQ_VEC8BIT (
 **  integer.
 */
 
-Obj FuncELM0_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
 {
-    UInt                p;
-    Obj     info;
+    UInt p;
+    Obj  info;
     UInt elts;
 
     RequirePositiveSmallInt("ELM0_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
     if (LEN_VEC8BIT(list) < p) {
         return Fail;
-    } else {
+    }
+    else {
         info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
         elts = ELS_BYTE_FIELDINFO_8BIT(info);
-        return FFE_FELT_FIELDINFO_8BIT(info)[
-                GETELT_FIELDINFO_8BIT(info)[CONST_BYTES_VEC8BIT(list)[(p - 1) / elts] +
-                256 * ((p - 1) % elts)]];
+        return FFE_FELT_FIELDINFO_8BIT(info)[GETELT_FIELDINFO_8BIT(
+            info)[CONST_BYTES_VEC8BIT(list)[(p - 1) / elts] +
+                  256 * ((p - 1) % elts)]];
     }
 }
 
@@ -2738,29 +2749,26 @@ Obj FuncELM0_VEC8BIT (
 **  vector <list>. An error is signalled if <pos> is not bound. It is the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
-Obj FuncELM_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
 {
-    UInt                p;
-    Obj     info;
+    UInt p;
+    Obj  info;
     UInt elts;
 
     RequirePositiveSmallInt("ELM_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
     if (LEN_VEC8BIT(list) < p) {
         ErrorReturnVoid(
-            "List Element: <list>[%d] must have an assigned value",
-            p, 0L, "you can 'return;' after assigning a value");
+            "List Element: <list>[%d] must have an assigned value", p, 0L,
+            "you can 'return;' after assigning a value");
         return ELM_LIST(list, p);
-    } else {
+    }
+    else {
         info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
         elts = ELS_BYTE_FIELDINFO_8BIT(info);
-        return FFE_FELT_FIELDINFO_8BIT(info)[
-                GETELT_FIELDINFO_8BIT(info)[CONST_BYTES_VEC8BIT(list)[(p - 1) / elts] +
-                256 * ((p - 1) % elts)]];
-
+        return FFE_FELT_FIELDINFO_8BIT(info)[GETELT_FIELDINFO_8BIT(
+            info)[CONST_BYTES_VEC8BIT(list)[(p - 1) / elts] +
+                  256 * ((p - 1) % elts)]];
     }
 }
 
@@ -2771,26 +2779,23 @@ Obj FuncELM_VEC8BIT (
 **
 **  The results are returned in the compressed format
 */
-Obj FuncELMS_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 poss )
+Obj FuncELMS_VEC8BIT(Obj self, Obj list, Obj poss)
 {
-    UInt                p;
-    Obj                 pos;
-    Obj     info;
-    UInt                elts;
-    UInt                len;
-    Obj                 res;
-    UInt                i;
-    UInt                elt;
-    UInt1               *gettab;
-    UInt1               *settab;
-    const UInt1         *ptrS;
-    UInt1               *ptrD;
-    UInt                 e;
-    UInt1                byte;
-    UInt                 len2;
+    UInt          p;
+    Obj           pos;
+    Obj           info;
+    UInt          elts;
+    UInt          len;
+    Obj           res;
+    UInt          i;
+    UInt          elt;
+    UInt1 *       gettab;
+    UInt1 *       settab;
+    const UInt1 * ptrS;
+    UInt1 *       ptrD;
+    UInt          e;
+    UInt1         byte;
+    UInt          len2;
 
     len = LEN_PLIST(poss);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
@@ -2809,16 +2814,20 @@ Obj FuncELMS_VEC8BIT (
     for (i = 1; i <= len; i++) {
         pos = ELM_PLIST(poss, i);
         if (!IS_INTOBJ(pos))
-            ErrorQuit("ELMS_VEC8BIT: positions list includes a %s, should all be small integers",
+            ErrorQuit("ELMS_VEC8BIT: positions list includes a %s, should "
+                      "all be small integers",
                       (Int)TNAM_OBJ(pos), 0L);
         if (pos <= INTOBJ_INT(0))
-            ErrorQuit("ELMS_VEC8BIT: positions list includes a non-positive number", 0L, 0L);
+            ErrorQuit(
+                "ELMS_VEC8BIT: positions list includes a non-positive number",
+                0L, 0L);
         p = INT_INTOBJ(pos);
         if (p > len2)
-            ErrorQuit("ELMS_VEC8BIT: positions list includes index %d in a list of length %d",
+            ErrorQuit("ELMS_VEC8BIT: positions list includes index %d in a "
+                      "list of length %d",
                       (Int)p, (Int)len2);
         elt = gettab[ptrS[(p - 1) / elts] + 256 * ((p - 1) % elts)];
-        byte = settab[ byte + 256 * (e + elts * elt)];
+        byte = settab[byte + 256 * (e + elts * elt)];
         e++;
         if (e == elts) {
             *ptrD++ = byte;
@@ -2833,7 +2842,6 @@ Obj FuncELMS_VEC8BIT (
 }
 
 
-
 /****************************************************************************
 **
 *F  FuncELMS_VEC8BIT_RANGE( <self>, <list>, <range> ) .
@@ -2841,27 +2849,24 @@ Obj FuncELMS_VEC8BIT (
 **
 **  The results are returned in the compressed format
 */
-Obj FuncELMS_VEC8BIT_RANGE (
-    Obj                 self,
-    Obj                 list,
-    Obj                 range  )
+Obj FuncELMS_VEC8BIT_RANGE(Obj self, Obj list, Obj range)
 {
-    UInt                p;
-    Obj     info;
-    UInt                elts;
-    UInt                len;
-    UInt                lenl;
-    UInt                low;
-    Int                inc;
-    Obj                 res;
-    UInt                i;
-    UInt                elt;
-    UInt1               *gettab;
-    UInt1               *settab;
-    const UInt1         *ptrS;
-    UInt1               *ptrD;
-    UInt                 e;
-    UInt1                byte;
+    UInt          p;
+    Obj           info;
+    UInt          elts;
+    UInt          len;
+    UInt          lenl;
+    UInt          low;
+    Int           inc;
+    Obj           res;
+    UInt          i;
+    UInt          elt;
+    UInt1 *       gettab;
+    UInt1 *       settab;
+    const UInt1 * ptrS;
+    UInt1 *       ptrD;
+    UInt          e;
+    UInt1         byte;
 
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
@@ -2871,10 +2876,13 @@ Obj FuncELMS_VEC8BIT_RANGE (
     lenl = LEN_VEC8BIT(list);
     if (inc < 0) {
         if (low > lenl || low + inc * (len - 1) < 1)
-            ErrorQuit("ELMS_VEC8BIT_RANGE: Range includes indices which are too high or too low",
+            ErrorQuit("ELMS_VEC8BIT_RANGE: Range includes indices which are "
+                      "too high or too low",
                       0L, 0L);
-    } else if (low < 1 || low + inc * (len - 1) > lenl)
-        ErrorQuit("ELMS_VEC8BIT_RANGE: Range includes indices which are too high or too low",
+    }
+    else if (low < 1 || low + inc * (len - 1) > lenl)
+        ErrorQuit("ELMS_VEC8BIT_RANGE: Range includes indices which are too "
+                  "high or too low",
                   0L, 0L);
     res = NewWordSizedBag(T_DATOBJ, SIZE_VEC8BIT(len, elts));
     SetTypeDatObj(res, TYPE_DATOBJ(list));
@@ -2886,7 +2894,7 @@ Obj FuncELMS_VEC8BIT_RANGE (
     ptrD = BYTES_VEC8BIT(res);
     e = 0;
     byte = 0;
-    p = low - 1;    // the -1 converts to 0 base 
+    p = low - 1;    // the -1 converts to 0 base
     if (p % elts == 0 && inc == 1 && len >= elts) {
         while (p < low + len - elts) {
             *ptrD++ = ptrS[p / elts];
@@ -2897,16 +2905,17 @@ Obj FuncELMS_VEC8BIT_RANGE (
         if (p < low + len - 1) {
             while (p < low + len - 1) {
                 elt = gettab[ptrS[p / elts] + 256 * (p % elts)];
-                byte = settab[ byte + 256 * (e + elts * elt)];
+                byte = settab[byte + 256 * (e + elts * elt)];
                 e++;
                 p++;
             }
             *ptrD = byte;
         }
-    } else {
+    }
+    else {
         for (i = 1; i <= len; i++) {
             elt = gettab[ptrS[p / elts] + 256 * (p % elts)];
-            byte = settab[ byte + 256 * (e + elts * elt)];
+            byte = settab[byte + 256 * (e + elts * elt)];
             e++;
             if (e == elts) {
                 *ptrD++ = byte;
@@ -2923,8 +2932,6 @@ Obj FuncELMS_VEC8BIT_RANGE (
 }
 
 
-
-
 /****************************************************************************
 **
 *F  FuncASS_VEC8BIT( <self>, <list>, <pos>, <elm> ) ass. elm of 8bit vector
@@ -2938,31 +2945,26 @@ Obj FuncELMS_VEC8BIT_RANGE (
 
 static Obj AsInternalFFE;
 
-void ASS_VEC8BIT (
-		     Obj                 list,
-		     Obj                 pos,
-		     Obj                 elm )
+void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
 {
-    UInt                p;
-    Obj                 info;
-    UInt                elts;
-    UInt                chr;
-    UInt                d;
-    UInt                q;
-    FF                  f;
+    UInt p;
+    Obj  info;
+    UInt elts;
+    UInt chr;
+    UInt d;
+    UInt q;
+    FF   f;
     UInt v;
-    Obj newelm;
+    Obj  newelm;
 
-    // check that <list> is mutable                                        
-    if (! IS_MUTABLE_OBJ(list)) {
-        ErrorReturnVoid(
-            "List Assignment: <list> must be a mutable list",
-            0L, 0L,
-            "you can 'return;' and ignore the assignment");
+    // check that <list> is mutable
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid("List Assignment: <list> must be a mutable list", 0L,
+                        0L, "you can 'return;' and ignore the assignment");
         return;
     }
 
-    // get the position                                                    
+    // get the position
     RequirePositiveSmallInt("ASS_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
@@ -2975,13 +2977,15 @@ void ASS_VEC8BIT (
     if (p <= LEN_VEC8BIT(list) + 1) {
         if (LEN_VEC8BIT(list) + 1 == p) {
             if (True == DoFilter(IsLockedRepresentationVector, list)) {
-                ErrorReturnVoid("List assignment would increase length of locked compressed vector", 0, 0,
+                ErrorReturnVoid("List assignment would increase length of "
+                                "locked compressed vector",
+                                0, 0,
                                 "You can `return;' to ignore the assignment");
                 return;
             }
             ResizeWordSizedBag(list, SIZE_VEC8BIT(p, elts));
             SET_LEN_VEC8BIT(list, p);
-            //  Pr("Extending 8 bit vector by 1",0,0); 
+            //  Pr("Extending 8 bit vector by 1",0,0);
         }
         if (!IS_FFE(elm)) {
             newelm = DoAttribute(AsInternalFFE, elm);
@@ -2990,11 +2994,11 @@ void ASS_VEC8BIT (
         }
         if (IS_FFE(elm) && chr == CharFFE(elm)) {
 
-            // We may need to rewrite the vector over a larger field 
-            if (d % DegreeFFE(elm) !=  0) {
+            // We may need to rewrite the vector over a larger field
+            if (d % DegreeFFE(elm) != 0) {
                 //        Pr("Rewriting over larger field",0,0);
-                f = CommonFF(FiniteField(chr, d), d,
-                             FLD_FFE(elm), DegreeFFE(elm));
+                f = CommonFF(FiniteField(chr, d), d, FLD_FFE(elm),
+                             DegreeFFE(elm));
                 if (f && SIZE_FF(f) <= 256) {
                     RewriteVec8Bit(list, SIZE_FF(f));
                     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
@@ -3002,7 +3006,8 @@ void ASS_VEC8BIT (
                     chr = P_FIELDINFO_8BIT(info);
                     d = D_FIELDINFO_8BIT(info);
                     q = Q_FIELDINFO_8BIT(info);
-                } else {
+                }
+                else {
                     PlainVec8Bit(list);
                     AssPlistFfe(list, p, elm);
                     return;
@@ -3015,15 +3020,17 @@ void ASS_VEC8BIT (
             // may need to promote the element to a bigger field
             // or restrict it to a smaller one
             if (v != 0 && q != SIZE_FF(FLD_FFE(elm))) {
-                assert(((v - 1) * (q - 1)) % (SIZE_FF(FLD_FFE(elm)) - 1) == 0);
+                assert(((v - 1) * (q - 1)) % (SIZE_FF(FLD_FFE(elm)) - 1) ==
+                       0);
                 v = 1 + (v - 1) * (q - 1) / (SIZE_FF(FLD_FFE(elm)) - 1);
             }
 
-            // finally do the assignment 
-            BYTES_VEC8BIT(list)[(p - 1) / elts] =
-                SETELT_FIELDINFO_8BIT(info)
-                [256 * (elts * FELT_FFE_FIELDINFO_8BIT(info)[v] + (p - 1) % elts) +
-                 BYTES_VEC8BIT(list)[(p - 1) / elts]];
+            // finally do the assignment
+            BYTES_VEC8BIT(list)
+            [(p - 1) / elts] = SETELT_FIELDINFO_8BIT(
+                info)[256 * (elts * FELT_FFE_FIELDINFO_8BIT(info)[v] +
+                             (p - 1) % elts) +
+                      BYTES_VEC8BIT(list)[(p - 1) / elts]];
             return;
         }
     }
@@ -3036,11 +3043,7 @@ void ASS_VEC8BIT (
     AssPlistFfe(list, p, elm);
 }
 
-Obj FuncASS_VEC8BIT (
-		     Obj                 self,
-		     Obj                 list,
-		     Obj                 pos,
-		     Obj                 elm )
+Obj FuncASS_VEC8BIT(Obj self, Obj list, Obj pos, Obj elm)
 {
     ASS_VEC8BIT(list, pos, elm);
     return 0;
@@ -3056,46 +3059,45 @@ Obj FuncASS_VEC8BIT (
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
 */
-Obj FuncUNB_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
 {
-    UInt                p;
-    Obj                 info;
+    UInt p;
+    Obj  info;
     UInt elts;
 
-    // check that <list> is mutable                                        
-    if (! IS_MUTABLE_OBJ(list)) {
-        ErrorReturnVoid(
-            "List Unbind: <list> must be a mutable list",
-            0L, 0L,
-            "you can 'return;' and ignore the unbind");
+    // check that <list> is mutable
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid("List Unbind: <list> must be a mutable list", 0L, 0L,
+                        "you can 'return;' and ignore the unbind");
         return 0;
     }
     if (True == DoFilter(IsLockedRepresentationVector, list)) {
-        ErrorReturnVoid("Unbind of entry of locked compressed vector is forbidden", 0, 0,
-                        "You can `return;' to ignore the assignment");
+        ErrorReturnVoid(
+            "Unbind of entry of locked compressed vector is forbidden", 0, 0,
+            "You can `return;' to ignore the assignment");
         return 0;
     }
 
-    // get the position                                                    
+    // get the position
     RequirePositiveSmallInt("UNB_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
 
-    // if we unbind the last position keep the representation              
+    // if we unbind the last position keep the representation
     if (LEN_VEC8BIT(list) < p) {
         ;
-    } else if (LEN_VEC8BIT(list) == p) {
-        // zero out the last entry first, for safety 
+    }
+    else if (LEN_VEC8BIT(list) == p) {
+        // zero out the last entry first, for safety
         info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
         elts = ELS_BYTE_FIELDINFO_8BIT(info);
-        BYTES_VEC8BIT(list)[(p - 1) / elts] =
-        SETELT_FIELDINFO_8BIT(info)[((p - 1) % elts) * 256 +
-        BYTES_VEC8BIT(list)[(p - 1) / elts]];
+        BYTES_VEC8BIT(list)
+        [(p - 1) / elts] =
+            SETELT_FIELDINFO_8BIT(info)[((p - 1) % elts) * 256 +
+                                        BYTES_VEC8BIT(list)[(p - 1) / elts]];
         ResizeWordSizedBag(list, 3 * sizeof(UInt) + (p + elts - 2) / elts);
         SET_LEN_VEC8BIT(list, p - 1);
-    } else {
+    }
+    else {
         PlainVec8Bit(list);
         UNB_LIST(list, p);
     }
@@ -3105,22 +3107,22 @@ Obj FuncUNB_VEC8BIT (
 /****************************************************************************
 **
 *F  FuncPOSITION_NONZERO_VEC8BIT( <self>, <list>, <zero> ) .
-**                               
+**
 **  The pointless zero argument is because this is a method for PositionNot
 **  It is *not* used in the code and can be replaced by a dummy argument.
 **
 */
 
-UInt PositionNonZeroVec8Bit ( Obj list, UInt from )
+UInt PositionNonZeroVec8Bit(Obj list, UInt from)
 {
-    Obj  info;
-    UInt len;
-    UInt nb;
-    UInt i, j;
-    UInt elts;
-    const UInt1 *ptr;
-    UInt1 byte;
-    UInt1 *gettab;
+    Obj           info;
+    UInt          len;
+    UInt          nb;
+    UInt          i, j;
+    UInt          elts;
+    const UInt1 * ptr;
+    UInt1         byte;
+    UInt1 *       gettab;
 
     len = LEN_VEC8BIT(list);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
@@ -3130,7 +3132,7 @@ UInt PositionNonZeroVec8Bit ( Obj list, UInt from )
     ptr = CONST_BYTES_VEC8BIT(list);
     i = from / elts;
     j = from % elts;
-    // might be an initial part byte 
+    // might be an initial part byte
     if (j) {
         if (i < nb && ptr[i])
             for (j = from % elts; j < elts && (i * elts + j < len); j++)
@@ -3139,14 +3141,14 @@ UInt PositionNonZeroVec8Bit ( Obj list, UInt from )
         i++;
     }
 
-    // skip empty bytes 
+    // skip empty bytes
     while (i < nb && !ptr[i])
         i++;
 
     if (i >= nb)
         return len + 1;
 
-    // Found a non-empty byte, locate the entry 
+    // Found a non-empty byte, locate the entry
     byte = ptr[i];
     j = 0;
     while (gettab[byte + 256 * j] == 0)
@@ -3154,21 +3156,13 @@ UInt PositionNonZeroVec8Bit ( Obj list, UInt from )
     return elts * i + j + 1;
 }
 
-          
 
-Obj FuncPOSITION_NONZERO_VEC8BIT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 zero )
+Obj FuncPOSITION_NONZERO_VEC8BIT(Obj self, Obj list, Obj zero)
 {
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, 0));
 }
 
-Obj FuncPOSITION_NONZERO_VEC8BIT3 (
-    Obj                 self,
-    Obj                 list,
-    Obj                 zero,
-    Obj                 from)
+Obj FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
 {
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, INT_INTOBJ(from)));
 }
@@ -3176,24 +3170,21 @@ Obj FuncPOSITION_NONZERO_VEC8BIT3 (
 /****************************************************************************
 **
 *F  FuncAPPEND_VEC8BIT( <self>, <vecl>, <vecr> ) .
-**                               
+**
 **
 */
-Obj FuncAPPEND_VEC8BIT (
-    Obj                 self,
-    Obj                 vecl,
-    Obj                 vecr )
+Obj FuncAPPEND_VEC8BIT(Obj self, Obj vecl, Obj vecr)
 {
-    Obj                 info;
-    UInt lenl, lenr;
-    UInt nb;
-    UInt i;
-    UInt elts;
-    UInt1 *ptrl;
-    const UInt1 *ptrr;
-    UInt1 bytel, byter, elt;
-    UInt1 *gettab, *settab;
-    UInt posl, posr;
+    Obj           info;
+    UInt          lenl, lenr;
+    UInt          nb;
+    UInt          i;
+    UInt          elts;
+    UInt1 *       ptrl;
+    const UInt1 * ptrr;
+    UInt1         bytel, byter, elt;
+    UInt1 *       gettab, *settab;
+    UInt          posl, posr;
 
     if (FIELD_VEC8BIT(vecl) != FIELD_VEC8BIT(vecr))
         return TRY_NEXT_METHOD;
@@ -3201,8 +3192,8 @@ Obj FuncAPPEND_VEC8BIT (
     lenl = LEN_VEC8BIT(vecl);
     lenr = LEN_VEC8BIT(vecr);
     if (True == DoFilter(IsLockedRepresentationVector, vecl) && lenr > 0) {
-        ErrorReturnVoid("Append to locked compressed vector is forbidden", 0, 0,
-                        "You can `return;' to ignore the operation");
+        ErrorReturnVoid("Append to locked compressed vector is forbidden", 0,
+                        0, "You can `return;' to ignore the operation");
         return 0;
     }
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(vecl));
@@ -3215,7 +3206,8 @@ Obj FuncAPPEND_VEC8BIT (
         nb = (lenr + elts - 1) / elts;
         for (i = 0; i < nb; i++)
             *ptrl++ = *ptrr++;
-    } else {
+    }
+    else {
         ptrl = BYTES_VEC8BIT(vecl) + (lenl - 1) / elts;
         bytel = *ptrl;
         posl = lenl;
@@ -3225,8 +3217,8 @@ Obj FuncAPPEND_VEC8BIT (
         gettab = GETELT_FIELDINFO_8BIT(info);
         settab = SETELT_FIELDINFO_8BIT(info);
         while (posr < lenr) {
-            elt = gettab[ byter + 256 * (posr % elts) ];
-            bytel = settab[ bytel + 256 * (posl % elts + elts * elt)];
+            elt = gettab[byter + 256 * (posr % elts)];
+            bytel = settab[bytel + 256 * (posl % elts + elts * elt)];
             if (++posl % elts == 0) {
                 *ptrl++ = bytel;
                 bytel = 0;
@@ -3235,11 +3227,12 @@ Obj FuncAPPEND_VEC8BIT (
                 byter = *++ptrr;
             }
         }
-        // Write last byte only if not already written: 
-        if (posl % elts != 0) *ptrl = bytel;
+        // Write last byte only if not already written:
+        if (posl % elts != 0)
+            *ptrl = bytel;
     }
     SET_LEN_VEC8BIT(vecl, lenl + lenr);
-    return (Obj) 0;
+    return (Obj)0;
 }
 
 
@@ -3253,34 +3246,34 @@ Obj FuncAPPEND_VEC8BIT (
 **  know that <vec> and <mat> are non-empty
 ** */
 
-Obj FuncPROD_VEC8BIT_MATRIX( Obj self, Obj vec, Obj mat)
+Obj FuncPROD_VEC8BIT_MATRIX(Obj self, Obj vec, Obj mat)
 {
-    Obj res;
-    Obj info;
-    UInt q;
-    UInt len, l2;
-    UInt len1;
-    Obj row1;
-    UInt i;
-    UInt elts;
-    UInt1* gettab;
-    const Obj *ffefelt;
-    Obj x;
+    Obj         res;
+    Obj         info;
+    UInt        q;
+    UInt        len, l2;
+    UInt        len1;
+    Obj         row1;
+    UInt        i;
+    UInt        elts;
+    UInt1 *     gettab;
+    const Obj * ffefelt;
+    Obj         x;
 
     len = LEN_VEC8BIT(vec);
     l2 = LEN_PLIST(mat);
     q = FIELD_VEC8BIT(vec);
 
-    // Get the first row, to establish the size of the result 
+    // Get the first row, to establish the size of the result
     row1 = ELM_PLIST(mat, 1);
-    if (! IS_VEC8BIT_REP(row1) || FIELD_VEC8BIT(row1) != q)
+    if (!IS_VEC8BIT_REP(row1) || FIELD_VEC8BIT(row1) != q)
         return TRY_NEXT_METHOD;
     len1 = LEN_VEC8BIT(row1);
 
-    // create the result space 
+    // create the result space
     res = ZeroVec8Bit(q, len1, IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1));
 
-    // Finally, we start work 
+    // Finally, we start work
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     gettab = GETELT_FIELDINFO_8BIT(info);
@@ -3288,18 +3281,18 @@ Obj FuncPROD_VEC8BIT_MATRIX( Obj self, Obj vec, Obj mat)
 
     for (i = 0; i < len; i++)
         if (i < l2) {
-            x = ffefelt[gettab[CONST_BYTES_VEC8BIT(vec)[i / elts] + 256 * (i % elts)]];
+            x = ffefelt[gettab[CONST_BYTES_VEC8BIT(vec)[i / elts] +
+                               256 * (i % elts)]];
             if (VAL_FFE(x) != 0) {
                 row1 = ELM_PLIST(mat, i + 1);
-                // This may be unduly draconian. Later we may want to be able to promote the rows
-                // to a bigger field
-                if ((! IS_VEC8BIT_REP(row1)) || (FIELD_VEC8BIT(row1) != q))
+                // This may be unduly draconian. Later we may want to be able
+                // to promote the rows to a bigger field
+                if ((!IS_VEC8BIT_REP(row1)) || (FIELD_VEC8BIT(row1) != q))
                     return TRY_NEXT_METHOD;
                 AddVec8BitVec8BitMultInner(res, res, row1, x, 1, len1);
             }
         }
     return res;
-
 }
 
 
@@ -3338,12 +3331,13 @@ static inline void SET_ELM_MAT8BIT(Obj mat, Int i, Obj row)
 *F  PlainMat8Bit( <mat> )
 **
 */
-void PlainMat8Bit(  Obj mat)
+void PlainMat8Bit(Obj mat)
 {
     UInt i, l;
-    Obj row;
-    l  = LEN_MAT8BIT(mat);
-    RetypeBag(mat, IS_MUTABLE_OBJ(mat) ? T_PLIST_TAB : T_PLIST_TAB + IMMUTABLE);
+    Obj  row;
+    l = LEN_MAT8BIT(mat);
+    RetypeBag(mat,
+              IS_MUTABLE_OBJ(mat) ? T_PLIST_TAB : T_PLIST_TAB + IMMUTABLE);
     SET_LEN_PLIST(mat, l);
     for (i = 1; i <= l; i++) {
         row = ELM_MAT8BIT(mat, i);
@@ -3358,7 +3352,7 @@ void PlainMat8Bit(  Obj mat)
 **
 */
 
-Obj FuncPLAIN_MAT8BIT( Obj self, Obj mat)
+Obj FuncPLAIN_MAT8BIT(Obj self, Obj mat)
 {
     PlainMat8Bit(mat);
     return 0;
@@ -3373,11 +3367,11 @@ Obj FuncPLAIN_MAT8BIT( Obj self, Obj mat)
 ** 8 bit vectors, written over the correct field
 */
 
-Obj FuncCONV_MAT8BIT( Obj self, Obj list, Obj q )
+Obj FuncCONV_MAT8BIT(Obj self, Obj list, Obj q)
 {
     UInt len, i, mut;
-    Obj tmp;
-    Obj type;
+    Obj  tmp;
+    Obj  type;
 
     RequirePositiveSmallInt("CONV_MAT8BIT", q, "q");
     PLAIN_LIST(list);
@@ -3399,7 +3393,6 @@ Obj FuncCONV_MAT8BIT( Obj self, Obj list, Obj q )
 }
 
 
-
 /****************************************************************************
 **
 *F ProdVec8BitMat8Bit( <vec>, <mat> )
@@ -3407,19 +3400,19 @@ Obj FuncCONV_MAT8BIT( Obj self, Obj list, Obj q )
 ** The caller must ensure that <vec> and <mat> are compatible
 */
 
-Obj ProdVec8BitMat8Bit( Obj vec, Obj mat )
+Obj ProdVec8BitMat8Bit(Obj vec, Obj mat)
 {
-    UInt q, len, len1, lenm, elts;
-    UInt i, j;
-    UInt1 byte;
-    const UInt1 *bptr;
-    UInt1 y;
-    Obj row1;
-    Obj res;
-    Obj info;
-    UInt1 * gettab;
-    const Obj *ffefelt;
-    Obj x;
+    UInt          q, len, len1, lenm, elts;
+    UInt          i, j;
+    UInt1         byte;
+    const UInt1 * bptr;
+    UInt1         y;
+    Obj           row1;
+    Obj           res;
+    Obj           info;
+    UInt1 *       gettab;
+    const Obj *   ffefelt;
+    Obj           x;
 
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
@@ -3429,7 +3422,7 @@ Obj ProdVec8BitMat8Bit( Obj vec, Obj mat )
     len1 = LEN_VEC8BIT(row1);
     res = ZeroVec8Bit(q, len1, IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1));
 
-    // Finally, we start work 
+    // Finally, we start work
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     gettab = GETELT_FIELDINFO_8BIT(info);
@@ -3438,20 +3431,21 @@ Obj ProdVec8BitMat8Bit( Obj vec, Obj mat )
     bptr = CONST_BYTES_VEC8BIT(vec);
     for (i = 0; i + elts < len; i += elts, bptr++) {
         if ((byte = *bptr)) {
-            for (j = 0; j < elts ; j++) {
+            for (j = 0; j < elts; j++) {
                 if (i + j < lenm) {
                     y = gettab[byte + 256 * j];
                     if (y) {
                         x = ffefelt[y];
                         row1 = ELM_MAT8BIT(mat, i + j + 1);
-                        AddVec8BitVec8BitMultInner(res, res, row1, x, 1, len1);
+                        AddVec8BitVec8BitMultInner(res, res, row1, x, 1,
+                                                   len1);
                     }
                 }
             }
         }
     }
     if ((byte = *bptr)) {
-        for (j = 0; i + j < len  ; j++) {
+        for (j = 0; i + j < len; j++) {
             if (i + j < lenm) {
                 y = gettab[byte + 256 * j];
                 if (y) {
@@ -3474,13 +3468,13 @@ Obj ProdVec8BitMat8Bit( Obj vec, Obj mat )
 **  fields and lengths.
 */
 
-Obj FuncPROD_VEC8BIT_MAT8BIT( Obj self, Obj vec, Obj mat)
+Obj FuncPROD_VEC8BIT_MAT8BIT(Obj self, Obj vec, Obj mat)
 {
     UInt q, q1, q2;
 
-    // Sort out length mismatches 
+    // Sort out length mismatches
 
-    // Now field mismatches -- consider promoting the vector 
+    // Now field mismatches -- consider promoting the vector
     q = FIELD_VEC8BIT(vec);
     q1 = FIELD_VEC8BIT(ELM_MAT8BIT(mat, 1));
     if (q != q1) {
@@ -3496,7 +3490,7 @@ Obj FuncPROD_VEC8BIT_MAT8BIT( Obj self, Obj vec, Obj mat)
             return TRY_NEXT_METHOD;
     }
 
-    // OK, now we can do the work 
+    // OK, now we can do the work
     return ProdVec8BitMat8Bit(vec, mat);
 }
 
@@ -3507,18 +3501,18 @@ Obj FuncPROD_VEC8BIT_MAT8BIT( Obj self, Obj vec, Obj mat)
 ** The caller must ensure compatibility
 */
 
-Obj ProdMat8BitVec8Bit( Obj mat, Obj vec)
+Obj ProdMat8BitVec8Bit(Obj mat, Obj vec)
 {
-    UInt len, i, q;
-    Obj info;
-    UInt1 *settab;
-    Obj res;
-    Obj row1;
-    UInt1 byte;
-    UInt elts;
-    UInt1 *feltffe;
-    UInt1* ptr;
-    Obj entry;
+    UInt    len, i, q;
+    Obj     info;
+    UInt1 * settab;
+    Obj     res;
+    Obj     row1;
+    UInt1   byte;
+    UInt    elts;
+    UInt1 * feltffe;
+    UInt1 * ptr;
+    Obj     entry;
     len = LEN_MAT8BIT(mat);
     q = FIELD_VEC8BIT(vec);
     row1 = ELM_MAT8BIT(mat, 1);
@@ -3532,7 +3526,8 @@ Obj ProdMat8BitVec8Bit( Obj mat, Obj vec)
     ptr = BYTES_VEC8BIT(res);
     for (i = 0; i < len; i++) {
         entry = ScalarProductVec8Bits(vec, ELM_MAT8BIT(mat, i + 1));
-        byte = settab[ byte + 256 * (elts * feltffe[VAL_FFE(entry)] +  i % elts)];
+        byte =
+            settab[byte + 256 * (elts * feltffe[VAL_FFE(entry)] + i % elts)];
         if (i % elts == elts - 1) {
             *ptr++ = byte;
             byte = 0;
@@ -3552,16 +3547,16 @@ Obj ProdMat8BitVec8Bit( Obj mat, Obj vec)
 **  fields and lengths.
 */
 
-Obj FuncPROD_MAT8BIT_VEC8BIT( Obj self, Obj mat, Obj vec)
+Obj FuncPROD_MAT8BIT_VEC8BIT(Obj self, Obj mat, Obj vec)
 {
     UInt q, q1, q2;
-    Obj row;
+    Obj  row;
 
-    // Sort out length mismatches 
+    // Sort out length mismatches
 
     row = ELM_MAT8BIT(mat, 1);
 
-    // Now field mismatches -- consider promoting the vector 
+    // Now field mismatches -- consider promoting the vector
     q = FIELD_VEC8BIT(vec);
     q1 = FIELD_VEC8BIT(row);
     if (q != q1) {
@@ -3577,7 +3572,7 @@ Obj FuncPROD_MAT8BIT_VEC8BIT( Obj self, Obj mat, Obj vec)
             return TRY_NEXT_METHOD;
     }
 
-    // OK, now we can do the work 
+    // OK, now we can do the work
     return ProdMat8BitVec8Bit(mat, vec);
 }
 
@@ -3589,14 +3584,14 @@ Obj FuncPROD_MAT8BIT_VEC8BIT( Obj self, Obj mat, Obj vec)
 **  Caller must check matrix sizes and field
 */
 
-Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
+Obj ProdMat8BitMat8Bit(Obj matl, Obj matr)
 {
-    Obj prod;
+    Obj  prod;
     UInt i;
     UInt len, q;
-    Obj row;
-    Obj locked_type;
-    Obj type;
+    Obj  row;
+    Obj  locked_type;
+    Obj  type;
 
     len = LEN_MAT8BIT(matl);
     q = FIELD_VEC8BIT(ELM_MAT8BIT(matl, 1));
@@ -3608,7 +3603,9 @@ Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
     SET_LEN_MAT8BIT(prod, len);
     type = TypeMat8Bit(q, IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr));
     SET_TYPE_POSOBJ(prod, type);
-    locked_type  = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(matl, 1)) || IS_MUTABLE_OBJ(ELM_MAT8BIT(matr, 1)));
+    locked_type =
+        TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(matl, 1)) ||
+                                 IS_MUTABLE_OBJ(ELM_MAT8BIT(matr, 1)));
     for (i = 1; i <= len; i++) {
         row = ProdVec8BitMat8Bit(ELM_MAT8BIT(matl, i), matr);
 
@@ -3620,7 +3617,6 @@ Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
         TakeInterrupt();
     }
     return prod;
-
 }
 
 /****************************************************************************
@@ -3629,10 +3625,10 @@ Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
 **
 */
 
-Obj FuncPROD_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
+Obj FuncPROD_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 {
     UInt ql, qr;
-    Obj rowl;
+    Obj  rowl;
 
     rowl = ELM_MAT8BIT(matl, 1);
     ql = FIELD_VEC8BIT(rowl);
@@ -3654,27 +3650,27 @@ Obj FuncPROD_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
 **
 */
 
-Obj InverseMat8Bit( Obj mat, UInt mut)
+Obj InverseMat8Bit(Obj mat, UInt mut)
 {
-    Obj cmat, inv;
-    UInt len, off;
-    UInt i, j, k;
-    Obj zero;
-    UInt q;
-    Obj info;
-    UInt1 *ptr;
-    UInt elts;
-    UInt1 *settab, *gettab;
-    UInt1 byte;
-    Obj row, row1, row2;
-    const Obj *ffefelt;
-    UInt1 *feltffe;
-    UInt pos;
-    UInt1 x = 0;
-    UInt o;
-    Obj xi;
-    Obj xn;
-    Obj type;
+    Obj         cmat, inv;
+    UInt        len, off;
+    UInt        i, j, k;
+    Obj         zero;
+    UInt        q;
+    Obj         info;
+    UInt1 *     ptr;
+    UInt        elts;
+    UInt1 *     settab, *gettab;
+    UInt1       byte;
+    Obj         row, row1, row2;
+    const Obj * ffefelt;
+    UInt1 *     feltffe;
+    UInt        pos;
+    UInt1       x = 0;
+    UInt        o;
+    Obj         xi;
+    Obj         xn;
+    Obj         type;
 
     row = ELM_MAT8BIT(mat, 1);
     q = FIELD_VEC8BIT(row);
@@ -3692,7 +3688,8 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
             return Fail;
         xi = INV(ffefelt[x]);
         row1 = NewWordSizedBag(T_DATOBJ, SIZE_VEC8BIT(1, elts));
-        type = TypeVec8BitLocked(q, mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(row)));
+        type = TypeVec8BitLocked(q, mut == 2 ||
+                                        (mut == 1 && IS_MUTABLE_OBJ(row)));
         SetTypeDatObj(row1, type);
         settab = SETELT_FIELDINFO_8BIT(info);
         feltffe = FELT_FFE_FIELDINFO_8BIT(info);
@@ -3709,7 +3706,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         return inv;
     }
 
-    // set up cmat and inv. Note that the row numbering is offset 
+    // set up cmat and inv. Note that the row numbering is offset
     cmat = NEW_PLIST(T_PLIST, len);
     zero = ZeroVec8Bit(q, len, 1);
     o = FELT_FFE_FIELDINFO_8BIT(info)[1];
@@ -3721,9 +3718,9 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         row = SHALLOW_COPY_OBJ(zero);
         ptr = BYTES_VEC8BIT(row) + (i - 1) / elts;
 
-        // we can't retain this pointer, because of garbage collections 
+        // we can't retain this pointer, because of garbage collections
         settab = SETELT_FIELDINFO_8BIT(info);
-        // we know we are replacing a zero  
+        // we know we are replacing a zero
         *ptr = settab[256 * ((i - 1) % elts + o * elts)];
         SET_ELM_PLIST(inv, i + 1, row);
         CHANGED_BAG(inv);
@@ -3737,7 +3734,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
     for (i = 1; i <= len; i++) {
         off = (i - 1) / elts;
         pos = (i - 1) % elts;
-        // find a non-zero entry in column i 
+        // find a non-zero entry in column i
         for (j = i; j <= len; j++) {
             row = ELM_PLIST(cmat, j);
             byte = CONST_BYTES_VEC8BIT(row)[off];
@@ -3745,11 +3742,11 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
                 break;
         }
 
-        // if we didn't find one 
+        // if we didn't find one
         if (j > len)
             return Fail;
 
-        // swap and normalize 
+        // swap and normalize
         row1 = ELM_PLIST(inv, j + 1);
         if (i != j) {
             SET_ELM_PLIST(cmat, j, ELM_PLIST(cmat, i));
@@ -3763,7 +3760,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
             MultVec8BitFFEInner(row1, row1, xi, 1, len);
         }
 
-        // Now clean out column 
+        // Now clean out column
         for (k = 1; k <= len; k++) {
             if (k < i || k > j) {
                 row2 = ELM_PLIST(cmat, k);
@@ -3782,10 +3779,11 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         }
     }
 
-    // Now clean up inv and return it 
+    // Now clean up inv and return it
     SET_ELM_PLIST(inv, 1, INTOBJ_INT(len));
-    type = TypeVec8BitLocked(q, mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(ELM_MAT8BIT(mat, 1))));
-    for (i = 2 ; i <= len + 1; i++) {
+    type = TypeVec8BitLocked(
+        q, mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(ELM_MAT8BIT(mat, 1))));
+    for (i = 2; i <= len + 1; i++) {
         row = ELM_PLIST(inv, i);
         SetTypeDatObj(row, type);
     }
@@ -3802,13 +3800,13 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
 **
 */
 
-Obj FuncINV_MAT8BIT_MUTABLE( Obj self, Obj mat)
+Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
-        mat = ErrorReturnObj("InverseOp: matrix must be square, not %d by %d",
-                             LEN_MAT8BIT(mat),
-                             LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)),
-                             "you can replace matrix <inv> via 'return <inv>;'");
+        mat = ErrorReturnObj(
+            "InverseOp: matrix must be square, not %d by %d",
+            LEN_MAT8BIT(mat), LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)),
+            "you can replace matrix <inv> via 'return <inv>;'");
         return INV(mat);
     }
 
@@ -3821,13 +3819,13 @@ Obj FuncINV_MAT8BIT_MUTABLE( Obj self, Obj mat)
 **
 */
 
-Obj FuncINV_MAT8BIT_SAME_MUTABILITY( Obj self, Obj mat)
+Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
-        mat = ErrorReturnObj("INVOp: matrix must be square, not %d by %d",
-                             LEN_MAT8BIT(mat),
-                             LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)),
-                             "you can replace matrix <inv> via 'return <inv>;'");
+        mat = ErrorReturnObj(
+            "INVOp: matrix must be square, not %d by %d", LEN_MAT8BIT(mat),
+            LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)),
+            "you can replace matrix <inv> via 'return <inv>;'");
         return INV_MUT(mat);
     }
 
@@ -3840,14 +3838,14 @@ Obj FuncINV_MAT8BIT_SAME_MUTABILITY( Obj self, Obj mat)
 **
 */
 
-Obj FuncINV_MAT8BIT_IMMUTABLE( Obj self, Obj mat)
+Obj FuncINV_MAT8BIT_IMMUTABLE(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         Obj inv;
-        mat = ErrorReturnObj("Inverse: matrix must be square, not %d by %d",
-                             LEN_MAT8BIT(mat),
-                             LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)),
-                             "you can replace matrix <inv> via 'return <inv>;'");
+        mat = ErrorReturnObj(
+            "Inverse: matrix must be square, not %d by %d", LEN_MAT8BIT(mat),
+            LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)),
+            "you can replace matrix <inv> via 'return <inv>;'");
         inv = INV_MUT(mat);
         MakeImmutable(inv);
         return inv;
@@ -3869,9 +3867,9 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
     UInt len2;
     UInt q;
     UInt q1, q2;
-    Obj row;
+    Obj  row;
     UInt pos;
-    Obj type;
+    Obj  type;
 
     RequirePositiveSmallInt("ASS_MAT8BIT", p, "position");
     pos = INT_INTOBJ(p);
@@ -3887,12 +3885,15 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
         if (IS_VEC8BIT_REP(obj)) {
             q = FIELD_VEC8BIT(obj);
             goto cando;
-        } else {
+        }
+        else {
             SET_TYPE_POSOBJ(mat, IS_MUTABLE_OBJ(mat) ? TYPE_LIST_GF2MAT
                                                      : TYPE_LIST_GF2MAT_IMM);
-            SetTypeDatObj(obj, IS_MUTABLE_OBJ(obj) ? TYPE_LIST_GF2VEC_LOCKED : TYPE_LIST_GF2VEC_IMM_LOCKED);
+            SetTypeDatObj(obj, IS_MUTABLE_OBJ(obj)
+                                   ? TYPE_LIST_GF2VEC_LOCKED
+                                   : TYPE_LIST_GF2VEC_IMM_LOCKED);
             SET_ELM_GF2MAT(mat, 1, obj);
-            return (Obj) 0;
+            return (Obj)0;
         }
     }
 
@@ -3909,7 +3910,8 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
 
     q = FIELD_VEC8BIT(row);
     if (IS_GF2VEC_REP(obj)) {
-        if (q % 2 != 0 || CALL_1ARGS(IsLockedRepresentationVector, obj) == True)
+        if (q % 2 != 0 ||
+            CALL_1ARGS(IsLockedRepresentationVector, obj) == True)
             goto cantdo;
         else {
             RewriteGF2Vec(obj, q);
@@ -3944,7 +3946,7 @@ cando:
     SetTypeDatObj(obj, type);
     SET_ELM_MAT8BIT(mat, pos, obj);
     CHANGED_BAG(mat);
-    return (Obj) 0;
+    return (Obj)0;
 
 cantdo:
     PlainMat8Bit(mat);
@@ -3960,12 +3962,13 @@ cantdo:
 *F  FuncELM_MAT8BIT( <self>, <mat>, <row> ) .  select a row of an 8bit matrix
 **
 */
-Obj FuncELM_MAT8BIT( Obj self, Obj mat, Obj row )
+Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj row)
 {
     RequirePositiveSmallInt("ELM_MAT8BIT", row, "position");
     UInt r = INT_INTOBJ(row);
     if (LEN_MAT8BIT(mat) < r) {
-        ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_MAT8BIT(mat));
+        ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
+                     LEN_MAT8BIT(mat));
     }
     return ELM_MAT8BIT(mat, r);
 }
@@ -3978,29 +3981,29 @@ Obj FuncELM_MAT8BIT( Obj self, Obj mat, Obj row )
 **  Caller's job to do all checks
 */
 
-Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
+Obj SumMat8BitMat8Bit(Obj ml, Obj mr)
 {
-    Obj sum;
+    Obj  sum;
     UInt ll, lr, wl, wr, ls;
     UInt q;
     UInt i;
     Obj  row;
-    Obj type;
+    Obj  type;
     ll = LEN_MAT8BIT(ml);
     lr = LEN_MAT8BIT(mr);
     wl = LEN_VEC8BIT(ELM_MAT8BIT(ml, 1));
     wr = LEN_VEC8BIT(ELM_MAT8BIT(mr, 1));
 
-    // We have to track the cases where the result is not rectangular 
-    if (((ll > lr) && (wr > wl)) ||
-    ((lr > ll) && (wl > wr)))
+    // We have to track the cases where the result is not rectangular
+    if (((ll > lr) && (wr > wl)) || ((lr > ll) && (wl > wr)))
         return TRY_NEXT_METHOD;
 
-    // Now sort out the size of the result 
+    // Now sort out the size of the result
     if (ll > lr) {
         ls = ll;
         assert(wl > wr);
-    } else {
+    }
+    else {
         ls = lr;
         assert(wr >= wl);
     }
@@ -4011,7 +4014,8 @@ Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
     SET_TYPE_POSOBJ(sum, type);
     SET_LEN_MAT8BIT(sum, ls);
 
-    type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(ml, 1)) || IS_MUTABLE_OBJ(ELM_MAT8BIT(mr, 1)));
+    type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(ml, 1)) ||
+                                    IS_MUTABLE_OBJ(ELM_MAT8BIT(mr, 1)));
 
     for (i = 1; i <= ls; i++) {
         if (i > ll)
@@ -4035,7 +4039,7 @@ Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
 **  Caller should check that both args are mat8bit over the same field
 */
 
-Obj FuncSUM_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
+Obj FuncSUM_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     UInt q;
     q = FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1));
@@ -4052,17 +4056,17 @@ Obj FuncSUM_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
 **  Caller's job to do all checks
 */
 
-Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
+Obj DiffMat8BitMat8Bit(Obj ml, Obj mr)
 {
-    Obj diff;
+    Obj  diff;
     UInt q;
     UInt i;
     Obj  row;
-    Obj type;
-    Obj info;
-    FF f;
-    FFV minusOne;
-    Obj mone;
+    Obj  type;
+    Obj  info;
+    FF   f;
+    FFV  minusOne;
+    Obj  mone;
     UInt ll, lr, wl, wr, ld;
 
     ll = LEN_MAT8BIT(ml);
@@ -4070,16 +4074,16 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
     wl = LEN_VEC8BIT(ELM_MAT8BIT(ml, 1));
     wr = LEN_VEC8BIT(ELM_MAT8BIT(mr, 1));
 
-    // We have to track the cases where the result is not rectangular 
-    if (((ll > lr) && (wr > wl)) ||
-        ((lr > ll) && (wl > wr)))
+    // We have to track the cases where the result is not rectangular
+    if (((ll > lr) && (wr > wl)) || ((lr > ll) && (wl > wr)))
         return TRY_NEXT_METHOD;
 
-    // Now sort out the size of the result 
+    // Now sort out the size of the result
     if (ll > lr) {
         ld = ll;
         assert(wl > wr);
-    } else {
+    }
+    else {
         ld = lr;
         assert(wr >= wl);
     }
@@ -4092,7 +4096,8 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
     type = TypeMat8Bit(q, IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr));
     SET_TYPE_POSOBJ(diff, type);
     SET_LEN_MAT8BIT(diff, ld);
-    type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(ml, 1)) || IS_MUTABLE_OBJ(ELM_MAT8BIT(mr, 1)));
+    type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(ELM_MAT8BIT(ml, 1)) ||
+                                    IS_MUTABLE_OBJ(ELM_MAT8BIT(mr, 1)));
     info = GetFieldInfo8Bit(q);
     f = FiniteField(P_FIELDINFO_8BIT(info), D_FIELDINFO_8BIT(info));
     minusOne = NEG_FFV(1, SUCC_FF(f));
@@ -4104,7 +4109,8 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
         else if (i > lr)
             row = CopyVec8Bit(ELM_MAT8BIT(ml, i), 1);
         else
-            row = SumVec8BitVec8BitMult(ELM_MAT8BIT(ml, i), ELM_MAT8BIT(mr, i), mone);
+            row = SumVec8BitVec8BitMult(ELM_MAT8BIT(ml, i),
+                                        ELM_MAT8BIT(mr, i), mone);
 
         SetTypeDatObj(row, type);
         SET_ELM_MAT8BIT(diff, i, row);
@@ -4120,7 +4126,7 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
 **  Caller should check that both args are mat8bit over the same field
 */
 
-Obj FuncDIFF_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
+Obj FuncDIFF_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     UInt q;
 
@@ -4139,16 +4145,16 @@ Obj FuncDIFF_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
 ** The first batch are utilities for the others
 */
 
-UInt RightMostNonZeroVec8Bit( Obj vec)
+UInt RightMostNonZeroVec8Bit(Obj vec)
 {
-    UInt q;
-    UInt len;
-    Obj info;
-    UInt elts;
+    UInt         q;
+    UInt         len;
+    Obj          info;
+    UInt         elts;
     const UInt1 *ptr, *ptrS;
-    Int i;
-    UInt1 *gettab;
-    //UInt1 byte; 
+    Int          i;
+    UInt1 *      gettab;
+    // UInt1 byte;
     len = LEN_VEC8BIT(vec);
     if (len == 0)
         return 0;
@@ -4158,7 +4164,7 @@ UInt RightMostNonZeroVec8Bit( Obj vec)
     ptrS = CONST_BYTES_VEC8BIT(vec);
     ptr = ptrS + (len - 1) / elts;
 
-    // handle last byte specially, unless it happens to be full 
+    // handle last byte specially, unless it happens to be full
     if (len % elts != 0) {
         gettab = GETELT_FIELDINFO_8BIT(info) + *ptr;
         for (i = len % elts - 1; i >= 0; i--) {
@@ -4168,38 +4174,38 @@ UInt RightMostNonZeroVec8Bit( Obj vec)
         ptr--;
     }
 
-    // now skip over empty bytes 
+    // now skip over empty bytes
     while (ptr >= ptrS && *ptr == 0)
-        ptr --;
+        ptr--;
     if (ptr < ptrS)
         return 0;
 
 
-    // Now look in the rightmost non-empty byte for the position 
+    // Now look in the rightmost non-empty byte for the position
     gettab = GETELT_FIELDINFO_8BIT(info) + *ptr;
     for (i = elts - 1; i >= 0; i--) {
-        if (gettab[256 * i]  != 0)
+        if (gettab[256 * i] != 0)
             return (elts * (ptr - ptrS) + i + 1);
     }
     Panic("this should never happen");
 }
 
-void ResizeVec8Bit( Obj vec, UInt newlen, UInt knownclean )
+void ResizeVec8Bit(Obj vec, UInt newlen, UInt knownclean)
 {
-    UInt q;
-    UInt len;
-    UInt elts;
-    Obj info;
-    UInt1 *settab;
-    UInt i;
-    UInt1 *ptr, *ptr2, byte;
+    UInt    q;
+    UInt    len;
+    UInt    elts;
+    Obj     info;
+    UInt1 * settab;
+    UInt    i;
+    UInt1 * ptr, *ptr2, byte;
     len = LEN_VEC8BIT(vec);
     if (len == newlen)
         return;
 
     if (True == DoFilter(IsLockedRepresentationVector, vec)) {
-        ErrorReturnVoid("Resize of locked compressed vector is forbidden", 0, 0,
-        "You can `return;' to ignore the operation");
+        ErrorReturnVoid("Resize of locked compressed vector is forbidden", 0,
+                        0, "You can `return;' to ignore the operation");
         return;
     }
 
@@ -4208,23 +4214,23 @@ void ResizeVec8Bit( Obj vec, UInt newlen, UInt knownclean )
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     SET_LEN_VEC8BIT(vec, newlen);
     ResizeWordSizedBag(vec, SIZE_VEC8BIT(newlen, elts));
-    // vector has got shorter. 
+    // vector has got shorter.
     if (len > newlen) {
         if (newlen % elts) {
-            // clean spare entries in last byte 
+            // clean spare entries in last byte
             settab = SETELT_FIELDINFO_8BIT(info);
             byte = CONST_BYTES_VEC8BIT(vec)[(newlen - 1) / elts];
             for (i = newlen % elts; i < elts; i++)
-                byte = settab[ byte + 256 * i];
+                byte = settab[byte + 256 * i];
             BYTES_VEC8BIT(vec)[(newlen - 1) / elts] = byte;
         }
-        // Clean spare bytes in last word for characteristic 2 
+        // Clean spare bytes in last word for characteristic 2
         if ((q % 2) == 0)
             for (i = (newlen + elts - 1) / elts; i % sizeof(UInt); i++)
                 BYTES_VEC8BIT(vec)[i] = 0;
     }
 
-    // vector has got longer and might be dirty 
+    // vector has got longer and might be dirty
     if (!knownclean && newlen > len) {
         settab = SETELT_FIELDINFO_8BIT(info);
         ptr = BYTES_VEC8BIT(vec);
@@ -4232,7 +4238,7 @@ void ResizeVec8Bit( Obj vec, UInt newlen, UInt knownclean )
             ptr += (len - 1) / elts;
             byte = *ptr;
             for (i = (len - 1) % elts + 1; i < elts; i++)
-                byte = settab[ byte + 256 * i];
+                byte = settab[byte + 256 * i];
             *ptr++ = byte;
         }
         ptr2 = BYTES_VEC8BIT(vec) + (newlen + elts - 1) / elts;
@@ -4242,19 +4248,19 @@ void ResizeVec8Bit( Obj vec, UInt newlen, UInt knownclean )
 }
 
 
-void ShiftLeftVec8Bit( Obj vec, UInt amount)
+void ShiftLeftVec8Bit(Obj vec, UInt amount)
 {
-    UInt q;
-    Obj info;
-    UInt elts;
-    UInt len;
+    UInt   q;
+    Obj    info;
+    UInt   elts;
+    UInt   len;
     UInt1 *ptr1, *ptr2, *end;
-    UInt1 fbyte, tbyte;
-    UInt from, to;
+    UInt1  fbyte, tbyte;
+    UInt   from, to;
     UInt1 *gettab, *settab;
-    UInt1 x;
+    UInt1  x;
 
-    // A couple of trivial cases 
+    // A couple of trivial cases
     if (amount == 0)
         return;
     len = LEN_VEC8BIT(vec);
@@ -4270,12 +4276,13 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
     ptr2 = BYTES_VEC8BIT(vec) + amount / elts;
     end = BYTES_VEC8BIT(vec) + (len + elts - 1) / elts;
 
-    // The easy case is just a shift by bytes 
+    // The easy case is just a shift by bytes
     if (amount % elts == 0) {
         while (ptr2 < end)
             *ptr1++ = *ptr2++;
-    } else {
-        // The general case 
+    }
+    else {
+        // The general case
         from = amount;
         to = 0;
         fbyte = *ptr2;
@@ -4286,9 +4293,8 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
         while (from < len) {
             x = gettab[fbyte + 256 * (from % elts)];
             tbyte = settab[tbyte + 256 * (to % elts + elts * x)];
-            if (++from % elts == 0)
-            {
-                if(++ptr2 < end)
+            if (++from % elts == 0) {
+                if (++ptr2 < end)
                     fbyte = *ptr2;
                 else
                     fbyte = 0;
@@ -4304,23 +4310,23 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
     ResizeVec8Bit(vec, len - amount, 0);
 }
 
-void ShiftRightVec8Bit( Obj vec, UInt amount) // pads with zeros 
+void ShiftRightVec8Bit(Obj vec, UInt amount)    // pads with zeros
 {
-    UInt q;
-    Obj info;
-    UInt elts;
-    UInt len;
+    UInt   q;
+    Obj    info;
+    UInt   elts;
+    UInt   len;
     UInt1 *ptr1, *ptr2, *end;
-    UInt1 fbyte, tbyte;
-    Int from, to;
+    UInt1  fbyte, tbyte;
+    Int    from, to;
     UInt1 *gettab, *settab;
-    UInt1 x;
+    UInt1  x;
 
-    // A trivial cases 
+    // A trivial cases
     if (amount == 0)
         return;
 
-    // make room 
+    // make room
     len = LEN_VEC8BIT(vec);
     ResizeVec8Bit(vec, len + amount, 0);
 
@@ -4330,15 +4336,16 @@ void ShiftRightVec8Bit( Obj vec, UInt amount) // pads with zeros
     ptr1 = BYTES_VEC8BIT(vec) + (len - 1 + amount) / elts;
     ptr2 = BYTES_VEC8BIT(vec) + (len - 1) / elts;
 
-    // The easy case is just a shift by bytes 
+    // The easy case is just a shift by bytes
     if (amount % elts == 0) {
         end = BYTES_VEC8BIT(vec);
         while (ptr2 >= end)
             *ptr1-- = *ptr2--;
         while (ptr1 >= end)
             *ptr1-- = (UInt1)0;
-    } else {
-        // The general case 
+    }
+    else {
+        // The general case
         from = len - 1;
         to = len + amount - 1;
         fbyte = *ptr2;
@@ -4365,7 +4372,6 @@ void ShiftRightVec8Bit( Obj vec, UInt amount) // pads with zeros
 }
 
 
-
 /****************************************************************************
 **
 *F FuncADD_COEFFS_VEC8BIT_3( <self>, <vec1>, <vec2>, <mult> )
@@ -4375,7 +4381,7 @@ void ShiftRightVec8Bit( Obj vec, UInt amount) // pads with zeros
 ** result.
 */
 
-Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
+Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
 {
     UInt q;
     UInt len;
@@ -4386,15 +4392,15 @@ Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
         ResizeVec8Bit(vec1, len, 0);
     }
 
-    // Now we know that the characteristics must match, but not the fields 
+    // Now we know that the characteristics must match, but not the fields
     q = FIELD_VEC8BIT(vec1);
 
-    // fix up fields if necessary 
+    // fix up fields if necessary
     if (q != FIELD_VEC8BIT(vec2) || q != SIZE_FF(FLD_FFE(mult))) {
-        Obj info, info1;
+        Obj  info, info1;
         UInt d, d1, q1, d2, d0, q0, p, i;
-        FFV val;
-        // find a common field 
+        FFV  val;
+        // find a common field
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vec2);
@@ -4410,11 +4416,13 @@ Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
-        if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vec1) == True) ||
-        (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vec2) == True))
+        if ((q0 > q &&
+             CALL_1ARGS(IsLockedRepresentationVector, vec1) == True) ||
+            (q0 > q1 &&
+             CALL_1ARGS(IsLockedRepresentationVector, vec2) == True))
             return TRY_NEXT_METHOD;
         RewriteVec8Bit(vec1, q0);
         RewriteVec8Bit(vec2, q0);
@@ -4437,7 +4445,7 @@ Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
 ** result.
 */
 
-Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
+Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
 {
     UInt q;
     UInt len;
@@ -4446,19 +4454,19 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
         ResizeVec8Bit(vec1, len, 0);
     }
 
-    // Now we know that the characteristics must match, but not the fields 
+    // Now we know that the characteristics must match, but not the fields
     q = FIELD_VEC8BIT(vec1);
 
-    // fix up fields if necessary 
+    // fix up fields if necessary
     if (q != FIELD_VEC8BIT(vec2)) {
-        Obj info, info1;
+        Obj  info, info1;
         UInt d, d1, q1, d0, q0, p, i;
 
-        // find a common field 
+        // find a common field
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vec2);
-        //Pr("q= %d q1= %d ",q,q1);
+        // Pr("q= %d q1= %d ",q,q1);
         info1 = GetFieldInfo8Bit(q1);
         d1 = D_FIELDINFO_8BIT(info1);
         d0 = LcmDegree(d, d1);
@@ -4467,13 +4475,15 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
-        //Pr("q0= %d d0= %d\n",q0,d0); 
+        // Pr("q0= %d d0= %d\n",q0,d0);
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
-        if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vec1) == True) ||
-            (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vec2) == True))
+        if ((q0 > q &&
+             CALL_1ARGS(IsLockedRepresentationVector, vec1) == True) ||
+            (q0 > q1 &&
+             CALL_1ARGS(IsLockedRepresentationVector, vec2) == True))
             return TRY_NEXT_METHOD;
         RewriteVec8Bit(vec1, q0);
         RewriteVec8Bit(vec2, q0);
@@ -4489,17 +4499,18 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
 **
 */
 
-Obj FuncSHIFT_VEC8BIT_LEFT( Obj self, Obj vec, Obj amount)
+Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 {
-    // should be checked in method selection 
+    // should be checked in method selection
     assert(IS_MUTABLE_OBJ(vec));
     while (!IS_INTOBJ(amount) || INT_INTOBJ(amount) < 0) {
-        amount = ErrorReturnObj("SHIFT_VEC8BIT_LEFT: <amount> must be a non-negative small integer",
-                                0, 0,
-                                "you can replace <amount> via 'return <amount>;'");
+        amount = ErrorReturnObj(
+            "SHIFT_VEC8BIT_LEFT: <amount> must be a non-negative small "
+            "integer",
+            0, 0, "you can replace <amount> via 'return <amount>;'");
     }
     ShiftLeftVec8Bit(vec, INT_INTOBJ(amount));
-    return (Obj) 0;
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -4508,16 +4519,17 @@ Obj FuncSHIFT_VEC8BIT_LEFT( Obj self, Obj vec, Obj amount)
 **
 */
 
-Obj FuncSHIFT_VEC8BIT_RIGHT( Obj self, Obj vec, Obj amount, Obj zero)
+Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 {
     assert(IS_MUTABLE_OBJ(vec));
     while (!IS_INTOBJ(amount) || INT_INTOBJ(amount) < 0) {
-        amount = ErrorReturnObj("SHIFT_VEC8BIT_RIGHT: <amount> must be a non-negative small integer",
-                                0, 0,
-                                "you can replace <amount> via 'return <amount>;'");
+        amount = ErrorReturnObj(
+            "SHIFT_VEC8BIT_RIGHT: <amount> must be a non-negative small "
+            "integer",
+            0, 0, "you can replace <amount> via 'return <amount>;'");
     }
     ShiftRightVec8Bit(vec, INT_INTOBJ(amount));
-    return (Obj) 0;
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -4526,28 +4538,28 @@ Obj FuncSHIFT_VEC8BIT_RIGHT( Obj self, Obj vec, Obj amount, Obj zero)
 **
 */
 
-Obj FuncRESIZE_VEC8BIT( Obj self, Obj vec, Obj newsize )
+Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
 {
     if (!IS_MUTABLE_OBJ(vec))
-        ErrorReturnVoid("RESIZE_VEC8BIT: vector must be mutable",
-                        0, 0,
+        ErrorReturnVoid("RESIZE_VEC8BIT: vector must be mutable", 0, 0,
                         "you can 'return;'");
     while (IS_INTOBJ(newsize) && INT_INTOBJ(newsize) < 0) {
-        newsize = ErrorReturnObj("RESIZE_VEC8BIT: <amount> must be a non-negative integer, not %d",
-                                 INT_INTOBJ(newsize), 0,
-                                 "you can replace <amount> via 'return <amount>;'");
+        newsize = ErrorReturnObj(
+            "RESIZE_VEC8BIT: <amount> must be a non-negative integer, not %d",
+            INT_INTOBJ(newsize), 0,
+            "you can replace <amount> via 'return <amount>;'");
     }
     ResizeVec8Bit(vec, INT_INTOBJ(newsize), 0);
-    return (Obj) 0;
+    return (Obj)0;
 }
-  
+
 /****************************************************************************
 **
 *F  FuncRIGHTMOST_NONZERO_VEC8BIT( <self>, <vec> )
 **
 */
 
-Obj FuncRIGHTMOST_NONZERO_VEC8BIT( Obj self, Obj vec)
+Obj FuncRIGHTMOST_NONZERO_VEC8BIT(Obj self, Obj vec)
 {
     return INTOBJ_INT(RightMostNonZeroVec8Bit(vec));
 }
@@ -4558,21 +4570,21 @@ Obj FuncRIGHTMOST_NONZERO_VEC8BIT( Obj self, Obj vec)
 **
 */
 
-void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
+void ProdCoeffsVec8Bit(Obj res, Obj vl, UInt ll, Obj vr, UInt lr)
 {
-    UInt q;
-    Obj info;
-    UInt elts;
-    UInt1 * addtab = 0;
-    UInt1 * pmulltab;
-    UInt1 * pmulutab = 0;
-    UInt p;
-    UInt i, j;
+    UInt         q;
+    Obj          info;
+    UInt         elts;
+    UInt1 *      addtab = 0;
+    UInt1 *      pmulltab;
+    UInt1 *      pmulutab = 0;
+    UInt         p;
+    UInt         i, j;
     const UInt1 *ptrl, *ptrr;
-    UInt1 *ptrp, bytel, byter;
-    UInt1 byte1, byte2;
-    UInt1 * gettab, *settab;
-    UInt1 partl = 0, partr = 0;
+    UInt1 *      ptrp, bytel, byter;
+    UInt1        byte1, byte2;
+    UInt1 *      gettab, *settab;
+    UInt1        partl = 0, partr = 0;
     q = FIELD_VEC8BIT(vl);
     assert(q == FIELD_VEC8BIT(vr));
     assert(q == FIELD_VEC8BIT(res));
@@ -4599,18 +4611,19 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
             for (j = 0; j < lr / elts; j++) {
                 byter = ptrr[j];
                 if (byter != 0) {
-                    byte1 = pmulltab[ 256 * bytel + byter];
+                    byte1 = pmulltab[256 * bytel + byter];
                     if (byte1 != 0) {
                         if (p != 2)
-                            ptrp[i + j] = addtab[ ptrp[i + j] + 256 * byte1];
+                            ptrp[i + j] = addtab[ptrp[i + j] + 256 * byte1];
                         else
                             ptrp[i + j] ^= byte1;
                     }
                     if (elts > 1) {
-                        byte2 = pmulutab[ 256 * bytel + byter];
+                        byte2 = pmulutab[256 * bytel + byter];
                         if (byte2 != 0) {
                             if (p != 2)
-                                ptrp[i + j + 1] = addtab[ ptrp[i + j + 1] + 256 * byte2];
+                                ptrp[i + j + 1] =
+                                    addtab[ptrp[i + j + 1] + 256 * byte2];
                             else
                                 ptrp[i + j + 1] ^= byte2;
                         }
@@ -4619,8 +4632,8 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
             }
     }
 
-    // The next two deal with the end byte from each polynomial, in combination with the whole
-    // bytes from the other polynomial
+    // The next two deal with the end byte from each polynomial, in
+    // combination with the whole bytes from the other polynomial
     gettab = GETELT_FIELDINFO_8BIT(info);
     settab = SETELT_FIELDINFO_8BIT(info);
     if (ll % elts != 0) {
@@ -4629,24 +4642,27 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
             partl = 0;
             for (i = (ll / elts) * elts; i < ll; i++) {
                 byte1 = gettab[bytel + 256 * (i % elts)];
-                partl = settab[partl + 256 * (i  % elts + elts * byte1)];
+                partl = settab[partl + 256 * (i % elts + elts * byte1)];
             }
             if (partl != 0)
                 for (j = 0; j < lr / elts; j++) {
                     byter = ptrr[j];
                     if (byter != 0) {
-                        byte2 = pmulltab[ 256 * partl + byter];
+                        byte2 = pmulltab[256 * partl + byter];
                         if (byte2 != 0) {
                             if (p != 2)
-                                ptrp[ll / elts + j] = addtab[ ptrp[ll / elts + j] + 256 * byte2];
+                                ptrp[ll / elts + j] =
+                                    addtab[ptrp[ll / elts + j] + 256 * byte2];
                             else
                                 ptrp[ll / elts + j] ^= byte2;
                         }
                         if (elts > 1) {
-                            byte2 = pmulutab[ 256 * partl + byter];
+                            byte2 = pmulutab[256 * partl + byter];
                             if (byte2 != 0) {
                                 if (p != 2)
-                                    ptrp[ll / elts + j + 1] = addtab[ ptrp[ll / elts + j + 1] + 256 * byte2];
+                                    ptrp[ll / elts + j + 1] =
+                                        addtab[ptrp[ll / elts + j + 1] +
+                                               256 * byte2];
                                 else
                                     ptrp[ll / elts + j + 1] ^= byte2;
                             }
@@ -4660,23 +4676,29 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
         if (byter != 0) {
             partr = 0;
             for (i = (lr / elts) * elts; i < lr; i++)
-                partr = settab[partr + 256 * (i  % elts + elts * gettab[byter + 256 * (i % elts)])];
+                partr =
+                    settab[partr +
+                           256 * (i % elts +
+                                  elts * gettab[byter + 256 * (i % elts)])];
             if (partr != 0)
                 for (i = 0; i < ll / elts; i++) {
                     bytel = ptrl[i];
                     if (bytel != 0) {
-                        byte1 = pmulltab[ 256 * partr + bytel];
+                        byte1 = pmulltab[256 * partr + bytel];
                         if (byte1 != 0) {
                             if (p != 2)
-                                ptrp[lr / elts  + i] = addtab[ ptrp[lr / elts + i] + 256 * byte1];
+                                ptrp[lr / elts + i] =
+                                    addtab[ptrp[lr / elts + i] + 256 * byte1];
                             else
                                 ptrp[lr / elts + i] ^= byte1;
                         }
                         if (elts > 1) {
-                            byte1 = pmulutab[ 256 * partr + bytel];
+                            byte1 = pmulutab[256 * partr + bytel];
                             if (byte1 != 0) {
                                 if (p != 2)
-                                    ptrp[lr / elts + i + 1] = addtab[ ptrp[lr / elts + i + 1] + 256 * byte1];
+                                    ptrp[lr / elts + i + 1] =
+                                        addtab[ptrp[lr / elts + i + 1] +
+                                               256 * byte1];
                                 else
                                     ptrp[lr / elts + i + 1] ^= byte1;
                             }
@@ -4686,20 +4708,22 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
         }
     }
 
-    // Finally, we have to multiply the two end bytes 
+    // Finally, we have to multiply the two end bytes
     if (ll % elts != 0 && lr % elts != 0 && partl != 0 && partr != 0) {
-        byte1 = pmulltab[ partl + 256 * partr];
+        byte1 = pmulltab[partl + 256 * partr];
         if (byte1 != 0) {
             if (p != 2)
-                ptrp[ll / elts + lr / elts] = addtab[ptrp[ll / elts + lr / elts] + 256 * byte1];
+                ptrp[ll / elts + lr / elts] =
+                    addtab[ptrp[ll / elts + lr / elts] + 256 * byte1];
             else
                 ptrp[ll / elts + lr / elts] ^= byte1;
         }
         if (elts > 1) {
-            byte2 = pmulutab[ partl + 256 * partr];
+            byte2 = pmulutab[partl + 256 * partr];
             if (byte2 != 0) {
                 if (p != 2)
-                    ptrp[ll / elts + lr / elts + 1] = addtab[ptrp[ll / elts + lr / elts + 1] + 256 * byte2];
+                    ptrp[ll / elts + lr / elts + 1] =
+                        addtab[ptrp[ll / elts + lr / elts + 1] + 256 * byte2];
                 else
                     ptrp[ll / elts + lr / elts + 1] ^= byte2;
             }
@@ -4713,12 +4737,12 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
 **
 */
 
-Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
+Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
 {
-    Int ll1, lr1;
+    Int  ll1, lr1;
     UInt q;
-    Obj info;
-    Obj res;
+    Obj  info;
+    Obj  res;
     UInt lenp;
     UInt last;
     q = FIELD_VEC8BIT(vl);
@@ -4726,7 +4750,7 @@ Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
         Obj  info1;
         UInt d, d1, q1, d0, q0, p, i;
 
-        // find a common field 
+        // find a common field
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -4739,33 +4763,37 @@ Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        // if the exponent is bigger than 31, overflow changes the value to 0 
+        // if the exponent is bigger than 31, overflow changes the value to 0
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
-        if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
-        (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vr) == True))
+        if ((q0 > q &&
+             CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
+            (q0 > q1 && CALL_1ARGS(IsLockedRepresentationVector, vr) == True))
             return TRY_NEXT_METHOD;
         RewriteVec8Bit(vl, q0);
         RewriteVec8Bit(vr, q0);
         q = q0;
     }
     if (!ARE_INTOBJS(ll, lr))
-        ErrorQuit("PROD_COEFFS_VEC8BIT: both lengths must be small integers, not a %s and a %s",
+        ErrorQuit("PROD_COEFFS_VEC8BIT: both lengths must be small integers, "
+                  "not a %s and a %s",
                   (Int)TNAM_OBJ(ll), (Int)TNAM_OBJ(lr));
     ll1 = INT_INTOBJ(ll);
     lr1 = INT_INTOBJ(lr);
     if (0 > ll1 || ll1 > LEN_VEC8BIT(vl))
-        ErrorQuit("ProdCoeffs: given length <ll> of left argt (%d)\n is negative or longer than the argt (%d)",
+        ErrorQuit("ProdCoeffs: given length <ll> of left argt (%d)\n is "
+                  "negative or longer than the argt (%d)",
                   INT_INTOBJ(ll), LEN_VEC8BIT(vl));
     if (0 > lr1 || lr1 > LEN_VEC8BIT(vr))
-        ErrorQuit("ProdCoeffs: given length <lr> of right argt (%d)\n is negative or longer than the argt (%d)",
+        ErrorQuit("ProdCoeffs: given length <lr> of right argt (%d)\n is "
+                  "negative or longer than the argt (%d)",
                   INT_INTOBJ(lr), LEN_VEC8BIT(vr));
     info = GetFieldInfo8Bit(q);
     if (ll1 == 0 && lr1 == 0)
         lenp = 0;
     else
         lenp = ll1 + lr1 - 1;
-    res = ZeroVec8Bit(q, lenp , 1);
+    res = ZeroVec8Bit(q, lenp, 1);
     ProdCoeffsVec8Bit(res, vl, ll1, vr, lr1);
     last = RightMostNonZeroVec8Bit(res);
     if (last != lenp)
@@ -4779,23 +4807,23 @@ Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
 **
 */
 
-Obj MakeShiftedVecs( Obj v, UInt len)
+Obj MakeShiftedVecs(Obj v, UInt len)
 {
-    UInt q;
-    Obj info;
-    UInt elts;
-    Obj shifts;
-    Obj ashift;
-    Obj vn, xi;
-    UInt i, j;
-    const Obj *ffefelt;
-    UInt1 *gettab;
-    UInt1 *settab;
-    UInt len1;
-    UInt1 x;
-    UInt1 *ptr;
-    UInt1 *ptrs[5]; // 5 is the largest value of elts we ever meet 
-    Obj type;
+    UInt        q;
+    Obj         info;
+    UInt        elts;
+    Obj         shifts;
+    Obj         ashift;
+    Obj         vn, xi;
+    UInt        i, j;
+    const Obj * ffefelt;
+    UInt1 *     gettab;
+    UInt1 *     settab;
+    UInt        len1;
+    UInt1       x;
+    UInt1 *     ptr;
+    UInt1 *     ptrs[5];    // 5 is the largest value of elts we ever meet
+    Obj         type;
 
     q = FIELD_VEC8BIT(v);
     assert(len <= LEN_VEC8BIT(v));
@@ -4818,80 +4846,84 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     gettab = GETELT_FIELDINFO_8BIT(info);
     ffefelt = FFE_FELT_FIELDINFO_8BIT(info);
 
-    x = gettab[BYTES_VEC8BIT(vn)[(len - 1) / elts] + 256 * ((len - 1) % elts)];
+    x = gettab[BYTES_VEC8BIT(vn)[(len - 1) / elts] +
+               256 * ((len - 1) % elts)];
     assert(x != 0);
     xi = INV(ffefelt[x]);
-    MultVec8BitFFEInner(vn, vn,  xi , 1, len);
+    MultVec8BitFFEInner(vn, vn, xi, 1, len);
     type = TypeVec8Bit(q, 0);
     SetTypeDatObj(vn, type);
 
-    // Now we start to build up the result 
+    // Now we start to build up the result
     shifts = NEW_PLIST_IMM(T_PLIST_TAB, elts + 2);
     SET_ELM_PLIST(shifts, elts + 1, INTOBJ_INT(len));
     SET_ELM_PLIST(shifts, elts + 2, xi);
     SET_LEN_PLIST(shifts, elts + 2);
 
-    // vn can simply be stored in one place 
+    // vn can simply be stored in one place
     SET_ELM_PLIST(shifts, (len - 1) % elts + 1, vn);
     CHANGED_BAG(shifts);
 
     if (elts > 1) {
-        // fill the rest up with zero vectors of suitable lengths 
+        // fill the rest up with zero vectors of suitable lengths
         for (i = 1; i < elts; i++) {
             ashift = ZeroVec8Bit(q, len + i, 0);
             SET_ELM_PLIST(shifts, (len + i - 1) % elts + 1, ashift);
             CHANGED_BAG(shifts);
         }
 
-        // reload the tables, in case there was a garbage collection 
+        // reload the tables, in case there was a garbage collection
         gettab = GETELT_FIELDINFO_8BIT(info);
         settab = SETELT_FIELDINFO_8BIT(info);
-        // Now run through the entries of vn inserting them into the shifted versions 
+        // Now run through the entries of vn inserting them into the shifted
+        // versions
         ptr = BYTES_VEC8BIT(vn);
         for (j = 1; j < elts; j++)
-            ptrs[j] = BYTES_VEC8BIT(ELM_PLIST(shifts, (len + j - 1) % elts + 1));
+            ptrs[j] =
+                BYTES_VEC8BIT(ELM_PLIST(shifts, (len + j - 1) % elts + 1));
         for (i = 0; i < len; i++) {
             x = gettab[*ptr + 256 * (i % elts)];
             if (x != 0) {
                 for (j = 1; j < elts; j++) {
-                    *(ptrs[j]) = settab[*(ptrs[j]) + 256 * ((i + j) % elts + elts * x)];
+                    *(ptrs[j]) = settab[*(ptrs[j]) +
+                                        256 * ((i + j) % elts + elts * x)];
                 }
             }
             if (i % elts == elts - 1)
                 ptr++;
             else
-                ptrs[elts - 1 - (i % elts)] ++;
+                ptrs[elts - 1 - (i % elts)]++;
         }
     }
 #ifdef HPCGAP
-    for (i=1; i <= elts; i++)
-      MakeBagReadOnly(ELM_PLIST(shifts, i));
+    for (i = 1; i <= elts; i++)
+        MakeBagReadOnly(ELM_PLIST(shifts, i));
     MakeBagReadOnly(shifts);
 #endif
     return shifts;
 }
 
-void ReduceCoeffsVec8Bit ( Obj vl, Obj vrshifted, Obj quot )
+void ReduceCoeffsVec8Bit(Obj vl, Obj vrshifted, Obj quot)
 {
-    UInt q;
-    Obj info;
-    UInt elts;
-    Int i, j, jj;
-    UInt1 *gettab;
-    UInt1 *ptrl1, *ptrl, *qptr = 0;
-    const UInt1 *ptrr;
-    UInt1 x;
-    UInt1 xn;
-    UInt p;
-    UInt lr;
-    UInt lrs;
-    UInt1 *multab, *settab = 0;
-    UInt1 *addtab = 0;
-    UInt1 * feltffe;
-    UInt1 y;
-    UInt ll = LEN_VEC8BIT(vl);
-    Obj vrs;
-    const Obj *ffefelt;
+    UInt          q;
+    Obj           info;
+    UInt          elts;
+    Int           i, j, jj;
+    UInt1 *       gettab;
+    UInt1 *       ptrl1, *ptrl, *qptr = 0;
+    const UInt1 * ptrr;
+    UInt1         x;
+    UInt1         xn;
+    UInt          p;
+    UInt          lr;
+    UInt          lrs;
+    UInt1 *       multab, *settab = 0;
+    UInt1 *       addtab = 0;
+    UInt1 *       feltffe;
+    UInt1         y;
+    UInt          ll = LEN_VEC8BIT(vl);
+    Obj           vrs;
+    const Obj *   ffefelt;
     q = FIELD_VEC8BIT(vl);
     info = GetFieldInfo8Bit(q);
     p = P_FIELDINFO_8BIT(info);
@@ -4911,7 +4943,8 @@ void ReduceCoeffsVec8Bit ( Obj vl, Obj vrshifted, Obj quot )
         ptrl1 = ptrl + i / elts;
         x = gettab[*ptrl1 + 256 * (i % elts)];
         if (qptr)
-            qptr[jj / elts] = settab[qptr[jj / elts] + 256 * (jj % elts + elts * x)];
+            qptr[jj / elts] =
+                settab[qptr[jj / elts] + 256 * (jj % elts + elts * x)];
         if (x != 0) {
 
             if (p == 2)
@@ -4931,11 +4964,12 @@ void ReduceCoeffsVec8Bit ( Obj vl, Obj vrshifted, Obj quot )
                 ptrl1--;
                 ptrr--;
             }
-            assert(! gettab[ptrl[i / elts] + 256 * (i % elts)]);
+            assert(!gettab[ptrl[i / elts] + 256 * (i % elts)]);
         }
     }
     if (quot) {
-        MultVec8BitFFEInner(quot, quot, ELM_PLIST(vrshifted, elts + 2), 1, ll - lr + 1);
+        MultVec8BitFFEInner(quot, quot, ELM_PLIST(vrshifted, elts + 2), 1,
+                            ll - lr + 1);
     }
 }
 
@@ -4946,20 +4980,22 @@ void ReduceCoeffsVec8Bit ( Obj vl, Obj vrshifted, Obj quot )
 **  NB note that these are not methods and MAY NOT return TRY_NEXT_METHOD
 */
 
-Obj FuncMAKE_SHIFTED_COEFFS_VEC8BIT( Obj self, Obj vr, Obj lr)
+Obj FuncMAKE_SHIFTED_COEFFS_VEC8BIT(Obj self, Obj vr, Obj lr)
 {
     if (!IS_INTOBJ(lr))
-        ErrorQuit("ReduceCoeffs: Length of right argument must be a small integer, not a %s",
+        ErrorQuit("ReduceCoeffs: Length of right argument must be a small "
+                  "integer, not a %s",
                   (Int)TNAM_OBJ(lr), 0L);
     if (INT_INTOBJ(lr) < 0 || INT_INTOBJ(lr) > LEN_VEC8BIT(vr)) {
-        ErrorQuit("ReduceCoeffs: given length <lr> of right argt (%d)\n is negative or longer than the argt (%d)",
+        ErrorQuit("ReduceCoeffs: given length <lr> of right argt (%d)\n is "
+                  "negative or longer than the argt (%d)",
                   INT_INTOBJ(lr), LEN_VEC8BIT(vr));
     }
     return MakeShiftedVecs(vr, INT_INTOBJ(lr));
 }
 
 
-Obj FuncREDUCE_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vrshifted)
+Obj FuncREDUCE_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
 {
     UInt q;
     UInt last;
@@ -4967,35 +5003,39 @@ Obj FuncREDUCE_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vrshifted)
     if (q != FIELD_VEC8BIT(ELM_PLIST(vrshifted, 1)))
         return Fail;
     if (!IS_INTOBJ(ll))
-        ErrorQuit("ReduceCoeffs: Length of left argument must be a small integer, not a %s",
+        ErrorQuit("ReduceCoeffs: Length of left argument must be a small "
+                  "integer, not a %s",
                   (Int)TNAM_OBJ(ll), 0L);
     if (0 > INT_INTOBJ(ll) || INT_INTOBJ(ll) > LEN_VEC8BIT(vl)) {
-        ErrorQuit("ReduceCoeffs: given length <ll> of left argt (%d)\n is negative or longer than the argt (%d)",
+        ErrorQuit("ReduceCoeffs: given length <ll> of left argt (%d)\n is "
+                  "negative or longer than the argt (%d)",
                   INT_INTOBJ(ll), LEN_VEC8BIT(vl));
     }
     ResizeVec8Bit(vl, INT_INTOBJ(ll), 0);
-    ReduceCoeffsVec8Bit(vl,  vrshifted, (Obj)0);
+    ReduceCoeffsVec8Bit(vl, vrshifted, (Obj)0);
     last = RightMostNonZeroVec8Bit(vl);
     ResizeVec8Bit(vl, last, 1);
     return INTOBJ_INT(last);
 }
 
-Obj FuncQUOTREM_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vrshifted)
+Obj FuncQUOTREM_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
 {
     UInt q;
-    Obj rem, quot, ret, info;
+    Obj  rem, quot, ret, info;
     UInt elts;
-    Int ill, lr;
-    Obj type;
+    Int  ill, lr;
+    Obj  type;
 
     q = FIELD_VEC8BIT(vl);
     if (q != FIELD_VEC8BIT(ELM_PLIST(vrshifted, 1)))
         return Fail;
     if (!IS_INTOBJ(ll))
-        ErrorQuit("QuotRemCoeffs: Length of left argument must be a small integer, not a %s",
+        ErrorQuit("QuotRemCoeffs: Length of left argument must be a small "
+                  "integer, not a %s",
                   (Int)TNAM_OBJ(ll), 0L);
     if (0 > INT_INTOBJ(ll) || INT_INTOBJ(ll) > LEN_VEC8BIT(vl)) {
-        ErrorQuit("QuotRemCoeffs: given length <ll> of left argt (%d)\n is negative or longer than the argt (%d)",
+        ErrorQuit("QuotRemCoeffs: given length <ll> of left argt (%d)\n is "
+                  "negative or longer than the argt (%d)",
                   INT_INTOBJ(ll), LEN_VEC8BIT(vl));
     }
     ill = INT_INTOBJ(ll);
@@ -5009,7 +5049,7 @@ Obj FuncQUOTREM_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vrshifted)
     SetTypeDatObj(quot, type);
     SET_FIELD_VEC8BIT(quot, q);
     SET_LEN_VEC8BIT(quot, ill - lr + 1);
-    ReduceCoeffsVec8Bit(rem,  vrshifted, quot);
+    ReduceCoeffsVec8Bit(rem, vrshifted, quot);
     ret = NEW_PLIST(T_PLIST_TAB, 2);
     SET_LEN_PLIST(ret, 2);
     SET_ELM_PLIST(ret, 1, quot);
@@ -5034,54 +5074,54 @@ Obj FuncQUOTREM_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vrshifted)
 static UInt RNheads, RNvectors, RNcoeffs, RNrelns;
 
 
-Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
+Obj SemiEchelonListVec8Bits(Obj mat, UInt TransformationsNeeded)
 {
     UInt nrows, ncols;
     UInt i, j, h;
-    //UInt block; 
-    Obj heads, vectors, coeffs = 0, relns = 0;
-    UInt nvecs, nrels = 0;
-    Obj coeffrow = 0;
-    Obj row;
-    Obj res;
-    UInt q, elts;
-    Obj info;
-    UInt1 *settab, *convtab, *gettab;
-    const Obj *convtab1;
-    UInt1 zero, one;
-    UInt1 x = 0;
-    const UInt1 *rowp;
-    UInt1 byte;
-    Obj y;
-    Obj type;
+    // UInt block;
+    Obj           heads, vectors, coeffs = 0, relns = 0;
+    UInt          nvecs, nrels = 0;
+    Obj           coeffrow = 0;
+    Obj           row;
+    Obj           res;
+    UInt          q, elts;
+    Obj           info;
+    UInt1 *       settab, *convtab, *gettab;
+    const Obj *   convtab1;
+    UInt1         zero, one;
+    UInt1         x = 0;
+    const UInt1 * rowp;
+    UInt1         byte;
+    Obj           y;
+    Obj           type;
 
     nrows = LEN_PLIST(mat);
     ncols = LEN_VEC8BIT(ELM_PLIST(mat, 1));
 
-    // Find the field info 
+    // Find the field info
     q = FIELD_VEC8BIT(ELM_PLIST(mat, 1));
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    // Get the Felt numbers for zero and one 
+    // Get the Felt numbers for zero and one
     convtab = FELT_FFE_FIELDINFO_8BIT(info);
     zero = convtab[0];
     one = convtab[1];
 
-    // Set up the lists for the results 
+    // Set up the lists for the results
     heads = NEW_PLIST(T_PLIST_CYC, ncols);
     SET_LEN_PLIST(heads, ncols);
     vectors = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
     nvecs = 0;
     if (TransformationsNeeded) {
         coeffs = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
-        relns  = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
+        relns = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
         nrels = 0;
     }
     for (i = 1; i <= ncols; i++)
         SET_ELM_PLIST(heads, i, INTOBJ_INT(0));
 
-    // Main loop starts here 
+    // Main loop starts here
     for (i = 1; i <= nrows; i++) {
         row = ELM_PLIST(mat, i);
         if (TransformationsNeeded) {
@@ -5092,24 +5132,29 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
             SET_FIELD_VEC8BIT(coeffrow, q);
             CHANGED_BAG(coeffrow);
 
-            // No garbage collection risk from here 
+            // No garbage collection risk from here
             settab = SETELT_FIELDINFO_8BIT(info);
-            BYTES_VEC8BIT(coeffrow)[(i - 1) / elts] = settab[256 * ((i - 1) % elts + elts * one)];
+            BYTES_VEC8BIT(coeffrow)
+            [(i - 1) / elts] = settab[256 * ((i - 1) % elts + elts * one)];
         }
-        // No garbage collection risk from here 
+        // No garbage collection risk from here
         gettab = GETELT_FIELDINFO_8BIT(info);
         convtab1 = FFE_FELT_FIELDINFO_8BIT(info);
 
-        // Clear out the current row 
+        // Clear out the current row
         for (j = 1; j <= ncols; j++) {
             h = INT_INTOBJ(ELM_PLIST(heads, j));
             if (h != 0) {
                 byte = CONST_BYTES_VEC8BIT(row)[(j - 1) / elts];
-                if (byte && zero != (x = gettab[ byte + 256 * ((j - 1) % elts)])) {
+                if (byte &&
+                    zero != (x = gettab[byte + 256 * ((j - 1) % elts)])) {
                     y = AINV(convtab1[x]);
-                    AddVec8BitVec8BitMultInner(row, row, ELM_PLIST(vectors, h), y, 1, ncols);
+                    AddVec8BitVec8BitMultInner(
+                        row, row, ELM_PLIST(vectors, h), y, 1, ncols);
                     if (TransformationsNeeded)
-                        AddVec8BitVec8BitMultInner(coeffrow, coeffrow, ELM_PLIST(coeffs, h), y, 1, nrows);
+                        AddVec8BitVec8BitMultInner(coeffrow, coeffrow,
+                                                   ELM_PLIST(coeffs, h), y, 1,
+                                                   nrows);
                 }
             }
         }
@@ -5119,7 +5164,8 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
             j += elts;
             rowp++;
         }
-        while (j <= ncols && (zero == (x = gettab[ *rowp + 256 * ((j - 1) % elts)])))
+        while (j <= ncols &&
+               (zero == (x = gettab[*rowp + 256 * ((j - 1) % elts)])))
             j++;
 
         if (j <= ncols) {
@@ -5135,8 +5181,9 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
                 CHANGED_BAG(coeffs);
                 SET_LEN_PLIST(coeffs, nvecs);
             }
-            // garbage collection OK again after here 
-        } else if (TransformationsNeeded) {
+            // garbage collection OK again after here
+        }
+        else if (TransformationsNeeded) {
             SET_ELM_PLIST(relns, ++nrels, coeffrow);
             CHANGED_BAG(relns);
             SET_LEN_PLIST(relns, nrels);
@@ -5176,25 +5223,25 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
 **  returns the rank
 */
 
-UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
+UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
 {
-    UInt nrows;
-    UInt ncols;
-    UInt workcol;
-    UInt workrow;
-    UInt rank;
-    Obj row, row2;
-    UInt byte;
-    UInt j;
-    Obj info;
-    UInt elts;
-    UInt1 x = 0;
-    UInt1 *gettab, *getcol;
-    Obj deter = 0;
-    UInt sign = 0;
-    const Obj *convtab;
-    Obj y;
-    UInt1 x2;
+    UInt        nrows;
+    UInt        ncols;
+    UInt        workcol;
+    UInt        workrow;
+    UInt        rank;
+    Obj         row, row2;
+    UInt        byte;
+    UInt        j;
+    Obj         info;
+    UInt        elts;
+    UInt1       x = 0;
+    UInt1 *     gettab, *getcol;
+    Obj         deter = 0;
+    UInt        sign = 0;
+    const Obj * convtab;
+    Obj         y;
+    UInt1       x2;
 
     nrows = LEN_PLIST(mat);
     row = ELM_PLIST(mat, 1);
@@ -5203,12 +5250,12 @@ UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(row));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    // Nothing here can cause a garbage collection 
+    // Nothing here can cause a garbage collection
 
     gettab = GETELT_FIELDINFO_8BIT(info);
     convtab = FFE_FELT_FIELDINFO_8BIT(info);
 
-    if (deterp != (Obj *) 0) {
+    if (deterp != (Obj *)0) {
         deter = ONE(convtab[1]);
         sign = 1;
     }
@@ -5216,7 +5263,7 @@ UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
         byte = (workcol - 1) / elts;
         getcol = gettab + 256 * ((workcol - 1) % elts);
 
-        for (workrow = rank + 1; workrow <= nrows; workrow ++) {
+        for (workrow = rank + 1; workrow <= nrows; workrow++) {
             row = ELM_PLIST(mat, workrow);
             x = getcol[CONST_BYTES_VEC8BIT(row)[byte]];
             if (x)
@@ -5236,15 +5283,18 @@ UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
                 SET_ELM_PLIST(mat, rank, row);
             }
             if (clearup)
-                for (j = 1; j < rank; j ++) {
+                for (j = 1; j < rank; j++) {
                     row2 = ELM_PLIST(mat, j);
-                    if ((x2 =  getcol[CONST_BYTES_VEC8BIT(row2)[byte]]))
-                        AddVec8BitVec8BitMultInner(row2, row2, row, AINV(convtab[x2]), workcol, ncols);
+                    if ((x2 = getcol[CONST_BYTES_VEC8BIT(row2)[byte]]))
+                        AddVec8BitVec8BitMultInner(row2, row2, row,
+                                                   AINV(convtab[x2]), workcol,
+                                                   ncols);
                 }
             for (j = workrow + 1; j <= nrows; j++) {
                 row2 = ELM_PLIST(mat, j);
-                if ((x2 =  getcol[CONST_BYTES_VEC8BIT(row2)[byte]]))
-                    AddVec8BitVec8BitMultInner(row2, row2, row, AINV(convtab[x2]), workcol, ncols);
+                if ((x2 = getcol[CONST_BYTES_VEC8BIT(row2)[byte]]))
+                    AddVec8BitVec8BitMultInner(
+                        row2, row2, row, AINV(convtab[x2]), workcol, ncols);
             }
         }
         if (TakeInterrupt()) {
@@ -5272,12 +5322,12 @@ UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
 ** Method selection can guarantee us a plain list of vectors in same char
 */
 
-Obj FuncSEMIECHELON_LIST_VEC8BITS( Obj self, Obj mat )
+Obj FuncSEMIECHELON_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
-    Obj row;
+    Obj  row;
     UInt q;
-    // check argts 
+    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5290,7 +5340,8 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS( Obj self, Obj mat )
         return TRY_NEXT_METHOD;
     for (i = 2; i <= len; i++) {
         row = ELM_PLIST(mat, i);
-        if (!IS_VEC8BIT_REP(row) || FIELD_VEC8BIT(row) != q || LEN_VEC8BIT(row) != width) {
+        if (!IS_VEC8BIT_REP(row) || FIELD_VEC8BIT(row) != q ||
+            LEN_VEC8BIT(row) != width) {
             return TRY_NEXT_METHOD;
         }
     }
@@ -5307,13 +5358,13 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS( Obj self, Obj mat )
 **  characteristic
 */
 
-Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS( Obj self, Obj mat )
+Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(Obj self, Obj mat)
 {
     UInt i, len;
-    Obj row;
+    Obj  row;
     UInt q;
     UInt width;
-    // check argts 
+    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5326,9 +5377,8 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS( Obj self, Obj mat )
         return TRY_NEXT_METHOD;
     for (i = 2; i <= len; i++) {
         row = ELM_PLIST(mat, i);
-        if (!IS_VEC8BIT_REP(row) ||
-        FIELD_VEC8BIT(row) != q ||
-        LEN_VEC8BIT(row) != width) {
+        if (!IS_VEC8BIT_REP(row) || FIELD_VEC8BIT(row) != q ||
+            LEN_VEC8BIT(row) != width) {
             return TRY_NEXT_METHOD;
         }
     }
@@ -5346,12 +5396,12 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS( Obj self, Obj mat )
 **  characteristic
 */
 
-Obj FuncTRIANGULIZE_LIST_VEC8BITS( Obj self, Obj mat )
+Obj FuncTRIANGULIZE_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
-    Obj row;
+    Obj  row;
     UInt q;
-    // check argts 
+    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5364,13 +5414,13 @@ Obj FuncTRIANGULIZE_LIST_VEC8BITS( Obj self, Obj mat )
         return TRY_NEXT_METHOD;
     for (i = 2; i <= len; i++) {
         row = ELM_PLIST(mat, i);
-        if (!IS_MUTABLE_OBJ(row) || !IS_VEC8BIT_REP(row)
-            || FIELD_VEC8BIT(row) != q || LEN_VEC8BIT(row) != width) {
+        if (!IS_MUTABLE_OBJ(row) || !IS_VEC8BIT_REP(row) ||
+            FIELD_VEC8BIT(row) != q || LEN_VEC8BIT(row) != width) {
             return TRY_NEXT_METHOD;
         }
     }
-    TriangulizeListVec8Bits(mat, 1, (Obj *) 0);
-    return (Obj) 0;
+    TriangulizeListVec8Bits(mat, 1, (Obj *)0);
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -5383,12 +5433,12 @@ Obj FuncTRIANGULIZE_LIST_VEC8BITS( Obj self, Obj mat )
 **  characteristic
 */
 
-Obj FuncRANK_LIST_VEC8BITS( Obj self, Obj mat )
+Obj FuncRANK_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
-    Obj row;
+    Obj  row;
     UInt q;
-    // check argts 
+    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5401,12 +5451,12 @@ Obj FuncRANK_LIST_VEC8BITS( Obj self, Obj mat )
         return TRY_NEXT_METHOD;
     for (i = 2; i <= len; i++) {
         row = ELM_PLIST(mat, i);
-        if (!IS_VEC8BIT_REP(row) || FIELD_VEC8BIT(row) != q
-            || LEN_VEC8BIT(row) != width) {
+        if (!IS_VEC8BIT_REP(row) || FIELD_VEC8BIT(row) != q ||
+            LEN_VEC8BIT(row) != width) {
             return TRY_NEXT_METHOD;
         }
     }
-    return INTOBJ_INT(TriangulizeListVec8Bits(mat, 0, (Obj *) 0));
+    return INTOBJ_INT(TriangulizeListVec8Bits(mat, 0, (Obj *)0));
 }
 
 /****************************************************************************
@@ -5419,13 +5469,13 @@ Obj FuncRANK_LIST_VEC8BITS( Obj self, Obj mat )
 **  characteristic
 */
 
-Obj FuncDETERMINANT_LIST_VEC8BITS( Obj self, Obj mat )
+Obj FuncDETERMINANT_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
-    Obj row;
+    Obj  row;
     UInt q;
-    Obj det;
-    // check argts 
+    Obj  det;
+    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5448,8 +5498,6 @@ Obj FuncDETERMINANT_LIST_VEC8BITS( Obj self, Obj mat )
 }
 
 
-
-
 /****************************************************************************
 **
 *F  Cmp_MAT8BIT_MAT8BIT( <ml>, <mr> )   compare matrices
@@ -5457,10 +5505,10 @@ Obj FuncDETERMINANT_LIST_VEC8BITS( Obj self, Obj mat )
 **  Assumes the matrices are over compatible fields
 */
 
-Int Cmp_MAT8BIT_MAT8BIT( Obj ml, Obj mr)
+Int Cmp_MAT8BIT_MAT8BIT(Obj ml, Obj mr)
 {
     UInt l1, l2, l, i;
-    Int c;
+    Int  c;
     l1 = LEN_MAT8BIT(ml);
     l2 = LEN_MAT8BIT(mr);
     l = (l1 < l2) ? l1 : l2;
@@ -5474,7 +5522,6 @@ Int Cmp_MAT8BIT_MAT8BIT( Obj ml, Obj mr)
     if (l1 > l2)
         return 1;
     return 0;
-
 }
 
 /****************************************************************************
@@ -5482,13 +5529,14 @@ Int Cmp_MAT8BIT_MAT8BIT( Obj ml, Obj mr)
 *F  FuncEQ_MAT8BIT_MAT8BIT( <ml>, <mr> )   compare matrices
 */
 
-Obj FuncEQ_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
+Obj FuncEQ_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     if (LEN_MAT8BIT(ml) != LEN_MAT8BIT(mr))
         return False;
     if (LEN_MAT8BIT(ml) == 0)
         return True;
-    if (FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1)) != FIELD_VEC8BIT(ELM_MAT8BIT(mr, 1)))
+    if (FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1)) !=
+        FIELD_VEC8BIT(ELM_MAT8BIT(mr, 1)))
         return EqListList(ml, mr) ? True : False;
     return (0 == Cmp_MAT8BIT_MAT8BIT(ml, mr)) ? True : False;
 }
@@ -5498,13 +5546,14 @@ Obj FuncEQ_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
 *F  FuncLT_MAT8BIT_MAT8BIT( <ml>, <mr> )   compare matrices
 */
 
-Obj FuncLT_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
+Obj FuncLT_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     if (LEN_MAT8BIT(ml) == 0)
         return (LEN_MAT8BIT(mr) != 0) ? True : False;
     if (LEN_MAT8BIT(mr) == 0)
         return False;
-    if (FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1)) != FIELD_VEC8BIT(ELM_MAT8BIT(mr, 1)))
+    if (FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1)) !=
+        FIELD_VEC8BIT(ELM_MAT8BIT(mr, 1)))
         return LtListList(ml, mr) ? True : False;
     return (Cmp_MAT8BIT_MAT8BIT(ml, mr) < 0) ? True : False;
 }
@@ -5515,30 +5564,30 @@ Obj FuncLT_MAT8BIT_MAT8BIT( Obj self, Obj ml, Obj mr)
 *F  FuncTRANSPOSED_MAT8BIT( <self>, <mat>) Fully mutable results
 **
 */
-Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
+Obj FuncTRANSPOSED_MAT8BIT(Obj self, Obj mat)
 {
-    UInt l, w;
-    Obj tra, row;
-    Obj r1;
-    UInt1 vals[BIPEB];
-    UInt val;
-    UInt imod, nrb, nstart;
-    UInt i, j, k, n, q, elts;
+    UInt    l, w;
+    Obj     tra, row;
+    Obj     r1;
+    UInt1   vals[BIPEB];
+    UInt    val;
+    UInt    imod, nrb, nstart;
+    UInt    i, j, k, n, q, elts;
     UInt1 * ptr;
-    Obj info;
-    UInt1 *gettab = 0, *settab = 0;
-    Obj type;
+    Obj     info;
+    UInt1 * gettab = 0, *settab = 0;
+    Obj     type;
 
-    // check argument 
+    // check argument
     if (TNUM_OBJ(mat) != T_POSOBJ) {
         mat = ErrorReturnObj(
-            "TRANSPOSED_MAT8BIT: Need compressed matrix\n",
-            0, 0,
+            "TRANSPOSED_MAT8BIT: Need compressed matrix\n", 0, 0,
             "You can return such matrix with 'return mat;'\n");
     }
-    // we will give result same type as mat 
+    // we will give result same type as mat
 
-    // we assume here that there is a first row  -- a zero row mat8bit is a bad thing
+    // we assume here that there is a first row  -- a zero row mat8bit is a
+    // bad thing
     r1 = ELM_MAT8BIT(mat, 1);
 
     l = LEN_MAT8BIT(mat);
@@ -5556,7 +5605,7 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     nrb = (w + elts - 1) / elts;
 
-    // create new matrix 
+    // create new matrix
     for (i = 1; i <= w; i++) {
         row = NewWordSizedBag(T_DATOBJ, SIZE_VEC8BIT(l, elts));
         SET_LEN_VEC8BIT(row, l);
@@ -5572,39 +5621,42 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
         settab = SETELT_FIELDINFO_8BIT(info);
     }
 
-    // set entries 
-    // run over elts row chunks of the original matrix 
+    // set entries
+    // run over elts row chunks of the original matrix
     for (i = 1; i <= l; i += elts) {
         imod = (i - 1) / elts;
 
-        // run through these rows in chunks, extract the bytes corresponding to an
-        // elts x elts submatrix into vals
+        // run through these rows in chunks, extract the bytes corresponding
+        // to an elts x elts submatrix into vals
         for (n = 0; n < nrb; n++) {
             for (j = 0; j < elts; j++) {
                 if ((i + j) > l) {
 
-                    vals[j] = 0; // outside matrix 
-
-                } else {
+                    vals[j] = 0;    // outside matrix
+                }
+                else {
                     vals[j] = CONST_BYTES_VEC8BIT(ELM_MAT8BIT(mat, i + j))[n];
                 }
             }
 
-            // write transposed values in new matrix 
+            // write transposed values in new matrix
             nstart = n * elts + 1;
-            for (j = 0; j < elts; j++) { // bit number = Row in transpose 
+            for (j = 0; j < elts; j++) {    // bit number = Row in transpose
                 if ((nstart + j) <= w) {
 
-                    // still within matrix 
+                    // still within matrix
                     if (elts > 1) {
                         val = 0;
                         for (k = 0; k < elts; k++) {
-                            val = settab[val + 256 * (k + elts * gettab[vals[k] + 256 * j])];
+                            val = settab[val +
+                                         256 * (k + elts * gettab[vals[k] +
+                                                                  256 * j])];
                         }
-                    } else
+                    }
+                    else
                         val = vals[0];
 
-                    // set entry 
+                    // set entry
                     ptr = BYTES_VEC8BIT(ELM_MAT8BIT(tra, nstart + j)) + imod;
                     *ptr = val;
                 }
@@ -5620,13 +5672,13 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
 *F  FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( <self>, <matl>, <matr>)
 **
 */
-Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
+Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 {
-    UInt nrowl, nrowr, ncoll, ncolr, ncol, p, q, i, j, k, l, s, zero,
-    mutable, elts;
-    Obj mat, type, row, info, shift[5];
-    UInt1 *getelt, *setelt, *scalar, *add, *data;
-    const UInt1 *datar;
+    UInt nrowl, nrowr, ncoll, ncolr, ncol, p, q, i, j, k, l, s, zero, mutable,
+        elts;
+    Obj           mat, type, row, info, shift[5];
+    UInt1 *       getelt, *setelt, *scalar, *add, *data;
+    const UInt1 * datar;
 
     nrowl = LEN_MAT8BIT(matl);
     nrowr = LEN_MAT8BIT(matr);
@@ -5643,59 +5695,68 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     zero = FELT_FFE_FIELDINFO_8BIT(info)[0];
 
-    // create a matrix 
-    mat = NewWordSizedBag(T_POSOBJ, sizeof(Obj) * (nrowl*nrowr + 2));
-    SET_LEN_MAT8BIT(mat, nrowl*nrowr);
+    // create a matrix
+    mat = NewWordSizedBag(T_POSOBJ, sizeof(Obj) * (nrowl * nrowr + 2));
+    SET_LEN_MAT8BIT(mat, nrowl * nrowr);
     SET_TYPE_POSOBJ(mat, TypeMat8Bit(q, mutable));
     type = TypeVec8BitLocked(q, mutable);
 
-    // allocate 0 matrix 
-    for (i = 1; i <= nrowl*nrowr; i++) {
+    // allocate 0 matrix
+    for (i = 1; i <= nrowl * nrowr; i++) {
         row = ZeroVec8Bit(q, ncoll * ncolr, mutable);
-        SetTypeDatObj(row, type); // locked type 
+        SetTypeDatObj(row, type);    // locked type
         SET_ELM_MAT8BIT(mat, i, row);
         CHANGED_BAG(mat);
     }
 
-    // allocate data for shifts of rows of matr 
+    // allocate data for shifts of rows of matr
     for (i = 0; i < elts; i++) {
-        shift[i] = NewWordSizedBag(T_DATOBJ, ncolr / elts + 200 + sizeof(Obj));
+        shift[i] =
+            NewWordSizedBag(T_DATOBJ, ncolr / elts + 200 + sizeof(Obj));
     }
 
-    // allocation is done. speed up operations by getting lookup tables 
+    // allocation is done. speed up operations by getting lookup tables
     getelt = GETELT_FIELDINFO_8BIT(info);
     setelt = SETELT_FIELDINFO_8BIT(info);
     scalar = SCALAR_FIELDINFO_8BIT(info);
     add = ADD_FIELDINFO_8BIT(info);
 
-    // fill in matrix 
+    // fill in matrix
     for (j = 1; j <= nrowr; j++) {
-        // create shifts of rows of matr 
+        // create shifts of rows of matr
         for (i = 0; i < elts; i++) {
-            data = (UInt1 *) ADDR_OBJ(shift[i]);
+            data = (UInt1 *)ADDR_OBJ(shift[i]);
             datar = CONST_BYTES_VEC8BIT(ELM_MAT8BIT(matr, j));
             for (k = 0; k < ncolr; k++)
-                data[(k + i) / elts] = setelt[data[(k + i) / elts] + 256 * ((k + i) % elts + getelt[datar[k / elts] + 256 * (k % elts)] * elts)];
+                data[(k + i) / elts] =
+                    setelt[data[(k + i) / elts] +
+                           256 * ((k + i) % elts +
+                                  getelt[datar[k / elts] + 256 * (k % elts)] *
+                                      elts)];
         }
         for (i = 1; i <= nrowl; i++) {
             data = BYTES_VEC8BIT(ELM_MAT8BIT(mat, (i - 1) * nrowr + j));
             ncol = 0;
             for (k = 0; k < ncoll; k++) {
-                s = getelt[CONST_BYTES_VEC8BIT(ELM_MAT8BIT(matl, i))[k / elts] + 256 * (k % elts)];
+                s = getelt[CONST_BYTES_VEC8BIT(
+                               ELM_MAT8BIT(matl, i))[k / elts] +
+                           256 * (k % elts)];
                 l = 0;
                 if (s != zero) {
-                    // append s*shift[ncol%elts] to data 
-                    datar = (const UInt1 *) CONST_ADDR_OBJ(shift[ncol % elts]);
+                    // append s*shift[ncol%elts] to data
+                    datar = (const UInt1 *)CONST_ADDR_OBJ(shift[ncol % elts]);
                     if (ncol % elts) {
                         if (p == 2)
                             data[-1] ^= scalar[*datar++ + 256 * s];
                         else
-                            data[-1] = add[data[-1] + 256 * scalar[*datar++ + 256 * s]];
+                            data[-1] = add[data[-1] +
+                                           256 * scalar[*datar++ + 256 * s]];
                         l = elts - ncol % elts;
                     }
                     for (; l < ncolr; l += elts)
-                        * data++ = scalar[*datar++ + 256 * s];
-                } else {
+                        *data++ = scalar[*datar++ + 256 * s];
+                }
+                else {
                     if (ncol % elts)
                         l = elts - ncol % elts;
                     data += (ncolr + elts - 1 - l) / elts;
@@ -5714,27 +5775,30 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
 *F  FuncMAT_ELM_MAT8BIT( <self>, <mat>, <row>, <col> )
 **
 */
-Obj FuncMAT_ELM_MAT8BIT( Obj self, Obj mat, Obj row, Obj col )
+Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",
                      (Int)TNAM_OBJ(row), 0L);
     }
     if (!IS_POS_INTOBJ(col)) {
-        ErrorMayQuit("column index must be a small positive integer, not a %s",
-                     (Int)TNAM_OBJ(col), 0L);
+        ErrorMayQuit(
+            "column index must be a small positive integer, not a %s",
+            (Int)TNAM_OBJ(col), 0L);
     }
 
     UInt r = INT_INTOBJ(row);
     if (LEN_MAT8BIT(mat) < r) {
-        ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_MAT8BIT(mat));
+        ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
+                     LEN_MAT8BIT(mat));
     }
 
     Obj vec = ELM_MAT8BIT(mat, r);
 
     UInt c = INT_INTOBJ(col);
     if (LEN_VEC8BIT(vec) < c) {
-        ErrorMayQuit("column index %d exceeds %d, the number of columns", c, LEN_VEC8BIT(vec));
+        ErrorMayQuit("column index %d exceeds %d, the number of columns", c,
+                     LEN_VEC8BIT(vec));
     }
 
     return FuncELM_VEC8BIT(self, vec, col);
@@ -5746,30 +5810,33 @@ Obj FuncMAT_ELM_MAT8BIT( Obj self, Obj mat, Obj row, Obj col )
 *F  FuncSET_MAT_ELM_MAT8BIT( <self>, <mat>, <row>, <col>, <elm> )
 **
 */
-Obj FuncSET_MAT_ELM_MAT8BIT( Obj self, Obj mat, Obj row, Obj col, Obj elm )
+Obj FuncSET_MAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",
                      (Int)TNAM_OBJ(row), 0L);
     }
     if (!IS_POS_INTOBJ(col)) {
-        ErrorMayQuit("column index must be a small positive integer, not a %s",
-                     (Int)TNAM_OBJ(col), 0L);
+        ErrorMayQuit(
+            "column index must be a small positive integer, not a %s",
+            (Int)TNAM_OBJ(col), 0L);
     }
 
     UInt r = INT_INTOBJ(row);
     if (LEN_MAT8BIT(mat) < r) {
-        ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_MAT8BIT(mat));
+        ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
+                     LEN_MAT8BIT(mat));
     }
 
     Obj vec = ELM_MAT8BIT(mat, r);
-    if ( ! IS_MUTABLE_OBJ(vec) ) {
+    if (!IS_MUTABLE_OBJ(vec)) {
         ErrorMayQuit("row %d is immutable", r, 0);
     }
 
     UInt c = INT_INTOBJ(col);
     if (LEN_VEC8BIT(vec) < c) {
-        ErrorMayQuit("column index %d exceeds %d, the number of columns", c, LEN_VEC8BIT(vec));
+        ErrorMayQuit("column index %d exceeds %d, the number of columns", c,
+                     LEN_VEC8BIT(vec));
     }
 
     // TODO: replace the following call by direct access? E.g. so that we can
@@ -5789,7 +5856,7 @@ Obj FuncSET_MAT_ELM_MAT8BIT( Obj self, Obj mat, Obj row, Obj col, Obj elm )
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(CONV_VEC8BIT, 2, "list,q"),
     GVAR_FUNC(COPY_VEC8BIT, 2, "list,q"),
@@ -5850,7 +5917,9 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(DISTANCE_DISTRIB_VEC8BITS, 3, " veclis, vec, d"),
     GVAR_FUNC(A_CLOSEST_VEC8BIT, 4, " veclis, vec, k, stop"),
     GVAR_FUNC(A_CLOSEST_VEC8BIT_COORDS, 4, " veclis, vec, k, stop"),
-    GVAR_FUNC(COSET_LEADERS_INNER_8BITS, 5, " veclis, weight, tofind, leaders, felts"),
+    GVAR_FUNC(COSET_LEADERS_INNER_8BITS,
+              5,
+              " veclis, weight, tofind, leaders, felts"),
     GVAR_FUNC(SEMIECHELON_LIST_VEC8BITS, 1, "mat"),
     GVAR_FUNC(SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS, 1, "mat"),
     GVAR_FUNC(TRIANGULIZE_LIST_VEC8BITS, 1, "mat"),
@@ -5875,13 +5944,13 @@ static StructGVarFunc GVarFuncs [] = {
 ** the loaded one and is not endian-safe anyway
 */
 
-static Int PreSave( StructInitInfo * module )
+static Int PreSave(StructInitInfo * module)
 {
     UInt q;
     for (q = 3; q <= 256; q++)
-        SET_ELM_PLIST(FieldInfo8Bit, q, (Obj) 0);
+        SET_ELM_PLIST(FieldInfo8Bit, q, (Obj)0);
 
-    // return success 
+    // return success
     return 0;
 }
 
@@ -5889,34 +5958,34 @@ static Int PreSave( StructInitInfo * module )
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-static Int InitKernel (
-    StructInitInfo *    module )
+static Int InitKernel(StructInitInfo * module)
 {
     RNheads = 0;
     RNvectors = 0;
     RNcoeffs = 0;
     RNrelns = 0;
 
-    // import type functions                                               
-    ImportFuncFromLibrary("TYPE_VEC8BIT",        &TYPE_VEC8BIT);
+    // import type functions
+    ImportFuncFromLibrary("TYPE_VEC8BIT", &TYPE_VEC8BIT);
     ImportFuncFromLibrary("TYPE_VEC8BIT_LOCKED", &TYPE_VEC8BIT_LOCKED);
-    ImportGVarFromLibrary("TYPES_VEC8BIT",       &TYPES_VEC8BIT);
-    ImportFuncFromLibrary("TYPE_MAT8BIT",        &TYPE_MAT8BIT);
-    ImportGVarFromLibrary("TYPES_MAT8BIT",       &TYPES_MAT8BIT);
-    ImportFuncFromLibrary("Is8BitVectorRep",     &IsVec8bitRep);
+    ImportGVarFromLibrary("TYPES_VEC8BIT", &TYPES_VEC8BIT);
+    ImportFuncFromLibrary("TYPE_MAT8BIT", &TYPE_MAT8BIT);
+    ImportGVarFromLibrary("TYPES_MAT8BIT", &TYPES_MAT8BIT);
+    ImportFuncFromLibrary("Is8BitVectorRep", &IsVec8bitRep);
     ImportGVarFromLibrary("TYPE_FIELDINFO_8BIT", &TYPE_FIELDINFO_8BIT);
 
-    // init filters and functions                                          
+    // init filters and functions
     InitHdlrFuncsFromTable(GVarFuncs);
 
     InitGlobalBag(&FieldInfo8Bit, "src/vec8bit.c:FieldInfo8Bit");
 
     InitFopyGVar("ConvertToVectorRep", &ConvertToVectorRep);
     InitFopyGVar("AddRowVector", &AddRowVector);
-    InitFopyGVar("IsLockedRepresentationVector", &IsLockedRepresentationVector);
+    InitFopyGVar("IsLockedRepresentationVector",
+                 &IsLockedRepresentationVector);
     InitFopyGVar("AsInternalFFE", &AsInternalFFE);
 
-    // return success                                                      
+    // return success
     return 0;
 }
 
@@ -5925,8 +5994,7 @@ static Int InitKernel (
 **
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-static Int InitLibrary (
-    StructInitInfo *    module )
+static Int InitLibrary(StructInitInfo * module)
 {
     FieldInfo8Bit = NEW_PLIST(T_PLIST_NDENSE, 257);
     SET_ELM_PLIST(FieldInfo8Bit, 257, INTOBJ_INT(1));
@@ -5934,11 +6002,11 @@ static Int InitLibrary (
 #ifdef HPCGAP
     MakeBagPublic(FieldInfo8Bit);
 #endif
-    // init filters and functions                                          
+    // init filters and functions
     InitGVarFuncsFromTable(GVarFuncs);
 
 
-    // return success                                                      
+    // return success
     return 0;
 }
 
@@ -5950,14 +6018,11 @@ static Int InitLibrary (
 static StructInitInfo module = {
     // init struct using C99 designated initializers; for a full list of
     // fields, please refer to the definition of StructInitInfo
-    .type = MODULE_BUILTIN,
-    .name = "vec8bit",
-    .initKernel = InitKernel,
-    .initLibrary = InitLibrary,
-    .preSave = PreSave,
+    .type = MODULE_BUILTIN,     .name = "vec8bit",  .initKernel = InitKernel,
+    .initLibrary = InitLibrary, .preSave = PreSave,
 };
 
-StructInitInfo * InitInfoVec8bit ( void )
+StructInitInfo * InitInfoVec8bit(void)
 {
     return &module;
 }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -255,24 +255,23 @@ static const UInt1 * Char2Lookup[9] = {
 
 void MakeFieldInfo8Bit( UInt q)
 {
-    FF   gfq;     /* the field */
-    UInt p;     /* characteristic */
-    UInt d;     /* degree */
-    UInt i, j, k, l;  /* loop variables */
-    UInt e;     /* number of elements per byte */
-    UInt size;      /* data structure size */
-    UInt pows[7];     /* table of powers of q for packing
-           and unpacking bytes */
-    Obj info;     /* The table being constructed */
-    FFV mult;     /* multiplier for scalar product */
-    FFV prod;     /* used in scalar product */
-    UInt val;                     /* used to build up some answers */
+    FF   gfq;     // the field 
+    UInt p;     // characteristic 
+    UInt d;     // degree 
+    UInt i, j, k, l;  // loop variables 
+    UInt e;     // number of elements per byte 
+    UInt size;      // data structure size 
+    UInt pows[7];     // table of powers of q for packing and unpacking bytes
+    Obj info;     // The table being constructed 
+    FFV mult;     // multiplier for scalar product 
+    FFV prod;     // used in scalar product 
+    UInt val;                     // used to build up some answers 
     UInt val0;
-    UInt elt, el1, el2;           /* used to build up some answers */
+    UInt elt, el1, el2;           // used to build up some answers 
     const FFV *succ;
-    UInt1* setelt_info; /* Cache a value, mainly to get around a bug in xcode 5.0 */
-    UInt1* getelt_info; /* ditto */
-    Int iej_cache;      /* ditto */
+    UInt1* setelt_info; // Cache a value, mainly to get around a bug in xcode 5.0 
+    UInt1* getelt_info; // ditto 
+    Int iej_cache;      // ditto 
 
 
     p = (UInt)PbyQ[q];
@@ -281,39 +280,39 @@ void MakeFieldInfo8Bit( UInt q)
     e = 0;
     for (i = 1; i <= 256; i *= q)
         pows[e++] = i;
-    pows[e] = i;    /* simplifies things to have one more */
+    pows[e] = i;    // simplifies things to have one more 
     e--;
 
-    size = sizeof(Obj) +   /* type */
-          sizeof(Obj) +   /* q */
-          sizeof(Obj) +   /* p */
-          sizeof(Obj) +   /* d */
-          sizeof(Obj) +   /* els per byte */
-          q * sizeof(Obj) +           /* position in GAP < order  by number */
-          q * sizeof(Obj) +           /* numbering from FFV */
-          q * sizeof(Obj) + /* immediate FFE by number */
-          256 * q * e + /* set element lookup */
-          256 * e +   /* get element lookup */
-          256 * q +   /* scalar multiply */
-          2 * 256 * 256 + /* inner product, 1 lot of polynomial multiply data */
-          ((e == 1) ? 0 : (256 * 256)) + /* the other lot of polynomial data */
-          ((p == 2) ? 0 : (256 * 256)); /* add byte */
+    size = sizeof(Obj) +   // type 
+          sizeof(Obj) +   // q 
+          sizeof(Obj) +   // p 
+          sizeof(Obj) +   // d 
+          sizeof(Obj) +   // els per byte 
+          q * sizeof(Obj) +           // position in GAP < order  by number 
+          q * sizeof(Obj) +           // numbering from FFV 
+          q * sizeof(Obj) + // immediate FFE by number 
+          256 * q * e + // set element lookup 
+          256 * e +   // get element lookup 
+          256 * q +   // scalar multiply 
+          2 * 256 * 256 + // inner product, 1 lot of polynomial multiply data 
+          ((e == 1) ? 0 : (256 * 256)) + // the other lot of polynomial data 
+          ((p == 2) ? 0 : (256 * 256)); // add byte 
 
     info = NewWordSizedBag(T_DATOBJ, size);
     SetTypeDatObj(info, TYPE_FIELDINFO_8BIT);
 
     succ = SUCC_FF(gfq);
 
-    /* from here to the end, no garbage collections should happen */
+    // from here to the end, no garbage collections should happen 
     SET_Q_FIELDINFO_8BIT(info, q);
     SET_P_FIELDINFO_8BIT(info, p);
     SET_D_FIELDINFO_8BIT(info, d);
     SET_ELS_BYTE_FIELDINFO_8BIT(info, e);
 
-    /* conversion tables FFV to/from our numbering
-       we assume that 0 and 1 are always the zero and one
-       of the field. In char 2, we assume that xor corresponds
-       to addition, otherwise, the order doesn't matter */
+    // conversion tables FFV to/from our numbering
+    // we assume that 0 and 1 are always the zero and one
+    // of the field. In char 2, we assume that xor corresponds
+    // to addition, otherwise, the order doesn't matter
 
     if (p != 2)
         for (i = 0; i < q; i++)
@@ -322,19 +321,19 @@ void MakeFieldInfo8Bit( UInt q)
         for (i = 0; i < q; i++)
             FELT_FFE_FIELDINFO_8BIT(info)[i] = Char2Lookup[d][i];
 
-    /* simply invert the permutation to get the other one */
+    // simply invert the permutation to get the other one 
     for (i = 0; i < q; i++) {
         j = FELT_FFE_FIELDINFO_8BIT(info)[i];
         SET_FFE_FELT_FIELDINFO_8BIT(info, j, NEW_FFE(gfq, i));
     }
 
-    /* Now we need to store the position in Elements(GF(q)) of each field element
-       for the sake of NumberFFVector
+    // Now we need to store the position in Elements(GF(q)) of each field element
+    // for the sake of NumberFFVector
+    // 
+    // The rules for < between finite field elements make this a bit
+    // complex for non-prime fields
 
-       The rules for < between finite field elements make this a bit
-       complex for non-prime fields */
-
-    /* deal with zero and one */
+    // deal with zero and one 
     SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, 0, INTOBJ_INT(0));
     SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, FELT_FFE_FIELDINFO_8BIT(info)[1],
         INTOBJ_INT(1));
@@ -344,8 +343,8 @@ void MakeFieldInfo8Bit( UInt q)
             for (i = 2; i < q; i++)
                 SET_GAPSEQ_FELT_FIELDINFO_8BIT(info, i, INTOBJ_INT(i));
         else {
-            /* run through subfields, filling in entry for all the new elements
-               of each field in turn */
+            // run through subfields, filling in entry for all the new elements
+            // of each field in turn
             UInt q1 = 1;
             UInt pos = 2;
             for (i = 1; i <= d; i++) {
@@ -367,8 +366,8 @@ void MakeFieldInfo8Bit( UInt q)
     setelt_info = SETELT_FIELDINFO_8BIT(info);
     getelt_info = GETELT_FIELDINFO_8BIT(info);
 
-    /* entry setting table SETELT...[(i*e+j)*256 +k] is the result
-       of overwriting the jth element with i in the byte k */
+    // entry setting table SETELT...[(i*e+j)*256 +k] is the result
+    // of overwriting the jth element with i in the byte k
     for (i = 0; i < q; i++)
         for (j = 0; j < e; j++)
         {
@@ -378,14 +377,14 @@ void MakeFieldInfo8Bit( UInt q)
                         ((k / pows[j + 1]) * pows[j + 1] + i*pows[j] + (k % pows[j]));
         }
 
-    /* entry access GETELT...[i*256+j] recovers the ith entry from the
-       byte j */
+    // entry access GETELT...[i*256+j] recovers the ith entry from the
+    // byte j
     for (i = 0; i < e; i++)
         for (j = 0; j < 256; j++)
             getelt_info[i * 256 + j] = (UInt1)(j / pows[i]) % q;
 
-    /* scalar * vector multiply SCALAR...[i*256+j] is the scalar
-       product of the byte j with the felt i */
+    // scalar * vector multiply SCALAR...[i*256+j] is the scalar
+    // product of the byte j with the felt i
     for (i = 0; i < q; i++) {
         mult = VAL_FFE(FFE_FELT_FIELDINFO_8BIT(info)[i]);
         for (j = 0; j < 256; j++) {
@@ -400,9 +399,8 @@ void MakeFieldInfo8Bit( UInt q)
         }
     }
 
-    /* inner product INNER...[i+256*j] is a byte whose LS entry is the contribution
-       to the inner product of bytes i and j */
-
+    // inner product INNER...[i+256*j] is a byte whose LS entry is the contribution
+    // to the inner product of bytes i and j
     for (i = 0; i < 256; i++)
         for (j = i; j < 256; j++) {
             val = 0;
@@ -419,8 +417,8 @@ void MakeFieldInfo8Bit( UInt q)
             INNER_FIELDINFO_8BIT(info)[j + 256 * i] = val;
         }
 
-    /* PMULL and PMULU are the lower and upper bytes of the product
-       of single-byte polynomials */
+    // PMULL and PMULU are the lower and upper bytes of the product
+    // of single-byte polynomials
     for (i = 0; i < 256; i++)
         for (j = i; j < 256; j++) {
             val0 = 0;
@@ -439,7 +437,7 @@ void MakeFieldInfo8Bit( UInt q)
             PMULL_FIELDINFO_8BIT(info)[i + 256 * j] = val0;
             PMULL_FIELDINFO_8BIT(info)[j + 256 * i] = val0;
 
-            /* if there is just one entry per byte then we don't need the upper half */
+            // if there is just one entry per byte then we don't need the upper half 
             if (ELS_BYTE_FIELDINFO_8BIT(info) > 1) {
                 val0 = 0;
                 for (k = e; k < 2 * e - 1; k++) {
@@ -460,8 +458,8 @@ void MakeFieldInfo8Bit( UInt q)
         }
 
 
-    /* In odd characteristic, we need the addition table
-       ADD...[i*256+j] is the vector sum of bytes i and j */
+    // In odd characteristic, we need the addition table
+    // ADD...[i*256+j] is the vector sum of bytes i and j
     if (p != 2) {
         for (i = 0; i < 256; i++)
             for (j = i; j < 256; j++) {
@@ -483,7 +481,7 @@ void MakeFieldInfo8Bit( UInt q)
 #ifdef HPCGAP
     MakeBagReadOnly(info);
 #endif
-    /* remember the result */
+    // remember the result 
 #ifdef HPCGAP
     ATOMIC_SET_ELM_PLIST_ONCE(FieldInfo8Bit, q, info);
 #else
@@ -529,7 +527,7 @@ void RewriteVec8Bit( Obj vec, UInt q)
     Obj info, info1;
     UInt len;
     UInt els, els1;
-    /*UInt mut = IS_MUTABLE_OBJ(vec); */
+    //UInt mut = IS_MUTABLE_OBJ(vec); 
     UInt mult;
 
     UInt1 *gettab1, byte1;
@@ -551,7 +549,7 @@ void RewriteVec8Bit( Obj vec, UInt q)
         return;
     }
 
-    /* extract the required info */
+    // extract the required info 
     len = LEN_VEC8BIT(vec);
     info = GetFieldInfo8Bit(q);
     info1 = GetFieldInfo8Bit(q1);
@@ -565,7 +563,7 @@ void RewriteVec8Bit( Obj vec, UInt q)
         return;
     }
 
-    /* enlarge the bag */
+    // enlarge the bag 
     ResizeWordSizedBag(vec, SIZE_VEC8BIT(len, els));
 
     gettab1 = GETELT_FIELDINFO_8BIT(info1);
@@ -627,12 +625,12 @@ void RewriteGF2Vec( Obj vec, UInt q )
         return;
     }
 
-    /* extract the required info */
+    // extract the required info 
     len = LEN_GF2VEC(vec);
     info = GetFieldInfo8Bit(q);
     els = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    /* enlarge the bag */
+    // enlarge the bag 
     ResizeWordSizedBag(vec, SIZE_VEC8BIT(len, els));
 
     settab = SETELT_FIELDINFO_8BIT(info);
@@ -671,21 +669,19 @@ void ConvVec8Bit (
     Obj                 list,
     UInt                q)
 {
-    Int                 len;            /* logical length of the vector    */
-    Int                 i;              /* loop variable                   */
-    UInt                p;  /* char */
-    UInt                d;  /* degree */
-    FF                  f;  /* field */
-    /* Obj                 x;  / an element */
-    Obj                 info; /* field info object */
-    UInt                elts; /* elements per byte */
-    UInt1 *             settab; /* element setting table */
-    UInt1 *             convtab; /* FFE -> FELT conversion table */
-    Obj                 firstthree[3]; /* the first three entries
-          may get clobbered my the early bytes */
-    UInt                e;  /* loop variable */
-    UInt1               byte; /* byte under construction */
-    UInt1*              ptr;  /* place to put byte */
+    Int                 len;            // logical length of the vector    
+    Int                 i;              // loop variable                   
+    UInt                p;  // char 
+    UInt                d;  // degree 
+    FF                  f;  // field 
+    Obj                 info; // field info object 
+    UInt                elts; // elements per byte 
+    UInt1 *             settab; // element setting table 
+    UInt1 *             convtab; // FFE -> FELT conversion table 
+    Obj                 firstthree[3]; // the first three entries may get clobbered my the early bytes
+    UInt                e;  // loop variable 
+    UInt1               byte; // byte under construction 
+    UInt1*              ptr;  // place to put byte 
     Obj                elt;
     UInt               val;
     UInt               nsize;
@@ -697,7 +693,7 @@ void ConvVec8Bit (
     if (q == 2)
         ErrorQuit("GF2 has its own representation\n", 0L, 0L);
 
-    /* already in the correct representation                               */
+    // already in the correct representation                               
     if (IS_VEC8BIT_REP(list)) {
         if (FIELD_VEC8BIT(list) == q)
             return;
@@ -705,8 +701,8 @@ void ConvVec8Bit (
             RewriteVec8Bit(list, q);
             return;
         }
-        /* remaining case is list is written over too large a field
-           pass through to the generic code */
+        // remaining case is list is written over too large a field
+        // pass through to the generic code
 
     } else if (IS_GF2VEC_REP(list)) {
         RewriteGF2Vec(list, q);
@@ -715,7 +711,7 @@ void ConvVec8Bit (
 
     len = LEN_LIST(list);
 
-    /* OK, so now we know which field we want, set up data */
+    // OK, so now we know which field we want, set up data 
     info = GetFieldInfo8Bit(q);
     p = P_FIELDINFO_8BIT(info);
     d = D_FIELDINFO_8BIT(info);
@@ -723,20 +719,20 @@ void ConvVec8Bit (
 
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    /* We may need to resize first, as small lists get BIGGER
-       in this process */
+    // We may need to resize first, as small lists get BIGGER
+    // in this process
     nsize = SIZE_VEC8BIT(len, elts);
     if (nsize > SIZE_OBJ(list))
         ResizeWordSizedBag(list, nsize);
 
 
-    /* writing the first byte may clobber the third list entry
-       before we have read it, so we take a copy */
+    // writing the first byte may clobber the third list entry
+    // before we have read it, so we take a copy
     firstthree[0] = ELM0_LIST(list, 1);
     firstthree[1] = ELM0_LIST(list, 2);
     firstthree[2] = ELM0_LIST(list, 3);
 
-    /* main loop -- e is the element within byte */
+    // main loop -- e is the element within byte 
     e = 0;
     byte = 0;
     ptr = BYTES_VEC8BIT(list);
@@ -748,8 +744,8 @@ void ConvVec8Bit (
         if (val != 0 && FLD_FFE(elt) != f) {
             val = 1 + (val - 1) * (q - 1) / (SIZE_FF(FLD_FFE(elt)) - 1);
         }
-        /* Must get these afresh after every list access, just in case this is
-         a virtual list whose accesses might cause a garbage collection */
+        // Must get these afresh after every list access, just in case this is
+        // a virtual list whose accesses might cause a garbage collection
         settab = SETELT_FIELDINFO_8BIT(info);
         convtab = FELT_FFE_FIELDINFO_8BIT(info);
         byte = settab[(e + elts * convtab[val]) * 256 + byte];
@@ -760,16 +756,17 @@ void ConvVec8Bit (
         }
     }
 
-    /* it can happen that the few bytes after the end of the data are
-       not zero, because they had data in them in the old version of the list
-       In most cases this doesn't matter, but in characteristic 2, we must
-       clear up to the end of the word, so that AddCoeffs behaves correctly.
-    SL -- lets do this in all characteristics, it can never hurt */
+    // it can happen that the few bytes after the end of the data are
+    // not zero, because they had data in them in the old version of the list
+    // In most cases this doesn't matter, but in characteristic 2, we must
+    // clear up to the end of the word, so that AddCoeffs behaves correctly.
+    // 
+    // SL -- lets do this in all characteristics, it can never hurt
 
     while ((ptr - BYTES_VEC8BIT(list)) % sizeof(UInt))
         *ptr++ = 0;
 
-    /* retype and resize bag */
+    // retype and resize bag 
     if (nsize != SIZE_OBJ(list))
         ResizeWordSizedBag(list, nsize);
     SET_LEN_VEC8BIT(list, len);
@@ -828,24 +825,24 @@ Obj NewVec8Bit (
     Obj                 list,
     UInt                q)
 {
-    Int                 len;            /* logical length of the vector    */
-    Int                 i;              /* loop variable                   */
-    UInt                p;	/* char */
-    UInt                d;	/* degree */
-    FF                  f;	/* field */
- /* Obj                 x;	/ an element */
-    Obj                 info;	/* field info object */
-    UInt                elts;	/* elements per byte */
-    UInt1 *             settab;	/* element setting table */
-    UInt1 *             convtab; /* FFE -> FELT conversion table */
-    UInt                e;	/* loop varibale */
-    UInt1               byte;	/* byte under construction */
-    UInt1*              ptr;	/* place to put byte */
+    Int                 len;            // logical length of the vector    
+    Int                 i;              // loop variable                   
+    UInt                p;	// char 
+    UInt                d;	// degree 
+    FF                  f;	// field 
+ // Obj                 x;	/ an element 
+    Obj                 info;	// field info object 
+    UInt                elts;	// elements per byte 
+    UInt1 *             settab;	// element setting table 
+    UInt1 *             convtab; // FFE -> FELT conversion table 
+    UInt                e;	// loop varibale 
+    UInt1               byte;	// byte under construction 
+    UInt1*              ptr;	// place to put byte 
     Obj                 elt;
     UInt                val;
     UInt                nsize;
     Obj                 type;
-    Obj                 res;            /* resulting 8bit vector object     */
+    Obj                 res;            // resulting 8bit vector object     
 
         
     if (q > 256)
@@ -853,54 +850,54 @@ Obj NewVec8Bit (
     if (q == 2)
       ErrorQuit("GF2 has its own representation\n", 0L, 0L);
 
-    /* already in the correct representation                               */
+    // already in the correct representation                               
     if ( IS_VEC8BIT_REP(list) )
       {
 	if( FIELD_VEC8BIT(list) == q ) 
 	  {
 	    res = CopyVec8Bit(list,1); 
         if (!IS_MUTABLE_OBJ(list))
-          /* index 0 is for immutable vectors */   
+          // index 0 is for immutable vectors    
 	  SetTypeDatObj( res, TypeVec8Bit( q, 0 ) );
         return res;
       }
 	else if ( FIELD_VEC8BIT(list) < q )
 	  {
-	    /* rewriting to a larger field */   
+	    // rewriting to a larger field    
         res = CopyVec8Bit(list,1);
         RewriteVec8Bit(res,q);
-        /* TODO: rework RewriteVec8Bit and avoid calling CopyVec8Bit */
+        // TODO: rework RewriteVec8Bit and avoid calling CopyVec8Bit 
         if (!IS_MUTABLE_OBJ(list))
           SetTypeDatObj( res, TypeVec8Bit( q, 0 ) );
 	    return res;
 	  }
-	/* remaining case is list is written over too large a field
-	   pass through to the generic code */
+	// remaining case is list is written over too large a field
+	// pass through to the generic code
 
     }
     else if ( IS_GF2VEC_REP(list) )
       {
         res = ShallowCopyVecGF2(list);  
         RewriteGF2Vec(res, q);
-        /* TODO: rework RewriteGF2Vec and avoid calling ShallowCopyVecGF2 */
+        // TODO: rework RewriteGF2Vec and avoid calling ShallowCopyVecGF2 
         if (!IS_MUTABLE_OBJ(list))
           SetTypeDatObj( res, TypeVec8Bit( q, 0 ) );
 	    return res;
       }
     
-    /* OK, so now we know which field we want, set up data */
+    // OK, so now we know which field we want, set up data 
     info = GetFieldInfo8Bit(q);
     p = P_FIELDINFO_8BIT(info);
     d = D_FIELDINFO_8BIT(info);
     f = FiniteField(p,d);
 
-    /* determine the size and create a new bag */    
+    // determine the size and create a new bag     
     len = LEN_LIST(list);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     nsize = SIZE_VEC8BIT(len,elts);
     res = NewWordSizedBag( T_DATOBJ, nsize );
     
-    /* main loop -- e is the element within byte */
+    // main loop -- e is the element within byte 
     e = 0;
     byte = 0;
     ptr = BYTES_VEC8BIT(res);
@@ -913,8 +910,8 @@ Obj NewVec8Bit (
 	{
 	  val = 1+(val-1)*(q-1)/(SIZE_FF(FLD_FFE(elt))-1);
 	}
-      /* Must get these afresh after every list access, just in case this is
-       a virtual list whose accesses might cause a garbage collection */
+      // Must get these afresh after every list access, just in case this is
+      // a virtual list whose accesses might cause a garbage collection
       settab = SETELT_FIELDINFO_8BIT(info);
       convtab = FELT_FFE_FIELDINFO_8BIT(info);
       byte = settab[(e + elts*convtab[val])*256 + byte];
@@ -926,7 +923,7 @@ Obj NewVec8Bit (
 	}
     }
     
-    /* retype bag */
+    // retype bag 
     SET_LEN_VEC8BIT( res, len );
     SET_FIELD_VEC8BIT( res, q );
     type = TypeVec8Bit( q, IS_MUTABLE_OBJ( list ) );
@@ -960,9 +957,9 @@ Obj FuncCOPY_VEC8BIT (
 void PlainVec8Bit (
     Obj                 list )
 {
-    Int                 len;            /* length of <list>                */
-    UInt                i;              /* loop variable                   */
-    Obj                 first;          /* first entry                     */
+    Int                 len;            // length of <list>                
+    UInt                i;              // loop variable                   
+    Obj                 first;          // first entry                     
     Obj                 second = 0;
     UInt                q;
     UInt                elts;
@@ -973,7 +970,7 @@ void PlainVec8Bit (
     Char *              startblank;
     Char *              endblank;
 
-    /* resize the list and retype it, in this order                        */
+    // resize the list and retype it, in this order                        
     if (True == DoFilter(IsLockedRepresentationVector, list)) {
         ErrorMayQuit("Attempt to convert locked compressed vector to plain list", 0, 0);
         return;
@@ -998,8 +995,8 @@ void PlainVec8Bit (
 
     if (len != 0) {
         gettab = GETELT_FIELDINFO_8BIT(info);
-        /* keep the first two entries
-           because setting the third destroys them  */
+        // keep the first two entries
+        // because setting the third destroys them
 
         first = FFE_FELT_FIELDINFO_8BIT(info)[gettab[CONST_BYTES_VEC8BIT(list)[0]]];
         if (len > 1)
@@ -1007,8 +1004,8 @@ void PlainVec8Bit (
             FFE_FELT_FIELDINFO_8BIT(info)
             [gettab[256 * (1 % elts) + CONST_BYTES_VEC8BIT(list)[1 / elts]]];
 
-        /* replace the bits by FF elts as the case may be        */
-        /* this must of course be done from the end of the list backwards      */
+        // replace the bits by FF elts as the case may be        
+        // this must of course be done from the end of the list backwards      
         for (i = len; 2 < i; i--) {
             fieldobj = FFE_FELT_FIELDINFO_8BIT(info)
             [gettab[256 * ((i - 1) % elts) + CONST_BYTES_VEC8BIT(list)[(i - 1) / elts]]];
@@ -1036,7 +1033,7 @@ Obj FuncPLAIN_VEC8BIT (
     Obj                 self,
     Obj                 list )
 {
-    /* check whether <list> is an 8bit vector                                */
+    // check whether <list> is an 8bit vector                                
     while (! IS_VEC8BIT_REP(list)) {
         list = ErrorReturnObj(
             "PLAIN_VEC8BIT: <list> must be an 8bit vector (not a %s)",
@@ -1050,7 +1047,7 @@ Obj FuncPLAIN_VEC8BIT (
     }
     PlainVec8Bit(list);
 
-    /* return nothing                                                      */
+    // return nothing                                                      
     return 0;
 }
 
@@ -1119,7 +1116,7 @@ void  AddVec8BitVec8BitInner( Obj sum,
     UInt p;
     UInt elts;
 
-    /* Maybe there's nothing to do */
+    // Maybe there's nothing to do 
     if (!stop)
         return;
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(sum));
@@ -1130,7 +1127,7 @@ void  AddVec8BitVec8BitInner( Obj sum,
     assert(LEN_VEC8BIT(vr) >= stop);
     p = P_FIELDINFO_8BIT(info);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
-    /* Convert from 1 based to zero based addressing */
+    // Convert from 1 based to zero based addressing 
     start --;
     stop --;
     if (p == 2) {
@@ -1236,7 +1233,7 @@ Obj SumVec8BitVec8Bit( Obj vl, Obj vr )
 **
 */
 
-static Obj ConvertToVectorRep;  /* BH: changed to static */
+static Obj ConvertToVectorRep;  // BH: changed to static 
 
 
 Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
@@ -1254,7 +1251,7 @@ Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         for (i = 0; i < newd; i++)
             newq *= p;
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (newd > 8 || newq > 256 ||
             (ql != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vl)) ||
             (qr != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vr))) {
@@ -1267,8 +1264,8 @@ Obj FuncSUM_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
     }
 
 
-    /* just add if they're the same length,
-       otherwise copy the longer and add in the shorter */
+    // just add if they're the same length,
+    // otherwise copy the longer and add in the shorter
 
     if (LEN_VEC8BIT(vl) == LEN_VEC8BIT(vr))
         return SumVec8BitVec8Bit(vl, vr);
@@ -1323,7 +1320,7 @@ void MultVec8BitFFEInner( Obj prod,
     assert(Q_FIELDINFO_8BIT(info) == SIZE_FF(FLD_FFE(scal)));
 
 
-    /* convert to 0 based addressing */
+    // convert to 0 based addressing 
     start--;
     stop--;
     tab = SCALAR_FIELDINFO_8BIT(info) +
@@ -1417,7 +1414,7 @@ Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
     Obj info;
     UInt d;
 
-    if (VAL_FFE(ffe) == 1) { /* ffe is the one */
+    if (VAL_FFE(ffe) == 1) { // ffe is the one 
         prod = CopyVec8Bit(vec, IS_MUTABLE_OBJ(vec));
     } else if (VAL_FFE(ffe) == 0)
         return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec), IS_MUTABLE_OBJ(vec));
@@ -1425,17 +1422,17 @@ Obj FuncPROD_VEC8BIT_FFE( Obj self, Obj vec, Obj ffe)
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(vec));
     d = D_FIELDINFO_8BIT(info);
 
-    /* family predicate should have handled this */
+    // family predicate should have handled this 
     assert(CHAR_FF(FLD_FFE(ffe)) == P_FIELDINFO_8BIT(info));
 
-    /* check for field compatibility */
+    // check for field compatibility 
     if (d % DEGR_FF(FLD_FFE(ffe))) {
         prod = ProdListScl(vec, ffe);
         CALL_1ARGS(ConvertToVectorRep, prod);
         return prod;
     }
 
-    /* Finally the main line */
+    // Finally the main line 
     return MultVec8BitFFE(vec, ffe);
 }
 
@@ -1495,7 +1492,7 @@ Obj AInvVec8Bit(Obj vec, UInt mut)
 {
     Obj info;
     UInt p;
-    /*UInt d; */
+    //UInt d; 
     UInt minusOne;
     Obj neg;
     FF f;
@@ -1503,12 +1500,12 @@ Obj AInvVec8Bit(Obj vec, UInt mut)
     p = P_FIELDINFO_8BIT(info);
 
     neg = CopyVec8Bit(vec, mut);
-    /* characteristic 2 case */
+    // characteristic 2 case 
     if (2 == p) {
         return neg;
     }
 
-    /* Otherwise */
+    // Otherwise 
     f = FiniteField(p, D_FIELDINFO_8BIT(info));
     minusOne = NEG_FFV(1, SUCC_FF(f));
     MultVec8BitFFEInner(neg, neg, NEW_FFE(f, minusOne), 1, LEN_VEC8BIT(neg));
@@ -1570,7 +1567,7 @@ void  AddVec8BitVec8BitMultInner( Obj sum,
     if (!stop)
         return;
 
-    /* Handle special cases of <mult> */
+    // Handle special cases of <mult> 
     if (VAL_FFE(mult) == 0 && sum == vl)
         return;
 
@@ -1579,13 +1576,13 @@ void  AddVec8BitVec8BitMultInner( Obj sum,
         return;
     }
 
-    /*  so we have some work. get the tables */
+    //  so we have some work. get the tables 
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(sum));
 
     p = P_FIELDINFO_8BIT(info);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    /* Convert from 1 based to zero based addressing */
+    // Convert from 1 based to zero based addressing 
     start --;
     stop --;
     if (p != 2)
@@ -1641,7 +1638,7 @@ Obj FuncMULT_VECTOR_VEC8BITS( Obj self, Obj vec, Obj mul)
     if (VAL_FFE(mul) == 1)
         return (Obj)0;
 
-    /* Now check the field of <mul> */
+    // Now check the field of <mul> 
     if (q != SIZE_FF(FLD_FFE(mul))) {
         Obj info;
         UInt d, d1;
@@ -1675,7 +1672,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
     UInt q;
     UInt len;
     len = LEN_VEC8BIT(vl);
-    /* There may be nothing to do */
+    // There may be nothing to do 
     if (LT(to, from))
         return (Obj) 0;
 
@@ -1684,7 +1681,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
                             0L, 0L,
                             "you can replace <right> via 'return <right>;'");
 
-        /* Now redispatch, because vr could be anything */
+        // Now redispatch, because vr could be anything 
         return CALL_3ARGS(AddRowVector, vl, vr, mul);
     }
     while (LT(INTOBJ_INT(len), to)) {
@@ -1695,16 +1692,16 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
     if (LT(to, from))
         return (Obj) 0;
 
-    /* Now we know that the characteristics must match, but not the fields */
+    // Now we know that the characteristics must match, but not the fields 
     q = FIELD_VEC8BIT(vl);
 
-    /* fix up fields if necessary */
+    // fix up fields if necessary 
     if (q != FIELD_VEC8BIT(vr) || q != SIZE_FF(FLD_FFE(mul))) {
         Obj info, info1;
         UInt d, d1, q1, d2, d0, q0, p, i;
         FFV val;
 
-        /* find a common field */
+        // find a common field 
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -1720,7 +1717,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5( Obj self, Obj vl, Obj vr, Obj mul, Obj from, O
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && DoFilter(IsLockedRepresentationVector, vl) == True) ||
@@ -1755,18 +1752,18 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_3( Obj self, Obj vl, Obj vr, Obj mul)
                             0L, 0L,
                             "you can replace <right> via 'return <right>;'");
 
-        /* Now redispatch, because vr could be anything */
+        // Now redispatch, because vr could be anything 
         return CALL_3ARGS(AddRowVector, vl, vr, mul);
     }
-    /* Now we know that the characteristics must match, but not the fields */
+    // Now we know that the characteristics must match, but not the fields 
     q = FIELD_VEC8BIT(vl);
 
-    /* fix up fields if necessary */
+    // fix up fields if necessary 
     if (q != FIELD_VEC8BIT(vr) || q != SIZE_FF(FLD_FFE(mul))) {
         Obj info, info1;
         UInt d, d1, q1, d2, d0, q0, p, i;
         FFV val;
-        /* find a common field */
+        // find a common field 
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -1782,7 +1779,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_3( Obj self, Obj vl, Obj vr, Obj mul)
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
@@ -1816,17 +1813,17 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_2( Obj self, Obj vl, Obj vr)
                             0L, 0L,
                             "you can replace <right> via 'return <right>;'");
 
-        /* Now redispatch, because vr could be anything */
+        // Now redispatch, because vr could be anything 
         return CALL_2ARGS(AddRowVector, vl, vr);
     }
-    /* Now we know that the characteristics must match, but not the fields */
+    // Now we know that the characteristics must match, but not the fields 
     q = FIELD_VEC8BIT(vl);
-    /* fix up fields if necessary */
+    // fix up fields if necessary 
     if (q != FIELD_VEC8BIT(vr)) {
         Obj info1;
         Obj info;
         UInt d, d1, q1, d0, q0, p, i;
-        /* find a common field */
+        // find a common field 
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -1839,7 +1836,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_2( Obj self, Obj vl, Obj vr)
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
@@ -1943,7 +1940,7 @@ Obj DiffVec8BitVec8Bit( Obj vl, Obj vr)
 Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
 {
     Obj diff;
-    /*UInt p; */
+    //UInt p; 
 
 
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr)) {
@@ -1957,7 +1954,7 @@ Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         newq = 1;
         for (i = 0; i < newd; i++)
             newq *= p;
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (newd > 8 || newq > 256 ||
         (ql != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vl)) ||
         (qr != newq && True == CALL_1ARGS(IsLockedRepresentationVector, vr))) {
@@ -1970,7 +1967,7 @@ Obj FuncDIFF_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr)
         }
     }
 
-    /* Finally the main line */
+    // Finally the main line 
     return DiffVec8BitVec8Bit(vl, vr);
 }
 
@@ -2007,8 +2004,7 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
     ptrL = CONST_BYTES_VEC8BIT(vl);
     ptrR = CONST_BYTES_VEC8BIT(vr);
 
-    /* we stop a little short, so as to handle the final byte
-       separately */
+    // we stop a little short, so as to handle the final byte separately
     endL = ptrL + lenl / elts;
     endR = ptrR + lenr / elts;
     gettab = GETELT_FIELDINFO_8BIT(info);
@@ -2032,13 +2028,13 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
                       0L, 0L);
         }
     }
-    /* now the final byte */
+    // now the final byte 
     if (lenl < lenr)
         len = lenl;
     else
         len = lenr;
 
-    /* look first at the shared part */
+    // look first at the shared part 
     for (e = 0; e < (len % elts); e++) {
         vall = gettab[*ptrL + 256 * e];
         valr = gettab[*ptrR + 256 * e];
@@ -2049,7 +2045,7 @@ Int CmpVec8BitVec8Bit( Obj vl, Obj vr )
                 return 1;
         }
     }
-    /* if that didn't decide then the longer list is bigger */
+    // if that didn't decide then the longer list is bigger 
     if (lenr > lenl)
         return -1;
     else if (lenr == lenl)
@@ -2191,12 +2187,12 @@ Obj FuncDISTANCE_VEC8BIT_VEC8BIT( Obj self, Obj vl, Obj vr )
 **
 */
 void DistDistrib8Bits(
-  Obj   veclis, /* pointers to matrix vectors and their multiples */
-  Obj           vec,    /* vector we compute distance to */
-  Obj   d,  /* distances list */
-  Obj           sum,  /* position of the sum vector */
-  UInt    pos,  /* recursion depth */
-  UInt    l /* length of basis */
+  Obj   veclis, // pointers to matrix vectors and their multiples 
+  Obj           vec,    // vector we compute distance to 
+  Obj   d,  // distances list 
+  Obj           sum,  // position of the sum vector 
+  UInt    pos,  // recursion depth 
+  UInt    l // length of basis 
   ) 
 {
     UInt    i;
@@ -2235,21 +2231,21 @@ void DistDistrib8Bits(
 
 Obj FuncDISTANCE_DISTRIB_VEC8BITS(
   Obj   self,
-  Obj   veclis, /* pointers to matrix vectors and their multiples */
-  Obj   vec,    /* vector we compute distance to */
-  Obj   d ) /* distances list */
+  Obj   veclis, // pointers to matrix vectors and their multiples 
+  Obj   vec,    // vector we compute distance to 
+  Obj   d ) // distances list 
 
 {
-    Obj   sum; /* sum vector */
+    Obj   sum; // sum vector 
     UInt    len;
     UInt           q;
 
     len = LEN_VEC8BIT(vec);
     q = FIELD_VEC8BIT(vec);
 
-    /* get space for sum vector and zero out */
+    // get space for sum vector and zero out 
     sum = ZeroVec8Bit(q, len, 0);
-    /* do the recursive work */
+    // do the recursive work 
     DistDistrib8Bits(veclis, vec, d, sum, 1, LEN_PLIST(veclis));
 
     return (Obj) 0;
@@ -2274,15 +2270,15 @@ void OverwriteVec8Bit( Obj dst, Obj src)
 }
 
 UInt AClosVec8Bit( 
-      Obj   veclis, /* pointers to matrix vectors and their multiples */
-      Obj           vec,    /* vector we compute distance to */
-      Obj           sum,  /* position of the sum vector */
-      UInt    pos,  /* recursion depth */
-      UInt    l,  /* length of basis */
-      UInt    cnt,  /* number of vectors used already */
-      UInt    stop, /* stop value */
-      UInt    bd, /* best distance so far */
-      Obj   bv, /* best vector so far */
+      Obj   veclis, // pointers to matrix vectors and their multiples 
+      Obj           vec,    // vector we compute distance to 
+      Obj           sum,  // position of the sum vector 
+      UInt    pos,  // recursion depth 
+      UInt    l,  // length of basis 
+      UInt    cnt,  // number of vectors used already 
+      UInt    stop, // stop value 
+      UInt    bd, // best distance so far 
+      Obj   bv, // best vector so far 
       Obj           coords,
       Obj           bcoords
       )
@@ -2293,8 +2289,8 @@ UInt AClosVec8Bit(
     UInt q;
     UInt len;
 
-    /* This is the case where we do not add any multiple of
-       the current basis vector */
+    // This is the case where we do not add any multiple of
+    // the current basis vector
     if (pos + cnt < l) {
         bd = AClosVec8Bit(veclis, vec, sum, pos + 1, l, cnt, stop, bd, bv, coords, bcoords);
         if (bd <= stop) {
@@ -2305,13 +2301,13 @@ UInt AClosVec8Bit(
     len = LEN_VEC8BIT(vec);
     vp = ELM_PLIST(veclis, pos);
 
-    /* we need to add each scalar multiple and recurse */
+    // we need to add each scalar multiple and recurse 
     for (i = 1; i <  q ; i++) {
         AddVec8BitVec8BitInner(sum, sum, ELM_PLIST(vp, i), 1, len);
         if (coords)
             SET_ELM_PLIST(coords, pos, INTOBJ_INT(i));
         if (cnt == 0) {
-            /* do we have a new best case */
+            // do we have a new best case 
             di = DistanceVec8Bits(sum, vec);
             if (di < bd) {
                 bd = di;
@@ -2332,7 +2328,7 @@ UInt AClosVec8Bit(
             }
         }
     }
-    /* reset component */
+    // reset component 
     AddVec8BitVec8BitInner(sum, sum, ELM_PLIST(vp, q), 1, len);
     if (coords)
         SET_ELM_PLIST(coords, pos, INTOBJ_INT(0));
@@ -2348,13 +2344,13 @@ UInt AClosVec8Bit(
 
 Obj FuncA_CLOSEST_VEC8BIT(
           Obj   self,
-          Obj   veclis, /* pointers to matrix vectors and their multiples */
-          Obj   vec,    /* vector we compute distance to */
-          Obj   cnt,  /* distances list */
-          Obj   stop) /* distances list */
+          Obj   veclis, // pointers to matrix vectors and their multiples 
+          Obj   vec,    // vector we compute distance to 
+          Obj   cnt,  // distances list 
+          Obj   stop) // distances list 
 {
-    Obj   sum; /* sum vector */
-    Obj   best; /* best vector */
+    Obj   sum; // sum vector 
+    Obj   best; // best vector 
     UInt  len;
     UInt q;
 
@@ -2366,14 +2362,14 @@ Obj FuncA_CLOSEST_VEC8BIT(
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
 
-    /* get space for sum vector and zero out */
+    // get space for sum vector and zero out 
 
     sum = ZeroVec8Bit(q, len, 1);
     best = ZeroVec8Bit(q, len, 1);
 
-    /* do the recursive work */
+    // do the recursive work 
     AClosVec8Bit(veclis, vec, sum, 1, LEN_PLIST(veclis),
-                 INT_INTOBJ(cnt), INT_INTOBJ(stop), len + 1, /* maximal value +1 */
+                 INT_INTOBJ(cnt), INT_INTOBJ(stop), len + 1, // maximal value +1 
                  best, (Obj)0, (Obj)0);
 
     return best;
@@ -2386,13 +2382,13 @@ Obj FuncA_CLOSEST_VEC8BIT(
 
 Obj FuncA_CLOSEST_VEC8BIT_COORDS(
           Obj   self,
-          Obj   veclis, /* pointers to matrix vectors and their multiples */
-          Obj   vec,    /* vector we compute distance to */
-          Obj   cnt,  /* distances list */
-          Obj   stop) /* distances list */    
+          Obj   veclis, // pointers to matrix vectors and their multiples 
+          Obj   vec,    // vector we compute distance to 
+          Obj   cnt,  // distances list 
+          Obj   stop) // distances list     
 {
-    Obj   sum; /* sum vector */
-    Obj   best; /* best vector */
+    Obj   sum; // sum vector 
+    Obj   best; // best vector 
     UInt    len, len2, i;
     UInt q;
     Obj coords;
@@ -2407,7 +2403,7 @@ Obj FuncA_CLOSEST_VEC8BIT_COORDS(
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
 
-    /* get space for sum vector and zero out */
+    // get space for sum vector and zero out 
 
     sum = ZeroVec8Bit(q, len, 1);
     best = ZeroVec8Bit(q, len, 1);
@@ -2421,9 +2417,9 @@ Obj FuncA_CLOSEST_VEC8BIT_COORDS(
         SET_ELM_PLIST(bcoords, i, INTOBJ_INT(0));
     }
 
-    /* do the recursive work */
+    // do the recursive work 
     AClosVec8Bit(veclis, vec, sum, 1, LEN_PLIST(veclis),
-    INT_INTOBJ(cnt), INT_INTOBJ(stop), len + 1, /* maximal value +1 */
+    INT_INTOBJ(cnt), INT_INTOBJ(stop), len + 1, // maximal value +1 
     best, coords, bcoords);
 
     res = NEW_PLIST(T_PLIST_DENSE_NHOM, 2);
@@ -2462,17 +2458,17 @@ Obj FuncNUMBER_VEC8BIT (Obj self, Obj vec)
     ptrS = CONST_BYTES_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
     res = INTOBJ_INT(0);
-    f = INTOBJ_INT(FIELD_VEC8BIT(vec)); /* Field size as GAP integer */
+    f = INTOBJ_INT(FIELD_VEC8BIT(vec)); // Field size as GAP integer 
 
     if (len == 0)
       return INTOBJ_INT(1);
 
     for (i = 0; i < len; i++) {
         elt = convtab[gettab[ptrS[i / elts] + 256 * (i % elts)]];
-        res = ProdInt(res, f); /* ``shift'' */
+        res = ProdInt(res, f); // ``shift'' 
         res = SumInt(res, elt);
         if (!IS_INTOBJ(res)) {
-            /* a garbage collection might have moved the pointers */
+            // a garbage collection might have moved the pointers 
             gettab = GETELT_FIELDINFO_8BIT(info);
             convtab = GAPSEQ_FELT_FIELDINFO_8BIT(info);
             ptrS = CONST_BYTES_VEC8BIT(vec);
@@ -2543,7 +2539,7 @@ UInt CosetLeadersInner8Bits( Obj veclis,
                 vc = CopyVec8Bit(v, 0);
                 SET_ELM_PLIST(leaders, sy + 1, vc);
                 CHANGED_BAG(leaders);
-                /* Also record all the multiples here */
+                // Also record all the multiples here 
                 wc = ZeroVec8Bit(q, lenw, 1);
                 settab = SETELT_FIELDINFO_8BIT(info);
                 gettab = GETELT_FIELDINFO_8BIT(info);
@@ -2890,7 +2886,7 @@ Obj FuncELMS_VEC8BIT_RANGE (
     ptrD = BYTES_VEC8BIT(res);
     e = 0;
     byte = 0;
-    p = low - 1;    /* the -1 converts to 0 base */
+    p = low - 1;    // the -1 converts to 0 base 
     if (p % elts == 0 && inc == 1 && len >= elts) {
         while (p < low + len - elts) {
             *ptrD++ = ptrS[p / elts];
@@ -2957,7 +2953,7 @@ void ASS_VEC8BIT (
     UInt v;
     Obj newelm;
 
-    /* check that <list> is mutable                                        */
+    // check that <list> is mutable                                        
     if (! IS_MUTABLE_OBJ(list)) {
         ErrorReturnVoid(
             "List Assignment: <list> must be a mutable list",
@@ -2966,7 +2962,7 @@ void ASS_VEC8BIT (
         return;
     }
 
-    /* get the position                                                    */
+    // get the position                                                    
     RequirePositiveSmallInt("ASS_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
@@ -2985,7 +2981,7 @@ void ASS_VEC8BIT (
             }
             ResizeWordSizedBag(list, SIZE_VEC8BIT(p, elts));
             SET_LEN_VEC8BIT(list, p);
-            /*  Pr("Extending 8 bit vector by 1",0,0); */
+            //  Pr("Extending 8 bit vector by 1",0,0); 
         }
         if (!IS_FFE(elm)) {
             newelm = DoAttribute(AsInternalFFE, elm);
@@ -2994,9 +2990,9 @@ void ASS_VEC8BIT (
         }
         if (IS_FFE(elm) && chr == CharFFE(elm)) {
 
-            /* We may need to rewrite the vector over a larger field */
+            // We may need to rewrite the vector over a larger field 
             if (d % DegreeFFE(elm) !=  0) {
-                /*        Pr("Rewriting over larger field",0,0);*/
+                //        Pr("Rewriting over larger field",0,0);
                 f = CommonFF(FiniteField(chr, d), d,
                              FLD_FFE(elm), DegreeFFE(elm));
                 if (f && SIZE_FF(f) <= 256) {
@@ -3016,14 +3012,14 @@ void ASS_VEC8BIT (
 
             v = VAL_FFE(elm);
 
-            /* may need to promote the element to a bigger field
-               or restrict it to a smaller one */
+            // may need to promote the element to a bigger field
+            // or restrict it to a smaller one
             if (v != 0 && q != SIZE_FF(FLD_FFE(elm))) {
                 assert(((v - 1) * (q - 1)) % (SIZE_FF(FLD_FFE(elm)) - 1) == 0);
                 v = 1 + (v - 1) * (q - 1) / (SIZE_FF(FLD_FFE(elm)) - 1);
             }
 
-            /* finally do the assignment */
+            // finally do the assignment 
             BYTES_VEC8BIT(list)[(p - 1) / elts] =
                 SETELT_FIELDINFO_8BIT(info)
                 [256 * (elts * FELT_FFE_FIELDINFO_8BIT(info)[v] + (p - 1) % elts) +
@@ -3032,11 +3028,9 @@ void ASS_VEC8BIT (
         }
     }
 
-    /* We fall through here if the assignment position is so large
-       as to leave a hole, or if the object to be assigned is
-       not of the right characteristic, or would create too large a field */
-
-    /*     Pr("Random assignment (8 bit)",0,0);*/
+    // We fall through here if the assignment position is so large
+    // as to leave a hole, or if the object to be assigned is
+    // not of the right characteristic, or would create too large a field
 
     PlainVec8Bit(list);
     AssPlistFfe(list, p, elm);
@@ -3071,7 +3065,7 @@ Obj FuncUNB_VEC8BIT (
     Obj                 info;
     UInt elts;
 
-    /* check that <list> is mutable                                        */
+    // check that <list> is mutable                                        
     if (! IS_MUTABLE_OBJ(list)) {
         ErrorReturnVoid(
             "List Unbind: <list> must be a mutable list",
@@ -3085,15 +3079,15 @@ Obj FuncUNB_VEC8BIT (
         return 0;
     }
 
-    /* get the position                                                    */
+    // get the position                                                    
     RequirePositiveSmallInt("UNB_VEC8BIT", pos, "position");
     p = INT_INTOBJ(pos);
 
-    /* if we unbind the last position keep the representation              */
+    // if we unbind the last position keep the representation              
     if (LEN_VEC8BIT(list) < p) {
         ;
-    } else if (/* p > 1 && */ LEN_VEC8BIT(list) == p) {
-        /* zero out the last entry first, for safety */
+    } else if (LEN_VEC8BIT(list) == p) {
+        // zero out the last entry first, for safety 
         info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
         elts = ELS_BYTE_FIELDINFO_8BIT(info);
         BYTES_VEC8BIT(list)[(p - 1) / elts] =
@@ -3136,7 +3130,7 @@ UInt PositionNonZeroVec8Bit ( Obj list, UInt from )
     ptr = CONST_BYTES_VEC8BIT(list);
     i = from / elts;
     j = from % elts;
-    /* might be an initial part byte */
+    // might be an initial part byte 
     if (j) {
         if (i < nb && ptr[i])
             for (j = from % elts; j < elts && (i * elts + j < len); j++)
@@ -3145,14 +3139,14 @@ UInt PositionNonZeroVec8Bit ( Obj list, UInt from )
         i++;
     }
 
-    /* skip empty bytes */
+    // skip empty bytes 
     while (i < nb && !ptr[i])
         i++;
 
     if (i >= nb)
         return len + 1;
 
-    /* Found a non-empty byte, locate the entry */
+    // Found a non-empty byte, locate the entry 
     byte = ptr[i];
     j = 0;
     while (gettab[byte + 256 * j] == 0)
@@ -3241,7 +3235,7 @@ Obj FuncAPPEND_VEC8BIT (
                 byter = *++ptrr;
             }
         }
-        /* Write last byte only if not already written: */
+        // Write last byte only if not already written: 
         if (posl % elts != 0) *ptrl = bytel;
     }
     SET_LEN_VEC8BIT(vecl, lenl + lenr);
@@ -3277,16 +3271,16 @@ Obj FuncPROD_VEC8BIT_MATRIX( Obj self, Obj vec, Obj mat)
     l2 = LEN_PLIST(mat);
     q = FIELD_VEC8BIT(vec);
 
-    /* Get the first row, to establish the size of the result */
+    // Get the first row, to establish the size of the result 
     row1 = ELM_PLIST(mat, 1);
     if (! IS_VEC8BIT_REP(row1) || FIELD_VEC8BIT(row1) != q)
         return TRY_NEXT_METHOD;
     len1 = LEN_VEC8BIT(row1);
 
-    /* create the result space */
+    // create the result space 
     res = ZeroVec8Bit(q, len1, IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1));
 
-    /* Finally, we start work */
+    // Finally, we start work 
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     gettab = GETELT_FIELDINFO_8BIT(info);
@@ -3297,8 +3291,8 @@ Obj FuncPROD_VEC8BIT_MATRIX( Obj self, Obj vec, Obj mat)
             x = ffefelt[gettab[CONST_BYTES_VEC8BIT(vec)[i / elts] + 256 * (i % elts)]];
             if (VAL_FFE(x) != 0) {
                 row1 = ELM_PLIST(mat, i + 1);
-                /* This may be unduly draconian. Later we may want to be able to promote the rows
-                   to a bigger field */
+                // This may be unduly draconian. Later we may want to be able to promote the rows
+                // to a bigger field
                 if ((! IS_VEC8BIT_REP(row1)) || (FIELD_VEC8BIT(row1) != q))
                     return TRY_NEXT_METHOD;
                 AddVec8BitVec8BitMultInner(res, res, row1, x, 1, len1);
@@ -3435,7 +3429,7 @@ Obj ProdVec8BitMat8Bit( Obj vec, Obj mat )
     len1 = LEN_VEC8BIT(row1);
     res = ZeroVec8Bit(q, len1, IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1));
 
-    /* Finally, we start work */
+    // Finally, we start work 
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     gettab = GETELT_FIELDINFO_8BIT(info);
@@ -3484,9 +3478,9 @@ Obj FuncPROD_VEC8BIT_MAT8BIT( Obj self, Obj vec, Obj mat)
 {
     UInt q, q1, q2;
 
-    /* Sort out length mismatches */
+    // Sort out length mismatches 
 
-    /* Now field mismatches -- consider promoting the vector */
+    // Now field mismatches -- consider promoting the vector 
     q = FIELD_VEC8BIT(vec);
     q1 = FIELD_VEC8BIT(ELM_MAT8BIT(mat, 1));
     if (q != q1) {
@@ -3502,7 +3496,7 @@ Obj FuncPROD_VEC8BIT_MAT8BIT( Obj self, Obj vec, Obj mat)
             return TRY_NEXT_METHOD;
     }
 
-    /* OK, now we can do the work */
+    // OK, now we can do the work 
     return ProdVec8BitMat8Bit(vec, mat);
 }
 
@@ -3563,11 +3557,11 @@ Obj FuncPROD_MAT8BIT_VEC8BIT( Obj self, Obj mat, Obj vec)
     UInt q, q1, q2;
     Obj row;
 
-    /* Sort out length mismatches */
+    // Sort out length mismatches 
 
     row = ELM_MAT8BIT(mat, 1);
 
-    /* Now field mismatches -- consider promoting the vector */
+    // Now field mismatches -- consider promoting the vector 
     q = FIELD_VEC8BIT(vec);
     q1 = FIELD_VEC8BIT(row);
     if (q != q1) {
@@ -3583,7 +3577,7 @@ Obj FuncPROD_MAT8BIT_VEC8BIT( Obj self, Obj mat, Obj vec)
             return TRY_NEXT_METHOD;
     }
 
-    /* OK, now we can do the work */
+    // OK, now we can do the work 
     return ProdMat8BitVec8Bit(mat, vec);
 }
 
@@ -3618,8 +3612,8 @@ Obj ProdMat8BitMat8Bit( Obj matl, Obj matr)
     for (i = 1; i <= len; i++) {
         row = ProdVec8BitMat8Bit(ELM_MAT8BIT(matl, i), matr);
 
-        /* Since I'm going to put this vector into a matrix, I must lock its
-        representation, so that it doesn't get rewritten over GF(q^k) */
+        // Since I'm going to put this vector into a matrix, I must lock its
+        // representation, so that it doesn't get rewritten over GF(q^k)
         SetTypeDatObj(row, locked_type);
         SET_ELM_MAT8BIT(prod, i, row);
         CHANGED_BAG(prod);
@@ -3715,7 +3709,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         return inv;
     }
 
-    /* set up cmat and inv. Note that the row numbering is offset */
+    // set up cmat and inv. Note that the row numbering is offset 
     cmat = NEW_PLIST(T_PLIST, len);
     zero = ZeroVec8Bit(q, len, 1);
     o = FELT_FFE_FIELDINFO_8BIT(info)[1];
@@ -3727,23 +3721,23 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         row = SHALLOW_COPY_OBJ(zero);
         ptr = BYTES_VEC8BIT(row) + (i - 1) / elts;
 
-        /* we can't retain this pointer, because of garbage collections */
+        // we can't retain this pointer, because of garbage collections 
         settab = SETELT_FIELDINFO_8BIT(info);
-        /* we know we are replacing a zero  */
+        // we know we are replacing a zero  
         *ptr = settab[256 * ((i - 1) % elts + o * elts)];
         SET_ELM_PLIST(inv, i + 1, row);
         CHANGED_BAG(inv);
     }
 
-    /* Now do Gaussian elimination in cmat and mirror it on inv
-     from here, no garbage collections are allowed until the end */
+    // Now do Gaussian elimination in cmat and mirror it on inv
+    // from here, no garbage collections are allowed until the end
     gettab = GETELT_FIELDINFO_8BIT(info);
     ffefelt = FFE_FELT_FIELDINFO_8BIT(info);
 
     for (i = 1; i <= len; i++) {
         off = (i - 1) / elts;
         pos = (i - 1) % elts;
-        /* find a non-zero entry in column i */
+        // find a non-zero entry in column i 
         for (j = i; j <= len; j++) {
             row = ELM_PLIST(cmat, j);
             byte = CONST_BYTES_VEC8BIT(row)[off];
@@ -3751,11 +3745,11 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
                 break;
         }
 
-        /* if we didn't find one */
+        // if we didn't find one 
         if (j > len)
             return Fail;
 
-        /* swap and normalize */
+        // swap and normalize 
         row1 = ELM_PLIST(inv, j + 1);
         if (i != j) {
             SET_ELM_PLIST(cmat, j, ELM_PLIST(cmat, i));
@@ -3769,7 +3763,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
             MultVec8BitFFEInner(row1, row1, xi, 1, len);
         }
 
-        /* Now clean out column */
+        // Now clean out column 
         for (k = 1; k <= len; k++) {
             if (k < i || k > j) {
                 row2 = ELM_PLIST(cmat, k);
@@ -3788,7 +3782,7 @@ Obj InverseMat8Bit( Obj mat, UInt mut)
         }
     }
 
-    /* Now clean up inv and return it */
+    // Now clean up inv and return it 
     SET_ELM_PLIST(inv, 1, INTOBJ_INT(len));
     type = TypeVec8BitLocked(q, mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(ELM_MAT8BIT(mat, 1))));
     for (i = 2 ; i <= len + 1; i++) {
@@ -3997,12 +3991,12 @@ Obj SumMat8BitMat8Bit( Obj ml, Obj mr)
     wl = LEN_VEC8BIT(ELM_MAT8BIT(ml, 1));
     wr = LEN_VEC8BIT(ELM_MAT8BIT(mr, 1));
 
-    /* We have to track the cases where the result is not rectangular */
+    // We have to track the cases where the result is not rectangular 
     if (((ll > lr) && (wr > wl)) ||
     ((lr > ll) && (wl > wr)))
         return TRY_NEXT_METHOD;
 
-    /* Now sort out the size of the result */
+    // Now sort out the size of the result 
     if (ll > lr) {
         ls = ll;
         assert(wl > wr);
@@ -4076,12 +4070,12 @@ Obj DiffMat8BitMat8Bit( Obj ml, Obj mr)
     wl = LEN_VEC8BIT(ELM_MAT8BIT(ml, 1));
     wr = LEN_VEC8BIT(ELM_MAT8BIT(mr, 1));
 
-    /* We have to track the cases where the result is not rectangular */
+    // We have to track the cases where the result is not rectangular 
     if (((ll > lr) && (wr > wl)) ||
         ((lr > ll) && (wl > wr)))
         return TRY_NEXT_METHOD;
 
-    /* Now sort out the size of the result */
+    // Now sort out the size of the result 
     if (ll > lr) {
         ld = ll;
         assert(wl > wr);
@@ -4154,7 +4148,7 @@ UInt RightMostNonZeroVec8Bit( Obj vec)
     const UInt1 *ptr, *ptrS;
     Int i;
     UInt1 *gettab;
-    /*UInt1 byte; */
+    //UInt1 byte; 
     len = LEN_VEC8BIT(vec);
     if (len == 0)
         return 0;
@@ -4164,7 +4158,7 @@ UInt RightMostNonZeroVec8Bit( Obj vec)
     ptrS = CONST_BYTES_VEC8BIT(vec);
     ptr = ptrS + (len - 1) / elts;
 
-    /* handle last byte specially, unless it happens to be full */
+    // handle last byte specially, unless it happens to be full 
     if (len % elts != 0) {
         gettab = GETELT_FIELDINFO_8BIT(info) + *ptr;
         for (i = len % elts - 1; i >= 0; i--) {
@@ -4174,14 +4168,14 @@ UInt RightMostNonZeroVec8Bit( Obj vec)
         ptr--;
     }
 
-    /* now skip over empty bytes */
+    // now skip over empty bytes 
     while (ptr >= ptrS && *ptr == 0)
         ptr --;
     if (ptr < ptrS)
         return 0;
 
 
-    /* Now look in the rightmost non-empty byte for the position */
+    // Now look in the rightmost non-empty byte for the position 
     gettab = GETELT_FIELDINFO_8BIT(info) + *ptr;
     for (i = elts - 1; i >= 0; i--) {
         if (gettab[256 * i]  != 0)
@@ -4214,23 +4208,23 @@ void ResizeVec8Bit( Obj vec, UInt newlen, UInt knownclean )
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     SET_LEN_VEC8BIT(vec, newlen);
     ResizeWordSizedBag(vec, SIZE_VEC8BIT(newlen, elts));
-    /* vector has got shorter. */
+    // vector has got shorter. 
     if (len > newlen) {
         if (newlen % elts) {
-            /* clean spare entries in last byte */
+            // clean spare entries in last byte 
             settab = SETELT_FIELDINFO_8BIT(info);
             byte = CONST_BYTES_VEC8BIT(vec)[(newlen - 1) / elts];
             for (i = newlen % elts; i < elts; i++)
                 byte = settab[ byte + 256 * i];
             BYTES_VEC8BIT(vec)[(newlen - 1) / elts] = byte;
         }
-        /* Clean spare bytes in last word for characteristic 2 */
+        // Clean spare bytes in last word for characteristic 2 
         if ((q % 2) == 0)
             for (i = (newlen + elts - 1) / elts; i % sizeof(UInt); i++)
                 BYTES_VEC8BIT(vec)[i] = 0;
     }
 
-    /* vector has got longer and might be dirty */
+    // vector has got longer and might be dirty 
     if (!knownclean && newlen > len) {
         settab = SETELT_FIELDINFO_8BIT(info);
         ptr = BYTES_VEC8BIT(vec);
@@ -4260,7 +4254,7 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
     UInt1 *gettab, *settab;
     UInt1 x;
 
-    /* A couple of trivial cases */
+    // A couple of trivial cases 
     if (amount == 0)
         return;
     len = LEN_VEC8BIT(vec);
@@ -4276,12 +4270,12 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
     ptr2 = BYTES_VEC8BIT(vec) + amount / elts;
     end = BYTES_VEC8BIT(vec) + (len + elts - 1) / elts;
 
-    /* The easy case is just a shift by bytes */
+    // The easy case is just a shift by bytes 
     if (amount % elts == 0) {
         while (ptr2 < end)
             *ptr1++ = *ptr2++;
     } else {
-        /* The general case */
+        // The general case 
         from = amount;
         to = 0;
         fbyte = *ptr2;
@@ -4310,7 +4304,7 @@ void ShiftLeftVec8Bit( Obj vec, UInt amount)
     ResizeVec8Bit(vec, len - amount, 0);
 }
 
-void ShiftRightVec8Bit( Obj vec, UInt amount) /* pads with zeros */
+void ShiftRightVec8Bit( Obj vec, UInt amount) // pads with zeros 
 {
     UInt q;
     Obj info;
@@ -4322,11 +4316,11 @@ void ShiftRightVec8Bit( Obj vec, UInt amount) /* pads with zeros */
     UInt1 *gettab, *settab;
     UInt1 x;
 
-    /* A trivial cases */
+    // A trivial cases 
     if (amount == 0)
         return;
 
-    /* make room */
+    // make room 
     len = LEN_VEC8BIT(vec);
     ResizeVec8Bit(vec, len + amount, 0);
 
@@ -4336,7 +4330,7 @@ void ShiftRightVec8Bit( Obj vec, UInt amount) /* pads with zeros */
     ptr1 = BYTES_VEC8BIT(vec) + (len - 1 + amount) / elts;
     ptr2 = BYTES_VEC8BIT(vec) + (len - 1) / elts;
 
-    /* The easy case is just a shift by bytes */
+    // The easy case is just a shift by bytes 
     if (amount % elts == 0) {
         end = BYTES_VEC8BIT(vec);
         while (ptr2 >= end)
@@ -4344,7 +4338,7 @@ void ShiftRightVec8Bit( Obj vec, UInt amount) /* pads with zeros */
         while (ptr1 >= end)
             *ptr1-- = (UInt1)0;
     } else {
-        /* The general case */
+        // The general case 
         from = len - 1;
         to = len + amount - 1;
         fbyte = *ptr2;
@@ -4392,15 +4386,15 @@ Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
         ResizeVec8Bit(vec1, len, 0);
     }
 
-    /* Now we know that the characteristics must match, but not the fields */
+    // Now we know that the characteristics must match, but not the fields 
     q = FIELD_VEC8BIT(vec1);
 
-    /* fix up fields if necessary */
+    // fix up fields if necessary 
     if (q != FIELD_VEC8BIT(vec2) || q != SIZE_FF(FLD_FFE(mult))) {
         Obj info, info1;
         UInt d, d1, q1, d2, d0, q0, p, i;
         FFV val;
-        /* find a common field */
+        // find a common field 
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vec2);
@@ -4416,7 +4410,7 @@ Obj FuncADD_COEFFS_VEC8BIT_3( Obj self, Obj vec1, Obj vec2, Obj mult )
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vec1) == True) ||
@@ -4452,19 +4446,19 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
         ResizeVec8Bit(vec1, len, 0);
     }
 
-    /* Now we know that the characteristics must match, but not the fields */
+    // Now we know that the characteristics must match, but not the fields 
     q = FIELD_VEC8BIT(vec1);
 
-    /* fix up fields if necessary */
+    // fix up fields if necessary 
     if (q != FIELD_VEC8BIT(vec2)) {
         Obj info, info1;
         UInt d, d1, q1, d0, q0, p, i;
 
-        /* find a common field */
+        // find a common field 
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vec2);
-        /*Pr("q= %d q1= %d ",q,q1);*/
+        //Pr("q= %d q1= %d ",q,q1);
         info1 = GetFieldInfo8Bit(q1);
         d1 = D_FIELDINFO_8BIT(info1);
         d0 = LcmDegree(d, d1);
@@ -4473,9 +4467,9 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
         q0 = 1;
         for (i = 0; i < d0; i++)
             q0 *= p;
-        /*Pr("q0= %d d0= %d\n",q0,d0); */
+        //Pr("q0= %d d0= %d\n",q0,d0); 
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vec1) == True) ||
@@ -4497,7 +4491,7 @@ Obj FuncADD_COEFFS_VEC8BIT_2( Obj self, Obj vec1, Obj vec2 )
 
 Obj FuncSHIFT_VEC8BIT_LEFT( Obj self, Obj vec, Obj amount)
 {
-    /* should be checked in method selection */
+    // should be checked in method selection 
     assert(IS_MUTABLE_OBJ(vec));
     while (!IS_INTOBJ(amount) || INT_INTOBJ(amount) < 0) {
         amount = ErrorReturnObj("SHIFT_VEC8BIT_LEFT: <amount> must be a non-negative small integer",
@@ -4597,8 +4591,8 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
     ptrr = CONST_BYTES_VEC8BIT(vr);
     ptrp = BYTES_VEC8BIT(res);
 
-    /* This calculation is done in four parts. The first deals with the whole
-       bytes from both polynomials */
+    // This calculation is done in four parts. The first deals with the whole
+    // bytes from both polynomials
     for (i = 0; i < ll / elts; i++) {
         bytel = ptrl[i];
         if (bytel != 0)
@@ -4625,8 +4619,8 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
             }
     }
 
-    /* The next two deal with the end byte from each polynomial, in combination with the whole
-       bytes from the other polynomial */
+    // The next two deal with the end byte from each polynomial, in combination with the whole
+    // bytes from the other polynomial
     gettab = GETELT_FIELDINFO_8BIT(info);
     settab = SETELT_FIELDINFO_8BIT(info);
     if (ll % elts != 0) {
@@ -4692,7 +4686,7 @@ void ProdCoeffsVec8Bit ( Obj res, Obj vl, UInt ll, Obj vr, UInt lr )
         }
     }
 
-    /* Finally, we have to multiply the two end bytes */
+    // Finally, we have to multiply the two end bytes 
     if (ll % elts != 0 && lr % elts != 0 && partl != 0 && partr != 0) {
         byte1 = pmulltab[ partl + 256 * partr];
         if (byte1 != 0) {
@@ -4732,7 +4726,7 @@ Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
         Obj  info1;
         UInt d, d1, q1, d0, q0, p, i;
 
-        /* find a common field */
+        // find a common field 
         info = GetFieldInfo8Bit(q);
         d = D_FIELDINFO_8BIT(info);
         q1 = FIELD_VEC8BIT(vr);
@@ -4745,7 +4739,7 @@ Obj FuncPROD_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vr, Obj lr  )
         for (i = 0; i < d0; i++)
             q0 *= p;
 
-        /* if the exponent is bigger than 31, overflow changes the value to 0 */
+        // if the exponent is bigger than 31, overflow changes the value to 0 
         if (d0 > 8 || q0 > 256)
             return TRY_NEXT_METHOD;
         if ((q0 > q && CALL_1ARGS(IsLockedRepresentationVector, vl) == True) ||
@@ -4800,7 +4794,7 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     UInt len1;
     UInt1 x;
     UInt1 *ptr;
-    UInt1 *ptrs[5]; /* 5 is the largest value of elts we ever meet */
+    UInt1 *ptrs[5]; // 5 is the largest value of elts we ever meet 
     Obj type;
 
     q = FIELD_VEC8BIT(v);
@@ -4808,8 +4802,8 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    /* normalize a copy of v in vn -- normalize means monic, and actual length
-       equal to length parameter */
+    // normalize a copy of v in vn -- normalize means monic, and actual length
+    // equal to length parameter
     vn = CopyVec8Bit(v, 1);
     ResizeVec8Bit(vn, len, 0);
     len1 = (len == 0) ? 0 : RightMostNonZeroVec8Bit(vn);
@@ -4831,28 +4825,28 @@ Obj MakeShiftedVecs( Obj v, UInt len)
     type = TypeVec8Bit(q, 0);
     SetTypeDatObj(vn, type);
 
-    /* Now we start to build up the result */
+    // Now we start to build up the result 
     shifts = NEW_PLIST_IMM(T_PLIST_TAB, elts + 2);
     SET_ELM_PLIST(shifts, elts + 1, INTOBJ_INT(len));
     SET_ELM_PLIST(shifts, elts + 2, xi);
     SET_LEN_PLIST(shifts, elts + 2);
 
-    /* vn can simply be stored in one place */
+    // vn can simply be stored in one place 
     SET_ELM_PLIST(shifts, (len - 1) % elts + 1, vn);
     CHANGED_BAG(shifts);
 
     if (elts > 1) {
-        /* fill the rest up with zero vectors of suitable lengths */
+        // fill the rest up with zero vectors of suitable lengths 
         for (i = 1; i < elts; i++) {
             ashift = ZeroVec8Bit(q, len + i, 0);
             SET_ELM_PLIST(shifts, (len + i - 1) % elts + 1, ashift);
             CHANGED_BAG(shifts);
         }
 
-        /* reload the tables, in case there was a garbage collection */
+        // reload the tables, in case there was a garbage collection 
         gettab = GETELT_FIELDINFO_8BIT(info);
         settab = SETELT_FIELDINFO_8BIT(info);
-        /* Now run through the entries of vn inserting them into the shifted versions */
+        // Now run through the entries of vn inserting them into the shifted versions 
         ptr = BYTES_VEC8BIT(vn);
         for (j = 1; j < elts; j++)
             ptrs[j] = BYTES_VEC8BIT(ELM_PLIST(shifts, (len + j - 1) % elts + 1));
@@ -5044,7 +5038,7 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
 {
     UInt nrows, ncols;
     UInt i, j, h;
-    /*UInt block; */
+    //UInt block; 
     Obj heads, vectors, coeffs = 0, relns = 0;
     UInt nvecs, nrels = 0;
     Obj coeffrow = 0;
@@ -5064,17 +5058,17 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
     nrows = LEN_PLIST(mat);
     ncols = LEN_VEC8BIT(ELM_PLIST(mat, 1));
 
-    /* Find the field info */
+    // Find the field info 
     q = FIELD_VEC8BIT(ELM_PLIST(mat, 1));
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    /* Get the Felt numbers for zero and one */
+    // Get the Felt numbers for zero and one 
     convtab = FELT_FFE_FIELDINFO_8BIT(info);
     zero = convtab[0];
     one = convtab[1];
 
-    /* Set up the lists for the results */
+    // Set up the lists for the results 
     heads = NEW_PLIST(T_PLIST_CYC, ncols);
     SET_LEN_PLIST(heads, ncols);
     vectors = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
@@ -5087,7 +5081,7 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
     for (i = 1; i <= ncols; i++)
         SET_ELM_PLIST(heads, i, INTOBJ_INT(0));
 
-    /* Main loop starts here */
+    // Main loop starts here 
     for (i = 1; i <= nrows; i++) {
         row = ELM_PLIST(mat, i);
         if (TransformationsNeeded) {
@@ -5098,15 +5092,15 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
             SET_FIELD_VEC8BIT(coeffrow, q);
             CHANGED_BAG(coeffrow);
 
-            /* No garbage collection risk from here */
+            // No garbage collection risk from here 
             settab = SETELT_FIELDINFO_8BIT(info);
             BYTES_VEC8BIT(coeffrow)[(i - 1) / elts] = settab[256 * ((i - 1) % elts + elts * one)];
         }
-        /* No garbage collection risk from here */
+        // No garbage collection risk from here 
         gettab = GETELT_FIELDINFO_8BIT(info);
         convtab1 = FFE_FELT_FIELDINFO_8BIT(info);
 
-        /* Clear out the current row */
+        // Clear out the current row 
         for (j = 1; j <= ncols; j++) {
             h = INT_INTOBJ(ELM_PLIST(heads, j));
             if (h != 0) {
@@ -5141,7 +5135,7 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
                 CHANGED_BAG(coeffs);
                 SET_LEN_PLIST(coeffs, nvecs);
             }
-            /* garbage collection OK again after here */
+            // garbage collection OK again after here 
         } else if (TransformationsNeeded) {
             SET_ELM_PLIST(relns, ++nrels, coeffrow);
             CHANGED_BAG(relns);
@@ -5209,7 +5203,7 @@ UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(row));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-    /* Nothing here can cause a garbage collection */
+    // Nothing here can cause a garbage collection 
 
     gettab = GETELT_FIELDINFO_8BIT(info);
     convtab = FFE_FELT_FIELDINFO_8BIT(info);
@@ -5283,7 +5277,7 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS( Obj self, Obj mat )
     UInt i, len, width;
     Obj row;
     UInt q;
-    /* check argts */
+    // check argts 
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5319,7 +5313,7 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS( Obj self, Obj mat )
     Obj row;
     UInt q;
     UInt width;
-    /* check argts */
+    // check argts 
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5357,7 +5351,7 @@ Obj FuncTRIANGULIZE_LIST_VEC8BITS( Obj self, Obj mat )
     UInt i, len, width;
     Obj row;
     UInt q;
-    /* check argts */
+    // check argts 
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5394,7 +5388,7 @@ Obj FuncRANK_LIST_VEC8BITS( Obj self, Obj mat )
     UInt i, len, width;
     Obj row;
     UInt q;
-    /* check argts */
+    // check argts 
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5431,7 +5425,7 @@ Obj FuncDETERMINANT_LIST_VEC8BITS( Obj self, Obj mat )
     Obj row;
     UInt q;
     Obj det;
-    /* check argts */
+    // check argts 
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5535,16 +5529,16 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
     UInt1 *gettab = 0, *settab = 0;
     Obj type;
 
-    /* check argument */
+    // check argument 
     if (TNUM_OBJ(mat) != T_POSOBJ) {
         mat = ErrorReturnObj(
             "TRANSPOSED_MAT8BIT: Need compressed matrix\n",
             0, 0,
             "You can return such matrix with 'return mat;'\n");
     }
-    /* we will give result same type as mat */
+    // we will give result same type as mat 
 
-    /* we assume here that there is a first row  -- a zero row mat8bit is a bad thing*/
+    // we assume here that there is a first row  -- a zero row mat8bit is a bad thing
     r1 = ELM_MAT8BIT(mat, 1);
 
     l = LEN_MAT8BIT(mat);
@@ -5562,7 +5556,7 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     nrb = (w + elts - 1) / elts;
 
-    /* create new matrix */
+    // create new matrix 
     for (i = 1; i <= w; i++) {
         row = NewWordSizedBag(T_DATOBJ, SIZE_VEC8BIT(l, elts));
         SET_LEN_VEC8BIT(row, l);
@@ -5578,30 +5572,30 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
         settab = SETELT_FIELDINFO_8BIT(info);
     }
 
-    /* set entries */
-    /* run over elts row chunks of the original matrix */
+    // set entries 
+    // run over elts row chunks of the original matrix 
     for (i = 1; i <= l; i += elts) {
         imod = (i - 1) / elts;
 
-        /* run through these rows in chunks, extract the bytes corresponding to an
-         elts x elts submatrix into vals */
+        // run through these rows in chunks, extract the bytes corresponding to an
+        // elts x elts submatrix into vals
         for (n = 0; n < nrb; n++) {
             for (j = 0; j < elts; j++) {
                 if ((i + j) > l) {
 
-                    vals[j] = 0; /* outside matrix */
+                    vals[j] = 0; // outside matrix 
 
                 } else {
                     vals[j] = CONST_BYTES_VEC8BIT(ELM_MAT8BIT(mat, i + j))[n];
                 }
             }
 
-            /* write transposed values in new matrix */
+            // write transposed values in new matrix 
             nstart = n * elts + 1;
-            for (j = 0; j < elts; j++) { /* bit number = Row in transpose */
+            for (j = 0; j < elts; j++) { // bit number = Row in transpose 
                 if ((nstart + j) <= w) {
 
-                    /* still within matrix */
+                    // still within matrix 
                     if (elts > 1) {
                         val = 0;
                         for (k = 0; k < elts; k++) {
@@ -5610,7 +5604,7 @@ Obj FuncTRANSPOSED_MAT8BIT( Obj self, Obj mat)
                     } else
                         val = vals[0];
 
-                    /* set entry */
+                    // set entry 
                     ptr = BYTES_VEC8BIT(ELM_MAT8BIT(tra, nstart + j)) + imod;
                     *ptr = val;
                 }
@@ -5649,34 +5643,34 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     zero = FELT_FFE_FIELDINFO_8BIT(info)[0];
 
-    /* create a matrix */
+    // create a matrix 
     mat = NewWordSizedBag(T_POSOBJ, sizeof(Obj) * (nrowl*nrowr + 2));
     SET_LEN_MAT8BIT(mat, nrowl*nrowr);
     SET_TYPE_POSOBJ(mat, TypeMat8Bit(q, mutable));
     type = TypeVec8BitLocked(q, mutable);
 
-    /* allocate 0 matrix */
+    // allocate 0 matrix 
     for (i = 1; i <= nrowl*nrowr; i++) {
         row = ZeroVec8Bit(q, ncoll * ncolr, mutable);
-        SetTypeDatObj(row, type); /* locked type */
+        SetTypeDatObj(row, type); // locked type 
         SET_ELM_MAT8BIT(mat, i, row);
         CHANGED_BAG(mat);
     }
 
-    /* allocate data for shifts of rows of matr */
+    // allocate data for shifts of rows of matr 
     for (i = 0; i < elts; i++) {
         shift[i] = NewWordSizedBag(T_DATOBJ, ncolr / elts + 200 + sizeof(Obj));
     }
 
-    /* allocation is done. speed up operations by getting lookup tables */
+    // allocation is done. speed up operations by getting lookup tables 
     getelt = GETELT_FIELDINFO_8BIT(info);
     setelt = SETELT_FIELDINFO_8BIT(info);
     scalar = SCALAR_FIELDINFO_8BIT(info);
     add = ADD_FIELDINFO_8BIT(info);
 
-    /* fill in matrix */
+    // fill in matrix 
     for (j = 1; j <= nrowr; j++) {
-        /* create shifts of rows of matr */
+        // create shifts of rows of matr 
         for (i = 0; i < elts; i++) {
             data = (UInt1 *) ADDR_OBJ(shift[i]);
             datar = CONST_BYTES_VEC8BIT(ELM_MAT8BIT(matr, j));
@@ -5690,7 +5684,7 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( Obj self, Obj matl, Obj matr)
                 s = getelt[CONST_BYTES_VEC8BIT(ELM_MAT8BIT(matl, i))[k / elts] + 256 * (k % elts)];
                 l = 0;
                 if (s != zero) {
-                    /* append s*shift[ncol%elts] to data */
+                    // append s*shift[ncol%elts] to data 
                     datar = (const UInt1 *) CONST_ADDR_OBJ(shift[ncol % elts]);
                     if (ncol % elts) {
                         if (p == 2)
@@ -5887,7 +5881,7 @@ static Int PreSave( StructInitInfo * module )
     for (q = 3; q <= 256; q++)
         SET_ELM_PLIST(FieldInfo8Bit, q, (Obj) 0);
 
-    /* return success */
+    // return success 
     return 0;
 }
 
@@ -5903,7 +5897,7 @@ static Int InitKernel (
     RNcoeffs = 0;
     RNrelns = 0;
 
-    /* import type functions                                               */
+    // import type functions                                               
     ImportFuncFromLibrary("TYPE_VEC8BIT",        &TYPE_VEC8BIT);
     ImportFuncFromLibrary("TYPE_VEC8BIT_LOCKED", &TYPE_VEC8BIT_LOCKED);
     ImportGVarFromLibrary("TYPES_VEC8BIT",       &TYPES_VEC8BIT);
@@ -5912,7 +5906,7 @@ static Int InitKernel (
     ImportFuncFromLibrary("Is8BitVectorRep",     &IsVec8bitRep);
     ImportGVarFromLibrary("TYPE_FIELDINFO_8BIT", &TYPE_FIELDINFO_8BIT);
 
-    /* init filters and functions                                          */
+    // init filters and functions                                          
     InitHdlrFuncsFromTable(GVarFuncs);
 
     InitGlobalBag(&FieldInfo8Bit, "src/vec8bit.c:FieldInfo8Bit");
@@ -5922,7 +5916,7 @@ static Int InitKernel (
     InitFopyGVar("IsLockedRepresentationVector", &IsLockedRepresentationVector);
     InitFopyGVar("AsInternalFFE", &AsInternalFFE);
 
-    /* return success                                                      */
+    // return success                                                      
     return 0;
 }
 
@@ -5940,11 +5934,11 @@ static Int InitLibrary (
 #ifdef HPCGAP
     MakeBagPublic(FieldInfo8Bit);
 #endif
-    /* init filters and functions                                          */
+    // init filters and functions                                          
     InitGVarFuncsFromTable(GVarFuncs);
 
 
-    /* return success                                                      */
+    // return success                                                      
     return 0;
 }
 

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -54,7 +54,7 @@
 
 /****************************************************************************
 **
-*F  IS_VEC8BIT_REP( <obj> )  . . . . . . check that <obj> is in 8bit GFQ vector rep
+*F  IS_VEC8BIT_REP( <obj> ) . . .  check that <obj> is in 8bit GFQ vector rep
 **
 ** #define IS_VEC8BIT_REP(obj) \
 **  (TNUM_OBJ(obj)==T_DATOBJ && True == DoFilter(IsVec8bitRep,obj))
@@ -1030,7 +1030,7 @@ void PlainVec8Bit (
 
 /****************************************************************************
 **
-*F  FuncPLAIN_VEC8BIT( <self>, <list> ) . . .  convert back into ordinary list
+*F  FuncPLAIN_VEC8BIT( <self>, <list> ) . . . .  convert back into plain list
 */
 Obj FuncPLAIN_VEC8BIT (
     Obj                 self,
@@ -1536,8 +1536,8 @@ Obj FuncAINV_VEC8BIT_IMMUTABLE( Obj self, Obj vec )
 **
 *F  AddVec8BitVec8BitMultInner( <sum>, <vl>, <vr>, <mult> <start>, <stop> )
 **
-**  This is the real vector add multiple routine. Others are all calls to this
-**  one. It adds <mult>*<vr> to <vl> leaving the result in <sum>
+**  This is the real vector add multiple routine. Others are all calls to
+**  this one. It adds <mult>*<vr> to <vl> leaving the result in <sum>
 ** 
 **  Addition is done from THE BLOCK containing <start> to the one
 **  containing <stop> INCLUSIVE. The remainder of <sum> is unchanged.
@@ -2484,7 +2484,8 @@ Obj FuncNUMBER_VEC8BIT (Obj self, Obj vec)
 
 /****************************************************************************
 **
-*F FuncCOSET_LEADERS_INNER_8BITS( <self>, <veclis>, <weight>, <tofind>, <leaders> )
+*F  FuncCOSET_LEADERS_INNER_8BITS( <self>, <veclis>, <weight>, <tofind>,
+**                                                                <leaders> )
 **
 ** Search for new coset leaders of weight <weight>
 */
@@ -2702,11 +2703,11 @@ Obj FuncQ_VEC8BIT (
 
 /****************************************************************************
 **
-*F  FuncELM0_VEC8BIT( <self>, <list>, <pos> )  . select an elm of an 8bit vector
+*F  FuncELM0_VEC8BIT( <self>, <list>, <pos> ) . select elm of an 8bit vector
 **
-**  'ELM0_VEC8BIT'  returns the element at the  position  <pos> of the boolean
-**  list <list>, or `Fail' if <list> has no assigned  object at <pos>.  It is
-**  the  responsibility of  the caller to   ensure  that <pos> is  a positive
+**  'ELM0_VEC8BIT' returns the element at the position <pos> of the 8bit
+**  vector <list>, or `Fail' if <list> has no assigned  object at <pos>. It
+**  is the responsibility of the caller to ensure that <pos> is a positive
 **  integer.
 */
 
@@ -2735,10 +2736,10 @@ Obj FuncELM0_VEC8BIT (
 
 /****************************************************************************
 **
-*F  FuncELM_VEC8BIT( <self>, <list>, <pos> ) . . select an elm of an 8bit vector
+*F  FuncELM_VEC8BIT( <self>, <list>, <pos> ) . . select elm of an 8bit vector
 **
-**  'ELM_VEC8BIT' returns the element at the position <pos>  of the 8bit vector
-**  <list>.   An  error  is signalled  if  <pos>  is  not bound.    It is the
+**  'ELM_VEC8BIT' returns the element at the position <pos> of the 8bit
+**  vector <list>. An error is signalled if <pos> is not bound. It is the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
 Obj FuncELM_VEC8BIT (
@@ -2770,7 +2771,7 @@ Obj FuncELM_VEC8BIT (
 
 /****************************************************************************
 **
-*F  FuncELMS_VEC8BIT( <self>, <list>, <poss> ) . select elms of an 8 bit vector
+*F  FuncELMS_VEC8BIT( <self>, <list>, <poss> ) . select elms of 8 bit vector
 **
 **  The results are returned in the compressed format
 */
@@ -2930,10 +2931,10 @@ Obj FuncELMS_VEC8BIT_RANGE (
 
 /****************************************************************************
 **
-*F  FuncASS_VEC8BIT( <self>, <list>, <pos>, <elm> ) set an elm of an 8bit vector
+*F  FuncASS_VEC8BIT( <self>, <list>, <pos>, <elm> ) ass. elm of 8bit vector
 **
-**  'ASS_VEC8BIT' assigns the element  <elm> at the position  <pos> to the 8bit
-**  vector <list>.
+**  'ASS_VEC8BIT' assigns the element  <elm> at the position  <pos> to the
+**  8bit vector <list>.
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive,
 **  and that <elm> is not 0.
@@ -3054,9 +3055,9 @@ Obj FuncASS_VEC8BIT (
 
 /****************************************************************************
 **
-*F  FuncUNB_VEC8BIT( <self>, <list>, <pos> ) . unbind position of a GFQ vector
+*F  FuncUNB_VEC8BIT( <self>, <list>, <pos> )  unbind position of a GFQ vector
 **
-**  'UNB_VEC8BIT' unbind  the element at  the position  <pos> in  a GFQ vector
+**  'UNB_VEC8BIT' unbind  the element at the position <pos> in  a GFQ vector
 **  <list>.
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
@@ -5029,10 +5030,11 @@ Obj FuncQUOTREM_COEFFS_VEC8BIT( Obj self, Obj vl, Obj ll, Obj vrshifted)
 *F  Obj SemiechelonListVec8Bits( <mat>, <transformationneeded> )
 **
 **
-** This is essentially a method for SemiEchelonMat or SemiEchelonMatTransformation
+**  This is essentially a method for SemiEchelonMat or
+**  SemiEchelonMatTransformation.
 **
-** <mat> is assumed by this point to be a list of mutable 8 bit vectors over
-** the same field, which can be overwritten if necessary
+**  <mat> is assumed by this point to be a list of mutable 8 bit vectors over
+**  the same field, which can be overwritten if necessary
 */
 
 static UInt RNheads, RNvectors, RNcoeffs, RNrelns;
@@ -5175,8 +5177,9 @@ Obj SemiEchelonListVec8Bits( Obj mat, UInt TransformationsNeeded )
 
 /****************************************************************************
 **
-*F  UInt TriangulizeListVec8Bits( <mat>, <clearup>, <deterp> ) -- returns the rank
+*F  UInt TriangulizeListVec8Bits( <mat>, <clearup>, <deterp> )
 **
+**  returns the rank
 */
 
 UInt TriangulizeListVec8Bits( Obj mat, UInt clearup, Obj *deterp)
@@ -5306,7 +5309,8 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS( Obj self, Obj mat )
 **
 **  Method for SemiEchelonMatTransformations for plain lists of 8 bit vectors
 **
-** Method selection can guarantee us a plain list of vectors in same characteristic
+**  Method selection can guarantee us a plain list of vectors in same
+**  characteristic
 */
 
 Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS( Obj self, Obj mat )
@@ -5344,7 +5348,8 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS( Obj self, Obj mat )
 **
 **  Method for TriangulizeMat for plain lists of 8 bit vectors
 **
-** Method selection can guarantee us a plain list of vectors in same characteristic
+**  Method selection can guarantee us a plain list of vectors in same
+**  characteristic
 */
 
 Obj FuncTRIANGULIZE_LIST_VEC8BITS( Obj self, Obj mat )
@@ -5380,7 +5385,8 @@ Obj FuncTRIANGULIZE_LIST_VEC8BITS( Obj self, Obj mat )
 **
 **  Method for RankMatDestructive for plain lists of 8 bit vectors
 **
-** Method selection can guarantee us a plain list of vectors in same characteristic
+**  Method selection can guarantee us a plain list of vectors in same
+**  characteristic
 */
 
 Obj FuncRANK_LIST_VEC8BITS( Obj self, Obj mat )
@@ -5415,7 +5421,8 @@ Obj FuncRANK_LIST_VEC8BITS( Obj self, Obj mat )
 **
 **  Method for DeterminantMatDestructive for plain lists of 8 bit vectors
 **
-** Method selection can guarantee us a plain list of vectors in same characteristic
+**  Method selection can guarantee us a plain list of vectors in same
+**  characteristic
 */
 
 Obj FuncDETERMINANT_LIST_VEC8BITS( Obj self, Obj mat )
@@ -5780,9 +5787,8 @@ Obj FuncSET_MAT_ELM_MAT8BIT( Obj self, Obj mat, Obj row, Obj col, Obj elm )
 
 /****************************************************************************
 **
-*f * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * * */
-
-
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
 
 
 /****************************************************************************

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2941,8 +2941,7 @@ Obj FuncELMS_VEC8BIT_RANGE (
 
 static Obj AsInternalFFE;
 
-Obj FuncASS_VEC8BIT (
-		     Obj                 self,
+void ASS_VEC8BIT (
 		     Obj                 list,
 		     Obj                 pos,
 		     Obj                 elm )
@@ -2963,7 +2962,7 @@ Obj FuncASS_VEC8BIT (
             "List Assignment: <list> must be a mutable list",
             0L, 0L,
             "you can 'return;' and ignore the assignment");
-        return 0;
+        return;
     }
 
     /* get the position                                                    */
@@ -2981,7 +2980,7 @@ Obj FuncASS_VEC8BIT (
             if (True == DoFilter(IsLockedRepresentationVector, list)) {
                 ErrorReturnVoid("List assignment would increase length of locked compressed vector", 0, 0,
                                 "You can `return;' to ignore the assignment");
-                return 0;
+                return;
             }
             ResizeWordSizedBag(list, SIZE_VEC8BIT(p, elts));
             SET_LEN_VEC8BIT(list, p);
@@ -3009,7 +3008,7 @@ Obj FuncASS_VEC8BIT (
                 } else {
                     PlainVec8Bit(list);
                     AssPlistFfe(list, p, elm);
-                    return 0;
+                    return;
                 }
             }
 
@@ -3028,7 +3027,7 @@ Obj FuncASS_VEC8BIT (
                 SETELT_FIELDINFO_8BIT(info)
                 [256 * (elts * FELT_FFE_FIELDINFO_8BIT(info)[v] + (p - 1) % elts) +
                  BYTES_VEC8BIT(list)[(p - 1) / elts]];
-            return 0;
+            return;
         }
     }
 
@@ -3040,9 +3039,17 @@ Obj FuncASS_VEC8BIT (
 
     PlainVec8Bit(list);
     AssPlistFfe(list, p, elm);
-    return 0;
 }
 
+Obj FuncASS_VEC8BIT (
+		     Obj                 self,
+		     Obj                 list,
+		     Obj                 pos,
+		     Obj                 elm )
+{
+    ASS_VEC8BIT(list, pos, elm);
+    return 0;
+}
 
 
 /****************************************************************************
@@ -5766,7 +5773,8 @@ Obj FuncSET_MAT_ELM_MAT8BIT( Obj self, Obj mat, Obj row, Obj col, Obj elm )
 
     // TODO: replace the following call by direct access? E.g. so that we can
     // always reject input elements in the "wrong domain"?
-    return FuncASS_VEC8BIT( self, vec, col, elm );
+    ASS_VEC8BIT(vec, col, elm);
+    return 0;
 }
 
 

--- a/src/vec8bit.h
+++ b/src/vec8bit.h
@@ -30,7 +30,7 @@ extern Obj CopyVec8Bit( Obj list, UInt mut );
 
 /****************************************************************************
 **
-*F  IS_VEC8BIT_REP( <obj> )  . . . . . . check that <obj> is in 8bit GFQ vector rep
+*F  IS_VEC8BIT_REP( <obj> ) . . .  check that <obj> is in 8bit GFQ vector rep
 */
 extern Obj IsVec8bitRep;
 
@@ -49,11 +49,10 @@ extern void PlainVec8Bit ( Obj                 list );
 
 /****************************************************************************
 **
-*F  FuncASS_VEC8BIT( <self>, <list>, <pos>, <elm> ) set an elm of an 8bit vector
+*F  ASS_VEC8BIT( <list>, <pos>, <elm> ) . . . .  set an elm of an 8bit vector
 **
 */
-extern Obj FuncASS_VEC8BIT (
-    Obj                 self,
+extern void ASS_VEC8BIT (
     Obj                 list,
     Obj                 pos,
     Obj                 elm );

--- a/src/vec8bit.h
+++ b/src/vec8bit.h
@@ -81,7 +81,7 @@ extern Obj GetFieldInfo8Bit(UInt q);
 **  'LEN_VEC8BIT' returns the logical length of the 8bit GFQ vector <list>,
 **  as a C integer.
 **
-**  Note that 'LEN_VEC8BIT' is a macro, so do not call it with  arguments that
+**  Note that 'LEN_VEC8BIT' is a macro, so do not call it with arguments that
 **  have side effects.
 */
 #define LEN_VEC8BIT(list) ((Int)(CONST_ADDR_OBJ(list)[1]))
@@ -141,11 +141,11 @@ extern Obj GetFieldInfo8Bit(UInt q);
 *F  SET_XXX_FIELDINFO_8BIT( <obj>, <xxx> ) . . .setters needed by ANSI
 **                                         needed for scalar but not pointers
 **
-**  For machines with alignment restrictions. it's important to put all
-**  the word-sized data BEFORE all the byte-sized data (especially FFE_FELT...
-**  which may have odd length
+**  For machines with alignment restrictions. It is important to put all
+**  the word-sized data BEFORE all the byte-sized data; especially
+**  FFE_FELT_FIELDINFO_8BIT which may have odd length
 **
-**  Note ADD has to be last, because it is not there in characteristic 2
+**  Note ADD_* has to be last, because it is not there in characteristic 2
 */
 
 #define Q_FIELDINFO_8BIT(info) ((UInt)(CONST_ADDR_OBJ(info)[1]))
@@ -189,7 +189,7 @@ extern Obj GetFieldInfo8Bit(UInt q);
 
 /****************************************************************************
 **
-*F  InitInfoVec8bit()  . . . . . . . . . . . . . . . . table of init functions
+*F  InitInfoVec8bit() . . . . . . . . . . . . . . . . table of init functions
 */
 extern StructInitInfo * InitInfoVec8bit ( void );
 

--- a/src/vec8bit.h
+++ b/src/vec8bit.h
@@ -18,7 +18,7 @@
 **
 */
 
-extern void RewriteGF2Vec( Obj vec, UInt q);
+extern void RewriteGF2Vec(Obj vec, UInt q);
 
 /****************************************************************************
 **
@@ -26,7 +26,7 @@ extern void RewriteGF2Vec( Obj vec, UInt q);
 **
 */
 
-extern Obj CopyVec8Bit( Obj list, UInt mut );
+extern Obj CopyVec8Bit(Obj list, UInt mut);
 
 /****************************************************************************
 **
@@ -34,9 +34,8 @@ extern Obj CopyVec8Bit( Obj list, UInt mut );
 */
 extern Obj IsVec8bitRep;
 
-#define IS_VEC8BIT_REP(obj) \
-  (TNUM_OBJ(obj)==T_DATOBJ && True == DoFilter(IsVec8bitRep,obj))
-
+#define IS_VEC8BIT_REP(obj)                                                  \
+    (TNUM_OBJ(obj) == T_DATOBJ && True == DoFilter(IsVec8bitRep, obj))
 
 
 /****************************************************************************
@@ -45,17 +44,14 @@ extern Obj IsVec8bitRep;
 **
 **  'PlainVec8Bit' converts the  vector <list> to a plain list.
 */
-extern void PlainVec8Bit ( Obj                 list );
+extern void PlainVec8Bit(Obj list);
 
 /****************************************************************************
 **
 *F  ASS_VEC8BIT( <list>, <pos>, <elm> ) . . . .  set an elm of an 8bit vector
 **
 */
-extern void ASS_VEC8BIT (
-    Obj                 list,
-    Obj                 pos,
-    Obj                 elm );
+extern void ASS_VEC8BIT(Obj list, Obj pos, Obj elm);
 
 
 /****************************************************************************
@@ -191,7 +187,7 @@ extern Obj GetFieldInfo8Bit(UInt q);
 **
 *F  InitInfoVec8bit() . . . . . . . . . . . . . . . . table of init functions
 */
-extern StructInitInfo * InitInfoVec8bit ( void );
+extern StructInitInfo * InitInfoVec8bit(void);
 
 
-#endif // GAP_VEC8BIT_H
+#endif    // GAP_VEC8BIT_H

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -152,16 +152,16 @@ Obj AddCoeffsGF2VecGF2Vec (
     const UInt *        ptV;
     UInt                len;
 
-    /* get the length                                                      */
+    // get the length                                                      
     len = LEN_GF2VEC(vec);
     
-    /* grow <sum> is necessary                                             */
+    // grow <sum> is necessary                                             
     if ( LEN_GF2VEC(sum) < len ) {
         ResizeWordSizedBag( sum, SIZE_PLEN_GF2VEC(len) );
         SET_LEN_GF2VEC( sum, len );
     }
 
-    /* add <vec> to <sum>                                                  */
+    // add <vec> to <sum>                                                  
     ptS = BLOCKS_GF2VEC(sum);
     ptV = CONST_BLOCKS_GF2VEC(vec);
     AddGF2VecToGF2Vec(ptS, ptV, len);
@@ -177,7 +177,7 @@ CopySection_GF2Vecs(Obj src, Obj dest, UInt smin, UInt dmin, UInt nelts)
     const UInt * sptr;
     UInt * dptr;
 
-    /* switch to zero-based indices and find the first blocks and so on */
+    // switch to zero-based indices and find the first blocks and so on 
     soff = (smin - 1) % BIPEB;
     doff = (dmin - 1) % BIPEB;
     sptr = CONST_BLOCKS_GF2VEC(src) + (smin - 1) / BIPEB;
@@ -212,16 +212,16 @@ Obj AddPartialGF2VecGF2Vec (
     Obj                 vr,
     UInt                n )
 {
-    const UInt *        ptL;            /* bit field of <vl>               */
-    const UInt *        ptR;            /* bit field of <vr>               */
-    UInt *              ptS;            /* bit field of <sum>              */
-    UInt *              end;            /* end marker                      */
-    UInt                len;            /* length of the list              */
-    UInt                offset;         /* number of block to start adding */
+    const UInt *        ptL;            // bit field of <vl>               
+    const UInt *        ptR;            // bit field of <vr>               
+    UInt *              ptS;            // bit field of <sum>              
+    UInt *              end;            // end marker                      
+    UInt                len;            // length of the list              
+    UInt                offset;         // number of block to start adding 
     UInt                x;
     
 
-    /* both operands lie in the same field                                 */
+    // both operands lie in the same field                                 
     len = LEN_GF2VEC(vl);
     if ( len != LEN_GF2VEC(vr) ) {
         ErrorMayQuit( "Vector +: vectors must have the same length",
@@ -230,7 +230,7 @@ Obj AddPartialGF2VecGF2Vec (
     }
 
 
-    /* calculate the offset for adding                                     */
+    // calculate the offset for adding                                     
     if ( n == 1 ) {  
         ptL = CONST_BLOCKS_GF2VEC(vl);
         ptR = CONST_BLOCKS_GF2VEC(vr);
@@ -244,11 +244,11 @@ Obj AddPartialGF2VecGF2Vec (
         end = ptS + ((len+BIPEB-1)/BIPEB) - offset;
     }
     
-    /* loop over the entries and add                                       */
+    // loop over the entries and add                                       
     if (vl == sum)
       while ( ptS < end )
 	{
-	  /* maybe remove this condition */
+	  // maybe remove this condition 
 	  if ((x = *ptR)!= 0)
 	    *ptS = *ptL ^ x;
 	  ptL++; ptS++; ptR++;
@@ -256,7 +256,7 @@ Obj AddPartialGF2VecGF2Vec (
     else if (vr == sum)
       while ( ptS < end )
 	{
-	  /* maybe remove this condition */
+	  // maybe remove this condition 
 	  if ((x = *ptL) != 0)
 	    *ptS = *ptR ^ x;
 	  ptL++; ptS++; ptR++;
@@ -265,7 +265,7 @@ Obj AddPartialGF2VecGF2Vec (
       while (ptS < end )
 	*ptS++ = *ptL++ ^ *ptR++;
 
-    /* return the result                                                   */
+    // return the result                                                   
     return sum;
 }
 
@@ -307,18 +307,18 @@ Obj AddPartialGF2VecGF2Vec (
 
 Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
 {
-    const UInt *        ptL;            /* bit field of <vl>               */
-    const UInt *        ptR;            /* bit field of <vr>               */
-    UInt                lenL;           /* length of the list              */
-    UInt                lenR;           /* length of the list              */
-    UInt                len;            /* minimum of the lengths          */
-    UInt                nrb;            /* number of whole blocks to use   */
-    UInt                m;              /* number of bits in a block       */
-    UInt                n;              /* number of bits in blist         */
-    UInt                i;              /* loop variable                   */
-    UInt                mask;           /* bit selecting mask              */
+    const UInt *        ptL;            // bit field of <vl>               
+    const UInt *        ptR;            // bit field of <vr>               
+    UInt                lenL;           // length of the list              
+    UInt                lenR;           // length of the list              
+    UInt                len;            // minimum of the lengths          
+    UInt                nrb;            // number of whole blocks to use   
+    UInt                m;              // number of bits in a block       
+    UInt                n;              // number of bits in blist         
+    UInt                i;              // loop variable                   
+    UInt                mask;           // bit selecting mask              
 
-    /* both operands lie in the same field                                 */
+    // both operands lie in the same field                                 
     lenL = LEN_GF2VEC(vl);
     lenR = LEN_GF2VEC(vr);
     len = (lenL < lenR) ? lenL : lenR;
@@ -330,7 +330,7 @@ Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
       return 0;
     }
 
-    /* loop over the entries and multiply                                  */
+    // loop over the entries and multiply                                  
     ptL = CONST_BLOCKS_GF2VEC(vl);
     ptR = CONST_BLOCKS_GF2VEC(vr);
     nrb = len /BIPEB;
@@ -340,7 +340,7 @@ Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
         PARITY_BLOCK(m);
         n ^= m;
     }
-    /* now process the remaining bits */
+    // now process the remaining bits 
 
     mask = 1;
     for (i = 0; i < len % BIPEB; i++)
@@ -349,7 +349,7 @@ Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
 	mask <<= 1;
       }
 
-    /* return the result                                                   */
+    // return the result                                                   
     return (n & 1) ? GF2One : GF2Zero;
 }
 
@@ -365,47 +365,47 @@ Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
 */
 Obj ProdGF2VecGF2Mat ( Obj vl, Obj vr )
 {
-    UInt                len;            /* length of the list              */
+    UInt                len;            // length of the list              
     UInt                stop;
-    UInt                col;            /* length of the rows              */
-    UInt                i;              /* loop variables                  */
-    Obj                 prod;           /* product, result                 */
-    Obj                 row1;           /* top row of matrix               */
+    UInt                col;            // length of the rows              
+    UInt                i;              // loop variables                  
+    Obj                 prod;           // product, result                 
+    Obj                 row1;           // top row of matrix               
     UInt *              start;
     const UInt *        ptL;
     UInt                mask;
     
-    /* both operands lie in the same field                                 */
+    // both operands lie in the same field                                 
     len = LEN_GF2VEC(vl);
     if (len > LEN_GF2MAT(vr))
       len = LEN_GF2MAT(vr);
     
-    /* make the result vector                                              */
+    // make the result vector                                              
     row1 = ELM_GF2MAT( vr, 1 );
     col = LEN_GF2VEC( row1 );
     NEW_GF2VEC( prod, (IS_MUTABLE_OBJ(vl) || IS_MUTABLE_OBJ(row1)) ? 
 		TYPE_LIST_GF2VEC : TYPE_LIST_GF2VEC_IMM, col );
     
-    /* get the start and end block                                         */
+    // get the start and end block                                         
     start = BLOCKS_GF2VEC(prod);
     ptL   = CONST_BLOCKS_GF2VEC(vl);
 
-    /* loop over the vector                                                */
+    // loop over the vector                                                
     for ( i = 1;  i <= len;  ptL++ )  {
 
-        /* if the whole block is zero, get the next entry                  */
+        // if the whole block is zero, get the next entry                  
         if (*ptL == 0) {
             i += BIPEB;
             continue;
         }
         
-        /* run through the block                                           */
+        // run through the block                                           
         stop = i + BIPEB - 1;
         if ( len < stop )
             stop = len;
         for ( mask = 1;  i <= stop;  i++, mask <<= 1 ) {
 
-            /* if there is entry add the row to the result                 */
+            // if there is entry add the row to the result                 
             if ( (*ptL & mask) != 0 ) {
                 const UInt * ptRR = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(vr,i));
 		AddGF2VecToGF2Vec(start, ptRR, col);
@@ -413,7 +413,7 @@ Obj ProdGF2VecGF2Mat ( Obj vl, Obj vr )
         }
     }
 
-    /* return the result                                                   */
+    // return the result                                                   
     return prod;
 }
 
@@ -430,20 +430,20 @@ Obj ProdGF2VecGF2Mat ( Obj vl, Obj vr )
 */
 Obj ProdGF2MatGF2Vec ( Obj ml, Obj vr )
 {
-    UInt                len;            /* length of the vector            */
-    UInt                ln1;            /* length of the rows of the mx    */
-    UInt                ln2;            /* length of the matrix            */
-    const UInt *        ptL;            /* bit field of <ml>[j]            */
-    const UInt *        ptR;            /* bit field of <vr>               */
-    UInt                nrb;            /* number of blocks in blist       */
-    UInt                m;              /* number of bits in a block       */
-    UInt                n;              /* number of bits in blist         */
-    UInt                i;              /* loop variable                   */
-    UInt                j;              /* loop variable                   */
-    Obj                 prod;           /* result                          */
-    UInt                mask;           /* a one bit mask */
+    UInt                len;            // length of the vector            
+    UInt                ln1;            // length of the rows of the mx    
+    UInt                ln2;            // length of the matrix            
+    const UInt *        ptL;            // bit field of <ml>[j]            
+    const UInt *        ptR;            // bit field of <vr>               
+    UInt                nrb;            // number of blocks in blist       
+    UInt                m;              // number of bits in a block       
+    UInt                n;              // number of bits in blist         
+    UInt                i;              // loop variable                   
+    UInt                j;              // loop variable                   
+    Obj                 prod;           // result                          
+    UInt                mask;           // a one bit mask 
     
-    /* both operands lie in the same field                                 */
+    // both operands lie in the same field                                 
     len = LEN_GF2VEC(vr);
     ln2 = LEN_GF2MAT(ml);
     if ( 0 == ln2 ) {
@@ -455,11 +455,11 @@ Obj ProdGF2MatGF2Vec ( Obj ml, Obj vr )
       len = ln1;
     }
 
-    /* make the result vector                                              */
+    // make the result vector                                              
     NEW_GF2VEC( prod, (IS_MUTABLE_OBJ(ELM_GF2MAT(ml,1)) || IS_MUTABLE_OBJ(vr)) ? 
 		TYPE_LIST_GF2VEC :TYPE_LIST_GF2VEC_IMM, ln2 );
 
-    /* loop over the entries and multiply                                  */
+    // loop over the entries and multiply                                  
     nrb = len/BIPEB;
     for ( j = 1;  j <= ln2;  j++ ) {
         ptL = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml,j));
@@ -483,7 +483,7 @@ Obj ProdGF2MatGF2Vec ( Obj ml, Obj vr )
             BLOCK_ELM_GF2VEC(prod,j) |= MASK_POS_GF2VEC(j);
     }
 
-    /* return the result                                                   */
+    // return the result                                                   
     return prod;
 }
 
@@ -528,8 +528,8 @@ Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
     {
       row = ProdGF2VecGF2Mat(ELM_GF2MAT(ml,i),mr);
 
-      /* Since I'm going to put this vector into a matrix, I must lock its
-	 representation, so that it doesn't get rewritten over GF(2^k) */
+      // Since I'm going to put this vector into a matrix, I must lock its
+	  // representation, so that it doesn't get rewritten over GF(2^k)
       SetTypeDatObj(row, rtype);
       SET_ELM_GF2MAT(prod,i,row);
       CHANGED_BAG(prod);
@@ -539,12 +539,12 @@ Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
 }
 
 
-/* Utility functions for the advanced matrix multiply code below */
+// Utility functions for the advanced matrix multiply code below 
 
 
-/* extract nbits bits starting from position from in vector vptr
-   return them as the nbits least significant bits in a UInt.
-   Bits are always numbered least-significant first */
+// extract nbits bits starting from position from in vector vptr
+// return them as the nbits least significant bits in a UInt.
+// Bits are always numbered least-significant first
 
 static inline UInt getbits(const UInt * vptr, UInt from, UInt nbits)
 {
@@ -555,13 +555,13 @@ static inline UInt getbits(const UInt * vptr, UInt from, UInt nbits)
   UInt word2;
   if (lbit <= BIPEB)
     {
-      /* range is all in one word */
+      // range is all in one word 
       word1 <<= BIPEB -lbit;
       word1 >>= BIPEB - nbits;
     }
   else
     {
-      /* range is split across two words */
+      // range is split across two words 
       word1 >>= shift1;
       lbit -= BIPEB;
       word2 = vptr[wno+1];
@@ -572,8 +572,8 @@ static inline UInt getbits(const UInt * vptr, UInt from, UInt nbits)
   return word1;
 }
 
-/* To avoid having a lot of arguments to the recursive getgreasedata function,
-   we put the things that don't change in the recursive call into this structure */
+// To avoid having a lot of arguments to the recursive getgreasedata function,
+// we put the things that don't change in the recursive call into this structure
 
 struct greaseinfo {
   UInt *pgtags;
@@ -585,10 +585,8 @@ struct greaseinfo {
 
 
 
-/* Make if necessary the grease row for bits
-   controlled by the data in g. Recursive
-   so can't be inlined */
-
+// Make if necessary the grease row for bits controlled by the data in g.
+// Recursive so can't be inlined
 static const UInt * getgreasedata( struct greaseinfo *g, UInt bits)
 { 
   UInt x,y;
@@ -600,63 +598,62 @@ static const UInt * getgreasedata( struct greaseinfo *g, UInt bits)
   switch(g->pgtags[bits])
     {
     case 0:
-      /* Need to make the row */
+      // Need to make the row 
       x = g->pgrules[bits];
       y = bits ^ (1 << x);
-      /* make it by adding row x to grease vector indexed y */
+      // make it by adding row x to grease vector indexed y 
       ps =g->prrows[x];
       ps2 = getgreasedata(g,y);
       pd1 = g->pgbuf + (bits-3)*g->nblocks;
       pd = pd1;
-      /* time critical inner loop */
+      // time critical inner loop 
       for (i = g->nblocks; i > 0; i--)
 	*pd++ = *ps++ ^ *ps2++;
-      /* record that we made it */
+      // record that we made it 
       g->pgtags[bits] = 1;
       return pd1;
 
     case 1:
-      /* we've made this one already, so just return it */
+      // we've made this one already, so just return it 
       return  g->pgbuf + (bits-3)*g->nblocks;
 
     case 2:
-      /* This one does not need making, bits actually
-	 has just a single 1 bit in it */
+      // This one does not need making, bits actually
+       // has just a single 1 bit in it
       return g->prrows[g->pgrules[bits]];
 
     }
-  return (UInt *)0;		/* can't actually get here
-				 include the return to pacify compiler */
+  return (UInt *)0;		// can't actually get here; include the return to pacify compiler
 }
 
 
 
 Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
 {
-  Obj prod;			/* Product Matrix */
-  UInt i,j, k, b;		/* Loop counters */
-  UInt gs;			/* Actual level of grease for current block */
-  const UInt *rptr;		/* Pointer to current row of ml */
-  UInt bits;			/* current chunk of current row, for lookup in grease tables */
-  const UInt *v;		/* pointer to computed grease vector */
-  UInt len, rlen, ilen;		/* len = length of ml, ilen = row length of ml = length of mr, rlen = row length of mr */
-  Obj row;			/* current row of ml, or row of prod when it is being built */
-  Obj rtype;			/* type of rows of prod */
-  Obj gbuf = (Obj)0;		/* grease buffer */
-  Obj gtags = (Obj) 0;		/* grease tags (whether that row is known yet */
-  Obj grules = (Obj) 0;		/* rules for making new grease vectors */
-  UInt *pgrules;		/* pointer to contents of grules*/
-  UInt *pgtags = (UInt *)0;	/* pointer to contents of gtags */
-  UInt *pgbuf = (UInt *)0;	/* pointer to grease buffer */
-  UInt nwords;			/* number of words in a row of mr */
-  UInt glen;			/* 1 << greasesize */
-  UInt bs;			/* actual size of current block */
-  UInt *pprow;			/* pointer into current row of prod */
-  Obj lrowptrs;			/* cache of direct pointers to rows of ml */
-  const UInt **plrows;		/* and a direct pointer to that cache */
-  Obj rrowptrs;			/* and for mr */
+  Obj prod;			// Product Matrix 
+  UInt i,j, k, b;		// Loop counters 
+  UInt gs;			// Actual level of grease for current block 
+  const UInt *rptr;		// Pointer to current row of ml 
+  UInt bits;			// current chunk of current row, for lookup in grease tables 
+  const UInt *v;		// pointer to computed grease vector 
+  UInt len, rlen, ilen;		// len = length of ml, ilen = row length of ml = length of mr, rlen = row length of mr 
+  Obj row;			// current row of ml, or row of prod when it is being built 
+  Obj rtype;			// type of rows of prod 
+  Obj gbuf = (Obj)0;		// grease buffer 
+  Obj gtags = (Obj) 0;		// grease tags (whether that row is known yet 
+  Obj grules = (Obj) 0;		// rules for making new grease vectors 
+  UInt *pgrules;		// pointer to contents of grules
+  UInt *pgtags = (UInt *)0;	// pointer to contents of gtags 
+  UInt *pgbuf = (UInt *)0;	// pointer to grease buffer 
+  UInt nwords;			// number of words in a row of mr 
+  UInt glen;			// 1 << greasesize 
+  UInt bs;			// actual size of current block 
+  UInt *pprow;			// pointer into current row of prod 
+  Obj lrowptrs;			// cache of direct pointers to rows of ml 
+  const UInt **plrows;		// and a direct pointer to that cache 
+  Obj rrowptrs;			// and for mr 
   const UInt **prrows;
-  Obj prowptrs;			/* and for prod */
+  Obj prowptrs;			// and for prod 
   UInt **pprows;
   struct greaseinfo g;
   
@@ -666,7 +663,7 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
   ilen = LEN_GF2MAT(mr);
   nwords = NUMBER_BLOCKS_GF2VEC(row);
   
-  /* Make a zero product matrix */
+  // Make a zero product matrix 
   prod = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(len));
   SET_LEN_GF2MAT(prod,len);
   if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr))
@@ -691,17 +688,17 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
       CHANGED_BAG(prod);
     }
 
-  /* Cap greasesize and blocksize by the actual length  */
+  // Cap greasesize and blocksize by the actual length  
   if (ilen < greasesize)
     greasesize = ilen;
   if (ilen < greasesize*blocksize)
     blocksize = (ilen + greasesize-1)/greasesize;
 
 
-  /* calculate glen*/
+  // calculate glen
   glen = 1 << greasesize;
   
-  /* Allocate memory */
+  // Allocate memory 
 
   lrowptrs = NewBag(T_DATOBJ, sizeof(UInt *)*len);
   rrowptrs = NewBag(T_DATOBJ, sizeof(UInt *)*ilen);
@@ -714,14 +711,14 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
       grules = NewBag(T_DATOBJ, sizeof(Int)* glen);
       
       
-      /* From here no garbage collections */
+      // From here no garbage collections 
       
       pgtags = (UInt *)ADDR_OBJ(gtags);
       pgrules = (UInt *)ADDR_OBJ(grules);
       pgbuf = (UInt *)ADDR_OBJ(gbuf);
       
 
-      /* Calculate the greasing rules */
+      // Calculate the greasing rules 
       for (j = 3; j < glen; j++)
 	for (i = 0; i < greasesize; i++)
 	  if ((j & (1 << i)) != 0)
@@ -732,13 +729,13 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
       for (j = 0; j < greasesize; j++)
 	pgrules[1<<j] = j;
 
-      /* fill in some more bits of g */
+      // fill in some more bits of g 
       g.pgrules = pgrules;
       g.nblocks = nwords;
     }
 
-  /* Take direct pointers to all the parts of all the matrices to avoid multiple
-     indirection overheads */
+  // Take direct pointers to all the parts of all the matrices to avoid
+  // multiple indirection overheads
   plrows = (const UInt **)CONST_ADDR_OBJ(lrowptrs);
   prrows = (const UInt **)CONST_ADDR_OBJ(rrowptrs);
   pprows = (UInt **)ADDR_OBJ(prowptrs);
@@ -752,48 +749,48 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
     prrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mr, i+1));
 
 
-  /* OK, finally ready to start work */
-  /* loop over blocks */
+  // OK, finally ready to start work 
+  // loop over blocks 
   for (b = 1; b <= ilen; b += blocksize*greasesize)
     {
-      /* last block may be a small one */
+      // last block may be a small one 
       bs = blocksize;
       if ((b + bs*greasesize) > ilen)
 	bs = (ilen - b + greasesize)/greasesize;
 
-      /* If we're greasing, start afresh */
+      // If we're greasing, start afresh 
       if (greasesize > 1)
 	{
 	  for (k = 0; k < bs; k++)
 	    {
 	      for (j = 0; j < 1 << greasesize; j++)
 		pgtags[k*glen+j] = 0;
-	      /* powers of 2 correspond to rows of mr */
+	      // powers of 2 correspond to rows of mr 
 	      for (j =0; j < greasesize; j++)
 		pgtags[k*glen+ (1<<j)] = 2;
 	    }
 	}
       
-      /* For each block, we run through rows of ml & prod */
+      // For each block, we run through rows of ml & prod 
       for (j = 1; j <= len; j++)
 	{
-	  /* get pointers */
+	  // get pointers 
 	  rptr = plrows[j-1];
 	  pprow = pprows[j-1];
 
-	  /* Now within the block, we have multiple grease-units, run through them */
+	  // Now within the block, we have multiple grease-units, run through them 
 	  for (i = 0; i < bs; i++)
 	    {
-	      /* start of current grease unit */	     
+	      // start of current grease unit 	     
 	      k = b + i*greasesize;
 
-	      /* last unit of last block may be short */
+	      // last unit of last block may be short 
 	      gs = greasesize;
 	      if (k+gs > ilen)
 		gs = ilen - k +1;
 
-	      /* find the appropriate parts of grease tags
-		 grease buffer and mr. Store in g */
+	      // find the appropriate parts of grease tags
+		 // grease buffer and mr. Store in g
 	      
 	      if (gs > 1)
 		{
@@ -802,29 +799,29 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
 		  g.prrows = prrows + k -1;
 		}
 
-	      /* get a chunk from a row of ml */
+	      // get a chunk from a row of ml 
 	      bits = getbits(rptr, k, gs);
 
-	      /* 0 means nothing to do */
+	      // 0 means nothing to do 
 	      if (bits == 0)
 		continue;
-	      else if (bits == 1) /* handle this one specially to speed up the greaselevel 1 case */
-		v = prrows[k-1]; /* -1 is because k is 1-based index */
+	      else if (bits == 1) // handle this one specially to speed up the greaselevel 1 case 
+		v = prrows[k-1]; // -1 is because k is 1-based index 
 	      else
-		v = getgreasedata(&g,bits); /* The main case */
-				/* This function should be inlined */
+		v = getgreasedata(&g,bits); // The main case 
+				// This function should be inlined 
 	      AddGF2VecToGF2Vec(pprow, v,  rlen);  
 	    }  
 	  }
 	
-      /* Allow GAP to respond to Ctrl-C */
+      // Allow GAP to respond to Ctrl-C 
       if (TakeInterrupt()) {
-	/* Might have been a garbage collection, reload everything */
+	// Might have been a garbage collection, reload everything 
 	if (greasesize >= 2) {
 	  pgtags = (UInt *)ADDR_OBJ(gtags);
 	  pgrules = (UInt *)ADDR_OBJ(grules);
 	  pgbuf = (UInt *)ADDR_OBJ(gbuf);
-	  /* fill in some more bits of g */
+	  // fill in some more bits of g 
 	  g.pgrules = pgrules;
 	  g.nblocks = nwords;
 	}
@@ -862,18 +859,18 @@ Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
   if (len > LEN_PLIST(mat))
     len = LEN_PLIST(mat);
 
-  /* Get the first row, to establish the size of the result */
+  // Get the first row, to establish the size of the result 
   row1 = ELM_PLIST(mat,1);  
   if (! IS_GF2VEC_REP(row1))
     return TRY_NEXT_METHOD;
   len1 = LEN_GF2VEC(row1);
 
-  /* create the result space */
+  // create the result space 
   NEW_GF2VEC( res,
 	      (IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1)) ? TYPE_LIST_GF2VEC : TYPE_LIST_GF2VEC_IMM,
 	      len1);
 
-  /* Finally, we start work */
+  // Finally, we start work 
   for (i = 1; i <= len; i++)
     {
       if (i % BIPEB == 1)
@@ -900,21 +897,21 @@ Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 */
 Obj InversePlistGF2VecsDesstructive( Obj list )
 {
-    UInt                len;            /* dimension                       */
-    Obj                 inv;            /* result                          */
-    Obj                 row;            /* row vector                      */
-    Obj                 old;            /* row from <mat>                  */
-    Obj                 tmp;            /* temporary                       */
-    UInt *              ptQ;            /* data block of <row>             */
-    const UInt *        ptP;            /* data block of source row        */
-    const UInt *        end;            /* end marker                      */
-    const UInt *        end2;           /* end marker                      */
-    UInt                i;              /* loop variable                   */
-    UInt                k;              /* loop variable                   */
+    UInt                len;            // dimension                       
+    Obj                 inv;            // result                          
+    Obj                 row;            // row vector                      
+    Obj                 old;            // row from <mat>                  
+    Obj                 tmp;            // temporary                       
+    UInt *              ptQ;            // data block of <row>             
+    const UInt *        ptP;            // data block of source row        
+    const UInt *        end;            // end marker                      
+    const UInt *        end2;           // end marker                      
+    UInt                i;              // loop variable                   
+    UInt                k;              // loop variable                   
 
     len = LEN_PLIST(list);
     
-    /* create the identity matrix                                          */
+    // create the identity matrix                                          
     tmp = NEW_PLIST( T_PLIST, len );
     for ( i = len;  0 < i;  i-- ) {
       NEW_GF2VEC( row, TYPE_LIST_GF2VEC, len );
@@ -925,10 +922,10 @@ Obj InversePlistGF2VecsDesstructive( Obj list )
     SET_LEN_PLIST(tmp, len);
     inv = tmp;
 
-    /* now start with ( id | mat ) towards ( inv | id )                    */
+    // now start with ( id | mat ) towards ( inv | id )                    
     for ( k = 1;  k <= len;  k++ ) {
 
-        /* find a nonzero entry in column <k>                              */
+        // find a nonzero entry in column <k>                              
         for ( i = k;  i <= len;  i++ ) {
             row = ELM_PLIST( list, i );
             if ( CONST_BLOCK_ELM_GF2VEC(row,k) & MASK_POS_GF2VEC(k) )
@@ -946,7 +943,7 @@ Obj InversePlistGF2VecsDesstructive( Obj list )
             SET_ELM_PLIST( inv, k, row );
         }
         
-        /* clear entries                                                   */
+        // clear entries                                                   
         old = ELM_PLIST( list, k );
         end = CONST_BLOCKS_GF2VEC(old) + ((len+BIPEB-1)/BIPEB);
         for ( i = 1;  i <= len;  i++ ) {
@@ -955,14 +952,14 @@ Obj InversePlistGF2VecsDesstructive( Obj list )
             row = ELM_PLIST( list, i );
             if ( CONST_BLOCK_ELM_GF2VEC(row,k) & MASK_POS_GF2VEC(k) ) {
 
-                /* clear <mat>                                             */
+                // clear <mat>                                             
                 ptQ = &(BLOCK_ELM_GF2VEC(row,k));
                 ptP = &(CONST_BLOCK_ELM_GF2VEC(old,k));
                 while ( ptP < end ) {
                     *ptQ++ ^= *ptP++;
                 }
 
-                /* modify <inv>                                            */
+                // modify <inv>                                            
                 row  = ELM_PLIST( inv, i );
                 ptQ  = BLOCKS_GF2VEC(row);
                 row  = ELM_PLIST( inv, k );
@@ -992,21 +989,21 @@ Obj InverseGF2Mat (
     Obj                 mat,
     UInt                mut)
 {
-    UInt                len;            /* dimension                       */
-    Obj                 inv;            /* result                          */
-    Obj                 row;            /* row vector                      */
-    Obj                 tmp;            /* temporary                       */
-    UInt                i;              /* loop variable                   */
-    Obj                 old;            /* row from <mat>                  */
-    const UInt *        ptQ;            /* data block of <row>             */
-    UInt *              ptP;            /* data block of source row        */
-    UInt *              end;            /* end marker                      */
+    UInt                len;            // dimension                       
+    Obj                 inv;            // result                          
+    Obj                 row;            // row vector                      
+    Obj                 tmp;            // temporary                       
+    UInt                i;              // loop variable                   
+    Obj                 old;            // row from <mat>                  
+    const UInt *        ptQ;            // data block of <row>             
+    UInt *              ptP;            // data block of source row        
+    UInt *              end;            // end marker                      
     Obj                 rtype;
 
-    /* make a structural copy of <mat> as list of GF2 vectors              */
+    // make a structural copy of <mat> as list of GF2 vectors              
     len = LEN_GF2MAT(mat);
 
-    /* special routes for very small matrices */
+    // special routes for very small matrices 
     if ( len == 0 ) {
         return CopyObj(mat,1);
     }
@@ -1037,7 +1034,7 @@ Obj InverseGF2Mat (
     if (inv == Fail)
       return inv;
     
-    /* convert list <inv> into a matrix                                    */
+    // convert list <inv> into a matrix                                    
     ResizeBag( inv, SIZE_PLEN_GF2MAT(len) );
     if (mut == 2 ||
 	(mut == 1 && IS_MUTABLE_OBJ(mat) && IS_MUTABLE_OBJ(ELM_GF2MAT(mat, 1))))
@@ -1130,7 +1127,7 @@ Obj SemiEchelonListGF2Vecs( Obj mat, UInt TransformationsNeeded )
 	  BLOCK_ELM_GF2VEC( coeffrow, i) |= MASK_POS_GF2VEC(i);
 	}
       
-      /* No garbage collection risk from here */
+      // No garbage collection risk from here 
       rowp = BLOCKS_GF2VEC(row);
       if (TransformationsNeeded)
 	coeffrowp = BLOCKS_GF2VEC(coeffrow);
@@ -1156,24 +1153,24 @@ Obj SemiEchelonListGF2Vecs( Obj mat, UInt TransformationsNeeded )
       while ( j <= ncols && !(*rowp & MASK_POS_GF2VEC(j)))
 	j++;
 
-      /* garbage collection OK again after here */
+      // garbage collection OK again after here 
       if (j <= ncols)
 	{
 	  SET_ELM_PLIST(vectors, ++nvecs, row);
-          CHANGED_BAG(vectors);    /* Could be an old bag by now. Max. */
+          CHANGED_BAG(vectors);    // Could be an old bag by now. Max. 
 	  SET_LEN_PLIST(vectors, nvecs);
 	  SET_ELM_PLIST( heads, j, INTOBJ_INT(nvecs));
 	  if (TransformationsNeeded)
 	    {
 	      SET_ELM_PLIST(coeffs, nvecs, coeffrow);
-              CHANGED_BAG(coeffs);    /* Could be an old bag by now. Max. */
+              CHANGED_BAG(coeffs);    // Could be an old bag by now. Max. 
 	      SET_LEN_PLIST(coeffs, nvecs);
 	    }
 	}
       else if (TransformationsNeeded)
 	{
 	  SET_ELM_PLIST(relns, ++nrels, coeffrow);
-          CHANGED_BAG(relns);    /* Could be an old bag by now. Max. */
+          CHANGED_BAG(relns);    // Could be an old bag by now. Max. 
 	  SET_LEN_PLIST(relns, nrels);
 	}
       TakeInterrupt();
@@ -1231,7 +1228,7 @@ UInt TriangulizeListGF2Vecs( Obj mat, UInt clearup)
   ncols = LEN_GF2VEC( ELM_PLIST(mat, 1));
   rank = 0;
 
-  /* Nothing here can cause a garbage collection */
+  // Nothing here can cause a garbage collection 
   
   for (workcol = 1; workcol <= ncols; workcol++)
     {
@@ -1291,17 +1288,17 @@ static Obj IsLockedRepresentationVector;
 void PlainGF2Vec (
     Obj                 list )
 {
-    Int                 len;            /* length of <list>                */
-    UInt                i;              /* loop variable                   */
-    Obj                 first = 0;          /* first entry                     */
+    Int                 len;            // length of <list>                
+    UInt                i;              // loop variable                   
+    Obj                 first = 0;          // first entry                     
     UInt                tnum;
 
 
-    /* check for representation lock */
+    // check for representation lock 
     if (True == DoFilter( IsLockedRepresentationVector, list))
       ErrorMayQuit("Cannot convert a locked GF2 vector into a plain list", 0, 0);
     
-    /* resize the list and retype it, in this order                        */
+    // resize the list and retype it, in this order                        
     len = LEN_GF2VEC(list);
 
     if (len == 0)
@@ -1314,19 +1311,19 @@ void PlainGF2Vec (
     GROW_PLIST( list, (UInt)len );
     SET_LEN_PLIST( list, len );
 
-    /* keep the first entry because setting the second destroys the first  */
+    // keep the first entry because setting the second destroys the first  
     if (len == 0)
       SET_ELM_PLIST( list, 1 , 0);
     else
       first = ELM_GF2VEC(list,1);
 
-    /* wipe out the first entry of the GF2 vector (which becomes the  second */
-    /* entry of the plain list, in case the list has length 1.             */
+    // wipe out the first entry of the GF2 vector (which becomes the  second 
+    // entry of the plain list, in case the list has length 1.             
     if (len == 1)
       SET_ELM_PLIST( list, 2, 0 );
     
-    /* replace the bits by 'GF2One' or 'GF2Zero' as the case may be        */
-    /* this must of course be done from the end of the list backwards      */
+    // replace the bits by 'GF2One' or 'GF2Zero' as the case may be        
+    // this must of course be done from the end of the list backwards      
     for ( i = len;  1 < i;  i-- )
         SET_ELM_PLIST( list, i, ELM_GF2VEC( list, i ) );
     if (len != 0)
@@ -1345,15 +1342,15 @@ void PlainGF2Vec (
 void PlainGF2Mat (
     Obj                 list )
 {
-    Int                 len;            /* length of <list>                */
-    UInt                i;              /* loop variable                   */
+    Int                 len;            // length of <list>                
+    UInt                i;              // loop variable                   
 
-    /* resize the list and retype it, in this order                        */
+    // resize the list and retype it, in this order                        
     len = LEN_GF2MAT(list);
     RetypeBag( list, IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE );
     SET_LEN_PLIST( list, len );
 
-    /* shift the entries to the left                                       */
+    // shift the entries to the left                                       
     for ( i = 1;  i <= len;  i++ ) {
         SET_ELM_PLIST( list, i, ELM_GF2MAT( list, i ) );
     }
@@ -1369,35 +1366,35 @@ void PlainGF2Mat (
 void ConvGF2Vec (
     Obj                 list )
 {
-    Int                 len;            /* logical length of the vector    */
-    Int                 i;              /* loop variable                   */
-    UInt                block;          /* one block of the boolean list   */
-    UInt                bit;            /* one bit of a block              */
+    Int                 len;            // logical length of the vector    
+    Int                 i;              // loop variable                   
+    UInt                block;          // one block of the boolean list   
+    UInt                bit;            // one bit of a block              
     Obj                 x;
         
-    /* already in the correct representation                               */
+    // already in the correct representation                               
     if ( IS_GF2VEC_REP(list) ) {
         return;
     }
 
-    /* Otherwise make it a plain list so that we will know where it keeps
-       its data -- could do much better in the case of GF(2^n) vectors that actually
-       lie over GF(2) */
+    // Otherwise make it a plain list so that we will know where it keeps
+    // its data -- could do much better in the case of GF(2^n) vectors that actually
+    // lie over GF(2)
 
     if (IS_VEC8BIT_REP(list))
       PlainVec8Bit(list);
     else
       PLAIN_LIST( list );
     
-    /* change its representation                                           */
+    // change its representation                                           
     len   = LEN_PLIST(list);
 
-    /* We may have to resize the bag now because a length 1
-       plain list is shorter than a length 1 GF2VEC */
+    // We may have to resize the bag now because a length 1
+    // plain list is shorter than a length 1 GF2VEC
     if (SIZE_PLEN_GF2VEC(len) > SIZE_OBJ(list))
       ResizeBag( list, SIZE_PLEN_GF2VEC(len) );
 
-    /* now do the work */
+    // now do the work 
     block = 0;
     bit   = 1;
     for ( i = 1;  i <= len;  i++ ) {
@@ -1406,7 +1403,7 @@ void ConvGF2Vec (
 	block |= bit;
       else if (x != GF2Zero)
 	{
-	  /* might be GF(2) elt written over bigger field */
+	  // might be GF(2) elt written over bigger field 
 	  if (EQ(x, GF2One))
 	    block |= bit;
 	  else if (!EQ(x, GF2Zero))
@@ -1421,7 +1418,7 @@ void ConvGF2Vec (
       }
     }
 
-    /* retype and resize bag                                               */
+    // retype and resize bag                                               
     ResizeWordSizedBag( list, SIZE_PLEN_GF2VEC(len) );
     SET_LEN_GF2VEC( list, len );
     if ( IS_PLIST_MUTABLE( list ) ) {
@@ -1441,10 +1438,10 @@ Obj FuncCONV_GF2VEC (
     Obj                 self,
     Obj                 list )
 {
-    /* check whether <list> is a GF2 vector                               */
+    // check whether <list> is a GF2 vector                               
     ConvGF2Vec(list);
 
-    /* return nothing                                                      */
+    // return nothing                                                      
     return 0;
 }
 
@@ -1458,14 +1455,14 @@ Obj FuncCONV_GF2VEC (
 Obj NewGF2Vec (
     Obj                 list )
 {
-    Int                 len;            /* logical length of the vector    */
-    Int                 i;              /* loop variable                   */
-    UInt                block;          /* one block of the boolean list   */
-    UInt                bit;            /* one bit of a block              */
+    Int                 len;            // logical length of the vector    
+    Int                 i;              // loop variable                   
+    UInt                block;          // one block of the boolean list   
+    UInt                bit;            // one bit of a block              
     Obj                 x;
-    Obj                 res;            /* resulting GF2 vector object     */
+    Obj                 res;            // resulting GF2 vector object     
     
-    /* already in the correct representation                               */
+    // already in the correct representation                               
     if ( IS_GF2VEC_REP(list) ) {
         res = ShallowCopyVecGF2(list);
         if (!IS_MUTABLE_OBJ(list))
@@ -1488,7 +1485,7 @@ Obj NewGF2Vec (
     len = LEN_PLIST(list);
     NEW_GF2VEC( res, TYPE_LIST_GF2VEC, len );
     
-    /* now do the work */
+    // now do the work 
     block = 0;
     bit   = 1;
     for ( i = 1;  i <= len;  i++ ) {
@@ -1497,7 +1494,7 @@ Obj NewGF2Vec (
 	    block |= bit;
       else if (x != GF2Zero)
 	    {
-	      /* might be GF(2) elt written over bigger field */
+	      // might be GF(2) elt written over bigger field 
 	      if (EQ(x, GF2One))
 	        block |= bit;
 	      else if (!EQ(x, GF2Zero))
@@ -1506,13 +1503,13 @@ Obj NewGF2Vec (
       
       bit = bit << 1;
       if ( bit == 0 || i == len ) {
-	    BLOCK_ELM_GF2VEC(res,i) = block; /* only changed list to res */
+	    BLOCK_ELM_GF2VEC(res,i) = block; // only changed list to res 
 	    block = 0;
 	    bit   = 1;
       }
     }
 
-    /* mutability should be inherited from the argument */
+    // mutability should be inherited from the argument 
     if ( IS_PLIST_MUTABLE( list ) )
         SetTypeDatObj( res , TYPE_LIST_GF2VEC);
     else
@@ -1532,7 +1529,7 @@ Obj FuncCOPY_GF2VEC (
     Obj                 self,
     Obj                 list )
 {
-    /* check whether <list> is a GF2 vector                               */
+    // check whether <list> is a GF2 vector                               
     list = NewGF2Vec(list);
 
     return list;
@@ -1588,7 +1585,7 @@ Obj FuncPLAIN_GF2VEC (
     Obj                 self,
     Obj                 list )
 {
-    /* check whether <list> is a GF2 vector                                */
+    // check whether <list> is a GF2 vector                                
     while ( ! IS_GF2VEC_REP(list) ) {
         list = ErrorReturnObj(
             "PLAIN_GF2VEC: <list> must be a GF2 vector (not a %s)",
@@ -1597,7 +1594,7 @@ Obj FuncPLAIN_GF2VEC (
     }
     PlainGF2Vec(list);
 
-    /* return nothing                                                      */
+    // return nothing                                                      
     return 0;
 }
 
@@ -1610,7 +1607,7 @@ Obj FuncPLAIN_GF2VEC (
 */
 
 
-/*   A list of flip values for bytes (i.e. ..xyz -> zyx..) */
+//   A list of flip values for bytes (i.e. ..xyz -> zyx..) 
 
 static const UInt1 revertlist [] ={
  0, 128, 64, 192, 32, 160, 96, 224, 16, 144, 80, 208, 48, 176, 112, 240, 8, 
@@ -1631,20 +1628,20 @@ static const UInt1 revertlist [] ={
   143, 79, 207, 47, 175, 111, 239, 31, 159, 95, 223, 63, 191, 127, 255
 };
 
-/* Takes an UInt a on n bits and returns the Uint obtained by reverting the
- * bits */
+// Takes an UInt a on n bits and returns the Uint obtained by reverting the
+// bits
 UInt revertbits(UInt a, Int n)
 {
   UInt b,c;
   b=0;
   while (n>8) {
-    c=a&0xff; /* last byte */
+    c=a&0xff; // last byte 
     a = a>>8;
     b = b<<8;
-    b += (UInt) revertlist[(UInt1)c]; /* add flipped */
+    b += (UInt) revertlist[(UInt1)c]; // add flipped 
     n -=8;
   }
-  /* cope with the last n bits */
+  // cope with the last n bits 
   a &= 0xff;
   b= b<<n;
   c=(UInt) revertlist[(UInt1)a];
@@ -1662,13 +1659,13 @@ Int Cmp_GF2VEC_GF2VEC (
     Obj                 vl,
     Obj                 vr )
 {
-    UInt                i;              /* loop variable                   */
-    const UInt *        bl;             /* block of <vl>                   */
-    const UInt *        br;             /* block of <vr>                   */
-    UInt                len,lenl,lenr;  /* length of the list              */
+    UInt                i;              // loop variable                   
+    const UInt *        bl;             // block of <vl>                   
+    const UInt *        br;             // block of <vr>                   
+    UInt                len,lenl,lenr;  // length of the list              
     UInt a,b,nb;
 
-    /* get and check the length                                            */
+    // get and check the length                                            
     lenl = LEN_GF2VEC(vl);
     lenr = LEN_GF2VEC(vr);
     nb=NUMBER_BLOCKS_GF2VEC(vl);
@@ -1677,11 +1674,11 @@ Int Cmp_GF2VEC_GF2VEC (
       nb = a;
     }
 
-    /* check all blocks                                                    */
+    // check all blocks                                                    
     bl = CONST_BLOCKS_GF2VEC(vl);
     br = CONST_BLOCKS_GF2VEC(vr);
     for ( i = nb;  1 < i;  i--, bl++, br++ ) {
-	/* comparison is numeric of the reverted lists*/
+	// comparison is numeric of the reverted lists
       if (*bl != *br)
 	{
 	  a=revertbits(*bl,BIPEB);
@@ -1693,16 +1690,16 @@ Int Cmp_GF2VEC_GF2VEC (
     }
     
 
-    /* The last block remains */
+    // The last block remains 
     len=lenl;
     if (len>lenr) {
       len=lenr;
     }
 
-    /* are both vectors length 0? */
+    // are both vectors length 0? 
     if (len == 0 ) return 0;
 
-    /* is there still a full block in common? */
+    // is there still a full block in common? 
     len = len % BIPEB;
     if (len == 0) {
       a=revertbits(*bl,BIPEB);
@@ -1718,7 +1715,7 @@ Int Cmp_GF2VEC_GF2VEC (
     if (a>b)
       return 1;
     
-    /* blocks still the same --left length must be smaller to be true */
+    // blocks still the same --left length must be smaller to be true 
     if (lenr>lenl)
       return -1;
     if (lenl > lenr)
@@ -1738,7 +1735,7 @@ Obj FuncEQ_GF2VEC_GF2VEC (
     Obj                 vl,
     Obj                 vr )
 {
-  /* we can do this case MUCH faster if we just want equality */
+  // we can do this case MUCH faster if we just want equality 
   if (LEN_GF2VEC(vl)  != LEN_GF2VEC(vr))
     return False;
   return (Cmp_GF2VEC_GF2VEC(vl,vr) == 0) ? True : False;
@@ -1822,30 +1819,30 @@ Obj FuncELMS_GF2VEC (
     Obj                 list,
     Obj                 poss )
 {
-    Obj                 elms;           /* selected sublist, result        */
-    Int                 lenList;        /* length of <list>                */
-    Int                 lenPoss;        /* length of positions             */
-    Int                 pos;            /* position as integer             */
-    Int                 inc;            /* increment in a range            */
-    Int                 i;              /* loop variable                   */
+    Obj                 elms;           // selected sublist, result        
+    Int                 lenList;        // length of <list>                
+    Int                 lenPoss;        // length of positions             
+    Int                 pos;            // position as integer             
+    Int                 inc;            // increment in a range            
+    Int                 i;              // loop variable                   
     Obj                 apos;
 
-    /* get the length of <list>                                            */
+    // get the length of <list>                                            
     lenList = LEN_GF2VEC(list);
 
-    /* general code for arbritrary lists, which are ranges                 */
+    // general code for arbritrary lists, which are ranges                 
     if ( ! IS_RANGE(poss) ) {
 
-        /* get the length of <positions>                                   */
+        // get the length of <positions>                                   
         lenPoss = LEN_LIST(poss);
 
-        /* make the result vector                                          */
+        // make the result vector                                          
         NEW_GF2VEC( elms, TYPE_LIST_GF2VEC, lenPoss );
 
-        /* loop over the entries of <positions> and select                 */
+        // loop over the entries of <positions> and select                 
         for ( i = 1;  i <= lenPoss;  i++ ) {
 
-            /* get next position                                           */
+            // get next position                                           
 
 	  apos = ELM0_LIST( poss, i);
 	  if (!apos || !IS_INTOBJ(apos))
@@ -1858,7 +1855,7 @@ Obj FuncELMS_GF2VEC (
 	    return 0;
 	  }
 	  
-	  /* assign the element into <elms>                              */
+	  // assign the element into <elms>                              
 	  if ( ELM_GF2VEC( list, pos ) == GF2One ) {
 	    BLOCK_ELM_GF2VEC(elms,i) |= MASK_POS_GF2VEC(i);
 	  }
@@ -1866,15 +1863,15 @@ Obj FuncELMS_GF2VEC (
 	
     }
 
-    /* special code for ranges                                             */
+    // special code for ranges                                             
     else {
 
-        /* get the length of <positions>, the first elements, and the inc. */
+        // get the length of <positions>, the first elements, and the inc. 
         lenPoss = GET_LEN_RANGE(poss);
         pos = GET_LOW_RANGE(poss);
         inc = GET_INC_RANGE(poss);
 
-        /* check that no <position> is larger than <lenList>               */
+        // check that no <position> is larger than <lenList>               
         if ( lenList < pos ) {
             ErrorMayQuit( "List Elements: <list>[%d] must have a value",
                        pos, 0L );
@@ -1886,14 +1883,14 @@ Obj FuncELMS_GF2VEC (
             return 0;
         }
 
-        /* make the result vector                                          */
+        // make the result vector                                          
         NEW_GF2VEC( elms, TYPE_LIST_GF2VEC, lenPoss );
 	
-	/* increment 1 ranges is a block copy */
+	// increment 1 ranges is a block copy 
 	if (inc == 1)
 	  CopySection_GF2Vecs(list, elms, pos, 1, lenPoss);
 
-        /* loop over the entries of <positions> and select                 */
+        // loop over the entries of <positions> and select                 
         else {
            for ( i = 1;  i <= lenPoss;  i++, pos += inc ) {
                 if ( ELM_GF2VEC(list,pos) == GF2One ) {
@@ -1903,7 +1900,7 @@ Obj FuncELMS_GF2VEC (
         }
     }
 
-    /* return the result                                                   */
+    // return the result                                                   
     return elms;
 }
 
@@ -1925,7 +1922,7 @@ Obj FuncASS_GF2VEC (
     Obj                 pos,
     Obj                 elm )
 {
-    /* check that <list> is mutable                                        */
+    // check that <list> is mutable                                        
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
             "List Assignment: <list> must be a mutable list",
@@ -1934,10 +1931,10 @@ Obj FuncASS_GF2VEC (
         return 0;
     }
 
-    /* get the position                                                    */
+    // get the position                                                    
     UInt p = GetSmallInt("ASS_GF2VEC", pos, "pos");
 
-    /* if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep         */
+    // if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep         
     if ( p <= LEN_GF2VEC(list)+1 ) {
         if ( LEN_GF2VEC(list)+1 == p ) {
 	  if (DoFilter(IsLockedRepresentationVector, list) == True)
@@ -1953,19 +1950,19 @@ Obj FuncASS_GF2VEC (
         }
 	else if (IS_FFE(elm) && CHAR_FF(FLD_FFE(elm)) == 2 && DEGR_FF(FLD_FFE(elm)) <= 8)
 	  {
-	    /*	    Pr("Rewriting GF2 vector over larger field",0,0); */
+	    //	    Pr("Rewriting GF2 vector over larger field",0,0); 
 	    RewriteGF2Vec(list, SIZE_FF(FLD_FFE(elm)));
 	    ASS_VEC8BIT(list, pos, elm);
 	  }
         else
 	  {
-	    /* 	    Pr("arbitrary assignment (GF2)",0,0); */
+	    // 	    Pr("arbitrary assignment (GF2)",0,0); 
 	    PlainGF2Vec(list);
 	    ASS_LIST( list, p, elm );
 	  }
     }
     else {
-      /*       Pr("arbitrary assignment 2 (GF2)",0,0); */
+      //       Pr("arbitrary assignment 2 (GF2)",0,0); 
         PlainGF2Vec(list);
         ASS_LIST( list, p, elm );
     }
@@ -1982,7 +1979,7 @@ Obj FuncPLAIN_GF2MAT (
 {
     PlainGF2Mat(list);
 
-    /* return nothing                                                      */
+    // return nothing                                                      
     return 0;
 }
 
@@ -2003,7 +2000,7 @@ Obj FuncASS_GF2MAT (
     Obj                 pos,
     Obj                 elm )
 {
-    /* check that <list> is mutable                                        */
+    // check that <list> is mutable                                        
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
             "List Assignment: <list> must be a mutable list",
@@ -2012,10 +2009,10 @@ Obj FuncASS_GF2MAT (
         return 0;
     }
 
-    /* get the position                                                    */
+    // get the position                                                    
     UInt p = GetSmallInt("ASS_GF2MAT", pos, "pos");
 
-    /* if <elm> is a GF2 vector and the length is OK, keep the rep         */
+    // if <elm> is a GF2 vector and the length is OK, keep the rep         
     if ( ! IS_GF2VEC_REP(elm)  ) {
         PlainGF2Mat(list);
         ASS_LIST( list, p, elm );
@@ -2076,7 +2073,7 @@ Obj FuncUNB_GF2VEC (
     Obj                 list,
     Obj                 pos )
 {
-    /* check that <list> is mutable                                        */
+    // check that <list> is mutable                                        
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
             "List Unbind: <list> must be a mutable list",
@@ -2093,10 +2090,10 @@ Obj FuncUNB_GF2VEC (
         return 0;
     }
 
-    /* get the position                                                    */
+    // get the position                                                    
     UInt p = GetSmallInt("UNB_GF2VEC", pos, "pos");
 
-    /* if we unbind the last position keep the representation              */
+    // if we unbind the last position keep the representation              
     if ( LEN_GF2VEC(list) < p ) {
         ;
     }
@@ -2126,7 +2123,7 @@ Obj FuncUNB_GF2MAT (
     Obj                 list,
     Obj                 pos )
 {
-    /* check that <list> is mutable                                        */
+    // check that <list> is mutable                                        
     if ( ! IS_MUTABLE_OBJ(list) ) {
         ErrorReturnVoid(
             "List Unbind: <list> must be a mutable list",
@@ -2135,10 +2132,10 @@ Obj FuncUNB_GF2MAT (
         return 0;
     }
 
-    /* get the position                                                    */
+    // get the position                                                    
     UInt p = GetSmallInt("UNB_GF2MAT", pos, "pos");
 
-    /* if we unbind the last position keep the representation              */
+    // if we unbind the last position keep the representation              
     if ( p > 1 && LEN_GF2MAT(list) < p ) {
         ;
     }
@@ -2173,7 +2170,7 @@ Obj FuncZERO_GF2VEC (
     Obj                 zero;
     UInt                len;
 
-    /* create a new GF2 vector                                             */
+    // create a new GF2 vector                                             
     len = LEN_GF2VEC(mat);
     NEW_GF2VEC( zero, TYPE_LIST_GF2VEC, len );
     return zero;
@@ -2191,7 +2188,7 @@ Obj FuncZERO_GF2VEC_2 (
 {
     Obj                 zero;
 
-    /* create a new GF2 vector*/
+    // create a new GF2 vector
     if (!IS_INTOBJ(len))
       ErrorMayQuit("ZERO_GF2VEC2: length must be a small integer, not a %s",
 		(Int)TNAM_OBJ(len),0L);
@@ -2332,7 +2329,7 @@ Obj FuncSUM_GF2VEC_GF2VEC (
     Obj                 vl,
     Obj                 vr )
 {
-    Obj                 sum;            /* sum, result                     */
+    Obj                 sum;            // sum, result                     
     UInt ll,lr;
 
     ll = LEN_GF2VEC(vl);
@@ -2511,17 +2508,17 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT (
     Obj                 vr,
     Obj                 mul )
 {
-    /* do nothing if <mul> is zero                                         */
+    // do nothing if <mul> is zero                                         
     if ( EQ(mul,GF2Zero) ) {
         return INTOBJ_INT( RightMostOneGF2Vec(vl) );
     }
 
-    /* add if <mul> is one                                                 */
+    // add if <mul> is one                                                 
     if ( EQ(mul,GF2One) ) {
         return AddCoeffsGF2VecGF2Vec( vl, vr );
     }
 
-    /* try next method                                                     */
+    // try next method                                                     
     return TRY_NEXT_METHOD;
 }
 
@@ -2536,17 +2533,17 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT_LIMS (
     Obj                 vr,
     Obj                 mul )
 {
-    /* do nothing if <mul> is zero                                         */
+    // do nothing if <mul> is zero                                         
     if ( EQ(mul,GF2Zero) ) {
         return INTOBJ_INT( RightMostOneGF2Vec(vl) );
     }
 
-    /* add if <mul> is one                                                 */
+    // add if <mul> is one                                                 
     if ( EQ(mul,GF2One) ) {
         return AddCoeffsGF2VecGF2Vec( vl, vr );
     }
 
-    /* try next method                                                     */
+    // try next method                                                     
     return TRY_NEXT_METHOD;
 }
 
@@ -2578,7 +2575,7 @@ Obj FuncSHRINKCOEFFS_GF2VEC (
     UInt *              ptr;
     UInt		off;
 
-    /* get length and number of blocks                                     */
+    // get length and number of blocks                                     
     len = LEN_GF2VEC(vec);
     if ( len == 0 ) {
         return INTOBJ_INT(0);
@@ -2588,28 +2585,28 @@ Obj FuncSHRINKCOEFFS_GF2VEC (
     onbb = nbb; 
     ptr = BLOCKS_GF2VEC(vec) + (nbb-1);
     
-    /* number of insignificant bit positions in last word */
+    // number of insignificant bit positions in last word 
     off = BIPEB - ((len-1)%BIPEB+1); 
     
-    /* mask out the last bits */
+    // mask out the last bits 
 #ifdef SYS_IS_64_BIT
     *ptr &= 0xffffffffffffffff >> off;
 #else
     *ptr &= 0xffffffff >> off;
 #endif
 
-    /* find last non-trivial block */
+    // find last non-trivial block 
     while ( 0 < nbb && ! *ptr ) {
         nbb--;
         ptr--;
     }
-    /* did the block number change? */
+    // did the block number change? 
     if (nbb < onbb) {
       len = nbb * BIPEB;
     }
 
-    /* find position inside this block                   */
-    /* we are guaranteed not to cross a block boundary ! */
+    // find position inside this block                   
+    // we are guaranteed not to cross a block boundary ! 
     while ( 0 < len && ! ( *ptr & MASK_POS_GF2VEC(len) ) ) {
         len--;
     }
@@ -2634,7 +2631,7 @@ UInt PositionNonZeroGF2Vec ( Obj vec, UInt from)
     const UInt *        ptr;
     UInt                pos;
 
-    /* get length and number of blocks                                     */
+    // get length and number of blocks                                     
     len = LEN_GF2VEC(vec);
     if ( len == 0 ) {
       return 1;
@@ -2644,7 +2641,7 @@ UInt PositionNonZeroGF2Vec ( Obj vec, UInt from)
     nbb = from / BIPEB;
     pos = from % BIPEB;
     ptr = CONST_BLOCKS_GF2VEC(vec)+nbb;
-    if (pos) /* partial block to check */
+    if (pos) // partial block to check 
       {
 	pos = from+1;
 	while ( (pos - 1)%BIPEB  && pos <= len)
@@ -2658,19 +2655,19 @@ UInt PositionNonZeroGF2Vec ( Obj vec, UInt from)
 	nbb++;
 	ptr++;
       }
-    /* find first non-trivial block                                         */
+    // find first non-trivial block                                         
     nb = NUMBER_BLOCKS_GF2VEC(vec);
     while ( nbb < nb && ! *ptr ) {
         nbb++;
         ptr++;
     }
 
-    /* find position inside this block                                     */
+    // find position inside this block                                     
     pos = nbb * BIPEB + 1;
     while ( pos <= len && ! ( *ptr & MASK_POS_GF2VEC(pos) ) ) {
         pos++;
     }
-    /* as the code is intended to run over, trailing 1's are innocent */
+    // as the code is intended to run over, trailing 1's are innocent 
     if (pos <= len)
       return pos;
     else
@@ -2798,7 +2795,7 @@ Obj FuncSUM_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
       wm = wl;
     }
 
-  /* In this case, the result is not rectangular */
+  // In this case, the result is not rectangular 
   
   if ((ll > lr && wr > wl) || (ll < lr && wr < wl)) 
     return TRY_NEXT_METHOD;
@@ -2823,7 +2820,7 @@ Obj FuncSUM_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
   for (i = 1; i <= lm; i++)
     {
 
-      /* copy the longer vector and add the shorter */
+      // copy the longer vector and add the shorter 
       if (wl == ws) 
 	{
 	  sv = ShallowCopyVecGF2( ELM_GF2MAT( matl, i));
@@ -2874,18 +2871,18 @@ Obj FuncTRANSPOSED_GF2MAT( Obj self, Obj mat)
   UInt imod,nrb,nstart;
   UInt i,j,k,n;
 
-  /* check argument */
+  // check argument 
   if (TNUM_OBJ(mat) != T_POSOBJ) {
      mat = ErrorReturnObj(
             "TRANSPOSED_GF2MAT: Need compressed matrix over GF(2)\n",
             0, 0, 
             "You can return such matrix with 'return mat;'\n");
   }
-  /* type for mat */
+  // type for mat 
   typ = TYPE_LIST_GF2MAT;
 
 
-  /* we assume here that there is a first row */
+  // we assume here that there is a first row 
   r1 = ELM_GF2MAT(mat,1);
   
   l = LEN_GF2MAT(mat);
@@ -2895,49 +2892,49 @@ Obj FuncTRANSPOSED_GF2MAT( Obj self, Obj mat)
   tra = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT( w ));
   SET_TYPE_POSOBJ(tra, typ);
 
-  /* type for rows */
+  // type for rows 
   typ = TYPE_LIST_GF2VEC_LOCKED;
   
   SET_LEN_GF2MAT(tra, w);
-  /* create new matrix */
+  // create new matrix 
   for (i = 1; i <= w; i++) {
     NEW_GF2VEC( row,  typ, l );
     SET_ELM_GF2MAT( tra, i, row);
     CHANGED_BAG(tra);
   }
-  /* set entries */
-  /* run over BIPEB row chunks of the original matrix */
+  // set entries 
+  // run over BIPEB row chunks of the original matrix 
   for (i = 1; i <= l; i=i+BIPEB) {
     imod=(i-1)/BIPEB;
-    /* run through these rows in block chunks */
+    // run through these rows in block chunks 
     for (n=0;n<nrb;n++) {
       for (j=0;j<BIPEB;j++) {
 	if ((i+j)>l) {
-	  vals[j]=0; /* outside matrix */ 
+	  vals[j]=0; // outside matrix  
 	}
 	else {
 	  const UInt * ptr=CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mat,i+j))+n;
 	  vals[j]=*ptr;
 	}
       }
-      /* write transposed values in new matrix */
+      // write transposed values in new matrix 
       mask=1;
       nstart=n*BIPEB+1;
-      for (j=0;j<BIPEB;j++) { /* bit number = Row in transpose */
+      for (j=0;j<BIPEB;j++) { // bit number = Row in transpose 
 	if ((nstart+j)<=w) {
-	  /* still within matrix */
+	  // still within matrix 
 	  val=0;
 	  bit=1;
 	  for (k=0;k<BIPEB;k++) {
 	    if (mask==(vals[k]&mask)) {
-	      val|=bit; /* set bit */
+	      val|=bit; // set bit 
 	    }
 	    bit=bit<<1;
 	  }
-	  /* set entry */
+	  // set entry 
 	  UInt * ptr = BLOCKS_GF2VEC(ELM_GF2MAT(tra,nstart+j))+imod;
 	  *ptr=val;
-	  /* next bit */
+	  // next bit 
 	  mask=mask<<1;
 	}
       }
@@ -2956,18 +2953,18 @@ Obj FuncNUMBER_GF2VEC( Obj self, Obj vec )
 {
   UInt len,nd,i;
   UInt head,a;
-  UInt off,off2;		/* 0 based */
-  Obj zahl;  /* the long number */
+  UInt off,off2;		// 0 based 
+  Obj zahl;  // the long number 
   UInt *num2;
   mp_limb_t *vp;
   len = LEN_GF2VEC(vec);
   if (len == 0)
     return INTOBJ_INT(1);
   num2 = BLOCKS_GF2VEC(vec) + (len-1)/BIPEB;
-  off = (len -1) % BIPEB + 1; /* number of significant bits in last word */
-  off2 = BIPEB - off;         /* number of insignificant bits in last word */
+  off = (len -1) % BIPEB + 1; // number of significant bits in last word 
+  off2 = BIPEB - off;         // number of insignificant bits in last word 
 
-  /* mask out the last bits */
+  // mask out the last bits 
 #ifdef SYS_IS_64_BIT
   *num2 &= 0xffffffffffffffff >> off2;
 #else
@@ -2975,38 +2972,38 @@ Obj FuncNUMBER_GF2VEC( Obj self, Obj vec )
 #endif
 
   if (len <=NR_SMALL_INT_BITS) 
-    /* it still fits into a small integer */
+    // it still fits into a small integer 
     return INTOBJ_INT(revertbits(*num2,len));
   else {
-    /* we might have to build a long integer */
+    // we might have to build a long integer 
 
-    /* the number of words (limbs) we need. */
+    // the number of words (limbs) we need. 
     nd = ((len-1)/GMP_LIMB_BITS)+1;
 
     zahl = NewBag( T_INTPOS, nd*sizeof(UInt) );
-    /*    zahl = NewBag( T_INTPOS, (((nd+1)>>1)<<1)*sizeof(UInt) );*/
-    /* +1)>>1)<<1: round up to next even number*/
+    //    zahl = NewBag( T_INTPOS, (((nd+1)>>1)<<1)*sizeof(UInt) );
+    // +1)>>1)<<1: round up to next even number
 
-    /* garbage collection might lose pointer */
+    // garbage collection might lose pointer 
     const UInt *num = CONST_BLOCKS_GF2VEC(vec) + (len-1)/BIPEB;
 
-    vp = (mp_limb_t *)ADDR_OBJ(zahl); /* the place we write to */
+    vp = (mp_limb_t *)ADDR_OBJ(zahl); // the place we write to 
     i=1;
 
     if (off!=BIPEB) {
-      head = revertbits(*num,off); /* the last 'off' bits, reverted */
+      head = revertbits(*num,off); // the last 'off' bits, reverted 
       while (i<nd) {
-	/* next word */
+	// next word 
 	num--;
-	*vp = head; /* the bits left from last word */
-	a = revertbits(*num,BIPEB); /* the full word reverted */
-	head = a>>off2; /* next head: trailing `off' bits */
-	a =a << off; /* the rest of the word */
+	*vp = head; // the bits left from last word 
+	a = revertbits(*num,BIPEB); // the full word reverted 
+	head = a>>off2; // next head: trailing `off' bits 
+	a =a << off; // the rest of the word 
 	*vp |=a;
 	vp++;
 	i++;
       }
-      *vp = head; /* last head bits */
+      *vp = head; // last head bits 
       vp++;
     }
     else {
@@ -3097,17 +3094,17 @@ Obj FuncLT_GF2MAT_GF2MAT( Obj self, Obj ml, Obj mr)
 UInt DistGF2Vecs(const UInt* ptL, const UInt* ptR, UInt len)
 {
   UInt 			sum,m;
-  const UInt *          end;            /* end marker                      */
+  const UInt *          end;            // end marker                      
 
   /*T this  function will not work if the vectors have more than 2^28
    * entries */
 
   end = ptL + ((len+BIPEB-1)/BIPEB);
   sum=0;
-  /* loop over the entries */
-  /*T possibly unroll this loop */
+  // loop over the entries 
+  //T possibly unroll this loop 
   while ( ptL < end ) {
-    m = *ptL++ ^ *ptR++; /* xor of bits, nr bits therein is difference */
+    m = *ptL++ ^ *ptR++; // xor of bits, nr bits therein is difference 
     sum += COUNT_TRUES_BLOCK(m);
   }
   return sum;
@@ -3125,12 +3122,12 @@ Obj FuncDIST_GF2VEC_GF2VEC (
     Obj                 vl,
     Obj                 vr )
 {
-  UInt                  len;            /* length of the list              */
-  UInt                  off;            /* bit offset at the end to clean out */
-  UInt *                ptL;            /* bit field of <vl>               */
-  UInt *                ptR;            /* bit field of <vr>               */
-  UInt *                end;            /* pointer used to zero out end bit */
-  /* get and check the length                                            */
+  UInt                  len;            // length of the list              
+  UInt                  off;            // bit offset at the end to clean out 
+  UInt *                ptL;            // bit field of <vl>               
+  UInt *                ptR;            // bit field of <vr>               
+  UInt *                end;            // pointer used to zero out end bit 
+  // get and check the length                                            
   len = LEN_GF2VEC(vl);
 
   if ( len != LEN_GF2VEC(vr) ) {
@@ -3139,13 +3136,13 @@ Obj FuncDIST_GF2VEC_GF2VEC (
     return 0;
   }
 
-  /* calculate the offsets */
+  // calculate the offsets 
   ptL = BLOCKS_GF2VEC(vl);
   ptR = BLOCKS_GF2VEC(vr);
 
-/* mask out the last bits */
-  off = (len -1) % BIPEB + 1; /* number of significant bits in last word */
-  off = BIPEB - off;          /* number of insignificant bits in last word */
+// mask out the last bits 
+  off = (len -1) % BIPEB + 1; // number of significant bits in last word 
+  off = BIPEB - off;          // number of insignificant bits in last word 
   end = ptL + ((len-1)/BIPEB);
 #ifdef SYS_IS_64_BIT
   *end &= 0xffffffffffffffff >> off;
@@ -3164,13 +3161,13 @@ Obj FuncDIST_GF2VEC_GF2VEC (
 
 
 void DistVecClosVec(
-  Obj		veclis, /* pointers to matrix vectors and their multiples */
-  Obj 	        ovec,    /* vector we compute distance to */
-  Obj		d,	/* distances list */
-  Obj  	        osum,	/* position of the sum vector */
-  UInt		pos,	/* recursion depth */
-  UInt		l,	/* length of basis */
-  UInt		len )	/* length of the involved vectors */
+  Obj		veclis, // pointers to matrix vectors and their multiples 
+  Obj 	        ovec,    // vector we compute distance to 
+  Obj		d,	// distances list 
+  Obj  	        osum,	// position of the sum vector 
+  UInt		pos,	// recursion depth 
+  UInt		l,	// length of basis 
+  UInt		len )	// length of the involved vectors 
 {
   UInt 		i;
   UInt		di;
@@ -3213,38 +3210,38 @@ void DistVecClosVec(
 
 Obj FuncDIST_VEC_CLOS_VEC(
   Obj		self,
-  Obj		veclis, /* pointers to matrix vectors and their multiples */
-  Obj		vec,    /* vector we compute distance to */
-  Obj		d )	/* distances list */
+  Obj		veclis, // pointers to matrix vectors and their multiples 
+  Obj		vec,    // vector we compute distance to 
+  Obj		d )	// distances list 
 
 {
-  Obj		sum; /* sum vector */
+  Obj		sum; // sum vector 
   UInt 		len;
 
   len = LEN_GF2VEC(vec);
 
-  /* get space for sum vector */
+  // get space for sum vector 
   NEW_GF2VEC( sum, TYPE_LIST_GF2VEC, len );
 
-  /* do the recursive work */
+  // do the recursive work 
   DistVecClosVec(veclis,vec,d,sum,1,LEN_PLIST(veclis),len);
 
   return (Obj) 0;
 }
 
 UInt AClosVec(
-  Obj		veclis, /* pointers to matrix vectors and their multiples */
-  Obj 	        ovec,    /* vector we compute distance to */
-  Obj  	        osum,	/* position of the sum vector */
-  UInt		pos,	/* recursion depth */
-  UInt		l,	/* length of basis */
-  UInt		len,	/* length of the involved vectors */
-  UInt		cnt,	/* numbr of vectors used */
-  UInt		stop,	/* stop value */
-  UInt		bd,	/* best distance so far */
-  Obj		obv,    /* best vector so far */
-  Obj           coords,  /* coefficients to get current vector */
-  Obj           bcoords  /* coefficients to get best vector */
+  Obj		veclis, // pointers to matrix vectors and their multiples 
+  Obj 	        ovec,    // vector we compute distance to 
+  Obj  	        osum,	// position of the sum vector 
+  UInt		pos,	// recursion depth 
+  UInt		l,	// length of basis 
+  UInt		len,	// length of the involved vectors 
+  UInt		cnt,	// numbr of vectors used 
+  UInt		stop,	// stop value 
+  UInt		bd,	// best distance so far 
+  Obj		obv,    // best vector so far 
+  Obj           coords,  // coefficients to get current vector 
+  Obj           bcoords  // coefficients to get best vector 
   )	
 {
   UInt		di;
@@ -3257,7 +3254,7 @@ UInt AClosVec(
 
 
 
-  /* maybe we don't add this basis vector -- if this leaves us enough possibilitiies */
+  // maybe we don't add this basis vector -- if this leaves us enough possibilitiies 
   if ( pos+cnt<l ) {
     bd = AClosVec(veclis,ovec,osum,pos+1,l,len,cnt,stop,bd,obv,coords,bcoords);
       if (bd<=stop) {
@@ -3266,7 +3263,7 @@ UInt AClosVec(
   }
 
 
-  /* Otherwise we do */
+  // Otherwise we do 
   
   vec = CONST_BLOCKS_GF2VEC(ovec);
   sum = BLOCKS_GF2VEC(osum);
@@ -3280,12 +3277,12 @@ UInt AClosVec(
     }
 
   
-  if (cnt == 0) /* this is a candidate */
+  if (cnt == 0) // this is a candidate 
     {
       di=DistGF2Vecs(sum,vec,len);
       if (di<bd) {
 	
-	/* store new result */
+	// store new result 
 	bd=di;
 	bv = BLOCKS_GF2VEC(obv);
 	end = bv+((len+BIPEB-1)/BIPEB);
@@ -3304,7 +3301,7 @@ UInt AClosVec(
 	  }
       }
     }
-  else /* need to add in some more */
+  else // need to add in some more 
     {
       bd=AClosVec(veclis,ovec,osum,pos+1,l,len,cnt-1,stop,bd,obv,coords,bcoords);
       if (bd<=stop) {
@@ -3312,7 +3309,7 @@ UInt AClosVec(
       }
     }
     
-  /* reset component  */
+  // reset component  
   AddGF2VecToGF2Vec(sum,w,len);
   if (coords != (Obj) 0)
     {
@@ -3329,14 +3326,14 @@ UInt AClosVec(
 
 Obj FuncA_CLOS_VEC(
   Obj		self,
-  Obj		veclis, /* pointers to matrix vectors and their multiples */
-  Obj		vec,    /* vector we compute distance to */
-  Obj		cnt,	/* distances list */
-  Obj		stop)	/* distances list */
+  Obj		veclis, // pointers to matrix vectors and their multiples 
+  Obj		vec,    // vector we compute distance to 
+  Obj		cnt,	// distances list 
+  Obj		stop)	// distances list 
 
 {
-  Obj		sum; /* sum vector */
-  Obj		best; /* best vector */
+  Obj		sum; // sum vector 
+  Obj		best; // best vector 
   UInt 		len;
 
   len = LEN_GF2VEC(vec);
@@ -3346,13 +3343,13 @@ Obj FuncA_CLOS_VEC(
 	      (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
   
 
-  /* get space for sum vector and zero out */
+  // get space for sum vector and zero out 
   NEW_GF2VEC( sum, TYPE_LIST_GF2VEC, len );
   NEW_GF2VEC( best, TYPE_LIST_GF2VEC, len );
 
-  /* do the recursive work */
+  // do the recursive work 
   AClosVec(veclis,vec,sum,1, LEN_PLIST(veclis),len,
-    INT_INTOBJ(cnt),INT_INTOBJ(stop),len+1, /* maximal value +1 */
+    INT_INTOBJ(cnt),INT_INTOBJ(stop),len+1, // maximal value +1 
 	   best, (Obj) 0, (Obj) 0);
 
   return best;
@@ -3360,17 +3357,17 @@ Obj FuncA_CLOS_VEC(
 
 Obj FuncA_CLOS_VEC_COORDS(
   Obj		self,
-  Obj		veclis, /* pointers to matrix vectors and their multiples */
-  Obj		vec,    /* vector we compute distance to */
-  Obj		cnt,	/* distances list */
-  Obj		stop)	/* distances list */
+  Obj		veclis, // pointers to matrix vectors and their multiples 
+  Obj		vec,    // vector we compute distance to 
+  Obj		cnt,	// distances list 
+  Obj		stop)	// distances list 
 
 {
-  Obj		sum; /* sum vector */
-  Obj		best; /* best vector */
-  Obj         coords; /* coefficients of mat to get current */
-  Obj         bcoords; /* coefficients of mat to get best */
-  Obj           res; /* length 2 plist for results */
+  Obj		sum; // sum vector 
+  Obj		best; // best vector 
+  Obj         coords; // coefficients of mat to get current 
+  Obj         bcoords; // coefficients of mat to get best 
+  Obj           res; // length 2 plist for results 
   UInt 		len, len2,i;
 
   len = LEN_GF2VEC(vec);
@@ -3381,7 +3378,7 @@ Obj FuncA_CLOS_VEC_COORDS(
 	      (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
   
 
-  /* get space for sum vector and zero out */
+  // get space for sum vector and zero out 
   NEW_GF2VEC( sum, TYPE_LIST_GF2VEC, len );
   NEW_GF2VEC( best, TYPE_LIST_GF2VEC, len );
 
@@ -3397,9 +3394,9 @@ Obj FuncA_CLOS_VEC_COORDS(
       SET_ELM_PLIST(bcoords,i,INTOBJ_INT(0));
     }
 
-  /* do the recursive work */
+  // do the recursive work 
   AClosVec(veclis,vec,sum,1, len2 ,len,
-    INT_INTOBJ(cnt),INT_INTOBJ(stop),len+1, /* maximal value +1 */
+    INT_INTOBJ(cnt),INT_INTOBJ(stop),len+1, // maximal value +1 
 	   best,coords,bcoords);
 
   res = NEW_PLIST(T_PLIST_DENSE_NHOM,2);
@@ -3433,12 +3430,12 @@ UInt CosetLeadersInnerGF2( Obj veclis,
   Obj vc;
   UInt i;
     
-  /* we know that the length of w does not exceed BIPEB -4 here
-     (or there would not be room in a PLIST for all the coset leaders)
-    we use this to do a lot of GF2 vector operations for w "in-place"
-
-    Even more in this direction could be done, but this no longer
-  the rate-determining step for any feasible application*/
+  // We know that the length of w does not exceed BIPEB -4 here
+  // (or there would not be room in a PLIST for all the coset leaders).
+  // We use this to do a lot of GF2 vector operations for w "in-place"
+  // 
+  // Even more in this direction could be done, but this no longer
+  // the rate-determining step for any feasible application
   
   if (weight == 1)
     {
@@ -3548,13 +3545,13 @@ void ResizeGF2Vec( Obj vec, UInt newlen )
     {
       ResizeWordSizedBag(vec,SIZE_PLEN_GF2VEC(newlen));
 
-      /* now clean remainder of last block */
+      // now clean remainder of last block 
       if (len == 0)
 	ptr = BLOCKS_GF2VEC(vec);
       else
 	{
 	  ptr = BLOCKS_GF2VEC(vec) + (len -1)/BIPEB;
-	  off = BIPEB - ((len -1)% BIPEB + 1); /* number of insignificant bits in last word */
+	  off = BIPEB - ((len -1)% BIPEB + 1); // number of insignificant bits in last word 
 #ifdef SYS_IS_64_BIT
 	  *ptr &= 0xffffffffffffffff >> off;
 #else
@@ -3563,9 +3560,10 @@ void ResizeGF2Vec( Obj vec, UInt newlen )
 	  ptr++;
 	}
       
-      /* and clean new blocks -- shouldn't need to do this, but
-	 it's very cheap */
-      /* newlen can't be zero here, since it is bigger than len */
+      // and clean new blocks -- shouldn't need to do this, but
+	  // it's very cheap
+
+      // newlen can't be zero here, since it is bigger than len 
       nptr = BLOCKS_GF2VEC(vec) + (newlen -1)/BIPEB; 
       while (ptr <= nptr)
 	*ptr++ = 0;
@@ -3575,7 +3573,7 @@ void ResizeGF2Vec( Obj vec, UInt newlen )
     }
   else
     {
-      /* clean remainder of new last block, if any */
+      // clean remainder of new last block, if any 
       if (newlen % BIPEB)
 	{
 	  ptr = BLOCKS_GF2VEC(vec) + (newlen -1)/BIPEB;
@@ -3710,13 +3708,13 @@ void ShiftRightGF2Vec( Obj vec, UInt amount )
   ResizeGF2Vec(vec, len+amount);
   if (amount % BIPEB == 0)
     {
-      /* move the blocks */
+      // move the blocks 
       ptr1 = BLOCKS_GF2VEC(vec) + (len - 1 + amount)/BIPEB;
       ptr2 = ptr1 - amount/BIPEB;
       for (i = 0; i < (len + BIPEB - 1)/BIPEB; i++)
 	*ptr1-- = *ptr2--;
 
-      /* and fill with zeroes */
+      // and fill with zeroes 
       ptr2 = BLOCKS_GF2VEC(vec);
       while (ptr1 >= ptr2)
 	*ptr1-- = 0;
@@ -3724,8 +3722,7 @@ void ShiftRightGF2Vec( Obj vec, UInt amount )
   else
     {
       ptr1 = BLOCKS_GF2VEC(vec) + (len -1 + amount)/BIPEB;
-      ptr2 = ptr1 - amount/BIPEB; /* this can sometimes be the block AFTER the old last block,
-				     but this must be OK */
+      ptr2 = ptr1 - amount/BIPEB; // this can sometimes be the block AFTER the old last block, but this must be OK
       off = amount % BIPEB;
       ptr0 = BLOCKS_GF2VEC(vec);
       while (1)
@@ -3767,7 +3764,7 @@ Obj FuncSHIFT_RIGHT_GF2VEC( Obj self, Obj vec, Obj amount)
   return (Obj)0;
 }
 
-/* ReduceCoeffs */
+// ReduceCoeffs 
 
 /****************************************************************************
 **
@@ -3876,7 +3873,7 @@ Obj ProductCoeffsGF2Vec( Obj vec1, UInt len1, Obj vec2, UInt len2)
     len = len1 + len2 -1;
   NEW_GF2VEC(prod, TYPE_LIST_GF2VEC, len);
 
-  /* better to do the longer loop on the inside */
+  // better to do the longer loop on the inside 
   if (len2 < len1)
     {
       UInt tmp;
@@ -4092,7 +4089,7 @@ Obj FuncSEMIECHELON_LIST_GF2VECS( Obj self, Obj mat )
   UInt i,len;
   UInt width;
   Obj row;
-  /* check argts */
+  // check argts 
   len = LEN_PLIST(mat);
   if (!len)
     return TRY_NEXT_METHOD;
@@ -4129,7 +4126,7 @@ Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS( Obj self, Obj mat )
   UInt i,len;
   UInt width;
   Obj row;
-  /* check argts */
+  // check argts 
   len = LEN_PLIST(mat);
   if (!len)
     return TRY_NEXT_METHOD;
@@ -4162,7 +4159,7 @@ Obj FuncTRIANGULIZE_LIST_GF2VECS( Obj self, Obj mat)
   UInt i,len;
   UInt width;
   Obj row;
-  /* check argts */
+  // check argts 
   len = LEN_PLIST(mat);
   if (!len)
     return TRY_NEXT_METHOD;
@@ -4196,7 +4193,7 @@ Obj FuncRANK_LIST_GF2VECS( Obj self, Obj mat)
   UInt i,len;
   UInt width;
   Obj row;
-  /* check argts */
+  // check argts 
   len = LEN_PLIST(mat);
   if (!len)
     return TRY_NEXT_METHOD;
@@ -4229,7 +4226,7 @@ Obj FuncDETERMINANT_LIST_GF2VECS( Obj self, Obj mat)
   UInt i,len;
   UInt width;
   Obj row;
-  /* check argts */
+  // check argts 
   len = LEN_PLIST(mat);
   if (!len)
     return TRY_NEXT_METHOD;
@@ -4274,7 +4271,7 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
 
   mutable = IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr);
 
-  /* create a matrix */
+  // create a matrix 
   mat = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(nrowp));
   SET_LEN_GF2MAT(mat,nrowp);
   if (mutable) {
@@ -4285,7 +4282,7 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
       type = TYPE_LIST_GF2VEC_IMM_LOCKED;
   }
 
-  /* allocate 0 matrix */
+  // allocate 0 matrix 
 
   for (i = 1; i <= nrowp; i++) {
     NEW_GF2VEC(row, type, ncolp);
@@ -4293,21 +4290,21 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
     CHANGED_BAG(mat);
   }
 
-  /* allocate data for shifts of rows of matr */
+  // allocate data for shifts of rows of matr 
   for (i = 0; i < BIPEB; i++) {
     shift[i] = NewBag(T_DATOBJ, SIZE_PLEN_GF2VEC(ncolr+2*BIPEB));
   }
 
-  /* fill in matrix */
+  // fill in matrix 
   for (j = 1; j <= nrowr; j++) {
-    /* create shifts of rows of matr */
+    // create shifts of rows of matr 
     data = (UInt *) ADDR_OBJ(shift[0]);
     datar = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(matr,j));
     for (k = 0; k < (ncolr+BIPEB-1)/BIPEB; k++)
       data[k] = datar[k];
     data[k] = 0;
     
-    for (i = 1; i < BIPEB; i++) { /* now shifts in [1..BIPEB-1] */
+    for (i = 1; i < BIPEB; i++) { // now shifts in [1..BIPEB-1] 
       data = (UInt *) ADDR_OBJ(shift[i]);
       datar = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(matr,j));
       data[0] = datar[0] << i;
@@ -4321,7 +4318,7 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
       for (k = 1; k <= ncoll; k++) {
 	l = 0;
 	if (CONST_BLOCK_ELM_GF2VEC(ELM_GF2MAT(matl,i),k) & MASK_POS_GF2VEC(k)) {
-	  /* append shift[ncol%BIPEB] to data */
+	  // append shift[ncol%BIPEB] to data 
 	  datar = (const UInt *) CONST_ADDR_OBJ(shift[ncol%BIPEB]);
 	  if (ncol % BIPEB) {
 	    data[-1] ^= *datar++;
@@ -4515,7 +4512,7 @@ static Int InitKernel (
   RNcoeffs = 0;
   RNrelns = 0;
 
-    /* import type functions                                               */
+    // import type functions                                               
     ImportGVarFromLibrary( "TYPE_LIST_GF2VEC",     &TYPE_LIST_GF2VEC     );
     ImportGVarFromLibrary( "TYPE_LIST_GF2VEC_IMM", &TYPE_LIST_GF2VEC_IMM );
     ImportGVarFromLibrary( "TYPE_LIST_GF2VEC_IMM_LOCKED", &TYPE_LIST_GF2VEC_IMM_LOCKED );
@@ -4524,16 +4521,16 @@ static Int InitKernel (
     ImportGVarFromLibrary( "TYPE_LIST_GF2MAT",     &TYPE_LIST_GF2MAT     );
     ImportGVarFromLibrary( "TYPE_LIST_GF2MAT_IMM", &TYPE_LIST_GF2MAT_IMM );
 
-    /* initialize one and zero of GF2                                      */
+    // initialize one and zero of GF2                                      
     ImportGVarFromLibrary( "GF2One",  &GF2One  );
     ImportGVarFromLibrary( "GF2Zero", &GF2Zero );
 
-    /* init filters and functions                                          */
+    // init filters and functions                                          
     InitHdlrFuncsFromTable( GVarFuncs );
 
     InitFopyGVar("IsLockedRepresentationVector", &IsLockedRepresentationVector);
 
-    /* return success                                                      */
+    // return success                                                      
     return 0;
 }
 
@@ -4545,10 +4542,10 @@ static Int InitKernel (
 static Int InitLibrary (
     StructInitInfo *    module )
 {
-    /* init filters and functions                                          */
+    // init filters and functions                                          
     InitGVarFuncsFromTable( GVarFuncs );
 
-    /* return success                                                      */
+    // return success                                                      
     return 0;
 }
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -105,16 +105,13 @@ Obj GF2Zero;
 *F * * * * * * * * * * * * arithmetic operations  * * * * * * * * * * * * * *
 */
 
-static inline void AddGF2VecToGF2Vec(
-  UInt *	ptS,
-  const UInt *	ptV,
-  UInt		len)
+static inline void AddGF2VecToGF2Vec(UInt * ptS, const UInt * ptV, UInt len)
 {
-  register UInt ct;
-  ct = (len+BIPEB-1)/BIPEB;
-  while ( ct-- ) {
-    *ptS++ ^= *ptV++;
-  }
+    register UInt ct;
+    ct = (len + BIPEB - 1) / BIPEB;
+    while (ct--) {
+        *ptS++ ^= *ptV++;
+    }
 }
 
 /****************************************************************************
@@ -126,42 +123,39 @@ static inline void AddGF2VecToGF2Vec(
 **  position of the rightmost Z(2) is returned.
 */
 
-UInt RightMostOneGF2Vec (
-    Obj                 vec )
+UInt RightMostOneGF2Vec(Obj vec)
 {
-    UInt                len;
+    UInt len;
 
     len = LEN_GF2VEC(vec);
-    while ( 0 < len ) {
-        if ( CONST_BLOCK_ELM_GF2VEC(vec,len) == 0 )
-	    len = BIPEB*((len-1)/BIPEB);
-        else if ( BLOCK_ELM_GF2VEC(vec,len) & MASK_POS_GF2VEC(len) )
+    while (0 < len) {
+        if (CONST_BLOCK_ELM_GF2VEC(vec, len) == 0)
+            len = BIPEB * ((len - 1) / BIPEB);
+        else if (BLOCK_ELM_GF2VEC(vec, len) & MASK_POS_GF2VEC(len))
             break;
-	else
-	  len--;
+        else
+            len--;
     }
     return len;
 }
 
 
-Obj AddCoeffsGF2VecGF2Vec (
-    Obj                 sum,
-    Obj                 vec )
+Obj AddCoeffsGF2VecGF2Vec(Obj sum, Obj vec)
 {
-    UInt *              ptS;
-    const UInt *        ptV;
-    UInt                len;
+    UInt *       ptS;
+    const UInt * ptV;
+    UInt         len;
 
-    // get the length                                                      
+    // get the length
     len = LEN_GF2VEC(vec);
-    
-    // grow <sum> is necessary                                             
-    if ( LEN_GF2VEC(sum) < len ) {
-        ResizeWordSizedBag( sum, SIZE_PLEN_GF2VEC(len) );
-        SET_LEN_GF2VEC( sum, len );
+
+    // grow <sum> is necessary
+    if (LEN_GF2VEC(sum) < len) {
+        ResizeWordSizedBag(sum, SIZE_PLEN_GF2VEC(len));
+        SET_LEN_GF2VEC(sum, len);
     }
 
-    // add <vec> to <sum>                                                  
+    // add <vec> to <sum>
     ptS = BLOCKS_GF2VEC(sum);
     ptV = CONST_BLOCKS_GF2VEC(vec);
     AddGF2VecToGF2Vec(ptS, ptV, len);
@@ -172,12 +166,12 @@ Obj AddCoeffsGF2VecGF2Vec (
 static inline void
 CopySection_GF2Vecs(Obj src, Obj dest, UInt smin, UInt dmin, UInt nelts)
 {
-    UInt   soff;
-    UInt   doff;
+    UInt         soff;
+    UInt         doff;
     const UInt * sptr;
-    UInt * dptr;
+    UInt *       dptr;
 
-    // switch to zero-based indices and find the first blocks and so on 
+    // switch to zero-based indices and find the first blocks and so on
     soff = (smin - 1) % BIPEB;
     doff = (dmin - 1) % BIPEB;
     sptr = CONST_BLOCKS_GF2VEC(src) + (smin - 1) / BIPEB;
@@ -196,76 +190,74 @@ CopySection_GF2Vecs(Obj src, Obj dest, UInt smin, UInt dmin, UInt nelts)
 **  the result in <sum>.
 **
 **  Note: The other entries are set to be zero. So use a higher value for <n>
-**        only for vectors, which both have leading zero-entries. 
+**        only for vectors, which both have leading zero-entries.
 **
 **  You  can use  the parameter  <n> for  example for  an  gauss-algorithm on
 **  gf2-matrices  can be  improved,  because when  using the gauss-algorithm,
 **  you  know that  the leading entries of two vectors to be  added are equal
-**  zero. If <n> = 1 all entries are added. 
+**  zero. If <n> = 1 all entries are added.
 **
-**  Note that the caller has to ensure, that <sum> is a gf2-vector with the 
+**  Note that the caller has to ensure, that <sum> is a gf2-vector with the
 **  correct size.
 */
-Obj AddPartialGF2VecGF2Vec (
-    Obj                 sum,
-    Obj                 vl,
-    Obj                 vr,
-    UInt                n )
+Obj AddPartialGF2VecGF2Vec(Obj sum, Obj vl, Obj vr, UInt n)
 {
-    const UInt *        ptL;            // bit field of <vl>               
-    const UInt *        ptR;            // bit field of <vr>               
-    UInt *              ptS;            // bit field of <sum>              
-    UInt *              end;            // end marker                      
-    UInt                len;            // length of the list              
-    UInt                offset;         // number of block to start adding 
-    UInt                x;
-    
+    const UInt * ptL;       // bit field of <vl>
+    const UInt * ptR;       // bit field of <vr>
+    UInt *       ptS;       // bit field of <sum>
+    UInt *       end;       // end marker
+    UInt         len;       // length of the list
+    UInt         offset;    // number of block to start adding
+    UInt         x;
 
-    // both operands lie in the same field                                 
+
+    // both operands lie in the same field
     len = LEN_GF2VEC(vl);
-    if ( len != LEN_GF2VEC(vr) ) {
-        ErrorMayQuit( "Vector +: vectors must have the same length",
-                   0L, 0L );
+    if (len != LEN_GF2VEC(vr)) {
+        ErrorMayQuit("Vector +: vectors must have the same length", 0L, 0L);
         return 0;
     }
 
 
-    // calculate the offset for adding                                     
-    if ( n == 1 ) {  
+    // calculate the offset for adding
+    if (n == 1) {
         ptL = CONST_BLOCKS_GF2VEC(vl);
         ptR = CONST_BLOCKS_GF2VEC(vr);
         ptS = BLOCKS_GF2VEC(sum);
-        end = ptS + ((len+BIPEB-1)/BIPEB);
-    } else {
-        offset = ( n - 1 ) / BIPEB;
-        ptL = CONST_BLOCKS_GF2VEC(vl) + offset ;
-        ptR = CONST_BLOCKS_GF2VEC(vr) + offset ;
-        ptS = BLOCKS_GF2VEC(sum) + offset ;
-        end = ptS + ((len+BIPEB-1)/BIPEB) - offset;
+        end = ptS + ((len + BIPEB - 1) / BIPEB);
     }
-    
-    // loop over the entries and add                                       
-    if (vl == sum)
-      while ( ptS < end )
-	{
-	  // maybe remove this condition 
-	  if ((x = *ptR)!= 0)
-	    *ptS = *ptL ^ x;
-	  ptL++; ptS++; ptR++;
-	}
-    else if (vr == sum)
-      while ( ptS < end )
-	{
-	  // maybe remove this condition 
-	  if ((x = *ptL) != 0)
-	    *ptS = *ptR ^ x;
-	  ptL++; ptS++; ptR++;
-	}
-    else
-      while (ptS < end )
-	*ptS++ = *ptL++ ^ *ptR++;
+    else {
+        offset = (n - 1) / BIPEB;
+        ptL = CONST_BLOCKS_GF2VEC(vl) + offset;
+        ptR = CONST_BLOCKS_GF2VEC(vr) + offset;
+        ptS = BLOCKS_GF2VEC(sum) + offset;
+        end = ptS + ((len + BIPEB - 1) / BIPEB) - offset;
+    }
 
-    // return the result                                                   
+    // loop over the entries and add
+    if (vl == sum)
+        while (ptS < end) {
+            // maybe remove this condition
+            if ((x = *ptR) != 0)
+                *ptS = *ptL ^ x;
+            ptL++;
+            ptS++;
+            ptR++;
+        }
+    else if (vr == sum)
+        while (ptS < end) {
+            // maybe remove this condition
+            if ((x = *ptL) != 0)
+                *ptS = *ptR ^ x;
+            ptL++;
+            ptS++;
+            ptR++;
+        }
+    else
+        while (ptS < end)
+            *ptS++ = *ptL++ ^ *ptR++;
+
+    // return the result
     return sum;
 }
 
@@ -284,72 +276,72 @@ Obj AddPartialGF2VecGF2Vec (
 */
 #ifdef SYS_IS_64_BIT
 
-#define PARITY_BLOCK(m) \
-  do { m = m ^ (m>>32); \
-       m = m ^ (m>>16); \
-       m = m ^ (m>>8);  \
-       m = m ^ (m>>4);  \
-       m = m ^ (m>>2);  \
-       m = m ^ (m>>1);  \
-  } while(0)
+#define PARITY_BLOCK(m)                                                      \
+    do {                                                                     \
+        m = m ^ (m >> 32);                                                   \
+        m = m ^ (m >> 16);                                                   \
+        m = m ^ (m >> 8);                                                    \
+        m = m ^ (m >> 4);                                                    \
+        m = m ^ (m >> 2);                                                    \
+        m = m ^ (m >> 1);                                                    \
+    } while (0)
 
 #else
 
-#define PARITY_BLOCK(m) \
-  do { m = m ^ (m>>16); \
-       m = m ^ (m>>8);  \
-       m = m ^ (m>>4);  \
-       m = m ^ (m>>2);  \
-       m = m ^ (m>>1);  \
-  } while(0)
+#define PARITY_BLOCK(m)                                                      \
+    do {                                                                     \
+        m = m ^ (m >> 16);                                                   \
+        m = m ^ (m >> 8);                                                    \
+        m = m ^ (m >> 4);                                                    \
+        m = m ^ (m >> 2);                                                    \
+        m = m ^ (m >> 1);                                                    \
+    } while (0)
 
 #endif
 
-Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
+Obj ProdGF2VecGF2Vec(Obj vl, Obj vr)
 {
-    const UInt *        ptL;            // bit field of <vl>               
-    const UInt *        ptR;            // bit field of <vr>               
-    UInt                lenL;           // length of the list              
-    UInt                lenR;           // length of the list              
-    UInt                len;            // minimum of the lengths          
-    UInt                nrb;            // number of whole blocks to use   
-    UInt                m;              // number of bits in a block       
-    UInt                n;              // number of bits in blist         
-    UInt                i;              // loop variable                   
-    UInt                mask;           // bit selecting mask              
+    const UInt * ptL;     // bit field of <vl>
+    const UInt * ptR;     // bit field of <vr>
+    UInt         lenL;    // length of the list
+    UInt         lenR;    // length of the list
+    UInt         len;     // minimum of the lengths
+    UInt         nrb;     // number of whole blocks to use
+    UInt         m;       // number of bits in a block
+    UInt         n;       // number of bits in blist
+    UInt         i;       // loop variable
+    UInt         mask;    // bit selecting mask
 
-    // both operands lie in the same field                                 
+    // both operands lie in the same field
     lenL = LEN_GF2VEC(vl);
     lenR = LEN_GF2VEC(vr);
     len = (lenL < lenR) ? lenL : lenR;
-    
-    if ( len == 0 ) {
-      ErrorMayQuit(
-        "Vector *: both vectors must have at least one entry",
-        (Int)0, (Int)0 );
-      return 0;
+
+    if (len == 0) {
+        ErrorMayQuit("Vector *: both vectors must have at least one entry",
+                     (Int)0, (Int)0);
+        return 0;
     }
 
-    // loop over the entries and multiply                                  
+    // loop over the entries and multiply
     ptL = CONST_BLOCKS_GF2VEC(vl);
     ptR = CONST_BLOCKS_GF2VEC(vr);
-    nrb = len /BIPEB;
-    n   = 0;
-    for ( i = nrb;  i > 0;  i-- ) {
+    nrb = len / BIPEB;
+    n = 0;
+    for (i = nrb; i > 0; i--) {
         m = (*ptL++) & (*ptR++);
         PARITY_BLOCK(m);
         n ^= m;
     }
-    // now process the remaining bits 
+    // now process the remaining bits
 
     mask = 1;
-    for (i = 0; i < len % BIPEB; i++)
-      {
-	n ^= (mask & *ptL & *ptR) >> i;
-	mask <<= 1;
-      }
+    for (i = 0; i < len % BIPEB; i++) {
+        n ^= (mask & *ptL & *ptR) >> i;
+        mask <<= 1;
+    }
 
-    // return the result                                                   
+    // return the result
     return (n & 1) ? GF2One : GF2Zero;
 }
 
@@ -363,57 +355,60 @@ Obj ProdGF2VecGF2Vec ( Obj vl, Obj vr )
 **  multiplied by the corresponding entry of <vl>.  Note that the  caller has
 **  to ensure, that <vl> is a gf2-vector and <vr> is a gf2-matrix.
 */
-Obj ProdGF2VecGF2Mat ( Obj vl, Obj vr )
+Obj ProdGF2VecGF2Mat(Obj vl, Obj vr)
 {
-    UInt                len;            // length of the list              
-    UInt                stop;
-    UInt                col;            // length of the rows              
-    UInt                i;              // loop variables                  
-    Obj                 prod;           // product, result                 
-    Obj                 row1;           // top row of matrix               
-    UInt *              start;
-    const UInt *        ptL;
-    UInt                mask;
-    
-    // both operands lie in the same field                                 
+    UInt         len;    // length of the list
+    UInt         stop;
+    UInt         col;     // length of the rows
+    UInt         i;       // loop variables
+    Obj          prod;    // product, result
+    Obj          row1;    // top row of matrix
+    UInt *       start;
+    const UInt * ptL;
+    UInt         mask;
+
+    // both operands lie in the same field
     len = LEN_GF2VEC(vl);
     if (len > LEN_GF2MAT(vr))
-      len = LEN_GF2MAT(vr);
-    
-    // make the result vector                                              
-    row1 = ELM_GF2MAT( vr, 1 );
-    col = LEN_GF2VEC( row1 );
-    NEW_GF2VEC( prod, (IS_MUTABLE_OBJ(vl) || IS_MUTABLE_OBJ(row1)) ? 
-		TYPE_LIST_GF2VEC : TYPE_LIST_GF2VEC_IMM, col );
-    
-    // get the start and end block                                         
+        len = LEN_GF2MAT(vr);
+
+    // make the result vector
+    row1 = ELM_GF2MAT(vr, 1);
+    col = LEN_GF2VEC(row1);
+    NEW_GF2VEC(prod,
+               (IS_MUTABLE_OBJ(vl) || IS_MUTABLE_OBJ(row1))
+                   ? TYPE_LIST_GF2VEC
+                   : TYPE_LIST_GF2VEC_IMM,
+               col);
+
+    // get the start and end block
     start = BLOCKS_GF2VEC(prod);
-    ptL   = CONST_BLOCKS_GF2VEC(vl);
+    ptL = CONST_BLOCKS_GF2VEC(vl);
 
-    // loop over the vector                                                
-    for ( i = 1;  i <= len;  ptL++ )  {
+    // loop over the vector
+    for (i = 1; i <= len; ptL++) {
 
-        // if the whole block is zero, get the next entry                  
+        // if the whole block is zero, get the next entry
         if (*ptL == 0) {
             i += BIPEB;
             continue;
         }
-        
-        // run through the block                                           
-        stop = i + BIPEB - 1;
-        if ( len < stop )
-            stop = len;
-        for ( mask = 1;  i <= stop;  i++, mask <<= 1 ) {
 
-            // if there is entry add the row to the result                 
-            if ( (*ptL & mask) != 0 ) {
-                const UInt * ptRR = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(vr,i));
-		AddGF2VecToGF2Vec(start, ptRR, col);
+        // run through the block
+        stop = i + BIPEB - 1;
+        if (len < stop)
+            stop = len;
+        for (mask = 1; i <= stop; i++, mask <<= 1) {
+
+            // if there is entry add the row to the result
+            if ((*ptL & mask) != 0) {
+                const UInt * ptRR = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(vr, i));
+                AddGF2VecToGF2Vec(start, ptRR, col);
             }
         }
     }
 
-    // return the result                                                   
+    // return the result
     return prod;
 }
 
@@ -428,62 +423,64 @@ Obj ProdGF2VecGF2Mat ( Obj vl, Obj vr )
 **  Note that the  caller has
 **  to ensure, that <ml> is a GF2 matrix and <vr> is a GF2 vector.
 */
-Obj ProdGF2MatGF2Vec ( Obj ml, Obj vr )
+Obj ProdGF2MatGF2Vec(Obj ml, Obj vr)
 {
-    UInt                len;            // length of the vector            
-    UInt                ln1;            // length of the rows of the mx    
-    UInt                ln2;            // length of the matrix            
-    const UInt *        ptL;            // bit field of <ml>[j]            
-    const UInt *        ptR;            // bit field of <vr>               
-    UInt                nrb;            // number of blocks in blist       
-    UInt                m;              // number of bits in a block       
-    UInt                n;              // number of bits in blist         
-    UInt                i;              // loop variable                   
-    UInt                j;              // loop variable                   
-    Obj                 prod;           // result                          
-    UInt                mask;           // a one bit mask 
-    
-    // both operands lie in the same field                                 
+    UInt         len;     // length of the vector
+    UInt         ln1;     // length of the rows of the mx
+    UInt         ln2;     // length of the matrix
+    const UInt * ptL;     // bit field of <ml>[j]
+    const UInt * ptR;     // bit field of <vr>
+    UInt         nrb;     // number of blocks in blist
+    UInt         m;       // number of bits in a block
+    UInt         n;       // number of bits in blist
+    UInt         i;       // loop variable
+    UInt         j;       // loop variable
+    Obj          prod;    // result
+    UInt         mask;    // a one bit mask
+
+    // both operands lie in the same field
     len = LEN_GF2VEC(vr);
     ln2 = LEN_GF2MAT(ml);
-    if ( 0 == ln2 ) {
-      ErrorMayQuit("PROD: empty GF2 matrix * GF2 vector not allowed",0,0);
+    if (0 == ln2) {
+        ErrorMayQuit("PROD: empty GF2 matrix * GF2 vector not allowed", 0, 0);
     }
 
-    ln1 = LEN_GF2VEC(ELM_GF2MAT(ml,1));
-    if ( len > ln1 ) {
-      len = ln1;
+    ln1 = LEN_GF2VEC(ELM_GF2MAT(ml, 1));
+    if (len > ln1) {
+        len = ln1;
     }
 
-    // make the result vector                                              
-    NEW_GF2VEC( prod, (IS_MUTABLE_OBJ(ELM_GF2MAT(ml,1)) || IS_MUTABLE_OBJ(vr)) ? 
-		TYPE_LIST_GF2VEC :TYPE_LIST_GF2VEC_IMM, ln2 );
+    // make the result vector
+    NEW_GF2VEC(prod,
+               (IS_MUTABLE_OBJ(ELM_GF2MAT(ml, 1)) || IS_MUTABLE_OBJ(vr))
+                   ? TYPE_LIST_GF2VEC
+                   : TYPE_LIST_GF2VEC_IMM,
+               ln2);
 
-    // loop over the entries and multiply                                  
-    nrb = len/BIPEB;
-    for ( j = 1;  j <= ln2;  j++ ) {
-        ptL = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml,j));
+    // loop over the entries and multiply
+    nrb = len / BIPEB;
+    for (j = 1; j <= ln2; j++) {
+        ptL = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml, j));
         ptR = CONST_BLOCKS_GF2VEC(vr);
-        n   = 0;
-        for ( i = 1;  i <= nrb;  i++ ) {
+        n = 0;
+        for (i = 1; i <= nrb; i++) {
             m = (*ptL++) & (*ptR++);
             PARITY_BLOCK(m);
             n ^= m;
         }
 
-	mask = 1;
-	for (i = 0; i < len % BIPEB; i++)
-	  {
-	    n ^= (mask & *ptL & *ptR) >> i;
-	    mask <<= 1;
-	  }
+        mask = 1;
+        for (i = 0; i < len % BIPEB; i++) {
+            n ^= (mask & *ptL & *ptR) >> i;
+            mask <<= 1;
+        }
 
-	
-        if ( n & 1 )
-            BLOCK_ELM_GF2VEC(prod,j) |= MASK_POS_GF2VEC(j);
+
+        if (n & 1)
+            BLOCK_ELM_GF2VEC(prod, j) |= MASK_POS_GF2VEC(j);
     }
 
-    // return the result                                                   
+    // return the result
     return prod;
 }
 
@@ -501,45 +498,43 @@ Obj ProdGF2MatGF2Vec ( Obj ml, Obj vr )
 **  must be compatible.
 */
 
-Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
+Obj ProdGF2MatGF2MatSimple(Obj ml, Obj mr)
 {
-  Obj prod;
-  UInt i;
-  UInt len;
-  Obj row;
-  Obj rtype;
-  len = LEN_GF2MAT(ml);
-  prod = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(len));
-  SET_LEN_GF2MAT(prod,len);
-  if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr))
-    {
-      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT);
-      if (IS_MUTABLE_OBJ(ELM_GF2MAT(ml,1)) || IS_MUTABLE_OBJ(ELM_GF2MAT(mr,1)))
-	rtype = TYPE_LIST_GF2VEC_LOCKED;
-      else
-	rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
+    Obj  prod;
+    UInt i;
+    UInt len;
+    Obj  row;
+    Obj  rtype;
+    len = LEN_GF2MAT(ml);
+    prod = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(len));
+    SET_LEN_GF2MAT(prod, len);
+    if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr)) {
+        SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT);
+        if (IS_MUTABLE_OBJ(ELM_GF2MAT(ml, 1)) ||
+            IS_MUTABLE_OBJ(ELM_GF2MAT(mr, 1)))
+            rtype = TYPE_LIST_GF2VEC_LOCKED;
+        else
+            rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
-  else
-    {
-      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT_IMM);
-      rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
+    else {
+        SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT_IMM);
+        rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
-  for (i = 1; i <= len; i++)
-    {
-      row = ProdGF2VecGF2Mat(ELM_GF2MAT(ml,i),mr);
+    for (i = 1; i <= len; i++) {
+        row = ProdGF2VecGF2Mat(ELM_GF2MAT(ml, i), mr);
 
-      // Since I'm going to put this vector into a matrix, I must lock its
-	  // representation, so that it doesn't get rewritten over GF(2^k)
-      SetTypeDatObj(row, rtype);
-      SET_ELM_GF2MAT(prod,i,row);
-      CHANGED_BAG(prod);
-      TakeInterrupt();
+        // Since I'm going to put this vector into a matrix, I must lock its
+        // representation, so that it doesn't get rewritten over GF(2^k)
+        SetTypeDatObj(row, rtype);
+        SET_ELM_GF2MAT(prod, i, row);
+        CHANGED_BAG(prod);
+        TakeInterrupt();
     }
-  return prod;
+    return prod;
 }
 
 
-// Utility functions for the advanced matrix multiply code below 
+// Utility functions for the advanced matrix multiply code below
 
 
 // extract nbits bits starting from position from in vector vptr
@@ -548,296 +543,285 @@ Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
 
 static inline UInt getbits(const UInt * vptr, UInt from, UInt nbits)
 {
-  UInt wno = (from  -1)/BIPEB;
-  UInt word1 = vptr[wno];
-  UInt shift1 = (from -1)% BIPEB;
-  UInt lbit = shift1 + nbits;
-  UInt word2;
-  if (lbit <= BIPEB)
-    {
-      // range is all in one word 
-      word1 <<= BIPEB -lbit;
-      word1 >>= BIPEB - nbits;
+    UInt wno = (from - 1) / BIPEB;
+    UInt word1 = vptr[wno];
+    UInt shift1 = (from - 1) % BIPEB;
+    UInt lbit = shift1 + nbits;
+    UInt word2;
+    if (lbit <= BIPEB) {
+        // range is all in one word
+        word1 <<= BIPEB - lbit;
+        word1 >>= BIPEB - nbits;
     }
-  else
-    {
-      // range is split across two words 
-      word1 >>= shift1;
-      lbit -= BIPEB;
-      word2 = vptr[wno+1];
-      word2 <<= BIPEB-lbit;
-      word2 >>= shift1-lbit;
-      word1 |= word2;
+    else {
+        // range is split across two words
+        word1 >>= shift1;
+        lbit -= BIPEB;
+        word2 = vptr[wno + 1];
+        word2 <<= BIPEB - lbit;
+        word2 >>= shift1 - lbit;
+        word1 |= word2;
     }
-  return word1;
+    return word1;
 }
 
 // To avoid having a lot of arguments to the recursive getgreasedata function,
-// we put the things that don't change in the recursive call into this structure
+// we put the things that don't change in the recursive call into this
+// structure
 
 struct greaseinfo {
-  UInt *pgtags;
-  UInt *pgbuf;
-  UInt nblocks;
-  UInt *pgrules;
-  const UInt **prrows;
+    UInt *        pgtags;
+    UInt *        pgbuf;
+    UInt          nblocks;
+    UInt *        pgrules;
+    const UInt ** prrows;
 };
-
 
 
 // Make if necessary the grease row for bits controlled by the data in g.
 // Recursive so can't be inlined
-static const UInt * getgreasedata( struct greaseinfo *g, UInt bits)
-{ 
-  UInt x,y;
-  const UInt *ps;
-  UInt *pd;
-  const UInt *ps2;
-  UInt i;
-  UInt *pd1;
-  switch(g->pgtags[bits])
-    {
+static const UInt * getgreasedata(struct greaseinfo * g, UInt bits)
+{
+    UInt         x, y;
+    const UInt * ps;
+    UInt *       pd;
+    const UInt * ps2;
+    UInt         i;
+    UInt *       pd1;
+    switch (g->pgtags[bits]) {
     case 0:
-      // Need to make the row 
-      x = g->pgrules[bits];
-      y = bits ^ (1 << x);
-      // make it by adding row x to grease vector indexed y 
-      ps =g->prrows[x];
-      ps2 = getgreasedata(g,y);
-      pd1 = g->pgbuf + (bits-3)*g->nblocks;
-      pd = pd1;
-      // time critical inner loop 
-      for (i = g->nblocks; i > 0; i--)
-	*pd++ = *ps++ ^ *ps2++;
-      // record that we made it 
-      g->pgtags[bits] = 1;
-      return pd1;
+        // Need to make the row
+        x = g->pgrules[bits];
+        y = bits ^ (1 << x);
+        // make it by adding row x to grease vector indexed y
+        ps = g->prrows[x];
+        ps2 = getgreasedata(g, y);
+        pd1 = g->pgbuf + (bits - 3) * g->nblocks;
+        pd = pd1;
+        // time critical inner loop
+        for (i = g->nblocks; i > 0; i--)
+            *pd++ = *ps++ ^ *ps2++;
+        // record that we made it
+        g->pgtags[bits] = 1;
+        return pd1;
 
     case 1:
-      // we've made this one already, so just return it 
-      return  g->pgbuf + (bits-3)*g->nblocks;
+        // we've made this one already, so just return it
+        return g->pgbuf + (bits - 3) * g->nblocks;
 
     case 2:
-      // This one does not need making, bits actually
-       // has just a single 1 bit in it
-      return g->prrows[g->pgrules[bits]];
-
+        // This one does not need making, bits actually
+        // has just a single 1 bit in it
+        return g->prrows[g->pgrules[bits]];
     }
-  return (UInt *)0;		// can't actually get here; include the return to pacify compiler
+    return (UInt *)0;    // can't actually get here; include the return to
+                         // pacify compiler
 }
 
 
-
-Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
+Obj ProdGF2MatGF2MatAdvanced(Obj ml, Obj mr, UInt greasesize, UInt blocksize)
 {
-  Obj prod;			// Product Matrix 
-  UInt i,j, k, b;		// Loop counters 
-  UInt gs;			// Actual level of grease for current block 
-  const UInt *rptr;		// Pointer to current row of ml 
-  UInt bits;			// current chunk of current row, for lookup in grease tables 
-  const UInt *v;		// pointer to computed grease vector 
-  UInt len, rlen, ilen;		// len = length of ml, ilen = row length of ml = length of mr, rlen = row length of mr 
-  Obj row;			// current row of ml, or row of prod when it is being built 
-  Obj rtype;			// type of rows of prod 
-  Obj gbuf = (Obj)0;		// grease buffer 
-  Obj gtags = (Obj) 0;		// grease tags (whether that row is known yet 
-  Obj grules = (Obj) 0;		// rules for making new grease vectors 
-  UInt *pgrules;		// pointer to contents of grules
-  UInt *pgtags = (UInt *)0;	// pointer to contents of gtags 
-  UInt *pgbuf = (UInt *)0;	// pointer to grease buffer 
-  UInt nwords;			// number of words in a row of mr 
-  UInt glen;			// 1 << greasesize 
-  UInt bs;			// actual size of current block 
-  UInt *pprow;			// pointer into current row of prod 
-  Obj lrowptrs;			// cache of direct pointers to rows of ml 
-  const UInt **plrows;		// and a direct pointer to that cache 
-  Obj rrowptrs;			// and for mr 
-  const UInt **prrows;
-  Obj prowptrs;			// and for prod 
-  UInt **pprows;
-  struct greaseinfo g;
-  
-  len = LEN_GF2MAT(ml);
-  row = ELM_GF2MAT(mr, 1);
-  rlen = LEN_GF2VEC(row);
-  ilen = LEN_GF2MAT(mr);
-  nwords = NUMBER_BLOCKS_GF2VEC(row);
-  
-  // Make a zero product matrix 
-  prod = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(len));
-  SET_LEN_GF2MAT(prod,len);
-  if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr))
-    {
-      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT);
-      if (IS_MUTABLE_OBJ(ELM_GF2MAT(ml,1)) || IS_MUTABLE_OBJ(ELM_GF2MAT(mr,1)))
-	rtype = TYPE_LIST_GF2VEC_LOCKED;
-      else
-	rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
-    }
-  else
-    {
-      SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT_IMM);
-      rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
-    }
+    Obj          prod;          // Product Matrix
+    UInt         i, j, k, b;    // Loop counters
+    UInt         gs;            // Actual level of grease for current block
+    const UInt * rptr;          // Pointer to current row of ml
+    UInt bits;    // current chunk of current row, for lookup in grease tables
+    const UInt * v;          // pointer to computed grease vector
+    UInt len, rlen, ilen;    // len = length of ml, ilen = row length of ml =
+                             // length of mr, rlen = row length of mr
+    Obj    row;    // current row of ml, or row of prod when it is being built
+    Obj    rtype;              // type of rows of prod
+    Obj    gbuf = (Obj)0;      // grease buffer
+    Obj    gtags = (Obj)0;     // grease tags (whether that row is known yet
+    Obj    grules = (Obj)0;    // rules for making new grease vectors
+    UInt * pgrules;            // pointer to contents of grules
+    UInt * pgtags = (UInt *)0;     // pointer to contents of gtags
+    UInt * pgbuf = (UInt *)0;      // pointer to grease buffer
+    UInt   nwords;                 // number of words in a row of mr
+    UInt   glen;                   // 1 << greasesize
+    UInt   bs;                     // actual size of current block
+    UInt * pprow;                  // pointer into current row of prod
+    Obj    lrowptrs;               // cache of direct pointers to rows of ml
+    const UInt **     plrows;      // and a direct pointer to that cache
+    Obj               rrowptrs;    // and for mr
+    const UInt **     prrows;
+    Obj               prowptrs;    // and for prod
+    UInt **           pprows;
+    struct greaseinfo g;
 
+    len = LEN_GF2MAT(ml);
+    row = ELM_GF2MAT(mr, 1);
+    rlen = LEN_GF2VEC(row);
+    ilen = LEN_GF2MAT(mr);
+    nwords = NUMBER_BLOCKS_GF2VEC(row);
 
-  for (i = 1; i <= len; i++)
-    {
-      NEW_GF2VEC(row, rtype, rlen);
-      SET_ELM_GF2MAT(prod,i,row);
-      CHANGED_BAG(prod);
+    // Make a zero product matrix
+    prod = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(len));
+    SET_LEN_GF2MAT(prod, len);
+    if (IS_MUTABLE_OBJ(ml) || IS_MUTABLE_OBJ(mr)) {
+        SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT);
+        if (IS_MUTABLE_OBJ(ELM_GF2MAT(ml, 1)) ||
+            IS_MUTABLE_OBJ(ELM_GF2MAT(mr, 1)))
+            rtype = TYPE_LIST_GF2VEC_LOCKED;
+        else
+            rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
+    }
+    else {
+        SET_TYPE_POSOBJ(prod, TYPE_LIST_GF2MAT_IMM);
+        rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
 
-  // Cap greasesize and blocksize by the actual length  
-  if (ilen < greasesize)
-    greasesize = ilen;
-  if (ilen < greasesize*blocksize)
-    blocksize = (ilen + greasesize-1)/greasesize;
 
-
-  // calculate glen
-  glen = 1 << greasesize;
-  
-  // Allocate memory 
-
-  lrowptrs = NewBag(T_DATOBJ, sizeof(UInt *)*len);
-  rrowptrs = NewBag(T_DATOBJ, sizeof(UInt *)*ilen);
-  prowptrs = NewBag(T_DATOBJ, sizeof(UInt *)*len);
-  
-  if (greasesize >= 2)
-    {
-      gbuf = NewBag(T_DATOBJ, sizeof(UInt)*nwords*(glen-3)*blocksize);
-      gtags = NewBag(T_DATOBJ, sizeof(UInt)* glen*blocksize);
-      grules = NewBag(T_DATOBJ, sizeof(Int)* glen);
-      
-      
-      // From here no garbage collections 
-      
-      pgtags = (UInt *)ADDR_OBJ(gtags);
-      pgrules = (UInt *)ADDR_OBJ(grules);
-      pgbuf = (UInt *)ADDR_OBJ(gbuf);
-      
-
-      // Calculate the greasing rules 
-      for (j = 3; j < glen; j++)
-	for (i = 0; i < greasesize; i++)
-	  if ((j & (1 << i)) != 0)
-	    {
-	      pgrules[j] = i;
-	      break;
-	    }
-      for (j = 0; j < greasesize; j++)
-	pgrules[1<<j] = j;
-
-      // fill in some more bits of g 
-      g.pgrules = pgrules;
-      g.nblocks = nwords;
+    for (i = 1; i <= len; i++) {
+        NEW_GF2VEC(row, rtype, rlen);
+        SET_ELM_GF2MAT(prod, i, row);
+        CHANGED_BAG(prod);
     }
 
-  // Take direct pointers to all the parts of all the matrices to avoid
-  // multiple indirection overheads
-  plrows = (const UInt **)CONST_ADDR_OBJ(lrowptrs);
-  prrows = (const UInt **)CONST_ADDR_OBJ(rrowptrs);
-  pprows = (UInt **)ADDR_OBJ(prowptrs);
+    // Cap greasesize and blocksize by the actual length
+    if (ilen < greasesize)
+        greasesize = ilen;
+    if (ilen < greasesize * blocksize)
+        blocksize = (ilen + greasesize - 1) / greasesize;
 
-  for (i = 0; i < len; i++)
-    {
-      plrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml,i+1));
-      pprows[i] = BLOCKS_GF2VEC(ELM_GF2MAT(prod, i+1));
+
+    // calculate glen
+    glen = 1 << greasesize;
+
+    // Allocate memory
+
+    lrowptrs = NewBag(T_DATOBJ, sizeof(UInt *) * len);
+    rrowptrs = NewBag(T_DATOBJ, sizeof(UInt *) * ilen);
+    prowptrs = NewBag(T_DATOBJ, sizeof(UInt *) * len);
+
+    if (greasesize >= 2) {
+        gbuf =
+            NewBag(T_DATOBJ, sizeof(UInt) * nwords * (glen - 3) * blocksize);
+        gtags = NewBag(T_DATOBJ, sizeof(UInt) * glen * blocksize);
+        grules = NewBag(T_DATOBJ, sizeof(Int) * glen);
+
+
+        // From here no garbage collections
+
+        pgtags = (UInt *)ADDR_OBJ(gtags);
+        pgrules = (UInt *)ADDR_OBJ(grules);
+        pgbuf = (UInt *)ADDR_OBJ(gbuf);
+
+
+        // Calculate the greasing rules
+        for (j = 3; j < glen; j++)
+            for (i = 0; i < greasesize; i++)
+                if ((j & (1 << i)) != 0) {
+                    pgrules[j] = i;
+                    break;
+                }
+        for (j = 0; j < greasesize; j++)
+            pgrules[1 << j] = j;
+
+        // fill in some more bits of g
+        g.pgrules = pgrules;
+        g.nblocks = nwords;
     }
-  for (i = 0; i < ilen; i++)
-    prrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mr, i+1));
 
+    // Take direct pointers to all the parts of all the matrices to avoid
+    // multiple indirection overheads
+    plrows = (const UInt **)CONST_ADDR_OBJ(lrowptrs);
+    prrows = (const UInt **)CONST_ADDR_OBJ(rrowptrs);
+    pprows = (UInt **)ADDR_OBJ(prowptrs);
 
-  // OK, finally ready to start work 
-  // loop over blocks 
-  for (b = 1; b <= ilen; b += blocksize*greasesize)
-    {
-      // last block may be a small one 
-      bs = blocksize;
-      if ((b + bs*greasesize) > ilen)
-	bs = (ilen - b + greasesize)/greasesize;
-
-      // If we're greasing, start afresh 
-      if (greasesize > 1)
-	{
-	  for (k = 0; k < bs; k++)
-	    {
-	      for (j = 0; j < 1 << greasesize; j++)
-		pgtags[k*glen+j] = 0;
-	      // powers of 2 correspond to rows of mr 
-	      for (j =0; j < greasesize; j++)
-		pgtags[k*glen+ (1<<j)] = 2;
-	    }
-	}
-      
-      // For each block, we run through rows of ml & prod 
-      for (j = 1; j <= len; j++)
-	{
-	  // get pointers 
-	  rptr = plrows[j-1];
-	  pprow = pprows[j-1];
-
-	  // Now within the block, we have multiple grease-units, run through them 
-	  for (i = 0; i < bs; i++)
-	    {
-	      // start of current grease unit 	     
-	      k = b + i*greasesize;
-
-	      // last unit of last block may be short 
-	      gs = greasesize;
-	      if (k+gs > ilen)
-		gs = ilen - k +1;
-
-	      // find the appropriate parts of grease tags
-		 // grease buffer and mr. Store in g
-	      
-	      if (gs > 1)
-		{
-		  g.pgtags = pgtags + glen*i;
-		  g.pgbuf = pgbuf + (glen-3)*nwords*i;
-		  g.prrows = prrows + k -1;
-		}
-
-	      // get a chunk from a row of ml 
-	      bits = getbits(rptr, k, gs);
-
-	      // 0 means nothing to do 
-	      if (bits == 0)
-		continue;
-	      else if (bits == 1) // handle this one specially to speed up the greaselevel 1 case 
-		v = prrows[k-1]; // -1 is because k is 1-based index 
-	      else
-		v = getgreasedata(&g,bits); // The main case 
-				// This function should be inlined 
-	      AddGF2VecToGF2Vec(pprow, v,  rlen);  
-	    }  
-	  }
-	
-      // Allow GAP to respond to Ctrl-C 
-      if (TakeInterrupt()) {
-	// Might have been a garbage collection, reload everything 
-	if (greasesize >= 2) {
-	  pgtags = (UInt *)ADDR_OBJ(gtags);
-	  pgrules = (UInt *)ADDR_OBJ(grules);
-	  pgbuf = (UInt *)ADDR_OBJ(gbuf);
-	  // fill in some more bits of g 
-	  g.pgrules = pgrules;
-	  g.nblocks = nwords;
-	}
-	plrows = (const UInt **)CONST_ADDR_OBJ(lrowptrs);
-	prrows = (const UInt **)CONST_ADDR_OBJ(rrowptrs);
-	pprows = (UInt **)ADDR_OBJ(prowptrs);
-	for (i = 0; i < len; i++)
-	  {
-	    plrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml,i+1));
-	    pprows[i] = BLOCKS_GF2VEC(ELM_GF2MAT(prod, i+1));
-	  }
-	for (i = 0; i < ilen; i++)
-	  prrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mr, i+1));
-      }
+    for (i = 0; i < len; i++) {
+        plrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml, i + 1));
+        pprows[i] = BLOCKS_GF2VEC(ELM_GF2MAT(prod, i + 1));
     }
-  return prod;
+    for (i = 0; i < ilen; i++)
+        prrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mr, i + 1));
+
+
+    // OK, finally ready to start work
+    // loop over blocks
+    for (b = 1; b <= ilen; b += blocksize * greasesize) {
+        // last block may be a small one
+        bs = blocksize;
+        if ((b + bs * greasesize) > ilen)
+            bs = (ilen - b + greasesize) / greasesize;
+
+        // If we're greasing, start afresh
+        if (greasesize > 1) {
+            for (k = 0; k < bs; k++) {
+                for (j = 0; j < 1 << greasesize; j++)
+                    pgtags[k * glen + j] = 0;
+                // powers of 2 correspond to rows of mr
+                for (j = 0; j < greasesize; j++)
+                    pgtags[k * glen + (1 << j)] = 2;
+            }
+        }
+
+        // For each block, we run through rows of ml & prod
+        for (j = 1; j <= len; j++) {
+            // get pointers
+            rptr = plrows[j - 1];
+            pprow = pprows[j - 1];
+
+            // Now within the block, we have multiple grease-units, run
+            // through them
+            for (i = 0; i < bs; i++) {
+                // start of current grease unit
+                k = b + i * greasesize;
+
+                // last unit of last block may be short
+                gs = greasesize;
+                if (k + gs > ilen)
+                    gs = ilen - k + 1;
+
+                // find the appropriate parts of grease tags
+                // grease buffer and mr. Store in g
+
+                if (gs > 1) {
+                    g.pgtags = pgtags + glen * i;
+                    g.pgbuf = pgbuf + (glen - 3) * nwords * i;
+                    g.prrows = prrows + k - 1;
+                }
+
+                // get a chunk from a row of ml
+                bits = getbits(rptr, k, gs);
+
+                // 0 means nothing to do
+                if (bits == 0)
+                    continue;
+                else if (bits == 1)    // handle this one specially to speed
+                                       // up the greaselevel 1 case
+                    v = prrows[k - 1];    // -1 is because k is 1-based index
+                else
+                    v = getgreasedata(
+                        &g, bits);    // The main case
+                                      // This function should be inlined
+                AddGF2VecToGF2Vec(pprow, v, rlen);
+            }
+        }
+
+        // Allow GAP to respond to Ctrl-C
+        if (TakeInterrupt()) {
+            // Might have been a garbage collection, reload everything
+            if (greasesize >= 2) {
+                pgtags = (UInt *)ADDR_OBJ(gtags);
+                pgrules = (UInt *)ADDR_OBJ(grules);
+                pgbuf = (UInt *)ADDR_OBJ(gbuf);
+                // fill in some more bits of g
+                g.pgrules = pgrules;
+                g.nblocks = nwords;
+            }
+            plrows = (const UInt **)CONST_ADDR_OBJ(lrowptrs);
+            prrows = (const UInt **)CONST_ADDR_OBJ(rrowptrs);
+            pprows = (UInt **)ADDR_OBJ(prowptrs);
+            for (i = 0; i < len; i++) {
+                plrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(ml, i + 1));
+                pprows[i] = BLOCKS_GF2VEC(ELM_GF2MAT(prod, i + 1));
+            }
+            for (i = 0; i < ilen; i++)
+                prrows[i] = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mr, i + 1));
+        }
+    }
+    return prod;
 }
 
 /****************************************************************************
@@ -848,43 +832,42 @@ Obj ProdGF2MatGF2MatAdvanced( Obj ml, Obj mr, UInt greasesize , UInt blocksize)
 */
 Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 {
-  Obj res;
-  UInt len;
-  UInt len1;
-  Obj row1;
-  UInt i;
-  UInt block = 0;
-  
-  len = LEN_GF2VEC(vec);
-  if (len > LEN_PLIST(mat))
-    len = LEN_PLIST(mat);
+    Obj  res;
+    UInt len;
+    UInt len1;
+    Obj  row1;
+    UInt i;
+    UInt block = 0;
 
-  // Get the first row, to establish the size of the result 
-  row1 = ELM_PLIST(mat,1);  
-  if (! IS_GF2VEC_REP(row1))
-    return TRY_NEXT_METHOD;
-  len1 = LEN_GF2VEC(row1);
+    len = LEN_GF2VEC(vec);
+    if (len > LEN_PLIST(mat))
+        len = LEN_PLIST(mat);
 
-  // create the result space 
-  NEW_GF2VEC( res,
-	      (IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1)) ? TYPE_LIST_GF2VEC : TYPE_LIST_GF2VEC_IMM,
-	      len1);
+    // Get the first row, to establish the size of the result
+    row1 = ELM_PLIST(mat, 1);
+    if (!IS_GF2VEC_REP(row1))
+        return TRY_NEXT_METHOD;
+    len1 = LEN_GF2VEC(row1);
 
-  // Finally, we start work 
-  for (i = 1; i <= len; i++)
-    {
-      if (i % BIPEB == 1)
-	block = CONST_BLOCK_ELM_GF2VEC(vec,i);
-      if (block & MASK_POS_GF2VEC(i))
-     	{
-	  row1 = ELM_PLIST(mat,i);  
-	  if (! IS_GF2VEC_REP(row1))
-	    return TRY_NEXT_METHOD;
-	  AddPartialGF2VecGF2Vec(res, res, row1, 1);
-	}
+    // create the result space
+    NEW_GF2VEC(res,
+               (IS_MUTABLE_OBJ(vec) || IS_MUTABLE_OBJ(row1))
+                   ? TYPE_LIST_GF2VEC
+                   : TYPE_LIST_GF2VEC_IMM,
+               len1);
+
+    // Finally, we start work
+    for (i = 1; i <= len; i++) {
+        if (i % BIPEB == 1)
+            block = CONST_BLOCK_ELM_GF2VEC(vec, i);
+        if (block & MASK_POS_GF2VEC(i)) {
+            row1 = ELM_PLIST(mat, i);
+            if (!IS_GF2VEC_REP(row1))
+                return TRY_NEXT_METHOD;
+            AddPartialGF2VecGF2Vec(res, res, row1, 1);
+        }
     }
-  return res;
-
+    return res;
 }
 
 /****************************************************************************
@@ -893,88 +876,87 @@ Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 **
 **  This is intended to form the core of a method for InverseOp.
 **  by this point it should be checked that list is a plain list of GF2
-**  vectors of equal lengths. 
+**  vectors of equal lengths.
 */
-Obj InversePlistGF2VecsDesstructive( Obj list )
+Obj InversePlistGF2VecsDesstructive(Obj list)
 {
-    UInt                len;            // dimension                       
-    Obj                 inv;            // result                          
-    Obj                 row;            // row vector                      
-    Obj                 old;            // row from <mat>                  
-    Obj                 tmp;            // temporary                       
-    UInt *              ptQ;            // data block of <row>             
-    const UInt *        ptP;            // data block of source row        
-    const UInt *        end;            // end marker                      
-    const UInt *        end2;           // end marker                      
-    UInt                i;              // loop variable                   
-    UInt                k;              // loop variable                   
+    UInt         len;     // dimension
+    Obj          inv;     // result
+    Obj          row;     // row vector
+    Obj          old;     // row from <mat>
+    Obj          tmp;     // temporary
+    UInt *       ptQ;     // data block of <row>
+    const UInt * ptP;     // data block of source row
+    const UInt * end;     // end marker
+    const UInt * end2;    // end marker
+    UInt         i;       // loop variable
+    UInt         k;       // loop variable
 
     len = LEN_PLIST(list);
-    
-    // create the identity matrix                                          
-    tmp = NEW_PLIST( T_PLIST, len );
-    for ( i = len;  0 < i;  i-- ) {
-      NEW_GF2VEC( row, TYPE_LIST_GF2VEC, len );
-      BLOCK_ELM_GF2VEC(row,i) |= MASK_POS_GF2VEC(i);
-      SET_ELM_PLIST( tmp, i, row );
-      CHANGED_BAG(tmp);
+
+    // create the identity matrix
+    tmp = NEW_PLIST(T_PLIST, len);
+    for (i = len; 0 < i; i--) {
+        NEW_GF2VEC(row, TYPE_LIST_GF2VEC, len);
+        BLOCK_ELM_GF2VEC(row, i) |= MASK_POS_GF2VEC(i);
+        SET_ELM_PLIST(tmp, i, row);
+        CHANGED_BAG(tmp);
     }
     SET_LEN_PLIST(tmp, len);
     inv = tmp;
 
-    // now start with ( id | mat ) towards ( inv | id )                    
-    for ( k = 1;  k <= len;  k++ ) {
+    // now start with ( id | mat ) towards ( inv | id )
+    for (k = 1; k <= len; k++) {
 
-        // find a nonzero entry in column <k>                              
-        for ( i = k;  i <= len;  i++ ) {
-            row = ELM_PLIST( list, i );
-            if ( CONST_BLOCK_ELM_GF2VEC(row,k) & MASK_POS_GF2VEC(k) )
+        // find a nonzero entry in column <k>
+        for (i = k; i <= len; i++) {
+            row = ELM_PLIST(list, i);
+            if (CONST_BLOCK_ELM_GF2VEC(row, k) & MASK_POS_GF2VEC(k))
                 break;
         }
-        if ( i > len )  {
+        if (i > len) {
             return Fail;
         }
-        if ( i != k )  {
-            row = ELM_PLIST( list, i );
-            SET_ELM_PLIST( list, i, ELM_PLIST( list, k ) );
-            SET_ELM_PLIST( list, k, row );
-            row = ELM_PLIST( inv, i );
-            SET_ELM_PLIST( inv, i, ELM_PLIST( inv, k ) );
-            SET_ELM_PLIST( inv, k, row );
+        if (i != k) {
+            row = ELM_PLIST(list, i);
+            SET_ELM_PLIST(list, i, ELM_PLIST(list, k));
+            SET_ELM_PLIST(list, k, row);
+            row = ELM_PLIST(inv, i);
+            SET_ELM_PLIST(inv, i, ELM_PLIST(inv, k));
+            SET_ELM_PLIST(inv, k, row);
         }
-        
-        // clear entries                                                   
-        old = ELM_PLIST( list, k );
-        end = CONST_BLOCKS_GF2VEC(old) + ((len+BIPEB-1)/BIPEB);
-        for ( i = 1;  i <= len;  i++ ) {
-            if ( i == k )
-                continue;
-            row = ELM_PLIST( list, i );
-            if ( CONST_BLOCK_ELM_GF2VEC(row,k) & MASK_POS_GF2VEC(k) ) {
 
-                // clear <mat>                                             
-                ptQ = &(BLOCK_ELM_GF2VEC(row,k));
-                ptP = &(CONST_BLOCK_ELM_GF2VEC(old,k));
-                while ( ptP < end ) {
+        // clear entries
+        old = ELM_PLIST(list, k);
+        end = CONST_BLOCKS_GF2VEC(old) + ((len + BIPEB - 1) / BIPEB);
+        for (i = 1; i <= len; i++) {
+            if (i == k)
+                continue;
+            row = ELM_PLIST(list, i);
+            if (CONST_BLOCK_ELM_GF2VEC(row, k) & MASK_POS_GF2VEC(k)) {
+
+                // clear <mat>
+                ptQ = &(BLOCK_ELM_GF2VEC(row, k));
+                ptP = &(CONST_BLOCK_ELM_GF2VEC(old, k));
+                while (ptP < end) {
                     *ptQ++ ^= *ptP++;
                 }
 
-                // modify <inv>                                            
-                row  = ELM_PLIST( inv, i );
-                ptQ  = BLOCKS_GF2VEC(row);
-                row  = ELM_PLIST( inv, k );
-                ptP  = CONST_BLOCKS_GF2VEC(row);
-                end2 = ptP + ((len+BIPEB-1)/BIPEB);
-                while ( ptP < end2 ) {
+                // modify <inv>
+                row = ELM_PLIST(inv, i);
+                ptQ = BLOCKS_GF2VEC(row);
+                row = ELM_PLIST(inv, k);
+                ptP = CONST_BLOCKS_GF2VEC(row);
+                end2 = ptP + ((len + BIPEB - 1) / BIPEB);
+                while (ptP < end2) {
                     *ptQ++ ^= *ptP++;
                 }
             }
         }
-	TakeInterrupt();
+        TakeInterrupt();
     }
     return inv;
 }
-    
 
 
 /****************************************************************************
@@ -985,69 +967,66 @@ Obj InversePlistGF2VecsDesstructive( Obj list )
 **
 */
 
-Obj InverseGF2Mat (
-    Obj                 mat,
-    UInt                mut)
+Obj InverseGF2Mat(Obj mat, UInt mut)
 {
-    UInt                len;            // dimension                       
-    Obj                 inv;            // result                          
-    Obj                 row;            // row vector                      
-    Obj                 tmp;            // temporary                       
-    UInt                i;              // loop variable                   
-    Obj                 old;            // row from <mat>                  
-    const UInt *        ptQ;            // data block of <row>             
-    UInt *              ptP;            // data block of source row        
-    UInt *              end;            // end marker                      
-    Obj                 rtype;
+    UInt         len;    // dimension
+    Obj          inv;    // result
+    Obj          row;    // row vector
+    Obj          tmp;    // temporary
+    UInt         i;      // loop variable
+    Obj          old;    // row from <mat>
+    const UInt * ptQ;    // data block of <row>
+    UInt *       ptP;    // data block of source row
+    UInt *       end;    // end marker
+    Obj          rtype;
 
-    // make a structural copy of <mat> as list of GF2 vectors              
+    // make a structural copy of <mat> as list of GF2 vectors
     len = LEN_GF2MAT(mat);
 
-    // special routes for very small matrices 
-    if ( len == 0 ) {
-        return CopyObj(mat,1);
+    // special routes for very small matrices
+    if (len == 0) {
+        return CopyObj(mat, 1);
     }
-    if (len == 1 ) {
-      row = ELM_GF2MAT(mat,1);
-      if (CONST_BLOCKS_GF2VEC(row)[0] & 1)
-	{
-	  return CopyObj(mat, 1);
-	}
-      else
-	return Fail;
+    if (len == 1) {
+        row = ELM_GF2MAT(mat, 1);
+        if (CONST_BLOCKS_GF2VEC(row)[0] & 1) {
+            return CopyObj(mat, 1);
+        }
+        else
+            return Fail;
     }
-    
-    tmp = NEW_PLIST( T_PLIST, len );
-    for ( i = len;  0 < i;  i-- ) {
-        old = ELM_GF2MAT( mat, i );
-        NEW_GF2VEC( row, TYPE_LIST_GF2VEC_IMM, len );
+
+    tmp = NEW_PLIST(T_PLIST, len);
+    for (i = len; 0 < i; i--) {
+        old = ELM_GF2MAT(mat, i);
+        NEW_GF2VEC(row, TYPE_LIST_GF2VEC_IMM, len);
         ptQ = CONST_BLOCKS_GF2VEC(old);
         ptP = BLOCKS_GF2VEC(row);
-        end = ptP + ((len+BIPEB-1)/BIPEB);
-        while ( ptP < end )
+        end = ptP + ((len + BIPEB - 1) / BIPEB);
+        while (ptP < end)
             *ptP++ = *ptQ++;
-        SET_ELM_PLIST( tmp, i, row );
+        SET_ELM_PLIST(tmp, i, row);
         CHANGED_BAG(tmp);
     }
-    SET_LEN_PLIST(tmp,len);
-    inv = InversePlistGF2VecsDesstructive( tmp );
+    SET_LEN_PLIST(tmp, len);
+    inv = InversePlistGF2VecsDesstructive(tmp);
     if (inv == Fail)
-      return inv;
-    
-    // convert list <inv> into a matrix                                    
-    ResizeBag( inv, SIZE_PLEN_GF2MAT(len) );
-    if (mut == 2 ||
-	(mut == 1 && IS_MUTABLE_OBJ(mat) && IS_MUTABLE_OBJ(ELM_GF2MAT(mat, 1))))
-      rtype = TYPE_LIST_GF2VEC_LOCKED;
+        return inv;
+
+    // convert list <inv> into a matrix
+    ResizeBag(inv, SIZE_PLEN_GF2MAT(len));
+    if (mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(mat) &&
+                     IS_MUTABLE_OBJ(ELM_GF2MAT(mat, 1))))
+        rtype = TYPE_LIST_GF2VEC_LOCKED;
     else
-      rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
-    for ( i = len;  0 < i;  i-- ) {
-      row = ELM_PLIST(inv,i);
-      SET_TYPE_POSOBJ(row, rtype);
-      SET_ELM_GF2MAT( inv, i, row );
+        rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
+    for (i = len; 0 < i; i--) {
+        row = ELM_PLIST(inv, i);
+        SET_TYPE_POSOBJ(row, rtype);
+        SET_ELM_GF2MAT(inv, i, row);
     }
-    SET_LEN_GF2MAT( inv, len );
-    RetypeBag( inv, T_POSOBJ );
+    SET_LEN_GF2MAT(inv, len);
+    RetypeBag(inv, T_POSOBJ);
     SET_TYPE_POSOBJ(inv, (mut == 2 || (mut == 1 && IS_MUTABLE_OBJ(mat)))
                              ? TYPE_LIST_GF2MAT
                              : TYPE_LIST_GF2MAT_IMM);
@@ -1060,18 +1039,18 @@ Obj InverseGF2Mat (
 **
 */
 
-Obj ShallowCopyVecGF2( Obj vec )
+Obj ShallowCopyVecGF2(Obj vec)
 {
-  Obj copy;
-  UInt len;
-  const UInt *ptrS;
-  UInt *ptrD;
-  len = LEN_GF2VEC(vec);
-  NEW_GF2VEC( copy, TYPE_LIST_GF2VEC, len);
-  ptrS = CONST_BLOCKS_GF2VEC(vec);
-  ptrD = BLOCKS_GF2VEC(copy);
-  memcpy(ptrD, ptrS, NUMBER_BLOCKS_GF2VEC(vec)*sizeof(UInt));
-  return copy;
+    Obj          copy;
+    UInt         len;
+    const UInt * ptrS;
+    UInt *       ptrD;
+    len = LEN_GF2VEC(vec);
+    NEW_GF2VEC(copy, TYPE_LIST_GF2VEC, len);
+    ptrS = CONST_BLOCKS_GF2VEC(vec);
+    ptrD = BLOCKS_GF2VEC(copy);
+    memcpy(ptrD, ptrS, NUMBER_BLOCKS_GF2VEC(vec) * sizeof(UInt));
+    return copy;
 }
 
 /****************************************************************************
@@ -1090,117 +1069,107 @@ Obj ShallowCopyVecGF2( Obj vec )
 */
 
 
-
 static UInt RNheads, RNvectors, RNcoeffs, RNrelns;
 
 
-Obj SemiEchelonListGF2Vecs( Obj mat, UInt TransformationsNeeded )
+Obj SemiEchelonListGF2Vecs(Obj mat, UInt TransformationsNeeded)
 {
-  UInt nrows, ncols;
-  UInt i,j,h;
-  Obj heads,vectors, coeffs = 0, relns = 0;
-  UInt nvecs, nrels = 0;
-  Obj coeffrow = 0;
-  Obj row;
-  UInt *rowp, *coeffrowp = 0;
-  Obj res;
-  nrows = LEN_PLIST(mat);
-  ncols = LEN_GF2VEC(ELM_PLIST(mat,1));
-  heads = NEW_PLIST(T_PLIST_CYC, ncols);
-  SET_LEN_PLIST(heads, ncols);
-  vectors = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
-  nvecs = 0;
-  if (TransformationsNeeded)
-    {
-      coeffs = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
-      relns  = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
-      nrels = 0;
+    UInt  nrows, ncols;
+    UInt  i, j, h;
+    Obj   heads, vectors, coeffs = 0, relns = 0;
+    UInt  nvecs, nrels = 0;
+    Obj   coeffrow = 0;
+    Obj   row;
+    UInt *rowp, *coeffrowp = 0;
+    Obj   res;
+    nrows = LEN_PLIST(mat);
+    ncols = LEN_GF2VEC(ELM_PLIST(mat, 1));
+    heads = NEW_PLIST(T_PLIST_CYC, ncols);
+    SET_LEN_PLIST(heads, ncols);
+    vectors = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
+    nvecs = 0;
+    if (TransformationsNeeded) {
+        coeffs = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
+        relns = NEW_PLIST(T_PLIST_TAB_RECT, nrows);
+        nrels = 0;
     }
-  for (i = 1; i <= ncols; i++)
-    SET_ELM_PLIST(heads, i, INTOBJ_INT(0));
-  for (i = 1; i <= nrows; i++)
-    {
-      row = ELM_PLIST(mat, i);
-      if (TransformationsNeeded)
-	{
-	  NEW_GF2VEC(coeffrow, TYPE_LIST_GF2VEC, nrows);
-	  BLOCK_ELM_GF2VEC( coeffrow, i) |= MASK_POS_GF2VEC(i);
-	}
-      
-      // No garbage collection risk from here 
-      rowp = BLOCKS_GF2VEC(row);
-      if (TransformationsNeeded)
-	coeffrowp = BLOCKS_GF2VEC(coeffrow);
-      for (j = 1; j <= ncols; j++)
-	{
-	  h = INT_INTOBJ(ELM_PLIST(heads, j));
-	  if (h != 0)
-	    {
-	      if (rowp[(j-1)/BIPEB] & MASK_POS_GF2VEC(j))
-		{
-		  AddGF2VecToGF2Vec(rowp, CONST_BLOCKS_GF2VEC(ELM_PLIST(vectors,h)), ncols);
-		  if (TransformationsNeeded)
-		    AddGF2VecToGF2Vec(coeffrowp, CONST_BLOCKS_GF2VEC(ELM_PLIST(coeffs,h)), nrows);
-		}
-	    }
-	}
-      j = 1;
-      while (j <= ncols && !*rowp)
-	{
-	  j += BIPEB;
-	  rowp++;
-	}
-      while ( j <= ncols && !(*rowp & MASK_POS_GF2VEC(j)))
-	j++;
+    for (i = 1; i <= ncols; i++)
+        SET_ELM_PLIST(heads, i, INTOBJ_INT(0));
+    for (i = 1; i <= nrows; i++) {
+        row = ELM_PLIST(mat, i);
+        if (TransformationsNeeded) {
+            NEW_GF2VEC(coeffrow, TYPE_LIST_GF2VEC, nrows);
+            BLOCK_ELM_GF2VEC(coeffrow, i) |= MASK_POS_GF2VEC(i);
+        }
 
-      // garbage collection OK again after here 
-      if (j <= ncols)
-	{
-	  SET_ELM_PLIST(vectors, ++nvecs, row);
-          CHANGED_BAG(vectors);    // Could be an old bag by now. Max. 
-	  SET_LEN_PLIST(vectors, nvecs);
-	  SET_ELM_PLIST( heads, j, INTOBJ_INT(nvecs));
-	  if (TransformationsNeeded)
-	    {
-	      SET_ELM_PLIST(coeffs, nvecs, coeffrow);
-              CHANGED_BAG(coeffs);    // Could be an old bag by now. Max. 
-	      SET_LEN_PLIST(coeffs, nvecs);
-	    }
-	}
-      else if (TransformationsNeeded)
-	{
-	  SET_ELM_PLIST(relns, ++nrels, coeffrow);
-          CHANGED_BAG(relns);    // Could be an old bag by now. Max. 
-	  SET_LEN_PLIST(relns, nrels);
-	}
-      TakeInterrupt();
+        // No garbage collection risk from here
+        rowp = BLOCKS_GF2VEC(row);
+        if (TransformationsNeeded)
+            coeffrowp = BLOCKS_GF2VEC(coeffrow);
+        for (j = 1; j <= ncols; j++) {
+            h = INT_INTOBJ(ELM_PLIST(heads, j));
+            if (h != 0) {
+                if (rowp[(j - 1) / BIPEB] & MASK_POS_GF2VEC(j)) {
+                    AddGF2VecToGF2Vec(
+                        rowp, CONST_BLOCKS_GF2VEC(ELM_PLIST(vectors, h)),
+                        ncols);
+                    if (TransformationsNeeded)
+                        AddGF2VecToGF2Vec(
+                            coeffrowp,
+                            CONST_BLOCKS_GF2VEC(ELM_PLIST(coeffs, h)), nrows);
+                }
+            }
+        }
+        j = 1;
+        while (j <= ncols && !*rowp) {
+            j += BIPEB;
+            rowp++;
+        }
+        while (j <= ncols && !(*rowp & MASK_POS_GF2VEC(j)))
+            j++;
+
+        // garbage collection OK again after here
+        if (j <= ncols) {
+            SET_ELM_PLIST(vectors, ++nvecs, row);
+            CHANGED_BAG(vectors);    // Could be an old bag by now. Max.
+            SET_LEN_PLIST(vectors, nvecs);
+            SET_ELM_PLIST(heads, j, INTOBJ_INT(nvecs));
+            if (TransformationsNeeded) {
+                SET_ELM_PLIST(coeffs, nvecs, coeffrow);
+                CHANGED_BAG(coeffs);    // Could be an old bag by now. Max.
+                SET_LEN_PLIST(coeffs, nvecs);
+            }
+        }
+        else if (TransformationsNeeded) {
+            SET_ELM_PLIST(relns, ++nrels, coeffrow);
+            CHANGED_BAG(relns);    // Could be an old bag by now. Max.
+            SET_LEN_PLIST(relns, nrels);
+        }
+        TakeInterrupt();
     }
-  if (RNheads == 0)
-    {
-      RNheads = RNamName("heads");
-      RNvectors = RNamName("vectors");
+    if (RNheads == 0) {
+        RNheads = RNamName("heads");
+        RNvectors = RNamName("vectors");
     }
-  res = NEW_PREC( TransformationsNeeded ? 4 : 2);
-  AssPRec(res,RNheads,heads);
-  AssPRec(res,RNvectors,vectors);
-  if (LEN_PLIST(vectors) == 0)
-    RetypeBag(vectors, T_PLIST_EMPTY);
-  if (TransformationsNeeded)
-    {
-      if (RNcoeffs == 0)
-	{
-	  RNcoeffs = RNamName("coeffs");
-	  RNrelns = RNamName("relations");
-	}
-      AssPRec(res,RNcoeffs,coeffs);
-      if (LEN_PLIST(coeffs) == 0)
-	RetypeBag(coeffs, T_PLIST_EMPTY);
-      AssPRec(res,RNrelns,relns);
-      if (LEN_PLIST(relns) == 0)
-	RetypeBag(relns, T_PLIST_EMPTY);
+    res = NEW_PREC(TransformationsNeeded ? 4 : 2);
+    AssPRec(res, RNheads, heads);
+    AssPRec(res, RNvectors, vectors);
+    if (LEN_PLIST(vectors) == 0)
+        RetypeBag(vectors, T_PLIST_EMPTY);
+    if (TransformationsNeeded) {
+        if (RNcoeffs == 0) {
+            RNcoeffs = RNamName("coeffs");
+            RNrelns = RNamName("relations");
+        }
+        AssPRec(res, RNcoeffs, coeffs);
+        if (LEN_PLIST(coeffs) == 0)
+            RetypeBag(coeffs, T_PLIST_EMPTY);
+        AssPRec(res, RNrelns, relns);
+        if (LEN_PLIST(relns) == 0)
+            RetypeBag(relns, T_PLIST_EMPTY);
     }
-  SortPRecRNam(res,0);
-  return res;
+    SortPRecRNam(res, 0);
+    return res;
 }
 
 /****************************************************************************
@@ -1211,63 +1180,58 @@ Obj SemiEchelonListGF2Vecs( Obj mat, UInt TransformationsNeeded )
 **
 */
 
-UInt TriangulizeListGF2Vecs( Obj mat, UInt clearup)
+UInt TriangulizeListGF2Vecs(Obj mat, UInt clearup)
 {
-  UInt nrows;
-  UInt ncols;
-  UInt workcol;
-  UInt workrow;
-  UInt rank;
-  Obj row, row2;
-  const UInt *rowp;
-  UInt *row2p;
-  UInt block;
-  UInt mask;
-  UInt j;
-  nrows = LEN_PLIST( mat );
-  ncols = LEN_GF2VEC( ELM_PLIST(mat, 1));
-  rank = 0;
+    UInt         nrows;
+    UInt         ncols;
+    UInt         workcol;
+    UInt         workrow;
+    UInt         rank;
+    Obj          row, row2;
+    const UInt * rowp;
+    UInt *       row2p;
+    UInt         block;
+    UInt         mask;
+    UInt         j;
+    nrows = LEN_PLIST(mat);
+    ncols = LEN_GF2VEC(ELM_PLIST(mat, 1));
+    rank = 0;
 
-  // Nothing here can cause a garbage collection 
-  
-  for (workcol = 1; workcol <= ncols; workcol++)
-    {
-      block = (workcol-1)/BIPEB;
-      mask = MASK_POS_GF2VEC(workcol);
-      for (workrow = rank+1; workrow <= nrows &&
-	     !(CONST_BLOCKS_GF2VEC(ELM_PLIST(mat, workrow))[block] & mask); workrow ++)
-	;
-      if (workrow <= nrows)
-	{
-	  rank++;
-	  row = ELM_PLIST(mat, workrow);
-	  if (workrow != rank)
-	    {
-	      SET_ELM_PLIST(mat, workrow, ELM_PLIST(mat, rank));
-	      SET_ELM_PLIST(mat, rank, row);
-	    }
-	  rowp = CONST_BLOCKS_GF2VEC(row);
-	  if (clearup)
-	    for (j = 1; j < rank; j ++)
-	      {
-		row2 = ELM_PLIST(mat, j);
-		row2p = BLOCKS_GF2VEC(row2);
-		if (row2p[block] & mask)
-		  AddGF2VecToGF2Vec(row2p,rowp, ncols);
-	      }
-	  for (j = workrow+1; j <= nrows; j++)
-	    {
-	      row2 = ELM_PLIST(mat, j);
-	      row2p = BLOCKS_GF2VEC(row2);
-	      if (row2p[block] & mask)
-		AddGF2VecToGF2Vec(row2p,rowp, ncols);
-	    }
-	  
-	}
-      TakeInterrupt();
-      
+    // Nothing here can cause a garbage collection
+
+    for (workcol = 1; workcol <= ncols; workcol++) {
+        block = (workcol - 1) / BIPEB;
+        mask = MASK_POS_GF2VEC(workcol);
+        for (workrow = rank + 1;
+             workrow <= nrows &&
+             !(CONST_BLOCKS_GF2VEC(ELM_PLIST(mat, workrow))[block] & mask);
+             workrow++)
+            ;
+        if (workrow <= nrows) {
+            rank++;
+            row = ELM_PLIST(mat, workrow);
+            if (workrow != rank) {
+                SET_ELM_PLIST(mat, workrow, ELM_PLIST(mat, rank));
+                SET_ELM_PLIST(mat, rank, row);
+            }
+            rowp = CONST_BLOCKS_GF2VEC(row);
+            if (clearup)
+                for (j = 1; j < rank; j++) {
+                    row2 = ELM_PLIST(mat, j);
+                    row2p = BLOCKS_GF2VEC(row2);
+                    if (row2p[block] & mask)
+                        AddGF2VecToGF2Vec(row2p, rowp, ncols);
+                }
+            for (j = workrow + 1; j <= nrows; j++) {
+                row2 = ELM_PLIST(mat, j);
+                row2p = BLOCKS_GF2VEC(row2);
+                if (row2p[block] & mask)
+                    AddGF2VecToGF2Vec(row2p, rowp, ncols);
+            }
+        }
+        TakeInterrupt();
     }
-  return rank;
+    return rank;
 }
 
 /****************************************************************************
@@ -1285,49 +1249,49 @@ UInt TriangulizeListGF2Vecs( Obj mat, UInt clearup)
 static Obj IsLockedRepresentationVector;
 
 
-void PlainGF2Vec (
-    Obj                 list )
+void PlainGF2Vec(Obj list)
 {
-    Int                 len;            // length of <list>                
-    UInt                i;              // loop variable                   
-    Obj                 first = 0;          // first entry                     
-    UInt                tnum;
+    Int  len;          // length of <list>
+    UInt i;            // loop variable
+    Obj  first = 0;    // first entry
+    UInt tnum;
 
 
-    // check for representation lock 
-    if (True == DoFilter( IsLockedRepresentationVector, list))
-      ErrorMayQuit("Cannot convert a locked GF2 vector into a plain list", 0, 0);
-    
-    // resize the list and retype it, in this order                        
+    // check for representation lock
+    if (True == DoFilter(IsLockedRepresentationVector, list))
+        ErrorMayQuit("Cannot convert a locked GF2 vector into a plain list",
+                     0, 0);
+
+    // resize the list and retype it, in this order
     len = LEN_GF2VEC(list);
 
     if (len == 0)
-      tnum = T_PLIST_EMPTY;
+        tnum = T_PLIST_EMPTY;
     else
-      tnum = T_PLIST_FFE;
+        tnum = T_PLIST_FFE;
     if (!IS_MUTABLE_OBJ(list))
-      tnum += IMMUTABLE;
-    RetypeBag( list, tnum);
-    GROW_PLIST( list, (UInt)len );
-    SET_LEN_PLIST( list, len );
+        tnum += IMMUTABLE;
+    RetypeBag(list, tnum);
+    GROW_PLIST(list, (UInt)len);
+    SET_LEN_PLIST(list, len);
 
-    // keep the first entry because setting the second destroys the first  
+    // keep the first entry because setting the second destroys the first
     if (len == 0)
-      SET_ELM_PLIST( list, 1 , 0);
+        SET_ELM_PLIST(list, 1, 0);
     else
-      first = ELM_GF2VEC(list,1);
+        first = ELM_GF2VEC(list, 1);
 
-    // wipe out the first entry of the GF2 vector (which becomes the  second 
-    // entry of the plain list, in case the list has length 1.             
+    // wipe out the first entry of the GF2 vector (which becomes the  second
+    // entry of the plain list, in case the list has length 1.
     if (len == 1)
-      SET_ELM_PLIST( list, 2, 0 );
-    
-    // replace the bits by 'GF2One' or 'GF2Zero' as the case may be        
-    // this must of course be done from the end of the list backwards      
-    for ( i = len;  1 < i;  i-- )
-        SET_ELM_PLIST( list, i, ELM_GF2VEC( list, i ) );
+        SET_ELM_PLIST(list, 2, 0);
+
+    // replace the bits by 'GF2One' or 'GF2Zero' as the case may be
+    // this must of course be done from the end of the list backwards
+    for (i = len; 1 < i; i--)
+        SET_ELM_PLIST(list, i, ELM_GF2VEC(list, i));
     if (len != 0)
-	SET_ELM_PLIST( list, 1, first );
+        SET_ELM_PLIST(list, 1, first);
 
     CHANGED_BAG(list);
 }
@@ -1339,22 +1303,21 @@ void PlainGF2Vec (
 **
 **  'PlainGF2Mat' converts the GF2 matrix <list> to a plain list.
 */
-void PlainGF2Mat (
-    Obj                 list )
+void PlainGF2Mat(Obj list)
 {
-    Int                 len;            // length of <list>                
-    UInt                i;              // loop variable                   
+    Int  len;    // length of <list>
+    UInt i;      // loop variable
 
-    // resize the list and retype it, in this order                        
+    // resize the list and retype it, in this order
     len = LEN_GF2MAT(list);
-    RetypeBag( list, IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE );
-    SET_LEN_PLIST( list, len );
+    RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST + IMMUTABLE);
+    SET_LEN_PLIST(list, len);
 
-    // shift the entries to the left                                       
-    for ( i = 1;  i <= len;  i++ ) {
-        SET_ELM_PLIST( list, i, ELM_GF2MAT( list, i ) );
+    // shift the entries to the left
+    for (i = 1; i <= len; i++) {
+        SET_ELM_PLIST(list, i, ELM_GF2MAT(list, i));
     }
-    SHRINK_PLIST( list, len );
+    SHRINK_PLIST(list, len);
     CHANGED_BAG(list);
 }
 
@@ -1363,70 +1326,71 @@ void PlainGF2Mat (
 **
 *F  ConvGF2Vec( <list> )  . . . . . . convert a list into a GF2 vector object
 */
-void ConvGF2Vec (
-    Obj                 list )
+void ConvGF2Vec(Obj list)
 {
-    Int                 len;            // logical length of the vector    
-    Int                 i;              // loop variable                   
-    UInt                block;          // one block of the boolean list   
-    UInt                bit;            // one bit of a block              
-    Obj                 x;
-        
-    // already in the correct representation                               
-    if ( IS_GF2VEC_REP(list) ) {
+    Int  len;      // logical length of the vector
+    Int  i;        // loop variable
+    UInt block;    // one block of the boolean list
+    UInt bit;      // one bit of a block
+    Obj  x;
+
+    // already in the correct representation
+    if (IS_GF2VEC_REP(list)) {
         return;
     }
 
     // Otherwise make it a plain list so that we will know where it keeps
-    // its data -- could do much better in the case of GF(2^n) vectors that actually
-    // lie over GF(2)
+    // its data -- could do much better in the case of GF(2^n) vectors that
+    // actually lie over GF(2)
 
     if (IS_VEC8BIT_REP(list))
-      PlainVec8Bit(list);
+        PlainVec8Bit(list);
     else
-      PLAIN_LIST( list );
-    
-    // change its representation                                           
-    len   = LEN_PLIST(list);
+        PLAIN_LIST(list);
+
+    // change its representation
+    len = LEN_PLIST(list);
 
     // We may have to resize the bag now because a length 1
     // plain list is shorter than a length 1 GF2VEC
     if (SIZE_PLEN_GF2VEC(len) > SIZE_OBJ(list))
-      ResizeBag( list, SIZE_PLEN_GF2VEC(len) );
+        ResizeBag(list, SIZE_PLEN_GF2VEC(len));
 
-    // now do the work 
+    // now do the work
     block = 0;
-    bit   = 1;
-    for ( i = 1;  i <= len;  i++ ) {
-      x = ELM_PLIST(list, i);
-      if (x == GF2One)
-	block |= bit;
-      else if (x != GF2Zero)
-	{
-	  // might be GF(2) elt written over bigger field 
-	  if (EQ(x, GF2One))
-	    block |= bit;
-	  else if (!EQ(x, GF2Zero))
-	    ErrorMayQuit("COPY_GF2VEC: argument must be a list of GF2 elements", 0L, 0L);
-	}
-      
-      bit = bit << 1;
-      if ( bit == 0 || i == len ) {
-	BLOCK_ELM_GF2VEC(list,i) = block;
-	block = 0;
-	bit   = 1;
-      }
+    bit = 1;
+    for (i = 1; i <= len; i++) {
+        x = ELM_PLIST(list, i);
+        if (x == GF2One)
+            block |= bit;
+        else if (x != GF2Zero) {
+            // might be GF(2) elt written over bigger field
+            if (EQ(x, GF2One))
+                block |= bit;
+            else if (!EQ(x, GF2Zero))
+                ErrorMayQuit(
+                    "COPY_GF2VEC: argument must be a list of GF2 elements",
+                    0L, 0L);
+        }
+
+        bit = bit << 1;
+        if (bit == 0 || i == len) {
+            BLOCK_ELM_GF2VEC(list, i) = block;
+            block = 0;
+            bit = 1;
+        }
     }
 
-    // retype and resize bag                                               
-    ResizeWordSizedBag( list, SIZE_PLEN_GF2VEC(len) );
-    SET_LEN_GF2VEC( list, len );
-    if ( IS_PLIST_MUTABLE( list ) ) {
-        SetTypeDatObj( list, TYPE_LIST_GF2VEC);
-    } else {
-        SetTypeDatObj( list, TYPE_LIST_GF2VEC_IMM);
+    // retype and resize bag
+    ResizeWordSizedBag(list, SIZE_PLEN_GF2VEC(len));
+    SET_LEN_GF2VEC(list, len);
+    if (IS_PLIST_MUTABLE(list)) {
+        SetTypeDatObj(list, TYPE_LIST_GF2VEC);
     }
-    RetypeBag( list, T_DATOBJ );
+    else {
+        SetTypeDatObj(list, TYPE_LIST_GF2VEC_IMM);
+    }
+    RetypeBag(list, T_DATOBJ);
 }
 
 
@@ -1434,14 +1398,12 @@ void ConvGF2Vec (
 **
 *F  FuncCONV_GF2VEC( <self>, <list> ) . . . . . convert into a GF2 vector rep
 */
-Obj FuncCONV_GF2VEC (
-    Obj                 self,
-    Obj                 list )
+Obj FuncCONV_GF2VEC(Obj self, Obj list)
 {
-    // check whether <list> is a GF2 vector                               
+    // check whether <list> is a GF2 vector
     ConvGF2Vec(list);
 
-    // return nothing                                                      
+    // return nothing
     return 0;
 }
 
@@ -1449,29 +1411,29 @@ Obj FuncCONV_GF2VEC (
 /****************************************************************************
 **
 *F  NewGF2Vec( <list> )  . . . . . . convert a list into a GF2 vector object
-** 
+**
 **  This is a non-destructive counterpart of ConvGF2Vec
 */
-Obj NewGF2Vec (
-    Obj                 list )
+Obj NewGF2Vec(Obj list)
 {
-    Int                 len;            // logical length of the vector    
-    Int                 i;              // loop variable                   
-    UInt                block;          // one block of the boolean list   
-    UInt                bit;            // one bit of a block              
-    Obj                 x;
-    Obj                 res;            // resulting GF2 vector object     
-    
-    // already in the correct representation                               
-    if ( IS_GF2VEC_REP(list) ) {
+    Int  len;      // logical length of the vector
+    Int  i;        // loop variable
+    UInt block;    // one block of the boolean list
+    UInt bit;      // one bit of a block
+    Obj  x;
+    Obj  res;    // resulting GF2 vector object
+
+    // already in the correct representation
+    if (IS_GF2VEC_REP(list)) {
         res = ShallowCopyVecGF2(list);
         if (!IS_MUTABLE_OBJ(list))
-          SetTypeDatObj(res, TYPE_LIST_GF2VEC_IMM);
+            SetTypeDatObj(res, TYPE_LIST_GF2VEC_IMM);
         return res;
     }
 
     if (!IS_LIST(list)) {
-        ErrorMayQuit("COPY_GF2VEC: argument must be a list of GF2 elements", 0L, 0L);
+        ErrorMayQuit("COPY_GF2VEC: argument must be a list of GF2 elements",
+                     0L, 0L);
     }
     if (!IS_PLIST(list)) {
         list = SHALLOW_COPY_OBJ(list);
@@ -1479,42 +1441,43 @@ Obj NewGF2Vec (
         if (IS_VEC8BIT_REP(list))
             PlainVec8Bit(list);
         else
-            PLAIN_LIST( list );
-    }
-    
-    len = LEN_PLIST(list);
-    NEW_GF2VEC( res, TYPE_LIST_GF2VEC, len );
-    
-    // now do the work 
-    block = 0;
-    bit   = 1;
-    for ( i = 1;  i <= len;  i++ ) {
-      x = ELM_PLIST(list, i);
-      if (x == GF2One)
-	    block |= bit;
-      else if (x != GF2Zero)
-	    {
-	      // might be GF(2) elt written over bigger field 
-	      if (EQ(x, GF2One))
-	        block |= bit;
-	      else if (!EQ(x, GF2Zero))
-            ErrorMayQuit("COPY_GF2VEC: argument must be a list of GF2 elements", 0L, 0L);
-	    }
-      
-      bit = bit << 1;
-      if ( bit == 0 || i == len ) {
-	    BLOCK_ELM_GF2VEC(res,i) = block; // only changed list to res 
-	    block = 0;
-	    bit   = 1;
-      }
+            PLAIN_LIST(list);
     }
 
-    // mutability should be inherited from the argument 
-    if ( IS_PLIST_MUTABLE( list ) )
-        SetTypeDatObj( res , TYPE_LIST_GF2VEC);
+    len = LEN_PLIST(list);
+    NEW_GF2VEC(res, TYPE_LIST_GF2VEC, len);
+
+    // now do the work
+    block = 0;
+    bit = 1;
+    for (i = 1; i <= len; i++) {
+        x = ELM_PLIST(list, i);
+        if (x == GF2One)
+            block |= bit;
+        else if (x != GF2Zero) {
+            // might be GF(2) elt written over bigger field
+            if (EQ(x, GF2One))
+                block |= bit;
+            else if (!EQ(x, GF2Zero))
+                ErrorMayQuit(
+                    "COPY_GF2VEC: argument must be a list of GF2 elements",
+                    0L, 0L);
+        }
+
+        bit = bit << 1;
+        if (bit == 0 || i == len) {
+            BLOCK_ELM_GF2VEC(res, i) = block;    // only changed list to res
+            block = 0;
+            bit = 1;
+        }
+    }
+
+    // mutability should be inherited from the argument
+    if (IS_PLIST_MUTABLE(list))
+        SetTypeDatObj(res, TYPE_LIST_GF2VEC);
     else
-        SetTypeDatObj( res , TYPE_LIST_GF2VEC_IMM);
-    
+        SetTypeDatObj(res, TYPE_LIST_GF2VEC_IMM);
+
     return res;
 }
 
@@ -1525,11 +1488,9 @@ Obj NewGF2Vec (
 **
 **  This is a non-destructive counterpart of FuncCONV_GF2VEC
 */
-Obj FuncCOPY_GF2VEC (
-    Obj                 self,
-    Obj                 list )
+Obj FuncCOPY_GF2VEC(Obj self, Obj list)
 {
-    // check whether <list> is a GF2 vector                               
+    // check whether <list> is a GF2 vector
     list = NewGF2Vec(list);
 
     return list;
@@ -1540,40 +1501,40 @@ Obj FuncCOPY_GF2VEC (
 *F FuncCONV_GF2MAT (<self>, <list> ) . . . convert into a GF2 matrix rep
 **
 ** <list> should be a a list of compressed GF2 vectors
-**  
+**
 */
-Obj FuncCONV_GF2MAT( Obj self, Obj list)
+Obj FuncCONV_GF2MAT(Obj self, Obj list)
 {
-  UInt len, i;
-  Obj tmp;
-  UInt mut;
-  len = LEN_LIST(list);
-  if (len == 0)
-    return (Obj)0;
-  
-  PLAIN_LIST(list);
-  GROW_PLIST(list, len+1);
-  for (i = len; i > 0 ; i--)
-    {
-      tmp = ELM_PLIST(list, i);
-      if (!IS_GF2VEC_REP(tmp))
-	{
-	  int j;
-	  for (j = i+1; j <= len; j++)
-	    {
-	      tmp = ELM_PLIST(list, j+1);
-	      SET_ELM_PLIST(list,j,tmp);
-	    }
-	  ErrorMayQuit("CONV_GF2MAT: argument must be a list of compressed GF2 vectors", 0L, 0L);
-	}
-      SetTypeDatObj(tmp, IS_MUTABLE_OBJ(tmp) ? TYPE_LIST_GF2VEC_LOCKED: TYPE_LIST_GF2VEC_IMM_LOCKED);
-      SET_ELM_PLIST(list, i+1, tmp);
+    UInt len, i;
+    Obj  tmp;
+    UInt mut;
+    len = LEN_LIST(list);
+    if (len == 0)
+        return (Obj)0;
+
+    PLAIN_LIST(list);
+    GROW_PLIST(list, len + 1);
+    for (i = len; i > 0; i--) {
+        tmp = ELM_PLIST(list, i);
+        if (!IS_GF2VEC_REP(tmp)) {
+            int j;
+            for (j = i + 1; j <= len; j++) {
+                tmp = ELM_PLIST(list, j + 1);
+                SET_ELM_PLIST(list, j, tmp);
+            }
+            ErrorMayQuit("CONV_GF2MAT: argument must be a list of compressed "
+                         "GF2 vectors",
+                         0L, 0L);
+        }
+        SetTypeDatObj(tmp, IS_MUTABLE_OBJ(tmp) ? TYPE_LIST_GF2VEC_LOCKED
+                                               : TYPE_LIST_GF2VEC_IMM_LOCKED);
+        SET_ELM_PLIST(list, i + 1, tmp);
     }
-  SET_ELM_PLIST(list,1,INTOBJ_INT(len));
-  mut = IS_PLIST_MUTABLE(list);
-  RetypeBag(list, T_POSOBJ);
-  SET_TYPE_POSOBJ(list, mut ? TYPE_LIST_GF2MAT : TYPE_LIST_GF2MAT_IMM);
-  return (Obj) 0;
+    SET_ELM_PLIST(list, 1, INTOBJ_INT(len));
+    mut = IS_PLIST_MUTABLE(list);
+    RetypeBag(list, T_POSOBJ);
+    SET_TYPE_POSOBJ(list, mut ? TYPE_LIST_GF2MAT : TYPE_LIST_GF2MAT_IMM);
+    return (Obj)0;
 }
 
 
@@ -1581,24 +1542,20 @@ Obj FuncCONV_GF2MAT( Obj self, Obj list)
 **
 *F  FuncPLAIN_GF2VEC( <self>, <list> ) . . .  convert back into ordinary list
 */
-Obj FuncPLAIN_GF2VEC (
-    Obj                 self,
-    Obj                 list )
+Obj FuncPLAIN_GF2VEC(Obj self, Obj list)
 {
-    // check whether <list> is a GF2 vector                                
-    while ( ! IS_GF2VEC_REP(list) ) {
+    // check whether <list> is a GF2 vector
+    while (!IS_GF2VEC_REP(list)) {
         list = ErrorReturnObj(
             "PLAIN_GF2VEC: <list> must be a GF2 vector (not a %s)",
             (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
+            "you can replace <list> via 'return <list>;'");
     }
     PlainGF2Vec(list);
 
-    // return nothing                                                      
+    // return nothing
     return 0;
 }
-
-
 
 
 /****************************************************************************
@@ -1607,47 +1564,47 @@ Obj FuncPLAIN_GF2VEC (
 */
 
 
-//   A list of flip values for bytes (i.e. ..xyz -> zyx..) 
+//   A list of flip values for bytes (i.e. ..xyz -> zyx..)
 
-static const UInt1 revertlist [] ={
- 0, 128, 64, 192, 32, 160, 96, 224, 16, 144, 80, 208, 48, 176, 112, 240, 8, 
-  136, 72, 200, 40, 168, 104, 232, 24, 152, 88, 216, 56, 184, 120, 248, 4, 
-  132, 68, 196, 36, 164, 100, 228, 20, 148, 84, 212, 52, 180, 116, 244, 12, 
-  140, 76, 204, 44, 172, 108, 236, 28, 156, 92, 220, 60, 188, 124, 252, 2, 
-  130, 66, 194, 34, 162, 98, 226, 18, 146, 82, 210, 50, 178, 114, 242, 10, 
-  138, 74, 202, 42, 170, 106, 234, 26, 154, 90, 218, 58, 186, 122, 250, 6, 
-  134, 70, 198, 38, 166, 102, 230, 22, 150, 86, 214, 54, 182, 118, 246, 14, 
-  142, 78, 206, 46, 174, 110, 238, 30, 158, 94, 222, 62, 190, 126, 254, 1, 
-  129, 65, 193, 33, 161, 97, 225, 17, 145, 81, 209, 49, 177, 113, 241, 9, 
-  137, 73, 201, 41, 169, 105, 233, 25, 153, 89, 217, 57, 185, 121, 249, 5, 
-  133, 69, 197, 37, 165, 101, 229, 21, 149, 85, 213, 53, 181, 117, 245, 13, 
-  141, 77, 205, 45, 173, 109, 237, 29, 157, 93, 221, 61, 189, 125, 253, 3, 
-  131, 67, 195, 35, 163, 99, 227, 19, 147, 83, 211, 51, 179, 115, 243, 11, 
-  139, 75, 203, 43, 171, 107, 235, 27, 155, 91, 219, 59, 187, 123, 251, 7, 
-  135, 71, 199, 39, 167, 103, 231, 23, 151, 87, 215, 55, 183, 119, 247, 15, 
-  143, 79, 207, 47, 175, 111, 239, 31, 159, 95, 223, 63, 191, 127, 255
+static const UInt1 revertlist[] = {
+    0,  128, 64, 192, 32, 160, 96,  224, 16, 144, 80, 208, 48, 176, 112, 240,
+    8,  136, 72, 200, 40, 168, 104, 232, 24, 152, 88, 216, 56, 184, 120, 248,
+    4,  132, 68, 196, 36, 164, 100, 228, 20, 148, 84, 212, 52, 180, 116, 244,
+    12, 140, 76, 204, 44, 172, 108, 236, 28, 156, 92, 220, 60, 188, 124, 252,
+    2,  130, 66, 194, 34, 162, 98,  226, 18, 146, 82, 210, 50, 178, 114, 242,
+    10, 138, 74, 202, 42, 170, 106, 234, 26, 154, 90, 218, 58, 186, 122, 250,
+    6,  134, 70, 198, 38, 166, 102, 230, 22, 150, 86, 214, 54, 182, 118, 246,
+    14, 142, 78, 206, 46, 174, 110, 238, 30, 158, 94, 222, 62, 190, 126, 254,
+    1,  129, 65, 193, 33, 161, 97,  225, 17, 145, 81, 209, 49, 177, 113, 241,
+    9,  137, 73, 201, 41, 169, 105, 233, 25, 153, 89, 217, 57, 185, 121, 249,
+    5,  133, 69, 197, 37, 165, 101, 229, 21, 149, 85, 213, 53, 181, 117, 245,
+    13, 141, 77, 205, 45, 173, 109, 237, 29, 157, 93, 221, 61, 189, 125, 253,
+    3,  131, 67, 195, 35, 163, 99,  227, 19, 147, 83, 211, 51, 179, 115, 243,
+    11, 139, 75, 203, 43, 171, 107, 235, 27, 155, 91, 219, 59, 187, 123, 251,
+    7,  135, 71, 199, 39, 167, 103, 231, 23, 151, 87, 215, 55, 183, 119, 247,
+    15, 143, 79, 207, 47, 175, 111, 239, 31, 159, 95, 223, 63, 191, 127, 255
 };
 
 // Takes an UInt a on n bits and returns the Uint obtained by reverting the
 // bits
 UInt revertbits(UInt a, Int n)
 {
-  UInt b,c;
-  b=0;
-  while (n>8) {
-    c=a&0xff; // last byte 
-    a = a>>8;
-    b = b<<8;
-    b += (UInt) revertlist[(UInt1)c]; // add flipped 
-    n -=8;
-  }
-  // cope with the last n bits 
-  a &= 0xff;
-  b= b<<n;
-  c=(UInt) revertlist[(UInt1)a];
-  c = c>> (8-n);
-  b+=c;
-  return b;
+    UInt b, c;
+    b = 0;
+    while (n > 8) {
+        c = a & 0xff;    // last byte
+        a = a >> 8;
+        b = b << 8;
+        b += (UInt)revertlist[(UInt1)c];    // add flipped
+        n -= 8;
+    }
+    // cope with the last n bits
+    a &= 0xff;
+    b = b << n;
+    c = (UInt)revertlist[(UInt1)a];
+    c = c >> (8 - n);
+    b += c;
+    return b;
 }
 
 /****************************************************************************
@@ -1655,74 +1612,72 @@ UInt revertbits(UInt a, Int n)
 *F  Cmp_GF2Vecs( <vl>, <vr> )   compare GF2 vectors -- internal
 **                                    returns -1, 0 or 1
 */
-Int Cmp_GF2VEC_GF2VEC (
-    Obj                 vl,
-    Obj                 vr )
+Int Cmp_GF2VEC_GF2VEC(Obj vl, Obj vr)
 {
-    UInt                i;              // loop variable                   
-    const UInt *        bl;             // block of <vl>                   
-    const UInt *        br;             // block of <vr>                   
-    UInt                len,lenl,lenr;  // length of the list              
-    UInt a,b,nb;
+    UInt         i;                  // loop variable
+    const UInt * bl;                 // block of <vl>
+    const UInt * br;                 // block of <vr>
+    UInt         len, lenl, lenr;    // length of the list
+    UInt         a, b, nb;
 
-    // get and check the length                                            
+    // get and check the length
     lenl = LEN_GF2VEC(vl);
     lenr = LEN_GF2VEC(vr);
-    nb=NUMBER_BLOCKS_GF2VEC(vl);
-    a=NUMBER_BLOCKS_GF2VEC(vr);
-    if (a<nb) {
-      nb = a;
+    nb = NUMBER_BLOCKS_GF2VEC(vl);
+    a = NUMBER_BLOCKS_GF2VEC(vr);
+    if (a < nb) {
+        nb = a;
     }
 
-    // check all blocks                                                    
+    // check all blocks
     bl = CONST_BLOCKS_GF2VEC(vl);
     br = CONST_BLOCKS_GF2VEC(vr);
-    for ( i = nb;  1 < i;  i--, bl++, br++ ) {
-	// comparison is numeric of the reverted lists
-      if (*bl != *br)
-	{
-	  a=revertbits(*bl,BIPEB);
-	  b=revertbits(*br,BIPEB);
-	  if ( a < b )
-            return -1;
-	  else return 1;
-	}
-    }
-    
-
-    // The last block remains 
-    len=lenl;
-    if (len>lenr) {
-      len=lenr;
+    for (i = nb; 1 < i; i--, bl++, br++) {
+        // comparison is numeric of the reverted lists
+        if (*bl != *br) {
+            a = revertbits(*bl, BIPEB);
+            b = revertbits(*br, BIPEB);
+            if (a < b)
+                return -1;
+            else
+                return 1;
+        }
     }
 
-    // are both vectors length 0? 
-    if (len == 0 ) return 0;
 
-    // is there still a full block in common? 
+    // The last block remains
+    len = lenl;
+    if (len > lenr) {
+        len = lenr;
+    }
+
+    // are both vectors length 0?
+    if (len == 0)
+        return 0;
+
+    // is there still a full block in common?
     len = len % BIPEB;
     if (len == 0) {
-      a=revertbits(*bl,BIPEB);
-      b=revertbits(*br,BIPEB);
+        a = revertbits(*bl, BIPEB);
+        b = revertbits(*br, BIPEB);
     }
     else {
-      a=revertbits(*bl,len);
-      b=revertbits(*br,len);
+        a = revertbits(*bl, len);
+        b = revertbits(*br, len);
     }
 
-    if (a<b)
-      return -1;
-    if (a>b)
-      return 1;
-    
-    // blocks still the same --left length must be smaller to be true 
-    if (lenr>lenl)
-      return -1;
-    if (lenl > lenr)
-      return 1;
-    
-    return 0;
+    if (a < b)
+        return -1;
+    if (a > b)
+        return 1;
 
+    // blocks still the same --left length must be smaller to be true
+    if (lenr > lenl)
+        return -1;
+    if (lenl > lenr)
+        return 1;
+
+    return 0;
 }
 
 
@@ -1730,15 +1685,12 @@ Int Cmp_GF2VEC_GF2VEC (
 **
 *F  FuncEQ_GF2VEC_GF2VEC( <self>, <vl>, <vr> )   test equality of GF2 vectors
 */
-Obj FuncEQ_GF2VEC_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncEQ_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-  // we can do this case MUCH faster if we just want equality 
-  if (LEN_GF2VEC(vl)  != LEN_GF2VEC(vr))
-    return False;
-  return (Cmp_GF2VEC_GF2VEC(vl,vr) == 0) ? True : False;
+    // we can do this case MUCH faster if we just want equality
+    if (LEN_GF2VEC(vl) != LEN_GF2VEC(vr))
+        return False;
+    return (Cmp_GF2VEC_GF2VEC(vl, vr) == 0) ? True : False;
 }
 
 
@@ -1746,9 +1698,7 @@ Obj FuncEQ_GF2VEC_GF2VEC (
 **
 *F  FuncLEN_GF2VEC( <self>, <list> )  . . . . . . . .  length of a GF2 vector
 */
-Obj FuncLEN_GF2VEC (
-    Obj                 self,
-    Obj                 list )
+Obj FuncLEN_GF2VEC(Obj self, Obj list)
 {
     return INTOBJ_INT(LEN_GF2VEC(list));
 }
@@ -1763,17 +1713,14 @@ Obj FuncLEN_GF2VEC (
 **  the  responsibility of  the caller to   ensure  that <pos> is  a positive
 **  integer.
 */
-Obj FuncELM0_GF2VEC (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 {
     UInt p = GetSmallInt("ELM0_GF2VEC", pos, "pos");
-    if ( LEN_GF2VEC(list) < p ) {
+    if (LEN_GF2VEC(list) < p) {
         return Fail;
     }
     else {
-        return ELM_GF2VEC( list, p );
+        return ELM_GF2VEC(list, p);
     }
 }
 
@@ -1786,20 +1733,17 @@ Obj FuncELM0_GF2VEC (
 **  <list>.   An  error  is signalled  if  <pos>  is  not bound.    It is the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
-Obj FuncELM_GF2VEC (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncELM_GF2VEC(Obj self, Obj list, Obj pos)
 {
     UInt p = GetSmallInt("ELM_GF2VEC", pos, "pos");
-    if ( LEN_GF2VEC(list) < p ) {
+    if (LEN_GF2VEC(list) < p) {
         ErrorReturnVoid(
-            "List Element: <list>[%d] must have an assigned value",
-            p, 0L, "you can 'return;' after assigning a value" );
-        return ELM_LIST( list, p );
+            "List Element: <list>[%d] must have an assigned value", p, 0L,
+            "you can 'return;' after assigning a value");
+        return ELM_LIST(list, p);
     }
     else {
-        return ELM_GF2VEC( list, p );
+        return ELM_GF2VEC(list, p);
     }
 }
 
@@ -1814,93 +1758,90 @@ Obj FuncELM_GF2VEC (
 **  only positive integers.  An error is signalled if an element of <poss> is
 **  larger than the length of <list>.
 */
-Obj FuncELMS_GF2VEC (
-    Obj                 self,
-    Obj                 list,
-    Obj                 poss )
+Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
 {
-    Obj                 elms;           // selected sublist, result        
-    Int                 lenList;        // length of <list>                
-    Int                 lenPoss;        // length of positions             
-    Int                 pos;            // position as integer             
-    Int                 inc;            // increment in a range            
-    Int                 i;              // loop variable                   
-    Obj                 apos;
+    Obj elms;       // selected sublist, result
+    Int lenList;    // length of <list>
+    Int lenPoss;    // length of positions
+    Int pos;        // position as integer
+    Int inc;        // increment in a range
+    Int i;          // loop variable
+    Obj apos;
 
-    // get the length of <list>                                            
+    // get the length of <list>
     lenList = LEN_GF2VEC(list);
 
-    // general code for arbritrary lists, which are ranges                 
-    if ( ! IS_RANGE(poss) ) {
+    // general code for arbritrary lists, which are ranges
+    if (!IS_RANGE(poss)) {
 
-        // get the length of <positions>                                   
+        // get the length of <positions>
         lenPoss = LEN_LIST(poss);
 
-        // make the result vector                                          
-        NEW_GF2VEC( elms, TYPE_LIST_GF2VEC, lenPoss );
+        // make the result vector
+        NEW_GF2VEC(elms, TYPE_LIST_GF2VEC, lenPoss);
 
-        // loop over the entries of <positions> and select                 
-        for ( i = 1;  i <= lenPoss;  i++ ) {
+        // loop over the entries of <positions> and select
+        for (i = 1; i <= lenPoss; i++) {
 
-            // get next position                                           
+            // get next position
 
-	  apos = ELM0_LIST( poss, i);
-	  if (!apos || !IS_INTOBJ(apos))
-	    ErrorMayQuit("ELMS_GF2VEC: error at position %d in positions list, entry must be bound to a small integer",
-		      i, 0L);
-	  pos = INT_INTOBJ( apos );
-	  if ( lenList < pos ) {
-	    ErrorMayQuit( "List Elements: <list>[%d] must have a value",
-		       pos, 0L );
-	    return 0;
-	  }
-	  
-	  // assign the element into <elms>                              
-	  if ( ELM_GF2VEC( list, pos ) == GF2One ) {
-	    BLOCK_ELM_GF2VEC(elms,i) |= MASK_POS_GF2VEC(i);
-	  }
+            apos = ELM0_LIST(poss, i);
+            if (!apos || !IS_INTOBJ(apos))
+                ErrorMayQuit("ELMS_GF2VEC: error at position %d in positions "
+                             "list, entry must be bound to a small integer",
+                             i, 0L);
+            pos = INT_INTOBJ(apos);
+            if (lenList < pos) {
+                ErrorMayQuit("List Elements: <list>[%d] must have a value",
+                             pos, 0L);
+                return 0;
+            }
+
+            // assign the element into <elms>
+            if (ELM_GF2VEC(list, pos) == GF2One) {
+                BLOCK_ELM_GF2VEC(elms, i) |= MASK_POS_GF2VEC(i);
+            }
         }
-	
     }
 
-    // special code for ranges                                             
+    // special code for ranges
     else {
 
-        // get the length of <positions>, the first elements, and the inc. 
+        // get the length of <positions>, the first elements, and the inc.
         lenPoss = GET_LEN_RANGE(poss);
         pos = GET_LOW_RANGE(poss);
         inc = GET_INC_RANGE(poss);
 
-        // check that no <position> is larger than <lenList>               
-        if ( lenList < pos ) {
-            ErrorMayQuit( "List Elements: <list>[%d] must have a value",
-                       pos, 0L );
+        // check that no <position> is larger than <lenList>
+        if (lenList < pos) {
+            ErrorMayQuit("List Elements: <list>[%d] must have a value", pos,
+                         0L);
             return 0;
         }
-        if ( lenList < pos + (lenPoss-1) * inc ) {
-            ErrorMayQuit( "List Elements: <list>[%d] must have a value",
-                       pos + (lenPoss-1) * inc, 0L );
+        if (lenList < pos + (lenPoss - 1) * inc) {
+            ErrorMayQuit("List Elements: <list>[%d] must have a value",
+                         pos + (lenPoss - 1) * inc, 0L);
             return 0;
         }
 
-        // make the result vector                                          
-        NEW_GF2VEC( elms, TYPE_LIST_GF2VEC, lenPoss );
-	
-	// increment 1 ranges is a block copy 
-	if (inc == 1)
-	  CopySection_GF2Vecs(list, elms, pos, 1, lenPoss);
+        // make the result vector
+        NEW_GF2VEC(elms, TYPE_LIST_GF2VEC, lenPoss);
 
-        // loop over the entries of <positions> and select                 
+        // increment 1 ranges is a block copy
+        if (inc == 1)
+            CopySection_GF2Vecs(list, elms, pos, 1, lenPoss);
+
+        // loop over the entries of <positions> and select
         else {
-           for ( i = 1;  i <= lenPoss;  i++, pos += inc ) {
-                if ( ELM_GF2VEC(list,pos) == GF2One ) {
-                    BLOCK_ELM_GF2VEC(elms,i) |= MASK_POS_GF2VEC(i);
+            for (i = 1; i <= lenPoss; i++, pos += inc) {
+                if (ELM_GF2VEC(list, pos) == GF2One) {
+                    BLOCK_ELM_GF2VEC(elms, i) |= MASK_POS_GF2VEC(i);
                 }
             }
         }
     }
 
-    // return the result                                                   
+    // return the result
     return elms;
 }
 
@@ -1916,55 +1857,50 @@ Obj FuncELMS_GF2VEC (
 **  and that <elm> is not 0.
 */
 
-Obj FuncASS_GF2VEC (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos,
-    Obj                 elm )
+Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
 {
-    // check that <list> is mutable                                        
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        ErrorReturnVoid(
-            "List Assignment: <list> must be a mutable list",
-            0L, 0L,
-            "you can 'return;' and ignore the assignment" );
+    // check that <list> is mutable
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid("List Assignment: <list> must be a mutable list", 0L,
+                        0L, "you can 'return;' and ignore the assignment");
         return 0;
     }
 
-    // get the position                                                    
+    // get the position
     UInt p = GetSmallInt("ASS_GF2VEC", pos, "pos");
 
-    // if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep         
-    if ( p <= LEN_GF2VEC(list)+1 ) {
-        if ( LEN_GF2VEC(list)+1 == p ) {
-	  if (DoFilter(IsLockedRepresentationVector, list) == True)
-	    ErrorMayQuit("Assignment forbidden beyond the end of locked GF2 vector", 0, 0);
-	  ResizeWordSizedBag( list, SIZE_PLEN_GF2VEC(p) );
-	  SET_LEN_GF2VEC( list, p );
+    // if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep
+    if (p <= LEN_GF2VEC(list) + 1) {
+        if (LEN_GF2VEC(list) + 1 == p) {
+            if (DoFilter(IsLockedRepresentationVector, list) == True)
+                ErrorMayQuit("Assignment forbidden beyond the end of locked "
+                             "GF2 vector",
+                             0, 0);
+            ResizeWordSizedBag(list, SIZE_PLEN_GF2VEC(p));
+            SET_LEN_GF2VEC(list, p);
         }
-        if ( EQ(GF2One,elm) ) {
-            BLOCK_ELM_GF2VEC(list,p) |= MASK_POS_GF2VEC(p);
+        if (EQ(GF2One, elm)) {
+            BLOCK_ELM_GF2VEC(list, p) |= MASK_POS_GF2VEC(p);
         }
-        else if ( EQ(GF2Zero,elm) ) {
-            BLOCK_ELM_GF2VEC(list,p) &= ~MASK_POS_GF2VEC(p);
+        else if (EQ(GF2Zero, elm)) {
+            BLOCK_ELM_GF2VEC(list, p) &= ~MASK_POS_GF2VEC(p);
         }
-	else if (IS_FFE(elm) && CHAR_FF(FLD_FFE(elm)) == 2 && DEGR_FF(FLD_FFE(elm)) <= 8)
-	  {
-	    //	    Pr("Rewriting GF2 vector over larger field",0,0); 
-	    RewriteGF2Vec(list, SIZE_FF(FLD_FFE(elm)));
-	    ASS_VEC8BIT(list, pos, elm);
-	  }
-        else
-	  {
-	    // 	    Pr("arbitrary assignment (GF2)",0,0); 
-	    PlainGF2Vec(list);
-	    ASS_LIST( list, p, elm );
-	  }
+        else if (IS_FFE(elm) && CHAR_FF(FLD_FFE(elm)) == 2 &&
+                 DEGR_FF(FLD_FFE(elm)) <= 8) {
+            //	    Pr("Rewriting GF2 vector over larger field",0,0);
+            RewriteGF2Vec(list, SIZE_FF(FLD_FFE(elm)));
+            ASS_VEC8BIT(list, pos, elm);
+        }
+        else {
+            // 	    Pr("arbitrary assignment (GF2)",0,0);
+            PlainGF2Vec(list);
+            ASS_LIST(list, p, elm);
+        }
     }
     else {
-      //       Pr("arbitrary assignment 2 (GF2)",0,0); 
+        //       Pr("arbitrary assignment 2 (GF2)",0,0);
         PlainGF2Vec(list);
-        ASS_LIST( list, p, elm );
+        ASS_LIST(list, p, elm);
     }
     return 0;
 }
@@ -1973,13 +1909,11 @@ Obj FuncASS_GF2VEC (
 **
 *F  FuncPLAIN_GF2MAT( <self>, <list> ) . . .  convert back into ordinary list
 */
-Obj FuncPLAIN_GF2MAT (
-    Obj                 self,
-    Obj                 list )
+Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
 {
     PlainGF2Mat(list);
 
-    // return nothing                                                      
+    // return nothing
     return 0;
 }
 
@@ -1994,51 +1928,47 @@ Obj FuncPLAIN_GF2MAT (
 **  It is the responsibility of the caller  to ensure that <pos> is positive,
 **  and that <elm> is not 0.
 */
-Obj FuncASS_GF2MAT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos,
-    Obj                 elm )
+Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
 {
-    // check that <list> is mutable                                        
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        ErrorReturnVoid(
-            "List Assignment: <list> must be a mutable list",
-            0L, 0L,
-            "you can 'return;' and ignore the assignment" );
+    // check that <list> is mutable
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid("List Assignment: <list> must be a mutable list", 0L,
+                        0L, "you can 'return;' and ignore the assignment");
         return 0;
     }
 
-    // get the position                                                    
+    // get the position
     UInt p = GetSmallInt("ASS_GF2MAT", pos, "pos");
 
-    // if <elm> is a GF2 vector and the length is OK, keep the rep         
-    if ( ! IS_GF2VEC_REP(elm)  ) {
+    // if <elm> is a GF2 vector and the length is OK, keep the rep
+    if (!IS_GF2VEC_REP(elm)) {
         PlainGF2Mat(list);
-        ASS_LIST( list, p, elm );
+        ASS_LIST(list, p, elm);
     }
-    else if ( p == 1 && 1 >= LEN_GF2MAT(list) ) {
-        ResizeBag( list, SIZE_PLEN_GF2MAT(p) );
-	SetTypeDatObj(elm, IS_MUTABLE_OBJ(elm) ? TYPE_LIST_GF2VEC_LOCKED : TYPE_LIST_GF2VEC_IMM_LOCKED);
-        SET_ELM_GF2MAT( list, p, elm );
-	CHANGED_BAG(list);
+    else if (p == 1 && 1 >= LEN_GF2MAT(list)) {
+        ResizeBag(list, SIZE_PLEN_GF2MAT(p));
+        SetTypeDatObj(elm, IS_MUTABLE_OBJ(elm) ? TYPE_LIST_GF2VEC_LOCKED
+                                               : TYPE_LIST_GF2VEC_IMM_LOCKED);
+        SET_ELM_GF2MAT(list, p, elm);
+        CHANGED_BAG(list);
     }
-    else if ( p > LEN_GF2MAT(list)+1 ) {
+    else if (p > LEN_GF2MAT(list) + 1) {
         PlainGF2Mat(list);
-        ASS_LIST( list, p, elm );
+        ASS_LIST(list, p, elm);
     }
-    else if ( LEN_GF2VEC(elm) == LEN_GF2VEC(ELM_GF2MAT(list,1)) ) {
-        if ( LEN_GF2MAT(list)+1 == p ) {
-            ResizeBag( list, SIZE_PLEN_GF2MAT(p) );
-            SET_LEN_GF2MAT( list, p );
+    else if (LEN_GF2VEC(elm) == LEN_GF2VEC(ELM_GF2MAT(list, 1))) {
+        if (LEN_GF2MAT(list) + 1 == p) {
+            ResizeBag(list, SIZE_PLEN_GF2MAT(p));
+            SET_LEN_GF2MAT(list, p);
         }
-	SetTypeDatObj(elm, IS_MUTABLE_OBJ(elm) ? TYPE_LIST_GF2VEC_LOCKED : TYPE_LIST_GF2VEC_IMM_LOCKED);
-        SET_ELM_GF2MAT( list, p, elm );
+        SetTypeDatObj(elm, IS_MUTABLE_OBJ(elm) ? TYPE_LIST_GF2VEC_LOCKED
+                                               : TYPE_LIST_GF2VEC_IMM_LOCKED);
+        SET_ELM_GF2MAT(list, p, elm);
         CHANGED_BAG(list);
     }
     else {
         PlainGF2Mat(list);
-        ASS_LIST( list, p, elm );
+        ASS_LIST(list, p, elm);
     }
     return 0;
 }
@@ -2049,11 +1979,12 @@ Obj FuncASS_GF2MAT (
 *F  FuncELM_GF2MAT( <self>, <mat>, <row> ) . . . select a row of a GF2 matrix
 **
 */
-Obj FuncELM_GF2MAT( Obj self, Obj mat, Obj row )
+Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
 {
     UInt r = GetSmallInt("ELM_GF2MAT", row, "row");
     if (LEN_GF2MAT(mat) < r) {
-        ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_GF2MAT(mat));
+        ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
+                     LEN_GF2MAT(mat));
     }
     return ELM_GF2MAT(mat, r);
 }
@@ -2068,42 +1999,35 @@ Obj FuncELM_GF2MAT( Obj self, Obj mat, Obj row )
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
 */
-Obj FuncUNB_GF2VEC (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
 {
-    // check that <list> is mutable                                        
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        ErrorReturnVoid(
-            "List Unbind: <list> must be a mutable list",
-            0L, 0L,
-            "you can 'return;' and ignore the unbind" );
+    // check that <list> is mutable
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid("List Unbind: <list> must be a mutable list", 0L, 0L,
+                        "you can 'return;' and ignore the unbind");
         return 0;
     }
 
-    if (DoFilter(IsLockedRepresentationVector, list) == True)
-    {
-      ErrorReturnVoid( "Unbind forbidden on locked GF2 vector",
-		          0L, 0L,
-            "you can 'return;' and ignore the operation" );
+    if (DoFilter(IsLockedRepresentationVector, list) == True) {
+        ErrorReturnVoid("Unbind forbidden on locked GF2 vector", 0L, 0L,
+                        "you can 'return;' and ignore the operation");
         return 0;
     }
 
-    // get the position                                                    
+    // get the position
     UInt p = GetSmallInt("UNB_GF2VEC", pos, "pos");
 
-    // if we unbind the last position keep the representation              
-    if ( LEN_GF2VEC(list) < p ) {
+    // if we unbind the last position keep the representation
+    if (LEN_GF2VEC(list) < p) {
         ;
     }
-    else if ( LEN_GF2VEC(list) == p ) {
-        ResizeWordSizedBag( list, SIZE_PLEN_GF2VEC(p-1) );
-        SET_LEN_GF2VEC( list, p-1 );
+    else if (LEN_GF2VEC(list) == p) {
+        ResizeWordSizedBag(list, SIZE_PLEN_GF2VEC(p - 1));
+        SET_LEN_GF2VEC(list, p - 1);
     }
     else {
         PlainGF2Vec(list);
-        UNB_LIST( list, p );
+        UNB_LIST(list, p);
     }
     return 0;
 }
@@ -2118,34 +2042,29 @@ Obj FuncUNB_GF2VEC (
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
 */
-Obj FuncUNB_GF2MAT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+Obj FuncUNB_GF2MAT(Obj self, Obj list, Obj pos)
 {
-    // check that <list> is mutable                                        
-    if ( ! IS_MUTABLE_OBJ(list) ) {
-        ErrorReturnVoid(
-            "List Unbind: <list> must be a mutable list",
-            0L, 0L,
-            "you can 'return;' and ignore the unbind" );
+    // check that <list> is mutable
+    if (!IS_MUTABLE_OBJ(list)) {
+        ErrorReturnVoid("List Unbind: <list> must be a mutable list", 0L, 0L,
+                        "you can 'return;' and ignore the unbind");
         return 0;
     }
 
-    // get the position                                                    
+    // get the position
     UInt p = GetSmallInt("UNB_GF2MAT", pos, "pos");
 
-    // if we unbind the last position keep the representation              
-    if ( p > 1 && LEN_GF2MAT(list) < p ) {
+    // if we unbind the last position keep the representation
+    if (p > 1 && LEN_GF2MAT(list) < p) {
         ;
     }
-    else if ( LEN_GF2MAT(list) == p ) {
-        ResizeBag( list, SIZE_PLEN_GF2MAT(p-1) );
-        SET_LEN_GF2MAT( list, p-1 );
+    else if (LEN_GF2MAT(list) == p) {
+        ResizeBag(list, SIZE_PLEN_GF2MAT(p - 1));
+        SET_LEN_GF2MAT(list, p - 1);
     }
     else {
         PlainGF2Mat(list);
-        UNB_LIST( list, p );
+        UNB_LIST(list, p);
     }
     return 0;
 }
@@ -2163,16 +2082,14 @@ Obj FuncUNB_GF2MAT (
 **
 **  return the zero vector over GF2 of the same length as <mat>.
 */
-Obj FuncZERO_GF2VEC (
-    Obj                 self,
-    Obj                 mat )
+Obj FuncZERO_GF2VEC(Obj self, Obj mat)
 {
-    Obj                 zero;
-    UInt                len;
+    Obj  zero;
+    UInt len;
 
-    // create a new GF2 vector                                             
+    // create a new GF2 vector
     len = LEN_GF2VEC(mat);
-    NEW_GF2VEC( zero, TYPE_LIST_GF2VEC, len );
+    NEW_GF2VEC(zero, TYPE_LIST_GF2VEC, len);
     return zero;
 }
 
@@ -2182,18 +2099,16 @@ Obj FuncZERO_GF2VEC (
 **
 **  return the zero vector over GF2 of length <len>
 */
-Obj FuncZERO_GF2VEC_2 (
-    Obj                 self,
-    Obj                 len )
+Obj FuncZERO_GF2VEC_2(Obj self, Obj len)
 {
-    Obj                 zero;
+    Obj zero;
 
     // create a new GF2 vector
     if (!IS_INTOBJ(len))
-      ErrorMayQuit("ZERO_GF2VEC2: length must be a small integer, not a %s",
-		(Int)TNAM_OBJ(len),0L);
-    
-    NEW_GF2VEC( zero, TYPE_LIST_GF2VEC, INT_INTOBJ(len) );
+        ErrorMayQuit("ZERO_GF2VEC2: length must be a small integer, not a %s",
+                     (Int)TNAM_OBJ(len), 0L);
+
+    NEW_GF2VEC(zero, TYPE_LIST_GF2VEC, INT_INTOBJ(len));
     return zero;
 }
 
@@ -2206,21 +2121,20 @@ Obj FuncZERO_GF2VEC_2 (
 **  INVERSE_PLIST_GF2VECS_DESTRUCTIVE
 ** might do just as good a job
 */
-Obj FuncINV_GF2MAT_MUTABLE (
-    Obj                 self,
-    Obj                 mat )
+Obj FuncINV_GF2MAT_MUTABLE(Obj self, Obj mat)
 {
-    UInt                len;
+    UInt len;
 
     len = LEN_GF2MAT(mat);
-    if ( len != 0 ) {
-        if ( len != LEN_GF2VEC(ELM_GF2MAT(mat,1)) ) {
-            mat = ErrorReturnObj( "<matrix> must be square", 0, 0,
-                                  "you can replace <matrix> via 'return <matrix>;'" );
-	    return INV(mat);
+    if (len != 0) {
+        if (len != LEN_GF2VEC(ELM_GF2MAT(mat, 1))) {
+            mat = ErrorReturnObj(
+                "<matrix> must be square", 0, 0,
+                "you can replace <matrix> via 'return <matrix>;'");
+            return INV(mat);
         }
     }
-    return InverseGF2Mat(mat,2);
+    return InverseGF2Mat(mat, 2);
 }
 
 /****************************************************************************
@@ -2231,21 +2145,20 @@ Obj FuncINV_GF2MAT_MUTABLE (
 **  INVERSE_PLIST_GF2VECS_DESTRUCTIVE
 ** might do just as good a job
 */
-Obj FuncINV_GF2MAT_SAME_MUTABILITY (
-    Obj                 self,
-    Obj                 mat )
+Obj FuncINV_GF2MAT_SAME_MUTABILITY(Obj self, Obj mat)
 {
-    UInt                len;
+    UInt len;
 
     len = LEN_GF2MAT(mat);
-    if ( len != 0 ) {
-        if ( len != LEN_GF2VEC(ELM_GF2MAT(mat,1)) ) {
-            mat = ErrorReturnObj( "<matrix> must be square", 0, 0,
-                                  "you can replace <matrix> via 'return <matrix>;'" );
-	    return INV_MUT(mat);
+    if (len != 0) {
+        if (len != LEN_GF2VEC(ELM_GF2MAT(mat, 1))) {
+            mat = ErrorReturnObj(
+                "<matrix> must be square", 0, 0,
+                "you can replace <matrix> via 'return <matrix>;'");
+            return INV_MUT(mat);
         }
     }
-    return InverseGF2Mat(mat,1);
+    return InverseGF2Mat(mat, 1);
 }
 
 /****************************************************************************
@@ -2256,24 +2169,23 @@ Obj FuncINV_GF2MAT_SAME_MUTABILITY (
 **  INVERSE_PLIST_GF2VECS_DESTRUCTIVE
 ** might do just as good a job
 */
-Obj FuncINV_GF2MAT_IMMUTABLE (
-    Obj                 self,
-    Obj                 mat )
+Obj FuncINV_GF2MAT_IMMUTABLE(Obj self, Obj mat)
 {
-    UInt                len;
+    UInt len;
 
     len = LEN_GF2MAT(mat);
-    if ( len != 0 ) {
-        if ( len != LEN_GF2VEC(ELM_GF2MAT(mat,1)) ) {
-	  Obj inv;
-	  mat = ErrorReturnObj( "<matrix> must be square", 0, 0,
-				"you can replace <matrix> via 'return <matrix>;'" );
-	  inv = INV(mat);
-	  MakeImmutable(inv);
-	  return inv;
+    if (len != 0) {
+        if (len != LEN_GF2VEC(ELM_GF2MAT(mat, 1))) {
+            Obj inv;
+            mat = ErrorReturnObj(
+                "<matrix> must be square", 0, 0,
+                "you can replace <matrix> via 'return <matrix>;'");
+            inv = INV(mat);
+            MakeImmutable(inv);
+            return inv;
         }
     }
-    return InverseGF2Mat(mat,0);
+    return InverseGF2Mat(mat, 0);
 }
 
 
@@ -2283,31 +2195,28 @@ Obj FuncINV_GF2MAT_IMMUTABLE (
 **
 **  invert possible GF2 matrix
 */
-Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE( Obj self, Obj list )
+Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE(Obj self, Obj list)
 {
-  UInt len,i;
-  Obj row;
-  len = LEN_PLIST(list);
-  for (i = 1; i <= len; i++)
-    {
-      row = ELM_PLIST(list,i);
-      if (!IS_GF2VEC_REP(row) || LEN_GF2VEC(row) != len)
-	return TRY_NEXT_METHOD;
+    UInt len, i;
+    Obj  row;
+    len = LEN_PLIST(list);
+    for (i = 1; i <= len; i++) {
+        row = ELM_PLIST(list, i);
+        if (!IS_GF2VEC_REP(row) || LEN_GF2VEC(row) != len)
+            return TRY_NEXT_METHOD;
     }
-  if ( len == 0 ) {
-    return CopyObj(list,1);
-  }
-  if (len == 1 ) {
-    row = ELM_PLIST(list,1);
-    if (CONST_BLOCKS_GF2VEC(row)[0] & 1)
-      {
-	return CopyObj(list, 1);
-	}
-    else
-      return Fail;
-  }
-  return InversePlistGF2VecsDesstructive(list);
-  
+    if (len == 0) {
+        return CopyObj(list, 1);
+    }
+    if (len == 1) {
+        row = ELM_PLIST(list, 1);
+        if (CONST_BLOCKS_GF2VEC(row)[0] & 1) {
+            return CopyObj(list, 1);
+        }
+        else
+            return Fail;
+    }
+    return InversePlistGF2VecsDesstructive(list);
 }
 
 
@@ -2324,28 +2233,23 @@ Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE( Obj self, Obj list )
 **  'FuncSUM_GF2VEC_GF2VEC'  is  an improved  version of 'SumListList', which
 **  does not call 'SUM' but uses bit operations instead.
 */
-Obj FuncSUM_GF2VEC_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncSUM_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-    Obj                 sum;            // sum, result                     
-    UInt ll,lr;
+    Obj  sum;    // sum, result
+    UInt ll, lr;
 
     ll = LEN_GF2VEC(vl);
     lr = LEN_GF2VEC(vr);
-    
-    
-    if (ll < lr)
-      {
-	sum = ShallowCopyVecGF2(vr);
-	AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sum),CONST_BLOCKS_GF2VEC(vl),ll);
-      }
-    else
-      {
-	sum = ShallowCopyVecGF2(vl);
-	AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sum),CONST_BLOCKS_GF2VEC(vr),lr);
-      }
+
+
+    if (ll < lr) {
+        sum = ShallowCopyVecGF2(vr);
+        AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sum), CONST_BLOCKS_GF2VEC(vl), ll);
+    }
+    else {
+        sum = ShallowCopyVecGF2(vl);
+        AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sum), CONST_BLOCKS_GF2VEC(vr), lr);
+    }
 
     if (!IS_MUTABLE_OBJ(vl) && !IS_MUTABLE_OBJ(vr))
         SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2VEC_IMM);
@@ -2359,20 +2263,16 @@ Obj FuncSUM_GF2VEC_GF2VEC (
 **                                      . . . . .  sum of GF2 vectors
 **
 */
-Obj FuncMULT_VECTOR_GF2VECS_2 (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 mul )
+Obj FuncMULT_VECTOR_GF2VECS_2(Obj self, Obj vl, Obj mul)
 {
-    if (EQ(mul,GF2One))
-      return (Obj) 0;
-    else if (EQ(mul,GF2Zero))
-      {
-	AddCoeffsGF2VecGF2Vec(vl,vl);
-	return (Obj) 0;
-      }
+    if (EQ(mul, GF2One))
+        return (Obj)0;
+    else if (EQ(mul, GF2Zero)) {
+        AddCoeffsGF2VecGF2Vec(vl, vl);
+        return (Obj)0;
+    }
     else
-      return TRY_NEXT_METHOD;
+        return TRY_NEXT_METHOD;
 }
 
 
@@ -2383,12 +2283,9 @@ Obj FuncMULT_VECTOR_GF2VECS_2 (
 **  'FuncPROD_GF2VEC_GF2VEC' returns the product of  the two GF2 vectors <vl>
 **  and <vr>.  The product is either `GF2One' or `GF2Zero'.
 */
-Obj FuncPROD_GF2VEC_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncPROD_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-    return ProdGF2VecGF2Vec( vl, vr );
+    return ProdGF2VecGF2Vec(vl, vr);
 }
 
 
@@ -2402,12 +2299,9 @@ Obj FuncPROD_GF2VEC_GF2VEC (
 **  The  product is  again a  GF2 vector.  It  is  the  responsibility of the
 **  caller to ensure that <vl> is a  GF2 vector, <vr>  a GF2 matrix.
 */
-Obj FuncPROD_GF2VEC_GF2MAT (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncPROD_GF2VEC_GF2MAT(Obj self, Obj vl, Obj vr)
 {
-    return ProdGF2VecGF2Mat( vl, vr );
+    return ProdGF2VecGF2Mat(vl, vr);
 }
 
 /****************************************************************************
@@ -2420,22 +2314,18 @@ Obj FuncPROD_GF2VEC_GF2MAT (
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
 */
-Obj FuncPROD_GF2MAT_GF2MAT (
-    Obj                 self,
-    Obj                 ml,
-    Obj                 mr )
+Obj FuncPROD_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
-  UInt lenl = LEN_GF2MAT(ml);
-  UInt lenm;
-  if (lenl >= 128)
-    {
-      lenm = LEN_GF2VEC(ELM_GF2MAT(ml,1));
-      if (lenm >= 128 && lenm == LEN_GF2MAT(mr) && LEN_GF2VEC(ELM_GF2MAT(mr,1)) >= 128)
-	{
-	  return ProdGF2MatGF2MatAdvanced( ml, mr, 8, (lenm+255)/256);
-	}
+    UInt lenl = LEN_GF2MAT(ml);
+    UInt lenm;
+    if (lenl >= 128) {
+        lenm = LEN_GF2VEC(ELM_GF2MAT(ml, 1));
+        if (lenm >= 128 && lenm == LEN_GF2MAT(mr) &&
+            LEN_GF2VEC(ELM_GF2MAT(mr, 1)) >= 128) {
+            return ProdGF2MatGF2MatAdvanced(ml, mr, 8, (lenm + 255) / 256);
+        }
     }
-    return ProdGF2MatGF2MatSimple( ml, mr );
+    return ProdGF2MatGF2MatSimple(ml, mr);
 }
 
 /****************************************************************************
@@ -2448,18 +2338,15 @@ Obj FuncPROD_GF2MAT_GF2MAT (
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
 */
-Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE (
-    Obj                 self,
-    Obj                 ml,
-    Obj                 mr )
+Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE(Obj self, Obj ml, Obj mr)
 {
-    return ProdGF2MatGF2MatSimple( ml, mr );
+    return ProdGF2MatGF2MatSimple(ml, mr);
 }
 
 
 /****************************************************************************
 **
-*F  FuncPROD_GF2MAT_GF2MAT_ADVANCED( <self>, <ml>, <mr>, <greaselevel>, 
+*F  FuncPROD_GF2MAT_GF2MAT_ADVANCED( <self>, <ml>, <mr>, <greaselevel>,
 **                                                              <blocksize> )
 **
 **  'FuncPROD_GF2MAT_GF2MAT_ADVANCED' returns the product of the GF2 matrices
@@ -2468,14 +2355,11 @@ Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE (
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
 */
-Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED (
-    Obj                 self,
-    Obj                 ml,
-    Obj                 mr,
-    Obj                 greaselevel,
-    Obj                 blocksize)
+Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED(
+    Obj self, Obj ml, Obj mr, Obj greaselevel, Obj blocksize)
 {
-    return ProdGF2MatGF2MatAdvanced( ml, mr, INT_INTOBJ(greaselevel), INT_INTOBJ(blocksize) );
+    return ProdGF2MatGF2MatAdvanced(ml, mr, INT_INTOBJ(greaselevel),
+                                    INT_INTOBJ(blocksize));
 }
 
 
@@ -2489,12 +2373,9 @@ Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED (
 **  The  product is  again a  GF2 vector.  It  is  the  responsibility of the
 **  caller to ensure that <vr> is a  GF2 vector, <vl>  a GF2 matrix.
 */
-Obj FuncPROD_GF2MAT_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncPROD_GF2MAT_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-    return ProdGF2MatGF2Vec( vl, vr );
+    return ProdGF2MatGF2Vec(vl, vr);
 }
 
 
@@ -2502,23 +2383,19 @@ Obj FuncPROD_GF2MAT_GF2VEC (
 **
 *F  FuncADDCOEFFS_GF2VEC_GF2VEC_MULT( <self>, <vl>, <vr>, <mul> ) GF2 vectors
 */
-Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr,
-    Obj                 mul )
+Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(Obj self, Obj vl, Obj vr, Obj mul)
 {
-    // do nothing if <mul> is zero                                         
-    if ( EQ(mul,GF2Zero) ) {
-        return INTOBJ_INT( RightMostOneGF2Vec(vl) );
+    // do nothing if <mul> is zero
+    if (EQ(mul, GF2Zero)) {
+        return INTOBJ_INT(RightMostOneGF2Vec(vl));
     }
 
-    // add if <mul> is one                                                 
-    if ( EQ(mul,GF2One) ) {
-        return AddCoeffsGF2VecGF2Vec( vl, vr );
+    // add if <mul> is one
+    if (EQ(mul, GF2One)) {
+        return AddCoeffsGF2VecGF2Vec(vl, vr);
     }
 
-    // try next method                                                     
+    // try next method
     return TRY_NEXT_METHOD;
 }
 
@@ -2527,23 +2404,19 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT (
 *F  FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(<self>,<vl>,<vr>,<mul>,<from>,<to>)
 **  GF2 vectors
 */
-Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT_LIMS (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr,
-    Obj                 mul )
+Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT_LIMS(Obj self, Obj vl, Obj vr, Obj mul)
 {
-    // do nothing if <mul> is zero                                         
-    if ( EQ(mul,GF2Zero) ) {
-        return INTOBJ_INT( RightMostOneGF2Vec(vl) );
+    // do nothing if <mul> is zero
+    if (EQ(mul, GF2Zero)) {
+        return INTOBJ_INT(RightMostOneGF2Vec(vl));
     }
 
-    // add if <mul> is one                                                 
-    if ( EQ(mul,GF2One) ) {
-        return AddCoeffsGF2VecGF2Vec( vl, vr );
+    // add if <mul> is one
+    if (EQ(mul, GF2One)) {
+        return AddCoeffsGF2VecGF2Vec(vl, vr);
     }
 
-    // try next method                                                     
+    // try next method
     return TRY_NEXT_METHOD;
 }
 
@@ -2552,12 +2425,9 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT_LIMS (
 **
 *F  FuncADDCOEFFS_GF2VEC_GF2VEC( <self>, <vl>, <vr> ) . . . . . . GF2 vectors
 */
-Obj FuncADDCOEFFS_GF2VEC_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncADDCOEFFS_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-    return AddCoeffsGF2VecGF2Vec( vl, vr );
+    return AddCoeffsGF2VecGF2Vec(vl, vr);
 }
 
 
@@ -2565,53 +2435,51 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC (
 **
 *F  FuncSHRINKCOEFFS_GF2VEC( <self>, <vec> )  . . . . . remove trailing zeros
 */
-Obj FuncSHRINKCOEFFS_GF2VEC (
-    Obj                 self,
-    Obj                 vec )
+Obj FuncSHRINKCOEFFS_GF2VEC(Obj self, Obj vec)
 {
-    UInt                len;
-    UInt                nbb;
-    UInt                onbb;
-    UInt *              ptr;
-    UInt		off;
+    UInt   len;
+    UInt   nbb;
+    UInt   onbb;
+    UInt * ptr;
+    UInt   off;
 
-    // get length and number of blocks                                     
+    // get length and number of blocks
     len = LEN_GF2VEC(vec);
-    if ( len == 0 ) {
+    if (len == 0) {
         return INTOBJ_INT(0);
     }
 
-    nbb = ( len + BIPEB - 1 ) / BIPEB;
-    onbb = nbb; 
-    ptr = BLOCKS_GF2VEC(vec) + (nbb-1);
-    
-    // number of insignificant bit positions in last word 
-    off = BIPEB - ((len-1)%BIPEB+1); 
-    
-    // mask out the last bits 
+    nbb = (len + BIPEB - 1) / BIPEB;
+    onbb = nbb;
+    ptr = BLOCKS_GF2VEC(vec) + (nbb - 1);
+
+    // number of insignificant bit positions in last word
+    off = BIPEB - ((len - 1) % BIPEB + 1);
+
+    // mask out the last bits
 #ifdef SYS_IS_64_BIT
     *ptr &= 0xffffffffffffffff >> off;
 #else
     *ptr &= 0xffffffff >> off;
 #endif
 
-    // find last non-trivial block 
-    while ( 0 < nbb && ! *ptr ) {
+    // find last non-trivial block
+    while (0 < nbb && !*ptr) {
         nbb--;
         ptr--;
     }
-    // did the block number change? 
+    // did the block number change?
     if (nbb < onbb) {
-      len = nbb * BIPEB;
+        len = nbb * BIPEB;
     }
 
-    // find position inside this block                   
-    // we are guaranteed not to cross a block boundary ! 
-    while ( 0 < len && ! ( *ptr & MASK_POS_GF2VEC(len) ) ) {
+    // find position inside this block
+    // we are guaranteed not to cross a block boundary !
+    while (0 < len && !(*ptr & MASK_POS_GF2VEC(len))) {
         len--;
     }
-    ResizeWordSizedBag( vec, SIZE_PLEN_GF2VEC(len) );
-    SET_LEN_GF2VEC( vec, len );
+    ResizeWordSizedBag(vec, SIZE_PLEN_GF2VEC(len));
+    SET_LEN_GF2VEC(vec, len);
     return INTOBJ_INT(len);
 }
 
@@ -2623,102 +2491,91 @@ Obj FuncSHRINKCOEFFS_GF2VEC (
 **  It is *not* used in the code and can be replaced by a dummy argument.
 */
 
-UInt PositionNonZeroGF2Vec ( Obj vec, UInt from)
+UInt PositionNonZeroGF2Vec(Obj vec, UInt from)
 {
-    UInt                len;
-    UInt                nbb;
-    UInt                nb;
-    const UInt *        ptr;
-    UInt                pos;
+    UInt         len;
+    UInt         nbb;
+    UInt         nb;
+    const UInt * ptr;
+    UInt         pos;
 
-    // get length and number of blocks                                     
+    // get length and number of blocks
     len = LEN_GF2VEC(vec);
-    if ( len == 0 ) {
-      return 1;
+    if (len == 0) {
+        return 1;
     }
 
 
     nbb = from / BIPEB;
     pos = from % BIPEB;
-    ptr = CONST_BLOCKS_GF2VEC(vec)+nbb;
-    if (pos) // partial block to check 
-      {
-	pos = from+1;
-	while ( (pos - 1)%BIPEB  && pos <= len)
-	  {
-	    if ((*ptr) & MASK_POS_GF2VEC(pos)) 
-	      return (pos);
-	    pos++;
-	  }
-	if (pos > len)
-	  return len+1;
-	nbb++;
-	ptr++;
-      }
-    // find first non-trivial block                                         
+    ptr = CONST_BLOCKS_GF2VEC(vec) + nbb;
+    if (pos)    // partial block to check
+    {
+        pos = from + 1;
+        while ((pos - 1) % BIPEB && pos <= len) {
+            if ((*ptr) & MASK_POS_GF2VEC(pos))
+                return (pos);
+            pos++;
+        }
+        if (pos > len)
+            return len + 1;
+        nbb++;
+        ptr++;
+    }
+    // find first non-trivial block
     nb = NUMBER_BLOCKS_GF2VEC(vec);
-    while ( nbb < nb && ! *ptr ) {
+    while (nbb < nb && !*ptr) {
         nbb++;
         ptr++;
     }
 
-    // find position inside this block                                     
+    // find position inside this block
     pos = nbb * BIPEB + 1;
-    while ( pos <= len && ! ( *ptr & MASK_POS_GF2VEC(pos) ) ) {
+    while (pos <= len && !(*ptr & MASK_POS_GF2VEC(pos))) {
         pos++;
     }
-    // as the code is intended to run over, trailing 1's are innocent 
+    // as the code is intended to run over, trailing 1's are innocent
     if (pos <= len)
-      return pos;
+        return pos;
     else
-      return len+1;
+        return len + 1;
 }
 
 
-Obj FuncPOSITION_NONZERO_GF2VEC(
-    Obj                 self,
-    Obj                 vec,
-    Obj                 zero)
+Obj FuncPOSITION_NONZERO_GF2VEC(Obj self, Obj vec, Obj zero)
 {
-  return INTOBJ_INT(PositionNonZeroGF2Vec(vec, 0));
+    return INTOBJ_INT(PositionNonZeroGF2Vec(vec, 0));
 }
 
-Obj FuncPOSITION_NONZERO_GF2VEC3(
-    Obj                 self,
-    Obj                 vec,
-    Obj                 zero,
-    Obj                 from)
+Obj FuncPOSITION_NONZERO_GF2VEC3(Obj self, Obj vec, Obj zero, Obj from)
 {
-  return INTOBJ_INT(PositionNonZeroGF2Vec(vec, INT_INTOBJ(from)));
+    return INTOBJ_INT(PositionNonZeroGF2Vec(vec, INT_INTOBJ(from)));
 }
 
 
-
-Obj FuncCOPY_SECTION_GF2VECS(Obj self, Obj src, Obj dest, Obj from, Obj to, Obj howmany) 
+Obj FuncCOPY_SECTION_GF2VECS(
+    Obj self, Obj src, Obj dest, Obj from, Obj to, Obj howmany)
 {
-  Int   ifrom;
-  Int   ito;
-  Int   ihowmany;
-  UInt  lens;
-  UInt  lend;
-  if (!IS_GF2VEC_REP(src) ||
-      !IS_GF2VEC_REP(dest) ||
-      !IS_INTOBJ(from) || 
-      !IS_INTOBJ(to) || 
-      !IS_INTOBJ(howmany)) 
-    ErrorMayQuit("Bad argument types", 0,0);
-  ifrom = INT_INTOBJ(from);
-  ito = INT_INTOBJ(to);
-  ihowmany = INT_INTOBJ(howmany);
-  lens = LEN_GF2VEC(src);
-  lend = LEN_GF2VEC(dest);
-  if (ifrom <= 0 || ito <= 0 ||
-      ihowmany < 0 || ifrom + ihowmany -1 > lens || ito + ihowmany -1 > lend)
-    ErrorMayQuit("Bad argument values",0,0);
-  if (!IS_MUTABLE_OBJ(dest))
-    ErrorMayQuit("Immutable destination vector", 0,0);
-  CopySection_GF2Vecs(src, dest, (UInt)ifrom, (UInt)ito, (UInt)ihowmany);
-  return (Obj) 0;
+    Int  ifrom;
+    Int  ito;
+    Int  ihowmany;
+    UInt lens;
+    UInt lend;
+    if (!IS_GF2VEC_REP(src) || !IS_GF2VEC_REP(dest) || !IS_INTOBJ(from) ||
+        !IS_INTOBJ(to) || !IS_INTOBJ(howmany))
+        ErrorMayQuit("Bad argument types", 0, 0);
+    ifrom = INT_INTOBJ(from);
+    ito = INT_INTOBJ(to);
+    ihowmany = INT_INTOBJ(howmany);
+    lens = LEN_GF2VEC(src);
+    lend = LEN_GF2VEC(dest);
+    if (ifrom <= 0 || ito <= 0 || ihowmany < 0 ||
+        ifrom + ihowmany - 1 > lens || ito + ihowmany - 1 > lend)
+        ErrorMayQuit("Bad argument values", 0, 0);
+    if (!IS_MUTABLE_OBJ(dest))
+        ErrorMayQuit("Immutable destination vector", 0, 0);
+    CopySection_GF2Vecs(src, dest, (UInt)ifrom, (UInt)ito, (UInt)ihowmany);
+    return (Obj)0;
 }
 
 
@@ -2728,20 +2585,19 @@ Obj FuncCOPY_SECTION_GF2VECS(Obj self, Obj src, Obj dest, Obj from, Obj to, Obj 
 **
 */
 
-Obj FuncAPPEND_GF2VEC( Obj self, Obj vecl, Obj vecr )
+Obj FuncAPPEND_GF2VEC(Obj self, Obj vecl, Obj vecr)
 {
-  UInt lenl, lenr;
-  lenl = LEN_GF2VEC(vecl);
-  lenr = LEN_GF2VEC(vecr);
-  if (True == DoFilter(IsLockedRepresentationVector, vecl) && lenr > 0)
-    {
-      ErrorMayQuit("Append to locked compressed vector is forbidden", 0, 0);
-      return 0;
+    UInt lenl, lenr;
+    lenl = LEN_GF2VEC(vecl);
+    lenr = LEN_GF2VEC(vecr);
+    if (True == DoFilter(IsLockedRepresentationVector, vecl) && lenr > 0) {
+        ErrorMayQuit("Append to locked compressed vector is forbidden", 0, 0);
+        return 0;
     }
-  ResizeWordSizedBag(vecl, SIZE_PLEN_GF2VEC(lenl+lenr));
-  CopySection_GF2Vecs(vecr, vecl, 1, lenl+1, lenr);
-  SET_LEN_GF2VEC(vecl,lenl+lenr);
-  return (Obj) 0;
+    ResizeWordSizedBag(vecl, SIZE_PLEN_GF2VEC(lenl + lenr));
+    CopySection_GF2Vecs(vecr, vecl, 1, lenl + 1, lenr);
+    SET_LEN_GF2VEC(vecl, lenl + lenr);
+    return (Obj)0;
 }
 
 
@@ -2751,9 +2607,9 @@ Obj FuncAPPEND_GF2VEC( Obj self, Obj vecl, Obj vecr )
 **
 */
 
-Obj FuncSHALLOWCOPY_GF2VEC( Obj self, Obj vec)
+Obj FuncSHALLOWCOPY_GF2VEC(Obj self, Obj vec)
 {
-  return ShallowCopyVecGF2(vec);
+    return ShallowCopyVecGF2(vec);
 }
 
 /****************************************************************************
@@ -2763,96 +2619,87 @@ Obj FuncSHALLOWCOPY_GF2VEC( Obj self, Obj vec)
 */
 
 
-Obj FuncSUM_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
+Obj FuncSUM_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 {
-  UInt ll,lr,ls, lm,wl,wr,ws,wm;
-  Obj sum;
-  Obj vl,vr, sv;
-  UInt i;
-  Obj rtype;
-  ll = LEN_GF2MAT(matl);
-  lr = LEN_GF2MAT(matr);
-  if (ll > lr)
-    {
-      ls = ll;
-      lm = lr;
+    UInt ll, lr, ls, lm, wl, wr, ws, wm;
+    Obj  sum;
+    Obj  vl, vr, sv;
+    UInt i;
+    Obj  rtype;
+    ll = LEN_GF2MAT(matl);
+    lr = LEN_GF2MAT(matr);
+    if (ll > lr) {
+        ls = ll;
+        lm = lr;
     }
-  else
-    {
-      ls = lr;
-      lm = ll;
+    else {
+        ls = lr;
+        lm = ll;
     }
-  wl = LEN_GF2VEC(ELM_GF2MAT(matl, 1));
-  wr = LEN_GF2VEC(ELM_GF2MAT(matr, 1));
-  if (wl > wr)
-    {
-      ws = wl;
-      wm = wr;
+    wl = LEN_GF2VEC(ELM_GF2MAT(matl, 1));
+    wr = LEN_GF2VEC(ELM_GF2MAT(matr, 1));
+    if (wl > wr) {
+        ws = wl;
+        wm = wr;
     }
-  else
-    {
-      ws = wr;
-      wm = wl;
+    else {
+        ws = wr;
+        wm = wl;
     }
 
-  // In this case, the result is not rectangular 
-  
-  if ((ll > lr && wr > wl) || (ll < lr && wr < wl)) 
-    return TRY_NEXT_METHOD;
+    // In this case, the result is not rectangular
 
-  
-  sum = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT( ls ));
-  if (IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr))
-    {
-      SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2MAT);
-      if (IS_MUTABLE_OBJ(ELM_GF2MAT(matl,1)) || IS_MUTABLE_OBJ(ELM_GF2MAT(matr,1)))
-	rtype = TYPE_LIST_GF2VEC_LOCKED;
-      else
-	rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
-    }
-  else
-    {
-      SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2MAT_IMM);
-      rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
-    }
-  
-  SET_LEN_GF2MAT(sum, ls);
-  for (i = 1; i <= lm; i++)
-    {
+    if ((ll > lr && wr > wl) || (ll < lr && wr < wl))
+        return TRY_NEXT_METHOD;
 
-      // copy the longer vector and add the shorter 
-      if (wl == ws) 
-	{
-	  sv = ShallowCopyVecGF2( ELM_GF2MAT( matl, i));
-	  vr = ELM_GF2MAT( matr, i);
-	  AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sv), CONST_BLOCKS_GF2VEC(vr), wm);
-	}
-      else
-	{
-	  sv = ShallowCopyVecGF2( ELM_GF2MAT(matr, i));
-	  vl = ELM_GF2MAT( matl, i);
-	  AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sv), CONST_BLOCKS_GF2VEC(vl), wm);
-	}
-      
-      SetTypeDatObj(sv, rtype);
-      SET_ELM_GF2MAT( sum, i, sv);
-      CHANGED_BAG(sum);
-    }
-  for (; i <= ls; i++)
-    {
-      if (ll > lr)
-	sv = ELM_GF2MAT(matl, i);
-      else
-	sv = ELM_GF2MAT(matr, i);
 
-      if (rtype == TYPE_LIST_GF2VEC_LOCKED)
-	sv = ShallowCopyVecGF2( sv );
-      
-      SetTypeDatObj(sv, rtype);
-      SET_ELM_GF2MAT( sum, i, sv);
-      CHANGED_BAG(sum);      
+    sum = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(ls));
+    if (IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr)) {
+        SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2MAT);
+        if (IS_MUTABLE_OBJ(ELM_GF2MAT(matl, 1)) ||
+            IS_MUTABLE_OBJ(ELM_GF2MAT(matr, 1)))
+            rtype = TYPE_LIST_GF2VEC_LOCKED;
+        else
+            rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
-  return sum;
+    else {
+        SET_TYPE_POSOBJ(sum, TYPE_LIST_GF2MAT_IMM);
+        rtype = TYPE_LIST_GF2VEC_IMM_LOCKED;
+    }
+
+    SET_LEN_GF2MAT(sum, ls);
+    for (i = 1; i <= lm; i++) {
+
+        // copy the longer vector and add the shorter
+        if (wl == ws) {
+            sv = ShallowCopyVecGF2(ELM_GF2MAT(matl, i));
+            vr = ELM_GF2MAT(matr, i);
+            AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sv), CONST_BLOCKS_GF2VEC(vr), wm);
+        }
+        else {
+            sv = ShallowCopyVecGF2(ELM_GF2MAT(matr, i));
+            vl = ELM_GF2MAT(matl, i);
+            AddGF2VecToGF2Vec(BLOCKS_GF2VEC(sv), CONST_BLOCKS_GF2VEC(vl), wm);
+        }
+
+        SetTypeDatObj(sv, rtype);
+        SET_ELM_GF2MAT(sum, i, sv);
+        CHANGED_BAG(sum);
+    }
+    for (; i <= ls; i++) {
+        if (ll > lr)
+            sv = ELM_GF2MAT(matl, i);
+        else
+            sv = ELM_GF2MAT(matr, i);
+
+        if (rtype == TYPE_LIST_GF2VEC_LOCKED)
+            sv = ShallowCopyVecGF2(sv);
+
+        SetTypeDatObj(sv, rtype);
+        SET_ELM_GF2MAT(sum, i, sv);
+        CHANGED_BAG(sum);
+    }
+    return sum;
 }
 
 
@@ -2861,86 +2708,87 @@ Obj FuncSUM_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
 *F  FuncTRANSPOSED_GF2MAT( <self>, <mat>)
 **
 */
-Obj FuncTRANSPOSED_GF2MAT( Obj self, Obj mat)
+Obj FuncTRANSPOSED_GF2MAT(Obj self, Obj mat)
 {
-  UInt l,w;
-  Obj tra,row;
-  Obj typ,r1;
-  UInt vals[BIPEB];
-  UInt mask,val,bit;
-  UInt imod,nrb,nstart;
-  UInt i,j,k,n;
+    UInt l, w;
+    Obj  tra, row;
+    Obj  typ, r1;
+    UInt vals[BIPEB];
+    UInt mask, val, bit;
+    UInt imod, nrb, nstart;
+    UInt i, j, k, n;
 
-  // check argument 
-  if (TNUM_OBJ(mat) != T_POSOBJ) {
-     mat = ErrorReturnObj(
-            "TRANSPOSED_GF2MAT: Need compressed matrix over GF(2)\n",
-            0, 0, 
+    // check argument
+    if (TNUM_OBJ(mat) != T_POSOBJ) {
+        mat = ErrorReturnObj(
+            "TRANSPOSED_GF2MAT: Need compressed matrix over GF(2)\n", 0, 0,
             "You can return such matrix with 'return mat;'\n");
-  }
-  // type for mat 
-  typ = TYPE_LIST_GF2MAT;
-
-
-  // we assume here that there is a first row 
-  r1 = ELM_GF2MAT(mat,1);
-  
-  l = LEN_GF2MAT(mat);
-  w = LEN_GF2VEC(r1);
-  nrb=NUMBER_BLOCKS_GF2VEC(r1);
-
-  tra = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT( w ));
-  SET_TYPE_POSOBJ(tra, typ);
-
-  // type for rows 
-  typ = TYPE_LIST_GF2VEC_LOCKED;
-  
-  SET_LEN_GF2MAT(tra, w);
-  // create new matrix 
-  for (i = 1; i <= w; i++) {
-    NEW_GF2VEC( row,  typ, l );
-    SET_ELM_GF2MAT( tra, i, row);
-    CHANGED_BAG(tra);
-  }
-  // set entries 
-  // run over BIPEB row chunks of the original matrix 
-  for (i = 1; i <= l; i=i+BIPEB) {
-    imod=(i-1)/BIPEB;
-    // run through these rows in block chunks 
-    for (n=0;n<nrb;n++) {
-      for (j=0;j<BIPEB;j++) {
-	if ((i+j)>l) {
-	  vals[j]=0; // outside matrix  
-	}
-	else {
-	  const UInt * ptr=CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mat,i+j))+n;
-	  vals[j]=*ptr;
-	}
-      }
-      // write transposed values in new matrix 
-      mask=1;
-      nstart=n*BIPEB+1;
-      for (j=0;j<BIPEB;j++) { // bit number = Row in transpose 
-	if ((nstart+j)<=w) {
-	  // still within matrix 
-	  val=0;
-	  bit=1;
-	  for (k=0;k<BIPEB;k++) {
-	    if (mask==(vals[k]&mask)) {
-	      val|=bit; // set bit 
-	    }
-	    bit=bit<<1;
-	  }
-	  // set entry 
-	  UInt * ptr = BLOCKS_GF2VEC(ELM_GF2MAT(tra,nstart+j))+imod;
-	  *ptr=val;
-	  // next bit 
-	  mask=mask<<1;
-	}
-      }
     }
-  }
-  return tra;
+    // type for mat
+    typ = TYPE_LIST_GF2MAT;
+
+
+    // we assume here that there is a first row
+    r1 = ELM_GF2MAT(mat, 1);
+
+    l = LEN_GF2MAT(mat);
+    w = LEN_GF2VEC(r1);
+    nrb = NUMBER_BLOCKS_GF2VEC(r1);
+
+    tra = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(w));
+    SET_TYPE_POSOBJ(tra, typ);
+
+    // type for rows
+    typ = TYPE_LIST_GF2VEC_LOCKED;
+
+    SET_LEN_GF2MAT(tra, w);
+    // create new matrix
+    for (i = 1; i <= w; i++) {
+        NEW_GF2VEC(row, typ, l);
+        SET_ELM_GF2MAT(tra, i, row);
+        CHANGED_BAG(tra);
+    }
+    // set entries
+    // run over BIPEB row chunks of the original matrix
+    for (i = 1; i <= l; i = i + BIPEB) {
+        imod = (i - 1) / BIPEB;
+        // run through these rows in block chunks
+        for (n = 0; n < nrb; n++) {
+            for (j = 0; j < BIPEB; j++) {
+                if ((i + j) > l) {
+                    vals[j] = 0;    // outside matrix
+                }
+                else {
+                    const UInt * ptr =
+                        CONST_BLOCKS_GF2VEC(ELM_GF2MAT(mat, i + j)) + n;
+                    vals[j] = *ptr;
+                }
+            }
+            // write transposed values in new matrix
+            mask = 1;
+            nstart = n * BIPEB + 1;
+            for (j = 0; j < BIPEB; j++) {    // bit number = Row in transpose
+                if ((nstart + j) <= w) {
+                    // still within matrix
+                    val = 0;
+                    bit = 1;
+                    for (k = 0; k < BIPEB; k++) {
+                        if (mask == (vals[k] & mask)) {
+                            val |= bit;    // set bit
+                        }
+                        bit = bit << 1;
+                    }
+                    // set entry
+                    UInt * ptr =
+                        BLOCKS_GF2VEC(ELM_GF2MAT(tra, nstart + j)) + imod;
+                    *ptr = val;
+                    // next bit
+                    mask = mask << 1;
+                }
+            }
+        }
+    }
+    return tra;
 }
 
 
@@ -2949,90 +2797,86 @@ Obj FuncTRANSPOSED_GF2MAT( Obj self, Obj mat)
 *F  FuncNUMBER_GF2VEC( <self>, <vect> )
 **
 */
-Obj FuncNUMBER_GF2VEC( Obj self, Obj vec )
+Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
 {
-  UInt len,nd,i;
-  UInt head,a;
-  UInt off,off2;		// 0 based 
-  Obj zahl;  // the long number 
-  UInt *num2;
-  mp_limb_t *vp;
-  len = LEN_GF2VEC(vec);
-  if (len == 0)
-    return INTOBJ_INT(1);
-  num2 = BLOCKS_GF2VEC(vec) + (len-1)/BIPEB;
-  off = (len -1) % BIPEB + 1; // number of significant bits in last word 
-  off2 = BIPEB - off;         // number of insignificant bits in last word 
+    UInt        len, nd, i;
+    UInt        head, a;
+    UInt        off, off2;    // 0 based
+    Obj         zahl;         // the long number
+    UInt *      num2;
+    mp_limb_t * vp;
+    len = LEN_GF2VEC(vec);
+    if (len == 0)
+        return INTOBJ_INT(1);
+    num2 = BLOCKS_GF2VEC(vec) + (len - 1) / BIPEB;
+    off = (len - 1) % BIPEB + 1;    // number of significant bits in last word
+    off2 = BIPEB - off;    // number of insignificant bits in last word
 
-  // mask out the last bits 
+    // mask out the last bits
 #ifdef SYS_IS_64_BIT
-  *num2 &= 0xffffffffffffffff >> off2;
+    *num2 &= 0xffffffffffffffff >> off2;
 #else
-  *num2 &= 0xffffffff >> off2;
+    *num2 &= 0xffffffff >> off2;
 #endif
 
-  if (len <=NR_SMALL_INT_BITS) 
-    // it still fits into a small integer 
-    return INTOBJ_INT(revertbits(*num2,len));
-  else {
-    // we might have to build a long integer 
-
-    // the number of words (limbs) we need. 
-    nd = ((len-1)/GMP_LIMB_BITS)+1;
-
-    zahl = NewBag( T_INTPOS, nd*sizeof(UInt) );
-    //    zahl = NewBag( T_INTPOS, (((nd+1)>>1)<<1)*sizeof(UInt) );
-    // +1)>>1)<<1: round up to next even number
-
-    // garbage collection might lose pointer 
-    const UInt *num = CONST_BLOCKS_GF2VEC(vec) + (len-1)/BIPEB;
-
-    vp = (mp_limb_t *)ADDR_OBJ(zahl); // the place we write to 
-    i=1;
-
-    if (off!=BIPEB) {
-      head = revertbits(*num,off); // the last 'off' bits, reverted 
-      while (i<nd) {
-	// next word 
-	num--;
-	*vp = head; // the bits left from last word 
-	a = revertbits(*num,BIPEB); // the full word reverted 
-	head = a>>off2; // next head: trailing `off' bits 
-	a =a << off; // the rest of the word 
-	*vp |=a;
-	vp++;
-	i++;
-      }
-      *vp = head; // last head bits 
-      vp++;
-    }
+    if (len <= NR_SMALL_INT_BITS)
+        // it still fits into a small integer
+        return INTOBJ_INT(revertbits(*num2, len));
     else {
-      while (i<=nd) {
-        *vp=revertbits(*num--,BIPEB);
-	vp++;
-	i++;
-      }
+        // we might have to build a long integer
+
+        // the number of words (limbs) we need.
+        nd = ((len - 1) / GMP_LIMB_BITS) + 1;
+
+        zahl = NewBag(T_INTPOS, nd * sizeof(UInt));
+        //    zahl = NewBag( T_INTPOS, (((nd+1)>>1)<<1)*sizeof(UInt) );
+        // +1)>>1)<<1: round up to next even number
+
+        // garbage collection might lose pointer
+        const UInt * num = CONST_BLOCKS_GF2VEC(vec) + (len - 1) / BIPEB;
+
+        vp = (mp_limb_t *)ADDR_OBJ(zahl);    // the place we write to
+        i = 1;
+
+        if (off != BIPEB) {
+            head = revertbits(*num, off);    // the last 'off' bits, reverted
+            while (i < nd) {
+                // next word
+                num--;
+                *vp = head;    // the bits left from last word
+                a = revertbits(*num, BIPEB);    // the full word reverted
+                head = a >> off2;    // next head: trailing `off' bits
+                a = a << off;        // the rest of the word
+                *vp |= a;
+                vp++;
+                i++;
+            }
+            *vp = head;    // last head bits
+            vp++;
+        }
+        else {
+            while (i <= nd) {
+                *vp = revertbits(*num--, BIPEB);
+                vp++;
+                i++;
+            }
+        }
+
+
+        zahl = GMP_NORMALIZE(zahl);
+        zahl = GMP_REDUCE(zahl);
+
+        return zahl;
     }
-
-
-    zahl = GMP_NORMALIZE(zahl);
-    zahl = GMP_REDUCE(zahl);
-    
-    return zahl;
-  }
-
 }
 
 /****************************************************************************
 **
 *F  FuncLT_GF2VEC_GF2VEC( <self>, <vl>, <vr> )   compare GF2 vectors
 */
-Obj FuncLT_GF2VEC_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncLT_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-  return (Cmp_GF2VEC_GF2VEC(vl,vr) < 0) ? True : False;
+    return (Cmp_GF2VEC_GF2VEC(vl, vr) < 0) ? True : False;
 }
 
 /****************************************************************************
@@ -3040,25 +2884,23 @@ Obj FuncLT_GF2VEC_GF2VEC (
 *F  Cmp_GF2MAT_GF2MAT( <ml>, <mr> )   compare GF2 matrices
 */
 
-Int Cmp_GF2MAT_GF2MAT( Obj ml, Obj mr)
+Int Cmp_GF2MAT_GF2MAT(Obj ml, Obj mr)
 {
-  UInt l1, l2,l, i;
-  Int c;
-  l1 = INT_INTOBJ(ELM_PLIST(ml,1));
-  l2 = INT_INTOBJ(ELM_PLIST(mr,1));
-  l = (l1 < l2) ? l1 : l2;
-  for (i = 2; i <= l+1; i++)
-    {
-      c = Cmp_GF2VEC_GF2VEC(ELM_PLIST(ml,i), ELM_PLIST(mr,i));
-      if (c != 0)
-	return c;
+    UInt l1, l2, l, i;
+    Int  c;
+    l1 = INT_INTOBJ(ELM_PLIST(ml, 1));
+    l2 = INT_INTOBJ(ELM_PLIST(mr, 1));
+    l = (l1 < l2) ? l1 : l2;
+    for (i = 2; i <= l + 1; i++) {
+        c = Cmp_GF2VEC_GF2VEC(ELM_PLIST(ml, i), ELM_PLIST(mr, i));
+        if (c != 0)
+            return c;
     }
-  if (l1 < l2)
-    return -1;
-  if (l1 > l2)
-    return 1;
-  return 0;
-  
+    if (l1 < l2)
+        return -1;
+    if (l1 > l2)
+        return 1;
+    return 0;
 }
 
 /****************************************************************************
@@ -3066,11 +2908,11 @@ Int Cmp_GF2MAT_GF2MAT( Obj ml, Obj mr)
 *F  FuncEQ_GF2MAT_GF2MAT( <ml>, <mr> )   compare GF2 matrices
 */
 
-Obj FuncEQ_GF2MAT_GF2MAT( Obj self, Obj ml, Obj mr)
+Obj FuncEQ_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
-  if (ELM_PLIST(ml,1) != ELM_PLIST(mr,1))
-    return False;
-  return (0 == Cmp_GF2MAT_GF2MAT(ml,mr)) ? True : False;
+    if (ELM_PLIST(ml, 1) != ELM_PLIST(mr, 1))
+        return False;
+    return (0 == Cmp_GF2MAT_GF2MAT(ml, mr)) ? True : False;
 }
 
 /****************************************************************************
@@ -3078,9 +2920,9 @@ Obj FuncEQ_GF2MAT_GF2MAT( Obj self, Obj ml, Obj mr)
 *F  FuncLT_GF2MAT_GF2MAT( <ml>, <mr> )   compare GF2 matrices
 */
 
-Obj FuncLT_GF2MAT_GF2MAT( Obj self, Obj ml, Obj mr)
+Obj FuncLT_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
-  return (Cmp_GF2MAT_GF2MAT(ml,mr) < 0) ? True : False;
+    return (Cmp_GF2MAT_GF2MAT(ml, mr) < 0) ? True : False;
 }
 
 /****************************************************************************
@@ -3089,25 +2931,25 @@ Obj FuncLT_GF2MAT_GF2MAT( Obj self, Obj ml, Obj mr)
 **
 **  computes the GF2-vector distance of two blocks in memory, pointed to by
 **  ptL and ptR for a GF(2) vector of <len> entries.
-**  
+**
 */
-UInt DistGF2Vecs(const UInt* ptL, const UInt* ptR, UInt len)
+UInt DistGF2Vecs(const UInt * ptL, const UInt * ptR, UInt len)
 {
-  UInt 			sum,m;
-  const UInt *          end;            // end marker                      
+    UInt         sum, m;
+    const UInt * end;    // end marker
 
-  /*T this  function will not work if the vectors have more than 2^28
-   * entries */
+    /*T this  function will not work if the vectors have more than 2^28
+     * entries */
 
-  end = ptL + ((len+BIPEB-1)/BIPEB);
-  sum=0;
-  // loop over the entries 
-  //T possibly unroll this loop 
-  while ( ptL < end ) {
-    m = *ptL++ ^ *ptR++; // xor of bits, nr bits therein is difference 
-    sum += COUNT_TRUES_BLOCK(m);
-  }
-  return sum;
+    end = ptL + ((len + BIPEB - 1) / BIPEB);
+    sum = 0;
+    // loop over the entries
+    // T possibly unroll this loop
+    while (ptL < end) {
+        m = *ptL++ ^ *ptR++;    // xor of bits, nr bits therein is difference
+        sum += COUNT_TRUES_BLOCK(m);
+    }
+    return sum;
 }
 
 /****************************************************************************
@@ -3115,296 +2957,285 @@ UInt DistGF2Vecs(const UInt* ptL, const UInt* ptR, UInt len)
 *F  FuncDIST_GF2VEC_GF2VEC( <self>, <vl>, <vr> )
 **
 **  'FuncDIST_GF2VEC_GF2VEC' returns the number of position in which two
-**  gf2-vectors <vl>  and  <vr> differ.                            
+**  gf2-vectors <vl>  and  <vr> differ.
 */
-Obj FuncDIST_GF2VEC_GF2VEC (
-    Obj                 self,
-    Obj                 vl,
-    Obj                 vr )
+Obj FuncDIST_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
-  UInt                  len;            // length of the list              
-  UInt                  off;            // bit offset at the end to clean out 
-  UInt *                ptL;            // bit field of <vl>               
-  UInt *                ptR;            // bit field of <vr>               
-  UInt *                end;            // pointer used to zero out end bit 
-  // get and check the length                                            
-  len = LEN_GF2VEC(vl);
+    UInt   len;    // length of the list
+    UInt   off;    // bit offset at the end to clean out
+    UInt * ptL;    // bit field of <vl>
+    UInt * ptR;    // bit field of <vr>
+    UInt * end;    // pointer used to zero out end bit
+    // get and check the length
+    len = LEN_GF2VEC(vl);
 
-  if ( len != LEN_GF2VEC(vr) ) {
-    ErrorMayQuit(
-      "DIST_GF2VEC_GF2VEC: vectors must have the same length",0L,0L);
-    return 0;
-  }
+    if (len != LEN_GF2VEC(vr)) {
+        ErrorMayQuit("DIST_GF2VEC_GF2VEC: vectors must have the same length",
+                     0L, 0L);
+        return 0;
+    }
 
-  // calculate the offsets 
-  ptL = BLOCKS_GF2VEC(vl);
-  ptR = BLOCKS_GF2VEC(vr);
+    // calculate the offsets
+    ptL = BLOCKS_GF2VEC(vl);
+    ptR = BLOCKS_GF2VEC(vr);
 
-// mask out the last bits 
-  off = (len -1) % BIPEB + 1; // number of significant bits in last word 
-  off = BIPEB - off;          // number of insignificant bits in last word 
-  end = ptL + ((len-1)/BIPEB);
+    // mask out the last bits
+    off = (len - 1) % BIPEB + 1;    // number of significant bits in last word
+    off = BIPEB - off;    // number of insignificant bits in last word
+    end = ptL + ((len - 1) / BIPEB);
 #ifdef SYS_IS_64_BIT
-  *end &= 0xffffffffffffffff >> off;
+    *end &= 0xffffffffffffffff >> off;
 #else
-  *end &= 0xffffffff >> off;
+    *end &= 0xffffffff >> off;
 #endif
-  end = ptR + ((len-1)/BIPEB);
+    end = ptR + ((len - 1) / BIPEB);
 #ifdef SYS_IS_64_BIT
-  *end &= 0xffffffffffffffff >> off;
+    *end &= 0xffffffffffffffff >> off;
 #else
-  *end &= 0xffffffff >> off;
+    *end &= 0xffffffff >> off;
 #endif
 
-  return INTOBJ_INT(DistGF2Vecs(ptL,ptR,len));
+    return INTOBJ_INT(DistGF2Vecs(ptL, ptR, len));
 }
 
 
 void DistVecClosVec(
-  Obj		veclis, // pointers to matrix vectors and their multiples 
-  Obj 	        ovec,    // vector we compute distance to 
-  Obj		d,	// distances list 
-  Obj  	        osum,	// position of the sum vector 
-  UInt		pos,	// recursion depth 
-  UInt		l,	// length of basis 
-  UInt		len )	// length of the involved vectors 
+    Obj  veclis,    // pointers to matrix vectors and their multiples
+    Obj  ovec,      // vector we compute distance to
+    Obj  d,         // distances list
+    Obj  osum,      // position of the sum vector
+    UInt pos,       // recursion depth
+    UInt l,         // length of basis
+    UInt len)       // length of the involved vectors
 {
-  UInt 		i;
-  UInt		di;
-  Obj		cnt;
-  Obj		vp;
-  const UInt *  vec;
-  Obj           one;
-  Obj           tmp;
+    UInt         i;
+    UInt         di;
+    Obj          cnt;
+    Obj          vp;
+    const UInt * vec;
+    Obj          one;
+    Obj          tmp;
 
-  vec = CONST_BLOCKS_GF2VEC(ovec);
-  vp = ELM_PLIST(veclis,pos);
-  one = INTOBJ_INT(1);
-  
-  for (i=0;i<=1;i++) {
-    if (pos < l)
-      {
-	DistVecClosVec(veclis,ovec,d,osum,pos+1,l,len);
-      }
-    else
-      {
-	di=DistGF2Vecs(CONST_BLOCKS_GF2VEC(osum),vec,len);
+    vec = CONST_BLOCKS_GF2VEC(ovec);
+    vp = ELM_PLIST(veclis, pos);
+    one = INTOBJ_INT(1);
 
-	cnt=ELM_PLIST(d,di+1);
-	if (IS_INTOBJ(cnt) && SUM_INTOBJS(tmp, cnt, one))
-	  {
-	    cnt = tmp;
-	    SET_ELM_PLIST(d,di+1,cnt);
-	  }
-	else
-	  {
-	    cnt=SumInt(cnt,one);
-	    vec = CONST_BLOCKS_GF2VEC(ovec);
-	    SET_ELM_PLIST(d,di+1,cnt);
-	    CHANGED_BAG(d);
-	  }
-      }
-    AddGF2VecToGF2Vec(BLOCKS_GF2VEC(osum),CONST_BLOCKS_GF2VEC(ELM_PLIST(vp,i+1)),len);
-  }
+    for (i = 0; i <= 1; i++) {
+        if (pos < l) {
+            DistVecClosVec(veclis, ovec, d, osum, pos + 1, l, len);
+        }
+        else {
+            di = DistGF2Vecs(CONST_BLOCKS_GF2VEC(osum), vec, len);
+
+            cnt = ELM_PLIST(d, di + 1);
+            if (IS_INTOBJ(cnt) && SUM_INTOBJS(tmp, cnt, one)) {
+                cnt = tmp;
+                SET_ELM_PLIST(d, di + 1, cnt);
+            }
+            else {
+                cnt = SumInt(cnt, one);
+                vec = CONST_BLOCKS_GF2VEC(ovec);
+                SET_ELM_PLIST(d, di + 1, cnt);
+                CHANGED_BAG(d);
+            }
+        }
+        AddGF2VecToGF2Vec(BLOCKS_GF2VEC(osum),
+                          CONST_BLOCKS_GF2VEC(ELM_PLIST(vp, i + 1)), len);
+    }
 }
 
 Obj FuncDIST_VEC_CLOS_VEC(
-  Obj		self,
-  Obj		veclis, // pointers to matrix vectors and their multiples 
-  Obj		vec,    // vector we compute distance to 
-  Obj		d )	// distances list 
+    Obj self,
+    Obj veclis,    // pointers to matrix vectors and their multiples
+    Obj vec,       // vector we compute distance to
+    Obj d)         // distances list
 
 {
-  Obj		sum; // sum vector 
-  UInt 		len;
+    Obj  sum;    // sum vector
+    UInt len;
 
-  len = LEN_GF2VEC(vec);
+    len = LEN_GF2VEC(vec);
 
-  // get space for sum vector 
-  NEW_GF2VEC( sum, TYPE_LIST_GF2VEC, len );
+    // get space for sum vector
+    NEW_GF2VEC(sum, TYPE_LIST_GF2VEC, len);
 
-  // do the recursive work 
-  DistVecClosVec(veclis,vec,d,sum,1,LEN_PLIST(veclis),len);
+    // do the recursive work
+    DistVecClosVec(veclis, vec, d, sum, 1, LEN_PLIST(veclis), len);
 
-  return (Obj) 0;
+    return (Obj)0;
 }
 
-UInt AClosVec(
-  Obj		veclis, // pointers to matrix vectors and their multiples 
-  Obj 	        ovec,    // vector we compute distance to 
-  Obj  	        osum,	// position of the sum vector 
-  UInt		pos,	// recursion depth 
-  UInt		l,	// length of basis 
-  UInt		len,	// length of the involved vectors 
-  UInt		cnt,	// numbr of vectors used 
-  UInt		stop,	// stop value 
-  UInt		bd,	// best distance so far 
-  Obj		obv,    // best vector so far 
-  Obj           coords,  // coefficients to get current vector 
-  Obj           bcoords  // coefficients to get best vector 
-  )	
+UInt AClosVec(Obj veclis,    // pointers to matrix vectors and their multiples
+              Obj ovec,      // vector we compute distance to
+              Obj osum,      // position of the sum vector
+              UInt pos,      // recursion depth
+              UInt l,        // length of basis
+              UInt len,      // length of the involved vectors
+              UInt cnt,      // numbr of vectors used
+              UInt stop,     // stop value
+              UInt bd,       // best distance so far
+              Obj  obv,      // best vector so far
+              Obj  coords,    // coefficients to get current vector
+              Obj  bcoords    // coefficients to get best vector
+)
 {
-  UInt		di;
-  Obj		vp;
-  UInt *        sum;
-  UInt *        bv;
-  const UInt *  vec;
-  const UInt *  end;
-  const UInt *  w;
+    UInt         di;
+    Obj          vp;
+    UInt *       sum;
+    UInt *       bv;
+    const UInt * vec;
+    const UInt * end;
+    const UInt * w;
 
 
-
-  // maybe we don't add this basis vector -- if this leaves us enough possibilitiies 
-  if ( pos+cnt<l ) {
-    bd = AClosVec(veclis,ovec,osum,pos+1,l,len,cnt,stop,bd,obv,coords,bcoords);
-      if (bd<=stop) {
-        return bd;
-      }
-  }
-
-
-  // Otherwise we do 
-  
-  vec = CONST_BLOCKS_GF2VEC(ovec);
-  sum = BLOCKS_GF2VEC(osum);
-  vp = ELM_PLIST(veclis,pos);
-  w = CONST_BLOCKS_GF2VEC(ELM_PLIST(vp,1));
-  AddGF2VecToGF2Vec(sum,w,len);
-
-  if (coords != (Obj) 0)
-    {
-      SET_ELM_PLIST(coords,pos,INTOBJ_INT(1));
+    // maybe we don't add this basis vector -- if this leaves us enough
+    // possibilitiies
+    if (pos + cnt < l) {
+        bd = AClosVec(veclis, ovec, osum, pos + 1, l, len, cnt, stop, bd, obv,
+                      coords, bcoords);
+        if (bd <= stop) {
+            return bd;
+        }
     }
 
-  
-  if (cnt == 0) // this is a candidate 
-    {
-      di=DistGF2Vecs(sum,vec,len);
-      if (di<bd) {
-	
-	// store new result 
-	bd=di;
-	bv = BLOCKS_GF2VEC(obv);
-	end = bv+((len+BIPEB-1)/BIPEB);
-	while (bv<end) 
-	  *bv++=*sum++;
-	sum = BLOCKS_GF2VEC(osum);
-	if (coords != (Obj) 0)
-	  {
-	    UInt i;
-	    for (i=1; i <= l; i++)
-	      {
-		Obj x;
-		x = ELM_PLIST(coords,i);
-		SET_ELM_PLIST(bcoords,i,x);
-	      }
-	  }
-      }
+
+    // Otherwise we do
+
+    vec = CONST_BLOCKS_GF2VEC(ovec);
+    sum = BLOCKS_GF2VEC(osum);
+    vp = ELM_PLIST(veclis, pos);
+    w = CONST_BLOCKS_GF2VEC(ELM_PLIST(vp, 1));
+    AddGF2VecToGF2Vec(sum, w, len);
+
+    if (coords != (Obj)0) {
+        SET_ELM_PLIST(coords, pos, INTOBJ_INT(1));
     }
-  else // need to add in some more 
+
+
+    if (cnt == 0)    // this is a candidate
     {
-      bd=AClosVec(veclis,ovec,osum,pos+1,l,len,cnt-1,stop,bd,obv,coords,bcoords);
-      if (bd<=stop) {
-	return bd;
-      }
+        di = DistGF2Vecs(sum, vec, len);
+        if (di < bd) {
+
+            // store new result
+            bd = di;
+            bv = BLOCKS_GF2VEC(obv);
+            end = bv + ((len + BIPEB - 1) / BIPEB);
+            while (bv < end)
+                *bv++ = *sum++;
+            sum = BLOCKS_GF2VEC(osum);
+            if (coords != (Obj)0) {
+                UInt i;
+                for (i = 1; i <= l; i++) {
+                    Obj x;
+                    x = ELM_PLIST(coords, i);
+                    SET_ELM_PLIST(bcoords, i, x);
+                }
+            }
+        }
     }
-    
-  // reset component  
-  AddGF2VecToGF2Vec(sum,w,len);
-  if (coords != (Obj) 0)
+    else    // need to add in some more
     {
-      SET_ELM_PLIST(coords,pos,INTOBJ_INT(0));
+        bd = AClosVec(veclis, ovec, osum, pos + 1, l, len, cnt - 1, stop, bd,
+                      obv, coords, bcoords);
+        if (bd <= stop) {
+            return bd;
+        }
     }
-  
-  TakeInterrupt();
-  return bd;
+
+    // reset component
+    AddGF2VecToGF2Vec(sum, w, len);
+    if (coords != (Obj)0) {
+        SET_ELM_PLIST(coords, pos, INTOBJ_INT(0));
+    }
+
+    TakeInterrupt();
+    return bd;
 }
-
-
-
 
 
 Obj FuncA_CLOS_VEC(
-  Obj		self,
-  Obj		veclis, // pointers to matrix vectors and their multiples 
-  Obj		vec,    // vector we compute distance to 
-  Obj		cnt,	// distances list 
-  Obj		stop)	// distances list 
+    Obj self,
+    Obj veclis,    // pointers to matrix vectors and their multiples
+    Obj vec,       // vector we compute distance to
+    Obj cnt,       // distances list
+    Obj stop)      // distances list
 
 {
-  Obj		sum; // sum vector 
-  Obj		best; // best vector 
-  UInt 		len;
+    Obj  sum;     // sum vector
+    Obj  best;    // best vector
+    UInt len;
 
-  len = LEN_GF2VEC(vec);
+    len = LEN_GF2VEC(vec);
 
-  if (!ARE_INTOBJS(cnt,stop))
-    ErrorMayQuit("AClosVec: cnt and stop must be small integers, not a %s and a %s",
-	      (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
-  
+    if (!ARE_INTOBJS(cnt, stop))
+        ErrorMayQuit("AClosVec: cnt and stop must be small integers, not a "
+                     "%s and a %s",
+                     (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
 
-  // get space for sum vector and zero out 
-  NEW_GF2VEC( sum, TYPE_LIST_GF2VEC, len );
-  NEW_GF2VEC( best, TYPE_LIST_GF2VEC, len );
 
-  // do the recursive work 
-  AClosVec(veclis,vec,sum,1, LEN_PLIST(veclis),len,
-    INT_INTOBJ(cnt),INT_INTOBJ(stop),len+1, // maximal value +1 
-	   best, (Obj) 0, (Obj) 0);
+    // get space for sum vector and zero out
+    NEW_GF2VEC(sum, TYPE_LIST_GF2VEC, len);
+    NEW_GF2VEC(best, TYPE_LIST_GF2VEC, len);
 
-  return best;
+    // do the recursive work
+    AClosVec(veclis, vec, sum, 1, LEN_PLIST(veclis), len, INT_INTOBJ(cnt),
+             INT_INTOBJ(stop), len + 1,    // maximal value +1
+             best, (Obj)0, (Obj)0);
+
+    return best;
 }
 
 Obj FuncA_CLOS_VEC_COORDS(
-  Obj		self,
-  Obj		veclis, // pointers to matrix vectors and their multiples 
-  Obj		vec,    // vector we compute distance to 
-  Obj		cnt,	// distances list 
-  Obj		stop)	// distances list 
+    Obj self,
+    Obj veclis,    // pointers to matrix vectors and their multiples
+    Obj vec,       // vector we compute distance to
+    Obj cnt,       // distances list
+    Obj stop)      // distances list
 
 {
-  Obj		sum; // sum vector 
-  Obj		best; // best vector 
-  Obj         coords; // coefficients of mat to get current 
-  Obj         bcoords; // coefficients of mat to get best 
-  Obj           res; // length 2 plist for results 
-  UInt 		len, len2,i;
+    Obj  sum;        // sum vector
+    Obj  best;       // best vector
+    Obj  coords;     // coefficients of mat to get current
+    Obj  bcoords;    // coefficients of mat to get best
+    Obj  res;        // length 2 plist for results
+    UInt len, len2, i;
 
-  len = LEN_GF2VEC(vec);
-  len2 = LEN_PLIST(veclis);
+    len = LEN_GF2VEC(vec);
+    len2 = LEN_PLIST(veclis);
 
-  if (!ARE_INTOBJS(cnt,stop))
-    ErrorMayQuit("AClosVec: cnt and stop must be small integers, not a %s and a %s",
-	      (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
-  
+    if (!ARE_INTOBJS(cnt, stop))
+        ErrorMayQuit("AClosVec: cnt and stop must be small integers, not a "
+                     "%s and a %s",
+                     (Int)TNAM_OBJ(cnt), (Int)TNAM_OBJ(stop));
 
-  // get space for sum vector and zero out 
-  NEW_GF2VEC( sum, TYPE_LIST_GF2VEC, len );
-  NEW_GF2VEC( best, TYPE_LIST_GF2VEC, len );
 
-  coords = NEW_PLIST(  T_PLIST_CYC, len2 );
-  SET_LEN_PLIST( coords, len2 );
+    // get space for sum vector and zero out
+    NEW_GF2VEC(sum, TYPE_LIST_GF2VEC, len);
+    NEW_GF2VEC(best, TYPE_LIST_GF2VEC, len);
 
-  bcoords = NEW_PLIST(  T_PLIST_CYC, len2 );
-  SET_LEN_PLIST( bcoords, len2 );
-  
-  for (i=1; i <= len2; i++)
-    {
-      SET_ELM_PLIST(coords,i,INTOBJ_INT(0));
-      SET_ELM_PLIST(bcoords,i,INTOBJ_INT(0));
+    coords = NEW_PLIST(T_PLIST_CYC, len2);
+    SET_LEN_PLIST(coords, len2);
+
+    bcoords = NEW_PLIST(T_PLIST_CYC, len2);
+    SET_LEN_PLIST(bcoords, len2);
+
+    for (i = 1; i <= len2; i++) {
+        SET_ELM_PLIST(coords, i, INTOBJ_INT(0));
+        SET_ELM_PLIST(bcoords, i, INTOBJ_INT(0));
     }
 
-  // do the recursive work 
-  AClosVec(veclis,vec,sum,1, len2 ,len,
-    INT_INTOBJ(cnt),INT_INTOBJ(stop),len+1, // maximal value +1 
-	   best,coords,bcoords);
+    // do the recursive work
+    AClosVec(veclis, vec, sum, 1, len2, len, INT_INTOBJ(cnt),
+             INT_INTOBJ(stop), len + 1,    // maximal value +1
+             best, coords, bcoords);
 
-  res = NEW_PLIST(T_PLIST_DENSE_NHOM,2);
-  SET_LEN_PLIST(res,2);
-  SET_ELM_PLIST(res,1,best);
-  SET_ELM_PLIST(res,2,bcoords);
-  CHANGED_BAG(res);
-  return res;
+    res = NEW_PLIST(T_PLIST_DENSE_NHOM, 2);
+    SET_LEN_PLIST(res, 2);
+    SET_ELM_PLIST(res, 1, best);
+    SET_ELM_PLIST(res, 2, bcoords);
+    CHANGED_BAG(res);
+    return res;
 }
 
 /****************************************************************************
@@ -3414,91 +3245,87 @@ Obj FuncA_CLOS_VEC_COORDS(
 ** Search for new coset leaders of weight <weight>
 */
 
-UInt CosetLeadersInnerGF2( Obj veclis,
-			   Obj v,
-			   Obj w,
-			   UInt weight,
-			   UInt pos,
-			   Obj leaders,
-			   UInt tofind )
+UInt CosetLeadersInnerGF2(
+    Obj veclis, Obj v, Obj w, UInt weight, UInt pos, Obj leaders, UInt tofind)
 {
-  UInt found = 0;
-  UInt len = LEN_GF2VEC(v);
-  UInt lenw = LEN_GF2VEC(w);
-  UInt sy;
-  UInt u0;
-  Obj vc;
-  UInt i;
-    
-  // We know that the length of w does not exceed BIPEB -4 here
-  // (or there would not be room in a PLIST for all the coset leaders).
-  // We use this to do a lot of GF2 vector operations for w "in-place"
-  // 
-  // Even more in this direction could be done, but this no longer
-  // the rate-determining step for any feasible application
-  
-  if (weight == 1)
-    {
-      for (i = pos; i <= len; i++)
-	{
-	  u0 = CONST_BLOCKS_GF2VEC(ELM_PLIST(ELM_PLIST(veclis, i),1))[0];
-	  BLOCKS_GF2VEC(w)[0] ^= u0;
-	  BLOCK_ELM_GF2VEC(v, i) |= MASK_POS_GF2VEC(i);
+    UInt found = 0;
+    UInt len = LEN_GF2VEC(v);
+    UInt lenw = LEN_GF2VEC(w);
+    UInt sy;
+    UInt u0;
+    Obj  vc;
+    UInt i;
 
-	  sy = revertbits(CONST_BLOCKS_GF2VEC(w)[0], lenw);
-	  if ((Obj) 0 == ELM_PLIST(leaders,sy+1))
-	    {
-	      NEW_GF2VEC(vc, TYPE_LIST_GF2VEC_IMM, len);
-	      memcpy(BLOCKS_GF2VEC(vc), CONST_BLOCKS_GF2VEC(v), NUMBER_BLOCKS_GF2VEC(v) * sizeof(UInt));
-	      SET_ELM_PLIST(leaders,sy+1,vc);
-	      CHANGED_BAG(leaders);
-	      if (++found == tofind)
-		return found;
-	    }
-	  BLOCKS_GF2VEC(w)[0] ^= u0;
-	  BLOCK_ELM_GF2VEC(v, i) &= ~MASK_POS_GF2VEC(i);
-	}
+    // We know that the length of w does not exceed BIPEB -4 here
+    // (or there would not be room in a PLIST for all the coset leaders).
+    // We use this to do a lot of GF2 vector operations for w "in-place"
+    //
+    // Even more in this direction could be done, but this no longer
+    // the rate-determining step for any feasible application
+
+    if (weight == 1) {
+        for (i = pos; i <= len; i++) {
+            u0 = CONST_BLOCKS_GF2VEC(ELM_PLIST(ELM_PLIST(veclis, i), 1))[0];
+            BLOCKS_GF2VEC(w)[0] ^= u0;
+            BLOCK_ELM_GF2VEC(v, i) |= MASK_POS_GF2VEC(i);
+
+            sy = revertbits(CONST_BLOCKS_GF2VEC(w)[0], lenw);
+            if ((Obj)0 == ELM_PLIST(leaders, sy + 1)) {
+                NEW_GF2VEC(vc, TYPE_LIST_GF2VEC_IMM, len);
+                memcpy(BLOCKS_GF2VEC(vc), CONST_BLOCKS_GF2VEC(v),
+                       NUMBER_BLOCKS_GF2VEC(v) * sizeof(UInt));
+                SET_ELM_PLIST(leaders, sy + 1, vc);
+                CHANGED_BAG(leaders);
+                if (++found == tofind)
+                    return found;
+            }
+            BLOCKS_GF2VEC(w)[0] ^= u0;
+            BLOCK_ELM_GF2VEC(v, i) &= ~MASK_POS_GF2VEC(i);
+        }
     }
-  else
-    {
-      if (pos + weight <= len)
-	{
-	  found += CosetLeadersInnerGF2(veclis, v, w, weight, pos+1, leaders, tofind);
-	  if (found == tofind)
-	    return found;
-	}
-      u0 = CONST_BLOCKS_GF2VEC(ELM_PLIST(ELM_PLIST(veclis, pos),1))[0];
-      BLOCKS_GF2VEC(w)[0] ^= u0;
-      BLOCK_ELM_GF2VEC(v, pos) |= MASK_POS_GF2VEC(pos);
-      found += CosetLeadersInnerGF2(veclis, v, w, weight -1, pos + 1, leaders, tofind - found);
-      if (found == tofind)
-	return found;
-      BLOCKS_GF2VEC(w)[0] ^= u0;
-      BLOCK_ELM_GF2VEC(v, pos) &= ~MASK_POS_GF2VEC(pos);
+    else {
+        if (pos + weight <= len) {
+            found += CosetLeadersInnerGF2(veclis, v, w, weight, pos + 1,
+                                          leaders, tofind);
+            if (found == tofind)
+                return found;
+        }
+        u0 = CONST_BLOCKS_GF2VEC(ELM_PLIST(ELM_PLIST(veclis, pos), 1))[0];
+        BLOCKS_GF2VEC(w)[0] ^= u0;
+        BLOCK_ELM_GF2VEC(v, pos) |= MASK_POS_GF2VEC(pos);
+        found += CosetLeadersInnerGF2(veclis, v, w, weight - 1, pos + 1,
+                                      leaders, tofind - found);
+        if (found == tofind)
+            return found;
+        BLOCKS_GF2VEC(w)[0] ^= u0;
+        BLOCK_ELM_GF2VEC(v, pos) &= ~MASK_POS_GF2VEC(pos);
     }
-  TakeInterrupt();
-  return found;
+    TakeInterrupt();
+    return found;
 }
 
 
-
-
-Obj FuncCOSET_LEADERS_INNER_GF2( Obj self, Obj veclis, Obj weight, Obj tofind, Obj leaders)
+Obj FuncCOSET_LEADERS_INNER_GF2(
+    Obj self, Obj veclis, Obj weight, Obj tofind, Obj leaders)
 {
-  Obj v,w;
-  UInt lenv, lenw;
+    Obj  v, w;
+    UInt lenv, lenw;
 
-  if (!ARE_INTOBJS(weight,tofind))
-    ErrorMayQuit("COSET_LEADERS_INNER_GF2: weight and tofind must be smal integers, not a %s and a %s",
-	      (Int)TNAM_OBJ(weight), (Int)TNAM_OBJ(tofind));
-  
-  lenv = LEN_PLIST(veclis);
-  NEW_GF2VEC(v, TYPE_LIST_GF2VEC, lenv);
-  lenw = LEN_GF2VEC(ELM_PLIST(ELM_PLIST(veclis,1),1));
-  NEW_GF2VEC(w, TYPE_LIST_GF2VEC, lenw);
-  if (lenw > BIPEB-4)
-    ErrorMayQuit("COSET_LEADERS_INNER_GF2: too many cosets to return the leaders in a plain list",0,0);
-  return INTOBJ_INT(CosetLeadersInnerGF2( veclis, v, w, INT_INTOBJ(weight), 1, leaders, INT_INTOBJ(tofind)));
+    if (!ARE_INTOBJS(weight, tofind))
+        ErrorMayQuit("COSET_LEADERS_INNER_GF2: weight and tofind must be "
+                     "smal integers, not a %s and a %s",
+                     (Int)TNAM_OBJ(weight), (Int)TNAM_OBJ(tofind));
+
+    lenv = LEN_PLIST(veclis);
+    NEW_GF2VEC(v, TYPE_LIST_GF2VEC, lenv);
+    lenw = LEN_GF2VEC(ELM_PLIST(ELM_PLIST(veclis, 1), 1));
+    NEW_GF2VEC(w, TYPE_LIST_GF2VEC, lenw);
+    if (lenw > BIPEB - 4)
+        ErrorMayQuit("COSET_LEADERS_INNER_GF2: too many cosets to return the "
+                     "leaders in a plain list",
+                     0, 0);
+    return INTOBJ_INT(CosetLeadersInnerGF2(veclis, v, w, INT_INTOBJ(weight),
+                                           1, leaders, INT_INTOBJ(tofind)));
 }
 
 /****************************************************************************
@@ -3513,9 +3340,9 @@ Obj FuncCOSET_LEADERS_INNER_GF2( Obj self, Obj veclis, Obj weight, Obj tofind, O
 **
 */
 
-Obj FuncRIGHTMOST_NONZERO_GF2VEC( Obj self, Obj vec )
+Obj FuncRIGHTMOST_NONZERO_GF2VEC(Obj self, Obj vec)
 {
-  return INTOBJ_INT(RightMostOneGF2Vec(vec));
+    return INTOBJ_INT(RightMostOneGF2Vec(vec));
 }
 
 /****************************************************************************
@@ -3524,69 +3351,65 @@ Obj FuncRIGHTMOST_NONZERO_GF2VEC( Obj self, Obj vec )
 **
 */
 
-void ResizeGF2Vec( Obj vec, UInt newlen )
+void ResizeGF2Vec(Obj vec, UInt newlen)
 {
-  UInt len;
-  UInt *ptr;
-  UInt *nptr;
-  UInt off;
-  len = LEN_GF2VEC(vec);
-  if (len == newlen)
-    return;
-  if (True == DoFilter(IsLockedRepresentationVector, vec))
-    {
-      ErrorReturnVoid("Resize of locked compressed vector is forbidden", 0, 0,
-		      "You can `return;' to ignore the operation");
-      return;
+    UInt   len;
+    UInt * ptr;
+    UInt * nptr;
+    UInt   off;
+    len = LEN_GF2VEC(vec);
+    if (len == newlen)
+        return;
+    if (True == DoFilter(IsLockedRepresentationVector, vec)) {
+        ErrorReturnVoid("Resize of locked compressed vector is forbidden", 0,
+                        0, "You can `return;' to ignore the operation");
+        return;
     }
 
-  
-  if (newlen > len)
-    {
-      ResizeWordSizedBag(vec,SIZE_PLEN_GF2VEC(newlen));
 
-      // now clean remainder of last block 
-      if (len == 0)
-	ptr = BLOCKS_GF2VEC(vec);
-      else
-	{
-	  ptr = BLOCKS_GF2VEC(vec) + (len -1)/BIPEB;
-	  off = BIPEB - ((len -1)% BIPEB + 1); // number of insignificant bits in last word 
+    if (newlen > len) {
+        ResizeWordSizedBag(vec, SIZE_PLEN_GF2VEC(newlen));
+
+        // now clean remainder of last block
+        if (len == 0)
+            ptr = BLOCKS_GF2VEC(vec);
+        else {
+            ptr = BLOCKS_GF2VEC(vec) + (len - 1) / BIPEB;
+            off = BIPEB - ((len - 1) % BIPEB +
+                           1);    // number of insignificant bits in last word
 #ifdef SYS_IS_64_BIT
-	  *ptr &= 0xffffffffffffffff >> off;
+            *ptr &= 0xffffffffffffffff >> off;
 #else
-	  *ptr &= 0xffffffff >> off;
+            *ptr &= 0xffffffff >> off;
 #endif
-	  ptr++;
-	}
-      
-      // and clean new blocks -- shouldn't need to do this, but
-	  // it's very cheap
+            ptr++;
+        }
 
-      // newlen can't be zero here, since it is bigger than len 
-      nptr = BLOCKS_GF2VEC(vec) + (newlen -1)/BIPEB; 
-      while (ptr <= nptr)
-	*ptr++ = 0;
+        // and clean new blocks -- shouldn't need to do this, but
+        // it's very cheap
 
-      SET_LEN_GF2VEC(vec, newlen);
-      return;
+        // newlen can't be zero here, since it is bigger than len
+        nptr = BLOCKS_GF2VEC(vec) + (newlen - 1) / BIPEB;
+        while (ptr <= nptr)
+            *ptr++ = 0;
+
+        SET_LEN_GF2VEC(vec, newlen);
+        return;
     }
-  else
-    {
-      // clean remainder of new last block, if any 
-      if (newlen % BIPEB)
-	{
-	  ptr = BLOCKS_GF2VEC(vec) + (newlen -1)/BIPEB;
-	  off = BIPEB - ((newlen-1) % BIPEB + 1);
+    else {
+        // clean remainder of new last block, if any
+        if (newlen % BIPEB) {
+            ptr = BLOCKS_GF2VEC(vec) + (newlen - 1) / BIPEB;
+            off = BIPEB - ((newlen - 1) % BIPEB + 1);
 #ifdef SYS_IS_64_BIT
-	  *ptr &= 0xffffffffffffffff >> off;
+            *ptr &= 0xffffffffffffffff >> off;
 #else
-	  *ptr &= 0xffffffff >> off;
+            *ptr &= 0xffffffff >> off;
 #endif
-	}
-      SET_LEN_GF2VEC(vec, newlen);
-      ResizeWordSizedBag(vec, SIZE_PLEN_GF2VEC(newlen));
-      return;
+        }
+        SET_LEN_GF2VEC(vec, newlen);
+        ResizeWordSizedBag(vec, SIZE_PLEN_GF2VEC(newlen));
+        return;
     }
 }
 
@@ -3596,23 +3419,25 @@ void ResizeGF2Vec( Obj vec, UInt newlen )
 **
 */
 
-Obj FuncRESIZE_GF2VEC( Obj self, Obj vec, Obj newlen)
+Obj FuncRESIZE_GF2VEC(Obj self, Obj vec, Obj newlen)
 {
-  Int newlen1;
-  if (!IS_MUTABLE_OBJ(vec))
-    {
-      ErrorReturnVoid("RESIZE_GF2VEC: the vector must be mutable", 0, 0,
-		      "you may 'return;' to skip the operation");
-      return (Obj)0;
+    Int newlen1;
+    if (!IS_MUTABLE_OBJ(vec)) {
+        ErrorReturnVoid("RESIZE_GF2VEC: the vector must be mutable", 0, 0,
+                        "you may 'return;' to skip the operation");
+        return (Obj)0;
     }
-  if (!IS_INTOBJ(newlen))
-    ErrorMayQuit("RESIZE_GF2VEC: newlen must be a small integer, not a %s",
-	      (Int)TNAM_OBJ(newlen), 0L);
-  newlen1 = INT_INTOBJ(newlen);
-  if (newlen1 < 0) 
-    ErrorMayQuit("RESIZE_GF2VEC: the new size must be a non-negative integer, not %d", newlen1, 0);
-  ResizeGF2Vec(vec, newlen1);
-  return (Obj)0;
+    if (!IS_INTOBJ(newlen))
+        ErrorMayQuit(
+            "RESIZE_GF2VEC: newlen must be a small integer, not a %s",
+            (Int)TNAM_OBJ(newlen), 0L);
+    newlen1 = INT_INTOBJ(newlen);
+    if (newlen1 < 0)
+        ErrorMayQuit("RESIZE_GF2VEC: the new size must be a non-negative "
+                     "integer, not %d",
+                     newlen1, 0);
+    ResizeGF2Vec(vec, newlen1);
+    return (Obj)0;
 }
 
 
@@ -3622,46 +3447,42 @@ Obj FuncRESIZE_GF2VEC( Obj self, Obj vec, Obj newlen)
 **
 */
 
-void ShiftLeftGF2Vec( Obj vec, UInt amount )
+void ShiftLeftGF2Vec(Obj vec, UInt amount)
 {
-  UInt len;
-  UInt *ptr1, *ptr2;
-  UInt i;
-  UInt block;
-  UInt off;
-  if (amount == 0)
-    return;
-  len = LEN_GF2VEC(vec);
-  if (amount >= len)
-    {
-      ResizeGF2Vec(vec, 0);
-      return;
+    UInt  len;
+    UInt *ptr1, *ptr2;
+    UInt  i;
+    UInt  block;
+    UInt  off;
+    if (amount == 0)
+        return;
+    len = LEN_GF2VEC(vec);
+    if (amount >= len) {
+        ResizeGF2Vec(vec, 0);
+        return;
     }
-  if (amount % BIPEB == 0)
-    {
-      ptr1 = BLOCKS_GF2VEC(vec);
-      ptr2 = ptr1 + amount/BIPEB;
-      for (i = 0; i < (len - amount + BIPEB - 1)/BIPEB; i++)
-	*ptr1++ = *ptr2++;
+    if (amount % BIPEB == 0) {
+        ptr1 = BLOCKS_GF2VEC(vec);
+        ptr2 = ptr1 + amount / BIPEB;
+        for (i = 0; i < (len - amount + BIPEB - 1) / BIPEB; i++)
+            *ptr1++ = *ptr2++;
     }
-  else
-    {
-      ptr1 = BLOCKS_GF2VEC(vec);
-      ptr2 = ptr1 + amount/BIPEB;
-      off = amount % BIPEB;
-      for (i = 0; i < (len - amount + BIPEB - 1)/BIPEB - 1; i++)
-      {
+    else {
+        ptr1 = BLOCKS_GF2VEC(vec);
+        ptr2 = ptr1 + amount / BIPEB;
+        off = amount % BIPEB;
+        for (i = 0; i < (len - amount + BIPEB - 1) / BIPEB - 1; i++) {
+            block = (*ptr2++) >> off;
+            block |= (*ptr2) << (BIPEB - off);
+            *ptr1++ = block;
+        }
+        // Handle last block seperately to avoid reading off end of Bag
         block = (*ptr2++) >> off;
-        block |= (*ptr2) << (BIPEB - off);
-        *ptr1++ = block;
-      }
-      // Handle last block seperately to avoid reading off end of Bag
-      block = (*ptr2++) >> off;
-      if(ptr2 < BLOCKS_GF2VEC(vec) + NUMBER_BLOCKS_GF2VEC(vec))
-        block |= (*ptr2) << (BIPEB - off);
-      *ptr1 = block;
+        if (ptr2 < BLOCKS_GF2VEC(vec) + NUMBER_BLOCKS_GF2VEC(vec))
+            block |= (*ptr2) << (BIPEB - off);
+        *ptr1 = block;
     }
-  ResizeGF2Vec(vec, len-amount);
+    ResizeGF2Vec(vec, len - amount);
 }
 
 /****************************************************************************
@@ -3670,23 +3491,25 @@ void ShiftLeftGF2Vec( Obj vec, UInt amount )
 **
 */
 
-Obj FuncSHIFT_LEFT_GF2VEC( Obj self, Obj vec, Obj amount)
+Obj FuncSHIFT_LEFT_GF2VEC(Obj self, Obj vec, Obj amount)
 {
-  Int amount1;
-  if (!IS_MUTABLE_OBJ(vec)) 
-    {
-      ErrorReturnVoid("SHIFT_LEFT_GF2VEC: the vector must be mutable", 0, 0,
-		      "you may 'return;' to skip the operation");
-      return (Obj)0;
+    Int amount1;
+    if (!IS_MUTABLE_OBJ(vec)) {
+        ErrorReturnVoid("SHIFT_LEFT_GF2VEC: the vector must be mutable", 0, 0,
+                        "you may 'return;' to skip the operation");
+        return (Obj)0;
     }
-  if (!IS_INTOBJ(amount))
-    ErrorMayQuit("SHIFT_LEFT_GF2VEC: the amount to shift must be a small integer, not a %d",
-	      (Int)TNAM_OBJ(amount), 0L);
-  amount1 = INT_INTOBJ(amount);
-  if (amount1 < 0)
-     ErrorMayQuit("SHIFT_LEFT_GF2VEC: <amount> must be a non-negative integer, not %d", amount1, 0);
-  ShiftLeftGF2Vec(vec, amount1);
-  return (Obj)0;
+    if (!IS_INTOBJ(amount))
+        ErrorMayQuit("SHIFT_LEFT_GF2VEC: the amount to shift must be a small "
+                     "integer, not a %d",
+                     (Int)TNAM_OBJ(amount), 0L);
+    amount1 = INT_INTOBJ(amount);
+    if (amount1 < 0)
+        ErrorMayQuit("SHIFT_LEFT_GF2VEC: <amount> must be a non-negative "
+                     "integer, not %d",
+                     amount1, 0);
+    ShiftLeftGF2Vec(vec, amount1);
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -3695,47 +3518,46 @@ Obj FuncSHIFT_LEFT_GF2VEC( Obj self, Obj vec, Obj amount)
 **
 */
 
-void ShiftRightGF2Vec( Obj vec, UInt amount )
+void ShiftRightGF2Vec(Obj vec, UInt amount)
 {
-  UInt len;
-  UInt *ptr1, *ptr2, *ptr0;
-  UInt i;
-  UInt block;
-  UInt off;
-  if (amount == 0)
-    return;
-  len = LEN_GF2VEC(vec);
-  ResizeGF2Vec(vec, len+amount);
-  if (amount % BIPEB == 0)
-    {
-      // move the blocks 
-      ptr1 = BLOCKS_GF2VEC(vec) + (len - 1 + amount)/BIPEB;
-      ptr2 = ptr1 - amount/BIPEB;
-      for (i = 0; i < (len + BIPEB - 1)/BIPEB; i++)
-	*ptr1-- = *ptr2--;
+    UInt  len;
+    UInt *ptr1, *ptr2, *ptr0;
+    UInt  i;
+    UInt  block;
+    UInt  off;
+    if (amount == 0)
+        return;
+    len = LEN_GF2VEC(vec);
+    ResizeGF2Vec(vec, len + amount);
+    if (amount % BIPEB == 0) {
+        // move the blocks
+        ptr1 = BLOCKS_GF2VEC(vec) + (len - 1 + amount) / BIPEB;
+        ptr2 = ptr1 - amount / BIPEB;
+        for (i = 0; i < (len + BIPEB - 1) / BIPEB; i++)
+            *ptr1-- = *ptr2--;
 
-      // and fill with zeroes 
-      ptr2 = BLOCKS_GF2VEC(vec);
-      while (ptr1 >= ptr2)
-	*ptr1-- = 0;
+        // and fill with zeroes
+        ptr2 = BLOCKS_GF2VEC(vec);
+        while (ptr1 >= ptr2)
+            *ptr1-- = 0;
     }
-  else
-    {
-      ptr1 = BLOCKS_GF2VEC(vec) + (len -1 + amount)/BIPEB;
-      ptr2 = ptr1 - amount/BIPEB; // this can sometimes be the block AFTER the old last block, but this must be OK
-      off = amount % BIPEB;
-      ptr0 = BLOCKS_GF2VEC(vec);
-      while (1)
-	{
-	  block = (*ptr2--) << off;
-	  if (ptr2 < ptr0)
-	    break;
-	  block |= (*ptr2) >> (BIPEB - off);
-	  *ptr1-- = block;
-	}
-      *ptr1-- = block;
-      while (ptr1 >= ptr0)
-	*ptr1-- = 0;
+    else {
+        ptr1 = BLOCKS_GF2VEC(vec) + (len - 1 + amount) / BIPEB;
+        ptr2 = ptr1 - amount / BIPEB;    // this can sometimes be the block
+                                         // AFTER the old last block, but this
+                                         // must be OK
+        off = amount % BIPEB;
+        ptr0 = BLOCKS_GF2VEC(vec);
+        while (1) {
+            block = (*ptr2--) << off;
+            if (ptr2 < ptr0)
+                break;
+            block |= (*ptr2) >> (BIPEB - off);
+            *ptr1-- = block;
+        }
+        *ptr1-- = block;
+        while (ptr1 >= ptr0)
+            *ptr1-- = 0;
     }
 }
 
@@ -3745,26 +3567,28 @@ void ShiftRightGF2Vec( Obj vec, UInt amount )
 **
 */
 
-Obj FuncSHIFT_RIGHT_GF2VEC( Obj self, Obj vec, Obj amount)
+Obj FuncSHIFT_RIGHT_GF2VEC(Obj self, Obj vec, Obj amount)
 {
-  Int amount1;
-  if (!IS_MUTABLE_OBJ(vec))
-    {
-      ErrorReturnVoid("SHIFT_RIGHT_GF2VEC: the vector must be mutable", 0, 0,
-		      "you may 'return;' to skip the operation");
-      return (Obj)0;
+    Int amount1;
+    if (!IS_MUTABLE_OBJ(vec)) {
+        ErrorReturnVoid("SHIFT_RIGHT_GF2VEC: the vector must be mutable", 0,
+                        0, "you may 'return;' to skip the operation");
+        return (Obj)0;
     }
-  if (!IS_INTOBJ(amount))
-    ErrorMayQuit("SHIFT_RIGHT_GF2VEC: the amount to shift must be a small integer, not a %s",
-	      (Int)TNAM_OBJ(amount), 0L);
-  amount1 = INT_INTOBJ(amount);
-  if (amount1 < 0)
-      ErrorMayQuit("SHIFT_RIGHT_GF2VEC: <amount> must be a non-negative integer, not %d", amount1, 0);
-  ShiftRightGF2Vec(vec, amount1);
-  return (Obj)0;
+    if (!IS_INTOBJ(amount))
+        ErrorMayQuit("SHIFT_RIGHT_GF2VEC: the amount to shift must be a "
+                     "small integer, not a %s",
+                     (Int)TNAM_OBJ(amount), 0L);
+    amount1 = INT_INTOBJ(amount);
+    if (amount1 < 0)
+        ErrorMayQuit("SHIFT_RIGHT_GF2VEC: <amount> must be a non-negative "
+                     "integer, not %d",
+                     amount1, 0);
+    ShiftRightGF2Vec(vec, amount1);
+    return (Obj)0;
 }
 
-// ReduceCoeffs 
+// ReduceCoeffs
 
 /****************************************************************************
 **
@@ -3772,54 +3596,50 @@ Obj FuncSHIFT_RIGHT_GF2VEC( Obj self, Obj vec, Obj amount)
 **
 */
 
-void AddShiftedVecGF2VecGF2( Obj vec1, Obj vec2, UInt len2, UInt off )
+void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
 {
-  UInt *ptr1;
-  const UInt *ptr2;
-  UInt i;
-  UInt block;
-  UInt shift1, shift2;
-  if (off % BIPEB == 0)
-    {
-      ptr1 = BLOCKS_GF2VEC(vec1) + off/BIPEB;
-      ptr2 = CONST_BLOCKS_GF2VEC(vec2);
-      for (i = 0; i < (len2 - 1)/BIPEB; i++)
-	*ptr1++ ^= *ptr2++;
-      block = *ptr2;
+    UInt *       ptr1;
+    const UInt * ptr2;
+    UInt         i;
+    UInt         block;
+    UInt         shift1, shift2;
+    if (off % BIPEB == 0) {
+        ptr1 = BLOCKS_GF2VEC(vec1) + off / BIPEB;
+        ptr2 = CONST_BLOCKS_GF2VEC(vec2);
+        for (i = 0; i < (len2 - 1) / BIPEB; i++)
+            *ptr1++ ^= *ptr2++;
+        block = *ptr2;
 #ifdef SYS_IS_64_BIT
-      block &= (0xFFFFFFFFFFFFFFFF >> (BIPEB - (len2-1) % BIPEB -1));
+        block &= (0xFFFFFFFFFFFFFFFF >> (BIPEB - (len2 - 1) % BIPEB - 1));
 #else
-      block &= (0xFFFFFFFF >> (BIPEB - (len2-1) % BIPEB-1));
+        block &= (0xFFFFFFFF >> (BIPEB - (len2 - 1) % BIPEB - 1));
 #endif
-      *ptr1 ^= block;
+        *ptr1 ^= block;
     }
-  else
-    {
-      ptr1 = BLOCKS_GF2VEC(vec1) + off/BIPEB;
-      ptr2 = CONST_BLOCKS_GF2VEC(vec2);
-      shift1 = off %BIPEB;
-      shift2 = BIPEB - off%BIPEB;
-      for (i = 0; i < len2/BIPEB; i++)
-	{
-	  *ptr1++ ^= *ptr2 << shift1;
-	  *ptr1   ^= *ptr2++ >> shift2;
-	}
+    else {
+        ptr1 = BLOCKS_GF2VEC(vec1) + off / BIPEB;
+        ptr2 = CONST_BLOCKS_GF2VEC(vec2);
+        shift1 = off % BIPEB;
+        shift2 = BIPEB - off % BIPEB;
+        for (i = 0; i < len2 / BIPEB; i++) {
+            *ptr1++ ^= *ptr2 << shift1;
+            *ptr1 ^= *ptr2++ >> shift2;
+        }
 
-      if (len2 % BIPEB)
-	{
-	  block = *ptr2;
+        if (len2 % BIPEB) {
+            block = *ptr2;
 #ifdef SYS_IS_64_BIT
-	  block &= 0xFFFFFFFFFFFFFFFF >> (BIPEB - (len2-1) % BIPEB-1);
+            block &= 0xFFFFFFFFFFFFFFFF >> (BIPEB - (len2 - 1) % BIPEB - 1);
 #else
-	  block &= 0xFFFFFFFF >> (BIPEB - (len2-1) % BIPEB-1);
+            block &= 0xFFFFFFFF >> (BIPEB - (len2 - 1) % BIPEB - 1);
 #endif
-	  *ptr1++ ^= block << shift1;
-	  if (len2 % BIPEB + off % BIPEB > BIPEB)
-	    {
-	      assert(ptr1 < BLOCKS_GF2VEC(vec1) + (LEN_GF2VEC(vec1) + BIPEB -1)/BIPEB);
-	      *ptr1 ^= block >> shift2;
-	    }
-	}
+            *ptr1++ ^= block << shift1;
+            if (len2 % BIPEB + off % BIPEB > BIPEB) {
+                assert(ptr1 < BLOCKS_GF2VEC(vec1) +
+                                  (LEN_GF2VEC(vec1) + BIPEB - 1) / BIPEB);
+                *ptr1 ^= block >> shift2;
+            }
+        }
     }
 }
 
@@ -3829,29 +3649,32 @@ void AddShiftedVecGF2VecGF2( Obj vec1, Obj vec2, UInt len2, UInt off )
 **
 */
 
-Obj FuncADD_GF2VEC_GF2VEC_SHIFTED( Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
+Obj FuncADD_GF2VEC_GF2VEC_SHIFTED(
+    Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
 {
-  Int off1, len2a;
-  if (!IS_INTOBJ(off))
-    ErrorMayQuit("ADD_GF2VEC_GF2VEC_SHIFTED: offset should be a small integer not a %s",
-	      (Int)TNAM_OBJ(off), 0L);
-  off1 = INT_INTOBJ(off);
-  if (off1 < 0)
-    {
-       ErrorMayQuit("ADD_GF2VEC_GF2VEC_SHIFTED: <offset> must be a non-negative integer",
-			   0,0);
+    Int off1, len2a;
+    if (!IS_INTOBJ(off))
+        ErrorMayQuit("ADD_GF2VEC_GF2VEC_SHIFTED: offset should be a small "
+                     "integer not a %s",
+                     (Int)TNAM_OBJ(off), 0L);
+    off1 = INT_INTOBJ(off);
+    if (off1 < 0) {
+        ErrorMayQuit("ADD_GF2VEC_GF2VEC_SHIFTED: <offset> must be a "
+                     "non-negative integer",
+                     0, 0);
     }
-  len2a = INT_INTOBJ(len2);
-  while (len2a < 0 && len2a <= LEN_GF2VEC(vec2)) 
-    {
-      len2 = ErrorReturnObj("ADD_GF2VEC_GF2VEC_SHIFTED: <len2> must be a non-negative integer\nand less than the actual length of the vector",
-			   0,0,"you can replace <len2> via 'return <len2>;'");
-      len2a = INT_INTOBJ(len2);
+    len2a = INT_INTOBJ(len2);
+    while (len2a < 0 && len2a <= LEN_GF2VEC(vec2)) {
+        len2 = ErrorReturnObj(
+            "ADD_GF2VEC_GF2VEC_SHIFTED: <len2> must be a non-negative "
+            "integer\nand less than the actual length of the vector",
+            0, 0, "you can replace <len2> via 'return <len2>;'");
+        len2a = INT_INTOBJ(len2);
     }
-  if (len2a + off1 > LEN_GF2VEC(vec1))
-    ResizeGF2Vec(vec1, len2a+ off1);
-  AddShiftedVecGF2VecGF2( vec1, vec2, len2a, off1);
-  return (Obj) 0;
+    if (len2a + off1 > LEN_GF2VEC(vec1))
+        ResizeGF2Vec(vec1, len2a + off1);
+    AddShiftedVecGF2VecGF2(vec1, vec2, len2a, off1);
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -3860,45 +3683,42 @@ Obj FuncADD_GF2VEC_GF2VEC_SHIFTED( Obj self, Obj vec1, Obj vec2, Obj len2, Obj o
 **
 */
 
-Obj ProductCoeffsGF2Vec( Obj vec1, UInt len1, Obj vec2, UInt len2)
+Obj ProductCoeffsGF2Vec(Obj vec1, UInt len1, Obj vec2, UInt len2)
 {
-  Obj prod;
-  UInt i,e;
-  const UInt *ptr;
-  UInt block = 0;
-  UInt len;
-  if (len1 == 0 && len2 == 0)
-    len = 0;
-  else
-    len = len1 + len2 -1;
-  NEW_GF2VEC(prod, TYPE_LIST_GF2VEC, len);
+    Obj          prod;
+    UInt         i, e;
+    const UInt * ptr;
+    UInt         block = 0;
+    UInt         len;
+    if (len1 == 0 && len2 == 0)
+        len = 0;
+    else
+        len = len1 + len2 - 1;
+    NEW_GF2VEC(prod, TYPE_LIST_GF2VEC, len);
 
-  // better to do the longer loop on the inside 
-  if (len2 < len1)
-    {
-      UInt tmp;
-      Obj tmpv;
-      tmp = len1;
-      len1 = len2;
-      len2 = tmp;
-      tmpv = vec1;
-      vec1 = vec2;
-      vec2 = tmpv;
+    // better to do the longer loop on the inside
+    if (len2 < len1) {
+        UInt tmp;
+        Obj  tmpv;
+        tmp = len1;
+        len1 = len2;
+        len2 = tmp;
+        tmpv = vec1;
+        vec1 = vec2;
+        vec2 = tmpv;
     }
 
-  ptr = CONST_BLOCKS_GF2VEC(vec1);
-  e = BIPEB;
-  for (i = 0; i < len1; i++)
-    {
-      if (e == BIPEB)
-	{
-	  block = *ptr++;
-	  e = 0;
-	}
-      if (block & ((UInt)1 << e++))
-	AddShiftedVecGF2VecGF2( prod, vec2, len2, i);
+    ptr = CONST_BLOCKS_GF2VEC(vec1);
+    e = BIPEB;
+    for (i = 0; i < len1; i++) {
+        if (e == BIPEB) {
+            block = *ptr++;
+            e = 0;
+        }
+        if (block & ((UInt)1 << e++))
+            AddShiftedVecGF2VecGF2(prod, vec2, len2, i);
     }
-  return prod;
+    return prod;
 }
 
 /****************************************************************************
@@ -3907,27 +3727,30 @@ Obj ProductCoeffsGF2Vec( Obj vec1, UInt len1, Obj vec2, UInt len2)
 **
 */
 
-Obj FuncPROD_COEFFS_GF2VEC( Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2 )
+Obj FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
-  UInt len1a, len2a;
-  Obj prod;
-  UInt last;
-  if (!ARE_INTOBJS(len1,len2))
-    ErrorMayQuit("PROD_COEFFS_GF2VEC: vector lengths must be small integers, not a %s and a %s",
-	      (Int)TNAM_OBJ(len1), (Int)TNAM_OBJ(len2));
-  len2a = INT_INTOBJ(len2);
-   if (len2a > LEN_GF2VEC(vec2)) 
-       ErrorMayQuit("PROD_COEFFS_GF2VEC: <len2> must not be more than the actual\nlength of the vector",
-		 0,0);
-  len1a = INT_INTOBJ(len1);
-  if (len1a > LEN_GF2VEC(vec1)) 
-       ErrorMayQuit("PROD_COEFFS_GF2VEC: <len1> must be not more than the actual\nlength of the vector",
-		 0,0);
-  prod = ProductCoeffsGF2Vec( vec1, len1a, vec2, len2a );
-  last = RightMostOneGF2Vec(prod);
-  if (last < LEN_GF2VEC(prod))
-    ResizeGF2Vec(prod, last);
-  return prod;
+    UInt len1a, len2a;
+    Obj  prod;
+    UInt last;
+    if (!ARE_INTOBJS(len1, len2))
+        ErrorMayQuit("PROD_COEFFS_GF2VEC: vector lengths must be small "
+                     "integers, not a %s and a %s",
+                     (Int)TNAM_OBJ(len1), (Int)TNAM_OBJ(len2));
+    len2a = INT_INTOBJ(len2);
+    if (len2a > LEN_GF2VEC(vec2))
+        ErrorMayQuit("PROD_COEFFS_GF2VEC: <len2> must not be more than the "
+                     "actual\nlength of the vector",
+                     0, 0);
+    len1a = INT_INTOBJ(len1);
+    if (len1a > LEN_GF2VEC(vec1))
+        ErrorMayQuit("PROD_COEFFS_GF2VEC: <len1> must be not more than the "
+                     "actual\nlength of the vector",
+                     0, 0);
+    prod = ProductCoeffsGF2Vec(vec1, len1a, vec2, len2a);
+    last = RightMostOneGF2Vec(prod);
+    if (last < LEN_GF2VEC(prod))
+        ResizeGF2Vec(prod, last);
+    return prod;
 }
 
 /****************************************************************************
@@ -3936,38 +3759,35 @@ Obj FuncPROD_COEFFS_GF2VEC( Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2 )
 **
 */
 
-void ReduceCoeffsGF2Vec( Obj vec1, Obj vec2, UInt len2, Obj quotient )
+void ReduceCoeffsGF2Vec(Obj vec1, Obj vec2, UInt len2, Obj quotient)
 {
-  UInt len1 = LEN_GF2VEC(vec1);
-  UInt i,j,e;
-  const UInt *ptr;
-  UInt *qptr = (UInt *)0;
-  if (len2 > len1)
-    return;
-  i = len1 -1;
-  e = (i % BIPEB);
-  ptr = CONST_BLOCKS_GF2VEC(vec1) + (i/BIPEB);
-  if (quotient != (Obj) 0)
-    qptr = BLOCKS_GF2VEC(quotient);
-  j = len1-len2+1;
-  while (i+ 1 >= len2)
-    {
-      if (*ptr & ((UInt)1 << e))
-	{
-	  AddShiftedVecGF2VecGF2(vec1, vec2, len2, i - len2 + 1);
-	  if (qptr)
-	    qptr[(j-1)/BIPEB] |= MASK_POS_GF2VEC(j);
-	}
-      assert(!(*ptr & ((UInt)1<<e)));
-      if (e == 0)
-	{
-	  e = BIPEB -1;
-	  ptr--;
-	}
-      else
-	e--;
-      i--;
-      j--;
+    UInt         len1 = LEN_GF2VEC(vec1);
+    UInt         i, j, e;
+    const UInt * ptr;
+    UInt *       qptr = (UInt *)0;
+    if (len2 > len1)
+        return;
+    i = len1 - 1;
+    e = (i % BIPEB);
+    ptr = CONST_BLOCKS_GF2VEC(vec1) + (i / BIPEB);
+    if (quotient != (Obj)0)
+        qptr = BLOCKS_GF2VEC(quotient);
+    j = len1 - len2 + 1;
+    while (i + 1 >= len2) {
+        if (*ptr & ((UInt)1 << e)) {
+            AddShiftedVecGF2VecGF2(vec1, vec2, len2, i - len2 + 1);
+            if (qptr)
+                qptr[(j - 1) / BIPEB] |= MASK_POS_GF2VEC(j);
+        }
+        assert(!(*ptr & ((UInt)1 << e)));
+        if (e == 0) {
+            e = BIPEB - 1;
+            ptr--;
+        }
+        else
+            e--;
+        i--;
+        j--;
     }
 }
 
@@ -3976,45 +3796,48 @@ void ReduceCoeffsGF2Vec( Obj vec1, Obj vec2, UInt len2, Obj quotient )
 *F  FuncREDUCE_COEFFS_GF2VEC( <self>, <vec1>, <len1>, <vec2>, <len2> )
 **
 */
-Obj FuncREDUCE_COEFFS_GF2VEC( Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+Obj FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
-  UInt last;
-  Int len2a;
-  if (!IS_INTOBJ(len1))
-    ErrorMayQuit("REDUCE_COEFFS_GF2VEC: given length <len1> of left argt must be a small integer, not a %s",
-	      (Int)TNAM_OBJ(len1),0L);
-  if (INT_INTOBJ(len1) < 0 || INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
-    ErrorMayQuit("ReduceCoeffs: given length <len1> of left argt (%d)\nis longer than the argt (%d)",
-	      INT_INTOBJ(len1), LEN_GF2VEC(vec1));
-  if (!IS_INTOBJ(len2))
-    ErrorMayQuit("REDUCE_COEFFS_GF2VEC: given length <len2> of right argt must be a small integer, not a %s",
-	      (Int)TNAM_OBJ(len2),0L);
-  len2a = INT_INTOBJ(len2);
-  if ( len2a < 0 ||  len2a > LEN_GF2VEC(vec2))
-    ErrorMayQuit("ReduceCoeffs: given length <len2> of right argt (%d)\nis longer than the argt (%d)",
-		     len2a, LEN_GF2VEC(vec2));
-  ResizeGF2Vec(vec1, INT_INTOBJ(len1));
-  
-  while ( 0 < len2a ) {
-    if ( CONST_BLOCK_ELM_GF2VEC(vec2,len2a) == 0 )
-      len2a = BIPEB*((len2a-1)/BIPEB);
-    else if ( CONST_BLOCK_ELM_GF2VEC(vec2,len2a) & MASK_POS_GF2VEC(len2a) )
-      break;
-    else
-      len2a--;
-  }
+    UInt last;
+    Int  len2a;
+    if (!IS_INTOBJ(len1))
+        ErrorMayQuit("REDUCE_COEFFS_GF2VEC: given length <len1> of left argt "
+                     "must be a small integer, not a %s",
+                     (Int)TNAM_OBJ(len1), 0L);
+    if (INT_INTOBJ(len1) < 0 || INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
+        ErrorMayQuit("ReduceCoeffs: given length <len1> of left argt "
+                     "(%d)\nis longer than the argt (%d)",
+                     INT_INTOBJ(len1), LEN_GF2VEC(vec1));
+    if (!IS_INTOBJ(len2))
+        ErrorMayQuit("REDUCE_COEFFS_GF2VEC: given length <len2> of right "
+                     "argt must be a small integer, not a %s",
+                     (Int)TNAM_OBJ(len2), 0L);
+    len2a = INT_INTOBJ(len2);
+    if (len2a < 0 || len2a > LEN_GF2VEC(vec2))
+        ErrorMayQuit("ReduceCoeffs: given length <len2> of right argt "
+                     "(%d)\nis longer than the argt (%d)",
+                     len2a, LEN_GF2VEC(vec2));
+    ResizeGF2Vec(vec1, INT_INTOBJ(len1));
 
-  if (len2a == 0)
-    {
-      ErrorReturnVoid("ReduceCoeffs: second argument must not be zero", 0, 0,
-		      "you may 'return;' to skip the reduction");
-      return 0;
+    while (0 < len2a) {
+        if (CONST_BLOCK_ELM_GF2VEC(vec2, len2a) == 0)
+            len2a = BIPEB * ((len2a - 1) / BIPEB);
+        else if (CONST_BLOCK_ELM_GF2VEC(vec2, len2a) & MASK_POS_GF2VEC(len2a))
+            break;
+        else
+            len2a--;
     }
-  
-  ReduceCoeffsGF2Vec( vec1, vec2, len2a, (Obj)0);
-  last = RightMostOneGF2Vec(vec1);
-  ResizeGF2Vec(vec1, last);
-  return INTOBJ_INT(last);
+
+    if (len2a == 0) {
+        ErrorReturnVoid("ReduceCoeffs: second argument must not be zero", 0,
+                        0, "you may 'return;' to skip the reduction");
+        return 0;
+    }
+
+    ReduceCoeffsGF2Vec(vec1, vec2, len2a, (Obj)0);
+    last = RightMostOneGF2Vec(vec1);
+    ResizeGF2Vec(vec1, last);
+    return INTOBJ_INT(last);
 }
 
 /****************************************************************************
@@ -4022,55 +3845,60 @@ Obj FuncREDUCE_COEFFS_GF2VEC( Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 *F  FuncQUOTREM_COEFFS_GF2VEC( <self>, <vec1>, <len1>, <vec2>, <len2> )
 **
 */
-Obj FuncQUOTREM_COEFFS_GF2VEC( Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+Obj FuncQUOTREM_COEFFS_GF2VEC(
+    Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
-     Int len2a;
-     Int len1a = INT_INTOBJ(len1);
-     Obj quotv, remv, ret;
-     if (!IS_INTOBJ(len1))
-     ErrorMayQuit("QUOTREM_COEFFS_GF2VEC: given length <len1> of left argt must be a small integer, not a %s",
-		  (Int)TNAM_OBJ(len1),0L);
-     if (INT_INTOBJ(len1) < 0 || INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
-     ErrorMayQuit("QuotremCoeffs: given length <len1> of left argt (%d)\nis longer than the argt (%d)",
-		  INT_INTOBJ(len1), LEN_GF2VEC(vec1));
-     if (!IS_INTOBJ(len2))
-     ErrorMayQuit("QUOTREM_COEFFS_GF2VEC: given length <len2> of right argt must be a small integer, not a %s",
-		  (Int)TNAM_OBJ(len2),0L);
-     len2a = INT_INTOBJ(len2);
-     if ( len2a < 0 ||  len2a > LEN_GF2VEC(vec2))
-     ErrorMayQuit("QuotremCoeffs: given length <len2> of right argt (%d)\nis longer than the argt (%d)",
-		  len2a, LEN_GF2VEC(vec2));
-     
-     while ( 0 < len2a ) {
-       if ( CONST_BLOCK_ELM_GF2VEC(vec2,len2a) == 0 )
-	 len2a = BIPEB*((len2a-1)/BIPEB);
-       else if ( CONST_BLOCK_ELM_GF2VEC(vec2,len2a) & MASK_POS_GF2VEC(len2a) )
-	 break;
-       else
-	 len2a--;
-     } 
-     if (len2a == 0) {
-       ErrorReturnVoid("QuotremCoeffs: second argument must not be zero", 0, 0,
-		       "you may 'return;' to skip the reduction");
-       return 0;
-     }
+    Int len2a;
+    Int len1a = INT_INTOBJ(len1);
+    Obj quotv, remv, ret;
+    if (!IS_INTOBJ(len1))
+        ErrorMayQuit("QUOTREM_COEFFS_GF2VEC: given length <len1> of left "
+                     "argt must be a small integer, not a %s",
+                     (Int)TNAM_OBJ(len1), 0L);
+    if (INT_INTOBJ(len1) < 0 || INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
+        ErrorMayQuit("QuotremCoeffs: given length <len1> of left argt "
+                     "(%d)\nis longer than the argt (%d)",
+                     INT_INTOBJ(len1), LEN_GF2VEC(vec1));
+    if (!IS_INTOBJ(len2))
+        ErrorMayQuit("QUOTREM_COEFFS_GF2VEC: given length <len2> of right "
+                     "argt must be a small integer, not a %s",
+                     (Int)TNAM_OBJ(len2), 0L);
+    len2a = INT_INTOBJ(len2);
+    if (len2a < 0 || len2a > LEN_GF2VEC(vec2))
+        ErrorMayQuit("QuotremCoeffs: given length <len2> of right argt "
+                     "(%d)\nis longer than the argt (%d)",
+                     len2a, LEN_GF2VEC(vec2));
 
-     NEW_GF2VEC(remv, TYPE_LIST_GF2VEC, len1a);
-     memcpy(BLOCKS_GF2VEC(remv), CONST_BLOCKS_GF2VEC(vec1),
-	    ((len1a + BIPEB-1)/BIPEB)*sizeof(UInt));
-     
-     NEW_GF2VEC(quotv, TYPE_LIST_GF2VEC, len1a-len2a+1);
-     ReduceCoeffsGF2Vec( remv, vec2, len2a, quotv);
-     
-     ret = NEW_PLIST(T_PLIST_TAB, 2);
-     SET_LEN_PLIST(ret, 2);
-     
-     SET_ELM_PLIST(ret, 1, quotv);
-     SET_ELM_PLIST(ret, 2, remv);
+    while (0 < len2a) {
+        if (CONST_BLOCK_ELM_GF2VEC(vec2, len2a) == 0)
+            len2a = BIPEB * ((len2a - 1) / BIPEB);
+        else if (CONST_BLOCK_ELM_GF2VEC(vec2, len2a) & MASK_POS_GF2VEC(len2a))
+            break;
+        else
+            len2a--;
+    }
+    if (len2a == 0) {
+        ErrorReturnVoid("QuotremCoeffs: second argument must not be zero", 0,
+                        0, "you may 'return;' to skip the reduction");
+        return 0;
+    }
 
-     CHANGED_BAG(ret);
+    NEW_GF2VEC(remv, TYPE_LIST_GF2VEC, len1a);
+    memcpy(BLOCKS_GF2VEC(remv), CONST_BLOCKS_GF2VEC(vec1),
+           ((len1a + BIPEB - 1) / BIPEB) * sizeof(UInt));
 
-return ret;
+    NEW_GF2VEC(quotv, TYPE_LIST_GF2VEC, len1a - len2a + 1);
+    ReduceCoeffsGF2Vec(remv, vec2, len2a, quotv);
+
+    ret = NEW_PLIST(T_PLIST_TAB, 2);
+    SET_LEN_PLIST(ret, 2);
+
+    SET_ELM_PLIST(ret, 1, quotv);
+    SET_ELM_PLIST(ret, 2, remv);
+
+    CHANGED_BAG(ret);
+
+    return ret;
 }
 
 
@@ -4084,31 +3912,29 @@ return ret;
 **  vectors
 */
 
-Obj FuncSEMIECHELON_LIST_GF2VECS( Obj self, Obj mat )
+Obj FuncSEMIECHELON_LIST_GF2VECS(Obj self, Obj mat)
 {
-  UInt i,len;
-  UInt width;
-  Obj row;
-  // check argts 
-  len = LEN_PLIST(mat);
-  if (!len)
-    return TRY_NEXT_METHOD;
-  row = ELM_PLIST(mat,1);
-  if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
-    return TRY_NEXT_METHOD;
-  width = LEN_GF2VEC(row);
-  if (width == 0)
-    return TRY_NEXT_METHOD;
-  for (i = 2; i <= len; i++)
-    {
-      row = ELM_PLIST(mat, i);
-      if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
-	  LEN_GF2VEC(row)!= width)
-	{
-	  return TRY_NEXT_METHOD;
-	}
+    UInt i, len;
+    UInt width;
+    Obj  row;
+    // check argts
+    len = LEN_PLIST(mat);
+    if (!len)
+        return TRY_NEXT_METHOD;
+    row = ELM_PLIST(mat, 1);
+    if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
+        return TRY_NEXT_METHOD;
+    width = LEN_GF2VEC(row);
+    if (width == 0)
+        return TRY_NEXT_METHOD;
+    for (i = 2; i <= len; i++) {
+        row = ELM_PLIST(mat, i);
+        if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
+            LEN_GF2VEC(row) != width) {
+            return TRY_NEXT_METHOD;
+        }
     }
-  return SemiEchelonListGF2Vecs( mat, 0);
+    return SemiEchelonListGF2Vecs(mat, 0);
 }
 
 /****************************************************************************
@@ -4121,31 +3947,29 @@ Obj FuncSEMIECHELON_LIST_GF2VECS( Obj self, Obj mat )
 **  vectors
 */
 
-Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS( Obj self, Obj mat )
+Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(Obj self, Obj mat)
 {
-  UInt i,len;
-  UInt width;
-  Obj row;
-  // check argts 
-  len = LEN_PLIST(mat);
-  if (!len)
-    return TRY_NEXT_METHOD;
-  row = ELM_PLIST(mat,1);
-  if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
-    return TRY_NEXT_METHOD;
-  width = LEN_GF2VEC(row);
-  if (width == 0)
-    return TRY_NEXT_METHOD;
-  for (i = 2; i <= len; i++)
-    {
-      row = ELM_PLIST(mat, i);
-      if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
-	  LEN_GF2VEC(row)!= width)
-	{
-	  return TRY_NEXT_METHOD;
-	}
+    UInt i, len;
+    UInt width;
+    Obj  row;
+    // check argts
+    len = LEN_PLIST(mat);
+    if (!len)
+        return TRY_NEXT_METHOD;
+    row = ELM_PLIST(mat, 1);
+    if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
+        return TRY_NEXT_METHOD;
+    width = LEN_GF2VEC(row);
+    if (width == 0)
+        return TRY_NEXT_METHOD;
+    for (i = 2; i <= len; i++) {
+        row = ELM_PLIST(mat, i);
+        if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
+            LEN_GF2VEC(row) != width) {
+            return TRY_NEXT_METHOD;
+        }
     }
-  return SemiEchelonListGF2Vecs( mat, 1);
+    return SemiEchelonListGF2Vecs(mat, 1);
 }
 
 /****************************************************************************
@@ -4154,32 +3978,30 @@ Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS( Obj self, Obj mat )
 **
 */
 
-Obj FuncTRIANGULIZE_LIST_GF2VECS( Obj self, Obj mat)
+Obj FuncTRIANGULIZE_LIST_GF2VECS(Obj self, Obj mat)
 {
-  UInt i,len;
-  UInt width;
-  Obj row;
-  // check argts 
-  len = LEN_PLIST(mat);
-  if (!len)
-    return TRY_NEXT_METHOD;
-  row = ELM_PLIST(mat,1);
-  if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
-    return TRY_NEXT_METHOD;
-  width = LEN_GF2VEC(row);
-  if (width == 0)
-    return TRY_NEXT_METHOD;
-  for (i = 2; i <= len; i++)
-    {
-      row = ELM_PLIST(mat, i);
-      if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
-	  LEN_GF2VEC(row)!= width)
-	{
-	  return TRY_NEXT_METHOD;
-	}
+    UInt i, len;
+    UInt width;
+    Obj  row;
+    // check argts
+    len = LEN_PLIST(mat);
+    if (!len)
+        return TRY_NEXT_METHOD;
+    row = ELM_PLIST(mat, 1);
+    if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
+        return TRY_NEXT_METHOD;
+    width = LEN_GF2VEC(row);
+    if (width == 0)
+        return TRY_NEXT_METHOD;
+    for (i = 2; i <= len; i++) {
+        row = ELM_PLIST(mat, i);
+        if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
+            LEN_GF2VEC(row) != width) {
+            return TRY_NEXT_METHOD;
+        }
     }
-  TriangulizeListGF2Vecs( mat, 1 );
-  return (Obj) 0;
+    TriangulizeListGF2Vecs(mat, 1);
+    return (Obj)0;
 }
 
 /****************************************************************************
@@ -4188,31 +4010,29 @@ Obj FuncTRIANGULIZE_LIST_GF2VECS( Obj self, Obj mat)
 **
 */
 
-Obj FuncRANK_LIST_GF2VECS( Obj self, Obj mat)
+Obj FuncRANK_LIST_GF2VECS(Obj self, Obj mat)
 {
-  UInt i,len;
-  UInt width;
-  Obj row;
-  // check argts 
-  len = LEN_PLIST(mat);
-  if (!len)
-    return TRY_NEXT_METHOD;
-  row = ELM_PLIST(mat,1);
-  if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
-    return TRY_NEXT_METHOD;
-  width = LEN_GF2VEC(row);
-  if (width == 0)
-    return TRY_NEXT_METHOD;
-  for (i = 2; i <= len; i++)
-    {
-      row = ELM_PLIST(mat, i);
-      if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
-	  LEN_GF2VEC(row)!= width)
-	{
-	  return TRY_NEXT_METHOD;
-	}
+    UInt i, len;
+    UInt width;
+    Obj  row;
+    // check argts
+    len = LEN_PLIST(mat);
+    if (!len)
+        return TRY_NEXT_METHOD;
+    row = ELM_PLIST(mat, 1);
+    if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
+        return TRY_NEXT_METHOD;
+    width = LEN_GF2VEC(row);
+    if (width == 0)
+        return TRY_NEXT_METHOD;
+    for (i = 2; i <= len; i++) {
+        row = ELM_PLIST(mat, i);
+        if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
+            LEN_GF2VEC(row) != width) {
+            return TRY_NEXT_METHOD;
+        }
     }
-  return INTOBJ_INT(TriangulizeListGF2Vecs( mat , 0));
+    return INTOBJ_INT(TriangulizeListGF2Vecs(mat, 0));
 }
 
 /****************************************************************************
@@ -4221,31 +4041,29 @@ Obj FuncRANK_LIST_GF2VECS( Obj self, Obj mat)
 **
 */
 
-Obj FuncDETERMINANT_LIST_GF2VECS( Obj self, Obj mat)
+Obj FuncDETERMINANT_LIST_GF2VECS(Obj self, Obj mat)
 {
-  UInt i,len;
-  UInt width;
-  Obj row;
-  // check argts 
-  len = LEN_PLIST(mat);
-  if (!len)
-    return TRY_NEXT_METHOD;
-  row = ELM_PLIST(mat,1);
-  if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
-    return TRY_NEXT_METHOD;
-  width = LEN_GF2VEC(row);
-  if (width == 0)
-    return TRY_NEXT_METHOD;
-  for (i = 2; i <= len; i++)
-    {
-      row = ELM_PLIST(mat, i);
-      if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
-	  LEN_GF2VEC(row)!= width)
-	{
-	  return TRY_NEXT_METHOD;
-	}
+    UInt i, len;
+    UInt width;
+    Obj  row;
+    // check argts
+    len = LEN_PLIST(mat);
+    if (!len)
+        return TRY_NEXT_METHOD;
+    row = ELM_PLIST(mat, 1);
+    if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row))
+        return TRY_NEXT_METHOD;
+    width = LEN_GF2VEC(row);
+    if (width == 0)
+        return TRY_NEXT_METHOD;
+    for (i = 2; i <= len; i++) {
+        row = ELM_PLIST(mat, i);
+        if (!IS_MUTABLE_OBJ(row) || !IS_GF2VEC_REP(row) ||
+            LEN_GF2VEC(row) != width) {
+            return TRY_NEXT_METHOD;
+        }
     }
-  return (len == TriangulizeListGF2Vecs( mat , 0)) ? GF2One : GF2Zero;
+    return (len == TriangulizeListGF2Vecs(mat, 0)) ? GF2One : GF2Zero;
 }
 
 /****************************************************************************
@@ -4254,89 +4072,91 @@ Obj FuncDETERMINANT_LIST_GF2VECS( Obj self, Obj mat)
 **
 */
 
-Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
+Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 {
-  UInt nrowl, nrowr, nrowp, ncoll, ncolr, ncolp, ncol,
-    i, j, k, l, mutable;
-  Obj mat, type, row, shift[BIPEB];
-  UInt *data;
-  const UInt *datar;
+    UInt nrowl, nrowr, nrowp, ncoll, ncolr, ncolp, ncol, i, j, k, l, mutable;
+    Obj  mat, type, row, shift[BIPEB];
+    UInt *       data;
+    const UInt * datar;
 
-  nrowl = LEN_GF2MAT(matl);
-  nrowr = LEN_GF2MAT(matr);
-  nrowp = nrowl*nrowr;
-  ncoll = LEN_GF2VEC(ELM_GF2MAT(matl,1));
-  ncolr = LEN_GF2VEC(ELM_GF2MAT(matr,1));
-  ncolp = ncoll*ncolr;
+    nrowl = LEN_GF2MAT(matl);
+    nrowr = LEN_GF2MAT(matr);
+    nrowp = nrowl * nrowr;
+    ncoll = LEN_GF2VEC(ELM_GF2MAT(matl, 1));
+    ncolr = LEN_GF2VEC(ELM_GF2MAT(matr, 1));
+    ncolp = ncoll * ncolr;
 
-  mutable = IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr);
+    mutable = IS_MUTABLE_OBJ(matl) || IS_MUTABLE_OBJ(matr);
 
-  // create a matrix 
-  mat = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(nrowp));
-  SET_LEN_GF2MAT(mat,nrowp);
-  if (mutable) {
-      SET_TYPE_POSOBJ(mat, TYPE_LIST_GF2MAT);
-      type = TYPE_LIST_GF2VEC_LOCKED;
-  } else {
-      SET_TYPE_POSOBJ(mat, TYPE_LIST_GF2MAT_IMM);
-      type = TYPE_LIST_GF2VEC_IMM_LOCKED;
-  }
-
-  // allocate 0 matrix 
-
-  for (i = 1; i <= nrowp; i++) {
-    NEW_GF2VEC(row, type, ncolp);
-    SET_ELM_GF2MAT(mat,i,row);
-    CHANGED_BAG(mat);
-  }
-
-  // allocate data for shifts of rows of matr 
-  for (i = 0; i < BIPEB; i++) {
-    shift[i] = NewBag(T_DATOBJ, SIZE_PLEN_GF2VEC(ncolr+2*BIPEB));
-  }
-
-  // fill in matrix 
-  for (j = 1; j <= nrowr; j++) {
-    // create shifts of rows of matr 
-    data = (UInt *) ADDR_OBJ(shift[0]);
-    datar = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(matr,j));
-    for (k = 0; k < (ncolr+BIPEB-1)/BIPEB; k++)
-      data[k] = datar[k];
-    data[k] = 0;
-    
-    for (i = 1; i < BIPEB; i++) { // now shifts in [1..BIPEB-1] 
-      data = (UInt *) ADDR_OBJ(shift[i]);
-      datar = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(matr,j));
-      data[0] = datar[0] << i;
-      for (k = 1; k < (ncolr+BIPEB-1)/BIPEB; k++)
-	data[k] = (datar[k] << i) | (datar[k-1] >> (BIPEB-i));
-      data[k] = datar[k-1] >> (BIPEB-i);
+    // create a matrix
+    mat = NewBag(T_POSOBJ, SIZE_PLEN_GF2MAT(nrowp));
+    SET_LEN_GF2MAT(mat, nrowp);
+    if (mutable) {
+        SET_TYPE_POSOBJ(mat, TYPE_LIST_GF2MAT);
+        type = TYPE_LIST_GF2VEC_LOCKED;
     }
-    for (i = 1; i <= nrowl; i++) {
-      data = BLOCKS_GF2VEC(ELM_GF2MAT(mat,(i-1)*nrowr+j));
-      ncol = 0;
-      for (k = 1; k <= ncoll; k++) {
-	l = 0;
-	if (CONST_BLOCK_ELM_GF2VEC(ELM_GF2MAT(matl,i),k) & MASK_POS_GF2VEC(k)) {
-	  // append shift[ncol%BIPEB] to data 
-	  datar = (const UInt *) CONST_ADDR_OBJ(shift[ncol%BIPEB]);
-	  if (ncol % BIPEB) {
-	    data[-1] ^= *datar++;
-	    l = BIPEB - ncol%BIPEB;
-	  }
-	  for (; l < ncolr; l += BIPEB)
-	    *data++ = *datar++;
-	} else {
-	  if (ncol % BIPEB)
-	    l = BIPEB - ncol%BIPEB;
-	  data += (ncolr+BIPEB-1-l)/BIPEB;
-	}
-	ncol += ncolr;
-      }
+    else {
+        SET_TYPE_POSOBJ(mat, TYPE_LIST_GF2MAT_IMM);
+        type = TYPE_LIST_GF2VEC_IMM_LOCKED;
     }
-  }
 
-  return mat;
+    // allocate 0 matrix
+
+    for (i = 1; i <= nrowp; i++) {
+        NEW_GF2VEC(row, type, ncolp);
+        SET_ELM_GF2MAT(mat, i, row);
+        CHANGED_BAG(mat);
+    }
+
+    // allocate data for shifts of rows of matr
+    for (i = 0; i < BIPEB; i++) {
+        shift[i] = NewBag(T_DATOBJ, SIZE_PLEN_GF2VEC(ncolr + 2 * BIPEB));
+    }
+
+    // fill in matrix
+    for (j = 1; j <= nrowr; j++) {
+        // create shifts of rows of matr
+        data = (UInt *)ADDR_OBJ(shift[0]);
+        datar = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(matr, j));
+        for (k = 0; k < (ncolr + BIPEB - 1) / BIPEB; k++)
+            data[k] = datar[k];
+        data[k] = 0;
+
+        for (i = 1; i < BIPEB; i++) {    // now shifts in [1..BIPEB-1]
+            data = (UInt *)ADDR_OBJ(shift[i]);
+            datar = CONST_BLOCKS_GF2VEC(ELM_GF2MAT(matr, j));
+            data[0] = datar[0] << i;
+            for (k = 1; k < (ncolr + BIPEB - 1) / BIPEB; k++)
+                data[k] = (datar[k] << i) | (datar[k - 1] >> (BIPEB - i));
+            data[k] = datar[k - 1] >> (BIPEB - i);
+        }
+        for (i = 1; i <= nrowl; i++) {
+            data = BLOCKS_GF2VEC(ELM_GF2MAT(mat, (i - 1) * nrowr + j));
+            ncol = 0;
+            for (k = 1; k <= ncoll; k++) {
+                l = 0;
+                if (CONST_BLOCK_ELM_GF2VEC(ELM_GF2MAT(matl, i), k) &
+                    MASK_POS_GF2VEC(k)) {
+                    // append shift[ncol%BIPEB] to data
+                    datar = (const UInt *)CONST_ADDR_OBJ(shift[ncol % BIPEB]);
+                    if (ncol % BIPEB) {
+                        data[-1] ^= *datar++;
+                        l = BIPEB - ncol % BIPEB;
+                    }
+                    for (; l < ncolr; l += BIPEB)
+                        *data++ = *datar++;
+                }
+                else {
+                    if (ncol % BIPEB)
+                        l = BIPEB - ncol % BIPEB;
+                    data += (ncolr + BIPEB - 1 - l) / BIPEB;
+                }
+                ncol += ncolr;
+            }
+        }
+    }
+
+    return mat;
 }
 
 
@@ -4345,27 +4165,30 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT( Obj self, Obj matl, Obj matr)
 *F  FuncMAT_ELM_GF2MAT( <self>, <mat>, <row>, <col> )
 **
 */
-Obj FuncMAT_ELM_GF2MAT( Obj self, Obj mat, Obj row, Obj col )
+Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",
                      (Int)TNAM_OBJ(row), 0L);
     }
     if (!IS_POS_INTOBJ(col)) {
-        ErrorMayQuit("column index must be a small positive integer, not a %s",
-                     (Int)TNAM_OBJ(col), 0L);
+        ErrorMayQuit(
+            "column index must be a small positive integer, not a %s",
+            (Int)TNAM_OBJ(col), 0L);
     }
 
     UInt r = INT_INTOBJ(row);
     if (LEN_GF2MAT(mat) < r) {
-        ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_GF2MAT(mat));
+        ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
+                     LEN_GF2MAT(mat));
     }
 
     Obj vec = ELM_GF2MAT(mat, r);
 
     UInt c = INT_INTOBJ(col);
     if (LEN_GF2VEC(vec) < c) {
-        ErrorMayQuit("column index %d exceeds %d, the number of columns", c, LEN_GF2VEC(vec));
+        ErrorMayQuit("column index %d exceeds %d, the number of columns", c,
+                     LEN_GF2VEC(vec));
     }
 
     return ELM_GF2VEC(vec, c);
@@ -4377,40 +4200,44 @@ Obj FuncMAT_ELM_GF2MAT( Obj self, Obj mat, Obj row, Obj col )
 *F  FuncSET_MAT_ELM_GF2MAT( <self>, <mat>, <row>, <col>, <elm> )
 **
 */
-Obj FuncSET_MAT_ELM_GF2MAT( Obj self, Obj mat, Obj row, Obj col, Obj elm )
+Obj FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",
                      (Int)TNAM_OBJ(row), 0L);
     }
     if (!IS_POS_INTOBJ(col)) {
-        ErrorMayQuit("column index must be a small positive integer, not a %s",
-                     (Int)TNAM_OBJ(col), 0L);
+        ErrorMayQuit(
+            "column index must be a small positive integer, not a %s",
+            (Int)TNAM_OBJ(col), 0L);
     }
 
     UInt r = INT_INTOBJ(row);
     if (LEN_GF2MAT(mat) < r) {
-        ErrorMayQuit("row index %d exceeds %d, the number of rows", r, LEN_GF2MAT(mat));
+        ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
+                     LEN_GF2MAT(mat));
     }
 
     Obj vec = ELM_GF2MAT(mat, r);
-    if ( ! IS_MUTABLE_OBJ(vec) ) {
+    if (!IS_MUTABLE_OBJ(vec)) {
         ErrorMayQuit("row %d is immutable", r, 0);
     }
 
     UInt c = INT_INTOBJ(col);
     if (LEN_GF2VEC(vec) < c) {
-        ErrorMayQuit("column index %d exceeds %d, the number of columns", c, LEN_GF2VEC(vec));
+        ErrorMayQuit("column index %d exceeds %d, the number of columns", c,
+                     LEN_GF2VEC(vec));
     }
 
-    if ( EQ(GF2One, elm) ) {
-        BLOCK_ELM_GF2VEC(vec,c) |= MASK_POS_GF2VEC(c);
+    if (EQ(GF2One, elm)) {
+        BLOCK_ELM_GF2VEC(vec, c) |= MASK_POS_GF2VEC(c);
     }
-    else if ( EQ(GF2Zero, elm) ) {
-        BLOCK_ELM_GF2VEC(vec,c) &= ~MASK_POS_GF2VEC(c);
+    else if (EQ(GF2Zero, elm)) {
+        BLOCK_ELM_GF2VEC(vec, c) &= ~MASK_POS_GF2VEC(c);
     }
     else {
-        ErrorMayQuit("SET_MAT_ELM_GF2MAT: assigned element must be a GF(2) element, not a %s",
+        ErrorMayQuit("SET_MAT_ELM_GF2MAT: assigned element must be a GF(2) "
+                     "element, not a %s",
                      (Int)TNAM_OBJ(elm), 0L);
     }
 
@@ -4428,7 +4255,7 @@ Obj FuncSET_MAT_ELM_GF2MAT( Obj self, Obj mat, Obj row, Obj col, Obj elm )
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(CONV_GF2VEC, 1, "list"),
     GVAR_FUNC(COPY_GF2VEC, 1, "list"),
@@ -4459,7 +4286,9 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(PROD_GF2MAT_GF2VEC, 2, "gf2mat, gf2vec"),
     GVAR_FUNC(PROD_GF2MAT_GF2MAT, 2, "gf2matl, gf2matr"),
     GVAR_FUNC(PROD_GF2MAT_GF2MAT_SIMPLE, 2, "gf2matl, gf2matr"),
-    GVAR_FUNC(PROD_GF2MAT_GF2MAT_ADVANCED, 4, "gf2matl, gf2matr, greaselevel, blocklevel"),
+    GVAR_FUNC(PROD_GF2MAT_GF2MAT_ADVANCED,
+              4,
+              "gf2matl, gf2matr, greaselevel, blocklevel"),
     GVAR_FUNC(ADDCOEFFS_GF2VEC_GF2VEC_MULT, 3, "gf2vec, gf2vec, mul"),
     GVAR_FUNC(ADDCOEFFS_GF2VEC_GF2VEC, 2, "gf2vec, gf2vec"),
     GVAR_FUNC(SHRINKCOEFFS_GF2VEC, 1, "gf2vec"),
@@ -4504,33 +4333,35 @@ static StructGVarFunc GVarFuncs [] = {
 **
 *F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
 */
-static Int InitKernel (
-    StructInitInfo *    module )
+static Int InitKernel(StructInitInfo * module)
 {
-  RNheads = 0;
-  RNvectors = 0;
-  RNcoeffs = 0;
-  RNrelns = 0;
+    RNheads = 0;
+    RNvectors = 0;
+    RNcoeffs = 0;
+    RNrelns = 0;
 
-    // import type functions                                               
-    ImportGVarFromLibrary( "TYPE_LIST_GF2VEC",     &TYPE_LIST_GF2VEC     );
-    ImportGVarFromLibrary( "TYPE_LIST_GF2VEC_IMM", &TYPE_LIST_GF2VEC_IMM );
-    ImportGVarFromLibrary( "TYPE_LIST_GF2VEC_IMM_LOCKED", &TYPE_LIST_GF2VEC_IMM_LOCKED );
-    ImportGVarFromLibrary( "TYPE_LIST_GF2VEC_LOCKED", &TYPE_LIST_GF2VEC_LOCKED );
-    ImportFuncFromLibrary( "IsGF2VectorRep",       &IsGF2VectorRep       );
-    ImportGVarFromLibrary( "TYPE_LIST_GF2MAT",     &TYPE_LIST_GF2MAT     );
-    ImportGVarFromLibrary( "TYPE_LIST_GF2MAT_IMM", &TYPE_LIST_GF2MAT_IMM );
+    // import type functions
+    ImportGVarFromLibrary("TYPE_LIST_GF2VEC", &TYPE_LIST_GF2VEC);
+    ImportGVarFromLibrary("TYPE_LIST_GF2VEC_IMM", &TYPE_LIST_GF2VEC_IMM);
+    ImportGVarFromLibrary("TYPE_LIST_GF2VEC_IMM_LOCKED",
+                          &TYPE_LIST_GF2VEC_IMM_LOCKED);
+    ImportGVarFromLibrary("TYPE_LIST_GF2VEC_LOCKED",
+                          &TYPE_LIST_GF2VEC_LOCKED);
+    ImportFuncFromLibrary("IsGF2VectorRep", &IsGF2VectorRep);
+    ImportGVarFromLibrary("TYPE_LIST_GF2MAT", &TYPE_LIST_GF2MAT);
+    ImportGVarFromLibrary("TYPE_LIST_GF2MAT_IMM", &TYPE_LIST_GF2MAT_IMM);
 
-    // initialize one and zero of GF2                                      
-    ImportGVarFromLibrary( "GF2One",  &GF2One  );
-    ImportGVarFromLibrary( "GF2Zero", &GF2Zero );
+    // initialize one and zero of GF2
+    ImportGVarFromLibrary("GF2One", &GF2One);
+    ImportGVarFromLibrary("GF2Zero", &GF2Zero);
 
-    // init filters and functions                                          
-    InitHdlrFuncsFromTable( GVarFuncs );
+    // init filters and functions
+    InitHdlrFuncsFromTable(GVarFuncs);
 
-    InitFopyGVar("IsLockedRepresentationVector", &IsLockedRepresentationVector);
+    InitFopyGVar("IsLockedRepresentationVector",
+                 &IsLockedRepresentationVector);
 
-    // return success                                                      
+    // return success
     return 0;
 }
 
@@ -4539,13 +4370,12 @@ static Int InitKernel (
 **
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-static Int InitLibrary (
-    StructInitInfo *    module )
+static Int InitLibrary(StructInitInfo * module)
 {
-    // init filters and functions                                          
-    InitGVarFuncsFromTable( GVarFuncs );
+    // init filters and functions
+    InitGVarFuncsFromTable(GVarFuncs);
 
-    // return success                                                      
+    // return success
     return 0;
 }
 
@@ -4563,7 +4393,7 @@ static StructInitInfo module = {
     .initLibrary = InitLibrary,
 };
 
-StructInitInfo * InitInfoGF2Vec ( void )
+StructInitInfo * InitInfoGF2Vec(void)
 {
     return &module;
 }

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1933,7 +1933,7 @@ Obj FuncASS_GF2VEC (
     }
 
     /* get the position                                                    */
-    UInt p = GetSmallInt("ASS_VEC8BIT", pos, "pos");
+    UInt p = GetSmallInt("ASS_GF2VEC", pos, "pos");
 
     /* if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep         */
     if ( p <= LEN_GF2VEC(list)+1 ) {
@@ -1953,7 +1953,7 @@ Obj FuncASS_GF2VEC (
 	  {
 	    /*	    Pr("Rewriting GF2 vector over larger field",0,0); */
 	    RewriteGF2Vec(list, SIZE_FF(FLD_FFE(elm)));
-	    FuncASS_VEC8BIT(self, list, pos, elm);
+	    ASS_VEC8BIT(list, pos, elm);
 	  }
         else
 	  {

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -59,7 +59,7 @@ Obj TYPE_LIST_GF2VEC_IMM;
 
 /****************************************************************************
 **
-*V  TYPE_LIST_GF2VEC_IMM_LOCKED. . . .  type of an immutable GF2 vector object
+*V  TYPE_LIST_GF2VEC_IMM_LOCKED . . .  type of an immutable GF2 vector object
 **                                          with locked representation
 */
 Obj TYPE_LIST_GF2VEC_IMM_LOCKED;
@@ -198,7 +198,7 @@ CopySection_GF2Vecs(Obj src, Obj dest, UInt smin, UInt dmin, UInt nelts)
 **  Note: The other entries are set to be zero. So use a higher value for <n>
 **        only for vectors, which both have leading zero-entries. 
 **
-**  You  can use  the parameter  <n> for  example for  an  gauss-algorithm on 
+**  You  can use  the parameter  <n> for  example for  an  gauss-algorithm on
 **  gf2-matrices  can be  improved,  because when  using the gauss-algorithm,
 **  you  know that  the leading entries of two vectors to be  added are equal
 **  zero. If <n> = 1 all entries are added. 
@@ -489,15 +489,16 @@ Obj ProdGF2MatGF2Vec ( Obj ml, Obj vr )
 
 /****************************************************************************
 **
-*F  ProdGF2MatGF2MatSimple( <ml>, <mr> )  . .  product of GF2 matrix and GF2 matrix
+*F  ProdGF2MatGF2MatSimple( <ml>, <mr> ) . . . .  product of two GF2 matrices
 *F  ProdGF2MatGF2MatAdvanced( <ml>, <mr>, <greaselevel>, <blocksize> )
-**                                     . .  product of GF2 matrix and GF2 matrix
+**                                     . .  product of twp GF2 matrices
 **
-**  'ProdGF2MatGF2MatSimple'  returns the product  of the  GF2 matrix <ml>  and the
-**  GF2 matrix  <mr>.  This simply calls ProdGF2VecGF2Mat once on each row.
+**  'ProdGF2MatGF2MatSimple' returns the product of the GF2 matrix <ml> and
+**  the GF2 matrix <mr>. This simply calls ProdGF2VecGF2Mat once on each row.
 **
-** ProdGF2MatGF2MatAdvanced uses the specified grease and blocking to accelerate
-** larger matrix multiplies. In this case, the matrix dimensions must be compatible.
+**  ProdGF2MatGF2MatAdvanced uses the specified grease and blocking to
+**  accelerate larger matrix multiplies. In this case, the matrix dimensions
+**  must be compatible.
 */
 
 Obj ProdGF2MatGF2MatSimple( Obj ml, Obj mr )
@@ -894,8 +895,8 @@ Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 *F  InversePlistGF2VecsDesstructive( <list> )
 **
 **  This is intended to form the core of a method for InverseOp.
-**  by this point it should be checked that list is a plain list of GF2 vectors
-**  of equal lengths. 
+**  by this point it should be checked that list is a plain list of GF2
+**  vectors of equal lengths. 
 */
 Obj InversePlistGF2VecsDesstructive( Obj list )
 {
@@ -1082,7 +1083,8 @@ Obj ShallowCopyVecGF2( Obj vec )
 **
 **  The matrix needs to have mutable rows, so it can't be a GF2 mat
 **
-**  This has changed. There should now be a method for mutable GF2mats as well.
+**  This has changed. There should now be a method for mutable GF2mats as
+**  well.
 **
 **  This function DOES NOT CHECK that the rows are all GF2 vectors
 **
@@ -2280,7 +2282,9 @@ Obj FuncINV_GF2MAT_IMMUTABLE (
 
 /****************************************************************************
 **
-*F  FuncINV_PLIST_GF2VECS_DESTRUCTIVE( <self>, <list> ) . . .invert possible GF2 matrix
+*F  FuncINV_PLIST_GF2VECS_DESTRUCTIVE( <self>, <list> )
+**
+**  invert possible GF2 matrix
 */
 Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE( Obj self, Obj list )
 {
@@ -2413,8 +2417,8 @@ Obj FuncPROD_GF2VEC_GF2MAT (
 **
 *F  FuncPROD_GF2MAT_GF2MAT( <self>, <ml>, <mr> ) product of GF2 vector/matrix
 **
-**  'FuncPROD_GF2MAT_GF2MAT' returns  the product of the GF2 matricess <ml> and
-**  <mr>.
+**  'FuncPROD_GF2MAT_GF2MAT' returns the product of the GF2 matricess <ml>
+**  and <mr>.
 **
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
@@ -2439,10 +2443,10 @@ Obj FuncPROD_GF2MAT_GF2MAT (
 
 /****************************************************************************
 **
-*F  FuncPROD_GF2MAT_GF2MAT_SIMPLE( <self>, <ml>, <mr> ) product of GF2 vector/matrix
+*F  FuncPROD_GF2MAT_GF2MAT_SIMPLE( <self>, <ml>, <mr> )
 **
-**  'FuncPROD_GF2MAT_GF2MAT' returns  the product of the GF2 matricess <ml> and
-**  <mr>. It never uses grease or blocking.
+**  'FuncPROD_GF2MAT_GF2MAT' returns  the product of the GF2 matricess <ml>
+**  and <mr>. It never uses grease or blocking.
 **
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
@@ -2458,10 +2462,11 @@ Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE (
 
 /****************************************************************************
 **
-*F  FuncPROD_GF2MAT_GF2MAT_ADVANCED( <self>, <ml>, <mr>, <greaselevel>, <blocksize> ) 
+*F  FuncPROD_GF2MAT_GF2MAT_ADVANCED( <self>, <ml>, <mr>, <greaselevel>, 
+**                                                              <blocksize> )
 **
-**  'FuncPROD_GF2MAT_GF2MAT_ADVANCED' returns  the product of the GF2 matricess <ml> and
-**  <mr> using grease level <greaselevel> and block size <blocksize>
+**  'FuncPROD_GF2MAT_GF2MAT_ADVANCED' returns the product of the GF2 matrices
+**  <ml> and <mr> using grease level <greaselevel> and block size <blocksize>
 **
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
@@ -2522,7 +2527,7 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT (
 
 /****************************************************************************
 **
-*F  FuncADDCOEFFS_GF2VEC_GF2VEC_MULT( <self>, <vl>, <vr>, <mul>, <from>, <to> )
+*F  FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(<self>,<vl>,<vr>,<mul>,<from>,<to>)
 **  GF2 vectors
 */
 Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT_LIMS (
@@ -3407,7 +3412,7 @@ Obj FuncA_CLOS_VEC_COORDS(
 
 /****************************************************************************
 **
-*F FuncCOSET_LEADERS_INNER_GF2( <self>, <veclis>, <weight>, <tofind>, <leaders> )
+*F  FuncCOSET_LEADERS_INNER_GF2(<self>,<veclis>,<weight>,<tofind>,<leaders>)
 **
 ** Search for new coset leaders of weight <weight>
 */
@@ -4078,7 +4083,8 @@ return ret;
 **
 **  Method for SemiEchelonMat for plain lists of GF2 vectors
 **
-** Method selection can guarantee us a plain list of characteristic 2 vectors 
+**  Method selection can guarantee us a plain list of characteristic 2
+**  vectors
 */
 
 Obj FuncSEMIECHELON_LIST_GF2VECS( Obj self, Obj mat )
@@ -4114,7 +4120,8 @@ Obj FuncSEMIECHELON_LIST_GF2VECS( Obj self, Obj mat )
 **
 **  Method for SemiEchelonMatTransformations for plain lists of GF2 vectors
 **
-** Method selection can guarantee us a plain list of characteristic 2 vectors 
+**  Method selection can guarantee us a plain list of characteristic 2
+**  vectors
 */
 
 Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS( Obj self, Obj mat )

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -17,19 +17,19 @@
 **
 *F  IS_GF2VEC_REP( <obj> )  . . . . . . check that <obj> is in GF2 vector rep
 */
-#define IS_GF2VEC_REP(obj) \
-  (TNUM_OBJ(obj)==T_DATOBJ && DoFilter(IsGF2VectorRep,obj) == True)
+#define IS_GF2VEC_REP(obj)                                                   \
+    (TNUM_OBJ(obj) == T_DATOBJ && DoFilter(IsGF2VectorRep, obj) == True)
 
 
 /****************************************************************************
 **
 *F  NEW_GF2VEC( <vec>, <type>, <len> )  . . . . . . . create a new GF2 vector
 */
-#define NEW_GF2VEC( vec, type, len ) \
-    do { \
-        vec = NewBag( T_DATOBJ, SIZE_PLEN_GF2VEC(len) ); \
-        SetTypeDatObj(vec, type); \
-        SET_LEN_GF2VEC(vec, len); \
+#define NEW_GF2VEC(vec, type, len)                                           \
+    do {                                                                     \
+        vec = NewBag(T_DATOBJ, SIZE_PLEN_GF2VEC(len));                       \
+        SetTypeDatObj(vec, type);                                            \
+        SET_LEN_GF2VEC(vec, len);                                            \
     } while (0)
 
 
@@ -43,14 +43,14 @@
 **  Note that 'LEN_GF2VEC' is a macro, so do not call it with  arguments that
 **  have side effects.
 */
-#define LEN_GF2VEC(list)         ((Int)(CONST_ADDR_OBJ(list)[1]))
+#define LEN_GF2VEC(list) ((Int)(CONST_ADDR_OBJ(list)[1]))
 
 
 /****************************************************************************
 **
 *F  NUMBER_BLOCKS_GF2VEC( <vec> ) . . . . . . . number of UInt blocks in list
 */
-#define NUMBER_BLOCKS_GF2VEC(list)      ((LEN_GF2VEC((list))+ BIPEB-1)/BIPEB)
+#define NUMBER_BLOCKS_GF2VEC(list) ((LEN_GF2VEC((list)) + BIPEB - 1) / BIPEB)
 
 
 /****************************************************************************
@@ -59,8 +59,8 @@
 **
 **  returns a pointer to the start of the data of the GF2 vector
 */
-#define BLOCKS_GF2VEC(list)             ((UInt*)(ADDR_OBJ(list)+2))
-#define CONST_BLOCKS_GF2VEC(list)       ((const UInt*)(CONST_ADDR_OBJ(list)+2))
+#define BLOCKS_GF2VEC(list) ((UInt *)(ADDR_OBJ(list) + 2))
+#define CONST_BLOCKS_GF2VEC(list) ((const UInt *)(CONST_ADDR_OBJ(list) + 2))
 
 
 /****************************************************************************
@@ -75,8 +75,9 @@
 **  Note that 'BLOCK_ELM_GF2VEC' is a macro, so do not call it with arguments
 **  that have side effects.
 */
-#define BLOCK_ELM_GF2VEC(list, pos)    (BLOCKS_GF2VEC(list)[((pos)-1)/BIPEB])
-#define CONST_BLOCK_ELM_GF2VEC(list, pos)    (CONST_BLOCKS_GF2VEC(list)[((pos)-1)/BIPEB])
+#define BLOCK_ELM_GF2VEC(list, pos) (BLOCKS_GF2VEC(list)[((pos)-1) / BIPEB])
+#define CONST_BLOCK_ELM_GF2VEC(list, pos)                                    \
+    (CONST_BLOCKS_GF2VEC(list)[((pos)-1) / BIPEB])
 
 
 /****************************************************************************
@@ -89,15 +90,15 @@
 **  Note that 'SET_LEN_GF2VEC' is a macro, so do  not  call it with arguments
 **  that have side effects.
 */
-#define SET_LEN_GF2VEC(list,len)        (ADDR_OBJ(list)[1] = (Obj)(len))
+#define SET_LEN_GF2VEC(list, len) (ADDR_OBJ(list)[1] = (Obj)(len))
 
 
 /****************************************************************************
 **
 *F  SIZE_PLEN_GF2VEC( <len> ) . . . . . . . . physical length of a GF2 vector
 */
-#define SIZE_PLEN_GF2VEC(len) \
-                           (2*sizeof(Obj)+((len)+BIPEB-1)/BIPEB*sizeof(UInt))
+#define SIZE_PLEN_GF2VEC(len)                                                \
+    (2 * sizeof(Obj) + ((len) + BIPEB - 1) / BIPEB * sizeof(UInt))
 
 
 /****************************************************************************
@@ -111,7 +112,7 @@
 **  Note that 'MASK_POS_GF2VEC' is a  macro, so do not call it with arguments
 **  that have side effects.
 */
-#define MASK_POS_GF2VEC( pos ) (((UInt) 1)<<((pos)-1)%BIPEB)
+#define MASK_POS_GF2VEC(pos) (((UInt)1) << ((pos)-1) % BIPEB)
 
 
 /****************************************************************************
@@ -125,8 +126,9 @@
 **  Note that 'ELM_GF2VEC' is a macro, so do  not call it with arguments that
 **  have side effects.
 */
-#define ELM_GF2VEC(list,pos) \
-  ((CONST_BLOCK_ELM_GF2VEC(list,pos) & MASK_POS_GF2VEC(pos)) ?  GF2One : GF2Zero)
+#define ELM_GF2VEC(list, pos)                                                \
+    ((CONST_BLOCK_ELM_GF2VEC(list, pos) & MASK_POS_GF2VEC(pos)) ? GF2One     \
+                                                                : GF2Zero)
 
 
 /****************************************************************************
@@ -139,7 +141,7 @@
 **  Note that 'LEN_GF2MAT' is a macro, so do not call it with  arguments that
 **  have side effects.
 */
-#define LEN_GF2MAT(list)         (INT_INTOBJ(CONST_ADDR_OBJ(list)[1]))
+#define LEN_GF2MAT(list) (INT_INTOBJ(CONST_ADDR_OBJ(list)[1]))
 
 
 /****************************************************************************
@@ -152,7 +154,7 @@
 **  Note that 'SET_LEN_GF2MAT' is a  macro, so do not  call it with arguments
 **  that have side effects.
 */
-#define SET_LEN_GF2MAT(list,len)    (ADDR_OBJ(list)[1]=INTOBJ_INT(len))
+#define SET_LEN_GF2MAT(list, len) (ADDR_OBJ(list)[1] = INTOBJ_INT(len))
 
 
 /****************************************************************************
@@ -166,7 +168,7 @@
 **  Note that 'ELM_GF2MAT' is a macro, so do  not call it with arguments that
 **  have side effects.
 */
-#define ELM_GF2MAT(list,pos)    (CONST_ADDR_OBJ(list)[pos+1])
+#define ELM_GF2MAT(list, pos) (CONST_ADDR_OBJ(list)[pos + 1])
 
 
 /****************************************************************************
@@ -180,14 +182,14 @@
 **  Note that 'ELM_GF2MAT' is a macro, so do  not call it with arguments that
 **  have side effects.
 */
-#define SET_ELM_GF2MAT(list,pos,elm)    (ADDR_OBJ(list)[pos+1]=elm)
+#define SET_ELM_GF2MAT(list, pos, elm) (ADDR_OBJ(list)[pos + 1] = elm)
 
 
 /****************************************************************************
 **
 *F  SIZE_PLEN_GF2MAT( <len> ) . . . . . . . . physical length of a GF2 matrix
 */
-#define SIZE_PLEN_GF2MAT(len)   (((len)+2)*sizeof(Obj))
+#define SIZE_PLEN_GF2MAT(len) (((len) + 2) * sizeof(Obj))
 
 /****************************************************************************
 **
@@ -233,7 +235,7 @@ extern Obj TYPE_LIST_GF2MAT_IMM;
 
 extern Obj IsGF2VectorRep;
 
-extern Obj ShallowCopyVecGF2( Obj vec );
+extern Obj ShallowCopyVecGF2(Obj vec);
 
 /****************************************************************************
 **
@@ -245,7 +247,7 @@ extern Obj ShallowCopyVecGF2( Obj vec );
 **
 *F  InitInfoGF2Vec()  . . . . . . . . . . . . . . . . table of init functions
 */
-StructInitInfo * InitInfoGF2Vec ( void );
+StructInitInfo * InitInfoGF2Vec(void);
 
 
-#endif // GAP_VECGF2_H
+#endif    // GAP_VECGF2_H

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -204,7 +204,7 @@ extern Obj TYPE_LIST_GF2VEC_IMM;
 
 /****************************************************************************
 **
-*V  TYPE_LIST_GF2VEC_IMM_LOCKED. . . .  type of an immutable GF2 vector object
+*V  TYPE_LIST_GF2VEC_IMM_LOCKED . . . type of an immutable GF2 vector object
 **                                          with locked representation
 */
 extern Obj TYPE_LIST_GF2VEC_IMM_LOCKED;


### PR DESCRIPTION
So I was looking into what it would take to implement a new-style MatrixObj version of the GF2 and 8bit matrix code; and as many times before, I shied away because of the messy state of things.

So despite our usual conventions, I decided to simply clang-format all of that the code, and hope you won't mind too much. But I think it'll be really helpful for future work on that.