### PR TITLE
kernel: pass func obj explicitly to PrintStat, PrintExpr

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1061,7 +1061,7 @@ void PrintFunction (
         // print the code
         Obj oldLVars;
         SWITCH_TO_NEW_LVARS(func, narg, NLOC_FUNC(func), oldLVars);
-        PrintStat( OFFSET_FIRST_STAT );
+        PrintStat(BODY_FUNC(func), OFFSET_FIRST_STAT);
         SWITCH_TO_OLD_LVARS( oldLVars );
     }
     Pr("%4<\n",0L,0L);

--- a/src/code.c
+++ b/src/code.c
@@ -157,7 +157,6 @@ void SET_VISITED_STAT(Stat stat)
 
 #define SET_FUNC_CALL(call,x)   WRITE_EXPR(call, 0, x)
 #define SET_ARGI_CALL(call,i,x) WRITE_EXPR(call, i, x)
-#define SET_ARGI_INFO(info,i,x) WRITE_STAT(info, (i) - 1, x)
 
 
 static inline void PushOffsBody( void ) {
@@ -3082,12 +3081,12 @@ void CodeInfoEnd   (
     UInt                i;              /* loop variable                   */
 
     /* allocate the new statement                                          */
-    stat = NewStat( T_INFO, SIZE_NARG_INFO(2+narg) );
+    stat = NewStat(T_INFO, (2 + narg) * sizeof(Expr));
 
     /* narg only counts the printable arguments                            */
     for ( i = narg + 2; 0 < i; i-- ) {
         expr = PopExpr();
-        SET_ARGI_INFO(stat, i, expr);
+        WRITE_STAT(stat, i - 1, expr);
     }
 
     /* push the statement                                                  */

--- a/src/code.c
+++ b/src/code.c
@@ -155,10 +155,6 @@ void SET_VISITED_STAT(Stat stat)
 }
 
 
-#define SET_FUNC_CALL(call,x)   WRITE_EXPR(call, 0, x)
-#define SET_ARGI_CALL(call,i,x) WRITE_EXPR(call, i, x)
-
-
 static inline void PushOffsBody( void ) {
     GAP_ASSERT(CS(OffsBodyCount) < MAX_FUNC_EXPR_NESTING);
     CS(OffsBodyStack)[CS(OffsBodyCount)++] = CS(OffsBody);
@@ -740,19 +736,21 @@ void CodeFuncCallEnd (
     UInt                i;              /* loop variable                   */
     Expr                opts = 0;       /* record literal for the options  */
     Expr                wrapper;        /* wrapper for calls with options  */
+    UInt                size;
 
     /* allocate the function call                                          */
+    size = (nr + 1) * sizeof(Expr);
     if ( funccall && nr <= 6 ) {
-        call = NewExpr( T_FUNCCALL_0ARGS+nr, SIZE_NARG_CALL(nr) );
+        call = NewExpr(T_FUNCCALL_0ARGS + nr, size);
     }
     else if ( funccall /* && 6 < nr */ ) {
-        call = NewExpr( T_FUNCCALL_XARGS,    SIZE_NARG_CALL(nr) );
+        call = NewExpr(T_FUNCCALL_XARGS, size);
     }
     else if ( /* ! funccall && */ nr <=6 ) {
-        call = NewExpr( T_PROCCALL_0ARGS+nr, SIZE_NARG_CALL(nr) );
+        call = NewExpr(T_PROCCALL_0ARGS + nr, size);
     }
     else /* if ( ! funccall && 6 < nr ) */ {
-        call = NewExpr( T_PROCCALL_XARGS,    SIZE_NARG_CALL(nr) );
+        call = NewExpr(T_PROCCALL_XARGS, size);
     }
 
     /* get the options record if any */
@@ -762,12 +760,12 @@ void CodeFuncCallEnd (
     /* enter the argument expressions                                      */
     for ( i = nr; 1 <= i; i-- ) {
         arg = PopExpr();
-        SET_ARGI_CALL(call, i, arg);
+        WRITE_EXPR(call, i, arg);
     }
 
     /* enter the function expression                                       */
     func = PopExpr();
-    SET_FUNC_CALL(call, func);
+    WRITE_EXPR(call, 0, func);
 
     /* wrap up the call with the options */
     if (options)

--- a/src/code.h
+++ b/src/code.h
@@ -265,6 +265,11 @@ EXPORT_INLINE const Stat * CONST_ADDR_STAT(Stat stat)
     return (const Stat *)STATE(PtrBody) + stat / sizeof(Stat);
 }
 
+EXPORT_INLINE const Stat * CONST_ADDR_STAT_IN_BODY(Obj body, Stat stat)
+{
+    return (const Stat *)CONST_ADDR_OBJ(body) + stat / sizeof(Stat);
+}
+
 
 /****************************************************************************
 **
@@ -285,6 +290,12 @@ EXPORT_INLINE const StatHeader * CONST_STAT_HEADER(Stat stat)
     return (const StatHeader *)CONST_ADDR_STAT(stat) - 1;
 }
 
+EXPORT_INLINE const StatHeader * CONST_STAT_HEADER_IN_BODY(Obj  body,
+                                                           Stat stat)
+{
+    return (const StatHeader *)CONST_ADDR_STAT_IN_BODY(body, stat) - 1;
+}
+
 
 /****************************************************************************
 **
@@ -297,6 +308,10 @@ EXPORT_INLINE Int TNUM_STAT(Stat stat)
     return CONST_STAT_HEADER(stat)->type;
 }
 
+EXPORT_INLINE Int TNUM_STAT_IN_BODY(Obj body, Stat stat)
+{
+    return CONST_STAT_HEADER_IN_BODY(body, stat)->type;
+}
 
 /****************************************************************************
 **
@@ -309,6 +324,11 @@ EXPORT_INLINE Int SIZE_STAT(Stat stat)
     return CONST_STAT_HEADER(stat)->size;
 }
 
+EXPORT_INLINE Int SIZE_STAT_IN_BODY(Obj body, Stat stat)
+{
+    return CONST_STAT_HEADER_IN_BODY(body, stat)->size;
+}
+
 
 /****************************************************************************
 **
@@ -316,9 +336,9 @@ EXPORT_INLINE Int SIZE_STAT(Stat stat)
 **
 **  'LINE_STAT' returns the line number of the statement <stat>.
 */
-EXPORT_INLINE Int LINE_STAT(Stat stat)
+EXPORT_INLINE Int LINE_STAT(Obj body, Stat stat)
 {
-    return CONST_STAT_HEADER(stat)->line;
+    return CONST_STAT_HEADER_IN_BODY(body, stat)->line;
 }
 
 
@@ -343,6 +363,8 @@ EXPORT_INLINE Int VISITED_STAT(Stat stat)
 **  profiling wass turned on.
 */
 void SET_VISITED_STAT(Stat stat);
+
+Stat READ_STAT_IN_BODY(Obj body, Stat stat, Int idx);
 
 
 /****************************************************************************
@@ -515,6 +537,15 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
     return TNUM_STAT(expr);
 }
 
+EXPORT_INLINE Int TNUM_EXPR_IN_BODY(Obj body, Expr expr)
+{
+    if (IS_REFLVAR(expr))
+        return T_REFLVAR;
+    if (IS_INTEXPR(expr))
+        return T_INTEXPR;
+    return TNUM_STAT_IN_BODY(body, expr);
+}
+
 
 /****************************************************************************
 **
@@ -526,6 +557,7 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 **  'T_REFLVAR' or 'T_INTEXPR'.
 */
 #define SIZE_EXPR(expr) SIZE_STAT(expr)
+#define SIZE_EXPR_IN_BODY(body, expr) SIZE_STAT_IN_BODY(body, expr)
 
 
 /****************************************************************************
@@ -541,6 +573,8 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 #define CONST_ADDR_EXPR(expr) CONST_ADDR_STAT(expr)
 
 #define READ_EXPR(expr, idx) (CONST_ADDR_EXPR(expr)[idx])
+
+#define READ_EXPR_IN_BODY(body, expr, idx) READ_STAT_IN_BODY(body, expr, idx)
 
 
 /****************************************************************************

--- a/src/code.h
+++ b/src/code.h
@@ -571,27 +571,6 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 
 /****************************************************************************
 **
-*F  ARGI_INFO(<info>,<i>) . . .  <i>-th formal argument for an Info statement
-*F  NARG_SIZE_INFO(<size>)  . . . . number of arguments for an Info statement
-*F  SIZE_NARG_INFO(<narg>)  . . . . . . size of the bag for an Info statement
-**
-**  'ARGI_INFO' returns the expression   that evaluates to the <i>-th  actual
-**  argument for the Info  statement <info>.  This is a  legal left value, so
-**  it can be used to set the expression too.
-**
-**  'NARG_SIZE_INFO' returns the number of  arguments in a function call from
-**  the size <size> of the function call bag (as returned by 'SIZE_STAT').
-**
-**  'SIZE_NARG_INFO' returns the size a  function call bag  should have for a
-**  function call bag with <narg> arguments.
-*/
-#define ARGI_INFO(info,i)       READ_STAT(info, (i) - 1)
-#define NARG_SIZE_INFO(size)    ((size) / sizeof(Expr))
-#define SIZE_NARG_INFO(narg)    ((narg) * sizeof(Expr))
-
-
-/****************************************************************************
-**
 *V  CodeResult  . . . . . . . . . . . . . . . . . . . . . .  result of coding
 **
 **  'CodeResult'  is the result  of the coding, i.e.,   the function that was

--- a/src/code.h
+++ b/src/code.h
@@ -542,32 +542,6 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 
 #define READ_EXPR(expr, idx) (CONST_ADDR_EXPR(expr)[idx])
 
-/****************************************************************************
-**
-*F  FUNC_CALL(<call>) . . . . . . . . . . . . .  function for a function call
-*F  ARGI_CALL(<call>,<i>) . . . .  <i>-th formal argument for a function call
-*F  NARG_SIZE_CALL(<size>)  . . . . . number of arguments for a function call
-*F  SIZE_NARG_CALL(<narg>)  . . . . . . . size of the bag for a function call
-**
-**  'FUNC_CALL'  returns the expression that should  evaluate to the function
-**  for the procedure or  function call <call>.   This is a legal left value,
-**  so it can be used to set the expression too.
-**
-**  'ARGI_CALL'  returns  the expression that evaluate   to the <i>-th actual
-**  argument for the procedure or function call <call>.  This is a legal left
-**  value, so it can be used to set the expression too.
-**
-**  'NARG_SIZE_CALL' returns the number of  arguments in a function call from
-**  the size <size> of the function call bag (as returned by 'SIZE_EXPR').
-**
-**  'SIZE_NARG_CALL' returns the size a  function call bag  should have for a
-**  function call bag with <narg> arguments.
-*/
-#define FUNC_CALL(call)         READ_EXPR(call, 0)
-#define ARGI_CALL(call,i)       READ_EXPR(call, i)
-#define NARG_SIZE_CALL(size)    (((size) / sizeof(Expr)) - 1)
-#define SIZE_NARG_CALL(narg)    (((narg) + 1) * sizeof(Expr))
-
 
 /****************************************************************************
 **

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -4961,19 +4961,19 @@ static void CompInfo(Stat stat)
     Int                 i;
 
     Emit( "\n/* Info( ... ); */\n" );
-    sel = CompExpr( ARGI_INFO( stat, 1 ) );
-    lev = CompExpr( ARGI_INFO( stat, 2 ) );
+    sel = CompExpr(READ_STAT(stat, 0));
+    lev = CompExpr(READ_STAT(stat, 1));
     lst = CVAR_TEMP( NewTemp( "lst" ) );
     tmp = CVAR_TEMP( NewTemp( "tmp" ) );
     Emit( "%c = InfoCheckLevel( %c, %c );\n", tmp, sel, lev );
     Emit( "if ( %c == True ) {\n", tmp );
     if ( IS_TEMP_CVAR( tmp ) )  FreeTemp( TEMP_CVAR( tmp ) );
-    narg = NARG_SIZE_INFO(SIZE_STAT(stat))-2;
+    narg = SIZE_STAT(stat) / sizeof(Expr);
     Emit( "%c = NEW_PLIST( T_PLIST, %d );\n", lst, narg );
     Emit( "SET_LEN_PLIST( %c, %d );\n", lst, narg );
-    for ( i = 1;  i <= narg;  i++ ) {
-        tmp = CompExpr( ARGI_INFO( stat, i+2 ) );
-        Emit( "SET_ELM_PLIST( %c, %d, %c );\n", lst, i, tmp );
+    for (i = 2; i < narg; i++) {
+        tmp = CompExpr(READ_STAT(stat, i));
+        Emit("SET_ELM_PLIST( %c, %d, %c );\n", lst, i - 1, tmp);
         Emit( "CHANGED_BAG(%c);\n", lst );
         if ( IS_TEMP_CVAR( tmp ) )  FreeTemp( TEMP_CVAR( tmp ) );
     }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -3589,7 +3589,9 @@ static void CompProccall0to6Args(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* special case to inline 'Add'                                        */
@@ -3656,7 +3658,9 @@ static void CompProccallXArgs(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the reference to the function                               */
@@ -3747,7 +3751,7 @@ static void CompIf(Stat stat)
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
         Emit( "\n/* if " );
-        PrintExpr(READ_EXPR(stat, 0));
+        PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 0));
         Emit( " then */\n" );
     }
 
@@ -3782,7 +3786,7 @@ static void CompIf(Stat stat)
         /* print a comment                                                 */
         if ( CompPass == 2 ) {
             Emit( "\n/* elif " );
-            PrintExpr(READ_EXPR(stat, 2 * (i - 1)));
+            PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 2 * (i - 1)));
             Emit( " then */\n" );
         }
 
@@ -3890,9 +3894,9 @@ static void CompFor(Stat stat)
         /* print a comment                                                 */
         if ( CompPass == 2 ) {
             Emit( "\n/* for " );
-            PrintExpr(READ_EXPR(stat, 0));
+            PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 0));
             Emit( " in " );
