### PR TITLE
Add make check-manuals to makemanuals Travis test

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -754,9 +754,8 @@ clean-doc:
 # Manual consistency check
 check-manuals: all
 	$(MKDIR_P) dev/log
-	((cd doc/ref ; \
-	  echo 'Read("testconsistency.g");' | $(TESTGAP) ) \
-	  > `date -u +dev/log/check_manuals_%Y-%m-%d-%H-%M` 2>&1 )
+	( cd doc/ref ; echo 'Read("testconsistency.g");' | $(TESTGAP) | \
+	               tee `date -u +../../dev/log/check_manuals_%Y-%m-%d-%H-%M` )
 
 .PHONY: doc clean-doc manuals check-manuals
 

--- a/doc/ref/testconsistency.g
+++ b/doc/ref/testconsistency.g
@@ -238,7 +238,8 @@ Print( with, " with examples \n");
 Print( without , " without examples \n");
 end;
 
-CheckDocCoverage(doc);
+# Uncomment next line to add ManSections without examples to the test log
+# CheckDocCoverage(doc);
 QUIT_GAP( CheckManSectionTypes(doc) );
 
 

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -127,6 +127,7 @@ GAPInput
 
   makemanuals)
     make doc
+    make check-manuals
     ;;
 
   testmanuals)


### PR DESCRIPTION
This continues #3105 and #3112. After partial clean up of types of ManSections (#3105) and fixing all `<Ref>` elements to ensure that they refer to an item properly mentioning its type, derived from the type of the ManSection for the corresponding item (#3112), the next step is to extend the `makemanuals` test in Travis to ensure that we maintain the reference manual in this state. Also, the log, a fragment of which is below, will be accessible on Travis, to provide a list of ManSections having no examples.

