### PR TITLE
Add some functions to libgap API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,11 @@ doc/gapmacrodoc.idx
 /builds/
 
 /libgap.la
-/.libs
+.libs/
+
+/tst/testlibgap/basic
+/tst/testlibgap/basic.out
+/tst/testlibgap/wscreate
+/tst/testlibgap/wscreate.out
+/tst/testlibgap/wsload
+/tst/testlibgap/wsload.out

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -2,9 +2,11 @@
 
 #include "libgap-api.h"
 
+#include "ariths.h"
 #include "bool.h"
 #include "opers.h"
 #include "calls.h"
+#include "gap.h"
 #include "gapstate.h"
 #include "gvars.h"
 #include "lists.h"
@@ -15,39 +17,26 @@
 //
 // Setup and initialisation
 //
-void GAP_Initialize(int          argc,
-                    char **      argv,
-                    char **      env,
-                    CallbackFunc markBagsCallback,
-                    CallbackFunc errorCallback)
+void GAP_Initialize(int              argc,
+                    char **          argv,
+                    char **          env,
+                    GAP_CallbackFunc markBagsCallback,
+                    GAP_CallbackFunc errorCallback)
 {
     InitializeGap(&argc, argv, env);
     SetExtraMarkFuncBags(markBagsCallback);
     STATE(JumpToCatchCallback) = errorCallback;
+
+    GAP_True = True;
+    GAP_False = False;
+    GAP_Fail = Fail;
 }
 
 
-// Combines GVarName and ValGVar. For a given string, it returns the value
-// of the gvar with name <name>, or NULL if the global variable is not
-// defined.
-Obj GAP_ValueGlobalVariable(const char * name)
-{
-    UInt gvar = GVarName(name);
-    // TODO: GVarName should never return 0?
-    if (gvar != 0) {
-        return ValGVar(gvar);
-    }
-    else {
-        return NULL;
-    }
-}
+////
+//// program evaluation and execution
+////
 
-//
-// Evaluate a string of GAP commands
-//
-// To see an example of how to use this function
-// see tst/testlibgap/basic.c
-//
 Obj GAP_EvalString(const char * cmd)
 {
     Obj instream;
@@ -62,26 +51,210 @@ Obj GAP_EvalString(const char * cmd)
     return res;
 }
 
