### PR TITLE
prevent infinite recursions in echoandcheck SyWriteandcheck

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -153,19 +153,24 @@ ssize_t echoandcheck(int fid, const char *buf, size_t count) {
   int ret;
   if (syBuf[fid].type == gzip_socket) {
       ret = gzwrite(syBuf[fid].gzfp, buf, count);
-      if (ret < 0)
+      if (ret < 0) {
           ErrorQuit(
               "Could not write to compressed file, see 'LastSystemError();'\n",
               0L, 0L);
+      }
   }
   else {
       ret = write(syBuf[fid].echo, buf, count);
-      if (ret < 0)
-          ErrorQuit("Could not write to file descriptor %d, see "
-                    "'LastSystemError();'\n",
-                    syBuf[fid].fp, 0L);
+      if (ret < 0) {
+          if (syBuf[fid].fp == fileno(stdout) || syBuf[fid].fp == fileno(stderr)) {
+              Panic("Could not write to stdout/stderr.");
+          } else {
+              ErrorQuit("Could not write to file descriptor %d, see "
+                        "'LastSystemError();'\n",
+                        syBuf[fid].fp, 0L);
+          }
+      }
   }
-
   return ret;
 }
 
@@ -1540,17 +1545,23 @@ static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count)
     int ret;
     if (syBuf[fid].type == gzip_socket) {
         ret = gzwrite(syBuf[fid].gzfp, buf, count);
-        if (ret < 0)
+        if (ret < 0) {
             ErrorQuit(
                 "Cannot write to compressed file, see 'LastSystemError();'\n",
                 0L, 0L);
+        }
     }
     else {
         ret = write(syBuf[fid].fp, buf, count);
-        if (ret < 0)
-            ErrorQuit("Cannot write to file descriptor %d, see "
-                      "'LastSystemError();'\n",
-                      syBuf[fid].fp, 0L);
+        if (ret < 0) {
+            if (syBuf[fid].fp == fileno(stdout) || syBuf[fid].fp == fileno(stderr)) {
+                Panic("Could not write to stdout/stderr.");
+            } else {
+                ErrorQuit("Cannot write to file descriptor %d, see "
+                          "'LastSystemError();'\n",
+                          syBuf[fid].fp, 0L);
+            }
+        }
     }
 
     return ret;


### PR DESCRIPTION
This can occur in cases where the stdio streams (specifically stderr, but it can also happen with just stdout) cannot be written to for some reason, resulting in EIO errors on `write()` calls to their file descriptors.

The recursions occur because if an error occurs on writing to the stream, `ErrorQuit` is called which may in turn attempt to write to the same stream.    This is similar to, but a somewhat different manifestation of #3028.

I'm not really happy with this fix since it's more of a band-aid; what is really needed is broader refactoring to error handling, as discussed partly in #2487.  But that's a longer-term effort.  In the meantime, this is needed for libgap, preferably in **4.10.1**.

To demonstrate the problem this fixes, one easy way is to just run:

```
$ ./gap > /dev/full
$ ./gap > /dev/full
Error, Cannot write to file descriptor 1, see 'LastSystemError();'
 in
  Print( " ", btop, "   ", gap, " ", GAPInfo.BuildVersion, " of ", sysdate, "\n", " ", vert, "  GAP  ", vert,
 "   https://www.gap-system.org\n", " ", bbot, "   Architecture: ", GAPInfo.Architecture, "\n"
 ); at /home/embray/src/gap-system/gap/lib/init.g:510 called from
ShowKernelInformation(  ); at /home/embray/src/gap-system/gap/lib/init.g:565 called from
func(  ); at /home/embray/src/gap-system/gap/lib/system.g:215 called from
<function "CallAndInstallPostRestore">( <arguments> )
 called from read-eval loop at /home/embray/src/gap-system/gap/lib/init.g:567
Error, Cannot write to file descriptor 1, see 'LastSystemError();'

< ... some more errors ... >

<function "SESSION">( <arguments> )
 called from read-eval loop at *stdin*:1
Syntax error: ; expected

Segmentation fault (core dumped)
```

With the patch, the same example will result in a few error messages as well, but then wait at the prompt (which just isn't displayed).

This is just one example.  A more realistic use case is one where GAP is started as a subprocess with stdout and stderr redirected to pipes, and then one of those pipes is closed.