### PR TITLE
Handle \r without a \n in cygwin

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1618,6 +1618,8 @@ static Int syGetchTerm(Int fid)
         syBuf[fid].crlast = 1;
         return (Int)'\n';
     }
+    // We saw a '\r' without a '\n'
+    syBuf[fid].crlast = 0;
 #endif  /* line end hack */
 
     /* return the character                                                */
@@ -1678,6 +1680,8 @@ static Int syGetchNonTerm(Int fid)
         syBuf[fid].crlast = 1;
         return (Int)'\n';
     }
+    // We saw a '\r' without a '\n'
+    syBuf[fid].crlast = 0;
 #endif  /* line end hack */
 
     /* return the character                                                */


### PR DESCRIPTION
This fixes the problem whereby if GAP on windows sees a \r, it will remove the next \n, no matter how far away it is.

This isn't tested, because I found it very hard to come up with a sensible test, as git (or other tools) can try to "clean up" line endings. Hopefully the PR is clean enough.

In practice, there turns out to be a whole bunch of things that could be "improved" around here, but I don't really want to rewrite lots of the file handling. This fixes a single, immediate, problem.