### PR TITLE
Revert "test: shorten domain.tst to accommodate Semigroups"

### DIFF
--- a/tst/testinstall/domain.tst
+++ b/tst/testinstall/domain.tst
@@ -18,10 +18,8 @@ gap> M = I;
 false
 gap> I = J;
 false
-
-# TODO: Reinstate a version that is compatible with the Semigroups package
-#gap> M = J;
-#Error, no method found for comparing two infinite domains
+gap> M = J;
+Error, no method found for comparing two infinite domains
 
 #
 gap> STOP_TEST("domain.tst");


### PR DESCRIPTION
This reverts commit 06e07de68f919431b67bdee1c521f0c7b3abf08b from PR #2797.

There was a test in `testinstall/domain.tst` that was not compatible with the Semigroups package. This was resolved back in Semigroups 3.0.18, so this test can be reinstated.