### PR TITLE
Replace FindPRec, the function for looking up members of a precord.

### DIFF
--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -603,8 +603,7 @@ static void PrintTLRecord(Obj obj)
   for (i = 0; i < deftable[AR_CAP].atom; i++) {
     UInt key = deftable[AR_DATA+2*i].atom;
     Obj value = deftable[AR_DATA+2*i+1].obj;
-    UInt dummy;
-    if (key && (!record || !FindPRec(record, key, &dummy, 0))) {
+    if (key && (!record || !PositionPRec(record, key, 0))) {
       if (comma)
         Pr("%2<, %2>", 0L, 0L);
       Pr("%H", (Int)(NAME_RNAM(key)), 0L);
@@ -994,7 +993,7 @@ Obj GetTLRecordField(Obj record, UInt rnam)
   contents = GetTLInner(record);
   table = ADDR_OBJ(contents);
   tlrecord = table[TLR_DATA+TLS(threadID)];
-  if (!tlrecord || !FindPRec(tlrecord, rnam, &pos, 1)) {
+  if (!tlrecord || !(pos = PositionPRec(tlrecord, rnam, 1))) {
     Obj result;
     Obj defrec = table[TLR_DEFAULTS];
     result = GetARecordField(defrec, rnam);
@@ -1022,7 +1021,8 @@ Obj GetTLRecordField(Obj record, UInt rnam)
           result = CALL_1ARGS(func, record);
         TLS(currentRegion) = savedRegion;
         if (!result) {
-          if (!FindPRec(tlrecord, rnam, &pos, 1))
+          pos = PositionPRec(tlrecord, rnam, 1);
+          if (!pos)
             return 0;
           return GET_ELM_PREC(tlrecord, pos);
         }

--- a/src/precord.c
+++ b/src/precord.c
@@ -308,9 +308,7 @@ Int IsbPRec (
     Obj                 rec,
     UInt                rnam )
 {
-    UInt                i;              /* loop variable                   */
-
-    return FindPRec(rec,rnam,&i,1);
+    return PositionPRec(rec, rnam, 1) != 0;
 }
 
 
@@ -326,9 +324,8 @@ Obj ElmPRec (
     Obj                 rec,
     UInt                rnam )
 {
-    UInt                i;              /* loop variable                   */
-
-    if (FindPRec(rec,rnam,&i,1))
+    UInt i = PositionPRec(rec, rnam, 1);
+    if (i)
         return GET_ELM_PREC( rec, i );
 
     ErrorMayQuit("Record Element: '<rec>.%g' must have an assigned value",
@@ -348,14 +345,15 @@ void UnbPRec (
     UInt                rnam )
 {
     UInt                len;            /* length of <rec>                 */
-    UInt                i;              /* loop variable                   */
 
     // Accept T_PREC and T_COMOBJ, reject T_PREC+IMMUTABLE
     if (TNUM_OBJ(rec) == T_PREC+IMMUTABLE) {
         ErrorMayQuit("Record Unbind: <rec> must be a mutable record", 0, 0);
     }
 
-    if (FindPRec( rec, rnam, &i, 1 )) {
+    UInt i = PositionPRec(rec, rnam, 1);
+
+    if (i) {
         /* otherwise move everything forward                               */
         len = LEN_PREC( rec );
         for ( ; i < len; i++ ) {
@@ -368,8 +366,8 @@ void UnbPRec (
 
         /* resize the record                                               */
         SET_LEN_PREC(rec,LEN_PREC(rec)-1);
-
-    } else
+    }
+    else
         /* do nothing if no such component exists                          */
         return;
 }
@@ -388,7 +386,6 @@ void AssPRec (
     Obj                 val )
 {
     UInt                len;            /* length of <rec>                 */
-    UInt                i;              /* loop variable                   */
 
     // Accept T_PREC and T_COMOBJ, reject T_PREC+IMMUTABLE
     if (TNUM_OBJ(rec) == T_PREC+IMMUTABLE) {
@@ -403,7 +400,9 @@ void AssPRec (
         SortPRecRNam(rec,0);
     }
 
-    if (!FindPRec( rec, rnam, &i, 0 )) {
+    UInt i = PositionPRec(rec, rnam, 0);
+
+    if (!i) {
         /* No cleanup allowed here to allow for multiple assignments! */
         /* extend the record if no such component exists                   */
         len++;

--- a/src/precord.h
+++ b/src/precord.h
@@ -168,17 +168,29 @@ EXPORT_INLINE Obj GET_ELM_PREC(Obj rec, UInt i)
 
 /****************************************************************************
 **
-*F  FindPRec( <rec>, <rnam>, <pos>, <cleanup> )
+*F  PositionPRec( <rec>, <rnam>, <cleanup> )
 *F   . . . . . . . . . . . . . . . . . find a component name by binary search
 **
-**  Searches <rnam> in <rec>, sets <pos> to the position where it is found
-**  (return value 1) or where it should be inserted if it is not found
-**  (return value 0).
+**  Searches <rnam> in <rec>, returns the position where it is found, or 0
+**  if it is not present.
 **  If <cleanup> is nonzero, a dirty record is automatically cleaned up.
 **  If <cleanup> is 0, this does not happen.
+**
+**
+*F  FindPRec( <rec>, <rnam>, <pos>, <cleanup> )
+*F   . . . . . . . . . . . . . . . . . find a component name by binary search
+**  A deprecated variant of PositionPRec, which sets <pos> to the position
+**  where the value is contained (or NULL if it is not present) and returns 1
+**  if the record contained rnam, and 0 otherwise.
 **/
 
-UInt FindPRec(Obj rec, UInt rnam, UInt * pos, int cleanup);
+UInt PositionPRec(Obj rec, UInt rnam, int cleanup);
+
+EXPORT_INLINE UInt FindPRec(Obj rec, UInt rnam, UInt * pos, int cleanup)
+{
+    *pos = PositionPRec(rec, rnam, cleanup);
+    return (*pos != 0);
+}
 
 
 /****************************************************************************


### PR DESCRIPTION
Short version: There was a function call `FindPRec`. I replaced it with a slightly faster, slightly cleaner method called `PositionPRec`. I left a implementation of `FindPRec` using `PositionPRec` because it is used by the semigroups package, hopefully this can be eventually removed.

Longer:

While investigating another bug, I thought the problem was in FindPRec, and I did find a bug in FindPRec (when it returns 0, it sometimes fails to set the pointer `pos`).

However, then it turned out if FindPRec returns 0, no-one uses pos anyway.

I decided to rewrite the function to be (in my opinion) easier to read. I also carefully benchmarked a number of micro-optimisations using valgrind, and believe I have found a local optima. This produces a small but measurable improvement on record-heavy benchmarks.

I would like to do some other cleanups (The return value of GET_RNAM_PREC is really a signed integer, but we treat it as an unsigned integer. In general I'd like to be more careful about this signed/unsigned business). However, I that PR will be much larger and much simpler, so I thought I'd do this first.