### PR TITLE
extend the default `BrauerTableOp` method

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -3102,10 +3102,33 @@ DeclareOperation( "CharacterTable", [ IsString ] );
 ##  returns its <A>p</A>-modular
 ##  character table if &GAP; can compute this table, and <K>fail</K>
 ##  otherwise.
-##  The <A>p</A>-modular table can be computed for <A>p</A>-solvable groups
-##  (using the Fong-Swan Theorem) and in the case that <A>ordtbl</A> is a
-##  table from the &GAP; character table library for which also the
-##  <A>p</A>-modular table is contained in the table library.
+##  <P/>
+##  The <A>p</A>-modular table can be computed in the following cases.
+##  <P/>
+##  <List>
+##  <Item>
+##    The group is <A>p</A>-solvable (see <Ref Oper="IsPSolvable"/>,
+##    apply the Fong-Swan Theorem);
+##  </Item>
+##  <Item>
+##    the Sylow <A>p</A>-subgroup of <A>G</A> is cyclic,
+##    and all <A>p</A>-modular Brauer characters of <A>G</A>
+##    lift to ordinary characters
+##    (note that this situation can be detected from the ordinary
+##    character table of <A>G</A>);
+##  </Item>
+##  <Item>
+##    the table <A>ordtbl</A> stores information how it was constructed from
+##    other tables (as a direct product or as an isoclinic variant,
+##    for example),
+##    and the Brauer tables of the source tables can be computed;
+##  </Item>
+##  <Item>
+##    <A>ordtbl</A> is a table from the &GAP; character table library
+##    for which also the <A>p</A>-modular table is contained in the table
+##    library.
+##  </Item>
+##  </List>
 ##  <P/>
 ##  The default method for a group and a prime delegates to
 ##  <Ref Oper="BrauerTable" Label="for a group, and a prime integer"/>

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -89,5 +89,28 @@ true
 gap> ForAny( ComputedPrimeBlockss( t ), IsMutable );
 false
 
+# create certain Brauer tables ...
+# ... of p-solvable groups
+gap> t:= CharacterTable( SymmetricGroup( 4 ) );;
+gap> IsCharacterTable( t mod 2 );
+true
+gap> IsCharacterTable( t mod 3 );
+true
+
+# ... where all Brauer characters lift to characteristic zero
+gap> g:= PSL(2,5);;
+gap> t:= CharacterTable( g );;
+gap> IsCharacterTable( t mod 3 );
+true
+gap> IsCharacterTable( t mod 5 );
+true
+
+# ... where the Brauer tables of the factors of a product can be computed
+gap> g:= AlternatingGroup( 5 );;
+gap> t:= CharacterTable( g );;
+gap> t:= CharacterTableDirectProduct( t, t );;
+gap> IsCharacterTable( t mod 5 );
+true
+
 ##
 gap> STOP_TEST( "ctbl.tst", 1);


### PR DESCRIPTION
- extended the default `BrauerTableOp` method to the case
  of cyclic defect such that all Brauer characters lift
  to characteristic zero (this case can be detected from the
  ordinary character table)

- extended the documentation accordingly

- extended the tests accordingly