### PR TITLE
Fix some inconsistencies in the reference manual

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -453,12 +453,12 @@ memory it allocated).
 
 <ManSection>
 <Func Name="Sleep" Arg='time'/>
-<Func Name="NanoSleep" Arg='time'/>
+<Func Name="MicroSleep" Arg='time'/>
 
 <Description>
 These functions make GAP stop execution for a given period of time. The time
-to stop is given to <Ref Func="Sleep"/> in seconds and <Ref Func="NanoSleep"/>
-in nanoseconds.
+to stop is given to <Ref Func="Sleep"/> in seconds and <Ref Func="MicroSleep"/>
+in microseconds.
 </Description>
 </ManSection>
 

--- a/doc/ref/floats.xml
+++ b/doc/ref/floats.xml
@@ -104,7 +104,7 @@ Floating-point numbers may be created using the single function
 <Ref Func="Float"/>, which accepts as arguments rational, string,
 or floating-point numbers. Floating-point numbers may
 also be created, in any floating-point representation, using
-<Ref Func="NewFloat"/> as in <C>NewFloat(IsIEEE754FloatRep,355/113)</C>,
+<Ref Constr="NewFloat"/> as in <C>NewFloat(IsIEEE754FloatRep,355/113)</C>,
 by supplying the category filter of the desired new floating-point number;
 or using <Ref Func="MakeFloat"/> as in <C>NewFloat(1.0,355/113)</C>,
 by supplying a sample floating-point number.
@@ -235,7 +235,7 @@ Complex arithmetic may be implemented in packages, and is present in
 <Package>float</Package>. Complex numbers are treated as usual
 numbers; they may be input with an extra "i" as in
 <C>-0.5+0.866i</C>. They may also be created using <Ref
-Oper="NewFloat"/> with three arguments: the float filter, the real
+Constr="NewFloat"/> with three arguments: the float filter, the real
 part, and the imaginary part.
 <P/>
 

--- a/doc/ref/foa.xml
+++ b/doc/ref/foa.xml
@@ -193,7 +193,7 @@ In this case, the result can be stored as the value of the attribute
 This attribute is considered by a call
 <C>Blocks( <A>G</A>, <A>D</A>, <A>opr</A> )</C>
 (i.e., without <A>seed</A>) in the same way as
-<Ref Func="Orbits"/> considers <C>OrbitsAttr</C>.
+<Ref Oper="Orbits" Label="attribute"/> considers <C>OrbitsAttr</C>.
 <P/>
 To set this up,
 the declaration file <F>lib/oprt.gd</F> contains the following lines:

--- a/doc/ref/meataxe.xml
+++ b/doc/ref/meataxe.xml
@@ -416,8 +416,8 @@ see&nbsp;<Ref Func="MTX.NormedBasisAndBaseChange"/>)
 </ManSection>
 
 <ManSection>
-<Func Name="MTX.InducedActionMatrix" Arg='mat, sub'/>
-<Func Name="MTX.InducedActionMatrixNB" Arg='mat, sub'/>
+<Func Name="MTX.InducedActionSubMatrix" Arg='mat, sub'/>
+<Func Name="MTX.InducedActionSubMatrixNB" Arg='mat, sub'/>
 <Func Name="MTX.InducedActionFactorMatrix" Arg='mat, sub[, compl]'/>
 
 <Description>

--- a/doc/ref/obsolete.xml
+++ b/doc/ref/obsolete.xml
@@ -266,11 +266,11 @@ systems) in the directory <C>GAPInfo.UserGapRoot</C>.
   simply a property of semigroups, there is no category <C>IsSemilattice</C>. 
   <P/>
 
-  From Version 4.8 onwards, <C>IsSemilatticeAsSemigroup</C> is renamed
-  <C>IsSemilattice</C>, and <C>IsMonoidAsSemigroup</C> returns <C>true</C> for
-  semigroups in the category <Ref Filt = "IsMonoid"/>.
-  
-  <#Include Label="IsSemilatticeAsSemigroup">
+  From Version 4.8 onwards, <C>IsMonoidAsSemigroup</C> returns
+  <C>true</C> for semigroups in the category <Ref Filt = "IsMonoid"/>,
+  and <C>IsSemilatticeAsSemigroup</C> has been moved to the
+  <Package>Semigroups</Package> under the new name
+  <Ref Prop="IsSemilattice" BookName = "Semigroups"/>.
 </Section>
 
 </Chapter>

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -48,49 +48,49 @@ end);
 ## <#GAPDoc Label="Float-Math-Commands">
 ## <ManSection>
 ##   <Heading>Standard mathematical operations</Heading>