-//
-// Returns the GAP object containing
-// <string>
+
+////
+//// variables
+////
+
+Obj GAP_ValueGlobalVariable(const char * name)
+{
+    UInt gvar = GVarName(name);
+    // TODO: GVarName should never return 0?
+    if (gvar != 0) {
+        return ValGVar(gvar);
+    }
+    else {
+        return NULL;
+    }
+}
+
+
+////
+//// arithmetic
+////
+
+int GAP_EQ(Obj a, Obj b)
+{
+    return EQ(a, b);
+}
+
+int GAP_LT(Obj a, Obj b)
+{
+    return LT(a, b);
+}
+
+int GAP_IN(Obj a, Obj b)
+{
+    return IN(a, b);
+}
+
+Obj GAP_SUM(Obj a, Obj b)
+{
+    return SUM(a, b);
+}
+
+Obj GAP_DIFF(Obj a, Obj b)
+{
+    return DIFF(a, b);
+}
+
+Obj GAP_PROD(Obj a, Obj b)
+{
+    return PROD(a, b);
+}
+
+Obj GAP_QUO(Obj a, Obj b)
+{
+    return QUO(a, b);
+}
+
+Obj GAP_LQUO(Obj a, Obj b)
+{
+    return LQUO(a, b);
+}
+
+Obj GAP_POW(Obj a, Obj b)
+{
+    return POW(a, b);
+}
+
+Obj GAP_COMM(Obj a, Obj b)
+{
+    return COMM(a, b);
+}
+
+Obj GAP_MOD(Obj a, Obj b)
+{
+    return MOD(a, b);
+}
+
+
+////
+//// booleans
+////
+
+Obj GAP_True;
+Obj GAP_False;
+Obj GAP_Fail;
+
+
+////
+//// calls
+////
+
+Obj GAP_CallFuncList(Obj func, Obj args)
+{
+    return CallFuncList(func, args);
+}
+
+Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[])
+{
+    Obj result;
+    Obj list;
+
+    if (TNUM_OBJ(func) == T_FUNCTION) {
+
+        // call the function
+        switch (narg) {
+        case 0:
+            result = CALL_0ARGS(func);
+            break;
+        case 1:
+            result = CALL_1ARGS(func, args[0]);
+            break;
+        case 2:
+            result = CALL_2ARGS(func, args[0], args[1]);
+            break;
+        case 3:
+            result = CALL_3ARGS(func, args[0], args[1], args[2]);
+            break;
+        case 4:
+            result = CALL_4ARGS(func, args[0], args[1], args[2], args[3]);
+            break;
+        case 5:
+            result =
+                CALL_5ARGS(func, args[0], args[1], args[2], args[3], args[4]);
+            break;
+        case 6:
+            result = CALL_6ARGS(func, args[0], args[1], args[2], args[3],
+                                args[4], args[5]);
+            break;
+        default:
+            list = NewPlistFromArray(args, narg);
+            result = CALL_XARGS(func, list);
+        }
+    }
+    else {
+        list = NewPlistFromArray(args, narg);
+        result = DoOperation2Args(CallFuncListOper, func, list);
+    }
+
+    return result;
+}
+
+
+////
+//// lists
+////
+
+int GAP_IsList(Obj obj)
+{
+    return obj && IS_LIST(obj);
+}
+
+UInt GAP_LenList(Obj obj)
+{
+    return LEN_LIST(obj);
+}
+
+void GAP_AssList(Obj list, UInt pos, Obj val)
+{
+    if (val)
+        ASS_LIST(list, pos, val);
+    else
+        UNB_LIST(list, pos);
+}
+
+Obj GAP_ElmList(Obj list, UInt pos)
+{
+    if (pos == 0)
+        return 0;
+    return ELM0_LIST(list, pos);
+}
+
+Obj GAP_NewPlist(Int capacity)
+{
+    return NEW_PLIST(T_PLIST_EMPTY, capacity);
+}
+
+
+////
+//// strings
+////
+
+int GAP_IsString(Obj obj)
+{
+    return obj && IS_STRING_REP(obj);
+}
+
+UInt GAP_LenString(Obj obj)
+{
+    return GET_LEN_STRING(obj);
+}
+
 Obj GAP_MakeString(const char * string)
 {
     return MakeString(string);
 }
 
-//
-// Returns a pointer to the
-// contents of the GAP string object <string>
-char * GAP_CSTR_STRING(Obj string)
+Obj GAP_MakeImmString(const char * string)
 {
-    return CSTR_STRING(string);
+    return MakeImmString(string);
 }
 
-//
-// Returns a new empty plain list
-// with capacity <capacity>
-Obj GAP_NewPlist(Int capacity)
+char * GAP_CSTR_STRING(Obj string)
 {
-    return NEW_PLIST(T_PLIST_EMPTY, capacity);
+    if (!IS_STRING_REP(string))
+        return 0;
+    return CSTR_STRING(string);
 }

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -1,24 +1,151 @@
-// LibGAP API - API for using GAP as shared library.
+//// LibGAP API - API for using GAP as shared library.
 
 #ifndef LIBGAP_API_H
 #define LIBGAP_API_H
 
-#include "gap.h"
+#include "system.h"
 
-typedef void (*CallbackFunc)(void);
 
-// Initialisation and finalization
+////
+//// Setup and initialisation
+////
 
-void GAP_Initialize(int          argc,
-                    char **      argv,
-                    char **      env,
-                    CallbackFunc markBagsCallback,
-                    CallbackFunc errorCallback);
+typedef void (*GAP_CallbackFunc)(void);
 
