### PR TITLE
Add HallSubgroup fallback method

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -3210,6 +3210,22 @@ InstallMethod( HallSubgroupOp,
 
 #############################################################################
 ##
+#M  HallSubgroupOp( <G>, <pi> ) . . . . . . . . . . . . .  for a finite group
+##
+InstallMethod( HallSubgroupOp,
+    "fallback method for a finite group",
+    [ IsGroup and IsFinite, IsList ],
+    function( G, pi )
+    local iso, H;
+
+    iso := IsomorphismPermGroup( G );
+    H := HallSubgroup( ImagesSource( iso ), pi );
+    return PreImagesSet(iso, H);
+    end );
+
+
+#############################################################################
+##
 #M  NormalHallSubgroupsFromSylows( <G> )
 ##
 InstallGlobalFunction( NormalHallSubgroupsFromSylows, function( arg )

--- a/tst/testinstall/opers/HallSubgroup.tst
+++ b/tst/testinstall/opers/HallSubgroup.tst
@@ -16,4 +16,17 @@ gap> G := Group([ [ [ Z(2)^0, 0*Z(2), 0*Z(2) ],
 > [ Z(2)^0, 0*Z(2), 0*Z(2) ] ] ]);;
 gap> List(HallSubgroup(G, [2,3]), IdGroup);
 [ [ 24, 12 ], [ 24, 12 ] ]
+
+#
+gap> G:=PerfectGroup(60,1);
+A5
+gap> IsFpGroup(G);
+true
+gap> H:=HallSubgroup(G,[2,3]);;
+gap> Size(H);
+12
+gap> GeneratorsOfGroup(H);
+[ b, a*b^-1*a*b*a^-1 ]
+
+#
 gap> STOP_TEST("HallSubgroup.tst", 1);


### PR DESCRIPTION
This allows computing Hall subgroups for arbitrary finite groups
via an isomorphism into a permutation group.