-##   <Oper Name="Cos" Arg="f"/>
-##   <Oper Name="Sin" Arg="f"/>
-##   <Oper Name="Tan" Arg="f"/>
-##   <Oper Name="Sec" Arg="f"/>
-##   <Oper Name="Csc" Arg="f"/>
-##   <Oper Name="Cot" Arg="f"/>
-##   <Oper Name="Asin" Arg="f"/>
-##   <Oper Name="Acos" Arg="f"/>
-##   <Oper Name="Atan" Arg="f"/>
-##   <Oper Name="Cosh" Arg="f"/>
-##   <Oper Name="Sinh" Arg="f"/>
-##   <Oper Name="Tanh" Arg="f"/>
-##   <Oper Name="Sech" Arg="f"/>
-##   <Oper Name="Csch" Arg="f"/>
-##   <Oper Name="Coth" Arg="f"/>
-##   <Oper Name="Asinh" Arg="f"/>
-##   <Oper Name="Acosh" Arg="f"/>
-##   <Oper Name="Atanh" Arg="f"/>
+##   <Attr Name="Cos" Arg="f"/>
+##   <Attr Name="Sin" Arg="f"/>
+##   <Attr Name="Tan" Arg="f"/>
+##   <Attr Name="Sec" Arg="f"/>
+##   <Attr Name="Csc" Arg="f"/>
+##   <Attr Name="Cot" Arg="f"/>
+##   <Attr Name="Asin" Arg="f"/>
+##   <Attr Name="Acos" Arg="f"/>
+##   <Attr Name="Atan" Arg="f"/>
+##   <Attr Name="Cosh" Arg="f"/>
+##   <Attr Name="Sinh" Arg="f"/>
+##   <Attr Name="Tanh" Arg="f"/>
+##   <Attr Name="Sech" Arg="f"/>
+##   <Attr Name="Csch" Arg="f"/>
+##   <Attr Name="Coth" Arg="f"/>
+##   <Attr Name="Asinh" Arg="f"/>
+##   <Attr Name="Acosh" Arg="f"/>
+##   <Attr Name="Atanh" Arg="f"/>
 ##   <Oper Name="Log" Arg="f"/>
-##   <Oper Name="Log2" Arg="f"/>
-##   <Oper Name="Log10" Arg="f"/>
-##   <Oper Name="Log1p" Arg="f"/>
-##   <Oper Name="Exp" Arg="f"/>
-##   <Oper Name="Exp2" Arg="f"/>
-##   <Oper Name="Exp10" Arg="f"/>
-##   <Oper Name="Expm1" Arg="f"/>
-##   <Oper Name="CubeRoot" Arg="f"/>
-##   <Oper Name="Square" Arg="f"/>
-##   <Oper Name="Ceil" Arg="f"/>
-##   <Oper Name="Floor" Arg="f"/>
-##   <Oper Name="Round" Arg="f"/>
-##   <Oper Name="Trunc" Arg="f"/>
+##   <Attr Name="Log2" Arg="f"/>
+##   <Attr Name="Log10" Arg="f"/>
+##   <Attr Name="Log1p" Arg="f"/>
+##   <Attr Name="Exp" Arg="f"/>
+##   <Attr Name="Exp2" Arg="f"/>
+##   <Attr Name="Exp10" Arg="f"/>
+##   <Attr Name="Expm1" Arg="f"/>
+##   <Attr Name="CubeRoot" Arg="f"/>
+##   <Attr Name="Square" Arg="f"/>
+##   <Attr Name="Ceil" Arg="f"/>
+##   <Attr Name="Floor" Arg="f"/>
+##   <Attr Name="Round" Arg="f"/>
+##   <Attr Name="Trunc" Arg="f"/>
 ##   <Oper Name="Atan2" Arg="y x"/>
-##   <Oper Name="FrExp" Arg="f"/>
+##   <Attr Name="FrExp" Arg="f"/>
 ##   <Oper Name="LdExp" Arg="f exp"/>
