### PR TITLE
kernel: cleanup src/integer.{c,h}

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -121,8 +121,8 @@ extern Obj RequireArgument(const char * funcname,
 **
 *F  RequireInt
 */
-#define RequireInt(funcname, op, argname) \
-    RequireArgumentCondition(funcname, op, argname, IS_INT(op), \
+#define RequireInt(funcname, op) \
+    RequireArgumentCondition(funcname, op, #op, IS_INT(op), \
         "must be an integer")
 
 

--- a/src/integer.c
+++ b/src/integer.c
@@ -133,8 +133,6 @@ static Obj ObjInt_UIntInv( UInt i );
 
 #define SIZE_INT_OR_INTOBJ(obj) (IS_INTOBJ(obj) ? 1 : SIZE_INT(obj))
 
-#define REQUIRE_INT_ARG(funcname, argname, op) RequireInt(funcname, op, argname)
-
 #define RequireNonzero(funcname, op, argname) \
     do { \
       if (op == INTOBJ_INT(0) ) { \
@@ -154,9 +152,9 @@ static Obj IsIntFilt;
 
 /****************************************************************************
 **
-*F  TypeInt(<gmp>)  . . . . . . . . . . . . . . . . . . .  type of integer
+*F  TypeInt(<val>) . . . . . . . . . . . . . . . . . . . . .  type of integer
 **
-**  'TypeInt' returns the type of the integer <gmp>.
+**  'TypeInt' returns the type of the integer <val>.
 **
 **  'TypeInt' is the function in 'TypeObjFuncs' for integers.
 */
@@ -218,31 +216,31 @@ Obj FuncIS_INT ( Obj self, Obj val )
 
 /****************************************************************************
 **
-*F  SaveInt( <gmp> )
+*F  SaveInt( <op> )
 **
-**  
+**
 */
-void SaveInt( Obj gmp )
+void SaveInt(Obj op)
 {
-  const UInt *ptr = CONST_ADDR_INT(gmp);
-  for (UInt i = 0; i < SIZE_INT(gmp); i++)
-      SaveUInt(*ptr++);
-  return;
+    const UInt * ptr = CONST_ADDR_INT(op);
+    for (UInt i = 0; i < SIZE_INT(op); i++)
+        SaveUInt(*ptr++);
+    return;
 }
 
 
 /****************************************************************************
 **
-*F  LoadInt( <gmp> )
+*F  LoadInt( <op> )
 **
 **
 */
-void LoadInt( Obj gmp )
+void LoadInt(Obj op)
 {
-  UInt *ptr = ADDR_INT(gmp);
-  for (UInt i = 0; i < SIZE_INT(gmp); i++)
-      *ptr++ = LoadUInt();
-  return;
+    UInt * ptr = ADDR_INT(op);
+    for (UInt i = 0; i < SIZE_INT(op); i++)
+        *ptr++ = LoadUInt();
+    return;
 }
 
 
@@ -386,46 +384,46 @@ static inline void UPDATE_FAKEMPZ( fake_mpz_t fake )
 
 /****************************************************************************
 **
-*F  GMP_NORMALIZE( <gmp> ) . . . . . . .  remove leading zeros from a GMP bag
+*F  GMP_NORMALIZE( <op> ) . . . . . . .  remove leading zeros from a GMP bag
 **
-**  'GMP_NORMALIZE' removes any leading zeros from a <GMP> and returns a
-**  small int or resizes the bag if possible.
-**  
+**  'GMP_NORMALIZE' removes any leading zeros from a large integer object
+**  and returns a small int or resizes the bag if possible.
+**
 */
-Obj GMP_NORMALIZE ( Obj gmp )
+Obj GMP_NORMALIZE(Obj op)
 {
-  mp_size_t size;
-  if (IS_INTOBJ( gmp )) {
-    return gmp;
-  }
-  for ( size = SIZE_INT(gmp); size != (mp_size_t)1; size-- ) {
-    if ( CONST_ADDR_INT(gmp)[(size - 1)] != 0 ) {
-      break;
+    mp_size_t size;
+    if (IS_INTOBJ(op)) {
+        return op;
     }
-  }
-  if ( size < SIZE_INT(gmp) ) {
-    ResizeBag( gmp, size*sizeof(mp_limb_t) );
-  }
-  return gmp;
+    for (size = SIZE_INT(op); size != (mp_size_t)1; size--) {
+        if (CONST_ADDR_INT(op)[(size - 1)] != 0) {
+            break;
+        }
+    }
+    if (size < SIZE_INT(op)) {
+        ResizeBag(op, size * sizeof(mp_limb_t));
+    }
+    return op;
 }
 
-Obj GMP_REDUCE( Obj gmp )
+Obj GMP_REDUCE(Obj op)
 {
-  if (IS_INTOBJ( gmp )) {
-    return gmp;
-  }
-  if ( SIZE_INT(gmp) == 1) {
-    if ( ( VAL_LIMB0(gmp) <= INT_INTOBJ_MAX ) ||
-         ( IS_INTNEG(gmp) && VAL_LIMB0(gmp) == -INT_INTOBJ_MIN ) ) {
-      if ( IS_INTNEG(gmp) ) {
-        return INTOBJ_INT( -(Int)VAL_LIMB0(gmp) );
-      }
-      else {
-        return INTOBJ_INT(  (Int)VAL_LIMB0(gmp) );
-      }
+    if (IS_INTOBJ(op)) {
+        return op;
     }
-  }
-  return gmp;
+    if (SIZE_INT(op) == 1) {
+        if ((VAL_LIMB0(op) <= INT_INTOBJ_MAX) ||
+            (IS_INTNEG(op) && VAL_LIMB0(op) == -INT_INTOBJ_MIN)) {
+            if (IS_INTNEG(op)) {
+                return INTOBJ_INT(-(Int)VAL_LIMB0(op));
+            }
+            else {
+                return INTOBJ_INT((Int)VAL_LIMB0(op));
+            }
+        }
+    }
+    return op;
 }
 
 /****************************************************************************
@@ -468,10 +466,10 @@ int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
   return 1;
 }
 
-  
+
 /****************************************************************************
 **
-*F  ObjInt_Int( <cint> ) . . . . . . . . . . . convert c int to gmp or intobj
+*F  ObjInt_Int( <cint> ) . . . . . . . . . .  convert c int to integer object
 **
 **  'ObjInt_Int' takes the C integer <cint> and returns the equivalent
 **  GMP obj or int obj, according to the value of <cint>.
@@ -720,10 +718,9 @@ static inline UInt AbsOfSmallInt(Obj x)
 
 /****************************************************************************
 **
-*F  PrintInt( <gmp> ) . . . . . . . . . . . . . . . . print a GMP constant
+*F  PrintInt( <op> ) . . . . . . . . . . . . . . . .  print an integer object
 **
-**  'PrintInt' prints the GMP integer <gmp> in the usual decimal
-**  notation.
+**  'PrintInt' prints the integer <op> in the usual decimal notation.
 */
 void PrintInt ( Obj op )
 {
@@ -766,30 +763,30 @@ void PrintInt ( Obj op )
 
 /****************************************************************************
 **
-*F  StringIntBase( <gmp>, <base> )
+*F  StringIntBase( <op>, <base> )
 **
-** Convert the integer <gmp> to a string relative to the given base <base>.
+** Convert the integer <op> to a string relative to the given base <base>.
 ** Here, base may range from 2 to 36.
 */
-static Obj StringIntBase( Obj gmp, int base )
+static Obj StringIntBase(Obj op, int base)
 {
   int len;
   Obj res;
   fake_mpz_t v;
 
-  GAP_ASSERT(IS_INT(gmp));
-  CHECK_INT(gmp);
+  GAP_ASSERT(IS_INT(op));
+  CHECK_INT(op);
   GAP_ASSERT(2 <= base && base <= 36);
 
   /* 0 is special */
-  if ( gmp == INTOBJ_INT(0) ) {
+  if (op == INTOBJ_INT(0)) {
     res = NEW_STRING(1);
     CHARS_STRING(res)[0] = '0';
     return res;
   }
 
   /* convert integer to fake_mpz_t */
-  FAKEMPZ_GMPorINTOBJ( v, gmp );
+  FAKEMPZ_GMPorINTOBJ(v, op);
 
   /* allocate the result string */
   len = mpz_sizeinbase( MPZ_FAKEMPZ(v), base ) + 2;
@@ -809,21 +806,21 @@ static Obj StringIntBase( Obj gmp, int base )
 
 /****************************************************************************
 **
-*F  FuncHexStringInt( <self>, <gmp> ) . . . . . . . .  hex string for gmp int
-*F  FuncIntHexString( <self>, <string> ) . . . . . .  gmp int from hex string
-**  
-**  The  function  `FuncHexStringInt'  constructs from  a gmp integer  the
+*F  FuncHexStringInt( <self>, <n> ) . . . . . . . . .  hex string for GAP int
+*F  FuncIntHexString( <self>, <string> ) . . . . . .  GAP int from hex string
+**
+**  The  function  `FuncHexStringInt'  constructs from  a GAP integer  the
 **  corresponding string in  hexadecimal notation. It has  a leading '-'
 **  for negative numbers and the digits 10..15 are written as A..F.
-**  
+**
 **  The  function `FuncIntHexString'  does  the converse,  but here  the
 **  letters a..f are also allowed in <string> instead of A..F.
 **
 */
-Obj FuncHexStringInt( Obj self, Obj gmp )
+Obj FuncHexStringInt(Obj self, Obj n)
 {
-  REQUIRE_INT_ARG( "HexStringInt", "op", gmp );
-  return StringIntBase( gmp, 16 );
+    RequireInt("HexStringInt", n);
+    return StringIntBase(n, 16);
 }
 
 
@@ -981,22 +978,22 @@ Int CLog2Int(Int a)
 
 /****************************************************************************
 **
-*F  FuncLog2Int( <self>, <gmp> ) . . . . . . . . . .  nr of bits of a GMP - 1
-**  
+*F  FuncLog2Int( <self>, <n> ) . . . . . . . . . . . nr of bits of a GAP int
+**
 **  Given to GAP-Level as "Log2Int".
 */
-Obj FuncLog2Int( Obj self, Obj integer)
+Obj FuncLog2Int(Obj self, Obj n)
 {
-    RequireInt("Log2Int", integer, "n");
+    RequireInt("Log2Int", n);
 
-    if (IS_INTOBJ(integer)) {
-        return INTOBJ_INT(CLog2Int(INT_INTOBJ(integer)));
+    if (IS_INTOBJ(n)) {
+        return INTOBJ_INT(CLog2Int(INT_INTOBJ(n)));
     }
 
-    UInt len = SIZE_INT(integer) - 1;
-    UInt a = CLog2UInt( CONST_ADDR_INT(integer)[len] );
+    UInt len = SIZE_INT(n) - 1;
+    UInt a = CLog2UInt(CONST_ADDR_INT(n)[len]);
 
-    CHECK_INT(integer);
+    CHECK_INT(n);
 
 #ifdef SYS_IS_64_BIT
     return INTOBJ_INT(len * GMP_LIMB_BITS + a);
@@ -1010,16 +1007,15 @@ Obj FuncLog2Int( Obj self, Obj integer)
 
 /****************************************************************************
 **
-*F  FuncSTRING_INT( <self>, <gmp> ) . . . . . . . . convert a GMP to a string
+*F  FuncSTRING_INT( <self>, <n> ) . . . . . .  convert an integer to a string
 **
-**  `FuncSTRING_INT' returns an immutable string representing the integer
-**  <gmp>
+**  `FuncSTRING_INT' returns an immutable string representing the integer <n>
 **
 */
-Obj FuncSTRING_INT( Obj self, Obj integer )
+Obj FuncSTRING_INT(Obj self, Obj n)
 {
-  REQUIRE_INT_ARG( "STRING_INT", "op", integer );
-  return StringIntBase( integer, 10 );
+    RequireInt("STRING_INT", n);
+    return StringIntBase(n, 10);
 }
 
 
@@ -1112,114 +1108,115 @@ Obj FuncINT_STRING ( Obj self, Obj string )
 
 /****************************************************************************
 **
-*F  EqInt( <gmpL>, <gmpR> ) . . . . . . . . .  test if two integers are equal
+*F  EqInt( <opL>, <opR> ) . . . . . . . . . .  test if two integers are equal
 **
-**  
-**  'EqInt' returns 1  if  the two integer   arguments <intL> and  <intR> are
-**  equal and 0 otherwise.
+**  'EqInt' returns 1 if the two integer arguments <opL> and <opR> are equal
+**  and 0 otherwise.
 */
-Int EqInt ( Obj gmpL, Obj gmpR )
+Int EqInt(Obj opL, Obj opR)
 {
-  CHECK_INT(gmpL);
-  CHECK_INT(gmpR);
+    CHECK_INT(opL);
+    CHECK_INT(opR);
 
-  /* compare two small integers */
-  if ( ARE_INTOBJS( gmpL, gmpR ) )
-    return gmpL == gmpR;
+    /* compare two small integers */
+    if (ARE_INTOBJS(opL, opR))
+        return opL == opR;
 
-  /* a small int cannot equal a large int */
-  if ( IS_INTOBJ(gmpL) != IS_INTOBJ(gmpR) )
-    return 0;
+    /* a small int cannot equal a large int */
+    if (IS_INTOBJ(opL) != IS_INTOBJ(opR))
+        return 0;
 
-  /* compare the sign and size */
-  if ( TNUM_OBJ(gmpL) != TNUM_OBJ(gmpR)
-       || SIZE_INT(gmpL) != SIZE_INT(gmpR) )
-    return 0L;
+    /* compare the sign and size */
+    if (TNUM_OBJ(opL) != TNUM_OBJ(opR) || SIZE_INT(opL) != SIZE_INT(opR))
+        return 0;
 
-  if ( mpn_cmp( (mp_srcptr)CONST_ADDR_INT(gmpL), (mp_srcptr)CONST_ADDR_INT(gmpR), SIZE_INT(gmpL) ) == 0 ) 
-    return 1L;
-  else
-    return 0L;
+    if (mpn_cmp((mp_srcptr)CONST_ADDR_INT(opL),
+                (mp_srcptr)CONST_ADDR_INT(opR), SIZE_INT(opL)) == 0)
+        return 1;
+    else
+        return 0;
 }
 
 /****************************************************************************
 **
-*F  LtInt( <gmpL>, <gmpR> )  . . . . . . . . . . test whether <gmpL> < <gmpR>
+*F  LtInt( <opL>, <opR> ) . . . . . . test if an integer is less than another
 **
+**  'LtInt' returns 1 if the integer <opL> is strictly less than the
+**  integer <opR> and 0 otherwise.
 */
-Int LtInt ( Obj gmpL, Obj gmpR )
+Int LtInt(Obj opL, Obj opR)
 {
-  Int res;
+    Int res;
 
-  CHECK_INT(gmpL);
-  CHECK_INT(gmpR);
+    CHECK_INT(opL);
+    CHECK_INT(opR);
 
-  /* compare two small integers */
-  if ( ARE_INTOBJS( gmpL, gmpR ) )
-    return (Int)gmpL < (Int)gmpR;
+    /* compare two small integers */
+    if (ARE_INTOBJS(opL, opR))
+        return (Int)opL < (Int)opR;
 
-  /* a small int is always less than a positive large int */
-  if ( IS_INTOBJ(gmpL) != IS_INTOBJ(gmpR) )
-    return ( IS_INTOBJ(gmpL) && IS_INTPOS(gmpR) )
-        || ( IS_INTNEG(gmpL) && IS_INTOBJ(gmpR) );
+    /* a small int is always less than a positive large int */
+    if (IS_INTOBJ(opL) != IS_INTOBJ(opR))
+        return (IS_INTOBJ(opL) && IS_INTPOS(opR)) ||
+               (IS_INTNEG(opL) && IS_INTOBJ(opR));
 
-  /* compare two large integers */
-  if ( TNUM_OBJ(gmpL) != TNUM_OBJ(gmpR) ) /* different signs? */
-    return IS_INTNEG(gmpL);
+    /* compare two large integers */
+    if (TNUM_OBJ(opL) != TNUM_OBJ(opR)) /* different signs? */
+        return IS_INTNEG(opL);
 
-  /* signs are equal; compare sizes and absolute values */
-  if ( SIZE_INT(gmpL) < SIZE_INT(gmpR) )
-    res = 1;
-  else if ( SIZE_INT(gmpL) > SIZE_INT(gmpR) )
-    res = 0;
-  else
-    res = mpn_cmp( (mp_srcptr)CONST_ADDR_INT(gmpL), (mp_srcptr)CONST_ADDR_INT(gmpR), SIZE_INT(gmpL) ) < 0;
+    /* signs are equal; compare sizes and absolute values */
+    if (SIZE_INT(opL) < SIZE_INT(opR))
+        res = 1;
+    else if (SIZE_INT(opL) > SIZE_INT(opR))
+        res = 0;
+    else
+        res = mpn_cmp((mp_srcptr)CONST_ADDR_INT(opL),
+                      (mp_srcptr)CONST_ADDR_INT(opR), SIZE_INT(opL)) < 0;
 
-  /* if both arguments are negative, flip the result */
-  if ( IS_INTNEG(gmpL) )
-    res = !res;
+    /* if both arguments are negative, flip the result */
+    if (IS_INTNEG(opL))
+        res = !res;
 
-  return res;
+    return res;
 }
 
 
 /****************************************************************************
 **
-*F  SumOrDiffInt( <gmpL>, <gmpR>, <sign> ) . . .  sum or diff of two integers
+*F  SumOrDiffInt( <opL>, <opR>, <sign> ) . . . .  sum or diff of two integers
 **
-**  'SumOrDiffInt' returns the sum or difference of the two GMP int arguments
-**  <gmpL> and <gmpR>, depending on whether sign is +1 or -1. It handles
-**  operands of type 'T_INT', 'T_INTPOS' and 'T_INTNEG'.
+**  'SumOrDiffInt' returns the sum or difference of the two integer arguments
+**  <opL> and <opR>, depending on whether sign is +1 or -1.
 **
 **  'SumOrDiffInt'  is a little  bit  tricky since  there are  many different
 **  cases to handle: each operand can be positive or negative, small or large
 **  integer.
 */
-static Obj SumOrDiffInt ( Obj gmpL, Obj gmpR, Int sign )
+static Obj SumOrDiffInt(Obj opL, Obj opR, Int sign)
 {
   UInt sizeL, sizeR;
   fake_mpz_t mpzL, mpzR, mpzResult;
   Obj result;
 
-  CHECK_INT(gmpL);
-  CHECK_INT(gmpR);
+  CHECK_INT(opL);
+  CHECK_INT(opR);
 
   /* handle trivial cases first */
-  if ( gmpR == INTOBJ_INT(0) )
-    return gmpL;
-  if ( gmpL == INTOBJ_INT(0) ) {
+  if (opR == INTOBJ_INT(0))
+    return opL;
+  if (opL == INTOBJ_INT(0)) {
     if (sign == 1)
-      return gmpR;
+      return opR;
     else
-      return AInvInt(gmpR);
+      return AInvInt(opR);
   }
 
-  sizeL = SIZE_INT_OR_INTOBJ(gmpL);
-  sizeR = SIZE_INT_OR_INTOBJ(gmpR);
+  sizeL = SIZE_INT_OR_INTOBJ(opL);
+  sizeR = SIZE_INT_OR_INTOBJ(opR);
 
   NEW_FAKEMPZ( mpzResult, sizeL > sizeR ? sizeL+1 : sizeR+1 );
-  FAKEMPZ_GMPorINTOBJ( mpzL, gmpL );
-  FAKEMPZ_GMPorINTOBJ( mpzR, gmpR );
+  FAKEMPZ_GMPorINTOBJ(mpzL, opL);
+  FAKEMPZ_GMPorINTOBJ(mpzR, opR);
 
   /* add or subtract */
   if (sign == 1)
@@ -1239,94 +1236,92 @@ static Obj SumOrDiffInt ( Obj gmpL, Obj gmpR, Int sign )
 
 /****************************************************************************
 **
-*F  SumInt( <gmpL>, <gmpR> ) . . . . . . . . . . . .  sum of two GMP integers
+*F  SumInt( <opL>, <opR> ) . . . . . . . . . . . . . . .  sum of two integers
 **
 */
-inline Obj SumInt ( Obj gmpL, Obj gmpR )
+inline Obj SumInt(Obj opL, Obj opR)
 {
-  Obj sum;
+    Obj sum;
 
-  if ( !ARE_INTOBJS(gmpL, gmpR) || !SUM_INTOBJS( sum, gmpL, gmpR) )
-    sum = SumOrDiffInt( gmpL, gmpR, +1 );
+    if (!ARE_INTOBJS(opL, opR) || !SUM_INTOBJS(sum, opL, opR))
+        sum = SumOrDiffInt(opL, opR, +1);
 
-  CHECK_INT(sum);
-  return sum;
-
+    CHECK_INT(sum);
+    return sum;
 }
 
 
 /****************************************************************************
 **
-*F  DiffInt( <gmpL>, <gmpR> ) . . . . . . . .  difference of two GMP integers
+*F  DiffInt( <opL>, <opR> ) . . . . . . . . . . .  difference of two integers
 **
 */
-inline Obj DiffInt ( Obj gmpL, Obj gmpR )
+inline Obj DiffInt(Obj opL, Obj opR)
 {
-  Obj dif;
-  
-  if ( !ARE_INTOBJS(gmpL, gmpR) || !DIFF_INTOBJS( dif, gmpL, gmpR) )
-    dif = SumOrDiffInt( gmpL, gmpR, -1 );
-  
-  CHECK_INT(dif);
-  return dif;
+    Obj dif;
+
+    if (!ARE_INTOBJS(opL, opR) || !DIFF_INTOBJS(dif, opL, opR))
+        dif = SumOrDiffInt(opL, opR, -1);
+
+    CHECK_INT(dif);
+    return dif;
 }
 
 
 /****************************************************************************
 **
-*F  ZeroInt(<gmp>)  . . . . . . . . . . . . . . . . . . . .  zero of integers
+*F  ZeroInt(<op>)  . . . . . . . . . . . . . . . . . . . . . zero of integers
 */
-Obj ZeroInt ( Obj  op )
+Obj ZeroInt(Obj op)
 {
-  return INTOBJ_INT( (Int)0 );
+    return INTOBJ_INT(0);
 }
 
 
 /****************************************************************************
 **
-*F  AInvInt(<gmp>) . . . . . . . . . . . . . . additive inverse of an integer
+*F  AInvInt( <op> ) . . . . . . . . . . . . .  additive inverse of an integer
 */
-Obj AInvInt ( Obj gmp )
+Obj AInvInt(Obj op)
 {
   Obj inv;
 
-  CHECK_INT(gmp);
+  CHECK_INT(op);
 
-  /* handle small integer                                                */
-  if ( IS_INTOBJ( gmp ) ) {
+  // handle small integer
+  if (IS_INTOBJ(op)) {
     
-    /* special case (ugh)                                              */
-    if ( gmp == INTOBJ_MIN ) {
+    // special case (ugh)
+    if (op == INTOBJ_MIN) {
       inv = NewBag( T_INTPOS, sizeof(mp_limb_t) );
       SET_VAL_LIMB0( inv, -INT_INTOBJ_MIN );
     }
     
-    /* general case                                                    */
+    // general case
     else {
-      inv = INTOBJ_INT( - INT_INTOBJ( gmp ) );
+      inv = INTOBJ_INT(-INT_INTOBJ(op));
     }
     
   }
 
   else {
-    if ( IS_INTPOS(gmp) ) {
-      /* special case                                                        */
-      if ( SIZE_INT(gmp) == 1 && VAL_LIMB0(gmp) == -INT_INTOBJ_MIN ) {
+    if (IS_INTPOS(op)) {
+      // special case
+      if (SIZE_INT(op) == 1 && VAL_LIMB0(op) == -INT_INTOBJ_MIN) {
         return INTOBJ_MIN;
       }
       else {
-        inv = NewBag( T_INTNEG, SIZE_OBJ(gmp) );
+        inv = NewBag( T_INTNEG, SIZE_OBJ(op) );
       }
     }
     
     else {
-      inv = NewBag( T_INTPOS, SIZE_OBJ(gmp) );
+      inv = NewBag( T_INTPOS, SIZE_OBJ(op) );
     }
 
-    memcpy( ADDR_INT(inv), CONST_ADDR_INT(gmp), SIZE_OBJ(gmp) );
+    memcpy( ADDR_INT(inv), CONST_ADDR_INT(op), SIZE_OBJ(op) );
   }
   
-  /* return the inverse                                                    */
   CHECK_INT(inv);
   return inv;
 
@@ -1360,10 +1355,10 @@ Obj AbsInt( Obj op )
   return Fail;
 }
 
-Obj FuncABS_INT(Obj self, Obj x)
+Obj FuncABS_INT(Obj self, Obj n)
 {
-    RequireInt("AbsInt", x, "x");
-    Obj res = AbsInt(x);
+    RequireInt("AbsInt", n);
+    Obj res = AbsInt(n);
     CHECK_INT(res);
     return res;
 }
@@ -1391,10 +1386,10 @@ Obj SignInt( Obj op )
   return Fail;
 }
 
-Obj FuncSIGN_INT(Obj self, Obj x)
+Obj FuncSIGN_INT(Obj self, Obj n)
 {
-    RequireInt("SignInt", x, "x");
-    Obj res = SignInt(x);
+    RequireInt("SignInt", n);
+    Obj res = SignInt(n);
     CHECK_INT(res);
     return res;
 }
@@ -1402,47 +1397,46 @@ Obj FuncSIGN_INT(Obj self, Obj x)
 
 /****************************************************************************
 **
-*F  ProdInt( <intL>, <intR> ) . . . . . . . . . . . . product of two integers
+*F  ProdInt( <opL>, <opR> ) . . . . . . . . . . . . . product of two integers
 **
-**  'ProdInt' returns the product of the two  integer  arguments  <intL>  and
-**  <intR>.  'ProdInt' handles  operands  of  type  'T_INT',  'T_INTPOS'  and
-**  'T_INTNEG'.
+**  'ProdInt' returns the product of the two  integer  arguments  <opL>  and
+**  <opR>.
 */
-Obj ProdInt ( Obj gmpL, Obj gmpR )
+Obj ProdInt(Obj opL, Obj opR)
 {
   Obj                 prd;            /* handle of the result bag          */
   UInt sizeL, sizeR;
   fake_mpz_t mpzL, mpzR, mpzResult;
 
-  CHECK_INT(gmpL);
-  CHECK_INT(gmpR);
+  CHECK_INT(opL);
+  CHECK_INT(opR);
 
   /* multiplying two small integers                                        */
-  if ( ARE_INTOBJS( gmpL, gmpR ) ) {
+  if ( ARE_INTOBJS( opL, opR ) ) {
     
     /* multiply two small integers with a small product                    */
-    if ( PROD_INTOBJS( prd, gmpL, gmpR ) ) {
+    if ( PROD_INTOBJS( prd, opL, opR ) ) {
       CHECK_INT(prd);
       return prd;
     }
   }
 
   /* handle trivial cases first */
-  if ( gmpL == INTOBJ_INT(0) || gmpR == INTOBJ_INT(1) )
-    return gmpL;
-  if ( gmpR == INTOBJ_INT(0) || gmpL == INTOBJ_INT(1) )
-    return gmpR;
-  if ( gmpR == INTOBJ_INT(-1) )
-    return AInvInt( gmpL );
-  if ( gmpL == INTOBJ_INT(-1) )
-    return AInvInt( gmpR );
+  if ( opL == INTOBJ_INT(0) || opR == INTOBJ_INT(1) )
+    return opL;
+  if ( opR == INTOBJ_INT(0) || opL == INTOBJ_INT(1) )
+    return opR;
+  if ( opR == INTOBJ_INT(-1) )
+    return AInvInt( opL );
+  if ( opL == INTOBJ_INT(-1) )
+    return AInvInt( opR );
 
-  sizeL = SIZE_INT_OR_INTOBJ(gmpL);
-  sizeR = SIZE_INT_OR_INTOBJ(gmpR);
-    
+  sizeL = SIZE_INT_OR_INTOBJ(opL);
+  sizeR = SIZE_INT_OR_INTOBJ(opR);
+
   NEW_FAKEMPZ( mpzResult, sizeL + sizeR );
-  FAKEMPZ_GMPorINTOBJ( mpzL, gmpL );
-  FAKEMPZ_GMPorINTOBJ( mpzR, gmpR );
+  FAKEMPZ_GMPorINTOBJ( mpzL, opL );
+  FAKEMPZ_GMPorINTOBJ( mpzR, opR );
 
   /* multiply */
   mpz_mul( MPZ_FAKEMPZ(mpzResult), MPZ_FAKEMPZ(mpzL), MPZ_FAKEMPZ(mpzR) );
@@ -1543,7 +1537,7 @@ Obj FuncPROD_INT_OBJ ( Obj self, Obj opL, Obj opR )
 
 /****************************************************************************
 **
-*F  OneInt(<gmp>) . . . . . . . . . . . . . . . . . . . . . one of an integer
+*F  OneInt(<op>) . . . . . . . . . . . . . . . . . . . . .  one of an integer
 */
 Obj OneInt ( Obj op )
 {
@@ -1553,44 +1547,43 @@ Obj OneInt ( Obj op )
 
 /****************************************************************************
 **
-*F  PowInt( <intL>, <intR> )  . . . . . . . . . . . . . . power of an integer
+*F  PowInt( <opL>, <opR> ) . . . . . . . . . . . . . . .  power of an integer
 **
-**  'PowInt' returns the <intR>-th (an integer) power of the integer  <intL>.
-**  'PowInt' handles operands of type 'T_INT', 'T_INTPOS' and 'T_INTNEG'.
+**  'PowInt' returns the <opR>-th (an integer) power of the integer <opL>.
 */
-Obj PowInt ( Obj gmpL, Obj gmpR )
+Obj PowInt ( Obj opL, Obj opR )
 {
   Int                 i;
   Obj                 pow;
 
-  CHECK_INT(gmpL);
-  CHECK_INT(gmpR);
+  CHECK_INT(opL);
+  CHECK_INT(opR);
 
-  if ( gmpR == INTOBJ_INT(0) ) {
+  if ( opR == INTOBJ_INT(0) ) {
     pow = INTOBJ_INT(1);
   }
-  else if ( gmpL == INTOBJ_INT(0) ) {
-    if ( IS_NEG_INT( gmpR ) ) {
+  else if ( opL == INTOBJ_INT(0) ) {
+    if ( IS_NEG_INT( opR ) ) {
       ErrorMayQuit("Integer operands: <base> must not be zero", 0, 0);
     }
     pow = INTOBJ_INT(0);
   }
-  else if ( gmpL == INTOBJ_INT(1) ) {
+  else if ( opL == INTOBJ_INT(1) ) {
     pow = INTOBJ_INT(1);
   }
-  else if ( gmpL == INTOBJ_INT(-1) ) {
-    pow = IS_EVEN_INT(gmpR) ? INTOBJ_INT(1) : INTOBJ_INT(-1);
+  else if ( opL == INTOBJ_INT(-1) ) {
+    pow = IS_EVEN_INT(opR) ? INTOBJ_INT(1) : INTOBJ_INT(-1);
   }
 
   /* power with a large exponent */
-  else if ( ! IS_INTOBJ(gmpR) ) {
+  else if ( ! IS_INTOBJ(opR) ) {
     ErrorMayQuit("Integer operands: <exponent> is too large", 0, 0);
   }
   
   /* power with a negative exponent */
-  else if ( INT_INTOBJ(gmpR) < 0 ) {
+  else if ( INT_INTOBJ(opR) < 0 ) {
     pow = QUO( INTOBJ_INT(1),
-               PowInt( gmpL, INTOBJ_INT( -INT_INTOBJ(gmpR)) ) );
+               PowInt( opL, INTOBJ_INT( -INT_INTOBJ(opR)) ) );
   }
   
   /* findme - can we use the gmp function mpz_n_pow_ui? */
@@ -1598,10 +1591,10 @@ Obj PowInt ( Obj gmpL, Obj gmpR )
   /* power with a small positive exponent, do it by a repeated squaring  */
   else {
     pow = INTOBJ_INT(1);
-    i = INT_INTOBJ(gmpR);
+    i = INT_INTOBJ(opR);
     while ( i != 0 ) {
-      if ( i % 2 == 1 )  pow = ProdInt( pow, gmpL );
-      if ( i     >  1 )  gmpL = ProdInt( gmpL, gmpL );
+      if ( i % 2 == 1 )  pow = ProdInt( pow, opL );
+      if ( i     >  1 )  opL = ProdInt( opL, opL );
       TakeInterrupt();
       i = i / 2;
     }
@@ -1694,11 +1687,10 @@ Obj FuncPOW_OBJ_INT ( Obj self, Obj opL, Obj opR )
 
 /****************************************************************************
 **
-*F  ModInt( <opL>, <opR> )  . representative of residue class of an integer
+*F  ModInt( <opL>, <opR> ) . .  representative of residue class of an integer
 **
 **  'ModInt' returns the smallest positive representative of the residue
-**  class of the integer <opL> modulo the integer <opR>. 'ModInt' handles
-**  operands of type 'T_INT', 'T_INTPOS', 'T_INTNEG'.
+**  class of the integer <opL> modulo the integer <opR>.
 */
 Obj ModInt(Obj opL, Obj opR)
 {
@@ -1827,10 +1819,9 @@ Obj ModInt(Obj opL, Obj opR)
 
 /****************************************************************************
 **
-*F  QuoInt( <opL>, <opR> )  . . . . . . . . . . . quotient of two integers
+*F  QuoInt( <opL>, <opR> ) . . . . . . . . . . . . . quotient of two integers
 **
-**  'QuoInt' returns the integer part of the two integers <opL> and  <opR>.
-**  'QuoInt' handles operands of type  'T_INT',  'T_INTPOS'  and  'T_INTNEG'.
+**  'QuoInt' returns the integer part of the two integers <opL> and <opR>.
 **
 **  Note that this routine is not called from 'EvalQuo', the  division of two
 **  integers yields a rational and is therefor performed in 'QuoRat'. This
@@ -1934,34 +1925,33 @@ Obj QuoInt(Obj opL, Obj opR)
 
 /****************************************************************************
 **
-*F  FuncQUO_INT(<self>,<opL>,<opR>) . . . . . . .  internal function 'QuoInt'
+*F  FuncQUO_INT( <self>, <a>, <b> ) . . . . . . .  internal function 'QuoInt'
 **
 **  'FuncQUO_INT' implements the internal function 'QuoInt'.
 **
-**  'QuoInt( <i>, <k> )'
+**  'QuoInt( <a>, <b> )'
 **
 **  'Quo' returns the  integer part of the quotient  of its integer operands.
-**  If <i>  and <k> are  positive 'Quo( <i>,  <k> )' is  the largest positive
-**  integer <q>  such that '<q> * <k>  \<= <i>'.  If  <i> or  <k> or both are
-**  negative we define 'Abs( Quo(<i>,<k>) ) = Quo( Abs(<i>), Abs(<k>) )'  and
-**  'Sign( Quo(<i>,<k>) ) = Sign(<i>) * Sign(<k>)'.  Dividing by 0  causes an
+**  If <a>  and <b> are  positive 'Quo( <a>,  <b> )' is  the largest positive
+**  integer <q>  such that '<q> * <b>  \<= <a>'.  If  <a> or  <b> or both are
+**  negative we define 'Abs( Quo(<a>,<b>) ) = Quo( Abs(<a>), Abs(<b>) )'  and
+**  'Sign( Quo(<a>,<b>) ) = Sign(<a>) * Sign(<b>)'.  Dividing by 0  causes an
 **  error.  'Rem' (see "Rem") can be used to compute the remainder.
 */
-Obj FuncQUO_INT ( Obj self, Obj opL, Obj opR )
+Obj FuncQUO_INT(Obj self, Obj a, Obj b)
 {
-  REQUIRE_INT_ARG( "QuoInt", "left", opL );
-  REQUIRE_INT_ARG( "QuoInt", "right", opR );
-  return QuoInt( opL, opR );
+    RequireInt("QuoInt", a);
+    RequireInt("QuoInt", b);
+    return QuoInt(a, b);
 }
 
 
 /****************************************************************************
 **
-*F  RemInt( <opL>, <opR> )  . . . . . . . . . . . remainder of two integers
+*F  RemInt( <opL>, <opR> ) . . . . . . . . . . . .  remainder of two integers
 **
 **  'RemInt' returns the remainder of the quotient  of  the  integers  <opL>
-**  and <opR>.  'RemInt' handles operands of type  'T_INT',  'T_INTPOS'  and
-**  'T_INTNEG'.
+**  and <opR>.
 **
 **  Note that the remainder is different from the value returned by the 'mod'
 **  operator which is always positive, while the result of 'RemInt' has
@@ -2064,29 +2054,29 @@ Obj RemInt(Obj opL, Obj opR)
 
 /****************************************************************************
 **
-*F  FuncREM_INT(<self>,<opL>,<opR>)  . . . . . . .  internal function 'RemInt'
+*F  FuncREM_INT( <self>, <a>, <b> )  . . . . . . . internal function 'RemInt'
 **
 **  'FuncREM_INT' implements the internal function 'RemInt'.
 **
-**  'RemInt( <i>, <k> )'
+**  'RemInt( <a>, <b> )'
 **
-**  'Rem' returns the remainder of its two integer operands,  i.e., if <k> is
-**  not equal to zero 'Rem( <i>, <k> ) = <i> - <k> *  Quo( <i>, <k> )'.  Note
-**  that the rules given  for 'Quo' (see "Quo") imply  that 'Rem( <i>, <k> )'
-**  has the same sign as <i> and its absolute value is strictly less than the
+**  'RemInt' returns the remainder of its two integer operands, i.e., if <k>
+**  is not equal to zero 'Rem( <i>, <k> ) = <i> - <k> *  Quo( <i>, <k> )'.
+**  Note that the rules given for 'Quo' imply that 'Rem( <i>, <k> )' has the
+**  same sign as <i> and its absolute value is strictly less than the
 **  absolute value of <k>.  Dividing by 0 causes an error.
 */
-Obj FuncREM_INT ( Obj self, Obj opL, Obj opR )
+Obj FuncREM_INT(Obj self, Obj a, Obj b)
 {
-  REQUIRE_INT_ARG( "RemInt", "left", opL );
-  REQUIRE_INT_ARG( "RemInt", "right", opR );
-  return RemInt( opL, opR );
+    RequireInt("RemInt", a);
+    RequireInt("RemInt", b);
+    return RemInt(a, b);
 }
 
 
 /****************************************************************************
 **
-*F  GcdInt( <opL>, <opR> )  . . . . . . . . . . .  gcd of two GMP integers
+*F  GcdInt( <opL>, <opR> ) . . . . . . . . . . . . . . .  gcd of two integers
 **
 **  'GcdInt' returns the gcd of the two integers <opL> and <opR>.
 **
@@ -2138,24 +2128,30 @@ Obj GcdInt ( Obj opL, Obj opR )
 
 /****************************************************************************
 **
-*F  FuncGCD_INT(<self>,<opL>,<opR>)  . . . . . . .  internal function 'GcdInt'
+*F  FuncGCD_INT(<self>,<a>,<b>)  . . . . . . .  internal function 'GcdInt'
 **
 **  'FuncGCD_INT' implements the internal function 'GcdInt'.
 **
-**  'GcdInt( <i>, <k> )'
+**  'GcdInt( <a>, <b> )'
 **
-**  'Gcd'  returns the greatest common divisor   of the two  integers <m> and
-**  <n>, i.e.,  the  greatest integer that  divides  both <m>  and  <n>.  The
+**  'Gcd'  returns the greatest common divisor   of the two  integers <a> and
+**  <b>, i.e.,  the  greatest integer that  divides  both <a>  and  <b>.  The
 **  greatest common divisor is never negative, even if the arguments are.  We
-**  define $gcd( m, 0 ) = gcd( 0, m ) = abs( m )$ and $gcd( 0, 0 ) = 0$.
+**  define $gcd( a, 0 ) = gcd( 0, a ) = abs( a )$ and $gcd( 0, 0 ) = 0$.
 */
-Obj FuncGCD_INT ( Obj self, Obj opL, Obj opR )
+Obj FuncGCD_INT(Obj self, Obj a, Obj b)
 {
-  REQUIRE_INT_ARG( "GcdInt", "left", opL );
-  REQUIRE_INT_ARG( "GcdInt", "right", opR );
-  return GcdInt( opL, opR );
+    RequireInt("GcdInt", a);
+    RequireInt("GcdInt", b);
+    return GcdInt(a, b);
 }
 
+/****************************************************************************
+**
+*F  LcmInt( <opL>, <opR> )  . . . . . . . . . . . . . . . lcm of two integers
+**
+**  'LcmInt' returns the lcm of the two integers <opL> and <opR>.
+*/
 Obj LcmInt(Obj opL, Obj opR)
 {
     UInt       sizeL, sizeR;
@@ -2196,11 +2192,11 @@ Obj LcmInt(Obj opL, Obj opR)
     return result;
 }
 
-Obj FuncLCM_INT(Obj self, Obj opL, Obj opR)
+Obj FuncLCM_INT(Obj self, Obj a, Obj b)
 {
-    REQUIRE_INT_ARG("LcmInt", "left", opL);
-    REQUIRE_INT_ARG("LcmInt", "right", opR);
-    return LcmInt(opL, opR);
+    RequireInt("LcmInt", a);
+    RequireInt("LcmInt", b);
+    return LcmInt(a, b);
 }
 
 /****************************************************************************
@@ -2310,9 +2306,8 @@ Obj BinomialInt(Obj n, Obj k)
 
 Obj FuncBINOMIAL_INT(Obj self, Obj n, Obj k)
 {
-    REQUIRE_INT_ARG("Binomial", "n", n);
-    REQUIRE_INT_ARG("Binomial", "k", k);
-
+    RequireInt("Binomial", n);
+    RequireInt("Binomial", k);
     return BinomialInt(n, k);
 }
 
@@ -2320,19 +2315,19 @@ Obj FuncBINOMIAL_INT(Obj self, Obj n, Obj k)
 /****************************************************************************
 **
 */
-Obj FuncJACOBI_INT ( Obj self, Obj opL, Obj opR )
+Obj FuncJACOBI_INT(Obj self, Obj n, Obj m)
 {
   fake_mpz_t mpzL, mpzR;
   int result;
 
-  REQUIRE_INT_ARG( "Jacobi", "n", opL );
-  REQUIRE_INT_ARG( "Jacobi", "m", opR );
+  RequireInt("Jacobi", n);
+  RequireInt("Jacobi", m);
 
-  CHECK_INT(opL);
-  CHECK_INT(opR);
+  CHECK_INT(n);
+  CHECK_INT(m);
 
-  FAKEMPZ_GMPorINTOBJ( mpzL, opL );
-  FAKEMPZ_GMPorINTOBJ( mpzR, opR );
+  FAKEMPZ_GMPorINTOBJ(mpzL, n);
+  FAKEMPZ_GMPorINTOBJ(mpzR, m);
 
   result = mpz_kronecker( MPZ_FAKEMPZ(mpzL), MPZ_FAKEMPZ(mpzR) );
   CHECK_FAKEMPZ(mpzL);
@@ -2351,8 +2346,8 @@ Obj FuncPVALUATION_INT(Obj self, Obj n, Obj p)
   mpz_t mpzResult;
   int k;
 
-  REQUIRE_INT_ARG("PValuation", "n", n);
-  REQUIRE_INT_ARG("PValuation", "p", p);
+  RequireInt("PValuation", n);
+  RequireInt("PValuation", p);
 
   CHECK_INT(n);
   CHECK_INT(p);
@@ -2397,8 +2392,8 @@ Obj FuncROOT_INT(Obj self, Obj n, Obj k)
 {
     fake_mpz_t n_mpz, result_mpz;
 
-    REQUIRE_INT_ARG("Root", "n", n);
-    REQUIRE_INT_ARG("Root", "k", k);
+    RequireInt("Root", n);
+    RequireInt("Root", k);
 
     if (!IS_POS_INT(k))
         ErrorMayQuit("Root: <k> must be a positive integer", 0, 0);
@@ -2510,9 +2505,9 @@ Obj InverseModInt(Obj base, Obj mod)
 */
 Obj FuncINVMODINT ( Obj self, Obj base, Obj mod )
 {
-  REQUIRE_INT_ARG( "InverseModInt", "base", base );
-  REQUIRE_INT_ARG( "InverseModInt", "mod", mod );
-  return InverseModInt( base, mod );
+    RequireInt("InverseModInt", base);
+    RequireInt("InverseModInt", mod);
+    return InverseModInt(base, mod);
 }
 
 
@@ -2523,9 +2518,9 @@ Obj FuncPOWERMODINT(Obj self, Obj base, Obj exp, Obj mod)
 {
   fake_mpz_t base_mpz, exp_mpz, mod_mpz, result_mpz;
 
-  REQUIRE_INT_ARG( "PowerModInt", "base", base );
-  REQUIRE_INT_ARG( "PowerModInt", "exp", exp );
-  REQUIRE_INT_ARG( "PowerModInt", "mod", mod );
+  RequireInt("PowerModInt", base);
+  RequireInt("PowerModInt", exp);
+  RequireInt("PowerModInt", mod);
 
   CHECK_INT(base);
   CHECK_INT(exp);
@@ -2567,7 +2562,7 @@ Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
   fake_mpz_t n_mpz;
   Int res;
 
-  REQUIRE_INT_ARG( "IsProbablyPrimeInt", "n", n );
+  RequireInt("IsProbablyPrimeInt", n);
   RequirePositiveSmallInt( "IsProbablyPrimeInt", reps, "reps" );
 
   CHECK_INT(n);
@@ -2634,7 +2629,7 @@ Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
        rd += (unsigned long) ((UInt4) nextrandMT_int32(mt) & 
                               ((UInt4) -1L >> (64-n))) << 32;
        res = INTOBJ_INT((Int)rd);
-     }  
+     }
 #else
      res = INTOBJ_INT((Int)(nextrandMT_int32(mt) & ((UInt4) -1L >> (32-n))));
 #endif
@@ -2747,14 +2742,14 @@ static StructGVarFilt GVarFilts [] = {
 */
 static StructGVarFunc GVarFuncs[] = {
 
-    GVAR_FUNC(QUO_INT, 2, "gmp1, gmp2"),
-    GVAR_FUNC(ABS_INT, 1, "x"),
-    GVAR_FUNC(SIGN_INT, 1, "x"),
-    GVAR_FUNC(REM_INT, 2, "gmp1, gmp2"),
-    GVAR_FUNC(GCD_INT, 2, "gmp1, gmp2"),
-    GVAR_FUNC(LCM_INT, 2, "gmp1, gmp2"),
-    GVAR_FUNC(PROD_INT_OBJ, 2, "gmp, obj"),
-    GVAR_FUNC(POW_OBJ_INT, 2, "obj, gmp"),
+    GVAR_FUNC(QUO_INT, 2, "a, b"),
+    GVAR_FUNC(ABS_INT, 1, "n"),
+    GVAR_FUNC(SIGN_INT, 1, "n"),
+    GVAR_FUNC(REM_INT, 2, "a, b"),
+    GVAR_FUNC(GCD_INT, 2, "a, b"),
+    GVAR_FUNC(LCM_INT, 2, "a, b"),
+    GVAR_FUNC(PROD_INT_OBJ, 2, "opL, opR"),
+    GVAR_FUNC(POW_OBJ_INT, 2, "opL, opR"),
     GVAR_FUNC(JACOBI_INT, 2, "n, m"),
     GVAR_FUNC(FACTORIAL_INT, 1, "n"),
     GVAR_FUNC(BINOMIAL_INT, 2, "n, k"),
@@ -2763,10 +2758,10 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(POWERMODINT, 3, "base, exp, mod"),
     GVAR_FUNC(IS_PROBAB_PRIME_INT, 2, "n, reps"),
     GVAR_FUNC(INVMODINT, 2, "base, mod"),
-    GVAR_FUNC(HexStringInt, 1, "gmp"),
+    GVAR_FUNC(HexStringInt, 1, "n"),
     GVAR_FUNC(IntHexString, 1, "string"),
     GVAR_FUNC(Log2Int, 1, "n"),
-    GVAR_FUNC(STRING_INT, 1, "gmp"),
+    GVAR_FUNC(STRING_INT, 1, "n"),
     GVAR_FUNC(INT_STRING, 1, "string"),
     GVAR_FUNC(RandomIntegerMT, 2, "mtstr, nrbits"),
 
@@ -2831,7 +2826,7 @@ static Int InitKernel ( StructInitInfo * module )
     AInvMutFuncs[ t1 ] = AInvInt;
     OneFuncs [ t1 ] = OneInt;
     OneMutFuncs [ t1 ] = OneInt;
-  }    
+  }
 
     /* install the default power methods                                   */
   for ( t1 = T_INT; t1 <= T_INTNEG; t1++ ) {

--- a/src/integer.h
+++ b/src/integer.h
@@ -177,10 +177,9 @@ extern Obj GMP_NORMALIZE( Obj gmp );
 
 /****************************************************************************
 **
-*F  PrintInt( <int> ) . . . . . . . . . . . . . . . print an integer constant
+*F  PrintInt( <op> ) . . . . . . . . . . . . . . . .  print an integer object
 **
-**  'PrintInt'  prints  the integer  <int>   in the  usual  decimal notation.
-**  'PrintInt' handles objects of type 'T_INT', 'T_INTPOS' and 'T_INTNEG'.
+**  'PrintInt' prints the integer <op> in the usual decimal notation.
 */
 extern void PrintInt( Obj op );
 
@@ -197,17 +196,17 @@ Obj IntStringInternal(Obj string, const Char *str);
 
 /****************************************************************************
 **
-*F  EqInt( <opL>, <opR> ) . . . . . test if two integers are equal
+*F  EqInt( <opL>, <opR> ) . . . . . . . . . .  test if two integers are equal
 **
-**  'EqInt' returns 1  if  the two GMP integer arguments <opL> and
-**  <opR> are equal and 0 otherwise.
+**  'EqInt' returns 1 if the two integer arguments <opL> and <opR> are equal
+**  and 0 otherwise.
 */
 extern Int EqInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  LtInt( <opL>, <opR> )  test if an integer is less than another
+*F  LtInt( <opL>, <opR> ) . . . . . . test if an integer is less than another
 **
 **  'LtInt' returns 1 if the integer <opL> is strictly less than the
 **  integer <opR> and 0 otherwise.
@@ -217,24 +216,28 @@ extern Int LtInt( Obj opL, Obj opR );
 
 /****************************************************************************
 **
-*F  SumInt( <opL>, <opR> )  . . . . . . . . .  sum of two integers
+*F  SumInt( <opL>, <opR> ) . . . . . . . . . . . . . . .  sum of two integers
 **
-**  'SumInt' returns the sum of the two integer arguments <opL> and
-**  <opR>.
-**
+**  'SumInt' returns the sum of the two integer arguments <opL> and <opR>.
 */
 extern Obj SumInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  DiffInt( <opL>, <opR> ) . . . . difference of two integers
+*F  DiffInt( <opL>, <opR> ) . . . . . . . . . . .  difference of two integers
 **
 **  'DiffInt' returns the difference of the two integer arguments <opL>
 **  and <opR>.
-**
 */
 extern Obj DiffInt( Obj opL, Obj opR );
+
+
+/****************************************************************************
+**
+*F  AInvInt( <op> ) . . . . . . . . . . . . .  additive inverse of an integer
+*/
+extern Obj AInvInt(Obj op);
 
 
 /****************************************************************************
@@ -253,61 +256,55 @@ extern Obj SignInt( Obj op );
 
 /****************************************************************************
 **
-*F  ProdInt( <opL>, <opR> ) . . . . .  product of two integers
+*F  ProdInt( <opL>, <opR> ) . . . . . . . . . . . . . product of two integers
 **
-**  'ProdInt' returns the product of the two integer arguments <opL>
-**  and <opR>.
-**
+**  'ProdInt' returns the product of the two  integer  arguments  <opL>  and
+**  <opR>.
 */
 extern Obj ProdInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  ModInt( <opL>, <opR> ) representative of res class of an integer
+*F  ModInt( <opL>, <opR> ) . .  representative of residue class of an integer
 **
 **  'ModInt' returns the smallest positive representative of the residue
-**  class of the  integer  <opL>  modulo  the  integer  <opR>.
-**
+**  class of the integer <opL> modulo the integer <opR>.
 */
 extern Obj ModInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  PowInt( <opL>, <opR> )  . . . . . . . . power of an integer
+*F  PowInt( <opL>, <opR> ) . . . . . . . . . . . . . . .  power of an integer
 **
-**  'PowInt' returns the <opR>-th power of the integer <opL>.
-**
+**  'PowInt' returns the <opR>-th (an integer) power of the integer <opL>.
 */
 extern Obj PowInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  QuoInt( <opL>, <opR> )  . . . . . quotient of two integers
+*F  QuoInt( <opL>, <opR> ) . . . . . . . . . . . . . quotient of two integers
 **
-**  'QuoInt' returns the integer part of the two integers <opL> and
-**  <opR>.
-**
+**  'QuoInt' returns the integer part of the two integers <opL> and <opR>.
 */
 extern Obj QuoInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  RemInt( <opL>, <opR> )  . . . .  remainder of two integers
+*F  RemInt( <opL>, <opR> ) . . . . . . . . . . . .  remainder of two integers
 **
-**  'RemInt' returns the remainder of the quotient of the integers
-**  <opL> and <opR>.
-**
+**  'RemInt' returns the remainder of the quotient of the integers <opL> and
+**  <opR>.
 */
 extern Obj RemInt( Obj opL, Obj opR );
 
 
 /****************************************************************************
 **
-*F  GcdInt( <opL>, <opR> )  . . . . . . .  gcd of two integers
+*F  GcdInt( <opL>, <opR> ) . . . . . . . . . . . . . . .  gcd of two integers
 **
 **  'GcdInt' returns the gcd of the two integers <opL> and <opR>.
 */
@@ -316,7 +313,7 @@ extern Obj GcdInt( Obj opL, Obj opR );
 
 /****************************************************************************
 **
-*F  LcmInt( <opL>, <opR> )  . . . . . . .  lcm of two integers
+*F  LcmInt( <opL>, <opR> )  . . . . . . . . . . . . . . . lcm of two integers
 **
 **  'LcmInt' returns the lcm of the two integers <opL> and <opR>.
 */
@@ -325,24 +322,15 @@ extern Obj LcmInt( Obj opL, Obj opR );
 
 /****************************************************************************
 **
-*F  AInvInt( <op> ) . . . . . . . . . . . . .  additive inverse of an integer
-**
-*/
-extern Obj AInvInt( Obj op );
-
-
-/****************************************************************************
-**
 *F  InverseModInt( <op> ) . . . .  mult. inverse of an integer modulo another
-**
 */
 extern Obj InverseModInt(Obj base, Obj mod);
 
 
 /****************************************************************************
 **
-**  Compute log2 of the absolute value of an Int, i.e. the index of the highest
-**  set bit. For input 0, return -1.
+**  Compute log2 of the absolute value of an Int, i.e. the index of the
+**  highest set bit. For input 0, return -1.
 */
 extern Int CLog2Int( Int intnum );
 
@@ -350,7 +338,6 @@ extern Int CLog2Int( Int intnum );
 /****************************************************************************
 **
 *F  BinomialInt(<n>, <k>) . . . .  return the binomial coefficient of n and k
-**
 */
 extern Obj BinomialInt(Obj n, Obj k);
 

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -244,7 +244,7 @@ Obj GAP_MakeObjInt(const UInt * limbs, Int size)
 
 Int GAP_SizeInt(Obj obj)
 {
-    RequireInt("GAP_SizeInt", obj, "obj");
+    RequireInt("GAP_SizeInt", obj);
     if (obj == INTOBJ_INT(0))
         return 0;
     Int size = (IS_INTOBJ(obj) ? 1 : SIZE_INT(obj));

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -316,9 +316,9 @@ Error, Integer operations: <divisor> must be nonzero
 gap> QuoInt(bigPos, 0);
 Error, Integer operations: <divisor> must be nonzero
 gap> QuoInt(fail,1);
-Error, QuoInt: <left> must be an integer (not the value 'fail')
+Error, QuoInt: <a> must be an integer (not the value 'fail')
 gap> QuoInt(1,fail);
-Error, QuoInt: <right> must be an integer (not the value 'fail')
+Error, QuoInt: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> QuoInt(-2^28, -1);
@@ -366,9 +366,9 @@ Error, Integer operations: <divisor> must be nonzero
 gap> RemInt(bigPos, 0);
 Error, Integer operations: <divisor> must be nonzero
 gap> RemInt(fail,1);
-Error, RemInt: <left> must be an integer (not the value 'fail')
+Error, RemInt: <a> must be an integer (not the value 'fail')
 gap> RemInt(1,fail);
-Error, RemInt: <right> must be an integer (not the value 'fail')
+Error, RemInt: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> RemInt(-2^28, 2^28);
@@ -439,9 +439,9 @@ true
 
 #
 gap> GcdInt(fail,1);
-Error, GcdInt: <left> must be an integer (not the value 'fail')
+Error, GcdInt: <a> must be an integer (not the value 'fail')
 gap> GcdInt(1,fail);
-Error, GcdInt: <right> must be an integer (not the value 'fail')
+Error, GcdInt: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> GcdInt(0, 0);
@@ -486,9 +486,9 @@ true
 
 #
 gap> LcmInt(fail,1);
-Error, LcmInt: <left> must be an integer (not the value 'fail')
+Error, LcmInt: <a> must be an integer (not the value 'fail')
 gap> LcmInt(1,fail);
-Error, LcmInt: <right> must be an integer (not the value 'fail')
+Error, LcmInt: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> LcmInt(0, 0);
@@ -520,7 +520,7 @@ true
 gap> AbsInt(fail);
 Error, AbsRat: <op> must be a rational (not the value 'fail')
 gap> ABS_INT(fail);
-Error, AbsInt: <x> must be an integer (not the value 'fail')
+Error, AbsInt: <n> must be an integer (not the value 'fail')
 
 #
 # SignInt
@@ -530,7 +530,7 @@ gap> List(data, SignInt);
 gap> SignInt(fail);
 Error, SignRat: <op> must be a rational (not the value 'fail')
 gap> SIGN_INT(fail);
-Error, SignInt: <x> must be an integer (not the value 'fail')
+Error, SignInt: <n> must be an integer (not the value 'fail')
 
 #
 # QuotientMod
@@ -571,7 +571,7 @@ gap> dataHex := List(data, HexStringInt);
 [ "-56BC75E2D63100001", "-56BC75E2D63100000", "-2710", "-1", "0", "1", 
   "2710", "56BC75E2D63100000", "56BC75E2D63100001" ]
 gap> HexStringInt("abc");
-Error, HexStringInt: <op> must be an integer (not a list (string))
+Error, HexStringInt: <n> must be an integer (not a list (string))
 gap> List(dataHex, IntHexString) = data;
 true
 gap> dataHex;  # HexStringInt used to destroy its argument


### PR DESCRIPTION
* tweak the `RequireInt` macro to automatically deduce the argument name
* rename function arguments from gmpL -> opL, gmpR -> opR, gmp -> op
  especially in user visible places
* remove other gratuitous references to "GMP integer"
* sync comments in integer.h and integer.c

... and then also did some `git clang-format`ing of the changed lines, to remove various whitespace etc. -- all of those can be ignored by viewing this PR with the "Hide whitespace changes" option enabled.