### PR TITLE
Start using C++ templates for partial perms kernel code

### DIFF
--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -1577,107 +1577,57 @@ static Obj FuncRIGHT_ONE_PPERM(Obj self, Obj f)
 }
 
 // f<=g if and only if f is a restriction of g
-static Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
+template <typename TF, typename TG>
+static Obj NaturalLeqPartialPerm(Obj f, Obj g)
 {
     UInt   def, deg, i, j, rank;
-    UInt2 *ptf2, *ptg2;
-    UInt4 *ptf4, *ptg4;
+    TF *   ptf;
+    TG *   ptg;
     Obj    dom;
 
+    def = DEG_PPERM<TF>(f);
+    ptf = ADDR_PPERM<TF>(f);
+    if (def == 0)
+        return True;
+
+    deg = DEG_PPERM<TG>(g);
+    ptg = ADDR_PPERM<TG>(g);
+    if (DOM_PPERM(f) == NULL) {
+        for (i = 0; i < def; i++) {
+            if (ptf[i] != 0 && ptf[i] != IMAGEPP(i + 1, ptg, deg))
+                return False;
+        }
+    }
+    else {
+        dom = DOM_PPERM(f);
+        rank = RANK_PPERM<TF>(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i));
+            if (ptf[j - 1] != IMAGEPP(j, ptg, deg))
+                return False;
+        }
+    }
+
+    return True;
+}
+
+static Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
+{
     RequirePartialPerm("NaturalLeqPartialPerm", f);
     RequirePartialPerm("NaturalLeqPartialPerm", g);
 
-    if (TNUM_OBJ(f) == T_PPERM2) {
-        def = DEG_PPERM2(f);
-        ptf2 = ADDR_PPERM2(f);
-        if (def == 0)
-            return True;
-
-        if (TNUM_OBJ(g) == T_PPERM2) {
-            deg = DEG_PPERM2(g);
-            ptg2 = ADDR_PPERM2(g);
-            if (DOM_PPERM(f) == NULL) {
-                for (i = 0; i < def; i++) {
-                    if (ptf2[i] != 0 && ptf2[i] != IMAGEPP(i + 1, ptg2, deg))
-                        return False;
-                }
-            }
-            else {
-                dom = DOM_PPERM(f);
-                rank = RANK_PPERM2(f);
-                for (i = 1; i <= rank; i++) {
-                    j = INT_INTOBJ(ELM_PLIST(dom, i));
-                    if (ptf2[j - 1] != IMAGEPP(j, ptg2, deg))
-                        return False;
-                }
-            }
-        }
-        else {
-            deg = DEG_PPERM4(g);
-            ptg4 = ADDR_PPERM4(g);
-            if (DOM_PPERM(f) == NULL) {
-                for (i = 0; i < def; i++) {
-                    if (ptf2[i] != 0 && ptf2[i] != IMAGEPP(i + 1, ptg4, deg))
-                        return False;
-                }
-            }
-            else {
-                dom = DOM_PPERM(f);
-                rank = RANK_PPERM2(f);
-                for (i = 1; i <= rank; i++) {
-                    j = INT_INTOBJ(ELM_PLIST(dom, i));
-                    if (ptf2[j - 1] != IMAGEPP(j, ptg4, deg))
-                        return False;
-                }
-            }
-        }
+    if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM2) {
+        return NaturalLeqPartialPerm<UInt2, UInt2>(f, g);
     }
-    else if (TNUM_OBJ(f) == T_PPERM4) {
-        def = DEG_PPERM4(f);
-        ptf4 = ADDR_PPERM4(f);
-        if (def == 0)
-            return True;
-
-        if (TNUM_OBJ(g) == T_PPERM2) {
-            deg = DEG_PPERM2(g);
-            ptg2 = ADDR_PPERM2(g);
-            if (DOM_PPERM(f) == NULL) {
-                for (i = 0; i < def; i++) {
-                    if (ptf4[i] != 0 && ptf4[i] != IMAGEPP(i + 1, ptg2, deg))
-                        return False;
-                }
-            }
-            else {
-                dom = DOM_PPERM(f);
-                rank = RANK_PPERM4(f);
-                for (i = 1; i <= rank; i++) {
-                    j = INT_INTOBJ(ELM_PLIST(dom, i));
-                    if (ptf4[j - 1] != IMAGEPP(j, ptg2, deg))
-                        return False;
-                }
-            }
-        }
-        else {
-            deg = DEG_PPERM4(g);
-            ptg4 = ADDR_PPERM4(g);
-            if (DOM_PPERM(f) == NULL) {
-                for (i = 0; i < def; i++) {
-                    if (ptf4[i] != 0 && ptf4[i] != IMAGEPP(i + 1, ptg4, deg))
-                        return False;
-                }
-            }
-            else {
-                dom = DOM_PPERM(f);
-                rank = RANK_PPERM4(f);
-                for (i = 1; i <= rank; i++) {
-                    j = INT_INTOBJ(ELM_PLIST(dom, i));
-                    if (ptf4[j - 1] != IMAGEPP(j, ptg4, deg))
-                        return False;
-                }
-            }
-        }
+    else if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM4) {
+        return NaturalLeqPartialPerm<UInt2, UInt4>(f, g);
     }
-    return True;
+    else if (TNUM_OBJ(f) == T_PPERM4 && TNUM_OBJ(g) == T_PPERM2) {
+        return NaturalLeqPartialPerm<UInt4, UInt2>(f, g);
+    }
+    else /* if (TNUM_OBJ(f) == T_PPERM4 && TNUM_OBJ(g) == T_PPERM4) */ {
+        return NaturalLeqPartialPerm<UInt4, UInt4>(f, g);
+    }
 }
 
 static Obj FuncJOIN_IDEM_PPERMS(Obj self, Obj f, Obj g)

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -3509,110 +3509,62 @@ static Obj ProdPerm2PPerm4(Obj p, Obj f)
 }
 
 // the inverse of a partial perm
+template <typename Res, typename T>
+static Obj InvPPerm(Obj f)
+{
+    ASSERT_IS_PPERM<T>(f);
+
+    UInt    deg, codeg, i, j, rank;
+    const T * ptf;
+    Res *     ptinv;
+    Obj     inv, dom;
+
+    deg = DEG_PPERM<T>(f);
+    codeg = CODEG_PPERM<T>(f);
+
+    GAP_ASSERT((deg < 65536) == (sizeof(Res) == 2));
+
+    inv = NEW_PPERM<Res>(codeg);
+    ptf = CONST_ADDR_PPERM<T>(f);
+    ptinv = ADDR_PPERM<Res>(inv);
+    dom = DOM_PPERM(f);
+    if (dom == NULL) {
+        for (i = 0; i < deg; i++)
+            if (ptf[i] != 0)
+                ptinv[ptf[i] - 1] = i + 1;
+    }
+    else {
+        rank = RANK_PPERM<T>(f);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptinv[ptf[j] - 1] = j + 1;
+        }
+    }
+    SET_CODEG_PPERM<Res>(inv, deg);
+
+    return inv;
+}
+
 static Obj InvPPerm2(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-
-    UInt    deg, codeg, i, j, rank;
-    UInt2 * ptf, *ptinv2;
-    UInt4 * ptinv4;
-    Obj     inv, dom;
-
-    deg = DEG_PPERM2(f);
-    codeg = CODEG_PPERM2(f);
-
-    if (deg < 65536) {
-        inv = NEW_PPERM2(codeg);
-        ptf = ADDR_PPERM2(f);
-        ptinv2 = ADDR_PPERM2(inv);
-        if (DOM_PPERM(f) == NULL) {
-            for (i = 0; i < deg; i++)
-                if (ptf[i] != 0)
-                    ptinv2[ptf[i] - 1] = i + 1;
-        }
-        else {
-            dom = DOM_PPERM(f);
-            rank = RANK_PPERM2(f);
-            for (i = 1; i <= rank; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptinv2[ptf[j] - 1] = j + 1;
-            }
-        }
-        SET_CODEG_PPERM2(inv, deg);
+    if (DEG_PPERM2(f) < 65536) {
+        return InvPPerm<UInt2, UInt2>(f);
     }
     else {
-        inv = NEW_PPERM4(codeg);
-        ptf = ADDR_PPERM2(f);
-        ptinv4 = ADDR_PPERM4(inv);
-        if (DOM_PPERM(f) == NULL) {
-            for (i = 0; i < deg; i++)
-                if (ptf[i] != 0)
-                    ptinv4[ptf[i] - 1] = i + 1;
-        }
-        else {
-            dom = DOM_PPERM(f);
-            rank = RANK_PPERM2(f);
-            for (i = 1; i <= rank; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptinv4[ptf[j] - 1] = j + 1;
-            }
-        }
-        SET_CODEG_PPERM4(inv, deg);
+        return InvPPerm<UInt4, UInt2>(f);
     }
-    return inv;
 }
 
 static Obj InvPPerm4(Obj f)
 {
     GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-
-    UInt    deg, codeg, i, j, rank;
-    UInt2 * ptinv2;
-    UInt4 * ptf, *ptinv4;
-    Obj     inv, dom;
-
-    deg = DEG_PPERM4(f);
-    codeg = CODEG_PPERM4(f);
-
-    if (deg < 65536) {
-        inv = NEW_PPERM2(codeg);
-        ptf = ADDR_PPERM4(f);
-        ptinv2 = ADDR_PPERM2(inv);
-        if (DOM_PPERM(f) == NULL) {
-            for (i = 0; i < deg; i++)
-                if (ptf[i] != 0)
-                    ptinv2[ptf[i] - 1] = i + 1;
-        }
-        else {
-            dom = DOM_PPERM(f);
-            rank = RANK_PPERM4(f);
-            for (i = 1; i <= rank; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptinv2[ptf[j] - 1] = j + 1;
-            }
-        }
-        SET_CODEG_PPERM2(inv, deg);
+    if (DEG_PPERM4(f) < 65536) {
+        return InvPPerm<UInt2, UInt4>(f);
     }
     else {
-        inv = NEW_PPERM4(codeg);
-        ptf = ADDR_PPERM4(f);
-        ptinv4 = ADDR_PPERM4(inv);
-        if (DOM_PPERM(f) == NULL) {
-            for (i = 0; i < deg; i++)
-                if (ptf[i] != 0)
-                    ptinv4[ptf[i] - 1] = i + 1;
-        }
-        else {
-            dom = DOM_PPERM(f);
-            rank = RANK_PPERM4(f);
-            for (i = 1; i <= rank; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptinv4[ptf[j] - 1] = j + 1;
-            }
-        }
-        SET_CODEG_PPERM4(inv, deg);
+        return InvPPerm<UInt4, UInt4>(f);
     }
-    return inv;
 }
 
 // Conjugation: p ^ -1 * f * p

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -386,38 +386,26 @@ static Obj SORT_PLIST_INTOBJ(Obj res)
     return res;
 }
 
+template <typename T>
 static Obj PreImagePPermInt(Obj pt, Obj f)
 {
     GAP_ASSERT(IS_INTOBJ(pt));
-    GAP_ASSERT(IS_PPERM(f));
+    ASSERT_IS_PPERM<T>(f);
 
-    UInt2 * ptf2;
-    UInt4 * ptf4;
+    T *     ptf;
     UInt    i, cpt, deg;
 
     cpt = INT_INTOBJ(pt);
-
-    if (cpt > (TNUM_OBJ(f) == T_PPERM2 ? CODEG_PPERM2(f) : CODEG_PPERM4(f)))
+    if (cpt > CODEG_PPERM<T>(f))
         return Fail;
 
     i = 0;
-
-    if (TNUM_OBJ(f) == T_PPERM2) {
-        ptf2 = ADDR_PPERM2(f);
-        deg = DEG_PPERM2(f);
-        while (i < deg && ptf2[i] != cpt)
-            i++;
-        if (i == deg || ptf2[i] != cpt)
-            return Fail;
-    }
-    else {
-        ptf4 = ADDR_PPERM4(f);
-        deg = DEG_PPERM4(f);
-        while (i < deg && ptf4[i] != cpt)
-            i++;
-        if (i == deg || ptf4[i] != cpt)
-            return Fail;
-    }
+    ptf = ADDR_PPERM<T>(f);
+    deg = DEG_PPERM<T>(f);
+    while (i < deg && ptf[i] != cpt)
+        i++;
+    if (i == deg || ptf[i] != cpt)
+        return Fail;
     return INTOBJ_INT(i + 1);
 }
 
@@ -638,7 +626,12 @@ static Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
 /* preimage under a partial perm */
 static Obj FuncPREIMAGE_PPERM_INT(Obj self, Obj f, Obj pt)
 {
-    return PreImagePPermInt(pt, f);
+    RequirePartialPerm("PREIMAGE_PPERM_INT", f);
+    RequireSmallInt("PREIMAGE_PPERM_INT", pt, "pt");
+    if (TNUM_OBJ(f) == T_PPERM2)
+        return PreImagePPermInt<UInt2>(pt, f);
+    else
+        return PreImagePPermInt<UInt4>(pt, f);
 }
 
 // find img(f)
@@ -6384,8 +6377,8 @@ static Int InitKernel(StructInitInfo * module)
     QuoFuncs[T_PPERM2][T_PPERM4] = QuoPPerm24;
     QuoFuncs[T_PPERM4][T_PPERM2] = QuoPPerm42;
     QuoFuncs[T_PPERM4][T_PPERM4] = QuoPPerm44;
-    QuoFuncs[T_INT][T_PPERM2] = PreImagePPermInt;
-    QuoFuncs[T_INT][T_PPERM4] = PreImagePPermInt;
+    QuoFuncs[T_INT][T_PPERM2] = PreImagePPermInt<UInt2>;
+    QuoFuncs[T_INT][T_PPERM4] = PreImagePPermInt<UInt4>;
     LQuoFuncs[T_PERM2][T_PPERM2] = LQuoPerm2PPerm2;
     LQuoFuncs[T_PERM2][T_PPERM4] = LQuoPerm2PPerm4;
     LQuoFuncs[T_PERM4][T_PPERM2] = LQuoPerm4PPerm2;

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -2918,235 +2918,74 @@ static Obj InvPPerm4(Obj f)
 }
 
 // Conjugation: p ^ -1 * f * p
