### PR TITLE
kernel: add MakeImmutableNoRecurse

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -212,12 +212,9 @@ Obj DoCopyBlist(Obj list, Int mut)
     Obj copy;
 
     /* make a copy                                                         */
-    if ( mut ) {
-      copy = NewBag( MUTABLE_TNUM(TNUM_OBJ(list)), SIZE_OBJ(list) );
-    }
-    else {
-      copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
-    }
+    copy = NewBag(MUTABLE_TNUM(TNUM_OBJ(list)), SIZE_OBJ(list));
+    if (!mut)
+        MakeImmutableNoRecurse(copy);
 
     /* copy the subvalues                                                  */
     memcpy(ADDR_OBJ(copy), CONST_ADDR_OBJ(list),
@@ -1605,7 +1602,7 @@ Obj FuncMEET_BLIST (
 
 void MakeImmutableBlist( Obj blist )
 {
-  RetypeBag(blist, IMMUTABLE_TNUM(TNUM_OBJ(blist)));
+    MakeImmutableNoRecurse(blist);
 }
 
 /****************************************************************************

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -685,7 +685,7 @@ Obj FuncMAKE_BITFIELDS(Obj self, Obj widths)
         AssPRec(ms, RNamName("booleanSetters"), bsetters);
     }
     SortPRecRNam(ms, 0);
-    RetypeBag(ms, T_PREC + IMMUTABLE);
+    MakeImmutableNoRecurse(ms);
     return ms;
 }
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -528,6 +528,24 @@ static inline void SET_TYPE_OBJ(Obj obj, Obj type)
 */
 extern void MakeImmutable( Obj obj );
 
+
+/****************************************************************************
+**
+*F  MakeImmutableNoRecurse( <obj> ) . . set immutable flag on internal object
+**
+**  This is an unsafe helper function, for use in functions installed as
+**  handlers in 'MakeImmutableObjFuncs' for internal objects tracking their
+**  mutability, i.e., in the range FIRST_IMM_MUT_TNUM to LAST_IMM_MUT_TNUM.
+**  It only modifies the TNUM, and does not make subobjects immutable.
+*/
+static inline void MakeImmutableNoRecurse(Obj obj)
+{
+    UInt type = TNUM_OBJ(obj);
+    GAP_ASSERT((FIRST_IMM_MUT_TNUM <= type) && (type <= LAST_IMM_MUT_TNUM));
+    RetypeBag(obj, type | IMMUTABLE);
+}
+
+
 /****************************************************************************
 **
 *F  CheckedMakeImmutable( <obj> )  . . . . . . . . . make an object immutable

--- a/src/plist.c
+++ b/src/plist.c
@@ -919,12 +919,9 @@ Obj CopyPlist (
     GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make a copy                                                         */
-    if ( mut ) {
-        copy = NewBag( TNUM_OBJ(list), SIZE_OBJ(list) );
-    }
-    else {
-        copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
-    }
+    copy = NewBag(TNUM_OBJ(list), SIZE_OBJ(list));
+    if (!mut)
+        MakeImmutableNoRecurse(copy);
     ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(list)[0];
 
     /* leave a forwarding pointer                                          */
@@ -2584,7 +2581,7 @@ void MakeImmutablePlistInHom(Obj list)
 {
     // change the tnum first, to avoid infinite recursion for objects that
     // contain themselves
-    RetypeBag(list, IMMUTABLE_TNUM(TNUM_OBJ(list)));
+    MakeImmutableNoRecurse(list);
 
     // FIXME HPC-GAP: there is a potential race here: <list> becomes public
     // the moment we change its type, but it's not ready for public access
@@ -2611,7 +2608,7 @@ void MakeImmutablePlistInHom(Obj list)
 
 void MakeImmutablePlistNoMutElms( Obj list )
 {
-  RetypeBag( list, IMMUTABLE_TNUM(TNUM_OBJ(list)));
+    MakeImmutableNoRecurse(list);
 }
 
 /****************************************************************************

--- a/src/precord.c
+++ b/src/precord.c
@@ -175,12 +175,9 @@ Obj CopyPRec (
     GAP_ASSERT(IS_MUTABLE_OBJ(rec));
 
     /* make a copy                                                     */
-    if ( mut ) {
-        copy = NewBag( TNUM_OBJ(rec), SIZE_OBJ(rec) );
-    }
-    else {
-        copy = NewBag( IMMUTABLE_TNUM(TNUM_OBJ(rec)), SIZE_OBJ(rec) );
-    }
+    copy = NewBag(T_PREC, SIZE_OBJ(rec));
+    if (!mut)
+        MakeImmutableNoRecurse(copy);
     memcpy(ADDR_OBJ(copy), CONST_ADDR_OBJ(rec), SIZE_OBJ(rec));
 
     // leave a forwarding pointer
@@ -224,7 +221,7 @@ void MakeImmutablePRec(Obj rec)
 {
     // change the tnum first, to avoid infinite recursion for objects that
     // contain themselves
-    RetypeBag(rec, IMMUTABLE_TNUM(TNUM_OBJ(rec)));
+    MakeImmutableNoRecurse(rec);
 
     // FIXME HPC-GAP: there is a potential race here: <rec> becomes public
     // the moment we change its type, but it's not ready for public access

--- a/src/range.c
+++ b/src/range.c
@@ -123,12 +123,9 @@ Obj CopyRange (
     GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make a copy                                                         */
-    if ( mut ) {
-        copy = NewBag( TNUM_OBJ(list), SIZE_OBJ(list) );
-    }
-    else {
-        copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
-    }
+    copy = NewBag(TNUM_OBJ(list), SIZE_OBJ(list));
+    if (!mut)
+        MakeImmutableNoRecurse(copy);
     ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(list)[0];
 
     /* leave a forwarding pointer                                          */
@@ -863,7 +860,7 @@ Obj FuncIS_RANGE_REP (
 
 void MakeImmutableRange( Obj range )
 {
-  RetypeBag( range, IMMUTABLE_TNUM(TNUM_OBJ(range)));
+    MakeImmutableNoRecurse(range);
 }
 
 /****************************************************************************

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -545,12 +545,9 @@ Obj CopyString (
     GAP_ASSERT(IS_MUTABLE_OBJ(list));
 
     /* make object for  copy                                               */
-    if ( mut ) {
-        copy = NewBag( TNUM_OBJ(list), SIZE_OBJ(list) );
-    }
-    else {
-        copy = NewBag( IMMUTABLE_TNUM( TNUM_OBJ(list) ), SIZE_OBJ(list) );
-    }
+    copy = NewBag(TNUM_OBJ(list), SIZE_OBJ(list));
+    if (!mut)
+        MakeImmutableNoRecurse(copy);
     ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(list)[0];
 
     /* leave a forwarding pointer                                          */

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -351,7 +351,7 @@ extern Int IsStringConv (
 */
 static inline void MakeImmutableString(Obj str)
 {
-    RetypeBag(str, IMMUTABLE_TNUM(TNUM_OBJ(str)));
+    MakeImmutableNoRecurse(str);
 }
 
 

--- a/src/trans.c
+++ b/src/trans.c
@@ -457,12 +457,8 @@ Obj FuncTRANS_IMG_KER_NC(Obj self, Obj img, Obj ker)
     if (!IS_PLIST(copy_ker)) {
         PLAIN_LIST(copy_ker);
     }
-    if (IS_MUTABLE_OBJ(copy_img)) {
-        RetypeBag(copy_img, TNUM_OBJ(copy_img) + IMMUTABLE);
-    }
-    if (IS_MUTABLE_OBJ(copy_ker)) {
-        RetypeBag(copy_ker, TNUM_OBJ(copy_ker) + IMMUTABLE);
-    }
+    MakeImmutableNoRecurse(copy_img);
+    MakeImmutableNoRecurse(copy_ker);
 
     deg = LEN_LIST(copy_ker);
 
@@ -515,12 +511,8 @@ Obj FuncIDEM_IMG_KER_NC(Obj self, Obj img, Obj ker)
     if (!IS_PLIST(copy_ker)) {
         PLAIN_LIST(copy_ker);
     }
-    if (IS_MUTABLE_OBJ(copy_img)) {
-        RetypeBag(copy_img, TNUM_OBJ(copy_img) + IMMUTABLE);
-    }
-    if (IS_MUTABLE_OBJ(copy_ker)) {
-        RetypeBag(copy_ker, TNUM_OBJ(copy_ker) + IMMUTABLE);
-    }
+    MakeImmutableNoRecurse(copy_img);
+    MakeImmutableNoRecurse(copy_ker);
 
     deg = LEN_LIST(copy_ker);
     rank = LEN_LIST(copy_img);


### PR DESCRIPTION
This used to be part of PR #3015. Compared to that, I've added a comment to `MakeImmutableNoRecurse`, and changed it to GAP_ASSERT on "unsupported" TNUMs.