### PR TITLE
FIX: ClosureSubgroup assumes closure is in parent.

### DIFF
--- a/doc/ref/fldabnum.xml
+++ b/doc/ref/fldabnum.xml
@@ -178,7 +178,7 @@ over a non-cyclotomic field.
 <P/>
 <Example><![CDATA[
 gap> g:= GaloisGroup( AsField( Field( [ Sqrt(5) ] ), CF(5) ) );
-<group with 1 generators>
+<group of size 2 with 1 generators>
 gap> gens:= GeneratorsOfGroup( g );
 [ ANFAutomorphism( AsField( NF(5,[ 1, 4 ]), CF(5) ), 4 ) ]
 gap> x:= last[1];;  x^2;

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2402,7 +2402,9 @@ local G,obj,close;
     else
       obj:= ClosureGroup( G, obj, arg[3] );
     fi;
+
     if close and not IsIdenticalObj( Parent( G ), obj ) then
+      Assert(2,IsSubset(Parent(G),obj));
       SetParent( obj, Parent( G ) );
     fi;
     return obj;

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -950,7 +950,9 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
       # make generators of homomorphism fit nicely to presentation
       gf:=IsomorphismFpGroup(a);
       e:=List(MappingGeneratorsImages(gf)[1],x->PreImagesRepresentative(hom,x));
-      k:=ClosureSubgroupNC(KernelOfMultiplicativeGeneralMapping(hom),e);
+      # we cannot guarantee that the parent contains e, so no
+      # ClosureSubgroup.
+      k:=ClosureGroup(KernelOfMultiplicativeGeneralMapping(hom),e);
       Add(nu,k);
       Add(nn,PreImage(hom,Stabilizer(i)));
       Add(nf,GroupHomomorphismByImagesNC(k,Range(gf),Concatenation(e,kg),

--- a/tst/testbugfix/2019-04-09-Lattice.tst
+++ b/tst/testbugfix/2019-04-09-Lattice.tst
@@ -1,0 +1,3 @@
+# see https://github.com/gap-system/gap/pull/3397
+gap> l:=AllSmallGroups(960,IsSolvableGroup,false);;g:=l[5];;
+gap> StructureDescription(g);;t:=TableOfMarks(g);;


### PR DESCRIPTION
Can happen in perfect subgroup computation, as reported by S.Bouc on 4/8/19.
Added assertion to catch this sitiuation in other cases.