### PR TITLE
kernel: reduce use of config.h #defines

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -71,4 +71,10 @@ void InstallBacktraceHandlers(void)
     signal(SIGFPE, BacktraceHandler);
 }
 
+#else
+
+void InstallBacktraceHandlers(void)
+{
+}
+
 #endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -44,8 +44,6 @@
 #endif
 
 
-#if defined(HAVE_BACKTRACE) && defined(PRINT_BACKTRACE)
 void InstallBacktraceHandlers(void);
-#endif
 
 #endif

--- a/src/fibhash.h
+++ b/src/fibhash.h
@@ -13,22 +13,17 @@
 
 #include "system.h"
 
-#if !defined(SIZEOF_VOID_P)
-#error Require SIZEOF_VOID_P to be defined
-#endif
-
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
 #define FIB_HASH_MULT 0x9e3779b9UL
 #else
 #define FIB_HASH_MULT 0x9e3779b97f4a7c13UL
 #endif
 
-#define FIB_HASH_BITS (SIZEOF_VOID_P * 8)
+#define FIB_HASH_BITS (sizeof(void *) * 8)
 
 EXPORT_INLINE UInt FibHash(UInt word, unsigned bits)
 {
-  return (word * FIB_HASH_MULT) >>
-    (FIB_HASH_BITS - bits);
+    return (word * FIB_HASH_MULT) >> (FIB_HASH_BITS - bits);
 }
 
 #endif // GAP_FIBHASH_H