-            PrintExpr(READ_EXPR(stat, 1));
+            PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 1));
             Emit( " do */\n" );
         }
 
@@ -3976,9 +3980,9 @@ static void CompFor(Stat stat)
         /* print a comment                                                 */
         if ( CompPass == 2 ) {
             Emit( "\n/* for " );
-            PrintExpr(READ_EXPR(stat, 0));
+            PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 0));
             Emit( " in " );
-            PrintExpr(READ_EXPR(stat, 1));
+            PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 1));
             Emit( " do */\n" );
         }
 
@@ -4135,7 +4139,7 @@ static void CompWhile(Stat stat)
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
         Emit( "\n/* while " );
-        PrintExpr(READ_EXPR(stat, 0));
+        PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 0));
         Emit( " do */\n" );
     }
 
@@ -4205,7 +4209,7 @@ static void CompRepeat(Stat stat)
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
         Emit( "\n/* until " );
-        PrintExpr(READ_EXPR(stat, 0));
+        PrintExpr(BODY_FUNC(CURR_FUNC()), READ_EXPR(stat, 0));
         Emit( " */\n" );
     }
 
@@ -4227,7 +4231,9 @@ static void CompBreak(Stat stat)
 {
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     Emit( "break;\n" );
@@ -4241,7 +4247,9 @@ static void CompContinue(Stat stat)
 {
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     Emit( "continue;\n" );
@@ -4258,7 +4266,9 @@ static void CompReturnObj(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the expression                                              */
@@ -4283,7 +4293,9 @@ static void CompReturnVoid(Stat stat)
 {
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* emit code to remove stack frame                                     */
@@ -4305,7 +4317,9 @@ static void CompAssLVar(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the right hand side expression                              */
@@ -4336,7 +4350,9 @@ static void CompUnbLVar(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* emit the code for the assignment                                    */
@@ -4362,7 +4378,9 @@ static void CompAssHVar(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the right hand side expression                              */
@@ -4389,7 +4407,9 @@ static void CompUnbHVar(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* emit the code for the assignment                                    */
@@ -4411,7 +4431,9 @@ static void CompAssGVar(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the right hand side expression                              */
@@ -4437,7 +4459,9 @@ static void CompUnbGVar(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* emit the code for the assignment                                    */
@@ -4459,7 +4483,9 @@ static void CompAssList(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expression                                         */
@@ -4504,7 +4530,9 @@ static void CompAsssList(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expression                                         */
@@ -4539,7 +4567,9 @@ static void CompAssListLev(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expressions                                        */
@@ -4578,7 +4608,9 @@ static void CompAsssListLev(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expressions                                        */
@@ -4615,7 +4647,9 @@ static void CompUnbList(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expression                                         */
@@ -4646,7 +4680,9 @@ static void CompAssRecName(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4680,7 +4716,9 @@ static void CompAssRecExpr(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4713,7 +4751,9 @@ static void CompUnbRecName(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4742,7 +4782,9 @@ static void CompUnbRecExpr(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4772,7 +4814,9 @@ static void CompAssPosObj(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expression                                         */
@@ -4806,7 +4850,9 @@ static void CompUnbPosObj(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the list expression                                         */
@@ -4837,7 +4883,9 @@ static void CompAssComObjName(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4871,7 +4919,9 @@ static void CompAssComObjExpr(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4904,7 +4954,9 @@ static void CompUnbComObjName(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */
@@ -4933,7 +4985,9 @@ static void CompUnbComObjExpr(Stat stat)
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
-        Emit( "\n/* " ); PrintStat( stat ); Emit( " */\n" );
+        Emit("\n/* ");
+        PrintStat(BODY_FUNC(CURR_FUNC()), stat);
+        Emit(" */\n");
     }
 
     /* compile the record expression                                       */

--- a/src/error.c
+++ b/src/error.c
@@ -180,10 +180,10 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
     GAP_ASSERT(call == BRK_CALL_TO());
 
     Obj retlist = Fail;
-    Int type = TNUM_STAT(call);
+    Int type = TNUM_STAT_IN_BODY(body, call);
     if ((FIRST_STAT_TNUM <= type && type <= LAST_STAT_TNUM) ||
         (FIRST_EXPR_TNUM <= type && type <= LAST_EXPR_TNUM)) {
-        Int line = LINE_STAT(call);
+        Int line = LINE_STAT(body, call);
         Obj filename = GET_FILENAME_BODY(body);
         retlist = NewPlistFromArgs(filename, INTOBJ_INT(line));
     }
@@ -224,21 +224,18 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
         Pr("<corrupted statement> ", 0L, 0L);
     }
     else {
-        Obj currLVars = STATE(CurrLVars);
-        SWITCH_TO_OLD_LVARS(context);
         GAP_ASSERT(call == BRK_CALL_TO());
 
-        Int type = TNUM_STAT(call);
+        Int type = TNUM_STAT_IN_BODY(body, call);
         Obj filename = GET_FILENAME_BODY(body);
         if (FIRST_STAT_TNUM <= type && type <= LAST_STAT_TNUM) {
-            PrintStat(call);
-            Pr(" at %g:%d", (Int)filename, LINE_STAT(call));
+            PrintStat(body, call);
+            Pr(" at %g:%d", (Int)filename, LINE_STAT(body, call));
         }
         else if (FIRST_EXPR_TNUM <= type && type <= LAST_EXPR_TNUM) {
-            PrintExpr(call);
-            Pr(" at %g:%d", (Int)filename, LINE_STAT(call));
+            PrintExpr(body, call);
+            Pr(" at %g:%d", (Int)filename, LINE_STAT(body, call));
         }
-        SWITCH_TO_OLD_LVARS(currLVars);
     }
 
     /* HACK: close the output again */

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -135,11 +135,11 @@ EXPORT_INLINE Obj EVAL_BOOL_EXPR(Expr expr)
 **
 **  'PrintExpr' prints the expression <expr>.
 */
-void PrintExpr(Expr expr);
+void PrintExpr(Obj body, Expr);
 
 
-void PrintRecExpr1(Expr expr); /* needed for printing
-                                       function calls with options */
+void PrintRecExpr1(Obj body, Expr); /* needed for printing
+                                          function calls with options */
 
 /****************************************************************************
 **
@@ -149,7 +149,7 @@ void PrintRecExpr1(Expr expr); /* needed for printing
 **  expressions a pointer to the printer for expressions  of this type, i.e.,
 **  the function that should be called to print expressions of this type.
 */
-extern  void            (* PrintExprFuncs [256] ) ( Expr expr );
+extern void (*PrintExprFuncs[256])(Obj body, Expr expr);
 
 
 /****************************************************************************

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -686,10 +686,10 @@ static Obj EvalFuncExpr(Expr expr)
 **
 **  'PrintFuncExpr' prints a function expression.
 */
-static void PrintFuncExpr(Expr expr)
+static void PrintFuncExpr(Obj body, Expr expr)
 {
     /* get the function expression bag                                     */
-    Obj fexp = GET_VALUE_FROM_CURRENT_BODY(READ_EXPR(expr, 0));
+    Obj fexp = ELM_PLIST(VALUES_BODY(body), READ_EXPR(expr, 0));
     PrintFunction( fexp );
 }
 
@@ -700,19 +700,19 @@ static void PrintFuncExpr(Expr expr)
 **
 **  'PrintProccall' prints a procedure call.
 */
-static void PrintFunccall(Expr call);
+static void PrintFunccall(Obj body, Expr call);
 
-static void PrintFunccallOpts(Expr call);
+static void PrintFunccallOpts(Obj body, Expr call);
 
-static void PrintProccall(Stat call)
+static void PrintProccall(Obj body, Stat call)
 {
-    PrintFunccall( call );
+    PrintFunccall(body, call);
     Pr( ";", 0L, 0L );
 }
 
-static void PrintProccallOpts(Stat call)
+static void PrintProccallOpts(Obj body, Stat call)
 {
-    PrintFunccallOpts( call );
+    PrintFunccallOpts(body, call);
     Pr( ";", 0L, 0L );
 }
 
@@ -723,42 +723,41 @@ static void PrintProccallOpts(Stat call)
 **
 **  'PrintFunccall' prints a function call.
 */
-static void            PrintFunccall1 (
-    Expr                call )
+static void PrintFunccall1(Obj body, Expr call)
 {
     UInt                i;              /* loop variable                   */
 
     /* print the expression that should evaluate to a function             */
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(call, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, call, 0));
 
     /* print the opening parenthesis                                       */
     Pr("%<( %>",0L,0L);
 
     /* print the expressions that evaluate to the actual arguments         */
-    const UInt nr = SIZE_EXPR(call) / sizeof(Expr) - 1;
+    const UInt nr = SIZE_EXPR_IN_BODY(body, call) / sizeof(Expr) - 1;
     for (i = 1; i <= nr; i++) {
-        PrintExpr(READ_EXPR(call, i));
+        PrintExpr(body, READ_EXPR_IN_BODY(body, call, i));
         if (i != nr) {
             Pr("%<, %>",0L,0L);
         }
     }
 }
 
-static void PrintFunccall(Expr call)
+static void PrintFunccall(Obj body, Expr call)
 {
-  PrintFunccall1( call );
-  
-  /* print the closing parenthesis                                       */
-  Pr(" %2<)",0L,0L);
+    PrintFunccall1(body, call);
+
+    /* print the closing parenthesis                                       */
+    Pr(" %2<)", 0L, 0L);
 }
 
 
-static void PrintFunccallOpts(Expr call)
+static void PrintFunccallOpts(Obj body, Expr call)
 {
-    PrintFunccall1(READ_STAT(call, 1));
+    PrintFunccall1(body, READ_STAT_IN_BODY(body, call, 1));
     Pr(" :%2> ", 0L, 0L);
-    PrintRecExpr1(READ_STAT(call, 0));
+    PrintRecExpr1(body, READ_STAT_IN_BODY(body, call, 0));
     Pr(" %4<)", 0L, 0L);
 }
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -106,20 +106,19 @@ static UInt ExecProccallOpts(Stat call)
 
 /****************************************************************************
 **
-*F  ExecProccall0args(<call>)  .  execute a procedure call with 0    arguments
-*F  ExecProccall1args(<call>)  .  execute a procedure call with 1    arguments
-*F  ExecProccall2args(<call>)  .  execute a procedure call with 2    arguments
-*F  ExecProccall3args(<call>)  .  execute a procedure call with 3    arguments
-*F  ExecProccall4args(<call>)  .  execute a procedure call with 4    arguments
-*F  ExecProccall5args(<call>)  .  execute a procedure call with 5    arguments
-*F  ExecProccall6args(<call>)  .  execute a procedure call with 6    arguments
-*F  ExecProccallXargs(<call>)  .  execute a procedure call with more arguments
+*F  ExecProccall0args(<call>) .  execute a procedure call with 0    arguments
+*F  ExecProccall1args(<call>) .  execute a procedure call with 1    arguments
+*F  ExecProccall2args(<call>) .  execute a procedure call with 2    arguments
+*F  ExecProccall3args(<call>) .  execute a procedure call with 3    arguments
+*F  ExecProccall4args(<call>) .  execute a procedure call with 4    arguments
+*F  ExecProccall5args(<call>) .  execute a procedure call with 5    arguments
+*F  ExecProccall6args(<call>) .  execute a procedure call with 6    arguments
+*F  ExecProccallXargs(<call>) .  execute a procedure call with more arguments
 **
-**  'ExecProccall<i>args'  executes  a  procedure   call   to the    function
-**  'FUNC_CALL(<call>)'   with   the   arguments   'ARGI_CALL(<call>,1)'   to
-**  'ARGI_CALL(<call>,<i>)'.  It discards the value returned by the function
-**  and returns the statement execution status (as per EXEC_STAT, q.v.)
-**  resulting from the procedure call, which in fact is always 0.
+**  'ExecProccall<i>args'  executes  a procedure  call  to  a  GAP  function.
+**  It discards the value returned by the function and returns the statement
+**  execution status (as per EXEC_STAT, q.v.) resulting from the procedure
+**  call, which in fact is always 0.
 */
 
 static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call)
@@ -130,20 +129,20 @@ static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call)
     Obj result;
 
     // evaluate the function
-    func = EVAL_EXPR( FUNC_CALL( call ) );
- 
+    func = EVAL_EXPR(READ_EXPR(call, 0));
+
     // evaluate the arguments
     if (nr <= 6 && TNUM_OBJ(func) == T_FUNCTION) {
         for (UInt i = 1; i <= nr; i++) {
-            a[i - 1] = EVAL_EXPR(ARGI_CALL(call, i));
+            a[i - 1] = EVAL_EXPR(READ_EXPR(call, i));
         }
     }
     else {
-        UInt realNr = NARG_SIZE_CALL(SIZE_STAT(call));
+        UInt realNr = SIZE_STAT(call) / sizeof(Expr) - 1;
         args = NEW_PLIST(T_PLIST, realNr);
         SET_LEN_PLIST(args, realNr);
         for (UInt i = 1; i <= realNr; i++) {
-            Obj argi = EVAL_EXPR(ARGI_CALL(call, i));
+            Obj argi = EVAL_EXPR(READ_EXPR(call, i));
             SET_ELM_PLIST(args, i, argi);
             CHANGED_BAG(args);
         }
@@ -258,7 +257,7 @@ static UInt ExecProccall6args(Stat call)
 
 static UInt ExecProccallXargs(Stat call)
 {
-    // pass in 7 (instead of NARG_SIZE_CALL(SIZE_STAT(call)))
+    // pass in 7 instead of the actual number of arguments,
     // to allow the compiler to perform better optimizations
     // (as we know that the number of arguments is >= 7 here)
     EvalOrExecCall(1, 7, call);
@@ -294,18 +293,17 @@ static Obj EvalFunccallOpts(Expr call)
 
 /****************************************************************************
 **
-*F  EvalFunccall0args(<call>)  . . execute a function call with 0    arguments
-*F  EvalFunccall1args(<call>)  . . execute a function call with 1    arguments
-*F  EvalFunccall2args(<call>)  . . execute a function call with 2    arguments
-*F  EvalFunccall3args(<call>)  . . execute a function call with 3    arguments
-*F  EvalFunccall4args(<call>)  . . execute a function call with 4    arguments
-*F  EvalFunccall5args(<call>)  . . execute a function call with 5    arguments
-*F  EvalFunccall6args(<call>)  . . execute a function call with 6    arguments
-*F  EvalFunccallXargs(<call>)  . . execute a function call with more arguments
+*F  EvalFunccall0args(<call>) . . execute a function call with 0    arguments
+*F  EvalFunccall1args(<call>) . . execute a function call with 1    arguments
+*F  EvalFunccall2args(<call>) . . execute a function call with 2    arguments
+*F  EvalFunccall3args(<call>) . . execute a function call with 3    arguments
+*F  EvalFunccall4args(<call>) . . execute a function call with 4    arguments
+*F  EvalFunccall5args(<call>) . . execute a function call with 5    arguments
+*F  EvalFunccall6args(<call>) . . execute a function call with 6    arguments
+*F  EvalFunccallXargs(<call>) . . execute a function call with more arguments
 **
-**  'EvalFunccall<i>args'  executes  a     function call   to   the  function
-**  'FUNC_CALL(<call>)'    with  the   arguments    'ARGI_CALL(<call>,1)'  to
-**  'ARGI_CALL(<call>,<i>)'.  It returns the value returned by the function.
+**  'EvalFunccall<i>args'  executes  a  function  call  to  a  GAP  function.
+**  It returns the value returned by the function.
 */
 
 static Obj EvalFunccall0args(Expr call)
@@ -345,7 +343,7 @@ static Obj EvalFunccall6args(Expr call)
 
 static Obj EvalFunccallXargs(Expr call)
 {
-    // pass in 7 (instead of NARG_SIZE_CALL(SIZE_EXPR(call)))
+    // pass in 7 instead of the actual number of arguments,
     // to allow the compiler to perform better optimizations
     // (as we know that the number of arguments is >= 7 here)
     return EvalOrExecCall(0, 7, call);
@@ -732,15 +730,16 @@ static void            PrintFunccall1 (
 
     /* print the expression that should evaluate to a function             */
     Pr("%2>",0L,0L);
-    PrintExpr( FUNC_CALL(call) );
+    PrintExpr(READ_EXPR(call, 0));
 
     /* print the opening parenthesis                                       */
     Pr("%<( %>",0L,0L);
 
     /* print the expressions that evaluate to the actual arguments         */
-    for ( i = 1; i <= NARG_SIZE_CALL( SIZE_EXPR(call) ); i++ ) {
-        PrintExpr( ARGI_CALL(call,i) );
-        if ( i != NARG_SIZE_CALL( SIZE_EXPR(call) ) ) {
+    const UInt nr = SIZE_EXPR(call) / sizeof(Expr) - 1;
+    for (i = 1; i <= nr; i++) {
+        PrintExpr(READ_EXPR(call, i));
+        if (i != nr) {
             Pr("%<, %>",0L,0L);
         }
     }

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -43,8 +43,8 @@ UInt (*OriginalExecStatFuncsForHook[256])(Stat stat);
 Obj (*OriginalEvalExprFuncsForHook[256])(Expr expr);
 Obj (*OriginalEvalBoolFuncsForHook[256])(Expr expr);
 
-void (*OriginalPrintStatFuncsForHook[256])(Stat stat);
-void (*OriginalPrintExprFuncsForHook[256])(Expr expr);
+void (*OriginalPrintStatFuncsForHook[256])(Obj body, Stat stat);
+void (*OriginalPrintExprFuncsForHook[256])(Obj body, Expr expr);
 
 /****************************************************************************
 **
@@ -82,7 +82,7 @@ void InstallExecStatFunc(Int pos, UInt (*stat)(Stat))
     HashUnlock(&activeHooks);
 }
 
-void InstallPrintStatFunc(Int pos, void (*stat)(Stat))
+void InstallPrintStatFunc(Int pos, void (*stat)(Obj, Stat))
 {
     OriginalPrintStatFuncsForHook[pos] = stat;
     HashLock(&activeHooks);
@@ -92,7 +92,7 @@ void InstallPrintStatFunc(Int pos, void (*stat)(Stat))
     HashUnlock(&activeHooks);
 }
 
-void InstallPrintExprFunc(Int pos, void (*expr)(Expr))
+void InstallPrintExprFunc(Int pos, void (*expr)(Obj, Expr))
 {
     OriginalPrintExprFuncsForHook[pos] = expr;
     HashLock(&activeHooks);

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -19,8 +19,8 @@
 void InstallEvalBoolFunc(Int, Obj (*)(Expr));
 void InstallEvalExprFunc(Int, Obj (*)(Expr));
 void InstallExecStatFunc(Int, UInt (*)(Stat));
-void InstallPrintStatFunc(Int, void (*)(Stat));
-void InstallPrintExprFunc(Int, void (*)(Expr));
+void InstallPrintStatFunc(Int, void (*)(Obj, Stat));
+void InstallPrintExprFunc(Int, void (*)(Obj, Expr));
 
 
 /****************************************************************************
@@ -36,8 +36,8 @@ extern UInt (*OriginalExecStatFuncsForHook[256])(Stat stat);
 extern Obj (*OriginalEvalExprFuncsForHook[256])(Expr expr);
 extern Obj (*OriginalEvalBoolFuncsForHook[256])(Expr expr);
 
-extern void (*OriginalPrintStatFuncsForHook[256])(Stat stat);
-extern void (*OriginalPrintExprFuncsForHook[256])(Expr expr);
+extern void (*OriginalPrintStatFuncsForHook[256])(Obj body, Stat stat);
+extern void (*OriginalPrintExprFuncsForHook[256])(Obj body, Expr expr);
 
 
 /****************************************************************************
@@ -103,8 +103,8 @@ Int DeactivateHooks(struct InterpreterHooks * hook);
 ** Look at that code to get an idea how to use them.
 */
 struct PrintHooks {
-    void (*printStatPassthrough)(Stat stat);
-    void (*printExprPassthrough)(Expr stat);
+    void (*printStatPassthrough)(Obj body, Stat stat);
+    void (*printExprPassthrough)(Obj body, Expr stat);
 };
 
 void ActivatePrintHooks(struct PrintHooks * hook);

--- a/src/profile.c
+++ b/src/profile.c
@@ -501,7 +501,7 @@ static inline void outputStat(Stat stat, int exec, int visited)
         return;
     }
 
-    line = LINE_STAT(stat);
+    line = LINE_STAT(CURR_FUNC(), stat);
     printOutput(line, nameid, exec, visited);
 }
 
@@ -810,7 +810,7 @@ static void setColour(void)
   }
 }
 
-static void ProfilePrintStatPassthrough(Stat stat)
+static void ProfilePrintStatPassthrough(Obj body, Stat stat)
 {
   Int SavedColour = CurrentColour;
   if(VISITED_STAT(stat)) {
@@ -820,20 +820,21 @@ static void ProfilePrintStatPassthrough(Stat stat)
     CurrentColour = 2;
   }
   setColour();
-  OriginalPrintStatFuncsForHook[TNUM_STAT(stat)](stat);
+  UInt tnum = TNUM_STAT_IN_BODY(body, stat);
+  OriginalPrintStatFuncsForHook[tnum](body, stat);
   CurrentColour = SavedColour;
   setColour();
 }
 
-static void ProfilePrintExprPassthrough(Expr stat)
+static void ProfilePrintExprPassthrough(Obj body, Expr stat)
 {
   Int SavedColour = -1;
   /* There are two cases we must pass through without touching */
   /* From TNUM_EXPR */
   if(IS_REFLVAR(stat)) {
-    OriginalPrintExprFuncsForHook[T_REFLVAR](stat);
+    OriginalPrintExprFuncsForHook[T_REFLVAR](body, stat);
   } else if(IS_INTEXPR(stat)) {
-    OriginalPrintExprFuncsForHook[T_INTEXPR](stat);
+    OriginalPrintExprFuncsForHook[T_INTEXPR](body, stat);
   } else {
     SavedColour = CurrentColour;
     if(VISITED_STAT(stat)) {
@@ -843,7 +844,8 @@ static void ProfilePrintExprPassthrough(Expr stat)
       CurrentColour = 2;
     }
     setColour();
-    OriginalPrintExprFuncsForHook[TNUM_STAT(stat)](stat);
+    UInt tnum = TNUM_EXPR_IN_BODY(body, stat);
+    OriginalPrintExprFuncsForHook[tnum](body, stat);
     CurrentColour = SavedColour;
     setColour();
   }

--- a/src/stats.c
+++ b/src/stats.c
@@ -846,14 +846,14 @@ static UInt ExecInfo(Stat stat)
     Obj             args;
     Obj             arg;
 
-    selectors = EVAL_EXPR( ARGI_INFO( stat, 1 ) );
-    level = EVAL_EXPR( ARGI_INFO( stat, 2) );
+    selectors = EVAL_EXPR(READ_STAT(stat, 0));
+    level = EVAL_EXPR(READ_STAT(stat, 1));
 
     selected = InfoCheckLevel(selectors, level);
     if (selected == True) {
 
         /* Get the number of arguments to be printed                       */
-        narg = NARG_SIZE_INFO(SIZE_STAT(stat)) - 2;
+        narg = SIZE_STAT(stat) / sizeof(Expr) - 2;
 
         /* set up a list                                                   */
         args = NEW_PLIST( T_PLIST, narg );
@@ -867,7 +867,7 @@ static UInt ExecInfo(Stat stat)
                of arg, which may happen after the pointer to args has been
                extracted
             */
-            arg = EVAL_EXPR(ARGI_INFO(stat, i+2));
+            arg = EVAL_EXPR(READ_STAT(stat, i + 1));
             SET_ELM_PLIST(args, i, arg);
             CHANGED_BAG(args);
         }
@@ -1416,9 +1416,10 @@ static void PrintInfo(Stat stat)
     Pr("%<( %>",0L,0L);
 
     /* print the expressions that evaluate to the actual arguments         */
-    for ( i = 1; i <= NARG_SIZE_INFO( SIZE_STAT(stat) ); i++ ) {
-        PrintExpr( ARGI_INFO(stat,i) );
-        if ( i != NARG_SIZE_INFO( SIZE_STAT(stat) ) ) {
+    UInt narg = SIZE_STAT(stat) / sizeof(Expr);
+    for (i = 0; i < narg; i++) {
+        PrintExpr(READ_STAT(stat, i));
+        if (i != narg) {
             Pr("%<, %>",0L,0L);
         }
     }

--- a/src/stats.h
+++ b/src/stats.h
@@ -116,7 +116,7 @@ void InterruptExecStat(void);
 **  'PrintStat' simply dispatches  through the table  'PrintStatFuncs' to the
 **  appropriate printer.
 */
-void PrintStat(Stat stat);
+void PrintStat(Obj body, Stat);
 
 
 /****************************************************************************
@@ -127,7 +127,7 @@ void PrintStat(Stat stat);
 **  statements a pointer to the  printer for statements  of this type,  i.e.,
 **  the function that should be called to print statements of this type.
 */
-extern  void            (* PrintStatFuncs[256] ) ( Stat stat );
+extern void (*PrintStatFuncs[256])(Obj body, Stat stat);
 
 
 /****************************************************************************

--- a/src/vars.c
+++ b/src/vars.c
@@ -196,16 +196,16 @@ static Obj EvalIsbLVar(Expr expr)
 **
 **  'PrintAssLVar' prints the local variable assignment statement <stat>.
 */
-static void PrintAssLVar(Stat stat)
+static void PrintAssLVar(Obj body, Stat stat)
 {
     Pr( "%2>", 0L, 0L );
     Pr("%H", (Int)NAME_LVAR(READ_STAT(stat, 0)), 0L);
     Pr( "%< %>:= ", 0L, 0L );
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr( "%2<;", 0L, 0L );
 }
 
-static void PrintUnbLVar(Stat stat)
+static void PrintUnbLVar(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%H", (Int)NAME_LVAR(READ_STAT(stat, 0)), 0L);
@@ -219,15 +219,15 @@ static void PrintUnbLVar(Stat stat)
 **
 **  'PrintRefLVar' prints the local variable reference expression <expr>.
 */
-static void PrintRefLVar(Expr expr)
+static void PrintRefLVar(Obj body, Expr expr)
 {
     Pr( "%H", (Int)NAME_LVAR( LVAR_REFLVAR(expr) ), 0L );
 }
 
-static void PrintIsbLVar(Expr expr)
+static void PrintIsbLVar(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr("%H", (Int)NAME_LVAR(READ_EXPR(expr, 0)), 0L);
+    Pr("%H", (Int)NAME_LVAR(READ_EXPR_IN_BODY(body, expr, 0)), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -367,19 +367,19 @@ static Obj EvalIsbHVar(Expr expr)
 **
 **  'PrintAssHVar' prints the higher variable assignment statement <stat>.
 */
-static void PrintAssHVar(Stat stat)
+static void PrintAssHVar(Obj body, Stat stat)
 {
     Pr( "%2>", 0L, 0L );
-    Pr("%H", (Int)NAME_HVAR(READ_STAT(stat, 0)), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_STAT_IN_BODY(body, stat, 0)), 0L);
     Pr( "%< %>:= ", 0L, 0L );
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr( "%2<;", 0L, 0L );
 }
 
-static void PrintUnbHVar(Stat stat)
+static void PrintUnbHVar(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr("%H", (Int)NAME_HVAR(READ_STAT(stat, 0)), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_STAT_IN_BODY(body, stat, 0)), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -390,15 +390,15 @@ static void PrintUnbHVar(Stat stat)
 **
 **  'PrintRefHVar' prints the higher variable reference expression <expr>.
 */
-static void PrintRefHVar(Expr expr)
+static void PrintRefHVar(Obj body, Expr expr)
 {
-    Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_EXPR_IN_BODY(body, expr, 0)), 0L);
 }
 
-static void PrintIsbHVar(Expr expr)
+static void PrintIsbHVar(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr("%H", (Int)NAME_HVAR(READ_EXPR(expr, 0)), 0L);
+    Pr("%H", (Int)NAME_HVAR(READ_EXPR_IN_BODY(body, expr, 0)), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -472,19 +472,19 @@ static Obj EvalIsbGVar(Expr expr)
 **
 **  'PrVarAss' prints the global variable assignment statement <stat>.
 */
-static void PrintAssGVar(Stat stat)
+static void PrintAssGVar(Obj body, Stat stat)
 {
     Pr( "%2>", 0L, 0L );
-    Pr("%H", (Int)NameGVar(READ_STAT(stat, 0)), 0L);
+    Pr("%H", (Int)NameGVar(READ_STAT_IN_BODY(body, stat, 0)), 0L);
     Pr( "%< %>:= ", 0L, 0L );
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr( "%2<;", 0L, 0L );
 }
 
-static void PrintUnbGVar(Stat stat)
+static void PrintUnbGVar(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
-    Pr("%H", (Int)NameGVar(READ_STAT(stat, 0)), 0L);
+    Pr("%H", (Int)NameGVar(READ_STAT_IN_BODY(body, stat, 0)), 0L);
     Pr( " );", 0L, 0L );
 }
 
@@ -495,15 +495,15 @@ static void PrintUnbGVar(Stat stat)
 **
 **  'PrintRefGVar' prints the global variable reference expression <expr>.
 */
-static void PrintRefGVar(Expr expr)
+static void PrintRefGVar(Obj body, Expr expr)
 {
-    Pr("%H", (Int)NameGVar(READ_STAT(expr, 0)), 0L);
+    Pr("%H", (Int)NameGVar(READ_STAT_IN_BODY(body, expr, 0)), 0L);
 }
 
-static void PrintIsbGVar(Expr expr)
+static void PrintIsbGVar(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
-    Pr("%H", (Int)NameGVar(READ_EXPR(expr, 0)), 0L);
+    Pr("%H", (Int)NameGVar(READ_EXPR_IN_BODY(body, expr, 0)), 0L);
     Pr( " )", 0L, 0L );
 }
 
@@ -987,44 +987,44 @@ static Obj EvalIsbList(Expr expr)
 **
 **  Linebreaks are preferred before the ':='.
 */
-static void PrintAssList(Stat stat)
+static void PrintAssList(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintAss2List(Stat stat)
+static void PrintAss2List(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr("%<, %>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 3));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 3));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintUnbList(Stat stat)
+static void PrintUnbList(Obj body, Stat stat)
 {
   Int narg = SIZE_STAT(stat)/sizeof(Stat) -1;
   Int i;
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %>",0L,0L);
-      PrintExpr(READ_EXPR(stat, i));
+      PrintExpr(body, READ_EXPR_IN_BODY(body, stat, i));
     }
     Pr("%<]",0L,0L);
     Pr( " );", 0L, 0L );
@@ -1040,15 +1040,15 @@ static void PrintUnbList(Stat stat)
 **
 **  Linebreaks are preferred before the ':='.
 */
-static void PrintAsssList(Stat stat)
+static void PrintAsssList(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<{",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr("%<}",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
@@ -1062,54 +1062,54 @@ static void PrintAsssList(Stat stat)
 **
 **  Linebreaks are preferred after the '['.
 */
-static void PrintElmList(Expr expr)
+static void PrintElmList(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr("%<]",0L,0L);
 }
 
-static void PrintElm2List(Expr expr)
+static void PrintElm2List(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr("%<, %<",0L,0L);
-    PrintExpr(READ_EXPR(expr, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 2));
     Pr("%<]",0L,0L);
 }
 
-static void PrintElmListLevel(Expr expr)
+static void PrintElmListLevel(Obj body, Expr expr)
 {
   Int i;
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) -2 ;
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %<",0L,0L);
-      PrintExpr(READ_EXPR(expr, i));
+      PrintExpr(body, READ_EXPR_IN_BODY(body, expr, i));
     }
     Pr("%<]",0L,0L);
 }
 
 
-static void PrintIsbList(Expr expr)
+static void PrintIsbList(Obj body, Expr expr)
 {
   Int narg = SIZE_EXPR(expr)/sizeof(Expr) - 1;
   Int i;
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<[",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     for (i = 2; i <= narg; i++) {
       Pr("%<, %>", 0L, 0L);
-      PrintExpr(READ_EXPR(expr, i));
+      PrintExpr(body, READ_EXPR_IN_BODY(body, expr, i));
     }
     Pr("%<]",0L,0L);
     Pr( " )", 0L, 0L );
@@ -1125,12 +1125,12 @@ static void PrintIsbList(Expr expr)
 **
 **  Linebreaks are preferred after the '{'.
 */
-static void PrintElmsList(Expr expr)
+static void PrintElmsList(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<{",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr("%<}",0L,0L);
 }
 
@@ -1354,25 +1354,25 @@ static Obj EvalIsbRecExpr(Expr expr)
 **  'PrintAssRecName' prints the  record  assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static void PrintAssRecName(Stat stat)
+static void PrintAssRecName(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT_IN_BODY(body, stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintUnbRecName(Stat stat)
+static void PrintUnbRecName(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT_IN_BODY(body, stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1385,25 +1385,25 @@ static void PrintUnbRecName(Stat stat)
 **  'PrintAssRecExpr' prints the  record  assignment statement <stat>  of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static void PrintAssRecExpr(Stat stat)
+static void PrintAssRecExpr(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr(")%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintUnbRecExpr(Stat stat)
+static void PrintUnbRecExpr(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr(")%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1416,22 +1416,22 @@ static void PrintUnbRecExpr(Stat stat)
 **  'PrintElmRecName' prints the record element expression <expr> of the form
 **  '<record>.<name>'.
 */
-static void PrintElmRecName(Expr expr)
+static void PrintElmRecName(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR_IN_BODY(body, expr, 1)), 0L);
     Pr("%<",0L,0L);
 }
 
-static void PrintIsbRecName(Expr expr)
+static void PrintIsbRecName(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR_IN_BODY(body, expr, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1444,22 +1444,22 @@ static void PrintIsbRecName(Expr expr)
 **  'PrintElmRecExpr' prints the record element expression <expr> of the form
 **  '<record>.(<name>)'.
 */
-static void PrintElmRecExpr(Expr expr)
+static void PrintElmRecExpr(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr(")%<",0L,0L);
 }
 
-static void PrintIsbRecExpr(Expr expr)
+static void PrintIsbRecExpr(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<.(",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr(")%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1592,25 +1592,25 @@ static Obj EvalIsbPosObj(Expr expr)
 **
 **  Linebreaks are preferred before the ':='.
 */
-static void PrintAssPosObj(Stat stat)
+static void PrintAssPosObj(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<![",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr("%<]",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintUnbPosObj(Stat stat)
+static void PrintUnbPosObj(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<![",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr("%<]",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1625,22 +1625,22 @@ static void PrintUnbPosObj(Stat stat)
 **
 **  Linebreaks are preferred after the '['.
 */
-static void PrintElmPosObj(Expr expr)
+static void PrintElmPosObj(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<![",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr("%<]",0L,0L);
 }
 
-static void PrintIsbPosObj(Expr expr)
+static void PrintIsbPosObj(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<![",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr("%<]",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1873,25 +1873,25 @@ static Obj EvalIsbComObjExpr(Expr expr)
 **  'PrintAssComObjName' prints the  record assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static void PrintAssComObjName(Stat stat)
+static void PrintAssComObjName(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT_IN_BODY(body, stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintUnbComObjName(Stat stat)
+static void PrintUnbComObjName(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_STAT(stat, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_STAT_IN_BODY(body, stat, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1904,25 +1904,25 @@ static void PrintUnbComObjName(Stat stat)
 **  'PrintAssComObjExpr' prints the  record assignment statement <stat>  of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static void PrintAssComObjExpr(Stat stat)
+static void PrintAssComObjExpr(Obj body, Stat stat)
 {
     Pr("%4>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr(")%<",0L,0L);
     Pr("%< %>:= ",0L,0L);
-    PrintExpr(READ_EXPR(stat, 2));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 2));
     Pr("%2<;",0L,0L);
 }
 
-static void PrintUnbComObjExpr(Stat stat)
+static void PrintUnbComObjExpr(Obj body, Stat stat)
 {
     Pr( "Unbind( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(stat, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr(READ_EXPR(stat, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, stat, 1));
     Pr(")%<",0L,0L);
     Pr( " );", 0L, 0L );
 }
@@ -1935,22 +1935,22 @@ static void PrintUnbComObjExpr(Stat stat)
 **  'PrintElmComObjName' prints the  record  element expression <expr> of   the
 **  form '<record>.<name>'.
 */
-static void PrintElmComObjName(Expr expr)
+static void PrintElmComObjName(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR_IN_BODY(body, expr, 1)), 0L);
     Pr("%<",0L,0L);
 }
 
-static void PrintIsbComObjName(Expr expr)
+static void PrintIsbComObjName(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<!.",0L,0L);
-    Pr("%H", (Int)NAME_RNAM(READ_EXPR(expr, 1)), 0L);
+    Pr("%H", (Int)NAME_RNAM(READ_EXPR_IN_BODY(body, expr, 1)), 0L);
     Pr("%<",0L,0L);
     Pr( " )", 0L, 0L );
 }
@@ -1963,22 +1963,22 @@ static void PrintIsbComObjName(Expr expr)
 **  'PrintElmComObjExpr' prints the record   element expression <expr>  of  the
 **  form '<record>.(<name>)'.
 */
-static void PrintElmComObjExpr(Expr expr)
+static void PrintElmComObjExpr(Obj body, Expr expr)
 {
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr(")%<",0L,0L);
 }
 
-static void PrintIsbComObjExpr(Expr expr)
+static void PrintIsbComObjExpr(Obj body, Expr expr)
 {
     Pr( "IsBound( ", 0L, 0L );
     Pr("%2>",0L,0L);
-    PrintExpr(READ_EXPR(expr, 0));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 0));
     Pr("%<!.(",0L,0L);
-    PrintExpr(READ_EXPR(expr, 1));
+    PrintExpr(body, READ_EXPR_IN_BODY(body, expr, 1));
     Pr(")%<",0L,0L);
     Pr( " )", 0L, 0L );
 }


### PR DESCRIPTION
... instead of implicitly assuming that we are printing the "current" function. This is a small step towards decoupling the code for generating, executing, and printing function bodies. The long term goal is that coding passes the T_BODY object around explicitly, and `STATE(PtrBody)` is used only by the executor. It thus becomes read-only and can be made `const`.

This change also means we can print function bodies w/o first switching to the function.