### PR TITLE
Double escape backslash in make_doc.in

### DIFF
--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -13,7 +13,7 @@ echo "--------------------"
 "$GAP" $GAPARGS -A <<EOF
 base:="@abs_top_srcdir@";;
 books:=["ref", "tut", "changes", "hpc", "dev"];;
-latexOpts := rec(Maintitlesize := "\\fontsize{36}{38}\\selectfont");;
+latexOpts := rec(Maintitlesize := "\\\\fontsize{36}{38}\\\\selectfont");;
 for run in [1,2] do
   for book in books do
     path := Concatenation(base, "/doc/", book);


### PR DESCRIPTION
The backslash needs double escape because of shell. (Bad title page noticed by Bill Allombert.)