### PR TITLE
Implement 2-cohomology and module computations for arbitrary finite groups, not just solvable ones, via `TwoCohomologyGeneric`

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -589,6 +589,18 @@ see <Cite Key="BJR87"/>.
 </Section>
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="2-Cohomology">
+<Heading>2-Cohomology</Heading>
+
+<#Include Label="TwoCohomologyGeneric">
+<#Include Label="FpGroupCocycle">
+
+Also see Section <Ref Sect="2-Cohomology and Extensions"/> for operations and
+methods specific for Pc groups.
+
+</Section>
+
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Tests for the Availability of Methods">
 <Heading>Tests for the Availability of Methods</Heading>
 

--- a/doc/ref/grppc.xml
+++ b/doc/ref/grppc.xml
@@ -417,6 +417,8 @@ The only method with is special for pc groups is a method
 to compute intersections of subgroups, since here a pcgs of a parent
 group is needed and this can only by guaranteed within pc groups.
 
+Section <Ref Sect="2-Cohomology"/> describes operations and methods for
+arbitrary finite groups.
 </Section>
 
 

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -799,6 +799,7 @@ local aug,w,p,pres,f,fam,opt;
   pres := PresentationAugmentedCosetTable( aug, "y",0# printlevel
                     ,true) ;# intialize tracking before the `1or2' routine!
   opt:=TzOptions(pres);
+
   if ValueOption("expandLimit")<>fail then
     opt.expandLimit:=ValueOption("expandLimit");
   else
@@ -815,12 +816,16 @@ local aug,w,p,pres,f,fam,opt;
     opt.lengthLimit:=Int(3/2*pres!.tietze[TZ_TOTAL]); # not too big.
   fi;
   if ValueOption("generatorsLimit")<>fail then
-    opt.lengthLimit:=ValueOption("generatorsLimit");
+    opt.generatorsLimit:=ValueOption("generatorsLimit");
   fi;
 
   TzOptions(pres).printLevel:=InfoLevel(InfoFpGroup); 
-  TzEliminateRareOcurrences(pres,50);
-  TzGoGo(pres); # cleanup
+  if ValueOption("quick")=true then
+    TzGo(pres);
+  else
+    TzEliminateRareOcurrences(pres,50);
+    TzGoGo(pres); # cleanup
+  fi;
 
   # new free group
   f:=FpGroupPresentation(pres,str);
@@ -1143,7 +1148,11 @@ InstallMethod(MaximalAbelianQuotient,
         true, [IsSubgroupFpGroup], 0,
 function(U)
 local phi,m;
-  phi:=IsomorphismFpGroup(U);
+  # do cheaper Tietze (and thus do not store)
+  phi:=AttributeValueNotSet(IsomorphismFpGroup,U:
+    eliminationsLimit:=50,
+    generatorsLimit:=Length(GeneratorsOfGroup(Parent(U)))*LogInt(IndexInWholeGroup(U),2),
+    quick); 
   m:=MaximalAbelianQuotient(Image(phi));
   SetAbelianInvariants(U,AbelianInvariants(Image(phi)));
   return phi*MaximalAbelianQuotient(Image(phi));

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -30,7 +30,7 @@ function( g, S )
     fi;
     m := MovedPoints(S);
     l := NrMovedPoints(S);
-    
+   
     if g = One( g )  then
         return true;
     elif l = 0  then
@@ -57,13 +57,13 @@ end );
 ##
 ##
 InstallOtherMethod( RepresentativeActionOp, "natural alternating group",
-  true, [ IsNaturalAlternatingGroup, IsObject, IsObject, IsFunction ], 
-  # the objects might be group elements: rank up	
+  true, [ IsNaturalAlternatingGroup, IsObject, IsObject, IsFunction ],
+  # the objects might be group elements: rank up       
   {} -> 2*RankFilter(IsMultiplicativeElementWithInverse),
 function ( G, d, e, opr )
 local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
   # test for internal rep
-  if HasGeneratorsOfGroup(G) and 
+  if HasGeneratorsOfGroup(G) and
     not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
     TryNextMethod();
   fi;
@@ -71,7 +71,7 @@ local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
   if opr=OnPoints then
     if IsInt(d) and IsInt(e) then
       if d in dom and e in dom and Length(dom)>2 then
-	return (d,e,First(dom,i->i<>d and i<>e));
+        return (d,e,First(dom,i->i<>d and i<>e));
       else
         return fail;
       fi;
@@ -79,10 +79,10 @@ local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
       sortfun:=function(a,b) return Length(a)<Length(b);end;
       if Order(d)=1 then #LargestMovedPoint does not work for ().
         if Order(e)=1 then
-	  return ();
-	else
-	  return fail;
-	fi;
+          return ();
+        else
+          return fail;
+        fi;
       fi;
       if CycleStructurePerm(d)<>CycleStructurePerm(e) then
         return fail;
@@ -97,38 +97,38 @@ local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
       rep:=MappingPermListList(Concatenation(cd),Concatenation(ce));
       if SignPerm(rep)=-1 then
         dom2:=Difference(dom,Union(Concatenation(cd),Concatenation(ce)));
-	if Length(dom2)>1 then
-	  rep:=rep*(dom2[1],dom2[2]);
-	else
-	  #this is more complicated
-	  TryNextMethod();
+        if Length(dom2)>1 then
+          rep:=rep*(dom2[1],dom2[2]);
+        else
+          #this is more complicated
+          TryNextMethod();
 
-	  # temporarily disabled, Situation is more complicated
-	  cd:=Filtered(cd,i->IsSubset(dom,i));
-	  d:=CycleStructurePerm(d);
-	  e:=PositionProperty([1..Length(d)],i->IsBound(d[i]) and
-	    # cycle structure is shifted, so this is even length
-	    # we need either to swap a pair of even cycles or to 3-cycle
-	    # odd cycles
-	    ((IsInt((i+1)/2) and d[i]>1) or
-	    (IsInt(i/2) and d[i]>2)));
-	  if e=fail then
-	    rep:=fail;
-	  elif IsInt((e+1)/2) then
-	    cd:=Filtered(cd,i->Length(i)=e+1);
-	    cd:=cd{[1,2]};
-	    rep:=MappingPermListList(Concatenation(cd),
-	                                 Concatenation([cd[2],cd[1]]))*rep;
-	  else
-	    cd:=Filtered(cd,i->Length(i)=e+1);
-	    cd:=cd{[1,2,3]};
-	    rep:=MappingPermListList(Concatenation(cd),
-	                             Concatenation([cd[2],cd[3],cd[1]]))*rep;
-	  fi;
+          # temporarily disabled, Situation is more complicated
+          cd:=Filtered(cd,i->IsSubset(dom,i));
+          d:=CycleStructurePerm(d);
+          e:=PositionProperty([1..Length(d)],i->IsBound(d[i]) and
+            # cycle structure is shifted, so this is even length
+            # we need either to swap a pair of even cycles or to 3-cycle
+            # odd cycles
+            ((IsInt((i+1)/2) and d[i]>1) or
+            (IsInt(i/2) and d[i]>2)));
+          if e=fail then
+            rep:=fail;
+          elif IsInt((e+1)/2) then
+            cd:=Filtered(cd,i->Length(i)=e+1);
+            cd:=cd{[1,2]};
+            rep:=MappingPermListList(Concatenation(cd),
+                                         Concatenation([cd[2],cd[1]]))*rep;
+          else
+            cd:=Filtered(cd,i->Length(i)=e+1);
+            cd:=cd{[1,2,3]};
+            rep:=MappingPermListList(Concatenation(cd),
+                                     Concatenation([cd[2],cd[3],cd[1]]))*rep;
+          fi;
         fi;
       fi;
       if rep<>fail then
-	Assert(1,dp^rep=ep);
+        Assert(1,dp^rep=ep);
       fi;
       return rep;
     fi;
@@ -140,23 +140,23 @@ local dom,dom2,sortfun,max,cd,ce,rep,dp,ep;
     if IsSubset(dom,Set(d)) and IsSubset(dom,Set(e)) then
       rep:=MappingPermListList(d,e);
       if SignPerm(rep)=-1 then
-	cd:=Difference(dom,e);
-	if Length(cd)>1 then
-	  rep:=rep*(cd[1],cd[2]);
-	elif opr=OnSets then
-	  if Length(d)>1 then
-	    rep:=(d[1],d[2])*rep;
-	  else
-	    rep:=fail; # set Length <2, maximal 1 further point in dom,imposs.
-	  fi;
-	else # opr=OnTuples, not enough points left
-	  rep:=fail;
-	fi;
+        cd:=Difference(dom,e);
+        if Length(cd)>1 then
+          rep:=rep*(cd[1],cd[2]);
+        elif opr=OnSets then
+          if Length(d)>1 then
+            rep:=(d[1],d[2])*rep;
+          else
+            rep:=fail; # set Length <2, maximal 1 further point in dom,imposs.
+          fi;
+        else # opr=OnTuples, not enough points left
+          rep:=fail;
+        fi;
       fi;
       return rep;
     fi;
   fi;
-  TryNextMethod(); 
+  TryNextMethod();
 end);
 
 
@@ -169,12 +169,12 @@ function ( G, p )
             sgs,        # strong generating set of <G>
             q,          # power of <p>
             i,          # loop variable
-	    trf,
-	    mov,
-	    deg;
+            trf,
+            mov,
+            deg;
 
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -188,7 +188,7 @@ function ( G, p )
             Add( sgs, (mov[1],mov[2])(mov[i-1],mov[i]) );
             q := q * p;
         fi;
-	trf:=MappingPermListList([1..deg],mov); # translating perm
+        trf:=MappingPermListList([1..deg],mov); # translating perm
         while i mod q = 0  do
             Add( sgs, PermList( Concatenation(
                         [1..i-q], [i-q+1+q/p..i], [i-q+1..i-q+q/p] ) )^trf );
@@ -199,7 +199,7 @@ function ( G, p )
     # make the Sylow subgroup
     S := SubgroupNC( G, sgs );
     SetSize(S,p^Length(sgs));
-    
+   
 
     # add the stabilizer chain
     #MakeStabChainStrongGenerators( S, Reversed([1..G.degree]), sgs );
@@ -224,11 +224,11 @@ function ( G )
             prt,        # partition of <G>
             sum,        # partial sum of the entries in <prt>
             rep,        # representative of a conjugacy class of <G>
