### PR TITLE
Fix writing past end of bag in objscoll-impl

### DIFF
--- a/src/objscoll-impl.h
+++ b/src/objscoll-impl.h
@@ -501,7 +501,7 @@ Int Solution(
         i = (SIZE_OBJ(ww)-sizeof(Obj)-1) / sizeof(Int);
         ResizeBag( ww, num*sizeof(Int)+sizeof(Obj)+1 );
         qtr = (Int*)(ADDR_OBJ(ww)+1);
-        for ( i = i+1;  i <= num;  i++ )
+        for ( i = i+1;  i < num;  i++ )
             qtr[i] = 0;
     }
 
@@ -517,7 +517,7 @@ Int Solution(
         i = (SIZE_OBJ(uu)-sizeof(Obj)-1) / sizeof(Int);
         ResizeBag( uu, num*sizeof(Int)+sizeof(Obj)+1 );
         qtr = (Int*)(ADDR_OBJ(uu)+1);
-        for ( i = i+1;  i <= num;  i++ )
+        for ( i = i+1;  i < num;  i++ )
             qtr[i] = 0;
     }
 

--- a/tst/testbugfix/2018-11-16-ConjugacyClasses.tst
+++ b/tst/testbugfix/2018-11-16-ConjugacyClasses.tst
@@ -1,0 +1,9 @@
+# Reported in github PR 2990
+# Needs a GAP compiled with --enable-valgrind, then run as
+# valgrind ./gap, to detect the problem which was fixed.
+gap> h:= Group([ (1,17,2,18,6,13)(3,20)(4,11,10,16,5,12,8,15,9,19,7,14), 
+> (1,19)(2,18,5,16,6,13,7,15)(3,11)(4,17,9,20,10,14,8,12) ]);;
+gap> Size(h);
+1036800
+gap> Size(ConjugacyClasses(h));
+44


### PR DESCRIPTION
Fixes #2990 . This is quite hard to test, but this seems to fix it on my machine.