### PR TITLE
kernel: rewrite SCR_SIFT_HELPER using C++ templates

### DIFF
--- a/src/modules-builtin.c
+++ b/src/modules-builtin.c
@@ -66,6 +66,12 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
 
     /* arithmetic operations                                               */
     InitInfoAriths,
+
+    /* record packages                                                     */
+    InitInfoRecords,
+    InitInfoPRecord,
+
+    /* internal types                                                      */
     InitInfoInt,
     InitInfoIntFuncs,
     InitInfoRat,
@@ -76,10 +82,6 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
     InitInfoPPerm,
     InitInfoBool,
     InitInfoMacfloat,
-
-    /* record packages                                                     */
-    InitInfoRecords,
-    InitInfoPRecord,
 
     /* list packages                                                       */
     InitInfoLists,


### PR DESCRIPTION
This also fixes a bug where it called DEG_PERM2 on a T_PERM4. I do not know if this caused user visible problems.