-##   <Oper Name="AbsoluteValue" Arg="f" Label="for floats"/>
-##   <Oper Name="Norm" Arg="f" Label="for floats"/>
+##   <Attr Name="AbsoluteValue" Arg="f" Label="for floats"/>
+##   <Attr Name="Norm" Arg="f" Label="for floats"/>
 ##   <Oper Name="Hypothenuse" Arg="x y"/>
-##   <Oper Name="Frac" Arg="f"/>
-##   <Oper Name="SinCos" Arg="f"/>
-##   <Oper Name="Erf" Arg="f"/>
-##   <Oper Name="Zeta" Arg="f"/>
-##   <Oper Name="Gamma" Arg="f"/>
+##   <Attr Name="Frac" Arg="f"/>
+##   <Attr Name="SinCos" Arg="f"/>
+##   <Attr Name="Erf" Arg="f"/>
+##   <Attr Name="Zeta" Arg="f"/>
+##   <Attr Name="Gamma" Arg="f"/>
 ##   <Description>
 ##     Standard math functions.
 ##   </Description>
@@ -270,7 +270,7 @@ DeclareGlobalFunction("RootsFloat");
 ## </ManSection>
 ## <ManSection>
 ##   <Attr Name="AbsoluteDiameter" Arg="x"/>
-##   <Attr Name="Diameter" Arg="x"/>
+##   <Oper Name="Diameter" Arg="x"/>
 ##   <Description>
 ##     Returns the absolute diameter of the interval <A>x</A>, namely
 ##     the difference <C>Sup(x)-Inf(x)</C>.
@@ -338,7 +338,7 @@ DeclareOperation("BisectInterval", [IsFloatInterval]);
 ## <ManSection>
 ##   <Heading>Float creators</Heading>
 ##   <Func Name="Float" Arg="obj"/>
-##   <Oper Name="NewFloat" Arg="filter, obj"/>
+##   <Constr Name="NewFloat" Arg="filter, obj"/>
 ##   <Oper Name="MakeFloat" Arg="sample obj, obj"/>
 ##   <Returns>A new floating-point number, based on <A>obj</A></Returns>
 ##   <Description>
@@ -385,7 +385,7 @@ DeclareOperation("BisectInterval", [IsFloatInterval]);
 ## </ManSection>
 ##
 ## <ManSection>
-##   <Attr Name="Cyc" Arg="f [degree]" Label="for floats"/>
+##   <Oper Name="Cyc" Arg="f [degree]" Label="for floats"/>
 ##   <Returns>A cyclotomic approximation to <A>f</A></Returns>
 ##   <Description>
 ##     This command constructs a cyclotomic approximation to the

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -871,7 +871,7 @@ DeclareAttribute( "AbelianRank", IsGroup );
 ##
 ##  <#GAPDoc Label="IsInfiniteAbelianizationGroup:grp">
 ##  <ManSection>
-##  <Attr Name="IsInfiniteAbelianizationGroup" Arg='G'/>
+##  <Prop Name="IsInfiniteAbelianizationGroup" Arg='G'/>
 ##
 ##  <Description>
 ##  <Index Subkey="for groups" Key="IsInfiniteAbelianizationGroup">

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -453,7 +453,7 @@ DeclareGlobalFunction("LowLayerSubgroups");
 ##
 ##  <#GAPDoc Label="ContainedConjugates">
 ##  <ManSection>
-##  <Func Name="ContainedConjugates" Arg='G, A, B'/>
+##  <Oper Name="ContainedConjugates" Arg='G, A, B'/>
 ##
 ##  <Description>
 ##  For <M>A,B \leq G</M> this operation returns representatives of the <A>A</A>
@@ -478,7 +478,7 @@ DeclareSynonym("EmbeddedConjugates",ContainedConjugates);
 ##
 ##  <#GAPDoc Label="ContainingConjugates">
 ##  <ManSection>
-##  <Func Name="ContainingConjugates" Arg='G, A, B'/>
+##  <Oper Name="ContainingConjugates" Arg='G, A, B'/>
 ##
 ##  <Description>
 ##  For <M>A,B \leq G</M> this operation returns all <A>G</A> conjugates of <A>A</A> 
@@ -503,7 +503,7 @@ DeclareSynonym("EmbeddingConjugates",ContainingConjugates);
 ##
 ##  <#GAPDoc Label="MinimalFaithfulPermutationDegree">
 ##  <ManSection>
