### PR TITLE
ENHANCE: Special redispatch for Nat.Hom.ByNS if group is found out to be finite

### DIFF
--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -1151,6 +1151,9 @@ function(G,N)
   return GenericFindActionKernel(G,N);
 end);
 
+RedispatchOnCondition(FindActionKernel,IsIdenticalObj,[IsGroup,IsGroup],
+  [IsGroup and IsFinite,IsGroup],0);
+
 InstallMethod(FindActionKernel,"general case: can't do",IsIdenticalObj,
   [IsGroup,IsGroup],0,
 function(G,N)
@@ -1400,6 +1403,12 @@ local h;
   fi;
   if h=fail then
     # now we try to find a suitable operation
+
+    # redispatch upon finiteness test, as following will fail in infinite case
+    if not HasIsFinite(G) and IsFinite(G) then
+      return NaturalHomomorphismByNormalSubgroupOp(G,N);
+    fi;
+
     h:=FindActionKernel(G,N);
     if h<>fail then
       Info(InfoFactor,1,"Action of degree ",
@@ -1414,6 +1423,15 @@ local h;
   # return the map
   return h;
 end);
+
+RedispatchOnCondition(NaturalHomomorphismByNormalSubgroupNCOrig,IsIdenticalObj,
+  [IsGroup,IsGroup],[IsGroup and IsFinite,IsGroup],0);
+
+RedispatchOnCondition(NaturalHomomorphismByNormalSubgroupInParent,true,
+  [IsGroup],[IsGroup and IsFinite],0);
+
+RedispatchOnCondition(FactorGroupNC,IsIdenticalObj,
+  [IsGroup,IsGroup],[IsGroup and IsFinite,IsGroup],0);
 
 #############################################################################
 ##

--- a/tst/testbugfix/2018-12-01-Nathom.tst
+++ b/tst/testbugfix/2018-12-01-Nathom.tst
@@ -1,0 +1,5 @@
+# Reported in github PR 3070
+# Degenerate example where the subgroup can be formed without finiteness test (as the group
+# is cyclic).
+gap> G := Group([[[E(3),0,0],[0,E(3),0],[0,0,E(3)]],[[1,0,0],[0,0,1],[0,1,0]]]);;
+gap> FactorGroup(G,Center(G));;


### PR DESCRIPTION
This is needed, as for matrix groups the earlier `NiceMonomorphism` dispatch does not hold.
Test is only done before expesive action search is started, so negligible cost.

Also added redispatches in case the NiceMonomorphism approach is ever removed.

This fixes #3070
