### PR TITLE
Add quick nonsolvability test before trying permutation Pcgs

### DIFF
--- a/doc/tut/group.xml
+++ b/doc/tut/group.xml
@@ -1176,7 +1176,7 @@ gap> niceaut := NiceObject( aut );
 Group([ (1,4,2,3), (1,5,4)(2,6,3), (1,2)(3,4), (3,4)(5,6) ])
 gap> IsomorphismGroups( niceaut, SymmetricGroup( 4 ) );
 [ (1,4,2,3), (1,5,4)(2,6,3), (1,2)(3,4), (3,4)(5,6) ] ->
-[ (1,4,3,2), (1,4,2), (1,3)(2,4), (1,4)(2,3) ]
+[ (1,4,2,3), (1,2,3), (1,2)(3,4), (1,3)(2,4) ]
 ]]></Example>
 <P/>
 The range of  a nice monomorphism is  in most cases a permutation  group,

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -3944,10 +3944,10 @@ DeclareAttributeSuppCT( "SourceOfIsoclinicTable", IsNearlyCharacterTable,
 ##  gap> tg:= CharacterTable( g );;
 ##  gap> IsRecord(
 ##  >        TransformingPermutationsCharacterTables( index2[1], tg ) );
-##  true
+##  false
 ##  gap> IsRecord(
 ##  >        TransformingPermutationsCharacterTables( index2[2], tg ) );
-##  false
+##  true
 ##  ]]></Example>
 ##  <P/>
 ##  Alternatively, we could construct the character table of the central
@@ -4436,11 +4436,11 @@ DeclareGlobalFunction( "NormalSubgroupClasses" );
 ##    Character( CharacterTable( S4 ), [ 3, 1, -1, 0, -1 ] ), 
 ##    Character( CharacterTable( S4 ), [ 1, 1, 1, 1, 1 ] ) ]
 ##  gap> kernel:= KernelOfCharacter( irr[3] );
-##  Group([ (1,2)(3,4), (1,4)(2,3) ])
+##  Group([ (1,2)(3,4), (1,3)(2,4) ])
 ##  gap> HasNormalSubgroupClassesInfo( tbl );
 ##  true
 ##  gap> NormalSubgroupClassesInfo( tbl );
-##  rec( nsg := [ Group([ (1,2)(3,4), (1,4)(2,3) ]) ],
+##  rec( nsg := [ Group([ (1,2)(3,4), (1,3)(2,4) ]) ],
 ##    nsgclasses := [ [ 1, 3 ] ], nsgfactors := [  ] )
 ##  gap> ClassPositionsOfNormalSubgroup( tbl, kernel );
 ##  [ 1, 3 ]

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1877,8 +1877,8 @@ DeclareAttribute( "MinimalNormalSubgroups", IsGroup );
 ##  returns a list of all normal subgroups of <A>G</A>.
 ##  <Example><![CDATA[
 ##  gap> g:=SymmetricGroup(4);;NormalSubgroups(g);
-##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,3)
-##    (2,4) ]), Group(()) ]
+##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,2)
+##    (3,4) ]), Group(()) ]
 ##  ]]></Example>
 ##  <P/>
 ##  The algorithm for the computation of normal subgroups is described in
@@ -3234,7 +3234,7 @@ DeclareOperation("CentralizerModulo", [IsGroup,IsGroup,IsObject]);
 ##  [ <pc group of size 12 with 3 generators>, Group([ y3, y*y3 ]), Group([ y*y3 ]) ]
 ##  gap> g:=SymmetricGroup(4);;
 ##  gap> PCentralSeries(g,2);
-##  [ Sym( [ 1 .. 4 ] ), Group([ (1,2,3), (2,3,4) ]) ]
+##  [ Sym( [ 1 .. 4 ] ), Group([ (1,2,3), (1,3,4) ]) ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1248,7 +1248,7 @@ local som,elvth,fct,gens,new,l,i,j,a,b,bound;
 
   elvth:=One(G);
   fct:=function(G) 
-    elvth:=elvth*Product(List([1..Random([1..5])],x->Random(GeneratorsOfGroup(G))^Random([-3..3])));
+    elvth:=elvth*Product([1..Random(1,5)],x->Random(GeneratorsOfGroup(G))^Random(-3,3));
     return elvth;
   end;
 

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1243,7 +1243,7 @@ local som,elvth,fct,gens,new,l,i,j,a,b,bound;
   som:=MovedPoints(G);
   bound:=Int(LogInt(Length(som)^5,3)/2); #Dixon Bound
   if Length(som)>100 then
-    som:=som{List([1..100],x->Random([1..Length(som)]))};
+    som:=som{List([1..100],x->Random(1, Length(som)))};
   fi;
 
   elvth:=One(G);

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1232,9 +1232,72 @@ end );
 ##
 #M  IsSolvableGroup( <G> )  . . . . . . . . . . . . . . . .  solvability test
 ##
