### PR TITLE
Change PrintCSV to not use SizeScreen

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -943,9 +943,15 @@ local nohead,file,sep,f, line, fields, l, r, i,s,t,add,dir;
 end);
 
 InstallGlobalFunction(PrintCSV,function(arg)
-  local file,l,printEntry, rf, r, i, j,sz;
+  local stream,l,printEntry, rf, r, i, j, oldStreamFormattingStatus;
 
-  file:=arg[1];
+  if IsString(arg[1]) then
+    stream:=OutputTextFile(arg[1],false);
+  elif IsOutputStream(arg[1]) then
+    stream:=arg[1];
+  else
+    Error("PrintCSV: filename must be a string or an output stream");
+  fi;
   l:=arg[2];
   printEntry:=function(s)
   local p,q;
@@ -984,11 +990,11 @@ InstallGlobalFunction(PrintCSV,function(arg)
       # integers as string
       s:=Concatenation("\"_",s,"\"");
     fi;
-    AppendTo(file,s,"\c");
+    AppendTo(stream,s,"\c");
   end;
 
-  sz:=SizeScreen();
-  SizeScreen([4096,sz[2]]);
+  oldStreamFormattingStatus:=PrintFormattingStatus(stream);
+  SetPrintFormattingStatus(stream,false);
   if Length(arg)>2 then
     rf:=arg[3];
   else
@@ -1016,29 +1022,29 @@ InstallGlobalFunction(PrintCSV,function(arg)
     end);
   fi;
 
-  PrintTo(file);
+  PrintTo(stream);
 
   if ValueOption("noheader")<>true then
     printEntry(rf[1]);
     for j in [2..Length(rf)] do
-      AppendTo(file,",");
+      AppendTo(stream,",");
       printEntry(ReplacedString(rf[j],"_"," "));
     od;
-    AppendTo(file,"\n");
+    AppendTo(stream,"\n");
   fi;
 
   for  i in l do
     for j in [1..Length(rf)] do
       if j>1 then
-	AppendTo(file,",");
+        AppendTo(stream,",");
       fi;
       if IsBound(i.(rf[j])) then
         printEntry(i.(rf[j]));
       fi;
     od;
-    AppendTo(file,"\n");
+    AppendTo(stream,"\n");
   od;
-  SizeScreen(sz);
+  SetPrintFormattingStatus(stream,oldStreamFormattingStatus);
 end);
 
 

--- a/tst/testinstall/stringobj.tst
+++ b/tst/testinstall/stringobj.tst
@@ -3,7 +3,7 @@
 ##  This file tests various aspects of strings in IsStringRep
 ##
 #@local OldCopyToStringRep,a2000,a3000,at2000,at3000,cp1,cp2,cp3
-#@local ret2000,ret3000,s,tmp,tmpdir,fname,dir,filename
+#@local ret2000,ret3000,s,tmp,tmpdir,fname,dir,filename,sstream,fstream,t,u
 gap> START_TEST("stringobj.tst");
 
 # RemoveCharacters
@@ -132,6 +132,42 @@ gap> ReadCSV(fname,true);
   rec( field1 := "\"Alas, poor Yorick\", the call went", field4 := 4, 
       field5 := 6 ), rec( field4 := 7 ), rec( field3 := 11, field5 := 12 ), 
   rec( field3 := "yy", field4 := "x", field5 := "zzz" ) ]
+gap> sstream := OutputTextString([],false);;
+gap> fstream := OutputTextFile(fname,false);;
+gap> SetPrintFormattingStatus(sstream,false);;
+gap> SetPrintFormattingStatus(fstream,true);;
+gap> s:=rec(string1:=List([1..200],x->'a'),string2:=List([1..200],x->'b'));;
+gap> t:=rec(string1:=List([1..200],x->'c'),string2:=List([1..200],x->'d'));;
+gap> u:=rec(string1:=List([1..200],x->'e'),string2:=List([1..200],x->'f'));;
+gap> PrintCSV(sstream,[s,t,u]);
+gap> PrintCSV(fstream,[s,t,u]);
+gap> ReadCSV(fname,true);
+[ rec( field1 := "string1", field2 := "string2" ), 
+  rec( 
+      field1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 
+      field2 := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ), 
+  rec( 
+      field1 := "ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", 
+      field2 := "ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\
+ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" ), 
+  rec( 
+      field1 := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", 
+      field2 := "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\
+fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" ) ]
+gap> PrintFormattingStatus(sstream) = false;
+true
+gap> PrintFormattingStatus(fstream) = true;
+true
 
 # Long Strings
 # All these strings are 2000 or 3000 characters long, to make sure we fill the string buffer at least once or twice


### PR DESCRIPTION
- instead of using a filename (string) this functions now uses
output streams
- if the first argument is a filename then this function now creates
an output stream
- PrintFormattingStatus is set to false on the given output stream,
at the end it is set to true again

Fixes #2545