### PR TITLE
fix a bug in ClassPositionsOfLowerCentralSeries

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1090,7 +1090,7 @@ InstallOtherMethod( ElementaryAbelianSeries,
 
     # if <G> is a list compute an elementary series through a given normal one
     if not IsSolvableGroup( G[1] )  then
-      Error( "<G> must be solvable" );
+      return fail;
     fi;
     for i  in [ 1 .. Length(G)-1 ]  do
       if not IsNormal(G[1],G[i+1]) or not IsSubgroup(G[i],G[i+1])  then
@@ -1114,7 +1114,7 @@ InstallMethod( ElementaryAbelianSeries,
 
     # compute an elementary series if it is not known
     if not IsSolvableGroup( G )  then
-      Error( "<G> must be solvable" );
+      return fail;
     fi;
 
     # there is a method for pcgs computable groups we should use if

--- a/lib/grpnice.gd
+++ b/lib/grpnice.gd
@@ -787,7 +787,12 @@ BindGlobal( "GroupSeriesMethodByNiceMonomorphism", function( oper, par )
         function( obj )
             local   nice,  list,  i;
             nice := NiceMonomorphism(obj);
-            list := ShallowCopy( oper( NiceObject(obj) ) );
+            list := oper( NiceObject(obj) );
+            if not IsList( list ) then
+              # The result may be 'fail'.
+              return list;
+            fi;
+            list:= ShallowCopy( list );
             for i  in [ 1 .. Length(list) ]  do
                 list[i] := GroupByNiceMonomorphism( nice, list[i] );
                 SetParent( list[i], obj );

--- a/tst/testextra/ctbl.tst
+++ b/tst/testextra/ctbl.tst
@@ -1,0 +1,95 @@
+#############################################################################
+##
+##  excluded from 'testinstall.g' as it takes considerable time
+##
+#@local tmpSolvableResiduum, n, i, g, t, l
+
+#
+gap> START_TEST( "ctbl.tst" );
+
+##
+gap> tmpSolvableResiduum:= function( G )
+>      local iso;
+>      if Size( G ) = 1 then  # bug in 'SQ'
+>        return G;
+>      elif IsSolvable( G ) then
+>        return TrivialSubgroup( G );
+>      fi;
+>      iso:= IsomorphismFpGroup( G );
+>      return PreImages( iso, Kernel(
+>        EpimorphismSolvableQuotient( ImagesSource( iso ), Size( G ) ) ) );
+>    end;;
+gap> for n in [ 1 .. 150 ] do
+>      for i in [ 1 .. NumberSmallGroups( n ) ] do
+>        g:= SmallGroup( n, i );
+>        t:= CharacterTable( g );
+>        if NormalSubgroupClasses( t, ClassPositionsOfCentre( t ) )
+>           <> Centre( g ) then
+>          Error( "ClassPositionsOfCentre?" );
+>        fi;
+>        if NormalSubgroupClasses( t, ClassPositionsOfDerivedSubgroup( t ) )
+>           <> DerivedSubgroup( g ) then
+>          Error( "ClassPositionsOfDerivedSubgroup?" );
+>        fi;
+>        if NormalSubgroupClasses( t, ClassPositionsOfFittingSubgroup( t ) )
+>           <> FittingSubgroup( g ) then
+>          Error( "ClassPositionsOfFittingSubgroup?" );
+>        fi;
+>        if NormalSubgroupClasses( t, ClassPositionsOfSolvableResiduum( t ) )
+>           <> tmpSolvableResiduum( g ) then
+>          Error( "ClassPositionsOfSolvableResiduum?" );
+>        fi;
+>        if NormalSubgroupClasses( t, ClassPositionsOfSupersolvableResiduum( t ) )
+>           <> SupersolvableResiduum( g ) then
+>          Error( "ClassPositionsOfSupersolvableResiduum?" );
+>        fi;
+>        if List( ClassPositionsOfLowerCentralSeries( t ),
+>                 l -> NormalSubgroupClasses( t, l ) )
+>           <> LowerCentralSeries( g ) then
+>          Error( "ClassPositionsOfLowerCentralSeries?" );
+>        fi;
+>        l:= Reversed( UpperCentralSeries( g ) );
+>        if 1 < Length( l ) then
+>          Remove( l, 1 );
+>        fi;
+>        if List( ClassPositionsOfUpperCentralSeries( t ),
+>                 l -> NormalSubgroupClasses( t, l ) )
+>           <> l then
+>          Error( "ClassPositionsOfUpperCentralSeries?" );
+>        fi;
+>        if SortedList( List( ClassPositionsOfMaximalNormalSubgroups( t ),
+>                 l -> NormalSubgroupClasses( t, l ) ) )
+>           <> SortedList( MaximalNormalSubgroups( g ) ) then
+>          Error( "ClassPositionsOfMaximalNormalSubgroups?" );
+>        fi;
+>        if SortedList( List( ClassPositionsOfMinimalNormalSubgroups( t ),
+>                 l -> NormalSubgroupClasses( t, l ) ) )
+>           <> SortedList( MinimalNormalSubgroups( g ) ) then
+>          Error( "ClassPositionsOfMinimalNormalSubgroups?" );
+>        fi;
+>        if not IsAbelian( t ) and
+>           SortedList( List( ClassPositionsOfNormalSubgroups( t ),
+>                 l -> NormalSubgroupClasses( t, l ) ) )
+>           <> SortedList( NormalSubgroups( g ) ) then
+>          Error( "ClassPositionsOfNormalSubgroups?" );
+>        fi;
+>        if ( not IsElementaryAbelian( g ) ) or ( Size( g ) < 128 ) then
+>          l:= ClassPositionsOfElementaryAbelianSeries( t );
+>          if l = fail then
+>            if IsSolvable( g ) then
+>              Error( "ClassPositionsOfElementaryAbelianSeries?" );
+>            fi;
+>          else
+>            l:= List( l, x -> NormalSubgroupClasses( t, x ) );
+>            if ForAny( [ 1 .. Length( l ) - 1 ],
+>                       i -> not IsElementaryAbelian( l[i] / l[ i+1 ] ) ) then
+>              Error( "ClassPositionsOfElementaryAbelianSeries?" );
+>            fi;
+>          fi;
+>        fi;
+>      od;
+>    od;
+
+##
+gap> STOP_TEST( "ctbl.tst" );
+

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -112,5 +112,19 @@ gap> t:= CharacterTableDirectProduct( t, t );;
 gap> IsCharacterTable( t mod 5 );
 true
 
+# test a bugfix
+gap> g:= SmallGroup( 96, 3 );;
+gap> t:= CharacterTable( g );;
+gap> ClassPositionsOfLowerCentralSeries( t );
+[ [ 1 .. 12 ], [ 1, 3, 4, 5, 6, 9, 10, 11 ] ]
+gap> g:= SmallGroup( 3^5, 22 );;
+gap> t:= CharacterTable( g );;
+gap> ClassPositionsOfLowerCentralSeries( t );
+[ [ 1 .. 35 ], [ 1, 4, 6, 12, 15 ], [ 1, 6, 15 ], [ 1 ] ]
+gap> g:= SmallGroup( 96, 66 );;
+gap> t:= CharacterTable( g );;
+gap> ClassPositionsOfSupersolvableResiduum( t );
+[ 1, 5, 6 ]
+
 ##
-gap> STOP_TEST( "ctbl.tst", 1);
+gap> STOP_TEST( "ctbl.tst" );


### PR DESCRIPTION
This pull request is intended to deal with issue #3321.

The proposed changes are as follows.

1. fixed errors in
   `ClassPositionsOfLowerCentralSeries`, `ClassPositionsOfSolvableResiduum`, `ClassPositionsOfSupersolvableResiduum`, which may lead to wrong results

2. avoid calling `ClassPositionsOfNormalSubgroups` in situations where this may lead to a huge list
   (the worst cases are large elementary abelian groups),
   in `IsSimpleCharacterTable`, `ClassPositionsOfMinimalNormalSubgroups`, `ClassPositionsOfFittingSubgroup`, `ClassPositionsOfSolvableRadical`, `ClassPositionsOfSolvableResiduum`, `ClassPositionsOfSupersolvableResiduum`, `IsPSolvableCharacterTableOp`

3. added extensive tests for the `ClassPositionsOf...` functions, which would not be reasonable without the changes under 2

4. fixed an `ElementaryAbelianSeries` method such that `fail` is returned in the case of nonsolvable groups, instead of calling `Error`; note that the documentation promises `fail` in this case

5. as a consequence of 4., `GroupSeriesByNiceMonomorphism` is now aware of `fail` results