### PR TITLE
kernel: fix string copying logic

### DIFF
--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -1243,7 +1243,8 @@ Obj CopyToStringRep(
     copy = NEW_STRING(lenString);
 
     if ( IS_STRING_REP(string) ) {
-        memcpy(ADDR_OBJ(copy), CONST_ADDR_OBJ(string), SIZE_OBJ(string));
+        memcpy(CHARS_STRING(copy), CONST_CHARS_STRING(string),
+            GET_LEN_STRING(string));
         /* XXX no error checks? */
     } else {
         /* copy the string to the string representation                     */
@@ -1267,7 +1268,7 @@ Obj CopyToStringRep(
 */
 Obj ImmutableString(Obj string)
 {
-    if (!IS_STRING_REP(string) || !IS_MUTABLE_OBJ(string)) {
+    if (!IS_STRING_REP(string) || IS_MUTABLE_OBJ(string)) {
         string = CopyToStringRep(string);
         MakeImmutableString(string);
     }


### PR DESCRIPTION
This pull request fixes two bugs in `src/stringobj.c`.

1. Calling `CopyToStringRep()` with a string whose length had been shortened by `SET_STR_LEN()` or which for some other reason leaves one or more words at the end unused could overwrite random memory, as `memcpy()` used `SIZE_OBJ()` for its length.
2. Part of the logic in `ImmutableString()` was inverted, copying the string if it was immutable rather than if it was mutable.