### PR TITLE
MakeReadOnlyObj makes objects immutable in GAP

### DIFF
--- a/lib/hpc/thread1.g
+++ b/lib/hpc/thread1.g
@@ -20,7 +20,7 @@
 # Mock functions from thread1.g
 
 BIND_GLOBAL("MakeThreadLocal", ID_FUNC);
-BIND_GLOBAL("MakeReadOnlyObj", ID_FUNC);
+BIND_GLOBAL("MakeReadOnlyObj", MakeImmutable);
 BIND_GLOBAL("MakeReadOnlyRaw", ID_FUNC);
 BIND_GLOBAL("MakeReadOnlySingleObj", ID_FUNC);
 


### PR DESCRIPTION
Then code that is supposed to work both under GAP and HPC-GAP can
directly use MakeReadOnlyObj.

Fixes #3132.