### PR TITLE
MatrixObj: remove Fold / Unfold

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1165,20 +1165,6 @@ InstallOtherMethod( KroneckerProduct, "for two 8bit matrices",
     return kroneckerproduct;
   end );
 
-InstallMethod( Fold, "for an 8bit vector, a positive int, and an 8bit matrix",
-  [ IsVectorObj and Is8BitVectorRep, IsPosInt, Is8BitMatrixRep ],
-  function( v, rl, t )
-    local rows,i,tt,m;
-    m := [];
-    tt := ZeroVector(rl,v);
-    for i in [1..Length(v)/rl] do
-        CopySubVector(v,tt,[(i-1)*rl+1..i*rl],[1..rl]);
-        Add(m,ShallowCopy(tt)); 
-    od;
-    ConvertToMatrixRep(m,Q_VEC8BIT(m[1]));
-    return m;
-  end );
-
 InstallMethod( ConstructingFilter, "for an 8bit vector",
   [ Is8BitVectorRep ], function(v) return Is8BitVectorRep; end );
 InstallMethod( ConstructingFilter, "for an 8bit matrix",

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2498,20 +2498,6 @@ InstallOtherMethod( KroneckerProduct, "for two gf2 matrices",
   [IsGF2MatrixRep and IsMatrix, IsGF2MatrixRep and IsMatrix],
   KRONECKERPRODUCT_GF2MAT_GF2MAT );
 
-InstallMethod( Fold, "for a gf2 vector, a positive int, and a gf2 matrix",
-  [ IsVectorObj and IsGF2VectorRep, IsPosInt, IsGF2MatrixRep ],
-  function( v, rl, t )
-    local rows,i,tt,m;
-    m := [];
-    tt := ZeroVector(rl,v);
-    for i in [1..Length(v)/rl] do
-        CopySubVector(v,tt,[(i-1)*rl+1..i*rl],[1..rl]);
-        Add(m,ShallowCopy(tt)); 
-    od;
-    ConvertToMatrixRep(m,2);
-    return m;
-  end );
-
 InstallMethod( ConstructingFilter, "for a gf2 vector",
   [ IsGF2VectorRep ], function(v) return IsGF2VectorRep; end );
 InstallMethod( ConstructingFilter, "for a gf2 matrix",

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -311,37 +311,6 @@ InstallMethod( IdentityMatrix,
     return NewMatrix( rep, basedomain, dim, IdentityMat( dim, basedomain ) );
   end );
 
-
-
-InstallMethod( Unfold, "for a matrix object, and a vector object",
-  [ IsMatrixObj, IsVectorObj ],
-  function( m, w )
-    local v,i,l;
-    if Length(m) = 0 then
-        return ZeroVector(0,w);
-    else
-        l := NumberColumns(m);
-        v := ZeroVector(Length(m)*l,w);
-        for i in [1..Length(m)] do
-            CopySubVector( m[i], v, [1..l], [(i-1)*l+1..i*l] );
-        od;
-        return v;
-    fi;
-  end );
-
-InstallMethod( Fold, "for a vector, a positive int, and a matrix",
-  [ IsVectorObj, IsPosInt, IsMatrixObj ],
-  function( v, rl, t )
-    local rows,i,tt,m;
-    m := Matrix([],rl,t);
-    tt := ZeroVector(rl,v);
-    for i in [1..Length(v)/rl] do
-        CopySubVector(v,tt,[(i-1)*rl+1..i*rl],[1..rl]);
-        Add(m,ShallowCopy(tt));
-    od;
-    return m;
-  end );
-
 InstallMethod( CompanionMatrix, "for a polynomial and a matrix",
   [ IsUnivariatePolynomial, IsMatrixObj ],
   function( po, m )

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1135,19 +1135,6 @@ DeclareOperation( "IsLowerTriangularMat", [IsMatrixObj] );
 DeclareOperation( "KroneckerProduct", [IsMatrixObj,IsMatrixObj] );
 # The result is fully mutable.
 
-# FIXME: what is the purpose of Unfold and Fold?
-# Maybe remove them, and wait if somebody asks for / needs this
-
-DeclareOperation( "Unfold", [IsMatrixObj, IsVectorObj] );
-# Concatenates all rows of a matrix to one single vector in the same
-# representation as the given template vector. Usually this must
-# be compatible with the representation of the matrix given.
-DeclareOperation( "Fold", [IsVectorObj, IsPosInt, IsMatrixObj] );
-# Cuts the row vector into pieces of length the second argument
-# and forms a matrix out of the pieces in the same representation 
-# as the third argument. The length of the vector must be a multiple
-# of the second argument.
-
 # The following unwraps a matrix to a list of lists:
 DeclareOperation( "Unpack", [IsRowListMatrix] );
 # It guarantees to copy, that is changing the returned object does

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -1292,35 +1292,6 @@ InstallMethod( \*, "for a plist vector and a plist matrix",
     return res;
   end );
 
-InstallMethod( Unfold, "for a plist matrix",
-  [ IsPlistMatrixRep, IsPlistVectorRep ],
-  function( m, w )
-    local v,i,l;
-    if Length(m![ROWSPOS]) = 0 then
-        return ShallowCopy(m![EMPOS]);
-    else
-        l := m![RLPOS];
-        v := ZeroVector(Length(m![ROWSPOS])*l,m![EMPOS]);
-        for i in [1..Length(m![ROWSPOS])] do
-            CopySubVector( m![ROWSPOS][i], v, [1..l], [(i-1)*l+1..i*l] );
-        od;
-        return v;
-    fi;
-  end );
-
-InstallMethod( Fold, "for a plist vector, a positive int, and a plist matrix",
-  [ IsPlistVectorRep, IsPosInt, IsPlistMatrixRep ],
-  function( v, rl, t )
-    local rows,i,tt,m;
-    m := Matrix([],rl,t);
-    tt := ZeroVector(rl,v);
-    for i in [1..Length(v![ELSPOS])/rl] do
-        Add(m![ROWSPOS],v{[(i-1)*rl+1..i*rl]});
-    od;
-    return m;
-  end );
-
-
 #InstallMethod( \^, "for a plist vector and an integer",
 #  [ IsPlistMatrixRep, IsInt ],
 #  function( m, i )

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1122,20 +1122,6 @@ InstallOtherMethod( KroneckerProduct, "for two 8bit matrices",
     return kroneckerproduct;
   end );
 
-InstallMethod( Fold, "for an 8bit vector, a positive int, and an 8bit matrix",
-  [ IsVectorObj and Is8BitVectorRep, IsPosInt, Is8BitMatrixRep ],
-  function( v, rl, t )
-    local rows,i,tt,m;
-    m := [];
-    tt := ZeroVector(rl,v);
-    for i in [1..Length(v)/rl] do
-        CopySubVector(v,tt,[(i-1)*rl+1..i*rl],[1..rl]);
-        Add(m,ShallowCopy(tt)); 
-    od;
-    ConvertToMatrixRep(m,Q_VEC8BIT(m[1]));
-    return m;
-  end );
-
 InstallMethod( ConstructingFilter, "for an 8bit vector",
   [ Is8BitVectorRep ], function(v) return Is8BitVectorRep; end );
 InstallMethod( ConstructingFilter, "for an 8bit matrix",

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2309,20 +2309,6 @@ InstallOtherMethod( KroneckerProduct, "for two gf2 matrices",
   [IsGF2MatrixRep and IsMatrix, IsGF2MatrixRep and IsMatrix],
   KRONECKERPRODUCT_GF2MAT_GF2MAT );
 
-InstallMethod( Fold, "for a gf2 vector, a positive int, and a gf2 matrix",
-  [ IsVectorObj and IsGF2VectorRep, IsPosInt, IsGF2MatrixRep ],
-  function( v, rl, t )
-    local rows,i,tt,m;
-    m := [];
-    tt := ZeroVector(rl,v);
-    for i in [1..Length(v)/rl] do
-        CopySubVector(v,tt,[(i-1)*rl+1..i*rl],[1..rl]);
-        Add(m,ShallowCopy(tt)); 
-    od;
-    ConvertToMatrixRep(m,2);
-    return m;
-  end );
-
 InstallMethod( ConstructingFilter, "for a gf2 vector",
   [ IsGF2VectorRep ], function(v) return IsGF2VectorRep; end );
 InstallMethod( ConstructingFilter, "for a gf2 matrix",


### PR DESCRIPTION
These operations are not really needed or used; and the name "fold"
already has another [well-established meaning in functional programming](https://en.wikipedia.org/wiki/Fold_(higher-order_function)),
and its use here is very confusing for me.

Indeed, I'd like to add a `Fold` that does what "usually" is expected under that name.

Since this was never documented, there should be no issue removing it.
