### PR TITLE
Reference manual tweaks and fixes

### DIFF
--- a/doc/changes/changes-4.10.xml
+++ b/doc/changes/changes-4.10.xml
@@ -5,9 +5,7 @@ This chapter contains an overview of the most important changes
 introduced in &GAP; 4.10.0 release (the first public release of &GAP; 4.10).
 Later it will also contain information about subsequent update 
 releases for &GAP; 4.10.
-<P/>
-
-These changes are also listed on the Wiki page
+These changes are also listed on the Wiki page:<P/>
 <URL>https://github.com/gap-system/GAP/wiki/gap-4.10-release-notes</URL>.
 
 <Section Label="GAP4.10.0">
@@ -203,7 +201,8 @@ Relevant pull requests:
 
 </Item>
 <Item><URL><LinkText>&Hash;2136</LinkText><Link>https://github.com/gap-system/gap/pull/2136</Link></URL>
-      Add <C>shortname</C> entry to record returned by <C>IsomorphismTypeInfoFiniteSimpleGroup</C>
+  Add a <C>shortname</C> component to the record that is returned by
+  the attribute <C>IsomorphismTypeInfoFiniteSimpleGroup</C>
 </Item>
 <Item><URL><LinkText>&Hash;2181</LinkText><Link>https://github.com/gap-system/gap/pull/2181</Link></URL>
       Implement <C>Union(X,Y)</C>, where <C>X</C> and <C>Y</C> are in

--- a/doc/changes/changes45.xml
+++ b/doc/changes/changes45.xml
@@ -428,7 +428,7 @@ or x86_64 compatible processors provided by Frank Lübeck, see
 <Item>
 <Package>BOB</Package>, a tool for Linux and Mac OS X to download and build 
 &GAP; and its packages from source provided by M. Neunhöffer:
-<URL>http://www-groups.mcs.st-and.ac.uk/~neunhoef/Computer/Software/Gap/bob.html</URL>.
+<URL>https://gap-system.github.io/bob</URL>.
 </Item>
 
 <Item>

--- a/doc/changes/changes49.xml
+++ b/doc/changes/changes49.xml
@@ -5,9 +5,7 @@ This chapter contains an overview of the most important changes
 introduced in &GAP; 4.9.1 release (the 1st public release of &GAP; 4.9).
 Later it will also contain information about subsequent update 
 releases for &GAP; 4.9.
-<P/>
-
-These changes are also listed on the Wiki page
+These changes are also listed on the Wiki page:<P/>
 <URL>https://github.com/gap-system/GAP/wiki/gap-4.9-release-notes</URL>.
 
 <Section Label="GAP491">

--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -3666,7 +3666,7 @@
   <publisher>AMS</publisher>
   <year>1995</year>
   <number>556</number>
-  <note>vol. 116</note>
+  <volume>116</volume>
   <crossref>NPbook95</crossref>
   <issn>0065-9266</issn>
   <mrnumber>1265024 (95k:20081)</mrnumber>
@@ -4137,7 +4137,7 @@
   <publisher>AMS</publisher>
   <year>1995</year>
   <number>556</number>
-  <note>vol. 116</note>
+  <volume>116</volume>
   <crossref>NPbook95</crossref>
   <issn>0065-9266</issn>
   <mrnumber>1265024 (95k:20081)</mrnumber>

--- a/doc/ref/copyright.xml
+++ b/doc/ref/copyright.xml
@@ -37,7 +37,7 @@ This helps us to keep track of the number of &GAP; users.
 <P/>
 If you publish a mathematical result that was partly obtained using
 &GAP;, please cite &GAP;, just as you would cite another paper that you
-used (see below for sample citation). Also we would appreciate if you
+used (see below for a sample citation). Also we would appreciate if you
 could inform us about such a paper, which we will add to the &GAP;
 <URL Text="bibliography">https://www.gap-system.org/Doc/Bib/bib.html</URL>.
 <P/>

--- a/doc/ref/grppc.xml
+++ b/doc/ref/grppc.xml
@@ -137,8 +137,8 @@ the <E>family pcgs</E>.
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Elements of pc groups">
-<Heading>Elements of pc groups</Heading>
+<Section Label="Elements of Pc groups">
+<Heading>Elements of Pc groups</Heading>
 
 <ManSection>
 <Heading>Comparison of elements of pc groups</Heading>

