### PR TITLE
Give the plist TNUMS more human-readable names

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -2542,65 +2542,65 @@ static Obj FuncIsRectangularTablePlist(Obj self, Obj plist)
 *V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
 */
 static StructBagNames BagNames[] = {
-  { T_PLIST,                                "list (plain)" },
-  { T_PLIST            +IMMUTABLE,          "list (plain,imm)" },
+  { T_PLIST,                                "plain list" },
+  { T_PLIST            +IMMUTABLE,          "immutable plain list" },
 
-  { T_PLIST_NDENSE,                         "list (plain,ndense)" },
-  { T_PLIST_NDENSE     +IMMUTABLE,          "list (plain,ndense,imm)" },
+  { T_PLIST_NDENSE,                         "non-dense plain list" },
+  { T_PLIST_NDENSE     +IMMUTABLE,          "immutable non-dense plain list" },
 
-  { T_PLIST_DENSE,                          "list (plain,dense)" },
-  { T_PLIST_DENSE      +IMMUTABLE,          "list (plain,dense,imm)" },
+  { T_PLIST_DENSE,                          "dense plain list" },
+  { T_PLIST_DENSE      +IMMUTABLE,          "immutable dense plain list" },
 
-  { T_PLIST_DENSE_NHOM,                     "list (plain,dense,nhom)" },
-  { T_PLIST_DENSE_NHOM +IMMUTABLE,          "list (plain,dense,nhom,imm)" },
+  { T_PLIST_DENSE_NHOM,                     "dense non-homogeneous plain list" },
+  { T_PLIST_DENSE_NHOM +IMMUTABLE,          "immutable dense non-homogeneous plain list" },
 
-  { T_PLIST_DENSE_NHOM_SSORT,               "list (plain,dense,nhom,ssort)" },
-  { T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE,    "list (plain,dense,nhom,ssort,imm)" },
+  { T_PLIST_DENSE_NHOM_SSORT,               "dense non-homogeneous strictly-sorted plain list" },
+  { T_PLIST_DENSE_NHOM_SSORT +IMMUTABLE,    "immutable dense non-homogeneous strictly-sorted plain list" },
 
-  { T_PLIST_DENSE_NHOM_NSORT,               "list (plain,dense,nhom,nsort)" },
-  { T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE,    "list (plain,dense,nhom,nsort,imm)" },
+  { T_PLIST_DENSE_NHOM_NSORT,               "dense non-homogeneous non-strictly-sorted plain list" },
+  { T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE,    "immutable dense non-homogeneous non-strictly-sorted plain list" },
 
-  { T_PLIST_EMPTY,                          "list (plain,empty)" },
-  { T_PLIST_EMPTY      +IMMUTABLE,          "list (plain,empty,imm)" },
+  { T_PLIST_EMPTY,                          "empty plain list" },
+  { T_PLIST_EMPTY      +IMMUTABLE,          "immutable empty plain list" },
 
-  { T_PLIST_HOM,                            "list (plain,hom)" },
-  { T_PLIST_HOM        +IMMUTABLE,          "list (plain,hom,imm)" },
+  { T_PLIST_HOM,                            "homogeneous plain list" },
+  { T_PLIST_HOM        +IMMUTABLE,          "immutable homogeneous plain list" },
 
-  { T_PLIST_HOM_NSORT,                      "list (plain,hom,nsort)" },
-  { T_PLIST_HOM_NSORT  +IMMUTABLE,          "list (plain,hom,nsort,imm)" },
+  { T_PLIST_HOM_NSORT,                      "homogeneous non-strictly-sorted plain list" },
+  { T_PLIST_HOM_NSORT  +IMMUTABLE,          "immutable homogeneous non-strictly-sorted plain list" },
 
-  { T_PLIST_HOM_SSORT,                      "list (plain,hom,ssort)" },
-  { T_PLIST_HOM_SSORT +IMMUTABLE,           "list (plain,hom,ssort,imm)" },
+  { T_PLIST_HOM_SSORT,                      "homogeneous strictly-sorted plain list" },
+  { T_PLIST_HOM_SSORT +IMMUTABLE,           "immutable homogeneous strictly-sorted plain list" },
 
-  { T_PLIST_TAB,                            "list (plain,table)" },
-  { T_PLIST_TAB       +IMMUTABLE,           "list (plain,table,imm)" },
+  { T_PLIST_TAB,                            "plain list (table)" },
+  { T_PLIST_TAB       +IMMUTABLE,           "immutable plain list (table)" },
 
-  { T_PLIST_TAB_NSORT,                      "list (plain,table,nsort)" },
-  { T_PLIST_TAB_NSORT +IMMUTABLE,           "list (plain,table,nsort,imm)" },
+  { T_PLIST_TAB_NSORT,                      "non-strictly-sorted plain list (table)" },
+  { T_PLIST_TAB_NSORT +IMMUTABLE,           "immutable non-strictly-sorted plain list (table)" },
 
-  { T_PLIST_TAB_SSORT,                      "list (plain,table,ssort)" },
-  { T_PLIST_TAB_SSORT +IMMUTABLE,           "list (plain,table,ssort,imm)" },
+  { T_PLIST_TAB_SSORT,                      "strictly-sorted plain list (table)" },
+  { T_PLIST_TAB_SSORT +IMMUTABLE,           "immutable strictly-sorted plain list (table)" },
 
-  { T_PLIST_TAB_RECT,                       "list (plain,rect table)" },
-  { T_PLIST_TAB_RECT       +IMMUTABLE,      "list (plain,rect table,imm)" },
+  { T_PLIST_TAB_RECT,                       "plain list (rectangular table)" },
+  { T_PLIST_TAB_RECT       +IMMUTABLE,      "immutable plain list (rectangular table)" },
 
-  { T_PLIST_TAB_RECT_NSORT,                 "list (plain,rect table,nsort)" },
-  { T_PLIST_TAB_RECT_NSORT +IMMUTABLE,      "list (plain,rect table,nsort,imm)" },
+  { T_PLIST_TAB_RECT_NSORT,                 "non-strictly-sorted plain list (rectangular table)" },
+  { T_PLIST_TAB_RECT_NSORT +IMMUTABLE,      "immutable non-strictly-sorted plain list (rectangular table)" },
 
-  { T_PLIST_TAB_RECT_SSORT,                 "list (plain,rect table,ssort)" },
-  { T_PLIST_TAB_RECT_SSORT +IMMUTABLE,      "list (plain,rect table,ssort,imm)" },
+  { T_PLIST_TAB_RECT_SSORT,                 "strictly-sorted plain list (rectangular table)" },
+  { T_PLIST_TAB_RECT_SSORT +IMMUTABLE,      "immutable strictly-sorted plain list (rectangular table)" },
 
-  { T_PLIST_CYC,                            "list (plain,cyc)" },
-  { T_PLIST_CYC       +IMMUTABLE,           "list (plain,cyc,imm)" },
+  { T_PLIST_CYC,                            "plain list of cyclotomics" },
+  { T_PLIST_CYC       +IMMUTABLE,           "immutable plain list of cyclotomics" },
 
-  { T_PLIST_CYC_NSORT,                      "list (plain,cyc,nsort)" },
-  { T_PLIST_CYC_NSORT +IMMUTABLE,           "list (plain,cyc,nsort,imm)" },
+  { T_PLIST_CYC_NSORT,                      "non-strictly-sorted plain list of cyclotomics" },
+  { T_PLIST_CYC_NSORT +IMMUTABLE,           "immutable non-strictly-sorted plain list of cyclotomics" },
 
-  { T_PLIST_CYC_SSORT,                      "list (plain,cyc,ssort)" },
-  { T_PLIST_CYC_SSORT +IMMUTABLE,           "list (plain,cyc,ssort,imm)" },
+  { T_PLIST_CYC_SSORT,                      "strictly-sorted plain list of cyclotomics" },
+  { T_PLIST_CYC_SSORT +IMMUTABLE,           "immutable strictly-sorted plain list of cyclotomics" },
 
-  { T_PLIST_FFE,                     "list (sml fin fld elms)" },
-  { T_PLIST_FFE +IMMUTABLE,          "list (sml fin fld elms,imm)" },
+  { T_PLIST_FFE,                            "plain list of small finite field elements" },
+  { T_PLIST_FFE +IMMUTABLE,                 "immutable plain list of small finite field elements" },
 
   { -1,                                     "" }
 };

