### PR TITLE
Prevent blist functions from modifying immutable blists (and several other kernel tweaks leading up to this)

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -1181,32 +1181,32 @@ static Obj FuncPositionNthTrueBlist(
 
 /****************************************************************************
 **
-*F  FuncIsSubsetBlist( <self>, <list1>, <list2> ) . . . . . . . . subset test
+*F  FuncIsSubsetBlist( <self>, <blist1>, <blist2> ) . . . . . . . subset test
 **
 **  'FuncIsSubsetBlist' implements the internal function 'IsSubsetBlist'.
 **
-**  'IsSubsetBlist( <list1>, <list2> )'
+**  'IsSubsetBlist( <blist1>, <blist2> )'
 **
-**  'IsSubsetBlist' returns 'true' if the boolean list <list2> is a subset of
-**  the  boolean  list <list1>, which must  have  equal length.  <list2> is a
-**  subset of <list1> if '<list2>[<i>] >= <list1>[<i>]' for all <i>.
+**  'IsSubsetBlist' returns 'true' if the boolean list <blist2> is a subset
+**  of the  boolean  list <blist1>, which must  have  equal length.  <blist2>
+**  is a subset of <blist1> if '<blist2>[<i>] >= <blist1>[<i>]' for all <i>.
 */
-static Obj FuncIS_SUB_BLIST(Obj self, Obj list1, Obj list2)
+static Obj FuncIS_SUB_BLIST(Obj self, Obj blist1, Obj blist2)
 {
     const UInt *        ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("IsSubsetBlist", list1, "blist1");
-    RequireBlist("IsSubsetBlist", list2, "blist2");
-    CheckSameLength("IsSubsetBlist", "blist1", "blist2", list1, list2);
+    RequireBlist("IsSubsetBlist", blist1, "blist1");
+    RequireBlist("IsSubsetBlist", blist2, "blist2");
+    CheckSameLength("IsSubsetBlist", "blist1", "blist2", blist1, blist2);
 
     /* test for subset property blockwise                                  */
-    ptr1 = CONST_BLOCKS_BLIST(list1);
-    ptr2 = CONST_BLOCKS_BLIST(list2);
+    ptr1 = CONST_BLOCKS_BLIST(blist1);
+    ptr2 = CONST_BLOCKS_BLIST(blist2);
 
-    for ( i = NUMBER_BLOCKS_BLIST(list1); 0 < i; i-- ) {
+    for ( i = NUMBER_BLOCKS_BLIST(blist1); 0 < i; i-- ) {
         if ( *ptr1 != (*ptr1 | *ptr2) )
             break;
         ptr1++;  ptr2++;
@@ -1219,7 +1219,7 @@ static Obj FuncIS_SUB_BLIST(Obj self, Obj list1, Obj list2)
 
 /****************************************************************************
 **
-*F  FuncUNITE_BLIST( <self>, <list1>, <list2> ) . unite one list with another
+*F  FuncUNITE_BLIST( <self>, <blist1>, <blist2> ) . unite one list with another
 **
 **  'FuncUNITE_BLIST' implements the internal function 'UniteBlist'.
 **
@@ -1229,21 +1229,21 @@ static Obj FuncIS_SUB_BLIST(Obj self, Obj list1, Obj list2)
 **  <blist2>,  which  must  have the   same  length.  This  is  equivalent to
 **  assigning '<blist1>[<i>] := <blist1>[<i>] or <blist2>[<i>]' for all <i>.
 */
-static Obj FuncUNITE_BLIST(Obj self, Obj list1, Obj list2)
+static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
 {
     UInt *              ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("UniteBlist", list1, "blist1");
-    RequireBlist("UniteBlist", list2, "blist2");
-    CheckSameLength("UniteBlist", "blist1", "blist2", list1, list2);
+    RequireBlist("UniteBlist", blist1, "blist1");
+    RequireBlist("UniteBlist", blist2, "blist2");
+    CheckSameLength("UniteBlist", "blist1", "blist2", blist1, blist2);
 
     /* compute the union by *or*-ing blockwise                             */
-    ptr1 = BLOCKS_BLIST(list1);
-    ptr2 = CONST_BLOCKS_BLIST(list2);
-    for ( i = (LEN_BLIST(list1)+BIPEB-1)/BIPEB; 0 < i; i-- ) {
+    ptr1 = BLOCKS_BLIST(blist1);
+    ptr2 = CONST_BLOCKS_BLIST(blist2);
+    for ( i = (LEN_BLIST(blist1)+BIPEB-1)/BIPEB; 0 < i; i-- ) {
         *ptr1++ |= *ptr2++;
     }
 
@@ -1473,33 +1473,32 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub)
 
 /****************************************************************************
 **
-*F  FuncINTER_BLIST( <self>, <list1>, <list2> ) .  <list1> intersection <list2>
+*F  FuncINTER_BLIST( <self>, <blist1>, <blist2> ) .  <blist1> intersection <blist2>
 **
 **  'FuncINTER_BLIST' implements the function 'IntersectBlist'.
 **
-**  'IntersectBlist( <list1>, <list2> )'
+**  'IntersectBlist( <blist1>, <blist2> )'
 **
-**  'IntersectBlist' intersects the   boolean list <list1> with  the  boolean
-**  list <list2>, which  must have the  same length.   This is equivalent  to
-**  assigning '<list1>[<i>] := <list1>[<i>] and <list2>[<i>]' for all <i>.
+**  'IntersectBlist' intersects the   boolean list <blist1> with  the  boolean
+**  list <blist2>, which  must have the  same length.   This is equivalent  to
+**  assigning '<blist1>[<i>] := <blist1>[<i>] and <blist2>[<i>]' for all <i>.
 */
-static Obj FuncINTER_BLIST(Obj self, Obj list1, Obj list2)
+static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
 {
     UInt *              ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("IntersectBlist", list1, "blist1");
-    RequireBlist("IntersectBlist", list2, "blist2");
-    CheckSameLength("IntersectBlist", "blist1", "blist2", list1, list2);
+    RequireBlist("IntersectBlist", blist1, "blist1");
+    RequireBlist("IntersectBlist", blist2, "blist2");
+    CheckSameLength("IntersectBlist", "blist1", "blist2", blist1, blist2);
 
     /* compute the intersection by *and*-ing blockwise                     */
-    ptr1 = BLOCKS_BLIST(list1);
-    ptr2 = CONST_BLOCKS_BLIST(list2);
-    for ( i = NUMBER_BLOCKS_BLIST(list1); 0 < i; i-- ) {
+    ptr1 = BLOCKS_BLIST(blist1);
+    ptr2 = CONST_BLOCKS_BLIST(blist2);
+    for ( i = NUMBER_BLOCKS_BLIST(blist1); 0 < i; i-- )
         *ptr1++ &= *ptr2++;
-    }
 
     /* return nothing, this function is a procedure                        */
     return 0;
@@ -1508,34 +1507,32 @@ static Obj FuncINTER_BLIST(Obj self, Obj list1, Obj list2)
 
 /****************************************************************************
 **
-*F  FuncSUBTR_BLIST( <self>, <list1>, <list2> ) . . . . . . <list1> - <list2>
+*F  FuncSUBTR_BLIST( <self>, <blist1>, <blist2> ) . . . . . . <blist1> - <blist2>
 **
 **  'FuncSUBTR_BLIST' implements the internal function 'SubtractBlist'.
 **
-**  'SubtractBlist( <list1>, <list2> )'
+**  'SubtractBlist( <blist1>, <blist2> )'
 **
-**  'SubtractBlist' subtracts the boolean  list <list2> from the boolean list
-**  <list1>, which  must have the  same length.  This is equivalent assigning
-**  '<list1>[<i>] := <list1>[<i>] and not <list2>[<i>]' for all <i>.
+**  'SubtractBlist' subtracts the boolean  list <blist2> from the boolean list
+**  <blist1>, which  must have the  same length.  This is equivalent assigning
+**  '<blist1>[<i>] := <blist1>[<i>] and not <blist2>[<i>]' for all <i>.
 */
-static Obj FuncSUBTR_BLIST(Obj self, Obj list1, Obj list2)
+static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
 {
     UInt *              ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("SubtractBlist", list1, "blist1");
-    RequireBlist("SubtractBlist", list2, "blist2");
-    CheckSameLength("SubtractBlist", "blist1", "blist2", list1, list2);
+    RequireBlist("SubtractBlist", blist1, "blist1");
+    RequireBlist("SubtractBlist", blist2, "blist2");
+    CheckSameLength("SubtractBlist", "blist1", "blist2", blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
-    ptr1 = BLOCKS_BLIST(list1);
-    ptr2 = CONST_BLOCKS_BLIST(list2);
-    for ( i = NUMBER_BLOCKS_BLIST(list1); 0 < i; i-- ) 
-      { 
+    ptr1 = BLOCKS_BLIST(blist1);
+    ptr2 = CONST_BLOCKS_BLIST(blist2);
+    for ( i = NUMBER_BLOCKS_BLIST(blist1); 0 < i; i-- )
         *ptr1++ &= ~ *ptr2++; 
-      }
 
     /* return nothing, this function is a procedure */
     return 0;
@@ -1543,97 +1540,95 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj list1, Obj list2)
 
 /****************************************************************************
 **
-*F  FuncMEET_BLIST( <self>, <list1>, <list2> ) . . . 
+*F  FuncMEET_BLIST( <self>, <blist1>, <blist2> ) . . . 
 **
 **  'FuncMEET_BLIST' implements the internal function 'MeetBlist'.
 **
-**  'MeetBlist( <list1>, <list2> )'
+**  'MeetBlist( <blist1>, <blist2> )'
 **
-**  'MeetBlist' returns true if list1 and list2 have true in the same
+**  'MeetBlist' returns true if blist1 and blist2 have true in the same
 **  position and false otherwise. It is equivalent to, but faster than
-**  SizeBlist(IntersectionBlist(list1, list2)) <> 0
+**  SizeBlist(IntersectionBlist(blist1, blist2)) <> 0
 **  The lists must have the same length.
 */
 
-static Obj FuncMEET_BLIST(Obj self, Obj list1, Obj list2)
+static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
 {
     const UInt *        ptr1;           /* pointer to the first argument   */
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("MeetBlist", list1, "blist1");
-    RequireBlist("MeetBlist", list2, "blist2");
-    CheckSameLength("MeetBlist", "blist1", "blist2", list1, list2);
+    RequireBlist("MeetBlist", blist1, "blist1");
+    RequireBlist("MeetBlist", blist2, "blist2");
+    CheckSameLength("MeetBlist", "blist1", "blist2", blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
-    ptr1 = CONST_BLOCKS_BLIST(list1);
-    ptr2 = CONST_BLOCKS_BLIST(list2);
-    for ( i = NUMBER_BLOCKS_BLIST(list1); 0 < i; i-- ) 
-      { 
+    ptr1 = CONST_BLOCKS_BLIST(blist1);
+    ptr2 = CONST_BLOCKS_BLIST(blist2);
+    for ( i = NUMBER_BLOCKS_BLIST(blist1); 0 < i; i-- )
         if (*ptr1++ & *ptr2++) return True;
-      }
 
     return False;
 }
 
 /****************************************************************************
 **
-*F  FuncFLIP_BLIST( <self>, <list> ) . . .
+*F  FuncFLIP_BLIST( <self>, <blist> ) . . .
 **
 **  'FuncFLIP_BLIST' implements the internal function 'FlipBlist'.
 **
-**  'FlipBlist( <list> )'
+**  'FlipBlist( <blist> )'
 **
-**  'FlipBlist' changes every value in the blist <list> from true to false, and
-**  vice versa.
+**  'FlipBlist' changes every value in the blist <blist> from true to false,
+**  and vice versa.
 */
 
-static Obj FuncFLIP_BLIST(Obj self, Obj list)
+static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
-    RequireBlist("FlipBlist", list, "blist");
+    RequireBlist("FlipBlist", blist, "blist");
 
-    if (LEN_BLIST(list) == 0) {
+    if (LEN_BLIST(blist) == 0) {
         return 0;
     }
 
-    UInt * ptr = BLOCKS_BLIST(list);
-    for (UInt i = NUMBER_BLOCKS_BLIST(list); 0 < i; i--) {
+    UInt * ptr = BLOCKS_BLIST(blist);
+    for (UInt i = NUMBER_BLOCKS_BLIST(blist); 0 < i; i--) {
         *ptr = ~(*ptr);
         ptr++;
     }
     // If the logical length of the boolean list is not a multiple of BIPEB the
     // last block will contain unused bits, which are then zero.
     UInt mask =
-        ~(UInt)0 >> ((BIPEB * NUMBER_BLOCKS_BLIST(list)) - LEN_BLIST(list));
-    ptr = BLOCK_ELM_BLIST_PTR(list, LEN_BLIST(list));
+        ~(UInt)0 >> ((BIPEB * NUMBER_BLOCKS_BLIST(blist)) - LEN_BLIST(blist));
+    ptr = BLOCK_ELM_BLIST_PTR(blist, LEN_BLIST(blist));
     *ptr &= mask;
     return 0;
 }
 
 /****************************************************************************
 **
-*F  FuncCLEAR_ALL_BLIST( <self>, <list> ) . . .
+*F  FuncCLEAR_ALL_BLIST( <self>, <blist> ) . . .
 **
 **  'FuncCLEAR_ALL_BLIST' implements the internal function 'ClearAllBlist'.
 **
-**  'ClearAllBlist( <list> )'
+**  'ClearAllBlist( <blist> )'
 **
-**  'ClearAllBlist' changes every value in the blist <list> to false.
+**  'ClearAllBlist' changes every value in the blist <blist> to false.
 */
 
-static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj list)
+static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
-    RequireBlist("ClearAllBitsBlist", list, "blist");
+    RequireBlist("ClearAllBitsBlist", blist, "blist");
 
-    if (LEN_BLIST(list) == 0) {
+    if (LEN_BLIST(blist) == 0) {
         return 0;
     }
 
-    UInt * ptr = BLOCKS_BLIST(list);
-    for (UInt i = NUMBER_BLOCKS_BLIST(list); 0 < i; i--) {
+    UInt * ptr = BLOCKS_BLIST(blist);
+    for (UInt i = NUMBER_BLOCKS_BLIST(blist); 0 < i; i--) {
         *ptr++ = 0;
     }
 
@@ -1642,33 +1637,33 @@ static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj list)
 
 /****************************************************************************
 **
-*F  FuncSET_ALL_BLIST( <self>, <list> ) . . .
+*F  FuncSET_ALL_BLIST( <self>, <blist> ) . . .
 **
 **  'FuncSET_ALL_BLIST' implements the internal function 'SetAllBlist'.
 **
-**  'SetAllBlist( <list> )'
+**  'SetAllBlist( <blist> )'
 **
-**  'SetAllBlist' changes every value in the blist <list> to true.
+**  'SetAllBlist' changes every value in the blist <blist> to true.
 */
 
-static Obj FuncSET_ALL_BLIST(Obj self, Obj list)
+static Obj FuncSET_ALL_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
-    RequireBlist("SetAllBitsBlist", list, "blist");
+    RequireBlist("SetAllBitsBlist", blist, "blist");
 
-    if (LEN_BLIST(list) == 0) {
+    if (LEN_BLIST(blist) == 0) {
         return 0;
     }
 
-    UInt * ptr = BLOCKS_BLIST(list);
-    for (UInt i = NUMBER_BLOCKS_BLIST(list); 0 < i; i--) {
+    UInt * ptr = BLOCKS_BLIST(blist);
+    for (UInt i = NUMBER_BLOCKS_BLIST(blist); 0 < i; i--) {
         *ptr++ = ~(UInt)0;
     }
     // If the logical length of the boolean list is not a multiple of BIPEB the
     // last block will contain unused bits, which are then zero.
     UInt mask =
-        ~(UInt)0 >> ((BIPEB * NUMBER_BLOCKS_BLIST(list)) - LEN_BLIST(list));
-    ptr = BLOCK_ELM_BLIST_PTR(list, LEN_BLIST(list));
+        ~(UInt)0 >> ((BIPEB * NUMBER_BLOCKS_BLIST(blist)) - LEN_BLIST(blist));
+    ptr = BLOCK_ELM_BLIST_PTR(blist, LEN_BLIST(blist));
     *ptr &= mask;
 
     return 0;

--- a/src/blister.c
+++ b/src/blister.c
@@ -85,9 +85,9 @@
 #include "set.h"
 
 
-#define RequireBlist(funcname, op, argname)                                  \
-    RequireArgumentConditionEx(funcname, op, "<" argname ">",                \
-                               IsBlistConv(op), "must be a boolean list")
+#define RequireBlist(funcname, op)                                           \
+    RequireArgumentCondition(funcname, op, IsBlistConv(op),                  \
+                             "must be a boolean list")
 
 /****************************************************************************
 **
@@ -1042,7 +1042,7 @@ static Obj FiltIS_BLIST_REP(Obj self, Obj obj)
 */
 static Obj FuncSIZE_BLIST(Obj self, Obj blist)
 {
-    RequireBlist("SizeBlist", blist, "blist");
+    RequireBlist("SizeBlist", blist);
     return INTOBJ_INT(SizeBlist(blist));
 }
 
@@ -1109,7 +1109,7 @@ static Obj FuncLIST_BLIST(Obj self, Obj list, Obj blist)
     /* get and check the first argument                                    */
     RequireSmallList("ListBlist", list);
     /* get and check the second argument                                   */
-    RequireBlist("ListBlist", blist, "blist");
+    RequireBlist("ListBlist", blist);
     RequireSameLength("ListBlist", blist, list);
 
     /* compute the number of 'true'-s                                      */
@@ -1151,8 +1151,8 @@ static Obj FuncPositionNthTrueBlist(
     UInt                m,  mask;
     const UInt *        ptr;
 
-    /* Check the arguments. */    
-    RequireBlist("ListBlist", blist, "blist");
+    /* Check the arguments. */
+    RequireBlist("ListBlist", blist);
     Int nth = GetPositiveSmallIntEx("Position", Nth, "<nth>");
 
     nrb = NUMBER_BLOCKS_BLIST(blist);
@@ -1198,8 +1198,8 @@ static Obj FuncIS_SUB_BLIST(Obj self, Obj blist1, Obj blist2)
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("IsSubsetBlist", blist1, "blist1");
-    RequireBlist("IsSubsetBlist", blist2, "blist2");
+    RequireBlist("IsSubsetBlist", blist1);
+    RequireBlist("IsSubsetBlist", blist2);
     RequireSameLength("IsSubsetBlist", blist1, blist2);
 
     /* test for subset property blockwise                                  */
@@ -1236,8 +1236,8 @@ static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("UniteBlist", blist1, "blist1");
-    RequireBlist("UniteBlist", blist2, "blist2");
+    RequireBlist("UniteBlist", blist1);
+    RequireBlist("UniteBlist", blist2);
     RequireSameLength("UniteBlist", blist1, blist2);
 
     /* compute the union by *or*-ing blockwise                             */
@@ -1279,7 +1279,7 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub)
 
     lenList  = LEN_LIST( list );
 
-    RequireBlist("UniteBlistList", blist, "blist");
+    RequireBlist("UniteBlistList", blist);
     RequireSameLength("UniteBlistList", blist, list);
     RequireSmallList("UniteBlistList", sub);
 
@@ -1490,8 +1490,8 @@ static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("IntersectBlist", blist1, "blist1");
-    RequireBlist("IntersectBlist", blist2, "blist2");
+    RequireBlist("IntersectBlist", blist1);
+    RequireBlist("IntersectBlist", blist2);
     RequireSameLength("IntersectBlist", blist1, blist2);
 
     /* compute the intersection by *and*-ing blockwise                     */
@@ -1524,8 +1524,8 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("SubtractBlist", blist1, "blist1");
-    RequireBlist("SubtractBlist", blist2, "blist2");
+    RequireBlist("SubtractBlist", blist1);
+    RequireBlist("SubtractBlist", blist2);
     RequireSameLength("SubtractBlist", blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
@@ -1559,8 +1559,8 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
     UInt                i;              /* loop variable                   */
 
     /* get and check the arguments                                         */
-    RequireBlist("MeetBlist", blist1, "blist1");
-    RequireBlist("MeetBlist", blist2, "blist2");
+    RequireBlist("MeetBlist", blist1);
+    RequireBlist("MeetBlist", blist2);
     RequireSameLength("MeetBlist", blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
@@ -1587,7 +1587,7 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
 static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
-    RequireBlist("FlipBlist", blist, "blist");
+    RequireBlist("FlipBlist", blist);
 
     if (LEN_BLIST(blist) == 0) {
         return 0;
@@ -1621,7 +1621,7 @@ static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
-    RequireBlist("ClearAllBitsBlist", blist, "blist");
+    RequireBlist("ClearAllBitsBlist", blist);
 
     if (LEN_BLIST(blist) == 0) {
         return 0;
@@ -1649,7 +1649,7 @@ static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 static Obj FuncSET_ALL_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
-    RequireBlist("SetAllBitsBlist", blist, "blist");
+    RequireBlist("SetAllBitsBlist", blist);
 
     if (LEN_BLIST(blist) == 0) {
         return 0;

--- a/src/blister.c
+++ b/src/blister.c
@@ -1200,7 +1200,7 @@ static Obj FuncIS_SUB_BLIST(Obj self, Obj blist1, Obj blist2)
     /* get and check the arguments                                         */
     RequireBlist("IsSubsetBlist", blist1, "blist1");
     RequireBlist("IsSubsetBlist", blist2, "blist2");
-    CheckSameLength("IsSubsetBlist", "blist1", "blist2", blist1, blist2);
+    RequireSameLength("IsSubsetBlist", blist1, blist2);
 
     /* test for subset property blockwise                                  */
     ptr1 = CONST_BLOCKS_BLIST(blist1);
@@ -1238,7 +1238,7 @@ static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
     /* get and check the arguments                                         */
     RequireBlist("UniteBlist", blist1, "blist1");
     RequireBlist("UniteBlist", blist2, "blist2");
-    CheckSameLength("UniteBlist", "blist1", "blist2", blist1, blist2);
+    RequireSameLength("UniteBlist", blist1, blist2);
 
     /* compute the union by *or*-ing blockwise                             */
     ptr1 = BLOCKS_BLIST(blist1);
@@ -1492,7 +1492,7 @@ static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
     /* get and check the arguments                                         */
     RequireBlist("IntersectBlist", blist1, "blist1");
     RequireBlist("IntersectBlist", blist2, "blist2");
-    CheckSameLength("IntersectBlist", "blist1", "blist2", blist1, blist2);
+    RequireSameLength("IntersectBlist", blist1, blist2);
 
     /* compute the intersection by *and*-ing blockwise                     */
     ptr1 = BLOCKS_BLIST(blist1);
@@ -1526,7 +1526,7 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
     /* get and check the arguments                                         */
     RequireBlist("SubtractBlist", blist1, "blist1");
     RequireBlist("SubtractBlist", blist2, "blist2");
-    CheckSameLength("SubtractBlist", "blist1", "blist2", blist1, blist2);
+    RequireSameLength("SubtractBlist", blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
     ptr1 = BLOCKS_BLIST(blist1);
@@ -1561,7 +1561,7 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
     /* get and check the arguments                                         */
     RequireBlist("MeetBlist", blist1, "blist1");
     RequireBlist("MeetBlist", blist2, "blist2");
-    CheckSameLength("MeetBlist", "blist1", "blist2", blist1, blist2);
+    RequireSameLength("MeetBlist", blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
     ptr1 = CONST_BLOCKS_BLIST(blist1);

--- a/src/blister.c
+++ b/src/blister.c
@@ -1016,7 +1016,7 @@ static Obj FiltIS_BLIST(Obj self, Obj val)
 */
 static Obj FuncIS_BLIST_CONV(Obj self, Obj val)
 {
-    /* let 'IsBlist' do the work                                           */
+    // let 'IsBlistConv' do the work
     return IsBlistConv( val ) ? True : False;
 }
 
@@ -1047,7 +1047,6 @@ static Obj FuncSIZE_BLIST(Obj self, Obj blist)
 }
 
 
-
 /****************************************************************************
 **
 *F  FuncBLIST_LIST( <self>, <list>, <sub> )  make boolean list from a sublist
@@ -1069,7 +1068,6 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub);
 
 static Obj FuncBLIST_LIST(Obj self, Obj list, Obj sub)
 {
-    /* get and check the arguments                                         */
     RequireSmallList("BlistList", list);
     RequireSmallList("BlistList", sub);
 
@@ -1081,7 +1079,6 @@ static Obj FuncBLIST_LIST(Obj self, Obj list, Obj sub)
 
     return blist;
 }
-
 
 
 /****************************************************************************
@@ -1106,9 +1103,7 @@ static Obj FuncLIST_BLIST(Obj self, Obj list, Obj blist)
     UInt                nn;
     UInt                i;              /* loop variable                   */
 
-    /* get and check the first argument                                    */
     RequireSmallList("ListBlist", list);
-    /* get and check the second argument                                   */
     RequireBlist("ListBlist", blist);
     RequireSameLength("ListBlist", blist, list);
 
@@ -1139,8 +1134,6 @@ static Obj FuncLIST_BLIST(Obj self, Obj list, Obj blist)
 **
 *F  FuncPositionNthTrueBlist( <self>, <blist>, <Nth> )  . . . find true value
 **
-*N  1992/12/15 martin this depends on 'BIPEB' being 32
-*N  Fixed up for 64 SL
 */
 static Obj FuncPositionNthTrueBlist(
 
@@ -1197,7 +1190,6 @@ static Obj FuncIS_SUB_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    /* get and check the arguments                                         */
     RequireBlist("IsSubsetBlist", blist1);
     RequireBlist("IsSubsetBlist", blist2);
     RequireSameLength("IsSubsetBlist", blist1, blist2);
@@ -1235,7 +1227,6 @@ static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    /* get and check the arguments                                         */
     RequireBlist("UniteBlist", blist1);
     RequireMutable("UniteBlist", blist1, "boolean list");
     RequireBlist("UniteBlist", blist2);
@@ -1275,7 +1266,6 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub)
     UInt                i, j, k = 0, l;     /* loop variables                  */
     long                s, t;           /* elements of a range             */
 
-    /* get and check the arguments                                         */
     RequireSmallList("UniteBlistList", list);
     RequireBlist("UniteBlistList", blist);
     RequireMutable("UniteBlistList", blist, "boolean list");
@@ -1489,7 +1479,6 @@ static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    /* get and check the arguments                                         */
     RequireBlist("IntersectBlist", blist1);
     RequireMutable("IntersectBlist", blist1, "boolean list");
     RequireBlist("IntersectBlist", blist2);
@@ -1524,7 +1513,6 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    /* get and check the arguments                                         */
     RequireBlist("SubtractBlist", blist1);
     RequireMutable("SubtractBlist", blist1, "boolean list");
     RequireBlist("SubtractBlist", blist2);
@@ -1560,7 +1548,6 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    /* get and check the arguments                                         */
     RequireBlist("MeetBlist", blist1);
     RequireBlist("MeetBlist", blist2);
     RequireSameLength("MeetBlist", blist1, blist2);

--- a/src/blister.c
+++ b/src/blister.c
@@ -1237,6 +1237,7 @@ static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
 
     /* get and check the arguments                                         */
     RequireBlist("UniteBlist", blist1);
+    RequireMutable("UniteBlist", blist1, "boolean list");
     RequireBlist("UniteBlist", blist2);
     RequireSameLength("UniteBlist", blist1, blist2);
 
@@ -1276,13 +1277,12 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub)
 
     /* get and check the arguments                                         */
     RequireSmallList("UniteBlistList", list);
-
-    lenList  = LEN_LIST( list );
-
     RequireBlist("UniteBlistList", blist);
+    RequireMutable("UniteBlistList", blist, "boolean list");
     RequireSameLength("UniteBlistList", blist, list);
     RequireSmallList("UniteBlistList", sub);
 
+    lenList  = LEN_LIST( list );
     lenSub   = LEN_LIST( sub );
 
     // if the sublist is empty, nothing has to be done
@@ -1491,6 +1491,7 @@ static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
 
     /* get and check the arguments                                         */
     RequireBlist("IntersectBlist", blist1);
+    RequireMutable("IntersectBlist", blist1, "boolean list");
     RequireBlist("IntersectBlist", blist2);
     RequireSameLength("IntersectBlist", blist1, blist2);
 
@@ -1525,6 +1526,7 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
 
     /* get and check the arguments                                         */
     RequireBlist("SubtractBlist", blist1);
+    RequireMutable("SubtractBlist", blist1, "boolean list");
     RequireBlist("SubtractBlist", blist2);
     RequireSameLength("SubtractBlist", blist1, blist2);
 
@@ -1588,6 +1590,7 @@ static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
     RequireBlist("FlipBlist", blist);
+    RequireMutable("FlipBlist", blist, "boolean list");
 
     if (LEN_BLIST(blist) == 0) {
         return 0;
@@ -1622,6 +1625,7 @@ static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
     RequireBlist("ClearAllBitsBlist", blist);
+    RequireMutable("ClearAllBitsBlist", blist, "boolean list");
 
     if (LEN_BLIST(blist) == 0) {
         return 0;
@@ -1650,6 +1654,7 @@ static Obj FuncSET_ALL_BLIST(Obj self, Obj blist)
 {
     // get and check the arguments
     RequireBlist("SetAllBitsBlist", blist);
+    RequireMutable("SetAllBitsBlist", blist, "boolean list");
 
     if (LEN_BLIST(blist) == 0) {
         return 0;

--- a/src/error.c
+++ b/src/error.c
@@ -519,7 +519,7 @@ void ErrorMayQuit(const Char * msg, Int arg1, Int arg2)
 void CheckIsPossList(const Char * desc, Obj poss)
 {
     if ( ! IS_POSS_LIST( poss ) ) {
-        ErrorMayQuit("%s: <positions> must be a dense list of positive integers",
+        ErrorMayQuit("%s: <poss> must be a dense list of positive integers",
             (Int)desc, 0 );
     }
 }

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2894,7 +2894,7 @@ void            IntrAsssList ( void )
     /* get and check the positions                                         */
     poss = PopObj();
     CheckIsPossList("List Assignments", poss);
-    CheckSameLength("List Assignments", "rhss", "poss", rhss, poss);
+    RequireSameLength("List Assignments", rhss, poss);
 
     /* get the list (checking is done by 'ASSS_LIST')                      */
     list = PopObj();

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2894,7 +2894,7 @@ void            IntrAsssList ( void )
     /* get and check the positions                                         */
     poss = PopObj();
     CheckIsPossList("List Assignments", poss);
-    CheckSameLength("List Assignments", "rhss", "positions", rhss, poss);
+    CheckSameLength("List Assignments", "rhss", "poss", rhss, poss);
 
     /* get the list (checking is done by 'ASSS_LIST')                      */
     list = PopObj();

--- a/src/lists.c
+++ b/src/lists.c
@@ -1871,7 +1871,7 @@ void AsssListCheck (
 {
     CheckIsPossList("List Assignments", poss);
     RequireDenseList("List Assignments", rhss);
-    CheckSameLength("List Assignments", "rhss", "poss", rhss, poss);
+    RequireSameLength("List Assignments", rhss, poss);
     ASSS_LIST( list, poss, rhss );
 }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -922,7 +922,7 @@ void            AsssListDefault (
 
     CheckIsPossList("List Assignments", poss);
     CheckIsDenseList("List Assignments", "rhss", objs);
-    CheckSameLength("List Assignments", "rhss", "positions", objs, poss);
+    CheckSameLength("List Assignments", "rhss", "poss", objs, poss);
 
     /* general code                                                        */
     if ( ! IS_RANGE(poss) ) {
@@ -1658,7 +1658,7 @@ void            AsssListLevel (
             /* select the elements to assign                               */
             obj = ELMW_LIST( objs, i );
             CheckIsDenseList("List Assignments", "objs", obj);
-            CheckSameLength("List Assignments", "objs", "positions", obj, poss);
+            CheckSameLength("List Assignments", "objs", "poss", obj, poss);
 
             /* assign the elements                                         */
             ASSS_LIST( list, poss, obj );
@@ -1871,7 +1871,7 @@ void AsssListCheck (
 {
     CheckIsPossList("List Assignments", poss);
     RequireDenseList("List Assignments", rhss);
-    CheckSameLength("List Assignments", "rhss", "positions", rhss, poss);
+    CheckSameLength("List Assignments", "rhss", "poss", rhss, poss);
     ASSS_LIST( list, poss, rhss );
 }
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -609,7 +609,7 @@ static UInt ExecAsssList(Expr stat)
     /* evaluate and check right hand sides                                 */
     rhss = EVAL_EXPR(READ_STAT(stat, 2));
     RequireDenseList("List Assignments", rhss);
-    CheckSameLength("List Assignments", "rhss", "positions", rhss, poss);
+    CheckSameLength("List Assignments", "rhss", "poss", rhss, poss);
 
     /* assign the right hand sides to several elements of the list         */
     ASSS_LIST( list, poss, rhss );

--- a/src/vars.c
+++ b/src/vars.c
@@ -609,7 +609,7 @@ static UInt ExecAsssList(Expr stat)
     /* evaluate and check right hand sides                                 */
     rhss = EVAL_EXPR(READ_STAT(stat, 2));
     RequireDenseList("List Assignments", rhss);
-    CheckSameLength("List Assignments", "rhss", "poss", rhss, poss);
+    RequireSameLength("List Assignments", rhss, poss);
 
     /* assign the right hand sides to several elements of the list         */
     ASSS_LIST( list, poss, rhss );

--- a/tst/testinstall/kernel/blister.tst
+++ b/tst/testinstall/kernel/blister.tst
@@ -150,6 +150,11 @@ gap> UniteBlist([true,false,true], [true,false]);
 Error, UniteBlist: <blist1> must have the same length as <blist2> (lengths are\
  3 and 2)
 gap> x:= [false,true,true,false];;
+gap> UniteBlist(Immutable(x), [true,true,false,false]);
+Error, UniteBlist: <blist1> must be a mutable boolean list (not a list (boolea\
+n,imm))
+gap> x;
+[ false, true, true, false ]
 gap> UniteBlist(x, [true,true,false,false]);
 gap> x;
 [ true, true, true, false ]
@@ -165,6 +170,11 @@ e 1 and 2)
 gap> UniteBlistList([1,2], [true,false], fail);
 Error, UniteBlistList: <sub> must be a small list (not the value 'fail')
 gap> x:= [true,true,false];;
+gap> UniteBlistList([1,2,3], Immutable(x), [2,3]);
+Error, UniteBlistList: <blist> must be a mutable boolean list (not a list (boo\
+lean,imm))
+gap> x;
+[ true, true, false ]
 gap> UniteBlistList([1,2,3], x, [2,3]);
 gap> x;
 [ true, true, true ]
@@ -178,6 +188,11 @@ gap> IntersectBlist([true,false,true], [true,false]);
 Error, IntersectBlist: <blist1> must have the same length as <blist2> (lengths\
  are 3 and 2)
 gap> x:= [false,true,true,false];;
+gap> IntersectBlist(Immutable(x), [true,true,false,false]);
+Error, IntersectBlist: <blist1> must be a mutable boolean list (not a list (bo\
+olean,imm))
+gap> x;
+[ false, true, true, false ]
 gap> IntersectBlist(x, [true,true,false,false]);
 gap> x;
 [ false, true, false, false ]
@@ -191,6 +206,11 @@ gap> SubtractBlist([true,false,true], [true,false]);
 Error, SubtractBlist: <blist1> must have the same length as <blist2> (lengths \
 are 3 and 2)
 gap> x:= [false,true,true,false];;
+gap> SubtractBlist(Immutable(x), [true,true,false,false]);
+Error, SubtractBlist: <blist1> must be a mutable boolean list (not a list (boo\
+lean,imm))
+gap> x;
+[ false, true, true, false ]
 gap> SubtractBlist(x, [true,true,false,false]);
 gap> x;
 [ false, false, true, false ]
@@ -213,6 +233,11 @@ false
 gap> FLIP_BLIST(fail);
 Error, FlipBlist: <blist> must be a boolean list (not the value 'fail')
 gap> x:= [false,true,true,false];;
+gap> FlipBlist(Immutable(x));
+Error, FlipBlist: <blist> must be a mutable boolean list (not a list (boolean,\
+imm))
+gap> x;
+[ false, true, true, false ]
 gap> FLIP_BLIST(x);
 gap> x;
 [ true, false, false, true ]
@@ -232,6 +257,11 @@ gap> for i in [0..200] do
 gap> SET_ALL_BLIST(fail);
 Error, SetAllBitsBlist: <blist> must be a boolean list (not the value 'fail')
 gap> x:= [false,true,true,false];;
+gap> SET_ALL_BLIST(Immutable(x));
+Error, SetAllBitsBlist: <blist> must be a mutable boolean list (not a list (bo\
+olean,imm))
+gap> x;
+[ false, true, true, false ]
 gap> SET_ALL_BLIST(x);
 gap> x;
 [ true, true, true, true ]
@@ -250,6 +280,11 @@ gap> CLEAR_ALL_BLIST(fail);
 Error, ClearAllBitsBlist: <blist> must be a boolean list (not the value 'fail'\
 )
 gap> x:= [false,true,true,false];;
+gap> CLEAR_ALL_BLIST(Immutable(x));
+Error, ClearAllBitsBlist: <blist> must be a mutable boolean list (not a list (\
+boolean,imm))
+gap> x;
+[ false, true, true, false ]
 gap> CLEAR_ALL_BLIST(x);
 gap> x;
 [ false, false, false, false ]

--- a/tst/testinstall/kernel/blister.tst
+++ b/tst/testinstall/kernel/blister.tst
@@ -95,7 +95,7 @@ gap> IsPositionsList(d);
 false
 gap> x:=[1,2,3];;
 gap> x{a};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 
 # IsHomogBlist
 gap> List(l, IsHomogeneousList);

--- a/tst/testinstall/kernel/lists.tst
+++ b/tst/testinstall/kernel/lists.tst
@@ -61,9 +61,9 @@ Error, List Element: <list> must be a list (not the integer 1)
 
 #
 gap> ELMS_LIST(1,1);
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> ELMS_LIST([1],1);
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> ELMS_LIST([1],[2]);
 Error, List Elements: <list>[2] must have an assigned value
 gap> ELMS_LIST([1,2,3],[1,3]);
@@ -105,7 +105,7 @@ gap> l:=[];; ASS_LIST(l,1,1); l;
 gap> ASSS_LIST([1],[1],1);
 Error, List Assignments: <rhss> must be a dense list (not the integer 1)
 gap> ASSS_LIST([1],1,[1]);
-Error, List Assignments: <positions> must be a dense list of positive integers
+Error, List Assignments: <poss> must be a dense list of positive integers
 gap> ASSS_LIST(1,[1],[1]);
 Error, List Assignments: <list> must be a list (not the integer 1)
 gap> l:=[];; ASSS_LIST(l,[1],[1]); l;
@@ -115,7 +115,7 @@ gap> l:=[];; ASSS_LIST(l,[1],[1]); l;
 gap> ASSS_LIST_DEFAULT([1],[1],1);
 Error, List Assignments: <rhss> must be a dense list
 gap> ASSS_LIST_DEFAULT([1],1,[1]);
-Error, List Assignments: <positions> must be a dense list of positive integers
+Error, List Assignments: <poss> must be a dense list of positive integers
 gap> ASSS_LIST_DEFAULT(1,[1],[1]);
 Error, List Assignments: <list> must be a list (not the integer 1)
 gap> l:=[];; ASSS_LIST_DEFAULT(l,[1],[1]); l;

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -47,7 +47,7 @@ gap> a{[1]}{[1]}[1];
 gap> a{[1,,2]}:=1;
 Error, List Assignments: <rhss> must be a dense list (not the integer 1)
 gap> a{[1,,2]}:=[1,2];
-Error, List Assignments: <positions> must be a dense list of positive integers
+Error, List Assignments: <poss> must be a dense list of positive integers
 
 #
 gap> a{[1]}{[1]}[1] := 42;
@@ -66,10 +66,10 @@ gap> a{[1]}{[1]} := [ 18, 19 ];
 Error, List Assignments: <objs> must have the same length as <lists> (lengths \
 are 2 and 1)
 gap> a{[1]}{[1]} := [ [ 18, 19 ] ] ;
-Error, List Assignments: <objs> must have the same length as <positions> (leng\
-ths are 2 and 1)
+Error, List Assignments: <objs> must have the same length as <poss> (lengths a\
+re 2 and 1)
 gap> a{[1]}{[1,,3]} := [ [ [ 18, 19 ] ] ];
-Error, List Assignments: <positions> must be a dense list of positive integers
+Error, List Assignments: <poss> must be a dense list of positive integers
 gap> a{[1]}{[1]} := [ [ [ 18, 19 ] ] ];
 [ [ [ 18, 19 ] ] ]
 gap> a;
@@ -99,12 +99,12 @@ Unbind(a[1,1,1]);
 # slices
 #
 gap> 1{1};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 
 # ... for blists
 gap> list := [true,false,true];;
 gap> list{1};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> list{[4]};
 Error, List Elements: <list>[4] must have an assigned value
 gap> list{[1,2,3]} = list;  # with a plist as selector
@@ -121,7 +121,7 @@ Error, List Elements: <list>[4] must have an assigned value
 # ... for plists
 gap> list := [1, 2, 4];;
 gap> list{1};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> list{[4]};
 Error, List Elements: <list>[4] must have an assigned value
 gap> list{[1,2,3]} = list;  # with a plist as selector
@@ -138,7 +138,7 @@ Error, List Elements: <list>[4] must have an assigned value
 # ... for ranges
 gap> list := [1..3];;
 gap> list{1};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> list{[4]};
 Error, List Elements: <list>[4] must have an assigned value
 gap> list{[1,2,3]} = list;  # with a plist as selector
@@ -155,7 +155,7 @@ Error, List Elements: <list>[4] must have an assigned value
 # ... for strings
 gap> list := "abc";;
 gap> list{1};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> list{[4]};
 Error, List Elements: <list>[4] must have an assigned value
 gap> list{[1,2,3]} = list;  # with a plist as selector

--- a/tst/testinstall/range.tst
+++ b/tst/testinstall/range.tst
@@ -82,7 +82,7 @@ gap> [-5,-3..5]{[2..3]};
 gap> [-5,-3..5]{[2..4]};
 [ -3, -1 .. 1 ]
 gap> [-5,-3..5]{[0..7]};
-Error, List Elements: <positions> must be a dense list of positive integers
+Error, List Elements: <poss> must be a dense list of positive integers
 gap> [-5,-3..5]{[1..7]};
 Error, List Elements: <list>[7] must have an assigned value
 gap> [-5,-3..5]{[1..6]};
@@ -106,8 +106,8 @@ gap> x{[2,5,3]} := [7,8,9];
 gap> x;
 [ -5, 7, 9, 1, 8, 5 ]
 gap> x{[2,4]} := [2..4];
-Error, List Assignments: <rhss> must have the same length as <positions> (leng\
-ths are 3 and 2)
+Error, List Assignments: <rhss> must have the same length as <poss> (lengths a\
+re 3 and 2)
 gap> Immutable([-5,-3..5]){[2..3]} := [2..3];
 Error, List Assignments: <list> must be a mutable list
 gap> x := [-5,-3..5];


### PR DESCRIPTION
This conflicts with PR #3385, so that PR should be merged first; after which I can rebase and update this PR.

But I wanted to put it out now, to make sure I don't leave it bitrotting here for another half year ;-).

Resolves #3393