### PR TITLE
Print issue tracker, maintainers and contributors in package banners

### DIFF
--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -52,19 +52,20 @@ gap> Display(DefaultPackageBannerString(rec()));
 -----------------------------------------------------------------------------
 
 
-#
+# 
 gap> pkginfo := rec(
 >         PackageName := "TestPkg",
 >         Version := "1.0",
 >         PackageWWWHome := "https://www.gap-system.org",
 >         PackageDoc := [ rec( LongTitle := "A test package" ) ],
 >         Persons := [ rec( IsAuthor := true,
+>                           IsMaintainer := true,
 >                           FirstNames := "Lord",
 >                           LastName := "Vader",
 >                           WWWHome := "https://www.gap-system.org/~darth"
 >                           ) ]);;
 
-#
+# just one author & maintainer
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
 Loading  TestPkg 1.0 (A test package)
@@ -73,39 +74,120 @@ Homepage: https://www.gap-system.org
 -----------------------------------------------------------------------------
 
 
-#
-gap> Add(pkginfo.Persons, rec( IsAuthor := true, FirstNames := "Luke",
->                           LastName := "Skywalker", Email := "luke.skywalker@gap-system.org" ));
+# add a maintainer who is not an author
+gap> Add(pkginfo.Persons, rec( IsAuthor := false, IsMaintainer := true,
+>                           FirstNames := "Luke", LastName := "Skywalker",
+>                           Email := "luke.skywalker@gap-system.org" ));
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
 Loading  TestPkg 1.0 (A test package)
