### PR TITLE
Add support for writing to ERROR_OUTPUT from kernel code

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -33,12 +33,48 @@
 
 
 static Obj ErrorInner;
+static Obj ERROR_OUTPUT = NULL;
 
 
 /****************************************************************************
 **
 *F * * * * * * * * * * * * * * error functions * * * * * * * * * * * * * * *
 */
+
+/****************************************************************************
+**
+*F  OpenErrorOutput()  . . . . . . . open the file or stream assigned to the
+**                                   ERROR_OUTPUT global variable defined in
+**                                   error.g, or "*errout*" otherwise
+*/
+UInt OpenErrorOutput( void )
+{
+    /* Try to print the output to stream. Use *errout* as a fallback. */
+    UInt ret = 0;
+
+    if (ERROR_OUTPUT != NULL) {
+        if (IsStringConv(ERROR_OUTPUT)) {
+            ret = OpenOutput(CONST_CSTR_STRING(ERROR_OUTPUT));
+        }
+        else {
+            ret = OpenOutputStream(ERROR_OUTPUT);
+        }
+    }
+
+    if (!ret) {
+        /* It may be we already tried and failed to open *errout* above but
+         * but this is an extreme case so it can't hurt to try again
+         * anyways */
+        if ((ret = OpenOutput("*errout*"))) {
+            Pr("failed to open error stream\n", 0, 0);
+        }
+        else {
+            Panic("failed to open *errout*");
+        }
+    }
+
+    return ret;
+}
 
 
 /****************************************************************************
@@ -581,6 +617,7 @@ static Int InitKernel(StructInitInfo * module)
     InitHdlrFuncsFromTable(GVarFuncs);
 
     ImportFuncFromLibrary("ErrorInner", &ErrorInner);
+    ImportGVarFromLibrary("ERROR_OUTPUT", &ERROR_OUTPUT);
 
     // return success
     return 0;

--- a/src/error.c
+++ b/src/error.c
@@ -65,7 +65,8 @@ UInt OpenErrorOutput( void )
         /* It may be we already tried and failed to open *errout* above but
          * but this is an extreme case so it can't hurt to try again
          * anyways */
-        if ((ret = OpenOutput("*errout*"))) {
+        ret = OpenOutput("*errout*");
+        if (ret) {
             Pr("failed to open error stream\n", 0, 0);
         }
         else {

--- a/src/error.c
+++ b/src/error.c
@@ -34,6 +34,7 @@
 
 static Obj ErrorInner;
 static Obj ERROR_OUTPUT = NULL;
+static Obj IsOutputStream;
 
 
 /****************************************************************************
@@ -57,7 +58,9 @@ UInt OpenErrorOutput( void )
             ret = OpenOutput(CONST_CSTR_STRING(ERROR_OUTPUT));
         }
         else {
-            ret = OpenOutputStream(ERROR_OUTPUT);
+            if (CALL_1ARGS(IsOutputStream, ERROR_OUTPUT) == True) {
+                ret = OpenOutputStream(ERROR_OUTPUT);
+            }
         }
     }
 
@@ -618,6 +621,7 @@ static Int InitKernel(StructInitInfo * module)
     InitHdlrFuncsFromTable(GVarFuncs);
 
     ImportFuncFromLibrary("ErrorInner", &ErrorInner);
+    ImportFuncFromLibrary("IsOutputStream", &IsOutputStream);
     ImportGVarFromLibrary("ERROR_OUTPUT", &ERROR_OUTPUT);
 
     // return success

--- a/src/error.h
+++ b/src/error.h
@@ -33,6 +33,14 @@ Int RegisterBreakloopObserver(intfunc func);
 
 /****************************************************************************
 **
+*F  OpenErrorOutput()  . . . . . . . open the file or stream assigned to the
+**                                   ERROR_OUTPUT global variable defined in
+**                                   error.g, or "*errout*" otherwise
+*/
+extern UInt OpenErrorOutput();
+
+/****************************************************************************
+**
 *F  ErrorQuit( <msg>, <arg1>, <arg2> )  . . . . . . . . . . .  print and quit
 */
 extern void ErrorQuit(const Char * msg, Int arg1, Int arg2) NORETURN;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -16,6 +16,7 @@
 
 #include "scanner.h"
 
+#include "error.h"
 #include "gapstate.h"
 #include "gaputils.h"
 #include "io.h"
@@ -42,7 +43,7 @@ static void SyntaxErrorOrWarning(const Char * msg, UInt error)
     if (STATE(NrErrLine) == 0) {
 
         // open error output
-        OpenOutput("*errout*");
+        OpenErrorOutput();
 
         // print the message ...
         if (error)


### PR DESCRIPTION
#2824 added a global variable called `ERROR_OUTPUT` to `lib/error.g`, which can be manipulated to control the file/stream that error output is sent to by the error library.  This works for most cases; however, code in the kernel that outputs error messages ought also to write to whatever `ERROR_OUTPUT` points to, rather than defaulting to `"*errout*".

The one case I found this to be an issue was in printing syntax errors, though there may be other cases.

This is my first attempt to work around it, and my first addition of new code to GAP, so please be kind--I've tried my best to observe and follow local conventions, etc.

One problem with this PR I'm aware of currently is that when using `ImportGVarFromLibrary`, it sets that global variable as read-only by default, which was not previously the case for `ERROR_OUTPUT`.  I'm not exactly sure why it does this, as it is still possible to set the variable read-write afterwards.  This may be a good change though. It would prevent accidental clobbering of `ERROR_OUTPUT`: In order to change it you really have to mean it.  I've seen this pattern in use in a couple of packages when overriding `ErrorInner` as well, so there is precedent for it.  But I don't know whether or not that's considered an anti-pattern.