### PR TITLE
kernel: remove `environ` arguments, remove sysenviron

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -35,6 +35,7 @@
 #include "stats.h"   // for ClearError
 #include "streams.h"
 #include "stringobj.h"
+#include "sysenv.h"
 #include "sysfiles.h"
 #include "sysmem.h"
 #include "sysopt.h"
@@ -150,8 +151,6 @@ void ViewObjHandler ( Obj obj )
 */
 UInt QUITTINGGVar;
 
-
-static char **sysenviron;
 
 /*
 TL: Obj ShellContext = 0;
@@ -433,7 +432,7 @@ Obj FuncSHELL (Obj self, Obj args)
   return res;
 }
 
-int realmain( int argc, char * argv[], char * environ[] )
+int realmain( int argc, char * argv[] )
 {
   UInt                type;                   /* result of compile       */
   Obj                 func;                   /* function (compiler)     */
@@ -442,7 +441,7 @@ int realmain( int argc, char * argv[], char * environ[] )
   SetupGAPLocation(argc, argv);
 
   /* initialize everything and read init.g which runs the GAP session */
-  InitializeGap( &argc, argv, environ );
+  InitializeGap( &argc, argv );
   if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial
                                    read of init.g  somehow*/
     /* maybe compile in which case init.g got skipped */
@@ -468,17 +467,17 @@ int realmain( int argc, char * argv[], char * environ[] )
 }
 
 #if !defined(COMPILECYGWINDLL)
-int main ( int argc, char * argv[], char * environ[] )
+int main ( int argc, char * argv[] )
 {
 #if defined(HAVE_BACKTRACE) && defined(PRINT_BACKTRACE)
   InstallBacktraceHandlers();
 #endif
 
 #ifdef HPCGAP
-  RunThreadedMain(realmain, argc, argv, environ);
+  RunThreadedMain(realmain, argc, argv);
   return 0;
 #else
-  return realmain(argc, argv, environ);
+  return realmain(argc, argv);
 #endif
 }
 