-by Lord Vader (https://www.gap-system.org/~darth) and
+by Lord Vader (https://www.gap-system.org/~darth).
+maintained by:
+   Lord Vader (https://www.gap-system.org/~darth) and
    Luke Skywalker (luke.skywalker@gap-system.org).
 Homepage: https://www.gap-system.org
 -----------------------------------------------------------------------------
 
 
-#
-gap> Add(pkginfo.Persons, rec( IsAuthor := true, FirstNames := "Leia", LastName := "Organa" ));
+# add an author who is not a maintainer
+gap> Add(pkginfo.Persons, rec( IsAuthor := true, IsMaintainer := false,
+>                           FirstNames := "Leia", LastName := "Organa" ));
+gap> Display(DefaultPackageBannerString(pkginfo));
+-----------------------------------------------------------------------------
+Loading  TestPkg 1.0 (A test package)
+by Lord Vader (https://www.gap-system.org/~darth) and
+   Leia Organa.
+maintained by:
+   Lord Vader (https://www.gap-system.org/~darth) and
+   Luke Skywalker (luke.skywalker@gap-system.org).
+Homepage: https://www.gap-system.org
+-----------------------------------------------------------------------------
+
+
+# add a contributor
+gap> Add(pkginfo.Persons, rec( IsAuthor := false, IsMaintainer := false,
+>                           FirstNames := "Yoda", LastName := "",
+>                           WWWHome := "https://www.gap-system.org/~yoda"));
+gap> Display(DefaultPackageBannerString(pkginfo));
+-----------------------------------------------------------------------------
+Loading  TestPkg 1.0 (A test package)
+by Lord Vader (https://www.gap-system.org/~darth) and
+   Leia Organa.
+with contributions by:
+   Yoda  (https://www.gap-system.org/~yoda).
+maintained by:
+   Lord Vader (https://www.gap-system.org/~darth) and
+   Luke Skywalker (luke.skywalker@gap-system.org).
+Homepage: https://www.gap-system.org
+-----------------------------------------------------------------------------
+
+
+# test what happens if all are authors and maintainers
+gap> for p in pkginfo.Persons do p.IsAuthor:=true; p.IsMaintainer:=true; od;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
 Loading  TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth),
-   Luke Skywalker (luke.skywalker@gap-system.org), and
-   Leia Organa.
+   Luke Skywalker (luke.skywalker@gap-system.org),
+   Leia Organa, and
+   Yoda  (https://www.gap-system.org/~yoda).
 Homepage: https://www.gap-system.org
 -----------------------------------------------------------------------------
 
 
-#
+# test what happens if all are authors but not maintainers
+gap> for p in pkginfo.Persons do p.IsAuthor:=true; p.IsMaintainer:=false; od;
+gap> Display(DefaultPackageBannerString(pkginfo));
+-----------------------------------------------------------------------------
+Loading  TestPkg 1.0 (A test package)
+by Lord Vader (https://www.gap-system.org/~darth),
+   Luke Skywalker (luke.skywalker@gap-system.org),
+   Leia Organa, and
+   Yoda  (https://www.gap-system.org/~yoda).
+Homepage: https://www.gap-system.org
+-----------------------------------------------------------------------------
+
+
+# test what happens if all are maintainers but not authors
 gap> for p in pkginfo.Persons do p.IsAuthor:=false; p.IsMaintainer:=true; od;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
 Loading  TestPkg 1.0 (A test package)
-maintained by Lord Vader (https://www.gap-system.org/~darth),
-              Luke Skywalker (luke.skywalker@gap-system.org), and
-              Leia Organa.
+maintained by:
+   Lord Vader (https://www.gap-system.org/~darth),
+   Luke Skywalker (luke.skywalker@gap-system.org),
+   Leia Organa, and
+   Yoda  (https://www.gap-system.org/~yoda).
 Homepage: https://www.gap-system.org
+-----------------------------------------------------------------------------
+
+
+# test what happens if all are contributors
+gap> for p in pkginfo.Persons do p.IsAuthor:=false; p.IsMaintainer:=false; od;
+gap> Display(DefaultPackageBannerString(pkginfo));
+-----------------------------------------------------------------------------
+Loading  TestPkg 1.0 (A test package)
+with contributions by:
+   Lord Vader (https://www.gap-system.org/~darth),
+   Luke Skywalker (luke.skywalker@gap-system.org),
+   Leia Organa, and
+   Yoda  (https://www.gap-system.org/~yoda).
+Homepage: https://www.gap-system.org
+-----------------------------------------------------------------------------
+
+
+# test IssueTrackerURL
+gap> pkginfo.IssueTrackerURL := "https://issues.gap-system.org/";;
+gap> Display(DefaultPackageBannerString(pkginfo));
+-----------------------------------------------------------------------------
+Loading  TestPkg 1.0 (A test package)
+with contributions by:
+   Lord Vader (https://www.gap-system.org/~darth),
+   Luke Skywalker (luke.skywalker@gap-system.org),
+   Leia Organa, and
+   Yoda  (https://www.gap-system.org/~yoda).
+Homepage: https://www.gap-system.org
+Report issues at https://issues.gap-system.org/
 -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
If available, print the issue tracker URL as part of the default package banner. Also, if the list of package maintainers is non-empty and different from the list of package authors, always print it. Both changes are meant to help users to identify whom to contact about issues.

Finally, any people in the person record who are neither author nor maintainer are listed under "with contributions by". This matches what GitHubPagesForGAP does, and how various packages seem to use these fields. It means that we now really list all people in the persons record at least once in the default package banner.

Some examples:

### All persons are both author and maintainer: no change
```
Loading  AutoDoc 2018.09.20 (Generate documentation from GAP source code)
by Sebastian Gutsche (http://wwwb.math.rwth-aachen.de/~gutsche/) and
   Max Horn (http://www.quendi.de/math).
Homepage: https://gap-packages.github.io/AutoDoc
Report issues at https://github.com/gap-packages/AutoDoc/issues
```

### List of authors and maintainers differ
```
Loading  AutPGrp 1.10 (Computing the Automorphism Group of a p-Group)
by Bettina Eick (http://www.icm.tu-bs.de/~beick) and
   Eamonn O'Brien (http://www.math.auckland.ac.nz/~obrien).
maintained by:
   Bettina Eick (http://www.icm.tu-bs.de/~beick) and
   Max Horn (http://www.quendi.de/math).
Homepage: https://gap-packages.github.io/autpgrp/
Report issues at https://github.com/gap-packages/autpgrp/issues
```
```
Loading  AtlasRep 1.5.1 (An Atlas of Group Representations)
by Robert A. Wilson (http://www.maths.qmw.ac.uk/~raw),
   Richard A. Parker (richpark@gmx.co.uk),
   Simon Nickerson (http://nickerson.org.uk/groups),
   John N. Bray (http://www.maths.qmw.ac.uk/~jnb), and
   Thomas Breuer (http://www.math.rwth-aachen.de/~Thomas.Breuer).
maintained by:
   Thomas Breuer (http://www.math.rwth-aachen.de/~Thomas.Breuer).
Homepage: http://www.math.rwth-aachen.de/~Thomas.Breuer/atlasrep
```
```
Loading  IO 4.5.4 (Bindings for low level C library I/O routines)
by Max Neunhöffer (http://www-groups.mcs.st-and.ac.uk/~neunhoef).
maintained by:
   Max Horn (http://www.quendi.de/math).
Homepage: https://gap-packages.github.io/io
Report issues at https://github.com/gap-packages/io/issues
```

### Packages "with contributions by"

Some packages have "contributors", e.g. in Homalge (ping to @mohamed-barakat). I think this change would also allow `semigroups`, `recog` and `xmod` to switch to the default package banner.
```
Loading  HomalgToCAS 2018.06.15 (A window to the outer world)
by Thomas Bächler (http://wwwb.math.rwth-aachen.de/~thomas/),
   Mohamed Barakat (http://www.mathematik.uni-kl.de/~barakat/),
   Simon Görtzen (http://wwwb.math.rwth-aachen.de/~simon/),
   Sebastian Gutsche (http://wwwb.math.rwth-aachen.de/~gutsche/), and
   Vinay Wagh (http://www.iitg.ernet.in/vinay.wagh/).
with contributions by:
   Thomas Breuer (http://www.math.rwth-aachen.de/~Thomas.Breuer/) and
   Frank Lübeck (http://www.math.rwth-aachen.de/~Frank.Luebeck/).
maintained by:
   Mohamed Barakat (http://www.mathematik.uni-kl.de/~barakat/) and
   Simon Görtzen (http://wwwb.math.rwth-aachen.de/~simon/).
Homepage: http://homalg-project.github.io/homalg_project/HomalgToCAS/
```

```
Loading  Digraphs 0.13.0 (Digraphs - Methods for digraphs)
by Jan De Beule (http://homepages.vub.ac.be/~jdbeule/),
   Julius Jonusas (http://www-groups.mcs.st-andrews.ac.uk/~julius/),
   James Mitchell (http://goo.gl/ZtViV6),
   Michael Torpey (http://www-groups.mcs.st-andrews.ac.uk/~mct25/), and
   Wilf Wilson (http://wilf.me).
with contributions by:
   Stuart Burrell (sb235@st-andrews.ac.uk),
   Luke Elliott (le27@st-andrews.ac.uk),
   Christopher Jefferson (http://caj.host.cs.st-andrews.ac.uk),
   Markus Pfeiffer (https://www.morphism.de/~markusp/),
   Christopher Russell (cr66@st-andrews.ac.uk), and
   Finn Smith (fls3@st-andrews.ac.uk).
maintained by:
   James Mitchell (http://goo.gl/ZtViV6).
Homepage: https://gap-packages.github.io/Digraphs
Report issues at https://github.com/gap-packages/Digraphs/issues
```

```
Loading  Guarana 0.96.1 (Applications of Lie methods for computations with infinite polycyclic groups)
by Björn Assmann (bjoern@mcs.st-and.ac.uk).
with contributions by:
   John McDermott (jjm@mcs.st-and.ac.uk).
maintained by:
   The GAP Team (support@gap-system.org).
Homepage: https://gap-packages.github.io/guarana/
Report issues at https://github.com/gap-packages/guarana/issues
```

