### PR TITLE
libgap: fix name of GAP_EnterDebugMessage_

### DIFF
--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -412,7 +412,7 @@ void GAP_LeaveStack_(void)
     EnterStackCount--;
 }
 
-void GAP_EnterDebugMessage(char * message, char * file, int line)
+void GAP_EnterDebugMessage_(char * message, char * file, int line)
 {
     fprintf(stderr, "%s: %d; %s:%d\n", message, EnterStackCount, file,
             line);


### PR DESCRIPTION
Without this, GAP_ENTER_DEBUG is broken.

Note sure if we plan to make a GAP 4.10.2 before GAP 4.11, but just in case we might want to backport this to stable-4.10.