### PR TITLE
Forbid installing new implications to representations using `InstallTrueMethod`

### DIFF
--- a/lib/basis.gi
+++ b/lib/basis.gi
@@ -687,11 +687,14 @@ InstallGlobalFunction( "InstallHandlingByNiceBasis",
     filter:= ValueGlobal( name );
 
     # Install the detection of the filter.
+    # The mechanism is safe only if the domain can store
+    # its nice variant, thus we will install it only for cases where
+    # 'IsAttributeStoringRep' is guaranteed.
     entry:= First( NiceBasisFiltersInfo,
                    x -> IsIdenticalObj( filter, x[1] ) );
     entry[3] := record.detect;
+    filter:= filter and IsFreeLeftModule and IsAttributeStoringRep;
     InstallTrueMethod( IsHandledByNiceBasis, filter );
-    filter:= IsFreeLeftModule and filter;
 
     # Install the methods.
     InstallMethod( NiceFreeLeftModuleInfo,

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -284,29 +284,32 @@ end);
 ##  Adding logical implications can change the rank of filters (see
 ##  <Ref Func="RankFilter"/>) and consequently the rank, and so choice of
 ##  methods for operations (see <Ref Sect="Applicable Methods and Method Selection"/>).
-##  By default <C>InstallTrueMethod</C> adjusts the method selection data
-##  structures to take care of this, but this process can be time-consuming,
+##  By default <Ref Func="InstallTrueMethod"/> adjusts the method selection
+##  data structures to take care of this,
+##  but this process can be time-consuming,
 ##  so functions <Ref Func="SuspendMethodReordering"/> and
 ##  <Ref Func="ResumeMethodReordering"/> are provided to allow control of this process.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-
 BIND_GLOBAL( "InstallTrueMethod", function ( tofilt, from )
-    local i;
+    local fromflags, i, j;
 
     # Check whether 'tofilt' involves or implies representations.
+    fromflags:= TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( from ) ) );
     for i in TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( tofilt ) ) ) do
       if INFO_FILTERS[i] = FNUM_REP_KERN or INFO_FILTERS[i] = FNUM_REP then
-        # This is allowed only if 'from' consists of representations.
-        for i in TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( from ) ) ) do
-          if not ( INFO_FILTERS[i] = FNUM_REP_KERN or
-                   INFO_FILTERS[i] = FNUM_REP ) then
-            Error( "<tofilt> must not involve representation filters" );
-          fi;
-        od;
-        break;
+        # This is allowed only if either 'from' already implies filter 'i'
+        # or if 'from' consists of representations.
+        if not i in fromflags then
+          for j in fromflags do
+            if not ( INFO_FILTERS[j] = FNUM_REP_KERN or
+                     INFO_FILTERS[j] = FNUM_REP ) then
+              Error( "<tofilt> must not involve new representation filters" );
+            fi;
+          od;
+        fi;
       fi;
     od;
 
@@ -320,7 +323,6 @@ BIND_GLOBAL( "InstallTrueMethod", function ( tofilt, from )
     if REORDER_METHODS_SUSPENSION_LEVEL = 0 then
         RECALCULATE_ALL_METHOD_RANKS();
     fi;
-
 end );
 
 

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -294,6 +294,21 @@ end);
 ##
 
 BIND_GLOBAL( "InstallTrueMethod", function ( tofilt, from )
+    local i;
+
+    # Check whether 'tofilt' involves or implies representations.
+    for i in TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( tofilt ) ) ) do
+      if INFO_FILTERS[i] = FNUM_REP_KERN or INFO_FILTERS[i] = FNUM_REP then
+        # This is allowed only if 'from' consists of representations.
+        for i in TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( from ) ) ) do
+          if not ( INFO_FILTERS[i] = FNUM_REP_KERN or
+                   INFO_FILTERS[i] = FNUM_REP ) then
+            Error( "<tofilt> must not involve representation filters" );
+          fi;
+        od;
+        break;
+      fi;
+    od;
 
     InstallTrueMethodNewFilter( tofilt, from );
 

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -294,21 +294,15 @@ end);
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "InstallTrueMethod", function ( tofilt, from )
-    local fromflags, i, j;
+    local fromflags, i;
 
     # Check whether 'tofilt' involves or implies representations.
     fromflags:= TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( from ) ) );
     for i in TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( tofilt ) ) ) do
       if INFO_FILTERS[i] = FNUM_REP_KERN or INFO_FILTERS[i] = FNUM_REP then
