### PR TITLE
Fix RankOfPartialPermSemigroup for groups

### DIFF
--- a/lib/semipperm.gi
+++ b/lib/semipperm.gi
@@ -94,17 +94,17 @@ InstallMethod(CodegreeOfPartialPermSemigroup,
 s-> DegreeOfPartialPermSemigroup(s));
 
 InstallMethod(RankOfPartialPermSemigroup,
-"for a partial perm semigroup",
+"for a partial perm semigroup with generators of semigroup",
 [IsPartialPermSemigroup and HasGeneratorsOfSemigroup],
 S -> RankOfPartialPermCollection(GeneratorsOfSemigroup(S)));
 
 InstallMethod(RankOfPartialPermSemigroup,
-"for a partial perm semigroup",
-[IsPartialPermSemigroup and HasGeneratorsOfGroup],
-S -> RankOfPartialPermCollection(GeneratorsOfGroup(S)));
+"for a partial perm monoid",
+[IsPartialPermMonoid],
+S -> RankOfPartialPerm(One(S)));
 
 InstallMethod(RankOfPartialPermCollection,
-"for a partial perm semigroup",
+"for a partial perm semigroup with generators of semigroup",
 [IsPartialPermSemigroup and HasGeneratorsOfSemigroup],
 s-> RankOfPartialPermCollection(GeneratorsOfSemigroup(s)));
 

--- a/tst/testinstall/semipperm.tst
+++ b/tst/testinstall/semipperm.tst
@@ -87,6 +87,9 @@ gap> RankOfPartialPermSemigroup(S);
 gap> S := Group(PartialPerm([]));;
 gap> RankOfPartialPermSemigroup(S);
 0
+gap> S := Group([], PartialPerm([1, 2]));;
+gap> RankOfPartialPermSemigroup(S);
+2
 
 # Test Domain/ImageOfPartialPermCollection/Semigroup
 gap> S := Semigroup(PartialPerm([1, 2, 3], [4, 5, 11]), 


### PR DESCRIPTION
Previously, `RankOfPartialPermSemigroup` for a group of partial permutations would give an unexpected error if the `GeneratorsOfGroup` were empty (it delegated to `RankOfPartialPermCollection(GeneratorsOfGroup(G))`). A simpler things to do for groups, and for monoids actually, is to call `RankOfPartialPerm(One(G))`.

Resolves #3037.