### PR TITLE
Fix IsMonomialMatrix for compressed matrices

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2574,7 +2574,7 @@ InstallMethod( IsMonomialMatrix,
     if Length( M ) <> len  then
         return false;
     fi;
-    found:= BlistList( M, [] );
+    found:= ListWithIdenticalEntries( len, false );
     for row  in M  do
         j := PositionNonZero( row );
         if len < j or found[j]  then

--- a/tst/testbugfix/2018-12-28-IsMonomialMatrix.tst
+++ b/tst/testbugfix/2018-12-28-IsMonomialMatrix.tst
@@ -1,0 +1,4 @@
+gap> Number(SL(2,2), IsMonomialMatrix);
+2
+gap> Number(SL(2,3), IsMonomialMatrix);
+4


### PR DESCRIPTION
Note that for MatrixObj implementations which are *not* lists, doing `for row in M do` may not work anymore (unless we decide to officially define that `Iterator(matobj)` shall return a row iterator).

Fixes #3148

We could backport this, the change should be safe enough; but since this is an ancient bug, there is no urgent need to do it either.