### PR TITLE
kernel: simplify code which uses NAME_RNAM

### DIFF
--- a/src/precord.c
+++ b/src/precord.c
@@ -543,23 +543,16 @@ static Obj InnerRecNames(Obj rec)
 {
     Obj                 list;           /* list of record names, result    */
     UInt                rnam;           /* one name of record              */
-    Obj                 string;         /* one name as string              */
     UInt                i;
-    Obj                 name;
     SortPRecRNam(rec,0);   /* Make sure rnams are sorted and thus negative */
 
     /* allocate the list                                                   */
     list = NEW_PLIST( T_PLIST, LEN_PREC(rec) );
-    SET_LEN_PLIST( list, LEN_PREC(rec) );
 
     /* loop over the components                                            */
     for ( i = 1; i <= LEN_PREC(rec); i++ ) {
         rnam = -GET_RNAM_PREC(rec, i);
-        /* could have been moved by garbage collection */
-        name = NAME_RNAM( rnam );
-        string = CopyToStringRep( name );
-        SET_ELM_PLIST( list, i, string );
-        CHANGED_BAG( list );
+        PushPlist( list, NAME_RNAM( rnam ) );
     }
 
     /* return the list                                                     */

--- a/src/records.c
+++ b/src/records.c
@@ -287,8 +287,6 @@ static Obj FuncRNamObj(Obj self, Obj obj)
 */
 static Obj FuncNameRNam(Obj self, Obj rnam)
 {
-    Obj                 name;
-    Obj                 oname;
     const UInt          countRNam = LEN_PLIST(NamesRNam);
     while ( ! IS_INTOBJ(rnam)
          || INT_INTOBJ(rnam) <= 0
@@ -298,9 +296,7 @@ static Obj FuncNameRNam(Obj self, Obj rnam)
             (Int)TNAM_OBJ(rnam), 0L,
             "you can replace <rnam> via 'return <rnam>;'" );
     }
-    oname = NAME_RNAM( INT_INTOBJ(rnam) );
-    name = CopyToStringRep(oname);
-    return name;
+    return NAME_RNAM( INT_INTOBJ(rnam) );
 }
 
 
@@ -515,18 +511,14 @@ UInt            completion_rnam (
 
 static Obj FuncALL_RNAMES(Obj self)
 {
-    Obj                 copy, s;
+    Obj                 copy;
     UInt                i;
-    Obj                 name;
     const UInt          countRNam = LEN_PLIST(NamesRNam);
 
     copy = NEW_PLIST_IMM( T_PLIST, countRNam );
     for ( i = 1;  i <= countRNam;  i++ ) {
-        name = NAME_RNAM( i );
-        s = CopyToStringRep(name);
-        SET_ELM_PLIST( copy, i, s );
+        PushPlist( copy, NAME_RNAM( i ) );
     }
-    SET_LEN_PLIST( copy, countRNam );
     return copy;
 }
 


### PR DESCRIPTION
Since NAME_RNAM returns immutable strings in string rep, there is no
need for us to copy them around. We can just use the original strings.