### PR TITLE
Move COUNT_TRUES_BLOCK(S) out of header

### DIFF
--- a/src/blister.h
+++ b/src/blister.h
@@ -258,30 +258,7 @@ void ConvBlist(Obj list);
 **  'COUNT_TRUES_BLOCKS'.
 **
 */
-static inline UInt COUNT_TRUES_BLOCK(UInt block)
-{
-#if USE_POPCNT && defined(HAVE___BUILTIN_POPCOUNTL)
-    return __builtin_popcountl(block);
-#else
-#ifdef SYS_IS_64_BIT
-    block =
-        (block & 0x5555555555555555L) + ((block >> 1) & 0x5555555555555555L);
-    block =
-        (block & 0x3333333333333333L) + ((block >> 2) & 0x3333333333333333L);
-    block = (block + (block >> 4)) & 0x0f0f0f0f0f0f0f0fL;
-    block = (block + (block >> 8));
-    block = (block + (block >> 16));
-    block = (block + (block >> 32)) & 0x00000000000000ffL;
-#else
-    block = (block & 0x55555555) + ((block >> 1) & 0x55555555);
-    block = (block & 0x33333333) + ((block >> 2) & 0x33333333);
-    block = (block + (block >> 4)) & 0x0f0f0f0f;
-    block = (block + (block >> 8));
-    block = (block + (block >> 16)) & 0x000000ff;
-#endif
-    return block;
-#endif
-}
+UInt COUNT_TRUES_BLOCK(UInt block);
 
 /****************************************************************************
 **
@@ -304,24 +281,7 @@ static inline UInt COUNT_TRUES_BLOCK(UInt block)
 **
 **  TODO: monitor this situation periodically.
 */
-static inline UInt COUNT_TRUES_BLOCKS(const UInt * ptr, UInt nblocks)
-{
-    UInt n = 0;
-    while (nblocks >= 4) {
-        UInt n1 = COUNT_TRUES_BLOCK(*ptr++);
-        UInt n2 = COUNT_TRUES_BLOCK(*ptr++);
-        UInt n3 = COUNT_TRUES_BLOCK(*ptr++);
-        UInt n4 = COUNT_TRUES_BLOCK(*ptr++);
-        n += n1 + n2 + n3 + n4;
-        nblocks -= 4;
-    }
-    while (nblocks) {
-        n += COUNT_TRUES_BLOCK(*ptr++);
-        nblocks--;
-    }
-    // return the number of bits
-    return n;
-}
+UInt COUNT_TRUES_BLOCKS(const UInt * ptr, UInt nblocks);
 
 /****************************************************************************
 **


### PR DESCRIPTION
This moves COUNT_TRUES_BLOCK(S) back out of the header.

After investigation, I decided to just make them normal non-inlined functions. COUNT_TRUES_BLOCKS should take long enough function overhead is not significant, and COUNT_TRUES_BLOCK can be inlined with link-time optimisation. If we enable link-time optimisation, lots of other little functions can be inlined away, and nowadays most modern compilers support it, and it's easy to use (I wouldn't want to use link time optimsiation every time I compile, just because it leads to long compile times even when you only make a small change).