### PR TITLE
Valgrind fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,14 @@ matrix:
     # vary compared to the in-tree builds, we turn off coverage reporting by
     # setting NO_COVERAGE=1; this has the extra benefit of also running the
     # tests at least once with the ReproducibleBehaviour option turned off.
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build
+    #
+    # The '--enable-valgrind' checks that GAP builds and runs correctly when
+    # compiled with valgrind support. We do not actually run any tests using
+    # valgrind, as it is too slow.
+    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-valgrind"
+      addons:
+        apt_packages:
+            valgrind
 
     # same as above, but in 32 bit mode, also turn off debugging (see elsewhere in this file for
     # an explanation)

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -509,7 +509,7 @@ static void CANARY_FORBID_ACCESS_ALL_BAGS(void)
 #define CANARY_ENABLE_VALGRIND() VALGRIND_ENABLE_ERROR_REPORTING
 
 // CHANGED_BAG must be here to disable/enable valgrind
-static void CHANGED_BAG(Bag bag)
+void CHANGED_BAG(Bag bag)
 {
     CANARY_DISABLE_VALGRIND();
     if (CONST_PTR_BAG(bag) <= YoungBags && LINK_BAG(bag) == bag) {


### PR DESCRIPTION
A recent PR broke --enable-valgrind.

This fixes it, and makes sure we test it in future (it doesn't actually run any tests in valgrind, because they are too slow to finish in reasonable time on travis, but we at least check GAP builds and runs with the flag enabled.