### PR TITLE
kernel/gac: fix CompUnbComObjExpr

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -539,7 +539,7 @@ typedef UInt    GVar;
 #define COMP_USE_GVAR_COPY      (1L << 1)
 #define COMP_USE_GVAR_FOPY      (1L << 2)
 
-Bag             CompInfoGVar;
+static Bag CompInfoGVar;
 
 static void CompSetUseGVar(GVar gvar, UInt mode)
 {
@@ -581,7 +581,7 @@ typedef UInt    RNam;
 
 #define COMP_USE_RNAM_ID        (1L << 0)
 
-Bag             CompInfoRNam;
+static Bag CompInfoRNam;
 
 static void CompSetUseRNam(RNam rnam, UInt mode)
 {
@@ -4693,7 +4693,7 @@ static void CompUnbRecExpr(Stat stat)
     /* compile the record expression                                       */
     record = CompExpr(READ_STAT(stat, 0));
 
-    /* get the name (stored immediately in the statement)                  */
+    /* get the name expression                                             */
     rnam = CompExpr(READ_STAT(stat, 1));
 
     /* emit the code for the assignment                                    */
@@ -4884,9 +4884,8 @@ static void CompUnbComObjExpr(Stat stat)
     /* compile the record expression                                       */
     record = CompExpr(READ_STAT(stat, 0));
 
-    /* get the name (stored immediately in the statement)                  */
+    /* get the name expression                                             */
     rnam = CompExpr(READ_STAT(stat, 1));
-    CompSetUseRNam( rnam, COMP_USE_RNAM_ID );
 
     /* emit the code for the assignment                                    */
     Emit( "UnbComObj( %c, RNamObj(%c) );\n", record, rnam );

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -32,7 +32,6 @@ static Obj  GF_test__loops;
 static GVar G_runtest;
 
 /* record names used in handlers */
-static RNam R_WarnOnUnboundGlobals;
 static RNam R_myopt;
 static RNam R_x;
 static RNam R_a;
@@ -1964,7 +1963,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_runtest = GVarName( "runtest" );
  
  /* record names used in handlers */
- R_WarnOnUnboundGlobals = RNamName( "WarnOnUnboundGlobals" );
  R_myopt = RNamName( "myopt" );
  R_x = RNamName( "x" );
  R_a = RNamName( "a" );

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -32,7 +32,6 @@ static Obj  GF_test__loops;
 static GVar G_runtest;
 
 /* record names used in handlers */
-static RNam R_WarnOnUnboundGlobals;
 static RNam R_myopt;
 static RNam R_x;
 static RNam R_a;
@@ -1964,7 +1963,6 @@ static Int PostRestore ( StructInitInfo * module )
  G_runtest = GVarName( "runtest" );
  
  /* record names used in handlers */
- R_WarnOnUnboundGlobals = RNamName( "WarnOnUnboundGlobals" );
  R_myopt = RNamName( "myopt" );
  R_x = RNamName( "x" );
  R_a = RNamName( "a" );


### PR DESCRIPTION
CompUnbComObjExpr was calling CompSetUseRNam but should not; this lead to the value of random RNams being emitted to the generated C code.

This lead to a test failure in #3234.
