### PR TITLE
kernel/gac: don't hardcode TNUM values in generated C code

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -2252,11 +2252,13 @@ static CVar CompIntExpr(Expr expr)
         val = CVAR_TEMP( NewTemp( "val" ) );
         siz = SIZE_OBJ(obj);
         typ = TNUM_OBJ(obj);
-        Emit( "%c = NewWordSizedBag(%d, %d);\n", val, typ, siz);
         if ( typ == T_INTPOS ) {
+            Emit( "%c = NewWordSizedBag(T_INTPOS, %d);\n", val, siz);
             SetInfoCVar(val, W_INT_POS);
         }
         else {
+            GAP_ASSERT(typ == T_INTNEG);
+            Emit( "%c = NewWordSizedBag(T_INTNEG, %d);\n", val, siz);
             SetInfoCVar(val, W_INT);
         }
 

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -114,7 +114,7 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, l_x, t_2 );
  
  /* y := 100000000000000000000; */
- t_1 = NewWordSizedBag(1, 16);
+ t_1 = NewWordSizedBag(T_INTPOS, 16);
  C_SET_LIMB8( t_1, 0, 7766279631452241920LL);
  C_SET_LIMB8( t_1, 1, 5LL);
  l_y = t_1;

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -114,7 +114,7 @@ static Obj  HdlrFunc2 (
  CALL_2ARGS( t_1, l_x, t_2 );
  
  /* y := 100000000000000000000; */
- t_1 = NewWordSizedBag(1, 16);
+ t_1 = NewWordSizedBag(T_INTPOS, 16);
  C_SET_LIMB8( t_1, 0, 7766279631452241920LL);
  C_SET_LIMB8( t_1, 1, 5LL);
  l_y = t_1;


### PR DESCRIPTION
In particular, output `T_INTPOS` instead of `1` (in theory, we also
output `T_INTNEG`, but in practice, GAP currently never generates
negative integer constants; but this might change in the future.