### PR TITLE
Remove support for float literals starting with a period [DO NOT MERGE]

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1495,13 +1495,6 @@ static void ReadFuncExprAbbrevSingle(ReaderState * rs, TypSymbolSet follow)
 */
 static void ReadLiteral(ReaderState * rs, TypSymbolSet follow, Char mode)
 {
-    if (rs->s.Symbol == S_DOT) {
-        // HACK: The only way a dot could turn up here is in a floating point
-        // literal that starts with '.'. Call back to the scanner to deal
-        // with this.
-        ScanForFloatAfterDotHACK(&rs->s);
-    }
-
     switch (rs->s.Symbol) {
 
     /* <Int>                                                               */

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -342,17 +342,4 @@ void Match(ScannerState * s,
            TypSymbolSet   skipto);
 
 
-/****************************************************************************
-**
-*F  ScanForFloatAfterDotHACK()
-**
-**  This function is called by 'ReadLiteral' if it encounters a single dot in
-**  form the of the symbol 'S_DOT'. The only legal way this could happen is
-**  if the dot is the start of a float literal like '.123'. As the scanner
-**  cannot detect this without being context aware, we must provide this
-**  function to allow the reader to signal to the scanner about this.
-*/
-void ScanForFloatAfterDotHACK(ScannerState * s);
-
-
 #endif // GAP_SCANNER_H

--- a/tst/testbugfix/2013-08-21-t00295.tst
+++ b/tst/testbugfix/2013-08-21-t00295.tst
@@ -1,7 +1,6 @@
 # 2013/08/21 (MH)
 gap> . . . .
-Syntax error: Badly formed number: need a digit before or after the decimal po\
-int in stream:1
+Syntax error: literal expected in stream:1
 . . . .
 ^
-Syntax error: Record component name expected in stream:2
+Syntax error: ; expected in stream:2

--- a/tst/testinstall/float.tst
+++ b/tst/testinstall/float.tst
@@ -775,7 +775,7 @@ gap> ComplexConjugate(1.3);
 #
 gap> Display(1.3);
 1.3
-gap> Display(-.4e6);
+gap> Display(-0.4e6);
 -400000.
 gap> PrintObj(1.3); Print("Q\n");
 1.3Q

--- a/tst/testinstall/longnumber.tst
+++ b/tst/testinstall/longnumber.tst
@@ -152,8 +152,6 @@ gap> 1.;
 1.
 gap> 0.;
 0.
-gap> .1;
-0.1
 gap> 0.1;
 0.1
 gap> 1111111111111111111111111111111111111.1;
@@ -161,31 +159,28 @@ gap> 1111111111111111111111111111111111111.1;
 gap> 1.11111111111111111111111111111111111111;
 1.11111
 gap> .;
-Syntax error: Badly formed number: need a digit before or after the decimal po\
-int in stream:1
+Syntax error: literal expected in stream:1
 .;
 ^
 gap> .n;
-Syntax error: Badly formed number: need a digit before or after the decimal po\
-int in stream:1
+Syntax error: literal expected in stream:1
 .n;
 ^
 gap> .q;
-Syntax error: Badly formed number: need a digit before or after the decimal po\
-int in stream:1
+Syntax error: literal expected in stream:1
 .q;
 ^
 gap> .0n;
-Error, failed to convert float literal
+Syntax error: literal expected in stream:1
+.0n;
+^
 gap> .0q;
-Syntax error: Badly formed number: need at least one digit in the exponent in \
-stream:1
+Syntax error: literal expected in stream:1
 .0q;
-^^^
+^
 gap> .0qn;
-Syntax error: Badly formed number: need at least one digit in the exponent in \
-stream:1
+Syntax error: literal expected in stream:1
 .0qn;
-^^^
+^
 gap> Unbind(x);
 gap> STOP_TEST( "longnumber.tst", 1);


### PR DESCRIPTION
Before this patch, writing .0 instead of 0.0 was allowed, as in C, C++, D, Java, Julia, Go, Perl, Python and many other languages. This required a hack in the form of an additional entry pointer for our scanner. We now get rid of it, matching languages like Ada, Haskell, OCaml, Rust, Swift.

The main motivation for this is to reduce the API surface of the GAP scanner, and to remove the need for code using it to emulate the reader (or at least substantial parts of it) in order to provide a fully compliant tokenizer for GAP code. This should simplify external implementations of code formatters and other similar code which wants to "parse" GAP code somehow.

Usability should not really be impacted: first off, most floats don't get entered by hand anyway, and secondly, usage of floats in GAP still is a relative rare thing, I expect only few people use it. Of course some package might use float constants starting with a dot somewhere, but so far I have not found any. In any case, code using such constants should be trivial to adapt, and once adapted, the code will of course still work in older GAP releases just fine, too.

Right now, I can only think of two serious arguments against this (which of course just means that my imagination is limited):
* some code somebody has might rely on reading a large number of floats from a text file, and some of those floats start with a dot. But I think this would be easy to resolve, e.g. by preprocessing the input with a python script (or plain old `sed`, plus a regex).
* breaking changes to language are a major no-go. I'd generally agree with this; but I think floats in GAP are *very* much a niche feature only, and, as explained above, I expect it to break very little existing code, if any.

I'd be very much interested to hear what others think about this, esp. @laurentbartholdi. 