### PR TITLE
kernel: remove some dead code involving NargError

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -311,7 +311,7 @@ static Obj DoWrap6args(
 /* Pull this out to avoid repetition, since it gets a little more complex in 
    the presence of partially variadic functions */
 
-Obj NargError(Obj func, Int actual)
+NORETURN static void NargError(Obj func, Int actual)
 {
   Int narg = NARG_FUNC(func);
 
@@ -326,9 +326,7 @@ Obj NargError(Obj func, Int actual)
 
 static Obj DoFail0args(Obj self)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 0);
-    return CallFuncList( self, argx );
+    NargError(self, 0);
 }
 
 
@@ -338,9 +336,7 @@ static Obj DoFail0args(Obj self)
 */
 static Obj DoFail1args(Obj self, Obj arg1)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 1);
-    return CallFuncList( self, argx );
+    NargError(self, 1);
 }
 
 
@@ -350,9 +346,7 @@ static Obj DoFail1args(Obj self, Obj arg1)
 */
 static Obj DoFail2args(Obj self, Obj arg1, Obj arg2)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 2);
-    return CallFuncList( self, argx );
+    NargError(self, 2);
 }
 
 
@@ -362,9 +356,7 @@ static Obj DoFail2args(Obj self, Obj arg1, Obj arg2)
 */
 static Obj DoFail3args(Obj self, Obj arg1, Obj arg2, Obj arg3)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 3);
-    return CallFuncList( self, argx );
+    NargError(self, 3);
 }
 
 
@@ -374,9 +366,7 @@ static Obj DoFail3args(Obj self, Obj arg1, Obj arg2, Obj arg3)
 */
 static Obj DoFail4args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 4);
-    return CallFuncList( self, argx );
+    NargError(self, 4);
 }
 
 
@@ -387,9 +377,7 @@ static Obj DoFail4args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4)
 static Obj
 DoFail5args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 5);
-    return CallFuncList( self, argx );
+    NargError(self, 5);
 }
 
 
@@ -400,9 +388,7 @@ DoFail5args(Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5)
 static Obj DoFail6args(
     Obj self, Obj arg1, Obj arg2, Obj arg3, Obj arg4, Obj arg5, Obj arg6)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, 6);
-    return CallFuncList( self, argx );
+    NargError(self, 6);
 }
 
 
@@ -412,9 +398,7 @@ static Obj DoFail6args(
 */
 static Obj DoFailXargs(Obj self, Obj args)
 {
-    Obj                 argx;           /* arguments list (to continue)    */
-    argx =NargError(self, LEN_LIST(args));
-    return CallFuncList( self, argx );
+    NargError(self, LEN_LIST(args));
 }
 
 

--- a/src/calls.h
+++ b/src/calls.h
@@ -291,7 +291,6 @@ EXPORT_INLINE ObjFunc_1ARGS HDLR_XARGS(Obj func)
     return (ObjFunc_1ARGS)HDLR_FUNC(func, 7);
 }
 
-Obj NargError(Obj func, Int actual);
 
 /****************************************************************************
 **

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -579,7 +579,7 @@ static Obj DoPartialUnWrapFunc(Obj func, Obj args)
     UInt named;    /* number of arguments */
     UInt i;        /* loop variable */
     UInt len;
-    Obj  argx, result;
+    Obj  result;
 
     HookedLineIntoFunction(func);
 
@@ -587,8 +587,7 @@ static Obj DoPartialUnWrapFunc(Obj func, Obj args)
     len = LEN_PLIST(args);
 
     if (named > len) { /* Can happen for > 6 arguments */
-      argx = NargError(func, len);
-      return DoOperation2Args(CallFuncListOper, func, argx);
+        ErrorMayQuitNrAtLeastArgs(named, len);
     }
 
 #ifdef HPCGAP

--- a/tst/testinstall/kernel/calls.tst
+++ b/tst/testinstall/kernel/calls.tst
@@ -47,9 +47,13 @@ Error, Function: number of arguments must be at least 2 (not 0)
 gap> f:={a1,a2,a3,a4,a5,a6,a7,a8}->a1;;
 gap> f();
 Error, Function: number of arguments must be 8 (not 0)
+gap> f(1,2,3,4,5,6,7,8,9);
+Error, Function: number of arguments must be 8 (not 9)
 gap> f:={a1,a2,a3,a4,a5,a6,a7,a8,rest...}->a1;;
 gap> f();
 Error, Function: number of arguments must be at least 8 (not 0)
+gap> f(1,2,3,4,5,6,7);
+Error, Function: number of arguments must be at least 8 (not 7)
 
 # test DoProf0args, DoProf1args, ...
 gap> o:={l...} -> l;;


### PR DESCRIPTION
It cannot return anymore, so we can delete code after calls to NargError.
Also add two more tests to increase coverage a bit