### PR TITLE
kernel: add 'static' keyword where possible

### DIFF
--- a/src/ariths.c
+++ b/src/ariths.c
@@ -44,7 +44,7 @@ ArithMethod1 ZeroFuncs [LAST_REAL_TNUM+1];
 */
 static Obj ZEROOp;
 
-Obj ZeroObject (
+static Obj ZeroObject (
     Obj                 obj )
 
 {
@@ -59,7 +59,7 @@ Obj ZeroObject (
 **
 *F  VerboseZeroObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-Obj VerboseZeroObject (
+static Obj VerboseZeroObject (
     Obj                 obj )
 
 {
@@ -90,7 +90,7 @@ static void InstallZeroObject ( Int verb )
 **
 *F  FuncZERO( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'ZERO'
 */
-Obj FuncZERO (
+static Obj FuncZERO (
     Obj                 self,
     Obj                 obj )
 {
@@ -110,7 +110,7 @@ ArithMethod1 ZeroMutFuncs [LAST_REAL_TNUM+1];
 */
 static Obj ZeroOp;
 
-Obj ZeroMutObject (
+static Obj ZeroMutObject (
     Obj                 obj )
 
 {
@@ -125,7 +125,7 @@ Obj ZeroMutObject (
 **
 *F  VerboseZeroMutObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-Obj VerboseZeroMutObject (
+static Obj VerboseZeroMutObject (
     Obj                 obj )
 
 {
@@ -156,7 +156,7 @@ static void InstallZeroMutObject ( Int verb )
 **
 *F  FuncZERO_MUT( <self>, <obj> ) . . . . . . . . . . . . . . call 'ZERO_MUT'
 */
-Obj FuncZERO_MUT (
+static Obj FuncZERO_MUT (
     Obj                 self,
     Obj                 obj )
 {
@@ -180,7 +180,7 @@ ArithMethod1 AInvMutFuncs[ LAST_REAL_TNUM + 1];
 */
 static Obj AInvOp;
 
-Obj AInvObject (
+static Obj AInvObject (
     Obj                 obj )
 {
   Obj val;
@@ -194,7 +194,7 @@ Obj AInvObject (
 **
 *F  VerboseAInvObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-Obj VerboseAInvObject (
+static Obj VerboseAInvObject (
     Obj                 obj )
 {
   Obj val;
@@ -224,7 +224,7 @@ static void InstallAInvObject(Int verb)
 **
 *F  FuncAINV( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'AINV'
 */
-Obj FuncAINV (
+static Obj FuncAINV (
     Obj                 self,
     Obj                 obj )
 {
@@ -237,7 +237,7 @@ Obj FuncAINV (
 */
 static Obj AdditiveInverseOp;
 
-Obj AInvMutObject (
+static Obj AInvMutObject (
     Obj                 obj )
 {
   Obj val;
@@ -251,7 +251,7 @@ Obj AInvMutObject (
 **
 *F  VerboseAInvMutObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-Obj VerboseAInvMutObject (
+static Obj VerboseAInvMutObject (
     Obj                 obj )
 {
   Obj val;
@@ -281,7 +281,7 @@ static void InstallAInvMutObject(Int verb)
 **
 *F  FuncAINV_MUT( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'AINV'
 */
-Obj FuncAINV_MUT (
+static Obj FuncAINV_MUT (
     Obj                 self,
     Obj                 obj )
 {
@@ -302,7 +302,7 @@ ArithMethod1 OneFuncs [LAST_REAL_TNUM+1];
 */
 static Obj OneOp;
 
-Obj OneObject (
+static Obj OneObject (
     Obj                 obj )
 {
   Obj val;
@@ -316,7 +316,7 @@ Obj OneObject (
 **
 *F  VerboseOneObject( <obj> ) . . . . . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseOneObject (
+static Obj VerboseOneObject (
     Obj                 obj )
 {
   Obj val;
@@ -346,7 +346,7 @@ static void InstallOneObject ( Int verb )
 **
 *F  FuncONE( <self>, <obj> ) . . . . . . . . . . . . . . . . .  call 'ONE'
 */
-Obj FuncONE (
+static Obj FuncONE (
     Obj                 self,
     Obj                 obj )
 {
@@ -366,7 +366,7 @@ ArithMethod1 OneMutFuncs [LAST_REAL_TNUM+1];
 */
 static Obj OneMutOp;
 
-Obj OneMutObject (
+static Obj OneMutObject (
     Obj                 obj )
 {
   Obj val;
@@ -380,7 +380,7 @@ Obj OneMutObject (
 **
 *F  VerboseOneMutObject( <obj> ) . . .  . . . . . . . . . . . .  call methsel
 */
-Obj VerboseOneMutObject (
+static Obj VerboseOneMutObject (
     Obj                 obj )
 {
   Obj val;
@@ -410,7 +410,7 @@ static void InstallOneMutObject ( Int verb )
 **
 *F  FuncONE_MUT( <self>, <obj> ) . . . . . . . . . . . . . . . .call 'ONE_MUT'
 */
-Obj FuncONE_MUT (
+static Obj FuncONE_MUT (
     Obj                 self,
     Obj                 obj )
 {
@@ -431,7 +431,7 @@ ArithMethod1 InvFuncs [LAST_REAL_TNUM+1];
 */
 static Obj InvOp;
 
-Obj InvObject (
+static Obj InvObject (
     Obj                 obj )
 {
   Obj val;
@@ -445,7 +445,7 @@ Obj InvObject (
 **
 *F  VerboseInvObject( <obj> ) . . . . . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseInvObject (
+static Obj VerboseInvObject (
     Obj                 obj )
 {
   Obj val;
@@ -475,7 +475,7 @@ static void InstallInvObject ( Int verb )
 **
 *F  FuncINV( <self>, <obj> )  . . . . . . . . . . . . . . . . . .  call 'INV'
 */
-Obj FuncINV (
+static Obj FuncINV (
     Obj                 self,
     Obj                 obj )
 {
@@ -496,7 +496,7 @@ ArithMethod1 InvMutFuncs [LAST_REAL_TNUM+1];
 */
 static Obj InvMutOp;
 
-Obj InvMutObject (
+static Obj InvMutObject (
     Obj                 obj )
 {
   Obj val;
@@ -510,7 +510,7 @@ Obj InvMutObject (
 **
 *F  VerboseInvMutObject( <obj> ) . . .  . . . . . . . . . . . .  call methsel
 */
-Obj VerboseInvMutObject (
+static Obj VerboseInvMutObject (
     Obj                 obj )
 {
   Obj val;
@@ -540,7 +540,7 @@ static void InstallInvMutObject ( Int verb )
 **
 *F  FuncINV_MUT( <self>, <obj> )  . . .  . . . . . . . . . .  call 'INV_MUT'
 */
-Obj FuncINV_MUT (
+static Obj FuncINV_MUT (
     Obj                 self,
     Obj                 obj )
 {
@@ -564,7 +564,7 @@ CompaMethod EqFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  EqNot( <opL>, <opR> ) . . . . . . . . . . . . . . . . . . . . . not equal
 */
-Int EqNot (
+static Int EqNot (
     Obj                 opL,
     Obj                 opR )
 {
@@ -590,7 +590,7 @@ Int EqObject (
 **
 *F  VerboseEqObject( <opL>, <opR> ) . . . . . . . . . . . . . .  call methsel
 */
-Int VerboseEqObject (
+static Int VerboseEqObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -622,7 +622,7 @@ static void InstallEqObject ( Int verb )
 **
 *F  FuncEQ( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . . . call 'EQ'
 */
-Obj FuncEQ (
+static Obj FuncEQ (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -651,7 +651,7 @@ CompaMethod LtFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 Obj LtOper;
 
-Int LtObject (
+static Int LtObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -663,7 +663,7 @@ Int LtObject (
 **
 *F  VerboseLtObject( <opL>, <opR> ) . . . . . . . . . . . . . .  call methsel
 */
-Int VerboseLtObject (
+static Int VerboseLtObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -695,7 +695,7 @@ static void InstallLtObject ( Int verb )
 **
 *F  FuncLT( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . . . call 'LT'
 */
-Obj FuncLT (
+static Obj FuncLT (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -715,7 +715,7 @@ CompaMethod InFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  InUndefined( <self>, <opL>, <opR> ) . . . . . . . . . . . . . cannot 'in'
 */
-Int InUndefined (
+static Int InUndefined (
     Obj                 opL,
     Obj                 opR )
 {
@@ -730,7 +730,7 @@ Int InUndefined (
 */
 static Obj InOper;
 
-Int InObject (
+static Int InObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -742,7 +742,7 @@ Int InObject (
 **
 *F  VerboseInObject( <opL>, <opR> ) . . . . . . . . . . . . . .  call methsel
 */
-Int VerboseInObject (
+static Int VerboseInObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -774,7 +774,7 @@ static void InstallInObject ( Int verb )
 **
 *F  FuncIN( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . . . call 'IN'
 */
-Obj FuncIN (
+static Obj FuncIN (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -801,7 +801,7 @@ ArithMethod2    SumFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 Obj SumOper;
 
-Obj SumObject (
+static Obj SumObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -816,7 +816,7 @@ Obj SumObject (
 **
 *F  VerboseSumObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseSumObject (
+static Obj VerboseSumObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -851,7 +851,7 @@ static void InstallSumObject ( Int verb )
 **
 *F  FuncSUM( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'SUM'
 */
-Obj FuncSUM (
+static Obj FuncSUM (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -871,7 +871,7 @@ ArithMethod2 DiffFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  DiffDefault( <opL>, <opR> ) . . . . . . . . . . . . call 'SUM' and 'AINV'
 */
-Obj DiffDefault (
+static Obj DiffDefault (
     Obj                 opL,
     Obj                 opR )
 {
@@ -888,7 +888,7 @@ Obj DiffDefault (
 */
 static Obj DiffOper;
 
-Obj DiffObject (
+static Obj DiffObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -903,7 +903,7 @@ Obj DiffObject (
 **
 *F  VerboseDiffObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseDiffObject (
+static Obj VerboseDiffObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -938,7 +938,7 @@ static void InstallDiffObject ( Int verb )
 **
 *F  FuncDIFF_DEFAULT( <self>, <opL>, <opR> )  . . . . . .  call 'DiffDefault'
 */
-Obj FuncDIFF_DEFAULT (
+static Obj FuncDIFF_DEFAULT (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -951,7 +951,7 @@ Obj FuncDIFF_DEFAULT (
 **
 *F  FuncDIFF( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'DIFF'
 */
-Obj FuncDIFF (
+static Obj FuncDIFF (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -973,7 +973,7 @@ ArithMethod2    ProdFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 static Obj ProdOper;
 
-Obj ProdObject (
+static Obj ProdObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -988,7 +988,7 @@ Obj ProdObject (
 **
 *F  VerboseProdObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseProdObject (
+static Obj VerboseProdObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1023,7 +1023,7 @@ static void InstallProdObject ( Int verb )
 **
 *F  FuncPROD( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'PROD'
 */
-Obj FuncPROD (
+static Obj FuncPROD (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1043,7 +1043,7 @@ ArithMethod2 QuoFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  QuoDefault( <opL>, <opR> )  . . . . . . . . . . . . call 'INV' and 'PROD'
 */
-Obj QuoDefault (
+static Obj QuoDefault (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1059,7 +1059,7 @@ Obj QuoDefault (
 */
 static Obj QuoOper;
 
-Obj QuoObject (
+static Obj QuoObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1074,7 +1074,7 @@ Obj QuoObject (
 **
 *F  VerboseQuoObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseQuoObject (
+static Obj VerboseQuoObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1109,7 +1109,7 @@ static void InstallQuoObject ( Int verb )
 **
 *F  FuncQUO_DEFAULT( <self>, <opL>, <opR> ) . . . . . . . . call 'QuoDefault'
 */
-Obj FuncQUO_DEFAULT (
+static Obj FuncQUO_DEFAULT (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1122,7 +1122,7 @@ Obj FuncQUO_DEFAULT (
 **
 *F  FuncQUO( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'QUO'
 */
-Obj FuncQUO (
+static Obj FuncQUO (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1142,7 +1142,7 @@ ArithMethod2 LQuoFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  LQuoDefault( <opL>, <opR> ) . . . . . . . . . . . . call 'INV' and 'PROD'
 */
-Obj LQuoDefault (
+static Obj LQuoDefault (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1158,7 +1158,7 @@ Obj LQuoDefault (
 */
 static Obj LQuoOper;
 
-Obj LQuoObject (
+static Obj LQuoObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1173,7 +1173,7 @@ Obj LQuoObject (
 **
 *F  VerboseLQuoObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseLQuoObject (
+static Obj VerboseLQuoObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1208,7 +1208,7 @@ static void InstallLQuoObject ( Int verb )
 **
 *F  FuncLQUO_DEFAULT( <self>, <opL>, <opR> )  . . . . . .  call 'LQuoDefault'
 */
-Obj FuncLQUO_DEFAULT (
+static Obj FuncLQUO_DEFAULT (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1221,7 +1221,7 @@ Obj FuncLQUO_DEFAULT (
 **
 *F  FuncLQUO( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'LQUO'
 */
-Obj FuncLQUO (
+static Obj FuncLQUO (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1241,7 +1241,7 @@ ArithMethod2 PowFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  PowDefault( <opL>, <opR> )  . . . . . . . . . . .  call 'LQUO' and 'PROD'
 */
-Obj PowDefault (
+static Obj PowDefault (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1257,7 +1257,7 @@ Obj PowDefault (
 */
 static Obj PowOper;
 
-Obj PowObject (
+static Obj PowObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1272,7 +1272,7 @@ Obj PowObject (
 **
 *F  VerbosePowObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-Obj VerbosePowObject (
+static Obj VerbosePowObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1308,7 +1308,7 @@ static void InstallPowObject ( Int verb )
 **
 *F  FuncPOW_DEFAULT( <self>, <opL>, <opR> ) . . . . . . . . call 'PowDefault'
 */
-Obj FuncPOW_DEFAULT (
+static Obj FuncPOW_DEFAULT (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1321,7 +1321,7 @@ Obj FuncPOW_DEFAULT (
 **
 *F  FuncPOW( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'POW'
 */
-Obj FuncPOW (
+static Obj FuncPOW (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1341,7 +1341,7 @@ ArithMethod2 CommFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  CommDefault( <opL>, <opR> ) . . . . . . . . . . .  call 'LQUO' and 'PROD'
 */
-Obj CommDefault (
+static Obj CommDefault (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1359,7 +1359,7 @@ Obj CommDefault (
 */
 static Obj CommOper;
 
-Obj CommObject (
+static Obj CommObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1374,7 +1374,7 @@ Obj CommObject (
 **
 *F  VerboseCommObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseCommObject (
+static Obj VerboseCommObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1409,7 +1409,7 @@ static void InstallCommObject ( Int verb )
 **
 *F  FuncCOMM_DEFAULT( <self>, <opL>, <opR> )  . . . . . .  call 'CommDefault'
 */
-Obj FuncCOMM_DEFAULT (
+static Obj FuncCOMM_DEFAULT (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1422,7 +1422,7 @@ Obj FuncCOMM_DEFAULT (
 **
 *F  FuncCOMM( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'COMM'
 */
-Obj FuncCOMM (
+static Obj FuncCOMM (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )
@@ -1445,7 +1445,7 @@ ArithMethod2 ModFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 static Obj ModOper;
 
-Obj ModObject (
+static Obj ModObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1460,7 +1460,7 @@ Obj ModObject (
 **
 *F  VerboseModObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-Obj VerboseModObject (
+static Obj VerboseModObject (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1495,7 +1495,7 @@ static void InstallModObject ( Int verb )
 **
 *F  FuncMOD( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'MOD'
 */
-Obj FuncMOD (
+static Obj FuncMOD (
     Obj                 self,
     Obj                 opL,
     Obj                 opR )

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -44,8 +44,7 @@ ArithMethod1 ZeroFuncs [LAST_REAL_TNUM+1];
 */
 static Obj ZEROOp;
 
-static Obj ZeroObject (
-    Obj                 obj )
+static Obj ZeroObject(Obj obj)
 
 {
   Obj val;
@@ -59,8 +58,7 @@ static Obj ZeroObject (
 **
 *F  VerboseZeroObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-static Obj VerboseZeroObject (
-    Obj                 obj )
+static Obj VerboseZeroObject(Obj obj)
 
 {
   Obj val;
@@ -90,9 +88,7 @@ static void InstallZeroObject ( Int verb )
 **
 *F  FuncZERO( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'ZERO'
 */
-static Obj FuncZERO (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncZERO(Obj self, Obj obj)
 {
     return ZERO(obj);
 }
@@ -110,8 +106,7 @@ ArithMethod1 ZeroMutFuncs [LAST_REAL_TNUM+1];
 */
 static Obj ZeroOp;
 
-static Obj ZeroMutObject (
-    Obj                 obj )
+static Obj ZeroMutObject(Obj obj)
 
 {
   Obj val;
@@ -125,8 +120,7 @@ static Obj ZeroMutObject (
 **
 *F  VerboseZeroMutObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-static Obj VerboseZeroMutObject (
-    Obj                 obj )
+static Obj VerboseZeroMutObject(Obj obj)
 
 {
   Obj val;
@@ -156,9 +150,7 @@ static void InstallZeroMutObject ( Int verb )
 **
 *F  FuncZERO_MUT( <self>, <obj> ) . . . . . . . . . . . . . . call 'ZERO_MUT'
 */
-static Obj FuncZERO_MUT (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncZERO_MUT(Obj self, Obj obj)
 {
     return ZERO_MUT(obj);
 }
@@ -180,8 +172,7 @@ ArithMethod1 AInvMutFuncs[ LAST_REAL_TNUM + 1];
 */
 static Obj AInvOp;
 
-static Obj AInvObject (
-    Obj                 obj )
+static Obj AInvObject(Obj obj)
 {
   Obj val;
   val = DoOperation1Args( AInvOp, obj );
@@ -194,8 +185,7 @@ static Obj AInvObject (
 **
 *F  VerboseAInvObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-static Obj VerboseAInvObject (
-    Obj                 obj )
+static Obj VerboseAInvObject(Obj obj)
 {
   Obj val;
   val = DoVerboseOperation1Args( AInvOp, obj );
@@ -224,9 +214,7 @@ static void InstallAInvObject(Int verb)
 **
 *F  FuncAINV( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'AINV'
 */
-static Obj FuncAINV (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncAINV(Obj self, Obj obj)
 {
     return AINV(obj);
 }
@@ -237,8 +225,7 @@ static Obj FuncAINV (
 */
 static Obj AdditiveInverseOp;
 
-static Obj AInvMutObject (
-    Obj                 obj )
+static Obj AInvMutObject(Obj obj)
 {
   Obj val;
   val = DoOperation1Args( AdditiveInverseOp, obj );
@@ -251,8 +238,7 @@ static Obj AInvMutObject (
 **
 *F  VerboseAInvMutObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
 */
-static Obj VerboseAInvMutObject (
-    Obj                 obj )
+static Obj VerboseAInvMutObject(Obj obj)
 {
   Obj val;
   val = DoVerboseOperation1Args( AdditiveInverseOp, obj );
@@ -281,9 +267,7 @@ static void InstallAInvMutObject(Int verb)
 **
 *F  FuncAINV_MUT( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'AINV'
 */
-static Obj FuncAINV_MUT (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncAINV_MUT(Obj self, Obj obj)
 {
     return AINV_MUT(obj);
 }
@@ -302,8 +286,7 @@ ArithMethod1 OneFuncs [LAST_REAL_TNUM+1];
 */
 static Obj OneOp;
 
-static Obj OneObject (
-    Obj                 obj )
+static Obj OneObject(Obj obj)
 {
   Obj val;
   val = DoOperation1Args( OneOp, obj );
@@ -316,8 +299,7 @@ static Obj OneObject (
 **
 *F  VerboseOneObject( <obj> ) . . . . . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseOneObject (
-    Obj                 obj )
+static Obj VerboseOneObject(Obj obj)
 {
   Obj val;
   val = DoVerboseOperation1Args( OneOp, obj );
@@ -346,9 +328,7 @@ static void InstallOneObject ( Int verb )
 **
 *F  FuncONE( <self>, <obj> ) . . . . . . . . . . . . . . . . .  call 'ONE'
 */
-static Obj FuncONE (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncONE(Obj self, Obj obj)
 {
     return ONE(obj);
 }
@@ -366,8 +346,7 @@ ArithMethod1 OneMutFuncs [LAST_REAL_TNUM+1];
 */
 static Obj OneMutOp;
 
-static Obj OneMutObject (
-    Obj                 obj )
+static Obj OneMutObject(Obj obj)
 {
   Obj val;
   val = DoOperation1Args( OneMutOp, obj );
@@ -380,8 +359,7 @@ static Obj OneMutObject (
 **
 *F  VerboseOneMutObject( <obj> ) . . .  . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseOneMutObject (
-    Obj                 obj )
+static Obj VerboseOneMutObject(Obj obj)
 {
   Obj val;
   val = DoVerboseOperation1Args( OneMutOp, obj );
@@ -410,9 +388,7 @@ static void InstallOneMutObject ( Int verb )
 **
 *F  FuncONE_MUT( <self>, <obj> ) . . . . . . . . . . . . . . . .call 'ONE_MUT'
 */
-static Obj FuncONE_MUT (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncONE_MUT(Obj self, Obj obj)
 {
     return ONE_MUT(obj);
 }
@@ -431,8 +407,7 @@ ArithMethod1 InvFuncs [LAST_REAL_TNUM+1];
 */
 static Obj InvOp;
 
-static Obj InvObject (
-    Obj                 obj )
+static Obj InvObject(Obj obj)
 {
   Obj val;
   val = DoOperation1Args( InvOp, obj );
@@ -445,8 +420,7 @@ static Obj InvObject (
 **
 *F  VerboseInvObject( <obj> ) . . . . . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseInvObject (
-    Obj                 obj )
+static Obj VerboseInvObject(Obj obj)
 {
   Obj val;
   val = DoVerboseOperation1Args( InvOp, obj );
@@ -475,9 +449,7 @@ static void InstallInvObject ( Int verb )
 **
 *F  FuncINV( <self>, <obj> )  . . . . . . . . . . . . . . . . . .  call 'INV'
 */
-static Obj FuncINV (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncINV(Obj self, Obj obj)
 {
     return INV( obj );
 }
@@ -496,8 +468,7 @@ ArithMethod1 InvMutFuncs [LAST_REAL_TNUM+1];
 */
 static Obj InvMutOp;
 
-static Obj InvMutObject (
-    Obj                 obj )
+static Obj InvMutObject(Obj obj)
 {
   Obj val;
   val = DoOperation1Args( InvMutOp, obj );
@@ -510,8 +481,7 @@ static Obj InvMutObject (
 **
 *F  VerboseInvMutObject( <obj> ) . . .  . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseInvMutObject (
-    Obj                 obj )
+static Obj VerboseInvMutObject(Obj obj)
 {
   Obj val;
   val = DoVerboseOperation1Args( InvMutOp, obj );
@@ -540,9 +510,7 @@ static void InstallInvMutObject ( Int verb )
 **
 *F  FuncINV_MUT( <self>, <obj> )  . . .  . . . . . . . . . .  call 'INV_MUT'
 */
-static Obj FuncINV_MUT (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncINV_MUT(Obj self, Obj obj)
 {
     return INV_MUT( obj );
 }
@@ -564,9 +532,7 @@ CompaMethod EqFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  EqNot( <opL>, <opR> ) . . . . . . . . . . . . . . . . . . . . . not equal
 */
-static Int EqNot (
-    Obj                 opL,
-    Obj                 opR )
+static Int EqNot(Obj opL, Obj opR)
 {
     return 0L;
 }
@@ -590,9 +556,7 @@ Int EqObject (
 **
 *F  VerboseEqObject( <opL>, <opR> ) . . . . . . . . . . . . . .  call methsel
 */
-static Int VerboseEqObject (
-    Obj                 opL,
-    Obj                 opR )
+static Int VerboseEqObject(Obj opL, Obj opR)
 {
     return (DoVerboseOperation2Args( EqOper, opL, opR ) == True);
 }
@@ -622,10 +586,7 @@ static void InstallEqObject ( Int verb )
 **
 *F  FuncEQ( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . . . call 'EQ'
 */
-static Obj FuncEQ (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncEQ(Obj self, Obj opL, Obj opR)
 {
   /* if both operands are T_MACFLOAT, we use the comparison method in all cases,
      even if the objects are identical. In this manner, we can have 0./0. != 0./0. as
@@ -651,9 +612,7 @@ CompaMethod LtFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 Obj LtOper;
 
-static Int LtObject (
-    Obj                 opL,
-    Obj                 opR )
+static Int LtObject(Obj opL, Obj opR)
 {
     return (DoOperation2Args( LtOper, opL, opR ) == True);
 }
@@ -663,9 +622,7 @@ static Int LtObject (
 **
 *F  VerboseLtObject( <opL>, <opR> ) . . . . . . . . . . . . . .  call methsel
 */
-static Int VerboseLtObject (
-    Obj                 opL,
-    Obj                 opR )
+static Int VerboseLtObject(Obj opL, Obj opR)
 {
     return (DoVerboseOperation2Args( LtOper, opL, opR ) == True);
 }
@@ -695,10 +652,7 @@ static void InstallLtObject ( Int verb )
 **
 *F  FuncLT( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . . . call 'LT'
 */
-static Obj FuncLT (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncLT(Obj self, Obj opL, Obj opR)
 {
     return (LT( opL, opR ) ? True : False);
 }
@@ -715,9 +669,7 @@ CompaMethod InFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  InUndefined( <self>, <opL>, <opR> ) . . . . . . . . . . . . . cannot 'in'
 */
-static Int InUndefined (
-    Obj                 opL,
-    Obj                 opR )
+static Int InUndefined(Obj opL, Obj opR)
 {
     ErrorMayQuit("operations: IN of %s and %s is not defined",
                  (Int)TNAM_OBJ(opL), (Int)TNAM_OBJ(opR));
@@ -730,9 +682,7 @@ static Int InUndefined (
 */
 static Obj InOper;
 
-static Int InObject (
-    Obj                 opL,
-    Obj                 opR )
+static Int InObject(Obj opL, Obj opR)
 {
     return (DoOperation2Args( InOper, opL, opR ) == True);
 }
@@ -742,9 +692,7 @@ static Int InObject (
 **
 *F  VerboseInObject( <opL>, <opR> ) . . . . . . . . . . . . . .  call methsel
 */
-static Int VerboseInObject (
-    Obj                 opL,
-    Obj                 opR )
+static Int VerboseInObject(Obj opL, Obj opR)
 {
     return (DoVerboseOperation2Args( InOper, opL, opR ) == True);
 }
@@ -774,10 +722,7 @@ static void InstallInObject ( Int verb )
 **
 *F  FuncIN( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . . . call 'IN'
 */
-static Obj FuncIN (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncIN(Obj self, Obj opL, Obj opR)
 {
     return (IN( opL, opR ) ? True : False);
 }
@@ -801,9 +746,7 @@ ArithMethod2    SumFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 Obj SumOper;
 
-static Obj SumObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj SumObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( SumOper, opL, opR );
@@ -816,9 +759,7 @@ static Obj SumObject (
 **
 *F  VerboseSumObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseSumObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseSumObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoVerboseOperation2Args( SumOper, opL, opR );
@@ -851,10 +792,7 @@ static void InstallSumObject ( Int verb )
 **
 *F  FuncSUM( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'SUM'
 */
-static Obj FuncSUM (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncSUM(Obj self, Obj opL, Obj opR)
 {
     return SUM( opL, opR );
 }
@@ -871,9 +809,7 @@ ArithMethod2 DiffFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  DiffDefault( <opL>, <opR> ) . . . . . . . . . . . . call 'SUM' and 'AINV'
 */
-static Obj DiffDefault (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
 
@@ -888,9 +824,7 @@ static Obj DiffDefault (
 */
 static Obj DiffOper;
 
-static Obj DiffObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( DiffOper, opL, opR );
@@ -903,9 +837,7 @@ static Obj DiffObject (
 **
 *F  VerboseDiffObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseDiffObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseDiffObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoVerboseOperation2Args( DiffOper, opL, opR );
@@ -938,10 +870,7 @@ static void InstallDiffObject ( Int verb )
 **
 *F  FuncDIFF_DEFAULT( <self>, <opL>, <opR> )  . . . . . .  call 'DiffDefault'
 */
-static Obj FuncDIFF_DEFAULT (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncDIFF_DEFAULT(Obj self, Obj opL, Obj opR)
 {
     return DiffDefault( opL, opR );
 }
@@ -951,10 +880,7 @@ static Obj FuncDIFF_DEFAULT (
 **
 *F  FuncDIFF( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'DIFF'
 */
-static Obj FuncDIFF (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncDIFF(Obj self, Obj opL, Obj opR)
 {
     return DIFF( opL, opR );
 }
@@ -973,9 +899,7 @@ ArithMethod2    ProdFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 static Obj ProdOper;
 
-static Obj ProdObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( ProdOper, opL, opR );
@@ -988,9 +912,7 @@ static Obj ProdObject (
 **
 *F  VerboseProdObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseProdObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseProdObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoVerboseOperation2Args( ProdOper, opL, opR );
@@ -1023,10 +945,7 @@ static void InstallProdObject ( Int verb )
 **
 *F  FuncPROD( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'PROD'
 */
-static Obj FuncPROD (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncPROD(Obj self, Obj opL, Obj opR)
 {
     return PROD( opL, opR );
 }
@@ -1043,9 +962,7 @@ ArithMethod2 QuoFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  QuoDefault( <opL>, <opR> )  . . . . . . . . . . . . call 'INV' and 'PROD'
 */
-static Obj QuoDefault (
-    Obj                 opL,
-    Obj                 opR )
+static Obj QuoDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
     tmp = INV_MUT( opR );
@@ -1059,9 +976,7 @@ static Obj QuoDefault (
 */
 static Obj QuoOper;
 
-static Obj QuoObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj QuoObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( QuoOper, opL, opR );
@@ -1074,9 +989,7 @@ static Obj QuoObject (
 **
 *F  VerboseQuoObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseQuoObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseQuoObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoVerboseOperation2Args( QuoOper, opL, opR );
@@ -1109,10 +1022,7 @@ static void InstallQuoObject ( Int verb )
 **
 *F  FuncQUO_DEFAULT( <self>, <opL>, <opR> ) . . . . . . . . call 'QuoDefault'
 */
-static Obj FuncQUO_DEFAULT (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncQUO_DEFAULT(Obj self, Obj opL, Obj opR)
 {
     return QuoDefault( opL, opR );
 }
@@ -1122,10 +1032,7 @@ static Obj FuncQUO_DEFAULT (
 **
 *F  FuncQUO( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'QUO'
 */
-static Obj FuncQUO (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncQUO(Obj self, Obj opL, Obj opR)
 {
     return QUO( opL, opR );
 }
@@ -1142,9 +1049,7 @@ ArithMethod2 LQuoFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  LQuoDefault( <opL>, <opR> ) . . . . . . . . . . . . call 'INV' and 'PROD'
 */
-static Obj LQuoDefault (
-    Obj                 opL,
-    Obj                 opR )
+static Obj LQuoDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
     tmp = INV_MUT( opL );
@@ -1158,9 +1063,7 @@ static Obj LQuoDefault (
 */
 static Obj LQuoOper;
 
-static Obj LQuoObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj LQuoObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( LQuoOper, opL, opR );
@@ -1173,9 +1076,7 @@ static Obj LQuoObject (
 **
 *F  VerboseLQuoObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseLQuoObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseLQuoObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( LQuoOper, opL, opR );
@@ -1208,10 +1109,7 @@ static void InstallLQuoObject ( Int verb )
 **
 *F  FuncLQUO_DEFAULT( <self>, <opL>, <opR> )  . . . . . .  call 'LQuoDefault'
 */
-static Obj FuncLQUO_DEFAULT (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncLQUO_DEFAULT(Obj self, Obj opL, Obj opR)
 {
     return LQuoDefault( opL, opR );
 }
@@ -1221,10 +1119,7 @@ static Obj FuncLQUO_DEFAULT (
 **
 *F  FuncLQUO( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'LQUO'
 */
-static Obj FuncLQUO (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncLQUO(Obj self, Obj opL, Obj opR)
 {
     return LQUO( opL, opR );
 }
@@ -1241,9 +1136,7 @@ ArithMethod2 PowFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  PowDefault( <opL>, <opR> )  . . . . . . . . . . .  call 'LQUO' and 'PROD'
 */
-static Obj PowDefault (
-    Obj                 opL,
-    Obj                 opR )
+static Obj PowDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
     tmp = LQUO( opR, opL );
@@ -1257,9 +1150,7 @@ static Obj PowDefault (
 */
 static Obj PowOper;
 
-static Obj PowObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj PowObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( PowOper, opL, opR );
@@ -1272,9 +1163,7 @@ static Obj PowObject (
 **
 *F  VerbosePowObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-static Obj VerbosePowObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerbosePowObject(Obj opL, Obj opR)
 {
    
   Obj val;
@@ -1308,10 +1197,7 @@ static void InstallPowObject ( Int verb )
 **
 *F  FuncPOW_DEFAULT( <self>, <opL>, <opR> ) . . . . . . . . call 'PowDefault'
 */
-static Obj FuncPOW_DEFAULT (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncPOW_DEFAULT(Obj self, Obj opL, Obj opR)
 {
     return PowDefault( opL, opR );
 }
@@ -1321,10 +1207,7 @@ static Obj FuncPOW_DEFAULT (
 **
 *F  FuncPOW( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'POW'
 */
-static Obj FuncPOW (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncPOW(Obj self, Obj opL, Obj opR)
 {
     return POW( opL, opR );
 }
@@ -1341,9 +1224,7 @@ ArithMethod2 CommFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 **
 *F  CommDefault( <opL>, <opR> ) . . . . . . . . . . .  call 'LQUO' and 'PROD'
 */
-static Obj CommDefault (
-    Obj                 opL,
-    Obj                 opR )
+static Obj CommDefault(Obj opL, Obj opR)
 {
     Obj                 tmp1;
     Obj                 tmp2;
@@ -1359,9 +1240,7 @@ static Obj CommDefault (
 */
 static Obj CommOper;
 
-static Obj CommObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj CommObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( CommOper, opL, opR );
@@ -1374,9 +1253,7 @@ static Obj CommObject (
 **
 *F  VerboseCommObject( <opL>, <opR> ) . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseCommObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseCommObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoVerboseOperation2Args( CommOper, opL, opR );
@@ -1409,10 +1286,7 @@ static void InstallCommObject ( Int verb )
 **
 *F  FuncCOMM_DEFAULT( <self>, <opL>, <opR> )  . . . . . .  call 'CommDefault'
 */
-static Obj FuncCOMM_DEFAULT (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncCOMM_DEFAULT(Obj self, Obj opL, Obj opR)
 {
     return CommDefault( opL, opR );
 }
@@ -1422,10 +1296,7 @@ static Obj FuncCOMM_DEFAULT (
 **
 *F  FuncCOMM( <self>, <opL>, <opR> )  . . . . . . . . . . . . . . call 'COMM'
 */
-static Obj FuncCOMM (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncCOMM(Obj self, Obj opL, Obj opR)
 {
     return COMM( opL, opR );
 }
@@ -1445,9 +1316,7 @@ ArithMethod2 ModFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 */
 static Obj ModOper;
 
-static Obj ModObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ModObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoOperation2Args( ModOper, opL, opR );
@@ -1460,9 +1329,7 @@ static Obj ModObject (
 **
 *F  VerboseModObject( <opL>, <opR> )  . . . . . . . . . . . . .  call methsel
 */
-static Obj VerboseModObject (
-    Obj                 opL,
-    Obj                 opR )
+static Obj VerboseModObject(Obj opL, Obj opR)
 {
   Obj val;
   val = DoVerboseOperation2Args( ModOper, opL, opR );
@@ -1495,10 +1362,7 @@ static void InstallModObject ( Int verb )
 **
 *F  FuncMOD( <self>, <opL>, <opR> ) . . . . . . . . . . . . . . .  call 'MOD'
 */
-static Obj FuncMOD (
-    Obj                 self,
-    Obj                 opL,
-    Obj                 opR )
+static Obj FuncMOD(Obj self, Obj opL, Obj opR)
 {
     return MOD( opL, opR );
 }

--- a/src/blister.c
+++ b/src/blister.c
@@ -99,16 +99,16 @@
 
 /* The following are imported from the GAP level, we have one type for
  * each blist TNUM. */
-Obj TYPE_BLIST_MUT;
-Obj TYPE_BLIST_IMM;
-Obj TYPE_BLIST_NSORT_MUT;
-Obj TYPE_BLIST_NSORT_IMM;
-Obj TYPE_BLIST_SSORT_MUT;
-Obj TYPE_BLIST_SSORT_IMM;
-Obj TYPE_BLIST_EMPTY_MUT;
-Obj TYPE_BLIST_EMPTY_IMM;
+static Obj TYPE_BLIST_MUT;
+static Obj TYPE_BLIST_IMM;
+static Obj TYPE_BLIST_NSORT_MUT;
+static Obj TYPE_BLIST_NSORT_IMM;
+static Obj TYPE_BLIST_SSORT_MUT;
+static Obj TYPE_BLIST_SSORT_IMM;
+static Obj TYPE_BLIST_EMPTY_MUT;
+static Obj TYPE_BLIST_EMPTY_IMM;
 
-Obj TypeBlist(Obj list)
+static Obj TypeBlist(Obj list)
 {
     /* special case for the empty blist                                    */
     if ( LEN_BLIST(list) == 0 ) {
@@ -119,7 +119,7 @@ Obj TypeBlist(Obj list)
     }
 }
 
-Obj TypeBlistNSort(Obj list)
+static Obj TypeBlistNSort(Obj list)
 {
     /* special case for the empty blist                                    */
     if ( LEN_BLIST(list) == 0 ) {
@@ -131,7 +131,7 @@ Obj TypeBlistNSort(Obj list)
     }
 }
 
-Obj TypeBlistSSort(Obj list)
+static Obj TypeBlistSSort(Obj list)
 {
     /* special case for the empty blist                                    */
     if ( LEN_BLIST(list) == 0 ) {
@@ -149,7 +149,7 @@ Obj TypeBlistSSort(Obj list)
 **
 **   The saving method for the blist tnums
 */
-void SaveBlist (
+static void SaveBlist (
     Obj                 bl )
 {
     UInt                i;
@@ -168,7 +168,7 @@ void SaveBlist (
 **
 **   The loading method for the blist tnums
 */
-void LoadBlist (
+static void LoadBlist (
     Obj                 bl )
 {
     UInt                i;
@@ -205,7 +205,7 @@ void LoadBlist (
 **  'CopyBlist' is the function in 'CopyObjFuncs' for boolean lists.
 */
 
-Obj DoCopyBlist(Obj list, Int mut)
+static Obj DoCopyBlist(Obj list, Int mut)
 {
     Obj copy;
 
@@ -225,7 +225,7 @@ Obj DoCopyBlist(Obj list, Int mut)
 
 #if !defined(USE_THREADSAFE_COPYING)
 
-Obj CopyBlist (
+static Obj CopyBlist (
     Obj                 list,
     Int                 mut )
 {
@@ -244,7 +244,7 @@ Obj CopyBlist (
 #endif // !defined(USE_THREADSAFE_COPYING)
 
 
-Obj ShallowCopyBlist ( Obj list)
+static Obj ShallowCopyBlist ( Obj list)
 {
   return DoCopyBlist(list, 1);
 }
@@ -262,7 +262,7 @@ Obj ShallowCopyBlist ( Obj list)
 **  'EqBlist' returns 'true' if the two boolean lists <listL> and <listR> are
 **  equal and 'false' otherwise.
 */
-Int EqBlist (
+static Int EqBlist (
     Obj                 listL,
     Obj                 listR )
 {
@@ -300,7 +300,7 @@ Int EqBlist (
 **
 **  'LenBlist' is the function in 'LenListFuncs' for boolean lists.
 */
-Int LenBlist (
+static Int LenBlist (
     Obj                 list )
 {
     return LEN_BLIST( list );
@@ -317,7 +317,7 @@ Int LenBlist (
 **
 **  'IsbBlist' is the function in 'IsbListFuncs' for boolean lists.
 */
-Int IsbBlist (
+static Int IsbBlist (
     Obj                 list,
     Int                 pos )
 {
@@ -333,7 +333,7 @@ Int IsbBlist (
 **  <list>, or 0 if  <list>  has no  assigned object  at  <pos>.  It  is  the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
-Obj Elm0Blist (
+static Obj Elm0Blist (
     Obj                 list,
     Int                 pos )
 {
@@ -354,7 +354,7 @@ Obj Elm0Blist (
 **  <pos>  is less  than or  equal   to the length   of  <list>, this is  the
 **  responsibility of the caller.
 */
-Obj Elm0vBlist (
+static Obj Elm0vBlist (
     Obj                 list,
     Int                 pos )
 {
@@ -374,7 +374,7 @@ Obj Elm0vBlist (
 **  'ElmBlist'   is  the  function  in    'ElmListFuncs'  for boolean  lists.
 **  'ElmvBlist' is the function in 'ElmvListFuncs' for boolean lists.
 */
-Obj ElmBlist (
+static Obj ElmBlist (
     Obj                 list,
     Int                 pos )
 {
@@ -398,7 +398,7 @@ Obj ElmBlist (
 **  responsibility of the caller.
 **
 */
-Obj ElmvBlist (
+static Obj ElmvBlist (
     Obj                 list,
     Int                 pos )
 {
@@ -419,7 +419,7 @@ Obj ElmvBlist (
 **
 **  'ElmsBlist' is the function in 'ElmsListFuncs' for boolean lists.
 */
-Obj ElmsBlist (
+static Obj ElmsBlist (
     Obj                 list,
     Obj                 poss )
 {
@@ -611,7 +611,7 @@ void AssBlist (
 **
 **  'PosBlist' is the function in 'PosListFuncs' for boolean lists.
 */
-Obj PosBlist (
+static Obj PosBlist (
     Obj                 list,
     Obj                 val,
     Obj                 start )
@@ -721,7 +721,7 @@ Obj PosBlist (
 **
 **  'PlainBlist' is the function in 'PlainListFuncs' for boolean lists.
 */
-void PlainBlist (
+static void PlainBlist (
     Obj                 list )
 {
     Int                 len;            /* length of <list>                */
@@ -750,7 +750,7 @@ void PlainBlist (
 **  'IsPossBlist' returns  1 if  <list> is  empty, and 0 otherwise, since a
 **  boolean list is a positions list if and only if it is empty.
 */
-Int IsPossBlist (
+static Int IsPossBlist (
     Obj                 list )
 {
     return LEN_BLIST(list) == 0;
@@ -761,7 +761,7 @@ Int IsPossBlist (
 **
 *F  IsHomogBlist( <list> )  . . . . . . . . . . check if <list> is homogenous
 */
-Int IsHomogBlist (
+static Int IsHomogBlist (
     Obj                 list )
 {
     return (0 < LEN_BLIST(list));
@@ -772,7 +772,7 @@ Int IsHomogBlist (
 **
 *F  IsSSortBlist( <list> )  . . . . . . .  check if <list> is strictly sorted
 */
-Int IsSSortBlist (
+static Int IsSSortBlist (
     Obj                 list )
 {
     Int                 isSort;
@@ -840,7 +840,7 @@ void ConvBlist (
 **  list that   has no holes  and contains  only  'true' and  'false',  and 0
 **  otherwise.
 */
-Int IsBlist (
+static Int IsBlist (
     Obj                 list )
 {
     UInt                isBlist;        /* result of the test              */
@@ -888,7 +888,7 @@ Int IsBlist (
 **  boolean lists into the compact representation of type 'T_BLIST' described
 **  above.
 */
-Int IsBlistConv (
+static Int IsBlistConv (
     Obj                 list )
 {
     UInt                isBlist;        /* result of the test              */
@@ -939,7 +939,7 @@ Int IsBlistConv (
 **  The work is done in `COUNT_TRUES_BLOCKS` in blister.h and the algorithms
 **  are documented there.
 */
-UInt SizeBlist (
+static UInt SizeBlist (
     Obj                 blist )
 {
     const UInt *        ptr;            /* pointer to blist                */
@@ -970,9 +970,9 @@ UInt SizeBlist (
 **  otherwise.  A value is a   boolean list if  it is  a lists without  holes
 **  containing only  'true' and 'false'.
 */
-Obj IsBlistFilt;
+static Obj IsBlistFilt;
 
-Obj FuncIS_BLIST (
+static Obj FuncIS_BLIST (
     Obj                 self,
     Obj                 val )
 {
@@ -993,7 +993,7 @@ Obj FuncIS_BLIST (
 **  otherwise.  A value is a   boolean list if  it is  a lists without  holes
 **  containing only  'true' and 'false'.
 */
-Obj FuncIS_BLIST_CONV (
+static Obj FuncIS_BLIST_CONV (
     Obj                 self,
     Obj                 val )
 {
@@ -1007,9 +1007,9 @@ Obj FuncIS_BLIST_CONV (
 **
 *F  FuncIS_BLIST_REP( <self>, <obj> ) . . test if value is a boolean list rep
 */
-Obj IsBlistRepFilt;
+static Obj IsBlistRepFilt;
 
-Obj FuncIS_BLIST_REP (
+static Obj FuncIS_BLIST_REP (
     Obj                 self,
     Obj                 obj )
 {
@@ -1023,7 +1023,7 @@ Obj FuncIS_BLIST_REP (
 **
 **  'FuncSIZE_BLIST' implements the internal function 'SizeBlist'
 */
-Obj FuncSIZE_BLIST (
+static Obj FuncSIZE_BLIST (
     Obj                 self,
     Obj                 blist )
 {
@@ -1050,9 +1050,9 @@ Obj FuncSIZE_BLIST (
 **  arbitrary list that has no holes.
 */
 
-Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub);
+static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub);
 
-Obj FuncBLIST_LIST (
+static Obj FuncBLIST_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 sub )
@@ -1086,7 +1086,7 @@ Obj FuncBLIST_LIST (
 **  same as in <list>.
 **
 */
-Obj FuncLIST_BLIST (
+static Obj FuncLIST_BLIST (
     Obj                 self,
     Obj                 list,
     Obj                 blist )
@@ -1133,7 +1133,7 @@ Obj FuncLIST_BLIST (
 *N  1992/12/15 martin this depends on 'BIPEB' being 32
 *N  Fixed up for 64 SL
 */
-Obj FuncPositionNthTrueBlist (
+static Obj FuncPositionNthTrueBlist (
 
     Obj                 self,
     Obj                 blist,
@@ -1184,7 +1184,7 @@ Obj FuncPositionNthTrueBlist (
 **  the  boolean  list <list1>, which must  have  equal length.  <list2> is a
 **  subset of <list1> if '<list2>[<i>] >= <list1>[<i>]' for all <i>.
 */
-Obj FuncIS_SUB_BLIST (
+static Obj FuncIS_SUB_BLIST (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -1225,7 +1225,7 @@ Obj FuncIS_SUB_BLIST (
 **  <blist2>,  which  must  have the   same  length.  This  is  equivalent to
 **  assigning '<blist1>[<i>] := <blist1>[<i>] or <blist2>[<i>]' for all <i>.
 */
-Obj FuncUNITE_BLIST (
+static Obj FuncUNITE_BLIST (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -1262,7 +1262,7 @@ Obj FuncUNITE_BLIST (
 **  'UniteBlistList'  works like `BlistList', but adds the entries to the
 **  existing <blist>.
 */
-Obj FuncUNITE_BLIST_LIST (
+static Obj FuncUNITE_BLIST_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 blist,
@@ -1486,7 +1486,7 @@ Obj FuncUNITE_BLIST_LIST (
 **  list <list2>, which  must have the  same length.   This is equivalent  to
 **  assigning '<list1>[<i>] := <list1>[<i>] and <list2>[<i>]' for all <i>.
 */
-Obj FuncINTER_BLIST (
+static Obj FuncINTER_BLIST (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -1524,7 +1524,7 @@ Obj FuncINTER_BLIST (
 **  <list1>, which  must have the  same length.  This is equivalent assigning
 **  '<list1>[<i>] := <list1>[<i>] and not <list2>[<i>]' for all <i>.
 */
-Obj FuncSUBTR_BLIST (
+static Obj FuncSUBTR_BLIST (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -1564,7 +1564,7 @@ Obj FuncSUBTR_BLIST (
 **  The lists must have the same length.
 */
 
-Obj FuncMEET_BLIST (
+static Obj FuncMEET_BLIST (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -1596,7 +1596,7 @@ Obj FuncMEET_BLIST (
 *F  MakeImmutableBlist( <blist> )
 */
 
-void MakeImmutableBlist( Obj blist )
+static void MakeImmutableBlist( Obj blist )
 {
     MakeImmutableNoRecurse(blist);
 }

--- a/src/blister.c
+++ b/src/blister.c
@@ -149,8 +149,7 @@ static Obj TypeBlistSSort(Obj list)
 **
 **   The saving method for the blist tnums
 */
-static void SaveBlist (
-    Obj                 bl )
+static void SaveBlist(Obj bl)
 {
     UInt                i;
     const UInt *        ptr;
@@ -168,8 +167,7 @@ static void SaveBlist (
 **
 **   The loading method for the blist tnums
 */
-static void LoadBlist (
-    Obj                 bl )
+static void LoadBlist(Obj bl)
 {
     UInt                i;
     UInt *              ptr;
@@ -225,9 +223,7 @@ static Obj DoCopyBlist(Obj list, Int mut)
 
 #if !defined(USE_THREADSAFE_COPYING)
 
-static Obj CopyBlist (
-    Obj                 list,
-    Int                 mut )
+static Obj CopyBlist(Obj list, Int mut)
 {
     Obj copy;
 
@@ -244,7 +240,7 @@ static Obj CopyBlist (
 #endif // !defined(USE_THREADSAFE_COPYING)
 
 
-static Obj ShallowCopyBlist ( Obj list)
+static Obj ShallowCopyBlist(Obj list)
 {
   return DoCopyBlist(list, 1);
 }
@@ -262,9 +258,7 @@ static Obj ShallowCopyBlist ( Obj list)
 **  'EqBlist' returns 'true' if the two boolean lists <listL> and <listR> are
 **  equal and 'false' otherwise.
 */
-static Int EqBlist (
-    Obj                 listL,
-    Obj                 listR )
+static Int EqBlist(Obj listL, Obj listR)
 {
     long                lenL;           /* length of the left operand      */
     long                lenR;           /* length of the right operand     */
@@ -300,8 +294,7 @@ static Int EqBlist (
 **
 **  'LenBlist' is the function in 'LenListFuncs' for boolean lists.
 */
-static Int LenBlist (
-    Obj                 list )
+static Int LenBlist(Obj list)
 {
     return LEN_BLIST( list );
 }
@@ -317,9 +310,7 @@ static Int LenBlist (
 **
 **  'IsbBlist' is the function in 'IsbListFuncs' for boolean lists.
 */
-static Int IsbBlist (
-    Obj                 list,
-    Int                 pos )
+static Int IsbBlist(Obj list, Int pos)
 {
     return (pos <= LEN_BLIST(list));
 }
@@ -333,9 +324,7 @@ static Int IsbBlist (
 **  <list>, or 0 if  <list>  has no  assigned object  at  <pos>.  It  is  the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
-static Obj Elm0Blist (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0Blist(Obj list, Int pos)
 {
     if ( pos <= LEN_BLIST( list ) ) {
         return ELM_BLIST( list, pos );
@@ -354,9 +343,7 @@ static Obj Elm0Blist (
 **  <pos>  is less  than or  equal   to the length   of  <list>, this is  the
 **  responsibility of the caller.
 */
-static Obj Elm0vBlist (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0vBlist(Obj list, Int pos)
 {
     return ELM_BLIST( list, pos );
 }
@@ -374,9 +361,7 @@ static Obj Elm0vBlist (
 **  'ElmBlist'   is  the  function  in    'ElmListFuncs'  for boolean  lists.
 **  'ElmvBlist' is the function in 'ElmvListFuncs' for boolean lists.
 */
-static Obj ElmBlist (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmBlist(Obj list, Int pos)
 {
 
     /* check the position                                                  */
@@ -398,9 +383,7 @@ static Obj ElmBlist (
 **  responsibility of the caller.
 **
 */
-static Obj ElmvBlist (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmvBlist(Obj list, Int pos)
 {
     /* select and return the element                                       */
     return ELM_BLIST( list, pos );
@@ -419,9 +402,7 @@ static Obj ElmvBlist (
 **
 **  'ElmsBlist' is the function in 'ElmsListFuncs' for boolean lists.
 */
-static Obj ElmsBlist (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsBlist(Obj list, Obj poss)
 {
     Obj                 elms;           /* selected sublist, result        */
     Int                 lenList;        /* length of <list>                */
@@ -611,10 +592,7 @@ void AssBlist (
 **
 **  'PosBlist' is the function in 'PosListFuncs' for boolean lists.
 */
-static Obj PosBlist (
-    Obj                 list,
-    Obj                 val,
-    Obj                 start )
+static Obj PosBlist(Obj list, Obj val, Obj start)
 {
     Int                 len;            /* logical length of the list      */
     const UInt *        ptr;            /* pointer to the blocks           */
@@ -721,8 +699,7 @@ static Obj PosBlist (
 **
 **  'PlainBlist' is the function in 'PlainListFuncs' for boolean lists.
 */
-static void PlainBlist (
-    Obj                 list )
+static void PlainBlist(Obj list)
 {
     Int                 len;            /* length of <list>                */
     UInt                i;              /* loop variable                   */
@@ -750,8 +727,7 @@ static void PlainBlist (
 **  'IsPossBlist' returns  1 if  <list> is  empty, and 0 otherwise, since a
 **  boolean list is a positions list if and only if it is empty.
 */
-static Int IsPossBlist (
-    Obj                 list )
+static Int IsPossBlist(Obj list)
 {
     return LEN_BLIST(list) == 0;
 }
@@ -761,8 +737,7 @@ static Int IsPossBlist (
 **
 *F  IsHomogBlist( <list> )  . . . . . . . . . . check if <list> is homogenous
 */
-static Int IsHomogBlist (
-    Obj                 list )
+static Int IsHomogBlist(Obj list)
 {
     return (0 < LEN_BLIST(list));
 }
@@ -772,8 +747,7 @@ static Int IsHomogBlist (
 **
 *F  IsSSortBlist( <list> )  . . . . . . .  check if <list> is strictly sorted
 */
-static Int IsSSortBlist (
-    Obj                 list )
+static Int IsSSortBlist(Obj list)
 {
     Int                 isSort;
 
@@ -840,8 +814,7 @@ void ConvBlist (
 **  list that   has no holes  and contains  only  'true' and  'false',  and 0
 **  otherwise.
 */
-static Int IsBlist (
-    Obj                 list )
+static Int IsBlist(Obj list)
 {
     UInt                isBlist;        /* result of the test              */
     Int                 len;            /* logical length of the list      */
@@ -888,8 +861,7 @@ static Int IsBlist (
 **  boolean lists into the compact representation of type 'T_BLIST' described
 **  above.
 */
-static Int IsBlistConv (
-    Obj                 list )
+static Int IsBlistConv(Obj list)
 {
     UInt                isBlist;        /* result of the test              */
     Int                 len;            /* logical length of the list      */
@@ -939,8 +911,7 @@ static Int IsBlistConv (
 **  The work is done in `COUNT_TRUES_BLOCKS` in blister.h and the algorithms
 **  are documented there.
 */
-static UInt SizeBlist (
-    Obj                 blist )
+static UInt SizeBlist(Obj blist)
 {
     const UInt *        ptr;            /* pointer to blist                */
     UInt                nrb;            /* number of blocks in blist       */
@@ -972,9 +943,7 @@ static UInt SizeBlist (
 */
 static Obj IsBlistFilt;
 
-static Obj FuncIS_BLIST (
-    Obj                 self,
-    Obj                 val )
+static Obj FuncIS_BLIST(Obj self, Obj val)
 {
     /* let 'IsBlist' do the work                                           */
     return IsBlist( val ) ? True : False;
@@ -993,9 +962,7 @@ static Obj FuncIS_BLIST (
 **  otherwise.  A value is a   boolean list if  it is  a lists without  holes
 **  containing only  'true' and 'false'.
 */
-static Obj FuncIS_BLIST_CONV (
-    Obj                 self,
-    Obj                 val )
+static Obj FuncIS_BLIST_CONV(Obj self, Obj val)
 {
     /* let 'IsBlist' do the work                                           */
     return IsBlistConv( val ) ? True : False;
@@ -1009,9 +976,7 @@ static Obj FuncIS_BLIST_CONV (
 */
 static Obj IsBlistRepFilt;
 
-static Obj FuncIS_BLIST_REP (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_BLIST_REP(Obj self, Obj obj)
 {
     return (IS_BLIST_REP( obj ) ? True : False);
 }
@@ -1023,9 +988,7 @@ static Obj FuncIS_BLIST_REP (
 **
 **  'FuncSIZE_BLIST' implements the internal function 'SizeBlist'
 */
-static Obj FuncSIZE_BLIST (
-    Obj                 self,
-    Obj                 blist )
+static Obj FuncSIZE_BLIST(Obj self, Obj blist)
 {
     RequireBlist("SizeBlist", blist, "blist");
     return INTOBJ_INT(SizeBlist(blist));
@@ -1052,10 +1015,7 @@ static Obj FuncSIZE_BLIST (
 
 static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub);
 
-static Obj FuncBLIST_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 sub )
+static Obj FuncBLIST_LIST(Obj self, Obj list, Obj sub)
 {
     /* get and check the arguments                                         */
     RequireSmallList("BlistList", list);
@@ -1086,10 +1046,7 @@ static Obj FuncBLIST_LIST (
 **  same as in <list>.
 **
 */
-static Obj FuncLIST_BLIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 blist )
+static Obj FuncLIST_BLIST(Obj self, Obj list, Obj blist)
 {
     Obj                 sub;            /* handle of the result            */
     Int                 len;            /* logical length of the list      */
@@ -1133,11 +1090,9 @@ static Obj FuncLIST_BLIST (
 *N  1992/12/15 martin this depends on 'BIPEB' being 32
 *N  Fixed up for 64 SL
 */
-static Obj FuncPositionNthTrueBlist (
+static Obj FuncPositionNthTrueBlist(
 
-    Obj                 self,
-    Obj                 blist,
-    Obj                 Nth )
+    Obj self, Obj blist, Obj Nth)
 {
     UInt                nrb;
     Int                 pos, i;
@@ -1184,10 +1139,7 @@ static Obj FuncPositionNthTrueBlist (
 **  the  boolean  list <list1>, which must  have  equal length.  <list2> is a
 **  subset of <list1> if '<list2>[<i>] >= <list1>[<i>]' for all <i>.
 */
-static Obj FuncIS_SUB_BLIST (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncIS_SUB_BLIST(Obj self, Obj list1, Obj list2)
 {
     const UInt *        ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
@@ -1225,10 +1177,7 @@ static Obj FuncIS_SUB_BLIST (
 **  <blist2>,  which  must  have the   same  length.  This  is  equivalent to
 **  assigning '<blist1>[<i>] := <blist1>[<i>] or <blist2>[<i>]' for all <i>.
 */
-static Obj FuncUNITE_BLIST (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncUNITE_BLIST(Obj self, Obj list1, Obj list2)
 {
     UInt *              ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
@@ -1262,11 +1211,7 @@ static Obj FuncUNITE_BLIST (
 **  'UniteBlistList'  works like `BlistList', but adds the entries to the
 **  existing <blist>.
 */
-static Obj FuncUNITE_BLIST_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 blist,
-    Obj                 sub )
+static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub)
 {
     UInt  *             ptrBlist;       /* pointer to the boolean list     */
     UInt                block;          /* one block of boolean list       */
@@ -1486,10 +1431,7 @@ static Obj FuncUNITE_BLIST_LIST (
 **  list <list2>, which  must have the  same length.   This is equivalent  to
 **  assigning '<list1>[<i>] := <list1>[<i>] and <list2>[<i>]' for all <i>.
 */
-static Obj FuncINTER_BLIST (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncINTER_BLIST(Obj self, Obj list1, Obj list2)
 {
     UInt *              ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
@@ -1524,10 +1466,7 @@ static Obj FuncINTER_BLIST (
 **  <list1>, which  must have the  same length.  This is equivalent assigning
 **  '<list1>[<i>] := <list1>[<i>] and not <list2>[<i>]' for all <i>.
 */
-static Obj FuncSUBTR_BLIST (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncSUBTR_BLIST(Obj self, Obj list1, Obj list2)
 {
     UInt *              ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
@@ -1564,10 +1503,7 @@ static Obj FuncSUBTR_BLIST (
 **  The lists must have the same length.
 */
 
-static Obj FuncMEET_BLIST (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncMEET_BLIST(Obj self, Obj list1, Obj list2)
 {
     const UInt *        ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
@@ -1596,7 +1532,7 @@ static Obj FuncMEET_BLIST (
 *F  MakeImmutableBlist( <blist> )
 */
 
-static void MakeImmutableBlist( Obj blist )
+static void MakeImmutableBlist(Obj blist)
 {
     MakeImmutableNoRecurse(blist);
 }

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -85,7 +85,7 @@ void InitFreeFuncBag(UInt type, TNumFreeFuncBags finalizer_func)
 
 #ifndef WARD_ENABLED
 
-void StandardFinalizer(void * bagContents, void * data)
+static void StandardFinalizer(void * bagContents, void * data)
 {
     Bag    bag;
     void * bagContents2;
@@ -121,7 +121,7 @@ static unsigned GCMKind[MAX_GC_PREFIX_DESC + 1];
  * the overhead is negligible for large objects.
  */
 
-void BuildPrefixGCDescriptor(unsigned prefix_len)
+static void BuildPrefixGCDescriptor(unsigned prefix_len)
 {
 
     if (prefix_len) {
@@ -195,7 +195,7 @@ static void TLAllocatorInit(void)
 **  references to other bags, and > 0 to indicate a specific memory layout
 **  descriptor.
 **/
-void * AllocateBagMemory(int gc_type, int type, UInt size)
+static void * AllocateBagMemory(int gc_type, int type, UInt size)
 {
     assert(gc_type >= -1);
     void * result = NULL;
@@ -239,7 +239,7 @@ void * AllocateMemoryBlock(UInt size)
     return GC_malloc(size);
 }
 
-int TabMarkTypeBags[NUM_TYPES];
+static int TabMarkTypeBags[NUM_TYPES];
 
 void InitMarkFuncBags(UInt type, TNumMarkFuncBags mark_func)
 {

--- a/src/bool.c
+++ b/src/bool.c
@@ -71,9 +71,9 @@ Obj Undefined;
 **
 **  'TypeBool' is the function in 'TypeObjFuncs' for boolean values.
 */
-Obj TYPE_BOOL;
+static Obj TYPE_BOOL;
 
-Obj TypeBool (
+static Obj TypeBool (
     Obj                 val )
 {
     return TYPE_BOOL;
@@ -86,7 +86,7 @@ Obj TypeBool (
 **
 **  'PrintBool' prints the boolean value <bool>.
 */
-void PrintBool (
+static void PrintBool (
     Obj                 bool )
 {
     if ( bool == True ) {
@@ -111,7 +111,7 @@ void PrintBool (
 **  'EqBool' returns '1' if the two boolean values <boolL> and <boolR> are
 **  equal, and '0' otherwise.
 */
-Int EqBool (
+static Int EqBool (
     Obj                 boolL,
     Obj                 boolR )
 {
@@ -125,7 +125,7 @@ Int EqBool (
 **
 **  The ordering of Booleans is true < false < fail.
 */
-Int LtBool (
+static Int LtBool (
     Obj                 boolL,
     Obj                 boolR )
 {
@@ -148,9 +148,9 @@ Int LtBool (
 **  'IsBool'  returns  'true'  if  <obj>  is   a boolean  value  and  'false'
 **  otherwise.
 */
-Obj IsBoolFilt;
+static Obj IsBoolFilt;
 
-Obj IsBoolHandler (
+static Obj IsBoolHandler (
     Obj                 self,
     Obj                 obj )
 {
@@ -177,7 +177,7 @@ Obj IsBoolHandler (
 **  Those  functions are  useful for  dispatcher  tables if the types already
 **  determine the outcome.
 */
-Obj ReturnTrue1 (
+static Obj ReturnTrue1 (
     Obj                 self,
     Obj                 val1 )
 {
@@ -189,7 +189,7 @@ Obj ReturnTrue1 (
 **
 *F  ReturnTrue2( <val1>, <val2> ) . . . . . . . . . . . . . .  return  'True'
 */
-Obj ReturnTrue2 (
+static Obj ReturnTrue2 (
     Obj                 self,
     Obj                 val1,
     Obj                 val2 )
@@ -202,7 +202,7 @@ Obj ReturnTrue2 (
 **
 *F  ReturnTrue3( <val1>, <val2>, <val3> ) . . . . . . . . . .  return  'True'
 */
-Obj ReturnTrue3 (
+static Obj ReturnTrue3 (
     Obj                 self,
     Obj                 val1,
     Obj                 val2,
@@ -218,7 +218,7 @@ Obj ReturnTrue3 (
 **
 **  'ReturnFalse?' likewise return 'False'.
 */
-Obj ReturnFalse1 (
+static Obj ReturnFalse1 (
     Obj                 self,
     Obj                 val1 )
 {
@@ -230,7 +230,7 @@ Obj ReturnFalse1 (
 **
 *F  ReturnFalse2( <val1>, <val2> )  . . . . . . . . . . . . .  return 'False'
 */
-Obj ReturnFalse2 (
+static Obj ReturnFalse2 (
     Obj                 self,
     Obj                 val1,
     Obj                 val2 )
@@ -243,7 +243,7 @@ Obj ReturnFalse2 (
 **
 *F  ReturnFalse3( <val1>, <val2>, <val3> )  . . . . . . . . .  return 'False'
 */
-Obj ReturnFalse3 (
+static Obj ReturnFalse3 (
     Obj                 self,
     Obj                 val1,
     Obj                 val2,
@@ -259,7 +259,7 @@ Obj ReturnFalse3 (
 **
 **  'ReturnFail?' likewise return 'Fail'.
 */
-Obj ReturnFail1 (
+static Obj ReturnFail1 (
     Obj                 self,
     Obj                 val1 )
 {
@@ -271,7 +271,7 @@ Obj ReturnFail1 (
 **
 *F  ReturnFail2( <val1>, <val2> ) . . . . . . . . . . . . . .  return  'Fail'
 */
-Obj ReturnFail2 (
+static Obj ReturnFail2 (
     Obj                 self,
     Obj                 val1,
     Obj                 val2 )
@@ -284,7 +284,7 @@ Obj ReturnFail2 (
 **
 *F  ReturnFail3( <val1>, <val2>, <val3> ) . . . . . . . . . .  return  'Fail'
 */
-Obj ReturnFail3 (
+static Obj ReturnFail3 (
     Obj                 self,
     Obj                 val1,
     Obj                 val2,
@@ -301,7 +301,7 @@ Obj ReturnFail3 (
 **  Actually, there is nothing to do
 */
 
-void SaveBool( Obj obj )
+static void SaveBool( Obj obj )
 {
 }
 
@@ -312,7 +312,7 @@ void SaveBool( Obj obj )
 **  Actually, there is nothing to do
 */
 
-void LoadBool( Obj obj )
+static void LoadBool( Obj obj )
 {
 }
 

--- a/src/bool.c
+++ b/src/bool.c
@@ -73,8 +73,7 @@ Obj Undefined;
 */
 static Obj TYPE_BOOL;
 
-static Obj TypeBool (
-    Obj                 val )
+static Obj TypeBool(Obj val)
 {
     return TYPE_BOOL;
 }
@@ -86,8 +85,7 @@ static Obj TypeBool (
 **
 **  'PrintBool' prints the boolean value <bool>.
 */
-static void PrintBool (
-    Obj                 bool )
+static void PrintBool(Obj bool)
 {
     if ( bool == True ) {
         Pr( "true", 0L, 0L );
@@ -111,9 +109,7 @@ static void PrintBool (
 **  'EqBool' returns '1' if the two boolean values <boolL> and <boolR> are
 **  equal, and '0' otherwise.
 */
-static Int EqBool (
-    Obj                 boolL,
-    Obj                 boolR )
+static Int EqBool(Obj boolL, Obj boolR)
 {
     return boolL == boolR;
 }
@@ -125,9 +121,7 @@ static Int EqBool (
 **
 **  The ordering of Booleans is true < false < fail.
 */
-static Int LtBool (
-    Obj                 boolL,
-    Obj                 boolR )
+static Int LtBool(Obj boolL, Obj boolR)
 {
     if (boolL == True)
         return boolR != True;
@@ -150,9 +144,7 @@ static Int LtBool (
 */
 static Obj IsBoolFilt;
 
-static Obj IsBoolHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj IsBoolHandler(Obj self, Obj obj)
 {
     /* return 'true' if <obj> is a boolean and 'false' otherwise           */
     if ( TNUM_OBJ(obj) == T_BOOL ) {
@@ -177,9 +169,7 @@ static Obj IsBoolHandler (
 **  Those  functions are  useful for  dispatcher  tables if the types already
 **  determine the outcome.
 */
-static Obj ReturnTrue1 (
-    Obj                 self,
-    Obj                 val1 )
+static Obj ReturnTrue1(Obj self, Obj val1)
 {
     return True;
 }
@@ -189,10 +179,7 @@ static Obj ReturnTrue1 (
 **
 *F  ReturnTrue2( <val1>, <val2> ) . . . . . . . . . . . . . .  return  'True'
 */
-static Obj ReturnTrue2 (
-    Obj                 self,
-    Obj                 val1,
-    Obj                 val2 )
+static Obj ReturnTrue2(Obj self, Obj val1, Obj val2)
 {
     return True;
 }
@@ -202,11 +189,7 @@ static Obj ReturnTrue2 (
 **
 *F  ReturnTrue3( <val1>, <val2>, <val3> ) . . . . . . . . . .  return  'True'
 */
-static Obj ReturnTrue3 (
-    Obj                 self,
-    Obj                 val1,
-    Obj                 val2,
-    Obj                 val3 )
+static Obj ReturnTrue3(Obj self, Obj val1, Obj val2, Obj val3)
 {
     return True;
 }
@@ -218,9 +201,7 @@ static Obj ReturnTrue3 (
 **
 **  'ReturnFalse?' likewise return 'False'.
 */
-static Obj ReturnFalse1 (
-    Obj                 self,
-    Obj                 val1 )
+static Obj ReturnFalse1(Obj self, Obj val1)
 {
     return False;
 }
@@ -230,10 +211,7 @@ static Obj ReturnFalse1 (
 **
 *F  ReturnFalse2( <val1>, <val2> )  . . . . . . . . . . . . .  return 'False'
 */
-static Obj ReturnFalse2 (
-    Obj                 self,
-    Obj                 val1,
-    Obj                 val2 )
+static Obj ReturnFalse2(Obj self, Obj val1, Obj val2)
 {
     return False;
 }
@@ -243,11 +221,7 @@ static Obj ReturnFalse2 (
 **
 *F  ReturnFalse3( <val1>, <val2>, <val3> )  . . . . . . . . .  return 'False'
 */
-static Obj ReturnFalse3 (
-    Obj                 self,
-    Obj                 val1,
-    Obj                 val2,
-    Obj                 val3 )
+static Obj ReturnFalse3(Obj self, Obj val1, Obj val2, Obj val3)
 {
     return False;
 }
@@ -259,9 +233,7 @@ static Obj ReturnFalse3 (
 **
 **  'ReturnFail?' likewise return 'Fail'.
 */
-static Obj ReturnFail1 (
-    Obj                 self,
-    Obj                 val1 )
+static Obj ReturnFail1(Obj self, Obj val1)
 {
     return Fail;
 }
@@ -271,10 +243,7 @@ static Obj ReturnFail1 (
 **
 *F  ReturnFail2( <val1>, <val2> ) . . . . . . . . . . . . . .  return  'Fail'
 */
-static Obj ReturnFail2 (
-    Obj                 self,
-    Obj                 val1,
-    Obj                 val2 )
+static Obj ReturnFail2(Obj self, Obj val1, Obj val2)
 {
     return Fail;
 }
@@ -284,11 +253,7 @@ static Obj ReturnFail2 (
 **
 *F  ReturnFail3( <val1>, <val2>, <val3> ) . . . . . . . . . .  return  'Fail'
 */
-static Obj ReturnFail3 (
-    Obj                 self,
-    Obj                 val1,
-    Obj                 val2,
-    Obj                 val3 )
+static Obj ReturnFail3(Obj self, Obj val1, Obj val2, Obj val3)
 {
     return Fail;
 }
@@ -301,7 +266,7 @@ static Obj ReturnFail3 (
 **  Actually, there is nothing to do
 */
 
-static void SaveBool( Obj obj )
+static void SaveBool(Obj obj)
 {
 }
 
@@ -312,7 +277,7 @@ static void SaveBool( Obj obj )
 **  Actually, there is nothing to do
 */
 
-static void LoadBool( Obj obj )
+static void LoadBool(Obj obj)
 {
 }
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -142,7 +142,7 @@ static inline void SET_STOR_WOUT_PROF(Obj prof, UInt8 n)
 **  'DoWrapXargs' handler,  since in  this  case the function  call mechanism
 **  already requires that the passed arguments are collected in a list.
 */
-Obj DoWrap0args (
+static Obj DoWrap0args (
     Obj                 self )
 {
     Obj                 result;         /* value of function call, result  */
@@ -161,7 +161,7 @@ Obj DoWrap0args (
 **
 *F  DoWrap1args( <self>, <arg1> ) . . . . . . . wrap up 1 arguments in a list
 */
-Obj DoWrap1args (
+static Obj DoWrap1args (
     Obj                 self,
     Obj                 arg1 )
 {
@@ -183,7 +183,7 @@ Obj DoWrap1args (
 **
 *F  DoWrap2args( <self>, <arg1>, ... )  . . . . wrap up 2 arguments in a list
 */
-Obj DoWrap2args (
+static Obj DoWrap2args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2 )
@@ -207,7 +207,7 @@ Obj DoWrap2args (
 **
 *F  DoWrap3args( <self>, <arg1>, ... )  . . . . wrap up 3 arguments in a list
 */
-Obj DoWrap3args (
+static Obj DoWrap3args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -233,7 +233,7 @@ Obj DoWrap3args (
 **
 *F  DoWrap4args( <self>, <arg1>, ... )  . . . . wrap up 4 arguments in a list
 */
-Obj DoWrap4args (
+static Obj DoWrap4args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -261,7 +261,7 @@ Obj DoWrap4args (
 **
 *F  DoWrap5args( <self>, <arg1>, ... )  . . . . wrap up 5 arguments in a list
 */
-Obj DoWrap5args (
+static Obj DoWrap5args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -291,7 +291,7 @@ Obj DoWrap5args (
 **
 *F  DoWrap6args( <self>, <arg1>, ... )  . . . . wrap up 6 arguments in a list
 */
-Obj DoWrap6args (
+static Obj DoWrap6args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -350,7 +350,7 @@ Obj NargError(Obj func, Int actual)
   }
 }
 
-Obj DoFail0args (
+static Obj DoFail0args (
     Obj                 self )
 {
     Obj                 argx;           /* arguments list (to continue)    */
@@ -363,7 +363,7 @@ Obj DoFail0args (
 **
 *F  DoFail1args( <self>,<arg1> ) . . .  fail a function call with 1 arguments
 */
-Obj DoFail1args (
+static Obj DoFail1args (
     Obj                 self,
     Obj                 arg1 )
 {
@@ -377,7 +377,7 @@ Obj DoFail1args (
 **
 *F  DoFail2args( <self>, <arg1>, ... )  fail a function call with 2 arguments
 */
-Obj DoFail2args (
+static Obj DoFail2args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2 )
@@ -392,7 +392,7 @@ Obj DoFail2args (
 **
 *F  DoFail3args( <self>, <arg1>, ... )  fail a function call with 3 arguments
 */
-Obj DoFail3args (
+static Obj DoFail3args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -408,7 +408,7 @@ Obj DoFail3args (
 **
 *F  DoFail4args( <self>, <arg1>, ... )  fail a function call with 4 arguments
 */
-Obj DoFail4args (
+static Obj DoFail4args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -425,7 +425,7 @@ Obj DoFail4args (
 **
 *F  DoFail5args( <self>, <arg1>, ... )  fail a function call with 5 arguments
 */
-Obj DoFail5args (
+static Obj DoFail5args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -443,7 +443,7 @@ Obj DoFail5args (
 **
 *F  DoFail6args( <self>, <arg1>, ... )  fail a function call with 6 arguments
 */
-Obj DoFail6args (
+static Obj DoFail6args (
     Obj                 self,
     Obj                 arg1,
     Obj                 arg2,
@@ -462,7 +462,7 @@ Obj DoFail6args (
 **
 *F  DoFailXargs( <self>, <args> )  . .  fail a function call with X arguments
 */
-Obj DoFailXargs (
+static Obj DoFailXargs (
     Obj                 self,
     Obj                 args )
 {
@@ -1038,7 +1038,7 @@ Obj ArgStringToList(const Char *nams_c) {
 static Obj TYPE_FUNCTION;
 static Obj TYPE_OPERATION;
 
-Obj TypeFunction (
+static Obj TypeFunction (
     Obj                 func )
 {
     return ( IS_OPERATION(func) ? TYPE_OPERATION : TYPE_FUNCTION );
@@ -1184,7 +1184,7 @@ void PrintKernelFunction(Obj func)
 */
 static Obj IsFunctionFilt;
 
-Obj FuncIS_FUNCTION (
+static Obj FuncIS_FUNCTION (
     Obj                 self,
     Obj                 obj )
 {
@@ -1269,7 +1269,7 @@ Obj CallFuncList ( Obj func, Obj list )
 
 }
 
-Obj FuncCALL_FUNC_LIST (
+static Obj FuncCALL_FUNC_LIST (
     Obj                 self,
     Obj                 func,
     Obj                 list )
@@ -1279,7 +1279,7 @@ Obj FuncCALL_FUNC_LIST (
     return CallFuncList(func, list);
 }
 
-Obj FuncCALL_FUNC_LIST_WRAP (
+static Obj FuncCALL_FUNC_LIST_WRAP (
     Obj                 self,
     Obj                 func,
     Obj                 list )
@@ -1315,7 +1315,7 @@ Obj FuncCALL_FUNC_LIST_WRAP (
 static Obj NAME_FUNC_Oper;
 static Obj SET_NAME_FUNC_Oper;
 
-Obj FuncNAME_FUNC (
+static Obj FuncNAME_FUNC (
     Obj                 self,
     Obj                 func )
 {
@@ -1335,7 +1335,7 @@ Obj FuncNAME_FUNC (
     }
 }
 
-Obj FuncSET_NAME_FUNC(
+static Obj FuncSET_NAME_FUNC(
                       Obj self,
                       Obj func,
                       Obj name )
@@ -1357,7 +1357,7 @@ Obj FuncSET_NAME_FUNC(
 */
 static Obj NARG_FUNC_Oper;
 
-Obj FuncNARG_FUNC (
+static Obj FuncNARG_FUNC (
     Obj                 self,
     Obj                 func )
 {
@@ -1376,7 +1376,7 @@ Obj FuncNARG_FUNC (
 */
 static Obj NAMS_FUNC_Oper;
 
-Obj FuncNAMS_FUNC (
+static Obj FuncNAMS_FUNC (
     Obj                 self,
     Obj                 func )
 {
@@ -1397,7 +1397,7 @@ Obj FuncNAMS_FUNC (
 */
 static Obj LOCKS_FUNC_Oper;
 
-Obj FuncLOCKS_FUNC(Obj self, Obj func)
+static Obj FuncLOCKS_FUNC(Obj self, Obj func)
 {
 #ifdef HPCGAP
     Obj locks;
@@ -1423,7 +1423,7 @@ Obj FuncLOCKS_FUNC(Obj self, Obj func)
 */
 static Obj PROF_FUNC_Oper;
 
-Obj FuncPROF_FUNC (
+static Obj FuncPROF_FUNC (
     Obj                 self,
     Obj                 func )
 {
@@ -1447,7 +1447,7 @@ Obj FuncPROF_FUNC (
 **
 *F  FuncCLEAR_PROFILE_FUNC( <self>, <func> )  . . . . . . . . . clear profile
 */
-Obj FuncCLEAR_PROFILE_FUNC(
+static Obj FuncCLEAR_PROFILE_FUNC(
     Obj                 self,
     Obj                 func )
 {
@@ -1482,7 +1482,7 @@ Obj FuncCLEAR_PROFILE_FUNC(
 **
 *F  FuncPROFILE_FUNC( <self>, <func> )  . . . . . . . . . . . . start profile
 */
-Obj FuncPROFILE_FUNC(
+static Obj FuncPROFILE_FUNC(
     Obj                 self,
     Obj                 func )
 {
@@ -1533,7 +1533,7 @@ Obj FuncPROFILE_FUNC(
 **
 *F  FuncIS_PROFILED_FUNC( <self>, <func> )  . . check if function is profiled
 */
-Obj FuncIS_PROFILED_FUNC(
+static Obj FuncIS_PROFILED_FUNC(
     Obj                 self,
     Obj                 func )
 {
@@ -1541,7 +1541,7 @@ Obj FuncIS_PROFILED_FUNC(
     return ( TNUM_OBJ(PROF_FUNC(func)) != T_FUNCTION ) ? False : True;
 }
 
-Obj FuncFILENAME_FUNC(Obj self, Obj func)
+static Obj FuncFILENAME_FUNC(Obj self, Obj func)
 {
     RequireFunction("FILENAME_FUNC", func);
 
@@ -1553,7 +1553,7 @@ Obj FuncFILENAME_FUNC(Obj self, Obj func)
     return Fail;
 }
 
-Obj FuncSTARTLINE_FUNC(Obj self, Obj func)
+static Obj FuncSTARTLINE_FUNC(Obj self, Obj func)
 {
     RequireFunction("STARTLINE_FUNC", func);
 
@@ -1565,7 +1565,7 @@ Obj FuncSTARTLINE_FUNC(Obj self, Obj func)
     return Fail;
 }
 
-Obj FuncENDLINE_FUNC(Obj self, Obj func)
+static Obj FuncENDLINE_FUNC(Obj self, Obj func)
 {
     RequireFunction("ENDLINE_FUNC", func);
 
@@ -1577,7 +1577,7 @@ Obj FuncENDLINE_FUNC(Obj self, Obj func)
     return Fail;
 }
 
-Obj FuncLOCATION_FUNC(Obj self, Obj func)
+static Obj FuncLOCATION_FUNC(Obj self, Obj func)
 {
     RequireFunction("LOCATION_FUNC", func);
 
@@ -1593,7 +1593,7 @@ Obj FuncLOCATION_FUNC(Obj self, Obj func)
 **
 *F  FuncUNPROFILE_FUNC( <self>, <func> )  . . . . . . . . . . .  stop profile
 */
-Obj FuncUNPROFILE_FUNC(
+static Obj FuncUNPROFILE_FUNC(
     Obj                 self,
     Obj                 func )
 {
@@ -1624,7 +1624,7 @@ Obj FuncUNPROFILE_FUNC(
 **  'FuncIsKernelFunction' returns Fail if <func> is not a function, True if
 **  <func> is a kernel function, and False otherwise.
 */
-Obj FuncIsKernelFunction(Obj self, Obj func)
+static Obj FuncIsKernelFunction(Obj self, Obj func)
 {
     if (!IS_FUNC(func))
         return Fail;
@@ -1672,7 +1672,7 @@ static ObjFunc LoadHandler( void )
 *F  SaveFunction( <func> )  . . . . . . . . . . . . . . . . . save a function
 **
 */
-void SaveFunction ( Obj func )
+static void SaveFunction ( Obj func )
 {
   const FuncBag * header = CONST_FUNC(func);
   for (UInt i = 0; i <= 7; i++)
@@ -1694,7 +1694,7 @@ void SaveFunction ( Obj func )
 *F  LoadFunction( <func> )  . . . . . . . . . . . . . . . . . load a function
 **
 */
-void LoadFunction ( Obj func )
+static void LoadFunction ( Obj func )
 {
   FuncBag * header = FUNC(func);
   for (UInt i = 0; i <= 7; i++)
@@ -1719,7 +1719,7 @@ void LoadFunction ( Obj func )
 **
 **  'MarkFunctionSubBags' is the marking function for bags of type 'T_FUNCTION'.
 */
-void MarkFunctionSubBags(Obj func)
+static void MarkFunctionSubBags(Obj func)
 {
     // the first eight slots are pointers to C functions, so we need
     // to skip those for marking

--- a/src/calls.c
+++ b/src/calls.c
@@ -142,8 +142,7 @@ static inline void SET_STOR_WOUT_PROF(Obj prof, UInt8 n)
 **  'DoWrapXargs' handler,  since in  this  case the function  call mechanism
 **  already requires that the passed arguments are collected in a list.
 */
-static Obj DoWrap0args (
-    Obj                 self )
+static Obj DoWrap0args(Obj self)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -161,9 +160,7 @@ static Obj DoWrap0args (
 **
 *F  DoWrap1args( <self>, <arg1> ) . . . . . . . wrap up 1 arguments in a list
 */
-static Obj DoWrap1args (
-    Obj                 self,
-    Obj                 arg1 )
+static Obj DoWrap1args(Obj self, Obj arg1)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -183,10 +180,7 @@ static Obj DoWrap1args (
 **
 *F  DoWrap2args( <self>, <arg1>, ... )  . . . . wrap up 2 arguments in a list
 */
-static Obj DoWrap2args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2 )
+static Obj DoWrap2args(Obj self, Obj arg1, Obj arg2)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -207,11 +201,7 @@ static Obj DoWrap2args (
 **
 *F  DoWrap3args( <self>, <arg1>, ... )  . . . . wrap up 3 arguments in a list
 */
-static Obj DoWrap3args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3 )
+static Obj DoWrap3args(Obj self, Obj arg1, Obj arg2, Obj arg3)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -233,12 +223,7 @@ static Obj DoWrap3args (
 **
 *F  DoWrap4args( <self>, <arg1>, ... )  . . . . wrap up 4 arguments in a list
 */
-static Obj DoWrap4args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3,
-    Obj                 arg4 )
+static Obj DoWrap4args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -261,13 +246,8 @@ static Obj DoWrap4args (
 **
 *F  DoWrap5args( <self>, <arg1>, ... )  . . . . wrap up 5 arguments in a list
 */
-static Obj DoWrap5args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3,
-    Obj                 arg4,
-    Obj                 arg5 )
+static Obj
+DoWrap5args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -291,14 +271,8 @@ static Obj DoWrap5args (
 **
 *F  DoWrap6args( <self>, <arg1>, ... )  . . . . wrap up 6 arguments in a list
 */
-static Obj DoWrap6args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3,
-    Obj                 arg4,
-    Obj                 arg5,
-    Obj                 arg6 )
+static Obj DoWrap6args(
+    Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
     Obj                 result;         /* value of function call, result  */
     Obj                 args;           /* arguments list                  */
@@ -350,8 +324,7 @@ Obj NargError(Obj func, Int actual)
   }
 }
 
-static Obj DoFail0args (
-    Obj                 self )
+static Obj DoFail0args(Obj self)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 0);
@@ -363,9 +336,7 @@ static Obj DoFail0args (
 **
 *F  DoFail1args( <self>,<arg1> ) . . .  fail a function call with 1 arguments
 */
-static Obj DoFail1args (
-    Obj                 self,
-    Obj                 arg1 )
+static Obj DoFail1args(Obj self, Obj arg1)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 1);
@@ -377,10 +348,7 @@ static Obj DoFail1args (
 **
 *F  DoFail2args( <self>, <arg1>, ... )  fail a function call with 2 arguments
 */
-static Obj DoFail2args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2 )
+static Obj DoFail2args(Obj self, Obj arg1, Obj arg2)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 2);
@@ -392,11 +360,7 @@ static Obj DoFail2args (
 **
 *F  DoFail3args( <self>, <arg1>, ... )  fail a function call with 3 arguments
 */
-static Obj DoFail3args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3 )
+static Obj DoFail3args(Obj self, Obj arg1, Obj arg2, Obj arg3)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 3);
@@ -408,12 +372,7 @@ static Obj DoFail3args (
 **
 *F  DoFail4args( <self>, <arg1>, ... )  fail a function call with 4 arguments
 */
-static Obj DoFail4args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3,
-    Obj                 arg4 )
+static Obj DoFail4args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 4);
@@ -425,13 +384,8 @@ static Obj DoFail4args (
 **
 *F  DoFail5args( <self>, <arg1>, ... )  fail a function call with 5 arguments
 */
-static Obj DoFail5args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3,
-    Obj                 arg4,
-    Obj                 arg5 )
+static Obj
+DoFail5args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 5);
@@ -443,14 +397,8 @@ static Obj DoFail5args (
 **
 *F  DoFail6args( <self>, <arg1>, ... )  fail a function call with 6 arguments
 */
-static Obj DoFail6args (
-    Obj                 self,
-    Obj                 arg1,
-    Obj                 arg2,
-    Obj                 arg3,
-    Obj                 arg4,
-    Obj                 arg5,
-    Obj                 arg6 )
+static Obj DoFail6args(
+    Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, 6);
@@ -462,9 +410,7 @@ static Obj DoFail6args (
 **
 *F  DoFailXargs( <self>, <args> )  . .  fail a function call with X arguments
 */
-static Obj DoFailXargs (
-    Obj                 self,
-    Obj                 args )
+static Obj DoFailXargs(Obj self, Obj args)
 {
     Obj                 argx;           /* arguments list (to continue)    */
     argx =NargError(self, LEN_LIST(args));
@@ -1038,8 +984,7 @@ Obj ArgStringToList(const Char *nams_c) {
 static Obj TYPE_FUNCTION;
 static Obj TYPE_OPERATION;
 
-static Obj TypeFunction (
-    Obj                 func )
+static Obj TypeFunction(Obj func)
 {
     return ( IS_OPERATION(func) ? TYPE_OPERATION : TYPE_FUNCTION );
 }
@@ -1184,9 +1129,7 @@ void PrintKernelFunction(Obj func)
 */
 static Obj IsFunctionFilt;
 
-static Obj FuncIS_FUNCTION (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_FUNCTION(Obj self, Obj obj)
 {
     if      ( TNUM_OBJ(obj) == T_FUNCTION ) {
         return True;
@@ -1269,20 +1212,14 @@ Obj CallFuncList ( Obj func, Obj list )
 
 }
 
-static Obj FuncCALL_FUNC_LIST (
-    Obj                 self,
-    Obj                 func,
-    Obj                 list )
+static Obj FuncCALL_FUNC_LIST(Obj self, Obj func, Obj list)
 {
     /* check that the second argument is a list                            */
     RequireSmallList("CallFuncList", list);
     return CallFuncList(func, list);
 }
 
-static Obj FuncCALL_FUNC_LIST_WRAP (
-    Obj                 self,
-    Obj                 func,
-    Obj                 list )
+static Obj FuncCALL_FUNC_LIST_WRAP(Obj self, Obj func, Obj list)
 {
     Obj retval, retlist;
     /* check that the second argument is a list                            */
@@ -1315,9 +1252,7 @@ static Obj FuncCALL_FUNC_LIST_WRAP (
 static Obj NAME_FUNC_Oper;
 static Obj SET_NAME_FUNC_Oper;
 
-static Obj FuncNAME_FUNC (
-    Obj                 self,
-    Obj                 func )
+static Obj FuncNAME_FUNC(Obj self, Obj func)
 {
     Obj                 name;
 
@@ -1335,10 +1270,7 @@ static Obj FuncNAME_FUNC (
     }
 }
 
-static Obj FuncSET_NAME_FUNC(
-                      Obj self,
-                      Obj func,
-                      Obj name )
+static Obj FuncSET_NAME_FUNC(Obj self, Obj func, Obj name)
 {
     RequireStringRep("SET_NAME_FUNC", name);
 
@@ -1357,9 +1289,7 @@ static Obj FuncSET_NAME_FUNC(
 */
 static Obj NARG_FUNC_Oper;
 
-static Obj FuncNARG_FUNC (
-    Obj                 self,
-    Obj                 func )
+static Obj FuncNARG_FUNC(Obj self, Obj func)
 {
     if ( TNUM_OBJ(func) == T_FUNCTION ) {
         return INTOBJ_INT( NARG_FUNC(func) );
@@ -1376,9 +1306,7 @@ static Obj FuncNARG_FUNC (
 */
 static Obj NAMS_FUNC_Oper;
 
-static Obj FuncNAMS_FUNC (
-    Obj                 self,
-    Obj                 func )
+static Obj FuncNAMS_FUNC(Obj self, Obj func)
 {
   Obj nams;
     if ( TNUM_OBJ(func) == T_FUNCTION ) {
@@ -1423,9 +1351,7 @@ static Obj FuncLOCKS_FUNC(Obj self, Obj func)
 */
 static Obj PROF_FUNC_Oper;
 
-static Obj FuncPROF_FUNC (
-    Obj                 self,
-    Obj                 func )
+static Obj FuncPROF_FUNC(Obj self, Obj func)
 {
     Obj                 prof;
 
@@ -1447,9 +1373,7 @@ static Obj FuncPROF_FUNC (
 **
 *F  FuncCLEAR_PROFILE_FUNC( <self>, <func> )  . . . . . . . . . clear profile
 */
-static Obj FuncCLEAR_PROFILE_FUNC(
-    Obj                 self,
-    Obj                 func )
+static Obj FuncCLEAR_PROFILE_FUNC(Obj self, Obj func)
 {
     Obj                 prof;
 
@@ -1482,9 +1406,7 @@ static Obj FuncCLEAR_PROFILE_FUNC(
 **
 *F  FuncPROFILE_FUNC( <self>, <func> )  . . . . . . . . . . . . start profile
 */
-static Obj FuncPROFILE_FUNC(
-    Obj                 self,
-    Obj                 func )
+static Obj FuncPROFILE_FUNC(Obj self, Obj func)
 {
     Obj                 prof;
     Obj                 copy;
@@ -1533,9 +1455,7 @@ static Obj FuncPROFILE_FUNC(
 **
 *F  FuncIS_PROFILED_FUNC( <self>, <func> )  . . check if function is profiled
 */
-static Obj FuncIS_PROFILED_FUNC(
-    Obj                 self,
-    Obj                 func )
+static Obj FuncIS_PROFILED_FUNC(Obj self, Obj func)
 {
     RequireFunction("IS_PROFILED_FUNC", func);
     return ( TNUM_OBJ(PROF_FUNC(func)) != T_FUNCTION ) ? False : True;
@@ -1593,9 +1513,7 @@ static Obj FuncLOCATION_FUNC(Obj self, Obj func)
 **
 *F  FuncUNPROFILE_FUNC( <self>, <func> )  . . . . . . . . . . .  stop profile
 */
-static Obj FuncUNPROFILE_FUNC(
-    Obj                 self,
-    Obj                 func )
+static Obj FuncUNPROFILE_FUNC(Obj self, Obj func)
 {
     Obj                 prof;
 
@@ -1672,7 +1590,7 @@ static ObjFunc LoadHandler( void )
 *F  SaveFunction( <func> )  . . . . . . . . . . . . . . . . . save a function
 **
 */
-static void SaveFunction ( Obj func )
+static void SaveFunction(Obj func)
 {
   const FuncBag * header = CONST_FUNC(func);
   for (UInt i = 0; i <= 7; i++)
@@ -1694,7 +1612,7 @@ static void SaveFunction ( Obj func )
 *F  LoadFunction( <func> )  . . . . . . . . . . . . . . . . . load a function
 **
 */
-static void LoadFunction ( Obj func )
+static void LoadFunction(Obj func)
 {
   FuncBag * header = FUNC(func);
   for (UInt i = 0; i <= 7; i++)

--- a/src/code.c
+++ b/src/code.c
@@ -243,9 +243,7 @@ static Stat NewStatWithProf (
     return stat;
 }
 
-static Stat NewStat (
-    UInt                type,
-    UInt                size)
+static Stat NewStat(UInt type, UInt size)
 {
     return NewStatWithProf(type, size, GetInputLineNumber());
 }
@@ -258,9 +256,7 @@ static Stat NewStat (
 **  'NewExpr' allocates a new expression memory block of  the type <type> and
 **  <size> bytes.  'NewExpr' returns the identifier of the new expression.
 */
-static Expr            NewExpr (
-    UInt                type,
-    UInt                size )
+static Expr NewExpr(UInt type, UInt size)
 {
     return NewStat(type, size);
 }
@@ -459,8 +455,7 @@ static Expr PopExpr(void)
 **  'PushUnaryOp' pushes a   unary  operator expression onto the   expression
 **  stack.  <type> is the type of the operator (currently only 'T_NOT').
 */
-static void PushUnaryOp (
-    UInt                type )
+static void PushUnaryOp(UInt type)
 {
     Expr                unop;           /* unary operator, result          */
     Expr                op;             /* operand                         */
@@ -484,8 +479,7 @@ static void PushUnaryOp (
 **  'PushBinaryOp' pushes a binary   operator expression onto  the expression
 **  stack.  <type> is the type of the operator.
 */
-static void PushBinaryOp (
-    UInt                type )
+static void PushBinaryOp(UInt type)
 {
     Expr                binop;          /* binary operator, result         */
     Expr                opL;            /* left operand                    */
@@ -3150,7 +3144,7 @@ void CodeAssertEnd3Args ( void )
 **  machines of different endianness, but this would mean parsing the bag as
 **  we save it which it would be nice to avoid just now.
 */
-static void SaveBody ( Obj body )
+static void SaveBody(Obj body)
 {
   UInt i;
   const UInt *ptr = (const UInt *) CONST_ADDR_OBJ(body);
@@ -3171,7 +3165,7 @@ static void SaveBody ( Obj body )
 **  are currently both UInt
 **
 */
-static void LoadBody ( Obj body )
+static void LoadBody(Obj body)
 {
   UInt i;
   UInt *ptr;

--- a/src/code.c
+++ b/src/code.c
@@ -243,7 +243,7 @@ static Stat NewStatWithProf (
     return stat;
 }
 
-Stat NewStat (
+static Stat NewStat (
     UInt                type,
     UInt                size)
 {
@@ -258,7 +258,7 @@ Stat NewStat (
 **  'NewExpr' allocates a new expression memory block of  the type <type> and
 **  <size> bytes.  'NewExpr' returns the identifier of the new expression.
 */
-Expr            NewExpr (
+static Expr            NewExpr (
     UInt                type,
     UInt                size )
 {
@@ -459,7 +459,7 @@ static Expr PopExpr(void)
 **  'PushUnaryOp' pushes a   unary  operator expression onto the   expression
 **  stack.  <type> is the type of the operator (currently only 'T_NOT').
 */
-void PushUnaryOp (
+static void PushUnaryOp (
     UInt                type )
 {
     Expr                unop;           /* unary operator, result          */
@@ -484,7 +484,7 @@ void PushUnaryOp (
 **  'PushBinaryOp' pushes a binary   operator expression onto  the expression
 **  stack.  <type> is the type of the operator.
 */
-void PushBinaryOp (
+static void PushBinaryOp (
     UInt                type )
 {
     Expr                binop;          /* binary operator, result         */
@@ -3150,7 +3150,7 @@ void CodeAssertEnd3Args ( void )
 **  machines of different endianness, but this would mean parsing the bag as
 **  we save it which it would be nice to avoid just now.
 */
-void SaveBody ( Obj body )
+static void SaveBody ( Obj body )
 {
   UInt i;
   const UInt *ptr = (const UInt *) CONST_ADDR_OBJ(body);
@@ -3171,7 +3171,7 @@ void SaveBody ( Obj body )
 **  are currently both UInt
 **
 */
-void LoadBody ( Obj body )
+static void LoadBody ( Obj body )
 {
   UInt i;
   UInt *ptr;

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -144,7 +144,7 @@ typedef struct {
 *F  WordVectorAndClear( <type>, <vv>, <num> )
 */
 template <typename UIntN>
-Obj WordVectorAndClear(Obj type, Obj vv, Int num)
+static Obj WordVectorAndClear(Obj type, Obj vv, Int num)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -189,7 +189,7 @@ Obj WordVectorAndClear(Obj type, Obj vv, Int num)
 **  WARNING: This function assumes that <vv> is cleared!
 */
 template <typename UIntN>
-Int VectorWord(Obj vv, Obj v, Int num)
+static Int VectorWord(Obj vv, Obj v, Int num)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -330,7 +330,7 @@ static Int SAddPartIntoExpVec(Int *         v,
 **  If a stack overflow occurs, we simply stop and return false.
 */
 template <typename UIntN>
-Int SingleCollectWord(Obj sc, Obj vv, Obj w)
+static Int SingleCollectWord(Obj sc, Obj vv, Obj w)
 {
     Int         ebits;      /* number of bits in the exponent              */
     UInt        expm;       /* unsigned exponent mask                      */
@@ -608,7 +608,7 @@ Int SingleCollectWord(Obj sc, Obj vv, Obj w)
 *F  Solution( <sc>, <ww>, <uu>, <func> )
 */
 template <typename UIntN>
-Int Solution(Obj sc, Obj ww, Obj uu, FuncIOOO func)
+static Int Solution(Obj sc, Obj ww, Obj uu, FuncIOOO func)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -844,7 +844,7 @@ static void AddPartIntoExpVec(Int *         v,
 **  If a stack overflow occurs, we simply stop and return false.
 */
 template <typename UIntN>
-Int CombiCollectWord(Obj sc, Obj vv, Obj w)
+static Int CombiCollectWord(Obj sc, Obj vv, Obj w)
 {
     Int         ebits;      /* number of bits in the exponent              */
     UInt        expm;       /* unsigned exponent mask                      */
@@ -1238,7 +1238,7 @@ FinPowConjCol * FinPowConjCollectors [6] =
 **
 *F  CollectWordOrFail( <fc>, <sc>, <vv>, <w> )
 */
-Obj CollectWordOrFail ( 
+static Obj CollectWordOrFail ( 
     FinPowConjCol *     fc, 
     Obj                 sc,
     Obj                 vv,
@@ -1275,7 +1275,7 @@ Obj CollectWordOrFail (
 **
 *F  ReducedComm( <fc>, <sc>, <w>, <u> )
 */
-Obj ReducedComm (
+static Obj ReducedComm (
     FinPowConjCol *     fc,
     Obj                 sc,
     Obj                 w,
@@ -1347,7 +1347,7 @@ Obj ReducedComm (
 **
 *F  ReducedForm( <fc>, <sc>, <w> )
 */
-Obj ReducedForm (
+static Obj ReducedForm (
     FinPowConjCol *     fc,
     Obj                 sc,
     Obj                 w )
@@ -1385,7 +1385,7 @@ Obj ReducedForm (
 **
 *F  ReducedLeftQuotient( <fc>, <sc>, <w>, <u> )
 */
-Obj ReducedLeftQuotient ( 
+static Obj ReducedLeftQuotient ( 
     FinPowConjCol *     fc,
     Obj                 sc,
     Obj                 w,
@@ -1441,7 +1441,7 @@ Obj ReducedLeftQuotient (
 **
 *F  ReducedProduct( <fc>, <sc>, <w>, <u> )
 */
-Obj ReducedProduct ( 
+static Obj ReducedProduct ( 
     FinPowConjCol *     fc,
     Obj                 sc,
     Obj                 w,
@@ -1481,7 +1481,7 @@ Obj ReducedProduct (
 **
 *F  ReducedPowerSmallInt( <fc>, <sc>, <w>, <pow> )
 */
-Obj ReducedPowerSmallInt ( 
+static Obj ReducedPowerSmallInt ( 
     FinPowConjCol *     fc,
     Obj                 sc,
     Obj                 w,
@@ -1584,7 +1584,7 @@ Obj ReducedPowerSmallInt (
 **
 *F  ReducedQuotient( <fc>, <sc>, <w>, <u> )
 */
-Obj ReducedQuotient ( 
+static Obj ReducedQuotient ( 
     FinPowConjCol *     fc,
     Obj                 sc,
     Obj                 w,
@@ -1720,7 +1720,7 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 **
 *F  SET_SCOBJ_MAX_STACK_SIZE( <self>, <size> )
 */
-Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
+static Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
 {
     CollectorsState()->SC_MAX_STACK_SIZE =
         GetPositiveSmallInt("SET_SCOBJ_MAX_STACK_SIZE", size);

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -1238,11 +1238,7 @@ FinPowConjCol * FinPowConjCollectors [6] =
 **
 *F  CollectWordOrFail( <fc>, <sc>, <vv>, <w> )
 */
-static Obj CollectWordOrFail ( 
-    FinPowConjCol *     fc, 
-    Obj                 sc,
-    Obj                 vv,
-    Obj                 w )
+static Obj CollectWordOrFail(FinPowConjCol * fc, Obj sc, Obj vv, Obj w)
 {
     Int                 i;              /* loop variable                   */
     Obj *               ptr;            /* pointer into the array <vv>     */
@@ -1275,11 +1271,7 @@ static Obj CollectWordOrFail (
 **
 *F  ReducedComm( <fc>, <sc>, <w>, <u> )
 */
-static Obj ReducedComm (
-    FinPowConjCol *     fc,
-    Obj                 sc,
-    Obj                 w,
-    Obj                 u )
+static Obj ReducedComm(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
 {
     Obj                 type;       /* type of the returned object         */
     Int                 num;        /* number of gen/exp pairs in <data>   */
@@ -1347,10 +1339,7 @@ static Obj ReducedComm (
 **
 *F  ReducedForm( <fc>, <sc>, <w> )
 */
-static Obj ReducedForm (
-    FinPowConjCol *     fc,
-    Obj                 sc,
-    Obj                 w )
+static Obj ReducedForm(FinPowConjCol * fc, Obj sc, Obj w)
 {
     Int                 num;    /* number of gen/exp pairs in <data>       */
     Int                 i;      /* loop variable for gen/exp pairs         */
@@ -1385,11 +1374,7 @@ static Obj ReducedForm (
 **
 *F  ReducedLeftQuotient( <fc>, <sc>, <w>, <u> )
 */
-static Obj ReducedLeftQuotient ( 
-    FinPowConjCol *     fc,
-    Obj                 sc,
-    Obj                 w,
-    Obj                 u )
+static Obj ReducedLeftQuotient(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
 {
     Obj                 type;       /* type of the return objue            */
     Int                 num;        /* number of gen/exp pairs in <data>   */
@@ -1441,11 +1426,7 @@ static Obj ReducedLeftQuotient (
 **
 *F  ReducedProduct( <fc>, <sc>, <w>, <u> )
 */
-static Obj ReducedProduct ( 
-    FinPowConjCol *     fc,
-    Obj                 sc,
-    Obj                 w,
-    Obj                 u )
+static Obj ReducedProduct(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
 {
     Obj                 type;       /* type of the return objue            */
     Int                 num;        /* number of gen/exp pairs in <data>   */
@@ -1481,11 +1462,7 @@ static Obj ReducedProduct (
 **
 *F  ReducedPowerSmallInt( <fc>, <sc>, <w>, <pow> )
 */
-static Obj ReducedPowerSmallInt ( 
-    FinPowConjCol *     fc,
-    Obj                 sc,
-    Obj                 w,
-    Obj                 vpow )
+static Obj ReducedPowerSmallInt(FinPowConjCol * fc, Obj sc, Obj w, Obj vpow)
 {
     Obj                 type;       /* type of the return objue            */
     Int                 num;        /* number of gen/exp pairs in <data>   */
@@ -1584,11 +1561,7 @@ static Obj ReducedPowerSmallInt (
 **
 *F  ReducedQuotient( <fc>, <sc>, <w>, <u> )
 */
-static Obj ReducedQuotient ( 
-    FinPowConjCol *     fc,
-    Obj                 sc,
-    Obj                 w,
-    Obj                 u )
+static Obj ReducedQuotient(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
 {
     Obj                 type;       /* type of the return objue            */
     Int                 num;        /* number of gen/exp pairs in <data>   */
@@ -1720,7 +1693,7 @@ Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 **
 *F  SET_SCOBJ_MAX_STACK_SIZE( <self>, <size> )
 */
-static Obj FuncSET_SCOBJ_MAX_STACK_SIZE ( Obj self, Obj size )
+static Obj FuncSET_SCOBJ_MAX_STACK_SIZE(Obj self, Obj size)
 {
     CollectorsState()->SC_MAX_STACK_SIZE =
         GetPositiveSmallInt("SET_SCOBJ_MAX_STACK_SIZE", size);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -50,7 +50,7 @@ static Int CompFastIntArith;
 **
 *V  CompFastPlainLists  . option to emit code that handles plain lists faster
 */
-static Int CompFastPlainLists ;
+static Int CompFastPlainLists;
 
 
 /****************************************************************************
@@ -64,7 +64,7 @@ static Int CompFastListFuncs;
 **
 *V  CompCheckTypes  . . . . option to emit code that assumes all types are ok.
 */
-static Int CompCheckTypes ;
+static Int CompCheckTypes;
 
 
 /****************************************************************************
@@ -227,9 +227,7 @@ typedef UInt4           LVar;
 
 #define W_INT_SMALL_POS         (W_INT_SMALL | W_INT_POS)
 
-static void            SetInfoCVar (
-    CVar                cvar,
-    UInt                type )
+static void SetInfoCVar(CVar cvar, UInt type)
 {
     Bag                 info;           /* its info bag                    */
 
@@ -248,8 +246,7 @@ static void            SetInfoCVar (
     }
 }
 
-static Int             GetInfoCVar (
-    CVar                cvar )
+static Int GetInfoCVar(CVar cvar)
 {
     Bag                 info;           /* its info bag                    */
 
@@ -277,15 +274,13 @@ static Int             GetInfoCVar (
     }
 }
 
-static Int             HasInfoCVar (
-    CVar                cvar,
-    Int                 type )
+static Int HasInfoCVar(CVar cvar, Int type)
 {
     return ((GetInfoCVar( cvar ) & type) == type);
 }
 
 
-static Bag             NewInfoCVars ( void )
+static Bag NewInfoCVars(void)
 {
     Bag                 old;
     Bag                 new;
@@ -294,9 +289,7 @@ static Bag             NewInfoCVars ( void )
     return new;
 }
 
-static void            CopyInfoCVars (
-    Bag                 dst,
-    Bag                 src )
+static void CopyInfoCVars(Bag dst, Bag src)
 {
     Int                 i;
     if ( SIZE_BAG(dst) < SIZE_BAG(src) )  ResizeBag( dst, SIZE_BAG(src) );
@@ -315,9 +308,7 @@ static void            CopyInfoCVars (
     }
 }
 
-static void            MergeInfoCVars (
-    Bag                 dst,
-    Bag                 src )
+static void MergeInfoCVars(Bag dst, Bag src)
 {
     Int                 i;
     if ( SIZE_BAG(dst) < SIZE_BAG(src) )  ResizeBag( dst, SIZE_BAG(src) );
@@ -331,9 +322,7 @@ static void            MergeInfoCVars (
     }
 }
 
-static Int             IsEqInfoCVars (
-    Bag                 dst,
-    Bag                 src )
+static Int IsEqInfoCVars(Bag dst, Bag src)
 {
     Int                 i;
     if ( SIZE_BAG(dst) < SIZE_BAG(src) )  ResizeBag( dst, SIZE_BAG(src) );
@@ -368,8 +357,7 @@ static Int             IsEqInfoCVars (
 */
 typedef UInt4           Temp;
 
-static Temp           NewTemp (
-    const Char *        name )
+static Temp NewTemp(const Char * name)
 {
     Temp                temp;           /* new temporary, result           */
     Bag                 info;           /* information bag                 */
@@ -394,8 +382,7 @@ static Temp           NewTemp (
     return temp;
 }
 
-static void            FreeTemp (
-    Temp                temp )
+static void FreeTemp(Temp temp)
 {
     Bag                 info;           /* information bag                 */
 
@@ -441,8 +428,7 @@ static void            FreeTemp (
 */
 typedef UInt4           HVar;
 
-static void            CompSetUseHVar (
-    HVar                hvar )
+static void CompSetUseHVar(HVar hvar)
 {
     Bag                 info;           /* its info bag                    */
     Int                 i;              /* loop variable                   */
@@ -464,8 +450,7 @@ static void            CompSetUseHVar (
 
 }
 
-static Int             CompGetUseHVar (
-    HVar                hvar )
+static Int CompGetUseHVar(HVar hvar)
 {
     Bag                 info;           /* its info bag                    */
     Int                 i;              /* loop variable                   */
@@ -480,8 +465,7 @@ static Int             CompGetUseHVar (
     return (TNUM_LVAR_INFO( info, (hvar & 0xFFFF) ) == W_HIGHER);
 }
 
-static UInt            GetLevlHVar (
-    HVar                hvar )
+static UInt GetLevlHVar(HVar hvar)
 {
     UInt                levl;           /* level of higher variable        */
     Bag                 info;           /* its info bag                    */
@@ -500,8 +484,7 @@ static UInt            GetLevlHVar (
     return levl - 1;
 }
 
-static UInt            GetIndxHVar (
-    HVar                hvar )
+static UInt GetIndxHVar(HVar hvar)
 {
     UInt                indx;           /* index of higher variable        */
     Bag                 info;           /* its info bag                    */
@@ -558,9 +541,7 @@ typedef UInt    GVar;
 
 Bag             CompInfoGVar;
 
-static void            CompSetUseGVar (
-    GVar                gvar,
-    UInt                mode )
+static void CompSetUseGVar(GVar gvar, UInt mode)
 {
     /* only mark in pass 1                                                 */
     if ( CompPass != 1 )  return;
@@ -574,8 +555,7 @@ static void            CompSetUseGVar (
     ((UInt*)PTR_BAG(CompInfoGVar))[gvar] |= mode;
 }
 
-static UInt            CompGetUseGVar (
-    GVar                gvar )
+static UInt CompGetUseGVar(GVar gvar)
 {
     return ((UInt*)PTR_BAG(CompInfoGVar))[gvar];
 }
@@ -603,9 +583,7 @@ typedef UInt    RNam;
 
 Bag             CompInfoRNam;
 
-static void            CompSetUseRNam (
-    RNam                rnam,
-    UInt                mode )
+static void CompSetUseRNam(RNam rnam, UInt mode)
 {
     /* only mark in pass 1                                                 */
     if ( CompPass != 1 )  return;
@@ -619,8 +597,7 @@ static void            CompSetUseRNam (
     ((UInt*)PTR_BAG(CompInfoRNam))[rnam] |= mode;
 }
 
-static UInt            CompGetUseRNam (
-    RNam                rnam )
+static UInt CompGetUseRNam(RNam rnam)
 {
     return ((UInt*)PTR_BAG(CompInfoRNam))[rnam];
 }
@@ -642,13 +619,11 @@ static UInt            CompGetUseRNam (
 **  ('INTOBJ_INT(<int>)'  for integers,  'a_<name>' for arguments, 'l_<name>'
 **  for locals, 't_<nr>' for temporaries), and '%%' outputs a single '%'.
 */
-static Int             EmitIndent;
+static Int EmitIndent;
 
-static Int             EmitIndent2;
+static Int EmitIndent2;
 
-static void            Emit (
-    const char *        fmt,
-    ... )
+static void Emit(const char * fmt, ...)
 {
     Int                 narg;           /* number of arguments             */
     va_list             ap;             /* argument list pointer           */
@@ -802,9 +777,7 @@ static void            Emit (
 **
 *F  CompCheckBound( <obj>, <name> ) emit code to check that <obj> has a value
 */
-static void CompCheckBound (
-    CVar                obj,
-    Obj                 name )
+static void CompCheckBound(CVar obj, Obj name)
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
@@ -819,8 +792,7 @@ static void CompCheckBound (
 **
 *F  CompCheckFuncResult( <obj> )  . emit code to check that <obj> has a value
 */
-static void CompCheckFuncResult (
-    CVar                obj )
+static void CompCheckFuncResult(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
@@ -835,8 +807,7 @@ static void CompCheckFuncResult (
 **
 *F  CompCheckIntSmall( <obj> )   emit code to check that <obj> is a small int
 */
-static void CompCheckIntSmall (
-    CVar                obj )
+static void CompCheckIntSmall(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL ) ) {
         if ( CompCheckTypes ) {
@@ -852,8 +823,7 @@ static void CompCheckIntSmall (
 **
 *F  CompCheckIntSmallPos( <obj> ) emit code to check that <obj> is a position
 */
-static void CompCheckIntSmallPos (
-    CVar                obj )
+static void CompCheckIntSmallPos(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL_POS ) ) {
         if ( CompCheckTypes ) {
@@ -867,8 +837,7 @@ static void CompCheckIntSmallPos (
 **
 *F  CompCheckIntPos( <obj> ) emit code to check that <obj> is a position
 */
-static void CompCheckIntPos (
-    CVar                obj )
+static void CompCheckIntPos(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_POS ) ) {
         if ( CompCheckTypes ) {
@@ -883,8 +852,7 @@ static void CompCheckIntPos (
 **
 *F  CompCheckBool( <obj> )  . . .  emit code to check that <obj> is a boolean
 */
-static void CompCheckBool (
-    CVar                obj )
+static void CompCheckBool(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_BOOL ) ) {
         if ( CompCheckTypes ) {
@@ -900,8 +868,7 @@ static void CompCheckBool (
 **
 *F  CompCheckFunc( <obj> )  . . . emit code to check that <obj> is a function
 */
-static void CompCheckFunc (
-    CVar                obj )
+static void CompCheckFunc(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_FUNC ) ) {
         if ( CompCheckTypes ) {
@@ -925,11 +892,10 @@ static void CompCheckFunc (
 **  'CompExpr' compiles the expression <expr> and returns the C variable that
 **  will contain the result.
 */
-static CVar (* CompExprFuncs[256]) ( Expr expr );
+static CVar (*CompExprFuncs[256])(Expr expr);
 
 
-static CVar CompExpr (
-    Expr                expr )
+static CVar CompExpr(Expr expr)
 {
     return (* CompExprFuncs[ TNUM_EXPR(expr) ])( expr );
 }
@@ -939,8 +905,7 @@ static CVar CompExpr (
 **
 *F  CompUnknownExpr( <expr> ) . . . . . . . . . . . .  log unknown expression
 */
-static CVar CompUnknownExpr (
-    Expr                expr )
+static CVar CompUnknownExpr(Expr expr)
 {
     Emit( "CANNOT COMPILE EXPRESSION OF TNUM %d;\n", TNUM_EXPR(expr) );
     return 0;
@@ -952,10 +917,9 @@ static CVar CompUnknownExpr (
 **
 *F  CompBoolExpr( <expr> )  . . . . . . . compile bool expr and return C bool
 */
-static CVar (* CompBoolExprFuncs[256]) ( Expr expr );
+static CVar (*CompBoolExprFuncs[256])(Expr expr);
 
-static CVar CompBoolExpr (
-    Expr                expr )
+static CVar CompBoolExpr(Expr expr)
 {
     return (* CompBoolExprFuncs[ TNUM_EXPR(expr) ])( expr );
 }
@@ -965,8 +929,7 @@ static CVar CompBoolExpr (
 **
 *F  CompUnknownBool( <expr> ) . . . . . . . . . .  use 'CompExpr' and convert
 */
-static CVar CompUnknownBool (
-    Expr                expr )
+static CVar CompUnknownBool(Expr expr)
 {
     CVar                res;            /* result                          */
     CVar                val;            /* value of expression             */
@@ -998,17 +961,14 @@ static CVar CompUnknownBool (
 static GVar G_Length;
 
 
-
 /****************************************************************************
 **
 *F  CompFunccall0to6Args( <expr> )  . . . T_FUNCCALL_0ARGS...T_FUNCCALL_6ARGS
 */
-static CVar CompRefGVarFopy (
-            Expr                expr );
+static CVar CompRefGVarFopy(Expr expr);
 
 
-static CVar CompFunccall0to6Args (
-    Expr                expr )
+static CVar CompFunccall0to6Args(Expr expr)
 {
     CVar                result;         /* result, result                  */
     CVar                func;           /* function                        */
@@ -1077,8 +1037,7 @@ static CVar CompFunccall0to6Args (
 **
 *F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_FUNCCALL_XARGS
 */
-static CVar CompFunccallXArgs (
-    Expr                expr )
+static CVar CompFunccallXArgs(Expr expr)
 {
     CVar                result;         /* result, result                  */
     CVar                func;           /* function                        */
@@ -1131,8 +1090,7 @@ static CVar CompFunccallXArgs (
 **
 *F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_FUNCCALL_OPTS
 */
-static CVar CompFunccallOpts(
-                      Expr expr)
+static CVar CompFunccallOpts(Expr expr)
 {
   CVar opts = CompExpr(READ_STAT(expr, 0));
   GVar pushOptions;
@@ -1154,8 +1112,7 @@ static CVar CompFunccallOpts(
 **
 *F  CompFuncExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_FUNC_EXPR
 */
-static CVar CompFuncExpr (
-    Expr                expr )
+static CVar CompFuncExpr(Expr expr)
 {
     CVar                func;           /* function, result                */
     CVar                tmp;            /* dummy body                      */
@@ -1200,8 +1157,7 @@ static CVar CompFuncExpr (
 **
 *F  CompOr( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_OR
 */
-static CVar CompOr (
-    Expr                expr )
+static CVar CompOr(Expr expr)
 {
     CVar                val;            /* or, result                      */
     CVar                left;           /* left operand                    */
@@ -1240,8 +1196,7 @@ static CVar CompOr (
 **
 *F  CompOrBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_OR
 */
-static CVar CompOrBool (
-    Expr                expr )
+static CVar CompOrBool(Expr expr)
 {
     CVar                val;            /* or, result                      */
     CVar                left;           /* left operand                    */
@@ -1280,8 +1235,7 @@ static CVar CompOrBool (
 **
 *F  CompAnd( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_AND
 */
-static CVar CompAnd (
-    Expr                expr )
+static CVar CompAnd(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1339,8 +1293,7 @@ static CVar CompAnd (
 **
 *F  CompAndBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . T_AND
 */
-static CVar CompAndBool (
-    Expr                expr )
+static CVar CompAndBool(Expr expr)
 {
     CVar                val;            /* or, result                      */
     CVar                left;           /* left operand                    */
@@ -1379,8 +1332,7 @@ static CVar CompAndBool (
 **
 *F  CompNot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_NOT
 */
-static CVar CompNot (
-    Expr                expr )
+static CVar CompNot(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* operand                         */
@@ -1409,8 +1361,7 @@ static CVar CompNot (
 **
 *F  CompNotBoot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . T_NOT
 */
-static CVar CompNotBool (
-    Expr                expr )
+static CVar CompNotBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* operand                         */
@@ -1439,8 +1390,7 @@ static CVar CompNotBool (
 **
 *F  CompEq( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_EQ
 */
-static CVar CompEq (
-    Expr                expr )
+static CVar CompEq(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1477,8 +1427,7 @@ static CVar CompEq (
 **
 *F  CompEqBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_EQ
 */
-static CVar CompEqBool (
-    Expr                expr )
+static CVar CompEqBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1515,8 +1464,7 @@ static CVar CompEqBool (
 **
 *F  CompNe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_NE
 */
-static CVar CompNe (
-    Expr                expr )
+static CVar CompNe(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1553,8 +1501,7 @@ static CVar CompNe (
 **
 *F  CompNeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_NE
 */
-static CVar CompNeBool (
-    Expr                expr )
+static CVar CompNeBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1591,8 +1538,7 @@ static CVar CompNeBool (
 **
 *F  CompLt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_LT
 */
-static CVar CompLt (
-    Expr                expr )
+static CVar CompLt(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1629,8 +1575,7 @@ static CVar CompLt (
 **
 *F  CompLtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_LT
 */
-static CVar CompLtBool (
-    Expr                expr )
+static CVar CompLtBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1667,8 +1612,7 @@ static CVar CompLtBool (
 **
 *F  CompGe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_GE
 */
-static CVar CompGe (
-    Expr                expr )
+static CVar CompGe(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1705,8 +1649,7 @@ static CVar CompGe (
 **
 *F  CompGeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_GE
 */
-static CVar CompGeBool (
-    Expr                expr )
+static CVar CompGeBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1743,8 +1686,7 @@ static CVar CompGeBool (
 **
 *F  CompGt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_GT
 */
-static CVar CompGt (
-    Expr                expr )
+static CVar CompGt(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1781,8 +1723,7 @@ static CVar CompGt (
 **
 *F  CompGtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_GT
 */
-static CVar CompGtBool (
-    Expr                expr )
+static CVar CompGtBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1819,8 +1760,7 @@ static CVar CompGtBool (
 **
 *F  CompLe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_LE
 */
-static CVar CompLe (
-    Expr                expr )
+static CVar CompLe(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1857,8 +1797,7 @@ static CVar CompLe (
 **
 *F  CompLeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_LE
 */
-static CVar            CompLeBool (
-    Expr                expr )
+static CVar CompLeBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1895,8 +1834,7 @@ static CVar            CompLeBool (
 **
 *F  CompIn( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_IN
 */
-static CVar CompIn (
-    Expr                expr )
+static CVar CompIn(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1928,8 +1866,7 @@ static CVar CompIn (
 **
 *F  CompInBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_IN
 */
-static CVar CompInBool (
-    Expr                expr )
+static CVar CompInBool(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -1961,8 +1898,7 @@ static CVar CompInBool (
 **
 *F  CompSum( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_SUM
 */
-static CVar CompSum (
-    Expr                expr )
+static CVar CompSum(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2007,8 +1943,7 @@ static CVar CompSum (
 **
 *F  CompAInv( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_AINV
 */
-static CVar CompAInv (
-    Expr                expr )
+static CVar CompAInv(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2050,8 +1985,7 @@ static CVar CompAInv (
 **
 *F  CompDiff( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_DIFF
 */
-static CVar CompDiff (
-    Expr                expr )
+static CVar CompDiff(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2096,8 +2030,7 @@ static CVar CompDiff (
 **
 *F  CompProd( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_PROD
 */
-static CVar CompProd (
-    Expr                expr )
+static CVar CompProd(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2142,8 +2075,7 @@ static CVar CompProd (
 **
 *F  CompQuo( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_QUO
 */
-static CVar CompQuo (
-    Expr                expr )
+static CVar CompQuo(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2175,8 +2107,7 @@ static CVar CompQuo (
 **
 *F  CompMod( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_MOD
 */
-static CVar CompMod (
-    Expr                expr )
+static CVar CompMod(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2213,8 +2144,7 @@ static CVar CompMod (
 **
 *F  CompPow( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_POW
 */
-static CVar CompPow (
-    Expr                expr )
+static CVar CompPow(Expr expr)
 {
     CVar                val;            /* result                          */
     CVar                left;           /* left operand                    */
@@ -2267,8 +2197,7 @@ static CVar CompPow (
 **
 */
 
-static CVar CompIntExpr (
-    Expr                expr )
+static CVar CompIntExpr(Expr expr)
 {
     CVar                val;
     Int                 siz;
@@ -2313,8 +2242,7 @@ static CVar CompIntExpr (
 **
 *F  CompTildeExpr( <expr> )  . . . . . . . . . . . . . . . . . . T_TILDE_EXPR
 */
-static CVar CompTildeExpr (
-    Expr                expr )
+static CVar CompTildeExpr(Expr expr)
 {
     Emit( "if ( ! STATE(Tilde) ) {\n");
     Emit( "    ErrorMayQuit(\"'~' does not have a value here\",0L,0L);\n" );
@@ -2335,8 +2263,7 @@ static CVar CompTildeExpr (
 **
 *F  CompTrueExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_TRUE_EXPR
 */
-static CVar CompTrueExpr (
-    Expr                expr )
+static CVar CompTrueExpr(Expr expr)
 {
     CVar                val;            /* value, result                   */
 
@@ -2358,8 +2285,7 @@ static CVar CompTrueExpr (
 **
 *F  CompFalseExpr( <expr> ) . . . . . . . . . . . . . . . . . .  T_FALSE_EXPR
 */
-static CVar CompFalseExpr (
-    Expr                expr )
+static CVar CompFalseExpr(Expr expr)
 {
     CVar                val;            /* value, result                   */
 
@@ -2381,8 +2307,7 @@ static CVar CompFalseExpr (
 **
 *F  CompCharExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_CHAR_EXPR
 */
-static CVar            CompCharExpr (
-    Expr                expr )
+static CVar CompCharExpr(Expr expr)
 {
     CVar                val;            /* result                          */
 
@@ -2404,8 +2329,7 @@ static CVar            CompCharExpr (
 **
 *F  CompPermExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_PERM_EXPR
 */
-static CVar CompPermExpr (
-    Expr                expr )
+static CVar CompPermExpr(Expr expr)
 {
     CVar                perm;           /* result                          */
     CVar                lcyc;           /* one cycle as list               */
@@ -2468,13 +2392,12 @@ static CVar CompPermExpr (
 **
 *F  CompListExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_LIST_EXPR
 */
-static CVar CompListExpr1 ( Expr expr );
-static void CompListExpr2 ( CVar list, Expr expr );
-static CVar CompRecExpr1 ( Expr expr );
-static void CompRecExpr2 ( CVar rec, Expr expr );
+static CVar CompListExpr1(Expr expr);
+static void CompListExpr2(CVar list, Expr expr);
+static CVar CompRecExpr1(Expr expr);
+static void CompRecExpr2(CVar rec, Expr expr);
 
-static CVar CompListExpr (
-    Expr                expr )
+static CVar CompListExpr(Expr expr)
 {
     CVar                list;           /* list, result                    */
 
@@ -2491,8 +2414,7 @@ static CVar CompListExpr (
 **
 *F  CompListTildeExpr( <expr> ) . . . . . . . . . . . . . . T_LIST_TILDE_EXPR
 */
-static CVar CompListTildeExpr (
-    Expr                expr )
+static CVar CompListTildeExpr(Expr expr)
 {
     CVar                list;           /* list value, result              */
     CVar                tilde;          /* old value of tilde              */
@@ -2523,8 +2445,7 @@ static CVar CompListTildeExpr (
 **
 *F  CompListExpr1( <expr> ) . . . . . . . . . . . . . . . . . . . . . . local
 */
-static CVar CompListExpr1 (
-    Expr                expr )
+static CVar CompListExpr1(Expr expr)
 {
     CVar                list;           /* list, result                    */
     Int                 len;            /* logical length of the list      */
@@ -2551,9 +2472,7 @@ static CVar CompListExpr1 (
 **
 *F  CompListExpr2( <list>, <expr> ) . . . . . . . . . . . . . . . . . . local
 */
-static void CompListExpr2 (
-    CVar                list,
-    Expr                expr )
+static void CompListExpr2(CVar list, Expr expr)
 {
     CVar                sub;            /* subexpression                   */
     Int                 len;            /* logical length of the list      */
@@ -2607,8 +2526,7 @@ static void CompListExpr2 (
 **
 *F  CompRangeExpr( <expr> ) . . . . . . . . . . . . . . . . . .  T_RANGE_EXPR
 */
-static CVar CompRangeExpr (
-    Expr                expr )
+static CVar CompRangeExpr(Expr expr)
 {
     CVar                range;          /* range, result                   */
     CVar                first;          /* first  element                  */
@@ -2663,8 +2581,7 @@ static CVar CompRangeExpr (
 **
 *F  CompStringExpr( <expr> )  . . . . . . . . . . compile a string expression
 */
-static CVar CompStringExpr (
-    Expr                expr )
+static CVar CompStringExpr(Expr expr)
 {
     CVar                string;         /* string value, result            */
     Obj                 str;            // the actual string object
@@ -2690,8 +2607,7 @@ static CVar CompStringExpr (
 **
 *F  CompRecExpr( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REC_EXPR
 */
-static CVar CompRecExpr (
-    Expr                expr )
+static CVar CompRecExpr(Expr expr)
 {
     CVar                rec;            /* record value, result            */
 
@@ -2708,8 +2624,7 @@ static CVar CompRecExpr (
 **
 *F  CompRecTildeExpr( <expr> )  . . . . . . . . . . . . . .  T_REC_TILDE_EXPR
 */
-static CVar CompRecTildeExpr (
-    Expr                expr )
+static CVar CompRecTildeExpr(Expr expr)
 {
     CVar                rec;            /* record value, result            */
     CVar                tilde;          /* old value of tilde              */
@@ -2740,8 +2655,7 @@ static CVar CompRecTildeExpr (
 **
 *F  CompRecExpr1( <expr> )  . . . . . . . . . . . . . . . . . . . . . . local
 */
-static CVar CompRecExpr1 (
-    Expr                expr )
+static CVar CompRecExpr1(Expr expr)
 {
     CVar                rec;            /* record value, result            */
     Int                 len;            /* number of components            */
@@ -2767,9 +2681,7 @@ static CVar CompRecExpr1 (
 **
 *F  CompRecExpr2( <rec>, <expr> ) . . . . . . . . . . . . . . . . . . . local
 */
-static void            CompRecExpr2 (
-    CVar                rec,
-    Expr                expr )
+static void CompRecExpr2(CVar rec, Expr expr)
 {
     CVar                rnam;           /* name of component               */
     CVar                sub;            /* value of subexpression          */
@@ -2837,8 +2749,7 @@ static void            CompRecExpr2 (
 **
 *F  CompRefLVar( <expr> ) . . . . . . .  T_REFLVAR
 */
-static CVar CompRefLVar (
-    Expr                expr )
+static CVar CompRefLVar(Expr expr)
 {
     CVar                val;            /* value, result                   */
     LVar                lvar;           /* local variable                  */
@@ -2866,8 +2777,7 @@ static CVar CompRefLVar (
 **
 *F  CompIsbLVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_LVAR
 */
-static CVar CompIsbLVar (
-    Expr                expr )
+static CVar CompIsbLVar(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                val;            /* value                           */
@@ -2906,8 +2816,7 @@ static CVar CompIsbLVar (
 **
 *F  CompRefHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REF_HVAR
 */
-static CVar CompRefHVar (
-    Expr                expr )
+static CVar CompRefHVar(Expr expr)
 {
     CVar                val;            /* value, result                   */
     HVar                hvar;           /* higher variable                 */
@@ -2935,8 +2844,7 @@ static CVar CompRefHVar (
 **
 *F  CompIsbHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_HVAR
 */
-static CVar CompIsbHVar (
-    Expr                expr )
+static CVar CompIsbHVar(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                val;            /* value                           */
@@ -2972,8 +2880,7 @@ static CVar CompIsbHVar (
 **
 *F  CompRefGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REF_GVAR
 */
-static CVar CompRefGVar (
-    Expr                expr )
+static CVar CompRefGVar(Expr expr)
 {
     CVar                val;            /* value, result                   */
     GVar                gvar;           /* higher variable                 */
@@ -3000,8 +2907,7 @@ static CVar CompRefGVar (
 **
 *F  CompRefGVarFopy( <expr> ) . . . . . . . . . . . . . . . . . . . . . local
 */
-static CVar CompRefGVarFopy (
-    Expr                expr )
+static CVar CompRefGVarFopy(Expr expr)
 {
     CVar                val;            /* value, result                   */
     GVar                gvar;           /* higher variable                 */
@@ -3028,8 +2934,7 @@ static CVar CompRefGVarFopy (
 **
 *F  CompIsbGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_GVAR
 */
-static CVar CompIsbGVar (
-    Expr                expr )
+static CVar CompIsbGVar(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                val;            /* value, result                   */
@@ -3064,8 +2969,7 @@ static CVar CompIsbGVar (
 **
 *F  CompElmList( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ELM_LIST
 */
-static CVar CompElmList (
-    Expr                expr )
+static CVar CompElmList(Expr expr)
 {
     CVar                elm;            /* element, result                 */
     CVar                list;           /* list                            */
@@ -3111,8 +3015,7 @@ static CVar CompElmList (
 **
 *F  CompElmsList( <expr> )  . . . . . . . . . . . . . . . . . . . T_ELMS_LIST
 */
-static CVar CompElmsList (
-    Expr                expr )
+static CVar CompElmsList(Expr expr)
 {
     CVar                elms;           /* elements, result                */
     CVar                list;           /* list                            */
@@ -3146,8 +3049,7 @@ static CVar CompElmsList (
 **
 *F  CompElmListLev( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_LIST_LEV
 */
-static CVar CompElmListLev (
-    Expr                expr )
+static CVar CompElmListLev(Expr expr)
 {
     CVar                lists;          /* lists                           */
     CVar                pos;            /* position                        */
@@ -3178,8 +3080,7 @@ static CVar CompElmListLev (
 **
 *F  CompElmsListLev( <expr> ) . . . . . . . . . . . . . . . . T_ELMS_LIST_LEV
 */
-static CVar CompElmsListLev (
-    Expr                expr )
+static CVar CompElmsListLev(Expr expr)
 {
     CVar                lists;          /* lists                           */
     CVar                poss;           /* positions                       */
@@ -3209,8 +3110,7 @@ static CVar CompElmsListLev (
 **
 *F  CompIsbList( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_LIST
 */
-static CVar CompIsbList (
-    Expr                expr )
+static CVar CompIsbList(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                list;           /* list                            */
@@ -3245,8 +3145,7 @@ static CVar CompIsbList (
 **
 *F  CompElmRecName( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_REC_NAME
 */
-static CVar CompElmRecName (
-    Expr                expr )
+static CVar CompElmRecName(Expr expr)
 {
     CVar                elm;            /* element, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3280,8 +3179,7 @@ static CVar CompElmRecName (
 **
 *F  CompElmRecExpr( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_REC_EXPR
 */
-static CVar CompElmRecExpr (
-    Expr                expr )
+static CVar CompElmRecExpr(Expr expr)
 {
     CVar                elm;            /* element, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3315,8 +3213,7 @@ static CVar CompElmRecExpr (
 **
 *F  CompIsbRecName( <expr> )  . . . . . . . . . . . . . . . .  T_ISB_REC_NAME
 */
-static CVar CompIsbRecName (
-    Expr                expr )
+static CVar CompIsbRecName(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3351,8 +3248,7 @@ static CVar CompIsbRecName (
 **
 *F  CompIsbRecExpr( <expr> )  . . . . . . . . . . . . . . . .  T_ISB_REC_EXPR
 */
-static CVar CompIsbRecExpr (
-    Expr                expr )
+static CVar CompIsbRecExpr(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3387,8 +3283,7 @@ static CVar CompIsbRecExpr (
 **
 *F  CompElmPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ELM_POSOBJ
 */
-static CVar CompElmPosObj (
-    Expr                expr )
+static CVar CompElmPosObj(Expr expr)
 {
     CVar                elm;            /* element, result                 */
     CVar                list;           /* list                            */
@@ -3423,8 +3318,7 @@ static CVar CompElmPosObj (
 **
 *F  CompIsbPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ISB_POSOBJ
 */
-static CVar CompIsbPosObj (
-    Expr                expr )
+static CVar CompIsbPosObj(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                list;           /* list                            */
@@ -3459,8 +3353,7 @@ static CVar CompIsbPosObj (
 **
 *F  CompElmObjName( <expr> )  . . . . . . . . . . . . . . . T_ELM_COMOBJ_NAME
 */
-static CVar CompElmComObjName (
-    Expr                expr )
+static CVar CompElmComObjName(Expr expr)
 {
     CVar                elm;            /* element, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3495,8 +3388,7 @@ static CVar CompElmComObjName (
 **
 *F  CompElmComObjExpr( <expr> ) . . . . . . . . . . . . . . T_ELM_COMOBJ_EXPR
 */
-static CVar CompElmComObjExpr (
-    Expr                expr )
+static CVar CompElmComObjExpr(Expr expr)
 {
     CVar                elm;            /* element, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3530,8 +3422,7 @@ static CVar CompElmComObjExpr (
 **
 *F  CompIsbComObjName( <expr> ) . . . . . . . . . . . . . . T_ISB_COMOBJ_NAME
 */
-static CVar CompIsbComObjName (
-    Expr                expr )
+static CVar CompIsbComObjName(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3566,8 +3457,7 @@ static CVar CompIsbComObjName (
 **
 *F  CompIsbComObjExpr( <expr> ) . . . . . . . . . . . . . . T_ISB_COMOBJ_EXPR
 */
-static CVar CompIsbComObjExpr (
-    Expr                expr )
+static CVar CompIsbComObjExpr(Expr expr)
 {
     CVar                isb;            /* isbound, result                 */
     CVar                record;         /* the record, left operand        */
@@ -3610,10 +3500,9 @@ static CVar CompIsbComObjExpr (
 **
 **  'CompStat' compiles the statement <stat>.
 */
-static void (* CompStatFuncs[256]) ( Stat stat );
+static void (*CompStatFuncs[256])(Stat stat);
 
-static void CompStat (
-    Stat                stat )
+static void CompStat(Stat stat)
 {
     (* CompStatFuncs[ TNUM_STAT(stat) ])( stat );
 }
@@ -3623,8 +3512,7 @@ static void CompStat (
 **
 *F  CompUnknownStat( <stat> ) . . . . . . . . . . . . . . . . signal an error
 */
-static void CompUnknownStat (
-    Stat                stat )
+static void CompUnknownStat(Stat stat)
 {
     Emit( "CANNOT COMPILE STATEMENT OF TNUM %d;\n", TNUM_STAT(stat) );
 }
@@ -3641,8 +3529,7 @@ static GVar G_Add;
 **
 *F  CompProccall0to6Args( <stat> )  . . . T_PROCCALL_0ARGS...T_PROCCALL_6ARGS
 */
-static void CompProccall0to6Args (
-    Stat                stat )
+static void CompProccall0to6Args(Stat stat)
 {
     CVar                func;           /* function                        */
     CVar                args[8];        /* arguments                       */
@@ -3706,8 +3593,7 @@ static void CompProccall0to6Args (
 **
 *F  CompProccallXArgs . . . . . . . . . . . . . . . . . . .  T_PROCCALL_XARGS
 */
-static void CompProccallXArgs (
-    Stat                stat )
+static void CompProccallXArgs(Stat stat)
 {
     CVar                func;           /* function                        */
     CVar                argl;           /* argument list                   */
@@ -3755,8 +3641,7 @@ static void CompProccallXArgs (
 **
 *F  CompProccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_PROCCALL_OPTS
 */
-static void CompProccallOpts(
-                      Stat stat)
+static void CompProccallOpts(Stat stat)
 {
   CVar opts = CompExpr(READ_STAT(stat, 0));
   GVar pushOptions;
@@ -3776,8 +3661,7 @@ static void CompProccallOpts(
 **
 *F  CompSeqStat( <stat> ) . . . . . . . . . . . . .  T_SEQ_STAT...T_SEQ_STAT7
 */
-static void CompSeqStat (
-    Stat                stat )
+static void CompSeqStat(Stat stat)
 {
     UInt                nr;             /* number of statements            */
     UInt                i;              /* loop variable                   */
@@ -3796,8 +3680,7 @@ static void CompSeqStat (
 **
 *F  CompIf( <stat> )  . . . . . . . . T_IF/T_IF_ELSE/T_IF_ELIF/T_IF_ELIF_ELSE
 */
-static void CompIf (
-    Stat                stat )
+static void CompIf(Stat stat)
 {
     CVar                cond;           /* condition                       */
     UInt                nr;             /* number of branches              */
@@ -3931,8 +3814,7 @@ static void CompIf (
 **
 *F  CompFor( <stat> ) . . . . . . . T_FOR...T_FOR3/T_FOR_RANGE...T_FOR_RANGE3
 */
-static void CompFor (
-    Stat                stat )
+static void CompFor(Stat stat)
 {
     UInt                var;            /* loop variable                   */
     Char                vart;           /* variable type                   */
@@ -4171,8 +4053,7 @@ static void CompFor (
 **
 *F  CompWhile( <stat> ) . . . . . . . . . . . . . . . . .  T_WHILE...T_WHILE3
 */
-static void CompWhile (
-    Stat                stat )
+static void CompWhile(Stat stat)
 {
     CVar                cond;           /* condition                       */
     Int                 pass;           /* current pass                    */
@@ -4229,8 +4110,7 @@ static void CompWhile (
 **
 *F  CompRepeat( <stat> )  . . . . . . . . . . . . . . .  T_REPEAT...T_REPEAT3
 */
-static void CompRepeat (
-    Stat                stat )
+static void CompRepeat(Stat stat)
 {
     CVar                cond;           /* condition                       */
     Int                 pass;           /* current pass                    */
@@ -4290,8 +4170,7 @@ static void CompRepeat (
 **
 *F  CompBreak( <stat> ) . . . . . . . . . . . . . . . . . . . . . . . T_BREAK
 */
-static void CompBreak (
-    Stat                stat )
+static void CompBreak(Stat stat)
 {
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -4305,8 +4184,7 @@ static void CompBreak (
 **
 *F  CompContinue( <stat> ) . . . . . . . . . . . . . . . . . . . . T_CONTINUE
 */
-static void CompContinue (
-    Stat                stat )
+static void CompContinue(Stat stat)
 {
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -4321,8 +4199,7 @@ static void CompContinue (
 **
 *F  CompReturnObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_RETURN_OBJ
 */
-static void CompReturnObj (
-    Stat                stat )
+static void CompReturnObj(Stat stat)
 {
     CVar                obj;            /* returned object                 */
 
@@ -4349,8 +4226,7 @@ static void CompReturnObj (
 **
 *F  CompReturnVoid( <stat> )  . . . . . . . . . . . . . . . . . T_RETURN_VOID
 */
-static void CompReturnVoid (
-    Stat                stat )
+static void CompReturnVoid(Stat stat)
 {
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -4369,8 +4245,7 @@ static void CompReturnVoid (
 **
 *F  CompAssLVar( <stat> ) . . . . . . . . . . . .  T_ASS_LVAR...T_ASS_LVAR_16
 */
-static void            CompAssLVar (
-    Stat                stat )
+static void CompAssLVar(Stat stat)
 {
     LVar                lvar;           /* local variable                  */
     CVar                rhs;            /* right hand side                 */
@@ -4402,8 +4277,7 @@ static void            CompAssLVar (
 **
 *F  CompUnbLVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_LVAR
 */
-static void CompUnbLVar (
-    Stat                stat )
+static void CompUnbLVar(Stat stat)
 {
     LVar                lvar;           /* local variable                  */
 
@@ -4428,8 +4302,7 @@ static void CompUnbLVar (
 **
 *F  CompAssHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_HVAR
 */
-static void CompAssHVar (
-    Stat                stat )
+static void CompAssHVar(Stat stat)
 {
     HVar                hvar;           /* higher variable                 */
     CVar                rhs;            /* right hand side                 */
@@ -4457,8 +4330,7 @@ static void CompAssHVar (
 **
 *F  CompUnbHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_HVAR
 */
-static void CompUnbHVar (
-    Stat                stat )
+static void CompUnbHVar(Stat stat)
 {
     HVar                hvar;           /* higher variable                 */
 
@@ -4479,8 +4351,7 @@ static void CompUnbHVar (
 **
 *F  CompAssGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_GVAR
 */
-static void CompAssGVar (
-    Stat                stat )
+static void CompAssGVar(Stat stat)
 {
     GVar                gvar;           /* global variable                 */
     CVar                rhs;            /* right hand side                 */
@@ -4507,8 +4378,7 @@ static void CompAssGVar (
 **
 *F  CompUnbGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_GVAR
 */
-static void            CompUnbGVar (
-    Stat                stat )
+static void CompUnbGVar(Stat stat)
 {
     GVar                gvar;           /* global variable                 */
 
@@ -4528,8 +4398,7 @@ static void            CompUnbGVar (
 **
 *F  CompAssList( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_LIST
 */
-static void CompAssList (
-    Stat                stat )
+static void CompAssList(Stat stat)
 {
     CVar                list;           /* list                            */
     CVar                pos;            /* position                        */
@@ -4574,8 +4443,7 @@ static void CompAssList (
 **
 *F  CompAsssList( <stat> )  . . . . . . . . . . . . . . . . . . . T_ASSS_LIST
 */
-static void CompAsssList (
-    Stat                stat )
+static void CompAsssList(Stat stat)
 {
     CVar                list;           /* list                            */
     CVar                poss;           /* positions                       */
@@ -4609,8 +4477,7 @@ static void CompAsssList (
 **
 *F  CompAssListLev( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_LIST_LEV
 */
-static void CompAssListLev (
-    Stat                stat )
+static void CompAssListLev(Stat stat)
 {
     CVar                lists;          /* lists                           */
     CVar                pos;            /* position                        */
@@ -4649,8 +4516,7 @@ static void CompAssListLev (
 **
 *F  CompAsssListLev( <stat> ) . . . . . . . . . . . . . . . . T_ASSS_LIST_LEV
 */
-static void CompAsssListLev (
-    Stat                stat )
+static void CompAsssListLev(Stat stat)
 {
     CVar                lists;          /* list                            */
     CVar                poss;           /* positions                       */
@@ -4689,8 +4555,7 @@ static void CompAsssListLev (
 **
 *F  CompUnbList( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_LIST
 */
-static void CompUnbList (
-    Stat                stat )
+static void CompUnbList(Stat stat)
 {
     CVar                list;           /* list, left operand              */
     CVar                pos;            /* position, left operand          */
@@ -4720,8 +4585,7 @@ static void CompUnbList (
 **
 *F  CompAssRecName( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_REC_NAME
 */
-static void CompAssRecName (
-    Stat                stat )
+static void CompAssRecName(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -4755,8 +4619,7 @@ static void CompAssRecName (
 **
 *F  CompAssRecExpr( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_REC_EXPR
 */
-static void CompAssRecExpr (
-    Stat                stat )
+static void CompAssRecExpr(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     CVar                rnam;           /* name, left operand              */
@@ -4790,8 +4653,7 @@ static void CompAssRecExpr (
 **
 *F  CompUnbRecName( <stat> )  . . . . . . . . . . . . . . . .  T_UNB_REC_NAME
 */
-static void CompUnbRecName (
-    Stat                stat )
+static void CompUnbRecName(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -4820,8 +4682,7 @@ static void CompUnbRecName (
 **
 *F  CompUnbRecExpr( <stat> )  . . . . . . . . . . . . . . . .  T_UNB_REC_EXPR
 */
-static void            CompUnbRecExpr (
-    Stat                stat )
+static void CompUnbRecExpr(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     CVar                rnam;           /* name, left operand              */
@@ -4850,8 +4711,7 @@ static void            CompUnbRecExpr (
 **
 *F  CompAssPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASS_POSOBJ
 */
-static void CompAssPosObj (
-    Stat                stat )
+static void CompAssPosObj(Stat stat)
 {
     CVar                list;           /* list                            */
     CVar                pos;            /* position                        */
@@ -4886,8 +4746,7 @@ static void CompAssPosObj (
 **
 *F  CompUnbPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_UNB_POSOBJ
 */
-static void CompUnbPosObj (
-    Stat                stat )
+static void CompUnbPosObj(Stat stat)
 {
     CVar                list;           /* list, left operand              */
     CVar                pos;            /* position, left operand          */
@@ -4917,8 +4776,7 @@ static void CompUnbPosObj (
 **
 *F  CompAssComObjName( <stat> ) . . . . . . . . . . . . . . T_ASS_COMOBJ_NAME
 */
-static void CompAssComObjName (
-    Stat                stat )
+static void CompAssComObjName(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -4952,8 +4810,7 @@ static void CompAssComObjName (
 **
 *F  CompAssComObjExpr( <stat> ) . . . . . . . . . . . . . . T_ASS_COMOBJ_EXPR
 */
-static void CompAssComObjExpr (
-    Stat                stat )
+static void CompAssComObjExpr(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     CVar                rnam;           /* name, left operand              */
@@ -4987,8 +4844,7 @@ static void CompAssComObjExpr (
 **
 *F  CompUnbComObjName( <stat> ) . . . . . . . . . . . . . . T_UNB_COMOBJ_NAME
 */
-static void CompUnbComObjName (
-    Stat                stat )
+static void CompUnbComObjName(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -5017,8 +4873,7 @@ static void CompUnbComObjName (
 **
 *F  CompUnbComObjExpr( <stat> ) . . . . . . . . . . . . . . T_UNB_COMOBJ_EXPR
 */
-static void CompUnbComObjExpr (
-    Stat                stat )
+static void CompUnbComObjExpr(Stat stat)
 {
     CVar                record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -5047,8 +4902,7 @@ static void CompUnbComObjExpr (
 **
 *F  CompEmpty( <stat> )  . . . . . . . . . . . . . . . . . . . . . . . T_EMPY
 */
-static void CompEmpty (
-    Stat                stat )
+static void CompEmpty(Stat stat)
 {
     // do nothing
 }
@@ -5057,8 +4911,7 @@ static void CompEmpty (
 **
 *F  CompInfo( <stat> )  . . . . . . . . . . . . . . . . . . . . . . .  T_INFO
 */
-static void CompInfo (
-    Stat                stat )
+static void CompInfo(Stat stat)
 {
     CVar                tmp;
     CVar                sel;
@@ -5098,8 +4951,7 @@ static void CompInfo (
 **
 *F  CompAssert2( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASSERT_2ARGS
 */
-static void CompAssert2 (
-    Stat                stat )
+static void CompAssert2(Stat stat)
 {
     CVar                lev;            /* the level                       */
     CVar                cnd;            /* the condition                   */
@@ -5124,8 +4976,7 @@ static void CompAssert2 (
 **
 *F  CompAssert3( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASSERT_3ARGS
 */
-static void CompAssert3 (
-    Stat                stat )
+static void CompAssert3(Stat stat)
 {
     CVar                lev;            /* the level                       */
     CVar                cnd;            /* the condition                   */
@@ -5166,8 +5017,7 @@ static void CompAssert3 (
 */
 static Obj CompFunctions;
 
-static void CompFunc (
-    Obj                 func )
+static void CompFunc(Obj func)
 {
     Bag                 info;           /* info bag for this function      */
     Int                 narg;           /* number of arguments             */
@@ -5512,9 +5362,7 @@ Int CompileFunc (
 **
 *F  FuncCOMPILE_FUNC( <self>, <output>, <func>, <name>, <magic1>, <magic2> )
 */
-static Obj FuncCOMPILE_FUNC (
-    Obj                 self,
-    Obj                 arg )
+static Obj FuncCOMPILE_FUNC(Obj self, Obj arg)
 {
     Obj                 output;
     Obj                 func;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -43,35 +43,35 @@
 **
 *V  CompFastIntArith  . . option to emit code that handles small ints. faster
 */
-Int CompFastIntArith;
+static Int CompFastIntArith;
 
 
 /****************************************************************************
 **
 *V  CompFastPlainLists  . option to emit code that handles plain lists faster
 */
-Int CompFastPlainLists ;
+static Int CompFastPlainLists ;
 
 
 /****************************************************************************
 **
 *V  CompFastListFuncs . . option to emit code that inlines calls to functions
 */
-Int CompFastListFuncs;
+static Int CompFastListFuncs;
 
 
 /****************************************************************************
 **
 *V  CompCheckTypes  . . . . option to emit code that assumes all types are ok.
 */
-Int CompCheckTypes ;
+static Int CompCheckTypes ;
 
 
 /****************************************************************************
 **
 *V  CompCheckListElements .  option to emit code that assumes list elms exist
 */
-Int CompCheckListElements;
+static Int CompCheckListElements;
 
 
 /****************************************************************************
@@ -102,7 +102,7 @@ Int CompCheckListElements;
 **  unneccessary  computations during the first pass,  the  advantage is that
 **  the two passes are guaranteed to do exactly the same computations.
 */
-Int CompPass;
+static Int CompPass;
 
 
 /****************************************************************************
@@ -227,7 +227,7 @@ typedef UInt4           LVar;
 
 #define W_INT_SMALL_POS         (W_INT_SMALL | W_INT_POS)
 
-void            SetInfoCVar (
+static void            SetInfoCVar (
     CVar                cvar,
     UInt                type )
 {
@@ -248,7 +248,7 @@ void            SetInfoCVar (
     }
 }
 
-Int             GetInfoCVar (
+static Int             GetInfoCVar (
     CVar                cvar )
 {
     Bag                 info;           /* its info bag                    */
@@ -277,7 +277,7 @@ Int             GetInfoCVar (
     }
 }
 
-Int             HasInfoCVar (
+static Int             HasInfoCVar (
     CVar                cvar,
     Int                 type )
 {
@@ -285,7 +285,7 @@ Int             HasInfoCVar (
 }
 
 
-Bag             NewInfoCVars ( void )
+static Bag             NewInfoCVars ( void )
 {
     Bag                 old;
     Bag                 new;
@@ -294,7 +294,7 @@ Bag             NewInfoCVars ( void )
     return new;
 }
 
-void            CopyInfoCVars (
+static void            CopyInfoCVars (
     Bag                 dst,
     Bag                 src )
 {
@@ -315,7 +315,7 @@ void            CopyInfoCVars (
     }
 }
 
-void            MergeInfoCVars (
+static void            MergeInfoCVars (
     Bag                 dst,
     Bag                 src )
 {
@@ -331,7 +331,7 @@ void            MergeInfoCVars (
     }
 }
 
-Int             IsEqInfoCVars (
+static Int             IsEqInfoCVars (
     Bag                 dst,
     Bag                 src )
 {
@@ -368,7 +368,7 @@ Int             IsEqInfoCVars (
 */
 typedef UInt4           Temp;
 
-Temp            NewTemp (
+static Temp           NewTemp (
     const Char *        name )
 {
     Temp                temp;           /* new temporary, result           */
@@ -394,7 +394,7 @@ Temp            NewTemp (
     return temp;
 }
 
-void            FreeTemp (
+static void            FreeTemp (
     Temp                temp )
 {
     Bag                 info;           /* information bag                 */
@@ -441,7 +441,7 @@ void            FreeTemp (
 */
 typedef UInt4           HVar;
 
-void            CompSetUseHVar (
+static void            CompSetUseHVar (
     HVar                hvar )
 {
     Bag                 info;           /* its info bag                    */
@@ -464,7 +464,7 @@ void            CompSetUseHVar (
 
 }
 
-Int             CompGetUseHVar (
+static Int             CompGetUseHVar (
     HVar                hvar )
 {
     Bag                 info;           /* its info bag                    */
@@ -480,7 +480,7 @@ Int             CompGetUseHVar (
     return (TNUM_LVAR_INFO( info, (hvar & 0xFFFF) ) == W_HIGHER);
 }
 
-UInt            GetLevlHVar (
+static UInt            GetLevlHVar (
     HVar                hvar )
 {
     UInt                levl;           /* level of higher variable        */
@@ -500,7 +500,7 @@ UInt            GetLevlHVar (
     return levl - 1;
 }
 
-UInt            GetIndxHVar (
+static UInt            GetIndxHVar (
     HVar                hvar )
 {
     UInt                indx;           /* index of higher variable        */
@@ -558,7 +558,7 @@ typedef UInt    GVar;
 
 Bag             CompInfoGVar;
 
-void            CompSetUseGVar (
+static void            CompSetUseGVar (
     GVar                gvar,
     UInt                mode )
 {
@@ -574,7 +574,7 @@ void            CompSetUseGVar (
     ((UInt*)PTR_BAG(CompInfoGVar))[gvar] |= mode;
 }
 
-UInt            CompGetUseGVar (
+static UInt            CompGetUseGVar (
     GVar                gvar )
 {
     return ((UInt*)PTR_BAG(CompInfoGVar))[gvar];
@@ -603,7 +603,7 @@ typedef UInt    RNam;
 
 Bag             CompInfoRNam;
 
-void            CompSetUseRNam (
+static void            CompSetUseRNam (
     RNam                rnam,
     UInt                mode )
 {
@@ -619,7 +619,7 @@ void            CompSetUseRNam (
     ((UInt*)PTR_BAG(CompInfoRNam))[rnam] |= mode;
 }
 
-UInt            CompGetUseRNam (
+static UInt            CompGetUseRNam (
     RNam                rnam )
 {
     return ((UInt*)PTR_BAG(CompInfoRNam))[rnam];
@@ -642,11 +642,11 @@ UInt            CompGetUseRNam (
 **  ('INTOBJ_INT(<int>)'  for integers,  'a_<name>' for arguments, 'l_<name>'
 **  for locals, 't_<nr>' for temporaries), and '%%' outputs a single '%'.
 */
-Int             EmitIndent;
+static Int             EmitIndent;
 
-Int             EmitIndent2;
+static Int             EmitIndent2;
 
-void            Emit (
+static void            Emit (
     const char *        fmt,
     ... )
 {
@@ -802,7 +802,7 @@ void            Emit (
 **
 *F  CompCheckBound( <obj>, <name> ) emit code to check that <obj> has a value
 */
-void CompCheckBound (
+static void CompCheckBound (
     CVar                obj,
     Obj                 name )
 {
@@ -819,7 +819,7 @@ void CompCheckBound (
 **
 *F  CompCheckFuncResult( <obj> )  . emit code to check that <obj> has a value
 */
-void CompCheckFuncResult (
+static void CompCheckFuncResult (
     CVar                obj )
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
@@ -835,7 +835,7 @@ void CompCheckFuncResult (
 **
 *F  CompCheckIntSmall( <obj> )   emit code to check that <obj> is a small int
 */
-void CompCheckIntSmall (
+static void CompCheckIntSmall (
     CVar                obj )
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL ) ) {
@@ -852,7 +852,7 @@ void CompCheckIntSmall (
 **
 *F  CompCheckIntSmallPos( <obj> ) emit code to check that <obj> is a position
 */
-void CompCheckIntSmallPos (
+static void CompCheckIntSmallPos (
     CVar                obj )
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL_POS ) ) {
@@ -867,7 +867,7 @@ void CompCheckIntSmallPos (
 **
 *F  CompCheckIntPos( <obj> ) emit code to check that <obj> is a position
 */
-void CompCheckIntPos (
+static void CompCheckIntPos (
     CVar                obj )
 {
     if ( ! HasInfoCVar( obj, W_INT_POS ) ) {
@@ -883,7 +883,7 @@ void CompCheckIntPos (
 **
 *F  CompCheckBool( <obj> )  . . .  emit code to check that <obj> is a boolean
 */
-void CompCheckBool (
+static void CompCheckBool (
     CVar                obj )
 {
     if ( ! HasInfoCVar( obj, W_BOOL ) ) {
@@ -900,7 +900,7 @@ void CompCheckBool (
 **
 *F  CompCheckFunc( <obj> )  . . . emit code to check that <obj> is a function
 */
-void CompCheckFunc (
+static void CompCheckFunc (
     CVar                obj )
 {
     if ( ! HasInfoCVar( obj, W_FUNC ) ) {
@@ -925,10 +925,10 @@ void CompCheckFunc (
 **  'CompExpr' compiles the expression <expr> and returns the C variable that
 **  will contain the result.
 */
-CVar (* CompExprFuncs[256]) ( Expr expr );
+static CVar (* CompExprFuncs[256]) ( Expr expr );
 
 
-CVar CompExpr (
+static CVar CompExpr (
     Expr                expr )
 {
     return (* CompExprFuncs[ TNUM_EXPR(expr) ])( expr );
@@ -939,7 +939,7 @@ CVar CompExpr (
 **
 *F  CompUnknownExpr( <expr> ) . . . . . . . . . . . .  log unknown expression
 */
-CVar CompUnknownExpr (
+static CVar CompUnknownExpr (
     Expr                expr )
 {
     Emit( "CANNOT COMPILE EXPRESSION OF TNUM %d;\n", TNUM_EXPR(expr) );
@@ -952,9 +952,9 @@ CVar CompUnknownExpr (
 **
 *F  CompBoolExpr( <expr> )  . . . . . . . compile bool expr and return C bool
 */
-CVar (* CompBoolExprFuncs[256]) ( Expr expr );
+static CVar (* CompBoolExprFuncs[256]) ( Expr expr );
 
-CVar CompBoolExpr (
+static CVar CompBoolExpr (
     Expr                expr )
 {
     return (* CompBoolExprFuncs[ TNUM_EXPR(expr) ])( expr );
@@ -965,7 +965,7 @@ CVar CompBoolExpr (
 **
 *F  CompUnknownBool( <expr> ) . . . . . . . . . .  use 'CompExpr' and convert
 */
-CVar CompUnknownBool (
+static CVar CompUnknownBool (
     Expr                expr )
 {
     CVar                res;            /* result                          */
@@ -995,7 +995,7 @@ CVar CompUnknownBool (
 **
 *V  G_Length  . . . . . . . . . . . . . . . . . . . . . . . function 'Length'
 */
-GVar G_Length;
+static GVar G_Length;
 
 
 
@@ -1003,11 +1003,11 @@ GVar G_Length;
 **
 *F  CompFunccall0to6Args( <expr> )  . . . T_FUNCCALL_0ARGS...T_FUNCCALL_6ARGS
 */
-extern CVar CompRefGVarFopy (
+static CVar CompRefGVarFopy (
             Expr                expr );
 
 
-CVar CompFunccall0to6Args (
+static CVar CompFunccall0to6Args (
     Expr                expr )
 {
     CVar                result;         /* result, result                  */
@@ -1077,7 +1077,7 @@ CVar CompFunccall0to6Args (
 **
 *F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_FUNCCALL_XARGS
 */
-CVar CompFunccallXArgs (
+static CVar CompFunccallXArgs (
     Expr                expr )
 {
     CVar                result;         /* result, result                  */
@@ -1131,7 +1131,7 @@ CVar CompFunccallXArgs (
 **
 *F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_FUNCCALL_OPTS
 */
-CVar CompFunccallOpts(
+static CVar CompFunccallOpts(
                       Expr expr)
 {
   CVar opts = CompExpr(READ_STAT(expr, 0));
@@ -1154,7 +1154,7 @@ CVar CompFunccallOpts(
 **
 *F  CompFuncExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_FUNC_EXPR
 */
-CVar CompFuncExpr (
+static CVar CompFuncExpr (
     Expr                expr )
 {
     CVar                func;           /* function, result                */
@@ -1200,7 +1200,7 @@ CVar CompFuncExpr (
 **
 *F  CompOr( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_OR
 */
-CVar CompOr (
+static CVar CompOr (
     Expr                expr )
 {
     CVar                val;            /* or, result                      */
@@ -1240,7 +1240,7 @@ CVar CompOr (
 **
 *F  CompOrBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_OR
 */
-CVar CompOrBool (
+static CVar CompOrBool (
     Expr                expr )
 {
     CVar                val;            /* or, result                      */
@@ -1280,7 +1280,7 @@ CVar CompOrBool (
 **
 *F  CompAnd( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_AND
 */
-CVar CompAnd (
+static CVar CompAnd (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1339,7 +1339,7 @@ CVar CompAnd (
 **
 *F  CompAndBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . T_AND
 */
-CVar CompAndBool (
+static CVar CompAndBool (
     Expr                expr )
 {
     CVar                val;            /* or, result                      */
@@ -1379,7 +1379,7 @@ CVar CompAndBool (
 **
 *F  CompNot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_NOT
 */
-CVar CompNot (
+static CVar CompNot (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1409,7 +1409,7 @@ CVar CompNot (
 **
 *F  CompNotBoot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . T_NOT
 */
-CVar CompNotBool (
+static CVar CompNotBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1439,7 +1439,7 @@ CVar CompNotBool (
 **
 *F  CompEq( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_EQ
 */
-CVar CompEq (
+static CVar CompEq (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1477,7 +1477,7 @@ CVar CompEq (
 **
 *F  CompEqBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_EQ
 */
-CVar CompEqBool (
+static CVar CompEqBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1515,7 +1515,7 @@ CVar CompEqBool (
 **
 *F  CompNe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_NE
 */
-CVar CompNe (
+static CVar CompNe (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1553,7 +1553,7 @@ CVar CompNe (
 **
 *F  CompNeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_NE
 */
-CVar CompNeBool (
+static CVar CompNeBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1591,7 +1591,7 @@ CVar CompNeBool (
 **
 *F  CompLt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_LT
 */
-CVar CompLt (
+static CVar CompLt (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1629,7 +1629,7 @@ CVar CompLt (
 **
 *F  CompLtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_LT
 */
-CVar CompLtBool (
+static CVar CompLtBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1667,7 +1667,7 @@ CVar CompLtBool (
 **
 *F  CompGe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_GE
 */
-CVar CompGe (
+static CVar CompGe (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1705,7 +1705,7 @@ CVar CompGe (
 **
 *F  CompGeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_GE
 */
-CVar CompGeBool (
+static CVar CompGeBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1743,7 +1743,7 @@ CVar CompGeBool (
 **
 *F  CompGt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_GT
 */
-CVar CompGt (
+static CVar CompGt (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1781,7 +1781,7 @@ CVar CompGt (
 **
 *F  CompGtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_GT
 */
-CVar CompGtBool (
+static CVar CompGtBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1819,7 +1819,7 @@ CVar CompGtBool (
 **
 *F  CompLe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_LE
 */
-CVar CompLe (
+static CVar CompLe (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1857,7 +1857,7 @@ CVar CompLe (
 **
 *F  CompLeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_LE
 */
-CVar            CompLeBool (
+static CVar            CompLeBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1895,7 +1895,7 @@ CVar            CompLeBool (
 **
 *F  CompIn( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_IN
 */
-CVar CompIn (
+static CVar CompIn (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1928,7 +1928,7 @@ CVar CompIn (
 **
 *F  CompInBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_IN
 */
-CVar CompInBool (
+static CVar CompInBool (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -1961,7 +1961,7 @@ CVar CompInBool (
 **
 *F  CompSum( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_SUM
 */
-CVar CompSum (
+static CVar CompSum (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2007,7 +2007,7 @@ CVar CompSum (
 **
 *F  CompAInv( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_AINV
 */
-CVar CompAInv (
+static CVar CompAInv (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2050,7 +2050,7 @@ CVar CompAInv (
 **
 *F  CompDiff( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_DIFF
 */
-CVar CompDiff (
+static CVar CompDiff (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2096,7 +2096,7 @@ CVar CompDiff (
 **
 *F  CompProd( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_PROD
 */
-CVar CompProd (
+static CVar CompProd (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2142,7 +2142,7 @@ CVar CompProd (
 **
 *F  CompQuo( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_QUO
 */
-CVar CompQuo (
+static CVar CompQuo (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2175,7 +2175,7 @@ CVar CompQuo (
 **
 *F  CompMod( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_MOD
 */
-CVar CompMod (
+static CVar CompMod (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2213,7 +2213,7 @@ CVar CompMod (
 **
 *F  CompPow( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_POW
 */
-CVar CompPow (
+static CVar CompPow (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2267,7 +2267,7 @@ CVar CompPow (
 **
 */
 
-CVar CompIntExpr (
+static CVar CompIntExpr (
     Expr                expr )
 {
     CVar                val;
@@ -2313,7 +2313,7 @@ CVar CompIntExpr (
 **
 *F  CompTildeExpr( <expr> )  . . . . . . . . . . . . . . . . . . T_TILDE_EXPR
 */
-CVar CompTildeExpr (
+static CVar CompTildeExpr (
     Expr                expr )
 {
     Emit( "if ( ! STATE(Tilde) ) {\n");
@@ -2335,7 +2335,7 @@ CVar CompTildeExpr (
 **
 *F  CompTrueExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_TRUE_EXPR
 */
-CVar CompTrueExpr (
+static CVar CompTrueExpr (
     Expr                expr )
 {
     CVar                val;            /* value, result                   */
@@ -2358,7 +2358,7 @@ CVar CompTrueExpr (
 **
 *F  CompFalseExpr( <expr> ) . . . . . . . . . . . . . . . . . .  T_FALSE_EXPR
 */
-CVar CompFalseExpr (
+static CVar CompFalseExpr (
     Expr                expr )
 {
     CVar                val;            /* value, result                   */
@@ -2381,7 +2381,7 @@ CVar CompFalseExpr (
 **
 *F  CompCharExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_CHAR_EXPR
 */
-CVar            CompCharExpr (
+static CVar            CompCharExpr (
     Expr                expr )
 {
     CVar                val;            /* result                          */
@@ -2404,7 +2404,7 @@ CVar            CompCharExpr (
 **
 *F  CompPermExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_PERM_EXPR
 */
-CVar CompPermExpr (
+static CVar CompPermExpr (
     Expr                expr )
 {
     CVar                perm;           /* result                          */
@@ -2468,12 +2468,12 @@ CVar CompPermExpr (
 **
 *F  CompListExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_LIST_EXPR
 */
-extern CVar CompListExpr1 ( Expr expr );
-extern void CompListExpr2 ( CVar list, Expr expr );
-extern CVar CompRecExpr1 ( Expr expr );
-extern void CompRecExpr2 ( CVar rec, Expr expr );
+static CVar CompListExpr1 ( Expr expr );
+static void CompListExpr2 ( CVar list, Expr expr );
+static CVar CompRecExpr1 ( Expr expr );
+static void CompRecExpr2 ( CVar rec, Expr expr );
 
-CVar CompListExpr (
+static CVar CompListExpr (
     Expr                expr )
 {
     CVar                list;           /* list, result                    */
@@ -2491,7 +2491,7 @@ CVar CompListExpr (
 **
 *F  CompListTildeExpr( <expr> ) . . . . . . . . . . . . . . T_LIST_TILDE_EXPR
 */
-CVar CompListTildeExpr (
+static CVar CompListTildeExpr (
     Expr                expr )
 {
     CVar                list;           /* list value, result              */
@@ -2523,7 +2523,7 @@ CVar CompListTildeExpr (
 **
 *F  CompListExpr1( <expr> ) . . . . . . . . . . . . . . . . . . . . . . local
 */
-CVar CompListExpr1 (
+static CVar CompListExpr1 (
     Expr                expr )
 {
     CVar                list;           /* list, result                    */
@@ -2551,7 +2551,7 @@ CVar CompListExpr1 (
 **
 *F  CompListExpr2( <list>, <expr> ) . . . . . . . . . . . . . . . . . . local
 */
-void CompListExpr2 (
+static void CompListExpr2 (
     CVar                list,
     Expr                expr )
 {
@@ -2607,7 +2607,7 @@ void CompListExpr2 (
 **
 *F  CompRangeExpr( <expr> ) . . . . . . . . . . . . . . . . . .  T_RANGE_EXPR
 */
-CVar CompRangeExpr (
+static CVar CompRangeExpr (
     Expr                expr )
 {
     CVar                range;          /* range, result                   */
@@ -2663,7 +2663,7 @@ CVar CompRangeExpr (
 **
 *F  CompStringExpr( <expr> )  . . . . . . . . . . compile a string expression
 */
-CVar CompStringExpr (
+static CVar CompStringExpr (
     Expr                expr )
 {
     CVar                string;         /* string value, result            */
@@ -2690,7 +2690,7 @@ CVar CompStringExpr (
 **
 *F  CompRecExpr( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REC_EXPR
 */
-CVar CompRecExpr (
+static CVar CompRecExpr (
     Expr                expr )
 {
     CVar                rec;            /* record value, result            */
@@ -2708,7 +2708,7 @@ CVar CompRecExpr (
 **
 *F  CompRecTildeExpr( <expr> )  . . . . . . . . . . . . . .  T_REC_TILDE_EXPR
 */
-CVar CompRecTildeExpr (
+static CVar CompRecTildeExpr (
     Expr                expr )
 {
     CVar                rec;            /* record value, result            */
@@ -2740,7 +2740,7 @@ CVar CompRecTildeExpr (
 **
 *F  CompRecExpr1( <expr> )  . . . . . . . . . . . . . . . . . . . . . . local
 */
-CVar CompRecExpr1 (
+static CVar CompRecExpr1 (
     Expr                expr )
 {
     CVar                rec;            /* record value, result            */
@@ -2767,7 +2767,7 @@ CVar CompRecExpr1 (
 **
 *F  CompRecExpr2( <rec>, <expr> ) . . . . . . . . . . . . . . . . . . . local
 */
-void            CompRecExpr2 (
+static void            CompRecExpr2 (
     CVar                rec,
     Expr                expr )
 {
@@ -2837,7 +2837,7 @@ void            CompRecExpr2 (
 **
 *F  CompRefLVar( <expr> ) . . . . . . .  T_REFLVAR
 */
-CVar CompRefLVar (
+static CVar CompRefLVar (
     Expr                expr )
 {
     CVar                val;            /* value, result                   */
@@ -2866,7 +2866,7 @@ CVar CompRefLVar (
 **
 *F  CompIsbLVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_LVAR
 */
-CVar CompIsbLVar (
+static CVar CompIsbLVar (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -2906,7 +2906,7 @@ CVar CompIsbLVar (
 **
 *F  CompRefHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REF_HVAR
 */
-CVar CompRefHVar (
+static CVar CompRefHVar (
     Expr                expr )
 {
     CVar                val;            /* value, result                   */
@@ -2935,7 +2935,7 @@ CVar CompRefHVar (
 **
 *F  CompIsbHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_HVAR
 */
-CVar CompIsbHVar (
+static CVar CompIsbHVar (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -2972,7 +2972,7 @@ CVar CompIsbHVar (
 **
 *F  CompRefGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REF_GVAR
 */
-CVar CompRefGVar (
+static CVar CompRefGVar (
     Expr                expr )
 {
     CVar                val;            /* value, result                   */
@@ -3000,7 +3000,7 @@ CVar CompRefGVar (
 **
 *F  CompRefGVarFopy( <expr> ) . . . . . . . . . . . . . . . . . . . . . local
 */
-CVar CompRefGVarFopy (
+static CVar CompRefGVarFopy (
     Expr                expr )
 {
     CVar                val;            /* value, result                   */
@@ -3028,7 +3028,7 @@ CVar CompRefGVarFopy (
 **
 *F  CompIsbGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_GVAR
 */
-CVar CompIsbGVar (
+static CVar CompIsbGVar (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3064,7 +3064,7 @@ CVar CompIsbGVar (
 **
 *F  CompElmList( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ELM_LIST
 */
-CVar CompElmList (
+static CVar CompElmList (
     Expr                expr )
 {
     CVar                elm;            /* element, result                 */
@@ -3111,7 +3111,7 @@ CVar CompElmList (
 **
 *F  CompElmsList( <expr> )  . . . . . . . . . . . . . . . . . . . T_ELMS_LIST
 */
-CVar CompElmsList (
+static CVar CompElmsList (
     Expr                expr )
 {
     CVar                elms;           /* elements, result                */
@@ -3146,7 +3146,7 @@ CVar CompElmsList (
 **
 *F  CompElmListLev( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_LIST_LEV
 */
-CVar CompElmListLev (
+static CVar CompElmListLev (
     Expr                expr )
 {
     CVar                lists;          /* lists                           */
@@ -3178,7 +3178,7 @@ CVar CompElmListLev (
 **
 *F  CompElmsListLev( <expr> ) . . . . . . . . . . . . . . . . T_ELMS_LIST_LEV
 */
-CVar CompElmsListLev (
+static CVar CompElmsListLev (
     Expr                expr )
 {
     CVar                lists;          /* lists                           */
@@ -3209,7 +3209,7 @@ CVar CompElmsListLev (
 **
 *F  CompIsbList( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_LIST
 */
-CVar CompIsbList (
+static CVar CompIsbList (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3245,7 +3245,7 @@ CVar CompIsbList (
 **
 *F  CompElmRecName( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_REC_NAME
 */
-CVar CompElmRecName (
+static CVar CompElmRecName (
     Expr                expr )
 {
     CVar                elm;            /* element, result                 */
@@ -3280,7 +3280,7 @@ CVar CompElmRecName (
 **
 *F  CompElmRecExpr( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_REC_EXPR
 */
-CVar CompElmRecExpr (
+static CVar CompElmRecExpr (
     Expr                expr )
 {
     CVar                elm;            /* element, result                 */
@@ -3315,7 +3315,7 @@ CVar CompElmRecExpr (
 **
 *F  CompIsbRecName( <expr> )  . . . . . . . . . . . . . . . .  T_ISB_REC_NAME
 */
-CVar CompIsbRecName (
+static CVar CompIsbRecName (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3351,7 +3351,7 @@ CVar CompIsbRecName (
 **
 *F  CompIsbRecExpr( <expr> )  . . . . . . . . . . . . . . . .  T_ISB_REC_EXPR
 */
-CVar CompIsbRecExpr (
+static CVar CompIsbRecExpr (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3387,7 +3387,7 @@ CVar CompIsbRecExpr (
 **
 *F  CompElmPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ELM_POSOBJ
 */
-CVar CompElmPosObj (
+static CVar CompElmPosObj (
     Expr                expr )
 {
     CVar                elm;            /* element, result                 */
@@ -3423,7 +3423,7 @@ CVar CompElmPosObj (
 **
 *F  CompIsbPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ISB_POSOBJ
 */
-CVar CompIsbPosObj (
+static CVar CompIsbPosObj (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3459,7 +3459,7 @@ CVar CompIsbPosObj (
 **
 *F  CompElmObjName( <expr> )  . . . . . . . . . . . . . . . T_ELM_COMOBJ_NAME
 */
-CVar CompElmComObjName (
+static CVar CompElmComObjName (
     Expr                expr )
 {
     CVar                elm;            /* element, result                 */
@@ -3495,7 +3495,7 @@ CVar CompElmComObjName (
 **
 *F  CompElmComObjExpr( <expr> ) . . . . . . . . . . . . . . T_ELM_COMOBJ_EXPR
 */
-CVar CompElmComObjExpr (
+static CVar CompElmComObjExpr (
     Expr                expr )
 {
     CVar                elm;            /* element, result                 */
@@ -3530,7 +3530,7 @@ CVar CompElmComObjExpr (
 **
 *F  CompIsbComObjName( <expr> ) . . . . . . . . . . . . . . T_ISB_COMOBJ_NAME
 */
-CVar CompIsbComObjName (
+static CVar CompIsbComObjName (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3566,7 +3566,7 @@ CVar CompIsbComObjName (
 **
 *F  CompIsbComObjExpr( <expr> ) . . . . . . . . . . . . . . T_ISB_COMOBJ_EXPR
 */
-CVar CompIsbComObjExpr (
+static CVar CompIsbComObjExpr (
     Expr                expr )
 {
     CVar                isb;            /* isbound, result                 */
@@ -3610,9 +3610,9 @@ CVar CompIsbComObjExpr (
 **
 **  'CompStat' compiles the statement <stat>.
 */
-void (* CompStatFuncs[256]) ( Stat stat );
+static void (* CompStatFuncs[256]) ( Stat stat );
 
-void CompStat (
+static void CompStat (
     Stat                stat )
 {
     (* CompStatFuncs[ TNUM_STAT(stat) ])( stat );
@@ -3623,7 +3623,7 @@ void CompStat (
 **
 *F  CompUnknownStat( <stat> ) . . . . . . . . . . . . . . . . signal an error
 */
-void CompUnknownStat (
+static void CompUnknownStat (
     Stat                stat )
 {
     Emit( "CANNOT COMPILE STATEMENT OF TNUM %d;\n", TNUM_STAT(stat) );
@@ -3634,14 +3634,14 @@ void CompUnknownStat (
 **
 *V  G_Add . . . . . . . . . . . . . . . . . . . . . . . . . .  function 'Add'
 */
-GVar G_Add;
+static GVar G_Add;
 
 
 /****************************************************************************
 **
 *F  CompProccall0to6Args( <stat> )  . . . T_PROCCALL_0ARGS...T_PROCCALL_6ARGS
 */
-void CompProccall0to6Args (
+static void CompProccall0to6Args (
     Stat                stat )
 {
     CVar                func;           /* function                        */
@@ -3706,7 +3706,7 @@ void CompProccall0to6Args (
 **
 *F  CompProccallXArgs . . . . . . . . . . . . . . . . . . .  T_PROCCALL_XARGS
 */
-void CompProccallXArgs (
+static void CompProccallXArgs (
     Stat                stat )
 {
     CVar                func;           /* function                        */
@@ -3755,7 +3755,7 @@ void CompProccallXArgs (
 **
 *F  CompProccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_PROCCALL_OPTS
 */
-void CompProccallOpts(
+static void CompProccallOpts(
                       Stat stat)
 {
   CVar opts = CompExpr(READ_STAT(stat, 0));
@@ -3776,7 +3776,7 @@ void CompProccallOpts(
 **
 *F  CompSeqStat( <stat> ) . . . . . . . . . . . . .  T_SEQ_STAT...T_SEQ_STAT7
 */
-void CompSeqStat (
+static void CompSeqStat (
     Stat                stat )
 {
     UInt                nr;             /* number of statements            */
@@ -3796,7 +3796,7 @@ void CompSeqStat (
 **
 *F  CompIf( <stat> )  . . . . . . . . T_IF/T_IF_ELSE/T_IF_ELIF/T_IF_ELIF_ELSE
 */
-void CompIf (
+static void CompIf (
     Stat                stat )
 {
     CVar                cond;           /* condition                       */
@@ -3931,7 +3931,7 @@ void CompIf (
 **
 *F  CompFor( <stat> ) . . . . . . . T_FOR...T_FOR3/T_FOR_RANGE...T_FOR_RANGE3
 */
-void CompFor (
+static void CompFor (
     Stat                stat )
 {
     UInt                var;            /* loop variable                   */
@@ -4171,7 +4171,7 @@ void CompFor (
 **
 *F  CompWhile( <stat> ) . . . . . . . . . . . . . . . . .  T_WHILE...T_WHILE3
 */
-void CompWhile (
+static void CompWhile (
     Stat                stat )
 {
     CVar                cond;           /* condition                       */
@@ -4229,7 +4229,7 @@ void CompWhile (
 **
 *F  CompRepeat( <stat> )  . . . . . . . . . . . . . . .  T_REPEAT...T_REPEAT3
 */
-void CompRepeat (
+static void CompRepeat (
     Stat                stat )
 {
     CVar                cond;           /* condition                       */
@@ -4290,7 +4290,7 @@ void CompRepeat (
 **
 *F  CompBreak( <stat> ) . . . . . . . . . . . . . . . . . . . . . . . T_BREAK
 */
-void CompBreak (
+static void CompBreak (
     Stat                stat )
 {
     /* print a comment                                                     */
@@ -4305,7 +4305,7 @@ void CompBreak (
 **
 *F  CompContinue( <stat> ) . . . . . . . . . . . . . . . . . . . . T_CONTINUE
 */
-void CompContinue (
+static void CompContinue (
     Stat                stat )
 {
     /* print a comment                                                     */
@@ -4321,7 +4321,7 @@ void CompContinue (
 **
 *F  CompReturnObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_RETURN_OBJ
 */
-void CompReturnObj (
+static void CompReturnObj (
     Stat                stat )
 {
     CVar                obj;            /* returned object                 */
@@ -4349,7 +4349,7 @@ void CompReturnObj (
 **
 *F  CompReturnVoid( <stat> )  . . . . . . . . . . . . . . . . . T_RETURN_VOID
 */
-void CompReturnVoid (
+static void CompReturnVoid (
     Stat                stat )
 {
     /* print a comment                                                     */
@@ -4369,7 +4369,7 @@ void CompReturnVoid (
 **
 *F  CompAssLVar( <stat> ) . . . . . . . . . . . .  T_ASS_LVAR...T_ASS_LVAR_16
 */
-void            CompAssLVar (
+static void            CompAssLVar (
     Stat                stat )
 {
     LVar                lvar;           /* local variable                  */
@@ -4402,7 +4402,7 @@ void            CompAssLVar (
 **
 *F  CompUnbLVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_LVAR
 */
-void CompUnbLVar (
+static void CompUnbLVar (
     Stat                stat )
 {
     LVar                lvar;           /* local variable                  */
@@ -4428,7 +4428,7 @@ void CompUnbLVar (
 **
 *F  CompAssHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_HVAR
 */
-void CompAssHVar (
+static void CompAssHVar (
     Stat                stat )
 {
     HVar                hvar;           /* higher variable                 */
@@ -4457,7 +4457,7 @@ void CompAssHVar (
 **
 *F  CompUnbHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_HVAR
 */
-void CompUnbHVar (
+static void CompUnbHVar (
     Stat                stat )
 {
     HVar                hvar;           /* higher variable                 */
@@ -4479,7 +4479,7 @@ void CompUnbHVar (
 **
 *F  CompAssGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_GVAR
 */
-void CompAssGVar (
+static void CompAssGVar (
     Stat                stat )
 {
     GVar                gvar;           /* global variable                 */
@@ -4507,7 +4507,7 @@ void CompAssGVar (
 **
 *F  CompUnbGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_GVAR
 */
-void            CompUnbGVar (
+static void            CompUnbGVar (
     Stat                stat )
 {
     GVar                gvar;           /* global variable                 */
@@ -4528,7 +4528,7 @@ void            CompUnbGVar (
 **
 *F  CompAssList( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_LIST
 */
-void CompAssList (
+static void CompAssList (
     Stat                stat )
 {
     CVar                list;           /* list                            */
@@ -4574,7 +4574,7 @@ void CompAssList (
 **
 *F  CompAsssList( <stat> )  . . . . . . . . . . . . . . . . . . . T_ASSS_LIST
 */
-void CompAsssList (
+static void CompAsssList (
     Stat                stat )
 {
     CVar                list;           /* list                            */
@@ -4609,7 +4609,7 @@ void CompAsssList (
 **
 *F  CompAssListLev( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_LIST_LEV
 */
-void CompAssListLev (
+static void CompAssListLev (
     Stat                stat )
 {
     CVar                lists;          /* lists                           */
@@ -4649,7 +4649,7 @@ void CompAssListLev (
 **
 *F  CompAsssListLev( <stat> ) . . . . . . . . . . . . . . . . T_ASSS_LIST_LEV
 */
-void CompAsssListLev (
+static void CompAsssListLev (
     Stat                stat )
 {
     CVar                lists;          /* list                            */
@@ -4689,7 +4689,7 @@ void CompAsssListLev (
 **
 *F  CompUnbList( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_LIST
 */
-void CompUnbList (
+static void CompUnbList (
     Stat                stat )
 {
     CVar                list;           /* list, left operand              */
@@ -4720,7 +4720,7 @@ void CompUnbList (
 **
 *F  CompAssRecName( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_REC_NAME
 */
-void CompAssRecName (
+static void CompAssRecName (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -4755,7 +4755,7 @@ void CompAssRecName (
 **
 *F  CompAssRecExpr( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_REC_EXPR
 */
-void CompAssRecExpr (
+static void CompAssRecExpr (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -4790,7 +4790,7 @@ void CompAssRecExpr (
 **
 *F  CompUnbRecName( <stat> )  . . . . . . . . . . . . . . . .  T_UNB_REC_NAME
 */
-void CompUnbRecName (
+static void CompUnbRecName (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -4820,7 +4820,7 @@ void CompUnbRecName (
 **
 *F  CompUnbRecExpr( <stat> )  . . . . . . . . . . . . . . . .  T_UNB_REC_EXPR
 */
-void            CompUnbRecExpr (
+static void            CompUnbRecExpr (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -4850,7 +4850,7 @@ void            CompUnbRecExpr (
 **
 *F  CompAssPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASS_POSOBJ
 */
-void CompAssPosObj (
+static void CompAssPosObj (
     Stat                stat )
 {
     CVar                list;           /* list                            */
@@ -4886,7 +4886,7 @@ void CompAssPosObj (
 **
 *F  CompUnbPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_UNB_POSOBJ
 */
-void CompUnbPosObj (
+static void CompUnbPosObj (
     Stat                stat )
 {
     CVar                list;           /* list, left operand              */
@@ -4917,7 +4917,7 @@ void CompUnbPosObj (
 **
 *F  CompAssComObjName( <stat> ) . . . . . . . . . . . . . . T_ASS_COMOBJ_NAME
 */
-void CompAssComObjName (
+static void CompAssComObjName (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -4952,7 +4952,7 @@ void CompAssComObjName (
 **
 *F  CompAssComObjExpr( <stat> ) . . . . . . . . . . . . . . T_ASS_COMOBJ_EXPR
 */
-void CompAssComObjExpr (
+static void CompAssComObjExpr (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -4987,7 +4987,7 @@ void CompAssComObjExpr (
 **
 *F  CompUnbComObjName( <stat> ) . . . . . . . . . . . . . . T_UNB_COMOBJ_NAME
 */
-void CompUnbComObjName (
+static void CompUnbComObjName (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -5017,7 +5017,7 @@ void CompUnbComObjName (
 **
 *F  CompUnbComObjExpr( <stat> ) . . . . . . . . . . . . . . T_UNB_COMOBJ_EXPR
 */
-void CompUnbComObjExpr (
+static void CompUnbComObjExpr (
     Stat                stat )
 {
     CVar                record;         /* record, left operand            */
@@ -5047,7 +5047,7 @@ void CompUnbComObjExpr (
 **
 *F  CompEmpty( <stat> )  . . . . . . . . . . . . . . . . . . . . . . . T_EMPY
 */
-void CompEmpty (
+static void CompEmpty (
     Stat                stat )
 {
     // do nothing
@@ -5057,7 +5057,7 @@ void CompEmpty (
 **
 *F  CompInfo( <stat> )  . . . . . . . . . . . . . . . . . . . . . . .  T_INFO
 */
-void CompInfo (
+static void CompInfo (
     Stat                stat )
 {
     CVar                tmp;
@@ -5098,7 +5098,7 @@ void CompInfo (
 **
 *F  CompAssert2( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASSERT_2ARGS
 */
-void CompAssert2 (
+static void CompAssert2 (
     Stat                stat )
 {
     CVar                lev;            /* the level                       */
@@ -5124,7 +5124,7 @@ void CompAssert2 (
 **
 *F  CompAssert3( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASSERT_3ARGS
 */
-void CompAssert3 (
+static void CompAssert3 (
     Stat                stat )
 {
     CVar                lev;            /* the level                       */
@@ -5164,9 +5164,9 @@ void CompAssert3 (
 **  'CompFunc' compiles the function <func>, i.e., it emits  the code for the
 **  handler of the function <func> and the handlers of all its subfunctions.
 */
-Obj CompFunctions;
+static Obj CompFunctions;
 
-void CompFunc (
+static void CompFunc (
     Obj                 func )
 {
     Bag                 info;           /* info bag for this function      */
@@ -5512,7 +5512,7 @@ Int CompileFunc (
 **
 *F  FuncCOMPILE_FUNC( <self>, <output>, <func>, <name>, <magic1>, <magic2> )
 */
-Obj FuncCOMPILE_FUNC (
+static Obj FuncCOMPILE_FUNC (
     Obj                 self,
     Obj                 arg )
 {

--- a/src/costab.c
+++ b/src/costab.c
@@ -89,10 +89,9 @@ static void CleanOut( void )
 **
 **  ... more about ApplyRel ...
 */
-static Obj FuncApplyRel (
-    Obj                 self,
-    Obj                 app,            /* handle of the application list  */
-    Obj                 rel )           /* handle of the relator           */
+static Obj FuncApplyRel(Obj self,
+                        Obj app, /* handle of the application list  */
+                        Obj rel) /* handle of the relator           */
 {
     
     Int                 lp;             /* left pointer into relator       */
@@ -370,9 +369,7 @@ static void HandleCoinc (
 **
 *F  FuncMakeConsequences( <self>, <list> )  find consqs of a coset definition
 */
-static Obj FuncMakeConsequences (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncMakeConsequences(Obj self, Obj list)
 {
     Obj                 hdSubs;         /*                                 */
     Obj                 objRels;        /*                                 */
@@ -552,9 +549,7 @@ static Obj FuncMakeConsequences (
 **  This  is a  special version  of  `FuncMakeConsequences'  for the subgroup
 **  presentation routines.
 */
-static Obj FuncMakeConsequencesPres (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncMakeConsequencesPres(Obj self, Obj list)
 {
     Obj                 objDefs1;       /* handle of defs list part 1      */
     Obj                 objDefs2;       /* handle of defs list part 2      */
@@ -665,10 +660,7 @@ static Obj FuncMakeConsequencesPres (
 **  If  not  <stan> = 1  the table  is standardized  using the  (new)  lenlex
 **  standard (this is the default).
 */
-static Obj FuncStandardizeTableC (
-    Obj                 self,
-    Obj                 table,
-    Obj                 stan )
+static Obj FuncStandardizeTableC(Obj self, Obj table, Obj stan)
 {
     Obj *               ptTable;        /* pointer to table                */
     UInt                nrgen;          /* number of rows of the table / 2 */
@@ -1096,11 +1088,7 @@ static void AddCosetFactor2 (
 **
 **  ...more about ApplyRel2...
 */
-static Obj FuncApplyRel2 (
-    Obj                 self,
-    Obj                 app,
-    Obj                 rel,
-    Obj                 nums )
+static Obj FuncApplyRel2(Obj self, Obj app, Obj rel, Obj nums)
 {
     Obj *               ptApp;          /* pointer to that list            */
     Obj                 word;           /* handle of resulting word        */
@@ -1351,9 +1339,7 @@ static Obj FuncApplyRel2 (
 **  'FuncCopyRel' returns a copy  of the given RRS  relator such that the bag
 **  of the copy does not exceed the minimal required size.
 */
-static Obj FuncCopyRel ( 
-    Obj                 self,
-    Obj                 rel )           /* the given relator               */
+static Obj FuncCopyRel(Obj self, Obj rel) /* the given relator */
 {
     Obj *               ptRel;          /* pointer to the given relator    */
     Obj                 copy;           /* the copy                        */
@@ -1389,9 +1375,7 @@ static Obj FuncCopyRel (
 **  routines.  It replaces the given relator by its canonical representative.
 **  It does not return anything.
 */
-static Obj FuncMakeCanonical (
-    Obj                 self,
-    Obj                 rel )           /* the given relator               */
+static Obj FuncMakeCanonical(Obj self, Obj rel) /* the given relator */
 {
     Obj *               ptRel;          /* pointer to the relator          */
     Obj                 obj1,  obj2;    /* handles 0f relator entries      */
@@ -1545,10 +1529,7 @@ static Obj FuncMakeCanonical (
 **  in the  current generators, if  it finds any, or it  defines a new proper
 **  tree entry, and then returns it.
 */
-static Obj FuncTreeEntry(
-    Obj                 self,
-    Obj                 tree,
-    Obj                 word )
+static Obj FuncTreeEntry(Obj self, Obj tree, Obj word)
 {
     Obj *               ptTree1;        /* pointer to that component       */
     Obj *               ptTree2;        /* pointer to that component       */
@@ -1815,11 +1796,7 @@ static Obj FuncTreeEntry(
 **  If  not  <stan> = 1  the table  is standardized  using the  (new)  lenlex
 **  standard (this is the default).
 */
-static Obj FuncStandardizeTable2C (
-    Obj                 self,
-    Obj                 table,
-    Obj                 table2,
-    Obj                 stan )
+static Obj FuncStandardizeTable2C(Obj self, Obj table, Obj table2, Obj stan)
 {
     Obj *               ptTable;        /* pointer to table                */
     Obj *               ptTabl2;        /* pointer to coset factor table   */
@@ -1939,10 +1916,9 @@ static Obj FuncStandardizeTable2C (
 **
 **  'FuncAddAbelianRelator' implements 'AddAbelianRelator(<rels>,<number>)'
 */
-static Obj FuncAddAbelianRelator (
-    Obj                 self,
-    Obj                 rels,           /* relators list                   */
-    Obj                 number )
+static Obj FuncAddAbelianRelator(Obj self,
+                                 Obj rels, /* relators list */
+                                 Obj number)
 {
     Obj *               ptRels;         /* pointer to relators list        */
     Obj *               pt1;            /* pointer to a relator            */
@@ -2018,12 +1994,9 @@ static Obj FuncAddAbelianRelator (
 
 /* new type functions that use different data structures */
 
-static UInt ret1,ret2;
+static UInt ret1, ret2;
 
-static UInt RelatorScan (
-  Obj t,
-  UInt di,
-  Obj r )
+static UInt RelatorScan(Obj t, UInt di, Obj r)
 {
     UInt  m,i,p,a,j;
     UInt  pa=0,pb=0;
@@ -2100,12 +2073,11 @@ static Obj TYPE_LOWINDEX_DATA;
 *F  FuncLOWINDEX_COSET_SCAN( <t>,<r>,<s1>,<s2>)
 **
 */
-static Obj FuncLOWINDEX_COSET_SCAN (
-    Obj                 self,
-    Obj                 t,              /* table */
-    Obj                 r,              /* relators */
-    Obj                 s1,             /* stack */
-    Obj                 s2 )            /* stack */
+static Obj FuncLOWINDEX_COSET_SCAN(Obj self,
+                                   Obj t,  /* table */
+                                   Obj r,  /* relators */
+                                   Obj s1, /* stack */
+                                   Obj s2) /* stack */
 {
   UInt ok,i,j,d,e,x,y,l,sd;
   Obj  rx;
@@ -2187,12 +2159,11 @@ static Obj FuncLOWINDEX_COSET_SCAN (
 *F  FuncLOWINDEX_IS_FIRST( <t>,<n>,<mu>,<nu>)
 **
 */
-static Obj FuncLOWINDEX_IS_FIRST (
-    Obj                 self,
-    Obj                 t,              /* table */
-    Obj                 nobj,              /* relators */
-    Obj                 muo,             /* stack */
-    Obj                 nuo )            /* stack */
+static Obj FuncLOWINDEX_IS_FIRST(Obj self,
+                                 Obj t,    /* table */
+                                 Obj nobj, /* relators */
+                                 Obj muo,  /* stack */
+                                 Obj nuo)  /* stack */
 {
   UInt l,ok,b,g,ga,de,a,n,mm;
   UInt * mu;
@@ -2245,9 +2216,7 @@ static Obj FuncLOWINDEX_IS_FIRST (
 *F  FuncLOWINDEX_PREPARE_RELS( <rels> )
 **
 */
-static Obj FuncLOWINDEX_PREPARE_RELS (
-    Obj                 self,
-    Obj                 r )             /* rels */
+static Obj FuncLOWINDEX_PREPARE_RELS(Obj self, Obj r) /* rels */
 {
    UInt i,j,k,l;
    Obj ri, rel;
@@ -2274,13 +2243,12 @@ static Obj FuncLOWINDEX_PREPARE_RELS (
 *F  FuncTC_QUICK_SCAN( <c>,<o>,<alpha>,<w>)
 **
 */
-static Obj FuncTC_QUICK_SCAN (
-    Obj                 self,
-    Obj                 c,              /* table */
-    Obj                 o,              /* offset */
-    Obj                 a,              /* alpha */
-    Obj                 w,              /* word */
-    Obj                 result )        /* result list */
+static Obj FuncTC_QUICK_SCAN(Obj self,
+                             Obj c,      /* table */
+                             Obj o,      /* offset */
+                             Obj a,      /* alpha */
+                             Obj w,      /* word */
+                             Obj result) /* result list */
 {
   Int f,b,ff,bb,r,i,j,alpha,offset;
 

--- a/src/costab.c
+++ b/src/costab.c
@@ -89,7 +89,7 @@ static void CleanOut( void )
 **
 **  ... more about ApplyRel ...
 */
-Obj FuncApplyRel (
+static Obj FuncApplyRel (
     Obj                 self,
     Obj                 app,            /* handle of the application list  */
     Obj                 rel )           /* handle of the relator           */
@@ -370,7 +370,7 @@ static void HandleCoinc (
 **
 *F  FuncMakeConsequences( <self>, <list> )  find consqs of a coset definition
 */
-Obj FuncMakeConsequences (
+static Obj FuncMakeConsequences (
     Obj                 self,
     Obj                 list )
 {
@@ -552,7 +552,7 @@ Obj FuncMakeConsequences (
 **  This  is a  special version  of  `FuncMakeConsequences'  for the subgroup
 **  presentation routines.
 */
-Obj FuncMakeConsequencesPres (
+static Obj FuncMakeConsequencesPres (
     Obj                 self,
     Obj                 list )
 {
@@ -665,7 +665,7 @@ Obj FuncMakeConsequencesPres (
 **  If  not  <stan> = 1  the table  is standardized  using the  (new)  lenlex
 **  standard (this is the default).
 */
-Obj FuncStandardizeTableC (
+static Obj FuncStandardizeTableC (
     Obj                 self,
     Obj                 table,
     Obj                 stan )
@@ -1096,7 +1096,7 @@ static void AddCosetFactor2 (
 **
 **  ...more about ApplyRel2...
 */
-Obj FuncApplyRel2 (
+static Obj FuncApplyRel2 (
     Obj                 self,
     Obj                 app,
     Obj                 rel,
@@ -1351,7 +1351,7 @@ Obj FuncApplyRel2 (
 **  'FuncCopyRel' returns a copy  of the given RRS  relator such that the bag
 **  of the copy does not exceed the minimal required size.
 */
-Obj FuncCopyRel ( 
+static Obj FuncCopyRel ( 
     Obj                 self,
     Obj                 rel )           /* the given relator               */
 {
@@ -1389,7 +1389,7 @@ Obj FuncCopyRel (
 **  routines.  It replaces the given relator by its canonical representative.
 **  It does not return anything.
 */
-Obj FuncMakeCanonical (
+static Obj FuncMakeCanonical (
     Obj                 self,
     Obj                 rel )           /* the given relator               */
 {
@@ -1545,7 +1545,7 @@ Obj FuncMakeCanonical (
 **  in the  current generators, if  it finds any, or it  defines a new proper
 **  tree entry, and then returns it.
 */
-Obj FuncTreeEntry(
+static Obj FuncTreeEntry(
     Obj                 self,
     Obj                 tree,
     Obj                 word )
@@ -1815,7 +1815,7 @@ Obj FuncTreeEntry(
 **  If  not  <stan> = 1  the table  is standardized  using the  (new)  lenlex
 **  standard (this is the default).
 */
-Obj FuncStandardizeTable2C (
+static Obj FuncStandardizeTable2C (
     Obj                 self,
     Obj                 table,
     Obj                 table2,
@@ -1939,7 +1939,7 @@ Obj FuncStandardizeTable2C (
 **
 **  'FuncAddAbelianRelator' implements 'AddAbelianRelator(<rels>,<number>)'
 */
-Obj FuncAddAbelianRelator (
+static Obj FuncAddAbelianRelator (
     Obj                 self,
     Obj                 rels,           /* relators list                   */
     Obj                 number )
@@ -2018,9 +2018,9 @@ Obj FuncAddAbelianRelator (
 
 /* new type functions that use different data structures */
 
-UInt ret1,ret2;
+static UInt ret1,ret2;
 
-UInt RelatorScan (
+static UInt RelatorScan (
   Obj t,
   UInt di,
   Obj r )
@@ -2093,14 +2093,14 @@ UInt RelatorScan (
 }
 
 /* data object type for the mangled relators */
-Obj TYPE_LOWINDEX_DATA;
+static Obj TYPE_LOWINDEX_DATA;
 
 /****************************************************************************
 **
 *F  FuncLOWINDEX_COSET_SCAN( <t>,<r>,<s1>,<s2>)
 **
 */
-Obj FuncLOWINDEX_COSET_SCAN (
+static Obj FuncLOWINDEX_COSET_SCAN (
     Obj                 self,
     Obj                 t,              /* table */
     Obj                 r,              /* relators */
@@ -2187,7 +2187,7 @@ Obj FuncLOWINDEX_COSET_SCAN (
 *F  FuncLOWINDEX_IS_FIRST( <t>,<n>,<mu>,<nu>)
 **
 */
-Obj FuncLOWINDEX_IS_FIRST (
+static Obj FuncLOWINDEX_IS_FIRST (
     Obj                 self,
     Obj                 t,              /* table */
     Obj                 nobj,              /* relators */
@@ -2245,7 +2245,7 @@ Obj FuncLOWINDEX_IS_FIRST (
 *F  FuncLOWINDEX_PREPARE_RELS( <rels> )
 **
 */
-Obj FuncLOWINDEX_PREPARE_RELS (
+static Obj FuncLOWINDEX_PREPARE_RELS (
     Obj                 self,
     Obj                 r )             /* rels */
 {
@@ -2274,7 +2274,7 @@ Obj FuncLOWINDEX_PREPARE_RELS (
 *F  FuncTC_QUICK_SCAN( <c>,<o>,<alpha>,<w>)
 **
 */
-Obj FuncTC_QUICK_SCAN (
+static Obj FuncTC_QUICK_SCAN (
     Obj                 self,
     Obj                 c,              /* table */
     Obj                 o,              /* offset */

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -194,7 +194,7 @@ extern inline struct CycModuleState *CycState(void)
 #define LastNCyc    CycState()->LastNCyc
 
 
-void GrowResultCyc(UInt size) {
+static void GrowResultCyc(UInt size) {
     Obj *res;
     UInt i;
     if (ResultCyc == 0) {
@@ -217,9 +217,9 @@ void GrowResultCyc(UInt size) {
 **
 **  'TypeCyc' is the function in 'TypeObjFuncs' for cyclotomics.
 */
-Obj             TYPE_CYC;
+static Obj             TYPE_CYC;
 
-Obj             TypeCyc (
+static Obj             TypeCyc (
     Obj                 cyc )
 {
     return TYPE_CYC;
@@ -235,7 +235,7 @@ Obj             TypeCyc (
 **  In principle this is very easy, but it is complicated because we  do  not
 **  want to print stuff like '+1*', '-1*', 'E(<n>)^0', 'E(<n>)^1, etc.
 */
-void            PrintCyc (
+static void            PrintCyc (
     Obj                 cyc )
 {
     UInt                n;              /* order of the field              */
@@ -317,7 +317,7 @@ void            PrintCyc (
 **  'EqCyc'  is  pretty  simple because   every    cyclotomic  has a   unique
 **  representation, so we just have to compare the terms.
 */
-Int             EqCyc (
+static Int             EqCyc (
     Obj                 opL,
     Obj                 opR )
 {
@@ -373,7 +373,7 @@ Int             EqCyc (
 **  'LtCyc'  is  pretty  simple because   every    cyclotomic  has a   unique
 **  representation, so we just have to compare the terms.
 */
-Int             LtCyc (
+static Int             LtCyc (
     Obj                 opL,
     Obj                 opR )
 {
@@ -419,14 +419,14 @@ Int             LtCyc (
         return 0L;
 }
 
-Int             LtCycYes (
+static Int             LtCycYes (
     Obj                 opL,
     Obj                 opR )
 {
     return 1L;
 }
 
-Int             LtCycNot (
+static Int             LtCycNot (
     Obj                 opL,
     Obj                 opR )
 {
@@ -489,7 +489,7 @@ Int             LtCycNot (
 **  Those divisions are quite expensive  on  some  processors, e.g., MIPS and
 **  SPARC, and they may singlehanded account for 20 percent of the runtime.
 */
-void            ConvertToBase (
+static void            ConvertToBase (
     UInt                n )
 {
     Obj *               res;            /* pointer to the result           */
@@ -629,7 +629,7 @@ void            ConvertToBase (
 **  combination of   linear  independent  roots,  they  would  work  also  if
 **  cyclotomic integers were written as polynomials in $e_n$.
 */
-Obj             Cyclotomic (
+static Obj             Cyclotomic (
     UInt                n,
     UInt                m )
 {
@@ -808,7 +808,7 @@ Obj             Cyclotomic (
 ** respectively.
 */
 
-UInt4 CyclotomicsLimit = 1000000;
+static UInt4 CyclotomicsLimit = 1000000;
 
 static UInt FindCommonField(UInt nl, UInt nr, UInt *ml, UInt *mr)
 {
@@ -856,7 +856,7 @@ static UInt FindCommonField(UInt nl, UInt nr, UInt *ml, UInt *mr)
   return n;
 }
 
-Obj FuncSetCyclotomicsLimit(Obj self, Obj newlimit)
+static Obj FuncSetCyclotomicsLimit(Obj self, Obj newlimit)
 {
     UInt ulimit = GetPositiveSmallInt("SetCyclotomicsLimit", newlimit);
 
@@ -876,7 +876,7 @@ Obj FuncSetCyclotomicsLimit(Obj self, Obj newlimit)
     return 0;
 }
 
-Obj FuncGetCyclotomicsLimit(Obj self)
+static Obj FuncGetCyclotomicsLimit(Obj self)
 {
     return INTOBJ_INT(CyclotomicsLimit);
 }
@@ -891,7 +891,7 @@ Obj FuncGetCyclotomicsLimit(Obj self)
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-Obj             SumCyc (
+static Obj             SumCyc (
     Obj                 opL,
     Obj                 opR )
 {
@@ -977,7 +977,7 @@ Obj             SumCyc (
 **
 **  'ZeroCyc' returns the additive neutral element of the cyclotomic <op>.
 */
-Obj             ZeroCyc (
+static Obj             ZeroCyc (
     Obj                 op )
 {
     return INTOBJ_INT( 0L );
@@ -990,7 +990,7 @@ Obj             ZeroCyc (
 **
 **  'AInvCyc' returns the additive inverse element of the cyclotomic <op>.
 */
-Obj             AInvCyc (
+static Obj             AInvCyc (
     Obj                 op )
 {
     Obj                 res;            /* inverse, result                 */
@@ -1042,7 +1042,7 @@ Obj             AInvCyc (
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-Obj             DiffCyc (
+static Obj             DiffCyc (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1131,7 +1131,7 @@ Obj             DiffCyc (
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-Obj             ProdCycInt (
+static Obj             ProdCycInt (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1227,7 +1227,7 @@ Obj             ProdCycInt (
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-Obj             ProdCyc (
+static Obj             ProdCyc (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1360,7 +1360,7 @@ Obj             ProdCyc (
 **  'OneCyc'  returns  the multiplicative neutral  element  of the cyclotomic
 **  <op>.
 */
-Obj             OneCyc (
+static Obj             OneCyc (
     Obj                 op )
 {
     return INTOBJ_INT( 1L );
@@ -1381,7 +1381,7 @@ Obj             OneCyc (
 **  can compute the quotient $prd / (op * prd)$ with 'ProdCycInt'.
 *T better multiply only the *different* conjugates?
 */
-Obj             InvCyc (
+static Obj             InvCyc (
     Obj                 op )
 {
     Obj                 prd;            /* product of conjugates           */
@@ -1441,7 +1441,7 @@ Obj             InvCyc (
 **  'PowCyc' returns the <opR>th, which must be  an  integer,  power  of  the
 **  cyclotomic <opL>.  The left operand may also be an integer or a rational.
 */
-Obj             PowCyc (
+static Obj             PowCyc (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1521,9 +1521,9 @@ Obj             PowCyc (
 **  'E'  returns a  primitive  root of order <n>, which must  be  a  positive
 **  integer, represented as cyclotomic.
 */
-Obj EOper;
+static Obj EOper;
 
-Obj FuncE (
+static Obj FuncE (
     Obj                 self,
     Obj                 n )
 {
@@ -1570,9 +1570,9 @@ Obj FuncE (
 **  'IsCyc' returns 'true'  if the value <val> is   a cyclotomic and  'false'
 **  otherwise.
 */
-Obj IsCycFilt;
+static Obj IsCycFilt;
 
-Obj FuncIS_CYC (
+static Obj FuncIS_CYC (
     Obj                 self,
     Obj                 val )
 {
@@ -1601,9 +1601,9 @@ Obj FuncIS_CYC (
 **
 **  'IsCycInt' relies on the fact that the base is an integral base.
 */
-Obj IsCycIntOper;
+static Obj IsCycIntOper;
 
-Obj FuncIS_CYC_INT (
+static Obj FuncIS_CYC_INT (
     Obj                 self,
     Obj                 val )
 {
@@ -1647,9 +1647,9 @@ Obj FuncIS_CYC_INT (
 **  'Conductor' returns the N of the cyclotomic <cyc>, i.e., the order of the
 **  roots of which <cyc> is written as a linear combination.
 */
-Obj ConductorAttr;
+static Obj ConductorAttr;
 
-Obj FuncCONDUCTOR (
+static Obj FuncCONDUCTOR (
     Obj                 self,
     Obj                 cyc )
 {
@@ -1720,9 +1720,9 @@ Obj FuncCONDUCTOR (
 **  of which <cyc> is written as a linear combination.  The <i>th element  of
 **  the list is the coefficient of $e_l^{i-1}$.
 */
-Obj CoeffsCycOper;
+static Obj CoeffsCycOper;
 
-Obj FuncCOEFFS_CYC (
+static Obj FuncCOEFFS_CYC (
     Obj                 self,
     Obj                 cyc )
 {
@@ -1784,9 +1784,9 @@ Obj FuncCOEFFS_CYC (
 **  <ord> may be any integer, of course if it is not relative prime to  $ord$
 **  the mapping will not be an automorphism, though still an endomorphism.
 */
-Obj GaloisCycOper;
+static Obj GaloisCycOper;
 
-Obj FuncGALOIS_CYC (
+static Obj FuncGALOIS_CYC (
     Obj                 self,
     Obj                 cyc,
     Obj                 ord )
@@ -1960,9 +1960,9 @@ Obj FuncGALOIS_CYC (
 **  'CycList' returns the cyclotomic described by the list <list>
 **  of rationals.
 */
-Obj CycListOper;
+static Obj CycListOper;
 
-Obj FuncCycList (
+static Obj FuncCycList (
     Obj                 self,
     Obj                 list )
 {
@@ -2012,7 +2012,7 @@ Obj FuncCycList (
 **
 **  'MarkCycSubBags' is the marking function for bags of type 'T_CYC'.
 */
-void MarkCycSubBags( Obj cyc )
+static void MarkCycSubBags( Obj cyc )
 {
     MarkArrayOfBags( COEFS_CYC( cyc ), SIZE_CYC(cyc) );
 }
@@ -2024,7 +2024,7 @@ void MarkCycSubBags( Obj cyc )
 **
 **  We do not save the XXX_CYC field, since it is not used.
 */
-void  SaveCyc ( Obj cyc )
+static void  SaveCyc ( Obj cyc )
 {
   UInt len, i;
   const Obj *coefs;
@@ -2045,7 +2045,7 @@ void  SaveCyc ( Obj cyc )
 **
 **  We do not load the XXX_CYC field, since it is not used.
 */
-void  LoadCyc ( Obj cyc )
+static void  LoadCyc ( Obj cyc )
 {
   UInt len, i;
   Obj *coefs;

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -194,7 +194,8 @@ extern inline struct CycModuleState *CycState(void)
 #define LastNCyc    CycState()->LastNCyc
 
 
-static void GrowResultCyc(UInt size) {
+static void GrowResultCyc(UInt size)
+{
     Obj *res;
     UInt i;
     if (ResultCyc == 0) {
@@ -217,10 +218,9 @@ static void GrowResultCyc(UInt size) {
 **
 **  'TypeCyc' is the function in 'TypeObjFuncs' for cyclotomics.
 */
-static Obj             TYPE_CYC;
+static Obj TYPE_CYC;
 
-static Obj             TypeCyc (
-    Obj                 cyc )
+static Obj TypeCyc(Obj cyc)
 {
     return TYPE_CYC;
 }
@@ -235,8 +235,7 @@ static Obj             TypeCyc (
 **  In principle this is very easy, but it is complicated because we  do  not
 **  want to print stuff like '+1*', '-1*', 'E(<n>)^0', 'E(<n>)^1, etc.
 */
-static void            PrintCyc (
-    Obj                 cyc )
+static void PrintCyc(Obj cyc)
 {
     UInt                n;              /* order of the field              */
     UInt                len;            /* number of terms                 */
@@ -317,9 +316,7 @@ static void            PrintCyc (
 **  'EqCyc'  is  pretty  simple because   every    cyclotomic  has a   unique
 **  representation, so we just have to compare the terms.
 */
-static Int             EqCyc (
-    Obj                 opL,
-    Obj                 opR )
+static Int EqCyc(Obj opL, Obj opR)
 {
     UInt                len;            /* number of terms                 */
     const Obj *         cfl;            /* ptr to coeffs of left operand   */
@@ -373,9 +370,7 @@ static Int             EqCyc (
 **  'LtCyc'  is  pretty  simple because   every    cyclotomic  has a   unique
 **  representation, so we just have to compare the terms.
 */
-static Int             LtCyc (
-    Obj                 opL,
-    Obj                 opR )
+static Int LtCyc(Obj opL, Obj opR)
 {
     UInt                lel;            /* nr of terms of left operand     */
     const Obj *         cfl;            /* ptr to coeffs of left operand   */
@@ -419,16 +414,12 @@ static Int             LtCyc (
         return 0L;
 }
 
-static Int             LtCycYes (
-    Obj                 opL,
-    Obj                 opR )
+static Int LtCycYes(Obj opL, Obj opR)
 {
     return 1L;
 }
 
-static Int             LtCycNot (
-    Obj                 opL,
-    Obj                 opR )
+static Int LtCycNot(Obj opL, Obj opR)
 {
     return 0L;
 }
@@ -489,8 +480,7 @@ static Int             LtCycNot (
 **  Those divisions are quite expensive  on  some  processors, e.g., MIPS and
 **  SPARC, and they may singlehanded account for 20 percent of the runtime.
 */
-static void            ConvertToBase (
-    UInt                n )
+static void ConvertToBase(UInt n)
 {
     Obj *               res;            /* pointer to the result           */
     UInt                nn;             /* copy of n to factorize          */
@@ -629,9 +619,7 @@ static void            ConvertToBase (
 **  combination of   linear  independent  roots,  they  would  work  also  if
 **  cyclotomic integers were written as polynomials in $e_n$.
 */
-static Obj             Cyclotomic (
-    UInt                n,
-    UInt                m )
+static Obj Cyclotomic(UInt n, UInt m)
 {
     Obj                 cyc;            /* cyclotomic, result              */
     UInt                len;            /* number of terms                 */
@@ -891,9 +879,7 @@ static Obj FuncGetCyclotomicsLimit(Obj self)
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-static Obj             SumCyc (
-    Obj                 opL,
-    Obj                 opR )
+static Obj SumCyc(Obj opL, Obj opR)
 {
     UInt                nl, nr;         /* order of left and right field   */
     UInt                n;              /* order of smallest superfield    */
@@ -977,8 +963,7 @@ static Obj             SumCyc (
 **
 **  'ZeroCyc' returns the additive neutral element of the cyclotomic <op>.
 */
-static Obj             ZeroCyc (
-    Obj                 op )
+static Obj ZeroCyc(Obj op)
 {
     return INTOBJ_INT( 0L );
 }
@@ -990,8 +975,7 @@ static Obj             ZeroCyc (
 **
 **  'AInvCyc' returns the additive inverse element of the cyclotomic <op>.
 */
-static Obj             AInvCyc (
-    Obj                 op )
+static Obj AInvCyc(Obj op)
 {
     Obj                 res;            /* inverse, result                 */
     UInt                len;            /* number of terms                 */
@@ -1042,9 +1026,7 @@ static Obj             AInvCyc (
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-static Obj             DiffCyc (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffCyc(Obj opL, Obj opR)
 {
     UInt                nl, nr;         /* order of left and right field   */
     UInt                n;              /* order of smallest superfield    */
@@ -1131,9 +1113,7 @@ static Obj             DiffCyc (
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-static Obj             ProdCycInt (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdCycInt(Obj opL, Obj opR)
 {
     Obj                 hdP;            /* product, result                 */
     UInt                len;            /* number of terms                 */
@@ -1227,9 +1207,7 @@ static Obj             ProdCycInt (
 **  This   function  is lengthy  because  we  try to  use immediate   integer
 **  arithmetic if possible to avoid the function call overhead.
 */
-static Obj             ProdCyc (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdCyc(Obj opL, Obj opR)
 {
     UInt                nl, nr;         /* order of left and right field   */
     UInt                n;              /* order of smallest superfield    */
@@ -1360,8 +1338,7 @@ static Obj             ProdCyc (
 **  'OneCyc'  returns  the multiplicative neutral  element  of the cyclotomic
 **  <op>.
 */
-static Obj             OneCyc (
-    Obj                 op )
+static Obj OneCyc(Obj op)
 {
     return INTOBJ_INT( 1L );
 }
@@ -1381,8 +1358,7 @@ static Obj             OneCyc (
 **  can compute the quotient $prd / (op * prd)$ with 'ProdCycInt'.
 *T better multiply only the *different* conjugates?
 */
-static Obj             InvCyc (
-    Obj                 op )
+static Obj InvCyc(Obj op)
 {
     Obj                 prd;            /* product of conjugates           */
     UInt                n;              /* order of the field              */
@@ -1441,9 +1417,7 @@ static Obj             InvCyc (
 **  'PowCyc' returns the <opR>th, which must be  an  integer,  power  of  the
 **  cyclotomic <opL>.  The left operand may also be an integer or a rational.
 */
-static Obj             PowCyc (
-    Obj                 opL,
-    Obj                 opR )
+static Obj PowCyc(Obj opL, Obj opR)
 {
     Obj                 pow;            /* power (result)                  */
     Int                 exp;            /* exponent (right operand)        */
@@ -1523,9 +1497,7 @@ static Obj             PowCyc (
 */
 static Obj EOper;
 
-static Obj FuncE (
-    Obj                 self,
-    Obj                 n )
+static Obj FuncE(Obj self, Obj n)
 {
     Obj *               res;            /* pointer into result bag         */
 
@@ -1572,9 +1544,7 @@ static Obj FuncE (
 */
 static Obj IsCycFilt;
 
-static Obj FuncIS_CYC (
-    Obj                 self,
-    Obj                 val )
+static Obj FuncIS_CYC(Obj self, Obj val)
 {
     /* return 'true' if <obj> is a cyclotomic and 'false' otherwise        */
     if ( IS_INT(val) || TNUM_OBJ(val) == T_CYC || TNUM_OBJ(val) == T_RAT )
@@ -1603,9 +1573,7 @@ static Obj FuncIS_CYC (
 */
 static Obj IsCycIntOper;
 
-static Obj FuncIS_CYC_INT (
-    Obj                 self,
-    Obj                 val )
+static Obj FuncIS_CYC_INT(Obj self, Obj val)
 {
     UInt                len;            /* number of terms                 */
     const Obj *         cfs;            /* pointer to the coefficients     */
@@ -1649,9 +1617,7 @@ static Obj FuncIS_CYC_INT (
 */
 static Obj ConductorAttr;
 
-static Obj FuncCONDUCTOR (
-    Obj                 self,
-    Obj                 cyc )
+static Obj FuncCONDUCTOR(Obj self, Obj cyc)
 {
     UInt                n;              /* N of the cyclotomic, result     */
     UInt                m;              /* N of element of the list        */
@@ -1722,9 +1688,7 @@ static Obj FuncCONDUCTOR (
 */
 static Obj CoeffsCycOper;
 
-static Obj FuncCOEFFS_CYC (
-    Obj                 self,
-    Obj                 cyc )
+static Obj FuncCOEFFS_CYC(Obj self, Obj cyc)
 {
     Obj                 list;           /* list of coefficients, result    */
     UInt                n;              /* order of field                  */
@@ -1786,10 +1750,7 @@ static Obj FuncCOEFFS_CYC (
 */
 static Obj GaloisCycOper;
 
-static Obj FuncGALOIS_CYC (
-    Obj                 self,
-    Obj                 cyc,
-    Obj                 ord )
+static Obj FuncGALOIS_CYC(Obj self, Obj cyc, Obj ord)
 {
     Obj                 gal;            /* galois conjugate, result        */
     Obj                 sum;            /* sum of two coefficients         */
@@ -1962,9 +1923,7 @@ static Obj FuncGALOIS_CYC (
 */
 static Obj CycListOper;
 
-static Obj FuncCycList (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncCycList(Obj self, Obj list)
 {
     UInt                i;              /* loop variable                   */
     Obj *               res;            /* pointer into result bag         */
@@ -2012,7 +1971,7 @@ static Obj FuncCycList (
 **
 **  'MarkCycSubBags' is the marking function for bags of type 'T_CYC'.
 */
-static void MarkCycSubBags( Obj cyc )
+static void MarkCycSubBags(Obj cyc)
 {
     MarkArrayOfBags( COEFS_CYC( cyc ), SIZE_CYC(cyc) );
 }
@@ -2024,7 +1983,7 @@ static void MarkCycSubBags( Obj cyc )
 **
 **  We do not save the XXX_CYC field, since it is not used.
 */
-static void  SaveCyc ( Obj cyc )
+static void SaveCyc(Obj cyc)
 {
   UInt len, i;
   const Obj *coefs;
@@ -2045,7 +2004,7 @@ static void  SaveCyc ( Obj cyc )
 **
 **  We do not load the XXX_CYC field, since it is not used.
 */
-static void  LoadCyc ( Obj cyc )
+static void LoadCyc(Obj cyc)
 {
   UInt len, i;
   Obj *coefs;

--- a/src/dt.c
+++ b/src/dt.c
@@ -260,7 +260,7 @@ static Obj  Part(Obj list, Int pos1, Int pos2);
 **  Dt_add is used to store the library function dt_add.
 */
 
-static Obj                    Dt_add;
+static Obj Dt_add;
 
 /****************************************************************************
 **
@@ -268,8 +268,7 @@ static Obj                    Dt_add;
 **
 **  'UnmarkTree' removes all marks of all nodes of the tree <tree>.
 */
-static void  UnmarkTree(
-                  Obj   tree )
+static void UnmarkTree(Obj tree)
 {
     UInt     i, len; /*  loop variable                     */
 
@@ -289,9 +288,7 @@ static void  UnmarkTree(
 **
 **  'UnmarkTree' removes all marks of all nodes of the tree <tree>.
 */
-static Obj  FuncUnmarkTree(
-                     Obj  self,
-                     Obj  tree   )
+static Obj FuncUnmarkTree(Obj self, Obj tree)
 {
     UnmarkTree(tree);
     return  0;
@@ -311,10 +308,7 @@ static Obj  FuncUnmarkTree(
 **  is equal to {1,...,n} for a positive integer n,  'Mark' actually returns
 **  the Maximum of {pos(a) | a almost equal to (<reftree>, index)}.
 */
-static UInt   Mark(
-            Obj   tree,
-            Obj   reftree,
-            Int   indexx  )
+static UInt Mark(Obj tree, Obj reftree, Int indexx)
 {
     UInt  i, /*  loop variable                    */
           m, /*  integer to return                */
@@ -368,11 +362,7 @@ static UInt   Mark(
 **  and <index2> has to be a positive integer less or equal to the number of
 **  nodes of <tree2>.
 */
-static Int     AlmostEqual(
-                     Obj    tree1,
-                     Int    index1,
-                     Obj    tree2,
-                     Int    index2    )
+static Int AlmostEqual(Obj tree1, Int index1, Obj tree2, Int index2)
 {
     UInt   k, schranke; /*   loop variable                                             */
     /*  First the two top nodes of tree(<tree1>, index1) and
@@ -418,11 +408,7 @@ static Int     AlmostEqual(
 **  and <index2> has to be a positive integer less or equal to the number of
 **  nodes of <tree2>.
 */
-static Int     Equal(
-               Obj     tree1,
-               Int     index1,
-               Obj     tree2,
-               Int     index2   )
+static Int Equal(Obj tree1, Int index1, Obj tree2, Int index2)
 {
     UInt   k, schranke; /*  loop variable                                   */
 
@@ -467,11 +453,7 @@ static Int     Equal(
 **  of <tree>,  and <index2> has to be a positive integer less or equal to
 **  the number of nodes of <reftree>.
 */
-static Obj    Mark2(
-              Obj        tree,
-              Int        index1,
-              Obj        reftree,
-              Int        index2   )
+static Obj Mark2(Obj tree, Int index1, Obj reftree, Int index2)
 {
     UInt    i, /*  loop variable                                          */
             len;
@@ -552,9 +534,7 @@ static Obj    Mark2(
 **  does not exist 'Findtree' returns 0 (as C integer).  Note that this holds
 **  if and only if tree(<tree>, index) is marked.
 */
-static UInt    FindTree(
-                 Obj     tree,
-                 Int     indexx )
+static UInt FindTree(Obj tree, Int indexx)
 {
     UInt   i; /*     loop variable                                    */
 
@@ -608,9 +588,7 @@ static UInt    FindTree(
 **  'MakeFormulaVector' only returns correct results if all nodes of <tree>
 **  are unmarked.
 */
-static Obj    MakeFormulaVector(
-                          Obj    tree,
-                          Obj    pr   )
+static Obj MakeFormulaVector(Obj tree, Obj pr)
 {
     UInt  i, /*    denominator of a binomial coefficient              */
           j, /*    loop variable                                      */
@@ -694,10 +672,7 @@ static Obj    MakeFormulaVector(
 **  'MakeFormulaVector' returns the formula vector for the tree <tree> and
 **  the pc-presentation <pr>.
 */
-static Obj    FuncMakeFormulaVector(
-                              Obj      self,
-                              Obj      tree,
-                              Obj      pr            )
+static Obj FuncMakeFormulaVector(Obj self, Obj tree, Obj pr)
 {
     if  (LEN_PLIST(tree) == 5)
         ErrorReturnVoid("<tree> has to be a non-atom", 0L, 0L,
@@ -716,11 +691,7 @@ static Obj    FuncMakeFormulaVector(
 **  tree(<tree1>, index1) and tree(<tree2>, index2) both occur. It is assumed
 **  that tree(<tree1>, index1) is not equal to tree(<tree2>, index2). 
 */
-static Int     Leftof(
-                Obj     tree1,
-                Int     index1,
-                Obj     tree2,
-                Int     index2    )
+static Int Leftof(Obj tree1, Int index1, Obj tree2, Int index2)
 {
     if  ( DT_LENGTH(tree1, index1) ==  1  &&  DT_LENGTH(tree2, index2) == 1 ) {
         if (DT_SIDE(tree1, index1) == LEFT && DT_SIDE(tree2, index2) == RIGHT)
@@ -766,11 +737,7 @@ static Int     Leftof(
 **  tree(<tree1>, index1) and tree(<tree2>, index2) are non-atoms,  then their
 **  right trees and their left trees are not equal. 
 */
-static Int    Leftof2(
-                Obj    tree1,
-                Int    index1,
-                Obj    tree2,
-                Int    index2     )
+static Int Leftof2(Obj tree1, Int index1, Obj tree2, Int index2)
 {
     if  ( DT_GEN(tree2, index2) < DT_GEN(tree1, DT_RIGHT(tree1, index1) )  )
         return  0;
@@ -797,11 +764,7 @@ static Int    Leftof2(
 **  right(tree(<tree2>, index2) ) or left(tree(<tree1>, index1) ) does not
 **  equal left(tree(<tree2>, index2) ). 
 */
-static Int    Earlier(
-                Obj    tree1,
-                Int    index1,
-                Obj    tree2,
-                Int    index2         )
+static Int Earlier(Obj tree1, Int index1, Obj tree2, Int index2)
 {
     if  ( DT_LENGTH(tree1, index1) == 1 )
         return  1;
@@ -830,13 +793,10 @@ static Int    Earlier(
 */
 
 /* See below: */
-static void GetReps( Obj list, Obj reps );
-static void FindNewReps2( Obj tree, Obj reps, Obj pr);
+static void GetReps(Obj list, Obj reps);
+static void FindNewReps2(Obj tree, Obj reps, Obj pr);
 
-static void    GetPols( 
-                Obj    list,
-                Obj    pr,
-                Obj    pols     )
+static void GetPols(Obj list, Obj pr, Obj pols)
 {
     Obj    lreps,
            rreps,
@@ -890,11 +850,7 @@ static void    GetPols(
 **  FuncGetPols implements the internal function GetPols.
 */
 
-static Obj      FuncGetPols(
-                     Obj      self,
-                     Obj      list,
-                     Obj      pr,
-                     Obj      pols      )
+static Obj FuncGetPols(Obj self, Obj list, Obj pr, Obj pols)
 {
     if  (LEN_PLIST(list) != 4)
         ErrorReturnVoid("<list> must be a generalised representative not a tree"
@@ -914,11 +870,9 @@ static Obj      FuncGetPols(
 */
 
 /* See below: */
-static void FindNewReps1( Obj tree, Obj reps);
+static void FindNewReps1(Obj tree, Obj reps);
 
-static void    GetReps( 
-                Obj    list,
-                Obj    reps     )
+static void GetReps(Obj list, Obj reps)
 {
     Obj    lreps,
            rreps,
@@ -999,13 +953,19 @@ static void    GetReps(
 */
 
 /* See below: */
-static void  FindSubs1( Obj tree, Int x, Obj list1, Obj list2, Obj a, Obj b, 
-                 Int al, Int ar, Int bl, Int br, Obj reps );
+static void FindSubs1(Obj tree,
+                      Int x,
+                      Obj list1,
+                      Obj list2,
+                      Obj a,
+                      Obj b,
+                      Int al,
+                      Int ar,
+                      Int bl,
+                      Int br,
+                      Obj reps);
 
-static void   FindNewReps1(
-                    Obj     tree,
-                    Obj     reps
-                                      )
+static void FindNewReps1(Obj tree, Obj reps)
 {
     Obj   y,           /*  stores a copy of <tree>                       */
           lsubs,       /*  stores pos(<subtree>) for all subtrees of
@@ -1089,15 +1049,23 @@ static void   FindNewReps1(
 }
 
 /* See below: */
-static void  FindSubs2( Obj tree, Int x, Obj list1, Obj list2, Obj a, Obj b, 
-                 Int al, Int ar, Int bl, Int br, Obj reps, Obj pr );
+static void FindSubs2(Obj tree,
+                      Int x,
+                      Obj list1,
+                      Obj list2,
+                      Obj a,
+                      Obj b,
+                      Int al,
+                      Int ar,
+                      Int bl,
+                      Int br,
+                      Obj reps,
+                      Obj pr);
 
-static void   FindNewReps2(
-                    Obj     tree,
-                    Obj     reps,
-                    Obj     pr  /*  pc-presentation for a 
-                                 **  nilpotent group <G>                 */
-                                      )
+static void
+FindNewReps2(Obj tree, Obj reps, Obj pr /*  pc-presentation for a
+                                         **  nilpotent group <G> */
+)
 {
     Obj   lsubs,       /*  stores pos(<subtree>) for all subtrees of
                        **  left(<tree>) in a given almost equal class    */
@@ -1184,15 +1152,14 @@ static void   FindNewReps2(
 }
 
 
-static void   FindNewReps(
-                    Obj     tree,
-                    Obj     reps,
-                    Obj     pr,  /*  pc-presentation for a 
-                                 **  nilpotent group <G>                 */
+static void FindNewReps(Obj tree,
+                        Obj reps,
+                        Obj pr, /*  pc-presentation for a
+                                **  nilpotent group <G>                 */
 
-                    Obj     max  /*  every generator <g_i> of <G> with
-                                 **  i > max lies in the center of <G>   */
-                                      )
+                        Obj max /*  every generator <g_i> of <G> with
+                                **  i > max lies in the center of <G>   */
+)
 {
     Obj   y,           /*  stores a copy of <tree>                       */
           lsubs,       /*  stores pos(<subtree>) for all subtrees of
@@ -1314,12 +1281,7 @@ static void   FindNewReps(
 **  'FuncFindNewReps' implements the internal function 'FindNewReps'.
 */
 
-static Obj    FuncFindNewReps(
-                        Obj     self,
-                        Obj     tree,
-                        Obj     reps,
-                        Obj     pr,
-                        Obj     max       )
+static Obj FuncFindNewReps(Obj self, Obj tree, Obj reps, Obj pr, Obj max)
 {
 
     /*  test if <tree> is really a tree                                    */
@@ -1430,28 +1392,27 @@ v**  argument.
 **  FindNewReps2.  FindSubs is called from FindNewReps and calls FindNewReps.
 */
 
-static void  FindSubs1(
-                Obj        tree,
-                Int        x,     /*  subtree of <tree>                     */
-                Obj        list1, /*  list containing all subtrees of
-                                  **  left(<tree>) almost equal to
-                                  **  tree(<tree>, x)                       */
-                                  
-                Obj        list2, /*  list containing all subtrees of
-                                  **  right(<tree>) almost equal to
-                                  **  tree(<tree>, x)                       */
+static void FindSubs1(Obj tree,
+                      Int x,     /*  subtree of <tree>                     */
+                      Obj list1, /*  list containing all subtrees of
+                                 **  left(<tree>) almost equal to
+                                 **  tree(<tree>, x)                       */
 
-                Obj        a,     /*  list to change,  containing the
-                                  **  pos-arguments of the trees in list1   */
+                      Obj list2, /*  list containing all subtrees of
+                                 **  right(<tree>) almost equal to
+                                 **  tree(<tree>, x)                       */
 
-                Obj        b,     /*  list to change,  containing tthe
-                                  **  pos-arguments of the trees in list2   */
-                Int        al,
-                Int        ar,
-                Int        bl,
-                Int        br,
-                Obj        reps  /*  list of representatives for all trees */
-                                        )
+                      Obj a, /*  list to change,  containing the
+                             **  pos-arguments of the trees in list1   */
+
+                      Obj b, /*  list to change,  containing tthe
+                             **  pos-arguments of the trees in list2   */
+                      Int al,
+                      Int ar,
+                      Int bl,
+                      Int br,
+                      Obj reps /*  list of representatives for all trees */
+)
 {
    Int    i;  /*  loop variable                                             */
 
@@ -1507,29 +1468,28 @@ static void  FindSubs1(
 }
 
 
-static void  FindSubs2(
-                Obj        tree,
-                Int        x,     /*  subtree of <tree>                     */
-                Obj        list1, /*  list containing all subtrees of
-                                  **  left(<tree>) almost equal to
-                                  **  tree(<tree>, x)                       */
-                                  
-                Obj        list2, /*  list containing all subtrees of
-                                  **  right(<tree>) almost equal to
-                                  **  tree(<tree>, x)                       */
+static void FindSubs2(Obj tree,
+                      Int x,     /*  subtree of <tree>                     */
+                      Obj list1, /*  list containing all subtrees of
+                                 **  left(<tree>) almost equal to
+                                 **  tree(<tree>, x)                       */
 
-                Obj        a,     /*  list to change,  containing the
-                                  **  pos-arguments of the trees in list1   */
+                      Obj list2, /*  list containing all subtrees of
+                                 **  right(<tree>) almost equal to
+                                 **  tree(<tree>, x)                       */
 
-                Obj        b,     /*  list to change,  containing the
-                                  **  pos-arguments of the trees in list2   */
-                Int        al,
-                Int        ar,
-                Int        bl,
-                Int        br,
-                Obj        reps,  /*  list of representatives for all trees */
-                Obj        pr    /*  pc-presentation                       */
-                                        )
+                      Obj a, /*  list to change,  containing the
+                             **  pos-arguments of the trees in list1   */
+
+                      Obj b, /*  list to change,  containing the
+                             **  pos-arguments of the trees in list2   */
+                      Int al,
+                      Int ar,
+                      Int bl,
+                      Int br,
+                      Obj reps, /*  list of representatives for all trees */
+                      Obj pr    /*  pc-presentation                       */
+)
 {
    Int    i;  /*  loop variable                                             */
 
@@ -1585,30 +1545,29 @@ static void  FindSubs2(
 }
 
 
-static void  FindSubs(
-                Obj        tree,
-                Int        x,     /*  subtree of <tree>                     */
-                Obj        list1, /*  list containing all subtrees of
-                                  **  left(<tree>) almost equal to
-                                  **  tree(<tree>, x)                       */
-                                  
-                Obj        list2, /*  list containing all subtrees of
-                                  **  right(<tree>) almost equal to
-                                  **  tree(<tree>, x)                       */
+static void FindSubs(Obj tree,
+                     Int x,     /*  subtree of <tree>                     */
+                     Obj list1, /*  list containing all subtrees of
+                                **  left(<tree>) almost equal to
+                                **  tree(<tree>, x)                       */
 
-                Obj        a,     /*  list to change,  containing the
-                                  **  pos-arguments of the trees in list1   */
+                     Obj list2, /*  list containing all subtrees of
+                                **  right(<tree>) almost equal to
+                                **  tree(<tree>, x)                       */
 
-                Obj        b,     /*  list to change,  containing the
-                                  **  pos-arguments of the trees in list2   */
-                Int        al,
-                Int        ar,
-                Int        bl,
-                Int        br,
-                Obj        reps,  /*  list of representatives for all trees */
-                Obj        pr,    /*  pc-presentation                       */
-                Obj        max    /*  needed to call 'FindNewReps'          */
-                                        )
+                     Obj a, /*  list to change,  containing the
+                            **  pos-arguments of the trees in list1   */
+
+                     Obj b, /*  list to change,  containing the
+                            **  pos-arguments of the trees in list2   */
+                     Int al,
+                     Int ar,
+                     Int bl,
+                     Int br,
+                     Obj reps, /*  list of representatives for all trees */
+                     Obj pr,   /*  pc-presentation                       */
+                     Obj max   /*  needed to call 'FindNewReps'          */
+)
 {
    Int    i;  /*  loop variable                                             */
 
@@ -1671,10 +1630,7 @@ static void  FindSubs(
 **  'SetSubs' sets the pos-arguments of the subtrees of <tree>,  contained
 **  in <list> according to the entries in the list <a>.
 */
-static void    SetSubs(
-                 Obj       list,
-                 Obj       a,
-                 Obj       tree    )
+static void SetSubs(Obj list, Obj a, Obj tree)
 {
     UInt   i,j;  /*  loop variables                                         */
     UInt   len, len2;
@@ -1698,9 +1654,7 @@ static void    SetSubs(
 **  top node of each of those trees.
 */
 
-static void    UnmarkAEClass(
-                       Obj      tree,
-                       Obj      list  )
+static void UnmarkAEClass(Obj tree, Obj list)
 {
     UInt  i,j, len, len2;
 
@@ -1729,8 +1683,7 @@ static void    UnmarkAEClass(
 **  monomials.  DT_evaluation is called from the library function dt_add.
 */
 
-static Obj    FuncDT_evaluation(Obj      self,
-                    Obj      vector)
+static Obj FuncDT_evaluation(Obj self, Obj vector)
 {
     UInt   res,i;
 

--- a/src/dt.c
+++ b/src/dt.c
@@ -260,7 +260,7 @@ static Obj  Part(Obj list, Int pos1, Int pos2);
 **  Dt_add is used to store the library function dt_add.
 */
 
-Obj                    Dt_add;
+static Obj                    Dt_add;
 
 /****************************************************************************
 **
@@ -268,7 +268,7 @@ Obj                    Dt_add;
 **
 **  'UnmarkTree' removes all marks of all nodes of the tree <tree>.
 */
-void  UnmarkTree(
+static void  UnmarkTree(
                   Obj   tree )
 {
     UInt     i, len; /*  loop variable                     */
@@ -289,7 +289,7 @@ void  UnmarkTree(
 **
 **  'UnmarkTree' removes all marks of all nodes of the tree <tree>.
 */
-Obj  FuncUnmarkTree(
+static Obj  FuncUnmarkTree(
                      Obj  self,
                      Obj  tree   )
 {
@@ -311,7 +311,7 @@ Obj  FuncUnmarkTree(
 **  is equal to {1,...,n} for a positive integer n,  'Mark' actually returns
 **  the Maximum of {pos(a) | a almost equal to (<reftree>, index)}.
 */
-UInt   Mark(
+static UInt   Mark(
             Obj   tree,
             Obj   reftree,
             Int   indexx  )
@@ -368,7 +368,7 @@ UInt   Mark(
 **  and <index2> has to be a positive integer less or equal to the number of
 **  nodes of <tree2>.
 */
-Int     AlmostEqual(
+static Int     AlmostEqual(
                      Obj    tree1,
                      Int    index1,
                      Obj    tree2,
@@ -418,7 +418,7 @@ Int     AlmostEqual(
 **  and <index2> has to be a positive integer less or equal to the number of
 **  nodes of <tree2>.
 */
-Int     Equal(
+static Int     Equal(
                Obj     tree1,
                Int     index1,
                Obj     tree2,
@@ -467,7 +467,7 @@ Int     Equal(
 **  of <tree>,  and <index2> has to be a positive integer less or equal to
 **  the number of nodes of <reftree>.
 */
-Obj    Mark2(
+static Obj    Mark2(
               Obj        tree,
               Int        index1,
               Obj        reftree,
@@ -552,7 +552,7 @@ Obj    Mark2(
 **  does not exist 'Findtree' returns 0 (as C integer).  Note that this holds
 **  if and only if tree(<tree>, index) is marked.
 */
-UInt    FindTree(
+static UInt    FindTree(
                  Obj     tree,
                  Int     indexx )
 {
@@ -608,7 +608,7 @@ UInt    FindTree(
 **  'MakeFormulaVector' only returns correct results if all nodes of <tree>
 **  are unmarked.
 */
-Obj    MakeFormulaVector(
+static Obj    MakeFormulaVector(
                           Obj    tree,
                           Obj    pr   )
 {
@@ -694,7 +694,7 @@ Obj    MakeFormulaVector(
 **  'MakeFormulaVector' returns the formula vector for the tree <tree> and
 **  the pc-presentation <pr>.
 */
-Obj    FuncMakeFormulaVector(
+static Obj    FuncMakeFormulaVector(
                               Obj      self,
                               Obj      tree,
                               Obj      pr            )
@@ -716,7 +716,7 @@ Obj    FuncMakeFormulaVector(
 **  tree(<tree1>, index1) and tree(<tree2>, index2) both occur. It is assumed
 **  that tree(<tree1>, index1) is not equal to tree(<tree2>, index2). 
 */
-Int     Leftof(
+static Int     Leftof(
                 Obj     tree1,
                 Int     index1,
                 Obj     tree2,
@@ -766,7 +766,7 @@ Int     Leftof(
 **  tree(<tree1>, index1) and tree(<tree2>, index2) are non-atoms,  then their
 **  right trees and their left trees are not equal. 
 */
-Int    Leftof2(
+static Int    Leftof2(
                 Obj    tree1,
                 Int    index1,
                 Obj    tree2,
@@ -797,7 +797,7 @@ Int    Leftof2(
 **  right(tree(<tree2>, index2) ) or left(tree(<tree1>, index1) ) does not
 **  equal left(tree(<tree2>, index2) ). 
 */
-Int    Earlier(
+static Int    Earlier(
                 Obj    tree1,
                 Int    index1,
                 Obj    tree2,
@@ -830,10 +830,10 @@ Int    Earlier(
 */
 
 /* See below: */
-void GetReps( Obj list, Obj reps );
-void FindNewReps2( Obj tree, Obj reps, Obj pr);
+static void GetReps( Obj list, Obj reps );
+static void FindNewReps2( Obj tree, Obj reps, Obj pr);
 
-void    GetPols( 
+static void    GetPols( 
                 Obj    list,
                 Obj    pr,
                 Obj    pols     )
@@ -890,7 +890,7 @@ void    GetPols(
 **  FuncGetPols implements the internal function GetPols.
 */
 
-Obj      FuncGetPols(
+static Obj      FuncGetPols(
                      Obj      self,
                      Obj      list,
                      Obj      pr,
@@ -914,9 +914,9 @@ Obj      FuncGetPols(
 */
 
 /* See below: */
-void FindNewReps1( Obj tree, Obj reps);
+static void FindNewReps1( Obj tree, Obj reps);
 
-void    GetReps( 
+static void    GetReps( 
                 Obj    list,
                 Obj    reps     )
 {
@@ -999,10 +999,10 @@ void    GetReps(
 */
 
 /* See below: */
-void  FindSubs1( Obj tree, Int x, Obj list1, Obj list2, Obj a, Obj b, 
+static void  FindSubs1( Obj tree, Int x, Obj list1, Obj list2, Obj a, Obj b, 
                  Int al, Int ar, Int bl, Int br, Obj reps );
 
-void   FindNewReps1(
+static void   FindNewReps1(
                     Obj     tree,
                     Obj     reps
                                       )
@@ -1089,10 +1089,10 @@ void   FindNewReps1(
 }
 
 /* See below: */
-void  FindSubs2( Obj tree, Int x, Obj list1, Obj list2, Obj a, Obj b, 
+static void  FindSubs2( Obj tree, Int x, Obj list1, Obj list2, Obj a, Obj b, 
                  Int al, Int ar, Int bl, Int br, Obj reps, Obj pr );
 
-void   FindNewReps2(
+static void   FindNewReps2(
                     Obj     tree,
                     Obj     reps,
                     Obj     pr  /*  pc-presentation for a 
@@ -1184,7 +1184,7 @@ void   FindNewReps2(
 }
 
 
-void   FindNewReps(
+static void   FindNewReps(
                     Obj     tree,
                     Obj     reps,
                     Obj     pr,  /*  pc-presentation for a 
@@ -1314,7 +1314,7 @@ void   FindNewReps(
 **  'FuncFindNewReps' implements the internal function 'FindNewReps'.
 */
 
-Obj    FuncFindNewReps(
+static Obj    FuncFindNewReps(
                         Obj     self,
                         Obj     tree,
                         Obj     reps,
@@ -1340,7 +1340,7 @@ Obj    FuncFindNewReps(
 **  signals an error.
 */
 #if 0
-void  TestTree(
+static void  TestTree(
                Obj     tree)
 {
 
@@ -1385,7 +1385,7 @@ void  TestTree(
 **  'Part' returns <list>{ [<pos1>+1 .. <pos2>] }.
 */
 #if 0
-Obj    Part(
+static Obj    Part(
              Obj      list,
              Int      pos1,
              Int      pos2  )
@@ -1430,7 +1430,7 @@ v**  argument.
 **  FindNewReps2.  FindSubs is called from FindNewReps and calls FindNewReps.
 */
 
-void  FindSubs1(
+static void  FindSubs1(
                 Obj        tree,
                 Int        x,     /*  subtree of <tree>                     */
                 Obj        list1, /*  list containing all subtrees of
@@ -1507,7 +1507,7 @@ void  FindSubs1(
 }
 
 
-void  FindSubs2(
+static void  FindSubs2(
                 Obj        tree,
                 Int        x,     /*  subtree of <tree>                     */
                 Obj        list1, /*  list containing all subtrees of
@@ -1585,7 +1585,7 @@ void  FindSubs2(
 }
 
 
-void  FindSubs(
+static void  FindSubs(
                 Obj        tree,
                 Int        x,     /*  subtree of <tree>                     */
                 Obj        list1, /*  list containing all subtrees of
@@ -1671,7 +1671,7 @@ void  FindSubs(
 **  'SetSubs' sets the pos-arguments of the subtrees of <tree>,  contained
 **  in <list> according to the entries in the list <a>.
 */
-void    SetSubs(
+static void    SetSubs(
                  Obj       list,
                  Obj       a,
                  Obj       tree    )
@@ -1698,7 +1698,7 @@ void    SetSubs(
 **  top node of each of those trees.
 */
 
-void    UnmarkAEClass(
+static void    UnmarkAEClass(
                        Obj      tree,
                        Obj      list  )
 {
@@ -1729,7 +1729,7 @@ void    UnmarkAEClass(
 **  monomials.  DT_evaluation is called from the library function dt_add.
 */
 
-Obj    FuncDT_evaluation(Obj      self,
+static Obj    FuncDT_evaluation(Obj      self,
                     Obj      vector)
 {
     UInt   res,i;

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -53,13 +53,9 @@ static int             evlist, evlistvec;
 */
 
 /* See below: */
-static Obj     Evaluation( Obj vec, Obj xk, Obj power );
+static Obj Evaluation(Obj vec, Obj xk, Obj power);
 
-static void       MultGen(
-                    Obj     xk,
-                    UInt    gen,
-                    Obj     power,
-                    Obj     dtpols    )
+static void MultGen(Obj xk, UInt gen, Obj power, Obj dtpols)
 {
     UInt  i, j, len, len2;
     Obj   copy, sum, sum1, sum2, prod, ord, help;
@@ -119,10 +115,7 @@ static void       MultGen(
 **  <xk> and at <power>.
 */
 
-static Obj     Evaluation(
-                    Obj     vec,
-                    Obj     xk,
-                    Obj     power      )
+static Obj Evaluation(Obj vec, Obj xk, Obj power)
 {
     UInt i, len;
     Obj  prod, help;
@@ -155,12 +148,7 @@ static Obj     Evaluation(
 **  The result is an ordered word and is stored in <xk>.
 */
 
-static void        Multbound(
-                  Obj    xk,
-                  Obj    y,
-                  Int    anf,
-                  Int    end,
-                  Obj    dtpols  )
+static void Multbound(Obj xk, Obj y, Int anf, Int end, Obj dtpols)
 {
     int     i;
 
@@ -179,12 +167,7 @@ static void        Multbound(
 **  The result is an ordered word.
 */
 
-static Obj       Multiplybound(
-                     Obj      x,
-                     Obj      y,
-                     Int      anf,
-                     Int      end,
-                     Obj      dtpols  )
+static Obj Multiplybound(Obj x, Obj y, Int anf, Int end, Obj dtpols)
 {
     UInt   i, j, k, len, help;
     Obj    xk, res, sum;
@@ -296,12 +279,9 @@ static Obj       Multiplybound(
 */
 
 /* See below: */
-static Obj Solution( Obj x, Obj y, Obj dtpols );
+static Obj Solution(Obj x, Obj y, Obj dtpols);
 
-static Obj      Power(
-                Obj         x,
-                Obj         n,
-                Obj         dtpols     )
+static Obj Power(Obj x, Obj n, Obj dtpols)
 {
     Obj     res, m, y;
     UInt    i,len;
@@ -355,11 +335,9 @@ static Obj      Power(
 **
 **  Solution returns a solution for the equation <x>*a = <y> by evaluating
 **  the deep thought polynomials <dtpols>. The result is an ordered word.
-*/ 
+*/
 
-static Obj      Solution( Obj       x,
-                   Obj       y,
-                   Obj       dtpols  )
+static Obj Solution(Obj x, Obj y, Obj dtpols)
 
 {
     Obj    xk, res, m;
@@ -487,9 +465,7 @@ static Obj      Solution( Obj       x,
 **  the deep thought polynomials <dtpols>.
 */
 
-static Obj       Commutator( Obj     x,
-                      Obj     y,
-                      Obj     dtpols  )
+static Obj Commutator(Obj x, Obj y, Obj dtpols)
 {
     Obj    res, help;
 
@@ -509,9 +485,7 @@ static Obj       Commutator( Obj     x,
 **  deep thought polynomials <dtpols>. The result is an ordered word.
 */
 
-static Obj       Conjugate( Obj     x,
-                     Obj     y,
-                     Obj     dtpols  )
+static Obj Conjugate(Obj x, Obj y, Obj dtpols)
 {
     Obj    res;
 
@@ -532,11 +506,7 @@ static Obj       Conjugate( Obj     x,
 **  deep thought rewriting system <pcp>..
 */
 
-static Obj       Multiplyboundred( Obj     x,
-                            Obj     y,
-                            UInt    anf,
-                            UInt    end,
-                            Obj     pcp )
+static Obj Multiplyboundred(Obj x, Obj y, UInt anf, UInt end, Obj pcp)
 {
     Obj   orders, res, mod, c;
     UInt  i, len, len2, help;
@@ -568,9 +538,7 @@ static Obj       Multiplyboundred( Obj     x,
 **  system <pcp>.
 */
 
-static Obj       Powerred( Obj       x,
-                    Obj       n,
-                    Obj       pcp  )
+static Obj Powerred(Obj x, Obj n, Obj pcp)
 {
     Obj   orders, res, mod, c;
     UInt  i, len, len2,help;
@@ -602,9 +570,7 @@ static Obj       Powerred( Obj       x,
 **  rewriting system <pcp>.
 */
 
-static Obj       Solutionred( Obj       x,
-                       Obj       y,
-                       Obj       pcp  )
+static Obj Solutionred(Obj x, Obj y, Obj pcp)
 {
     Obj   orders, res, mod, c;
     UInt  i, len, len2, help;
@@ -636,9 +602,7 @@ static Obj       Solutionred( Obj       x,
 **  thought rewriting system <pcp>.
 */
 
-static Obj       Commutatorred( Obj    x,
-                         Obj    y,
-                         Obj    pcp  )
+static Obj Commutatorred(Obj x, Obj y, Obj pcp)
 {
     Obj    orders, mod, c, res;
     UInt   i, len, len2, help;
@@ -670,9 +634,7 @@ static Obj       Commutatorred( Obj    x,
 **  thought rewriting system <pcp>.
 */
 
-static Obj       Conjugatered( Obj    x,
-                         Obj    y,
-                         Obj    pcp  )
+static Obj Conjugatered(Obj x, Obj y, Obj pcp)
 {
     Obj    orders, mod, c, res;
     UInt   i, len, len2, help;
@@ -701,7 +663,7 @@ static Obj       Conjugatered( Obj    x,
 **  compress removes pairs (n,0) from the list of GAP integers <list>.
 */
 
-static void     compress( Obj        list )
+static void compress(Obj list)
 {    
     UInt    i, skip, len;
     
@@ -736,8 +698,7 @@ static void     compress( Obj        list )
 **  FuncDTCompress implements the internal function DTCompress.
 */
 
-static Obj      FuncDTCompress( Obj         self, 
-                       Obj         list  )
+static Obj FuncDTCompress(Obj self, Obj list)
 {
     compress(list);
     return  (Obj)0;
@@ -755,8 +716,7 @@ static Obj      FuncDTCompress( Obj         self,
 **  by <pcp>.
 */
 
-static void     ReduceWord( Obj      x,
-                      Obj      pcp )   
+static void ReduceWord(Obj x, Obj pcp)
 {
     Obj       powers, exponent;
     Obj       deepthoughtpols, help, potenz, quo, mod, prel;
@@ -829,10 +789,7 @@ static void     ReduceWord( Obj      x,
 **  with respect to the deep thought rewriting system <pcp>.
 */
 
-static Obj       FuncDTMultiply( Obj      self,
-                          Obj      x,
-                          Obj      y,
-                          Obj      pcp    )
+static Obj FuncDTMultiply(Obj self, Obj x, Obj y, Obj pcp)
 {
     Obj res;
 
@@ -859,10 +816,7 @@ static Obj       FuncDTMultiply( Obj      self,
 **  with respect to the deep thought rewriting system <pcp>.
 */
 
-static Obj       FuncDTPower( Obj       self,
-                       Obj       x,
-                       Obj       n,
-                       Obj       pcp  )
+static Obj FuncDTPower(Obj self, Obj x, Obj n, Obj pcp)
 {
     Obj    res;
 
@@ -885,10 +839,7 @@ static Obj       FuncDTPower( Obj       self,
 **  is reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-static Obj      FuncDTSolution( Obj     self,
-                         Obj     x,
-                         Obj     y,
-                         Obj     pcp )
+static Obj FuncDTSolution(Obj self, Obj x, Obj y, Obj pcp)
 {
     Obj     res;
 
@@ -913,10 +864,7 @@ static Obj      FuncDTSolution( Obj     self,
 **  is reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-static Obj        FuncDTCommutator( Obj      self,
-                             Obj      x,
-                             Obj      y,
-                             Obj      pcp  )
+static Obj FuncDTCommutator(Obj self, Obj x, Obj y, Obj pcp)
 {
     Obj   res;
 
@@ -939,10 +887,7 @@ static Obj        FuncDTCommutator( Obj      self,
 **  reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-static Obj        FuncDTConjugate( Obj      self,
-                            Obj      x,
-                            Obj      y,
-                            Obj      pcp  )
+static Obj FuncDTConjugate(Obj self, Obj x, Obj y, Obj pcp)
 {
     Obj   res;
 
@@ -967,10 +912,7 @@ static Obj        FuncDTConjugate( Obj      self,
 **  reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-static Obj       FuncDTQuotient( Obj      self,
-                           Obj      x,
-                           Obj      y,
-                           Obj      pcp )
+static Obj FuncDTQuotient(Obj self, Obj x, Obj y, Obj pcp)
 {
     Obj     help, res;
 

--- a/src/dteval.c
+++ b/src/dteval.c
@@ -53,9 +53,9 @@ static int             evlist, evlistvec;
 */
 
 /* See below: */
-Obj     Evaluation( Obj vec, Obj xk, Obj power );
+static Obj     Evaluation( Obj vec, Obj xk, Obj power );
 
-void       MultGen(
+static void       MultGen(
                     Obj     xk,
                     UInt    gen,
                     Obj     power,
@@ -119,7 +119,7 @@ void       MultGen(
 **  <xk> and at <power>.
 */
 
-Obj     Evaluation(
+static Obj     Evaluation(
                     Obj     vec,
                     Obj     xk,
                     Obj     power      )
@@ -155,7 +155,7 @@ Obj     Evaluation(
 **  The result is an ordered word and is stored in <xk>.
 */
 
-void        Multbound(
+static void        Multbound(
                   Obj    xk,
                   Obj    y,
                   Int    anf,
@@ -179,7 +179,7 @@ void        Multbound(
 **  The result is an ordered word.
 */
 
-Obj       Multiplybound(
+static Obj       Multiplybound(
                      Obj      x,
                      Obj      y,
                      Int      anf,
@@ -296,9 +296,9 @@ Obj       Multiplybound(
 */
 
 /* See below: */
-Obj Solution( Obj x, Obj y, Obj dtpols );
+static Obj Solution( Obj x, Obj y, Obj dtpols );
 
-Obj      Power(
+static Obj      Power(
                 Obj         x,
                 Obj         n,
                 Obj         dtpols     )
@@ -357,7 +357,7 @@ Obj      Power(
 **  the deep thought polynomials <dtpols>. The result is an ordered word.
 */ 
 
-Obj      Solution( Obj       x,
+static Obj      Solution( Obj       x,
                    Obj       y,
                    Obj       dtpols  )
 
@@ -487,7 +487,7 @@ Obj      Solution( Obj       x,
 **  the deep thought polynomials <dtpols>.
 */
 
-Obj       Commutator( Obj     x,
+static Obj       Commutator( Obj     x,
                       Obj     y,
                       Obj     dtpols  )
 {
@@ -509,7 +509,7 @@ Obj       Commutator( Obj     x,
 **  deep thought polynomials <dtpols>. The result is an ordered word.
 */
 
-Obj       Conjugate( Obj     x,
+static Obj       Conjugate( Obj     x,
                      Obj     y,
                      Obj     dtpols  )
 {
@@ -532,7 +532,7 @@ Obj       Conjugate( Obj     x,
 **  deep thought rewriting system <pcp>..
 */
 
-Obj       Multiplyboundred( Obj     x,
+static Obj       Multiplyboundred( Obj     x,
                             Obj     y,
                             UInt    anf,
                             UInt    end,
@@ -568,7 +568,7 @@ Obj       Multiplyboundred( Obj     x,
 **  system <pcp>.
 */
 
-Obj       Powerred( Obj       x,
+static Obj       Powerred( Obj       x,
                     Obj       n,
                     Obj       pcp  )
 {
@@ -602,7 +602,7 @@ Obj       Powerred( Obj       x,
 **  rewriting system <pcp>.
 */
 
-Obj       Solutionred( Obj       x,
+static Obj       Solutionred( Obj       x,
                        Obj       y,
                        Obj       pcp  )
 {
@@ -636,7 +636,7 @@ Obj       Solutionred( Obj       x,
 **  thought rewriting system <pcp>.
 */
 
-Obj       Commutatorred( Obj    x,
+static Obj       Commutatorred( Obj    x,
                          Obj    y,
                          Obj    pcp  )
 {
@@ -670,7 +670,7 @@ Obj       Commutatorred( Obj    x,
 **  thought rewriting system <pcp>.
 */
 
-Obj       Conjugatered( Obj    x,
+static Obj       Conjugatered( Obj    x,
                          Obj    y,
                          Obj    pcp  )
 {
@@ -701,7 +701,7 @@ Obj       Conjugatered( Obj    x,
 **  compress removes pairs (n,0) from the list of GAP integers <list>.
 */
 
-void     compress( Obj        list )
+static void     compress( Obj        list )
 {    
     UInt    i, skip, len;
     
@@ -736,7 +736,7 @@ void     compress( Obj        list )
 **  FuncDTCompress implements the internal function DTCompress.
 */
 
-Obj      FuncDTCompress( Obj         self, 
+static Obj      FuncDTCompress( Obj         self, 
                        Obj         list  )
 {
     compress(list);
@@ -755,7 +755,7 @@ Obj      FuncDTCompress( Obj         self,
 **  by <pcp>.
 */
 
-void     ReduceWord( Obj      x,
+static void     ReduceWord( Obj      x,
                       Obj      pcp )   
 {
     Obj       powers, exponent;
@@ -829,7 +829,7 @@ void     ReduceWord( Obj      x,
 **  with respect to the deep thought rewriting system <pcp>.
 */
 
-Obj       FuncDTMultiply( Obj      self,
+static Obj       FuncDTMultiply( Obj      self,
                           Obj      x,
                           Obj      y,
                           Obj      pcp    )
@@ -859,7 +859,7 @@ Obj       FuncDTMultiply( Obj      self,
 **  with respect to the deep thought rewriting system <pcp>.
 */
 
-Obj       FuncDTPower( Obj       self,
+static Obj       FuncDTPower( Obj       self,
                        Obj       x,
                        Obj       n,
                        Obj       pcp  )
@@ -885,7 +885,7 @@ Obj       FuncDTPower( Obj       self,
 **  is reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-Obj      FuncDTSolution( Obj     self,
+static Obj      FuncDTSolution( Obj     self,
                          Obj     x,
                          Obj     y,
                          Obj     pcp )
@@ -913,7 +913,7 @@ Obj      FuncDTSolution( Obj     self,
 **  is reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-Obj        FuncDTCommutator( Obj      self,
+static Obj        FuncDTCommutator( Obj      self,
                              Obj      x,
                              Obj      y,
                              Obj      pcp  )
@@ -939,7 +939,7 @@ Obj        FuncDTCommutator( Obj      self,
 **  reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-Obj        FuncDTConjugate( Obj      self,
+static Obj        FuncDTConjugate( Obj      self,
                             Obj      x,
                             Obj      y,
                             Obj      pcp  )
@@ -967,7 +967,7 @@ Obj        FuncDTConjugate( Obj      self,
 **  reduced with respect to the deep thought rewriting system <pcp>.
 */
 
-Obj       FuncDTQuotient( Obj      self,
+static Obj       FuncDTQuotient( Obj      self,
                            Obj      x,
                            Obj      y,
                            Obj      pcp )

--- a/src/error.c
+++ b/src/error.c
@@ -89,7 +89,7 @@ UInt OpenErrorOutput( void )
 *F  FuncDownEnv( <self>, <level> )  . . . . . . . . .  change the environment
 */
 
-void DownEnvInner(Int depth)
+static void DownEnvInner(Int depth)
 {
     /* if we are asked to go up ... */
     if (depth < 0) {
@@ -115,7 +115,7 @@ void DownEnvInner(Int depth)
     }
 }
 
-Obj FuncDownEnv(Obj self, Obj args)
+static Obj FuncDownEnv(Obj self, Obj args)
 {
     Int depth;
 
@@ -137,7 +137,7 @@ Obj FuncDownEnv(Obj self, Obj args)
     return (Obj)0;
 }
 
-Obj FuncUpEnv(Obj self, Obj args)
+static Obj FuncUpEnv(Obj self, Obj args)
 {
     Int depth;
     if (LEN_PLIST(args) == 0) {
@@ -158,7 +158,7 @@ Obj FuncUpEnv(Obj self, Obj args)
     return (Obj)0;
 }
 
-Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
+static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
 {
     if (context == STATE(BottomLVars))
         return Fail;
@@ -191,7 +191,7 @@ Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
     return retlist;
 }
 
-Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
+static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
 {
     if (context == STATE(BottomLVars))
         return 0;
@@ -251,7 +251,7 @@ Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
 *F  FuncCALL_WITH_CATCH( <self>, <func> )
 **
 */
-Obj FuncCALL_WITH_CATCH(Obj self, Obj func, Obj args)
+static Obj FuncCALL_WITH_CATCH(Obj self, Obj func, Obj args)
 {
     return CALL_WITH_CATCH(func, args);
 }
@@ -329,7 +329,7 @@ Obj CALL_WITH_CATCH(Obj func, volatile Obj args)
     return res;
 }
 
-Obj FuncJUMP_TO_CATCH(Obj self, Obj payload)
+static Obj FuncJUMP_TO_CATCH(Obj self, Obj payload)
 {
     STATE(ThrownObject) = payload;
     if (STATE(JumpToCatchCallback) != 0) {
@@ -339,7 +339,7 @@ Obj FuncJUMP_TO_CATCH(Obj self, Obj payload)
     return 0;
 }
 
-Obj FuncSetUserHasQuit(Obj Self, Obj value)
+static Obj FuncSetUserHasQuit(Obj Self, Obj value)
 {
     STATE(UserHasQuit) = INT_INTOBJ(value);
     if (STATE(UserHasQuit))
@@ -390,7 +390,7 @@ static Obj ErrorMessageToGAPString(const Char * msg, Int arg1, Int arg2)
 }
 
 
-Obj CallErrorInner(const Char * msg,
+static Obj CallErrorInner(const Char * msg,
                    Int          arg1,
                    Int          arg2,
                    UInt         justQuit,

--- a/src/error.c
+++ b/src/error.c
@@ -391,13 +391,13 @@ static Obj ErrorMessageToGAPString(const Char * msg, Int arg1, Int arg2)
 
 
 static Obj CallErrorInner(const Char * msg,
-                   Int          arg1,
-                   Int          arg2,
-                   UInt         justQuit,
-                   UInt         mayReturnVoid,
-                   UInt         mayReturnObj,
-                   Obj          lateMessage,
-                   UInt         printThisStatement)
+                          Int          arg1,
+                          Int          arg2,
+                          UInt         justQuit,
+                          UInt         mayReturnVoid,
+                          UInt         mayReturnObj,
+                          Obj          lateMessage,
+                          UInt         printThisStatement)
 {
     // Must do this before creating any other GAP objects,
     // as one of the args could be a pointer into a Bag.

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -73,8 +73,7 @@ Obj             (* EvalBoolFuncs [256]) ( Expr expr );
 **  error.  If this is ever called, then  GAP is in  serious trouble, such as
 **  an overwritten type field of an expression.
 */
-static Obj             EvalUnknownExpr (
-    Expr                expr )
+static Obj EvalUnknownExpr(Expr expr)
 {
     Pr( "Panic: tried to evaluate an expression of unknown type '%d'\n",
         (Int)TNUM_EXPR(expr), 0L );
@@ -94,8 +93,7 @@ static Obj             EvalUnknownExpr (
 **  are   not a priori    known  to evaluate  to a    boolean value  (such as
 **  function calls).
 */
-static Obj             EvalUnknownBool (
-    Expr                expr )
+static Obj EvalUnknownBool(Expr expr)
 {
     Obj                 val;            /* value, result                   */
 
@@ -126,8 +124,7 @@ static Obj             EvalUnknownBool (
 **
 **      if (index > max) or (list[index] = 0)  then ... fi;
 */
-static Obj             EvalOr (
-    Expr                expr )
+static Obj EvalOr(Expr expr)
 {
     Obj                 opL;            /* evaluated left operand          */
     Expr                tmp;            /* temporary expression            */
@@ -159,8 +156,7 @@ static Obj             EvalOr (
 **
 **      if (index <= max) and (list[index] = 0)  then ... fi;
 */
-static Obj             EvalAnd (
-    Expr                expr )
+static Obj EvalAnd(Expr expr)
 {
     Obj                 opL;            /* evaluated left  operand         */
     Obj                 opR;            /* evaluated right operand         */
@@ -205,8 +201,7 @@ static Obj             EvalAnd (
 **  i.e., 'true' if the operand is 'false', and 'false' otherwise.  'EvalNot'
 **  is called from 'EVAL_EXPR' to evaluate expressions of type 'T_NOT'.
 */
-static Obj             EvalNot (
-    Expr                expr )
+static Obj EvalNot(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 op;             /* evaluated operand               */
@@ -235,8 +230,7 @@ static Obj             EvalNot (
 **
 **  'EvalEq' evaluates the operands and then calls the 'EQ' macro.
 */
-static Obj             EvalEq (
-    Expr                expr )
+static Obj EvalEq(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -269,8 +263,7 @@ static Obj             EvalEq (
 **
 **  'EvalNe' is simply implemented as 'not <objL> = <objR>'.
 */
-static Obj             EvalNe (
-    Expr                expr )
+static Obj EvalNe(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -303,8 +296,7 @@ static Obj             EvalNe (
 **
 **  'EvalLt' evaluates the operands and then calls the 'LT' macro.
 */
-static Obj             EvalLt (
-    Expr                expr )
+static Obj EvalLt(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -337,8 +329,7 @@ static Obj             EvalLt (
 **
 **  'EvalGe' is simply implemented as 'not <objL> < <objR>'.
 */
-static Obj             EvalGe (
-    Expr                expr )
+static Obj EvalGe(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -371,8 +362,7 @@ static Obj             EvalGe (
 **
 **  'EvalGt' is simply implemented as '<objR> < <objL>'.
 */
-static Obj             EvalGt (
-    Expr                expr )
+static Obj EvalGt(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -405,8 +395,7 @@ static Obj             EvalGt (
 **
 **  'EvalLe' is simply implemented as 'not <objR> < <objR>'.
 */
-static Obj             EvalLe (
-    Expr                expr )
+static Obj EvalLe(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -437,8 +426,7 @@ static Obj             EvalLe (
 **  'false' otherwise.    'EvalIn' is  called  from  'EVAL_EXPR'  to evaluate
 **  expressions of type 'T_IN'.
 */
-static Obj             EvalIn (
-    Expr                expr )
+static Obj EvalIn(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -473,8 +461,7 @@ static Obj             EvalIn (
 **
 **  'EvalSum' evaluates the operands and then calls the 'SUM' macro.
 */
-static Obj             EvalSum (
-    Expr                expr )
+static Obj EvalSum(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -511,8 +498,7 @@ static Obj             EvalSum (
 **
 **  'EvalAInv' evaluates the operand and then calls the 'AINV' macro.
 */
-static Obj             EvalAInv (
-    Expr                expr )
+static Obj EvalAInv(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -542,8 +528,7 @@ static Obj             EvalAInv (
 **
 **  'EvalDiff' evaluates the operands and then calls the 'DIFF' macro.
 */
-static Obj             EvalDiff (
-    Expr                expr )
+static Obj EvalDiff(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -581,8 +566,7 @@ static Obj             EvalDiff (
 **
 **  'EvalProd' evaluates the operands and then calls the 'PROD' macro.
 */
-static Obj             EvalProd (
-    Expr                expr )
+static Obj EvalProd(Expr expr)
 {
     Obj                 val;            /* result                          */
     Obj                 opL;            /* evaluated left  operand         */
@@ -620,8 +604,7 @@ static Obj             EvalProd (
 **
 **  'EvalQuo' evaluates the operands and then calls the 'QUO' macro.
 */
-static Obj             EvalQuo (
-    Expr                expr )
+static Obj EvalQuo(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -654,8 +637,7 @@ static Obj             EvalQuo (
 **
 **  'EvalMod' evaluates the operands and then calls the 'MOD' macro.
 */
-static Obj             EvalMod (
-    Expr                expr )
+static Obj EvalMod(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -688,8 +670,7 @@ static Obj             EvalMod (
 **
 **  'EvalPow' evaluates the operands and then calls the 'POW' macro.
 */
-static Obj             EvalPow (
-    Expr                expr )
+static Obj EvalPow(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     Obj                 opL;            /* evaluated left  operand         */
@@ -718,8 +699,7 @@ static Obj             EvalPow (
 **  'EvalIntExpr' evaluates the literal integer expression <expr> and returns
 **  its value.
 */
-static Obj             EvalIntExpr (
-    Expr                expr )
+static Obj EvalIntExpr(Expr expr)
 {
     UInt ix = READ_EXPR(expr, 0);
     return  GET_VALUE_FROM_CURRENT_BODY(ix);
@@ -731,8 +711,7 @@ static Obj             EvalIntExpr (
 **
 **  'EvalTildeExpr' evaluates the tilde expression and returns its value.
 */
-static Obj             EvalTildeExpr (
-    Expr                expr )
+static Obj EvalTildeExpr(Expr expr)
 {
     if( ! (STATE(Tilde)) ) {
         ErrorQuit("'~' does not have a value here",0L,0L);
@@ -747,8 +726,7 @@ static Obj             EvalTildeExpr (
 **  'EvalTrueExpr' evaluates the  literal true expression <expr> and  returns
 **  its value (True).
 */
-static Obj             EvalTrueExpr (
-    Expr                expr )
+static Obj EvalTrueExpr(Expr expr)
 {
     return True;
 }
@@ -761,8 +739,7 @@ static Obj             EvalTrueExpr (
 **  'EvalFalseExpr' evaluates the literal false expression <expr> and returns
 **  its value (False).
 */
-static Obj             EvalFalseExpr (
-    Expr                expr )
+static Obj EvalFalseExpr(Expr expr)
 {
     return False;
 }
@@ -775,8 +752,7 @@ static Obj             EvalFalseExpr (
 **  'EvalCharExpr' evaluates  the   literal character expression <expr>   and
 **  returns its value.
 */
-static Obj             EvalCharExpr (
-    Expr                expr )
+static Obj EvalCharExpr(Expr expr)
 {
     return ObjsChar[ READ_EXPR(expr, 0) ];
 }
@@ -793,8 +769,7 @@ static Obj GetFromExpr(Obj cycle, Int j)
     return EVAL_EXPR(READ_EXPR((Expr)cycle, j - 1));
 }
 
-static Obj             EvalPermExpr (
-    Expr                expr )
+static Obj EvalPermExpr(Expr expr)
 {
     Obj                 perm;           /* permutation, result             */
     UInt4 *             ptr4;           /* pointer into perm               */
@@ -858,8 +833,7 @@ static Obj             EvalPermExpr (
 static Obj  ListExpr1(Expr expr, Int tildeInUse);
 static void ListExpr2(Obj list, Expr expr, Int tildeInUse);
 
-static Obj             EvalListExpr (
-    Expr                expr )
+static Obj EvalListExpr(Expr expr)
 {
     Obj                 list;         /* list value, result                */
 
@@ -887,8 +861,7 @@ static Obj             EvalListExpr (
 **  expression can  refer to   this  variable and  its subobjects  to  create
 **  objects that are not trees.
 */
-static Obj             EvalListTildeExpr (
-    Expr                expr )
+static Obj EvalListTildeExpr(Expr expr)
 {
     Obj                 list;           /* list value, result              */
     Obj                 tilde;          /* old value of tilde              */
@@ -1021,8 +994,7 @@ static ALWAYS_INLINE void ListExpr2(Obj list, Expr expr, Int tildeInUse)
 **
 **  'EvalRangeExpr' evaluates the range expression <expr> to a range value.
 */
-static Obj             EvalRangeExpr (
-    Expr                expr )
+static Obj EvalRangeExpr(Expr expr)
 {
     Obj                 range;          /* range, result                   */
     Obj                 val;            /* subvalue of range               */
@@ -1097,8 +1069,7 @@ static Obj             EvalRangeExpr (
 **  'EvalStringExpr'   evaluates the  string  expression  <expr>  to a string
 **  value.
 */
-static Obj             EvalStringExpr (
-    Expr                expr )
+static Obj EvalStringExpr(Expr expr)
 {
     UInt ix = READ_EXPR(expr, 0);
     Obj string = GET_VALUE_FROM_CURRENT_BODY(ix);
@@ -1116,8 +1087,7 @@ static Obj CONVERT_FLOAT_LITERAL;
 static Obj FLOAT_LITERAL_CACHE;
 static Obj MAX_FLOAT_LITERAL_CACHE_SIZE;
 
-static Obj             EvalFloatExprLazy (
-    Expr                expr )
+static Obj EvalFloatExprLazy(Expr expr)
 {
     Obj                 string;         /* string value            */
     UInt                 len;           /* size of expression              */
@@ -1178,8 +1148,7 @@ static Obj EvalFloatExprEager(Expr expr)
 static Obj  RecExpr1(Expr expr);
 static void RecExpr2(Obj rec, Expr expr);
 
-static Obj             EvalRecExpr (
-    Expr                expr )
+static Obj EvalRecExpr(Expr expr)
 {
     Obj                 rec;            /* record value, result            */
 
@@ -1207,8 +1176,7 @@ static Obj             EvalRecExpr (
 **  expression    can refer to this variable    and its  subobjects to create
 **  objects that are not trees.
 */
-static Obj             EvalRecTildeExpr (
-    Expr                expr )
+static Obj EvalRecTildeExpr(Expr expr)
 {
     Obj                 rec;            /* record value, result            */
     Obj                 tilde;          /* old value of tilde              */
@@ -1339,8 +1307,7 @@ void            (* PrintExprFuncs[256] ) ( Expr expr );
 **  this  is ever called,   then  GAP is  in  serious   trouble, such as   an
 **  overwritten type field of an expression.
 */
-static void            PrintUnknownExpr (
-    Expr                expr )
+static void PrintUnknownExpr(Expr expr)
 {
     Pr( "Panic: tried to print an expression of unknown type '%d'\n",
         (Int)TNUM_EXPR(expr), 0L );
@@ -1381,8 +1348,7 @@ extern inline struct ExprsState * ExprsState(void)
 **
 **  'PrintNot' print a not operation in the following form: 'not <expr>'.
 */
-static void            PrintNot (
-    Expr                expr )
+static void PrintNot(Expr expr)
 {
     UInt                oldPrec;
 
@@ -1412,8 +1378,7 @@ static void            PrintNot (
 **  'PrintBinop'  prints  the   binary operator    expression <expr>,   using
 **  'PrintPrecedence' for parenthesising.
 */
-static void            PrintAInv (
-    Expr                expr )
+static void PrintAInv(Expr expr)
 {
     UInt                oldPrec;
 
@@ -1435,8 +1400,7 @@ static void            PrintAInv (
     PrintPrecedence = oldPrec;
 }
 
-static void            PrintBinop (
-    Expr                expr )
+static void PrintBinop(Expr expr)
 {
     UInt                oldPrec;        /* old precedence level           */
     const Char *        op;             /* operand                         */
@@ -1504,8 +1468,7 @@ static void            PrintBinop (
 **
 **  'PrintIntExpr' prints the literal integer expression <expr>.
 */
-static void            PrintIntExpr (
-    Expr                expr )
+static void PrintIntExpr(Expr expr)
 {
     if ( IS_INTEXPR(expr) ) {
         Pr( "%d", INT_INTEXPR(expr), 0L );
@@ -1520,8 +1483,7 @@ static void            PrintIntExpr (
 **
 *F  PrintTildeExpr(<expr>) . . . . . . . . . . . print tilde expression
 */
-static void            PrintTildeExpr (
-    Expr                expr )
+static void PrintTildeExpr(Expr expr)
 {
     Pr( "~", 0L, 0L );
 }
@@ -1530,8 +1492,7 @@ static void            PrintTildeExpr (
 **
 *F  PrintTrueExpr(<expr>) . . . . . . . . . . . print literal true expression
 */
-static void            PrintTrueExpr (
-    Expr                expr )
+static void PrintTrueExpr(Expr expr)
 {
     Pr( "true", 0L, 0L );
 }
@@ -1541,8 +1502,7 @@ static void            PrintTrueExpr (
 **
 *F  PrintFalseExpr(<expr>)  . . . . . . . . .  print literal false expression
 */
-static void            PrintFalseExpr (
-    Expr                expr )
+static void PrintFalseExpr(Expr expr)
 {
     Pr( "false", 0L, 0L );
 }
@@ -1552,8 +1512,7 @@ static void            PrintFalseExpr (
 **
 *F  PrintCharExpr(<expr>) . . . . . . . .  print literal character expression
 */
-static void            PrintCharExpr (
-    Expr                expr )
+static void PrintCharExpr(Expr expr)
 {
     UChar               chr;
 
@@ -1575,8 +1534,7 @@ static void            PrintCharExpr (
 **
 **  'PrintPermExpr' prints the permutation expression <expr>.
 */
-static void            PrintPermExpr (
-    Expr                expr )
+static void PrintPermExpr(Expr expr)
 {
     Expr                cycle;          /* one cycle of permutation expr.  */
     UInt                i, j;           /* loop variables                  */
@@ -1610,8 +1568,7 @@ static void            PrintPermExpr (
 **
 **  'PrintListExpr' prints the list expression <expr>.
 */
-static void            PrintListExpr (
-    Expr                expr )
+static void PrintListExpr(Expr expr)
 {
     Int                 len;            /* logical length of <list>        */
     Expr                elm;            /* one element from <list>         */
@@ -1642,8 +1599,7 @@ static void            PrintListExpr (
 **
 **  'PrintRangeExpr' prints the record expression <expr>.
 */
-static void            PrintRangeExpr (
-    Expr                expr )
+static void PrintRangeExpr(Expr expr)
 {
     if ( SIZE_EXPR( expr ) == 2*sizeof(Expr) ) {
         Pr("%2>[ %2>",0L,0L);    PrintExpr( READ_EXPR(expr, 0) );
@@ -1665,8 +1621,7 @@ static void            PrintRangeExpr (
 **
 **  'PrintStringExpr' prints the string expression <expr>.
 */
-static void            PrintStringExpr (
-    Expr                expr )
+static void PrintStringExpr(Expr expr)
 {
     UInt ix = READ_EXPR(expr, 0);
     Obj string =  GET_VALUE_FROM_CURRENT_BODY(ix);
@@ -1680,8 +1635,7 @@ static void            PrintStringExpr (
 **
 **  'PrintFloatExpr' prints the float expression <expr>.
 */
-static void            PrintFloatExprLazy (
-    Expr                expr )
+static void PrintFloatExprLazy(Expr expr)
 {
   // FIXME: this code is not GC safe
   Pr("%s", (Int)(((const char *)CONST_ADDR_EXPR(expr) + 2*sizeof(UInt))), 0L);
@@ -1693,8 +1647,7 @@ static void            PrintFloatExprLazy (
 **
 **  'PrintFloatExpr' prints the float expression <expr>.
 */
-static void            PrintFloatExprEager (
-    Expr                expr )
+static void PrintFloatExprEager(Expr expr)
 {
   // FIXME: this code is not GC safe
   Char mark;
@@ -1743,8 +1696,7 @@ void            PrintRecExpr1 (
     }
 }
 
-static void            PrintRecExpr (
-    Expr                expr )
+static void PrintRecExpr(Expr expr)
 {
     Pr("%2>rec(\n%2>",0L,0L);
     PrintRecExpr1(expr);

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -73,7 +73,7 @@ Obj             (* EvalBoolFuncs [256]) ( Expr expr );
 **  error.  If this is ever called, then  GAP is in  serious trouble, such as
 **  an overwritten type field of an expression.
 */
-Obj             EvalUnknownExpr (
+static Obj             EvalUnknownExpr (
     Expr                expr )
 {
     Pr( "Panic: tried to evaluate an expression of unknown type '%d'\n",
@@ -94,7 +94,7 @@ Obj             EvalUnknownExpr (
 **  are   not a priori    known  to evaluate  to a    boolean value  (such as
 **  function calls).
 */
-Obj             EvalUnknownBool (
+static Obj             EvalUnknownBool (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -126,7 +126,7 @@ Obj             EvalUnknownBool (
 **
 **      if (index > max) or (list[index] = 0)  then ... fi;
 */
-Obj             EvalOr (
+static Obj             EvalOr (
     Expr                expr )
 {
     Obj                 opL;            /* evaluated left operand          */
@@ -159,7 +159,7 @@ Obj             EvalOr (
 **
 **      if (index <= max) and (list[index] = 0)  then ... fi;
 */
-Obj             EvalAnd (
+static Obj             EvalAnd (
     Expr                expr )
 {
     Obj                 opL;            /* evaluated left  operand         */
@@ -205,7 +205,7 @@ Obj             EvalAnd (
 **  i.e., 'true' if the operand is 'false', and 'false' otherwise.  'EvalNot'
 **  is called from 'EVAL_EXPR' to evaluate expressions of type 'T_NOT'.
 */
-Obj             EvalNot (
+static Obj             EvalNot (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -235,7 +235,7 @@ Obj             EvalNot (
 **
 **  'EvalEq' evaluates the operands and then calls the 'EQ' macro.
 */
-Obj             EvalEq (
+static Obj             EvalEq (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -269,7 +269,7 @@ Obj             EvalEq (
 **
 **  'EvalNe' is simply implemented as 'not <objL> = <objR>'.
 */
-Obj             EvalNe (
+static Obj             EvalNe (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -303,7 +303,7 @@ Obj             EvalNe (
 **
 **  'EvalLt' evaluates the operands and then calls the 'LT' macro.
 */
-Obj             EvalLt (
+static Obj             EvalLt (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -337,7 +337,7 @@ Obj             EvalLt (
 **
 **  'EvalGe' is simply implemented as 'not <objL> < <objR>'.
 */
-Obj             EvalGe (
+static Obj             EvalGe (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -371,7 +371,7 @@ Obj             EvalGe (
 **
 **  'EvalGt' is simply implemented as '<objR> < <objL>'.
 */
-Obj             EvalGt (
+static Obj             EvalGt (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -405,7 +405,7 @@ Obj             EvalGt (
 **
 **  'EvalLe' is simply implemented as 'not <objR> < <objR>'.
 */
-Obj             EvalLe (
+static Obj             EvalLe (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -437,7 +437,7 @@ Obj             EvalLe (
 **  'false' otherwise.    'EvalIn' is  called  from  'EVAL_EXPR'  to evaluate
 **  expressions of type 'T_IN'.
 */
-Obj             EvalIn (
+static Obj             EvalIn (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -473,7 +473,7 @@ Obj             EvalIn (
 **
 **  'EvalSum' evaluates the operands and then calls the 'SUM' macro.
 */
-Obj             EvalSum (
+static Obj             EvalSum (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -511,7 +511,7 @@ Obj             EvalSum (
 **
 **  'EvalAInv' evaluates the operand and then calls the 'AINV' macro.
 */
-Obj             EvalAInv (
+static Obj             EvalAInv (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -542,7 +542,7 @@ Obj             EvalAInv (
 **
 **  'EvalDiff' evaluates the operands and then calls the 'DIFF' macro.
 */
-Obj             EvalDiff (
+static Obj             EvalDiff (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -581,7 +581,7 @@ Obj             EvalDiff (
 **
 **  'EvalProd' evaluates the operands and then calls the 'PROD' macro.
 */
-Obj             EvalProd (
+static Obj             EvalProd (
     Expr                expr )
 {
     Obj                 val;            /* result                          */
@@ -620,7 +620,7 @@ Obj             EvalProd (
 **
 **  'EvalQuo' evaluates the operands and then calls the 'QUO' macro.
 */
-Obj             EvalQuo (
+static Obj             EvalQuo (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -654,7 +654,7 @@ Obj             EvalQuo (
 **
 **  'EvalMod' evaluates the operands and then calls the 'MOD' macro.
 */
-Obj             EvalMod (
+static Obj             EvalMod (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -688,7 +688,7 @@ Obj             EvalMod (
 **
 **  'EvalPow' evaluates the operands and then calls the 'POW' macro.
 */
-Obj             EvalPow (
+static Obj             EvalPow (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -718,7 +718,7 @@ Obj             EvalPow (
 **  'EvalIntExpr' evaluates the literal integer expression <expr> and returns
 **  its value.
 */
-Obj             EvalIntExpr (
+static Obj             EvalIntExpr (
     Expr                expr )
 {
     UInt ix = READ_EXPR(expr, 0);
@@ -731,7 +731,7 @@ Obj             EvalIntExpr (
 **
 **  'EvalTildeExpr' evaluates the tilde expression and returns its value.
 */
-Obj             EvalTildeExpr (
+static Obj             EvalTildeExpr (
     Expr                expr )
 {
     if( ! (STATE(Tilde)) ) {
@@ -747,7 +747,7 @@ Obj             EvalTildeExpr (
 **  'EvalTrueExpr' evaluates the  literal true expression <expr> and  returns
 **  its value (True).
 */
-Obj             EvalTrueExpr (
+static Obj             EvalTrueExpr (
     Expr                expr )
 {
     return True;
@@ -761,7 +761,7 @@ Obj             EvalTrueExpr (
 **  'EvalFalseExpr' evaluates the literal false expression <expr> and returns
 **  its value (False).
 */
-Obj             EvalFalseExpr (
+static Obj             EvalFalseExpr (
     Expr                expr )
 {
     return False;
@@ -775,7 +775,7 @@ Obj             EvalFalseExpr (
 **  'EvalCharExpr' evaluates  the   literal character expression <expr>   and
 **  returns its value.
 */
-Obj             EvalCharExpr (
+static Obj             EvalCharExpr (
     Expr                expr )
 {
     return ObjsChar[ READ_EXPR(expr, 0) ];
@@ -793,7 +793,7 @@ static Obj GetFromExpr(Obj cycle, Int j)
     return EVAL_EXPR(READ_EXPR((Expr)cycle, j - 1));
 }
 
-Obj             EvalPermExpr (
+static Obj             EvalPermExpr (
     Expr                expr )
 {
     Obj                 perm;           /* permutation, result             */
@@ -858,7 +858,7 @@ Obj             EvalPermExpr (
 static Obj  ListExpr1(Expr expr, Int tildeInUse);
 static void ListExpr2(Obj list, Expr expr, Int tildeInUse);
 
-Obj             EvalListExpr (
+static Obj             EvalListExpr (
     Expr                expr )
 {
     Obj                 list;         /* list value, result                */
@@ -887,7 +887,7 @@ Obj             EvalListExpr (
 **  expression can  refer to   this  variable and  its subobjects  to  create
 **  objects that are not trees.
 */
-Obj             EvalListTildeExpr (
+static Obj             EvalListTildeExpr (
     Expr                expr )
 {
     Obj                 list;           /* list value, result              */
@@ -1021,7 +1021,7 @@ static ALWAYS_INLINE void ListExpr2(Obj list, Expr expr, Int tildeInUse)
 **
 **  'EvalRangeExpr' evaluates the range expression <expr> to a range value.
 */
-Obj             EvalRangeExpr (
+static Obj             EvalRangeExpr (
     Expr                expr )
 {
     Obj                 range;          /* range, result                   */
@@ -1097,7 +1097,7 @@ Obj             EvalRangeExpr (
 **  'EvalStringExpr'   evaluates the  string  expression  <expr>  to a string
 **  value.
 */
-Obj             EvalStringExpr (
+static Obj             EvalStringExpr (
     Expr                expr )
 {
     UInt ix = READ_EXPR(expr, 0);
@@ -1116,7 +1116,7 @@ static Obj CONVERT_FLOAT_LITERAL;
 static Obj FLOAT_LITERAL_CACHE;
 static Obj MAX_FLOAT_LITERAL_CACHE_SIZE;
 
-Obj             EvalFloatExprLazy (
+static Obj             EvalFloatExprLazy (
     Expr                expr )
 {
     Obj                 string;         /* string value            */
@@ -1158,7 +1158,7 @@ Obj             EvalFloatExprLazy (
 **  'EvalFloatExpr'   evaluates the  float  expression  <expr>  to a float
 **  value.
 */
-Obj EvalFloatExprEager(Expr expr)
+static Obj EvalFloatExprEager(Expr expr)
 {
     UInt ix = READ_EXPR(expr, 0);
     return  GET_VALUE_FROM_CURRENT_BODY(ix);
@@ -1178,7 +1178,7 @@ Obj EvalFloatExprEager(Expr expr)
 static Obj  RecExpr1(Expr expr);
 static void RecExpr2(Obj rec, Expr expr);
 
-Obj             EvalRecExpr (
+static Obj             EvalRecExpr (
     Expr                expr )
 {
     Obj                 rec;            /* record value, result            */
@@ -1207,7 +1207,7 @@ Obj             EvalRecExpr (
 **  expression    can refer to this variable    and its  subobjects to create
 **  objects that are not trees.
 */
-Obj             EvalRecTildeExpr (
+static Obj             EvalRecTildeExpr (
     Expr                expr )
 {
     Obj                 rec;            /* record value, result            */
@@ -1339,7 +1339,7 @@ void            (* PrintExprFuncs[256] ) ( Expr expr );
 **  this  is ever called,   then  GAP is  in  serious   trouble, such as   an
 **  overwritten type field of an expression.
 */
-void            PrintUnknownExpr (
+static void            PrintUnknownExpr (
     Expr                expr )
 {
     Pr( "Panic: tried to print an expression of unknown type '%d'\n",
@@ -1381,7 +1381,7 @@ extern inline struct ExprsState * ExprsState(void)
 **
 **  'PrintNot' print a not operation in the following form: 'not <expr>'.
 */
-void            PrintNot (
+static void            PrintNot (
     Expr                expr )
 {
     UInt                oldPrec;
@@ -1412,7 +1412,7 @@ void            PrintNot (
 **  'PrintBinop'  prints  the   binary operator    expression <expr>,   using
 **  'PrintPrecedence' for parenthesising.
 */
-void            PrintAInv (
+static void            PrintAInv (
     Expr                expr )
 {
     UInt                oldPrec;
@@ -1435,7 +1435,7 @@ void            PrintAInv (
     PrintPrecedence = oldPrec;
 }
 
-void            PrintBinop (
+static void            PrintBinop (
     Expr                expr )
 {
     UInt                oldPrec;        /* old precedence level           */
@@ -1504,7 +1504,7 @@ void            PrintBinop (
 **
 **  'PrintIntExpr' prints the literal integer expression <expr>.
 */
-void            PrintIntExpr (
+static void            PrintIntExpr (
     Expr                expr )
 {
     if ( IS_INTEXPR(expr) ) {
@@ -1520,7 +1520,7 @@ void            PrintIntExpr (
 **
 *F  PrintTildeExpr(<expr>) . . . . . . . . . . . print tilde expression
 */
-void            PrintTildeExpr (
+static void            PrintTildeExpr (
     Expr                expr )
 {
     Pr( "~", 0L, 0L );
@@ -1530,7 +1530,7 @@ void            PrintTildeExpr (
 **
 *F  PrintTrueExpr(<expr>) . . . . . . . . . . . print literal true expression
 */
-void            PrintTrueExpr (
+static void            PrintTrueExpr (
     Expr                expr )
 {
     Pr( "true", 0L, 0L );
@@ -1541,7 +1541,7 @@ void            PrintTrueExpr (
 **
 *F  PrintFalseExpr(<expr>)  . . . . . . . . .  print literal false expression
 */
-void            PrintFalseExpr (
+static void            PrintFalseExpr (
     Expr                expr )
 {
     Pr( "false", 0L, 0L );
@@ -1552,7 +1552,7 @@ void            PrintFalseExpr (
 **
 *F  PrintCharExpr(<expr>) . . . . . . . .  print literal character expression
 */
-void            PrintCharExpr (
+static void            PrintCharExpr (
     Expr                expr )
 {
     UChar               chr;
@@ -1575,7 +1575,7 @@ void            PrintCharExpr (
 **
 **  'PrintPermExpr' prints the permutation expression <expr>.
 */
-void            PrintPermExpr (
+static void            PrintPermExpr (
     Expr                expr )
 {
     Expr                cycle;          /* one cycle of permutation expr.  */
@@ -1610,7 +1610,7 @@ void            PrintPermExpr (
 **
 **  'PrintListExpr' prints the list expression <expr>.
 */
-void            PrintListExpr (
+static void            PrintListExpr (
     Expr                expr )
 {
     Int                 len;            /* logical length of <list>        */
@@ -1642,7 +1642,7 @@ void            PrintListExpr (
 **
 **  'PrintRangeExpr' prints the record expression <expr>.
 */
-void            PrintRangeExpr (
+static void            PrintRangeExpr (
     Expr                expr )
 {
     if ( SIZE_EXPR( expr ) == 2*sizeof(Expr) ) {
@@ -1665,7 +1665,7 @@ void            PrintRangeExpr (
 **
 **  'PrintStringExpr' prints the string expression <expr>.
 */
-void            PrintStringExpr (
+static void            PrintStringExpr (
     Expr                expr )
 {
     UInt ix = READ_EXPR(expr, 0);
@@ -1680,7 +1680,7 @@ void            PrintStringExpr (
 **
 **  'PrintFloatExpr' prints the float expression <expr>.
 */
-void            PrintFloatExprLazy (
+static void            PrintFloatExprLazy (
     Expr                expr )
 {
   // FIXME: this code is not GC safe
@@ -1693,7 +1693,7 @@ void            PrintFloatExprLazy (
 **
 **  'PrintFloatExpr' prints the float expression <expr>.
 */
-void            PrintFloatExprEager (
+static void            PrintFloatExprEager (
     Expr                expr )
 {
   // FIXME: this code is not GC safe
@@ -1743,7 +1743,7 @@ void            PrintRecExpr1 (
     }
 }
 
-void            PrintRecExpr (
+static void            PrintRecExpr (
     Expr                expr )
 {
     Pr("%2>rec(\n%2>",0L,0L);
@@ -1753,7 +1753,7 @@ void            PrintRecExpr (
 }
 
 
-Obj FuncFLUSH_FLOAT_LITERAL_CACHE(Obj self)
+static Obj FuncFLUSH_FLOAT_LITERAL_CACHE(Obj self)
 {
 #ifdef HPCGAP
     FLOAT_LITERAL_CACHE = NewAtomicList(T_ALIST, 0);

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -334,9 +334,7 @@ UInt CharFFE (
     return CHAR_FF( FLD_FFE(ffe) );
 }
 
-static Obj FuncCHAR_FFE_DEFAULT (
-    Obj                 self,
-    Obj                 ffe )
+static Obj FuncCHAR_FFE_DEFAULT(Obj self, Obj ffe)
 {
     return INTOBJ_INT( CHAR_FF( FLD_FFE(ffe) ) );
 }
@@ -382,9 +380,7 @@ UInt DegreeFFE (
     return d;
 }
 
-static Obj FuncDEGREE_FFE_DEFAULT (
-    Obj                 self,
-    Obj                 ffe )
+static Obj FuncDEGREE_FFE_DEFAULT(Obj self, Obj ffe)
 {
     return INTOBJ_INT( DegreeFFE( ffe ) );
 }
@@ -424,9 +420,7 @@ Obj TypeFFE(Obj ffe)
 **  Since '=' ought  to be transitive we also  want 'b = c'  to be 'true' and
 **  this is a problem, because they are represented over incompatible fields.
 */
-static Int             EqFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Int EqFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR;         /* value of left and right         */
     FF                  fL, fR;         /* field of left and right         */
@@ -482,9 +476,7 @@ static Int             EqFFE (
 **  'LtFFEFFE' returns 'True' if the  finite field element <opL> is  strictly
 **  less than the finite field element <opR> and 'False' otherwise.
 */
-static Int             LtFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Int LtFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR;         /* value of left and right         */
     FF                  fL, fR;         /* field of left and right         */
@@ -541,9 +533,7 @@ static Int             LtFFE (
 **  'PrFFV' prints the value <val> from the finite field <fld>.
 **
 */
-static void            PrFFV (
-    FF                  fld,
-    FFV                 val )
+static void PrFFV(FF fld, FFV val)
 {
     UInt                q;              /* size   of finite field          */
     UInt                p;              /* char.  of finite field          */
@@ -591,8 +581,7 @@ static void            PrFFV (
 **
 **  'PrFFE' prints the finite field element <ffe>.
 */
-static void            PrFFE (
-    Obj                 ffe )
+static void PrFFE(Obj ffe)
 {
     PrFFV( FLD_FFE(ffe), VAL_FFE(ffe) );
 }
@@ -615,9 +604,7 @@ static void            PrFFE (
 */
 static Obj SUM_FFE_LARGE;
 
-static Obj             SumFFEFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj SumFFEFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fL, fR, fX;     /* field of left, right, result    */
@@ -659,9 +646,7 @@ static Obj             SumFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             SumFFEInt (
-    Obj                 opL,
-    Obj                 opR )
+static Obj SumFFEInt(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -691,9 +676,7 @@ static Obj             SumFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             SumIntFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj SumIntFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -728,8 +711,7 @@ static Obj             SumIntFFE (
 **
 *F  ZeroFFE(<op>) . . . . . . . . . . . . . .  zero of a finite field element
 */
-static Obj             ZeroFFE (
-    Obj                 op )
+static Obj ZeroFFE(Obj op)
 {
     FF                  fX;             /* field of result                 */
 
@@ -745,8 +727,7 @@ static Obj             ZeroFFE (
 **
 *F  AInvFFE(<op>) . . . . . . . . . . additive inverse of finite field element
 */
-static Obj             AInvFFE (
-    Obj                 op )
+static Obj AInvFFE(Obj op)
 {
     FFV                 v, vX;          /* value of operand, result        */
     FF                  fX;             /* field of result                 */
@@ -782,9 +763,7 @@ static Obj             AInvFFE (
 */
 static Obj DIFF_FFE_LARGE;
 
-static Obj             DiffFFEFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffFFEFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fL, fR, fX;     /* field of left, right, result    */
@@ -827,9 +806,7 @@ static Obj             DiffFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             DiffFFEInt (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffFFEInt(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -860,9 +837,7 @@ static Obj             DiffFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             DiffIntFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffIntFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -911,9 +886,7 @@ static Obj             DiffIntFFE (
 */
 static Obj PROD_FFE_LARGE;
 
-static Obj             ProdFFEFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdFFEFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fL, fR, fX;     /* field of left, right, result    */
@@ -955,9 +928,7 @@ static Obj             ProdFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             ProdFFEInt (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdFFEInt(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -987,9 +958,7 @@ static Obj             ProdFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             ProdIntFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdIntFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -1024,8 +993,7 @@ static Obj             ProdIntFFE (
 **
 *F  OneFFE(<op>)  . . . . . . . . . . . . . . . one of a finite field element
 */
-static Obj             OneFFE (
-    Obj                 op )
+static Obj OneFFE(Obj op)
 {
     FF                  fX;             /* field of result                 */
 
@@ -1041,8 +1009,7 @@ static Obj             OneFFE (
 **
 *F  InvFFE(<op>)  . . . . . . . . . . . . . . inverse of finite field element
 */
-static Obj             InvFFE (
-    Obj                 op )
+static Obj InvFFE(Obj op)
 {
     FFV                 v, vX;          /* value of operand, result        */
     FF                  fX;             /* field of result                 */
@@ -1079,9 +1046,7 @@ static Obj             InvFFE (
 */
 static Obj QUO_FFE_LARGE;
 
-static Obj             QuoFFEFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj QuoFFEFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fL, fR, fX;     /* field of left, right, result    */
@@ -1130,9 +1095,7 @@ static Obj             QuoFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             QuoFFEInt (
-    Obj                 opL,
-    Obj                 opR )
+static Obj QuoFFEInt(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -1169,9 +1132,7 @@ static Obj             QuoFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-static Obj             QuoIntFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj QuoIntFFE(Obj opL, Obj opR)
 {
     FFV                 vL, vR, vX;     /* value of left, right, result    */
     FF                  fX;             /* field of result                 */
@@ -1220,9 +1181,7 @@ static Obj             QuoIntFFE (
 **  'PowFFEInt' just does the conversions mentioned  above and then calls the
 **  macro 'POW_FFV' to do the actual exponentiation.
 */
-static Obj             PowFFEInt (
-    Obj                 opL,
-    Obj                 opR )
+static Obj PowFFEInt(Obj opL, Obj opR)
 {
     FFV                 vL, vX;         /* value of left, result           */
     Int                 vR;             /* value of right                  */
@@ -1268,9 +1227,7 @@ static Obj             PowFFEInt (
 **
 *F  PowFFEFFE( <opL>, <opR> ) . . . . . . conjugate of a finite field element
 */
-static Obj PowFFEFFE (
-    Obj                 opL,
-    Obj                 opR )
+static Obj PowFFEFFE(Obj opL, Obj opR)
 {
     /* get the field for the result                                        */
     if ( CHAR_FF( FLD_FFE(opL) ) != CHAR_FF( FLD_FFE(opR) ) ) {
@@ -1294,9 +1251,7 @@ static Obj PowFFEFFE (
 */
 static Obj IsFFEFilt;
 
-static Obj FuncIS_FFE (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_FFE(Obj self, Obj obj)
 {
     /* return 'true' if <obj> is a finite field element                    */
     if ( IS_FFE(obj) ) {
@@ -1322,10 +1277,7 @@ static Obj FuncIS_FFE (
 */
 static Obj LOG_FFE_LARGE;
 
-static Obj FuncLOG_FFE_DEFAULT (
-    Obj                 self,
-    Obj                 opZ,
-    Obj                 opR )
+static Obj FuncLOG_FFE_DEFAULT(Obj self, Obj opZ, Obj opR)
 {
     FFV                 vZ, vR;         /* value of left, right            */
     FF                  fZ, fR, fX;     /* field of left, right, common    */
@@ -1412,8 +1364,7 @@ static Obj FuncLOG_FFE_DEFAULT (
 */
 static Obj IntFF;
 
-static Obj INT_FF (
-    FF                  ff )
+static Obj INT_FF(FF ff)
 {
     Obj                 conv;           /* conversion table, result        */
     Int                 q;              /* size of finite field            */
@@ -1442,10 +1393,7 @@ static Obj INT_FF (
 }
 
 
-
-static Obj FuncINT_FFE_DEFAULT (
-    Obj                 self,
-    Obj                 z )
+static Obj FuncINT_FFE_DEFAULT(Obj self, Obj z)
 {
     FFV                 v;              /* value of finite field element   */
     FF                  ff;             /* finite field                    */
@@ -1495,9 +1443,7 @@ static Obj FuncINT_FFE_DEFAULT (
 */
 static Obj ZOp;
 
-static Obj FuncZ (
-    Obj                 self,
-    Obj                 q )
+static Obj FuncZ(Obj self, Obj q)
 {
     FF                  ff;             /* the finite field                */
 
@@ -1520,7 +1466,7 @@ static Obj FuncZ (
     return NEW_FFE(ff, (q == INTOBJ_INT(2)) ? 1 : 2);
 }
 
-static Obj FuncZ2 ( Obj self, Obj p, Obj d)
+static Obj FuncZ2(Obj self, Obj p, Obj d)
 {
     FF   ff;
     Int  ip, id, id1;

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -56,7 +56,6 @@ static Obj TypeFF0;
 **
 **  These GAP functions are called to compute types of finite field elemnents
 */
-
 static Obj TYPE_FFE;
 static Obj TYPE_FFE0;
 static Obj TYPE_KERNEL_OBJECT;
@@ -335,7 +334,7 @@ UInt CharFFE (
     return CHAR_FF( FLD_FFE(ffe) );
 }
 
-Obj FuncCHAR_FFE_DEFAULT (
+static Obj FuncCHAR_FFE_DEFAULT (
     Obj                 self,
     Obj                 ffe )
 {
@@ -383,7 +382,7 @@ UInt DegreeFFE (
     return d;
 }
 
-Obj FuncDEGREE_FFE_DEFAULT (
+static Obj FuncDEGREE_FFE_DEFAULT (
     Obj                 self,
     Obj                 ffe )
 {
@@ -425,7 +424,7 @@ Obj TypeFFE(Obj ffe)
 **  Since '=' ought  to be transitive we also  want 'b = c'  to be 'true' and
 **  this is a problem, because they are represented over incompatible fields.
 */
-Int             EqFFE (
+static Int             EqFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -483,7 +482,7 @@ Int             EqFFE (
 **  'LtFFEFFE' returns 'True' if the  finite field element <opL> is  strictly
 **  less than the finite field element <opR> and 'False' otherwise.
 */
-Int             LtFFE (
+static Int             LtFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -542,7 +541,7 @@ Int             LtFFE (
 **  'PrFFV' prints the value <val> from the finite field <fld>.
 **
 */
-void            PrFFV (
+static void            PrFFV (
     FF                  fld,
     FFV                 val )
 {
@@ -592,7 +591,7 @@ void            PrFFV (
 **
 **  'PrFFE' prints the finite field element <ffe>.
 */
-void            PrFFE (
+static void            PrFFE (
     Obj                 ffe )
 {
     PrFFV( FLD_FFE(ffe), VAL_FFE(ffe) );
@@ -616,7 +615,7 @@ void            PrFFE (
 */
 static Obj SUM_FFE_LARGE;
 
-Obj             SumFFEFFE (
+static Obj             SumFFEFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -660,7 +659,7 @@ Obj             SumFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-Obj             SumFFEInt (
+static Obj             SumFFEInt (
     Obj                 opL,
     Obj                 opR )
 {
@@ -692,7 +691,7 @@ Obj             SumFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-Obj             SumIntFFE (
+static Obj             SumIntFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -729,7 +728,7 @@ Obj             SumIntFFE (
 **
 *F  ZeroFFE(<op>) . . . . . . . . . . . . . .  zero of a finite field element
 */
-Obj             ZeroFFE (
+static Obj             ZeroFFE (
     Obj                 op )
 {
     FF                  fX;             /* field of result                 */
@@ -746,7 +745,7 @@ Obj             ZeroFFE (
 **
 *F  AInvFFE(<op>) . . . . . . . . . . additive inverse of finite field element
 */
-Obj             AInvFFE (
+static Obj             AInvFFE (
     Obj                 op )
 {
     FFV                 v, vX;          /* value of operand, result        */
@@ -783,7 +782,7 @@ Obj             AInvFFE (
 */
 static Obj DIFF_FFE_LARGE;
 
-Obj             DiffFFEFFE (
+static Obj             DiffFFEFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -828,7 +827,7 @@ Obj             DiffFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-Obj             DiffFFEInt (
+static Obj             DiffFFEInt (
     Obj                 opL,
     Obj                 opR )
 {
@@ -861,7 +860,7 @@ Obj             DiffFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-Obj             DiffIntFFE (
+static Obj             DiffIntFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -912,7 +911,7 @@ Obj             DiffIntFFE (
 */
 static Obj PROD_FFE_LARGE;
 
-Obj             ProdFFEFFE (
+static Obj             ProdFFEFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -956,7 +955,7 @@ Obj             ProdFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-Obj             ProdFFEInt (
+static Obj             ProdFFEInt (
     Obj                 opL,
     Obj                 opR )
 {
@@ -988,7 +987,7 @@ Obj             ProdFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-Obj             ProdIntFFE (
+static Obj             ProdIntFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1025,7 +1024,7 @@ Obj             ProdIntFFE (
 **
 *F  OneFFE(<op>)  . . . . . . . . . . . . . . . one of a finite field element
 */
-Obj             OneFFE (
+static Obj             OneFFE (
     Obj                 op )
 {
     FF                  fX;             /* field of result                 */
@@ -1042,7 +1041,7 @@ Obj             OneFFE (
 **
 *F  InvFFE(<op>)  . . . . . . . . . . . . . . inverse of finite field element
 */
-Obj             InvFFE (
+static Obj             InvFFE (
     Obj                 op )
 {
     FFV                 v, vX;          /* value of operand, result        */
@@ -1080,7 +1079,7 @@ Obj             InvFFE (
 */
 static Obj QUO_FFE_LARGE;
 
-Obj             QuoFFEFFE (
+static Obj             QuoFFEFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1131,7 +1130,7 @@ Obj             QuoFFEFFE (
     return NEW_FFE( fX, vX );
 }
 
-Obj             QuoFFEInt (
+static Obj             QuoFFEInt (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1170,7 +1169,7 @@ Obj             QuoFFEInt (
     return NEW_FFE( fX, vX );
 }
 
-Obj             QuoIntFFE (
+static Obj             QuoIntFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1221,7 +1220,7 @@ Obj             QuoIntFFE (
 **  'PowFFEInt' just does the conversions mentioned  above and then calls the
 **  macro 'POW_FFV' to do the actual exponentiation.
 */
-Obj             PowFFEInt (
+static Obj             PowFFEInt (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1269,7 +1268,7 @@ Obj             PowFFEInt (
 **
 *F  PowFFEFFE( <opL>, <opR> ) . . . . . . conjugate of a finite field element
 */
-Obj PowFFEFFE (
+static Obj PowFFEFFE (
     Obj                 opL,
     Obj                 opR )
 {
@@ -1293,9 +1292,9 @@ Obj PowFFEFFE (
 **  and 'false' otherwise.   'IsFFE' will cause  an  error if  called with an
 **  unbound variable.
 */
-Obj IsFFEFilt;
+static Obj IsFFEFilt;
 
-Obj FuncIS_FFE (
+static Obj FuncIS_FFE (
     Obj                 self,
     Obj                 obj )
 {
@@ -1321,9 +1320,9 @@ Obj FuncIS_FFE (
 **  'LogFFE'  returns the logarithm of  the nonzero finite  field element <z>
 **  with respect to the root <r> which must lie in the same field like <z>.
 */
-Obj LOG_FFE_LARGE;
+static Obj LOG_FFE_LARGE;
 
-Obj FuncLOG_FFE_DEFAULT (
+static Obj FuncLOG_FFE_DEFAULT (
     Obj                 self,
     Obj                 opZ,
     Obj                 opR )
@@ -1411,9 +1410,9 @@ Obj FuncLOG_FFE_DEFAULT (
 **  element <z>, which must of course be  an element  of a prime field, i.e.,
 **  the smallest integer <i> such that '<i> * <z>^0 = <z>'.
 */
-Obj IntFF;
+static Obj IntFF;
 
-Obj INT_FF (
+static Obj INT_FF (
     FF                  ff )
 {
     Obj                 conv;           /* conversion table, result        */
@@ -1444,7 +1443,7 @@ Obj INT_FF (
 
 
 
-Obj FuncINT_FFE_DEFAULT (
+static Obj FuncINT_FFE_DEFAULT (
     Obj                 self,
     Obj                 z )
 {
@@ -1496,7 +1495,7 @@ Obj FuncINT_FFE_DEFAULT (
 */
 static Obj ZOp;
 
-Obj FuncZ (
+static Obj FuncZ (
     Obj                 self,
     Obj                 q )
 {
@@ -1521,7 +1520,7 @@ Obj FuncZ (
     return NEW_FFE(ff, (q == INTOBJ_INT(2)) ? 1 : 2);
 }
 
-Obj FuncZ2 ( Obj self, Obj p, Obj d)
+static Obj FuncZ2 ( Obj self, Obj p, Obj d)
 {
     FF   ff;
     Int  ip, id, id1;

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -684,7 +684,7 @@ Obj             MakeFunction (
 **
 **  'EvalFuncExpr' evaluates the function expression <expr> to a function.
 */
-Obj             EvalFuncExpr (
+static Obj             EvalFuncExpr (
     Expr                expr )
 {
     Obj                 fexs;           /* func. expr. list of curr. func. */
@@ -705,7 +705,7 @@ Obj             EvalFuncExpr (
 **
 **  'PrintFuncExpr' prints a function expression.
 */
-void            PrintFuncExpr (
+static void            PrintFuncExpr (
     Expr                expr )
 {
     Obj                 fexs;           /* func. expr. list of curr. func. */
@@ -725,20 +725,20 @@ void            PrintFuncExpr (
 **
 **  'PrintProccall' prints a procedure call.
 */
-extern  void            PrintFunccall (
+static  void            PrintFunccall (
             Expr                call );
 
-extern  void            PrintFunccallOpts (
+static  void            PrintFunccallOpts (
             Expr                call );
 
-void            PrintProccall (
+static void            PrintProccall (
     Stat                call )
 {
     PrintFunccall( call );
     Pr( ";", 0L, 0L );
 }
 
-void            PrintProccallOpts (
+static void            PrintProccallOpts (
     Stat                call )
 {
     PrintFunccallOpts( call );
@@ -773,7 +773,7 @@ static void            PrintFunccall1 (
     }
 }
 
-void            PrintFunccall (
+static void            PrintFunccall (
     Expr                call )
 {
   PrintFunccall1( call );
@@ -783,7 +783,7 @@ void            PrintFunccall (
 }
 
 
-void             PrintFunccallOpts (
+static void             PrintFunccallOpts (
     Expr                call )
 {
     PrintFunccall1(READ_STAT(call, 1));
@@ -824,7 +824,7 @@ void ExecEnd(UInt error)
 **
 */
 
-Obj FuncSetRecursionTrapInterval( Obj self,  Obj interval )
+static Obj FuncSetRecursionTrapInterval( Obj self,  Obj interval )
 {
     while (!IS_INTOBJ(interval) || INT_INTOBJ(interval) <= 5)
         interval = ErrorReturnObj(
@@ -835,7 +835,7 @@ Obj FuncSetRecursionTrapInterval( Obj self,  Obj interval )
     return 0;
 }
 
-Obj FuncGetRecursionDepth( Obj self )
+static Obj FuncGetRecursionDepth( Obj self )
 {
     return INTOBJ_INT(GetRecursionDepth());
 }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -684,8 +684,7 @@ Obj             MakeFunction (
 **
 **  'EvalFuncExpr' evaluates the function expression <expr> to a function.
 */
-static Obj             EvalFuncExpr (
-    Expr                expr )
+static Obj EvalFuncExpr(Expr expr)
 {
     Obj                 fexs;           /* func. expr. list of curr. func. */
     Obj                 fexp;           /* function expression bag         */
@@ -705,8 +704,7 @@ static Obj             EvalFuncExpr (
 **
 **  'PrintFuncExpr' prints a function expression.
 */
-static void            PrintFuncExpr (
-    Expr                expr )
+static void PrintFuncExpr(Expr expr)
 {
     Obj                 fexs;           /* func. expr. list of curr. func. */
     Obj                 fexp;           /* function expression bag         */
@@ -725,21 +723,17 @@ static void            PrintFuncExpr (
 **
 **  'PrintProccall' prints a procedure call.
 */
-static  void            PrintFunccall (
-            Expr                call );
+static void PrintFunccall(Expr call);
 
-static  void            PrintFunccallOpts (
-            Expr                call );
+static void PrintFunccallOpts(Expr call);
 
-static void            PrintProccall (
-    Stat                call )
+static void PrintProccall(Stat call)
 {
     PrintFunccall( call );
     Pr( ";", 0L, 0L );
 }
 
-static void            PrintProccallOpts (
-    Stat                call )
+static void PrintProccallOpts(Stat call)
 {
     PrintFunccallOpts( call );
     Pr( ";", 0L, 0L );
@@ -773,8 +767,7 @@ static void            PrintFunccall1 (
     }
 }
 
-static void            PrintFunccall (
-    Expr                call )
+static void PrintFunccall(Expr call)
 {
   PrintFunccall1( call );
   
@@ -783,8 +776,7 @@ static void            PrintFunccall (
 }
 
 
-static void             PrintFunccallOpts (
-    Expr                call )
+static void PrintFunccallOpts(Expr call)
 {
     PrintFunccall1(READ_STAT(call, 1));
     Pr(" :%2> ", 0L, 0L);
@@ -824,7 +816,7 @@ void ExecEnd(UInt error)
 **
 */
 
-static Obj FuncSetRecursionTrapInterval( Obj self,  Obj interval )
+static Obj FuncSetRecursionTrapInterval(Obj self, Obj interval)
 {
     while (!IS_INTOBJ(interval) || INT_INTOBJ(interval) <= 5)
         interval = ErrorReturnObj(
@@ -835,7 +827,7 @@ static Obj FuncSetRecursionTrapInterval( Obj self,  Obj interval )
     return 0;
 }
 
-static Obj FuncGetRecursionDepth( Obj self )
+static Obj FuncGetRecursionDepth(Obj self)
 {
     return INTOBJ_INT(GetRecursionDepth());
 }

--- a/src/gap.c
+++ b/src/gap.c
@@ -157,16 +157,16 @@ TL: Obj ShellContext = 0;
 TL: Obj BaseShellContext = 0;
 */
 
-static Obj Shell ( Obj context, 
-            UInt canReturnVoid,
-            UInt canReturnObj,
-            UInt lastDepth,
-            UInt setTime,
-            Char *prompt,
-            Obj preCommandHook,
-            UInt catchQUIT,
-            Char *inFile,
-            Char *outFile)
+static Obj Shell(Obj    context,
+                 UInt   canReturnVoid,
+                 UInt   canReturnObj,
+                 UInt   lastDepth,
+                 UInt   setTime,
+                 Char * prompt,
+                 Obj    preCommandHook,
+                 UInt   catchQUIT,
+                 Char * inFile,
+                 Char * outFile)
 {
   UInt time = 0;
   UInt8 mem = 0;
@@ -338,8 +338,7 @@ static Obj Shell ( Obj context,
 }
 
 
-
-static Obj FuncSHELL (Obj self, Obj args)
+static Obj FuncSHELL(Obj self, Obj args)
 {
   Obj context = 0;
   UInt canReturnVoid = 0;
@@ -487,9 +486,7 @@ int main ( int argc, char * argv[] )
 **
 *F  FuncID_FUNC( <self>, <val1> ) . . . . . . . . . . . . . . . return <val1>
 */
-static Obj FuncID_FUNC (
-                 Obj                 self,
-                 Obj                 val1 )
+static Obj FuncID_FUNC(Obj self, Obj val1)
 {
   return val1;
 }
@@ -498,9 +495,7 @@ static Obj FuncID_FUNC (
 **
 *F  FuncRETURN_FIRST( <self>, <args> ) . . . . . . . . Return first argument
 */
-static Obj FuncRETURN_FIRST (
-                 Obj                 self,
-                 Obj                 args )
+static Obj FuncRETURN_FIRST(Obj self, Obj args)
 {
   if (!IS_PLIST(args) || LEN_PLIST(args) < 1)
         ErrorMayQuit("RETURN_FIRST requires one or more arguments",0,0);
@@ -512,9 +507,7 @@ static Obj FuncRETURN_FIRST (
 **
 *F  FuncRETURN_NOTHING( <self>, <arg> ) . . . . . . . . . . . Return nothing
 */
-static Obj FuncRETURN_NOTHING (
-                 Obj                 self,
-                 Obj                 arg )
+static Obj FuncRETURN_NOTHING(Obj self, Obj arg)
 {
   return 0;
 }
@@ -532,14 +525,13 @@ static Obj FuncRETURN_NOTHING (
 **  How much time execution of statements take is of course system dependent.
 **  The accuracy of this number is also system dependent.
 */
-static Obj FuncRuntime (
-                 Obj                 self )
+static Obj FuncRuntime(Obj self)
 {
   return INTOBJ_INT( SyTime() );
 }
 
 
-static Obj FuncRUNTIMES( Obj     self)
+static Obj FuncRUNTIMES(Obj self)
 {
   Obj    res;
   res = NEW_PLIST(T_PLIST, 4);
@@ -625,9 +617,7 @@ static Obj FuncNanosecondsSinceEpochInfo(Obj self)
 **  to leave this value unaffected.  Note that those parameters can  also  be
 **  set with the command line options '-x <x>' and '-y <y>'.
 */
-static Obj FuncSizeScreen (
-                    Obj                 self,
-                    Obj                 args )
+static Obj FuncSizeScreen(Obj self, Obj args)
 {
   Obj                 size;           /* argument and result list        */
   Obj                 elm;            /* one entry from size             */
@@ -719,9 +709,7 @@ static Obj FuncSizeScreen (
 */
 static Obj WindowCmdString;
 
-static Obj FuncWindowCmd (
-                   Obj              self,
-                   Obj             args )
+static Obj FuncWindowCmd(Obj self, Obj args)
 {
   Obj             tmp;
   Obj               list;
@@ -873,9 +861,7 @@ static Obj FuncWindowCmd (
 **
 **  'GASMAN( "display" | "clear" | "collect" | "message" | "partial" )'
 */
-static Obj FuncGASMAN (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncGASMAN(Obj self, Obj args)
 {
     /* check the argument                                                  */
     if ( ! IS_SMALL_LIST(args) || LEN_LIST(args) == 0 ) {
@@ -1029,12 +1015,12 @@ static Obj FuncGASMAN_STATS(Obj self)
   return res;      
 }
 
-static Obj FuncGASMAN_MESSAGE_STATUS( Obj self )
+static Obj FuncGASMAN_MESSAGE_STATUS(Obj self)
 {
   return INTOBJ_INT(SyMsgsFlagBags);
 }
 
-static Obj FuncGASMAN_LIMITS( Obj self )
+static Obj FuncGASMAN_LIMITS(Obj self)
 {
   Obj list;
   list = NEW_PLIST_IMM(T_PLIST_CYC, 3);
@@ -1060,7 +1046,7 @@ static Obj FuncGASMAN_MEM_CHECK(Obj self, Obj newval)
 *F  FuncTotalMemoryAllocated( <self> ) .expert function 'TotalMemoryAllocated'
 */
 
-static Obj FuncTotalMemoryAllocated( Obj self )
+static Obj FuncTotalMemoryAllocated(Obj self)
 {
     return ObjInt_UInt8(SizeAllBags);
 }
@@ -1102,9 +1088,7 @@ static Obj FuncTNAM_OBJ(Obj self, Obj obj)
 **
 *F  FuncOBJ_HANDLE( <self>, <obj> ) . . . . . .  expert function 'OBJ_HANDLE'
 */
-static Obj FuncOBJ_HANDLE (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncOBJ_HANDLE(Obj self, Obj obj)
 {
     UInt                hand;
     UInt                prod;
@@ -1184,7 +1168,7 @@ static Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 **
 */
 
-static Obj FuncSleep( Obj self, Obj secs )
+static Obj FuncSleep(Obj self, Obj secs)
 {
     Int s = GetSmallInt("Sleep", secs);
 
@@ -1208,7 +1192,7 @@ static Obj FuncSleep( Obj self, Obj secs )
 **
 */
 
-static Obj FuncMicroSleep( Obj self, Obj msecs )
+static Obj FuncMicroSleep(Obj self, Obj msecs)
 {
     Int s = GetSmallInt("MicroSleep", msecs);
 
@@ -1247,7 +1231,7 @@ static int SetExitValue(Obj code)
 **
 */
 
-static Obj FuncGAP_EXIT_CODE( Obj self, Obj code )
+static Obj FuncGAP_EXIT_CODE(Obj self, Obj code)
 {
   if (!SetExitValue(code))
     ErrorQuit("GAP_EXIT_CODE: Argument must be boolean or integer", 0L, 0L);
@@ -1261,7 +1245,7 @@ static Obj FuncGAP_EXIT_CODE( Obj self, Obj code )
 **
 */
 
-static Obj FuncQUIT_GAP( Obj self, Obj args )
+static Obj FuncQUIT_GAP(Obj self, Obj args)
 {
   if ( LEN_LIST(args) == 0 ) {
     SystemErrorCode = 0;
@@ -1281,7 +1265,7 @@ static Obj FuncQUIT_GAP( Obj self, Obj args )
 **
 */
 
-static Obj FuncFORCE_QUIT_GAP( Obj self, Obj args )
+static Obj FuncFORCE_QUIT_GAP(Obj self, Obj args)
 {
   if ( LEN_LIST(args) == 0 )
   {
@@ -1300,7 +1284,7 @@ static Obj FuncFORCE_QUIT_GAP( Obj self, Obj args )
 **
 */
 
-static Obj FuncSHOULD_QUIT_ON_BREAK( Obj self)
+static Obj FuncSHOULD_QUIT_ON_BREAK(Obj self)
 {
   return SyQuitOnBreak ? True : False;
 }
@@ -1313,7 +1297,8 @@ static Obj FuncSHOULD_QUIT_ON_BREAK( Obj self)
 ** the assortment of global variables previously used
 */
 
-static Obj FuncKERNEL_INFO(Obj self) {
+static Obj FuncKERNEL_INFO(Obj self)
+{
   Obj res = NEW_PREC(0);
   UInt r,lenvec;
   Char *p;
@@ -1462,10 +1447,11 @@ static Obj FuncKERNEL_INFO(Obj self) {
 
 static UInt BreakPointValue;
 
-static Obj FuncBREAKPOINT(Obj self, Obj arg) {
-  if (IS_INTOBJ(arg))
-    BreakPointValue = INT_INTOBJ(arg);
-  return (Obj) 0;
+static Obj FuncBREAKPOINT(Obj self, Obj arg)
+{
+    if (IS_INTOBJ(arg))
+        BreakPointValue = INT_INTOBJ(arg);
+    return (Obj)0;
 }
 
 #ifdef HPCGAP

--- a/src/gap.c
+++ b/src/gap.c
@@ -101,7 +101,7 @@ UInt Time;
 **  which is automatically assigned the amount of memory allocated while
 **  executing the last command.
 */
-UInt MemoryAllocated;
+static UInt MemoryAllocated;
 
 
 #ifndef HPCGAP
@@ -149,7 +149,7 @@ void ViewObjHandler ( Obj obj )
 **
 *F  main( <argc>, <argv> )  . . . . . . .  main program, read-eval-print loop
 */
-UInt QUITTINGGVar;
+static UInt QUITTINGGVar;
 
 
 /*
@@ -157,7 +157,7 @@ TL: Obj ShellContext = 0;
 TL: Obj BaseShellContext = 0;
 */
 
-Obj Shell ( Obj context, 
+static Obj Shell ( Obj context, 
             UInt canReturnVoid,
             UInt canReturnObj,
             UInt lastDepth,
@@ -339,7 +339,7 @@ Obj Shell ( Obj context,
 
 
 
-Obj FuncSHELL (Obj self, Obj args)
+static Obj FuncSHELL (Obj self, Obj args)
 {
   Obj context = 0;
   UInt canReturnVoid = 0;
@@ -487,7 +487,7 @@ int main ( int argc, char * argv[] )
 **
 *F  FuncID_FUNC( <self>, <val1> ) . . . . . . . . . . . . . . . return <val1>
 */
-Obj FuncID_FUNC (
+static Obj FuncID_FUNC (
                  Obj                 self,
                  Obj                 val1 )
 {
@@ -498,7 +498,7 @@ Obj FuncID_FUNC (
 **
 *F  FuncRETURN_FIRST( <self>, <args> ) . . . . . . . . Return first argument
 */
-Obj FuncRETURN_FIRST (
+static Obj FuncRETURN_FIRST (
                  Obj                 self,
                  Obj                 args )
 {
@@ -512,7 +512,7 @@ Obj FuncRETURN_FIRST (
 **
 *F  FuncRETURN_NOTHING( <self>, <arg> ) . . . . . . . . . . . Return nothing
 */
-Obj FuncRETURN_NOTHING (
+static Obj FuncRETURN_NOTHING (
                  Obj                 self,
                  Obj                 arg )
 {
@@ -532,14 +532,14 @@ Obj FuncRETURN_NOTHING (
 **  How much time execution of statements take is of course system dependent.
 **  The accuracy of this number is also system dependent.
 */
-Obj FuncRuntime (
+static Obj FuncRuntime (
                  Obj                 self )
 {
   return INTOBJ_INT( SyTime() );
 }
 
 
-Obj FuncRUNTIMES( Obj     self)
+static Obj FuncRUNTIMES( Obj     self)
 {
   Obj    res;
   res = NEW_PLIST(T_PLIST, 4);
@@ -561,7 +561,7 @@ Obj FuncRUNTIMES( Obj     self)
 **  function wraps SyNanosecondsSinceEpoch.
 **
 */
-Obj FuncNanosecondsSinceEpoch(Obj self)
+static Obj FuncNanosecondsSinceEpoch(Obj self)
 {
   Int8 val = SyNanosecondsSinceEpoch();
 
@@ -581,7 +581,7 @@ Obj FuncNanosecondsSinceEpoch(Obj self)
 **  contains information about the timers used for FuncNanosecondsSinceEpoch
 **
 */
-Obj FuncNanosecondsSinceEpochInfo(Obj self)
+static Obj FuncNanosecondsSinceEpochInfo(Obj self)
 {
   Obj res, tmp;
   Int8 resolution;
@@ -625,7 +625,7 @@ Obj FuncNanosecondsSinceEpochInfo(Obj self)
 **  to leave this value unaffected.  Note that those parameters can  also  be
 **  set with the command line options '-x <x>' and '-y <y>'.
 */
-Obj FuncSizeScreen (
+static Obj FuncSizeScreen (
                     Obj                 self,
                     Obj                 args )
 {
@@ -719,7 +719,7 @@ Obj FuncSizeScreen (
 */
 static Obj WindowCmdString;
 
-Obj FuncWindowCmd (
+static Obj FuncWindowCmd (
                    Obj              self,
                    Obj             args )
 {
@@ -873,7 +873,7 @@ Obj FuncWindowCmd (
 **
 **  'GASMAN( "display" | "clear" | "collect" | "message" | "partial" )'
 */
-Obj FuncGASMAN (
+static Obj FuncGASMAN (
     Obj                 self,
     Obj                 args )
 {
@@ -1005,7 +1005,7 @@ again:
     return 0;
 }
 
-Obj FuncGASMAN_STATS(Obj self)
+static Obj FuncGASMAN_STATS(Obj self)
 {
   Obj res;
   Obj row;
@@ -1029,12 +1029,12 @@ Obj FuncGASMAN_STATS(Obj self)
   return res;      
 }
 
-Obj FuncGASMAN_MESSAGE_STATUS( Obj self )
+static Obj FuncGASMAN_MESSAGE_STATUS( Obj self )
 {
   return INTOBJ_INT(SyMsgsFlagBags);
 }
 
-Obj FuncGASMAN_LIMITS( Obj self )
+static Obj FuncGASMAN_LIMITS( Obj self )
 {
   Obj list;
   list = NEW_PLIST_IMM(T_PLIST_CYC, 3);
@@ -1047,7 +1047,7 @@ Obj FuncGASMAN_LIMITS( Obj self )
 
 #ifdef GAP_MEM_CHECK
 
-Obj FuncGASMAN_MEM_CHECK(Obj self, Obj newval)
+static Obj FuncGASMAN_MEM_CHECK(Obj self, Obj newval)
 {
     EnableMemCheck = INT_INTOBJ(newval);
     return 0;
@@ -1060,7 +1060,7 @@ Obj FuncGASMAN_MEM_CHECK(Obj self, Obj newval)
 *F  FuncTotalMemoryAllocated( <self> ) .expert function 'TotalMemoryAllocated'
 */
 
-Obj FuncTotalMemoryAllocated( Obj self )
+static Obj FuncTotalMemoryAllocated( Obj self )
 {
     return ObjInt_UInt8(SizeAllBags);
 }
@@ -1073,7 +1073,7 @@ Obj FuncTotalMemoryAllocated( Obj self )
 **  returns the bag size of the object. This does not include the size of
 **  sub-objects.
 */
-Obj FuncSIZE_OBJ(Obj self, Obj obj)
+static Obj FuncSIZE_OBJ(Obj self, Obj obj)
 {
     if (IS_INTOBJ(obj) || IS_FFE(obj))
         return INTOBJ_INT(0);
@@ -1084,7 +1084,7 @@ Obj FuncSIZE_OBJ(Obj self, Obj obj)
 **
 *F  FuncTNUM_OBJ( <self>, <obj> ) . . . . . . . .  expert function 'TNUM_OBJ'
 */
-Obj FuncTNUM_OBJ(Obj self, Obj obj)
+static Obj FuncTNUM_OBJ(Obj self, Obj obj)
 {
     return INTOBJ_INT(TNUM_OBJ(obj));
 }
@@ -1093,7 +1093,7 @@ Obj FuncTNUM_OBJ(Obj self, Obj obj)
 **
 *F  FuncTNAM_OBJ( <self>, <obj> ) . . . . . . . .  expert function 'TNAM_OBJ'
 */
-Obj FuncTNAM_OBJ(Obj self, Obj obj)
+static Obj FuncTNAM_OBJ(Obj self, Obj obj)
 {
     return MakeImmString(TNAM_OBJ(obj));
 }
@@ -1102,7 +1102,7 @@ Obj FuncTNAM_OBJ(Obj self, Obj obj)
 **
 *F  FuncOBJ_HANDLE( <self>, <obj> ) . . . . . .  expert function 'OBJ_HANDLE'
 */
-Obj FuncOBJ_HANDLE (
+static Obj FuncOBJ_HANDLE (
     Obj                 self,
     Obj                 obj )
 {
@@ -1139,7 +1139,7 @@ Obj FuncOBJ_HANDLE (
 **  object non-identical objects will have different handles. The integers
 **  may be large.
 */
-Obj FuncHANDLE_OBJ(Obj self, Obj obj)
+static Obj FuncHANDLE_OBJ(Obj self, Obj obj)
 {
     return ObjInt_UInt((UInt) obj);
 }
@@ -1152,7 +1152,7 @@ HANDLE_OBJ for non-immediate objects, but divided by sizeof(Obj), which gets
 rids of a few zero bits and thus increases the chance of the result value
 to be an immediate integer. */
 
-Obj FuncMASTER_POINTER_NUMBER(Obj self, Obj o)
+static Obj FuncMASTER_POINTER_NUMBER(Obj self, Obj o)
 {
     if (IS_INTOBJ(o) || IS_FFE(o)) {
         return INTOBJ_INT(0);
@@ -1169,7 +1169,7 @@ Obj FuncMASTER_POINTER_NUMBER(Obj self, Obj o)
 }
 
 /* Returns a measure of the size of a GAP function */
-Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
+static Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 {
     Obj body;
     if (TNUM_OBJ(f) != T_FUNCTION) return Fail;
@@ -1184,7 +1184,7 @@ Obj FuncFUNC_BODY_SIZE(Obj self, Obj f)
 **
 */
 
-Obj FuncSleep( Obj self, Obj secs )
+static Obj FuncSleep( Obj self, Obj secs )
 {
     Int s = GetSmallInt("Sleep", secs);
 
@@ -1208,7 +1208,7 @@ Obj FuncSleep( Obj self, Obj secs )
 **
 */
 
-Obj FuncMicroSleep( Obj self, Obj msecs )
+static Obj FuncMicroSleep( Obj self, Obj msecs )
 {
     Int s = GetSmallInt("MicroSleep", msecs);
 
@@ -1247,7 +1247,7 @@ static int SetExitValue(Obj code)
 **
 */
 
-Obj FuncGAP_EXIT_CODE( Obj self, Obj code )
+static Obj FuncGAP_EXIT_CODE( Obj self, Obj code )
 {
   if (!SetExitValue(code))
     ErrorQuit("GAP_EXIT_CODE: Argument must be boolean or integer", 0L, 0L);
@@ -1261,7 +1261,7 @@ Obj FuncGAP_EXIT_CODE( Obj self, Obj code )
 **
 */
 
-Obj FuncQUIT_GAP( Obj self, Obj args )
+static Obj FuncQUIT_GAP( Obj self, Obj args )
 {
   if ( LEN_LIST(args) == 0 ) {
     SystemErrorCode = 0;
@@ -1281,7 +1281,7 @@ Obj FuncQUIT_GAP( Obj self, Obj args )
 **
 */
 
-Obj FuncFORCE_QUIT_GAP( Obj self, Obj args )
+static Obj FuncFORCE_QUIT_GAP( Obj self, Obj args )
 {
   if ( LEN_LIST(args) == 0 )
   {
@@ -1300,7 +1300,7 @@ Obj FuncFORCE_QUIT_GAP( Obj self, Obj args )
 **
 */
 
-Obj FuncSHOULD_QUIT_ON_BREAK( Obj self)
+static Obj FuncSHOULD_QUIT_ON_BREAK( Obj self)
 {
   return SyQuitOnBreak ? True : False;
 }
@@ -1313,7 +1313,7 @@ Obj FuncSHOULD_QUIT_ON_BREAK( Obj self)
 ** the assortment of global variables previously used
 */
 
-Obj FuncKERNEL_INFO(Obj self) {
+static Obj FuncKERNEL_INFO(Obj self) {
   Obj res = NEW_PREC(0);
   UInt r,lenvec;
   Char *p;
@@ -1460,9 +1460,9 @@ Obj FuncKERNEL_INFO(Obj self) {
 ** condition based on the value of BreakPointValue to other breakpoints.
 */
 
-UInt BreakPointValue;
+static UInt BreakPointValue;
 
-Obj FuncBREAKPOINT(Obj self, Obj arg) {
+static Obj FuncBREAKPOINT(Obj self, Obj arg) {
   if (IS_INTOBJ(arg))
     BreakPointValue = INT_INTOBJ(arg);
   return (Obj) 0;
@@ -1476,7 +1476,7 @@ Obj FuncBREAKPOINT(Obj self, Obj arg) {
 **
 */
 
-Obj FuncTHREAD_UI(Obj self)
+static Obj FuncTHREAD_UI(Obj self)
 {
   return ThreadUI ? True : False;
 }

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -747,7 +747,7 @@ TNumGlobalBags GlobalBags;
 */
 static UInt GlobalSortingStatus;
 
-static void ClearGlobalBags ( void )
+static void ClearGlobalBags(void)
 {
   UInt i;
   for (i = 0; i < GlobalBags.nr; i++)
@@ -1789,7 +1789,7 @@ UInt ResizeBag (
 syJmp_buf RegsBags;
 
 #if defined(SPARC)
-static void SparcStackFuncBags( void )
+static void SparcStackFuncBags(void)
 {
   asm (" ta 0x3 ");
   asm (" mov %sp,%o0" );
@@ -1797,7 +1797,7 @@ static void SparcStackFuncBags( void )
 #endif
 
 
-static void GenStackFuncBags ( void )
+static void GenStackFuncBags(void)
 {
     Bag *               top;            /* top of stack                    */
     Bag *               p;              /* loop variable                   */

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -282,7 +282,7 @@ Bag *                   MptrEndBags;
 Bag *                   OldBags;
 Bag *                   YoungBags;
 Bag *                   AllocBags;
-UInt                    AllocSizeBags;
+static UInt             AllocSizeBags;
 Bag *                   EndBags;
 
 /* These macros, are (a) for more readable code, but more importantly
@@ -509,7 +509,7 @@ static void CANARY_FORBID_ACCESS_ALL_BAGS(void)
 #define CANARY_ENABLE_VALGRIND() VALGRIND_ENABLE_ERROR_REPORTING
 
 // CHANGED_BAG must be here to disable/enable valgrind
-void CHANGED_BAG(Bag bag)
+static void CHANGED_BAG(Bag bag)
 {
     CANARY_DISABLE_VALGRIND();
     if (CONST_PTR_BAG(bag) <= YoungBags && LINK_BAG(bag) == bag) {
@@ -747,7 +747,7 @@ TNumGlobalBags GlobalBags;
 */
 static UInt GlobalSortingStatus;
 
-void ClearGlobalBags ( void )
+static void ClearGlobalBags ( void )
 {
   UInt i;
   for (i = 0; i < GlobalBags.nr; i++)
@@ -1046,7 +1046,7 @@ void            InitCollectFuncBags (
 
 Int EnableMemCheck = 0;
 
-Int enableMemCheck(Char ** argv, void * dummy)
+static Int enableMemCheck(Char ** argv, void * dummy)
 {
     SyFputs( "# Warning: --enableMemCheck causes SEVERE slowdowns. Starting GAP may take several days!\n", 3 );
     EnableMemCheck = 1;
@@ -1789,7 +1789,7 @@ UInt ResizeBag (
 syJmp_buf RegsBags;
 
 #if defined(SPARC)
-void SparcStackFuncBags( void )
+static void SparcStackFuncBags( void )
 {
   asm (" ta 0x3 ");
   asm (" mov %sp,%o0" );
@@ -1797,7 +1797,7 @@ void SparcStackFuncBags( void )
 #endif
 
 
-void GenStackFuncBags ( void )
+static void GenStackFuncBags ( void )
 {
     Bag *               top;            /* top of stack                    */
     Bag *               p;              /* loop variable                   */
@@ -1832,7 +1832,7 @@ void GenStackFuncBags ( void )
 #endif
 }
 
-UInt FullBags;
+static UInt FullBags;
 
 /*  These are used to overwrite masterpointers which may still be
 linked from weak pointer objects but whose bag bodies have been

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -252,9 +252,7 @@ static Obj             TableGVars;
 */
 Obj             ErrorMustEvalToFuncFunc;
 
-static Obj             ErrorMustEvalToFuncHandler (
-    Obj                 self,
-    Obj                 args )
+static Obj ErrorMustEvalToFuncHandler(Obj self, Obj args)
 {
     ErrorQuit(
         "Function Calls: <func> must be a function",
@@ -276,9 +274,7 @@ static Obj             ErrorMustEvalToFuncHandler (
 */
 Obj             ErrorMustHaveAssObjFunc;
 
-static Obj             ErrorMustHaveAssObjHandler (
-    Obj                 self,
-    Obj                 args )
+static Obj ErrorMustHaveAssObjHandler(Obj self, Obj args)
 {
     ErrorQuit(
         "Variable: <<unknown>> must have an assigned value",
@@ -475,7 +471,8 @@ Obj             ValGVarTL (
     return val;
 }
 
-static Obj FuncIsThreadLocalGVar( Obj self, Obj name) {
+static Obj FuncIsThreadLocalGVar(Obj self, Obj name)
+{
   if (!IsStringConv(name))
     ErrorMayQuit("IsThreadLocalGVar: argument must be a string (not a %s)",
                  (Int)TNAM_OBJ(name), 0L);
@@ -488,7 +485,8 @@ static Obj FuncIsThreadLocalGVar( Obj self, Obj name) {
 
 
 #ifdef USE_GVAR_BUCKETS
-static Obj NewGVarBucket(void) {
+static Obj NewGVarBucket(void)
+{
     Obj result = NEW_PLIST(T_PLIST, GVAR_BUCKET_SIZE);
     SET_LEN_PLIST(result, GVAR_BUCKET_SIZE);
 #ifdef HPCGAP
@@ -733,9 +731,7 @@ void MakeThreadLocalVar (
 **  'MakeReadOnlyGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) read only.
 */
-static Obj FuncMakeReadOnlyGVar (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncMakeReadOnlyGVar(Obj self, Obj name)
 {       
     // check the argument
     RequireStringRep("MakeReadOnlyGVar", name);
@@ -796,9 +792,7 @@ void MakeReadWriteGVar (
 **  'MakeReadWriteGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) read and writable.
 */
-static Obj FuncMakeReadWriteGVar (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncMakeReadWriteGVar(Obj self, Obj name)
 {
     // check the argument
     RequireStringRep("MakeReadWriteGVar", name);
@@ -877,9 +871,7 @@ static Obj FuncIsConstantGVar(Obj self, Obj name)
 **  cause the execution  of an assignment to  that global variable, otherwise
 **  an error is signalled.
 */
-static Obj             FuncAUTO (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncAUTO(Obj self, Obj args)
 {
     Obj                 func;           /* the function to call            */
     Obj                 arg;            /* the argument to pass            */
@@ -982,8 +974,7 @@ UInt            completion_gvar (
 **
 *F  FuncIDENTS_GVAR( <self> ) . . . . . . . . . .  idents of global variables
 */
-static Obj FuncIDENTS_GVAR (
-    Obj                 self )
+static Obj FuncIDENTS_GVAR(Obj self)
 {
     Obj                 copy;
     UInt                i;
@@ -1010,8 +1001,7 @@ static Obj FuncIDENTS_GVAR (
     return copy;
 }
 
-static Obj FuncIDENTS_BOUND_GVARS (
-    Obj                 self )
+static Obj FuncIDENTS_BOUND_GVARS(Obj self)
 {
     Obj                 copy;
     UInt                i, j;
@@ -1046,10 +1036,7 @@ static Obj FuncIDENTS_BOUND_GVARS (
 **
 *F  FuncASS_GVAR( <self>, <gvar>, <val> ) . . . . assign to a global variable
 */
-static Obj FuncASS_GVAR (
-    Obj                 self,
-    Obj                 gvar,
-    Obj                 val )
+static Obj FuncASS_GVAR(Obj self, Obj gvar, Obj val)
 {
     // check the argument
     RequireStringRep("READ", gvar);
@@ -1063,9 +1050,7 @@ static Obj FuncASS_GVAR (
 **
 *F  FuncISB_GVAR( <self>, <gvar> )  . . check assignment of a global variable
 */
-static Obj FuncISB_GVAR (
-    Obj                 self,
-    Obj                 gvar )
+static Obj FuncISB_GVAR(Obj self, Obj gvar)
 {
     // check the argument
     RequireStringRep("ISB_GVAR", gvar);
@@ -1090,9 +1075,7 @@ static Obj FuncISB_GVAR (
 *F  FuncIS_AUTO_GVAR( <self>, <gvar> ) . . check if a global variable is auto
 */
 
-static Obj FuncIS_AUTO_GVAR (
-    Obj                 self,
-    Obj                 gvar )
+static Obj FuncIS_AUTO_GVAR(Obj self, Obj gvar)
 {
     // check the argument
     RequireStringRep("IS_AUTO_GVAR", gvar);
@@ -1106,9 +1089,7 @@ static Obj FuncIS_AUTO_GVAR (
 *F  FuncVAL_GVAR( <self>, <gvar> )  . . contents of a global variable
 */
 
-static Obj FuncVAL_GVAR (
-    Obj                 self,
-   Obj                 gvar )
+static Obj FuncVAL_GVAR(Obj self, Obj gvar)
 {
     Obj val;
 
@@ -1128,9 +1109,7 @@ static Obj FuncVAL_GVAR (
 *F  FuncUNB_GVAR( <self>, <gvar> )  . . unbind a global variable
 */
 
-static Obj FuncUNB_GVAR (
-    Obj                 self,
-    Obj                 gvar )
+static Obj FuncUNB_GVAR(Obj self, Obj gvar)
 {
     // check the argument
     RequireStringRep("UNB_GVAR", gvar);
@@ -1395,8 +1374,8 @@ void GVarsAfterCollectBags(void)
 
 #ifdef HPCGAP
 
-static GVarDescriptor *FirstDeclaredGVar;
-static GVarDescriptor *LastDeclaredGVar;
+static GVarDescriptor * FirstDeclaredGVar;
+static GVarDescriptor * LastDeclaredGVar;
 
 /****************************************************************************
 **

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -252,7 +252,7 @@ static Obj             TableGVars;
 */
 Obj             ErrorMustEvalToFuncFunc;
 
-Obj             ErrorMustEvalToFuncHandler (
+static Obj             ErrorMustEvalToFuncHandler (
     Obj                 self,
     Obj                 args )
 {
@@ -276,7 +276,7 @@ Obj             ErrorMustEvalToFuncHandler (
 */
 Obj             ErrorMustHaveAssObjFunc;
 
-Obj             ErrorMustHaveAssObjHandler (
+static Obj             ErrorMustHaveAssObjHandler (
     Obj                 self,
     Obj                 args )
 {
@@ -475,7 +475,7 @@ Obj             ValGVarTL (
     return val;
 }
 
-Obj FuncIsThreadLocalGVar( Obj self, Obj name) {
+static Obj FuncIsThreadLocalGVar( Obj self, Obj name) {
   if (!IsStringConv(name))
     ErrorMayQuit("IsThreadLocalGVar: argument must be a string (not a %s)",
                  (Int)TNAM_OBJ(name), 0L);
@@ -488,7 +488,7 @@ Obj FuncIsThreadLocalGVar( Obj self, Obj name) {
 
 
 #ifdef USE_GVAR_BUCKETS
-Obj NewGVarBucket(void) {
+static Obj NewGVarBucket(void) {
     Obj result = NEW_PLIST(T_PLIST, GVAR_BUCKET_SIZE);
     SET_LEN_PLIST(result, GVAR_BUCKET_SIZE);
 #ifdef HPCGAP
@@ -512,13 +512,13 @@ Obj ExprGVar ( UInt gvar )
 
 /* TL: Obj CurrNamespace = 0; */
 
-Obj FuncSET_NAMESPACE(Obj self, Obj str)
+static Obj FuncSET_NAMESPACE(Obj self, Obj str)
 {
     STATE(CurrNamespace) = str;
     return 0;
 }
 
-Obj FuncGET_NAMESPACE(Obj self)
+static Obj FuncGET_NAMESPACE(Obj self)
 {
     return STATE(CurrNamespace);
 }
@@ -733,7 +733,7 @@ void MakeThreadLocalVar (
 **  'MakeReadOnlyGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) read only.
 */
-Obj FuncMakeReadOnlyGVar (
+static Obj FuncMakeReadOnlyGVar (
     Obj                 self,
     Obj                 name )
 {       
@@ -758,7 +758,7 @@ Obj FuncMakeReadOnlyGVar (
 **  'MakeConstantGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) constant.
 */
-Obj FuncMakeConstantGVar(Obj self, Obj name)
+static Obj FuncMakeConstantGVar(Obj self, Obj name)
 {
     // check the argument
     RequireStringRep("MakeConstantGVar", name);
@@ -796,7 +796,7 @@ void MakeReadWriteGVar (
 **  'MakeReadWriteGVar' make the global  variable with the name <name>  (which
 **  must be a GAP string) read and writable.
 */
-Obj FuncMakeReadWriteGVar (
+static Obj FuncMakeReadWriteGVar (
     Obj                 self,
     Obj                 name )
 {
@@ -877,7 +877,7 @@ static Obj FuncIsConstantGVar(Obj self, Obj name)
 **  cause the execution  of an assignment to  that global variable, otherwise
 **  an error is signalled.
 */
-Obj             FuncAUTO (
+static Obj             FuncAUTO (
     Obj                 self,
     Obj                 args )
 {
@@ -982,7 +982,7 @@ UInt            completion_gvar (
 **
 *F  FuncIDENTS_GVAR( <self> ) . . . . . . . . . .  idents of global variables
 */
-Obj FuncIDENTS_GVAR (
+static Obj FuncIDENTS_GVAR (
     Obj                 self )
 {
     Obj                 copy;
@@ -1010,7 +1010,7 @@ Obj FuncIDENTS_GVAR (
     return copy;
 }
 
-Obj FuncIDENTS_BOUND_GVARS (
+static Obj FuncIDENTS_BOUND_GVARS (
     Obj                 self )
 {
     Obj                 copy;
@@ -1046,7 +1046,7 @@ Obj FuncIDENTS_BOUND_GVARS (
 **
 *F  FuncASS_GVAR( <self>, <gvar>, <val> ) . . . . assign to a global variable
 */
-Obj FuncASS_GVAR (
+static Obj FuncASS_GVAR (
     Obj                 self,
     Obj                 gvar,
     Obj                 val )
@@ -1063,7 +1063,7 @@ Obj FuncASS_GVAR (
 **
 *F  FuncISB_GVAR( <self>, <gvar> )  . . check assignment of a global variable
 */
-Obj FuncISB_GVAR (
+static Obj FuncISB_GVAR (
     Obj                 self,
     Obj                 gvar )
 {
@@ -1090,7 +1090,7 @@ Obj FuncISB_GVAR (
 *F  FuncIS_AUTO_GVAR( <self>, <gvar> ) . . check if a global variable is auto
 */
 
-Obj FuncIS_AUTO_GVAR (
+static Obj FuncIS_AUTO_GVAR (
     Obj                 self,
     Obj                 gvar )
 {
@@ -1106,7 +1106,7 @@ Obj FuncIS_AUTO_GVAR (
 *F  FuncVAL_GVAR( <self>, <gvar> )  . . contents of a global variable
 */
 
-Obj FuncVAL_GVAR (
+static Obj FuncVAL_GVAR (
     Obj                 self,
    Obj                 gvar )
 {
@@ -1128,7 +1128,7 @@ Obj FuncVAL_GVAR (
 *F  FuncUNB_GVAR( <self>, <gvar> )  . . unbind a global variable
 */
 
-Obj FuncUNB_GVAR (
+static Obj FuncUNB_GVAR (
     Obj                 self,
     Obj                 gvar )
 {
@@ -1395,8 +1395,8 @@ void GVarsAfterCollectBags(void)
 
 #ifdef HPCGAP
 
-GVarDescriptor *FirstDeclaredGVar;
-GVarDescriptor *LastDeclaredGVar;
+static GVarDescriptor *FirstDeclaredGVar;
+static GVarDescriptor *LastDeclaredGVar;
 
 /****************************************************************************
 **

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -102,19 +102,19 @@ void InstallPrintExprFunc(Int pos, void (*expr)(Expr))
     HashUnlock(&activeHooks);
 }
 
-UInt ProfileExecStatPassthrough(Stat stat)
+static UInt ProfileExecStatPassthrough(Stat stat)
 {
     GAP_HOOK_LOOP(visitStat, stat);
     return OriginalExecStatFuncsForHook[TNUM_STAT(stat)](stat);
 }
 
-Obj ProfileEvalExprPassthrough(Expr stat)
+static Obj ProfileEvalExprPassthrough(Expr stat)
 {
     GAP_HOOK_LOOP(visitStat, stat);
     return OriginalEvalExprFuncsForHook[TNUM_STAT(stat)](stat);
 }
 
-Obj ProfileEvalBoolPassthrough(Expr stat)
+static Obj ProfileEvalBoolPassthrough(Expr stat)
 {
     /* There are two cases we must pass through without touching */
     /* From TNUM_EXPR */

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -297,8 +297,8 @@ static int SerializedAlready(Obj obj)
 /* TNum-specific serialization/deserialization functions */
 
 static void RegisterSerializerFunctions(UInt                    tnum,
-                                 SerializationFunction   sfun,
-                                 DeserializationFunction dfun)
+                                        SerializationFunction   sfun,
+                                        DeserializationFunction dfun)
 {
     SerializationFuncByTNum[tnum] = sfun;
     DeserializationFuncByTNum[tnum] = dfun;

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -146,7 +146,7 @@ void AddGCRoots(void)
     GC_add_roots(p, (char *)p + sizeof(GAPState));
 }
 
-void RemoveGCRoots(void)
+static void RemoveGCRoots(void)
 {
     void * p = ActiveGAPState();
 #if defined(__CYGWIN__) || defined(__CYGWIN32__)
@@ -306,7 +306,7 @@ static Obj MakeImmString2(const Char * cstr1, const Char * cstr2)
     return result;
 }
 
-void * DispatchThread(void * arg)
+static void * DispatchThread(void * arg)
 {
     ThreadData * this_thread = arg;
     Region *     region;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -202,7 +202,7 @@ int TryLockMonitor(Monitor * monitor)
     return !pthread_mutex_trylock(&monitor->lock);
 }
 
-void UnlockMonitor(Monitor * monitor)
+static void UnlockMonitor(Monitor * monitor)
 {
     pthread_mutex_unlock(&monitor->lock);
 }
@@ -216,7 +216,7 @@ void UnlockMonitor(Monitor * monitor)
  ** again upon exit.
  */
 
-void WaitForMonitor(Monitor * monitor)
+static void WaitForMonitor(Monitor * monitor)
 {
     struct WaitList node;
     node.thread = GetTLS();
@@ -364,9 +364,9 @@ static Obj ArgumentError(const char * message)
 }
 
 /* TODO: register globals */
-Obj             FirstKeepAlive;
-Obj             LastKeepAlive;
-pthread_mutex_t KeepAliveLock;
+static Obj             FirstKeepAlive;
+static Obj             LastKeepAlive;
+static pthread_mutex_t KeepAliveLock;
 
 #define KEPTALIVE(obj) (ADDR_OBJ(obj)[1])
 #define PREV_KEPT(obj) (ADDR_OBJ(obj)[2])
@@ -463,7 +463,7 @@ static void ThreadedInterpreter(void * funcargs)
 ** is a unique identifier for the thread.
 */
 
-Obj FuncCreateThread(Obj self, Obj funcargs)
+static Obj FuncCreateThread(Obj self, Obj funcargs)
 {
     Int  i, n;
     Obj  thread;
@@ -490,7 +490,7 @@ Obj FuncCreateThread(Obj self, Obj funcargs)
 ** The function waits for an existing thread to finish.
 */
 
-Obj FuncWaitThread(Obj self, Obj obj)
+static Obj FuncWaitThread(Obj self, Obj obj)
 {
     const char * error = NULL;
     RequireThread("WaitThread", obj, "thread");
@@ -513,7 +513,7 @@ Obj FuncWaitThread(Obj self, Obj obj)
 **
 */
 
-Obj FuncCurrentThread(Obj self)
+static Obj FuncCurrentThread(Obj self)
 {
     return TLS(threadObject);
 }
@@ -524,7 +524,7 @@ Obj FuncCurrentThread(Obj self)
 **
 */
 
-Obj FuncThreadID(Obj self, Obj thread)
+static Obj FuncThreadID(Obj self, Obj thread)
 {
     RequireThread("ThreadID", thread, "thread");
     return INTOBJ_INT(ThreadID(thread));
@@ -536,7 +536,7 @@ Obj FuncThreadID(Obj self, Obj thread)
 **
 */
 
-Obj FuncKillThread(Obj self, Obj thread)
+static Obj FuncKillThread(Obj self, Obj thread)
 {
     int id;
     if (IS_INTOBJ(thread)) {
@@ -563,7 +563,7 @@ Obj FuncKillThread(Obj self, Obj thread)
 #define AS_STRING(s) #s
 
 
-Obj FuncInterruptThread(Obj self, Obj thread, Obj handler)
+static Obj FuncInterruptThread(Obj self, Obj thread, Obj handler)
 {
     int id;
     if (IS_INTOBJ(thread)) {
@@ -592,7 +592,7 @@ Obj FuncInterruptThread(Obj self, Obj thread, Obj handler)
 **
 */
 
-Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func)
+static Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func)
 {
     if (!IS_INTOBJ(handler) || INT_INTOBJ(handler) < 1 ||
         INT_INTOBJ(handler) > MAX_INTERRUPT)
@@ -621,7 +621,7 @@ Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func)
 */
 
 
-Obj FuncPauseThread(Obj self, Obj thread)
+static Obj FuncPauseThread(Obj self, Obj thread)
 {
     int id;
     if (IS_INTOBJ(thread)) {
@@ -646,7 +646,7 @@ Obj FuncPauseThread(Obj self, Obj thread)
 */
 
 
-Obj FuncResumeThread(Obj self, Obj thread)
+static Obj FuncResumeThread(Obj self, Obj thread)
 {
     int id;
     if (IS_INTOBJ(thread)) {
@@ -672,7 +672,7 @@ Obj FuncResumeThread(Obj self, Obj thread)
 */
 static Obj PublicRegion;
 
-Obj FuncRegionOf(Obj self, Obj obj)
+static Obj FuncRegionOf(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     return region == NULL ? PublicRegion : region->obj;
@@ -688,7 +688,7 @@ Obj FuncRegionOf(Obj self, Obj obj)
 */
 
 
-Obj FuncSetRegionName(Obj self, Obj obj, Obj name)
+static Obj FuncSetRegionName(Obj self, Obj obj, Obj name)
 {
     Region * region = GetRegionOf(obj);
     if (!region)
@@ -700,7 +700,7 @@ Obj FuncSetRegionName(Obj self, Obj obj, Obj name)
     return (Obj)0;
 }
 
-Obj FuncClearRegionName(Obj self, Obj obj)
+static Obj FuncClearRegionName(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     if (!region)
@@ -710,7 +710,7 @@ Obj FuncClearRegionName(Obj self, Obj obj)
     return (Obj)0;
 }
 
-Obj FuncRegionName(Obj self, Obj obj)
+static Obj FuncRegionName(Obj self, Obj obj)
 {
     Obj      result;
     Region * region = GetRegionOf(obj);
@@ -727,7 +727,7 @@ Obj FuncRegionName(Obj self, Obj obj)
 **
 */
 
-Obj FuncIsShared(Obj self, Obj obj)
+static Obj FuncIsShared(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     return (region && !region->fixed_owner) ? True : False;
@@ -739,7 +739,7 @@ Obj FuncIsShared(Obj self, Obj obj)
 **
 */
 
-Obj FuncIsPublic(Obj self, Obj obj)
+static Obj FuncIsPublic(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     return region == NULL ? True : False;
@@ -751,7 +751,7 @@ Obj FuncIsPublic(Obj self, Obj obj)
 **
 */
 
-Obj FuncIsThreadLocal(Obj self, Obj obj)
+static Obj FuncIsThreadLocal(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     return (region && region->fixed_owner && region->owner == GetTLS())
@@ -765,7 +765,7 @@ Obj FuncIsThreadLocal(Obj self, Obj obj)
 **
 */
 
-Obj FuncHaveWriteAccess(Obj self, Obj obj)
+static Obj FuncHaveWriteAccess(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     if (region != NULL &&
@@ -781,7 +781,7 @@ Obj FuncHaveWriteAccess(Obj self, Obj obj)
 **
 */
 
-Obj FuncHaveReadAccess(Obj self, Obj obj)
+static Obj FuncHaveReadAccess(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     if (region != NULL && CheckReadAccess(obj))
@@ -801,24 +801,24 @@ Obj FuncHaveReadAccess(Obj self, Obj obj)
 */
 
 
-Obj FuncHASH_LOCK(Obj self, Obj target)
+static Obj FuncHASH_LOCK(Obj self, Obj target)
 {
     HashLock(target);
     return (Obj)0;
 }
 
-Obj FuncHASH_UNLOCK(Obj self, Obj target)
+static Obj FuncHASH_UNLOCK(Obj self, Obj target)
 {
     HashUnlock(target);
     return (Obj)0;
 }
 
-Obj FuncHASH_LOCK_SHARED(Obj self, Obj target)
+static Obj FuncHASH_LOCK_SHARED(Obj self, Obj target)
 {
     HashLockShared(target);
     return (Obj)0;
 }
-Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target)
+static Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target)
 {
     HashUnlockShared(target);
     return (Obj)0;
@@ -833,7 +833,7 @@ Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target)
 **
 */
 
-Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function)
+static Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function)
 {
     volatile int locked = 0;
     jmp_buf      readJmpError;
@@ -852,7 +852,7 @@ Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function)
     return (Obj)0;
 }
 
-Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function)
+static Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function)
 {
     volatile int locked = 0;
     jmp_buf      readJmpError;
@@ -877,7 +877,7 @@ Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function)
 **
 */
 
-Obj FuncCREATOR_OF(Obj self, Obj obj)
+static Obj FuncCREATOR_OF(Obj self, Obj obj)
 {
 #ifdef TRACK_CREATOR
     Obj result = NEW_PLIST_IMM(T_PLIST, 2);
@@ -901,7 +901,7 @@ Obj FuncCREATOR_OF(Obj self, Obj obj)
 #endif
 }
 
-Obj FuncDISABLE_GUARDS(Obj self, Obj flag)
+static Obj FuncDISABLE_GUARDS(Obj self, Obj flag)
 {
     if (flag == False)
         TLS(DisableGuards) = 0;
@@ -915,7 +915,7 @@ Obj FuncDISABLE_GUARDS(Obj self, Obj flag)
     return (Obj)0;
 }
 
-Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func)
+static Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func)
 {
     Region * volatile oldRegion = TLS(currentRegion);
     Region * volatile region = GetRegionOf(obj);
@@ -939,39 +939,39 @@ Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func)
 }
 
 
-Obj TYPE_THREAD;
-Obj TYPE_SEMAPHORE;
-Obj TYPE_CHANNEL;
-Obj TYPE_BARRIER;
-Obj TYPE_SYNCVAR;
-Obj TYPE_REGION;
+static Obj TYPE_THREAD;
+static Obj TYPE_SEMAPHORE;
+static Obj TYPE_CHANNEL;
+static Obj TYPE_BARRIER;
+static Obj TYPE_SYNCVAR;
+static Obj TYPE_REGION;
 
-Obj TypeThread(Obj obj)
+static Obj TypeThread(Obj obj)
 {
     return TYPE_THREAD;
 }
 
-Obj TypeSemaphore(Obj obj)
+static Obj TypeSemaphore(Obj obj)
 {
     return TYPE_SEMAPHORE;
 }
 
-Obj TypeChannel(Obj obj)
+static Obj TypeChannel(Obj obj)
 {
     return TYPE_CHANNEL;
 }
 
-Obj TypeBarrier(Obj obj)
+static Obj TypeBarrier(Obj obj)
 {
     return TYPE_BARRIER;
 }
 
-Obj TypeSyncVar(Obj obj)
+static Obj TypeSyncVar(Obj obj)
 {
     return TYPE_SYNCVAR;
 }
 
-Obj TypeRegion(Obj obj)
+static Obj TypeRegion(Obj obj)
 {
     return TYPE_REGION;
 }
@@ -991,7 +991,7 @@ static void PrintSyncVar(Obj);
 static void PrintRegion(Obj);
 
 GVarDescriptor LastInaccessibleGVar;
-GVarDescriptor MAX_INTERRUPTGVar;
+static GVarDescriptor MAX_INTERRUPTGVar;
 
 static UInt RNAM_SIGINT;
 static UInt RNAM_SIGCHLD;
@@ -1354,7 +1354,7 @@ static int DestroyChannel(Channel * channel)
 }
 #endif
 
-Obj FuncCreateChannel(Obj self, Obj args)
+static Obj FuncCreateChannel(Obj self, Obj args)
 {
     int capacity;
     switch (LEN_PLIST(args)) {
@@ -1383,7 +1383,7 @@ static int IsChannel(Obj obj)
     return obj && TNUM_OBJ(obj) == T_CHANNEL;
 }
 
-Obj FuncDestroyChannel(Obj self, Obj channel)
+static Obj FuncDestroyChannel(Obj self, Obj channel)
 {
     RequireChannel("DestroyChannel", channel);
     if (!DestroyChannel(ObjPtr(channel)))
@@ -1391,27 +1391,27 @@ Obj FuncDestroyChannel(Obj self, Obj channel)
     return (Obj)0;
 }
 
-Obj FuncTallyChannel(Obj self, Obj channel)
+static Obj FuncTallyChannel(Obj self, Obj channel)
 {
     RequireChannel("TallyChannel", channel);
     return INTOBJ_INT(TallyChannel(ObjPtr(channel)));
 }
 
-Obj FuncSendChannel(Obj self, Obj channel, Obj obj)
+static Obj FuncSendChannel(Obj self, Obj channel, Obj obj)
 {
     RequireChannel("SendChannel", channel);
     SendChannel(ObjPtr(channel), obj, 1);
     return (Obj)0;
 }
 
-Obj FuncTransmitChannel(Obj self, Obj channel, Obj obj)
+static Obj FuncTransmitChannel(Obj self, Obj channel, Obj obj)
 {
     RequireChannel("TransmitChannel", channel);
     SendChannel(ObjPtr(channel), obj, 0);
     return (Obj)0;
 }
 
-Obj FuncMultiSendChannel(Obj self, Obj channel, Obj list)
+static Obj FuncMultiSendChannel(Obj self, Obj channel, Obj list)
 {
     RequireChannel("MultiSendChannel", channel);
     CheckIsDenseList("MultiSendChannel", "list", list);
@@ -1419,7 +1419,7 @@ Obj FuncMultiSendChannel(Obj self, Obj channel, Obj list)
     return (Obj)0;
 }
 
-Obj FuncMultiTransmitChannel(Obj self, Obj channel, Obj list)
+static Obj FuncMultiTransmitChannel(Obj self, Obj channel, Obj list)
 {
     RequireChannel("MultiTransmitChannel", channel);
     CheckIsDenseList("MultiTransmitChannel", "list", list);
@@ -1427,7 +1427,7 @@ Obj FuncMultiTransmitChannel(Obj self, Obj channel, Obj list)
     return (Obj)0;
 }
 
-Obj FuncTryMultiSendChannel(Obj self, Obj channel, Obj list)
+static Obj FuncTryMultiSendChannel(Obj self, Obj channel, Obj list)
 {
     RequireChannel("TryMultiSendChannel", channel);
     CheckIsDenseList("TryMultiSendChannel", "list", list);
@@ -1435,7 +1435,7 @@ Obj FuncTryMultiSendChannel(Obj self, Obj channel, Obj list)
 }
 
 
-Obj FuncTryMultiTransmitChannel(Obj self, Obj channel, Obj list)
+static Obj FuncTryMultiTransmitChannel(Obj self, Obj channel, Obj list)
 {
     RequireChannel("TryMultiTransmitChannel", channel);
     CheckIsDenseList("TryMultiTransmitChannel", "list", list);
@@ -1443,25 +1443,25 @@ Obj FuncTryMultiTransmitChannel(Obj self, Obj channel, Obj list)
 }
 
 
-Obj FuncTrySendChannel(Obj self, Obj channel, Obj obj)
+static Obj FuncTrySendChannel(Obj self, Obj channel, Obj obj)
 {
     RequireChannel("TrySendChannel", channel);
     return TrySendChannel(ObjPtr(channel), obj, 1) ? True : False;
 }
 
-Obj FuncTryTransmitChannel(Obj self, Obj channel, Obj obj)
+static Obj FuncTryTransmitChannel(Obj self, Obj channel, Obj obj)
 {
     RequireChannel("TryTransmitChannel", channel);
     return TrySendChannel(ObjPtr(channel), obj, 0) ? True : False;
 }
 
-Obj FuncReceiveChannel(Obj self, Obj channel)
+static Obj FuncReceiveChannel(Obj self, Obj channel)
 {
     RequireChannel("ReceiveChannel", channel);
     return ReceiveChannel(ObjPtr(channel));
 }
 
-int IsChannelList(Obj list)
+static int IsChannelList(Obj list)
 {
     int len = LEN_PLIST(list);
     int i;
@@ -1471,7 +1471,7 @@ int IsChannelList(Obj list)
     return 1;
 }
 
-Obj FuncReceiveAnyChannel(Obj self, Obj args)
+static Obj FuncReceiveAnyChannel(Obj self, Obj args)
 {
     if (IsChannelList(args))
         return ReceiveAnyChannel(args, 0);
@@ -1485,7 +1485,7 @@ Obj FuncReceiveAnyChannel(Obj self, Obj args)
     }
 }
 
-Obj FuncReceiveAnyChannelWithIndex(Obj self, Obj args)
+static Obj FuncReceiveAnyChannelWithIndex(Obj self, Obj args)
 {
     if (IsChannelList(args))
         return ReceiveAnyChannel(args, 1);
@@ -1499,20 +1499,20 @@ Obj FuncReceiveAnyChannelWithIndex(Obj self, Obj args)
     }
 }
 
-Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj count)
+static Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj count)
 {
     RequireChannel("MultiReceiveChannel", channel);
     RequireNonnegativeSmallInt("MultiReceiveChannel", count);
     return MultiReceiveChannel(ObjPtr(channel), INT_INTOBJ(count));
 }
 
-Obj FuncInspectChannel(Obj self, Obj channel)
+static Obj FuncInspectChannel(Obj self, Obj channel)
 {
     RequireChannel("InspectChannel", channel);
     return InspectChannel(ObjPtr(channel));
 }
 
-Obj FuncTryReceiveChannel(Obj self, Obj channel, Obj obj)
+static Obj FuncTryReceiveChannel(Obj self, Obj channel, Obj obj)
 {
     RequireChannel("TryReceiveChannel", channel);
     return TryReceiveChannel(ObjPtr(channel), obj);
@@ -1530,7 +1530,7 @@ static Obj CreateSemaphore(UInt count)
     return semBag;
 }
 
-Obj FuncCreateSemaphore(Obj self, Obj args)
+static Obj FuncCreateSemaphore(Obj self, Obj args)
 {
     Int count;
     switch (LEN_PLIST(args)) {
@@ -1554,7 +1554,7 @@ Obj FuncCreateSemaphore(Obj self, Obj args)
     return CreateSemaphore(count);
 }
 
-Obj FuncSignalSemaphore(Obj self, Obj semaphore)
+static Obj FuncSignalSemaphore(Obj self, Obj semaphore)
 {
     Semaphore * sem;
     RequireSemaphore("SignalSemaphore", semaphore);
@@ -1567,7 +1567,7 @@ Obj FuncSignalSemaphore(Obj self, Obj semaphore)
     return (Obj)0;
 }
 
-Obj FuncWaitSemaphore(Obj self, Obj semaphore)
+static Obj FuncWaitSemaphore(Obj self, Obj semaphore)
 {
     Semaphore * sem;
     RequireSemaphore("WaitSemaphore", semaphore);
@@ -1584,7 +1584,7 @@ Obj FuncWaitSemaphore(Obj self, Obj semaphore)
     return (Obj)0;
 }
 
-Obj FuncTryWaitSemaphore(Obj self, Obj semaphore)
+static Obj FuncTryWaitSemaphore(Obj self, Obj semaphore)
 {
     Semaphore * sem;
     int         success;
@@ -1601,30 +1601,30 @@ Obj FuncTryWaitSemaphore(Obj self, Obj semaphore)
     return success ? True : False;
 }
 
-void LockBarrier(Barrier * barrier)
+static void LockBarrier(Barrier * barrier)
 {
     LockMonitor(ObjPtr(barrier->monitor));
 }
 
-void UnlockBarrier(Barrier * barrier)
+static void UnlockBarrier(Barrier * barrier)
 {
     UnlockMonitor(ObjPtr(barrier->monitor));
 }
 
-void JoinBarrier(Barrier * barrier)
+static void JoinBarrier(Barrier * barrier)
 {
     barrier->waiting++;
     WaitForMonitor(ObjPtr(barrier->monitor));
     barrier->waiting--;
 }
 
-void SignalBarrier(Barrier * barrier)
+static void SignalBarrier(Barrier * barrier)
 {
     if (barrier->waiting)
         SignalMonitor(ObjPtr(barrier->monitor));
 }
 
-Obj CreateBarrier(void)
+static Obj CreateBarrier(void)
 {
     Bag       barrierBag;
     Barrier * barrier;
@@ -1637,7 +1637,7 @@ Obj CreateBarrier(void)
     return barrierBag;
 }
 
-void StartBarrier(Barrier * barrier, UInt count)
+static void StartBarrier(Barrier * barrier, UInt count)
 {
     LockBarrier(barrier);
     barrier->count = count;
@@ -1645,7 +1645,7 @@ void StartBarrier(Barrier * barrier, UInt count)
     UnlockBarrier(barrier);
 }
 
-void WaitBarrier(Barrier * barrier)
+static void WaitBarrier(Barrier * barrier)
 {
     UInt phaseDelta;
     LockBarrier(barrier);
@@ -1659,17 +1659,17 @@ void WaitBarrier(Barrier * barrier)
         ArgumentError("WaitBarrier: Barrier was reset");
 }
 
-Obj FuncCreateBarrier(Obj self)
+static Obj FuncCreateBarrier(Obj self)
 {
     return CreateBarrier();
 }
 
-int IsBarrier(Obj obj)
+static int IsBarrier(Obj obj)
 {
     return obj && TNUM_OBJ(obj) == T_BARRIER;
 }
 
-Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
+static Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
 {
     RequireBarrier("StartBarrier", barrier);
     Int c = GetSmallInt("StartBarrier", count);
@@ -1677,14 +1677,14 @@ Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
     return (Obj)0;
 }
 
-Obj FuncWaitBarrier(Obj self, Obj barrier)
+static Obj FuncWaitBarrier(Obj self, Obj barrier)
 {
     RequireBarrier("WaitBarrier", barrier);
     WaitBarrier(ObjPtr(barrier));
     return (Obj)0;
 }
 
-void SyncWrite(SyncVar * var, Obj value)
+static void SyncWrite(SyncVar * var, Obj value)
 {
     Monitor * monitor = ObjPtr(var->monitor);
     LockMonitor(monitor);
@@ -1699,7 +1699,7 @@ void SyncWrite(SyncVar * var, Obj value)
     UnlockMonitor(monitor);
 }
 
-int SyncTryWrite(SyncVar * var, Obj value)
+static int SyncTryWrite(SyncVar * var, Obj value)
 {
     Monitor * monitor = ObjPtr(var->monitor);
     LockMonitor(monitor);
@@ -1714,7 +1714,7 @@ int SyncTryWrite(SyncVar * var, Obj value)
     return 1;
 }
 
-Obj CreateSyncVar(void)
+static Obj CreateSyncVar(void)
 {
     Bag       syncvarBag;
     SyncVar * syncvar;
@@ -1727,7 +1727,7 @@ Obj CreateSyncVar(void)
 }
 
 
-Obj SyncRead(SyncVar * var)
+static Obj SyncRead(SyncVar * var)
 {
     Monitor * monitor = ObjPtr(var->monitor);
     LockMonitor(monitor);
@@ -1739,41 +1739,41 @@ Obj SyncRead(SyncVar * var)
     return var->value;
 }
 
-Obj SyncIsBound(SyncVar * var)
+static Obj SyncIsBound(SyncVar * var)
 {
     return var->value ? True : False;
 }
 
-int IsSyncVar(Obj var)
+static int IsSyncVar(Obj var)
 {
     return var && TNUM_OBJ(var) == T_SYNCVAR;
 }
 
-Obj FuncCreateSyncVar(Obj self)
+static Obj FuncCreateSyncVar(Obj self)
 {
     return CreateSyncVar();
 }
 
-Obj FuncSyncWrite(Obj self, Obj syncvar, Obj value)
+static Obj FuncSyncWrite(Obj self, Obj syncvar, Obj value)
 {
     RequireSyncVar("SyncWrite", syncvar);
     SyncWrite(ObjPtr(syncvar), value);
     return (Obj)0;
 }
 
-Obj FuncSyncTryWrite(Obj self, Obj syncvar, Obj value)
+static Obj FuncSyncTryWrite(Obj self, Obj syncvar, Obj value)
 {
     RequireSyncVar("SyncTryWrite", syncvar);
     return SyncTryWrite(ObjPtr(syncvar), value) ? True : False;
 }
 
-Obj FuncSyncRead(Obj self, Obj syncvar)
+static Obj FuncSyncRead(Obj self, Obj syncvar)
 {
     RequireSyncVar("SyncRead", syncvar);
     return SyncRead(ObjPtr(syncvar));
 }
 
-Obj FuncSyncIsBound(Obj self, Obj syncvar)
+static Obj FuncSyncIsBound(Obj self, Obj syncvar)
 {
     RequireSyncVar("SyncIsBound", syncvar);
     return SyncIsBound(ObjPtr(syncvar));
@@ -1896,7 +1896,7 @@ static void PrintRegion(Obj obj)
     Pr(">", 0L, 0L);
 }
 
-Obj FuncIS_LOCKED(Obj self, Obj obj)
+static Obj FuncIS_LOCKED(Obj self, Obj obj)
 {
     Region * region = IS_BAG_REF(obj) ? REGION(obj) : NULL;
     if (!region)
@@ -1904,7 +1904,7 @@ Obj FuncIS_LOCKED(Obj self, Obj obj)
     return INTOBJ_INT(IsLocked(region));
 }
 
-Obj FuncLOCK(Obj self, Obj args)
+static Obj FuncLOCK(Obj self, Obj args)
 {
     int   numargs = LEN_PLIST(args);
     int   count = 0;
@@ -1937,7 +1937,7 @@ Obj FuncLOCK(Obj self, Obj args)
     return Fail;
 }
 
-Obj FuncDO_LOCK(Obj self, Obj args)
+static Obj FuncDO_LOCK(Obj self, Obj args)
 {
     Obj result = FuncLOCK(self, args);
     if (result == Fail)
@@ -1945,7 +1945,7 @@ Obj FuncDO_LOCK(Obj self, Obj args)
     return result;
 }
 
-Obj FuncWRITE_LOCK(Obj self, Obj obj)
+static Obj FuncWRITE_LOCK(Obj self, Obj obj)
 {
     const LockMode modes[] = { LOCK_MODE_READWRITE };
     int result = LockObjects(1, &obj, modes);
@@ -1954,7 +1954,7 @@ Obj FuncWRITE_LOCK(Obj self, Obj obj)
     return INTOBJ_INT(result);
 }
 
-Obj FuncREAD_LOCK(Obj self, Obj obj)
+static Obj FuncREAD_LOCK(Obj self, Obj obj)
 {
     const LockMode modes[] = { LOCK_MODE_READONLY };
     int result = LockObjects(1, &obj, modes);
@@ -1963,7 +1963,7 @@ Obj FuncREAD_LOCK(Obj self, Obj obj)
     return INTOBJ_INT(result);
 }
 
-Obj FuncTRYLOCK(Obj self, Obj args)
+static Obj FuncTRYLOCK(Obj self, Obj args)
 {
     int   numargs = LEN_PLIST(args);
     int   count = 0;
@@ -1996,14 +1996,14 @@ Obj FuncTRYLOCK(Obj self, Obj args)
     return Fail;
 }
 
-Obj FuncUNLOCK(Obj self, Obj sp)
+static Obj FuncUNLOCK(Obj self, Obj sp)
 {
     RequireNonnegativeSmallInt("UNLOCK", sp);
     PopRegionLocks(INT_INTOBJ(sp));
     return (Obj)0;
 }
 
-Obj FuncCURRENT_LOCKS(Obj self)
+static Obj FuncCURRENT_LOCKS(Obj self)
 {
     UInt i, len = TLS(lockStackPointer);
     Obj  result = NEW_PLIST(T_PLIST, len);
@@ -2047,7 +2047,7 @@ MigrateObjects(int count, Obj * objects, Region * target, int retype)
     return 1;
 }
 
-Obj FuncREFINE_TYPE(Obj self, Obj obj)
+static Obj FuncREFINE_TYPE(Obj self, Obj obj)
 {
     if (IS_BAG_REF(obj) && CheckExclusiveWriteAccess(obj)) {
         TYPE_OBJ(obj);
@@ -2055,7 +2055,7 @@ Obj FuncREFINE_TYPE(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncMAKE_PUBLIC_NORECURSE(Obj self, Obj obj)
+static Obj FuncMAKE_PUBLIC_NORECURSE(Obj self, Obj obj)
 {
     if (!MigrateObjects(1, &obj, NULL, 0))
         return ArgumentError("MAKE_PUBLIC_NORECURSE: Thread does not have "
@@ -2063,7 +2063,7 @@ Obj FuncMAKE_PUBLIC_NORECURSE(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncFORCE_MAKE_PUBLIC(Obj self, Obj obj)
+static Obj FuncFORCE_MAKE_PUBLIC(Obj self, Obj obj)
 {
     if (!IS_BAG_REF(obj))
         return ArgumentError("FORCE_MAKE_PUBLIC: Argument is a small integer "
@@ -2072,7 +2072,7 @@ Obj FuncFORCE_MAKE_PUBLIC(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec)
+static Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec)
 {
     Region * region = NewRegion();
     if (name != Fail && !IsStringConv(name))
@@ -2088,7 +2088,7 @@ Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec)
     return obj;
 }
 
-Obj FuncMIGRATE_NORECURSE(Obj self, Obj obj, Obj target)
+static Obj FuncMIGRATE_NORECURSE(Obj self, Obj obj, Obj target)
 {
     Region * target_region = GetRegionOf(target);
     if (!target_region ||
@@ -2101,7 +2101,7 @@ Obj FuncMIGRATE_NORECURSE(Obj self, Obj obj, Obj target)
     return obj;
 }
 
-Obj FuncADOPT_NORECURSE(Obj self, Obj obj)
+static Obj FuncADOPT_NORECURSE(Obj self, Obj obj)
 {
     if (!MigrateObjects(1, &obj, TLS(threadRegion), 0))
         return ArgumentError("ADOPT_NORECURSE: Thread does not have "
@@ -2109,7 +2109,7 @@ Obj FuncADOPT_NORECURSE(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncREACHABLE(Obj self, Obj obj)
+static Obj FuncREACHABLE(Obj self, Obj obj)
 {
     Obj result = ReachableObjectsFrom(obj);
     if (result == NULL) {
@@ -2120,17 +2120,17 @@ Obj FuncREACHABLE(Obj self, Obj obj)
     return result;
 }
 
-Obj FuncCLONE_REACHABLE(Obj self, Obj obj)
+static Obj FuncCLONE_REACHABLE(Obj self, Obj obj)
 {
     return CopyReachableObjectsFrom(obj, 0, 0, 0);
 }
 
-Obj FuncCLONE_DELIMITED(Obj self, Obj obj)
+static Obj FuncCLONE_DELIMITED(Obj self, Obj obj)
 {
     return CopyReachableObjectsFrom(obj, 1, 0, 0);
 }
 
-Obj FuncNEW_REGION(Obj self, Obj name, Obj prec)
+static Obj FuncNEW_REGION(Obj self, Obj name, Obj prec)
 {
     Region * region = NewRegion();
     if (name != Fail && !IsStringConv(name))
@@ -2143,13 +2143,13 @@ Obj FuncNEW_REGION(Obj self, Obj name, Obj prec)
     return region->obj;
 }
 
-Obj FuncREGION_PRECEDENCE(Obj self, Obj regobj)
+static Obj FuncREGION_PRECEDENCE(Obj self, Obj regobj)
 {
     Region * region = GetRegionOf(regobj);
     return region == NULL ? INTOBJ_INT(0) : INTOBJ_INT(region->prec);
 }
 
-Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
+static Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
 {
     Region * region = NewRegion();
     Obj      reachable;
@@ -2168,7 +2168,7 @@ Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
     return obj;
 }
 
-Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
+static Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
 {
     Region * region = NewRegion();
     Obj      reachable;
@@ -2187,7 +2187,7 @@ Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
     return obj;
 }
 
-Obj FuncADOPT(Obj self, Obj obj)
+static Obj FuncADOPT(Obj self, Obj obj)
 {
     Obj reachable = ReachableObjectsFrom(obj);
     if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1,
@@ -2197,7 +2197,7 @@ Obj FuncADOPT(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncMAKE_PUBLIC(Obj self, Obj obj)
+static Obj FuncMAKE_PUBLIC(Obj self, Obj obj)
 {
     Obj reachable = ReachableObjectsFrom(obj);
     if (!MigrateObjects(LEN_PLIST(reachable), ADDR_OBJ(reachable) + 1, NULL,
@@ -2207,7 +2207,7 @@ Obj FuncMAKE_PUBLIC(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncMIGRATE(Obj self, Obj obj, Obj target)
+static Obj FuncMIGRATE(Obj self, Obj obj, Obj target)
 {
     Region * target_region = GetRegionOf(target);
     Obj      reachable;
@@ -2223,7 +2223,7 @@ Obj FuncMIGRATE(Obj self, Obj obj, Obj target)
     return obj;
 }
 
-Obj FuncMIGRATE_RAW(Obj self, Obj obj, Obj target)
+static Obj FuncMIGRATE_RAW(Obj self, Obj obj, Obj target)
 {
     Region * target_region = GetRegionOf(target);
     Obj      reachable;
@@ -2239,7 +2239,7 @@ Obj FuncMIGRATE_RAW(Obj self, Obj obj, Obj target)
     return obj;
 }
 
-Obj FuncMakeThreadLocal(Obj self, Obj var)
+static Obj FuncMakeThreadLocal(Obj self, Obj var)
 {
     char * name;
     UInt   gvar;
@@ -2253,7 +2253,7 @@ Obj FuncMakeThreadLocal(Obj self, Obj var)
     return (Obj)0;
 }
 
-Obj FuncMakeReadOnlyObj(Obj self, Obj obj)
+static Obj FuncMakeReadOnlyObj(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     Obj      reachable;
@@ -2267,7 +2267,7 @@ Obj FuncMakeReadOnlyObj(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncMakeReadOnlyRaw(Obj self, Obj obj)
+static Obj FuncMakeReadOnlyRaw(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     Obj      reachable;
@@ -2281,7 +2281,7 @@ Obj FuncMakeReadOnlyRaw(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncMakeReadOnlySingleObj(Obj self, Obj obj)
+static Obj FuncMakeReadOnlySingleObj(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     if (!region || region == ReadOnlyRegion)
@@ -2292,39 +2292,39 @@ Obj FuncMakeReadOnlySingleObj(Obj self, Obj obj)
     return obj;
 }
 
-Obj FuncIsReadOnlyObj(Obj self, Obj obj)
+static Obj FuncIsReadOnlyObj(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
     return (region == ReadOnlyRegion) ? True : False;
 }
 
-Obj FuncENABLE_AUTO_RETYPING(Obj self)
+static Obj FuncENABLE_AUTO_RETYPING(Obj self)
 {
     AutoRetyping = 1;
     return (Obj)0;
 }
 
-Obj FuncORDERED_READ(Obj self, Obj obj)
+static Obj FuncORDERED_READ(Obj self, Obj obj)
 {
     MEMBAR_READ();
     return obj;
 }
 
-Obj FuncORDERED_WRITE(Obj self, Obj obj)
+static Obj FuncORDERED_WRITE(Obj self, Obj obj)
 {
     MEMBAR_WRITE();
     return obj;
 }
 
-Obj FuncDEFAULT_SIGINT_HANDLER(Obj self)
+static Obj FuncDEFAULT_SIGINT_HANDLER(Obj self)
 {
     /* do nothing */
     return (Obj)0;
 }
 
-UInt SigVTALRMCounter = 0;
+static UInt SigVTALRMCounter = 0;
 
-Obj FuncDEFAULT_SIGVTALRM_HANDLER(Obj self)
+static Obj FuncDEFAULT_SIGVTALRM_HANDLER(Obj self)
 {
     SigVTALRMCounter++;
     return (Obj)0;
@@ -2334,7 +2334,7 @@ Obj FuncDEFAULT_SIGVTALRM_HANDLER(Obj self)
     extern void syWindowChangeIntr(int signr);
 #endif
 
-Obj FuncDEFAULT_SIGWINCH_HANDLER(Obj self)
+static Obj FuncDEFAULT_SIGWINCH_HANDLER(Obj self)
 {
 #ifdef SIGWINCH
     syWindowChangeIntr(SIGWINCH);
@@ -2352,7 +2352,7 @@ static void HandleSignal(Obj handlers, UInt rnam)
 
 static sigset_t GAPSignals;
 
-Obj FuncSIGWAIT(Obj self, Obj handlers)
+static Obj FuncSIGWAIT(Obj self, Obj handlers)
 {
     int sig;
     if (!IS_REC(handlers))
@@ -2397,7 +2397,7 @@ void InitSignals(void)
     setitimer(ITIMER_VIRTUAL, &timer, NULL);
 }
 
-Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
+static Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
 {
     UInt n;
     RequireNonnegativeSmallInt("PERIODIC_CHECK", count);
@@ -2419,7 +2419,7 @@ Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
 /*
  * Region lock performance counters
  */
-Obj FuncREGION_COUNTERS_ENABLE(Obj self, Obj obj)
+static Obj FuncREGION_COUNTERS_ENABLE(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
 
@@ -2431,7 +2431,7 @@ Obj FuncREGION_COUNTERS_ENABLE(Obj self, Obj obj)
     return (Obj)0;
 }
 
-Obj FuncREGION_COUNTERS_DISABLE(Obj self, Obj obj)
+static Obj FuncREGION_COUNTERS_DISABLE(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
 
@@ -2443,7 +2443,7 @@ Obj FuncREGION_COUNTERS_DISABLE(Obj self, Obj obj)
     return (Obj)0;
 }
 
-Obj FuncREGION_COUNTERS_GET_STATE(Obj self, Obj obj)
+static Obj FuncREGION_COUNTERS_GET_STATE(Obj self, Obj obj)
 {
     Obj      result;
     Region * region = GetRegionOf(obj);
@@ -2457,7 +2457,7 @@ Obj FuncREGION_COUNTERS_GET_STATE(Obj self, Obj obj)
     return result;
 }
 
-Obj FuncREGION_COUNTERS_GET(Obj self, Obj obj)
+static Obj FuncREGION_COUNTERS_GET(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
 
@@ -2468,7 +2468,7 @@ Obj FuncREGION_COUNTERS_GET(Obj self, Obj obj)
     return GetRegionLockCounters(region);
 }
 
-Obj FuncREGION_COUNTERS_RESET(Obj self, Obj obj)
+static Obj FuncREGION_COUNTERS_RESET(Obj self, Obj obj)
 {
     Region * region = GetRegionOf(obj);
 
@@ -2481,21 +2481,21 @@ Obj FuncREGION_COUNTERS_RESET(Obj self, Obj obj)
     return (Obj)0;
 }
 
-Obj FuncTHREAD_COUNTERS_ENABLE(Obj self)
+static Obj FuncTHREAD_COUNTERS_ENABLE(Obj self)
 {
     TLS(CountActive) = 1;
 
     return (Obj)0;
 }
 
-Obj FuncTHREAD_COUNTERS_DISABLE(Obj self)
+static Obj FuncTHREAD_COUNTERS_DISABLE(Obj self)
 {
     TLS(CountActive) = 0;
 
     return (Obj)0;
 }
 
-Obj FuncTHREAD_COUNTERS_GET_STATE(Obj self)
+static Obj FuncTHREAD_COUNTERS_GET_STATE(Obj self)
 {
     Obj result;
 
@@ -2504,14 +2504,14 @@ Obj FuncTHREAD_COUNTERS_GET_STATE(Obj self)
     return result;
 }
 
-Obj FuncTHREAD_COUNTERS_RESET(Obj self)
+static Obj FuncTHREAD_COUNTERS_RESET(Obj self)
 {
     TLS(LocksAcquired) = TLS(LocksContended) = 0;
 
     return (Obj)0;
 }
 
-Obj FuncTHREAD_COUNTERS_GET(Obj self)
+static Obj FuncTHREAD_COUNTERS_GET(Obj self)
 {
     Obj result;
 

--- a/src/integer.c
+++ b/src/integer.c
@@ -156,13 +156,13 @@ static Obj IsIntFilt;
 **
 **  'TypeInt' is the function in 'TypeObjFuncs' for integers.
 */
-Obj             TYPE_INT_SMALL_ZERO;
-Obj             TYPE_INT_SMALL_POS;
-Obj             TYPE_INT_SMALL_NEG;
-Obj             TYPE_INT_LARGE_POS;
-Obj             TYPE_INT_LARGE_NEG;
+static Obj             TYPE_INT_SMALL_ZERO;
+static Obj             TYPE_INT_SMALL_POS;
+static Obj             TYPE_INT_SMALL_NEG;
+static Obj             TYPE_INT_LARGE_POS;
+static Obj             TYPE_INT_LARGE_NEG;
 
-Obj             TypeIntSmall (
+static Obj             TypeIntSmall (
     Obj                 val )
 {
     if ( 0 == INT_INTOBJ(val) ) {
@@ -176,12 +176,12 @@ Obj             TypeIntSmall (
     }
 }
 
-Obj TypeIntLargePos ( Obj val )
+static Obj TypeIntLargePos ( Obj val )
 {
     return TYPE_INT_LARGE_POS;
 }
 
-Obj TypeIntLargeNeg ( Obj val )
+static Obj TypeIntLargeNeg ( Obj val )
 {
     return TYPE_INT_LARGE_NEG;
 }
@@ -198,7 +198,7 @@ Obj TypeIntLargeNeg ( Obj val )
 **  'IsInt'  returns 'true'  if the  value  <val>  is a small integer or a
 **  large int, and 'false' otherwise.
 */
-Obj FuncIS_INT ( Obj self, Obj val )
+static Obj FuncIS_INT ( Obj self, Obj val )
 {
   if ( IS_INT(val) ) {
     return True;
@@ -218,7 +218,7 @@ Obj FuncIS_INT ( Obj self, Obj val )
 **
 **
 */
-void SaveInt(Obj op)
+static void SaveInt(Obj op)
 {
     const UInt * ptr = CONST_ADDR_INT(op);
     for (UInt i = 0; i < SIZE_INT(op); i++)
@@ -233,7 +233,7 @@ void SaveInt(Obj op)
 **
 **
 */
-void LoadInt(Obj op)
+static void LoadInt(Obj op)
 {
     UInt * ptr = ADDR_INT(op);
     for (UInt i = 0; i < SIZE_INT(op); i++)
@@ -430,7 +430,8 @@ Obj GMP_REDUCE(Obj op)
 **  the given integer object <op> is normalized and reduced.
 **
 */
-int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
+#if DEBUG_GMP
+static int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
 {
   mp_size_t size;
   if ( IS_INTOBJ( op ) ) {
@@ -463,6 +464,7 @@ int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
   }
   return 1;
 }
+#endif
 
 
 /****************************************************************************
@@ -815,7 +817,7 @@ static Obj StringIntBase(Obj op, int base)
 **  letters a..f are also allowed in <string> instead of A..F.
 **
 */
-Obj FuncHexStringInt(Obj self, Obj n)
+static Obj FuncHexStringInt(Obj self, Obj n)
 {
     RequireInt("HexStringInt", n);
     return StringIntBase(n, 16);
@@ -985,7 +987,7 @@ Int CLog2Int(Int a)
 **
 **  Given to GAP-Level as "Log2Int".
 */
-Obj FuncLog2Int(Obj self, Obj n)
+static Obj FuncLog2Int(Obj self, Obj n)
 {
     RequireInt("Log2Int", n);
 
@@ -1015,7 +1017,7 @@ Obj FuncLog2Int(Obj self, Obj n)
 **  `FuncSTRING_INT' returns an immutable string representing the integer <n>
 **
 */
-Obj FuncSTRING_INT(Obj self, Obj n)
+static Obj FuncSTRING_INT(Obj self, Obj n)
 {
     RequireInt("STRING_INT", n);
     return StringIntBase(n, 10);
@@ -1096,7 +1098,7 @@ Obj IntStringInternal(Obj string, const Char *str)
 **  fail if the string is not a valid integer.
 **
 */
-Obj FuncINT_STRING ( Obj self, Obj string )
+static Obj FuncINT_STRING ( Obj self, Obj string )
 {
     if( !IS_STRING(string) ) {
         return Fail;
@@ -1275,7 +1277,7 @@ inline Obj DiffInt(Obj opL, Obj opR)
 **
 *F  ZeroInt(<op>)  . . . . . . . . . . . . . . . . . . . . . zero of integers
 */
-Obj ZeroInt(Obj op)
+static Obj ZeroInt(Obj op)
 {
     return INTOBJ_INT(0);
 }
@@ -1358,7 +1360,7 @@ Obj AbsInt( Obj op )
   return Fail;
 }
 
-Obj FuncABS_INT(Obj self, Obj n)
+static Obj FuncABS_INT(Obj self, Obj n)
 {
     RequireInt("AbsInt", n);
     Obj res = AbsInt(n);
@@ -1389,7 +1391,7 @@ Obj SignInt( Obj op )
   return Fail;
 }
 
-Obj FuncSIGN_INT(Obj self, Obj n)
+static Obj FuncSIGN_INT(Obj self, Obj n)
 {
     RequireInt("SignInt", n);
     Obj res = SignInt(n);
@@ -1532,7 +1534,7 @@ static Obj ProdIntObj ( Obj n, Obj op )
   return res;
 }
 
-Obj FuncPROD_INT_OBJ ( Obj self, Obj opL, Obj opR )
+static Obj FuncPROD_INT_OBJ ( Obj self, Obj opL, Obj opR )
 {
   return ProdIntObj( opL, opR );
 }
@@ -1542,7 +1544,7 @@ Obj FuncPROD_INT_OBJ ( Obj self, Obj opL, Obj opR )
 **
 *F  OneInt(<op>) . . . . . . . . . . . . . . . . . . . . .  one of an integer
 */
-Obj OneInt ( Obj op )
+static Obj OneInt ( Obj op )
 {
   return INTOBJ_INT( 1 );
 }
@@ -1613,7 +1615,7 @@ Obj PowInt ( Obj opL, Obj opR )
 **
 *F  PowObjInt(<op>,<n>) . . . . . . . . . . power of an object and an integer
 */
-Obj             PowObjInt ( Obj op, Obj n )
+static Obj             PowObjInt ( Obj op, Obj n )
 {
   Obj                 res = 0;        /* result                          */
   UInt                i, k;           /* loop variables                  */
@@ -1682,7 +1684,7 @@ Obj             PowObjInt ( Obj op, Obj n )
   return res;
 }
 
-Obj FuncPOW_OBJ_INT ( Obj self, Obj opL, Obj opR )
+static Obj FuncPOW_OBJ_INT ( Obj self, Obj opL, Obj opR )
 {
   return PowObjInt( opL, opR );
 }
@@ -1941,7 +1943,7 @@ Obj QuoInt(Obj opL, Obj opR)
 **  'Sign( Quo(<a>,<b>) ) = Sign(<a>) * Sign(<b>)'.  Dividing by 0  causes an
 **  error.  'Rem' (see "Rem") can be used to compute the remainder.
 */
-Obj FuncQUO_INT(Obj self, Obj a, Obj b)
+static Obj FuncQUO_INT(Obj self, Obj a, Obj b)
 {
     RequireInt("QuoInt", a);
     RequireInt("QuoInt", b);
@@ -2069,7 +2071,7 @@ Obj RemInt(Obj opL, Obj opR)
 **  same sign as <i> and its absolute value is strictly less than the
 **  absolute value of <k>.  Dividing by 0 causes an error.
 */
-Obj FuncREM_INT(Obj self, Obj a, Obj b)
+static Obj FuncREM_INT(Obj self, Obj a, Obj b)
 {
     RequireInt("RemInt", a);
     RequireInt("RemInt", b);
@@ -2142,7 +2144,7 @@ Obj GcdInt ( Obj opL, Obj opR )
 **  greatest common divisor is never negative, even if the arguments are.  We
 **  define $gcd( a, 0 ) = gcd( 0, a ) = abs( a )$ and $gcd( 0, 0 ) = 0$.
 */
-Obj FuncGCD_INT(Obj self, Obj a, Obj b)
+static Obj FuncGCD_INT(Obj self, Obj a, Obj b)
 {
     RequireInt("GcdInt", a);
     RequireInt("GcdInt", b);
@@ -2195,7 +2197,7 @@ Obj LcmInt(Obj opL, Obj opR)
     return result;
 }
 
-Obj FuncLCM_INT(Obj self, Obj a, Obj b)
+static Obj FuncLCM_INT(Obj self, Obj a, Obj b)
 {
     RequireInt("LcmInt", a);
     RequireInt("LcmInt", b);
@@ -2205,7 +2207,7 @@ Obj FuncLCM_INT(Obj self, Obj a, Obj b)
 /****************************************************************************
 **
 */
-Obj FuncFACTORIAL_INT(Obj self, Obj n)
+static Obj FuncFACTORIAL_INT(Obj self, Obj n)
 {
     RequireNonnegativeSmallInt("Factorial", n);
 
@@ -2307,7 +2309,7 @@ Obj BinomialInt(Obj n, Obj k)
     return result;
 }
 
-Obj FuncBINOMIAL_INT(Obj self, Obj n, Obj k)
+static Obj FuncBINOMIAL_INT(Obj self, Obj n, Obj k)
 {
     RequireInt("Binomial", n);
     RequireInt("Binomial", k);
@@ -2318,7 +2320,7 @@ Obj FuncBINOMIAL_INT(Obj self, Obj n, Obj k)
 /****************************************************************************
 **
 */
-Obj FuncJACOBI_INT(Obj self, Obj n, Obj m)
+static Obj FuncJACOBI_INT(Obj self, Obj n, Obj m)
 {
   fake_mpz_t mpzL, mpzR;
   int result;
@@ -2343,7 +2345,7 @@ Obj FuncJACOBI_INT(Obj self, Obj n, Obj m)
 /****************************************************************************
 **
 */
-Obj FuncPVALUATION_INT(Obj self, Obj n, Obj p)
+static Obj FuncPVALUATION_INT(Obj self, Obj n, Obj p)
 {
   fake_mpz_t mpzN, mpzP;
   mpz_t mpzResult;
@@ -2391,7 +2393,7 @@ Obj FuncPVALUATION_INT(Obj self, Obj n, Obj p)
 /****************************************************************************
 **
 */
-Obj FuncROOT_INT(Obj self, Obj n, Obj k)
+static Obj FuncROOT_INT(Obj self, Obj n, Obj k)
 {
     fake_mpz_t n_mpz, result_mpz;
 
@@ -2506,7 +2508,7 @@ Obj InverseModInt(Obj base, Obj mod)
 /****************************************************************************
 **
 */
-Obj FuncINVMODINT ( Obj self, Obj base, Obj mod )
+static Obj FuncINVMODINT ( Obj self, Obj base, Obj mod )
 {
     RequireInt("InverseModInt", base);
     RequireInt("InverseModInt", mod);
@@ -2517,7 +2519,7 @@ Obj FuncINVMODINT ( Obj self, Obj base, Obj mod )
 /****************************************************************************
 **
 */
-Obj FuncPOWERMODINT(Obj self, Obj base, Obj exp, Obj mod)
+static Obj FuncPOWERMODINT(Obj self, Obj base, Obj exp, Obj mod)
 {
   fake_mpz_t base_mpz, exp_mpz, mod_mpz, result_mpz;
 
@@ -2560,7 +2562,7 @@ Obj FuncPOWERMODINT(Obj self, Obj base, Obj exp, Obj mod)
 /****************************************************************************
 **
 */
-Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
+static Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
 {
   fake_mpz_t n_mpz;
   Int res;
@@ -2604,7 +2606,7 @@ Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
 **  integer digit lengths and different ranges of small integers).
 **  
 */
-Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
+static Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
 {
   Obj res;
   Int i, n, q, r, qoff, len;
@@ -2678,31 +2680,31 @@ Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
 **  The following functions only exist to enable use to test the conversion
 **  functions (Int_ObjInt, ObjInt_Int, etc.) via a regular .tst file.
 */
-Obj FuncINTERNAL_TEST_CONV_INT(Obj self, Obj val)
+static Obj FuncINTERNAL_TEST_CONV_INT(Obj self, Obj val)
 {
     Int ival = Int_ObjInt(val);
     return ObjInt_Int(ival);
 }
 
-Obj FuncINTERNAL_TEST_CONV_UINT(Obj self, Obj val)
+static Obj FuncINTERNAL_TEST_CONV_UINT(Obj self, Obj val)
 {
     UInt ival = UInt_ObjInt(val);
     return ObjInt_UInt(ival);
 }
 
-Obj FuncINTERNAL_TEST_CONV_UINTINV(Obj self, Obj val)
+static Obj FuncINTERNAL_TEST_CONV_UINTINV(Obj self, Obj val)
 {
     UInt ival = UInt_ObjInt(val);
     return ObjInt_UIntInv(ival);
 }
 
-Obj FuncINTERNAL_TEST_CONV_INT8(Obj self, Obj val)
+static Obj FuncINTERNAL_TEST_CONV_INT8(Obj self, Obj val)
 {
     Int8 ival = Int8_ObjInt(val);
     return ObjInt_Int8(ival);
 }
 
-Obj FuncINTERNAL_TEST_CONV_UINT8(Obj self, Obj val)
+static Obj FuncINTERNAL_TEST_CONV_UINT8(Obj self, Obj val)
 {
     UInt8 ival = UInt8_ObjInt(val);
     return ObjInt_UInt8(ival);

--- a/src/integer.c
+++ b/src/integer.c
@@ -156,14 +156,13 @@ static Obj IsIntFilt;
 **
 **  'TypeInt' is the function in 'TypeObjFuncs' for integers.
 */
-static Obj             TYPE_INT_SMALL_ZERO;
-static Obj             TYPE_INT_SMALL_POS;
-static Obj             TYPE_INT_SMALL_NEG;
-static Obj             TYPE_INT_LARGE_POS;
-static Obj             TYPE_INT_LARGE_NEG;
+static Obj TYPE_INT_SMALL_ZERO;
+static Obj TYPE_INT_SMALL_POS;
+static Obj TYPE_INT_SMALL_NEG;
+static Obj TYPE_INT_LARGE_POS;
+static Obj TYPE_INT_LARGE_NEG;
 
-static Obj             TypeIntSmall (
-    Obj                 val )
+static Obj TypeIntSmall(Obj val)
 {
     if ( 0 == INT_INTOBJ(val) ) {
         return TYPE_INT_SMALL_ZERO;
@@ -176,12 +175,12 @@ static Obj             TypeIntSmall (
     }
 }
 
-static Obj TypeIntLargePos ( Obj val )
+static Obj TypeIntLargePos(Obj val)
 {
     return TYPE_INT_LARGE_POS;
 }
 
-static Obj TypeIntLargeNeg ( Obj val )
+static Obj TypeIntLargeNeg(Obj val)
 {
     return TYPE_INT_LARGE_NEG;
 }
@@ -198,7 +197,7 @@ static Obj TypeIntLargeNeg ( Obj val )
 **  'IsInt'  returns 'true'  if the  value  <val>  is a small integer or a
 **  large int, and 'false' otherwise.
 */
-static Obj FuncIS_INT ( Obj self, Obj val )
+static Obj FuncIS_INT(Obj self, Obj val)
 {
   if ( IS_INT(val) ) {
     return True;
@@ -431,7 +430,7 @@ Obj GMP_REDUCE(Obj op)
 **
 */
 #if DEBUG_GMP
-static int IS_NORMALIZED_AND_REDUCED( Obj op, const char *func, int line )
+static int IS_NORMALIZED_AND_REDUCED(Obj op, const char * func, int line)
 {
   mp_size_t size;
   if ( IS_INTOBJ( op ) ) {
@@ -1098,7 +1097,7 @@ Obj IntStringInternal(Obj string, const Char *str)
 **  fail if the string is not a valid integer.
 **
 */
-static Obj FuncINT_STRING ( Obj self, Obj string )
+static Obj FuncINT_STRING(Obj self, Obj string)
 {
     if( !IS_STRING(string) ) {
         return Fail;
@@ -1534,7 +1533,7 @@ static Obj ProdIntObj ( Obj n, Obj op )
   return res;
 }
 
-static Obj FuncPROD_INT_OBJ ( Obj self, Obj opL, Obj opR )
+static Obj FuncPROD_INT_OBJ(Obj self, Obj opL, Obj opR)
 {
   return ProdIntObj( opL, opR );
 }
@@ -1544,7 +1543,7 @@ static Obj FuncPROD_INT_OBJ ( Obj self, Obj opL, Obj opR )
 **
 *F  OneInt(<op>) . . . . . . . . . . . . . . . . . . . . .  one of an integer
 */
-static Obj OneInt ( Obj op )
+static Obj OneInt(Obj op)
 {
   return INTOBJ_INT( 1 );
 }
@@ -1615,7 +1614,7 @@ Obj PowInt ( Obj opL, Obj opR )
 **
 *F  PowObjInt(<op>,<n>) . . . . . . . . . . power of an object and an integer
 */
-static Obj             PowObjInt ( Obj op, Obj n )
+static Obj PowObjInt(Obj op, Obj n)
 {
   Obj                 res = 0;        /* result                          */
   UInt                i, k;           /* loop variables                  */
@@ -1684,7 +1683,7 @@ static Obj             PowObjInt ( Obj op, Obj n )
   return res;
 }
 
-static Obj FuncPOW_OBJ_INT ( Obj self, Obj opL, Obj opR )
+static Obj FuncPOW_OBJ_INT(Obj self, Obj opL, Obj opR)
 {
   return PowObjInt( opL, opR );
 }
@@ -2508,7 +2507,7 @@ Obj InverseModInt(Obj base, Obj mod)
 /****************************************************************************
 **
 */
-static Obj FuncINVMODINT ( Obj self, Obj base, Obj mod )
+static Obj FuncINVMODINT(Obj self, Obj base, Obj mod)
 {
     RequireInt("InverseModInt", base);
     RequireInt("InverseModInt", mod);

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -47,7 +47,7 @@
 #define UPPER_MASK 0x80000000UL /* most significant w-r bits */
 #define LOWER_MASK 0x7fffffffUL /* least significant r bits */
 
-static void initGRMT(UInt4 *mt, UInt4 s)
+static void initGRMT(UInt4 * mt, UInt4 s)
 {
     UInt4 mti;
     mt[0]= s & 0xffffffffUL;
@@ -83,7 +83,7 @@ static inline UInt4 uint4frombytes(const UChar * s, UInt4 pos, UInt4 len)
   return res;
 }
 
-static Obj FuncInitRandomMT( Obj self, Obj initstr)
+static Obj FuncInitRandomMT(Obj self, Obj initstr)
 {
   Obj str;
   const UChar *init_key;
@@ -422,7 +422,8 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 **  length of the computer.
 **  A <maxlen> value of -1 indicates infinity.
 */
-static Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj seed, Obj offset, Obj maxlen)
+static Obj
+FuncHASHKEY_BAG(Obj self, Obj obj, Obj seed, Obj offset, Obj maxlen)
 {
   Int n;
   if ( IS_INTOBJ(obj) )

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -47,7 +47,7 @@
 #define UPPER_MASK 0x80000000UL /* most significant w-r bits */
 #define LOWER_MASK 0x7fffffffUL /* least significant r bits */
 
-void initGRMT(UInt4 *mt, UInt4 s)
+static void initGRMT(UInt4 *mt, UInt4 s)
 {
     UInt4 mti;
     mt[0]= s & 0xffffffffUL;
@@ -83,7 +83,7 @@ static inline UInt4 uint4frombytes(const UChar * s, UInt4 pos, UInt4 len)
   return res;
 }
 
-Obj FuncInitRandomMT( Obj self, Obj initstr)
+static Obj FuncInitRandomMT( Obj self, Obj initstr)
 {
   Obj str;
   const UChar *init_key;
@@ -422,7 +422,7 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
 **  length of the computer.
 **  A <maxlen> value of -1 indicates infinity.
 */
-Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj seed, Obj offset, Obj maxlen)
+static Obj FuncHASHKEY_BAG(Obj self, Obj obj, Obj seed, Obj offset, Obj maxlen)
 {
   Int n;
   if ( IS_INTOBJ(obj) )
@@ -618,7 +618,7 @@ static Obj FuncBUILD_BITFIELDS(Obj self, Obj args)
 }
 
 
-Obj FuncMAKE_BITFIELDS(Obj self, Obj widths)
+static Obj FuncMAKE_BITFIELDS(Obj self, Obj widths)
 {
     if (!IS_LIST(widths))
         ErrorMayQuit("MAKE_BITFIELDS: widths must be a list", 0, 0);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1426,7 +1426,7 @@ void            IntrNot ( void )
 **  actions to interpret the respective operator expression.  They are called
 **  by the reader *after* *both* operands are read.
 */
-void            IntrXX ( void )
+static void IntrXX(void)
 {
     Obj                 opL;            /* left operand                    */
     Obj                 opR;            /* right operand                   */
@@ -3792,7 +3792,7 @@ enum {
     INFODATA_OUTPUT,
 };
 
-Obj InfoDecision;
+static Obj InfoDecision;
 static Obj IsInfoClassListRep;
 static Obj DefaultInfoHandler;
 

--- a/src/io.c
+++ b/src/io.c
@@ -406,7 +406,7 @@ static TypOutputFile * PushNewOutput(void)
 static GVarDescriptor DEFAULT_INPUT_STREAM;
 static GVarDescriptor DEFAULT_OUTPUT_STREAM;
 
-static UInt OpenDefaultInput( void )
+static UInt OpenDefaultInput(void)
 {
   Obj func, stream;
   stream = TLS(DefaultInput);
@@ -424,7 +424,7 @@ static UInt OpenDefaultInput( void )
   return OpenInputStream(stream, 0);
 }
 
-static UInt OpenDefaultOutput( void )
+static UInt OpenDefaultOutput(void)
 {
   Obj func, stream;
   stream = TLS(DefaultOutput);
@@ -1219,7 +1219,7 @@ static Int GetLine2 (
 **  If there is an  input logfile in use  and the input  file is '*stdin*' or
 **  '*errin*' 'GetLine' echoes the new line to the logfile.
 */
-static Char GetLine ( void )
+static Char GetLine(void)
 {
     /* if file is '*stdin*' or '*errin*' print the prompt and flush it     */
     /* if the GAP function `PrintPromptHook' is defined then it is called  */
@@ -1287,10 +1287,7 @@ static Char GetLine ( void )
 **  with the inefficient C- strlen.  (FL)
 */
 
-static void PutLine2(
-        TypOutputFile *         output,
-        const Char *            line,
-        UInt                    len )
+static void PutLine2(TypOutputFile * output, const Char * line, UInt len)
 {
   Obj                     str;
   UInt                    lstr;
@@ -1360,10 +1357,8 @@ static void PutLineTo(TypOutputFile * stream, UInt len)
 
 /* helper function to add a hint about a possible line break;
    a triple (pos, value, indent), such that the minimal (value-pos) wins */
-static void addLineBreakHint(TypOutputFile * stream,
-                      Int             pos,
-                      Int             val,
-                      Int             indentdiff)
+static void
+addLineBreakHint(TypOutputFile * stream, Int pos, Int val, Int indentdiff)
 {
   Int nr, i;
   /* find next free slot */
@@ -1571,7 +1566,7 @@ static void PutChrTo(TypOutputFile * stream, Char ch)
 **
 */
 
-static Obj FuncToggleEcho( Obj self)
+static Obj FuncToggleEcho(Obj self)
 {
     IO()->Input->echo = 1 - IO()->Input->echo;
     return (Obj)0;
@@ -1583,7 +1578,7 @@ static Obj FuncToggleEcho( Obj self)
 **
 **  returns the current `Prompt' as GAP string.
 */
-static Obj FuncCPROMPT( Obj self)
+static Obj FuncCPROMPT(Obj self)
 {
   Obj p;
   p = MakeString(STATE(Prompt));
@@ -1599,7 +1594,7 @@ static Obj FuncCPROMPT( Obj self)
 **  (important is the flush character without resetting the cursor column)
 */
 
-static Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
+static Obj FuncPRINT_CPROMPT(Obj self, Obj prompt)
 {
   if (IS_STRING_REP(prompt)) {
     /* by assigning to Prompt we also tell readline (if used) what the
@@ -2015,7 +2010,7 @@ void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 }
 
 
-static Obj FuncINPUT_FILENAME( Obj self)
+static Obj FuncINPUT_FILENAME(Obj self)
 {
     if (IO()->Input == 0)
         return MakeImmString("*defin*");
@@ -2024,7 +2019,7 @@ static Obj FuncINPUT_FILENAME( Obj self)
     return GetCachedFilename(gapnameid);
 }
 
-static Obj FuncINPUT_LINENUMBER( Obj self)
+static Obj FuncINPUT_LINENUMBER(Obj self)
 {
     return INTOBJ_INT(IO()->Input ? IO()->Input->number : 0);
 }

--- a/src/io.c
+++ b/src/io.c
@@ -136,7 +136,7 @@ static Obj PrintFormattingStatus;
 **
 **  'FilenameCache' is a list of previously opened filenames.
 */
-Obj FilenameCache;
+static Obj FilenameCache;
 
 /* TODO: Eliminate race condition in HPC-GAP */
 static Char promptBuf[81];
@@ -403,10 +403,10 @@ static TypOutputFile * PushNewOutput(void)
 }
 
 #ifdef HPCGAP
-GVarDescriptor DEFAULT_INPUT_STREAM;
-GVarDescriptor DEFAULT_OUTPUT_STREAM;
+static GVarDescriptor DEFAULT_INPUT_STREAM;
+static GVarDescriptor DEFAULT_OUTPUT_STREAM;
 
-UInt OpenDefaultInput( void )
+static UInt OpenDefaultInput( void )
 {
   Obj func, stream;
   stream = TLS(DefaultInput);
@@ -424,7 +424,7 @@ UInt OpenDefaultInput( void )
   return OpenInputStream(stream, 0);
 }
 
-UInt OpenDefaultOutput( void )
+static UInt OpenDefaultOutput( void )
 {
   Obj func, stream;
   stream = TLS(DefaultOutput);
@@ -1219,7 +1219,7 @@ static Int GetLine2 (
 **  If there is an  input logfile in use  and the input  file is '*stdin*' or
 **  '*errin*' 'GetLine' echoes the new line to the logfile.
 */
-Char GetLine ( void )
+static Char GetLine ( void )
 {
     /* if file is '*stdin*' or '*errin*' print the prompt and flush it     */
     /* if the GAP function `PrintPromptHook' is defined then it is called  */
@@ -1287,7 +1287,7 @@ Char GetLine ( void )
 **  with the inefficient C- strlen.  (FL)
 */
 
-void PutLine2(
+static void PutLine2(
         TypOutputFile *         output,
         const Char *            line,
         UInt                    len )
@@ -1331,7 +1331,7 @@ void PutLine2(
 **  'OutputLog' is not 0 and the output file is '*stdout*' or '*errout*'.
 **
 */
-void PutLineTo(TypOutputFile * stream, UInt len)
+static void PutLineTo(TypOutputFile * stream, UInt len)
 {
   PutLine2( stream, stream->line, len );
 
@@ -1360,7 +1360,7 @@ void PutLineTo(TypOutputFile * stream, UInt len)
 
 /* helper function to add a hint about a possible line break;
    a triple (pos, value, indent), such that the minimal (value-pos) wins */
-void addLineBreakHint(TypOutputFile * stream,
+static void addLineBreakHint(TypOutputFile * stream,
                       Int             pos,
                       Int             val,
                       Int             indentdiff)
@@ -1390,7 +1390,7 @@ void addLineBreakHint(TypOutputFile * stream,
 }
 /* helper function to find line break position,
    returns position nr in stream[hints] or -1 if none found */
-Int nrLineBreak(TypOutputFile * stream)
+static Int nrLineBreak(TypOutputFile * stream)
 {
   Int nr=-1, min, i;
   for (i = 0, min = INT_MAX; stream->hints[3*i] != -1; i++)
@@ -1409,7 +1409,7 @@ Int nrLineBreak(TypOutputFile * stream)
 }
 
 
-void PutChrTo(TypOutputFile * stream, Char ch)
+static void PutChrTo(TypOutputFile * stream, Char ch)
 {
   Int                 i, hint, spos;
   Char                str [MAXLENOUTPUTLINE];
@@ -1571,7 +1571,7 @@ void PutChrTo(TypOutputFile * stream, Char ch)
 **
 */
 
-Obj FuncToggleEcho( Obj self)
+static Obj FuncToggleEcho( Obj self)
 {
     IO()->Input->echo = 1 - IO()->Input->echo;
     return (Obj)0;
@@ -1583,7 +1583,7 @@ Obj FuncToggleEcho( Obj self)
 **
 **  returns the current `Prompt' as GAP string.
 */
-Obj FuncCPROMPT( Obj self)
+static Obj FuncCPROMPT( Obj self)
 {
   Obj p;
   p = MakeString(STATE(Prompt));
@@ -1599,7 +1599,7 @@ Obj FuncCPROMPT( Obj self)
 **  (important is the flush character without resetting the cursor column)
 */
 
-Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
+static Obj FuncPRINT_CPROMPT( Obj self, Obj prompt )
 {
   if (IS_STRING_REP(prompt)) {
     /* by assigning to Prompt we also tell readline (if used) what the
@@ -2015,7 +2015,7 @@ void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 }
 
 
-Obj FuncINPUT_FILENAME( Obj self)
+static Obj FuncINPUT_FILENAME( Obj self)
 {
     if (IO()->Input == 0)
         return MakeImmString("*defin*");
@@ -2024,18 +2024,18 @@ Obj FuncINPUT_FILENAME( Obj self)
     return GetCachedFilename(gapnameid);
 }
 
-Obj FuncINPUT_LINENUMBER( Obj self)
+static Obj FuncINPUT_LINENUMBER( Obj self)
 {
     return INTOBJ_INT(IO()->Input ? IO()->Input->number : 0);
 }
 
-Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val)
+static Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val)
 {
     IO()->OutputStack[1]->format = (val != False);
     return val;
 }
 
-Obj FuncIS_INPUT_TTY(Obj self)
+static Obj FuncIS_INPUT_TTY(Obj self)
 {
     GAP_ASSERT(IO()->Input);
     if (IO()->Input->isstream)
@@ -2043,7 +2043,7 @@ Obj FuncIS_INPUT_TTY(Obj self)
     return SyBufIsTTY(IO()->Input->file) ? True : False;
 }
 
-Obj FuncIS_OUTPUT_TTY(Obj self)
+static Obj FuncIS_OUTPUT_TTY(Obj self)
 {
     GAP_ASSERT(IO()->Output);
     if (IO()->Output->isstream)
@@ -2051,7 +2051,7 @@ Obj FuncIS_OUTPUT_TTY(Obj self)
     return SyBufIsTTY(IO()->Output->file) ? True : False;
 }
 
-Obj FuncGET_FILENAME_CACHE(Obj self)
+static Obj FuncGET_FILENAME_CACHE(Obj self)
 {
   return CopyObj(FilenameCache, 1);
 }

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -275,7 +275,7 @@ static void ChildStatusChanged(int whichsig)
 }
 
 #ifdef HPCGAP
-Obj FuncDEFAULT_SIGCHLD_HANDLER(Obj self)
+static Obj FuncDEFAULT_SIGCHLD_HANDLER(Obj self)
 {
     ChildStatusChanged(SIGCHLD);
     return (Obj)0;
@@ -407,7 +407,7 @@ static void HandleChildStatusChanges(UInt pty)
     }
 }
 
-Obj FuncCREATE_PTY_IOSTREAM(Obj self, Obj dir, Obj prog, Obj args)
+static Obj FuncCREATE_PTY_IOSTREAM(Obj self, Obj dir, Obj prog, Obj args)
 {
     Obj    allargs[MAX_ARGS + 1];
     Char * argv[MAX_ARGS + 2];
@@ -523,7 +523,7 @@ static UInt HashLockStreamIfAvailable(Obj stream)
     return pty;
 }
 
-Obj FuncWRITE_IOSTREAM(Obj self, Obj stream, Obj string, Obj len)
+static Obj FuncWRITE_IOSTREAM(Obj self, Obj stream, Obj string, Obj len)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -534,7 +534,7 @@ Obj FuncWRITE_IOSTREAM(Obj self, Obj stream, Obj string, Obj len)
     return INTOBJ_INT(result);
 }
 
-Obj FuncREAD_IOSTREAM(Obj self, Obj stream, Obj len)
+static Obj FuncREAD_IOSTREAM(Obj self, Obj stream, Obj len)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -550,7 +550,7 @@ Obj FuncREAD_IOSTREAM(Obj self, Obj stream, Obj len)
     return string;
 }
 
-Obj FuncREAD_IOSTREAM_NOWAIT(Obj self, Obj stream, Obj len)
+static Obj FuncREAD_IOSTREAM_NOWAIT(Obj self, Obj stream, Obj len)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -566,7 +566,7 @@ Obj FuncREAD_IOSTREAM_NOWAIT(Obj self, Obj stream, Obj len)
     return string;
 }
 
-Obj FuncKILL_CHILD_IOSTREAM(Obj self, Obj stream)
+static Obj FuncKILL_CHILD_IOSTREAM(Obj self, Obj stream)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -577,7 +577,7 @@ Obj FuncKILL_CHILD_IOSTREAM(Obj self, Obj stream)
     return 0;
 }
 
-Obj FuncSIGNAL_CHILD_IOSTREAM(Obj self, Obj stream, Obj sig)
+static Obj FuncSIGNAL_CHILD_IOSTREAM(Obj self, Obj stream, Obj sig)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -588,7 +588,7 @@ Obj FuncSIGNAL_CHILD_IOSTREAM(Obj self, Obj stream, Obj sig)
     return 0;
 }
 
-Obj FuncCLOSE_PTY_IOSTREAM(Obj self, Obj stream)
+static Obj FuncCLOSE_PTY_IOSTREAM(Obj self, Obj stream)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -619,7 +619,7 @@ Obj FuncCLOSE_PTY_IOSTREAM(Obj self, Obj stream)
     return 0;
 }
 
-Obj FuncIS_BLOCKED_IOSTREAM(Obj self, Obj stream)
+static Obj FuncIS_BLOCKED_IOSTREAM(Obj self, Obj stream)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 
@@ -629,7 +629,7 @@ Obj FuncIS_BLOCKED_IOSTREAM(Obj self, Obj stream)
     return isBlocked ? True : False;
 }
 
-Obj FuncFD_OF_IOSTREAM(Obj self, Obj stream)
+static Obj FuncFD_OF_IOSTREAM(Obj self, Obj stream)
 {
     UInt pty = HashLockStreamIfAvailable(stream);
 

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -82,7 +82,7 @@ void InitFreeFuncBag(UInt type, TNumFreeFuncBags finalizer_func)
     TabFreeFuncBags[type] = finalizer_func;
 }
 
-void JFinalizer(jl_value_t * obj)
+static void JFinalizer(jl_value_t * obj)
 {
     BagHeader * hdr = (BagHeader *)obj;
     Bag         contents = (Bag)(hdr + 1);
@@ -189,7 +189,7 @@ treap_t * alloc_treap(void)
     return result;
 }
 
-void free_treap(treap_t * t)
+static void free_treap(treap_t * t)
 {
     t->right = treap_free_list;
     treap_free_list = t;
@@ -343,7 +343,7 @@ static uint64_t xorshift_rng(void)
 
 static treap_t * bigvals;
 
-void alloc_bigval(void * addr, size_t size)
+static void alloc_bigval(void * addr, size_t size)
 {
     treap_t * node = alloc_treap();
     node->addr = addr;
@@ -352,7 +352,7 @@ void alloc_bigval(void * addr, size_t size)
     treap_insert(&bigvals, node);
 }
 
-void free_bigval(void * p)
+static void free_bigval(void * p)
 {
     if (p) {
         treap_delete(&bigvals, p);
@@ -515,7 +515,7 @@ void CHANGED_BAG(Bag bag)
     jl_gc_wb_back(BAG_HEADER(bag));
 }
 
-void GapRootScanner(int full)
+static void GapRootScanner(int full)
 {
     // mark our Julia module (this contains references to our custom data
     // types, which thus also will not be collected prematurely)
@@ -554,7 +554,7 @@ void GapRootScanner(int full)
     }
 }
 
-void GapTaskScanner(jl_task_t * task, int root_task)
+static void GapTaskScanner(jl_task_t * task, int root_task)
 {
     size_t size;
     int    tid;

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -42,10 +42,7 @@
 **  The  list is  automatically extended to   make room for  the new element.
 **  'AddList' returns nothing, it is called only for its side effect.
 */
-static void            AddList3 (
-    Obj                 list,
-    Obj                 obj,
-    Int                 pos)
+static void AddList3(Obj list, Obj obj, Int pos)
 {
     Int                 len;
     Int                 i;
@@ -65,10 +62,7 @@ void            AddList (
 }
 
 
-static void            AddPlist3 (
-    Obj                 list,
-    Obj                 obj,
-    Int                 pos )
+static void AddPlist3(Obj list, Obj obj, Int pos)
 {
   UInt len;
 
@@ -103,11 +97,7 @@ void            AddPlist (
 
 static Obj AddListOper;
 
-static Obj FuncADD_LIST3 (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj,
-    Obj                 pos)
+static Obj FuncADD_LIST3(Obj self, Obj list, Obj obj, Obj pos)
 {
     /* dispatch                */
   Int ipos;
@@ -140,10 +130,7 @@ static Obj FuncADD_LIST3 (
 }
 
 
-static Obj FuncADD_LIST (
-                  Obj self,
-                  Obj list,
-                  Obj obj)
+static Obj FuncADD_LIST(Obj self, Obj list, Obj obj)
 {
   FuncADD_LIST3(self, list, obj, (Obj)0);
   return (Obj) 0;
@@ -157,8 +144,7 @@ static Obj FuncADD_LIST (
 **  'RemList' removes the last object <obj> from the end of the list <list>,
 **  and returns it.
 */
-static Obj            RemList (
-    Obj                 list)
+static Obj RemList(Obj list)
 {
     Int                 pos; 
     Obj result;
@@ -198,9 +184,7 @@ static Obj RemPlist(Obj list)
 
 static Obj RemListOper;
 
-static Obj FuncREM_LIST (
-    Obj                 self,
-    Obj                 list)
+static Obj FuncREM_LIST(Obj self, Obj list)
 
 {
     /* dispatch                                                            */
@@ -230,10 +214,7 @@ static Obj FuncREM_LIST (
 **  in which case the corresponding positions  will be left empty in <list1>.
 **  'AppendList' returns nothing, it is called only for its side effect.
 */
-static Obj             FuncAPPEND_LIST_INTR (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncAPPEND_LIST_INTR(Obj self, Obj list1, Obj list2)
 {
     UInt                len1;           /* length of the first list        */
     UInt                len2;           /* length of the second list       */
@@ -305,10 +286,7 @@ static Obj             FuncAPPEND_LIST_INTR (
 
 static Obj AppendListOper;
 
-static Obj             FuncAPPEND_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj )
+static Obj FuncAPPEND_LIST(Obj self, Obj list, Obj obj)
 {
     /* dispatch                                                            */
     if ( TNUM_OBJ( list ) < FIRST_EXTERNAL_TNUM ) {
@@ -338,9 +316,7 @@ static Obj             FuncAPPEND_LIST (
 **  of <list>, the index where <obj> must be inserted to keep the list sorted
 **  is returned.
 */
-static UInt            POSITION_SORTED_LIST (
-    Obj                 list,
-    Obj                 obj )
+static UInt POSITION_SORTED_LIST(Obj list, Obj obj)
 {
     UInt                l;              /* low                             */
     UInt                h;              /* high                            */
@@ -382,10 +358,7 @@ UInt            PositionSortedDensePlist (
     return h;
 }
 
-static Obj             FuncPOSITION_SORTED_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj )
+static Obj FuncPOSITION_SORTED_LIST(Obj self, Obj list, Obj obj)
 {
     UInt                h;              /* position, result                */
 
@@ -420,10 +393,7 @@ static Obj             FuncPOSITION_SORTED_LIST (
 **  of <list>, the index where <obj> must be inserted to keep the list sorted
 **  is returned.
 */
-static UInt            POSITION_SORTED_LISTComp (
-    Obj                 list,
-    Obj                 obj,
-    Obj                 func )
+static UInt POSITION_SORTED_LISTComp(Obj list, Obj obj, Obj func)
 {
     UInt                l;              /* low                             */
     UInt                h;              /* high                            */
@@ -443,10 +413,7 @@ static UInt            POSITION_SORTED_LISTComp (
     return h;
 }
 
-static UInt            PositionSortedDensePlistComp (
-    Obj                 list,
-    Obj                 obj,
-    Obj                 func )
+static UInt PositionSortedDensePlistComp(Obj list, Obj obj, Obj func)
 {
     UInt                l;              /* low                             */
     UInt                h;              /* high                            */
@@ -466,11 +433,8 @@ static UInt            PositionSortedDensePlistComp (
     return h;
 }
 
-static Obj             FuncPOSITION_SORTED_LIST_COMP (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj,
-    Obj                 func )
+static Obj
+FuncPOSITION_SORTED_LIST_COMP(Obj self, Obj list, Obj obj, Obj func)
 {
     UInt                h;              /* position, result                */
 
@@ -493,10 +457,7 @@ static Obj             FuncPOSITION_SORTED_LIST_COMP (
 }
 
 
-static Obj             FuncPOSITION_FIRST_COMPONENT_SORTED (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj)
+static Obj FuncPOSITION_FIRST_COMPONENT_SORTED(Obj self, Obj list, Obj obj)
 {
   UInt top, bottom,middle;
   Obj x;
@@ -831,9 +792,7 @@ UInt            RemoveDupsDensePlist (
 **
 *F  FuncSORT_LIST( <self>, <list> ) . . . . . . . . . . . . . . . sort a list
 */
-static Obj FuncSORT_LIST (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncSORT_LIST(Obj self, Obj list)
 {
     /* check the first argument                                            */
     RequireSmallList("SORT_LIST", list);
@@ -851,9 +810,7 @@ static Obj FuncSORT_LIST (
     return (Obj)0;
 }
 
-static Obj FuncSTABLE_SORT_LIST (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncSTABLE_SORT_LIST(Obj self, Obj list)
 {
     /* check the first argument                                            */
     RequireSmallList("STABLE_SORT_LIST", list);
@@ -877,10 +834,7 @@ static Obj FuncSTABLE_SORT_LIST (
 **
 *F  FuncSORT_LIST_COMP( <self>, <list>, <func> )  . . . . . . . . sort a list
 */
-static Obj FuncSORT_LIST_COMP (
-    Obj                 self,
-    Obj                 list,
-    Obj                 func )
+static Obj FuncSORT_LIST_COMP(Obj self, Obj list, Obj func)
 {
     /* check the first argument                                            */
     RequireSmallList("SORT_LIST_COMP", list);
@@ -900,10 +854,7 @@ static Obj FuncSORT_LIST_COMP (
     return (Obj)0;
 }
 
-static Obj FuncSTABLE_SORT_LIST_COMP (
-    Obj                 self,
-    Obj                 list,
-    Obj                 func )
+static Obj FuncSTABLE_SORT_LIST_COMP(Obj self, Obj list, Obj func)
 {
     /* check the first argument                                            */
     RequireSmallList("STABLE_SORT_LIST_COMP", list);
@@ -928,10 +879,7 @@ static Obj FuncSTABLE_SORT_LIST_COMP (
 **
 *F  FuncSORT_PARA_LIST( <self>, <list> )  . . . . . . sort a list with shadow
 */
-static Obj FuncSORT_PARA_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj               shadow )
+static Obj FuncSORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 {
     /* check the first two arguments                                       */
     RequireSmallList("SORT_PARA_LIST", list);
@@ -951,10 +899,7 @@ static Obj FuncSORT_PARA_LIST (
     return (Obj)0;
 }
 
-static Obj FuncSTABLE_SORT_PARA_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj               shadow )
+static Obj FuncSTABLE_SORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 {
     /* check the first two arguments                                       */
     RequireSmallList("STABLE_SORT_PARA_LIST", list);
@@ -979,11 +924,7 @@ static Obj FuncSTABLE_SORT_PARA_LIST (
 **
 *F  FuncSORT_LIST_COMP( <self>, <list>, <func> )  . . . . . . . . sort a list
 */
-static Obj FuncSORT_PARA_LIST_COMP (
-    Obj                 self,
-    Obj                 list,
-    Obj               shadow,
-    Obj                 func )
+static Obj FuncSORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 {
     /* check the first two arguments                                       */
     RequireSmallList("SORT_PARA_LIST_COMP", list);
@@ -1005,11 +946,8 @@ static Obj FuncSORT_PARA_LIST_COMP (
     return (Obj)0;
 }
 
-static Obj FuncSTABLE_SORT_PARA_LIST_COMP (
-    Obj                 self,
-    Obj                 list,
-    Obj               shadow,
-    Obj                 func )
+static Obj
+FuncSTABLE_SORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 {
     /* check the first two arguments                                       */
     RequireSmallList("SORT_PARA_LIST_COMP", list);
@@ -1044,10 +982,7 @@ static Obj FuncSTABLE_SORT_PARA_LIST_COMP (
 **  equivalent  to  specifying no operation.   This function  exists  because
 **  there are places where the operation in not an option.
 */
-static Obj             FuncOnPoints (
-    Obj                 self,
-    Obj                 point,
-    Obj                 elm )
+static Obj FuncOnPoints(Obj self, Obj point, Obj elm)
 {
     return POW( point, elm );
 }
@@ -1064,10 +999,7 @@ static Obj             FuncOnPoints (
 **  specifies  the componentwise operation    of group elements on  pairs  of
 **  points, which are represented by lists of length 2.
 */
-static Obj             FuncOnPairs (
-    Obj                 self,
-    Obj                 pair,
-    Obj                 elm )
+static Obj FuncOnPairs(Obj self, Obj pair, Obj elm)
 {
     Obj                 img;            /* image, result                   */
     Obj                 tmp;            /* temporary                       */
@@ -1107,10 +1039,7 @@ static Obj             FuncOnPairs (
 **  points, which are represented by lists.  'OnPairs' is the special case of
 **  'OnTuples' for tuples with two elements.
 */
-static Obj             FuncOnTuples (
-    Obj                 self,
-    Obj                 tuple,
-    Obj                 elm )
+static Obj FuncOnTuples(Obj self, Obj tuple, Obj elm)
 {
     Obj                 img;            /* image, result                   */
     Obj                 tmp;            /* temporary                       */
@@ -1174,10 +1103,7 @@ static Obj             FuncOnTuples (
 **  represented by sorted lists of points without duplicates (see "Sets").
 */
 
-static Obj             FuncOnSets (
-    Obj                 self,
-    Obj                 set,
-    Obj                 elm )
+static Obj FuncOnSets(Obj self, Obj set, Obj elm)
 {
     Obj                 img;            /* handle of the image, result     */
     UInt                status;        /* the elements are mutable        */
@@ -1254,10 +1180,7 @@ static Obj             FuncOnSets (
 **
 **  specifies that group elements operate by multiplication from the right.
 */
-static Obj             FuncOnRight (
-    Obj                 self,
-    Obj                 point,
-    Obj                 elm )
+static Obj FuncOnRight(Obj self, Obj point, Obj elm)
 {
     return PROD( point, elm );
 }
@@ -1274,10 +1197,7 @@ static Obj             FuncOnRight (
 **  specifies that group elements operate by multiplication from the left
 **  with the inverse.
 */
-static Obj             FuncOnLeftInverse (
-    Obj                 self,
-    Obj                 point,
-    Obj                 elm )
+static Obj FuncOnLeftInverse(Obj self, Obj point, Obj elm)
 {
     return LQUO(elm, point);
 }
@@ -1411,7 +1331,7 @@ static Obj FuncSTRONGLY_CONNECTED_COMPONENTS_DIGRAPH(Obj self, Obj digraph)
 **  Argument names in the manual: fromlst, fromind, fromstep, tolst, toind, tostep, n
 */
 
-static Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
+static Obj FuncCOPY_LIST_ENTRIES(Obj self, Obj args)
 {  
   Obj srclist;
   Int srcstart;

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -42,7 +42,7 @@
 **  The  list is  automatically extended to   make room for  the new element.
 **  'AddList' returns nothing, it is called only for its side effect.
 */
-void            AddList3 (
+static void            AddList3 (
     Obj                 list,
     Obj                 obj,
     Int                 pos)
@@ -64,19 +64,8 @@ void            AddList (
   AddList3(list, obj, -1);
 }
 
-extern Obj FuncADD_LIST(
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj );
 
-extern Obj FuncADD_LIST3(
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj,
-    Obj                 pos );
-
-
-void            AddPlist3 (
+static void            AddPlist3 (
     Obj                 list,
     Obj                 obj,
     Int                 pos )
@@ -103,6 +92,7 @@ void            AddPlist3 (
     }
     ASS_LIST( list, pos, obj);
 }
+
 void            AddPlist (
     Obj                 list,
     Obj                 obj)
@@ -113,7 +103,7 @@ void            AddPlist (
 
 static Obj AddListOper;
 
-Obj FuncADD_LIST3 (
+static Obj FuncADD_LIST3 (
     Obj                 self,
     Obj                 list,
     Obj                 obj,
@@ -150,7 +140,7 @@ Obj FuncADD_LIST3 (
 }
 
 
-Obj FuncADD_LIST (
+static Obj FuncADD_LIST (
                   Obj self,
                   Obj list,
                   Obj obj)
@@ -167,7 +157,7 @@ Obj FuncADD_LIST (
 **  'RemList' removes the last object <obj> from the end of the list <list>,
 **  and returns it.
 */
-Obj            RemList (
+static Obj            RemList (
     Obj                 list)
 {
     Int                 pos; 
@@ -180,10 +170,6 @@ Obj            RemList (
     UNB_LIST(list, pos);
     return result;
 }
-
-extern Obj FuncREM_LIST(
-    Obj                 self,
-    Obj                 list);
 
 static Obj RemPlist(Obj list)
 {
@@ -212,7 +198,7 @@ static Obj RemPlist(Obj list)
 
 static Obj RemListOper;
 
-Obj FuncREM_LIST (
+static Obj FuncREM_LIST (
     Obj                 self,
     Obj                 list)
 
@@ -244,7 +230,7 @@ Obj FuncREM_LIST (
 **  in which case the corresponding positions  will be left empty in <list1>.
 **  'AppendList' returns nothing, it is called only for its side effect.
 */
-Obj             FuncAPPEND_LIST_INTR (
+static Obj             FuncAPPEND_LIST_INTR (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -319,7 +305,7 @@ Obj             FuncAPPEND_LIST_INTR (
 
 static Obj AppendListOper;
 
-Obj             FuncAPPEND_LIST (
+static Obj             FuncAPPEND_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 obj )
@@ -352,7 +338,7 @@ Obj             FuncAPPEND_LIST (
 **  of <list>, the index where <obj> must be inserted to keep the list sorted
 **  is returned.
 */
-UInt            POSITION_SORTED_LIST (
+static UInt            POSITION_SORTED_LIST (
     Obj                 list,
     Obj                 obj )
 {
@@ -396,7 +382,7 @@ UInt            PositionSortedDensePlist (
     return h;
 }
 
-Obj             FuncPOSITION_SORTED_LIST (
+static Obj             FuncPOSITION_SORTED_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 obj )
@@ -434,7 +420,7 @@ Obj             FuncPOSITION_SORTED_LIST (
 **  of <list>, the index where <obj> must be inserted to keep the list sorted
 **  is returned.
 */
-UInt            POSITION_SORTED_LISTComp (
+static UInt            POSITION_SORTED_LISTComp (
     Obj                 list,
     Obj                 obj,
     Obj                 func )
@@ -457,7 +443,7 @@ UInt            POSITION_SORTED_LISTComp (
     return h;
 }
 
-UInt            PositionSortedDensePlistComp (
+static UInt            PositionSortedDensePlistComp (
     Obj                 list,
     Obj                 obj,
     Obj                 func )
@@ -480,7 +466,7 @@ UInt            PositionSortedDensePlistComp (
     return h;
 }
 
-Obj             FuncPOSITION_SORTED_LIST_COMP (
+static Obj             FuncPOSITION_SORTED_LIST_COMP (
     Obj                 self,
     Obj                 list,
     Obj                 obj,
@@ -507,7 +493,7 @@ Obj             FuncPOSITION_SORTED_LIST_COMP (
 }
 
 
-Obj             FuncPOSITION_FIRST_COMPONENT_SORTED (
+static Obj             FuncPOSITION_FIRST_COMPONENT_SORTED (
     Obj                 self,
     Obj                 list,
     Obj                 obj)
@@ -845,7 +831,7 @@ UInt            RemoveDupsDensePlist (
 **
 *F  FuncSORT_LIST( <self>, <list> ) . . . . . . . . . . . . . . . sort a list
 */
-Obj FuncSORT_LIST (
+static Obj FuncSORT_LIST (
     Obj                 self,
     Obj                 list )
 {
@@ -865,7 +851,7 @@ Obj FuncSORT_LIST (
     return (Obj)0;
 }
 
-Obj FuncSTABLE_SORT_LIST (
+static Obj FuncSTABLE_SORT_LIST (
     Obj                 self,
     Obj                 list )
 {
@@ -891,7 +877,7 @@ Obj FuncSTABLE_SORT_LIST (
 **
 *F  FuncSORT_LIST_COMP( <self>, <list>, <func> )  . . . . . . . . sort a list
 */
-Obj FuncSORT_LIST_COMP (
+static Obj FuncSORT_LIST_COMP (
     Obj                 self,
     Obj                 list,
     Obj                 func )
@@ -914,7 +900,7 @@ Obj FuncSORT_LIST_COMP (
     return (Obj)0;
 }
 
-Obj FuncSTABLE_SORT_LIST_COMP (
+static Obj FuncSTABLE_SORT_LIST_COMP (
     Obj                 self,
     Obj                 list,
     Obj                 func )
@@ -942,7 +928,7 @@ Obj FuncSTABLE_SORT_LIST_COMP (
 **
 *F  FuncSORT_PARA_LIST( <self>, <list> )  . . . . . . sort a list with shadow
 */
-Obj FuncSORT_PARA_LIST (
+static Obj FuncSORT_PARA_LIST (
     Obj                 self,
     Obj                 list,
     Obj               shadow )
@@ -965,7 +951,7 @@ Obj FuncSORT_PARA_LIST (
     return (Obj)0;
 }
 
-Obj FuncSTABLE_SORT_PARA_LIST (
+static Obj FuncSTABLE_SORT_PARA_LIST (
     Obj                 self,
     Obj                 list,
     Obj               shadow )
@@ -993,7 +979,7 @@ Obj FuncSTABLE_SORT_PARA_LIST (
 **
 *F  FuncSORT_LIST_COMP( <self>, <list>, <func> )  . . . . . . . . sort a list
 */
-Obj FuncSORT_PARA_LIST_COMP (
+static Obj FuncSORT_PARA_LIST_COMP (
     Obj                 self,
     Obj                 list,
     Obj               shadow,
@@ -1019,7 +1005,7 @@ Obj FuncSORT_PARA_LIST_COMP (
     return (Obj)0;
 }
 
-Obj FuncSTABLE_SORT_PARA_LIST_COMP (
+static Obj FuncSTABLE_SORT_PARA_LIST_COMP (
     Obj                 self,
     Obj                 list,
     Obj               shadow,
@@ -1058,7 +1044,7 @@ Obj FuncSTABLE_SORT_PARA_LIST_COMP (
 **  equivalent  to  specifying no operation.   This function  exists  because
 **  there are places where the operation in not an option.
 */
-Obj             FuncOnPoints (
+static Obj             FuncOnPoints (
     Obj                 self,
     Obj                 point,
     Obj                 elm )
@@ -1078,7 +1064,7 @@ Obj             FuncOnPoints (
 **  specifies  the componentwise operation    of group elements on  pairs  of
 **  points, which are represented by lists of length 2.
 */
-Obj             FuncOnPairs (
+static Obj             FuncOnPairs (
     Obj                 self,
     Obj                 pair,
     Obj                 elm )
@@ -1121,7 +1107,7 @@ Obj             FuncOnPairs (
 **  points, which are represented by lists.  'OnPairs' is the special case of
 **  'OnTuples' for tuples with two elements.
 */
-Obj             FuncOnTuples (
+static Obj             FuncOnTuples (
     Obj                 self,
     Obj                 tuple,
     Obj                 elm )
@@ -1188,7 +1174,7 @@ Obj             FuncOnTuples (
 **  represented by sorted lists of points without duplicates (see "Sets").
 */
 
-Obj             FuncOnSets (
+static Obj             FuncOnSets (
     Obj                 self,
     Obj                 set,
     Obj                 elm )
@@ -1268,7 +1254,7 @@ Obj             FuncOnSets (
 **
 **  specifies that group elements operate by multiplication from the right.
 */
-Obj             FuncOnRight (
+static Obj             FuncOnRight (
     Obj                 self,
     Obj                 point,
     Obj                 elm )
@@ -1288,7 +1274,7 @@ Obj             FuncOnRight (
 **  specifies that group elements operate by multiplication from the left
 **  with the inverse.
 */
-Obj             FuncOnLeftInverse (
+static Obj             FuncOnLeftInverse (
     Obj                 self,
     Obj                 point,
     Obj                 elm )
@@ -1425,7 +1411,7 @@ static Obj FuncSTRONGLY_CONNECTED_COMPONENTS_DIGRAPH(Obj self, Obj digraph)
 **  Argument names in the manual: fromlst, fromind, fromstep, tolst, toind, tostep, n
 */
 
-Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
+static Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
 {  
   Obj srclist;
   Int srcstart;
@@ -1566,7 +1552,7 @@ Obj FuncCOPY_LIST_ENTRIES( Obj self, Obj args )
 }
 
 
-Obj FuncLIST_WITH_IDENTICAL_ENTRIES(Obj self, Obj n, Obj obj)
+static Obj FuncLIST_WITH_IDENTICAL_ENTRIES(Obj self, Obj n, Obj obj)
 {
     RequireNonnegativeSmallInt("LIST_WITH_IDENTICAL_ENTRIES", n);
 

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -77,7 +77,7 @@ Int             EqListList (
     return 1L;
 }
 
-Obj FuncEQ_LIST_LIST_DEFAULT (
+static Obj FuncEQ_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -127,7 +127,7 @@ Int             LtListList (
     return (lenL < lenR);
 }
 
-Obj FuncLT_LIST_LIST_DEFAULT (
+static Obj FuncLT_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -143,14 +143,14 @@ Obj FuncLT_LIST_LIST_DEFAULT (
 **  'InList' returns a   nonzero value if  <objL>  is a  member of  the  list
 **  <listR>, and zero otherwise.
 */
-Int             InList (
+static Int             InList (
     Obj                 objL,
     Obj                 listR )
 {
   return Fail != POS_LIST( listR, objL, INTOBJ_INT(0L) );
 }
 
-Obj FuncIN_LIST_DEFAULT (
+static Obj FuncIN_LIST_DEFAULT (
     Obj                 self,
     Obj                 obj,
     Obj                 list )
@@ -290,7 +290,7 @@ Obj             SumListList (
     return listS;
 }
 
-Obj FuncSUM_SCL_LIST_DEFAULT (
+static Obj FuncSUM_SCL_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -298,7 +298,7 @@ Obj FuncSUM_SCL_LIST_DEFAULT (
     return SumSclList( listL, listR );
 }
 
-Obj FuncSUM_LIST_SCL_DEFAULT (
+static Obj FuncSUM_LIST_SCL_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -306,7 +306,7 @@ Obj FuncSUM_LIST_SCL_DEFAULT (
     return SumListScl( listL, listR );
 }
 
-Obj FuncSUM_LIST_LIST_DEFAULT (
+static Obj FuncSUM_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -328,7 +328,7 @@ Obj FuncSUM_LIST_LIST_DEFAULT (
 **
 **  'ZeroListDefault' is a generic function for the zero.
 */
-Obj             ZeroListDefault (
+static Obj             ZeroListDefault (
     Obj                 list )
 {
     Obj                 res;
@@ -387,7 +387,7 @@ Obj             ZeroListDefault (
     return res;
 }
 
-Obj FuncZERO_LIST_DEFAULT (
+static Obj FuncZERO_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -395,7 +395,7 @@ Obj FuncZERO_LIST_DEFAULT (
 }
 
 
-Obj             ZeroListMutDefault (
+static Obj             ZeroListMutDefault (
     Obj                 list )
 {
     Obj                 res;
@@ -449,7 +449,7 @@ Obj             ZeroListMutDefault (
     return res;
 }
 
-Obj FuncZERO_MUT_LIST_DEFAULT (
+static Obj FuncZERO_MUT_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -464,7 +464,7 @@ Obj FuncZERO_MUT_LIST_DEFAULT (
    we want an immutable result, we can (a) reuse a single row of zeros
    (b) record that the result is a rectangular table */
 
-Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
+static Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
 {
   Obj zrow;
   UInt len;
@@ -496,7 +496,7 @@ Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
 **  'AInvListDefault' is a generic function for the additive inverse.
 */
 
-Obj AInvMutListDefault (
+static Obj AInvMutListDefault (
     Obj                 list )
 {
     Obj                 res;
@@ -549,14 +549,14 @@ Obj AInvMutListDefault (
     return res;
 }
 
-Obj FuncAINV_MUT_LIST_DEFAULT (
+static Obj FuncAINV_MUT_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
     return AInvMutListDefault( list );
 }
 
-Obj AInvListDefault (
+static Obj AInvListDefault (
     Obj                 list )
 {
     Obj                 res;
@@ -613,7 +613,7 @@ Obj AInvListDefault (
     return res;
 }
 
-Obj FuncAINV_LIST_DEFAULT (
+static Obj FuncAINV_LIST_DEFAULT (
     Obj                 self,
     Obj                 list )
 {
@@ -809,7 +809,7 @@ Obj             DiffListList (
     return listD;
 }
 
-Obj FuncDIFF_SCL_LIST_DEFAULT (
+static Obj FuncDIFF_SCL_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -817,7 +817,7 @@ Obj FuncDIFF_SCL_LIST_DEFAULT (
     return DiffSclList( listL, listR );
 }
 
-Obj FuncDIFF_LIST_SCL_DEFAULT (
+static Obj FuncDIFF_LIST_SCL_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -825,7 +825,7 @@ Obj FuncDIFF_LIST_SCL_DEFAULT (
     return DiffListScl( listL, listR );
 }
 
-Obj FuncDIFF_LIST_LIST_DEFAULT (
+static Obj FuncDIFF_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -987,7 +987,7 @@ Obj             ProdListList (
     return listP;
 }
 
-Obj FuncPROD_SCL_LIST_DEFAULT (
+static Obj FuncPROD_SCL_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -995,7 +995,7 @@ Obj FuncPROD_SCL_LIST_DEFAULT (
     return ProdSclList( listL, listR );
 }
 
-Obj FuncPROD_LIST_SCL_DEFAULT (
+static Obj FuncPROD_LIST_SCL_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR )
@@ -1003,7 +1003,7 @@ Obj FuncPROD_LIST_SCL_DEFAULT (
     return ProdListScl( listL, listR );
 }
 
-Obj FuncPROD_LIST_LIST_DEFAULT (
+static Obj FuncPROD_LIST_LIST_DEFAULT (
     Obj                 self,
     Obj                 listL,
     Obj                 listR,
@@ -1044,7 +1044,7 @@ Obj FuncPROD_LIST_LIST_DEFAULT (
 **  and 2 for a fully mutable result.
 */
 
-Obj             OneMatrix (
+static Obj             OneMatrix (
     Obj                 mat,
     UInt                mut)
 {
@@ -1114,21 +1114,21 @@ Obj             OneMatrix (
     return res;
 }
 
-Obj FuncONE_MATRIX_IMMUTABLE (
+static Obj FuncONE_MATRIX_IMMUTABLE (
     Obj                 self,
     Obj                 list )
 {
     return OneMatrix( list,0 );
 }
 
-Obj FuncONE_MATRIX_SAME_MUTABILITY (
+static Obj FuncONE_MATRIX_SAME_MUTABILITY (
     Obj                 self,
     Obj                 list )
 {
     return OneMatrix( list,1 );
 }
 
-Obj FuncONE_MATRIX_MUTABLE (
+static Obj FuncONE_MATRIX_MUTABLE (
     Obj                 self,
     Obj                 list )
 {
@@ -1154,7 +1154,7 @@ Obj FuncONE_MATRIX_MUTABLE (
 **  calls to AddRowVector, etc.
 */
 
-Obj             InvMatrix (
+static Obj             InvMatrix (
     Obj                 mat,
     UInt                mut)
 {
@@ -1288,17 +1288,17 @@ Obj             InvMatrix (
     return res;
 }
 
-Obj FuncINV_MATRIX_MUTABLE( Obj self, Obj mat)
+static Obj FuncINV_MATRIX_MUTABLE( Obj self, Obj mat)
 {
   return InvMatrix(mat, 2);
 }
 
-Obj FuncINV_MATRIX_SAME_MUTABILITY( Obj self, Obj mat)
+static Obj FuncINV_MATRIX_SAME_MUTABILITY( Obj self, Obj mat)
 {
   return InvMatrix(mat, 1);
 }
 
-Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
+static Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
 {
   return InvMatrix(mat, 0);
 }
@@ -1317,7 +1317,7 @@ Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
 static Obj AddRowVectorOp;   /* BH changed to static */
 static Obj MultVectorLeftOp; /* BH changed to static */
 
-Obj FuncADD_ROW_VECTOR_5( Obj self,
+static Obj FuncADD_ROW_VECTOR_5( Obj self,
                           Obj list1,
                           Obj list2,
                           Obj mult,
@@ -1353,7 +1353,7 @@ Obj FuncADD_ROW_VECTOR_5( Obj self,
 **  This version is specialised to the "fast" case where list1 and list2 are
 **  plain lists of cyclotomics and mult is a small integers
 */
-Obj FuncADD_ROW_VECTOR_5_FAST ( Obj self,
+static Obj FuncADD_ROW_VECTOR_5_FAST ( Obj self,
                                 Obj list1,
                                 Obj list2,
                                 Obj mult,
@@ -1397,7 +1397,7 @@ Obj FuncADD_ROW_VECTOR_5_FAST ( Obj self,
 *T  This could be speeded up still further by using special code for various
 **  types of list -- this version just uses generic list ops
 */
-Obj FuncADD_ROW_VECTOR_3( Obj self,
+static Obj FuncADD_ROW_VECTOR_3( Obj self,
                           Obj list1,
                           Obj list2,
                           Obj mult)
@@ -1428,7 +1428,7 @@ Obj FuncADD_ROW_VECTOR_3( Obj self,
 **  This version is specialised to the "fast" case where list1 and list2 are
 **  plain lists of cyclotomics and mult is a small integers
 */
-Obj FuncADD_ROW_VECTOR_3_FAST ( Obj self,
+static Obj FuncADD_ROW_VECTOR_3_FAST ( Obj self,
                                 Obj list1,
                                 Obj list2,
                                 Obj mult )
@@ -1467,7 +1467,7 @@ Obj FuncADD_ROW_VECTOR_3_FAST ( Obj self,
 *T  This could be speeded up still further by using special code for various
 **  types of list -- this version just uses generic list ops
 */
-Obj FuncADD_ROW_VECTOR_2( Obj self,
+static Obj FuncADD_ROW_VECTOR_2( Obj self,
                           Obj list1,
                           Obj list2)
 {
@@ -1496,7 +1496,7 @@ Obj FuncADD_ROW_VECTOR_2( Obj self,
 **  This version is specialised to the "fast" case where list1 and list2 are
 **  plain lists of cyclotomics 
 */
-Obj FuncADD_ROW_VECTOR_2_FAST ( Obj self,
+static Obj FuncADD_ROW_VECTOR_2_FAST ( Obj self,
                                 Obj list1,
                                 Obj list2 )
 {
@@ -1552,12 +1552,12 @@ static inline Obj MULT_VECTOR_LEFT_RIGHT_2(Obj list, Obj mult, UInt left)
   return 0;
 }
 
-Obj FuncMULT_VECTOR_LEFT_2(Obj self, Obj list, Obj mult)
+static Obj FuncMULT_VECTOR_LEFT_2(Obj self, Obj list, Obj mult)
 {
     return MULT_VECTOR_LEFT_RIGHT_2(list, mult, 1);
 }
 
-Obj FuncMULT_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
+static Obj FuncMULT_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
 {
     return MULT_VECTOR_LEFT_RIGHT_2(list, mult, 0);
 }
@@ -1573,7 +1573,7 @@ Obj FuncMULT_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
 **  multiplier
 */
 
-Obj FuncMULT_VECTOR_2_FAST( Obj self,
+static Obj FuncMULT_VECTOR_2_FAST( Obj self,
                                 Obj list,
                                 Obj mult )
 {
@@ -1604,7 +1604,7 @@ Obj FuncMULT_VECTOR_2_FAST( Obj self,
 */
 
 
-Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
+static Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
                               Obj vec,
                               Obj mat )
 {
@@ -1655,9 +1655,9 @@ Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
 **
 */
 
-Obj ConvertToMatrixRep;
+static Obj ConvertToMatrixRep;
 
-Obj InvMatWithRowVecs( Obj mat, UInt mut)
+static Obj InvMatWithRowVecs( Obj mat, UInt mut)
 {
   Obj                 res;            /* result                          */
   Obj                 matcopy;        /* copy of mat                     */
@@ -1808,17 +1808,17 @@ Obj InvMatWithRowVecs( Obj mat, UInt mut)
 }
 
 
-Obj FuncINV_MAT_DEFAULT_MUTABLE ( Obj self, Obj mat)
+static Obj FuncINV_MAT_DEFAULT_MUTABLE ( Obj self, Obj mat)
 {
   return InvMatWithRowVecs(mat, 2);
 }
 
-Obj FuncINV_MAT_DEFAULT_SAME_MUTABILITY ( Obj self, Obj mat)
+static Obj FuncINV_MAT_DEFAULT_SAME_MUTABILITY ( Obj self, Obj mat)
 {
   return InvMatWithRowVecs(mat, 1);
 }
 
-Obj FuncINV_MAT_DEFAULT_IMMUTABLE ( Obj self, Obj mat)
+static Obj FuncINV_MAT_DEFAULT_IMMUTABLE ( Obj self, Obj mat)
 {
   return InvMatWithRowVecs(mat, 0);
 }
@@ -1836,7 +1836,7 @@ Obj FuncINV_MAT_DEFAULT_IMMUTABLE ( Obj self, Obj mat)
 ** entries are small integers, as are their sums
 */
 
-Obj FuncADD_TO_LIST_ENTRIES_PLIST_RANGE ( 
+static Obj FuncADD_TO_LIST_ENTRIES_PLIST_RANGE ( 
                               Obj self,
                               Obj list,
                               Obj range,

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -77,10 +77,7 @@ Int             EqListList (
     return 1L;
 }
 
-static Obj FuncEQ_LIST_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncEQ_LIST_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return (EqListList( listL, listR ) ? True : False);
 }
@@ -127,10 +124,7 @@ Int             LtListList (
     return (lenL < lenR);
 }
 
-static Obj FuncLT_LIST_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncLT_LIST_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return (LtListList( listL, listR ) ? True : False);
 }
@@ -143,17 +137,12 @@ static Obj FuncLT_LIST_LIST_DEFAULT (
 **  'InList' returns a   nonzero value if  <objL>  is a  member of  the  list
 **  <listR>, and zero otherwise.
 */
-static Int             InList (
-    Obj                 objL,
-    Obj                 listR )
+static Int InList(Obj objL, Obj listR)
 {
   return Fail != POS_LIST( listR, objL, INTOBJ_INT(0L) );
 }
 
-static Obj FuncIN_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 list )
+static Obj FuncIN_LIST_DEFAULT(Obj self, Obj obj, Obj list)
 {
     return (InList( obj, list ) ? True : False);
 }
@@ -290,26 +279,17 @@ Obj             SumListList (
     return listS;
 }
 
-static Obj FuncSUM_SCL_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncSUM_SCL_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return SumSclList( listL, listR );
 }
 
-static Obj FuncSUM_LIST_SCL_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncSUM_LIST_SCL_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return SumListScl( listL, listR );
 }
 
-static Obj FuncSUM_LIST_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncSUM_LIST_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return SumListList( listL, listR );
 }
@@ -328,8 +308,7 @@ static Obj FuncSUM_LIST_LIST_DEFAULT (
 **
 **  'ZeroListDefault' is a generic function for the zero.
 */
-static Obj             ZeroListDefault (
-    Obj                 list )
+static Obj ZeroListDefault(Obj list)
 {
     Obj                 res;
 /*  Obj                 elm; */
@@ -387,16 +366,13 @@ static Obj             ZeroListDefault (
     return res;
 }
 
-static Obj FuncZERO_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncZERO_LIST_DEFAULT(Obj self, Obj list)
 {
     return ZeroListDefault( list );
 }
 
 
-static Obj             ZeroListMutDefault (
-    Obj                 list )
+static Obj ZeroListMutDefault(Obj list)
 {
     Obj                 res;
 /*  Obj                 elm; */
@@ -449,9 +425,7 @@ static Obj             ZeroListMutDefault (
     return res;
 }
 
-static Obj FuncZERO_MUT_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncZERO_MUT_LIST_DEFAULT(Obj self, Obj list)
 {
     return ZeroListMutDefault( list );
 }
@@ -464,7 +438,7 @@ static Obj FuncZERO_MUT_LIST_DEFAULT (
    we want an immutable result, we can (a) reuse a single row of zeros
    (b) record that the result is a rectangular table */
 
-static Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
+static Obj FuncZERO_ATTR_MAT(Obj self, Obj mat)
 {
   Obj zrow;
   UInt len;
@@ -496,8 +470,7 @@ static Obj FuncZERO_ATTR_MAT( Obj self, Obj mat )
 **  'AInvListDefault' is a generic function for the additive inverse.
 */
 
-static Obj AInvMutListDefault (
-    Obj                 list )
+static Obj AInvMutListDefault(Obj list)
 {
     Obj                 res;
     Obj                 elm;
@@ -549,15 +522,12 @@ static Obj AInvMutListDefault (
     return res;
 }
 
-static Obj FuncAINV_MUT_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncAINV_MUT_LIST_DEFAULT(Obj self, Obj list)
 {
     return AInvMutListDefault( list );
 }
 
-static Obj AInvListDefault (
-    Obj                 list )
+static Obj AInvListDefault(Obj list)
 {
     Obj                 res;
     Obj                 elm;
@@ -613,9 +583,7 @@ static Obj AInvListDefault (
     return res;
 }
 
-static Obj FuncAINV_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncAINV_LIST_DEFAULT(Obj self, Obj list)
 {
     return AInvListDefault( list );
 }
@@ -809,26 +777,17 @@ Obj             DiffListList (
     return listD;
 }
 
-static Obj FuncDIFF_SCL_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncDIFF_SCL_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return DiffSclList( listL, listR );
 }
 
-static Obj FuncDIFF_LIST_SCL_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncDIFF_LIST_SCL_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return DiffListScl( listL, listR );
 }
 
-static Obj FuncDIFF_LIST_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncDIFF_LIST_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return DiffListList( listL, listR );
 }
@@ -987,27 +946,18 @@ Obj             ProdListList (
     return listP;
 }
 
-static Obj FuncPROD_SCL_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncPROD_SCL_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return ProdSclList( listL, listR );
 }
 
-static Obj FuncPROD_LIST_SCL_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR )
+static Obj FuncPROD_LIST_SCL_DEFAULT(Obj self, Obj listL, Obj listR)
 {
     return ProdListScl( listL, listR );
 }
 
-static Obj FuncPROD_LIST_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 listL,
-    Obj                 listR,
-    Obj                 depthdiff)
+static Obj
+FuncPROD_LIST_LIST_DEFAULT(Obj self, Obj listL, Obj listR, Obj depthdiff)
 {
   Obj prod;
   prod = ProdListList( listL, listR );
@@ -1044,9 +994,7 @@ static Obj FuncPROD_LIST_LIST_DEFAULT (
 **  and 2 for a fully mutable result.
 */
 
-static Obj             OneMatrix (
-    Obj                 mat,
-    UInt                mut)
+static Obj OneMatrix(Obj mat, UInt mut)
 {
     Obj                 res = 0;        /* one, result                     */
     Obj                 row;            /* one row of the result           */
@@ -1114,23 +1062,17 @@ static Obj             OneMatrix (
     return res;
 }
 
-static Obj FuncONE_MATRIX_IMMUTABLE (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncONE_MATRIX_IMMUTABLE(Obj self, Obj list)
 {
     return OneMatrix( list,0 );
 }
 
-static Obj FuncONE_MATRIX_SAME_MUTABILITY (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncONE_MATRIX_SAME_MUTABILITY(Obj self, Obj list)
 {
     return OneMatrix( list,1 );
 }
 
-static Obj FuncONE_MATRIX_MUTABLE (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncONE_MATRIX_MUTABLE(Obj self, Obj list)
 {
     return OneMatrix( list,2 );
 }
@@ -1154,9 +1096,7 @@ static Obj FuncONE_MATRIX_MUTABLE (
 **  calls to AddRowVector, etc.
 */
 
-static Obj             InvMatrix (
-    Obj                 mat,
-    UInt                mut)
+static Obj InvMatrix(Obj mat, UInt mut)
 {
     Obj                 res = 0;        /* power, result                   */
     Obj                 row;            /* one row of the matrix           */
@@ -1288,17 +1228,17 @@ static Obj             InvMatrix (
     return res;
 }
 
-static Obj FuncINV_MATRIX_MUTABLE( Obj self, Obj mat)
+static Obj FuncINV_MATRIX_MUTABLE(Obj self, Obj mat)
 {
   return InvMatrix(mat, 2);
 }
 
-static Obj FuncINV_MATRIX_SAME_MUTABILITY( Obj self, Obj mat)
+static Obj FuncINV_MATRIX_SAME_MUTABILITY(Obj self, Obj mat)
 {
   return InvMatrix(mat, 1);
 }
 
-static Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
+static Obj FuncINV_MATRIX_IMMUTABLE(Obj self, Obj mat)
 {
   return InvMatrix(mat, 0);
 }
@@ -1317,12 +1257,8 @@ static Obj FuncINV_MATRIX_IMMUTABLE( Obj self, Obj mat)
 static Obj AddRowVectorOp;   /* BH changed to static */
 static Obj MultVectorLeftOp; /* BH changed to static */
 
-static Obj FuncADD_ROW_VECTOR_5( Obj self,
-                          Obj list1,
-                          Obj list2,
-                          Obj mult,
-                          Obj from,
-                          Obj to )
+static Obj FuncADD_ROW_VECTOR_5(
+    Obj self, Obj list1, Obj list2, Obj mult, Obj from, Obj to)
 {
   UInt i;
   Obj el1,el2;
@@ -1353,12 +1289,8 @@ static Obj FuncADD_ROW_VECTOR_5( Obj self,
 **  This version is specialised to the "fast" case where list1 and list2 are
 **  plain lists of cyclotomics and mult is a small integers
 */
-static Obj FuncADD_ROW_VECTOR_5_FAST ( Obj self,
-                                Obj list1,
-                                Obj list2,
-                                Obj mult,
-                                Obj from,
-                                Obj to )
+static Obj FuncADD_ROW_VECTOR_5_FAST(
+    Obj self, Obj list1, Obj list2, Obj mult, Obj from, Obj to)
 {
   UInt i;
   Obj e1,e2, prd, sum;
@@ -1397,10 +1329,7 @@ static Obj FuncADD_ROW_VECTOR_5_FAST ( Obj self,
 *T  This could be speeded up still further by using special code for various
 **  types of list -- this version just uses generic list ops
 */
-static Obj FuncADD_ROW_VECTOR_3( Obj self,
-                          Obj list1,
-                          Obj list2,
-                          Obj mult)
+static Obj FuncADD_ROW_VECTOR_3(Obj self, Obj list1, Obj list2, Obj mult)
 {
   UInt i;
   UInt len = LEN_LIST(list1);
@@ -1428,10 +1357,7 @@ static Obj FuncADD_ROW_VECTOR_3( Obj self,
 **  This version is specialised to the "fast" case where list1 and list2 are
 **  plain lists of cyclotomics and mult is a small integers
 */
-static Obj FuncADD_ROW_VECTOR_3_FAST ( Obj self,
-                                Obj list1,
-                                Obj list2,
-                                Obj mult )
+static Obj FuncADD_ROW_VECTOR_3_FAST(Obj self, Obj list1, Obj list2, Obj mult)
 {
   UInt i;
   Obj e1,e2, prd, sum;
@@ -1467,9 +1393,7 @@ static Obj FuncADD_ROW_VECTOR_3_FAST ( Obj self,
 *T  This could be speeded up still further by using special code for various
 **  types of list -- this version just uses generic list ops
 */
-static Obj FuncADD_ROW_VECTOR_2( Obj self,
-                          Obj list1,
-                          Obj list2)
+static Obj FuncADD_ROW_VECTOR_2(Obj self, Obj list1, Obj list2)
 {
   UInt i;
   Obj el1,el2;
@@ -1496,9 +1420,7 @@ static Obj FuncADD_ROW_VECTOR_2( Obj self,
 **  This version is specialised to the "fast" case where list1 and list2 are
 **  plain lists of cyclotomics 
 */
-static Obj FuncADD_ROW_VECTOR_2_FAST ( Obj self,
-                                Obj list1,
-                                Obj list2 )
+static Obj FuncADD_ROW_VECTOR_2_FAST(Obj self, Obj list1, Obj list2)
 {
   UInt i;
   Obj e1,e2, sum;
@@ -1573,9 +1495,7 @@ static Obj FuncMULT_VECTOR_RIGHT_2(Obj self, Obj list, Obj mult)
 **  multiplier
 */
 
-static Obj FuncMULT_VECTOR_2_FAST( Obj self,
-                                Obj list,
-                                Obj mult )
+static Obj FuncMULT_VECTOR_2_FAST(Obj self, Obj list, Obj mult)
 {
   UInt i;
   Obj el,prd;
@@ -1604,9 +1524,7 @@ static Obj FuncMULT_VECTOR_2_FAST( Obj self,
 */
 
 
-static Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
-                              Obj vec,
-                              Obj mat )
+static Obj FuncPROD_VEC_MAT_DEFAULT(Obj self, Obj vec, Obj mat)
 {
   Obj res;
   Obj elt;
@@ -1657,7 +1575,7 @@ static Obj FuncPROD_VEC_MAT_DEFAULT( Obj self,
 
 static Obj ConvertToMatrixRep;
 
-static Obj InvMatWithRowVecs( Obj mat, UInt mut)
+static Obj InvMatWithRowVecs(Obj mat, UInt mut)
 {
   Obj                 res;            /* result                          */
   Obj                 matcopy;        /* copy of mat                     */
@@ -1808,17 +1726,17 @@ static Obj InvMatWithRowVecs( Obj mat, UInt mut)
 }
 
 
-static Obj FuncINV_MAT_DEFAULT_MUTABLE ( Obj self, Obj mat)
+static Obj FuncINV_MAT_DEFAULT_MUTABLE(Obj self, Obj mat)
 {
   return InvMatWithRowVecs(mat, 2);
 }
 
-static Obj FuncINV_MAT_DEFAULT_SAME_MUTABILITY ( Obj self, Obj mat)
+static Obj FuncINV_MAT_DEFAULT_SAME_MUTABILITY(Obj self, Obj mat)
 {
   return InvMatWithRowVecs(mat, 1);
 }
 
-static Obj FuncINV_MAT_DEFAULT_IMMUTABLE ( Obj self, Obj mat)
+static Obj FuncINV_MAT_DEFAULT_IMMUTABLE(Obj self, Obj mat)
 {
   return InvMatWithRowVecs(mat, 0);
 }
@@ -1836,11 +1754,8 @@ static Obj FuncINV_MAT_DEFAULT_IMMUTABLE ( Obj self, Obj mat)
 ** entries are small integers, as are their sums
 */
 
-static Obj FuncADD_TO_LIST_ENTRIES_PLIST_RANGE ( 
-                              Obj self,
-                              Obj list,
-                              Obj range,
-                              Obj x)
+static Obj
+FuncADD_TO_LIST_ENTRIES_PLIST_RANGE(Obj self, Obj list, Obj range, Obj x)
 {
   UInt low, high, incr;
   Obj y,z;

--- a/src/lists.c
+++ b/src/lists.c
@@ -53,17 +53,14 @@
 */
 Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
-static Obj             IsListFilt;
+static Obj IsListFilt;
 
-static Obj             FuncIS_LIST (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_LIST(Obj self, Obj obj)
 {
     return (IS_LIST( obj ) ? True : False);
 }
 
-static Int             IsListObject (
-    Obj                 obj )
+static Int IsListObject(Obj obj)
 {
     return (DoFilter( IsListFilt, obj ) == True);
 }
@@ -82,13 +79,12 @@ static Int             IsListObject (
 */
 Int             (*IsSmallListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
-static Obj             IsSmallListFilt;
-static Obj             HasIsSmallListFilt;
-static Obj             LengthAttr;
-static Obj             SetIsSmallList;
+static Obj IsSmallListFilt;
+static Obj HasIsSmallListFilt;
+static Obj LengthAttr;
+static Obj SetIsSmallList;
 
-static Int             IsSmallListObject (
-    Obj                 obj )
+static Int IsSmallListObject(Obj obj)
 {
   Obj len;
   if (DoFilter(IsListFilt, obj) != True)
@@ -145,9 +141,7 @@ static Int             IsSmallListObject (
 **    internal types (NOT YET IMPLEMENTED)
 */
 
-static Obj FuncLENGTH (
-    Obj             self,
-    Obj             list )
+static Obj FuncLENGTH(Obj self, Obj list)
 {
     /* internal list types                                                 */
 #ifdef HPCGAP
@@ -187,9 +181,7 @@ static Obj FuncLENGTH (
 */
 Int (*LenListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static Obj FuncLEN_LIST (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncLEN_LIST(Obj self, Obj list)
 {
     /* special case for plain lists (avoid conversion back and forth)      */
     if ( IS_PLIST(list) ) {
@@ -203,15 +195,13 @@ static Obj FuncLEN_LIST (
 }
 
 
-static Int LenListError (
-    Obj                 list )
+static Int LenListError(Obj list)
 {
     RequireArgument("Length", list, "must be a list");
 }
 
 
-static Int LenListObject (
-    Obj                 obj )
+static Int LenListObject(Obj obj)
 {
     Obj                 len;
 
@@ -237,21 +227,18 @@ static Int LenListObject (
 
 Obj             (*LengthFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static Obj LengthError (
-    Obj                 list )
+static Obj LengthError(Obj list)
 {
     RequireArgument("Length", list, "must be a list");
 }
 
 
-static Obj LengthObject (
-    Obj                 obj )
+static Obj LengthObject(Obj obj)
 {
     return FuncLENGTH( LengthAttr, obj );
 }
 
-static Obj LengthInternal (
-    Obj                 obj )
+static Obj LengthInternal(Obj obj)
 {
     return INTOBJ_INT(LEN_LIST(obj));
 }
@@ -273,10 +260,7 @@ Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 static Obj             IsbListOper;
 
-static Obj             FuncISB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+static Obj FuncISB_LIST(Obj self, Obj list, Obj pos)
 {
     if (IS_POS_INTOBJ(pos))
         return ISB_LIST( list, INT_INTOBJ(pos) ) ? True : False;
@@ -284,16 +268,12 @@ static Obj             FuncISB_LIST (
         return ISBB_LIST( list, pos ) ? True : False;
 }
 
-static Int             IsbListError (
-    Obj                 list,
-    Int                 pos )
+static Int IsbListError(Obj list, Int pos)
 {
     RequireArgument("IsBound", list, "must be a list");
 }
 
-static Int             IsbListObject (
-    Obj                 list,
-    Int                 pos )
+static Int IsbListObject(Obj list, Int pos)
 {
     return DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True;
 }
@@ -386,9 +366,7 @@ Obj (*Elm0vListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **
 *F  Elm0ListError( <list>, <pos> )  . . . . . . . . . . . . . . error message
 */
-static Obj Elm0ListError (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0ListError(Obj list, Int pos)
 {
     RequireArgument("List Element", list, "must be a list");
 }
@@ -411,9 +389,7 @@ static Obj Elm0ListError (
 */
 static Obj Elm0ListOper;
 
-static Obj Elm0ListObject (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0ListObject(Obj list, Int pos)
 {
     Obj                 elm;
 
@@ -434,10 +410,7 @@ static Obj Elm0ListObject (
 **
 *F  FuncELM0_LIST( <self>, <list>, <pos> )  . . . . . . operation `ELM0_LIST'
 */
-static Obj FuncELM0_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+static Obj FuncELM0_LIST(Obj self, Obj list, Obj pos)
 {
     Obj                 elm;
     elm = ELM0_LIST( list, INT_INTOBJ(pos) );
@@ -492,9 +465,7 @@ Obj (*ElmwListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **
 *F  ElmListError( <list>, <pos> ) . . . . . . . . . . . . . . . error message
 */
-static Obj ElmListError (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmListError(Obj list, Int pos)
 {
     RequireArgument("List Element", list, "must be a list");
 }
@@ -512,7 +483,7 @@ static Obj ElmListError (
 */
 static Obj ElmListOper;
 
-static Obj ElmListObject( Obj list, Int pos)
+static Obj ElmListObject(Obj list, Int pos)
 {
     return ELMB_LIST( list, INTOBJ_INT(pos) );
 }
@@ -590,9 +561,7 @@ Obj (*ElmsListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj poss );
 **
 *F  ElmsListError(<list>,<poss>)  . . . . . . . . .  error selection function
 */
-static Obj ElmsListError (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsListError(Obj list, Obj poss)
 {
     RequireArgument("List Elements", list, "must be a list");
 }
@@ -606,9 +575,7 @@ static Obj ElmsListError (
 */
 static Obj ElmsListOper;
 
-static Obj ElmsListObject (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsListObject(Obj list, Obj poss)
 {
     Obj                 elm;
 
@@ -624,10 +591,7 @@ static Obj ElmsListObject (
 **
 *F  FuncELMS_LIST( <self>, <list>, <poss> ) . . . . . . `ELMS_LIST' operation
 */
-static Obj FuncELMS_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 poss )
+static Obj FuncELMS_LIST(Obj self, Obj list, Obj poss)
 {
     return ElmsListCheck( list, poss );
 }
@@ -752,10 +716,7 @@ Obj ElmsListDefault (
 **
 *F  FuncELMS_LIST_DEFAULT( <self>, <list>, <poss> ) . . . . `ElmsListDefault'
 */
-static Obj FuncELMS_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 poss )
+static Obj FuncELMS_LIST_DEFAULT(Obj self, Obj list, Obj poss)
 {
     return ElmsListDefault( list, poss );
 }
@@ -805,10 +766,7 @@ void             (*UnbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 static Obj             UnbListOper;
 
-static Obj             FuncUNB_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 pos )
+static Obj FuncUNB_LIST(Obj self, Obj list, Obj pos)
 {
     if (IS_POS_INTOBJ(pos))
         UNB_LIST( list, INT_INTOBJ(pos) );
@@ -817,9 +775,7 @@ static Obj             FuncUNB_LIST (
     return 0;
 }
 
-static void            UnbListError (
-    Obj                 list,
-    Int                 pos )
+static void UnbListError(Obj list, Int pos)
 {
     RequireArgument("Unbind", list, "must be a list");
 }
@@ -832,9 +788,7 @@ void            UnbListDefault (
     UNB_LIST( list, pos );
 }
 
-static void            UnbListObject (
-    Obj                 list,
-    Int                 pos )
+static void UnbListObject(Obj list, Int pos)
 {
     DoOperation2Args( UnbListOper, list, INTOBJ_INT(pos) );
 }
@@ -876,18 +830,12 @@ static Obj FuncASS_LIST(Obj self, Obj list, Obj pos, Obj obj)
     return 0;
 }
 
-static void            AssListError (
-    Obj                 list,
-    Int                 pos,
-    Obj                 obj )
+static void AssListError(Obj list, Int pos, Obj obj)
 {
     RequireArgument("List Assignment", list, "must be a list");
 }
 
-static void            AssListDefault (
-    Obj                 list,
-    Int                 pos,
-    Obj                 obj )
+static void AssListDefault(Obj list, Int pos, Obj obj)
 {
     PLAIN_LIST( list );
     ASS_LIST( list, pos, obj );
@@ -952,20 +900,13 @@ void            (*AsssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj poss, Obj obj
 
 static Obj             AsssListOper;
 
-static Obj             FuncASSS_LIST (
-    Obj                 self,
-    Obj                 list,
-    Obj                 poss,
-    Obj                 objs )
+static Obj FuncASSS_LIST(Obj self, Obj list, Obj poss, Obj objs)
 {
     AsssListCheck( list, poss, objs );
     return 0;
 }
 
-static void            AsssListError (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 objs )
+static void AsssListError(Obj list, Obj poss, Obj objs)
 {
     RequireArgument("List Assignments", list, "must be a list");
 }
@@ -1035,19 +976,12 @@ void            AsssListDefault (
 
 }
 
-static void            AsssListObject (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 objs )
+static void AsssListObject(Obj list, Obj poss, Obj objs)
 {
     DoOperation3Args( AsssListOper, list, poss, objs );
 }
 
-static Obj FuncASSS_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 poss,
-    Obj                 objs )
+static Obj FuncASSS_LIST_DEFAULT(Obj self, Obj list, Obj poss, Obj objs)
 {
     AsssListDefault( list, poss, objs );
     return 0;
@@ -1066,11 +1000,9 @@ static Obj FuncASSS_LIST_DEFAULT (
 */
 Int             (*IsDenseListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static Obj             IsDenseListFilt;
+static Obj IsDenseListFilt;
 
-static Obj             FuncIS_DENSE_LIST (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_DENSE_LIST(Obj self, Obj obj)
 {
     return (IS_DENSE_LIST( obj ) ? True : False);
 }
@@ -1100,8 +1032,7 @@ Int             IsDenseListDefault (
     return 1L;
 }
 
-static Int             IsDenseListObject (
-    Obj                 obj )
+static Int IsDenseListObject(Obj obj)
 {
     return (DoFilter( IsDenseListFilt, obj ) == True);
 }
@@ -1120,11 +1051,9 @@ static Int             IsDenseListObject (
 */
 Int             (*IsHomogListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static Obj             IsHomogListFilt;
+static Obj IsHomogListFilt;
 
-static Obj             FuncIS_HOMOG_LIST (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_HOMOG_LIST(Obj self, Obj obj)
 {
     return (IS_HOMOG_LIST( obj ) ? True : False);
 }
@@ -1164,8 +1093,7 @@ Int             IsHomogListDefault (
     return 1L;
 }
 
-static Int             IsHomogListObject (
-    Obj                 obj )
+static Int IsHomogListObject(Obj obj)
 {
     return (DoFilter( IsHomogListFilt, obj ) == True);
 }
@@ -1183,11 +1111,9 @@ static Int             IsHomogListObject (
 */
 Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static Obj             IsTableListFilt;
+static Obj IsTableListFilt;
 
-static Obj             FuncIS_TABLE_LIST (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_TABLE_LIST(Obj self, Obj obj)
 {
     return (IS_TABLE_LIST( obj ) ? True : False);
 }
@@ -1235,8 +1161,7 @@ Int             IsTableListDefault (
     return 1L;
 }
 
-static Int             IsTableListObject (
-    Obj                 obj )
+static Int IsTableListObject(Obj obj)
 {
     return (DoFilter( IsTableListFilt, obj ) == True);
 }
@@ -1257,9 +1182,7 @@ Int (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
 static Obj IsSSortListProp;
 
-static Obj FuncIS_SSORT_LIST (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_SSORT_LIST(Obj self, Obj obj)
 {
     return (IS_SSORT_LIST( obj ) ? True : False);
 }
@@ -1303,15 +1226,12 @@ Int IsSSortListDefault (
     return 2L;
 }
 
-static Int             IsSSortListObject (
-    Obj                 obj )
+static Int IsSSortListObject(Obj obj)
 {
     return (DoProperty( IsSSortListProp, obj ) == True);
 }
 
-static Obj FuncIS_SSORT_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_SSORT_LIST_DEFAULT(Obj self, Obj obj)
 {
     return (IsSSortListDefault( obj ) ? True : False);
 }
@@ -1329,11 +1249,9 @@ static Obj FuncIS_SSORT_LIST_DEFAULT (
 */
 Int             (*IsPossListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static Obj             IsPossListProp;
+static Obj IsPossListProp;
 
-static Obj             FuncIS_POSS_LIST (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_POSS_LIST(Obj self, Obj obj)
 {
     return (IS_POSS_LIST(obj) ? True : False);
 }
@@ -1372,15 +1290,12 @@ Int             IsPossListDefault (
     return 1L;
 }
 
-static Int             IsPossListObject (
-    Obj                 obj )
+static Int IsPossListObject(Obj obj)
 {
     return (DoProperty( IsPossListProp, obj ) == True);
 }
 
-static Obj FuncIS_POSS_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_POSS_LIST_DEFAULT(Obj self, Obj obj)
 {
     return (IsPossListDefault( obj ) ? True : False);
 }
@@ -1401,19 +1316,12 @@ Obj             (*PosListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj obj, Obj start
 
 static Obj             PosListOper;
 
-static Obj             PosListHandler2 (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj )
+static Obj PosListHandler2(Obj self, Obj list, Obj obj)
 {
     return POS_LIST( list, obj, INTOBJ_INT(0) );
 }
 
-static Obj             PosListHandler3 (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj,
-    Obj                 start )
+static Obj PosListHandler3(Obj self, Obj list, Obj obj, Obj start)
 {
     if (TNUM_OBJ(start) != T_INTPOS && !IS_NONNEG_INTOBJ(start)) {
         RequireArgument("Position", start, "must be a non-negative integer");
@@ -1421,10 +1329,7 @@ static Obj             PosListHandler3 (
     return POS_LIST( list, obj, start );
 }
 
-static Obj             PosListError (
-    Obj                 list,
-    Obj                 obj,
-    Obj                 start )
+static Obj PosListError(Obj list, Obj obj, Obj start)
 {
     RequireArgument("Position", list, "must be a list");
 }
@@ -1463,19 +1368,12 @@ Obj             PosListDefault (
     }
 }
 
-static Obj             PosListObject (
-    Obj                 list,
-    Obj                 obj,
-    Obj                 start )
+static Obj PosListObject(Obj list, Obj obj, Obj start)
 {
     return DoOperation3Args( PosListOper, list, obj, start );
 }
 
-static Obj FuncPOS_LIST_DEFAULT (
-    Obj                 self,
-    Obj                 list,
-    Obj                 obj,
-    Obj                 start )
+static Obj FuncPOS_LIST_DEFAULT(Obj self, Obj list, Obj obj, Obj start)
 {
     return PosListDefault( list, obj, start ) ;
 }
@@ -1808,8 +1706,7 @@ void            AsssListLevel (
 */
 void            (*PlainListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-static void            PlainListError (
-    Obj                 list )
+static void PlainListError(Obj list)
 {
     ErrorQuit(
         "Panic: cannot convert <list> (is a %s) to a plain list",
@@ -1821,7 +1718,7 @@ static void            PlainListError (
 **
 *F  TYPES_LIST_FAM(<fam>) . . . . . . .  list of types of lists over a family
 */
-static UInt            TYPES_LIST_FAM_RNam;
+static UInt TYPES_LIST_FAM_RNam;
 
 Obj             TYPES_LIST_FAM (
     Obj                 fam )
@@ -1850,8 +1747,7 @@ Obj             TYPES_LIST_FAM (
 **
 **  'PrintList' simply prints the list.
 */
-static void            PrintListDefault (
-    Obj                 list )
+static void PrintListDefault(Obj list)
 {
     Obj                 elm;
 
@@ -1877,9 +1773,7 @@ static void            PrintListDefault (
     Pr(" %4<]",0L,0L);
 }
 
-static void            PrintPathList (
-    Obj                 list,
-    Int                 indx )
+static void PrintPathList(Obj list, Int indx)
 {
     Pr( "[%d]", indx, 0L );
 }

--- a/src/lists.c
+++ b/src/lists.c
@@ -53,16 +53,16 @@
 */
 Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj             IsListFilt;
+static Obj             IsListFilt;
 
-Obj             FuncIS_LIST (
+static Obj             FuncIS_LIST (
     Obj                 self,
     Obj                 obj )
 {
     return (IS_LIST( obj ) ? True : False);
 }
 
-Int             IsListObject (
+static Int             IsListObject (
     Obj                 obj )
 {
     return (DoFilter( IsListFilt, obj ) == True);
@@ -82,12 +82,12 @@ Int             IsListObject (
 */
 Int             (*IsSmallListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj             IsSmallListFilt;
-Obj             HasIsSmallListFilt;
-Obj             LengthAttr;
-Obj             SetIsSmallList;
+static Obj             IsSmallListFilt;
+static Obj             HasIsSmallListFilt;
+static Obj             LengthAttr;
+static Obj             SetIsSmallList;
 
-Int             IsSmallListObject (
+static Int             IsSmallListObject (
     Obj                 obj )
 {
   Obj len;
@@ -145,7 +145,7 @@ Int             IsSmallListObject (
 **    internal types (NOT YET IMPLEMENTED)
 */
 
-Obj FuncLENGTH (
+static Obj FuncLENGTH (
     Obj             self,
     Obj             list )
 {
@@ -187,7 +187,7 @@ Obj FuncLENGTH (
 */
 Int (*LenListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj FuncLEN_LIST (
+static Obj FuncLEN_LIST (
     Obj                 self,
     Obj                 list )
 {
@@ -203,14 +203,14 @@ Obj FuncLEN_LIST (
 }
 
 
-Int LenListError (
+static Int LenListError (
     Obj                 list )
 {
     RequireArgument("Length", list, "must be a list");
 }
 
 
-Int LenListObject (
+static Int LenListObject (
     Obj                 obj )
 {
     Obj                 len;
@@ -237,20 +237,20 @@ Int LenListObject (
 
 Obj             (*LengthFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj LengthError (
+static Obj LengthError (
     Obj                 list )
 {
     RequireArgument("Length", list, "must be a list");
 }
 
 
-Obj LengthObject (
+static Obj LengthObject (
     Obj                 obj )
 {
     return FuncLENGTH( LengthAttr, obj );
 }
 
-Obj LengthInternal (
+static Obj LengthInternal (
     Obj                 obj )
 {
     return INTOBJ_INT(LEN_LIST(obj));
@@ -273,7 +273,7 @@ Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 static Obj             IsbListOper;
 
-Obj             FuncISB_LIST (
+static Obj             FuncISB_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos )
@@ -284,14 +284,14 @@ Obj             FuncISB_LIST (
         return ISBB_LIST( list, pos ) ? True : False;
 }
 
-Int             IsbListError (
+static Int             IsbListError (
     Obj                 list,
     Int                 pos )
 {
     RequireArgument("IsBound", list, "must be a list");
 }
 
-Int             IsbListObject (
+static Int             IsbListObject (
     Obj                 list,
     Int                 pos )
 {
@@ -340,7 +340,7 @@ Obj (*Elm0ListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 Obj (*ElmDefListFuncs[LAST_REAL_TNUM + 1])(Obj list, Int pos, Obj def);
 
 // Default implementation of ELM_DEFAULT_LIST
-Obj ElmDefListDefault(Obj list, Int pos, Obj def)
+static Obj ElmDefListDefault(Obj list, Int pos, Obj def)
 {
     Obj val = ELM0_LIST(list, pos);
     if (val) {
@@ -360,12 +360,12 @@ Obj ElmDefListDefault(Obj list, Int pos, Obj def)
 */
 static Obj ElmDefListOper;
 
-Obj ElmDefListObject(Obj list, Int pos, Obj def)
+static Obj ElmDefListObject(Obj list, Int pos, Obj def)
 {
     return DoOperation3Args(ElmDefListOper, list, INTOBJ_INT(pos), def);
 }
 
-Obj FuncELM_DEFAULT_LIST(Obj self, Obj list, Obj pos, Obj def)
+static Obj FuncELM_DEFAULT_LIST(Obj self, Obj list, Obj pos, Obj def)
 {
     Int ipos = GetPositiveSmallInt("GetWithDefault", pos);
     return ELM_DEFAULT_LIST(list, ipos, def);
@@ -386,7 +386,7 @@ Obj (*Elm0vListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **
 *F  Elm0ListError( <list>, <pos> )  . . . . . . . . . . . . . . error message
 */
-Obj Elm0ListError (
+static Obj Elm0ListError (
     Obj                 list,
     Int                 pos )
 {
@@ -411,7 +411,7 @@ Obj Elm0ListError (
 */
 static Obj Elm0ListOper;
 
-Obj Elm0ListObject (
+static Obj Elm0ListObject (
     Obj                 list,
     Int                 pos )
 {
@@ -434,7 +434,7 @@ Obj Elm0ListObject (
 **
 *F  FuncELM0_LIST( <self>, <list>, <pos> )  . . . . . . operation `ELM0_LIST'
 */
-Obj FuncELM0_LIST (
+static Obj FuncELM0_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos )
@@ -492,7 +492,7 @@ Obj (*ElmwListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 **
 *F  ElmListError( <list>, <pos> ) . . . . . . . . . . . . . . . error message
 */
-Obj ElmListError (
+static Obj ElmListError (
     Obj                 list,
     Int                 pos )
 {
@@ -512,7 +512,7 @@ Obj ElmListError (
 */
 static Obj ElmListOper;
 
-Obj ElmListObject( Obj list, Int pos)
+static Obj ElmListObject( Obj list, Int pos)
 {
     return ELMB_LIST( list, INTOBJ_INT(pos) );
 }
@@ -559,7 +559,7 @@ Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2)
 **
 *F  FuncELM_LIST( <self>, <list>, <pos> ) . . . . . . .  operation `ELM_LIST'
 */
-Obj FuncELM_LIST(Obj self, Obj list, Obj pos)
+static Obj FuncELM_LIST(Obj self, Obj list, Obj pos)
 {
     if (IS_POS_INTOBJ(pos))
         return ELM_LIST(list, INT_INTOBJ(pos));
@@ -590,7 +590,7 @@ Obj (*ElmsListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj poss );
 **
 *F  ElmsListError(<list>,<poss>)  . . . . . . . . .  error selection function
 */
-Obj ElmsListError (
+static Obj ElmsListError (
     Obj                 list,
     Obj                 poss )
 {
@@ -606,7 +606,7 @@ Obj ElmsListError (
 */
 static Obj ElmsListOper;
 
-Obj ElmsListObject (
+static Obj ElmsListObject (
     Obj                 list,
     Obj                 poss )
 {
@@ -624,7 +624,7 @@ Obj ElmsListObject (
 **
 *F  FuncELMS_LIST( <self>, <list>, <poss> ) . . . . . . `ELMS_LIST' operation
 */
-Obj FuncELMS_LIST (
+static Obj FuncELMS_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 poss )
@@ -752,7 +752,7 @@ Obj ElmsListDefault (
 **
 *F  FuncELMS_LIST_DEFAULT( <self>, <list>, <poss> ) . . . . `ElmsListDefault'
 */
-Obj FuncELMS_LIST_DEFAULT (
+static Obj FuncELMS_LIST_DEFAULT (
     Obj                 self,
     Obj                 list,
     Obj                 poss )
@@ -805,7 +805,7 @@ void             (*UnbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
 
 static Obj             UnbListOper;
 
-Obj             FuncUNB_LIST (
+static Obj             FuncUNB_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 pos )
@@ -817,7 +817,7 @@ Obj             FuncUNB_LIST (
     return 0;
 }
 
-void            UnbListError (
+static void            UnbListError (
     Obj                 list,
     Int                 pos )
 {
@@ -832,7 +832,7 @@ void            UnbListDefault (
     UNB_LIST( list, pos );
 }
 
-void            UnbListObject (
+static void            UnbListObject (
     Obj                 list,
     Int                 pos )
 {
@@ -867,7 +867,7 @@ void            (*AssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos, Obj obj )
 
 static Obj AssListOper;
 
-Obj FuncASS_LIST(Obj self, Obj list, Obj pos, Obj obj)
+static Obj FuncASS_LIST(Obj self, Obj list, Obj pos, Obj obj)
 {
     if (IS_POS_INTOBJ(pos))
         ASS_LIST(list, INT_INTOBJ(pos), obj);
@@ -876,7 +876,7 @@ Obj FuncASS_LIST(Obj self, Obj list, Obj pos, Obj obj)
     return 0;
 }
 
-void            AssListError (
+static void            AssListError (
     Obj                 list,
     Int                 pos,
     Obj                 obj )
@@ -884,7 +884,7 @@ void            AssListError (
     RequireArgument("List Assignment", list, "must be a list");
 }
 
-void            AssListDefault (
+static void            AssListDefault (
     Obj                 list,
     Int                 pos,
     Obj                 obj )
@@ -952,7 +952,7 @@ void            (*AsssListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj poss, Obj obj
 
 static Obj             AsssListOper;
 
-Obj             FuncASSS_LIST (
+static Obj             FuncASSS_LIST (
     Obj                 self,
     Obj                 list,
     Obj                 poss,
@@ -962,7 +962,7 @@ Obj             FuncASSS_LIST (
     return 0;
 }
 
-void            AsssListError (
+static void            AsssListError (
     Obj                 list,
     Obj                 poss,
     Obj                 objs )
@@ -1035,7 +1035,7 @@ void            AsssListDefault (
 
 }
 
-void            AsssListObject (
+static void            AsssListObject (
     Obj                 list,
     Obj                 poss,
     Obj                 objs )
@@ -1043,7 +1043,7 @@ void            AsssListObject (
     DoOperation3Args( AsssListOper, list, poss, objs );
 }
 
-Obj FuncASSS_LIST_DEFAULT (
+static Obj FuncASSS_LIST_DEFAULT (
     Obj                 self,
     Obj                 list,
     Obj                 poss,
@@ -1066,9 +1066,9 @@ Obj FuncASSS_LIST_DEFAULT (
 */
 Int             (*IsDenseListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj             IsDenseListFilt;
+static Obj             IsDenseListFilt;
 
-Obj             FuncIS_DENSE_LIST (
+static Obj             FuncIS_DENSE_LIST (
     Obj                 self,
     Obj                 obj )
 {
@@ -1100,7 +1100,7 @@ Int             IsDenseListDefault (
     return 1L;
 }
 
-Int             IsDenseListObject (
+static Int             IsDenseListObject (
     Obj                 obj )
 {
     return (DoFilter( IsDenseListFilt, obj ) == True);
@@ -1120,9 +1120,9 @@ Int             IsDenseListObject (
 */
 Int             (*IsHomogListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj             IsHomogListFilt;
+static Obj             IsHomogListFilt;
 
-Obj             FuncIS_HOMOG_LIST (
+static Obj             FuncIS_HOMOG_LIST (
     Obj                 self,
     Obj                 obj )
 {
@@ -1164,7 +1164,7 @@ Int             IsHomogListDefault (
     return 1L;
 }
 
-Int             IsHomogListObject (
+static Int             IsHomogListObject (
     Obj                 obj )
 {
     return (DoFilter( IsHomogListFilt, obj ) == True);
@@ -1183,9 +1183,9 @@ Int             IsHomogListObject (
 */
 Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj             IsTableListFilt;
+static Obj             IsTableListFilt;
 
-Obj             FuncIS_TABLE_LIST (
+static Obj             FuncIS_TABLE_LIST (
     Obj                 self,
     Obj                 obj )
 {
@@ -1235,7 +1235,7 @@ Int             IsTableListDefault (
     return 1L;
 }
 
-Int             IsTableListObject (
+static Int             IsTableListObject (
     Obj                 obj )
 {
     return (DoFilter( IsTableListFilt, obj ) == True);
@@ -1255,9 +1255,9 @@ Int             IsTableListObject (
 */
 Int (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj IsSSortListProp;
+static Obj IsSSortListProp;
 
-Obj FuncIS_SSORT_LIST (
+static Obj FuncIS_SSORT_LIST (
     Obj                 self,
     Obj                 obj )
 {
@@ -1303,13 +1303,13 @@ Int IsSSortListDefault (
     return 2L;
 }
 
-Int             IsSSortListObject (
+static Int             IsSSortListObject (
     Obj                 obj )
 {
     return (DoProperty( IsSSortListProp, obj ) == True);
 }
 
-Obj FuncIS_SSORT_LIST_DEFAULT (
+static Obj FuncIS_SSORT_LIST_DEFAULT (
     Obj                 self,
     Obj                 obj )
 {
@@ -1329,9 +1329,9 @@ Obj FuncIS_SSORT_LIST_DEFAULT (
 */
 Int             (*IsPossListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-Obj             IsPossListProp;
+static Obj             IsPossListProp;
 
-Obj             FuncIS_POSS_LIST (
+static Obj             FuncIS_POSS_LIST (
     Obj                 self,
     Obj                 obj )
 {
@@ -1372,13 +1372,13 @@ Int             IsPossListDefault (
     return 1L;
 }
 
-Int             IsPossListObject (
+static Int             IsPossListObject (
     Obj                 obj )
 {
     return (DoProperty( IsPossListProp, obj ) == True);
 }
 
-Obj FuncIS_POSS_LIST_DEFAULT (
+static Obj FuncIS_POSS_LIST_DEFAULT (
     Obj                 self,
     Obj                 obj )
 {
@@ -1401,7 +1401,7 @@ Obj             (*PosListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Obj obj, Obj start
 
 static Obj             PosListOper;
 
-Obj             PosListHandler2 (
+static Obj             PosListHandler2 (
     Obj                 self,
     Obj                 list,
     Obj                 obj )
@@ -1409,7 +1409,7 @@ Obj             PosListHandler2 (
     return POS_LIST( list, obj, INTOBJ_INT(0) );
 }
 
-Obj             PosListHandler3 (
+static Obj             PosListHandler3 (
     Obj                 self,
     Obj                 list,
     Obj                 obj,
@@ -1421,7 +1421,7 @@ Obj             PosListHandler3 (
     return POS_LIST( list, obj, start );
 }
 
-Obj             PosListError (
+static Obj             PosListError (
     Obj                 list,
     Obj                 obj,
     Obj                 start )
@@ -1463,7 +1463,7 @@ Obj             PosListDefault (
     }
 }
 
-Obj             PosListObject (
+static Obj             PosListObject (
     Obj                 list,
     Obj                 obj,
     Obj                 start )
@@ -1471,7 +1471,7 @@ Obj             PosListObject (
     return DoOperation3Args( PosListOper, list, obj, start );
 }
 
-Obj FuncPOS_LIST_DEFAULT (
+static Obj FuncPOS_LIST_DEFAULT (
     Obj                 self,
     Obj                 list,
     Obj                 obj,
@@ -1808,7 +1808,7 @@ void            AsssListLevel (
 */
 void            (*PlainListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
 
-void            PlainListError (
+static void            PlainListError (
     Obj                 list )
 {
     ErrorQuit(
@@ -1821,7 +1821,7 @@ void            PlainListError (
 **
 *F  TYPES_LIST_FAM(<fam>) . . . . . . .  list of types of lists over a family
 */
-UInt            TYPES_LIST_FAM_RNam;
+static UInt            TYPES_LIST_FAM_RNam;
 
 Obj             TYPES_LIST_FAM (
     Obj                 fam )
@@ -1850,7 +1850,7 @@ Obj             TYPES_LIST_FAM (
 **
 **  'PrintList' simply prints the list.
 */
-void            PrintListDefault (
+static void            PrintListDefault (
     Obj                 list )
 {
     Obj                 elm;
@@ -1877,7 +1877,7 @@ void            PrintListDefault (
     Pr(" %4<]",0L,0L);
 }
 
-void            PrintPathList (
+static void            PrintPathList (
     Obj                 list,
     Int                 indx )
 {

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -45,9 +45,9 @@
 **
 **  'TypeMacfloat' is the function in 'TypeObjFuncs' for macfloatean values.
 */
-Obj TYPE_MACFLOAT;
+static Obj TYPE_MACFLOAT;
 
-Obj TypeMacfloat (
+static Obj TypeMacfloat (
     Obj                 val )
 {  
     return TYPE_MACFLOAT;
@@ -81,7 +81,7 @@ static void PrintMacfloatToBuf(char *buf, size_t bufsize, Double val, int precis
 **
 **  'PrintMacfloat' prints the macfloating value <macfloat>.
 */
-void PrintMacfloat(Obj x)
+static void PrintMacfloat(Obj x)
 {
     Char buf[1024];
     // TODO: should we use PRINTFDIGITS instead of 16?
@@ -97,14 +97,14 @@ void PrintMacfloat(Obj x)
 **  'EqMacfloat' returns 'True' if the two macfloatean values <macfloatL> and <macfloatR> are
 **  equal, and 'False' otherwise.
 */
-Int EqMacfloat (
+static Int EqMacfloat (
     Obj                 macfloatL,
     Obj                 macfloatR )
 {
   return VAL_MACFLOAT(macfloatL) == VAL_MACFLOAT(macfloatR);
 }
 
-Obj FuncEQ_MACFLOAT (
+static Obj FuncEQ_MACFLOAT (
     Obj                 self,
     Obj                 macfloatL,
     Obj                 macfloatR )
@@ -118,7 +118,7 @@ Obj FuncEQ_MACFLOAT (
 *F  LtMacfloat( <macfloatL>, <macfloatR> )  . . . . . . . . .  test if <macfloatL> <  <macfloatR>
 **
 */
-Int LtMacfloat (
+static Int LtMacfloat (
     Obj                 macfloatL,
     Obj                 macfloatR )
 {
@@ -131,7 +131,7 @@ Int LtMacfloat (
 *F  SaveMacfloat( <macfloat> ) . . . . . . . . . . . . . . . . . . . . save a Macfloatean 
 **
 */
-void SaveMacfloat( Obj obj )
+static void SaveMacfloat( Obj obj )
 {
     const UInt1 *data = (const UInt1 *)CONST_ADDR_OBJ(obj);
     for (UInt i = 0; i < sizeof(Double); i++)
@@ -143,7 +143,7 @@ void SaveMacfloat( Obj obj )
 *F  LoadMacfloat( <macfloat> ) . . . . . . . . . . . . . . . . . . . . save a Macfloatean 
 **
 */
-void LoadMacfloat( Obj obj )
+static void LoadMacfloat( Obj obj )
 {
     UInt1 *data = (UInt1 *)ADDR_OBJ(obj);
     for (UInt i = 0; i < sizeof(Double); i++)
@@ -165,7 +165,7 @@ Obj NEW_MACFLOAT( Double val )
 */
 
 
-Obj ZeroMacfloat( Obj f )
+static Obj ZeroMacfloat( Obj f )
 {
   return NEW_MACFLOAT((Double)0.0);
 }
@@ -177,7 +177,7 @@ Obj ZeroMacfloat( Obj f )
 */
 
 
-Obj AInvMacfloat( Obj f )
+static Obj AInvMacfloat( Obj f )
 {
   return NEW_MACFLOAT(-VAL_MACFLOAT(f));
 }
@@ -189,7 +189,7 @@ Obj AInvMacfloat( Obj f )
 */
 
 
-Obj OneMacfloat( Obj f )
+static Obj OneMacfloat( Obj f )
 {
   return NEW_MACFLOAT((Double)1.0);
 }
@@ -201,7 +201,7 @@ Obj OneMacfloat( Obj f )
 */
 
 
-Obj InvMacfloat( Obj f )
+static Obj InvMacfloat( Obj f )
 {
   return NEW_MACFLOAT((Double)1.0/VAL_MACFLOAT(f));
 }
@@ -213,7 +213,7 @@ Obj InvMacfloat( Obj f )
 */
 
 
-Obj ProdMacfloat( Obj fl, Obj fr )
+static Obj ProdMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)*VAL_MACFLOAT(fr));
 }
@@ -225,7 +225,7 @@ Obj ProdMacfloat( Obj fl, Obj fr )
 */
 
 
-Obj PowMacfloat( Obj fl, Obj fr )
+static Obj PowMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(MATH(pow)(VAL_MACFLOAT(fl),VAL_MACFLOAT(fr)));
 }
@@ -237,7 +237,7 @@ Obj PowMacfloat( Obj fl, Obj fr )
 */
 
 
-Obj SumMacfloat( Obj fl, Obj fr )
+static Obj SumMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)+VAL_MACFLOAT(fr));
 }
@@ -249,7 +249,7 @@ Obj SumMacfloat( Obj fl, Obj fr )
 */
 
 
-Obj DiffMacfloat( Obj fl, Obj fr )
+static Obj DiffMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)-VAL_MACFLOAT(fr));
 }
@@ -261,7 +261,7 @@ Obj DiffMacfloat( Obj fl, Obj fr )
 */
 
 
-Obj QuoMacfloat( Obj fl, Obj fr )
+static Obj QuoMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)/VAL_MACFLOAT(fr));
 }
@@ -273,7 +273,7 @@ Obj QuoMacfloat( Obj fl, Obj fr )
 */
 
 
-Obj LQuoMacfloat( Obj fl, Obj fr )
+static Obj LQuoMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fr)/VAL_MACFLOAT(fl));
 }
@@ -285,7 +285,7 @@ Obj LQuoMacfloat( Obj fl, Obj fr )
 */
 
 
-Obj ModMacfloat( Obj fl, Obj fr )
+static Obj ModMacfloat( Obj fl, Obj fr )
 {
   return NEW_MACFLOAT(MATH(fmod)(VAL_MACFLOAT(fl),VAL_MACFLOAT(fr)));
 }
@@ -297,7 +297,7 @@ Obj ModMacfloat( Obj fl, Obj fr )
 **
 */
 
-Obj FuncMACFLOAT_INT( Obj self, Obj i )
+static Obj FuncMACFLOAT_INT( Obj self, Obj i )
 {
   if (!IS_INTOBJ(i))
     return Fail;
@@ -311,7 +311,7 @@ Obj FuncMACFLOAT_INT( Obj self, Obj i )
 **
 */
 
-Obj FuncMACFLOAT_STRING( Obj self, Obj s )
+static Obj FuncMACFLOAT_STRING( Obj self, Obj s )
 {
     RequireStringRep("MACFLOAT_STRING", s);
 
@@ -329,7 +329,7 @@ Obj FuncMACFLOAT_STRING( Obj self, Obj s )
 **
 */
 
-Obj SumIntMacfloat( Obj i, Obj f )
+static Obj SumIntMacfloat( Obj i, Obj f )
 {
   return NEW_MACFLOAT( (Double)(INT_INTOBJ(i)) + VAL_MACFLOAT(f));
 }
@@ -342,13 +342,13 @@ Obj SumIntMacfloat( Obj i, Obj f )
 */
 
 #define MAKEMATHPRIMITIVE(NAME,name)                    \
-  Obj Func##NAME##_MACFLOAT( Obj self, Obj f )          \
+  static Obj Func##NAME##_MACFLOAT( Obj self, Obj f )          \
   {                                                     \
     return NEW_MACFLOAT(MATH(name)(VAL_MACFLOAT(f)));   \
   }
 
 #define MAKEMATHPRIMITIVE2(NAME,name)                                   \
-  Obj Func##NAME##_MACFLOAT( Obj self, Obj f, Obj g)                    \
+  static Obj Func##NAME##_MACFLOAT( Obj self, Obj f, Obj g)                    \
   {                                                                     \
     return NEW_MACFLOAT(MATH(name)(VAL_MACFLOAT(f),VAL_MACFLOAT(g)));   \
   }
@@ -387,20 +387,20 @@ MAKEMATHPRIMITIVE(ABS,fabs)
 MAKEMATHPRIMITIVE2(ATAN2,atan2)
 MAKEMATHPRIMITIVE2(HYPOT,hypot)
 
-Obj FuncSIGN_MACFLOAT( Obj self, Obj f )
+static Obj FuncSIGN_MACFLOAT( Obj self, Obj f )
 {
   Double vf = VAL_MACFLOAT(f);
   
   return vf == 0. ? INTOBJ_INT(0) : signbit(vf) ? INTOBJ_INT(-1) : INTOBJ_INT(1);
 }
 
-Obj FuncSIGNBIT_MACFLOAT( Obj self, Obj f )
+static Obj FuncSIGNBIT_MACFLOAT( Obj self, Obj f )
 {
   return signbit(VAL_MACFLOAT(f)) ? True : False;
 }
 
 
-Obj FuncINTFLOOR_MACFLOAT(Obj self, Obj macfloat)
+static Obj FuncINTFLOOR_MACFLOAT(Obj self, Obj macfloat)
 {
     RequireMacFloat("INTFLOOR_MACFLOAT", macfloat);
 
@@ -437,7 +437,7 @@ Obj FuncINTFLOOR_MACFLOAT(Obj self, Obj macfloat)
   return IntHexString(str);
 }
 
-Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
+static Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
 {
   Char buf[1024];
   Obj str;
@@ -449,12 +449,12 @@ Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
   return str;
 }
 
-Obj FuncLDEXP_MACFLOAT( Obj self, Obj f, Obj i)
+static Obj FuncLDEXP_MACFLOAT( Obj self, Obj f, Obj i)
 {
   return NEW_MACFLOAT(ldexp(VAL_MACFLOAT(f),INT_INTOBJ(i)));
 }
 
-Obj FuncFREXP_MACFLOAT( Obj self, Obj f)
+static Obj FuncFREXP_MACFLOAT( Obj self, Obj f)
 {
   int i;
   Obj d = NEW_MACFLOAT(frexp (VAL_MACFLOAT(f), &i));

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -47,8 +47,7 @@
 */
 static Obj TYPE_MACFLOAT;
 
-static Obj TypeMacfloat (
-    Obj                 val )
+static Obj TypeMacfloat(Obj val)
 {  
     return TYPE_MACFLOAT;
 }
@@ -97,17 +96,12 @@ static void PrintMacfloat(Obj x)
 **  'EqMacfloat' returns 'True' if the two macfloatean values <macfloatL> and <macfloatR> are
 **  equal, and 'False' otherwise.
 */
-static Int EqMacfloat (
-    Obj                 macfloatL,
-    Obj                 macfloatR )
+static Int EqMacfloat(Obj macfloatL, Obj macfloatR)
 {
   return VAL_MACFLOAT(macfloatL) == VAL_MACFLOAT(macfloatR);
 }
 
-static Obj FuncEQ_MACFLOAT (
-    Obj                 self,
-    Obj                 macfloatL,
-    Obj                 macfloatR )
+static Obj FuncEQ_MACFLOAT(Obj self, Obj macfloatL, Obj macfloatR)
 {
   return EqMacfloat(macfloatL,macfloatR) ? True : False;
 }
@@ -118,9 +112,7 @@ static Obj FuncEQ_MACFLOAT (
 *F  LtMacfloat( <macfloatL>, <macfloatR> )  . . . . . . . . .  test if <macfloatL> <  <macfloatR>
 **
 */
-static Int LtMacfloat (
-    Obj                 macfloatL,
-    Obj                 macfloatR )
+static Int LtMacfloat(Obj macfloatL, Obj macfloatR)
 {
   return VAL_MACFLOAT(macfloatL) < VAL_MACFLOAT(macfloatR);
 }
@@ -131,7 +123,7 @@ static Int LtMacfloat (
 *F  SaveMacfloat( <macfloat> ) . . . . . . . . . . . . . . . . . . . . save a Macfloatean 
 **
 */
-static void SaveMacfloat( Obj obj )
+static void SaveMacfloat(Obj obj)
 {
     const UInt1 *data = (const UInt1 *)CONST_ADDR_OBJ(obj);
     for (UInt i = 0; i < sizeof(Double); i++)
@@ -143,7 +135,7 @@ static void SaveMacfloat( Obj obj )
 *F  LoadMacfloat( <macfloat> ) . . . . . . . . . . . . . . . . . . . . save a Macfloatean 
 **
 */
-static void LoadMacfloat( Obj obj )
+static void LoadMacfloat(Obj obj)
 {
     UInt1 *data = (UInt1 *)ADDR_OBJ(obj);
     for (UInt i = 0; i < sizeof(Double); i++)
@@ -165,7 +157,7 @@ Obj NEW_MACFLOAT( Double val )
 */
 
 
-static Obj ZeroMacfloat( Obj f )
+static Obj ZeroMacfloat(Obj f)
 {
   return NEW_MACFLOAT((Double)0.0);
 }
@@ -177,7 +169,7 @@ static Obj ZeroMacfloat( Obj f )
 */
 
 
-static Obj AInvMacfloat( Obj f )
+static Obj AInvMacfloat(Obj f)
 {
   return NEW_MACFLOAT(-VAL_MACFLOAT(f));
 }
@@ -189,7 +181,7 @@ static Obj AInvMacfloat( Obj f )
 */
 
 
-static Obj OneMacfloat( Obj f )
+static Obj OneMacfloat(Obj f)
 {
   return NEW_MACFLOAT((Double)1.0);
 }
@@ -201,7 +193,7 @@ static Obj OneMacfloat( Obj f )
 */
 
 
-static Obj InvMacfloat( Obj f )
+static Obj InvMacfloat(Obj f)
 {
   return NEW_MACFLOAT((Double)1.0/VAL_MACFLOAT(f));
 }
@@ -213,7 +205,7 @@ static Obj InvMacfloat( Obj f )
 */
 
 
-static Obj ProdMacfloat( Obj fl, Obj fr )
+static Obj ProdMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)*VAL_MACFLOAT(fr));
 }
@@ -225,7 +217,7 @@ static Obj ProdMacfloat( Obj fl, Obj fr )
 */
 
 
-static Obj PowMacfloat( Obj fl, Obj fr )
+static Obj PowMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(MATH(pow)(VAL_MACFLOAT(fl),VAL_MACFLOAT(fr)));
 }
@@ -237,7 +229,7 @@ static Obj PowMacfloat( Obj fl, Obj fr )
 */
 
 
-static Obj SumMacfloat( Obj fl, Obj fr )
+static Obj SumMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)+VAL_MACFLOAT(fr));
 }
@@ -249,7 +241,7 @@ static Obj SumMacfloat( Obj fl, Obj fr )
 */
 
 
-static Obj DiffMacfloat( Obj fl, Obj fr )
+static Obj DiffMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)-VAL_MACFLOAT(fr));
 }
@@ -261,7 +253,7 @@ static Obj DiffMacfloat( Obj fl, Obj fr )
 */
 
 
-static Obj QuoMacfloat( Obj fl, Obj fr )
+static Obj QuoMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fl)/VAL_MACFLOAT(fr));
 }
@@ -273,7 +265,7 @@ static Obj QuoMacfloat( Obj fl, Obj fr )
 */
 
 
-static Obj LQuoMacfloat( Obj fl, Obj fr )
+static Obj LQuoMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(VAL_MACFLOAT(fr)/VAL_MACFLOAT(fl));
 }
@@ -285,7 +277,7 @@ static Obj LQuoMacfloat( Obj fl, Obj fr )
 */
 
 
-static Obj ModMacfloat( Obj fl, Obj fr )
+static Obj ModMacfloat(Obj fl, Obj fr)
 {
   return NEW_MACFLOAT(MATH(fmod)(VAL_MACFLOAT(fl),VAL_MACFLOAT(fr)));
 }
@@ -297,7 +289,7 @@ static Obj ModMacfloat( Obj fl, Obj fr )
 **
 */
 
-static Obj FuncMACFLOAT_INT( Obj self, Obj i )
+static Obj FuncMACFLOAT_INT(Obj self, Obj i)
 {
   if (!IS_INTOBJ(i))
     return Fail;
@@ -311,7 +303,7 @@ static Obj FuncMACFLOAT_INT( Obj self, Obj i )
 **
 */
 
-static Obj FuncMACFLOAT_STRING( Obj self, Obj s )
+static Obj FuncMACFLOAT_STRING(Obj self, Obj s)
 {
     RequireStringRep("MACFLOAT_STRING", s);
 
@@ -329,7 +321,7 @@ static Obj FuncMACFLOAT_STRING( Obj self, Obj s )
 **
 */
 
-static Obj SumIntMacfloat( Obj i, Obj f )
+static Obj SumIntMacfloat(Obj i, Obj f)
 {
   return NEW_MACFLOAT( (Double)(INT_INTOBJ(i)) + VAL_MACFLOAT(f));
 }
@@ -341,17 +333,17 @@ static Obj SumIntMacfloat( Obj i, Obj f )
 **
 */
 
-#define MAKEMATHPRIMITIVE(NAME,name)                    \
-  static Obj Func##NAME##_MACFLOAT( Obj self, Obj f )          \
-  {                                                     \
-    return NEW_MACFLOAT(MATH(name)(VAL_MACFLOAT(f)));   \
-  }
+#define MAKEMATHPRIMITIVE(NAME, name)                                        \
+    static Obj Func##NAME##_MACFLOAT(Obj self, Obj f)                        \
+    {                                                                        \
+        return NEW_MACFLOAT(MATH(name)(VAL_MACFLOAT(f)));                    \
+    }
 
-#define MAKEMATHPRIMITIVE2(NAME,name)                                   \
-  static Obj Func##NAME##_MACFLOAT( Obj self, Obj f, Obj g)                    \
-  {                                                                     \
-    return NEW_MACFLOAT(MATH(name)(VAL_MACFLOAT(f),VAL_MACFLOAT(g)));   \
-  }
+#define MAKEMATHPRIMITIVE2(NAME, name)                                       \
+    static Obj Func##NAME##_MACFLOAT(Obj self, Obj f, Obj g)                 \
+    {                                                                        \
+        return NEW_MACFLOAT(MATH(name)(VAL_MACFLOAT(f), VAL_MACFLOAT(g)));   \
+    }
 
 MAKEMATHPRIMITIVE(COS,cos)
 MAKEMATHPRIMITIVE(SIN,sin)
@@ -387,14 +379,14 @@ MAKEMATHPRIMITIVE(ABS,fabs)
 MAKEMATHPRIMITIVE2(ATAN2,atan2)
 MAKEMATHPRIMITIVE2(HYPOT,hypot)
 
-static Obj FuncSIGN_MACFLOAT( Obj self, Obj f )
+static Obj FuncSIGN_MACFLOAT(Obj self, Obj f)
 {
   Double vf = VAL_MACFLOAT(f);
   
   return vf == 0. ? INTOBJ_INT(0) : signbit(vf) ? INTOBJ_INT(-1) : INTOBJ_INT(1);
 }
 
-static Obj FuncSIGNBIT_MACFLOAT( Obj self, Obj f )
+static Obj FuncSIGNBIT_MACFLOAT(Obj self, Obj f)
 {
   return signbit(VAL_MACFLOAT(f)) ? True : False;
 }
@@ -437,7 +429,7 @@ static Obj FuncINTFLOOR_MACFLOAT(Obj self, Obj macfloat)
   return IntHexString(str);
 }
 
-static Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
+static Obj FuncSTRING_DIGITS_MACFLOAT(Obj self, Obj gapprec, Obj f)
 {
   Char buf[1024];
   Obj str;
@@ -449,12 +441,12 @@ static Obj FuncSTRING_DIGITS_MACFLOAT( Obj self, Obj gapprec, Obj f)
   return str;
 }
 
-static Obj FuncLDEXP_MACFLOAT( Obj self, Obj f, Obj i)
+static Obj FuncLDEXP_MACFLOAT(Obj self, Obj f, Obj i)
 {
   return NEW_MACFLOAT(ldexp(VAL_MACFLOAT(f),INT_INTOBJ(i)));
 }
 
-static Obj FuncFREXP_MACFLOAT( Obj self, Obj f)
+static Obj FuncFREXP_MACFLOAT(Obj self, Obj f)
 {
   int i;
   Obj d = NEW_MACFLOAT(frexp (VAL_MACFLOAT(f), &i));

--- a/src/modules.c
+++ b/src/modules.c
@@ -73,8 +73,8 @@ typedef struct {
 
 
 StructInitInfoExt Modules[MAX_MODULES];
-static UInt              NrModules;
-static UInt              NrBuiltinModules;
+static UInt       NrModules;
+static UInt       NrBuiltinModules;
 
 
 typedef struct {
@@ -180,7 +180,7 @@ void ActivateModule(StructInitInfo * info)
 **  return value indicates which error occurred.
 */
 #ifdef HAVE_DLOPEN
-static Int SyLoadModule( const Char * name, InitInfoFunc * func )
+static Int SyLoadModule(const Char * name, InitInfoFunc * func)
 {
     void *          init;
     void *          handle;

--- a/src/modules.c
+++ b/src/modules.c
@@ -53,8 +53,8 @@
 #define MAX_MODULE_FILENAMES (MAX_MODULES * 50)
 #endif
 
-Char   LoadedModuleFilenames[MAX_MODULE_FILENAMES];
-Char * NextLoadedModuleFilename = LoadedModuleFilenames;
+static Char   LoadedModuleFilenames[MAX_MODULE_FILENAMES];
+static Char * NextLoadedModuleFilename = LoadedModuleFilenames;
 
 extern const InitInfoFunc InitFuncsBuiltinModules[];
 
@@ -73,8 +73,8 @@ typedef struct {
 
 
 StructInitInfoExt Modules[MAX_MODULES];
-UInt              NrModules;
-UInt              NrBuiltinModules;
+static UInt              NrModules;
+static UInt              NrBuiltinModules;
 
 
 typedef struct {
@@ -125,7 +125,7 @@ static void RegisterModuleState(StructInitInfo * info)
 **
 *F  FuncGAP_CRC( <self>, <name> ) . . . . . . . create a crc value for a file
 */
-Obj FuncGAP_CRC(Obj self, Obj filename)
+static Obj FuncGAP_CRC(Obj self, Obj filename)
 {
     /* check the argument                                                  */
     RequireStringRep("GAP_CRC", filename);
@@ -180,7 +180,7 @@ void ActivateModule(StructInitInfo * info)
 **  return value indicates which error occurred.
 */
 #ifdef HAVE_DLOPEN
-Int SyLoadModule( const Char * name, InitInfoFunc * func )
+static Int SyLoadModule( const Char * name, InitInfoFunc * func )
 {
     void *          init;
     void *          handle;
@@ -208,7 +208,7 @@ Int SyLoadModule( const Char * name, InitInfoFunc * func )
 **
 *F  FuncLOAD_DYN( <self>, <name>, <crc> ) . . .  try to load a dynamic module
 */
-Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
+static Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
 {
     StructInitInfo * info;
     Obj              crc1;
@@ -285,7 +285,7 @@ Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
 **
 *F  FuncLOAD_STAT( <self>, <name>, <crc> )  . . . . try to load static module
 */
-Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
+static Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
 {
     StructInitInfo * info = 0;
     Obj              crc1;
@@ -340,7 +340,7 @@ Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
 **
 *F  FuncSHOW_STAT() . . . . . . . . . . . . . . . . . . . show static modules
 */
-Obj FuncSHOW_STAT(Obj self)
+static Obj FuncSHOW_STAT(Obj self)
 {
     Obj              modules;
     Obj              name;
@@ -383,7 +383,7 @@ Obj FuncSHOW_STAT(Obj self)
 **
 *F  FuncLoadedModules( <self> ) . . . . . . . . . . . list all loaded modules
 */
-Obj FuncLoadedModules(Obj self)
+static Obj FuncLoadedModules(Obj self)
 {
     Int              i;
     StructInitInfo * m;
@@ -760,7 +760,7 @@ void ImportFuncFromLibrary(const Char * name, Obj * address)
 **
 *F  FuncExportToKernelFinished( <self> )  . . . . . . . . . . check functions
 */
-Obj FuncExportToKernelFinished(Obj self)
+static Obj FuncExportToKernelFinished(Obj self)
 {
     UInt i;
     Int  errs = 0;

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -79,7 +79,7 @@ extern inline struct CFTLModuleState *CFTLState(void)
   CHANGED_BAG( wst ); CHANGED_BAG( west ); CHANGED_BAG( est ); }
 
                                 
-void AddIn( Obj list, Obj w, Obj e ) {
+static void AddIn( Obj list, Obj w, Obj e ) {
 
   Int    g,  i;
   Obj    r,  s,  t;
@@ -98,7 +98,7 @@ void AddIn( Obj list, Obj w, Obj e ) {
 
 }
 
-Obj CollectPolycyc (
+static Obj CollectPolycyc (
     Obj pcp,
     Obj list,
     Obj word )
@@ -325,7 +325,7 @@ Obj CollectPolycyc (
     return (Obj)0;
 }
 
-Obj FuncCollectPolycyclic (
+static Obj FuncCollectPolycyclic (
     Obj self,
     Obj pcp,
     Obj list,

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -79,7 +79,8 @@ extern inline struct CFTLModuleState *CFTLState(void)
   CHANGED_BAG( wst ); CHANGED_BAG( west ); CHANGED_BAG( est ); }
 
                                 
-static void AddIn( Obj list, Obj w, Obj e ) {
+static void AddIn(Obj list, Obj w, Obj e)
+{
 
   Int    g,  i;
   Obj    r,  s,  t;
@@ -98,10 +99,7 @@ static void AddIn( Obj list, Obj w, Obj e ) {
 
 }
 
-static Obj CollectPolycyc (
-    Obj pcp,
-    Obj list,
-    Obj word )
+static Obj CollectPolycyc(Obj pcp, Obj list, Obj word)
 {
     Int    ngens   = INT_INTOBJ( CONST_ADDR_OBJ(pcp)[ PC_NUMBER_OF_GENERATORS ] );
     Obj    commute = CONST_ADDR_OBJ(pcp)[ PC_COMMUTE ];
@@ -325,11 +323,7 @@ static Obj CollectPolycyc (
     return (Obj)0;
 }
 
-static Obj FuncCollectPolycyclic (
-    Obj self,
-    Obj pcp,
-    Obj list,
-    Obj word )
+static Obj FuncCollectPolycyclic(Obj self, Obj pcp, Obj list, Obj word)
 {
   CollectPolycyc( pcp, list, word );
   return (Obj)0;

--- a/src/objects.c
+++ b/src/objects.c
@@ -118,9 +118,7 @@ void SET_TNAM_TNUM(UInt tnum, const Char *name)
 **
 *F  FuncFAMILY_TYPE( <self>, <type> ) . . . . . . handler for 'FAMILY_TYPE'
 */
-static Obj FuncFAMILY_TYPE (
-    Obj                 self,
-    Obj                 type )
+static Obj FuncFAMILY_TYPE(Obj self, Obj type)
 {
     return FAMILY_TYPE( type );
 }
@@ -130,9 +128,7 @@ static Obj FuncFAMILY_TYPE (
 **
 *F  FuncFAMILY_OBJ( <self>, <obj> ) . . . . . . .  handler for 'FAMILY_OBJ'
 */
-static Obj FuncFAMILY_OBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncFAMILY_OBJ(Obj self, Obj obj)
 {
     return FAMILY_OBJ( obj );
 }
@@ -148,8 +144,7 @@ static Obj FuncFAMILY_OBJ (
 */
 Obj (*TypeObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-static Obj TypeObjError (
-    Obj                 obj )
+static Obj TypeObjError(Obj obj)
 {
     ErrorQuit( "Panic: basic object of type '%s' is unkind",
                (Int)TNAM_OBJ(obj), 0L );
@@ -165,7 +160,7 @@ static Obj TypeObjError (
 
 void (*SetTypeObjFuncs[ LAST_REAL_TNUM+1 ]) ( Obj obj, Obj type );
 
-static void SetTypeObjError ( Obj obj, Obj type )
+static void SetTypeObjError(Obj obj, Obj type)
 {
     ErrorQuit( "Panic: cannot change type of object of type '%s'",
                (Int)TNAM_OBJ(obj), 0L );
@@ -177,9 +172,7 @@ static void SetTypeObjError ( Obj obj, Obj type )
 *F  FuncTYPE_OBJ( <self>, <obj> ) . . . . . . . . .  handler for 'TYPE_OBJ'
 */
 #ifndef WARD_ENABLED
-static Obj FuncTYPE_OBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncTYPE_OBJ(Obj self, Obj obj)
 {
     return TYPE_OBJ( obj );
 }
@@ -189,10 +182,7 @@ static Obj FuncTYPE_OBJ (
 **
 *F  FuncSET_TYPE_OBJ( <self>, <obj>, <type> ) . . handler for 'SET_TYPE_OBJ'
 */
-static Obj FuncSET_TYPE_OBJ (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 type )
+static Obj FuncSET_TYPE_OBJ(Obj self, Obj obj, Obj type)
 {
     SET_TYPE_OBJ( obj, type );
     return (Obj) 0;
@@ -213,8 +203,7 @@ Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
 static Obj IsMutableObjFilt;
 
-static Int IsMutableObjError (
-    Obj                 obj )
+static Int IsMutableObjError(Obj obj)
 {
     ErrorQuit(
         "Panic: tried to test mutability of unsupported type '%s'",
@@ -222,8 +211,7 @@ static Int IsMutableObjError (
     return 0;
 }
 
-static Int IsMutableObjObject (
-    Obj                 obj )
+static Int IsMutableObjObject(Obj obj)
 {
 #ifdef HPCGAP
     if (RegionBag(obj) == ReadOnlyRegion)
@@ -237,9 +225,7 @@ static Int IsMutableObjObject (
 **
 *F  IsMutableObjHandler( <self>, <obj> )  . . .  handler for 'IS_MUTABLE_OBJ'
 */
-static Obj IsMutableObjHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj IsMutableObjHandler(Obj self, Obj obj)
 {
     return (IS_MUTABLE_OBJ( obj ) ? True : False);
 }
@@ -253,9 +239,7 @@ static Obj IsMutableObjHandler (
 
 static Obj IsInternallyMutableObjFilt;
 
-static Obj IsInternallyMutableObjHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj IsInternallyMutableObjHandler(Obj self, Obj obj)
 {
     return (TNUM_OBJ(obj) == T_DATOBJ &&
       RegionBag(obj) != ReadOnlyRegion &&
@@ -284,8 +268,7 @@ Int (*IsCopyableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
 static Obj IsCopyableObjFilt;
 
-static Int IsCopyableObjError (
-    Obj                 obj )
+static Int IsCopyableObjError(Obj obj)
 {
     ErrorQuit(
         "Panic: tried to test copyability of unsupported type '%s'",
@@ -293,8 +276,7 @@ static Int IsCopyableObjError (
     return 0L;
 }
 
-static Int IsCopyableObjObject (
-    Obj                 obj )
+static Int IsCopyableObjObject(Obj obj)
 {
     return (DoFilter( IsCopyableObjFilt, obj ) == True);
 }
@@ -304,9 +286,7 @@ static Int IsCopyableObjObject (
 **
 *F  IsCopyableObjHandler( <self>, <obj> ) . . . handler for 'IS_COPYABLE_OBJ'
 */
-static Obj IsCopyableObjHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj IsCopyableObjHandler(Obj self, Obj obj)
 {
     return (IS_COPYABLE_OBJ( obj ) ? True : False);
 }
@@ -325,8 +305,7 @@ static Obj ShallowCopyObjOper;
 **
 *F  ShallowCopyObjError( <obj> )  . . . . . . . . . . . . . . .  unknown type
 */
-static Obj ShallowCopyObjError (
-    Obj                 obj )
+static Obj ShallowCopyObjError(Obj obj)
 {
     ErrorQuit(
         "Panic: tried to shallow copy object of unsupported type '%s'",
@@ -339,8 +318,7 @@ static Obj ShallowCopyObjError (
 **
 *F  ShallowCopyObjConstant( <obj> ) . . . . . . . . . . . . . . .  do nothing
 */
-static Obj ShallowCopyObjConstant (
-    Obj                 obj )
+static Obj ShallowCopyObjConstant(Obj obj)
 {
     return obj;
 }
@@ -350,8 +328,7 @@ static Obj ShallowCopyObjConstant (
 **
 *F  ShallowCopyObjObject( <obj> ) . . . . . . . . . . . . . . . . call method
 */
-static Obj ShallowCopyObjObject (
-    Obj                 obj )
+static Obj ShallowCopyObjObject(Obj obj)
 {
     return DoOperation1Args( ShallowCopyObjOper, obj );
 }
@@ -361,8 +338,7 @@ static Obj ShallowCopyObjObject (
 **
 *F  ShallowCopyObjDefault( <obj> )  . . . . . . . . . .  default shallow copy
 */
-static Obj ShallowCopyObjDefault (
-    Obj                 obj )
+static Obj ShallowCopyObjDefault(Obj obj)
 {
     Obj                 new;
     const Obj *         o;
@@ -383,9 +359,7 @@ static Obj ShallowCopyObjDefault (
 **
 *F  ShallowCopyObjHandler( <self>, <obj> )  .  handler for 'SHALLOW_COPY_OBJ'
 */
-static Obj ShallowCopyObjHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj ShallowCopyObjHandler(Obj self, Obj obj)
 {
     return SHALLOW_COPY_OBJ( obj );
 }
@@ -548,9 +522,7 @@ static void MarkCopyingSubBags(Obj obj)
 **
 *F  CopyObjError( <obj> ) . . . . . . . . . . . . . . . . . . .  unknown type
 */
-static Obj             CopyObjError (
-    Obj                 obj,
-    Int                 mut )
+static Obj CopyObjError(Obj obj, Int mut)
 {
     ErrorQuit(
         "Panic: tried to copy object of unsupported type '%s'",
@@ -563,8 +535,7 @@ static Obj             CopyObjError (
 **
 *F  CleanObjError( <obj> )  . . . . . . . . . . . . . . . . . .  unknown type
 */
-static void CleanObjError (
-    Obj                 obj )
+static void CleanObjError(Obj obj)
 {
     ErrorQuit(
         "Panic: tried to clean object of unsupported type '%s'",
@@ -576,9 +547,7 @@ static void CleanObjError (
 **
 *F  CopyObjConstant( <obj> )  . . . . . . . . . . . .  copy a constant object
 */
-static Obj CopyObjConstant (
-    Obj                 obj,
-    Int                 mut )
+static Obj CopyObjConstant(Obj obj, Int mut)
 {
     return obj;
 }
@@ -588,9 +557,7 @@ static Obj CopyObjConstant (
 **
 *F  CopyObjPosObj( <obj>, <mut> ) . . . . . . . . .  copy a positional object
 */
-static Obj CopyObjPosObj (
-    Obj                 obj,
-    Int                 mut )
+static Obj CopyObjPosObj(Obj obj, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
@@ -633,8 +600,7 @@ static Obj CopyObjPosObj (
 **
 *F  CleanObjPosObj( <obj> ) . . . . . . . . . . . . . . . . . .  clean posobj
 */
-static void CleanObjPosObj (
-    Obj                 obj )
+static void CleanObjPosObj(Obj obj)
 {
     UInt                i;              /* loop variable                   */
 
@@ -651,9 +617,7 @@ static void CleanObjPosObj (
 **
 *F  CopyObjComObj( <obj>, <mut> ) . . . . . . . . . . . . . . . copy a comobj
 */
-static Obj CopyObjComObj (
-    Obj                 obj,
-    Int                 mut )
+static Obj CopyObjComObj(Obj obj, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
@@ -697,8 +661,7 @@ static Obj CopyObjComObj (
 **
 *F  CleanObjComObj( <obj> ) . . . . . . . . . . . . . . . . .  clean a comobj
 */
-static void CleanObjComObj (
-    Obj                 obj )
+static void CleanObjComObj(Obj obj)
 {
     UInt                i;              /* loop variable                   */
 
@@ -714,9 +677,7 @@ static void CleanObjComObj (
 **
 *F  CopyObjDatObj( <obj>, <mut> ) . . . . . . . . . . . . . . . copy a datobj
 */
-static Obj CopyObjDatObj (
-    Obj                 obj,
-    Int                 mut )
+static Obj CopyObjDatObj(Obj obj, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
 
@@ -748,8 +709,7 @@ static Obj CopyObjDatObj (
 **
 *F  CleanObjDatObj( <obj> ) . . . . . . . . . . . . . . . . .  clean a datobj
 */
-static void CleanObjDatObj (
-    Obj                 obj )
+static void CleanObjDatObj(Obj obj)
 {
 }
 
@@ -759,9 +719,7 @@ static void CleanObjDatObj (
 **
 *F  FuncIMMUTABLE_COPY_OBJ( <self>, <obj> )  . . . . immutable copy of <obj>
 */
-static Obj FuncIMMUTABLE_COPY_OBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIMMUTABLE_COPY_OBJ(Obj self, Obj obj)
 {
     return CopyObj( obj, 0 );
 }
@@ -771,9 +729,7 @@ static Obj FuncIMMUTABLE_COPY_OBJ (
 **
 *F  FuncDEEP_COPY_OBJ( <self>, <obj> )  . . . . . . mutable copy of <obj>
 */
-static Obj FuncDEEP_COPY_OBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncDEEP_COPY_OBJ(Obj self, Obj obj)
 {
     return CopyObj( obj, 1 );
 }
@@ -809,21 +765,20 @@ void CheckedMakeImmutable( Obj obj )
 }
 #endif
 
-static void MakeImmutableError( Obj obj)
+static void MakeImmutableError(Obj obj)
 {
   ErrorQuit("No make immutable function installed for a %s",
             (Int)TNAM_OBJ(obj), 0L);
 }
 
 
-
-static void MakeImmutableComObj( Obj obj)
+static void MakeImmutableComObj(Obj obj)
 {
   CALL_2ARGS( RESET_FILTER_OBJ, obj, IsMutableObjFilt );
   CALL_1ARGS( PostMakeImmutableOp, obj);
 }
 
-static void MakeImmutablePosObj( Obj obj)
+static void MakeImmutablePosObj(Obj obj)
 {
   CALL_2ARGS( RESET_FILTER_OBJ, obj, IsMutableObjFilt );
   CALL_1ARGS( PostMakeImmutableOp, obj);
@@ -845,7 +800,7 @@ static void MakeImmutablePosObj( Obj obj)
 static int ReadOnlyDatObjs = 0;
 #endif
 
-static void MakeImmutableDatObj( Obj obj)
+static void MakeImmutableDatObj(Obj obj)
 {
   CALL_2ARGS( RESET_FILTER_OBJ, obj, IsMutableObjFilt );
 #ifdef HPCGAP
@@ -858,7 +813,7 @@ static void MakeImmutableDatObj( Obj obj)
 #endif
 }
 
-static Obj FuncMakeImmutable( Obj self, Obj obj)
+static Obj FuncMakeImmutable(Obj self, Obj obj)
 {
 #ifdef HPCGAP
   CheckedMakeImmutable(obj);
@@ -1035,8 +990,7 @@ void (* PrintObjFuncs [ LAST_REAL_TNUM  +1 ])( Obj obj );
 */
 Obj PrintObjOper;
 
-static void PrintObjObject (
-    Obj                 obj )
+static void PrintObjObject(Obj obj)
 {
     DoOperation1Args( PrintObjOper, obj );
 }
@@ -1046,16 +1000,14 @@ static void PrintObjObject (
 **
 *F  PrintObjHandler( <self>, <obj> )  . . . . . . . .  handler for 'PrintObj'
 */
-static Obj PrintObjHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj PrintObjHandler(Obj self, Obj obj)
 {
     PrintObj( obj );
     return 0L;
 }
 
 
-static Obj FuncSET_PRINT_OBJ_INDEX (Obj self, Obj ind)
+static Obj FuncSET_PRINT_OBJ_INDEX(Obj self, Obj ind)
 {
   if (IS_INTOBJ(ind))
     STATE(PrintObjIndex) = INT_INTOBJ(ind);
@@ -1149,9 +1101,7 @@ void            ViewObj (
 **
 *F  FuncViewObj( <self>, <obj> )  . . . . . . . .  handler for 'ViewObj'
 */
-static Obj FuncViewObj (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncViewObj(Obj self, Obj obj)
 {
     ViewObj( obj );
     return 0L;
@@ -1170,9 +1120,7 @@ static Obj FuncViewObj (
 */
 void (* PrintPathFuncs [ LAST_REAL_TNUM /* +PRINTING */+1 ])( Obj obj, Int indx );
 
-static void PrintPathError (
-    Obj                 obj,
-    Int                 indx )
+static void PrintPathError(Obj obj, Int indx)
 {
     ErrorQuit(
         "Panic: tried to print a path of unsupported type '%s'",
@@ -1185,8 +1133,7 @@ static void PrintPathError (
 *F  TypeComObj( <obj> ) . . . . . . . . . . function version of 'TYPE_COMOBJ'
 */
 #ifndef WARD_ENABLED
-static Obj             TypeComObj (
-    Obj                 obj )
+static Obj TypeComObj(Obj obj)
 {
     Obj result = TYPE_COMOBJ( obj );
 #ifdef HPCGAP
@@ -1195,7 +1142,7 @@ static Obj             TypeComObj (
     return result;
 }
 
-static void SetTypeComObj( Obj obj, Obj type)
+static void SetTypeComObj(Obj obj, Obj type)
 {
 #ifdef HPCGAP
     ReadGuard(obj);
@@ -1211,9 +1158,7 @@ static void SetTypeComObj( Obj obj, Obj type)
 **
 *F  FuncIS_COMOBJ( <self>, <obj> ) . . . . . . . . handler for 'IS_COMOBJ'
 */
-static Obj FuncIS_COMOBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_COMOBJ(Obj self, Obj obj)
 {
 #ifdef HPCGAP
     switch (TNUM_OBJ(obj)) {
@@ -1233,10 +1178,7 @@ static Obj FuncIS_COMOBJ (
 **
 *F  FuncSET_TYPE_COMOBJ( <self>, <obj>, <type> ) . . .  'SET_TYPE_COMOBJ'
 */
-static Obj FuncSET_TYPE_COMOBJ (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 type )
+static Obj FuncSET_TYPE_COMOBJ(Obj self, Obj obj, Obj type)
 {
 #ifdef HPCGAP
     switch (TNUM_OBJ(obj)) {
@@ -1347,8 +1289,7 @@ Int IsbComObj(Obj obj, UInt rnam)
 *F  TypePosObj( <obj> ) . . . . . . . . . . function version of 'TYPE_POSOBJ'
 */
 #ifndef WARD_ENABLED
-static Obj TypePosObj (
-    Obj                 obj )
+static Obj TypePosObj(Obj obj)
 {
     Obj result = TYPE_POSOBJ( obj );
 #ifdef HPCGAP
@@ -1357,7 +1298,7 @@ static Obj TypePosObj (
     return result;
 }
 
-static void SetTypePosObj( Obj obj, Obj type)
+static void SetTypePosObj(Obj obj, Obj type)
 {
 #ifdef HPCGAP
     ReadGuard(obj);
@@ -1373,9 +1314,7 @@ static void SetTypePosObj( Obj obj, Obj type)
 **
 *F  FuncIS_POSOBJ( <self>, <obj> )  . . . . . . . handler for 'IS_POSOBJ'
 */
-static Obj FuncIS_POSOBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_POSOBJ(Obj self, Obj obj)
 {
    switch (TNUM_OBJ(obj)) {
       case T_POSOBJ:
@@ -1393,10 +1332,7 @@ static Obj FuncIS_POSOBJ (
 **
 *F  FuncSET_TYPE_POSOBJ( <self>, <obj>, <type> )  . . .  'SET_TYPE_POSOB'
 */
-static Obj FuncSET_TYPE_POSOBJ (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 type )
+static Obj FuncSET_TYPE_POSOBJ(Obj self, Obj obj, Obj type)
 {
 #ifdef HPCGAP
     switch (TNUM_OBJ(obj)) {
@@ -1430,9 +1366,7 @@ static Obj FuncSET_TYPE_POSOBJ (
 **
 *F  FuncLEN_POSOBJ( <self>, <obj> ) . . . . . .  handler for 'LEN_POSOBJ'
 */
-static Obj FuncLEN_POSOBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncLEN_POSOBJ(Obj self, Obj obj)
 {
 #ifdef HPCGAP
     switch (TNUM_OBJ(obj)) {
@@ -1576,8 +1510,7 @@ Int IsbPosObj(Obj obj, Int idx)
 **
 *F  TypeDatObj( <obj> ) . . . . . . . . . . function version of 'TYPE_DATOBJ'
 */
-static Obj             TypeDatObj (
-    Obj                 obj )
+static Obj TypeDatObj(Obj obj)
 {
     return TYPE_DATOBJ( obj );
 }
@@ -1602,9 +1535,7 @@ void SetTypeDatObj( Obj obj, Obj type)
 **
 *F  FuncIS_DATOBJ( <self>, <obj> ) . . . . . . . . handler for 'IS_DATOBJ'
 */
-static Obj FuncIS_DATOBJ (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_DATOBJ(Obj self, Obj obj)
 {
     return (TNUM_OBJ(obj) == T_DATOBJ ? True : False);
 }
@@ -1614,10 +1545,7 @@ static Obj FuncIS_DATOBJ (
 **
 *F  FuncSET_TYPE_DATOBJ( <self>, <obj>, <type> ) . . .  'SET_TYPE_DATOBJ'
 */
-static Obj FuncSET_TYPE_DATOBJ (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 type )
+static Obj FuncSET_TYPE_DATOBJ(Obj self, Obj obj, Obj type)
 {
 #ifndef WARD_ENABLED
 #ifdef HPCGAP
@@ -1640,10 +1568,7 @@ static Obj FuncSET_TYPE_DATOBJ (
 **
 **  'FuncIS_IDENTICAL_OBJ' implements 'IsIdentical'
 */
-static Obj FuncIS_IDENTICAL_OBJ (
-    Obj                 self,
-    Obj                 obj1,
-    Obj                 obj2 )
+static Obj FuncIS_IDENTICAL_OBJ(Obj self, Obj obj1, Obj obj2)
 {
     return (obj1 == obj2 ? True : False);
 }
@@ -1703,7 +1628,7 @@ void LoadObjError( Obj obj )
 **
 */
 
-static void SaveComObj( Obj comobj)
+static void SaveComObj(Obj comobj)
 {
   UInt len,i;
   SaveSubObj(TYPE_COMOBJ( comobj ));
@@ -1722,7 +1647,7 @@ static void SaveComObj( Obj comobj)
 **
 */
 
-static void SavePosObj( Obj posobj)
+static void SavePosObj(Obj posobj)
 {
   UInt len,i;
   SaveSubObj(TYPE_POSOBJ( posobj ));
@@ -1741,7 +1666,7 @@ static void SavePosObj( Obj posobj)
 **  UInts, or if it might be smaller data
 */
 
-static void SaveDatObj( Obj datobj)
+static void SaveDatObj(Obj datobj)
 {
   UInt len,i;
   const UInt * ptr;
@@ -1760,7 +1685,7 @@ static void SaveDatObj( Obj datobj)
 **
 */
 
-static void LoadComObj( Obj comobj)
+static void LoadComObj(Obj comobj)
 {
   UInt len,i;
   SET_TYPE_COMOBJ(comobj, LoadSubObj());
@@ -1779,7 +1704,7 @@ static void LoadComObj( Obj comobj)
 **
 */
 
-static void LoadPosObj( Obj posobj)
+static void LoadPosObj(Obj posobj)
 {
   UInt len,i;
   SET_TYPE_POSOBJ(posobj, LoadSubObj());
@@ -1798,7 +1723,7 @@ static void LoadPosObj( Obj posobj)
 **  UInts, or if it might be smaller data
 */
 
-static void LoadDatObj( Obj datobj)
+static void LoadDatObj(Obj datobj)
 {
   UInt len,i;
   UInt *ptr;
@@ -1836,10 +1761,7 @@ static Obj IsToBeDefinedObj;
 
 static Obj REREADING;
 
-static Obj FuncCLONE_OBJ (
-    Obj             self,
-    Obj             dst,
-    Obj             src )
+static Obj FuncCLONE_OBJ(Obj self, Obj dst, Obj src)
 {
     const Obj *     psrc;
     Obj *           pdst;

--- a/src/objects.c
+++ b/src/objects.c
@@ -118,7 +118,7 @@ void SET_TNAM_TNUM(UInt tnum, const Char *name)
 **
 *F  FuncFAMILY_TYPE( <self>, <type> ) . . . . . . handler for 'FAMILY_TYPE'
 */
-Obj FuncFAMILY_TYPE (
+static Obj FuncFAMILY_TYPE (
     Obj                 self,
     Obj                 type )
 {
@@ -130,7 +130,7 @@ Obj FuncFAMILY_TYPE (
 **
 *F  FuncFAMILY_OBJ( <self>, <obj> ) . . . . . . .  handler for 'FAMILY_OBJ'
 */
-Obj FuncFAMILY_OBJ (
+static Obj FuncFAMILY_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -148,7 +148,7 @@ Obj FuncFAMILY_OBJ (
 */
 Obj (*TypeObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj TypeObjError (
+static Obj TypeObjError (
     Obj                 obj )
 {
     ErrorQuit( "Panic: basic object of type '%s' is unkind",
@@ -165,7 +165,7 @@ Obj TypeObjError (
 
 void (*SetTypeObjFuncs[ LAST_REAL_TNUM+1 ]) ( Obj obj, Obj type );
 
-void SetTypeObjError ( Obj obj, Obj type )
+static void SetTypeObjError ( Obj obj, Obj type )
 {
     ErrorQuit( "Panic: cannot change type of object of type '%s'",
                (Int)TNAM_OBJ(obj), 0L );
@@ -177,7 +177,7 @@ void SetTypeObjError ( Obj obj, Obj type )
 *F  FuncTYPE_OBJ( <self>, <obj> ) . . . . . . . . .  handler for 'TYPE_OBJ'
 */
 #ifndef WARD_ENABLED
-Obj FuncTYPE_OBJ (
+static Obj FuncTYPE_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -189,7 +189,7 @@ Obj FuncTYPE_OBJ (
 **
 *F  FuncSET_TYPE_OBJ( <self>, <obj>, <type> ) . . handler for 'SET_TYPE_OBJ'
 */
-Obj FuncSET_TYPE_OBJ (
+static Obj FuncSET_TYPE_OBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -211,9 +211,9 @@ Obj FuncSET_TYPE_OBJ (
 */
 Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj IsMutableObjFilt;
+static Obj IsMutableObjFilt;
 
-Int IsMutableObjError (
+static Int IsMutableObjError (
     Obj                 obj )
 {
     ErrorQuit(
@@ -222,7 +222,7 @@ Int IsMutableObjError (
     return 0;
 }
 
-Int IsMutableObjObject (
+static Int IsMutableObjObject (
     Obj                 obj )
 {
 #ifdef HPCGAP
@@ -237,7 +237,7 @@ Int IsMutableObjObject (
 **
 *F  IsMutableObjHandler( <self>, <obj> )  . . .  handler for 'IS_MUTABLE_OBJ'
 */
-Obj IsMutableObjHandler (
+static Obj IsMutableObjHandler (
     Obj                 self,
     Obj                 obj )
 {
@@ -251,9 +251,9 @@ Obj IsMutableObjHandler (
 
 #ifdef HPCGAP
 
-Obj IsInternallyMutableObjFilt;
+static Obj IsInternallyMutableObjFilt;
 
-Obj IsInternallyMutableObjHandler (
+static Obj IsInternallyMutableObjHandler (
     Obj                 self,
     Obj                 obj )
 {
@@ -282,9 +282,9 @@ Int IsInternallyMutableObj(Obj obj) {
 */
 Int (*IsCopyableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj IsCopyableObjFilt;
+static Obj IsCopyableObjFilt;
 
-Int IsCopyableObjError (
+static Int IsCopyableObjError (
     Obj                 obj )
 {
     ErrorQuit(
@@ -293,7 +293,7 @@ Int IsCopyableObjError (
     return 0L;
 }
 
-Int IsCopyableObjObject (
+static Int IsCopyableObjObject (
     Obj                 obj )
 {
     return (DoFilter( IsCopyableObjFilt, obj ) == True);
@@ -304,7 +304,7 @@ Int IsCopyableObjObject (
 **
 *F  IsCopyableObjHandler( <self>, <obj> ) . . . handler for 'IS_COPYABLE_OBJ'
 */
-Obj IsCopyableObjHandler (
+static Obj IsCopyableObjHandler (
     Obj                 self,
     Obj                 obj )
 {
@@ -318,14 +318,14 @@ Obj IsCopyableObjHandler (
 */
 Obj (*ShallowCopyObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj ShallowCopyObjOper;
+static Obj ShallowCopyObjOper;
 
 
 /****************************************************************************
 **
 *F  ShallowCopyObjError( <obj> )  . . . . . . . . . . . . . . .  unknown type
 */
-Obj ShallowCopyObjError (
+static Obj ShallowCopyObjError (
     Obj                 obj )
 {
     ErrorQuit(
@@ -339,7 +339,7 @@ Obj ShallowCopyObjError (
 **
 *F  ShallowCopyObjConstant( <obj> ) . . . . . . . . . . . . . . .  do nothing
 */
-Obj ShallowCopyObjConstant (
+static Obj ShallowCopyObjConstant (
     Obj                 obj )
 {
     return obj;
@@ -350,7 +350,7 @@ Obj ShallowCopyObjConstant (
 **
 *F  ShallowCopyObjObject( <obj> ) . . . . . . . . . . . . . . . . call method
 */
-Obj ShallowCopyObjObject (
+static Obj ShallowCopyObjObject (
     Obj                 obj )
 {
     return DoOperation1Args( ShallowCopyObjOper, obj );
@@ -361,7 +361,7 @@ Obj ShallowCopyObjObject (
 **
 *F  ShallowCopyObjDefault( <obj> )  . . . . . . . . . .  default shallow copy
 */
-Obj ShallowCopyObjDefault (
+static Obj ShallowCopyObjDefault (
     Obj                 obj )
 {
     Obj                 new;
@@ -383,7 +383,7 @@ Obj ShallowCopyObjDefault (
 **
 *F  ShallowCopyObjHandler( <self>, <obj> )  .  handler for 'SHALLOW_COPY_OBJ'
 */
-Obj ShallowCopyObjHandler (
+static Obj ShallowCopyObjHandler (
     Obj                 self,
     Obj                 obj )
 {
@@ -529,7 +529,7 @@ void CLEAN_OBJ(Obj obj)
 
 extern TNumMarkFuncBags TabMarkFuncBags[NUM_TYPES];
 
-void MarkCopyingSubBags(Obj obj)
+static void MarkCopyingSubBags(Obj obj)
 {
     Obj fpl = CONST_ADDR_OBJ(obj)[0];
 
@@ -548,7 +548,7 @@ void MarkCopyingSubBags(Obj obj)
 **
 *F  CopyObjError( <obj> ) . . . . . . . . . . . . . . . . . . .  unknown type
 */
-Obj             CopyObjError (
+static Obj             CopyObjError (
     Obj                 obj,
     Int                 mut )
 {
@@ -563,7 +563,7 @@ Obj             CopyObjError (
 **
 *F  CleanObjError( <obj> )  . . . . . . . . . . . . . . . . . .  unknown type
 */
-void CleanObjError (
+static void CleanObjError (
     Obj                 obj )
 {
     ErrorQuit(
@@ -576,7 +576,7 @@ void CleanObjError (
 **
 *F  CopyObjConstant( <obj> )  . . . . . . . . . . . .  copy a constant object
 */
-Obj CopyObjConstant (
+static Obj CopyObjConstant (
     Obj                 obj,
     Int                 mut )
 {
@@ -588,7 +588,7 @@ Obj CopyObjConstant (
 **
 *F  CopyObjPosObj( <obj>, <mut> ) . . . . . . . . .  copy a positional object
 */
-Obj CopyObjPosObj (
+static Obj CopyObjPosObj (
     Obj                 obj,
     Int                 mut )
 {
@@ -633,7 +633,7 @@ Obj CopyObjPosObj (
 **
 *F  CleanObjPosObj( <obj> ) . . . . . . . . . . . . . . . . . .  clean posobj
 */
-void CleanObjPosObj (
+static void CleanObjPosObj (
     Obj                 obj )
 {
     UInt                i;              /* loop variable                   */
@@ -651,7 +651,7 @@ void CleanObjPosObj (
 **
 *F  CopyObjComObj( <obj>, <mut> ) . . . . . . . . . . . . . . . copy a comobj
 */
-Obj CopyObjComObj (
+static Obj CopyObjComObj (
     Obj                 obj,
     Int                 mut )
 {
@@ -697,7 +697,7 @@ Obj CopyObjComObj (
 **
 *F  CleanObjComObj( <obj> ) . . . . . . . . . . . . . . . . .  clean a comobj
 */
-void CleanObjComObj (
+static void CleanObjComObj (
     Obj                 obj )
 {
     UInt                i;              /* loop variable                   */
@@ -714,7 +714,7 @@ void CleanObjComObj (
 **
 *F  CopyObjDatObj( <obj>, <mut> ) . . . . . . . . . . . . . . . copy a datobj
 */
-Obj CopyObjDatObj (
+static Obj CopyObjDatObj (
     Obj                 obj,
     Int                 mut )
 {
@@ -748,7 +748,7 @@ Obj CopyObjDatObj (
 **
 *F  CleanObjDatObj( <obj> ) . . . . . . . . . . . . . . . . .  clean a datobj
 */
-void CleanObjDatObj (
+static void CleanObjDatObj (
     Obj                 obj )
 {
 }
@@ -759,7 +759,7 @@ void CleanObjDatObj (
 **
 *F  FuncIMMUTABLE_COPY_OBJ( <self>, <obj> )  . . . . immutable copy of <obj>
 */
-Obj FuncIMMUTABLE_COPY_OBJ (
+static Obj FuncIMMUTABLE_COPY_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -771,7 +771,7 @@ Obj FuncIMMUTABLE_COPY_OBJ (
 **
 *F  FuncDEEP_COPY_OBJ( <self>, <obj> )  . . . . . . mutable copy of <obj>
 */
-Obj FuncDEEP_COPY_OBJ (
+static Obj FuncDEEP_COPY_OBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -787,7 +787,7 @@ Obj FuncDEEP_COPY_OBJ (
 **
 */
 
-Obj PostMakeImmutableOp = 0;
+static Obj PostMakeImmutableOp = 0;
 
 void (*MakeImmutableObjFuncs[LAST_REAL_TNUM+1])( Obj );
 
@@ -809,7 +809,7 @@ void CheckedMakeImmutable( Obj obj )
 }
 #endif
 
-void MakeImmutableError( Obj obj)
+static void MakeImmutableError( Obj obj)
 {
   ErrorQuit("No make immutable function installed for a %s",
             (Int)TNAM_OBJ(obj), 0L);
@@ -817,13 +817,13 @@ void MakeImmutableError( Obj obj)
 
 
 
-void MakeImmutableComObj( Obj obj)
+static void MakeImmutableComObj( Obj obj)
 {
   CALL_2ARGS( RESET_FILTER_OBJ, obj, IsMutableObjFilt );
   CALL_1ARGS( PostMakeImmutableOp, obj);
 }
 
-void MakeImmutablePosObj( Obj obj)
+static void MakeImmutablePosObj( Obj obj)
 {
   CALL_2ARGS( RESET_FILTER_OBJ, obj, IsMutableObjFilt );
   CALL_1ARGS( PostMakeImmutableOp, obj);
@@ -845,7 +845,7 @@ void MakeImmutablePosObj( Obj obj)
 static int ReadOnlyDatObjs = 0;
 #endif
 
-void MakeImmutableDatObj( Obj obj)
+static void MakeImmutableDatObj( Obj obj)
 {
   CALL_2ARGS( RESET_FILTER_OBJ, obj, IsMutableObjFilt );
 #ifdef HPCGAP
@@ -858,7 +858,7 @@ void MakeImmutableDatObj( Obj obj)
 #endif
 }
 
-Obj FuncMakeImmutable( Obj self, Obj obj)
+static Obj FuncMakeImmutable( Obj self, Obj obj)
 {
 #ifdef HPCGAP
   CheckedMakeImmutable(obj);
@@ -920,7 +920,7 @@ static UInt LastPV = 0; /* This variable contains one of the values
 
 #ifdef HPCGAP
 /* On-demand creation of the PrintObj stack */
-void InitPrintObjStack(void)
+static void InitPrintObjStack(void)
 {
   if (!MODULE_STATE(Objects).PrintObjThiss) {
     MODULE_STATE(Objects).PrintObjThissObj = NewBag(T_DATOBJ, MAXPRINTDEPTH*sizeof(Obj)+sizeof(Obj));
@@ -1035,7 +1035,7 @@ void (* PrintObjFuncs [ LAST_REAL_TNUM  +1 ])( Obj obj );
 */
 Obj PrintObjOper;
 
-void PrintObjObject (
+static void PrintObjObject (
     Obj                 obj )
 {
     DoOperation1Args( PrintObjOper, obj );
@@ -1046,7 +1046,7 @@ void PrintObjObject (
 **
 *F  PrintObjHandler( <self>, <obj> )  . . . . . . . .  handler for 'PrintObj'
 */
-Obj PrintObjHandler (
+static Obj PrintObjHandler (
     Obj                 self,
     Obj                 obj )
 {
@@ -1055,7 +1055,7 @@ Obj PrintObjHandler (
 }
 
 
-Obj FuncSET_PRINT_OBJ_INDEX (Obj self, Obj ind)
+static Obj FuncSET_PRINT_OBJ_INDEX (Obj self, Obj ind)
 {
   if (IS_INTOBJ(ind))
     STATE(PrintObjIndex) = INT_INTOBJ(ind);
@@ -1073,7 +1073,7 @@ Obj FuncSET_PRINT_OBJ_INDEX (Obj self, Obj ind)
 **  recursion works nicely.
 */
 
-Obj ViewObjOper;
+static Obj ViewObjOper;
 
 void            ViewObj (
     Obj                 obj )
@@ -1149,7 +1149,7 @@ void            ViewObj (
 **
 *F  FuncViewObj( <self>, <obj> )  . . . . . . . .  handler for 'ViewObj'
 */
-Obj FuncViewObj (
+static Obj FuncViewObj (
     Obj                 self,
     Obj                 obj )
 {
@@ -1170,7 +1170,7 @@ Obj FuncViewObj (
 */
 void (* PrintPathFuncs [ LAST_REAL_TNUM /* +PRINTING */+1 ])( Obj obj, Int indx );
 
-void PrintPathError (
+static void PrintPathError (
     Obj                 obj,
     Int                 indx )
 {
@@ -1185,7 +1185,7 @@ void PrintPathError (
 *F  TypeComObj( <obj> ) . . . . . . . . . . function version of 'TYPE_COMOBJ'
 */
 #ifndef WARD_ENABLED
-Obj             TypeComObj (
+static Obj             TypeComObj (
     Obj                 obj )
 {
     Obj result = TYPE_COMOBJ( obj );
@@ -1195,7 +1195,7 @@ Obj             TypeComObj (
     return result;
 }
 
-void SetTypeComObj( Obj obj, Obj type)
+static void SetTypeComObj( Obj obj, Obj type)
 {
 #ifdef HPCGAP
     ReadGuard(obj);
@@ -1211,7 +1211,7 @@ void SetTypeComObj( Obj obj, Obj type)
 **
 *F  FuncIS_COMOBJ( <self>, <obj> ) . . . . . . . . handler for 'IS_COMOBJ'
 */
-Obj FuncIS_COMOBJ (
+static Obj FuncIS_COMOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1233,7 +1233,7 @@ Obj FuncIS_COMOBJ (
 **
 *F  FuncSET_TYPE_COMOBJ( <self>, <obj>, <type> ) . . .  'SET_TYPE_COMOBJ'
 */
-Obj FuncSET_TYPE_COMOBJ (
+static Obj FuncSET_TYPE_COMOBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -1347,7 +1347,7 @@ Int IsbComObj(Obj obj, UInt rnam)
 *F  TypePosObj( <obj> ) . . . . . . . . . . function version of 'TYPE_POSOBJ'
 */
 #ifndef WARD_ENABLED
-Obj TypePosObj (
+static Obj TypePosObj (
     Obj                 obj )
 {
     Obj result = TYPE_POSOBJ( obj );
@@ -1357,7 +1357,7 @@ Obj TypePosObj (
     return result;
 }
 
-void SetTypePosObj( Obj obj, Obj type)
+static void SetTypePosObj( Obj obj, Obj type)
 {
 #ifdef HPCGAP
     ReadGuard(obj);
@@ -1373,7 +1373,7 @@ void SetTypePosObj( Obj obj, Obj type)
 **
 *F  FuncIS_POSOBJ( <self>, <obj> )  . . . . . . . handler for 'IS_POSOBJ'
 */
-Obj FuncIS_POSOBJ (
+static Obj FuncIS_POSOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1393,7 +1393,7 @@ Obj FuncIS_POSOBJ (
 **
 *F  FuncSET_TYPE_POSOBJ( <self>, <obj>, <type> )  . . .  'SET_TYPE_POSOB'
 */
-Obj FuncSET_TYPE_POSOBJ (
+static Obj FuncSET_TYPE_POSOBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -1430,7 +1430,7 @@ Obj FuncSET_TYPE_POSOBJ (
 **
 *F  FuncLEN_POSOBJ( <self>, <obj> ) . . . . . .  handler for 'LEN_POSOBJ'
 */
-Obj FuncLEN_POSOBJ (
+static Obj FuncLEN_POSOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1576,7 +1576,7 @@ Int IsbPosObj(Obj obj, Int idx)
 **
 *F  TypeDatObj( <obj> ) . . . . . . . . . . function version of 'TYPE_DATOBJ'
 */
-Obj             TypeDatObj (
+static Obj             TypeDatObj (
     Obj                 obj )
 {
     return TYPE_DATOBJ( obj );
@@ -1602,7 +1602,7 @@ void SetTypeDatObj( Obj obj, Obj type)
 **
 *F  FuncIS_DATOBJ( <self>, <obj> ) . . . . . . . . handler for 'IS_DATOBJ'
 */
-Obj FuncIS_DATOBJ (
+static Obj FuncIS_DATOBJ (
     Obj                 self,
     Obj                 obj )
 {
@@ -1614,7 +1614,7 @@ Obj FuncIS_DATOBJ (
 **
 *F  FuncSET_TYPE_DATOBJ( <self>, <obj>, <type> ) . . .  'SET_TYPE_DATOBJ'
 */
-Obj FuncSET_TYPE_DATOBJ (
+static Obj FuncSET_TYPE_DATOBJ (
     Obj                 self,
     Obj                 obj,
     Obj                 type )
@@ -1640,7 +1640,7 @@ Obj FuncSET_TYPE_DATOBJ (
 **
 **  'FuncIS_IDENTICAL_OBJ' implements 'IsIdentical'
 */
-Obj FuncIS_IDENTICAL_OBJ (
+static Obj FuncIS_IDENTICAL_OBJ (
     Obj                 self,
     Obj                 obj1,
     Obj                 obj2 )
@@ -1703,7 +1703,7 @@ void LoadObjError( Obj obj )
 **
 */
 
-void SaveComObj( Obj comobj)
+static void SaveComObj( Obj comobj)
 {
   UInt len,i;
   SaveSubObj(TYPE_COMOBJ( comobj ));
@@ -1722,7 +1722,7 @@ void SaveComObj( Obj comobj)
 **
 */
 
-void SavePosObj( Obj posobj)
+static void SavePosObj( Obj posobj)
 {
   UInt len,i;
   SaveSubObj(TYPE_POSOBJ( posobj ));
@@ -1741,7 +1741,7 @@ void SavePosObj( Obj posobj)
 **  UInts, or if it might be smaller data
 */
 
-void SaveDatObj( Obj datobj)
+static void SaveDatObj( Obj datobj)
 {
   UInt len,i;
   const UInt * ptr;
@@ -1760,7 +1760,7 @@ void SaveDatObj( Obj datobj)
 **
 */
 
-void LoadComObj( Obj comobj)
+static void LoadComObj( Obj comobj)
 {
   UInt len,i;
   SET_TYPE_COMOBJ(comobj, LoadSubObj());
@@ -1779,7 +1779,7 @@ void LoadComObj( Obj comobj)
 **
 */
 
-void LoadPosObj( Obj posobj)
+static void LoadPosObj( Obj posobj)
 {
   UInt len,i;
   SET_TYPE_POSOBJ(posobj, LoadSubObj());
@@ -1798,7 +1798,7 @@ void LoadPosObj( Obj posobj)
 **  UInts, or if it might be smaller data
 */
 
-void LoadDatObj( Obj datobj)
+static void LoadDatObj( Obj datobj)
 {
   UInt len,i;
   UInt *ptr;
@@ -1832,11 +1832,11 @@ void LoadDatObj( Obj datobj)
 **  WARNING: at the moment the functions breaks on cloning `[1,~]'.  This can
 **  be fixed if necessary.
 */
-Obj IsToBeDefinedObj;
+static Obj IsToBeDefinedObj;
 
 static Obj REREADING;
 
-Obj FuncCLONE_OBJ (
+static Obj FuncCLONE_OBJ (
     Obj             self,
     Obj             dst,
     Obj             src )
@@ -1916,7 +1916,7 @@ Obj FuncCLONE_OBJ (
 **   This is inspired by the Smalltalk 'become:' operation.
 */
 
-Obj FuncSWITCH_OBJ(Obj self, Obj obj1, Obj obj2)
+static Obj FuncSWITCH_OBJ(Obj self, Obj obj1, Obj obj2)
 {
     if ( IS_INTOBJ(obj1) || IS_INTOBJ(obj2) ) {
         ErrorMayQuit("small integer objects cannot be switched", 0, 0);
@@ -1951,7 +1951,7 @@ Obj FuncSWITCH_OBJ(Obj self, Obj obj1, Obj obj2)
 **  it allows public objects to be exchanged.
 */
 
-Obj FuncFORCE_SWITCH_OBJ(Obj self, Obj obj1, Obj obj2)
+static Obj FuncFORCE_SWITCH_OBJ(Obj self, Obj obj1, Obj obj2)
 {
     if ( IS_INTOBJ(obj1) || IS_INTOBJ(obj2) ) {
         ErrorMayQuit("small integer objects cannot be switched", 0, 0);
@@ -1997,7 +1997,7 @@ Obj FuncFORCE_SWITCH_OBJ(Obj self, Obj obj1, Obj obj2)
         Pr("%s" #name "\n", (Int)indentStr, 0);                              \
     }
 
-Obj FuncDEBUG_TNUM_NAMES(Obj self)
+static Obj FuncDEBUG_TNUM_NAMES(Obj self)
 {
     UInt indentLvl = 0;
     Char indentStr[20] = "";

--- a/src/objfgelm.cc
+++ b/src/objfgelm.cc
@@ -1127,9 +1127,7 @@ static Obj FuncNBits_LengthWord(Obj self, Obj w)
 **
 *F  FuncNBits_NumberSyllables( <self>, <w> )
 */
-static Obj FuncNBits_NumberSyllables (
-    Obj         self,
-    Obj         w )
+static Obj FuncNBits_NumberSyllables(Obj self, Obj w)
 {
     /* return the number of syllables                                      */
     return INTOBJ_INT( NPAIRS_WORD(w) );
@@ -1140,10 +1138,7 @@ static Obj FuncNBits_NumberSyllables (
 * letter rep arithmetic */
 /**************************************************************************
 *F  FuncMULT_WOR_LETTREP( <self>, <a>,<b> ) */
-static Obj FuncMULT_WOR_LETTREP (
-    Obj         self,
-    Obj         a,
-    Obj         b)
+static Obj FuncMULT_WOR_LETTREP(Obj self, Obj a, Obj b)
 {
   UInt l,m,i,j,newlen,as,bs,ae,be;
   Obj n;
@@ -1252,10 +1247,7 @@ static Obj FuncMULT_WOR_LETTREP (
 }
 
 /*F  FuncMULT_BYT_LETTREP( <self>, <a>,<b> ) */
-static Obj FuncMULT_BYT_LETTREP (
-    Obj         self,
-    Obj         a,
-    Obj         b)
+static Obj FuncMULT_BYT_LETTREP(Obj self, Obj a, Obj b)
 {
   UInt l,m,i,j,newlen,as,bs,ae,be;
   Obj n;

--- a/src/objfgelm.cc
+++ b/src/objfgelm.cc
@@ -134,7 +134,7 @@ extern Obj NewWord(Obj type, UInt npairs)
 #define Func16Bits_Equal FuncNBits_Equal<UInt2>
 #define Func32Bits_Equal FuncNBits_Equal<UInt4>
 template <typename UIntN>
-Obj FuncNBits_Equal(Obj self, Obj l, Obj r)
+static Obj FuncNBits_Equal(Obj self, Obj l, Obj r)
 {
     Int         nl;             /* number of pairs to consider in <l>      */
     Int         nr;             /* number of pairs in <r>                  */
@@ -168,7 +168,7 @@ Obj FuncNBits_Equal(Obj self, Obj l, Obj r)
 #define Func16Bits_ExponentSums3 FuncNBits_ExponentSums3<UInt2>
 #define Func32Bits_ExponentSums3 FuncNBits_ExponentSums3<UInt4>
 template <typename UIntN>
-Obj FuncNBits_ExponentSums3(Obj self, Obj obj, Obj vstart, Obj vend)
+static Obj FuncNBits_ExponentSums3(Obj self, Obj obj, Obj vstart, Obj vend)
 {
     Int         start;          /* the lowest generator number             */
     Int         end;            /* the highest generator number            */
@@ -252,7 +252,7 @@ Obj FuncNBits_ExponentSums3(Obj self, Obj obj, Obj vstart, Obj vend)
 #define Func16Bits_ExponentSums1 FuncNBits_ExponentSums1<UInt2>
 #define Func32Bits_ExponentSums1 FuncNBits_ExponentSums1<UInt4>
 template <typename UIntN>
-Obj FuncNBits_ExponentSums1(Obj self, Obj obj)
+static Obj FuncNBits_ExponentSums1(Obj self, Obj obj)
 {
     return FuncNBits_ExponentSums3<UIntN>( self, obj,
         INTOBJ_INT(1), INTOBJ_INT(RANK_WORD(obj)) );
@@ -267,7 +267,7 @@ Obj FuncNBits_ExponentSums1(Obj self, Obj obj)
 #define Func16Bits_ExponentSyllable FuncNBits_ExponentSyllable<UInt2>
 #define Func32Bits_ExponentSyllable FuncNBits_ExponentSyllable<UInt4>
 template <typename UIntN>
-Obj FuncNBits_ExponentSyllable(Obj self, Obj w, Obj vi)
+static Obj FuncNBits_ExponentSyllable(Obj self, Obj w, Obj vi)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -307,7 +307,7 @@ Obj FuncNBits_ExponentSyllable(Obj self, Obj w, Obj vi)
 #define Func16Bits_ExtRepOfObj FuncNBits_ExtRepOfObj<UInt2>
 #define Func32Bits_ExtRepOfObj FuncNBits_ExtRepOfObj<UInt4>
 template <typename UIntN>
-Obj FuncNBits_ExtRepOfObj(Obj self, Obj obj)
+static Obj FuncNBits_ExtRepOfObj(Obj self, Obj obj)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -362,7 +362,7 @@ Obj FuncNBits_ExtRepOfObj(Obj self, Obj obj)
 #define Func16Bits_GeneratorSyllable FuncNBits_GeneratorSyllable<UInt2>
 #define Func32Bits_GeneratorSyllable FuncNBits_GeneratorSyllable<UInt4>
 template <typename UIntN>
-Obj FuncNBits_GeneratorSyllable(Obj self, Obj w, Obj vi)
+static Obj FuncNBits_GeneratorSyllable(Obj self, Obj w, Obj vi)
 {
     Int         ebits;          /* number of bits in the exponent          */
     Int         num;            /* number of gen/exp pairs in <data>       */
@@ -393,7 +393,7 @@ Obj FuncNBits_GeneratorSyllable(Obj self, Obj w, Obj vi)
 #define Func16Bits_HeadByNumber FuncNBits_HeadByNumber<UInt2>
 #define Func32Bits_HeadByNumber FuncNBits_HeadByNumber<UInt4>
 template <typename UIntN>
-Obj FuncNBits_HeadByNumber(Obj self, Obj l, Obj r)
+static Obj FuncNBits_HeadByNumber(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        genm;           /* generator mask                          */
@@ -471,7 +471,7 @@ Obj FuncNBits_HeadByNumber(Obj self, Obj l, Obj r)
 #define Func16Bits_Less FuncNBits_Less<UInt2>
 #define Func32Bits_Less FuncNBits_Less<UInt4>
 template <typename UIntN>
-Obj FuncNBits_Less(Obj self, Obj l, Obj r)
+static Obj FuncNBits_Less(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -571,7 +571,7 @@ Obj FuncNBits_Less(Obj self, Obj l, Obj r)
 #define Func16Bits_AssocWord FuncNBits_AssocWord<UInt2>
 #define Func32Bits_AssocWord FuncNBits_AssocWord<UInt4>
 template <typename UIntN>
-Obj FuncNBits_AssocWord(Obj self, Obj type, Obj data)
+static Obj FuncNBits_AssocWord(Obj self, Obj type, Obj data)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -624,7 +624,7 @@ Obj FuncNBits_AssocWord(Obj self, Obj type, Obj data)
 #define Func16Bits_ObjByVector FuncNBits_ObjByVector<UInt2>
 #define Func32Bits_ObjByVector FuncNBits_ObjByVector<UInt4>
 template <typename UIntN>
-Obj FuncNBits_ObjByVector(Obj self, Obj type, Obj data)
+static Obj FuncNBits_ObjByVector(Obj self, Obj type, Obj data)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* unsigned exponent mask                  */
@@ -685,7 +685,7 @@ Obj FuncNBits_ObjByVector(Obj self, Obj type, Obj data)
 #define Func16Bits_Power FuncNBits_Power<UInt2>
 #define Func32Bits_Power FuncNBits_Power<UInt4>
 template <typename UIntN>
-Obj FuncNBits_Power(Obj self, Obj l, Obj r)
+static Obj FuncNBits_Power(Obj self, Obj l, Obj r)
 {
     typedef typename OverflowType<UIntN>::type OInt;
 
@@ -918,7 +918,7 @@ Obj FuncNBits_Power(Obj self, Obj l, Obj r)
 #define Func16Bits_Product FuncNBits_Product<UInt2>
 #define Func32Bits_Product FuncNBits_Product<UInt4>
 template <typename UIntN>
-Obj FuncNBits_Product(Obj self, Obj l, Obj r)
+static Obj FuncNBits_Product(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -1003,7 +1003,7 @@ Obj FuncNBits_Product(Obj self, Obj l, Obj r)
 #define Func16Bits_Quotient FuncNBits_Quotient<UInt2>
 #define Func32Bits_Quotient FuncNBits_Quotient<UInt4>
 template <typename UIntN>
-Obj FuncNBits_Quotient(Obj self, Obj l, Obj r)
+static Obj FuncNBits_Quotient(Obj self, Obj l, Obj r)
 {
     Int         ebits;          /* number of bits in the exponent          */
     UInt        expm;           /* signed exponent mask                    */
@@ -1089,7 +1089,7 @@ Obj FuncNBits_Quotient(Obj self, Obj l, Obj r)
 #define Func16Bits_LengthWord FuncNBits_LengthWord<UInt2>
 #define Func32Bits_LengthWord FuncNBits_LengthWord<UInt4>
 template <typename UIntN>
-Obj FuncNBits_LengthWord(Obj self, Obj w)
+static Obj FuncNBits_LengthWord(Obj self, Obj w)
 {
   UInt npairs,i,ebits,exps,expm;
   Obj len, uexp;
@@ -1127,7 +1127,7 @@ Obj FuncNBits_LengthWord(Obj self, Obj w)
 **
 *F  FuncNBits_NumberSyllables( <self>, <w> )
 */
-Obj FuncNBits_NumberSyllables (
+static Obj FuncNBits_NumberSyllables (
     Obj         self,
     Obj         w )
 {
@@ -1140,7 +1140,7 @@ Obj FuncNBits_NumberSyllables (
 * letter rep arithmetic */
 /**************************************************************************
 *F  FuncMULT_WOR_LETTREP( <self>, <a>,<b> ) */
-Obj FuncMULT_WOR_LETTREP (
+static Obj FuncMULT_WOR_LETTREP (
     Obj         self,
     Obj         a,
     Obj         b)
@@ -1252,7 +1252,7 @@ Obj FuncMULT_WOR_LETTREP (
 }
 
 /*F  FuncMULT_BYT_LETTREP( <self>, <a>,<b> ) */
-Obj FuncMULT_BYT_LETTREP (
+static Obj FuncMULT_BYT_LETTREP (
     Obj         self,
     Obj         a,
     Obj         b)

--- a/src/objpcgel.cc
+++ b/src/objpcgel.cc
@@ -31,7 +31,7 @@ extern "C" {
 **
 *F  FuncNBitsPcWord_Comm( <self>, <left>, <right> )
 */
-static Obj FuncNBitsPcWord_Comm ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Comm(Obj self, Obj left, Obj right)
 {
     return FuncFinPowConjCol_ReducedComm(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -42,7 +42,7 @@ static Obj FuncNBitsPcWord_Comm ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_Conjugate( <self>, <left>, <right> )
 */
-static Obj FuncNBitsPcWord_Conjugate ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Conjugate(Obj self, Obj left, Obj right)
 {
     left = FuncFinPowConjCol_ReducedProduct(
                 self, COLLECTOR_PCWORD(left), left, right );
@@ -55,7 +55,7 @@ static Obj FuncNBitsPcWord_Conjugate ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_LeftQuotient( <self>, <left>, <right> )
 */
-static Obj FuncNBitsPcWord_LeftQuotient ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_LeftQuotient(Obj self, Obj left, Obj right)
 {
     return FuncFinPowConjCol_ReducedLeftQuotient(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -66,7 +66,7 @@ static Obj FuncNBitsPcWord_LeftQuotient ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_PowerSmallInt( <self>, <left>, <right> )
 */
-static Obj FuncNBitsPcWord_PowerSmallInt ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_PowerSmallInt(Obj self, Obj left, Obj right)
 {
     return FuncFinPowConjCol_ReducedPowerSmallInt(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -77,7 +77,7 @@ static Obj FuncNBitsPcWord_PowerSmallInt ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_Product( <self>, <left>, <right> )
 */
-static Obj FuncNBitsPcWord_Product ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Product(Obj self, Obj left, Obj right)
 {
     return FuncFinPowConjCol_ReducedProduct(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -88,7 +88,7 @@ static Obj FuncNBitsPcWord_Product ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_Quotient( <self>, <left>, <right> )
 */
-static Obj FuncNBitsPcWord_Quotient ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Quotient(Obj self, Obj left, Obj right)
 {
     return FuncFinPowConjCol_ReducedQuotient(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -260,7 +260,7 @@ static Obj ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 **
 *F  Func8Bits_DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func8Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func8Bits_DepthOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return DepthOfPcElement<UInt1>(self, pcgs, w);
 }
@@ -270,7 +270,7 @@ static Obj Func8Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func8Bits_ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-static Obj Func8Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+static Obj Func8Bits_ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
 {
     return ExponentOfPcElement<UInt1>(self, pcgs, w, pos);
 }
@@ -280,7 +280,7 @@ static Obj Func8Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  Func8Bits_LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func8Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func8Bits_LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return LeadingExponentOfPcElement<UInt1>(self, pcgs, w);
 }
@@ -289,7 +289,7 @@ static Obj Func8Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func8Bits_ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func8Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+static Obj Func8Bits_ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return ExponentsOfPcElement<UInt1>(self, pcgs, w);
 }
@@ -299,7 +299,7 @@ static Obj Func8Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 **
 *F  Func16Bits_DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func16Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func16Bits_DepthOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return DepthOfPcElement<UInt2>(self, pcgs, w);
 }
@@ -309,7 +309,7 @@ static Obj Func16Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func16Bits_ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-static Obj Func16Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+static Obj Func16Bits_ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
 {
     return ExponentOfPcElement<UInt2>(self, pcgs, w, pos);
 }
@@ -319,7 +319,7 @@ static Obj Func16Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  Func16Bits_LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func16Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func16Bits_LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return LeadingExponentOfPcElement<UInt2>(self, pcgs, w);
 }
@@ -328,7 +328,7 @@ static Obj Func16Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func16Bits_ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func16Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+static Obj Func16Bits_ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return ExponentsOfPcElement<UInt2>(self, pcgs, w);
 }
@@ -338,7 +338,7 @@ static Obj Func16Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 **
 *F  Func32Bits_DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func32Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func32Bits_DepthOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return DepthOfPcElement<UInt4>(self, pcgs, w);
 }
@@ -348,7 +348,7 @@ static Obj Func32Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func32Bits_ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-static Obj Func32Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+static Obj Func32Bits_ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
 {
     return ExponentOfPcElement<UInt4>(self, pcgs, w, pos);
 }
@@ -358,7 +358,7 @@ static Obj Func32Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  Func32Bits_LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func32Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func32Bits_LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return LeadingExponentOfPcElement<UInt4>(self, pcgs, w);
 }
@@ -367,7 +367,7 @@ static Obj Func32Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func32Bits_ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-static Obj Func32Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+static Obj Func32Bits_ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     return ExponentsOfPcElement<UInt4>(self, pcgs, w);
 }

--- a/src/objpcgel.cc
+++ b/src/objpcgel.cc
@@ -31,7 +31,7 @@ extern "C" {
 **
 *F  FuncNBitsPcWord_Comm( <self>, <left>, <right> )
 */
-Obj FuncNBitsPcWord_Comm ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Comm ( Obj self, Obj left, Obj right )
 {
     return FuncFinPowConjCol_ReducedComm(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -42,7 +42,7 @@ Obj FuncNBitsPcWord_Comm ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_Conjugate( <self>, <left>, <right> )
 */
-Obj FuncNBitsPcWord_Conjugate ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Conjugate ( Obj self, Obj left, Obj right )
 {
     left = FuncFinPowConjCol_ReducedProduct(
                 self, COLLECTOR_PCWORD(left), left, right );
@@ -55,7 +55,7 @@ Obj FuncNBitsPcWord_Conjugate ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_LeftQuotient( <self>, <left>, <right> )
 */
-Obj FuncNBitsPcWord_LeftQuotient ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_LeftQuotient ( Obj self, Obj left, Obj right )
 {
     return FuncFinPowConjCol_ReducedLeftQuotient(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -66,7 +66,7 @@ Obj FuncNBitsPcWord_LeftQuotient ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_PowerSmallInt( <self>, <left>, <right> )
 */
-Obj FuncNBitsPcWord_PowerSmallInt ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_PowerSmallInt ( Obj self, Obj left, Obj right )
 {
     return FuncFinPowConjCol_ReducedPowerSmallInt(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -77,7 +77,7 @@ Obj FuncNBitsPcWord_PowerSmallInt ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_Product( <self>, <left>, <right> )
 */
-Obj FuncNBitsPcWord_Product ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Product ( Obj self, Obj left, Obj right )
 {
     return FuncFinPowConjCol_ReducedProduct(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -88,7 +88,7 @@ Obj FuncNBitsPcWord_Product ( Obj self, Obj left, Obj right )
 **
 *F  FuncNBitsPcWord_Quotient( <self>, <left>, <right> )
 */
-Obj FuncNBitsPcWord_Quotient ( Obj self, Obj left, Obj right )
+static Obj FuncNBitsPcWord_Quotient ( Obj self, Obj left, Obj right )
 {
     return FuncFinPowConjCol_ReducedQuotient(
         self, COLLECTOR_PCWORD(left), left, right );
@@ -105,7 +105,7 @@ Obj FuncNBitsPcWord_Quotient ( Obj self, Obj left, Obj right )
 *F  DepthOfPcElement( <self>, <pcgs>, <w> )
 */
 template <typename UIntN>
-Obj DepthOfPcElement(Obj self, Obj pcgs, Obj w)
+static Obj DepthOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     Int         ebits;          /* number of bits in the exponent          */
 
@@ -126,7 +126,7 @@ Obj DepthOfPcElement(Obj self, Obj pcgs, Obj w)
 *F  ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
 template <typename UIntN>
-Obj ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
+static Obj ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
 {
     UInt        expm;           /* signed exponent mask                    */
     UInt        exps;           /* sign exponent mask                      */
@@ -170,7 +170,7 @@ Obj ExponentOfPcElement(Obj self, Obj pcgs, Obj w, Obj pos)
 *F  LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
 template <typename UIntN>
-Obj LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
+static Obj LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     UInt        expm;           /* signed exponent mask                    */
     UInt        exps;           /* sign exponent mask                      */
@@ -197,7 +197,7 @@ Obj LeadingExponentOfPcElement(Obj self, Obj pcgs, Obj w)
 *F  ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
 template <typename UIntN>
-Obj ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
+static Obj ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 {
     UInt        len;            /* length of pcgs */
     Obj         el;             /* exponents list */
@@ -260,7 +260,7 @@ Obj ExponentsOfPcElement(Obj self, Obj pcgs, Obj w)
 **
 *F  Func8Bits_DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func8Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func8Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 {
     return DepthOfPcElement<UInt1>(self, pcgs, w);
 }
@@ -270,7 +270,7 @@ Obj Func8Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func8Bits_ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-Obj Func8Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+static Obj Func8Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 {
     return ExponentOfPcElement<UInt1>(self, pcgs, w, pos);
 }
@@ -280,7 +280,7 @@ Obj Func8Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  Func8Bits_LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func8Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func8Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 {
     return LeadingExponentOfPcElement<UInt1>(self, pcgs, w);
 }
@@ -289,7 +289,7 @@ Obj Func8Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func8Bits_ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func8Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+static Obj Func8Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 {
     return ExponentsOfPcElement<UInt1>(self, pcgs, w);
 }
@@ -299,7 +299,7 @@ Obj Func8Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 **
 *F  Func16Bits_DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func16Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func16Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 {
     return DepthOfPcElement<UInt2>(self, pcgs, w);
 }
@@ -309,7 +309,7 @@ Obj Func16Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func16Bits_ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-Obj Func16Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+static Obj Func16Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 {
     return ExponentOfPcElement<UInt2>(self, pcgs, w, pos);
 }
@@ -319,7 +319,7 @@ Obj Func16Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  Func16Bits_LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func16Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func16Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 {
     return LeadingExponentOfPcElement<UInt2>(self, pcgs, w);
 }
@@ -328,7 +328,7 @@ Obj Func16Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func16Bits_ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func16Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+static Obj Func16Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 {
     return ExponentsOfPcElement<UInt2>(self, pcgs, w);
 }
@@ -338,7 +338,7 @@ Obj Func16Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 **
 *F  Func32Bits_DepthOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func32Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func32Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 {
     return DepthOfPcElement<UInt4>(self, pcgs, w);
 }
@@ -348,7 +348,7 @@ Obj Func32Bits_DepthOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func32Bits_ExponentOfPcElement( <self>, <pcgs>, <w>, <pos> )
 */
-Obj Func32Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
+static Obj Func32Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 {
     return ExponentOfPcElement<UInt4>(self, pcgs, w, pos);
 }
@@ -358,7 +358,7 @@ Obj Func32Bits_ExponentOfPcElement ( Obj self, Obj pcgs, Obj w, Obj pos )
 **
 *F  Func32Bits_LeadingExponentOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func32Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
+static Obj Func32Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 {
     return LeadingExponentOfPcElement<UInt4>(self, pcgs, w);
 }
@@ -367,7 +367,7 @@ Obj Func32Bits_LeadingExponentOfPcElement ( Obj self, Obj pcgs, Obj w )
 **
 *F  Func32Bits_ExponentsOfPcElement( <self>, <pcgs>, <w> )
 */
-Obj Func32Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
+static Obj Func32Bits_ExponentsOfPcElement ( Obj self, Obj pcgs, Obj w)
 {
     return ExponentsOfPcElement<UInt4>(self, pcgs, w);
 }

--- a/src/objset.c
+++ b/src/objset.c
@@ -27,15 +27,17 @@
 #include "hpc/traverse.h"
 #endif
 
-Obj TYPE_OBJSET;
-Obj TYPE_OBJMAP;
+static Obj TYPE_OBJSET;
+static Obj TYPE_OBJMAP;
 
-static Obj TypeObjSet(Obj obj) {
-  return TYPE_OBJSET;
+static Obj TypeObjSet(Obj obj)
+{
+    return TYPE_OBJSET;
 }
 
-static Obj TypeObjMap(Obj obj) {
-  return TYPE_OBJMAP;
+static Obj TypeObjMap(Obj obj)
+{
+    return TYPE_OBJMAP;
 }
 
 /** Object sets and maps --------------------
@@ -81,7 +83,8 @@ static Obj TypeObjMap(Obj obj) {
  *  ---------------------------------------
  */
 
-static void PrintObjSet(Obj set) {
+static void PrintObjSet(Obj set)
+{
   UInt i, size = CONST_ADDR_WORD(set)[OBJSET_SIZE];
   Int comma = 0;
   Pr("OBJ_SET([ ", 0L, 0L);
@@ -99,7 +102,8 @@ static void PrintObjSet(Obj set) {
   Pr(" ])", 0L, 0L);
 }
 
-static void PrintObjMap(Obj map) {
+static void PrintObjMap(Obj map)
+{
   UInt i, size = CONST_ADDR_WORD(map)[OBJSET_SIZE];
   Int comma = 0;
   Pr("OBJ_MAP([ ", 0L, 0L);
@@ -126,12 +130,14 @@ static void PrintObjMap(Obj map) {
  *  These functions are not yet implemented.
  */
 
-static void MarkObjSet(Obj obj) {
+static void MarkObjSet(Obj obj)
+{
   UInt size = CONST_ADDR_WORD(obj)[OBJSET_SIZE];
   MarkArrayOfBags( ADDR_OBJ(obj) + OBJSET_HDRSIZE, size );
 }
 
-static void MarkObjMap(Obj obj) {
+static void MarkObjMap(Obj obj)
+{
   UInt size = CONST_ADDR_WORD(obj)[OBJSET_SIZE];
   MarkArrayOfBags( ADDR_OBJ(obj) + OBJSET_HDRSIZE, 2 * size );
 }
@@ -145,7 +151,8 @@ static void MarkObjMap(Obj obj) {
  */
 
 
-static inline UInt ObjHash(Obj set, Obj obj) {
+static inline UInt ObjHash(Obj set, Obj obj)
+{
   return FibHash((UInt) obj, CONST_ADDR_WORD(set)[OBJSET_BITS]);
 }
 
@@ -179,7 +186,8 @@ Obj NewObjSet(void) {
 
 static void ResizeObjSet(Obj set, UInt bits);
 
-static void CheckObjSetForCleanUp(Obj set, UInt expand) {
+static void CheckObjSetForCleanUp(Obj set, UInt expand)
+{
   UInt size = CONST_ADDR_WORD(set)[OBJSET_SIZE];
   UInt bits = CONST_ADDR_WORD(set)[OBJSET_BITS];
   UInt used = CONST_ADDR_WORD(set)[OBJSET_USED] + expand;
@@ -225,7 +233,8 @@ Int FindObjSet(Obj set, Obj obj) {
  *  Precondition: `set` must not already contain `obj`.
  */
 
-static void AddObjSetNew(Obj set, Obj obj) {
+static void AddObjSetNew(Obj set, Obj obj)
+{
   UInt size = CONST_ADDR_WORD(set)[OBJSET_SIZE];
   UInt hash = ObjHash(set, obj);
   GAP_ASSERT(TNUM_OBJ(set) == T_OBJSET);
@@ -333,7 +342,8 @@ Obj ObjSetValues(Obj set) {
  *  `2^bits`. There must be at least one free entry remaining.
  */
 
-static void ResizeObjSet(Obj set, UInt bits) {
+static void ResizeObjSet(Obj set, UInt bits)
+{
   UInt i, new_size = (1 << bits);
   Int size = ADDR_WORD(set)[OBJSET_SIZE];
   Obj new = NewBag(T_OBJSET, (OBJSET_HDRSIZE+new_size)*sizeof(Bag)*4);
@@ -353,7 +363,7 @@ static void ResizeObjSet(Obj set, UInt bits) {
   CHANGED_BAG(set);
 }
 
-void SaveObjSet(Obj set)
+static void SaveObjSet(Obj set)
 {
     UInt size = ADDR_WORD(set)[OBJSET_SIZE];
     UInt bits = ADDR_WORD(set)[OBJSET_BITS];
@@ -369,7 +379,7 @@ void SaveObjSet(Obj set)
     }
 }
 
-void LoadObjSet(Obj set)
+static void LoadObjSet(Obj set)
 {
     UInt size = LoadUInt();
     UInt bits = LoadUInt();
@@ -388,7 +398,7 @@ void LoadObjSet(Obj set)
 
 #ifdef USE_THREADSAFE_COPYING
 #ifndef WARD_ENABLED
-void TraverseObjSet(TraversalState * traversal, Obj obj)
+static void TraverseObjSet(TraversalState * traversal, Obj obj)
 {
     UInt i, len = *(UInt *)(CONST_ADDR_OBJ(obj) + OBJSET_SIZE);
     for (i = 0; i < len; i++) {
@@ -398,7 +408,7 @@ void TraverseObjSet(TraversalState * traversal, Obj obj)
     }
 }
 
-void CopyObjSet(TraversalState * traversal, Obj copy, Obj original)
+static void CopyObjSet(TraversalState * traversal, Obj copy, Obj original)
 {
     UInt i, len = *(UInt *)(CONST_ADDR_OBJ(original) + OBJSET_SIZE);
     for (i = 0; i < len; i++) {
@@ -438,7 +448,8 @@ Obj NewObjMap(void) {
 
 static void ResizeObjMap(Obj map, UInt bits);
 
-static void CheckObjMapForCleanUp(Obj map, UInt expand) {
+static void CheckObjMapForCleanUp(Obj map, UInt expand)
+{
   UInt size = ADDR_WORD(map)[OBJSET_SIZE];
   UInt bits = ADDR_WORD(map)[OBJSET_BITS];
   UInt used = ADDR_WORD(map)[OBJSET_USED] + expand;
@@ -498,7 +509,8 @@ Obj LookupObjMap(Obj map, Obj obj) {
  *  Precondition: No other entry with key `key` exists within `map`.
  */
 
-static void AddObjMapNew(Obj map, Obj key, Obj value) {
+static void AddObjMapNew(Obj map, Obj key, Obj value)
+{
   UInt size = ADDR_WORD(map)[OBJSET_SIZE];
   UInt hash = ObjHash(map, key);
   for (;;) {
@@ -637,7 +649,8 @@ Obj ObjMapKeys(Obj set) {
  *  Precondition: The number of entries in `map` must be less than `2^bits`.
  */
 
-static void ResizeObjMap(Obj map, UInt bits) {
+static void ResizeObjMap(Obj map, UInt bits)
+{
   UInt i, new_size = (1 << bits);
   UInt size = ADDR_WORD(map)[OBJSET_SIZE];
   GAP_ASSERT(new_size >= size);
@@ -659,7 +672,7 @@ static void ResizeObjMap(Obj map, UInt bits) {
   CHANGED_BAG(new);
 }
 
-void SaveObjMap(Obj map)
+static void SaveObjMap(Obj map)
 {
     UInt size = ADDR_WORD(map)[OBJSET_SIZE];
     UInt bits = ADDR_WORD(map)[OBJSET_BITS];
@@ -677,7 +690,7 @@ void SaveObjMap(Obj map)
     }
 }
 
-void LoadObjMap(Obj map)
+static void LoadObjMap(Obj map)
 {
     UInt size = LoadUInt();
     UInt bits = LoadUInt();
@@ -697,7 +710,7 @@ void LoadObjMap(Obj map)
 
 #ifdef USE_THREADSAFE_COPYING
 #ifndef WARD_ENABLED
-void TraverseObjMap(TraversalState * traversal, Obj obj)
+static void TraverseObjMap(TraversalState * traversal, Obj obj)
 {
     UInt i, len = *(UInt *)(CONST_ADDR_OBJ(obj) + OBJSET_SIZE);
     for (i = 0; i < len; i++) {
@@ -710,7 +723,7 @@ void TraverseObjMap(TraversalState * traversal, Obj obj)
     }
 }
 
-void CopyObjMap(TraversalState * traversal, Obj copy, Obj original)
+static void CopyObjMap(TraversalState * traversal, Obj copy, Obj original)
 {
     UInt i, len = *(UInt *)(CONST_ADDR_OBJ(original) + OBJSET_SIZE);
     for (i = 0; i < len; i++) {
@@ -733,7 +746,8 @@ void CopyObjMap(TraversalState * traversal, Obj copy, Obj original)
  *  of the new set. If no argument is provided, an empty set is created.
  */
 
-static Obj FuncOBJ_SET(Obj self, Obj arg) {
+static Obj FuncOBJ_SET(Obj self, Obj arg)
+{
   Obj result;
   Obj list;
   UInt i, len;
@@ -855,7 +869,8 @@ static Obj FuncOBJ_SET_VALUES(Obj self, Obj set)
  *  provided, an empty map is created.
  */
 
-static Obj FuncOBJ_MAP(Obj self, Obj arg) {
+static Obj FuncOBJ_MAP(Obj self, Obj arg)
+{
   Obj result;
   Obj list;
   UInt i, len;

--- a/src/opers.c
+++ b/src/opers.c
@@ -82,8 +82,7 @@ static Obj TesterAndFilter(Obj getter);
 **
 *F  PrintFlags( <flags> ) . . . . . . . . . . . . . . . .  print a flags list
 */
-static void PrintFlags (
-    Obj                 flags )
+static void PrintFlags(Obj flags)
 {
     Pr( "<flag list>", 0L, 0L );
 }
@@ -95,8 +94,7 @@ static void PrintFlags (
 */
 static Obj TYPE_FLAGS;
 
-static Obj TypeFlags (
-    Obj                 flags )
+static Obj TypeFlags(Obj flags)
 {
     return TYPE_FLAGS;
 }
@@ -107,8 +105,7 @@ static Obj TypeFlags (
 *F  SaveFlags( <flags> )  . . . . . . . . . . . . . . . . . save a flags list
 **
 */
-static void SaveFlags (
-    Obj         flags )
+static void SaveFlags(Obj flags)
 {
     UInt        i, len, *ptr;
 
@@ -128,8 +125,7 @@ static void SaveFlags (
 *F  LoadFlags( <flags> )  . . . . . . . . . . . . . . . . . load a flags list
 **
 */
-static void LoadFlags(
-    Obj         flags )
+static void LoadFlags(Obj flags)
 {
     Obj         sub;
     UInt        i, len, *ptr;
@@ -166,9 +162,7 @@ static void LoadFlags(
 */
 #define HASH_FLAGS_SIZE (Int4)67108879L
 
-static Obj FuncHASH_FLAGS (
-    Obj                 self,
-    Obj                 flags )
+static Obj FuncHASH_FLAGS(Obj self, Obj flags)
 {
     Int4                 hash;
     Int4                 x;
@@ -230,9 +224,7 @@ static Obj FuncHASH_FLAGS (
 **
 **  see 'FuncPositionsTruesBlist' in "blister.c" for information.
 */
-static Obj FuncTRUES_FLAGS (
-    Obj                 self,
-    Obj                 flags )
+static Obj FuncTRUES_FLAGS(Obj self, Obj flags)
 {
     Obj                 sub;            /* handle of the result            */
     Int                 len;            /* logical length of the list      */
@@ -281,9 +273,7 @@ static Obj FuncTRUES_FLAGS (
 **
 **  see 'FuncSIZE_FLAGS'
 */
-static Obj FuncSIZE_FLAGS (
-    Obj                 self,
-    Obj                 flags )
+static Obj FuncSIZE_FLAGS(Obj self, Obj flags)
 {
     UInt *              ptr;            /* pointer to flags                */
     UInt                nrb;            /* number of blocks in flags       */
@@ -359,10 +349,7 @@ static Int EqFlags(Obj flags1, Obj flags2)
 **
 *F  FuncIS_EQUAL_FLAGS( <self>, <flags1>, <flags2> )  equality of flags lists
 */
-static Obj FuncIS_EQUAL_FLAGS (
-    Obj                 self,
-    Obj                 flags1,
-    Obj                 flags2 )
+static Obj FuncIS_EQUAL_FLAGS(Obj self, Obj flags1, Obj flags2)
 {
     /* do some trivial checks                                              */
     RequireFlags("IS_EQUAL_FLAGS", flags1);
@@ -438,10 +425,7 @@ Obj FuncIS_SUBSET_FLAGS (
 **
 *F  FuncSUB_FLAGS( <self>, <flags1>, <flags2> ) . . .  substract a flags list
 */
-static Obj FuncSUB_FLAGS (
-    Obj                 self,
-    Obj                 flags1,
-    Obj                 flags2 )
+static Obj FuncSUB_FLAGS(Obj self, Obj flags1, Obj flags2)
 {
     Obj                 flags;
     Int                 len1;
@@ -497,10 +481,7 @@ static Int AndFlagsCacheMiss;
 static Int AndFlagsCacheLost;
 #endif
 
-static Obj FuncAND_FLAGS (
-    Obj                 self,
-    Obj                 flags1,
-    Obj                 flags2 )
+static Obj FuncAND_FLAGS(Obj self, Obj flags1, Obj flags2)
 {
     Obj                 flags;
     Int                 len1;
@@ -644,7 +625,7 @@ enum { HIDDEN_IMPS_CACHE_LENGTH = 20003 };
 
 /* Forward declaration of FuncFLAGS_FILTER */
 static Obj FuncFLAGS_FILTER(Obj self, Obj oper);
-    
+
 /****************************************************************************
 **
 *F  FuncInstallHiddenTrueMethod( <filter>, <filters> ) Add a hidden true method
@@ -954,8 +935,7 @@ static Int CountFlags;
 **
 *F  SetterFilter( <oper> )  . . . . . . . . . . . . . . .  setter of a filter
 */
-static Obj SetterFilter (
-    Obj                 oper )
+static Obj SetterFilter(Obj oper)
 {
     Obj                 setter;
 
@@ -970,10 +950,7 @@ static Obj SetterFilter (
 **
 *F  SetterAndFilter( <getter> )  . . . . . .  setter of a concatenated filter
 */
-static Obj DoSetAndFilter (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 val )
+static Obj DoSetAndFilter(Obj self, Obj obj, Obj val)
 {
     Obj                 op;
 
@@ -996,8 +973,7 @@ static Obj DoSetAndFilter (
 }
 
 
-static Obj SetterAndFilter (
-    Obj                 getter )
+static Obj SetterAndFilter(Obj getter)
 {
     Obj                 setter;
     Obj                 obj;
@@ -1022,8 +998,7 @@ static Obj SetterAndFilter (
 **
 *F  TesterFilter( <oper> )  . . . . . . . . . . . . . . .  tester of a filter
 */
-static Obj TesterFilter (
-    Obj                 oper )
+static Obj TesterFilter(Obj oper)
 {
     Obj                 tester;
 
@@ -1038,8 +1013,7 @@ static Obj TesterFilter (
 **
 *F  TestAndFilter( <getter> )  . . . . . . . .tester of a concatenated filter
 */
-static Obj TesterAndFilter (
-    Obj                 getter )
+static Obj TesterAndFilter(Obj getter)
 {
     Obj                 tester;
 
@@ -1058,10 +1032,7 @@ static Obj TesterAndFilter (
 **
 *F  NewFilter( <name>, <narg>, <nams>, <hdlr> )  . . . . .  make a new filter
 */
-static Obj DoSetFilter (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 val )
+static Obj DoSetFilter(Obj self, Obj obj, Obj val)
 {
     Int                 flag1;
     Obj                 type;
@@ -1086,8 +1057,7 @@ static Obj DoSetFilter (
     return 0;
 }
 
-static Obj NewSetterFilter (
-    Obj                 getter )
+static Obj NewSetterFilter(Obj getter)
 {
     Obj                 setter;
 
@@ -1165,9 +1135,7 @@ static Obj FuncIS_FILTER(Obj self, Obj obj)
 **
 *F  NewAndFilter( <filt1>, <filt2> ) . . . . . make a new concatenated filter
 */
-static Obj DoAndFilter (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoAndFilter(Obj self, Obj obj)
 {
     Obj                 val;
     Obj                 op;
@@ -1234,7 +1202,7 @@ Obj NewAndFilter (
     return getter;
 }
 
-static Obj FuncIS_AND_FILTER( Obj self, Obj filt )
+static Obj FuncIS_AND_FILTER(Obj self, Obj filt)
 {
   return (IS_FUNC(filt) && HDLR_FUNC(filt, 1) == DoAndFilter) ? True : False;
 }
@@ -1251,10 +1219,7 @@ Obj ReturnTrueFilter;
 **
 *F  NewReturnTrueFilter() . . . . . . . . . . create a new return true filter
 */
-static Obj DoSetReturnTrueFilter (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 val )
+static Obj DoSetReturnTrueFilter(Obj self, Obj obj, Obj val)
 {
     if ( val != True ) {
          ErrorReturnVoid( "you cannot set this flag to 'false'",
@@ -1264,8 +1229,7 @@ static Obj DoSetReturnTrueFilter (
     return 0;
 }
 
-static Obj SetterReturnTrueFilter (
-    Obj                 getter )
+static Obj SetterReturnTrueFilter(Obj getter)
 {
     Obj                 setter;
 
@@ -1279,14 +1243,12 @@ static Obj SetterReturnTrueFilter (
     return setter;    
 }
 
-static Obj DoReturnTrueFilter (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoReturnTrueFilter(Obj self, Obj obj)
 {
     return True;
 }
 
-static Obj NewReturnTrueFilter ( void )
+static Obj NewReturnTrueFilter(void)
 {
     Obj                 getter;
     Obj                 setter;
@@ -1323,9 +1285,7 @@ static Obj NewReturnTrueFilter ( void )
 **
 *F  FuncNEW_FILTER( <self>, <name> )  . . . . . . . . . . . . .  new filter
 */
-static Obj FuncNEW_FILTER (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_FILTER(Obj self, Obj name)
 {
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
@@ -1341,9 +1301,7 @@ static Obj FuncNEW_FILTER (
 **
 *F  FuncFLAG1_FILTER( <self>, <oper> )  . . . . . . . . . . . .  `FLAG1_FILT'
 */
-static Obj FuncFLAG1_FILTER (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncFLAG1_FILTER(Obj self, Obj oper)
 {
     Obj                 flag1;
 
@@ -1359,10 +1317,7 @@ static Obj FuncFLAG1_FILTER (
 **
 *F  FuncSET_FLAG1_FILTER( <self>, <oper>, <flag1> ) . . . .  set `FLAG1_FILT'
 */
-static Obj FuncSET_FLAG1_FILTER (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 flag1 )
+static Obj FuncSET_FLAG1_FILTER(Obj self, Obj oper, Obj flag1)
 {
     RequireOperation(oper);
     SET_FLAG1_FILT(oper, flag1);
@@ -1374,9 +1329,7 @@ static Obj FuncSET_FLAG1_FILTER (
 **
 *F  FuncFLAG2_FILTER( <self>, <oper> )  . . . . . . . . . . . .  `FLAG2_FILT'
 */
-static Obj FuncFLAG2_FILTER (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncFLAG2_FILTER(Obj self, Obj oper)
 {
     Obj                 flag2;
 
@@ -1392,10 +1345,7 @@ static Obj FuncFLAG2_FILTER (
 **
 *F  FuncSET_FLAG2_FILTER( <self>, <oper>, <flag2> ) . . . .  set `FLAG2_FILT'
 */
-static Obj FuncSET_FLAG2_FILTER (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 flag2 )
+static Obj FuncSET_FLAG2_FILTER(Obj self, Obj oper, Obj flag2)
 {
     RequireOperation(oper);
     SET_FLAG2_FILT(oper, flag2);
@@ -1407,9 +1357,7 @@ static Obj FuncSET_FLAG2_FILTER (
 **
 *F  FuncFLAGS_FILTER( <self>, <oper> )  . . . . . . . . . . . .  `FLAGS_FILT'
 */
-static Obj FuncFLAGS_FILTER (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncFLAGS_FILTER(Obj self, Obj oper)
 {
     Obj                 flags;
 
@@ -1425,10 +1373,7 @@ static Obj FuncFLAGS_FILTER (
 **
 *F  FuncSET_FLAGS_FILTER( <self>, <oper>, <flags> ) . . . .  set `FLAGS_FILT'
 */
-static Obj FuncSET_FLAGS_FILTER (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 flags )
+static Obj FuncSET_FLAGS_FILTER(Obj self, Obj oper, Obj flags)
 {
     RequireOperation(oper);
     SET_FLAGS_FILT(oper, flags);
@@ -1440,9 +1385,7 @@ static Obj FuncSET_FLAGS_FILTER (
 **
 *F  FuncSETTER_FILTER( <self>, <oper> ) . . . . . . . . .  setter of a filter
 */
-static Obj FuncSETTER_FILTER (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncSETTER_FILTER(Obj self, Obj oper)
 {
     Obj                 setter;
 
@@ -1457,10 +1400,7 @@ static Obj FuncSETTER_FILTER (
 **
 *F  FuncSET_SETTER_FILTER( <self>, <oper>, <setter> )  set setter of a filter
 */
-static Obj FuncSET_SETTER_FILTER (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 setter )
+static Obj FuncSET_SETTER_FILTER(Obj self, Obj oper, Obj setter)
 {
     RequireOperation(oper);
     SET_SETTR_FILT(oper, setter);
@@ -1472,9 +1412,7 @@ static Obj FuncSET_SETTER_FILTER (
 **
 *F  FuncTESTER_FILTER( <self>, <oper> ) . . . . . . . . .  tester of a filter
 */
-static Obj FuncTESTER_FILTER (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncTESTER_FILTER(Obj self, Obj oper)
 {
     Obj                 tester;
 
@@ -1489,10 +1427,7 @@ static Obj FuncTESTER_FILTER (
 **
 *F  FuncSET_TESTER_FILTER( <self>, <oper>, <tester> )  set tester of a filter
 */
-static Obj FuncSET_TESTER_FILTER (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 tester )
+static Obj FuncSET_TESTER_FILTER(Obj self, Obj oper, Obj tester)
 {
     RequireOperation(oper);
     if ( SIZE_OBJ(oper) != sizeof(OperBag) ) {
@@ -1595,7 +1530,7 @@ static void FixTypeIDs( Bag b ) {
 
 #endif
 
-static Obj FuncCOMPACT_TYPE_IDS( Obj self )
+static Obj FuncCOMPACT_TYPE_IDS(Obj self)
 {
 #ifdef USE_GASMAN
   NextTypeID = INT_INTOBJ_MIN;
@@ -2308,14 +2243,15 @@ static Obj DoConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
                             arg3, 0, 0, 0);
 }
 
-static Obj DoConstructor4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
+static Obj
+DoConstructor4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
     return DoOperationNArgs(oper, 4, 0, 1, arg1, arg2,
                             arg3, arg4, 0, 0);
 }
 
-static Obj DoConstructor5Args(
-    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
+static Obj
+DoConstructor5Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
     return DoOperationNArgs(oper, 5, 0, 1, arg1, arg2,
                             arg3, arg4, arg5, 0);
@@ -2371,8 +2307,8 @@ static Obj DoVerboseConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
                             arg2, arg3, 0, 0, 0);
 }
 
-static Obj DoVerboseConstructor4Args(
-    Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
+static Obj
+DoVerboseConstructor4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
     return DoOperationNArgs(oper, 4, 1, 1, arg1,
                             arg2, arg3, arg4, 0, 0);
@@ -2515,9 +2451,7 @@ Obj DoAttribute (
 */
 #define DoVerboseSetAttribute  DoVerboseOperation2Args
 
-static Obj DoVerboseAttribute (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoVerboseAttribute(Obj self, Obj obj)
 {
     Obj                 val;
     Int                 flag2;
@@ -2568,9 +2502,7 @@ static Obj DoVerboseAttribute (
 **
 **  DoMutableAttribute( <attr>, <obj> )
 */
-static Obj DoMutableAttribute (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoMutableAttribute(Obj self, Obj obj)
 {
     Obj                 val;
     Int                 flag2;
@@ -2615,9 +2547,7 @@ static Obj DoMutableAttribute (
 **
 **  DoVerboseMutableAttribute( <attr>, <obj> )
 */
-static Obj DoVerboseMutableAttribute (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoVerboseMutableAttribute(Obj self, Obj obj)
 {
     Obj                 val;
     Int                 flag2;
@@ -2784,7 +2714,7 @@ Obj NewAttribute (
 **  should not have any one-argument declarations) into an attribute
 */
 
-static void ConvertOperationIntoAttribute( Obj oper, ObjFunc hdlr ) 
+static void ConvertOperationIntoAttribute(Obj oper, ObjFunc hdlr)
 {
     Obj                 setter;
     Obj                 tester;
@@ -2819,10 +2749,7 @@ Obj RESET_FILTER_OBJ;
 **
 **  DoSetProperty( <prop>, <obj>, <val> )
 */
-static Obj DoSetProperty (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 val )
+static Obj DoSetProperty(Obj self, Obj obj, Obj val)
 {
     Int                 flag1;
     Int                 flag2;
@@ -2943,9 +2870,7 @@ Obj DoProperty (
 **
 **  DoVerboseProperty( <prop>, <obj> )
 */
-static Obj DoVerboseProperty (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoVerboseProperty(Obj self, Obj obj)
 {
     Obj                 val;
     Int                 flag1;
@@ -3052,9 +2977,7 @@ Obj NewProperty (
 **
 **  DoUninstalledGlobalFunction( <oper>, <args> )
 */
-static Obj DoUninstalledGlobalFunction (
-    Obj                 oper,
-    Obj                 args )
+static Obj DoUninstalledGlobalFunction(Obj oper, Obj args)
 {
     ErrorQuit( "%g: function is not yet defined",
                (Int)NAME_FUNC(oper), 0L );
@@ -3066,9 +2989,7 @@ static Obj DoUninstalledGlobalFunction (
 **
 *F  NewGlobalFunction( <name>, <nams> )
 */
-static Obj NewGlobalFunction (
-    Obj                 name,
-    Obj                 nams )
+static Obj NewGlobalFunction(Obj name, Obj nams)
 {
     Obj                 func;
     Obj                 namobj;
@@ -3098,9 +3019,7 @@ static Obj NewGlobalFunction (
 **
 *F  InstallGlobalFunction( <oper>, <func> ) . . . . . . . . .  clone function
 */
-static void InstallGlobalFunction (
-    Obj                 oper,
-    Obj                 func )
+static void InstallGlobalFunction(Obj oper, Obj func)
 {
     // get the name
     Obj name = NAME_FUNC(oper);
@@ -3189,9 +3108,7 @@ void LoadOperationExtras (
 **
 *F  FuncNEW_OPERATION( <self>, <name> ) . . . . . . . . . . . . new operation
 */
-static Obj FuncNEW_OPERATION (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_OPERATION(Obj self, Obj name)
 {
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
@@ -3207,9 +3124,7 @@ static Obj FuncNEW_OPERATION (
 **
 *F  FuncNEW_CONSTRUCTOR( <self>, <name> ) . . . . . . . . . . new constructor
 */
-static Obj FuncNEW_CONSTRUCTOR (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_CONSTRUCTOR(Obj self, Obj name)
 {
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
@@ -3229,9 +3144,7 @@ static Obj FuncIS_CONSTRUCTOR(Obj self, Obj x)
 **
 *F  FuncNEW_ATTRIBUTE( <self>, <name> ) . . . . . . . . . . . . new attribute
 */
-static Obj FuncNEW_ATTRIBUTE (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_ATTRIBUTE(Obj self, Obj name)
 {
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
@@ -3245,9 +3158,7 @@ static Obj FuncNEW_ATTRIBUTE (
 **
 *F  FuncOPER_TO_ATTRIBUTE( <self>, oper ) make existing operation into attribute
 */
-static Obj FuncOPER_TO_ATTRIBUTE (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncOPER_TO_ATTRIBUTE(Obj self, Obj oper)
 {
     /* check the argument                                                  */
   if ( ! IS_OPERATION(oper) ) {
@@ -3263,9 +3174,7 @@ static Obj FuncOPER_TO_ATTRIBUTE (
 **
 *F  FuncOPER_TO_MUTABLE_ATTRIBUTE( <self>, oper ) make existing operation into attribute
 */
-static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE(Obj self, Obj oper)
 {
     /* check the argument                                                  */
   if ( ! IS_OPERATION(oper) ) {
@@ -3282,9 +3191,7 @@ static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE (
 **
 *F  FuncNEW_MUTABLE_ATTRIBUTE( <self>, <name> ) . . . . new mutable attribute
 */
-static Obj FuncNEW_MUTABLE_ATTRIBUTE (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_MUTABLE_ATTRIBUTE(Obj self, Obj name)
 {
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
@@ -3300,9 +3207,7 @@ static Obj FuncNEW_MUTABLE_ATTRIBUTE (
 **
 *F  FuncNEW_PROPERTY( <self>, <name> )  . . . . . . . . . . . .  new property
 */
-static Obj FuncNEW_PROPERTY (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_PROPERTY(Obj self, Obj name)
 {
     /* check the argument                                                  */
     if ( ! IsStringConv(name) ) {
@@ -3318,9 +3223,7 @@ static Obj FuncNEW_PROPERTY (
 **
 *F  FuncNEW_GLOBAL_FUNCTION( <self>, <name> ) . . . . . . new global function
 */
-static Obj FuncNEW_GLOBAL_FUNCTION (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncNEW_GLOBAL_FUNCTION(Obj self, Obj name)
 {
     Obj                 args;           
     Obj                 list;
@@ -3346,10 +3249,7 @@ static Obj FuncNEW_GLOBAL_FUNCTION (
 */
 static Obj REREADING;
 
-static Obj FuncINSTALL_GLOBAL_FUNCTION (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 func )
+static Obj FuncINSTALL_GLOBAL_FUNCTION(Obj self, Obj oper, Obj func)
 {
     /* check the arguments                                                 */
     RequireFunction("INSTALL_GLOBAL_FUNCTION", oper);
@@ -3375,9 +3275,7 @@ static Obj FuncINSTALL_GLOBAL_FUNCTION (
 */
 static Obj IsOperationFilt;
 
-static Obj FuncIS_OPERATION (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_OPERATION(Obj self, Obj obj)
 {
     if ( TNUM_OBJ(obj) == T_FUNCTION && IS_OPERATION(obj) ) {
         return True;
@@ -3395,9 +3293,7 @@ static Obj FuncIS_OPERATION (
 **
 *F  FuncMETHODS_OPERATION( <self>, <oper>, <narg> ) . . . . .  list of method
 */
-static Obj MethsOper (
-    Obj                 oper,
-    UInt                i )
+static Obj MethsOper(Obj oper, UInt i)
 {
     Obj                 methods;
     methods = METHS_OPER( oper, i );
@@ -3412,10 +3308,7 @@ static Obj MethsOper (
     return methods;
 }
 
-static Obj FuncMETHODS_OPERATION (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 narg )
+static Obj FuncMETHODS_OPERATION(Obj self, Obj oper, Obj narg)
 {
     Int                 n;
     Obj                 meth;
@@ -3437,10 +3330,7 @@ static Obj FuncMETHODS_OPERATION (
 **
 *F  FuncCHANGED_METHODS_OPERATION( <self>, <oper>, <narg> ) . . . clear cache
 */
-static Obj FuncCHANGED_METHODS_OPERATION (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 narg )
+static Obj FuncCHANGED_METHODS_OPERATION(Obj self, Obj oper, Obj narg)
 {
     Obj *               cache;
     Bag                 cacheBag;
@@ -3470,11 +3360,7 @@ static Obj FuncCHANGED_METHODS_OPERATION (
 **
 *F  FuncSET_METHODS_OPERATION( <self>, <oper>, <narg>, <list> ) . set methods
 */
-static Obj FuncSET_METHODS_OPERATION (
-    Obj                 self,
-    Obj                 oper,
-    Obj                 narg,
-    Obj                 meths )
+static Obj FuncSET_METHODS_OPERATION(Obj self, Obj oper, Obj narg, Obj meths)
 {
     Int                 n;
 
@@ -3495,10 +3381,7 @@ static Obj FuncSET_METHODS_OPERATION (
 **
 *F  FuncSETTER_FUNCTION( <self>, <name>, <filter> )  default attribute setter
 */
-static Obj DoSetterFunction (
-    Obj                 self,
-    Obj                 obj,
-    Obj                 value )
+static Obj DoSetterFunction(Obj self, Obj obj, Obj value)
 {
     Obj                 tmp;
     Obj                 tester;
@@ -3544,10 +3427,7 @@ static Obj DoSetterFunction (
 }
 
 
-static Obj FuncSETTER_FUNCTION (
-    Obj                 self,
-    Obj                 name,
-    Obj                 filter )
+static Obj FuncSETTER_FUNCTION(Obj self, Obj name, Obj filter)
 {
     Obj                 func;
     Obj                 fname;
@@ -3570,9 +3450,7 @@ static Obj FuncSETTER_FUNCTION (
 **
 *F  FuncGETTER_FUNCTION( <self>, <name> ) . . . . .  default attribute getter
 */
-static Obj DoGetterFunction (
-    Obj                 self,
-    Obj                 obj )
+static Obj DoGetterFunction(Obj self, Obj obj)
 {
     switch (TNUM_OBJ(obj)) {
       case T_COMOBJ:
@@ -3588,9 +3466,7 @@ static Obj DoGetterFunction (
 }
 
 
-static Obj FuncGETTER_FUNCTION (
-    Obj                 self,
-    Obj                 name )
+static Obj FuncGETTER_FUNCTION(Obj self, Obj name)
 {
     Obj                 func;
     Obj                 fname;
@@ -3606,8 +3482,7 @@ static Obj FuncGETTER_FUNCTION (
 **
 *F  FuncOPERS_CACHE_INFO( <self> )  . . . . . . .  return cache stats as list
 */
-static Obj FuncOPERS_CACHE_INFO (
-    Obj                        self )
+static Obj FuncOPERS_CACHE_INFO(Obj self)
 {
     Obj                 list;
     Int                 i;
@@ -3678,8 +3553,7 @@ static Obj FuncOPERS_CACHE_INFO (
 **
 *F  FuncCLEAR_CACHE_INFO( <self> )  . . . . . . . . . . . . clear cache stats
 */
-static Obj FuncCLEAR_CACHE_INFO (
-    Obj                        self )
+static Obj FuncCLEAR_CACHE_INFO(Obj self)
 {
 #ifdef COUNT_OPERS
     AndFlagsCacheHit = 0;
@@ -3770,9 +3644,7 @@ void ChangeDoOperations (
 **
 *F  FuncTRACE_METHODS( <oper> ) . . . . . . . .  switch tracing of methods on
 */
-static Obj FuncTRACE_METHODS (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncTRACE_METHODS(Obj self, Obj oper)
 {
     /* check the argument                                                  */
     RequireOperation(oper);
@@ -3789,9 +3661,7 @@ static Obj FuncTRACE_METHODS (
 **
 *F  FuncUNTRACE_METHODS( <oper> ) . . . . . . . switch tracing of methods off
 */
-static Obj FuncUNTRACE_METHODS (
-    Obj                 self,
-    Obj                 oper )
+static Obj FuncUNTRACE_METHODS(Obj self, Obj oper)
 {
 
     /* check the argument                                                  */
@@ -3809,10 +3679,7 @@ static Obj FuncUNTRACE_METHODS (
 *F  FuncSET_ATTRIBUTE_STORING( <self>, <attr>, <val> )
 **               switch off or on the setter call of an attribute
 */
-static Obj FuncSET_ATTRIBUTE_STORING (
-    Obj                 self,
-    Obj                 attr,
-    Obj                 val )
+static Obj FuncSET_ATTRIBUTE_STORING(Obj self, Obj attr, Obj val)
 {
   SET_ENABLED_ATTR(attr, (val == True) ? 1L : 0L);
   return 0;
@@ -3823,7 +3690,7 @@ static Obj FuncSET_ATTRIBUTE_STORING (
 *F  FuncDO_NOTHING_SETTER(<self> , <obj>, <val> )
 **
 */
-static Obj FuncDO_NOTHING_SETTER( Obj self, Obj obj, Obj val)
+static Obj FuncDO_NOTHING_SETTER(Obj self, Obj obj, Obj val)
 {
   return 0;
 }

--- a/src/opers.c
+++ b/src/opers.c
@@ -82,7 +82,7 @@ static Obj TesterAndFilter(Obj getter);
 **
 *F  PrintFlags( <flags> ) . . . . . . . . . . . . . . . .  print a flags list
 */
-void PrintFlags (
+static void PrintFlags (
     Obj                 flags )
 {
     Pr( "<flag list>", 0L, 0L );
@@ -95,7 +95,7 @@ void PrintFlags (
 */
 static Obj TYPE_FLAGS;
 
-Obj TypeFlags (
+static Obj TypeFlags (
     Obj                 flags )
 {
     return TYPE_FLAGS;
@@ -107,7 +107,7 @@ Obj TypeFlags (
 *F  SaveFlags( <flags> )  . . . . . . . . . . . . . . . . . save a flags list
 **
 */
-void SaveFlags (
+static void SaveFlags (
     Obj         flags )
 {
     UInt        i, len, *ptr;
@@ -128,7 +128,7 @@ void SaveFlags (
 *F  LoadFlags( <flags> )  . . . . . . . . . . . . . . . . . load a flags list
 **
 */
-void LoadFlags(
+static void LoadFlags(
     Obj         flags )
 {
     Obj         sub;
@@ -166,7 +166,7 @@ void LoadFlags(
 */
 #define HASH_FLAGS_SIZE (Int4)67108879L
 
-Obj FuncHASH_FLAGS (
+static Obj FuncHASH_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
@@ -230,7 +230,7 @@ Obj FuncHASH_FLAGS (
 **
 **  see 'FuncPositionsTruesBlist' in "blister.c" for information.
 */
-Obj FuncTRUES_FLAGS (
+static Obj FuncTRUES_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
@@ -281,7 +281,7 @@ Obj FuncTRUES_FLAGS (
 **
 **  see 'FuncSIZE_FLAGS'
 */
-Obj FuncSIZE_FLAGS (
+static Obj FuncSIZE_FLAGS (
     Obj                 self,
     Obj                 flags )
 {
@@ -310,7 +310,7 @@ Obj FuncSIZE_FLAGS (
 **
 *F  EqFlags( <flags1>, <flags2> ) . . . . . . . . . . equality of flags lists
 */
-Int EqFlags(Obj flags1, Obj flags2)
+static Int EqFlags(Obj flags1, Obj flags2)
 {
     Int                 len1;
     Int                 len2;
@@ -359,7 +359,7 @@ Int EqFlags(Obj flags1, Obj flags2)
 **
 *F  FuncIS_EQUAL_FLAGS( <self>, <flags1>, <flags2> )  equality of flags lists
 */
-Obj FuncIS_EQUAL_FLAGS (
+static Obj FuncIS_EQUAL_FLAGS (
     Obj                 self,
     Obj                 flags1,
     Obj                 flags2 )
@@ -438,7 +438,7 @@ Obj FuncIS_SUBSET_FLAGS (
 **
 *F  FuncSUB_FLAGS( <self>, <flags1>, <flags2> ) . . .  substract a flags list
 */
-Obj FuncSUB_FLAGS (
+static Obj FuncSUB_FLAGS (
     Obj                 self,
     Obj                 flags1,
     Obj                 flags2 )
@@ -497,7 +497,7 @@ static Int AndFlagsCacheMiss;
 static Int AndFlagsCacheLost;
 #endif
 
-Obj FuncAND_FLAGS (
+static Obj FuncAND_FLAGS (
     Obj                 self,
     Obj                 flags1,
     Obj                 flags2 )
@@ -638,18 +638,18 @@ Obj FuncAND_FLAGS (
     return flags;
 }
 
-Obj HIDDEN_IMPS;
-Obj WITH_HIDDEN_IMPS_FLAGS_CACHE;
+static Obj HIDDEN_IMPS;
+static Obj WITH_HIDDEN_IMPS_FLAGS_CACHE;
 enum { HIDDEN_IMPS_CACHE_LENGTH = 20003 };
 
 /* Forward declaration of FuncFLAGS_FILTER */
-Obj FuncFLAGS_FILTER(Obj self, Obj oper);
+static Obj FuncFLAGS_FILTER(Obj self, Obj oper);
     
 /****************************************************************************
 **
 *F  FuncInstallHiddenTrueMethod( <filter>, <filters> ) Add a hidden true method
 */
-Obj FuncInstallHiddenTrueMethod(Obj self, Obj filter, Obj filters)
+static Obj FuncInstallHiddenTrueMethod(Obj self, Obj filter, Obj filters)
 {
     Obj imp = FuncFLAGS_FILTER(0, filter);
     Obj imps = FuncFLAGS_FILTER(0, filters);
@@ -672,7 +672,7 @@ Obj FuncInstallHiddenTrueMethod(Obj self, Obj filter, Obj filters)
 **
 *F  FuncCLEAR_HIDDEN_IMP_CACHE( <self>, <flags> ) . . . .clear cache of flags
 */
-Obj FuncCLEAR_HIDDEN_IMP_CACHE(Obj self, Obj filter)
+static Obj FuncCLEAR_HIDDEN_IMP_CACHE(Obj self, Obj filter)
 {
   Int i;
   Obj flags = FuncFLAGS_FILTER(0, filter);
@@ -703,7 +703,7 @@ Obj FuncCLEAR_HIDDEN_IMP_CACHE(Obj self, Obj filter)
 static Int WITH_HIDDEN_IMPS_MISS=0;
 static Int WITH_HIDDEN_IMPS_HIT=0;
 #endif
-Obj FuncWITH_HIDDEN_IMPS_FLAGS(Obj self, Obj flags)
+static Obj FuncWITH_HIDDEN_IMPS_FLAGS(Obj self, Obj flags)
 {
     // do some trivial checks, so we can use IS_SUBSET_FLAGS
     RequireFlags("WITH_HIDDEN_IMPS_FLAGS", flags);
@@ -795,7 +795,7 @@ enum { IMPS_CACHE_LENGTH = 21001 };
 **
 *F  FuncCLEAR_IMP_CACHE( <self>, <flags> ) . . . . . . . clear cache of flags
 */
-Obj FuncCLEAR_IMP_CACHE(Obj self)
+static Obj FuncCLEAR_IMP_CACHE(Obj self)
 {
   Int i;
 #ifdef HPCGAP
@@ -820,7 +820,7 @@ Obj FuncCLEAR_IMP_CACHE(Obj self)
 static Int WITH_IMPS_FLAGS_MISS=0;
 static Int WITH_IMPS_FLAGS_HIT=0;
 #endif
-Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
+static Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
 {
     // do some trivial checks, so we can use IS_SUBSET_FLAGS
     RequireFlags("WITH_IMPS_FLAGS", flags);
@@ -921,7 +921,7 @@ Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
     return with;
 }
 
-Obj FuncWITH_IMPS_FLAGS_STAT(Obj self)
+static Obj FuncWITH_IMPS_FLAGS_STAT(Obj self)
 {
     Obj res;
     res = NEW_PLIST(T_PLIST, 3);
@@ -954,7 +954,7 @@ static Int CountFlags;
 **
 *F  SetterFilter( <oper> )  . . . . . . . . . . . . . . .  setter of a filter
 */
-Obj SetterFilter (
+static Obj SetterFilter (
     Obj                 oper )
 {
     Obj                 setter;
@@ -970,7 +970,7 @@ Obj SetterFilter (
 **
 *F  SetterAndFilter( <getter> )  . . . . . .  setter of a concatenated filter
 */
-Obj DoSetAndFilter (
+static Obj DoSetAndFilter (
     Obj                 self,
     Obj                 obj,
     Obj                 val )
@@ -996,7 +996,7 @@ Obj DoSetAndFilter (
 }
 
 
-Obj SetterAndFilter (
+static Obj SetterAndFilter (
     Obj                 getter )
 {
     Obj                 setter;
@@ -1022,7 +1022,7 @@ Obj SetterAndFilter (
 **
 *F  TesterFilter( <oper> )  . . . . . . . . . . . . . . .  tester of a filter
 */
-Obj TesterFilter (
+static Obj TesterFilter (
     Obj                 oper )
 {
     Obj                 tester;
@@ -1038,7 +1038,7 @@ Obj TesterFilter (
 **
 *F  TestAndFilter( <getter> )  . . . . . . . .tester of a concatenated filter
 */
-Obj TesterAndFilter (
+static Obj TesterAndFilter (
     Obj                 getter )
 {
     Obj                 tester;
@@ -1058,7 +1058,7 @@ Obj TesterAndFilter (
 **
 *F  NewFilter( <name>, <narg>, <nams>, <hdlr> )  . . . . .  make a new filter
 */
-Obj DoSetFilter (
+static Obj DoSetFilter (
     Obj                 self,
     Obj                 obj,
     Obj                 val )
@@ -1086,7 +1086,7 @@ Obj DoSetFilter (
     return 0;
 }
 
-Obj NewSetterFilter (
+static Obj NewSetterFilter (
     Obj                 getter )
 {
     Obj                 setter;
@@ -1155,7 +1155,7 @@ Obj NewFilter (
     return getter;    
 }
 
-Obj FuncIS_FILTER(Obj self, Obj obj)
+static Obj FuncIS_FILTER(Obj self, Obj obj)
 {
     return IS_FILTER(obj) ? True : False;
 }
@@ -1165,7 +1165,7 @@ Obj FuncIS_FILTER(Obj self, Obj obj)
 **
 *F  NewAndFilter( <filt1>, <filt2> ) . . . . . make a new concatenated filter
 */
-Obj DoAndFilter (
+static Obj DoAndFilter (
     Obj                 self,
     Obj                 obj )
 {
@@ -1234,7 +1234,7 @@ Obj NewAndFilter (
     return getter;
 }
 
-Obj FuncIS_AND_FILTER( Obj self, Obj filt )
+static Obj FuncIS_AND_FILTER( Obj self, Obj filt )
 {
   return (IS_FUNC(filt) && HDLR_FUNC(filt, 1) == DoAndFilter) ? True : False;
 }
@@ -1251,7 +1251,7 @@ Obj ReturnTrueFilter;
 **
 *F  NewReturnTrueFilter() . . . . . . . . . . create a new return true filter
 */
-Obj DoSetReturnTrueFilter (
+static Obj DoSetReturnTrueFilter (
     Obj                 self,
     Obj                 obj,
     Obj                 val )
@@ -1264,7 +1264,7 @@ Obj DoSetReturnTrueFilter (
     return 0;
 }
 
-Obj SetterReturnTrueFilter (
+static Obj SetterReturnTrueFilter (
     Obj                 getter )
 {
     Obj                 setter;
@@ -1279,14 +1279,14 @@ Obj SetterReturnTrueFilter (
     return setter;    
 }
 
-Obj DoReturnTrueFilter (
+static Obj DoReturnTrueFilter (
     Obj                 self,
     Obj                 obj )
 {
     return True;
 }
 
-Obj NewReturnTrueFilter ( void )
+static Obj NewReturnTrueFilter ( void )
 {
     Obj                 getter;
     Obj                 setter;
@@ -1323,7 +1323,7 @@ Obj NewReturnTrueFilter ( void )
 **
 *F  FuncNEW_FILTER( <self>, <name> )  . . . . . . . . . . . . .  new filter
 */
-Obj FuncNEW_FILTER (
+static Obj FuncNEW_FILTER (
     Obj                 self,
     Obj                 name )
 {
@@ -1341,7 +1341,7 @@ Obj FuncNEW_FILTER (
 **
 *F  FuncFLAG1_FILTER( <self>, <oper> )  . . . . . . . . . . . .  `FLAG1_FILT'
 */
-Obj FuncFLAG1_FILTER (
+static Obj FuncFLAG1_FILTER (
     Obj                 self,
     Obj                 oper )
 {
@@ -1359,7 +1359,7 @@ Obj FuncFLAG1_FILTER (
 **
 *F  FuncSET_FLAG1_FILTER( <self>, <oper>, <flag1> ) . . . .  set `FLAG1_FILT'
 */
-Obj FuncSET_FLAG1_FILTER (
+static Obj FuncSET_FLAG1_FILTER (
     Obj                 self,
     Obj                 oper,
     Obj                 flag1 )
@@ -1374,7 +1374,7 @@ Obj FuncSET_FLAG1_FILTER (
 **
 *F  FuncFLAG2_FILTER( <self>, <oper> )  . . . . . . . . . . . .  `FLAG2_FILT'
 */
-Obj FuncFLAG2_FILTER (
+static Obj FuncFLAG2_FILTER (
     Obj                 self,
     Obj                 oper )
 {
@@ -1392,7 +1392,7 @@ Obj FuncFLAG2_FILTER (
 **
 *F  FuncSET_FLAG2_FILTER( <self>, <oper>, <flag2> ) . . . .  set `FLAG2_FILT'
 */
-Obj FuncSET_FLAG2_FILTER (
+static Obj FuncSET_FLAG2_FILTER (
     Obj                 self,
     Obj                 oper,
     Obj                 flag2 )
@@ -1407,7 +1407,7 @@ Obj FuncSET_FLAG2_FILTER (
 **
 *F  FuncFLAGS_FILTER( <self>, <oper> )  . . . . . . . . . . . .  `FLAGS_FILT'
 */
-Obj FuncFLAGS_FILTER (
+static Obj FuncFLAGS_FILTER (
     Obj                 self,
     Obj                 oper )
 {
@@ -1425,7 +1425,7 @@ Obj FuncFLAGS_FILTER (
 **
 *F  FuncSET_FLAGS_FILTER( <self>, <oper>, <flags> ) . . . .  set `FLAGS_FILT'
 */
-Obj FuncSET_FLAGS_FILTER (
+static Obj FuncSET_FLAGS_FILTER (
     Obj                 self,
     Obj                 oper,
     Obj                 flags )
@@ -1440,7 +1440,7 @@ Obj FuncSET_FLAGS_FILTER (
 **
 *F  FuncSETTER_FILTER( <self>, <oper> ) . . . . . . . . .  setter of a filter
 */
-Obj FuncSETTER_FILTER (
+static Obj FuncSETTER_FILTER (
     Obj                 self,
     Obj                 oper )
 {
@@ -1457,7 +1457,7 @@ Obj FuncSETTER_FILTER (
 **
 *F  FuncSET_SETTER_FILTER( <self>, <oper>, <setter> )  set setter of a filter
 */
-Obj FuncSET_SETTER_FILTER (
+static Obj FuncSET_SETTER_FILTER (
     Obj                 self,
     Obj                 oper,
     Obj                 setter )
@@ -1472,7 +1472,7 @@ Obj FuncSET_SETTER_FILTER (
 **
 *F  FuncTESTER_FILTER( <self>, <oper> ) . . . . . . . . .  tester of a filter
 */
-Obj FuncTESTER_FILTER (
+static Obj FuncTESTER_FILTER (
     Obj                 self,
     Obj                 oper )
 {
@@ -1489,7 +1489,7 @@ Obj FuncTESTER_FILTER (
 **
 *F  FuncSET_TESTER_FILTER( <self>, <oper>, <tester> )  set tester of a filter
 */
-Obj FuncSET_TESTER_FILTER (
+static Obj FuncSET_TESTER_FILTER (
     Obj                 self,
     Obj                 oper,
     Obj                 tester )
@@ -1595,7 +1595,7 @@ static void FixTypeIDs( Bag b ) {
 
 #endif
 
-Obj FuncCOMPACT_TYPE_IDS( Obj self )
+static Obj FuncCOMPACT_TYPE_IDS( Obj self )
 {
 #ifdef USE_GASMAN
   NextTypeID = INT_INTOBJ_MIN;
@@ -2284,51 +2284,51 @@ Obj NewOperation(Obj name, Int narg, Obj nams, ObjFunc hdlr)
 *F  DoConstructorXArgs( <oper> )
 */
 
-Obj DoConstructor0Args(Obj oper)
+static Obj DoConstructor0Args(Obj oper)
 {
     ErrorQuit("constructors must have at least one argument", 0L, 0L);
     return 0;
 }
 
-Obj DoConstructor1Args(Obj oper, Obj arg1)
+static Obj DoConstructor1Args(Obj oper, Obj arg1)
 {
     return DoOperationNArgs(oper, 1, 0, 1, arg1, 0, 0,
                             0, 0, 0);
 }
 
-Obj DoConstructor2Args(Obj oper, Obj arg1, Obj arg2)
+static Obj DoConstructor2Args(Obj oper, Obj arg1, Obj arg2)
 {
     return DoOperationNArgs(oper, 2, 0, 1, arg1, arg2,
                             0, 0, 0, 0);
 }
 
-Obj DoConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
+static Obj DoConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
 {
     return DoOperationNArgs(oper, 3, 0, 1, arg1, arg2,
                             arg3, 0, 0, 0);
 }
 
-Obj DoConstructor4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
+static Obj DoConstructor4Args(Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
     return DoOperationNArgs(oper, 4, 0, 1, arg1, arg2,
                             arg3, arg4, 0, 0);
 }
 
-Obj DoConstructor5Args(
+static Obj DoConstructor5Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
     return DoOperationNArgs(oper, 5, 0, 1, arg1, arg2,
                             arg3, arg4, arg5, 0);
 }
 
-Obj DoConstructor6Args(
+static Obj DoConstructor6Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
     return DoOperationNArgs(oper, 6, 0, 1, arg1, arg2,
                             arg3, arg4, arg5, arg6);
 }
 
-Obj DoConstructorXArgs(Obj self, Obj args)
+static Obj DoConstructorXArgs(Obj self, Obj args)
 {
     ErrorQuit("sorry: cannot yet have X argument constructors", 0L, 0L);
     return 0;
@@ -2347,52 +2347,52 @@ Obj DoConstructorXArgs(Obj self, Obj args)
 *F  DoVerboseConstructorXArgs( <oper> )
 */
 
-Obj DoVerboseConstructor0Args(Obj oper)
+static Obj DoVerboseConstructor0Args(Obj oper)
 {
     ErrorQuit("constructors must have at least one argument", 0L, 0L);
     return 0;
 }
 
-Obj DoVerboseConstructor1Args(Obj oper, Obj arg1)
+static Obj DoVerboseConstructor1Args(Obj oper, Obj arg1)
 {
     return DoOperationNArgs(oper, 1, 1, 1, arg1,
                             0, 0, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor2Args(Obj oper, Obj arg1, Obj arg2)
+static Obj DoVerboseConstructor2Args(Obj oper, Obj arg1, Obj arg2)
 {
     return DoOperationNArgs(oper, 2, 1, 1, arg1,
                             arg2, 0, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
+static Obj DoVerboseConstructor3Args(Obj oper, Obj arg1, Obj arg2, Obj arg3)
 {
     return DoOperationNArgs(oper, 3, 1, 1, arg1,
                             arg2, arg3, 0, 0, 0);
 }
 
-Obj DoVerboseConstructor4Args(
+static Obj DoVerboseConstructor4Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
     return DoOperationNArgs(oper, 4, 1, 1, arg1,
                             arg2, arg3, arg4, 0, 0);
 }
 
-Obj DoVerboseConstructor5Args(
+static Obj DoVerboseConstructor5Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
     return DoOperationNArgs(oper, 5, 1, 1, arg1,
                             arg2, arg3, arg4, arg5, 0);
 }
 
-Obj DoVerboseConstructor6Args(
+static Obj DoVerboseConstructor6Args(
     Obj oper, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
     return DoOperationNArgs(oper, 6, 1, 1, arg1,
                             arg2, arg3, arg4, arg5, arg6);
 }
 
-Obj DoVerboseConstructorXArgs(Obj self, Obj args)
+static Obj DoVerboseConstructorXArgs(Obj self, Obj args)
 {
     ErrorQuit("sorry: cannot yet have X argument constructors", 0L, 0L);
     return 0;
@@ -2403,7 +2403,7 @@ Obj DoVerboseConstructorXArgs(Obj self, Obj args)
 **
 *F  NewConstructor( <name>> )
 */
-Obj NewConstructor(Obj name)
+static Obj NewConstructor(Obj name)
 {
     Obj                 oper;
 
@@ -2515,7 +2515,7 @@ Obj DoAttribute (
 */
 #define DoVerboseSetAttribute  DoVerboseOperation2Args
 
-Obj DoVerboseAttribute (
+static Obj DoVerboseAttribute (
     Obj                 self,
     Obj                 obj )
 {
@@ -2568,7 +2568,7 @@ Obj DoVerboseAttribute (
 **
 **  DoMutableAttribute( <attr>, <obj> )
 */
-Obj DoMutableAttribute (
+static Obj DoMutableAttribute (
     Obj                 self,
     Obj                 obj )
 {
@@ -2615,7 +2615,7 @@ Obj DoMutableAttribute (
 **
 **  DoVerboseMutableAttribute( <attr>, <obj> )
 */
-Obj DoVerboseMutableAttribute (
+static Obj DoVerboseMutableAttribute (
     Obj                 self,
     Obj                 obj )
 {
@@ -2784,7 +2784,7 @@ Obj NewAttribute (
 **  should not have any one-argument declarations) into an attribute
 */
 
-void ConvertOperationIntoAttribute( Obj oper, ObjFunc hdlr ) 
+static void ConvertOperationIntoAttribute( Obj oper, ObjFunc hdlr ) 
 {
     Obj                 setter;
     Obj                 tester;
@@ -2819,7 +2819,7 @@ Obj RESET_FILTER_OBJ;
 **
 **  DoSetProperty( <prop>, <obj>, <val> )
 */
-Obj DoSetProperty (
+static Obj DoSetProperty (
     Obj                 self,
     Obj                 obj,
     Obj                 val )
@@ -2943,7 +2943,7 @@ Obj DoProperty (
 **
 **  DoVerboseProperty( <prop>, <obj> )
 */
-Obj DoVerboseProperty (
+static Obj DoVerboseProperty (
     Obj                 self,
     Obj                 obj )
 {
@@ -3052,7 +3052,7 @@ Obj NewProperty (
 **
 **  DoUninstalledGlobalFunction( <oper>, <args> )
 */
-Obj DoUninstalledGlobalFunction (
+static Obj DoUninstalledGlobalFunction (
     Obj                 oper,
     Obj                 args )
 {
@@ -3066,7 +3066,7 @@ Obj DoUninstalledGlobalFunction (
 **
 *F  NewGlobalFunction( <name>, <nams> )
 */
-Obj NewGlobalFunction (
+static Obj NewGlobalFunction (
     Obj                 name,
     Obj                 nams )
 {
@@ -3098,7 +3098,7 @@ Obj NewGlobalFunction (
 **
 *F  InstallGlobalFunction( <oper>, <func> ) . . . . . . . . .  clone function
 */
-void InstallGlobalFunction (
+static void InstallGlobalFunction (
     Obj                 oper,
     Obj                 func )
 {
@@ -3189,7 +3189,7 @@ void LoadOperationExtras (
 **
 *F  FuncNEW_OPERATION( <self>, <name> ) . . . . . . . . . . . . new operation
 */
-Obj FuncNEW_OPERATION (
+static Obj FuncNEW_OPERATION (
     Obj                 self,
     Obj                 name )
 {
@@ -3207,7 +3207,7 @@ Obj FuncNEW_OPERATION (
 **
 *F  FuncNEW_CONSTRUCTOR( <self>, <name> ) . . . . . . . . . . new constructor
 */
-Obj FuncNEW_CONSTRUCTOR (
+static Obj FuncNEW_CONSTRUCTOR (
     Obj                 self,
     Obj                 name )
 {
@@ -3220,7 +3220,7 @@ Obj FuncNEW_CONSTRUCTOR (
     return NewConstructor( name );
 }
 
-Obj FuncIS_CONSTRUCTOR(Obj self, Obj x)
+static Obj FuncIS_CONSTRUCTOR(Obj self, Obj x)
 {
     return (IS_FUNC(x) && HDLR_FUNC(x, 1) == DoConstructor1Args) ? True : False;
 }
@@ -3229,7 +3229,7 @@ Obj FuncIS_CONSTRUCTOR(Obj self, Obj x)
 **
 *F  FuncNEW_ATTRIBUTE( <self>, <name> ) . . . . . . . . . . . . new attribute
 */
-Obj FuncNEW_ATTRIBUTE (
+static Obj FuncNEW_ATTRIBUTE (
     Obj                 self,
     Obj                 name )
 {
@@ -3245,7 +3245,7 @@ Obj FuncNEW_ATTRIBUTE (
 **
 *F  FuncOPER_TO_ATTRIBUTE( <self>, oper ) make existing operation into attribute
 */
-Obj FuncOPER_TO_ATTRIBUTE (
+static Obj FuncOPER_TO_ATTRIBUTE (
     Obj                 self,
     Obj                 oper )
 {
@@ -3263,7 +3263,7 @@ Obj FuncOPER_TO_ATTRIBUTE (
 **
 *F  FuncOPER_TO_MUTABLE_ATTRIBUTE( <self>, oper ) make existing operation into attribute
 */
-Obj FuncOPER_TO_MUTABLE_ATTRIBUTE (
+static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE (
     Obj                 self,
     Obj                 oper )
 {
@@ -3282,7 +3282,7 @@ Obj FuncOPER_TO_MUTABLE_ATTRIBUTE (
 **
 *F  FuncNEW_MUTABLE_ATTRIBUTE( <self>, <name> ) . . . . new mutable attribute
 */
-Obj FuncNEW_MUTABLE_ATTRIBUTE (
+static Obj FuncNEW_MUTABLE_ATTRIBUTE (
     Obj                 self,
     Obj                 name )
 {
@@ -3300,7 +3300,7 @@ Obj FuncNEW_MUTABLE_ATTRIBUTE (
 **
 *F  FuncNEW_PROPERTY( <self>, <name> )  . . . . . . . . . . . .  new property
 */
-Obj FuncNEW_PROPERTY (
+static Obj FuncNEW_PROPERTY (
     Obj                 self,
     Obj                 name )
 {
@@ -3318,7 +3318,7 @@ Obj FuncNEW_PROPERTY (
 **
 *F  FuncNEW_GLOBAL_FUNCTION( <self>, <name> ) . . . . . . new global function
 */
-Obj FuncNEW_GLOBAL_FUNCTION (
+static Obj FuncNEW_GLOBAL_FUNCTION (
     Obj                 self,
     Obj                 name )
 {
@@ -3346,7 +3346,7 @@ Obj FuncNEW_GLOBAL_FUNCTION (
 */
 static Obj REREADING;
 
-Obj FuncINSTALL_GLOBAL_FUNCTION (
+static Obj FuncINSTALL_GLOBAL_FUNCTION (
     Obj                 self,
     Obj                 oper,
     Obj                 func )
@@ -3375,7 +3375,7 @@ Obj FuncINSTALL_GLOBAL_FUNCTION (
 */
 static Obj IsOperationFilt;
 
-Obj FuncIS_OPERATION (
+static Obj FuncIS_OPERATION (
     Obj                 self,
     Obj                 obj )
 {
@@ -3395,7 +3395,7 @@ Obj FuncIS_OPERATION (
 **
 *F  FuncMETHODS_OPERATION( <self>, <oper>, <narg> ) . . . . .  list of method
 */
-Obj MethsOper (
+static Obj MethsOper (
     Obj                 oper,
     UInt                i )
 {
@@ -3412,7 +3412,7 @@ Obj MethsOper (
     return methods;
 }
 
-Obj FuncMETHODS_OPERATION (
+static Obj FuncMETHODS_OPERATION (
     Obj                 self,
     Obj                 oper,
     Obj                 narg )
@@ -3437,7 +3437,7 @@ Obj FuncMETHODS_OPERATION (
 **
 *F  FuncCHANGED_METHODS_OPERATION( <self>, <oper>, <narg> ) . . . clear cache
 */
-Obj FuncCHANGED_METHODS_OPERATION (
+static Obj FuncCHANGED_METHODS_OPERATION (
     Obj                 self,
     Obj                 oper,
     Obj                 narg )
@@ -3470,7 +3470,7 @@ Obj FuncCHANGED_METHODS_OPERATION (
 **
 *F  FuncSET_METHODS_OPERATION( <self>, <oper>, <narg>, <list> ) . set methods
 */
-Obj FuncSET_METHODS_OPERATION (
+static Obj FuncSET_METHODS_OPERATION (
     Obj                 self,
     Obj                 oper,
     Obj                 narg,
@@ -3495,7 +3495,7 @@ Obj FuncSET_METHODS_OPERATION (
 **
 *F  FuncSETTER_FUNCTION( <self>, <name>, <filter> )  default attribute setter
 */
-Obj DoSetterFunction (
+static Obj DoSetterFunction (
     Obj                 self,
     Obj                 obj,
     Obj                 value )
@@ -3544,7 +3544,7 @@ Obj DoSetterFunction (
 }
 
 
-Obj FuncSETTER_FUNCTION (
+static Obj FuncSETTER_FUNCTION (
     Obj                 self,
     Obj                 name,
     Obj                 filter )
@@ -3570,7 +3570,7 @@ Obj FuncSETTER_FUNCTION (
 **
 *F  FuncGETTER_FUNCTION( <self>, <name> ) . . . . .  default attribute getter
 */
-Obj DoGetterFunction (
+static Obj DoGetterFunction (
     Obj                 self,
     Obj                 obj )
 {
@@ -3588,7 +3588,7 @@ Obj DoGetterFunction (
 }
 
 
-Obj FuncGETTER_FUNCTION (
+static Obj FuncGETTER_FUNCTION (
     Obj                 self,
     Obj                 name )
 {
@@ -3606,7 +3606,7 @@ Obj FuncGETTER_FUNCTION (
 **
 *F  FuncOPERS_CACHE_INFO( <self> )  . . . . . . .  return cache stats as list
 */
-Obj FuncOPERS_CACHE_INFO (
+static Obj FuncOPERS_CACHE_INFO (
     Obj                        self )
 {
     Obj                 list;
@@ -3678,7 +3678,7 @@ Obj FuncOPERS_CACHE_INFO (
 **
 *F  FuncCLEAR_CACHE_INFO( <self> )  . . . . . . . . . . . . clear cache stats
 */
-Obj FuncCLEAR_CACHE_INFO (
+static Obj FuncCLEAR_CACHE_INFO (
     Obj                        self )
 {
 #ifdef COUNT_OPERS
@@ -3770,7 +3770,7 @@ void ChangeDoOperations (
 **
 *F  FuncTRACE_METHODS( <oper> ) . . . . . . . .  switch tracing of methods on
 */
-Obj FuncTRACE_METHODS (
+static Obj FuncTRACE_METHODS (
     Obj                 self,
     Obj                 oper )
 {
@@ -3789,7 +3789,7 @@ Obj FuncTRACE_METHODS (
 **
 *F  FuncUNTRACE_METHODS( <oper> ) . . . . . . . switch tracing of methods off
 */
-Obj FuncUNTRACE_METHODS (
+static Obj FuncUNTRACE_METHODS (
     Obj                 self,
     Obj                 oper )
 {
@@ -3809,7 +3809,7 @@ Obj FuncUNTRACE_METHODS (
 *F  FuncSET_ATTRIBUTE_STORING( <self>, <attr>, <val> )
 **               switch off or on the setter call of an attribute
 */
-Obj FuncSET_ATTRIBUTE_STORING (
+static Obj FuncSET_ATTRIBUTE_STORING (
     Obj                 self,
     Obj                 attr,
     Obj                 val )
@@ -3823,7 +3823,7 @@ Obj FuncSET_ATTRIBUTE_STORING (
 *F  FuncDO_NOTHING_SETTER(<self> , <obj>, <val> )
 **
 */
-Obj FuncDO_NOTHING_SETTER( Obj self, Obj obj, Obj val)
+static Obj FuncDO_NOTHING_SETTER( Obj self, Obj obj, Obj val)
 {
   return 0;
 }

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -211,17 +211,17 @@ static inline T * ADDR_TMP_PERM()
 **
 **  'TypePerm' is the function in 'TypeObjFuncs' for permutations.
 */
-Obj             TYPE_PERM2;
+static Obj             TYPE_PERM2;
 
-Obj             TYPE_PERM4;
+static Obj             TYPE_PERM4;
 
-Obj             TypePerm2 (
+static Obj             TypePerm2 (
     Obj                 perm )
 {
     return TYPE_PERM2;
 }
 
-Obj             TypePerm4 (
+static Obj             TypePerm4 (
     Obj                 perm )
 {
     return TYPE_PERM4;
@@ -242,7 +242,7 @@ Obj             TypePerm4 (
 **  enough to keep a terminal at 9600 baud busy for all but the extrem cases.
 */
 template <typename T>
-void PrintPerm(Obj perm)
+static void PrintPerm(Obj perm)
 {
     UInt                degPerm;        /* degree of the permutation       */
     const T *           ptPerm;         /* pointer to the permutation      */
@@ -301,7 +301,7 @@ void PrintPerm(Obj perm)
 **
 */
 template <typename TL, typename TR>
-Int EqPerm(Obj opL, Obj opR)
+static Int EqPerm(Obj opL, Obj opR)
 {
     UInt                degL;           /* degree of the left operand      */
     const TL *          ptL;            /* pointer to the left operand     */
@@ -349,7 +349,7 @@ Int EqPerm(Obj opL, Obj opR)
 **  respect to the images of 1,2,.., etc.
 */
 template <typename TL, typename TR>
-Int LtPerm(Obj opL, Obj opR)
+static Int LtPerm(Obj opL, Obj opR)
 {
     UInt                degL;           /* degree of the left operand      */
     const TL *          ptL;            /* pointer to the left operand     */
@@ -402,7 +402,7 @@ Int LtPerm(Obj opL, Obj opR)
 **  This is a little bit tuned but should be sufficiently easy to understand.
 */
 template <typename TL, typename TR>
-Obj ProdPerm(Obj opL, Obj opR)
+static Obj ProdPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -455,7 +455,7 @@ Obj ProdPerm(Obj opL, Obj opR)
 **  Unfortunatly this can not be done in <degree> steps, we need 2 * <degree>
 **  steps.
 */
-Obj QuoPerm(Obj opL, Obj opR)
+static Obj QuoPerm(Obj opL, Obj opR)
 {
     return PROD(opL, INV(opR));
 }
@@ -471,7 +471,7 @@ Obj QuoPerm(Obj opL, Obj opR)
 **  This can be done as fast as a single multiplication or inversion.
 */
 template <typename TL, typename TR>
-Obj LQuoPerm(Obj opL, Obj opR)
+static Obj LQuoPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -521,7 +521,7 @@ Obj LQuoPerm(Obj opL, Obj opR)
 *F  InvPerm( <perm> ) . . . . . . . . . . . . . . .  inverse of a permutation
 */
 template <typename T>
-Obj InvPerm(Obj perm)
+static Obj InvPerm(Obj perm)
 {
     Obj                 inv;            /* handle of the inverse (result)  */
     T *                 ptInv;          /* pointer to the inverse          */
@@ -561,7 +561,7 @@ Obj InvPerm(Obj perm)
 **  to be faster than binary powering, and does not need  temporary  storage.
 */
 template <typename T>
-Obj PowPermInt(Obj opL, Obj opR)
+static Obj PowPermInt(Obj opL, Obj opR)
 {
     Obj                 pow;            /* handle of the power (result)    */
     T *                 ptP;            /* pointer to the power            */
@@ -816,7 +816,7 @@ Obj PowPermInt(Obj opL, Obj opR)
 **  fixpoint of the permutation and thus simply returned.
 */
 template <typename T>
-Obj PowIntPerm(Obj opL, Obj opR)
+static Obj PowIntPerm(Obj opL, Obj opR)
 {
     Int                 img;            /* image (result)                  */
 
@@ -857,7 +857,7 @@ Obj PowIntPerm(Obj opL, Obj opR)
 static Obj PERM_INVERSE_THRESHOLD;
 
 template <typename T>
-Obj QuoIntPerm(Obj opL, Obj opR)
+static Obj QuoIntPerm(Obj opL, Obj opR)
 {
     T                   pre;            /* preimage (result)               */
     Int                 img;            /* image (left operand)            */
@@ -907,7 +907,7 @@ Obj QuoIntPerm(Obj opL, Obj opR)
 **  <opR>'.
 */
 template <typename TL, typename TR>
-Obj PowPerm(Obj opL, Obj opR)
+static Obj PowPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -956,7 +956,7 @@ Obj PowPerm(Obj opL, Obj opR)
 **  <opR>, that is defined as '<hd>\^-1 \*\ <opR>\^-1 \*\ <opL> \*\ <opR>'.
 */
 template <typename TL, typename TR>
-Obj CommPerm(Obj opL, Obj opR)
+static Obj CommPerm(Obj opL, Obj opR)
 {
     typedef typename ResultType<TL,TR>::type Res;
 
@@ -1002,7 +1002,7 @@ Obj CommPerm(Obj opL, Obj opR)
 **
 *F  OnePerm( <perm> )
 */
-Obj OnePerm (
+static Obj OnePerm (
     Obj                 op )
 {
     return IdentityPerm;
@@ -1021,9 +1021,9 @@ Obj OnePerm (
 **  'IsPerm' returns 'true' if the value <val> is a permutation and  'false'
 **  otherwise.
 */
-Obj IsPermFilt;
+static Obj IsPermFilt;
 
-Obj IsPermHandler (
+static Obj IsPermHandler (
     Obj                 self,
     Obj                 val )
 {
@@ -1109,7 +1109,7 @@ static inline Obj PermList(Obj list)
     return perm;
 }
 
-Obj             FuncPermList (
+static Obj             FuncPermList (
     Obj                 self,
     Obj                 list )
 {
@@ -1169,7 +1169,7 @@ UInt LargestMovedPointPerm(Obj perm)
 **
 **  GAP-level wrapper for 'LargestMovedPointPerm'.
 */
-Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
+static Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
 {
 
     /* check the argument                                                  */
@@ -1216,7 +1216,7 @@ static inline Obj CYCLE_LENGTH_PERM_INT(Obj perm, UInt pnt)
     return INTOBJ_INT(len);
 }
 
-Obj             FuncCYCLE_LENGTH_PERM_INT (
+static Obj             FuncCYCLE_LENGTH_PERM_INT (
     Obj                 self,
     Obj                 perm,
     Obj                 point )
@@ -1285,7 +1285,7 @@ static inline Obj CYCLE_PERM_INT(Obj perm, UInt pnt)
     return list;
 }
 
-Obj             FuncCYCLE_PERM_INT (
+static Obj             FuncCYCLE_PERM_INT (
     Obj                 self,
     Obj                 perm,
     Obj                 point )
@@ -1416,7 +1416,7 @@ static inline Obj CYCLE_STRUCT_PERM(Obj perm)
     return list;
 }
 
-Obj FuncCYCLE_STRUCT_PERM(Obj self, Obj perm)
+static Obj FuncCYCLE_STRUCT_PERM(Obj self, Obj perm)
 {
     /* evaluate and check the arguments                                    */
     RequirePermutation("CycleStructPerm", perm);
@@ -1492,7 +1492,7 @@ static inline Obj ORDER_PERM(Obj perm)
     return ord;
 }
 
-Obj             FuncORDER_PERM (
+static Obj             FuncORDER_PERM (
     Obj                 self,
     Obj                 perm )
 {
@@ -1569,7 +1569,7 @@ static inline Obj SIGN_PERM(Obj perm)
     return INTOBJ_INT( sign );
 }
 
-Obj             FuncSIGN_PERM (
+static Obj             FuncSIGN_PERM (
     Obj                 self,
     Obj                 perm )
 {
@@ -1688,7 +1688,7 @@ static inline Obj SMALLEST_GENERATOR_PERM(Obj perm)
     return small;
 }
 
-Obj             FuncSMALLEST_GENERATOR_PERM (
+static Obj             FuncSMALLEST_GENERATOR_PERM (
     Obj                 self,
     Obj                 perm )
 {
@@ -1805,7 +1805,7 @@ static inline Obj RESTRICTED_PERM(Obj perm, Obj dom, Obj test)
     return rest;
 }
 
-Obj             FuncRESTRICTED_PERM (
+static Obj             FuncRESTRICTED_PERM (
     Obj                 self,
     Obj                 perm,
     Obj                 dom,
@@ -1829,7 +1829,7 @@ Obj             FuncRESTRICTED_PERM (
 **  'TRIM_PERM' trims a permutation to the first <n> points. This can be
 ##  useful to save memory
 */
-Obj             FuncTRIM_PERM (
+static Obj             FuncTRIM_PERM (
     Obj                 self,
     Obj                 perm,
     Obj                 n )
@@ -1931,7 +1931,7 @@ SPLIT_PARTITION(Obj Ppoints, Obj Qnum, Obj jval, Obj g, Obj lst)
   return INTOBJ_INT(b+1);
 }
 
-Obj FuncSPLIT_PARTITION(
+static Obj FuncSPLIT_PARTITION(
     Obj self,
     Obj Ppoints,
     Obj Qnum,
@@ -1983,7 +1983,7 @@ static inline Obj DISTANCE_PERMS(Obj opL, Obj opR)
     return INTOBJ_INT(dist);
 }
 
-Obj FuncDISTANCE_PERMS(Obj self, Obj opL, Obj opR)
+static Obj FuncDISTANCE_PERMS(Obj self, Obj opL, Obj opR)
 {
     UInt type = (TNUM_OBJ(opL) == T_PERM2 ? 20 : 40) + (TNUM_OBJ(opR) == T_PERM2 ? 2 : 4);
     switch (type) {
@@ -2038,7 +2038,7 @@ static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
 
 }
 
-Obj             FuncSMALLEST_IMG_TUP_PERM (
+static Obj             FuncSMALLEST_IMG_TUP_PERM (
     Obj                 self,
     Obj                 tup,
     Obj                 perm )
@@ -2217,7 +2217,7 @@ Obj             OnSetsPerm (
 *F  SavePerm2( <perm2> )
 **
 */
-void SavePerm2(Obj perm)
+static void SavePerm2(Obj perm)
 {
     SaveSubObj(STOREDINV_PERM(perm));
     UInt len = DEG_PERM2(perm);
@@ -2231,7 +2231,7 @@ void SavePerm2(Obj perm)
 *F  SavePerm4( <perm4> )
 **
 */
-void SavePerm4(Obj perm)
+static void SavePerm4(Obj perm)
 {
     SaveSubObj(STOREDINV_PERM(perm));
     UInt len = DEG_PERM4(perm);
@@ -2245,7 +2245,7 @@ void SavePerm4(Obj perm)
 *F  LoadPerm2( <perm2> )
 **
 */
-void LoadPerm2(Obj perm)
+static void LoadPerm2(Obj perm)
 {
     ADDR_OBJ(perm)[0] = LoadSubObj();    // stored inverse
     UInt len = DEG_PERM2(perm);
@@ -2259,7 +2259,7 @@ void LoadPerm2(Obj perm)
 *F  LoadPerm4( <perm4> )
 **
 */
-void LoadPerm4(Obj perm)
+static void LoadPerm4(Obj perm)
 {
     ADDR_OBJ(perm)[0] = LoadSubObj();    // stored inverse
     UInt len = DEG_PERM4(perm);
@@ -2402,7 +2402,7 @@ static inline Int myquo(Obj pt, Obj perm)
   
 
 /* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
-Obj FuncAGESTC( Obj self, Obj args)
+static Obj FuncAGESTC( Obj self, Obj args)
 {
   Int i,j;
   Obj pt;
@@ -2456,7 +2456,7 @@ Obj FuncAGESTC( Obj self, Obj args)
 }
 
 /* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
-Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, Obj transversal, Obj genlabels)
+static Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, Obj transversal, Obj genlabels)
 {
   Int i,j;
   Int len = LEN_PLIST(orbit);
@@ -2506,7 +2506,7 @@ Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, O
 
 #define DEGREELIMITONSTACK 512
 
-Obj FuncMappingPermListList(Obj self, Obj src, Obj dst)
+static Obj FuncMappingPermListList(Obj self, Obj src, Obj dst)
 {
     Int l;
     Int i;
@@ -2677,7 +2677,7 @@ Obj FuncMappingPermListList(Obj self, Obj src, Obj dst)
 /* end ); */
 
 
-Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
+static Obj FuncSCR_SIFT_HELPER(Obj self, Obj S, Obj g, Obj n)
 {
   Obj stb = S;
   static UInt RN_stabilizer = 0;

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -211,18 +211,16 @@ static inline T * ADDR_TMP_PERM()
 **
 **  'TypePerm' is the function in 'TypeObjFuncs' for permutations.
 */
-static Obj             TYPE_PERM2;
+static Obj TYPE_PERM2;
 
-static Obj             TYPE_PERM4;
+static Obj TYPE_PERM4;
 
-static Obj             TypePerm2 (
-    Obj                 perm )
+static Obj TypePerm2(Obj perm)
 {
     return TYPE_PERM2;
 }
 
-static Obj             TypePerm4 (
-    Obj                 perm )
+static Obj TypePerm4(Obj perm)
 {
     return TYPE_PERM4;
 }
@@ -1002,8 +1000,7 @@ static Obj CommPerm(Obj opL, Obj opR)
 **
 *F  OnePerm( <perm> )
 */
-static Obj OnePerm (
-    Obj                 op )
+static Obj OnePerm(Obj op)
 {
     return IdentityPerm;
 }
@@ -1023,9 +1020,7 @@ static Obj OnePerm (
 */
 static Obj IsPermFilt;
 
-static Obj IsPermHandler (
-    Obj                 self,
-    Obj                 val )
+static Obj IsPermHandler(Obj self, Obj val)
 {
     /* return 'true' if <val> is a permutation and 'false' otherwise       */
     if ( TNUM_OBJ(val) == T_PERM2 || TNUM_OBJ(val) == T_PERM4 ) {
@@ -1109,9 +1104,7 @@ static inline Obj PermList(Obj list)
     return perm;
 }
 
-static Obj             FuncPermList (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncPermList(Obj self, Obj list)
 {
     /* check the arguments                                                 */
     RequireSmallList("PermList", list);
@@ -1216,10 +1209,7 @@ static inline Obj CYCLE_LENGTH_PERM_INT(Obj perm, UInt pnt)
     return INTOBJ_INT(len);
 }
 
-static Obj             FuncCYCLE_LENGTH_PERM_INT (
-    Obj                 self,
-    Obj                 perm,
-    Obj                 point )
+static Obj FuncCYCLE_LENGTH_PERM_INT(Obj self, Obj perm, Obj point)
 {
     UInt                pnt;            /* value of the point              */
 
@@ -1285,10 +1275,7 @@ static inline Obj CYCLE_PERM_INT(Obj perm, UInt pnt)
     return list;
 }
 
-static Obj             FuncCYCLE_PERM_INT (
-    Obj                 self,
-    Obj                 perm,
-    Obj                 point )
+static Obj FuncCYCLE_PERM_INT(Obj self, Obj perm, Obj point)
 {
     UInt                pnt;            /* value of the point              */
 
@@ -1492,9 +1479,7 @@ static inline Obj ORDER_PERM(Obj perm)
     return ord;
 }
 
-static Obj             FuncORDER_PERM (
-    Obj                 self,
-    Obj                 perm )
+static Obj FuncORDER_PERM(Obj self, Obj perm)
 {
     /* check arguments and extract permutation                             */
     RequirePermutation("OrderPerm", perm);
@@ -1569,9 +1554,7 @@ static inline Obj SIGN_PERM(Obj perm)
     return INTOBJ_INT( sign );
 }
 
-static Obj             FuncSIGN_PERM (
-    Obj                 self,
-    Obj                 perm )
+static Obj FuncSIGN_PERM(Obj self, Obj perm)
 {
     /* check arguments and extract permutation                             */
     RequirePermutation("SignPerm", perm);
@@ -1688,9 +1671,7 @@ static inline Obj SMALLEST_GENERATOR_PERM(Obj perm)
     return small;
 }
 
-static Obj             FuncSMALLEST_GENERATOR_PERM (
-    Obj                 self,
-    Obj                 perm )
+static Obj FuncSMALLEST_GENERATOR_PERM(Obj self, Obj perm)
 {
     /* check arguments and extract permutation                             */
     RequirePermutation("SmallestGeneratorPerm", perm);
@@ -1805,11 +1786,7 @@ static inline Obj RESTRICTED_PERM(Obj perm, Obj dom, Obj test)
     return rest;
 }
 
-static Obj             FuncRESTRICTED_PERM (
-    Obj                 self,
-    Obj                 perm,
-    Obj                 dom,
-    Obj                 test )
+static Obj FuncRESTRICTED_PERM(Obj self, Obj perm, Obj dom, Obj test)
 {
     /* check arguments and extract permutation                             */
     RequirePermutation("RestrictedPerm", perm);
@@ -1829,10 +1806,7 @@ static Obj             FuncRESTRICTED_PERM (
 **  'TRIM_PERM' trims a permutation to the first <n> points. This can be
 ##  useful to save memory
 */
-static Obj             FuncTRIM_PERM (
-    Obj                 self,
-    Obj                 perm,
-    Obj                 n )
+static Obj FuncTRIM_PERM(Obj self, Obj perm, Obj n)
 {
     UInt        deg,rdeg,i;
     UInt4*      addr;
@@ -1931,13 +1905,8 @@ SPLIT_PARTITION(Obj Ppoints, Obj Qnum, Obj jval, Obj g, Obj lst)
   return INTOBJ_INT(b+1);
 }
 
-static Obj FuncSPLIT_PARTITION(
-    Obj self,
-    Obj Ppoints,
-    Obj Qnum,
-    Obj jval,
-    Obj g,
-    Obj lst)
+static Obj
+FuncSPLIT_PARTITION(Obj self, Obj Ppoints, Obj Qnum, Obj jval, Obj g, Obj lst)
 {
   if (TNUM_OBJ(g)==T_PERM2) {
     return SPLIT_PARTITION<UInt2>(Ppoints, Qnum, jval, g, lst);
@@ -2038,10 +2007,7 @@ static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
 
 }
 
-static Obj             FuncSMALLEST_IMG_TUP_PERM (
-    Obj                 self,
-    Obj                 tup,
-    Obj                 perm )
+static Obj FuncSMALLEST_IMG_TUP_PERM(Obj self, Obj tup, Obj perm)
 {
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
         return SMALLEST_IMG_TUP_PERM<UInt2>(tup, perm);
@@ -2402,7 +2368,7 @@ static inline Int myquo(Obj pt, Obj perm)
   
 
 /* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
-static Obj FuncAGESTC( Obj self, Obj args)
+static Obj FuncAGESTC(Obj self, Obj args)
 {
   Int i,j;
   Obj pt;
@@ -2456,7 +2422,13 @@ static Obj FuncAGESTC( Obj self, Obj args)
 }
 
 /* Stabilizer chain helper implements AddGeneratorsExtendSchreierTree Inner loop */
-static Obj FuncAGEST( Obj self, Obj orbit, Obj newlabs,  Obj labels, Obj translabels, Obj transversal, Obj genlabels)
+static Obj FuncAGEST(Obj self,
+                     Obj orbit,
+                     Obj newlabs,
+                     Obj labels,
+                     Obj translabels,
+                     Obj transversal,
+                     Obj genlabels)
 {
   Int i,j;
   Int len = LEN_PLIST(orbit);

--- a/src/plist.c
+++ b/src/plist.c
@@ -447,7 +447,7 @@ static Int KTNumPlist(Obj list, Obj * famfirst)
 }
 
 
-Int KTNumHomPlist (
+static Int KTNumHomPlist (
     Obj                 list)
 {
     Int                 isTable = 0;    /* are <list>s elms all lists   */
@@ -575,7 +575,7 @@ Int KTNumHomPlist (
     return res;
 }
 
-Obj TypePlist( Obj list)
+static Obj TypePlist( Obj list)
 {
   return TypePlistWithKTNum( list, (UInt *) 0);
 }
@@ -692,7 +692,7 @@ static Obj TypePlistWithKTNum (
 #endif
 }
 
-Obj TypePlistNDense(Obj list)
+static Obj TypePlistNDense(Obj list)
 {
     if (IS_MUTABLE_OBJ(list))
         return TYPE_LIST_NDENSE_MUTABLE;
@@ -702,7 +702,7 @@ Obj TypePlistNDense(Obj list)
 
 #define         TypePlistDense       TypePlist
 
-Obj TypePlistDenseNHom(Obj list)
+static Obj TypePlistDenseNHom(Obj list)
 {
     if (IS_MUTABLE_OBJ(list))
         return TYPE_LIST_DENSE_NHOM_MUTABLE;
@@ -710,7 +710,7 @@ Obj TypePlistDenseNHom(Obj list)
         return TYPE_LIST_DENSE_NHOM_IMMUTABLE;
 }
 
-Obj TypePlistDenseNHomSSort(Obj list)
+static Obj TypePlistDenseNHomSSort(Obj list)
 {
     if (IS_MUTABLE_OBJ(list))
         return TYPE_LIST_DENSE_NHOM_SSORT_MUTABLE;
@@ -718,7 +718,7 @@ Obj TypePlistDenseNHomSSort(Obj list)
         return TYPE_LIST_DENSE_NHOM_SSORT_IMMUTABLE;
 }
 
-Obj TypePlistDenseNHomNSort(Obj list)
+static Obj TypePlistDenseNHomNSort(Obj list)
 {
     if (IS_MUTABLE_OBJ(list))
         return TYPE_LIST_DENSE_NHOM_NSORT_MUTABLE;
@@ -726,7 +726,7 @@ Obj TypePlistDenseNHomNSort(Obj list)
         return TYPE_LIST_DENSE_NHOM_NSORT_IMMUTABLE;
 }
 
-Obj TypePlistEmpty(Obj list)
+static Obj TypePlistEmpty(Obj list)
 {
     if (IS_MUTABLE_OBJ(list))
         return TYPE_LIST_EMPTY_MUTABLE;
@@ -734,7 +734,7 @@ Obj TypePlistEmpty(Obj list)
         return TYPE_LIST_EMPTY_IMMUTABLE;
 }
 
-Obj TypePlistHom(Obj list)
+static Obj TypePlistHom(Obj list)
 {
     Int                 tnum;           /* TNUM of <list>                  */
     Obj                 family;         /* family of elements              */
@@ -746,7 +746,7 @@ Obj TypePlistHom(Obj list)
     return TypePlistHomHelper(family, tnum, T_PLIST_HOM, list);
 }
 
-Obj TypePlistCyc(Obj list)
+static Obj TypePlistCyc(Obj list)
 {
     Int                 tnum;           /* TNUM of <list>                  */
     Obj                 family;         /* family of elements              */
@@ -760,7 +760,7 @@ Obj TypePlistCyc(Obj list)
     return TypePlistHomHelper(family, tnum, T_PLIST_CYC, list);
 }
 
-Obj TypePlistFfe(Obj list)
+static Obj TypePlistFfe(Obj list)
 {
     Int                 tnum;           /* TNUM of <list>                  */
     Obj                 family;         /* family of elements              */
@@ -777,7 +777,7 @@ Obj TypePlistFfe(Obj list)
 *F  SetTypePlistToPosObj(<list>, <kind>) .  convert list to positional object
 **
 */
-void SetTypePlistToPosObj(Obj list, Obj kind)
+static void SetTypePlistToPosObj(Obj list, Obj kind)
 {
     RetypeBag(list, T_POSOBJ);
     SET_TYPE_POSOBJ(list, kind);
@@ -819,7 +819,7 @@ Obj             ShallowCopyPlist (
 * Returns an empty plain list, but with space for len entries preallocated.
 *
 */
-Obj    FuncEmptyPlist( Obj self, Obj len )
+static Obj    FuncEmptyPlist( Obj self, Obj len )
 {
     RequireNonnegativeSmallInt("EmptyPlist", len);
     return NEW_PLIST(T_PLIST_EMPTY, INT_INTOBJ(len));
@@ -832,7 +832,7 @@ Obj    FuncEmptyPlist( Obj self, Obj len )
 *  Shrinks the bag of <list> to minimal possible size.
 *
 */
-Obj   FuncShrinkAllocationPlist( Obj self, Obj plist )
+static Obj   FuncShrinkAllocationPlist( Obj self, Obj plist )
 {
     RequirePlainList("ShrinkAllocationPlist", plist);
     SHRINK_PLIST(plist, LEN_PLIST(plist));
@@ -843,9 +843,9 @@ Obj   FuncShrinkAllocationPlist( Obj self, Obj plist )
 **
 *F  FuncIS_PLIST_REP( <self>, <obj> ) . . . . . . . .  handler for `IS_PLIST'
 */
-Obj IsPlistFilt;
+static Obj IsPlistFilt;
 
-Obj FuncIS_PLIST_REP (
+static Obj FuncIS_PLIST_REP (
     Obj                 self,
     Obj                 obj )
 {
@@ -856,7 +856,7 @@ Obj FuncIS_PLIST_REP (
 #ifdef USE_THREADSAFE_COPYING
 #ifndef WARD_ENABLED
 
-void TraversePlist(TraversalState * traversal, Obj obj)
+static void TraversePlist(TraversalState * traversal, Obj obj)
 {
     UInt  len = LEN_PLIST(obj);
     const Obj * ptr = CONST_ADDR_OBJ(obj) + 1;
@@ -866,7 +866,7 @@ void TraversePlist(TraversalState * traversal, Obj obj)
     }
 }
 
-void CopyPlist(TraversalState * traversal, Obj copy, Obj original)
+static void CopyPlist(TraversalState * traversal, Obj copy, Obj original)
 {
     UInt  len = LEN_PLIST(original);
     const Obj * ptr = CONST_ADDR_OBJ(original) + 1;
@@ -900,7 +900,7 @@ void CopyPlist(TraversalState * traversal, Obj copy, Obj original)
 **
 **  'CleanPlist' is the function in 'CleanObjFuncs' for plain lists.
 */
-Obj CopyPlist (
+static Obj CopyPlist (
     Obj                 list,
     Int                 mut )
 {
@@ -938,7 +938,7 @@ Obj CopyPlist (
 **
 *F  CleanPlist( <list> )  . . . . . . . . . . .  clean up a copied plain list
 */
-void CleanPlist (
+static void CleanPlist (
     Obj                 list )
 {
     UInt                i;              /* loop variable                   */
@@ -965,7 +965,7 @@ void CleanPlist (
 **
 **  Is called from the 'EQ' binop so both  operands  are  already  evaluated.
 */
-Int             EqPlist (
+static Int             EqPlist (
     Obj                 left,
     Obj                 right )
 {
@@ -1009,7 +1009,7 @@ Int             EqPlist (
 **
 **  Is called from the 'LT' binop so both operands are already evaluated.
 */
-Int             LtPlist (
+static Int             LtPlist (
     Obj                 left,
     Obj                 right )
 {
@@ -1059,13 +1059,13 @@ Int             LtPlist (
 **
 **  'LenPlist' is the function in 'LenListFuncs' for plain lists.
 */
-Int             LenPlist (
+static Int             LenPlist (
     Obj                 list )
 {
     return LEN_PLIST( list );
 }
 
-Int             LenPlistEmpty (
+static Int             LenPlistEmpty (
     Obj                 list )
 {
     return 0L;
@@ -1080,14 +1080,14 @@ Int             LenPlistEmpty (
 **  and 0 otherwise.  It is the responsibility of the caller to  ensure  that
 **  <pos> is a positive integer.
 */
-Int             IsbPlist (
+static Int             IsbPlist (
     Obj                 list,
     Int                 pos )
 {
     return (pos <= LEN_PLIST( list ) && ELM_PLIST( list, pos ) != 0);
 }
 
-Int             IsbPlistDense (
+static Int             IsbPlistDense (
     Obj                 list,
     Int                 pos )
 {
@@ -1108,7 +1108,7 @@ Int             IsbPlistDense (
 **  <pos>  is less  than or  equal   to the length   of  <list>, this is  the
 **  responsibility of the caller.
 */
-Obj             Elm0Plist (
+static Obj             Elm0Plist (
     Obj                 list,
     Int                 pos )
 {
@@ -1120,7 +1120,7 @@ Obj             Elm0Plist (
     }
 }
 
-Obj             Elm0vPlist (
+static Obj             Elm0vPlist (
     Obj                 list,
     Int                 pos )
 {
@@ -1147,7 +1147,7 @@ Obj             Elm0vPlist (
 **  'ElmPlist'   is the   function    in 'ElmListFuncs'   for  plain   lists.
 **  'ElmvPlist' is the function in 'ElmvListFuncs' for plain lists.
 */
-Obj             ElmPlist (
+static Obj             ElmPlist (
     Obj                 list,
     Int                 pos )
 {
@@ -1172,7 +1172,7 @@ Obj             ElmPlist (
     return elm;
 }
 
-Obj             ElmPlistDense (
+static Obj             ElmPlistDense (
     Obj                 list,
     Int                 pos )
 {
@@ -1191,7 +1191,7 @@ Obj             ElmPlistDense (
     return elm;
 }
 
-Obj             ElmvPlist (
+static Obj             ElmvPlist (
     Obj                 list,
     Int                 pos )
 {
@@ -1210,7 +1210,7 @@ Obj             ElmvPlist (
     return elm;
 }
 
-Obj             ElmvPlistDense (
+static Obj             ElmvPlistDense (
     Obj                 list,
     Int                 pos )
 {
@@ -1238,7 +1238,7 @@ Obj             ElmvPlistDense (
 **  'ElmsPlist' is the function in 'ElmsListFuncs' for plain lists which are
 **  not known to be dense.
 */
-Obj             ElmsPlist (
+static Obj             ElmsPlist (
     Obj                 list,
     Obj                 poss )
 {
@@ -1352,7 +1352,7 @@ Obj             ElmsPlist (
 /* This version for lists which are known to be at least dense
    and might be better */
 
-Obj             ElmsPlistDense (
+static Obj             ElmsPlistDense (
     Obj                 list,
     Obj                 poss )
 {
@@ -1516,7 +1516,7 @@ Obj             ElmsPlistDense (
 **
 **  'UnbPlist' is the function in 'UnbListFuncs' for plain lists.
 */
-void UnbPlist (
+static void UnbPlist (
     Obj                 list,
     Int                 pos )
 {
@@ -1573,7 +1573,7 @@ void            AssPlist (
         CHANGED_BAG( list );
 }
 
-void            AssPlistXXX (
+static void            AssPlistXXX (
     Obj                 list,
     Int                 pos,
     Obj                 val )
@@ -1600,7 +1600,7 @@ void            AssPlistXXX (
       SET_FILT_LIST(list, FN_IS_NDENSE);
 }
 
-void AssPlistCyc   (
+static void AssPlistCyc   (
     Obj                 list,
     Int                 pos,
     Obj                 val )
@@ -1703,7 +1703,7 @@ void AssPlistFfe   (
       }
 }
 
-void AssPlistDense (
+static void AssPlistDense (
     Obj                 list,
     Int                 pos,
     Obj                 val )
@@ -1731,7 +1731,7 @@ void AssPlistDense (
         SET_FILT_LIST( list, FN_IS_NDENSE );
 }
 
-void AssPlistHomog (
+static void AssPlistHomog (
     Obj                 list,
     Int                 pos,
     Obj                 val )
@@ -1874,7 +1874,7 @@ void AssPlistEmpty (
 **
 **  'AsssPlist' is the function in 'AsssListFuncs' for plain lists.
 */
-void            AsssPlist (
+static void            AsssPlist (
     Obj                 list,
     Obj                 poss,
     Obj                 vals )
@@ -1962,7 +1962,7 @@ void            AsssPlist (
     }
 }
 
-void            AsssPlistXXX (
+static void            AsssPlistXXX (
     Obj                 list,
     Obj                 poss,
     Obj                 vals )
@@ -1984,7 +1984,7 @@ void            AsssPlistXXX (
 **
 **  'IsDensePlist' is the function in 'IsDenseListFuncs' for plain lists.
 */
-Int             IsDensePlist (
+static Int             IsDensePlist (
     Obj                 list )
 {
     Int                 lenList;        /* length of <list>                */
@@ -2022,7 +2022,7 @@ Int             IsDensePlist (
 **
 **  'IsHomogPlist' is the function in 'IsHomogListFuncs' for plain lists.
 */
-Int             IsHomogPlist (
+static Int             IsHomogPlist (
     Obj                 list )
 {
     Int                 tnum;
@@ -2040,7 +2040,7 @@ Int             IsHomogPlist (
 **
 **  'IsTablePlist' is the function in 'IsTableListFuncs' for plain lists.
 */
-Int             IsTablePlist (
+static Int             IsTablePlist (
     Obj                 list )
 {
     Int                 tnum;
@@ -2059,7 +2059,7 @@ Int             IsTablePlist (
 **  'IsSSortPlist' is the function in 'IsSSortListFuncs' for plain lists.
 */
 
-Int             IsSSortPlist (
+static Int             IsSSortPlist (
     Obj                 list )
 {
     Int                 lenList;
@@ -2146,7 +2146,7 @@ Int             IsSSortPlist (
     return 0L;
 }
 
-Int             IsSSortPlistDense (
+static Int             IsSSortPlistDense (
     Obj                 list )
 {
     Int                 lenList;
@@ -2217,7 +2217,7 @@ Int             IsSSortPlistDense (
 
 }
 
-Int             IsSSortPlistHom (
+static Int             IsSSortPlistHom (
     Obj                 list )
 {
     Int                 lenList;
@@ -2266,7 +2266,7 @@ Int             IsSSortPlistHom (
 }
 
 
-Obj FuncSET_IS_SSORTED_PLIST(Obj self, Obj list)
+static Obj FuncSET_IS_SSORTED_PLIST(Obj self, Obj list)
 {
   SET_FILT_LIST(list, FN_IS_SSORT);
   return (Obj)0;
@@ -2282,7 +2282,7 @@ Obj FuncSET_IS_SSORTED_PLIST(Obj self, Obj list)
 **
 **  'IsPossPlist' is the function in 'IsPossListFuncs' for plain lists.
 */
-Int             IsPossPlist (
+static Int             IsPossPlist (
     Obj                 list )
 {
     Int                 lenList;        /* length of <list>                */
@@ -2326,7 +2326,7 @@ Int             IsPossPlist (
 **
 **  'PosPlist' is the function in 'PosListFuncs' for plain lists.
 */
-Obj             PosPlist (
+static Obj             PosPlist (
     Obj                 list,
     Obj                 val,
     Obj                 start )
@@ -2362,7 +2362,7 @@ Obj             PosPlist (
     return (lenList < i ? Fail : INTOBJ_INT(i));
 }
 
-Obj             PosPlistDense (
+static Obj             PosPlistDense (
     Obj                 list,
     Obj                 val,
     Obj                 start )
@@ -2399,7 +2399,7 @@ Obj             PosPlistDense (
     return (lenList < i ? Fail : INTOBJ_INT(i));
 }
 
-Obj             PosPlistSort (
+static Obj             PosPlistSort (
     Obj                 list,
     Obj                 val,
     Obj                 start )
@@ -2435,7 +2435,7 @@ Obj             PosPlistSort (
 }
 
 
-Obj             PosPlistHomSort (
+static Obj             PosPlistHomSort (
     Obj                 list,
     Obj                 val,
     Obj                 start )
@@ -2457,7 +2457,7 @@ Obj             PosPlistHomSort (
 **
 **  'PlainPlist' is the function in 'PlainListFuncs' for plain lists.
 */
-void            PlainPlist (
+static void            PlainPlist (
     Obj                 list )
 {
     return;
@@ -2469,7 +2469,7 @@ void            PlainPlist (
 **
 */
 
-void SavePlist( Obj list )
+static void SavePlist( Obj list )
 {
   UInt i;
   SaveUInt(LEN_PLIST(list));
@@ -2484,7 +2484,7 @@ void SavePlist( Obj list )
 **
 */
 
-void LoadPlist( Obj list )
+static void LoadPlist( Obj list )
 {
   UInt i;
   SET_LEN_PLIST(list, LoadUInt());
@@ -2498,7 +2498,7 @@ void LoadPlist( Obj list )
 **
 *F  FuncASS_PLIST_DEFAULT( <self>, <plist>, <pos>, <val> )  . . `AssPlistXXX'
 */
-Obj FuncASS_PLIST_DEFAULT (
+static Obj FuncASS_PLIST_DEFAULT (
     Obj                 self,
     Obj                 plist,
     Obj                 pos,
@@ -2527,7 +2527,7 @@ Obj FuncASS_PLIST_DEFAULT (
 **  here)
 */
 
-void MakeImmutablePlistInHom(Obj list)
+static void MakeImmutablePlistInHom(Obj list)
 {
     // change the tnum first, to avoid infinite recursion for objects that
     // contain themselves
@@ -2557,7 +2557,7 @@ void MakeImmutablePlistInHom(Obj list)
 **  here)
 */
 
-void MakeImmutablePlistNoMutElms( Obj list )
+static void MakeImmutablePlistNoMutElms( Obj list )
 {
     MakeImmutableNoRecurse(list);
 }
@@ -2573,7 +2573,7 @@ void MakeImmutablePlistNoMutElms( Obj list )
 **  it is rectangular
 */
 
-Obj FuncIsRectangularTablePlist( Obj self, Obj plist)
+static Obj FuncIsRectangularTablePlist( Obj self, Obj plist)
 {
   Obj len;
   UInt lenlist;

--- a/src/plist.c
+++ b/src/plist.c
@@ -447,8 +447,7 @@ static Int KTNumPlist(Obj list, Obj * famfirst)
 }
 
 
-static Int KTNumHomPlist (
-    Obj                 list)
+static Int KTNumHomPlist(Obj list)
 {
     Int                 isTable = 0;    /* are <list>s elms all lists   */
     Int                 isRect  = 0;    /* are <list>s elms all equal length */
@@ -575,7 +574,7 @@ static Int KTNumHomPlist (
     return res;
 }
 
-static Obj TypePlist( Obj list)
+static Obj TypePlist(Obj list)
 {
   return TypePlistWithKTNum( list, (UInt *) 0);
 }
@@ -819,7 +818,7 @@ Obj             ShallowCopyPlist (
 * Returns an empty plain list, but with space for len entries preallocated.
 *
 */
-static Obj    FuncEmptyPlist( Obj self, Obj len )
+static Obj FuncEmptyPlist(Obj self, Obj len)
 {
     RequireNonnegativeSmallInt("EmptyPlist", len);
     return NEW_PLIST(T_PLIST_EMPTY, INT_INTOBJ(len));
@@ -832,7 +831,7 @@ static Obj    FuncEmptyPlist( Obj self, Obj len )
 *  Shrinks the bag of <list> to minimal possible size.
 *
 */
-static Obj   FuncShrinkAllocationPlist( Obj self, Obj plist )
+static Obj FuncShrinkAllocationPlist(Obj self, Obj plist)
 {
     RequirePlainList("ShrinkAllocationPlist", plist);
     SHRINK_PLIST(plist, LEN_PLIST(plist));
@@ -845,9 +844,7 @@ static Obj   FuncShrinkAllocationPlist( Obj self, Obj plist )
 */
 static Obj IsPlistFilt;
 
-static Obj FuncIS_PLIST_REP (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_PLIST_REP(Obj self, Obj obj)
 {
     return (IS_PLIST( obj ) ? True : False);
 }
@@ -900,9 +897,7 @@ static void CopyPlist(TraversalState * traversal, Obj copy, Obj original)
 **
 **  'CleanPlist' is the function in 'CleanObjFuncs' for plain lists.
 */
-static Obj CopyPlist (
-    Obj                 list,
-    Int                 mut )
+static Obj CopyPlist(Obj list, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
@@ -938,8 +933,7 @@ static Obj CopyPlist (
 **
 *F  CleanPlist( <list> )  . . . . . . . . . . .  clean up a copied plain list
 */
-static void CleanPlist (
-    Obj                 list )
+static void CleanPlist(Obj list)
 {
     UInt                i;              /* loop variable                   */
 
@@ -965,9 +959,7 @@ static void CleanPlist (
 **
 **  Is called from the 'EQ' binop so both  operands  are  already  evaluated.
 */
-static Int             EqPlist (
-    Obj                 left,
-    Obj                 right )
+static Int EqPlist(Obj left, Obj right)
 {
     Int                 lenL;           /* length of the left operand      */
     Int                 lenR;           /* length of the right operand     */
@@ -1009,9 +1001,7 @@ static Int             EqPlist (
 **
 **  Is called from the 'LT' binop so both operands are already evaluated.
 */
-static Int             LtPlist (
-    Obj                 left,
-    Obj                 right )
+static Int LtPlist(Obj left, Obj right)
 {
     Int                 lenL;           /* length of the left operand      */
     Int                 lenR;           /* length of the right operand     */
@@ -1059,14 +1049,12 @@ static Int             LtPlist (
 **
 **  'LenPlist' is the function in 'LenListFuncs' for plain lists.
 */
-static Int             LenPlist (
-    Obj                 list )
+static Int LenPlist(Obj list)
 {
     return LEN_PLIST( list );
 }
 
-static Int             LenPlistEmpty (
-    Obj                 list )
+static Int LenPlistEmpty(Obj list)
 {
     return 0L;
 }
@@ -1080,16 +1068,12 @@ static Int             LenPlistEmpty (
 **  and 0 otherwise.  It is the responsibility of the caller to  ensure  that
 **  <pos> is a positive integer.
 */
-static Int             IsbPlist (
-    Obj                 list,
-    Int                 pos )
+static Int IsbPlist(Obj list, Int pos)
 {
     return (pos <= LEN_PLIST( list ) && ELM_PLIST( list, pos ) != 0);
 }
 
-static Int             IsbPlistDense (
-    Obj                 list,
-    Int                 pos )
+static Int IsbPlistDense(Obj list, Int pos)
 {
     return (pos <= LEN_PLIST( list ));
 }
@@ -1108,9 +1092,7 @@ static Int             IsbPlistDense (
 **  <pos>  is less  than or  equal   to the length   of  <list>, this is  the
 **  responsibility of the caller.
 */
-static Obj             Elm0Plist (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0Plist(Obj list, Int pos)
 {
     if ( pos <= LEN_PLIST( list ) ) {
         return ELM_PLIST( list, pos );
@@ -1120,9 +1102,7 @@ static Obj             Elm0Plist (
     }
 }
 
-static Obj             Elm0vPlist (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0vPlist(Obj list, Int pos)
 {
     return ELM_PLIST( list, pos );
 }
@@ -1147,9 +1127,7 @@ static Obj             Elm0vPlist (
 **  'ElmPlist'   is the   function    in 'ElmListFuncs'   for  plain   lists.
 **  'ElmvPlist' is the function in 'ElmvListFuncs' for plain lists.
 */
-static Obj             ElmPlist (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmPlist(Obj list, Int pos)
 {
     Obj                 elm;            /* the selected element, result    */
 
@@ -1172,9 +1150,7 @@ static Obj             ElmPlist (
     return elm;
 }
 
-static Obj             ElmPlistDense (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmPlistDense(Obj list, Int pos)
 {
     Obj                 elm;            /* the selected element, result    */
 
@@ -1191,9 +1167,7 @@ static Obj             ElmPlistDense (
     return elm;
 }
 
-static Obj             ElmvPlist (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmvPlist(Obj list, Int pos)
 {
     Obj                 elm;            /* the selected element, result    */
 
@@ -1210,9 +1184,7 @@ static Obj             ElmvPlist (
     return elm;
 }
 
-static Obj             ElmvPlistDense (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmvPlistDense(Obj list, Int pos)
 {
     Obj                 elm;            /* the selected element, result    */
 
@@ -1238,9 +1210,7 @@ static Obj             ElmvPlistDense (
 **  'ElmsPlist' is the function in 'ElmsListFuncs' for plain lists which are
 **  not known to be dense.
 */
-static Obj             ElmsPlist (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsPlist(Obj list, Obj poss)
 {
     Obj                 elms;           /* selected sublist, result        */
     Int                 lenList;        /* length of <list>                */
@@ -1352,9 +1322,7 @@ static Obj             ElmsPlist (
 /* This version for lists which are known to be at least dense
    and might be better */
 
-static Obj             ElmsPlistDense (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsPlistDense(Obj list, Obj poss)
 {
     Obj                 elms;           /* selected sublist, result        */
     Int                 lenList;        /* length of <list>                */
@@ -1516,9 +1484,7 @@ static Obj             ElmsPlistDense (
 **
 **  'UnbPlist' is the function in 'UnbListFuncs' for plain lists.
 */
-static void UnbPlist (
-    Obj                 list,
-    Int                 pos )
+static void UnbPlist(Obj list, Int pos)
 {
     /* if <pos> is less than the length, convert to plain list and unbind  */
     if ( pos < LEN_PLIST( list ) ) {
@@ -1573,10 +1539,7 @@ void            AssPlist (
         CHANGED_BAG( list );
 }
 
-static void            AssPlistXXX (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
+static void AssPlistXXX(Obj list, Int pos, Obj val)
 {
   Int len;
 
@@ -1600,10 +1563,7 @@ static void            AssPlistXXX (
       SET_FILT_LIST(list, FN_IS_NDENSE);
 }
 
-static void AssPlistCyc   (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
+static void AssPlistCyc(Obj list, Int pos, Obj val)
 {
   Int len;
 
@@ -1703,10 +1663,7 @@ void AssPlistFfe   (
       }
 }
 
-static void AssPlistDense (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
+static void AssPlistDense(Obj list, Int pos, Obj val)
 {
   Int len;
 
@@ -1731,10 +1688,7 @@ static void AssPlistDense (
         SET_FILT_LIST( list, FN_IS_NDENSE );
 }
 
-static void AssPlistHomog (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
+static void AssPlistHomog(Obj list, Int pos, Obj val)
 {
   Int len;
   Obj fam;
@@ -1874,10 +1828,7 @@ void AssPlistEmpty (
 **
 **  'AsssPlist' is the function in 'AsssListFuncs' for plain lists.
 */
-static void            AsssPlist (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 vals )
+static void AsssPlist(Obj list, Obj poss, Obj vals)
 {
     Int                 lenPoss;        /* length of <positions>           */
     Int                 pos;            /* <position> as integer           */
@@ -1962,10 +1913,7 @@ static void            AsssPlist (
     }
 }
 
-static void            AsssPlistXXX (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 vals )
+static void AsssPlistXXX(Obj list, Obj poss, Obj vals)
 {
     /* the list will probably loose its flags/properties                   */
     CLEAR_FILTS_LIST(list);
@@ -1984,8 +1932,7 @@ static void            AsssPlistXXX (
 **
 **  'IsDensePlist' is the function in 'IsDenseListFuncs' for plain lists.
 */
-static Int             IsDensePlist (
-    Obj                 list )
+static Int IsDensePlist(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Int                 i;              /* loop variable                   */
@@ -2022,8 +1969,7 @@ static Int             IsDensePlist (
 **
 **  'IsHomogPlist' is the function in 'IsHomogListFuncs' for plain lists.
 */
-static Int             IsHomogPlist (
-    Obj                 list )
+static Int IsHomogPlist(Obj list)
 {
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
@@ -2040,8 +1986,7 @@ static Int             IsHomogPlist (
 **
 **  'IsTablePlist' is the function in 'IsTableListFuncs' for plain lists.
 */
-static Int             IsTablePlist (
-    Obj                 list )
+static Int IsTablePlist(Obj list)
 {
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
@@ -2059,8 +2004,7 @@ static Int             IsTablePlist (
 **  'IsSSortPlist' is the function in 'IsSSortListFuncs' for plain lists.
 */
 
-static Int             IsSSortPlist (
-    Obj                 list )
+static Int IsSSortPlist(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2146,8 +2090,7 @@ static Int             IsSSortPlist (
     return 0L;
 }
 
-static Int             IsSSortPlistDense (
-    Obj                 list )
+static Int IsSSortPlistDense(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2217,8 +2160,7 @@ static Int             IsSSortPlistDense (
 
 }
 
-static Int             IsSSortPlistHom (
-    Obj                 list )
+static Int IsSSortPlistHom(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2282,8 +2224,7 @@ static Obj FuncSET_IS_SSORTED_PLIST(Obj self, Obj list)
 **
 **  'IsPossPlist' is the function in 'IsPossListFuncs' for plain lists.
 */
-static Int             IsPossPlist (
-    Obj                 list )
+static Int IsPossPlist(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -2326,10 +2267,7 @@ static Int             IsPossPlist (
 **
 **  'PosPlist' is the function in 'PosListFuncs' for plain lists.
 */
-static Obj             PosPlist (
-    Obj                 list,
-    Obj                 val,
-    Obj                 start )
+static Obj PosPlist(Obj list, Obj val, Obj start)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -2362,10 +2300,7 @@ static Obj             PosPlist (
     return (lenList < i ? Fail : INTOBJ_INT(i));
 }
 
-static Obj             PosPlistDense (
-    Obj                 list,
-    Obj                 val,
-    Obj                 start )
+static Obj PosPlistDense(Obj list, Obj val, Obj start)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -2399,10 +2334,7 @@ static Obj             PosPlistDense (
     return (lenList < i ? Fail : INTOBJ_INT(i));
 }
 
-static Obj             PosPlistSort (
-    Obj                 list,
-    Obj                 val,
-    Obj                 start )
+static Obj PosPlistSort(Obj list, Obj val, Obj start)
 {
     UInt                lenList;        /* logical length of the set       */
     UInt                i, j, k;        /* loop variables                  */
@@ -2435,10 +2367,7 @@ static Obj             PosPlistSort (
 }
 
 
-static Obj             PosPlistHomSort (
-    Obj                 list,
-    Obj                 val,
-    Obj                 start )
+static Obj PosPlistHomSort(Obj list, Obj val, Obj start)
 {
     /* deal with the case which can be decided by the family relationship  */
     if (FAMILY_OBJ(val) != FAMILY_OBJ(ELM_PLIST(list,1)))
@@ -2457,8 +2386,7 @@ static Obj             PosPlistHomSort (
 **
 **  'PlainPlist' is the function in 'PlainListFuncs' for plain lists.
 */
-static void            PlainPlist (
-    Obj                 list )
+static void PlainPlist(Obj list)
 {
     return;
 }
@@ -2469,7 +2397,7 @@ static void            PlainPlist (
 **
 */
 
-static void SavePlist( Obj list )
+static void SavePlist(Obj list)
 {
   UInt i;
   SaveUInt(LEN_PLIST(list));
@@ -2484,7 +2412,7 @@ static void SavePlist( Obj list )
 **
 */
 
-static void LoadPlist( Obj list )
+static void LoadPlist(Obj list)
 {
   UInt i;
   SET_LEN_PLIST(list, LoadUInt());
@@ -2498,11 +2426,7 @@ static void LoadPlist( Obj list )
 **
 *F  FuncASS_PLIST_DEFAULT( <self>, <plist>, <pos>, <val> )  . . `AssPlistXXX'
 */
-static Obj FuncASS_PLIST_DEFAULT (
-    Obj                 self,
-    Obj                 plist,
-    Obj                 pos,
-    Obj                 val )
+static Obj FuncASS_PLIST_DEFAULT(Obj self, Obj plist, Obj pos, Obj val)
 {
     Int                 p;
 
@@ -2557,7 +2481,7 @@ static void MakeImmutablePlistInHom(Obj list)
 **  here)
 */
 
-static void MakeImmutablePlistNoMutElms( Obj list )
+static void MakeImmutablePlistNoMutElms(Obj list)
 {
     MakeImmutableNoRecurse(list);
 }
@@ -2573,7 +2497,7 @@ static void MakeImmutablePlistNoMutElms( Obj list )
 **  it is rectangular
 */
 
-static Obj FuncIsRectangularTablePlist( Obj self, Obj plist)
+static Obj FuncIsRectangularTablePlist(Obj self, Obj plist)
 {
   Obj len;
   UInt lenlist;

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -48,7 +48,7 @@ extern "C" {
 
 #define IMAGEPP(i, ptf, deg) (i <= deg ? ptf[i - 1] : 0)
 
-Obj EmptyPartialPerm;
+static Obj EmptyPartialPerm;
 
 
 static ModuleStateOffset PPermStateOffset = -1;
@@ -349,13 +349,13 @@ static Obj PreImagePPermInt(Obj pt, Obj f)
  * GAP functions for partial perms
  *****************************************************************************/
 
-Obj FuncEmptyPartialPerm(Obj self)
+static Obj FuncEmptyPartialPerm(Obj self)
 {
     return EmptyPartialPerm;
 }
 
 /* method for creating a partial perm */
-Obj FuncDensePartialPermNC(Obj self, Obj img)
+static Obj FuncDensePartialPermNC(Obj self, Obj img)
 {
     GAP_ASSERT(IS_LIST(img));
 
@@ -407,7 +407,7 @@ Obj FuncDensePartialPermNC(Obj self, Obj img)
 }
 
 /* assumes that dom is a set and that img is duplicatefree */
-Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
+static Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
 {
     GAP_ASSERT(IS_LIST(dom));
     GAP_ASSERT(IS_LIST(img));
@@ -473,7 +473,7 @@ Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
 }
 
 /* the degree of pperm is the maximum point where it is defined */
-Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
+static Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
         return INTOBJ_INT(DEG_PPERM2(f));
@@ -487,7 +487,7 @@ Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
 
 /* the codegree of pperm is the maximum point in its image */
 
-Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f)
+static Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
         return INTOBJ_INT(CODEG_PPERM2(f));
@@ -500,7 +500,7 @@ Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f)
 }
 
 /* the rank is the number of points where it is defined */
-Obj FuncRankOfPartialPerm(Obj self, Obj f)
+static Obj FuncRankOfPartialPerm(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
         return INTOBJ_INT(RANK_PPERM2(f));
@@ -513,7 +513,7 @@ Obj FuncRankOfPartialPerm(Obj self, Obj f)
 }
 
 /* domain of a partial perm */
-Obj FuncDOMAIN_PPERM(Obj self, Obj f)
+static Obj FuncDOMAIN_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -529,7 +529,7 @@ Obj FuncDOMAIN_PPERM(Obj self, Obj f)
 }
 
 /* image list of pperm */
-Obj FuncIMAGE_PPERM(Obj self, Obj f)
+static Obj FuncIMAGE_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -585,7 +585,7 @@ Obj FuncIMAGE_PPERM(Obj self, Obj f)
 }
 
 /* image set of partial perm */
-Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
+static Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
         if (IMG_PPERM(f) == NULL) {
@@ -614,7 +614,7 @@ Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
 }
 
 /* preimage under a partial perm */
-Obj FuncPREIMAGE_PPERM_INT(Obj self, Obj f, Obj pt)
+static Obj FuncPREIMAGE_PPERM_INT(Obj self, Obj f, Obj pt)
 {
     return PreImagePPermInt(pt, f);
 }
@@ -638,7 +638,7 @@ static UInt4 * FindImg(UInt n, UInt rank, Obj img)
 }
 
 // the least m, r such that f^m=f^m+r
-Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f)
+static Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -737,7 +737,7 @@ Obj FuncINDEX_PERIOD_PPERM(Obj self, Obj f)
 }
 
 // the least power of <f> which is an idempotent
-Obj FuncSMALLEST_IDEM_POW_PPERM(Obj self, Obj f)
+static Obj FuncSMALLEST_IDEM_POW_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -754,7 +754,7 @@ Obj FuncSMALLEST_IDEM_POW_PPERM(Obj self, Obj f)
 
 /* returns the least list <out> such that for all <i> in [1..degree(f)]
  * there exists <j> in <out> and a pos int <k> such that <j^(f^k)=i>. */
-Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f)
+static Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -837,7 +837,7 @@ Obj FuncCOMPONENT_REPS_PPERM(Obj self, Obj f)
 }
 
 /* the number of components of a partial perm (as a functional digraph) */
-Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f)
+static Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -911,7 +911,7 @@ Obj FuncNR_COMPONENTS_PPERM(Obj self, Obj f)
 }
 
 /* the components of a partial perm (as a functional digraph) */
-Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
+static Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1023,7 +1023,7 @@ Obj FuncCOMPONENTS_PPERM(Obj self, Obj f)
 }
 
 // the points that can be obtained from <pt> by successively applying <f>.
-Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt)
+static Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt)
 {
     GAP_ASSERT(IS_PPERM(f));
     GAP_ASSERT(IS_INTOBJ(pt));
@@ -1073,7 +1073,7 @@ Obj FuncCOMPONENT_PPERM_INT(Obj self, Obj f, Obj pt)
 }
 
 // the fixed points of a partial perm
-Obj FuncFIXED_PTS_PPERM(Obj self, Obj f)
+static Obj FuncFIXED_PTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1140,7 +1140,7 @@ Obj FuncFIXED_PTS_PPERM(Obj self, Obj f)
     return out;
 }
 
-Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f)
+static Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1190,7 +1190,7 @@ Obj FuncNR_FIXED_PTS_PPERM(Obj self, Obj f)
 }
 
 // the moved points of a partial perm
-Obj FuncMOVED_PTS_PPERM(Obj self, Obj f)
+static Obj FuncMOVED_PTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1255,7 +1255,7 @@ Obj FuncMOVED_PTS_PPERM(Obj self, Obj f)
     return out;
 }
 
-Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f)
+static Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1304,7 +1304,7 @@ Obj FuncNR_MOVED_PTS_PPERM(Obj self, Obj f)
     return INTOBJ_INT(nr);
 }
 
-Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f)
+static Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1352,7 +1352,7 @@ Obj FuncLARGEST_MOVED_PT_PPERM(Obj self, Obj f)
     return INTOBJ_INT(0);
 }
 
-Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f)
+static Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1403,7 +1403,7 @@ Obj FuncSMALLEST_MOVED_PT_PPERM(Obj self, Obj f)
 }
 
 // convert a T_PPERM4 with codeg<65536 to a T_PPERM2
-Obj FuncTRIM_PPERM(Obj self, Obj f)
+static Obj FuncTRIM_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1444,13 +1444,13 @@ Int HashFuncForPPerm(Obj f)
                           (int)2 * DEG_PPERM2(f));
 }
 
-Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data)
+static Obj FuncHASH_FUNC_FOR_PPERM(Obj self, Obj f, Obj data)
 {
     return INTOBJ_INT(HashFuncForPPerm(f) % INT_INTOBJ(data) + 1);
 }
 
 // test if a partial perm is an idempotent
-Obj FuncIS_IDEM_PPERM(Obj self, Obj f)
+static Obj FuncIS_IDEM_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1501,7 +1501,7 @@ Obj FuncIS_IDEM_PPERM(Obj self, Obj f)
 }
 
 /* an idempotent partial perm <e> with ker(e)=ker(f) */
-Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
+static Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1548,7 +1548,7 @@ Obj FuncLEFT_ONE_PPERM(Obj self, Obj f)
 }
 
 // an idempotent partial perm <e> with im(e)=im(f)
-Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
+static Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -1599,7 +1599,7 @@ Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
 }
 
 // f<=g if and only if f is a restriction of g
-Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
+static Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
 {
     UInt   def, deg, i, j, rank;
     UInt2 *ptf2, *ptg2;
@@ -1702,7 +1702,7 @@ Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
     return True;
 }
 
-Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
+static Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
 {
     GAP_ASSERT(IS_PPERM(f));
     GAP_ASSERT(IS_PPERM(g));
@@ -1768,7 +1768,7 @@ Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)
 }
 
 // the union of f and g where this defines an injective function
-Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
+static Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
 {
     GAP_ASSERT(IS_PPERM(f));
     GAP_ASSERT(IS_PPERM(g));
@@ -2034,7 +2034,7 @@ Obj FuncJOIN_PPERMS(Obj self, Obj f, Obj g)
     return join;
 }
 
-Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
+static Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
 {
     GAP_ASSERT(IS_PPERM(f));
     GAP_ASSERT(IS_PPERM(g));
@@ -2161,7 +2161,7 @@ Obj FuncMEET_PPERMS(Obj self, Obj f, Obj g)
 }
 
 // restricted partial perm where set is assumed to be a set of positive ints
-Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
+static Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
 {
     GAP_ASSERT(IS_LIST(set));
 
@@ -2227,7 +2227,7 @@ Obj FuncRESTRICTED_PPERM(Obj self, Obj f, Obj set)
 
 // convert a permutation <p> to a partial perm on <set>, which is assumed to
 // be a set of positive integers
-Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
+static Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
 {
     GAP_ASSERT(IS_PERM(p));
     GAP_ASSERT(IS_LIST(set));
@@ -2329,7 +2329,7 @@ Obj FuncAS_PPERM_PERM(Obj self, Obj p, Obj set)
 }
 
 // for a partial perm with equal dom and img
-Obj FuncAS_PERM_PPERM(Obj self, Obj f)
+static Obj FuncAS_PERM_PPERM(Obj self, Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -2374,7 +2374,7 @@ Obj FuncAS_PERM_PPERM(Obj self, Obj f)
 
 // the permutation induced on im(f) by f^-1*g when im(g)=im(f)
 // and dom(f)=dom(g), no checking
-Obj FuncPERM_LEFT_QUO_PPERM_NC(Obj self, Obj f, Obj g)
+static Obj FuncPERM_LEFT_QUO_PPERM_NC(Obj self, Obj f, Obj g)
 {
     GAP_ASSERT(IS_PPERM(f));
     GAP_ASSERT(IS_PPERM(g));
@@ -2439,7 +2439,7 @@ Obj FuncPERM_LEFT_QUO_PPERM_NC(Obj self, Obj f, Obj g)
     return perm;
 }
 
-Obj FuncShortLexLeqPartialPerm(Obj self, Obj f, Obj g)
+static Obj FuncShortLexLeqPartialPerm(Obj self, Obj f, Obj g)
 {
     UInt   rankf, rankg, i, j, k;
     Obj    domf, domg;
@@ -2533,7 +2533,7 @@ Obj FuncShortLexLeqPartialPerm(Obj self, Obj f, Obj g)
     return False;
 }
 
-Obj FuncHAS_DOM_PPERM(Obj self, Obj f)
+static Obj FuncHAS_DOM_PPERM(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
         return (DOM_PPERM(f) == NULL ? False : True);
@@ -2544,7 +2544,7 @@ Obj FuncHAS_DOM_PPERM(Obj self, Obj f)
     return Fail;
 }
 
-Obj FuncHAS_IMG_PPERM(Obj self, Obj f)
+static Obj FuncHAS_IMG_PPERM(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
         return (IMG_PPERM(f) == NULL ? False : True);
@@ -2560,7 +2560,7 @@ Obj FuncHAS_IMG_PPERM(Obj self, Obj f)
 /* GAP kernel functions */
 
 // an idempotent partial perm on the union of the domain and image
-Obj OnePPerm(Obj f)
+static Obj OnePPerm(Obj f)
 {
     GAP_ASSERT(IS_PPERM(f));
 
@@ -2608,7 +2608,7 @@ Obj OnePPerm(Obj f)
 }
 
 /* equality for partial perms */
-Int EqPPerm22(Obj f, Obj g)
+static Int EqPPerm22(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -2643,7 +2643,7 @@ Int EqPPerm22(Obj f, Obj g)
     return 1L;
 }
 
-Int EqPPerm24(Obj f, Obj g)
+static Int EqPPerm24(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -2677,12 +2677,12 @@ Int EqPPerm24(Obj f, Obj g)
     return 1L;
 }
 
-Int EqPPerm42(Obj f, Obj g)
+static Int EqPPerm42(Obj f, Obj g)
 {
     return EqPPerm24(g, f);
 }
 
-Int EqPPerm44(Obj f, Obj g)
+static Int EqPPerm44(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -2717,7 +2717,7 @@ Int EqPPerm44(Obj f, Obj g)
 }
 
 /* less than for partial perms */
-Int LtPPerm22(Obj f, Obj g)
+static Int LtPPerm22(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -2747,7 +2747,7 @@ Int LtPPerm22(Obj f, Obj g)
     return 0L;
 }
 
-Int LtPPerm24(Obj f, Obj g)
+static Int LtPPerm24(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -2777,7 +2777,7 @@ Int LtPPerm24(Obj f, Obj g)
     return 0L;
 }
 
-Int LtPPerm42(Obj f, Obj g)
+static Int LtPPerm42(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -2807,7 +2807,7 @@ Int LtPPerm42(Obj f, Obj g)
     return 0L;
 }
 
-Int LtPPerm44(Obj f, Obj g)
+static Int LtPPerm44(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -2838,7 +2838,7 @@ Int LtPPerm44(Obj f, Obj g)
 }
 
 /* product of partial perm and partial perm */
-Obj ProdPPerm22(Obj f, Obj g)
+static Obj ProdPPerm22(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -2896,7 +2896,7 @@ Obj ProdPPerm22(Obj f, Obj g)
 }
 
 // the product is always pperm2
-Obj ProdPPerm42(Obj f, Obj g)
+static Obj ProdPPerm42(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -2955,7 +2955,7 @@ Obj ProdPPerm42(Obj f, Obj g)
 }
 
 // it is possible that f*g could be represented as a PPERM2
-Obj ProdPPerm44(Obj f, Obj g)
+static Obj ProdPPerm44(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -3019,7 +3019,7 @@ Obj ProdPPerm44(Obj f, Obj g)
 }
 
 // it is possible that f*g could be represented as a PPERM2
-Obj ProdPPerm24(Obj f, Obj g)
+static Obj ProdPPerm24(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -3086,7 +3086,7 @@ Obj ProdPPerm24(Obj f, Obj g)
 }
 
 // compose partial perms and perms
-Obj ProdPPerm2Perm2(Obj f, Obj p)
+static Obj ProdPPerm2Perm2(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
@@ -3180,7 +3180,7 @@ Obj ProdPPerm2Perm2(Obj f, Obj p)
     return fp;
 }
 
-Obj ProdPPerm4Perm4(Obj f, Obj p)
+static Obj ProdPPerm4Perm4(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
@@ -3242,7 +3242,7 @@ Obj ProdPPerm4Perm4(Obj f, Obj p)
     return fp;
 }
 
-Obj ProdPPerm2Perm4(Obj f, Obj p)
+static Obj ProdPPerm2Perm4(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
@@ -3282,7 +3282,7 @@ Obj ProdPPerm2Perm4(Obj f, Obj p)
     return fp;
 }
 
-Obj ProdPPerm4Perm2(Obj f, Obj p)
+static Obj ProdPPerm4Perm2(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
@@ -3322,7 +3322,7 @@ Obj ProdPPerm4Perm2(Obj f, Obj p)
 }
 
 // product of a perm and a partial perm
-Obj ProdPerm2PPerm2(Obj p, Obj f)
+static Obj ProdPerm2PPerm2(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
@@ -3365,7 +3365,7 @@ Obj ProdPerm2PPerm2(Obj p, Obj f)
     return pf;
 }
 
-Obj ProdPerm4PPerm4(Obj p, Obj f)
+static Obj ProdPerm4PPerm4(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
@@ -3408,7 +3408,7 @@ Obj ProdPerm4PPerm4(Obj p, Obj f)
     return pf;
 }
 
-Obj ProdPerm4PPerm2(Obj p, Obj f)
+static Obj ProdPerm4PPerm2(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
@@ -3452,7 +3452,7 @@ Obj ProdPerm4PPerm2(Obj p, Obj f)
     return pf;
 }
 
-Obj ProdPerm2PPerm4(Obj p, Obj f)
+static Obj ProdPerm2PPerm4(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
@@ -3497,7 +3497,7 @@ Obj ProdPerm2PPerm4(Obj p, Obj f)
 }
 
 // the inverse of a partial perm
-Obj InvPPerm2(Obj f)
+static Obj InvPPerm2(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
 
@@ -3550,7 +3550,7 @@ Obj InvPPerm2(Obj f)
     return inv;
 }
 
-Obj InvPPerm4(Obj f)
+static Obj InvPPerm4(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
 
@@ -3604,7 +3604,7 @@ Obj InvPPerm4(Obj f)
 }
 
 // Conjugation: p ^ -1 * f * p
-Obj PowPPerm2Perm2(Obj f, Obj p)
+static Obj PowPPerm2Perm2(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
@@ -3663,7 +3663,7 @@ Obj PowPPerm2Perm2(Obj f, Obj p)
     return conj;
 }
 
-Obj PowPPerm2Perm4(Obj f, Obj p)
+static Obj PowPPerm2Perm4(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
@@ -3712,7 +3712,7 @@ Obj PowPPerm2Perm4(Obj f, Obj p)
     return conj;
 }
 
-Obj PowPPerm4Perm2(Obj f, Obj p)
+static Obj PowPPerm4Perm2(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
@@ -3771,7 +3771,7 @@ Obj PowPPerm4Perm2(Obj f, Obj p)
     return conj;
 }
 
-Obj PowPPerm4Perm4(Obj f, Obj p)
+static Obj PowPPerm4Perm4(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
@@ -3830,7 +3830,7 @@ Obj PowPPerm4Perm4(Obj f, Obj p)
 }
 
 // g ^ -1 * f * g
-Obj PowPPerm22(Obj f, Obj g)
+static Obj PowPPerm22(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -4051,7 +4051,7 @@ Obj PowPPerm22(Obj f, Obj g)
     return conj;
 }
 
-Obj PowPPerm24(Obj f, Obj g)
+static Obj PowPPerm24(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -4273,7 +4273,7 @@ Obj PowPPerm24(Obj f, Obj g)
     return conj;
 }
 
-Obj PowPPerm42(Obj f, Obj g)
+static Obj PowPPerm42(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -4495,7 +4495,7 @@ Obj PowPPerm42(Obj f, Obj g)
     return conj;
 }
 
-Obj PowPPerm44(Obj f, Obj g)
+static Obj PowPPerm44(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -4717,7 +4717,7 @@ Obj PowPPerm44(Obj f, Obj g)
 }
 
 // f*p^-1
-Obj QuoPPerm2Perm2(Obj f, Obj p)
+static Obj QuoPPerm2Perm2(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
@@ -4827,7 +4827,7 @@ Obj QuoPPerm2Perm2(Obj f, Obj p)
     return quo;
 }
 
-Obj QuoPPerm4Perm4(Obj f, Obj p)
+static Obj QuoPPerm4Perm4(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
@@ -4908,7 +4908,7 @@ Obj QuoPPerm4Perm4(Obj f, Obj p)
     return quo;
 }
 
-Obj QuoPPerm2Perm4(Obj f, Obj p)
+static Obj QuoPPerm2Perm4(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
@@ -4970,7 +4970,7 @@ Obj QuoPPerm2Perm4(Obj f, Obj p)
     return quo;
 }
 
-Obj QuoPPerm4Perm2(Obj f, Obj p)
+static Obj QuoPPerm4Perm2(Obj f, Obj p)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
@@ -5028,7 +5028,7 @@ Obj QuoPPerm4Perm2(Obj f, Obj p)
 }
 
 // f*g^-1 for partial perms
-Obj QuoPPerm22(Obj f, Obj g)
+static Obj QuoPPerm22(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -5109,7 +5109,7 @@ Obj QuoPPerm22(Obj f, Obj g)
     return quo;
 }
 
-Obj QuoPPerm24(Obj f, Obj g)
+static Obj QuoPPerm24(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -5197,7 +5197,7 @@ Obj QuoPPerm24(Obj f, Obj g)
     return quo;
 }
 
-Obj QuoPPerm42(Obj f, Obj g)
+static Obj QuoPPerm42(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -5285,7 +5285,7 @@ Obj QuoPPerm42(Obj f, Obj g)
     return quo;
 }
 
-Obj QuoPPerm44(Obj f, Obj g)
+static Obj QuoPPerm44(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -5366,7 +5366,7 @@ Obj QuoPPerm44(Obj f, Obj g)
 }
 
 // i^f
-Obj PowIntPPerm2(Obj i, Obj f)
+static Obj PowIntPPerm2(Obj i, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
 
@@ -5379,7 +5379,7 @@ Obj PowIntPPerm2(Obj i, Obj f)
         IMAGEPP((UInt)INT_INTOBJ(i), ADDR_PPERM2(f), DEG_PPERM2(f)));
 }
 
-Obj PowIntPPerm4(Obj i, Obj f)
+static Obj PowIntPPerm4(Obj i, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
 
@@ -5393,7 +5393,7 @@ Obj PowIntPPerm4(Obj i, Obj f)
 }
 
 // p^-1*f
-Obj LQuoPerm2PPerm2(Obj p, Obj f)
+static Obj LQuoPerm2PPerm2(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
@@ -5477,7 +5477,7 @@ Obj LQuoPerm2PPerm2(Obj p, Obj f)
     return lquo;
 }
 
-Obj LQuoPerm2PPerm4(Obj p, Obj f)
+static Obj LQuoPerm2PPerm4(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
@@ -5561,7 +5561,7 @@ Obj LQuoPerm2PPerm4(Obj p, Obj f)
     return lquo;
 }
 
-Obj LQuoPerm4PPerm2(Obj p, Obj f)
+static Obj LQuoPerm4PPerm2(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
@@ -5646,7 +5646,7 @@ Obj LQuoPerm4PPerm2(Obj p, Obj f)
     return lquo;
 }
 
-Obj LQuoPerm4PPerm4(Obj p, Obj f)
+static Obj LQuoPerm4PPerm4(Obj p, Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
@@ -5731,7 +5731,7 @@ Obj LQuoPerm4PPerm4(Obj p, Obj f)
 }
 
 // f^-1*g
-Obj LQuoPPerm22(Obj f, Obj g)
+static Obj LQuoPPerm22(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -5840,7 +5840,7 @@ Obj LQuoPPerm22(Obj f, Obj g)
     return lquo;
 }
 
-Obj LQuoPPerm24(Obj f, Obj g)
+static Obj LQuoPPerm24(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -5950,7 +5950,7 @@ Obj LQuoPPerm24(Obj f, Obj g)
     return lquo;
 }
 
-Obj LQuoPPerm42(Obj f, Obj g)
+static Obj LQuoPPerm42(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
@@ -6060,7 +6060,7 @@ Obj LQuoPPerm42(Obj f, Obj g)
     return lquo;
 }
 
-Obj LQuoPPerm44(Obj f, Obj g)
+static Obj LQuoPPerm44(Obj f, Obj g)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
@@ -6355,7 +6355,7 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
     return res;
 }
 
-Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
+static Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
 {
     GAP_ASSERT(IS_LIST(set));
     GAP_ASSERT(IS_PPERM(f));
@@ -6429,7 +6429,7 @@ Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
 /* other internal things */
 
 /* Save and load */
-void SavePPerm2(Obj f)
+static void SavePPerm2(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
 
@@ -6441,7 +6441,7 @@ void SavePPerm2(Obj f)
         SaveUInt2(*ptr++);
 }
 
-void LoadPPerm2(Obj f)
+static void LoadPPerm2(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
 
@@ -6453,7 +6453,7 @@ void LoadPPerm2(Obj f)
         *ptr++ = LoadUInt2();
 }
 
-void SavePPerm4(Obj f)
+static void SavePPerm4(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
 
@@ -6465,7 +6465,7 @@ void SavePPerm4(Obj f)
         SaveUInt4(*ptr++);
 }
 
-void LoadPPerm4(Obj f)
+static void LoadPPerm4(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
 
@@ -6477,25 +6477,25 @@ void LoadPPerm4(Obj f)
         *ptr++ = LoadUInt4();
 }
 
-Obj TYPE_PPERM2;
+static Obj TYPE_PPERM2;
 
-Obj TypePPerm2(Obj f)
+static Obj TypePPerm2(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
     return TYPE_PPERM2;
 }
 
-Obj TYPE_PPERM4;
+static Obj TYPE_PPERM4;
 
-Obj TypePPerm4(Obj f)
+static Obj TypePPerm4(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
     return TYPE_PPERM4;
 }
 
-Obj IsPPermFilt;
+static Obj IsPPermFilt;
 
-Obj IsPPermHandler(Obj self, Obj val)
+static Obj IsPPermHandler(Obj self, Obj val)
 {
     /* return 'true' if <val> is a partial perm and 'false' otherwise       */
     if (TNUM_OBJ(val) == T_PPERM2 || TNUM_OBJ(val) == T_PPERM4) {

--- a/src/precord.c
+++ b/src/precord.c
@@ -60,10 +60,10 @@
 **
 **  'TypePRec' is the function in 'TypeObjFuncs' for plain records.
 */
-Obj TYPE_PREC_MUTABLE;
-Obj TYPE_PREC_IMMUTABLE;
+static Obj TYPE_PREC_MUTABLE;
+static Obj TYPE_PREC_IMMUTABLE;
 
-Obj TypePRec(Obj prec)
+static Obj TypePRec(Obj prec)
 {
     return IS_MUTABLE_OBJ(prec) ? TYPE_PREC_MUTABLE : TYPE_PREC_IMMUTABLE;
 }
@@ -73,7 +73,7 @@ Obj TypePRec(Obj prec)
 *F  SetTypePRecToComObj( <rec>, <kind> )  convert record to component object
 **
 */
-void SetTypePRecToComObj( Obj rec, Obj kind )
+static void SetTypePRecToComObj( Obj rec, Obj kind )
 {
     RetypeBag(rec, T_COMOBJ);
     SET_TYPE_COMOBJ(rec, kind);
@@ -100,7 +100,7 @@ Obj NEW_PREC(UInt len)
 **
 **  Returns 0 if nothing changed and 1 if enlarged.
 */
-Int             GrowPRec (
+static Int             GrowPRec (
     Obj                 rec,
     UInt                need )
 {
@@ -164,7 +164,7 @@ void CopyPRecord(TraversalState * traversal, Obj copy, Obj original)
 **
 **  'CleanPRec' is the function in 'TabCleanObj' for records.
 */
-Obj CopyPRec (
+static Obj CopyPRec (
     Obj                 rec,
     Int                 mut )
 {
@@ -198,7 +198,7 @@ Obj CopyPRec (
     return copy;
 }
 
-void CleanPRec (
+static void CleanPRec (
     Obj                 rec )
 {
     UInt                i;              /* loop variable                   */
@@ -217,7 +217,7 @@ void CleanPRec (
 *F  MakeImmutablePRec( <rec> )
 */
 
-void MakeImmutablePRec(Obj rec)
+static void MakeImmutablePRec(Obj rec)
 {
     // change the tnum first, to avoid infinite recursion for objects that
     // contain themselves
@@ -431,7 +431,7 @@ void AssPRec (
 */
 extern Obj PrintObjOper;
 
-void PrintPRec (
+static void PrintPRec (
     Obj                 rec )
 {
     DoOperation1Args( PrintObjOper, rec );
@@ -564,7 +564,7 @@ void SortPRecRNam (
 */
 
 
-void PrintPathPRec (
+static void PrintPathPRec (
     Obj                 rec,
     Int                 indx )
 {
@@ -582,7 +582,7 @@ void PrintPathPRec (
 **  'RecNames'  returns a list containing the  names of the components of the
 **  record <rec> as strings.
 */
-Obj InnerRecNames( Obj rec )
+static Obj InnerRecNames( Obj rec )
 {
     Obj                 list;           /* list of record names, result    */
     UInt                rnam;           /* one name of record              */
@@ -609,7 +609,7 @@ Obj InnerRecNames( Obj rec )
     return list;
 }
 
-Obj FuncREC_NAMES (
+static Obj FuncREC_NAMES (
     Obj                 self,
     Obj                 rec )
 {
@@ -633,7 +633,7 @@ Obj FuncREC_NAMES (
 *F  FuncREC_NAMES_COMOBJ( <self>, <rec> ) . . . record names of a record object
 */
 /* same as FuncREC_NAMES except for different argument check  */
-Obj FuncREC_NAMES_COMOBJ (
+static Obj FuncREC_NAMES_COMOBJ (
     Obj                 self,
     Obj                 rec )
 {
@@ -659,7 +659,7 @@ Obj FuncREC_NAMES_COMOBJ (
 **  'EqPRec' returns '1L'  if the two  operands <left> and <right> are equal
 **  and '0L' otherwise.  At least one operand must be a plain record.
 */
-Int EqPRec(Obj left, Obj right)
+static Int EqPRec(Obj left, Obj right)
 {
     UInt                i;              /* loop variable                   */
 
@@ -707,7 +707,7 @@ Int EqPRec(Obj left, Obj right)
 **  <right>, and '0L'  otherwise.  At least  one operand  must be a  plain
 **  record.
 */
-Int LtPRec(Obj left, Obj right)
+static Int LtPRec(Obj left, Obj right)
 {
     UInt                i;              /* loop variable                   */
     Int                 res;            /* result of comparison            */
@@ -763,7 +763,7 @@ Int LtPRec(Obj left, Obj right)
 **
 */
 
-void SavePRec( Obj prec )
+static void SavePRec( Obj prec )
 {
   UInt len,i;
   len = LEN_PREC(prec);
@@ -781,7 +781,7 @@ void SavePRec( Obj prec )
 **
 */
 
-void LoadPRec( Obj prec )
+static void LoadPRec( Obj prec )
 {
   UInt len,i;
   len = LoadUInt();

--- a/src/precord.c
+++ b/src/precord.c
@@ -73,7 +73,7 @@ static Obj TypePRec(Obj prec)
 *F  SetTypePRecToComObj( <rec>, <kind> )  convert record to component object
 **
 */
-static void SetTypePRecToComObj( Obj rec, Obj kind )
+static void SetTypePRecToComObj(Obj rec, Obj kind)
 {
     RetypeBag(rec, T_COMOBJ);
     SET_TYPE_COMOBJ(rec, kind);
@@ -100,9 +100,7 @@ Obj NEW_PREC(UInt len)
 **
 **  Returns 0 if nothing changed and 1 if enlarged.
 */
-static Int             GrowPRec (
-    Obj                 rec,
-    UInt                need )
+static Int GrowPRec(Obj rec, UInt need)
 {
     UInt                newsize, want, good;
 
@@ -164,9 +162,7 @@ void CopyPRecord(TraversalState * traversal, Obj copy, Obj original)
 **
 **  'CleanPRec' is the function in 'TabCleanObj' for records.
 */
-static Obj CopyPRec (
-    Obj                 rec,
-    Int                 mut )
+static Obj CopyPRec(Obj rec, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
@@ -198,8 +194,7 @@ static Obj CopyPRec (
     return copy;
 }
 
-static void CleanPRec (
-    Obj                 rec )
+static void CleanPRec(Obj rec)
 {
     UInt                i;              /* loop variable                   */
 
@@ -431,8 +426,7 @@ void AssPRec (
 */
 extern Obj PrintObjOper;
 
-static void PrintPRec (
-    Obj                 rec )
+static void PrintPRec(Obj rec)
 {
     DoOperation1Args( PrintObjOper, rec );
 }
@@ -564,9 +558,7 @@ void SortPRecRNam (
 */
 
 
-static void PrintPathPRec (
-    Obj                 rec,
-    Int                 indx )
+static void PrintPathPRec(Obj rec, Int indx)
 {
     Pr( ".%H", (Int)NAME_RNAM( labs((Int)(GET_RNAM_PREC(rec,indx))) ), 0L );
 }
@@ -582,7 +574,7 @@ static void PrintPathPRec (
 **  'RecNames'  returns a list containing the  names of the components of the
 **  record <rec> as strings.
 */
-static Obj InnerRecNames( Obj rec )
+static Obj InnerRecNames(Obj rec)
 {
     Obj                 list;           /* list of record names, result    */
     UInt                rnam;           /* one name of record              */
@@ -609,9 +601,7 @@ static Obj InnerRecNames( Obj rec )
     return list;
 }
 
-static Obj FuncREC_NAMES (
-    Obj                 self,
-    Obj                 rec )
+static Obj FuncREC_NAMES(Obj self, Obj rec)
 {
     /* check the argument                                                  */
     if (IS_PREC(rec)) {
@@ -633,9 +623,7 @@ static Obj FuncREC_NAMES (
 *F  FuncREC_NAMES_COMOBJ( <self>, <rec> ) . . . record names of a record object
 */
 /* same as FuncREC_NAMES except for different argument check  */
-static Obj FuncREC_NAMES_COMOBJ (
-    Obj                 self,
-    Obj                 rec )
+static Obj FuncREC_NAMES_COMOBJ(Obj self, Obj rec)
 {
     /* check the argument                                                  */
     switch (TNUM_OBJ(rec)) {
@@ -763,7 +751,7 @@ static Int LtPRec(Obj left, Obj right)
 **
 */
 
-static void SavePRec( Obj prec )
+static void SavePRec(Obj prec)
 {
   UInt len,i;
   len = LEN_PREC(prec);
@@ -781,7 +769,7 @@ static void SavePRec( Obj prec )
 **
 */
 
-static void LoadPRec( Obj prec )
+static void LoadPRec(Obj prec)
 {
   UInt len,i;
   len = LoadUInt();

--- a/src/profile.c
+++ b/src/profile.c
@@ -597,7 +597,8 @@ struct InterpreterHooks profileHooks = { visitStat,
                                          "line-by-line profiling" };
 
 
-static void enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
+static void
+enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
 {
     if(profileState_Active) {
         Panic("-P or -C can only be passed once\n");
@@ -660,11 +661,11 @@ Int enableMemoryProfilingAtStartup(Char ** argv, void * dummy)
 }
 
 static Obj FuncACTIVATE_PROFILING(Obj self,
-                           Obj filename, /* filename to write to */
-                           Obj coverage,
-                           Obj wallTime,
-                           Obj recordMem,
-                           Obj resolution)
+                                  Obj filename, /* filename to write to */
+                                  Obj coverage,
+                                  Obj wallTime,
+                                  Obj recordMem,
+                                  Obj resolution)
 {
     if(profileState_Active) {
       return Fail;
@@ -759,8 +760,7 @@ static Obj FuncACTIVATE_PROFILING(Obj self,
     return True;
 }
 
-static Obj FuncDEACTIVATE_PROFILING (
-    Obj                 self)
+static Obj FuncDEACTIVATE_PROFILING(Obj self)
 {
   HashLock(&profileState);
 
@@ -779,8 +779,7 @@ static Obj FuncDEACTIVATE_PROFILING (
   return True;
 }
 
-static Obj FuncIsLineByLineProfileActive (
-    Obj self)
+static Obj FuncIsLineByLineProfileActive(Obj self)
 {
   if(profileState_Active) {
     return True;

--- a/src/profile.c
+++ b/src/profile.c
@@ -105,7 +105,7 @@
 ** Store the current state of the profiler
 */
 
-Obj OutputtedFilenameList;
+static Obj OutputtedFilenameList;
 
 struct StatementLocation
 {
@@ -163,11 +163,11 @@ struct ProfileState
 } profileState;
 
 /* We keep this seperate as it is exported for use in other files */
-UInt profileState_Active;
+static UInt profileState_Active;
 
 
 // Output information about how this profile was configured
-void outputVersionInfo(void)
+static void outputVersionInfo(void)
 {
     const char timeTypeNames[3][10] = { "WallTime", "CPUTime", "Memory" };
     fprintf(profileState.Stream,
@@ -239,7 +239,7 @@ static inline UInt getFilenameIdOfCurrentFunction(void)
 }
 
 
-void HookedLineOutput(Obj func, char type)
+static void HookedLineOutput(Obj func, char type)
 {
   HashLock(&profileState);
   if(profileState_Active && profileState.OutputRepeats)
@@ -277,7 +277,7 @@ void HookedLineOutput(Obj func, char type)
   HashUnlock(&profileState);
 }
 
-void enterFunction(Obj func)
+static void enterFunction(Obj func)
 {
 #ifdef HPCGAP
     if (profileState.profiledThread != TLS(threadID))
@@ -288,7 +288,7 @@ void enterFunction(Obj func)
     HookedLineOutput(func, 'I');
 }
 
-void leaveFunction(Obj func)
+static void leaveFunction(Obj func)
 {
 #ifdef HPCGAP
     if (profileState.profiledThread != TLS(threadID))
@@ -524,7 +524,7 @@ static inline void outputInterpretedStat(Int file, Int line, Int exec)
     printOutput(line, file, exec, 0);
 }
 
-void visitStat(Stat stat)
+static void visitStat(Stat stat)
 {
 #ifdef HPCGAP
   if (profileState.profiledThread != TLS(threadID))
@@ -544,7 +544,7 @@ void visitStat(Stat stat)
   }
 }
 
-void visitInterpretedStat(Int file, Int line)
+static void visitInterpretedStat(Int file, Int line)
 {
 #ifdef HPCGAP
     if (profileState.profiledThread != TLS(threadID))
@@ -565,7 +565,7 @@ void visitInterpretedStat(Int file, Int line)
 ** check we executed something on those lines!
 **/
 
-void registerStat(Stat stat)
+static void registerStat(Stat stat)
 {
     int active;
     HashLock(&profileState);
@@ -576,7 +576,7 @@ void registerStat(Stat stat)
     HashUnlock(&profileState);
 }
 
-void registerInterpretedStat(Int file, Int line)
+static void registerInterpretedStat(Int file, Int line)
 {
     int active;
     HashLock(&profileState);
@@ -597,7 +597,7 @@ struct InterpreterHooks profileHooks = { visitStat,
                                          "line-by-line profiling" };
 
 
-void enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
+static void enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
 {
     if(profileState_Active) {
         Panic("-P or -C can only be passed once\n");
@@ -659,7 +659,7 @@ Int enableMemoryProfilingAtStartup(Char ** argv, void * dummy)
     return 1;
 }
 
-Obj FuncACTIVATE_PROFILING(Obj self,
+static Obj FuncACTIVATE_PROFILING(Obj self,
                            Obj filename, /* filename to write to */
                            Obj coverage,
                            Obj wallTime,
@@ -759,7 +759,7 @@ Obj FuncACTIVATE_PROFILING(Obj self,
     return True;
 }
 
-Obj FuncDEACTIVATE_PROFILING (
+static Obj FuncDEACTIVATE_PROFILING (
     Obj                 self)
 {
   HashLock(&profileState);
@@ -779,7 +779,7 @@ Obj FuncDEACTIVATE_PROFILING (
   return True;
 }
 
-Obj FuncIsLineByLineProfileActive (
+static Obj FuncIsLineByLineProfileActive (
     Obj self)
 {
   if(profileState_Active) {
@@ -797,7 +797,7 @@ Obj FuncIsLineByLineProfileActive (
 ** as being executed.
 */
 
-Int CurrentColour = 0;
+static Int CurrentColour = 0;
 
 static void setColour(void)
 {
@@ -812,7 +812,7 @@ static void setColour(void)
   }
 }
 
-void ProfilePrintStatPassthrough(Stat stat)
+static void ProfilePrintStatPassthrough(Stat stat)
 {
   Int SavedColour = CurrentColour;
   if(VISITED_STAT(stat)) {
@@ -827,7 +827,7 @@ void ProfilePrintStatPassthrough(Stat stat)
   setColour();
 }
 
-void ProfilePrintExprPassthrough(Expr stat)
+static void ProfilePrintExprPassthrough(Expr stat)
 {
   Int SavedColour = -1;
   /* There are two cases we must pass through without touching */
@@ -854,7 +854,7 @@ void ProfilePrintExprPassthrough(Expr stat)
 struct PrintHooks profilePrintHooks =
   {ProfilePrintStatPassthrough, ProfilePrintExprPassthrough};
 
-Obj activate_colored_output_from_profile(void)
+static Obj activate_colored_output_from_profile(void)
 {
     HashLock(&profileState);
 
@@ -874,7 +874,7 @@ Obj activate_colored_output_from_profile(void)
     return True;
 }
 
-Obj deactivate_colored_output_from_profile(void)
+static Obj deactivate_colored_output_from_profile(void)
 {
   HashLock(&profileState);
 
@@ -894,7 +894,7 @@ Obj deactivate_colored_output_from_profile(void)
   return True;
 }
 
-Obj FuncACTIVATE_COLOR_PROFILING(Obj self, Obj arg)
+static Obj FuncACTIVATE_COLOR_PROFILING(Obj self, Obj arg)
 {
   if(arg == True)
   {

--- a/src/range.c
+++ b/src/range.c
@@ -113,9 +113,7 @@ static Obj TypeRangeSSort(Obj list)
 **
 **  'CopyRange' is the function in 'CopyObjFuncs' for ranges.
 */
-static Obj CopyRange (
-    Obj                 list,
-    Int                 mut )
+static Obj CopyRange(Obj list, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
 
@@ -150,8 +148,7 @@ static Obj CopyRange (
 **
 **  'PrintRange' handles bags of type 'T_RANGE'.
 */
-static void            PrintRange (
-    Obj                 list )
+static void PrintRange(Obj list)
 {
     Pr( "%2>[ %2>%d",   
        GET_LOW_RANGE(list), 0L );
@@ -171,9 +168,7 @@ static void            PrintRange (
 **  'EqRange' returns 'true' if the two ranges <listL>  and <listR> are equal
 **  and 'false' otherwise.
 */
-static Int             EqRange (
-    Obj                 listL,
-    Obj                 listR )
+static Int EqRange(Obj listL, Obj listR)
 {
     return ( GET_LEN_RANGE(listL) == GET_LEN_RANGE(listR)
           && GET_LOW_RANGE(listL) == GET_LOW_RANGE(listR)
@@ -188,9 +183,7 @@ static Int             EqRange (
 **  'LtRange' returns 'true'  if  the range  <listL> is less  than the  range
 **  <listR> and 'false' otherwise.
 */
-static Int             LtRange (
-    Obj                 listL,
-    Obj                 listR )
+static Int LtRange(Obj listL, Obj listR)
 {
     /* first compare the first elements                                    */
     if ( GET_LOW_RANGE(listL) < GET_LOW_RANGE(listR) )
@@ -223,8 +216,7 @@ static Int             LtRange (
 **
 **  'LenRange' is the function in 'LenListFuncs' for ranges.
 */
-static Int             LenRange (
-    Obj                 list )
+static Int LenRange(Obj list)
 {
     return GET_LEN_RANGE( list );
 }
@@ -240,9 +232,7 @@ static Int             LenRange (
 **
 **  'IsbRange' is the function in 'IsbListFuncs' for ranges.
 */
-static Int             IsbRange (
-    Obj                 list,
-    Int                 pos )
+static Int IsbRange(Obj list, Int pos)
 {
     return (pos <= GET_LEN_RANGE(list));
 }
@@ -261,9 +251,7 @@ static Int             IsbRange (
 **  that <pos> is  less than or  equal to the  length of <list>, this is  the
 **  responsibility of the caller.
 */
-static Obj             Elm0Range (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0Range(Obj list, Int pos)
 {
     if ( pos <= GET_LEN_RANGE( list ) ) {
         return GET_ELM_RANGE( list, pos );
@@ -273,9 +261,7 @@ static Obj             Elm0Range (
     }
 }
 
-static Obj             Elm0vRange (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0vRange(Obj list, Int pos)
 {
     return GET_ELM_RANGE( list, pos );
 }
@@ -297,9 +283,7 @@ static Obj             Elm0vRange (
 **  'ElmRange' is the function in  'ElmListFuncs' for ranges.  'ElmvRange' is
 **  the function in 'ElmvListFuncs' for ranges.
 */
-static Obj             ElmRange (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmRange(Obj list, Int pos)
 {
     /* check the position                                                  */
     if ( GET_LEN_RANGE( list ) < pos ) {
@@ -311,9 +295,7 @@ static Obj             ElmRange (
     return GET_ELM_RANGE( list, pos );
 }
 
-static Obj             ElmvRange (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmvRange(Obj list, Int pos)
 {
     return GET_ELM_RANGE( list, pos );
 }
@@ -331,9 +313,7 @@ static Obj             ElmvRange (
 **
 **  'ElmsRange' is the function in 'ElmsListFuncs' for ranges.
 */
-static Obj             ElmsRange (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsRange(Obj list, Obj poss)
 {
     Obj                 elms;           /* selected sublist, result        */
     Int                 lenList;        /* length of <list>                */
@@ -438,10 +418,7 @@ static Obj             ElmsRange (
 **  same stuff as 'AssPlist'.  This is because a  range is not very likely to
 **  stay a range after the assignment.
 */
-static void            AssRange (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
+static void AssRange(Obj list, Int pos, Obj val)
 {
     /* convert the range into a plain list                                 */
     PLAIN_LIST( list );
@@ -475,10 +452,7 @@ static void            AssRange (
 **  same stuff as 'AsssPlist'.  This is because a range is not very likely to
 **  stay a range after the assignment.
 */
-static void            AsssRange (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 vals )
+static void AsssRange(Obj list, Obj poss, Obj vals)
 {
     /* convert <list> to a plain list                                      */
     PLAIN_LIST( list );
@@ -498,8 +472,7 @@ static void            AsssRange (
 **
 **  'IsPossRange' is the function in 'IsPossListFuncs' for ranges.
 */
-static Int             IsPossRange (
-    Obj                 list )
+static Int IsPossRange(Obj list)
 {
     /* test if the first element is positive                               */
     if ( GET_LOW_RANGE( list ) <= 0 )
@@ -583,8 +556,7 @@ Obj             PosRange (
 **
 **  'PlainRange' is the function in 'PlainListFuncs' for ranges.
 */
-static void            PlainRange (
-    Obj                 list )
+static void PlainRange(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Int                 low;            /* first element of <list>         */
@@ -618,8 +590,7 @@ static void            PlainRange (
 */
 static Obj IsRangeFilt;
 
-static Int             IsRange (
-    Obj                 list )
+static Int IsRange(Obj list)
 {
     Int                 isRange;        /* result of the test              */
     Int                 len;            /* logical length of list          */
@@ -707,9 +678,7 @@ static Int             IsRange (
 **  a range and 'false' otherwise.  A range is a list without holes such that
 **  the elements are  consecutive integers.
 */
-static Obj FuncIS_RANGE (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_RANGE(Obj self, Obj obj)
 {
     /* let 'IsRange' do the work for lists                                 */
     return IsRange(obj) ? True : False;
@@ -722,7 +691,7 @@ static Obj FuncIS_RANGE (
 **
 */
 
-static void SaveRange( Obj range )
+static void SaveRange(Obj range)
 {
   SaveSubObj(CONST_ADDR_OBJ(range)[0]); /* length */
   SaveSubObj(CONST_ADDR_OBJ(range)[1]); /* base */
@@ -735,7 +704,7 @@ static void SaveRange( Obj range )
 **
 */
 
-static void LoadRange( Obj range )
+static void LoadRange(Obj range)
 {
   ADDR_OBJ(range)[0] = LoadSubObj(); /* length */
   ADDR_OBJ(range)[1] = LoadSubObj(); /* base */
@@ -828,9 +797,7 @@ Obj Range3Check (
 */
 static Obj IsRangeRepFilt;
 
-static Obj FuncIS_RANGE_REP (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_RANGE_REP(Obj self, Obj obj)
 {
     return (IS_RANGE( obj ) ? True : False);
 }
@@ -841,7 +808,7 @@ static Obj FuncIS_RANGE_REP (
 **
 */
 
-static void MakeImmutableRange( Obj range )
+static void MakeImmutableRange(Obj range)
 {
     MakeImmutableNoRecurse(range);
 }
@@ -866,7 +833,7 @@ static Int egcd (Int a, Int b, Int *lastx, Int *lasty)
   return a;
 } /* returns g=gcd(a,b), with lastx*a+lasty*b = g */
 
-static Obj FuncINTER_RANGE( Obj self, Obj r1, Obj r2)
+static Obj FuncINTER_RANGE(Obj self, Obj r1, Obj r2)
 {
   Int low1, low2, inc1, inc2, lowi, inci, g, x, y;
   UInt len1, len2, leni;

--- a/src/range.c
+++ b/src/range.c
@@ -70,10 +70,10 @@
 **  'TypeRangeNSort' is the  function in 'TypeObjFuncs' for ranges which are
 **  not strictly sorted.
 */
-Obj TYPE_RANGE_NSORT_IMMUTABLE;
-Obj TYPE_RANGE_NSORT_MUTABLE;
+static Obj TYPE_RANGE_NSORT_IMMUTABLE;
+static Obj TYPE_RANGE_NSORT_MUTABLE;
 
-Obj TypeRangeNSort(Obj list)
+static Obj TypeRangeNSort(Obj list)
 {
     return IS_MUTABLE_OBJ(list) ? TYPE_RANGE_NSORT_MUTABLE
                                 : TYPE_RANGE_NSORT_IMMUTABLE;
@@ -87,10 +87,10 @@ Obj TypeRangeNSort(Obj list)
 **  'TypeRangeSSort' is the function in 'TypeObjFuncs' for ranges which are
 **  strictly sorted.
 */
-Obj TYPE_RANGE_SSORT_IMMUTABLE;
-Obj TYPE_RANGE_SSORT_MUTABLE;
+static Obj TYPE_RANGE_SSORT_IMMUTABLE;
+static Obj TYPE_RANGE_SSORT_MUTABLE;
 
-Obj TypeRangeSSort(Obj list)
+static Obj TypeRangeSSort(Obj list)
 {
     return IS_MUTABLE_OBJ(list) ? TYPE_RANGE_SSORT_MUTABLE
                                 : TYPE_RANGE_SSORT_IMMUTABLE;
@@ -113,7 +113,7 @@ Obj TypeRangeSSort(Obj list)
 **
 **  'CopyRange' is the function in 'CopyObjFuncs' for ranges.
 */
-Obj CopyRange (
+static Obj CopyRange (
     Obj                 list,
     Int                 mut )
 {
@@ -150,7 +150,7 @@ Obj CopyRange (
 **
 **  'PrintRange' handles bags of type 'T_RANGE'.
 */
-void            PrintRange (
+static void            PrintRange (
     Obj                 list )
 {
     Pr( "%2>[ %2>%d",   
@@ -171,7 +171,7 @@ void            PrintRange (
 **  'EqRange' returns 'true' if the two ranges <listL>  and <listR> are equal
 **  and 'false' otherwise.
 */
-Int             EqRange (
+static Int             EqRange (
     Obj                 listL,
     Obj                 listR )
 {
@@ -188,7 +188,7 @@ Int             EqRange (
 **  'LtRange' returns 'true'  if  the range  <listL> is less  than the  range
 **  <listR> and 'false' otherwise.
 */
-Int             LtRange (
+static Int             LtRange (
     Obj                 listL,
     Obj                 listR )
 {
@@ -223,7 +223,7 @@ Int             LtRange (
 **
 **  'LenRange' is the function in 'LenListFuncs' for ranges.
 */
-Int             LenRange (
+static Int             LenRange (
     Obj                 list )
 {
     return GET_LEN_RANGE( list );
@@ -240,7 +240,7 @@ Int             LenRange (
 **
 **  'IsbRange' is the function in 'IsbListFuncs' for ranges.
 */
-Int             IsbRange (
+static Int             IsbRange (
     Obj                 list,
     Int                 pos )
 {
@@ -261,7 +261,7 @@ Int             IsbRange (
 **  that <pos> is  less than or  equal to the  length of <list>, this is  the
 **  responsibility of the caller.
 */
-Obj             Elm0Range (
+static Obj             Elm0Range (
     Obj                 list,
     Int                 pos )
 {
@@ -273,7 +273,7 @@ Obj             Elm0Range (
     }
 }
 
-Obj             Elm0vRange (
+static Obj             Elm0vRange (
     Obj                 list,
     Int                 pos )
 {
@@ -297,7 +297,7 @@ Obj             Elm0vRange (
 **  'ElmRange' is the function in  'ElmListFuncs' for ranges.  'ElmvRange' is
 **  the function in 'ElmvListFuncs' for ranges.
 */
-Obj             ElmRange (
+static Obj             ElmRange (
     Obj                 list,
     Int                 pos )
 {
@@ -311,7 +311,7 @@ Obj             ElmRange (
     return GET_ELM_RANGE( list, pos );
 }
 
-Obj             ElmvRange (
+static Obj             ElmvRange (
     Obj                 list,
     Int                 pos )
 {
@@ -331,7 +331,7 @@ Obj             ElmvRange (
 **
 **  'ElmsRange' is the function in 'ElmsListFuncs' for ranges.
 */
-Obj             ElmsRange (
+static Obj             ElmsRange (
     Obj                 list,
     Obj                 poss )
 {
@@ -438,7 +438,7 @@ Obj             ElmsRange (
 **  same stuff as 'AssPlist'.  This is because a  range is not very likely to
 **  stay a range after the assignment.
 */
-void            AssRange (
+static void            AssRange (
     Obj                 list,
     Int                 pos,
     Obj                 val )
@@ -475,7 +475,7 @@ void            AssRange (
 **  same stuff as 'AsssPlist'.  This is because a range is not very likely to
 **  stay a range after the assignment.
 */
-void            AsssRange (
+static void            AsssRange (
     Obj                 list,
     Obj                 poss,
     Obj                 vals )
@@ -498,7 +498,7 @@ void            AsssRange (
 **
 **  'IsPossRange' is the function in 'IsPossListFuncs' for ranges.
 */
-Int             IsPossRange (
+static Int             IsPossRange (
     Obj                 list )
 {
     /* test if the first element is positive                               */
@@ -583,7 +583,7 @@ Obj             PosRange (
 **
 **  'PlainRange' is the function in 'PlainListFuncs' for ranges.
 */
-void            PlainRange (
+static void            PlainRange (
     Obj                 list )
 {
     Int                 lenList;        /* length of <list>                */
@@ -616,9 +616,9 @@ void            PlainRange (
 **  otherwise.  As a  side effect 'IsRange' converts proper ranges represented
 **  the ordinary way to the compact representation.
 */
-Obj IsRangeFilt;
+static Obj IsRangeFilt;
 
-Int             IsRange (
+static Int             IsRange (
     Obj                 list )
 {
     Int                 isRange;        /* result of the test              */
@@ -707,7 +707,7 @@ Int             IsRange (
 **  a range and 'false' otherwise.  A range is a list without holes such that
 **  the elements are  consecutive integers.
 */
-Obj FuncIS_RANGE (
+static Obj FuncIS_RANGE (
     Obj                 self,
     Obj                 obj )
 {
@@ -722,7 +722,7 @@ Obj FuncIS_RANGE (
 **
 */
 
-void SaveRange( Obj range )
+static void SaveRange( Obj range )
 {
   SaveSubObj(CONST_ADDR_OBJ(range)[0]); /* length */
   SaveSubObj(CONST_ADDR_OBJ(range)[1]); /* base */
@@ -735,7 +735,7 @@ void SaveRange( Obj range )
 **
 */
 
-void LoadRange( Obj range )
+static void LoadRange( Obj range )
 {
   ADDR_OBJ(range)[0] = LoadSubObj(); /* length */
   ADDR_OBJ(range)[1] = LoadSubObj(); /* base */
@@ -826,9 +826,9 @@ Obj Range3Check (
 **
 *F  FuncIS_RANGE_REP( <self>, <obj> ) . . . . . test if value is in range rep
 */
-Obj IsRangeRepFilt;
+static Obj IsRangeRepFilt;
 
-Obj FuncIS_RANGE_REP (
+static Obj FuncIS_RANGE_REP (
     Obj                 self,
     Obj                 obj )
 {
@@ -841,7 +841,7 @@ Obj FuncIS_RANGE_REP (
 **
 */
 
-void MakeImmutableRange( Obj range )
+static void MakeImmutableRange( Obj range )
 {
     MakeImmutableNoRecurse(range);
 }
@@ -866,7 +866,7 @@ static Int egcd (Int a, Int b, Int *lastx, Int *lasty)
   return a;
 } /* returns g=gcd(a,b), with lastx*a+lasty*b = g */
 
-Obj FuncINTER_RANGE( Obj self, Obj r1, Obj r2)
+static Obj FuncINTER_RANGE( Obj self, Obj r1, Obj r2)
 {
   Int low1, low2, inc1, inc2, lowi, inci, g, x, y;
   UInt len1, len2, leni;

--- a/src/rational.c
+++ b/src/rational.c
@@ -80,11 +80,10 @@
 **
 **  'TypeRat' is the function in 'TypeObjFuncs' for rationals.
 */
-static Obj             TYPE_RAT_POS;
-static Obj             TYPE_RAT_NEG;
+static Obj TYPE_RAT_POS;
+static Obj TYPE_RAT_NEG;
 
-static Obj             TypeRat (
-    Obj                 rat )
+static Obj TypeRat(Obj rat)
 {
     Obj                 num;
     CHECK_RAT(rat);
@@ -101,8 +100,7 @@ static Obj             TypeRat (
 **
 **      <numerator> / <denominator>
 */
-static void            PrintRat (
-    Obj                 rat )
+static void PrintRat(Obj rat)
 {
     Pr( "%>", 0L, 0L );
     PrintObj( NUM_RAT(rat) );
@@ -119,9 +117,7 @@ static void            PrintRat (
 **  'EqRat' returns 'true' if the two rationals <ratL> and <ratR>  are  equal
 **  and 'false' otherwise.
 */
-static Int             EqRat (
-    Obj                 opL,
-    Obj                 opR )
+static Int EqRat(Obj opL, Obj opR)
 {
     Obj                 numL, denL;     /* numerator and denominator left  */
     Obj                 numR, denR;     /* numerator and denominator right */
@@ -157,9 +153,7 @@ static Int             EqRat (
 **  'LtRat' returns 'true'  if  the  rational  <ratL>  is  smaller  than  the
 **  rational <ratR> and 'false' otherwise.  Either operand may be an integer.
 */
-static Int             LtRat (
-    Obj                 opL,
-    Obj                 opR )
+static Int LtRat(Obj opL, Obj opR)
 {
     Obj                 numL, denL;     /* numerator and denominator left  */
     Obj                 numR, denR;     /* numerator and denominator right */
@@ -196,9 +190,7 @@ static Int             LtRat (
 **  'SumRat'  returns the   sum of two  rationals  <opL>  and <opR>.   Either
 **  operand may also be an integer.  The sum is reduced.
 */
-static Obj             SumRat (
-    Obj                 opL,
-    Obj                 opR )
+static Obj SumRat(Obj opL, Obj opR)
 {
     Obj                 numL, denL;     /* numerator and denominator left  */
     Obj                 numR, denR;     /* numerator and denominator right */
@@ -265,8 +257,7 @@ static Obj             SumRat (
 **
 *F  ZeroRat(<op>) . . . . . . . . . . . . . . . . . . . .  zero of a rational
 */
-static Obj             ZeroRat (
-    Obj                 op )
+static Obj ZeroRat(Obj op)
 {
     return INTOBJ_INT( 0L );
 }
@@ -276,8 +267,7 @@ static Obj             ZeroRat (
 **
 *F  AInvRat(<op>) . . . . . . . . . . . . . .  additive inverse of a rational
 */
-static Obj             AInvRat (
-    Obj                 op )
+static Obj AInvRat(Obj op)
 {
     Obj                 res;
     Obj                 tmp;
@@ -296,7 +286,7 @@ static Obj             AInvRat (
 **
 *F  AbsRat(<op>) . . . . . . . . . . . . . . . . absolute value of a rational
 */
-static Obj AbsRat( Obj op )
+static Obj AbsRat(Obj op)
 {
     Obj res;
     Obj tmp;
@@ -314,7 +304,7 @@ static Obj AbsRat( Obj op )
 
 }
 
-static Obj FuncABS_RAT( Obj self, Obj op )
+static Obj FuncABS_RAT(Obj self, Obj op)
 {
     RequireRational("AbsRat", op);
     return (TNUM_OBJ(op) == T_RAT) ? AbsRat(op) : AbsInt(op);
@@ -324,13 +314,13 @@ static Obj FuncABS_RAT( Obj self, Obj op )
 **
 *F  SignRat(<op>) . . . . . . . . . . . . . . . . . . . .  sign of a rational
 */
-static Obj SignRat( Obj op )
+static Obj SignRat(Obj op)
 {
     CHECK_RAT(op);
     return SignInt( NUM_RAT(op) );
 }
 
-static Obj FuncSIGN_RAT( Obj self, Obj op )
+static Obj FuncSIGN_RAT(Obj self, Obj op)
 {
     RequireRational("SignRat", op);
     return (TNUM_OBJ(op) == T_RAT) ? SignRat(op) : SignInt(op);
@@ -344,9 +334,7 @@ static Obj FuncSIGN_RAT( Obj self, Obj op )
 **  'DiffRat' returns the  difference  of  two  rationals  <opL>  and  <opR>.
 **  Either operand may also be an integer.  The difference is reduced.
 */
-static Obj             DiffRat (
-    Obj                 opL,
-    Obj                 opR )
+static Obj DiffRat(Obj opL, Obj opR)
 {
     Obj                 numL, denL;     /* numerator and denominator left  */
     Obj                 numR, denR;     /* numerator and denominator right */
@@ -416,9 +404,7 @@ static Obj             DiffRat (
 **  'ProdRat' returns the  product of two rationals <opL> and  <opR>.  Either
 **  operand may also be an integer.  The product is reduced.
 */
-static Obj             ProdRat (
-    Obj                 opL,
-    Obj                 opR )
+static Obj ProdRat(Obj opL, Obj opR)
 {
     Obj                 numL, denL;     /* numerator and denominator left  */
     Obj                 numR, denR;     /* numerator and denominator right */
@@ -483,8 +469,7 @@ static Obj             ProdRat (
 **
 *F  OneRat(<op>)  . . . . . . . . . . . . . . . . . . . . . one of a rational
 */
-static Obj             OneRat (
-    Obj                 op )
+static Obj OneRat(Obj op)
 {
     return INTOBJ_INT( 1L );
 }
@@ -494,12 +479,9 @@ static Obj             OneRat (
 **
 *F  InvRat(<op>)  . . . . . . . . . . . . . . . . . . . inverse of a rational
 */
-static  Obj             QuoRat (
-            Obj                 opL,
-            Obj                 opR );
+static Obj QuoRat(Obj opL, Obj opR);
 
-static Obj             InvRat (
-    Obj                 op )
+static Obj InvRat(Obj op)
 {
   Obj res;
     CHECK_RAT(op);
@@ -518,9 +500,7 @@ static Obj             InvRat (
 **  'QuoRat'  returns the quotient of two rationals <opL> and  <opR>.  Either
 **  operand may also be an integer.  The quotient is reduced.
 */
-static Obj             QuoRat (
-    Obj                 opL,
-    Obj                 opR )
+static Obj QuoRat(Obj opL, Obj opR)
 {
     Obj                 numL, denL;     /* numerator and denominator left  */
     Obj                 numR, denR;     /* numerator and denominator right */
@@ -642,9 +622,7 @@ static Obj ModRat(Obj opL, Obj n)
 **  'PowRat' raises the rational <opL> to the  power  given  by  the  integer
 **  <opR>.  The power is reduced.
 */
-static Obj             PowRat (
-    Obj                 opL,
-    Obj                 opR )
+static Obj PowRat(Obj opL, Obj opR)
 {
     Obj                 numP, denP;     /* numerator and denominator power */
     Obj                 pow;            /* power                           */
@@ -716,11 +694,9 @@ static Obj             PowRat (
 **  'IsRat' returns  'true' if  the  value <val> is  a  rational and  'false'
 **  otherwise.
 */
-static Obj             IsRatFilt;
+static Obj IsRatFilt;
 
-static Obj             IsRatHandler (
-    Obj                 self,
-    Obj                 val )
+static Obj IsRatHandler(Obj self, Obj val)
 {
     /* return 'true' if <val> is a rational and 'false' otherwise          */
     if ( TNUM_OBJ(val) == T_RAT || IS_INT(val)  ) {
@@ -745,9 +721,7 @@ static Obj             IsRatHandler (
 **
 **  'NumeratorRat' returns the numerator of the rational <rat>.
 */
-static Obj             FuncNUMERATOR_RAT (
-    Obj                 self,
-    Obj                 rat )
+static Obj FuncNUMERATOR_RAT(Obj self, Obj rat)
 {
     /* check the argument                                                   */
     RequireRational("NumeratorRat", rat);
@@ -772,9 +746,7 @@ static Obj             FuncNUMERATOR_RAT (
 **
 **  'DenominatorRat' returns the denominator of the rational <rat>.
 */
-static Obj             FuncDENOMINATOR_RAT (
-    Obj                 self,
-    Obj                 rat )
+static Obj FuncDENOMINATOR_RAT(Obj self, Obj rat)
 {
     /* check the argument                                                  */
     RequireRational("DenominatorRat", rat);

--- a/src/rational.c
+++ b/src/rational.c
@@ -80,10 +80,10 @@
 **
 **  'TypeRat' is the function in 'TypeObjFuncs' for rationals.
 */
-Obj             TYPE_RAT_POS;
-Obj             TYPE_RAT_NEG;
+static Obj             TYPE_RAT_POS;
+static Obj             TYPE_RAT_NEG;
 
-Obj             TypeRat (
+static Obj             TypeRat (
     Obj                 rat )
 {
     Obj                 num;
@@ -101,7 +101,7 @@ Obj             TypeRat (
 **
 **      <numerator> / <denominator>
 */
-void            PrintRat (
+static void            PrintRat (
     Obj                 rat )
 {
     Pr( "%>", 0L, 0L );
@@ -119,7 +119,7 @@ void            PrintRat (
 **  'EqRat' returns 'true' if the two rationals <ratL> and <ratR>  are  equal
 **  and 'false' otherwise.
 */
-Int             EqRat (
+static Int             EqRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -157,7 +157,7 @@ Int             EqRat (
 **  'LtRat' returns 'true'  if  the  rational  <ratL>  is  smaller  than  the
 **  rational <ratR> and 'false' otherwise.  Either operand may be an integer.
 */
-Int             LtRat (
+static Int             LtRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -196,7 +196,7 @@ Int             LtRat (
 **  'SumRat'  returns the   sum of two  rationals  <opL>  and <opR>.   Either
 **  operand may also be an integer.  The sum is reduced.
 */
-Obj             SumRat (
+static Obj             SumRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -265,7 +265,7 @@ Obj             SumRat (
 **
 *F  ZeroRat(<op>) . . . . . . . . . . . . . . . . . . . .  zero of a rational
 */
-Obj             ZeroRat (
+static Obj             ZeroRat (
     Obj                 op )
 {
     return INTOBJ_INT( 0L );
@@ -276,7 +276,7 @@ Obj             ZeroRat (
 **
 *F  AInvRat(<op>) . . . . . . . . . . . . . .  additive inverse of a rational
 */
-Obj             AInvRat (
+static Obj             AInvRat (
     Obj                 op )
 {
     Obj                 res;
@@ -296,7 +296,7 @@ Obj             AInvRat (
 **
 *F  AbsRat(<op>) . . . . . . . . . . . . . . . . absolute value of a rational
 */
-Obj AbsRat( Obj op )
+static Obj AbsRat( Obj op )
 {
     Obj res;
     Obj tmp;
@@ -314,7 +314,7 @@ Obj AbsRat( Obj op )
 
 }
 
-Obj FuncABS_RAT( Obj self, Obj op )
+static Obj FuncABS_RAT( Obj self, Obj op )
 {
     RequireRational("AbsRat", op);
     return (TNUM_OBJ(op) == T_RAT) ? AbsRat(op) : AbsInt(op);
@@ -324,13 +324,13 @@ Obj FuncABS_RAT( Obj self, Obj op )
 **
 *F  SignRat(<op>) . . . . . . . . . . . . . . . . . . . .  sign of a rational
 */
-Obj SignRat( Obj op )
+static Obj SignRat( Obj op )
 {
     CHECK_RAT(op);
     return SignInt( NUM_RAT(op) );
 }
 
-Obj FuncSIGN_RAT( Obj self, Obj op )
+static Obj FuncSIGN_RAT( Obj self, Obj op )
 {
     RequireRational("SignRat", op);
     return (TNUM_OBJ(op) == T_RAT) ? SignRat(op) : SignInt(op);
@@ -344,7 +344,7 @@ Obj FuncSIGN_RAT( Obj self, Obj op )
 **  'DiffRat' returns the  difference  of  two  rationals  <opL>  and  <opR>.
 **  Either operand may also be an integer.  The difference is reduced.
 */
-Obj             DiffRat (
+static Obj             DiffRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -416,7 +416,7 @@ Obj             DiffRat (
 **  'ProdRat' returns the  product of two rationals <opL> and  <opR>.  Either
 **  operand may also be an integer.  The product is reduced.
 */
-Obj             ProdRat (
+static Obj             ProdRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -483,7 +483,7 @@ Obj             ProdRat (
 **
 *F  OneRat(<op>)  . . . . . . . . . . . . . . . . . . . . . one of a rational
 */
-Obj             OneRat (
+static Obj             OneRat (
     Obj                 op )
 {
     return INTOBJ_INT( 1L );
@@ -494,11 +494,11 @@ Obj             OneRat (
 **
 *F  InvRat(<op>)  . . . . . . . . . . . . . . . . . . . inverse of a rational
 */
-extern  Obj             QuoRat (
+static  Obj             QuoRat (
             Obj                 opL,
             Obj                 opR );
 
-Obj             InvRat (
+static Obj             InvRat (
     Obj                 op )
 {
   Obj res;
@@ -518,7 +518,7 @@ Obj             InvRat (
 **  'QuoRat'  returns the quotient of two rationals <opL> and  <opR>.  Either
 **  operand may also be an integer.  The quotient is reduced.
 */
-Obj             QuoRat (
+static Obj             QuoRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -618,7 +618,7 @@ Obj             QuoRat (
 **  such that $0 \<= t/s \< n$ and $r/s - t/s$ is a multiple of $n$.  This is
 **  rarely needed while computing modular inverses is very useful.
 */
-Obj ModRat(Obj opL, Obj n)
+static Obj ModRat(Obj opL, Obj n)
 {
     // invert the denominator
     Obj d = InverseModInt( DEN_RAT(opL), n );
@@ -642,7 +642,7 @@ Obj ModRat(Obj opL, Obj n)
 **  'PowRat' raises the rational <opL> to the  power  given  by  the  integer
 **  <opR>.  The power is reduced.
 */
-Obj             PowRat (
+static Obj             PowRat (
     Obj                 opL,
     Obj                 opR )
 {
@@ -716,9 +716,9 @@ Obj             PowRat (
 **  'IsRat' returns  'true' if  the  value <val> is  a  rational and  'false'
 **  otherwise.
 */
-Obj             IsRatFilt;
+static Obj             IsRatFilt;
 
-Obj             IsRatHandler (
+static Obj             IsRatHandler (
     Obj                 self,
     Obj                 val )
 {
@@ -745,7 +745,7 @@ Obj             IsRatHandler (
 **
 **  'NumeratorRat' returns the numerator of the rational <rat>.
 */
-Obj             FuncNUMERATOR_RAT (
+static Obj             FuncNUMERATOR_RAT (
     Obj                 self,
     Obj                 rat )
 {
@@ -772,7 +772,7 @@ Obj             FuncNUMERATOR_RAT (
 **
 **  'DenominatorRat' returns the denominator of the rational <rat>.
 */
-Obj             FuncDENOMINATOR_RAT (
+static Obj             FuncDENOMINATOR_RAT (
     Obj                 self,
     Obj                 rat )
 {
@@ -794,7 +794,7 @@ Obj             FuncDENOMINATOR_RAT (
 **
 */
 
-void SaveRat(Obj rat)
+static void SaveRat(Obj rat)
 {
   SaveSubObj(NUM_RAT(rat));
   SaveSubObj(DEN_RAT(rat));
@@ -806,7 +806,7 @@ void SaveRat(Obj rat)
 **
 */
 
-void LoadRat(Obj rat)
+static void LoadRat(Obj rat)
 {
   SET_NUM_RAT(rat, LoadSubObj());
   SET_DEN_RAT(rat, LoadSubObj());

--- a/src/records.c
+++ b/src/records.c
@@ -270,9 +270,7 @@ UInt            RNamObj (
 **  'RNamObj' returns the record name  corresponding  to  the  object  <obj>,
 **  which currently must be a string or an integer.
 */
-static Obj             FuncRNamObj (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncRNamObj(Obj self, Obj obj)
 {
     return INTOBJ_INT( RNamObj( obj ) );
 }
@@ -288,9 +286,7 @@ static Obj             FuncRNamObj (
 **
 **  'NameRName' returns the string corresponding to the record name <rnam>.
 */
-static Obj             FuncNameRNam (
-    Obj                 self,
-    Obj                 rnam )
+static Obj FuncNameRNam(Obj self, Obj rnam)
 {
     Obj                 name;
     Obj                 oname;
@@ -319,17 +315,14 @@ static Obj             FuncNameRNam (
 */
 Int             (*IsRecFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-static Obj             IsRecFilt;
+static Obj IsRecFilt;
 
-static Obj             IsRecHandler (
-    Obj                 self,
-    Obj                 obj )
+static Obj IsRecHandler(Obj self, Obj obj)
 {
     return (IS_REC(obj) ? True : False);
 }
 
-static Int             IsRecObject (
-    Obj                 obj )
+static Int IsRecObject(Obj obj)
 {
     return (DoFilter( IsRecFilt, obj ) == True);
 }
@@ -345,19 +338,14 @@ static Int             IsRecObject (
 */
 Obj             (*ElmRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 
-static Obj             ElmRecOper;
+static Obj ElmRecOper;
 
-static Obj             ElmRecHandler (
-    Obj                 self,
-    Obj                 rec,
-    Obj                 rnam )
+static Obj ElmRecHandler(Obj self, Obj rec, Obj rnam)
 {
     return ELM_REC( rec, INT_INTOBJ(rnam) );
 }
 
-static Obj             ElmRecError (
-    Obj                 rec,
-    UInt                rnam )
+static Obj ElmRecError(Obj rec, UInt rnam)
 {
     rec = ErrorReturnObj(
         "Record Element: <rec> must be a record (not a %s)",
@@ -366,9 +354,7 @@ static Obj             ElmRecError (
     return ELM_REC( rec, rnam );
 }
 
-static Obj             ElmRecObject (
-    Obj                 obj,
-    UInt                rnam )
+static Obj ElmRecObject(Obj obj, UInt rnam)
 {
   Obj elm;
   elm = DoOperation2Args( ElmRecOper, obj, INTOBJ_INT(rnam) );
@@ -390,19 +376,14 @@ static Obj             ElmRecObject (
 */
 Int             (*IsbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 
-static Obj             IsbRecOper;
+static Obj IsbRecOper;
 
-static Obj             IsbRecHandler (
-    Obj                 self,
-    Obj                 rec,
-    Obj                 rnam )
+static Obj IsbRecHandler(Obj self, Obj rec, Obj rnam)
 {
     return (ISB_REC( rec, INT_INTOBJ(rnam) ) ? True : False);
 }
 
-static Int             IsbRecError (
-    Obj                 rec,
-    UInt                rnam )
+static Int IsbRecError(Obj rec, UInt rnam)
 {
     rec = ErrorReturnObj(
         "Record IsBound: <rec> must be a record (not a %s)",
@@ -411,9 +392,7 @@ static Int             IsbRecError (
     return ISB_REC( rec, rnam );
 }
 
-static Int             IsbRecObject (
-    Obj                 obj,
-    UInt                rnam )
+static Int IsbRecObject(Obj obj, UInt rnam)
 {
     return (DoOperation2Args( IsbRecOper, obj, INTOBJ_INT(rnam) ) == True);
 }
@@ -429,22 +408,15 @@ static Int             IsbRecObject (
 */
 void            (*AssRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam, Obj obj );
 
-static Obj             AssRecOper;
+static Obj AssRecOper;
 
-static Obj             AssRecHandler (
-    Obj                 self,
-    Obj                 rec,
-    Obj                 rnam,
-    Obj                 obj )
+static Obj AssRecHandler(Obj self, Obj rec, Obj rnam, Obj obj)
 {
     ASS_REC( rec, INT_INTOBJ(rnam), obj );
     return 0;
 }
 
-static void            AssRecError (
-    Obj                 rec,
-    UInt                rnam,
-    Obj                 obj )
+static void AssRecError(Obj rec, UInt rnam, Obj obj)
 {
     rec = ErrorReturnObj(
         "Record Assignment: <rec> must be a record (not a %s)",
@@ -453,10 +425,7 @@ static void            AssRecError (
     ASS_REC( rec, rnam, obj );
 }
 
-static void            AssRecObject (
-    Obj                 obj,
-    UInt                rnam,
-    Obj                 val )
+static void AssRecObject(Obj obj, UInt rnam, Obj val)
 {
     DoOperation3Args( AssRecOper, obj, INTOBJ_INT(rnam), val );
 }
@@ -471,20 +440,15 @@ static void            AssRecObject (
 */
 void            (*UnbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 
-static Obj             UnbRecOper;
+static Obj UnbRecOper;
 
-static Obj             UnbRecHandler (
-    Obj                 self,
-    Obj                 rec,
-    Obj                 rnam )
+static Obj UnbRecHandler(Obj self, Obj rec, Obj rnam)
 {
     UNB_REC( rec, INT_INTOBJ(rnam) );
     return 0;
 }
 
-static void            UnbRecError (
-    Obj                 rec,
-    UInt                rnam )
+static void UnbRecError(Obj rec, UInt rnam)
 {
     rec = ErrorReturnObj(
         "Record Unbind: <rec> must be a record (not a %s)",
@@ -492,10 +456,8 @@ static void            UnbRecError (
         "you can replace <rec> via 'return <rec>;'" );
     UNB_REC( rec, rnam );
 }
-        
-static void            UnbRecObject (
-    Obj                 obj,
-    UInt                rnam )
+
+static void UnbRecObject(Obj obj, UInt rnam)
 {
     DoOperation2Args( UnbRecOper, obj, INTOBJ_INT(rnam) );
 }
@@ -552,8 +514,7 @@ UInt            completion_rnam (
     return next != 0;
 }
 
-static Obj FuncALL_RNAMES (
-    Obj                 self )
+static Obj FuncALL_RNAMES(Obj self)
 {
     Obj                 copy, s;
     UInt                i;

--- a/src/records.c
+++ b/src/records.c
@@ -270,7 +270,7 @@ UInt            RNamObj (
 **  'RNamObj' returns the record name  corresponding  to  the  object  <obj>,
 **  which currently must be a string or an integer.
 */
-Obj             FuncRNamObj (
+static Obj             FuncRNamObj (
     Obj                 self,
     Obj                 obj )
 {
@@ -288,7 +288,7 @@ Obj             FuncRNamObj (
 **
 **  'NameRName' returns the string corresponding to the record name <rnam>.
 */
-Obj             FuncNameRNam (
+static Obj             FuncNameRNam (
     Obj                 self,
     Obj                 rnam )
 {
@@ -319,16 +319,16 @@ Obj             FuncNameRNam (
 */
 Int             (*IsRecFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj             IsRecFilt;
+static Obj             IsRecFilt;
 
-Obj             IsRecHandler (
+static Obj             IsRecHandler (
     Obj                 self,
     Obj                 obj )
 {
     return (IS_REC(obj) ? True : False);
 }
 
-Int             IsRecObject (
+static Int             IsRecObject (
     Obj                 obj )
 {
     return (DoFilter( IsRecFilt, obj ) == True);
@@ -345,9 +345,9 @@ Int             IsRecObject (
 */
 Obj             (*ElmRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 
-Obj             ElmRecOper;
+static Obj             ElmRecOper;
 
-Obj             ElmRecHandler (
+static Obj             ElmRecHandler (
     Obj                 self,
     Obj                 rec,
     Obj                 rnam )
@@ -355,7 +355,7 @@ Obj             ElmRecHandler (
     return ELM_REC( rec, INT_INTOBJ(rnam) );
 }
 
-Obj             ElmRecError (
+static Obj             ElmRecError (
     Obj                 rec,
     UInt                rnam )
 {
@@ -366,7 +366,7 @@ Obj             ElmRecError (
     return ELM_REC( rec, rnam );
 }
 
-Obj             ElmRecObject (
+static Obj             ElmRecObject (
     Obj                 obj,
     UInt                rnam )
 {
@@ -390,9 +390,9 @@ Obj             ElmRecObject (
 */
 Int             (*IsbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 
-Obj             IsbRecOper;
+static Obj             IsbRecOper;
 
-Obj             IsbRecHandler (
+static Obj             IsbRecHandler (
     Obj                 self,
     Obj                 rec,
     Obj                 rnam )
@@ -400,7 +400,7 @@ Obj             IsbRecHandler (
     return (ISB_REC( rec, INT_INTOBJ(rnam) ) ? True : False);
 }
 
-Int             IsbRecError (
+static Int             IsbRecError (
     Obj                 rec,
     UInt                rnam )
 {
@@ -411,7 +411,7 @@ Int             IsbRecError (
     return ISB_REC( rec, rnam );
 }
 
-Int             IsbRecObject (
+static Int             IsbRecObject (
     Obj                 obj,
     UInt                rnam )
 {
@@ -429,9 +429,9 @@ Int             IsbRecObject (
 */
 void            (*AssRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam, Obj obj );
 
-Obj             AssRecOper;
+static Obj             AssRecOper;
 
-Obj             AssRecHandler (
+static Obj             AssRecHandler (
     Obj                 self,
     Obj                 rec,
     Obj                 rnam,
@@ -441,7 +441,7 @@ Obj             AssRecHandler (
     return 0;
 }
 
-void            AssRecError (
+static void            AssRecError (
     Obj                 rec,
     UInt                rnam,
     Obj                 obj )
@@ -453,7 +453,7 @@ void            AssRecError (
     ASS_REC( rec, rnam, obj );
 }
 
-void            AssRecObject (
+static void            AssRecObject (
     Obj                 obj,
     UInt                rnam,
     Obj                 val )
@@ -471,9 +471,9 @@ void            AssRecObject (
 */
 void            (*UnbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
 
-Obj             UnbRecOper;
+static Obj             UnbRecOper;
 
-Obj             UnbRecHandler (
+static Obj             UnbRecHandler (
     Obj                 self,
     Obj                 rec,
     Obj                 rnam )
@@ -482,7 +482,7 @@ Obj             UnbRecHandler (
     return 0;
 }
 
-void            UnbRecError (
+static void            UnbRecError (
     Obj                 rec,
     UInt                rnam )
 {
@@ -493,7 +493,7 @@ void            UnbRecError (
     UNB_REC( rec, rnam );
 }
         
-void            UnbRecObject (
+static void            UnbRecObject (
     Obj                 obj,
     UInt                rnam )
 {
@@ -552,7 +552,7 @@ UInt            completion_rnam (
     return next != 0;
 }
 
-Obj FuncALL_RNAMES (
+static Obj FuncALL_RNAMES (
     Obj                 self )
 {
     Obj                 copy, s;

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -108,7 +108,7 @@ static void CloseAfterLoad( void )
   LoadFile = -1;
 }
 
-void SAVE_BYTE_BUF( void )
+static void SAVE_BYTE_BUF( void )
 {
   if (SyWrite(SaveFile, LoadBuffer, LBEnd - LoadBuffer) < 0)
     ErrorQuit("Cannot write to file, see 'LastSystemError();'\n", 0L, 0L);
@@ -119,9 +119,9 @@ void SAVE_BYTE_BUF( void )
 #define SAVE_BYTE(byte) {if (LBPointer >= LBEnd) {SAVE_BYTE_BUF();} \
                           *LBPointer++ = (UInt1)(byte);}
 
-const Char * LoadByteErrorMessage = "Unexpected End of File in Load\n";
+static const Char * LoadByteErrorMessage = "Unexpected End of File in Load\n";
 
-UInt1 LOAD_BYTE_BUF( void )
+static UInt1 LOAD_BYTE_BUF( void )
 {
   Int ret;
   ret = SyRead(LoadFile, LoadBuffer, 100000);
@@ -451,7 +451,7 @@ static void report( Bag bag)
   fprintf(file,"%li %li\n", (long) TNUM_BAG(bag), (long) SIZE_BAG(bag));
 }
 
-Obj FuncBagStats(Obj self, Obj filename)
+static Obj FuncBagStats(Obj self, Obj filename)
 {
   file = fopen((Char *)CHARS_STRING(filename),"w");
   CallbackForAllBags(report);
@@ -484,7 +484,7 @@ static void ScanBag( Bag bag)
     hit = bag;
 }
 
-Obj FuncFindBag( Obj self, Obj minsize, Obj maxsize, Obj tnum )
+static Obj FuncFindBag( Obj self, Obj minsize, Obj maxsize, Obj tnum )
 {
   hit = (Bag) 0;
   fb_minsize = INT_INTOBJ(minsize);
@@ -620,7 +620,7 @@ Obj SaveWorkspace( Obj fname )
 }
 
 
-Obj FuncSaveWorkspace(Obj self, Obj filename )
+static Obj FuncSaveWorkspace(Obj self, Obj filename )
 {
   return SaveWorkspace( filename );
 }
@@ -770,7 +770,7 @@ static void PrSavedObj( UInt x)
     Pr("Reference to bag number %d\n",x>>2,0L);
 }
 
-Obj FuncDumpWorkspace( Obj self, Obj fname )
+static Obj FuncDumpWorkspace( Obj self, Obj fname )
 {
   UInt nMods, nGlobs, nBags, i, relative;
   Char buf[256];

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -108,7 +108,7 @@ static void CloseAfterLoad( void )
   LoadFile = -1;
 }
 
-static void SAVE_BYTE_BUF( void )
+static void SAVE_BYTE_BUF(void)
 {
   if (SyWrite(SaveFile, LoadBuffer, LBEnd - LoadBuffer) < 0)
     ErrorQuit("Cannot write to file, see 'LastSystemError();'\n", 0L, 0L);
@@ -121,7 +121,7 @@ static void SAVE_BYTE_BUF( void )
 
 static const Char * LoadByteErrorMessage = "Unexpected End of File in Load\n";
 
-static UInt1 LOAD_BYTE_BUF( void )
+static UInt1 LOAD_BYTE_BUF(void)
 {
   Int ret;
   ret = SyRead(LoadFile, LoadBuffer, 100000);
@@ -484,7 +484,7 @@ static void ScanBag( Bag bag)
     hit = bag;
 }
 
-static Obj FuncFindBag( Obj self, Obj minsize, Obj maxsize, Obj tnum )
+static Obj FuncFindBag(Obj self, Obj minsize, Obj maxsize, Obj tnum)
 {
   hit = (Bag) 0;
   fb_minsize = INT_INTOBJ(minsize);
@@ -620,7 +620,7 @@ Obj SaveWorkspace( Obj fname )
 }
 
 
-static Obj FuncSaveWorkspace(Obj self, Obj filename )
+static Obj FuncSaveWorkspace(Obj self, Obj filename)
 {
   return SaveWorkspace( filename );
 }
@@ -770,7 +770,7 @@ static void PrSavedObj( UInt x)
     Pr("Reference to bag number %d\n",x>>2,0L);
 }
 
-static Obj FuncDumpWorkspace( Obj self, Obj fname )
+static Obj FuncDumpWorkspace(Obj self, Obj fname)
 {
   UInt nMods, nGlobs, nBags, i, relative;
   Char buf[256];

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1012,7 +1012,7 @@ int IsKeyword(const char * str)
     return 0;
 }
 
-Obj FuncALL_KEYWORDS(Obj self)
+static Obj FuncALL_KEYWORDS(Obj self)
 {
     Obj l = NewEmptyPlist();
     for (UInt i = 0; i < ARRAY_SIZE(AllKeywords); i++) {

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -53,12 +53,7 @@
 **  'SCTableEntry' returns the coefficient $c_{i,j}^{k}$ from the structure
 **  constants table <table>.
 */
-static Obj FuncSC_TABLE_ENTRY (
-    Obj                 self,
-    Obj                 table,
-    Obj                 i,
-    Obj                 j,
-    Obj                 k )
+static Obj FuncSC_TABLE_ENTRY(Obj self, Obj table, Obj i, Obj j, Obj k)
 {
     Obj                 tmp;            /* temporary                       */
     Obj                 basis;          /* basis  list                     */
@@ -185,11 +180,7 @@ static Obj FuncSC_TABLE_ENTRY (
 **  'SCTableProduct'  returns the product   of  the two elements <list1>  and
 **  <list2> with respect to the structure constants table <table>.
 */
-static void SCTableProdAdd (
-    Obj                 res,
-    Obj                 coeff,
-    Obj                 basis_coeffs,
-    Int                 dim )
+static void SCTableProdAdd(Obj res, Obj coeff, Obj basis_coeffs, Int dim)
 {
     Obj                 basis;
     Obj                 coeffs;
@@ -218,11 +209,7 @@ static void SCTableProdAdd (
     }
 }
 
-static Obj FuncSC_TABLE_PRODUCT (
-    Obj                 self,
-    Obj                 table,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncSC_TABLE_PRODUCT(Obj self, Obj table, Obj list1, Obj list2)
 {
     Obj                 res;            /* result list                     */
     Obj                 row;            /* one row of sc table             */

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -53,7 +53,7 @@
 **  'SCTableEntry' returns the coefficient $c_{i,j}^{k}$ from the structure
 **  constants table <table>.
 */
-Obj FuncSC_TABLE_ENTRY (
+static Obj FuncSC_TABLE_ENTRY (
     Obj                 self,
     Obj                 table,
     Obj                 i,
@@ -185,7 +185,7 @@ Obj FuncSC_TABLE_ENTRY (
 **  'SCTableProduct'  returns the product   of  the two elements <list1>  and
 **  <list2> with respect to the structure constants table <table>.
 */
-void SCTableProdAdd (
+static void SCTableProdAdd (
     Obj                 res,
     Obj                 coeff,
     Obj                 basis_coeffs,
@@ -218,7 +218,7 @@ void SCTableProdAdd (
     }
 }
 
-Obj FuncSC_TABLE_PRODUCT (
+static Obj FuncSC_TABLE_PRODUCT (
     Obj                 self,
     Obj                 table,
     Obj                 list1,

--- a/src/set.c
+++ b/src/set.c
@@ -197,7 +197,7 @@ Obj SetList (
 **  'SetList' returns a new list even if the list <list> is already a  proper
 **  set, in this case it is equivalent to 'ShallowCopy' (see  "ShallowCopy").
 */
-Obj FuncLIST_SORTED_LIST (
+static Obj FuncLIST_SORTED_LIST (
     Obj                 self,
     Obj                 list )
 {
@@ -239,7 +239,7 @@ Obj FuncLIST_SORTED_LIST (
 **  are equal if every element of  <list1> is also  an element of <list2> and
 **  if every element of <list2> is also an element of <list1>.
 */
-Int             EqSet (
+static Int             EqSet (
     Obj                 listL,
     Obj                 listR )
 {
@@ -269,7 +269,7 @@ Int             EqSet (
     return 1L;
 }
 
-Obj             FuncIS_EQUAL_SET (
+static Obj             FuncIS_EQUAL_SET (
     Obj                 self,
     Obj                 list1,
     Obj                 list2 )
@@ -298,7 +298,7 @@ Obj             FuncIS_EQUAL_SET (
 **  Either  argument may also  be a list that is  not a proper  set, in which
 **  case 'IsSubsetSet' silently applies 'Set' (see "Set") to it first.
 */
-Obj             FuncIS_SUBSET_SET (
+static Obj             FuncIS_SUBSET_SET (
     Obj                 self,
     Obj                 set1,
     Obj                 set2 )
@@ -398,7 +398,7 @@ Obj             FuncIS_SUBSET_SET (
 **  'AddSet' does not return  anything, it is only  called for the side effect
 **  of changing <set>.
 */
-Obj FuncADD_SET (
+static Obj FuncADD_SET (
                  Obj                 self,
                  Obj                 set,
                  Obj                 obj )
@@ -522,7 +522,7 @@ Obj FuncADD_SET (
 **  'RemoveSet'   does   not return anything,  it   is  only called  for  the
 **  side effect of changing <set>.
 */
-Obj FuncREM_SET (
+static Obj FuncREM_SET (
     Obj                 self,
     Obj                 set,
     Obj                 obj )
@@ -580,7 +580,7 @@ Obj FuncREM_SET (
 **
 */
 
-Obj FuncUNITE_SET (
+static Obj FuncUNITE_SET (
     Obj                 self,
     Obj                 set1,
     Obj                 set2 )
@@ -753,7 +753,7 @@ static UInt InterSetInner2( Obj set1, Obj set2, Obj setr, UInt len1, UInt len2)
 }
 
 
-Obj FuncINTER_SET (
+static Obj FuncINTER_SET (
     Obj                 self,
     Obj                 set1,
     Obj                 set2 )
@@ -919,7 +919,7 @@ static UInt SubtrSetInner2( Obj set1, Obj set2, UInt len1, UInt len2)
   return lenr;
 }
 
-Obj FuncSUBTR_SET (
+static Obj FuncSUBTR_SET (
     Obj                 self,
     Obj                 set1,
     Obj                 set2 )

--- a/src/set.c
+++ b/src/set.c
@@ -197,9 +197,7 @@ Obj SetList (
 **  'SetList' returns a new list even if the list <list> is already a  proper
 **  set, in this case it is equivalent to 'ShallowCopy' (see  "ShallowCopy").
 */
-static Obj FuncLIST_SORTED_LIST (
-    Obj                 self,
-    Obj                 list )
+static Obj FuncLIST_SORTED_LIST(Obj self, Obj list)
 {
     Obj                 set;            /* result                          */
 
@@ -239,9 +237,7 @@ static Obj FuncLIST_SORTED_LIST (
 **  are equal if every element of  <list1> is also  an element of <list2> and
 **  if every element of <list2> is also an element of <list1>.
 */
-static Int             EqSet (
-    Obj                 listL,
-    Obj                 listR )
+static Int EqSet(Obj listL, Obj listR)
 {
     Int                 lenL;           /* length of the left operand      */
     Int                 lenR;           /* length of the right operand     */
@@ -269,10 +265,7 @@ static Int             EqSet (
     return 1L;
 }
 
-static Obj             FuncIS_EQUAL_SET (
-    Obj                 self,
-    Obj                 list1,
-    Obj                 list2 )
+static Obj FuncIS_EQUAL_SET(Obj self, Obj list1, Obj list2)
 {
     /* check the arguments, convert to sets if necessary                   */
     RequireSmallList("IsEqualSet", list1);
@@ -298,10 +291,7 @@ static Obj             FuncIS_EQUAL_SET (
 **  Either  argument may also  be a list that is  not a proper  set, in which
 **  case 'IsSubsetSet' silently applies 'Set' (see "Set") to it first.
 */
-static Obj             FuncIS_SUBSET_SET (
-    Obj                 self,
-    Obj                 set1,
-    Obj                 set2 )
+static Obj FuncIS_SUBSET_SET(Obj self, Obj set1, Obj set2)
 {
     UInt                len1;           /* length of  the left  set        */
     UInt                len2;           /* length of  the right set        */
@@ -398,10 +388,7 @@ static Obj             FuncIS_SUBSET_SET (
 **  'AddSet' does not return  anything, it is only  called for the side effect
 **  of changing <set>.
 */
-static Obj FuncADD_SET (
-                 Obj                 self,
-                 Obj                 set,
-                 Obj                 obj )
+static Obj FuncADD_SET(Obj self, Obj set, Obj obj)
 {
   UInt                len;            /* logical length of the list      */
   UInt                pos;            /* position                        */
@@ -522,10 +509,7 @@ static Obj FuncADD_SET (
 **  'RemoveSet'   does   not return anything,  it   is  only called  for  the
 **  side effect of changing <set>.
 */
-static Obj FuncREM_SET (
-    Obj                 self,
-    Obj                 set,
-    Obj                 obj )
+static Obj FuncREM_SET(Obj self, Obj set, Obj obj)
 {
     UInt                len;            /* logical length of the list      */
     UInt                pos;            /* position                        */
@@ -580,10 +564,7 @@ static Obj FuncREM_SET (
 **
 */
 
-static Obj FuncUNITE_SET (
-    Obj                 self,
-    Obj                 set1,
-    Obj                 set2 )
+static Obj FuncUNITE_SET(Obj self, Obj set1, Obj set2)
 {
     UInt                lenr;           /* length  of result set           */
     UInt                len1;           /* length  of left  set            */
@@ -753,10 +734,7 @@ static UInt InterSetInner2( Obj set1, Obj set2, Obj setr, UInt len1, UInt len2)
 }
 
 
-static Obj FuncINTER_SET (
-    Obj                 self,
-    Obj                 set1,
-    Obj                 set2 )
+static Obj FuncINTER_SET(Obj self, Obj set1, Obj set2)
 {
     UInt                len1;           /* length  of left  set            */
     UInt                len2;           /* length  of right set            */
@@ -919,10 +897,7 @@ static UInt SubtrSetInner2( Obj set1, Obj set2, UInt len1, UInt len2)
   return lenr;
 }
 
-static Obj FuncSUBTR_SET (
-    Obj                 self,
-    Obj                 set1,
-    Obj                 set2 )
+static Obj FuncSUBTR_SET(Obj self, Obj set1, Obj set2)
 {
     UInt                len1;           /* length  of left  set            */
     UInt                len2;           /* length  of right set            */

--- a/src/sortbase.h
+++ b/src/sortbase.h
@@ -82,7 +82,8 @@ static Int SORT_COMP_CHECK_EQ(SORT_FUNC_ARGS, Obj a, Obj b) {
         return SORT_COMP(a, b);
 }
 
-void PREFIXNAME(Shell)(SORT_FUNC_ARGS, Int start, Int end) {
+static void PREFIXNAME(Shell)(SORT_FUNC_ARGS, Int start, Int end)
+{
   UInt len; /* length of the list              */
   UInt h;   /* gap width in the shellsort      */
   SORT_CREATE_LOCAL(v);
@@ -204,7 +205,8 @@ static inline Int PREFIXNAME(Partition)(SORT_FUNC_ARGS, Int start, Int end,
   }
 }
 
-void PREFIXNAME(Insertion)(SORT_FUNC_ARGS, Int start, Int end) {
+static void PREFIXNAME(Insertion)(SORT_FUNC_ARGS, Int start, Int end)
+{
   SORT_CREATE_LOCAL(v);
   SORT_CREATE_LOCAL(w);
   UInt i, k; /* loop variables                  */
@@ -227,7 +229,8 @@ void PREFIXNAME(Insertion)(SORT_FUNC_ARGS, Int start, Int end) {
 
 /* This function performs an insertion sort with a limit to the number
  * of swaps performed -- if we pass that limit we abandon the sort */
-Obj PREFIXNAME(LimitedInsertion)(SORT_FUNC_ARGS, Int start, Int end) {
+static Obj PREFIXNAME(LimitedInsertion)(SORT_FUNC_ARGS, Int start, Int end)
+{
   SORT_CREATE_LOCAL(v);
   SORT_CREATE_LOCAL(w);
   UInt i, k;     /* loop variables                        */
@@ -257,7 +260,8 @@ Obj PREFIXNAME(LimitedInsertion)(SORT_FUNC_ARGS, Int start, Int end) {
 
 /* This function assumes it doesn't get called for ranges which are very small
  */
-void PREFIXNAME(CheckBadPivot)(SORT_FUNC_ARGS, Int start, Int end, Int pivot) {
+static void PREFIXNAME(CheckBadPivot)(SORT_FUNC_ARGS, Int start, Int end, Int pivot)
+{
   Int length = end - start;
   if (pivot - start < length / 8) {
     SWAP_INDICES(SORT_ARGS, pivot, pivot + length / 4);
@@ -268,7 +272,9 @@ void PREFIXNAME(CheckBadPivot)(SORT_FUNC_ARGS, Int start, Int end, Int pivot) {
     SWAP_INDICES(SORT_ARGS, pivot - 1, pivot - 1 - length / 4);
   }
 }
-void PREFIXNAME(QuickSort)(SORT_FUNC_ARGS, Int start, Int end, Int depth) {
+
+static void PREFIXNAME(QuickSort)(SORT_FUNC_ARGS, Int start, Int end, Int depth)
+{
   Int pivot, first_pass;
 
   if (end - start < 24) {
@@ -303,8 +309,9 @@ void SORT_FUNC_NAME(SORT_FUNC_ARGS) {
 
 // Merge the consecutive ranges [b1..e1] and [e1+1..e2] in place,
 // Using the temporary buffer 'tempbuf'.
-void PREFIXNAME(MergeRanges)(SORT_FUNC_ARGS, Int b1, Int e1, Int e2,
-                             Obj tempbuf) {
+static void PREFIXNAME(MergeRanges)(SORT_FUNC_ARGS, Int b1, Int e1, Int e2,
+                                    Obj tempbuf)
+{
   Int pos1 = b1;
   Int pos2 = e1 + 1;
   Int resultpos = 1;

--- a/src/stats.c
+++ b/src/stats.c
@@ -100,8 +100,7 @@ UInt            (* ExecStatFuncs[256]) ( Stat stat );
 **  this  is  ever  called, then   GAP is   in  serious  trouble, such as  an
 **  overwritten type field of a statement.
 */
-static UInt            ExecUnknownStat (
-    Stat                stat )
+static UInt ExecUnknownStat(Stat stat)
 {
     Pr(
         "Panic: tried to execute a statement of unknown type '%d'\n",
@@ -210,8 +209,7 @@ static UInt ExecSeqStat7(Stat stat)
 **  fourth subbag is the second body, and so  on.  If the if-statement has an
 **  else-branch, this is represented by a branch without a condition.
 */
-static UInt            ExecIf (
-    Stat                stat )
+static UInt ExecIf(Stat stat)
 {
     Expr                cond;           /* condition                       */
     Stat                body;           /* body                            */
@@ -230,8 +228,7 @@ static UInt            ExecIf (
     return 0;
 }
 
-static UInt            ExecIfElse (
-    Stat                stat )
+static UInt ExecIfElse(Stat stat)
 {
     Expr                cond;           /* condition                       */
     Stat                body;           /* body                            */
@@ -253,8 +250,7 @@ static UInt            ExecIfElse (
     return EXEC_STAT( body );
 }
 
-static UInt            ExecIfElif (
-    Stat                stat )
+static UInt ExecIfElif(Stat stat)
 {
     Expr                cond;           /* condition                       */
     Stat                body;           /* body                            */
@@ -284,8 +280,7 @@ static UInt            ExecIfElif (
     return 0;
 }
 
-static UInt            ExecIfElifElse (
-    Stat                stat )
+static UInt ExecIfElifElse(Stat stat)
 {
     Expr                cond;           /* condition                       */
     Stat                body;           /* body                            */
@@ -795,8 +790,7 @@ static UInt ExecRepeat3(Stat stat)
 **  A break-statement is  represented  by a bag of   type 'T_BREAK' with   no
 **  subbags.
 */
-static UInt            ExecBreak (
-    Stat                stat )
+static UInt ExecBreak(Stat stat)
 {
     /* return to the next loop                                             */
     return STATUS_BREAK;
@@ -814,8 +808,7 @@ static UInt            ExecBreak (
 **  A continue-statement is  represented  by a bag of   type 'T_CONTINUE' with   no
 **  subbags.
 */
-static UInt            ExecContinue (
-    Stat                stat )
+static UInt ExecContinue(Stat stat)
 {
     /* return to the next loop                                             */
     return STATUS_CONTINUE;
@@ -827,7 +820,7 @@ static UInt            ExecContinue (
 **
 **  Does nothing
 */
-static UInt ExecEmpty( Stat stat )
+static UInt ExecEmpty(Stat stat)
 {
   return 0;
 }
@@ -846,8 +839,7 @@ static UInt ExecEmpty( Stat stat )
 **  An  info-statement is represented by a  bag of type 'T_INFO' with subbags
 **  for the arguments
 */
-static UInt ExecInfo (
-    Stat            stat )
+static UInt ExecInfo(Stat stat)
 {
     Obj             selectors;
     Obj             level;
@@ -898,8 +890,7 @@ static UInt ExecInfo (
 **  A 2 argument assert-statement is  represented  by a bag of   type
 **  'T_ASSERT_2ARGS' with subbags for the 2 arguments
 */
-static UInt ExecAssert2Args (
-    Stat            stat )
+static UInt ExecAssert2Args(Stat stat)
 {
     Obj             level;
     Obj             decision;
@@ -927,8 +918,7 @@ static UInt ExecAssert2Args (
 **  A 3 argument assert-statement is  represented  by a bag of   type
 **  'T_ASSERT_3ARGS' with subbags for the 3 arguments
 */
-static UInt ExecAssert3Args (
-    Stat            stat )
+static UInt ExecAssert3Args(Stat stat)
 {
     Obj             level;
     Obj             decision;
@@ -970,8 +960,7 @@ static UInt ExecAssert3Args (
 **  with      one  subbag.    This  subbag     is   the    expression  of the
 **  return-value-statement.
 */
-static UInt            ExecReturnObj (
-    Stat                stat )
+static UInt ExecReturnObj(Stat stat)
 {
 #if !defined(HAVE_SIGNAL)
     /* test for an interrupt                                               */
@@ -1001,8 +990,7 @@ static UInt            ExecReturnObj (
 **  A return-void-statement  is represented by  a bag of type 'T_RETURN_VOID'
 **  with no subbags.
 */
-static UInt            ExecReturnVoid (
-    Stat                stat )
+static UInt ExecReturnVoid(Stat stat)
 {
 #if !defined(HAVE_SIGNAL)
     /* test for an interrupt                                               */
@@ -1074,8 +1062,7 @@ UInt TakeInterrupt( void )
 **  redispatches after a return from the break-loop.
 */
 
-static UInt ExecIntrStat (
-    Stat                stat )
+static UInt ExecIntrStat(Stat stat)
 {
 
     /* change the entries in 'ExecStatFuncs' back to the original          */
@@ -1192,8 +1179,7 @@ void            (* PrintStatFuncs[256] ) ( Stat stat );
 **  this  is  ever called,   then GAP  is in  serious   trouble, such  as  an
 **  overwritten type field of a statement.
 */
-static void            PrintUnknownStat (
-    Stat                stat )
+static void PrintUnknownStat(Stat stat)
 {
     ErrorQuit(
         "Panic: cannot print statement of type '%d'",
@@ -1207,8 +1193,7 @@ static void            PrintUnknownStat (
 **
 **  'PrintSeqStat' prints the statement sequence <stat>.
 */
-static void            PrintSeqStat (
-    Stat                stat )
+static void PrintSeqStat(Stat stat)
 {
     UInt                nr;             /* number of statements            */
     UInt                i;              /* loop variable                   */
@@ -1239,8 +1224,7 @@ static void            PrintSeqStat (
 **  Linebreaks are printed after the 'then' and the statements in the bodies.
 **  If necessary one is preferred immediately before the 'then'.
 */
-static void            PrintIf (
-    Stat                stat )
+static void PrintIf(Stat stat)
 {
     UInt                i;              /* loop variable                   */
     UInt                len;            /* length of loop                  */
@@ -1282,8 +1266,7 @@ static void            PrintIf (
 **  Linebreaks are printed after the 'do' and the statements in the body.  If
 **  necesarry it is preferred immediately before the 'in'.
 */
-static void            PrintFor (
-    Stat                stat )
+static void PrintFor(Stat stat)
 {
     UInt                i;              /* loop variable                   */
 
@@ -1309,8 +1292,7 @@ static void            PrintFor (
 **  Linebreaks are printed after the 'do' and the statments  in the body.  If
 **  necessary one is preferred immediately before the 'do'.
 */
-static void            PrintWhile (
-    Stat                stat )
+static void PrintWhile(Stat stat)
 {
     UInt                i;              /* loop variable                   */
 
@@ -1334,8 +1316,7 @@ static void            PrintWhile (
 **  necessary one is preferred immediately before the 'do'.
 */
 #ifdef HPCGAP
-static void            PrintAtomic (
-    Stat                stat )
+static void PrintAtomic(Stat stat)
 {
   UInt nrexprs;
     UInt                i;              /* loop variable                   */
@@ -1373,8 +1354,7 @@ static void            PrintAtomic (
 **  Linebreaks are printed after the 'repeat' and the statements in the body.
 **  If necessary one is preferred after the 'until'.
 */
-static void            PrintRepeat (
-    Stat                stat )
+static void PrintRepeat(Stat stat)
 {
     UInt                i;              /* loop variable                   */
 
@@ -1395,8 +1375,7 @@ static void            PrintRepeat (
 **
 **  'PrintBreak' prints the break-statement <stat>.
 */
-static void            PrintBreak (
-    Stat                stat )
+static void PrintBreak(Stat stat)
 {
     Pr( "break;", 0L, 0L );
 }
@@ -1407,8 +1386,7 @@ static void            PrintBreak (
 **
 **  'PrintContinue' prints the continue-statement <stat>.
 */
-static void            PrintContinue (
-    Stat                stat )
+static void PrintContinue(Stat stat)
 {
     Pr( "continue;", 0L, 0L );
 }
@@ -1418,7 +1396,7 @@ static void            PrintContinue (
 *F  PrintEmpty(<stat>)
 **
 */
-static void             PrintEmpty( Stat stat )
+static void PrintEmpty(Stat stat)
 {
   Pr( ";", 0L, 0L);
 }
@@ -1430,8 +1408,7 @@ static void             PrintEmpty( Stat stat )
 **  'PrintInfo' prints the info-statement <stat>.
 */
 
-static void            PrintInfo (
-    Stat               stat )
+static void PrintInfo(Stat stat)
 {
     UInt                i;              /* loop variable                   */
 
@@ -1460,8 +1437,7 @@ static void            PrintInfo (
 **  'PrintAssert2Args' prints the 2 argument assert-statement <stat>.
 */
 
-static void            PrintAssert2Args (
-    Stat               stat )
+static void PrintAssert2Args(Stat stat)
 {
 
     /* print the keyword                                                   */
@@ -1486,8 +1462,7 @@ static void            PrintAssert2Args (
 **  'PrintAssert3Args' prints the 3 argument assert-statement <stat>.
 */
 
-static void            PrintAssert3Args (
-    Stat               stat )
+static void PrintAssert3Args(Stat stat)
 {
 
     /* print the keyword                                                   */
@@ -1515,8 +1490,7 @@ static void            PrintAssert3Args (
 **
 **  'PrintReturnObj' prints the return-value-statement <stat>.
 */
-static void            PrintReturnObj (
-    Stat                stat )
+static void PrintReturnObj(Stat stat)
 {
     Expr expr = READ_STAT(stat, 0);
     if (TNUM_EXPR(expr) == T_REF_GVAR &&
@@ -1537,8 +1511,7 @@ static void            PrintReturnObj (
 **
 **  'PrintReturnVoid' prints the return-void-statement <stat>.
 */
-static void            PrintReturnVoid (
-    Stat                stat )
+static void PrintReturnVoid(Stat stat)
 {
     Pr( "return;", 0L, 0L );
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -100,7 +100,7 @@ UInt            (* ExecStatFuncs[256]) ( Stat stat );
 **  this  is  ever  called, then   GAP is   in  serious  trouble, such as  an
 **  overwritten type field of a statement.
 */
-UInt            ExecUnknownStat (
+static UInt            ExecUnknownStat (
     Stat                stat )
 {
     Pr(
@@ -153,39 +153,39 @@ static ALWAYS_INLINE UInt ExecSeqStatHelper(Stat stat, UInt nr)
     return 0;
 }
 
-UInt ExecSeqStat(Stat stat)
+static UInt ExecSeqStat(Stat stat)
 {
     // get the number of statements
     UInt nr = SIZE_STAT( stat ) / sizeof(Stat);
     return ExecSeqStatHelper(stat, nr);
 }
 
-UInt ExecSeqStat2(Stat stat)
+static UInt ExecSeqStat2(Stat stat)
 {
     return ExecSeqStatHelper(stat, 2);
 }
 
-UInt ExecSeqStat3(Stat stat)
+static UInt ExecSeqStat3(Stat stat)
 {
     return ExecSeqStatHelper(stat, 3);
 }
 
-UInt ExecSeqStat4(Stat stat)
+static UInt ExecSeqStat4(Stat stat)
 {
     return ExecSeqStatHelper(stat, 4);
 }
 
-UInt ExecSeqStat5(Stat stat)
+static UInt ExecSeqStat5(Stat stat)
 {
     return ExecSeqStatHelper(stat, 5);
 }
 
-UInt ExecSeqStat6(Stat stat)
+static UInt ExecSeqStat6(Stat stat)
 {
     return ExecSeqStatHelper(stat, 6);
 }
 
-UInt ExecSeqStat7(Stat stat)
+static UInt ExecSeqStat7(Stat stat)
 {
     return ExecSeqStatHelper(stat, 7);
 }
@@ -210,7 +210,7 @@ UInt ExecSeqStat7(Stat stat)
 **  fourth subbag is the second body, and so  on.  If the if-statement has an
 **  else-branch, this is represented by a branch without a condition.
 */
-UInt            ExecIf (
+static UInt            ExecIf (
     Stat                stat )
 {
     Expr                cond;           /* condition                       */
@@ -230,7 +230,7 @@ UInt            ExecIf (
     return 0;
 }
 
-UInt            ExecIfElse (
+static UInt            ExecIfElse (
     Stat                stat )
 {
     Expr                cond;           /* condition                       */
@@ -253,7 +253,7 @@ UInt            ExecIfElse (
     return EXEC_STAT( body );
 }
 
-UInt            ExecIfElif (
+static UInt            ExecIfElif (
     Stat                stat )
 {
     Expr                cond;           /* condition                       */
@@ -284,7 +284,7 @@ UInt            ExecIfElif (
     return 0;
 }
 
-UInt            ExecIfElifElse (
+static UInt            ExecIfElifElse (
     Stat                stat )
 {
     Expr                cond;           /* condition                       */
@@ -461,18 +461,18 @@ static ALWAYS_INLINE UInt ExecForHelper(Stat stat, UInt nr)
     return 0;
 }
 
-UInt ExecFor(Stat stat)
+static UInt ExecFor(Stat stat)
 {
     return ExecForHelper(stat, 1);
 }
 
 
-UInt ExecFor2(Stat stat)
+static UInt ExecFor2(Stat stat)
 {
     return ExecForHelper(stat, 2);
 }
 
-UInt ExecFor3(Stat stat)
+static UInt ExecFor3(Stat stat)
 {
     return ExecForHelper(stat, 3);
 }
@@ -555,17 +555,17 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     return 0;
 }
 
-UInt ExecForRange(Stat stat)
+static UInt ExecForRange(Stat stat)
 {
     return ExecForRangeHelper(stat, 1);
 }
 
-UInt ExecForRange2(Stat stat)
+static UInt ExecForRange2(Stat stat)
 {
     return ExecForRangeHelper(stat, 2);
 }
 
-UInt ExecForRange3(Stat stat)
+static UInt ExecForRange3(Stat stat)
 {
     return ExecForRangeHelper(stat, 3);
 }
@@ -576,7 +576,7 @@ UInt ExecForRange3(Stat stat)
 */
 
 #ifdef HPCGAP
-UInt ExecAtomic(Stat stat)
+static UInt ExecAtomic(Stat stat)
 {
   Obj tolock[MAX_ATOMIC_OBJS];
   LockMode lockmode[MAX_ATOMIC_OBJS];
@@ -694,17 +694,17 @@ static ALWAYS_INLINE UInt ExecWhileHelper(Stat stat, UInt nr)
     return 0;
 }
 
-UInt ExecWhile(Stat stat)
+static UInt ExecWhile(Stat stat)
 {
     return ExecWhileHelper(stat, 1);
 }
 
-UInt ExecWhile2(Stat stat)
+static UInt ExecWhile2(Stat stat)
 {
     return ExecWhileHelper(stat, 2);
 }
 
-UInt ExecWhile3(Stat stat)
+static UInt ExecWhile3(Stat stat)
 {
     return ExecWhileHelper(stat, 3);
 }
@@ -767,17 +767,17 @@ static ALWAYS_INLINE UInt ExecRepeatHelper(Stat stat, UInt nr)
     return 0;
 }
 
-UInt ExecRepeat(Stat stat)
+static UInt ExecRepeat(Stat stat)
 {
     return ExecRepeatHelper(stat, 1);
 }
 
-UInt ExecRepeat2(Stat stat)
+static UInt ExecRepeat2(Stat stat)
 {
     return ExecRepeatHelper(stat, 2);
 }
 
-UInt ExecRepeat3(Stat stat)
+static UInt ExecRepeat3(Stat stat)
 {
     return ExecRepeatHelper(stat, 3);
 }
@@ -795,7 +795,7 @@ UInt ExecRepeat3(Stat stat)
 **  A break-statement is  represented  by a bag of   type 'T_BREAK' with   no
 **  subbags.
 */
-UInt            ExecBreak (
+static UInt            ExecBreak (
     Stat                stat )
 {
     /* return to the next loop                                             */
@@ -814,7 +814,7 @@ UInt            ExecBreak (
 **  A continue-statement is  represented  by a bag of   type 'T_CONTINUE' with   no
 **  subbags.
 */
-UInt            ExecContinue (
+static UInt            ExecContinue (
     Stat                stat )
 {
     /* return to the next loop                                             */
@@ -827,7 +827,7 @@ UInt            ExecContinue (
 **
 **  Does nothing
 */
-UInt ExecEmpty( Stat stat )
+static UInt ExecEmpty( Stat stat )
 {
   return 0;
 }
@@ -846,7 +846,7 @@ UInt ExecEmpty( Stat stat )
 **  An  info-statement is represented by a  bag of type 'T_INFO' with subbags
 **  for the arguments
 */
-UInt ExecInfo (
+static UInt ExecInfo (
     Stat            stat )
 {
     Obj             selectors;
@@ -898,7 +898,7 @@ UInt ExecInfo (
 **  A 2 argument assert-statement is  represented  by a bag of   type
 **  'T_ASSERT_2ARGS' with subbags for the 2 arguments
 */
-UInt ExecAssert2Args (
+static UInt ExecAssert2Args (
     Stat            stat )
 {
     Obj             level;
@@ -927,7 +927,7 @@ UInt ExecAssert2Args (
 **  A 3 argument assert-statement is  represented  by a bag of   type
 **  'T_ASSERT_3ARGS' with subbags for the 3 arguments
 */
-UInt ExecAssert3Args (
+static UInt ExecAssert3Args (
     Stat            stat )
 {
     Obj             level;
@@ -970,7 +970,7 @@ UInt ExecAssert3Args (
 **  with      one  subbag.    This  subbag     is   the    expression  of the
 **  return-value-statement.
 */
-UInt            ExecReturnObj (
+static UInt            ExecReturnObj (
     Stat                stat )
 {
 #if !defined(HAVE_SIGNAL)
@@ -1001,7 +1001,7 @@ UInt            ExecReturnObj (
 **  A return-void-statement  is represented by  a bag of type 'T_RETURN_VOID'
 **  with no subbags.
 */
-UInt            ExecReturnVoid (
+static UInt            ExecReturnVoid (
     Stat                stat )
 {
 #if !defined(HAVE_SIGNAL)
@@ -1074,7 +1074,7 @@ UInt TakeInterrupt( void )
 **  redispatches after a return from the break-loop.
 */
 
-UInt ExecIntrStat (
+static UInt ExecIntrStat (
     Stat                stat )
 {
 
@@ -1192,7 +1192,7 @@ void            (* PrintStatFuncs[256] ) ( Stat stat );
 **  this  is  ever called,   then GAP  is in  serious   trouble, such  as  an
 **  overwritten type field of a statement.
 */
-void            PrintUnknownStat (
+static void            PrintUnknownStat (
     Stat                stat )
 {
     ErrorQuit(
@@ -1207,7 +1207,7 @@ void            PrintUnknownStat (
 **
 **  'PrintSeqStat' prints the statement sequence <stat>.
 */
-void            PrintSeqStat (
+static void            PrintSeqStat (
     Stat                stat )
 {
     UInt                nr;             /* number of statements            */
@@ -1239,7 +1239,7 @@ void            PrintSeqStat (
 **  Linebreaks are printed after the 'then' and the statements in the bodies.
 **  If necessary one is preferred immediately before the 'then'.
 */
-void            PrintIf (
+static void            PrintIf (
     Stat                stat )
 {
     UInt                i;              /* loop variable                   */
@@ -1282,7 +1282,7 @@ void            PrintIf (
 **  Linebreaks are printed after the 'do' and the statements in the body.  If
 **  necesarry it is preferred immediately before the 'in'.
 */
-void            PrintFor (
+static void            PrintFor (
     Stat                stat )
 {
     UInt                i;              /* loop variable                   */
@@ -1309,7 +1309,7 @@ void            PrintFor (
 **  Linebreaks are printed after the 'do' and the statments  in the body.  If
 **  necessary one is preferred immediately before the 'do'.
 */
-void            PrintWhile (
+static void            PrintWhile (
     Stat                stat )
 {
     UInt                i;              /* loop variable                   */
@@ -1334,7 +1334,7 @@ void            PrintWhile (
 **  necessary one is preferred immediately before the 'do'.
 */
 #ifdef HPCGAP
-void            PrintAtomic (
+static void            PrintAtomic (
     Stat                stat )
 {
   UInt nrexprs;
@@ -1373,7 +1373,7 @@ void            PrintAtomic (
 **  Linebreaks are printed after the 'repeat' and the statements in the body.
 **  If necessary one is preferred after the 'until'.
 */
-void            PrintRepeat (
+static void            PrintRepeat (
     Stat                stat )
 {
     UInt                i;              /* loop variable                   */
@@ -1395,7 +1395,7 @@ void            PrintRepeat (
 **
 **  'PrintBreak' prints the break-statement <stat>.
 */
-void            PrintBreak (
+static void            PrintBreak (
     Stat                stat )
 {
     Pr( "break;", 0L, 0L );
@@ -1407,7 +1407,7 @@ void            PrintBreak (
 **
 **  'PrintContinue' prints the continue-statement <stat>.
 */
-void            PrintContinue (
+static void            PrintContinue (
     Stat                stat )
 {
     Pr( "continue;", 0L, 0L );
@@ -1418,7 +1418,7 @@ void            PrintContinue (
 *F  PrintEmpty(<stat>)
 **
 */
-void             PrintEmpty( Stat stat )
+static void             PrintEmpty( Stat stat )
 {
   Pr( ";", 0L, 0L);
 }
@@ -1430,7 +1430,7 @@ void             PrintEmpty( Stat stat )
 **  'PrintInfo' prints the info-statement <stat>.
 */
 
-void            PrintInfo (
+static void            PrintInfo (
     Stat               stat )
 {
     UInt                i;              /* loop variable                   */
@@ -1460,7 +1460,7 @@ void            PrintInfo (
 **  'PrintAssert2Args' prints the 2 argument assert-statement <stat>.
 */
 
-void            PrintAssert2Args (
+static void            PrintAssert2Args (
     Stat               stat )
 {
 
@@ -1486,7 +1486,7 @@ void            PrintAssert2Args (
 **  'PrintAssert3Args' prints the 3 argument assert-statement <stat>.
 */
 
-void            PrintAssert3Args (
+static void            PrintAssert3Args (
     Stat               stat )
 {
 
@@ -1515,7 +1515,7 @@ void            PrintAssert3Args (
 **
 **  'PrintReturnObj' prints the return-value-statement <stat>.
 */
-void            PrintReturnObj (
+static void            PrintReturnObj (
     Stat                stat )
 {
     Expr expr = READ_STAT(stat, 0);
@@ -1537,7 +1537,7 @@ void            PrintReturnObj (
 **
 **  'PrintReturnVoid' prints the return-void-statement <stat>.
 */
-void            PrintReturnVoid (
+static void            PrintReturnVoid (
     Stat                stat )
 {
     Pr( "return;", 0L, 0L );

--- a/src/streams.c
+++ b/src/streams.c
@@ -221,7 +221,7 @@ static Obj FuncREAD_ALL_COMMANDS(
  The second entry, if present, is the return value of
  the command. If it not present, the command returned nothing.
 */
-static Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
+static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
 {
     Int status;
     Obj result;
@@ -532,8 +532,7 @@ Int READ_GAP_ROOT ( const Char * filename )
 **  input   from  '*stdin*'  and  '*errin*'  and  output  to  '*stdout*'  and
 **  '*errout*' will no longer be echoed to a file.
 */
-static Obj FuncCLOSE_LOG_TO (
-    Obj                 self )
+static Obj FuncCLOSE_LOG_TO(Obj self)
 {
     if ( ! CloseLog() ) {
         ErrorQuit("LogTo: can not close the logfile",0L,0L);
@@ -556,9 +555,7 @@ static Obj FuncCLOSE_LOG_TO (
 **  '*stdout*'  and  '*errout*',  to  the  file  with  the  name  <filename>.
 **  The file is created if it does not  exist,  otherwise  it  is  truncated.
 */
-static Obj FuncLOG_TO (
-    Obj                 self,
-    Obj                 filename )
+static Obj FuncLOG_TO(Obj self, Obj filename)
 {
     RequireStringRep("LogTo", filename);
     if ( ! OpenLog( CONST_CSTR_STRING(filename) ) ) {
@@ -575,9 +572,7 @@ static Obj FuncLOG_TO (
 **
 *F  FuncLOG_TO_STREAM( <stream> ) . . . . . . . . . start logging to a stream
 */
-static Obj FuncLOG_TO_STREAM (
-    Obj                 self,
-    Obj                 stream )
+static Obj FuncLOG_TO_STREAM(Obj self, Obj stream)
 {
     if ( ! OpenLogStream(stream) ) {
         ErrorReturnVoid( "LogTo: cannot log to stream", 0L, 0L,
@@ -600,8 +595,7 @@ static Obj FuncLOG_TO_STREAM (
 **  that input from  '*stdin*' and '*errin*' will   no longer be  echoed to a
 **  file.
 */
-static Obj FuncCLOSE_INPUT_LOG_TO (
-    Obj                 self )
+static Obj FuncCLOSE_INPUT_LOG_TO(Obj self)
 {
     if ( ! CloseInputLog() ) {
         ErrorQuit("InputLogTo: can not close the logfile",0L,0L);
@@ -623,9 +617,7 @@ static Obj FuncCLOSE_INPUT_LOG_TO (
 **  files, '*stdin*' and '*errin*' to the file with the name <filename>.  The
 **  file is created if it does not exist, otherwise it is truncated.
 */
-static Obj FuncINPUT_LOG_TO (
-    Obj                 self,
-    Obj                 filename )
+static Obj FuncINPUT_LOG_TO(Obj self, Obj filename)
 {
     RequireStringRep("InputLogTo", filename);
     if ( ! OpenInputLog( CONST_CSTR_STRING(filename) ) ) {
@@ -642,9 +634,7 @@ static Obj FuncINPUT_LOG_TO (
 **
 *F  FuncINPUT_LOG_TO_STREAM( <stream> ) . . . . . . start logging to a stream
 */
-static Obj FuncINPUT_LOG_TO_STREAM (
-    Obj                 self,
-    Obj                 stream )
+static Obj FuncINPUT_LOG_TO_STREAM(Obj self, Obj stream)
 {
     if ( ! OpenInputLogStream(stream) ) {
         ErrorReturnVoid( "InputLogTo: cannot log to stream", 0L, 0L,
@@ -667,8 +657,7 @@ static Obj FuncINPUT_LOG_TO_STREAM (
 **  so that output from '*stdin*' and '*errin*' will no longer be echoed to a
 **  file.
 */
-static Obj FuncCLOSE_OUTPUT_LOG_TO (
-    Obj                 self )
+static Obj FuncCLOSE_OUTPUT_LOG_TO(Obj self)
 {
     if ( ! CloseOutputLog() ) {
         ErrorQuit("OutputLogTo: can not close the logfile",0L,0L);
@@ -690,9 +679,7 @@ static Obj FuncCLOSE_OUTPUT_LOG_TO (
 **  files, '*stdin*' and '*errin*' to the file with the name <filename>.  The
 **  file is created if it does not exist, otherwise it is truncated.
 */
-static Obj FuncOUTPUT_LOG_TO (
-    Obj                 self,
-    Obj                 filename )
+static Obj FuncOUTPUT_LOG_TO(Obj self, Obj filename)
 {
     RequireStringRep("OutputLogTo", filename);
     if ( ! OpenOutputLog( CONST_CSTR_STRING(filename) ) ) {
@@ -709,9 +696,7 @@ static Obj FuncOUTPUT_LOG_TO (
 **
 *F  FuncOUTPUT_LOG_TO_STREAM( <stream> ) . . . . .  start logging to a stream
 */
-static Obj FuncOUTPUT_LOG_TO_STREAM (
-    Obj                 self,
-    Obj                 stream )
+static Obj FuncOUTPUT_LOG_TO_STREAM(Obj self, Obj stream)
 {
     if ( ! OpenOutputLogStream(stream) ) {
         ErrorReturnVoid( "OutputLogTo: cannot log to stream", 0L, 0L,
@@ -726,9 +711,7 @@ static Obj FuncOUTPUT_LOG_TO_STREAM (
 **
 *F  FuncPrint( <self>, <args> ) . . . . . . . . . . . . . . . .  print <args>
 */
-static Obj FuncPrint (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncPrint(Obj self, Obj args)
 {
     volatile Obj        arg;
     volatile UInt       i;
@@ -851,9 +834,7 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
 **
 *F  FuncPRINT_TO( <self>, <args> )  . . . . . . . . . . . . . .  print <args>
 */
-static Obj FuncPRINT_TO (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncPRINT_TO(Obj self, Obj args)
 {
     return PRINT_OR_APPEND_TO(args, 0);
 }
@@ -863,9 +844,7 @@ static Obj FuncPRINT_TO (
 **
 *F  FuncPRINT_TO_STREAM( <self>, <args> ) . . . . . . . . . . .  print <args>
 */
-static Obj FuncPRINT_TO_STREAM (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncPRINT_TO_STREAM(Obj self, Obj args)
 {
     /* Note that FuncPRINT_TO_STREAM and FuncAPPEND_TO_STREAM do exactly the
        same, they only differ in the function name they print as part
@@ -878,9 +857,7 @@ static Obj FuncPRINT_TO_STREAM (
 **
 *F  FuncAPPEND_TO( <self>, <args> ) . . . . . . . . . . . . . . append <args>
 */
-static Obj FuncAPPEND_TO (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncAPPEND_TO(Obj self, Obj args)
 {
     return PRINT_OR_APPEND_TO(args, 1);
 }
@@ -890,9 +867,7 @@ static Obj FuncAPPEND_TO (
 **
 *F  FuncAPPEND_TO_STREAM( <self>, <args> )  . . . . . . . . . . append <args>
 */
-static Obj FuncAPPEND_TO_STREAM (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncAPPEND_TO_STREAM(Obj self, Obj args)
 {
     /* Note that FuncPRINT_TO_STREAM and FuncAPPEND_TO_STREAM do exactly the
        same, they only differ in the function name they print as part
@@ -907,9 +882,7 @@ static Obj FuncAPPEND_TO_STREAM (
 **
 **  Read the current input and close the input stream.
 */
-static Obj FuncREAD (
-    Obj                 self,
-    Obj                 filename )
+static Obj FuncREAD(Obj self, Obj filename)
 {
    /* check the argument                                                  */
     RequireStringRep("READ", filename);
@@ -932,9 +905,7 @@ static Obj FuncREAD (
 **  a live prompt. This is initially designed for the files read from the
 **  command line.
 */
-static Obj FuncREAD_NORECOVERY (
-    Obj                 self,
-    Obj                 input )
+static Obj FuncREAD_NORECOVERY(Obj self, Obj input)
 {
     if ( IsStringConv( input ) ) {
         if ( ! OpenInput( CONST_CSTR_STRING(input) ) ) {
@@ -964,9 +935,7 @@ static Obj FuncREAD_NORECOVERY (
 **
 *F  FuncREAD_STREAM( <self>, <stream> )   . . . . . . . . . . . read a stream
 */
-static Obj FuncREAD_STREAM (
-    Obj                 self,
-    Obj                 stream )
+static Obj FuncREAD_STREAM(Obj self, Obj stream)
 {
 
     if (CALL_1ARGS(IsInputStream, stream) != True) {
@@ -989,11 +958,10 @@ static Obj FuncREAD_STREAM (
 **  Read data from <instream> in a read-eval-view loop and write all output
 **  to <outstream>.
 */
-static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT (
-    Obj                 self,
-    Obj                 instream,
-    Obj                 outstream,
-    Obj context )
+static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT(Obj self,
+                                             Obj instream,
+                                             Obj outstream,
+                                             Obj context)
 {
     Int res;
 
@@ -1028,10 +996,7 @@ static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT (
     return res ? True : False;
 }
 
-static Obj FuncREAD_STREAM_LOOP (
-    Obj                 self,
-    Obj                 stream,
-    Obj                 catcherrstdout)
+static Obj FuncREAD_STREAM_LOOP(Obj self, Obj stream, Obj catcherrstdout)
 {
     return FuncREAD_STREAM_LOOP_WITH_CONTEXT(self, stream, catcherrstdout,
                                              STATE(BottomLVars));
@@ -1040,9 +1005,7 @@ static Obj FuncREAD_STREAM_LOOP (
 **
 *F  FuncREAD_AS_FUNC( <self>, <filename> )  . . . . . . . . . . . read a file
 */
-static Obj FuncREAD_AS_FUNC (
-    Obj                 self,
-    Obj                 filename )
+static Obj FuncREAD_AS_FUNC(Obj self, Obj filename)
 {
     // check the argument
     RequireStringRep("READ_AS_FUNC", filename);
@@ -1061,9 +1024,7 @@ static Obj FuncREAD_AS_FUNC (
 **
 *F  FuncREAD_AS_FUNC_STREAM( <self>, <filename> ) . . . . . . . . read a file
 */
-static Obj FuncREAD_AS_FUNC_STREAM (
-    Obj                 self,
-    Obj                 stream )
+static Obj FuncREAD_AS_FUNC_STREAM(Obj self, Obj stream)
 {
     if (CALL_1ARGS(IsInputStream, stream) != True) {
         ErrorQuit("READ_AS_FUNC_STREAM: <stream> must be an input stream", 0, 0);
@@ -1083,9 +1044,7 @@ static Obj FuncREAD_AS_FUNC_STREAM (
 **
 *F  FuncREAD_GAP_ROOT( <self>, <filename> ) . . . . . . . . . . . read a file
 */
-static Obj FuncREAD_GAP_ROOT (
-    Obj                 self,
-    Obj                 filename )
+static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 {
     Char filenamecpy[GAP_PATH_MAX];
 
@@ -1103,8 +1062,7 @@ static Obj FuncREAD_GAP_ROOT (
 **
 *F  FuncTmpName( <self> ) . . . . . . . . . . . . . . return a temporary name
 */
-static Obj FuncTmpName (
-    Obj                 self )
+static Obj FuncTmpName(Obj self)
 {
     Char *              tmp;
     Obj                 name;
@@ -1121,8 +1079,7 @@ static Obj FuncTmpName (
 **
 *F  FuncTmpDirectory( <self> )  . . . . . . . .  return a temporary directory
 */
-static Obj FuncTmpDirectory (
-    Obj                 self )
+static Obj FuncTmpDirectory(Obj self)
 {
     Char *              tmp;
     Obj                 name;
@@ -1139,9 +1096,7 @@ static Obj FuncTmpDirectory (
 **
 *F  FuncRemoveFile( <self>, <name> )  . . . . . . . . . .  remove file <name>
 */
-static Obj FuncRemoveFile (
-    Obj             self,
-    Obj             filename )
+static Obj FuncRemoveFile(Obj self, Obj filename)
 {
     // check the argument
     RequireStringRep("RemoveFile", filename);
@@ -1154,9 +1109,7 @@ static Obj FuncRemoveFile (
 **
 *F  FuncCreateDir( <self>, <name> )  . . . . . . . . . . . . create directory
 */
-static Obj FuncCreateDir (
-    Obj             self,
-    Obj             filename )
+static Obj FuncCreateDir(Obj self, Obj filename)
 {
     // check the argument
     RequireStringRep("CreateDir", filename);
@@ -1169,9 +1122,7 @@ static Obj FuncCreateDir (
 **
 *F  FuncRemoveDir( <self>, <name> )  . . . . . . . . . . . . remove directory
 */
-static Obj FuncRemoveDir (
-    Obj             self,
-    Obj             filename )
+static Obj FuncRemoveDir(Obj self, Obj filename)
 {
     // check the argument
     RequireStringRep("RemoveDir", filename);
@@ -1184,9 +1135,7 @@ static Obj FuncRemoveDir (
 **
 *F  FuncIsDir( <self>, <name> )  . . . . . check whether something is a dir
 */
-static Obj FuncIsDir (
-    Obj             self,
-    Obj             filename )
+static Obj FuncIsDir(Obj self, Obj filename)
 {
     RequireStringRep("IsDir", filename);
 
@@ -1210,8 +1159,7 @@ static Obj FuncIsDir (
 static UInt ErrorMessageRNam;
 static UInt ErrorNumberRNam;
 
-static Obj FuncLastSystemError (
-    Obj             self )
+static Obj FuncLastSystemError(Obj self)
 {
     Obj             err;
     Obj             msg;
@@ -1242,9 +1190,7 @@ static Obj FuncLastSystemError (
 **
 *F  FuncIsExistingFile( <self>, <name> )  . . . . . . does file <name> exists
 */
-static Obj FuncIsExistingFile (
-    Obj             self,
-    Obj             filename )
+static Obj FuncIsExistingFile(Obj self, Obj filename)
 {
     Int             res;
 
@@ -1261,9 +1207,7 @@ static Obj FuncIsExistingFile (
 **
 *F  FuncIsReadableFile( <self>, <name> )  . . . . . . is file <name> readable
 */
-static Obj FuncIsReadableFile (
-    Obj             self,
-    Obj             filename )
+static Obj FuncIsReadableFile(Obj self, Obj filename)
 {
     Int             res;
 
@@ -1280,9 +1224,7 @@ static Obj FuncIsReadableFile (
 **
 *F  FuncIsWritableFile( <self>, <name> )  . . . . . . is file <name> writable
 */
-static Obj FuncIsWritableFile (
-    Obj             self,
-    Obj             filename )
+static Obj FuncIsWritableFile(Obj self, Obj filename)
 {
     Int             res;
 
@@ -1299,9 +1241,7 @@ static Obj FuncIsWritableFile (
 **
 *F  FuncIsExecutableFile( <self>, <name> )  . . . . is file <name> executable
 */
-static Obj FuncIsExecutableFile (
-    Obj             self,
-    Obj             filename )
+static Obj FuncIsExecutableFile(Obj self, Obj filename)
 {
     Int             res;
 
@@ -1318,9 +1258,7 @@ static Obj FuncIsExecutableFile (
 **
 *F  FuncIsDirectoryPath( <self>, <name> ) . . . .  is file <name> a directory
 */
-static Obj FuncIsDirectoryPathString (
-    Obj             self,
-    Obj             filename )
+static Obj FuncIsDirectoryPathString(Obj self, Obj filename)
 {
     Int             res;
 
@@ -1345,9 +1283,7 @@ static Obj FuncIsDirectoryPathString (
 **  reason for the error can be found with 'LastSystemError();' in GAP.
 **
 */
-static Obj FuncSTRING_LIST_DIR (
-    Obj         self,
-    Obj         dirname  )
+static Obj FuncSTRING_LIST_DIR(Obj self, Obj dirname)
 {
     DIR *dir;
     struct dirent *entry;
@@ -1389,9 +1325,7 @@ static Obj FuncSTRING_LIST_DIR (
 **
 *F  FuncCLOSE_FILE( <self>, <fid> ) . . . . . . . . . . . . .  close a stream
 */
-static Obj FuncCLOSE_FILE (
-    Obj             self,
-    Obj             fid )
+static Obj FuncCLOSE_FILE(Obj self, Obj fid)
 {
     // check the argument
     Int ifid = GetSmallInt("CLOSE_FILE", fid);
@@ -1406,9 +1340,7 @@ static Obj FuncCLOSE_FILE (
 **
 *F  FuncINPUT_TEXT_FILE( <self>, <name> ) . . . . . . . . . . . open a stream
 */
-static Obj FuncINPUT_TEXT_FILE (
-    Obj             self,
-    Obj             filename )
+static Obj FuncINPUT_TEXT_FILE(Obj self, Obj filename)
 {
     Int             fid;
 
@@ -1428,9 +1360,7 @@ static Obj FuncINPUT_TEXT_FILE (
 **
 *F  FuncIS_END_OF_FILE( <self>, <fid> ) . . . . . . . . . . .  is end of file
 */
-static Obj FuncIS_END_OF_FILE (
-    Obj             self,
-    Obj             fid )
+static Obj FuncIS_END_OF_FILE(Obj self, Obj fid)
 {
     // check the argument
     Int ifid = GetSmallInt("IS_END_OF_FILE", fid);
@@ -1444,10 +1374,7 @@ static Obj FuncIS_END_OF_FILE (
 **
 *F  FuncOUTPUT_TEXT_FILE( <self>, <name>, <append> )  . . . . . open a stream
 */
-static Obj FuncOUTPUT_TEXT_FILE (
-    Obj             self,
-    Obj             filename,
-    Obj             append )
+static Obj FuncOUTPUT_TEXT_FILE(Obj self, Obj filename, Obj append)
 {
     Int             fid;
 
@@ -1478,9 +1405,7 @@ static Obj FuncOUTPUT_TEXT_FILE (
 **
 *F  FuncPOSITION_FILE( <self>, <fid> )  . . . . . . . . .  position of stream
 */
-static Obj FuncPOSITION_FILE (
-    Obj             self,
-    Obj             fid )
+static Obj FuncPOSITION_FILE(Obj self, Obj fid)
 {
     // check the argument
     Int ifid = GetSmallInt("POSITION_FILE", fid);
@@ -1501,9 +1426,7 @@ static Obj FuncPOSITION_FILE (
 **
 *F  FuncREAD_BYTE_FILE( <self>, <fid> ) . . . . . . . . . . . . . read a byte
 */
-static Obj FuncREAD_BYTE_FILE (
-    Obj             self,
-    Obj             fid )
+static Obj FuncREAD_BYTE_FILE(Obj self, Obj fid)
 {
     // check the argument
     Int ifid = GetSmallInt("READ_BYTE_FILE", fid);
@@ -1521,9 +1444,7 @@ static Obj FuncREAD_BYTE_FILE (
 **  
 **  This uses fgets and works only if there are no zero characters in <fid>.
 */
-static Obj FuncREAD_LINE_FILE (
-    Obj             self,
-    Obj             fid )
+static Obj FuncREAD_LINE_FILE(Obj self, Obj fid)
 {
     Char            buf[256];
     Char *          cstr;
@@ -1572,10 +1493,7 @@ static Obj FuncREAD_LINE_FILE (
 **   (c) we have read <limit> bytes (-1 indicates no limit)
 */
 
-static Obj FuncREAD_ALL_FILE (
-    Obj             self,
-    Obj             fid,
-    Obj             limit)
+static Obj FuncREAD_ALL_FILE(Obj self, Obj fid, Obj limit)
 {
     Char            buf[20000];
     Int             len;
@@ -1666,10 +1584,7 @@ static Obj FuncREAD_ALL_FILE (
 **
 *F  FuncSEEK_POSITION_FILE( <self>, <fid>, <pos> )  . seek position of stream
 */
-static Obj FuncSEEK_POSITION_FILE (
-    Obj             self,
-    Obj             fid,
-    Obj             pos )
+static Obj FuncSEEK_POSITION_FILE(Obj self, Obj fid, Obj pos)
 {
     Int             ret;
 
@@ -1686,10 +1601,7 @@ static Obj FuncSEEK_POSITION_FILE (
 **
 *F  FuncWRITE_BYTE_FILE( <self>, <fid>, <byte> )  . . . . . . .  write a byte
 */
-static Obj FuncWRITE_BYTE_FILE (
-    Obj             self,
-    Obj             fid,
-    Obj             ch )
+static Obj FuncWRITE_BYTE_FILE(Obj self, Obj fid, Obj ch)
 {
     // check the argument
     Int ifid = GetSmallInt("WRITE_BYTE_FILE", fid);
@@ -1704,10 +1616,7 @@ static Obj FuncWRITE_BYTE_FILE (
 **
 *F  FuncWRITE_STRING_FILE_NC( <self>, <fid>, <string> ) .write a whole string
 */
-static Obj FuncWRITE_STRING_FILE_NC (
-    Obj             self,
-    Obj             fid,
-    Obj             str )
+static Obj FuncWRITE_STRING_FILE_NC(Obj self, Obj fid, Obj str)
 {
     Int             len = 0, l, ret;
     const char      *ptr;
@@ -1729,9 +1638,7 @@ static Obj FuncWRITE_STRING_FILE_NC (
     return True;
 }
 
-static Obj FuncREAD_STRING_FILE (
-    Obj             self,
-    Obj             fid )
+static Obj FuncREAD_STRING_FILE(Obj self, Obj fid)
 {
     // check the argument
     Int ifid = GetSmallInt("READ_STRING_FILE", fid);
@@ -1742,7 +1649,7 @@ static Obj FuncREAD_STRING_FILE (
 **
 *F  FuncFD_OF_FILE( <fid> )
 */
-static Obj FuncFD_OF_FILE(Obj self,Obj fid)
+static Obj FuncFD_OF_FILE(Obj self, Obj fid)
 {
     Int fd = GetSmallInt("FD_OF_FILE", fid);
     Int fdi = SyBufFileno(fd);
@@ -1763,8 +1670,12 @@ static Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 #endif
 
 #ifdef HAVE_SELECT
-static Obj FuncUNIXSelect(Obj self, Obj inlist, Obj outlist, Obj exclist, 
-                   Obj timeoutsec, Obj timeoutusec)
+static Obj FuncUNIXSelect(Obj self,
+                          Obj inlist,
+                          Obj outlist,
+                          Obj exclist,
+                          Obj timeoutsec,
+                          Obj timeoutusec)
 {
   fd_set infds,outfds,excfds;
   struct timeval tv;
@@ -1882,13 +1793,8 @@ static Obj FuncUNIXSelect(Obj self, Obj inlist, Obj outlist, Obj exclist,
 static Obj    ExecArgs  [ 1024 ];
 static Char * ExecCArgs [ 1024 ];
 
-static Obj FuncExecuteProcess (
-    Obj                 self,
-    Obj                 dir,
-    Obj                 prg,
-    Obj                 in,
-    Obj                 out,
-    Obj                 args )
+static Obj
+FuncExecuteProcess(Obj self, Obj dir, Obj prg, Obj in, Obj out, Obj args)
 {
     Obj                 tmp;
     Int                 res;

--- a/src/streams.c
+++ b/src/streams.c
@@ -207,7 +207,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
     return resultList;
 }
 
-Obj FuncREAD_ALL_COMMANDS(
+static Obj FuncREAD_ALL_COMMANDS(
     Obj self, Obj instream, Obj echo, Obj capture, Obj resultCallback)
 {
     return READ_ALL_COMMANDS(instream, echo, capture, resultCallback);
@@ -221,7 +221,7 @@ Obj FuncREAD_ALL_COMMANDS(
  The second entry, if present, is the return value of
  the command. If it not present, the command returned nothing.
 */
-Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
+static Obj FuncREAD_COMMAND_REAL ( Obj self, Obj stream, Obj echo )
 {
     Int status;
     Obj result;
@@ -532,7 +532,7 @@ Int READ_GAP_ROOT ( const Char * filename )
 **  input   from  '*stdin*'  and  '*errin*'  and  output  to  '*stdout*'  and
 **  '*errout*' will no longer be echoed to a file.
 */
-Obj FuncCLOSE_LOG_TO (
+static Obj FuncCLOSE_LOG_TO (
     Obj                 self )
 {
     if ( ! CloseLog() ) {
@@ -556,7 +556,7 @@ Obj FuncCLOSE_LOG_TO (
 **  '*stdout*'  and  '*errout*',  to  the  file  with  the  name  <filename>.
 **  The file is created if it does not  exist,  otherwise  it  is  truncated.
 */
-Obj FuncLOG_TO (
+static Obj FuncLOG_TO (
     Obj                 self,
     Obj                 filename )
 {
@@ -575,7 +575,7 @@ Obj FuncLOG_TO (
 **
 *F  FuncLOG_TO_STREAM( <stream> ) . . . . . . . . . start logging to a stream
 */
-Obj FuncLOG_TO_STREAM (
+static Obj FuncLOG_TO_STREAM (
     Obj                 self,
     Obj                 stream )
 {
@@ -600,7 +600,7 @@ Obj FuncLOG_TO_STREAM (
 **  that input from  '*stdin*' and '*errin*' will   no longer be  echoed to a
 **  file.
 */
-Obj FuncCLOSE_INPUT_LOG_TO (
+static Obj FuncCLOSE_INPUT_LOG_TO (
     Obj                 self )
 {
     if ( ! CloseInputLog() ) {
@@ -623,7 +623,7 @@ Obj FuncCLOSE_INPUT_LOG_TO (
 **  files, '*stdin*' and '*errin*' to the file with the name <filename>.  The
 **  file is created if it does not exist, otherwise it is truncated.
 */
-Obj FuncINPUT_LOG_TO (
+static Obj FuncINPUT_LOG_TO (
     Obj                 self,
     Obj                 filename )
 {
@@ -642,7 +642,7 @@ Obj FuncINPUT_LOG_TO (
 **
 *F  FuncINPUT_LOG_TO_STREAM( <stream> ) . . . . . . start logging to a stream
 */
-Obj FuncINPUT_LOG_TO_STREAM (
+static Obj FuncINPUT_LOG_TO_STREAM (
     Obj                 self,
     Obj                 stream )
 {
@@ -667,7 +667,7 @@ Obj FuncINPUT_LOG_TO_STREAM (
 **  so that output from '*stdin*' and '*errin*' will no longer be echoed to a
 **  file.
 */
-Obj FuncCLOSE_OUTPUT_LOG_TO (
+static Obj FuncCLOSE_OUTPUT_LOG_TO (
     Obj                 self )
 {
     if ( ! CloseOutputLog() ) {
@@ -690,7 +690,7 @@ Obj FuncCLOSE_OUTPUT_LOG_TO (
 **  files, '*stdin*' and '*errin*' to the file with the name <filename>.  The
 **  file is created if it does not exist, otherwise it is truncated.
 */
-Obj FuncOUTPUT_LOG_TO (
+static Obj FuncOUTPUT_LOG_TO (
     Obj                 self,
     Obj                 filename )
 {
@@ -709,7 +709,7 @@ Obj FuncOUTPUT_LOG_TO (
 **
 *F  FuncOUTPUT_LOG_TO_STREAM( <stream> ) . . . . .  start logging to a stream
 */
-Obj FuncOUTPUT_LOG_TO_STREAM (
+static Obj FuncOUTPUT_LOG_TO_STREAM (
     Obj                 self,
     Obj                 stream )
 {
@@ -726,7 +726,7 @@ Obj FuncOUTPUT_LOG_TO_STREAM (
 **
 *F  FuncPrint( <self>, <args> ) . . . . . . . . . . . . . . . .  print <args>
 */
-Obj FuncPrint (
+static Obj FuncPrint (
     Obj                 self,
     Obj                 args )
 {
@@ -851,7 +851,7 @@ static Obj PRINT_OR_APPEND_TO_STREAM(Obj args, int append)
 **
 *F  FuncPRINT_TO( <self>, <args> )  . . . . . . . . . . . . . .  print <args>
 */
-Obj FuncPRINT_TO (
+static Obj FuncPRINT_TO (
     Obj                 self,
     Obj                 args )
 {
@@ -863,7 +863,7 @@ Obj FuncPRINT_TO (
 **
 *F  FuncPRINT_TO_STREAM( <self>, <args> ) . . . . . . . . . . .  print <args>
 */
-Obj FuncPRINT_TO_STREAM (
+static Obj FuncPRINT_TO_STREAM (
     Obj                 self,
     Obj                 args )
 {
@@ -878,7 +878,7 @@ Obj FuncPRINT_TO_STREAM (
 **
 *F  FuncAPPEND_TO( <self>, <args> ) . . . . . . . . . . . . . . append <args>
 */
-Obj FuncAPPEND_TO (
+static Obj FuncAPPEND_TO (
     Obj                 self,
     Obj                 args )
 {
@@ -890,7 +890,7 @@ Obj FuncAPPEND_TO (
 **
 *F  FuncAPPEND_TO_STREAM( <self>, <args> )  . . . . . . . . . . append <args>
 */
-Obj FuncAPPEND_TO_STREAM (
+static Obj FuncAPPEND_TO_STREAM (
     Obj                 self,
     Obj                 args )
 {
@@ -907,7 +907,7 @@ Obj FuncAPPEND_TO_STREAM (
 **
 **  Read the current input and close the input stream.
 */
-Obj FuncREAD (
+static Obj FuncREAD (
     Obj                 self,
     Obj                 filename )
 {
@@ -932,7 +932,7 @@ Obj FuncREAD (
 **  a live prompt. This is initially designed for the files read from the
 **  command line.
 */
-Obj FuncREAD_NORECOVERY (
+static Obj FuncREAD_NORECOVERY (
     Obj                 self,
     Obj                 input )
 {
@@ -964,7 +964,7 @@ Obj FuncREAD_NORECOVERY (
 **
 *F  FuncREAD_STREAM( <self>, <stream> )   . . . . . . . . . . . read a stream
 */
-Obj FuncREAD_STREAM (
+static Obj FuncREAD_STREAM (
     Obj                 self,
     Obj                 stream )
 {
@@ -989,7 +989,7 @@ Obj FuncREAD_STREAM (
 **  Read data from <instream> in a read-eval-view loop and write all output
 **  to <outstream>.
 */
-Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT (
+static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT (
     Obj                 self,
     Obj                 instream,
     Obj                 outstream,
@@ -1028,7 +1028,7 @@ Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT (
     return res ? True : False;
 }
 
-Obj FuncREAD_STREAM_LOOP (
+static Obj FuncREAD_STREAM_LOOP (
     Obj                 self,
     Obj                 stream,
     Obj                 catcherrstdout)
@@ -1040,7 +1040,7 @@ Obj FuncREAD_STREAM_LOOP (
 **
 *F  FuncREAD_AS_FUNC( <self>, <filename> )  . . . . . . . . . . . read a file
 */
-Obj FuncREAD_AS_FUNC (
+static Obj FuncREAD_AS_FUNC (
     Obj                 self,
     Obj                 filename )
 {
@@ -1061,7 +1061,7 @@ Obj FuncREAD_AS_FUNC (
 **
 *F  FuncREAD_AS_FUNC_STREAM( <self>, <filename> ) . . . . . . . . read a file
 */
-Obj FuncREAD_AS_FUNC_STREAM (
+static Obj FuncREAD_AS_FUNC_STREAM (
     Obj                 self,
     Obj                 stream )
 {
@@ -1083,7 +1083,7 @@ Obj FuncREAD_AS_FUNC_STREAM (
 **
 *F  FuncREAD_GAP_ROOT( <self>, <filename> ) . . . . . . . . . . . read a file
 */
-Obj FuncREAD_GAP_ROOT (
+static Obj FuncREAD_GAP_ROOT (
     Obj                 self,
     Obj                 filename )
 {
@@ -1103,7 +1103,7 @@ Obj FuncREAD_GAP_ROOT (
 **
 *F  FuncTmpName( <self> ) . . . . . . . . . . . . . . return a temporary name
 */
-Obj FuncTmpName (
+static Obj FuncTmpName (
     Obj                 self )
 {
     Char *              tmp;
@@ -1121,7 +1121,7 @@ Obj FuncTmpName (
 **
 *F  FuncTmpDirectory( <self> )  . . . . . . . .  return a temporary directory
 */
-Obj FuncTmpDirectory (
+static Obj FuncTmpDirectory (
     Obj                 self )
 {
     Char *              tmp;
@@ -1139,7 +1139,7 @@ Obj FuncTmpDirectory (
 **
 *F  FuncRemoveFile( <self>, <name> )  . . . . . . . . . .  remove file <name>
 */
-Obj FuncRemoveFile (
+static Obj FuncRemoveFile (
     Obj             self,
     Obj             filename )
 {
@@ -1154,7 +1154,7 @@ Obj FuncRemoveFile (
 **
 *F  FuncCreateDir( <self>, <name> )  . . . . . . . . . . . . create directory
 */
-Obj FuncCreateDir (
+static Obj FuncCreateDir (
     Obj             self,
     Obj             filename )
 {
@@ -1169,7 +1169,7 @@ Obj FuncCreateDir (
 **
 *F  FuncRemoveDir( <self>, <name> )  . . . . . . . . . . . . remove directory
 */
-Obj FuncRemoveDir (
+static Obj FuncRemoveDir (
     Obj             self,
     Obj             filename )
 {
@@ -1184,7 +1184,7 @@ Obj FuncRemoveDir (
 **
 *F  FuncIsDir( <self>, <name> )  . . . . . check whether something is a dir
 */
-Obj FuncIsDir (
+static Obj FuncIsDir (
     Obj             self,
     Obj             filename )
 {
@@ -1207,10 +1207,10 @@ Obj FuncIsDir (
 **
 *F  FuncLastSystemError( <self> ) .  . . . . . .  return the last system error
 */
-UInt ErrorMessageRNam;
-UInt ErrorNumberRNam;
+static UInt ErrorMessageRNam;
+static UInt ErrorNumberRNam;
 
-Obj FuncLastSystemError (
+static Obj FuncLastSystemError (
     Obj             self )
 {
     Obj             err;
@@ -1242,7 +1242,7 @@ Obj FuncLastSystemError (
 **
 *F  FuncIsExistingFile( <self>, <name> )  . . . . . . does file <name> exists
 */
-Obj FuncIsExistingFile (
+static Obj FuncIsExistingFile (
     Obj             self,
     Obj             filename )
 {
@@ -1261,7 +1261,7 @@ Obj FuncIsExistingFile (
 **
 *F  FuncIsReadableFile( <self>, <name> )  . . . . . . is file <name> readable
 */
-Obj FuncIsReadableFile (
+static Obj FuncIsReadableFile (
     Obj             self,
     Obj             filename )
 {
@@ -1280,7 +1280,7 @@ Obj FuncIsReadableFile (
 **
 *F  FuncIsWritableFile( <self>, <name> )  . . . . . . is file <name> writable
 */
-Obj FuncIsWritableFile (
+static Obj FuncIsWritableFile (
     Obj             self,
     Obj             filename )
 {
@@ -1299,7 +1299,7 @@ Obj FuncIsWritableFile (
 **
 *F  FuncIsExecutableFile( <self>, <name> )  . . . . is file <name> executable
 */
-Obj FuncIsExecutableFile (
+static Obj FuncIsExecutableFile (
     Obj             self,
     Obj             filename )
 {
@@ -1318,7 +1318,7 @@ Obj FuncIsExecutableFile (
 **
 *F  FuncIsDirectoryPath( <self>, <name> ) . . . .  is file <name> a directory
 */
-Obj FuncIsDirectoryPathString (
+static Obj FuncIsDirectoryPathString (
     Obj             self,
     Obj             filename )
 {
@@ -1345,7 +1345,7 @@ Obj FuncIsDirectoryPathString (
 **  reason for the error can be found with 'LastSystemError();' in GAP.
 **
 */
-Obj FuncSTRING_LIST_DIR (
+static Obj FuncSTRING_LIST_DIR (
     Obj         self,
     Obj         dirname  )
 {
@@ -1389,7 +1389,7 @@ Obj FuncSTRING_LIST_DIR (
 **
 *F  FuncCLOSE_FILE( <self>, <fid> ) . . . . . . . . . . . . .  close a stream
 */
-Obj FuncCLOSE_FILE (
+static Obj FuncCLOSE_FILE (
     Obj             self,
     Obj             fid )
 {
@@ -1406,7 +1406,7 @@ Obj FuncCLOSE_FILE (
 **
 *F  FuncINPUT_TEXT_FILE( <self>, <name> ) . . . . . . . . . . . open a stream
 */
-Obj FuncINPUT_TEXT_FILE (
+static Obj FuncINPUT_TEXT_FILE (
     Obj             self,
     Obj             filename )
 {
@@ -1428,7 +1428,7 @@ Obj FuncINPUT_TEXT_FILE (
 **
 *F  FuncIS_END_OF_FILE( <self>, <fid> ) . . . . . . . . . . .  is end of file
 */
-Obj FuncIS_END_OF_FILE (
+static Obj FuncIS_END_OF_FILE (
     Obj             self,
     Obj             fid )
 {
@@ -1444,7 +1444,7 @@ Obj FuncIS_END_OF_FILE (
 **
 *F  FuncOUTPUT_TEXT_FILE( <self>, <name>, <append> )  . . . . . open a stream
 */
-Obj FuncOUTPUT_TEXT_FILE (
+static Obj FuncOUTPUT_TEXT_FILE (
     Obj             self,
     Obj             filename,
     Obj             append )
@@ -1478,7 +1478,7 @@ Obj FuncOUTPUT_TEXT_FILE (
 **
 *F  FuncPOSITION_FILE( <self>, <fid> )  . . . . . . . . .  position of stream
 */
-Obj FuncPOSITION_FILE (
+static Obj FuncPOSITION_FILE (
     Obj             self,
     Obj             fid )
 {
@@ -1501,7 +1501,7 @@ Obj FuncPOSITION_FILE (
 **
 *F  FuncREAD_BYTE_FILE( <self>, <fid> ) . . . . . . . . . . . . . read a byte
 */
-Obj FuncREAD_BYTE_FILE (
+static Obj FuncREAD_BYTE_FILE (
     Obj             self,
     Obj             fid )
 {
@@ -1521,7 +1521,7 @@ Obj FuncREAD_BYTE_FILE (
 **  
 **  This uses fgets and works only if there are no zero characters in <fid>.
 */
-Obj FuncREAD_LINE_FILE (
+static Obj FuncREAD_LINE_FILE (
     Obj             self,
     Obj             fid )
 {
@@ -1572,7 +1572,7 @@ Obj FuncREAD_LINE_FILE (
 **   (c) we have read <limit> bytes (-1 indicates no limit)
 */
 
-Obj FuncREAD_ALL_FILE (
+static Obj FuncREAD_ALL_FILE (
     Obj             self,
     Obj             fid,
     Obj             limit)
@@ -1666,7 +1666,7 @@ Obj FuncREAD_ALL_FILE (
 **
 *F  FuncSEEK_POSITION_FILE( <self>, <fid>, <pos> )  . seek position of stream
 */
-Obj FuncSEEK_POSITION_FILE (
+static Obj FuncSEEK_POSITION_FILE (
     Obj             self,
     Obj             fid,
     Obj             pos )
@@ -1686,7 +1686,7 @@ Obj FuncSEEK_POSITION_FILE (
 **
 *F  FuncWRITE_BYTE_FILE( <self>, <fid>, <byte> )  . . . . . . .  write a byte
 */
-Obj FuncWRITE_BYTE_FILE (
+static Obj FuncWRITE_BYTE_FILE (
     Obj             self,
     Obj             fid,
     Obj             ch )
@@ -1704,7 +1704,7 @@ Obj FuncWRITE_BYTE_FILE (
 **
 *F  FuncWRITE_STRING_FILE_NC( <self>, <fid>, <string> ) .write a whole string
 */
-Obj FuncWRITE_STRING_FILE_NC (
+static Obj FuncWRITE_STRING_FILE_NC (
     Obj             self,
     Obj             fid,
     Obj             str )
@@ -1729,7 +1729,7 @@ Obj FuncWRITE_STRING_FILE_NC (
     return True;
 }
 
-Obj FuncREAD_STRING_FILE (
+static Obj FuncREAD_STRING_FILE (
     Obj             self,
     Obj             fid )
 {
@@ -1742,7 +1742,7 @@ Obj FuncREAD_STRING_FILE (
 **
 *F  FuncFD_OF_FILE( <fid> )
 */
-Obj FuncFD_OF_FILE(Obj self,Obj fid)
+static Obj FuncFD_OF_FILE(Obj self,Obj fid)
 {
     Int fd = GetSmallInt("FD_OF_FILE", fid);
     Int fdi = SyBufFileno(fd);
@@ -1750,7 +1750,7 @@ Obj FuncFD_OF_FILE(Obj self,Obj fid)
 }
 
 #ifdef HPCGAP
-Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
+static Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 {
     Int fd = GetSmallInt("RAW_MODE_FILE", fid);
     if (onoff == False || onoff == Fail) {
@@ -1763,7 +1763,7 @@ Obj FuncRAW_MODE_FILE(Obj self, Obj fid, Obj onoff)
 #endif
 
 #ifdef HAVE_SELECT
-Obj FuncUNIXSelect(Obj self, Obj inlist, Obj outlist, Obj exclist, 
+static Obj FuncUNIXSelect(Obj self, Obj inlist, Obj outlist, Obj exclist, 
                    Obj timeoutsec, Obj timeoutusec)
 {
   fd_set infds,outfds,excfds;
@@ -1882,7 +1882,7 @@ Obj FuncUNIXSelect(Obj self, Obj inlist, Obj outlist, Obj exclist,
 static Obj    ExecArgs  [ 1024 ];
 static Char * ExecCArgs [ 1024 ];
 
-Obj FuncExecuteProcess (
+static Obj FuncExecuteProcess (
     Obj                 self,
     Obj                 dir,
     Obj                 prg,

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -94,8 +94,7 @@ Obj ObjsChar [256];
 */
 static Obj TYPE_CHAR;
 
-static Obj TypeChar (
-    Obj                 chr )
+static Obj TypeChar(Obj chr)
 {
     return TYPE_CHAR;
 }
@@ -108,9 +107,7 @@ static Obj TypeChar (
 **  'EqChar'  returns 'true'  if the two  characters <charL>  and <charR> are
 **  equal, and 'false' otherwise.
 */
-static Int EqChar (
-    Obj                 charL,
-    Obj                 charR )
+static Int EqChar(Obj charL, Obj charR)
 {
     return CHAR_VALUE(charL) == CHAR_VALUE(charR);
 }
@@ -123,9 +120,7 @@ static Int EqChar (
 **  'LtChar' returns  'true' if the    character <charL>  is less than    the
 **  character <charR>, and 'false' otherwise.
 */
-static Int LtChar (
-    Obj                 charL,
-    Obj                 charR )
+static Int LtChar(Obj charL, Obj charR)
 {
     return CHAR_VALUE(charL) < CHAR_VALUE(charR);
 }
@@ -137,8 +132,7 @@ static Int LtChar (
 **
 **  'PrChar' prints the character <chr>.
 */
-static void PrintChar (
-    Obj                 val )
+static void PrintChar(Obj val)
 {
     UChar               chr;
 
@@ -171,7 +165,7 @@ static void PrintChar (
 *F  SaveChar( <char> )  . . . . . . . . . . . . . . . . . .  save a character
 **
 */
-static void SaveChar ( Obj c )
+static void SaveChar(Obj c)
 {
     SaveUInt1( CHAR_VALUE(c));
 }
@@ -182,7 +176,7 @@ static void SaveChar ( Obj c )
 *F  LoadChar( <char> )  . . . . . . . . . . . . . . . . . .  load a character
 **
 */
-static void LoadChar( Obj c )
+static void LoadChar(Obj c)
 {
     SET_CHAR_VALUE(c, LoadUInt1());
 }
@@ -202,7 +196,7 @@ static void LoadChar( Obj c )
 **  Returns an empty string, with space for <len> characters preallocated.
 **
 */
-static Obj    FuncEmptyString( Obj self, Obj len )
+static Obj FuncEmptyString(Obj self, Obj len)
 {
     Obj                 new;
     RequireNonnegativeSmallInt("EmptyString", len);
@@ -219,7 +213,7 @@ static Obj    FuncEmptyString( Obj self, Obj len )
 **  compact representation).
 **
 */
-static Obj   FuncShrinkAllocationString( Obj self, Obj str )
+static Obj FuncShrinkAllocationString(Obj self, Obj str)
 {
     RequireStringRep("ShrinkAllocationString", str);
     SHRINK_STRING(str);
@@ -230,9 +224,7 @@ static Obj   FuncShrinkAllocationString( Obj self, Obj str )
 **
 *F  FuncCHAR_INT( <self>, <int> ) . . . . . . . . . . . . . . char by integer
 */
-static Obj FuncCHAR_INT (
-    Obj             self,
-    Obj             val )
+static Obj FuncCHAR_INT(Obj self, Obj val)
 {
     Int             chr;
 
@@ -251,9 +243,7 @@ static Obj FuncCHAR_INT (
 **
 *F  FuncINT_CHAR( <self>, <char> )  . . . . . . . . . . . . . integer by char
 */
-static Obj FuncINT_CHAR (
-    Obj             self,
-    Obj             val )
+static Obj FuncINT_CHAR(Obj self, Obj val)
 {
     /* get and check the character                                         */
     if (TNUM_OBJ(val) != T_CHAR) {
@@ -268,9 +258,7 @@ static Obj FuncINT_CHAR (
 **
 *F  FuncCHAR_SINT( <self>, <int> ) . . . . . . . . . . char by signed integer
 */
-static Obj FuncCHAR_SINT (
-    Obj             self,
-    Obj             val )
+static Obj FuncCHAR_SINT(Obj self, Obj val)
 {
     Int chr;
 
@@ -289,9 +277,7 @@ static Obj FuncCHAR_SINT (
 **
 *F  FuncSINT_CHAR( <self>, <char> ) . . . . . . . . .  signed integer by char
 */
-static Obj FuncSINT_CHAR (
-    Obj             self,
-    Obj             val )
+static Obj FuncSINT_CHAR(Obj self, Obj val)
 {
     /* get and check the character                                         */
     if (TNUM_OBJ(val) != T_CHAR) {
@@ -306,10 +292,7 @@ static Obj FuncSINT_CHAR (
 **
 *F  FuncSINTLIST_STRING( <self>, <string> ) signed integer list by string
 */
-static Obj FuncINTLIST_STRING (
-    Obj             self,
-    Obj             val,
-    Obj             sign )
+static Obj FuncINTLIST_STRING(Obj self, Obj val, Obj sign)
 {
   UInt l,i;
   Obj n, *addr;
@@ -339,9 +322,7 @@ static Obj FuncINTLIST_STRING (
   return n;
 }
 
-static Obj FuncSINTLIST_STRING (
-    Obj             self,
-    Obj             val )
+static Obj FuncSINTLIST_STRING(Obj self, Obj val)
 {
   return FuncINTLIST_STRING ( self, val, INTOBJ_INT(-1L) );
 }
@@ -350,9 +331,7 @@ static Obj FuncSINTLIST_STRING (
 **
 *F  FuncSTRING_SINTLIST( <self>, <string> ) string by signed integer list
 */
-static Obj FuncSTRING_SINTLIST (
-    Obj             self,
-    Obj             val )
+static Obj FuncSTRING_SINTLIST(Obj self, Obj val)
 {
   UInt l,i;
   Int low, inc;
@@ -399,9 +378,7 @@ static Obj FuncSTRING_SINTLIST (
 **
 *F  FuncREVNEG_STRING( <self>, <string> ) string by signed integer list
 */
-static Obj FuncREVNEG_STRING (
-    Obj             self,
-    Obj             val )
+static Obj FuncREVNEG_STRING(Obj self, Obj val)
 {
   UInt l,i,j;
   Obj n;
@@ -489,8 +466,7 @@ Int             GrowString (
 static Obj TYPES_STRING;
 
 
-static Obj TypeString (
-    Obj                 list )
+static Obj TypeString(Obj list)
 {
     return ELM_PLIST(TYPES_STRING, TNUM_OBJ(list) - T_STRING + 1);
 }
@@ -518,9 +494,7 @@ static Obj TypeString (
 **
 **  'CopyString' is the function in 'CopyObjFuncs' for strings.
 */
-static Obj CopyString (
-    Obj                 list,
-    Int                 mut )
+static Obj CopyString(Obj list, Int mut)
 {
     Obj                 copy;           /* handle of the copy, result      */
 
@@ -660,9 +634,7 @@ void PrintString1 (
 **  'EqString'  returns  'true' if the  two  strings <listL>  and <listR> are
 **  equal and 'false' otherwise.
 */
-static Int EqString (
-    Obj                 listL,
-    Obj                 listR )
+static Int EqString(Obj listL, Obj listR)
 {
   UInt lL, lR;
   const UInt1 *pL, *pR;
@@ -682,9 +654,7 @@ static Int EqString (
 **  'LtString' returns 'true' if  the string <listL> is  less than the string
 **  <listR> and 'false' otherwise.
 */
-static Int LtString (
-    Obj                 listL,
-    Obj                 listR )
+static Int LtString(Obj listL, Obj listR)
 {
   UInt lL, lR;
   const UInt1 *pL, *pR;
@@ -716,8 +686,7 @@ static Int LtString (
 **
 **  'LenString' is the function in 'LenListFuncs' for strings.
 */
-static Int LenString (
-    Obj                 list )
+static Int LenString(Obj list)
 {
     return GET_LEN_STRING( list );
 }
@@ -733,9 +702,7 @@ static Int LenString (
 **
 **  'IsbString'  is the function in 'IsbListFuncs'  for strings.
 */
-static Int IsbString (
-    Obj                 list,
-    Int                 pos )
+static Int IsbString(Obj list, Int pos)
 {
     /* since strings are dense, this must only test for the length         */
     return (pos <= GET_LEN_STRING(list));
@@ -793,9 +760,7 @@ static inline void SET_ELM_STRING(Obj list, Int pos, Obj val)
 **  'Elm0String'  is the function on 'Elm0ListFuncs'  for strings.
 **  'Elm0vString' is the function in 'Elm0vListFuncs' for strings.
 */
-static Obj Elm0String (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0String(Obj list, Int pos)
 {
     if ( pos <= GET_LEN_STRING( list ) ) {
         return GET_ELM_STRING( list, pos );
@@ -805,9 +770,7 @@ static Obj Elm0String (
     }
 }
 
-static Obj Elm0vString (
-    Obj                 list,
-    Int                 pos )
+static Obj Elm0vString(Obj list, Int pos)
 {
     return GET_ELM_STRING( list, pos );
 }
@@ -832,9 +795,7 @@ static Obj Elm0vString (
 **  'ElmfString' is the function in 'ElmfListFuncs' for strings.
 **  'ElmwString' is the function in 'ElmwListFuncs' for strings.
 */
-static Obj ElmString (
-    Obj                 list,
-    Int                 pos )
+static Obj ElmString(Obj list, Int pos)
 {
     /* check the position                                                  */
     if ( GET_LEN_STRING( list ) < pos ) {
@@ -863,9 +824,7 @@ static Obj ElmString (
 **
 **  'ElmsString' is the function in 'ElmsListFuncs' for strings.
 */
-static Obj ElmsString (
-    Obj                 list,
-    Obj                 poss )
+static Obj ElmsString(Obj list, Obj poss)
 {
     Obj                 elms;         /* selected sublist, result        */
     Int                 lenList;        /* length of <list>                */
@@ -969,10 +928,7 @@ static Obj ElmsString (
 **  'AssString' keeps <list> in string representation if possible.
 **  
 */
-static void AssString (
-    Obj                 list,
-    Int                 pos,
-    Obj                 val )
+static void AssString(Obj list, Int pos, Obj val)
 {
   UInt len = GET_LEN_STRING(list);
 
@@ -1023,10 +979,7 @@ static void AssString (
 **  <poss> can be important if <list> should stay in string representation.
 **   
 */
-static void AsssString (
-    Obj                 list,
-    Obj                 poss,
-    Obj                 vals )
+static void AsssString(Obj list, Obj poss, Obj vals)
 {
   Int i, len = LEN_LIST(poss);
   for (i = 1; i <= len; i++) {
@@ -1044,8 +997,7 @@ static void AsssString (
 **
 **  'IsSSortString' is the function in 'IsSSortListFuncs' for strings.
 */
-static Int IsSSortString (
-    Obj                 list )
+static Int IsSSortString(Obj list)
 {
     Int                 len;
     Int                 i;
@@ -1073,8 +1025,7 @@ static Int IsSSortString (
 **
 **  'IsPossString' is the function in 'TabIsPossList' for strings.
 */
-static Int IsPossString (
-    Obj                 list )
+static Int IsPossString(Obj list)
 {
     return GET_LEN_STRING( list ) == 0;
 }
@@ -1089,11 +1040,8 @@ static Int IsPossString (
 **  is not in the list.
 **
 **  'PosString' is the function in 'PosListFuncs' for strings.
-*/ 
-static Obj PosString (
-    Obj                 list,
-    Obj                 val,
-    Obj                 start )
+*/
+static Obj PosString(Obj list, Obj val, Obj start)
 {
     Int                 lenList;        /* length of <list>                */
     Int                 i;              /* loop variable                   */
@@ -1134,8 +1082,7 @@ static Obj PosString (
 **
 **  'PlainString' is the function in 'PlainListFuncs' for strings.
 */
-static void PlainString (
-    Obj                 list )
+static void PlainString(Obj list)
 {
     Int                 lenList;        /* logical length of the string    */
     Obj                 tmp;            /* handle of the list              */
@@ -1171,8 +1118,7 @@ Int (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
 static Obj IsStringFilt;
 
-static Int IsStringList (
-    Obj                 list )
+static Int IsStringList(Obj list)
 {
     Int                 lenList;
     Obj                 elm;
@@ -1194,14 +1140,12 @@ static Int IsStringList (
     return (lenList < i);
 }
 
-static Int IsStringListHom (
-    Obj                 list )
+static Int IsStringListHom(Obj list)
 {
     return (TNUM_OBJ( ELM_LIST(list,1) ) == T_CHAR);
 }
 
-static Int IsStringObject (
-    Obj                 obj )
+static Int IsStringObject(Obj obj)
 {
     return (DoFilter( IsStringFilt, obj ) != False);
 }
@@ -1334,9 +1278,7 @@ Int IsStringConv (
 **
 *F  FuncIS_STRING( <self>, <obj> )  . . . . . . . . .  test value is a string
 */
-static Obj FuncIS_STRING (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_STRING(Obj self, Obj obj)
 {
     return (IS_STRING( obj ) ? True : False);
 }
@@ -1346,9 +1288,7 @@ static Obj FuncIS_STRING (
 **
 *F  FuncIS_STRING_CONV( <self>, <obj> ) . . . . . . . . . . check and convert
 */
-static Obj FuncIS_STRING_CONV (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_STRING_CONV(Obj self, Obj obj)
 {
     /* return 'true' if <obj> is a string and 'false' otherwise            */
     return (IsStringConv(obj) ? True : False);
@@ -1359,9 +1299,7 @@ static Obj FuncIS_STRING_CONV (
 **
 *F  FuncCONV_STRING( <self>, <string> ) . . . . . . . . convert to string rep
 */
-static Obj FuncCONV_STRING (
-    Obj                 self,
-    Obj                 string )
+static Obj FuncCONV_STRING(Obj self, Obj string)
 {
     /* check whether <string> is a string                                  */
     if (!IS_STRING(string)) {
@@ -1382,9 +1320,7 @@ static Obj FuncCONV_STRING (
 */
 static Obj IsStringRepFilt;
 
-static Obj FuncIS_STRING_REP (
-    Obj                 self,
-    Obj                 obj )
+static Obj FuncIS_STRING_REP(Obj self, Obj obj)
 {
     return (IS_STRING_REP( obj ) ? True : False);
 }
@@ -1412,11 +1348,7 @@ static Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
 **  <off>+1, is  returned if such  a substring exists. Otherwise `fail' is
 **  returned.
 */
-static Obj FuncPOSITION_SUBSTRING( 
-                           Obj                  self,
-                           Obj                  string,
-                           Obj                  substr,
-                           Obj                  off )
+static Obj FuncPOSITION_SUBSTRING(Obj self, Obj string, Obj substr, Obj off)
 {
   Int    ipos, i, j, lens, lenss, max;
   const UInt1  *s, *ss;
@@ -1465,10 +1397,8 @@ static Obj FuncPOSITION_SUBSTRING(
 **  string  is  removed. Intermediate  sequences  of  whitespace characters  are
 **  substituted by a single space.
 **  
-*/ 
-static Obj FuncNormalizeWhitespace (
-                              Obj     self,
-                              Obj     string )
+*/
+static Obj FuncNormalizeWhitespace(Obj self, Obj string)
 {
   UInt1  *s, c;
   Int i, j, len, white;
@@ -1512,12 +1442,9 @@ static Obj FuncNormalizeWhitespace (
 *F  FuncREMOVE_CHARACTERS( <self>, <string>, <rem> ) . . . . . delete characters
 **  from <rem> in <string> in place 
 **    
-*/ 
+*/
 
-static Obj FuncREMOVE_CHARACTERS (
-                              Obj     self,
-                              Obj     string,
-                              Obj     rem     )
+static Obj FuncREMOVE_CHARACTERS(Obj self, Obj string, Obj rem)
 {
   UInt1  *s;
   Int i, j, len;
@@ -1558,11 +1485,8 @@ static Obj FuncREMOVE_CHARACTERS (
 *F  FuncTranslateString( <self>, <string>, <trans> ) . . . translate characters
 **  in <string> in place, <string>[i] = <trans>[<string>[i]] 
 **    
-*/ 
-static Obj FuncTranslateString (
-                              Obj     self,
-                              Obj     string,
-                              Obj     trans     )
+*/
+static Obj FuncTranslateString(Obj self, Obj string, Obj trans)
 {
   Int j, len;
 
@@ -1595,12 +1519,8 @@ static Obj FuncTranslateString (
 **    
 **  The difference of <seps> and <wspace> is that characters in <wspace> don't
 **  separate empty strings.
-*/ 
-static Obj FuncSplitStringInternal (
-                              Obj     self,
-                              Obj     string,
-                              Obj     seps,
-                              Obj     wspace    )
+*/
+static Obj FuncSplitStringInternal(Obj self, Obj string, Obj seps, Obj wspace)
 {
   const UInt1  *s;
   Int i, a, z, l, pos, len;
@@ -1769,7 +1689,7 @@ static Obj FuncNORMALIZE_NEWLINES(Obj self, Obj string)
 ** options
 */
 
-static Obj FuncSMALLINT_STR( Obj self, Obj str )
+static Obj FuncSMALLINT_STR(Obj self, Obj str)
 {
   const Char *string = CONST_CSTR_STRING(str);
   Int x = 0;

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -92,9 +92,9 @@ Obj ObjsChar [256];
 **
 **  'TypeChar' is the function in 'TypeObjFuncs' for character values.
 */
-Obj TYPE_CHAR;
+static Obj TYPE_CHAR;
 
-Obj TypeChar (
+static Obj TypeChar (
     Obj                 chr )
 {
     return TYPE_CHAR;
@@ -108,7 +108,7 @@ Obj TypeChar (
 **  'EqChar'  returns 'true'  if the two  characters <charL>  and <charR> are
 **  equal, and 'false' otherwise.
 */
-Int EqChar (
+static Int EqChar (
     Obj                 charL,
     Obj                 charR )
 {
@@ -123,7 +123,7 @@ Int EqChar (
 **  'LtChar' returns  'true' if the    character <charL>  is less than    the
 **  character <charR>, and 'false' otherwise.
 */
-Int LtChar (
+static Int LtChar (
     Obj                 charL,
     Obj                 charR )
 {
@@ -137,7 +137,7 @@ Int LtChar (
 **
 **  'PrChar' prints the character <chr>.
 */
-void PrintChar (
+static void PrintChar (
     Obj                 val )
 {
     UChar               chr;
@@ -171,7 +171,7 @@ void PrintChar (
 *F  SaveChar( <char> )  . . . . . . . . . . . . . . . . . .  save a character
 **
 */
-void SaveChar ( Obj c )
+static void SaveChar ( Obj c )
 {
     SaveUInt1( CHAR_VALUE(c));
 }
@@ -182,7 +182,7 @@ void SaveChar ( Obj c )
 *F  LoadChar( <char> )  . . . . . . . . . . . . . . . . . .  load a character
 **
 */
-void LoadChar( Obj c )
+static void LoadChar( Obj c )
 {
     SET_CHAR_VALUE(c, LoadUInt1());
 }
@@ -202,7 +202,7 @@ void LoadChar( Obj c )
 **  Returns an empty string, with space for <len> characters preallocated.
 **
 */
-Obj    FuncEmptyString( Obj self, Obj len )
+static Obj    FuncEmptyString( Obj self, Obj len )
 {
     Obj                 new;
     RequireNonnegativeSmallInt("EmptyString", len);
@@ -219,7 +219,7 @@ Obj    FuncEmptyString( Obj self, Obj len )
 **  compact representation).
 **
 */
-Obj   FuncShrinkAllocationString( Obj self, Obj str )
+static Obj   FuncShrinkAllocationString( Obj self, Obj str )
 {
     RequireStringRep("ShrinkAllocationString", str);
     SHRINK_STRING(str);
@@ -230,7 +230,7 @@ Obj   FuncShrinkAllocationString( Obj self, Obj str )
 **
 *F  FuncCHAR_INT( <self>, <int> ) . . . . . . . . . . . . . . char by integer
 */
-Obj FuncCHAR_INT (
+static Obj FuncCHAR_INT (
     Obj             self,
     Obj             val )
 {
@@ -251,7 +251,7 @@ Obj FuncCHAR_INT (
 **
 *F  FuncINT_CHAR( <self>, <char> )  . . . . . . . . . . . . . integer by char
 */
-Obj FuncINT_CHAR (
+static Obj FuncINT_CHAR (
     Obj             self,
     Obj             val )
 {
@@ -268,7 +268,7 @@ Obj FuncINT_CHAR (
 **
 *F  FuncCHAR_SINT( <self>, <int> ) . . . . . . . . . . char by signed integer
 */
-Obj FuncCHAR_SINT (
+static Obj FuncCHAR_SINT (
     Obj             self,
     Obj             val )
 {
@@ -289,7 +289,7 @@ Obj FuncCHAR_SINT (
 **
 *F  FuncSINT_CHAR( <self>, <char> ) . . . . . . . . .  signed integer by char
 */
-Obj FuncSINT_CHAR (
+static Obj FuncSINT_CHAR (
     Obj             self,
     Obj             val )
 {
@@ -306,7 +306,7 @@ Obj FuncSINT_CHAR (
 **
 *F  FuncSINTLIST_STRING( <self>, <string> ) signed integer list by string
 */
-Obj FuncINTLIST_STRING (
+static Obj FuncINTLIST_STRING (
     Obj             self,
     Obj             val,
     Obj             sign )
@@ -339,7 +339,7 @@ Obj FuncINTLIST_STRING (
   return n;
 }
 
-Obj FuncSINTLIST_STRING (
+static Obj FuncSINTLIST_STRING (
     Obj             self,
     Obj             val )
 {
@@ -350,7 +350,7 @@ Obj FuncSINTLIST_STRING (
 **
 *F  FuncSTRING_SINTLIST( <self>, <string> ) string by signed integer list
 */
-Obj FuncSTRING_SINTLIST (
+static Obj FuncSTRING_SINTLIST (
     Obj             self,
     Obj             val )
 {
@@ -399,7 +399,7 @@ Obj FuncSTRING_SINTLIST (
 **
 *F  FuncREVNEG_STRING( <self>, <string> ) string by signed integer list
 */
-Obj FuncREVNEG_STRING (
+static Obj FuncREVNEG_STRING (
     Obj             self,
     Obj             val )
 {
@@ -489,7 +489,7 @@ Int             GrowString (
 static Obj TYPES_STRING;
 
 
-Obj TypeString (
+static Obj TypeString (
     Obj                 list )
 {
     return ELM_PLIST(TYPES_STRING, TNUM_OBJ(list) - T_STRING + 1);
@@ -518,7 +518,7 @@ Obj TypeString (
 **
 **  'CopyString' is the function in 'CopyObjFuncs' for strings.
 */
-Obj CopyString (
+static Obj CopyString (
     Obj                 list,
     Int                 mut )
 {
@@ -660,7 +660,7 @@ void PrintString1 (
 **  'EqString'  returns  'true' if the  two  strings <listL>  and <listR> are
 **  equal and 'false' otherwise.
 */
-Int EqString (
+static Int EqString (
     Obj                 listL,
     Obj                 listR )
 {
@@ -682,7 +682,7 @@ Int EqString (
 **  'LtString' returns 'true' if  the string <listL> is  less than the string
 **  <listR> and 'false' otherwise.
 */
-Int LtString (
+static Int LtString (
     Obj                 listL,
     Obj                 listR )
 {
@@ -716,7 +716,7 @@ Int LtString (
 **
 **  'LenString' is the function in 'LenListFuncs' for strings.
 */
-Int LenString (
+static Int LenString (
     Obj                 list )
 {
     return GET_LEN_STRING( list );
@@ -733,7 +733,7 @@ Int LenString (
 **
 **  'IsbString'  is the function in 'IsbListFuncs'  for strings.
 */
-Int IsbString (
+static Int IsbString (
     Obj                 list,
     Int                 pos )
 {
@@ -793,7 +793,7 @@ static inline void SET_ELM_STRING(Obj list, Int pos, Obj val)
 **  'Elm0String'  is the function on 'Elm0ListFuncs'  for strings.
 **  'Elm0vString' is the function in 'Elm0vListFuncs' for strings.
 */
-Obj Elm0String (
+static Obj Elm0String (
     Obj                 list,
     Int                 pos )
 {
@@ -805,7 +805,7 @@ Obj Elm0String (
     }
 }
 
-Obj Elm0vString (
+static Obj Elm0vString (
     Obj                 list,
     Int                 pos )
 {
@@ -832,7 +832,7 @@ Obj Elm0vString (
 **  'ElmfString' is the function in 'ElmfListFuncs' for strings.
 **  'ElmwString' is the function in 'ElmwListFuncs' for strings.
 */
-Obj ElmString (
+static Obj ElmString (
     Obj                 list,
     Int                 pos )
 {
@@ -863,7 +863,7 @@ Obj ElmString (
 **
 **  'ElmsString' is the function in 'ElmsListFuncs' for strings.
 */
-Obj ElmsString (
+static Obj ElmsString (
     Obj                 list,
     Obj                 poss )
 {
@@ -969,7 +969,7 @@ Obj ElmsString (
 **  'AssString' keeps <list> in string representation if possible.
 **  
 */
-void AssString (
+static void AssString (
     Obj                 list,
     Int                 pos,
     Obj                 val )
@@ -1023,7 +1023,7 @@ void AssString (
 **  <poss> can be important if <list> should stay in string representation.
 **   
 */
-void AsssString (
+static void AsssString (
     Obj                 list,
     Obj                 poss,
     Obj                 vals )
@@ -1044,7 +1044,7 @@ void AsssString (
 **
 **  'IsSSortString' is the function in 'IsSSortListFuncs' for strings.
 */
-Int IsSSortString (
+static Int IsSSortString (
     Obj                 list )
 {
     Int                 len;
@@ -1073,7 +1073,7 @@ Int IsSSortString (
 **
 **  'IsPossString' is the function in 'TabIsPossList' for strings.
 */
-Int IsPossString (
+static Int IsPossString (
     Obj                 list )
 {
     return GET_LEN_STRING( list ) == 0;
@@ -1090,7 +1090,7 @@ Int IsPossString (
 **
 **  'PosString' is the function in 'PosListFuncs' for strings.
 */ 
-Obj PosString (
+static Obj PosString (
     Obj                 list,
     Obj                 val,
     Obj                 start )
@@ -1134,7 +1134,7 @@ Obj PosString (
 **
 **  'PlainString' is the function in 'PlainListFuncs' for strings.
 */
-void PlainString (
+static void PlainString (
     Obj                 list )
 {
     Int                 lenList;        /* logical length of the string    */
@@ -1169,9 +1169,9 @@ void PlainString (
 */
 Int (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
 
-Obj IsStringFilt;
+static Obj IsStringFilt;
 
-Int IsStringList (
+static Int IsStringList (
     Obj                 list )
 {
     Int                 lenList;
@@ -1194,13 +1194,13 @@ Int IsStringList (
     return (lenList < i);
 }
 
-Int IsStringListHom (
+static Int IsStringListHom (
     Obj                 list )
 {
     return (TNUM_OBJ( ELM_LIST(list,1) ) == T_CHAR);
 }
 
-Int IsStringObject (
+static Int IsStringObject (
     Obj                 obj )
 {
     return (DoFilter( IsStringFilt, obj ) != False);
@@ -1334,7 +1334,7 @@ Int IsStringConv (
 **
 *F  FuncIS_STRING( <self>, <obj> )  . . . . . . . . .  test value is a string
 */
-Obj FuncIS_STRING (
+static Obj FuncIS_STRING (
     Obj                 self,
     Obj                 obj )
 {
@@ -1346,7 +1346,7 @@ Obj FuncIS_STRING (
 **
 *F  FuncIS_STRING_CONV( <self>, <obj> ) . . . . . . . . . . check and convert
 */
-Obj FuncIS_STRING_CONV (
+static Obj FuncIS_STRING_CONV (
     Obj                 self,
     Obj                 obj )
 {
@@ -1359,7 +1359,7 @@ Obj FuncIS_STRING_CONV (
 **
 *F  FuncCONV_STRING( <self>, <string> ) . . . . . . . . convert to string rep
 */
-Obj FuncCONV_STRING (
+static Obj FuncCONV_STRING (
     Obj                 self,
     Obj                 string )
 {
@@ -1380,9 +1380,9 @@ Obj FuncCONV_STRING (
 **
 *F  FuncIS_STRING_REP( <self>, <obj> )  . . . . test if value is a string rep
 */
-Obj IsStringRepFilt;
+static Obj IsStringRepFilt;
 
-Obj FuncIS_STRING_REP (
+static Obj FuncIS_STRING_REP (
     Obj                 self,
     Obj                 obj )
 {
@@ -1393,7 +1393,7 @@ Obj FuncIS_STRING_REP (
 **
 *F  FuncCOPY_TO_STRING_REP( <self>, <obj> ) . copy a string into string rep
 */
-Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
+static Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
 {
     /* check whether <string> is a string                                 */
     if (!IS_STRING(string)) {
@@ -1412,7 +1412,7 @@ Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
 **  <off>+1, is  returned if such  a substring exists. Otherwise `fail' is
 **  returned.
 */
-Obj FuncPOSITION_SUBSTRING( 
+static Obj FuncPOSITION_SUBSTRING( 
                            Obj                  self,
                            Obj                  string,
                            Obj                  substr,
@@ -1466,7 +1466,7 @@ Obj FuncPOSITION_SUBSTRING(
 **  substituted by a single space.
 **  
 */ 
-Obj FuncNormalizeWhitespace (
+static Obj FuncNormalizeWhitespace (
                               Obj     self,
                               Obj     string )
 {
@@ -1514,7 +1514,7 @@ Obj FuncNormalizeWhitespace (
 **    
 */ 
 
-Obj FuncREMOVE_CHARACTERS (
+static Obj FuncREMOVE_CHARACTERS (
                               Obj     self,
                               Obj     string,
                               Obj     rem     )
@@ -1559,7 +1559,7 @@ Obj FuncREMOVE_CHARACTERS (
 **  in <string> in place, <string>[i] = <trans>[<string>[i]] 
 **    
 */ 
-Obj FuncTranslateString (
+static Obj FuncTranslateString (
                               Obj     self,
                               Obj     string,
                               Obj     trans     )
@@ -1596,7 +1596,7 @@ Obj FuncTranslateString (
 **  The difference of <seps> and <wspace> is that characters in <wspace> don't
 **  separate empty strings.
 */ 
-Obj FuncSplitStringInternal (
+static Obj FuncSplitStringInternal (
                               Obj     self,
                               Obj     string,
                               Obj     seps,
@@ -1698,7 +1698,7 @@ Obj FuncSplitStringInternal (
 ** within a string.
 */
 
-Obj FuncFIND_ALL_IN_STRING(Obj self, Obj string, Obj chars)
+static Obj FuncFIND_ALL_IN_STRING(Obj self, Obj string, Obj chars)
 {
   Obj result;
   UInt i, len, matches;
@@ -1737,7 +1737,7 @@ Obj FuncFIND_ALL_IN_STRING(Obj self, Obj string, Obj chars)
 ** returns it also as its result.
 */
 
-Obj FuncNORMALIZE_NEWLINES(Obj self, Obj string)
+static Obj FuncNORMALIZE_NEWLINES(Obj self, Obj string)
 {
   UInt i, j, len;
   Char *s;
@@ -1769,7 +1769,7 @@ Obj FuncNORMALIZE_NEWLINES(Obj self, Obj string)
 ** options
 */
 
-Obj FuncSMALLINT_STR( Obj self, Obj str )
+static Obj FuncSMALLINT_STR( Obj self, Obj str )
 {
   const Char *string = CONST_CSTR_STRING(str);
   Int x = 0;
@@ -1798,7 +1798,7 @@ Obj FuncSMALLINT_STR( Obj self, Obj str )
 **  larger or equal to the length of <string>.
 **  
 */
-void UnbString(Obj string, Int pos)
+static void UnbString(Obj string, Int pos)
 {
     GAP_ASSERT(IS_MUTABLE_OBJ(string));
 

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -734,7 +734,7 @@ static const CompilerT Compilers[] = {
     COMPILER_(T_ISB_COMOBJ_EXPR, ARG_("comobj"), ARG_("expression")),
 };
 
-Obj FuncSYNTAX_TREE(Obj self, Obj func)
+static Obj FuncSYNTAX_TREE(Obj self, Obj func)
 {
     Obj result;
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -352,7 +352,8 @@ gap> CrcString("GAP example string");
 */
 
 /* And here we include a variant working on a GAP string */
-static Obj FuncCrcString( Obj self, Obj str ) {
+static Obj FuncCrcString(Obj self, Obj str)
+{
     UInt4       crc;
     UInt4       old;
     UInt4       new;
@@ -401,7 +402,8 @@ static Obj FuncCrcString( Obj self, Obj str ) {
 ** the MIT License : http://stackoverflow.com/a/34271901/928031
 */
 
-static void find_yourself(const char * argv0, char * result, size_t resultsize)
+static void
+find_yourself(const char * argv0, char * result, size_t resultsize)
 {
     GAP_ASSERT(resultsize >= GAP_PATH_MAX);
 
@@ -589,7 +591,7 @@ void syWinPut (
 **  '@J'.  Then  'SyWinCmd' waits for  the window handlers answer and returns
 **  that string.
 */
-static Char WinCmdBuffer [8000];
+static Char WinCmdBuffer[8000];
 
 const Char * SyWinCmd (
     const Char *        str,
@@ -1012,14 +1014,14 @@ struct termios   syOld, syNew;           /* old and new terminal state      */
 
 static Int syFid;
 
-static void syAnswerCont ( int signr )
+static void syAnswerCont(int signr)
 {
     syStartraw( syFid );
     signal( SIGCONT, SIG_DFL );
     kill( getpid(), SIGCONT );
 }
 
-static void syAnswerTstp ( int signr )
+static void syAnswerTstp(int signr)
 {
     syStopraw( syFid );
     signal( SIGCONT, syAnswerCont );
@@ -1116,14 +1118,14 @@ void syStopraw (
 #ifdef HAVE_SIGNAL
 
 
-static UInt            syLastIntr;             /* time of the last interrupt      */
+static UInt syLastIntr; /* time of the last interrupt      */
 
 
 #ifdef HAVE_LIBREADLINE
 static Int doingReadline;
 #endif
 
-static void syAnswerIntr ( int signr )
+static void syAnswerIntr(int signr)
 {
     UInt                nowIntr;
 
@@ -1276,9 +1278,7 @@ void getwindowsize( void )
 **
 *f  syEchoch( <ch>, <fid> )
 */
-static void syEchoch (
-    Int                 ch,
-    Int                 fid )
+static void syEchoch(Int ch, Int fid)
 {
     Char                ch2;
 
@@ -1321,9 +1321,7 @@ Int SyEchoch (
 **
 *f  syEchos( <ch>, <fid> )
 */
-static void syEchos (
-    const Char *        str,
-    Int                 fid )
+static void syEchos(const Char * str, Int fid)
 {
     /* if running under a window handler, send the line to it              */
     if ( SyWindow && fid < 4 )
@@ -1341,9 +1339,8 @@ static void syEchos (
 **
 **  'SyFputs' is called to put the  <line>  to the file identified  by <fid>.
 */
-static UInt   syNrchar;                        /* nr of chars already on the line */
-static Char   syPrompt [MAXLENOUTPUTLINE];     /* characters already on the line  */
-
+static UInt syNrchar;                   /* nr of chars already on the line */
+static Char syPrompt[MAXLENOUTPUTLINE]; /* characters already on the line  */
 
 
 /****************************************************************************
@@ -1567,8 +1564,7 @@ static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count)
     return ret;
 }
 
-static Int syGetchTerm (
-    Int                 fid )
+static Int syGetchTerm(Int fid)
 {
     UChar                ch;
     Char                str[2];
@@ -1626,8 +1622,7 @@ static Int syGetchTerm (
     return (Int)ch;
 }
 
-static Int syGetchNonTerm (
-    Int                 fid )
+static Int syGetchNonTerm(Int fid)
 {
     UChar                ch;
     UInt                bufno;
@@ -1694,8 +1689,7 @@ static Int syGetchNonTerm (
 *f  syGetch( <fid> )
 */
 
-static Int syGetch (
-    Int                 fid )
+static Int syGetch(Int fid)
 {
     if (syBuf[fid].isTTY)
       return syGetchTerm(fid);
@@ -1791,12 +1785,12 @@ Int SyGetch (
 **      <esc>-T exchange two words.
 */
 
-static UInt   syCTRO;                          /* number of '<ctr>-O' pending     */
-static UInt   syESCN;                          /* number of '<Esc>-N' pending     */
+static UInt syCTRO; /* number of '<ctr>-O' pending     */
+static UInt syESCN; /* number of '<Esc>-N' pending     */
 
 static UInt FreezeStdin;    // When true, ignore if any new input from stdin
-                     // This is used to stop HPC-GAP from reading stdin while
-                     // forked subprocesses are running.
+                            // This is used to stop HPC-GAP from reading stdin
+                            // while forked subprocesses are running.
 
 
 #ifdef HAVE_SELECT
@@ -1987,13 +1981,7 @@ Int HasAvailableBytes( UInt fid )
 }
 
 
-
-
-static Char * syFgetsNoEdit (
-    Char *              line,
-    UInt                length,
-    Int                 fid,
-    UInt                block)
+static Char * syFgetsNoEdit(Char * line, UInt length, Int fid, UInt block)
 {
   UInt x = 0;
   int ret = 0;
@@ -2177,7 +2165,7 @@ static int GAP_rl_func(int count, int key)
    return 0;
 }
 
-static Obj FuncBINDKEYSTOGAPHANDLER (Obj self, Obj keys)
+static Obj FuncBINDKEYSTOGAPHANDLER(Obj self, Obj keys)
 {
   Char*  seq;
 
@@ -2188,7 +2176,7 @@ static Obj FuncBINDKEYSTOGAPHANDLER (Obj self, Obj keys)
   return True;
 }
 
-static Obj FuncBINDKEYSTOMACRO (Obj self, Obj keys, Obj macro)
+static Obj FuncBINDKEYSTOMACRO(Obj self, Obj keys, Obj macro)
 {
   Char   *seq, *macr;
 
@@ -2200,7 +2188,7 @@ static Obj FuncBINDKEYSTOMACRO (Obj self, Obj keys, Obj macro)
   return True;
 }
 
-static Obj FuncREADLINEINITLINE (Obj self, Obj line)
+static Obj FuncREADLINEINITLINE(Obj self, Obj line)
 {
   Char   *cline;
 
@@ -2214,7 +2202,7 @@ static Obj FuncREADLINEINITLINE (Obj self, Obj line)
 static Int ISINITREADLINE = 0;
 /* a hook function called regularly while waiting on input */
 static Int current_rl_fid;
-static int charreadhook_rl ( void )
+static int charreadhook_rl(void)
 {
 #ifdef HAVE_SELECT
     if (OnCharReadHookActiveCheck())
@@ -2223,7 +2211,7 @@ static int charreadhook_rl ( void )
   return 0;
 }
 
-static void initreadline ( void )
+static void initreadline(void)
 {
 
   /* allows users to configure GAP specific settings in their ~/.inputrc like:
@@ -2248,11 +2236,7 @@ static void initreadline ( void )
   ISINITREADLINE = 1;
 }
 
-static Char * readlineFgets (
-    Char *              line,
-    UInt                length,
-    Int                 fid,
-    UInt                block)
+static Char * readlineFgets(Char * line, UInt length, Int fid, UInt block)
 {
   char *                 rlres = (char*)NULL;
 
@@ -2330,11 +2314,7 @@ static Int syEndEdit(Int fid)
 
 #endif
 
-static Char * syFgets (
-    Char *              line,
-    UInt                length,
-    Int                 fid,
-    UInt                block)
+static Char * syFgets(Char * line, UInt length, Int fid, UInt block)
 {
     Int                 ch,  ch2,  ch3, last;
     Char                * p,  * q,  * r,  * s,  * t;

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -148,7 +148,8 @@ SYS_SY_BUFFER syBuffers[32];
 
 
 /* utility to check return value of 'write'  */
-ssize_t echoandcheck(int fid, const char *buf, size_t count) {
+static ssize_t echoandcheck(int fid, const char *buf, size_t count)
+{
   int ret;
   if (syBuf[fid].type == gzip_socket) {
       ret = gzwrite(syBuf[fid].gzfp, buf, count);
@@ -351,7 +352,7 @@ gap> CrcString("GAP example string");
 */
 
 /* And here we include a variant working on a GAP string */
-Obj FuncCrcString( Obj self, Obj str ) {
+static Obj FuncCrcString( Obj self, Obj str ) {
     UInt4       crc;
     UInt4       old;
     UInt4       new;
@@ -400,7 +401,7 @@ Obj FuncCrcString( Obj self, Obj str ) {
 ** the MIT License : http://stackoverflow.com/a/34271901/928031
 */
 
-void find_yourself(const char * argv0, char * result, size_t resultsize)
+static void find_yourself(const char * argv0, char * result, size_t resultsize)
 {
     GAP_ASSERT(resultsize >= GAP_PATH_MAX);
 
@@ -588,7 +589,7 @@ void syWinPut (
 **  '@J'.  Then  'SyWinCmd' waits for  the window handlers answer and returns
 **  that string.
 */
-Char WinCmdBuffer [8000];
+static Char WinCmdBuffer [8000];
 
 const Char * SyWinCmd (
     const Char *        str,
@@ -1009,16 +1010,16 @@ struct termios   syOld, syNew;           /* old and new terminal state      */
 
 #ifdef SIGTSTP
 
-Int syFid;
+static Int syFid;
 
-void syAnswerCont ( int signr )
+static void syAnswerCont ( int signr )
 {
     syStartraw( syFid );
     signal( SIGCONT, SIG_DFL );
     kill( getpid(), SIGCONT );
 }
 
-void syAnswerTstp ( int signr )
+static void syAnswerTstp ( int signr )
 {
     syStopraw( syFid );
     signal( SIGCONT, syAnswerCont );
@@ -1115,14 +1116,14 @@ void syStopraw (
 #ifdef HAVE_SIGNAL
 
 
-UInt            syLastIntr;             /* time of the last interrupt      */
+static UInt            syLastIntr;             /* time of the last interrupt      */
 
 
 #ifdef HAVE_LIBREADLINE
-Int doingReadline;
+static Int doingReadline;
 #endif
 
-void syAnswerIntr ( int signr )
+static void syAnswerIntr ( int signr )
 {
     UInt                nowIntr;
 
@@ -1275,7 +1276,7 @@ void getwindowsize( void )
 **
 *f  syEchoch( <ch>, <fid> )
 */
-void syEchoch (
+static void syEchoch (
     Int                 ch,
     Int                 fid )
 {
@@ -1320,7 +1321,7 @@ Int SyEchoch (
 **
 *f  syEchos( <ch>, <fid> )
 */
-void syEchos (
+static void syEchos (
     const Char *        str,
     Int                 fid )
 {
@@ -1340,8 +1341,8 @@ void syEchos (
 **
 **  'SyFputs' is called to put the  <line>  to the file identified  by <fid>.
 */
-UInt   syNrchar;                        /* nr of chars already on the line */
-Char   syPrompt [MAXLENOUTPUTLINE];     /* characters already on the line  */
+static UInt   syNrchar;                        /* nr of chars already on the line */
+static Char   syPrompt [MAXLENOUTPUTLINE];     /* characters already on the line  */
 
 
 
@@ -1566,7 +1567,7 @@ static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count)
     return ret;
 }
 
-Int syGetchTerm (
+static Int syGetchTerm (
     Int                 fid )
 {
     UChar                ch;
@@ -1625,7 +1626,7 @@ Int syGetchTerm (
     return (Int)ch;
 }
 
-Int syGetchNonTerm (
+static Int syGetchNonTerm (
     Int                 fid )
 {
     UChar                ch;
@@ -1693,7 +1694,7 @@ Int syGetchNonTerm (
 *f  syGetch( <fid> )
 */
 
-Int syGetch (
+static Int syGetch (
     Int                 fid )
 {
     if (syBuf[fid].isTTY)
@@ -1790,10 +1791,10 @@ Int SyGetch (
 **      <esc>-T exchange two words.
 */
 
-UInt   syCTRO;                          /* number of '<ctr>-O' pending     */
-UInt   syESCN;                          /* number of '<Esc>-N' pending     */
+static UInt   syCTRO;                          /* number of '<ctr>-O' pending     */
+static UInt   syESCN;                          /* number of '<Esc>-N' pending     */
 
-UInt FreezeStdin;    // When true, ignore if any new input from stdin
+static UInt FreezeStdin;    // When true, ignore if any new input from stdin
                      // This is used to stop HPC-GAP from reading stdin while
                      // forked subprocesses are running.
 
@@ -1808,13 +1809,13 @@ Obj OnCharReadHookOutFuncs = 0;/* a list of GAP functions with 0 args */
 Obj OnCharReadHookExcFds = 0;  /* a list of UNIX file descriptors */
 Obj OnCharReadHookExcFuncs = 0;/* a list of GAP functions with 0 args */
 
-Int OnCharReadHookActiveCheck(void)
+static Int OnCharReadHookActiveCheck(void)
 {
     return OnCharReadHookActive != 0 || FreezeStdin != 0;
 }
 
 
-void HandleCharReadHook(int stdinfd)
+static void HandleCharReadHook(int stdinfd)
 /* This is called directly before a character is read from stdin in the case
  * of an interactive session with command line editing. We have to return
  * as soon as stdin is ready to read! We just use `select' and care for
@@ -1988,7 +1989,7 @@ Int HasAvailableBytes( UInt fid )
 
 
 
-Char * syFgetsNoEdit (
+static Char * syFgetsNoEdit (
     Char *              line,
     UInt                length,
     Int                 fid,
@@ -2044,25 +2045,25 @@ Char * syFgetsNoEdit (
 /* will be imported from library, first is generic function which does some
    checks before returning result to kernel, the second is the list of handler
    functions which do the actual work. */
-Obj LineEditKeyHandler;
-Obj LineEditKeyHandlers;
-Obj GAPInfo;
+static Obj LineEditKeyHandler;
+static Obj LineEditKeyHandlers;
+static Obj GAPInfo;
 
 #ifdef HAVE_LIBREADLINE
 
 /* we import GAP level functions from GAPInfo components */
-Obj CLEFuncs;
-Obj KeyHandler;
+static Obj CLEFuncs;
+static Obj KeyHandler;
 
 static int GAPMacroNumber = 0;
 
-int GAP_set_macro(int count, int key)
+static int GAP_set_macro(int count, int key)
 {
  GAPMacroNumber = count;
  return 0;
 }
 /* a generic rl_command_func_t that delegates to GAP level */
-int GAP_rl_func(int count, int key)
+static int GAP_rl_func(int count, int key)
 {
    Obj   rldata, linestr, okey, res, obj, data, beginchange, endchange, m;
    Int   len, n, hook, dlen, max, i;
@@ -2176,7 +2177,7 @@ int GAP_rl_func(int count, int key)
    return 0;
 }
 
-Obj FuncBINDKEYSTOGAPHANDLER (Obj self, Obj keys)
+static Obj FuncBINDKEYSTOGAPHANDLER (Obj self, Obj keys)
 {
   Char*  seq;
 
@@ -2187,7 +2188,7 @@ Obj FuncBINDKEYSTOGAPHANDLER (Obj self, Obj keys)
   return True;
 }
 
-Obj FuncBINDKEYSTOMACRO (Obj self, Obj keys, Obj macro)
+static Obj FuncBINDKEYSTOMACRO (Obj self, Obj keys, Obj macro)
 {
   Char   *seq, *macr;
 
@@ -2199,7 +2200,7 @@ Obj FuncBINDKEYSTOMACRO (Obj self, Obj keys, Obj macro)
   return True;
 }
 
-Obj FuncREADLINEINITLINE (Obj self, Obj line)
+static Obj FuncREADLINEINITLINE (Obj self, Obj line)
 {
   Char   *cline;
 
@@ -2210,10 +2211,10 @@ Obj FuncREADLINEINITLINE (Obj self, Obj line)
 }
 
 /* init is needed once */
-Int ISINITREADLINE = 0;
+static Int ISINITREADLINE = 0;
 /* a hook function called regularly while waiting on input */
-Int current_rl_fid;
-int charreadhook_rl ( void )
+static Int current_rl_fid;
+static int charreadhook_rl ( void )
 {
 #ifdef HAVE_SELECT
     if (OnCharReadHookActiveCheck())
@@ -2222,7 +2223,7 @@ int charreadhook_rl ( void )
   return 0;
 }
 
-void initreadline ( void )
+static void initreadline ( void )
 {
 
   /* allows users to configure GAP specific settings in their ~/.inputrc like:
@@ -2247,7 +2248,7 @@ void initreadline ( void )
   ISINITREADLINE = 1;
 }
 
-Char * readlineFgets (
+static Char * readlineFgets (
     Char *              line,
     UInt                length,
     Int                 fid,
@@ -2329,7 +2330,7 @@ static Int syEndEdit(Int fid)
 
 #endif
 
-Char * syFgets (
+static Char * syFgets (
     Char *              line,
     UInt                length,
     Int                 fid,
@@ -2996,8 +2997,6 @@ void SySetErrorNo ( void )
 # define WIFEXITED(stat_val) (((stat_val) & 255) == 0)
 #endif
 
-void NullSignalHandler(int scratch) {}
-
 #ifdef SYS_IS_CYGWIN32
 
 UInt SyExecuteProcess (
@@ -3086,6 +3085,10 @@ UInt SyExecuteProcess (
 }
 
 #else
+
+static void NullSignalHandler(int scratch)
+{
+}
 
 UInt SyExecuteProcess (
     Char *                  dir,
@@ -3520,7 +3523,7 @@ Obj SyReadStringFile(Int fid)
 /* fstat seems completely broken under CYGWIN */
 /* first try to get the whole file as one chunk, this avoids garbage
    collections because of the GROW_STRING calls below    */
-Obj SyReadStringFileStat(Int fid)
+static Obj SyReadStringFileStat(Int fid)
 {
     Int             ret, len;
     Obj             str;

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -182,9 +182,9 @@ static inline UInt SyRoundUpToPagesize(UInt x)
     return r == 0 ? x : x - r + pagesize;
 }
 
-static void *     POOL = NULL;
-static UInt * * * syWorkspace = NULL;
-static UInt       syWorksize = 0;
+static void *   POOL = NULL;
+static UInt *** syWorkspace = NULL;
+static UInt     syWorksize = 0;
 
 #ifdef GAP_MEM_CHECK
 
@@ -335,7 +335,7 @@ void SyMAdviseFree(void) {
 #endif
 }
 
-static void *SyAnonMMap(size_t size)
+static void * SyAnonMMap(size_t size)
 {
     void *result;
     size = SyRoundUpToPagesize(size);
@@ -384,7 +384,8 @@ static int SyTryToIncreasePool(void)
 
 #else
 
-static void SyMAdviseFree(void) {
+static void SyMAdviseFree(void)
+{
     /* do nothing */
 }
 
@@ -398,7 +399,7 @@ static int SyTryToIncreasePool(void)
 
 static int halvingsdone = 0;
 
-static void SyInitialAllocPool( void )
+static void SyInitialAllocPool(void)
 {
 #ifdef HAVE_SYSCONF
 #ifdef _SC_PAGESIZE
@@ -432,7 +433,7 @@ static void SyInitialAllocPool( void )
    /* Now both syWorkspace and SyAllocPool are aligned to pagesize */
 }
 
-static UInt ***SyAllocBagsFromPool(Int size, UInt need)
+static UInt *** SyAllocBagsFromPool(Int size, UInt need)
 {
   /* get the storage, but only if we stay within the bounds              */
   /* if ( (0 < size && syWorksize + size <= SyStorMax) */
@@ -455,9 +456,7 @@ static UInt ***SyAllocBagsFromPool(Int size, UInt need)
 
 #if defined(HAVE_SBRK) && !defined(HAVE_VM_ALLOCATE) /* prefer `vm_allocate' over `sbrk' */
 
-UInt * * * SyAllocBags (
-    Int                 size,
-    UInt                need )
+UInt *** SyAllocBags(Int size, UInt need)
 {
     UInt * * *          ret;
     UInt adjust = 0;

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -182,9 +182,9 @@ static inline UInt SyRoundUpToPagesize(UInt x)
     return r == 0 ? x : x - r + pagesize;
 }
 
-void *     POOL = NULL;
-UInt * * * syWorkspace = NULL;
-UInt       syWorksize = 0;
+static void *     POOL = NULL;
+static UInt * * * syWorkspace = NULL;
+static UInt       syWorksize = 0;
 
 #ifdef GAP_MEM_CHECK
 
@@ -208,17 +208,17 @@ enum { membufcount = 64 };
 static void * membufs[membufcount];
 static UInt   membufSize;
 
-UInt GetMembufCount(void)
+static UInt GetMembufCount(void)
 {
     return membufcount;
 }
 
-void * GetMembuf(UInt i)
+static void * GetMembuf(UInt i)
 {
     return membufs[i];
 }
 
-UInt GetMembufSize(void)
+static UInt GetMembufSize(void)
 {
     return membufSize;
 }
@@ -238,7 +238,7 @@ static int order_pointers(const void * a, const void * b)
     }
 }
 
-void * SyAnonMMap(size_t size)
+static void * SyAnonMMap(size_t size)
 {
     size = SyRoundUpToPagesize(size);
     membufSize = size;
@@ -335,7 +335,8 @@ void SyMAdviseFree(void) {
 #endif
 }
 
-void *SyAnonMMap(size_t size) {
+static void *SyAnonMMap(size_t size)
+{
     void *result;
     size = SyRoundUpToPagesize(size);
 #ifdef SYS_IS_64_BIT
@@ -358,7 +359,7 @@ void *SyAnonMMap(size_t size) {
     return result;
 }
 
-int SyTryToIncreasePool(void)
+static int SyTryToIncreasePool(void)
 /* This tries to increase the pool size by a factor of 3/2, if this
  * worked, then 0 is returned, otherwise -1. */
 {
@@ -383,11 +384,11 @@ int SyTryToIncreasePool(void)
 
 #else
 
-void SyMAdviseFree(void) {
+static void SyMAdviseFree(void) {
     /* do nothing */
 }
 
-int SyTryToIncreasePool(void)
+static int SyTryToIncreasePool(void)
 {
     return -1;   /* Refuse */
 }
@@ -395,9 +396,9 @@ int SyTryToIncreasePool(void)
 #endif
 #endif
 
-int halvingsdone = 0;
+static int halvingsdone = 0;
 
-void SyInitialAllocPool( void )
+static void SyInitialAllocPool( void )
 {
 #ifdef HAVE_SYSCONF
 #ifdef _SC_PAGESIZE
@@ -431,7 +432,7 @@ void SyInitialAllocPool( void )
    /* Now both syWorkspace and SyAllocPool are aligned to pagesize */
 }
 
-UInt ***SyAllocBagsFromPool(Int size, UInt need)
+static UInt ***SyAllocBagsFromPool(Int size, UInt need)
 {
   /* get the storage, but only if we stay within the bounds              */
   /* if ( (0 < size && syWorksize + size <= SyStorMax) */

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -41,9 +41,7 @@
 **
 *F  CheckTietzeStack( <tietze>, <ptTietze> )
 */
-static void CheckTietzeStack (
-    Obj                 tietze,
-    Obj * *             ptTietze )
+static void CheckTietzeStack(Obj tietze, Obj ** ptTietze)
 {
     /*  check the Tietze stack                                             */
     RequirePlainList(0, tietze);
@@ -60,11 +58,8 @@ static void CheckTietzeStack (
 **
 *F  CheckTietzeRelators( <ptTietze>, <rels>, <ptRels>, <numrels> )
 */
-static void CheckTietzeRelators (
-    Obj *               ptTietze,
-    Obj *               rels,
-    Obj * *             ptRels,
-    Int *              numrels )
+static void
+CheckTietzeRelators(Obj * ptTietze, Obj * rels, Obj ** ptRels, Int * numrels)
 {
     *rels    = ptTietze[TZ_RELATORS];
     *numrels = INT_INTOBJ(ptTietze[TZ_NUMRELS]);
@@ -80,11 +75,8 @@ static void CheckTietzeRelators (
 **
 *F  CheckTietzeInverses( <ptTietze>, <invs>, <ptInvs>, <numgens> )
 */
-static void CheckTietzeInverses (
-    Obj *               ptTietze,
-    Obj *               invs,
-    Obj * *             ptInvs,
-    Int *               numgens )
+static void
+CheckTietzeInverses(Obj * ptTietze, Obj * invs, Obj ** ptInvs, Int * numgens)
 {
     /* get and check the Tietze inverses list                              */
     *invs    = ptTietze[TZ_INVERSES];
@@ -101,11 +93,8 @@ static void CheckTietzeInverses (
 **
 *F  CheckTietzeLengths( <ptTietze>, <numrels>, <lens>, <ptLens> )
 */
-static void CheckTietzeLengths (
-    Obj *               ptTietze,
-    Int                 numrels,
-    Obj *               lens,
-    Obj * *             ptLens )
+static void
+CheckTietzeLengths(Obj * ptTietze, Int numrels, Obj * lens, Obj ** ptLens)
 {
     /*  Get and check the Tietze lengths list                              */
     *lens = ptTietze[TZ_LENGTHS];
@@ -121,11 +110,8 @@ static void CheckTietzeLengths (
 **
 *F  CheckTietzeFlags( <ptTietze>, <numrels>, <flags>, <ptFlags> )
 */
-static void CheckTietzeFlags (
-    Obj *               ptTietze,
-    Int                 numrels,
-    Obj *               flags,
-    Obj * *             ptFlags )
+static void
+CheckTietzeFlags(Obj * ptTietze, Int numrels, Obj * flags, Obj ** ptFlags)
 {
     /* get and check the Tietze flags list                                 */
     *flags = ptTietze[TZ_FLAGS];
@@ -141,12 +127,8 @@ static void CheckTietzeFlags (
 **
 *F  CheckTietzeRelLengths( <ptTietze>, <ptRels>, <ptLens>, <nrels>, <total> )
 */
-static void CheckTietzeRelLengths (
-    Obj *               ptTietze,
-    Obj *               ptRels,
-    Obj *               ptLens,
-    Int                 numrels,
-    Int  *              total )
+static void CheckTietzeRelLengths(
+    Obj * ptTietze, Obj * ptRels, Obj * ptLens, Int numrels, Int * total)
 {
     Int                i;
 
@@ -173,9 +155,7 @@ static void CheckTietzeRelLengths (
 **
 *F  FuncTzSortC( <self>, <stack> )  . . . . . . . sort the relators by length
 */
-static Obj FuncTzSortC (
-    Obj                 self,
-    Obj                 tietze )
+static Obj FuncTzSortC(Obj self, Obj tietze)
 {
     Obj *               ptTietze;       /* pointer to the Tietze stack     */
     Obj                 rels;           /* relators list                   */
@@ -248,9 +228,7 @@ static Obj FuncTzSortC (
 **
 *F  FuncTzRenumberGens( <self>, <stack> ) . .  renumber the Tietze generators
 */
-static Obj FuncTzRenumberGens (
-    Obj                 self,
-    Obj                 tietze )
+static Obj FuncTzRenumberGens(Obj self, Obj tietze)
 {
     Obj *               ptTietze;       /* pointer to this stack           */
     Obj                 rels;           /* handle of the relators list     */
@@ -297,9 +275,7 @@ static Obj FuncTzRenumberGens (
 **
 *F  FuncTzReplaceGens( <self>, <stack> )  replace Tietze generators by others
 */
-static Obj FuncTzReplaceGens (
-    Obj                 self,
-    Obj                 tietze )
+static Obj FuncTzReplaceGens(Obj self, Obj tietze)
 {
     Obj *               ptTietze;       /* pointer to this stack           */
     Obj                 rels;           /* handle of the relators list     */
@@ -422,11 +398,7 @@ static Obj FuncTzReplaceGens (
 **
 *F  FuncTzSubstituteGen( <self>, <stack>, <gennum>, <word> )
 */
-static Obj FuncTzSubstituteGen (
-    Obj                 self,
-    Obj                 tietze,
-    Obj                 gennum,
-    Obj                 word )
+static Obj FuncTzSubstituteGen(Obj self, Obj tietze, Obj gennum, Obj word)
 {
     Obj *               ptTietze;       /* pointer to this stack           */
     Obj                 rels;           /* handle of the relators list     */
@@ -647,9 +619,7 @@ static Obj FuncTzSubstituteGen (
 **
 *F  FuncTzOccurrences( <self>, <args> ) . .  occurrences of Tietze generators
 */
-static Obj FuncTzOccurrences ( 
-    Obj                 self,
-    Obj                 args )
+static Obj FuncTzOccurrences(Obj self, Obj args)
 {
     Obj                 tietze;         /* handle of the Tietze stack      */
     Obj *               ptTietze;       /* pointer to the Tietze stack     */
@@ -853,9 +823,7 @@ static Obj FuncTzOccurrences (
 **
 *F  FuncTzOccurrencesPairs( <self>, <args> )  . . . . .  occurrences of pairs
 */
-static Obj FuncTzOccurrencesPairs (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncTzOccurrencesPairs(Obj self, Obj args)
 {
     Obj                 tietze;         /* handle of the Tietze stack      */
     Obj *               ptTietze;       /* pointer to the Tietze stack     */
@@ -1025,9 +993,7 @@ static Obj FuncTzOccurrencesPairs (
 **
 *F  FuncTzSearchC( <self>, <args> ) . find subword matches in Tietze relators
 */
-static Obj FuncTzSearchC (
-    Obj                 self,
-    Obj                 args )
+static Obj FuncTzSearchC(Obj self, Obj args)
 {
     Obj                 tietze;         /* handle of the Tietze stack      */
     Obj *               ptTietze;       /* pointer to this stack           */
@@ -1511,10 +1477,7 @@ static Obj FuncTzSearchC (
 
 /* rewriting using tz form relators */
 
-static Obj  FuncREDUCE_LETREP_WORDS_REW_SYS (
- Obj  self,
- Obj  tzrules,
- Obj  a_w )
+static Obj FuncREDUCE_LETREP_WORDS_REW_SYS(Obj self, Obj tzrules, Obj a_w)
 {
  UInt n,lt,i,k,p,j,lrul,eq,rlen,newlen,a;
  Obj w,nw,rul;

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -41,7 +41,7 @@
 **
 *F  CheckTietzeStack( <tietze>, <ptTietze> )
 */
-void CheckTietzeStack (
+static void CheckTietzeStack (
     Obj                 tietze,
     Obj * *             ptTietze )
 {
@@ -60,7 +60,7 @@ void CheckTietzeStack (
 **
 *F  CheckTietzeRelators( <ptTietze>, <rels>, <ptRels>, <numrels> )
 */
-void CheckTietzeRelators (
+static void CheckTietzeRelators (
     Obj *               ptTietze,
     Obj *               rels,
     Obj * *             ptRels,
@@ -80,7 +80,7 @@ void CheckTietzeRelators (
 **
 *F  CheckTietzeInverses( <ptTietze>, <invs>, <ptInvs>, <numgens> )
 */
-void CheckTietzeInverses (
+static void CheckTietzeInverses (
     Obj *               ptTietze,
     Obj *               invs,
     Obj * *             ptInvs,
@@ -101,7 +101,7 @@ void CheckTietzeInverses (
 **
 *F  CheckTietzeLengths( <ptTietze>, <numrels>, <lens>, <ptLens> )
 */
-void CheckTietzeLengths (
+static void CheckTietzeLengths (
     Obj *               ptTietze,
     Int                 numrels,
     Obj *               lens,
@@ -121,7 +121,7 @@ void CheckTietzeLengths (
 **
 *F  CheckTietzeFlags( <ptTietze>, <numrels>, <flags>, <ptFlags> )
 */
-void CheckTietzeFlags (
+static void CheckTietzeFlags (
     Obj *               ptTietze,
     Int                 numrels,
     Obj *               flags,
@@ -141,7 +141,7 @@ void CheckTietzeFlags (
 **
 *F  CheckTietzeRelLengths( <ptTietze>, <ptRels>, <ptLens>, <nrels>, <total> )
 */
-void CheckTietzeRelLengths (
+static void CheckTietzeRelLengths (
     Obj *               ptTietze,
     Obj *               ptRels,
     Obj *               ptLens,
@@ -173,7 +173,7 @@ void CheckTietzeRelLengths (
 **
 *F  FuncTzSortC( <self>, <stack> )  . . . . . . . sort the relators by length
 */
-Obj FuncTzSortC (
+static Obj FuncTzSortC (
     Obj                 self,
     Obj                 tietze )
 {
@@ -248,7 +248,7 @@ Obj FuncTzSortC (
 **
 *F  FuncTzRenumberGens( <self>, <stack> ) . .  renumber the Tietze generators
 */
-Obj FuncTzRenumberGens (
+static Obj FuncTzRenumberGens (
     Obj                 self,
     Obj                 tietze )
 {
@@ -297,7 +297,7 @@ Obj FuncTzRenumberGens (
 **
 *F  FuncTzReplaceGens( <self>, <stack> )  replace Tietze generators by others
 */
-Obj FuncTzReplaceGens (
+static Obj FuncTzReplaceGens (
     Obj                 self,
     Obj                 tietze )
 {
@@ -422,7 +422,7 @@ Obj FuncTzReplaceGens (
 **
 *F  FuncTzSubstituteGen( <self>, <stack>, <gennum>, <word> )
 */
-Obj FuncTzSubstituteGen (
+static Obj FuncTzSubstituteGen (
     Obj                 self,
     Obj                 tietze,
     Obj                 gennum,
@@ -647,7 +647,7 @@ Obj FuncTzSubstituteGen (
 **
 *F  FuncTzOccurrences( <self>, <args> ) . .  occurrences of Tietze generators
 */
-Obj FuncTzOccurrences ( 
+static Obj FuncTzOccurrences ( 
     Obj                 self,
     Obj                 args )
 {
@@ -853,7 +853,7 @@ Obj FuncTzOccurrences (
 **
 *F  FuncTzOccurrencesPairs( <self>, <args> )  . . . . .  occurrences of pairs
 */
-Obj FuncTzOccurrencesPairs (
+static Obj FuncTzOccurrencesPairs (
     Obj                 self,
     Obj                 args )
 {
@@ -1025,7 +1025,7 @@ Obj FuncTzOccurrencesPairs (
 **
 *F  FuncTzSearchC( <self>, <args> ) . find subword matches in Tietze relators
 */
-Obj FuncTzSearchC (
+static Obj FuncTzSearchC (
     Obj                 self,
     Obj                 args )
 {
@@ -1511,7 +1511,7 @@ Obj FuncTzSearchC (
 
 /* rewriting using tz form relators */
 
-Obj  FuncREDUCE_LETREP_WORDS_REW_SYS (
+static Obj  FuncREDUCE_LETREP_WORDS_REW_SYS (
  Obj  self,
  Obj  tzrules,
  Obj  a_w )

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -97,7 +97,7 @@ Obj IdentityTrans;
 ** Forward declarations
 *******************************************************************************/
 
-Obj FuncIMAGE_SET_TRANS(Obj self, Obj f);
+static Obj FuncIMAGE_SET_TRANS(Obj self, Obj f);
 
 /*******************************************************************************
 ** Internal functions for transformations
@@ -176,7 +176,7 @@ static inline UInt4 * ResizeInitTmpTrans(UInt len)
 // Find the rank, flat kernel, and image set (unsorted) of a transformation of
 // degree at most 65536.
 
-UInt INIT_TRANS2(Obj f)
+static UInt INIT_TRANS2(Obj f)
 {
     UInt    deg, rank, i, j;
     const UInt2 * ptf;
@@ -223,7 +223,7 @@ UInt INIT_TRANS2(Obj f)
 // Find the rank, flat kernel, and image set (unsorted) of a transformation of
 // degree at least 65537.
 
-UInt INIT_TRANS4(Obj f)
+static UInt INIT_TRANS4(Obj f)
 {
     UInt    deg, rank, i, j;
     const UInt4 * ptf;
@@ -320,7 +320,7 @@ static void REMOVE_DUPS_PLIST_INTOBJ(Obj res)
 // Returns a transformation with list of images <list>, this does not check
 // that <list> is really a list or that its entries define a transformation.
 
-Obj FuncTransformationNC(Obj self, Obj list)
+static Obj FuncTransformationNC(Obj self, Obj list)
 {
     UInt    i, deg;
     UInt2 * ptf2;
@@ -349,7 +349,7 @@ Obj FuncTransformationNC(Obj self, Obj list)
 // Returns a transformation that maps <src> to <ran>, this does not check that
 // <src> is duplicate-free.
 
-Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
+static Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
 {
     Int     deg, i, s, r;
     Obj     f;
@@ -428,7 +428,7 @@ Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
 // a transformation, i.e.  that the maximum value in <ker> equals the length
 // of <img>.
 
-Obj FuncTRANS_IMG_KER_NC(Obj self, Obj img, Obj ker)
+static Obj FuncTRANS_IMG_KER_NC(Obj self, Obj img, Obj ker)
 {
     Obj     f, copy_img, copy_ker;
     UInt2 * ptf2;
@@ -482,7 +482,7 @@ Obj FuncTRANS_IMG_KER_NC(Obj self, Obj img, Obj ker)
 // Note that this does not return the same transformation as TRANS_IMG_KER_NC
 // with the same arguments.
 
-Obj FuncIDEM_IMG_KER_NC(Obj self, Obj img, Obj ker)
+static Obj FuncIDEM_IMG_KER_NC(Obj self, Obj img, Obj ker)
 {
     Obj     f, copy_img, copy_ker;
     UInt2 * ptf2;
@@ -539,7 +539,7 @@ Obj FuncIDEM_IMG_KER_NC(Obj self, Obj img, Obj ker)
 // Returns an idempotent transformation e with ker(e) = ker(f), where <f> is a
 // transformation.
 
-Obj FuncLEFT_ONE_TRANS(Obj self, Obj f)
+static Obj FuncLEFT_ONE_TRANS(Obj self, Obj f)
 {
     Obj  ker, img;
     UInt rank, n, i;
@@ -573,7 +573,7 @@ Obj FuncLEFT_ONE_TRANS(Obj self, Obj f)
 // Returns an idempotent transformation e with im(e) = im(f), where <f> is a
 // transformation.
 
-Obj FuncRIGHT_ONE_TRANS(Obj self, Obj f)
+static Obj FuncRIGHT_ONE_TRANS(Obj self, Obj f)
 {
     Obj  ker, img;
     UInt deg, len, i, j, n;
@@ -612,7 +612,7 @@ Obj FuncRIGHT_ONE_TRANS(Obj self, Obj f)
 // Returns the degree of the transformation <f>, i.e. the least value <n> such
 // that <f> fixes [n + 1, n + 2, .. ].
 
-Obj FuncDegreeOfTransformation(Obj self, Obj f)
+static Obj FuncDegreeOfTransformation(Obj self, Obj f)
 {
     UInt    n, i, deg;
     const UInt2 * ptf2;
@@ -669,7 +669,7 @@ Obj FuncDegreeOfTransformation(Obj self, Obj f)
 // Returns the rank of transformation, i.e. number of distinct values in
 // [(1)f .. (n)f] where n = DegreeOfTransformation(f).
 
-Obj FuncRANK_TRANS(Obj self, Obj f)
+static Obj FuncRANK_TRANS(Obj self, Obj f)
 {
     if (TNUM_OBJ(f) == T_TRANS2) {
         return SumInt(INTOBJ_INT(RANK_TRANS2(f) - DEG_TRANS2(f)),
@@ -686,7 +686,7 @@ Obj FuncRANK_TRANS(Obj self, Obj f)
 // Returns the rank of the transformation <f> on [1 .. n], i.e. the number of
 // distinct values in [(1)f .. (n)f].
 
-Obj FuncRANK_TRANS_INT(Obj self, Obj f, Obj n)
+static Obj FuncRANK_TRANS_INT(Obj self, Obj f, Obj n)
 {
     UInt    rank, i, m;
     const UInt2 * ptf2;
@@ -739,7 +739,7 @@ Obj FuncRANK_TRANS_INT(Obj self, Obj f, Obj n)
 // distinct values in [(list[1])f .. (list[n])f], where <list> consists of
 // positive ints.
 
-Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list)
+static Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list)
 {
     UInt    rank, i, j, len, def;
     const UInt2 * ptf2;
@@ -820,7 +820,7 @@ Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list)
 // Returns the flat kernel of transformation on
 // [1 .. DegreeOfTransformation(f)].
 
-Obj FuncFLAT_KERNEL_TRANS(Obj self, Obj f)
+static Obj FuncFLAT_KERNEL_TRANS(Obj self, Obj f)
 {
 
     if (TNUM_OBJ(f) == T_TRANS2) {
@@ -842,7 +842,7 @@ Obj FuncFLAT_KERNEL_TRANS(Obj self, Obj f)
 
 // Returns the flat kernel of the transformation <f> on [1 .. n].
 
-Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
+static Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
 {
     Obj newObj, *ptnew;
     const Obj *ptker;
@@ -934,7 +934,7 @@ Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
 
 // Returns the kernel of a transformation <f> as a partition of [1 .. n].
 
-Obj FuncKERNEL_TRANS(Obj self, Obj f, Obj n)
+static Obj FuncKERNEL_TRANS(Obj self, Obj f, Obj n)
 {
     Obj     ker;
     UInt    i, j, deg, nr, m, rank, min;
@@ -989,7 +989,7 @@ Obj FuncKERNEL_TRANS(Obj self, Obj f, Obj n)
 
 // Returns the set (pt)f ^ -1.
 
-Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
+static Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
 {
     UInt deg, nr, i, j;
     Obj  out;
@@ -1039,7 +1039,7 @@ Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
 // Returns the duplicate free list of images of the transformation f on
 // [1 .. n] where n = DEG_TRANS(f). Note that this might not be sorted.
 
-Obj FuncUNSORTED_IMAGE_SET_TRANS(Obj self, Obj f)
+static Obj FuncUNSORTED_IMAGE_SET_TRANS(Obj self, Obj f)
 {
 
     if (TNUM_OBJ(f) == T_TRANS2) {
@@ -1061,7 +1061,7 @@ Obj FuncUNSORTED_IMAGE_SET_TRANS(Obj self, Obj f)
 // Returns the image set of the transformation f on [1 .. n] where n =
 // DegreeOfTransformation(f).
 
-Obj FuncIMAGE_SET_TRANS(Obj self, Obj f)
+static Obj FuncIMAGE_SET_TRANS(Obj self, Obj f)
 {
 
     Obj out = FuncUNSORTED_IMAGE_SET_TRANS(self, f);
@@ -1076,7 +1076,7 @@ Obj FuncIMAGE_SET_TRANS(Obj self, Obj f)
 
 // Returns the image set of the transformation f on [1 .. n].
 
-Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
+static Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
 {
     Obj     im, newObj;
     UInt    deg, m, len, i, j, rank;
@@ -1153,7 +1153,7 @@ Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
 
 // Returns the image list [(1)f .. (n)f] of the transformation f.
 
-Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
+static Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -1198,7 +1198,7 @@ Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
 
 // Test if a transformation is the identity.
 
-Obj FuncIS_ID_TRANS(Obj self, Obj f)
+static Obj FuncIS_ID_TRANS(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -1231,7 +1231,7 @@ Obj FuncIS_ID_TRANS(Obj self, Obj f)
 // Returns true if the transformation <f> is an idempotent and false if it is
 // not.
 
-Obj FuncIS_IDEM_TRANS(Obj self, Obj f)
+static Obj FuncIS_IDEM_TRANS(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -1268,7 +1268,7 @@ Obj FuncIS_IDEM_TRANS(Obj self, Obj f)
 // Returns the least m and r such that f ^ (m + r) = f ^ m, where f is a
 // transformation.
 
-Obj FuncIndexPeriodOfTransformation(Obj self, Obj f)
+static Obj FuncIndexPeriodOfTransformation(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -1404,7 +1404,7 @@ Obj FuncIndexPeriodOfTransformation(Obj self, Obj f)
 
 // Returns the least integer m such that f ^ m is an idempotent.
 
-Obj FuncSMALLEST_IDEM_POW_TRANS(Obj self, Obj f)
+static Obj FuncSMALLEST_IDEM_POW_TRANS(Obj self, Obj f)
 {
     Obj x, ind, per, pow;
 
@@ -1425,7 +1425,7 @@ Obj FuncSMALLEST_IDEM_POW_TRANS(Obj self, Obj f)
 // Returns True if the transformation or list <t> is injective on the list
 // <l>.
 
-Obj FuncIsInjectiveListTrans(Obj self, Obj l, Obj t)
+static Obj FuncIsInjectiveListTrans(Obj self, Obj l, Obj t)
 {
     UInt    n, i, j;
     const UInt2 * ptt2;
@@ -1524,7 +1524,7 @@ Obj FuncIsInjectiveListTrans(Obj self, Obj l, Obj t)
 // Returns a transformation g such that transformation f * g * f = f and
 // g * f * g = g, where f is a transformation.
 
-Obj FuncInverseOfTransformation(Obj self, Obj f)
+static Obj FuncInverseOfTransformation(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -1582,7 +1582,7 @@ Obj FuncInverseOfTransformation(Obj self, Obj f)
 // special case should be removed, and [0] should be replaced by [1 .. n] in
 // the Semigroup package.
 
-Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
+static Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -1684,7 +1684,7 @@ Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
 // transformation is not necessarily a permutation (mathematically), when n is
 // less than the largest moved point of p.
 
-Obj FuncAS_TRANS_PERM_INT(Obj self, Obj p, Obj deg)
+static Obj FuncAS_TRANS_PERM_INT(Obj self, Obj p, Obj deg)
 {
     const UInt2 *ptp2;
     UInt2 *ptf2;
@@ -1770,7 +1770,7 @@ Obj FuncAS_TRANS_PERM_INT(Obj self, Obj p, Obj deg)
 // Returns a transformation <f> such that (i)f = (i)p for all i <= n where <p>
 // is a permutation <p> and <n> is the largest moved point of <p>.
 
-Obj FuncAS_TRANS_PERM(Obj self, Obj p)
+static Obj FuncAS_TRANS_PERM(Obj self, Obj p)
 {
     const UInt2 * ptPerm2;
     const UInt4 * ptPerm4;
@@ -1807,7 +1807,7 @@ Obj FuncAS_TRANS_PERM(Obj self, Obj p)
 // Returns a permutation mathematically equal to the transformation <f> if
 // possible, and returns Fail if it is not possible
 
-Obj FuncAS_PERM_TRANS(Obj self, Obj f)
+static Obj FuncAS_PERM_TRANS(Obj self, Obj f)
 {
     const UInt2 *ptf2;
     const UInt4 *ptf4;
@@ -1853,7 +1853,7 @@ Obj FuncAS_PERM_TRANS(Obj self, Obj f)
 // Returns the permutation of the image of the transformation <f> induced by
 // <f> if possible, and returns Fail if it is not possible.
 
-Obj FuncPermutationOfImage(Obj self, Obj f)
+static Obj FuncPermutationOfImage(Obj self, Obj f)
 {
     const UInt2 *ptf2;
     const UInt4 *ptf4;
@@ -1925,7 +1925,7 @@ Obj FuncPermutationOfImage(Obj self, Obj f)
 // Returns the permutation of the im(f) induced by f ^ -1 * g under the
 // (unchecked) assumption that im(f) = im(g) and ker(f) = ker(g).
 
-Obj FuncPermLeftQuoTransformationNC(Obj self, Obj f, Obj g)
+static Obj FuncPermLeftQuoTransformationNC(Obj self, Obj f, Obj g)
 {
     const UInt2 *ptf2, *ptg2;
     const UInt4 *ptf4, *ptg4;
@@ -2034,7 +2034,7 @@ Obj FuncPermLeftQuoTransformationNC(Obj self, Obj f, Obj g)
 // Returns a transformation g such that (i)g = (i)f for all i in list, and
 // where (i)g = i for every other value of i.
 
-Obj FuncRestrictedTransformation(Obj self, Obj f, Obj list)
+static Obj FuncRestrictedTransformation(Obj self, Obj f, Obj list)
 {
     UInt   deg, i, k, len;
     const UInt2 *ptf2;
@@ -2120,7 +2120,7 @@ Obj FuncRestrictedTransformation(Obj self, Obj f, Obj list)
 // In the first form, this is similar to TRIM_TRANS except that a new
 // transformation is returned.
 
-Obj FuncAS_TRANS_TRANS(Obj self, Obj f, Obj m)
+static Obj FuncAS_TRANS_TRANS(Obj self, Obj f, Obj m)
 {
     const UInt2 *ptf2;
     const UInt4 *ptf4;
@@ -2191,7 +2191,7 @@ Obj FuncAS_TRANS_TRANS(Obj self, Obj f, Obj m)
 // assumed that f is actually a transformation of [1 .. m], i.e. that i ^ f <=
 // m for all i in [1 .. m].
 
-Obj FuncTRIM_TRANS(Obj self, Obj f, Obj m)
+static Obj FuncTRIM_TRANS(Obj self, Obj f, Obj m)
 {
     UInt    deg, i;
     UInt4 * ptf;
@@ -2266,7 +2266,7 @@ Int HashFuncForTrans(Obj f)
     return HASHKEY_BAG_NC(f, (UInt4)255, 3 * sizeof(Obj), (int)2 * deg);
 }
 
-Obj FuncHASH_FUNC_FOR_TRANS(Obj self, Obj f, Obj data)
+static Obj FuncHASH_FUNC_FOR_TRANS(Obj self, Obj f, Obj data)
 {
     return INTOBJ_INT((HashFuncForTrans(f) % INT_INTOBJ(data)) + 1);
 }
@@ -2277,7 +2277,7 @@ Obj FuncHASH_FUNC_FOR_TRANS(Obj self, Obj f, Obj data)
 
 // Returns the largest value i such that (i)f <> i or 0 if no such i exists.
 
-Obj FuncLARGEST_MOVED_PT_TRANS(Obj self, Obj f)
+static Obj FuncLARGEST_MOVED_PT_TRANS(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -2307,7 +2307,7 @@ Obj FuncLARGEST_MOVED_PT_TRANS(Obj self, Obj f)
 
 // Returns the largest value in [(1)f .. (n)f] where n = LargestMovedPoint(f).
 
-Obj FuncLARGEST_IMAGE_PT(Obj self, Obj f)
+static Obj FuncLARGEST_IMAGE_PT(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -2358,7 +2358,7 @@ Obj FuncLARGEST_IMAGE_PT(Obj self, Obj f)
 // not. Note that this differs from the GAP level function which returns
 // infinity if (i)f = i for all i.
 
-Obj FuncSMALLEST_MOVED_PT_TRANS(Obj self, Obj f)
+static Obj FuncSMALLEST_MOVED_PT_TRANS(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -2395,7 +2395,7 @@ Obj FuncSMALLEST_MOVED_PT_TRANS(Obj self, Obj f)
 // this differs from the GAP level function which returns infinity if (i)f = i
 // for all i.
 
-Obj FuncSMALLEST_IMAGE_PT(Obj self, Obj f)
+static Obj FuncSMALLEST_IMAGE_PT(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -2433,7 +2433,7 @@ Obj FuncSMALLEST_IMAGE_PT(Obj self, Obj f)
 // Returns the number of values <i> in [1 .. n] such that (i)f <> i, where n =
 // DegreeOfTransformation(f).
 
-Obj FuncNR_MOVED_PTS_TRANS(Obj self, Obj f)
+static Obj FuncNR_MOVED_PTS_TRANS(Obj self, Obj f)
 {
     UInt    nr, i, deg;
     const UInt2 * ptf2;
@@ -2467,7 +2467,7 @@ Obj FuncNR_MOVED_PTS_TRANS(Obj self, Obj f)
 // Returns the set of values <i> in [1 .. n] such that (i)f <> i, where n =
 // DegreeOfTransformation(f).
 
-Obj FuncMOVED_PTS_TRANS(Obj self, Obj f)
+static Obj FuncMOVED_PTS_TRANS(Obj self, Obj f)
 {
     UInt    len, deg, i;
     Obj     out;
@@ -2517,7 +2517,7 @@ Obj FuncMOVED_PTS_TRANS(Obj self, Obj f)
 // ^ k) = j. The least number of representatives is returned and these
 // representatives are partitioned according to the component they belong to.
 
-Obj FuncCOMPONENT_REPS_TRANS(Obj self, Obj f)
+static Obj FuncCOMPONENT_REPS_TRANS(Obj self, Obj f)
 {
     UInt    deg, i, nr, pt, index;
     Obj     img, out, comp;
@@ -2654,7 +2654,7 @@ Obj FuncCOMPONENT_REPS_TRANS(Obj self, Obj f)
 // Returns the number of connected components of the transformation <f>,
 // thought of as a functional digraph with DegreeOfTransformation(f) vertices.
 
-Obj FuncNR_COMPONENTS_TRANS(Obj self, Obj f)
+static Obj FuncNR_COMPONENTS_TRANS(Obj self, Obj f)
 {
     UInt    nr, m, i, j, deg;
     const UInt2 * ptf2;
@@ -2702,7 +2702,7 @@ Obj FuncNR_COMPONENTS_TRANS(Obj self, Obj f)
 // Returns the connected components of the transformation <f>, thought of as a
 // functional digraph with DegreeOfTransformation(f) vertices.
 
-Obj FuncCOMPONENTS_TRANS(Obj self, Obj f)
+static Obj FuncCOMPONENTS_TRANS(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -2817,7 +2817,7 @@ Obj FuncCOMPONENTS_TRANS(Obj self, Obj f)
 // Returns the list of distinct values [pt, (pt)f, (pt)f ^ 2, ..] where <f> is
 // a transformation and <pt> is a positive integer.
 
-Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
+static Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
 {
     UInt    deg, cpt, len;
     Obj     out;
@@ -2871,7 +2871,7 @@ Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
 // Returns the cycle contained in the component of the transformation <f>
 // containing the positive integer <pt>.
 
-Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
+static Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
 {
     UInt    deg, cpt, len, i;
     Obj     out;
@@ -2931,7 +2931,7 @@ Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
 // Returns the cycles of the transformation <f>, thought of as a
 // functional digraph with DegreeOfTransformation(f) vertices.
 
-Obj FuncCYCLES_TRANS(Obj self, Obj f)
+static Obj FuncCYCLES_TRANS(Obj self, Obj f)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -3022,7 +3022,7 @@ Obj FuncCYCLES_TRANS(Obj self, Obj f)
 // Returns the cycles of the transformation <f> contained in the components of
 // any of the elements in <list>.
 
-Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
+static Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -3153,7 +3153,7 @@ Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
 // it is assumed (and not checked) that the transformation f is injective on
 // list.
 
-Obj FuncINV_LIST_TRANS(Obj self, Obj list, Obj f)
+static Obj FuncINV_LIST_TRANS(Obj self, Obj list, Obj f)
 {
     const UInt2 *ptf2;
     const UInt4 *ptf4;
@@ -3234,7 +3234,7 @@ Obj FuncINV_LIST_TRANS(Obj self, Obj list, Obj f)
 // lists
 // of f and g in the above.
 
-Obj FuncTRANS_IMG_CONJ(Obj self, Obj f, Obj g)
+static Obj FuncTRANS_IMG_CONJ(Obj self, Obj f, Obj g)
 {
     Obj    perm;
     const UInt2 *ptf2, *ptg2;
@@ -3384,7 +3384,7 @@ Obj FuncTRANS_IMG_CONJ(Obj self, Obj f, Obj g)
 // kernel of transformation. This assumes (but doesn't check) that <p> is a
 // permutation of [1 .. Length(<ker>)] regardless of its degree.
 
-Obj FuncPOW_KER_PERM(Obj self, Obj ker, Obj p)
+static Obj FuncPOW_KER_PERM(Obj self, Obj ker, Obj p)
 {
     UInt    len, rank, i, dep;
     Obj     out;
@@ -3494,7 +3494,7 @@ Obj FuncPOW_KER_PERM(Obj self, Obj ker, Obj p)
 // transformation g such that g<f> ^ ker(x) = ker(x) = ker(gfx) and the action
 // of g<f> on ker(x) is the identity.
 
-Obj FuncINV_KER_TRANS(Obj self, Obj X, Obj f)
+static Obj FuncINV_KER_TRANS(Obj self, Obj X, Obj f)
 {
     Obj    g;
     const UInt2 *ptf2;
@@ -3600,7 +3600,7 @@ Obj FuncINV_KER_TRANS(Obj self, Obj X, Obj f)
 // set of <f> on [1 .. n] is returned instead. If the argument <set> is not
 // [0], then the third argument is ignored.
 
-Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
+static Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
 {
     const UInt2 * ptf2;
     const UInt4 * ptf4;
@@ -3667,7 +3667,7 @@ Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
 
 // Returns the identity transformation.
 
-Obj OneTrans(Obj f)
+static Obj OneTrans(Obj f)
 {
     return IdentityTrans;
 }
@@ -3676,7 +3676,7 @@ Obj OneTrans(Obj f)
 ** Equality for transformations
 *******************************************************************************/
 
-Int EqTrans22(Obj opL, Obj opR)
+static Int EqTrans22(Obj opL, Obj opR)
 {
     UInt degL = DEG_TRANS2(opL);
     UInt degR = DEG_TRANS2(opR);
@@ -3731,7 +3731,7 @@ Int EqTrans22(Obj opL, Obj opR)
     return 1L;
 }
 
-Int EqTrans44(Obj opL, Obj opR)
+static Int EqTrans44(Obj opL, Obj opR)
 {
     UInt degL = DEG_TRANS4(opL);
     UInt degR = DEG_TRANS4(opR);
@@ -3786,7 +3786,7 @@ Int EqTrans44(Obj opL, Obj opR)
     return 1L;
 }
 
-Int EqTrans24(Obj f, Obj g)
+static Int EqTrans24(Obj f, Obj g)
 {
     UInt    i, def, deg;
     const UInt2 * ptf;
@@ -3829,7 +3829,7 @@ Int EqTrans24(Obj f, Obj g)
     return 1L;
 }
 
-Int EqTrans42(Obj f, Obj g)
+static Int EqTrans42(Obj f, Obj g)
 {
     return EqTrans24(g, f);
 }
@@ -3838,7 +3838,7 @@ Int EqTrans42(Obj f, Obj g)
 ** Less than for transformations
 *******************************************************************************/
 
-Int LtTrans22(Obj f, Obj g)
+static Int LtTrans22(Obj f, Obj g)
 {
     UInt   i, def, deg;
     const UInt2 *ptf, *ptg;
@@ -3896,7 +3896,7 @@ Int LtTrans22(Obj f, Obj g)
     return 0L;
 }
 
-Int LtTrans24(Obj f, Obj g)
+static Int LtTrans24(Obj f, Obj g)
 {
     UInt    i, def, deg;
     const UInt2 * ptf;
@@ -3958,7 +3958,7 @@ Int LtTrans24(Obj f, Obj g)
     return 0L;
 }
 
-Int LtTrans42(Obj f, Obj g)
+static Int LtTrans42(Obj f, Obj g)
 {
     UInt    i, def, deg;
     const UInt4 * ptf;
@@ -4020,7 +4020,7 @@ Int LtTrans42(Obj f, Obj g)
     return 0L;
 }
 
-Int LtTrans44(Obj f, Obj g)
+static Int LtTrans44(Obj f, Obj g)
 {
     UInt   i, def, deg;
     const UInt4 *ptf, *ptg;
@@ -4081,7 +4081,7 @@ Int LtTrans44(Obj f, Obj g)
 ** Products for transformations
 *******************************************************************************/
 
-Obj ProdTrans22(Obj f, Obj g)
+static Obj ProdTrans22(Obj f, Obj g)
 {
     const UInt2 *ptf, *ptg;
     UInt2 *ptfg;
@@ -4112,7 +4112,7 @@ Obj ProdTrans22(Obj f, Obj g)
     return fg;
 }
 
-Obj ProdTrans24(Obj f, Obj g)
+static Obj ProdTrans24(Obj f, Obj g)
 {
     const UInt2 * ptf;
     const UInt4 * ptg;
@@ -4150,7 +4150,7 @@ Obj ProdTrans24(Obj f, Obj g)
     return fg;
 }
 
-Obj ProdTrans42(Obj f, Obj g)
+static Obj ProdTrans42(Obj f, Obj g)
 {
     const UInt4 * ptf;
     UInt4 * ptfg;
@@ -4188,7 +4188,7 @@ Obj ProdTrans42(Obj f, Obj g)
     return fg;
 }
 
-Obj ProdTrans44(Obj f, Obj g)
+static Obj ProdTrans44(Obj f, Obj g)
 {
     const UInt4 *ptf, *ptg;
     UInt4 *ptfg;
@@ -4223,7 +4223,7 @@ Obj ProdTrans44(Obj f, Obj g)
 ** Products for a transformation and permutation
 *******************************************************************************/
 
-Obj ProdTrans2Perm2(Obj f, Obj p)
+static Obj ProdTrans2Perm2(Obj f, Obj p)
 {
     const UInt2 *ptf, *ptp;
     UInt2 *ptfp;
@@ -4254,7 +4254,7 @@ Obj ProdTrans2Perm2(Obj f, Obj p)
     return fp;
 }
 
-Obj ProdTrans2Perm4(Obj f, Obj p)
+static Obj ProdTrans2Perm4(Obj f, Obj p)
 {
     const UInt2 * ptf;
     const UInt4 * ptp;
@@ -4289,7 +4289,7 @@ Obj ProdTrans2Perm4(Obj f, Obj p)
     return fp;
 }
 
-Obj ProdTrans4Perm2(Obj f, Obj p)
+static Obj ProdTrans4Perm2(Obj f, Obj p)
 {
     const UInt4 * ptf;
     UInt4 * ptfp;
@@ -4324,7 +4324,7 @@ Obj ProdTrans4Perm2(Obj f, Obj p)
     return fp;
 }
 
-Obj ProdTrans4Perm4(Obj f, Obj p)
+static Obj ProdTrans4Perm4(Obj f, Obj p)
 {
     const UInt4 *ptf, *ptp;
     UInt4 *ptfp;
@@ -4359,7 +4359,7 @@ Obj ProdTrans4Perm4(Obj f, Obj p)
 ** Products for a permutation and transformation
 *******************************************************************************/
 
-Obj ProdPerm2Trans2(Obj p, Obj f)
+static Obj ProdPerm2Trans2(Obj p, Obj f)
 {
     const UInt2 *ptf, *ptp;
     UInt2 *ptpf;
@@ -4390,7 +4390,7 @@ Obj ProdPerm2Trans2(Obj p, Obj f)
     return pf;
 }
 
-Obj ProdPerm2Trans4(Obj p, Obj f)
+static Obj ProdPerm2Trans4(Obj p, Obj f)
 {
     const UInt4 * ptf;
     UInt4 * ptpf;
@@ -4425,7 +4425,7 @@ Obj ProdPerm2Trans4(Obj p, Obj f)
     return pf;
 }
 
-Obj ProdPerm4Trans2(Obj p, Obj f)
+static Obj ProdPerm4Trans2(Obj p, Obj f)
 {
     const UInt2 * ptf;
     const UInt4 * ptp;
@@ -4460,7 +4460,7 @@ Obj ProdPerm4Trans2(Obj p, Obj f)
     return pf;
 }
 
-Obj ProdPerm4Trans4(Obj p, Obj f)
+static Obj ProdPerm4Trans4(Obj p, Obj f)
 {
     const UInt4 *ptf, *ptp;
     UInt4 *ptpf;
@@ -4495,7 +4495,7 @@ Obj ProdPerm4Trans4(Obj p, Obj f)
 ** Conjugate a transformation f by a permutation p: p ^ -1 * f * p
 *******************************************************************************/
 
-Obj PowTrans2Perm2(Obj f, Obj p)
+static Obj PowTrans2Perm2(Obj f, Obj p)
 {
     const UInt2 *ptf, *ptp;
     UInt2 *ptcnj;
@@ -4524,7 +4524,7 @@ Obj PowTrans2Perm2(Obj f, Obj p)
     return cnj;
 }
 
-Obj PowTrans2Perm4(Obj f, Obj p)
+static Obj PowTrans2Perm4(Obj f, Obj p)
 {
     const UInt2 * ptf;
     const UInt4 * ptp;
@@ -4557,7 +4557,7 @@ Obj PowTrans2Perm4(Obj f, Obj p)
     return cnj;
 }
 
-Obj PowTrans4Perm2(Obj f, Obj p)
+static Obj PowTrans4Perm2(Obj f, Obj p)
 {
     const UInt2 * ptp;
     const UInt4 * ptf;
@@ -4590,7 +4590,7 @@ Obj PowTrans4Perm2(Obj f, Obj p)
     return cnj;
 }
 
-Obj PowTrans4Perm4(Obj f, Obj p)
+static Obj PowTrans4Perm4(Obj f, Obj p)
 {
     const UInt4 *ptf, *ptp;
     UInt4 *ptcnj;
@@ -4623,7 +4623,7 @@ Obj PowTrans4Perm4(Obj f, Obj p)
 ** Quotient a transformation f by a permutation p: f * p ^ -1
 *******************************************************************************/
 
-Obj QuoTrans2Perm2(Obj f, Obj p)
+static Obj QuoTrans2Perm2(Obj f, Obj p)
 {
     UInt    def, dep, i;
     const UInt2 * ptf, *ptp;
@@ -4662,7 +4662,7 @@ Obj QuoTrans2Perm2(Obj f, Obj p)
     return quo;
 }
 
-Obj QuoTrans2Perm4(Obj f, Obj p)
+static Obj QuoTrans2Perm4(Obj f, Obj p)
 {
     UInt    def, dep, i;
     const UInt2 * ptf;
@@ -4704,7 +4704,7 @@ Obj QuoTrans2Perm4(Obj f, Obj p)
     return quo;
 }
 
-Obj QuoTrans4Perm2(Obj f, Obj p)
+static Obj QuoTrans4Perm2(Obj f, Obj p)
 {
     UInt    def, dep, i;
     const UInt4 * ptf;
@@ -4747,7 +4747,7 @@ Obj QuoTrans4Perm2(Obj f, Obj p)
     return quo;
 }
 
-Obj QuoTrans4Perm4(Obj f, Obj p)
+static Obj QuoTrans4Perm4(Obj f, Obj p)
 {
     UInt   def, dep, i;
     const UInt4 *ptf, *ptp;
@@ -4790,7 +4790,7 @@ Obj QuoTrans4Perm4(Obj f, Obj p)
 ** Left quotient a transformation f by a permutation p: p ^ -1 * f
 *******************************************************************************/
 
-Obj LQuoPerm2Trans2(Obj opL, Obj opR)
+static Obj LQuoPerm2Trans2(Obj opL, Obj opR)
 {
     UInt   degL, degR, degM, p;
     Obj    mod;
@@ -4827,7 +4827,7 @@ Obj LQuoPerm2Trans2(Obj opL, Obj opR)
     return mod;
 }
 
-Obj LQuoPerm2Trans4(Obj opL, Obj opR)
+static Obj LQuoPerm2Trans4(Obj opL, Obj opR)
 {
     UInt    degL, degR, degM, p;
     Obj     mod;
@@ -4867,7 +4867,7 @@ Obj LQuoPerm2Trans4(Obj opL, Obj opR)
     return mod;
 }
 
-Obj LQuoPerm4Trans2(Obj opL, Obj opR)
+static Obj LQuoPerm4Trans2(Obj opL, Obj opR)
 {
     UInt    degL, degR, degM, p;
     Obj     mod;
@@ -4907,7 +4907,7 @@ Obj LQuoPerm4Trans2(Obj opL, Obj opR)
     return mod;
 }
 
-Obj LQuoPerm4Trans4(Obj opL, Obj opR)
+static Obj LQuoPerm4Trans4(Obj opL, Obj opR)
 {
     UInt   degL, degR, degM, p;
     Obj    mod;
@@ -4948,7 +4948,7 @@ Obj LQuoPerm4Trans4(Obj opL, Obj opR)
 ** Apply a transformation to a point
 *******************************************************************************/
 
-Obj PowIntTrans2(Obj point, Obj f)
+static Obj PowIntTrans2(Obj point, Obj f)
 {
     Int img;
 
@@ -4965,7 +4965,7 @@ Obj PowIntTrans2(Obj point, Obj f)
     return INTOBJ_INT(img);
 }
 
-Obj PowIntTrans4(Obj point, Obj f)
+static Obj PowIntTrans4(Obj point, Obj f)
 {
     Int img;
 
@@ -5169,7 +5169,7 @@ Obj OnTuplesTrans(Obj tup, Obj f)
 *******************************************************************************/
 
 // Save and load
-void SaveTrans2(Obj f)
+static void SaveTrans2(Obj f)
 {
     const UInt2 * ptr;
     UInt    len, i;
@@ -5180,7 +5180,7 @@ void SaveTrans2(Obj f)
     }
 }
 
-void LoadTrans2(Obj f)
+static void LoadTrans2(Obj f)
 {
     UInt2 * ptr;
     UInt    len, i;
@@ -5191,7 +5191,7 @@ void LoadTrans2(Obj f)
     }
 }
 
-void SaveTrans4(Obj f)
+static void SaveTrans4(Obj f)
 {
     const UInt4 * ptr;
     UInt    len, i;
@@ -5202,7 +5202,7 @@ void SaveTrans4(Obj f)
     }
 }
 
-void LoadTrans4(Obj f)
+static void LoadTrans4(Obj f)
 {
     UInt4 * ptr;
     UInt    len, i;
@@ -5213,23 +5213,23 @@ void LoadTrans4(Obj f)
     }
 }
 
-Obj TYPE_TRANS2;
+static Obj TYPE_TRANS2;
 
-Obj TypeTrans2(Obj f)
+static Obj TypeTrans2(Obj f)
 {
     return TYPE_TRANS2;
 }
 
-Obj TYPE_TRANS4;
+static Obj TYPE_TRANS4;
 
-Obj TypeTrans4(Obj f)
+static Obj TypeTrans4(Obj f)
 {
     return TYPE_TRANS4;
 }
 
-Obj IsTransFilt;
+static Obj IsTransFilt;
 
-Obj IsTransHandler(Obj self, Obj val)
+static Obj IsTransHandler(Obj self, Obj val)
 {
     if (TNUM_OBJ(val) == T_TRANS2 || TNUM_OBJ(val) == T_TRANS4) {
         return True;

--- a/src/vars.c
+++ b/src/vars.c
@@ -156,8 +156,7 @@ void FreeLVarsBag(Bag bag)
 **  'ExecAssLVar' executes the local  variable assignment statement <stat> to
 **  the local variable that is referenced in <stat>.
 */
-static UInt            ExecAssLVar (
-    Stat                stat )
+static UInt ExecAssLVar(Stat stat)
 {
     Obj                 rhs;            /* value of right hand side        */
 
@@ -169,8 +168,7 @@ static UInt            ExecAssLVar (
     return 0;
 }
 
-static UInt            ExecUnbLVar (
-    Stat                stat )
+static UInt ExecUnbLVar(Stat stat)
 {
     /* unbind the local variable                                           */
     ASS_LVAR(READ_STAT(stat, 0), (Obj)0);
@@ -180,9 +178,7 @@ static UInt            ExecUnbLVar (
 }
 
 
-
-static Obj             EvalIsbLVar (
-    Expr                expr )
+static Obj EvalIsbLVar(Expr expr)
 {
     Obj                 val;            /* value, result                   */
 
@@ -200,8 +196,7 @@ static Obj             EvalIsbLVar (
 **
 **  'PrintAssLVar' prints the local variable assignment statement <stat>.
 */
-static void            PrintAssLVar (
-    Stat                stat )
+static void PrintAssLVar(Stat stat)
 {
     Pr( "%2>", 0L, 0L );
     Pr("%H", (Int)NAME_LVAR(READ_STAT(stat, 0)), 0L);
@@ -210,8 +205,7 @@ static void            PrintAssLVar (
     Pr( "%2<;", 0L, 0L );
 }
 
-static void            PrintUnbLVar (
-    Stat                stat )
+static void PrintUnbLVar(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%H", (Int)NAME_LVAR(READ_STAT(stat, 0)), 0L);
@@ -225,14 +219,12 @@ static void            PrintUnbLVar (
 **
 **  'PrintRefLVar' prints the local variable reference expression <expr>.
 */
-static void            PrintRefLVar (
-    Expr                expr )
+static void PrintRefLVar(Expr expr)
 {
     Pr( "%H", (Int)NAME_LVAR( LVAR_REFLVAR(expr) ), 0L );
 }
 
-static void            PrintIsbLVar (
-    Expr                expr )
+static void PrintIsbLVar(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%H", (Int)NAME_LVAR(READ_EXPR(expr, 0)), 0L);
@@ -312,8 +304,7 @@ Obj NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 **  'ExecAssHVar' executes the higher variable assignment statement <stat> to
 **  the higher variable that is referenced in <stat>.
 */
-static UInt            ExecAssHVar (
-    Stat                stat )
+static UInt ExecAssHVar(Stat stat)
 {
     Obj                 rhs;            /* value of right hand side        */
 
@@ -325,8 +316,7 @@ static UInt            ExecAssHVar (
     return 0;
 }
 
-static UInt            ExecUnbHVar (
-    Stat                stat )
+static UInt ExecUnbHVar(Stat stat)
 {
     /* unbind the higher variable                                          */
     ASS_HVAR(READ_STAT(stat, 0), 0);
@@ -343,8 +333,7 @@ static UInt            ExecUnbHVar (
 **  'EvalRefLVarXX' evaluates the higher variable reference expression <expr>
 **  to the higher variable that is referenced in <expr>.
 */
-static Obj             EvalRefHVar (
-    Expr                expr )
+static Obj EvalRefHVar(Expr expr)
 {
     Obj                 val;            /* value, result                   */
     UInt                hvar = READ_EXPR(expr, 0);
@@ -360,8 +349,7 @@ static Obj             EvalRefHVar (
     return val;
 }
 
-static Obj             EvalIsbHVar (
-    Expr                expr )
+static Obj EvalIsbHVar(Expr expr)
 {
     Obj                 val;            /* value, result                   */
 
@@ -379,8 +367,7 @@ static Obj             EvalIsbHVar (
 **
 **  'PrintAssHVar' prints the higher variable assignment statement <stat>.
 */
-static void            PrintAssHVar (
-    Stat                stat )
+static void PrintAssHVar(Stat stat)
 {
     Pr( "%2>", 0L, 0L );
     Pr("%H", (Int)NAME_HVAR(READ_STAT(stat, 0)), 0L);
@@ -389,8 +376,7 @@ static void            PrintAssHVar (
     Pr( "%2<;", 0L, 0L );
 }
 
-static void            PrintUnbHVar (
-    Stat                stat )
+static void PrintUnbHVar(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%H", (Int)NAME_HVAR(READ_STAT(stat, 0)), 0L);
@@ -404,14 +390,12 @@ static void            PrintUnbHVar (
 **
 **  'PrintRefHVar' prints the higher variable reference expression <expr>.
 */
-static void            PrintRefHVar (
-    Expr                expr )
+static void PrintRefHVar(Expr expr)
 {
     Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
 }
 
-static void            PrintIsbHVar (
-    Expr                expr )
+static void PrintIsbHVar(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
@@ -426,8 +410,7 @@ static void            PrintIsbHVar (
 **  'ExecAssGVar' executes the global variable assignment statement <stat> to
 **  the global variable that is referenced in <stat>.
 */
-static UInt            ExecAssGVar (
-    Stat                stat )
+static UInt ExecAssGVar(Stat stat)
 {
     Obj                 rhs;            /* value of right hand side        */
 
@@ -439,8 +422,7 @@ static UInt            ExecAssGVar (
     return 0;
 }
 
-static UInt            ExecUnbGVar (
-    Stat                stat )
+static UInt ExecUnbGVar(Stat stat)
 {
     /* unbind the global variable                                          */
     AssGVar(READ_STAT(stat, 0), (Obj)0);
@@ -457,8 +439,7 @@ static UInt            ExecUnbGVar (
 **  'EvalRefGVar' evaluates the  global variable reference expression  <expr>
 **  to the global variable that is referenced in <expr>.
 */
-static Obj             EvalRefGVar (
-    Expr                expr )
+static Obj EvalRefGVar(Expr expr)
 {
     Obj                 val;            /* value, result                   */
 
@@ -473,8 +454,7 @@ static Obj             EvalRefGVar (
     return val;
 }
 
-static Obj             EvalIsbGVar (
-    Expr                expr )
+static Obj EvalIsbGVar(Expr expr)
 {
     Obj                 val;            /* value, result                   */
 
@@ -492,8 +472,7 @@ static Obj             EvalIsbGVar (
 **
 **  'PrVarAss' prints the global variable assignment statement <stat>.
 */
-static void            PrintAssGVar (
-    Stat                stat )
+static void PrintAssGVar(Stat stat)
 {
     Pr( "%2>", 0L, 0L );
     Pr("%H", (Int)NameGVar(READ_STAT(stat, 0)), 0L);
@@ -502,8 +481,7 @@ static void            PrintAssGVar (
     Pr( "%2<;", 0L, 0L );
 }
 
-static void            PrintUnbGVar (
-    Stat                stat )
+static void PrintUnbGVar(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%H", (Int)NameGVar(READ_STAT(stat, 0)), 0L);
@@ -517,14 +495,12 @@ static void            PrintUnbGVar (
 **
 **  'PrintRefGVar' prints the global variable reference expression <expr>.
 */
-static void            PrintRefGVar (
-    Expr                expr )
+static void PrintRefGVar(Expr expr)
 {
     Pr("%H", (Int)NameGVar(READ_STAT(expr, 0)), 0L);
 }
 
-static void            PrintIsbGVar (
-    Expr                expr )
+static void PrintIsbGVar(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%H", (Int)NameGVar(READ_EXPR(expr, 0)), 0L);
@@ -539,8 +515,7 @@ static void            PrintIsbGVar (
 **  'ExecAssList'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>] := <rhs>;'.
 */
-static UInt            ExecAssList (
-    Expr                stat )
+static UInt ExecAssList(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -587,8 +562,7 @@ static UInt            ExecAssList (
 **  'ExecAss2List'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>,<position>] := <rhs>;'.
 */
-static UInt            ExecAss2List (
-    Expr                stat )
+static UInt ExecAss2List(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos1;           /* position, left operand          */
@@ -619,8 +593,7 @@ static UInt            ExecAss2List (
 **  'ExecAsssList' executes the list assignment statement  <stat> of the form
 **  '<list>{<positions>} := <rhss>;'.
 */
-static UInt            ExecAsssList (
-    Expr                stat )
+static UInt ExecAsssList(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 poss;           /* positions, left operand         */
@@ -660,8 +633,7 @@ static UInt            ExecAsssList (
 **  a  list, and 'ExecAssListLevel' assigns the  element '<rhss>[<i>]' to the
 **  list '<list>[<i>]' at <position>.
 */
-static UInt            ExecAssListLevel (
-    Expr                stat )
+static UInt ExecAssListLevel(Expr stat)
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, left operand          */
@@ -710,8 +682,7 @@ static UInt            ExecAssListLevel (
 **  a list, and 'ExecAsssListLevel' assigns the elements '<rhss>[<i>]' to the
 **  list '<list>[<i>]' at the positions <positions>.
 */
-static UInt            ExecAsssListLevel (
-    Expr                stat )
+static UInt ExecAsssListLevel(Expr stat)
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 poss;           /* position, left operand          */
@@ -747,8 +718,7 @@ static UInt            ExecAsssListLevel (
 **  'ExecUnbList'  executes the list   unbind  statement <stat> of the   form
 **  'Unbind( <list>[<position>] );'.
 */
-static UInt            ExecUnbList (
-    Expr                stat )
+static UInt ExecUnbList(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -792,8 +762,7 @@ static UInt            ExecUnbList (
 **  'EvalElmList' evaluates the list  element expression  <expr> of the  form
 **  '<list>[<position>]'.
 */
-static Obj             EvalElmList (
-    Expr                expr )
+static Obj EvalElmList(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 list;           /* list, left operand              */
@@ -838,8 +807,7 @@ static Obj             EvalElmList (
 **  'EvalElm2List' evaluates the list  element expression  <expr> of the  form
 **  '<list>[<pos1>,<pos2>]'.
 */
-static Obj             EvalElm2List (
-    Expr                expr )
+static Obj EvalElm2List(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 list;           /* list, left operand              */
@@ -867,8 +835,7 @@ static Obj             EvalElm2List (
 **  'EvalElmsList' evaluates the  list element expression  <expr> of the form
 **  '<list>{<positions>}'.
 */
-static Obj             EvalElmsList (
-    Expr                expr )
+static Obj EvalElmsList(Expr expr)
 {
     Obj                 elms;           /* elements, result                */
     Obj                 list;           /* list, left operand              */
@@ -902,8 +869,7 @@ static Obj             EvalElmsList (
 **  must be a  list of lists  and 'EvalElmListLevel'  selects the element  at
 **  <position> from each of the lists and returns the list of those values.
 */
-static Obj             EvalElmListLevel (
-    Expr                expr )
+static Obj EvalElmListLevel(Expr expr)
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, right operand         */
@@ -948,8 +914,7 @@ static Obj             EvalElmListLevel (
 **  <positions>  from each   of the lists  and  returns   the  list  of those
 **  sublists.
 */
-static Obj             EvalElmsListLevel (
-    Expr                expr )
+static Obj EvalElmsListLevel(Expr expr)
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 poss;           /* positions, right operand        */
@@ -981,8 +946,7 @@ static Obj             EvalElmsListLevel (
 **  'EvalIsbList'  evaluates the list  isbound expression  <expr> of the form
 **  'IsBound( <list>[<position>] )'.
 */
-static Obj             EvalIsbList (
-    Expr                expr )
+static Obj EvalIsbList(Expr expr)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, right operand         */
@@ -1023,8 +987,7 @@ static Obj             EvalIsbList (
 **
 **  Linebreaks are preferred before the ':='.
 */
-static void            PrintAssList (
-    Stat                stat )
+static void PrintAssList(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1036,8 +999,7 @@ static void            PrintAssList (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintAss2List (
-    Stat                stat )
+static void PrintAss2List(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1051,8 +1013,7 @@ static void            PrintAss2List (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintUnbList (
-    Stat                stat )
+static void PrintUnbList(Stat stat)
 {
   Int narg = SIZE_STAT(stat)/sizeof(Stat) -1;
   Int i;
@@ -1079,8 +1040,7 @@ static void            PrintUnbList (
 **
 **  Linebreaks are preferred before the ':='.
 */
-static void            PrintAsssList (
-    Stat                stat )
+static void PrintAsssList(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1102,8 +1062,7 @@ static void            PrintAsssList (
 **
 **  Linebreaks are preferred after the '['.
 */
-static void            PrintElmList (
-    Expr                expr )
+static void PrintElmList(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -1112,8 +1071,7 @@ static void            PrintElmList (
     Pr("%<]",0L,0L);
 }
 
-static void PrintElm2List (
-                     Expr expr )
+static void PrintElm2List(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -1124,8 +1082,7 @@ static void PrintElm2List (
     Pr("%<]",0L,0L);
 }
 
-static void PrintElmListLevel (
-                     Expr expr )
+static void PrintElmListLevel(Expr expr)
 {
   Int i;
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) -2 ;
@@ -1141,8 +1098,7 @@ static void PrintElmListLevel (
 }
 
 
-static void            PrintIsbList (
-    Expr                expr )
+static void PrintIsbList(Expr expr)
 {
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) - 1;
   Int i;
@@ -1169,8 +1125,7 @@ static void            PrintIsbList (
 **
 **  Linebreaks are preferred after the '{'.
 */
-static void            PrintElmsList (
-    Expr                expr )
+static void PrintElmsList(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -1187,8 +1142,7 @@ static void            PrintElmsList (
 **  'ExecAssRecName' executes the record  assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static UInt            ExecAssRecName (
-    Stat                stat )
+static UInt ExecAssRecName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1218,8 +1172,7 @@ static UInt            ExecAssRecName (
 **  'ExecAssRecExpr'  executes the record assignment  statement <stat> of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static UInt            ExecAssRecExpr (
-    Stat                stat )
+static UInt ExecAssRecExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1249,8 +1202,7 @@ static UInt            ExecAssRecExpr (
 **  'ExecUnbRecName' executes the record  unbind statement <stat> of the form
 **  'Unbind( <record>.<name> );'.
 */
-static UInt            ExecUnbRecName (
-    Stat                stat )
+static UInt ExecUnbRecName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1276,8 +1228,7 @@ static UInt            ExecUnbRecName (
 **  'ExecUnbRecExpr' executes the record  unbind statement <stat> of the form
 **  'Unbind( <record>.(<name>) );'.
 */
-static UInt            ExecUnbRecExpr (
-    Stat                stat )
+static UInt ExecUnbRecExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1303,8 +1254,7 @@ static UInt            ExecUnbRecExpr (
 **  'EvalElmRecName' evaluates the   record element expression  <expr> of the
 **  form '<record>.<name>'.
 */
-static Obj             EvalElmRecName (
-    Expr                expr )
+static Obj EvalElmRecName(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 record;         /* the record, left operand        */
@@ -1331,8 +1281,7 @@ static Obj             EvalElmRecName (
 **  'EvalElmRecExpr'  evaluates the record   element expression <expr> of the
 **  form '<record>.(<name>)'.
 */
-static Obj             EvalElmRecExpr (
-    Expr                expr )
+static Obj EvalElmRecExpr(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 record;         /* the record, left operand        */
@@ -1359,8 +1308,7 @@ static Obj             EvalElmRecExpr (
 **  'EvalElmRecName' evaluates the   record isbound expression  <expr> of the
 **  form 'IsBound( <record>.<name> )'.
 */
-static Obj             EvalIsbRecName (
-    Expr                expr )
+static Obj EvalIsbRecName(Expr expr)
 {
     Obj                 record;         /* the record, left operand        */
     UInt                rnam;           /* the name, right operand         */
@@ -1383,8 +1331,7 @@ static Obj             EvalIsbRecName (
 **  'EvalIsbRecExpr' evaluates  the record isbound  expression  <expr> of the
 **  form 'IsBound( <record>.(<name>) )'.
 */
-static Obj             EvalIsbRecExpr (
-    Expr                expr )
+static Obj EvalIsbRecExpr(Expr expr)
 {
     Obj                 record;         /* the record, left operand        */
     UInt                rnam;           /* the name, right operand         */
@@ -1407,8 +1354,7 @@ static Obj             EvalIsbRecExpr (
 **  'PrintAssRecName' prints the  record  assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static void            PrintAssRecName (
-    Stat                stat )
+static void PrintAssRecName(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1420,8 +1366,7 @@ static void            PrintAssRecName (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintUnbRecName (
-    Stat                stat )
+static void PrintUnbRecName(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1440,8 +1385,7 @@ static void            PrintUnbRecName (
 **  'PrintAssRecExpr' prints the  record  assignment statement <stat>  of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static void            PrintAssRecExpr (
-    Stat                stat )
+static void PrintAssRecExpr(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1453,8 +1397,7 @@ static void            PrintAssRecExpr (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintUnbRecExpr (
-    Stat                stat )
+static void PrintUnbRecExpr(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1473,8 +1416,7 @@ static void            PrintUnbRecExpr (
 **  'PrintElmRecName' prints the record element expression <expr> of the form
 **  '<record>.<name>'.
 */
-static void            PrintElmRecName (
-    Expr                expr )
+static void PrintElmRecName(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -1483,8 +1425,7 @@ static void            PrintElmRecName (
     Pr("%<",0L,0L);
 }
 
-static void            PrintIsbRecName (
-    Expr                expr )
+static void PrintIsbRecName(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1503,8 +1444,7 @@ static void            PrintIsbRecName (
 **  'PrintElmRecExpr' prints the record element expression <expr> of the form
 **  '<record>.(<name>)'.
 */
-static void            PrintElmRecExpr (
-    Expr                expr )
+static void PrintElmRecExpr(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -1513,8 +1453,7 @@ static void            PrintElmRecExpr (
     Pr(")%<",0L,0L);
 }
 
-static void            PrintIsbRecExpr (
-    Expr                expr )
+static void PrintIsbRecExpr(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1533,8 +1472,7 @@ static void            PrintIsbRecExpr (
 **  'ExecAssPosObj'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>] := <rhs>;'.
 */
-static UInt            ExecAssPosObj (
-    Expr                stat )
+static UInt ExecAssPosObj(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -1566,8 +1504,7 @@ static UInt            ExecAssPosObj (
 **  'ExecUnbPosObj'  executes the list   unbind  statement <stat> of the   form
 **  'Unbind( <list>[<position>] );'.
 */
-static UInt            ExecUnbPosObj (
-    Expr                stat )
+static UInt ExecUnbPosObj(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -1595,8 +1532,7 @@ static UInt            ExecUnbPosObj (
 **  'EvalElmPosObj' evaluates the list  element expression  <expr> of the  form
 **  '<list>[<position>]'.
 */
-static Obj             EvalElmPosObj (
-    Expr                expr )
+static Obj EvalElmPosObj(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 list;           /* list, left operand              */
@@ -1625,8 +1561,7 @@ static Obj             EvalElmPosObj (
 **  'EvalElmPosObj'  evaluates the list  isbound expression  <expr> of the form
 **  'IsBound( <list>[<position>] )'.
 */
-static Obj             EvalIsbPosObj (
-    Expr                expr )
+static Obj EvalIsbPosObj(Expr expr)
 {
     Obj                 isb;            /* isbound, result                 */
     Obj                 list;           /* list, left operand              */
@@ -1657,8 +1592,7 @@ static Obj             EvalIsbPosObj (
 **
 **  Linebreaks are preferred before the ':='.
 */
-static void            PrintAssPosObj (
-    Stat                stat )
+static void PrintAssPosObj(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1670,8 +1604,7 @@ static void            PrintAssPosObj (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintUnbPosObj (
-    Stat                stat )
+static void PrintUnbPosObj(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1692,8 +1625,7 @@ static void            PrintUnbPosObj (
 **
 **  Linebreaks are preferred after the '['.
 */
-static void            PrintElmPosObj (
-    Expr                expr )
+static void PrintElmPosObj(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -1702,8 +1634,7 @@ static void            PrintElmPosObj (
     Pr("%<]",0L,0L);
 }
 
-static void            PrintIsbPosObj (
-    Expr                expr )
+static void PrintIsbPosObj(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1722,8 +1653,7 @@ static void            PrintIsbPosObj (
 **  'ExecAssComObjName' executes the  record assignment statement <stat> of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static UInt            ExecAssComObjName (
-    Stat                stat )
+static UInt ExecAssComObjName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1753,8 +1683,7 @@ static UInt            ExecAssComObjName (
 **  'ExecAssComObjExpr' executes the record assignment  statement <stat> of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static UInt            ExecAssComObjExpr (
-    Stat                stat )
+static UInt ExecAssComObjExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1784,8 +1713,7 @@ static UInt            ExecAssComObjExpr (
 **  'ExecUnbComObjName' executes the record unbind statement <stat> of the form
 **  'Unbind( <record>.<name> );'.
 */
-static UInt            ExecUnbComObjName (
-    Stat                stat )
+static UInt ExecUnbComObjName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1811,8 +1739,7 @@ static UInt            ExecUnbComObjName (
 **  'ExecUnbComObjExpr' executes the record unbind statement <stat> of the form
 **  'Unbind( <record>.(<name>) );'.
 */
-static UInt            ExecUnbComObjExpr (
-    Stat                stat )
+static UInt ExecUnbComObjExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1838,8 +1765,7 @@ static UInt            ExecUnbComObjExpr (
 **  'EvalElmComObjName' evaluates the  record element expression  <expr> of the
 **  form '<record>.<name>'.
 */
-static Obj             EvalElmComObjName (
-    Expr                expr )
+static Obj EvalElmComObjName(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 record;         /* the record, left operand        */
@@ -1866,8 +1792,7 @@ static Obj             EvalElmComObjName (
 **  'EvalElmComObjExpr' evaluates the  record element expression  <expr> of the
 **  form '<record>.(<name>)'.
 */
-static Obj             EvalElmComObjExpr (
-    Expr                expr )
+static Obj EvalElmComObjExpr(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
     Obj                 record;         /* the record, left operand        */
@@ -1894,8 +1819,7 @@ static Obj             EvalElmComObjExpr (
 **  'EvalIsbComObjName' evaluates  the record isbound  expression <expr> of the
 **  form 'IsBound( <record>.<name> )'.
 */
-static Obj             EvalIsbComObjName (
-    Expr                expr )
+static Obj EvalIsbComObjName(Expr expr)
 {
     Obj                 isb;            /* element, result                 */
     Obj                 record;         /* the record, left operand        */
@@ -1922,8 +1846,7 @@ static Obj             EvalIsbComObjName (
 **  'EvalIsbComObjExpr'  evaluates the record isbound  expression <expr> of the
 **  form 'IsBound( <record>.(<name>) )'.
 */
-static Obj             EvalIsbComObjExpr (
-    Expr                expr )
+static Obj EvalIsbComObjExpr(Expr expr)
 {
     Obj                 isb;            /* element, result                 */
     Obj                 record;         /* the record, left operand        */
@@ -1950,8 +1873,7 @@ static Obj             EvalIsbComObjExpr (
 **  'PrintAssComObjName' prints the  record assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static void            PrintAssComObjName (
-    Stat                stat )
+static void PrintAssComObjName(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1963,8 +1885,7 @@ static void            PrintAssComObjName (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintUnbComObjName (
-    Stat                stat )
+static void PrintUnbComObjName(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -1983,8 +1904,7 @@ static void            PrintUnbComObjName (
 **  'PrintAssComObjExpr' prints the  record assignment statement <stat>  of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static void            PrintAssComObjExpr (
-    Stat                stat )
+static void PrintAssComObjExpr(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1996,8 +1916,7 @@ static void            PrintAssComObjExpr (
     Pr("%2<;",0L,0L);
 }
 
-static void            PrintUnbComObjExpr (
-    Stat                stat )
+static void PrintUnbComObjExpr(Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -2016,8 +1935,7 @@ static void            PrintUnbComObjExpr (
 **  'PrintElmComObjName' prints the  record  element expression <expr> of   the
 **  form '<record>.<name>'.
 */
-static void            PrintElmComObjName (
-    Expr                expr )
+static void PrintElmComObjName(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -2026,8 +1944,7 @@ static void            PrintElmComObjName (
     Pr("%<",0L,0L);
 }
 
-static void            PrintIsbComObjName (
-    Expr                expr )
+static void PrintIsbComObjName(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -2046,8 +1963,7 @@ static void            PrintIsbComObjName (
 **  'PrintElmComObjExpr' prints the record   element expression <expr>  of  the
 **  form '<record>.(<name>)'.
 */
-static void            PrintElmComObjExpr (
-    Expr                expr )
+static void PrintElmComObjExpr(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -2056,8 +1972,7 @@ static void            PrintElmComObjExpr (
     Pr(")%<",0L,0L);
 }
 
-static void            PrintIsbComObjExpr (
-    Expr                expr )
+static void PrintIsbComObjExpr(Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
@@ -2082,19 +1997,19 @@ static void            PrintIsbComObjExpr (
 */
 
 
-static Obj FuncGetCurrentLVars( Obj self )
+static Obj FuncGetCurrentLVars(Obj self)
 {
   // Need to promote to High Vars, else bag will be freed when function exits
   MakeHighVars(STATE(CurrLVars));
   return STATE(CurrLVars);
 }
 
-static Obj FuncGetBottomLVars( Obj self )
+static Obj FuncGetBottomLVars(Obj self)
 {
   return STATE(BottomLVars);
 }
 
-static Obj FuncParentLVars( Obj self, Obj lvars )
+static Obj FuncParentLVars(Obj self, Obj lvars)
 {
   if (!IS_LVARS_OR_HVARS(lvars)) {
       RequireArgument("ParentLVars", lvars, "must be an lvars");
@@ -2103,7 +2018,7 @@ static Obj FuncParentLVars( Obj self, Obj lvars )
   return parent ? parent : Fail;
 }
 
-static Obj FuncContentsLVars (Obj self, Obj lvars )
+static Obj FuncContentsLVars(Obj self, Obj lvars)
 {
   Obj contents = NEW_PREC(0);
   Obj func = FUNC_LVARS(lvars);
@@ -2131,13 +2046,13 @@ static Obj FuncContentsLVars (Obj self, Obj lvars )
 */
 #ifdef USE_GASMAN
 
-static void VarsBeforeCollectBags ( void )
+static void VarsBeforeCollectBags(void)
 {
   if (STATE(CurrLVars))
     CHANGED_BAG( STATE(CurrLVars) );
 }
 
-static void VarsAfterCollectBags ( void )
+static void VarsAfterCollectBags(void)
 {
   if (STATE(CurrLVars))
     {
@@ -2155,7 +2070,7 @@ static void VarsAfterCollectBags ( void )
 **
 */
 
-static void SaveLVars( Obj lvars )
+static void SaveLVars(Obj lvars)
 {
   UInt len,i;
   const Obj *ptr;
@@ -2174,7 +2089,7 @@ static void SaveLVars( Obj lvars )
 **
 */
 
-static void LoadLVars( Obj lvars )
+static void LoadLVars(Obj lvars)
 {
   UInt len,i;
   Obj *ptr;
@@ -2190,12 +2105,12 @@ static void LoadLVars( Obj lvars )
 
 static Obj TYPE_LVARS;
 
-static Obj TypeLVars( Obj lvars )
+static Obj TypeLVars(Obj lvars)
 {
   return TYPE_LVARS;
 }
 
-static void PrintLVars( Obj lvars )
+static void PrintLVars(Obj lvars)
 {
   Pr("<lvars bag>", 0,0);
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -156,7 +156,7 @@ void FreeLVarsBag(Bag bag)
 **  'ExecAssLVar' executes the local  variable assignment statement <stat> to
 **  the local variable that is referenced in <stat>.
 */
-UInt            ExecAssLVar (
+static UInt            ExecAssLVar (
     Stat                stat )
 {
     Obj                 rhs;            /* value of right hand side        */
@@ -169,7 +169,7 @@ UInt            ExecAssLVar (
     return 0;
 }
 
-UInt            ExecUnbLVar (
+static UInt            ExecUnbLVar (
     Stat                stat )
 {
     /* unbind the local variable                                           */
@@ -181,7 +181,7 @@ UInt            ExecUnbLVar (
 
 
 
-Obj             EvalIsbLVar (
+static Obj             EvalIsbLVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -200,7 +200,7 @@ Obj             EvalIsbLVar (
 **
 **  'PrintAssLVar' prints the local variable assignment statement <stat>.
 */
-void            PrintAssLVar (
+static void            PrintAssLVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
@@ -210,7 +210,7 @@ void            PrintAssLVar (
     Pr( "%2<;", 0L, 0L );
 }
 
-void            PrintUnbLVar (
+static void            PrintUnbLVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -225,13 +225,13 @@ void            PrintUnbLVar (
 **
 **  'PrintRefLVar' prints the local variable reference expression <expr>.
 */
-void            PrintRefLVar (
+static void            PrintRefLVar (
     Expr                expr )
 {
     Pr( "%H", (Int)NAME_LVAR( LVAR_REFLVAR(expr) ), 0L );
 }
 
-void            PrintIsbLVar (
+static void            PrintIsbLVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -312,7 +312,7 @@ Obj NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 **  'ExecAssHVar' executes the higher variable assignment statement <stat> to
 **  the higher variable that is referenced in <stat>.
 */
-UInt            ExecAssHVar (
+static UInt            ExecAssHVar (
     Stat                stat )
 {
     Obj                 rhs;            /* value of right hand side        */
@@ -325,7 +325,7 @@ UInt            ExecAssHVar (
     return 0;
 }
 
-UInt            ExecUnbHVar (
+static UInt            ExecUnbHVar (
     Stat                stat )
 {
     /* unbind the higher variable                                          */
@@ -343,7 +343,7 @@ UInt            ExecUnbHVar (
 **  'EvalRefLVarXX' evaluates the higher variable reference expression <expr>
 **  to the higher variable that is referenced in <expr>.
 */
-Obj             EvalRefHVar (
+static Obj             EvalRefHVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -360,7 +360,7 @@ Obj             EvalRefHVar (
     return val;
 }
 
-Obj             EvalIsbHVar (
+static Obj             EvalIsbHVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -379,7 +379,7 @@ Obj             EvalIsbHVar (
 **
 **  'PrintAssHVar' prints the higher variable assignment statement <stat>.
 */
-void            PrintAssHVar (
+static void            PrintAssHVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
@@ -389,7 +389,7 @@ void            PrintAssHVar (
     Pr( "%2<;", 0L, 0L );
 }
 
-void            PrintUnbHVar (
+static void            PrintUnbHVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -404,13 +404,13 @@ void            PrintUnbHVar (
 **
 **  'PrintRefHVar' prints the higher variable reference expression <expr>.
 */
-void            PrintRefHVar (
+static void            PrintRefHVar (
     Expr                expr )
 {
     Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
 }
 
-void            PrintIsbHVar (
+static void            PrintIsbHVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -426,7 +426,7 @@ void            PrintIsbHVar (
 **  'ExecAssGVar' executes the global variable assignment statement <stat> to
 **  the global variable that is referenced in <stat>.
 */
-UInt            ExecAssGVar (
+static UInt            ExecAssGVar (
     Stat                stat )
 {
     Obj                 rhs;            /* value of right hand side        */
@@ -439,7 +439,7 @@ UInt            ExecAssGVar (
     return 0;
 }
 
-UInt            ExecUnbGVar (
+static UInt            ExecUnbGVar (
     Stat                stat )
 {
     /* unbind the global variable                                          */
@@ -457,7 +457,7 @@ UInt            ExecUnbGVar (
 **  'EvalRefGVar' evaluates the  global variable reference expression  <expr>
 **  to the global variable that is referenced in <expr>.
 */
-Obj             EvalRefGVar (
+static Obj             EvalRefGVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -473,7 +473,7 @@ Obj             EvalRefGVar (
     return val;
 }
 
-Obj             EvalIsbGVar (
+static Obj             EvalIsbGVar (
     Expr                expr )
 {
     Obj                 val;            /* value, result                   */
@@ -492,7 +492,7 @@ Obj             EvalIsbGVar (
 **
 **  'PrVarAss' prints the global variable assignment statement <stat>.
 */
-void            PrintAssGVar (
+static void            PrintAssGVar (
     Stat                stat )
 {
     Pr( "%2>", 0L, 0L );
@@ -502,7 +502,7 @@ void            PrintAssGVar (
     Pr( "%2<;", 0L, 0L );
 }
 
-void            PrintUnbGVar (
+static void            PrintUnbGVar (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -517,13 +517,13 @@ void            PrintUnbGVar (
 **
 **  'PrintRefGVar' prints the global variable reference expression <expr>.
 */
-void            PrintRefGVar (
+static void            PrintRefGVar (
     Expr                expr )
 {
     Pr("%H", (Int)NameGVar(READ_STAT(expr, 0)), 0L);
 }
 
-void            PrintIsbGVar (
+static void            PrintIsbGVar (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -539,7 +539,7 @@ void            PrintIsbGVar (
 **  'ExecAssList'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>] := <rhs>;'.
 */
-UInt            ExecAssList (
+static UInt            ExecAssList (
     Expr                stat )
 {
     Obj                 list;           /* list, left operand              */
@@ -587,7 +587,7 @@ UInt            ExecAssList (
 **  'ExecAss2List'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>,<position>] := <rhs>;'.
 */
-UInt            ExecAss2List (
+static UInt            ExecAss2List (
     Expr                stat )
 {
     Obj                 list;           /* list, left operand              */
@@ -619,7 +619,7 @@ UInt            ExecAss2List (
 **  'ExecAsssList' executes the list assignment statement  <stat> of the form
 **  '<list>{<positions>} := <rhss>;'.
 */
-UInt            ExecAsssList (
+static UInt            ExecAsssList (
     Expr                stat )
 {
     Obj                 list;           /* list, left operand              */
@@ -660,7 +660,7 @@ UInt            ExecAsssList (
 **  a  list, and 'ExecAssListLevel' assigns the  element '<rhss>[<i>]' to the
 **  list '<list>[<i>]' at <position>.
 */
-UInt            ExecAssListLevel (
+static UInt            ExecAssListLevel (
     Expr                stat )
 {
     Obj                 lists;          /* lists, left operand             */
@@ -710,7 +710,7 @@ UInt            ExecAssListLevel (
 **  a list, and 'ExecAsssListLevel' assigns the elements '<rhss>[<i>]' to the
 **  list '<list>[<i>]' at the positions <positions>.
 */
-UInt            ExecAsssListLevel (
+static UInt            ExecAsssListLevel (
     Expr                stat )
 {
     Obj                 lists;          /* lists, left operand             */
@@ -747,7 +747,7 @@ UInt            ExecAsssListLevel (
 **  'ExecUnbList'  executes the list   unbind  statement <stat> of the   form
 **  'Unbind( <list>[<position>] );'.
 */
-UInt            ExecUnbList (
+static UInt            ExecUnbList (
     Expr                stat )
 {
     Obj                 list;           /* list, left operand              */
@@ -792,7 +792,7 @@ UInt            ExecUnbList (
 **  'EvalElmList' evaluates the list  element expression  <expr> of the  form
 **  '<list>[<position>]'.
 */
-Obj             EvalElmList (
+static Obj             EvalElmList (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -838,7 +838,7 @@ Obj             EvalElmList (
 **  'EvalElm2List' evaluates the list  element expression  <expr> of the  form
 **  '<list>[<pos1>,<pos2>]'.
 */
-Obj             EvalElm2List (
+static Obj             EvalElm2List (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -867,7 +867,7 @@ Obj             EvalElm2List (
 **  'EvalElmsList' evaluates the  list element expression  <expr> of the form
 **  '<list>{<positions>}'.
 */
-Obj             EvalElmsList (
+static Obj             EvalElmsList (
     Expr                expr )
 {
     Obj                 elms;           /* elements, result                */
@@ -902,7 +902,7 @@ Obj             EvalElmsList (
 **  must be a  list of lists  and 'EvalElmListLevel'  selects the element  at
 **  <position> from each of the lists and returns the list of those values.
 */
-Obj             EvalElmListLevel (
+static Obj             EvalElmListLevel (
     Expr                expr )
 {
     Obj                 lists;          /* lists, left operand             */
@@ -948,7 +948,7 @@ Obj             EvalElmListLevel (
 **  <positions>  from each   of the lists  and  returns   the  list  of those
 **  sublists.
 */
-Obj             EvalElmsListLevel (
+static Obj             EvalElmsListLevel (
     Expr                expr )
 {
     Obj                 lists;          /* lists, left operand             */
@@ -981,7 +981,7 @@ Obj             EvalElmsListLevel (
 **  'EvalIsbList'  evaluates the list  isbound expression  <expr> of the form
 **  'IsBound( <list>[<position>] )'.
 */
-Obj             EvalIsbList (
+static Obj             EvalIsbList (
     Expr                expr )
 {
     Obj                 list;           /* list, left operand              */
@@ -1023,7 +1023,7 @@ Obj             EvalIsbList (
 **
 **  Linebreaks are preferred before the ':='.
 */
-void            PrintAssList (
+static void            PrintAssList (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1036,7 +1036,7 @@ void            PrintAssList (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintAss2List (
+static void            PrintAss2List (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1051,7 +1051,7 @@ void            PrintAss2List (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintUnbList (
+static void            PrintUnbList (
     Stat                stat )
 {
   Int narg = SIZE_STAT(stat)/sizeof(Stat) -1;
@@ -1079,7 +1079,7 @@ void            PrintUnbList (
 **
 **  Linebreaks are preferred before the ':='.
 */
-void            PrintAsssList (
+static void            PrintAsssList (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1102,7 +1102,7 @@ void            PrintAsssList (
 **
 **  Linebreaks are preferred after the '['.
 */
-void            PrintElmList (
+static void            PrintElmList (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -1112,7 +1112,7 @@ void            PrintElmList (
     Pr("%<]",0L,0L);
 }
 
-void PrintElm2List (
+static void PrintElm2List (
                      Expr expr )
 {
     Pr("%2>",0L,0L);
@@ -1124,7 +1124,7 @@ void PrintElm2List (
     Pr("%<]",0L,0L);
 }
 
-void PrintElmListLevel (
+static void PrintElmListLevel (
                      Expr expr )
 {
   Int i;
@@ -1141,7 +1141,7 @@ void PrintElmListLevel (
 }
 
 
-void            PrintIsbList (
+static void            PrintIsbList (
     Expr                expr )
 {
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) - 1;
@@ -1169,7 +1169,7 @@ void            PrintIsbList (
 **
 **  Linebreaks are preferred after the '{'.
 */
-void            PrintElmsList (
+static void            PrintElmsList (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -1187,7 +1187,7 @@ void            PrintElmsList (
 **  'ExecAssRecName' executes the record  assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-UInt            ExecAssRecName (
+static UInt            ExecAssRecName (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1218,7 +1218,7 @@ UInt            ExecAssRecName (
 **  'ExecAssRecExpr'  executes the record assignment  statement <stat> of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-UInt            ExecAssRecExpr (
+static UInt            ExecAssRecExpr (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1249,7 +1249,7 @@ UInt            ExecAssRecExpr (
 **  'ExecUnbRecName' executes the record  unbind statement <stat> of the form
 **  'Unbind( <record>.<name> );'.
 */
-UInt            ExecUnbRecName (
+static UInt            ExecUnbRecName (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1276,7 +1276,7 @@ UInt            ExecUnbRecName (
 **  'ExecUnbRecExpr' executes the record  unbind statement <stat> of the form
 **  'Unbind( <record>.(<name>) );'.
 */
-UInt            ExecUnbRecExpr (
+static UInt            ExecUnbRecExpr (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1303,7 +1303,7 @@ UInt            ExecUnbRecExpr (
 **  'EvalElmRecName' evaluates the   record element expression  <expr> of the
 **  form '<record>.<name>'.
 */
-Obj             EvalElmRecName (
+static Obj             EvalElmRecName (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -1331,7 +1331,7 @@ Obj             EvalElmRecName (
 **  'EvalElmRecExpr'  evaluates the record   element expression <expr> of the
 **  form '<record>.(<name>)'.
 */
-Obj             EvalElmRecExpr (
+static Obj             EvalElmRecExpr (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -1359,7 +1359,7 @@ Obj             EvalElmRecExpr (
 **  'EvalElmRecName' evaluates the   record isbound expression  <expr> of the
 **  form 'IsBound( <record>.<name> )'.
 */
-Obj             EvalIsbRecName (
+static Obj             EvalIsbRecName (
     Expr                expr )
 {
     Obj                 record;         /* the record, left operand        */
@@ -1383,7 +1383,7 @@ Obj             EvalIsbRecName (
 **  'EvalIsbRecExpr' evaluates  the record isbound  expression  <expr> of the
 **  form 'IsBound( <record>.(<name>) )'.
 */
-Obj             EvalIsbRecExpr (
+static Obj             EvalIsbRecExpr (
     Expr                expr )
 {
     Obj                 record;         /* the record, left operand        */
@@ -1407,7 +1407,7 @@ Obj             EvalIsbRecExpr (
 **  'PrintAssRecName' prints the  record  assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-void            PrintAssRecName (
+static void            PrintAssRecName (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1420,7 +1420,7 @@ void            PrintAssRecName (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintUnbRecName (
+static void            PrintUnbRecName (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -1440,7 +1440,7 @@ void            PrintUnbRecName (
 **  'PrintAssRecExpr' prints the  record  assignment statement <stat>  of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-void            PrintAssRecExpr (
+static void            PrintAssRecExpr (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1453,7 +1453,7 @@ void            PrintAssRecExpr (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintUnbRecExpr (
+static void            PrintUnbRecExpr (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -1473,7 +1473,7 @@ void            PrintUnbRecExpr (
 **  'PrintElmRecName' prints the record element expression <expr> of the form
 **  '<record>.<name>'.
 */
-void            PrintElmRecName (
+static void            PrintElmRecName (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -1483,7 +1483,7 @@ void            PrintElmRecName (
     Pr("%<",0L,0L);
 }
 
-void            PrintIsbRecName (
+static void            PrintIsbRecName (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -1503,7 +1503,7 @@ void            PrintIsbRecName (
 **  'PrintElmRecExpr' prints the record element expression <expr> of the form
 **  '<record>.(<name>)'.
 */
-void            PrintElmRecExpr (
+static void            PrintElmRecExpr (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -1513,7 +1513,7 @@ void            PrintElmRecExpr (
     Pr(")%<",0L,0L);
 }
 
-void            PrintIsbRecExpr (
+static void            PrintIsbRecExpr (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -1533,7 +1533,7 @@ void            PrintIsbRecExpr (
 **  'ExecAssPosObj'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>] := <rhs>;'.
 */
-UInt            ExecAssPosObj (
+static UInt            ExecAssPosObj (
     Expr                stat )
 {
     Obj                 list;           /* list, left operand              */
@@ -1566,7 +1566,7 @@ UInt            ExecAssPosObj (
 **  'ExecUnbPosObj'  executes the list   unbind  statement <stat> of the   form
 **  'Unbind( <list>[<position>] );'.
 */
-UInt            ExecUnbPosObj (
+static UInt            ExecUnbPosObj (
     Expr                stat )
 {
     Obj                 list;           /* list, left operand              */
@@ -1595,7 +1595,7 @@ UInt            ExecUnbPosObj (
 **  'EvalElmPosObj' evaluates the list  element expression  <expr> of the  form
 **  '<list>[<position>]'.
 */
-Obj             EvalElmPosObj (
+static Obj             EvalElmPosObj (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -1625,7 +1625,7 @@ Obj             EvalElmPosObj (
 **  'EvalElmPosObj'  evaluates the list  isbound expression  <expr> of the form
 **  'IsBound( <list>[<position>] )'.
 */
-Obj             EvalIsbPosObj (
+static Obj             EvalIsbPosObj (
     Expr                expr )
 {
     Obj                 isb;            /* isbound, result                 */
@@ -1657,7 +1657,7 @@ Obj             EvalIsbPosObj (
 **
 **  Linebreaks are preferred before the ':='.
 */
-void            PrintAssPosObj (
+static void            PrintAssPosObj (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1670,7 +1670,7 @@ void            PrintAssPosObj (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintUnbPosObj (
+static void            PrintUnbPosObj (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -1692,7 +1692,7 @@ void            PrintUnbPosObj (
 **
 **  Linebreaks are preferred after the '['.
 */
-void            PrintElmPosObj (
+static void            PrintElmPosObj (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -1702,7 +1702,7 @@ void            PrintElmPosObj (
     Pr("%<]",0L,0L);
 }
 
-void            PrintIsbPosObj (
+static void            PrintIsbPosObj (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -1722,7 +1722,7 @@ void            PrintIsbPosObj (
 **  'ExecAssComObjName' executes the  record assignment statement <stat> of the
 **  form '<record>.<name> := <rhs>;'.
 */
-UInt            ExecAssComObjName (
+static UInt            ExecAssComObjName (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1753,7 +1753,7 @@ UInt            ExecAssComObjName (
 **  'ExecAssComObjExpr' executes the record assignment  statement <stat> of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-UInt            ExecAssComObjExpr (
+static UInt            ExecAssComObjExpr (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1784,7 +1784,7 @@ UInt            ExecAssComObjExpr (
 **  'ExecUnbComObjName' executes the record unbind statement <stat> of the form
 **  'Unbind( <record>.<name> );'.
 */
-UInt            ExecUnbComObjName (
+static UInt            ExecUnbComObjName (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1811,7 +1811,7 @@ UInt            ExecUnbComObjName (
 **  'ExecUnbComObjExpr' executes the record unbind statement <stat> of the form
 **  'Unbind( <record>.(<name>) );'.
 */
-UInt            ExecUnbComObjExpr (
+static UInt            ExecUnbComObjExpr (
     Stat                stat )
 {
     Obj                 record;         /* record, left operand            */
@@ -1838,7 +1838,7 @@ UInt            ExecUnbComObjExpr (
 **  'EvalElmComObjName' evaluates the  record element expression  <expr> of the
 **  form '<record>.<name>'.
 */
-Obj             EvalElmComObjName (
+static Obj             EvalElmComObjName (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -1866,7 +1866,7 @@ Obj             EvalElmComObjName (
 **  'EvalElmComObjExpr' evaluates the  record element expression  <expr> of the
 **  form '<record>.(<name>)'.
 */
-Obj             EvalElmComObjExpr (
+static Obj             EvalElmComObjExpr (
     Expr                expr )
 {
     Obj                 elm;            /* element, result                 */
@@ -1894,7 +1894,7 @@ Obj             EvalElmComObjExpr (
 **  'EvalIsbComObjName' evaluates  the record isbound  expression <expr> of the
 **  form 'IsBound( <record>.<name> )'.
 */
-Obj             EvalIsbComObjName (
+static Obj             EvalIsbComObjName (
     Expr                expr )
 {
     Obj                 isb;            /* element, result                 */
@@ -1922,7 +1922,7 @@ Obj             EvalIsbComObjName (
 **  'EvalIsbComObjExpr'  evaluates the record isbound  expression <expr> of the
 **  form 'IsBound( <record>.(<name>) )'.
 */
-Obj             EvalIsbComObjExpr (
+static Obj             EvalIsbComObjExpr (
     Expr                expr )
 {
     Obj                 isb;            /* element, result                 */
@@ -1950,7 +1950,7 @@ Obj             EvalIsbComObjExpr (
 **  'PrintAssComObjName' prints the  record assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-void            PrintAssComObjName (
+static void            PrintAssComObjName (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1963,7 +1963,7 @@ void            PrintAssComObjName (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintUnbComObjName (
+static void            PrintUnbComObjName (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -1983,7 +1983,7 @@ void            PrintUnbComObjName (
 **  'PrintAssComObjExpr' prints the  record assignment statement <stat>  of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-void            PrintAssComObjExpr (
+static void            PrintAssComObjExpr (
     Stat                stat )
 {
     Pr("%4>",0L,0L);
@@ -1996,7 +1996,7 @@ void            PrintAssComObjExpr (
     Pr("%2<;",0L,0L);
 }
 
-void            PrintUnbComObjExpr (
+static void            PrintUnbComObjExpr (
     Stat                stat )
 {
     Pr( "Unbind( ", 0L, 0L );
@@ -2016,7 +2016,7 @@ void            PrintUnbComObjExpr (
 **  'PrintElmComObjName' prints the  record  element expression <expr> of   the
 **  form '<record>.<name>'.
 */
-void            PrintElmComObjName (
+static void            PrintElmComObjName (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -2026,7 +2026,7 @@ void            PrintElmComObjName (
     Pr("%<",0L,0L);
 }
 
-void            PrintIsbComObjName (
+static void            PrintIsbComObjName (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -2046,7 +2046,7 @@ void            PrintIsbComObjName (
 **  'PrintElmComObjExpr' prints the record   element expression <expr>  of  the
 **  form '<record>.(<name>)'.
 */
-void            PrintElmComObjExpr (
+static void            PrintElmComObjExpr (
     Expr                expr )
 {
     Pr("%2>",0L,0L);
@@ -2056,7 +2056,7 @@ void            PrintElmComObjExpr (
     Pr(")%<",0L,0L);
 }
 
-void            PrintIsbComObjExpr (
+static void            PrintIsbComObjExpr (
     Expr                expr )
 {
     Pr( "IsBound( ", 0L, 0L );
@@ -2082,19 +2082,19 @@ void            PrintIsbComObjExpr (
 */
 
 
-Obj FuncGetCurrentLVars( Obj self )
+static Obj FuncGetCurrentLVars( Obj self )
 {
   // Need to promote to High Vars, else bag will be freed when function exits
   MakeHighVars(STATE(CurrLVars));
   return STATE(CurrLVars);
 }
 
-Obj FuncGetBottomLVars( Obj self )
+static Obj FuncGetBottomLVars( Obj self )
 {
   return STATE(BottomLVars);
 }
 
-Obj FuncParentLVars( Obj self, Obj lvars )
+static Obj FuncParentLVars( Obj self, Obj lvars )
 {
   if (!IS_LVARS_OR_HVARS(lvars)) {
       RequireArgument("ParentLVars", lvars, "must be an lvars");
@@ -2103,7 +2103,7 @@ Obj FuncParentLVars( Obj self, Obj lvars )
   return parent ? parent : Fail;
 }
 
-Obj FuncContentsLVars (Obj self, Obj lvars )
+static Obj FuncContentsLVars (Obj self, Obj lvars )
 {
   Obj contents = NEW_PREC(0);
   Obj func = FUNC_LVARS(lvars);
@@ -2131,13 +2131,13 @@ Obj FuncContentsLVars (Obj self, Obj lvars )
 */
 #ifdef USE_GASMAN
 
-void VarsBeforeCollectBags ( void )
+static void VarsBeforeCollectBags ( void )
 {
   if (STATE(CurrLVars))
     CHANGED_BAG( STATE(CurrLVars) );
 }
 
-void VarsAfterCollectBags ( void )
+static void VarsAfterCollectBags ( void )
 {
   if (STATE(CurrLVars))
     {
@@ -2155,7 +2155,7 @@ void VarsAfterCollectBags ( void )
 **
 */
 
-void SaveLVars( Obj lvars )
+static void SaveLVars( Obj lvars )
 {
   UInt len,i;
   const Obj *ptr;
@@ -2174,7 +2174,7 @@ void SaveLVars( Obj lvars )
 **
 */
 
-void LoadLVars( Obj lvars )
+static void LoadLVars( Obj lvars )
 {
   UInt len,i;
   Obj *ptr;
@@ -2188,14 +2188,14 @@ void LoadLVars( Obj lvars )
     *ptr++ = LoadSubObj();
 }
 
-Obj TYPE_LVARS;
+static Obj TYPE_LVARS;
 
-Obj TypeLVars( Obj lvars )
+static Obj TypeLVars( Obj lvars )
 {
   return TYPE_LVARS;
 }
 
-void PrintLVars( Obj lvars )
+static void PrintLVars( Obj lvars )
 {
   Pr("<lvars bag>", 0,0);
 }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -84,11 +84,11 @@ static Obj FieldInfo8Bit;
 *F  TypeVec8Bit( <q>, <mut> ) . . .  . . .type of a  vector object
 **
 */
-Obj TYPES_VEC8BIT;
-Obj TYPE_VEC8BIT;
-Obj TYPE_VEC8BIT_LOCKED;
+static Obj TYPES_VEC8BIT;
+static Obj TYPE_VEC8BIT;
+static Obj TYPE_VEC8BIT_LOCKED;
 
-Obj TypeVec8Bit(UInt q, UInt mut)
+static Obj TypeVec8Bit(UInt q, UInt mut)
 {
     UInt col = mut ? 1 : 2;
     Obj  type;
@@ -103,7 +103,7 @@ Obj TypeVec8Bit(UInt q, UInt mut)
         return type;
 }
 
-Obj TypeVec8BitLocked(UInt q, UInt mut)
+static Obj TypeVec8BitLocked(UInt q, UInt mut)
 {
     UInt col = mut ? 3 : 4;
     Obj  type;
@@ -124,10 +124,10 @@ Obj TypeVec8BitLocked(UInt q, UInt mut)
 *F  TypeMat8Bit( <q>, <mut> ) . . .  . . .type of a  matrix object
 **
 */
-Obj TYPES_MAT8BIT;
-Obj TYPE_MAT8BIT;
+static Obj TYPES_MAT8BIT;
+static Obj TYPE_MAT8BIT;
 
-Obj TypeMat8Bit(UInt q, UInt mut)
+static Obj TypeMat8Bit(UInt q, UInt mut)
 {
     UInt col = mut ? 1 : 2;
     Obj  type;
@@ -151,7 +151,7 @@ Obj TypeMat8Bit(UInt q, UInt mut)
 **
 */
 
-Obj TYPE_FIELDINFO_8BIT;
+static Obj TYPE_FIELDINFO_8BIT;
 
 
 #define SIZE_VEC8BIT(len, elts)                                              \
@@ -257,7 +257,7 @@ static const UInt1 * Char2Lookup[9] = {
 };
 
 
-void MakeFieldInfo8Bit(UInt q)
+static void MakeFieldInfo8Bit(UInt q)
 {
     FF   gfq;           // the field
     UInt p;             // characteristic
@@ -529,7 +529,7 @@ Obj GetFieldInfo8Bit(UInt q)
 
 static Obj IsLockedRepresentationVector;
 
-void RewriteVec8Bit(Obj vec, UInt q)
+static void RewriteVec8Bit(Obj vec, UInt q)
 {
     UInt q1 = FIELD_VEC8BIT(vec);
     Obj  info, info1;
@@ -682,7 +682,7 @@ void RewriteGF2Vec(Obj vec, UInt q)
 *F  ConvVec8Bit( <list>, <q> )  . . .  convert a list into 8bit vector object
 */
 
-void ConvVec8Bit(Obj list, UInt q)
+static void ConvVec8Bit(Obj list, UInt q)
 {
     Int     len;          // logical length of the vector
     Int     i;            // loop variable
@@ -797,7 +797,7 @@ void ConvVec8Bit(Obj list, UInt q)
 **
 */
 
-UInt LcmDegree(UInt d, UInt d1)
+static UInt LcmDegree(UInt d, UInt d1)
 {
     UInt x, y, g;
     x = d;
@@ -819,7 +819,7 @@ UInt LcmDegree(UInt d, UInt d1)
 **
 *F  FuncCONV_VEC8BIT( <self>, <list> ) . . . . . convert into 8bit vector rep
 */
-Obj FuncCONV_VEC8BIT(Obj self, Obj list, Obj q)
+static Obj FuncCONV_VEC8BIT(Obj self, Obj list, Obj q)
 {
     UInt iq = GetPositiveSmallInt("CONV_VEC8BIT", q);
     ConvVec8Bit(list, iq);
@@ -833,7 +833,7 @@ Obj FuncCONV_VEC8BIT(Obj self, Obj list, Obj q)
 **  This is a non-destructive counterpart of ConvVec8Bit
 */
 
-Obj NewVec8Bit(Obj list, UInt q)
+static Obj NewVec8Bit(Obj list, UInt q)
 {
     Int  len;           // logical length of the vector
     Int  i;             // loop variable
@@ -940,7 +940,7 @@ Obj NewVec8Bit(Obj list, UInt q)
 **
 **  This is a non-destructive counterpart of FuncCOPY_GF2VEC
 */
-Obj FuncCOPY_VEC8BIT(Obj self, Obj list, Obj q)
+static Obj FuncCOPY_VEC8BIT(Obj self, Obj list, Obj q)
 {
     UInt iq = GetPositiveSmallInt("COPY_VEC8BIT", q);
     return NewVec8Bit(list, iq);
@@ -1023,7 +1023,7 @@ void PlainVec8Bit(Obj list)
 **
 *F  FuncPLAIN_VEC8BIT( <self>, <list> ) . . . .  convert back into plain list
 */
-Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
+static Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
 {
     // check whether <list> is an 8bit vector
     while (!IS_VEC8BIT_REP(list)) {
@@ -1100,7 +1100,7 @@ Obj CopyVec8Bit(Obj list, UInt mut)
 **
 */
 
-void AddVec8BitVec8BitInner(Obj sum, Obj vl, Obj vr, UInt start, UInt stop)
+static void AddVec8BitVec8BitInner(Obj sum, Obj vl, Obj vr, UInt start, UInt stop)
 {
     Obj  info;
     UInt p;
@@ -1194,7 +1194,7 @@ void AddVec8BitVec8BitInner(Obj sum, Obj vl, Obj vr, UInt start, UInt stop)
 **  (mutable if either argument is).
 */
 
-Obj SumVec8BitVec8Bit(Obj vl, Obj vr)
+static Obj SumVec8BitVec8Bit(Obj vl, Obj vr)
 {
     Obj  sum;
     Obj  info;
@@ -1230,7 +1230,7 @@ Obj SumVec8BitVec8Bit(Obj vl, Obj vr)
 static Obj ConvertToVectorRep;    // BH: changed to static
 
 
-Obj FuncSUM_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
+static Obj FuncSUM_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     Obj sum;
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr)) {
@@ -1295,7 +1295,7 @@ Obj FuncSUM_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 **
 */
 
-void MultVec8BitFFEInner(Obj prod, Obj vec, Obj scal, UInt start, UInt stop)
+static void MultVec8BitFFEInner(Obj prod, Obj vec, Obj scal, UInt start, UInt stop)
 {
     Obj           info;
     UInt          elts;
@@ -1337,7 +1337,7 @@ void MultVec8BitFFEInner(Obj prod, Obj vec, Obj scal, UInt start, UInt stop)
 **
 */
 
-Obj MultVec8BitFFE(Obj vec, Obj scal)
+static Obj MultVec8BitFFE(Obj vec, Obj scal)
 {
     Obj  prod;
     Obj  info;
@@ -1403,7 +1403,7 @@ Obj ZeroVec8Bit(UInt q, UInt len, UInt mut)
 **
 */
 
-Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
+static Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
 {
     Obj  prod;
     Obj  info;
@@ -1439,7 +1439,7 @@ Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
 **
 */
 
-Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
+static Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 {
     return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec), 1);
 }
@@ -1450,7 +1450,7 @@ Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 **
 */
 
-Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
+static Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
 {
     UInt iq = GetPositiveSmallInt("ZERO_VEC8BIT_2", q);
     RequireNonnegativeSmallInt("ZERO_VEC8BIT_2", len);
@@ -1468,7 +1468,7 @@ Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
 ** Here we can fall back on the method above.
 */
 
-Obj FuncPROD_FFE_VEC8BIT(Obj self, Obj ffe, Obj vec)
+static Obj FuncPROD_FFE_VEC8BIT(Obj self, Obj ffe, Obj vec)
 {
     return FuncPROD_VEC8BIT_FFE(self, vec, ffe);
 }
@@ -1480,7 +1480,7 @@ Obj FuncPROD_FFE_VEC8BIT(Obj self, Obj ffe, Obj vec)
 ** GAP Callable methods for unary -
 */
 
-Obj AInvVec8Bit(Obj vec, UInt mut)
+static Obj AInvVec8Bit(Obj vec, UInt mut)
 {
     Obj  info;
     UInt p;
@@ -1504,17 +1504,17 @@ Obj AInvVec8Bit(Obj vec, UInt mut)
     return neg;
 }
 
-Obj FuncAINV_VEC8BIT_MUTABLE(Obj self, Obj vec)
+static Obj FuncAINV_VEC8BIT_MUTABLE(Obj self, Obj vec)
 {
     return AInvVec8Bit(vec, 1);
 }
 
-Obj FuncAINV_VEC8BIT_SAME_MUTABILITY(Obj self, Obj vec)
+static Obj FuncAINV_VEC8BIT_SAME_MUTABILITY(Obj self, Obj vec)
 {
     return AInvVec8Bit(vec, IS_MUTABLE_OBJ(vec));
 }
 
-Obj FuncAINV_VEC8BIT_IMMUTABLE(Obj self, Obj vec)
+static Obj FuncAINV_VEC8BIT_IMMUTABLE(Obj self, Obj vec)
 {
     return AInvVec8Bit(vec, 0);
 }
@@ -1537,7 +1537,7 @@ Obj FuncAINV_VEC8BIT_IMMUTABLE(Obj self, Obj vec)
 **
 */
 
-void AddVec8BitVec8BitMultInner(
+static void AddVec8BitVec8BitMultInner(
     Obj sum, Obj vl, Obj vr, Obj mult, UInt start, UInt stop)
 {
     Obj     info;
@@ -1620,7 +1620,7 @@ void AddVec8BitVec8BitMultInner(
 **  In-place scalar multiply
 */
 
-Obj FuncMULT_VECTOR_VEC8BITS(Obj self, Obj vec, Obj mul)
+static Obj FuncMULT_VECTOR_VEC8BITS(Obj self, Obj vec, Obj mul)
 {
     UInt q;
     q = FIELD_VEC8BIT(vec);
@@ -1655,9 +1655,9 @@ Obj FuncMULT_VECTOR_VEC8BITS(Obj self, Obj vec, Obj mul)
 **
 */
 
-Obj AddRowVector;
+static Obj AddRowVector;
 
-Obj FuncADD_ROWVECTOR_VEC8BITS_5(
+static Obj FuncADD_ROWVECTOR_VEC8BITS_5(
     Obj self, Obj vl, Obj vr, Obj mul, Obj from, Obj to)
 {
     UInt q;
@@ -1738,7 +1738,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_5(
 **
 */
 
-Obj FuncADD_ROWVECTOR_VEC8BITS_3(Obj self, Obj vl, Obj vr, Obj mul)
+static Obj FuncADD_ROWVECTOR_VEC8BITS_3(Obj self, Obj vl, Obj vr, Obj mul)
 {
     UInt q;
     if (LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr)) {
@@ -1800,7 +1800,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_3(Obj self, Obj vl, Obj vr, Obj mul)
 **
 */
 
-Obj FuncADD_ROWVECTOR_VEC8BITS_2(Obj self, Obj vl, Obj vr)
+static Obj FuncADD_ROWVECTOR_VEC8BITS_2(Obj self, Obj vl, Obj vr)
 {
     UInt q;
     if (LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr)) {
@@ -1858,7 +1858,7 @@ Obj FuncADD_ROWVECTOR_VEC8BITS_2(Obj self, Obj vl, Obj vr)
 **  (mutable if either argument is).
 */
 
-Obj SumVec8BitVec8BitMult(Obj vl, Obj vr, Obj mult)
+static Obj SumVec8BitVec8BitMult(Obj vl, Obj vr, Obj mult)
 {
     Obj  sum;
     Obj  info;
@@ -1895,7 +1895,7 @@ Obj SumVec8BitVec8BitMult(Obj vl, Obj vr, Obj mult)
 **
 */
 
-Obj DiffVec8BitVec8Bit(Obj vl, Obj vr)
+static Obj DiffVec8BitVec8Bit(Obj vl, Obj vr)
 {
     Obj info;
     FF  f;
@@ -1935,7 +1935,7 @@ Obj DiffVec8BitVec8Bit(Obj vl, Obj vr)
 **
 **  GAP callable method for binary -
 */
-Obj FuncDIFF_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
+static Obj FuncDIFF_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     Obj diff;
     // UInt p;
@@ -1981,7 +1981,7 @@ Obj FuncDIFF_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 **  deal with length variations
 */
 
-Int CmpVec8BitVec8Bit(Obj vl, Obj vr)
+static Int CmpVec8BitVec8Bit(Obj vl, Obj vr)
 {
     Obj           info;
     UInt          q;
@@ -2065,7 +2065,7 @@ Int CmpVec8BitVec8Bit(Obj vl, Obj vr)
 **
 */
 
-Obj ScalarProductVec8Bits(Obj vl, Obj vr)
+static Obj ScalarProductVec8Bits(Obj vl, Obj vr)
 {
     Obj           info;
     UInt1         acc;
@@ -2112,7 +2112,7 @@ Obj ScalarProductVec8Bits(Obj vl, Obj vr)
 *F  FuncPROD_VEC8BIT_VEC8BIT( <self>, <vl>, <vr> )
 */
 
-Obj FuncPROD_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
+static Obj FuncPROD_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return ProdListList(vl, vr);
@@ -2128,7 +2128,7 @@ Obj FuncPROD_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 **
 */
 
-UInt DistanceVec8Bits(Obj vl, Obj vr)
+static UInt DistanceVec8Bits(Obj vl, Obj vr)
 {
     Obj           info;
     const UInt1 * ptrL;
@@ -2172,7 +2172,7 @@ UInt DistanceVec8Bits(Obj vl, Obj vr)
 *F  FuncDISTANCE_VEC8BIT_VEC8BIT( <self>, <vl>, <vr> )
 */
 
-Obj FuncDISTANCE_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
+static Obj FuncDISTANCE_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr) ||
         LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr))
@@ -2187,7 +2187,7 @@ Obj FuncDISTANCE_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 *F  DistDistrib8Bits( <veclis>, <ovec>, <d>, <osum>, <pos>, <l>, <m>)
 **
 */
-void DistDistrib8Bits(
+static void DistDistrib8Bits(
     Obj  veclis,    // pointers to matrix vectors and their multiples
     Obj  vec,       // vector we compute distance to
     Obj  d,         // distances list
@@ -2232,7 +2232,7 @@ void DistDistrib8Bits(
     TakeInterrupt();
 }
 
-Obj FuncDISTANCE_DISTRIB_VEC8BITS(
+static Obj FuncDISTANCE_DISTRIB_VEC8BITS(
     Obj self,
     Obj veclis,    // pointers to matrix vectors and their multiples
     Obj vec,       // vector we compute distance to
@@ -2259,7 +2259,7 @@ Obj FuncDISTANCE_DISTRIB_VEC8BITS(
 *F
 */
 
-void OverwriteVec8Bit(Obj dst, Obj src)
+static void OverwriteVec8Bit(Obj dst, Obj src)
 {
     const UInt1 * ptrS;
     UInt1 *       ptrD;
@@ -2272,7 +2272,7 @@ void OverwriteVec8Bit(Obj dst, Obj src)
         *ptrD++ = *ptrS++;
 }
 
-UInt AClosVec8Bit(
+static UInt AClosVec8Bit(
     Obj  veclis,    // pointers to matrix vectors and their multiples
     Obj  vec,       // vector we compute distance to
     Obj  sum,       // position of the sum vector
@@ -2347,7 +2347,7 @@ UInt AClosVec8Bit(
 *F
 */
 
-Obj FuncA_CLOSEST_VEC8BIT(
+static Obj FuncA_CLOSEST_VEC8BIT(
     Obj self,
     Obj veclis,    // pointers to matrix vectors and their multiples
     Obj vec,       // vector we compute distance to
@@ -2386,7 +2386,7 @@ Obj FuncA_CLOSEST_VEC8BIT(
 *F
 */
 
-Obj FuncA_CLOSEST_VEC8BIT_COORDS(
+static Obj FuncA_CLOSEST_VEC8BIT_COORDS(
     Obj self,
     Obj veclis,    // pointers to matrix vectors and their multiples
     Obj vec,       // vector we compute distance to
@@ -2444,7 +2444,7 @@ Obj FuncA_CLOSEST_VEC8BIT_COORDS(
 **
 */
 
-Obj FuncNUMBER_VEC8BIT(Obj self, Obj vec)
+static Obj FuncNUMBER_VEC8BIT(Obj self, Obj vec)
 {
     Obj           info;
     UInt          elts;
@@ -2493,7 +2493,7 @@ Obj FuncNUMBER_VEC8BIT(Obj self, Obj vec)
 ** Search for new coset leaders of weight <weight>
 */
 
-UInt CosetLeadersInner8Bits(Obj  veclis,
+static UInt CosetLeadersInner8Bits(Obj  veclis,
                             Obj  v,
                             Obj  w,
                             UInt weight,
@@ -2617,7 +2617,7 @@ UInt CosetLeadersInner8Bits(Obj  veclis,
 }
 
 
-Obj FuncCOSET_LEADERS_INNER_8BITS(
+static Obj FuncCOSET_LEADERS_INNER_8BITS(
     Obj self, Obj veclis, Obj weight, Obj tofind, Obj leaders, Obj felts)
 {
     Obj  v, w;
@@ -2643,7 +2643,7 @@ Obj FuncCOSET_LEADERS_INNER_8BITS(
 **
 */
 
-Obj FuncEQ_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
+static Obj FuncEQ_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return EqListList(vl, vr) ? True : False;
@@ -2660,7 +2660,7 @@ Obj FuncEQ_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 **
 */
 
-Obj FuncLT_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
+static Obj FuncLT_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return LtListList(vl, vr) ? True : False;
@@ -2680,7 +2680,7 @@ Obj FuncLT_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 */
 
 
-Obj FuncSHALLOWCOPY_VEC8BIT(Obj self, Obj list)
+static Obj FuncSHALLOWCOPY_VEC8BIT(Obj self, Obj list)
 {
     return CopyVec8Bit(list, 1);
 }
@@ -2690,7 +2690,7 @@ Obj FuncSHALLOWCOPY_VEC8BIT(Obj self, Obj list)
 **
 *F  FuncLEN_VEC8BIT( <self>, <list> )  . . . . . . . .  length of a vector
 */
-Obj FuncLEN_VEC8BIT(Obj self, Obj list)
+static Obj FuncLEN_VEC8BIT(Obj self, Obj list)
 {
     return INTOBJ_INT(LEN_VEC8BIT(list));
 }
@@ -2699,7 +2699,7 @@ Obj FuncLEN_VEC8BIT(Obj self, Obj list)
 **
 *F  FuncQ_VEC8BIT( <self>, <list> )  . . . . . . . .  length of a vector
 */
-Obj FuncQ_VEC8BIT(Obj self, Obj list)
+static Obj FuncQ_VEC8BIT(Obj self, Obj list)
 {
     return INTOBJ_INT(FIELD_VEC8BIT(list));
 }
@@ -2715,7 +2715,7 @@ Obj FuncQ_VEC8BIT(Obj self, Obj list)
 **  integer.
 */
 
-Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
+static Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
 {
     UInt p;
     Obj  info;
@@ -2743,7 +2743,7 @@ Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
 **  vector <list>. An error is signalled if <pos> is not bound. It is the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
-Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
+static Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
 {
     UInt p;
     Obj  info;
@@ -2770,7 +2770,7 @@ Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
 **
 **  The results are returned in the compressed format
 */
-Obj FuncELMS_VEC8BIT(Obj self, Obj list, Obj poss)
+static Obj FuncELMS_VEC8BIT(Obj self, Obj list, Obj poss)
 {
     UInt          p;
     Obj           pos;
@@ -2840,7 +2840,7 @@ Obj FuncELMS_VEC8BIT(Obj self, Obj list, Obj poss)
 **
 **  The results are returned in the compressed format
 */
-Obj FuncELMS_VEC8BIT_RANGE(Obj self, Obj list, Obj range)
+static Obj FuncELMS_VEC8BIT_RANGE(Obj self, Obj list, Obj range)
 {
     UInt          p;
     Obj           info;
@@ -3033,7 +3033,7 @@ void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
     AssPlistFfe(list, p, elm);
 }
 
-Obj FuncASS_VEC8BIT(Obj self, Obj list, Obj pos, Obj elm)
+static Obj FuncASS_VEC8BIT(Obj self, Obj list, Obj pos, Obj elm)
 {
     ASS_VEC8BIT(list, pos, elm);
     return 0;
@@ -3049,7 +3049,7 @@ Obj FuncASS_VEC8BIT(Obj self, Obj list, Obj pos, Obj elm)
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
 */
-Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
+static Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
 {
     UInt p;
     Obj  info;
@@ -3102,7 +3102,7 @@ Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
 **
 */
 
-UInt PositionNonZeroVec8Bit(Obj list, UInt from)
+static UInt PositionNonZeroVec8Bit(Obj list, UInt from)
 {
     Obj           info;
     UInt          len;
@@ -3146,12 +3146,12 @@ UInt PositionNonZeroVec8Bit(Obj list, UInt from)
 }
 
 
-Obj FuncPOSITION_NONZERO_VEC8BIT(Obj self, Obj list, Obj zero)
+static Obj FuncPOSITION_NONZERO_VEC8BIT(Obj self, Obj list, Obj zero)
 {
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, 0));
 }
 
-Obj FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
+static Obj FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
 {
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, INT_INTOBJ(from)));
 }
@@ -3162,7 +3162,7 @@ Obj FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
 **
 **
 */
-Obj FuncAPPEND_VEC8BIT(Obj self, Obj vecl, Obj vecr)
+static Obj FuncAPPEND_VEC8BIT(Obj self, Obj vecl, Obj vecr)
 {
     Obj           info;
     UInt          lenl, lenr;
@@ -3236,7 +3236,7 @@ Obj FuncAPPEND_VEC8BIT(Obj self, Obj vecl, Obj vecr)
 **  know that <vec> and <mat> are non-empty
 ** */
 
-Obj FuncPROD_VEC8BIT_MATRIX(Obj self, Obj vec, Obj mat)
+static Obj FuncPROD_VEC8BIT_MATRIX(Obj self, Obj vec, Obj mat)
 {
     Obj         res;
     Obj         info;
@@ -3321,7 +3321,7 @@ static inline void SET_ELM_MAT8BIT(Obj mat, Int i, Obj row)
 *F  PlainMat8Bit( <mat> )
 **
 */
-void PlainMat8Bit(Obj mat)
+static void PlainMat8Bit(Obj mat)
 {
     UInt i, l;
     Obj  row;
@@ -3341,7 +3341,7 @@ void PlainMat8Bit(Obj mat)
 **
 */
 
-Obj FuncPLAIN_MAT8BIT(Obj self, Obj mat)
+static Obj FuncPLAIN_MAT8BIT(Obj self, Obj mat)
 {
     PlainMat8Bit(mat);
     return 0;
@@ -3356,7 +3356,7 @@ Obj FuncPLAIN_MAT8BIT(Obj self, Obj mat)
 ** 8 bit vectors, written over the correct field
 */
 
-Obj FuncCONV_MAT8BIT(Obj self, Obj list, Obj q)
+static Obj FuncCONV_MAT8BIT(Obj self, Obj list, Obj q)
 {
     UInt len, i, mut;
     Obj  tmp;
@@ -3389,7 +3389,7 @@ Obj FuncCONV_MAT8BIT(Obj self, Obj list, Obj q)
 ** The caller must ensure that <vec> and <mat> are compatible
 */
 
-Obj ProdVec8BitMat8Bit(Obj vec, Obj mat)
+static Obj ProdVec8BitMat8Bit(Obj vec, Obj mat)
 {
     UInt          q, len, len1, lenm, elts;
     UInt          i, j;
@@ -3457,7 +3457,7 @@ Obj ProdVec8BitMat8Bit(Obj vec, Obj mat)
 **  fields and lengths.
 */
 
-Obj FuncPROD_VEC8BIT_MAT8BIT(Obj self, Obj vec, Obj mat)
+static Obj FuncPROD_VEC8BIT_MAT8BIT(Obj self, Obj vec, Obj mat)
 {
     UInt q, q1, q2;
 
@@ -3490,7 +3490,7 @@ Obj FuncPROD_VEC8BIT_MAT8BIT(Obj self, Obj vec, Obj mat)
 ** The caller must ensure compatibility
 */
 
-Obj ProdMat8BitVec8Bit(Obj mat, Obj vec)
+static Obj ProdMat8BitVec8Bit(Obj mat, Obj vec)
 {
     UInt    len, i, q;
     Obj     info;
@@ -3536,7 +3536,7 @@ Obj ProdMat8BitVec8Bit(Obj mat, Obj vec)
 **  fields and lengths.
 */
 
-Obj FuncPROD_MAT8BIT_VEC8BIT(Obj self, Obj mat, Obj vec)
+static Obj FuncPROD_MAT8BIT_VEC8BIT(Obj self, Obj mat, Obj vec)
 {
     UInt q, q1, q2;
     Obj  row;
@@ -3573,7 +3573,7 @@ Obj FuncPROD_MAT8BIT_VEC8BIT(Obj self, Obj mat, Obj vec)
 **  Caller must check matrix sizes and field
 */
 
-Obj ProdMat8BitMat8Bit(Obj matl, Obj matr)
+static Obj ProdMat8BitMat8Bit(Obj matl, Obj matr)
 {
     Obj  prod;
     UInt i;
@@ -3614,7 +3614,7 @@ Obj ProdMat8BitMat8Bit(Obj matl, Obj matr)
 **
 */
 
-Obj FuncPROD_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
+static Obj FuncPROD_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 {
     UInt ql, qr;
     Obj  rowl;
@@ -3639,7 +3639,7 @@ Obj FuncPROD_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 **
 */
 
-Obj InverseMat8Bit(Obj mat, UInt mut)
+static Obj InverseMat8Bit(Obj mat, UInt mut)
 {
     Obj         cmat, inv;
     UInt        len, off;
@@ -3790,7 +3790,7 @@ Obj InverseMat8Bit(Obj mat, UInt mut)
 **
 */
 
-Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
+static Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         mat = ErrorReturnObj(
@@ -3809,7 +3809,7 @@ Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
 **
 */
 
-Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
+static Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         mat = ErrorReturnObj(
@@ -3828,7 +3828,7 @@ Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
 **
 */
 
-Obj FuncINV_MAT8BIT_IMMUTABLE(Obj self, Obj mat)
+static Obj FuncINV_MAT8BIT_IMMUTABLE(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         Obj inv;
@@ -3850,7 +3850,7 @@ Obj FuncINV_MAT8BIT_IMMUTABLE(Obj self, Obj mat)
 **
 */
 
-Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj pos, Obj obj)
+static Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj pos, Obj obj)
 {
     UInt len;
     UInt len1;
@@ -3951,7 +3951,7 @@ cantdo:
 *F  FuncELM_MAT8BIT( <self>, <mat>, <pos> ) .  select a row of an 8bit matrix
 **
 */
-Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj pos)
+static Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj pos)
 {
     UInt r = GetPositiveSmallInt("ELM_MAT8BIT", pos);
     if (LEN_MAT8BIT(mat) < r) {
@@ -3969,7 +3969,7 @@ Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj pos)
 **  Caller's job to do all checks
 */
 
-Obj SumMat8BitMat8Bit(Obj ml, Obj mr)
+static Obj SumMat8BitMat8Bit(Obj ml, Obj mr)
 {
     Obj  sum;
     UInt ll, lr, wl, wr, ls;
@@ -4027,7 +4027,7 @@ Obj SumMat8BitMat8Bit(Obj ml, Obj mr)
 **  Caller should check that both args are mat8bit over the same field
 */
 
-Obj FuncSUM_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
+static Obj FuncSUM_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     UInt q;
     q = FIELD_VEC8BIT(ELM_MAT8BIT(ml, 1));
@@ -4044,7 +4044,7 @@ Obj FuncSUM_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 **  Caller's job to do all checks
 */
 
-Obj DiffMat8BitMat8Bit(Obj ml, Obj mr)
+static Obj DiffMat8BitMat8Bit(Obj ml, Obj mr)
 {
     Obj  diff;
     UInt q;
@@ -4114,7 +4114,7 @@ Obj DiffMat8BitMat8Bit(Obj ml, Obj mr)
 **  Caller should check that both args are mat8bit over the same field
 */
 
-Obj FuncDIFF_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
+static Obj FuncDIFF_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     UInt q;
 
@@ -4133,7 +4133,7 @@ Obj FuncDIFF_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 ** The first batch are utilities for the others
 */
 
-UInt RightMostNonZeroVec8Bit(Obj vec)
+static UInt RightMostNonZeroVec8Bit(Obj vec)
 {
     UInt         q;
     UInt         len;
@@ -4178,7 +4178,7 @@ UInt RightMostNonZeroVec8Bit(Obj vec)
     Panic("this should never happen");
 }
 
-void ResizeVec8Bit(Obj vec, UInt newlen, UInt knownclean)
+static void ResizeVec8Bit(Obj vec, UInt newlen, UInt knownclean)
 {
     UInt    q;
     UInt    len;
@@ -4236,7 +4236,7 @@ void ResizeVec8Bit(Obj vec, UInt newlen, UInt knownclean)
 }
 
 
-void ShiftLeftVec8Bit(Obj vec, UInt amount)
+static void ShiftLeftVec8Bit(Obj vec, UInt amount)
 {
     UInt   q;
     Obj    info;
@@ -4299,7 +4299,7 @@ void ShiftLeftVec8Bit(Obj vec, UInt amount)
     ResizeVec8Bit(vec, len - amount, 0);
 }
 
-void ShiftRightVec8Bit(Obj vec, UInt amount)    // pads with zeros
+static void ShiftRightVec8Bit(Obj vec, UInt amount)    // pads with zeros
 {
     UInt   q;
     Obj    info;
@@ -4371,7 +4371,7 @@ void ShiftRightVec8Bit(Obj vec, UInt amount)    // pads with zeros
 ** result.
 */
 
-Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
+static Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
 {
     UInt q;
     UInt len;
@@ -4435,7 +4435,7 @@ Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
 ** result.
 */
 
-Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
+static Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
 {
     UInt q;
     UInt len;
@@ -4489,7 +4489,7 @@ Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
 **
 */
 
-Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
+static Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 {
     // should be checked in method selection
     assert(IS_MUTABLE_OBJ(vec));
@@ -4509,7 +4509,7 @@ Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 **
 */
 
-Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
+static Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 {
     assert(IS_MUTABLE_OBJ(vec));
     while (!IS_INTOBJ(amount) || INT_INTOBJ(amount) < 0) {
@@ -4528,7 +4528,7 @@ Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 **
 */
 
-Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
+static Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
 {
     if (!IS_MUTABLE_OBJ(vec))
         ErrorReturnVoid("RESIZE_VEC8BIT: vector must be mutable", 0, 0,
@@ -4549,7 +4549,7 @@ Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
 **
 */
 
-Obj FuncRIGHTMOST_NONZERO_VEC8BIT(Obj self, Obj vec)
+static Obj FuncRIGHTMOST_NONZERO_VEC8BIT(Obj self, Obj vec)
 {
     return INTOBJ_INT(RightMostNonZeroVec8Bit(vec));
 }
@@ -4560,7 +4560,7 @@ Obj FuncRIGHTMOST_NONZERO_VEC8BIT(Obj self, Obj vec)
 **
 */
 
-void ProdCoeffsVec8Bit(Obj res, Obj vl, UInt ll, Obj vr, UInt lr)
+static void ProdCoeffsVec8Bit(Obj res, Obj vl, UInt ll, Obj vr, UInt lr)
 {
     UInt         q;
     Obj          info;
@@ -4728,7 +4728,7 @@ void ProdCoeffsVec8Bit(Obj res, Obj vl, UInt ll, Obj vr, UInt lr)
 **
 */
 
-Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
+static Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
 {
     Int  ll1, lr1;
     UInt q;
@@ -4798,7 +4798,7 @@ Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
 **
 */
 
-Obj MakeShiftedVecs(Obj v, UInt len)
+static Obj MakeShiftedVecs(Obj v, UInt len)
 {
     UInt        q;
     Obj         info;
@@ -4894,7 +4894,7 @@ Obj MakeShiftedVecs(Obj v, UInt len)
     return shifts;
 }
 
-void ReduceCoeffsVec8Bit(Obj vl, Obj vrshifted, Obj quot)
+static void ReduceCoeffsVec8Bit(Obj vl, Obj vrshifted, Obj quot)
 {
     UInt          q;
     Obj           info;
@@ -4971,7 +4971,7 @@ void ReduceCoeffsVec8Bit(Obj vl, Obj vrshifted, Obj quot)
 **  NB note that these are not methods and MAY NOT return TRY_NEXT_METHOD
 */
 
-Obj FuncMAKE_SHIFTED_COEFFS_VEC8BIT(Obj self, Obj vr, Obj lr)
+static Obj FuncMAKE_SHIFTED_COEFFS_VEC8BIT(Obj self, Obj vr, Obj lr)
 {
     if (!IS_INTOBJ(lr))
         ErrorQuit("ReduceCoeffs: Length of right argument must be a small "
@@ -4986,7 +4986,7 @@ Obj FuncMAKE_SHIFTED_COEFFS_VEC8BIT(Obj self, Obj vr, Obj lr)
 }
 
 
-Obj FuncREDUCE_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
+static Obj FuncREDUCE_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
 {
     UInt q;
     UInt last;
@@ -5009,7 +5009,7 @@ Obj FuncREDUCE_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
     return INTOBJ_INT(last);
 }
 
-Obj FuncQUOTREM_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
+static Obj FuncQUOTREM_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
 {
     UInt q;
     Obj  rem, quot, ret, info;
@@ -5065,7 +5065,7 @@ Obj FuncQUOTREM_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
 static UInt RNheads, RNvectors, RNcoeffs, RNrelns;
 
 
-Obj SemiEchelonListVec8Bits(Obj mat, UInt TransformationsNeeded)
+static Obj SemiEchelonListVec8Bits(Obj mat, UInt TransformationsNeeded)
 {
     UInt nrows, ncols;
     UInt i, j, h;
@@ -5214,7 +5214,7 @@ Obj SemiEchelonListVec8Bits(Obj mat, UInt TransformationsNeeded)
 **  returns the rank
 */
 
-UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
+static UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
 {
     UInt        nrows;
     UInt        ncols;
@@ -5313,7 +5313,7 @@ UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
 ** Method selection can guarantee us a plain list of vectors in same char
 */
 
-Obj FuncSEMIECHELON_LIST_VEC8BITS(Obj self, Obj mat)
+static Obj FuncSEMIECHELON_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
     Obj  row;
@@ -5349,7 +5349,7 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS(Obj self, Obj mat)
 **  characteristic
 */
 
-Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(Obj self, Obj mat)
+static Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(Obj self, Obj mat)
 {
     UInt i, len;
     Obj  row;
@@ -5387,7 +5387,7 @@ Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(Obj self, Obj mat)
 **  characteristic
 */
 
-Obj FuncTRIANGULIZE_LIST_VEC8BITS(Obj self, Obj mat)
+static Obj FuncTRIANGULIZE_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
     Obj  row;
@@ -5424,7 +5424,7 @@ Obj FuncTRIANGULIZE_LIST_VEC8BITS(Obj self, Obj mat)
 **  characteristic
 */
 
-Obj FuncRANK_LIST_VEC8BITS(Obj self, Obj mat)
+static Obj FuncRANK_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
     Obj  row;
@@ -5460,7 +5460,7 @@ Obj FuncRANK_LIST_VEC8BITS(Obj self, Obj mat)
 **  characteristic
 */
 
-Obj FuncDETERMINANT_LIST_VEC8BITS(Obj self, Obj mat)
+static Obj FuncDETERMINANT_LIST_VEC8BITS(Obj self, Obj mat)
 {
     UInt i, len, width;
     Obj  row;
@@ -5496,7 +5496,7 @@ Obj FuncDETERMINANT_LIST_VEC8BITS(Obj self, Obj mat)
 **  Assumes the matrices are over compatible fields
 */
 
-Int Cmp_MAT8BIT_MAT8BIT(Obj ml, Obj mr)
+static Int Cmp_MAT8BIT_MAT8BIT(Obj ml, Obj mr)
 {
     UInt l1, l2, l, i;
     Int  c;
@@ -5520,7 +5520,7 @@ Int Cmp_MAT8BIT_MAT8BIT(Obj ml, Obj mr)
 *F  FuncEQ_MAT8BIT_MAT8BIT( <ml>, <mr> )   compare matrices
 */
 
-Obj FuncEQ_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
+static Obj FuncEQ_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     if (LEN_MAT8BIT(ml) != LEN_MAT8BIT(mr))
         return False;
@@ -5537,7 +5537,7 @@ Obj FuncEQ_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 *F  FuncLT_MAT8BIT_MAT8BIT( <ml>, <mr> )   compare matrices
 */
 
-Obj FuncLT_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
+static Obj FuncLT_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
     if (LEN_MAT8BIT(ml) == 0)
         return (LEN_MAT8BIT(mr) != 0) ? True : False;
@@ -5555,7 +5555,7 @@ Obj FuncLT_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 *F  FuncTRANSPOSED_MAT8BIT( <self>, <mat>) Fully mutable results
 **
 */
-Obj FuncTRANSPOSED_MAT8BIT(Obj self, Obj mat)
+static Obj FuncTRANSPOSED_MAT8BIT(Obj self, Obj mat)
 {
     UInt    l, w;
     Obj     tra, row;
@@ -5663,7 +5663,7 @@ Obj FuncTRANSPOSED_MAT8BIT(Obj self, Obj mat)
 *F  FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT( <self>, <matl>, <matr>)
 **
 */
-Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
+static Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 {
     UInt nrowl, nrowr, ncoll, ncolr, ncol, p, q, i, j, k, l, s, zero, mutable,
         elts;
@@ -5767,7 +5767,7 @@ Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 *F  FuncMAT_ELM_MAT8BIT( <self>, <mat>, <row>, <col> )
 **
 */
-Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
+static Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
 {
     UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row);
     UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col);
@@ -5792,7 +5792,7 @@ Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
 *F  FuncSET_MAT_ELM_MAT8BIT( <self>, <mat>, <row>, <col>, <elm> )
 **
 */
-Obj FuncSET_MAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
+static Obj FuncSET_MAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
     UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row);
     UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col);

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1100,7 +1100,8 @@ Obj CopyVec8Bit(Obj list, UInt mut)
 **
 */
 
-static void AddVec8BitVec8BitInner(Obj sum, Obj vl, Obj vr, UInt start, UInt stop)
+static void
+AddVec8BitVec8BitInner(Obj sum, Obj vl, Obj vr, UInt start, UInt stop)
 {
     Obj  info;
     UInt p;
@@ -1295,7 +1296,8 @@ static Obj FuncSUM_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 **
 */
 
-static void MultVec8BitFFEInner(Obj prod, Obj vec, Obj scal, UInt start, UInt stop)
+static void
+MultVec8BitFFEInner(Obj prod, Obj vec, Obj scal, UInt start, UInt stop)
 {
     Obj           info;
     UInt          elts;
@@ -2272,18 +2274,18 @@ static void OverwriteVec8Bit(Obj dst, Obj src)
         *ptrD++ = *ptrS++;
 }
 
-static UInt AClosVec8Bit(
-    Obj  veclis,    // pointers to matrix vectors and their multiples
-    Obj  vec,       // vector we compute distance to
-    Obj  sum,       // position of the sum vector
-    UInt pos,       // recursion depth
-    UInt l,         // length of basis
-    UInt cnt,       // number of vectors used already
-    UInt stop,      // stop value
-    UInt bd,        // best distance so far
-    Obj  bv,        // best vector so far
-    Obj  coords,
-    Obj  bcoords)
+static UInt
+AClosVec8Bit(Obj  veclis,    // pointers to matrix vectors and their multiples
+             Obj  vec,       // vector we compute distance to
+             Obj  sum,       // position of the sum vector
+             UInt pos,       // recursion depth
+             UInt l,         // length of basis
+             UInt cnt,       // number of vectors used already
+             UInt stop,      // stop value
+             UInt bd,        // best distance so far
+             Obj  bv,        // best vector so far
+             Obj  coords,
+             Obj  bcoords)
 {
     UInt i, j;
     UInt di;
@@ -2494,13 +2496,13 @@ static Obj FuncNUMBER_VEC8BIT(Obj self, Obj vec)
 */
 
 static UInt CosetLeadersInner8Bits(Obj  veclis,
-                            Obj  v,
-                            Obj  w,
-                            UInt weight,
-                            UInt pos,
-                            Obj  leaders,
-                            UInt tofind,
-                            Obj  felts)
+                                   Obj  v,
+                                   Obj  w,
+                                   UInt weight,
+                                   UInt pos,
+                                   Obj  leaders,
+                                   UInt tofind,
+                                   Obj  felts)
 {
     UInt    found = 0;
     UInt    len = LEN_VEC8BIT(v);
@@ -3151,7 +3153,8 @@ static Obj FuncPOSITION_NONZERO_VEC8BIT(Obj self, Obj list, Obj zero)
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, 0));
 }
 
-static Obj FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
+static Obj
+FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
 {
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, INT_INTOBJ(from)));
 }
@@ -5792,7 +5795,8 @@ static Obj FuncMAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col)
 *F  FuncSET_MAT_ELM_MAT8BIT( <self>, <mat>, <row>, <col>, <elm> )
 **
 */
-static Obj FuncSET_MAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
+static Obj
+FuncSET_MAT_ELM_MAT8BIT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
     UInt r = GetPositiveSmallInt("MAT_ELM_MAT8BIT", row);
     UInt c = GetPositiveSmallInt("MAT_ELM_MAT8BIT", col);

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -70,9 +70,7 @@ static Int IsVecFFE(Obj obj)
 **  'SumFFEVecFFE' is an improved version  of  'SumSclList', which  does  not
 **  call 'SUM'.
 */
-static Obj             SumFFEVecFFE (
-    Obj                 elmL,
-    Obj                 vecR )
+static Obj SumFFEVecFFE(Obj elmL, Obj vecR)
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
@@ -132,9 +130,7 @@ static Obj             SumFFEVecFFE (
 **  'SumVecFFEFFE' is an improved version  of  'SumListScl', which  does  not
 **  call 'SUM'.
 */
-static Obj             SumVecFFEFFE (
-    Obj                 vecL,
-    Obj                 elmR )
+static Obj SumVecFFEFFE(Obj vecL, Obj elmR)
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
@@ -193,9 +189,7 @@ static Obj             SumVecFFEFFE (
 **  'SumVecFFEVecFFE' is an improved version of 'SumListList', which does not
 **  call 'SUM'.
 */
-static Obj             SumVecFFEVecFFE (
-    Obj                 vecL,
-    Obj                 vecR )
+static Obj SumVecFFEVecFFE(Obj vecL, Obj vecR)
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
@@ -275,9 +269,7 @@ static Obj             SumVecFFEVecFFE (
 **  'DiffFFEVecFFE'  is an improved  version of 'DiffSclList', which does not
 **  call 'DIFF'.
 */
-static Obj             DiffFFEVecFFE (
-    Obj                 elmL,
-    Obj                 vecR )
+static Obj DiffFFEVecFFE(Obj elmL, Obj vecR)
 {
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
@@ -338,9 +330,7 @@ static Obj             DiffFFEVecFFE (
 **  'DiffVecFFEFFE' is an improved  version of 'DiffListScl', which  does not
 **  call 'DIFF'.
 */
-static Obj             DiffVecFFEFFE (
-    Obj                 vecL,
-    Obj                 elmR )
+static Obj DiffVecFFEFFE(Obj vecL, Obj elmR)
 {
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
@@ -401,9 +391,7 @@ static Obj             DiffVecFFEFFE (
 **  'DiffVecFFEVecFFE' is an improved  version of  'DiffListList', which does
 **  not call 'DIFF'.
 */
-static Obj             DiffVecFFEVecFFE (
-    Obj                 vecL,
-    Obj                 vecR )
+static Obj DiffVecFFEVecFFE(Obj vecL, Obj vecR)
 {
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
@@ -488,9 +476,7 @@ static Obj             DiffVecFFEVecFFE (
 **  'ProdFFEVecFFE'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD'.
 */
-static Obj             ProdFFEVecFFE (
-    Obj                 elmL,
-    Obj                 vecR )
+static Obj ProdFFEVecFFE(Obj elmL, Obj vecR)
 {
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
@@ -549,9 +535,7 @@ static Obj             ProdFFEVecFFE (
 **  'ProdVecFFEFFE'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD'.
 */
-static Obj             ProdVecFFEFFE (
-    Obj                 vecL,
-    Obj                 elmR )
+static Obj ProdVecFFEFFE(Obj vecL, Obj elmR)
 {
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
@@ -611,9 +595,7 @@ static Obj             ProdVecFFEFFE (
 **  'ProdVecFFEVecFFE' is an improved version  of 'ProdListList',  which does
 **  not call 'PROD'.
 */
-static Obj             ProdVecFFEVecFFE (
-    Obj                 vecL,
-    Obj                 vecR )
+static Obj ProdVecFFEVecFFE(Obj vecL, Obj vecR)
 {
     FFV                 valP;           /* one product                     */
     FFV                 valS;           /* sum of the products             */
@@ -671,7 +653,7 @@ static Obj             ProdVecFFEVecFFE (
 
 static Obj AddRowVectorOp;   /* BH changed to static */
 
-static Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
+static Obj FuncADD_ROWVECTOR_VECFFES_3(Obj self, Obj vecL, Obj vecR, Obj mult)
 {
     Obj *ptrL;
     const Obj *ptrR;
@@ -774,7 +756,7 @@ static Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 
 static Obj MultVectorLeftOp; /* BH changed to static */
 
-static Obj FuncMULT_VECTOR_VECFFES( Obj self, Obj vec, Obj mult )
+static Obj FuncMULT_VECTOR_VECFFES(Obj self, Obj vec, Obj mult)
 {
     Obj *ptr;
     FFV  valM;
@@ -845,7 +827,7 @@ static Obj FuncMULT_VECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 *F  FuncADD_ROWVECTOR_VECFFES_2( <self>, <vecL>, <vecR> )
 **
 */
-static Obj FuncADD_ROWVECTOR_VECFFES_2( Obj self, Obj vecL, Obj vecR )
+static Obj FuncADD_ROWVECTOR_VECFFES_2(Obj self, Obj vecL, Obj vecR)
 {
     Obj *ptrL;
     const Obj *ptrR;
@@ -1012,7 +994,7 @@ Obj             ProdVecFFEMatFFE (
 **  becuase it knows tha the zero is common and the result a vecffe
 */
 
-static Obj ZeroMutVecFFE( Obj vec )
+static Obj ZeroMutVecFFE(Obj vec)
 {
     UInt i, len;
     Obj res;
@@ -1029,7 +1011,7 @@ static Obj ZeroMutVecFFE( Obj vec )
     return res;
 }
 
-static Obj ZeroVecFFE( Obj vec )
+static Obj ZeroVecFFE(Obj vec)
 {
     UInt i, len;
     Obj res;
@@ -1047,12 +1029,12 @@ static Obj ZeroVecFFE( Obj vec )
 }
 
 
-static Obj FuncIS_VECFFE( Obj self, Obj vec)
+static Obj FuncIS_VECFFE(Obj self, Obj vec)
 {
     return IsVecFFE(vec) ? True : False;
 }
 
-static Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
+static Obj FuncCOMMON_FIELD_VECFFE(Obj self, Obj vec)
 {
     Obj elm;
     if (!IsVecFFE(vec))
@@ -1061,7 +1043,7 @@ static Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
     return INTOBJ_INT(SIZE_FF(FLD_FFE(elm)));
 }
 
-static Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
+static Obj FuncSMALLEST_FIELD_VECFFE(Obj self, Obj vec)
 {
     Obj elm;
     UInt deg, deg1, deg2, i, len, p, q;

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -33,7 +33,7 @@
 **
 **  One may think of this as an optimized special case of 'KTNumPlist'.
 */
-Int IsVecFFE(Obj obj)
+static Int IsVecFFE(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     if (tnum == T_PLIST_FFE || tnum == T_PLIST_FFE + IMMUTABLE)
@@ -70,7 +70,7 @@ Int IsVecFFE(Obj obj)
 **  'SumFFEVecFFE' is an improved version  of  'SumSclList', which  does  not
 **  call 'SUM'.
 */
-Obj             SumFFEVecFFE (
+static Obj             SumFFEVecFFE (
     Obj                 elmL,
     Obj                 vecR )
 {
@@ -132,7 +132,7 @@ Obj             SumFFEVecFFE (
 **  'SumVecFFEFFE' is an improved version  of  'SumListScl', which  does  not
 **  call 'SUM'.
 */
-Obj             SumVecFFEFFE (
+static Obj             SumVecFFEFFE (
     Obj                 vecL,
     Obj                 elmR )
 {
@@ -193,7 +193,7 @@ Obj             SumVecFFEFFE (
 **  'SumVecFFEVecFFE' is an improved version of 'SumListList', which does not
 **  call 'SUM'.
 */
-Obj             SumVecFFEVecFFE (
+static Obj             SumVecFFEVecFFE (
     Obj                 vecL,
     Obj                 vecR )
 {
@@ -275,7 +275,7 @@ Obj             SumVecFFEVecFFE (
 **  'DiffFFEVecFFE'  is an improved  version of 'DiffSclList', which does not
 **  call 'DIFF'.
 */
-Obj             DiffFFEVecFFE (
+static Obj             DiffFFEVecFFE (
     Obj                 elmL,
     Obj                 vecR )
 {
@@ -338,7 +338,7 @@ Obj             DiffFFEVecFFE (
 **  'DiffVecFFEFFE' is an improved  version of 'DiffListScl', which  does not
 **  call 'DIFF'.
 */
-Obj             DiffVecFFEFFE (
+static Obj             DiffVecFFEFFE (
     Obj                 vecL,
     Obj                 elmR )
 {
@@ -401,7 +401,7 @@ Obj             DiffVecFFEFFE (
 **  'DiffVecFFEVecFFE' is an improved  version of  'DiffListList', which does
 **  not call 'DIFF'.
 */
-Obj             DiffVecFFEVecFFE (
+static Obj             DiffVecFFEVecFFE (
     Obj                 vecL,
     Obj                 vecR )
 {
@@ -488,7 +488,7 @@ Obj             DiffVecFFEVecFFE (
 **  'ProdFFEVecFFE'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD'.
 */
-Obj             ProdFFEVecFFE (
+static Obj             ProdFFEVecFFE (
     Obj                 elmL,
     Obj                 vecR )
 {
@@ -549,7 +549,7 @@ Obj             ProdFFEVecFFE (
 **  'ProdVecFFEFFE'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD'.
 */
-Obj             ProdVecFFEFFE (
+static Obj             ProdVecFFEFFE (
     Obj                 vecL,
     Obj                 elmR )
 {
@@ -611,7 +611,7 @@ Obj             ProdVecFFEFFE (
 **  'ProdVecFFEVecFFE' is an improved version  of 'ProdListList',  which does
 **  not call 'PROD'.
 */
-Obj             ProdVecFFEVecFFE (
+static Obj             ProdVecFFEVecFFE (
     Obj                 vecL,
     Obj                 vecR )
 {
@@ -671,7 +671,7 @@ Obj             ProdVecFFEVecFFE (
 
 static Obj AddRowVectorOp;   /* BH changed to static */
 
-Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
+static Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 {
     Obj *ptrL;
     const Obj *ptrR;
@@ -774,7 +774,7 @@ Obj FuncADD_ROWVECTOR_VECFFES_3( Obj self, Obj vecL, Obj vecR, Obj mult )
 
 static Obj MultVectorLeftOp; /* BH changed to static */
 
-Obj FuncMULT_VECTOR_VECFFES( Obj self, Obj vec, Obj mult )
+static Obj FuncMULT_VECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 {
     Obj *ptr;
     FFV  valM;
@@ -845,7 +845,7 @@ Obj FuncMULT_VECTOR_VECFFES( Obj self, Obj vec, Obj mult )
 *F  FuncADD_ROWVECTOR_VECFFES_2( <self>, <vecL>, <vecR> )
 **
 */
-Obj FuncADD_ROWVECTOR_VECFFES_2( Obj self, Obj vecL, Obj vecR )
+static Obj FuncADD_ROWVECTOR_VECFFES_2( Obj self, Obj vecL, Obj vecR )
 {
     Obj *ptrL;
     const Obj *ptrR;
@@ -1012,7 +1012,7 @@ Obj             ProdVecFFEMatFFE (
 **  becuase it knows tha the zero is common and the result a vecffe
 */
 
-Obj ZeroMutVecFFE( Obj vec )
+static Obj ZeroMutVecFFE( Obj vec )
 {
     UInt i, len;
     Obj res;
@@ -1029,7 +1029,7 @@ Obj ZeroMutVecFFE( Obj vec )
     return res;
 }
 
-Obj ZeroVecFFE( Obj vec )
+static Obj ZeroVecFFE( Obj vec )
 {
     UInt i, len;
     Obj res;
@@ -1047,12 +1047,12 @@ Obj ZeroVecFFE( Obj vec )
 }
 
 
-Obj FuncIS_VECFFE( Obj self, Obj vec)
+static Obj FuncIS_VECFFE( Obj self, Obj vec)
 {
     return IsVecFFE(vec) ? True : False;
 }
 
-Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
+static Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
 {
     Obj elm;
     if (!IsVecFFE(vec))
@@ -1061,7 +1061,7 @@ Obj FuncCOMMON_FIELD_VECFFE( Obj self, Obj vec)
     return INTOBJ_INT(SIZE_FF(FLD_FFE(elm)));
 }
 
-Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
+static Obj FuncSMALLEST_FIELD_VECFFE( Obj self, Obj vec)
 {
     Obj elm;
     UInt deg, deg1, deg2, i, len, p, q;

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -619,7 +619,8 @@ static const UInt * getgreasedata(struct greaseinfo * g, UInt bits)
 }
 
 
-static Obj ProdGF2MatGF2MatAdvanced(Obj ml, Obj mr, UInt greasesize, UInt blocksize)
+static Obj
+ProdGF2MatGF2MatAdvanced(Obj ml, Obj mr, UInt greasesize, UInt blocksize)
 {
     Obj          prod;          // Product Matrix
     UInt         i, j, k, b;    // Loop counters
@@ -3031,18 +3032,19 @@ static Obj FuncDIST_VEC_CLOS_VEC(
     return (Obj)0;
 }
 
-static UInt AClosVec(Obj veclis,    // pointers to matrix vectors and their multiples
-              Obj ovec,      // vector we compute distance to
-              Obj osum,      // position of the sum vector
-              UInt pos,      // recursion depth
-              UInt l,        // length of basis
-              UInt len,      // length of the involved vectors
-              UInt cnt,      // numbr of vectors used
-              UInt stop,     // stop value
-              UInt bd,       // best distance so far
-              Obj  obv,      // best vector so far
-              Obj  coords,    // coefficients to get current vector
-              Obj  bcoords    // coefficients to get best vector
+static UInt
+AClosVec(Obj  veclis,    // pointers to matrix vectors and their multiples
+         Obj  ovec,      // vector we compute distance to
+         Obj  osum,      // position of the sum vector
+         UInt pos,       // recursion depth
+         UInt l,         // length of basis
+         UInt len,       // length of the involved vectors
+         UInt cnt,       // numbr of vectors used
+         UInt stop,      // stop value
+         UInt bd,        // best distance so far
+         Obj  obv,       // best vector so far
+         Obj  coords,    // coefficients to get current vector
+         Obj  bcoords    // coefficients to get best vector
 )
 {
     UInt         di;
@@ -3615,8 +3617,8 @@ static void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
 **
 */
 
-static Obj FuncADD_GF2VEC_GF2VEC_SHIFTED(
-    Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
+static Obj
+FuncADD_GF2VEC_GF2VEC_SHIFTED(Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
 {
     Int off1, len2a;
     if (!IS_INTOBJ(off))
@@ -3693,7 +3695,8 @@ static Obj ProductCoeffsGF2Vec(Obj vec1, UInt len1, Obj vec2, UInt len2)
 **
 */
 
-static Obj FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+static Obj
+FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     UInt len1a, len2a;
     Obj  prod;
@@ -3762,7 +3765,8 @@ static void ReduceCoeffsGF2Vec(Obj vec1, Obj vec2, UInt len2, Obj quotient)
 *F  FuncREDUCE_COEFFS_GF2VEC( <self>, <vec1>, <len1>, <vec2>, <len2> )
 **
 */
-static Obj FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+static Obj
+FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     UInt last;
     Int  len2a;
@@ -3811,8 +3815,8 @@ static Obj FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj 
 *F  FuncQUOTREM_COEFFS_GF2VEC( <self>, <vec1>, <len1>, <vec2>, <len2> )
 **
 */
-static Obj FuncQUOTREM_COEFFS_GF2VEC(
-    Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+static Obj
+FuncQUOTREM_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     Int len2a;
     Int len1a = INT_INTOBJ(len1);
@@ -4166,7 +4170,8 @@ static Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
 *F  FuncSET_MAT_ELM_GF2MAT( <self>, <mat>, <row>, <col>, <elm> )
 **
 */
-static Obj FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
+static Obj
+FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -90,14 +90,14 @@ Obj IsGF2VectorRep;
 **
 *V  GF2One  . . . . . . . . . . . . . . . . . . . . . . . . . . .  one of GF2
 */
-Obj GF2One;
+static Obj GF2One;
 
 
 /****************************************************************************
 **
 *V  GF2Zero . . . . . . . . . . . . . . . . . . . . . . . . . . . zero of GF2
 */
-Obj GF2Zero;
+static Obj GF2Zero;
 
 
 /****************************************************************************
@@ -123,7 +123,7 @@ static inline void AddGF2VecToGF2Vec(UInt * ptS, const UInt * ptV, UInt len)
 **  position of the rightmost Z(2) is returned.
 */
 
-UInt RightMostOneGF2Vec(Obj vec)
+static UInt RightMostOneGF2Vec(Obj vec)
 {
     UInt len;
 
@@ -140,7 +140,7 @@ UInt RightMostOneGF2Vec(Obj vec)
 }
 
 
-Obj AddCoeffsGF2VecGF2Vec(Obj sum, Obj vec)
+static Obj AddCoeffsGF2VecGF2Vec(Obj sum, Obj vec)
 {
     UInt *       ptS;
     const UInt * ptV;
@@ -200,7 +200,7 @@ CopySection_GF2Vecs(Obj src, Obj dest, UInt smin, UInt dmin, UInt nelts)
 **  Note that the caller has to ensure, that <sum> is a gf2-vector with the
 **  correct size.
 */
-Obj AddPartialGF2VecGF2Vec(Obj sum, Obj vl, Obj vr, UInt n)
+static Obj AddPartialGF2VecGF2Vec(Obj sum, Obj vl, Obj vr, UInt n)
 {
     const UInt * ptL;       // bit field of <vl>
     const UInt * ptR;       // bit field of <vr>
@@ -299,7 +299,7 @@ Obj AddPartialGF2VecGF2Vec(Obj sum, Obj vl, Obj vr, UInt n)
 
 #endif
 
-Obj ProdGF2VecGF2Vec(Obj vl, Obj vr)
+static Obj ProdGF2VecGF2Vec(Obj vl, Obj vr)
 {
     const UInt * ptL;     // bit field of <vl>
     const UInt * ptR;     // bit field of <vr>
@@ -355,7 +355,7 @@ Obj ProdGF2VecGF2Vec(Obj vl, Obj vr)
 **  multiplied by the corresponding entry of <vl>.  Note that the  caller has
 **  to ensure, that <vl> is a gf2-vector and <vr> is a gf2-matrix.
 */
-Obj ProdGF2VecGF2Mat(Obj vl, Obj vr)
+static Obj ProdGF2VecGF2Mat(Obj vl, Obj vr)
 {
     UInt         len;    // length of the list
     UInt         stop;
@@ -423,7 +423,7 @@ Obj ProdGF2VecGF2Mat(Obj vl, Obj vr)
 **  Note that the  caller has
 **  to ensure, that <ml> is a GF2 matrix and <vr> is a GF2 vector.
 */
-Obj ProdGF2MatGF2Vec(Obj ml, Obj vr)
+static Obj ProdGF2MatGF2Vec(Obj ml, Obj vr)
 {
     UInt         len;     // length of the vector
     UInt         ln1;     // length of the rows of the mx
@@ -498,7 +498,7 @@ Obj ProdGF2MatGF2Vec(Obj ml, Obj vr)
 **  must be compatible.
 */
 
-Obj ProdGF2MatGF2MatSimple(Obj ml, Obj mr)
+static Obj ProdGF2MatGF2MatSimple(Obj ml, Obj mr)
 {
     Obj  prod;
     UInt i;
@@ -619,7 +619,7 @@ static const UInt * getgreasedata(struct greaseinfo * g, UInt bits)
 }
 
 
-Obj ProdGF2MatGF2MatAdvanced(Obj ml, Obj mr, UInt greasesize, UInt blocksize)
+static Obj ProdGF2MatGF2MatAdvanced(Obj ml, Obj mr, UInt greasesize, UInt blocksize)
 {
     Obj          prod;          // Product Matrix
     UInt         i, j, k, b;    // Loop counters
@@ -830,7 +830,7 @@ Obj ProdGF2MatGF2MatAdvanced(Obj ml, Obj mr, UInt greasesize, UInt blocksize)
 **
 **  method to handle vector*plain list of GF2Vectors reasonably efficiently.
 */
-Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
+static Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 {
     Obj  res;
     UInt len;
@@ -878,7 +878,7 @@ Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
 **  by this point it should be checked that list is a plain list of GF2
 **  vectors of equal lengths.
 */
-Obj InversePlistGF2VecsDesstructive(Obj list)
+static Obj InversePlistGF2VecsDesstructive(Obj list)
 {
     UInt         len;     // dimension
     Obj          inv;     // result
@@ -967,7 +967,7 @@ Obj InversePlistGF2VecsDesstructive(Obj list)
 **
 */
 
-Obj InverseGF2Mat(Obj mat, UInt mut)
+static Obj InverseGF2Mat(Obj mat, UInt mut)
 {
     UInt         len;    // dimension
     Obj          inv;    // result
@@ -1072,7 +1072,7 @@ Obj ShallowCopyVecGF2(Obj vec)
 static UInt RNheads, RNvectors, RNcoeffs, RNrelns;
 
 
-Obj SemiEchelonListGF2Vecs(Obj mat, UInt TransformationsNeeded)
+static Obj SemiEchelonListGF2Vecs(Obj mat, UInt TransformationsNeeded)
 {
     UInt  nrows, ncols;
     UInt  i, j, h;
@@ -1180,7 +1180,7 @@ Obj SemiEchelonListGF2Vecs(Obj mat, UInt TransformationsNeeded)
 **
 */
 
-UInt TriangulizeListGF2Vecs(Obj mat, UInt clearup)
+static UInt TriangulizeListGF2Vecs(Obj mat, UInt clearup)
 {
     UInt         nrows;
     UInt         ncols;
@@ -1249,7 +1249,7 @@ UInt TriangulizeListGF2Vecs(Obj mat, UInt clearup)
 static Obj IsLockedRepresentationVector;
 
 
-void PlainGF2Vec(Obj list)
+static void PlainGF2Vec(Obj list)
 {
     Int  len;          // length of <list>
     UInt i;            // loop variable
@@ -1296,7 +1296,7 @@ void PlainGF2Vec(Obj list)
 **
 **  'PlainGF2Mat' converts the GF2 matrix <list> to a plain list.
 */
-void PlainGF2Mat(Obj list)
+static void PlainGF2Mat(Obj list)
 {
     Int  len;    // length of <list>
     UInt i;      // loop variable
@@ -1319,7 +1319,7 @@ void PlainGF2Mat(Obj list)
 **
 *F  ConvGF2Vec( <list> )  . . . . . . convert a list into a GF2 vector object
 */
-void ConvGF2Vec(Obj list)
+static void ConvGF2Vec(Obj list)
 {
     Int  len;      // logical length of the vector
     Int  i;        // loop variable
@@ -1391,7 +1391,7 @@ void ConvGF2Vec(Obj list)
 **
 *F  FuncCONV_GF2VEC( <self>, <list> ) . . . . . convert into a GF2 vector rep
 */
-Obj FuncCONV_GF2VEC(Obj self, Obj list)
+static Obj FuncCONV_GF2VEC(Obj self, Obj list)
 {
     // check whether <list> is a GF2 vector
     ConvGF2Vec(list);
@@ -1407,7 +1407,7 @@ Obj FuncCONV_GF2VEC(Obj self, Obj list)
 **
 **  This is a non-destructive counterpart of ConvGF2Vec
 */
-Obj NewGF2Vec(Obj list)
+static Obj NewGF2Vec(Obj list)
 {
     Int  len;      // logical length of the vector
     Int  i;        // loop variable
@@ -1481,7 +1481,7 @@ Obj NewGF2Vec(Obj list)
 **
 **  This is a non-destructive counterpart of FuncCONV_GF2VEC
 */
-Obj FuncCOPY_GF2VEC(Obj self, Obj list)
+static Obj FuncCOPY_GF2VEC(Obj self, Obj list)
 {
     // check whether <list> is a GF2 vector
     list = NewGF2Vec(list);
@@ -1496,7 +1496,7 @@ Obj FuncCOPY_GF2VEC(Obj self, Obj list)
 ** <list> should be a a list of compressed GF2 vectors
 **
 */
-Obj FuncCONV_GF2MAT(Obj self, Obj list)
+static Obj FuncCONV_GF2MAT(Obj self, Obj list)
 {
     UInt len, i;
     Obj  tmp;
@@ -1535,7 +1535,7 @@ Obj FuncCONV_GF2MAT(Obj self, Obj list)
 **
 *F  FuncPLAIN_GF2VEC( <self>, <list> ) . . .  convert back into ordinary list
 */
-Obj FuncPLAIN_GF2VEC(Obj self, Obj list)
+static Obj FuncPLAIN_GF2VEC(Obj self, Obj list)
 {
     // check whether <list> is a GF2 vector
     while (!IS_GF2VEC_REP(list)) {
@@ -1580,7 +1580,7 @@ static const UInt1 revertlist[] = {
 
 // Takes an UInt a on n bits and returns the Uint obtained by reverting the
 // bits
-UInt revertbits(UInt a, Int n)
+static UInt revertbits(UInt a, Int n)
 {
     UInt b, c;
     b = 0;
@@ -1605,7 +1605,7 @@ UInt revertbits(UInt a, Int n)
 *F  Cmp_GF2Vecs( <vl>, <vr> )   compare GF2 vectors -- internal
 **                                    returns -1, 0 or 1
 */
-Int Cmp_GF2VEC_GF2VEC(Obj vl, Obj vr)
+static Int Cmp_GF2VEC_GF2VEC(Obj vl, Obj vr)
 {
     UInt         i;                  // loop variable
     const UInt * bl;                 // block of <vl>
@@ -1678,7 +1678,7 @@ Int Cmp_GF2VEC_GF2VEC(Obj vl, Obj vr)
 **
 *F  FuncEQ_GF2VEC_GF2VEC( <self>, <vl>, <vr> )   test equality of GF2 vectors
 */
-Obj FuncEQ_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncEQ_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     // we can do this case MUCH faster if we just want equality
     if (LEN_GF2VEC(vl) != LEN_GF2VEC(vr))
@@ -1691,7 +1691,7 @@ Obj FuncEQ_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 **
 *F  FuncLEN_GF2VEC( <self>, <list> )  . . . . . . . .  length of a GF2 vector
 */
-Obj FuncLEN_GF2VEC(Obj self, Obj list)
+static Obj FuncLEN_GF2VEC(Obj self, Obj list)
 {
     return INTOBJ_INT(LEN_GF2VEC(list));
 }
@@ -1706,7 +1706,7 @@ Obj FuncLEN_GF2VEC(Obj self, Obj list)
 **  the  responsibility of  the caller to   ensure  that <pos> is  a positive
 **  integer.
 */
-Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
+static Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 {
     UInt p = GetSmallInt("ELM0_GF2VEC", pos);
     if (LEN_GF2VEC(list) < p) {
@@ -1726,7 +1726,7 @@ Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 **  <list>.   An  error  is signalled  if  <pos>  is  not bound.    It is the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 */
-Obj FuncELM_GF2VEC(Obj self, Obj list, Obj pos)
+static Obj FuncELM_GF2VEC(Obj self, Obj list, Obj pos)
 {
     UInt p = GetSmallInt("ELM_GF2VEC", pos);
     if (LEN_GF2VEC(list) < p) {
@@ -1749,7 +1749,7 @@ Obj FuncELM_GF2VEC(Obj self, Obj list, Obj pos)
 **  only positive integers.  An error is signalled if an element of <poss> is
 **  larger than the length of <list>.
 */
-Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
+static Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
 {
     Obj elms;       // selected sublist, result
     Int lenList;    // length of <list>
@@ -1848,7 +1848,7 @@ Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
 **  and that <elm> is not 0.
 */
 
-Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
+static Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
 {
     // check that <list> is mutable
     if (!IS_MUTABLE_OBJ(list)) {
@@ -1897,7 +1897,7 @@ Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
 **
 *F  FuncPLAIN_GF2MAT( <self>, <list> ) . . .  convert back into ordinary list
 */
-Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
+static Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
 {
     PlainGF2Mat(list);
 
@@ -1916,7 +1916,7 @@ Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
 **  It is the responsibility of the caller  to ensure that <pos> is positive,
 **  and that <elm> is not 0.
 */
-Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
+static Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
 {
     // check that <list> is mutable
     if (!IS_MUTABLE_OBJ(list)) {
@@ -1967,7 +1967,7 @@ Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
 *F  FuncELM_GF2MAT( <self>, <mat>, <row> ) . . . select a row of a GF2 matrix
 **
 */
-Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
+static Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
 {
     UInt r = GetSmallInt("ELM_GF2MAT", row);
     if (LEN_GF2MAT(mat) < r) {
@@ -1987,7 +1987,7 @@ Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
 */
-Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
+static Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
 {
     // check that <list> is mutable
     if (!IS_MUTABLE_OBJ(list)) {
@@ -2030,7 +2030,7 @@ Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
 **
 **  It is the responsibility of the caller  to ensure that <pos> is positive.
 */
-Obj FuncUNB_GF2MAT(Obj self, Obj list, Obj pos)
+static Obj FuncUNB_GF2MAT(Obj self, Obj list, Obj pos)
 {
     // check that <list> is mutable
     if (!IS_MUTABLE_OBJ(list)) {
@@ -2070,7 +2070,7 @@ Obj FuncUNB_GF2MAT(Obj self, Obj list, Obj pos)
 **
 **  return the zero vector over GF2 of the same length as <mat>.
 */
-Obj FuncZERO_GF2VEC(Obj self, Obj mat)
+static Obj FuncZERO_GF2VEC(Obj self, Obj mat)
 {
     Obj  zero;
     UInt len;
@@ -2087,7 +2087,7 @@ Obj FuncZERO_GF2VEC(Obj self, Obj mat)
 **
 **  return the zero vector over GF2 of length <len>
 */
-Obj FuncZERO_GF2VEC_2(Obj self, Obj len)
+static Obj FuncZERO_GF2VEC_2(Obj self, Obj len)
 {
     Obj zero;
 
@@ -2109,7 +2109,7 @@ Obj FuncZERO_GF2VEC_2(Obj self, Obj len)
 **  INVERSE_PLIST_GF2VECS_DESTRUCTIVE
 ** might do just as good a job
 */
-Obj FuncINV_GF2MAT_MUTABLE(Obj self, Obj mat)
+static Obj FuncINV_GF2MAT_MUTABLE(Obj self, Obj mat)
 {
     UInt len;
 
@@ -2133,7 +2133,7 @@ Obj FuncINV_GF2MAT_MUTABLE(Obj self, Obj mat)
 **  INVERSE_PLIST_GF2VECS_DESTRUCTIVE
 ** might do just as good a job
 */
-Obj FuncINV_GF2MAT_SAME_MUTABILITY(Obj self, Obj mat)
+static Obj FuncINV_GF2MAT_SAME_MUTABILITY(Obj self, Obj mat)
 {
     UInt len;
 
@@ -2157,7 +2157,7 @@ Obj FuncINV_GF2MAT_SAME_MUTABILITY(Obj self, Obj mat)
 **  INVERSE_PLIST_GF2VECS_DESTRUCTIVE
 ** might do just as good a job
 */
-Obj FuncINV_GF2MAT_IMMUTABLE(Obj self, Obj mat)
+static Obj FuncINV_GF2MAT_IMMUTABLE(Obj self, Obj mat)
 {
     UInt len;
 
@@ -2183,7 +2183,7 @@ Obj FuncINV_GF2MAT_IMMUTABLE(Obj self, Obj mat)
 **
 **  invert possible GF2 matrix
 */
-Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE(Obj self, Obj list)
+static Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE(Obj self, Obj list)
 {
     UInt len, i;
     Obj  row;
@@ -2221,7 +2221,7 @@ Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE(Obj self, Obj list)
 **  'FuncSUM_GF2VEC_GF2VEC'  is  an improved  version of 'SumListList', which
 **  does not call 'SUM' but uses bit operations instead.
 */
-Obj FuncSUM_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncSUM_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     Obj  sum;    // sum, result
     UInt ll, lr;
@@ -2251,7 +2251,7 @@ Obj FuncSUM_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 **                                      . . . . .  sum of GF2 vectors
 **
 */
-Obj FuncMULT_VECTOR_GF2VECS_2(Obj self, Obj vl, Obj mul)
+static Obj FuncMULT_VECTOR_GF2VECS_2(Obj self, Obj vl, Obj mul)
 {
     if (EQ(mul, GF2One))
         return (Obj)0;
@@ -2271,7 +2271,7 @@ Obj FuncMULT_VECTOR_GF2VECS_2(Obj self, Obj vl, Obj mul)
 **  'FuncPROD_GF2VEC_GF2VEC' returns the product of  the two GF2 vectors <vl>
 **  and <vr>.  The product is either `GF2One' or `GF2Zero'.
 */
-Obj FuncPROD_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncPROD_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     return ProdGF2VecGF2Vec(vl, vr);
 }
@@ -2287,7 +2287,7 @@ Obj FuncPROD_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 **  The  product is  again a  GF2 vector.  It  is  the  responsibility of the
 **  caller to ensure that <vl> is a  GF2 vector, <vr>  a GF2 matrix.
 */
-Obj FuncPROD_GF2VEC_GF2MAT(Obj self, Obj vl, Obj vr)
+static Obj FuncPROD_GF2VEC_GF2MAT(Obj self, Obj vl, Obj vr)
 {
     return ProdGF2VecGF2Mat(vl, vr);
 }
@@ -2302,7 +2302,7 @@ Obj FuncPROD_GF2VEC_GF2MAT(Obj self, Obj vl, Obj vr)
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
 */
-Obj FuncPROD_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
+static Obj FuncPROD_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
     UInt lenl = LEN_GF2MAT(ml);
     UInt lenm;
@@ -2326,7 +2326,7 @@ Obj FuncPROD_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
 */
-Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE(Obj self, Obj ml, Obj mr)
+static Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE(Obj self, Obj ml, Obj mr)
 {
     return ProdGF2MatGF2MatSimple(ml, mr);
 }
@@ -2343,7 +2343,7 @@ Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE(Obj self, Obj ml, Obj mr)
 **  The  product is  again a  GF2 matrix.  It  is  the  responsibility of the
 **  caller to ensure that <ml> and <mr> are  GF2 matrices
 */
-Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED(
+static Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED(
     Obj self, Obj ml, Obj mr, Obj greaselevel, Obj blocksize)
 {
     return ProdGF2MatGF2MatAdvanced(ml, mr, INT_INTOBJ(greaselevel),
@@ -2361,7 +2361,7 @@ Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED(
 **  The  product is  again a  GF2 vector.  It  is  the  responsibility of the
 **  caller to ensure that <vr> is a  GF2 vector, <vl>  a GF2 matrix.
 */
-Obj FuncPROD_GF2MAT_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncPROD_GF2MAT_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     return ProdGF2MatGF2Vec(vl, vr);
 }
@@ -2371,7 +2371,7 @@ Obj FuncPROD_GF2MAT_GF2VEC(Obj self, Obj vl, Obj vr)
 **
 *F  FuncADDCOEFFS_GF2VEC_GF2VEC_MULT( <self>, <vl>, <vr>, <mul> ) GF2 vectors
 */
-Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(Obj self, Obj vl, Obj vr, Obj mul)
+static Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(Obj self, Obj vl, Obj vr, Obj mul)
 {
     // do nothing if <mul> is zero
     if (EQ(mul, GF2Zero)) {
@@ -2391,7 +2391,7 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(Obj self, Obj vl, Obj vr, Obj mul)
 **
 *F  FuncADDCOEFFS_GF2VEC_GF2VEC( <self>, <vl>, <vr> ) . . . . . . GF2 vectors
 */
-Obj FuncADDCOEFFS_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncADDCOEFFS_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     return AddCoeffsGF2VecGF2Vec(vl, vr);
 }
@@ -2401,7 +2401,7 @@ Obj FuncADDCOEFFS_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 **
 *F  FuncSHRINKCOEFFS_GF2VEC( <self>, <vec> )  . . . . . remove trailing zeros
 */
-Obj FuncSHRINKCOEFFS_GF2VEC(Obj self, Obj vec)
+static Obj FuncSHRINKCOEFFS_GF2VEC(Obj self, Obj vec)
 {
     UInt   len;
     UInt   nbb;
@@ -2457,7 +2457,7 @@ Obj FuncSHRINKCOEFFS_GF2VEC(Obj self, Obj vec)
 **  It is *not* used in the code and can be replaced by a dummy argument.
 */
 
-UInt PositionNonZeroGF2Vec(Obj vec, UInt from)
+static UInt PositionNonZeroGF2Vec(Obj vec, UInt from)
 {
     UInt         len;
     UInt         nbb;
@@ -2508,18 +2508,18 @@ UInt PositionNonZeroGF2Vec(Obj vec, UInt from)
 }
 
 
-Obj FuncPOSITION_NONZERO_GF2VEC(Obj self, Obj vec, Obj zero)
+static Obj FuncPOSITION_NONZERO_GF2VEC(Obj self, Obj vec, Obj zero)
 {
     return INTOBJ_INT(PositionNonZeroGF2Vec(vec, 0));
 }
 
-Obj FuncPOSITION_NONZERO_GF2VEC3(Obj self, Obj vec, Obj zero, Obj from)
+static Obj FuncPOSITION_NONZERO_GF2VEC3(Obj self, Obj vec, Obj zero, Obj from)
 {
     return INTOBJ_INT(PositionNonZeroGF2Vec(vec, INT_INTOBJ(from)));
 }
 
 
-Obj FuncCOPY_SECTION_GF2VECS(
+static Obj FuncCOPY_SECTION_GF2VECS(
     Obj self, Obj src, Obj dest, Obj from, Obj to, Obj howmany)
 {
     Int  ifrom;
@@ -2551,7 +2551,7 @@ Obj FuncCOPY_SECTION_GF2VECS(
 **
 */
 
-Obj FuncAPPEND_GF2VEC(Obj self, Obj vecl, Obj vecr)
+static Obj FuncAPPEND_GF2VEC(Obj self, Obj vecl, Obj vecr)
 {
     UInt lenl, lenr;
     lenl = LEN_GF2VEC(vecl);
@@ -2573,7 +2573,7 @@ Obj FuncAPPEND_GF2VEC(Obj self, Obj vecl, Obj vecr)
 **
 */
 
-Obj FuncSHALLOWCOPY_GF2VEC(Obj self, Obj vec)
+static Obj FuncSHALLOWCOPY_GF2VEC(Obj self, Obj vec)
 {
     return ShallowCopyVecGF2(vec);
 }
@@ -2585,7 +2585,7 @@ Obj FuncSHALLOWCOPY_GF2VEC(Obj self, Obj vec)
 */
 
 
-Obj FuncSUM_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
+static Obj FuncSUM_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 {
     UInt ll, lr, ls, lm, wl, wr, ws, wm;
     Obj  sum;
@@ -2674,7 +2674,7 @@ Obj FuncSUM_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 *F  FuncTRANSPOSED_GF2MAT( <self>, <mat>)
 **
 */
-Obj FuncTRANSPOSED_GF2MAT(Obj self, Obj mat)
+static Obj FuncTRANSPOSED_GF2MAT(Obj self, Obj mat)
 {
     UInt l, w;
     Obj  tra, row;
@@ -2763,7 +2763,7 @@ Obj FuncTRANSPOSED_GF2MAT(Obj self, Obj mat)
 *F  FuncNUMBER_GF2VEC( <self>, <vect> )
 **
 */
-Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
+static Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
 {
     UInt        len, nd, i;
     UInt        head, a;
@@ -2840,7 +2840,7 @@ Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
 **
 *F  FuncLT_GF2VEC_GF2VEC( <self>, <vl>, <vr> )   compare GF2 vectors
 */
-Obj FuncLT_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncLT_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     return (Cmp_GF2VEC_GF2VEC(vl, vr) < 0) ? True : False;
 }
@@ -2850,7 +2850,7 @@ Obj FuncLT_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 *F  Cmp_GF2MAT_GF2MAT( <ml>, <mr> )   compare GF2 matrices
 */
 
-Int Cmp_GF2MAT_GF2MAT(Obj ml, Obj mr)
+static Int Cmp_GF2MAT_GF2MAT(Obj ml, Obj mr)
 {
     UInt l1, l2, l, i;
     Int  c;
@@ -2874,7 +2874,7 @@ Int Cmp_GF2MAT_GF2MAT(Obj ml, Obj mr)
 *F  FuncEQ_GF2MAT_GF2MAT( <ml>, <mr> )   compare GF2 matrices
 */
 
-Obj FuncEQ_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
+static Obj FuncEQ_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
     if (ELM_PLIST(ml, 1) != ELM_PLIST(mr, 1))
         return False;
@@ -2886,7 +2886,7 @@ Obj FuncEQ_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 *F  FuncLT_GF2MAT_GF2MAT( <ml>, <mr> )   compare GF2 matrices
 */
 
-Obj FuncLT_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
+static Obj FuncLT_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
     return (Cmp_GF2MAT_GF2MAT(ml, mr) < 0) ? True : False;
 }
@@ -2899,7 +2899,7 @@ Obj FuncLT_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 **  ptL and ptR for a GF(2) vector of <len> entries.
 **
 */
-UInt DistGF2Vecs(const UInt * ptL, const UInt * ptR, UInt len)
+static UInt DistGF2Vecs(const UInt * ptL, const UInt * ptR, UInt len)
 {
     UInt         sum, m;
     const UInt * end;    // end marker
@@ -2925,7 +2925,7 @@ UInt DistGF2Vecs(const UInt * ptL, const UInt * ptR, UInt len)
 **  'FuncDIST_GF2VEC_GF2VEC' returns the number of position in which two
 **  gf2-vectors <vl>  and  <vr> differ.
 */
-Obj FuncDIST_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
+static Obj FuncDIST_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
     UInt   len;    // length of the list
     UInt   off;    // bit offset at the end to clean out
@@ -2965,7 +2965,7 @@ Obj FuncDIST_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 }
 
 
-void DistVecClosVec(
+static void DistVecClosVec(
     Obj  veclis,    // pointers to matrix vectors and their multiples
     Obj  ovec,      // vector we compute distance to
     Obj  d,         // distances list
@@ -3010,7 +3010,7 @@ void DistVecClosVec(
     }
 }
 
-Obj FuncDIST_VEC_CLOS_VEC(
+static Obj FuncDIST_VEC_CLOS_VEC(
     Obj self,
     Obj veclis,    // pointers to matrix vectors and their multiples
     Obj vec,       // vector we compute distance to
@@ -3031,7 +3031,7 @@ Obj FuncDIST_VEC_CLOS_VEC(
     return (Obj)0;
 }
 
-UInt AClosVec(Obj veclis,    // pointers to matrix vectors and their multiples
+static UInt AClosVec(Obj veclis,    // pointers to matrix vectors and their multiples
               Obj ovec,      // vector we compute distance to
               Obj osum,      // position of the sum vector
               UInt pos,      // recursion depth
@@ -3120,7 +3120,7 @@ UInt AClosVec(Obj veclis,    // pointers to matrix vectors and their multiples
 }
 
 
-Obj FuncA_CLOS_VEC(
+static Obj FuncA_CLOS_VEC(
     Obj self,
     Obj veclis,    // pointers to matrix vectors and their multiples
     Obj vec,       // vector we compute distance to
@@ -3152,7 +3152,7 @@ Obj FuncA_CLOS_VEC(
     return best;
 }
 
-Obj FuncA_CLOS_VEC_COORDS(
+static Obj FuncA_CLOS_VEC_COORDS(
     Obj self,
     Obj veclis,    // pointers to matrix vectors and their multiples
     Obj vec,       // vector we compute distance to
@@ -3211,7 +3211,7 @@ Obj FuncA_CLOS_VEC_COORDS(
 ** Search for new coset leaders of weight <weight>
 */
 
-UInt CosetLeadersInnerGF2(
+static UInt CosetLeadersInnerGF2(
     Obj veclis, Obj v, Obj w, UInt weight, UInt pos, Obj leaders, UInt tofind)
 {
     UInt found = 0;
@@ -3271,7 +3271,7 @@ UInt CosetLeadersInnerGF2(
 }
 
 
-Obj FuncCOSET_LEADERS_INNER_GF2(
+static Obj FuncCOSET_LEADERS_INNER_GF2(
     Obj self, Obj veclis, Obj weight, Obj tofind, Obj leaders)
 {
     Obj  v, w;
@@ -3306,7 +3306,7 @@ Obj FuncCOSET_LEADERS_INNER_GF2(
 **
 */
 
-Obj FuncRIGHTMOST_NONZERO_GF2VEC(Obj self, Obj vec)
+static Obj FuncRIGHTMOST_NONZERO_GF2VEC(Obj self, Obj vec)
 {
     return INTOBJ_INT(RightMostOneGF2Vec(vec));
 }
@@ -3317,7 +3317,7 @@ Obj FuncRIGHTMOST_NONZERO_GF2VEC(Obj self, Obj vec)
 **
 */
 
-void ResizeGF2Vec(Obj vec, UInt newlen)
+static void ResizeGF2Vec(Obj vec, UInt newlen)
 {
     UInt   len;
     UInt * ptr;
@@ -3385,7 +3385,7 @@ void ResizeGF2Vec(Obj vec, UInt newlen)
 **
 */
 
-Obj FuncRESIZE_GF2VEC(Obj self, Obj vec, Obj newlen)
+static Obj FuncRESIZE_GF2VEC(Obj self, Obj vec, Obj newlen)
 {
     Int newlen1;
     if (!IS_MUTABLE_OBJ(vec)) {
@@ -3413,7 +3413,7 @@ Obj FuncRESIZE_GF2VEC(Obj self, Obj vec, Obj newlen)
 **
 */
 
-void ShiftLeftGF2Vec(Obj vec, UInt amount)
+static void ShiftLeftGF2Vec(Obj vec, UInt amount)
 {
     UInt  len;
     UInt *ptr1, *ptr2;
@@ -3457,7 +3457,7 @@ void ShiftLeftGF2Vec(Obj vec, UInt amount)
 **
 */
 
-Obj FuncSHIFT_LEFT_GF2VEC(Obj self, Obj vec, Obj amount)
+static Obj FuncSHIFT_LEFT_GF2VEC(Obj self, Obj vec, Obj amount)
 {
     Int amount1;
     if (!IS_MUTABLE_OBJ(vec)) {
@@ -3484,7 +3484,7 @@ Obj FuncSHIFT_LEFT_GF2VEC(Obj self, Obj vec, Obj amount)
 **
 */
 
-void ShiftRightGF2Vec(Obj vec, UInt amount)
+static void ShiftRightGF2Vec(Obj vec, UInt amount)
 {
     UInt  len;
     UInt *ptr1, *ptr2, *ptr0;
@@ -3533,7 +3533,7 @@ void ShiftRightGF2Vec(Obj vec, UInt amount)
 **
 */
 
-Obj FuncSHIFT_RIGHT_GF2VEC(Obj self, Obj vec, Obj amount)
+static Obj FuncSHIFT_RIGHT_GF2VEC(Obj self, Obj vec, Obj amount)
 {
     Int amount1;
     if (!IS_MUTABLE_OBJ(vec)) {
@@ -3562,7 +3562,7 @@ Obj FuncSHIFT_RIGHT_GF2VEC(Obj self, Obj vec, Obj amount)
 **
 */
 
-void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
+static void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
 {
     UInt *       ptr1;
     const UInt * ptr2;
@@ -3615,7 +3615,7 @@ void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
 **
 */
 
-Obj FuncADD_GF2VEC_GF2VEC_SHIFTED(
+static Obj FuncADD_GF2VEC_GF2VEC_SHIFTED(
     Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
 {
     Int off1, len2a;
@@ -3649,7 +3649,7 @@ Obj FuncADD_GF2VEC_GF2VEC_SHIFTED(
 **
 */
 
-Obj ProductCoeffsGF2Vec(Obj vec1, UInt len1, Obj vec2, UInt len2)
+static Obj ProductCoeffsGF2Vec(Obj vec1, UInt len1, Obj vec2, UInt len2)
 {
     Obj          prod;
     UInt         i, e;
@@ -3693,7 +3693,7 @@ Obj ProductCoeffsGF2Vec(Obj vec1, UInt len1, Obj vec2, UInt len2)
 **
 */
 
-Obj FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+static Obj FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     UInt len1a, len2a;
     Obj  prod;
@@ -3725,7 +3725,7 @@ Obj FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 **
 */
 
-void ReduceCoeffsGF2Vec(Obj vec1, Obj vec2, UInt len2, Obj quotient)
+static void ReduceCoeffsGF2Vec(Obj vec1, Obj vec2, UInt len2, Obj quotient)
 {
     UInt         len1 = LEN_GF2VEC(vec1);
     UInt         i, j, e;
@@ -3762,7 +3762,7 @@ void ReduceCoeffsGF2Vec(Obj vec1, Obj vec2, UInt len2, Obj quotient)
 *F  FuncREDUCE_COEFFS_GF2VEC( <self>, <vec1>, <len1>, <vec2>, <len2> )
 **
 */
-Obj FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
+static Obj FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     UInt last;
     Int  len2a;
@@ -3811,7 +3811,7 @@ Obj FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 *F  FuncQUOTREM_COEFFS_GF2VEC( <self>, <vec1>, <len1>, <vec2>, <len2> )
 **
 */
-Obj FuncQUOTREM_COEFFS_GF2VEC(
+static Obj FuncQUOTREM_COEFFS_GF2VEC(
     Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     Int len2a;
@@ -3878,7 +3878,7 @@ Obj FuncQUOTREM_COEFFS_GF2VEC(
 **  vectors
 */
 
-Obj FuncSEMIECHELON_LIST_GF2VECS(Obj self, Obj mat)
+static Obj FuncSEMIECHELON_LIST_GF2VECS(Obj self, Obj mat)
 {
     UInt i, len;
     UInt width;
@@ -3913,7 +3913,7 @@ Obj FuncSEMIECHELON_LIST_GF2VECS(Obj self, Obj mat)
 **  vectors
 */
 
-Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(Obj self, Obj mat)
+static Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(Obj self, Obj mat)
 {
     UInt i, len;
     UInt width;
@@ -3944,7 +3944,7 @@ Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(Obj self, Obj mat)
 **
 */
 
-Obj FuncTRIANGULIZE_LIST_GF2VECS(Obj self, Obj mat)
+static Obj FuncTRIANGULIZE_LIST_GF2VECS(Obj self, Obj mat)
 {
     UInt i, len;
     UInt width;
@@ -3976,7 +3976,7 @@ Obj FuncTRIANGULIZE_LIST_GF2VECS(Obj self, Obj mat)
 **
 */
 
-Obj FuncRANK_LIST_GF2VECS(Obj self, Obj mat)
+static Obj FuncRANK_LIST_GF2VECS(Obj self, Obj mat)
 {
     UInt i, len;
     UInt width;
@@ -4007,7 +4007,7 @@ Obj FuncRANK_LIST_GF2VECS(Obj self, Obj mat)
 **
 */
 
-Obj FuncDETERMINANT_LIST_GF2VECS(Obj self, Obj mat)
+static Obj FuncDETERMINANT_LIST_GF2VECS(Obj self, Obj mat)
 {
     UInt i, len;
     UInt width;
@@ -4038,7 +4038,7 @@ Obj FuncDETERMINANT_LIST_GF2VECS(Obj self, Obj mat)
 **
 */
 
-Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
+static Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 {
     UInt nrowl, nrowr, nrowp, ncoll, ncolr, ncolp, ncol, i, j, k, l, mutable;
     Obj  mat, type, row, shift[BIPEB];
@@ -4131,7 +4131,7 @@ Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 *F  FuncMAT_ELM_GF2MAT( <self>, <mat>, <row>, <col> )
 **
 */
-Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
+static Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",
@@ -4166,7 +4166,7 @@ Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
 *F  FuncSET_MAT_ELM_GF2MAT( <self>, <mat>, <row>, <col>, <elm> )
 **
 */
-Obj FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
+static Obj FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
     if (!IS_POS_INTOBJ(row)) {
         ErrorMayQuit("row index must be a small positive integer, not a %s",

--- a/src/vector.c
+++ b/src/vector.c
@@ -35,7 +35,7 @@
 **  'SumIntVector' is an improved version  of  'SumSclList', which  does  not
 **  call 'SUM' if the operands are immediate integers.
 */
-Obj             SumIntVector (
+static Obj             SumIntVector (
     Obj                 elmL,
     Obj                 vecR )
 {
@@ -84,7 +84,7 @@ Obj             SumIntVector (
 **  'SumVectorInt' is an improved version  of  'SumListScl', which  does  not
 **  call 'SUM' if the operands are immediate integers.
 */
-Obj             SumVectorInt (
+static Obj             SumVectorInt (
     Obj                 vecL,
     Obj                 elmR )
 {
@@ -133,7 +133,7 @@ Obj             SumVectorInt (
 **  'SumVectorVector' is an improved version of 'SumListList', which does not
 **  call 'SUM' if the operands are immediate integers.
 */
-Obj             SumVectorVector (
+static Obj             SumVectorVector (
     Obj                 vecL,
     Obj                 vecR )
 {
@@ -204,7 +204,7 @@ Obj             SumVectorVector (
 **  'DiffIntVector'  is an improved  version of 'DiffSclList', which does not
 **  call 'DIFF' if the operands are immediate integers.
 */
-Obj             DiffIntVector (
+static Obj             DiffIntVector (
     Obj                 elmL,
     Obj                 vecR )
 {
@@ -253,7 +253,7 @@ Obj             DiffIntVector (
 **  'DiffVectorInt' is an improved  version of 'DiffListScl', which  does not
 **  call 'DIFF' if the operands are immediate integers.
 */
-Obj             DiffVectorInt (
+static Obj             DiffVectorInt (
     Obj                 vecL,
     Obj                 elmR )
 {
@@ -302,7 +302,7 @@ Obj             DiffVectorInt (
 **  'DiffVectorVector' is an improved  version of  'DiffListList', which does
 **  not call 'DIFF' if the operands are immediate integers.
 */
-Obj             DiffVectorVector (
+static Obj             DiffVectorVector (
     Obj                 vecL,
     Obj                 vecR )
 {
@@ -382,7 +382,7 @@ Obj             DiffVectorVector (
 **  'ProdIntVector'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD' if the operands are immediate integers.
 */
-Obj             ProdIntVector (
+static Obj             ProdIntVector (
     Obj                 elmL,
     Obj                 vecR )
 {
@@ -431,7 +431,7 @@ Obj             ProdIntVector (
 **  'ProdVectorInt'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD' if the operands are immediate integers.
 */
-Obj             ProdVectorInt (
+static Obj             ProdVectorInt (
     Obj                 vecL,
     Obj                 elmR )
 {
@@ -480,7 +480,7 @@ Obj             ProdVectorInt (
 **  'ProdVectorVector' is an improved version  of 'ProdListList',  which does
 **  not call 'PROD' if the operands are immediate integers.
 */
-Obj             ProdVectorVector (
+static Obj             ProdVectorVector (
     Obj                 vecL,
     Obj                 vecR )
 {
@@ -546,7 +546,7 @@ Obj             ProdVectorVector (
 **  We now need to supply a handler for this and install it as a library method,
 **  
 */
-Obj             ProdVectorMatrix (
+static Obj             ProdVectorMatrix (
     Obj                 vecL,
     Obj                 matR )
 {
@@ -648,7 +648,7 @@ Obj             ProdVectorMatrix (
     return vecP;
 }
 
-Obj FuncPROD_VECTOR_MATRIX(Obj self, Obj vec, Obj mat)
+static Obj FuncPROD_VECTOR_MATRIX(Obj self, Obj vec, Obj mat)
 {
     return ProdVectorMatrix(vec, mat);
 }
@@ -663,7 +663,7 @@ Obj FuncPROD_VECTOR_MATRIX(Obj self, Obj vec, Obj mat)
 **  vectors, because it knows what the cyclotomic zero is.
 */
 
-Obj ZeroVector( Obj vec )
+static Obj ZeroVector( Obj vec )
 {
     UInt i, len;
     Obj res;
@@ -677,7 +677,7 @@ Obj ZeroVector( Obj vec )
     return res;
 }
 
-Obj ZeroMutVector( Obj vec )
+static Obj ZeroMutVector( Obj vec )
 {
     UInt i, len;
     Obj res;

--- a/src/vector.c
+++ b/src/vector.c
@@ -35,9 +35,7 @@
 **  'SumIntVector' is an improved version  of  'SumSclList', which  does  not
 **  call 'SUM' if the operands are immediate integers.
 */
-static Obj             SumIntVector (
-    Obj                 elmL,
-    Obj                 vecR )
+static Obj SumIntVector(Obj elmL, Obj vecR)
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
@@ -84,9 +82,7 @@ static Obj             SumIntVector (
 **  'SumVectorInt' is an improved version  of  'SumListScl', which  does  not
 **  call 'SUM' if the operands are immediate integers.
 */
-static Obj             SumVectorInt (
-    Obj                 vecL,
-    Obj                 elmR )
+static Obj SumVectorInt(Obj vecL, Obj elmR)
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
@@ -133,9 +129,7 @@ static Obj             SumVectorInt (
 **  'SumVectorVector' is an improved version of 'SumListList', which does not
 **  call 'SUM' if the operands are immediate integers.
 */
-static Obj             SumVectorVector (
-    Obj                 vecL,
-    Obj                 vecR )
+static Obj SumVectorVector(Obj vecL, Obj vecR)
 {
     Obj                 vecS;           /* handle of the sum               */
     Obj *               ptrS;           /* pointer into the sum            */
@@ -204,9 +198,7 @@ static Obj             SumVectorVector (
 **  'DiffIntVector'  is an improved  version of 'DiffSclList', which does not
 **  call 'DIFF' if the operands are immediate integers.
 */
-static Obj             DiffIntVector (
-    Obj                 elmL,
-    Obj                 vecR )
+static Obj DiffIntVector(Obj elmL, Obj vecR)
 {
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
@@ -253,9 +245,7 @@ static Obj             DiffIntVector (
 **  'DiffVectorInt' is an improved  version of 'DiffListScl', which  does not
 **  call 'DIFF' if the operands are immediate integers.
 */
-static Obj             DiffVectorInt (
-    Obj                 vecL,
-    Obj                 elmR )
+static Obj DiffVectorInt(Obj vecL, Obj elmR)
 {
     Obj                 vecD;           /* handle of the difference        */
     Obj *               ptrD;           /* pointer into the difference     */
@@ -302,9 +292,7 @@ static Obj             DiffVectorInt (
 **  'DiffVectorVector' is an improved  version of  'DiffListList', which does
 **  not call 'DIFF' if the operands are immediate integers.
 */
-static Obj             DiffVectorVector (
-    Obj                 vecL,
-    Obj                 vecR )
+static Obj DiffVectorVector(Obj vecL, Obj vecR)
 {
     Obj                 vecD;           /* handle of the sum               */
     Obj *               ptrD;           /* pointer into the sum            */
@@ -382,9 +370,7 @@ static Obj             DiffVectorVector (
 **  'ProdIntVector'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD' if the operands are immediate integers.
 */
-static Obj             ProdIntVector (
-    Obj                 elmL,
-    Obj                 vecR )
+static Obj ProdIntVector(Obj elmL, Obj vecR)
 {
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
@@ -431,9 +417,7 @@ static Obj             ProdIntVector (
 **  'ProdVectorInt'  is an  improved version of 'ProdSclList', which does not
 **  call 'PROD' if the operands are immediate integers.
 */
-static Obj             ProdVectorInt (
-    Obj                 vecL,
-    Obj                 elmR )
+static Obj ProdVectorInt(Obj vecL, Obj elmR)
 {
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
@@ -480,9 +464,7 @@ static Obj             ProdVectorInt (
 **  'ProdVectorVector' is an improved version  of 'ProdListList',  which does
 **  not call 'PROD' if the operands are immediate integers.
 */
-static Obj             ProdVectorVector (
-    Obj                 vecL,
-    Obj                 vecR )
+static Obj ProdVectorVector(Obj vecL, Obj vecR)
 {
     Obj                 elmP;           /* product, result                 */
     Obj                 elmS;           /* partial sum of result           */
@@ -546,9 +528,7 @@ static Obj             ProdVectorVector (
 **  We now need to supply a handler for this and install it as a library method,
 **  
 */
-static Obj             ProdVectorMatrix (
-    Obj                 vecL,
-    Obj                 matR )
+static Obj ProdVectorMatrix(Obj vecL, Obj matR)
 {
     Obj                 vecP;           /* handle of the product           */
     Obj *               ptrP;           /* pointer into the product        */
@@ -663,7 +643,7 @@ static Obj FuncPROD_VECTOR_MATRIX(Obj self, Obj vec, Obj mat)
 **  vectors, because it knows what the cyclotomic zero is.
 */
 
-static Obj ZeroVector( Obj vec )
+static Obj ZeroVector(Obj vec)
 {
     UInt i, len;
     Obj res;
@@ -677,7 +657,7 @@ static Obj ZeroVector( Obj vec )
     return res;
 }
 
-static Obj ZeroMutVector( Obj vec )
+static Obj ZeroMutVector(Obj vec)
 {
     UInt i, len;
     Obj res;

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -360,7 +360,7 @@ static Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 ** */
 
 
-static Int IsBoundElmWPObj( Obj wp, Obj pos)
+static Int IsBoundElmWPObj(Obj wp, Obj pos)
 {
     RequireWPObj("IsBoundElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("IsBoundElmWPObj", pos);
@@ -392,7 +392,7 @@ static Int IsBoundElmWPObj( Obj wp, Obj pos)
 **  GAP  handler for IsBound  test on WP object.   Remember that bindings can
 **  evaporate in any garbage collection.
 */
-static Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
+static Obj FuncIsBoundElmWPObj(Obj self, Obj wp, Obj pos)
 {
   return IsBoundElmWPObj(wp, pos) ? True : False;
 }
@@ -405,7 +405,7 @@ static Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 **  GAP  handler for Unbind on WP object. 
 */
 
-static Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
+static Obj FuncUnbindElmWPObj(Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("UnbindElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("UnbindElmWPObj", pos);
@@ -498,9 +498,9 @@ static Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 **  same type.
 */
 
-static Obj TYPE_WPOBJ;              
+static Obj TYPE_WPOBJ;
 
-static Obj TypeWPObj( Obj wp )
+static Obj TypeWPObj(Obj wp)
 {
   return TYPE_WPOBJ;
 }
@@ -512,7 +512,7 @@ static Obj TypeWPObj( Obj wp )
 */
 static Obj IsWPObjFilt;
 
-static Obj FuncIsWPObj( Obj self, Obj wp)
+static Obj FuncIsWPObj(Obj self, Obj wp)
 {
   return (TNUM_OBJ(wp) == T_WPOBJ) ? True : False;
 }
@@ -603,9 +603,7 @@ static void CopyWPObj(TraversalState * traversal, Obj copy, Obj original)
 **
 */
 
-static Obj CopyObjWPObj (
-    Obj                 obj,
-    Int                 mut )
+static Obj CopyObjWPObj(Obj obj, Int mut)
 {
     Obj                 copy;           /* copy, result                    */
     Obj                 tmp;            /* temporary variable              */
@@ -654,7 +652,7 @@ static Obj CopyObjWPObj (
 **
 */
 
-static void MakeImmutableWPObj( Obj obj )
+static void MakeImmutableWPObj(Obj obj)
 {
 #ifdef USE_BOEHM_GC
   UInt i;
@@ -725,8 +723,7 @@ static void MakeImmutableWPObj( Obj obj )
 **
 *F  CleanObjWPObj(<obj>) . . . . . . . . . . . . . . . . . .  clean WP object
 */
-static void CleanObjWPObj (
-    Obj                 obj )
+static void CleanObjWPObj(Obj obj)
 {
     UInt                i;              /* loop variable                   */
     Obj                 elm;            /* subobject                       */

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -220,7 +220,7 @@ static inline void GROW_WPOBJ(Obj wp, UInt need)
 **  WP object.
 */
 
-Obj FuncWeakPointerObj(Obj self, Obj list)
+static Obj FuncWeakPointerObj(Obj self, Obj list)
 {
   Obj wp; 
   Int i;
@@ -270,7 +270,7 @@ Obj FuncWeakPointerObj(Obj self, Obj list)
 **  only happens if we have exclusive write access.
 */
 
-Int LengthWPObj(Obj wp)
+static Int LengthWPObj(Obj wp)
 {
   Int changed = 0;
   Int len = STORED_LEN_WPOBJ(wp);
@@ -301,7 +301,7 @@ Int LengthWPObj(Obj wp)
 **  collection, as trailing items may evaporate.
 */
 
-Obj FuncLengthWPObj(Obj self, Obj wp)
+static Obj FuncLengthWPObj(Obj self, Obj wp)
 {
     RequireWPObj("LengthWPObj", wp);
     return INTOBJ_INT(LengthWPObj(wp));
@@ -316,7 +316,7 @@ Obj FuncLengthWPObj(Obj self, Obj wp)
 **  a WP object.
 */
 
-Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
+static Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 {
     RequireWPObj("SetElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("SetElmWPObj", pos);
@@ -360,7 +360,7 @@ Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 ** */
 
 
-Int IsBoundElmWPObj( Obj wp, Obj pos)
+static Int IsBoundElmWPObj( Obj wp, Obj pos)
 {
     RequireWPObj("IsBoundElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("IsBoundElmWPObj", pos);
@@ -392,7 +392,7 @@ Int IsBoundElmWPObj( Obj wp, Obj pos)
 **  GAP  handler for IsBound  test on WP object.   Remember that bindings can
 **  evaporate in any garbage collection.
 */
-Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
+static Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 {
   return IsBoundElmWPObj(wp, pos) ? True : False;
 }
@@ -405,7 +405,7 @@ Obj FuncIsBoundElmWPObj( Obj self, Obj wp, Obj pos)
 **  GAP  handler for Unbind on WP object. 
 */
 
-Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
+static Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("UnbindElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("UnbindElmWPObj", pos);
@@ -439,7 +439,7 @@ Obj FuncUnbindElmWPObj( Obj self, Obj wp, Obj pos)
 **
 **  Provide implementation of 'ElmDefListFuncs'.
 */
-Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
+static Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 {
     GAP_ASSERT(TNUM_OBJ(wp) == T_WPOBJ);
     GAP_ASSERT(ipos >= 1);
@@ -481,7 +481,7 @@ Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 **  IsBound, relying on the fact  that fail can never  dissapear in a garbage
 **  collection.
 */
-Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
+static Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 {
     RequireWPObj("ElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("ElmWPObj", pos);
@@ -498,9 +498,9 @@ Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 **  same type.
 */
 
-Obj TYPE_WPOBJ;              
+static Obj TYPE_WPOBJ;              
 
-Obj TypeWPObj( Obj wp )
+static Obj TypeWPObj( Obj wp )
 {
   return TYPE_WPOBJ;
 }
@@ -512,7 +512,7 @@ Obj TypeWPObj( Obj wp )
 */
 static Obj IsWPObjFilt;
 
-Obj FuncIsWPObj( Obj self, Obj wp)
+static Obj FuncIsWPObj( Obj self, Obj wp)
 {
   return (TNUM_OBJ(wp) == T_WPOBJ) ? True : False;
 }
@@ -555,7 +555,7 @@ static void SweepWeakPointerObj( Bag *src, Bag *dst, UInt len)
 
 #ifdef USE_THREADSAFE_COPYING
 #ifndef WARD_ENABLED
-void TraverseWPObj(TraversalState * traversal, Obj obj)
+static void TraverseWPObj(TraversalState * traversal, Obj obj)
 {
     UInt  len = STORED_LEN_WPOBJ(obj);
     const Obj * ptr = CONST_ADDR_OBJ(obj) + 1;
@@ -569,7 +569,7 @@ void TraverseWPObj(TraversalState * traversal, Obj obj)
     }
 }
 
-void CopyWPObj(TraversalState * traversal, Obj copy, Obj original)
+static void CopyWPObj(TraversalState * traversal, Obj copy, Obj original)
 {
     UInt  len = STORED_LEN_WPOBJ(original);
     const Obj * ptr = CONST_ADDR_OBJ(original) + 1;
@@ -603,7 +603,7 @@ void CopyWPObj(TraversalState * traversal, Obj copy, Obj original)
 **
 */
 
-Obj CopyObjWPObj (
+static Obj CopyObjWPObj (
     Obj                 obj,
     Int                 mut )
 {
@@ -654,7 +654,7 @@ Obj CopyObjWPObj (
 **
 */
 
-void MakeImmutableWPObj( Obj obj )
+static void MakeImmutableWPObj( Obj obj )
 {
 #ifdef USE_BOEHM_GC
   UInt i;
@@ -725,7 +725,7 @@ void MakeImmutableWPObj( Obj obj )
 **
 *F  CleanObjWPObj(<obj>) . . . . . . . . . . . . . . . . . .  clean WP object
 */
-void CleanObjWPObj (
+static void CleanObjWPObj (
     Obj                 obj )
 {
     UInt                i;              /* loop variable                   */
@@ -748,7 +748,7 @@ void CleanObjWPObj (
 *F  SaveWPObj(<wpobj>)
 */
 
-void SaveWPObj(Obj wpobj)
+static void SaveWPObj(Obj wpobj)
 {
     UInt len = STORED_LEN_WPOBJ(wpobj);
     SaveUInt(len);
@@ -762,7 +762,7 @@ void SaveWPObj(Obj wpobj)
 *F  LoadWPObj(<wpobj>)
 */
 
-void LoadWPObj(Obj wpobj)
+static void LoadWPObj(Obj wpobj)
 {
     const UInt len = LoadUInt();
     STORE_LEN_WPOBJ(wpobj, len);


### PR DESCRIPTION
This PR is somewhat dual to PR #3183 resp. #3202: it adds `static` to as many functions and variables as possible. This helps to find dead code (see e.g. PR #3203), may help compilers to do better optimizations, and also is a step towards defining a larger "libgap" API, by "hiding" away stuff that we do not explicitly want to export (this makes it harder to "cheat" and call those functions anyway; now people who want to do that hopefully will instead talk to us to get us to export them, giving us a chance to define a proper API).

The second commit is optional and clang-formats the first commit, based on the idea that if we touch those lines anyway, we might as well reformat them, too.