--- a/tst/testbugfix/2018-06-18-empty-OnTuples.tst
+++ b/tst/testbugfix/2018-06-18-empty-OnTuples.tst
@@ -9,10 +9,10 @@ gap> for i in [1, 2] do
 > new[i ^ perm] := Concatenation(new[i ^ perm], adj[i]);;
 > od;
 gap> List(new, TNAM_OBJ);
-[ "list (plain)", "list (plain)" ]
+[ "plain list", "plain list" ]
 gap> List(new, x -> OnTuples(x, perm));
 [ [  ], [ 1 ] ]
 gap> List(new, TNAM_OBJ);
-[ "list (plain)", "list (plain)" ]
+[ "plain list", "plain list" ]
 gap> List(new, x -> OnSets(x, perm));
 [ [  ], [ 1 ] ]

--- a/tst/testinstall/bitfields.tst
+++ b/tst/testinstall/bitfields.tst
@@ -60,7 +60,7 @@ Error, Field getter: <data> must be a small integer (not a ffe)
 gap> bf.setters[1](1, (1,2));
 Error, Field Setter: <val> must be a small integer (not a permutation (small))
 gap> bf.setters[1]([],1);
-Error, Field Setter: <data> must be a small integer (not a list (plain,empty))
+Error, Field Setter: <data> must be a small integer (not a empty plain list)
 gap> BuildBitfields([1],Z(5));
 Error, Fields builder: values must be small integers
 gap> MakeBitfields(100);

