### PR TITLE
Catch some corner cases for trivial group

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1739,6 +1739,11 @@ local   F,      # free group
 	relators,
 	i, k;       # loop variables
 
+    if IsTrivial(G) then
+      return GroupHomomorphismByFunction(G, TRIVIAL_FP_GROUP,
+                                         x->One(TRIVIAL_FP_GROUP),
+                                         x->One(G):noassert);
+    fi;
     # test for internal rep
     if HasGeneratorsOfGroup(G) and 
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -866,6 +866,9 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
   end;
 
   G:=arg[1];
+  if IsTrivial(G) then
+    return LatticeFromClasses(G,[G^G]);
+  fi;
   H:=fail;
   select:=fail;
   if Length(arg)>1 then
@@ -1241,6 +1244,11 @@ InstallMethod(LatticeSubgroups,"via radical",true,[IsGroup and
 
 InstallMethod(LatticeSubgroups,"cyclic extension",true,[IsGroup and
   IsFinite],0, LatticeByCyclicExtension );
+
+InstallMethod(LatticeSubgroups, "for the trivial group", true,
+  [IsGroup and IsTrivial],
+  0,
+  G -> LatticeFromClasses(G,[G^G]));
 
 RedispatchOnCondition( LatticeSubgroups, true,
     [ IsGroup ], [ IsFinite ], 0 );

--- a/tst/testbugfix/2019-01-18-grplatt.tst
+++ b/tst/testbugfix/2019-01-18-grplatt.tst
@@ -1,0 +1,8 @@
+gap> LatticeSubgroups(Group(()));
+<subgroup lattice of Group(()), 1 classes, 1 subgroups>
+gap> IsomorphismFpGroup(SymmetricGroup(1));
+MappingByFunction( Group(()), <fp group on the generators 
+[  ]>, function( x ) ... end, function( x ) ... end )
+gap> IsomorphismFpGroup(SymmetricGroup(1), "F");
+MappingByFunction( Group(()), <fp group on the generators 
+[  ]>, function( x ) ... end, function( x ) ... end )


### PR DESCRIPTION
In current master:

```
gap> G := Group(());;
gap> cc := ConjugacyClasses(G);;
gap> x := Representative(cc[1]);;
gap> C := Centralizer(G, x);;
gap> ConjugacyClassesSubgroups(C);
Error, usage: FreeGroup(<name1>,<name2>..) or FreeGroup(<rank>) at /home/mp397/git/gap/lib/grpfree.gi:467 called from
FreeGroup( deg - 1, nam ) at /home/mp397/git/gap/lib/gpprmsya.gi:1752 called from
IsomorphismFpGroup( G, Concatenation( "S_", String( Length( MovedPoints( G ) ) ), "." ) ) at /home/mp397/git/gap/lib/gpprmsya.gi:1728 called from
IsomorphismFpGroup( Image( hom ) ) at /home/mp397/git/gap/lib/grplatt.gi:890 called from
LatticeSubgroups( G ) at /home/mp397/git/gap/lib/grplatt.gi:208 called from
<function "unknown">( <arguments> )
 called from read-eval loop at *stdin*:5
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
```

This happens because GAP istrying to create a free group of rank `-1`, which does not exist.