### PR TITLE
Towards `make install` support: tweak usage of `config.h`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /config.log
 /config.status
 /configure
+/confdefs.h
+/conftest*
 /libtool
 /src/config.h.in
 /src/config.h.in~

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1195,6 +1195,7 @@ config.status: $(srcdir)/configure
 
 $(srcdir)/configure: $(configure_deps)
 	@if command -v autoconf >/dev/null 2>&1 ; then \
+	   echo "running autoconf" ; \
 	   cd $(srcdir) && autoconf ; \
 	 else \
 	   echo "autoconf not available, proceeding with stale configure" ; \
@@ -1211,6 +1212,7 @@ gen/stamp-h: $(srcdir)/src/config.h.in config.status
 
 $(srcdir)/src/config.h.in: $(configure_deps) 
 	@if command -v autoheader >/dev/null 2>&1 ; then \
+	   echo "running autoheader" ; \
 	   cd $(srcdir) && autoheader ; \
 	   rm -f gen/stamp-h ; \
 	 else \

--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ dnl
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug], [enable debug mode])],
     [AC_DEFINE([GAP_KERNEL_DEBUG], [1], [define if building in debug mode]),
-     AC_DEFINE([PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])],
+     AC_DEFINE([GAP_PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])],
     [enable_debug=no]
     )
 AC_MSG_CHECKING([whether to enable debug mode])
@@ -224,7 +224,7 @@ AC_MSG_RESULT([$enable_memory_checking])
 
 AC_ARG_ENABLE([valgrind],
     [AS_HELP_STRING([--enable-valgrind], [enable valgrind extensions to GASMAN])],
-    [AC_DEFINE([MEMORY_CANARY], [1], [define if building with valgrind extensions])],
+    [AC_DEFINE([GAP_MEMORY_CANARY], [1], [define if building with valgrind extensions])],
     [enable_valgrind=no]
     )
 AC_MSG_CHECKING([whether to enable valgrind extensions to GASMAN])
