### PR TITLE
Fix a typo in listfunc.h

### DIFF
--- a/src/listfunc.h
+++ b/src/listfunc.h
@@ -89,7 +89,7 @@ void SortPlistByRawObj(Obj list);
 **  'RemoveDupsDensePlist' removes duplicate elements from the dense
 **  plain list <list>.  <list> must be sorted.  'RemoveDupsDensePlist'
 **  returns 0 if <list> contains mutable elements, 1 if immutable but
-**  not homogenout, 2 otherwise
+**  not homogeneous, 2 otherwise
 */
 UInt RemoveDupsDensePlist(Obj list);
 


### PR DESCRIPTION
This typo has been there since GAP 4.2pre1, and a lot of people are watching me -- let's get this fixed ASAP.