### PR TITLE
buildsys: always generate sysinfo.gap

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -658,15 +658,6 @@ distclean-extern:
 	rm -rf extern/install
 
 
-########################################################################
-# Compatibility mode
-#
-# If enabled, we prepare the environment to look like it did with
-# the old build system, thus enabling existing packages with kernel
-# extensions to be compiled against this version of GAP/
-########################################################################
-ifeq ($(COMPAT_MODE),yes)
-
 # regenerate sysinfo.gap if necessary
 all: sysinfo.gap
 sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS cnf/GAP-CXXFLAGS cnf/GAP-LDFLAGS cnf/GAP-LIBS
@@ -693,6 +684,16 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 	@echo "GAP_OBJS=\"$(OBJS)\"" >> $@
 	@echo "" >> $@
 	@echo "JULIA=\"$(JULIA)\"" >> $@
+
+
+########################################################################
+# Compatibility mode
+#
+# If enabled, we prepare the environment to look like it did with
+# the old build system, thus enabling existing packages with kernel
+# extensions to be compiled against this version of GAP/
+########################################################################
+ifeq ($(COMPAT_MODE),yes)
 
 # regenerate bin/gap.sh if necessary
 all: bin/gap.sh


### PR DESCRIPTION
By accident, sysinfo.gap was only generated if the "compatibility mode"
of the build system was enabled. This is currently still on by default,
but I'd like to change that in a future release of GAP. This is a first
step towards this goal.

This PR was actually motivated by the build issue with `NormalizInterface` in @stevelinton's PR #2997 -- while looking at it, I noticed that compat mode still is on, and I never formulated a roadmap for phasing it out.

I'd like to backport this minor change to GAP 4.10, if nobody minds.