### PR TITLE
Add ShowUsedInfoClasses

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -58,6 +58,7 @@ SOURCES += src/gap.c
 SOURCES += gen/gap_version.c	# generated source file
 SOURCES += src/gvars.c
 SOURCES += src/hookintrprtr.c
+SOURCES += src/info.c
 SOURCES += src/integer.c
 SOURCES += src/intfuncs.c
 SOURCES += src/intrprtr.c

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -106,6 +106,8 @@ algorithms for the computation of a subgroup lattice.
 Note that not all info classes defined in the &GAP; library are currently
 documented.  Many &GAP; packages define additional info classes, which are
 typically documented in the corresponding package documentation.
+The function <Ref Func="ShowUsedInfoClasses"/> will show all info classes which
+&GAP; considers while executing code.
 <P/>
 The amount of information to be displayed by each info class can be separately
 specified by the user. This is done by selecting a non-negative integer
@@ -158,6 +160,35 @@ returns the info level of <A>infoclass</A>.
 </Description>
 </ManSection>
 <P/>
+<ManSection>
+<Func Name="ShowUsedInfoClasses" Arg='infoclass'/>
+
+<Description>
+Called with argument <K>true</K>, this makes &GAP; print the info class and level of
+ any executed <Ref Func="Info"/> statement. Calling with the argument <K>false</K> stops this
+ printing.
+
+Each level of each info class is only printed once. The history of printed
+info classes and levels is reset whenever <K>true</K> is passed.
+<P/>
+
+<Example><![CDATA[
+gap> ShowUsedInfoClasses(true);
+gap> Intersection(Group((1,3,2,4,5,6)), Group((1,2,3,4,5,6)));
+#I Would print info with SetInfoLevel(InfoOptions,1)
+#I Would print info with SetInfoLevel(InfoBckt,1)
+#I Would print info with SetInfoLevel(InfoBckt,3)
+#I Would print info with SetInfoLevel(InfoBckt,5)
+Group(())
+gap> Intersection(Group((1,3,2,4,5,6)), Group((1,2,3,4,5,6)));
+Group(())
+gap> ShowUsedInfoClasses(false);
+]]></Example>
+
+</Description>
+</ManSection>
+<P/>
+
 <ManSection>
 <Func Name="Info" Arg='infoclass, level, info[, moreinfo ...]'/>
 

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -317,6 +317,43 @@ end );
 
 #############################################################################
 ##