@@ -576,7 +576,7 @@ AS_IF([test "x$ARCHEXT" != "x"],
 AS_IF([test "x$ARCH" != "x"],
   [GAPARCH="$ARCH"])
 
-AC_DEFINE_UNQUOTED([SYS_ARCH], ["$GAPARCH"], [for backwards compatibility])
+AC_DEFINE_UNQUOTED([GAPARCH], ["$GAPARCH"], [for backwards compatibility])
 AC_SUBST([GAPARCH])
 
 AC_ARG_ENABLE([compat-mode],
@@ -756,7 +756,7 @@ AX_EXECINFO
 AS_IF([test "x$enable_hpcgap" = xyes],[
   AS_BOX([WARNING: Experimental HPC-GAP mode enabled])
   dnl also enable backtrace, to help debug spurious crashes
-  AC_DEFINE([PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])
+  AC_DEFINE([GAP_PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])
   ])
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -147,9 +147,7 @@ AC_DEFUN([CHECK_COMPILER_BUILTIN],
             [Define to 1 if the system has the `]$1[' built-in function])], []
         )])
 
-CHECK_COMPILER_BUILTIN([__builtin_smul_overflow],[0,0,0]);
-CHECK_COMPILER_BUILTIN([__builtin_smull_overflow],[0,0,0]);
-CHECK_COMPILER_BUILTIN([__builtin_smulll_overflow],[0,0,0]);
+CHECK_COMPILER_BUILTIN([__builtin_mul_overflow],[0,0,0]);
 CHECK_COMPILER_BUILTIN([__builtin_clz],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzl],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzll],[0]);

--- a/configure.ac
+++ b/configure.ac
@@ -108,21 +108,6 @@ dnl
 dnl endianess
 AC_C_BIGENDIAN
 
-dnl shifts
-AC_MSG_CHECKING([whether right shifts are arithmetic])
-AC_COMPUTE_INT(RIGHTSHIFTMINUSONE, [(-1L >> 1)+1])
-AS_IF([test x"$RIGHTSHIFTMINUSONE" = x0],
-    [
-    HAVE_ARITHRIGHTSHIFT=1
-    AC_MSG_RESULT([yes])
-    ],[
-    HAVE_ARITHRIGHTSHIFT=0
-    AC_MSG_RESULT([no])
-    ])
-AC_DEFINE_UNQUOTED([HAVE_ARITHRIGHTSHIFT],
-    [$HAVE_ARITHRIGHTSHIFT],
-    [define as 1 if >> for long int behaves like an arithmetic right shift for negative numbers])
-
 dnl function attributes
 AX_GCC_FUNC_ATTRIBUTE([always_inline])
 AX_GCC_FUNC_ATTRIBUTE([format])

--- a/configure.ac
+++ b/configure.ac
@@ -263,10 +263,10 @@ dnl User setting: Enable popcnt (on by default)
 dnl
 
 AC_ARG_ENABLE([popcnt],
-    AS_HELP_STRING([--enable-popcnt], [use __builtin_popcntl if available]),
+    AS_HELP_STRING([--enable-popcnt], [use __builtin_popcountl if available]),
     [],
     [enable_popcnt=yes])
-AC_MSG_CHECKING([whether to try and use __builtin_popcntl])
+AC_MSG_CHECKING([whether to try and use __builtin_popcountl])
 AC_MSG_RESULT([$enable_popcnt])
 
 AS_IF([test "x$enable_popcnt" != "xno"],
@@ -275,7 +275,7 @@ AS_IF([test "x$enable_popcnt" != "xno"],
 
 AC_DEFINE_UNQUOTED([USE_POPCNT],
     [$USE_POPCNT],
-    [define as 1 if we should try and use the __builtin_popcntl function if available])
+    [define as 1 if we should try and use the __builtin_popcountl function if available])
 
 dnl
 dnl External dependencies

--- a/src/debug.c
+++ b/src/debug.c
@@ -27,7 +27,7 @@
 #include "hpc/region.h"
 #endif
 
-#if defined(HAVE_BACKTRACE) && defined(PRINT_BACKTRACE)
+#if defined(HAVE_BACKTRACE) && defined(GAP_PRINT_BACKTRACE)
 #include <execinfo.h>
 #include <signal.h>
 

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -456,7 +456,7 @@ static inline UInt IS_BAG_BODY(void * ptr)
             ((UInt)ptr & (sizeof(Bag) - 1)) == 0);
 }
 
-#if defined(MEMORY_CANARY)
+#if defined(GAP_MEMORY_CANARY)
 
 #include <valgrind/valgrind.h>
 #include <valgrind/memcheck.h>

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -90,7 +90,7 @@ typedef struct {
 #ifdef USE_GASMAN
     Bag link;
 #endif
-#if defined(MEMORY_CANARY)
+#if defined(GAP_MEMORY_CANARY)
     // The following variable is marked as not readable or writable
     // in valgrind, to check for code reading before the start of a Bag.
     uint64_t memory_canary_padding[8];
@@ -370,18 +370,18 @@ void CHANGED_BAG(Bag bag);
 
 int IsGapObj(void *);
 
-#elif defined(MEMORY_CANARY)
+#elif defined(GAP_MEMORY_CANARY)
 
 /****************************************************************************
 **
-**  MEMORY_CANARY provides (basic) support for catching out-of-bounds memory
-**  problems in GAP. This is done through the excellent 'valgrind' program.
-**  valgrind is of limited use in GAP normally, because it doesn't understand
-**  GAP's memory manager. Enabling MEMORY_CANARY will make an executable where
-**  valgrind will detect memory issues.
+**  GAP_MEMORY_CANARY provides (basic) support for catching out-of-bounds
+**  memory problems in GAP. This is done through the excellent 'valgrind'
+**  program. Valgrind is of limited use in GAP normally, because it doesn't
+**  understand GAP's memory manager. Enabling GAP_MEMORY_CANARY will make an
+**  executable where valgrind will detect memory issues.
 **
-**  At the moment the detection is limited to only writing off the last allocated
-**  block.
+**  At the moment the detection is limited to only writing off the last
+**  allocated block.
 */
 
 void CHANGED_BAG(Bag b);

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -109,14 +109,13 @@ EXPORT_INLINE Int ARE_INTOBJS(Obj o1, Obj o2)
 /* Note that the C standard does not define what >> does here if the
  * value is negative. So we have to be careful if the C compiler
  * chooses to do a logical right shift. */
+GAP_STATIC_ASSERT((-1) >> 1 == -1, "right shifts are not arithmetic");
+GAP_STATIC_ASSERT((-2) >> 1 == -1, "right shifts are not arithmetic");
+
 EXPORT_INLINE Int INT_INTOBJ(Obj o)
 {
     GAP_ASSERT(IS_INTOBJ(o));
-#ifdef HAVE_ARITHRIGHTSHIFT
     return (Int)o >> 2;
-#else
-    return ((Int)o - 1) / 4;
-#endif
 }
 
 
@@ -272,14 +271,9 @@ EXPORT_INLINE Obj prod_intobjs(Int l, Int r)
     if ((HalfInt)l == (Int)l && (HalfInt)r == (Int)r)
         return (Obj)prod;
 
-// last resort: perform trial division
-#ifdef HAVE_ARITHRIGHTSHIFT
+    // last resort: perform trial division using arithmetic right shift
     if ((prod - 1) / (l >> 2) == r - 1)
         return (Obj)prod;
-#else
-    if ((prod - 1) / ((l - 1) / 4) == r - 1)
-        return (Obj)prod;
-#endif
 
     return (Obj)0;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -73,7 +73,7 @@ const Char * SyKernelVersion = "4.dev";
 **
 *V  SyArchitecture  . . . . . . . . . . . . . . . .  name of the architecture
 */
-const Char * SyArchitecture = SYS_ARCH;
+const Char * SyArchitecture = GAPARCH;
 
 
 /****************************************************************************


### PR DESCRIPTION
One major obstacle for `make install` target is our `config.h` file, which is currently included by all other GAP headers. But installing it unchanged is a big no-go for various reasons:

First off, if our headers are included by some other code which also uses autoconf, and also has a `config.h`, there can be a clash of `#define` names. In fact, there is *always* a clash for `PACKAGE_NAME`, `PACKAGE_STRING`, etc., and indeed, several GAP packages contain workaround for this.

One "solution" for this is to prefix all `#defines` in `config.h` with `GAP_`, which we can perhaps achieve with the [ax_prefix_config_h extension for autoconf](https://www.gnu.org/software/autoconf-archive/ax_prefix_config_h.html) or some similar hack. 

But even if we did that, this is not quite enough: some of these `#define`s are for compiler specific properties, but 3rd party code using our headers may be using a different compiler (think gcc vs. clang; or different gcc versions; etc.; on otherwise the same machine); and this is perfectly legal and valid. But if for example the compiler used to compile GAP supports the `__builtin_popcountl` intrinsic, we `#define HAVE___BUILTIN_POPCOUNTL 1` or possibly with the above extension `#define GAP_HAVE___BUILTIN_POPCOUNTL 1`. But if 3rd party code uses a compiler *without* that intrinsic, we'd now run into a compiler error, if the same `config.h` as previously generated when building GAP is used.

To fix this, we must not blindly rely on macros for compiler specific features in *headers*. We need to either avoid them, or code them defensively.

This PR moves us a step closer to solving this, and thus moves us a step closer to proper `make install` support.