### PR TITLE
Experiment: Try always compiling statements

### DIFF
--- a/lib/random.gi
+++ b/lib/random.gi
@@ -251,7 +251,7 @@ function(low, high)
 end );
 
 
-(function()
+tmpfunc := function()
     local func;
     func := function(installType)
         return function(args...)
@@ -312,7 +312,9 @@ end );
     end;
     InstallGlobalFunction("InstallMethodWithRandomSource", func(InstallMethod));
     InstallGlobalFunction("InstallOtherMethodWithRandomSource", func(InstallOtherMethod));
-end)();
+end;
+
+tmpfunc();
 
 # This method must rank below Random(SomeRandomSource, IsList)
 # for any random source SomeRandomSource, to avoid an infinite loop.

--- a/src/code.c
+++ b/src/code.c
@@ -1342,6 +1342,13 @@ void CodeReturnObj ( void )
 }
 
 
+void CodeReturnMaybeObj ( void )
+{
+    if(CS(CountExpr) >= 1) {
+        CodeReturnMaybeObj();
+    }
+}
+
 /****************************************************************************
 **
 *F  CodeReturnVoid()  . . . . . . . . . . . . . .  code return-void-statement

--- a/src/code.h
+++ b/src/code.h
@@ -848,6 +848,7 @@ extern  void            CodeBreak ( void );
 **  the expression <expr>.
 */
 extern  void            CodeReturnObj ( void );
+extern  void            CodeReturnMaybeObj ( void );
 
 
 /****************************************************************************

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -187,7 +187,7 @@ static Obj PopObj(void)
     return val;
 }
 
-static Obj PopVoidObj(void)
+Obj PopVoidObj(void)
 {
     Obj val = PopPlist( STATE(StackObj) );
 
@@ -200,7 +200,7 @@ static Obj PopVoidObj(void)
     return val;
 }
 
-static inline void StartFakeFuncExpr(Int startLine)
+void StartFakeFuncExpr(Int startLine)
 {
     assert(STATE(IntrCoding) == 0);
 
@@ -229,7 +229,7 @@ static inline void StartFakeFuncExpr(Int startLine)
     CodeFuncExprBegin(0, 0, nams, startLine);
 }
 
-static inline void FinishAndCallFakeFuncExpr(void)
+void FinishAndCallFakeFuncExpr(void)
 {
     assert(STATE(IntrCoding) == 0);
 
@@ -246,10 +246,12 @@ static inline void FinishAndCallFakeFuncExpr(void)
         PopPlist(STATE(StackNams));
 
     // call the function
-    CALL_0ARGS(func);
+    Obj ret = CALL_0ARGS(func);
 
-    // push void
-    PushVoidObj();
+    if(ret)
+        PushObj(ret);
+    else
+        PushVoidObj();
 }
 
 /****************************************************************************

--- a/src/io.c
+++ b/src/io.c
@@ -251,7 +251,6 @@ Char GET_NEXT_CHAR(void)
         // partial prompt from now on
         STATE(Prompt) = SyQuiet ? "" : "> ";
     }
-
     return *STATE(In);
 }
 


### PR DESCRIPTION
This is an experiment with always compiling code, rather than using the interpreter. This would greatly simplify GAP, by allowing us to delete the interpreter.

The time taken to start GAP is very similar to normal GAP. There are 2 known issues:

1) There are numerous warnings printed. These come from inside `if` statements, where variables are declared, and then used in a new function. As we now parse the entire `if` statement before executing it, the interpreter does not know these variables will be declared before they are then used in a function.

2) Expressions (like `x` or `2`) aren't currently handled yet, as they aren't statements. This isn't that hard to fix, but will require some fiddling.

The main question is, assuming these issues can be fixed, is it worth the amount of code which would be deleted to not interpret GAP?