+##  The following functions are used by ShowUsedInfoClasses
+##
+##  SHOWN_USED_INFO_CLASSES contains the InfoClasses which have been printed
+##  out by ShowUsedInfoClasses.
+##  RESET_SHOW_USED_INFO_CLASSES and SHOW_USED_INFO_CLASSES are called from
+##  the kernel.
+
+SHOWN_USED_INFO_CLASSES := [];
+
+if IsHPCGAP then
+    ShareInternalObj(INFO_CLASSES);
+fi;
+
+
+BIND_GLOBAL("RESET_SHOW_USED_INFO_CLASSES", function()
+    atomic readwrite SHOWN_USED_INFO_CLASSES do
+        SHOWN_USED_INFO_CLASSES := [];
+    od;
+end);
+
+BIND_GLOBAL("SHOW_USED_INFO_CLASSES", function(selectors, level)
+    local selector;
+    # Handle selectors possibly being a list
+    selectors := Flat([selectors]);
+    atomic readwrite SHOWN_USED_INFO_CLASSES do
+        for selector in selectors do
+            if not [selector, level] in SHOWN_USED_INFO_CLASSES then
+                Add(SHOWN_USED_INFO_CLASSES, [selector, level]);
+                Print("#I Would print info with SetInfoLevel(",
+                    selector, ",", level, ")\n");
+            fi;
+        od;
+    od;
+end);
+
+#############################################################################
+##
 #V  InfoDebug
 ##
 ##  This info class has a default level of 1.

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -38,6 +38,7 @@ extern "C" {
 #include "gapstate.h"
 #include "gasman.h"
 #include "gvars.h"
+#include "info.h"
 #include "integer.h"
 #include "intrprtr.h"
 #include "io.h"

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -104,6 +104,9 @@ typedef struct GAPState {
     Int PrintObjIndex;
     Int PrintObjDepth;
 
+    /* From info.c */
+    Int ShowUsedInfoClassesActive;
+
     UInt1 StateSlots[STATE_SLOTS_SIZE];
 
 /* Allocation */

--- a/src/info.c
+++ b/src/info.c
@@ -1,0 +1,129 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This file declares the functions handling Info statements.
+*/
+
+
+#include "info.h"
+
+#include "bool.h"
+#include "calls.h"
+#include "gvars.h"
+#include "modules.h"
+#include "plist.h"
+
+#ifdef HPCGAP
+#include "hpc/aobjects.h"
+#endif
+
+enum {
+    INFODATA_NUM = 1,
+    INFODATA_CURRENTLEVEL,
+    INFODATA_CLASSNAME,
+    INFODATA_HANDLER,
+    INFODATA_OUTPUT,
+};
+
+static Obj InfoDecision;
+static Obj IsInfoClassListRep;
+static Obj DefaultInfoHandler;
+
+void InfoDoPrint(Obj cls, Obj lvl, Obj args)
+{
+    if (IS_PLIST(cls))
+        cls = ELM_PLIST(cls, 1);
+#if defined(HPCGAP)
+    Obj fun = Elm0AList(cls, INFODATA_HANDLER);
+#else
+    Obj fun = ELM_PLIST(cls, INFODATA_HANDLER);
+#endif
+    if (!fun)
+        fun = DefaultInfoHandler;
+
+    CALL_3ARGS(fun, cls, lvl, args);
+}
+
+
+Obj InfoCheckLevel(Obj selectors, Obj level)
+{
+    // Fast-path the most common failing case.
+    // The fast-path only deals with the case where all arguments are of the
+    // correct type, and were False is returned.
+    if (CALL_1ARGS(IsInfoClassListRep, selectors) == True) {
+#if defined(HPCGAP)
+        Obj index = ElmAList(selectors, INFODATA_CURRENTLEVEL);
+#else
+        Obj index = ELM_PLIST(selectors, INFODATA_CURRENTLEVEL);
+#endif
+        if (IS_INTOBJ(index) && IS_INTOBJ(level)) {
+            // < on INTOBJs compares the represented integers.
+            if (index < level) {
+                return False;
+            }
+        }
+    }
+    return CALL_2ARGS(InfoDecision, selectors, level);
+}
+
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
+*/
+static Int InitKernel(StructInitInfo * module)
+{
+    /* The work of handling Info messages is delegated to the GAP level */
+    ImportFuncFromLibrary("InfoDecision", &InfoDecision);
+    ImportFuncFromLibrary("DefaultInfoHandler", &DefaultInfoHandler);
+    ImportFuncFromLibrary("IsInfoClassListRep", &IsInfoClassListRep);
+
+    /* return success                                                      */
+    return 0;
+}
+
+
+/****************************************************************************
+**
+*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+*/
+static Int InitLibrary(StructInitInfo * module)
+{
+    ExportAsConstantGVar(INFODATA_CURRENTLEVEL);
+    ExportAsConstantGVar(INFODATA_CLASSNAME);
+    ExportAsConstantGVar(INFODATA_HANDLER);
+    ExportAsConstantGVar(INFODATA_OUTPUT);
+    ExportAsConstantGVar(INFODATA_NUM);
+
+    /* return success                                                      */
+    return 0;
+}
+
+/****************************************************************************
+**
+*F  InitInfoInfo()  . . . . . . . . . . . . . . . . . table of init functions
+*/
+static StructInitInfo module = {
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "info",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+};
+
+StructInitInfo * InitInfoInfo(void)
+{
+    return &module;
+}

--- a/src/info.h
+++ b/src/info.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This file declares the functions handling Info statements.
+*/
+
+#ifndef GAP_INFO_H
+#define GAP_INFO_H
+
+#include "gap.h"
+#include "system.h"
+
+/****************************************************************************
+**
+*F  InfoCheckLevel( <selectors>, <level> )  . . . check if Info should output
+**  InfoDoPrint( <selectors>, <level>, <args> ) . . . print an Info statement
+*/
+
+Obj InfoCheckLevel(Obj selectors, Obj level);
+
+void InfoDoPrint(Obj cls, Obj lvl, Obj args);
+
+
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+
+/****************************************************************************
+**
+*F  InitInfoInfo()  . . . . . . . . . . . . . . . . . table of init functions
+*/
+StructInitInfo * InitInfoInfo(void);
+
+#endif

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -835,15 +835,11 @@ void IntrEmpty(void);
 *F  IntrInfoBegin() . . . . . . . . .  start interpretation of Info statement
 *F  IntrInfoMiddle() . . . . . . .  shift to interpreting printable arguments
 *F  IntrInfoEnd( <narg> ) . . Info statement complete, <narg> things to print
-*F  InfoCheckLevel( <selectors>, <level> )  . . . check if Info should output
 */
 
 void IntrInfoBegin(void);
 void IntrInfoMiddle(void);
 void IntrInfoEnd(UInt narg);
-Obj  InfoCheckLevel(Obj, Obj);
-
-void InfoDoPrint(Obj cls, Obj lvl, Obj args);
 
 
 /****************************************************************************

--- a/src/modules_builtin.c
+++ b/src/modules_builtin.c
@@ -13,6 +13,7 @@
 #include "compiled.h"
 #include "gap.h"
 #include "hookintrprtr.h"
+#include "info.h"
 #include "intfuncs.h"
 #include "iostream.h"
 #include "objccoll.h"
@@ -63,6 +64,7 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
     InitInfoVars,       /* must come after InitExpr and InitStats */
     InitInfoFuncs,
     InitInfoOpers,
+    InitInfoInfo,
     InitInfoIntrprtr,
     InitInfoCompiler,
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -23,6 +23,7 @@
 #include "exprs.h"
 #include "gvars.h"
 #include "hookintrprtr.h"
+#include "info.h"
 #include "intrprtr.h"
 #include "io.h"
 #include "lists.h"

--- a/tst/testinstall/info.tst
+++ b/tst/testinstall/info.tst
@@ -53,6 +53,32 @@ gap> Info(InfoTest1 + InfoTest2, 0);
 Error, level 0 Info messages are not allowed
 gap> Info(InfoTest1 + InfoTest2, "apple");
 Error, usage : Info(<selectors>, <level>, ...)
+gap> ShowUsedInfoClasses(true);
+gap> Info(InfoTest2, 2, "apple");
+#I Would print info with SetInfoLevel(InfoTest2,2)
+#I Would print info with SetInfoLevel(InfoGlobal,3)
+#I  apple
+gap> Info(InfoTest1 + InfoTest2, 2, "apple");
+#I Would print info with SetInfoLevel(InfoTest1,2)
+#I  apple
+gap> Info(InfoTest1 + InfoTest2, 2, "apple");
+#I  apple
+gap> Info(InfoTest1 + InfoTest2, 3, "apple");
+#I Would print info with SetInfoLevel(InfoTest1,3)
+#I Would print info with SetInfoLevel(InfoTest2,3)
+gap> Info(InfoTest1 + InfoTest2, 3, "apple");
+gap> ShowUsedInfoClasses(true);
+gap> Info(InfoTest1 + InfoTest2, 3, "apple");
+#I Would print info with SetInfoLevel(InfoTest1,3)
+#I Would print info with SetInfoLevel(InfoTest2,3)
+gap> Info(InfoTest1 + InfoTest2, 3, "apple");
+gap> ShowUsedInfoClasses(false);
+gap> ShowUsedInfoClasses(fail);
+Error, ShowUsedInfoClasses: <choice> must be true or false (not the value 'fai\
+l')
+gap> ShowUsedInfoClasses("abc");
+Error, ShowUsedInfoClasses: <choice> must be true or false (not a list (string\
+))
 gap> str := "";;
 gap> str2 := "";;
 gap> SetDefaultInfoOutput(OutputTextString(str, false));


### PR DESCRIPTION
Fixes #3379 

This is two commits -- the first pulls some Info stuff that was probably in the wrong place into it's own file, the second then adds ShowUsedInfoClasses (as described in the docs, and #3379).