### PR TITLE
kernel: tweak Get(Positive)SmallInt, Require(Positive)SmallInt

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -1146,7 +1146,7 @@ Obj FuncPositionNthTrueBlist (
 
     /* Check the arguments. */    
     RequireBlist("ListBlist", blist, "blist");
-    Int nth = GetPositiveSmallInt("Position", Nth, "nth");
+    Int nth = GetPositiveSmallIntEx("Position", Nth, "nth");
 
     nrb = NUMBER_BLOCKS_BLIST(blist);
     if ( ! nrb )  return Fail;

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -1711,8 +1711,8 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 */
 Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
 {
-    RequirePositiveSmallInt("SET_SCOBJ_MAX_STACK_SIZE", size, "size");
-    CollectorsState()->SC_MAX_STACK_SIZE = INT_INTOBJ(size);
+    CollectorsState()->SC_MAX_STACK_SIZE =
+        GetPositiveSmallInt("SET_SCOBJ_MAX_STACK_SIZE", size);
     return 0;
 }
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -858,8 +858,7 @@ static UInt FindCommonField(UInt nl, UInt nr, UInt *ml, UInt *mr)
 
 Obj FuncSetCyclotomicsLimit(Obj self, Obj newlimit)
 {
-    UInt ulimit =
-        GetPositiveSmallInt("SetCyclotomicsLimit", newlimit, "newlimit");
+    UInt ulimit = GetPositiveSmallInt("SetCyclotomicsLimit", newlimit);
 
     if (ulimit < CyclotomicsLimit) {
         ErrorMayQuit("SetCyclotomicsLimit: <newlimit> must not be less than "

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1535,7 +1535,7 @@ Obj FuncE (
     }
 
     /* get and check the argument                                          */
-    RequirePositiveSmallInt("E", n, "n");
+    GetPositiveSmallInt("E", n);
 
     /* for $e_1$ return 1 and for $e_2$ return -1                          */
     if ( n == INTOBJ_INT(1) )

--- a/src/error.h
+++ b/src/error.h
@@ -203,20 +203,30 @@ extern Obj RequireArgument(const char * funcname,
 
 /****************************************************************************
 **
-*F  GetSmallInt
+*F  GetSmallIntEx, GetSmallInt
 */
-static inline Int GetSmallInt(const char * funcname, Obj op, const char * argname)
+static inline Int
+GetSmallIntEx(const char * funcname, Obj op, const char * argname)
 {
     RequireSmallInt(funcname, op, argname);
     return INT_INTOBJ(op);
 }
 
+#define GetSmallInt(funcname, op) GetSmallIntEx(funcname, op, #op)
+
+/****************************************************************************
+**
+*F  GetPositiveSmallIntEx, GetPositiveSmallInt
+*/
 static inline Int
-GetPositiveSmallInt(const char * funcname, Obj op, const char * argname)
+GetPositiveSmallIntEx(const char * funcname, Obj op, const char * argname)
 {
     RequirePositiveSmallInt(funcname, op, argname);
     return INT_INTOBJ(op);
 }
+
+#define GetPositiveSmallInt(funcname, op)                                    \
+    GetPositiveSmallIntEx(funcname, op, #op)
 
 
 /****************************************************************************

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -829,7 +829,7 @@ Obj             EvalPermExpr (
 
             /* get and check current entry for the cycle                   */
             val = EVAL_EXPR(READ_EXPR(cycle, j - 1));
-            c = GetPositiveSmallInt("Permutation", val, "expr");
+            c = GetPositiveSmallIntEx("Permutation", val, "expr");
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",
                             0, 0);
@@ -1082,12 +1082,12 @@ Obj             EvalRangeExpr (
 
     /* evaluate the low value                                              */
     val = EVAL_EXPR(READ_EXPR(expr, 0));
-    low = GetSmallInt("Range", val, "first");
+    low = GetSmallIntEx("Range", val, "first");
 
     /* evaluate the second value (if present)                              */
     if ( SIZE_EXPR(expr) == 3*sizeof(Expr) ) {
         val = EVAL_EXPR(READ_EXPR(expr, 1));
-        Int ival = GetSmallInt("Range", val, "second");
+        Int ival = GetSmallIntEx("Range", val, "second");
         if (ival == low) {
             ErrorMayQuit("Range: <second> must not be equal to <first> (%d)",
                          (Int)low, 0);
@@ -1100,7 +1100,7 @@ Obj             EvalRangeExpr (
 
     /* evaluate and check the high value                                   */
     val = EVAL_EXPR(READ_EXPR(expr, SIZE_EXPR(expr) / sizeof(Expr) - 1));
-    high = GetSmallInt("Range", val, "last");
+    high = GetSmallIntEx("Range", val, "last");
     if ((high - low) % inc != 0) {
         ErrorMayQuit(
             "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",

--- a/src/gap.c
+++ b/src/gap.c
@@ -1188,7 +1188,7 @@ Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 
 Obj FuncSleep( Obj self, Obj secs )
 {
-    Int s = GetSmallInt("Sleep", secs, "secs");
+    Int s = GetSmallInt("Sleep", secs);
 
     if (s > 0)
         SySleep((UInt)s);
@@ -1212,7 +1212,7 @@ Obj FuncSleep( Obj self, Obj secs )
 
 Obj FuncMicroSleep( Obj self, Obj msecs )
 {
-    Int s = GetSmallInt("MicroSleep", msecs, "usecs");
+    Int s = GetSmallIntEx("MicroSleep", msecs, "usecs");
 
     if (s > 0)
         SyUSleep((UInt)s);

--- a/src/gap.c
+++ b/src/gap.c
@@ -1212,7 +1212,7 @@ Obj FuncSleep( Obj self, Obj secs )
 
 Obj FuncMicroSleep( Obj self, Obj msecs )
 {
-    Int s = GetSmallIntEx("MicroSleep", msecs, "usecs");
+    Int s = GetSmallInt("MicroSleep", msecs);
 
     if (s > 0)
         SyUSleep((UInt)s);

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1614,7 +1614,7 @@ Obj BindOncePosObj(Obj obj, Obj index, Obj *new, int eval, const char *currFuncN
   Int n;
   Bag *contents;
   Bag result;
-  n = GetPositiveSmallInt(currFuncName, index, "index");
+  n = GetPositiveSmallInt(currFuncName, index);
   ReadGuard(obj);
 #ifndef WARD_ENABLED
   contents = PTR_BAG(obj);
@@ -1670,7 +1670,7 @@ Obj BindOnceAPosObj(Obj obj, Obj index, Obj *new, int eval, const char *currFunc
   addr = ADDR_ATOM(obj);
   MEMBAR_READ();
   len = ALIST_LEN(addr[0].atom);
-  n = GetSmallInt(currFuncName, index, "index");
+  n = GetSmallInt(currFuncName, index);
   if (n <= 0 || n > len)
     FuncError("Index out of range");
   result = addr[n+1].obj;

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1614,8 +1614,7 @@ Obj BindOncePosObj(Obj obj, Obj index, Obj *new, int eval, const char *currFuncN
   Int n;
   Bag *contents;
   Bag result;
-  RequirePositiveSmallInt(currFuncName, index, "index");
-  n = INT_INTOBJ(index);
+  n = GetPositiveSmallInt(currFuncName, index, "index");
   ReadGuard(obj);
 #ifndef WARD_ENABLED
   contents = PTR_BAG(obj);

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1460,15 +1460,11 @@ Obj FuncReceiveAnyChannelWithIndex(Obj self, Obj args)
     }
 }
 
-Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj countobj)
+Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj count)
 {
-    int count;
     RequireChannel("MultiReceiveChannel", channel);
-    count = GetSmallIntEx("MultiReceiveChannel", countobj, "count");
-    if (count < 0)
-        return ArgumentError(
-            "MultiReceiveChannel: Size must be non-negative");
-    return MultiReceiveChannel(ObjPtr(channel), count);
+    RequireNonnegativeSmallInt("MultiReceiveChannel", count);
+    return MultiReceiveChannel(ObjPtr(channel), INT_INTOBJ(count));
 }
 
 Obj FuncInspectChannel(Obj self, Obj channel)

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1464,7 +1464,7 @@ Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj countobj)
 {
     int count;
     RequireChannel("MultiReceiveChannel", channel);
-    count = GetSmallInt("MultiReceiveChannel", countobj, "count");
+    count = GetSmallIntEx("MultiReceiveChannel", countobj, "count");
     if (count < 0)
         return ArgumentError(
             "MultiReceiveChannel: Size must be non-negative");
@@ -1642,7 +1642,7 @@ int IsBarrier(Obj obj)
 Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
 {
     RequireBarrier("StartBarrier", barrier);
-    Int c = GetSmallInt("StartBarrier", count, "count");
+    Int c = GetSmallInt("StartBarrier", count);
     StartBarrier(ObjPtr(barrier), c);
     return (Obj)0;
 }
@@ -2048,7 +2048,7 @@ Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec)
     if (name != Fail && !IsStringConv(name))
         return ArgumentError(
             "SHARE_NORECURSE: Second argument must be a string or fail");
-    Int p = GetSmallInt("SHARE_NORECURSE", prec, "prec");
+    Int p = GetSmallInt("SHARE_NORECURSE", prec);
     region->prec = p;
     if (!MigrateObjects(1, &obj, region, 0))
         return ArgumentError("SHARE_NORECURSE: Thread does not have "
@@ -2106,7 +2106,7 @@ Obj FuncNEW_REGION(Obj self, Obj name, Obj prec)
     if (name != Fail && !IsStringConv(name))
         return ArgumentError(
             "NEW_REGION: Second argument must be a string or fail");
-    Int p = GetSmallInt("NEW_REGION", prec, "prec");
+    Int p = GetSmallInt("NEW_REGION", prec);
     region->prec = p;
     if (name != Fail)
         SetRegionName(region, name);
@@ -2126,7 +2126,7 @@ Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
     if (name != Fail && !IsStringConv(name))
         return ArgumentError(
             "SHARE: Second argument must be a string or fail");
-    Int p = GetSmallInt("SHARE", prec, "prec");
+    Int p = GetSmallInt("SHARE", prec);
     region->prec = p;
     reachable = ReachableObjectsFrom(obj);
     if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1, region,
@@ -2145,7 +2145,7 @@ Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
     if (name != Fail && !IsStringConv(name))
         return ArgumentError(
             "SHARE_RAW: Second argument must be a string or fail");
-    Int p = GetSmallInt("SHARE_RAW", prec, "prec");
+    Int p = GetSmallInt("SHARE_RAW", prec);
     region->prec = p;
     reachable = ReachableObjectsFrom(obj);
     if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1, region,

--- a/src/integer.c
+++ b/src/integer.c
@@ -2561,13 +2561,13 @@ Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
   Int res;
 
   RequireInt("IsProbablyPrimeInt", n);
-  RequirePositiveSmallInt( "IsProbablyPrimeInt", reps, "reps" );
+  UInt r = GetPositiveSmallInt("IsProbablyPrimeInt", reps);
 
   CHECK_INT(n);
 
   FAKEMPZ_GMPorINTOBJ( n_mpz, n );
 
-  res = mpz_probab_prime_p( MPZ_FAKEMPZ(n_mpz), INT_INTOBJ(reps) );
+  res = mpz_probab_prime_p(MPZ_FAKEMPZ(n_mpz), r);
 
   if (res == 2) return True; /* definitely prime */
   if (res == 0) return False; /* definitely not prime */

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -444,9 +444,9 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
   }
 
   /* check the arguments                                                 */
-  Int seed = GetSmallInt("HASHKEY_BAG", opSeed, "seed");
+  Int seed = GetSmallIntEx("HASHKEY_BAG", opSeed, "seed");
 
-  Int offs = GetSmallInt("HASHKEY_BAG", opOffset, "offset");
+  Int offs = GetSmallIntEx("HASHKEY_BAG", opOffset, "offset");
   if (offs < 0 || offs > SIZE_OBJ(obj)) {
       ErrorMayQuit("HashKeyBag: <offset> must be non-negative and less than "
                    "the bag size",
@@ -454,7 +454,7 @@ Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj opSeed, Obj opOffset, Obj opMaxLen)
   }
 
   /* maximal number of bytes to read */
-  Int maxlen = GetSmallInt("HASHKEY_BAG", opMaxLen, "maxlen");
+  Int maxlen = GetSmallIntEx("HASHKEY_BAG", opMaxLen, "maxlen");
 
   n=SIZE_OBJ(obj)-offs;
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3171,10 +3171,6 @@ void            IntrElmListLevel ( Int narg,
       CHANGED_BAG(ixs);
     }
     SET_LEN_PLIST(ixs, narg);
-      
-    /* /\* get and check the position                                          *\/ */
-    /* pos = PopObj(); */
-    /* RequirePositiveSmallInt("List Element", pos, "position"); */
 
     /* get lists (if this works, then <lists> is nested <level> deep,      */
     /* checking it is nested <level>+1 deep is done by 'ElmListLevel')     */

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1968,7 +1968,7 @@ void            IntrPermCycle (
 
         /* get and check current entry for the cycle                       */
         val = PopObj();
-        c = GetPositiveSmallInt("Permutation", val, "expr");
+        c = GetPositiveSmallIntEx("Permutation", val, "expr");
         if (c > MAX_DEG_PERM4)
           ErrorQuit( "Permutation literal exceeds maximum permutation degree",
                      0, 0);
@@ -2174,12 +2174,12 @@ void            IntrListExprEnd (
 
         /* get the low value                                               */
         val = ELM_LIST( list, 1 );
-        low = GetSmallInt("Range", val, "first");
+        low = GetSmallIntEx("Range", val, "first");
 
         /* get the increment                                               */
         if ( nr == 3 ) {
             val = ELM_LIST( list, 2 );
-            Int v = GetSmallInt("Range", val, "second");
+            Int v = GetSmallIntEx("Range", val, "second");
             if ( v == low ) {
                 ErrorQuit(
                       "Range: <second> must not be equal to <first> (%d)",
@@ -2193,7 +2193,7 @@ void            IntrListExprEnd (
 
         /* get and check the high value                                    */
         val = ELM_LIST( list, LEN_LIST(list) );
-        Int v = GetSmallInt("Range", val, "last");
+        Int v = GetSmallIntEx("Range", val, "last");
         if ( (v - low) % inc != 0 ) {
             ErrorQuit(
                 "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",
@@ -3477,7 +3477,7 @@ void            IntrAssPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
 
     /* get the list (checking is done by 'ASS_LIST')                       */
     list = PopObj();
@@ -3503,7 +3503,7 @@ void            IntrUnbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
 
     /* get the list (checking is done by 'UNB_LIST')                       */
     list = PopObj();
@@ -3535,7 +3535,7 @@ void            IntrElmPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallInt("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
 
     /* get the list (checking is done by 'ELM_LIST')                       */
     list = PopObj();
@@ -3562,7 +3562,7 @@ void            IntrIsbPosObj ( void )
 
     /* get and check the position                                          */
     pos = PopObj();
-    p = GetPositiveSmallInt("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
 
     /* get the list (checking is done by 'ISB_LIST')                       */
     list = PopObj();

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1449,16 +1449,16 @@ Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
       RequireArgument("CopyListEntries", srclist, "fromlst",
                       "must be a plain list");
 
-  srcstart = GetSmallInt("CopyListEntries", ELM_PLIST(args, 2), "fromind");
-  srcinc = GetSmallInt("CopyListEntries", ELM_PLIST(args, 3), "fromstep");
+  srcstart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 2), "fromind");
+  srcinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 3), "fromstep");
   dstlist = ELM_PLIST(args,4);
   GAP_ASSERT(dstlist != 0);
   if (!IS_PLIST(dstlist) || !IS_MUTABLE_OBJ(dstlist))
       RequireArgument("CopyListEntries", dstlist, "tolst",
                       "must be a mutable plain list");
-  dststart = GetSmallInt("CopyListEntries", ELM_PLIST(args, 5), "toind");
-  dstinc = GetSmallInt("CopyListEntries", ELM_PLIST(args, 6), "tostep");
-  number = GetSmallInt("CopyListEntries", ELM_PLIST(args, 7), "n");
+  dststart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 5), "toind");
+  dstinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 6), "tostep");
+  number = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 7), "n");
 
   if (number == 0)
     return (Obj) 0;

--- a/src/lists.c
+++ b/src/lists.c
@@ -367,7 +367,7 @@ Obj ElmDefListObject(Obj list, Int pos, Obj def)
 
 Obj FuncELM_DEFAULT_LIST(Obj self, Obj list, Obj pos, Obj def)
 {
-    Int ipos = GetPositiveSmallInt("GetWithDefault", pos, "pos");
+    Int ipos = GetPositiveSmallInt("GetWithDefault", pos);
     return ELM_DEFAULT_LIST(list, ipos, def);
 }
 

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -1195,18 +1195,16 @@ Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
 **  Note that the order of the arguments to this function has been  reversed.
 */
 template <typename T>
-static inline Obj CYCLE_LENGTH_PERM_INT(Obj perm, Obj point)
+static inline Obj CYCLE_LENGTH_PERM_INT(Obj perm, UInt pnt)
 {
     const T *           ptPerm;         /* pointer to the permutation      */
     UInt                deg;            /* degree of the permutation       */
-    UInt                pnt;            /* value of the point              */
     UInt                len;            /* length of cycle (result)        */
     UInt                p;              /* loop variable                   */
 
     /* get pointer to the permutation, the degree, and the point       */
     ptPerm = CONST_ADDR_PERM<T>(perm);
     deg = DEG_PERM<T>(perm);
-    pnt = INT_INTOBJ(point)-1;
 
     /* now compute the length by looping over the cycle                */
     len = 1;
@@ -1223,15 +1221,17 @@ Obj             FuncCYCLE_LENGTH_PERM_INT (
     Obj                 perm,
     Obj                 point )
 {
+    UInt                pnt;            /* value of the point              */
+
     /* evaluate and check the arguments                                    */
     RequirePermutation("CycleLengthPermInt", perm);
-    RequirePositiveSmallInt("CycleLengthPermInt", point, "point");
+    pnt = GetPositiveSmallInt("CycleLengthPermInt", point) - 1;
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
-        return CYCLE_LENGTH_PERM_INT<UInt2>(perm, point);
+        return CYCLE_LENGTH_PERM_INT<UInt2>(perm, pnt);
     }
     else {
-        return CYCLE_LENGTH_PERM_INT<UInt4>(perm, point);
+        return CYCLE_LENGTH_PERM_INT<UInt4>(perm, pnt);
     }
 }
 
@@ -1248,20 +1248,18 @@ Obj             FuncCYCLE_LENGTH_PERM_INT (
 **  integer, under the permutation <perm> as a list.
 */
 template <typename T>
-static inline Obj CYCLE_PERM_INT(Obj perm, Obj point)
+static inline Obj CYCLE_PERM_INT(Obj perm, UInt pnt)
 {
     Obj                 list;           /* handle of the list (result)     */
     Obj *               ptList;         /* pointer to the list             */
     const T *           ptPerm;         /* pointer to the permutation      */
     UInt                deg;            /* degree of the permutation       */
-    UInt                pnt;            /* value of the point              */
     UInt                len;            /* length of the cycle             */
     UInt                p;              /* loop variable                   */
 
     /* get pointer to the permutation, the degree, and the point       */
     ptPerm = CONST_ADDR_PERM<T>(perm);
     deg = DEG_PERM<T>(perm);
-    pnt = INT_INTOBJ(point)-1;
 
     /* now compute the length by looping over the cycle                */
     len = 1;
@@ -1292,16 +1290,17 @@ Obj             FuncCYCLE_PERM_INT (
     Obj                 perm,
     Obj                 point )
 {
+    UInt                pnt;            /* value of the point              */
 
     /* evaluate and check the arguments                                    */
     RequirePermutation("CyclePermInt", perm);
-    RequirePositiveSmallInt("CyclePermInt", point, "point");
+    pnt = GetPositiveSmallInt("CyclePermInt", point) - 1;
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
-        return CYCLE_PERM_INT<UInt2>(perm, point);
+        return CYCLE_PERM_INT<UInt2>(perm, pnt);
     }
     else {
-        return CYCLE_PERM_INT<UInt4>(perm, point);
+        return CYCLE_PERM_INT<UInt4>(perm, pnt);
     }
 }
 

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2307,7 +2307,7 @@ Obj Array2Perm (
 
             /* get and check current entry for the cycle                   */
             val = ELM_LIST( cycle, j );
-            c = GetPositiveSmallInt("Permutation", val, "expr");
+            c = GetPositiveSmallIntEx("Permutation", val, "expr");
             if (c > MAX_DEG_PERM4)
               ErrorMayQuit( "Permutation literal exceeds maximum permutation degree",
                             0, 0);

--- a/src/plist.c
+++ b/src/plist.c
@@ -2507,8 +2507,7 @@ Obj FuncASS_PLIST_DEFAULT (
     Int                 p;
 
     /* check the arguments                                                 */
-    RequirePositiveSmallInt("List Assignment", pos, "pos");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("List Assignment", pos, "pos");
     if (!IS_PLIST(plist) || !IS_PLIST_MUTABLE(plist)) {
         RequireArgument(0, plist, "list", "must be a mutable plain list");
     }

--- a/src/plist.c
+++ b/src/plist.c
@@ -2507,7 +2507,7 @@ Obj FuncASS_PLIST_DEFAULT (
     Int                 p;
 
     /* check the arguments                                                 */
-    p = GetPositiveSmallInt("List Assignment", pos, "pos");
+    p = GetPositiveSmallInt("List Assignment", pos);
     if (!IS_PLIST(plist) || !IS_PLIST_MUTABLE(plist)) {
         RequireArgument(0, plist, "list", "must be a mutable plain list");
     }

--- a/src/range.c
+++ b/src/range.c
@@ -759,8 +759,8 @@ Obj Range2Check (
 {
     Obj                 range;
     Int                 f, l;
-    f = GetSmallInt("Range", first, "first");
-    l = GetSmallInt("Range", last, "last");
+    f = GetSmallInt("Range", first);
+    l = GetSmallInt("Range", last);
     if ( f > l ) {
         range = NEW_PLIST( T_PLIST, 0 );
     }
@@ -794,9 +794,9 @@ Obj Range3Check (
             "Range: <second> must not be equal to <first> (%d)",
             (Int)INT_INTOBJ(first), 0L );
     }
-    Int f = GetSmallInt("Range", first, "first");
-    Int i = GetSmallInt("Range", second, "second") - f;
-    Int l = GetSmallInt("Range", last, "last");
+    Int f = GetSmallInt("Range", first);
+    Int i = GetSmallInt("Range", second) - f;
+    Int l = GetSmallInt("Range", last);
     if ( (l - f) % i != 0 ) {
         ErrorQuit(
             "Range: <last>-<first> (%d) must be divisible by <inc> (%d)",

--- a/src/stats.c
+++ b/src/stats.c
@@ -520,9 +520,9 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     /* evaluate the range                                                  */
     VisitStatIfHooked(READ_STAT(stat, 1));
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 0));
-    first = GetSmallInt("Range", elm, "first");
+    first = GetSmallIntEx("Range", elm, "first");
     elm = EVAL_EXPR(READ_EXPR(READ_STAT(stat, 1), 1));
-    last = GetSmallInt("Range", elm, "last");
+    last = GetSmallIntEx("Range", elm, "last");
 
     /* get the body                                                        */
     body1 = READ_STAT(stat, 2);

--- a/src/streams.c
+++ b/src/streams.c
@@ -1394,7 +1394,7 @@ Obj FuncCLOSE_FILE (
     Obj             fid )
 {
     // check the argument
-    Int ifid = GetSmallInt("CLOSE_FILE", fid, "fid");
+    Int ifid = GetSmallInt("CLOSE_FILE", fid);
     
     /* call the system dependent function                                  */
     Int ret = SyFclose( ifid );
@@ -1433,7 +1433,7 @@ Obj FuncIS_END_OF_FILE (
     Obj             fid )
 {
     // check the argument
-    Int ifid = GetSmallInt("IS_END_OF_FILE", fid, "fid");
+    Int ifid = GetSmallInt("IS_END_OF_FILE", fid);
     
     Int ret = SyIsEndOfFile( ifid );
     return ret == -1 ? Fail : ( ret == 0 ? False : True );
@@ -1483,7 +1483,7 @@ Obj FuncPOSITION_FILE (
     Obj             fid )
 {
     // check the argument
-    Int ifid = GetSmallInt("POSITION_FILE", fid, "fid");
+    Int ifid = GetSmallInt("POSITION_FILE", fid);
 
     Int ret = SyFtell(ifid);
 
@@ -1506,7 +1506,7 @@ Obj FuncREAD_BYTE_FILE (
     Obj             fid )
 {
     // check the argument
-    Int ifid = GetSmallInt("READ_BYTE_FILE", fid, "fid");
+    Int ifid = GetSmallInt("READ_BYTE_FILE", fid);
     
     /* call the system dependent function                                  */
     Int ret = SyGetch( ifid );
@@ -1532,7 +1532,7 @@ Obj FuncREAD_LINE_FILE (
     Obj             str;
 
     // check the argument
-    Int ifid = GetSmallInt("READ_LINE_FILE", fid, "fid");
+    Int ifid = GetSmallInt("READ_LINE_FILE", fid);
 
     /* read <fid> until we see a newline or eof or we've read at least
        one byte and more are not immediately available */
@@ -1584,9 +1584,9 @@ Obj FuncREAD_ALL_FILE (
     UInt            csize;
 
     // check the argument
-    Int ifid = GetSmallInt("READ_ALL_FILE", fid, "fid");
+    Int ifid = GetSmallInt("READ_ALL_FILE", fid);
 
-    Int ilim = GetSmallInt("READ_ALL_FILE", limit, "limit");
+    Int ilim = GetSmallInt("READ_ALL_FILE", limit);
 
     /* read <fid> until we see  eof or we've read at least
        one byte and more are not immediately available */
@@ -1671,8 +1671,8 @@ Obj FuncSEEK_POSITION_FILE (
     Int             ret;
 
     // check the argument
-    Int ifid = GetSmallInt("SEEK_POSITION_FILE", fid, "fid");
-    Int ipos = GetSmallInt("SEEK_POSITION_FILE", pos, "pos");
+    Int ifid = GetSmallInt("SEEK_POSITION_FILE", fid);
+    Int ipos = GetSmallInt("SEEK_POSITION_FILE", pos);
     
     ret = SyFseek( ifid, ipos );
     return ret == -1 ? Fail : True;
@@ -1689,8 +1689,8 @@ Obj FuncWRITE_BYTE_FILE (
     Obj             ch )
 {
     // check the argument
-    Int ifid = GetSmallInt("WRITE_BYTE_FILE", fid, "fid");
-    Int ich = GetSmallInt("WRITE_BYTE_FILE", ch, "ch");
+    Int ifid = GetSmallInt("WRITE_BYTE_FILE", fid);
+    Int ich = GetSmallInt("WRITE_BYTE_FILE", ch);
     
     /* call the system dependent function                                  */
     Int ret = SyEchoch( ich, ifid );
@@ -1731,7 +1731,7 @@ Obj FuncREAD_STRING_FILE (
     Obj             fid )
 {
     // check the argument
-    Int ifid = GetSmallInt("READ_STRING_FILE", fid, "fid");
+    Int ifid = GetSmallInt("READ_STRING_FILE", fid);
     return SyReadStringFid(ifid);
 }
 
@@ -1741,7 +1741,7 @@ Obj FuncREAD_STRING_FILE (
 */
 Obj FuncFD_OF_FILE(Obj self,Obj fid)
 {
-    Int fd = GetSmallInt("FD_OF_FILE", fid, "fid");
+    Int fd = GetSmallInt("FD_OF_FILE", fid);
     Int fdi = SyBufFileno(fd);
     return INTOBJ_INT(fdi);
 }
@@ -1749,7 +1749,7 @@ Obj FuncFD_OF_FILE(Obj self,Obj fid)
 #ifdef HPCGAP
 Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 {
-    Int fd = GetSmallInt("RAW_MODE_FILE", fid, "fid");
+    Int fd = GetSmallInt("RAW_MODE_FILE", fid);
     if (onoff == False || onoff == Fail) {
         syStopraw(fd);
         return False;
@@ -1894,8 +1894,8 @@ Obj FuncExecuteProcess (
     // check the argument
     RequireStringRep("ExecuteProcess", dir);
     RequireStringRep("ExecuteProcess", prg);
-    Int iin = GetSmallInt("ExecuteProcess", in, "in");
-    Int iout = GetSmallInt("ExecuteProcess", out, "out");
+    Int iin = GetSmallInt("ExecuteProcess", in);
+    Int iout = GetSmallInt("ExecuteProcess", out);
     RequireSmallList("ExecuteProcess", args);
 
     /* create an argument array                                            */

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -237,7 +237,7 @@ Obj FuncCHAR_INT (
     Int             chr;
 
     /* get and check the integer value                                     */
-    chr = GetSmallInt("CHAR_INT", val, "val");
+    chr = GetSmallInt("CHAR_INT", val);
     if ( 255 < chr || chr < 0 ) {
         ErrorMayQuit("<val> must be an integer between 0 and 255", 0, 0);
     }
@@ -275,7 +275,7 @@ Obj FuncCHAR_SINT (
     Int chr;
 
     /* get and check the integer value                                     */
-    chr = GetSmallInt("CHAR_SINT", val, "val");
+    chr = GetSmallInt("CHAR_SINT", val);
     if (127 < chr || chr < -128) {
         ErrorMayQuit("<val> must be an integer between -128 and 127", 0, 0);
     }

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -1023,18 +1023,17 @@ Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
     Obj  out;
 
     RequireTransformation("PREIMAGES_TRANS_INT", f);
-    RequirePositiveSmallInt("PREIMAGES_TRANS_INT", pt, "pt");
+    i = GetPositiveSmallInt("PREIMAGES_TRANS_INT", pt) - 1;
 
     deg = DEG_TRANS(f);
 
-    if ((UInt)INT_INTOBJ(pt) > deg) {
+    if (i >= deg) {
         out = NEW_PLIST(T_PLIST_CYC, 1);
         SET_LEN_PLIST(out, 1);
         SET_ELM_PLIST(out, 1, pt);
         return out;
     }
 
-    i = INT_INTOBJ(pt) - 1;
     out = NEW_PLIST(T_PLIST_CYC_SSORT, 0);
     nr = 0;
 
@@ -2855,10 +2854,9 @@ Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
     UInt4 * ptseen;
 
     RequireTransformation("COMPONENT_TRANS_INT", f);
-    RequirePositiveSmallInt("COMPONENT_TRANS_INT", pt, "pt");
+    cpt = GetPositiveSmallInt("COMPONENT_TRANS_INT", pt) - 1;
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-    cpt = INT_INTOBJ(pt) - 1;
 
     if (cpt >= deg) {
         out = NEW_PLIST(T_PLIST_CYC_SSORT, 1);
@@ -2910,10 +2908,9 @@ Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
     UInt4 * ptseen;
 
     RequireTransformation("CYCLE_TRANS_INT", f);
-    RequirePositiveSmallInt("CYCLE_TRANS_INT", pt, "pt");
+    cpt = GetPositiveSmallInt("CYCLE_TRANS_INT", pt) - 1;
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
-    cpt = INT_INTOBJ(pt) - 1;
 
     if (cpt >= deg) {
         out = NEW_PLIST(T_PLIST_CYC_SSORT, 1);
@@ -4986,17 +4983,15 @@ Obj LQuoPerm4Trans4(Obj opL, Obj opR)
 ** Apply a transformation to a point
 *******************************************************************************/
 
-Obj PowIntTrans2(Obj i, Obj f)
+Obj PowIntTrans2(Obj point, Obj f)
 {
     Int img;
 
-    if (TNUM_OBJ(i) == T_INTPOS) {
-        return i;
+    if (TNUM_OBJ(point) == T_INTPOS) {
+        return point;
     }
 
-    RequirePositiveSmallInt("Tran. Operations", i, "point");
-
-    img = INT_INTOBJ(i);
+    img = GetPositiveSmallInt("Tran. Operations", point);
 
     if ((UInt)img <= DEG_TRANS2(f)) {
         img = (CONST_ADDR_TRANS2(f))[img - 1] + 1;
@@ -5005,17 +5000,15 @@ Obj PowIntTrans2(Obj i, Obj f)
     return INTOBJ_INT(img);
 }
 
-Obj PowIntTrans4(Obj i, Obj f)
+Obj PowIntTrans4(Obj point, Obj f)
 {
     Int img;
 
-    if (TNUM_OBJ(i) == T_INTPOS) {
-        return i;
+    if (TNUM_OBJ(point) == T_INTPOS) {
+        return point;
     }
 
-    RequirePositiveSmallInt("Tran. Operations", i, "point");
-
-    img = INT_INTOBJ(i);
+    img = GetPositiveSmallInt("Tran. Operations", point);
 
     if ((UInt)img <= DEG_TRANS4(f)) {
         img = (CONST_ADDR_TRANS4(f))[img - 1] + 1;

--- a/src/vars.c
+++ b/src/vars.c
@@ -1546,8 +1546,7 @@ UInt            ExecAssPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
@@ -1579,8 +1578,7 @@ UInt            ExecUnbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    RequirePositiveSmallInt("PosObj Assignment", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
 
     /* unbind the element                                                  */
     UnbPosObj(list, p);
@@ -1610,8 +1608,7 @@ Obj             EvalElmPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    RequirePositiveSmallInt("PosObj Element", pos, "position");
-    p = INT_INTOBJ( pos );
+    p = GetPositiveSmallInt("PosObj Element", pos, "position");
 
     /* special case for plain lists (use generic code to signal errors)    */
     elm = ElmPosObj(list, p);
@@ -1641,8 +1638,7 @@ Obj             EvalIsbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    RequirePositiveSmallInt("PosObj Element", pos, "position");
-    p = INT_INTOBJ( pos );
+    p = GetPositiveSmallInt("PosObj Element", pos, "position");
 
     /* get the result                                                      */
     isb = IsbPosObj(list, p) ? True : False;

--- a/src/vars.c
+++ b/src/vars.c
@@ -1546,7 +1546,7 @@ UInt            ExecAssPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
@@ -1578,7 +1578,7 @@ UInt            ExecUnbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
-    p = GetPositiveSmallInt("PosObj Assignment", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Assignment", pos, "position");
 
     /* unbind the element                                                  */
     UnbPosObj(list, p);
@@ -1608,7 +1608,7 @@ Obj             EvalElmPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    p = GetPositiveSmallInt("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
 
     /* special case for plain lists (use generic code to signal errors)    */
     elm = ElmPosObj(list, p);
@@ -1638,7 +1638,7 @@ Obj             EvalIsbPosObj (
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
-    p = GetPositiveSmallInt("PosObj Element", pos, "position");
+    p = GetPositiveSmallIntEx("PosObj Element", pos, "position");
 
     /* get the result                                                      */
     isb = IsbPosObj(list, p) ? True : False;

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2727,7 +2727,7 @@ Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
-    p = GetPositiveSmallInt("ELM0_VEC8BIT", pos, "position");
+    p = GetPositiveSmallIntEx("ELM0_VEC8BIT", pos, "position");
     if (LEN_VEC8BIT(list) < p) {
         return Fail;
     }
@@ -2755,7 +2755,7 @@ Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
-    p = GetPositiveSmallInt("ELM_VEC8BIT", pos, "position");
+    p = GetPositiveSmallIntEx("ELM_VEC8BIT", pos, "position");
     if (LEN_VEC8BIT(list) < p) {
         ErrorMayQuit("List Element: <list>[%d] must have an assigned value",
                      p, 0);
@@ -2962,7 +2962,7 @@ void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
     }
 
     // get the position
-    p = GetPositiveSmallInt("ASS_VEC8BIT", pos, "position");
+    p = GetPositiveSmallIntEx("ASS_VEC8BIT", pos, "position");
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     chr = P_FIELDINFO_8BIT(info);
@@ -3075,7 +3075,7 @@ Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
     }
 
     // get the position
-    p = GetPositiveSmallInt("UNB_VEC8BIT", pos, "position");
+    p = GetPositiveSmallIntEx("UNB_VEC8BIT", pos, "position");
 
     // if we unbind the last position keep the representation
     if (LEN_VEC8BIT(list) < p) {
@@ -3866,7 +3866,7 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
     UInt pos;
     Obj  type;
 
-    pos = GetPositiveSmallInt("ASS_MAT8BIT", p, "position");
+    pos = GetPositiveSmallIntEx("ASS_MAT8BIT", p, "position");
 
     len = LEN_MAT8BIT(mat);
     if (!IS_VEC8BIT_REP(obj) && !IS_GF2VEC_REP(obj))
@@ -3958,7 +3958,7 @@ cantdo:
 */
 Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj row)
 {
-    UInt r = GetPositiveSmallInt("ELM_MAT8BIT", row, "position");
+    UInt r = GetPositiveSmallIntEx("ELM_MAT8BIT", row, "position");
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
                      LEN_MAT8BIT(mat));
@@ -5770,8 +5770,8 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 */
 Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
 {
-    UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row, "row");
-    UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col, "col");
+    UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row);
+    UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col);
 
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
@@ -5795,8 +5795,8 @@ Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
 */
 Obj FuncSET_MAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
-    UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row, "row");
-    UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col, "col");
+    UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row);
+    UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col);
 
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -817,8 +817,8 @@ UInt LcmDegree(UInt d, UInt d1)
 */
 Obj FuncCONV_VEC8BIT(Obj self, Obj list, Obj q)
 {
-    RequirePositiveSmallInt("CONV_VEC8BIT", q, "q");
-    ConvVec8Bit(list, INT_INTOBJ(q));
+    UInt iq = GetPositiveSmallInt("CONV_VEC8BIT", q);
+    ConvVec8Bit(list, iq);
     return 0;
 }
 
@@ -938,8 +938,8 @@ Obj NewVec8Bit(Obj list, UInt q)
 */
 Obj FuncCOPY_VEC8BIT(Obj self, Obj list, Obj q)
 {
-    RequirePositiveSmallInt("COPY_VEC8BIT", q, "q");
-    return NewVec8Bit(list, INT_INTOBJ(q));
+    UInt iq = GetPositiveSmallInt("COPY_VEC8BIT", q);
+    return NewVec8Bit(list, iq);
 }
 
 /****************************************************************************
@@ -1456,11 +1456,9 @@ Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 
 Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
 {
-    if (!ARE_INTOBJS(q, len))
-        ErrorQuit("ZERO_VEC8BIT_2: arguments must be small integers, not a "
-                  "%s and a %s",
-                  (Int)TNAM_OBJ(q), (Int)TNAM_OBJ(len));
-    return ZeroVec8Bit(INT_INTOBJ(q), INT_INTOBJ(len), 1L);
+    UInt iq = GetPositiveSmallInt("ZERO_VEC8BIT_2", q);
+    RequireNonnegativeSmallInt("ZERO_VEC8BIT_2", len);
+    return ZeroVec8Bit(iq, INT_INTOBJ(len), 1);
 }
 
 /****************************************************************************
@@ -3368,21 +3366,21 @@ Obj FuncCONV_MAT8BIT(Obj self, Obj list, Obj q)
     Obj  tmp;
     Obj  type;
 
-    RequirePositiveSmallInt("CONV_MAT8BIT", q, "q");
+    UInt iq = GetPositiveSmallInt("CONV_MAT8BIT", q);
     PLAIN_LIST(list);
     len = LEN_PLIST(list);
     mut = IS_MUTABLE_OBJ(list);
     GROW_PLIST(list, len + 1);
     for (i = len; i >= 1; i--) {
         tmp = ELM_PLIST(list, i);
-        type = TypeVec8BitLocked(INT_INTOBJ(q), IS_MUTABLE_OBJ(tmp));
+        type = TypeVec8BitLocked(iq, IS_MUTABLE_OBJ(tmp));
         SetTypeDatObj(tmp, type);
         SET_ELM_MAT8BIT(list, i, tmp);
         CHANGED_BAG(list);
     }
     SET_LEN_MAT8BIT(list, len);
     RetypeBag(list, T_POSOBJ);
-    type = TypeMat8Bit(INT_INTOBJ(q), mut);
+    type = TypeMat8Bit(iq, mut);
     SET_TYPE_POSOBJ(list, type);
     return 0;
 }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2727,8 +2727,7 @@ Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
-    RequirePositiveSmallInt("ELM0_VEC8BIT", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("ELM0_VEC8BIT", pos, "position");
     if (LEN_VEC8BIT(list) < p) {
         return Fail;
     }
@@ -2756,8 +2755,7 @@ Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
-    RequirePositiveSmallInt("ELM_VEC8BIT", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("ELM_VEC8BIT", pos, "position");
     if (LEN_VEC8BIT(list) < p) {
         ErrorMayQuit("List Element: <list>[%d] must have an assigned value",
                      p, 0);
@@ -2964,8 +2962,7 @@ void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
     }
 
     // get the position
-    RequirePositiveSmallInt("ASS_VEC8BIT", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("ASS_VEC8BIT", pos, "position");
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     chr = P_FIELDINFO_8BIT(info);
@@ -3078,8 +3075,7 @@ Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
     }
 
     // get the position
-    RequirePositiveSmallInt("UNB_VEC8BIT", pos, "position");
-    p = INT_INTOBJ(pos);
+    p = GetPositiveSmallInt("UNB_VEC8BIT", pos, "position");
 
     // if we unbind the last position keep the representation
     if (LEN_VEC8BIT(list) < p) {
@@ -3870,8 +3866,7 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
     UInt pos;
     Obj  type;
 
-    RequirePositiveSmallInt("ASS_MAT8BIT", p, "position");
-    pos = INT_INTOBJ(p);
+    pos = GetPositiveSmallInt("ASS_MAT8BIT", p, "position");
 
     len = LEN_MAT8BIT(mat);
     if (!IS_VEC8BIT_REP(obj) && !IS_GF2VEC_REP(obj))
@@ -3963,8 +3958,7 @@ cantdo:
 */
 Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj row)
 {
-    RequirePositiveSmallInt("ELM_MAT8BIT", row, "position");
-    UInt r = INT_INTOBJ(row);
+    UInt r = GetPositiveSmallInt("ELM_MAT8BIT", row, "position");
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
                      LEN_MAT8BIT(mat));

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2727,7 +2727,7 @@ Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
-    p = GetPositiveSmallIntEx("ELM0_VEC8BIT", pos, "position");
+    p = GetPositiveSmallInt("ELM0_VEC8BIT", pos);
     if (LEN_VEC8BIT(list) < p) {
         return Fail;
     }
@@ -2755,7 +2755,7 @@ Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
-    p = GetPositiveSmallIntEx("ELM_VEC8BIT", pos, "position");
+    p = GetPositiveSmallInt("ELM_VEC8BIT", pos);
     if (LEN_VEC8BIT(list) < p) {
         ErrorMayQuit("List Element: <list>[%d] must have an assigned value",
                      p, 0);
@@ -2962,7 +2962,7 @@ void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
     }
 
     // get the position
-    p = GetPositiveSmallIntEx("ASS_VEC8BIT", pos, "position");
+    p = GetPositiveSmallInt("ASS_VEC8BIT", pos);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     chr = P_FIELDINFO_8BIT(info);
@@ -3075,7 +3075,7 @@ Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
     }
 
     // get the position
-    p = GetPositiveSmallIntEx("UNB_VEC8BIT", pos, "position");
+    p = GetPositiveSmallInt("UNB_VEC8BIT", pos);
 
     // if we unbind the last position keep the representation
     if (LEN_VEC8BIT(list) < p) {
@@ -3855,7 +3855,7 @@ Obj FuncINV_MAT8BIT_IMMUTABLE(Obj self, Obj mat)
 **
 */
 
-Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
+Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj pos, Obj obj)
 {
     UInt len;
     UInt len1;
@@ -3863,19 +3863,19 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
     UInt q;
     UInt q1, q2;
     Obj  row;
-    UInt pos;
+    UInt p;
     Obj  type;
 
-    pos = GetPositiveSmallIntEx("ASS_MAT8BIT", p, "position");
+    p = GetPositiveSmallInt("ASS_MAT8BIT", pos);
 
     len = LEN_MAT8BIT(mat);
     if (!IS_VEC8BIT_REP(obj) && !IS_GF2VEC_REP(obj))
         goto cantdo;
 
-    if (pos > len + 1)
+    if (p > len + 1)
         goto cantdo;
 
-    if (len == 1 && pos == 1) {
+    if (len == 1 && p == 1) {
         if (IS_VEC8BIT_REP(obj)) {
             q = FIELD_VEC8BIT(obj);
             goto cando;
@@ -3932,19 +3932,19 @@ Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj p, Obj obj)
     goto cantdo;
 
 cando:
-    if (pos > len) {
-        ResizeWordSizedBag(mat, sizeof(Obj) * (pos + 2));
-        SET_LEN_MAT8BIT(mat, pos);
+    if (p > len) {
+        ResizeWordSizedBag(mat, sizeof(Obj) * (p + 2));
+        SET_LEN_MAT8BIT(mat, p);
     }
     type = TypeVec8BitLocked(q, IS_MUTABLE_OBJ(obj));
     SetTypeDatObj(obj, type);
-    SET_ELM_MAT8BIT(mat, pos, obj);
+    SET_ELM_MAT8BIT(mat, p, obj);
     CHANGED_BAG(mat);
     return (Obj)0;
 
 cantdo:
     PlainMat8Bit(mat);
-    ASS_LIST(mat, pos, obj);
+    ASS_LIST(mat, p, obj);
     CHANGED_BAG(mat);
 
     return (Obj)0;
@@ -3953,12 +3953,12 @@ cantdo:
 
 /****************************************************************************
 **
-*F  FuncELM_MAT8BIT( <self>, <mat>, <row> ) .  select a row of an 8bit matrix
+*F  FuncELM_MAT8BIT( <self>, <mat>, <pos> ) .  select a row of an 8bit matrix
 **
 */
-Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj row)
+Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj pos)
 {
-    UInt r = GetPositiveSmallIntEx("ELM_MAT8BIT", row, "position");
+    UInt r = GetPositiveSmallInt("ELM_MAT8BIT", pos);
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
                      LEN_MAT8BIT(mat));

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1715,7 +1715,7 @@ Obj FuncLEN_GF2VEC(Obj self, Obj list)
 */
 Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 {
-    UInt p = GetSmallInt("ELM0_GF2VEC", pos, "pos");
+    UInt p = GetSmallInt("ELM0_GF2VEC", pos);
     if (LEN_GF2VEC(list) < p) {
         return Fail;
     }
@@ -1735,7 +1735,7 @@ Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 */
 Obj FuncELM_GF2VEC(Obj self, Obj list, Obj pos)
 {
-    UInt p = GetSmallInt("ELM_GF2VEC", pos, "pos");
+    UInt p = GetSmallInt("ELM_GF2VEC", pos);
     if (LEN_GF2VEC(list) < p) {
         ErrorMayQuit("List Element: <list>[%d] must have an assigned value",
                      p, 0);
@@ -1865,7 +1865,7 @@ Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
     }
 
     // get the position
-    UInt p = GetSmallInt("ASS_GF2VEC", pos, "pos");
+    UInt p = GetSmallInt("ASS_GF2VEC", pos);
 
     // if <elm> is Z(2) or 0*Z(2) and the position is OK, keep rep
     if (p <= LEN_GF2VEC(list) + 1) {
@@ -1933,7 +1933,7 @@ Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
     }
 
     // get the position
-    UInt p = GetSmallInt("ASS_GF2MAT", pos, "pos");
+    UInt p = GetSmallInt("ASS_GF2MAT", pos);
 
     // if <elm> is a GF2 vector and the length is OK, keep the rep
     if (!IS_GF2VEC_REP(elm)) {
@@ -1976,7 +1976,7 @@ Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
 */
 Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
 {
-    UInt r = GetSmallInt("ELM_GF2MAT", row, "row");
+    UInt r = GetSmallInt("ELM_GF2MAT", row);
     if (LEN_GF2MAT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
                      LEN_GF2MAT(mat));
@@ -2010,7 +2010,7 @@ Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
     }
 
     // get the position
-    UInt p = GetSmallInt("UNB_GF2VEC", pos, "pos");
+    UInt p = GetSmallInt("UNB_GF2VEC", pos);
 
     // if we unbind the last position keep the representation
     if (LEN_GF2VEC(list) < p) {
@@ -2047,7 +2047,7 @@ Obj FuncUNB_GF2MAT(Obj self, Obj list, Obj pos)
     }
 
     // get the position
-    UInt p = GetSmallInt("UNB_GF2MAT", pos, "pos");
+    UInt p = GetSmallInt("UNB_GF2MAT", pos);
 
     // if we unbind the last position keep the representation
     if (p > 1 && LEN_GF2MAT(list) < p) {

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -319,8 +319,7 @@ Obj FuncLengthWPObj(Obj self, Obj wp)
 Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 {
     RequireWPObj("SetElmWPObj", wp);
-    RequirePositiveSmallInt("SetElmWPObj", pos, "pos");
-    UInt ipos = INT_INTOBJ(pos);
+    UInt ipos = GetPositiveSmallInt("SetElmWPObj", pos, "pos");
 
 #ifdef USE_BOEHM_GC
   /* Ensure reference remains visible to GC in case val is
@@ -364,8 +363,7 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 Int IsBoundElmWPObj( Obj wp, Obj pos)
 {
     RequireWPObj("IsBoundElmWPObj", wp);
-    RequirePositiveSmallInt("IsBoundElmWPObj", pos, "pos");
-    UInt ipos = INT_INTOBJ(pos);
+    UInt ipos = GetPositiveSmallInt("IsBoundElmWPObj", pos, "pos");
 
 #ifdef HPCGAP
   volatile
@@ -410,8 +408,7 @@ Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("UnbindElmWPObj", wp);
-    RequirePositiveSmallInt("UnbindElmWPObj", pos, "pos");
-    UInt ipos = INT_INTOBJ(pos);
+    UInt ipos = GetPositiveSmallInt("UnbindElmWPObj", pos, "pos");
 
   Int len = LengthWPObj(wp);
   if ( ipos <= len ) {
@@ -487,8 +484,7 @@ Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("ElmWPObj", wp);
-    RequirePositiveSmallInt("ElmWPObj", pos, "pos");
-    Int ipos = INT_INTOBJ(pos);
+    UInt ipos = GetPositiveSmallInt("ElmWPObj", pos, "pos");
 
     return ElmDefWPList(wp, ipos, Fail);
 }

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -319,7 +319,7 @@ Obj FuncLengthWPObj(Obj self, Obj wp)
 Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 {
     RequireWPObj("SetElmWPObj", wp);
-    UInt ipos = GetPositiveSmallInt("SetElmWPObj", pos, "pos");
+    UInt ipos = GetPositiveSmallInt("SetElmWPObj", pos);
 
 #ifdef USE_BOEHM_GC
   /* Ensure reference remains visible to GC in case val is
@@ -363,7 +363,7 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 Int IsBoundElmWPObj( Obj wp, Obj pos)
 {
     RequireWPObj("IsBoundElmWPObj", wp);
-    UInt ipos = GetPositiveSmallInt("IsBoundElmWPObj", pos, "pos");
+    UInt ipos = GetPositiveSmallInt("IsBoundElmWPObj", pos);
 
 #ifdef HPCGAP
   volatile
@@ -408,7 +408,7 @@ Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("UnbindElmWPObj", wp);
-    UInt ipos = GetPositiveSmallInt("UnbindElmWPObj", pos, "pos");
+    UInt ipos = GetPositiveSmallInt("UnbindElmWPObj", pos);
 
   Int len = LengthWPObj(wp);
   if ( ipos <= len ) {
@@ -484,7 +484,7 @@ Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("ElmWPObj", wp);
-    UInt ipos = GetPositiveSmallInt("ElmWPObj", pos, "pos");
+    UInt ipos = GetPositiveSmallInt("ElmWPObj", pos);
 
     return ElmDefWPList(wp, ipos, Fail);
 }

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -168,7 +168,7 @@ gap> Sleep(1);
 
 #
 gap>    MicroSleep(fail);
-Error, MicroSleep: <usecs> must be a small integer (not the value 'fail')
+Error, MicroSleep: <msecs> must be a small integer (not the value 'fail')
 gap> MicroSleep(0);
 gap> MicroSleep(1);
 

--- a/tst/testinstall/straight.tst
+++ b/tst/testinstall/straight.tst
@@ -79,4 +79,3 @@ gap> ResultOfStraightLineProgram( prg, gens );
 
 #
 gap> STOP_TEST( "straight.tst" );
-


### PR DESCRIPTION
* renamed `Get(Positive)SmallInt` to `Get(Positive)SmallIntEx` (Ex for "extended)
* new function `Get(Positive)SmallInt` omit the `argname` argument, and instead deduced the argname from `op`
* converted a bunch of code to use `Get(Positive)SmallInt` instead of `Require(Positive)SmallInt`

The motivation for this is of course to reduce code duplication further, and making `Get(Positive)SmallInt` even easier to use. Indeed, in the future, we could even consider to omit the first argument (= the function name) in many, many cases, namely inside all kernel functions with a `self` variable, as we then can obtain the function name via `NAME_FUNC(self)`. Alas, that's a hypothetical right now, and not anything done by this PR.

This is part of PR #3109, but I figured it's easier to review and merge it on its own, after which PR #3109 can be rebased.