### PR TITLE
Give more helpful warning when using tabs in continuations

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -101,23 +101,23 @@ InstallGlobalFunction(ParseTestInput, function(str, ignorecomments, fnam)
         Add(outp[1], '\n');
       fi;
     elif Length(lines[i]) = 0 and ignorecomments = true and i < Length(lines) 
-         and Length(lines[i+1]) > 0 and lines[i+1][1] = '#' then
+         and StartsWith(lines[i+1], "#") then
       # ignore an empty line followed by comment lines
       Add(ign, i);
       i := i+1;
-      while i <= Length(lines) and Length(lines[i]) > 0 and
-            lines[i][1] = '#' and not StartsWith(lines[i], "#@") do
+      while i <= Length(lines) and StartsWith(lines[i], "#") and
+            not StartsWith(lines[i], "#@") do
         Add(ign, i);
         i := i+1;
       od;
-    elif Length(lines[i]) > 4 and lines[i]{[1..5]} = "gap> " then
+    elif StartsWith(lines[i], "gap> ") then
       foundcmd := false;
       Add(outp, "");
       Add(inp, lines[i]{[6..Length(lines[i])]});
       Add(inp[Length(inp)], '\n');
       Add(pos, i);
       i := i+1;
-    elif Length(lines[i]) > 1 and lines[i]{[1..2]} = "> " then
+    elif StartsWith(lines[i], "> ") then
       if foundcmd then
         testError("Invalid test file: #@ command found in the middle of a single test");
       fi;

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -124,6 +124,8 @@ InstallGlobalFunction(ParseTestInput, function(str, ignorecomments, fnam)
       Append(inp[Length(inp)], lines[i]{[3..Length(lines[i])]});
       Add(inp[Length(inp)], '\n');
       i := i+1;
+    elif StartsWith(lines[i], ">\t") then
+        testError("Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space");
     elif Length(outp) > 0 then
       if foundcmd then
         testError("Invalid test file: #@ command found in the middle of a single test");

--- a/tst/testspecial/broken-test-6.tst
+++ b/tst/testspecial/broken-test-6.tst
@@ -1,0 +1,7 @@
+gap> # continuation prompt followed by a tab leads to an error
+gap> f := function()
+>	local a;
+>	if a = 0 then
+>		Error("a is zero");
+>	fi;
+> end;;

--- a/tst/testspecial/broken-test.g
+++ b/tst/testspecial/broken-test.g
@@ -6,6 +6,8 @@ Test("broken-test-4.tst", rec(width := 800));
 quit;
 Test("broken-test-5.tst", rec(width := 800));
 quit;
+Test("broken-test-6.tst", rec(width := 800));
+quit;
 Test("invalidtestfile.tst", rec(width := 800));
 quit;
 Test("empty.tst", rec(width := 800));

--- a/tst/testspecial/broken-test.g.out
+++ b/tst/testspecial/broken-test.g.out
@@ -1,15 +1,15 @@
 gap> Test("broken-test-2.tst", rec(width := 800));
 Error, Invalid test file: #@ command found in the middle of a single test at broken-test-2.tst:5 at GAPROOT/lib/test.gi:31 called from
-testError( "Invalid test file: #@ command found in the middle of a single test" ); at GAPROOT/lib/test.gi:129 called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:569 called from
+testError( "Invalid test file: #@ command found in the middle of a single test" ); at GAPROOT/lib/test.gi:131 called from
+ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:571 called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-3.tst", rec(width := 800));
 Error, Invalid test file at broken-test-3.tst:5 at GAPROOT/lib/test.gi:31 called from
-testError( "Invalid test file" ); at GAPROOT/lib/test.gi:135 called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:569 called from
+testError( "Invalid test file" ); at GAPROOT/lib/test.gi:137 called from
+ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:571 called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -17,7 +17,7 @@ brk> quit;
 gap> Test("broken-test-4.tst", rec(width := 800));
 Error, Invalid test file: Nested #@if at broken-test-4.tst:2 at GAPROOT/lib/test.gi:31 called from
 testError( "Invalid test file: Nested #@if" ); at GAPROOT/lib/test.gi:52 called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:569 called from
+ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:571 called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -25,15 +25,23 @@ brk> quit;
 gap> Test("broken-test-5.tst", rec(width := 800));
 Error, Invalid test file: two #@else at broken-test-5.tst:7 at GAPROOT/lib/test.gi:31 called from
 testError( "Invalid test file: two #@else" ); at GAPROOT/lib/test.gi:63 called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:569 called from
+ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:571 called from
+<function "Test">( <arguments> )
+ called from read-eval loop at *stdin*:2
+type 'quit;' to quit to outer loop
+brk> quit;
+gap> Test("broken-test-6.tst", rec(width := 800));
+Error, Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space at broken-test-6.tst:3 at GAPROOT/lib/test.gi:31 called from
+testError( "Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space" ); at GAPROOT/lib/test.gi:128 called from
+ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:571 called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("invalidtestfile.tst", rec(width := 800));
 Error, Invalid test file at invalidtestfile.tst:7 at GAPROOT/lib/test.gi:31 called from
-testError( "Invalid test file" ); at GAPROOT/lib/test.gi:135 called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:569 called from
+testError( "Invalid test file" ); at GAPROOT/lib/test.gi:137 called from
+ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:571 called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop


### PR DESCRIPTION
This rejects continuations using 'tab' inside tests. They can
be confusing for users because GAP does not treat them as
continuations, but instead a line of output.

They are rejected, rather than treated as continuations, because
we do not want different parts of GAP to handle continuations
differently, or really start changing the definition of something
so fundamental.

This does break any tests which start an output line with '>\t',
but no such tests seem to exist and would be easily confused with
a continuation.

Fixes #3068 (by giving a nice error) while hopefully not breaking any tests (unlike my previous attempt at fixing this, which broke Browse).