### PR TITLE
More error cleanups

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -1152,17 +1152,16 @@ Obj FuncPositionNthTrueBlist (
     Obj                 Nth )
 {
     UInt                nrb;
-    Int                 nth,  pos,  i;
+    Int                 pos, i;
     UInt                m,  mask;
     const UInt *        ptr;
 
     /* Check the arguments. */    
     RequireBlist("ListBlist", blist, "blist");
-    RequirePositiveSmallInt("Position", Nth, "nth");
-    
+    Int nth = GetPositiveSmallInt("Position", Nth, "nth");
+
     nrb = NUMBER_BLOCKS_BLIST(blist);
     if ( ! nrb )  return Fail;
-    nth = INT_INTOBJ( Nth );
     pos = 0;
     ptr = CONST_BLOCKS_BLIST(blist);
     i = 1;

--- a/src/error.h
+++ b/src/error.h
@@ -231,6 +231,13 @@ static inline Int GetSmallInt(const char * funcname, Obj op, const char * argnam
     return INT_INTOBJ(op);
 }
 
+static inline Int
+GetPositiveSmallInt(const char * funcname, Obj op, const char * argname)
+{
+    RequirePositiveSmallInt(funcname, op, argname);
+    return INT_INTOBJ(op);
+}
+
 
 /****************************************************************************
 **

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1090,21 +1090,12 @@ Obj             EvalRangeExpr (
     /* evaluate the second value (if present)                              */
     if ( SIZE_EXPR(expr) == 3*sizeof(Expr) ) {
         val = EVAL_EXPR(READ_EXPR(expr, 1));
-        while ( ! IS_INTOBJ(val) || INT_INTOBJ(val) == low ) {
-            if ( ! IS_INTOBJ(val) ) {
-                val = ErrorReturnObj(
-                    "Range: <second> must be a small integer (not a %s)",
-                    (Int)TNAM_OBJ(val), 0,
-                    "you can replace <second> via 'return <second>;'" );
-            }
-            else {
-                val = ErrorReturnObj(
-                    "Range: <second> must not be equal to <first> (%d)",
-                    (Int)low, 0L,
-                    "you can replace the integer <second> via 'return <second>;'" );
-            }
+        Int ival = GetSmallInt("Range", val, "second");
+        if (ival == low) {
+            ErrorMayQuit("Range: <second> must not be equal to <first> (%d)",
+                         (Int)low, 0);
         }
-        inc = INT_INTOBJ(val) - low;
+        inc = ival - low;
     }
     else {
         inc = 1;
@@ -1112,21 +1103,12 @@ Obj             EvalRangeExpr (
 
     /* evaluate and check the high value                                   */
     val = EVAL_EXPR(READ_EXPR(expr, SIZE_EXPR(expr) / sizeof(Expr) - 1));
-    while ( ! IS_INTOBJ(val) || (INT_INTOBJ(val) - low) % inc != 0 ) {
-        if ( ! IS_INTOBJ(val) ) {
-            val = ErrorReturnObj(
-                "Range: <last> must be a small integer (not a %s)",
-                (Int)TNAM_OBJ(val), 0,
-                "you can replace <last> via 'return <last>;'" );
-        }
-        else {
-            val = ErrorReturnObj(
-                "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",
-                (Int)(INT_INTOBJ(val)-low), (Int)inc,
-                "you can replace the integer <last> via 'return <last>;'" );
-        }
+    high = GetSmallInt("Range", val, "last");
+    if ((high - low) % inc != 0) {
+        ErrorMayQuit(
+            "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",
+            (Int)(high - low), (Int)inc);
     }
-    high = INT_INTOBJ(val);
 
     /* if <low> is larger than <high> the range is empty                   */
     if ( (0 < inc && high < low) || (inc < 0 && low < high) ) {

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -833,8 +833,7 @@ Obj             EvalPermExpr (
 
             /* get and check current entry for the cycle                   */
             val = EVAL_EXPR(READ_EXPR(cycle, j - 1));
-            RequirePositiveSmallInt("Permutation", val, "expr");
-            c = INT_INTOBJ(val);
+            c = GetPositiveSmallInt("Permutation", val, "expr");
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",
                             0, 0);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1971,8 +1971,7 @@ void            IntrPermCycle (
 
         /* get and check current entry for the cycle                       */
         val = PopObj();
-        RequirePositiveSmallInt("Permutation", val, "expr");
-        c = INT_INTOBJ(val);
+        c = GetPositiveSmallInt("Permutation", val, "expr");
         if (c > MAX_DEG_PERM4)
           ErrorQuit( "Permutation literal exceeds maximum permutation degree",
                      0, 0);
@@ -3489,8 +3488,7 @@ void            IntrAssPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
 
     /* get the list (checking is done by 'ASS_LIST')                       */
     list = PopObj();
@@ -3516,8 +3514,7 @@ void            IntrUnbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
 
     /* get the list (checking is done by 'UNB_LIST')                       */
     list = PopObj();
@@ -3549,8 +3546,7 @@ void            IntrElmPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    RequirePositiveSmallInt("PosObj Element", pos, "position");
-    p = INT_INTOBJ( pos );
+    p = GetPositiveSmallInt("PosObj Element", pos, "position");
 
     /* get the list (checking is done by 'ELM_LIST')                       */
     list = PopObj();
@@ -3577,8 +3573,7 @@ void            IntrIsbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    RequirePositiveSmallInt("PosObj Element", pos, "position");
-    p = INT_INTOBJ( pos );
+    p = GetPositiveSmallInt("PosObj Element", pos, "position");
 
     /* get the list (checking is done by 'ISB_LIST')                       */
     list = PopObj();

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -821,19 +821,15 @@ Obj PowIntPerm(Obj opL, Obj opR)
 {
     Int                 img;            /* image (result)                  */
 
+    GAP_ASSERT(TNUM_OBJ(opL) == T_INTPOS || TNUM_OBJ(opL) == T_INT);
+
     /* large positive integers (> 2^28-1) are fixed by any permutation     */
     if ( TNUM_OBJ(opL) == T_INTPOS )
         return opL;
 
-    /* permutations do not act on negative integers                        */
-    img = INT_INTOBJ( opL );
-    if ( img <= 0 ) {
-        opL = ErrorReturnObj(
-            "Perm. Operations: <point> must be a positive integer (not %d)",
-            (Int)img, 0L,
-            "you can replace <point> via 'return <point>;'" );
-        return POW( opL, opR );
-    }
+    img = INT_INTOBJ(opL);
+    RequireArgumentCondition("PowIntPerm", opL, "point", img > 0,
+                             "must be a positive integer");
 
     /* compute the image                                                   */
     if ( img <= DEG_PERM<T>(opR) ) {
@@ -868,19 +864,15 @@ Obj QuoIntPerm(Obj opL, Obj opR)
     Int                 img;            /* image (left operand)            */
     const T *           ptR;            /* pointer to the permutation      */
 
+    GAP_ASSERT(TNUM_OBJ(opL) == T_INTPOS || TNUM_OBJ(opL) == T_INT);
+
     /* large positive integers (> 2^28-1) are fixed by any permutation     */
     if ( TNUM_OBJ(opL) == T_INTPOS )
         return opL;
 
-    /* permutations do not act on negative integers                        */
     img = INT_INTOBJ(opL);
-    if ( img <= 0 ) {
-        opL = ErrorReturnObj(
-            "Perm. Operations: <point> must be a positive integer (not %d)",
-            (Int)img, 0L,
-            "you can replace <point> via 'return <point>;'" );
-        return QUO( opL, opR );
-    }
+    RequireArgumentCondition("QuoIntPerm", opL, "point", img > 0,
+                             "must be a positive integer");
 
     Obj inv = STOREDINV_PERM(opR);
 
@@ -1123,12 +1115,7 @@ Obj             FuncPermList (
     Obj                 list )
 {
     /* check the arguments                                                 */
-    while ( ! IS_SMALL_LIST( list ) ) {
-        list = ErrorReturnObj(
-            "PermList: <list> must be a list (not a %s)",
-            (Int)TNAM_OBJ(list), 0L,
-            "you can replace <list> via 'return <list>;'" );
-    }
+    RequireSmallList("PermList", list);
 
     UInt len = LEN_LIST( list );
     if ( len <= 65536 ) {

--- a/tst/testinstall/kernel/exprs.tst
+++ b/tst/testinstall/kernel/exprs.tst
@@ -37,6 +37,12 @@ gap> f(1,1,1);
 Error, Range: <second> must not be equal to <first> (1)
 gap> f(1,3,4);
 Error, Range: <last>-<first> (3) must be divisible by <inc> (2)
+gap> f(2^100,1,2);
+Error, Range: <first> must be a small integer (not a large positive integer)
+gap> f(1,2^100,2);
+Error, Range: <second> must be a small integer (not a large positive integer)
+gap> f(1,2,2^200);
+Error, Range: <last> must be a small integer (not a large positive integer)
 
 # EvalRecExpr
 gap> f:={a,b} -> rec( (a) := b );;

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -207,8 +207,13 @@ gap> List(permAll, x -> x^-3);
 #
 # PowIntPerm
 #
+gap> (-1)^(1,2);
+Error, PowIntPerm: <point> must be a positive integer (not the integer -1)
+gap> (-2^100)^(1,2);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `^' on 2 arguments
 gap> 0^(1,2);
-Error, Perm. Operations: <point> must be a positive integer (not 0)
+Error, PowIntPerm: <point> must be a positive integer (not the integer 0)
 gap> n:=10^30;;
 gap> ForAll(permAll, g -> n^g = n);
 true
@@ -222,8 +227,13 @@ gap> List([1,2,3,4,1000],n->List(permBig, g->n^g));
 #
 # QuoIntPerm
 #
+gap> (-1)/(1,2);
+Error, QuoIntPerm: <point> must be a positive integer (not the integer -1)
+gap> (-2^100)/(1,2);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `*' on 2 arguments
 gap> 0/(1,2);
-Error, Perm. Operations: <point> must be a positive integer (not 0)
+Error, QuoIntPerm: <point> must be a positive integer (not the integer 0)
 gap> n:=10^30;;
 gap> ForAll(permAll, g -> n/g = n);
 true
@@ -280,7 +290,7 @@ true
 
 # PermList error handling
 gap> PermList(1);
-Error, PermList: <list> must be a list (not a integer)
+Error, PermList: <list> must be a small list (not the integer 1)
 
 # PermList error handling for T_PERM2
 gap> PermList([1,,3]);


### PR DESCRIPTION
Here is a few more error cleanups, mainly moving from `Require*` functions to `Get*` functions where possible, which helps reduce the number of INT_INTOBJ calls