-	    mov,deg,trf, # degree, moved points, transfer
+            mov,deg,trf, # degree, moved points, transfer
             i;          # loop variable
 
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -286,16 +286,16 @@ InstallOtherMethod( IsomorphismFpGroup, "alternating group,name",
     10, # override `IsSimpleGroup' method
 function ( G,str )
 local   F,      # free group
-	gens,	#generators of F
-	imgs,
-	hom,	# bijection
-	mov,deg,# moved pts, degree
-	m,	#[n/2]
-	relators,
-	r,s,	# generators
-	d,	# subset of pts
-	p,	# permutation
-	j;      # loop variables
+        gens,   #generators of F
+        imgs,
+        hom,    # bijection
+        mov,deg,# moved pts, degree
+        m,      #[n/2]
+        relators,
+        r,s,    # generators
+        d,      # subset of pts
+        p,      # permutation
+        j;      # loop variables
 
     # test for internal rep
     if (HasGeneratorsOfGroup(G) and
@@ -318,7 +318,7 @@ local   F,      # free group
       m:=(deg-1)/2;
       relators:=[r^deg/s^deg,r^deg/(r*s)^m];
       for j in [2..m] do
-	Add(relators,(r^-j*s^j)^2);
+        Add(relators,(r^-j*s^j)^2);
       od;
       #(1,2,3,..deg) and (1,3,2,4,5,..deg)
       p:=MappingPermListList(mov,Concatenation(mov{[2..deg]},[mov[1]]));
@@ -327,7 +327,7 @@ local   F,      # free group
       m:=deg/2;
       relators:=[r^(deg-1)/s^(deg-1),r^(deg-1)/(r*s)^m];
       for j in [1..m-1] do
-	Add(relators,(r^-j*s^-1*r*s^j)^2);
+        Add(relators,(r^-j*s^-1*r*s^j)^2);
       od;
       # (1,2,3,4..,deg-2,deg),(1,2,3,4,deg-3,deg-1,deg);
       d:=Concatenation(mov{[1..deg-2]},[mov[deg]]);
@@ -358,12 +358,12 @@ InstallMethod(IsomorphismFpGroupForRewriting,"alternating",
   [IsNaturalAlternatingGroup],0,
 function ( G )
 local   F,      # free group
-	gens,	#generators of F
-	imgs,
-	hom,	# bijection
-	mov,deg,
-	relators,
-	i, j;       # loop variables
+        gens,   #generators of F
+        imgs,
+        hom,    # bijection
+        mov,deg,
+        relators,
+        i, j;       # loop variables
 
   if Size(G)=1 then TryNextMethod();fi;
   mov:=MovedPoints(G);
@@ -424,11 +424,11 @@ local schreiertree, cosetrepresentative, flag, schtree, stab, k, p, j,
     schtree[k]:=();
     for i in list do
       for j in [1..Length(gens)] do
-	if mark[i^(inv[j])]=false then
-	    Add(list,i^(inv[j]));
-	    mark[i^(inv[j])]:=true;
-	    schtree[i^(inv[j])]:=gens[j];
-	fi;
+        if mark[i^(inv[j])]=false then
+            Add(list,i^(inv[j]));
+            mark[i^(inv[j])]:=true;
+            schtree[i^(inv[j])]:=gens[j];
+        fi;
       od;
     od;
     return schtree;
@@ -480,29 +480,29 @@ local schreiertree, cosetrepresentative, flag, schtree, stab, k, p, j,
     Add(int,orbits[k][1]);
     Add(int,1);
     if Length(int) <> n then
-	flag:=false;
+        flag:=false;
     else
       # int contains l2-1 extra l2-sets
       if l2=1 then
-	set:=Set(int);
+        set:=Set(int);
       else
-	count:=1;
-	flag2:=false;
-	repeat
-	  j:=int[count];
-	  cosetrep:=cosetrepresentative(schtree,pt1,j);
-	  cosetrep:=cosetrep^(-1);
-	  neworb2:=List(orbits[k],x->x^cosetrep);
-	  if Length(Intersection(int,neworb2))=n-l2 then
-	    set:= Union(Intersection(int,neworb2),[int[count]]);
-	    flag2:=true;
-	  else
-	    count:=count+1;
-	  fi;
-	until flag2 or count>l2;
-	if not flag2 then
-	    flag:=false;
-	fi;
+        count:=1;
+        flag2:=false;
+        repeat
+          j:=int[count];
+          cosetrep:=cosetrepresentative(schtree,pt1,j);
+          cosetrep:=cosetrep^(-1);
+          neworb2:=List(orbits[k],x->x^cosetrep);
+          if Length(Intersection(int,neworb2))=n-l2 then
+            set:= Union(Intersection(int,neworb2),[int[count]]);
+            flag2:=true;
+          else
+            count:=count+1;
+          fi;
+        until flag2 or count>l2;
+        if not flag2 then
+            flag:=false;
+        fi;
       fi;
     fi;
   fi;
@@ -572,36 +572,36 @@ local dom, n, mine, root, d, k, b, m, l,lh;
 
   if n>10 then # otherwise the size is immediate
     # test whether its socle could be A_l^m, acting on k-tuples in product
-    # action. 
+    # action.
     mine:=Minimum(List(Collected(Factors(n)),i->i[2]));
     for m in [1..mine] do
       root:=RootInt(n,m);
       if root^m=n then
-	# case k=1 -> A_root on points
-	if m>1 then # k=1, m=1: then it's A_n
-	  d:=PermNatAnTestDetect(g,root,m,1);
-	  if d<>fail then
-	    Info(InfoGroup,3,"Detected ",root,",",m,",",1,"\n");
-	    return d;
-	  fi;
-	fi;
+        # case k=1 -> A_root on points
+        if m>1 then # k=1, m=1: then it's A_n
+          d:=PermNatAnTestDetect(g,root,m,1);
+          if d<>fail then
+            Info(InfoGroup,3,"Detected ",root,",",m,",",1,"\n");
+            return d;
+          fi;
+        fi;
 
-	for l in [2..RootInt(2*root,2)+1] do
-	  lh:=Int(l/2)+1;
-	  k:=2;
-	  b:=Binomial(l,k);
-	  while b<root and k<lh do
-	    k:=k+1;
-	    b:=Binomial(l,k);
-	  od;
-	  if b=root then
-	    d:=PermNatAnTestDetect(g,l,m,k);
-	    if d<>fail then
-	      Info(InfoGroup,3,"Detected ",l,",",m,",",k,"\n");
-	      return d;
-	    fi;
-	  fi;
-	od;
+        for l in [2..RootInt(2*root,2)+1] do
+          lh:=Int(l/2)+1;
+          k:=2;
+          b:=Binomial(l,k);
+          while b<root and k<lh do
+            k:=k+1;
+            b:=Binomial(l,k);
+          od;
+          if b=root then
+            d:=PermNatAnTestDetect(g,l,m,k);
+            if d<>fail then
+              Info(InfoGroup,3,"Detected ",l,",",m,",",k,"\n");
+              return d;
+            fi;
+          fi;
+        od;
       fi;
     od;
   fi;
@@ -697,7 +697,7 @@ function( g, S )
 
     m := MovedPoints(S);
     l := NrMovedPoints(S);
-    
+   
     if g = One( g )  then
         return true;
     elif l = 0  then
@@ -777,7 +777,7 @@ BindGlobal("FLOYDS_ALGORITHM", function(rs, deg, even)
     return rnd;
 end);
 
-    
+   
 
 InstallMethodWithRandomSource( Random,
     "for a random source and a natural symmetric group: floyd's algorithm",
@@ -790,7 +790,7 @@ function ( rs, G )
             mov;
 
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -816,7 +816,7 @@ function ( rs, G )
             mov;
 
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -915,12 +915,12 @@ end);
 #M  StabilizerOp( <nat-sym-grp>, ...... )
 ##
 SYMGP_STABILIZER := function(sym, arg...)
-    local  k, act, pt, mov, stab, nat, diff, int, bls, mov1, parts, 
+    local  k, act, pt, mov, stab, nat, diff, int, bls, mov1, parts,
            part, bl, i, gens, size;
     k := Length(arg);
     act := arg[k];
     pt := arg[k-3];
-    
+   
     if arg[k-1] <> arg[k-2] then
         TryNextMethod();
     fi;
@@ -949,7 +949,7 @@ SYMGP_STABILIZER := function(sym, arg...)
         fi;
     elif act = OnTuplesTuples and IsList(pt) and ForAll(pt, x->IsList(x) and ForAll(x,IsPosInt)) then
         stab := SymmetricGroup(Difference(mov,Set(Flat(pt))));
-        nat := true;        
+        nat := true;       
     elif act = OnTuplesSets and IsList(pt) and ForAll(pt, x-> IsSet(x) and ForAll(x,IsPosInt)) then
         bls := List(mov, x-> List(pt, y-> x in y));
         mov1 := ShallowCopy(mov);
@@ -971,7 +971,7 @@ SYMGP_STABILIZER := function(sym, arg...)
         if Length(part) > 1 then
             Add(parts, part);
         fi;
-        
+       
         gens := [];
         size := 1;
         for part in parts do
@@ -991,32 +991,32 @@ SYMGP_STABILIZER := function(sym, arg...)
     return stab;
 end;
 
-        
+       
 
-        
-            
-        
+       
+           
+       
 
 InstallOtherMethod( StabilizerOp,"symmetric group", true,
     [ IsNaturalSymmetricGroup, IsObject, IsList, IsList, IsFunction ],
-  # the objects might be a group element: rank up	
-        {} -> RankFilter(IsMultiplicativeElementWithInverse) + 
+  # the objects might be a group element: rank up      
+        {} -> RankFilter(IsMultiplicativeElementWithInverse) +
         RankFilter(IsSolvableGroup),
         SYMGP_STABILIZER);
 
 InstallOtherMethod( StabilizerOp,"symmetric group", true,
     [ IsNaturalSymmetricGroup, IsDomain, IsObject, IsList, IsList, IsFunction ],
-  # the objects might be a group element: rank up	
-        {} -> RankFilter(IsMultiplicativeElementWithInverse) + 
+  # the objects might be a group element: rank up      
+        {} -> RankFilter(IsMultiplicativeElementWithInverse) +
         RankFilter(IsSolvableGroup),
         SYMGP_STABILIZER);
 
 InstallOtherMethod( StabilizerOp,"alternating group", true,
     [ IsNaturalAlternatingGroup, IsObject, IsList, IsList, IsFunction ],
-  # the objects might be a group element: rank up	
-        {} -> RankFilter(IsMultiplicativeElementWithInverse) + 
+  # the objects might be a group element: rank up      
+        {} -> RankFilter(IsMultiplicativeElementWithInverse) +
         RankFilter(IsSolvableGroup),
-function(g, arg...) 
+function(g, arg...)
 local s;
   s:=SymmetricParentGroup(g);
   # we cannot go to the symmetric group if the acting elements are different
@@ -1029,8 +1029,8 @@ end);
 
 InstallOtherMethod( StabilizerOp,"alternating group", true,
     [ IsNaturalAlternatingGroup, IsDomain, IsObject, IsList, IsList, IsFunction ],
-  # the objects might be a group element: rank up	
-        {} -> RankFilter(IsMultiplicativeElementWithInverse) + 
+  # the objects might be a group element: rank up      
+        {} -> RankFilter(IsMultiplicativeElementWithInverse) +
         RankFilter(IsSolvableGroup),
         function(g, arg...)
     return AlternatingSubgroup(CallFuncList(Stabilizer, Concatenation([SymmetricParentGroup(g)], arg)));
@@ -1058,12 +1058,12 @@ function ( G, g )
             lasts,      # '<lasts>[<l>]' is the last cycle of length <l>
             last,       # one cycle from <lasts>
             counts,     # number of cycles of each length
-	    mov,        # moved points of group
+            mov,        # moved points of group
             siz,        # size of centraliser
             l;
-    
+   
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -1092,38 +1092,38 @@ function ( G, g )
             counts[l] := counts[l]+1;
         fi;
     od;
-    
+   
     # loop over the cycles
     for cycle  in cycles  do
         l := Length(cycle);
       # add that cycle itself to the strong generators
       if l <> 1  then
-	  gen := MappingPermListList(cycle,
-	            Concatenation(cycle{[2..l]},[cycle[1]]));
-	  Add( sgs, gen );
+          gen := MappingPermListList(cycle,
+                    Concatenation(cycle{[2..l]},[cycle[1]]));
+          Add( sgs, gen );
       fi;
 
       # and this cycle can be mapped to the last cycle of this length
       if cycle <> lasts[ Length(cycle) ]  then
-	  last := lasts[ Length(cycle) ];
-	  gen := MappingPermListList(Concatenation(cycle,last),
-	                              Concatenation(last,cycle));
-	  Add( sgs, gen );
+          last := lasts[ Length(cycle) ];
+          gen := MappingPermListList(Concatenation(cycle,last),
+                                      Concatenation(last,cycle));
+          Add( sgs, gen );
       fi;
 
   od;
-  
+ 
   siz := 1;
   for l in [1..Length(counts)] do
       if IsBound(counts[l]) then
           siz := siz*l^counts[l]*Factorial(counts[l]);
       fi;
   od;
-  
+ 
   # make the centralizer
   C := SubgroupNC(  G , sgs );
   SetSize(C,siz);
-  
+ 
 
   # return the centralizer
   return C;
@@ -1145,12 +1145,12 @@ local b, bl,prop;
 
       # type of action on blocks
       if TransitiveGroupsAvailable(Length(dom)/Length(s)) then
-	Add(p,TransitiveIdentification(Action(G,Orbit(G,s,OnSets),OnSets)));
+        Add(p,TransitiveIdentification(Action(G,Orbit(G,s,OnSets),OnSets)));
       fi;
 
       # type of action on blocks
       if TransitiveGroupsAvailable(Length(s)) then
-	Add(p,TransitiveIdentification(Action(Stabilizer(G,s,OnSets),s)));
+        Add(p,TransitiveIdentification(Action(Stabilizer(G,s,OnSets),s)));
       fi;
     fi;
 
@@ -1203,11 +1203,11 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg,bp;
       pg:=Centralizer(s,b);
       for i in GeneratorsOfGroup(GL(Length(bas),RelativeOrders(bas)[1])) do
         bp:=dom[1];
-	w:=GroupHomomorphismByImagesNC(b,b,bas,
-	  List([1..Length(bas)],x->PcElementByExponents(bas,i[x])));
-	w:=List(dom,x->bp^Image(w,First(AsSSortedList(b),a->bp^a=x)));
-	w:=MappingPermListList(dom,w);
-	pg:=ClosureGroup(pg,w);
+        w:=GroupHomomorphismByImagesNC(b,b,bas,
+          List([1..Length(bas)],x->PcElementByExponents(bas,i[x])));
+        w:=List(dom,x->bp^Image(w,First(AsSSortedList(b),a->bp^a=x)));
+        w:=MappingPermListList(dom,w);
+        pg:=ClosureGroup(pg,w);
       od;
       return Intersection(s,pg);
     else
@@ -1215,7 +1215,7 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg,bp;
       b:=Reversed(b); # larger ones should give most reduction.
       pg:=NormalizerParentSA(s,b[1]);
       for i in [2..Length(b)] do
-	pg:=Normalizer(pg,b[i]);
+        pg:=Normalizer(pg,b[i]);
       od;
       return Intersection(s,pg);
     fi;
@@ -1230,23 +1230,23 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg,bp;
       return NormalizerParentSA(s,b);
     fi;
     # nonabelian socle
-    if PrimitiveGroupsAvailable(Length(dom)) 
+    if PrimitiveGroupsAvailable(Length(dom))
       and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
       Info(InfoPerformance,2,"Using Primitive Groups Library");
       # use library
       beta:=Factorial(Length(dom))/2;
       w:=CallFuncList(ValueGlobal("AllPrimitiveGroups"),
-	  [NrMovedPoints,Length(dom),IsSolvableGroup,false,
-	  x->Size(x)>Size(u) and Size(x) mod Size(u)=0 and
-	  Size(x)<beta,true]);
+          [NrMovedPoints,Length(dom),IsSolvableGroup,false,
+          x->Size(x)>Size(u) and Size(x) mod Size(u)=0 and
+          Size(x)<beta,true]);
       if Length(w)=0 then
-	return u; # must be self-normalizing
+        return u; # must be self-normalizing
       fi;
     fi;
     # find right automorphisms (socle cannot have centralizer)
     w:=AutomorphismGroup(b);
     opg:=NaturalHomomorphismByNormalSubgroupNC(w,
-	  InnerAutomorphismsAutomorphismGroup(w));
+          InnerAutomorphismsAutomorphismGroup(w));
     ll:=List(AsSSortedList(Image(opg)),x->PreImagesRepresentative(opg,x));
     ll:=Filtered(ll,IsConjugatorAutomorphism);
     ll:=List(ll,ConjugatorInnerAutomorphism);
@@ -1273,21 +1273,21 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg,bp;
       na:=Normalizer(SymmetricGroup(Length(b[1])),Image(alpha));
       w:=WreathProduct(na,nb);
       if issym then
-	perm:=s;
+        perm:=s;
       else
-	perm:=SymmetricGroup(MovedPoints(s));
+        perm:=SymmetricGroup(MovedPoints(s));
       fi;
       perm:=RepresentativeAction(perm,emb,GeneratorsOfGroup(u),OnTuples);
       if perm<>fail then
-	pg:=w^perm;
+        pg:=w^perm;
       else
-	#Print("Embedding Problem!\n");
-	w:=WreathProduct(SymmetricGroup(Length(b[1])),SymmetricGroup(Length(b)));
-	perm:=MappingPermListList([1..Length(o[1])],Concatenation(b));
-	pg:=w^perm;
+        #Print("Embedding Problem!\n");
+        w:=WreathProduct(SymmetricGroup(Length(b[1])),SymmetricGroup(Length(b)));
+        perm:=MappingPermListList([1..Length(o[1])],Concatenation(b));
+        pg:=w^perm;
       fi;
       if opg<>fail then
-	pg:=Intersection(pg,opg);
+        pg:=Intersection(pg,opg);
 
       fi;
       opg:=pg;
@@ -1309,67 +1309,67 @@ syll, act, typ, sel, bas, wdom, comp, lperm, other, away, i, j,b0,opg,bp;
     while is<=l do
       ll:=Length(o[is]);
       while ie<=l and Length(o[ie])=ll do
-	ie:=ie+1;
+        ie:=ie+1;
       od;
       # now length block is from is to ie-1
 
       syll:=SymmetricGroup(ll);
       # if the degrees are small enough, even get local types
-      if ll>1 and TransitiveGroupsAvailable(ll) 
+      if ll>1 and TransitiveGroupsAvailable(ll)
         and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
-	Info(InfoPerformance,2,"Using Transitive Groups Library");
-	Info(InfoGroup,1,"Length ",ll," sort by types");
-	act:=[];
-	typ:=[];
-	for i in [is..ie-1] do
-	  act[i]:=Action(u,o[i]);
-	  typ[i]:=TransitiveIdentification(act[i]);
-	od;
-	# rearrange
-	for i in Set(typ) do
-	  sel:=Filtered([is..ie-1],j->typ[j]=i);
-	  bas:=NormalizerParentSA(syll,act[sel[1]]);
-	  bas:=Normalizer(bas,act[sel[1]]);
-	  w:=WreathProduct(bas,SymmetricGroup(Length(sel)));
-	  wdom:=[1..ll*Length(sel)];
-	  comp:=WreathProductInfo(w).components;
-	  # now the suitable permutation
-	  perm:=();
-	  # first permutation on each component
-	  for j in [1..Length(sel)] do
-	    if j=1 then
-	      lperm:=();
-	    else
-	      lperm:=RepresentativeAction(syll,act[sel[1]],act[sel[j]]);
-	    fi;
-	    other:=Difference(wdom,comp[j]);
-	    away:=[1..Length(other)]+Length(wdom);
-	    perm:=perm*MappingPermListList(Concatenation(comp[j],other),
-				Concatenation([1..ll],away)) # j-th component
-		  *lperm # standard form
-		  *MappingPermListList(Concatenation([1..ll],away),
-				Concatenation(comp[j],other)); # to j orbit
-	  od;
-	  # and then of components
-	  perm:=perm*MappingPermListList(wdom,Concatenation(o{sel}));
-	  for i in SmallGeneratingSet(w) do
-	    Add(pg,i^perm);
-	  od;
-	od;
+        Info(InfoPerformance,2,"Using Transitive Groups Library");
+        Info(InfoGroup,1,"Length ",ll," sort by types");
+        act:=[];
+        typ:=[];
+        for i in [is..ie-1] do
+          act[i]:=Action(u,o[i]);
+          typ[i]:=TransitiveIdentification(act[i]);
+        od;
+        # rearrange
+        for i in Set(typ) do
+          sel:=Filtered([is..ie-1],j->typ[j]=i);
+          bas:=NormalizerParentSA(syll,act[sel[1]]);
+          bas:=Normalizer(bas,act[sel[1]]);
+          w:=WreathProduct(bas,SymmetricGroup(Length(sel)));
+          wdom:=[1..ll*Length(sel)];
+          comp:=WreathProductInfo(w).components;
+          # now the suitable permutation
+          perm:=();
+          # first permutation on each component
+          for j in [1..Length(sel)] do
+            if j=1 then
+              lperm:=();
+            else
+              lperm:=RepresentativeAction(syll,act[sel[1]],act[sel[j]]);
+            fi;
+            other:=Difference(wdom,comp[j]);
+            away:=[1..Length(other)]+Length(wdom);
+            perm:=perm*MappingPermListList(Concatenation(comp[j],other),
+                                Concatenation([1..ll],away)) # j-th component
+                  *lperm # standard form
+                  *MappingPermListList(Concatenation([1..ll],away),
+                                Concatenation(comp[j],other)); # to j orbit
+          od;
+          # and then of components
+          perm:=perm*MappingPermListList(wdom,Concatenation(o{sel}));
+          for i in SmallGeneratingSet(w) do
+            Add(pg,i^perm);
+          od;
+        od;
 
       else
-	bas:=syll;
-	w:=WreathProduct(bas,SymmetricGroup(ie-is));
-	perm:=MappingPermListList([1..ll*(ie-is)],Concatenation(o{[is..ie-1]}));
-	for i in SmallGeneratingSet(w) do
-	  Add(pg,i^perm);
-	od;
+        bas:=syll;
+        w:=WreathProduct(bas,SymmetricGroup(ie-is));
+        perm:=MappingPermListList([1..ll*(ie-is)],Concatenation(o{[is..ie-1]}));
+        for i in SmallGeneratingSet(w) do
+          Add(pg,i^perm);
+        od;
       fi;
       is:=ie;
     od;
     pg:=Group(pg,());
   fi;
-  if not issym then 
+  if not issym then
     pg:=AlternatingSubgroup(pg);
   fi;
   if (Size(pg)/Size(u))>10000 and IsSolvableGroup(pg) then
@@ -1382,7 +1382,7 @@ end);
 BindGlobal("DoNormalizerSA",function ( G, U )
 local P;
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -1481,7 +1481,7 @@ local og,oh,cb,cc,cac,perm1,perm2,
     ac:=SubgroupNC(s,ac);
     SetSize(ac,a);
     a:=RepresentativeAction(ac,g^perm,h);
-    if a=fail then 
+    if a=fail then
       return fail;
     else
       return perm*a;
@@ -1529,8 +1529,8 @@ local og,oh,cb,cc,cac,perm1,perm2,
       ac2:=Action(Stabilizer(g,b[i],OnSets),b[i]);
       perm:=RepresentativeAction(t,ac2,ac);
       if perm=fail then
-	# b cannot be conjugated -- inconsistent
-	Error("inconsistence");
+        # b cannot be conjugated -- inconsistent
+        Error("inconsistence");
       fi;
       perm:=perm^MappingPermListList([1..c],b[i]);
       g:=g^perm;
@@ -1539,8 +1539,8 @@ local og,oh,cb,cc,cac,perm1,perm2,
       ac2:=Action(Stabilizer(h,b[i],OnSets),b[i]);
       perm:=RepresentativeAction(t,ac2,ac);
       if perm=fail then
-	# cannot map onto -- wrong
-	return fail;
+        # cannot map onto -- wrong
+        return fail;
       fi;
       perm:=perm^MappingPermListList([1..c],b[i]);
       h:=h^perm;
@@ -1578,13 +1578,13 @@ end);
 #M  RepresentativeAction( <G>, <d>, <e>, <opr> ) .  . for symmetric groups
 ##
 InstallOtherMethod( RepresentativeActionOp, "for natural symmetric group",
-    true, [ IsNaturalSymmetricGroup, IsObject, IsObject, IsFunction ], 
-  # the objects might be group elements: rank up	
+    true, [ IsNaturalSymmetricGroup, IsObject, IsObject, IsFunction ],
+  # the objects might be group elements: rank up       
   {} -> 2*RankFilter(IsMultiplicativeElementWithInverse),
 function ( G, d, e, opr )
 local dom,n,sortfun,max,cd,ce,p1,p2;
   # test for internal rep
-  if HasGeneratorsOfGroup(G) and 
+  if HasGeneratorsOfGroup(G) and
     not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
     TryNextMethod();
   fi;
@@ -1594,7 +1594,7 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
   if opr=OnPoints then
     if IsInt(d) and IsInt(e) then
       if d in dom and e in dom then
-	return (d,e);
+        return (d,e);
       else
         return fail;
       fi;
@@ -1602,10 +1602,10 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
       sortfun:=function(a,b) return Length(a)<Length(b);end;
       if Order(d)=1 then #LargestMovedPoint does not work for ().
         if Order(e)=1 then
-	  return ();
-	else
-	  return fail;
-	fi;
+          return ();
+        else
+          return fail;
+        fi;
       fi;
       if CycleStructurePerm(d)<>CycleStructurePerm(e) then
         return fail;
@@ -1616,26 +1616,26 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
       Sort(cd,sortfun);
       Sort(ce,sortfun);
       return MappingPermListList(Concatenation(cd),Concatenation(ce));
-    elif IsPermGroup(d) and IsPermGroup(e) 
-      #and IsTransitive(d,dom) and IsTransitive(e,dom) 
+    elif IsPermGroup(d) and IsPermGroup(e)
+      #and IsTransitive(d,dom) and IsTransitive(e,dom)
       and IsSubset(G,d) and IsSubset(G,e) then
 
       if dom<>[1..n] then
-	# translate
-	p1:=MappingPermListList(dom,[1..n]);
-	p2:=SubgpConjSymmgp(G^p1,d^p1,e^p1);
-	if p2=false then
-	    TryNextMethod();
-	elif p2<>fail then
-	  p2:=p2^Inverse(p1);
-	fi;
-	return p2;
+        # translate
+        p1:=MappingPermListList(dom,[1..n]);
+        p2:=SubgpConjSymmgp(G^p1,d^p1,e^p1);
+        if p2=false then
+            TryNextMethod();
+        elif p2<>fail then
+          p2:=p2^Inverse(p1);
+        fi;
+        return p2;
       else
-	p2:=SubgpConjSymmgp(G,d,e);
-	if p2=false then
-	  TryNextMethod();
-	fi;
-	return p2;
+        p2:=SubgpConjSymmgp(G,d,e);
+        if p2=false then
+          TryNextMethod();
+        fi;
+        return p2;
       fi;
     fi;
   elif (opr=OnSets or opr=OnTuples) and (IsDuplicateFreeList(d) and
@@ -1651,7 +1651,7 @@ local dom,n,sortfun,max,cd,ce,p1,p2;
       return MappingPermListList(d,e);
     fi;
   fi;
-  TryNextMethod(); 
+  TryNextMethod();
 end);
 
 InstallMethod( SylowSubgroupOp,
@@ -1660,13 +1660,13 @@ InstallMethod( SylowSubgroupOp,
     [ IsNaturalSymmetricGroup, IsPosInt ], 0,
 function ( G, p )
 local   S,          # <p>-Sylow subgroup of <G>, result
-	sgs,        # strong generating set of <G>
-	q,          # power of <p>
-	mov,deg,trf, # degree, moved points, transfer
-	i;          # loop variable
+        sgs,        # strong generating set of <G>
+        q,          # power of <p>
+        mov,deg,trf, # degree, moved points, transfer
+        i;          # loop variable
 
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -1688,8 +1688,8 @@ local   S,          # <p>-Sylow subgroup of <G>, result
     # make the Sylow subgroup
     S := SubgroupNC(  G , sgs );
     SetSize(S,p^Length(sgs));
-    
-    
+   
+   
     if Size( S ) > 1 then
         SetIsPGroup( S, true );
         SetPrimePGroup( S, p );
@@ -1709,11 +1709,11 @@ function ( G )
             prt,        # partition of <G>
             sum,        # partial sum of the entries in <prt>
             rep,        # representative of a conjugacy class of <G>
-	    mov,deg,trf, # degree, moved points, transfer
+            mov,deg,trf, # degree, moved points, transfer
             i;          # loop variable
 
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -1729,8 +1729,8 @@ function ( G )
       rep := [2..deg];
       sum := 1;
       for i  in prt  do
-	  rep[sum+i-1] := sum;
-	  sum := sum + i;
+          rep[sum+i-1] := sum;
+          sum := sum + i;
       od;
       rep := PermList( rep )^trf;
 
@@ -1754,12 +1754,12 @@ InstallOtherMethod( IsomorphismFpGroup, "symmetric group,name", true,
     [ IsNaturalSymmetricGroup,IsString ], 0,
 function ( G,nam )
 local   F,      # free group
-	gens,	#generators of F
-	imgs,
-	hom,	# bijection
-	mov,deg,
-	relators,
-	i, k;       # loop variables
+        gens,   #generators of F
+        imgs,
+        hom,    # bijection
+        mov,deg,
+        relators,
+        i, k;       # loop variables
 
     if IsTrivial(G) then
       return GroupHomomorphismByFunction(G, TRIVIAL_FP_GROUP,
@@ -1767,7 +1767,7 @@ local   F,      # free group
                                          x->One(G):noassert);
     fi;
     # test for internal rep
-    if HasGeneratorsOfGroup(G) and 
+    if HasGeneratorsOfGroup(G) and
       not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
       TryNextMethod();
     fi;
@@ -1933,7 +1933,7 @@ local o,d,i,j,l,s;
     if j-1>i then
       s:=WreathProduct(s,SymmetricGroup(j-i));
     fi;
-    if d=false then 
+    if d=false then
       d:=s;
     else
       d:=DirectProduct(d,s);
@@ -1953,7 +1953,7 @@ function(G,r)
 local dom, l, sgs, nondupbase;
 
   # test for internal rep
-  if HasGeneratorsOfGroup(G) and 
+  if HasGeneratorsOfGroup(G) and
     not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
     TryNextMethod();
   fi;
@@ -1977,7 +1977,7 @@ function(G,r)
 local dom, l, sgs, nondupbase;
 
   # test for internal rep
-  if HasGeneratorsOfGroup(G) and 
+  if HasGeneratorsOfGroup(G) and
     not ForAll(GeneratorsOfGroup(G),IsInternalRep) then
     TryNextMethod();
   fi;
@@ -1987,7 +1987,7 @@ local dom, l, sgs, nondupbase;
   fi;
   dom:=Set(MovedPoints(G));
   l:=Length(dom);
-  
+ 
   if IsBound(r.base) then
       nondupbase:=DuplicateFreeList(r.base);
       dom:=Concatenation(Filtered(nondupbase,i->i in dom),Difference(dom,nondupbase));
@@ -2018,17 +2018,17 @@ local a,b,x,i;
     else
       Add(b,i);
       if Order(i)>2 then
-	Add(a,i^2);
+        Add(a,i^2);
       fi;
       if Length(b)>1 then
-	Add(a,b[1]/i);
+        Add(a,b[1]/i);
       fi;
     fi;
   od;
   a:=SubgroupNC(G,a);
   StabChainOptions(a).limit:=Size(G)/2;
   while Size(a)<Size(G)/2 do
-    repeat 
+    repeat
       #Print("close\n");
       x:=Random(GeneratorsOfGroup(a))^Random(b);
     until not x in a;
@@ -2163,7 +2163,7 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
   G:=arg[1];
   if Length(arg)>1 then
     prim:=arg[2];
-  else 
+  else
     prim:=false;
   fi;
   dom:=Set(MovedPoints(G));
@@ -2205,16 +2205,16 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     p:=Filtered(Partitions(n,2),i->i[1]<>i[2]);
     for i in p do
       if issn then
-	m:=DirectProduct(SymmetricGroup(i[1]),SymmetricGroup(i[2]));
+        m:=DirectProduct(SymmetricGroup(i[1]),SymmetricGroup(i[2]));
       else
-	if i[2]<2 then
-	  m:=AlternatingGroup(i[1]);
-	else
-	  m:=DirectProduct(AlternatingGroup(i[1]),AlternatingGroup(i[2]));
-	  # add a double transposition
-	  m:=ClosureGroupAddElm(m,(1,2)(n-1,n));
-	  SetSize(m,Factorial(i[1])*Factorial(i[2])/2);
-	fi;
+        if i[2]<2 then
+          m:=AlternatingGroup(i[1]);
+        else
+          m:=DirectProduct(AlternatingGroup(i[1]),AlternatingGroup(i[2]));
+          # add a double transposition
+          m:=ClosureGroupAddElm(m,(1,2)(n-1,n));
+          SetSize(m,Factorial(i[1])*Factorial(i[2])/2);
+        fi;
       fi;
       Add(max,m);
     od;
@@ -2227,15 +2227,15 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     for i in p do
       # exception: Table I, 1
       if n<>8 or i<>2 or issn then
-	v:=Group(SmallGeneratingSet(SymmetricGroup(i)));
-	SetSize(v,Factorial(i));
-	k:=Group(SmallGeneratingSet(SymmetricGroup(n/i)));
-	SetSize(k,Factorial(n/i));
-	m:=WreathProduct(v,k);
-	if not issn then
-	  m:=AlternatingSubgroup(m);
-	fi;
-	Add(max,m);
+        v:=Group(SmallGeneratingSet(SymmetricGroup(i)));
+        SetSize(v,Factorial(i));
+        k:=Group(SmallGeneratingSet(SymmetricGroup(n/i)));
+        SetSize(k,Factorial(n/i));
+        m:=WreathProduct(v,k);
+        if not issn then
+          m:=AlternatingSubgroup(m);
+        fi;
+        Add(max,m);
       fi;
     od;
   fi;
@@ -2252,23 +2252,23 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     m:=ClosureGroup(m,PermList(List(v,i->Position(v,i+k))));
     if Size(m)<Size(S) then
       if SignPermGroup(m)=1 then
-	# it's a subgroup of A_n, but there are two classes
-	# (the normalizer in S_n cannot increase)
-	if not issn then
-	  Add(max,m);
-	  Add(max,m^invol);
-	fi;
+        # it's a subgroup of A_n, but there are two classes
+        # (the normalizer in S_n cannot increase)
+        if not issn then
+          Add(max,m);
+          Add(max,m^invol);
+        fi;
       else
-	# the (intersection with A_n) is a maximal subgroup
-	if issn then
-	  Add(max,m);
-	else
-	  # exceptions: table I and Aff(3)=A3.
-	  if not n in [3,7,11,17,23] then
-	    m:=AlternatingSubgroup(m);
-	    Add(max,m);
-	  fi;
-	fi;
+        # the (intersection with A_n) is a maximal subgroup
+        if issn then
+          Add(max,m);
+        else
+          # exceptions: table I and Aff(3)=A3.
+          if not n in [3,7,11,17,23] then
+            m:=AlternatingSubgroup(m);
+            Add(max,m);
+          fi;
+        fi;
       fi;
     fi;
   fi;
@@ -2282,39 +2282,39 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     for i in pd do
       if IsBound(gps.series) then
         if gps.series="A" then
-	  gps:=[AlternatingGroup(gps.parameter)];
-	elif gps.series="L" then
-	  gps:=[PSL(gps.parameter[1],gps.parameter[2])];
-	elif gps.series="Z" then
-	  gps:=[];
-	fi;
+          gps:=[AlternatingGroup(gps.parameter)];
+        elif gps.series="L" then
+          gps:=[PSL(gps.parameter[1],gps.parameter[2])];
+        elif gps.series="Z" then
+          gps:=[];
+        fi;
       fi;
       if not IsList(gps) then
-	Error("code for creation of simple groups not yet implemented");
+        Error("code for creation of simple groups not yet implemented");
       else
-	# did we construct with some automorphisms?
-	for j in [1..Length(gps)] do
-	  while Size(gps[j])>n do
-	    gps[j]:=DerivedSubgroup(gps[j]);
-	  od;
-	od;
+        # did we construct with some automorphisms?
+        for j in [1..Length(gps)] do
+          while Size(gps[j])>n do
+            gps[j]:=DerivedSubgroup(gps[j]);
+          od;
+        od;
         gps:=List(gps,i->Image(SmallerDegreePermutationRepresentation(i)));
       fi;
       for j in gps do
-	m:=DiagonalSocleAction(j,i[2]+1);
-	m:=Normalizer(S,m);
-	if issn then
-	  if SignPermGroup(m)=-1 then
-	    Add(max,m);
-	  fi;
-	else
-	  if SignPermGroup(m)=-1 then
-	    Add(max,AlternatingSubgroup(m));
-	  else
-	    Add(max,m);
-	    Add(max,m^invol);
-	  fi;
-	fi;
+        m:=DiagonalSocleAction(j,i[2]+1);
+        m:=Normalizer(S,m);
+        if issn then
+          if SignPermGroup(m)=-1 then
+            Add(max,m);
+          fi;
+        else
+          if SignPermGroup(m)=-1 then
+            Add(max,AlternatingSubgroup(m));
+          else
+            Add(max,m);
+            Add(max,m^invol);
+          fi;
+        fi;
       od;
     od;
   fi;
@@ -2324,24 +2324,24 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     if i[1]>4 then # up to s_4 we get a solvable normal subgroup
       m:=WreathProductProductAction(SymmetricGroup(i[1]),SymmetricGroup(i[2]));
       if issn then
-	# add if not contained in A_n
-	if SignPermGroup(m)=-1 then
-	  Add(max,m);
-	fi;
+        # add if not contained in A_n
+        if SignPermGroup(m)=-1 then
+          Add(max,m);
+        fi;
       else
-	if SignPermGroup(m)=1 then
-	  Add(max,m);
-	  # the wreath product is alternating, so the normalizer cannot grow
-	  # and there must be a second class
-	  Add(max,m^invol);
-	else
-	  # the group is larger, so we have to intersect with A_n
-	  m:=AlternatingSubgroup(m);
-	  # but it might become imprimitive, use remark 2:
-	  if i[2]<>2 or 2<>(i[1] mod 4) or IsPrimitive(m,[1..n]) then
-	    Add(max,m);
-	  fi;
-	fi;
+        if SignPermGroup(m)=1 then
+          Add(max,m);
+          # the wreath product is alternating, so the normalizer cannot grow
+          # and there must be a second class
+          Add(max,m^invol);
+        else
+          # the group is larger, so we have to intersect with A_n
+          m:=AlternatingSubgroup(m);
+          # but it might become imprimitive, use remark 2:
+          if i[2]<>2 or 2<>(i[1] mod 4) or IsPrimitive(m,[1..n]) then
+            Add(max,m);
+          fi;
+        fi;
       fi;
     fi;
   od;
@@ -2355,10 +2355,10 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     # all type 2 nonalt groups of right parity
     k:=Factorial(n)/2;
     l:=CallFuncList(ValueGlobal("AllPrimitiveGroups"),
-	      [DegreeOperation,n,
-			  i->Size(i)<k and IsSimpleGroup(Socle(i))
-			  and not IsAbelian(Socle(i)),true,
-			  SignPermGroup,SignPermGroup(G)]);
+              [DegreeOperation,n,
+                          i->Size(i)<k and IsSimpleGroup(Socle(i))
+                          and not IsAbelian(Socle(i)),true,
+                          SignPermGroup,SignPermGroup(G)]);
 
     # remove obvious subgroups
     Sort(l,function(a,b)return Size(a)<Size(b);end);
@@ -2388,17 +2388,17 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     mf:=[];
     for i in [Length(l),Length(l)-1..1] do
       if i in sel then
-	Add(mf,l[i]);
-	for j in [1..i] do
-	  #is there a permisomorphic primitive subgroup?
-	  k:=IsomorphicSubgroups(l[i],l[j]);
-	  k:=List(k,Image);
-	  if ForAny(k,x->IsTransitive(x,[1..n]) and IsPrimitive(x,[1..n]) and
-	              PrimitiveIdentification(x)=PrimitiveIdentification(l[j]))
-		      then
-	    RemoveSet(sel,j);
-	  fi;
-	od;
+        Add(mf,l[i]);
+        for j in [1..i] do
+          #is there a permisomorphic primitive subgroup?
+          k:=IsomorphicSubgroups(l[i],l[j]);
+          k:=List(k,Image);
+          if ForAny(k,x->IsTransitive(x,[1..n]) and IsPrimitive(x,[1..n]) and
+                      PrimitiveIdentification(x)=PrimitiveIdentification(l[j]))
+                      then
+            RemoveSet(sel,j);
+          fi;
+        od;
       fi;
     od;
   else
@@ -2419,11 +2419,11 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
       # is a larger primitive group in S_n
       k:=CallFuncList(ValueGlobal("AllPrimitiveGroups"),
        [NrMovedPoints,n,SocleTypePrimitiveGroup,
-	  SocleTypePrimitiveGroup(m),SignPermGroup,-1]);
+          SocleTypePrimitiveGroup(m),SignPermGroup,-1]);
       k:=List(k,i->AlternatingSubgroup(i));
       if ForAll(k,j->not IsTransitive(j,[1..n]) or not IsPrimitive(j,[1..n])
-	      or PrimitiveIdentification(j)<>PrimitiveIdentification(m)) then
-	Add(max,m^invol);
+              or PrimitiveIdentification(j)<>PrimitiveIdentification(m)) then
+        Add(max,m^invol);
       fi;
     od;
   fi;

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4390,6 +4390,34 @@ DeclareOperation(
 
 DeclareGlobalFunction( "IsomorphismFpGroupByPcgs" );
 
+#############################################################################
+##
+#A  IsomorphismFpGroupForRewriting( <G> )
+##
+##  <#GAPDoc Label="IsomorphismFpGroupForRewriting">
+##  <ManSection>
+##  <Attr Name="IsomorphismFpGroupForRewriting" Arg='G'/>
+##
+##  <Description>
+##  returns an isomorphism from the given finite group <A>G</A> to a finitely
+##  presented group isomorphic to <A>G</A>. If possible, generators are
+##  chosen to lead to a monoid presentation that leads to a short
+##  set of confluent rewriting rules.
+##  <Example><![CDATA[
+##  gap> g := AlternatingGroup(5);;
+##  gap> iso := IsomorphismFpGroupForRewriting( g );
+##  [ (1,2,3), (1,2)(3,4), (1,2)(4,5) ] -> [ A_5.1, A_5.2, A_5.3 ]
+##  gap> fp := Image( iso );;
+##  gap> RelatorsOfFpGroup( fp );
+##  [ A_5.1^3, A_5.2^2, A_5.3^2, (A_5.1*A_5.2)^3, (A_5.1*A_5.3)^2,
+##    (A_5.2*A_5.3)^3 ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareAttribute( "IsomorphismFpGroupForRewriting", IsGroup );
+
 
 #############################################################################
 ##

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -191,6 +191,9 @@ local hom,gp,f;
   if HasIsFinite(gp) and not IsFinite(gp) then
     return fail;
   fi;
+  if HasIsomorphismPermGroup(gp) then return IsomorphismPermGroup(gp); fi;
+  if HasIsomorphismPcGroup(gp) then return IsomorphismPcGroup(gp); fi;
+
   if HasSize(gp) then
     f:=Factors(Size(gp));
     if Length(Set(f))=1 then

--- a/lib/grppcext.gi
+++ b/lib/grppcext.gi
@@ -53,11 +53,11 @@ InstallGlobalFunction(MappedPcElement,function( elm, pcgs, list )
     new := false;
     for i in [1..Length(vec)] do
       if vec[i]>0 then
-	if new=false then
-	  new := list[i]^vec[i];
+        if new=false then
+          new := list[i]^vec[i];
         else
-	  new := new * list[i]^vec[i];
-	fi;
+          new := new * list[i]^vec[i];
+        fi;
       fi;
     od;
     if new=false then
@@ -78,7 +78,7 @@ local vec, i,j;
   for i in [1..Length(vec)] do
     if vec[i]>0 then
       for j in [1..vec[i]] do
-	pt:=pt^list[i];
+        pt:=pt^list[i];
       od;
     fi;
   od;
@@ -226,40 +226,40 @@ BindGlobal( "FastExtSQ", function( G, M, c,check )
 
     for i in [1..n] do
       for j in [1..i] do
-	if i=j then
-	  exp:=ExponentsOfRelativePower(pcgs,i);
-	else
-	  exp:=ExponentsOfConjugate(pcgs,i,j);
-	fi;
-	w:=[];
-	# start at j -- there cannot be earlier entries.
-	for k in [j..n] do
-	  if exp[k]<>0 then
-	    Add(w,k);
-	    Add(w,exp[k]);
-	  fi;
-	od;
+        if i=j then
+          exp:=ExponentsOfRelativePower(pcgs,i);
+        else
+          exp:=ExponentsOfConjugate(pcgs,i,j);
+        fi;
+        w:=[];
+        # start at j -- there cannot be earlier entries.
+        for k in [j..n] do
+          if exp[k]<>0 then
+            Add(w,k);
+            Add(w,exp[k]);
+          fi;
+        od;
 
-	if not IsInt(c) then # add cocycle info
-	  p := (i^2-i)/2 + j - 1;
-	  for k  in [ 1 .. d ]  do
-	    l := c[p*d+k];
-	    if l <> z then
-	      Add( w, n+k );
-	      Add( w, IntFFE(l) );
-	    fi;
-	  od;
-	fi;
+        if not IsInt(c) then # add cocycle info
+          p := (i^2-i)/2 + j - 1;
+          for k  in [ 1 .. d ]  do
+            l := c[p*d+k];
+            if l <> z then
+              Add( w, n+k );
+              Add( w, IntFFE(l) );
+            fi;
+          od;
+        fi;
 
-	if Length(w)>0 then # other relators are considered trivial
-	  if i=j then
-	    w:=ObjByExtRep(fam,w);
-	    SetPower(col,i,w);
-	  elif w<>[i,1] then
-	    w:=ObjByExtRep(fam,w);
-	    SetConjugate(col,i,j,w);
-	  fi;
-	fi;
+        if Length(w)>0 then # other relators are considered trivial
+          if i=j then
+            w:=ObjByExtRep(fam,w);
+            SetPower(col,i,w);
+          elif w<>[i,1] then
+            w:=ObjByExtRep(fam,w);
+            SetConjugate(col,i,j,w);
+          fi;
+        fi;
       od;
     od;
 
@@ -269,18 +269,18 @@ BindGlobal( "FastExtSQ", function( G, M, c,check )
     # add operation of <G> on module
     for i  in [ 1 .. n ]  do
       for j  in [ 1 .. d ]  do
-	v := Mgens[i][j];
-	w := [];
-	for k  in [ 1 .. d ]  do
-	  l := v[k];
-	  if l <> z then
-	    Add( w, n+k );
-	    Add( w, IntFFE(l) );
-	  fi;
-	od;
-	if Length(w)>0 and w<>[n+j,1] then
-	  w:=ObjByExtRep(fam,w);
-	  SetConjugate(col,n+j,i,w);
+        v := Mgens[i][j];
+        w := [];
+        for k  in [ 1 .. d ]  do
+          l := v[k];
+          if l <> z then
+            Add( w, n+k );
+            Add( w, IntFFE(l) );
+          fi;
+        od;
+        if Length(w)>0 and w<>[n+j,1] then
+          w:=ObjByExtRep(fam,w);
+          SetConjugate(col,n+j,i,w);
         fi;
       od;
     od;
@@ -377,66 +377,66 @@ local ag, p1iso, agp, p2iso, DP, p1, p2, gens, genimgs, triso,s,i,u,opt,
       gens:=Pcgs(DP);
 
       genimgs:=List(gens,
-	  i->ImagesRepresentative(Embedding(D,1),
-	  PreImagesRepresentative(p1iso,
-	    PreImagesRepresentative(pc1,ImagesRepresentative(p1,i))))
-	    *ImagesRepresentative(Embedding(D,2),
-		PreImagesRepresentative(p2iso,
-		PreImagesRepresentative(pc2,ImagesRepresentative(p2,i)))) );
+          i->ImagesRepresentative(Embedding(D,1),
+          PreImagesRepresentative(p1iso,
+            PreImagesRepresentative(pc1,ImagesRepresentative(p1,i))))
+            *ImagesRepresentative(Embedding(D,2),
+                PreImagesRepresentative(p2iso,
+                PreImagesRepresentative(pc2,ImagesRepresentative(p2,i)))) );
 
     else
       opt:=rec(limit:=s,random:=1);
       if HasBaseOfGroup(agp) then
-	opt.knownBase:=BaseOfGroup(agp);
+        opt.knownBase:=BaseOfGroup(agp);
       fi;
       #p1iso:=p1iso*SmallerDegreePermutationRepresentation(agp);
       EraseNaturalHomomorphismsPool(agp);
       if s>1 then
-	repeat
-	  u:=Group(());
-	  gens:=[];
-	  for i in GeneratorsOfGroup(agp) do
-	    if Size(u)<s and not i in u then
-	      Add(gens,i);
-	      u:=DoClosurePrmGp(u,[i],opt);
-	    fi;
-	  od;
-	  if HasBaseOfGroup(agp) then
-	    SetBaseOfGroup(u,BaseOfGroup(agp));
-	  fi;
-	  #Print("rep ",Size(u)," ",s,"\n");
-	until Size(u)=s;
-	agp:=u;
+        repeat
+          u:=Group(());
+          gens:=[];
+          for i in GeneratorsOfGroup(agp) do
+            if Size(u)<s and not i in u then
+              Add(gens,i);
+              u:=DoClosurePrmGp(u,[i],opt);
+            fi;
+          od;
+          if HasBaseOfGroup(agp) then
+            SetBaseOfGroup(u,BaseOfGroup(agp));
+          fi;
+          #Print("rep ",Size(u)," ",s,"\n");
+        until Size(u)=s;
+        agp:=u;
       else
-	gens:=GeneratorsOfGroup(agp);
+        gens:=GeneratorsOfGroup(agp);
       fi;
       Info( InfoMatOrb, 1, "found ",Length(gens)," generators");
 
       DP:=DirectProduct(agp,gp2);
 #      SetIsSolvableGroup(DP,IsSolvableGroup(agp)
-#	and IsSolvableGroup(ImagesSource(p2iso)));
+#       and IsSolvableGroup(ImagesSource(p2iso)));
       p1:=Projection(DP,1);
       p2:=Projection(DP,2);
 #      if IsSolvableGroup(DP) then
-#	gens:=Pcgs(DP);
+#       gens:=Pcgs(DP);
 #      else
-	gens:=GeneratorsOfGroup(DP);
+        gens:=GeneratorsOfGroup(DP);
 #      fi;
       Unbind(ag);Unbind(agp);
 
       genimgs:=List(gens,
-	  i->ImagesRepresentative(Embedding(D,1),
-		PreImagesRepresentative(p1iso,ImagesRepresentative(p1,i)))
-	    *ImagesRepresentative(Embedding(D,2),
-		PreImagesRepresentative(p2iso,ImagesRepresentative(p2,i))) );
+          i->ImagesRepresentative(Embedding(D,1),
+                PreImagesRepresentative(p1iso,ImagesRepresentative(p1,i)))
+            *ImagesRepresentative(Embedding(D,2),
+                PreImagesRepresentative(p2iso,ImagesRepresentative(p2,i))) );
 
     fi;
     triso:=GroupHomomorphismByImagesNC(DP,D,gens,genimgs);
     SetIsBijective(triso,true);
     return rec(pairgens:=genimgs,
-	       permgens:=gens,
+               permgens:=gens,
                isomorphism:=triso,
-	       permgroup:=DP);
+               permgroup:=DP);
   else
     return false;
   fi;
@@ -459,7 +459,7 @@ local hom, sel, u, gens, i;
       r.permgroup:=Image(hom,r.permgroup);
       r.permgens:=List(r.permgens,i->Image(hom,i));
       if IsBound(r.isomorphism) then
-	r.isomorphism:=RestrictedInverseGeneralMapping(hom)*r.isomorphism;
+        r.isomorphism:=RestrictedInverseGeneralMapping(hom)*r.isomorphism;
       fi;
     fi;
 
@@ -469,13 +469,13 @@ local hom, sel, u, gens, i;
     gens:=r.permgens;
     for i in Reversed([1..Length(gens)]) do
       if not gens[i] in u then
-	u:=ClosureSubgroupNC(u,gens[i]);
-	Add(sel,i);
+        u:=ClosureSubgroupNC(u,gens[i]);
+        Add(sel,i);
       fi;
     od;
     for i in Reversed(sel) do
       if Size(r.permgroup)=Size(Difference(sel,[i])) then
-	RemoveSet(sel,i);
+        RemoveSet(sel,i);
       fi;
     od;
     if Length(sel)<Length(gens) then
@@ -558,7 +558,7 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
         D := DirectProduct( A, B );
     else
         D := arg[3];
-	A := DirectProductInfo(D).groups[1];
+        A := DirectProductInfo(D).groups[1];
     fi;
 
     # the trivial case
@@ -590,80 +590,80 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
       if Size(K)>1 then
 
         # get its stabilizer
-	if IsPcGroup(K) then
-	  K1:=CanonicalPcgsWrtFamilyPcgs(Centre(K));
+        if IsPcGroup(K) then
+          K1:=CanonicalPcgsWrtFamilyPcgs(Centre(K));
           K1nontriv:=Length(K1)>0;
-	  K2:=CanonicalPcgsWrtFamilyPcgs(K);
-	  f := function( pt, a ) 
-		 return CanonicalPcgsWrtFamilyPcgs(Group(List(pt,i->Image( a[1], i )))); 
-	       end;
-	else
-	  K1:=Centre(K);
+          K2:=CanonicalPcgsWrtFamilyPcgs(K);
+          f := function( pt, a ) 
+                 return CanonicalPcgsWrtFamilyPcgs(Group(List(pt,i->Image( a[1], i )))); 
+               end;
+        else
+          K1:=Centre(K);
           K1nontriv:=Size(K1)>1;
-	  K2:=K;
-	  f := function( pt, a ) return Image( a[1], pt ); end;
-	fi;
+          K2:=K;
+          f := function( pt, a ) return Image( a[1], pt ); end;
+        fi;
 
-	if K1nontriv and K1<>K2 then
-	  tmp := Stabilizer( D, K1,gens,genimgs, f );
+        if K1nontriv and K1<>K2 then
+          tmp := Stabilizer( D, K1,gens,genimgs, f );
 
-	  if Size(tmp)<Size(D) then
-	    Info( InfoMatOrb, 1, "    CompP: found orbit of centre of length ",
-		  Size(D)/Size( tmp ));
-	    D := tmp;
-	    if translate<>false then
-	      if HasIsSolvableGroup(D) and IsSolvableGroup(D) then
-		gens:=Pcgs(D);
-	      else
-		gens:=GeneratorsOfGroup(D);
-	      fi;
-	      genimgs:=List(gens,i->ImageElm(triso,i));
-	      translate:=rec(pairgens:=genimgs,
-		             permgens:=gens,
-			     isomorphism:=triso,
-		             permgroup:=D);
-	      EXReducePermutationActionPairs(translate);
-	      gens:=translate.permgens;
-	      genimgs:=translate.pairgens;
-	      triso:=translate.isomorphism;
-	      D:=translate.permgroup;
-	    else
-	      gens:=GeneratorsOfGroup(D);
-	      genimgs:=gens;
-	    fi;
-	  fi;
-	  tmp:=false; # clear memory
+          if Size(tmp)<Size(D) then
+            Info( InfoMatOrb, 1, "    CompP: found orbit of centre of length ",
+                  Size(D)/Size( tmp ));
+            D := tmp;
+            if translate<>false then
+              if HasIsSolvableGroup(D) and IsSolvableGroup(D) then
+                gens:=Pcgs(D);
+              else
+                gens:=GeneratorsOfGroup(D);
+              fi;
+              genimgs:=List(gens,i->ImageElm(triso,i));
+              translate:=rec(pairgens:=genimgs,
+                             permgens:=gens,
+                             isomorphism:=triso,
+                             permgroup:=D);
+              EXReducePermutationActionPairs(translate);
+              gens:=translate.permgens;
+              genimgs:=translate.pairgens;
+              triso:=translate.isomorphism;
+              D:=translate.permgroup;
+            else
+              gens:=GeneratorsOfGroup(D);
+              genimgs:=gens;
+            fi;
+          fi;
+          tmp:=false; # clear memory
 
-	fi;
+        fi;
 
         tmp := Stabilizer( D, K2,gens,genimgs, f );
 
-	if Size(tmp)<Size(D) then
-	  Info( InfoMatOrb, 1, "    CompP: found orbit of length ",
-		Size(D)/Size(tmp));
-	  D := tmp;
-	  if translate<>false then
-	    if HasIsSolvableGroup(D) and IsSolvableGroup(D) then
-	      gens:=Pcgs(D);
-	    else
-	      gens:=GeneratorsOfGroup(D);
-	    fi;
-	    genimgs:=List(gens,i->ImageElm(triso,i));
-	    translate:=rec(pairgens:=genimgs,
-			    permgens:=gens,
-			    isomorphism:=triso,
-			    permgroup:=D);
-	    EXReducePermutationActionPairs(translate);
-	    gens:=translate.permgens;
-	    genimgs:=translate.pairgens;
-	    triso:=translate.isomorphism;
-	    D:=translate.permgroup;
-	  else
-	    gens:=GeneratorsOfGroup(D);
-	    genimgs:=gens;
-	  fi;
-	fi;
-	tmp:=false; # clear memory
+        if Size(tmp)<Size(D) then
+          Info( InfoMatOrb, 1, "    CompP: found orbit of length ",
+                Size(D)/Size(tmp));
+          D := tmp;
+          if translate<>false then
+            if HasIsSolvableGroup(D) and IsSolvableGroup(D) then
+              gens:=Pcgs(D);
+            else
+              gens:=GeneratorsOfGroup(D);
+            fi;
+            genimgs:=List(gens,i->ImageElm(triso,i));
+            translate:=rec(pairgens:=genimgs,
+                            permgens:=gens,
+                            isomorphism:=triso,
+                            permgroup:=D);
+            EXReducePermutationActionPairs(translate);
+            gens:=translate.permgens;
+            genimgs:=translate.pairgens;
+            triso:=translate.isomorphism;
+            D:=translate.permgroup;
+          else
+            gens:=GeneratorsOfGroup(D);
+            genimgs:=gens;
+          fi;
+        fi;
+        tmp:=false; # clear memory
 
       fi;
     fi;
@@ -686,17 +686,17 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
       epi:=EpimorphismFromFreeGroup(G);
       Assert(1,MappingGeneratorsImages(epi)[2]=Ggens);
       f:=function( tup, elm )
-      local gens;
-        #gens := List( tup[1], x -> PreImagesRepresentative( elm[1], x ) );
-        #gens := List( gens, x -> MappedPcElement( x, tup[1], tup[2] ) );
-        gens := List( Ggens, x -> PreImagesRepresentative( elm[1], x ) );
-        gens := List( gens, x -> MappedWord( PreImagesRepresentative(epi,x),
-          GeneratorsOfGroup(Source(epi)), tup ) );
-        gens := List( gens, x -> x ^ elm[2] );
-        return gens;
-        #return Tuple( [tup[1], gens] );
-      end;
-        
+          local gens;
+            #gens := List( tup[1], x -> PreImagesRepresentative( elm[1], x ) );
+            #gens := List( gens, x -> MappedPcElement( x, tup[1], tup[2] ) );
+            gens := List( Ggens, x -> PreImagesRepresentative( elm[1], x ) );
+            gens := List( gens, x -> MappedWord( PreImagesRepresentative(epi,x),
+              GeneratorsOfGroup(Source(epi)), tup ) );
+            gens := List( gens, x -> x ^ elm[2] );
+            return gens;
+            #return Tuple( [tup[1], gens] );
+          end;
+
       elif Size(G)>20000 then
         # if G is too large we cannot write out elements
         elmlist:=fail; 
@@ -710,30 +710,30 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
 
       f:=function( tup, elm )
       local gens,i,p;
-	p:=PositionProperty(preimlist,x->IsIdenticalObj(x[1],elm[1]));
-	if p=fail then
-	  gens := List( Ggens, x -> PreImagesRepresentative( elm[1], x ) );
-	else
-	  gens:=preimlist[p][2];
-	fi;
-	gens:=List(gens,x->TracedPointPcElement(x,Ggens,elmlist{tup},baspt));
-	gens:=List(gens,x->x^elm[2]);
+        p:=PositionProperty(preimlist,x->IsIdenticalObj(x[1],elm[1]));
+        if p=fail then
+          gens := List( Ggens, x -> PreImagesRepresentative( elm[1], x ) );
+        else
+          gens:=preimlist[p][2];
+        fi;
+        gens:=List(gens,x->TracedPointPcElement(x,Ggens,elmlist{tup},baspt));
+        gens:=List(gens,x->x^elm[2]);
 
-	return gens;
+        return gens;
 
-	# tup:=ShallowCopy(tup); # get memory
-	# avoid duplicate matrices
-	# for i in [1..Length(gens)] do
-	#   p:=PositionSorted(elmlist,gens[i]);
-	#   if p<>fail and p<=Length(elmlist) and elmlist[p]=gens[i] then
-	#     tup[i]:=p;
-	#   else
-	#     AddSet(elmlist,gens[i]);
-	#     p:=PositionSorted(elmlist,gens[i]);
-	#     tup[i]:=p;
-	#   fi;
-	# od;
-	# return tup;
+        # tup:=ShallowCopy(tup); # get memory
+        # avoid duplicate matrices
+        # for i in [1..Length(gens)] do
+        #   p:=PositionSorted(elmlist,gens[i]);
+        #   if p<>fail and p<=Length(elmlist) and elmlist[p]=gens[i] then
+        #     tup[i]:=p;
+        #   else
+        #     AddSet(elmlist,gens[i]);
+        #     p:=PositionSorted(elmlist,gens[i]);
+        #     tup[i]:=p;
+        #   fi;
+        # od;
+        # return tup;
 
       end;
 
@@ -848,19 +848,19 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
     if translate<>false then
       l:=Size(D);
       if Length(gens)>3 then
-	# reduce generator number
-	
-	u:=SmallGeneratingSet(D);
-	if IsSubset(gens,u) then
-	  Info( InfoMatOrb, 3, "Reduce generators subset");
-	  idx:=List(u,x->Position(gens,x));
-	  gens:=gens{idx};
-	  genimgs:=genimgs{idx};
-	else
-	  Info( InfoMatOrb, 3, "Reduce generators new words");
-	  gens:=u;
-	  genimgs:=List(gens,i->ImageElm(triso,i));
-	fi;
+        # reduce generator number
+        
+        u:=SmallGeneratingSet(D);
+        if IsSubset(gens,u) then
+          Info( InfoMatOrb, 3, "Reduce generators subset");
+          idx:=List(u,x->Position(gens,x));
+          gens:=gens{idx};
+          genimgs:=genimgs{idx};
+        else
+          Info( InfoMatOrb, 3, "Reduce generators new words");
+          gens:=u;
+          genimgs:=List(gens,i->ImageElm(triso,i));
+        fi;
       fi;
       tmp:=SubgroupNC(Range(triso),genimgs);
       SetIsGroupOfAutomorphismsFiniteGroup(tmp,true);
@@ -869,7 +869,7 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
       # later
       tmp!.permrep:=rec(pairgens:=genimgs,
                       permgens:=gens,
-		      permgroup:=D);
+                      permgroup:=D);
       D:=tmp;
     fi;
     Info( InfoMatOrb, 1, "Total index: ",Dos/Size(D));

--- a/lib/grppcrep.gi
+++ b/lib/grppcrep.gi
@@ -190,12 +190,15 @@ end );
 #F TrivialModule( <n>, <F> ) . . . . . . . . . . . trivial module with n gens
 ##
 InstallGlobalFunction( TrivialModule, function( n, F )
-    return rec( field := F,
-                dimension := 1,
-                generators := ListWithIdenticalEntries( n,
-                                  Immutable( IdentityMat( 1, F ) ) ),
-                isMTXModule := true,
-                basis := [[One(F)]] );
+local r;
+    r:=rec( field := F,
+      dimension := 1,
+      generators := ListWithIdenticalEntries( n,
+                        Immutable( IdentityMat( 1, F ) ) ),
+      isMTXModule := true,
+      basis := [[One(F)]] );
+  if IsFinite(F) then r.IsOverFiniteField:=true;fi;
+  return r;
 end );
 
 #############################################################################

