### PR TITLE
Read lib/transatl.g before reading gap.ini

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -696,6 +696,14 @@ function()
     fi;
 end);
 
+
+############################################################################
+##
+#X  Name Synonyms for different spellings
+##
+ReadLib("transatl.g");
+
+
 CallAndInstallPostRestore( function()
     READ_GAP_ROOT( "gap.ini" );
 end );
@@ -789,13 +797,6 @@ CallAndInstallPostRestore( function()
     # user preference `UseColorPrompt'
     ColorPrompt( UserPreference( "UseColorPrompt" ) );
 end );
-
-
-############################################################################
-##
-#X  Name Synonyms for different spellings
-##
-ReadLib("transatl.g");
 
 
 #############################################################################


### PR DESCRIPTION
I have made this PR as a result of what I think would be the best solution to #2828 and #2996.

Currently, `lib/transatl.g` is read in `init.g` a bit later than `gap.ini`. This means that if a package is autoloaded from `gap.ini` and the package uses a name declared in `lib/transatl.g`, then an `unbound global variable` warning is given. This happens with GRAPE 4.8.1 in particular.

This PR moves the reading of `lib/transatl.g` to the point directly before reading `gap.ini`.

Anyway, I've created this PR as a discussion point. There might be very good reasons for why this is a bad idea; in this case, I will be keen to hear about them!