### PR TITLE
kernel: avoid accessing NLOC_FUNC in PrintFunction if possible

### DIFF
--- a/tst/testinstall/bitfields.tst
+++ b/tst/testinstall/bitfields.tst
@@ -29,12 +29,30 @@ gap> for i in [1..2+GAPInfo.BytesPerVariable] do
 
 #
 # Now test various error and extreme conditions
-#<
+#
 gap> bf := MakeBitfields(1);
 rec( booleanGetters := [ function( data ) ... end ], 
   booleanSetters := [ function( data, val ) ... end ], 
   getters := [ function( data ) ... end ], 
   setters := [ function( data, val ) ... end ], widths := [ 1 ] )
+
+#
+gap> Display(bf.getters[1]);
+function ( data )
+    <<kernel or compiled code>>
+end
+gap> Display(bf.setters[1]);
+function ( data, val )
+    <<kernel or compiled code>>
+end
+gap> Display(bf.booleanGetters[1]);
+function ( data )
+    <<kernel or compiled code>>
+end
+gap> Display(bf.booleanSetters[1]);
+function ( data, val )
+    <<kernel or compiled code>>
+end
 
 #
 gap> bf.getters[1](Z(5));


### PR DESCRIPTION
Reorder some of the code to ensure printing a  kernel function does not
needlessly access NLOC_FUNC. This avoids a potential problem with custom
functions that abuse NLOC_FUNC to store alternate data, such as the
"SmallInt Bitfield operations" in intfuncs.c.

Also, don't retain a pointer into a GAP object across calls that might
trigger a GC, such as `Pr`. But note that this code is only used in
HPC-GAP, and there we don't use a moving GC, so in practice this code
was fine anyway.