+template <typename Res, typename TF, typename TP>
+static Obj PowPPermPerm(Obj f, Obj p)
+{
+    ASSERT_IS_PPERM<TF>(f);
+    ASSERT_IS_PERM<TP>(p);
+
+    TF *    ptf;
+    TP *    ptp;
+    Res *   ptconj;
+    UInt    deg, dep, rank, degconj, i, j, k, codeg;
+    Obj     conj, dom;
+
+    deg = DEG_PPERM<TF>(f);
+    if (deg == 0)
+        return EmptyPartialPerm;
+
+    dep = DEG_PERM<TP>(p);
+    rank = RANK_PPERM<TF>(f);
+    ptp = ADDR_PERM<TP>(p);
+    dom = DOM_PPERM(f);
+
+    // find deg of conjugate
+    if (deg > dep) {
+        degconj = deg;
+    }
+    else {
+        degconj = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            if (ptp[j] >= degconj)
+                degconj = ptp[j] + 1;
+        }
+    }
+
+    conj = NEW_PPERM<Res>(degconj);
+    ptconj = ADDR_PPERM<Res>(conj);
+    ptp = ADDR_PERM<TP>(p);
+    ptf = ADDR_PPERM<TF>(f);
+    codeg = CODEG_PPERM<TF>(f);
+
+    if (codeg > dep) {
+        SET_CODEG_PPERM<Res>(conj, codeg);
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
+        }
+    }
+    else {
+        codeg = 0;
+        for (i = 1; i <= rank; i++) {
+            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
+            k = ptp[ptf[j] - 1] + 1;
+            ptconj[IMAGE(j, ptp, dep)] = k;
+            if (k > codeg)
+                codeg = k;
+        }
+        SET_CODEG_PPERM<Res>(conj, codeg);
+    }
+    return conj;
+}
+
+// special case for permutations of degree 65536
 static Obj PowPPerm2Perm2(Obj f, Obj p)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
-
-    UInt   deg, dep, rank, degconj, i, j, k, codeg;
-    UInt2 *ptf, *ptp, *ptconj;
-    Obj    conj, dom;
-
-    deg = DEG_PPERM2(f);
-    if (deg == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM2(p);
-    rank = RANK_PPERM2(f);
-    ptp = ADDR_PERM2(p);
-    dom = DOM_PPERM(f);
-
-    // FIXME HACK: workaround bug (proper fix will come with
-    // refactoring of this code to use C++ templates)
-    if (dep == 65536) {
-        return PROD(LQUO(p, f), p);
-    }
-
-    // find deg of conjugate
-    if (deg > dep) {
-        degconj = deg;
-    }
-    else {
-        degconj = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptp[j] >= degconj)
-                degconj = ptp[j] + 1;
-        }
-    }
-
-    conj = NEW_PPERM2(degconj);
-    ptconj = ADDR_PPERM2(conj);
-    ptp = ADDR_PERM2(p);
-    ptf = ADDR_PPERM2(f);
-    codeg = CODEG_PPERM2(f);
-
-    if (codeg > dep) {
-        SET_CODEG_PPERM2(conj, codeg);
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
-        }
-    }
-    else {
-        codeg = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            k = ptp[ptf[j] - 1] + 1;
-            ptconj[IMAGE(j, ptp, dep)] = k;
-            if (k > codeg)
-                codeg = k;
-        }
-        SET_CODEG_PPERM2(conj, codeg);
-    }
-
-    return conj;
-}
-
-static Obj PowPPerm2Perm4(Obj f, Obj p)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
-
-    UInt    deg, dep, rank, degconj, i, j, k, codeg;
-    UInt2 * ptf;
-    UInt4 * ptp, *ptconj;
-    Obj     conj, dom;
-
-    deg = DEG_PPERM2(f);
-    if (deg == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM4(p);
-    rank = RANK_PPERM2(f);
-    ptp = ADDR_PERM4(p);
-    dom = DOM_PPERM(f);
-    // find deg of conjugate
-    if (deg > dep) {
-        degconj = deg;
-    }
-    else {
-        degconj = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptp[j] >= degconj)
-                degconj = ptp[j] + 1;
-        }
-    }
-
-    conj = NEW_PPERM4(degconj);
-    ptconj = ADDR_PPERM4(conj);
-    ptp = ADDR_PERM4(p);
-    ptf = ADDR_PPERM2(f);
-    codeg = 0;
-
-    for (i = 1; i <= rank; i++) {
-        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-        k = ptp[ptf[j] - 1] + 1;
-        ptconj[IMAGE(j, ptp, dep)] = k;
-        if (k > codeg)
-            codeg = k;
-    }
-    SET_CODEG_PPERM4(conj, codeg);
-
-    return conj;
-}
-
-static Obj PowPPerm4Perm2(Obj f, Obj p)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
-
-    UInt    deg, dep, rank, degconj, i, j, k, codeg;
-    UInt4 * ptf, *ptconj;
-    UInt2 * ptp;
-    Obj     conj, dom;
-
-    deg = DEG_PPERM4(f);
-    if (deg == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM2(p);
-    rank = RANK_PPERM4(f);
-    ptp = ADDR_PERM2(p);
-    dom = DOM_PPERM(f);
-
-    // find deg of conjugate
-    if (deg > dep) {
-        degconj = deg;
-    }
-    else {
-        degconj = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptp[j] >= degconj)
-                degconj = ptp[j] + 1;
-        }
-    }
-
-    conj = NEW_PPERM4(degconj);
-    ptconj = ADDR_PPERM4(conj);
-    ptp = ADDR_PERM2(p);
-    ptf = ADDR_PPERM4(f);
-    codeg = CODEG_PPERM4(f);
-
-    if (codeg > dep) {
-        SET_CODEG_PPERM4(conj, codeg);
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
-        }
-    }
-    else {
-        codeg = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            k = ptp[ptf[j] - 1] + 1;
-            ptconj[IMAGE(j, ptp, dep)] = k;
-            if (k > codeg)
-                codeg = k;
-        }
-        SET_CODEG_PPERM4(conj, codeg);
-    }
-    return conj;
-}
-
-static Obj PowPPerm4Perm4(Obj f, Obj p)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
-
-    UInt   deg, dep, rank, degconj, i, j, k, codeg;
-    UInt4 *ptf, *ptp, *ptconj;
-    Obj    conj, dom;
-
-    deg = DEG_PPERM4(f);
-    if (deg == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM4(p);
-    rank = RANK_PPERM4(f);
-    ptp = ADDR_PERM4(p);
-    dom = DOM_PPERM(f);
-
-    // find deg of conjugate
-    if (deg > dep) {
-        degconj = deg;
-    }
-    else {
-        degconj = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptp[j] >= degconj)
-                degconj = ptp[j] + 1;
-        }
-    }
-
-    conj = NEW_PPERM4(degconj);
-    ptconj = ADDR_PPERM4(conj);
-    ptp = ADDR_PERM4(p);
-    ptf = ADDR_PPERM4(f);
-    codeg = CODEG_PPERM4(f);
-
-    if (codeg > dep) {
-        SET_CODEG_PPERM4(conj, codeg);
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            ptconj[IMAGE(j, ptp, dep)] = IMAGE(ptf[j] - 1, ptp, dep) + 1;
-        }
-    }
-    else {    // codeg(f)<=deg(p)
-        codeg = 0;
-        for (i = 1; i <= rank; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            k = ptp[ptf[j] - 1] + 1;
-            ptconj[IMAGE(j, ptp, dep)] = k;
-            if (k > codeg)
-                codeg = k;
-        }
-        SET_CODEG_PPERM4(conj, codeg);
-    }
-    return conj;
+    if (DEG_PERM2(p) == 65536)
+        return PowPPermPerm<UInt4, UInt2, UInt2>(f, p);
+    else
+        return PowPPermPerm<UInt2, UInt2, UInt2>(f, p);
 }
 
 // g ^ -1 * f * g
@@ -4173,10 +4012,10 @@ static Int InitKernel(StructInitInfo * module)
     ProdFuncs[T_PERM2][T_PPERM4] = ProdPermPPerm<UInt2, UInt4>;
     PowFuncs[T_INT][T_PPERM2] = PowIntPPerm2;
     PowFuncs[T_INT][T_PPERM4] = PowIntPPerm4;
-    PowFuncs[T_PPERM2][T_PERM2] = PowPPerm2Perm2;
-    PowFuncs[T_PPERM2][T_PERM4] = PowPPerm2Perm4;
-    PowFuncs[T_PPERM4][T_PERM2] = PowPPerm4Perm2;
-    PowFuncs[T_PPERM4][T_PERM4] = PowPPerm4Perm4;
+    PowFuncs[T_PPERM2][T_PERM2] = PowPPerm2Perm2; // special case
+    PowFuncs[T_PPERM2][T_PERM4] = PowPPermPerm<UInt4, UInt2, UInt4>;
+    PowFuncs[T_PPERM4][T_PERM2] = PowPPermPerm<UInt4, UInt4, UInt2>;
+    PowFuncs[T_PPERM4][T_PERM4] = PowPPermPerm<UInt4, UInt4, UInt4>;
     PowFuncs[T_PPERM2][T_PPERM2] = PowPPerm<UInt2, UInt2>;
     PowFuncs[T_PPERM2][T_PPERM4] = PowPPerm<UInt2, UInt4>;
     PowFuncs[T_PPERM4][T_PPERM2] = PowPPerm<UInt4, UInt2>;

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -2812,177 +2812,49 @@ static Obj ProdPPerm4Perm2(Obj f, Obj p)
 }
 
 // product of a perm and a partial perm
