### PR TITLE
Document that InputTextFile should not be used for binary files

### DIFF
--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -629,6 +629,11 @@ DeclareOperation( "InputTextString", [ IsString ] );
 ##  <Ref Filt="IsInputTextStream"/> that delivers the characters from the file
 ##  <A>filename</A>. If <A>filename</A> ends in <C>.gz</C> and the file is
 ##  a valid gzipped file, then the file will be transparently uncompressed.
+##  <P/>
+##  <C>InputTextFile</C> is designed for use with text files and automatically
+##  handles windows-style line endings. This means it should <E>not</E> be used for
+##  binary data. The <Ref BookName="IO" Oper="IO_File" /> function from the <Package>IO</Package>
+##  package should be used to access binary data.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
This is the second part of a "fix" for handing windows line endings.

The parsing was improved, but we still can't use InputTextFile to parse binary files. Document this fact and point people to IO_File for such needs.


Fixes #3273