### PR TITLE
stable-4.10: backport two buildsys changes to the GAPARCH

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -28,6 +28,10 @@ GC_SOURCES = @GC_SOURCES@
 COMPAT_MODE = @COMPAT_MODE@
 GAPARCH = @GAPARCH@
 
+# GAP kernel version
+GAP_KERNEL_MINOR_VERSION = @gap_kernel_minor_version@
+GAP_KERNEL_MAJOR_VERSION = @gap_kernel_major_version@
+
 # autoconf package metadata
 PACKAGE_BUGREPORT = @PACKAGE_BUGREPORT@
 PACKAGE_NAME = @PACKAGE_NAME@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -666,6 +666,9 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 	@echo "GAP_HPCGAP=$(HPCGAP)" >> $@
 	@echo "GAP_ADDGUARDS2=$(ADDGUARDS2)" >> $@
 	@echo "" >> $@
+	@echo "GAP_KERNEL_MAJOR_VERSION=$(GAP_KERNEL_MAJOR_VERSION)" >> $@
+	@echo "GAP_KERNEL_MINOR_VERSION=$(GAP_KERNEL_MINOR_VERSION)" >> $@
+	@echo "" >> $@
 	@echo "GAP_BIN_DIR=\"$(abs_builddir)\"" >> $@
 	@echo "GAP_LIB_DIR=\"$(abs_srcdir)\"" >> $@
 	@echo "" >> $@

--- a/configure.ac
+++ b/configure.ac
@@ -595,9 +595,13 @@ AC_DEFINE_UNQUOTED([GAP_KERNEL_MINOR_VERSION], $gap_kernel_minor_version, [The m
 dnl
 dnl User setting: Compatibility mode (on by default)
 dnl
-AS_IF([test "x$enable_hpcgap" = xyes],
-  [GAPARCH="$host-hpcgap${ABI}-kv${gap_kernel_major_version}"],
-  [GAPARCH="$host-default${ABI}-kv${gap_kernel_major_version}"])
+AS_IF(
+  [test "x$enable_hpcgap" = xyes],
+     [GAPARCH="$host-hpcgap${ABI}-kv${gap_kernel_major_version}"],
+  [test "x$with_julia" != xno],
+     [GAPARCH="$host-julia${ABI}-kv${gap_kernel_major_version}"],
+  # else
+     [GAPARCH="$host-default${ABI}-kv${gap_kernel_major_version}"])
 AS_IF([test "x$ARCHEXT" != "x"],
   [GAPARCH="$GAPARCH-$ARCHEXT"])
 AS_IF([test "x$ARCH" != "x"],

--- a/configure.ac
+++ b/configure.ac
@@ -579,13 +579,25 @@ AS_IF([test "x$with_gc" = xboehm],
   ]
 )
 
+dnl
+dnl Define kernel version
+dnl
+
+
+gap_kernel_major_version=3
+gap_kernel_minor_version=0
+AC_SUBST([gap_kernel_major_version])
+AC_SUBST([gap_kernel_minor_version])
+
+AC_DEFINE_UNQUOTED([GAP_KERNEL_MAJOR_VERSION], $gap_kernel_major_version, [The major version of the kernel ABI])
+AC_DEFINE_UNQUOTED([GAP_KERNEL_MINOR_VERSION], $gap_kernel_minor_version, [The minor version of the kernel ABI])
 
 dnl
 dnl User setting: Compatibility mode (on by default)
 dnl
 AS_IF([test "x$enable_hpcgap" = xyes],
-  [GAPARCH="$host-hpcgap${ABI}"],
-  [GAPARCH="$host-default${ABI}"])
+  [GAPARCH="$host-hpcgap${ABI}-kv${gap_kernel_major_version}"],
+  [GAPARCH="$host-default${ABI}-kv${gap_kernel_major_version}"])
 AS_IF([test "x$ARCHEXT" != "x"],
   [GAPARCH="$GAPARCH-$ARCHEXT"])
 AS_IF([test "x$ARCH" != "x"],

--- a/src/modules.h
+++ b/src/modules.h
@@ -40,8 +40,9 @@
 **
 */
 
-#define GAP_KERNEL_MAJOR_VERSION 3
-#define GAP_KERNEL_MINOR_VERSION 0
+// GAP_KERNEL_MAJOR_VERSION and GAP_KERNEL_MINOR_VERSION are defined in
+// config.h
+
 #define GAP_KERNEL_API_VERSION                                               \
     ((GAP_KERNEL_MAJOR_VERSION)*1000 + (GAP_KERNEL_MINOR_VERSION))
 


### PR DESCRIPTION
This PR backports two commits from master that change the GAPARCH string:
* one commit by @ChrisJefferson from PR #2873 which moves GAP the kernel version to the configure script; the only change is that I adapted it to preserve the kernel version used by 4.10; this commit also modifies the GAPARCH, by inserting the kernel version into it
* one commit from PR #2905 (out of three, the other two were already backported) which changes the GAPARCH to distinguish between "default" builds, HPC-GAP and Julia builds.

These changes are useful when one wants to debug HPC-GAP and Julia builds of GAP together with packages, as the different GAPARCHs ensure that rebuilding the same package for each build variant leaves separate binaries, so the package then can be used by those different builds (i.e., no need to keep separate pkg dirs, one can use out-of-tree builds for the different build configs).

The main concern (and the reason I did not push these backports directly) is that perhaps some code somewhere could be broken by the modified GAPARCH... We already tried hard to ensure that all deposited packages keep working, and I can't really think of problems, but I want that (a) tests for this change are run, and (b) would like to know if e.g. @ChrisJefferson can think of any potential issues