### PR TITLE
Fix finiteness condition in `IsomorphismGroups`

### DIFF
--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2151,8 +2151,11 @@ local m;
     IsFinite(G);
     IsFinite(H);
   fi;
-  if not IsFinite(G) and IsFinite(H) then
+  if not IsFinite(G) and not IsFinite(H) then
     Error("cannot test isomorphism of infinite groups");
+  fi;
+  if IsFinite(G) <> IsFinite(H) then
+    return fail;
   fi;
 
   #AH: Spezielle Methoden ?

--- a/tst/testbugfix/2019-03-08-IsomorphismGroups.tst
+++ b/tst/testbugfix/2019-03-08-IsomorphismGroups.tst
@@ -1,0 +1,9 @@
+# see https://github.com/gap-system/gap/pull/3331
+gap> F := FreeGroup( 1 );;
+gap> IsFinite( F );;
+gap> S := SymmetricGroup( 3 );;
+gap> IsFinite( S );;
+gap> IsomorphismGroups( F, S );
+fail
+gap> IsomorphismGroups( S, F );
+fail


### PR DESCRIPTION
Currently, the arguments of `IsomorphismGroups` are not handled symmetrically:

```
gap> F := FreeGroup(1);
<free group on the generators [ f1 ]>
gap> IsFinite( F );
false
gap> S := SymmetricGroup( 3 );
Sym( [ 1 .. 3 ] )
gap> IsFinite( S );
true
gap> IsomorphismGroups( S, F );
fail
gap> IsomorphismGroups( F, S );
Error, cannot test isomorphism of infinite groups at /usr/lib/gap/lib/morpheus.gi:2151 called from
<function "IsomorphismGroups">( <arguments> )
 called from read-eval loop at *stdin*:5
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk>
```

After this commit, in both cases `fail` is returned.