### PR TITLE
Change StructureDescription for infinite cyclic group

### DIFF
--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -695,7 +695,8 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##  <Listing><![CDATA[
 ##    StructureDescription(<G>) ::=
 ##        1                                 ; trivial group 
-##      | C<size>                           ; cyclic group
+##      | C<size>                           ; finite cyclic group
+##      | Z                                 ; infinite cyclic group
 ##      | A<degree>                         ; alternating group
 ##      | S<degree>                         ; symmetric group
 ##      | D<size>                           ; dihedral group
@@ -759,7 +760,7 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##    If <A>G</A> is abelian, then decompose it into cyclic factors
 ##    in <Q>elementary divisors style</Q>. For example,
 ##    <C>"C2 x C3 x C3"</C> is <C>"C6 x C3"</C>.
-##    For infinite abelian groups, <C>"C0"</C> denotes the group of integers.
+##    For infinite abelian groups, <C>"Z"</C> denotes the group of integers.
 ##  </Item>
 ##  <Mark>3.</Mark>
 ##  <Item>
@@ -883,9 +884,9 @@ DeclareGlobalFunction( "LinearGroupParameters" );
 ##  gap> StructureDescription(SmallGroup(504,7):nice);
 ##  "(C7 : Q8) : C9"
 ##  gap> StructureDescription(AbelianGroup([0,2,3]));
-##  "C0 x C6"
+##  "Z x C6"
 ##  gap> StructureDescription(AbelianGroup([0,0,0,2,3,6]):short);
-##  "0^3x6^2"
+##  "Z^3x6^2"
 ##  gap> StructureDescription(PSL(4,2));
 ##  "A8"
 ##  ]]></Example>

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -490,7 +490,7 @@ local Ns,MinNs,sel,a,sz,j,gs,g,N;
     Add(MinNs,Ns[a]);
     for j in ShallowCopy(sel) do
       if Size(Ns[j])>sz and Size(Ns[j]) mod sz=0 and IsSubset(Ns[j],Ns[a]) then
-	RemoveSet(sel,j);
+        RemoveSet(sel,j);
       fi;
     od;
   od;
@@ -1672,23 +1672,35 @@ BindGlobal( "SD_insertsep", # function to join parts of name
       return s;
     end);
 
+BindGlobal( "SD_cyclic",
+    function ( n )
+      if n = 0 or n = infinity then
+        return "Z";
+      fi;
+      return Concatenation("C",String(n));
+    end);
+
 BindGlobal( "SD_cycsaspowers", # function to write C2 x C2 x C2 as 2^3, etc.
     function ( name, cycsizes )
 
-      local  short, d, k, j, n;
+      local  short, g, d, k, j, n;
 
       short := ValueOption("short") = true;
       if not short then return name; fi;
       RemoveCharacters(name," ");
         cycsizes := Collected(cycsizes);
-        for n in cycsizes
-        do
+        for n in cycsizes do
           d := n[1]; k := n[2];
+          g := SD_cyclic(d);
+          if d = 0 then
+            d := "Z";
+          else
+            d := String(d);
+          fi;
           if k > 1 then
             for j in Reversed([2..k]) do
-              name := ReplacedString(name,SD_insertsep(List([1..j],
-                        i->Concatenation("C",String(d))),"x",""),
-                        Concatenation(String(d),"^",String(j)));
+              name := ReplacedString(name,SD_insertsep(List([1..j],i->g),"x",""),
+                        Concatenation(d,"^",String(j)));
             od;
           fi;
         od;
@@ -1709,8 +1721,7 @@ BindGlobal( "StructureDescriptionForAbelianGroups", # for abelian groups
     cycsizes := AbelianInvariants(G);
     cycsizes := Reversed(ElementaryDivisorsMat(DiagonalMat(cycsizes)));
     cycsizes := Filtered(cycsizes,n->n<>1);
-    return SD_cycsaspowers(SD_insertsep(List(cycsizes,
-                                             n->Concatenation("C",String(n))),
+    return SD_cycsaspowers(SD_insertsep(List(cycsizes, SD_cyclic),
                                         " x ",""), cycsizes);
   end );
 
@@ -1886,8 +1897,7 @@ BindGlobal( "StructureDescriptionForFiniteGroups", # for finite groups
       if cyclics <> [] then
         cycsizes := ElementaryDivisorsMat(DiagonalMat(List(cyclics,Size)));
         cycsizes := Filtered(cycsizes,n->n<>1);
-        cycname  := SD_cycsaspowers(SD_insertsep(List(cycsizes,
-                                    n->Concatenation("C",String(n))),
+        cycname  := SD_cycsaspowers(SD_insertsep(List(cycsizes, SD_cyclic),
                                     " x ",":."), cycsizes);
       else cycname := ""; fi;
       noncyclics := Difference(Gs,cyclics);

--- a/tst/testinstall/opers/StructureDescription.tst
+++ b/tst/testinstall/opers/StructureDescription.tst
@@ -15,9 +15,9 @@ gap> StructureDescription(SmallGroup(504,7));
 gap> StructureDescription(SmallGroup(504,7):nice);
 "(C7 : Q8) : C9"
 gap> StructureDescription(AbelianGroup([0,2,3]));
-"C0 x C6"
+"Z x C6"
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,6]):short);
-"0^3x6^2"
+"Z^3x6^2"
 gap> StructureDescription(PSL(4,2));
 "A8"
 
@@ -34,7 +34,7 @@ gap> List(AllPrimitiveGroups(DegreeAction, 8), StructureDescription);
 [ "(C2 x C2 x C2) : C7", "(C2 x C2 x C2) : (C7 : C3)", 
   "(C2 x C2 x C2) : PSL(3,2)", "PSL(3,2)", "PSL(3,2) : C2", "A8", "S8" ]
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,6]):short);
-"0^3x6^2"
+"Z^3x6^2"
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
 gap> StructureDescription(G);
 "A5 x A5"
@@ -87,9 +87,9 @@ true
 gap> StructureDescriptionForFiniteSimpleGroups(Ree(27));
 "Ree(27)"
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,4,5,6,7,8,9,10]));
-"C0 x C0 x C0 x C2520 x C60 x C6 x C2 x C2"
+"Z x Z x Z x C2520 x C60 x C6 x C2 x C2"
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,4,5,6,7,8,9,10]):short);
-"0^3x2520x60x6x2^2"
+"Z^3x2520x60x6x2^2"
 gap> infolevel:=InfoLevel(InfoWarning);; SetInfoLevel(InfoWarning,2);
 gap> StructureDescription(SmallGroup(48,16):recompute,nice);
 #I  Warning! Non-unique semidirect product:
@@ -104,7 +104,15 @@ gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
 gap> G := F/[s^2, r^3, s*r*s*r];;
 gap> StructureDescription(G);
 "S3"
+
+# some infinite groups
 gap> G := F/[s*r*s^(-1)*r^(-1)];;
 gap> StructureDescription(G);
-"C0 x C0"
+"Z x Z"
+gap> StructureDescription(CyclicGroup(infinity));
+"Z"
+gap> StructureDescription(AbelianGroup([0,2,0]));
+"Z x Z x C2"
+
+#
 gap> STOP_TEST("StructureDescription.tst", 1);


### PR DESCRIPTION
It used to be C0, now we refer to it as Z (as in: the integers), which
should be understood by more people without consulting the manual. Also,
the short name "0" is likewise replace by 0.

This is also consistent with what the RCWA package does in its custom
StructureDescription method.