### PR TITLE
ci: fast fail AppVeyor and Travis outdated jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,11 @@ install:
 
 # scripts that run after cloning repository
 build_script:
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
   - SET "PATH=%CYG_ROOT%\bin;%PATH%"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./etc/ci-prepare.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ matrix:
 
 script:
   - set -e
-  - gcov --version
+  - etc/travis_fastfail.sh
   - bash etc/ci-prepare.sh
   - bash etc/ci.sh
 

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -4,7 +4,8 @@ set -ex
 
 SRCDIR=${SRCDIR:-$PWD}
 
-# for debugging purposes print the environment and info about the HEAD commit
+# print some data useful for debugging issues with the build
+gcov --version
 printenv | sort
 git show --pretty=fuller -s
 

--- a/etc/travis_fastfail.sh
+++ b/etc/travis_fastfail.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# This file is a lightly modified copy of
+# https://github.com/JuliaLang/julia/blob/master/contrib/travis_fastfail.sh
+# written by Tony Kelman for the Julia project.
+#
+# License is MIT: https://julialang.org/license
+
+curlhdr="Accept: application/vnd.travis-ci.2+json"
+endpoint="https://api.travis-ci.org/repos/$TRAVIS_REPO_SLUG"
+
+# Fail fast for superseded builds to PR's
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  newestbuildforthisPR=$(curl -H "$curlhdr" $endpoint/builds?event_type=pull_request | \
+      jq ".builds | map(select(.pull_request_number == $TRAVIS_PULL_REQUEST))[0].number")
+  if [ $newestbuildforthisPR != null -a $newestbuildforthisPR != \"$TRAVIS_BUILD_NUMBER\" ]; then
+    echo "There are newer queued builds for this pull request, failing early."
+    exit 1
+  fi
+else
+  # And for non-latest push builds in branches other than master or stable*
+  case $TRAVIS_BRANCH in
+    master | stable*)
+      ;;
+    *)
+      if [ \"$TRAVIS_BUILD_NUMBER\" != $(curl -H "$curlhdr" \
+          $endpoint/branches/$TRAVIS_BRANCH | jq ".branch.number") ]; then
+        echo "There are newer queued builds for this branch, failing early."
+        exit 1
+      fi
+      ;;
+  esac
+fi


### PR DESCRIPTION
This code is taken from resp. based on what Julia does.

The etc/travis_fastfail.sh script is run as part of Travis jobs, and
auto-cancels "outdated" jobs for all PR builds, or builds for branches other
than master and stable*.

The difference to Travis' builtin auto-cancel feature is that Travis only
cancels full builds, but not individual jobs. That is, if a job of a build
already started, Travis will not cancel this build, so all jobs of that build
are run. With this PR, all subsequent jobs of an "outdated" build auto-cancel
as they are started.

In the future, perhaps we can rewrite this in Python, to get rid of the
dependency on jq; and perhaps we can also adapt this to work with AppVeyor.