### PR TITLE
Make TemporaryGlobalVarName obsolete

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -583,8 +583,7 @@ Second, the variable names are passed as strings,
 rather than being written directly into the statements. 
 <P/>
 Note that the functions <Ref Func="NamesGVars"/>,
-<Ref Func="NamesSystemGVars"/>, <Ref Func="NamesUserGVars"/>,
-and <Ref Func="TemporaryGlobalVarName"/>
+<Ref Func="NamesSystemGVars"/>, and <Ref Func="NamesUserGVars"/>,
 deal with the <E>global namespace</E>.
 
 
@@ -714,19 +713,6 @@ variable names created by the &GAP; library when &GAP; was started.
 This function returns an immutable sorted list of the global variable
 names created since the library was read, to which a value is
 currently bound.
-</Description>
-</ManSection>
-
-
-<ManSection>
-<Func Name="TemporaryGlobalVarName" Arg='[prefix]'/>
-
-<Description>
-returns a string  that can be used
-as the  name  of a global  variable  that is not bound   at the time when
-<Ref Func="TemporaryGlobalVarName"/> is called.
-The optional argument <A>prefix</A> can
-specify a string with which the name of the global variable starts.
 </Description>
 </ManSection>
 

--- a/doc/ref/obsolete.xml
+++ b/doc/ref/obsolete.xml
@@ -195,6 +195,12 @@ deprecated in GAP 4.10 since it was unused and only available for coefficient
 lists.
 Note that <C>MultRowVector</C> was also renamed to <C>MultVectorLeft</C>.
 
+<Index Key="TemporaryGlobalVarName"><C>TemporaryGlobalVarName</C></Index>
+The function <C>TemporaryGlobalVarName</C> has been deprecated in GAP 4.11.
+Code using it typically can be restructured to not need it, e.g. by
+using <Ref Func="EvalString"/>.
+
+
 <ManSection>
 <InfoClass Name="InfoObsolete"/>
 <Description>

--- a/lib/global.gd
+++ b/lib/global.gd
@@ -257,20 +257,3 @@ DeclareGlobalFunction("MakeConstantGlobal");
 ##
 DeclareGlobalFunction("BindGlobal");
 DeclareGlobalFunction("BindConstant");
-
-#############################################################################
-##
-#F  TemporaryGlobalVarName( [<prefix>] )   name of an unbound global variable
-##
-##  <ManSection>
-##  <Func Name="TemporaryGlobalVarName" Arg='[prefix]'/>
-##
-##  <Description>
-##  TemporaryGlobalVarName ( [<A>prefix</A>] ) returns a string that can be used
-##  as the name of a global variable that is not bound at the time when
-##  TemporaryGlobalVarName() is called.  The optional argument prefix can
-##  specify a string with which the name of the global variable starts.
-##  </Description>
-##  </ManSection>
-##
-DeclareGlobalFunction("TemporaryGlobalVarName");

--- a/lib/global.gi
+++ b/lib/global.gi
@@ -275,36 +275,3 @@ InstallGlobalFunction( BindConstant,
     Info( InfoGlobal, 2, "BindConstant: called to set ", name, " to ", value);
     BIND_CONSTANT( name, value );
 end);
-
-#############################################################################
-##
-#F  TemporaryGlobalVarName( [<prefix>] )   name of an unbound global variable
-##
-##  TemporaryGlobalVarName ( [<prefix>]  ) returns a string  that can be used
-##  as the  name  of a global  variable  that is not bound   at the time when
-##  TemporaryGlobalVarName()  is called.    The optional  argument prefix can
-##  specify a string with which the name of the global variable starts.
-##
-
-InstallGlobalFunction( TemporaryGlobalVarName,
-        function( arg )
-    local   prefix,  nr,  gvar;
-
-    if Length(arg) = 0 then
-        prefix := "TEMP";
-    elif Length(arg) = 1 and IsString( arg[1] ) then
-        prefix := arg[1];
-        CheckGlobalName( prefix );
-    else
-        return Error( "usage: TemporaryGlobalVarName( [<prefix>] )" );
-    fi;
-
-    nr := 0;
-    gvar:= prefix;
-    while ISBOUND_GLOBAL( gvar ) do
-        nr := nr + 1;
-        gvar := Concatenation( prefix, String(nr) );
-    od;
-
-    return gvar;
-end );

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -691,6 +691,24 @@ if GAPInfo.CommandLineOptions.D then InfoRead1 := Print; fi;
 if not IsBound(InfoRead1) then InfoRead1 := Ignore; fi;
 if not IsBound(InfoRead2) then InfoRead2 := Ignore; fi;
 
+#############################################################################
+##
+#F  TemporaryGlobalVarName( [<prefix>] )   name of an unbound global variable
+##
+##  <ManSection>
+##  <Func Name="TemporaryGlobalVarName" Arg='[prefix]'/>
+##
+##  <Description>
+##  TemporaryGlobalVarName ( [<A>prefix</A>] ) returns a string that can be used
+##  as the name of a global variable that is not bound at the time when
+##  TemporaryGlobalVarName() is called.  The optional argument prefix can
+##  specify a string with which the name of the global variable starts.
+##  </Description>
+##  </ManSection>
+##
+##  Still used in anupq, nq, resclasses, SCSCP (02/2019)
+DeclareGlobalFunction("TemporaryGlobalVarName");
+
 
 #############################################################################
 ##

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -959,6 +959,42 @@ BIND_GLOBAL( "SetFeatureObj", function ( obj, filter, val )
     fi;
 end );
 
+#############################################################################
+##
+#F  TemporaryGlobalVarName( [<prefix>] )   name of an unbound global variable
+##
+##  TemporaryGlobalVarName ( [<prefix>]  ) returns a string  that can be used
+##  as the  name  of a global  variable  that is not bound   at the time when
+##  TemporaryGlobalVarName()  is called.    The optional  argument prefix can
+##  specify a string with which the name of the global variable starts.
+##
+
+InstallGlobalFunction( TemporaryGlobalVarName,
+        function( arg )
+    local   prefix,  nr,  gvar;
+
+  Info(InfoObsolete, 2, "This usage of `TemporaryGlobalVarName` is no longer ",
+         "supported and will be removed eventually." );
+
+    if Length(arg) = 0 then
+        prefix := "TEMP";
+    elif Length(arg) = 1 and IsString( arg[1] ) then
+        prefix := arg[1];
+        CheckGlobalName( prefix );
+    else
+        return Error( "usage: TemporaryGlobalVarName( [<prefix>] )" );
+    fi;
+
+    nr := 0;
+    gvar:= prefix;
+    while ISBOUND_GLOBAL( gvar ) do
+        nr := nr + 1;
+        gvar := Concatenation( prefix, String(nr) );
+    od;
+
+    return gvar;
+end );
+
 
 if IsHPCGAP then
     BindThreadLocal("HIDDEN_GVARS",[]);


### PR DESCRIPTION
This is only used in two packages, SCSCP and anupq; I already have a
plan to get rid of it in anupq, and hope that SCSCP can also get rid of
it; alternatively, SCSCP could add its own copy of this function.

Resolves #2367