### PR TITLE
kernel: get rid of FEXS_FUNC

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1581,7 +1581,6 @@ static void SaveFunction(Obj func)
   SaveSubObj(header->nloc);
   SaveSubObj(header->body);
   SaveSubObj(header->envi);
-  SaveSubObj(header->fexs);
   if (IS_OPERATION(func))
     SaveOperationExtras( func );
 }
@@ -1603,7 +1602,6 @@ static void LoadFunction(Obj func)
   header->nloc = LoadSubObj();
   header->body = LoadSubObj();
   header->envi = LoadSubObj();
-  header->fexs = LoadSubObj();
   if (IS_OPERATION(func))
     LoadOperationExtras( func );
 }

--- a/src/calls.h
+++ b/src/calls.h
@@ -70,7 +70,6 @@ typedef Obj (* ObjFunc_6ARGS) (Obj self, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5,
 *F  NLOC_FUNC(<func>) . . . . . . . . . . . .  number of locals of a function
 *F  BODY_FUNC(<func>) . . . . . . . . . . . . . . . . . .  body of a function
 *F  ENVI_FUNC(<func>) . . . . . . . . . . . . . . . environment of a function
-*F  FEXS_FUNC(<func>) . . . . . . . . . . . .  func. expr. list of a function
 **
 **  These macros  make it possible  to access  the  various components  of  a
 **  function.
@@ -96,9 +95,6 @@ typedef Obj (* ObjFunc_6ARGS) (Obj self, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5,
 **  'ENVI_FUNC(<func>)'  is the  environment (i.e., the local  variables bag)
 **  that was current when <func> was created.
 **
-**  'FEXS_FUNC(<func>)'  is the function expressions list (i.e., the list of
-**  the function expressions of the functions defined inside of <func>).
-**
 **  'LCKS_FUNC(<func>)' is a string that contains the lock mode for the
 **  arguments of <func>. Each byte corresponds to the mode for an argument:
 **  0 means no lock, 1 means a read-only lock, 2 means a read-write lock.
@@ -114,7 +110,6 @@ typedef struct {
     Obj nloc;
     Obj body;
     Obj envi;
-    Obj fexs;
 #ifdef HPCGAP
     Obj locks;
 #endif
@@ -177,11 +172,6 @@ EXPORT_INLINE Obj ENVI_FUNC(Obj func)
     return CONST_FUNC(func)->envi;
 }
 
-EXPORT_INLINE Obj FEXS_FUNC(Obj func)
-{
-    return CONST_FUNC(func)->fexs;
-}
-
 #ifdef HPCGAP
 EXPORT_INLINE Obj LCKS_FUNC(Obj func)
 {
@@ -227,11 +217,6 @@ EXPORT_INLINE void SET_BODY_FUNC(Obj func, Obj body)
 EXPORT_INLINE void SET_ENVI_FUNC(Obj func, Obj envi)
 {
     FUNC(func)->envi = envi;
-}
-
-EXPORT_INLINE void SET_FEXS_FUNC(Obj func, Obj fexs)
-{
-    FUNC(func)->fexs = fexs;
 }
 
 #ifdef HPCGAP

--- a/src/code.c
+++ b/src/code.c
@@ -812,7 +812,6 @@ void CodeFuncExprBegin (
     Int                 startLine)
 {
     Obj                 fexp;           /* function expression bag         */
-    Obj                 fexs;           /* function expressions list       */
     Bag                 body;           /* function body                   */
     Bag                 old;            /* old frame                       */
     Stat                stat1;          /* first statement in body         */
@@ -828,11 +827,6 @@ void CodeFuncExprBegin (
 #ifdef HPCGAP
     if (nams) MakeBagPublic(nams);
 #endif
-    CHANGED_BAG( fexp );
-
-    /* give it a functions expressions list                                */
-    fexs = NEW_PLIST( T_PLIST, 0 );
-    SET_FEXS_FUNC( fexp, fexs );
     CHANGED_BAG( fexp );
 
     /* give it a body                                                      */
@@ -864,7 +858,6 @@ void CodeFuncExprEnd(UInt nr)
     Expr                expr;           /* function expression, result     */
     Stat                stat1;          /* single statement of body        */
     Obj                 fexp;           /* function expression bag         */
-    Obj                 fexs;           /* funct. expr. list of outer func */
     UInt                len;            /* length of func. expr. list      */
     UInt                i;              /* loop variable                   */
 
@@ -906,9 +899,6 @@ void CodeFuncExprEnd(UInt nr)
         WRITE_STAT(OFFSET_FIRST_STAT, nr - i, stat1);
     }
 
-    // make the function expression list immutable
-    MakeImmutable( FEXS_FUNC( fexp ) );
-
     // make the body values list (if any) immutable
     Obj values = ((BodyHeader *)STATE(PtrBody))->values;
     if (values)
@@ -927,8 +917,7 @@ void CodeFuncExprEnd(UInt nr)
     /* if this was inside another function definition, make the expression */
     /* and store it in the function expression list of the outer function  */
     if (STATE(CurrLVars) != CS(CodeLVars)) {
-        fexs = FEXS_FUNC( CURR_FUNC() );
-        len = PushPlist( fexs, fexp );
+        len = PushValue(fexp);
         expr = NewExpr( T_FUNC_EXPR, sizeof(Expr) );
         WRITE_EXPR(expr, 0, len);
         PushExpr( expr );

--- a/src/code.h
+++ b/src/code.h
@@ -104,6 +104,10 @@ void SET_ENDLINE_BODY(Obj body, UInt val);
 
 Obj GET_VALUE_FROM_CURRENT_BODY(Int ix);
 
+EXPORT_INLINE Obj VALUES_BODY(Obj body)
+{
+    return BODY_HEADER(body)->values;
+}
 
 /****************************************************************************
 **

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -660,7 +660,6 @@ Obj             MakeFunction (
 #ifdef HPCGAP
     SET_LCKS_FUNC( func, LCKS_FUNC( fexp ) );
 #endif
-    SET_FEXS_FUNC( func, FEXS_FUNC( fexp ) );
 
     /* return the function                                                 */
     return func;
@@ -675,12 +674,8 @@ Obj             MakeFunction (
 */
 static Obj EvalFuncExpr(Expr expr)
 {
-    Obj                 fexs;           /* func. expr. list of curr. func. */
-    Obj                 fexp;           /* function expression bag         */
-
     /* get the function expression bag                                     */
-    fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST(fexs, READ_EXPR(expr, 0));
+    Obj fexp = GET_VALUE_FROM_CURRENT_BODY(READ_EXPR(expr, 0));
 
     /* and make the function                                               */
     return MakeFunction( fexp );
@@ -695,14 +690,9 @@ static Obj EvalFuncExpr(Expr expr)
 */
 static void PrintFuncExpr(Expr expr)
 {
-    Obj                 fexs;           /* func. expr. list of curr. func. */
-    Obj                 fexp;           /* function expression bag         */
-
     /* get the function expression bag                                     */
-    fexs = FEXS_FUNC( CURR_FUNC() );
-    fexp = ELM_PLIST(fexs, READ_EXPR(expr, 0));
+    Obj fexp = GET_VALUE_FROM_CURRENT_BODY(READ_EXPR(expr, 0));
     PrintFunction( fexp );
-    /* Pr("function ... end",0L,0L); */
 }
 
 

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -163,11 +163,7 @@ static Obj SyntaxTreeFunccall(Obj result, Expr expr)
 
 static Obj SyntaxTreeFuncExpr(Obj result, Expr expr)
 {
-    Obj fexs;
-    Obj fexp;
-
-    fexs = FEXS_FUNC(CURR_FUNC());
-    fexp = ELM_PLIST(fexs, READ_EXPR(expr, 0));
+    Obj fexp = GET_VALUE_FROM_CURRENT_BODY(READ_EXPR(expr, 0));
 
     SyntaxTreeFunc(result, fexp);
 


### PR DESCRIPTION
This contains PRs #3262 and #3263, and will need to be rebased once those are merged. Only the last commit is "new" compared to those two PRs.

This breaks JuliaInterface and PARIInterface, but those can be fixed as described in PR #3263; in fact, we may want to first merge PR #3263, then fix those two packages, before merging this PR here.