### PR TITLE
Temporary fix for the Julia GC.

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -28,8 +28,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "julia.h"
-#include "julia_gcext.h"
+#include <julia.h>
+#include <julia_gcext.h>
 
 
 /****************************************************************************
@@ -93,6 +93,7 @@ static inline Bag * DATA(BagHeader * bag)
 
 
 static TNumExtraMarkFuncBags ExtraMarkFuncBags;
+
 void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func)
 {
     ExtraMarkFuncBags = func;
@@ -531,7 +532,7 @@ static void TryMarkRangeReverse(void * start, void * end)
 #ifdef MARKING_STRESS_TEST
             for (int j = 0; j < 1000; ++j) {
                 UInt val = (UInt)addr + rand() - rand();
-                TryMark((void*)val);
+                TryMark((void *)val);
             }
 #endif
         }
@@ -553,7 +554,7 @@ static void TryMarkRange(void * start, void * end)
 #ifdef MARKING_STRESS_TEST
             for (int j = 0; j < 1000; ++j) {
                 UInt val = (UInt)addr + rand() - rand();
-                TryMark((void*)val);
+                TryMark((void *)val);
             }
 #endif
         }
@@ -659,7 +660,7 @@ static void PreGCHook(int full)
     /* information at the beginning of garbage collections                 */
     SyMsgsBags(full, 0, 0);
 #ifndef REQUIRE_PRECISE_MARKING
-   memset(MarkCache, 0, sizeof(MarkCache));
+    memset(MarkCache, 0, sizeof(MarkCache));
 #ifdef STAT_MARK_CACHE
     MarkCacheHits = MarkCacheAttempts = MarkCacheCollisions = 0;
 #endif
@@ -708,8 +709,9 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
 {
     // HOOK: initialization happens here.
     GapStackBottom = stack_bottom;
-    for (UInt i = 0; i < NUM_TYPES; i++)
+    for (UInt i = 0; i < NUM_TYPES; i++) {
         TabMarkFuncBags[i] = MarkAllSubBags;
+    }
     // These callbacks need to be set before initialization so
     // that we can track objects allocated during `jl_init()`.
 #if !defined(DISABLE_BIGVAL_TRACKING)
@@ -800,7 +802,7 @@ void RetypeBag(Bag bag, UInt new_type)
         // different type is something better to be avoided anyway. So instead
         // of supporting a feature nobody uses right now, we error out and
         // wait to see if somebody complains.
-        Panic("cannot change bag type to one which requires a 'free' callback");
+        Panic("cannot change bag type to one requiring a 'free' callback");
     }
     header->type = new_type;
 }

--- a/src/julia_gc.h
+++ b/src/julia_gc.h
@@ -17,7 +17,9 @@
 **
 *F  MarkJuliaObj(<obj>) . . . . . . . . . . . . . . . . . . mark Julia object
 **
-**  'MarkJuliaObjSafe' marks a Julia object; the argument can be NULL.
+**  'MarkJuliaObjSafe' marks a Julia object; the argument can be NULL. No
+**  further checks are performed. If <obj> is not a Julia object, a crash
+**  may result.
 */
 
 void MarkJuliaObj(void * obj);
@@ -32,5 +34,15 @@ void MarkJuliaObj(void * obj);
 */
 
 void MarkJuliaObjSafe(void * obj);
+
+/****************************************************************************
+**
+*F  MarkJuliaWeakRef(<ref>)  . . . . . . . . . . .  mark Julia weak reference
+**
+**  'MarkJuliaWeakRef` marks a Julia weak reference. This must be a valid
+**  reference and cannot be NULL.
+*/
+
+void MarkJuliaWeakRef(void * obj);
 
 #endif

--- a/src/julia_gc.h
+++ b/src/julia_gc.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This file declares functions of the Julia GC interface.
+*/
+
+#ifndef GAP_JULIA_GC_H
+#define GAP_JULIA_GC_H
+
+/****************************************************************************
+**
+*F  MarkJuliaObj(<obj>) . . . . . . . . . . . . . . . . . . mark Julia object
+**
+**  'MarkJuliaObjSafe' marks a Julia object; the argument can be NULL.
+*/
+
+void MarkJuliaObj(void * obj);
+
+/****************************************************************************
+**
+*F  MarkJuliaObjSafe(<obj>) . . . . . . . . . . . . . . . . mark Julia object
+**
+**  'MarkJuliaObjSafe' marks a Julia object; the argument may be NULL.
+**  Extra validation steps are performed to determine whether <obj> is
+**  a valid Julia object. If not, it is silently ignored.
+*/
+
+void MarkJuliaObjSafe(void * obj);
+
+#endif


### PR DESCRIPTION
This addresses a problem where the Julia GC during a partial sweep frees
some, but not all objects of an unreachable data structure. If an
address to a remaining object of such a data structure is still randomly
hit during conservative stack scanning, it may erroneously try to mark
the deallocated objects, too.

This temporary fix works by validating each pointer before it is marked.
Because this is potentially expensive, the eventual solution should fix
the root cause, which is conservative stack scanning resurrecting
pointers to dead objects that have been freed during a partial
collection.