### PR TITLE
Run on Travis job with GCC 4.7, to verify we stay compatible with it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,10 +117,15 @@ matrix:
     # The '--enable-valgrind' checks that GAP builds and runs correctly when
     # compiled with valgrind support. We do not actually run any tests using
     # valgrind, as it is too slow.
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-valgrind"
+    #
+    # Also change the compiler to GCC 4.7, to ensure we stay compatible
+    # with that older version.
+    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-valgrind CC=gcc-4.7 CXX=g++-4.7"
       addons:
         apt_packages:
-            valgrind
+          - gcc-4.7
+          - g++-4.7
+          - valgrind
 
     # same as above, but in 32 bit mode, also turn off debugging (see elsewhere in this file for
     # an explanation)

--- a/src/finfield.h
+++ b/src/finfield.h
@@ -143,6 +143,8 @@ extern  Obj             SuccFF;
 */
 typedef UInt2           FFV;
 
+GAP_STATIC_ASSERT(sizeof(UInt) >= 2 * sizeof(FFV),
+                  "Overflow possibility in POW_FFV");
 
 /****************************************************************************
 **
@@ -287,8 +289,6 @@ EXPORT_INLINE FFV POW_FFV(FFV a, UInt n, const FFV * f)
 {
     GAP_ASSERT(a <= f[0]);
     GAP_ASSERT(n <= f[0]);
-    GAP_STATIC_ASSERT(sizeof(UInt) >= 2 * sizeof(FFV),
-                      "Overflow possibility in POW_FFV");
     if (!n)
         return 1;
     if (!a)

--- a/src/read.c
+++ b/src/read.c
@@ -259,20 +259,22 @@ enum REFTYPE {
 };
 
 typedef struct {
-    enum REFTYPE type;
+    UInt1 type;
 
     union {
-        UInt var;
-        UInt narg;
-        UInt rnam;
+        UInt2 nest0;
+        UInt2 level;
     };
 
     union {
-        UInt nest0;
-        UInt level;
+        UInt4 var;
+        UInt4 narg;
+        UInt4 rnam;
     };
+
 } LHSRef;
 
+GAP_STATIC_ASSERT(sizeof(LHSRef) <= 8, "LHSRef is too big");
 
 /****************************************************************************
 **


### PR DESCRIPTION
Note that 4.7 is the oldest GCC version readily available on Travis.

As a side effect, I was able to reproduce #3141, and added a workaround for it to this PR, too. Thus this PR also fixes #3141.