### PR TITLE
Further minor precord cleanups

### DIFF
--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -586,7 +586,7 @@ static void PrintTLRecord(Obj obj)
   if (record) {
     for (i = 1; i <= LEN_PREC(record); i++) {
       Obj val = GET_ELM_PREC(record, i);
-      Pr("%H", (Int)NAME_RNAM(labs((Int)GET_RNAM_PREC(record, i))), 0L);
+      Pr("%H", (Int)NAME_RNAM(labs(GET_RNAM_PREC(record, i))), 0L);
       Pr ("%< := %>", 0L, 0L);
       if (val)
         PrintObj(val);

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -626,7 +626,7 @@ static Obj DeserializeRecord(UInt tnum)
         Obj el = DeserializeObj();
         SET_ELM_PREC(result, i, el);
     }
-    SortPRecRNam(result, 1);
+    SortPRecRNam(result, 0);
     if (tnum == T_PREC + IMMUTABLE)
         RetypeBag(result, tnum);
     return result;

--- a/src/precord.c
+++ b/src/precord.c
@@ -247,7 +247,7 @@ UInt PositionPRec(Obj rec, UInt rnam, int cleanup)
     /* This only assumes that the rnam values in the record are sorted! */
     UInt low = 1;
     UInt high = LEN_PREC(rec);
-    if (high > 0 && GET_RNAM_PREC(rec,high) > 0) {
+    if (high > 0 && GET_RNAM_PREC(rec, high) > 0) {
         /* DIRTY! Not everything sorted! */
         if (cleanup) {
             SortPRecRNam(rec,0);
@@ -426,7 +426,6 @@ static void PrintPRec(Obj rec)
 }
 
 
-
 /****************************************************************************
 **
 *F  SortPRecRNam(<rec>, <inplace>) . . . . . . . sort the Rnams of the record
@@ -459,10 +458,11 @@ void SortPRecRNam (
     Obj space;
 
     /* Nothing has to be done if it is already sorted: */
-    if ( len == 0 || GET_RNAM_PREC(rec,len) < 0) return;
+    if (len == 0 || GET_RNAM_PREC(rec, len) < 0)
+        return;
 
     /* First find the "unsorted part" and check whether it is sorted! */
-    for (i = len-1;i >= 1 && GET_RNAM_PREC(rec,i) > 0;i--) {
+    for (i = len - 1; i >= 1 && GET_RNAM_PREC(rec, i) > 0; i--) {
         if (issorted && GET_RNAM_PREC(rec,i) > GET_RNAM_PREC(rec,i+1)) {
             issorted = 0;
         }
@@ -477,11 +477,11 @@ void SortPRecRNam (
      * sorted. */
     save = i;
     if (save == 1 ||
-        -GET_RNAM_PREC(rec,save-1) < GET_RNAM_PREC(rec,save)) {
+        -GET_RNAM_PREC(rec, save - 1) < GET_RNAM_PREC(rec, save)) {
         /* Otherwise, nothing has to be done since it is already
          * sorted, we only have to negate the RNams! */
         for (j = save;j <= len;j++)
-            SET_RNAM_PREC(rec,j,-GET_RNAM_PREC(rec,j));
+            SET_RNAM_PREC(rec, j, -GET_RNAM_PREC(rec, j));
         return;
     }
     /* Next we perform a merge sort on the two presorted areas. */
@@ -490,29 +490,33 @@ void SortPRecRNam (
     j = 1;
     k = 1;
     while (j < save && i <= len) {
-        if (-GET_RNAM_PREC(rec,j) < GET_RNAM_PREC(rec,i)) {
+        if (-GET_RNAM_PREC(rec, j) < GET_RNAM_PREC(rec, i)) {
             SET_RNAM_PREC(space,k,GET_RNAM_PREC(rec,j));
             SET_ELM_PREC(space,k,GET_ELM_PREC(rec,j));
             j++; k++;
-        } else {
-            SET_RNAM_PREC(space,k,-GET_RNAM_PREC(rec,i));
+        }
+        else {
+            SET_RNAM_PREC(space, k, -GET_RNAM_PREC(rec, i));
             SET_ELM_PREC(space,k,GET_ELM_PREC(rec,i));
             i++; k++;
         }
     }
     /* Copy the rest of the part still missing: */
     while (j < save) {
-        SET_RNAM_PREC(space,k,GET_RNAM_PREC(rec,j));
-        SET_ELM_PREC(space,k,GET_ELM_PREC(rec,j));
-        j++; k++;
+        SET_RNAM_PREC(space, k, GET_RNAM_PREC(rec, j));
+        SET_ELM_PREC(space, k, GET_ELM_PREC(rec, j));
+        j++;
+        k++;
     }
     while (i <= len) {
-        SET_RNAM_PREC(space,k,-GET_RNAM_PREC(rec,i));
-        SET_ELM_PREC(space,k,GET_ELM_PREC(rec,i));
-        i++; k++;
+        SET_RNAM_PREC(space, k, -GET_RNAM_PREC(rec, i));
+        SET_ELM_PREC(space, k, GET_ELM_PREC(rec, i));
+        i++;
+        k++;
     }
     /* Finally, copy everything back to where it came from: */
-    memcpy(ADDR_OBJ(rec)+2,CONST_ADDR_OBJ(space)+2,sizeof(Obj)*2*len);
+    memcpy(ADDR_OBJ(rec) + 2, CONST_ADDR_OBJ(space) + 2,
+           sizeof(Obj) * 2 * len);
 }
 
 /****************************************************************************
@@ -523,7 +527,7 @@ void SortPRecRNam (
 
 static void PrintPathPRec(Obj rec, Int indx)
 {
-    Pr( ".%H", (Int)NAME_RNAM( labs(GET_RNAM_PREC(rec,indx)) ), 0L );
+    Pr(".%H", (Int)NAME_RNAM(labs(GET_RNAM_PREC(rec, indx))), 0L);
 }
 
 /****************************************************************************
@@ -552,7 +556,7 @@ static Obj InnerRecNames(Obj rec)
 
     /* loop over the components                                            */
     for ( i = 1; i <= LEN_PREC(rec); i++ ) {
-        rnam = -GET_RNAM_PREC( rec, i );
+        rnam = -GET_RNAM_PREC(rec, i);
         /* could have been moved by garbage collection */
         name = NAME_RNAM( rnam );
         string = CopyToStringRep( name );
@@ -689,8 +693,8 @@ static Int LtPRec(Obj left, Obj right)
         /* The sense of this comparison is determined by the rule that
            unbound entries compare less than bound ones                    */
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            res = !LT( NAME_RNAM( labs(GET_RNAM_PREC(left,i)) ),
-                   NAME_RNAM( labs(GET_RNAM_PREC(right,i)) ) );
+            res = !LT(NAME_RNAM(labs(GET_RNAM_PREC(left, i))),
+                      NAME_RNAM(labs(GET_RNAM_PREC(right, i))));
             break;
         }
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -247,7 +247,7 @@ UInt PositionPRec(Obj rec, UInt rnam, int cleanup)
     /* This only assumes that the rnam values in the record are sorted! */
     UInt low = 1;
     UInt high = LEN_PREC(rec);
-    if (high > 0 && (Int) (GET_RNAM_PREC(rec,high)) > 0) {
+    if (high > 0 && GET_RNAM_PREC(rec,high) > 0) {
         /* DIRTY! Not everything sorted! */
         if (cleanup) {
             SortPRecRNam(rec,0);
@@ -261,7 +261,7 @@ UInt PositionPRec(Obj rec, UInt rnam, int cleanup)
              * fall back to binary search: */
             UInt i = high;
             while (i >= 1) {
-                Int rnam2 = (Int)(GET_RNAM_PREC(rec, i));
+                Int rnam2 = GET_RNAM_PREC(rec, i);
                 if (rnam == rnam2) {
                     GAP_ASSERT(i != 0);
                     return i;
@@ -282,7 +282,7 @@ UInt PositionPRec(Obj rec, UInt rnam, int cleanup)
     rnam = -rnam;
     while (low < high) {
         UInt i = (low + high) / 2; /* we always have low <= i < high */
-        rnam2 = (Int)(GET_RNAM_PREC(rec, i));
+        rnam2 = GET_RNAM_PREC(rec, i);
         if (rnam2 > rnam) {
             low = i + 1;
         }
@@ -460,13 +460,12 @@ void SortPRecRNam (
     UInt i,j,k,save;
     int issorted = 1;
     Obj space;
-    Obj tmp;
 
     /* Nothing has to be done if it is already sorted: */
-    if ( len == 0 || (Int) (GET_RNAM_PREC(rec,len)) < 0) return;
+    if ( len == 0 || GET_RNAM_PREC(rec,len) < 0) return;
 
     /* First find the "unsorted part" and check whether it is sorted! */
-    for (i = len-1;i >= 1 && (Int)(GET_RNAM_PREC(rec,i)) > 0;i--) {
+    for (i = len-1;i >= 1 && GET_RNAM_PREC(rec,i) > 0;i--) {
         if (issorted && GET_RNAM_PREC(rec,i) > GET_RNAM_PREC(rec,i+1)) {
             issorted = 0;
         }
@@ -481,11 +480,11 @@ void SortPRecRNam (
      * sorted. */
     save = i;
     if (save == 1 ||
-        -(Int)(GET_RNAM_PREC(rec,save-1)) < GET_RNAM_PREC(rec,save)) {
+        -GET_RNAM_PREC(rec,save-1) < GET_RNAM_PREC(rec,save)) {
         /* Otherwise, nothing has to be done since it is already
          * sorted, we only have to negate the RNams! */
         for (j = save;j <= len;j++)
-            SET_RNAM_PREC(rec,j,-(Int)(GET_RNAM_PREC(rec,j)));
+            SET_RNAM_PREC(rec,j,-GET_RNAM_PREC(rec,j));
         return;
     }
     /* Next we perform a merge sort on the two presorted areas. */
@@ -495,12 +494,12 @@ void SortPRecRNam (
         j = 1;
         k = 1;
         while (j < save && i <= len) {
-            if (-(Int)(GET_RNAM_PREC(rec,j)) < GET_RNAM_PREC(rec,i)) {
+            if (-GET_RNAM_PREC(rec,j) < GET_RNAM_PREC(rec,i)) {
                 SET_RNAM_PREC(space,k,GET_RNAM_PREC(rec,j));
                 SET_ELM_PREC(space,k,GET_ELM_PREC(rec,j));
                 j++; k++;
             } else {
-                SET_RNAM_PREC(space,k,-(Int)(GET_RNAM_PREC(rec,i)));
+                SET_RNAM_PREC(space,k,-GET_RNAM_PREC(rec,i));
                 SET_ELM_PREC(space,k,GET_ELM_PREC(rec,i));
                 i++; k++;
             }
@@ -512,7 +511,7 @@ void SortPRecRNam (
             j++; k++;
         }
         while (i <= len) {
-            SET_RNAM_PREC(space,k,-(Int)(GET_RNAM_PREC(rec,i)));
+            SET_RNAM_PREC(space,k,-GET_RNAM_PREC(rec,i));
             SET_ELM_PREC(space,k,GET_ELM_PREC(rec,i));
             i++; k++;
         }
@@ -522,21 +521,21 @@ void SortPRecRNam (
         /* i == save is the cut point */
         j = 1;
         for (j = 1; j < save; j++) {
-            if (-(Int)(GET_RNAM_PREC(rec,j)) > GET_RNAM_PREC(rec,i)) {
+            if (-GET_RNAM_PREC(rec,j) > GET_RNAM_PREC(rec,i)) {
                 /* we have to move something to position j! */
-                tmp = (Obj) (-(Int)(GET_RNAM_PREC(rec,j)));
-                SET_RNAM_PREC(rec,j,-(Int)(GET_RNAM_PREC(rec,i)));
-                SET_RNAM_PREC(rec,i,(UInt) tmp);
-                tmp = GET_ELM_PREC(rec,j);
+                Int tmprnam = (-GET_RNAM_PREC(rec,j));
+                SET_RNAM_PREC(rec,j,-GET_RNAM_PREC(rec,i));
+                SET_RNAM_PREC(rec,i,tmprnam);
+                Obj tmp = GET_ELM_PREC(rec,j);
                 SET_ELM_PREC(rec,j,GET_ELM_PREC(rec,i));
                 SET_ELM_PREC(rec,i,tmp);
                 /* Now we have to "bubble pos i up" until it is in the
                  * right position: */
                 for (k = i;k < len;k++) {
                     if (GET_RNAM_PREC(rec,k) > GET_RNAM_PREC(rec,k+1)) {
-                        tmp = (Obj) GET_RNAM_PREC(rec,k);
+                        tmprnam = GET_RNAM_PREC(rec,k);
                         SET_RNAM_PREC(rec,k,GET_RNAM_PREC(rec,k+1));
-                        SET_RNAM_PREC(rec,k+1,(UInt) tmp);
+                        SET_RNAM_PREC(rec,k+1,tmprnam);
                         tmp = GET_ELM_PREC(rec,k);
                         SET_ELM_PREC(rec,k,GET_ELM_PREC(rec,k+1));
                         SET_ELM_PREC(rec,k+1,tmp);
@@ -546,7 +545,7 @@ void SortPRecRNam (
         }
         /* Finally, we have to negate everything in the end: */
         for (j = save;j <= len;j++)
-            SET_RNAM_PREC(rec,j,-(Int)(GET_RNAM_PREC(rec,j)));
+            SET_RNAM_PREC(rec,j,-GET_RNAM_PREC(rec,j));
     }
 }
 
@@ -558,7 +557,7 @@ void SortPRecRNam (
 
 static void PrintPathPRec(Obj rec, Int indx)
 {
-    Pr( ".%H", (Int)NAME_RNAM( labs((Int)(GET_RNAM_PREC(rec,indx))) ), 0L );
+    Pr( ".%H", (Int)NAME_RNAM( labs(GET_RNAM_PREC(rec,indx)) ), 0L );
 }
 
 /****************************************************************************
@@ -587,7 +586,7 @@ static Obj InnerRecNames(Obj rec)
 
     /* loop over the components                                            */
     for ( i = 1; i <= LEN_PREC(rec); i++ ) {
-        rnam = -(Int)(GET_RNAM_PREC( rec, i ));
+        rnam = -GET_RNAM_PREC( rec, i );
         /* could have been moved by garbage collection */
         name = NAME_RNAM( rnam );
         string = CopyToStringRep( name );
@@ -724,8 +723,8 @@ static Int LtPRec(Obj left, Obj right)
         /* The sense of this comparison is determined by the rule that
            unbound entries compare less than bound ones                    */
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            res = !LT( NAME_RNAM( labs((Int)(GET_RNAM_PREC(left,i))) ),
-                   NAME_RNAM( labs((Int)(GET_RNAM_PREC(right,i))) ) );
+            res = !LT( NAME_RNAM( labs(GET_RNAM_PREC(left,i)) ),
+                   NAME_RNAM( labs(GET_RNAM_PREC(right,i)) ) );
             break;
         }
 

--- a/src/precord.c
+++ b/src/precord.c
@@ -251,10 +251,6 @@ UInt PositionPRec(Obj rec, UInt rnam, int cleanup)
         /* DIRTY! Not everything sorted! */
         if (cleanup) {
             SortPRecRNam(rec,0);
-            /* Note that this does not change the length and it cannot
-             * trigger a garbage collection if cleanup is 1!
-             * We do not want record accesses to trigger garbage
-             * collections! */
         } else {
             /* We are not allowed to cleanup, so we live with it, we
              * first try to find rnam in the mess at the end, then

--- a/src/precord.c
+++ b/src/precord.c
@@ -229,7 +229,7 @@ static void MakeImmutablePRec(Obj rec)
     // Sort the record at this point. This can never hurt, unless the record
     // will never be accessed again anyway. But for HPC-GAP it is essential so
     // that immutable records are actually binary unchanging.
-    SortPRecRNam(rec, 1);
+    SortPRecRNam(rec, 0);
 }
 
 

--- a/src/precord.h
+++ b/src/precord.h
@@ -97,6 +97,7 @@ EXPORT_INLINE UInt LEN_PREC(Obj rec)
 EXPORT_INLINE void SET_LEN_PREC(Obj rec, UInt nr)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
+    GAP_ASSERT(nr <= CAPACITY_PREC(rec));
     ((UInt *)(ADDR_OBJ(rec)))[1] = nr;
 }
 
@@ -126,7 +127,7 @@ EXPORT_INLINE void SET_RNAM_PREC(Obj rec, UInt i, UInt rnam)
 EXPORT_INLINE UInt GET_RNAM_PREC(Obj rec, UInt i)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
-    GAP_ASSERT(i <= CAPACITY_PREC(rec));
+    GAP_ASSERT(i <= LEN_PREC(rec));
     return *(const UInt *)(CONST_ADDR_OBJ(rec)+2*(i));
 }
 
@@ -156,7 +157,7 @@ EXPORT_INLINE void SET_ELM_PREC(Obj rec, UInt i, Obj val)
 EXPORT_INLINE Obj GET_ELM_PREC(Obj rec, UInt i)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
-    GAP_ASSERT(i <= CAPACITY_PREC(rec));
+    GAP_ASSERT(i <= LEN_PREC(rec));
     return *(CONST_ADDR_OBJ(rec)+2*(i)+1);
 }
 

--- a/src/precord.h
+++ b/src/precord.h
@@ -109,11 +109,11 @@ EXPORT_INLINE void SET_LEN_PREC(Obj rec, UInt nr)
 **  'SET_RNAM_PREC' sets   the name of  the  <i>-th  record component  of the
 **  record <rec> to the record name <rnam>.
 */
-EXPORT_INLINE void SET_RNAM_PREC(Obj rec, UInt i, UInt rnam)
+EXPORT_INLINE void SET_RNAM_PREC(Obj rec, UInt i, Int rnam)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
     GAP_ASSERT(i <= CAPACITY_PREC(rec));
-    *(UInt *)(ADDR_OBJ(rec)+2*(i)) = rnam;
+    *(Int *)(ADDR_OBJ(rec)+2*(i)) = rnam;
 }
 
 
@@ -124,11 +124,11 @@ EXPORT_INLINE void SET_RNAM_PREC(Obj rec, UInt i, UInt rnam)
 **  'GET_RNAM_PREC' returns the record name of the <i>-th record component of
 **  the record <rec>.
 */
-EXPORT_INLINE UInt GET_RNAM_PREC(Obj rec, UInt i)
+EXPORT_INLINE Int GET_RNAM_PREC(Obj rec, UInt i)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
     GAP_ASSERT(i <= LEN_PREC(rec));
-    return *(const UInt *)(CONST_ADDR_OBJ(rec)+2*(i));
+    return *(const Int *)(CONST_ADDR_OBJ(rec)+2*(i));
 }
 
 

--- a/src/precord.h
+++ b/src/precord.h
@@ -113,7 +113,7 @@ EXPORT_INLINE void SET_RNAM_PREC(Obj rec, UInt i, Int rnam)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
     GAP_ASSERT(i <= CAPACITY_PREC(rec));
-    *(Int *)(ADDR_OBJ(rec)+2*(i)) = rnam;
+    *(Int *)(ADDR_OBJ(rec) + 2 * (i)) = rnam;
 }
 
 
@@ -128,7 +128,7 @@ EXPORT_INLINE Int GET_RNAM_PREC(Obj rec, UInt i)
 {
     GAP_ASSERT(IS_PREC_OR_COMOBJ(rec));
     GAP_ASSERT(i <= LEN_PREC(rec));
-    return *(const Int *)(CONST_ADDR_OBJ(rec)+2*(i));
+    return *(const Int *)(CONST_ADDR_OBJ(rec) + 2 * (i));
 }
 
 


### PR DESCRIPTION
This is just some minor cleanups to precords, as I was exploring around the code.

I thought there was a bug relating to inplace/non-inplace sorting, but I've decided there isn't a problem. There was (I believe) originally a plan to use inplace sorting, but it was never used due to a typo. It was then accidentally used in HPC-GAP. I've removed it altogther.

The only reason not to remove the extra argument is that the function is called from the 'datastructures' package. At some point we could do something to remove the extra argument.