### PR TITLE
Partially revert "Replace GAP_ROOT_PATHS in tests with 'GAP_ROOT_PATH'"

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -87,7 +87,7 @@ end);
 
 InstallGlobalFunction(RunTests, function(arg)
   local tests, opts, breakOnError, inp, outp, pos, cmp, times, ttime, nrlines,
-        s, res, fres, t, f, i, gaproot;
+        s, res, fres, t, f, i;
   # don't enter break loop in case of error during test
   tests := arg[1];
   opts := rec( breakOnError := false, showProgress := "some" );
@@ -142,11 +142,6 @@ InstallGlobalFunction(RunTests, function(arg)
         Error("user interrupt");
         BreakOnError := opts.breakOnError;
     fi;
-    # Remove explicit references to GAP's root path, so
-    # tests can be run on multiple machines
-    for gaproot in GAPInfo.KernelInfo.GAP_ROOT_PATHS do
-        res := ReplacedString(res, gaproot, "GAPROOT/");
-    od;
     Add(cmp, res);
     Add(times, t);
   od;
@@ -205,9 +200,6 @@ end;
 ##  lines starting with <C>"#"</C>.<Br/>
 ##  All other lines are considered as &GAP; output from the
 ##  preceding &GAP; input.
-##  To simplify running tests when GAP is installed in different locations,
-##  any directory in GAPInfo.KernelInfo.GAP_ROOT_PATHS is replaced with the
-##  string GAPROOT/.
 ##  <P/>
 ##  By default the actual &GAP; output is compared exactly with the
 ##  stored output, and if these are different some information about the 

--- a/tst/testinstall/opers/LocationFunc.tst
+++ b/tst/testinstall/opers/LocationFunc.tst
@@ -6,8 +6,8 @@ gap> LocationFunc(f);
 "stream:1"
 
 # Library function
-gap> LocationFunc(Where);
-"GAPROOT/lib/error.g:79"
+gap> PositionSublist(LocationFunc(Where),"/lib/error.g:") <> fail;
+true
 
 # GAP function which was compiled to C code by gac
 gap> LocationFunc(INSTALL_METHOD_FLAGS);


### PR DESCRIPTION
This reverts commit 24a8e36ede40a7f8594782fd113218acf311aa6e.
It also makes the test of `LocationFunc` not depending on the
full path to the directory.

Closes #2981.