### PR TITLE
Fix Unbound global variable warning

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -61,8 +61,10 @@ typedef struct GAPState {
     UInt   NrError;
     UInt   NrErrLine;
     UInt   Symbol;
-    UInt   SymbolStartPos;
-    UInt   SymbolStartLine;
+
+    // Track the last 3 symbols, for 'Unbound global' warnings
+    UInt   SymbolStartPos[3];
+    UInt   SymbolStartLine[3];
 
     // Used for recording the first line of the fragment of code currently
     // begin interpreted, so the current line is outputted when profiling

--- a/src/read.c
+++ b/src/read.c
@@ -780,7 +780,8 @@ static void ReadCallVarAss(TypSymbolSet follow, Char mode)
           ||  ELM_REC(GAPInfo,WarnOnUnboundGlobalsRNam) != False )
       && ! SyCompilePlease )        // Not compiling
     {
-        SyntaxWarning("Unbound global variable");
+        // Need to pass an offset, because we have already parsed more tokens
+        SyntaxWarningWithOffset("Unbound global variable", 2);
     }
 
     /* followed by one or more selectors                                   */

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -278,10 +278,24 @@ int IsKeyword(const char * str);
 **  Both functions should only be called from the scanner or reader, but not
 **  from e.g. the interpreter or coder, let alone any other parts of GAP.
 **
+**  The 'WithOffset' variants allow marking a previously parsed token as
+**  the syntax error. This is used by 'Unbound global variable', as GAP
+**  does not know if a variable is unbound until another 2 tokens are read.
+**
 */
-void SyntaxError(const Char * msg);
+void SyntaxErrorWithOffset(const Char * msg, Int tokenoffset);
 