+
+# fast test for finding iteratively nontrivial commutators in a permutation group.
+# if this goes on too long the group may not be solvable. This can be much faster
+# for large degree groups than to use the full pcgs machinery (which uses the same
+# idea but builds a pcgs on the way).
+BindGlobal("QuickUnsolvabilityTestPerm",function(G)
+local som,elvth,fct,gens,new,l,i,j,a,b,bound;
+  # a few moved points
+  som:=MovedPoints(G);
+  bound:=Int(LogInt(Length(som)^5,3)/2);
+  if Length(som)>100 then
+    som:=som{List([1..100],x->Random([1..Length(som)]))};
+  fi;
+
+  elvth:=One(G);
+  fct:=function(G) 
+    elvth:=elvth*Product(List([1..Random([1..5])],x->Random(GeneratorsOfGroup(G))^Random([-3..3])));
+    return elvth;
+  end;
+
+  gens:=GeneratorsOfGroup(G);
+  # find one nontrivial commutator
+  new:=fail;
+  i:=1;
+  while i<=Length(gens) and new=fail do
+    j:=i+1;
+    while j<=Length(gens) and new=fail do
+      if ForAny(som,x->(x^gens[i])^gens[j]<>(x^gens[j])^gens[i]) then
+        new:=Comm(gens[i],gens[j]);
+      fi;
+      j:=j+1;
+    od;
+    i:=i+1;
+  od;
+  if new=fail then return fail;fi;
+
+  # now take commutators with conjugates to get down
+  i:=1;
+  repeat
+    gens:=new;
+    j:=1;
+    new:=fail;
+    l:=[gens];
+    while j<=10 and new=fail do
+      a:=Random(l)^fct(G);
+      b:=First(l,b->ForAny(som,x->(x^a)^b<>(x^b)^a));
+      if b<>fail then
+        new:=Comm(a,b);
+      else
+        Add(l,a);
+      fi;
+      j:=j+1;
+    od;
+    if new=fail then
+      return fail;
+    fi;
+    i:=i+1;
+  until i>bound;
+  return true;
+end);
+  
 InstallMethod( IsSolvableGroup,"for permgrp", true, [ IsPermGroup ], 0,
 function(G)
 local pcgs;
+  if QuickUnsolvabilityTestPerm(G)=true then return false;fi;
+
   pcgs:=TryPcgsPermGroup( G, false, false, true );
   if IsPcgs(pcgs) then
     SetIndicesEANormalSteps(pcgs,pcgs!.permpcgsNormalSteps);

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1241,7 +1241,7 @@ BindGlobal("QuickUnsolvabilityTestPerm",function(G)
 local som,elvth,fct,gens,new,l,i,j,a,b,bound;
   # a few moved points
   som:=MovedPoints(G);
-  bound:=Int(LogInt(Length(som)^5,3)/2);
+  bound:=Int(LogInt(Length(som)^5,3)/2); #Dixon Bound
   if Length(som)>100 then
     som:=som{List([1..100],x->Random([1..Length(som)]))};
   fi;

--- a/lib/morpheus.gd
+++ b/lib/morpheus.gd
@@ -508,7 +508,7 @@ DeclareGlobalFunction("IsomorphismGroups");
 ##  gap> h:=Group((1,2,3),(1,2));
 ##  Group([ (1,2,3), (1,2) ])
 ##  gap> quo:=GQuotients(g,h);
-##  [ [ (1,2,3,4), (1,3,4) ] -> [ (2,3), (1,2,3) ] ]
+##  [ [ (1,3,2,4), (1,2,3) ] -> [ (2,3), (1,2,3) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -194,9 +194,9 @@ DeclareGlobalFunction("CosetDecomposition");
 ##  <A>H</A>-conjugacy.
 ##  <Example><![CDATA[
 ##  gap> AllHomomorphismClasses(SymmetricGroup(4),SymmetricGroup(3)); 
-##  [ [ (1,2,3), (2,4) ] -> [ (), () ],
-##    [ (1,2,3), (2,4) ] -> [ (), (1,2) ],
-##    [ (1,2,3), (2,4) ] -> [ (1,2,3), (1,2) ] ]
+##  [ [ (1,2,3,4), (1,2) ] -> [ (), () ],
+##    [ (1,2,3,4), (1,2) ] -> [ (2,3), (1,2) ],
+##    [ (1,2,3,4), (1,2) ] -> [ (1,2), (1,2) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>


### PR DESCRIPTION
In larger degree permutation groups, `IsSolvableGroup` (or the test of calculating a Pcgs for stabilizer chain) can become expensive. Added a quick probabilistic check of iterated commutators beyond maximal derived length that will recognize such nonsolvable cases quickly.
(This is already testes extensively by existing examples.)