### PR TITLE
Fl readline fix

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -967,8 +967,9 @@ GAPInfo.CommandLineEditFunctions.Functions.Completion := function(l)
   if (not IsBound(cf.tabcompnam) and cf.tabcount = 2) or 
      (IsBound(cf.tabcompnam) and cf.tabcount in [2,4]) then
     if Length(cand) > 0 then
+      # we prepend the partial word which was completed
       return GAPInfo.CommandLineEditFunctions.Functions.DisplayMatches(
-                                                               Set(cand));
+                                        Concatenation([word], Set(cand)));
     else
       # ring the bell
       return GAPInfo.CommandLineEditFunctions.Functions.RingBell();

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2117,15 +2117,17 @@ int GAP_rl_func(int count, int key)
       if (hook == 1) {
          /* display matches */
          if (!IS_LIST(data)) return 0;
-         dlen = LEN_LIST(data);
-         char **strs = (char**)malloc((dlen+1) * sizeof(char*));
+         /* -1, because first is word to be completed */
+         dlen = LEN_LIST(data)-1;
+         /* +2, must be in 'argv' format, terminated by 0 */
+         char **strs = (char**)calloc(dlen+2, sizeof(char*));
          max = 0;
-         for (i=1; i <= dlen; i++) {
-            if (!IsStringConv(ELM_LIST(data, i))) {
+         for (i=0; i <= dlen; i++) {
+            if (!IsStringConv(ELM_LIST(data, i+1))) {
                free(strs);
                return 0;
             }
-            strs[i] = CSTR_STRING(ELM_LIST(data, i));
+            strs[i] = CSTR_STRING(ELM_LIST(data, i+1));
             if (max < strlen(strs[i])) max = strlen(strs[i]);
          }
          rl_display_match_list(strs, dlen, max);

--- a/src/system.c
+++ b/src/system.c
@@ -1160,6 +1160,7 @@ void InitSystem (
     InitSysFiles();
 
 #ifdef HAVE_LIBREADLINE
+    rl_readline_name = "GAP";
     rl_initialize ();
 #endif
     


### PR DESCRIPTION
This is an alternative for the pull request "Fix readline crash" #2986 by @ChrisJefferson.

@ChrisJefferson: Thanks for the report! I very rarely had crashes from completions before (also without the 'colored-completion-prefix' switch of readline, but could never reproduce them.

I agree that your proposed fix (#2986) should avoid the crashes, but as you already mentioned, the 'colored-completion-prefix'  switch does not yet work. This should be fixed by the present patch.

A second commit also fixes the problem that GAP did not read a '$if GAP' section of '~/.inputrc' on startup.