--- a/tst/testinstall/kbsemi.tst
+++ b/tst/testinstall/kbsemi.tst
@@ -51,7 +51,7 @@ gap> kbrws := KnuthBendixRewritingSystem(N);
 Knuth Bendix Rewriting System for Monoid( [ m1, m2 ] ) with rules 
 [ [ m2, m1 ] ]
 gap> kbrws := KnuthBendixRewritingSystem(N, {x,y} -> [y,x]);
-Error, <expr> must be 'true' or 'false' (not a list (plain,dense))
+Error, <expr> must be 'true' or 'false' (not a dense plain list)
 gap> kbrws := KnuthBendixRewritingSystem(N, \<);
 Knuth Bendix Rewriting System for Monoid( [ m1, m2 ] ) with rules 
 [ [ m2, m1 ] ]

--- a/tst/testinstall/kernel/stringobj.tst
+++ b/tst/testinstall/kernel/stringobj.tst
@@ -67,7 +67,7 @@ Error, STRING_SINTLIST: <val> must be a plain list of small integers or a rang\
 e (not the integer 1)
 gap> STRING_SINTLIST([ 'B' ]);
 Error, STRING_SINTLIST: <val> must be a plain list of small integers or a rang\
-e (not a list (plain,hom))
+e (not a homogeneous plain list)
 
 #
 gap> REVNEG_STRING(1);

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -246,56 +246,56 @@ gap> IsIdenticalObj(l[1], l[2]);
 true
 gap> l := ListWithIdenticalEntries(10, "GAP");;
 gap> TNAM_OBJ(l);
-"list (plain,hom)"
+"homogeneous plain list"
 gap> l;
 [ "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP", "GAP" ]
 gap> TNAM_OBJ(l);
-"list (plain,table)"
+"plain list (table)"
 gap> l := ListWithIdenticalEntries(10, PrimitiveRoot(GF(5)));
 [ Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5), Z(5) ]
 gap> TNAM_OBJ(l);
-"list (sml fin fld elms)"
+"plain list of small finite field elements"
 gap> l := ListWithIdenticalEntries(10, 5 / 7);
 [ 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7, 5/7 ]
 gap> TNAM_OBJ(l);
-"list (plain,cyc)"
+"plain list of cyclotomics"
 gap> l := ListWithIdenticalEntries(5, -1);
 [ -1, -1, -1, -1, -1 ]
 gap> TNAM_OBJ(l);
-"list (plain,cyc)"
+"plain list of cyclotomics"
 gap> l := ListWithIdenticalEntries(5, 8);
 [ 8, 8, 8, 8, 8 ]
 gap> TNAM_OBJ(l);
-"list (plain,cyc)"
+"plain list of cyclotomics"
 gap> l := ListWithIdenticalEntries(5, 0);
 [ 0, 0, 0, 0, 0 ]
 gap> TNAM_OBJ(l);
-"list (plain,cyc)"
+"plain list of cyclotomics"
 gap> l := ListWithIdenticalEntries(5, infinity);
 [ infinity, infinity, infinity, infinity, infinity ]
 gap> TNAM_OBJ(l);
-"list (plain,hom)"
+"homogeneous plain list"
 gap> l := ListWithIdenticalEntries(4, []);;
 gap> TNAM_OBJ(l);
