### PR TITLE
Support custom size function bags in InstallGlobalFunction

### DIFF
--- a/src/opers.c
+++ b/src/opers.c
@@ -3025,9 +3025,7 @@ static void InstallGlobalFunction(Obj oper, Obj func)
     Obj name = NAME_FUNC(oper);
 
     // clone the function
-    if ( SIZE_OBJ(oper) != SIZE_OBJ(func) ) {
-        ErrorQuit( "size mismatch of function bags", 0L, 0L );
-    }
+    ResizeBag(oper, SIZE_OBJ(func));
     memcpy(ADDR_OBJ(oper), CONST_ADDR_OBJ(func), SIZE_OBJ(func));
 
     SET_NAME_FUNC(oper, name ? ImmutableString(name) : 0);


### PR DESCRIPTION
Packages like JuliaInterface and PARIInterface allow defining special
GAP wrapper functions, which are implemented as T_FUNCTION bags with
some additional data in them. Right now, they abuse the `fexs` field for
that. In the future, they will use slightly larger function bags to
achieve their goal.

This patch makes it possible to use InstallGlobalFunction on such
wrapper functions.


@sebasguts This affects JuliaInterface. If we want JuliaInterface to be compatible with the next GAP 4.10 release, we need to backport this change.