-static Obj ProdPerm2PPerm2(Obj p, Obj f)
+template <typename TP, typename TF>
+static Obj ProdPermPPerm(Obj p, Obj f)
 {
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    ASSERT_IS_PERM<TP>(p);
+    ASSERT_IS_PPERM<TF>(f);
 
-    UInt2 *ptp, *ptf, *ptpf;
-    UInt  deg, degf, i;
-    Obj   pf;
+    TP * ptp;
+    TF * ptf;
+    TF * ptpf;
+    UInt degp, degf, i;
+    Obj  pf;
 
-    if (DEG_PPERM2(f) == 0)
+    if (DEG_PPERM<TF>(f) == 0)
         return EmptyPartialPerm;
 
-    deg = DEG_PERM2(p);
-    degf = DEG_PPERM2(f);
+    degp = DEG_PERM<TP>(p);
+    degf = DEG_PPERM<TF>(f);
 
-    if (deg < degf) {
-        pf = NEW_PPERM2(degf);
-        ptpf = ADDR_PPERM2(pf);
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM2(f);
-        for (i = 0; i < deg; i++)
+    if (degp < degf) {
+        pf = NEW_PPERM<TF>(degf);
+        ptpf = ADDR_PPERM<TF>(pf);
+        ptp = ADDR_PERM<TP>(p);
+        ptf = ADDR_PPERM<TF>(f);
+        for (i = 0; i < degp; i++)
             *ptpf++ = ptf[*ptp++];
         for (; i < degf; i++)
             *ptpf++ = ptf[i];
     }
     else {    // deg(f)<=deg(p)
         // find the degree
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM2(f);
-        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
-            deg--;
-        pf = NEW_PPERM2(deg);
-        ptpf = ADDR_PPERM2(pf);
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM2(f);
-        for (i = 0; i < deg; i++)
+        ptp = ADDR_PERM<TP>(p);
+        ptf = ADDR_PPERM<TF>(f);
+        while (ptp[degp - 1] >= degf || ptf[ptp[degp - 1]] == 0)
+            degp--;
+        pf = NEW_PPERM<TF>(degp);
+        ptpf = ADDR_PPERM<TF>(pf);
+        ptp = ADDR_PERM<TP>(p);
+        ptf = ADDR_PPERM<TF>(f);
+        for (i = 0; i < degp; i++)
             if (ptp[i] < degf)
                 ptpf[i] = ptf[ptp[i]];
     }
-    SET_CODEG_PPERM2(pf, CODEG_PPERM2(f));
-    return pf;
-}
-
-static Obj ProdPerm4PPerm4(Obj p, Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-
-    UInt4 *ptp, *ptf, *ptpf;
-    UInt  deg, degf, i;
-    Obj   pf;
-
-    if (DEG_PPERM4(f) == 0)
-        return EmptyPartialPerm;
-
-    deg = DEG_PERM4(p);
-    degf = DEG_PPERM4(f);
-
-    if (deg < degf) {
-        pf = NEW_PPERM4(degf);
-        ptpf = ADDR_PPERM4(pf);
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM4(f);
-        for (i = 0; i < deg; i++)
-            *ptpf++ = ptf[*ptp++];
-        for (; i < degf; i++)
-            *ptpf++ = ptf[i];
-    }
-    else {    // deg(f)<deg(p)
-        // find the degree
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM4(f);
-        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
-            deg--;
-        pf = NEW_PPERM4(deg);
-        ptpf = ADDR_PPERM4(pf);
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM4(f);
-        for (i = 0; i < deg; i++)
-            if (ptp[i] < degf)
-                ptpf[i] = ptf[ptp[i]];
-    }
-    SET_CODEG_PPERM4(pf, CODEG_PPERM4(f));
-    return pf;
-}
-
-static Obj ProdPerm4PPerm2(Obj p, Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-
-    UInt4  *ptp;
-    UInt2 *ptf, *ptpf;
-    UInt   deg, degf, i;
-    Obj    pf;
-
-    if (DEG_PPERM2(f) == 0)
-        return EmptyPartialPerm;
-
-    deg = DEG_PERM4(p);
-    degf = DEG_PPERM2(f);
-    if (deg < degf) {
-        pf = NEW_PPERM2(degf);
-        ptpf = ADDR_PPERM2(pf);
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM2(f);
-        for (i = 0; i < deg; i++)
-            *ptpf++ = ptf[*ptp++];
-        for (; i < degf; i++)
-            *ptpf++ = ptf[i];
-    }
-    else {    // deg(f)<=deg(p)
-        // find the degree
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM2(f);
-        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
-            deg--;
-        pf = NEW_PPERM2(deg);
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM2(f);
-        ptpf = ADDR_PPERM2(pf);
-        for (i = 0; i < deg; i++)
-            if (ptp[i] < degf)
-                ptpf[i] = ptf[ptp[i]];
-    }
-
-    SET_CODEG_PPERM2(pf, CODEG_PPERM2(f));
-    return pf;
-}
-
-static Obj ProdPerm2PPerm4(Obj p, Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-
-    UInt2 * ptp;
-    UInt4 * ptf, *ptpf;
-    UInt    deg, degf, i;
-    Obj     pf;
-
-    if (DEG_PPERM4(f) == 0)
-        return EmptyPartialPerm;
-
-    deg = DEG_PERM2(p);
-    degf = DEG_PPERM4(f);
-    if (deg < degf) {
-        pf = NEW_PPERM4(degf);
-        ptpf = ADDR_PPERM4(pf);
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM4(f);
-        for (i = 0; i < deg; i++)
-            *ptpf++ = ptf[*ptp++];
-        for (; i < degf; i++)
-            *ptpf++ = ptf[i];
-    }
-    else {    // deg(f)<deg(p)
-        // find the degree
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM4(f);
-        while (ptp[deg - 1] >= degf || ptf[ptp[deg - 1]] == 0)
-            deg--;
-        pf = NEW_PPERM4(deg);
-        ptpf = ADDR_PPERM4(pf);
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM4(f);
-        for (i = 0; i < deg; i++)
-            if (ptp[i] < degf)
-                ptpf[i] = ptf[ptp[i]];
-    }
-
-    SET_CODEG_PPERM4(pf, CODEG_PPERM4(f));
+    SET_CODEG_PPERM<TF>(pf, CODEG_PPERM<TF>(f));
     return pf;
 }
 
@@ -5780,10 +5652,10 @@ static Int InitKernel(StructInitInfo * module)
     ProdFuncs[T_PPERM4][T_PERM4] = ProdPPerm4Perm4;
     ProdFuncs[T_PPERM2][T_PERM4] = ProdPPerm2Perm4;
     ProdFuncs[T_PPERM4][T_PERM2] = ProdPPerm4Perm2;
-    ProdFuncs[T_PERM2][T_PPERM2] = ProdPerm2PPerm2;
-    ProdFuncs[T_PERM4][T_PPERM4] = ProdPerm4PPerm4;
-    ProdFuncs[T_PERM4][T_PPERM2] = ProdPerm4PPerm2;
-    ProdFuncs[T_PERM2][T_PPERM4] = ProdPerm2PPerm4;
+    ProdFuncs[T_PERM2][T_PPERM2] = ProdPermPPerm<UInt2, UInt2>;
+    ProdFuncs[T_PERM4][T_PPERM4] = ProdPermPPerm<UInt4, UInt4>;
+    ProdFuncs[T_PERM4][T_PPERM2] = ProdPermPPerm<UInt4, UInt2>;
+    ProdFuncs[T_PERM2][T_PPERM4] = ProdPermPPerm<UInt2, UInt4>;
     PowFuncs[T_INT][T_PPERM2] = PowIntPPerm2;
     PowFuncs[T_INT][T_PPERM4] = PowIntPPerm4;
     PowFuncs[T_PPERM2][T_PERM2] = PowPPerm2Perm2;

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -5465,8 +5465,8 @@ Obj OnSetsPPerm(Obj set, Obj f)
     UInt4 *     ptf4;
     UInt        deg;
     const Obj * ptset;
-    Obj *       ptres, tmp, res;
-    UInt        i, isint, k, reslen;
+    Obj *       ptres, res;
+    UInt        i, k, reslen;
 
     GAP_ASSERT(IS_PLIST(set));
     GAP_ASSERT(LEN_PLIST(set) > 0);
@@ -5480,7 +5480,6 @@ Obj OnSetsPPerm(Obj set, Obj f)
     ptset = CONST_ADDR_OBJ(set) + len;
     ptres = ADDR_OBJ(res) + 1;
     reslen = 0;
-    isint = 1;
 
     if (TNUM_OBJ(f) == T_PPERM2) {
         ptf2 = ADDR_PPERM2(f);
@@ -5491,9 +5490,8 @@ Obj OnSetsPPerm(Obj set, Obj f)
             if (IS_POS_INTOBJ(*ptset)) {
                 k = INT_INTOBJ(*ptset);
                 if (k <= deg && ptf2[k - 1] != 0) {
-                    tmp = INTOBJ_INT(ptf2[k - 1]);
                     reslen++;
-                    *ptres++ = tmp;
+                    *ptres++ = INTOBJ_INT(ptf2[k - 1]);
                 }
             }
             else {
@@ -5516,9 +5514,8 @@ Obj OnSetsPPerm(Obj set, Obj f)
             if (IS_POS_INTOBJ(*ptset)) {
                 k = INT_INTOBJ(*ptset);
                 if (k <= deg && ptf4[k - 1] != 0) {
-                    tmp = INTOBJ_INT(ptf4[k - 1]);
                     reslen++;
-                    *ptres++ = tmp;
+                    *ptres++ = INTOBJ_INT(ptf4[k - 1]);
                 }
             }
             else {
@@ -5536,17 +5533,12 @@ Obj OnSetsPPerm(Obj set, Obj f)
         RetypeBagSM(res, T_PLIST_EMPTY);
         return res;
     }
-    ResizeBag(res, (reslen + 1) * sizeof(Obj));
     SET_LEN_PLIST(res, reslen);
+    SHRINK_PLIST(res, reslen);
 
     // sort the result
-    if (isint) {
-        SortPlistByRawObj(res);
-        RetypeBagSM(res, T_PLIST_CYC_SSORT);
-    }
-    else {
-        SortDensePlist(res);
-    }
+    SortPlistByRawObj(res);
+    RetypeBagSM(res, T_PLIST_CYC_SSORT);
 
     return res;
 }
@@ -5586,13 +5578,14 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
     if (TNUM_OBJ(f) == T_PPERM2) {
         ptf2 = ADDR_PPERM2(f);
         deg = DEG_PPERM2(f);
+
         /* loop over the entries of the tuple                              */
         for (i = 1; i <= len; i++, pttup++) {
             if (IS_POS_INTOBJ(*pttup)) {
                 k = INT_INTOBJ(*pttup);
                 if (k <= deg && ptf2[k - 1] != 0) {
                     reslen++;
-                    *(ptres++) = INTOBJ_INT(ptf2[k - 1]);
+                    *ptres++ = INTOBJ_INT(ptf2[k - 1]);
                 }
             }
             else {
@@ -5609,13 +5602,14 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
     else {
         ptf4 = ADDR_PPERM4(f);
         deg = DEG_PPERM4(f);
+
         /* loop over the entries of the tuple                              */
         for (i = 1; i <= len; i++, pttup++) {
             if (IS_POS_INTOBJ(*pttup)) {
                 k = INT_INTOBJ(*pttup);
                 if (k <= deg && ptf4[k - 1] != 0) {
                     reslen++;
-                    *(ptres++) = INTOBJ_INT(ptf4[k - 1]);
+                    *ptres++ = INTOBJ_INT(ptf4[k - 1]);
                 }
             }
             else {
@@ -5629,8 +5623,8 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
             }
         }
     }
-    SET_LEN_PLIST(res, (Int)reslen);
-    SHRINK_PLIST(res, (Int)reslen);
+    SET_LEN_PLIST(res, reslen);
+    SHRINK_PLIST(res, reslen);
 
     return res;
 }

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -2924,8 +2924,8 @@ static Obj PowPPermPerm(Obj f, Obj p)
     ASSERT_IS_PPERM<TF>(f);
     ASSERT_IS_PERM<TP>(p);
 
-    TF *    ptf;
-    TP *    ptp;
+    const TF * ptf;
+    const TP * ptp;
     Res *   ptconj;
     UInt    deg, dep, rank, degconj, i, j, k, codeg;
     Obj     conj, dom;
@@ -2936,7 +2936,7 @@ static Obj PowPPermPerm(Obj f, Obj p)
 
     dep = DEG_PERM<TP>(p);
     rank = RANK_PPERM<TF>(f);
-    ptp = ADDR_PERM<TP>(p);
+    ptp = CONST_ADDR_PERM<TP>(p);
     dom = DOM_PPERM(f);
 
     // find deg of conjugate
@@ -2954,8 +2954,8 @@ static Obj PowPPermPerm(Obj f, Obj p)
 
     conj = NEW_PPERM<Res>(degconj);
     ptconj = ADDR_PPERM<Res>(conj);
-    ptp = ADDR_PERM<TP>(p);
-    ptf = ADDR_PPERM<TF>(f);
+    ptp = CONST_ADDR_PERM<TP>(p);
+    ptf = CONST_ADDR_PPERM<TF>(f);
     codeg = CODEG_PPERM<TF>(f);
 
     if (codeg > dep) {
@@ -2997,8 +2997,8 @@ static Obj PowPPerm(Obj f, Obj g)
     ASSERT_IS_PPERM<TF>(f);
     ASSERT_IS_PPERM<TG>(g);
 
-    TF *  ptf;
-    TG *  ptg;
+    const TF * ptf;
+    const TG * ptg;
     Res * ptconj;
     UInt  i, j, def, deg, dec, codeg, codec, min, img, len;
     Obj   dom, conj;
@@ -3009,8 +3009,8 @@ static Obj PowPPerm(Obj f, Obj g)
     if (def == 0 || deg == 0)
         return EmptyPartialPerm;
 
-    ptf = ADDR_PPERM<TF>(f);
-    ptg = ADDR_PPERM<TG>(g);
+    ptf = CONST_ADDR_PPERM<TF>(f);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     dom = DOM_PPERM(f);
     codeg = CODEG_PPERM<TG>(g);
     dec = 0;
@@ -3034,8 +3034,8 @@ static Obj PowPPerm(Obj f, Obj g)
             // create new pperm
             conj = NEW_PPERM<Res>(dec);
             ptconj = ADDR_PPERM<Res>(conj);
-            ptf = ADDR_PPERM<TF>(f);
-            ptg = ADDR_PPERM<TG>(g);
+            ptf = CONST_ADDR_PPERM<TF>(f);
+            ptg = CONST_ADDR_PPERM<TG>(g);
 
             // multiply
             for (i = 0; i < min; i++) {
@@ -3066,8 +3066,8 @@ static Obj PowPPerm(Obj f, Obj g)
             // create new pperm
             conj = NEW_PPERM<Res>(dec);
             ptconj = ADDR_PPERM<Res>(conj);
-            ptf = ADDR_PPERM<TF>(f);
-            ptg = ADDR_PPERM<TG>(g);
+            ptf = CONST_ADDR_PPERM<TF>(f);
+            ptg = CONST_ADDR_PPERM<TG>(g);
 
             // multiply
             for (i = 0; i < min; i++) {
@@ -3098,8 +3098,8 @@ static Obj PowPPerm(Obj f, Obj g)
             // create new pperm
             conj = NEW_PPERM<Res>(dec);
             ptconj = ADDR_PPERM<Res>(conj);
-            ptf = ADDR_PPERM<TF>(f);
-            ptg = ADDR_PPERM<TG>(g);
+            ptf = CONST_ADDR_PPERM<TF>(f);
+            ptg = CONST_ADDR_PPERM<TG>(g);
 
             // multiply
             for (i = 1; i <= len; i++) {
@@ -3130,8 +3130,8 @@ static Obj PowPPerm(Obj f, Obj g)
             // create new pperm
             conj = NEW_PPERM<Res>(dec);
             ptconj = ADDR_PPERM<Res>(conj);
-            ptf = ADDR_PPERM<TF>(f);
-            ptg = ADDR_PPERM<TG>(g);
+            ptf = CONST_ADDR_PPERM<TF>(f);
+            ptg = CONST_ADDR_PPERM<TG>(g);
 
             // multiply
             for (i = 1; i <= len; i++) {
@@ -3163,8 +3163,8 @@ static Obj PowPPerm(Obj f, Obj g)
             // create new pperm
             conj = NEW_PPERM<Res>(dec);
             ptconj = ADDR_PPERM<Res>(conj);
-            ptf = ADDR_PPERM<TF>(f);
-            ptg = ADDR_PPERM<TG>(g);
+            ptf = CONST_ADDR_PPERM<TF>(f);
+            ptg = CONST_ADDR_PPERM<TG>(g);
 
             // multiply
             for (i = 1; i <= len; i++) {
@@ -3194,8 +3194,8 @@ static Obj PowPPerm(Obj f, Obj g)
             // create new pperm
             conj = NEW_PPERM<Res>(dec);
             ptconj = ADDR_PPERM<Res>(conj);
-            ptf = ADDR_PPERM<TF>(f);
-            ptg = ADDR_PPERM<TG>(g);
+            ptf = CONST_ADDR_PPERM<TF>(f);
+            ptg = CONST_ADDR_PPERM<TG>(g);
 
             // multiply
             for (i = 1; i <= len; i++) {
@@ -3223,8 +3223,8 @@ static Obj QuoPPerm(Obj f, Obj g)
     ASSERT_IS_PPERM<TF>(f);
     ASSERT_IS_PPERM<TG>(g);
 
-    TF *    ptf;
-    TG *    ptg;
+    const TF * ptf;
+    const TG * ptg;
     UInt4 * ptquo;
     UInt4 * pttmp;
     UInt    deg, i, j, deginv, codeg, rank;
@@ -3242,7 +3242,7 @@ static Obj QuoPPerm(Obj f, Obj g)
         pttmp[i] = 0;
 
     // invert g into the buffer bag
-    ptg = ADDR_PPERM<TG>(g);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     if (DOM_PPERM(g) == NULL) {
         deg = DEG_PPERM<TG>(g);
         for (i = 0; i < deg; i++)
@@ -3260,7 +3260,7 @@ static Obj QuoPPerm(Obj f, Obj g)
 
     // find the degree of the quotient
     deg = DEG_PPERM<TF>(f);
-    ptf = ADDR_PPERM<TF>(f);
+    ptf = CONST_ADDR_PPERM<TF>(f);
     while (deg > 0 &&
            (ptf[deg - 1] == 0 || IMAGEPP(ptf[deg - 1], pttmp, deginv) == 0))
         deg--;
@@ -3270,7 +3270,7 @@ static Obj QuoPPerm(Obj f, Obj g)
     // create new pperm
     quo = NEW_PPERM4(deg);
     ptquo = ADDR_PPERM4(quo);
-    ptf = ADDR_PPERM<TF>(f);
+    ptf = CONST_ADDR_PPERM<TF>(f);
     pttmp = ADDR_PPERM4(TmpPPerm);
     codeg = 0;
 
@@ -3336,8 +3336,8 @@ static Obj LQuoPermPPerm(Obj p, Obj f)
     ASSERT_IS_PERM<TP>(p);
     ASSERT_IS_PPERM<TF>(f);
 
-    TP *   ptp;
-    TF *   ptf;
+    const TP *   ptp;
+    const TF *   ptf;
     TF *   ptlquo;
     UInt   def, dep, i, j, del, len;
     Obj    dom, lquo;
@@ -3352,8 +3352,8 @@ static Obj LQuoPermPPerm(Obj p, Obj f)
     if (dep < def) {
         lquo = NEW_PPERM<TF>(def);
         ptlquo = ADDR_PPERM<TF>(lquo);
-        ptp = ADDR_PERM<TP>(p);
-        ptf = ADDR_PPERM<TF>(f);
+        ptp = CONST_ADDR_PERM<TP>(p);
+        ptf = CONST_ADDR_PPERM<TF>(f);
         if (dom == NULL) {
             for (i = 0; i < dep; i++)
                 ptlquo[ptp[i]] = ptf[i];
@@ -3370,8 +3370,8 @@ static Obj LQuoPermPPerm(Obj p, Obj f)
     }
     else {    // deg(p)>=deg(f)
         del = 0;
-        ptp = ADDR_PERM<TP>(p);
-        ptf = ADDR_PPERM<TF>(f);
+        ptp = CONST_ADDR_PERM<TP>(p);
+        ptf = CONST_ADDR_PPERM<TF>(f);
         if (dom == NULL) {
             // find the degree
             for (i = 0; i < def; i++) {
@@ -3383,8 +3383,8 @@ static Obj LQuoPermPPerm(Obj p, Obj f)
             }
             lquo = NEW_PPERM<TF>(del);
             ptlquo = ADDR_PPERM<TF>(lquo);
-            ptp = ADDR_PERM<TP>(p);
-            ptf = ADDR_PPERM<TF>(f);
+            ptp = CONST_ADDR_PERM<TP>(p);
+            ptf = CONST_ADDR_PPERM<TF>(f);
 
             // if required below in case ptp[i]>del but ptf[i]=0
             for (i = 0; i < def; i++)
@@ -3403,8 +3403,8 @@ static Obj LQuoPermPPerm(Obj p, Obj f)
             }
             lquo = NEW_PPERM<TF>(del);
             ptlquo = ADDR_PPERM<TF>(lquo);
-            ptp = ADDR_PERM<TP>(p);
-            ptf = ADDR_PPERM<TF>(f);
+            ptp = CONST_ADDR_PERM<TP>(p);
+            ptf = CONST_ADDR_PPERM<TF>(f);
 
             for (i = 1; i <= len; i++) {
                 j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
@@ -3425,8 +3425,8 @@ static Obj LQuoPPerm(Obj f, Obj g)
     ASSERT_IS_PPERM<TF>(f);
     ASSERT_IS_PPERM<TG>(g);
 
-    TF * ptf;
-    TG * ptg;
+    const TF * ptf;
+    const TG * ptg;
     TG * ptlquo;
     UInt i, j, def, deg, del, codef, codel, min, len;
     Obj  dom, lquo;
@@ -3437,8 +3437,8 @@ static Obj LQuoPPerm(Obj f, Obj g)
     if (def == 0 || deg == 0)
         return EmptyPartialPerm;
 
-    ptf = ADDR_PPERM<TF>(f);
-    ptg = ADDR_PPERM<TG>(g);
+    ptf = CONST_ADDR_PPERM<TF>(f);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     dom = DOM_PPERM(g);
     del = 0;
     codef = CODEG_PPERM<TF>(f);
@@ -3460,8 +3460,8 @@ static Obj LQuoPPerm(Obj f, Obj g)
         // create new pperm
         lquo = NEW_PPERM<TG>(del);
         ptlquo = ADDR_PPERM<TG>(lquo);
-        ptf = ADDR_PPERM<TF>(f);
-        ptg = ADDR_PPERM<TG>(g);
+        ptf = CONST_ADDR_PPERM<TF>(f);
+        ptg = CONST_ADDR_PPERM<TG>(g);
 
         // multiply
         for (i = 0; i < min; i++) {
@@ -3487,8 +3487,8 @@ static Obj LQuoPPerm(Obj f, Obj g)
         // create new pperm
         lquo = NEW_PPERM<TG>(del);
         ptlquo = ADDR_PPERM<TG>(lquo);
-        ptf = ADDR_PPERM<TF>(f);
-        ptg = ADDR_PPERM<TG>(g);
+        ptf = CONST_ADDR_PPERM<TF>(f);
+        ptg = CONST_ADDR_PPERM<TG>(g);
 
         // multiply
         for (i = 1; i <= len; i++) {
@@ -3514,8 +3514,8 @@ static Obj LQuoPPerm(Obj f, Obj g)
         // create new pperm
         lquo = NEW_PPERM<TG>(del);
         ptlquo = ADDR_PPERM<TG>(lquo);
-        ptf = ADDR_PPERM<TF>(f);
-        ptg = ADDR_PPERM<TG>(g);
+        ptf = CONST_ADDR_PPERM<TF>(f);
+        ptg = CONST_ADDR_PPERM<TG>(g);
 
         // multiply
         for (i = 1; i <= len; i++) {

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -2403,18 +2403,19 @@ static Obj OnePPerm(Obj f)
 }
 
 /* equality for partial perms */
-static Int EqPPerm22(Obj f, Obj g)
+template <typename TF, typename TG>
+static Int EqPPerm(Obj f, Obj g)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+    ASSERT_IS_PPERM<TF>(f);
+    ASSERT_IS_PPERM<TG>(g);
 
-    UInt2 * ptf = ADDR_PPERM2(f);
-    UInt2 * ptg = ADDR_PPERM2(g);
-    UInt    deg = DEG_PPERM2(f);
+    TF *    ptf = ADDR_PPERM<TF>(f);
+    TG *    ptg = ADDR_PPERM<TG>(g);
+    UInt    deg = DEG_PPERM<TF>(f);
     UInt    i, j, rank;
     Obj     dom;
 
-    if (deg != DEG_PPERM2(g) || CODEG_PPERM2(f) != CODEG_PPERM2(g))
+    if (deg != DEG_PPERM<TG>(g) || CODEG_PPERM<TF>(f) != CODEG_PPERM<TG>(g))
         return 0L;
 
     if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
@@ -2424,84 +2425,10 @@ static Int EqPPerm22(Obj f, Obj g)
         return 1L;
     }
 
-    if (RANK_PPERM2(f) != RANK_PPERM2(g))
+    if (RANK_PPERM<TF>(f) != RANK_PPERM<TG>(g))
         return 0L;
     dom = DOM_PPERM(f);
-    rank = RANK_PPERM2(f);
-
-    for (i = 1; i <= rank; i++) {
-        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-        if (ptf[j] != ptg[j]) {
-            return 0L;
-        }
-    }
-    return 1L;
-}
-
-static Int EqPPerm24(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
-
-    UInt2 * ptf = ADDR_PPERM2(f);
-    UInt4 * ptg = ADDR_PPERM4(g);
-    UInt    deg = DEG_PPERM2(f);
-    UInt    i, j, rank;
-    Obj     dom;
-
-    if (deg != DEG_PPERM4(g) || CODEG_PPERM2(f) != CODEG_PPERM4(g))
-        return 0L;
-
-    if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
-        for (i = 0; i < deg; i++)
-            if (*(ptf++) != *(ptg++))
-                return 0L;
-        return 1L;
-    }
-
-    if (RANK_PPERM2(f) != RANK_PPERM4(g))
-        return 0L;
-    dom = DOM_PPERM(f);
-    rank = RANK_PPERM2(f);
-
-    for (i = 1; i <= rank; i++) {
-        j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-        if (ptf[j] != ptg[j])
-            return 0L;
-    }
-    return 1L;
-}
-
-static Int EqPPerm42(Obj f, Obj g)
-{
-    return EqPPerm24(g, f);
-}
-
-static Int EqPPerm44(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
-
-    UInt4 * ptf = ADDR_PPERM4(f);
-    UInt4 * ptg = ADDR_PPERM4(g);
-    UInt    i, j, rank;
-    UInt    deg = DEG_PPERM4(f);
-    Obj     dom;
-
-    if (deg != DEG_PPERM4(g) || CODEG_PPERM4(f) != CODEG_PPERM4(g))
-        return 0L;
-
-    if (DOM_PPERM(f) == NULL || DOM_PPERM(g) == NULL) {
-        for (i = 0; i < deg; i++)
-            if (*(ptf++) != *(ptg++))
-                return 0L;
-        return 1L;
-    }
-
-    if (RANK_PPERM4(f) != RANK_PPERM4(g))
-        return 0L;
-    dom = DOM_PPERM(f);
-    rank = RANK_PPERM4(f);
+    rank = RANK_PPERM<TF>(f);
 
     for (i = 1; i <= rank; i++) {
         j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
@@ -2512,108 +2439,19 @@ static Int EqPPerm44(Obj f, Obj g)
 }
 
 /* less than for partial perms */
-static Int LtPPerm22(Obj f, Obj g)
+template <typename TF, typename TG>
+static Int LtPPerm(Obj f, Obj g)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+    ASSERT_IS_PPERM<TF>(f);
+    ASSERT_IS_PPERM<TG>(g);
 
-    UInt2 * ptf = ADDR_PPERM2(f);
-    UInt2 * ptg = ADDR_PPERM2(g);
+    TF *    ptf = ADDR_PPERM<TF>(f);
+    TG *    ptg = ADDR_PPERM<TG>(g);
     UInt    deg, i;
 
-    deg = DEG_PPERM2(f);
-    if (deg != DEG_PPERM2(g)) {
-        if (deg < DEG_PPERM2(g)) {
-            return 1L;
-        }
-        else {
-            return 0L;
-        }
-    }
-
-    for (i = 0; i < deg; i++) {
-        if (*(ptf++) != *(ptg++)) {
-            if (*(--ptf) < *(--ptg))
-                return 1L;
-            else
-                return 0L;
-        }
-    }
-    return 0L;
-}
-
-static Int LtPPerm24(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
-
-    UInt2 * ptf = ADDR_PPERM2(f);
-    UInt4 * ptg = ADDR_PPERM4(g);
-    UInt    deg, i;
-
-    deg = DEG_PPERM2(f);
-    if (deg != DEG_PPERM4(g)) {
-        if (deg < DEG_PPERM4(g)) {
-            return 1L;
-        }
-        else {
-            return 0L;
-        }
-    }
-
-    for (i = 0; i < deg; i++) {
-        if (*(ptf++) != *(ptg++)) {
-            if (*(--ptf) < *(--ptg))
-                return 1L;
-            else
-                return 0L;
-        }
-    }
-    return 0L;
-}
-
-static Int LtPPerm42(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
-
-    UInt4 * ptf = ADDR_PPERM4(f);
-    UInt2 * ptg = ADDR_PPERM2(g);
-    UInt    deg, i;
-
-    deg = DEG_PPERM4(f);
-    if (deg != DEG_PPERM2(g)) {
-        if (deg < DEG_PPERM2(g)) {
-            return 1L;
-        }
-        else {
-            return 0L;
-        }
-    }
-
-    for (i = 0; i < deg; i++) {
-        if (*(ptf++) != *(ptg++)) {
-            if (*(--ptf) < *(--ptg))
-                return 1L;
-            else
-                return 0L;
-        }
-    }
-    return 0L;
-}
-
-static Int LtPPerm44(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
-
-    UInt4 * ptf = ADDR_PPERM4(f);
-    UInt4 * ptg = ADDR_PPERM4(g);
-    UInt    deg, i;
-
-    deg = DEG_PPERM4(f);
-    if (deg != DEG_PPERM4(g)) {
-        if (deg < DEG_PPERM4(g)) {
+    deg = DEG_PPERM<TF>(f);
+    if (deg != DEG_PPERM<TG>(g)) {
+        if (deg < DEG_PPERM<TG>(g)) {
             return 1L;
         }
         else {
@@ -6073,14 +5911,14 @@ static Int InitKernel(StructInitInfo * module)
     LoadObjFuncs[T_PPERM4] = LoadPPerm4;
 
     /* install the comparison methods                                      */
-    EqFuncs[T_PPERM2][T_PPERM2] = EqPPerm22;
-    EqFuncs[T_PPERM4][T_PPERM4] = EqPPerm44;
-    EqFuncs[T_PPERM4][T_PPERM2] = EqPPerm42;
-    EqFuncs[T_PPERM2][T_PPERM4] = EqPPerm24;
-    LtFuncs[T_PPERM2][T_PPERM2] = LtPPerm22;
-    LtFuncs[T_PPERM4][T_PPERM4] = LtPPerm44;
-    LtFuncs[T_PPERM2][T_PPERM4] = LtPPerm24;
-    LtFuncs[T_PPERM4][T_PPERM2] = LtPPerm42;
+    EqFuncs[T_PPERM2][T_PPERM2] = EqPPerm<UInt2, UInt2>;
+    EqFuncs[T_PPERM4][T_PPERM4] = EqPPerm<UInt4, UInt4>;
+    EqFuncs[T_PPERM4][T_PPERM2] = EqPPerm<UInt4, UInt2>;
+    EqFuncs[T_PPERM2][T_PPERM4] = EqPPerm<UInt2, UInt4>;
+    LtFuncs[T_PPERM2][T_PPERM2] = LtPPerm<UInt2, UInt2>;
+    LtFuncs[T_PPERM4][T_PPERM4] = LtPPerm<UInt4, UInt4>;
+    LtFuncs[T_PPERM2][T_PPERM4] = LtPPerm<UInt2, UInt4>;
+    LtFuncs[T_PPERM4][T_PPERM2] = LtPPerm<UInt4, UInt2>;
 
     /* install the binary operations */
     ProdFuncs[T_PPERM2][T_PPERM2] = ProdPPerm22;

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -76,7 +76,7 @@ struct T_PPERM<UInt4> {
 
 
 //
-// Various helper functions
+// Various helper functions for partial permutations
 //
 template <typename T>
 static void ASSERT_IS_PPERM(Obj pperm)
@@ -103,6 +103,49 @@ static inline UInt DEG_PPERM(Obj f)
 {
     ASSERT_IS_PPERM<T>(f);
     return (UInt)(SIZE_OBJ(f) - sizeof(T) - 2 * sizeof(Obj)) / sizeof(T);
+}
+
+
+//
+// Various helper functions for permutations
+//
+template <typename T>
+struct T_PERM {
+};
+template <>
+struct T_PERM<UInt2> {
+    static const UInt tnum = T_PERM2;
+};
+template <>
+struct T_PERM<UInt4> {
+    static const UInt tnum = T_PERM4;
+};
+
+template <typename T>
+static void ASSERT_IS_PERM(Obj perm)
+{
+    GAP_ASSERT(TNUM_OBJ(perm) == T_PERM<T>::tnum);
+}
+
+template <typename T>
+static inline UInt DEG_PERM(Obj perm)
+{
+    ASSERT_IS_PERM<T>(perm);
+    return (SIZE_OBJ(perm) - sizeof(Obj)) / sizeof(T);
+}
+
+template <typename T>
+static inline T * ADDR_PERM(Obj perm)
+{
+    ASSERT_IS_PERM<T>(perm);
+    return (T *)(ADDR_OBJ(perm) + 1);
+}
+
+template <typename T>
+static inline const T * CONST_ADDR_PERM(Obj perm)
+{
+    ASSERT_IS_PERM<T>(perm);
+    return (const T *)(CONST_ADDR_OBJ(perm) + 1);
 }
 
 

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -4489,27 +4489,31 @@ static Obj LQuoPermPPerm(Obj p, Obj f)
     return lquo;
 }
 
+
 // f^-1*g
-static Obj LQuoPPerm22(Obj f, Obj g)
+template <typename TF, typename TG>
+static Obj LQuoPPerm(Obj f, Obj g)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
+    ASSERT_IS_PPERM<TF>(f);
+    ASSERT_IS_PPERM<TG>(g);
 
-    UInt2 *ptg, *ptf, *ptlquo;
-    UInt   i, j, def, deg, del, codef, codel, min, len;
-    Obj    dom, lquo;
+    TF * ptf;
+    TG * ptg;
+    TG * ptlquo;
+    UInt i, j, def, deg, del, codef, codel, min, len;
+    Obj  dom, lquo;
 
     // check if we're in the trivial case
-    def = DEG_PPERM2(f);
-    deg = DEG_PPERM2(g);
+    def = DEG_PPERM<TF>(f);
+    deg = DEG_PPERM<TG>(g);
     if (def == 0 || deg == 0)
         return EmptyPartialPerm;
 
-    ptf = ADDR_PPERM2(f);
-    ptg = ADDR_PPERM2(g);
+    ptf = ADDR_PPERM<TF>(f);
+    ptg = ADDR_PPERM<TG>(g);
     dom = DOM_PPERM(g);
     del = 0;
-    codef = CODEG_PPERM2(f);
+    codef = CODEG_PPERM<TF>(f);
     codel = 0;
 
     if (dom == NULL) {
@@ -4526,10 +4530,10 @@ static Obj LQuoPPerm22(Obj f, Obj g)
             return EmptyPartialPerm;
 
         // create new pperm
-        lquo = NEW_PPERM2(del);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptf = ADDR_PPERM2(f);
-        ptg = ADDR_PPERM2(g);
+        lquo = NEW_PPERM<TG>(del);
+        ptlquo = ADDR_PPERM<TG>(lquo);
+        ptf = ADDR_PPERM<TF>(f);
+        ptg = ADDR_PPERM<TG>(g);
 
         // multiply
         for (i = 0; i < min; i++) {
@@ -4553,10 +4557,10 @@ static Obj LQuoPPerm22(Obj f, Obj g)
         }
 
         // create new pperm
-        lquo = NEW_PPERM2(del);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptf = ADDR_PPERM2(f);
-        ptg = ADDR_PPERM2(g);
+        lquo = NEW_PPERM<TG>(del);
+        ptlquo = ADDR_PPERM<TG>(lquo);
+        ptf = ADDR_PPERM<TF>(f);
+        ptg = ADDR_PPERM<TG>(g);
 
         // multiply
         for (i = 1; i <= len; i++) {
@@ -4580,10 +4584,10 @@ static Obj LQuoPPerm22(Obj f, Obj g)
         }
 
         // create new pperm
-        lquo = NEW_PPERM2(del);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptf = ADDR_PPERM2(f);
-        ptg = ADDR_PPERM2(g);
+        lquo = NEW_PPERM<TG>(del);
+        ptlquo = ADDR_PPERM<TG>(lquo);
+        ptf = ADDR_PPERM<TF>(f);
+        ptg = ADDR_PPERM<TG>(g);
 
         // multiply
         for (i = 1; i <= len; i++) {
@@ -4595,338 +4599,10 @@ static Obj LQuoPPerm22(Obj f, Obj g)
             }
         }
     }
-    SET_CODEG_PPERM2(lquo, codel);
+    SET_CODEG_PPERM<TG>(lquo, codel);
     return lquo;
 }
 
-static Obj LQuoPPerm24(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
-
-    UInt4 * ptg, *ptlquo;
-    UInt2 * ptf;
-    UInt    i, j, def, deg, del, codef, codel, min, len;
-    Obj     dom, lquo;
-
-    // check if we're in the trivial case
-    def = DEG_PPERM2(f);
-    deg = DEG_PPERM4(g);
-    if (def == 0 || deg == 0)
-        return EmptyPartialPerm;
-
-    ptf = ADDR_PPERM2(f);
-    ptg = ADDR_PPERM4(g);
-    dom = DOM_PPERM(g);
-    del = 0;
-    codef = CODEG_PPERM2(f);
-    codel = 0;
-
-    if (dom == NULL) {
-        // find the degree of lquo
-        min = MIN(def, deg);
-        for (i = 0; i < min; i++) {
-            if (ptg[i] != 0 && ptf[i] > del) {
-                del = ptf[i];
-                if (del == codef)
-                    break;
-            }
-        }
-        if (del == 0)
-            return EmptyPartialPerm;
-
-        // create new pperm
-        lquo = NEW_PPERM4(del);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptf = ADDR_PPERM2(f);
-        ptg = ADDR_PPERM4(g);
-
-        // multiply
-        for (i = 0; i < min; i++) {
-            if (ptf[i] != 0 && ptg[i] != 0) {
-                ptlquo[ptf[i] - 1] = ptg[i];
-                if (ptg[i] > codel)
-                    codel = ptg[i];
-            }
-        }
-    }
-    else if (deg > def) {    // dom(g) is known
-        // find the degree of lquo
-        len = LEN_PLIST(dom);
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (IMAGEPP(j + 1, ptf, def) > del) {
-                del = ptf[j];
-                if (del == codef)
-                    break;
-            }
-        }
-
-        // create new pperm
-        lquo = NEW_PPERM4(del);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptf = ADDR_PPERM2(f);
-        ptg = ADDR_PPERM4(g);
-
-        // multiply
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (IMAGEPP(j + 1, ptf, def) != 0) {
-                ptlquo[ptf[j] - 1] = ptg[j];
-                if (ptg[j] > codel)
-                    codel = ptg[j];
-            }
-        }
-    }
-    else {    // deg<=def and dom(g) is known
-        len = LEN_PLIST(dom);
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptf[j] > del) {
-                del = ptf[j];
-                if (del == codef)
-                    break;
-            }
-        }
-
-        // create new pperm
-        lquo = NEW_PPERM4(del);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptf = ADDR_PPERM2(f);
-        ptg = ADDR_PPERM4(g);
-
-        // multiply
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptf[j] != 0) {
-                ptlquo[ptf[j] - 1] = ptg[j];
-                if (ptg[j] > codel)
-                    codel = ptg[j];
-            }
-        }
-    }
-    SET_CODEG_PPERM4(lquo, codel);
-    return lquo;
-}
-
-static Obj LQuoPPerm42(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM2);
-
-    UInt2 * ptg, *ptlquo;
-    UInt4 * ptf;
-    UInt    i, j, def, deg, del, codef, codel, min, len;
-    Obj     dom, lquo;
-
-    // check if we're in the trivial case
-    def = DEG_PPERM4(f);
-    deg = DEG_PPERM2(g);
-    if (def == 0 || deg == 0)
-        return EmptyPartialPerm;
-
-    ptf = ADDR_PPERM4(f);
-    ptg = ADDR_PPERM2(g);
-    dom = DOM_PPERM(g);
-    del = 0;
-    codef = CODEG_PPERM4(f);
-    codel = 0;
-
-    if (dom == NULL) {
-        // find the degree of lquo
-        min = MIN(def, deg);
-        for (i = 0; i < min; i++) {
-            if (ptg[i] != 0 && ptf[i] > del) {
-                del = ptf[i];
-                if (del == codef)
-                    break;
-            }
-        }
-        if (del == 0)
-            return EmptyPartialPerm;
-
-        // create new pperm
-        lquo = NEW_PPERM2(del);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptf = ADDR_PPERM4(f);
-        ptg = ADDR_PPERM2(g);
-
-        // multiply
-        for (i = 0; i < min; i++) {
-            if (ptf[i] != 0 && ptg[i] != 0) {
-                ptlquo[ptf[i] - 1] = ptg[i];
-                if (ptg[i] > codel)
-                    codel = ptg[i];
-            }
-        }
-    }
-    else if (deg > def) {    // dom(g) is known
-        // find the degree of lquo
-        len = LEN_PLIST(dom);
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (IMAGEPP(j + 1, ptf, def) > del) {
-                del = ptf[j];
-                if (del == codef)
-                    break;
-            }
-        }
-
-        // create new pperm
-        lquo = NEW_PPERM2(del);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptf = ADDR_PPERM4(f);
-        ptg = ADDR_PPERM2(g);
-
-        // multiply
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (IMAGEPP(j + 1, ptf, def) != 0) {
-                ptlquo[ptf[j] - 1] = ptg[j];
-                if (ptg[j] > codel)
-                    codel = ptg[j];
-            }
-        }
-    }
-    else {    // deg<=def and dom(g) is known
-        len = LEN_PLIST(dom);
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptf[j] > del) {
-                del = ptf[j];
-                if (del == codef)
-                    break;
-            }
-        }
-
-        // create new pperm
-        lquo = NEW_PPERM2(del);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptf = ADDR_PPERM4(f);
-        ptg = ADDR_PPERM2(g);
-
-        // multiply
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptf[j] != 0) {
-                ptlquo[ptf[j] - 1] = ptg[j];
-                if (ptg[j] > codel)
-                    codel = ptg[j];
-            }
-        }
-    }
-    SET_CODEG_PPERM2(lquo, codel);
-    return lquo;
-}
-
-static Obj LQuoPPerm44(Obj f, Obj g)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    GAP_ASSERT(TNUM_OBJ(g) == T_PPERM4);
-
-    UInt4 *ptg, *ptf, *ptlquo;
-    UInt   i, j, def, deg, del, codef, codel, min, len;
-    Obj    dom, lquo;
-
-    // check if we're in the trivial case
-    def = DEG_PPERM4(f);
-    deg = DEG_PPERM4(g);
-    if (def == 0 || deg == 0)
-        return EmptyPartialPerm;
-
-    ptf = ADDR_PPERM4(f);
-    ptg = ADDR_PPERM4(g);
-    dom = DOM_PPERM(g);
-    del = 0;
-    codef = CODEG_PPERM4(f);
-    codel = 0;
-
-    if (dom == NULL) {
-        // find the degree of lquo
-        min = MIN(def, deg);
-        for (i = 0; i < min; i++) {
-            if (ptg[i] != 0 && ptf[i] > del) {
-                del = ptf[i];
-                if (del == codef)
-                    break;
-            }
-        }
-        if (del == 0)
-            return EmptyPartialPerm;
-
-        // create new pperm
-        lquo = NEW_PPERM4(del);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptf = ADDR_PPERM4(f);
-        ptg = ADDR_PPERM4(g);
-
-        // multiply
-        for (i = 0; i < min; i++) {
-            if (ptf[i] != 0 && ptg[i] != 0) {
-                ptlquo[ptf[i] - 1] = ptg[i];
-                if (ptg[i] > codel)
-                    codel = ptg[i];
-            }
-        }
-    }
-    else if (deg > def) {    // dom(g) is known
-        // find the degree of lquo
-        len = LEN_PLIST(dom);
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (IMAGEPP(j + 1, ptf, def) > del) {
-                del = ptf[j];
-                if (del == codef)
-                    break;
-            }
-        }
-
-        // create new pperm
-        lquo = NEW_PPERM4(del);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptf = ADDR_PPERM4(f);
-        ptg = ADDR_PPERM4(g);
-
-        // multiply
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (IMAGEPP(j + 1, ptf, def) != 0) {
-                ptlquo[ptf[j] - 1] = ptg[j];
-                if (ptg[j] > codel)
-                    codel = ptg[j];
-            }
-        }
-    }
-    else {    // deg<=def and dom(g) is known
-        len = LEN_PLIST(dom);
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptf[j] > del) {
-                del = ptf[j];
-                if (del == codef)
-                    break;
-            }
-        }
-
-        // create new pperm
-        lquo = NEW_PPERM4(del);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptf = ADDR_PPERM4(f);
-        ptg = ADDR_PPERM4(g);
-
-        // multiply
-        for (i = 1; i <= len; i++) {
-            j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-            if (ptf[j] != 0) {
-                ptlquo[ptf[j] - 1] = ptg[j];
-                if (ptg[j] > codel)
-                    codel = ptg[j];
-            }
-        }
-    }
-    SET_CODEG_PPERM4(lquo, codel);
-    return lquo;
-}
 
 /****************************************************************************
 **
@@ -5429,10 +5105,10 @@ static Int InitKernel(StructInitInfo * module)
     LQuoFuncs[T_PERM2][T_PPERM4] = LQuoPermPPerm<UInt2, UInt4>;
     LQuoFuncs[T_PERM4][T_PPERM2] = LQuoPermPPerm<UInt4, UInt2>;
     LQuoFuncs[T_PERM4][T_PPERM4] = LQuoPermPPerm<UInt4, UInt4>;
-    LQuoFuncs[T_PPERM2][T_PPERM2] = LQuoPPerm22;
-    LQuoFuncs[T_PPERM2][T_PPERM4] = LQuoPPerm24;
-    LQuoFuncs[T_PPERM4][T_PPERM2] = LQuoPPerm42;
-    LQuoFuncs[T_PPERM4][T_PPERM4] = LQuoPPerm44;
+    LQuoFuncs[T_PPERM2][T_PPERM2] = LQuoPPerm<UInt2, UInt2>;
+    LQuoFuncs[T_PPERM2][T_PPERM4] = LQuoPPerm<UInt2, UInt4>;
+    LQuoFuncs[T_PPERM4][T_PPERM2] = LQuoPPerm<UInt4, UInt2>;
+    LQuoFuncs[T_PPERM4][T_PPERM4] = LQuoPPerm<UInt4, UInt4>;
 
     /* install the one function for partial perms */
     OneFuncs[T_PPERM2] = OnePPerm;

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -264,15 +264,16 @@ static inline void SET_DOM_PPERM(Obj f, Obj dom)
 
 // find domain and img set (unsorted) return the rank
 
