### PR TITLE
kernel: change coding of integers, strings, eager floats (includes some SyntaxTree code tweaking)

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -72,6 +72,11 @@ typedef struct {
     // if non-zero, this is an immediate integer encoding the line
     // number where a function ends
     Obj endline;
+
+    // if non-zero, this points to a dense plist containing constant values
+    // referenced by the code in this function body
+    Obj values;
+
 } BodyHeader;
 
 EXPORT_INLINE BodyHeader *BODY_HEADER(Obj body)
@@ -93,6 +98,9 @@ UInt GET_STARTLINE_BODY(Obj body);
 void SET_STARTLINE_BODY(Obj body, UInt val);
 UInt GET_ENDLINE_BODY(Obj body);
 void SET_ENDLINE_BODY(Obj body, UInt val);
+
+extern Obj GET_VALUE_FROM_CURRENT_BODY(Int ix);
+
 
 /****************************************************************************
 **

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -688,14 +688,14 @@ void            Emit (
             }
 
             // emit a C string
-            else if ( *p == 's' || *p == 'S' || *p == 'C' ) {
+            else if ( *p == 's' || *p == 'S' ) {
                 const Char f[] = { '%', *p, 0 };
                 string = va_arg( ap, Char* );
                 Pr( f, (Int)string, 0L );
             }
 
             // emit a GAP string
-            else if ( *p == 'g' || *p == 'G' ) { 
+            else if ( *p == 'g' || *p == 'G' || *p == 'C' ) { 
                 const Char f[] = { '%', *p, 0 };
                 Obj str = va_arg( ap, Obj );
                 Pr( f, (Int)str, 0L );
@@ -2665,15 +2665,16 @@ CVar CompStringExpr (
     Expr                expr )
 {
     CVar                string;         /* string value, result            */
+    Obj                 str;            // the actual string object
 
     /* allocate a new temporary for the string                             */
     string = CVAR_TEMP( NewTemp( "string" ) );
 
+    // get the string of this expression
+    str = EVAL_EXPR(expr);
+
     /* create the string and copy the stuff                                */