-        # This is allowed only if either 'from' already implies filter 'i'
-        # or if 'from' consists of representations.
+        # This is allowed only if 'from' already implies filter 'i'.
         if not i in fromflags then
-          for j in fromflags do
-            if not ( INFO_FILTERS[j] = FNUM_REP_KERN or
-                     INFO_FILTERS[j] = FNUM_REP ) then
-              Error( "<tofilt> must not involve new representation filters" );
-            fi;
-          od;
+          Error( "<tofilt> must not involve new representation filters" );
         fi;
       fi;
     od;

--- a/lib/module.gd
+++ b/lib/module.gd
@@ -247,9 +247,7 @@ DeclareProperty( "IsFullMatrixModule", IsFreeLeftModule, 20 );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareCategory( "IsHandledByNiceBasis",
-    IsFreeLeftModule and IsAttributeStoringRep );
-#T individually choose for each repres. in this category?
+DeclareCategory( "IsHandledByNiceBasis", IsFreeLeftModule );
 #T why not `DeclareFilter' ?
 
 

--- a/lib/type.g
+++ b/lib/type.g
@@ -150,7 +150,9 @@ BIND_GLOBAL( "DeclareRepresentationKernel", function ( name, super, rep )
         od;
 
     od;
-    InstallTrueMethod( super, rep );
+
+    # Calling 'InstallTrueMethod' for two representations is not allowed.
+    InstallTrueMethodNewFilter( super, rep );
     BIND_GLOBAL( name, rep );
     SET_NAME_FUNC( rep, name );
 end );

--- a/lib/vspchom.gi
+++ b/lib/vspchom.gi
@@ -2171,7 +2171,8 @@ InstallMethod( Hom,
                                 IsFreeLeftModule
                             and IsFullHomModule
                             and IsLinearMappingsModule
-                            and IsGeneralMappingCollection ),
+                            and IsGeneralMappingCollection
+                            and IsAttributeStoringRep ),
                    rec() );
 
     SetLeftActingDomain( M, F );

--- a/tst/testinstall/method.tst
+++ b/tst/testinstall/method.tst
@@ -9,6 +9,12 @@ Error, required filters [ "IsInt", "IsRat", "IsCyc", "IsExtAElement",
     , "IsMultiplicativeElementWithInverse", "IsZDFRE", "IsAssociativeElement",
   "IsAdditivelyCommutativeElement", "IsCommutativeElement", "IsCyclotomic" ]
 for 1st argument do not match a declaration of Size
+gap> InstallTrueMethod( IsInternalRep, IsList );
+Error, <tofilt> must not involve new representation filters
+gap> InstallTrueMethod( IsDenseCoeffVectorRep, IsList );
+Error, <tofilt> must not involve new representation filters
+gap> InstallTrueMethod( IsInternalRep, IsSmallIntRep );
+gap> InstallTrueMethod( IsList and IsInternalRep, IsList and IsSmallIntRep );
 
 # Check names are set correctly
 gap> cheese := NewOperation("cheese", [IsObject]);
@@ -27,4 +33,4 @@ gap> List(Concatenation(funcs, ranks), NameFunction);
 [ "cheese method", "cheese for a list", "func3", 
   "Priority calculation for cheese", 
   "Priority calculation for cheese for a list", "rank3" ]
-gap> STOP_TEST("method.tst", 1);
+gap> STOP_TEST("method.tst");


### PR DESCRIPTION
(This pull request addresses a comment in issue #2818.)

Filters of type representation are intended to describe
the internal data of an object.
Thus a logical implication to such a filter makes sense only
if the implying filters are also representations.

As had be noticed by @fingolfin,
there was a now forbidden hidden implication in the library,
from `IsHandledByNiceBasis` to `IsAttributeStoringRep`.
Logically, one wants this rather the other way round,
that is, the mechanism relies on stored data and thus should be *restricted*
to situations where `IsAttributeStoringRep` is present.
I have now changed this setup accordingly, that is,
`IsAttributeStoringRep` is no longer implied by `IsHandledByNiceBasis`.
As a consequence, one `Objectify` call in the library had to be changed
such that `IsAttributeStoringRep` gets explicitly set.

(The same might happen also in packages.)