### PR TITLE
Prototype for GAP_Enter/Leave macros

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1140,6 +1140,13 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func)
 
 GAP_STATIC_ASSERT((sizeof(BagHeader) % sizeof(Bag)) == 0, "BagHeader size must be multiple of word size");
 
+
+void SetStackBottomBags(void * StackBottom)
+{
+    StackBottomBags = StackBottom;
+}
+
+
 void            InitBags (
     UInt                initial_size,
     Bag *               stack_bottom,

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -916,6 +916,8 @@ typedef void            (* TNumCollectFuncBags) ( void );
 extern  void            InitCollectFuncBags (
             TNumCollectFuncBags before_func,
             TNumCollectFuncBags after_func );
+
+extern void SetStackBottomBags(void * StackBottom);
 #endif
 
 // ExtraMarkFuncBags, if not NULL, is called during garbage collection

--- a/tst/testlibgap/common.c
+++ b/tst/testlibgap/common.c
@@ -6,16 +6,20 @@
 void test_eval(const char * cmd)
 {
     Obj  res, ires;
-    Int  rc, i;
+    Int  rc, i, ok;
     printf("gap> %s\n", cmd);
-    res = GAP_EvalString(cmd);
-    rc = GAP_LenList(res);
-    for (i = 1; i <= rc; i++) {
-        ires = GAP_ElmList(res, i);
-        if (GAP_ElmList(ires, 1) == GAP_True) {
-            Char * buffer = GAP_CSTR_STRING(GAP_ElmList(ires, 5));
-            if (buffer)
-                printf("%s\n", buffer);
+    ok = GAP_Enter();
+    if (ok) {
+        res = GAP_EvalString(cmd);
+        rc = GAP_LenList(res);
+        for (i = 1; i <= rc; i++) {
+            ires = GAP_ElmList(res, i);
+            if (GAP_ElmList(ires, 1) == GAP_True) {
+                Char * buffer = GAP_CSTR_STRING(GAP_ElmList(ires, 5));
+                if (buffer)
+                    printf("%s\n", buffer);
+            }
         }
     }
+    GAP_Leave();
 }


### PR DESCRIPTION
Prototype for GAP_Enter/Leave macros to bracket use of libgap and stack local GAP objects in code which embeds libgap.  See #3089 for discussion.

There are two parts to this:

First, the outer-most `GAP_Enter()` must set the `StackBottom` variable for GASMAN, without which objects tracked by GASMAN that are allocated on the stack are properly tracked (see #3089).

Second, the outer-most `GAP_Enter()` call should set a jump point for longjmps to `STATE(ReadJmpError)`.  Code within the GAP kernel may reset this, but we should
set it here in case any unexpected errors occur within the GAP kernel that are
not already handled appropriately by a `TRY_IF_NO_ERROR`.

For the first issue, we add `GAP_EnterStack()` and `GAP_LeaveStack()` macros which implement *just* the `StackBottom` handling without any other error handling.  We also add a function to gasman.c called `_MarkStackBottomBags` which just updates the StackBottom variable (this could be implemented for other GC's as well, either as a no-op or whatever else is appropriate).  Then the macro called `MarkStackBottomBags` (same name without underscore) can be used within a function to set `StackBottom` to somewhere at or near the beginning of that function's stack frame.  This uses
GCC's `__builtin_frame_address`, but support is probably needed for other platforms that don't have this.

The state variable `STATE(EnterStackCount)` is used to track recursive calls into `GAP_EnterStack()`.  We only want to set `StackBottom` on the outer-most call.  The count is decremented on `GAP_LeaveStack()`.  Some functions are provided for manipulating the counter from the API without directly exposing the GAP state, but I'm not sure if this is necessary or desirable, especially since it means `EnterStackCount` isn't updated atomically.  My hope was to avoid exposing too many GAP internals, but it may be necessary in order to implement these as macros.

For setting the `STATE(ReadJmpError)` jump buffer we provide a macro called `GAP_Error_Setjmp()` which is fairly straightforward, except that it needs to be written in such a way that it can be used in concert correctly with `GAP_EnterStack()`.  In particular, if returning to the site of a `GAP_Error_Setjmp()` call we do not want to accidentally re-increment the `EnterStackCount`.

Finally, the higher-level `GAP_Enter()` and `GAP_Leave()` macros are provided: The latter is just an alias for `GAP_LeaveStack()`, but the former carefully combines *both* `GAP_Error_Setjmp()` and `GAP_EnterStack()`.  Although called like a function, the `GAP_Enter()` macro expands to a compound statement (necessary for both `GAP_EnterStack()` and `GAP_Error_Setjmp()` to work properly).  The order of expansion is also deliberate so that this can be used like:

    jmp_retval = GAP_Enter();

so that the return value of the setjmp call can be stored in a variable while using `GAP_Enter()`, and can be checked to see whether an error occurred.  However, this requires some care to ensure that the following `GAP_EnterStack()` doesn't increment the `EnterStackCount` following a return to this point via a longjmp.