### PR TITLE
Make compiler aware of hvars, and the lvar bag cache

### DIFF
--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -2553,6 +2553,7 @@ static Obj  HdlrFunc7 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  ASS_LVAR( 1, a_getter );
  
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
@@ -3273,6 +3274,7 @@ static Obj  HdlrFunc11 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,4,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_keytest );
  
@@ -3769,6 +3771,7 @@ static Obj  HdlrFunc17 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,5,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -304,6 +304,7 @@ static Obj  HdlrFunc3 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_tester );
  

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -127,7 +127,7 @@ typedef UInt    RNam;
 /* higher variables, should go into 'vars.c' * * * * * * * * * * * * * * * */
 
 #define SWITCH_TO_NEW_FRAME     SWITCH_TO_NEW_LVARS
-#define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS
+#define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS_AND_FREE
 
 
 /* lists, should go into 'lists.c' * * * * * * * * * * * * * * * * * * * * */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5137,6 +5137,9 @@ static void CompFunc(Obj func)
     /* emit the code to switch to a new frame for outer functions          */
     Emit( "\n/* allocate new stack frame */\n" );
     Emit( "SWITCH_TO_NEW_FRAME(self,%d,0,oldFrame);\n",NHVAR_INFO(info));
+    if (NHVAR_INFO(info) > 0) {
+        Emit("MakeHighVars(STATE(CurrLVars));\n");
+    }
     for ( i = 1; i <= narg; i++ ) {
         if ( CompGetUseHVar( i ) ) {
             Emit( "ASS_LVAR( %d, %c );\n",GetIndxHVar(i),CVAR_LVAR(i));
@@ -5156,6 +5159,7 @@ static void CompFunc(Obj func)
 
     /* emit the code to switch back to the old frame and return            */
     Emit( "\n/* return; */\n" );
+
     Emit( "SWITCH_TO_OLD_FRAME(oldFrame);\n" );
     Emit( "return 0;\n" );
     Emit( "}\n" );

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -2604,6 +2604,7 @@ static Obj  HdlrFunc7 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  ASS_LVAR( 1, a_getter );
  
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
@@ -3336,6 +3337,7 @@ static Obj  HdlrFunc11 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,4,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_keytest );
  
@@ -3844,6 +3846,7 @@ static Obj  HdlrFunc17 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,5,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -343,6 +343,7 @@ static Obj  HdlrFunc3 (
  
  /* allocate new stack frame */
  SWITCH_TO_NEW_FRAME(self,2,0,oldFrame);
+ MakeHighVars(STATE(CurrLVars));
  ASS_LVAR( 1, a_name );
  ASS_LVAR( 2, a_tester );
  


### PR DESCRIPTION
GAP has the concept of lvars bags, which can become hvar bags if references to them are captured. This allows caching and reusing used lvars bags.

This is entirely ignored by the compiler -- it neither marks bags as hvar bags, or allows bags to be reused. I think these two things together cancel out, meaning this can't lead to any bag corruption, but I'm not 100% positive. I'd certainly be happier to fix it.

This PR makes the lvar bag cache much more useful -- without this PR it has about a 40% hit rate during startup, with this PR this goes up to about 95%.