-Obj GAP_ValueGlobalVariable(const char * name);
-Obj GAP_EvalString(const char * cmd);
-Obj GAP_MakeString(const char * string);
-char * GAP_CSTR_STRING(Obj string);
-Obj GAP_NewPlist(Int capacity);
+// TODO: document this function
+extern void GAP_Initialize(int              argc,
+                           char **          argv,
+                           char **          env,
+                           GAP_CallbackFunc markBagsCallback,
+                           GAP_CallbackFunc errorCallback);
+
+
+////
+//// program evaluation and execution
+////
+
+// Evaluate a string of GAP commands
+//
+// To see an example of how to use this function see tst/testlibgap/basic.c
+//
+// TODO: properly document this function
+extern Obj GAP_EvalString(const char * cmd);
+
+
+////
+//// variables
+////
+
+// Combines GVarName and ValGVar. For a given string, it returns the value
+// of the gvar with name <name>, or NULL if the global variable is not
+// defined.
+extern Obj GAP_ValueGlobalVariable(const char * name);
+
+
+////
+//// arithmetic
+////
+
+extern int GAP_EQ(Obj a, Obj b);
+extern int GAP_LT(Obj a, Obj b);
+extern int GAP_IN(Obj a, Obj b);
+
+extern Obj GAP_SUM(Obj a, Obj b);
+extern Obj GAP_DIFF(Obj a, Obj b);
+extern Obj GAP_PROD(Obj a, Obj b);
+extern Obj GAP_QUO(Obj a, Obj b);
+extern Obj GAP_LQUO(Obj a, Obj b);
+extern Obj GAP_POW(Obj a, Obj b);
+extern Obj GAP_COMM(Obj a, Obj b);
+extern Obj GAP_MOD(Obj a, Obj b);
+
+
+////
+//// booleans
+////
+
+extern Obj GAP_True;
+extern Obj GAP_False;
+extern Obj GAP_Fail;
+
+
+////
+//// calls
+////
+
+// Call the GAP object <func> as a function with arguments given
+// as a GAP list <args>.
+extern Obj GAP_CallFuncList(Obj func, Obj args);
+
+// Call the GAP object <func> as a function with arguments given
+// as an array <args> with <narg> entries
+extern Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[]);
+
+
+////
+//// lists
+////
+
+// Returns 1 if <obj> is a GAP list, 0 if not.
+extern int GAP_IsList(Obj obj);
+
+// Returns the length of the given GAP list.
+// If <list> is not a GAP list, an error may be raised.
+extern UInt GAP_LenList(Obj list);
+
+// Assign <val> at position <pos> into the GAP list <list>.
+// If <val> is zero, then this unbinds the list entry.
+// If <list> is not a GAP list, an error may be raised.
+extern void GAP_AssList(Obj list, UInt pos, Obj val);
+
+// Returns the element at the position <pos> in the list <list>.
+// Returns 0 if there is no entry at the given position.
+// Also returns 0 if <pos> is out of bounds, i.e., if <pos> is zero,
+// or larger than the length of the list.
+// If <list> is not a GAP list, an error may be raised.
+extern Obj GAP_ElmList(Obj list, UInt pos);
+
+// Returns a new empty plain list with capacity <capacity>
+extern Obj GAP_NewPlist(Int capacity);
+
+
+////
+//// strings
+////
+
+// Returns 1 if <obj> is a GAP string, 0 if not.
+extern int GAP_IsString(Obj obj);
+
+// Returns the length of the given GAP string.
+// If <string> is not a GAP string, an error may be raised.
+extern UInt GAP_LenString(Obj string);
+
+// Returns a pointer to the contents of the GAP string <string>.
+// Returns 0 if <string> is not a GAP string.
+//
+// Note: GAP strings may contain null bytes, so to copy the full string, you
+// should use `GAP_LenString` to determine its length. GAP always adds an
+// additional terminating null byte.
+//
+// Note: The pointer returned by this function is only valid until the next
+// GAP garbage collection. In particular, if you use any GAP APIs, then you
+// should assume that the pointer became stale. Barring that, you may safely
+// copy, inspect, or even modify the content of the string buffer.
+//
+// Usage example:
+//    Int len = GAP_LenString(string);
+//    char *buf = malloc(len + 1);
+//    memcpy(buf, GAP_CSTR_STRING(string), len + 1); // copy terminator, too
+//    // .. now we can safely use the content of buf
+extern char * GAP_CSTR_STRING(Obj obj);
+
+// Returns a new mutable GAP string containing a copy of the given NULL
+// terminated C string.
+extern Obj GAP_MakeString(const char * string);
+
+// Returns a immutable GAP string containing a copy of the given NULL
+// terminated C string.
+extern Obj GAP_MakeImmString(const char * string);
+
 
 #endif

