### PR TITLE
Officially document RationalCanonicalFormTransform and SimplexMethod; some minor tweaks

### DIFF
--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -429,6 +429,7 @@ See also chapter <Ref Chap="Integral matrices and lattices"/>
 <Heading>Matrices as Linear Mappings</Heading>
 
 <#Include Label="CharacteristicPolynomial">
+<#Include Label="RationalCanonicalFormTransform">
 <#Include Label="JordanDecomposition">
 <#Include Label="BlownUpMat">
 <#Include Label="BlownUpVector">
@@ -613,6 +614,15 @@ grease and level <A>b</A> blocking.
 <#Include Label="AsBlockMatrix">
 <#Include Label="BlockMatrix">
 <#Include Label="MatrixByBlockMatrix">
+
+</Section>
+
+
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="Linear Programming">
+<Heading>Linear Programming</Heading>
+
+<#Include Label="SimplexMethod">
 
 </Section>
 </Chapter>

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -108,7 +108,11 @@ local ffs,hom,U,rest,ker,r,p,l,i,depths;
   # transfer the IndicesEANormalSteps
   if ffs.pcgs<>ipcgs and HasIndicesEANormalSteps(ffs.pcgs) then
     U:=IndicesEANormalSteps(ffs.pcgs);
-    r:=ipcgs!.depthsInParent;
+    if IsBound(ipcgs!.depthsInParent) then
+      r:=ipcgs!.depthsInParent;
+    else
+      r:=List(ipcgs,x->DepthOfPcElement(ffs.pcgs,x));
+    fi;
     l:=[];
     for i in U{[1..Length(U)-1]} do # last one is length+1
       p:=PositionProperty(r,x->x>=i);

--- a/lib/grpcompl.gi
+++ b/lib/grpcompl.gi
@@ -59,7 +59,11 @@ local G,N,K,s, h, q, fpi, factorpres, com, comgens, cen, ocrels, fpcgs, ncom,
   G:=arg[1];
   N:=arg[2];
   # compute a series through N
-  s:=ChiefSeriesUnderAction(G,N);
+  if IsElementaryAbelian(N) then
+    s:=[N,TrivialSubgroup(N)];
+  else
+    s:=ChiefSeriesUnderAction(G,N);
+  fi;
   if Length(arg)=2 then
     K:=fail;
   else
@@ -69,10 +73,9 @@ local G,N,K,s, h, q, fpi, factorpres, com, comgens, cen, ocrels, fpcgs, ncom,
     s:=[h[1]];
     for i in h{[2..Length(h)]} do
       if Size(i)<Size(s[Length(s)]) then
-	Add(s,i);
+        Add(s,i);
       fi;
     od;