-static UInt INIT_PPERM2(Obj f)
+template <typename T>
+static UInt INIT_PPERM(Obj f)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    ASSERT_IS_PPERM<T>(f);
 
     UInt    deg, rank, i;
-    UInt2 * ptf;
+    T *     ptf;
     Obj     img, dom;
 
-    deg = DEG_PPERM2(f);
+    deg = DEG_PPERM<T>(f);
 
     if (deg == 0) {
         dom = ImmutableEmptyPlist;
@@ -286,51 +287,7 @@ static UInt INIT_PPERM2(Obj f)
     img = NEW_PLIST_IMM(T_PLIST_CYC, deg);
 
     /* renew the ptr in case of garbage collection */
-    ptf = ADDR_PPERM2(f);
-
-    rank = 0;
-    for (i = 0; i < deg; i++) {
-        if (ptf[i] != 0) {
-            rank++;
-            SET_ELM_PLIST(dom, rank, INTOBJ_INT(i + 1));
-            SET_ELM_PLIST(img, rank, INTOBJ_INT(ptf[i]));
-        }
-    }
-    GAP_ASSERT(rank != 0);    // rank = 0 => deg = 0, so this is not allowed
-
-    SHRINK_PLIST(img, (Int)rank);
-    SET_LEN_PLIST(img, (Int)rank);
-    SHRINK_PLIST(dom, (Int)rank);
-    SET_LEN_PLIST(dom, (Int)rank);
-
-    SET_DOM_PPERM(f, dom);
-    SET_IMG_PPERM(f, img);
-    CHANGED_BAG(f);
-    return rank;
-}
-
-static UInt INIT_PPERM4(Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-
-    UInt    deg, rank, i;
-    UInt4 * ptf;
-    Obj     img, dom;
-
-    deg = DEG_PPERM4(f);
-
-    if (deg == 0) {
-        dom = ImmutableEmptyPlist;
-        SET_DOM_PPERM(f, dom);
-        SET_IMG_PPERM(f, dom);
-        CHANGED_BAG(f);
-        return deg;
-    }
-
-    dom = NEW_PLIST_IMM(T_PLIST_CYC_SSORT, deg);
-    img = NEW_PLIST_IMM(T_PLIST_CYC, deg);
-
-    ptf = ADDR_PPERM4(f);
+    ptf = ADDR_PPERM<T>(f);
 
     rank = 0;
     for (i = 0; i < deg; i++) {
@@ -356,23 +313,29 @@ static UInt INIT_PPERM4(Obj f)
 static UInt INIT_PPERM(Obj f)
 {
     if (TNUM_OBJ(f) == T_PPERM2) {
-        return INIT_PPERM2(f);
+        return INIT_PPERM<UInt2>(f);
     }
     else {
-        return INIT_PPERM4(f);
+        return INIT_PPERM<UInt4>(f);
     }
+}
+
+template <typename T>
+static UInt RANK_PPERM(Obj f)
+{
+    ASSERT_IS_PPERM<T>(f);
+    return (IMG_PPERM(f) == NULL ? INIT_PPERM<T>(f)
+                                 : LEN_PLIST(IMG_PPERM(f)));
 }
 
 UInt RANK_PPERM2(Obj f)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-    return (IMG_PPERM(f) == NULL ? INIT_PPERM2(f) : LEN_PLIST(IMG_PPERM(f)));
+    return RANK_PPERM<UInt2>(f);
 }
 
 UInt RANK_PPERM4(Obj f)
 {
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-    return (IMG_PPERM(f) == NULL ? INIT_PPERM4(f) : LEN_PLIST(IMG_PPERM(f)));
+    return RANK_PPERM<UInt4>(f);
 }
 
 static Obj SORT_PLIST_INTOBJ(Obj res)

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -415,7 +415,7 @@ static Obj PreImagePPermInt(Obj pt, Obj f)
     GAP_ASSERT(IS_INTOBJ(pt));
     ASSERT_IS_PPERM<T>(f);
 
-    T *     ptf;
+    const T * ptf;
     UInt    i, cpt, deg;
 
     cpt = INT_INTOBJ(pt);
@@ -423,7 +423,7 @@ static Obj PreImagePPermInt(Obj pt, Obj f)
         return Fail;
 
     i = 0;
-    ptf = ADDR_PPERM<T>(f);
+    ptf = CONST_ADDR_PPERM<T>(f);
     deg = DEG_PPERM<T>(f);
     while (i < deg && ptf[i] != cpt)
         i++;
@@ -1641,17 +1641,17 @@ template <typename TF, typename TG>
 static Obj NaturalLeqPartialPerm(Obj f, Obj g)
 {
     UInt   def, deg, i, j, rank;
-    TF *   ptf;
-    TG *   ptg;
+    const TF * ptf;
+    const TG * ptg;
     Obj    dom;
 
     def = DEG_PPERM<TF>(f);
-    ptf = ADDR_PPERM<TF>(f);
+    ptf = CONST_ADDR_PPERM<TF>(f);
     if (def == 0)
         return True;
 
     deg = DEG_PPERM<TG>(g);
-    ptg = ADDR_PPERM<TG>(g);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     if (DOM_PPERM(f) == NULL) {
         for (i = 0; i < def; i++) {
             if (ptf[i] != 0 && ptf[i] != IMAGEPP(i + 1, ptg, deg))
@@ -1698,8 +1698,8 @@ static Obj JOIN_IDEM_PPERMS(Obj f, Obj g)
     UInt  def, deg, i;
     Obj   join = NULL;
     Res * ptjoin;
-    TF *  ptf;
-    TG *  ptg;
+    const TF * ptf;
+    const TG * ptg;
 
     def = DEG_PPERM(f);
     deg = DEG_PPERM(g);
@@ -1709,8 +1709,8 @@ static Obj JOIN_IDEM_PPERMS(Obj f, Obj g)
     join = NEW_PPERM<Res>(deg);
     SET_CODEG_PPERM<Res>(join, deg);
     ptjoin = ADDR_PPERM<Res>(join);
-    ptf = ADDR_PPERM<TF>(f);
-    ptg = ADDR_PPERM<TG>(g);
+    ptf = CONST_ADDR_PPERM<TF>(f);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     for (i = 0; i < def; i++) {
         ptjoin[i] = (ptf[i] != 0 ? ptf[i] : ptg[i]);
     }
@@ -1760,8 +1760,8 @@ static Obj JOIN_PPERMS(Obj f, Obj g)
 
     UInt   deg, i, j, degf, degg, codeg, rank;
     Res *   ptjoin;
-    TF *    ptf;
-    TG *    ptg;
+    const TF * ptf;
+    const TG * ptg;
     UInt4 * ptseen;
     Obj    join, dom;
 
@@ -1779,8 +1779,8 @@ static Obj JOIN_PPERMS(Obj f, Obj g)
     SET_CODEG_PPERM<Res>(join, codeg);
 
     ptjoin = ADDR_PPERM<Res>(join);
-    ptf = ADDR_PPERM<TF>(f);
-    ptg = ADDR_PPERM<TG>(g);
+    ptf = CONST_ADDR_PPERM<TF>(f);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     ptseen = ADDR_PPERM4(TmpPPerm);
 
     if (DOM_PPERM(f) != NULL) {
@@ -2452,8 +2452,8 @@ static Int EqPPerm(Obj f, Obj g)
     ASSERT_IS_PPERM<TF>(f);
     ASSERT_IS_PPERM<TG>(g);
 
-    TF *    ptf = ADDR_PPERM<TF>(f);
-    TG *    ptg = ADDR_PPERM<TG>(g);
+    const TF * ptf = CONST_ADDR_PPERM<TF>(f);
+    const TG * ptg = CONST_ADDR_PPERM<TG>(g);
     UInt    deg = DEG_PPERM<TF>(f);
     UInt    i, j, rank;
     Obj     dom;
@@ -2488,8 +2488,8 @@ static Int LtPPerm(Obj f, Obj g)
     ASSERT_IS_PPERM<TF>(f);
     ASSERT_IS_PPERM<TG>(g);
 
-    TF *    ptf = ADDR_PPERM<TF>(f);
-    TG *    ptg = ADDR_PPERM<TG>(g);
+    const TF * ptf = CONST_ADDR_PPERM<TF>(f);
+    const TG * ptg = CONST_ADDR_PPERM<TG>(g);
     UInt    deg, i;
 
     deg = DEG_PPERM<TF>(f);
@@ -2521,8 +2521,8 @@ static Obj ProdPPerm(Obj f, Obj g)
     ASSERT_IS_PPERM<TG>(g);
 
     UInt    deg, degg, i, j, rank, codeg;
-    TF *    ptf;
-    TG *    ptg;
+    const TF * ptf;
+    const TG * ptg;
     TG *    ptfg;
     Obj     fg, dom;
 
@@ -2532,8 +2532,8 @@ static Obj ProdPPerm(Obj f, Obj g)
     if (deg == 0 || degg == 0)
         return EmptyPartialPerm;
 
-    ptf = ADDR_PPERM<TF>(f);
-    ptg = ADDR_PPERM<TG>(g);
+    ptf = CONST_ADDR_PPERM<TF>(f);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     while (deg > 0 &&
            (ptf[deg - 1] == 0 || IMAGEPP(ptf[deg - 1], ptg, degg) == 0))
         deg--;
@@ -2543,8 +2543,8 @@ static Obj ProdPPerm(Obj f, Obj g)
     // create new pperm
     fg = NEW_PPERM<TG>(deg);
     ptfg = ADDR_PPERM<TG>(fg);
-    ptf = ADDR_PPERM<TF>(f);
-    ptg = ADDR_PPERM<TG>(g);
+    ptf = CONST_ADDR_PPERM<TF>(f);
+    ptg = CONST_ADDR_PPERM<TG>(g);
     codeg = 0;
 
     // compose in rank operations
@@ -2818,8 +2818,8 @@ static Obj ProdPermPPerm(Obj p, Obj f)
     ASSERT_IS_PERM<TP>(p);
     ASSERT_IS_PPERM<TF>(f);
 
-    TP * ptp;
-    TF * ptf;
+    const TP * ptp;
+    const TF * ptf;
     TF * ptpf;
     UInt degp, degf, i;
     Obj  pf;
@@ -2833,8 +2833,8 @@ static Obj ProdPermPPerm(Obj p, Obj f)
     if (degp < degf) {
         pf = NEW_PPERM<TF>(degf);
         ptpf = ADDR_PPERM<TF>(pf);
-        ptp = ADDR_PERM<TP>(p);
-        ptf = ADDR_PPERM<TF>(f);
+        ptp = CONST_ADDR_PERM<TP>(p);
+        ptf = CONST_ADDR_PPERM<TF>(f);
         for (i = 0; i < degp; i++)
             *ptpf++ = ptf[*ptp++];
         for (; i < degf; i++)
@@ -2842,14 +2842,14 @@ static Obj ProdPermPPerm(Obj p, Obj f)
     }
     else {    // deg(f)<=deg(p)
         // find the degree
-        ptp = ADDR_PERM<TP>(p);
-        ptf = ADDR_PPERM<TF>(f);
+        ptp = CONST_ADDR_PERM<TP>(p);
+        ptf = CONST_ADDR_PPERM<TF>(f);
         while (ptp[degp - 1] >= degf || ptf[ptp[degp - 1]] == 0)
             degp--;
         pf = NEW_PPERM<TF>(degp);
         ptpf = ADDR_PPERM<TF>(pf);
-        ptp = ADDR_PERM<TP>(p);
-        ptf = ADDR_PPERM<TF>(f);
+        ptp = CONST_ADDR_PERM<TP>(p);
+        ptf = CONST_ADDR_PPERM<TF>(f);
         for (i = 0; i < degp; i++)
             if (ptp[i] < degf)
                 ptpf[i] = ptf[ptp[i]];
@@ -4402,27 +4402,30 @@ static Obj PowIntPPerm4(Obj i, Obj f)
 }
 
 // p^-1*f
-static Obj LQuoPerm2PPerm2(Obj p, Obj f)
+template <typename TP, typename TF>
+static Obj LQuoPermPPerm(Obj p, Obj f)
 {
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
+    ASSERT_IS_PERM<TP>(p);
+    ASSERT_IS_PPERM<TF>(f);
 
-    UInt2 *ptp, *ptf, *ptlquo;
+    TP *   ptp;
+    TF *   ptf;
+    TF *   ptlquo;
     UInt   def, dep, i, j, del, len;
     Obj    dom, lquo;
 
-    def = DEG_PPERM2(f);
+    def = DEG_PPERM<TF>(f);
     if (def == 0)
         return EmptyPartialPerm;
 
-    dep = DEG_PERM2(p);
+    dep = DEG_PERM<TP>(p);
     dom = DOM_PPERM(f);
 
     if (dep < def) {
-        lquo = NEW_PPERM2(def);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM2(f);
+        lquo = NEW_PPERM<TF>(def);
+        ptlquo = ADDR_PPERM<TF>(lquo);
+        ptp = ADDR_PERM<TP>(p);
+        ptf = ADDR_PPERM<TF>(f);
         if (dom == NULL) {
             for (i = 0; i < dep; i++)
                 ptlquo[ptp[i]] = ptf[i];
@@ -4439,8 +4442,8 @@ static Obj LQuoPerm2PPerm2(Obj p, Obj f)
     }
     else {    // deg(p)>=deg(f)
         del = 0;
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM2(f);
+        ptp = ADDR_PERM<TP>(p);
+        ptf = ADDR_PPERM<TF>(f);
         if (dom == NULL) {
             // find the degree
             for (i = 0; i < def; i++) {
@@ -4450,10 +4453,10 @@ static Obj LQuoPerm2PPerm2(Obj p, Obj f)
                         break;
                 }
             }
-            lquo = NEW_PPERM2(del);
-            ptlquo = ADDR_PPERM2(lquo);
-            ptp = ADDR_PERM2(p);
-            ptf = ADDR_PPERM2(f);
+            lquo = NEW_PPERM<TF>(del);
+            ptlquo = ADDR_PPERM<TF>(lquo);
+            ptp = ADDR_PERM<TP>(p);
+            ptf = ADDR_PPERM<TF>(f);
 
             // if required below in case ptp[i]>del but ptf[i]=0
             for (i = 0; i < def; i++)
@@ -4470,10 +4473,10 @@ static Obj LQuoPerm2PPerm2(Obj p, Obj f)
                         break;
                 }
             }
-            lquo = NEW_PPERM2(del);
-            ptlquo = ADDR_PPERM2(lquo);
-            ptp = ADDR_PERM2(p);
-            ptf = ADDR_PPERM2(f);
+            lquo = NEW_PPERM<TF>(del);
+            ptlquo = ADDR_PPERM<TF>(lquo);
+            ptp = ADDR_PERM<TP>(p);
+            ptf = ADDR_PPERM<TF>(f);
 
             for (i = 1; i <= len; i++) {
                 j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
@@ -4482,260 +4485,7 @@ static Obj LQuoPerm2PPerm2(Obj p, Obj f)
         }
     }
 
-    SET_CODEG_PPERM2(lquo, CODEG_PPERM2(f));
-    return lquo;
-}
-
-static Obj LQuoPerm2PPerm4(Obj p, Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM2);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-
-    UInt2 *ptp;
-    UInt4 *ptf, *ptlquo;
-    UInt   def, dep, i, j, del, len;
-    Obj    dom, lquo;
-
-    def = DEG_PPERM4(f);
-    if (def == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM2(p);
-    dom = DOM_PPERM(f);
-
-    if (dep < def) {
-        lquo = NEW_PPERM4(def);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM4(f);
-        if (dom == NULL) {
-            for (i = 0; i < dep; i++)
-                ptlquo[ptp[i]] = ptf[i];
-            for (; i < def; i++)
-                ptlquo[i] = ptf[i];
-        }
-        else {
-            len = LEN_PLIST(dom);
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
-            }
-        }
-    }
-    else {    // deg(p)>=deg(f)
-        del = 0;
-        ptp = ADDR_PERM2(p);
-        ptf = ADDR_PPERM4(f);
-        if (dom == NULL) {
-            // find the degree
-            for (i = 0; i < def; i++) {
-                if (ptf[i] != 0 && ptp[i] >= del) {
-                    del = ptp[i] + 1;
-                    if (del == dep)
-                        break;
-                }
-            }
-            lquo = NEW_PPERM4(del);
-            ptlquo = ADDR_PPERM4(lquo);
-            ptp = ADDR_PERM2(p);
-            ptf = ADDR_PPERM4(f);
-
-            // if required below in case ptp[i]>del but ptf[i]=0
-            for (i = 0; i < def; i++)
-                if (ptf[i] != 0)
-                    ptlquo[ptp[i]] = ptf[i];
-        }
-        else {    // dom(f) is known
-            len = LEN_PLIST(dom);
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                if (ptp[j] >= del) {
-                    del = ptp[j] + 1;
-                    if (del == dep)
-                        break;
-                }
-            }
-            lquo = NEW_PPERM4(del);
-            ptlquo = ADDR_PPERM4(lquo);
-            ptp = ADDR_PERM2(p);
-            ptf = ADDR_PPERM4(f);
-
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptlquo[ptp[j]] = ptf[j];
-            }
-        }
-    }
-    SET_CODEG_PPERM4(lquo, CODEG_PPERM4(f));
-    return lquo;
-}
-
-static Obj LQuoPerm4PPerm2(Obj p, Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM2);
-
-    UInt4 *ptp, dep;
-    UInt2 *ptf, *ptlquo;
-    UInt   def, i, j, del, len;
-    Obj    dom, lquo;
-
-    def = DEG_PPERM2(f);
-    if (def == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM4(p);
-    dom = DOM_PPERM(f);
-
-    if (dep < def) {
-        lquo = NEW_PPERM2(def);
-        ptlquo = ADDR_PPERM2(lquo);
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM2(f);
-        if (dom == NULL) {
-            for (i = 0; i < dep; i++)
-                ptlquo[ptp[i]] = ptf[i];
-            for (; i < def; i++)
-                ptlquo[i] = ptf[i];
-        }
-        else {
-            len = LEN_PLIST(dom);
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
-            }
-        }
-    }
-    else {    // deg(p)>=deg(f)
-        del = 0;
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM2(f);
-        if (dom == NULL) {
-            // find the degree
-            for (i = 0; i < def; i++) {
-                if (ptf[i] != 0 && ptp[i] >= del) {
-                    del = ptp[i] + 1;
-                    if (del == dep)
-                        break;
-                }
-            }
-            lquo = NEW_PPERM2(del);
-            ptlquo = ADDR_PPERM2(lquo);
-            ptp = ADDR_PERM4(p);
-            ptf = ADDR_PPERM2(f);
-
-            // if required below in case ptp[i]>del but ptf[i]=0
-            for (i = 0; i < def; i++)
-                if (ptf[i] != 0)
-                    ptlquo[ptp[i]] = ptf[i];
-        }
-        else {    // dom(f) is known
-            len = LEN_PLIST(dom);
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                if (ptp[j] >= del) {
-                    del = ptp[j] + 1;
-                    if (del == dep)
-                        break;
-                }
-            }
-            lquo = NEW_PPERM2(del);
-            ptlquo = ADDR_PPERM2(lquo);
-            ptp = ADDR_PERM4(p);
-            ptf = ADDR_PPERM2(f);
-
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptlquo[ptp[j]] = ptf[j];
-            }
-        }
-    }
-
-    SET_CODEG_PPERM2(lquo, CODEG_PPERM2(f));
-    return lquo;
-}
-
-static Obj LQuoPerm4PPerm4(Obj p, Obj f)
-{
-    GAP_ASSERT(TNUM_OBJ(p) == T_PERM4);
-    GAP_ASSERT(TNUM_OBJ(f) == T_PPERM4);
-
-    UInt4 *ptp, *ptf, *ptlquo;
-    UInt   def, dep, i, j, del, len;
-    Obj    dom, lquo;
-
-    def = DEG_PPERM4(f);
-    if (def == 0)
-        return EmptyPartialPerm;
-
-    dep = DEG_PERM4(p);
-    dom = DOM_PPERM(f);
-
-    if (dep < def) {
-        lquo = NEW_PPERM4(def);
-        ptlquo = ADDR_PPERM4(lquo);
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM4(f);
-        if (dom == NULL) {
-            for (i = 0; i < dep; i++)
-                ptlquo[ptp[i]] = ptf[i];
-            for (; i < def; i++)
-                ptlquo[i] = ptf[i];
-        }
-        else {
-            len = LEN_PLIST(dom);
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptlquo[IMAGE(j, ptp, dep)] = ptf[j];
-            }
-        }
-    }
-    else {    // deg(p)>=deg(f)
-        del = 0;
-        ptp = ADDR_PERM4(p);
-        ptf = ADDR_PPERM4(f);
-        if (dom == NULL) {
-            // find the degree
-            for (i = 0; i < def; i++) {
-                if (ptf[i] != 0 && ptp[i] >= del) {
-                    del = ptp[i] + 1;
-                    if (del == dep)
-                        break;
-                }
-            }
-            lquo = NEW_PPERM4(del);
-            ptlquo = ADDR_PPERM4(lquo);
-            ptp = ADDR_PERM4(p);
-            ptf = ADDR_PPERM4(f);
-
-            // if required below in case ptp[i]>del but ptf[i]=0
-            for (i = 0; i < def; i++)
-                if (ptf[i] != 0)
-                    ptlquo[ptp[i]] = ptf[i];
-        }
-        else {    // dom(f) is known
-            len = LEN_PLIST(dom);
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                if (ptp[j] >= del) {
-                    del = ptp[j] + 1;
-                    if (del == dep)
-                        break;
-                }
-            }
-            lquo = NEW_PPERM4(del);
-            ptlquo = ADDR_PPERM4(lquo);
-            ptp = ADDR_PERM4(p);
-            ptf = ADDR_PPERM4(f);
-
-            for (i = 1; i <= len; i++) {
-                j = INT_INTOBJ(ELM_PLIST(dom, i)) - 1;
-                ptlquo[ptp[j]] = ptf[j];
-            }
-        }
-    }
-
-    SET_CODEG_PPERM4(lquo, CODEG_PPERM4(f));
+    SET_CODEG_PPERM<TF>(lquo, CODEG_PPERM<TF>(f));
     return lquo;
 }
 
