### PR TITLE
ci: enable parallel build webhook for Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - LDFLAGS="--coverage"
     # default config flags: enable debug asserts
     - CONFIGFLAGS="--enable-debug"
+    - COVERALLS_PARALLEL=true
 
 addons:
   apt_packages:
@@ -142,3 +143,4 @@ notifications:
     on_pull_requests: false
     on_success: change # default: always
     on_failure: change # default: always
+  webhooks: https://coveralls.io/webhook


### PR DESCRIPTION
This should ensure that coverage results are merged by Coveralls after all
have completed.

See <https://docs.coveralls.io/parallel-build-webhook> for details.

These changes are also contained in PR #3138, but it would be useful to have them in effect *now*, while it is not yet clear when that PR will be ready.