### PR TITLE
kernel: refactor bitfields code to avoid (ab)using FEXS_FUNC and NLOC_FUNC

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1577,7 +1577,7 @@ static ObjFunc LoadHandler( void )
 static void SaveFunction(Obj func)
 {
   const FuncBag * header = CONST_FUNC(func);
-  for (UInt i = 0; i <= 7; i++)
+  for (UInt i = 0; i < ARRAY_SIZE(header->handlers); i++)
     SaveHandler(header->handlers[i]);
   SaveSubObj(header->name);
   SaveSubObj(header->nargs);
@@ -1587,7 +1587,7 @@ static void SaveFunction(Obj func)
   SaveSubObj(header->body);
   SaveSubObj(header->envi);
   SaveSubObj(header->fexs);
-  if (SIZE_OBJ(func) != sizeof(FuncBag))
+  if (IS_OPERATION(func))
     SaveOperationExtras( func );
 }
 
@@ -1599,7 +1599,7 @@ static void SaveFunction(Obj func)
 static void LoadFunction(Obj func)
 {
   FuncBag * header = FUNC(func);
-  for (UInt i = 0; i <= 7; i++)
+  for (UInt i = 0; i < ARRAY_SIZE(header->handlers); i++)
     header->handlers[i] = LoadHandler();
   header->name = LoadSubObj();
   header->nargs = LoadSubObj();
@@ -1609,7 +1609,7 @@ static void LoadFunction(Obj func)
   header->body = LoadSubObj();
   header->envi = LoadSubObj();
   header->fexs = LoadSubObj();
-  if (SIZE_OBJ(func) != sizeof(FuncBag))
+  if (IS_OPERATION(func))
     LoadOperationExtras( func );
 }
 

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -489,34 +489,32 @@ Int HASHKEY_WHOLE_BAG_NC(Obj obj, UInt4 seed)
     return HASHKEY_BAG_NC(obj, seed, 0, SIZE_OBJ(obj));
 }
 
+
 /****************************************************************************
 **
-*F SmallInt Bitfield operations
-*
-* The goal here it to set up a division of the usable bits in a small
-* integer into fields which can be accessed very quickly from GAP
-* level and quickly and conveniently from C. The purpose is to allow
-* implementation of data structures that divide up the bits within a
-* word without having to make them entirely opaque to the GAP level or
-* ridiculously slow
-*
-* The API is defined in lib/bitfields.gd and works by providing the
-* user with a collection of functions to get and set fields and
-* assemble an entire word.
-*
-* These functions are constructed here and have special handlers. The
-* information the handlers need about the size and position of the
-* bitfields are stored in some of the fields of the function header
-* which are not normally used for kernel functions. Specifically, we
-* use the NLOC_FUNC and FEXS_FUNC fields, which we alias as
-* MASK_BITFIELD_FUNC and OFFSET_BITFIELD_FUNC.
-*
-* For fields of size 1 we also offer Boolean setters and getters which
-* accept and return True for 1 and False for 0. This makes for much
-* nicer code on the GAP side.
-*
+*F  SmallInt Bitfield operations
+**
+**  The goal here it to set up a division of the usable bits in a small
+**  integer into fields which can be accessed very quickly from GAP level and
+**  quickly and conveniently from C. The purpose is to allow implementation
+**  of data structures that divide up the bits within a word without having
+**  to make them entirely opaque to the GAP level or ridiculously slow.
+**
+**  The API is defined in lib/bitfields.gd and works by providing the user
+**  with a collection of functions to get and set fields and assemble an
+**  entire word.
+**
+**  These functions are constructed here and have special handlers. The
+**  information the handlers need about the size and position of the
+**  bitfields are stored in some of the fields of the function header which
+**  are not normally used for kernel functions. Specifically, we use the
+**  NLOC_FUNC and FEXS_FUNC fields, which we alias as MASK_BITFIELD_FUNC and
+**  OFFSET_BITFIELD_FUNC.
+**
+**  For fields of size 1 we also offer Boolean setters and getters which
+**  accept and return True for 1 and False for 0. This makes for much nicer
+**  code on the GAP side.
 */
-
 
 static inline UInt MASK_BITFIELD_FUNC(Obj func)
 {

--- a/tst/testinstall/bitfields.tst
+++ b/tst/testinstall/bitfields.tst
@@ -35,6 +35,8 @@ rec( booleanGetters := [ function( data ) ... end ],
   booleanSetters := [ function( data, val ) ... end ], 
   getters := [ function( data ) ... end ], 
   setters := [ function( data, val ) ... end ], widths := [ 1 ] )
+
+#
 gap> bf.getters[1](Z(5));
 Error, Field getter: argument must be small integer
 gap> bf.setters[1](1, (1,2));
@@ -45,4 +47,16 @@ gap> BuildBitfields([1],Z(5));
 Error, Fields builder: values must be small integers
 gap> MakeBitfields(100);
 Error, MAKE_BITFIELDS: total widths too large
+
+#
+gap> NameFunction(bf.getters[1]);
+"<field getter>"
+gap> NameFunction(bf.setters[1]);
+"<field setter>"
+gap> NameFunction(bf.booleanGetters[1]);
+"<boolean field getter>"
+gap> NameFunction(bf.booleanSetters[1]);
+"<boolean field setter>"
+
+#
 gap> STOP_TEST("bitfields.tst", 1);


### PR DESCRIPTION
We achieve this by instead allocating a slightly larger bag for the function, and then store the two extra values in the additional space. Note that we must store them as `Obj` and not as plain `UInt`, because the GC marking function for function bags expects that.

However, distinguish between operations and "normal" functions by the bag size. This still works if we compared the bag size against `sizeof(OperBag)`, as done by `IS_OPERATION`, but not if we compared it against `sizeof(FuncBag)` as done in `SaveFunction` and `LoadFunction`. So we change the latter to use `IS_OPERATION` to resolve that problem. (I plan to provide a PR in the future which replaces this size based detection by something more robust.)

Motivation for this, besides cleanliness / avoiding hacks that make the code harder to understand, is a desire to get rid of FEXS (PR for that upcoming).

Note that JuliaInterface and PARIInterface currently also abuse FEXS_FUNC in a similar fashion (CC @sebasguts and @markuspf ). But we can fix them in a similar way. If nobody beats me to it, I'll try to provide PRs for them doing this.