### PR TITLE
Add new IsSimpleSemigroup method in lib/reesmat.gi

### DIFF
--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -123,6 +123,19 @@ InstallMethod(IsSimpleSemigroup,
 [IsReesMatrixSubsemigroup and HasUnderlyingSemigroup],
 R-> IsSimpleSemigroup(UnderlyingSemigroup(R)));
 
+# This next method for `IsSimpleSemigroup` additionally requires the filter
+# `IsFinite`, but is otherwise identical.  In the Semigroups package, there are
+# some more general methods installed for `IsSimpleSemigroup` which include the
+# filter `IsFinite`. When the rank of `IsFinite` is sufficiently large, these
+# methods can beat the above method. The above method is a more specific method
+# and should always be the one chosen for Rees matrix subsemigroups with known
+# underlying semigroup, whether finite or infinite.
+
+InstallMethod(IsSimpleSemigroup, 
+"for finite subsemigroup of a Rees matrix semigroup with underlying semigroup", 
+[IsReesMatrixSubsemigroup and HasUnderlyingSemigroup and IsFinite],
+R -> IsSimpleSemigroup(UnderlyingSemigroup(R)));
+
 # check that the matrix has no rows or columns consisting entirely of 0s
 # and that the underlying semigroup is simple
 

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -244,6 +244,14 @@ gap> T := Semigroup(RMSElement(R, 2, S.1, 1));
 <subsemigroup of 2x1 Rees matrix semigroup with 1 generator>
 gap> IsSimpleSemigroup(T);
 true
+gap> S := FreeSemigroup(1);
+<free semigroup on the generators [ s1 ]>
+gap> S := S / [[S.1, S.1 ^ 4]];
+<fp semigroup on the generators [ s1 ]>
+gap> R := ReesMatrixSemigroup(S, [[S.1, S.1 ^ 2], [S.1, S.1 ^ 3]]);
+<Rees matrix semigroup 2x2 over <fp semigroup on the generators [ s1 ]>>
+gap> IsSimpleSemigroup(R);
+true
 
 # IsZeroSimpleSemigroup: for a Rees 0-matrix semigroup
 gap> S := Semigroup([Transformation([1, 1]), Transformation([2, 2])]);


### PR DESCRIPTION
The method installed in `lib/reesmat.gi` for `IsSimpleSemigroup` for `IsReesMatrixSubsemigroup and HasUnderlyingSemigroup` is definitely the best method for this type of argument. However, depending on the rank of `RankFilter(IsFinite)`, this method is sometimes beaten by the Semigroups package method for `IsSimpleSemigroup` for `IsSemigroup and IsFinite`. This was causing a test in `tst/teststandard/reesmat.tst` to run out of memory when all packages were loaded, since the Semigroups package was being used when it shouldn't have been used.

This issue is resolved by adding an identical method for `IsSimpleSemigroup` that additionally requires the filter `IsFinite`.

This resolves the problem reported in https://github.com/gap-system/gap/issues/2818#issuecomment-437592480 by @alex-konovalov.