### PR TITLE
kernel: export COUNT_TRUES_BLOCK(S) again

### DIFF
--- a/src/bits_intern.h
+++ b/src/bits_intern.h
@@ -50,7 +50,7 @@
 **  'COUNT_TRUES_BLOCKS'.
 **
 */
-static inline UInt COUNT_TRUES_BLOCK(UInt block)
+EXPORT_INLINE UInt COUNT_TRUES_BLOCK(UInt block)
 {
 #if USE_POPCNT && defined(HAVE___BUILTIN_POPCOUNTL)
     return __builtin_popcountl(block);
@@ -96,7 +96,7 @@ static inline UInt COUNT_TRUES_BLOCK(UInt block)
 **
 **  TODO: monitor this situation periodically.
 */
-static inline UInt COUNT_TRUES_BLOCKS(const UInt * ptr, UInt nblocks)
+EXPORT_INLINE UInt COUNT_TRUES_BLOCKS(const UInt * ptr, UInt nblocks)
 {
     UInt n = 0;
     while (nblocks >= 4) {

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -85,6 +85,11 @@ extern "C" {
 extern Obj InfoDecision;
 
 
+// for compatibility with the Digraphs package
+UInt COUNT_TRUES_BLOCK(UInt block);
+UInt COUNT_TRUES_BLOCKS(const UInt * ptr, UInt nblocks);
+
+
 /* types, should go into 'gvars.c' and 'records.c' * * * * * * * * * * * * */
 
 typedef UInt    GVar;


### PR DESCRIPTION
This is used by the Digraphs packages. We probably don't want to keep
COUNT_TRUES_BLOCK(S) in compiled.h, but this was the quickest thing I
could think of to just restore behavior. We can work on a better fix
later, but right now I just want to unbreak Digraphs.

Resolves #3312