--- a/doc/ref/grppc.xml
+++ b/doc/ref/grppc.xml
@@ -121,8 +121,8 @@ chapter&nbsp;<Ref Chap="Polycyclic Groups"/>.
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="The family pcgs">
-<Heading>The family pcgs</Heading>
+<Section Label="The Family Pcgs">
+<Heading>The Family Pcgs</Heading>
 
 Clearly, the generators of a power-conjugate presentation of
 a pc group <M>G</M> form a pcgs of the pc group. This pcgs is called
@@ -137,8 +137,8 @@ the <E>family pcgs</E>.
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Elements of Pc groups">
-<Heading>Elements of Pc groups</Heading>
+<Section Label="Elements of Pc Groups">
+<Heading>Elements of Pc Groups</Heading>
 
 <ManSection>
 <Heading>Comparison of elements of pc groups</Heading>
@@ -188,8 +188,8 @@ f2^2*f3*f4
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Pc groups versus fp groups">
-<Heading>Pc groups versus fp groups</Heading>
+<Section Label="Pc Groups versus Fp Groups">
+<Heading>Pc Groups versus Fp Groups</Heading>
 
 In theory pc groups are finitely presented groups.  In practice the
 arithmetic in pc groups is different from the arithmetic in fp

--- a/doc/ref/help.xml
+++ b/doc/ref/help.xml
@@ -292,7 +292,7 @@ in your <F>gap.ini</F> file (see&nbsp;<Ref Sect="sect:gap.ini"/>).
 <Mark><C>"less"</C> or <C>"more"</C></Mark>
 <Item>
   This is the same as <C>"screen"</C> but additionally the user preferences
-  <C>"Pager"</C> and <C>""PagerOptions"</C> are set,
+  <C>"Pager"</C> and <C>"PagerOptions"</C> are set,
   see the section&nbsp;<Ref Sect="The Pager Command"/> for more details.
 </Item>
 </List>

--- a/doc/ref/main.xml
+++ b/doc/ref/main.xml
@@ -42,16 +42,18 @@
     for the core part of the &GAP; system by the &GAP; Group.
     <P/>
     Most parts of this distribution, including the core part of the &GAP; 
-    system are distributed under the terms of the GNU General Public License, 
-    see <URL>http://www.gnu.org/licenses/gpl.html</URL> or the file 
-    <F>GPL</F> in the <F>etc</F> directory of the &GAP; 
+    system are distributed under the terms of the GNU General Public License
+    Version 2,
+    see <URL>http://www.gnu.org/licenses/old-licenses/gpl-2.0.html</URL> or the
+    <F>LICENSE</F> file in the root directory of the &GAP;
     installation.
     <P/>
     More detailed information about copyright and licenses of parts of this
     distribution can be found in Section 
     <Ref Sect="Copyright and License"/> of this manual.
     <P/>
-    &GAP; is developed over a long time and has many authors and contributors.
+    &GAP; has been developed over a long time and has many authors and
+    contributors.
     More detailed information can be found in Section
     <Ref Sect="Authors and Maintainers"/> of this manual.
   </Copyright>

--- a/doc/ref/moreinfo.xml
+++ b/doc/ref/moreinfo.xml
@@ -11,10 +11,8 @@
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 
 Information about &GAP; is best obtained from the &GAP; website
-<P/>
-	<URL>https://www.gap-system.org</URL>
-<P/>
-There you will find, amongst other things
+<URL>https://www.gap-system.org</URL>.
+There you will find, amongst other things:
 <List>
 <Item>
 directions to the sites from which you can download the

--- a/doc/ref/overview.xml
+++ b/doc/ref/overview.xml
@@ -17,14 +17,14 @@ is <E>free of charge</E> (except possibly for the immediate costs of delivering
 it to you), you are <E>free to pass it on</E> within certain limits, and 
 all of the workings of the system are <E>open for you to examine and change</E>.
 Details of these conditions can be found in Section 
