### PR TITLE
List object improvements

### DIFF
--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1786,14 +1786,14 @@ DeclareGlobalFunction( "PermListList" );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "SortParallel",
-    [ IsDenseList and IsMutable, IsDenseList and IsMutable ] );
+    [ IsList and IsMutable, IsList and IsMutable ] );
 DeclareOperation( "SortParallel",
-    [ IsDenseList and IsMutable, IsDenseList and IsMutable, IsFunction ] );
+    [ IsList and IsMutable, IsList and IsMutable, IsFunction ] );
 
 DeclareOperation( "StableSortParallel",
-    [ IsDenseList and IsMutable, IsDenseList and IsMutable ] );
+    [ IsList and IsMutable, IsList and IsMutable ] );
 DeclareOperation( "StableSortParallel",
-    [ IsDenseList and IsMutable, IsDenseList and IsMutable, IsFunction ] );
+    [ IsList and IsMutable, IsList and IsMutable, IsFunction ] );
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -1060,8 +1060,8 @@ InstallOtherMethod( IsSSortedList,
 #M  IsSSortedList(<list>)
 ##
 InstallMethod( IsSSortedList,
-    "for a small homogeneous list",
-    [ IsHomogeneousList and IsSmallList ],
+    "for a small list",
+    [ IsSmallList ],
     IS_SSORT_LIST_DEFAULT );
 
 InstallMethod( IsSSortedList,

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2460,15 +2460,15 @@ InstallMethod( SortingPerm,
 #M  SortParallel( <list>, <list2> ) . . . . . . .  sort two lists in parallel
 ##
 InstallMethod( SortParallel,
-    "for two dense and mutable lists",
-    [ IsDenseList and IsMutable,
-      IsDenseList and IsMutable ],
+    "for two mutable lists",
+    [ IsList and IsMutable,
+      IsList and IsMutable ],
     SORT_PARA_LIST );
 
 InstallMethod( StableSortParallel,
-    "for two dense and mutable lists",
-    [ IsDenseList and IsMutable,
-      IsDenseList and IsMutable ],
+    "for two mutable lists",
+    [ IsList and IsMutable,
+      IsList and IsMutable ],
     STABLE_SORT_PARA_LIST );
     
 #############################################################################
@@ -2494,16 +2494,16 @@ InstallMethod( StableSortParallel,
 #M  SortParallel( <list>, <list2>, <func> )
 ##
 InstallMethod( SortParallel,
-    "for two dense and mutable lists, and function",
-    [ IsDenseList and IsMutable,
-      IsDenseList and IsMutable,
+    "for mutable lists, and function",
+    [ IsList and IsMutable,
+      IsList and IsMutable,
       IsFunction ],
     SORT_PARA_LIST_COMP );
 
 InstallMethod( StableSortParallel,
-    "for two dense and mutable lists, and function",
-    [ IsDenseList and IsMutable,
-      IsDenseList and IsMutable,
+    "for two mutable lists, and function",
+    [ IsList and IsMutable,
+      IsList and IsMutable,
       IsFunction ],
     STABLE_SORT_PARA_LIST_COMP );
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -1348,17 +1348,19 @@ Int IsSSortListDefault (
         return 2L;
     }
 
-    /* a list must be homogeneous to be strictly sorted                    */
-    if ( ! IS_HOMOG_LIST(list) ) {
+    /* get the first element                                               */
+    elm1 = ELM0_LIST(list, 1);
+
+    if (!elm1) {
         return 0L;
     }
 
-    /* get the first element                                               */
-    elm1 = ELMW_LIST( list, 1 );
-
     /* compare each element with its precursor                             */
     for ( i = 2; i <= lenList; i++ ) {
-        elm2 = ELMW_LIST( list, i );
+        elm2 = ELM0_LIST(list, i);
+        if (!elm2) {
+            return 0L;
+        }
         if ( ! LT( elm1, elm2 ) ) {
             return 0L;
         }

--- a/src/plist.c
+++ b/src/plist.c
@@ -2120,7 +2120,6 @@ Int             IsSSortPlist (
     Obj                 fam=0;    /* initialize to help compiler */
     Int                 isHom;
     
-        
     /* get the length                                                      */
     lenList = LEN_PLIST( list );
 
@@ -2179,7 +2178,7 @@ Int             IsSSortPlist (
 	if (isHom)
 	  SET_FILT_LIST( list, FN_IS_HOMOG);
 	else
-	  SET_FILT_LIST( list, FN_IS_HOMOG);
+	  SET_FILT_LIST( list, FN_IS_NHOMOG);
 	SET_FILT_LIST( list, FN_IS_SSORT );
       }
       return 2L;

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -290,6 +290,26 @@ gap> l;
 gap> TNAM_OBJ(l);
 "list (plain,rect table)"
 
+# Check TNUM behaviours
+gap> x := [1,,"cheese"];;
+gap> x[2] := 2;;
+gap> IsSSortedList(x);;
+gap> TNAM_OBJ(x);
+"list (plain,dense)"
+gap> x := [1,,"cheese"];;
+gap> x[2] := 2;
+2
+gap> y := Immutable(x);;
+gap> IsIdenticalObj(x,y);
+false
+gap> TNAM_OBJ(x);
+"list (plain)"
+gap> TNAM_OBJ(y);
+"list (plain,imm)"
+gap> IsSSortedList(y);;
+gap> TNAM_OBJ(y);
+"list (plain,dense,nhom,ssort,imm)"
+
 # String, for a range
 gap> l := [5 .. 10];
 [ 5 .. 10 ]

--- a/tst/testinstall/objlist.tst
+++ b/tst/testinstall/objlist.tst
@@ -1,0 +1,71 @@
+# Create a list-like object, to test functionality of GAP for objects which implement
+# IsSmallList
+gap> DeclareCategory("IsTestListObj", IsSmallList);;
+gap> BindGlobal( "TestListObjFamily", NewFamily("TestListObjFamily") );;
+gap> DeclareRepresentation( "IsTestListObjRep", IsTestListObj and IsComponentObjectRep, []);;
+gap> BindGlobal( "TestListObjType", NewType(TestListObjFamily, IsTestListObjRep));;
+gap> BindGlobal( "TestListObjTypeMutable", NewType(TestListObjFamily,
+>                                        IsTestListObjRep and IsMutable));;
+gap> Wrap := {x} -> Objectify(TestListObjTypeMutable, rec(l := x));;
+gap> InstallMethod(ViewString, [ IsTestListObjRep ], {x} -> STRINGIFY(x!.l));;
+gap> InstallMethod(\[\], [ IsTestListObjRep, IsPosInt ], {x,i} -> x!.l[i]);;
+gap> InstallMethod(\[\]\:\=, [ IsTestListObjRep and IsMutable, IsPosInt, IsObject ],
+> function(x,i,o) x!.l[i] := o; end);
+gap> InstallMethod( Length, [ IsTestListObjRep ], {x} -> Length(x!.l));
+gap> InstallMethod( IsBound\[\], [ IsTestListObjRep, IsPosInt ], {x,i} -> IsBound(x!.l[i]));;
+gap> x := [10,20,"cheese"];;
+gap> y := [10,20,"cheese"];;
+gap> a := Wrap(x);;
+gap> b := Wrap(y);;
+gap> a[2];
+20
+gap> a = b;
+true
+gap> a < b;
+false
+gap> a[2] := 15;
+15
+gap> x;
+[ 10, 15, "cheese" ]
+gap> a = b;
+false
+gap> a < b;
+true
+gap> Length(a);
+3
+gap> 1 in a;
+false
+gap> 10 in a;
+true
+gap> IsSet(a);
+true
+gap> IsSortedList(a);
+true
+gap> a[2] := 10;
+10
+gap> IsSet(a);
+false
+gap> IsSortedList(a);
+true
+gap> a[2] := 2;
+2
+gap> IsSet(a);
+false
+gap> IsSortedList(a);
+false
+gap> a;
+[ 10, 2, "cheese" ]
+gap> Sort(a);
+gap> a;
+[ 2, 10, "cheese" ]
+gap> IsSet(a);
+true
+gap> x;
+[ 2, 10, "cheese" ]
+gap> Unbind(x[2]);
+gap> a;
+[ 2,, "cheese" ]
+gap> IsSet(a);
+false
+gap> IsSortedList(a);
+false

--- a/tst/testinstall/objlist.tst
+++ b/tst/testinstall/objlist.tst
@@ -62,6 +62,19 @@ gap> IsSet(a);
 true
 gap> x;
 [ 2, 10, "cheese" ]
+gap> SortBy(a, {z} -> z);
+gap> a;
+[ 2, 10, "cheese" ]
+gap> SortParallel([3,2,1],a);
+gap> a;
+[ "cheese", 10, 2 ]
+gap> l := [1,2,3];
+[ 1, 2, 3 ]
+gap> SortParallel(a,l);
+gap> a;
+[ 2, 10, "cheese" ]
+gap> l;
+[ 3, 2, 1 ]
 gap> Unbind(x[2]);
 gap> a;
 [ 2,, "cheese" ]


### PR DESCRIPTION
This is a selection of fixes which I came up with while trying to implement an object which acts as a mutable list.

* SortParallel requires IsDenseList. Sort and SortBy only require IsList and work fine, so unify with them.

* IsSSortedList requires the list is homogenous. In the distant past this was required for all lists, and then the requirement was removed for plists, without removing it for plists.

* Make sure we don't call _FILT_LIST on non-plists. To be honest I'm not totally happy with this and considered rewriting this bit of code to make it less fragile, but decided I didn't want to go down that rabbithole. This certainly makes things better than they were.
