### PR TITLE
kernel: add RetypeBagSM, RetypeBagSMIfWritable (step towards getting rid of IMMUTABLE)

### DIFF
--- a/src/bags.c
+++ b/src/bags.c
@@ -8,7 +8,9 @@
 **  SPDX-License-Identifier: GPL-2.0-or-later
 */
 
+#include "error.h"
 #include "gasman.h"
+#include "objects.h"    // HACK: for FIRST_IMM_MUT_TNUM; remove this later
 
 /****************************************************************************
 **
@@ -20,6 +22,36 @@ TNumInfoBags InfoBags[NUM_TYPES];
 
 
 UInt8 SizeAllBags;
+
+
+// TODO: perhaps this should become RetypeObj ?
+void RetypeBagSM(Bag bag, UInt new_type)
+{
+   if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
+        Int oldImm = !IS_MUTABLE_OBJ(bag);
+        Int newImm = new_type & IMMUTABLE;
+        if (newImm)
+            ErrorMayQuit("RetypeBagSM: target tnum should not indicate immutability", 0, 0);
+        if (oldImm)
+            new_type |= IMMUTABLE;
+    }
+    RetypeBag(bag, new_type);
+}
+
+#ifdef HPCGAP
+void RetypeBagSMIfWritable(Bag bag, UInt new_type)
+{
+   if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
+        Int oldImm = !IS_MUTABLE_OBJ(bag);
+        Int newImm = new_type & IMMUTABLE;
+        if (newImm)
+            ErrorMayQuit("RetypeBagSM: target tnum should not indicate immutability", 0, 0);
+        if (oldImm)
+            new_type |= IMMUTABLE;
+    }
+    RetypeBagIfWritable(bag, new_type);
+}
+#endif
 
 
 inline void MarkArrayOfBags(const Bag array[], UInt count)

--- a/src/blister.c
+++ b/src/blister.c
@@ -729,7 +729,7 @@ void PlainBlist (
 
     /* resize the list and retype it, in this order                        */
     len = LEN_BLIST(list);
-    RetypeBag( list, IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST+IMMUTABLE );
+    RetypeBagSM( list, T_PLIST );
     GROW_PLIST( list, (UInt)len );
     SET_LEN_PLIST( list, len );
 
@@ -826,7 +826,7 @@ void ConvBlist (
             bit = 1;
         }
     }
