### PR TITLE
kernel: RequireArguments: make <...> in argnames explicit; add RequireFilter to opers.c 

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -84,9 +84,9 @@
 #include "set.h"
 
 
-#define RequireBlist(funcname, op, argname) \
-    RequireArgumentCondition(funcname, op, argname, IsBlistConv(op), \
-        "must be a boolean list")
+#define RequireBlist(funcname, op, argname)                                  \
+    RequireArgumentConditionEx(funcname, op, "<" argname ">",                \
+                               IsBlistConv(op), "must be a boolean list")
 
 /****************************************************************************
 **
@@ -1146,7 +1146,7 @@ Obj FuncPositionNthTrueBlist (
 
     /* Check the arguments. */    
     RequireBlist("ListBlist", blist, "blist");
-    Int nth = GetPositiveSmallIntEx("Position", Nth, "nth");
+    Int nth = GetPositiveSmallIntEx("Position", Nth, "<nth>");
 
     nrb = NUMBER_BLOCKS_BLIST(blist);
     if ( ! nrb )  return Fail;

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -890,7 +890,7 @@ static Obj  HdlrFunc3 (
       t_3 = NewAndFilter( l_match, t_5 );
      }
      else {
-      RequireArgument(0, l_match, "expr",
+      RequireArgumentEx(0, l_match, "<expr>",
       "must be 'true' or 'false' or a filter" );
      }
      l_match = t_3;
@@ -2638,7 +2638,7 @@ static Obj  HdlrFunc7 (
      t_5 = NewAndFilter( l_cats, t_7 );
     }
     else {
-     RequireArgument(0, l_cats, "expr",
+     RequireArgumentEx(0, l_cats, "<expr>",
      "must be 'true' or 'false' or a filter" );
     }
     l_cats = t_5;
@@ -3143,7 +3143,7 @@ static Obj  HdlrFunc15 (
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -228,7 +228,7 @@ static Obj  HdlrFunc2 (
   t_5 = NewAndFilter( t_6, a_tester );
  }
  else {
-  RequireArgument(0, t_6, "expr",
+  RequireArgumentEx(0, t_6, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SET_ELM_PLIST( t_4, 1, t_5 );

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -99,17 +99,17 @@ typedef UInt    RNam;
     if (obj == 0)                                                            \
         ErrorQuit("function must return a value", 0L, 0L);
 
-#define CHECK_INT_SMALL(obj) RequireSmallInt(0, obj, "obj");
+#define CHECK_INT_SMALL(obj) RequireSmallInt(0, obj, "<obj>");
 
-#define CHECK_INT_SMALL_POS(obj) RequirePositiveSmallInt(0, obj, "obj");
+#define CHECK_INT_SMALL_POS(obj) RequirePositiveSmallInt(0, obj, "<obj>");
 
 #define CHECK_INT_POS(obj)                                                   \
     if (!IS_POS_INT(obj))                                                    \
-        RequireArgument(0, obj, "obj", "must be a positive integer");
+        RequireArgumentEx(0, obj, "<obj>", "must be a positive integer");
 
 #define CHECK_BOOL(obj)                                                      \
     if (obj != True && obj != False)                                         \
-        RequireArgument(0, obj, "obj", "must be 'true' or 'false'");
+        RequireArgumentEx(0, obj, "<obj>", "must be 'true' or 'false'");
 
 #define CHECK_FUNC(obj) RequireFunction(0, obj);
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1317,7 +1317,7 @@ CVar CompAnd (
 
     /* signal an error                                                     */
     Emit( "else {\n" );
-    Emit( "RequireArgument(0, %c, \"expr\",\n"
+    Emit( "RequireArgumentEx(0, %c, \"<expr>\",\n"
             "\"must be 'true' or 'false' or a filter\" );\n", left );
     Emit( "}\n" );
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1667,7 +1667,7 @@ Obj FuncCONDUCTOR (
     /* check the argument                                                  */
     if (!IS_INT(cyc) && TNUM_OBJ(cyc) != T_RAT && TNUM_OBJ(cyc) != T_CYC &&
         !IS_SMALL_LIST(cyc)) {
-        RequireArgument("Conductor", cyc, "cyc",
+        RequireArgument("Conductor", cyc,
                         "must be a cyclotomic or a small list");
     }
 
@@ -1687,7 +1687,6 @@ Obj FuncCONDUCTOR (
             cyc = ELMV_LIST( list, i );
             if (!IS_INT(cyc) && TNUM_OBJ(cyc) != T_RAT &&
                 TNUM_OBJ(cyc) != T_CYC) {
-                // RequireArgument("Conductor", op, "argname", "msg");
                 ErrorMayQuit(
                     "Conductor: <list>[%d] must be a cyclotomic (not a %s)",
                     (Int)i, (Int)TNAM_OBJ(cyc));
@@ -1741,7 +1740,7 @@ Obj FuncCOEFFS_CYC (
 
     /* check the argument                                                  */
     if (!IS_INT(cyc) && TNUM_OBJ(cyc) != T_RAT && TNUM_OBJ(cyc) != T_CYC) {
-        RequireArgument("COEFFSCYC", cyc, "cyc", "must be a cyclotomic");
+        RequireArgument("COEFFSCYC", cyc, "must be a cyclotomic");
     }
 
     /* if <cyc> is rational just put it in a list of length 1              */
@@ -1979,8 +1978,7 @@ Obj FuncCycList (
 
     /* get and check the argument                                          */
     if ( ! IS_PLIST( list ) || ! IS_DENSE_LIST( list ) ) {
-        RequireArgument("CycList", list, "list",
-                        "must be a dense plain list");
+        RequireArgument("CycList", list, "must be a dense plain list");
     }
 
     /* enlarge the buffer if necessary                                     */
@@ -1995,8 +1993,8 @@ Obj FuncCycList (
             // reset ResultCyc, otherwise the next operation using it will see
             // our left-over garbage data
             SET_LEN_PLIST( ResultCyc, 0 );
-            RequireArgument("CycList", val, 0,
-                            "each entry must be a rational");
+            RequireArgumentEx("CycList", val, 0,
+                              "each entry must be a rational");
         }
         res[i] = val;
     }

--- a/src/error.c
+++ b/src/error.c
@@ -552,12 +552,12 @@ void CheckSameLength(const Char * desc, const Char *leftName, const Char *rightN
 
 /****************************************************************************
 **
-*F  RequireArgument
+*F  RequireArgumentEx
 */
-Obj RequireArgument(const char * funcname,
-                    Obj          op,
-                    const char * argname,
-                    const char * msg)
+Obj RequireArgumentEx(const char * funcname,
+                      Obj          op,
+                      const char * argname,
+                      const char * msg)
 {
     char msgbuf[1024] = { 0 };
     Int  arg1 = 0;
@@ -568,9 +568,8 @@ Obj RequireArgument(const char * funcname,
         strlcat(msgbuf, ": ", sizeof(msgbuf));
     }
     if (argname) {
-        strlcat(msgbuf, "<", sizeof(msgbuf));
         strlcat(msgbuf, argname, sizeof(msgbuf));
-        strlcat(msgbuf, "> ", sizeof(msgbuf));
+        strlcat(msgbuf, " ", sizeof(msgbuf));
     }
     strlcat(msgbuf, msg, sizeof(msgbuf));
     if (IS_INTOBJ(op)) {

--- a/src/error.h
+++ b/src/error.h
@@ -93,7 +93,7 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 
 /****************************************************************************
 **
-*F  RequireArgument( <funcname>, <op>, <argname>, <msg>)
+*F  RequireArgumentEx( <funcname>, <op>, <argname>, <msg>)
 **
 **  Raises an error via ErrorMayQuit with an error message of this form:
 **    funcname: <argname> msg (not a %s)
@@ -103,102 +103,116 @@ ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 **  If funcname is 0, then 'funcname: ' is omitted from the message.
 **  If argname is 0, then '<argname> ' is omitted from the message.
 */
-extern Obj RequireArgument(const char * funcname,
-                           Obj          op,
-                           const char * argname,
-                           const char * msg) NORETURN;
+extern Obj RequireArgumentEx(const char * funcname,
+                             Obj          op,
+                             const char * argname,
+                             const char * msg) NORETURN;
+
+#define NICE_ARGNAME(op) "<" #op ">"
+
+/****************************************************************************
+**
+*F  RequireArgument
+*/
+#define RequireArgument(funcname, op, msg)                                   \
+    RequireArgumentEx(funcname, op, NICE_ARGNAME(op), msg)
+
+/****************************************************************************
+**
+*F  RequireArgumentConditionEx
+*/
+#define RequireArgumentConditionEx(funcname, op, argname, cond, msg)         \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            RequireArgumentEx(funcname, op, argname, msg);                   \
+        }                                                                    \
+    } while (0)
 
 /****************************************************************************
 **
 *F  RequireArgumentCondition
 */
-#define RequireArgumentCondition(funcname, op, argname, cond, msg)           \
-    do {                                                                     \
-        if (!(cond)) {                                                       \
-            RequireArgument(funcname, op, argname, msg);                     \
-        }                                                                    \
-    } while (0)
+#define RequireArgumentCondition(funcname, op, cond, msg)                    \
+    RequireArgumentConditionEx(funcname, op, NICE_ARGNAME(op), cond, msg)
 
 
 /****************************************************************************
 **
 *F  RequireInt
 */
-#define RequireInt(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_INT(op), \
-        "must be an integer")
+#define RequireInt(funcname, op)                                             \
+    RequireArgumentCondition(funcname, op, IS_INT(op), "must be an integer")
 
 
 /****************************************************************************
 **
 *F  RequireSmallInt
 */
-#define RequireSmallInt(funcname, op, argname) \
-    RequireArgumentCondition(funcname, op, argname, IS_INTOBJ(op), \
-        "must be a small integer")
+#define RequireSmallInt(funcname, op, argname)                               \
+    RequireArgumentConditionEx(funcname, op, argname, IS_INTOBJ(op),         \
+                               "must be a small integer")
 
 
 /****************************************************************************
 **
 *F  RequirePositiveSmallInt
 */
-#define RequirePositiveSmallInt(funcname, op, argname) \
-    RequireArgumentCondition(funcname, op, argname, IS_POS_INTOBJ(op), \
-        "must be a positive small integer")
+#define RequirePositiveSmallInt(funcname, op, argname)                       \
+    RequireArgumentConditionEx(funcname, op, argname, IS_POS_INTOBJ(op),     \
+                               "must be a positive small integer")
 
 
 /****************************************************************************
 **
 *F  RequireNonnegativeSmallInt
 */
-#define RequireNonnegativeSmallInt(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_NONNEG_INTOBJ(op), \
-        "must be a non-negative small integer")
+#define RequireNonnegativeSmallInt(funcname, op)                             \
+    RequireArgumentCondition(funcname, op, IS_NONNEG_INTOBJ(op),             \
+                             "must be a non-negative small integer")
 
 
 /****************************************************************************
 **
 *F  RequireSmallList
 */
-#define RequireSmallList(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_SMALL_LIST(op), \
-        "must be a small list")
+#define RequireSmallList(funcname, op)                                       \
+    RequireArgumentCondition(funcname, op, IS_SMALL_LIST(op),                \
+                             "must be a small list")
 
 
 /****************************************************************************
 **
 *F  RequireFunction
 */
-#define RequireFunction(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_FUNC(op), \
-        "must be a function")
+#define RequireFunction(funcname, op)                                        \
+    RequireArgumentCondition(funcname, op, IS_FUNC(op), "must be a function")
 
 
 /****************************************************************************
 **
 *F  RequireStringRep
 */
-#define RequireStringRep(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IsStringConv(op), \
-        "must be a string")
+#define RequireStringRep(funcname, op)                                       \
+    RequireArgumentCondition(funcname, op, IsStringConv(op),                 \
+                             "must be a string")
 
 
 /****************************************************************************
 **
 *F  RequirePermutation
 */
-#define RequirePermutation(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_PERM(op), \
-        "must be a permutation")
+#define RequirePermutation(funcname, op)                                     \
+    RequireArgumentCondition(funcname, op, IS_PERM(op),                      \
+                             "must be a permutation")
 
 
 /****************************************************************************
 **
 *F  RequirePlainList
 */
-#define RequirePlainList(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_PLIST(op), \
-        "must be a plain list")
+#define RequirePlainList(funcname, op)                                       \
+    RequireArgumentCondition(funcname, op, IS_PLIST(op),                     \
+                             "must be a plain list")
 
 
 /****************************************************************************
@@ -212,7 +226,8 @@ GetSmallIntEx(const char * funcname, Obj op, const char * argname)
     return INT_INTOBJ(op);
 }
 
-#define GetSmallInt(funcname, op) GetSmallIntEx(funcname, op, #op)
+#define GetSmallInt(funcname, op)                                            \
+    GetSmallIntEx(funcname, op, NICE_ARGNAME(op))
 
 /****************************************************************************
 **
@@ -226,7 +241,7 @@ GetPositiveSmallIntEx(const char * funcname, Obj op, const char * argname)
 }
 
 #define GetPositiveSmallInt(funcname, op)                                    \
-    GetPositiveSmallIntEx(funcname, op, #op)
+    GetPositiveSmallIntEx(funcname, op, NICE_ARGNAME(op))
 
 
 /****************************************************************************

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -104,7 +104,7 @@ Obj             EvalUnknownBool (
 
     /* check that the value is either 'true' or 'false'                    */
     if (val != True && val != False) {
-        RequireArgument(0, val, "expr", "must be 'true' or 'false'");
+        RequireArgumentEx(0, val, "<expr>", "must be 'true' or 'false'");
     }
 
     /* return the value                                                    */
@@ -188,8 +188,8 @@ Obj             EvalAnd (
     
     /* signal an error                                                     */
     else {
-        RequireArgument(0, opL, "expr",
-                        "must be 'true' or 'false' or a filter");
+        RequireArgumentEx(0, opL, "<expr>",
+                          "must be 'true' or 'false' or a filter");
     }
     
     /* please 'lint'                                                       */
@@ -829,7 +829,7 @@ Obj             EvalPermExpr (
 
             /* get and check current entry for the cycle                   */
             val = EVAL_EXPR(READ_EXPR(cycle, j - 1));
-            c = GetPositiveSmallIntEx("Permutation", val, "expr");
+            c = GetPositiveSmallIntEx("Permutation", val, "<expr>");
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",
                             0, 0);
@@ -1082,12 +1082,12 @@ Obj             EvalRangeExpr (
 
     /* evaluate the low value                                              */
     val = EVAL_EXPR(READ_EXPR(expr, 0));
-    low = GetSmallIntEx("Range", val, "first");
+    low = GetSmallIntEx("Range", val, "<first>");
 
     /* evaluate the second value (if present)                              */
     if ( SIZE_EXPR(expr) == 3*sizeof(Expr) ) {
         val = EVAL_EXPR(READ_EXPR(expr, 1));
-        Int ival = GetSmallIntEx("Range", val, "second");
+        Int ival = GetSmallIntEx("Range", val, "<second>");
         if (ival == low) {
             ErrorMayQuit("Range: <second> must not be equal to <first> (%d)",
                          (Int)low, 0);
@@ -1100,7 +1100,7 @@ Obj             EvalRangeExpr (
 
     /* evaluate and check the high value                                   */
     val = EVAL_EXPR(READ_EXPR(expr, SIZE_EXPR(expr) / sizeof(Expr) - 1));
-    high = GetSmallIntEx("Range", val, "last");
+    high = GetSmallIntEx("Range", val, "<last>");
     if ((high - low) % inc != 0) {
         ErrorMayQuit(
             "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -922,7 +922,7 @@ static Obj  HdlrFunc3 (
       t_3 = NewAndFilter( l_match, t_5 );
      }
      else {
-      RequireArgument(0, l_match, "expr",
+      RequireArgumentEx(0, l_match, "<expr>",
       "must be 'true' or 'false' or a filter" );
      }
      l_match = t_3;
@@ -2697,7 +2697,7 @@ static Obj  HdlrFunc7 (
      t_5 = NewAndFilter( l_cats, t_7 );
     }
     else {
-     RequireArgument(0, l_cats, "expr",
+     RequireArgumentEx(0, l_cats, "<expr>",
      "must be 'true' or 'false' or a filter" );
     }
     l_cats = t_5;
@@ -3206,7 +3206,7 @@ static Obj  HdlrFunc15 (
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -267,7 +267,7 @@ static Obj  HdlrFunc2 (
   t_5 = NewAndFilter( t_6, a_tester );
  }
  else {
-  RequireArgument(0, t_6, "expr",
+  RequireArgumentEx(0, t_6, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SET_ELM_PLIST( t_4, 1, t_5 );

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -43,25 +43,24 @@
 #include <pthread.h>
 
 
-#define RequireThread(funcname, op, argname) \
-    RequireArgumentCondition(funcname, op, argname, TNUM_OBJ(op) == T_THREAD, \
-        "must be a thread object")
+#define RequireThread(funcname, op, argname)                                 \
+    RequireArgumentConditionEx(funcname, op, "<" argname ">",                \
+                               TNUM_OBJ(op) == T_THREAD,                     \
+                               "must be a thread object")
 
-#define RequireChannel(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IsChannel(op), \
-        "must be a channel")
+#define RequireChannel(funcname, op)                                         \
+    RequireArgumentCondition(funcname, op, IsChannel(op), "must be a channel")
 
-#define RequireSemaphore(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, TNUM_OBJ(op) == T_SEMAPHORE, \
-        "must be a semaphore")
+#define RequireSemaphore(funcname, op)                                       \
+    RequireArgumentCondition(funcname, op, TNUM_OBJ(op) == T_SEMAPHORE,      \
+                             "must be a semaphore")
 
-#define RequireBarrier(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IsBarrier(op), \
-        "must be a barrier")
+#define RequireBarrier(funcname, op)                                         \
+    RequireArgumentCondition(funcname, op, IsBarrier(op), "must be a barrier")
 
-#define RequireSyncVar(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IsSyncVar(op), \
-        "must be a synchronization variable")
+#define RequireSyncVar(funcname, op)                                         \
+    RequireArgumentCondition(funcname, op, IsSyncVar(op),                    \
+                             "must be a synchronization variable")
 
 
 struct WaitList {

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -622,7 +622,7 @@ void            IntrIfBeginBody ( void )
     /* get and check the condition                                         */
     cond = PopObj();
     if ( cond != True && cond != False ) {
-        RequireArgument(0, cond, "expr", "must be 'true' or 'false'");
+        RequireArgumentEx(0, cond, "<expr>", "must be 'true' or 'false'");
     }
 
     /* if the condition is 'false', ignore the body                        */
@@ -1292,13 +1292,13 @@ void            IntrOr ( void )
             PushObj( opR );
         }
         else {
-            RequireArgument(0, opR, "expr", "must be 'true' or 'false'");
+            RequireArgumentEx(0, opR, "<expr>", "must be 'true' or 'false'");
         }
     }
 
     /* signal an error                                                     */
     else {
-        RequireArgument(0, opL, "expr", "must be 'true' or 'false'");
+        RequireArgumentEx(0, opL, "<expr>", "must be 'true' or 'false'");
     }
 }
 
@@ -1364,7 +1364,7 @@ void            IntrAnd ( void )
             PushObj( opR );
         }
         else {
-            RequireArgument(0, opR, "expr", "must be 'true' or 'false'");
+            RequireArgumentEx(0, opR, "<expr>", "must be 'true' or 'false'");
         }
     }
 
@@ -1375,8 +1375,8 @@ void            IntrAnd ( void )
 
     /* signal an error                                                     */
     else {
-        RequireArgument(0, opL, "expr",
-                        "must be 'true' or 'false' or a filter");
+        RequireArgumentEx(0, opL, "<expr>",
+                          "must be 'true' or 'false' or a filter");
     }
 }
 
@@ -1402,7 +1402,7 @@ void            IntrNot ( void )
     /* get and check the operand                                           */
     op = PopObj();
     if ( op != True && op != False ) {
-        RequireArgument(0, op, "expr", "must be 'true' or 'false'");
+        RequireArgumentEx(0, op, "<expr>", "must be 'true' or 'false'");
     }
 
     /* negate the operand                                                  */
@@ -1968,7 +1968,7 @@ void            IntrPermCycle (
 
         /* get and check current entry for the cycle                       */
         val = PopObj();
-        c = GetPositiveSmallIntEx("Permutation", val, "expr");
+        c = GetPositiveSmallIntEx("Permutation", val, "<expr>");
         if (c > MAX_DEG_PERM4)
           ErrorQuit( "Permutation literal exceeds maximum permutation degree",
                      0, 0);
@@ -2174,12 +2174,12 @@ void            IntrListExprEnd (
 
         /* get the low value                                               */
         val = ELM_LIST( list, 1 );
-        low = GetSmallIntEx("Range", val, "first");
+        low = GetSmallIntEx("Range", val, "<first>");
 
         /* get the increment                                               */
         if ( nr == 3 ) {
             val = ELM_LIST( list, 2 );
-            Int v = GetSmallIntEx("Range", val, "second");
+            Int v = GetSmallIntEx("Range", val, "<second>");
             if ( v == low ) {
                 ErrorQuit(
                       "Range: <second> must not be equal to <first> (%d)",
@@ -2193,7 +2193,7 @@ void            IntrListExprEnd (
 
         /* get and check the high value                                    */
         val = ELM_LIST( list, LEN_LIST(list) );
-        Int v = GetSmallIntEx("Range", val, "last");
+        Int v = GetSmallIntEx("Range", val, "<last>");
         if ( (v - low) % inc != 0 ) {
             ErrorQuit(
                 "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",
@@ -3477,7 +3477,7 @@ void            IntrAssPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
     /* get the list (checking is done by 'ASS_LIST')                       */
     list = PopObj();
@@ -3503,7 +3503,7 @@ void            IntrUnbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
     /* get the list (checking is done by 'UNB_LIST')                       */
     list = PopObj();
@@ -3535,7 +3535,7 @@ void            IntrElmPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
     /* get the list (checking is done by 'ELM_LIST')                       */
     list = PopObj();
@@ -3562,7 +3562,7 @@ void            IntrIsbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
     /* get the list (checking is done by 'ISB_LIST')                       */
     list = PopObj();
@@ -4010,8 +4010,8 @@ void             IntrAssertAfterCondition ( void )
     if (condition == True)
       STATE(IntrIgnoring)= 2;
     else if (condition != False)
-        RequireArgument("Assert", condition, "cond",
-                        "must be 'true' or 'false'");
+        RequireArgumentEx("Assert", condition, "<cond>",
+                          "must be 'true' or 'false'");
 }
 
 void             IntrAssertEnd2Args ( void )

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1197,7 +1197,7 @@ Obj             FuncOnSets (
 
     /* check the type of the first argument                                */
     if (!HAS_FILT_LIST(set, FN_IS_SSORT) && !IsSet(set)) {
-        RequireArgument("OnSets", set, "set", "must be a set");
+        RequireArgument("OnSets", set, "must be a set");
     }
 
     /* special case for the empty list */
@@ -1446,19 +1446,19 @@ Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
   srclist = ELM_PLIST(args, 1);
   GAP_ASSERT(srclist != 0);
   if (!IS_PLIST(srclist))
-      RequireArgument("CopyListEntries", srclist, "fromlst",
-                      "must be a plain list");
+      RequireArgumentEx("CopyListEntries", srclist, "<fromlst>",
+                        "must be a plain list");
 
-  srcstart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 2), "fromind");
-  srcinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 3), "fromstep");
+  srcstart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 2), "<fromind>");
+  srcinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 3), "<fromstep>");
   dstlist = ELM_PLIST(args,4);
   GAP_ASSERT(dstlist != 0);
   if (!IS_PLIST(dstlist) || !IS_MUTABLE_OBJ(dstlist))
-      RequireArgument("CopyListEntries", dstlist, "tolst",
-                      "must be a mutable plain list");
-  dststart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 5), "toind");
-  dstinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 6), "tostep");
-  number = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 7), "n");
+      RequireArgumentEx("CopyListEntries", dstlist, "<tolst>",
+                        "must be a mutable plain list");
+  dststart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 5), "<toind>");
+  dstinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 6), "<tostep>");
+  number = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 7), "<n>");
 
   if (number == 0)
     return (Obj) 0;

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -1888,12 +1888,10 @@ static Obj  FuncMONOM_TOT_DEG_LEX ( Obj self, Obj u, Obj  v ) {
   Obj  lexico;
 
   if (!IS_PLIST(u) || !IS_DENSE_LIST(u)) {
-      RequireArgument("MONOM_TOT_DEG_LEX", u, "u",
-                      "must be a dense plain list");
+      RequireArgument("MONOM_TOT_DEG_LEX", u, "must be a dense plain list");
   }
   if (!IS_PLIST(v) || !IS_DENSE_LIST(v)) {
-      RequireArgument("MONOM_TOT_DEG_LEX", v, "v",
-                      "must be a dense plain list");
+      RequireArgument("MONOM_TOT_DEG_LEX", v, "must be a dense plain list");
   }
     
   lu = LEN_PLIST( u );
@@ -1966,10 +1964,10 @@ static Obj  FuncMONOM_GRLEX( Obj self, Obj u, Obj  v ) {
   Obj  total,ai,bi;
 
   if (!IS_PLIST(u) || !IS_DENSE_LIST(u)) {
-      RequireArgument("MONOM_GRLEX", u, "u", "must be a dense plain list");
+      RequireArgument("MONOM_GRLEX", u, "must be a dense plain list");
   }
   if (!IS_PLIST(v) || !IS_DENSE_LIST(v)) {
-      RequireArgument("MONOM_GRLEX", v, "v", "must be a dense plain list");
+      RequireArgument("MONOM_GRLEX", v, "must be a dense plain list");
   }
     
   lu = LEN_PLIST( u );

--- a/src/lists.c
+++ b/src/lists.c
@@ -206,7 +206,7 @@ Obj FuncLEN_LIST (
 Int LenListError (
     Obj                 list )
 {
-    RequireArgument("Length", list, "list", "must be a list");
+    RequireArgument("Length", list, "must be a list");
 }
 
 
@@ -217,8 +217,8 @@ Int LenListObject (
 
     len = FuncLENGTH( LengthAttr, obj );
     if (!IS_NONNEG_INTOBJ(len)) {
-        RequireArgument("Length", len, 0,
-                        "method must return a non-negative value");
+        RequireArgumentEx("Length", len, 0,
+                          "method must return a non-negative value");
     }
     return INT_INTOBJ( len );
 }
@@ -240,7 +240,7 @@ Obj             (*LengthFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 Obj LengthError (
     Obj                 list )
 {
-    RequireArgument("Length", list, "list", "must be a list");
+    RequireArgument("Length", list, "must be a list");
 }
 
 
@@ -288,7 +288,7 @@ Int             IsbListError (
     Obj                 list,
     Int                 pos )
 {
-    RequireArgument("IsBound", list, "list", "must be a list");
+    RequireArgument("IsBound", list, "must be a list");
 }
 
 Int             IsbListObject (
@@ -390,7 +390,7 @@ Obj Elm0ListError (
     Obj                 list,
     Int                 pos )
 {
-    RequireArgument("List Element", list, "list", "must be a list");
+    RequireArgument("List Element", list, "must be a list");
 }
 
 
@@ -496,7 +496,7 @@ Obj ElmListError (
     Obj                 list,
     Int                 pos )
 {
-    RequireArgument("List Element", list, "list", "must be a list");
+    RequireArgument("List Element", list, "must be a list");
 }
 
 
@@ -594,7 +594,7 @@ Obj ElmsListError (
     Obj                 list,
     Obj                 poss )
 {
-    RequireArgument("List Elements", list, "list", "must be a list");
+    RequireArgument("List Elements", list, "must be a list");
 }
 
 
@@ -823,7 +823,7 @@ void            UnbListError (
     Obj                 list,
     Int                 pos )
 {
-    RequireArgument("Unbind", list, "list", "must be a list");
+    RequireArgument("Unbind", list, "must be a list");
 }
 
 void            UnbListDefault (
@@ -883,7 +883,7 @@ void            AssListError (
     Int                 pos,
     Obj                 obj )
 {
-    RequireArgument("List Assignment", list, "list", "must be a list");
+    RequireArgument("List Assignment", list, "must be a list");
 }
 
 void            AssListDefault (
@@ -969,7 +969,7 @@ void            AsssListError (
     Obj                 poss,
     Obj                 objs )
 {
-    RequireArgument("List Assignments", list, "list", "must be a list");
+    RequireArgument("List Assignments", list, "must be a list");
 }
 
 void            AsssListDefault (
@@ -1418,8 +1418,7 @@ Obj             PosListHandler3 (
     Obj                 start )
 {
     if (TNUM_OBJ(start) != T_INTPOS && !IS_NONNEG_INTOBJ(start)) {
-        RequireArgument("Position", start, "start",
-                        "must be a non-negative integer");
+        RequireArgument("Position", start, "must be a non-negative integer");
     }
     return POS_LIST( list, obj, start );
 }
@@ -1429,7 +1428,7 @@ Obj             PosListError (
     Obj                 obj,
     Obj                 start )
 {
-    RequireArgument("Position", list, "list", "must be a list");
+    RequireArgument("Position", list, "must be a list");
 }
 
 Obj             PosListDefault (
@@ -1594,7 +1593,7 @@ void            ElmsListLevel (
        Resolving this properly requires some more discussion. But until
        then, this change at least prevents hard crashes. */
     if (!IS_PLIST(lists)) {
-        RequireArgument("List Elements", lists, "lists", "must be a list");
+        RequireArgument("List Elements", lists, "must be a list");
     }
 
     /* if <level> is one, perform the replacements                         */

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -32,7 +32,7 @@
 #include "stringobj.h"
 
 #define RequireMacFloat(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_MACFLOAT(op), \
+    RequireArgumentCondition(funcname, op, IS_MACFLOAT(op), \
         "must be a macfloat")
 
 

--- a/src/objset.c
+++ b/src/objset.c
@@ -768,8 +768,7 @@ static Obj FuncOBJ_SET(Obj self, Obj arg) {
 
 static Obj FuncADD_OBJ_SET(Obj self, Obj set, Obj obj)
 {
-    RequireArgumentCondition("ADD_OBJ_SET", set, "objset",
-                             TNUM_OBJ(set) == T_OBJSET,
+    RequireArgumentCondition("ADD_OBJ_SET", set, TNUM_OBJ(set) == T_OBJSET,
                              "must be a mutable object set");
 
     AddObjSet(set, obj);
@@ -785,8 +784,7 @@ static Obj FuncADD_OBJ_SET(Obj self, Obj set, Obj obj)
 
 static Obj FuncREMOVE_OBJ_SET(Obj self, Obj set, Obj obj)
 {
-    RequireArgumentCondition("REMOVE_OBJ_SET", set, "objset",
-                             TNUM_OBJ(set) == T_OBJSET,
+    RequireArgumentCondition("REMOVE_OBJ_SET", set, TNUM_OBJ(set) == T_OBJSET,
                              "must be a mutable object set");
 
     RemoveObjSet(set, obj);
@@ -803,7 +801,7 @@ static Obj FuncREMOVE_OBJ_SET(Obj self, Obj set, Obj obj)
 
 static Obj FuncFIND_OBJ_SET(Obj self, Obj set, Obj obj)
 {
-    RequireArgumentCondition("FIND_OBJ_SET", set, "objset",
+    RequireArgumentCondition("FIND_OBJ_SET", set,
                              TNUM_OBJ(set) == T_OBJSET ||
                                  TNUM_OBJ(set) == T_OBJSET + IMMUTABLE,
                              "must be an object set");
@@ -821,8 +819,7 @@ static Obj FuncFIND_OBJ_SET(Obj self, Obj set, Obj obj)
 
 static Obj FuncCLEAR_OBJ_SET(Obj self, Obj set)
 {
-    RequireArgumentCondition("CLEAR_OBJ_SET", set, "objset",
-                             TNUM_OBJ(set) == T_OBJSET,
+    RequireArgumentCondition("CLEAR_OBJ_SET", set, TNUM_OBJ(set) == T_OBJSET,
                              "must be a mutable object set");
 
     ClearObjSet(set);
@@ -838,7 +835,7 @@ static Obj FuncCLEAR_OBJ_SET(Obj self, Obj set)
 
 static Obj FuncOBJ_SET_VALUES(Obj self, Obj set)
 {
-    RequireArgumentCondition("OBJ_SET_VALUES", set, "objset",
+    RequireArgumentCondition("OBJ_SET_VALUES", set,
                              TNUM_OBJ(set) == T_OBJSET ||
                                  TNUM_OBJ(set) == T_OBJSET + IMMUTABLE,
                              "must be an object set");
@@ -893,8 +890,7 @@ static Obj FuncOBJ_MAP(Obj self, Obj arg) {
 
 static Obj FuncADD_OBJ_MAP(Obj self, Obj map, Obj key, Obj value)
 {
-    RequireArgumentCondition("ADD_OBJ_MAP", map, "objmap",
-                             TNUM_OBJ(map) == T_OBJMAP,
+    RequireArgumentCondition("ADD_OBJ_MAP", map, TNUM_OBJ(map) == T_OBJMAP,
                              "must be a mutable object map");
 
     AddObjMap(map, key, value);
@@ -912,7 +908,7 @@ static Obj FuncADD_OBJ_MAP(Obj self, Obj map, Obj key, Obj value)
 
 static Obj FuncFIND_OBJ_MAP(Obj self, Obj map, Obj key, Obj defvalue)
 {
-    RequireArgumentCondition("FIND_OBJ_MAP", map, "objmap",
+    RequireArgumentCondition("FIND_OBJ_MAP", map,
                              TNUM_OBJ(map) == T_OBJMAP ||
                                  TNUM_OBJ(map) == T_OBJMAP + IMMUTABLE,
                              "must be an object map");
@@ -933,7 +929,7 @@ static Obj FuncFIND_OBJ_MAP(Obj self, Obj map, Obj key, Obj defvalue)
 
 static Obj FuncCONTAINS_OBJ_MAP(Obj self, Obj map, Obj key)
 {
-    RequireArgumentCondition("CONTAINS_OBJ_MAP", map, "objmap",
+    RequireArgumentCondition("CONTAINS_OBJ_MAP", map,
                              TNUM_OBJ(map) == T_OBJMAP ||
                                  TNUM_OBJ(map) == T_OBJMAP + IMMUTABLE,
                              "must be an object map");
@@ -952,8 +948,7 @@ static Obj FuncCONTAINS_OBJ_MAP(Obj self, Obj map, Obj key)
 
 static Obj FuncREMOVE_OBJ_MAP(Obj self, Obj map, Obj key)
 {
-    RequireArgumentCondition("REMOVE_OBJ_MAP", map, "objmap",
-                             TNUM_OBJ(map) == T_OBJMAP,
+    RequireArgumentCondition("REMOVE_OBJ_MAP", map, TNUM_OBJ(map) == T_OBJMAP,
                              "must be a mutable object map");
 
     RemoveObjMap(map, key);
@@ -969,8 +964,7 @@ static Obj FuncREMOVE_OBJ_MAP(Obj self, Obj map, Obj key)
 
 static Obj FuncCLEAR_OBJ_MAP(Obj self, Obj map)
 {
-    RequireArgumentCondition("CLEAR_OBJ_MAP", map, "objmap",
-                             TNUM_OBJ(map) == T_OBJMAP,
+    RequireArgumentCondition("CLEAR_OBJ_MAP", map, TNUM_OBJ(map) == T_OBJMAP,
                              "must be a mutable object map");
 
     ClearObjMap(map);
@@ -986,7 +980,7 @@ static Obj FuncCLEAR_OBJ_MAP(Obj self, Obj map)
 
 static Obj FuncOBJ_MAP_VALUES(Obj self, Obj map)
 {
-    RequireArgumentCondition("OBJ_MAP_VALUES", map, "objmap",
+    RequireArgumentCondition("OBJ_MAP_VALUES", map,
                              TNUM_OBJ(map) == T_OBJMAP ||
                                  TNUM_OBJ(map) == T_OBJMAP + IMMUTABLE,
                              "must be an object map");
@@ -1004,7 +998,7 @@ static Obj FuncOBJ_MAP_VALUES(Obj self, Obj map)
 
 static Obj FuncOBJ_MAP_KEYS(Obj self, Obj map)
 {
-    RequireArgumentCondition("OBJ_MAP_KEYS", map, "objmap",
+    RequireArgumentCondition("OBJ_MAP_KEYS", map,
                              TNUM_OBJ(map) == T_OBJMAP ||
                                  TNUM_OBJ(map) == T_OBJMAP + IMMUTABLE,
                              "must be an object map");
@@ -1036,22 +1030,22 @@ static StructBagNames BagNames[] = {
 **
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
-static StructGVarFunc GVarFuncs [] = {
+static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(OBJ_SET, -1, "[list]"),
-    GVAR_FUNC(ADD_OBJ_SET, 2, "objset, obj"),
-    GVAR_FUNC(REMOVE_OBJ_SET, 2, "objset, obj"),
-    GVAR_FUNC(FIND_OBJ_SET, 2, "objset, obj"),
-    GVAR_FUNC(CLEAR_OBJ_SET, 1, "objset"),
-    GVAR_FUNC(OBJ_SET_VALUES, 1, "objset"),
+    GVAR_FUNC(ADD_OBJ_SET, 2, "set, obj"),
+    GVAR_FUNC(REMOVE_OBJ_SET, 2, "set, obj"),
+    GVAR_FUNC(FIND_OBJ_SET, 2, "set, obj"),
+    GVAR_FUNC(CLEAR_OBJ_SET, 1, "set"),
+    GVAR_FUNC(OBJ_SET_VALUES, 1, "set"),
     GVAR_FUNC(OBJ_MAP, -1, "[list]"),
-    GVAR_FUNC(ADD_OBJ_MAP, 3, "objmap, key, value"),
-    GVAR_FUNC(REMOVE_OBJ_MAP, 2, "objmap, obj"),
-    GVAR_FUNC(FIND_OBJ_MAP, 3, "objmap, obj, default"),
-    GVAR_FUNC(CONTAINS_OBJ_MAP, 2, "objmap, obj"),
-    GVAR_FUNC(CLEAR_OBJ_MAP, 1, "objmap"),
-    GVAR_FUNC(OBJ_MAP_VALUES, 1, "objmap"),
-    GVAR_FUNC(OBJ_MAP_KEYS, 1, "objmap"),
+    GVAR_FUNC(ADD_OBJ_MAP, 3, "map, key, value"),
+    GVAR_FUNC(REMOVE_OBJ_MAP, 2, "map, obj"),
+    GVAR_FUNC(FIND_OBJ_MAP, 3, "map, obj, default"),
+    GVAR_FUNC(CONTAINS_OBJ_MAP, 2, "map, obj"),
+    GVAR_FUNC(CLEAR_OBJ_MAP, 1, "map"),
+    GVAR_FUNC(OBJ_MAP_VALUES, 1, "map"),
+    GVAR_FUNC(OBJ_MAP_KEYS, 1, "map"),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/src/opers.c
+++ b/src/opers.c
@@ -61,12 +61,12 @@ static Obj ArglistObj;
 *F * * * * * * * * * * * * internal flags functions * * * * * * * * * * * * *
 */
 
-#define RequireFlags(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, TNUM_OBJ(op) == T_FLAGS, \
-        "must be a flags list")
+#define RequireFlags(funcname, op)                                           \
+    RequireArgumentCondition(funcname, op, TNUM_OBJ(op) == T_FLAGS,          \
+                             "must be a flags list")
 
 #define RequireOperation(op)                                                 \
-    RequireArgumentCondition(CSTR_STRING(NAME_FUNC(self)), op, #op,          \
+    RequireArgumentCondition(CSTR_STRING(NAME_FUNC(self)), op,               \
                              IS_OPERATION(op), "must be an operation")
 
 
@@ -3434,7 +3434,7 @@ Obj FuncMETHODS_OPERATION (
     RequireOperation(oper);
     n = IS_INTOBJ(narg) ? INT_INTOBJ(narg) : -1;
     if (n < 0 || n > MAX_OPER_ARGS)
-        RequireArgument("METHODS_OPERATION", narg, "narg",
+        RequireArgument("METHODS_OPERATION", narg,
                         "must be an integer between 0 and 6");
     meth = MethsOper( oper, (UInt)n );
 #ifdef HPCGAP
@@ -3461,7 +3461,7 @@ Obj FuncCHANGED_METHODS_OPERATION (
     RequireOperation(oper);
     n = IS_INTOBJ(narg) ? INT_INTOBJ(narg) : -1;
     if (n < 0 || n > MAX_OPER_ARGS)
-        RequireArgument("CHANGED_METHODS_OPERATION", narg, "narg",
+        RequireArgument("CHANGED_METHODS_OPERATION", narg,
                         "must be an integer between 0 and 6");
 #ifdef HPCGAP
     if (!PreThreadCreation) {
@@ -3492,7 +3492,7 @@ Obj FuncSET_METHODS_OPERATION (
     RequireOperation(oper);
     n = IS_INTOBJ(narg) ? INT_INTOBJ(narg) : -1;
     if (n < 0 || n > MAX_OPER_ARGS)
-        RequireArgument("SET_METHODS_OPERATION", narg, "narg",
+        RequireArgument("SET_METHODS_OPERATION", narg,
                         "must be an integer between 0 and 6");
 #ifdef HPCGAP
     MEMBAR_WRITE();

--- a/src/opers.c
+++ b/src/opers.c
@@ -65,6 +65,10 @@ static Obj ArglistObj;
     RequireArgumentCondition(funcname, op, TNUM_OBJ(op) == T_FLAGS,          \
                              "must be a flags list")
 
+#define RequireFilter(funcname, op, argname)                                                 \
+    RequireArgumentConditionEx(funcname, op, argname,          \
+                             IS_FILTER(op), "must be a filter")
+
 #define RequireOperation(op)                                                 \
     RequireArgumentCondition(CSTR_STRING(NAME_FUNC(self)), op,               \
                              IS_OPERATION(op), "must be an operation")
@@ -1189,13 +1193,8 @@ Obj NewAndFilter (
     Obj                 str;
     char*               s;
 
-    if (!IS_FILTER(oper1))
-        ErrorQuit("<oper1> must be a filter (not a %s)", (Int)TNAM_OBJ(oper1),
-                  0);
-
-    if (!IS_FILTER(oper2))
-        ErrorQuit("<oper2> must be a filter (not a %s)", (Int)TNAM_OBJ(oper2),
-                  0);
+    RequireFilter(0, oper1, "<oper1>");
+    RequireFilter(0, oper2, "<oper2>");
 
     if ( oper1 == ReturnTrueFilter )
         return oper2;
@@ -1988,14 +1987,7 @@ static ALWAYS_INLINE Obj DoOperationNArgs(Obj  oper,
         types[1] = TYPE_OBJ_FEO(arg2);
     case 1:
         if (constructor) {
-            while (!IS_OPERATION(arg1)) {
-                arg1 = ErrorReturnObj("Constructor: the first argument must "
-                                      "be a filter not a %s",
-                                      (Int)TNAM_OBJ(arg1), 0L,
-                                      "you can replace the first argument "
-                                      "<arg1> via 'return <arg1>;'");
-            }
-
+            RequireFilter("Constructor", arg1, "the first argument");
             types[0] = FLAGS_FILT(arg1);
         }
         else

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -827,8 +827,8 @@ Obj PowIntPerm(Obj opL, Obj opR)
         return opL;
 
     img = INT_INTOBJ(opL);
-    RequireArgumentCondition("PowIntPerm", opL, "point", img > 0,
-                             "must be a positive integer");
+    RequireArgumentConditionEx("PowIntPerm", opL, "<point>", img > 0,
+                               "must be a positive integer");
 
     /* compute the image                                                   */
     if ( img <= DEG_PERM<T>(opR) ) {
@@ -870,8 +870,8 @@ Obj QuoIntPerm(Obj opL, Obj opR)
         return opL;
 
     img = INT_INTOBJ(opL);
-    RequireArgumentCondition("QuoIntPerm", opL, "point", img > 0,
-                             "must be a positive integer");
+    RequireArgumentConditionEx("QuoIntPerm", opL, "<point>", img > 0,
+                               "must be a positive integer");
 
     Obj inv = STOREDINV_PERM(opR);
 
@@ -2306,7 +2306,7 @@ Obj Array2Perm (
 
             /* get and check current entry for the cycle                   */
             val = ELM_LIST( cycle, j );
-            c = GetPositiveSmallIntEx("Permutation", val, "expr");
+            c = GetPositiveSmallIntEx("Permutation", val, "<expr>");
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",
                             0, 0);

--- a/src/plist.c
+++ b/src/plist.c
@@ -2509,7 +2509,7 @@ Obj FuncASS_PLIST_DEFAULT (
     /* check the arguments                                                 */
     p = GetPositiveSmallInt("List Assignment", pos);
     if (!IS_PLIST(plist) || !IS_PLIST_MUTABLE(plist)) {
-        RequireArgument(0, plist, "list", "must be a mutable plain list");
+        RequireArgumentEx(0, plist, "<list>", "must be a mutable plain list");
     }
 
     /* call `AssPlistXXX'                                                  */

--- a/src/range.c
+++ b/src/range.c
@@ -878,9 +878,10 @@ Obj FuncINTER_RANGE( Obj self, Obj r1, Obj r2)
   UInt len1, len2, leni;
   
   if (!IS_RANGE(r1) || !IS_MUTABLE_OBJ(r1))
-      RequireArgument("INTER_RANGE", r1, "range1", "must be a mutable range");
+      RequireArgumentEx("INTER_RANGE", r1, "<range1>",
+                        "must be a mutable range");
   if (!IS_RANGE(r2))
-      RequireArgument("INTER_RANGE", r2, "range2", "must be a range");
+      RequireArgumentEx("INTER_RANGE", r2, "<range2>", "must be a range");
 
   low1 = GET_LOW_RANGE(r1);
   low2 = GET_LOW_RANGE(r2);

--- a/src/rational.c
+++ b/src/rational.c
@@ -67,7 +67,7 @@
 
 
 #define RequireRational(funcname, op)                                        \
-    RequireArgumentCondition(funcname, op, #op,                              \
+    RequireArgumentCondition(funcname, op,                                   \
                              TNUM_OBJ(op) == T_RAT || IS_INT(op),            \
                              "must be a rational")
 

--- a/src/set.c
+++ b/src/set.c
@@ -34,9 +34,9 @@
 #include "sysopt.h"    // for SyInitializing
 
 
-#define RequireMutableSet(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_MUTABLE_OBJ(op) && IsSet(op), \
-        "must be a mutable proper set")
+#define RequireMutableSet(funcname, op)                                      \
+    RequireArgumentCondition(funcname, op, IS_MUTABLE_OBJ(op) && IsSet(op),  \
+                             "must be a mutable proper set")
 
 
 /****************************************************************************

--- a/src/stats.c
+++ b/src/stats.c
@@ -520,9 +520,9 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     /* evaluate the range                                                  */
     VisitStatIfHooked(READ_STAT(stat, 1));
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 0));
-    first = GetSmallIntEx("Range", elm, "first");
+    first = GetSmallIntEx("Range", elm, "<first>");
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 1));
-    last = GetSmallIntEx("Range", elm, "last");
+    last = GetSmallIntEx("Range", elm, "<last>");
 
     /* get the body                                                        */
     body1 = READ_STAT(stat, 2);
@@ -908,8 +908,8 @@ UInt ExecAssert2Args (
     if ( ! LT(CurrentAssertionLevel, level) )  {
         decision = EVAL_EXPR(READ_STAT(stat, 1));
         if (decision != True && decision != False) {
-            RequireArgument("Assert", decision, "cond",
-                            "must be 'true' or 'false'");
+            RequireArgumentEx("Assert", decision, "<cond>",
+                              "must be 'true' or 'false'");
         }
         if ( decision == False ) {
             ErrorReturnVoid( "Assertion failure", 0L, 0L, "you may 'return;'");
@@ -938,8 +938,8 @@ UInt ExecAssert3Args (
     if ( ! LT(CurrentAssertionLevel, level) ) {
         decision = EVAL_EXPR(READ_STAT(stat, 1));
         if (decision != True && decision != False) {
-            RequireArgument("Assert", decision, "cond",
-                            "must be 'true' or 'false'");
+            RequireArgumentEx("Assert", decision, "<cond>",
+                              "must be 'true' or 'false'");
         }
         if ( decision == False ) {
             message = EVAL_EXPR(READ_STAT(stat, 2));

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -257,7 +257,7 @@ Obj FuncINT_CHAR (
 {
     /* get and check the character                                         */
     if (TNUM_OBJ(val) != T_CHAR) {
-        RequireArgument("INT_CHAR", val, "val", "must be a character");
+        RequireArgument("INT_CHAR", val, "must be a character");
     }
 
     /* return the character                                                */
@@ -295,7 +295,7 @@ Obj FuncSINT_CHAR (
 {
     /* get and check the character                                         */
     if (TNUM_OBJ(val) != T_CHAR) {
-        RequireArgument("SINT_CHAR", val, "val", "must be a character");
+        RequireArgument("SINT_CHAR", val, "must be a character");
     }
 
     /* return the character                                                */
@@ -365,7 +365,7 @@ Obj FuncSTRING_SINTLIST (
   /* general code */
   if (!IS_RANGE(val) && !IS_PLIST(val)) {
   again:
-      RequireArgument("STRING_SINTLIST", val, "val",
+      RequireArgument("STRING_SINTLIST", val,
                       "must be a plain list of small integers or a range");
   }
   if (! IS_RANGE(val) ) {
@@ -1381,7 +1381,7 @@ Obj FuncCONV_STRING (
 {
     /* check whether <string> is a string                                  */
     if (!IS_STRING(string)) {
-        RequireArgument("ConvString", string, "string", "must be a string");
+        RequireArgument("ConvString", string, "must be a string");
     }
 
     /* convert to the string representation                                */
@@ -1409,15 +1409,13 @@ Obj FuncIS_STRING_REP (
 **
 *F  FuncCOPY_TO_STRING_REP( <self>, <obj> ) . copy a string into string rep
 */
-Obj FuncCOPY_TO_STRING_REP (
-    Obj                 self,
-    Obj                 obj )
+Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
 {
-    /* check whether <obj> is a string                                  */
-    if (!IS_STRING(obj)) {
-        RequireArgument("CopyToStringRep", obj, "string", "must be a string");
+    /* check whether <string> is a string                                 */
+    if (!IS_STRING(string)) {
+        RequireArgument("CopyToStringRep", string, "must be a string");
     }
-    return CopyToStringRep(obj);
+    return CopyToStringRep(string);
 }
 
 /****************************************************************************

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -777,15 +777,14 @@ Obj FuncSYNTAX_TREE(Obj self, Obj func)
     Obj result;
 
     if (!IS_FUNC(func) || IsKernelFunction(func) || IS_OPERATION(func)) {
-        RequireArgument("SYNTAX_TREE", func, "function",
-                        "must be a plain GAP function");
+        RequireArgument("SYNTAX_TREE", func, "must be a plain GAP function");
     }
 
     result = NewSyntaxTreeNode("T_FUNC_EXPR");
     return SyntaxTreeFunc(result, func);
 }
 
-static StructGVarFunc GVarFuncs[] = { GVAR_FUNC(SYNTAX_TREE, 1, "function"),
+static StructGVarFunc GVarFuncs[] = { GVAR_FUNC(SYNTAX_TREE, 1, "func"),
                                       { 0, 0, 0, 0, 0 } };
 
 static Int InitKernel(StructInitInfo * module)

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -74,9 +74,9 @@ extern "C" {
 #define MIN(a, b) (a < b ? a : b)
 #define MAX(a, b) (a < b ? b : a)
 
-#define RequireTransformation(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, IS_TRANS(op), \
-        "must be a transformation")
+#define RequireTransformation(funcname, op)                                  \
+    RequireArgumentCondition(funcname, op, IS_TRANS(op),                     \
+                             "must be a transformation")
 
 
 static ModuleStateOffset TransStateOffset = -1;

--- a/src/vars.c
+++ b/src/vars.c
@@ -1546,7 +1546,7 @@ UInt            ExecAssPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
@@ -1578,7 +1578,7 @@ UInt            ExecUnbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
     /* unbind the element                                                  */
     UnbPosObj(list, p);
@@ -1608,7 +1608,7 @@ Obj             EvalElmPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
     /* special case for plain lists (use generic code to signal errors)    */
     elm = ElmPosObj(list, p);
@@ -1638,7 +1638,7 @@ Obj             EvalIsbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
     /* get the result                                                      */
     isb = IsbPosObj(list, p) ? True : False;
@@ -2097,7 +2097,7 @@ Obj FuncGetBottomLVars( Obj self )
 Obj FuncParentLVars( Obj self, Obj lvars )
 {
   if (!IS_LVARS_OR_HVARS(lvars)) {
-      RequireArgument("ParentLVars", lvars, "lvars", "must be an lvars");
+      RequireArgument("ParentLVars", lvars, "must be an lvars");
   }
   Obj parent = PARENT_LVARS(lvars);
   return parent ? parent : Fail;

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -41,9 +41,9 @@
 #include "julia.h"
 #endif
 
-#define RequireWPObj(funcname, op) \
-    RequireArgumentCondition(funcname, op, #op, TNUM_OBJ(op) == T_WPOBJ, \
-        "must be a weak pointer object")
+#define RequireWPObj(funcname, op)                                           \
+    RequireArgumentCondition(funcname, op, TNUM_OBJ(op) == T_WPOBJ,          \
+                             "must be a weak pointer object")
 
 
 /****************************************************************************

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -44,7 +44,7 @@ static Obj  HdlrFunc3 (
   t_1 = NewAndFilter( t_2, INTOBJ_INT(1) );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -115,7 +115,7 @@ static Obj  HdlrFunc5 (
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -157,7 +157,7 @@ static Obj  HdlrFunc6 (
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -196,7 +196,7 @@ static Obj  HdlrFunc2 (
   t_2 = NewAndFilter( t_3, INTOBJ_INT(1) );
  }
  else {
-  RequireArgument(0, t_3, "expr",
+  RequireArgumentEx(0, t_3, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );
@@ -268,7 +268,7 @@ static Obj  HdlrFunc2 (
   t_2 = NewAndFilter( t_3, t_5 );
  }
  else {
-  RequireArgument(0, t_3, "expr",
+  RequireArgumentEx(0, t_3, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -44,7 +44,7 @@ static Obj  HdlrFunc3 (
   t_1 = NewAndFilter( t_2, INTOBJ_INT(1) );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -115,7 +115,7 @@ static Obj  HdlrFunc5 (
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -157,7 +157,7 @@ static Obj  HdlrFunc6 (
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
-  RequireArgument(0, t_2, "expr",
+  RequireArgumentEx(0, t_2, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -196,7 +196,7 @@ static Obj  HdlrFunc2 (
   t_2 = NewAndFilter( t_3, INTOBJ_INT(1) );
  }
  else {
-  RequireArgument(0, t_3, "expr",
+  RequireArgumentEx(0, t_3, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );
@@ -268,7 +268,7 @@ static Obj  HdlrFunc2 (
   t_2 = NewAndFilter( t_3, t_5 );
  }
  else {
-  RequireArgument(0, t_3, "expr",
+  RequireArgumentEx(0, t_3, "<expr>",
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );

--- a/tst/testinstall/boolean.tst
+++ b/tst/testinstall/boolean.tst
@@ -76,7 +76,7 @@ Error, <expr> must be 'true' or 'false' or a filter (not a function)
 gap> IsAssociative and ReturnTrue;
 Error, <oper2> must be a filter (not a function)
 gap> IsAssociative and true;
-Error, <oper2> must be a filter (not a boolean or fail)
+Error, <oper2> must be a filter (not the value 'true')
 gap> IsAssociative and Center;
 Error, <oper2> must be a filter (not a function)
 gap> IsAssociative and FirstOp;
@@ -108,7 +108,7 @@ Error, <expr> must be 'true' or 'false' or a filter (not a function)
 gap> function() return IsAssociative and ReturnTrue; end();
 Error, <oper2> must be a filter (not a function)
 gap> function() return IsAssociative and true; end();
-Error, <oper2> must be a filter (not a boolean or fail)
+Error, <oper2> must be a filter (not the value 'true')
 gap> function() return IsAssociative and Center; end();
 Error, <oper2> must be a filter (not a function)
 gap> function() return IsAssociative and FirstOp; end();

--- a/tst/testinstall/constructor.tst
+++ b/tst/testinstall/constructor.tst
@@ -8,7 +8,9 @@ Error, constructors must have at least one argument
 gap> c := NewConstructor("foobar",[IsObject]);
 <Constructor "foobar">
 gap> c(1);
-Error, Constructor: the first argument must be a filter not a integer
+Error, Constructor: the first argument must be a filter (not the integer 1)
+gap> c(c);
+Error, Constructor: the first argument must be a filter (not a function)
 gap> c(IsInt);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `foobar' on 1 arguments

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -176,7 +176,7 @@ Error, SET_TESTER_FILTER: <oper> must be an operation (not the value 'fail')
 
 # DoOperationNArgs
 gap> SymmetricGroupCons(1,2);
-Error, Constructor: the first argument must be a filter not a integer
+Error, Constructor: the first argument must be a filter (not the integer 1)
 
 #
 gap> NEW_OPERATION(fail);

--- a/tst/testinstall/objmap.tst
+++ b/tst/testinstall/objmap.tst
@@ -95,22 +95,21 @@ gap> for i in [1..MAPvals] do
 
 #
 gap> ADD_OBJ_MAP(fail, fail, fail);
-Error, ADD_OBJ_MAP: <objmap> must be a mutable object map (not the value 'fail\
-')
+Error, ADD_OBJ_MAP: <map> must be a mutable object map (not the value 'fail')
 gap> FIND_OBJ_MAP(fail, fail, fail);
-Error, FIND_OBJ_MAP: <objmap> must be an object map (not the value 'fail')
+Error, FIND_OBJ_MAP: <map> must be an object map (not the value 'fail')
 gap> CONTAINS_OBJ_MAP(fail, fail);
-Error, CONTAINS_OBJ_MAP: <objmap> must be an object map (not the value 'fail')
+Error, CONTAINS_OBJ_MAP: <map> must be an object map (not the value 'fail')
 gap> REMOVE_OBJ_MAP(fail, fail);
-Error, REMOVE_OBJ_MAP: <objmap> must be a mutable object map (not the value 'f\
-ail')
+Error, REMOVE_OBJ_MAP: <map> must be a mutable object map (not the value 'fail\
+')
 gap> CLEAR_OBJ_MAP(fail);
-Error, CLEAR_OBJ_MAP: <objmap> must be a mutable object map (not the value 'fa\
-il')
+Error, CLEAR_OBJ_MAP: <map> must be a mutable object map (not the value 'fail'\
+)
 gap> OBJ_MAP_VALUES(fail);
-Error, OBJ_MAP_VALUES: <objmap> must be an object map (not the value 'fail')
+Error, OBJ_MAP_VALUES: <map> must be an object map (not the value 'fail')
 gap> OBJ_MAP_KEYS(fail);
-Error, OBJ_MAP_KEYS: <objmap> must be an object map (not the value 'fail')
+Error, OBJ_MAP_KEYS: <map> must be an object map (not the value 'fail')
 
 #
 gap> STOP_TEST( "objmap.tst", 1);

--- a/tst/testinstall/objset.tst
+++ b/tst/testinstall/objset.tst
@@ -79,21 +79,20 @@ gap> for i in [1..setvals] do
 
 #
 gap> ADD_OBJ_SET(fail, fail);
-Error, ADD_OBJ_SET: <objset> must be a mutable object set (not the value 'fail\
-')
+Error, ADD_OBJ_SET: <set> must be a mutable object set (not the value 'fail')
 gap> REMOVE_OBJ_SET(fail, fail);
-Error, REMOVE_OBJ_SET: <objset> must be a mutable object set (not the value 'f\
-ail')
+Error, REMOVE_OBJ_SET: <set> must be a mutable object set (not the value 'fail\
+')
 gap> FIND_OBJ_SET(fail, fail);
-Error, FIND_OBJ_SET: <objset> must be an object set (not the value 'fail')
+Error, FIND_OBJ_SET: <set> must be an object set (not the value 'fail')
 gap> CLEAR_OBJ_SET(fail);
-Error, CLEAR_OBJ_SET: <objset> must be a mutable object set (not the value 'fa\
-il')
+Error, CLEAR_OBJ_SET: <set> must be a mutable object set (not the value 'fail'\
+)
 gap> OBJ_SET_VALUES(fail);
-Error, OBJ_SET_VALUES: <objset> must be an object set (not the value 'fail')
+Error, OBJ_SET_VALUES: <set> must be an object set (not the value 'fail')
 gap> CLEAR_OBJ_SET(fail);
-Error, CLEAR_OBJ_SET: <objset> must be a mutable object set (not the value 'fa\
-il')
+Error, CLEAR_OBJ_SET: <set> must be a mutable object set (not the value 'fail'\
+)
 
 #
 gap> STOP_TEST( "objset.tst", 1);

--- a/tst/testinstall/syntaxtree.tst
+++ b/tst/testinstall/syntaxtree.tst
@@ -1,17 +1,15 @@
 
 #
 gap> SYNTAX_TREE(1);
-Error, SYNTAX_TREE: <function> must be a plain GAP function (not the integer 1\
-)
+Error, SYNTAX_TREE: <func> must be a plain GAP function (not the integer 1)
 gap> SYNTAX_TREE(\+);
-Error, SYNTAX_TREE: <function> must be a plain GAP function (not a function)
+Error, SYNTAX_TREE: <func> must be a plain GAP function (not a function)
 gap> SyntaxTree(1);
-Error, SYNTAX_TREE: <function> must be a plain GAP function (not the integer 1\
-)
+Error, SYNTAX_TREE: <func> must be a plain GAP function (not the integer 1)
 gap> SyntaxTree(x -> x);
 <syntax tree>
 gap> SyntaxTree(\+);
-Error, SYNTAX_TREE: <function> must be a plain GAP function (not a function)
+Error, SYNTAX_TREE: <func> must be a plain GAP function (not a function)
 
 # Just try compiling all functions we can find in the workspace
 # to see nothing crashes.


### PR DESCRIPTION
The first commit changes calls like:

    RequireArgument("CopyToStringRep", obj, "string", "must be a string");

to this:

    RequireArgument("CopyToStringRep", obj, "<string>", "must be a string");

This change makes `RequireArgument` and the derived macros and functions more
flexible: in cases where there is no clear argument name (say inside a method
for addition), we can instead of `"<arg>"` write something more expressive, like
`"the left operand"`.

The second commit adds a new `RequireFilter` helper to `opers.c`, with a tighter check than we used before. Previously, we accepted this code, now it results in an error (again, as it
did in GAP 4.9):

    SymmetricGroupCons(SymmetricGroupCons, 2);

The second commit makes use of the increased flexibility introduced by the first commit.