### PR TITLE
ci: explicitly install python27 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,11 +12,11 @@ environment:
   matrix:
     - CYG_ARCH: x86
       CYG_ROOT: C:\cygwin
-      PACKAGES: "-P python-pip"
+      PACKAGES: "-P python27,python27-pip"
       ABI: 32
     - CYG_ARCH: x86_64
       CYG_ROOT: C:\cygwin64
-      PACKAGES: "-P libgmp-devel,zlib-devel,python-pip"
+      PACKAGES: "-P libgmp-devel,zlib-devel,python27,python27-pip"
       CFLAGS: "--coverage"
       LDFLAGS: "--coverage"
 # FIXME: HPC-GAP build on AppVeyor disabled for now, as it crashes


### PR DESCRIPTION
This works around a bug where Cygwin may end up uninstalling python completely when we just ask for installing the python-pop package.