### PR TITLE
Allow floating point values in memory command line options

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -868,7 +868,7 @@ static sizeMultiplier memoryUnits[]= {
 
 static UInt ParseMemory( Char * s)
 {
-  UInt size  = atol(s);
+  double size = atof(s);
   Char symbol =  s[strlen(s)-1];
   UInt i;
   UInt maxmem;
@@ -882,10 +882,9 @@ static UInt ParseMemory( Char * s)
     if (symbol == memoryUnits[i].symbol) {
       UInt value = memoryUnits[i].value;
       if (size > maxmem/value)
-        size = maxmem;
+        return maxmem;
       else
-        size *= value;
-      return size;
+        return size * value;
     }      
   }
   if (!IsDigit(symbol))


### PR DESCRIPTION
So, I always assumed that `-o 2.5G` did what I expected (allocated 2.5GB of memory), but turns out the `.5` was silently ignored. Switch to using `atof` so we parse a floating point number.

We still silently ignore badly written constants, but I think this is a useful improvement.

Release notes suggestion:

* Support floating point numbers when specifying how much memory GAP should use, for example "-o 2.5G".