### PR TITLE
Add tests for slow IO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - libreadline-dev
     - python
     - python-pip
+    - perl
 
 #
 # The following test jobs are roughly sorted by duration, from longest to

--- a/tst/teststandard/processes/slowwrite.sh
+++ b/tst/teststandard/processes/slowwrite.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# We use printf here to allow the arguments to contain '\n'
+# so we can explictly control where newlines appear.
+printf "$2"
+sleep 1
+printf "$3"

--- a/tst/teststandard/processes/streamio.tst
+++ b/tst/teststandard/processes/streamio.tst
@@ -1,0 +1,53 @@
+#@local scriptdir, write, checkPartialRead, process, c
+#
+gap> START_TEST("streamio.tst");
+gap> scriptdir := DirectoriesLibrary( "tst/teststandard/processes/" );;
+gap> write := Filename(scriptdir, "slowwrite.sh");;
+
+# Read the output of 'prog', using 'readfunc'. The output should
+# come in two parts, 'firstread' and 'secondread'.
+# If GAP is too slow, allow 'firstread' and 'secondread' to be read
+# in one step, but then return 'false'.
+# We run this function multiple times to avoid very occasional failures
+# due to OS scheduling.
+gap> checkPartialRead := function(prog, readfunc, firstread, secondread)
+> local process, l;
+> process := InputOutputLocalProcess(DirectoryCurrent(), prog, ["prog", firstread, secondread]);
+> l := ReadLine(process);
+> if l = Concatenation(firstread, secondread) then
+>   if ReadLine(process) <> fail then Error("Invalid end - type 1"); fi;
+>   CloseStream(process);
+>   return false;
+> else
+>   if ReadLine(process) <> secondread then Error("Missing second"); fi;
+>   if ReadLine(process) <> fail then Error("Invalid end - type 2"); fi;
+>   CloseStream(process);
+>   return true;
+> fi;
+> end;;
+gap> ForAny([1..10], x -> checkPartialRead(write, ReadLine, "aaa", "aaa\n"));
+true
+gap> ForAny([1..10], x -> checkPartialRead(write, ReadLine, "aaa", "aaa"));
+true
+gap> ForAny([1..10], x -> checkPartialRead(write, ReadAll, "aaa", "aaa\n"));
+true
+
+# Read as bytes, which is always identical
+gap> process := InputOutputLocalProcess(DirectoryCurrent(), write, ["prog", "abc", "def"]);
+< input/output stream to slowwrite.sh >
+gap> c := ReadByte(process);
+97
+gap> c := ReadByte(process);
+98
+gap> c := ReadByte(process);
+99
+gap> c := ReadByte(process);
+100
+gap> c := ReadByte(process);
+101
+gap> c := ReadByte(process);
+102
+gap> c := ReadByte(process);
+fail
+gap> CloseStream(process);
+gap> STOP_TEST("streamio.tst", 1);


### PR DESCRIPTION
This adds some tests for when processes are slow at returning input to GAP.

As well as being (hopefully) generally useful, this is also one of the remaining sources of variation in coverage.