### PR TITLE
Separate testextra from teststandard

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1040,6 +1040,20 @@ teststandard: all
           ReadGapRoot( "tst/teststandard.g" );' | $(TESTGAP) | \
             tee `date -u +dev/log/teststandard2_%Y-%m-%d-%H-%M` )
 
+# run testextra.g twice:
+# - without packages (except needed to run GAP)
+# - with all packages loaded
+testextra: all
+	$(MKDIR_P) dev/log
+	( echo 'SetUserPreference("UseColorsInTerminal",false); \
+          SetUserPreference("ReproducibleBehaviour", true); \
+          ReadGapRoot( "tst/testextra.g" );' | $(TESTGAP) | \
+            tee `date -u +dev/log/testextra1_%Y-%m-%d-%H-%M` )
+	( echo 'SetUserPreference("UseColorsInTerminal",false); LoadAllPackages(); \
+	      SetUserPreference("ReproducibleBehaviour", true); \
+          ReadGapRoot( "tst/testextra.g" );' | $(TESTGAP) | \
+            tee `date -u +dev/log/testextra2_%Y-%m-%d-%H-%M` )
+
 # run testbugfix.g twice:
 # - without packages (except needed to run GAP)
 # - with all packages loaded

--- a/tst/testextra.g
+++ b/tst/testextra.g
@@ -16,7 +16,6 @@
 
 Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n\n" );
 
-bits := String(8*GAPInfo.BytesPerVariable);
 dirs := [
   DirectoriesLibrary( "tst/testextra" )
 ];

--- a/tst/testextra.g
+++ b/tst/testextra.g
@@ -7,7 +7,7 @@
 ##
 ##  SPDX-License-Identifier: GPL-2.0-or-later
 ##
-##  This file exercices 'tst/testextra' tests, which are very slow. 
+##  This file exercises 'tst/testextra' tests, which are very slow. 
 ##
 ##  To run it, use this command:
 ##

--- a/tst/testextra.g
+++ b/tst/testextra.g
@@ -1,0 +1,26 @@
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+##  This file exercices 'tst/testextra' tests, which are very slow. 
+##
+##  To run it, use this command:
+##
+##  gap> Read( Filename( DirectoriesLibrary( "tst" ), "testextra.g" ) );
+##
+
+Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n\n" );
+
+bits := String(8*GAPInfo.BytesPerVariable);
+dirs := [
+  DirectoriesLibrary( "tst/testextra" )
+];
+TestDirectory( dirs, rec(exitGAP := true) );
+  
+# Should never get here
+FORCE_QUIT_GAP(1);

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -21,7 +21,6 @@ Print( "You should start GAP4 using `gap -A -x 80 -r -m 100m -o 1g -K 2g'.\n\n" 
 dirs := [
   DirectoriesLibrary( "tst/teststandard" ),
   DirectoriesLibrary( "tst/testinstall" ),
-  DirectoriesLibrary( "tst/testextra" ),
 ];
 TestDirectory( dirs, rec(exitGAP := true) );
   


### PR DESCRIPTION
I would like to separate `testextra` from `teststandard` and make it a separate target. This will help to harmonise the GAP test suite and bring closer tests that can be called locally via `make test{install/standard/bugfix/extra}` etc. and in Travis. Otherwise, we have the situation when, first, nobody runs `make teststandard` locally because everyone knows that this will take ages; second, it is more difficult to analyse `make teststandard` logs because of interference between tests.

More about the latter: as you can see from this [Jenkins log](https://gap-ci.cs.st-andrews.ac.uk/view/GAP-nightly/job/GAP-stable-test/GAPCOPTS=64build,GAPTARGET=standard,label=kovacs/276/console) (St Andrews access only), it has 0 diffs with no packages loaded and 30 diffs with all packages loaded. The first diff is
```
########> Diff in /circa/scratch/gap-jenkins/workspace/GAP-stable-test/GAPCOPT\
S/64build/GAPTARGET/standard/label/kovacs/GAP-stable-snapshot/tst/testextra/gr\
pauto.tst:152
# Input is:
IsomorphismGroups(gp1,gp2)<>fail;
# Expected output:
true
# But found:
Error, reached the pre-set memory limit
(change it with the -o command line option)
########
```
and then the situation goes out of control: even some tests which are known to pass otherwise in `testinstall` now have unexplainable failures, for example:
```
########> Diff in /circa/scratch/gap-jenkins/workspace/GAP-stable-test/GAPCOPT\
S/64build/GAPTARGET/standard/label/kovacs/GAP-stable-snapshot/tst/testinstall/\
grpmat.tst:30
# Input is:
Size( AutomorphismGroup( G ) );
# Expected output:
24
# But found:
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `ExponentsOfPcElement' on 2 arguments
########
```
This is why isolating `testextra` would be helpful.

Next step (in this or a separate PR) would be removing `testtravis.g` and replacing it by `teststandard.g` which now (i.e. in this PR) runs the same two directories. 

After merging this PR, I will have to adapt some of my setup for Jenkins.
