### PR TITLE
Fix NumberFFVector documentation, add an example

### DIFF
--- a/lib/listcoef.gd
+++ b/lib/listcoef.gd
@@ -11,7 +11,7 @@
 #############################################################################
 ##
 ##  <#GAPDoc Label="[1]{listcoef}">
-##  The following operations all perform arithmetic on row vectors.
+##  The following operations all perform arithmetic on row vectors,
 ##  given as homogeneous lists of the same length, containing
 ##  elements of a commutative ring.
 ##  <P/>

--- a/lib/vecmat.gd
+++ b/lib/vecmat.gd
@@ -419,11 +419,23 @@ DeclareOperation( "ImmutableVector",[IsObject,IsRowVector]);
 ##  <Oper Name="NumberFFVector" Arg='vec, sz'/>
 ##
 ##  <Description>
-##  returns an integer that gives the position of the finite field row vector
+##  returns an integer that gives the position minus one of the finite field row vector
 ##  <A>vec</A> in the sorted list of all row vectors over the field with
 ##  <A>sz</A> elements in the same dimension as <A>vec</A>.
 ##  <Ref Func="NumberFFVector"/> returns <K>fail</K> if the vector cannot be
 ##  represented over the field with <A>sz</A> elements.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> v:=[0,1,2,0]*Z(3);;
+##  gap> NumberFFVector(v, 3);
+##  21
+##  gap> NumberFFVector(Zero(v),3);
+##  0
+##  gap> V:=EnumeratorSorted(GF(3)^4);
+##  <enumerator of ( GF(3)^4 )>
+##  gap> V[21+1] = v;
+##  true
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
The documentation of NumberFFVector made it sound as if a value from 1 to q^n is returned, but it really returns a value from 0 to q^n-1.

Also fix another unrelated typo in listcoef.gd.

This could be backported.