-"list (plain,hom)"
+"homogeneous plain list"
 gap> l;
 [ [  ], [  ], [  ], [  ] ]
 gap> TNAM_OBJ(l);
-"list (plain,rect table)"
+"plain list (rectangular table)"
 gap> l := ListWithIdenticalEntries(4, [5]);;
 gap> TNAM_OBJ(l);
-"list (plain,hom)"
+"homogeneous plain list"
 gap> l;
 [ [ 5 ], [ 5 ], [ 5 ], [ 5 ] ]
 gap> TNAM_OBJ(l);
-"list (plain,rect table)"
+"plain list (rectangular table)"
 
 # Check TNUM behaviours
 gap> x := [1,,"cheese"];;
 gap> x[2] := 2;;
 gap> IsSSortedList(x);;
 gap> TNAM_OBJ(x);
-"list (plain,dense)"
+"dense plain list"
 gap> x := [1,,"cheese"];;
 gap> x[2] := 2;
 2
@@ -303,12 +303,12 @@ gap> y := Immutable(x);;
 gap> IsIdenticalObj(x,y);
 false
 gap> TNAM_OBJ(x);
-"list (plain)"
+"plain list"
 gap> TNAM_OBJ(y);
-"list (plain,imm)"
+"immutable plain list"
 gap> IsSSortedList(y);;
 gap> TNAM_OBJ(y);
-"list (plain,dense,nhom,ssort,imm)"
+"immutable dense non-homogeneous strictly-sorted plain list"
 
 # String, for a range
 gap> l := [5 .. 10];

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -201,7 +201,8 @@ gap> l := [];; Append(l,l); l;
 gap> l := [1,2,3,4];; Append(l,l); l;
 [ 1, 2, 3, 4, 1, 2, 3, 4 ]
 gap> Append(Immutable([1,2,3]), [1,2,3]);
-Error, Append: <list1> must be a mutable list (not a list (plain,cyc,imm))
+Error, Append: <list1> must be a mutable list (not a immutable plain list of c\
+yclotomics)
 gap> Append([1,2,3], () );
 Error, AppendList: <list2> must be a small list (not a permutation (small))
 gap> Append( () , [1,2,3] );
@@ -246,8 +247,8 @@ gap> CopyListEntries(s,3,-1,"abc",4,-3,2);
 Error, CopyListEntries: <tolst> must be a mutable plain list (not a list (stri\
 ng))
 gap> CopyListEntries(s,3,-1,Immutable([1,2,3]),4,-3,2);
-Error, CopyListEntries: <tolst> must be a mutable plain list (not a list (plai\
-n,cyc,imm))
+Error, CopyListEntries: <tolst> must be a mutable plain list (not a immutable \
+plain list of cyclotomics)
 gap> CopyListEntries(s, "cheese", 1, l, 1, 1, 2);
 Error, CopyListEntries: <fromind> must be a small integer (not a list (string)\
 )

--- a/tst/testinstall/opers/ListBlist.tst
+++ b/tst/testinstall/opers/ListBlist.tst
@@ -5,7 +5,8 @@ gap> ListBlist([],[false,true]);
 Error, ListBlist: <blist> must have the same length as <list> (lengths are 2 a\
 nd 0)
 gap> ListBlist([],[1,2]);
-Error, ListBlist: <blist> must be a boolean list (not a list (plain,cyc))
+Error, ListBlist: <blist> must be a boolean list (not a plain list of cyclotom\
+ics)
 gap> ListBlist([],[]);
 [  ]
 gap> ListBlist([1,2],[false,true]);

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -754,14 +754,14 @@ gap> IsInjectiveListTrans([1, 2], [2,3]);
 Error, the second argument must consist of positive integers in the range [1 .\
 . 2]
 gap> IsInjectiveListTrans([1, []], f);
-Error, the entries of the first argument must be positive integers (not a list\
- (plain,empty))
+Error, the entries of the first argument must be positive integers (not a empt\
+y plain list)
 gap> IsInjectiveListTrans([1, []], [1, 2, 3]);
-Error, the entries of the first argument must be positive integers (not a list\
- (plain,empty))
+Error, the entries of the first argument must be positive integers (not a empt\
+y plain list)
 gap> IsInjectiveListTrans([1, []], ID_TRANS4);
