### PR TITLE
kernel: simplify coding of lazy and eager float literals

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -940,8 +940,7 @@ Obj ArgStringToList(const Char *nams_c) {
         while ( nams_c[l] != ' ' && nams_c[l] != ',' && nams_c[l] != '\0' ) {
             l++;
         }
-        C_NEW_STRING( tmp, l - k, nams_c + k );
-        MakeImmutableString( tmp );
+        tmp = MakeImmStringWithLen(nams_c + k, l - k);
         SET_ELM_PLIST( nams_o, i, tmp );
         CHANGED_BAG( nams_o );
         k = l;

--- a/src/code.c
+++ b/src/code.c
@@ -1942,8 +1942,7 @@ void CodeFloatExpr(Char * str)
         mark = str[l - 1];
     }
     if (l1 < l) {
-        Obj s;
-        C_NEW_STRING(s, l1, str);
+        Obj s = MakeImmStringWithLen(str, l1);
         CodeEagerFloatExpr(s, mark);
     }
     else {

--- a/src/code.h
+++ b/src/code.h
@@ -1073,9 +1073,7 @@ void CodeStringExpr(Obj str);
 **
 *F  CodeFloatExpr(<str>) . . . . . . . . . .  code literal float expression
 */
-void CodeFloatExpr(Char * str);
-
-void CodeLongFloatExpr(Obj str);
+void CodeFloatExpr(Obj str);
 
 
 /****************************************************************************

--- a/src/gap.c
+++ b/src/gap.c
@@ -812,7 +812,7 @@ static Obj FuncWindowCmd(Obj self, Obj args)
       for ( n=0,m=1;  '0' <= *inptr && *inptr <= '9';  inptr++,m *= 10,len-- )
         n += (*inptr-'0') * m;
       inptr++; /* ignore the '+' */
-      C_NEW_STRING(tmp, n, inptr);
+      tmp = MakeImmStringWithLen(inptr, n);
       inptr += n;
       len -= n+2;
       AssPlist( list, i, tmp );

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1808,16 +1808,13 @@ void IntrFloatExpr(Obj string, Char * str)
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
     SKIP_IF_IGNORING();
+    if (string == 0)
+        string = MakeString(str);
     if ( STATE(IntrCoding)    > 0 ) {
-        if (string)
-            CodeLongFloatExpr(string);
-        else
-            CodeFloatExpr( str );
+        CodeFloatExpr(string);
         return;
     }
 
-    if (string == 0)
-        string = MakeString(str);
     PushObj(ConvertFloatLiteralEager(string));
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -1305,7 +1305,7 @@ static void PutLine2(TypOutputFile * output, const Char * line, UInt len)
     }
 
     /* Space for the null is allowed for in GAP strings */
-    C_NEW_STRING( str, len, line );
+    str = MakeImmStringWithLen(line, len);
 
     /* now delegate to library level */
     CALL_2ARGS( WriteAllFunc, output->stream, str );

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -34,9 +34,9 @@
 **  This package consists of three parts.
 **  
 **  The first part consists of the functions 'NEW_STRING', 'CHARS_STRING' (or
-**  'CSTR_STRING'),  'GET_LEN_STRING', 'SET_LEN_STRING', 'C_NEW_STRING' and
-**  more. These and the functions below use the detailed knowledge about the
-**  representation of strings.
+**  'CSTR_STRING'),  'GET_LEN_STRING', 'SET_LEN_STRING', and more. These and
+**  the functions below use the detailed knowledge about the representation
+**  of strings.
 **  
 **  The second part  consists  of  the  functions  'LenString',  'ElmString',
 **  'ElmsStrings', 'AssString',  'AsssString', PlainString',

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -327,18 +327,6 @@ Int IsStringConv(Obj obj);
 
 /****************************************************************************
 **
-*F  C_NEW_STRING( <string>, <len>, <cstring> )  . . . . . . create GAP string
-*/
-#define C_NEW_STRING(string,len,cstr) \
-  do { \
-    size_t tmp_len = (len); \
-    string = NEW_STRING( tmp_len ); \
-    memcpy( CHARS_STRING(string), (cstr), tmp_len ); \
-  } while ( 0 );
-
-
-/****************************************************************************
-**
 *F  MakeImmutableString( <str> ) . . . . . . make a string immutable in place
 */
 EXPORT_INLINE void MakeImmutableString(Obj str)
@@ -351,20 +339,39 @@ EXPORT_INLINE void MakeImmutableString(Obj str)
 // MakeString and MakeImmString are inlineable so 'strlen' can be optimised
 // away for constant strings.
 
-EXPORT_INLINE Obj MakeString(const Char * cstr)
+EXPORT_INLINE Obj MakeStringWithLen(const char * buf, size_t len)
 {
-    size_t len = strlen(cstr);
-    Obj    result = NEW_STRING(len);
-    memcpy(CHARS_STRING(result), cstr, len);
+    Obj result = NEW_STRING(len);
+    memcpy(CHARS_STRING(result), buf, len);
     return result;
 }
 
-EXPORT_INLINE Obj MakeImmString(const Char * cstr)
+EXPORT_INLINE Obj MakeString(const char * cstr)
+{
+    return MakeStringWithLen(cstr, strlen(cstr));
+}
+
+EXPORT_INLINE Obj MakeImmString(const char * cstr)
 {
     Obj result = MakeString(cstr);
     MakeImmutableString(result);
     return result;
 }
+
+EXPORT_INLINE Obj MakeImmStringWithLen(const char * buf, size_t len)
+{
+    Obj result = MakeStringWithLen(buf, len);
+    MakeImmutableString(result);
+    return result;
+}
+
+
+/****************************************************************************
+**
+*F  C_NEW_STRING( <string>, <len>, <cstring> )  . . . . . . create GAP string
+*/
+#define C_NEW_STRING(string,len,cstr) \
+    string = MakeStringWithLen( (cstr), (len) )
 
 
 /****************************************************************************
@@ -380,6 +387,7 @@ EXPORT_INLINE Obj MakeImmString(const Char * cstr)
 */
 #define C_NEW_STRING_DYN(string,cstr) \
   C_NEW_STRING(string, strlen(cstr), cstr)
+
 
 /****************************************************************************
 **

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -297,13 +297,9 @@ static Obj SyntaxTreeRecExpr(Obj result, Expr expr)
 
 static Obj SyntaxTreeFloatLazy(Obj result, Expr expr)
 {
-    UInt len;
     Obj  string;
 
-    len = READ_EXPR(expr, 0);
-    string = NEW_STRING(len);
-    memcpy(CHARS_STRING(string),
-           (const char *)CONST_ADDR_EXPR(expr) + 2 * sizeof(UInt), len);
+    string = GET_VALUE_FROM_CURRENT_BODY(READ_EXPR(expr, 1));
     AssPRec(result, RNamName("value"), string);
     return result;
 }


### PR DESCRIPTION
Also add add new helpers `MakeStringWithLen`, `MakeImmStringWithLen`.

This simplifies further work on the SyntaxTree (re/de/...)compiler code.