### PR TITLE
Show a warning when GroupWithGenerators called on a domain

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4401,6 +4401,13 @@ InstallMethod( GroupWithGenerators,
 function( gens )
 local G,typ;
 
+  if IsGroup(gens) then
+    Info( InfoPerformance, 1,
+      "Calling `GroupWithGenerators' on a group usually is very inefficient.");
+    Info( InfoPerformance, 1,
+      "Use the list of generators of the group instead.");
+  fi;
+
   gens:=AsList(gens);
   typ:=MakeGroupyType(FamilyObj(gens),
           IsGroup and IsAttributeStoringRep 
@@ -4418,6 +4425,13 @@ InstallMethod( GroupWithGenerators,
     IsCollsElms, [ IsCollection, IsMultiplicativeElementWithInverse ],
 function( gens, id )
 local G,typ;
+
+  if IsGroup(gens) then
+    Info( InfoPerformance, 1,
+      "Calling `GroupWithGenerators' on a group usually is very inefficient.");
+    Info( InfoPerformance, 1,
+      "Use the list of generators of the group instead.");
+  fi;
 
   gens:=AsList(gens);
   typ:=MakeGroupyType(FamilyObj(gens),


### PR DESCRIPTION
In GAP <= 4.9, the following undocumented use of `GroupWithGenerators`
was possible:

    gap> GroupWithGenerators( Group( (1,2) ) );
    Group([ (), (1,2) ])

This does not work in GAP 4.10.0, and #3095 restored this never documented
behavior to avoid regressions in code that used to work previously.

This PR adds a warning when such use of `GroupWithGenerators` is detected.