### PR TITLE
Don't set SyAllocPool = 0 for Cygwin, but do use MAP_NORESERVE for mmap

### DIFF
--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -280,6 +280,12 @@ int SyTryToIncreasePool(void)
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#ifdef SYS_IS_CYGWIN32
+#define GAP_MMAP_FLAGS MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE
+#else
+#define GAP_MMAP_FLAGS MAP_PRIVATE|MAP_ANONYMOUS
+#endif
+
 static void *SyMMapStart = NULL;   /* Start of mmap'ed region for POOL */
 static void *SyMMapEnd;            /* End of mmap'ed region for POOL */
 static void *SyMMapAdvised;        /* We have already advised about non-usage
@@ -341,15 +347,15 @@ static void * SyAnonMMap(size_t size)
     size = SyRoundUpToPagesize(size);
 #ifdef SYS_IS_64_BIT
     /* The following is at 16 Terabyte: */
-    result = mmap((void *) (16L*1024*1024*1024*1024), size, 
-                  PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+    result = mmap((void *) (16L*1024*1024*1024*1024), size,
+                  PROT_READ|PROT_WRITE, GAP_MMAP_FLAGS, -1, 0);
     if (result == MAP_FAILED) {
         result = mmap(NULL, size, PROT_READ|PROT_WRITE,
-            MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+            GAP_MMAP_FLAGS, -1, 0);
     }
 #else
     result = mmap(NULL, size, PROT_READ|PROT_WRITE,
-        MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+        GAP_MMAP_FLAGS, -1, 0);
 #endif
     if (result == MAP_FAILED)
         result = NULL;
@@ -370,7 +376,7 @@ static int SyTryToIncreasePool(void)
     size = (Int) SyMMapEnd - (Int) SyMMapStart;
     newchunk = SyRoundUpToPagesize(size/2);
     result = mmap(SyMMapEnd, newchunk, PROT_READ|PROT_WRITE,
-                  MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+                  GAP_MMAP_FLAGS, -1, 0);
     if (result == MAP_FAILED) return -1;
     if (result != SyMMapEnd) {
         munmap(result,newchunk);

--- a/src/system.c
+++ b/src/system.c
@@ -1072,11 +1072,7 @@ void InitSystem (
 #else
     SyStorMin = 64 * 1024L;
     SyStorMax = 1024*1024L;          /* This is in kB! */
-#ifdef SYS_IS_CYGWIN32
-    SyAllocPool = 0;                 /* works better on cygwin */
-#else
     SyAllocPool = 1536L*1024*1024;   /* Note this is in bytes! */
-#endif
 #endif
     SyStorOverrun = 0;
     SyStorKill = 0;


### PR DESCRIPTION
This is a version of the patch from https://trac.sagemath.org/ticket/27214

TL;DR This is an issue that has come up in the past with Pari as well.  When you mmap a large region of memory in Cygwin, and then fork() the process, the entirety of that region has to have physical memory committed to it.

This is a known issue on Cygwin and is sort-of by design (or rather a known limitation due to the underlying OS).  The workaround, generally, is to use the non-POSIX `MAP_NORESERVE` flag which comes from Linux, but has slightly different, albeit similar implications.

For now we just use the `MAP_NORESERVE` flag on Cygwin, though it could be used on Linux as well.  The implication is that it is possible to reserve a larger region of memory even if there are not enough physical pages at the time of the `mmap()` call to fill the entire region (though if there is enough physical memory later then it's no problem).  The main downside to this is that if you reach a point where you do run out of physical memory to handle writes to the mmap'd region, then the application will crash (segfault most likely). Though I haven't tried to reproduce such a situation in GAP.