### PR TITLE
Make Refinements an AtomicRecord so it can be added to by users

### DIFF
--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -1546,7 +1546,7 @@ end );
 ##
 #V  Refinements . . . . . . . . . . . . . . .  record of refinement processes
 ##
-InstallValue( Refinements, rec() );
+InstallValue( Refinements, AtomicRecord() );
 
 #############################################################################
 ##
@@ -1859,12 +1859,6 @@ function( rbase, image, G, f, Q, strat )
     return MeetPartitionStrat( rbase, image, Q, t, strat );
 end);
 Refinements.(STBBCKT_STRING_TWOCLOSURE):=Refinements_TwoClosure;
-
-#############################################################################
-##
-## After construction, make Refinements immutable for thread-safety
-##
-MakeImmutable(Refinements);
 
 
 #############################################################################


### PR DESCRIPTION
Previously Refinements was made Immutable for HPC-GAP, but the
documentation for partition backtrack says it can be added to
by users.