### PR TITLE
Travis: re-enable OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,9 @@ matrix:
           - libzmq3-dev:i386        # for ZeroMQInterface
 
     # OS X builds: since those are slow and limited on Travis, we only run testinstall
-    # OS X builds are currently disabled because Travis has performance problems
-    # - env: TEST_SUITES="docomp testinstall"
-    #  os: osx
-    #  compiler: clang
+    - env: TEST_SUITES="docomp testinstall"
+      os: osx
+      compiler: clang
 
     # test creating the manual
     - env: TEST_SUITES=makemanuals


### PR DESCRIPTION
It seems OS X builds got better on Travis recently, so I figured we could give it another try. Would also be nice to get automated tests with clang back (but of course we can / should also do that with one of the Linux builds).