### PR TITLE
Enable Backtraces with --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,7 +224,8 @@ dnl User setting: Debug mode (off by default)
 dnl
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug], [enable debug mode])],
-    [AC_DEFINE([GAP_KERNEL_DEBUG], [1], [define if building in debug mode])],
+    [AC_DEFINE([GAP_KERNEL_DEBUG], [1], [define if building in debug mode]),
+     AC_DEFINE([PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])],
     [enable_debug=no]
     )
 AC_MSG_CHECKING([whether to enable debug mode])

--- a/src/debug.c
+++ b/src/debug.c
@@ -67,10 +67,8 @@ void InstallBacktraceHandlers(void)
 {
     signal(SIGSEGV, BacktraceHandler);
     signal(SIGBUS, BacktraceHandler);
-    signal(SIGINT, BacktraceHandler);
     signal(SIGABRT, BacktraceHandler);
     signal(SIGFPE, BacktraceHandler);
-    signal(SIGTERM, BacktraceHandler);
 }
 
 #endif


### PR DESCRIPTION
This enables backtraces when GAP crashes, when GAP is compiled with --enable-debug. This will be (I hope!) particularly useful when GAP crashes on travis.

At the same time I made it so GAP will only print a backtrace when it actually crashes, not just because it was killed, or was terminated.