### PR TITLE
gac: emit semicolon after all CHECK_* calls; turn CHECK_{BOOL,FUNC} into functions

### DIFF
--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -224,8 +224,8 @@ static Obj  HdlrFunc2 (
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -239,10 +239,10 @@ static Obj  HdlrFunc2 (
  /* if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then */
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
- CHECK_BOUND( t_4, "IMM_FLAGS" )
+ CHECK_BOUND( t_4, "IMM_FLAGS" );
  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -256,18 +256,18 @@ static Obj  HdlrFunc2 (
  /* flags := SUB_FLAGS( flags, IMM_FLAGS ); */
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
- CHECK_BOUND( t_3, "IMM_FLAGS" )
+ CHECK_BOUND( t_3, "IMM_FLAGS" );
  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flagspos = t_1;
  
  /* tried := [  ]; */
@@ -278,7 +278,7 @@ static Obj  HdlrFunc2 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* flags := type![2]; */
@@ -287,14 +287,14 @@ static Obj  HdlrFunc2 (
  
  /* RUN_IMMEDIATE_METHODS_RUNS := RUN_IMMEDIATE_METHODS_RUNS + 1; */
  t_2 = GC_RUN__IMMEDIATE__METHODS__RUNS;
- CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" )
+ CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_RUN__IMMEDIATE__METHODS__RUNS, t_1 );
  
  /* if TRACE_IMMEDIATE_METHODS then */
  t_2 = GC_TRACE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -331,26 +331,26 @@ static Obj  HdlrFunc2 (
   
   /* if IsBound( IMMEDIATES[j] ) then */
   t_7 = GC_IMMEDIATES;
-  CHECK_BOUND( t_7, "IMMEDIATES" )
-  CHECK_INT_POS( l_j )
+  CHECK_BOUND( t_7, "IMMEDIATES" );
+  CHECK_INT_POS( l_j );
   t_6 = C_ISB_LIST( t_7, l_j );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* imm := IMMEDIATES[j]; */
    t_6 = GC_IMMEDIATES;
-   CHECK_BOUND( t_6, "IMMEDIATES" )
+   CHECK_BOUND( t_6, "IMMEDIATES" );
    C_ELM_LIST_FPL( t_5, t_6, l_j )
    l_imm = t_5;
    
    /* for i in [ 0, SIZE_IMMEDIATE_METHOD_ENTRY .. LEN_LIST( imm ) - SIZE_IMMEDIATE_METHOD_ENTRY ] do */
    t_9 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    t_12 = GF_LEN__LIST;
    t_11 = CALL_1ARGS( t_12, l_imm );
-   CHECK_FUNC_RESULT( t_11 )
+   CHECK_FUNC_RESULT( t_11 );
    t_12 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    C_DIFF_FIA( t_10, t_11, t_12 )
    t_8 = Range3Check( INTOBJ_INT(0), t_9, t_10 );
    if ( IS_SMALL_LIST(t_8) ) {
@@ -377,21 +377,21 @@ static Obj  HdlrFunc2 (
     /* if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then */
     t_13 = GF_IS__SUBSET__FLAGS;
     C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
-    CHECK_INT_POS( t_15 )
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_14, l_imm, t_15 )
     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
-    CHECK_FUNC_RESULT( t_12 )
-    CHECK_BOOL( t_12 )
+    CHECK_FUNC_RESULT( t_12 );
+    CHECK_BOOL( t_12 );
     t_11 = (Obj)(UInt)(t_12 != False);
     t_10 = t_11;
     if ( t_10 ) {
      t_15 = GF_IS__SUBSET__FLAGS;
      C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
-     CHECK_INT_POS( t_17 )
+     CHECK_INT_POS( t_17 );
      C_ELM_LIST_FPL( t_16, l_imm, t_17 )
      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
-     CHECK_FUNC_RESULT( t_14 )
-     CHECK_BOOL( t_14 )
+     CHECK_FUNC_RESULT( t_14 );
+     CHECK_BOOL( t_14 );
      t_13 = (Obj)(UInt)(t_14 != False);
      t_12 = (Obj)(UInt)( ! ((Int)t_13) );
      t_10 = t_12;
@@ -399,7 +399,7 @@ static Obj  HdlrFunc2 (
     t_9 = t_10;
     if ( t_9 ) {
      C_SUM_FIA( t_14, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_14 )
+     CHECK_INT_POS( t_14 );
      C_ELM_LIST_FPL( t_13, l_imm, t_14 )
      t_12 = (Obj)(UInt)(IN( t_13, l_tried ));
      t_11 = (Obj)(UInt)( ! ((Int)t_12) );
@@ -409,37 +409,37 @@ static Obj  HdlrFunc2 (
      
      /* meth := IMMEDIATE_METHODS[imm[i + 6]]; */
      t_10 = GC_IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" )
+     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" );
      C_SUM_FIA( t_12, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_12 )
+     CHECK_INT_POS( t_12 );
      C_ELM_LIST_FPL( t_11, l_imm, t_12 )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_9, t_10, t_11 )
      l_meth = t_9;
      
      /* res := meth( obj ); */
-     CHECK_FUNC( l_meth )
+     CHECK_FUNC( l_meth );
      t_9 = CALL_1ARGS( l_meth, a_obj );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      l_res = t_9;
      
      /* ADD_LIST( tried, imm[i + 6] ); */
      t_9 = GF_ADD__LIST;
      C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
      CALL_2ARGS( t_9, l_tried, t_10 );
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
-     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" )
+     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" );
      C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
      AssGVar( G_RUN__IMMEDIATE__METHODS__CHECKS, t_9 );
      
      /* if TRACE_IMMEDIATE_METHODS then */
      t_10 = GC_TRACE__IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" )
-     CHECK_BOOL( t_10 )
+     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" );
+     CHECK_BOOL( t_10 );
      t_9 = (Obj)(UInt)(t_10 != False);
      if ( t_9 ) {
       
@@ -448,15 +448,15 @@ static Obj  HdlrFunc2 (
       t_10 = MakeString( "#I  immediate: " );
       t_12 = GF_NAME__FUNC;
       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_14 )
+      CHECK_INT_POS( t_14 );
       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
       t_11 = CALL_1ARGS( t_12, t_13 );
-      CHECK_FUNC_RESULT( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
       CALL_2ARGS( t_9, t_10, t_11 );
       
       /* if imm[i + 7] <> false then */
       C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
-      CHECK_INT_POS( t_11 )
+      CHECK_INT_POS( t_11 );
       C_ELM_LIST_FPL( t_10, l_imm, t_11 )
       t_11 = False;
       t_9 = (Obj)(UInt)( ! EQ( t_10, t_11 ));
@@ -466,7 +466,7 @@ static Obj  HdlrFunc2 (
        t_9 = GF_Print;
        t_10 = MakeString( ": " );
        C_SUM_FIA( t_12, l_i, INTOBJ_INT(7) )
-       CHECK_INT_POS( t_12 )
+       CHECK_INT_POS( t_12 );
        C_ELM_LIST_FPL( t_11, l_imm, t_12 )
        CALL_2ARGS( t_9, t_10, t_11 );
        
@@ -477,12 +477,12 @@ static Obj  HdlrFunc2 (
       t_9 = GF_Print;
       t_10 = MakeString( " at " );
       C_SUM_FIA( t_13, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_13 )
+      CHECK_INT_POS( t_13 );
       C_ELM_LIST_FPL( t_12, l_imm, t_13 )
       C_ELM_LIST_FPL( t_11, t_12, INTOBJ_INT(1) )
       t_12 = MakeString( ":" );
       C_SUM_FIA( t_15, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_15 )
+      CHECK_INT_POS( t_15 );
       C_ELM_LIST_FPL( t_14, l_imm, t_15 )
       C_ELM_LIST_FPL( t_13, t_14, INTOBJ_INT(2) )
       t_14 = MakeString( "\n" );
@@ -493,7 +493,7 @@ static Obj  HdlrFunc2 (
      
      /* if res <> TRY_NEXT_METHOD then */
      t_10 = GC_TRY__NEXT__METHOD;
-     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" )
+     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" );
      t_9 = (Obj)(UInt)( ! EQ( l_res, t_10 ));
      if ( t_9 ) {
       
@@ -503,9 +503,9 @@ static Obj  HdlrFunc2 (
       
       /* imm[i + 2]( obj, res ); */
       C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
-      CHECK_INT_POS( t_10 )
+      CHECK_INT_POS( t_10 );
       C_ELM_LIST_FPL( t_9, l_imm, t_10 )
-      CHECK_FUNC( t_9 )
+      CHECK_FUNC( t_9 );
       CALL_2ARGS( t_9, a_obj, l_res );
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
@@ -514,7 +514,7 @@ static Obj  HdlrFunc2 (
       
       /* RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1; */
       t_10 = GC_RUN__IMMEDIATE__METHODS__HITS;
-      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" )
+      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" );
       C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
       AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, t_9 );
       
@@ -522,10 +522,10 @@ static Obj  HdlrFunc2 (
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
       t_13 = CALL_1ARGS( t_14, a_obj );
-      CHECK_FUNC_RESULT( t_13 )
+      CHECK_FUNC_RESULT( t_13 );
       t_11 = CALL_2ARGS( t_12, t_13, l_type );
-      CHECK_FUNC_RESULT( t_11 )
-      CHECK_BOOL( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
+      CHECK_BOOL( t_11 );
       t_10 = (Obj)(UInt)(t_11 != False);
       t_9 = (Obj)(UInt)( ! ((Int)t_10) );
       if ( t_9 ) {
@@ -533,29 +533,29 @@ static Obj  HdlrFunc2 (
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
        t_9 = CALL_1ARGS( t_10, a_obj );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_type = t_9;
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
        t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
-       CHECK_BOUND( t_12, "IMM_FLAGS" )
+       CHECK_BOUND( t_12, "IMM_FLAGS" );
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
        t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 )
+       CHECK_FUNC_RESULT( t_10 );
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
@@ -635,15 +635,15 @@ static Obj  HdlrFunc3 (
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_baserank );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* rank := baserank(  ); */
-  CHECK_FUNC( a_baserank )
+  CHECK_FUNC( a_baserank );
   t_1 = CALL_0ARGS( a_baserank );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_rank = t_1;
   
  }
@@ -660,15 +660,15 @@ static Obj  HdlrFunc3 (
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
  t_2 = CALL_1ARGS( t_3, a_opr );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if 0 = LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_flags );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -676,7 +676,7 @@ static Obj  HdlrFunc3 (
    t_1 = GF_Error;
    t_3 = GF_NAME__FUNC;
    t_2 = CALL_1ARGS( t_3, a_opr );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_3 = MakeString( ": constructors must have at least one argument" );
    CALL_2ARGS( t_1, t_2, t_3 );
    
@@ -687,7 +687,7 @@ static Obj  HdlrFunc3 (
   t_3 = GF_RankFilter;
   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_DIFF_FIA( t_1, l_rank, t_2 )
   l_rank = t_1;
   
@@ -722,7 +722,7 @@ static Obj  HdlrFunc3 (
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
    t_6 = CALL_1ARGS( t_7, l_i );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
    
@@ -735,13 +735,13 @@ static Obj  HdlrFunc3 (
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_flags );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_methods = t_1;
  
  /* if info = false then */
@@ -752,7 +752,7 @@ static Obj  HdlrFunc3 (
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
   t_1 = CALL_1ARGS( t_2, a_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   a_info = t_1;
   
  }
@@ -764,9 +764,9 @@ static Obj  HdlrFunc3 (
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
   t_3 = CALL_1ARGS( t_4, a_opr );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
@@ -795,13 +795,13 @@ static Obj  HdlrFunc3 (
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_methods );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
   if ( t_1 ) {
    C_SUM_FIA( t_6, l_narg, INTOBJ_INT(3) )
    C_SUM_FIA( t_5, l_i, t_6 )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ELM_LIST_FPL( t_4, l_methods, t_5 )
    t_3 = (Obj)(UInt)(LT( l_rank, t_4 ));
    t_1 = t_3;
@@ -822,8 +822,8 @@ static Obj  HdlrFunc3 (
  
  /* if REREADING then */
  t_2 = GC_REREADING;
- CHECK_BOUND( t_2, "REREADING" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "REREADING" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -834,13 +834,13 @@ static Obj  HdlrFunc3 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_methods );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
     C_SUM_FIA( t_6, l_k, l_narg )
     C_SUM_FIA( t_5, t_6, INTOBJ_INT(3) )
-    CHECK_INT_POS( t_5 )
+    CHECK_INT_POS( t_5 );
     C_ELM_LIST_FPL( t_4, l_methods, t_5 )
     t_3 = (Obj)(UInt)(EQ( l_rank, t_4 ));
     t_1 = t_3;
@@ -850,7 +850,7 @@ static Obj  HdlrFunc3 (
    /* if info = methods[k + narg + 4] then */
    C_SUM_FIA( t_4, l_k, l_narg )
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(4) )
-   CHECK_INT_POS( t_3 )
+   CHECK_INT_POS( t_3 );
    C_ELM_LIST_FPL( t_2, l_methods, t_3 )
    t_1 = (Obj)(UInt)(EQ( a_info, t_2 ));
    if ( t_1 ) {
@@ -860,7 +860,7 @@ static Obj  HdlrFunc3 (
     l_match = t_1;
     
     /* for j in [ 1 .. narg ] do */
-    CHECK_INT_SMALL( l_narg )
+    CHECK_INT_SMALL( l_narg );
     t_2 = l_narg;
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
@@ -874,7 +874,7 @@ static Obj  HdlrFunc3 (
      else if ( l_match == True ) {
       C_SUM_FIA( t_7, l_k, l_j )
       C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_6 )
+      CHECK_INT_POS( t_6 );
       C_ELM_LIST_FPL( t_5, l_methods, t_6 )
       C_ELM_LIST_FPL( t_6, a_flags, l_j )
       t_4 = (EQ( t_5, t_6 ) ? True : False);
@@ -883,7 +883,7 @@ static Obj  HdlrFunc3 (
      else if (IS_FILTER( l_match ) ) {
       C_SUM_FIA( t_8, l_k, l_j )
       C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_7 )
+      CHECK_INT_POS( t_7 );
       C_ELM_LIST_FPL( t_6, l_methods, t_7 )
       C_ELM_LIST_FPL( t_7, a_flags, l_j )
       t_5 = (EQ( t_6, t_7 ) ? True : False);
@@ -899,7 +899,7 @@ static Obj  HdlrFunc3 (
     /* od */
     
     /* if match then */
-    CHECK_BOOL( l_match )
+    CHECK_BOOL( l_match );
     t_1 = (Obj)(UInt)(l_match != False);
     if ( t_1 ) {
      
@@ -932,8 +932,8 @@ static Obj  HdlrFunc3 (
  
  /* if not REREADING or not replace then */
  t_4 = GC_REREADING;
- CHECK_BOUND( t_4, "REREADING" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "REREADING" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
  t_1 = t_2;
@@ -964,7 +964,7 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_2, 6, INTOBJ_INT(1) );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_methods );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_DIFF_FIA( t_3, t_4, l_i )
   SET_ELM_PLIST( t_2, 7, t_3 );
   CHANGED_BAG( t_2 );
@@ -980,7 +980,7 @@ static Obj  HdlrFunc3 (
   
   /* rel := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_rel = t_1;
   
  }
@@ -993,7 +993,7 @@ static Obj  HdlrFunc3 (
    
    /* rel := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_rel = t_1;
    
   }
@@ -1002,28 +1002,28 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_rel );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD then */
     t_2 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_2 )
+    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_rel );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1042,7 +1042,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <famrel> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1062,7 +1062,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1078,7 +1078,7 @@ static Obj  HdlrFunc3 (
   
   /* method := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_method = t_1;
   
  }
@@ -1091,7 +1091,7 @@ static Obj  HdlrFunc3 (
    
    /* method := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_method = t_1;
    
   }
@@ -1100,22 +1100,22 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_method );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then */
     t_3 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_3 )
+    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
      t_5 = CALL_1ARGS( t_6, a_method );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      t_1 = t_3;
@@ -1125,13 +1125,13 @@ static Obj  HdlrFunc3 (
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_method );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1150,7 +1150,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <method> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1170,7 +1170,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1181,11 +1181,11 @@ static Obj  HdlrFunc3 (
  
  /* methods[i + 1] := rel; */
  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_rel )
  
  /* for k in [ 1 .. narg ] do */
- CHECK_INT_SMALL( l_narg )
+ CHECK_INT_SMALL( l_narg );
  t_2 = l_narg;
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
@@ -1195,7 +1195,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + k + 1] := flags[k]; */
   C_SUM_FIA( t_4, l_i, l_k )
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_3 )
+  CHECK_INT_POS( t_3 );
   C_ELM_LIST_FPL( t_4, a_flags, l_k )
   C_ASS_LIST_FPL( l_methods, t_3, t_4 )
   
@@ -1205,22 +1205,22 @@ static Obj  HdlrFunc3 (
  /* methods[i + (narg + 2)] := method; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_method )
  
  /* methods[i + (narg + 3)] := rank; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(3) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, l_rank )
  
  /* methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info ); */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(4) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  t_3 = GF_IMMUTABLE__COPY__OBJ;
  t_2 = CALL_1ARGS( t_3, a_info );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
  /* if 6 >= 5 then */
@@ -1230,26 +1230,26 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_MakeImmutable;
   t_4 = NEW_PLIST( T_PLIST, 3 );
   SET_LEN_PLIST( t_4, 3 );
   t_6 = GF_INPUT__FILENAME;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_READEVALCOMMAND__LINENUMBER;
-  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" )
+  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_INPUT__LINENUMBER;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 3, t_5 );
   CHANGED_BAG( t_4 );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
  }
@@ -1262,7 +1262,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 6)] := baserank; */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
   
  }
@@ -1400,7 +1400,7 @@ static Obj  HdlrFunc6 (
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_arglist );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_len = t_1;
  
  /* if len < 3 then */
@@ -1422,8 +1422,8 @@ static Obj  HdlrFunc6 (
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
  t_3 = CALL_1ARGS( t_4, l_opr );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1440,8 +1440,8 @@ static Obj  HdlrFunc6 (
  t_4 = GF_IS__STRING__REP;
  C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( ! t_1 ) {
@@ -1483,8 +1483,8 @@ static Obj  HdlrFunc6 (
   t_5 = GF_IS__FUNCTION;
   C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
   t_4 = CALL_1ARGS( t_5, t_6 );
-  CHECK_FUNC_RESULT( t_4 )
-  CHECK_BOOL( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
+  CHECK_BOOL( t_4 );
   t_3 = (Obj)(UInt)(t_4 != False);
   t_1 = t_3;
  }
@@ -1511,7 +1511,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_4 = C_ISB_LIST( a_arglist, l_pos );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
@@ -1520,8 +1520,8 @@ static Obj  HdlrFunc6 (
   t_6 = GF_IS__LIST;
   C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = (Obj)(UInt)( ! ((Int)t_4) );
   t_1 = t_3;
@@ -1543,11 +1543,11 @@ static Obj  HdlrFunc6 (
  
  /* if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then */
  t_3 = GC_GAPInfo;
- CHECK_BOUND( t_3, "GAPInfo" )
+ CHECK_BOUND( t_3, "GAPInfo" );
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_filters );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1555,7 +1555,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_2 = MakeString( "methods can have at most " );
   t_4 = GC_GAPInfo;
-  CHECK_BOUND( t_4, "GAPInfo" )
+  CHECK_BOUND( t_4, "GAPInfo" );
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   t_4 = MakeString( " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1566,7 +1566,7 @@ static Obj  HdlrFunc6 (
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, l_filters );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
   
@@ -1581,8 +1581,8 @@ static Obj  HdlrFunc6 (
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, l_filters );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(1);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1592,8 +1592,8 @@ static Obj  HdlrFunc6 (
    t_5 = GF_IS__STRING__REP;
    C_ELM_LIST_FPL( t_6, l_filters, l_i )
    t_4 = CALL_1ARGS( t_5, t_6 );
-   CHECK_FUNC_RESULT( t_4 )
-   CHECK_BOOL( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
+   CHECK_BOOL( t_4 );
    t_3 = (Obj)(UInt)(t_4 != False);
    if ( t_3 ) {
     
@@ -1611,15 +1611,15 @@ static Obj  HdlrFunc6 (
     t_4 = GF_EvalString;
     C_ELM_LIST_FPL( t_5, l_filters, l_i )
     t_3 = CALL_1ARGS( t_4, t_5 );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
     C_ELM_LIST_FPL( t_7, l_filters, l_i )
     t_5 = CALL_1ARGS( t_6, t_7 );
-    CHECK_FUNC_RESULT( t_5 )
-    CHECK_BOOL( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
+    CHECK_BOOL( t_5 );
     t_4 = (Obj)(UInt)(t_5 != False);
     t_3 = (Obj)(UInt)( ! ((Int)t_4) );
     if ( t_3 ) {
@@ -1663,17 +1663,17 @@ static Obj  HdlrFunc6 (
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_info1 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[32];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
    t_1 = CALL_1ARGS( t_2, l_info1 );
-   CHECK_FUNC_RESULT( t_1 )
-   CHECK_INT_POS( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[93];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
@@ -1722,14 +1722,14 @@ static Obj  HdlrFunc6 (
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
   t_6 = CALL_1ARGS( t_7, l_i );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   CALL_2ARGS( t_5, l_flags, t_6 );
   
  }
  /* od */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1747,23 +1747,23 @@ static Obj  HdlrFunc6 (
   t_4 = GF_IS__INT;
   C_ELM_LIST_FPL( t_5, a_arglist, l_pos )
   t_3 = CALL_1ARGS( t_4, t_5 );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = t_2;
   if ( ! t_1 ) {
    t_7 = GF_IS__FUNCTION;
    C_ELM_LIST_FPL( t_8, a_arglist, l_pos )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
-   CHECK_BOOL( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
+   CHECK_BOOL( t_6 );
    t_5 = (Obj)(UInt)(t_6 != False);
    t_4 = t_5;
    if ( t_4 ) {
     t_8 = GF_NARG__FUNC;
     C_ELM_LIST_FPL( t_9, a_arglist, l_pos )
     t_7 = CALL_1ARGS( t_8, t_9 );
-    CHECK_FUNC_RESULT( t_7 )
+    CHECK_FUNC_RESULT( t_7 );
     t_6 = (Obj)(UInt)(EQ( t_7, INTOBJ_INT(0) ));
     t_4 = t_6;
    }
@@ -1771,7 +1771,7 @@ static Obj  HdlrFunc6 (
    if ( t_3 ) {
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, a_arglist );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_5 = (Obj)(UInt)(LT( l_pos, t_6 ));
     t_3 = t_5;
    }
@@ -1800,7 +1800,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1821,7 +1821,7 @@ static Obj  HdlrFunc6 (
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
  t_5 = CALL_1ARGS( t_6, l_opr );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
  if ( t_3 ) {
@@ -1830,7 +1830,7 @@ static Obj  HdlrFunc6 (
   t_5 = t_6;
   if ( ! t_5 ) {
    t_8 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_8, "RETURN_TRUE" )
+   CHECK_BOUND( t_8, "RETURN_TRUE" );
    t_7 = (Obj)(UInt)(EQ( l_rel, t_8 ));
    t_5 = t_7;
   }
@@ -1840,7 +1840,7 @@ static Obj  HdlrFunc6 (
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_filters );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
  }
@@ -1851,7 +1851,7 @@ static Obj  HdlrFunc6 (
   t_3 = t_4;
   if ( ! t_3 ) {
    t_6 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_6, "RETURN_TRUE" )
+   CHECK_BOUND( t_6, "RETURN_TRUE" );
    t_5 = (Obj)(UInt)(EQ( l_method, t_6 ));
    t_3 = t_5;
   }
@@ -1863,7 +1863,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -1872,12 +1872,12 @@ static Obj  HdlrFunc6 (
  
  /* if CHECK_INSTALL_METHOD and check then */
  t_3 = GC_CHECK__INSTALL__METHOD;
- CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
- CHECK_BOOL( t_3 )
+ CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( t_1 ) {
-  CHECK_BOOL( a_check )
+  CHECK_BOOL( a_check );
   t_3 = (Obj)(UInt)(a_check != False);
   t_1 = t_3;
  }
@@ -1885,7 +1885,7 @@ static Obj  HdlrFunc6 (
   
   /* if opr in WRAPPER_OPERATIONS then */
   t_2 = GC_WRAPPER__OPERATIONS;
-  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
   t_1 = (Obj)(UInt)(IN( l_opr, t_2 ));
   if ( t_1 ) {
    
@@ -1894,7 +1894,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_4 = MakeString( "\n" );
    t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
    t_6 = MakeString( "#I  underlying operation(s)" );
@@ -1906,12 +1906,12 @@ static Obj  HdlrFunc6 (
   /* req := GET_OPER_FLAGS( opr ); */
   t_2 = GF_GET__OPER__FLAGS;
   t_1 = CALL_1ARGS( t_2, l_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_req = t_1;
   
   /* if req = fail then */
   t_2 = GC_fail;
-  CHECK_BOUND( t_2, "fail" )
+  CHECK_BOUND( t_2, "fail" );
   t_1 = (Obj)(UInt)(EQ( l_req, t_2 ));
   if ( t_1 ) {
    
@@ -1920,7 +1920,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    CALL_2ARGS( t_1, t_2, t_3 );
    
   }
@@ -1956,10 +1956,10 @@ static Obj  HdlrFunc6 (
    
    /* if not GAPInfo.CommandLineOptions.N then */
    t_9 = GC_GAPInfo;
-   CHECK_BOUND( t_9, "GAPInfo" )
+   CHECK_BOUND( t_9, "GAPInfo" );
    t_8 = ELM_REC( t_9, R_CommandLineOptions );
    t_7 = ELM_REC( t_8, R_N );
-   CHECK_BOOL( t_7 )
+   CHECK_BOOL( t_7 );
    t_6 = (Obj)(UInt)(t_7 != False);
    t_5 = (Obj)(UInt)( ! ((Int)t_6) );
    if ( t_5 ) {
@@ -1968,7 +1968,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -1980,7 +1980,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -2003,7 +2003,7 @@ static Obj  HdlrFunc6 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
@@ -2018,17 +2018,17 @@ static Obj  HdlrFunc6 (
    l_j = t_1;
    
    /* reqs := req[j]; */
-   CHECK_INT_POS( l_j )
+   CHECK_INT_POS( l_j );
    C_ELM_LIST_FPL( t_1, l_req, l_j )
    l_reqs = t_1;
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_reqs );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_imp );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
     
@@ -2039,8 +2039,8 @@ static Obj  HdlrFunc6 (
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, l_reqs );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_INT_SMALL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_INT_SMALL( t_2 );
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
           t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2051,8 +2051,8 @@ static Obj  HdlrFunc6 (
      C_ELM_LIST_FPL( t_7, l_imp, l_i )
      C_ELM_LIST_FPL( t_8, l_reqs, l_i )
      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      if ( t_3 ) {
@@ -2100,10 +2100,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2113,7 +2113,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( "the number of arguments does not match a declaration of " );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      CALL_2ARGS( t_1, t_2, t_3 );
      
     }
@@ -2127,7 +2127,7 @@ static Obj  HdlrFunc6 (
      t_3 = MakeString( "match a declaration of " );
      t_5 = GF_NAME__FUNC;
      t_4 = CALL_1ARGS( t_5, l_opr );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      t_5 = MakeString( "\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
      
@@ -2141,10 +2141,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2153,18 +2153,18 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Error;
      t_2 = MakeString( "required filters " );
      t_4 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
      t_3 = CALL_1ARGS( t_4, t_5 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( "\nfor " );
      t_6 = GF_Ordinal;
      t_5 = CALL_1ARGS( t_6, l_notmatch );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_6 = MakeString( " argument do not match a declaration of " );
      t_8 = GF_NAME__FUNC;
      t_7 = CALL_1ARGS( t_8, l_opr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
      
     }
@@ -2181,7 +2181,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 2, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "(\03" );
@@ -2189,7 +2189,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__FILENAME;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 4, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "\03 +" );
@@ -2197,7 +2197,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__LINENUMBER;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 6, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( ") \03" );
@@ -2210,10 +2210,10 @@ static Obj  HdlrFunc6 (
      
      /* for j in NamesFilter( imp[notmatch] ) do */
      t_5 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_6, l_imp, l_notmatch )
      t_4 = CALL_1ARGS( t_5, t_6 );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      if ( IS_SMALL_LIST(t_4) ) {
       t_3 = (Obj)(UInt)1;
       t_1 = INTOBJ_INT(1);
@@ -2248,7 +2248,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( " for " );
      t_4 = GF_Ordinal;
      t_3 = CALL_1ARGS( t_4, l_notmatch );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( " argument do not match \03a " );
      t_5 = MakeString( "declaration\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
@@ -2269,28 +2269,28 @@ static Obj  HdlrFunc6 (
    
    /* for k in [ j + 1 .. LEN_LIST( req ) ] do */
    C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
-   CHECK_INT_SMALL( t_2 )
+   CHECK_INT_SMALL( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_INT_SMALL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_INT_SMALL( t_3 );
    for ( t_1 = t_2;
          ((Int)t_1) <= ((Int)t_3);
          t_1 = (Obj)(((UInt)t_1)+4) ) {
     l_k = t_1;
     
     /* reqs := req[k]; */
-    CHECK_INT_POS( l_k )
+    CHECK_INT_POS( l_k );
     C_ELM_LIST_FPL( t_4, l_req, l_k )
     l_reqs = t_4;
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
     t_5 = CALL_1ARGS( t_6, l_reqs );
-    CHECK_FUNC_RESULT( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, l_imp );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
      
@@ -2301,8 +2301,8 @@ static Obj  HdlrFunc6 (
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
      t_5 = CALL_1ARGS( t_6, l_reqs );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_INT_SMALL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_INT_SMALL( t_5 );
      for ( t_4 = INTOBJ_INT(1);
            ((Int)t_4) <= ((Int)t_5);
            t_4 = (Obj)(((UInt)t_4)+4) ) {
@@ -2313,8 +2313,8 @@ static Obj  HdlrFunc6 (
       C_ELM_LIST_FPL( t_10, l_imp, l_i )
       C_ELM_LIST_FPL( t_11, l_reqs, l_i )
       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-      CHECK_FUNC_RESULT( t_8 )
-      CHECK_BOOL( t_8 )
+      CHECK_FUNC_RESULT( t_8 );
+      CHECK_BOOL( t_8 );
       t_7 = (Obj)(UInt)(t_8 != False);
       t_6 = (Obj)(UInt)( ! ((Int)t_7) );
       if ( t_6 ) {
@@ -2346,7 +2346,7 @@ static Obj  HdlrFunc6 (
       t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
-      CHECK_FUNC_RESULT( t_6 )
+      CHECK_FUNC_RESULT( t_6 );
       t_7 = MakeString( " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
@@ -2367,7 +2367,7 @@ static Obj  HdlrFunc6 (
  
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
- CHECK_BOUND( l_rank, "rank" )
+ CHECK_BOUND( l_rank, "rank" );
  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
  
  /* return; */
@@ -2410,7 +2410,7 @@ static Obj  HdlrFunc8 (
  
  /* for prop in props do */
  t_4 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_4, "props" )
+ CHECK_BOUND( t_4, "props" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -2435,11 +2435,11 @@ static Obj  HdlrFunc8 (
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
   t_8 = CALL_1ARGS( t_9, l_prop );
-  CHECK_FUNC_RESULT( t_8 )
-  CHECK_FUNC( t_8 )
+  CHECK_FUNC_RESULT( t_8 );
+  CHECK_FUNC( t_8 );
   t_7 = CALL_1ARGS( t_8, a_obj );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_BOOL( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (Obj)(UInt)( ! ((Int)t_6) );
   if ( t_5 ) {
@@ -2449,20 +2449,20 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop )
+   CHECK_FUNC( l_prop );
    t_8 = CALL_1ARGS( l_prop, a_obj );
-   CHECK_FUNC_RESULT( t_8 )
-   CHECK_BOOL( t_8 )
+   CHECK_FUNC_RESULT( t_8 );
+   CHECK_BOOL( t_8 );
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
     t_10 = CALL_1ARGS( t_11, l_prop );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_FUNC( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_FUNC( t_10 );
     t_9 = CALL_1ARGS( t_10, a_obj );
-    CHECK_FUNC_RESULT( t_9 )
-    CHECK_BOOL( t_9 )
+    CHECK_FUNC_RESULT( t_9 );
+    CHECK_BOOL( t_9 );
     t_8 = (Obj)(UInt)(t_9 != False);
     t_6 = t_8;
    }
@@ -2471,7 +2471,7 @@ static Obj  HdlrFunc8 (
     
     /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
-    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
+    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
     
@@ -2490,10 +2490,10 @@ static Obj  HdlrFunc8 (
   
   /* return getter( obj ); */
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "getter" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "getter" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_1ARGS( t_2, a_obj );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2504,7 +2504,7 @@ static Obj  HdlrFunc8 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2559,10 +2559,10 @@ static Obj  HdlrFunc7 (
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2570,7 +2570,7 @@ static Obj  HdlrFunc7 (
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_flags = t_1;
   
   /* rank := 0; */
@@ -2578,7 +2578,7 @@ static Obj  HdlrFunc7 (
   
   /* cats := IS_OBJECT; */
   t_1 = GC_IS__OBJECT;
-  CHECK_BOUND( t_1, "IS_OBJECT" )
+  CHECK_BOUND( t_1, "IS_OBJECT" );
   l_cats = t_1;
   
   /* props := [  ]; */
@@ -2589,7 +2589,7 @@ static Obj  HdlrFunc7 (
   /* for i in TRUES_FLAGS( flags ) do */
   t_5 = GF_TRUES__FLAGS;
   t_4 = CALL_1ARGS( t_5, l_flags );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
    t_1 = INTOBJ_INT(1);
@@ -2613,11 +2613,11 @@ static Obj  HdlrFunc7 (
    
    /* if INFO_FILTERS[i] in FNUM_CATS_AND_REPS then */
    t_7 = GC_INFO__FILTERS;
-   CHECK_BOUND( t_7, "INFO_FILTERS" )
-   CHECK_INT_POS( l_i )
+   CHECK_BOUND( t_7, "INFO_FILTERS" );
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_6, t_7, l_i )
    t_7 = GC_FNUM__CATS__AND__REPS;
-   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" )
+   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" );
    t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
    if ( t_5 ) {
     
@@ -2627,14 +2627,14 @@ static Obj  HdlrFunc7 (
     }
     else if ( l_cats == True ) {
      t_7 = GC_FILTERS;
-     CHECK_BOUND( t_7, "FILTERS" )
+     CHECK_BOUND( t_7, "FILTERS" );
      C_ELM_LIST_FPL( t_6, t_7, l_i )
-     CHECK_BOOL( t_6 )
+     CHECK_BOOL( t_6 );
      t_5 = t_6;
     }
     else if (IS_FILTER( l_cats ) ) {
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      t_5 = NewAndFilter( l_cats, t_7 );
     }
@@ -2647,10 +2647,10 @@ static Obj  HdlrFunc7 (
     /* rank := rank - RankFilter( FILTERS[i] ); */
     t_7 = GF_RankFilter;
     t_9 = GC_FILTERS;
-    CHECK_BOUND( t_9, "FILTERS" )
+    CHECK_BOUND( t_9, "FILTERS" );
     C_ELM_LIST_FPL( t_8, t_9, l_i )
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     C_DIFF_FIA( t_5, l_rank, t_6 )
     l_rank = t_5;
     
@@ -2659,19 +2659,19 @@ static Obj  HdlrFunc7 (
    /* elif INFO_FILTERS[i] in FNUM_PROS then */
    else {
     t_7 = GC_INFO__FILTERS;
-    CHECK_BOUND( t_7, "INFO_FILTERS" )
+    CHECK_BOUND( t_7, "INFO_FILTERS" );
     C_ELM_LIST_FPL( t_6, t_7, l_i )
     t_7 = GC_FNUM__PROS;
-    CHECK_BOUND( t_7, "FNUM_PROS" )
+    CHECK_BOUND( t_7, "FNUM_PROS" );
     t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
     if ( t_5 ) {
      
      /* ADD_LIST( props, FILTERS[i] ); */
      t_5 = GF_ADD__LIST;
      t_6 = OBJ_LVAR( 2 );
-     CHECK_BOUND( t_6, "props" )
+     CHECK_BOUND( t_6, "props" );
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      CALL_2ARGS( t_5, t_6, t_7 );
      
@@ -2685,15 +2685,15 @@ static Obj  HdlrFunc7 (
   /* MakeImmutable( props ); */
   t_1 = GF_MakeImmutable;
   t_2 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_2, "props" )
+  CHECK_BOUND( t_2, "props" );
   CALL_1ARGS( t_1, t_2 );
   
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_4, "props" )
+  CHECK_BOUND( t_4, "props" );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -2717,7 +2717,7 @@ static Obj  HdlrFunc7 (
   end ); */
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
-   CHECK_BOUND( t_2, "getter" )
+   CHECK_BOUND( t_2, "getter" );
    t_3 = MakeString( "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -2775,15 +2775,15 @@ static Obj  HdlrFunc9 (
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 2, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
- CHECK_BOUND( t_5, "DO_NOTHING_SETTER" )
+ CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
@@ -2821,7 +2821,7 @@ static Obj  HdlrFunc10 (
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_list );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
  
@@ -2851,13 +2851,13 @@ static Obj  HdlrFunc10 (
   C_SUM_FIA( t_6, l_i, l_k )
   C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_j = t_1;
   
   /* if list[j] < elm then */
-  CHECK_INT_POS( l_j )
+  CHECK_INT_POS( l_j );
   C_ELM_LIST_FPL( t_2, a_list, l_j )
   t_1 = (Obj)(UInt)(LT( t_2, a_elm ));
   if ( t_1 ) {
@@ -2905,8 +2905,8 @@ static Obj  HdlrFunc12 (
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
  t_3 = CALL_1ARGS( t_4, a_key );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2914,7 +2914,7 @@ static Obj  HdlrFunc12 (
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "name" )
+  CHECK_BOUND( t_2, "name" );
   t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -2976,32 +2976,32 @@ static Obj  HdlrFunc14 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3010,26 +3010,26 @@ static Obj  HdlrFunc14 (
   
   /* erg := oper( D, key ); */
   t_2 = OBJ_HVAR( (1 << 16) | 3 );
-  CHECK_BOUND( t_2, "oper" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "oper" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
   t_1 = CALL_2ARGS( t_2, l_known, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
   if ( ! t_1 ) {
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_4, l_known, l_i )
    t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
    t_1 = t_3;
@@ -3040,29 +3040,29 @@ static Obj  HdlrFunc14 (
    C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
    AsssListCheck( l_known, t_1, t_2 );
    
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    t_2 = GF_IMMUTABLE__COPY__OBJ;
    t_1 = CALL_1ARGS( t_2, a_key );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
    /* known[i + 1] := IMMUTABLE_COPY_OBJ( erg ); */
    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_3 = GF_IMMUTABLE__COPY__OBJ;
    t_2 = CALL_1ARGS( t_3, l_erg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
   }
@@ -3073,7 +3073,7 @@ static Obj  HdlrFunc14 (
  
  /* return known[i + 1]; */
  C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_2 )
+ CHECK_INT_POS( t_2 );
  C_ELM_LIST_FPL( t_1, l_known, t_2 )
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3105,34 +3105,34 @@ static Obj  HdlrFunc15 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (EQ( t_4, a_key ) ? True : False);
   t_1 = t_3;
@@ -3177,32 +3177,32 @@ static Obj  HdlrFunc16 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3213,29 +3213,29 @@ static Obj  HdlrFunc16 (
   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
   AsssListCheck( l_known, t_1, t_2 );
   
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   t_2 = GF_IMMUTABLE__COPY__OBJ;
   t_1 = CALL_1ARGS( t_2, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
   /* known[i + 1] := IMMUTABLE_COPY_OBJ( obj ); */
   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_IMMUTABLE__COPY__OBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
  }
@@ -3279,7 +3279,7 @@ static Obj  HdlrFunc11 (
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_2, "keytest" )
+ CHECK_BOUND( t_2, "keytest" );
  t_3 = MakeString( "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
@@ -3305,9 +3305,9 @@ static Obj  HdlrFunc11 (
  /* str := SHALLOW_COPY_OBJ( name ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_3, "name" )
+ CHECK_BOUND( t_3, "name" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
@@ -3328,7 +3328,7 @@ static Obj  HdlrFunc11 (
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
@@ -3338,7 +3338,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* APPEND_LIST_INTR( str, "s" ); */
@@ -3354,7 +3354,7 @@ static Obj  HdlrFunc11 (
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 4, t_1 );
  
  /* InstallMethod( attr, "default method", true, [ domreq ], 0, function ( D )
@@ -3362,7 +3362,7 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
- CHECK_BOUND( t_2, "attr" )
+ CHECK_BOUND( t_2, "attr" );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -3381,7 +3381,7 @@ static Obj  HdlrFunc11 (
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, a_domreq );
@@ -3393,12 +3393,12 @@ static Obj  HdlrFunc11 (
  /* ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_WRAPPER__OPERATIONS;
- CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+ CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_5, "name" )
+ CHECK_BOUND( t_5, "name" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
@@ -3420,9 +3420,9 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_4, "name" )
+ CHECK_BOUND( t_4, "name" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3447,7 +3447,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3470,7 +3470,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3495,7 +3495,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
@@ -3507,7 +3507,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
  t_3 = GC_IS__OBJECT;
- CHECK_BOUND( t_3, "IS_OBJECT" )
+ CHECK_BOUND( t_3, "IS_OBJECT" );
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
  CALL_2ARGS( t_1, l_str, t_2 );
@@ -3527,7 +3527,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
@@ -3537,7 +3537,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], 3, ArgStringToList("D,key,obj"), HdlrFunc16 );
@@ -3593,9 +3593,9 @@ static Obj  HdlrFunc18 (
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_7, "reqs" )
+ CHECK_BOUND( t_7, "reqs" );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -3620,37 +3620,37 @@ static Obj  HdlrFunc18 (
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
   t_7 = OBJ_HVAR( (1 << 16) | 4 );
-  CHECK_BOUND( t_7, "re" )
-  CHECK_BOOL( t_7 )
+  CHECK_BOUND( t_7, "re" );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
    t_12 = OBJ_HVAR( (1 << 16) | 3 );
-   CHECK_BOUND( t_12, "cond" )
+   CHECK_BOUND( t_12, "cond" );
    t_13 = OBJ_HVAR( (1 << 16) | 5 );
-   CHECK_BOUND( t_13, "i" )
-   CHECK_INT_POS( t_13 )
+   CHECK_BOUND( t_13, "i" );
+   CHECK_INT_POS( t_13 );
    t_11 = C_ISB_LIST( t_12, t_13 );
    t_10 = (Obj)(UInt)(t_11 != False);
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
     t_17 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_17, "cond" )
+    CHECK_BOUND( t_17, "cond" );
     t_18 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_18, "i" )
-    CHECK_INT_POS( t_18 )
+    CHECK_BOUND( t_18, "i" );
+    CHECK_INT_POS( t_18 );
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
-    CHECK_FUNC_RESULT( t_14 )
-    CHECK_FUNC( t_14 )
+    CHECK_FUNC_RESULT( t_14 );
+    CHECK_FUNC( t_14 );
     t_16 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_16, "i" )
-    CHECK_INT_POS( t_16 )
+    CHECK_BOUND( t_16, "i" );
+    CHECK_INT_POS( t_16 );
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
     t_13 = CALL_1ARGS( t_14, t_15 );
-    CHECK_FUNC_RESULT( t_13 )
-    CHECK_BOOL( t_13 )
+    CHECK_FUNC_RESULT( t_13 );
+    CHECK_BOOL( t_13 );
     t_12 = (Obj)(UInt)(t_13 != False);
     t_11 = (Obj)(UInt)( ! ((Int)t_12) );
     t_9 = t_11;
@@ -3658,19 +3658,19 @@ static Obj  HdlrFunc18 (
    t_8 = t_9;
    if ( t_8 ) {
     t_13 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_13, "cond" )
+    CHECK_BOUND( t_13, "cond" );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
-    CHECK_FUNC( t_12 )
+    CHECK_FUNC( t_12 );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_BOOL( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_BOOL( t_11 );
     t_10 = (Obj)(UInt)(t_11 != False);
     t_8 = t_10;
    }
@@ -3678,21 +3678,21 @@ static Obj  HdlrFunc18 (
    if ( t_7 ) {
     t_12 = GF_Tester;
     t_14 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_14, "cond" )
+    CHECK_BOUND( t_14, "cond" );
     t_15 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_15, "i" )
-    CHECK_INT_POS( t_15 )
+    CHECK_BOUND( t_15, "i" );
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_FUNC( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_FUNC( t_11 );
     t_13 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_13, "i" )
-    CHECK_INT_POS( t_13 )
+    CHECK_BOUND( t_13, "i" );
+    CHECK_INT_POS( t_13 );
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
     t_10 = CALL_1ARGS( t_11, t_12 );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_BOOL( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_BOOL( t_10 );
     t_9 = (Obj)(UInt)(t_10 != False);
     t_7 = t_9;
    }
@@ -3705,17 +3705,17 @@ static Obj  HdlrFunc18 (
  
  /* if re then */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "re" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "re" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
   t_3 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_3, "oper" )
+  CHECK_BOUND( t_3, "oper" );
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3726,7 +3726,7 @@ static Obj  HdlrFunc18 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3770,7 +3770,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
   
@@ -3804,7 +3804,7 @@ static Obj  HdlrFunc17 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
    
@@ -3848,7 +3848,7 @@ static Obj  HdlrFunc17 (
  
  /* for i in reqs do */
  t_4 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_4, "reqs" )
+ CHECK_BOUND( t_4, "reqs" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -3871,12 +3871,12 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 5, t_2 );
   
   /* val := val - RankFilter( i ); */
-  CHECK_BOUND( l_val, "val" )
+  CHECK_BOUND( l_val, "val" );
   t_7 = GF_RankFilter;
   t_8 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_8, "i" )
+  CHECK_BOUND( t_8, "i" );
   t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
   
@@ -3897,11 +3897,11 @@ static Obj  HdlrFunc17 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "oper" )
- CHECK_BOUND( l_info, "info" )
- CHECK_BOUND( l_fampred, "fampred" )
+ CHECK_BOUND( t_2, "oper" );
+ CHECK_BOUND( l_info, "info" );
+ CHECK_BOUND( l_fampred, "fampred" );
  t_3 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_3, "reqs" )
+ CHECK_BOUND( t_3, "reqs" );
  t_4 = NewFunction( NameFunc[18], -1, ArgStringToList("arg"), HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewFunctionBody();
@@ -4318,7 +4318,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -4554,17 +4554,17 @@ static Obj  HdlrFunc1 (
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
- CHECK_BOUND( t_2, "ViewObj" )
+ CHECK_BOUND( t_2, "ViewObj" );
  t_3 = MakeString( "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 1, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
- CHECK_BOUND( t_6, "PRINT_OBJ" )
+ CHECK_BOUND( t_6, "PRINT_OBJ" );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -216,12 +216,12 @@ static Obj  HdlrFunc2 (
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
  t_6 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_6, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_6, "IsAttributeStoringRep" );
  if ( t_6 == False ) {
   t_5 = t_6;
  }
  else if ( t_6 == True ) {
-  CHECK_BOOL( a_tester )
+  CHECK_BOOL( a_tester );
   t_5 = a_tester;
  }
  else if (IS_FILTER( t_6 ) ) {
@@ -234,10 +234,10 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_GETTER__FLAGS;
- CHECK_BOUND( t_5, "GETTER_FLAGS" )
+ CHECK_BOUND( t_5, "GETTER_FLAGS" );
  t_7 = GF_GETTER__FUNCTION;
  t_6 = CALL_1ARGS( t_7, a_name );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
@@ -264,13 +264,13 @@ static Obj  HdlrFunc4 (
  
  /* obj!.(name) := val; */
  t_1 = OBJ_HVAR( (1 << 16) | 1 );
- CHECK_BOUND( t_1, "name" )
+ CHECK_BOUND( t_1, "name" );
  AssComObj( a_obj, RNamObj(t_1), a_val );
  
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_2, "tester" )
+ CHECK_BOUND( t_2, "tester" );
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
@@ -309,7 +309,7 @@ static Obj  HdlrFunc3 (
  ASS_LVAR( 2, a_tester );
  
  /* if mutflag then */
- CHECK_BOOL( a_mutflag )
+ CHECK_BOOL( a_mutflag );
  t_1 = (Obj)(UInt)(a_mutflag != False);
  if ( t_1 ) {
   
@@ -324,11 +324,11 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], 2, ArgStringToList("obj,val"), HdlrFunc4 );
@@ -352,20 +352,20 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_SETTER__FUNCTION;
   t_7 = OBJ_LVAR( 1 );
-  CHECK_BOUND( t_7, "name" )
+  CHECK_BOUND( t_7, "name" );
   t_8 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_8, "tester" )
+  CHECK_BOUND( t_8, "tester" );
   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -413,22 +413,22 @@ static Obj  HdlrFunc5 (
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_imp__filter = t_1;
  
  /* type := Subtype( typeOfFamilies, IsAttributeStoringRep ); */
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_3, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_3, "IsAttributeStoringRep" );
  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* for pair in CATEGORIES_FAMILY do */
  t_4 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_4, "CATEGORIES_FAMILY" )
+ CHECK_BOUND( t_4, "CATEGORIES_FAMILY" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -454,8 +454,8 @@ static Obj  HdlrFunc5 (
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -463,7 +463,7 @@ static Obj  HdlrFunc5 (
    t_6 = GF_Subtype;
    C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    l_type = t_5;
    
   }
@@ -485,7 +485,7 @@ static Obj  HdlrFunc5 (
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
  t_1 = CALL_1ARGS( t_2, a_name );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_NAME, t_1 );
  
  /* family!.REQ_FLAGS := req_filter; */
@@ -541,11 +541,11 @@ static Obj  HdlrFunc6 (
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_3 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_3, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_3, "EMPTY_FLAGS" );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -574,11 +574,11 @@ static Obj  HdlrFunc7 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -609,12 +609,12 @@ static Obj  HdlrFunc8 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_imp );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -647,15 +647,15 @@ static Obj  HdlrFunc9 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_req );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_6 = GF_FLAGS__FILTER;
  t_5 = CALL_1ARGS( t_6, a_imp );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -684,17 +684,17 @@ static Obj  HdlrFunc10 (
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
   
   /* return NewFamily2( TypeOfFamilies, arg[1] ); */
   t_2 = GF_NewFamily2;
   t_3 = GC_TypeOfFamilies;
-  CHECK_BOUND( t_3, "TypeOfFamilies" )
+  CHECK_BOUND( t_3, "TypeOfFamilies" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -704,18 +704,18 @@ static Obj  HdlrFunc10 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
    
    /* return NewFamily3( TypeOfFamilies, arg[1], arg[2] ); */
    t_2 = GF_NewFamily3;
    t_3 = GC_TypeOfFamilies;
-   CHECK_BOUND( t_3, "TypeOfFamilies" )
+   CHECK_BOUND( t_3, "TypeOfFamilies" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
    
@@ -725,19 +725,19 @@ static Obj  HdlrFunc10 (
   else {
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, a_arg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
     
     /* return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] ); */
     t_2 = GF_NewFamily4;
     t_3 = GC_TypeOfFamilies;
-    CHECK_BOUND( t_3, "TypeOfFamilies" )
+    CHECK_BOUND( t_3, "TypeOfFamilies" );
     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-    CHECK_FUNC_RESULT( t_1 )
+    CHECK_FUNC_RESULT( t_1 );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
     
@@ -747,20 +747,20 @@ static Obj  HdlrFunc10 (
    else {
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, a_arg );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
      
      /* return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] ); */
      t_2 = GF_NewFamily5;
      t_3 = GC_TypeOfFamilies;
-     CHECK_BOUND( t_3, "TypeOfFamilies" )
+     CHECK_BOUND( t_3, "TypeOfFamilies" );
      C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
      C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
      C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
      
@@ -840,14 +840,14 @@ static Obj  HdlrFunc11 (
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = ElmComObj( a_family, R_HASH__SIZE );
  t_2 = MOD( t_3, t_4 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_hash = t_1;
  
  /* if IsBound( cache[hash] ) then */
- CHECK_INT_POS( l_hash )
+ CHECK_INT_POS( l_hash );
  t_2 = C_ISB_LIST( l_cache, l_hash );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
@@ -860,8 +860,8 @@ static Obj  HdlrFunc11 (
   t_3 = GF_IS__EQUAL__FLAGS;
   t_4 = ElmPosObj( l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -873,18 +873,18 @@ static Obj  HdlrFunc11 (
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_5 = ElmPosObj( l_cached, 3 );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_BOOL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_BOOL( t_3 );
    t_2 = (Obj)(UInt)(t_3 != False);
    t_1 = t_2;
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
     t_6 = CALL_1ARGS( t_7, l_cached );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
-    CHECK_FUNC_RESULT( t_4 )
-    CHECK_BOOL( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
+    CHECK_BOOL( t_4 );
     t_3 = (Obj)(UInt)(t_4 != False);
     t_1 = t_3;
    }
@@ -893,10 +893,10 @@ static Obj  HdlrFunc11 (
     /* if IS_IDENTICAL_OBJ( parent, fail ) then */
     t_3 = GF_IS__IDENTICAL__OBJ;
     t_4 = GC_fail;
-    CHECK_BOUND( t_4, "fail" )
+    CHECK_BOUND( t_4, "fail" );
     t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_BOOL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -907,8 +907,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( cached ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, l_cached );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -938,7 +938,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -955,10 +955,10 @@ static Obj  HdlrFunc11 (
     /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
     t_3 = GF_LEN__POSOBJ;
     t_2 = CALL_1ARGS( t_3, a_parent );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_4 = GF_LEN__POSOBJ;
     t_3 = CALL_1ARGS( t_4, l_cached );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
     if ( t_1 ) {
      
@@ -969,8 +969,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, a_parent );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1007,8 +1007,8 @@ static Obj  HdlrFunc11 (
        t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
        t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-       CHECK_FUNC_RESULT( t_7 )
-       CHECK_BOOL( t_7 )
+       CHECK_FUNC_RESULT( t_7 );
+       CHECK_BOOL( t_7 );
        t_6 = (Obj)(UInt)(t_7 != False);
        t_5 = (Obj)(UInt)( ! ((Int)t_6) );
        t_3 = t_5;
@@ -1034,7 +1034,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -1056,7 +1056,7 @@ static Obj  HdlrFunc11 (
   
   /* NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1; */
   t_2 = GC_NEW__TYPE__CACHE__MISS;
-  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" )
+  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   AssGVar( G_NEW__TYPE__CACHE__MISS, t_1 );
   
@@ -1065,15 +1065,15 @@ static Obj  HdlrFunc11 (
  
  /* NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1; */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
  
  /* if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  t_3 = GC_NEW__TYPE__ID__LIMIT;
- CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" )
+ CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" );
  t_1 = (Obj)(UInt)(! LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1089,7 +1089,7 @@ static Obj  HdlrFunc11 (
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
   t_1 = CALL_0ARGS( t_2 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
  }
@@ -1109,16 +1109,16 @@ static Obj  HdlrFunc11 (
  
  /* type[4] := NEW_TYPE_NEXT_ID; */
  t_1 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" );
  C_ASS_LIST_FPL( l_type, INTOBJ_INT(4), t_1 )
  
  /* if not IS_IDENTICAL_OBJ( parent, fail ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1126,8 +1126,8 @@ static Obj  HdlrFunc11 (
   /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
   t_3 = GF_LEN__POSOBJ;
   t_2 = CALL_1ARGS( t_3, a_parent );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(5);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1207,10 +1207,10 @@ static Obj  HdlrFunc11 (
    t_8 = GF_HASH__FLAGS;
    t_9 = ElmPosObj( l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_6 = MOD( t_7, l_ncl );
    C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ASS_LIST_FPL( l_ncache, t_5, l_t )
    
   }
@@ -1225,10 +1225,10 @@ static Obj  HdlrFunc11 (
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
   t_3 = CALL_1ARGS( t_4, a_flags );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = MOD( t_3, l_ncl );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_ncache, t_1, l_type )
   
  }
@@ -1284,17 +1284,17 @@ static Obj  HdlrFunc12 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1332,15 +1332,15 @@ static Obj  HdlrFunc13 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1371,8 +1371,8 @@ static Obj  HdlrFunc14 (
  t_4 = GF_IsFamily;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1388,18 +1388,18 @@ static Obj  HdlrFunc14 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* type := NewType3( TypeOfTypes, arg[1], arg[2] ); */
   t_2 = GF_NewType3;
   t_3 = GC_TypeOfTypes;
-  CHECK_BOUND( t_3, "TypeOfTypes" )
+  CHECK_BOUND( t_3, "TypeOfTypes" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1408,19 +1408,19 @@ static Obj  HdlrFunc14 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
    
    /* type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] ); */
    t_2 = GF_NewType4;
    t_3 = GC_TypeOfTypes;
-   CHECK_BOUND( t_3, "TypeOfTypes" )
+   CHECK_BOUND( t_3, "TypeOfTypes" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_type = t_1;
    
   }
@@ -1438,7 +1438,7 @@ static Obj  HdlrFunc14 (
  /* fi */
  
  /* return type; */
- CHECK_BOUND( l_type, "type" )
+ CHECK_BOUND( l_type, "type" );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
@@ -1472,21 +1472,21 @@ static Obj  HdlrFunc15 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1521,20 +1521,20 @@ static Obj  HdlrFunc16 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1566,8 +1566,8 @@ static Obj  HdlrFunc17 (
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1583,7 +1583,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1592,7 +1592,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1606,7 +1606,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1644,18 +1644,18 @@ static Obj  HdlrFunc18 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1688,17 +1688,17 @@ static Obj  HdlrFunc19 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1726,8 +1726,8 @@ static Obj  HdlrFunc20 (
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1743,7 +1743,7 @@ static Obj  HdlrFunc20 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1752,7 +1752,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1767,7 +1767,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1887,9 +1887,9 @@ static Obj  HdlrFunc25 (
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1916,9 +1916,9 @@ static Obj  HdlrFunc26 (
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1947,8 +1947,8 @@ static Obj  HdlrFunc27 (
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1964,8 +1964,8 @@ static Obj  HdlrFunc27 (
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -1979,8 +1979,8 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -1995,8 +1995,8 @@ static Obj  HdlrFunc27 (
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2042,20 +2042,20 @@ static Obj  HdlrFunc28 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* newtype := Subtype2( type, filter ); */
  t_2 = GF_Subtype2;
  t_1 = CALL_2ARGS( t_2, l_type, a_filter );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_newtype = t_1;
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2069,8 +2069,8 @@ static Obj  HdlrFunc28 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2084,8 +2084,8 @@ static Obj  HdlrFunc28 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2110,15 +2110,15 @@ static Obj  HdlrFunc28 (
  
  /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
  t_4 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = t_3;
  if ( ! t_2 ) {
   t_6 = GF_IsNoImmediateMethodsObject;
   t_5 = CALL_1ARGS( t_6, a_obj );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_2 = t_4;
  }
@@ -2131,7 +2131,7 @@ static Obj  HdlrFunc28 (
   t_4 = ElmPosObj( l_newtype, 2 );
   t_5 = ElmPosObj( l_type, 2 );
   t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2165,8 +2165,8 @@ static Obj  HdlrFunc29 (
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2181,8 +2181,8 @@ static Obj  HdlrFunc29 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2191,9 +2191,9 @@ static Obj  HdlrFunc29 (
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
   t_4 = CALL_1ARGS( t_5, a_obj );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2202,8 +2202,8 @@ static Obj  HdlrFunc29 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2212,9 +2212,9 @@ static Obj  HdlrFunc29 (
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
    t_4 = CALL_1ARGS( t_5, a_obj );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2223,8 +2223,8 @@ static Obj  HdlrFunc29 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2233,9 +2233,9 @@ static Obj  HdlrFunc29 (
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
     t_4 = CALL_1ARGS( t_5, a_obj );
-    CHECK_FUNC_RESULT( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     CALL_2ARGS( t_1, a_obj, t_2 );
     
    }
@@ -2310,7 +2310,7 @@ static Obj  HdlrFunc30 (
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* extra := [  ]; */
@@ -2321,10 +2321,10 @@ static Obj  HdlrFunc30 (
  /* if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then */
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
- CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2332,7 +2332,7 @@ static Obj  HdlrFunc30 (
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, a_arg );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
   l_extra = t_1;
@@ -2354,13 +2354,13 @@ static Obj  HdlrFunc30 (
   
   /* nflags := EMPTY_FLAGS; */
   t_1 = GC_EMPTY__FLAGS;
-  CHECK_BOUND( t_1, "EMPTY_FLAGS" )
+  CHECK_BOUND( t_1, "EMPTY_FLAGS" );
   l_nflags = t_1;
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_6 = CALL_1ARGS( t_7, a_arg );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
@@ -2385,25 +2385,25 @@ static Obj  HdlrFunc30 (
    l_i = t_2;
    
    /* attr := arg[i]; */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_5, a_arg, l_i )
    l_attr = t_5;
    
    /* val := arg[i + 1]; */
    C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_6 )
+   CHECK_INT_POS( t_6 );
    C_ELM_LIST_FPL( t_5, a_arg, t_6 )
    l_val = t_5;
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
    t_6 = CALL_1ARGS( t_7, l_attr );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
     
     /* if val then */
-    CHECK_BOOL( l_val )
+    CHECK_BOOL( l_val );
     t_5 = (Obj)(UInt)(l_val != False);
     if ( t_5 ) {
      
@@ -2411,9 +2411,9 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_7 = CALL_1ARGS( t_8, l_attr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2426,11 +2426,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2444,13 +2444,13 @@ static Obj  HdlrFunc30 (
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
     t_10 = CALL_1ARGS( t_11, l_attr );
-    CHECK_FUNC_RESULT( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
-    CHECK_FUNC_RESULT( t_8 )
+    CHECK_FUNC_RESULT( t_8 );
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_7 = GC_LENGTH__SETTER__METHODS__2;
-    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" )
+    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
     t_5 = (Obj)(UInt)( ! EQ( t_6, t_7 ));
     if ( t_5 ) {
      
@@ -2470,10 +2470,10 @@ static Obj  HdlrFunc30 (
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
      t_5 = CALL_1ARGS( t_6, l_attr );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_7 = GF_IMMUTABLE__COPY__OBJ;
      t_6 = CALL_1ARGS( t_7, l_val );
-     CHECK_FUNC_RESULT( t_6 )
+     CHECK_FUNC_RESULT( t_6 );
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) ); */
@@ -2481,11 +2481,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2498,8 +2498,8 @@ static Obj  HdlrFunc30 (
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = (Obj)(UInt)( ! ((Int)t_2) );
   if ( t_1 ) {
@@ -2508,26 +2508,26 @@ static Obj  HdlrFunc30 (
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = CALL_1ARGS( t_2, t_3 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_flags = t_1;
    
    /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
-   CHECK_BOUND( t_4, "TypeOfTypes" )
+   CHECK_BOUND( t_4, "TypeOfTypes" );
    t_6 = GF_FamilyType;
    t_5 = CALL_1ARGS( t_6, l_type );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_7 = GC_fail;
-   CHECK_BOUND( t_7, "fail" )
+   CHECK_BOUND( t_7, "fail" );
    t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, t_2, l_obj );
    
   }
@@ -2548,7 +2548,7 @@ static Obj  HdlrFunc30 (
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_extra );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
@@ -2574,14 +2574,14 @@ static Obj  HdlrFunc30 (
   
   /* if Tester( extra[i] )( obj ) then */
   t_8 = GF_Tester;
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_9, l_extra, l_i )
   t_7 = CALL_1ARGS( t_8, t_9 );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_FUNC( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_FUNC( t_7 );
   t_6 = CALL_1ARGS( t_7, l_obj );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -2591,7 +2591,7 @@ static Obj  HdlrFunc30 (
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_8 = MakeString( "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
@@ -2600,7 +2600,7 @@ static Obj  HdlrFunc30 (
    t_7 = GF_Tester;
    C_ELM_LIST_FPL( t_8, l_extra, l_i )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -2610,10 +2610,10 @@ static Obj  HdlrFunc30 (
   t_6 = GF_Setter;
   C_ELM_LIST_FPL( t_7, l_extra, l_i )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_FUNC( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC( t_5 );
   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_7 )
+  CHECK_INT_POS( t_7 );
   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
   CALL_2ARGS( t_5, l_obj, t_6 );
   
@@ -2659,7 +2659,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -3124,14 +3124,14 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
- CHECK_BOUND( t_3, "TYPE_OBJ" )
+ CHECK_BOUND( t_3, "TYPE_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
- CHECK_BOUND( t_3, "FAMILY_OBJ" )
+ CHECK_BOUND( t_3, "FAMILY_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
@@ -3167,9 +3167,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
- CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
+ CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
@@ -3177,9 +3177,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
- CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
@@ -3187,9 +3187,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
- CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
@@ -3256,7 +3256,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
- CHECK_BOUND( t_3, "SetFilterObj" )
+ CHECK_BOUND( t_3, "SetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
@@ -3289,7 +3289,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
- CHECK_BOUND( t_3, "ResetFilterObj" )
+ CHECK_BOUND( t_3, "ResetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -3297,16 +3297,16 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
- CHECK_BOUND( t_3, "Ignore" )
+ CHECK_BOUND( t_3, "Ignore" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -111,11 +111,15 @@ typedef UInt    RNam;
     if (!IS_POS_INT(obj))                                                    \
         RequireArgumentEx(0, obj, "<obj>", "must be a positive integer");
 
-#define CHECK_BOOL(obj)                                                      \
-    if (obj != True && obj != False)                                         \
-        RequireArgumentEx(0, obj, "<obj>", "must be 'true' or 'false'");
+static inline void CHECK_BOOL(Obj expr)
+{
+    RequireTrueOrFalse(0, expr); // use <expr> to match interpreter error
+}
 
-#define CHECK_FUNC(obj) RequireFunction(0, obj);
+static inline void CHECK_FUNC(Obj obj)
+{
+    RequireFunction(0, obj);
+}
 
 #define CHECK_NR_ARGS(narg, args)                                            \
     if (narg != LEN_PLIST(args))                                             \

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -781,7 +781,7 @@ static void CompCheckBound(CVar obj, Obj name)
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_BOUND( %c, \"%g\" )\n", obj, name );
+            Emit( "CHECK_BOUND( %c, \"%g\" );\n", obj, name );
         }
         SetInfoCVar( obj, W_BOUND );
     }
@@ -796,7 +796,7 @@ static void CompCheckFuncResult(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_FUNC_RESULT( %c )\n", obj );
+            Emit( "CHECK_FUNC_RESULT( %c );\n", obj );
         }
         SetInfoCVar( obj, W_BOUND );
     }
@@ -811,7 +811,7 @@ static void CompCheckIntSmall(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_INT_SMALL( %c )\n", obj );
+            Emit( "CHECK_INT_SMALL( %c );\n", obj );
         }
         SetInfoCVar( obj, W_INT_SMALL );
     }
@@ -827,7 +827,7 @@ static void CompCheckIntSmallPos(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL_POS ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_INT_SMALL_POS( %c )\n", obj );
+            Emit( "CHECK_INT_SMALL_POS( %c );\n", obj );
         }
         SetInfoCVar( obj, W_INT_SMALL_POS );
     }
@@ -841,7 +841,7 @@ static void CompCheckIntPos(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_POS ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_INT_POS( %c )\n", obj );
+            Emit( "CHECK_INT_POS( %c );\n", obj );
         }
         SetInfoCVar( obj, W_INT_POS );
     }
@@ -856,7 +856,7 @@ static void CompCheckBool(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_BOOL ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_BOOL( %c )\n", obj );
+            Emit( "CHECK_BOOL( %c );\n", obj );
         }
         SetInfoCVar( obj, W_BOOL );
     }
@@ -872,7 +872,7 @@ static void CompCheckFunc(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_FUNC ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_FUNC( %c )\n", obj );
+            Emit( "CHECK_FUNC( %c );\n", obj );
         }
         SetInfoCVar( obj, W_FUNC );
     }

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -240,8 +240,8 @@ static Obj  HdlrFunc2 (
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -255,10 +255,10 @@ static Obj  HdlrFunc2 (
  /* if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then */
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
- CHECK_BOUND( t_4, "IMM_FLAGS" )
+ CHECK_BOUND( t_4, "IMM_FLAGS" );
  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -272,18 +272,18 @@ static Obj  HdlrFunc2 (
  /* flags := SUB_FLAGS( flags, IMM_FLAGS ); */
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
- CHECK_BOUND( t_3, "IMM_FLAGS" )
+ CHECK_BOUND( t_3, "IMM_FLAGS" );
  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flagspos = t_1;
  
  /* tried := [  ]; */
@@ -294,7 +294,7 @@ static Obj  HdlrFunc2 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* flags := type![2]; */
@@ -303,14 +303,14 @@ static Obj  HdlrFunc2 (
  
  /* RUN_IMMEDIATE_METHODS_RUNS := RUN_IMMEDIATE_METHODS_RUNS + 1; */
  t_2 = GC_RUN__IMMEDIATE__METHODS__RUNS;
- CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" )
+ CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_RUN__IMMEDIATE__METHODS__RUNS, t_1 );
  
  /* if TRACE_IMMEDIATE_METHODS then */
  t_2 = GC_TRACE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -347,26 +347,26 @@ static Obj  HdlrFunc2 (
   
   /* if IsBound( IMMEDIATES[j] ) then */
   t_7 = GC_IMMEDIATES;
-  CHECK_BOUND( t_7, "IMMEDIATES" )
-  CHECK_INT_POS( l_j )
+  CHECK_BOUND( t_7, "IMMEDIATES" );
+  CHECK_INT_POS( l_j );
   t_6 = C_ISB_LIST( t_7, l_j );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* imm := IMMEDIATES[j]; */
    t_6 = GC_IMMEDIATES;
-   CHECK_BOUND( t_6, "IMMEDIATES" )
+   CHECK_BOUND( t_6, "IMMEDIATES" );
    C_ELM_LIST_FPL( t_5, t_6, l_j )
    l_imm = t_5;
    
    /* for i in [ 0, SIZE_IMMEDIATE_METHOD_ENTRY .. LEN_LIST( imm ) - SIZE_IMMEDIATE_METHOD_ENTRY ] do */
    t_9 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    t_12 = GF_LEN__LIST;
    t_11 = CALL_1ARGS( t_12, l_imm );
-   CHECK_FUNC_RESULT( t_11 )
+   CHECK_FUNC_RESULT( t_11 );
    t_12 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    C_DIFF_FIA( t_10, t_11, t_12 )
    t_8 = Range3Check( INTOBJ_INT(0), t_9, t_10 );
    if ( IS_SMALL_LIST(t_8) ) {
@@ -393,21 +393,21 @@ static Obj  HdlrFunc2 (
     /* if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then */
     t_13 = GF_IS__SUBSET__FLAGS;
     C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
-    CHECK_INT_POS( t_15 )
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_14, l_imm, t_15 )
     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
-    CHECK_FUNC_RESULT( t_12 )
-    CHECK_BOOL( t_12 )
+    CHECK_FUNC_RESULT( t_12 );
+    CHECK_BOOL( t_12 );
     t_11 = (Obj)(UInt)(t_12 != False);
     t_10 = t_11;
     if ( t_10 ) {
      t_15 = GF_IS__SUBSET__FLAGS;
      C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
-     CHECK_INT_POS( t_17 )
+     CHECK_INT_POS( t_17 );
      C_ELM_LIST_FPL( t_16, l_imm, t_17 )
      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
-     CHECK_FUNC_RESULT( t_14 )
-     CHECK_BOOL( t_14 )
+     CHECK_FUNC_RESULT( t_14 );
+     CHECK_BOOL( t_14 );
      t_13 = (Obj)(UInt)(t_14 != False);
      t_12 = (Obj)(UInt)( ! ((Int)t_13) );
      t_10 = t_12;
@@ -415,7 +415,7 @@ static Obj  HdlrFunc2 (
     t_9 = t_10;
     if ( t_9 ) {
      C_SUM_FIA( t_14, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_14 )
+     CHECK_INT_POS( t_14 );
      C_ELM_LIST_FPL( t_13, l_imm, t_14 )
      t_12 = (Obj)(UInt)(IN( t_13, l_tried ));
      t_11 = (Obj)(UInt)( ! ((Int)t_12) );
@@ -425,37 +425,37 @@ static Obj  HdlrFunc2 (
      
      /* meth := IMMEDIATE_METHODS[imm[i + 6]]; */
      t_10 = GC_IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" )
+     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" );
      C_SUM_FIA( t_12, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_12 )
+     CHECK_INT_POS( t_12 );
      C_ELM_LIST_FPL( t_11, l_imm, t_12 )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_9, t_10, t_11 )
      l_meth = t_9;
      
      /* res := meth( obj ); */
-     CHECK_FUNC( l_meth )
+     CHECK_FUNC( l_meth );
      t_9 = CALL_1ARGS( l_meth, a_obj );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      l_res = t_9;
      
      /* ADD_LIST( tried, imm[i + 6] ); */
      t_9 = GF_ADD__LIST;
      C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
      CALL_2ARGS( t_9, l_tried, t_10 );
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
-     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" )
+     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" );
      C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
      AssGVar( G_RUN__IMMEDIATE__METHODS__CHECKS, t_9 );
      
      /* if TRACE_IMMEDIATE_METHODS then */
      t_10 = GC_TRACE__IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" )
-     CHECK_BOOL( t_10 )
+     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" );
+     CHECK_BOOL( t_10 );
      t_9 = (Obj)(UInt)(t_10 != False);
      if ( t_9 ) {
       
@@ -464,15 +464,15 @@ static Obj  HdlrFunc2 (
       t_10 = MakeString( "#I  immediate: " );
       t_12 = GF_NAME__FUNC;
       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_14 )
+      CHECK_INT_POS( t_14 );
       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
       t_11 = CALL_1ARGS( t_12, t_13 );
-      CHECK_FUNC_RESULT( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
       CALL_2ARGS( t_9, t_10, t_11 );
       
       /* if imm[i + 7] <> false then */
       C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
-      CHECK_INT_POS( t_11 )
+      CHECK_INT_POS( t_11 );
       C_ELM_LIST_FPL( t_10, l_imm, t_11 )
       t_11 = False;
       t_9 = (Obj)(UInt)( ! EQ( t_10, t_11 ));
@@ -482,7 +482,7 @@ static Obj  HdlrFunc2 (
        t_9 = GF_Print;
        t_10 = MakeString( ": " );
        C_SUM_FIA( t_12, l_i, INTOBJ_INT(7) )
-       CHECK_INT_POS( t_12 )
+       CHECK_INT_POS( t_12 );
        C_ELM_LIST_FPL( t_11, l_imm, t_12 )
        CALL_2ARGS( t_9, t_10, t_11 );
        
@@ -493,12 +493,12 @@ static Obj  HdlrFunc2 (
       t_9 = GF_Print;
       t_10 = MakeString( " at " );
       C_SUM_FIA( t_13, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_13 )
+      CHECK_INT_POS( t_13 );
       C_ELM_LIST_FPL( t_12, l_imm, t_13 )
       C_ELM_LIST_FPL( t_11, t_12, INTOBJ_INT(1) )
       t_12 = MakeString( ":" );
       C_SUM_FIA( t_15, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_15 )
+      CHECK_INT_POS( t_15 );
       C_ELM_LIST_FPL( t_14, l_imm, t_15 )
       C_ELM_LIST_FPL( t_13, t_14, INTOBJ_INT(2) )
       t_14 = MakeString( "\n" );
@@ -509,7 +509,7 @@ static Obj  HdlrFunc2 (
      
      /* if res <> TRY_NEXT_METHOD then */
      t_10 = GC_TRY__NEXT__METHOD;
-     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" )
+     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" );
      t_9 = (Obj)(UInt)( ! EQ( l_res, t_10 ));
      if ( t_9 ) {
       
@@ -519,9 +519,9 @@ static Obj  HdlrFunc2 (
       
       /* imm[i + 2]( obj, res ); */
       C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
-      CHECK_INT_POS( t_10 )
+      CHECK_INT_POS( t_10 );
       C_ELM_LIST_FPL( t_9, l_imm, t_10 )
-      CHECK_FUNC( t_9 )
+      CHECK_FUNC( t_9 );
       CALL_2ARGS( t_9, a_obj, l_res );
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
@@ -530,7 +530,7 @@ static Obj  HdlrFunc2 (
       
       /* RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1; */
       t_10 = GC_RUN__IMMEDIATE__METHODS__HITS;
-      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" )
+      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" );
       C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
       AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, t_9 );
       
@@ -538,10 +538,10 @@ static Obj  HdlrFunc2 (
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
       t_13 = CALL_1ARGS( t_14, a_obj );
-      CHECK_FUNC_RESULT( t_13 )
+      CHECK_FUNC_RESULT( t_13 );
       t_11 = CALL_2ARGS( t_12, t_13, l_type );
-      CHECK_FUNC_RESULT( t_11 )
-      CHECK_BOOL( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
+      CHECK_BOOL( t_11 );
       t_10 = (Obj)(UInt)(t_11 != False);
       t_9 = (Obj)(UInt)( ! ((Int)t_10) );
       if ( t_9 ) {
@@ -549,29 +549,29 @@ static Obj  HdlrFunc2 (
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
        t_9 = CALL_1ARGS( t_10, a_obj );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_type = t_9;
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
        t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
-       CHECK_BOUND( t_12, "IMM_FLAGS" )
+       CHECK_BOUND( t_12, "IMM_FLAGS" );
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
        t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 )
+       CHECK_FUNC_RESULT( t_10 );
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
@@ -651,23 +651,23 @@ static Obj  HdlrFunc3 (
  /* lk := WRITE_LOCK( METHODS_OPERATION_REGION ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_METHODS__OPERATION__REGION;
- CHECK_BOUND( t_3, "METHODS_OPERATION_REGION" )
+ CHECK_BOUND( t_3, "METHODS_OPERATION_REGION" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_baserank );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* rank := baserank(  ); */
-  CHECK_FUNC( a_baserank )
+  CHECK_FUNC( a_baserank );
   t_1 = CALL_0ARGS( a_baserank );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_rank = t_1;
   
  }
@@ -684,15 +684,15 @@ static Obj  HdlrFunc3 (
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
  t_2 = CALL_1ARGS( t_3, a_opr );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if 0 = LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_flags );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -700,7 +700,7 @@ static Obj  HdlrFunc3 (
    t_1 = GF_Error;
    t_3 = GF_NAME__FUNC;
    t_2 = CALL_1ARGS( t_3, a_opr );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_3 = MakeString( ": constructors must have at least one argument" );
    CALL_2ARGS( t_1, t_2, t_3 );
    
@@ -711,7 +711,7 @@ static Obj  HdlrFunc3 (
   t_3 = GF_RankFilter;
   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_DIFF_FIA( t_1, l_rank, t_2 )
   l_rank = t_1;
   
@@ -746,7 +746,7 @@ static Obj  HdlrFunc3 (
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
    t_6 = CALL_1ARGS( t_7, l_i );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
    
@@ -759,19 +759,19 @@ static Obj  HdlrFunc3 (
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_flags );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_methods = t_1;
  
  /* methods := methods{[ 1 .. LEN_LIST( methods ) ]}; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = Range2Check( INTOBJ_INT(1), t_3 );
  t_1 = ElmsListCheck( l_methods, t_2 );
  l_methods = t_1;
@@ -784,7 +784,7 @@ static Obj  HdlrFunc3 (
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
   t_1 = CALL_1ARGS( t_2, a_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   a_info = t_1;
   
  }
@@ -796,9 +796,9 @@ static Obj  HdlrFunc3 (
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
   t_3 = CALL_1ARGS( t_4, a_opr );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
@@ -827,13 +827,13 @@ static Obj  HdlrFunc3 (
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_methods );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
   if ( t_1 ) {
    C_SUM_FIA( t_6, l_narg, INTOBJ_INT(3) )
    C_SUM_FIA( t_5, l_i, t_6 )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ELM_LIST_FPL( t_4, l_methods, t_5 )
    t_3 = (Obj)(UInt)(LT( l_rank, t_4 ));
    t_1 = t_3;
@@ -854,8 +854,8 @@ static Obj  HdlrFunc3 (
  
  /* if REREADING then */
  t_2 = GC_REREADING;
- CHECK_BOUND( t_2, "REREADING" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "REREADING" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -866,13 +866,13 @@ static Obj  HdlrFunc3 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_methods );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
     C_SUM_FIA( t_6, l_k, l_narg )
     C_SUM_FIA( t_5, t_6, INTOBJ_INT(3) )
-    CHECK_INT_POS( t_5 )
+    CHECK_INT_POS( t_5 );
     C_ELM_LIST_FPL( t_4, l_methods, t_5 )
     t_3 = (Obj)(UInt)(EQ( l_rank, t_4 ));
     t_1 = t_3;
@@ -882,7 +882,7 @@ static Obj  HdlrFunc3 (
    /* if info = methods[k + narg + 4] then */
    C_SUM_FIA( t_4, l_k, l_narg )
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(4) )
-   CHECK_INT_POS( t_3 )
+   CHECK_INT_POS( t_3 );
    C_ELM_LIST_FPL( t_2, l_methods, t_3 )
    t_1 = (Obj)(UInt)(EQ( a_info, t_2 ));
    if ( t_1 ) {
@@ -892,7 +892,7 @@ static Obj  HdlrFunc3 (
     l_match = t_1;
     
     /* for j in [ 1 .. narg ] do */
-    CHECK_INT_SMALL( l_narg )
+    CHECK_INT_SMALL( l_narg );
     t_2 = l_narg;
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
@@ -906,7 +906,7 @@ static Obj  HdlrFunc3 (
      else if ( l_match == True ) {
       C_SUM_FIA( t_7, l_k, l_j )
       C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_6 )
+      CHECK_INT_POS( t_6 );
       C_ELM_LIST_FPL( t_5, l_methods, t_6 )
       C_ELM_LIST_FPL( t_6, a_flags, l_j )
       t_4 = (EQ( t_5, t_6 ) ? True : False);
@@ -915,7 +915,7 @@ static Obj  HdlrFunc3 (
      else if (IS_FILTER( l_match ) ) {
       C_SUM_FIA( t_8, l_k, l_j )
       C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_7 )
+      CHECK_INT_POS( t_7 );
       C_ELM_LIST_FPL( t_6, l_methods, t_7 )
       C_ELM_LIST_FPL( t_7, a_flags, l_j )
       t_5 = (EQ( t_6, t_7 ) ? True : False);
@@ -931,7 +931,7 @@ static Obj  HdlrFunc3 (
     /* od */
     
     /* if match then */
-    CHECK_BOOL( l_match )
+    CHECK_BOOL( l_match );
     t_1 = (Obj)(UInt)(l_match != False);
     if ( t_1 ) {
      
@@ -964,8 +964,8 @@ static Obj  HdlrFunc3 (
  
  /* if not REREADING or not replace then */
  t_4 = GC_REREADING;
- CHECK_BOUND( t_4, "REREADING" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "REREADING" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
  t_1 = t_2;
@@ -996,7 +996,7 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_2, 6, INTOBJ_INT(1) );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_methods );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_DIFF_FIA( t_3, t_4, l_i )
   SET_ELM_PLIST( t_2, 7, t_3 );
   CHANGED_BAG( t_2 );
@@ -1012,7 +1012,7 @@ static Obj  HdlrFunc3 (
   
   /* rel := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_rel = t_1;
   
  }
@@ -1025,7 +1025,7 @@ static Obj  HdlrFunc3 (
    
    /* rel := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_rel = t_1;
    
   }
@@ -1034,28 +1034,28 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_rel );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD then */
     t_2 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_2 )
+    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_rel );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1074,7 +1074,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <famrel> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1094,7 +1094,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1110,7 +1110,7 @@ static Obj  HdlrFunc3 (
   
   /* method := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_method = t_1;
   
  }
@@ -1123,7 +1123,7 @@ static Obj  HdlrFunc3 (
    
    /* method := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_method = t_1;
    
   }
@@ -1132,22 +1132,22 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_method );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then */
     t_3 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_3 )
+    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
      t_5 = CALL_1ARGS( t_6, a_method );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      t_1 = t_3;
@@ -1157,13 +1157,13 @@ static Obj  HdlrFunc3 (
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_method );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1182,7 +1182,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <method> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1202,7 +1202,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1213,11 +1213,11 @@ static Obj  HdlrFunc3 (
  
  /* methods[i + 1] := rel; */
  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_rel )
  
  /* for k in [ 1 .. narg ] do */
- CHECK_INT_SMALL( l_narg )
+ CHECK_INT_SMALL( l_narg );
  t_2 = l_narg;
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
@@ -1227,7 +1227,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + k + 1] := flags[k]; */
   C_SUM_FIA( t_4, l_i, l_k )
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_3 )
+  CHECK_INT_POS( t_3 );
   C_ELM_LIST_FPL( t_4, a_flags, l_k )
   C_ASS_LIST_FPL( l_methods, t_3, t_4 )
   
@@ -1237,22 +1237,22 @@ static Obj  HdlrFunc3 (
  /* methods[i + (narg + 2)] := method; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_method )
  
  /* methods[i + (narg + 3)] := rank; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(3) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, l_rank )
  
  /* methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info ); */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(4) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  t_3 = GF_IMMUTABLE__COPY__OBJ;
  t_2 = CALL_1ARGS( t_3, a_info );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
  /* if 6 >= 5 then */
@@ -1262,26 +1262,26 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_MakeImmutable;
   t_4 = NEW_PLIST( T_PLIST, 3 );
   SET_LEN_PLIST( t_4, 3 );
   t_6 = GF_INPUT__FILENAME;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_READEVALCOMMAND__LINENUMBER;
-  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" )
+  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_INPUT__LINENUMBER;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 3, t_5 );
   CHANGED_BAG( t_4 );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
  }
@@ -1294,7 +1294,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 6)] := baserank; */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
   
  }
@@ -1304,7 +1304,7 @@ static Obj  HdlrFunc3 (
  t_1 = GF_SET__METHODS__OPERATION;
  t_3 = GF_MakeReadOnlySingleObj;
  t_2 = CALL_1ARGS( t_3, l_methods );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_3ARGS( t_1, a_opr, l_narg, t_2 );
  
  /* UNLOCK( lk ); */
@@ -1439,15 +1439,15 @@ static Obj  HdlrFunc6 (
  /* lk := READ_LOCK( OPERATIONS_REGION ); */
  t_2 = GF_READ__LOCK;
  t_3 = GC_OPERATIONS__REGION;
- CHECK_BOUND( t_3, "OPERATIONS_REGION" )
+ CHECK_BOUND( t_3, "OPERATIONS_REGION" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_arglist );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_len = t_1;
  
  /* if len < 3 then */
@@ -1469,8 +1469,8 @@ static Obj  HdlrFunc6 (
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
  t_3 = CALL_1ARGS( t_4, l_opr );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1487,8 +1487,8 @@ static Obj  HdlrFunc6 (
  t_4 = GF_IS__STRING__REP;
  C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( ! t_1 ) {
@@ -1530,8 +1530,8 @@ static Obj  HdlrFunc6 (
   t_5 = GF_IS__FUNCTION;
   C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
   t_4 = CALL_1ARGS( t_5, t_6 );
-  CHECK_FUNC_RESULT( t_4 )
-  CHECK_BOOL( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
+  CHECK_BOOL( t_4 );
   t_3 = (Obj)(UInt)(t_4 != False);
   t_1 = t_3;
  }
@@ -1558,7 +1558,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_4 = C_ISB_LIST( a_arglist, l_pos );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
@@ -1567,8 +1567,8 @@ static Obj  HdlrFunc6 (
   t_6 = GF_IS__LIST;
   C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = (Obj)(UInt)( ! ((Int)t_4) );
   t_1 = t_3;
@@ -1590,11 +1590,11 @@ static Obj  HdlrFunc6 (
  
  /* if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then */
  t_3 = GC_GAPInfo;
- CHECK_BOUND( t_3, "GAPInfo" )
+ CHECK_BOUND( t_3, "GAPInfo" );
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_filters );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1602,7 +1602,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_2 = MakeString( "methods can have at most " );
   t_4 = GC_GAPInfo;
-  CHECK_BOUND( t_4, "GAPInfo" )
+  CHECK_BOUND( t_4, "GAPInfo" );
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   t_4 = MakeString( " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1613,7 +1613,7 @@ static Obj  HdlrFunc6 (
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, l_filters );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
   
@@ -1628,8 +1628,8 @@ static Obj  HdlrFunc6 (
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, l_filters );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(1);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1639,8 +1639,8 @@ static Obj  HdlrFunc6 (
    t_5 = GF_IS__STRING__REP;
    C_ELM_LIST_FPL( t_6, l_filters, l_i )
    t_4 = CALL_1ARGS( t_5, t_6 );
-   CHECK_FUNC_RESULT( t_4 )
-   CHECK_BOOL( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
+   CHECK_BOOL( t_4 );
    t_3 = (Obj)(UInt)(t_4 != False);
    if ( t_3 ) {
     
@@ -1658,15 +1658,15 @@ static Obj  HdlrFunc6 (
     t_4 = GF_EvalString;
     C_ELM_LIST_FPL( t_5, l_filters, l_i )
     t_3 = CALL_1ARGS( t_4, t_5 );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
     C_ELM_LIST_FPL( t_7, l_filters, l_i )
     t_5 = CALL_1ARGS( t_6, t_7 );
-    CHECK_FUNC_RESULT( t_5 )
-    CHECK_BOOL( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
+    CHECK_BOOL( t_5 );
     t_4 = (Obj)(UInt)(t_5 != False);
     t_3 = (Obj)(UInt)( ! ((Int)t_4) );
     if ( t_3 ) {
@@ -1710,17 +1710,17 @@ static Obj  HdlrFunc6 (
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_info1 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[32];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
    t_1 = CALL_1ARGS( t_2, l_info1 );
-   CHECK_FUNC_RESULT( t_1 )
-   CHECK_INT_POS( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[93];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
@@ -1769,14 +1769,14 @@ static Obj  HdlrFunc6 (
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
   t_6 = CALL_1ARGS( t_7, l_i );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   CALL_2ARGS( t_5, l_flags, t_6 );
   
  }
  /* od */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1794,23 +1794,23 @@ static Obj  HdlrFunc6 (
   t_4 = GF_IS__INT;
   C_ELM_LIST_FPL( t_5, a_arglist, l_pos )
   t_3 = CALL_1ARGS( t_4, t_5 );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = t_2;
   if ( ! t_1 ) {
    t_7 = GF_IS__FUNCTION;
    C_ELM_LIST_FPL( t_8, a_arglist, l_pos )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
-   CHECK_BOOL( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
+   CHECK_BOOL( t_6 );
    t_5 = (Obj)(UInt)(t_6 != False);
    t_4 = t_5;
    if ( t_4 ) {
     t_8 = GF_NARG__FUNC;
     C_ELM_LIST_FPL( t_9, a_arglist, l_pos )
     t_7 = CALL_1ARGS( t_8, t_9 );
-    CHECK_FUNC_RESULT( t_7 )
+    CHECK_FUNC_RESULT( t_7 );
     t_6 = (Obj)(UInt)(EQ( t_7, INTOBJ_INT(0) ));
     t_4 = t_6;
    }
@@ -1818,7 +1818,7 @@ static Obj  HdlrFunc6 (
    if ( t_3 ) {
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, a_arglist );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_5 = (Obj)(UInt)(LT( l_pos, t_6 ));
     t_3 = t_5;
    }
@@ -1847,7 +1847,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1868,7 +1868,7 @@ static Obj  HdlrFunc6 (
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
  t_5 = CALL_1ARGS( t_6, l_opr );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
  if ( t_3 ) {
@@ -1877,7 +1877,7 @@ static Obj  HdlrFunc6 (
   t_5 = t_6;
   if ( ! t_5 ) {
    t_8 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_8, "RETURN_TRUE" )
+   CHECK_BOUND( t_8, "RETURN_TRUE" );
    t_7 = (Obj)(UInt)(EQ( l_rel, t_8 ));
    t_5 = t_7;
   }
@@ -1887,7 +1887,7 @@ static Obj  HdlrFunc6 (
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_filters );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
  }
@@ -1898,7 +1898,7 @@ static Obj  HdlrFunc6 (
   t_3 = t_4;
   if ( ! t_3 ) {
    t_6 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_6, "RETURN_TRUE" )
+   CHECK_BOUND( t_6, "RETURN_TRUE" );
    t_5 = (Obj)(UInt)(EQ( l_method, t_6 ));
    t_3 = t_5;
   }
@@ -1910,7 +1910,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -1919,12 +1919,12 @@ static Obj  HdlrFunc6 (
  
  /* if CHECK_INSTALL_METHOD and check then */
  t_3 = GC_CHECK__INSTALL__METHOD;
- CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
- CHECK_BOOL( t_3 )
+ CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( t_1 ) {
-  CHECK_BOOL( a_check )
+  CHECK_BOOL( a_check );
   t_3 = (Obj)(UInt)(a_check != False);
   t_1 = t_3;
  }
@@ -1932,7 +1932,7 @@ static Obj  HdlrFunc6 (
   
   /* if opr in WRAPPER_OPERATIONS then */
   t_2 = GC_WRAPPER__OPERATIONS;
-  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
   t_1 = (Obj)(UInt)(IN( l_opr, t_2 ));
   if ( t_1 ) {
    
@@ -1941,7 +1941,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_4 = MakeString( "\n" );
    t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
    t_6 = MakeString( "#I  underlying operation(s)" );
@@ -1953,12 +1953,12 @@ static Obj  HdlrFunc6 (
   /* req := GET_OPER_FLAGS( opr ); */
   t_2 = GF_GET__OPER__FLAGS;
   t_1 = CALL_1ARGS( t_2, l_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_req = t_1;
   
   /* if req = fail then */
   t_2 = GC_fail;
-  CHECK_BOUND( t_2, "fail" )
+  CHECK_BOUND( t_2, "fail" );
   t_1 = (Obj)(UInt)(EQ( l_req, t_2 ));
   if ( t_1 ) {
    
@@ -1967,7 +1967,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    CALL_2ARGS( t_1, t_2, t_3 );
    
   }
@@ -2003,10 +2003,10 @@ static Obj  HdlrFunc6 (
    
    /* if not GAPInfo.CommandLineOptions.N then */
    t_9 = GC_GAPInfo;
-   CHECK_BOUND( t_9, "GAPInfo" )
+   CHECK_BOUND( t_9, "GAPInfo" );
    t_8 = ELM_REC( t_9, R_CommandLineOptions );
    t_7 = ELM_REC( t_8, R_N );
-   CHECK_BOOL( t_7 )
+   CHECK_BOOL( t_7 );
    t_6 = (Obj)(UInt)(t_7 != False);
    t_5 = (Obj)(UInt)( ! ((Int)t_6) );
    if ( t_5 ) {
@@ -2015,7 +2015,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -2027,7 +2027,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -2050,7 +2050,7 @@ static Obj  HdlrFunc6 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
@@ -2065,17 +2065,17 @@ static Obj  HdlrFunc6 (
    l_j = t_1;
    
    /* reqs := req[j]; */
-   CHECK_INT_POS( l_j )
+   CHECK_INT_POS( l_j );
    C_ELM_LIST_FPL( t_1, l_req, l_j )
    l_reqs = t_1;
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_reqs );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_imp );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
     
@@ -2086,8 +2086,8 @@ static Obj  HdlrFunc6 (
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, l_reqs );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_INT_SMALL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_INT_SMALL( t_2 );
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
           t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2098,8 +2098,8 @@ static Obj  HdlrFunc6 (
      C_ELM_LIST_FPL( t_7, l_imp, l_i )
      C_ELM_LIST_FPL( t_8, l_reqs, l_i )
      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      if ( t_3 ) {
@@ -2147,10 +2147,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2160,7 +2160,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( "the number of arguments does not match a declaration of " );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      CALL_2ARGS( t_1, t_2, t_3 );
      
     }
@@ -2174,7 +2174,7 @@ static Obj  HdlrFunc6 (
      t_3 = MakeString( "match a declaration of " );
      t_5 = GF_NAME__FUNC;
      t_4 = CALL_1ARGS( t_5, l_opr );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      t_5 = MakeString( "\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
      
@@ -2188,10 +2188,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2200,18 +2200,18 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Error;
      t_2 = MakeString( "required filters " );
      t_4 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
      t_3 = CALL_1ARGS( t_4, t_5 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( "\nfor " );
      t_6 = GF_Ordinal;
      t_5 = CALL_1ARGS( t_6, l_notmatch );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_6 = MakeString( " argument do not match a declaration of " );
      t_8 = GF_NAME__FUNC;
      t_7 = CALL_1ARGS( t_8, l_opr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
      
     }
@@ -2228,7 +2228,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 2, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "(\03" );
@@ -2236,7 +2236,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__FILENAME;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 4, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "\03 +" );
@@ -2244,7 +2244,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__LINENUMBER;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 6, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( ") \03" );
@@ -2257,10 +2257,10 @@ static Obj  HdlrFunc6 (
      
      /* for j in NamesFilter( imp[notmatch] ) do */
      t_5 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_6, l_imp, l_notmatch )
      t_4 = CALL_1ARGS( t_5, t_6 );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      if ( IS_SMALL_LIST(t_4) ) {
       t_3 = (Obj)(UInt)1;
       t_1 = INTOBJ_INT(1);
@@ -2295,7 +2295,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( " for " );
      t_4 = GF_Ordinal;
      t_3 = CALL_1ARGS( t_4, l_notmatch );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( " argument do not match \03a " );
      t_5 = MakeString( "declaration\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
@@ -2316,28 +2316,28 @@ static Obj  HdlrFunc6 (
    
    /* for k in [ j + 1 .. LEN_LIST( req ) ] do */
    C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
-   CHECK_INT_SMALL( t_2 )
+   CHECK_INT_SMALL( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_INT_SMALL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_INT_SMALL( t_3 );
    for ( t_1 = t_2;
          ((Int)t_1) <= ((Int)t_3);
          t_1 = (Obj)(((UInt)t_1)+4) ) {
     l_k = t_1;
     
     /* reqs := req[k]; */
-    CHECK_INT_POS( l_k )
+    CHECK_INT_POS( l_k );
     C_ELM_LIST_FPL( t_4, l_req, l_k )
     l_reqs = t_4;
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
     t_5 = CALL_1ARGS( t_6, l_reqs );
-    CHECK_FUNC_RESULT( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, l_imp );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
      
@@ -2348,8 +2348,8 @@ static Obj  HdlrFunc6 (
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
      t_5 = CALL_1ARGS( t_6, l_reqs );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_INT_SMALL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_INT_SMALL( t_5 );
      for ( t_4 = INTOBJ_INT(1);
            ((Int)t_4) <= ((Int)t_5);
            t_4 = (Obj)(((UInt)t_4)+4) ) {
@@ -2360,8 +2360,8 @@ static Obj  HdlrFunc6 (
       C_ELM_LIST_FPL( t_10, l_imp, l_i )
       C_ELM_LIST_FPL( t_11, l_reqs, l_i )
       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-      CHECK_FUNC_RESULT( t_8 )
-      CHECK_BOOL( t_8 )
+      CHECK_FUNC_RESULT( t_8 );
+      CHECK_BOOL( t_8 );
       t_7 = (Obj)(UInt)(t_8 != False);
       t_6 = (Obj)(UInt)( ! ((Int)t_7) );
       if ( t_6 ) {
@@ -2393,7 +2393,7 @@ static Obj  HdlrFunc6 (
       t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
-      CHECK_FUNC_RESULT( t_6 )
+      CHECK_FUNC_RESULT( t_6 );
       t_7 = MakeString( " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
@@ -2414,7 +2414,7 @@ static Obj  HdlrFunc6 (
  
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
- CHECK_BOUND( l_rank, "rank" )
+ CHECK_BOUND( l_rank, "rank" );
  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
  
  /* UNLOCK( lk ); */
@@ -2461,7 +2461,7 @@ static Obj  HdlrFunc8 (
  
  /* for prop in props do */
  t_4 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_4, "props" )
+ CHECK_BOUND( t_4, "props" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -2486,11 +2486,11 @@ static Obj  HdlrFunc8 (
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
   t_8 = CALL_1ARGS( t_9, l_prop );
-  CHECK_FUNC_RESULT( t_8 )
-  CHECK_FUNC( t_8 )
+  CHECK_FUNC_RESULT( t_8 );
+  CHECK_FUNC( t_8 );
   t_7 = CALL_1ARGS( t_8, a_obj );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_BOOL( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (Obj)(UInt)( ! ((Int)t_6) );
   if ( t_5 ) {
@@ -2500,20 +2500,20 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop )
+   CHECK_FUNC( l_prop );
    t_8 = CALL_1ARGS( l_prop, a_obj );
-   CHECK_FUNC_RESULT( t_8 )
-   CHECK_BOOL( t_8 )
+   CHECK_FUNC_RESULT( t_8 );
+   CHECK_BOOL( t_8 );
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
     t_10 = CALL_1ARGS( t_11, l_prop );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_FUNC( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_FUNC( t_10 );
     t_9 = CALL_1ARGS( t_10, a_obj );
-    CHECK_FUNC_RESULT( t_9 )
-    CHECK_BOOL( t_9 )
+    CHECK_FUNC_RESULT( t_9 );
+    CHECK_BOOL( t_9 );
     t_8 = (Obj)(UInt)(t_9 != False);
     t_6 = t_8;
    }
@@ -2522,7 +2522,7 @@ static Obj  HdlrFunc8 (
     
     /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
-    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
+    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
     
@@ -2541,10 +2541,10 @@ static Obj  HdlrFunc8 (
   
   /* return getter( obj ); */
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "getter" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "getter" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_1ARGS( t_2, a_obj );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2555,7 +2555,7 @@ static Obj  HdlrFunc8 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2610,10 +2610,10 @@ static Obj  HdlrFunc7 (
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2621,7 +2621,7 @@ static Obj  HdlrFunc7 (
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_flags = t_1;
   
   /* rank := 0; */
@@ -2629,7 +2629,7 @@ static Obj  HdlrFunc7 (
   
   /* cats := IS_OBJECT; */
   t_1 = GC_IS__OBJECT;
-  CHECK_BOUND( t_1, "IS_OBJECT" )
+  CHECK_BOUND( t_1, "IS_OBJECT" );
   l_cats = t_1;
   
   /* props := [  ]; */
@@ -2640,15 +2640,15 @@ static Obj  HdlrFunc7 (
   /* lk := READ_LOCK( FILTER_REGION ); */
   t_2 = GF_READ__LOCK;
   t_3 = GC_FILTER__REGION;
-  CHECK_BOUND( t_3, "FILTER_REGION" )
+  CHECK_BOUND( t_3, "FILTER_REGION" );
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_lk = t_1;
   
   /* for i in TRUES_FLAGS( flags ) do */
   t_5 = GF_TRUES__FLAGS;
   t_4 = CALL_1ARGS( t_5, l_flags );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
    t_1 = INTOBJ_INT(1);
@@ -2672,11 +2672,11 @@ static Obj  HdlrFunc7 (
    
    /* if INFO_FILTERS[i] in FNUM_CATS_AND_REPS then */
    t_7 = GC_INFO__FILTERS;
-   CHECK_BOUND( t_7, "INFO_FILTERS" )
-   CHECK_INT_POS( l_i )
+   CHECK_BOUND( t_7, "INFO_FILTERS" );
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_6, t_7, l_i )
    t_7 = GC_FNUM__CATS__AND__REPS;
-   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" )
+   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" );
    t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
    if ( t_5 ) {
     
@@ -2686,14 +2686,14 @@ static Obj  HdlrFunc7 (
     }
     else if ( l_cats == True ) {
      t_7 = GC_FILTERS;
-     CHECK_BOUND( t_7, "FILTERS" )
+     CHECK_BOUND( t_7, "FILTERS" );
      C_ELM_LIST_FPL( t_6, t_7, l_i )
-     CHECK_BOOL( t_6 )
+     CHECK_BOOL( t_6 );
      t_5 = t_6;
     }
     else if (IS_FILTER( l_cats ) ) {
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      t_5 = NewAndFilter( l_cats, t_7 );
     }
@@ -2706,10 +2706,10 @@ static Obj  HdlrFunc7 (
     /* rank := rank - RankFilter( FILTERS[i] ); */
     t_7 = GF_RankFilter;
     t_9 = GC_FILTERS;
-    CHECK_BOUND( t_9, "FILTERS" )
+    CHECK_BOUND( t_9, "FILTERS" );
     C_ELM_LIST_FPL( t_8, t_9, l_i )
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     C_DIFF_FIA( t_5, l_rank, t_6 )
     l_rank = t_5;
     
@@ -2718,19 +2718,19 @@ static Obj  HdlrFunc7 (
    /* elif INFO_FILTERS[i] in FNUM_PROS then */
    else {
     t_7 = GC_INFO__FILTERS;
-    CHECK_BOUND( t_7, "INFO_FILTERS" )
+    CHECK_BOUND( t_7, "INFO_FILTERS" );
     C_ELM_LIST_FPL( t_6, t_7, l_i )
     t_7 = GC_FNUM__PROS;
-    CHECK_BOUND( t_7, "FNUM_PROS" )
+    CHECK_BOUND( t_7, "FNUM_PROS" );
     t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
     if ( t_5 ) {
      
      /* ADD_LIST( props, FILTERS[i] ); */
      t_5 = GF_ADD__LIST;
      t_6 = OBJ_LVAR( 2 );
-     CHECK_BOUND( t_6, "props" )
+     CHECK_BOUND( t_6, "props" );
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      CALL_2ARGS( t_5, t_6, t_7 );
      
@@ -2748,15 +2748,15 @@ static Obj  HdlrFunc7 (
   /* MakeImmutable( props ); */
   t_1 = GF_MakeImmutable;
   t_2 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_2, "props" )
+  CHECK_BOUND( t_2, "props" );
   CALL_1ARGS( t_1, t_2 );
   
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_4, "props" )
+  CHECK_BOUND( t_4, "props" );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -2780,7 +2780,7 @@ static Obj  HdlrFunc7 (
   end ); */
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
-   CHECK_BOUND( t_2, "getter" )
+   CHECK_BOUND( t_2, "getter" );
    t_3 = MakeString( "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -2838,15 +2838,15 @@ static Obj  HdlrFunc9 (
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 2, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
- CHECK_BOUND( t_5, "DO_NOTHING_SETTER" )
+ CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
@@ -2884,7 +2884,7 @@ static Obj  HdlrFunc10 (
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_list );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
  
@@ -2914,13 +2914,13 @@ static Obj  HdlrFunc10 (
   C_SUM_FIA( t_6, l_i, l_k )
   C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_j = t_1;
   
   /* if list[j] < elm then */
-  CHECK_INT_POS( l_j )
+  CHECK_INT_POS( l_j );
   C_ELM_LIST_FPL( t_2, a_list, l_j )
   t_1 = (Obj)(UInt)(LT( t_2, a_elm ));
   if ( t_1 ) {
@@ -2968,8 +2968,8 @@ static Obj  HdlrFunc12 (
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
  t_3 = CALL_1ARGS( t_4, a_key );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2977,7 +2977,7 @@ static Obj  HdlrFunc12 (
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "name" )
+  CHECK_BOUND( t_2, "name" );
   t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -3039,32 +3039,32 @@ static Obj  HdlrFunc14 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3073,26 +3073,26 @@ static Obj  HdlrFunc14 (
   
   /* erg := oper( D, key ); */
   t_2 = OBJ_HVAR( (1 << 16) | 3 );
-  CHECK_BOUND( t_2, "oper" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "oper" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
   t_1 = CALL_2ARGS( t_2, l_known, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
   if ( ! t_1 ) {
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_4, l_known, l_i )
    t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
    t_1 = t_3;
@@ -3103,29 +3103,29 @@ static Obj  HdlrFunc14 (
    C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
    AsssListCheck( l_known, t_1, t_2 );
    
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    t_2 = GF_IMMUTABLE__COPY__OBJ;
    t_1 = CALL_1ARGS( t_2, a_key );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
    /* known[i + 1] := IMMUTABLE_COPY_OBJ( erg ); */
    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_3 = GF_IMMUTABLE__COPY__OBJ;
    t_2 = CALL_1ARGS( t_3, l_erg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
   }
@@ -3136,7 +3136,7 @@ static Obj  HdlrFunc14 (
  
  /* return known[i + 1]; */
  C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_2 )
+ CHECK_INT_POS( t_2 );
  C_ELM_LIST_FPL( t_1, l_known, t_2 )
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3168,34 +3168,34 @@ static Obj  HdlrFunc15 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (EQ( t_4, a_key ) ? True : False);
   t_1 = t_3;
@@ -3240,32 +3240,32 @@ static Obj  HdlrFunc16 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3276,29 +3276,29 @@ static Obj  HdlrFunc16 (
   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
   AsssListCheck( l_known, t_1, t_2 );
   
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   t_2 = GF_IMMUTABLE__COPY__OBJ;
   t_1 = CALL_1ARGS( t_2, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
   /* known[i + 1] := IMMUTABLE_COPY_OBJ( obj ); */
   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_IMMUTABLE__COPY__OBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
  }
@@ -3342,7 +3342,7 @@ static Obj  HdlrFunc11 (
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_2, "keytest" )
+ CHECK_BOUND( t_2, "keytest" );
  t_3 = MakeString( "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
@@ -3368,9 +3368,9 @@ static Obj  HdlrFunc11 (
  /* str := SHALLOW_COPY_OBJ( name ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_3, "name" )
+ CHECK_BOUND( t_3, "name" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
@@ -3391,7 +3391,7 @@ static Obj  HdlrFunc11 (
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
@@ -3401,7 +3401,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* APPEND_LIST_INTR( str, "s" ); */
@@ -3417,7 +3417,7 @@ static Obj  HdlrFunc11 (
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 4, t_1 );
  
  /* InstallMethod( attr, "default method", true, [ domreq ], 0, function ( D )
@@ -3425,7 +3425,7 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
- CHECK_BOUND( t_2, "attr" )
+ CHECK_BOUND( t_2, "attr" );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -3444,7 +3444,7 @@ static Obj  HdlrFunc11 (
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, a_domreq );
@@ -3456,20 +3456,20 @@ static Obj  HdlrFunc11 (
  /* lk := WRITE_LOCK( OPERATIONS_REGION ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_OPERATIONS__REGION;
- CHECK_BOUND( t_3, "OPERATIONS_REGION" )
+ CHECK_BOUND( t_3, "OPERATIONS_REGION" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_WRAPPER__OPERATIONS;
- CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+ CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_5, "name" )
+ CHECK_BOUND( t_5, "name" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* UNLOCK( lk ); */
@@ -3495,9 +3495,9 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_4, "name" )
+ CHECK_BOUND( t_4, "name" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3522,7 +3522,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3545,7 +3545,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3570,7 +3570,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
@@ -3582,7 +3582,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
  t_3 = GC_IS__OBJECT;
- CHECK_BOUND( t_3, "IS_OBJECT" )
+ CHECK_BOUND( t_3, "IS_OBJECT" );
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
  CALL_2ARGS( t_1, l_str, t_2 );
@@ -3602,7 +3602,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
@@ -3612,7 +3612,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], 3, ArgStringToList("D,key,obj"), HdlrFunc16 );
@@ -3668,9 +3668,9 @@ static Obj  HdlrFunc18 (
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_7, "reqs" )
+ CHECK_BOUND( t_7, "reqs" );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -3695,37 +3695,37 @@ static Obj  HdlrFunc18 (
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
   t_7 = OBJ_HVAR( (1 << 16) | 4 );
-  CHECK_BOUND( t_7, "re" )
-  CHECK_BOOL( t_7 )
+  CHECK_BOUND( t_7, "re" );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
    t_12 = OBJ_HVAR( (1 << 16) | 3 );
-   CHECK_BOUND( t_12, "cond" )
+   CHECK_BOUND( t_12, "cond" );
    t_13 = OBJ_HVAR( (1 << 16) | 5 );
-   CHECK_BOUND( t_13, "i" )
-   CHECK_INT_POS( t_13 )
+   CHECK_BOUND( t_13, "i" );
+   CHECK_INT_POS( t_13 );
    t_11 = C_ISB_LIST( t_12, t_13 );
    t_10 = (Obj)(UInt)(t_11 != False);
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
     t_17 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_17, "cond" )
+    CHECK_BOUND( t_17, "cond" );
     t_18 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_18, "i" )
-    CHECK_INT_POS( t_18 )
+    CHECK_BOUND( t_18, "i" );
+    CHECK_INT_POS( t_18 );
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
-    CHECK_FUNC_RESULT( t_14 )
-    CHECK_FUNC( t_14 )
+    CHECK_FUNC_RESULT( t_14 );
+    CHECK_FUNC( t_14 );
     t_16 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_16, "i" )
-    CHECK_INT_POS( t_16 )
+    CHECK_BOUND( t_16, "i" );
+    CHECK_INT_POS( t_16 );
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
     t_13 = CALL_1ARGS( t_14, t_15 );
-    CHECK_FUNC_RESULT( t_13 )
-    CHECK_BOOL( t_13 )
+    CHECK_FUNC_RESULT( t_13 );
+    CHECK_BOOL( t_13 );
     t_12 = (Obj)(UInt)(t_13 != False);
     t_11 = (Obj)(UInt)( ! ((Int)t_12) );
     t_9 = t_11;
@@ -3733,19 +3733,19 @@ static Obj  HdlrFunc18 (
    t_8 = t_9;
    if ( t_8 ) {
     t_13 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_13, "cond" )
+    CHECK_BOUND( t_13, "cond" );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
-    CHECK_FUNC( t_12 )
+    CHECK_FUNC( t_12 );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_BOOL( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_BOOL( t_11 );
     t_10 = (Obj)(UInt)(t_11 != False);
     t_8 = t_10;
    }
@@ -3753,21 +3753,21 @@ static Obj  HdlrFunc18 (
    if ( t_7 ) {
     t_12 = GF_Tester;
     t_14 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_14, "cond" )
+    CHECK_BOUND( t_14, "cond" );
     t_15 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_15, "i" )
-    CHECK_INT_POS( t_15 )
+    CHECK_BOUND( t_15, "i" );
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_FUNC( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_FUNC( t_11 );
     t_13 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_13, "i" )
-    CHECK_INT_POS( t_13 )
+    CHECK_BOUND( t_13, "i" );
+    CHECK_INT_POS( t_13 );
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
     t_10 = CALL_1ARGS( t_11, t_12 );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_BOOL( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_BOOL( t_10 );
     t_9 = (Obj)(UInt)(t_10 != False);
     t_7 = t_9;
    }
@@ -3780,17 +3780,17 @@ static Obj  HdlrFunc18 (
  
  /* if re then */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "re" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "re" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
   t_3 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_3, "oper" )
+  CHECK_BOUND( t_3, "oper" );
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3801,7 +3801,7 @@ static Obj  HdlrFunc18 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3845,7 +3845,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
   
@@ -3879,7 +3879,7 @@ static Obj  HdlrFunc17 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
    
@@ -3923,7 +3923,7 @@ static Obj  HdlrFunc17 (
  
  /* for i in reqs do */
  t_4 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_4, "reqs" )
+ CHECK_BOUND( t_4, "reqs" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -3946,12 +3946,12 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 5, t_2 );
   
   /* val := val - RankFilter( i ); */
-  CHECK_BOUND( l_val, "val" )
+  CHECK_BOUND( l_val, "val" );
   t_7 = GF_RankFilter;
   t_8 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_8, "i" )
+  CHECK_BOUND( t_8, "i" );
   t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
   
@@ -3972,11 +3972,11 @@ static Obj  HdlrFunc17 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "oper" )
- CHECK_BOUND( l_info, "info" )
- CHECK_BOUND( l_fampred, "fampred" )
+ CHECK_BOUND( t_2, "oper" );
+ CHECK_BOUND( l_info, "info" );
+ CHECK_BOUND( l_fampred, "fampred" );
  t_3 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_3, "reqs" )
+ CHECK_BOUND( t_3, "reqs" );
  t_4 = NewFunction( NameFunc[18], -1, ArgStringToList("arg"), HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewFunctionBody();
@@ -4088,7 +4088,7 @@ static Obj  HdlrFunc1 (
  t_4 = GF_NewSpecialRegion;
  t_5 = MakeString( "operation methods" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, baserank, method )
@@ -4403,7 +4403,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -4639,17 +4639,17 @@ static Obj  HdlrFunc1 (
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
- CHECK_BOUND( t_2, "ViewObj" )
+ CHECK_BOUND( t_2, "ViewObj" );
  t_3 = MakeString( "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 1, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
- CHECK_BOUND( t_6, "PRINT_OBJ" )
+ CHECK_BOUND( t_6, "PRINT_OBJ" );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -255,12 +255,12 @@ static Obj  HdlrFunc2 (
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
  t_6 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_6, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_6, "IsAttributeStoringRep" );
  if ( t_6 == False ) {
   t_5 = t_6;
  }
  else if ( t_6 == True ) {
-  CHECK_BOOL( a_tester )
+  CHECK_BOOL( a_tester );
   t_5 = a_tester;
  }
  else if (IS_FILTER( t_6 ) ) {
@@ -273,10 +273,10 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_GETTER__FLAGS;
- CHECK_BOUND( t_5, "GETTER_FLAGS" )
+ CHECK_BOUND( t_5, "GETTER_FLAGS" );
  t_7 = GF_GETTER__FUNCTION;
  t_6 = CALL_1ARGS( t_7, a_name );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
@@ -303,13 +303,13 @@ static Obj  HdlrFunc4 (
  
  /* obj!.(name) := val; */
  t_1 = OBJ_HVAR( (1 << 16) | 1 );
- CHECK_BOUND( t_1, "name" )
+ CHECK_BOUND( t_1, "name" );
  AssComObj( a_obj, RNamObj(t_1), a_val );
  
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_2, "tester" )
+ CHECK_BOUND( t_2, "tester" );
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
@@ -348,7 +348,7 @@ static Obj  HdlrFunc3 (
  ASS_LVAR( 2, a_tester );
  
  /* if mutflag then */
- CHECK_BOOL( a_mutflag )
+ CHECK_BOOL( a_mutflag );
  t_1 = (Obj)(UInt)(a_mutflag != False);
  if ( t_1 ) {
   
@@ -363,11 +363,11 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], 2, ArgStringToList("obj,val"), HdlrFunc4 );
@@ -391,20 +391,20 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_SETTER__FUNCTION;
   t_7 = OBJ_LVAR( 1 );
-  CHECK_BOUND( t_7, "name" )
+  CHECK_BOUND( t_7, "name" );
   t_8 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_8, "tester" )
+  CHECK_BOUND( t_8, "tester" );
   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -452,30 +452,30 @@ static Obj  HdlrFunc5 (
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_imp__filter = t_1;
  
  /* type := Subtype( typeOfFamilies, IsAttributeStoringRep ); */
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_3, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_3, "IsAttributeStoringRep" );
  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* lock := READ_LOCK( CATEGORIES_FAMILY ); */
  t_2 = GF_READ__LOCK;
  t_3 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_3, "CATEGORIES_FAMILY" )
+ CHECK_BOUND( t_3, "CATEGORIES_FAMILY" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
  /* for pair in CATEGORIES_FAMILY do */
  t_4 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_4, "CATEGORIES_FAMILY" )
+ CHECK_BOUND( t_4, "CATEGORIES_FAMILY" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -501,8 +501,8 @@ static Obj  HdlrFunc5 (
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -510,7 +510,7 @@ static Obj  HdlrFunc5 (
    t_6 = GF_Subtype;
    C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    l_type = t_5;
    
   }
@@ -526,7 +526,7 @@ static Obj  HdlrFunc5 (
  /* family := AtomicRecord(  ); */
  t_2 = GF_AtomicRecord;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_family = t_1;
  
  /* SET_TYPE_COMOBJ( family, type ); */
@@ -536,7 +536,7 @@ static Obj  HdlrFunc5 (
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
  t_1 = CALL_1ARGS( t_2, a_name );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_NAME, t_1 );
  
  /* family!.REQ_FLAGS := req_filter; */
@@ -554,9 +554,9 @@ static Obj  HdlrFunc5 (
  /* lock := WRITE_LOCK( DS_TYPE_CACHE ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_DS__TYPE__CACHE;
- CHECK_BOUND( t_3, "DS_TYPE_CACHE" )
+ CHECK_BOUND( t_3, "DS_TYPE_CACHE" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
  /* family!.TYPES := MIGRATE_RAW( [  ], DS_TYPE_CACHE ); */
@@ -564,9 +564,9 @@ static Obj  HdlrFunc5 (
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  t_4 = GC_DS__TYPE__CACHE;
- CHECK_BOUND( t_4, "DS_TYPE_CACHE" )
+ CHECK_BOUND( t_4, "DS_TYPE_CACHE" );
  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_TYPES, t_1 );
  
  /* UNLOCK( lock ); */
@@ -577,9 +577,9 @@ static Obj  HdlrFunc5 (
  t_2 = GF_MakeWriteOnceAtomic;
  t_4 = GF_AtomicList;
  t_3 = CALL_1ARGS( t_4, INTOBJ_INT(27) );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_TYPES__LIST__FAM, t_1 );
  
  /* return family; */
@@ -609,11 +609,11 @@ static Obj  HdlrFunc6 (
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_3 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_3, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_3, "EMPTY_FLAGS" );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -642,11 +642,11 @@ static Obj  HdlrFunc7 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -677,12 +677,12 @@ static Obj  HdlrFunc8 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_imp );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -715,15 +715,15 @@ static Obj  HdlrFunc9 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_req );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_6 = GF_FLAGS__FILTER;
  t_5 = CALL_1ARGS( t_6, a_imp );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -752,17 +752,17 @@ static Obj  HdlrFunc10 (
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
   
   /* return NewFamily2( TypeOfFamilies, arg[1] ); */
   t_2 = GF_NewFamily2;
   t_3 = GC_TypeOfFamilies;
-  CHECK_BOUND( t_3, "TypeOfFamilies" )
+  CHECK_BOUND( t_3, "TypeOfFamilies" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -772,18 +772,18 @@ static Obj  HdlrFunc10 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
    
    /* return NewFamily3( TypeOfFamilies, arg[1], arg[2] ); */
    t_2 = GF_NewFamily3;
    t_3 = GC_TypeOfFamilies;
-   CHECK_BOUND( t_3, "TypeOfFamilies" )
+   CHECK_BOUND( t_3, "TypeOfFamilies" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
    
@@ -793,19 +793,19 @@ static Obj  HdlrFunc10 (
   else {
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, a_arg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
     
     /* return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] ); */
     t_2 = GF_NewFamily4;
     t_3 = GC_TypeOfFamilies;
-    CHECK_BOUND( t_3, "TypeOfFamilies" )
+    CHECK_BOUND( t_3, "TypeOfFamilies" );
     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-    CHECK_FUNC_RESULT( t_1 )
+    CHECK_FUNC_RESULT( t_1 );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
     
@@ -815,20 +815,20 @@ static Obj  HdlrFunc10 (
    else {
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, a_arg );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
      
      /* return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] ); */
      t_2 = GF_NewFamily5;
      t_3 = GC_TypeOfFamilies;
-     CHECK_BOUND( t_3, "TypeOfFamilies" )
+     CHECK_BOUND( t_3, "TypeOfFamilies" );
      C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
      C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
      C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
      
@@ -904,9 +904,9 @@ static Obj  HdlrFunc11 (
  /* lock := WRITE_LOCK( DS_TYPE_CACHE ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_DS__TYPE__CACHE;
- CHECK_BOUND( t_3, "DS_TYPE_CACHE" )
+ CHECK_BOUND( t_3, "DS_TYPE_CACHE" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
  /* cache := family!.TYPES; */
@@ -916,14 +916,14 @@ static Obj  HdlrFunc11 (
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = ElmComObj( a_family, R_HASH__SIZE );
  t_2 = MOD( t_3, t_4 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_hash = t_1;
  
  /* if IsBound( cache[hash] ) then */
- CHECK_INT_POS( l_hash )
+ CHECK_INT_POS( l_hash );
  t_2 = C_ISB_LIST( l_cache, l_hash );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
@@ -936,8 +936,8 @@ static Obj  HdlrFunc11 (
   t_3 = GF_IS__EQUAL__FLAGS;
   t_4 = ElmPosObj( l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -949,18 +949,18 @@ static Obj  HdlrFunc11 (
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_5 = ElmPosObj( l_cached, 3 );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_BOOL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_BOOL( t_3 );
    t_2 = (Obj)(UInt)(t_3 != False);
    t_1 = t_2;
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
     t_6 = CALL_1ARGS( t_7, l_cached );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
-    CHECK_FUNC_RESULT( t_4 )
-    CHECK_BOOL( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
+    CHECK_BOOL( t_4 );
     t_3 = (Obj)(UInt)(t_4 != False);
     t_1 = t_3;
    }
@@ -969,10 +969,10 @@ static Obj  HdlrFunc11 (
     /* if IS_IDENTICAL_OBJ( parent, fail ) then */
     t_3 = GF_IS__IDENTICAL__OBJ;
     t_4 = GC_fail;
-    CHECK_BOUND( t_4, "fail" )
+    CHECK_BOUND( t_4, "fail" );
     t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_BOOL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -983,8 +983,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( cached ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, l_cached );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1014,7 +1014,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -1035,10 +1035,10 @@ static Obj  HdlrFunc11 (
     /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
     t_3 = GF_LEN__POSOBJ;
     t_2 = CALL_1ARGS( t_3, a_parent );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_4 = GF_LEN__POSOBJ;
     t_3 = CALL_1ARGS( t_4, l_cached );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
     if ( t_1 ) {
      
@@ -1049,8 +1049,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, a_parent );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1087,8 +1087,8 @@ static Obj  HdlrFunc11 (
        t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
        t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-       CHECK_FUNC_RESULT( t_7 )
-       CHECK_BOOL( t_7 )
+       CHECK_FUNC_RESULT( t_7 );
+       CHECK_BOOL( t_7 );
        t_6 = (Obj)(UInt)(t_7 != False);
        t_5 = (Obj)(UInt)( ! ((Int)t_6) );
        t_3 = t_5;
@@ -1114,7 +1114,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -1140,7 +1140,7 @@ static Obj  HdlrFunc11 (
   
   /* NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1; */
   t_2 = GC_NEW__TYPE__CACHE__MISS;
-  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" )
+  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   AssGVar( G_NEW__TYPE__CACHE__MISS, t_1 );
   
@@ -1149,15 +1149,15 @@ static Obj  HdlrFunc11 (
  
  /* NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1; */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
  
  /* if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  t_3 = GC_NEW__TYPE__ID__LIMIT;
- CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" )
+ CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" );
  t_1 = (Obj)(UInt)(! LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1173,7 +1173,7 @@ static Obj  HdlrFunc11 (
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
   t_1 = CALL_0ARGS( t_2 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
  }
@@ -1191,7 +1191,7 @@ static Obj  HdlrFunc11 (
  /* data := MakeReadOnlyObj( data ); */
  t_2 = GF_MakeReadOnlyObj;
  t_1 = CALL_1ARGS( t_2, a_data );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_data = t_1;
  
  /* type[3] := data; */
@@ -1199,16 +1199,16 @@ static Obj  HdlrFunc11 (
  
  /* type[4] := NEW_TYPE_NEXT_ID; */
  t_1 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" );
  C_ASS_LIST_FPL( l_type, INTOBJ_INT(4), t_1 )
  
  /* if not IS_IDENTICAL_OBJ( parent, fail ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1216,8 +1216,8 @@ static Obj  HdlrFunc11 (
   /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
   t_3 = GF_LEN__POSOBJ;
   t_2 = CALL_1ARGS( t_3, a_parent );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(5);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1267,7 +1267,7 @@ static Obj  HdlrFunc11 (
   /* MIGRATE_RAW( ncache, DS_TYPE_CACHE ); */
   t_1 = GF_MIGRATE__RAW;
   t_2 = GC_DS__TYPE__CACHE;
-  CHECK_BOUND( t_2, "DS_TYPE_CACHE" )
+  CHECK_BOUND( t_2, "DS_TYPE_CACHE" );
   CALL_2ARGS( t_1, l_ncache, t_2 );
   
   /* ncl := 3 * family!.HASH_SIZE + 1; */
@@ -1303,10 +1303,10 @@ static Obj  HdlrFunc11 (
    t_8 = GF_HASH__FLAGS;
    t_9 = ElmPosObj( l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_6 = MOD( t_7, l_ncl );
    C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ASS_LIST_FPL( l_ncache, t_5, l_t )
    
   }
@@ -1321,10 +1321,10 @@ static Obj  HdlrFunc11 (
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
   t_3 = CALL_1ARGS( t_4, a_flags );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = MOD( t_3, l_ncl );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_ncache, t_1, l_type )
   
  }
@@ -1388,17 +1388,17 @@ static Obj  HdlrFunc12 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1436,15 +1436,15 @@ static Obj  HdlrFunc13 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1475,8 +1475,8 @@ static Obj  HdlrFunc14 (
  t_4 = GF_IsFamily;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1492,18 +1492,18 @@ static Obj  HdlrFunc14 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* type := NewType3( TypeOfTypes, arg[1], arg[2] ); */
   t_2 = GF_NewType3;
   t_3 = GC_TypeOfTypes;
-  CHECK_BOUND( t_3, "TypeOfTypes" )
+  CHECK_BOUND( t_3, "TypeOfTypes" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1512,19 +1512,19 @@ static Obj  HdlrFunc14 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
    
    /* type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] ); */
    t_2 = GF_NewType4;
    t_3 = GC_TypeOfTypes;
-   CHECK_BOUND( t_3, "TypeOfTypes" )
+   CHECK_BOUND( t_3, "TypeOfTypes" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_type = t_1;
    
   }
@@ -1542,7 +1542,7 @@ static Obj  HdlrFunc14 (
  /* fi */
  
  /* return type; */
- CHECK_BOUND( l_type, "type" )
+ CHECK_BOUND( l_type, "type" );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
@@ -1576,21 +1576,21 @@ static Obj  HdlrFunc15 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1625,20 +1625,20 @@ static Obj  HdlrFunc16 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1669,15 +1669,15 @@ static Obj  HdlrFunc17 (
  /* p := READ_LOCK( arg ); */
  t_2 = GF_READ__LOCK;
  t_1 = CALL_1ARGS( t_2, a_arg );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_p = t_1;
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1693,7 +1693,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1702,7 +1702,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1716,7 +1716,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1758,18 +1758,18 @@ static Obj  HdlrFunc18 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1802,17 +1802,17 @@ static Obj  HdlrFunc19 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1840,8 +1840,8 @@ static Obj  HdlrFunc20 (
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1857,7 +1857,7 @@ static Obj  HdlrFunc20 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1866,7 +1866,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1881,7 +1881,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1978,7 +1978,7 @@ static Obj  HdlrFunc24 (
  t_1 = GF_StrictBindOnce;
  t_3 = GF_MakeImmutable;
  t_2 = CALL_1ARGS( t_3, a_data );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_3ARGS( t_1, a_K, INTOBJ_INT(3), t_2 );
  
  /* return; */
@@ -2008,9 +2008,9 @@ static Obj  HdlrFunc25 (
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -2037,9 +2037,9 @@ static Obj  HdlrFunc26 (
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -2069,8 +2069,8 @@ static Obj  HdlrFunc27 (
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2086,24 +2086,24 @@ static Obj  HdlrFunc27 (
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if IS_SUBSET_FLAGS( flags, IsAtomicPositionalObjectRepFlags ) then */
   t_3 = GF_IS__SUBSET__FLAGS;
   t_4 = GC_IsAtomicPositionalObjectRepFlags;
-  CHECK_BOUND( t_4, "IsAtomicPositionalObjectRepFlags" )
+  CHECK_BOUND( t_4, "IsAtomicPositionalObjectRepFlags" );
   t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2111,7 +2111,7 @@ static Obj  HdlrFunc27 (
    t_1 = GF_FORCE__SWITCH__OBJ;
    t_3 = GF_FixedAtomicList;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2123,26 +2123,26 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
    /* if IS_ATOMIC_RECORD( obj ) then */
    t_3 = GF_IS__ATOMIC__RECORD;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if IS_SUBSET_FLAGS( flags, IsNonAtomicComponentObjectRepFlags ) then */
     t_3 = GF_IS__SUBSET__FLAGS;
     t_4 = GC_IsNonAtomicComponentObjectRepFlags;
-    CHECK_BOUND( t_4, "IsNonAtomicComponentObjectRepFlags" )
+    CHECK_BOUND( t_4, "IsNonAtomicComponentObjectRepFlags" );
     t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_BOOL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -2150,7 +2150,7 @@ static Obj  HdlrFunc27 (
      t_1 = GF_FORCE__SWITCH__OBJ;
      t_3 = GF_FromAtomicRecord;
      t_2 = CALL_1ARGS( t_3, a_obj );
-     CHECK_FUNC_RESULT( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
      CALL_2ARGS( t_1, a_obj, t_2 );
      
     }
@@ -2162,10 +2162,10 @@ static Obj  HdlrFunc27 (
    else {
     t_4 = GF_IS__SUBSET__FLAGS;
     t_5 = GC_IsNonAtomicComponentObjectRepFlags;
-    CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRepFlags" )
+    CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRepFlags" );
     t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
-    CHECK_FUNC_RESULT( t_3 )
-    CHECK_BOOL( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2174,7 +2174,7 @@ static Obj  HdlrFunc27 (
      t_1 = GF_FORCE__SWITCH__OBJ;
      t_3 = GF_AtomicRecord;
      t_2 = CALL_1ARGS( t_3, a_obj );
-     CHECK_FUNC_RESULT( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
      CALL_2ARGS( t_1, a_obj, t_2 );
      
     }
@@ -2188,8 +2188,8 @@ static Obj  HdlrFunc27 (
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2203,8 +2203,8 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2219,8 +2219,8 @@ static Obj  HdlrFunc27 (
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2236,8 +2236,8 @@ static Obj  HdlrFunc27 (
  /* if IsReadOnlyPositionalObjectRep( obj ) then */
  t_3 = GF_IsReadOnlyPositionalObjectRep;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2281,20 +2281,20 @@ static Obj  HdlrFunc28 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* newtype := Subtype2( type, filter ); */
  t_2 = GF_Subtype2;
  t_1 = CALL_2ARGS( t_2, l_type, a_filter );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_newtype = t_1;
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2308,8 +2308,8 @@ static Obj  HdlrFunc28 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2323,8 +2323,8 @@ static Obj  HdlrFunc28 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2349,15 +2349,15 @@ static Obj  HdlrFunc28 (
  
  /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
  t_4 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = t_3;
  if ( ! t_2 ) {
   t_6 = GF_IsNoImmediateMethodsObject;
   t_5 = CALL_1ARGS( t_6, a_obj );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_2 = t_4;
  }
@@ -2370,7 +2370,7 @@ static Obj  HdlrFunc28 (
   t_4 = ElmPosObj( l_newtype, 2 );
   t_5 = ElmPosObj( l_type, 2 );
   t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2404,8 +2404,8 @@ static Obj  HdlrFunc29 (
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2420,8 +2420,8 @@ static Obj  HdlrFunc29 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2430,9 +2430,9 @@ static Obj  HdlrFunc29 (
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
   t_4 = CALL_1ARGS( t_5, a_obj );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2441,8 +2441,8 @@ static Obj  HdlrFunc29 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2451,9 +2451,9 @@ static Obj  HdlrFunc29 (
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
    t_4 = CALL_1ARGS( t_5, a_obj );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2462,8 +2462,8 @@ static Obj  HdlrFunc29 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2472,9 +2472,9 @@ static Obj  HdlrFunc29 (
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
     t_4 = CALL_1ARGS( t_5, a_obj );
-    CHECK_FUNC_RESULT( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     CALL_2ARGS( t_1, a_obj, t_2 );
     
    }
@@ -2549,7 +2549,7 @@ static Obj  HdlrFunc30 (
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* extra := [  ]; */
@@ -2560,10 +2560,10 @@ static Obj  HdlrFunc30 (
  /* if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then */
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
- CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2571,7 +2571,7 @@ static Obj  HdlrFunc30 (
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, a_arg );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
   l_extra = t_1;
@@ -2593,13 +2593,13 @@ static Obj  HdlrFunc30 (
   
   /* nflags := EMPTY_FLAGS; */
   t_1 = GC_EMPTY__FLAGS;
-  CHECK_BOUND( t_1, "EMPTY_FLAGS" )
+  CHECK_BOUND( t_1, "EMPTY_FLAGS" );
   l_nflags = t_1;
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_6 = CALL_1ARGS( t_7, a_arg );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
@@ -2624,25 +2624,25 @@ static Obj  HdlrFunc30 (
    l_i = t_2;
    
    /* attr := arg[i]; */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_5, a_arg, l_i )
    l_attr = t_5;
    
    /* val := arg[i + 1]; */
    C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_6 )
+   CHECK_INT_POS( t_6 );
    C_ELM_LIST_FPL( t_5, a_arg, t_6 )
    l_val = t_5;
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
    t_6 = CALL_1ARGS( t_7, l_attr );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
     
     /* if val then */
-    CHECK_BOOL( l_val )
+    CHECK_BOOL( l_val );
     t_5 = (Obj)(UInt)(l_val != False);
     if ( t_5 ) {
      
@@ -2650,9 +2650,9 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_7 = CALL_1ARGS( t_8, l_attr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2665,11 +2665,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2683,13 +2683,13 @@ static Obj  HdlrFunc30 (
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
     t_10 = CALL_1ARGS( t_11, l_attr );
-    CHECK_FUNC_RESULT( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
-    CHECK_FUNC_RESULT( t_8 )
+    CHECK_FUNC_RESULT( t_8 );
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_7 = GC_LENGTH__SETTER__METHODS__2;
-    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" )
+    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
     t_5 = (Obj)(UInt)( ! EQ( t_6, t_7 ));
     if ( t_5 ) {
      
@@ -2709,10 +2709,10 @@ static Obj  HdlrFunc30 (
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
      t_5 = CALL_1ARGS( t_6, l_attr );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_7 = GF_IMMUTABLE__COPY__OBJ;
      t_6 = CALL_1ARGS( t_7, l_val );
-     CHECK_FUNC_RESULT( t_6 )
+     CHECK_FUNC_RESULT( t_6 );
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) ); */
@@ -2720,11 +2720,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2737,8 +2737,8 @@ static Obj  HdlrFunc30 (
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = (Obj)(UInt)( ! ((Int)t_2) );
   if ( t_1 ) {
@@ -2747,26 +2747,26 @@ static Obj  HdlrFunc30 (
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = CALL_1ARGS( t_2, t_3 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_flags = t_1;
    
    /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
-   CHECK_BOUND( t_4, "TypeOfTypes" )
+   CHECK_BOUND( t_4, "TypeOfTypes" );
    t_6 = GF_FamilyType;
    t_5 = CALL_1ARGS( t_6, l_type );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_7 = GC_fail;
-   CHECK_BOUND( t_7, "fail" )
+   CHECK_BOUND( t_7, "fail" );
    t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, t_2, l_obj );
    
   }
@@ -2787,7 +2787,7 @@ static Obj  HdlrFunc30 (
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_extra );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
@@ -2813,14 +2813,14 @@ static Obj  HdlrFunc30 (
   
   /* if Tester( extra[i] )( obj ) then */
   t_8 = GF_Tester;
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_9, l_extra, l_i )
   t_7 = CALL_1ARGS( t_8, t_9 );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_FUNC( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_FUNC( t_7 );
   t_6 = CALL_1ARGS( t_7, l_obj );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -2830,7 +2830,7 @@ static Obj  HdlrFunc30 (
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_8 = MakeString( "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
@@ -2839,7 +2839,7 @@ static Obj  HdlrFunc30 (
    t_7 = GF_Tester;
    C_ELM_LIST_FPL( t_8, l_extra, l_i )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -2849,10 +2849,10 @@ static Obj  HdlrFunc30 (
   t_6 = GF_Setter;
   C_ELM_LIST_FPL( t_7, l_extra, l_i )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_FUNC( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC( t_5 );
   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_7 )
+  CHECK_INT_POS( t_7 );
   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
   CALL_2ARGS( t_5, l_obj, t_6 );
   
@@ -2898,7 +2898,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -2934,7 +2934,7 @@ static Obj  HdlrFunc1 (
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssGVar( G_DS__TYPE__CACHE, t_1 );
  
  /* BIND_GLOBAL( "NEW_FAMILY", function ( typeOfFamilies, name, req_filter, imp_filter )
@@ -3372,14 +3372,14 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
- CHECK_BOUND( t_3, "TYPE_OBJ" )
+ CHECK_BOUND( t_3, "TYPE_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
- CHECK_BOUND( t_3, "FAMILY_OBJ" )
+ CHECK_BOUND( t_3, "FAMILY_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
@@ -3415,9 +3415,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
- CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
+ CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
@@ -3425,9 +3425,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
- CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
@@ -3435,9 +3435,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
- CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
@@ -3519,7 +3519,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
- CHECK_BOUND( t_3, "SetFilterObj" )
+ CHECK_BOUND( t_3, "SetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
@@ -3552,7 +3552,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
- CHECK_BOUND( t_3, "ResetFilterObj" )
+ CHECK_BOUND( t_3, "ResetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -3560,16 +3560,16 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
- CHECK_BOUND( t_3, "Ignore" )
+ CHECK_BOUND( t_3, "Ignore" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */

--- a/tst/test-compile/and_filter.g
+++ b/tst/test-compile/and_filter.g
@@ -15,4 +15,7 @@ CALL_WITH_CATCH({} -> Center and IsAssociative, []);
 # trigger error 2:
 CALL_WITH_CATCH({} -> IsAssociative and Center, []);
 
+CALL_WITH_CATCH({} -> 1 and false, []);
+CALL_WITH_CATCH({} -> 1 or true, []);
+
 end;

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -37,7 +37,7 @@ static Obj  HdlrFunc3 (
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_1 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_2 ) ) {
@@ -72,7 +72,7 @@ static Obj  HdlrFunc4 (
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (t_2 ? True : False);
  if ( t_1 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_3 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_1 = (t_3 ? True : False);
  }
@@ -99,19 +99,19 @@ static Obj  HdlrFunc5 (
  
  /* return Center and IsAssociative; */
  t_2 = GC_Center;
- CHECK_BOUND( t_2, "Center" )
+ CHECK_BOUND( t_2, "Center" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_IsAssociative;
-  CHECK_BOUND( t_3, "IsAssociative" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "IsAssociative" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
+  CHECK_BOUND( t_4, "IsAssociative" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -141,19 +141,19 @@ static Obj  HdlrFunc6 (
  
  /* return IsAssociative and Center; */
  t_2 = GC_IsAssociative;
- CHECK_BOUND( t_2, "IsAssociative" )
+ CHECK_BOUND( t_2, "IsAssociative" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_Center;
-  CHECK_BOUND( t_3, "Center" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "Center" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_Center;
-  CHECK_BOUND( t_4, "Center" )
+  CHECK_BOUND( t_4, "Center" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -189,7 +189,7 @@ static Obj  HdlrFunc2 (
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_2 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_3 ) ) {
@@ -208,7 +208,7 @@ static Obj  HdlrFunc2 (
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (t_3 ? True : False);
  if ( t_2 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_4 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_2 = (t_4 ? True : False);
  }
@@ -227,7 +227,7 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -243,26 +243,26 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( IsAssociative and IsAssociative, "\n" ); */
  t_1 = GF_Print;
  t_3 = GC_IsAssociative;
- CHECK_BOUND( t_3, "IsAssociative" )
+ CHECK_BOUND( t_3, "IsAssociative" );
  if ( t_3 == False ) {
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
-  CHECK_BOOL( t_4 )
+  CHECK_BOUND( t_4, "IsAssociative" );
+  CHECK_BOOL( t_4 );
   t_2 = t_4;
  }
  else if (IS_FILTER( t_3 ) ) {
   t_5 = GC_IsAssociative;
-  CHECK_BOUND( t_5, "IsAssociative" )
+  CHECK_BOUND( t_5, "IsAssociative" );
   t_2 = NewAndFilter( t_3, t_5 );
  }
  else {

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -1,6 +1,6 @@
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-49920958"
+#define FILE_CRC  "-101028112"
 
 /* global variables used in handlers */
 static GVar G_Print;
@@ -17,7 +17,7 @@ static Obj  GC_Center;
 /* record names used in handlers */
 
 /* information for the functions */
-static Obj  NameFunc[7];
+static Obj  NameFunc[9];
 static Obj FileName;
 
 /* handler for function 3 */
@@ -168,6 +168,72 @@ static Obj  HdlrFunc6 (
  return 0;
 }
 
+/* handler for function 7 */
+static Obj  HdlrFunc7 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 and false; */
+ if ( INTOBJ_INT(1) == False ) {
+  t_1 = INTOBJ_INT(1);
+ }
+ else if ( INTOBJ_INT(1) == True ) {
+  t_2 = False;
+  t_1 = t_2;
+ }
+ else if (IS_FILTER( INTOBJ_INT(1) ) ) {
+  t_3 = False;
+  t_1 = NewAndFilter( INTOBJ_INT(1), t_3 );
+ }
+ else {
+  RequireArgumentEx(0, INTOBJ_INT(1), "<expr>",
+  "must be 'true' or 'false' or a filter" );
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 8 */
+static Obj  HdlrFunc8 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 or true; */
+ CHECK_BOOL( INTOBJ_INT(1) );
+ t_2 = (Obj)(UInt)(INTOBJ_INT(1) != False);
+ t_1 = (t_2 ? True : False);
+ if ( t_1 == False ) {
+  t_4 = True;
+  t_3 = (Obj)(UInt)(t_4 != False);
+  t_1 = (t_3 ? True : False);
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
 /* handler for function 2 */
 static Obj  HdlrFunc2 (
  Obj  self )
@@ -306,6 +372,36 @@ static Obj  HdlrFunc2 (
  SET_LEN_PLIST( t_3, 0 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
+ /* CALL_WITH_CATCH( function (  )
+      return 1 and false;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[7], 0, 0, HdlrFunc7 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 18);
+ SET_ENDLINE_BODY(t_3, 18);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
+ /* CALL_WITH_CATCH( function (  )
+      return 1 or true;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[8], 0, 0, HdlrFunc8 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 19);
+ SET_ENDLINE_BODY(t_3, 19);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
@@ -343,13 +439,19 @@ static Obj  HdlrFunc1 (
       CALL_WITH_CATCH( function (  )
             return IsAssociative and Center;
         end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 and false;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 or true;
+        end, [  ] );
       return;
   end; */
  t_1 = NewFunction( NameFunc[2], 0, 0, HdlrFunc2 );
  SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
  t_2 = NewFunctionBody();
  SET_STARTLINE_BODY(t_2, 1);
- SET_ENDLINE_BODY(t_2, 18);
+ SET_ENDLINE_BODY(t_2, 21);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
  AssGVar( G_runtest, t_1 );
@@ -384,6 +486,8 @@ static Int PostRestore ( StructInitInfo * module )
  NameFunc[4] = 0;
  NameFunc[5] = 0;
  NameFunc[6] = 0;
+ NameFunc[7] = 0;
+ NameFunc[8] = 0;
  
  /* return success */
  return 0;
@@ -415,6 +519,10 @@ static Int InitKernel ( StructInitInfo * module )
  InitGlobalBag( &(NameFunc[5]), "and_filter.g:NameFunc[5]("FILE_CRC")" );
  InitHandlerFunc( HdlrFunc6, "and_filter.g:HdlrFunc6("FILE_CRC")" );
  InitGlobalBag( &(NameFunc[6]), "and_filter.g:NameFunc[6]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc7, "and_filter.g:HdlrFunc7("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[7]), "and_filter.g:NameFunc[7]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc8, "and_filter.g:HdlrFunc8("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[8]), "and_filter.g:NameFunc[8]("FILE_CRC")" );
  
  /* return success */
  return 0;
@@ -449,7 +557,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_DYNAMIC,
  .name        = "and_filter.g",
- .crc         = -49920958,
+ .crc         = -101028112,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/tst/test-compile/and_filter.g.out
+++ b/tst/test-compile/and_filter.g.out
@@ -5,3 +5,5 @@ true
 <Property "IsAssociative">
 Error, <expr> must be 'true' or 'false' or a filter (not a function)
 Error, <oper2> must be a filter (not a function)
+Error, <expr> must be 'true' or 'false' or a filter (not the integer 1)
+Error, <expr> must be 'true' or 'false' (not the integer 1)

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -37,7 +37,7 @@ static Obj  HdlrFunc3 (
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_1 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_2 ) ) {
@@ -72,7 +72,7 @@ static Obj  HdlrFunc4 (
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (t_2 ? True : False);
  if ( t_1 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_3 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_1 = (t_3 ? True : False);
  }
@@ -99,19 +99,19 @@ static Obj  HdlrFunc5 (
  
  /* return Center and IsAssociative; */
  t_2 = GC_Center;
- CHECK_BOUND( t_2, "Center" )
+ CHECK_BOUND( t_2, "Center" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_IsAssociative;
-  CHECK_BOUND( t_3, "IsAssociative" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "IsAssociative" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
+  CHECK_BOUND( t_4, "IsAssociative" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -141,19 +141,19 @@ static Obj  HdlrFunc6 (
  
  /* return IsAssociative and Center; */
  t_2 = GC_IsAssociative;
- CHECK_BOUND( t_2, "IsAssociative" )
+ CHECK_BOUND( t_2, "IsAssociative" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_Center;
-  CHECK_BOUND( t_3, "Center" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "Center" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_Center;
-  CHECK_BOUND( t_4, "Center" )
+  CHECK_BOUND( t_4, "Center" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -189,7 +189,7 @@ static Obj  HdlrFunc2 (
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_2 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_3 ) ) {
@@ -208,7 +208,7 @@ static Obj  HdlrFunc2 (
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (t_3 ? True : False);
  if ( t_2 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_4 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_2 = (t_4 ? True : False);
  }
@@ -227,7 +227,7 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -243,26 +243,26 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( IsAssociative and IsAssociative, "\n" ); */
  t_1 = GF_Print;
  t_3 = GC_IsAssociative;
- CHECK_BOUND( t_3, "IsAssociative" )
+ CHECK_BOUND( t_3, "IsAssociative" );
  if ( t_3 == False ) {
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
-  CHECK_BOOL( t_4 )
+  CHECK_BOUND( t_4, "IsAssociative" );
+  CHECK_BOOL( t_4 );
   t_2 = t_4;
  }
  else if (IS_FILTER( t_3 ) ) {
   t_5 = GC_IsAssociative;
-  CHECK_BOUND( t_5, "IsAssociative" )
+  CHECK_BOUND( t_5, "IsAssociative" );
   t_2 = NewAndFilter( t_3, t_5 );
  }
  else {

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -1,6 +1,6 @@
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-49920958"
+#define FILE_CRC  "-101028112"
 
 /* global variables used in handlers */
 static GVar G_Print;
@@ -17,7 +17,7 @@ static Obj  GC_Center;
 /* record names used in handlers */
 
 /* information for the functions */
-static Obj  NameFunc[7];
+static Obj  NameFunc[9];
 static Obj FileName;
 
 /* handler for function 3 */
@@ -168,6 +168,72 @@ static Obj  HdlrFunc6 (
  return 0;
 }
 
+/* handler for function 7 */
+static Obj  HdlrFunc7 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 and false; */
+ if ( INTOBJ_INT(1) == False ) {
+  t_1 = INTOBJ_INT(1);
+ }
+ else if ( INTOBJ_INT(1) == True ) {
+  t_2 = False;
+  t_1 = t_2;
+ }
+ else if (IS_FILTER( INTOBJ_INT(1) ) ) {
+  t_3 = False;
+  t_1 = NewAndFilter( INTOBJ_INT(1), t_3 );
+ }
+ else {
+  RequireArgumentEx(0, INTOBJ_INT(1), "<expr>",
+  "must be 'true' or 'false' or a filter" );
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 8 */
+static Obj  HdlrFunc8 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 or true; */
+ CHECK_BOOL( INTOBJ_INT(1) );
+ t_2 = (Obj)(UInt)(INTOBJ_INT(1) != False);
+ t_1 = (t_2 ? True : False);
+ if ( t_1 == False ) {
+  t_4 = True;
+  t_3 = (Obj)(UInt)(t_4 != False);
+  t_1 = (t_3 ? True : False);
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
 /* handler for function 2 */
 static Obj  HdlrFunc2 (
  Obj  self )
@@ -306,6 +372,36 @@ static Obj  HdlrFunc2 (
  SET_LEN_PLIST( t_3, 0 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
+ /* CALL_WITH_CATCH( function (  )
+      return 1 and false;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[7], 0, 0, HdlrFunc7 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 18);
+ SET_ENDLINE_BODY(t_3, 18);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
+ /* CALL_WITH_CATCH( function (  )
+      return 1 or true;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[8], 0, 0, HdlrFunc8 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 19);
+ SET_ENDLINE_BODY(t_3, 19);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
@@ -343,13 +439,19 @@ static Obj  HdlrFunc1 (
       CALL_WITH_CATCH( function (  )
             return IsAssociative and Center;
         end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 and false;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 or true;
+        end, [  ] );
       return;
   end; */
  t_1 = NewFunction( NameFunc[2], 0, 0, HdlrFunc2 );
  SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
  t_2 = NewFunctionBody();
  SET_STARTLINE_BODY(t_2, 1);
- SET_ENDLINE_BODY(t_2, 18);
+ SET_ENDLINE_BODY(t_2, 21);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
  AssGVar( G_runtest, t_1 );
@@ -384,6 +486,8 @@ static Int PostRestore ( StructInitInfo * module )
  NameFunc[4] = 0;
  NameFunc[5] = 0;
  NameFunc[6] = 0;
+ NameFunc[7] = 0;
+ NameFunc[8] = 0;
  
  /* return success */
  return 0;
@@ -415,6 +519,10 @@ static Int InitKernel ( StructInitInfo * module )
  InitGlobalBag( &(NameFunc[5]), "and_filter.g:NameFunc[5]("FILE_CRC")" );
  InitHandlerFunc( HdlrFunc6, "and_filter.g:HdlrFunc6("FILE_CRC")" );
  InitGlobalBag( &(NameFunc[6]), "and_filter.g:NameFunc[6]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc7, "and_filter.g:HdlrFunc7("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[7]), "and_filter.g:NameFunc[7]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc8, "and_filter.g:HdlrFunc8("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[8]), "and_filter.g:NameFunc[8]("FILE_CRC")" );
  
  /* return success */
  return 0;
@@ -449,7 +557,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "and_filter.g",
- .crc         = -49920958,
+ .crc         = -101028112,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/tst/test-compile/assert.g.dynamic.c
+++ b/tst/test-compile/assert.g.dynamic.c
@@ -33,7 +33,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -93,7 +93,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/assert.g.static.c
+++ b/tst/test-compile/assert.g.static.c
@@ -33,7 +33,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -93,7 +93,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -216,49 +216,49 @@ static Obj  HdlrFunc3 (
  /* Print( vararg_fun(  ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -274,7 +274,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -295,7 +295,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -308,7 +308,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -322,7 +322,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -988,7 +988,7 @@ static Obj  HdlrFunc9 (
  
  /* l[1 + 1] := 2; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL_INTOBJ( l_l, t_1, INTOBJ_INT(2) )
  
  /* l![3] := 3; */
@@ -996,7 +996,7 @@ static Obj  HdlrFunc9 (
  
  /* l![2 + 2] := 4; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_1 )
+ CHECK_INT_SMALL_POS( t_1 );
  AssPosObj( l_l, INT_INTOBJ(t_1), INTOBJ_INT(4) );
  
  /* Display( l ); */
@@ -1014,7 +1014,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[2] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_4 )
+ CHECK_INT_POS( t_4 );
  C_ELM_LIST_FPL( t_3, l_l, t_4 )
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1030,7 +1030,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[4] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_4 )
+ CHECK_INT_SMALL_POS( t_4 );
  t_3 = ElmPosObj( l_l, INT_INTOBJ(t_4) );
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -216,49 +216,49 @@ static Obj  HdlrFunc3 (
  /* Print( vararg_fun(  ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -274,7 +274,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -295,7 +295,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -308,7 +308,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -322,7 +322,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -988,7 +988,7 @@ static Obj  HdlrFunc9 (
  
  /* l[1 + 1] := 2; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL_INTOBJ( l_l, t_1, INTOBJ_INT(2) )
  
  /* l![3] := 3; */
@@ -996,7 +996,7 @@ static Obj  HdlrFunc9 (
  
  /* l![2 + 2] := 4; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_1 )
+ CHECK_INT_SMALL_POS( t_1 );
  AssPosObj( l_l, INT_INTOBJ(t_1), INTOBJ_INT(4) );
  
  /* Display( l ); */
@@ -1014,7 +1014,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[2] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_4 )
+ CHECK_INT_POS( t_4 );
  C_ELM_LIST_FPL( t_3, l_l, t_4 )
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1030,7 +1030,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[4] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_4 )
+ CHECK_INT_SMALL_POS( t_4 );
  t_3 = ElmPosObj( l_l, INT_INTOBJ(t_4) );
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );

--- a/tst/test-compile/function_types.g.dynamic.c
+++ b/tst/test-compile/function_types.g.dynamic.c
@@ -161,7 +161,7 @@ static Obj  HdlrFunc7 (
  /* return f1(  ); */
  t_2 = GF_f1;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -184,7 +184,7 @@ static Obj  HdlrFunc8 (
  /* return f1( 1, 2 ); */
  t_2 = GF_f1;
  t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -207,7 +207,7 @@ static Obj  HdlrFunc9 (
  /* return f2( 1, 2, 3 ); */
  t_2 = GF_f2;
  t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -230,7 +230,7 @@ static Obj  HdlrFunc10 (
  /* return f4(  ); */
  t_2 = GF_f4;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  

--- a/tst/test-compile/function_types.g.static.c
+++ b/tst/test-compile/function_types.g.static.c
@@ -161,7 +161,7 @@ static Obj  HdlrFunc7 (
  /* return f1(  ); */
  t_2 = GF_f1;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -184,7 +184,7 @@ static Obj  HdlrFunc8 (
  /* return f1( 1, 2 ); */
  t_2 = GF_f1;
  t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -207,7 +207,7 @@ static Obj  HdlrFunc9 (
  /* return f2( 1, 2, 3 ); */
  t_2 = GF_f2;
  t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -230,7 +230,7 @@ static Obj  HdlrFunc10 (
  /* return f4(  ); */
  t_2 = GF_f4;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  

--- a/tst/test-compile/info.g.dynamic.c
+++ b/tst/test-compile/info.g.dynamic.c
@@ -36,15 +36,15 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -57,7 +57,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -71,22 +71,22 @@ static Obj  HdlrFunc2 (
  /* SetInfoLevel( InfoDebug, 2 ); */
  t_1 = GF_SetInfoLevel;
  t_2 = GC_InfoDebug;
- CHECK_BOUND( t_2, "InfoDebug" )
+ CHECK_BOUND( t_2, "InfoDebug" );
  CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(3) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -99,7 +99,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -112,7 +112,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );

--- a/tst/test-compile/info.g.static.c
+++ b/tst/test-compile/info.g.static.c
@@ -36,15 +36,15 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -57,7 +57,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -71,22 +71,22 @@ static Obj  HdlrFunc2 (
  /* SetInfoLevel( InfoDebug, 2 ); */
  t_1 = GF_SetInfoLevel;
  t_2 = GC_InfoDebug;
- CHECK_BOUND( t_2, "InfoDebug" )
+ CHECK_BOUND( t_2, "InfoDebug" );
  CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(3) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -99,7 +99,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -112,7 +112,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );

--- a/tst/test-compile/print_various.g.dynamic.c
+++ b/tst/test-compile/print_various.g.dynamic.c
@@ -95,7 +95,7 @@ static Obj  HdlrFunc2 (
  CHANGED_BAG( t_5 );
  t_4 = Array2Perm( t_6 );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/print_various.g.static.c
+++ b/tst/test-compile/print_various.g.static.c
@@ -95,7 +95,7 @@ static Obj  HdlrFunc2 (
  CHANGED_BAG( t_5 );
  t_4 = Array2Perm( t_6 );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/ranges.g.dynamic.c
+++ b/tst/test-compile/ranges.g.dynamic.c
@@ -86,7 +86,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ 1, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -98,7 +98,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ - 2 ^ 80, 0 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -111,7 +111,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 1, 2, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -124,7 +124,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ - 2 ^ 80, 0, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -138,7 +138,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 0, 2 ^ 80, 2 ^ 81 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(0) );
@@ -158,7 +158,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 2, 2 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -174,7 +174,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 4, 7 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -195,7 +195,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 4, 2, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(4) );

--- a/tst/test-compile/ranges.g.static.c
+++ b/tst/test-compile/ranges.g.static.c
@@ -86,7 +86,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ 1, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -98,7 +98,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ - 2 ^ 80, 0 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -111,7 +111,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 1, 2, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -124,7 +124,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ - 2 ^ 80, 0, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -138,7 +138,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 0, 2 ^ 80, 2 ^ 81 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(0) );
@@ -158,7 +158,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 2, 2 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -174,7 +174,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 4, 7 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -195,7 +195,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 4, 2, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(4) );


### PR DESCRIPTION
Main motivation for this is to ensure sensible error message in gac compiled code which match those produced by the interpreter and coder. A new test verifies this for `CHECK_BOOL`.

I was planning to add a similar test for `CHECK_FUNC`, but that revealed bugs in gac related to that, so that test along with a fix will be in a separate PR.
