### PR TITLE
Travis: disable -Werror for Julia builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
     - env: TEST_SUITES=testbugfix
 
     # test Julia integration
-    - env: TEST_SUITES="testinstall" JULIA=yes
+    - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
 
     # out of tree builds -- these are mainly done to verify that the build
     # system work in this scenario. Since we don't expect the test results to

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -23,7 +23,7 @@ BUILDDIR=$PWD
 
 if [[ $HPCGAP = yes ]]
 then
-  CONFIGFLAGS="$CONFIGFLAGS --enable-hpcgap"
+  CONFIGFLAGS="--enable-hpcgap $CONFIGFLAGS"
 fi
 
 
@@ -36,12 +36,12 @@ then
   pushd julia-*
   JULIA_PATH=$(pwd)
   popd
-  CONFIGFLAGS="$CONFIGFLAGS --with-gc=julia --with-julia=$JULIA_PATH"
+  CONFIGFLAGS="--with-gc=julia --with-julia=$JULIA_PATH $CONFIGFLAGS"
 fi
 
 
 # configure and make GAP
-time "$SRCDIR/configure" $CONFIGFLAGS --enable-Werror
+time "$SRCDIR/configure" --enable-Werror $CONFIGFLAGS
 time make V=1 -j4
 
 # download packages; instruct wget to retry several times if the


### PR DESCRIPTION
This avoids a test failure due to a warning triggered by the nightly build
version of the Julia headers.

To achieve this, this patch also changes etc/ci-prepare.sh to prepend flag to
CONFIGFLAGS, instead of appending. Since later options override earlier ones,
this makes it possible to override options from .travis.yml.