-    Emit( "%c = MakeString( \"%C\" );\n",
-          /* the sizeof(UInt) offset is to get past the length of the string
-             which is now stored in the front of the literal */
-          string, sizeof(UInt)+ (const Char*)CONST_ADDR_EXPR(expr) );
+    Emit( "%c = MakeString( \"%C\" );\n", string, str);
 
     /* we know that the result is a list                                   */
     SetInfoCVar( string, W_LIST );

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2279,10 +2279,13 @@ CVar CompIntExpr (
         return CVAR_INTG( INT_INTEXPR(expr) );
     }
     else {
+        // get the actual integer
+        Obj obj = EVAL_EXPR(expr);
+
         val = CVAR_TEMP( NewTemp( "val" ) );
-        siz = SIZE_EXPR(expr) - sizeof(UInt);
-        typ = READ_EXPR(expr, 0);
-        Emit( "%c = C_MAKE_INTEGER_BAG(%d, %d);\n",val, siz, typ);
+        siz = SIZE_OBJ(obj);
+        typ = TNUM_OBJ(obj);
+        Emit( "%c = C_MAKE_INTEGER_BAG(%d, %d);\n", val, siz, typ);
         if ( typ == T_INTPOS ) {
             SetInfoCVar(val, W_INT_POS);
         }
@@ -2291,12 +2294,11 @@ CVar CompIntExpr (
         }
 
         for ( i = 0; i < siz/INTEGER_UNIT_SIZE; i++ ) {
+            UInt limb = CONST_ADDR_INT(obj)[i];
 #if INTEGER_UNIT_SIZE == 4
-            Emit("C_SET_LIMB4( %c, %d, %dL);\n", val, i,
-                 ((UInt4 *)((const UInt *)CONST_ADDR_EXPR(expr) + 1))[i]);
+            Emit("C_SET_LIMB4( %c, %d, %dL);\n", val, i, limb);
 #elif INTEGER_UNIT_SIZE == 8
-            Emit("C_SET_LIMB8( %c, %d, %dLL);\n", val, i,
-                 ((UInt8 *)((const UInt *)CONST_ADDR_EXPR(expr) + 1))[i]);
+            Emit("C_SET_LIMB8( %c, %d, %dLL);\n", val, i, limb);
 #else
             #error unsupported INTEGER_UNIT_SIZE
 #endif

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -721,15 +721,8 @@ Obj             EvalPow (
 Obj             EvalIntExpr (
     Expr                expr )
 {
-    Obj                 val;            /* integer, result                 */
-
-    /* allocate the integer                                                */
-    val = NewBag(READ_EXPR(expr, 0), SIZE_EXPR(expr) - sizeof(UInt));
-    memcpy(ADDR_OBJ(val), ((const UInt *)CONST_ADDR_EXPR(expr)) + 1,
-           SIZE_EXPR(expr) - sizeof(UInt));
-
-    /* return the value                                                    */
-    return val;
+    UInt ix = READ_EXPR(expr, 0);
+    return  GET_VALUE_FROM_CURRENT_BODY(ix);
 }
 
 /****************************************************************************
@@ -1107,15 +1100,9 @@ Obj             EvalRangeExpr (
 Obj             EvalStringExpr (
     Expr                expr )
 {
-    Obj                 string;         /* string value, result            */
-    UInt                 len;           /* size of expression              */
-
-    len = READ_EXPR(expr, 0);
-    string = NEW_STRING(len);
-    memcpy(ADDR_OBJ(string), CONST_ADDR_EXPR(expr), SIZEBAG_STRINGLEN(len));
-
-    /* return the string                                                   */
-    return string;
+    UInt ix = READ_EXPR(expr, 0);
+    Obj string = GET_VALUE_FROM_CURRENT_BODY(ix);
+    return SHALLOW_COPY_OBJ(string);
 }
 
 /****************************************************************************
@@ -1171,13 +1158,10 @@ Obj             EvalFloatExprLazy (
 **  'EvalFloatExpr'   evaluates the  float  expression  <expr>  to a float
 **  value.
 */
-extern Obj EAGER_FLOAT_LITERAL_CACHE;
-
 Obj EvalFloatExprEager(Expr expr)
 {
     UInt ix = READ_EXPR(expr, 0);
-    Obj fl = ELM_LIST(EAGER_FLOAT_LITERAL_CACHE, ix);
-    return fl;
+    return  GET_VALUE_FROM_CURRENT_BODY(ix);
 }
 
 
@@ -1684,7 +1668,10 @@ void            PrintRangeExpr (
 void            PrintStringExpr (
     Expr                expr )
 {
-    PrintString(EvalStringExpr(expr));
+    UInt ix = READ_EXPR(expr, 0);
+    Obj string =  GET_VALUE_FROM_CURRENT_BODY(ix);
+
+    PrintString(string);
 }
 
 /****************************************************************************

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1696,6 +1696,7 @@ void            PrintStringExpr (
 void            PrintFloatExprLazy (
     Expr                expr )
 {
+  // FIXME: this code is not GC safe
   Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 2*sizeof(UInt))), 0L);
 }
 
@@ -1708,6 +1709,7 @@ void            PrintFloatExprLazy (
 void            PrintFloatExprEager (
     Expr                expr )
 {
+  // FIXME: this code is not GC safe
   Char mark;
   Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 3*sizeof(UInt))), 0L);
   Pr("_",0L,0L);

--- a/src/io.c
+++ b/src/io.c
@@ -1640,8 +1640,8 @@ void ResetOutputIndent(void)
 **          to a string in STRING_REP format which is printed in '%s' format
 **  '%G'    the corresponding argument is the address of an Obj which points
 **          to a string in STRING_REP format which is printed in '%S' format
-**  '%C'    the corresponding argument is the address of  a  null  terminated
-**          character string which is printed with C escapes.
+**  '%C'    the corresponding argument is the address of an Obj which points
+**          to a string in STRING_REP format which is printed with C escapes
 **  '%d'    the corresponding argument is a signed integer, which is printed.
 **          Between the '%' and the 'd' an integer might be used  to  specify
 **          the width of a field in which the integer is right justified.  If
@@ -1836,6 +1836,9 @@ static inline void FormatOutput(
     /* '%C' print a string with the necessary C escapes            */
     else if ( *p == 'C' ) {
 
+      arg1obj = (Obj)arg1;
+      arg1 = (Int)CONST_CSTR_STRING(arg1obj);
+
       /* compute how many characters this identifier requires    */
       for ( const Char * q = (const Char *)arg1; *q != '\0' && prec > 0; q++ ) {
         if      ( *q == '\n'  ) { prec -= 2; }
@@ -1854,7 +1857,12 @@ static inline void FormatOutput(
       while ( prec-- > 0 )  put_a_char(state, ' ');
 
       /* print the string                                        */
-      for ( const Char * q = (const Char *)arg1; *q != '\0'; q++ ) {
+      Int i = 0;
+      while (1) {
+        const Char* q = CONST_CSTR_STRING(arg1obj) + i++;
+        if (*q == 0)
+            break;
+
         if      ( *q == '\n'  ) { put_a_char(state, '\\'); put_a_char(state, 'n');  }
         else if ( *q == '\t'  ) { put_a_char(state, '\\'); put_a_char(state, 't');  }
         else if ( *q == '\r'  ) { put_a_char(state, '\\'); put_a_char(state, 'r');  }

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -561,12 +561,11 @@ static const CompilerT Compilers[] = {
     COMPILER(T_PROCCALL_6ARGS, SyntaxTreeFunccall),
     COMPILER(T_PROCCALL_XARGS, SyntaxTreeFunccall),
 
-    COMPILER(T_PROCCALL_OPTS,
-             SyntaxTreeDefaultCompiler,
-             ARG_("opts"),
-             ARG_("call")),
+    COMPILER_(T_PROCCALL_OPTS,
+              ARG_("opts"),
+              ARG_("call")),
 
-    COMPILER(T_EMPTY, SyntaxTreeDefaultCompiler),
+    COMPILER_(T_EMPTY),
 
     COMPILER(T_SEQ_STAT, SyntaxTreeSeqStat),
     COMPILER(T_SEQ_STAT2, SyntaxTreeSeqStat),
@@ -598,7 +597,7 @@ static const CompilerT Compilers[] = {
     COMPILER(T_REPEAT3, SyntaxTreeRepeat),
 
 #ifdef HPCGAP
-    COMPILER(T_ATOMIC, SyntaxTreeDefaultCompiler),
+    COMPILER_(T_ATOMIC),
 #endif
 
     COMPILER_(T_BREAK),

--- a/tst/testinstall/opers/MemoryUsage.tst
+++ b/tst/testinstall/opers/MemoryUsage.tst
@@ -96,9 +96,9 @@ true
 #
 # test functions
 #
-gap> f:=x->x;; MemoryUsage(f) - SIZE_OBJ(f) in [160, 96];
+gap> f:=x->x;; MemoryUsage(f) - SIZE_OBJ(f) in [168, 100];
 true
-gap> f:=x->x+1;; MemoryUsage(f) - SIZE_OBJ(f) in [184, 112];
+gap> f:=x->x+1;; MemoryUsage(f) - SIZE_OBJ(f) in [192, 116];
 true
 gap> MemoryUsage(f) = MemoryUsage(f);
 true


### PR DESCRIPTION
When coding GAP function bodies, we now have an (optional) plist in the function body of (immutable) values. Instead of storing the raw data for an integer or string within the respective expression, we instead store the integer resp. string in that values plist, and retrieve it from there when printing or evaluation such expressions (for strings, evaluation returns a shallow copy of the stored string constant, to preserve semantics). For eager floats, the values plist is used instead of `EAGER_FLOAT_LITERAL_CACHE`, which is removed by this patch (thus resolving part of issue #1993).

These changes have several advantages:
* we avoid a possible GC crash when compiling (large) string expressions
* a function like `f := x -> 12345678901234567890` used to return a newinteger object with each call; now it always returns the same integer, i.e., `IsIdenticalObj(f(1), f(2));` now returns true
* floats benefit from avoiding use of a global "cache" which never is emptied (thus these eager float literals now are garbage collected if the function referencing them is garbage collected)
* the cache simplifies future optimizations: e.g. we could convert expressions like `-2^100` by evaluating them and storing the result in the values list; we could also store permutations precomputed, that is, replace a `T_PERM_EXPR` and the `T_PERM_CYCLE` expressions nested in it by a single "constant expression" that references the immutable permutation described by these expressions (at least in the case these expressions were explicitly defined, i.e., `(1,2)` would work but not `(i,j)`


To enable this, the SyntaxTree code is slightly tweaks to use EVAL_EXPR for some kinds of expressions, thus making it independent of the internal coding of those expressions.

Contains PR #3176