@@ -1374,17 +1373,17 @@ Obj FuncKERNEL_INFO(Obj self) {
   AssPRec(res,r, tmp);
 
   tmp = NEW_PREC(0);
-  for (i = 0; sysenviron[i]; i++) {
-    for (p = sysenviron[i]; *p != '='; p++)
+  for (i = 0; environ[i]; i++) {
+    for (p = environ[i]; *p != '='; p++)
       ;
-    lenstr2 = (UInt) (p-sysenviron[i]);
+    lenstr2 = (UInt) (p-environ[i]);
     p++;   /* Move pointer behind = character */
     lenstr = strlen(p);
     if (lenstr2 > lenstr)
         str = NEW_STRING(lenstr2);
     else
         str = NEW_STRING(lenstr);
-    strncat(CSTR_STRING(str),sysenviron[i],lenstr2);
+    strncat(CSTR_STRING(str),environ[i],lenstr2);
     r = RNamName(CONST_CSTR_STRING(str));
     *(CSTR_STRING(str)) = 0;
     strncat(CSTR_STRING(str),p, lenstr);
@@ -1724,8 +1723,7 @@ static Obj POST_RESTORE;
 
 void InitializeGap (
     int *               pargc,
-    char *              argv [],
-    char *              environ [] )
+    char *              argv [] )
 {
     /* initialize the basic system and gasman                              */
     InitSystem( *pargc, argv );
@@ -1743,8 +1741,6 @@ void InitializeGap (
     STATE(UserHasQUIT) = 0;
     STATE(UserHasQuit) = 0;
     STATE(JumpToCatchCallback) = 0;
-
-    sysenviron = environ;
 
     // get info structures for the built in modules
     ModulesSetup();

--- a/src/gap.h
+++ b/src/gap.h
@@ -123,8 +123,7 @@ enum {
 */
 extern void InitializeGap (
             int *               pargc,
-            char *              argv [],
-            char *              environ [] );
+            char *              argv [] );
 
 
 #endif // GAP_GAP_H

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -205,15 +205,13 @@ void InitMainThread(void)
     TLS(CountActive) = 1;
 }
 
-static NOINLINE void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
+static NOINLINE void RunThreadedMain2(int (*mainFunction)(int, char **),
                              int     argc,
-                             char ** argv,
-                             char ** environ);
+                             char ** argv);
 
-void RunThreadedMain(int (*mainFunction)(int, char **, char **),
+void RunThreadedMain(int (*mainFunction)(int, char **),
                      int     argc,
-                     char ** argv,
-                     char ** environ)
+                     char ** argv)
 {
 #ifndef HAVE_NATIVE_TLS
 #ifdef STACK_GROWS_UP
@@ -240,13 +238,12 @@ void RunThreadedMain(int (*mainFunction)(int, char **, char **),
     }
 #endif
 #endif
-    RunThreadedMain2(mainFunction, argc, argv, environ);
+    RunThreadedMain2(mainFunction, argc, argv);
 }
 
-static void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
+static void RunThreadedMain2(int (*mainFunction)(int, char **),
                              int     argc,
-                             char ** argv,
-                             char ** environ)
+                             char ** argv)
 {
     int                    i;
     static pthread_mutex_t main_thread_mutex;
@@ -276,7 +273,7 @@ static void RunThreadedMain2(int (*mainFunction)(int, char **, char **),
     InitSignals();
     if (sySetjmp(TLS(threadExit)))
         exit(0);
-    exit((*mainFunction)(argc, argv, environ));
+    exit((*mainFunction)(argc, argv));
 }
 
 void CreateMainRegion(void)

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -44,10 +44,9 @@ void AddGCRoots(void);
 void RemoveGCroots(void);
 
 void RunThreadedMain(
-        int (*mainFunction)(int, char **, char **),
+        int (*mainFunction)(int, char **),
         int argc,
-        char **argv,
-        char **environ );
+        char **argv );
 
 void CreateMainRegion(void);
 Obj RunThread(void (*start)(void *), void *arg);

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -31,11 +31,10 @@
 //
 void GAP_Initialize(int              argc,
                     char **          argv,
-                    char **          env,
                     GAP_CallbackFunc markBagsCallback,
                     GAP_CallbackFunc errorCallback)
 {
-    InitializeGap(&argc, argv, env);
+    InitializeGap(&argc, argv);
     SetExtraMarkFuncBags(markBagsCallback);
     STATE(JumpToCatchCallback) = errorCallback;
 

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -25,7 +25,6 @@ typedef void (*GAP_CallbackFunc)(void);
 // TODO: document this function
 extern void GAP_Initialize(int              argc,
                            char **          argv,
-                           char **          env,
                            GAP_CallbackFunc markBagsCallback,
                            GAP_CallbackFunc errorCallback);
 

--- a/src/sysenv.h
+++ b/src/sysenv.h
@@ -8,9 +8,23 @@
 **  SPDX-License-Identifier: GPL-2.0-or-later
 */
 
-extern int realmain(int argc, char *argv[]);
+#ifndef GAP_SYSENV_H
+#define GAP_SYSENV_H
 
-int main(int argc, char *argv[])
-{
-    return realmain(argc, argv);
-}
+#ifdef SYS_IS_CYGWIN32
+
+// cygwin declares environ in unistd.h
+#include <unistd.h>
+
+#elif defined(__APPLE__)
+
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+
+#elif !defined(environ)
+
+extern char ** environ;
+
+#endif
+
+#endif    // GAP_SYSENV_H

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -31,6 +31,7 @@
 #include "records.h"
 #include "stats.h"
 #include "stringobj.h"
+#include "sysenv.h"
 #include "sysopt.h"
 
 #include "hpc/thread.h"
@@ -2986,12 +2987,6 @@ void SySetErrorNo ( void )
 #endif
 #ifndef WIFEXITED
 # define WIFEXITED(stat_val) (((stat_val) & 255) == 0)
-#endif
-
-#ifdef SYS_IS_CYGWIN32
-// cygwin declares environ in unistd.h
-#else
-extern char ** environ;
 #endif
 
 void NullSignalHandler(int scratch) {}

--- a/tst/testlibgap/basic.c
+++ b/tst/testlibgap/basic.c
@@ -5,7 +5,7 @@
 int main(int argc, char ** argv)
 {
     printf("# Initializing GAP...\n");
-    GAP_Initialize(argc, argv, environ, 0L, 0L);
+    GAP_Initialize(argc, argv, 0, 0);
     test_eval("1+2+3;");
     test_eval("g:=FreeGroup(2);");
     test_eval("a:=g.1;");

--- a/tst/testlibgap/wscreate.c
+++ b/tst/testlibgap/wscreate.c
@@ -5,7 +5,7 @@
 #include "common.h"
 int main(int argc, char ** argv)
 {
-    GAP_Initialize(argc, argv, environ, 0L, 0L);
+    GAP_Initialize(argc, argv, 0, 0);
     test_eval("g:=FreeGroup(2);");
     test_eval("a:=g.1;");
     test_eval("b:=g.2;");

--- a/tst/testlibgap/wsload.c
+++ b/tst/testlibgap/wsload.c
@@ -12,7 +12,7 @@ int main(int argc, char ** argv)
     args[argc] = lpar;
     args[argc+1] = wsname;
     args[argc+2] = NULL;
-    GAP_Initialize(argc+2, args, environ, 0L, 0L);
+    GAP_Initialize(argc+2, args, 0, 0);
     printf("# looking at saved stuff...\n");
     test_eval("g;");
     test_eval("a;");


### PR DESCRIPTION
This is an alternative to PR #3106 by @embray based on the discussion there.

Closes #3106