### PR TITLE
Fix `ci-gather-coverage.sh`

### DIFF
--- a/etc/ci-gather-coverage.sh
+++ b/etc/ci-gather-coverage.sh
@@ -18,7 +18,7 @@ fi
 SRCDIR=${SRCDIR:-$PWD}
 
 # Make sure any Error() immediately exits GAP with exit code 1.
-GAP="bin/gap.sh --quitonbreak --nointeract --alwaystrace -q"
+GAP="bin/gap.sh --quitonbreak --alwaystrace -q"
 
 # change into BUILDDIR (creating it if necessary), and turn it into an absolute path
 if [[ -n "$BUILDDIR" ]]
@@ -46,11 +46,17 @@ for f in DirectoryContents(d) do
     Add(covs, f);
     Print("  ", f, "\n");
 od;
-Print("Merging ", Length(covs), " coverage files...\n");
-r := MergeLineByLineProfiles(covs);;
-Print("Outputting JSON\n");
-OutputJsonCoverage(r, "gap-coverage.json");;
-QUIT_GAP(0);
+if Length(covs) > 0 then
+    Print("Merging ", Length(covs), " coverage files...\n");
+    r := MergeLineByLineProfiles(covs);;
+    Print("Outputting JSON\n");
+    OutputJsonCoverage(r, "gap-coverage.json");;
+else
+    # Don't error, because we might want to gather
+    # gcov coverage, so just inform that we didn't find
+    # GAP coverage data
+    Print("No coverage files found...\n");
+fi;
 GAPInput
 
 # generate kernel coverage reports by running gcov


### PR DESCRIPTION
`--nointeract` prevents a session to be started, and hence input on stdin has
no effect.

Closes #3019 