### PR TITLE
Fix rewriteToFile handling with #@if

### DIFF
--- a/tst/testinstall/restrictedperm.tst
+++ b/tst/testinstall/restrictedperm.tst
@@ -11,10 +11,11 @@ Error, <g> must be a permutation and <D> a plain list or range,
 gap> RestrictedPerm((),[ 1, 0 ]);
 Error, <g> must be a permutation and <D> a plain list or range,
    consisting of a union of cycles of <g>
-gap> RestrictedPerm((1,2^40),[ 1, () ]);
 #@if 8*GAPInfo.BytesPerVariable = 64
+gap> RestrictedPerm((1,2^40),[ 1, () ]);
 Error, Permutation literal exceeds maximum permutation degree
 #@else
+gap> RestrictedPerm((1,2^40),[ 1, () ]);
 Error, Permutation: <expr> must be a positive small integer (not a large posit\
 ive integer)
 #@fi


### PR DESCRIPTION
This limits #@if / #@else / #@endif to only appear between tests (just before a 'gap>', or at the end of the file). This makes it easy to support rewriteToFile (which is also fixed).