-##  <Func Name="MinimalFaithfulPermutationDegree" Arg='G'/>
+##  <Oper Name="MinimalFaithfulPermutationDegree" Arg='G'/>
 ##
 ##  <Description>
 ##  For  a finite group <A>G</A> this operation calculates the least

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -309,7 +309,7 @@ DeclareGlobalFunction( "ConcatenationOfVectors" );
 
 ##  <#GAPDoc Label="MatObj_ExtractSubVector">
 ##  <ManSection>
-##    <Func Arg="V,l" Name="ExtractSubVector" Label="for IsVectorObj,IsList"/>
+##    <Oper Arg="V,l" Name="ExtractSubVector" Label="for IsVectorObj,IsList"/>
 ##    <Returns>a vector object</Returns>
 ##    <Description>
 ##      Returns a new vector containing the entries of <A>V</A>

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -2078,7 +2078,7 @@ DeclareOperation("BaseField",[IsObject]);
 ##
 ##  <#GAPDoc Label="SimplexMethod">
 ##  <ManSection>
-##  <Oper Name="SimplexMethod" Arg='A,b,c'/>
+##  <Func Name="SimplexMethod" Arg='A,b,c'/>
 ##
 ##  <Description>
 ##  Find a rational vector <A>x</A> that maximizes <M><A>x</A>\cdot<A>c</A></M>, subject

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -559,7 +559,6 @@ DeclareOperation( "LaTeXObj", [ IS_OBJECT ] );
 ##
 #F  IsSemilatticeAsSemigroup( <S> ) is the semigroup <S> a semilattice
 ##
-##  <#GAPDoc Label="IsSemilatticeAsSemigroup">
 ##  <ManSection>
 ##  <Prop Name="IsSemilatticeAsSemigroup" Arg='S'/>
 ##
@@ -576,7 +575,6 @@ DeclareOperation( "LaTeXObj", [ IS_OBJECT ] );
 ##    beta-releases.  #  It should <E>not</E> be used in new code.
 ##  </Description>
 ##  </ManSection>
-##  <#/GAPDoc>
 ##
 ##  Not used in any redistributed packages (11/2017)
 #DeclareSynonymAttr( "IsSemilatticeAsSemigroup", IsSemilattice );

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -479,7 +479,7 @@ end);
 ##  in the former case, a property is returned, in the latter case an
 ##  attribute that is not a property.
 ##  <P/>
-##  For example, to set up the operation <Ref Func="Orbits"/>,
+##  For example, to set up the operation <Ref Oper="Orbits" Label="operation"/>,
 ##  the declaration file <F>lib/oprt.gd</F> contains the following line of
 ##  code:
 ##  <Log><![CDATA[
@@ -495,7 +495,7 @@ end);
 ##  ]]></Log>
 ##  which are usually entered in calls to <Ref Func="OrbitsishOperation"/>.
 ##  <P/>
-##  The new operation, e.g., <Ref Func="Orbits"/>,
+##  The new operation, e.g., <Ref Oper="Orbits" Label="operation"/>,
 ##  can be called either as <C>Orbits( <A>xset</A> )</C> for an external set
 ##  <A>xset</A>, or as <C>Orbits( <A>G</A> )</C> for a permutation group
 ##  <A>G</A>, meaning the orbits on the moved


### PR DESCRIPTION
I have run `make check-manuals` and fixed some inconsistencies that it reports, for example, referring to things that do no longer exist, or using wrong types in ManSections. This now reduces the number of errors on `Ref` elements to zero, so opens the way to use `make check-manuals` for continuous integration. You can see part of the report it produces below. 

