### PR TITLE
Add doublecoset benchmark

### DIFF
--- a/benchmark/doublecoset/doublecoset1.tst
+++ b/benchmark/doublecoset/doublecoset1.tst
@@ -7,13 +7,12 @@
 ##
 ##  This  file  tests for double coset calculations
 ##
-gap> START_TEST("doublecoset.tst");
-gap> g:=SimpleGroup("Co3");;
+gap> START_TEST("doublecoset2.tst");
+gap> g:=SimpleGroup("J2");;
 gap> m:=MaximalSubgroupClassReps(g);;
-gap> u:=First(m,x->Index(g,x)=17931375);;
+gap> u:=First(m,x->Index(g,x)=10080);;
 gap> dc:=DoubleCosetRepsAndSizes(g,u,u);;
 gap> Length(dc);Sum(dc,x->x[2])=Size(g);
-913
+191
 true
-
-gap> STOP_TEST( "doublecoset.tst", 1);
+gap> STOP_TEST( "doublecoset1.tst", 1);

--- a/benchmark/doublecoset/doublecoset2.tst
+++ b/benchmark/doublecoset/doublecoset2.tst
@@ -1,0 +1,18 @@
+#############################################################################
+##
+#W  doublecoset.tst                                     Alexander Hulpke
+##
+##
+#Y  Copyright (C)  1997,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
+##
+##  This  file  tests for double coset calculations
+##
+gap> START_TEST("doublecoset2.tst");
+gap> g:=SimpleGroup("J3");;
+gap> m:=MaximalSubgroupClassReps(g);;
+gap> u:=First(m,x->Index(g,x)=43605);;
+gap> dc:=DoubleCosetRepsAndSizes(g,u,u);;
+gap> Length(dc);Sum(dc,x->x[2])=Size(g);
+57
+true
+gap> STOP_TEST( "doublecoset2.tst", 1);

--- a/benchmark/doublecoset/doublecoset3.tst
+++ b/benchmark/doublecoset/doublecoset3.tst
@@ -1,0 +1,18 @@
+#############################################################################
+##
+#W  doublecoset.tst                                     Alexander Hulpke
+##
+##
+#Y  Copyright (C)  1997,  Lehrstuhl D für Mathematik,  RWTH Aachen,  Germany
+##
+##  This  file  tests for double coset calculations
+##
+gap> START_TEST("doublecoset3.tst");
+gap> g:=SimpleGroup("Co3");;
+gap> m:=MaximalSubgroupClassReps(g);;
+gap> u:=First(m,x->Index(g,x)=17931375);;
+gap> dc:=DoubleCosetRepsAndSizes(g,u,u);;
+gap> Length(dc);Sum(dc,x->x[2])=Size(g);
+913
+true
+gap> STOP_TEST( "doublecoset3.tst", 1);

--- a/benchmark/doublecoset/test1.g
+++ b/benchmark/doublecoset/test1.g
@@ -1,0 +1,17 @@
+#description
+#author
+#timelimit
+#cmdlineops
+#packages
+
+starttime := Runtime();
+
+res := Test( "doublecoset1.tst", rec(showProgress := true) );
+
+Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
+
+if res then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;

--- a/benchmark/doublecoset/test2.g
+++ b/benchmark/doublecoset/test2.g
@@ -1,0 +1,17 @@
+#description
+#author
+#timelimit
+#cmdlineops
+#packages
+
+starttime := Runtime();
+
+res := Test( "doublecoset2.tst", rec(showProgress := true) );
+
+Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
+
+if res then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;

--- a/benchmark/doublecoset/test3.g
+++ b/benchmark/doublecoset/test3.g
@@ -1,0 +1,17 @@
+#description
+#author
+#timelimit
+#cmdlineops
+#packages
+
+starttime := Runtime();
+
+res := Test( "doublecoset3.tst", rec(showProgress := true) );
+
+Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
+
+if res then
+  QUIT_GAP(0);
+else
+  QUIT_GAP(1);
+fi;


### PR DESCRIPTION
The test from tst/testextra/doublecoset.tst, added in #2741 by @hulpke, requires more memory than in the default `make teststandard` setting, so it is moved to benchmarks, with two more shorter tests added.