### PR TITLE
RFC: kernel: remove FUNC_CALL, ARGI_{CALL,INFO}, NARG_SIZE_{CALL,INFO}, SIZE_NARG_{CALL,INFO}

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -155,10 +155,6 @@ void SET_VISITED_STAT(Stat stat)
 }
 
 
-#define SET_FUNC_CALL(call,x)   WRITE_EXPR(call, 0, x)
-#define SET_ARGI_CALL(call,i,x) WRITE_EXPR(call, i, x)
-
-
 static inline void PushOffsBody( void ) {
     GAP_ASSERT(CS(OffsBodyCount) < MAX_FUNC_EXPR_NESTING);
     CS(OffsBodyStack)[CS(OffsBodyCount)++] = CS(OffsBody);
@@ -720,19 +716,21 @@ void CodeFuncCallEnd (
     UInt                i;              /* loop variable                   */
     Expr                opts = 0;       /* record literal for the options  */
     Expr                wrapper;        /* wrapper for calls with options  */
+    UInt                size;
 
     /* allocate the function call                                          */
+    size = (nr + 1) * sizeof(Expr);
     if ( funccall && nr <= 6 ) {
-        call = NewExpr( EXPR_FUNCCALL_0ARGS+nr, SIZE_NARG_CALL(nr) );
+        call = NewExpr(EXPR_FUNCCALL_0ARGS + nr, size);
     }
     else if ( funccall /* && 6 < nr */ ) {
-        call = NewExpr( EXPR_FUNCCALL_XARGS,    SIZE_NARG_CALL(nr) );
+        call = NewExpr(EXPR_FUNCCALL_XARGS, size);
     }
     else if ( /* ! funccall && */ nr <=6 ) {
-        call = NewExpr( STAT_PROCCALL_0ARGS+nr, SIZE_NARG_CALL(nr) );
+        call = NewExpr(STAT_PROCCALL_0ARGS + nr, size);
     }
     else /* if ( ! funccall && 6 < nr ) */ {
-        call = NewExpr( STAT_PROCCALL_XARGS,    SIZE_NARG_CALL(nr) );
+        call = NewExpr(STAT_PROCCALL_XARGS, size);
     }
 
     /* get the options record if any */
@@ -742,12 +740,12 @@ void CodeFuncCallEnd (
     /* enter the argument expressions                                      */
     for ( i = nr; 1 <= i; i-- ) {
         arg = PopExpr();
-        SET_ARGI_CALL(call, i, arg);
+        WRITE_EXPR(call, i, arg);
     }
 
     /* enter the function expression                                       */
     func = PopExpr();
-    SET_FUNC_CALL(call, func);
+    WRITE_EXPR(call, 0, func);
 
     /* wrap up the call with the options */
     if (options)

--- a/src/code.c
+++ b/src/code.c
@@ -157,7 +157,6 @@ void SET_VISITED_STAT(Stat stat)
 
 #define SET_FUNC_CALL(call,x)   WRITE_EXPR(call, 0, x)
 #define SET_ARGI_CALL(call,i,x) WRITE_EXPR(call, i, x)
-#define SET_ARGI_INFO(info,i,x) WRITE_STAT(info, (i) - 1, x)
 
 
 static inline void PushOffsBody( void ) {
@@ -3088,12 +3087,12 @@ void CodeInfoEnd   (
     UInt                i;              /* loop variable                   */
 
     /* allocate the new statement                                          */
-    stat = NewStat( STAT_INFO, SIZE_NARG_INFO(2+narg) );
+    stat = NewStat(STAT_INFO, (2 + narg) * sizeof(Expr));
 
     /* narg only counts the printable arguments                            */
     for ( i = narg + 2; 0 < i; i-- ) {
         expr = PopExpr();
-        SET_ARGI_INFO(stat, i, expr);
+        WRITE_STAT(stat, i - 1, expr);
     }
 
     /* push the statement                                                  */

--- a/src/code.h
+++ b/src/code.h
@@ -592,27 +592,6 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 
 /****************************************************************************
 **
-*F  ARGI_INFO(<info>,<i>) . . .  <i>-th formal argument for an Info statement
-*F  NARG_SIZE_INFO(<size>)  . . . . number of arguments for an Info statement
-*F  SIZE_NARG_INFO(<narg>)  . . . . . . size of the bag for an Info statement
-**
-**  'ARGI_INFO' returns the expression   that evaluates to the <i>-th  actual
-**  argument for the Info  statement <info>.  This is a  legal left value, so
-**  it can be used to set the expression too.
-**
-**  'NARG_SIZE_INFO' returns the number of  arguments in a function call from
-**  the size <size> of the function call bag (as returned by 'SIZE_STAT').
-**
-**  'SIZE_NARG_INFO' returns the size a  function call bag  should have for a
-**  function call bag with <narg> arguments.
-*/
-#define ARGI_INFO(info,i)       READ_STAT(info, (i) - 1)
-#define NARG_SIZE_INFO(size)    ((size) / sizeof(Expr))
-#define SIZE_NARG_INFO(narg)    ((narg) * sizeof(Expr))
-
-
-/****************************************************************************
-**
 *V  CodeResult  . . . . . . . . . . . . . . . . . . . . . .  result of coding
 **
 **  'CodeResult'  is the result  of the coding, i.e.,   the function that was

--- a/src/code.h
+++ b/src/code.h
@@ -563,32 +563,6 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 
 #define READ_EXPR(expr, idx) (CONST_ADDR_EXPR(expr)[idx])
 
-/****************************************************************************
-**
-*F  FUNC_CALL(<call>) . . . . . . . . . . . . .  function for a function call
-*F  ARGI_CALL(<call>,<i>) . . . .  <i>-th formal argument for a function call
-*F  NARG_SIZE_CALL(<size>)  . . . . . number of arguments for a function call
-*F  SIZE_NARG_CALL(<narg>)  . . . . . . . size of the bag for a function call
-**
-**  'FUNC_CALL'  returns the expression that should  evaluate to the function
-**  for the procedure or  function call <call>.   This is a legal left value,
-**  so it can be used to set the expression too.
-**
-**  'ARGI_CALL'  returns  the expression that evaluate   to the <i>-th actual
-**  argument for the procedure or function call <call>.  This is a legal left
-**  value, so it can be used to set the expression too.
-**
-**  'NARG_SIZE_CALL' returns the number of  arguments in a function call from
-**  the size <size> of the function call bag (as returned by 'SIZE_EXPR').
-**
-**  'SIZE_NARG_CALL' returns the size a  function call bag  should have for a
-**  function call bag with <narg> arguments.
-*/
-#define FUNC_CALL(call)         READ_EXPR(call, 0)
-#define ARGI_CALL(call,i)       READ_EXPR(call, i)
-#define NARG_SIZE_CALL(size)    (((size) / sizeof(Expr)) - 1)
-#define SIZE_NARG_CALL(narg)    (((narg) + 1) * sizeof(Expr))
-
 
 /****************************************************************************
 **

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -4975,19 +4975,19 @@ static void CompInfo(Stat stat)
     Int                 i;
 
     Emit( "\n/* Info( ... ); */\n" );
-    sel = CompExpr( ARGI_INFO( stat, 1 ) );
-    lev = CompExpr( ARGI_INFO( stat, 2 ) );
+    sel = CompExpr(READ_STAT(stat, 0));
+    lev = CompExpr(READ_STAT(stat, 1));
     lst = CVAR_TEMP( NewTemp( "lst" ) );
     tmp = CVAR_TEMP( NewTemp( "tmp" ) );
     Emit( "%c = InfoCheckLevel( %c, %c );\n", tmp, sel, lev );
     Emit( "if ( %c == True ) {\n", tmp );
     if ( IS_TEMP_CVAR( tmp ) )  FreeTemp( TEMP_CVAR( tmp ) );
-    narg = NARG_SIZE_INFO(SIZE_STAT(stat))-2;
+    narg = SIZE_STAT(stat) / sizeof(Expr) - 2;
     Emit( "%c = NEW_PLIST( T_PLIST, %d );\n", lst, narg );
     Emit( "SET_LEN_PLIST( %c, %d );\n", lst, narg );
     for ( i = 1;  i <= narg;  i++ ) {
-        tmp = CompExpr( ARGI_INFO( stat, i+2 ) );
-        Emit( "SET_ELM_PLIST( %c, %d, %c );\n", lst, i, tmp );
+        tmp = CompExpr(READ_STAT(stat, i + 1));
+        Emit( "SET_ELM_PLIST( %c, %d, %c );\n", lst, i, tmp);
         Emit( "CHANGED_BAG(%c);\n", lst );
         if ( IS_TEMP_CVAR( tmp ) )  FreeTemp( TEMP_CVAR( tmp ) );
     }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -959,14 +959,18 @@ static CVar CompFunccall0to6Args(Expr expr)
     CVar                args [8];       /* arguments                       */
     Int                 narg;           /* number of arguments             */
     Int                 i;              /* loop variable                   */
+    Expr                funcExpr;
+
+    funcExpr = READ_EXPR(expr, 0);
+    narg = SIZE_STAT(expr) / sizeof(Expr) - 1;
 
     /* special case to inline 'Length'                                     */
     if ( CompFastListFuncs
-      && TNUM_EXPR( FUNC_CALL(expr) ) == EXPR_REF_GVAR
-      && READ_EXPR( FUNC_CALL(expr), 0 ) == G_Length
-      && NARG_SIZE_CALL(SIZE_EXPR(expr)) == 1 ) {
+      && TNUM_EXPR(funcExpr) == EXPR_REF_GVAR
+      && READ_EXPR(funcExpr, 0) == G_Length
+      && narg == 1 ) {
         result = CVAR_TEMP( NewTemp( "result" ) );
-        args[1] = CompExpr( ARGI_CALL(expr,1) );
+        args[1] = CompExpr(READ_EXPR(expr, 1));
         if ( CompFastPlainLists ) {
             Emit( "C_LEN_LIST_FPL( %c, %c )\n", result, args[1] );
         }
@@ -982,17 +986,16 @@ static CVar CompFunccall0to6Args(Expr expr)
     result = CVAR_TEMP( NewTemp( "result" ) );
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(expr) ) == EXPR_REF_GVAR ) {
-        func = CompRefGVarFopy( FUNC_CALL(expr) );
+    if (TNUM_EXPR(funcExpr) == EXPR_REF_GVAR) {
+        func = CompRefGVarFopy(funcExpr);
     }
     else {
-        func = CompExpr( FUNC_CALL(expr) );
+        func = CompExpr(funcExpr);
     }
 
     /* compile the argument expressions                                    */
-    narg = NARG_SIZE_CALL(SIZE_EXPR(expr));
     for ( i = 1; i <= narg; i++ ) {
-        args[i] = CompExpr( ARGI_CALL(expr,i) );
+        args[i] = CompExpr(READ_EXPR(expr, i));
     }
 
     /* emit the code for the function call                                 */
@@ -1040,25 +1043,28 @@ static CVar CompFunccallXArgs(Expr expr)
     CVar                argi;           /* <i>-th argument                 */
     UInt                narg;           /* number of arguments             */
     UInt                i;              /* loop variable                   */
+    Expr                funcExpr;
+
+    funcExpr = READ_EXPR(expr, 0);
 
     /* allocate a temporary for the result                                 */
     result = CVAR_TEMP( NewTemp( "result" ) );
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(expr) ) == EXPR_REF_GVAR ) {
-        func = CompRefGVarFopy( FUNC_CALL(expr) );
+    if (TNUM_EXPR(funcExpr) == EXPR_REF_GVAR) {
+        func = CompRefGVarFopy(funcExpr);
     }
     else {
-        func = CompExpr( FUNC_CALL(expr) );
+        func = CompExpr(funcExpr);
     }
 
     /* compile the argument expressions                                    */
-    narg = NARG_SIZE_CALL(SIZE_EXPR(expr));
+    narg = SIZE_STAT(expr) / sizeof(Expr) - 1;
     argl = CVAR_TEMP( NewTemp( "argl" ) );
     Emit( "%c = NEW_PLIST( T_PLIST, %d );\n", argl, narg );
     Emit( "SET_LEN_PLIST( %c, %d );\n", argl, narg );
     for ( i = 1; i <= narg; i++ ) {
-        argi = CompExpr( ARGI_CALL( expr, i ) );
+        argi = CompExpr(READ_EXPR(expr, i));
         Emit( "SET_ELM_PLIST( %c, %d, %c );\n", argl, i, argi );
         if ( ! HasInfoCVar( argi, W_INT_SMALL ) ) {
             Emit( "CHANGED_BAG( %c );\n", argl );
@@ -3575,6 +3581,10 @@ static void CompProccall0to6Args(Stat stat)
     CVar                args[8];        /* arguments                       */
     UInt                narg;           /* number of arguments             */
     UInt                i;              /* loop variable                   */
+    Expr                funcExpr;
+
+    funcExpr = READ_EXPR(stat, 0);
+    narg = SIZE_STAT(stat) / sizeof(Expr) - 1;
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -3583,11 +3593,11 @@ static void CompProccall0to6Args(Stat stat)
 
     /* special case to inline 'Add'                                        */
     if ( CompFastListFuncs
-      && TNUM_EXPR( FUNC_CALL(stat) ) == EXPR_REF_GVAR
-      && READ_EXPR( FUNC_CALL(stat), 0 ) == G_Add
-      && NARG_SIZE_CALL(SIZE_EXPR(stat)) == 2 ) {
-        args[1] = CompExpr( ARGI_CALL(stat,1) );
-        args[2] = CompExpr( ARGI_CALL(stat,2) );
+      && TNUM_EXPR(funcExpr) == EXPR_REF_GVAR
+      && READ_EXPR(funcExpr, 0 ) == G_Add
+      && narg == 2 ) {
+        args[1] = CompExpr(READ_EXPR(stat, 1));
+        args[2] = CompExpr(READ_EXPR(stat, 2));
         if ( CompFastPlainLists ) {
             Emit( "C_ADD_LIST_FPL( %c, %c )\n", args[1], args[2] );
         }
@@ -3600,17 +3610,16 @@ static void CompProccall0to6Args(Stat stat)
     }
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(stat) ) == EXPR_REF_GVAR ) {
-        func = CompRefGVarFopy( FUNC_CALL(stat) );
+    if (TNUM_EXPR(funcExpr) == EXPR_REF_GVAR) {
+        func = CompRefGVarFopy(funcExpr);
     }
     else {
-        func = CompExpr( FUNC_CALL(stat) );
+        func = CompExpr(funcExpr);
     }
 
     /* compile the argument expressions                                    */
-    narg = NARG_SIZE_CALL(SIZE_STAT(stat));
     for ( i = 1; i <= narg; i++ ) {
-        args[i] = CompExpr( ARGI_CALL(stat,i) );
+        args[i] = CompExpr(READ_EXPR(stat, i));
     }
 
     /* emit the code for the procedure call                                */
@@ -3651,6 +3660,9 @@ static void CompProccallXArgs(Stat stat)
     CVar                argi;           /* <i>-th argument                 */
     UInt                narg;           /* number of arguments             */
     UInt                i;              /* loop variable                   */
+    Expr                funcExpr;
+
+    funcExpr = READ_EXPR(stat, 0);
 
     /* print a comment                                                     */
     if ( CompPass == 2 ) {
@@ -3658,20 +3670,20 @@ static void CompProccallXArgs(Stat stat)
     }
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(stat) ) == EXPR_REF_GVAR ) {
-        func = CompRefGVarFopy( FUNC_CALL(stat) );
+    if (TNUM_EXPR(funcExpr) == EXPR_REF_GVAR) {
+        func = CompRefGVarFopy(funcExpr);
     }
     else {
-        func = CompExpr( FUNC_CALL(stat) );
+        func = CompExpr(funcExpr);
     }
 
     /* compile the argument expressions                                    */
-    narg = NARG_SIZE_CALL(SIZE_STAT(stat));
+    narg = SIZE_STAT(stat) / sizeof(Expr) - 1;
     argl = CVAR_TEMP( NewTemp( "argl" ) );
     Emit( "%c = NEW_PLIST( T_PLIST, %d );\n", argl, narg );
     Emit( "SET_LEN_PLIST( %c, %d );\n", argl, narg );
     for ( i = 1; i <= narg; i++ ) {
-        argi = CompExpr( ARGI_CALL( stat, i ) );
+        argi = CompExpr(READ_EXPR(stat, i));
         Emit( "SET_ELM_PLIST( %c, %d, %c );\n", argl, i, argi );
         if ( ! HasInfoCVar( argi, W_INT_SMALL ) ) {
             Emit( "CHANGED_BAG( %c );\n", argl );

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -106,20 +106,19 @@ static UInt ExecProccallOpts(Stat call)
 
 /****************************************************************************
 **
-*F  ExecProccall0args(<call>)  .  execute a procedure call with 0    arguments
-*F  ExecProccall1args(<call>)  .  execute a procedure call with 1    arguments
-*F  ExecProccall2args(<call>)  .  execute a procedure call with 2    arguments
-*F  ExecProccall3args(<call>)  .  execute a procedure call with 3    arguments
-*F  ExecProccall4args(<call>)  .  execute a procedure call with 4    arguments
-*F  ExecProccall5args(<call>)  .  execute a procedure call with 5    arguments
-*F  ExecProccall6args(<call>)  .  execute a procedure call with 6    arguments
-*F  ExecProccallXargs(<call>)  .  execute a procedure call with more arguments
+*F  ExecProccall0args(<call>) .  execute a procedure call with 0    arguments
+*F  ExecProccall1args(<call>) .  execute a procedure call with 1    arguments
+*F  ExecProccall2args(<call>) .  execute a procedure call with 2    arguments
+*F  ExecProccall3args(<call>) .  execute a procedure call with 3    arguments
+*F  ExecProccall4args(<call>) .  execute a procedure call with 4    arguments
+*F  ExecProccall5args(<call>) .  execute a procedure call with 5    arguments
+*F  ExecProccall6args(<call>) .  execute a procedure call with 6    arguments
+*F  ExecProccallXargs(<call>) .  execute a procedure call with more arguments
 **
-**  'ExecProccall<i>args'  executes  a  procedure   call   to the    function
-**  'FUNC_CALL(<call>)'   with   the   arguments   'ARGI_CALL(<call>,1)'   to
-**  'ARGI_CALL(<call>,<i>)'.  It discards the value returned by the function
-**  and returns the statement execution status (as per EXEC_STAT, q.v.)
-**  resulting from the procedure call, which in fact is always 0.
+**  'ExecProccall<i>args'  executes  a procedure  call  to  a  GAP  function.
+**  It discards the value returned by the function and returns the statement
+**  execution status (as per EXEC_STAT, q.v.) resulting from the procedure
+**  call, which in fact is always 0.
 */
 
 static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call)
@@ -130,20 +129,20 @@ static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call)
     Obj result;
 
     // evaluate the function
-    func = EVAL_EXPR( FUNC_CALL( call ) );
- 
+    func = EVAL_EXPR(READ_EXPR(call, 0));
+
     // evaluate the arguments
     if (nr <= 6 && TNUM_OBJ(func) == T_FUNCTION) {
         for (UInt i = 1; i <= nr; i++) {
-            a[i - 1] = EVAL_EXPR(ARGI_CALL(call, i));
+            a[i - 1] = EVAL_EXPR(READ_EXPR(call, i));
         }
     }
     else {
-        UInt realNr = NARG_SIZE_CALL(SIZE_STAT(call));
+        UInt realNr = SIZE_STAT(call) / sizeof(Expr) - 1;
         args = NEW_PLIST(T_PLIST, realNr);
         SET_LEN_PLIST(args, realNr);
         for (UInt i = 1; i <= realNr; i++) {
-            Obj argi = EVAL_EXPR(ARGI_CALL(call, i));
+            Obj argi = EVAL_EXPR(READ_EXPR(call, i));
             SET_ELM_PLIST(args, i, argi);
             CHANGED_BAG(args);
         }
@@ -256,7 +255,7 @@ static UInt ExecProccall6args(Stat call)
 
 static UInt ExecProccallXargs(Stat call)
 {
-    // pass in 7 (instead of NARG_SIZE_CALL(SIZE_STAT(call)))
+    // pass in 7 instead of the actual number of arguments,
     // to allow the compiler to perform better optimizations
     // (as we know that the number of arguments is >= 7 here)
     EvalOrExecCall(1, 7, call);
@@ -292,18 +291,17 @@ static Obj EvalFunccallOpts(Expr call)
 
 /****************************************************************************
 **
-*F  EvalFunccall0args(<call>)  . . execute a function call with 0    arguments
-*F  EvalFunccall1args(<call>)  . . execute a function call with 1    arguments
-*F  EvalFunccall2args(<call>)  . . execute a function call with 2    arguments
-*F  EvalFunccall3args(<call>)  . . execute a function call with 3    arguments
-*F  EvalFunccall4args(<call>)  . . execute a function call with 4    arguments
-*F  EvalFunccall5args(<call>)  . . execute a function call with 5    arguments
-*F  EvalFunccall6args(<call>)  . . execute a function call with 6    arguments
-*F  EvalFunccallXargs(<call>)  . . execute a function call with more arguments
+*F  EvalFunccall0args(<call>) . . execute a function call with 0    arguments
+*F  EvalFunccall1args(<call>) . . execute a function call with 1    arguments
+*F  EvalFunccall2args(<call>) . . execute a function call with 2    arguments
+*F  EvalFunccall3args(<call>) . . execute a function call with 3    arguments
+*F  EvalFunccall4args(<call>) . . execute a function call with 4    arguments
+*F  EvalFunccall5args(<call>) . . execute a function call with 5    arguments
+*F  EvalFunccall6args(<call>) . . execute a function call with 6    arguments
+*F  EvalFunccallXargs(<call>) . . execute a function call with more arguments
 **
-**  'EvalFunccall<i>args'  executes  a     function call   to   the  function
-**  'FUNC_CALL(<call>)'    with  the   arguments    'ARGI_CALL(<call>,1)'  to
-**  'ARGI_CALL(<call>,<i>)'.  It returns the value returned by the function.
+**  'EvalFunccall<i>args'  executes  a  function  call  to  a  GAP  function.
+**  It returns the value returned by the function.
 */
 
 static Obj EvalFunccall0args(Expr call)
@@ -343,7 +341,7 @@ static Obj EvalFunccall6args(Expr call)
 
 static Obj EvalFunccallXargs(Expr call)
 {
-    // pass in 7 (instead of NARG_SIZE_CALL(SIZE_EXPR(call)))
+    // pass in 7 instead of the actual number of arguments,
     // to allow the compiler to perform better optimizations
     // (as we know that the number of arguments is >= 7 here)
     return EvalOrExecCall(0, 7, call);
@@ -730,15 +728,16 @@ static void            PrintFunccall1 (
 
     /* print the expression that should evaluate to a function             */
     Pr("%2>",0L,0L);
-    PrintExpr( FUNC_CALL(call) );
+    PrintExpr(READ_EXPR(call, 0));
 
     /* print the opening parenthesis                                       */
     Pr("%<( %>",0L,0L);
 
     /* print the expressions that evaluate to the actual arguments         */
-    for ( i = 1; i <= NARG_SIZE_CALL( SIZE_EXPR(call) ); i++ ) {
-        PrintExpr( ARGI_CALL(call,i) );
-        if ( i != NARG_SIZE_CALL( SIZE_EXPR(call) ) ) {
+    const UInt nr = SIZE_EXPR(call) / sizeof(Expr) - 1;
+    for (i = 1; i <= nr; i++) {
+        PrintExpr(READ_EXPR(call, i));
+        if (i != nr) {
             Pr("%<, %>",0L,0L);
         }
     }

--- a/src/stats.c
+++ b/src/stats.c
@@ -847,14 +847,14 @@ static UInt ExecInfo(Stat stat)
     Obj             args;
     Obj             arg;
 
-    selectors = EVAL_EXPR( ARGI_INFO( stat, 1 ) );
-    level = EVAL_EXPR( ARGI_INFO( stat, 2) );
+    selectors = EVAL_EXPR(READ_STAT(stat, 0));
+    level = EVAL_EXPR(READ_STAT(stat, 1));
 
     selected = InfoCheckLevel(selectors, level);
     if (selected == True) {
 
         /* Get the number of arguments to be printed                       */
-        narg = NARG_SIZE_INFO(SIZE_STAT(stat)) - 2;
+        narg = SIZE_STAT(stat) / sizeof(Expr) - 2;
 
         /* set up a list                                                   */
         args = NEW_PLIST( T_PLIST, narg );
@@ -868,7 +868,7 @@ static UInt ExecInfo(Stat stat)
                of arg, which may happen after the pointer to args has been
                extracted
             */
-            arg = EVAL_EXPR(ARGI_INFO(stat, i+2));
+            arg = EVAL_EXPR(READ_STAT(stat, i + 1));
             SET_ELM_PLIST(args, i, arg);
             CHANGED_BAG(args);
         }
@@ -1413,9 +1413,10 @@ static void PrintInfo(Stat stat)
     Pr("%<( %>",0L,0L);
 
     /* print the expressions that evaluate to the actual arguments         */
-    for ( i = 1; i <= NARG_SIZE_INFO( SIZE_STAT(stat) ); i++ ) {
-        PrintExpr( ARGI_INFO(stat,i) );
-        if ( i != NARG_SIZE_INFO( SIZE_STAT(stat) ) ) {
+    UInt narg = SIZE_STAT(stat) / sizeof(Expr);
+    for (i = 1; i <= narg; i++) {
+        PrintExpr(READ_STAT(stat, i - 1));
+        if (i != narg) {
             Pr("%<, %>",0L,0L);
         }
     }

--- a/tst/test-compile/info.g
+++ b/tst/test-compile/info.g
@@ -6,5 +6,5 @@ runtest := function()
     Print(InfoLevel(InfoDebug),"\n");
     Info(InfoDebug, 3, "Do not print");
     Info(InfoDebug, 2, "print this B");
-    Info(InfoDebug, 1, "print this C");
+    Info(InfoDebug, 1, "print ", "this ", "C");
 end;

--- a/tst/test-compile/info.g.dynamic.c
+++ b/tst/test-compile/info.g.dynamic.c
@@ -1,6 +1,6 @@
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "58141340"
+#define FILE_CRC  "121059807"
 
 /* global variables used in handlers */
 static GVar G_Print;
@@ -140,10 +140,16 @@ static Obj  HdlrFunc2 (
  CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
-  t_2 = NEW_PLIST( T_PLIST, 1 );
-  SET_LEN_PLIST( t_2, 1 );
-  t_3 = MakeString( "print this C" );
+  t_2 = NEW_PLIST( T_PLIST, 3 );
+  SET_LEN_PLIST( t_2, 3 );
+  t_3 = MakeString( "print " );
   SET_ELM_PLIST( t_2, 1, t_3 );
+  CHANGED_BAG(t_2);
+  t_3 = MakeString( "this " );
+  SET_ELM_PLIST( t_2, 2, t_3 );
+  CHANGED_BAG(t_2);
+  t_3 = MakeString( "C" );
+  SET_ELM_PLIST( t_2, 3, t_3 );
   CHANGED_BAG(t_2);
   InfoDoPrint( t_1, INTOBJ_INT(1), t_2 );
  }
@@ -176,7 +182,7 @@ static Obj  HdlrFunc1 (
       Print( InfoLevel( InfoDebug ), "\n" );
       Info( InfoDebug, 3, "Do not print" );
       Info( InfoDebug, 2, "print this B" );
-      Info( InfoDebug, 1, "print this C" );
+      Info( InfoDebug, 1, "print ", "this ", "C" );
       return;
   end; */
  t_1 = NewFunction( NameFunc[2], 0, 0, HdlrFunc2 );
@@ -270,7 +276,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_DYNAMIC,
  .name        = "info.g",
- .crc         = 58141340,
+ .crc         = 121059807,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/tst/test-compile/info.g.static.c
+++ b/tst/test-compile/info.g.static.c
@@ -1,6 +1,6 @@
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "58141340"
+#define FILE_CRC  "121059807"
 
 /* global variables used in handlers */
 static GVar G_Print;
@@ -140,10 +140,16 @@ static Obj  HdlrFunc2 (
  CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
-  t_2 = NEW_PLIST( T_PLIST, 1 );
-  SET_LEN_PLIST( t_2, 1 );
-  t_3 = MakeString( "print this C" );
+  t_2 = NEW_PLIST( T_PLIST, 3 );
+  SET_LEN_PLIST( t_2, 3 );
+  t_3 = MakeString( "print " );
   SET_ELM_PLIST( t_2, 1, t_3 );
+  CHANGED_BAG(t_2);
+  t_3 = MakeString( "this " );
+  SET_ELM_PLIST( t_2, 2, t_3 );
+  CHANGED_BAG(t_2);
+  t_3 = MakeString( "C" );
+  SET_ELM_PLIST( t_2, 3, t_3 );
   CHANGED_BAG(t_2);
   InfoDoPrint( t_1, INTOBJ_INT(1), t_2 );
  }
@@ -176,7 +182,7 @@ static Obj  HdlrFunc1 (
       Print( InfoLevel( InfoDebug ), "\n" );
       Info( InfoDebug, 3, "Do not print" );
       Info( InfoDebug, 2, "print this B" );
-      Info( InfoDebug, 1, "print this C" );
+      Info( InfoDebug, 1, "print ", "this ", "C" );
       return;
   end; */
  t_1 = NewFunction( NameFunc[2], 0, 0, HdlrFunc2 );
@@ -270,7 +276,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "info.g",
- .crc         = 58141340,
+ .crc         = 121059807,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,


### PR DESCRIPTION
This is a subset of PR #3257, and quite possibly controversial. After all, why remove access helper functions and replace them with raw access? Well, the immediate reason in PR #3257 is the following: Right now, any access to function bodies (i.e., `T_BODY` kernel objects), be it to write them (during code), execute them, print them, or turn them into a GAP readable form via `SyntaxTree`, requires that one sets the global variable `STATE(PtrBody)` to point to the `T_BODY` (via `SWITCH_TO_NEW_LVARS`); then perform the access; then restore`STATE(PtrBody)` (via `SWITCH_TO_OLD_LVARS`). This is rather awkward. So, why is it done? Well, for the *executor*, this is an optimization: it allows us to avoids lots of calls to `ADDR_OBJ`/`PTR_BAG`. That the other kinds of access go through it, though, is not necessary at all; and so my goal is to change this. The hope is that ultimately, the code accessing the `T_BODY` objects will get simpler and thus easier to maintain, and to learn about for people interested in them. And at the same time, it might enable further optimizations for the executor (for starters, we then could turn `STATE(PtrBody)` into a const pointer).

The problem now is that the new code, which does not set `STATE(PtrBody)`, cannot use `ARGI_CALL` etc. anymore, as those implicitly go through `STATE(PtrBody)`.

This now leads me to my request for comments: I see the following alternatives, and I am interested to learn what others thinks; perhaps you have additional ideas; and anyway, it's good for myself to spell these out. Ultimately, I'd prefer an approach that also allows us to cover other types of statements and expressions, though.

1. Just live without these accessors (i.e., what this PR does right now); after all, we do that for all other statement types, whose structure often is of similar complexity, or even more complex, and not documented explicitly anywhere either. (Of course "other code is not documented well" is not exactly a great argument; but here it still has *some* merit, I'd argue. But I hope we can do better...)

2. Leave `FUNC_CALL`, `ARGI_CALL`, etc. in, but add in alternates, say, `FUNC_CALL_IN_BODY`, which also gets the `Obj body` as an argument, and switch code to use those as it transitions from using `STATE(PtrBody)` to passing the body object explicitly. (We can reduce code duplication by adding `FUNC_CALL_PTR` etc. which works similar to the next suggestion:)

3. Replace `FUNC_CALL(call)` by a helper function `Expr FUNC_CALL(void *ptrBody, Expr call)`; the first argument then either is `STATE(PtrBody)`, or else `ADDR_OBJ(body)`, depending on the use case.

4. Add C `struct`s which describe the layout of a function call, then use these for access. Something like this:
```C
struct CodedFuncCall {
   Expr func; // the function to call
   Expr args[]; // the arguments, as a variable length array
};
```
   However, this does not actually solve the whole problem, as we'd still need something like `NARG_SIZE_CALL` and `SIZE_NARG_CALL`. Moreover, flexible array members (i.e.,. `Expr args[];`) are not supported by C++, making this change very potentially problematic for kernel extensions with C++ code, and also possible future conversions of select GAP source files from C to C++.

5. Use a lightweight C++ class to abstract this (in a sense, that seems like the nicest solution to me, but earlier we agreed that we want to be very, very careful and restrictive about adding more C++ code, esp. code using C++ features we are not using yet...). In our case, this could work as follows (of course there is also a lot of potential for inheritance here, but I'll try to keep it simple; also, this code is untested and incomplete, and just meant to give an idea):
```C++
class CodedFuncCall {
  void * ptr;
public:
  // constructors for reading
  CodedFuncCall(Stat stat) : ptr(STATE(PtrBody) + stat) { }
  CodedFuncCall(Obj body, Stat stat) : ptr(ADDR_OBJ(body) + stat) { }
  // constructor for writing
  CodedFuncCall(int narg) {
    Stat stat = NewStat(T_FUNCCALL+narg, (1+narg)*sizeof(Expr));
    ptr = STATE(PtrBody) + stat;
  }
  
  // these could be moved to a parent class
  int size() const { return ((const StatHeader *)ptr - 1)->size; }
  int type() const { return ((const StatHeader *)ptr - 1)->type; }
  
  // reading (with const qualifier, so can be called on const instances)
  int narg() const { return size() / sizeof(Expr) - 1; }
  Expr func() const { return ptr[0]; }
  Expr arg(int i) const {
     GAP_ASSERT(1 <= i && i <= narg());
     return ptr[i];
  }

  // writing (for coding)
  void setFunc(Expr expr) { ptr[0] = expr; }
  Expr setArg(int i, Expr expr) {
     GAP_ASSERT(1 <= i && i <= narg());
     ptr[i] = expr;
  }
};
...

  const CodedFuncCall theCall(body, stat); // for reading only, hence const
  for (i = 1; i <= theCall.nargs(); i++) {
    Expr arg = theCall.arg(i);
    ... now do somethingn with the argument...
    theCall.setFunc(0); // will lead to a compiler error, as theCall is const
  }
```

6. ... some other ideas... ?