-<Ref Chap="Copyright and License" BookName="ref"/>.
+<Ref Sect="Copyright and License" BookName="ref"/>.
 <P/>
 The system is <Q>extensible</Q> in that you can write your own  programs  in
 the &GAP; language, and use them in just the same way  as  the  programs
 which form part of the system  (the  <Q>library</Q>).  Indeed,  we  actively
 support the contribution, refereeing and distribution  of  extensions  to
 the system, in the form of <Q>&GAP; packages</Q>.  Further details of  this
-can be found in chapter <Ref BookName="ref" Chap="Using and Developing GAP Packages"/>,
+can be found in Chapter <Ref BookName="ref" Chap="Using and Developing GAP Packages"/>,
 and on our website.
 <P/>
 Development of &GAP; began at Lehrstuhl D für Mathematik,
@@ -40,8 +40,9 @@ A sign of the further internationalization of the project was the
 Colorado State University, Fort Collins.
 <P/>
 More information on the motivation and development of &GAP; to date,
-can be found on our Web pages in a section entitled <Q>Release history
-and Prefaces</Q>.
+can be found on our website in a section entitled
+<Q>Some History of &GAP;</Q>:
+<URL>https://www.gap-system.org/Doc/History/history.html</URL>.
 <P/>
 For those readers who have used an earlier version of &GAP;, an
 overview of the changes from &GAP;&nbsp;4.4 and a brief 
@@ -56,7 +57,7 @@ a number of packages. The core system consists of four main parts.
     <List>
     <Item>
       automatic dynamic storage management, which the user needn't bother
-      about in his programming;
+      about when programming;
     </Item>
     <Item>
       a   set of  time-critical basic   functions, e.g.   <Q>arithmetic</Q>,
@@ -90,11 +91,12 @@ A much larger <E>library of &GAP; functions</E> that
   implement algebraic and other algorithms.  Since this is written
   entirely in the &GAP; language, the &GAP; language is both the
   main implementation language and the user language of the system.
-  Therefore the user can as easily as the original programmers
+  Therefore a user can, as easily as the original programmers,
   investigate and vary algorithms of the library and add new ones to
-  it, first for own use and eventually for the benefit of all &GAP;
+  it, first for their own use and eventually for the benefit of all &GAP;
   users.
 </Item>
+<!-- Is the following point now out of date? -->
 <Item>
 A <E>library of group theoretical data</E> which contains
   various libraries of groups, including the library of small groups
@@ -128,6 +130,7 @@ recent versions ready for release at this time, new packages and new
 versions may be released at any time and can be easily installed in
 your copy of &GAP;.
 <P/>
+<!-- TODO update this paragraph -->
 With &GAP; there are two packages (the library of ordinary and
 Brauer character tables, and the library of tables of marks) which
 contain functionality developed from parts of the &GAP; core

--- a/doc/ref/pcgs.xml
+++ b/doc/ref/pcgs.xml
@@ -186,7 +186,7 @@ these exponents can be looked up and do not need to be computed.
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Subgroups of Polycyclic Groups - Induced Pcgs">
-<Heading>Subgroups of Polycyclic Groups - Induced Pcgs</Heading>
+<Heading>Subgroups of Polycyclic Groups &ndash; Induced Pcgs</Heading>
 
 Let <A>U</A> be a subgroup of <A>G</A> and let <A>P</A> be a pcgs of <A>G</A> as above such
 that <A>P</A> determines the subnormal series

--- a/doc/ref/pperm.xml
+++ b/doc/ref/pperm.xml
@@ -291,7 +291,7 @@ For example, the category test function for partial permutations is
       consists of integers.  <P/>
       
       This function is the analogue in the context of
-      partial permutations of <Ref Func="Permutation" BookName="ref" 
+      partial permutations of <Ref Func="Permutation"
         Label="for a group, an action domain, etc."/> or 
       <Ref Func="TransformationOp"/>.<P/>
       
@@ -965,7 +965,7 @@ gap> LeftOne(f);
   <Meth Name="One" Arg="f" Label="for a partial perm"/>
   <Returns>A partial permutation.</Returns>
   <Description>
-    As described in <Ref Attr="OneImmutable" BookName="ref"/>,
+    As described in <Ref Attr="OneImmutable"/>,
     <C>One</C> returns the multiplicative neutral element of the partial
     permutation <A>f</A>, which is the identity partial permutation on the
     union of the domain and image of <A>f</A>. Equivalently, the one of
