### PR TITLE
Make some interpreter / reader errors a bit nicer

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -1338,7 +1338,7 @@ static void ReadFuncExpr (
     ReadFuncExprBody(follow, 0, nloc, args, startLine);
 
     /* 'end'                                                               */
-    Match( S_END, "end", follow );
+    Match(S_END, "while parsing a function: statement or 'end'", follow);
 }
 
 
@@ -1994,7 +1994,7 @@ static void ReadIf (
     }
 
     /* 'fi'                                                                */
-    Match( S_FI, "fi", follow );
+    Match(S_FI, "while parsing an 'if' statement: statement or 'fi'", follow);
     TRY_IF_NO_ERROR { IntrIfEnd( nrb ); }
 }
 
@@ -2044,7 +2044,7 @@ static void ReadFor (
     ReaderState()->LoopNesting--;
 
     /* 'od'                                                                */
-    Match( S_OD, "od", follow );
+    Match(S_OD, "while parsing a 'for' loop: statement or 'od'", follow);
     TRY_IF_NO_ERROR {
         IntrForEnd();
     }
@@ -2095,7 +2095,7 @@ static void ReadWhile (
     ReaderState()->LoopNesting--;
 
     /* 'od'                                                                */
-    Match( S_OD, "od", follow );
+    Match(S_OD, "while parsing a 'while' loop: statement or 'od'", follow);
     TRY_IF_NO_ERROR {
         IntrWhileEnd();
     }
@@ -2171,7 +2171,7 @@ static void ReadAtomic (
     TRY_IF_NO_ERROR { IntrAtomicEndBody( nrs ); }
 
     /* 'od'                                                                */
-    Match( S_OD, "od", follow );
+    Match(S_OD, "while parsing an atomic block: statement or 'od'", follow);
     TRY_IF_NO_ERROR {
         IntrAtomicEnd();
     }
@@ -2225,7 +2225,7 @@ static void ReadRepeat (
     ReaderState()->LoopNesting--;
 
     /* 'until' <Expr>                                                      */
-    Match( S_UNTIL, "until", EXPRBEGIN|follow );
+    Match(S_UNTIL, "while parsing a 'repeat' loop: statement or 'until'", EXPRBEGIN|follow);
     ReadExpr( follow, 'r' );
     TRY_IF_NO_ERROR {
         IntrRepeatEnd();

--- a/tst/testbugfix/2012-09-06-t00253.tst
+++ b/tst/testbugfix/2012-09-06-t00253.tst
@@ -13,6 +13,7 @@ gap> Read(s);
 Syntax error: ) expected in stream:4
     v := rec(a := [];);
                     ^
-Syntax error: end expected in stream:5
+Syntax error: while parsing a function: statement or 'end' expected in stream:\
+5
 od;
 ^^

--- a/tst/testinstall/error.tst
+++ b/tst/testinstall/error.tst
@@ -1,0 +1,26 @@
+#
+gap> function() 123; end;
+Syntax error: while parsing a function: statement or 'end' expected in stream:\
+1
+function() 123; end;
+           ^^^
+gap> if true then 123; fi;
+Syntax error: while parsing an 'if' statement: statement or 'fi' expected in s\
+tream:1
+if true then 123; fi;
+             ^^^
+gap> while true do 123; od;
+Syntax error: while parsing a 'while' loop: statement or 'od' expected in stre\
+am:1
+while true do 123; od;
+              ^^^
+gap> repeat 123; until true;
+Syntax error: while parsing a 'repeat' loop: statement or 'until' expected in \
+stream:1
+repeat 123; until true;
+       ^^^
+gap> for i in [1..3] do 123; od;
+Syntax error: while parsing a 'for' loop: statement or 'od' expected in stream\
+:1
+for i in [1..3] do 123; od;
+                   ^^^

--- a/tst/testinstall/help.tst
+++ b/tst/testinstall/help.tst
@@ -5,7 +5,8 @@ gap> if true then ?what fi;
 Syntax error: '?' cannot be used in this context in stream:1
 if true then ?what fi;
              ^^^^^^^^^
-Syntax error: fi expected in stream:2
+Syntax error: while parsing an 'if' statement: statement or 'fi' expected in s\
+tream:2
 
 
 #
@@ -13,7 +14,8 @@ gap> if false then ?what fi;
 Syntax error: '?' cannot be used in this context in stream:1
 if false then ?what fi;
               ^^^^^^^^^
-Syntax error: fi expected in stream:2
+Syntax error: while parsing an 'if' statement: statement or 'fi' expected in s\
+tream:2
 
 
 #
@@ -22,7 +24,8 @@ gap> f := function()
 Syntax error: '?' cannot be used in this context in stream:2
 ?help
 ^^^^^
-Syntax error: end expected in stream:3
+Syntax error: while parsing a function: statement or 'end' expected in stream:\
+3
 
 
 #


### PR DESCRIPTION
Previously, we produced errors like this:

    gap> function() 123; end;
    Syntax error: inside a function, statement or 'end' expected
    function() 123; end;
               ^^^

This now is slightly more helpful and reads as follows.

    gap> function() 123; end;
    Syntax error: while parsing a function: statement or 'end' expected
    function() 123; end;
               ^^^

Similar adjustments are made for loops, atomic blocks and if statements.

Resolves #1117