### PR TITLE
Added GAP_ValueMacFloat to libgap-api

### DIFF
--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -10,6 +10,7 @@
 #include "gvars.h"
 #include "integer.h"
 #include "lists.h"
+#include "macfloat.h"
 #include "opers.h"
 #include "plist.h"
 #include "streams.h"
@@ -191,6 +192,29 @@ Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[])
     }
 
     return result;
+}
+
+
+////
+//// floats
+////
+
+Int GAP_IsMacFloat(Obj obj)
+{
+    return IS_MACFLOAT(obj);
+}
+
+double GAP_ValueMacFloat(Obj obj)
+{
+    if (!IS_MACFLOAT(obj)) {
+        ErrorMayQuit("<obj> is not a MacFloat", 0, 0);
+    }
+    return (double)VAL_MACFLOAT(obj);
+}
+
+Obj GAP_NewMacFloat(double x)
+{
+    return NEW_MACFLOAT(x);
 }
 
 

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -78,8 +78,23 @@ extern Obj GAP_Fail;
 extern Obj GAP_CallFuncList(Obj func, Obj args);
 
 // Call the GAP object <func> as a function with arguments given
-// as an array <args> with <narg> entries
+// as an array <args> with <narg> entries.
 extern Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[]);
+
+
+////
+//// floats
+////
+
+// Returns 1 if <obj> is a GAP machine float, 0 if not.
+extern Int GAP_IsMacFloat(Obj obj);
+
+// Returns the value of the GAP machine float object <obj>.
+// If <obj> is not a machine float object, an error is raised.
+extern double GAP_ValueMacFloat(Obj obj);
+
+// Returns a new GAP machine float with value <x>.
+extern Obj GAP_NewMacFloat(double x);
 
 
 ////


### PR DESCRIPTION
I decided to use `double` instead of `Double` to not having to include `macfloats.h` into `libgap-api.h`