### PR TITLE
performance enhancements in subgroup lattice

### DIFF
--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -736,6 +736,8 @@ BindGlobal("DoClosurePrmGp",function( G, gens, options )
             fi;
         od;
     else
+        o:=ValueOption("knownClosureSize");
+        if IsInt(o) then options.limit:=o;fi;
         chain := ClosureRandomPermGroup( chain, gens, options );
     fi;
 


### PR DESCRIPTION
With this, GAP can calculate the subgroups of HNM4 on 1920 points -- before runs out of memory.