### PR TITLE
Add tests for viewing/printing nested self-referential lists/records, and cleanup related code

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -101,7 +101,6 @@ typedef struct GAPState {
                                    // that use GAP as a library to handle errors
 
     /* From objects.c */
-    Int PrintObjIndex;
     Int PrintObjDepth;
 
     /* From info.c */

--- a/src/lists.c
+++ b/src/lists.c
@@ -1759,7 +1759,7 @@ static void PrintListDefault(Obj list)
         if ( elm != 0 ) {
             if (1 < i)
                 Pr("%<,%< %2>", 0L, 0L);
-            STATE(PrintObjIndex) = i;
+            SetPrintObjIndex(i);
             PrintObj( elm );
         }
         else {

--- a/src/objects.c
+++ b/src/objects.c
@@ -47,6 +47,7 @@ static ModuleStateOffset ObjectsStateOffset = -1;
 
 typedef struct {
     Obj   PrintObjThis;
+    Int   PrintObjIndex;
 #if defined(HPCGAP)
     Obj   PrintObjThissObj;
     Obj * PrintObjThiss;
@@ -920,14 +921,14 @@ void            PrintObj (
 
     if ( !fromview  && 0 < STATE(PrintObjDepth) ) {
         os->PrintObjThiss[STATE(PrintObjDepth)-1]   = os->PrintObjThis;
-        os->PrintObjIndices[STATE(PrintObjDepth)-1] = STATE(PrintObjIndex);
+        os->PrintObjIndices[STATE(PrintObjDepth)-1] = os->PrintObjIndex;
     }
 
     /* handle the <obj>                                                    */
     if (!fromview) {
         STATE(PrintObjDepth) += 1;
         os->PrintObjThis   = obj;
-        STATE(PrintObjIndex)  = 0;
+        os->PrintObjIndex  = 0;
     }
 
     /* dispatch to the appropriate printing function                       */
@@ -958,7 +959,7 @@ void            PrintObj (
         /* if <obj> is a subobject, then restore and unmark the superobject*/
         if ( 0 < STATE(PrintObjDepth) ) {
             os->PrintObjThis  = os->PrintObjThiss[STATE(PrintObjDepth)-1];
-            STATE(PrintObjIndex) = os->PrintObjIndices[STATE(PrintObjDepth)-1];
+            os->PrintObjIndex = os->PrintObjIndices[STATE(PrintObjDepth)-1];
         }
     }
     LastPV = lastPV;
@@ -1002,11 +1003,15 @@ static Obj PrintObjHandler(Obj self, Obj obj)
 }
 
 
-static Obj FuncSET_PRINT_OBJ_INDEX(Obj self, Obj ind)
+void SetPrintObjIndex(Int index)
 {
-  if (IS_INTOBJ(ind))
-    STATE(PrintObjIndex) = INT_INTOBJ(ind);
-  return 0;
+    MODULE_STATE(Objects).PrintObjIndex = index;
+}
+
+static Obj FuncSET_PRINT_OBJ_INDEX(Obj self, Obj index)
+{
+    SetPrintObjIndex(GetSmallInt("SET_PRINT_OBJ_INDEX", index));
+    return 0;
 }
 
 
@@ -1051,13 +1056,13 @@ void            ViewObj (
 
     if ( 0 < STATE(PrintObjDepth) ) {
         os->PrintObjThiss[STATE(PrintObjDepth)-1]   = os->PrintObjThis;
-        os->PrintObjIndices[STATE(PrintObjDepth)-1] =  STATE(PrintObjIndex);
+        os->PrintObjIndices[STATE(PrintObjDepth)-1] = os->PrintObjIndex;
     }
 
     /* handle the <obj>                                                    */
     STATE(PrintObjDepth) += 1;
     os->PrintObjThis   = obj;
-    STATE(PrintObjIndex)  = 0;
+    os->PrintObjIndex  = 0;
 
     /* dispatch to the appropriate viewing function                       */
 
@@ -1086,7 +1091,7 @@ void            ViewObj (
     /* if <obj> is a subobject, then restore and unmark the superobject    */
     if ( 0 < STATE(PrintObjDepth) ) {
         os->PrintObjThis  = os->PrintObjThiss[STATE(PrintObjDepth)-1];
-        STATE(PrintObjIndex) = os->PrintObjIndices[STATE(PrintObjDepth)-1];
+        os->PrintObjIndex = os->PrintObjIndices[STATE(PrintObjDepth)-1];
     }
 
     LastPV = lastPV;

--- a/src/objects.h
+++ b/src/objects.h
@@ -757,6 +757,8 @@ void PrintObj(Obj obj);
 
 extern Obj PrintObjOper;
 
+void SetPrintObjIndex(Int index);
+
 
 /****************************************************************************
 **

--- a/tst/testinstall/tilde.tst
+++ b/tst/testinstall/tilde.tst
@@ -1,4 +1,4 @@
-#@local aqq,bool,f,l,list1,list2,r,rec1,rec2,rem,i
+#@local aqq,bool,f,l,r,l2,r2,l3,r3,list1,list2,rec1,rec2,rem,i
 gap> START_TEST("tilde.tst");
 
 #
@@ -31,6 +31,54 @@ gap> [ 1, 2, [0 .. Length(~)] ];
 [ 1, 2, [ 0 .. 2 ] ]
 gap> [0, 1 + ~, 2 ];
 [ 0, [ 1 ], 2 ]
+
+#
+# Test viewing of nested self-referential lists and records
+# (involves kernel vars PrintObjDepth, PrintObjIndex, ...)
+#
+gap> l := [ ~ ];
+[ ~ ]
+gap> r := rec(a:=~);
+rec( a := ~ )
+gap> l2 := [l, r];
+[ [ ~[1] ], rec( a := ~[2] ) ]
+gap> r2 := rec(l:=l, r:=r);
+rec( l := [ ~.l ], r := rec( a := ~.r ) )
+gap> l3 := [ l2, r2 ];
+[ [ [ ~[1][1] ], rec( a := ~[1][2] ) ], 
+  rec( l := [ ~[2].l ], r := rec( a := ~[2].r ) ) ]
+gap> r3:= rec( a:= l2, b := r2 );
+rec( a := [ [ ~.a[1] ], rec( a := ~.a[2] ) ], 
+  b := rec( l := [ ~.b.l ], r := rec( a := ~.b.r ) ) )
+
+# now also test printing
+gap> Print(l, "\n");
+[ ~ ]
+gap> Print(l2, "\n");
+[ [ ~[1] ], rec(
+      a := ~[2] ) ]
+gap> Print(l3, "\n");
+[ [ [ ~[1][1] ], rec(
+          a := ~[1][2] ) ], rec(
+      l := [ ~[2].l ],
+      r := rec(
+          a := ~[2].r ) ) ]
+gap> Print(r, "\n");
+rec(
+  a := ~ )
+gap> Print(r2, "\n");
+rec(
+  l := [ ~.l ],
+  r := rec(
+      a := ~.r ) )
+gap> Print(r3, "\n");
+rec(
+  a := [ [ ~.a[1] ], rec(
+          a := ~.a[2] ) ],
+  b := rec(
+      l := [ ~.b.l ],
+      r := rec(
+          a := ~.b.r ) ) )
 
 #
 gap> [ (x->~)(1) ];


### PR DESCRIPTION
Another old change I had sitting on my hard disk for far too long:

At some point I tried to understand how the recursive printing/viewing of self-referential objects worked, and to help me, I very mildly refactored the code, and added some test cases that trigger this code.

I actually came to the conclusion that a subtle problem exists with this code, albeit in such a remote fringe case that I am not surprised if nobody ever run into it or will ever run into it (unless they deliberately try to trigger it): if printing is interrupted by a break loop, then we reset the "PrintObj stack" in `Shell()`, and later "restore" it, like this:
```C
  oldPrintDepth = STATE(PrintObjDepth);
  STATE(PrintObjDepth) = 0;
...
  STATE(PrintObjDepth) = oldPrintDepth;
```
But obviously this is *not* sufficient to actually save/restore the PrintObj stack! Thus, if we print a self-referential list; which is interrupted by a break loop; then print another or the same self-referential list during the break loop; and then return; then the PrintObj stack will be corrupt, and all kinds of weird stuff might happen: most likely, garbage is printed or errors are triggered for OOB access to lists or records. From a cursory glance, I don't think it would crash, but I wouldn't want to rule that out either without digging deeper.

If somebody wants to try to reproduce this, they could then also look into fixing this: I'd try to add functions `SavePrintObjStack` and `RestorePrintObjStack` which get called from `Shell`, and which copy/restore the state to some auxiliary object (probably a plist, or something slightly more complex), and restores from there as wel.