@@ -5675,10 +5425,10 @@ static Int InitKernel(StructInitInfo * module)
     QuoFuncs[T_PPERM4][T_PPERM4] = QuoPPerm44;
     QuoFuncs[T_INT][T_PPERM2] = PreImagePPermInt<UInt2>;
     QuoFuncs[T_INT][T_PPERM4] = PreImagePPermInt<UInt4>;
-    LQuoFuncs[T_PERM2][T_PPERM2] = LQuoPerm2PPerm2;
-    LQuoFuncs[T_PERM2][T_PPERM4] = LQuoPerm2PPerm4;
-    LQuoFuncs[T_PERM4][T_PPERM2] = LQuoPerm4PPerm2;
-    LQuoFuncs[T_PERM4][T_PPERM4] = LQuoPerm4PPerm4;
+    LQuoFuncs[T_PERM2][T_PPERM2] = LQuoPermPPerm<UInt2, UInt2>;
+    LQuoFuncs[T_PERM2][T_PPERM4] = LQuoPermPPerm<UInt2, UInt4>;
+    LQuoFuncs[T_PERM4][T_PPERM2] = LQuoPermPPerm<UInt4, UInt2>;
+    LQuoFuncs[T_PERM4][T_PPERM4] = LQuoPermPPerm<UInt4, UInt4>;
     LQuoFuncs[T_PPERM2][T_PPERM2] = LQuoPPerm22;
     LQuoFuncs[T_PPERM2][T_PPERM4] = LQuoPPerm24;
     LQuoFuncs[T_PPERM4][T_PPERM2] = LQuoPPerm42;


### PR DESCRIPTION
These changes were carefully prepared: usually, I took a group of 2 or 4 functions to be merged into a single function, put them into a separate document, then used regex search and replace to replace common patterns by their C++ counterpart (e.g  replace `2(f)` by `<TF>(f)` to convert things like `ADDR_PPERM2(f)` to `ADDR_PPERM<TF>(f)`). After a bunch of such scripted conversions, a few manual changes (typically for `NEW_PPERM` calls and other output related calls) were performed. Afterwards, ideally the 2 or 4 variants of the code already were identical; if not, then any minor cosmetic differences (spaces, extra parens/braces/etc.) were aligned, until the matched.

Still, mistakes can happen, which is why I usually convert only 1-2 functions per commit, to make it easier to bisect any regressions introduced by these changes.