### PR TITLE
travis: use Julia 1.1.0-rc1 for tests

### DIFF
--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -30,10 +30,11 @@ fi
 if [[ $JULIA = yes ]]
 then
   # TODO: once Julia 1.1 is released, switch to stable Julia versions here?
-  wget https://julialangnightlies-s3.julialang.org/bin/linux/x64/1.1/julia-b55b85cd99-linux64.tar.gz
+  # or maybe use Travis' `language: julia` feature?
+  wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-rc1-linux-x86_64.tar.gz
   #wget https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz
-  tar xvf julia-*-linux64.tar.gz
-  rm julia-*-linux64.tar.gz
+  tar xvf julia-*.tar.gz
+  rm julia-*.tar.gz
   pushd julia-*
   JULIA_PATH=$(pwd)
   popd


### PR DESCRIPTION
This should be backported to stable-4.10 simply so that tests there will also be based on Julia 1.1, and not some random old nighly build.

Once Julia 1.1 is out, I'll update this once more to target that.