@@ -983,7 +983,7 @@ gap> One(f);
   <Meth Name="MultiplicativeZero" Arg="f" Label="for a partial perm"/>
   <Returns>The empty partial permutation.</Returns>
   <Description>
-    As described in <Ref Attr="MultiplicativeZero" BookName="ref"/>,
+    As described in <Ref Attr="MultiplicativeZero"/>,
     <C>Zero</C> returns the multiplicative zero element of the partial
     permutation <A>f</A>, which is the empty partial permutation. 
     <Example>
@@ -1692,7 +1692,7 @@ false]]></Example>
        <Mark>Partial permutation semigroups</Mark>
        <Item>
          If <A>S</A> is a partial permutation semigroup that does not satisfy
-         <Ref Prop="IsMonoid" BookName="ref"/> but where
+         <Ref Func="IsMonoid"/> but where
          <C>MultiplicativeNeutralElement(<A>S</A>)&lt;>fail</C>, then
          <C>IsomorphismPartialPermMonoid(<A>S</A>)</C> returns an isomorphism
          from <A>S</A> to an inverse monoid of partial permutations.

--- a/doc/ref/preface.xml
+++ b/doc/ref/preface.xml
@@ -16,27 +16,29 @@
 
 Welcome to &GAP;. 
 This is one of three manuals documenting the core part of &GAP;, 
-the other being the <E>&GAP; Tutorial</E>
-<Alt Only="HTML">(see <Ref BookName="tut" Label="Preface"/>)</Alt>.
-and the document called <E><Q>&GAP; - Changes from Earlier Versions</Q></E>
-<Alt Only="HTML">(see <Ref BookName="Changes" Label="Preface"/>)</Alt>.
+the others being the <E>&GAP; Tutorial</E>
+<Alt Only="HTML">(see <Ref BookName="tut" Label="Preface"/>)</Alt>
+and the document called
+<E><Q>&GAP; - Changes from Earlier Versions</Q></E><Alt Only="HTML"> (see
+<Ref BookName="Changes" Label="Preface"/>)</Alt>.
 <P/>
 This preface serves not only to introduce <Q>The &GAP; Reference Manual</Q>, 
 but also as an introduction to the whole system.
 <P/>
 &GAP; stands  for  <E>Groups, Algorithms  and Programming</E>.  The  name was
-chosen to reflect  the aim of  the  system, which  is introduced in  this
+chosen to reflect the original aim of the  system, which  is introduced in  this
 reference manual.  Since  that  choice,  the  system has become   somewhat
 broader,    and  you will  also   find information   about algorithms and
 programming  for other   algebraic structures,   such as semigroups   and
 algebras.
 <P/>
-This manual, the <E>&GAP; reference manual</E> contains the official definitions
+This manual, the <E>&GAP; Reference Manual</E> contains the official definitions
 of &GAP; functions. It should contain all the information needed to 
 use &GAP;, and is not intended to be read cover-to-cover.
 <P/>
-To get started a new user may first look at parts of the <E>&GAP; Tutorial</E> 
-<Alt Only="HTML">(see <Ref BookName="tut" Label="Preface"/>)</Alt>. 
+To get started a new user may first look at parts of the
+<E>&GAP; Tutorial</E><Alt Only="HTML"> (see
+<Ref BookName="tut" Label="Preface"/>)</Alt>. 
 <P/>
 A lot of the functionality of the system and a number of
 contributed extensions are provided as <Q>&GAP; packages</Q>
@@ -72,10 +74,9 @@ provide copyright and licensing information.
 &GAP; is the work of very many people, many of whom still maintain
 parts of the system. A complete list of authors, and an approximation
 to the current list of maintainers can be found on the &GAP;
-World Wide Web site at
+website at
  <URL>https://www.gap-system.org/Contacts/People/authors.html</URL> and 
  <URL>https://www.gap-system.org/Contacts/People/modules.html</URL>.
-
 
 All &GAP; packages have their
 own authors and maintainers. It should however be noted that some
@@ -94,12 +95,13 @@ a refereeing system for modules, and we would note, in particular
 that, although it does not use the standard package interface, the
 library of small groups has been refereed and accepted on exactly the
 same basis as the accepted  packages.
