### PR TITLE
Do not end pragma scanning at \t (horizontal tab) character

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -754,7 +754,7 @@ static void GetPragma(void)
     UInt i = 0;
     Char c = PEEK_CURR_CHAR();
 
-    while ( c != '\n' && c != '\r' && c != '\f' && c != '\t' && c != '\377') {
+    while ( c != '\n' && c != '\r' && c != '\377') {
         i = AddCharToBuf(&string, buf, sizeof(buf), i, c);
 
         // read the next character

--- a/tst/testinstall/pragma.tst
+++ b/tst/testinstall/pragma.tst
@@ -10,3 +10,12 @@ function ( x )
     #% pragma
     return x;
 end
+gap> x := function( x )
+>       #% pragma	with	tab
+>       return x;
+>    end;;
+gap> Display( x );
+function ( x )
+    #% pragma	with	tab
+    return x;
+end


### PR DESCRIPTION
but continue to scan until a "line break" character is encountered