### PR TITLE
travis: allow Julia tests to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,9 +105,6 @@ matrix:
     # run bugfix regression tests
     - env: TEST_SUITES=testbugfix
 
-    # test Julia integration
-    - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
-
     # out of tree builds -- these are mainly done to verify that the build
     # system work in this scenario. Since we don't expect the test results to
     # vary compared to the in-tree builds, we turn off coverage reporting by
@@ -139,6 +136,14 @@ matrix:
 
     # test error reporting and compiling as well as libgap
     - env: TEST_SUITES="testspecial test-compile testlibgap"
+
+    # test Julia integration
+    - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
+
+  allow_failures:
+    # allow Julia integration to fail for now, until random GC crashes are resolved
+    # note that this must match the entry for Julia above exactly
+    - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
 
 script:
   - set -e


### PR DESCRIPTION
Unfortunately we are currently experiencing random crashes in the Julia GC, leading to annoying false failures for PR builds. So we allow this test job to fail for now.

We could backport this to 4.10 f the problem starts to appear there, too, but for now it seems to be fine.