### PR TITLE
kernel: rename RACErrorHelper to RequireArgument

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -582,12 +582,12 @@ void CheckSameLength(const Char * desc, const Char *leftName, const Char *rightN
 
 /****************************************************************************
 **
-*F  RACErrorHelper
+*F  RequireArgument
 */
-Obj RACErrorHelper(const char * funcname,
-                   Obj          op,
-                   const char * argname,
-                   const char * msg)
+Obj RequireArgument(const char * funcname,
+                    Obj          op,
+                    const char * argname,
+                    const char * msg)
 {
     char msgbuf[1024] = { 0 };
     Int  arg1 = 0;

--- a/src/error.h
+++ b/src/error.h
@@ -132,10 +132,10 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 **
 *F  RACErrorHelper
 */
-extern Obj RACErrorHelper(const char * funcname,
-                          Obj          op,
-                          const char * argname,
-                          const char * msg);
+extern Obj RequireArgument(const char * funcname,
+                           Obj          op,
+                           const char * argname,
+                           const char * msg);
 
 /****************************************************************************
 **
@@ -144,7 +144,7 @@ extern Obj RACErrorHelper(const char * funcname,
 #define RequireArgumentCondition(funcname, op, argname, cond, msg)           \
     do {                                                                     \
         if (!(cond)) {                                                       \
-            RACErrorHelper(funcname, op, argname, msg);                   \
+            RequireArgument(funcname, op, argname, msg);                     \
         }                                                                    \
     } while (0)
 


### PR DESCRIPTION
This fits in with the general naming pattern for the macros
derived from it.