--- a/lib/grpreps.gi
+++ b/lib/grpreps.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  This file is part of GAP, a system for computational discrete algebra.
-##  This files's authors include Bettina Eick.
+##  This files's authors include Bettina Eick and Alexander Hulpke.
 ##
 ##  Copyright of GAP belongs to its developers, whose names are too numerous
 ##  to list here. Please refer to the COPYRIGHT file for details.
@@ -44,21 +44,194 @@ end);
 ##
 #M IrreducibleModules( <G>, <F>, <dim> ). . . .constituents of regular module
 ##
-InstallMethod( IrreducibleModules,
-    "generic method for groups and finite field",
-    true, 
-    [ IsGroup, IsField and IsFinite, IsInt ],
-    0,
+InstallMethod(IrreducibleModules,"generic method for groups and finite field",
+    true, [ IsGroup, IsField and IsFinite, IsInt ], 0,
 function( G, F, dim )
-    local modu, modus,gens;
-    modu := RegularModule( G, F );
-    gens:=modu[1];
-    modu:=modu[2];
-    modus := List( MTX.CollectedFactors( modu ), x -> x[1] );
-    if dim > 0 then
-        modus := Filtered( modus, x -> MTX.Dimension(x) <= dim );
+local modu, modus,gens,v,subs,sub,ser,i,j,a,si,dims,cf,mats,clos,bas,rad;
+
+  if dim=1 then
+    # linear representations come from G/G'
+    gens:=GeneratorsOfGroup(G);
+    a:=DerivedSubgroup(G);
+    if Size(a)=Size(G) then 
+      return [gens,[TrivialModule(Length(gens),F)]];
+    else
+      a:=MaximalAbelianQuotient(G);
+      si:=List(gens,x->ImagesRepresentative(a,x));
+      sub:=IrreducibleModules(Group(si),F,1);
+      if sub[1]=si then
+        return [gens,sub[2]];
+      else
+        modu:=[];
+        for i in sub[2] do
+          v:=GroupHomomorphismByImages(Image(a),Group(i.generators),sub[1],i.generators);
+          Add(modu,GModuleByMats(List(si,x->ImagesRepresentative(v,x)),F));
+        od;
+        return [gens,modu];
+      fi;
     fi;
-    return [gens,modus];
+
+  fi;
+
+  modu := RegularModule( G, F );
+  gens:=modu[1];
+  modu:=modu[2];
+
+  # The augmentation ideal of a P-normal subgroup lies in the radical
+  if Characteristic(F)=0 then
+    si:=TrivialSubgroup(G);
+  else
+    si:=PCore(G,Characteristic(F));
+  fi;
+
+  mats:=modu.generators;
+  bas:=One(modu.generators[1]);
+  rad:=0;
+
+  if Size(si)>1 then
+
+    # get augmentation ideal of subgroup, at least approximate from
+    # generators
+    a:=AsList(G);
+    cf:=Set(List(GeneratorsOfGroup(si),x->Position(a,x)));
+
+    for i in cf do
+      v:=ShallowCopy(Zero(modu.generators[1][1]));
+      v[Position(a,One(si))]:=One(F);v[i]:=-One(F);
+      v:=SolutionMat(bas,v){[rad+1..Length(bas)]};
+      if not IsZero(v) then
+        sub:=MTX.SpinnedBasis(v,mats,modu.field);
+
+        # extend to full basis
+        clos:=BaseSteinitzVectors(One(mats[1]),sub).factorspace;
+        j:=ImmutableMatrix(modu.field,Concatenation(sub,clos))^-1;
+        # cut out factor bit
+        mats:=List(mats,x->x^j);
+        j:=[Length(sub)+1..Length(mats[1])];
+        mats:=List(mats,x->ImmutableMatrix(modu.field,x{j}{j}));
+
+        # translate in old basis
+        j:=bas{[rad+1..Length(bas)]};
+        sub:=List(sub,x->x*j);
+        clos:=List(clos,x->x*j);
+
+        bas:=Concatenation(bas{[1..rad]},sub,clos);
+        rad:=rad+Length(sub);
+       
+      fi;
+    od;
+  fi;
+
+  a:=Length(mats[1]);
+  Info(InfoMeatAxe,1,"Work in factor dimension ",a);
+  subs:=[];
+  # It is quite likely that a vector [1,-1] spans a submodule
+  # want that n(n+1)>2> dim/1000
+  j:=QuoInt(a,1000);
+  for i in [1..First([1..a],n->n*(n+1)/2>j)] do
+    v:=ShallowCopy(Zero(modu.generators[1][1]));
+    v[1]:=One(F);v[Random([2..a])]:=-One(F);
+    v:=SolutionMat(bas,v){[rad+1..Length(bas)]};
+    if not IsZero(v) then
+      sub:=MTX.SpinnedBasis(v,mats,modu.field);
+      sub:=ImmutableMatrix(modu.field,TriangulizedMat(sub));
+      if not sub in subs then 
+        Add(subs,sub);
+      fi;
+    fi;
+  od;
+
+  Info(InfoMeatAxe,1,"submodules:",List(subs,Length));
+
+  if Length(subs)>0 then
+    # close under sums/intersections to form series
+    ser:=[[],subs[1],One(mats[1])];
+    for i in [2..Length(subs)] do
+      a:=subs[i];
+      j:=2;
+      while j<Length(ser) and a<>fail do
+        si:=List(SumIntersectionMat(ser[j],a),
+          x->ImmutableMatrix(modu.field,TriangulizedMat(x)));
+        if Length(si[2])>Length(ser[j-1]) and Length(si[2])<Length(ser[j]) then
+          ser:=Concatenation(ser{[1..j-1]},[si[2]],ser{[j..Length(ser)]});
+          j:=j+1;
+        fi;
+        if si[1]=ser[j] or si[1]=ser[j+1] then
+          a:=fail; # in this or next step, no further refinement
+        else
+          a:=si[1];
+        fi;
+        j:=j+1;
+      od;
+    od;
+
+    dims:=List(ser,Length);
+    Info(InfoMeatAxe,1,"series:",dims);
+
+    # find a basis reflecting the series
+    si:=[];
+    for i in [2..Length(ser)] do
+      Add(si,BaseSteinitzVectors(ser[i],ser[i-1]).factorspace);
+    od;
+
+    # base change
+    si:=ImmutableMatrix(modu.field,Concatenation(si))^-1;
+    mats:=List(mats,x->x^si);
+    modus:=[];
+    for i in [2..Length(dims)] do
+      si:=[dims[i-1]+1..dims[i]];
+      modu:=GModuleByMats(List(mats,x->x{si}{si}),modu.field);
+      cf:=List(MTX.CollectedFactors(modu),x->x[1]);
+      if dim>0 then cf:=Filtered(cf,x->MTX.Dimension(x)<=dim);fi;
+      for j in cf do
+        if ForAll(modus,
+          x->x.dimension<>j.dimension or MTX.Isomorphism(x,j)=fail) then
+            Add(modus,j);
+        fi;
+      od;
+    od;
+
+  else
+    modus:=List(MTX.CollectedFactors(modu),x->x[1]);
+  fi;
+  SortBy(modus,x->x.dimension);
+  if dim>0 then modus:=Filtered(modus,x->MTX.Dimension(x)<=dim);fi;
+
+  return [gens,modus];
+end);
+
+InstallMethod(IrreducibleModules,
+  "permutation group, finite field, Burnside-Brauer",
+    true, [ IsPermGroup, IsField and IsFinite, IsInt ], 2,
+function(G,field,dim)
+local n,mats,mo,moduln,i,j,k,t;
+  if dim=1 then TryNextMethod();fi; # special abelian case
+  n:=LargestMovedPoint(G);
+  mats:=List(GeneratorsOfGroup(G),x->PermutationMat(x,n,field));
+  n:=Length(mats);
+  mo:=GModuleByMats(mats,field);
+  moduln:=List(MTX.CollectedFactors(mo),x->x[1]);
+  i:=1;
+  while i<=Length(moduln) do
+    j:=1;
+    while j<=i do
+      t:=GModuleByMats(List([1..n],x->KroneckerProduct(moduln[i].generators[x],
+        moduln[j].generators[x])),field);
+      t:=List(MTX.CollectedFactors(t),x->x[1]);
+      Info(InfoMeatAxe,i," ",j," ",List(t,x->x.dimension));
+      for k in t do
+        MTX.IsIrreducible(k);
+        if ForAll(moduln,x->MTX.Isomorphism(k,x)=fail) then 
+          Add(moduln,k);
+        fi;
+      od;
+      j:=j+1;
+    od;
+    i:=i+1;
+  od;
+  SortBy(moduln,x->x.dimension);
+  if dim>0 then moduln:=Filtered(moduln,x->MTX.Dimension(x)<=dim);fi;
+  return [GeneratorsOfGroup(G),moduln];
 end);
 
 

--- a/lib/grpreps.gi
+++ b/lib/grpreps.gi
@@ -92,12 +92,13 @@ local modu, modus,gens,v,subs,sub,ser,i,j,a,si,dims,cf,mats,clos,bas,rad;
 
     # get augmentation ideal of subgroup, at least approximate from
     # generators
-    a:=AsList(G);
-    cf:=Set(List(GeneratorsOfGroup(si),x->Position(a,x)));
+    a:=Enumerator(G);
+    cf:=Set(GeneratorsOfGroup(si),x->Position(a,x));
 
     for i in cf do
       v:=ShallowCopy(Zero(modu.generators[1][1]));
-      v[Position(a,One(si))]:=One(F);v[i]:=-One(F);
+      Assert(0, Position(a,One(si)) = 1);
+      v[1]:=One(F);v[i]:=-One(F);
       v:=SolutionMat(bas,v){[rad+1..Length(bas)]};
       if not IsZero(v) then
         sub:=MTX.SpinnedBasis(v,mats,modu.field);

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -2445,6 +2445,17 @@ SMTX_Homomorphisms:= function(m1, m2)
 
    dim1:=SMTX.Dimension(m1); dim2:=SMTX.Dimension(m2);
 
+   if dim1=1 then
+     # m1 is 1-dimensional -- eigenspace intersection
+     el:=List([1..Length(m1.generators)],x->NullspaceMat(m2.generators[x]-m1.generators[x][1][1]*m2.generators[x]^0));
+
+     imvecs:=el[1];
+     for j in [2..Length(el)] do
+       imvecs:=SumIntersectionMat(imvecs,el[j])[2];
+     od;
+     return List(imvecs,x->ImmutableMatrix(m1.field,[x]));
+   fi;
+
    m1bas:=[];
    m1bas[1]:= SMTX.AlgElNullspaceVec(m1);
 

--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -156,7 +156,9 @@ DeclareOperation( "TwoCoboundaries", [ IsPcGroup, IsObject ] );
 ##  <Oper Name="TwoCohomology" Arg='G, M'/>
 ##
 ##  <Description>
-##  returns a record defining the second cohomology group as factor space of 
+##  This operation computes the second cohomology group for the special
+##  case of a Pc Group.
+##  It returns a record defining the second cohomology group as factor space of 
 ##  the space of cocycles by the space of coboundaries.
 ##  <A>G</A> must be a pc group and the generators of <A>M</A> must
 ##  correspond to the pcgs of <A>G</A>.
@@ -184,3 +186,123 @@ DeclareOperation( "TwoCoboundaries", [ IsPcGroup, IsObject ] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "TwoCohomology", [ IsPcGroup, IsObject ] );
+
+#############################################################################
+##
+#O  TwoCohomologyGeneric( <G>, <M> )
+##
+##  <#GAPDoc Label="TwoCohomologyGeneric">
+##  <ManSection>
+##  <Oper Name="TwoCohomologyGeneric" Arg='G, M'/>
+##
+##  <Description>
+##  This function computes the second cohomology group for an arbitrary
+##  finite group <A>G</A>. The generators of the module <A>M</A> must
+##  correspond to the generators of <A>G</A>.
+##  
+##  It returns a record with components <C>coboundaries</C>,
+##  <C>cocycles</C> and <C>cohomology</C> which are lists of vectors that form a
+##  basis of the respective group. <C>cohomology</C> is chosen as a vector space
+##  complement to <C>coboundaries</C> in the <C>cocycles</C>.
+##  These vectors are representing tails in <A>M</A> with respect to the
+##  <C>relators</C> of the presentation <C>presentation</C> of <A>G</A>.
+##  (Note that this presentation is on a generating set chosen by the
+##  routine, this generating system corresponds to the components
+##  <C>group</C> and <C>module</C> of the record returned.
+##  The extension corresponding to a cocyle <C>c</C> can be constructed as
+##  <C>Extension(r,c)</C> where <C>r</C> is the cohomology record. This is
+##  currently done as a finitely presented group.
+##  <Example><![CDATA[
+##  gap> g:=Group((1,2,3,4,5),(1,2,3));;
+##  gap> mats:=[[[2,0,0,1],[1,2,1,0],[2,1,1,1],[2,1,1,0]],
+##  > [[0,2,0,0],[1,2,1,0],[0,0,1,0],[0,0,0,1]]]*Z(3)^0;;
+##  gap> mo:=GModuleByMats(mats,GF(3));;
+##  gap> coh:=TwoCohomologyGeneric(g,mo);;
+##  gap> coh.cocycles;
+##  [ < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) > ]
+##  gap> coh.coboundaries;
+##  [ < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) >,
+##    < immutable compressed vector length 44 over GF(3) > ]
+##  gap> coh.cohomology;
+##  [ < immutable compressed vector length 44 over GF(3) > ]
+##  gap> g1:=FpGroupCocycle(coh,coh.zero);
+##  <fp group of size 4860 on the generators [ F1, F2, F3, m1, m2, m3, m4 ]>
+##  gap> g2:=FpGroupCocycle(coh,coh.cohomology[1]);
+##  <fp group of size 4860 on the generators [ F1, F2, F3, m1, m2, m3, m4 ]>
+##  gap> Length(ComplementClassesRepresentatives(g1,RadicalGroup(g1)));
+##  3
+##  gap> Length(ComplementClassesRepresentatives(g2,RadicalGroup(g2)));
+##  0
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
+
+#############################################################################
+##
+#O  FpGroupCocycle( <r>, <c>, <doperm> )
+##
+##  <#GAPDoc Label="FpGroupCocycle">
+##  <ManSection>
+##  <Func Name="FpGroupCocycle" Arg='r, c [,doperm]'/>
+##
+##  <Description>
+##  For a record <A>r</A> as returned by
+##  <Ref Oper="TwoCohomologyGeneric"/> and a vector <A>c</A> in the space of
+##  two-cocycles, this operation returns a finitely presented group that is
+##  an extension corresponding to the cocycle <A>c</A>. If the underlying
+##  module has dimension <M>d</M>, the last <M>d</M> generators generate the
+##  normal subgroup.
+##  If the optional parameter <A>doperm</A> is given as <A>true</A>, a
+##  faithful permutation representation is computed and stored in the
+##  attribute <Ref Attr="IsomorphismPermGroup"/> of the computed group.
+##  <Example><![CDATA[
+##  gap> g:=Group((2,15,8,16)(3,17,14,21)(4,23,20,6)(5,9,22,11)(7,13,19,25),
+##  > (2,12,7,17)(3,18,13,23)(4,24,19,9)(5,10,25,15)(6,11,16,21));;
+##  gap> StructureDescription(g);
+##  "GL(2,5)"
+##  gap> mats:=[[[1,1,0,2],[2,0,0,0],[0,2,2,0],[0,1,0,0]],
+##  > [[0,0,0,1],[1,1,2,0],[1,0,2,1],[1,0,1,0]]]*Z(3)^0;;
+##  gap> mo:=GModuleByMats(mats,GF(3));;
+##  gap> coh:=TwoCohomologyGeneric(g,mo);;
+##  gap> coh.cohomology;
+##  [ < immutable compressed vector length 116 over GF(3) > ]
+##  gap> p:=FpGroupCocycle(coh,coh.zero,true);
+##  <fp group of size 38880 on the generators
+##  [ F1, F2, F3, F4, F5, F6, m1, m2, m3, m4 ]>
+##  gap> g1:=Image(IsomorphismPermGroup(p));
+##  <permutation group with 10 generators>
+##  gap> NrMovedPoints(g1);
+##  39
+##  gap> p:=FpGroupCocycle(coh,coh.cohomology[1],true);
+##  <fp group of size 38880 on the generators
+##  [ F1, F2, F3, F4, F5, F6, m1, m2, m3, m4 ]>
+##  gap> g2:=Image(IsomorphismPermGroup(p));
+##  <permutation group with 10 generators>
+##  gap> NrMovedPoints(g2);
+##  69
+##  gap> List(MaximalSubgroupClassReps(g1),Size);
+##  [ 480, 480, 480, 19440, 3888, 7776, 6480 ]
+##  gap> List(MaximalSubgroupClassReps(g2),Size);
+##  [ 19440, 3888, 7776, 6480 ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("FpGroupCocycle");
+

--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -306,3 +306,20 @@ DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
 ##
 DeclareGlobalFunction("FpGroupCocycle");
 
+#############################################################################
+##
+#O  CompatiblePairOrbitRepsGeneric( <compair>,<coh> )
+##
+##  <#GAPDoc Label="CompatiblePairOrbitRepsGeneric">
+##  <ManSection>
+##  <Func Name="CompatiblePairOrbitRepsGeneric" Arg='compair, coh'/>
+##
+##  <Description>
+##  <Example><![CDATA[
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("CompatiblePairOrbitRepsGeneric");
+

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -900,8 +900,6 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     return a;
   end;
 
-  onemat:=One(mo.generators[1]);
-  zerovec:=Zero(onemat[1]);
   # matrix corresponding to monoid word
   mapped:=function(list)
   local a,i;
@@ -1072,6 +1070,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       x->ImagesRepresentative(m,
       PreImagesRepresentative(fm,x))); #Elements for monoid generators
     pre:=mats;
