### PR TITLE
Rename Wrap -> wrap in a test

### DIFF
--- a/tst/testinstall/objlist.tst
+++ b/tst/testinstall/objlist.tst
@@ -6,7 +6,7 @@ gap> DeclareRepresentation( "IsTestListObjRep", IsTestListObj and IsComponentObj
 gap> BindGlobal( "TestListObjType", NewType(TestListObjFamily, IsTestListObjRep));;
 gap> BindGlobal( "TestListObjTypeMutable", NewType(TestListObjFamily,
 >                                        IsTestListObjRep and IsMutable));;
-gap> Wrap := {x} -> Objectify(TestListObjTypeMutable, rec(l := x));;
+gap> wrap := {x} -> Objectify(TestListObjTypeMutable, rec(l := x));;
 gap> InstallMethod(ViewString, [ IsTestListObjRep ], {x} -> STRINGIFY(x!.l));;
 gap> InstallMethod(\[\], [ IsTestListObjRep, IsPosInt ], {x,i} -> x!.l[i]);;
 gap> InstallMethod(\[\]\:\=, [ IsTestListObjRep and IsMutable, IsPosInt, IsObject ],
@@ -15,8 +15,8 @@ gap> InstallMethod( Length, [ IsTestListObjRep ], {x} -> Length(x!.l));
 gap> InstallMethod( IsBound\[\], [ IsTestListObjRep, IsPosInt ], {x,i} -> IsBound(x!.l[i]));;
 gap> x := [10,20,"cheese"];;
 gap> y := [10,20,"cheese"];;
-gap> a := Wrap(x);;
-gap> b := Wrap(y);;
+gap> a := wrap(x);;
+gap> b := wrap(y);;
 gap> a[2];
 20
 gap> a = b;


### PR DESCRIPTION
`Wrap` is defined as an operation in the FinInG package, hence this test fails when is loaded.

This fixes the problem reported in my comment in https://github.com/gap-system/gap/commit/ab6497a02d74adf95e4dcc67198a850f8db25656#commitcomment-31327775