### PR TITLE
Add ConjugacyClassesForSolvableGroup

### DIFF
--- a/lib/clas.gd
+++ b/lib/clas.gd
@@ -250,6 +250,9 @@ DeclareGlobalFunction( "ConjugacyClassesByOrbits" );
 # `noaction' option is not set, otherwise it returns `fail'.
 DeclareGlobalFunction( "ConjugacyClassesForSmallGroup" );
 
+DeclareGlobalFunction( "ConjugacyClassesForSolvableGroup" );
+
+
 #############################################################################
 ##
 #F  ConjugacyClassesByHomomorphicImage( <G>, <hom> )

--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -433,40 +433,33 @@ InstallGlobalFunction(ConjugacyClassesForSmallGroup,function(G)
   fi;
 end);
 
+InstallGlobalFunction( ConjugacyClassesForSolvableGroup,
+  function( G )
+  local   cls,  cl,  c;
 
-InstallMethod( ConjugacyClasses, "for groups: try random search",
+  cls := [  ];
+  for cl  in ClassesSolvableGroup( G, 0 )  do
+    c := ConjugacyClass( G, cl.representative, cl.centralizer );
+    Assert(2,Centralizer(G,cl.representative)=cl.centralizer);
+    Add( cls, c );
+  od;
+  Assert(1,Sum(cls,Size)=Size(G));
+  return cls;
+end );
+
+InstallMethod( ConjugacyClasses, "for groups: try solvable method and random search",
   [ IsGroup and IsFinite ],
 function(G)
 local cl;
   cl:=ConjugacyClassesForSmallGroup(G);
   if cl<>fail then
     return cl;
+  elif IsSolvableGroup( G ) and CanEasilyComputePcgs(G) then
+    return ConjugacyClassesForSolvableGroup(G);
   else
     return ConjugacyClassesByRandomSearch(G);
   fi;
 end);
-
-InstallMethod( ConjugacyClasses, "try solvable method",
-    [ IsGroup and IsFinite ],
-    function( G )
-    local   cls,  cl,  c;
-
-  cl:=ConjugacyClassesForSmallGroup(G);
-  if cl<>fail then
-    return cl;
-  elif IsSolvableGroup( G ) and CanEasilyComputePcgs(G) then
-      cls := [  ];
-      for cl  in ClassesSolvableGroup( G, 0 )  do
-	  c := ConjugacyClass( G, cl.representative, cl.centralizer );
-	  Assert(2,Centralizer(G,cl.representative)=cl.centralizer);
-	  Add( cls, c );
-      od;
-      Assert(1,Sum(cls,Size)=Size(G));
-      return cls;
-  else
-      TryNextMethod();
-  fi;
-end );
 
 #############################################################################
 ##

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -3061,6 +3061,8 @@ local cl;
   cl:=ConjugacyClassesForSmallGroup(G);
   if cl<>fail then
     return cl;
+  elif IsSolvableGroup( G ) and CanEasilyComputePcgs(G) then
+    return ConjugacyClassesForSolvableGroup(G);
   elif IsSimpleGroup( G ) then
     cl:=ClassesFromClassical(G);
     if cl=fail then


### PR DESCRIPTION
.. and use it in two ConjugacyClasses methods: the generic one
for finite groups, and the one for permutation groups. Also merge
the two existing "generic" methods for finite groups (they had the
same rank, which is rather brittle).

This speeds up the computation of ConjugacyClasses for e.g.

    G:=WreathProduct(CyclicGroup(IsPermGroup,12), DihedralGroup(IsPermGroup,12));

from 110 seconds to 53 seconds on my laptop.