-Error, the entries of the first argument must be positive integers (not a list\
- (plain,empty))
+Error, the entries of the first argument must be positive integers (not a empt\
+y plain list)
 
 # Test PermLeftQuoTransformationNC
 gap> f := Transformation([3, 8, 1, 9, 9, 4, 10, 5, 10, 6]);;
@@ -1256,7 +1256,8 @@ gap> f := AsTransformation((1,2)(3,65537));;
 gap> h := INV_KER_TRANS([1, 2], f);
 Transformation( [ 2, 1 ] )
 gap> h := INV_KER_TRANS([1, 2], [1]);
-Error, INV_KER_TRANS: <f> must be a transformation (not a list (plain,cyc))
+Error, INV_KER_TRANS: <f> must be a transformation (not a plain list of cyclot\
+omics)
 
 # IS_IDEM_TRANS
 gap> IS_IDEM_TRANS(IdentityTransformation);

--- a/tst/testinstall/weakptr-badargs.tst
+++ b/tst/testinstall/weakptr-badargs.tst
@@ -5,8 +5,8 @@ gap> w := WeakPointerObj([1,,3,4]);;
 gap> SetElmWPObj(w, 0, 0);
 Error, SetElmWPObj: <pos> must be a positive small integer (not the integer 0)
 gap> SetElmWPObj(w, [1,2], 0);
-Error, SetElmWPObj: <pos> must be a positive small integer (not a list (plain,\
-cyc))
+Error, SetElmWPObj: <pos> must be a positive small integer (not a plain list o\
+f cyclotomics)
 gap> SetElmWPObj(w, (), 0);
 Error, SetElmWPObj: <pos> must be a positive small integer (not a permutation \
 (small))
@@ -17,30 +17,30 @@ gap> UnbindElmWPObj(w, 0);
 Error, UnbindElmWPObj: <pos> must be a positive small integer (not the integer\
  0)
 gap> UnbindElmWPObj(w, []);
-Error, UnbindElmWPObj: <pos> must be a positive small integer (not a list (pla\
-in,empty))
+Error, UnbindElmWPObj: <pos> must be a positive small integer (not a empty pla\
+in list)
 gap> UnbindElmWPObj([], 2);
-Error, UnbindElmWPObj: <wp> must be a weak pointer object (not a list (plain,e\
-mpty))
+Error, UnbindElmWPObj: <wp> must be a weak pointer object (not a empty plain l\
+ist)
 gap> ElmWPObj(w, 0);
 Error, ElmWPObj: <pos> must be a positive small integer (not the integer 0)
 gap> ElmWPObj(w, []);
-Error, ElmWPObj: <pos> must be a positive small integer (not a list (plain,emp\
-ty))
+Error, ElmWPObj: <pos> must be a positive small integer (not a empty plain lis\
+t)
 gap> ElmWPObj([], 1);
-Error, ElmWPObj: <wp> must be a weak pointer object (not a list (plain,empty))
+Error, ElmWPObj: <wp> must be a weak pointer object (not a empty plain list)
 gap> IsBoundElmWPObj(w, 0);
 Error, IsBoundElmWPObj: <pos> must be a positive small integer (not the intege\
 r 0)
 gap> IsBoundElmWPObj(w, []);
-Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a list (pl\
-ain,empty))
+Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a empty pl\
+ain list)
 gap> IsBoundElmWPObj([], 1);
-Error, IsBoundElmWPObj: <wp> must be a weak pointer object (not a list (plain,\
-empty))
+Error, IsBoundElmWPObj: <wp> must be a weak pointer object (not a empty plain \
+list)
 gap> LengthWPObj([]);
-Error, LengthWPObj: <wp> must be a weak pointer object (not a list (plain,empt\
-y))
+Error, LengthWPObj: <wp> must be a weak pointer object (not a empty plain list\
+)
 gap> LengthWPObj(0);
 Error, LengthWPObj: <wp> must be a weak pointer object (not the integer 0)
 gap> STOP_TEST( "weakptr-badargs.tst", 1);


### PR DESCRIPTION
We are increasingly printing out the TNUMs of types, and I had someone at GAP days ask me what "list (plain, nhom)" meant. A reasonable question!

This replaces the names with longer human-readable names. I'm happy for tweaks to the names (I find non-strictly-sorted long. I thought about writing "set" in that case, or non-strictly sorted?). This does make them much longer.

I notice we seem to use both homogeneous and homogenous, I went with the first, as it is (I believe) correct, and we use it much more.