### PR TITLE
Preserve more properties in DirectProduct

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -28,7 +28,9 @@ local d, prop;
 
   # test/set a few properties and attributes from factors
 
-  for prop in [IsFinite, IsNilpotentGroup, IsAbelian, IsSolvableGroup] do
+  for prop in [IsFinite, IsNilpotentGroup, IsAbelian, IsSolvableGroup, IsBand,
+               IsInverseSemigroup, IsRegularSemigroup, IsIdempotentGenerated,
+               IsLeftZeroSemigroup, IsRightZeroSemigroup, IsZeroSemigroup] do
     if ForAll(arg, Tester(prop)) then
       Setter(prop)(d, ForAll(arg, prop));
     fi;

--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -31,8 +31,10 @@ local d, prop;
   for prop in [IsFinite, IsNilpotentGroup, IsAbelian, IsSolvableGroup, IsBand,
                IsInverseSemigroup, IsRegularSemigroup, IsIdempotentGenerated,
                IsLeftZeroSemigroup, IsRightZeroSemigroup, IsZeroSemigroup] do
-    if ForAll(arg, Tester(prop)) then
-      Setter(prop)(d, ForAll(arg, prop));
+    if ForAny(arg, x -> Tester(prop)(x) and not prop(x)) then
+      Setter(prop)(d, false);
+    elif ForAll(arg, x -> Tester(prop)(x) and prop(x)) then
+      Setter(prop)(d, true);
     fi;
   od;
     

--- a/tst/testinstall/gprd.tst
+++ b/tst/testinstall/gprd.tst
@@ -1,0 +1,53 @@
+#############################################################################
+##
+#W  gprd.tst                   GAP library                Wilf A. Wilson
+##
+##
+#Y  Copyright (C)  2018, The GAP Group
+##
+#@local g1,g2,g3,d1,d2,d3,d4
+gap> START_TEST("gprd.tst");
+
+# Test that information about IsNilpotentGroup is preserved by DirectProduct
+gap> g1 := SymmetricGroup(3);;
+gap> IsNilpotentGroup(g1);
+false
+gap> g2 := CyclicGroup(IsPermGroup, 6);;
+gap> IsNilpotentGroup(g2);
+true
+gap> d1 := DirectProduct(g1, g1);;
+gap> HasIsNilpotentGroup(d1) and not IsNilpotentGroup(d1);
+true
+gap> d2 := DirectProduct(g1, g2);;
+gap> HasIsNilpotentGroup(d2) and not IsNilpotentGroup(d2);
+true
+gap> d3 := DirectProduct(g2, g2);;
+gap> HasIsNilpotentGroup(d3) and IsNilpotentGroup(d3);
+true
+gap> g3 := Group([(1,2), (1,2,3)]);;
+gap> d4 := DirectProduct(g3, g3, g3);;
+gap> (HasIsNilpotentGroup(g3) and HasIsNilpotentGroup(d4)
+> and not IsNilpotentGroup(d4)) or (not HasIsNilpotentGroup(g3) and not
+> HasIsNilpotentGroup(d4));
+true
+
+# Test that information about IsFinite is preserved by DirectProduct
+gap> g1 := SymmetricGroup(3);;
+gap> HasIsFinite(g1) and IsFinite(g1);
+true
+gap> g2 := FreeGroup(1);;
+gap> IsFinite(g2);
+false
+gap> d1 := DirectProduct(g1, g1);;
+gap> HasIsFinite(d1) and IsFinite(d1);
+true
+gap> d2 := DirectProduct(g1, g2);;
+gap> HasIsFinite(d2) and not IsFinite(d2);
+true
+gap> d3 := DirectProduct(g2, g2);;
+gap> HasIsFinite(d3) and not IsFinite(d3);
+true
+
+#
+gap> STOP_TEST("gprd.tst");
+

--- a/tst/testinstall/gprd.tst
+++ b/tst/testinstall/gprd.tst
@@ -47,6 +47,10 @@ true
 gap> d3 := DirectProduct(g2, g2);;
 gap> HasIsFinite(d3) and not IsFinite(d3);
 true
+gap> g3 := SymmetricGroup(5);;
+gap> d4 := DirectProduct(g1, g2, g3);;
+gap> HasIsFinite(d4) and not IsFinite(d4);
+true
 
 #
 gap> STOP_TEST("gprd.tst");


### PR DESCRIPTION
The soon-to-be-released Semigroups 3.1.0 is going to prove much greater support for creating direct products of semigroups. It does this by installing methods for `DirectProductOp` for certain kinds of semigroups, which uses the `DirectProduct` function in the GAP library. When this library function has created a direct product, it tries to see whether it can set some properties that are preserved by direct products and that are known for the factors. So I thought it made sense to increase this list of properties for when the arguments are semigroups.

What do people think? Is this going to slow things down noticeably for groups, where all of these properties are irrelevant? Is there a better way of doing this? Or is it a bad idea?