### PR TITLE
kernel: fix another crash caused by function body values

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1583,7 +1583,8 @@ void CodeIntExpr(Obj val)
     else {
         GAP_ASSERT(TNUM_OBJ(val) == T_INTPOS || TNUM_OBJ(val) == T_INTNEG);
         expr = NewExpr( T_INT_EXPR, sizeof(UInt) );
-        WRITE_EXPR(expr, 0, PushValue(val));
+        Int ix = PushValue(val);
+        WRITE_EXPR(expr, 0, ix);
     }
 
     /* push the expression                                                 */
@@ -1781,7 +1782,8 @@ void CodeStringExpr (
     GAP_ASSERT(IS_STRING_REP(str));
 
     Expr string = NewExpr( T_STRING_EXPR, sizeof(UInt) );
-    WRITE_EXPR(string, 0, PushValue(str));
+    Int ix = PushValue(str);
+    WRITE_EXPR(string, 0, ix);
     PushExpr( string );
 }
 


### PR DESCRIPTION
The bad code did `WRITE_EXPR(expr, 0, PushValue(val));` which expands to

    ADDR_EXPR(expr)[0] = PushValue(val));

But this first computes the address on the left side, then calls PushValue;
if the latter then triggers a garbage collection, the address may become
invalid, and we get a crash, or worse: data corruption.