### PR TITLE
Improve info if needed dep for a package does not exist

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -875,7 +875,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
           if testpair = false then
             # This dependency is not satisfied.
             test:= false;
-            LogPackageLoadingMessage( PACKAGE_INFO,
+            LogPackageLoadingMessage( PACKAGE_WARNING,
                 Concatenation( "PackageAvailabilityInfo: dependency '",
                     name2, "' is not satisfied" ), inforec.PackageName );
             if not checkall then


### PR DESCRIPTION
Print the "dependency XYZ is not satisfied" info message with
warning level PACKAGE_WARNING instead of PACKAGE_INFO. This seems
to be more in line with what the manual promises, namely:

> PACKAGE_WARNING should be used whenever GAP has detected a reason why a
> package cannot be loaded, and where the message describes how to solve
> this problem, for example if a package binary is missing.

So if a package cannot be loaded because one of its needed dependencies
is not the name of any known package, that certainly is something the
user would like to know.

Before this change:

    gap> SetInfoLevel( InfoPackageLoading, PACKAGE_WARNING );
    gap> LoadPackage("pkg_with_missing_dep");
    fail

After this change:

    gap> SetInfoLevel( InfoPackageLoading, PACKAGE_WARNING );
    gap> LoadPackage("pkg_with_missing_dep");
    #I  pkg_with_missing_dep: PackageAvailabilityInfo: dependency 'missing_pkg' is not satisfied
    fail


Motivated by issue #3306