### PR TITLE
buildsys: resolve some issues if path contains spaces

### DIFF
--- a/cnf/build-extern.sh
+++ b/cnf/build-extern.sh
@@ -12,7 +12,7 @@ pkg=$1; shift
 src=$1; shift # directory with package sources -- must be an absolute path
 
 builddir=extern/build/$pkg
-prefix=$PWD/extern/install/$pkg
+prefix="$PWD/extern/install/$pkg"
 
 mkdir -p "$builddir"
 
@@ -21,7 +21,7 @@ mkdir -p "$builddir"
 if [[ ( ! "$builddir/config.status" -nt "$src/configure" )
     || ( "config.status" -nt "$builddir/config.status" ) ]] ; then
   pushd "$builddir"
-  "$src/configure" --prefix=$prefix "$@"
+  "$src/configure" --prefix="$prefix" "$@"
   popd
 fi
 

--- a/cnf/compat/gap.sh.in
+++ b/cnf/compat/gap.sh.in
@@ -3,7 +3,7 @@
 GAP_EXE=$GAP_DIR
 if [ "x$GAP_DIR" = "x" ]; then
   GAP_DIR=$(cd "@abs_top_srcdir@" && pwd)
-  GAP_EXE=@abs_top_builddir@
+  GAP_EXE="@abs_top_builddir@"
 fi
 
 exec "$GAP_EXE/gap" -l "$GAP_DIR" "$@"

--- a/extern/gmp/config.guess
+++ b/extern/gmp/config.guess
@@ -60,11 +60,11 @@ SHELL=${CONFIG_SHELL-/bin/sh}
 # Identify ourselves on --version, --help or errors
 if test $# != 0; then
   echo "(GNU MP wrapped config.guess)"
-  $SHELL $configfsf_guess "$@"
+  $SHELL "$configfsf_guess" "$@"
   exit 1
 fi
 
-guess_full=`$SHELL $configfsf_guess`
+guess_full=`$SHELL "$configfsf_guess"`
 if test $? != 0; then
   exit 1
 fi

--- a/extern/gmp/config.sub
+++ b/extern/gmp/config.sub
@@ -71,7 +71,7 @@ SHELL=${CONFIG_SHELL-/bin/sh}
 case "$1" in
 "" | -*)
   echo "(GNU MP wrapped config.sub)" 1>&2
-  $SHELL $configfsf_sub "$@"
+  $SHELL "$configfsf_sub" "$@"
   exit
   ;;
 esac
@@ -135,7 +135,7 @@ armcortexr4 | armcortexr5 | armcortexm3 | arm*neon | xgene1 | exynosm1 | thunder
 
 *)
   # Don't need or want to change the given name, just run configfsf.sub
-  $SHELL $configfsf_sub "$given_full"
+  $SHELL "$configfsf_sub" "$given_full"
   if test $? = 0; then
     exit 0
   else
@@ -146,7 +146,7 @@ esac
 
 
 test_full="$test_cpu$given_rest"
-canonical_full=`$SHELL $configfsf_sub "$test_full"`
+canonical_full=`$SHELL "$configfsf_sub" "$test_full"`
 if test $? = 0; then
   :
 else


### PR DESCRIPTION
Properly quote paths in a few more places to ensure the affected
scripts work inside directories with spaces in their name.

Note that even though a few GMP files also are fixed, this is not
enough to actually allow GMP to build in the described situation:
GMP even contains a check that aborts compilation if there are spaces
in the PWD (but these checks actually only are reached with the
fixes in this PR...). The main reason I added the GMP fixes here is
that perhaps they can be contributed back to upstream, in case
upstream is not completely against trying to address this issue.

Overall, building GAP in a path with whitespaces seems to work fine; but various packages may have issues with it.