### PR TITLE
Use TmpNameAllArchs instead of TmpName

### DIFF
--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -8,7 +8,7 @@ gap> CLOSE_LOG_TO();
 Error, LogTo: can not close the logfile
 gap> LOG_TO(fail);
 Error, LogTo: <filename> must be a string (not the value 'fail')
-gap> LOG_TO(TmpName());
+gap> LOG_TO(TmpNameAllArchs());
 true
 gap> CLOSE_LOG_TO();
 true
@@ -25,7 +25,7 @@ gap> CLOSE_INPUT_LOG_TO();
 Error, InputLogTo: can not close the logfile
 gap> INPUT_LOG_TO(fail);
 Error, InputLogTo: <filename> must be a string (not the value 'fail')
-gap> INPUT_LOG_TO(TmpName());
+gap> INPUT_LOG_TO(TmpNameAllArchs());
 true
 gap> CLOSE_INPUT_LOG_TO();
 true
@@ -42,7 +42,7 @@ gap> CLOSE_OUTPUT_LOG_TO();
 Error, OutputLogTo: can not close the logfile
 gap> OUTPUT_LOG_TO(fail);
 Error, OutputLogTo: <filename> must be a string (not the value 'fail')
-gap> OUTPUT_LOG_TO(TmpName());
+gap> OUTPUT_LOG_TO(TmpNameAllArchs());
 true
 gap> CLOSE_OUTPUT_LOG_TO();
 true


### PR DESCRIPTION
Otherwise, `TmpName` produces a non-existing path on Windows.
Closes #3309