### PR TITLE
kernel: fix potential GC crash in CompStringExpr

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -688,14 +688,14 @@ void            Emit (
             }
 
             // emit a C string
-            else if ( *p == 's' || *p == 'S' || *p == 'C' ) {
+            else if ( *p == 's' || *p == 'S' ) {
                 const Char f[] = { '%', *p, 0 };
                 string = va_arg( ap, Char* );
                 Pr( f, (Int)string, 0L );
             }
 
             // emit a GAP string
-            else if ( *p == 'g' || *p == 'G' ) { 
+            else if ( *p == 'g' || *p == 'G' || *p == 'C' ) { 
                 const Char f[] = { '%', *p, 0 };
                 Obj str = va_arg( ap, Obj );
                 Pr( f, (Int)str, 0L );
@@ -2665,15 +2665,16 @@ CVar CompStringExpr (
     Expr                expr )
 {
     CVar                string;         /* string value, result            */
+    Obj                 str;            // the actual string object
 
     /* allocate a new temporary for the string                             */
     string = CVAR_TEMP( NewTemp( "string" ) );
 
+    // get the string of this expression
+    str = EVAL_EXPR(expr);
+
     /* create the string and copy the stuff                                */
-    Emit( "%c = MakeString( \"%C\" );\n",
-          /* the sizeof(UInt) offset is to get past the length of the string
-             which is now stored in the front of the literal */
-          string, sizeof(UInt)+ (const Char*)CONST_ADDR_EXPR(expr) );
+    Emit( "%c = MakeString( \"%C\" );\n", string, str);
 
     /* we know that the result is a list                                   */
     SetInfoCVar( string, W_LIST );

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1696,6 +1696,7 @@ void            PrintStringExpr (
 void            PrintFloatExprLazy (
     Expr                expr )
 {
+  // FIXME: this code is not GC safe
   Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 2*sizeof(UInt))), 0L);
 }
 
@@ -1708,6 +1709,7 @@ void            PrintFloatExprLazy (
 void            PrintFloatExprEager (
     Expr                expr )
 {
+  // FIXME: this code is not GC safe
   Char mark;
   Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 3*sizeof(UInt))), 0L);
   Pr("_",0L,0L);

--- a/src/io.c
+++ b/src/io.c
@@ -1640,8 +1640,8 @@ void ResetOutputIndent(void)
 **          to a string in STRING_REP format which is printed in '%s' format
 **  '%G'    the corresponding argument is the address of an Obj which points
 **          to a string in STRING_REP format which is printed in '%S' format
-**  '%C'    the corresponding argument is the address of  a  null  terminated
-**          character string which is printed with C escapes.
+**  '%C'    the corresponding argument is the address of an Obj which points
+**          to a string in STRING_REP format which is printed with C escapes
 **  '%d'    the corresponding argument is a signed integer, which is printed.
 **          Between the '%' and the 'd' an integer might be used  to  specify
 **          the width of a field in which the integer is right justified.  If
@@ -1836,6 +1836,9 @@ static inline void FormatOutput(
     /* '%C' print a string with the necessary C escapes            */
     else if ( *p == 'C' ) {
 
+      arg1obj = (Obj)arg1;
+      arg1 = (Int)CONST_CSTR_STRING(arg1obj);
+
       /* compute how many characters this identifier requires    */
       for ( const Char * q = (const Char *)arg1; *q != '\0' && prec > 0; q++ ) {
         if      ( *q == '\n'  ) { prec -= 2; }
@@ -1854,7 +1857,12 @@ static inline void FormatOutput(
       while ( prec-- > 0 )  put_a_char(state, ' ');
 
       /* print the string                                        */
-      for ( const Char * q = (const Char *)arg1; *q != '\0'; q++ ) {
+      Int i = 0;
+      while (1) {
+        const Char* q = CONST_CSTR_STRING(arg1obj) + i++;
+        if (*q == 0)
+            break;
+
         if      ( *q == '\n'  ) { put_a_char(state, '\\'); put_a_char(state, 'n');  }
         else if ( *q == '\t'  ) { put_a_char(state, '\\'); put_a_char(state, 't');  }
         else if ( *q == '\r'  ) { put_a_char(state, '\\'); put_a_char(state, 'r');  }


### PR DESCRIPTION
Emit calls Pr, and Pr can lead to a GC. Thus passing a pointer into
a function body bag is not safe. We avoid this by instead evaluating the
string expression, then passing the string object to Emit and hence Pr;
for this to work, we changed the semantics of `%C` in Pr, which is OK,
as this code is the only place using it.

Also add FIXMEs to additional unsafe code; fixing that code requires
more effort.

But all of these are really obscure, and as long as we print into a file, not a string stream, it is rather unlikely that we'd ever trigger any of these (and few people use gac to start with).