### PR TITLE
Do not require SSortedLists are homogeneous

### DIFF
--- a/src/lists.c
+++ b/src/lists.c
@@ -1840,8 +1840,6 @@ Obj SET_FILTER_LIST(Obj list, Obj filter)
     if (FuncIS_SUBSET_FLAGS(0,flags,FLAGS_FILT(IsSSortListProp))==True) {
         new = SetFiltListTNums[TNUM_OBJ(list)][FN_IS_DENSE];
         if ( new < 0 )  goto error;
-        new = SetFiltListTNums[TNUM_OBJ(list)][FN_IS_HOMOG];
-        if ( new < 0 )  goto error;
         new = SetFiltListTNums[TNUM_OBJ(list)][FN_IS_SSORT];
         if ( new > 0 )  RetypeBag( list, new );  else goto error;
     }

--- a/tst/testbugfix/2019-04-10-SSortedList.tst
+++ b/tst/testbugfix/2019-04-10-SSortedList.tst
@@ -1,0 +1,7 @@
+# Check we can make non-homogeneous lists into SSortedLists.
+gap> l:= [ 1, Z(2) ];;
+gap> SetIsSSortedList( l, true );
+gap> IsSSortedList( l );
+true
+gap> Filtered( l, IsObject );
+[ 1, Z(2)^0 ]


### PR DESCRIPTION
Fixes #3398 

Basically, we were requiring SSortedLists be homogeneous. There was (I think) a point where that was true, but it's not a requirement any more.