--- a/src/gap.c
+++ b/src/gap.c
@@ -464,9 +464,7 @@ int realmain( int argc, char * argv[] )
 #if !defined(COMPILECYGWINDLL)
 int main ( int argc, char * argv[] )
 {
-#if defined(HAVE_BACKTRACE) && defined(PRINT_BACKTRACE)
   InstallBacktraceHandlers();
-#endif
 
 #ifdef HPCGAP
   RunThreadedMain(realmain, argc, argv);

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -921,7 +921,7 @@ Bag NextBagRestoring( UInt type, UInt flags, UInt size )
   header->flags = flags;
   header->size = size;
   header->link = NextMptrRestoring;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
   header->reserved = 0;
 #endif
 
@@ -1291,7 +1291,7 @@ Bag NewBag (
     header->type = type;
     header->flags = 0;
     header->size = size;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
     header->reserved = 0;
 #endif
 
@@ -1446,7 +1446,7 @@ UInt ResizeBag (
     UInt type     = header->type;
     UInt flags    = header->flags;
     UInt old_size = header->size;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
     GAP_ASSERT(header->reserved == 0);
 #endif
 
@@ -1484,7 +1484,7 @@ UInt ResizeBag (
         }
 
         header->size = new_size;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
         GAP_ASSERT(header->reserved == 0);
 #endif
     }
@@ -1512,7 +1512,7 @@ UInt ResizeBag (
         SizeAllBags             += new_size - old_size;
 
         header->size = new_size;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
         GAP_ASSERT(header->reserved == 0);
 #endif
     }
@@ -1534,7 +1534,7 @@ UInt ResizeBag (
         header->flags = 0;
         header->size =
             sizeof(BagHeader) + (TIGHT_WORDS_BAG(old_size) - 1) * sizeof(Bag);
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
         GAP_ASSERT(header->reserved == 0);
 #endif
 
@@ -1545,7 +1545,7 @@ UInt ResizeBag (
         newHeader->type = type;
         newHeader->flags = flags;
         newHeader->size = new_size;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
         GAP_ASSERT(newHeader->reserved == 0);
 #endif
 
@@ -2108,7 +2108,7 @@ again:
             dstHeader->type = header->type;
             dstHeader->flags = header->flags;
             dstHeader->size = header->size;
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
             dstHeader->reserved = 0;
 #endif
 
@@ -2374,7 +2374,7 @@ void CheckMasterPointers( void )
             Panic("Master pointer with bad link word detected");
         }
 
-#if SIZEOF_VOID_P == 4
+#ifndef SYS_IS_64_BIT
         // sanity check: reserved bits must be unused
         if (BAG_HEADER(bag)->reserved != 0) {
             Panic("Master pointer with non-zero reserved bits "

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -81,9 +81,9 @@ typedef UInt * *        Bag;
 typedef struct {
     uint8_t type : 8;
     uint8_t flags : 8;
-#if SIZEOF_VOID_P == 8
+#ifdef SYS_IS_64_BIT
     uint64_t size : 48;
-#elif SIZEOF_VOID_P == 4
+#else
     uint16_t reserved : 16;
     uint32_t size : 32;
 #endif

--- a/src/hpc/tlsconfig.h
+++ b/src/hpc/tlsconfig.h
@@ -20,7 +20,7 @@
 
 #ifndef HAVE_NATIVE_TLS
 
-#if SIZEOF_VOID_P == 8
+#ifdef SYS_IS_64_BIT
 #define TLS_SIZE (1L << 20)
 #else
 #define TLS_SIZE (1L << 18)

--- a/src/integer.c
+++ b/src/integer.c
@@ -2791,6 +2791,12 @@ static Int InitKernel ( StructInitInfo * module )
   if (mp_bits_per_limb != GMP_LIMB_BITS) {
     Panic("GMP limb size mismatch");
   }
+  if (INTOBJ_MIN != INTOBJ_INT(INT_INTOBJ_MIN)) {
+    Panic("INTOBJ_MIN mismatch");
+  }
+  if (INTOBJ_MAX != INTOBJ_INT(INT_INTOBJ_MAX)) {
+    Panic("INTOBJ_MAX mismatch");
+  }
 
   /* init filters and functions                                            */
   InitHdlrFiltsFromTable( GVarFilts );

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -36,19 +36,17 @@
 
 #include "system.h"
 
-#ifdef SYS_IS_64_BIT
-#define NR_SMALL_INT_BITS  (64 - 4)
-#else
-#define NR_SMALL_INT_BITS  (32 - 4)
-#endif
+enum {
+    NR_SMALL_INT_BITS = sizeof(UInt) * 8 - 4,
 
-// the minimal / maximal possible values of an immediate integer object:
-#define INT_INTOBJ_MIN  (-(1L << NR_SMALL_INT_BITS))
-#define INT_INTOBJ_MAX  ((1L << NR_SMALL_INT_BITS) - 1)
+    // the minimal / maximal possible values of an immediate integer object:
+    INT_INTOBJ_MIN = -(1L << NR_SMALL_INT_BITS),
+    INT_INTOBJ_MAX =  (1L << NR_SMALL_INT_BITS) - 1,
+};
 
 // the minimal / maximal possible immediate integer objects:
-#define INTOBJ_MIN  INTOBJ_INT(INT_INTOBJ_MIN)
-#define INTOBJ_MAX  INTOBJ_INT(INT_INTOBJ_MAX)
+#define INTOBJ_MIN  (Obj)(((UInt)INT_INTOBJ_MIN << 2) + 0x01)
+#define INTOBJ_MAX  (Obj)(((UInt)INT_INTOBJ_MAX << 2) + 0x01)
 
 
 /****************************************************************************

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -221,7 +221,7 @@ void SaveUInt( UInt data )
     SaveUInt8(data);
 }
 
-UInt8 LoadUInt ( void )
+UInt LoadUInt ( void )
 {
     return LoadUInt8();
 }

--- a/src/system.h
+++ b/src/system.h
@@ -123,37 +123,29 @@ enum {
 **
 *T  Char, Int1, Int2, Int4, Int, UChar, UInt1, UInt2, UInt4, UInt .  integers
 **
-**  'Char',  'Int1',  'Int2',  'Int4',  'Int',   'UChar',   'UInt1', 'UInt2',
-**  'UInt4', 'UInt'  and possibly 'Int8' and 'UInt8' are the integer types.
-**
-**  Note that to get this to work, all files must be compiled with or without
-**  '-DSYS_IS_64_BIT', not just "system.c".
+**  'Char', 'Int1', 'Int2', 'Int4', 'Int8', 'Int', 'UChar', 'UInt1', 'UInt2',
+**  'UInt4', 'UInt8', 'UInt' are the integer types.
 **
 **  '(U)Int<n>' should be exactly <n> bytes long
 **  '(U)Int' should be the same length as a bag identifier
 */
 
 
-typedef char              Char;
+typedef char     Char;
+typedef uint8_t  UChar;
 
 typedef int8_t   Int1;
 typedef int16_t  Int2;
 typedef int32_t  Int4;
 typedef int64_t  Int8;
 
-typedef uint8_t  UChar;
 typedef uint8_t  UInt1;
 typedef uint16_t UInt2;
 typedef uint32_t UInt4;
 typedef uint64_t UInt8;
 
-#ifdef SYS_IS_64_BIT
-typedef Int8     Int;
-typedef UInt8    UInt;
-#else
-typedef Int4     Int;
-typedef UInt4    UInt;
-#endif
+typedef intptr_t  Int;
+typedef uintptr_t UInt;
 
 GAP_STATIC_ASSERT(sizeof(void *) == sizeof(Int), "sizeof(Int) is wrong");
 GAP_STATIC_ASSERT(sizeof(void *) == sizeof(UInt), "sizeof(UInt) is wrong");


### PR DESCRIPTION
This reduces the need for `config.h` and is part of work towards implementing `make install`.

This is part of PR #3287, extracted for easier reviewing.