### PR TITLE
Change GroupWithGenerators to accept collections again

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4401,13 +4401,14 @@ InstallMethod( GroupWithGenerators,
 function( gens )
 local G,typ;
 
+  gens:=AsList(gens);
   typ:=MakeGroupyType(FamilyObj(gens),
           IsGroup and IsAttributeStoringRep 
           and HasIsEmpty and HasGeneratorsOfMagmaWithInverses,
           gens,false,true);
 
   G:=rec();
-  ObjectifyWithAttributes(G,typ,GeneratorsOfMagmaWithInverses,AsList(gens));
+  ObjectifyWithAttributes(G,typ,GeneratorsOfMagmaWithInverses,gens);
 
   return G;
 end );
@@ -4418,13 +4419,14 @@ InstallMethod( GroupWithGenerators,
 function( gens, id )
 local G,typ;
 
+  gens:=AsList(gens);
   typ:=MakeGroupyType(FamilyObj(gens),
           IsGroup and IsAttributeStoringRep 
             and HasIsEmpty and HasGeneratorsOfMagmaWithInverses and HasOne,
             gens,id,true);
 
   G:=rec();
-  ObjectifyWithAttributes(G,typ,GeneratorsOfMagmaWithInverses,AsList(gens),
+  ObjectifyWithAttributes(G,typ,GeneratorsOfMagmaWithInverses,gens,
                           One,id);
 
   return G;

--- a/tst/testbugfix/2018-12-06-GroupWithGenerators.tst
+++ b/tst/testbugfix/2018-12-06-GroupWithGenerators.tst
@@ -1,0 +1,5 @@
+# These are undocumented, but should still work
+gap> GroupByGenerators( Group( (1,2) ) );
+Group([ (), (1,2) ])
+gap> GroupWithGenerators( Group( (1,2) ) );
+Group([ (), (1,2) ])


### PR DESCRIPTION
In GAP <= 4.9, this worked:

    gap> GroupByGenerators( Group( (1,2) ) );
    Group([ (), (1,2) ])

In GAP 4.10, this was broken and instead lead to a "method not found" error.
While strictly speaking this was never documented behavior, we restore it
to avoid regressions in code that relied on this undocumented behavior.

Resolves #2703 

This is a less intrusive (and thus hopefully less controversial) alternative to PR #3091. Closes #3091