+    onemat:=One(G);
     for i in [1..Length(hastail)] do
       r:=rules[hastail[i]];
       m:=LeftQuotient(mapped(r[2]),mapped(r[1]));
@@ -1079,6 +1078,9 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       solvec:=Concatenation(solvec,m*One(field));
     od;
   fi;
+
+  onemat:=One(mo.generators[1]);
+  zerovec:=Zero(onemat[1]);
 
   mats:=List(GeneratorsOfMonoid(mon),
     x->ImagesRepresentative(hom,PreImagesRepresentative(fp,

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -273,9 +273,9 @@ InstallGlobalFunction( CollectorSQ, function( G, M, isSplit )
         k := Characteristic( M.field );
         for i  in [ 1 .. Length(r.orders) ]  do
             for j  in [ 1 .. i ]  do
-		# we can avoid
-		if Order(pcgs[i]) mod k <>0 and Order(pcgs[j]) mod k <>0 then
-		# was: r.orders[i] <> k and r.orders[j] <> k  then
+                # we can avoid
+                if Order(pcgs[i]) mod k <>0 and Order(pcgs[j]) mod k <>0 then
+                # was: r.orders[i] <> k and r.orders[j] <> k  then
                     AddSet( r.avoid, (i^2-i)/2 + j );
                 fi;
             od;

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -250,4 +250,27 @@ gap> NrMovedPoints(Source(sm));
 157464
 gap> NrMovedPoints(Range(sm))<200;
 true
+
+# construct extensions
+gap> g:=PerfectGroup(IsPermGroup,3840,1);;
+gap> cf:=List(MTX.CollectedFactors(RegularModule(g,GF(2))[2]),x->x[1]);;
+gap> List(cf,x->x.dimension);
+[ 1, 4, 4 ]
+gap> coh:=TwoCohomologyGeneric(g,cf[2]);;
+gap> coh.cohomology;
+[ <an immutable GF2 vector of length 336>, <an immutable GF2 vector of length
+    336> ]
+gap> e:=Elements(VectorSpace(GF(2),coh.cohomology));;
+gap> p:=List(e,x->FpGroupCocycle(coh,x,true));
+[ <fp group of size 61440 on the generators [ F1, F2, F3, F4, F5, F6, F7, F8,
+      m1, m2, m3, m4 ]>, <fp group of size 61440 on the generators
+    [ F1, F2, F3, F4, F5, F6, F7, F8, m1, m2, m3, m4 ]>,
+  <fp group of size 61440 on the generators [ F1, F2, F3, F4, F5, F6, F7, F8,
+      m1, m2, m3, m4 ]>, <fp group of size 61440 on the generators
+    [ F1, F2, F3, F4, F5, F6, F7, F8, m1, m2, m3, m4 ]> ]
+gap> p:=List(p,x->Image(IsomorphismPermGroup(x)));
+[ <permutation group of size 61440 with 12 generators>,
+  <permutation group of size 61440 with 12 generators>,
+  <permutation group of size 61440 with 12 generators>,
+  <permutation group of size 61440 with 12 generators> ]
 gap> STOP_TEST( "grpperm.tst", 1);

--- a/tst/testextra/makeperfect.g
+++ b/tst/testextra/makeperfect.g
@@ -1,0 +1,81 @@
+# construct perfect groups of given order
+
+Practice:=function(n) #makes perfect
+local isot,res,resp,d,i,j,nt,p,e,q,cf,m,coh,v,new,quot,nts,pf,pl,comp,reps;
+  isot:=function(g,h)
+  local c,d;
+    if Collected(List(ConjugacyClasses(g),
+      x->[Order(Representative(x)),Size(x)]))<>
+       Collected(List(ConjugacyClasses(h),
+      x->[Order(Representative(x)),Size(x)])) then return false;
+    fi;
+    if Collected(List(MaximalSubgroupClassReps(g),Size))<>
+       Collected(List(MaximalSubgroupClassReps(h),Size)) then return false;
+    fi;
+    if Collected(List(NormalSubgroups(g),
+      x->[Size(x),IsAbelian(x),Size(Centralizer(g,x))]))<>
+       Collected(List(NormalSubgroups(h),
+      x->[Size(x),IsAbelian(x),Size(Centralizer(h,x))])) then return false;
+    fi;
+    c:=CharacterTable(g);;Irr(c);
+    d:=CharacterTable(h);;Irr(d);
+    if TransformingPermutationsCharacterTables(c,d)=fail then return false;fi;
+    return IsomorphismGroups(g,h)<>fail;
+  end;
+
+  res:=[];
+  resp:=[];
+  d:=Filtered(DivisorsInt(n),x->x<n);
+  for i in d do
+    nts:=n/i;
+    if IsPrimePowerInt(nts) then
+      p:=Factors(nts)[1];
+      e:=LogInt(nts,p);
+      pl:=[];
+      for j in [1..NrPerfectGroups(i)] do
+        q:=PerfectGroup(IsPermGroup,i,j);
+        new:=Name(q);
+        q:=Group(SmallGeneratingSet(q));
+        SetName(q,new);
+        Add(pl,q);
+      od;
+      for j in [1..Length(pl)] do
+        q:=pl[j];
+        #Print("Using ",i,", ",j,": ",q,"\n");
+        cf:=IrreducibleModules(q,GF(p),e)[2];
+        cf:=Filtered(cf,x->x.dimension=e);
+        for m in cf do
+          #Print("Module dimension ",m.dimension,"\n");
+          coh:=TwoCohomologyGeneric(q,m);
+
+          comp:=CompatiblePairs(q,m);
+          reps:=CompatiblePairOrbitRepsGeneric(comp,coh);
+          for v in reps do
+            new:=FpGroupCocycle(coh,v,true);
+            if IsPerfect(new) then
+              # could it have been gotten in another way?
+              pf:=Image(IsomorphismPermGroup(new));
+              nt:=NormalSubgroups(pf);
+              if ForAll(nt,x->Size(x)=1 or Size(x)>=nts) then
+                nt:=Filtered(nt,x->Size(x)=nts);
+                if (not ForAny(List(nt,x->pf/x),x->ForAny([1..j-1],y->
+                    isot(pl[y],x)))) and ForAll(resp,
+                      x->isot(x,Image(IsomorphismPermGroup(new)))=false) then
+                  Add(res,new);
+                  Add(resp,Image(IsomorphismPermGroup(new)));
+                  #Print("found nr. ",Length(res),"\n");
+                else
+                  #Print("smallerb\n");
+                fi;
+              #else Print("smallera\n");
+              fi;
+            fi;
+          od;
+
+        od;
+      od;
+    fi;
+  od;
+  return res;
+end;
+

--- a/tst/testextra/perfect.tst
+++ b/tst/testextra/perfect.tst
@@ -1,0 +1,13 @@
+#############################################################################
+##
+##  Test for cohomology and isomorphism: Recompute perfect groups
+##
+gap> START_TEST("perfect.tst");
+gap> READ_GAP_ROOT("tst/testextra/makeperfect.g");;
+gap> l:=Practice(1920);;
+gap> Length(l);
+7
+gap> l:=Practice(10752);;
+gap> Length(l);
+9
+gap> STOP_TEST( "perfect.tst", 1);

--- a/tst/testinstall/twocohom.tst
+++ b/tst/testinstall/twocohom.tst
@@ -1,0 +1,25 @@
+gap> START_TEST("twocohom.tst");
+gap> g:=PerfectGroup(IsPermGroup,1344,1);;
+gap> mo:=IrreducibleModules(g,GF(2),1);;List(mo[2],x->x.dimension);
+[ 1 ]
+gap> mo:=IrreducibleModules(g,GF(2),0);;List(mo[2],x->x.dimension);
+[ 1, 3, 3, 8 ]
+gap> coh:=TwoCohomologyGeneric(g,mo[2][2]:
+> model:=PerfectGroup(IsPermGroup,10752,1));;
+gap> Length(coh.cohomology);
+2
+gap> comp:=CompatiblePairs(g,mo[2][2]);
+<group of size 2688 with 5 generators>
+gap> reps:=CompatiblePairOrbitRepsGeneric(comp,coh);;Length(reps);
+3
+gap> h:=FpGroupCocycle(coh,reps[1],true);;
+gap> h:=Image(IsomorphismPermGroup(h));;
+gap> Collected(List(MaximalSubgroupClassReps(h),Size));
+[ [ 1344, 7 ], [ 1536, 2 ] ]
+gap> h:=FpGroupCocycle(coh,reps[2],true);;
+gap> h:=Image(IsomorphismPermGroup(h));;
+gap> Collected(List(MaximalSubgroupClassReps(h),Size));
+[ [ 1344, 3 ], [ 1536, 2 ] ]
+
+# that's all, folks
+gap> STOP_TEST( "twocohom.tst", 1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -56,6 +56,12 @@ true
 gap> Sum(ConjugacyClasses(g),Size);
 1384120320
 
+# Construct modules
+gap> g:=PerfectGroup(IsPermGroup,5376,1);;
+gap> s:=IrreducibleModules(g,GF(2),0);;
+gap> Collected(List(s[2],x->x.dimension));
+[ [ 1, 1 ], [ 3, 2 ], [ 8, 1 ] ]
+
 # Unbind variables so we can GC memory
 gap> Unbind(g); Unbind(dc); Unbind(ac); Unbind(g); Unbind(p); Unbind(s);
 gap> STOP_TEST( "permgrp.tst", 1);


### PR DESCRIPTION
Uses rewriting system since pc presentation will not always be available.
This is both code for the cohomology group, and for constructing the extension corresponding to a particular cocycle. Group is constructed by default as Fp group, but there is an option to have it compute a faithful permutation representation.

Also includes improved routines for `IrreducibleModules` for the non-pc case once such cohomology routines exist, and action of compatible pairs on the cohomology group.

There is a test in `testextra` that, as application, constructs perfect groups anew. (This could easily go to larger orders, if desired, at the moment two quick tests are in.)