### PR TITLE
FIX: Fitting free data use in clashom

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -2398,8 +2398,15 @@ local r,	#radical
       hom:=ser.factorhom;
       ntrihom:=true;
       f:=Image(hom);
+      # if lift setup is inherited, f might not be trivial-fitting
+      if Size(RadicalGroup(f))>1 then
+        # this is proper recursion
+        cl:=ConjugacyClasses(f:onlysizes:=false);
+        cl:=List(cl,x->[Representative(x),Centralizer(x)]);
+      else
       # we need centralizers
-      cl:=ConjugacyClassesFittingFreeGroup(f:onlysizes:=false);
+        cl:=ConjugacyClassesFittingFreeGroup(f:onlysizes:=false);
+      fi;
       fants:=Filtered(NormalSubgroups(f),x->Size(x)>1 and Size(x)<Size(f));
     else
       if IsPermGroup(G) then

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -191,15 +191,17 @@ local ffs,hom,U,rest,ker,r,p,l,i,depths;
 
   U!.cachedFFS:=[[ffs,r]];
 
-  # FittingFreeLiftSetup for U
-  r:=rec(inducedfrom:=ffs,
-         pcgs:=ipcgs,
-	 depths:=depths,
-         pcisom:=ffs.pcisom,
-         radical:=ker,
-         factorhom:=rest
-	);
-  SetFittingFreeLiftSetup(U,r);
+  # FittingFreeLiftSetup for U, if correct
+  if Size(RadicalGroup(Image(rest,U)))=1 then
+    r:=rec(inducedfrom:=ffs,
+          pcgs:=ipcgs,
+          depths:=depths,
+          pcisom:=ffs.pcisom,
+          radical:=ker,
+          factorhom:=rest
+          );
+    SetFittingFreeLiftSetup(U,r);
+  fi;
 
   return U;
 

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -138,7 +138,7 @@ local ffs,hom,U,rest,ker,r,p,l,i,depths;
     for i in U{[1..Length(U)-1]} do # last one is length+1
       p:=PositionProperty(r,x->x>=i);
       if p<>fail and p<=Length(ipcgs) and not p in l then
-	Add(l,p);
+        Add(l,p);
       fi;
     od;
     Add(l,Length(ipcgs)+1);

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1,7 +1,8 @@
 #############################################################################
 ##
 ##  This file is part of GAP, a system for computational discrete algebra.
-##  This files's authors include Thomas Breuer, Frank Celler, Bettina Eick, Heiko Theißen.
+##  This files's authors include Thomas Breuer, Frank Celler, Bettina Eick,
+##  Heiko Theißen.
 ##
 ##  Copyright of GAP belongs to its developers, whose names are too numerous
 ##  to list here. Please refer to the COPYRIGHT file for details.
@@ -1875,8 +1876,8 @@ DeclareAttribute( "MinimalNormalSubgroups", IsGroup );
 ##  returns a list of all normal subgroups of <A>G</A>.
 ##  <Example><![CDATA[
 ##  gap> g:=SymmetricGroup(4);;NormalSubgroups(g);
-##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,2)
-##    (3,4) ]), Group(()) ]
+##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), Group([ (1,4)(2,3), (1,3)
+##    (2,4) ]), Group(()) ]
 ##  ]]></Example>
 ##  <P/>
 ##  The algorithm for the computation of normal subgroups is described in
@@ -3232,7 +3233,7 @@ DeclareOperation("CentralizerModulo", [IsGroup,IsGroup,IsObject]);
 ##  [ <pc group of size 12 with 3 generators>, Group([ y3, y*y3 ]), Group([ y*y3 ]) ]
 ##  gap> g:=SymmetricGroup(4);;
 ##  gap> PCentralSeries(g,2);
-##  [ Sym( [ 1 .. 4 ] ), Group([ (1,2,3), (1,3,4) ]) ]
+##  [ Sym( [ 1 .. 4 ] ), Group([ (1,2,3), (2,3,4) ]) ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -473,8 +473,16 @@ BindGlobal( "Matrix_CharacteristicPolynomialSameField",
             vec[i] := zero;
         fi;
     od;
-    Assert(3, IsZero(Value(cp,imat)));
     Assert(2, Length(CoefficientsOfUnivariatePolynomial(cp)) = n+1);
+    if AssertionLevel()>=3 then
+      # cannot use Value(cp,imat), as this uses characteristic polynomial
+      n:=Zero(imat);
+      one:=One(imat);
+      for i in Reversed(CoefficientsOfUnivariatePolynomial(cp)) do
+        n:=n*imat+(i*one);
+      od;
+      Assert(3,IsZero(n));
+    fi;
     Info(InfoMatrix,1,"Characteristic Polynomial returns ", cp);
     return cp;
 end );

--- a/tst/testbugfix/2018-12-30-clashom.tst
+++ b/tst/testbugfix/2018-12-30-clashom.tst
@@ -1,0 +1,5 @@
+# Bug #3139
+gap> wreathy := WreathProduct(SymmetricGroup(2),SymmetricGroup(5));;
+gap> classes := ConjugacyClasses(wreathy);;
+gap> badsubgroup := StabilizerOfExternalSet( classes[2] );;
+gap> ConjugacyClasses( badsubgroup );;


### PR DESCRIPTION
If the group has been obtained as subgroup from a fitting free computation,
the data will be inherited and might not guarantee that the factor group
really is fitting free. Test/resolve this.

This fixes gap-system#3139

Also recode assertion to avoid #3140