+<!-- TODO update the previous paragraph -->
 <P/>
 We also include with this distribution a
 number of packages which have not (yet) gone through our refereeing
 process. Some may be accepted in the future, in other cases the
 authors have chosen not to submit them.  More information can be found
-on our World Wide Web site 
+on our website 
 (see Section <Ref Sect="Further Information about GAP"/>).
 <P/>
 
@@ -112,7 +114,7 @@ on our World Wide Web site
 		 <Heading>Acknowledgements</Heading>
 
 Very many people have worked on, and contributed to, &GAP; over the
-years since its inception. On our Web site you will find the prefaces
+years since its inception. On our website you will find the prefaces
 to the previous releases, each of which acknowledges people who have
 made special contributions to that release. Even so, it is appropriate
 to mention here Joachim Neubüser whose vision of a free,

--- a/doc/ref/semigrp.xml
+++ b/doc/ref/semigrp.xml
@@ -86,14 +86,14 @@ For documentation on ideals for magmas, see <Ref Func="Magma"/>.
 </Section>
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Congruences for semigroups">
-<Heading>Congruences for semigroups</Heading>
+<Section Label="Congruences on semigroups">
+<Heading>Congruences on semigroups</Heading>
 
 An equivalence or a congruence on a semigroup is the
 equivalence or congruence on the semigroup considered as a magma.
 So, to deal with equivalences and congruences on semigroups,
 magma functions are used.
-For documentation on equivalences and congruences for magmas,
+For documentation on equivalences and congruences on magmas,
 see <Ref Func="Magma"/>.
 
 <#Include Label="IsSemigroupCongruence">

--- a/doc/ref/trans.xml
+++ b/doc/ref/trans.xml
@@ -313,7 +313,7 @@ Transformation( [ 2, 4, 2, 6, 6, 7, 8, 2, 10, 10, 11, 8 ] )
       <P/>
       
       This function is the analogue in the context of transformations of 
-      <Ref Func="Permutation" BookName="ref" 
+      <Ref Func="Permutation"
         Label = "for a group, an action domain, etc."/>.
       <P/>
       
@@ -609,7 +609,7 @@ gap> PermutationOfImage( f );
       </Index>
       returns <C><A>g</A> ^ -1 * <A>f</A> * <A>g</A></C> when
       <A>f</A> is a transformation and <A>g</A> is a permutation
-      <Ref Oper="\^" BookName="ref"/>.  
+      <Ref Oper="\^"/>.  
       This operation requires essentially the same number of steps as
       multiplying a transformation by a permutation, which is
       approximately one third of the number required to first invert

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -2105,8 +2105,8 @@ DeclareGlobalFunction( "SimplexMethod" );
 ##
 ##  <Description>
 ##  <Index>Frobenius Normal Form</Index>
-##  For a matrix <A>A</A> return a matrix <A>P</A> such that
-##  <M><A>A</A>^<A>P</A></M> is in rational canonical form (also called
+##  For a matrix <C>A</C>, return a matrix <C>P</C> such that
+##  <M>A^{P}</M> is in rational canonical form (also called
 ##  Frobenius normal form). The algorithm used is the basic textbook
 ##  version and thus not of optimal complexity.
 ##  <Example><![CDATA[

--- a/lib/transatl.g
+++ b/lib/transatl.g
@@ -5,7 +5,7 @@
 ##
 #Y  Copyright (C) 2005 The GAP Group
 ##
-##  This file contains synonym declarations for function sthat are spelled
+##  This file contains synonym declarations for functions that are spelled
 ##  differently on different sides of the Atlantic, such as
 ##  `Stabilizer/Stabiliser' and `Solvable/Soluble'.
 ##


### PR DESCRIPTION
I have noticed several typos, inconsistencies, and out-of-date pieces of information towards the start of the GAP reference manual (I read the first few 20-30 pages one day), and I've fixed them.

I've also added several TODOs for points where there is obviously out-of-date information that I have not got around to updating (most of these relate to statements about the SmallGrp library, which is now a package). If you're happy with TODOs living in the `.xml` files, and you're happy with the changes, then please go ahead and merge this, because I'm probably not going to do any more of this for a little while.

When I get round to doing more, I can always open another PR.