### PR TITLE
Workaround for error #3055 and fix for GQuotient

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -738,6 +738,11 @@ local clT,	# classes T
 			  dsz:=DivisorsInt(scj);
 			fi;
 			while not minlen in dsz do
+                          # workaround rare problem -- try again
+                          if First(dsz,i->i>=minlen)=fail then
+                            return ConjugacyClassesSubwreath(
+                              F,M,n,autT,T,Lloc,components,embeddings,projections);
+                          fi;
 			  # minimum gcd multiple to get at least the
 			  # smallest divisor
 			  minlen:=minlen+

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5134,7 +5134,7 @@ InstallMethod(StoredExcludedOrders,"fp group",true,
 
 InstallGlobalFunction(ExcludedOrders,
 function(arg)
-local f,a,i,j,gens,tstord,excl,p,s;
+local f,a,b,i,j,gens,tstord,excl,p,s;
   f:=arg[1];
   s:=StoredExcludedOrders(f);
   gens:=FreeGeneratorsOfFpGroup(f);
@@ -5170,24 +5170,32 @@ local f,a,i,j,gens,tstord,excl,p,s;
       else
 	p:=PresentationFpGroup(f,0);
 	AddRelator(p,p!.generators[i]^j);
+        TzInitGeneratorImages(p);
 	TzGoGo(p);
 	if Length(p!.generators)=0 then
 	  AddSet(excl[i],j);
 	  AddSet(s[i][1],j);
 	else
 	  if i=1 then
-	    a:=[gens[2]];
+	    b:=[gens[2]];
 	  else
-	    a:=[gens[1]];
+	    b:=[gens[1]];
 	  fi;
 	  a:=CosetTableFromGensAndRels(gens,
-	       Concatenation(RelatorsOfFpGroup(f),[gens[i]^j]),a:
+	       Concatenation(RelatorsOfFpGroup(f),[gens[i]^j]),b:
 	       max:=15999,silent);
-	  if IsList(a) and Length(a[1])=1 and
-	     # now we can try the size
-	     Size(FpGroupPresentation(p))=1 then
-	    AddSet(excl[i],j);
-	    AddSet(s[i][1],j);
+          if IsList(a) and Length(a[1])=1 then
+            a:=FpGroupPresentation(p);
+            b:=List(b,x->MappedWord(x,FreeGeneratorsOfFpGroup(f),TzImagesOldGens(p)));
+            b:=List(b,x->MappedWord(x,p!.generators,GeneratorsOfGroup(a)));
+            # now we can try the size. Ensure we use the generator we know
+            a:=NEWTC_CosetEnumerator(FreeGeneratorsOfFpGroup(a),RelatorsOfFpGroup(a),
+              List(b,UnderlyingElement), true, false : cyclic := true,
+              limit := 50000 );
+            if NEWTC_CyclicSubgroupOrder(a)=1 then
+              AddSet(excl[i],j);
+              AddSet(s[i][1],j);
+            fi;
 	  fi;
 	fi;
       fi;

--- a/tst/testbugfix/2018-12-17-gquotient.tst
+++ b/tst/testbugfix/2018-12-17-gquotient.tst
@@ -1,0 +1,7 @@
+# reported by Giles Gardam. The code for eliminating element orders can run astray if 
+# a quotent by a generator power is cyclic, but also has cyclic subgroups of infinite
+# index.
+gap> F := FreeGroup("a", "b", "c");;
+gap> G := F/ParseRelators(F,"a2b5a2b2C2,a5c3B2");;
+gap> Length(GQuotients(G,AlternatingGroup(5)));
+1


### PR DESCRIPTION
This is a bug that arises very rarely, maybe based on random
selections. In this case restart calculations.

(The bug was reported in #3055)

Also fix for GQuotient running slow in certain cases of groups with infinite quotients.