-
   fi;
 
   Info(InfoComplement,1,"Series of factors:",

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -2097,28 +2097,31 @@ DeclareGlobalFunction( "SimplexMethod" );
 
 #############################################################################
 ##
-#O  RationalCanonicalFormTransform( <A> )
+#O  RationalCanonicalFormTransform( <mat> )
 ##
-##  <#GAPDoc Label="Frobenius Normal Form">
+##  <#GAPDoc Label="RationalCanonicalFormTransform">
 ##  <ManSection>
-##  <Oper Name="RationalCanonicalFormTransform" Arg='A'/>
+##  <Func Name="RationalCanonicalFormTransform" Arg='mat'/>
 ##
 ##  <Description>
+##  <Index>Frobenius Normal Form</Index>
 ##  For a matrix <A>A</A> return a matrix <A>P</A> such that
-##  <M><A>A</A>^<A>P</A></M> is in rational canonical form (also called Frobenius normal form).
-##  The algorithm used is the basic textbook version and thus not of optimal complexity.
+##  <M><A>A</A>^<A>P</A></M> is in rational canonical form (also called
+##  Frobenius normal form). The algorithm used is the basic textbook
+##  version and thus not of optimal complexity.
 ##  <Example><![CDATA[
-##  gap> aa:=[ [ 0, -8, 12, 40, -36, 4, 0, 59, 15, -9 ], [ -2, -2, -2, 6, -11, 1, -1, 10, 1, 0 ],
-##  >   [ 1, 5, 0, -6, 12, -2, 0, -12, -4, 2 ], [ 0, 0, 0, 2, 0, 0, 0, 7, 0, 0 ],
-##  >   [ 0, 2, -3, -7, 8, -1, 0, -7, -3, 2 ], [ -5, -4, -6, 18, -30, 2, -2, 35, 5, -1 ],
-##  >   [ -1, -6, 6, 20, -28, 3, 0, 24, 10, -6 ], [ 0, 0, 0, -1, 0, 0, 0, -3, 0, 0 ],
-##  >   [ 0, 0, -1, -2, -2, 0, -1, -7, 0, 0 ], [ 0, -8, 9, 21, -36, 4, -2, 12, 12, -8 ] ];;
+##  gap> aa:=[[0,-8,12,40,-36,4,0,59,15,-9],[-2,-2,-2,6,-11,1,-1,10,1,0],
+##  > [1,5,0,-6,12,-2,0,-12,-4,2],[0,0,0,2,0,0,0,7,0,0],
+##  > [0,2,-3,-7,8,-1,0,-7,-3,2],[-5,-4,-6,18,-30,2,-2,35,5,-1],
+##  > [-1,-6,6,20,-28,3,0,24,10,-6],[0,0,0,-1,0,0,0,-3,0,0],
+##  > [0,0,-1,-2,-2,0,-1,-7,0,0],[0,-8,9,21,-36,4,-2,12,12,-8]];;
 ##  gap> t:=RationalCanonicalFormTransform(aa);;
 ##  gap> aa^t;
-##  [ [ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 ], [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ],
-##    [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ],
-##    [ 0, 0, 0, 0, 0, 1, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 1, 0, -1 ],
-##    [ 0, 0, 0, 0, 0, 0, 0, 0, 1, -1 ] ]
+##  [ [ 0, 0, 0, 1, 0, 0, 0, 0, 0, 0 ], [ 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+##    [ 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ], [ 0, 0, 1, 0, 0, 0, 0, 0, 0, 0 ],
+##    [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ],
+##    [ 0, 0, 0, 0, 0, 1, 0, 0, 0, 1 ], [ 0, 0, 0, 0, 0, 0, 1, 0, 0, 0 ],
+##    [ 0, 0, 0, 0, 0, 0, 0, 1, 0, -1 ], [ 0, 0, 0, 0, 0, 0, 0, 0, 1, -1 ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/norad.gi
+++ b/lib/norad.gi
@@ -552,7 +552,7 @@ local sus,ser,len,factorhom,uf,n,d,up,mran,nran,mpcgs,pcgs,pcisom,nf,ng,np,sub,
 	# work in quotient modules first
 	module:=GModuleByMats(Concatenation(ngm,npm),f);
 	sumos:=Reversed(MTX.BasesCompositionSeries(module));
-  Info(InfoFitFree,2,"module layers ",List(sumos,Length));
+	Info(InfoFitFree,2,"module layers ",List(sumos,Length));
 	sumos:=sumos{[2..Length(sumos)]};
 
 	for fs in sumos do
@@ -1013,7 +1013,7 @@ local sus,ser,len,factorhom,uf,n,d,up,mran,nran,mpcgs,pcgs,pcisom,nf,ng,np,sub,
 
               # construct the map reps->preimages and map the gens we want (to work
               # in the right coordinates)
-              map:=GroupGeneralMappingByImages(uf,G,map,l);
+              map:=GroupGeneralMappingByImagesNC(uf,G,map,l);
               l:=List(uff,x->ImagesRepresentative(map,x));
             fi;
 


### PR DESCRIPTION
Put `RationalCanonicalFormTransform` and `SimplexMethod` into manual

Skip unneccessary tests or calculations that can become expensive in large examples. (Too large to be suitable for tests.)

Recalculate parent depth entries if they do not yet exist. (Cannot reconstruct example that lead to change.)

