### PR TITLE
in configure, run Julia without `startup.jl`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -473,11 +473,11 @@ AS_IF([test "x$with_julia" != xno],[
   AC_PATH_PROG([JULIA], [julia], [], [${with_julia}/bin ${PATH}])
   AS_IF([test "x$JULIA" = x],[ AC_MSG_ERROR([no julia executable found]) ])
 
-  JL_SHARE=$($JULIA -e 'print(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia"))')
+  JL_SHARE=$($JULIA --startup-file=no -e 'print(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia"))')
   AS_IF([test -f "${JL_SHARE}/julia-config.jl"], [], [AC_MSG_ERROR([no julia-config.jl found])])
 
   AC_MSG_CHECKING([for JULIA_CPPFLAGS])
-  JULIA_CPPFLAGS=$(${JULIA} ${JL_SHARE}/julia-config.jl --cflags 2>/dev/null)
+  JULIA_CPPFLAGS=$(${JULIA} --startup-file=no ${JL_SHARE}/julia-config.jl --cflags 2>/dev/null)
   AS_IF([ test $? != 0 ], [AC_MSG_ERROR([failed to obtain JULIA_CPPFLAGS from julia-config.jl])])
   JULIA_CPPFLAGS=${JULIA_CPPFLAGS/-std=gnu99/}  # need to remove -std=gnu99 for our C++ code
   # remove apostrophes, they mess up quoting when used in shell code(although
@@ -489,13 +489,13 @@ AS_IF([test "x$with_julia" != xno],[
   AC_MSG_RESULT([${JULIA_CPPFLAGS}])
 
   AC_MSG_CHECKING([for JULIA_LDFLAGS])
-  JULIA_LDFLAGS=$(${JULIA} ${JL_SHARE}/julia-config.jl --ldflags)
+  JULIA_LDFLAGS=$(${JULIA} --startup-file=no ${JL_SHARE}/julia-config.jl --ldflags)
   AS_IF([ test $? != 0 ], [AC_MSG_ERROR([failed to obtain JULIA_LDFLAGS from julia-config.jl])])
   JULIA_LDFLAGS=${JULIA_LDFLAGS//\'/}
   AC_MSG_RESULT([${JULIA_LDFLAGS}])
 
   AC_MSG_CHECKING([for JULIA_LIBS])
-  JULIA_LIBS=$(${JULIA} ${JL_SHARE}/julia-config.jl --ldlibs)
+  JULIA_LIBS=$(${JULIA} --startup-file=no ${JL_SHARE}/julia-config.jl --ldlibs)
   AS_IF([ test $? != 0 ], [AC_MSG_ERROR([failed to obtain JULIA_LIBS from julia-config.jl])])
   JULIA_LIBS=${JULIA_LIBS//\'/}
   AC_MSG_RESULT([${JULIA_LIBS}])


### PR DESCRIPTION
I had put a `print` statement into my `startup.jl` file,
for test purposes, and then GAP's `configure` ran into an error
because the printed message was regarded as the value of `JL_SHARE` etc.

I think it is better not to read `startup.jl` at all in this situation.