-void SyntaxWarning(const Char * msg);
+void SyntaxWarningWithOffset(const Char * msg, Int tokenoffset);
+
+EXPORT_INLINE void SyntaxError(const Char * msg)
+{
+    SyntaxErrorWithOffset(msg, 0);
+}
+
+EXPORT_INLINE void SyntaxWarning(const Char * msg)
+{
+    SyntaxWarningWithOffset(msg, 0);
+}
 
 
 /****************************************************************************

--- a/tst/testbugfix/2018-06-29-CurrLHSGVar.tst
+++ b/tst/testbugfix/2018-06-29-CurrLHSGVar.tst
@@ -6,7 +6,7 @@ gap> for i in [ 1 .. 10 ] do
 > od;
 Syntax warning: Unbound global variable in stream:3
     xxx := List( [], x -> string );
-                                 ^
+                          ^^^^^^
 
 # ... but this did not; now it does
 gap> Unbind(string);
@@ -16,4 +16,4 @@ gap> for i in [ 1 .. 10 ] do
 > od;
 Syntax warning: Unbound global variable in stream:3
     List( [], x -> string );
-                          ^
+                   ^^^^^^

--- a/tst/testinstall/auto.tst
+++ b/tst/testinstall/auto.tst
@@ -4,7 +4,7 @@ gap> g := function(x) Print("Checkg\n"); end;;
 gap> f := function(x) Print("Checkf\n"); testglobalvar := 3; end;;
 Syntax warning: Unbound global variable in stream:1
 f := function(x) Print("Checkf\n"); testglobalvar := 3; end;;
-                                                  ^^
+                                    ^^^^^^^^^^^^^
 gap> AUTO(g, 1, "testglobalvar");
 gap> IsAutoGlobal("testglobalvar");
 true

--- a/tst/testinstall/bound.tst
+++ b/tst/testinstall/bound.tst
@@ -30,13 +30,13 @@ Error, Variable: 'BADVARNAME' must have an assigned value
 gap> f := ({} -> BADVARNAME );;
 Syntax warning: Unbound global variable in stream:1
 f := ({} -> BADVARNAME );;
-                       ^
+            ^^^^^^^^^^
 gap> f();
 Error, Variable: 'BADVARNAME' must have an assigned value
 gap> f := ({} -> IsBound(BADVARNAME[BADLISTNAME]) );;
 Syntax warning: Unbound global variable in stream:1
 f := ({} -> IsBound(BADVARNAME[BADLISTNAME]) );;
-                                          ^
+                               ^^^^^^^^^^^
 gap> f();
 Error, Variable: 'BADVARNAME' must have an assigned value
 

--- a/tst/testinstall/unbound.tst
+++ b/tst/testinstall/unbound.tst
@@ -1,0 +1,46 @@
+#@local f
+gap> START_TEST("unbound.tst");
+gap> f := function() unknownvarname := 1; end;;
+Syntax warning: Unbound global variable in stream:1
+f := function() unknownvarname := 1; end;;
+                ^^^^^^^^^^^^^^
+gap> f := function() unknownvarname.test := 2; end;;
+Syntax warning: Unbound global variable in stream:1
+f := function() unknownvarname.test := 2; end;;
+                ^^^^^^^^^^^^^^
+gap> f := function() unknownvarname1 := unknownvarname2; end;;
+Syntax warning: Unbound global variable in stream:1
+f := function() unknownvarname1 := unknownvarname2; end;;
+                ^^^^^^^^^^^^^^^
+Syntax warning: Unbound global variable in stream:1
+f := function() unknownvarname1 := unknownvarname2; end;;
+                                   ^^^^^^^^^^^^^^^
+
+# Cases where we can't get the right marker, check we do not crash
+gap> f := function() unknownvarname
+> := 2; end;;
+Syntax warning: Unbound global variable in stream:2
+:= 2; end;;
+ ^
+gap> f := function() unknownva\
+> name := 2; end;;
+Syntax warning: Unbound global variable in stream:2
+name := 2; end;;
+ ^^^^^^
+gap> f := function() unknownva\
+> name
+> := 2; end;;
+Syntax warning: Unbound global variable in stream:3
+:= 2; end;;
+ ^
+
+# Not global variable problems
+gap> f := function(unknownname) unknownname := 2; end;;
+gap> f := function() unknownname -> 3; end;;
+Syntax error: Function literal in impossible context in stream:1
+f := function() unknownname -> 3; end;;
+                            ^^
+gap> f := function() return unknownname -> 3; end;;
+
+#
+gap> STOP_TEST( "unknown.tst", 1);

--- a/tst/testinstall/weakptr-badargs.tst
+++ b/tst/testinstall/weakptr-badargs.tst
@@ -4,7 +4,7 @@ gap> START_TEST("weakptr-badargs.tst");
 gap> w := WeakPointerObject([1,,3,4]);
 Syntax warning: Unbound global variable in stream:1
 w := WeakPointerObject([1,,3,4]);
-                      ^
+     ^^^^^^^^^^^^^^^^^
 Error, Variable: 'WeakPointerObject' must have a value
 gap> w := WeakPointerObj([1,,3,4]);;
 gap> SetElmWPObj(w, 0, 0);
@@ -37,7 +37,7 @@ Error, ElmWPObj: <wp> must be a weak pointer object (not a list (plain,empty))
 gap> IsBoundWPObj(w, 0);
 Syntax warning: Unbound global variable in stream:1
 IsBoundWPObj(w, 0);
-            ^
+^^^^^^^^^^^^
 Error, Variable: 'IsBoundWPObj' must have a value
 gap> IsBoundElmWPObj(w, 0);
 Error, IsBoundElmWPObj: <pos> must be a positive small integer (not the intege\

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -24,14 +24,14 @@ brk> Unbind(x);
 brk> x:=42;
 Syntax warning: Unbound global variable in *errin*:4
 x:=42;
- ^^
+^
 42
 brk> IsBound(x);
 true
 brk> unbound_global;
 Syntax warning: Unbound global variable in *errin*:6
 unbound_global;
-              ^
+^^^^^^^^^^^^^^
 Error, Variable: 'unbound_global' must have a value in
   Error( "breakpoint" ); at *stdin*:9 called from 
 g( 10 ) at *stdin*:12 called from


### PR DESCRIPTION
This fixes the fact that the ^^^^ markers on unbound globals would point to the wrong place.