```
****************************************************************
*** Doc coverage report 
****************************************************************
2856 mansections 
1318 with examples 
1538 without examples 
****************************************************************
*** Checking types in ManSections 
****************************************************************
./../../lib/magma.gd:672 : Centralizer uses Attr instead of Oper
./../../lib/grp.gd:3540 : GrowthFunctionOfGroup uses Oper instead of Attr
./../../lib/oprt.gd:1242 : Orbit uses Oper instead of Func
./../../lib/oprt.gd:1280 : Orbits uses Oper instead of Attr
./../../lib/oprt.gd:1305 : OrbitsDomain uses Oper instead of Attr
./../../lib/oprt.gd:1356 : OrbitLength uses Oper instead of Func
./../../lib/oprt.gd:1377 : OrbitLengths uses Oper instead of Attr
./../../lib/oprt.gd:1399 : OrbitLengthsDomain uses Oper instead of Attr
./../../lib/oprt.gd:1430 : OrbitStabilizer uses Oper instead of Func
./../../lib/oprt.gd:1034 : SparseActionHomomorphism uses Oper instead of Func
./../../lib/oprt.gd:
1036 : SortedSparseActionHomomorphism uses Oper instead of Func
./../../lib/oprt.gd:1991 : CycleLengths uses Oper instead of Func
./../../lib/oprt.gd:1695 : IsTransitive uses Oper instead of Prop
./../../lib/oprt.gd:1516 : Transitivity uses Oper instead of Attr
./../../lib/oprt.gd:1843 : RankAction uses Oper instead of Attr
./../../lib/oprt.gd:1779 : IsSemiRegular uses Oper instead of Prop
./../../lib/oprt.gd:1806 : IsRegular uses Oper instead of Prop
./../../lib/oprt.gd:1669 : Earns uses Oper instead of Attr
./../../lib/oprt.gd:1730 : IsPrimitive uses Oper instead of Prop
./../../lib/oprt.gd:1551 : Blocks uses Oper instead of Func
./../../lib/oprt.gd:1553 : Blocks uses Attr instead of Func
./../../lib/oprt.gd:1595 : MaximalBlocks uses Oper instead of Func
./../../lib/oprt.gd:1597 : MaximalBlocks uses Attr instead of Func
./../../lib/oprt.gd:
1633 : RepresentativesMinimalBlocks uses Oper instead of Func
./../../lib/oprt.gd:
1636 : RepresentativesMinimalBlocks uses Attr instead of Func
./../../lib/oprt.gd:1147 : ExternalSet uses Oper instead of Attr
./../../lib/oprt.gd:1198 : ExternalSubset uses Oper instead of Func
./../../lib/oprt.gd:1220 : ExternalOrbit uses Oper instead of Func
./../../lib/oprt.gd:1452 : ExternalOrbits uses Oper instead of Attr
./../../lib/oprt.gd:1478 : ExternalOrbitsStabilizers uses Oper instead of Attr
./../../lib/ratfun.gd:1378 : Discriminant uses Oper instead of Attr
./../../lib/tom.gd:1506 : CyclicExtensionsTom uses Oper instead of Attr
./../../lib/ctbl.gd:1110 : IsAlmostSimple uses Prop instead of Oper
./../../lib/ctbl.gd:1114 : IsMonomial uses Prop instead of Oper
./../../lib/ctbl.gd:1115 : IsNilpotent uses Prop instead of Oper
./../../lib/ctbl.gd:1116 : IsPerfect uses Prop instead of Oper
./../../lib/ctbl.gd:1117 : IsSimple uses Prop instead of Oper
./../../lib/ctbl.gd:1118 : IsSolvable uses Prop instead of Oper
./../../lib/ctbl.gd:1119 : IsSporadicSimple uses Prop instead of Oper
./../../lib/ctbl.gd:1120 : IsSupersolvable uses Prop instead of Oper
./../../lib/ctbl.gd:2469 : DecompositionMatrix uses Oper instead of Attr
./../../lib/ctbl.gd:3824 : CharacterTableIsoclinic uses Oper instead of Attr
./../../lib/ctblmaps.gd:
583 : FusionConjugacyClassesOp uses Oper instead of Attr
./../../lib/ctblmono.gd:607 : TestMonomial uses Oper instead of Attr
./../../lib/ctblmono.gd:609 : TestMonomial uses Oper instead of Attr
./../../lib/ctblmono.gd:762 : TestRelativelySM uses Oper instead of Attr
./../../lib/ctblmono.gd:764 : TestRelativelySM uses Oper instead of Attr
****************************************************************
*** Checking types in cross-references 
****************************************************************
Found 7578 Ref elements including 7506 within the Reference manual
****************************************************************
Selected 3741 ManSections of the following types:
Attr - 753
Fam - 8
Filt - 358
Func - 1372
InfoClass - 21
Meth - 68
Oper - 894
Prop - 223
Var - 44
Found 47 errors in ManSection types 
Selected 6231 Ref elements referring to ManSections 
Found 0 errors and 2647 warnings in Ref elements 
To show warnings, use CheckManSectionTypes(doc,true); 
****************************************************************
```