--- a/tst/testlibgap/basic.c
+++ b/tst/testlibgap/basic.c
@@ -6,7 +6,6 @@ int main(int argc, char ** argv)
 {
     printf("# Initializing GAP...\n");
     GAP_Initialize(argc, argv, environ, 0L, 0L);
-    CollectBags(0, 1);    // full GC
     test_eval("1+2+3;");
     test_eval("g:=FreeGroup(2);");
     test_eval("a:=g.1;");

--- a/tst/testlibgap/common.c
+++ b/tst/testlibgap/common.c
@@ -3,55 +3,19 @@
  */
 #include "common.h"
 
-UInt GAP_List_Length(Obj list)
-{
-    return LEN_LIST(list);
-}
-
-Obj GAP_List_AtPosition(Obj list, Int pos)
-{
-    return ELM_LIST(list, pos);
-}
-
-UInt GAP_String_Length(Obj string)
-{
-    return GET_LEN_STRING(string);
-}
-
-Int GAP_String_GetCString(Obj string, Char * buffer, UInt n)
-{
-    UInt len;
-
-    if (IS_STRING(string)) {
-        if (!IS_STRING_REP(string))
-            string = CopyToStringRep(string);
-        len = GET_LEN_STRING(string) + 1;
-        if (len >= n)
-            len = n - 1;
-        // Have to use mempcy because GAP strings can contain
-        // \0.
-        memcpy(buffer, CSTR_STRING(string), len);
-        if (len == n - 1)
-            buffer[n] = '\0';
-        return 1;
-    }
-    return 0;
-}
-
 void test_eval(const char * cmd)
 {
     Obj  res, ires;
     Int  rc, i;
-    Char buffer[4096];
     printf("gap> %s\n", cmd);
     res = GAP_EvalString(cmd);
-    rc = GAP_List_Length(res);
+    rc = GAP_LenList(res);
     for (i = 1; i <= rc; i++) {
-        ires = GAP_List_AtPosition(res, i);
-        if (GAP_List_AtPosition(ires, 1) == True) {
-            GAP_String_GetCString(GAP_List_AtPosition(ires, 5), buffer,
-                                  sizeof(buffer));
-            printf("%s\n", buffer);
+        ires = GAP_ElmList(res, i);
+        if (GAP_ElmList(ires, 1) == GAP_True) {
+            Char * buffer = GAP_CSTR_STRING(GAP_ElmList(ires, 5));
+            if (buffer)
+                printf("%s\n", buffer);
         }
     }
 }

--- a/tst/testlibgap/common.h
+++ b/tst/testlibgap/common.h
@@ -1,11 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
-#include <compiled.h>
+
 #include <libgap-api.h>
 extern char ** environ;
 
-UInt GAP_List_Length(Obj list);
-Obj GAP_List_AtPosition(Obj list, Int pos);
-UInt GAP_String_Length(Obj string);
-Int GAP_String_GetCString(Obj string, Char * buffer, UInt n);
 void test_eval(const char * cmd);

--- a/tst/testlibgap/wscreate.c
+++ b/tst/testlibgap/wscreate.c
@@ -6,7 +6,6 @@
 int main(int argc, char ** argv)
 {
     GAP_Initialize(argc, argv, environ, 0L, 0L);
-    CollectBags(0, 1);    // full GC
     test_eval("g:=FreeGroup(2);");
     test_eval("a:=g.1;");
     test_eval("b:=g.2;");


### PR DESCRIPTION
Also make `GAP_CSTR_STRING` easier to use (by not crashing for non-string inputs), and tweak testlibgap

This wraps some functions for which I have seen used "in the wild" in various places (mostly SageMath, and GAPJulia). Of course this is not yet enough, and some things should be tweaked, but I think it gets us closer.