### PR TITLE
Remove non-working coverage target

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -452,7 +452,6 @@ distclean: clean
 	rm -f doc/make_doc
 	rm -rf gen
 	rm -rf dev/log
-	rm -rf coverage
 	rm -rf tags
 	rm -rf TAGS
 	rmdir bin cnf dev doc src 2>/dev/null || : # remove dirs if they are now empty
@@ -1016,12 +1015,8 @@ testlibgap: ${LIBGAPTESTS}
 
 .PHONY: testlibgap
 
-coverage:
-	gcov -o . $(SOURCES)
-
 .PHONY: testinstall testmanuals testobsoletes teststandard testbugfix
 .PHONY: testpackage testpackages testpackagesload testpackagesvars
-.PHONY: coverage
 
 ########################################################################
 # Bootstrap rules

--- a/etc/ci-gather-coverage.sh
+++ b/etc/ci-gather-coverage.sh
@@ -74,9 +74,6 @@ else
 fi;
 GAPInput
 
-# generate kernel coverage reports by running gcov
-make coverage
-
 # upload to coveralls.io
 if [[ -f gap-coveralls.json ]]
 then


### PR DESCRIPTION
Gathering coverage with gcov is a bit more complicated than just running gcov.
It is probably best done running a tool such as lcov or gcovr. For now stop
pretending we support coverage collection.