### PR TITLE
Backport libgap api to 4.10

### DIFF
--- a/src/integer.h
+++ b/src/integer.h
@@ -146,7 +146,23 @@ extern UInt UInt_ObjInt(Obj i);
 extern Int8 Int8_ObjInt(Obj i);    
 extern UInt8 UInt8_ObjInt(Obj i);    
 
-    
+
+/****************************************************************************
+**
+*F  MakeObjInt(<limbs>, <size>) . . . . . . . . . create a new integer object
+**
+**  Construct an integer object from the limbs at which <limbs> points. The
+**  absolute value of <size> determines the number of limbs. If <size> is
+**  zero, then `INTOBJ_INT(0)` is returned. Otherwise, the sign of the
+**  returned integer object is determined by the sign of <size>.
+**
+**  Note that GAP automatically reduces and normalized the integer object,
+**  i.e., it will discard any leading zeros; and if the integer fits into a
+**  small integer, it will be returned as such.
+*/
+extern Obj MakeObjInt(const UInt * limbs, int size);
+
+
 /****************************************************************************
 **
 **  Reduce and normalize the given large integer object if necessary.

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -2,51 +2,58 @@
 
 #include "libgap-api.h"
 
+#include "ariths.h"
 #include "bool.h"
-#include "opers.h"
 #include "calls.h"
+#include "gap.h"
 #include "gapstate.h"
 #include "gvars.h"
+#include "integer.h"
 #include "lists.h"
+#include "macfloat.h"
+#include "opers.h"
+#include "plist.h"
 #include "streams.h"
 #include "stringobj.h"
+
+
+// BACKPORT for GAP 4.10, which does not have NewPlistFromArray yet
+static inline Obj NewPlistFromArray(const Obj * list, Int length)
+{
+    if (length == 0) {
+        return NEW_PLIST(T_PLIST_EMPTY, 0);
+    }
+
+    Obj o = NEW_PLIST(T_PLIST, length);
+    SET_LEN_PLIST(o, length);
+    memcpy(BASE_PTR_PLIST(o), list, length * sizeof(Obj));
+    return o;
+}
+
 
 //
 // Setup and initialisation
 //
-void GAP_Initialize(int          argc,
-                    char **      argv,
-                    char **      env,
-                    CallbackFunc markBagsCallback,
-                    CallbackFunc errorCallback)
+void GAP_Initialize(int              argc,
+                    char **          argv,
+                    char **          env,
+                    GAP_CallbackFunc markBagsCallback,
+                    GAP_CallbackFunc errorCallback)
 {
     InitializeGap(&argc, argv, env);
     SetExtraMarkFuncBags(markBagsCallback);
     STATE(JumpToCatchCallback) = errorCallback;
+
+    GAP_True = True;
+    GAP_False = False;
+    GAP_Fail = Fail;
 }
 
 
-// Combines GVarName and ValGVar. For a given string, it returns the value
-// of the gvar with name <name>, or NULL if the global variable is not
-// defined.
-Obj GAP_ValueGlobalVariable(const char * name)
-{
-    UInt gvar = GVarName(name);
-    // TODO: GVarName should never return 0?
-    if (gvar != 0) {
-        return ValGVar(gvar);
-    }
-    else {
-        return NULL;
-    }
-}
+////
+//// program evaluation and execution
+////
 
-//
-// Evaluate a string of GAP commands
-//
-// To see an example of how to use this function
-// see tst/testlibgap/basic.c
-//
 Obj GAP_EvalString(const char * cmd)
 {
     Obj instream;
@@ -59,4 +66,292 @@ Obj GAP_EvalString(const char * cmd)
     instream = DoOperation1Args(streamFunc, MakeString(cmd));
     res = READ_ALL_COMMANDS(instream, False, True, viewObjFunc);
     return res;
+}
+
+
+////
+//// variables
+////
+
+Obj GAP_ValueGlobalVariable(const char * name)
+{
+    UInt gvar = GVarName(name);
+    // TODO: GVarName should never return 0?
+    if (gvar != 0) {
+        return ValGVar(gvar);
+    }
+    else {
+        return NULL;
+    }
+}
+
+
+////
+//// arithmetic
+////
+
+int GAP_EQ(Obj a, Obj b)
+{
+    return EQ(a, b);
+}
+
+int GAP_LT(Obj a, Obj b)
+{
+    return LT(a, b);
+}
+
+int GAP_IN(Obj a, Obj b)
+{
+    return IN(a, b);
+}
+
+Obj GAP_SUM(Obj a, Obj b)
+{
+    return SUM(a, b);
+}
+
+Obj GAP_DIFF(Obj a, Obj b)
+{
+    return DIFF(a, b);
+}
+
+Obj GAP_PROD(Obj a, Obj b)
+{
+    return PROD(a, b);
+}
+
+Obj GAP_QUO(Obj a, Obj b)
+{
+    return QUO(a, b);
+}
+
+Obj GAP_LQUO(Obj a, Obj b)
+{
+    return LQUO(a, b);
+}
+
+Obj GAP_POW(Obj a, Obj b)
+{
+    return POW(a, b);
+}
+
+Obj GAP_COMM(Obj a, Obj b)
+{
+    return COMM(a, b);
+}
+
+Obj GAP_MOD(Obj a, Obj b)
+{
+    return MOD(a, b);
+}
+
+
+////
+//// booleans
+////
+
+Obj GAP_True;
+Obj GAP_False;
+Obj GAP_Fail;
+
+
+////
+//// calls
+////
+
+Obj GAP_CallFuncList(Obj func, Obj args)
+{
+    return CallFuncList(func, args);
+}
+
+Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[])
+{
+    Obj result;
+    Obj list;
+
+    if (TNUM_OBJ(func) == T_FUNCTION) {
+
+        // call the function
+        switch (narg) {
+        case 0:
+            result = CALL_0ARGS(func);
+            break;
+        case 1:
+            result = CALL_1ARGS(func, args[0]);
+            break;
+        case 2:
+            result = CALL_2ARGS(func, args[0], args[1]);
+            break;
+        case 3:
+            result = CALL_3ARGS(func, args[0], args[1], args[2]);
+            break;
+        case 4:
+            result = CALL_4ARGS(func, args[0], args[1], args[2], args[3]);
+            break;
+        case 5:
+            result =
+                CALL_5ARGS(func, args[0], args[1], args[2], args[3], args[4]);
+            break;
+        case 6:
+            result = CALL_6ARGS(func, args[0], args[1], args[2], args[3],
+                                args[4], args[5]);
+            break;
+        default:
+            list = NewPlistFromArray(args, narg);
+            result = CALL_XARGS(func, list);
+        }
+    }
+    else {
+        list = NewPlistFromArray(args, narg);
+        result = DoOperation2Args(CallFuncListOper, func, list);
+    }
+
+    return result;
+}
+
+
+////
+//// floats
+////
+
+Int GAP_IsMacFloat(Obj obj)
+{
+    return IS_MACFLOAT(obj);
+}
+
+double GAP_ValueMacFloat(Obj obj)
+{
+    if (!IS_MACFLOAT(obj)) {
+        ErrorMayQuit("<obj> is not a MacFloat", 0, 0);
+    }
+    return (double)VAL_MACFLOAT(obj);
+}
+
+Obj GAP_NewMacFloat(double x)
+{
+    return NEW_MACFLOAT(x);
+}
+
+
+////
+//// integers
+////
+
+int GAP_IsInt(Obj obj)
+{
+    return obj && IS_INT(obj);
+}
+
+int GAP_IsSmallInt(Obj obj)
+{
+    return obj && IS_INTOBJ(obj);
+}
+
+int GAP_IsLargeInt(Obj obj)
+{
+    return obj && IS_LARGEINT(obj);
+}
+
+Obj GAP_MakeObjInt(const UInt * limbs, Int size)
+{
+    return MakeObjInt(limbs, size);
+}
+
+Int GAP_SizeInt(Obj obj)
+{
+    if (!IS_INT(obj)) {
+        ErrorMayQuit("GAP_SizeInt: <obj> must be an integer (not a %s)",
+                  (Int)TNAM_OBJ(obj), 0);
+    }
+    if (obj == INTOBJ_INT(0))
+        return 0;
+    Int size = (IS_INTOBJ(obj) ? 1 : SIZE_INT(obj));
+    return IS_POS_INT(obj) ? size : -size;
+}
+
+const UInt * GAP_AddrInt(Obj obj)
+{
+    if (obj && IS_LARGEINT(obj))
+        return CONST_ADDR_INT(obj);
+    else
+        return 0;
+}
+
+////
+//// lists
+////
+
+int GAP_IsList(Obj obj)
+{
+    return obj && IS_LIST(obj);
+}
+
+UInt GAP_LenList(Obj obj)
+{
+    return LEN_LIST(obj);
+}
+
+void GAP_AssList(Obj list, UInt pos, Obj val)
+{
+    if (val)
+        ASS_LIST(list, pos, val);
+    else
+        UNB_LIST(list, pos);
+}
+
+Obj GAP_ElmList(Obj list, UInt pos)
+{
+    if (pos == 0)
+        return 0;
+    return ELM0_LIST(list, pos);
+}
+
+Obj GAP_NewPlist(Int capacity)
+{
+    return NEW_PLIST(T_PLIST_EMPTY, capacity);
+}
+
+
+////
+//// strings
+////
+
+int GAP_IsString(Obj obj)
+{
+    return obj && IS_STRING_REP(obj);
+}
+
+UInt GAP_LenString(Obj obj)
+{
+    return GET_LEN_STRING(obj);
+}
+
+Obj GAP_MakeString(const char * string)
+{
+    return MakeString(string);
+}
+
+Obj GAP_MakeImmString(const char * string)
+{
+    return MakeImmString(string);
+}
+
+char * GAP_CSTR_STRING(Obj string)
+{
+    if (!IS_STRING_REP(string))
+        return 0;
+    return CSTR_STRING(string);
+}
+
+Int GAP_ValueOfChar(Obj obj)
+{
+    if (TNUM_OBJ(obj) != T_CHAR) {
+        return -1;
+    }
+    return (Int)CHAR_VALUE(obj);
+}
+
+Obj GAP_CharWithValue(UChar obj)
+{
+    return ObjsChar[obj];
 }

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -1,21 +1,215 @@
-// LibGAP API - API for using GAP as shared library.
+//// LibGAP API - API for using GAP as shared library.
 
 #ifndef LIBGAP_API_H
 #define LIBGAP_API_H
 
-#include "gap.h"
+#include "system.h"
 
-typedef void (*CallbackFunc)(void);
 
-// Initialisation and finalization
+////
+//// Setup and initialisation
+////
 
-void GAP_Initialize(int          argc,
-                    char **      argv,
-                    char **      env,
-                    CallbackFunc markBagsCallback,
-                    CallbackFunc errorCallback);
+typedef void (*GAP_CallbackFunc)(void);
 
-Obj GAP_ValueGlobalVariable(const char * name);
-Obj GAP_EvalString(const char * cmd);
+// TODO: document this function
+extern void GAP_Initialize(int              argc,
+                           char **          argv,
+                           char **          env,
+                           GAP_CallbackFunc markBagsCallback,
+                           GAP_CallbackFunc errorCallback);
+
+
+////
+//// program evaluation and execution
+////
+
+// Evaluate a string of GAP commands
+//
+// To see an example of how to use this function see tst/testlibgap/basic.c
+//
+// TODO: properly document this function
+extern Obj GAP_EvalString(const char * cmd);
+
+
+////
+//// variables
+////
+
+// Combines GVarName and ValGVar. For a given string, it returns the value
+// of the gvar with name <name>, or NULL if the global variable is not
+// defined.
+extern Obj GAP_ValueGlobalVariable(const char * name);
+
+
+////
+//// arithmetic
+////
+
+extern int GAP_EQ(Obj a, Obj b);
+extern int GAP_LT(Obj a, Obj b);
+extern int GAP_IN(Obj a, Obj b);
+
+extern Obj GAP_SUM(Obj a, Obj b);
+extern Obj GAP_DIFF(Obj a, Obj b);
+extern Obj GAP_PROD(Obj a, Obj b);
+extern Obj GAP_QUO(Obj a, Obj b);
+extern Obj GAP_LQUO(Obj a, Obj b);
+extern Obj GAP_POW(Obj a, Obj b);
+extern Obj GAP_COMM(Obj a, Obj b);
+extern Obj GAP_MOD(Obj a, Obj b);
+
+
+////
+//// booleans
+////
+
+extern Obj GAP_True;
+extern Obj GAP_False;
+extern Obj GAP_Fail;
+
+
+////
+//// calls
+////
+
+// Call the GAP object <func> as a function with arguments given
+// as a GAP list <args>.
+extern Obj GAP_CallFuncList(Obj func, Obj args);
+
+// Call the GAP object <func> as a function with arguments given
+// as an array <args> with <narg> entries.
+extern Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[]);
+
+
+////
+//// floats
+////
+
+// Returns 1 if <obj> is a GAP machine float, 0 if not.
+extern Int GAP_IsMacFloat(Obj obj);
+
+// Returns the value of the GAP machine float object <obj>.
+// If <obj> is not a machine float object, an error is raised.
+extern double GAP_ValueMacFloat(Obj obj);
+
+// Returns a new GAP machine float with value <x>.
+extern Obj GAP_NewMacFloat(double x);
+
+
+////
+//// integers
+////
+
+// Returns 1 if <obj> is a GAP integer, 0 if not.
+extern int GAP_IsInt(Obj obj);
+
+// Returns 1 if <obj> is a GAP small (aka immediate) integer, 0 if not.
+extern int GAP_IsSmallInt(Obj obj);
+
+// Returns 1 if <obj> is a GAP large integer, 0 if not.
+extern int GAP_IsLargeInt(Obj obj);
+
+
+// Construct an integer object from the limbs at which <limbs> points (for a
+// definition of "limbs", please consult the comment at the top of
+// `integer.c`). The absolute value of <size> determines the number of limbs.
+// If <size> is zero, then `INTOBJ_INT(0)` is returned. Otherwise, the sign
+// of the returned integer object is determined by the sign of <size>.
+// //
+// Note that GAP automatically reduces and normalized the integer object,
+// i.e., it will discard any leading zeros; and if the integer fits into a
+// small integer, it will be returned as such.
+extern Obj GAP_MakeObjInt(const UInt * limbs, Int size);
+
+// If <obj> is a GAP integer, returns the number of limbs needed to store the
+// integer, times the sign. If <obj> is the integer 0, then 0 is returned. If
+// <obj> is any other small integer, then 1 or -1 is returned, depending on
+// its sign.
+//
+// If <obj> is not a GAP integer, an error is raised.
+extern Int GAP_SizeInt(Obj obj);
+
+// Returns a pointer to the limbs of a the GAP large integer <obj>.
+// If <obj> is not a GAP large integer, then NULL is returned.
+//
+// Note: The pointer returned by this function is only valid until the next
+// GAP garbage collection. In particular, if you use any GAP APIs, then you
+// should assume that the pointer became stale. Barring that, you may safely
+// copy, inspect, or even modify the content of the string buffer.
+extern const UInt * GAP_AddrInt(Obj obj);
+
+
+////
+//// lists
+////
+
+// Returns 1 if <obj> is a GAP list, 0 if not.
+extern int GAP_IsList(Obj obj);
+
+// Returns the length of the given GAP list.
+// If <list> is not a GAP list, an error may be raised.
+extern UInt GAP_LenList(Obj list);
+
+// Assign <val> at position <pos> into the GAP list <list>.
+// If <val> is zero, then this unbinds the list entry.
+// If <list> is not a GAP list, an error may be raised.
+extern void GAP_AssList(Obj list, UInt pos, Obj val);
+
+// Returns the element at the position <pos> in the list <list>.
+// Returns 0 if there is no entry at the given position.
+// Also returns 0 if <pos> is out of bounds, i.e., if <pos> is zero,
+// or larger than the length of the list.
+// If <list> is not a GAP list, an error may be raised.
+extern Obj GAP_ElmList(Obj list, UInt pos);
+
+// Returns a new empty plain list with capacity <capacity>
+extern Obj GAP_NewPlist(Int capacity);
+
+
+////
+//// strings
+////
+
+// Returns 1 if <obj> is a GAP string, 0 if not.
+extern int GAP_IsString(Obj obj);
+
+// Returns the length of the given GAP string.
+// If <string> is not a GAP string, an error may be raised.
+extern UInt GAP_LenString(Obj string);
+
+// Returns a pointer to the contents of the GAP string <string>.
+// Returns 0 if <string> is not a GAP string.
+//
+// Note: GAP strings may contain null bytes, so to copy the full string, you
+// should use `GAP_LenString` to determine its length. GAP always adds an
+// additional terminating null byte.
+//
+// Note: The pointer returned by this function is only valid until the next
+// GAP garbage collection. In particular, if you use any GAP APIs, then you
+// should assume that the pointer became stale. Barring that, you may safely
+// copy, inspect, or even modify the content of the string buffer.
+//
+// Usage example:
+//    Int len = GAP_LenString(string);
+//    char *buf = malloc(len + 1);
+//    memcpy(buf, GAP_CSTR_STRING(string), len + 1); // copy terminator, too
+//    // .. now we can safely use the content of buf
+extern char * GAP_CSTR_STRING(Obj obj);
+
+// Returns a new mutable GAP string containing a copy of the given NULL
+// terminated C string.
+extern Obj GAP_MakeString(const char * string);
+
+// Returns a immutable GAP string containing a copy of the given NULL
+// terminated C string.
+extern Obj GAP_MakeImmString(const char * string);
+
+// Returns the value of the GAP character object <obj>.
+// If <obj> is not a GAP character object, it returns -1.
+extern Int GAP_ValueOfChar(Obj obj);
+
+// Returns the GAP character object with value <obj>.
+extern Obj GAP_CharWithValue(UChar obj);
 
 #endif


### PR DESCRIPTION
This is a backport of all the libgap-api changes done on master, so that these will appear in GAP 4.10.1. I hope this will help folks like @embray who are trying to use this.

Of course we can delay merging this in case people plan to submit more libgap-api changes. Or we just make additional PRs for that.

Note that I had to make some minor modifications to `libgap-api.c`: We don't have `RequireInt` in stable-4.10, nor `NewPlistFromArray`. For the latter, I just added it to `libgap-api.c`; for the former, I replaced the call by (almost) equivalent code using `ErrorMayQuit`. For future updates, one needs to retain those (but that's easy enough).

Note: I did not cherry-pick individual PRs modifying libgap-api, as that would have been more work with no clear gain. Nor did I cherry-pick the commit which added `NewPlistFromArray`, as it also modified several .c files, and while those changes should be harmless, I'd rather go for minimal changes that are guaranteed to not affect code outside `libgap-api.c`.