### PR TITLE
Remove some obsolete code from compiler.c

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2843,13 +2843,7 @@ CVar CompRefLVar (
     CVar                val;            /* value, result                   */
     LVar                lvar;           /* local variable                  */
 
-    /* get the local variable                                              */
-    if ( IS_REFLVAR(expr) ) {
-        lvar = LVAR_REFLVAR(expr);
-    }
-    else {
-        lvar = (LVar)(READ_EXPR(expr, 0));
-    }
+    lvar = LVAR_REFLVAR(expr);
 
     /* emit the code to get the value                                      */
     if ( CompGetUseHVar( lvar ) ) {


### PR DESCRIPTION
This code relates to an obsolete way references to local variables used to be
coded as, which has been removed in 8d2ca938.