```
****************************************************************
*** Looking for ManSections having no examples 
****************************************************************
./help.xml:193 : SetHelpViewer
./../../lib/pager.gd:21 : Pager
./run.xml:578 : SaveWorkspace
./../../lib/system.g:552 : ARCH_IS_UNIX
...
./integers.xml:144 : \mod
./../../lib/zmodnz.gd:159 : ZmodnZ
./../../lib/zmodnz.gd:30 : IsZmodnZObj
./../../lib/random.gd:20 : IsRandomSource
./../../lib/random.gd:147 : IsMersenneTwister
./../../lib/bitfields.gd:19 : MakeBitfields
./../../lib/numtheor.gd:38 : InfoNumtheor
./../../lib/combinat.gd:294 : Combinations
./../../lib/combinat.gd:408 : Arrangements
./../../lib/combinat.gd:479 : UnorderedTuples
./../../lib/combinat.gd:510 : NrUnorderedTuples
./../../lib/combinat.gd:593 : Tuples
./../../lib/combinat.gd:623 : EnumeratorOfTuples
...
****************************************************************
*** Doc coverage report 
****************************************************************
2856 mansections 
1318 with examples 
1538 without examples 
****************************************************************
*** Checking types in ManSections 
****************************************************************
./../../lib/magma.gd:673 : Centralizer uses Attr instead of Oper
./../../lib/grp.gd:3538 : GrowthFunctionOfGroup uses Oper instead of Attr
./../../lib/oprt.gd:1243 : Orbit uses Oper instead of Func
./../../lib/oprt.gd:1281 : Orbits uses Oper instead of Attr
./../../lib/oprt.gd:1306 : OrbitsDomain uses Oper instead of Attr
./../../lib/oprt.gd:1357 : OrbitLength uses Oper instead of Func
./../../lib/oprt.gd:1378 : OrbitLengths uses Oper instead of Attr
./../../lib/oprt.gd:1400 : OrbitLengthsDomain uses Oper instead of Attr
./../../lib/oprt.gd:1431 : OrbitStabilizer uses Oper instead of Func
./../../lib/oprt.gd:1035 : SparseActionHomomorphism uses Oper instead of Func
./../../lib/oprt.gd:
1037 : SortedSparseActionHomomorphism uses Oper instead of Func
./../../lib/oprt.gd:1992 : CycleLengths uses Oper instead of Func
./../../lib/oprt.gd:1696 : IsTransitive uses Oper instead of Prop
./../../lib/oprt.gd:1517 : Transitivity uses Oper instead of Attr
./../../lib/oprt.gd:1844 : RankAction uses Oper instead of Attr
./../../lib/oprt.gd:1780 : IsSemiRegular uses Oper instead of Prop
./../../lib/oprt.gd:1807 : IsRegular uses Oper instead of Prop
./../../lib/oprt.gd:1670 : Earns uses Oper instead of Attr
./../../lib/oprt.gd:1731 : IsPrimitive uses Oper instead of Prop
./../../lib/oprt.gd:1552 : Blocks uses Oper instead of Func
./../../lib/oprt.gd:1554 : Blocks uses Attr instead of Func
./../../lib/oprt.gd:1596 : MaximalBlocks uses Oper instead of Func
./../../lib/oprt.gd:1598 : MaximalBlocks uses Attr instead of Func
./../../lib/oprt.gd:
1634 : RepresentativesMinimalBlocks uses Oper instead of Func
./../../lib/oprt.gd:
1637 : RepresentativesMinimalBlocks uses Attr instead of Func
./../../lib/oprt.gd:1148 : ExternalSet uses Oper instead of Attr
./../../lib/oprt.gd:1199 : ExternalSubset uses Oper instead of Func
./../../lib/oprt.gd:1221 : ExternalOrbit uses Oper instead of Func
./../../lib/oprt.gd:1453 : ExternalOrbits uses Oper instead of Attr
./../../lib/oprt.gd:1479 : ExternalOrbitsStabilizers uses Oper instead of Attr
./../../lib/ratfun.gd:1378 : Discriminant uses Oper instead of Attr
./../../lib/tom.gd:1506 : CyclicExtensionsTom uses Oper instead of Attr
./../../lib/ctbl.gd:1110 : IsAlmostSimple uses Prop instead of Oper
./../../lib/ctbl.gd:1114 : IsMonomial uses Prop instead of Oper
./../../lib/ctbl.gd:1115 : IsNilpotent uses Prop instead of Oper
./../../lib/ctbl.gd:1116 : IsPerfect uses Prop instead of Oper
./../../lib/ctbl.gd:1117 : IsSimple uses Prop instead of Oper
./../../lib/ctbl.gd:1118 : IsSolvable uses Prop instead of Oper
./../../lib/ctbl.gd:1119 : IsSporadicSimple uses Prop instead of Oper
./../../lib/ctbl.gd:1120 : IsSupersolvable uses Prop instead of Oper
./../../lib/ctbl.gd:2469 : DecompositionMatrix uses Oper instead of Attr
./../../lib/ctbl.gd:3824 : CharacterTableIsoclinic uses Oper instead of Attr
./../../lib/ctblmaps.gd:
584 : FusionConjugacyClassesOp uses Oper instead of Attr
./../../lib/ctblmono.gd:607 : TestMonomial uses Oper instead of Attr
./../../lib/ctblmono.gd:609 : TestMonomial uses Oper instead of Attr
./../../lib/ctblmono.gd:762 : TestRelativelySM uses Oper instead of Attr
./../../lib/ctblmono.gd:764 : TestRelativelySM uses Oper instead of Attr
****************************************************************
*** Checking types in cross-references 
****************************************************************
Found 7574 Ref elements including 7502 within the Reference manual
****************************************************************
Selected 3742 ManSections of the following types:
Attr - 753
Fam - 8
Filt - 358
Func - 1373
InfoClass - 21
Meth - 68
Oper - 894
Prop - 223
Var - 44
Found 47 errors in ManSection types 
Selected 6229 Ref elements referring to ManSections 
Found 0 errors and 0 warnings in Ref elements 
****************************************************************
```