-    RetypeBag( list, IS_MUTABLE_OBJ(list) ? T_BLIST : T_BLIST+IMMUTABLE );
+    RetypeBagSM( list, T_BLIST );
     ResizeBag( list, SIZE_PLEN_BLIST(len) );
     SET_LEN_BLIST( list, len );
 }

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -497,6 +497,23 @@ extern  void            RetypeBagIfWritable (
 #define RetypeBagIfWritable(x,y)     RetypeBag(x,y)
 #endif
 
+
+/****************************************************************************
+**
+**  'RetypeBagSM' works like 'RetypeBag', but ensures that the given bag
+**  returns the same mutability (SM).
+**
+**  FIXME: for now, this checks the tnums; later, this will be turned
+**  into a check for an object flag
+*/
+extern void RetypeBagSM(Bag bag, UInt new_type);
+#ifdef HPCGAP
+extern void RetypeBagSMIfWritable(Bag bag, UInt new_type);
+#else
+#define RetypeBagSMIfWritable(x,y)   RetypeBagSM(x,y)
+#endif
+
+
 /****************************************************************************
 **
 *F  ResizeBag(<bag>,<new>)  . . . . . . . . . . . .  change the size of a bag

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -364,7 +364,7 @@ Obj             ZeroListDefault (
           RetypeBag(res, TNUM_OBJ(list));
         else if (TNUM_OBJ(list) >= T_PLIST_CYC &&
                  TNUM_OBJ(list) < T_PLIST_FFE)
-          RetypeBag(res, IS_MUTABLE_OBJ(list) ? T_PLIST_CYC : T_PLIST_CYC+IMMUTABLE);
+          RetypeBagSM(res, T_PLIST_CYC);
         else if (HAS_FILT_LIST(list, FN_IS_DENSE))
           {
             SET_FILT_LIST( res, FN_IS_DENSE );
@@ -590,7 +590,7 @@ Obj AInvListDefault (
           RetypeBag(res, TNUM_OBJ(list));
         else if (TNUM_OBJ(list) >= T_PLIST_CYC &&
                  TNUM_OBJ(list) < T_PLIST_FFE)
-          RetypeBag(res, IS_MUTABLE_OBJ(list) ? T_PLIST_CYC : T_PLIST_CYC+IMMUTABLE );
+          RetypeBagSM(res, T_PLIST_CYC);
         else if (HAS_FILT_LIST(list, FN_IS_DENSE))
           {
             SET_FILT_LIST( res, FN_IS_DENSE );

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2189,8 +2189,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
     // sort the result
     if (isint) {
         SortPlistByRawObj(res);
-        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
-                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
+        RetypeBagSM(res, T_PLIST_CYC_SSORT);
     }
     else {
         SortDensePlist(res);

--- a/src/plist.c
+++ b/src/plist.c
@@ -400,7 +400,7 @@ static Int KTNumPlist(Obj list, Obj * famfirst)
           {
             res = (lenList == 1) ? T_PLIST_CYC_SSORT : T_PLIST_CYC;
             /* This is a hack */
-            RetypeBag(list, res + ( IS_MUTABLE_OBJ(list) ? 0 : IMMUTABLE ));
+            RetypeBagSM(list, res);
           }
         else if (IS_FFE(ELM_PLIST(list,1)))
           {
@@ -418,7 +418,7 @@ static Int KTNumPlist(Obj list, Obj * famfirst)
             if (isFFE)
               {
                 res = T_PLIST_FFE;
-                RetypeBag(list, res + ( IS_MUTABLE_OBJ(list) ? 0 : IMMUTABLE ));
+                RetypeBagSM(list, res);
               }
             else
               res = T_PLIST_HOM;
@@ -491,7 +491,7 @@ Int KTNumHomPlist (
           res = T_PLIST_CYC;
 
         /* This is a hack */
-        RetypeBag(list, res + ( IS_MUTABLE_OBJ(list) ? 0 : IMMUTABLE ));
+        RetypeBagSM(list, res);
         goto finish;
       }
     if (IS_FFE(elm))
@@ -510,7 +510,7 @@ Int KTNumHomPlist (
         if (isFFE)
           {
             res = T_PLIST_FFE;
-            RetypeBag(list, res + ( IS_MUTABLE_OBJ(list) ? 0 : IMMUTABLE ));
+            RetypeBagSM(list, res);
             goto finish;
           }
       }
@@ -1995,7 +1995,7 @@ Int             IsDensePlist (
 
     /* special case for empty list                                         */
     if ( lenList == 0 ) {
-        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
+        RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
         return 1L;
     }
 
@@ -2075,7 +2075,7 @@ Int             IsSSortPlist (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
+        RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
         return 2L;
     }
 
@@ -2162,7 +2162,7 @@ Int             IsSSortPlistDense (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
+        RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
         return 2L;
     }
 
@@ -2230,7 +2230,7 @@ Int             IsSSortPlistHom (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
+        RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
         return 2L;
     }
 

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -306,7 +306,7 @@ static Obj SORT_PLIST_INTOBJ(Obj res)
         return res;
 
     SortPlistByRawObj(res);
-    RetypeBag(res, T_PLIST_CYC_SSORT + IMMUTABLE);
+    RetypeBagSM(res, T_PLIST_CYC_SSORT);
     return res;
 }
 
@@ -6253,8 +6253,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
         }
     }
     if (reslen == 0) {
-        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_EMPTY
-                                             : T_PLIST_EMPTY + IMMUTABLE);
+        RetypeBagSM(res, T_PLIST_EMPTY);
         return res;
     }
     ResizeBag(res, (reslen + 1) * sizeof(Obj));
@@ -6263,8 +6262,7 @@ Obj OnSetsPPerm(Obj set, Obj f)
     // sort the result
     if (isint) {
         SortPlistByRawObj(res);
-        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
-                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
+        RetypeBagSM(res, T_PLIST_CYC_SSORT);
     }
     else {
         SortDensePlist(res);
@@ -6415,13 +6413,11 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
     SET_LEN_PLIST(res, reslen);
 
     if (reslen == 0) {
-        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_EMPTY
-                                             : T_PLIST_EMPTY + IMMUTABLE);
+        RetypeBagSM(res, T_PLIST_EMPTY);
     }
     else {
         SortPlistByRawObj(res);
-        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
-                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
+        RetypeBagSM(res, T_PLIST_CYC_SSORT);
     }
 
     return res;

