### PR TITLE
More tests and minor bug fix for PrintToFormatted; fix bug in READ_ALL_FILE on Cygwin

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1353,7 +1353,7 @@ InstallGlobalFunction(PrintToFormatted, function(stream, s, data...)
                 ErrorNoReturn("first data argument must be a record when using {",toprint.id,"}");
             fi;
             if not IsBound(data[1].(toprint.id)) then
-                ErrorNoReturn("no record member '",toprint[1].id,"'");
+                ErrorNoReturn("no record member '",toprint.id,"'");
             fi;
             var := data[1].(toprint.id);
         fi;

--- a/src/streams.c
+++ b/src/streams.c
@@ -1579,6 +1579,7 @@ Obj FuncREAD_ALL_FILE (
 {
     Char            buf[20000];
     Int             len;
+    // Length of string read this loop (or negative for error)
     UInt            lstr;
     Obj             str;
     UInt            csize;
@@ -1598,6 +1599,7 @@ Obj FuncREAD_ALL_FILE (
  getmore:
 #endif
     while (ilim == -1 || len < ilim ) {
+      lstr = 0;
       if ( len > 0 && !HasAvailableBytes(ifid))
           break;
       if (SyBufIsTTY(ifid)) {
@@ -1650,7 +1652,8 @@ Obj FuncREAD_ALL_FILE (
     }
     len = j;
     SET_LEN_STRING(str, len);
-    if (ilim != -1 && len < ilim)
+    // If we have not yet read enough, and have read at least one character this loop, then read more
+    if (ilim != -1 && len < ilim && lstr > 0)
         goto getmore;
 #endif
     ResizeBag( str, SIZEBAG_STRINGLEN(len) );

--- a/tst/testinstall/format.tst
+++ b/tst/testinstall/format.tst
@@ -79,4 +79,9 @@ gap> PrintToFormatted([1,2], "abc");
 Error, Usage: PrintToFormatted(<stream>, <string>, <data>...)
 gap> PrintToFormatted("*stdout*", [1,2]);
 Error, Usage: PrintToFormatted(<stream>, <string>, <data>...)
+gap> PrintFormatted("abc{}{}{}\n", 2, 3);
+Error, out of bounds -- used 
+3 replacement fields without id when there are only 2 arguments
+gap> PrintFormatted("abc{3}\n", 2);
+Error, out of bounds -- asked for {3} when there are only 1 arguments
 gap> STOP_TEST("format.tst",1);

--- a/tst/testinstall/format.tst
+++ b/tst/testinstall/format.tst
@@ -84,4 +84,6 @@ Error, out of bounds -- used
 3 replacement fields without id when there are only 2 arguments
 gap> PrintFormatted("abc{3}\n", 2);
 Error, out of bounds -- asked for {3} when there are only 1 arguments
+gap> PrintFormatted("abc{x}\n", rec(y := 2));
+Error, no record member 'x'
 gap> STOP_TEST("format.tst",1);

--- a/tst/testinstall/integer.tst
+++ b/tst/testinstall/integer.tst
@@ -65,6 +65,18 @@ gap> FactorsInt(n) = [ n ];
 true
 
 #
+gap> StringPP(-3);
+"-3"
+gap> StringPP(0);
+"0"
+gap> StringPP(-10);
+"-2*5"
+gap> StringPP(10);
+"2*5"
+gap> StringPP(10000);
+"2^4*5^4"
+
+#
 gap> Filtered([-4..20], IsPrimePowerInt);
 [ -3, -2, 2, 3, 4, 5, 7, 8, 9, 11, 13, 16, 17, 19 ]
 gap> IsPrimePowerInt(1009^1009);

--- a/tst/testinstall/rationals.tst
+++ b/tst/testinstall/rationals.tst
@@ -43,6 +43,16 @@ gap> Rat("3-5");
 fail
 gap> Rat(3.7e-1);                                                  
 37/100
+gap> Rat("-");
+fail
+gap> Rat("1/2/3");
+fail
+gap> Rat("1.2.3");
+fail
+gap> Rat("1.2/2");
+3/5
+gap> Rat("2.4/1.2");
+2
 
 # division by zero
 gap> 0/0;

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -12,6 +12,8 @@ gap> ReadLine(x);
 fail
 gap> ReadLine(x);
 fail
+gap> SeekPositionStream(x, -1);
+fail
 gap> SeekPositionStream(x, 0);
 true
 gap> ReadLine(x);
@@ -77,6 +79,12 @@ gap> FileString( Filename(dir, "test.g.gz"), "\037\213\b\b0,\362W\000\ctest.g\00
 32
 gap> StringFile( Filename(dir, "test.g") ) = "1+1;\n" or ARCH_IS_WINDOWS(); # works only when Cygwin installed with gzip
 true
+gap> StringFile( "/" );
+Error, in StringFile: Is a directory (21)
+
+gap> FileString("/dev/full", "outdata", false);
+Error, in FileString: No space left on device (28)
+
 gap> READ_ALL_COMMANDS(InputTextString(""), false, false, false);
 [  ]
 gap> READ_ALL_COMMANDS(InputTextString("a := (3,7,1); y := a^(-1);"), false, false, false);

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -26,6 +26,30 @@ gap> CloseStream(stream);
 gap> stream;
 closed-stream
 
+# partial reads
+gap> stream := InputTextFile( fname );;
+gap> ReadAll(stream, 2);
+"12"
+gap> CloseStream(stream);
+gap> stream;
+closed-stream
+
+# too long partial read
+gap> stream := InputTextFile( fname );;
+gap> ReadAll(stream, 5);
+"123"
+gap> CloseStream(stream);
+gap> stream;
+closed-stream
+
+# error partial read
+gap> stream := InputTextFile( fname );;
+gap> ReadAll(stream, -1);
+Error, ReadAll: negative limit is not allowed
+gap> CloseStream(stream);
+gap> stream;
+closed-stream
+
 # append to initial data
 gap> stream := OutputTextFile( fname, true );;
 gap> PrintTo( stream, "4");
@@ -82,7 +106,18 @@ gap> StringFile(fname);
 #
 
 # output
-gap> res:="";;
+gap> res:="abc";;
+gap> stream := OutputTextString(res, true);
+OutputTextString(3)
+gap> res;
+"abc"
+gap> PrintTo( stream, "1" );
+gap> res;
+"abc1"
+gap> stream := OutputTextString(res, false);
+OutputTextString(0)
+gap> res;
+""
 gap> stream := OutputTextString(res, true);
 OutputTextString(0)
 gap> PrintTo( stream, "1");
@@ -93,6 +128,10 @@ gap> PrintTo( stream, "another line\n", "last line without newline");
 gap> CloseStream(stream);
 gap> res;
 "123\n567\nsome line\nanother line\nlast line without newline"
+gap> OutputTextString("abc");
+Error, Usage OutputTextString( <string>, <append> )
+gap> OutputTextString(Immutable("abc"), true);
+Error, <str> must be mutable
 
 # input
 gap> stream := InputTextString( res );
@@ -111,6 +150,24 @@ gap> ReadAllLine(stream, false, line -> 0 < Length(line) and line[Length(line)] 
 "last line without newline"
 gap> ReadAllLine(stream);
 fail
+gap> stream := InputTextString( res );
+InputTextString(0,56)
+gap> ReadAll(stream, 3);
+"123"
+gap> ReadAll(stream, -1);
+Error, ReadAll: negative limit is not allowed
+gap> ReadAll(stream, 0);
+""
+gap> ReadAll(stream, 1000);
+"\n567\nsome line\nanother line\nlast line without newline"
+gap> SeekPositionStream(stream, -1);
+fail
+gap> SeekPositionStream(stream, 1000);
+fail
+gap> SeekPositionStream(stream, 1);
+true
+gap> ReadLine(stream);
+"23\n"
 
 # Test reading longer file
 gap> dir := DirectoriesLibrary("tst/testinstall/files");;
@@ -135,6 +192,20 @@ gap> PrintTo(fail);
 Error, first argument must be a filename or output stream
 gap> AppendTo(fail);
 Error, first argument must be a filename or output stream
+
+# None stream
+gap> stream := OutputTextNone();
+OutputTextNone()
+gap> PrintObj(stream); Print("\n");
+OutputTextNone()
+gap> WriteAll(stream, "abc");
+true
+gap> WriteByte(stream, 3);
+true
+gap> WriteByte(stream, 300);
+Error, <byte> must an integer between 0 and 255
+gap> SetPrintFormattingStatus(stream, fail);
+Error, Print formatting status must be true or false
 
 #
 gap> STOP_TEST( "streams.tst", 1);

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -3,7 +3,7 @@
 ##  This file tests output methods (mainly for strings)
 ##
 #@local OldCopyToStringRep,a2000,a3000,at2000,at3000,cp1,cp2,cp3
-#@local ret2000,ret3000,s,tmp,x,tmpdir,fname,dir
+#@local ret2000,ret3000,s,tmp,x,tmpdir,fname,dir,filename
 gap> START_TEST("strings.tst");
 
 # FFE
@@ -75,6 +75,9 @@ gap> "
 Syntax error: String must not include <newline> in stream:1
 "
 ^
+gap> "abc" + "def";
+Error, concatenating strings via + is not supported, use Concatenation(<a>,<b>\
+) instead
 
 # Empty string
 gap> x:="";
@@ -254,7 +257,16 @@ true
 
 # Working with CSV files
 gap> dir := DirectoriesLibrary("tst/testinstall/files");;
-gap> s := ReadCSV( Filename(dir, "example.csv"), ';' );
+gap> filename := Filename(dir, "example.csv");;
+gap> s := ReadCSV( filename, ';' );
+[ rec( f := 2, f1 := 1, f_2 := 3 ), rec( f1 := 4, f_2 := 6 ), rec( f1 := 7 ), 
+  rec( f := 11, f_2 := 12 ), rec( f := "yy", f1 := "x", f_2 := "zzz" ) ]
+
+# Check without .csv
+gap> s := ReadCSV( filename{[1..Length(filename)-4]}, ';' );
+[ rec( f := 2, f1 := 1, f_2 := 3 ), rec( f1 := 4, f_2 := 6 ), rec( f1 := 7 ), 
+  rec( f := 11, f_2 := 12 ), rec( f := "yy", f1 := "x", f_2 := "zzz" ) ]
+gap> s := ReadCSV( filename{[1..Length(filename)-4]}, ";" );
 [ rec( f := 2, f1 := 1, f_2 := 3 ), rec( f1 := 4, f_2 := 6 ), rec( f1 := 7 ), 
   rec( f := 11, f_2 := 12 ), rec( f := "yy", f1 := "x", f_2 := "zzz" ) ]
 gap> tmpdir := DirectoryTemporary();;


### PR DESCRIPTION
This fixes a minor bug (when trying to print an Error, GAP produces a different Error).

While fixing this, I decided to write a bunch of other tests to improve coverage.