### PR TITLE
Two fixes for fp group homomorphisms and Improvement for Fitting free matrix group setup

### DIFF
--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -88,7 +88,11 @@ local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r;
 	    serdepths:=List(ffs.depths,y->First([1..Length(r)],x->r[x]>=y))
 	    );
   Add(cache,[ffs,r]); # keep
-  SetSize(U,Product(RelativeOrders(k))*Size(Image(rest)));
+  if Length(k)=0 then
+    SetSize(U,Size(Image(rest)));
+  else
+    SetSize(U,Product(RelativeOrders(k))*Size(Image(rest)));
+  fi;
   return r;
 
 end);

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -31,7 +31,21 @@ local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r;
 
   pcisom:=ffs.pcisom;
 
-  rest:=RestrictedMapping(ffs.factorhom,U);
+  #rest:=RestrictedMapping(ffs.factorhom,U);
+  if IsPermGroup(U) and AssertionLevel()>1 then
+    rest:=GroupHomomorphismByImages(U,Range(ffs.factorhom),GeneratorsOfGroup(U),
+      List(GeneratorsOfGroup(U),x->ImagesRepresentative(ffs.factorhom,x)));
+  else
+    RUN_IN_GGMBI:=true; # hack to skip Nice treatment
+    rest:=GroupHomomorphismByImagesNC(U,Range(ffs.factorhom),GeneratorsOfGroup(U),
+      List(GeneratorsOfGroup(U),x->ImagesRepresentative(ffs.factorhom,x)));
+    RUN_IN_GGMBI:=false;
+  fi;
+  Assert(1,rest<>fail);
+
+  if HasRecogDecompinfoHomomorphism(ffs.factorhom) then
+    SetRecogDecompinfoHomomorphism(rest,RecogDecompinfoHomomorphism(ffs.factorhom));
+  fi;
 
   # in radical?
   if ForAll(MappingGeneratorsImages(rest)[2],IsOne) then
@@ -139,7 +153,7 @@ local ffs,hom,U,rest,ker,r,p,l,i,depths;
     rest:=GroupHomomorphismByImagesNC(U,Range(hom),gens,imgs);
     RUN_IN_GGMBI:=false;
   fi;
-  if rest=fail then Error("can't build homomorphism"); fi;
+  Assert(1,rest<>fail);
 
   if HasRecogDecompinfoHomomorphism(hom) then
     SetRecogDecompinfoHomomorphism(rest,RecogDecompinfoHomomorphism(hom));

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -65,7 +65,11 @@ local s,sg,o,gi;
   o:=One(Range(hom));
   # take the images corresponding to the free gens in case of reordering or
   # duplicates
-  gi:=MappingGeneratorsImages(hom)[2]{hom!.genpositions};
+  #gi:=MappingGeneratorsImages(hom)[2]{ListPerm(PermList(hom!.genpositions)^-1,
+  #  Length(hom!.genpositions))};
+  gi:=[];
+  gi{hom!.genpositions}:=MappingGeneratorsImages(hom)[2];
+
   return ForAll(RelatorsOfFpGroup(s),i->MappedWord(i,sg,gi)=o);
 end);
 
@@ -88,7 +92,10 @@ local s, bas, sg, o, gi, l, p, rel, start, i;
   o:=One(Range(hom));
   # take the images corresponding to the free gens in case of reordering or
   # duplicates
-  gi:=MappingGeneratorsImages(hom)[2]{hom!.genpositions};
+  #gi:=MappingGeneratorsImages(hom)[2]{ListPerm(PermList(hom!.genpositions)^-1,
+  #  Length(hom!.genpositions))};
+  gi:=[];
+  gi{hom!.genpositions}:=MappingGeneratorsImages(hom)[2];
   for rel in RelatorsOfFpGroup(s) do
     l:=LetterRepAssocWord(rel);
     for start in bas do

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -27,6 +27,9 @@ InstallMethod(Order,"for automorphisms",true,[IsGroupHomomorphism],0,
 function(hom)
 local map,phi,o,lo,i,j,start,img,d,nat,ser,jord,first;
   d:=Source(hom);
+  if not (HasIsFinite(d) and IsFinite(d)) then
+    TryNextMethod();
+  fi;
   if Size(d)<=10000 then
     ser:=[d,TrivialSubgroup(d)]; # no need to be clever if small
   else

--- a/tst/testbugfix/2018-12-11-fphomgenmix.tst
+++ b/tst/testbugfix/2018-12-11-fphomgenmix.tst
@@ -1,0 +1,15 @@
+# test for fpgroup homs on mixed generators (fixing #3100)
+gap> f := FreeGroup(18);;
+gap> q := f / [ f.1*f.3*f.7, f.2*f.6*f.8, f.4*f.18*f.14, f.5*f.13*f.9, f.10*f.12*f.16,
+> f.11*f.15*f.17, f.1*f.6, f.2*f.7, f.3*f.18, f.4*f.13, f.5*f.8, f.9*f.12, f.10*f.15, f.11*f.16,
+> f.14*f.17 ];;
+gap> src := [ q.3^-1*q.2^-1, q.2, q.3, q.4, q.5, q.2*q.3, q.7, q.8, q.9, q.10, q.11, q.12, q.13,
+> q.14, q.15, q.16, q.17, q.18 ];;
+gap> dst := [ q.16, q.10, q.12, q.13, q.14, q.11, q.15, q.17, q.18, q.1, q.2, q.3, q.4, q.5, q.6,
+> q.7, q.8, q.9 ];;
+gap> hom := GroupHomomorphismByImages(q,q,src,dst);;
+gap> inv := GroupHomomorphismByImages(q,q,dst,src);;
+gap> IsMapping(hom);
+true
+gap> IsMapping(inv);
+true

--- a/tst/testbugfix/2018-12-11-fphomord.tst
+++ b/tst/testbugfix/2018-12-11-fphomord.tst
@@ -1,0 +1,5 @@
+# hom. order of infinite group in special case (fixing #3097)
+gap> f := FreeGroup(2);;
+gap> x := GroupHomomorphismByImages(f,f,[f.1,f.2],[f.2,f.1]);;
+gap> Order(x);
+2


### PR DESCRIPTION
This fixes #3097, #3100 and a nuisance error when working with matrix groups under the fitting free setup (avoid `RestrictedMapping` which runs into trouble).