--- a/src/range.c
+++ b/src/range.c
@@ -597,7 +597,7 @@ void            PlainRange (
     inc     = GET_INC_RANGE( list );
 
     /* change the type of the list, and allocate enough space              */
-    RetypeBag( list, IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST + IMMUTABLE );
+    RetypeBagSM( list, T_PLIST );
     GROW_PLIST( list, lenList );
     SET_LEN_PLIST( list, lenList );
 
@@ -681,13 +681,7 @@ Int             IsRange (
         /* if <list> is a range, convert to the compact representation   */
         isRange = (len < i);
         if ( isRange ) {
-            if ( IS_MUTABLE_OBJ(list) ) {
-                RetypeBag( list, (0 < inc ? T_RANGE_SSORT : T_RANGE_NSORT) );
-            }
-            else {
-                RetypeBag( list, (0 < inc ? T_RANGE_SSORT : T_RANGE_NSORT)
-                                 + IMMUTABLE );
-            }
+            RetypeBagSM( list, (0 < inc ? T_RANGE_SSORT : T_RANGE_NSORT) );
             ResizeBag( list, 3 * sizeof(Obj) );
             SET_LEN_RANGE( list, len );
             SET_LOW_RANGE( list, low );

--- a/src/set.c
+++ b/src/set.c
@@ -68,7 +68,7 @@ Int IsSet (
 
         /* if <list> is the empty list, it is a set (:-)                     */
         if ( LEN_PLIST(list) == 0 ) {
-            RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
+            RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
             isSet = 1;
         }
 
@@ -90,7 +90,7 @@ Int IsSet (
         /* if <list> is the empty list, it is a set (:-)                     */
         if ( LEN_LIST(list) == 0 ) {
             PLAIN_LIST( list );
-            RetypeBagIfWritable(list, IS_MUTABLE_OBJ(list) ? T_PLIST_EMPTY : T_PLIST_EMPTY+IMMUTABLE);
+            RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
             isSet = 1;
         }
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -1307,7 +1307,7 @@ void ConvString (
     CHARS_STRING(tmp)[lenString] = '\0';
 
     /* copy back to string  */
-    RetypeBag( string, IS_MUTABLE_OBJ(string)?T_STRING:T_STRING+IMMUTABLE );
+    RetypeBagSM( string, T_STRING );
     ResizeBag( string, SIZEBAG_STRINGLEN(lenString) );
     /* copy data area from tmp */
     memcpy(ADDR_OBJ(string), CONST_ADDR_OBJ(tmp), SIZE_OBJ(tmp));

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -1096,7 +1096,7 @@ Obj FuncIMAGE_SET_TRANS(Obj self, Obj f)
 
     if (!IS_SSORT_LIST(out)) {
         SortPlistByRawObj(out);
-        RetypeBag(out, T_PLIST_CYC_SSORT + IMMUTABLE);
+        RetypeBagSM(out, T_PLIST_CYC_SSORT);
         return out;
     }
     return out;
@@ -1155,7 +1155,7 @@ Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
         SHRINK_PLIST(newObj, (Int)rank);
         SET_LEN_PLIST(newObj, (Int)rank);
         SortPlistByRawObj(newObj);
-        RetypeBag(newObj, T_PLIST_CYC_SSORT + IMMUTABLE);
+        RetypeBagSM(newObj, T_PLIST_CYC_SSORT);
     }
     else {
         // m > deg and so m is at least 1!
@@ -5101,8 +5101,7 @@ Obj OnSetsTrans(Obj set, Obj f)
         SortPlistByRawObj(res);
         REMOVE_DUPS_PLIST_INTOBJ(res);
 
-        RetypeBag(res, IS_PLIST_MUTABLE(set) ? T_PLIST_CYC_SSORT
-                                             : T_PLIST_CYC_SSORT + IMMUTABLE);
+        RetypeBagSM(res, T_PLIST_CYC_SSORT);
     }
     else {
         SortDensePlist(res);

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -959,7 +959,6 @@ void PlainVec8Bit(Obj list)
     UInt    elts;
     Obj     info;
     UInt1 * gettab;
-    UInt    tnum;
     Obj     fieldobj;
     Char *  startblank;
     Char *  endblank;
@@ -977,14 +976,7 @@ void PlainVec8Bit(Obj list)
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
 
-
-    if (len == 0)
-        tnum = T_PLIST_EMPTY;
-    else
-        tnum = T_PLIST_FFE;
-    if (!IS_MUTABLE_OBJ(list))
-        tnum += IMMUTABLE;
-    RetypeBag(list, tnum);
+    RetypeBagSM(list, (len == 0) ? T_PLIST_EMPTY : T_PLIST_FFE);
 
     GROW_PLIST(list, (UInt)len);
     SET_LEN_PLIST(list, len);
@@ -3329,8 +3321,7 @@ void PlainMat8Bit(Obj mat)
     UInt i, l;
     Obj  row;
     l = LEN_MAT8BIT(mat);
-    RetypeBag(mat,
-              IS_MUTABLE_OBJ(mat) ? T_PLIST_TAB : T_PLIST_TAB + IMMUTABLE);
+    RetypeBagSM(mat, T_PLIST_TAB);
     SET_LEN_PLIST(mat, l);
     for (i = 1; i <= l; i++) {
         row = ELM_MAT8BIT(mat, i);

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -54,8 +54,7 @@ Int IsVecFFE(Obj obj)
         if (!IS_FFE(x) || FLD_FFE(x) != fld)
             return 0;
     }
-    RetypeBag(obj,
-              (tnum & IMMUTABLE) ? T_PLIST_FFE + IMMUTABLE : T_PLIST_FFE);
+    RetypeBagSM(obj, T_PLIST_FFE);
     return 1;
 }
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1254,8 +1254,6 @@ void PlainGF2Vec(Obj list)
     Int  len;          // length of <list>
     UInt i;            // loop variable
     Obj  first = 0;    // first entry
-    UInt tnum;
-
 
     // check for representation lock
     if (True == DoFilter(IsLockedRepresentationVector, list))
@@ -1265,13 +1263,8 @@ void PlainGF2Vec(Obj list)
     // resize the list and retype it, in this order
     len = LEN_GF2VEC(list);
 
-    if (len == 0)
-        tnum = T_PLIST_EMPTY;
-    else
-        tnum = T_PLIST_FFE;
-    if (!IS_MUTABLE_OBJ(list))
-        tnum += IMMUTABLE;
-    RetypeBag(list, tnum);
+    RetypeBagSM(list, (len == 0) ? T_PLIST_EMPTY : T_PLIST_FFE);
+
     GROW_PLIST(list, (UInt)len);
     SET_LEN_PLIST(list, len);
 
@@ -1310,7 +1303,7 @@ void PlainGF2Mat(Obj list)
 
     // resize the list and retype it, in this order
     len = LEN_GF2MAT(list);
-    RetypeBag(list, IS_MUTABLE_OBJ(list) ? T_PLIST : T_PLIST + IMMUTABLE);
+    RetypeBagSM(list, T_PLIST);
     SET_LEN_PLIST(list, len);
 
     // shift the entries to the left


### PR DESCRIPTION
This PR adds a new helper `RetypeBagSM`, with "SM" = "same mutability" (an abbreviation also used elsewhere in GAP), a wrapper around `RetypeBag` which attempts to preserve "mutability" of objects. Its sibling `RetypeBagSMIfWritable ` does the same for `RetypeBagSMWritable`. 

The long term goal here is to get another step closer to turning `IMMUTABLE` from a bit inside the TNUM to a proper object flag; code rewritten to use `RetypeBagSM`  typically looses a reference or two to `IMMUTABLE` and also `IS_MUTABLE_OBJ `, and does not have to be adjusted when / if the "big switch" happens.

However, I think this is also a change that is useful in itself: Code using `RetypeBagSM` usually is shorter than the code it replaces, and expresses its intent more clearly. This also avoids certain types of bugs.

I consider the names provisional; if you have a better suggestion, let me know. We could also call it `RetypeBagWithSameMutability`, but I am a bit wary about too long names (but won't object if people prefer that). In any case, I envision that on the long term, this function will actually vanish again, because once we have replaced IMMUTABLE by an object flag, any call to `RetypeBag` will automatically preserve mutability. To get there, the next step might be to introduce another wrapper for `RetypeBag` which also does not change the mutability, but which raises an error if the given TNUMs would lead to that. I.e., while `RetypeBagSM` is used in code which explicitly works on preserving mutability, that new code would be used in code which just changes TNUMs without any explicit checks for mutability. In the end, any code which changes mutability (of internal objects) then should do so via `MakeImmutableNoRecurse`. 

As a variation of this, we could also change calls of `RetypeBag` to `RetypeBagSM` after manually verifying that it is currently correct, i.e., does not accidentally change the mutability of the object.