### PR TITLE
kernel: fix GC crash in PushValue()

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -517,9 +517,13 @@ void PushBinaryOp (
 static Int PushValue(Obj val)
 {
     BodyHeader * header = (BodyHeader *)STATE(PtrBody);
-    if (!header->values)
-        header->values = NEW_PLIST(T_PLIST, 4);
-    return PushPlist(header->values, val);
+    Obj values = header->values;
+    if (!values) {
+        values = NEW_PLIST(T_PLIST, 4);
+        header = (BodyHeader *)STATE(PtrBody);
+        header->values = values;
+    }
+    return PushPlist(values, val);
 }
 
 


### PR DESCRIPTION
The NEW_PLIST call could trigger a GC, which then rendered the value of header
invalid, possibly leading to arbitrary memory corruption, and also the values
pointer of the function body was then not set correctly.

Fixes #3187