### PR TITLE
ci: enable coverage for C++ code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: c
 
 env:
   global:
-    - CFLAGS="--coverage -O2"
+    - CFLAGS="--coverage -O2 -g"
+    - CXXFLAGS="--coverage -O2 -g"
     - LDFLAGS="--coverage"
     # default config flags: enable debug asserts
     - CONFIGFLAGS="--enable-debug"
@@ -45,7 +46,7 @@ matrix:
     # digraphs and other kernel extensions using C++ code (due to GCC's
     # `profiler_trace.h` calling `atexit`; but that fails in loadable modules
     # for technical reasons)
-    - env: TEST_SUITES=testpackages CFLAGS="-O2" LDFLAGS=
+    - env: TEST_SUITES=testpackages CFLAGS="-O2" CXXFLAGS="-O2" LDFLAGS=
       addons:
         apt_packages:
           - gcc-multilib
@@ -62,7 +63,7 @@ matrix:
           - libzmq3-dev             # for ZeroMQInterface
 
     # compiler packages and run package tests in 32 bit mode
-    - env: TEST_SUITES=testpackages CFLAGS="-O2" LDFLAGS= ABI=32
+    - env: TEST_SUITES=testpackages CFLAGS="-O2" CXXFLAGS="-O2" LDFLAGS= ABI=32
       addons:
         apt_packages:
           - gcc-multilib

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -90,10 +90,10 @@ then
   time git clone https://github.com/gap-packages/profiling
 
   # Compile io and profiling packages
-  # we deliberately reset CFLAGS and LDFLAGS to prevent them from being
+  # we deliberately reset CFLAGS, CXXFLAGS, LDFLAGS to prevent them from being
   # compiled with coverage gathering, because otherwise gcov may confuse
   # IO's src/io.c with GAP's.
-  CFLAGS= LDFLAGS= "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR" io* profiling*
+  CFLAGS= CXXFLAGS= LDFLAGS= "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR" io* profiling*
 
   #
   # Factint is incompatible with HPCGAP and interferes with some tests

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -57,11 +57,12 @@ do
     # see <https://gcc.gnu.org/gcc-4.9/porting_to.html>
     printf "%s\n" 1 i "#include <stddef.h>" . w | ed float*/src/mp_poly.C
 
-    # reset CFLAGS and LDFLAGS before compiling packages, to prevent
+    # reset CFLAGS, CXXFLAGS, LDFLAGS before compiling packages, to prevent
     # them from being compiled with coverage gathering, because
     # otherwise gcov may confuse IO's src/io.c, or anupq's src/read.c,
     # with GAP kernel files with the same name
     unset CFLAGS
+    unset CXXFLAGS
     unset LDFLAGS
     if ! "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR"
     then


### PR DESCRIPTION
This is an attempt to get code coverage for C++ code on Codecov and Coveralls working.