### PR TITLE
Added more specialised function for testing conjugacy of subgroups of Sn

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1552,6 +1552,20 @@ local og,oh,cb,cc,cac,perm1,perm2,
   fi;
 end);
 
+InstallMethod( IsConjugate, "for natural symmetric group",
+    true, [ IsNaturalSymmetricGroup, IsGroup, IsGroup ],
+function (s, g, h)
+  local res;
+  res := SubgpConjSymmgp(s, g, h);
+  if IsPerm(res) then
+    return true;
+  elif res = fail then
+    return false;
+  else
+   TryNextMethod();
+  fi;
+end);
+
 #############################################################################
 ##
 #M  RepresentativeAction( <G>, <d>, <e>, <opr> ) .  . for symmetric groups

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1273,7 +1273,7 @@ DeclareGlobalFunction("MaximalSolvableSubgroups");
 ##  is the smallest normal subgroup of <A>G</A> that has a solvable factor group.
 ##  <Example><![CDATA[
 ##  gap> PerfectResiduum(Group((1,2,3,4,5),(1,2)));
-##  Group([ (1,3,2), (1,4,3), (3,5,4) ])
+##  Group([ (1,3,2), (1,4,3), (2,5,4) ])
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/tst/testinstall/ConjNatSym.tst
+++ b/tst/testinstall/ConjNatSym.tst
@@ -1,0 +1,14 @@
+# The following two test use the new version for natural symmetric group
+
+gap> IsConjugate( SymmetricGroup(5), Group((1,2)), Group((3,4)));
+true
+gap> IsConjugate( SymmetricGroup(5), Group((1,2)), Group((3,4,5)));
+false
+
+# This runs into the TryNextMethod case
+gap> IsConjugate( SymmetricGroup(200),PrimitiveGroup(200,4), PrimitiveGroup(200,3));
+false
+
+# Here, using SubgpConjSymmgp yields a significant speedup
+gap> IsConjugate(SymmetricGroup(250),Group([ (1,5,9,7)(2,3)(4,8,6,10), (1,9)(5,7)(8,10), (1,9)(8,10) ]), Group([ (1,3)(2,8,10)(4,6)(5,11,7,9), (2,8)(9,11), (1,3)(4,6)(5,9,7,11)(8,10) ]));
+false


### PR DESCRIPTION
Directly using `SubgpConjSymmgp` as a specialized method  when testing two subgroups of a natural symmetric group for conjugacy in the full symmetric group often yields a speedup as for example in the last case in the test file. 