### PR TITLE
kernel: rename expression and statement "TNUMs" to avoid confusion with actual TNUMs

### DIFF
--- a/src/code.h
+++ b/src/code.h
@@ -184,8 +184,8 @@ enum STAT_TNUM {
         // run full). We don't want to compound statements to be interrupted,
         // relying instead on their sub-statements being interruptible. This
         // results in a slightly better user experience in break loops, where
-        // the interrupted statement is printed, which works better for single
-        // statements than for compound statements.
+        // the interrupted statement is printed, which works better for
+        // single statements than for compound statements.
         START_ENUM_RANGE(FIRST_NON_INTERRUPT_STAT),
 
             START_ENUM_RANGE(FIRST_COMPOUND_STAT),
@@ -368,17 +368,17 @@ void SET_VISITED_STAT(Stat stat);
 
 /****************************************************************************
 **
-*F  IS_REF_LVAR(<expr>). . . . test if an expression is a reference to a local
-*F  REF_LVAR_LVAR(<lvar>)  . . . . . convert a local to a reference to a local
-*F  LVAR_REF_LVAR(<expr>)  . . . . . convert a reference to a local to a local
+*F  IS_REF_LVAR(<expr>) . . . test if an expression is a reference to a local
+*F  REF_LVAR_LVAR(<lvar>) . . . . . convert a local to a reference to a local
+*F  LVAR_REF_LVAR(<expr>) . . . . . convert a reference to a local to a local
 **
-**  'IS_REF_LVAR'  returns  1  if  the  expression <expr>  is  an  (immediate)
+**  'IS_REF_LVAR' returns 1 if the expression <expr> is an (immediate)
 **  reference to a local variable, and 0 otherwise.
 **
-**  'REF_LVAR_LVAR'  returns  a (immediate) reference  to   the local variable
+**  'REF_LVAR_LVAR' returns a (immediate) reference to the local variable
 **  <lvar> (given by its index).
 **
-**  'LVAR_REF_LVAR' returns the local variable (by  its index) to which <expr>
+**  'LVAR_REF_LVAR' returns the local variable (by its index) to which <expr>
 **  is a (immediate) reference.
 */
 EXPORT_INLINE Int IS_REF_LVAR(Expr expr)
@@ -682,9 +682,8 @@ void CodeFuncCallEnd(UInt funccall, UInt options, UInt nr);
 **
 **  'CodeFuncExprEnd'  is an action to  code  a function  expression.  It  is
 **  called when the reader encounters the end of a function expression.  <nr>
-**  is the number of statements in the body of the function. If <pushExpr>
-**  is set, the current function expression is pushed on the expression stack.
-**
+**  is the number of statements in the body of the function. If <pushExpr> is
+**  set, the current function expression is pushed on the expression stack.
 */
 void CodeFuncExprBegin(Int narg, Int nloc, Obj nams, Int startLine);
 
@@ -709,9 +708,9 @@ Int AddValueToBody(Obj val);
 *F  CodeFuncCallOptionsEndElmEmpty() .. .  . . . . .code options, end element
 *F  CodeFuncCallOptionsEnd(<nr>)  . . . . . . . . . . . . . code options, end
 **
-**  The net effect of all of these is to leave a record expression on the stack
-**  containing the options record. It will be picked up by
-**  CodeFuncCallEnd()
+**  The net effect of all of these is to leave a record expression on the
+**  stack containing the options record. It will be picked up by
+**  CodeFuncCallEnd().
 **
 */
 void CodeFuncCallOptionsBegin(void);
@@ -811,26 +810,26 @@ void CodeForEnd(void);
 
 /****************************************************************************
 **
-*F  CodeAtomicBegin()  . . . . . . .  code atomic-statement, begin of statement
-*F  CodeAtomicBeginBody()  . . . . . . . . code atomic-statement, begin of body
-*F  CodeAtomicEndBody( <nr> )  . . . . . . . code atomic-statement, end of body
-*F  CodeAtomicEnd()  . . . . . . . . .  code atomic-statement, end of statement
+*F  CodeAtomicBegin() . . . . . . . code atomic-statement, begin of statement
+*F  CodeAtomicBeginBody() . . . . . . .  code atomic-statement, begin of body
+*F  CodeAtomicEndBody(<nr>) . . . . . . .  code atomic-statement, end of body
+*F  CodeAtomicEnd() . . . . . . . . . code atomic-statement, end of statement
 **
-**  'CodeAtomicBegin'  is an action to  code a atomic-statement.   It is called
-**  when the  reader encounters the 'atomic',  i.e., *before* the condition is
+**  'CodeAtomicBegin' is an action to code an atomic-statement. It is called
+**  when the reader encounters the 'atomic', i.e., *before* the condition is
 **  read.
 **
-**  'CodeAtomicBeginBody'  is  an action   to code a  atomic-statement.   It is
-**  called when  the reader encounters  the beginning  of the statement body,
+**  'CodeAtomicBeginBody' is an action to code a atomic-statement. It is
+**  called when the reader encounters the beginning of the statement body,
 **  i.e., *after* the condition is read.
 **
-**  'CodeAtomicEndBody' is an action to  code a atomic-statement.  It is called
-**  when the reader encounters  the end of  the statement body.  <nr> is  the
+**  'CodeAtomicEndBody' is an action to code a atomic-statement. It is called
+**  when the reader encounters the end of the statement body. <nr> is the
 **  number of statements in the body.
 **
-**  'CodeAtomicEnd' is an action to code a atomic-statement.  It is called when
-**  the reader encounters  the end  of the  statement, i.e., immediate  after
-**  'CodeAtomicEndBody'.
+**  'CodeAtomicEnd' is an action to code a atomic-statement. It is called
+**  when the reader encounters the end of the statement, i.e., immediately
+**  after 'CodeAtomicEndBody'.
 */
 
 void CodeAtomicBegin(void);

--- a/src/code.h
+++ b/src/code.h
@@ -162,21 +162,21 @@ void WRITE_EXPR(Expr expr, UInt idx, UInt val);
 enum STAT_TNUM {
     START_ENUM_RANGE(FIRST_STAT_TNUM),
 
-        T_PROCCALL_0ARGS,
-        T_PROCCALL_1ARGS,
-        T_PROCCALL_2ARGS,
-        T_PROCCALL_3ARGS,
-        T_PROCCALL_4ARGS,
-        T_PROCCALL_5ARGS,
-        T_PROCCALL_6ARGS,
-        T_PROCCALL_XARGS,
+        STAT_PROCCALL_0ARGS,
+        STAT_PROCCALL_1ARGS,
+        STAT_PROCCALL_2ARGS,
+        STAT_PROCCALL_3ARGS,
+        STAT_PROCCALL_4ARGS,
+        STAT_PROCCALL_5ARGS,
+        STAT_PROCCALL_6ARGS,
+        STAT_PROCCALL_XARGS,
 
-        T_PROCCALL_OPTS,
+        STAT_PROCCALL_OPTS,
 
-        // T_EMPTY could also be considered to be "T_SEQ_STAT0", but it
+        // STAT_EMPTY could also be considered to be "T_SEQ_STAT0", but it
         // must be an interruptible statement, so that loops with empty
         // body can be interrupted.
-        T_EMPTY,
+        STAT_EMPTY,
 
         // The statement types between FIRST_NON_INTERRUPT_STAT and
         // LAST_NON_INTERRUPT_STAT will not be interrupted (which may happen
@@ -190,37 +190,37 @@ enum STAT_TNUM {
 
             START_ENUM_RANGE(FIRST_COMPOUND_STAT),
 
-            T_SEQ_STAT,
-            T_SEQ_STAT2,
-            T_SEQ_STAT3,
-            T_SEQ_STAT4,
-            T_SEQ_STAT5,
-            T_SEQ_STAT6,
-            T_SEQ_STAT7,
+            STAT_SEQ_STAT,
+            STAT_SEQ_STAT2,
+            STAT_SEQ_STAT3,
+            STAT_SEQ_STAT4,
+            STAT_SEQ_STAT5,
+            STAT_SEQ_STAT6,
+            STAT_SEQ_STAT7,
 
-            T_IF,
-            T_IF_ELSE,
-            T_IF_ELIF,
-            T_IF_ELIF_ELSE,
+            STAT_IF,
+            STAT_IF_ELSE,
+            STAT_IF_ELIF,
+            STAT_IF_ELIF_ELSE,
 
-            T_FOR,
-            T_FOR2,
-            T_FOR3,
+            STAT_FOR,
+            STAT_FOR2,
+            STAT_FOR3,
 
-            T_FOR_RANGE,
-            T_FOR_RANGE2,
-            T_FOR_RANGE3,
+            STAT_FOR_RANGE,
+            STAT_FOR_RANGE2,
+            STAT_FOR_RANGE3,
 
-            T_WHILE,
-            T_WHILE2,
-            T_WHILE3,
+            STAT_WHILE,
+            STAT_WHILE2,
+            STAT_WHILE3,
 
-            T_REPEAT,
-            T_REPEAT2,
-            T_REPEAT3,
+            STAT_REPEAT,
+            STAT_REPEAT2,
+            STAT_REPEAT3,
 
 #ifdef HPCGAP
-            T_ATOMIC,
+            STAT_ATOMIC,
 #endif
 
             END_ENUM_RANGE(LAST_COMPOUND_STAT),
@@ -229,45 +229,45 @@ enum STAT_TNUM {
 
         START_ENUM_RANGE(FIRST_CONTROL_FLOW_STAT),
 
-            T_BREAK,
-            T_CONTINUE,
-            T_RETURN_OBJ,
-            T_RETURN_VOID,
+            STAT_BREAK,
+            STAT_CONTINUE,
+            STAT_RETURN_OBJ,
+            STAT_RETURN_VOID,
 
         END_ENUM_RANGE(LAST_CONTROL_FLOW_STAT),
 
-        T_ASS_LVAR,
-        T_UNB_LVAR,
+        STAT_ASS_LVAR,
+        STAT_UNB_LVAR,
 
-        T_ASS_HVAR,
-        T_UNB_HVAR,
+        STAT_ASS_HVAR,
+        STAT_UNB_HVAR,
 
-        T_ASS_GVAR,
-        T_UNB_GVAR,
+        STAT_ASS_GVAR,
+        STAT_UNB_GVAR,
 
-        T_ASS_LIST,
-        T_ASS2_LIST,
-        T_ASSS_LIST,
-        T_ASS_LIST_LEV,
-        T_ASSS_LIST_LEV,
-        T_UNB_LIST,
+        STAT_ASS_LIST,
+        STAT_ASS2_LIST,
+        STAT_ASSS_LIST,
+        STAT_ASS_LIST_LEV,
+        STAT_ASSS_LIST_LEV,
+        STAT_UNB_LIST,
 
-        T_ASS_REC_NAME,
-        T_ASS_REC_EXPR,
-        T_UNB_REC_NAME,
-        T_UNB_REC_EXPR,
+        STAT_ASS_REC_NAME,
+        STAT_ASS_REC_EXPR,
+        STAT_UNB_REC_NAME,
+        STAT_UNB_REC_EXPR,
 
-        T_ASS_POSOBJ,
-        T_UNB_POSOBJ,
+        STAT_ASS_POSOBJ,
+        STAT_UNB_POSOBJ,
 
-        T_ASS_COMOBJ_NAME,
-        T_ASS_COMOBJ_EXPR,
-        T_UNB_COMOBJ_NAME,
-        T_UNB_COMOBJ_EXPR,
+        STAT_ASS_COMOBJ_NAME,
+        STAT_ASS_COMOBJ_EXPR,
+        STAT_UNB_COMOBJ_NAME,
+        STAT_UNB_COMOBJ_EXPR,
 
-        T_INFO,
-        T_ASSERT_2ARGS,
-        T_ASSERT_3ARGS,
+        STAT_INFO,
+        STAT_ASSERT_2ARGS,
+        STAT_ASSERT_3ARGS,
         T_PRAGMA,
 
     END_ENUM_RANGE(LAST_STAT_TNUM),
@@ -368,30 +368,30 @@ void SET_VISITED_STAT(Stat stat);
 
 /****************************************************************************
 **
-*F  IS_REFLVAR(<expr>). . . . test if an expression is a reference to a local
-*F  REFLVAR_LVAR(<lvar>)  . . . . . convert a local to a reference to a local
-*F  LVAR_REFLVAR(<expr>)  . . . . . convert a reference to a local to a local
+*F  IS_REF_LVAR(<expr>). . . . test if an expression is a reference to a local
+*F  REF_LVAR_LVAR(<lvar>)  . . . . . convert a local to a reference to a local
+*F  LVAR_REF_LVAR(<expr>)  . . . . . convert a reference to a local to a local
 **
-**  'IS_REFLVAR'  returns  1  if  the  expression <expr>  is  an  (immediate)
+**  'IS_REF_LVAR'  returns  1  if  the  expression <expr>  is  an  (immediate)
 **  reference to a local variable, and 0 otherwise.
 **
-**  'REFLVAR_LVAR'  returns  a (immediate) reference  to   the local variable
+**  'REF_LVAR_LVAR'  returns  a (immediate) reference  to   the local variable
 **  <lvar> (given by its index).
 **
-**  'LVAR_REFLVAR' returns the local variable (by  its index) to which <expr>
+**  'LVAR_REF_LVAR' returns the local variable (by  its index) to which <expr>
 **  is a (immediate) reference.
 */
-EXPORT_INLINE Int IS_REFLVAR(Expr expr)
+EXPORT_INLINE Int IS_REF_LVAR(Expr expr)
 {
     return ((Int)expr & 0x03) == 0x03;
 }
 
-EXPORT_INLINE Expr REFLVAR_LVAR(Int lvar)
+EXPORT_INLINE Expr REF_LVAR_LVAR(Int lvar)
 {
     return (Expr)((lvar << 2) + 0x03);
 }
 
-EXPORT_INLINE Int LVAR_REFLVAR(Expr expr)
+EXPORT_INLINE Int LVAR_REF_LVAR(Expr expr)
 {
     return (Int)expr >> 2;
 }
@@ -440,82 +440,82 @@ EXPORT_INLINE Int INT_INTEXPR(Expr expr)
 enum EXPR_TNUM {
     START_ENUM_RANGE_INIT(FIRST_EXPR_TNUM, 128),
 
-    T_FUNCCALL_0ARGS,
-    T_FUNCCALL_1ARGS,
-    T_FUNCCALL_2ARGS,
-    T_FUNCCALL_3ARGS,
-    T_FUNCCALL_4ARGS,
-    T_FUNCCALL_5ARGS,
-    T_FUNCCALL_6ARGS,
-    T_FUNCCALL_XARGS,
-    T_FUNC_EXPR,
+    EXPR_FUNCCALL_0ARGS,
+    EXPR_FUNCCALL_1ARGS,
+    EXPR_FUNCCALL_2ARGS,
+    EXPR_FUNCCALL_3ARGS,
+    EXPR_FUNCCALL_4ARGS,
+    EXPR_FUNCCALL_5ARGS,
+    EXPR_FUNCCALL_6ARGS,
+    EXPR_FUNCCALL_XARGS,
+    EXPR_FUNC,
 
-    T_FUNCCALL_OPTS,
+    EXPR_FUNCCALL_OPTS,
 
-    T_OR,
-    T_AND,
-    T_NOT,
-    T_EQ,
-    T_NE,
-    T_LT,
-    T_GE,
-    T_GT,
-    T_LE,
-    T_IN,
-    T_SUM,
-    T_AINV,
-    T_DIFF,
-    T_PROD,
-    T_QUO,
-    T_MOD,
-    T_POW,
+    EXPR_OR,
+    EXPR_AND,
+    EXPR_NOT,
+    EXPR_EQ,
+    EXPR_NE,
+    EXPR_LT,
+    EXPR_GE,
+    EXPR_GT,
+    EXPR_LE,
+    EXPR_IN,
+    EXPR_SUM,
+    EXPR_AINV,
+    EXPR_DIFF,
+    EXPR_PROD,
+    EXPR_QUO,
+    EXPR_MOD,
+    EXPR_POW,
 
-    T_INTEXPR,
-    T_INT_EXPR,
-    T_TRUE_EXPR,
-    T_FALSE_EXPR,
-    T_TILDE_EXPR,
-    T_CHAR_EXPR,
-    T_PERM_EXPR,
-    T_PERM_CYCLE,
-    T_LIST_EXPR,
-    T_LIST_TILDE_EXPR,
-    T_RANGE_EXPR,
-    T_STRING_EXPR,
-    T_REC_EXPR,
-    T_REC_TILDE_EXPR,
+    EXPR_INT,
+    EXPR_INTPOS,
+    EXPR_TRUE,
+    EXPR_FALSE,
+    EXPR_TILDE,
+    EXPR_CHAR,
+    EXPR_PERM,
+    EXPR_PERM_CYCLE,
+    EXPR_LIST,
+    EXPR_LIST_TILDE,
+    EXPR_RANGE,
+    EXPR_STRING,
+    EXPR_REC,
+    EXPR_REC_TILDE,
 
-    T_FLOAT_EXPR_EAGER,
-    T_FLOAT_EXPR_LAZY,
+    EXPR_FLOAT_EAGER,
+    EXPR_FLOAT_LAZY,
 
-    T_REFLVAR,
-    T_ISB_LVAR,
+    EXPR_REF_LVAR,
+    EXPR_ISB_LVAR,
 
-    T_REF_HVAR,
-    T_ISB_HVAR,
+    EXPR_REF_HVAR,
+    EXPR_ISB_HVAR,
 
-    T_REF_GVAR,
-    T_ISB_GVAR,
+    EXPR_REF_GVAR,
+    EXPR_ISB_GVAR,
 
-    T_ELM_LIST,
-    T_ELM2_LIST,
-    T_ELMS_LIST,
-    T_ELM_LIST_LEV,
-    T_ELMS_LIST_LEV,
-    T_ISB_LIST,
+    EXPR_ELM_LIST,
+    EXPR_ELM2_LIST,
+    EXPR_ELMS_LIST,
+    EXPR_ELM_LIST_LEV,
+    EXPR_ELMS_LIST_LEV,
+    EXPR_ISB_LIST,
 
-    T_ELM_REC_NAME,
-    T_ELM_REC_EXPR,
-    T_ISB_REC_NAME,
-    T_ISB_REC_EXPR,
+    EXPR_ELM_REC_NAME,
+    EXPR_ELM_REC_EXPR,
+    EXPR_ISB_REC_NAME,
+    EXPR_ISB_REC_EXPR,
 
-    T_ELM_POSOBJ,
-    T_ISB_POSOBJ,
+    EXPR_ELM_POSOBJ,
+    EXPR_ISB_POSOBJ,
 
-    T_ELM_COMOBJ_NAME,
-    T_ELM_COMOBJ_EXPR,
-    T_ISB_COMOBJ_NAME,
-    T_ISB_COMOBJ_EXPR,
+    EXPR_ELM_COMOBJ_NAME,
+    EXPR_ELM_COMOBJ_EXPR,
+    EXPR_ISB_COMOBJ_NAME,
+    EXPR_ISB_COMOBJ_EXPR,
 
     END_ENUM_RANGE(LAST_EXPR_TNUM)
 };
@@ -529,10 +529,10 @@ enum EXPR_TNUM {
 */
 EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 {
-    if (IS_REFLVAR(expr))
-        return T_REFLVAR;
+    if (IS_REF_LVAR(expr))
+        return EXPR_REF_LVAR;
     if (IS_INTEXPR(expr))
-        return T_INTEXPR;
+        return EXPR_INT;
     return TNUM_STAT(expr);
 }
 
@@ -544,7 +544,7 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 **  'SIZE_EXPR' returns the size of the expression <expr>.
 **
 **  Note  that  it is *fatal*  to apply  'SIZE_EXPR'   to expressions of type
-**  'T_REFLVAR' or 'T_INTEXPR'.
+**  'EXPR_REF_LVAR' or 'EXPR_INT'.
 */
 #define SIZE_EXPR(expr) SIZE_STAT(expr)
 
@@ -557,7 +557,7 @@ EXPORT_INLINE Int TNUM_EXPR(Expr expr)
 **  expression <expr>.
 **
 **  Note  that  it is *fatal*  to apply  'ADDR_EXPR'   to expressions of type
-**  'T_REFLVAR' or 'T_INTEXPR'.
+**  'EXPR_REF_LVAR' or 'EXPR_INT'.
 */
 #define CONST_ADDR_EXPR(expr) CONST_ADDR_STAT(expr)
 
@@ -1163,7 +1163,7 @@ void CodeUnbLVar(UInt lvar);
 **  encounters a local variable.
 **
 **  A   reference to   a local  variable    is represented immediately   (see
-**  'REFLVAR_LVAR').
+**  'REF_LVAR_LVAR').
 */
 void CodeRefLVar(UInt lvar);
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -947,7 +947,7 @@ static GVar G_Length;
 
 /****************************************************************************
 **
-*F  CompFunccall0to6Args( <expr> )  . . . T_FUNCCALL_0ARGS...T_FUNCCALL_6ARGS
+*F  CompFunccall0to6Args( <expr> )  . . . EXPR_FUNCCALL_0ARGS...EXPR_FUNCCALL_6ARGS
 */
 static CVar CompRefGVarFopy(Expr expr);
 
@@ -962,7 +962,7 @@ static CVar CompFunccall0to6Args(Expr expr)
 
     /* special case to inline 'Length'                                     */
     if ( CompFastListFuncs
-      && TNUM_EXPR( FUNC_CALL(expr) ) == T_REF_GVAR
+      && TNUM_EXPR( FUNC_CALL(expr) ) == EXPR_REF_GVAR
       && READ_EXPR( FUNC_CALL(expr), 0 ) == G_Length
       && NARG_SIZE_CALL(SIZE_EXPR(expr)) == 1 ) {
         result = CVAR_TEMP( NewTemp( "result" ) );
@@ -982,7 +982,7 @@ static CVar CompFunccall0to6Args(Expr expr)
     result = CVAR_TEMP( NewTemp( "result" ) );
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(expr) ) == T_REF_GVAR ) {
+    if ( TNUM_EXPR( FUNC_CALL(expr) ) == EXPR_REF_GVAR ) {
         func = CompRefGVarFopy( FUNC_CALL(expr) );
     }
     else {
@@ -1030,7 +1030,7 @@ static CVar CompFunccall0to6Args(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_FUNCCALL_XARGS
+*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  EXPR_FUNCCALL_XARGS
 */
 static CVar CompFunccallXArgs(Expr expr)
 {
@@ -1045,7 +1045,7 @@ static CVar CompFunccallXArgs(Expr expr)
     result = CVAR_TEMP( NewTemp( "result" ) );
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(expr) ) == T_REF_GVAR ) {
+    if ( TNUM_EXPR( FUNC_CALL(expr) ) == EXPR_REF_GVAR ) {
         func = CompRefGVarFopy( FUNC_CALL(expr) );
     }
     else {
@@ -1087,7 +1087,7 @@ static CVar CompFunccallXArgs(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_FUNCCALL_OPTS
+*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  EXPR_FUNCCALL_OPTS
 */
 static CVar CompFunccallOpts(Expr expr)
 {
@@ -1109,7 +1109,7 @@ static CVar CompFunccallOpts(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFuncExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_FUNC_EXPR
+*F  CompFuncExpr( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_FUNC
 */
 static CVar CompFuncExpr(Expr expr)
 {
@@ -1165,7 +1165,7 @@ static CVar CompFuncExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompOr( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_OR
+*F  CompOr( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_OR
 */
 static CVar CompOr(Expr expr)
 {
@@ -1204,7 +1204,7 @@ static CVar CompOr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompOrBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_OR
+*F  CompOrBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_OR
 */
 static CVar CompOrBool(Expr expr)
 {
@@ -1243,7 +1243,7 @@ static CVar CompOrBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompAnd( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_AND
+*F  CompAnd( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_AND
 */
 static CVar CompAnd(Expr expr)
 {
@@ -1301,7 +1301,7 @@ static CVar CompAnd(Expr expr)
 
 /****************************************************************************
 **
-*F  CompAndBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . T_AND
+*F  CompAndBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . EXPR_AND
 */
 static CVar CompAndBool(Expr expr)
 {
@@ -1340,7 +1340,7 @@ static CVar CompAndBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_NOT
+*F  CompNot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_NOT
 */
 static CVar CompNot(Expr expr)
 {
@@ -1369,7 +1369,7 @@ static CVar CompNot(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNotBoot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . T_NOT
+*F  CompNotBoot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . EXPR_NOT
 */
 static CVar CompNotBool(Expr expr)
 {
@@ -1398,7 +1398,7 @@ static CVar CompNotBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompEq( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_EQ
+*F  CompEq( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_EQ
 */
 static CVar CompEq(Expr expr)
 {
@@ -1435,7 +1435,7 @@ static CVar CompEq(Expr expr)
 
 /****************************************************************************
 **
-*F  CompEqBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_EQ
+*F  CompEqBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_EQ
 */
 static CVar CompEqBool(Expr expr)
 {
@@ -1472,7 +1472,7 @@ static CVar CompEqBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_NE
+*F  CompNe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_NE
 */
 static CVar CompNe(Expr expr)
 {
@@ -1509,7 +1509,7 @@ static CVar CompNe(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_NE
+*F  CompNeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_NE
 */
 static CVar CompNeBool(Expr expr)
 {
@@ -1546,7 +1546,7 @@ static CVar CompNeBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompLt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_LT
+*F  CompLt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_LT
 */
 static CVar CompLt(Expr expr)
 {
@@ -1583,7 +1583,7 @@ static CVar CompLt(Expr expr)
 
 /****************************************************************************
 **
-*F  CompLtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_LT
+*F  CompLtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_LT
 */
 static CVar CompLtBool(Expr expr)
 {
@@ -1620,7 +1620,7 @@ static CVar CompLtBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompGe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_GE
+*F  CompGe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_GE
 */
 static CVar CompGe(Expr expr)
 {
@@ -1657,7 +1657,7 @@ static CVar CompGe(Expr expr)
 
 /****************************************************************************
 **
-*F  CompGeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_GE
+*F  CompGeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_GE
 */
 static CVar CompGeBool(Expr expr)
 {
@@ -1694,7 +1694,7 @@ static CVar CompGeBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompGt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_GT
+*F  CompGt( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_GT
 */
 static CVar CompGt(Expr expr)
 {
@@ -1731,7 +1731,7 @@ static CVar CompGt(Expr expr)
 
 /****************************************************************************
 **
-*F  CompGtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_GT
+*F  CompGtBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_GT
 */
 static CVar CompGtBool(Expr expr)
 {
@@ -1768,7 +1768,7 @@ static CVar CompGtBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompLe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_LE
+*F  CompLe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_LE
 */
 static CVar CompLe(Expr expr)
 {
@@ -1805,7 +1805,7 @@ static CVar CompLe(Expr expr)
 
 /****************************************************************************
 **
-*F  CompLeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_LE
+*F  CompLeBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_LE
 */
 static CVar CompLeBool(Expr expr)
 {
@@ -1842,7 +1842,7 @@ static CVar CompLeBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIn( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  T_IN
+*F  CompIn( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_IN
 */
 static CVar CompIn(Expr expr)
 {
@@ -1874,7 +1874,7 @@ static CVar CompIn(Expr expr)
 
 /****************************************************************************
 **
-*F  CompInBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_IN
+*F  CompInBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_IN
 */
 static CVar CompInBool(Expr expr)
 {
@@ -1906,7 +1906,7 @@ static CVar CompInBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompSum( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_SUM
+*F  CompSum( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_SUM
 */
 static CVar CompSum(Expr expr)
 {
@@ -1951,7 +1951,7 @@ static CVar CompSum(Expr expr)
 
 /****************************************************************************
 **
-*F  CompAInv( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_AINV
+*F  CompAInv( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_AINV
 */
 static CVar CompAInv(Expr expr)
 {
@@ -1993,7 +1993,7 @@ static CVar CompAInv(Expr expr)
 
 /****************************************************************************
 **
-*F  CompDiff( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_DIFF
+*F  CompDiff( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_DIFF
 */
 static CVar CompDiff(Expr expr)
 {
@@ -2038,7 +2038,7 @@ static CVar CompDiff(Expr expr)
 
 /****************************************************************************
 **
-*F  CompProd( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  T_PROD
+*F  CompProd( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_PROD
 */
 static CVar CompProd(Expr expr)
 {
@@ -2083,7 +2083,7 @@ static CVar CompProd(Expr expr)
 
 /****************************************************************************
 **
-*F  CompQuo( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_QUO
+*F  CompQuo( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_QUO
 */
 static CVar CompQuo(Expr expr)
 {
@@ -2115,7 +2115,7 @@ static CVar CompQuo(Expr expr)
 
 /****************************************************************************
 **
-*F  CompMod( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_MOD
+*F  CompMod( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_MOD
 */
 static CVar CompMod(Expr expr)
 {
@@ -2152,7 +2152,7 @@ static CVar CompMod(Expr expr)
 
 /****************************************************************************
 **
-*F  CompPow( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . T_POW
+*F  CompPow( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_POW
 */
 static CVar CompPow(Expr expr)
 {
@@ -2189,7 +2189,7 @@ static CVar CompPow(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIntExpr( <expr> ) . . . . . . . . . . . . . . .  T_INTEXPR/T_INT_EXPR
+*F  CompIntExpr( <expr> ) . . . . . . . . . . . . . . .  EXPR_INT/EXPR_INTPOS
 **
 **  This is complicated by the need to produce code that will compile
 **  correctly in 32 or 64 bit and with or without GMP.
@@ -2280,7 +2280,7 @@ static CVar CompIntExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompTildeExpr( <expr> )  . . . . . . . . . . . . . . . . . . T_TILDE_EXPR
+*F  CompTildeExpr( <expr> )  . . . . . . . . . . . . . . . . . . EXPR_TILDE
 */
 static CVar CompTildeExpr(Expr expr)
 {
@@ -2301,7 +2301,7 @@ static CVar CompTildeExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompTrueExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_TRUE_EXPR
+*F  CompTrueExpr( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_TRUE
 */
 static CVar CompTrueExpr(Expr expr)
 {
@@ -2323,7 +2323,7 @@ static CVar CompTrueExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFalseExpr( <expr> ) . . . . . . . . . . . . . . . . . .  T_FALSE_EXPR
+*F  CompFalseExpr( <expr> ) . . . . . . . . . . . . . . . . . .  EXPR_FALSE
 */
 static CVar CompFalseExpr(Expr expr)
 {
@@ -2345,7 +2345,7 @@ static CVar CompFalseExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompCharExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_CHAR_EXPR
+*F  CompCharExpr( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_CHAR
 */
 static CVar CompCharExpr(Expr expr)
 {
@@ -2367,7 +2367,7 @@ static CVar CompCharExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompPermExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_PERM_EXPR
+*F  CompPermExpr( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_PERM
 */
 static CVar CompPermExpr(Expr expr)
 {
@@ -2430,7 +2430,7 @@ static CVar CompPermExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompListExpr( <expr> )  . . . . . . . . . . . . . . . . . . . T_LIST_EXPR
+*F  CompListExpr( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_LIST
 */
 static CVar CompListExpr1(Expr expr);
 static void CompListExpr2(CVar list, Expr expr);
@@ -2452,7 +2452,7 @@ static CVar CompListExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompListTildeExpr( <expr> ) . . . . . . . . . . . . . . T_LIST_TILDE_EXPR
+*F  CompListTildeExpr( <expr> ) . . . . . . . . . . . . . . EXPR_LIST_TILDE
 */
 static CVar CompListTildeExpr(Expr expr)
 {
@@ -2530,7 +2530,7 @@ static void CompListExpr2(CVar list, Expr expr)
         }
 
         /* special case if subexpression is a list expression              */
-        else if (TNUM_EXPR(READ_EXPR(expr, i - 1)) == T_LIST_EXPR) {
+        else if (TNUM_EXPR(READ_EXPR(expr, i - 1)) == EXPR_LIST) {
             sub = CompListExpr1(READ_EXPR(expr, i - 1));
             Emit( "SET_ELM_PLIST( %c, %d, %c );\n", list, i, sub );
             Emit( "CHANGED_BAG( %c );\n", list );
@@ -2539,7 +2539,7 @@ static void CompListExpr2(CVar list, Expr expr)
         }
 
         /* special case if subexpression is a record expression            */
-        else if (TNUM_EXPR(READ_EXPR(expr, i - 1)) == T_REC_EXPR) {
+        else if (TNUM_EXPR(READ_EXPR(expr, i - 1)) == EXPR_REC) {
             sub = CompRecExpr1(READ_EXPR(expr, i - 1));
             Emit( "SET_ELM_PLIST( %c, %d, %c );\n", list, i, sub );
             Emit( "CHANGED_BAG( %c );\n", list );
@@ -2564,7 +2564,7 @@ static void CompListExpr2(CVar list, Expr expr)
 
 /****************************************************************************
 **
-*F  CompRangeExpr( <expr> ) . . . . . . . . . . . . . . . . . .  T_RANGE_EXPR
+*F  CompRangeExpr( <expr> ) . . . . . . . . . . . . . . . . . .  EXPR_RANGE
 */
 static CVar CompRangeExpr(Expr expr)
 {
@@ -2645,7 +2645,7 @@ static CVar CompStringExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompRecExpr( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REC_EXPR
+*F  CompRecExpr( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_REC
 */
 static CVar CompRecExpr(Expr expr)
 {
@@ -2662,7 +2662,7 @@ static CVar CompRecExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompRecTildeExpr( <expr> )  . . . . . . . . . . . . . .  T_REC_TILDE_EXPR
+*F  CompRecTildeExpr( <expr> )  . . . . . . . . . . . . . .  EXPR_REC_TILDE
 */
 static CVar CompRecTildeExpr(Expr expr)
 {
@@ -2756,7 +2756,7 @@ static void CompRecExpr2(CVar rec, Expr expr)
         }
 
         /* special case if subexpression is a list expression             */
-        else if ( TNUM_EXPR( tmp ) == T_LIST_EXPR ) {
+        else if ( TNUM_EXPR( tmp ) == EXPR_LIST ) {
             sub = CompListExpr1( tmp );
             Emit( "AssPRec( %c, (UInt)%c, %c );\n", rec, rnam, sub );
             CompListExpr2( sub, tmp );
@@ -2764,7 +2764,7 @@ static void CompRecExpr2(CVar rec, Expr expr)
         }
 
         /* special case if subexpression is a record expression            */
-        else if ( TNUM_EXPR( tmp ) == T_REC_EXPR ) {
+        else if ( TNUM_EXPR( tmp ) == EXPR_REC ) {
             sub = CompRecExpr1( tmp );
             Emit( "AssPRec( %c, (UInt)%c, %c );\n", rec, rnam, sub );
             CompRecExpr2( sub, tmp );
@@ -2787,14 +2787,14 @@ static void CompRecExpr2(CVar rec, Expr expr)
 
 /****************************************************************************
 **
-*F  CompRefLVar( <expr> ) . . . . . . .  T_REFLVAR
+*F  CompRefLVar( <expr> ) . . . . . . .  EXPR_REF_LVAR
 */
 static CVar CompRefLVar(Expr expr)
 {
     CVar                val;            /* value, result                   */
     LVar                lvar;           /* local variable                  */
 
-    lvar = LVAR_REFLVAR(expr);
+    lvar = LVAR_REF_LVAR(expr);
 
     /* emit the code to get the value                                      */
     if ( CompGetUseHVar( lvar ) ) {
@@ -2815,7 +2815,7 @@ static CVar CompRefLVar(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbLVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_LVAR
+*F  CompIsbLVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_ISB_LVAR
 */
 static CVar CompIsbLVar(Expr expr)
 {
@@ -2854,7 +2854,7 @@ static CVar CompIsbLVar(Expr expr)
 
 /****************************************************************************
 **
-*F  CompRefHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REF_HVAR
+*F  CompRefHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_REF_HVAR
 */
 static CVar CompRefHVar(Expr expr)
 {
@@ -2882,7 +2882,7 @@ static CVar CompRefHVar(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_HVAR
+*F  CompIsbHVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_ISB_HVAR
 */
 static CVar CompIsbHVar(Expr expr)
 {
@@ -2918,7 +2918,7 @@ static CVar CompIsbHVar(Expr expr)
 
 /****************************************************************************
 **
-*F  CompRefGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_REF_GVAR
+*F  CompRefGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_REF_GVAR
 */
 static CVar CompRefGVar(Expr expr)
 {
@@ -2972,7 +2972,7 @@ static CVar CompRefGVarFopy(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_GVAR
+*F  CompIsbGVar( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_ISB_GVAR
 */
 static CVar CompIsbGVar(Expr expr)
 {
@@ -3007,7 +3007,7 @@ static CVar CompIsbGVar(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmList( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ELM_LIST
+*F  CompElmList( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_ELM_LIST
 */
 static CVar CompElmList(Expr expr)
 {
@@ -3053,7 +3053,7 @@ static CVar CompElmList(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmsList( <expr> )  . . . . . . . . . . . . . . . . . . . T_ELMS_LIST
+*F  CompElmsList( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_ELMS_LIST
 */
 static CVar CompElmsList(Expr expr)
 {
@@ -3087,7 +3087,7 @@ static CVar CompElmsList(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmListLev( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_LIST_LEV
+*F  CompElmListLev( <expr> )  . . . . . . . . . . . . . . . .  EXPR_ELM_LIST_LEV
 */
 static CVar CompElmListLev(Expr expr)
 {
@@ -3118,7 +3118,7 @@ static CVar CompElmListLev(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmsListLev( <expr> ) . . . . . . . . . . . . . . . . T_ELMS_LIST_LEV
+*F  CompElmsListLev( <expr> ) . . . . . . . . . . . . . . . . EXPR_ELMS_LIST_LEV
 */
 static CVar CompElmsListLev(Expr expr)
 {
@@ -3148,7 +3148,7 @@ static CVar CompElmsListLev(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbList( <expr> ) . . . . . . . . . . . . . . . . . . . .  T_ISB_LIST
+*F  CompIsbList( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_ISB_LIST
 */
 static CVar CompIsbList(Expr expr)
 {
@@ -3183,7 +3183,7 @@ static CVar CompIsbList(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmRecName( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_REC_NAME
+*F  CompElmRecName( <expr> )  . . . . . . . . . . . . . . . .  EXPR_ELM_REC_NAME
 */
 static CVar CompElmRecName(Expr expr)
 {
@@ -3217,7 +3217,7 @@ static CVar CompElmRecName(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmRecExpr( <expr> )  . . . . . . . . . . . . . . . .  T_ELM_REC_EXPR
+*F  CompElmRecExpr( <expr> )  . . . . . . . . . . . . . . . .  EXPR_ELM_REC_EXPR
 */
 static CVar CompElmRecExpr(Expr expr)
 {
@@ -3251,7 +3251,7 @@ static CVar CompElmRecExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbRecName( <expr> )  . . . . . . . . . . . . . . . .  T_ISB_REC_NAME
+*F  CompIsbRecName( <expr> )  . . . . . . . . . . . . . . . .  EXPR_ISB_REC_NAME
 */
 static CVar CompIsbRecName(Expr expr)
 {
@@ -3286,7 +3286,7 @@ static CVar CompIsbRecName(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbRecExpr( <expr> )  . . . . . . . . . . . . . . . .  T_ISB_REC_EXPR
+*F  CompIsbRecExpr( <expr> )  . . . . . . . . . . . . . . . .  EXPR_ISB_REC_EXPR
 */
 static CVar CompIsbRecExpr(Expr expr)
 {
@@ -3321,7 +3321,7 @@ static CVar CompIsbRecExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ELM_POSOBJ
+*F  CompElmPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  EXPR_ELM_POSOBJ
 */
 static CVar CompElmPosObj(Expr expr)
 {
@@ -3356,7 +3356,7 @@ static CVar CompElmPosObj(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  T_ISB_POSOBJ
+*F  CompIsbPosObj( <expr> ) . . . . . . . . . . . . . . . . . .  EXPR_ISB_POSOBJ
 */
 static CVar CompIsbPosObj(Expr expr)
 {
@@ -3391,7 +3391,7 @@ static CVar CompIsbPosObj(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmObjName( <expr> )  . . . . . . . . . . . . . . . T_ELM_COMOBJ_NAME
+*F  CompElmObjName( <expr> )  . . . . . . . . . . . . . . . EXPR_ELM_COMOBJ_NAME
 */
 static CVar CompElmComObjName(Expr expr)
 {
@@ -3426,7 +3426,7 @@ static CVar CompElmComObjName(Expr expr)
 
 /****************************************************************************
 **
-*F  CompElmComObjExpr( <expr> ) . . . . . . . . . . . . . . T_ELM_COMOBJ_EXPR
+*F  CompElmComObjExpr( <expr> ) . . . . . . . . . . . . . . EXPR_ELM_COMOBJ_EXPR
 */
 static CVar CompElmComObjExpr(Expr expr)
 {
@@ -3460,7 +3460,7 @@ static CVar CompElmComObjExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbComObjName( <expr> ) . . . . . . . . . . . . . . T_ISB_COMOBJ_NAME
+*F  CompIsbComObjName( <expr> ) . . . . . . . . . . . . . . EXPR_ISB_COMOBJ_NAME
 */
 static CVar CompIsbComObjName(Expr expr)
 {
@@ -3495,7 +3495,7 @@ static CVar CompIsbComObjName(Expr expr)
 
 /****************************************************************************
 **
-*F  CompIsbComObjExpr( <expr> ) . . . . . . . . . . . . . . T_ISB_COMOBJ_EXPR
+*F  CompIsbComObjExpr( <expr> ) . . . . . . . . . . . . . . EXPR_ISB_COMOBJ_EXPR
 */
 static CVar CompIsbComObjExpr(Expr expr)
 {
@@ -3567,7 +3567,7 @@ static GVar G_Add;
 
 /****************************************************************************
 **
-*F  CompProccall0to6Args( <stat> )  . . . T_PROCCALL_0ARGS...T_PROCCALL_6ARGS
+*F  CompProccall0to6Args( <stat> )  . . . STAT_PROCCALL_0ARGS...STAT_PROCCALL_6ARGS
 */
 static void CompProccall0to6Args(Stat stat)
 {
@@ -3583,7 +3583,7 @@ static void CompProccall0to6Args(Stat stat)
 
     /* special case to inline 'Add'                                        */
     if ( CompFastListFuncs
-      && TNUM_EXPR( FUNC_CALL(stat) ) == T_REF_GVAR
+      && TNUM_EXPR( FUNC_CALL(stat) ) == EXPR_REF_GVAR
       && READ_EXPR( FUNC_CALL(stat), 0 ) == G_Add
       && NARG_SIZE_CALL(SIZE_EXPR(stat)) == 2 ) {
         args[1] = CompExpr( ARGI_CALL(stat,1) );
@@ -3600,7 +3600,7 @@ static void CompProccall0to6Args(Stat stat)
     }
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(stat) ) == T_REF_GVAR ) {
+    if ( TNUM_EXPR( FUNC_CALL(stat) ) == EXPR_REF_GVAR ) {
         func = CompRefGVarFopy( FUNC_CALL(stat) );
     }
     else {
@@ -3642,7 +3642,7 @@ static void CompProccall0to6Args(Stat stat)
 
 /****************************************************************************
 **
-*F  CompProccallXArgs . . . . . . . . . . . . . . . . . . .  T_PROCCALL_XARGS
+*F  CompProccallXArgs . . . . . . . . . . . . . . . . . . .  STAT_PROCCALL_XARGS
 */
 static void CompProccallXArgs(Stat stat)
 {
@@ -3658,7 +3658,7 @@ static void CompProccallXArgs(Stat stat)
     }
 
     /* compile the reference to the function                               */
-    if ( TNUM_EXPR( FUNC_CALL(stat) ) == T_REF_GVAR ) {
+    if ( TNUM_EXPR( FUNC_CALL(stat) ) == EXPR_REF_GVAR ) {
         func = CompRefGVarFopy( FUNC_CALL(stat) );
     }
     else {
@@ -3694,7 +3694,7 @@ static void CompProccallXArgs(Stat stat)
 
 /****************************************************************************
 **
-*F  CompProccallXArgs( <expr> ) . . . . . . . . . . . . . .  T_PROCCALL_OPTS
+*F  CompProccallXArgs( <expr> ) . . . . . . . . . . . . . .  STAT_PROCCALL_OPTS
 */
 static void CompProccallOpts(Stat stat)
 {
@@ -3714,7 +3714,7 @@ static void CompProccallOpts(Stat stat)
 
 /****************************************************************************
 **
-*F  CompSeqStat( <stat> ) . . . . . . . . . . . . .  T_SEQ_STAT...T_SEQ_STAT7
+*F  CompSeqStat( <stat> ) . . . . . . . . . . . . .  STAT_SEQ_STAT...STAT_SEQ_STAT7
 */
 static void CompSeqStat(Stat stat)
 {
@@ -3733,7 +3733,7 @@ static void CompSeqStat(Stat stat)
 
 /****************************************************************************
 **
-*F  CompIf( <stat> )  . . . . . . . . T_IF/T_IF_ELSE/T_IF_ELIF/T_IF_ELIF_ELSE
+*F  CompIf( <stat> )  . . . . . . . . STAT_IF/STAT_IF_ELSE/STAT_IF_ELIF/STAT_IF_ELIF_ELSE
 */
 static void CompIf(Stat stat)
 {
@@ -3778,7 +3778,7 @@ static void CompIf(Stat stat)
     for ( i = 2; i <= nr; i++ ) {
 
         /* do not handle 'else' branch here                                */
-        if (i == nr && TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == T_TRUE_EXPR)
+        if (i == nr && TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == EXPR_TRUE)
             break;
 
         /* print a comment                                                 */
@@ -3853,7 +3853,7 @@ static void CompIf(Stat stat)
 
     /* close all unbalanced parenthesis                                    */
     for ( i = 2; i <= nr; i++ ) {
-        if (i == nr && TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == T_TRUE_EXPR)
+        if (i == nr && TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == EXPR_TRUE)
             break;
         Emit( "}\n" );
     }
@@ -3867,7 +3867,7 @@ static void CompIf(Stat stat)
 
 /****************************************************************************
 **
-*F  CompFor( <stat> ) . . . . . . . T_FOR...T_FOR3/T_FOR_RANGE...T_FOR_RANGE3
+*F  CompFor( <stat> ) . . . . . . . STAT_FOR...STAT_FOR3/STAT_FOR_RANGE...STAT_FOR_RANGE3
 */
 static void CompFor(Stat stat)
 {
@@ -3884,9 +3884,9 @@ static void CompFor(Stat stat)
     Int                 i;              /* loop variable                   */
 
     /* handle 'for <lvar> in [<first>..<last>] do'                         */
-    if ( IS_REFLVAR( READ_STAT(stat, 0) )
-      && ! CompGetUseHVar( LVAR_REFLVAR( READ_STAT(stat, 0) ) )
-      && TNUM_EXPR( READ_STAT(stat, 1) ) == T_RANGE_EXPR
+    if ( IS_REF_LVAR( READ_STAT(stat, 0) )
+      && ! CompGetUseHVar( LVAR_REF_LVAR( READ_STAT(stat, 0) ) )
+      && TNUM_EXPR( READ_STAT(stat, 1) ) == EXPR_RANGE
       && SIZE_EXPR( READ_STAT(stat, 1) ) == 2*sizeof(Expr) ) {
 
         /* print a comment                                                 */
@@ -3899,7 +3899,7 @@ static void CompFor(Stat stat)
         }
 
         /* get the local variable                                          */
-        var = LVAR_REFLVAR(READ_STAT(stat, 0));
+        var = LVAR_REF_LVAR(READ_STAT(stat, 0));
 
         /* allocate a new temporary for the loop variable                  */
         lidx = CVAR_TEMP( NewTemp( "lidx" ) );
@@ -3985,20 +3985,20 @@ static void CompFor(Stat stat)
         }
 
         /* get the variable (initialize them first to please 'lint')       */
-        if ( IS_REFLVAR( READ_STAT(stat, 0) )
-          && ! CompGetUseHVar( LVAR_REFLVAR( READ_STAT(stat, 0) ) ) ) {
-            var = LVAR_REFLVAR( READ_STAT(stat, 0) );
+        if ( IS_REF_LVAR( READ_STAT(stat, 0) )
+          && ! CompGetUseHVar( LVAR_REF_LVAR( READ_STAT(stat, 0) ) ) ) {
+            var = LVAR_REF_LVAR( READ_STAT(stat, 0) );
             vart = 'l';
         }
-        else if (IS_REFLVAR(READ_STAT(stat, 0))) {
-            var = LVAR_REFLVAR(READ_STAT(stat, 0));
+        else if (IS_REF_LVAR(READ_STAT(stat, 0))) {
+            var = LVAR_REF_LVAR(READ_STAT(stat, 0));
             vart = 'm';
         }
-        else if (TNUM_EXPR(READ_STAT(stat, 0)) == T_REF_HVAR) {
+        else if (TNUM_EXPR(READ_STAT(stat, 0)) == EXPR_REF_HVAR) {
             var = READ_EXPR(READ_STAT(stat, 0), 0);
             vart = 'h';
         }
-        else /* if ( TNUM_EXPR( READ_STAT(stat, 0) ) == T_REF_GVAR ) */ {
+        else /* if ( TNUM_EXPR( READ_STAT(stat, 0) ) == EXPR_REF_GVAR ) */ {
             var = READ_EXPR(READ_STAT(stat, 0), 0);
             CompSetUseGVar( var, COMP_USE_GVAR_ID );
             vart = 'g';
@@ -4106,7 +4106,7 @@ static void CompFor(Stat stat)
 
 /****************************************************************************
 **
-*F  CompWhile( <stat> ) . . . . . . . . . . . . . . . . .  T_WHILE...T_WHILE3
+*F  CompWhile( <stat> ) . . . . . . . . . . . . . . . . .  STAT_WHILE...STAT_WHILE3
 */
 static void CompWhile(Stat stat)
 {
@@ -4163,7 +4163,7 @@ static void CompWhile(Stat stat)
 
 /****************************************************************************
 **
-*F  CompRepeat( <stat> )  . . . . . . . . . . . . . . .  T_REPEAT...T_REPEAT3
+*F  CompRepeat( <stat> )  . . . . . . . . . . . . . . .  STAT_REPEAT...STAT_REPEAT3
 */
 static void CompRepeat(Stat stat)
 {
@@ -4223,7 +4223,7 @@ static void CompRepeat(Stat stat)
 
 /****************************************************************************
 **
-*F  CompBreak( <stat> ) . . . . . . . . . . . . . . . . . . . . . . . T_BREAK
+*F  CompBreak( <stat> ) . . . . . . . . . . . . . . . . . . . . . . . STAT_BREAK
 */
 static void CompBreak(Stat stat)
 {
@@ -4237,7 +4237,7 @@ static void CompBreak(Stat stat)
 
 /****************************************************************************
 **
-*F  CompContinue( <stat> ) . . . . . . . . . . . . . . . . . . . . T_CONTINUE
+*F  CompContinue( <stat> ) . . . . . . . . . . . . . . . . . . . . STAT_CONTINUE
 */
 static void CompContinue(Stat stat)
 {
@@ -4252,7 +4252,7 @@ static void CompContinue(Stat stat)
 
 /****************************************************************************
 **
-*F  CompReturnObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_RETURN_OBJ
+*F  CompReturnObj( <stat> ) . . . . . . . . . . . . . . . . . .  STAT_RETURN_OBJ
 */
 static void CompReturnObj(Stat stat)
 {
@@ -4279,7 +4279,7 @@ static void CompReturnObj(Stat stat)
 
 /****************************************************************************
 **
-*F  CompReturnVoid( <stat> )  . . . . . . . . . . . . . . . . . T_RETURN_VOID
+*F  CompReturnVoid( <stat> )  . . . . . . . . . . . . . . . . . STAT_RETURN_VOID
 */
 static void CompReturnVoid(Stat stat)
 {
@@ -4298,7 +4298,7 @@ static void CompReturnVoid(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssLVar( <stat> ) . . . . . . . . . . . .  T_ASS_LVAR...T_ASS_LVAR_16
+*F  CompAssLVar( <stat> ) . . . . . . . . . . . .  STAT_ASS_LVAR...T_ASS_LVAR_16
 */
 static void CompAssLVar(Stat stat)
 {
@@ -4330,7 +4330,7 @@ static void CompAssLVar(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbLVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_LVAR
+*F  CompUnbLVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_UNB_LVAR
 */
 static void CompUnbLVar(Stat stat)
 {
@@ -4355,7 +4355,7 @@ static void CompUnbLVar(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_HVAR
+*F  CompAssHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_ASS_HVAR
 */
 static void CompAssHVar(Stat stat)
 {
@@ -4383,7 +4383,7 @@ static void CompAssHVar(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_HVAR
+*F  CompUnbHVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_UNB_HVAR
 */
 static void CompUnbHVar(Stat stat)
 {
@@ -4404,7 +4404,7 @@ static void CompUnbHVar(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_GVAR
+*F  CompAssGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_ASS_GVAR
 */
 static void CompAssGVar(Stat stat)
 {
@@ -4431,7 +4431,7 @@ static void CompAssGVar(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_GVAR
+*F  CompUnbGVar( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_UNB_GVAR
 */
 static void CompUnbGVar(Stat stat)
 {
@@ -4451,7 +4451,7 @@ static void CompUnbGVar(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssList( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_ASS_LIST
+*F  CompAssList( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_ASS_LIST
 */
 static void CompAssList(Stat stat)
 {
@@ -4496,7 +4496,7 @@ static void CompAssList(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAsssList( <stat> )  . . . . . . . . . . . . . . . . . . . T_ASSS_LIST
+*F  CompAsssList( <stat> )  . . . . . . . . . . . . . . . . . . . STAT_ASSS_LIST
 */
 static void CompAsssList(Stat stat)
 {
@@ -4530,7 +4530,7 @@ static void CompAsssList(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssListLev( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_LIST_LEV
+*F  CompAssListLev( <stat> )  . . . . . . . . . . . . . . . .  STAT_ASS_LIST_LEV
 */
 static void CompAssListLev(Stat stat)
 {
@@ -4569,7 +4569,7 @@ static void CompAssListLev(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAsssListLev( <stat> ) . . . . . . . . . . . . . . . . T_ASSS_LIST_LEV
+*F  CompAsssListLev( <stat> ) . . . . . . . . . . . . . . . . STAT_ASSS_LIST_LEV
 */
 static void CompAsssListLev(Stat stat)
 {
@@ -4608,7 +4608,7 @@ static void CompAsssListLev(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbList( <stat> ) . . . . . . . . . . . . . . . . . . . .  T_UNB_LIST
+*F  CompUnbList( <stat> ) . . . . . . . . . . . . . . . . . . . .  STAT_UNB_LIST
 */
 static void CompUnbList(Stat stat)
 {
@@ -4638,7 +4638,7 @@ static void CompUnbList(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssRecName( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_REC_NAME
+*F  CompAssRecName( <stat> )  . . . . . . . . . . . . . . . .  STAT_ASS_REC_NAME
 */
 static void CompAssRecName(Stat stat)
 {
@@ -4672,7 +4672,7 @@ static void CompAssRecName(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssRecExpr( <stat> )  . . . . . . . . . . . . . . . .  T_ASS_REC_EXPR
+*F  CompAssRecExpr( <stat> )  . . . . . . . . . . . . . . . .  STAT_ASS_REC_EXPR
 */
 static void CompAssRecExpr(Stat stat)
 {
@@ -4706,7 +4706,7 @@ static void CompAssRecExpr(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbRecName( <stat> )  . . . . . . . . . . . . . . . .  T_UNB_REC_NAME
+*F  CompUnbRecName( <stat> )  . . . . . . . . . . . . . . . .  STAT_UNB_REC_NAME
 */
 static void CompUnbRecName(Stat stat)
 {
@@ -4735,7 +4735,7 @@ static void CompUnbRecName(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbRecExpr( <stat> )  . . . . . . . . . . . . . . . .  T_UNB_REC_EXPR
+*F  CompUnbRecExpr( <stat> )  . . . . . . . . . . . . . . . .  STAT_UNB_REC_EXPR
 */
 static void CompUnbRecExpr(Stat stat)
 {
@@ -4764,7 +4764,7 @@ static void CompUnbRecExpr(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASS_POSOBJ
+*F  CompAssPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  STAT_ASS_POSOBJ
 */
 static void CompAssPosObj(Stat stat)
 {
@@ -4799,7 +4799,7 @@ static void CompAssPosObj(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  T_UNB_POSOBJ
+*F  CompUnbPosObj( <stat> ) . . . . . . . . . . . . . . . . . .  STAT_UNB_POSOBJ
 */
 static void CompUnbPosObj(Stat stat)
 {
@@ -4829,7 +4829,7 @@ static void CompUnbPosObj(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssComObjName( <stat> ) . . . . . . . . . . . . . . T_ASS_COMOBJ_NAME
+*F  CompAssComObjName( <stat> ) . . . . . . . . . . . . . . STAT_ASS_COMOBJ_NAME
 */
 static void CompAssComObjName(Stat stat)
 {
@@ -4863,7 +4863,7 @@ static void CompAssComObjName(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssComObjExpr( <stat> ) . . . . . . . . . . . . . . T_ASS_COMOBJ_EXPR
+*F  CompAssComObjExpr( <stat> ) . . . . . . . . . . . . . . STAT_ASS_COMOBJ_EXPR
 */
 static void CompAssComObjExpr(Stat stat)
 {
@@ -4897,7 +4897,7 @@ static void CompAssComObjExpr(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbComObjName( <stat> ) . . . . . . . . . . . . . . T_UNB_COMOBJ_NAME
+*F  CompUnbComObjName( <stat> ) . . . . . . . . . . . . . . STAT_UNB_COMOBJ_NAME
 */
 static void CompUnbComObjName(Stat stat)
 {
@@ -4926,7 +4926,7 @@ static void CompUnbComObjName(Stat stat)
 
 /****************************************************************************
 **
-*F  CompUnbComObjExpr( <stat> ) . . . . . . . . . . . . . . T_UNB_COMOBJ_EXPR
+*F  CompUnbComObjExpr( <stat> ) . . . . . . . . . . . . . . STAT_UNB_COMOBJ_EXPR
 */
 static void CompUnbComObjExpr(Stat stat)
 {
@@ -4963,7 +4963,7 @@ static void CompEmpty(Stat stat)
   
 /****************************************************************************
 **
-*F  CompInfo( <stat> )  . . . . . . . . . . . . . . . . . . . . . . .  T_INFO
+*F  CompInfo( <stat> )  . . . . . . . . . . . . . . . . . . . . . . .  STAT_INFO
 */
 static void CompInfo(Stat stat)
 {
@@ -5003,7 +5003,7 @@ static void CompInfo(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssert2( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASSERT_2ARGS
+*F  CompAssert2( <stat> ) . . . . . . . . . . . . . . . . . .  STAT_ASSERT_2ARGS
 */
 static void CompAssert2(Stat stat)
 {
@@ -5027,7 +5027,7 @@ static void CompAssert2(Stat stat)
 
 /****************************************************************************
 **
-*F  CompAssert3( <stat> ) . . . . . . . . . . . . . . . . . .  T_ASSERT_3ARGS
+*F  CompAssert3( <stat> ) . . . . . . . . . . . . . . . . . .  STAT_ASSERT_3ARGS
 */
 static void CompAssert3(Stat stat)
 {
@@ -5531,164 +5531,164 @@ static Int InitKernel (
         CompExprFuncs[ i ] = CompUnknownExpr;
     }
 
-    CompExprFuncs[ T_FUNCCALL_0ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_1ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_2ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_3ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_4ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_5ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_6ARGS  ] = CompFunccall0to6Args;
-    CompExprFuncs[ T_FUNCCALL_XARGS  ] = CompFunccallXArgs;
-    CompExprFuncs[ T_FUNC_EXPR       ] = CompFuncExpr;
+    CompExprFuncs[ EXPR_FUNCCALL_0ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_1ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_2ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_3ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_4ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_5ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_6ARGS  ] = CompFunccall0to6Args;
+    CompExprFuncs[ EXPR_FUNCCALL_XARGS  ] = CompFunccallXArgs;
+    CompExprFuncs[ EXPR_FUNC       ] = CompFuncExpr;
 
-    CompExprFuncs[ T_OR              ] = CompOr;
-    CompExprFuncs[ T_AND             ] = CompAnd;
-    CompExprFuncs[ T_NOT             ] = CompNot;
-    CompExprFuncs[ T_EQ              ] = CompEq;
-    CompExprFuncs[ T_NE              ] = CompNe;
-    CompExprFuncs[ T_LT              ] = CompLt;
-    CompExprFuncs[ T_GE              ] = CompGe;
-    CompExprFuncs[ T_GT              ] = CompGt;
-    CompExprFuncs[ T_LE              ] = CompLe;
-    CompExprFuncs[ T_IN              ] = CompIn;
+    CompExprFuncs[ EXPR_OR              ] = CompOr;
+    CompExprFuncs[ EXPR_AND             ] = CompAnd;
+    CompExprFuncs[ EXPR_NOT             ] = CompNot;
+    CompExprFuncs[ EXPR_EQ              ] = CompEq;
+    CompExprFuncs[ EXPR_NE              ] = CompNe;
+    CompExprFuncs[ EXPR_LT              ] = CompLt;
+    CompExprFuncs[ EXPR_GE              ] = CompGe;
+    CompExprFuncs[ EXPR_GT              ] = CompGt;
+    CompExprFuncs[ EXPR_LE              ] = CompLe;
+    CompExprFuncs[ EXPR_IN              ] = CompIn;
 
-    CompExprFuncs[ T_SUM             ] = CompSum;
-    CompExprFuncs[ T_AINV            ] = CompAInv;
-    CompExprFuncs[ T_DIFF            ] = CompDiff;
-    CompExprFuncs[ T_PROD            ] = CompProd;
-    CompExprFuncs[ T_QUO             ] = CompQuo;
-    CompExprFuncs[ T_MOD             ] = CompMod;
-    CompExprFuncs[ T_POW             ] = CompPow;
+    CompExprFuncs[ EXPR_SUM             ] = CompSum;
+    CompExprFuncs[ EXPR_AINV            ] = CompAInv;
+    CompExprFuncs[ EXPR_DIFF            ] = CompDiff;
+    CompExprFuncs[ EXPR_PROD            ] = CompProd;
+    CompExprFuncs[ EXPR_QUO             ] = CompQuo;
+    CompExprFuncs[ EXPR_MOD             ] = CompMod;
+    CompExprFuncs[ EXPR_POW             ] = CompPow;
 
-    CompExprFuncs[ T_INTEXPR         ] = CompIntExpr;
-    CompExprFuncs[ T_INT_EXPR        ] = CompIntExpr;
-    CompExprFuncs[ T_TRUE_EXPR       ] = CompTrueExpr;
-    CompExprFuncs[ T_FALSE_EXPR      ] = CompFalseExpr;
-    CompExprFuncs[ T_TILDE_EXPR      ] = CompTildeExpr;
-    CompExprFuncs[ T_CHAR_EXPR       ] = CompCharExpr;
-    CompExprFuncs[ T_PERM_EXPR       ] = CompPermExpr;
-    CompExprFuncs[ T_PERM_CYCLE      ] = CompUnknownExpr;
-    CompExprFuncs[ T_LIST_EXPR       ] = CompListExpr;
-    CompExprFuncs[ T_LIST_TILDE_EXPR ] = CompListTildeExpr;
-    CompExprFuncs[ T_RANGE_EXPR      ] = CompRangeExpr;
-    CompExprFuncs[ T_STRING_EXPR     ] = CompStringExpr;
-    CompExprFuncs[ T_REC_EXPR        ] = CompRecExpr;
-    CompExprFuncs[ T_REC_TILDE_EXPR  ] = CompRecTildeExpr;
+    CompExprFuncs[ EXPR_INT         ] = CompIntExpr;
+    CompExprFuncs[ EXPR_INTPOS        ] = CompIntExpr;
+    CompExprFuncs[ EXPR_TRUE       ] = CompTrueExpr;
+    CompExprFuncs[ EXPR_FALSE      ] = CompFalseExpr;
+    CompExprFuncs[ EXPR_TILDE      ] = CompTildeExpr;
+    CompExprFuncs[ EXPR_CHAR       ] = CompCharExpr;
+    CompExprFuncs[ EXPR_PERM       ] = CompPermExpr;
+    CompExprFuncs[ EXPR_PERM_CYCLE      ] = CompUnknownExpr;
+    CompExprFuncs[ EXPR_LIST       ] = CompListExpr;
+    CompExprFuncs[ EXPR_LIST_TILDE ] = CompListTildeExpr;
+    CompExprFuncs[ EXPR_RANGE      ] = CompRangeExpr;
+    CompExprFuncs[ EXPR_STRING     ] = CompStringExpr;
+    CompExprFuncs[ EXPR_REC        ] = CompRecExpr;
+    CompExprFuncs[ EXPR_REC_TILDE  ] = CompRecTildeExpr;
 
-    CompExprFuncs[ T_REFLVAR         ] = CompRefLVar;
-    CompExprFuncs[ T_ISB_LVAR        ] = CompIsbLVar;
-    CompExprFuncs[ T_REF_HVAR        ] = CompRefHVar;
-    CompExprFuncs[ T_ISB_HVAR        ] = CompIsbHVar;
-    CompExprFuncs[ T_REF_GVAR        ] = CompRefGVar;
-    CompExprFuncs[ T_ISB_GVAR        ] = CompIsbGVar;
+    CompExprFuncs[ EXPR_REF_LVAR         ] = CompRefLVar;
+    CompExprFuncs[ EXPR_ISB_LVAR        ] = CompIsbLVar;
+    CompExprFuncs[ EXPR_REF_HVAR        ] = CompRefHVar;
+    CompExprFuncs[ EXPR_ISB_HVAR        ] = CompIsbHVar;
+    CompExprFuncs[ EXPR_REF_GVAR        ] = CompRefGVar;
+    CompExprFuncs[ EXPR_ISB_GVAR        ] = CompIsbGVar;
 
-    CompExprFuncs[ T_ELM_LIST        ] = CompElmList;
-    CompExprFuncs[ T_ELMS_LIST       ] = CompElmsList;
-    CompExprFuncs[ T_ELM_LIST_LEV    ] = CompElmListLev;
-    CompExprFuncs[ T_ELMS_LIST_LEV   ] = CompElmsListLev;
-    CompExprFuncs[ T_ISB_LIST        ] = CompIsbList;
-    CompExprFuncs[ T_ELM_REC_NAME    ] = CompElmRecName;
-    CompExprFuncs[ T_ELM_REC_EXPR    ] = CompElmRecExpr;
-    CompExprFuncs[ T_ISB_REC_NAME    ] = CompIsbRecName;
-    CompExprFuncs[ T_ISB_REC_EXPR    ] = CompIsbRecExpr;
+    CompExprFuncs[ EXPR_ELM_LIST        ] = CompElmList;
+    CompExprFuncs[ EXPR_ELMS_LIST       ] = CompElmsList;
+    CompExprFuncs[ EXPR_ELM_LIST_LEV    ] = CompElmListLev;
+    CompExprFuncs[ EXPR_ELMS_LIST_LEV   ] = CompElmsListLev;
+    CompExprFuncs[ EXPR_ISB_LIST        ] = CompIsbList;
+    CompExprFuncs[ EXPR_ELM_REC_NAME    ] = CompElmRecName;
+    CompExprFuncs[ EXPR_ELM_REC_EXPR    ] = CompElmRecExpr;
+    CompExprFuncs[ EXPR_ISB_REC_NAME    ] = CompIsbRecName;
+    CompExprFuncs[ EXPR_ISB_REC_EXPR    ] = CompIsbRecExpr;
 
-    CompExprFuncs[ T_ELM_POSOBJ      ] = CompElmPosObj;
-    CompExprFuncs[ T_ISB_POSOBJ      ] = CompIsbPosObj;
-    CompExprFuncs[ T_ELM_COMOBJ_NAME ] = CompElmComObjName;
-    CompExprFuncs[ T_ELM_COMOBJ_EXPR ] = CompElmComObjExpr;
-    CompExprFuncs[ T_ISB_COMOBJ_NAME ] = CompIsbComObjName;
-    CompExprFuncs[ T_ISB_COMOBJ_EXPR ] = CompIsbComObjExpr;
+    CompExprFuncs[ EXPR_ELM_POSOBJ      ] = CompElmPosObj;
+    CompExprFuncs[ EXPR_ISB_POSOBJ      ] = CompIsbPosObj;
+    CompExprFuncs[ EXPR_ELM_COMOBJ_NAME ] = CompElmComObjName;
+    CompExprFuncs[ EXPR_ELM_COMOBJ_EXPR ] = CompElmComObjExpr;
+    CompExprFuncs[ EXPR_ISB_COMOBJ_NAME ] = CompIsbComObjName;
+    CompExprFuncs[ EXPR_ISB_COMOBJ_EXPR ] = CompIsbComObjExpr;
 
-    CompExprFuncs[ T_FUNCCALL_OPTS   ] = CompFunccallOpts;
+    CompExprFuncs[ EXPR_FUNCCALL_OPTS   ] = CompFunccallOpts;
     
     /* enter the boolean expression compilers into the table               */
     for ( i = 0; i < 256; i++ ) {
         CompBoolExprFuncs[ i ] = CompUnknownBool;
     }
 
-    CompBoolExprFuncs[ T_OR              ] = CompOrBool;
-    CompBoolExprFuncs[ T_AND             ] = CompAndBool;
-    CompBoolExprFuncs[ T_NOT             ] = CompNotBool;
-    CompBoolExprFuncs[ T_EQ              ] = CompEqBool;
-    CompBoolExprFuncs[ T_NE              ] = CompNeBool;
-    CompBoolExprFuncs[ T_LT              ] = CompLtBool;
-    CompBoolExprFuncs[ T_GE              ] = CompGeBool;
-    CompBoolExprFuncs[ T_GT              ] = CompGtBool;
-    CompBoolExprFuncs[ T_LE              ] = CompLeBool;
-    CompBoolExprFuncs[ T_IN              ] = CompInBool;
+    CompBoolExprFuncs[ EXPR_OR              ] = CompOrBool;
+    CompBoolExprFuncs[ EXPR_AND             ] = CompAndBool;
+    CompBoolExprFuncs[ EXPR_NOT             ] = CompNotBool;
+    CompBoolExprFuncs[ EXPR_EQ              ] = CompEqBool;
+    CompBoolExprFuncs[ EXPR_NE              ] = CompNeBool;
+    CompBoolExprFuncs[ EXPR_LT              ] = CompLtBool;
+    CompBoolExprFuncs[ EXPR_GE              ] = CompGeBool;
+    CompBoolExprFuncs[ EXPR_GT              ] = CompGtBool;
+    CompBoolExprFuncs[ EXPR_LE              ] = CompLeBool;
+    CompBoolExprFuncs[ EXPR_IN              ] = CompInBool;
 
     /* enter the statement compilers into the table                        */
     for ( i = 0; i < 256; i++ ) {
         CompStatFuncs[ i ] = CompUnknownStat;
     }
 
-    CompStatFuncs[ T_PROCCALL_0ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_1ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_2ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_3ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_4ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_5ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_6ARGS  ] = CompProccall0to6Args;
-    CompStatFuncs[ T_PROCCALL_XARGS  ] = CompProccallXArgs;
+    CompStatFuncs[ STAT_PROCCALL_0ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_1ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_2ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_3ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_4ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_5ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_6ARGS  ] = CompProccall0to6Args;
+    CompStatFuncs[ STAT_PROCCALL_XARGS  ] = CompProccallXArgs;
 
-    CompStatFuncs[ T_SEQ_STAT        ] = CompSeqStat;
-    CompStatFuncs[ T_SEQ_STAT2       ] = CompSeqStat;
-    CompStatFuncs[ T_SEQ_STAT3       ] = CompSeqStat;
-    CompStatFuncs[ T_SEQ_STAT4       ] = CompSeqStat;
-    CompStatFuncs[ T_SEQ_STAT5       ] = CompSeqStat;
-    CompStatFuncs[ T_SEQ_STAT6       ] = CompSeqStat;
-    CompStatFuncs[ T_SEQ_STAT7       ] = CompSeqStat;
-    CompStatFuncs[ T_IF              ] = CompIf;
-    CompStatFuncs[ T_IF_ELSE         ] = CompIf;
-    CompStatFuncs[ T_IF_ELIF         ] = CompIf;
-    CompStatFuncs[ T_IF_ELIF_ELSE    ] = CompIf;
-    CompStatFuncs[ T_FOR             ] = CompFor;
-    CompStatFuncs[ T_FOR2            ] = CompFor;
-    CompStatFuncs[ T_FOR3            ] = CompFor;
-    CompStatFuncs[ T_FOR_RANGE       ] = CompFor;
-    CompStatFuncs[ T_FOR_RANGE2      ] = CompFor;
-    CompStatFuncs[ T_FOR_RANGE3      ] = CompFor;
-    CompStatFuncs[ T_WHILE           ] = CompWhile;
-    CompStatFuncs[ T_WHILE2          ] = CompWhile;
-    CompStatFuncs[ T_WHILE3          ] = CompWhile;
-    CompStatFuncs[ T_REPEAT          ] = CompRepeat;
-    CompStatFuncs[ T_REPEAT2         ] = CompRepeat;
-    CompStatFuncs[ T_REPEAT3         ] = CompRepeat;
-    CompStatFuncs[ T_BREAK           ] = CompBreak;
-    CompStatFuncs[ T_CONTINUE        ] = CompContinue;
-    CompStatFuncs[ T_RETURN_OBJ      ] = CompReturnObj;
-    CompStatFuncs[ T_RETURN_VOID     ] = CompReturnVoid;
+    CompStatFuncs[ STAT_SEQ_STAT        ] = CompSeqStat;
+    CompStatFuncs[ STAT_SEQ_STAT2       ] = CompSeqStat;
+    CompStatFuncs[ STAT_SEQ_STAT3       ] = CompSeqStat;
+    CompStatFuncs[ STAT_SEQ_STAT4       ] = CompSeqStat;
+    CompStatFuncs[ STAT_SEQ_STAT5       ] = CompSeqStat;
+    CompStatFuncs[ STAT_SEQ_STAT6       ] = CompSeqStat;
+    CompStatFuncs[ STAT_SEQ_STAT7       ] = CompSeqStat;
+    CompStatFuncs[ STAT_IF              ] = CompIf;
+    CompStatFuncs[ STAT_IF_ELSE         ] = CompIf;
+    CompStatFuncs[ STAT_IF_ELIF         ] = CompIf;
+    CompStatFuncs[ STAT_IF_ELIF_ELSE    ] = CompIf;
+    CompStatFuncs[ STAT_FOR             ] = CompFor;
+    CompStatFuncs[ STAT_FOR2            ] = CompFor;
+    CompStatFuncs[ STAT_FOR3            ] = CompFor;
+    CompStatFuncs[ STAT_FOR_RANGE       ] = CompFor;
+    CompStatFuncs[ STAT_FOR_RANGE2      ] = CompFor;
+    CompStatFuncs[ STAT_FOR_RANGE3      ] = CompFor;
+    CompStatFuncs[ STAT_WHILE           ] = CompWhile;
+    CompStatFuncs[ STAT_WHILE2          ] = CompWhile;
+    CompStatFuncs[ STAT_WHILE3          ] = CompWhile;
+    CompStatFuncs[ STAT_REPEAT          ] = CompRepeat;
+    CompStatFuncs[ STAT_REPEAT2         ] = CompRepeat;
+    CompStatFuncs[ STAT_REPEAT3         ] = CompRepeat;
+    CompStatFuncs[ STAT_BREAK           ] = CompBreak;
+    CompStatFuncs[ STAT_CONTINUE        ] = CompContinue;
+    CompStatFuncs[ STAT_RETURN_OBJ      ] = CompReturnObj;
+    CompStatFuncs[ STAT_RETURN_VOID     ] = CompReturnVoid;
 
-    CompStatFuncs[ T_ASS_LVAR        ] = CompAssLVar;
-    CompStatFuncs[ T_UNB_LVAR        ] = CompUnbLVar;
-    CompStatFuncs[ T_ASS_HVAR        ] = CompAssHVar;
-    CompStatFuncs[ T_UNB_HVAR        ] = CompUnbHVar;
-    CompStatFuncs[ T_ASS_GVAR        ] = CompAssGVar;
-    CompStatFuncs[ T_UNB_GVAR        ] = CompUnbGVar;
+    CompStatFuncs[ STAT_ASS_LVAR        ] = CompAssLVar;
+    CompStatFuncs[ STAT_UNB_LVAR        ] = CompUnbLVar;
+    CompStatFuncs[ STAT_ASS_HVAR        ] = CompAssHVar;
+    CompStatFuncs[ STAT_UNB_HVAR        ] = CompUnbHVar;
+    CompStatFuncs[ STAT_ASS_GVAR        ] = CompAssGVar;
+    CompStatFuncs[ STAT_UNB_GVAR        ] = CompUnbGVar;
 
-    CompStatFuncs[ T_ASS_LIST        ] = CompAssList;
-    CompStatFuncs[ T_ASSS_LIST       ] = CompAsssList;
-    CompStatFuncs[ T_ASS_LIST_LEV    ] = CompAssListLev;
-    CompStatFuncs[ T_ASSS_LIST_LEV   ] = CompAsssListLev;
-    CompStatFuncs[ T_UNB_LIST        ] = CompUnbList;
-    CompStatFuncs[ T_ASS_REC_NAME    ] = CompAssRecName;
-    CompStatFuncs[ T_ASS_REC_EXPR    ] = CompAssRecExpr;
-    CompStatFuncs[ T_UNB_REC_NAME    ] = CompUnbRecName;
-    CompStatFuncs[ T_UNB_REC_EXPR    ] = CompUnbRecExpr;
+    CompStatFuncs[ STAT_ASS_LIST        ] = CompAssList;
+    CompStatFuncs[ STAT_ASSS_LIST       ] = CompAsssList;
+    CompStatFuncs[ STAT_ASS_LIST_LEV    ] = CompAssListLev;
+    CompStatFuncs[ STAT_ASSS_LIST_LEV   ] = CompAsssListLev;
+    CompStatFuncs[ STAT_UNB_LIST        ] = CompUnbList;
+    CompStatFuncs[ STAT_ASS_REC_NAME    ] = CompAssRecName;
+    CompStatFuncs[ STAT_ASS_REC_EXPR    ] = CompAssRecExpr;
+    CompStatFuncs[ STAT_UNB_REC_NAME    ] = CompUnbRecName;
+    CompStatFuncs[ STAT_UNB_REC_EXPR    ] = CompUnbRecExpr;
 
-    CompStatFuncs[ T_ASS_POSOBJ      ] = CompAssPosObj;
-    CompStatFuncs[ T_UNB_POSOBJ      ] = CompUnbPosObj;
-    CompStatFuncs[ T_ASS_COMOBJ_NAME ] = CompAssComObjName;
-    CompStatFuncs[ T_ASS_COMOBJ_EXPR ] = CompAssComObjExpr;
-    CompStatFuncs[ T_UNB_COMOBJ_NAME ] = CompUnbComObjName;
-    CompStatFuncs[ T_UNB_COMOBJ_EXPR ] = CompUnbComObjExpr;
+    CompStatFuncs[ STAT_ASS_POSOBJ      ] = CompAssPosObj;
+    CompStatFuncs[ STAT_UNB_POSOBJ      ] = CompUnbPosObj;
+    CompStatFuncs[ STAT_ASS_COMOBJ_NAME ] = CompAssComObjName;
+    CompStatFuncs[ STAT_ASS_COMOBJ_EXPR ] = CompAssComObjExpr;
+    CompStatFuncs[ STAT_UNB_COMOBJ_NAME ] = CompUnbComObjName;
+    CompStatFuncs[ STAT_UNB_COMOBJ_EXPR ] = CompUnbComObjExpr;
 
-    CompStatFuncs[ T_INFO            ] = CompInfo;
-    CompStatFuncs[ T_ASSERT_2ARGS    ] = CompAssert2;
-    CompStatFuncs[ T_ASSERT_3ARGS    ] = CompAssert3;
-    CompStatFuncs[ T_EMPTY           ] = CompEmpty;
+    CompStatFuncs[ STAT_INFO            ] = CompInfo;
+    CompStatFuncs[ STAT_ASSERT_2ARGS    ] = CompAssert2;
+    CompStatFuncs[ STAT_ASSERT_3ARGS    ] = CompAssert3;
+    CompStatFuncs[ STAT_EMPTY           ] = CompEmpty;
 
-    CompStatFuncs[ T_PROCCALL_OPTS   ] = CompProccallOpts;
+    CompStatFuncs[ STAT_PROCCALL_OPTS   ] = CompProccallOpts;
     /* return success                                                      */
     return 0;
 }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -62,7 +62,7 @@ static Int CompFastListFuncs;
 
 /****************************************************************************
 **
-*V  CompCheckTypes  . . . . option to emit code that assumes all types are ok.
+*V  CompCheckTypes . . . . option to emit code that assumes all types are ok.
 */
 static Int CompCheckTypes;
 
@@ -1030,7 +1030,7 @@ static CVar CompFunccall0to6Args(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  EXPR_FUNCCALL_XARGS
+*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . EXPR_FUNCCALL_XARGS
 */
 static CVar CompFunccallXArgs(Expr expr)
 {
@@ -1087,7 +1087,7 @@ static CVar CompFunccallXArgs(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . . .  EXPR_FUNCCALL_OPTS
+*F  CompFunccallXArgs( <expr> ) . . . . . . . . . . . . .  EXPR_FUNCCALL_OPTS
 */
 static CVar CompFunccallOpts(Expr expr)
 {
@@ -1109,7 +1109,7 @@ static CVar CompFunccallOpts(Expr expr)
 
 /****************************************************************************
 **
-*F  CompFuncExpr( <expr> )  . . . . . . . . . . . . . . . . . . . EXPR_FUNC
+*F  CompFuncExpr( <expr> ) . . . . . . . . . . . . . . . . . . . .  EXPR_FUNC
 */
 static CVar CompFuncExpr(Expr expr)
 {
@@ -1165,7 +1165,7 @@ static CVar CompFuncExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompOr( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_OR
+*F  CompOr( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_OR
 */
 static CVar CompOr(Expr expr)
 {
@@ -1204,7 +1204,7 @@ static CVar CompOr(Expr expr)
 
 /****************************************************************************
 **
-*F  CompOrBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_OR
+*F  CompOrBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . .  EXPR_OR
 */
 static CVar CompOrBool(Expr expr)
 {
@@ -1243,7 +1243,7 @@ static CVar CompOrBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompAnd( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_AND
+*F  CompAnd( <expr> ) . . . . . . . . . . . . . . . . . . . . . . .  EXPR_AND
 */
 static CVar CompAnd(Expr expr)
 {
@@ -1301,7 +1301,7 @@ static CVar CompAnd(Expr expr)
 
 /****************************************************************************
 **
-*F  CompAndBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . EXPR_AND
+*F  CompAndBool( <expr> ) . . . . . . . . . . . . . . . . . . . . .  EXPR_AND
 */
 static CVar CompAndBool(Expr expr)
 {
@@ -1340,7 +1340,7 @@ static CVar CompAndBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . . EXPR_NOT
+*F  CompNot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . .  EXPR_NOT
 */
 static CVar CompNot(Expr expr)
 {
@@ -1369,7 +1369,7 @@ static CVar CompNot(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNotBoot( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . EXPR_NOT
+*F  CompNotBoot( <expr> ) . . . . . . . . . . . . . . . . . . . . .  EXPR_NOT
 */
 static CVar CompNotBool(Expr expr)
 {
@@ -1398,7 +1398,7 @@ static CVar CompNotBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompEq( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_EQ
+*F  CompEq( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_EQ
 */
 static CVar CompEq(Expr expr)
 {
@@ -1435,7 +1435,7 @@ static CVar CompEq(Expr expr)
 
 /****************************************************************************
 **
-*F  CompEqBool( <expr> )  . . . . . . . . . . . . . . . . . . . . . . .  EXPR_EQ
+*F  CompEqBool( <expr> ) . . . . . . . . . . . . . . . . . . . . . .  EXPR_EQ
 */
 static CVar CompEqBool(Expr expr)
 {
@@ -1472,7 +1472,7 @@ static CVar CompEqBool(Expr expr)
 
 /****************************************************************************
 **
-*F  CompNe( <expr> )  . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_NE
+*F  CompNe( <expr> ) . . . . . . . . . . . . . . . . . . . . . . . . .  EXPR_NE
 */
 static CVar CompNe(Expr expr)
 {

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -117,7 +117,7 @@ static Obj EvalUnknownBool(Expr expr)
 **  'EvalOr' evaluates the or-expression <expr> and  returns its value, i.e.,
 **  'true'  if  either of  the operands  is  'true',  and 'false'  otherwise.
 **  'EvalOr'  is   called from  'EVAL_EXPR' to  evaluate  expressions of type
-**  'T_OR'.
+**  'EXPR_OR'.
 **
 **  If '<expr>.left'  is   already  'true' 'EvalOr'  returns  'true'  without
 **  evaluating '<expr>.right'.  This allows constructs like
@@ -149,7 +149,7 @@ static Obj EvalOr(Expr expr)
 **  'EvalAnd'  evaluates  the and-expression <expr>   and  returns its value,
 **  i.e.,   'true'  if both  operands  are   'true',  and  'false' otherwise.
 **  'EvalAnd' is called from   'EVAL_EXPR' to  evaluate expressions  of  type
-**  'T_AND'.
+**  'EXPR_AND'.
 **
 **  If '<expr>.left' is  already  'false' 'EvalAnd' returns 'false'   without
 **  evaluating '<expr>.right'.  This allows constructs like
@@ -199,7 +199,7 @@ static Obj EvalAnd(Expr expr)
 **
 **  'EvalNot'  evaluates the  not-expression  <expr>  and returns its  value,
 **  i.e., 'true' if the operand is 'false', and 'false' otherwise.  'EvalNot'
-**  is called from 'EVAL_EXPR' to evaluate expressions of type 'T_NOT'.
+**  is called from 'EVAL_EXPR' to evaluate expressions of type 'EXPR_NOT'.
 */
 static Obj EvalNot(Expr expr)
 {
@@ -226,7 +226,7 @@ static Obj EvalNot(Expr expr)
 **  'EvalEq' evaluates the  equality-expression <expr> and returns its value,
 **  i.e.,  'true' if  the  operand '<expr>.left'   is equal  to  the  operand
 **  '<expr>.right'   and   'false'  otherwise.   'EvalEq'  is   called   from
-**  'EVAL_EXPR' to evaluate expressions of type 'T_EQ'.
+**  'EVAL_EXPR' to evaluate expressions of type 'EXPR_EQ'.
 **
 **  'EvalEq' evaluates the operands and then calls the 'EQ' macro.
 */
@@ -259,7 +259,7 @@ static Obj EvalEq(Expr expr)
 **  'EvalNe'   evaluates the  comparison-expression  <expr>  and  returns its
 **  value, i.e.,  'true'  if the operand   '<expr>.left' is not equal  to the
 **  operand  '<expr>.right' and  'false' otherwise.  'EvalNe'  is called from
-**  'EVAL_EXPR' to evaluate expressions of type 'T_LT'.
+**  'EVAL_EXPR' to evaluate expressions of type 'EXPR_LT'.
 **
 **  'EvalNe' is simply implemented as 'not <objL> = <objR>'.
 */
@@ -292,7 +292,7 @@ static Obj EvalNe(Expr expr)
 **  'EvalLt' evaluates  the  comparison-expression   <expr> and  returns  its
 **  value, i.e., 'true' if the operand '<expr>.left' is less than the operand
 **  '<expr>.right'  and  'false'   otherwise.    'EvalLt'  is   called   from
-**  'EVAL_EXPR' to evaluate expressions of type 'T_LT'.
+**  'EVAL_EXPR' to evaluate expressions of type 'EXPR_LT'.
 **
 **  'EvalLt' evaluates the operands and then calls the 'LT' macro.
 */
@@ -325,7 +325,7 @@ static Obj EvalLt(Expr expr)
 **  'EvalGe'  evaluates  the comparison-expression   <expr>  and returns  its
 **  value, i.e., 'true' if the operand '<expr>.left' is greater than or equal
 **  to the operand '<expr>.right' and 'false'  otherwise.  'EvalGe' is called
-**  from 'EVAL_EXPR' to evaluate expressions of type 'T_GE'.
+**  from 'EVAL_EXPR' to evaluate expressions of type 'EXPR_GE'.
 **
 **  'EvalGe' is simply implemented as 'not <objL> < <objR>'.
 */
@@ -358,7 +358,7 @@ static Obj EvalGe(Expr expr)
 **  'EvalGt'  evaluates  the  comparison-expression <expr>   and  returns its
 **  value, i.e.,  'true' if the  operand  '<expr>.left' is  greater than  the
 **  operand '<expr>.right' and 'false' otherwise.    'EvalGt' is called  from
-**  'EVAL_EXPR' to evaluate expressions of type 'T_GT'.
+**  'EVAL_EXPR' to evaluate expressions of type 'EXPR_GT'.
 **
 **  'EvalGt' is simply implemented as '<objR> < <objL>'.
 */
@@ -391,7 +391,7 @@ static Obj EvalGt(Expr expr)
 **  'EvalLe' evaluates   the comparison-expression   <expr> and  returns  its
 **  value, i.e., 'true' if the operand '<expr>.left' is  less or equal to the
 **  operand '<expr>.right' and 'false'   otherwise.  'EvalLe' is  called from
-**  'EVAL_EXPR' to evaluate expressions of type 'T_LE'.
+**  'EVAL_EXPR' to evaluate expressions of type 'EXPR_LE'.
 **
 **  'EvalLe' is simply implemented as 'not <objR> < <objR>'.
 */
@@ -424,7 +424,7 @@ static Obj EvalLe(Expr expr)
 **  'EvalIn' evaluates the in-expression <expr>  and returns its value, i.e.,
 **  'true' if  the  operand '<expr>.left'  is a  member of '<expr>.right' and
 **  'false' otherwise.    'EvalIn' is  called  from  'EVAL_EXPR'  to evaluate
-**  expressions of type 'T_IN'.
+**  expressions of type 'EXPR_IN'.
 */
 static Obj EvalIn(Expr expr)
 {
@@ -457,7 +457,7 @@ static Obj EvalIn(Expr expr)
 **  'EvalSum'  evaluates the  sum-expression  <expr> and  returns its  value,
 **  i.e., the sum of   the  two operands '<expr>.left'   and  '<expr>.right'.
 **  'EvalSum'   is called from 'EVAL_EXPR'   to  evaluate expressions of type
-**  'T_SUM'.
+**  'EXPR_SUM'.
 **
 **  'EvalSum' evaluates the operands and then calls the 'SUM' macro.
 */
@@ -494,7 +494,7 @@ static Obj EvalSum(Expr expr)
 **
 **  'EvalAInv' evaluates  the additive  inverse-expression  and  returns  its
 **  value, i.e., the  additive inverse of  the operand.  'EvalAInv' is called
-**  from 'EVAL_EXPR' to evaluate expressions of type 'T_AINV'.
+**  from 'EVAL_EXPR' to evaluate expressions of type 'EXPR_AINV'.
 **
 **  'EvalAInv' evaluates the operand and then calls the 'AINV' macro.
 */
@@ -524,7 +524,7 @@ static Obj EvalAInv(Expr expr)
 **  'EvalDiff'  evaluates  the difference-expression <expr>   and returns its
 **  value, i.e.,   the   difference of  the two  operands   '<expr>.left' and
 **  '<expr>.right'.  'EvalDiff'    is  called from   'EVAL_EXPR'  to evaluate
-**  expressions of type 'T_DIFF'.
+**  expressions of type 'EXPR_DIFF'.
 **
 **  'EvalDiff' evaluates the operands and then calls the 'DIFF' macro.
 */
@@ -562,7 +562,7 @@ static Obj EvalDiff(Expr expr)
 **  'EvalProd' evaluates the product-expression <expr>  and returns it value,
 **  i.e., the product of  the two operands '<expr>.left'  and '<expr>.right'.
 **  'EvalProd'  is called from   'EVAL_EXPR' to evaluate  expressions of type
-**  'T_PROD'.
+**  'EXPR_PROD'.
 **
 **  'EvalProd' evaluates the operands and then calls the 'PROD' macro.
 */
@@ -600,7 +600,7 @@ static Obj EvalProd(Expr expr)
 **  'EvalQuo' evaluates the quotient-expression <expr> and returns its value,
 **  i.e., the quotient of the  two operands '<expr>.left' and '<expr>.right'.
 **  'EvalQuo' is  called  from 'EVAL_EXPR' to   evaluate expressions  of type
-**  'T_QUO'.
+**  'EXPR_QUO'.
 **
 **  'EvalQuo' evaluates the operands and then calls the 'QUO' macro.
 */
@@ -633,7 +633,7 @@ static Obj EvalQuo(Expr expr)
 **  'EvalMod' evaluates the  remainder-expression   <expr> and returns    its
 **  value, i.e.,  the  remainder  of   the two  operands   '<expr>.left'  and
 **  '<expr>.right'.  'EvalMod'  is   called   from  'EVAL_EXPR'  to  evaluate
-**  expressions of type 'T_MOD'.
+**  expressions of type 'EXPR_MOD'.
 **
 **  'EvalMod' evaluates the operands and then calls the 'MOD' macro.
 */
@@ -666,7 +666,7 @@ static Obj EvalMod(Expr expr)
 **  'EvalPow'  evaluates the power-expression  <expr>  and returns its value,
 **  i.e.,   the power of the  two  operands '<expr>.left' and '<expr>.right'.
 **  'EvalPow' is called  from  'EVAL_EXPR'  to evaluate expressions  of  type
-**  'T_POW'.
+**  'EXPR_POW'.
 **
 **  'EvalPow' evaluates the operands and then calls the 'POW' macro.
 */
@@ -1337,21 +1337,21 @@ static void PrintBinop(Expr expr)
 
     /* select the new precedence level                                    */
     switch ( TNUM_EXPR(expr) ) {
-    case T_OR:     op = "or";   PrintPrecedence =  2;  break;
-    case T_AND:    op = "and";  PrintPrecedence =  4;  break;
-    case T_EQ:     op = "=";    PrintPrecedence =  8;  break;
-    case T_LT:     op = "<";    PrintPrecedence =  8;  break;
-    case T_GT:     op = ">";    PrintPrecedence =  8;  break;
-    case T_NE:     op = "<>";   PrintPrecedence =  8;  break;
-    case T_LE:     op = "<=";   PrintPrecedence =  8;  break;
-    case T_GE:     op = ">=";   PrintPrecedence =  8;  break;
-    case T_IN:     op = "in";   PrintPrecedence =  8;  break;
-    case T_SUM:    op = "+";    PrintPrecedence = 10;  break;
-    case T_DIFF:   op = "-";    PrintPrecedence = 10;  break;
-    case T_PROD:   op = "*";    PrintPrecedence = 12;  break;
-    case T_QUO:    op = "/";    PrintPrecedence = 12;  break;
-    case T_MOD:    op = "mod";  PrintPrecedence = 12;  break;
-    case T_POW:    op = "^";    PrintPrecedence = 16;  break;
+    case EXPR_OR:     op = "or";   PrintPrecedence =  2;  break;
+    case EXPR_AND:    op = "and";  PrintPrecedence =  4;  break;
+    case EXPR_EQ:     op = "=";    PrintPrecedence =  8;  break;
+    case EXPR_LT:     op = "<";    PrintPrecedence =  8;  break;
+    case EXPR_GT:     op = ">";    PrintPrecedence =  8;  break;
+    case EXPR_NE:     op = "<>";   PrintPrecedence =  8;  break;
+    case EXPR_LE:     op = "<=";   PrintPrecedence =  8;  break;
+    case EXPR_GE:     op = ">=";   PrintPrecedence =  8;  break;
+    case EXPR_IN:     op = "in";   PrintPrecedence =  8;  break;
+    case EXPR_SUM:    op = "+";    PrintPrecedence = 10;  break;
+    case EXPR_DIFF:   op = "-";    PrintPrecedence = 10;  break;
+    case EXPR_PROD:   op = "*";    PrintPrecedence = 12;  break;
+    case EXPR_QUO:    op = "/";    PrintPrecedence = 12;  break;
+    case EXPR_MOD:    op = "mod";  PrintPrecedence = 12;  break;
+    case EXPR_POW:    op = "^";    PrintPrecedence = 16;  break;
     default:       op = "<bogus-operator>";   break;
     }
 
@@ -1360,11 +1360,11 @@ static void PrintBinop(Expr expr)
     else Pr("%2>",0L,0L);
 
     /* print the left operand                                              */
-    if ( TNUM_EXPR(expr) == T_POW
+    if ( TNUM_EXPR(expr) == EXPR_POW
          && ((  (IS_INTEXPR(READ_EXPR(expr, 0))
                  && INT_INTEXPR(READ_EXPR(expr, 0)) < 0)
                 || TNUM_EXPR(READ_EXPR(expr, 0)) == T_INTNEG)
-             || TNUM_EXPR(READ_EXPR(expr, 0)) == T_POW) ) {
+             || TNUM_EXPR(READ_EXPR(expr, 0)) == EXPR_POW) ) {
         Pr( "(", 0L, 0L );
         PrintExpr(READ_EXPR(expr, 0));
         Pr( ")", 0L, 0L );
@@ -1682,59 +1682,59 @@ static Int InitKernel (
     }
 
     /* install the evaluators for logical operations                       */
-    InstallEvalExprFunc( T_OR             , EvalOr);   
-    InstallEvalExprFunc( T_AND            , EvalAnd);  
-    InstallEvalExprFunc( T_NOT            , EvalNot);  
+    InstallEvalExprFunc( EXPR_OR             , EvalOr);   
+    InstallEvalExprFunc( EXPR_AND            , EvalAnd);  
+    InstallEvalExprFunc( EXPR_NOT            , EvalNot);  
 
     /* the logical operations are guaranteed to return booleans            */
-    InstallEvalBoolFunc( T_OR             , EvalOr);
-    InstallEvalBoolFunc( T_AND            , EvalAnd);
-    InstallEvalBoolFunc( T_NOT            , EvalNot);
+    InstallEvalBoolFunc( EXPR_OR             , EvalOr);
+    InstallEvalBoolFunc( EXPR_AND            , EvalAnd);
+    InstallEvalBoolFunc( EXPR_NOT            , EvalNot);
 
     /* install the evaluators for comparison operations                    */
-    InstallEvalExprFunc( T_EQ             , EvalEq);   
-    InstallEvalExprFunc( T_NE             , EvalNe);   
-    InstallEvalExprFunc( T_LT             , EvalLt);   
-    InstallEvalExprFunc( T_GE             , EvalGe);   
-    InstallEvalExprFunc( T_GT             , EvalGt);   
-    InstallEvalExprFunc( T_LE             , EvalLe);   
-    InstallEvalExprFunc( T_IN             , EvalIn);     
+    InstallEvalExprFunc( EXPR_EQ             , EvalEq);   
+    InstallEvalExprFunc( EXPR_NE             , EvalNe);   
+    InstallEvalExprFunc( EXPR_LT             , EvalLt);   
+    InstallEvalExprFunc( EXPR_GE             , EvalGe);   
+    InstallEvalExprFunc( EXPR_GT             , EvalGt);   
+    InstallEvalExprFunc( EXPR_LE             , EvalLe);   
+    InstallEvalExprFunc( EXPR_IN             , EvalIn);     
 
     /* the comparison operations are guaranteed to return booleans         */
-    InstallEvalBoolFunc( T_EQ             , EvalEq);
-    InstallEvalBoolFunc( T_NE             , EvalNe);
-    InstallEvalBoolFunc( T_LT             , EvalLt);
-    InstallEvalBoolFunc( T_GE             , EvalGe);
-    InstallEvalBoolFunc( T_GT             , EvalGt);
-    InstallEvalBoolFunc( T_LE             , EvalLe);
-    InstallEvalBoolFunc( T_IN             , EvalIn);
+    InstallEvalBoolFunc( EXPR_EQ             , EvalEq);
+    InstallEvalBoolFunc( EXPR_NE             , EvalNe);
+    InstallEvalBoolFunc( EXPR_LT             , EvalLt);
+    InstallEvalBoolFunc( EXPR_GE             , EvalGe);
+    InstallEvalBoolFunc( EXPR_GT             , EvalGt);
+    InstallEvalBoolFunc( EXPR_LE             , EvalLe);
+    InstallEvalBoolFunc( EXPR_IN             , EvalIn);
 
     /* install the evaluators for binary operations                        */
-    InstallEvalExprFunc( T_SUM            , EvalSum);
-    InstallEvalExprFunc( T_AINV           , EvalAInv);
-    InstallEvalExprFunc( T_DIFF           , EvalDiff);
-    InstallEvalExprFunc( T_PROD           , EvalProd);
-    InstallEvalExprFunc( T_QUO            , EvalQuo);
-    InstallEvalExprFunc( T_MOD            , EvalMod);
-    InstallEvalExprFunc( T_POW            , EvalPow);
+    InstallEvalExprFunc( EXPR_SUM            , EvalSum);
+    InstallEvalExprFunc( EXPR_AINV           , EvalAInv);
+    InstallEvalExprFunc( EXPR_DIFF           , EvalDiff);
+    InstallEvalExprFunc( EXPR_PROD           , EvalProd);
+    InstallEvalExprFunc( EXPR_QUO            , EvalQuo);
+    InstallEvalExprFunc( EXPR_MOD            , EvalMod);
+    InstallEvalExprFunc( EXPR_POW            , EvalPow);
 
     /* install the evaluators for literal expressions                      */
-    InstallEvalExprFunc( T_INT_EXPR       , EvalIntExpr);
-    InstallEvalExprFunc( T_TRUE_EXPR      , EvalTrueExpr);
-    InstallEvalExprFunc( T_FALSE_EXPR     , EvalFalseExpr);
-    InstallEvalExprFunc( T_TILDE_EXPR     , EvalTildeExpr);
-    InstallEvalExprFunc( T_CHAR_EXPR      , EvalCharExpr);
-    InstallEvalExprFunc( T_PERM_EXPR      , EvalPermExpr);
-    InstallEvalExprFunc( T_FLOAT_EXPR_LAZY  , EvalFloatExprLazy);
-    InstallEvalExprFunc( T_FLOAT_EXPR_EAGER , EvalFloatExprEager);
+    InstallEvalExprFunc( EXPR_INTPOS       , EvalIntExpr);
+    InstallEvalExprFunc( EXPR_TRUE      , EvalTrueExpr);
+    InstallEvalExprFunc( EXPR_FALSE     , EvalFalseExpr);
+    InstallEvalExprFunc( EXPR_TILDE     , EvalTildeExpr);
+    InstallEvalExprFunc( EXPR_CHAR      , EvalCharExpr);
+    InstallEvalExprFunc( EXPR_PERM      , EvalPermExpr);
+    InstallEvalExprFunc( EXPR_FLOAT_LAZY  , EvalFloatExprLazy);
+    InstallEvalExprFunc( EXPR_FLOAT_EAGER , EvalFloatExprEager);
 
     /* install the evaluators for list and record expressions              */
-    InstallEvalExprFunc( T_LIST_EXPR      , EvalListExpr);
-    InstallEvalExprFunc( T_LIST_TILDE_EXPR, EvalListTildeExpr);
-    InstallEvalExprFunc( T_RANGE_EXPR     , EvalRangeExpr);
-    InstallEvalExprFunc( T_STRING_EXPR    , EvalStringExpr);
-    InstallEvalExprFunc( T_REC_EXPR       , EvalRecExpr);
-    InstallEvalExprFunc( T_REC_TILDE_EXPR , EvalRecTildeExpr);
+    InstallEvalExprFunc( EXPR_LIST      , EvalListExpr);
+    InstallEvalExprFunc( EXPR_LIST_TILDE, EvalListTildeExpr);
+    InstallEvalExprFunc( EXPR_RANGE     , EvalRangeExpr);
+    InstallEvalExprFunc( EXPR_STRING    , EvalStringExpr);
+    InstallEvalExprFunc( EXPR_REC       , EvalRecExpr);
+    InstallEvalExprFunc( EXPR_REC_TILDE , EvalRecTildeExpr);
 
     /* clear the tables for the printing dispatching                       */
     for ( type = 0; type < 256; type++ ) {
@@ -1742,46 +1742,46 @@ static Int InitKernel (
     }
 
     /* install the printers for logical operations                         */
-    InstallPrintExprFunc( T_OR             , PrintBinop);
-    InstallPrintExprFunc( T_AND            , PrintBinop);
-    InstallPrintExprFunc( T_NOT            , PrintNot);
+    InstallPrintExprFunc( EXPR_OR             , PrintBinop);
+    InstallPrintExprFunc( EXPR_AND            , PrintBinop);
+    InstallPrintExprFunc( EXPR_NOT            , PrintNot);
 
     /* install the printers for comparison operations                      */
-    InstallPrintExprFunc( T_EQ             , PrintBinop);
-    InstallPrintExprFunc( T_LT             , PrintBinop);
-    InstallPrintExprFunc( T_NE             , PrintBinop);
-    InstallPrintExprFunc( T_GE             , PrintBinop);
-    InstallPrintExprFunc( T_GT             , PrintBinop);
-    InstallPrintExprFunc( T_LE             , PrintBinop);
-    InstallPrintExprFunc( T_IN             , PrintBinop);
+    InstallPrintExprFunc( EXPR_EQ             , PrintBinop);
+    InstallPrintExprFunc( EXPR_LT             , PrintBinop);
+    InstallPrintExprFunc( EXPR_NE             , PrintBinop);
+    InstallPrintExprFunc( EXPR_GE             , PrintBinop);
+    InstallPrintExprFunc( EXPR_GT             , PrintBinop);
+    InstallPrintExprFunc( EXPR_LE             , PrintBinop);
+    InstallPrintExprFunc( EXPR_IN             , PrintBinop);
 
     /* install the printers for binary operations                          */
-    InstallPrintExprFunc( T_SUM            , PrintBinop);
-    InstallPrintExprFunc( T_AINV           , PrintAInv);
-    InstallPrintExprFunc( T_DIFF           , PrintBinop);
-    InstallPrintExprFunc( T_PROD           , PrintBinop);
-    InstallPrintExprFunc( T_QUO            , PrintBinop);
-    InstallPrintExprFunc( T_MOD            , PrintBinop);
-    InstallPrintExprFunc( T_POW            , PrintBinop);
+    InstallPrintExprFunc( EXPR_SUM            , PrintBinop);
+    InstallPrintExprFunc( EXPR_AINV           , PrintAInv);
+    InstallPrintExprFunc( EXPR_DIFF           , PrintBinop);
+    InstallPrintExprFunc( EXPR_PROD           , PrintBinop);
+    InstallPrintExprFunc( EXPR_QUO            , PrintBinop);
+    InstallPrintExprFunc( EXPR_MOD            , PrintBinop);
+    InstallPrintExprFunc( EXPR_POW            , PrintBinop);
 
     /* install the printers for literal expressions                        */
-    InstallPrintExprFunc( T_INTEXPR        , PrintIntExpr);
-    InstallPrintExprFunc( T_INT_EXPR       , PrintIntExpr);
-    InstallPrintExprFunc( T_TRUE_EXPR      , PrintTrueExpr);
-    InstallPrintExprFunc( T_FALSE_EXPR     , PrintFalseExpr);
-    InstallPrintExprFunc( T_TILDE_EXPR     , PrintTildeExpr);
-    InstallPrintExprFunc( T_CHAR_EXPR      , PrintCharExpr);
-    InstallPrintExprFunc( T_PERM_EXPR      , PrintPermExpr);
-    InstallPrintExprFunc( T_FLOAT_EXPR_LAZY  , PrintFloatExprLazy);
-    InstallPrintExprFunc( T_FLOAT_EXPR_EAGER , PrintFloatExprEager);
+    InstallPrintExprFunc( EXPR_INT        , PrintIntExpr);
+    InstallPrintExprFunc( EXPR_INTPOS       , PrintIntExpr);
+    InstallPrintExprFunc( EXPR_TRUE      , PrintTrueExpr);
+    InstallPrintExprFunc( EXPR_FALSE     , PrintFalseExpr);
+    InstallPrintExprFunc( EXPR_TILDE     , PrintTildeExpr);
+    InstallPrintExprFunc( EXPR_CHAR      , PrintCharExpr);
+    InstallPrintExprFunc( EXPR_PERM      , PrintPermExpr);
+    InstallPrintExprFunc( EXPR_FLOAT_LAZY  , PrintFloatExprLazy);
+    InstallPrintExprFunc( EXPR_FLOAT_EAGER , PrintFloatExprEager);
 
     /* install the printers for list and record expressions                */
-    InstallPrintExprFunc( T_LIST_EXPR      , PrintListExpr);
-    InstallPrintExprFunc( T_LIST_TILDE_EXPR, PrintListExpr);
-    InstallPrintExprFunc( T_RANGE_EXPR     , PrintRangeExpr);
-    InstallPrintExprFunc( T_STRING_EXPR    , PrintStringExpr);
-    InstallPrintExprFunc( T_REC_EXPR       , PrintRecExpr);
-    InstallPrintExprFunc( T_REC_TILDE_EXPR , PrintRecExpr);
+    InstallPrintExprFunc( EXPR_LIST      , PrintListExpr);
+    InstallPrintExprFunc( EXPR_LIST_TILDE, PrintListExpr);
+    InstallPrintExprFunc( EXPR_RANGE     , PrintRangeExpr);
+    InstallPrintExprFunc( EXPR_STRING    , PrintStringExpr);
+    InstallPrintExprFunc( EXPR_REC       , PrintRecExpr);
+    InstallPrintExprFunc( EXPR_REC_TILDE , PrintRecExpr);
 
     /* return success                                                      */
     return 0;

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -22,9 +22,9 @@
 
 /****************************************************************************
 **
-*F  OBJ_REF_LVAR(<expr>) . . . . . . . . . . . value of a reference to a local
+*F  OBJ_REF_LVAR(<expr>) . . . . . . . . . . .value of a reference to a local
 **
-**  'OBJ_REF_LVAR'  returns  the value of  the reference  to a  local variable
+**  'OBJ_REF_LVAR' returns the value of the reference to a local variable
 **  <expr>.
 */
 EXPORT_INLINE Obj OBJ_REF_LVAR(Expr expr)

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -22,14 +22,14 @@
 
 /****************************************************************************
 **
-*F  OBJ_REFLVAR(<expr>) . . . . . . . . . . . value of a reference to a local
+*F  OBJ_REF_LVAR(<expr>) . . . . . . . . . . . value of a reference to a local
 **
-**  'OBJ_REFLVAR'  returns  the value of  the reference  to a  local variable
+**  'OBJ_REF_LVAR'  returns  the value of  the reference  to a  local variable
 **  <expr>.
 */
-EXPORT_INLINE Obj OBJ_REFLVAR(Expr expr)
+EXPORT_INLINE Obj OBJ_REF_LVAR(Expr expr)
 {
-    Int lvar = LVAR_REFLVAR(expr);
+    Int lvar = LVAR_REF_LVAR(expr);
     if (OBJ_LVAR(lvar) != 0) {
         return OBJ_LVAR(lvar);
     }
@@ -88,8 +88,8 @@ extern Obj (*EvalExprFuncs[256])(Expr expr);
 
 EXPORT_INLINE Obj EVAL_EXPR(Expr expr)
 {
-    if (IS_REFLVAR(expr)) {
-        return OBJ_REFLVAR(expr);
+    if (IS_REF_LVAR(expr)) {
+        return OBJ_REF_LVAR(expr);
     }
     else if (IS_INTEXPR(expr)) {
         return OBJ_INTEXPR(expr);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -873,47 +873,47 @@ static Int InitKernel (
     InitHandlerFunc( DoPartialUnWrapFunc, "pUW");
 
     /* install the evaluators and executors                                */
-    InstallExecStatFunc( T_PROCCALL_0ARGS , ExecProccall0args);
-    InstallExecStatFunc( T_PROCCALL_1ARGS , ExecProccall1args);
-    InstallExecStatFunc( T_PROCCALL_2ARGS , ExecProccall2args);
-    InstallExecStatFunc( T_PROCCALL_3ARGS , ExecProccall3args);
-    InstallExecStatFunc( T_PROCCALL_4ARGS , ExecProccall4args);
-    InstallExecStatFunc( T_PROCCALL_5ARGS , ExecProccall5args);
-    InstallExecStatFunc( T_PROCCALL_6ARGS , ExecProccall6args);
-    InstallExecStatFunc( T_PROCCALL_XARGS , ExecProccallXargs);
-    InstallExecStatFunc( T_PROCCALL_OPTS  , ExecProccallOpts);
+    InstallExecStatFunc( STAT_PROCCALL_0ARGS , ExecProccall0args);
+    InstallExecStatFunc( STAT_PROCCALL_1ARGS , ExecProccall1args);
+    InstallExecStatFunc( STAT_PROCCALL_2ARGS , ExecProccall2args);
+    InstallExecStatFunc( STAT_PROCCALL_3ARGS , ExecProccall3args);
+    InstallExecStatFunc( STAT_PROCCALL_4ARGS , ExecProccall4args);
+    InstallExecStatFunc( STAT_PROCCALL_5ARGS , ExecProccall5args);
+    InstallExecStatFunc( STAT_PROCCALL_6ARGS , ExecProccall6args);
+    InstallExecStatFunc( STAT_PROCCALL_XARGS , ExecProccallXargs);
+    InstallExecStatFunc( STAT_PROCCALL_OPTS  , ExecProccallOpts);
 
-    InstallEvalExprFunc( T_FUNCCALL_0ARGS , EvalFunccall0args);
-    InstallEvalExprFunc( T_FUNCCALL_1ARGS , EvalFunccall1args);
-    InstallEvalExprFunc( T_FUNCCALL_2ARGS , EvalFunccall2args);
-    InstallEvalExprFunc( T_FUNCCALL_3ARGS , EvalFunccall3args);
-    InstallEvalExprFunc( T_FUNCCALL_4ARGS , EvalFunccall4args);
-    InstallEvalExprFunc( T_FUNCCALL_5ARGS , EvalFunccall5args);
-    InstallEvalExprFunc( T_FUNCCALL_6ARGS , EvalFunccall6args);
-    InstallEvalExprFunc( T_FUNCCALL_XARGS , EvalFunccallXargs);
-    InstallEvalExprFunc( T_FUNCCALL_OPTS  , EvalFunccallOpts);
-    InstallEvalExprFunc( T_FUNC_EXPR      , EvalFuncExpr);
+    InstallEvalExprFunc( EXPR_FUNCCALL_0ARGS , EvalFunccall0args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_1ARGS , EvalFunccall1args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_2ARGS , EvalFunccall2args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_3ARGS , EvalFunccall3args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_4ARGS , EvalFunccall4args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_5ARGS , EvalFunccall5args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_6ARGS , EvalFunccall6args);
+    InstallEvalExprFunc( EXPR_FUNCCALL_XARGS , EvalFunccallXargs);
+    InstallEvalExprFunc( EXPR_FUNCCALL_OPTS  , EvalFunccallOpts);
+    InstallEvalExprFunc( EXPR_FUNC      , EvalFuncExpr);
 
     /* install the printers                                                */
-    InstallPrintStatFunc( T_PROCCALL_0ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_1ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_2ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_3ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_4ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_5ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_6ARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_XARGS , PrintProccall);
-    InstallPrintStatFunc( T_PROCCALL_OPTS  , PrintProccallOpts);
-    InstallPrintExprFunc( T_FUNCCALL_0ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_1ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_2ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_3ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_4ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_5ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_6ARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_XARGS , PrintFunccall);
-    InstallPrintExprFunc( T_FUNCCALL_OPTS  , PrintFunccallOpts);
-    InstallPrintExprFunc( T_FUNC_EXPR      , PrintFuncExpr);
+    InstallPrintStatFunc( STAT_PROCCALL_0ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_1ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_2ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_3ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_4ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_5ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_6ARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_XARGS , PrintProccall);
+    InstallPrintStatFunc( STAT_PROCCALL_OPTS  , PrintProccallOpts);
+    InstallPrintExprFunc( EXPR_FUNCCALL_0ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_1ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_2ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_3ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_4ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_5ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_6ARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_XARGS , PrintFunccall);
+    InstallPrintExprFunc( EXPR_FUNCCALL_OPTS  , PrintFunccallOpts);
+    InstallPrintExprFunc( EXPR_FUNC      , PrintFuncExpr);
 
     /* return success                                                      */
     return 0;

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -118,11 +118,11 @@ static Obj ProfileEvalBoolPassthrough(Expr stat)
 {
     /* There are two cases we must pass through without touching */
     /* From TNUM_EXPR */
-    if (IS_REFLVAR(stat)) {
-        return OriginalEvalBoolFuncsForHook[T_REFLVAR](stat);
+    if (IS_REF_LVAR(stat)) {
+        return OriginalEvalBoolFuncsForHook[EXPR_REF_LVAR](stat);
     }
     if (IS_INTEXPR(stat)) {
-        return OriginalEvalBoolFuncsForHook[T_INTEXPR](stat);
+        return OriginalEvalBoolFuncsForHook[EXPR_INT](stat);
     }
     GAP_HOOK_LOOP(visitStat, stat);
     return OriginalEvalBoolFuncsForHook[TNUM_STAT(stat)](stat);

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -54,9 +54,9 @@
 // immediate objects or NULL pointers, but not on any other random data
 // #define REQUIRE_PRECISE_MARKING
 
-// if STAT_MARK_CACHE is defined, we track some statistics about the
+// if COLLECT_MARK_CACHE_STATS is defined, we track some statistics about the
 // usage of the MarkCache
-// #define STAT_MARK_CACHE
+// #define COLLECT_MARK_CACHE_STATS
 
 // if MARKING_STRESS_TEST is defined, we stress test the TryMark code
 // #define MARKING_STRESS_TEST
@@ -93,7 +93,7 @@
 // expensive call to the Julia runtime.
 
 static Bag MarkCache[MARK_CACHE_SIZE];
-#ifdef STAT_MARK_CACHE
+#ifdef COLLECT_MARK_CACHE_STATS
 static UInt MarkCacheHits, MarkCacheAttempts, MarkCacheCollisions;
 #endif
 
@@ -748,7 +748,7 @@ static void PreGCHook(int full)
     SyMsgsBags(full, 0, 0);
 #ifndef REQUIRE_PRECISE_MARKING
     memset(MarkCache, 0, sizeof(MarkCache));
-#ifdef STAT_MARK_CACHE
+#ifdef COLLECT_MARK_CACHE_STATS
     MarkCacheHits = MarkCacheAttempts = MarkCacheCollisions = 0;
 #endif
 #endif
@@ -760,7 +760,7 @@ static void PostGCHook(int full)
     /* information at the end of garbage collections                 */
     UInt totalAlloc = 0;    // FIXME -- is this data even available?
     SyMsgsBags(full, 6, totalAlloc);
-#ifdef STAT_MARK_CACHE
+#ifdef COLLECT_MARK_CACHE_STATS
     /* printf("\n>>>Attempts: %ld\nHit rate: %lf\nCollision rate: %lf\n",
       (long) MarkCacheAttempts,
       (double) MarkCacheHits/(double)MarkCacheAttempts,
@@ -1014,7 +1014,7 @@ inline void MarkBag(Bag bag)
 
     jl_value_t * p = (jl_value_t *)bag;
 #ifndef REQUIRE_PRECISE_MARKING
-#ifdef STAT_MARK_CACHE
+#ifdef COLLECT_MARK_CACHE_STATS
     MarkCacheAttempts++;
 #endif
     UInt hash = MARK_HASH((UInt)bag);
@@ -1024,14 +1024,14 @@ inline void MarkBag(Bag bag)
             // not a valid object
             return;
         }
-#ifdef STAT_MARK_CACHE
+#ifdef COLLECT_MARK_CACHE_STATS
         if (MarkCache[hash])
             MarkCacheCollisions++;
 #endif
         MarkCache[hash] = bag;
     }
     else {
-#ifdef STAT_MARK_CACHE
+#ifdef COLLECT_MARK_CACHE_STATS
         MarkCacheHits++;
 #endif
     }

--- a/src/profile.c
+++ b/src/profile.c
@@ -92,7 +92,7 @@
 **  ever evaluated and it appears to never be executed. We special case this
 **  if ForRange, by marking the range as evaluated.
 **
-**  We purposesfully ignore T_TRUE_EXPR and T_FALSE_EXPR, which represent the
+**  We purposesfully ignore EXPR_TRUE and EXPR_FALSE, which represent the
 **  constants 'true' and 'false', as they are often read but not 'executed'.
 **  We already ignored all integer and float constants anyway.
 **  However, the main reason this was added is that GAP represents 'else'
@@ -482,7 +482,7 @@ static inline void outputStat(Stat stat, int exec, int visited)
     // Explicitly skip these two cases, as they are often specially handled
     // and also aren't really interesting statements (something else will
     // be executed whenever they are).
-    if (TNUM_STAT(stat) == T_TRUE_EXPR || TNUM_STAT(stat) == T_FALSE_EXPR) {
+    if (TNUM_STAT(stat) == EXPR_TRUE || TNUM_STAT(stat) == EXPR_FALSE) {
         return;
     }
 
@@ -830,10 +830,10 @@ static void ProfilePrintExprPassthrough(Expr stat)
   Int SavedColour = -1;
   /* There are two cases we must pass through without touching */
   /* From TNUM_EXPR */
-  if(IS_REFLVAR(stat)) {
-    OriginalPrintExprFuncsForHook[T_REFLVAR](stat);
+  if(IS_REF_LVAR(stat)) {
+    OriginalPrintExprFuncsForHook[EXPR_REF_LVAR](stat);
   } else if(IS_INTEXPR(stat)) {
-    OriginalPrintExprFuncsForHook[T_INTEXPR](stat);
+    OriginalPrintExprFuncsForHook[EXPR_INT](stat);
   } else {
     SavedColour = CurrentColour;
     if(VISITED_STAT(stat)) {

--- a/src/stats.c
+++ b/src/stats.c
@@ -135,7 +135,7 @@ UInt HaveInterrupt(void)
 **  then 0 is returned.
 **
 **  A statement sequence with <n> statements is represented by  a bag of type
-**  'T_SEQ_STAT' with  <n> subbags.  The first  is  the  first statement, the
+**  'STAT_SEQ_STAT' with  <n> subbags.  The first  is  the  first statement, the
 **  second is the second statement, and so on.
 */
 static ALWAYS_INLINE UInt ExecSeqStatHelper(Stat stat, UInt nr)
@@ -204,7 +204,7 @@ static UInt ExecSeqStat7(Stat stat)
 **  tell the  calling executor that a  leave-statement was executed).   If no
 **  leave-statement is executed, then 0 is returned.
 **
-**  An if-statement with <n> branches is represented by  a bag of type 'T_IF'
+**  An if-statement with <n> branches is represented by  a bag of type 'STAT_IF'
 **  with 2*<n> subbags.  The first subbag is  the first condition, the second
 **  subbag is the  first body, the third subbag  is the second condition, the
 **  fourth subbag is the second body, and so  on.  If the if-statement has an
@@ -330,7 +330,7 @@ static UInt ExecIfElifElse(Stat stat)
 **  then 0 is returned.
 **
 **  A for-loop with <n> statements  in its body   is represented by a bag  of
-**  type 'T_FOR' with <n>+2  subbags.  The first  subbag is an assignment bag
+**  type 'STAT_FOR' with <n>+2  subbags.  The first  subbag is an assignment bag
 **  for the loop variable, the second subbag  is the list-expression, and the
 **  remaining subbags are the statements.
 */
@@ -356,15 +356,15 @@ static ALWAYS_INLINE UInt ExecForHelper(Stat stat, UInt nr)
 
     /* get the variable (initialize them first to please 'lint')           */
     const Stat varstat = READ_STAT(stat, 0);
-    if (IS_REFLVAR(varstat)) {
-        var = LVAR_REFLVAR(varstat);
+    if (IS_REF_LVAR(varstat)) {
+        var = LVAR_REF_LVAR(varstat);
         vart = 'l';
     }
-    else if (TNUM_EXPR(varstat) == T_REF_HVAR) {
+    else if (TNUM_EXPR(varstat) == EXPR_REF_HVAR) {
         var = READ_EXPR(varstat, 0);
         vart = 'h';
     }
-    else /* if ( TNUM_EXPR( varstat ) == T_REF_GVAR ) */ {
+    else /* if ( TNUM_EXPR( varstat ) == EXPR_REF_GVAR ) */ {
         var = READ_EXPR(varstat, 0);
         vart = 'g';
     }
@@ -490,7 +490,7 @@ static UInt ExecFor3(Stat stat)
 **  then 0 is returned.
 **
 **  A short for-loop with <n> statements in its body is  represented by a bag
-**  of   type 'T_FOR_RANGE'  with <n>+2 subbags.     The  first subbag is  an
+**  of   type 'STAT_FOR_RANGE'  with <n>+2 subbags.     The  first subbag is  an
 **  assignment   bag  for  the  loop  variable,   the second    subbag is the
 **  list-expression, and the remaining subbags are the statements.
 */
@@ -508,7 +508,7 @@ static ALWAYS_INLINE UInt ExecForRangeHelper(Stat stat, UInt nr)
     GAP_ASSERT(1 <= nr && nr <= 3);
 
     /* get the variable (initialize them first to please 'lint')           */
-    lvar = LVAR_REFLVAR(READ_STAT(stat, 0));
+    lvar = LVAR_REF_LVAR(READ_STAT(stat, 0));
 
     /* evaluate the range                                                  */
     VisitStatIfHooked(READ_STAT(stat, 1));
@@ -644,7 +644,7 @@ static UInt ExecAtomic(Stat stat)
 **  leave-statement was executed, then 0 is returned.
 **
 **  A while-loop with <n> statements  in its body  is represented by a bag of
-**  type  'T_WHILE' with <n>+1 subbags.   The first  subbag is the condition,
+**  type  'STAT_WHILE' with <n>+1 subbags.   The first  subbag is the condition,
 **  the second subbag is the first statement,  the third subbag is the second
 **  statement, and so on.
 */
@@ -718,7 +718,7 @@ static UInt ExecWhile3(Stat stat)
 **  leave-statement was executed, then 0 is returned.
 **
 **  A repeat-loop with <n> statements in its body is  represented by a bag of
-**  type 'T_REPEAT'  with <n>+1 subbags.  The  first subbag is the condition,
+**  type 'STAT_REPEAT'  with <n>+1 subbags.  The  first subbag is the condition,
 **  the second subbag is the first statement, the  third subbag is the second
 **  statement, and so on.
 */
@@ -785,7 +785,7 @@ static UInt ExecRepeat3(Stat stat)
 **  This is done by returning STATUS_BREAK (to tell the calling executor that
 **  a break-statement was executed).
 **
-**  A break-statement is  represented  by a bag of   type 'T_BREAK' with   no
+**  A break-statement is  represented  by a bag of   type 'STAT_BREAK' with   no
 **  subbags.
 */
 static UInt ExecBreak(Stat stat)
@@ -803,7 +803,7 @@ static UInt ExecBreak(Stat stat)
 **  This is done by returning STATUS_CONTINUE (to tell the calling executor
 **  that a continue-statement was executed).
 **
-**  A continue-statement is  represented  by a bag of   type 'T_CONTINUE' with   no
+**  A continue-statement is  represented  by a bag of   type 'STAT_CONTINUE' with   no
 **  subbags.
 */
 static UInt ExecContinue(Stat stat)
@@ -834,7 +834,7 @@ static UInt ExecEmpty(Stat stat)
 **  function InfoDecision to decide whether the message has to be printed. If
 **  it has, the other arguments are evaluated and passed to InfoDoPrint
 **
-**  An  info-statement is represented by a  bag of type 'T_INFO' with subbags
+**  An  info-statement is represented by a  bag of type 'STAT_INFO' with subbags
 **  for the arguments
 */
 static UInt ExecInfo(Stat stat)
@@ -886,7 +886,7 @@ static UInt ExecInfo(Stat stat)
 **  'ExecAssert2Args' executes the 2 argument assert-statement <stat>.
 **
 **  A 2 argument assert-statement is  represented  by a bag of   type
-**  'T_ASSERT_2ARGS' with subbags for the 2 arguments
+**  'STAT_ASSERT_2ARGS' with subbags for the 2 arguments
 */
 static UInt ExecAssert2Args(Stat stat)
 {
@@ -911,7 +911,7 @@ static UInt ExecAssert2Args(Stat stat)
 **  'ExecAssert3Args' executes the 3 argument assert-statement <stat>.
 **
 **  A 3 argument assert-statement is  represented  by a bag of   type
-**  'T_ASSERT_3ARGS' with subbags for the 3 arguments
+**  'STAT_ASSERT_3ARGS' with subbags for the 3 arguments
 */
 static UInt ExecAssert3Args(Stat stat)
 {
@@ -948,7 +948,7 @@ static UInt ExecAssert3Args(Stat stat)
 **  return-value-statement, and returning   1 (to tell   the calling executor
 **  that a return-value-statement was executed).
 **
-**  A return-value-statement  is represented by a  bag of type 'T_RETURN_OBJ'
+**  A return-value-statement  is represented by a  bag of type 'STAT_RETURN_OBJ'
 **  with      one  subbag.    This  subbag     is   the    expression  of the
 **  return-value-statement.
 */
@@ -979,7 +979,7 @@ static UInt ExecReturnObj(Stat stat)
 **  This  is done by   returning 2  (to tell    the calling executor  that  a
 **  return-void-statement was executed).
 **
-**  A return-void-statement  is represented by  a bag of type 'T_RETURN_VOID'
+**  A return-void-statement  is represented by  a bag of type 'STAT_RETURN_VOID'
 **  with no subbags.
 */
 static UInt ExecReturnVoid(Stat stat)
@@ -1232,7 +1232,7 @@ static void PrintIf(Stat stat)
     /* print the 'elif' branch                                             */
     for (i = 2; i <= len; i++) {
         if (i == len &&
-            TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == T_TRUE_EXPR) {
+            TNUM_EXPR(READ_STAT(stat, 2 * (i - 1))) == EXPR_TRUE) {
             Pr( "else%4>\n", 0L, 0L );
         }
         else {
@@ -1485,7 +1485,7 @@ static void PrintAssert3Args(Stat stat)
 static void PrintReturnObj(Stat stat)
 {
     Expr expr = READ_STAT(stat, 0);
-    if (TNUM_EXPR(expr) == T_REF_GVAR &&
+    if (TNUM_EXPR(expr) == EXPR_REF_GVAR &&
         READ_STAT(expr, 0) == GVarName("TRY_NEXT_METHOD")) {
         Pr( "TryNextMethod();", 0L, 0L );
     }
@@ -1546,40 +1546,40 @@ static Int InitKernel (
     }
 
     /* install executors for compound statements                           */
-    InstallExecStatFunc( T_SEQ_STAT       , ExecSeqStat);
-    InstallExecStatFunc( T_SEQ_STAT2      , ExecSeqStat2);
-    InstallExecStatFunc( T_SEQ_STAT3      , ExecSeqStat3);
-    InstallExecStatFunc( T_SEQ_STAT4      , ExecSeqStat4);
-    InstallExecStatFunc( T_SEQ_STAT5      , ExecSeqStat5);
-    InstallExecStatFunc( T_SEQ_STAT6      , ExecSeqStat6);
-    InstallExecStatFunc( T_SEQ_STAT7      , ExecSeqStat7);
-    InstallExecStatFunc( T_IF             , ExecIf);
-    InstallExecStatFunc( T_IF_ELSE        , ExecIfElse);
-    InstallExecStatFunc( T_IF_ELIF        , ExecIfElif);
-    InstallExecStatFunc( T_IF_ELIF_ELSE   , ExecIfElifElse);
-    InstallExecStatFunc( T_FOR            , ExecFor);
-    InstallExecStatFunc( T_FOR2           , ExecFor2);
-    InstallExecStatFunc( T_FOR3           , ExecFor3);
-    InstallExecStatFunc( T_FOR_RANGE      , ExecForRange);
-    InstallExecStatFunc( T_FOR_RANGE2     , ExecForRange2);
-    InstallExecStatFunc( T_FOR_RANGE3     , ExecForRange3);
-    InstallExecStatFunc( T_WHILE          , ExecWhile);
-    InstallExecStatFunc( T_WHILE2         , ExecWhile2);
-    InstallExecStatFunc( T_WHILE3         , ExecWhile3);
-    InstallExecStatFunc( T_REPEAT         , ExecRepeat);
-    InstallExecStatFunc( T_REPEAT2        , ExecRepeat2);
-    InstallExecStatFunc( T_REPEAT3        , ExecRepeat3);
-    InstallExecStatFunc( T_BREAK          , ExecBreak);
-    InstallExecStatFunc( T_CONTINUE       , ExecContinue);
-    InstallExecStatFunc( T_INFO           , ExecInfo);
-    InstallExecStatFunc( T_ASSERT_2ARGS   , ExecAssert2Args);
-    InstallExecStatFunc( T_ASSERT_3ARGS   , ExecAssert3Args);
-    InstallExecStatFunc( T_RETURN_OBJ     , ExecReturnObj);
-    InstallExecStatFunc( T_RETURN_VOID    , ExecReturnVoid);
-    InstallExecStatFunc( T_EMPTY          , ExecEmpty);
+    InstallExecStatFunc( STAT_SEQ_STAT       , ExecSeqStat);
+    InstallExecStatFunc( STAT_SEQ_STAT2      , ExecSeqStat2);
+    InstallExecStatFunc( STAT_SEQ_STAT3      , ExecSeqStat3);
+    InstallExecStatFunc( STAT_SEQ_STAT4      , ExecSeqStat4);
+    InstallExecStatFunc( STAT_SEQ_STAT5      , ExecSeqStat5);
+    InstallExecStatFunc( STAT_SEQ_STAT6      , ExecSeqStat6);
+    InstallExecStatFunc( STAT_SEQ_STAT7      , ExecSeqStat7);
+    InstallExecStatFunc( STAT_IF             , ExecIf);
+    InstallExecStatFunc( STAT_IF_ELSE        , ExecIfElse);
+    InstallExecStatFunc( STAT_IF_ELIF        , ExecIfElif);
+    InstallExecStatFunc( STAT_IF_ELIF_ELSE   , ExecIfElifElse);
+    InstallExecStatFunc( STAT_FOR            , ExecFor);
+    InstallExecStatFunc( STAT_FOR2           , ExecFor2);
+    InstallExecStatFunc( STAT_FOR3           , ExecFor3);
+    InstallExecStatFunc( STAT_FOR_RANGE      , ExecForRange);
+    InstallExecStatFunc( STAT_FOR_RANGE2     , ExecForRange2);
+    InstallExecStatFunc( STAT_FOR_RANGE3     , ExecForRange3);
+    InstallExecStatFunc( STAT_WHILE          , ExecWhile);
+    InstallExecStatFunc( STAT_WHILE2         , ExecWhile2);
+    InstallExecStatFunc( STAT_WHILE3         , ExecWhile3);
+    InstallExecStatFunc( STAT_REPEAT         , ExecRepeat);
+    InstallExecStatFunc( STAT_REPEAT2        , ExecRepeat2);
+    InstallExecStatFunc( STAT_REPEAT3        , ExecRepeat3);
+    InstallExecStatFunc( STAT_BREAK          , ExecBreak);
+    InstallExecStatFunc( STAT_CONTINUE       , ExecContinue);
+    InstallExecStatFunc( STAT_INFO           , ExecInfo);
+    InstallExecStatFunc( STAT_ASSERT_2ARGS   , ExecAssert2Args);
+    InstallExecStatFunc( STAT_ASSERT_3ARGS   , ExecAssert3Args);
+    InstallExecStatFunc( STAT_RETURN_OBJ     , ExecReturnObj);
+    InstallExecStatFunc( STAT_RETURN_VOID    , ExecReturnVoid);
+    InstallExecStatFunc( STAT_EMPTY          , ExecEmpty);
     InstallExecStatFunc( T_PRAGMA         , ExecEmpty);
 #ifdef HPCGAP
-    InstallExecStatFunc( T_ATOMIC         , ExecAtomic);
+    InstallExecStatFunc( STAT_ATOMIC         , ExecAtomic);
 #endif
 
     /* install printers for non-statements                                */
@@ -1587,40 +1587,40 @@ static Int InitKernel (
         InstallPrintStatFunc(i, PrintUnknownStat);
     }
     /* install printing functions for compound statements                  */
-    InstallPrintStatFunc( T_SEQ_STAT       , PrintSeqStat);
-    InstallPrintStatFunc( T_SEQ_STAT2      , PrintSeqStat);
-    InstallPrintStatFunc( T_SEQ_STAT3      , PrintSeqStat);
-    InstallPrintStatFunc( T_SEQ_STAT4      , PrintSeqStat);
-    InstallPrintStatFunc( T_SEQ_STAT5      , PrintSeqStat);
-    InstallPrintStatFunc( T_SEQ_STAT6      , PrintSeqStat);
-    InstallPrintStatFunc( T_SEQ_STAT7      , PrintSeqStat);
-    InstallPrintStatFunc( T_IF             , PrintIf);
-    InstallPrintStatFunc( T_IF_ELSE        , PrintIf);
-    InstallPrintStatFunc( T_IF_ELIF        , PrintIf);
-    InstallPrintStatFunc( T_IF_ELIF_ELSE   , PrintIf);
-    InstallPrintStatFunc( T_FOR            , PrintFor);
-    InstallPrintStatFunc( T_FOR2           , PrintFor);
-    InstallPrintStatFunc( T_FOR3           , PrintFor);
-    InstallPrintStatFunc( T_FOR_RANGE      , PrintFor);
-    InstallPrintStatFunc( T_FOR_RANGE2     , PrintFor);
-    InstallPrintStatFunc( T_FOR_RANGE3     , PrintFor);
-    InstallPrintStatFunc( T_WHILE          , PrintWhile);
-    InstallPrintStatFunc( T_WHILE2         , PrintWhile);
-    InstallPrintStatFunc( T_WHILE3         , PrintWhile);
-    InstallPrintStatFunc( T_REPEAT         , PrintRepeat);
-    InstallPrintStatFunc( T_REPEAT2        , PrintRepeat);
-    InstallPrintStatFunc( T_REPEAT3        , PrintRepeat);
-    InstallPrintStatFunc( T_BREAK          , PrintBreak);
-    InstallPrintStatFunc( T_CONTINUE       , PrintContinue);
-    InstallPrintStatFunc( T_INFO           , PrintInfo);
-    InstallPrintStatFunc( T_ASSERT_2ARGS   , PrintAssert2Args);
-    InstallPrintStatFunc( T_ASSERT_3ARGS   , PrintAssert3Args);
-    InstallPrintStatFunc( T_RETURN_OBJ     , PrintReturnObj);
-    InstallPrintStatFunc( T_RETURN_VOID    , PrintReturnVoid);
-    InstallPrintStatFunc( T_EMPTY          , PrintEmpty);
+    InstallPrintStatFunc( STAT_SEQ_STAT       , PrintSeqStat);
+    InstallPrintStatFunc( STAT_SEQ_STAT2      , PrintSeqStat);
+    InstallPrintStatFunc( STAT_SEQ_STAT3      , PrintSeqStat);
+    InstallPrintStatFunc( STAT_SEQ_STAT4      , PrintSeqStat);
+    InstallPrintStatFunc( STAT_SEQ_STAT5      , PrintSeqStat);
+    InstallPrintStatFunc( STAT_SEQ_STAT6      , PrintSeqStat);
+    InstallPrintStatFunc( STAT_SEQ_STAT7      , PrintSeqStat);
+    InstallPrintStatFunc( STAT_IF             , PrintIf);
+    InstallPrintStatFunc( STAT_IF_ELSE        , PrintIf);
+    InstallPrintStatFunc( STAT_IF_ELIF        , PrintIf);
+    InstallPrintStatFunc( STAT_IF_ELIF_ELSE   , PrintIf);
+    InstallPrintStatFunc( STAT_FOR            , PrintFor);
+    InstallPrintStatFunc( STAT_FOR2           , PrintFor);
+    InstallPrintStatFunc( STAT_FOR3           , PrintFor);
+    InstallPrintStatFunc( STAT_FOR_RANGE      , PrintFor);
+    InstallPrintStatFunc( STAT_FOR_RANGE2     , PrintFor);
+    InstallPrintStatFunc( STAT_FOR_RANGE3     , PrintFor);
+    InstallPrintStatFunc( STAT_WHILE          , PrintWhile);
+    InstallPrintStatFunc( STAT_WHILE2         , PrintWhile);
+    InstallPrintStatFunc( STAT_WHILE3         , PrintWhile);
+    InstallPrintStatFunc( STAT_REPEAT         , PrintRepeat);
+    InstallPrintStatFunc( STAT_REPEAT2        , PrintRepeat);
+    InstallPrintStatFunc( STAT_REPEAT3        , PrintRepeat);
+    InstallPrintStatFunc( STAT_BREAK          , PrintBreak);
+    InstallPrintStatFunc( STAT_CONTINUE       , PrintContinue);
+    InstallPrintStatFunc( STAT_INFO           , PrintInfo);
+    InstallPrintStatFunc( STAT_ASSERT_2ARGS   , PrintAssert2Args);
+    InstallPrintStatFunc( STAT_ASSERT_3ARGS   , PrintAssert3Args);
+    InstallPrintStatFunc( STAT_RETURN_OBJ     , PrintReturnObj);
+    InstallPrintStatFunc( STAT_RETURN_VOID    , PrintReturnVoid);
+    InstallPrintStatFunc( STAT_EMPTY          , PrintEmpty);
     InstallPrintStatFunc( T_PRAGMA         , PrintPragma);
 #ifdef HPCGAP
-    InstallPrintStatFunc( T_ATOMIC         , PrintAtomic);
+    InstallPrintStatFunc( STAT_ATOMIC         , PrintAtomic);
 #endif
 
     for ( i = 0; i < ARRAY_SIZE(ExecStatFuncs); i++ )

--- a/src/stats.h
+++ b/src/stats.h
@@ -49,8 +49,8 @@ extern  UInt            (* ExecStatFuncs[256]) ( Stat stat );
 UInt EXEC_STAT(Stat stat);
 
 // Executes the current function and returns its return value
-// if the last statement was T_RETURN_OBJ, or null if the last
-// statement was T_RETURN_VOID
+// if the last statement was STAT_RETURN_OBJ, or null if the last
+// statement was STAT_RETURN_VOID
 Obj EXEC_CURR_FUNC(void);
 
 /****************************************************************************

--- a/src/vars.c
+++ b/src/vars.c
@@ -2076,9 +2076,10 @@ static void SaveLVars(Obj lvars)
 {
   UInt len,i;
   const Obj *ptr;
-  SaveSubObj(FUNC_LVARS(lvars));
-  SaveUInt(STAT_LVARS(lvars));
-  SaveSubObj(PARENT_LVARS(lvars));
+  const LVarsHeader * hdr = (const LVarsHeader *)CONST_ADDR_OBJ(lvars);
+  SaveSubObj(hdr->func);
+  SaveUInt(hdr->stat);
+  SaveSubObj(hdr->parent);
   len = (SIZE_OBJ(lvars) - (2*sizeof(Obj)+sizeof(UInt)))/sizeof(Obj);
   ptr = CONST_ADDR_OBJ(lvars)+3;
   for (i = 0; i < len; i++)

--- a/src/vars.c
+++ b/src/vars.c
@@ -221,7 +221,7 @@ static void PrintUnbLVar(Stat stat)
 */
 static void PrintRefLVar(Expr expr)
 {
-    Pr( "%H", (Int)NAME_LVAR( LVAR_REFLVAR(expr) ), 0L );
+    Pr( "%H", (Int)NAME_LVAR( LVAR_REF_LVAR(expr) ), 0L );
 }
 
 static void PrintIsbLVar(Expr expr)
@@ -2193,110 +2193,110 @@ static Int InitKernel (
     PrintObjFuncs[ T_HVARS ] = PrintLVars;
 
     /* install executors, evaluators, and printers for local variables     */
-    InstallExecStatFunc( T_ASS_LVAR       , ExecAssLVar);
-    InstallExecStatFunc( T_UNB_LVAR       , ExecUnbLVar);
-    // no EvalExprFunc for T_REFLVAR, it is handled immediately by EVAL_EXPR
-    InstallEvalExprFunc( T_ISB_LVAR       , EvalIsbLVar);
+    InstallExecStatFunc( STAT_ASS_LVAR       , ExecAssLVar);
+    InstallExecStatFunc( STAT_UNB_LVAR       , ExecUnbLVar);
+    // no EvalExprFunc for EXPR_REF_LVAR, it is handled immediately by EVAL_EXPR
+    InstallEvalExprFunc( EXPR_ISB_LVAR       , EvalIsbLVar);
 
-    InstallPrintStatFunc( T_ASS_LVAR       , PrintAssLVar);
-    InstallPrintStatFunc( T_UNB_LVAR       , PrintUnbLVar);
-    InstallPrintExprFunc( T_REFLVAR        , PrintRefLVar);
-    InstallPrintExprFunc( T_ISB_LVAR       , PrintIsbLVar);
+    InstallPrintStatFunc( STAT_ASS_LVAR       , PrintAssLVar);
+    InstallPrintStatFunc( STAT_UNB_LVAR       , PrintUnbLVar);
+    InstallPrintExprFunc( EXPR_REF_LVAR        , PrintRefLVar);
+    InstallPrintExprFunc( EXPR_ISB_LVAR       , PrintIsbLVar);
 
     /* install executors, evaluators, and printers for higher variables    */
-    InstallExecStatFunc( T_ASS_HVAR       , ExecAssHVar);
-    InstallExecStatFunc( T_UNB_HVAR       , ExecUnbHVar);
-    InstallEvalExprFunc( T_REF_HVAR       , EvalRefHVar);
-    InstallEvalExprFunc( T_ISB_HVAR       , EvalIsbHVar);
-    InstallPrintStatFunc( T_ASS_HVAR       , PrintAssHVar);
-    InstallPrintStatFunc( T_UNB_HVAR       , PrintUnbHVar);
-    InstallPrintExprFunc( T_REF_HVAR       , PrintRefHVar);
-    InstallPrintExprFunc( T_ISB_HVAR       , PrintIsbHVar);
+    InstallExecStatFunc( STAT_ASS_HVAR       , ExecAssHVar);
+    InstallExecStatFunc( STAT_UNB_HVAR       , ExecUnbHVar);
+    InstallEvalExprFunc( EXPR_REF_HVAR       , EvalRefHVar);
+    InstallEvalExprFunc( EXPR_ISB_HVAR       , EvalIsbHVar);
+    InstallPrintStatFunc( STAT_ASS_HVAR       , PrintAssHVar);
+    InstallPrintStatFunc( STAT_UNB_HVAR       , PrintUnbHVar);
+    InstallPrintExprFunc( EXPR_REF_HVAR       , PrintRefHVar);
+    InstallPrintExprFunc( EXPR_ISB_HVAR       , PrintIsbHVar);
 
     /* install executors, evaluators, and printers for global variables    */
-    InstallExecStatFunc( T_ASS_GVAR       , ExecAssGVar);
-    InstallExecStatFunc( T_UNB_GVAR       , ExecUnbGVar);
-    InstallEvalExprFunc( T_REF_GVAR       , EvalRefGVar);
-    InstallEvalExprFunc( T_ISB_GVAR       , EvalIsbGVar);
-    InstallPrintStatFunc( T_ASS_GVAR       , PrintAssGVar);
-    InstallPrintStatFunc( T_UNB_GVAR       , PrintUnbGVar);
-    InstallPrintExprFunc( T_REF_GVAR       , PrintRefGVar);
-    InstallPrintExprFunc( T_ISB_GVAR       , PrintIsbGVar);
+    InstallExecStatFunc( STAT_ASS_GVAR       , ExecAssGVar);
+    InstallExecStatFunc( STAT_UNB_GVAR       , ExecUnbGVar);
+    InstallEvalExprFunc( EXPR_REF_GVAR       , EvalRefGVar);
+    InstallEvalExprFunc( EXPR_ISB_GVAR       , EvalIsbGVar);
+    InstallPrintStatFunc( STAT_ASS_GVAR       , PrintAssGVar);
+    InstallPrintStatFunc( STAT_UNB_GVAR       , PrintUnbGVar);
+    InstallPrintExprFunc( EXPR_REF_GVAR       , PrintRefGVar);
+    InstallPrintExprFunc( EXPR_ISB_GVAR       , PrintIsbGVar);
 
     /* install executors, evaluators, and printers for list elements       */
-    InstallExecStatFunc( T_ASS_LIST       , ExecAssList);
-    InstallExecStatFunc( T_ASSS_LIST      , ExecAsssList);
-    InstallExecStatFunc( T_ASS_LIST_LEV   , ExecAssListLevel);
-    InstallExecStatFunc( T_ASSS_LIST_LEV  , ExecAsssListLevel);
-    InstallExecStatFunc( T_ASS2_LIST  , ExecAss2List);
-    InstallPrintStatFunc( T_ASS2_LIST  , PrintAss2List);
+    InstallExecStatFunc( STAT_ASS_LIST       , ExecAssList);
+    InstallExecStatFunc( STAT_ASSS_LIST      , ExecAsssList);
+    InstallExecStatFunc( STAT_ASS_LIST_LEV   , ExecAssListLevel);
+    InstallExecStatFunc( STAT_ASSS_LIST_LEV  , ExecAsssListLevel);
+    InstallExecStatFunc( STAT_ASS2_LIST  , ExecAss2List);
+    InstallPrintStatFunc( STAT_ASS2_LIST  , PrintAss2List);
     
-    InstallExecStatFunc( T_UNB_LIST       , ExecUnbList);
-    InstallEvalExprFunc( T_ELM_LIST       , EvalElmList);
-    InstallEvalExprFunc( T_ELMS_LIST      , EvalElmsList);
-    InstallEvalExprFunc( T_ELM_LIST_LEV   , EvalElmListLevel);
-    InstallEvalExprFunc( T_ELMS_LIST_LEV  , EvalElmsListLevel);
-    InstallEvalExprFunc( T_ISB_LIST       , EvalIsbList);
-    InstallEvalExprFunc( T_ELM2_LIST      , EvalElm2List);
-    InstallPrintExprFunc( T_ELM2_LIST     , PrintElm2List);
+    InstallExecStatFunc( STAT_UNB_LIST       , ExecUnbList);
+    InstallEvalExprFunc( EXPR_ELM_LIST       , EvalElmList);
+    InstallEvalExprFunc( EXPR_ELMS_LIST      , EvalElmsList);
+    InstallEvalExprFunc( EXPR_ELM_LIST_LEV   , EvalElmListLevel);
+    InstallEvalExprFunc( EXPR_ELMS_LIST_LEV  , EvalElmsListLevel);
+    InstallEvalExprFunc( EXPR_ISB_LIST       , EvalIsbList);
+    InstallEvalExprFunc( EXPR_ELM2_LIST      , EvalElm2List);
+    InstallPrintExprFunc( EXPR_ELM2_LIST     , PrintElm2List);
     
-    InstallPrintStatFunc( T_ASS_LIST       , PrintAssList);
-    InstallPrintStatFunc( T_ASSS_LIST      , PrintAsssList);
-    InstallPrintStatFunc( T_ASS_LIST_LEV   , PrintAssList);
-    InstallPrintStatFunc( T_ASSS_LIST_LEV  , PrintAsssList);
-    InstallPrintStatFunc( T_UNB_LIST       , PrintUnbList);
-    InstallPrintExprFunc( T_ELM_LIST       , PrintElmList);
-    InstallPrintExprFunc( T_ELMS_LIST      , PrintElmsList);
-    InstallPrintExprFunc( T_ELM_LIST_LEV   , PrintElmListLevel);
-    InstallPrintExprFunc( T_ELMS_LIST_LEV  , PrintElmsList);
-    InstallPrintExprFunc( T_ISB_LIST       , PrintIsbList);
+    InstallPrintStatFunc( STAT_ASS_LIST       , PrintAssList);
+    InstallPrintStatFunc( STAT_ASSS_LIST      , PrintAsssList);
+    InstallPrintStatFunc( STAT_ASS_LIST_LEV   , PrintAssList);
+    InstallPrintStatFunc( STAT_ASSS_LIST_LEV  , PrintAsssList);
+    InstallPrintStatFunc( STAT_UNB_LIST       , PrintUnbList);
+    InstallPrintExprFunc( EXPR_ELM_LIST       , PrintElmList);
+    InstallPrintExprFunc( EXPR_ELMS_LIST      , PrintElmsList);
+    InstallPrintExprFunc( EXPR_ELM_LIST_LEV   , PrintElmListLevel);
+    InstallPrintExprFunc( EXPR_ELMS_LIST_LEV  , PrintElmsList);
+    InstallPrintExprFunc( EXPR_ISB_LIST       , PrintIsbList);
 
 
     /* install executors, evaluators, and printers for record elements     */
-    InstallExecStatFunc( T_ASS_REC_NAME   , ExecAssRecName);
-    InstallExecStatFunc( T_ASS_REC_EXPR   , ExecAssRecExpr);
-    InstallExecStatFunc( T_UNB_REC_NAME   , ExecUnbRecName);
-    InstallExecStatFunc( T_UNB_REC_EXPR   , ExecUnbRecExpr);
-    InstallEvalExprFunc( T_ELM_REC_NAME   , EvalElmRecName);
-    InstallEvalExprFunc( T_ELM_REC_EXPR   , EvalElmRecExpr);
-    InstallEvalExprFunc( T_ISB_REC_NAME   , EvalIsbRecName);
-    InstallEvalExprFunc( T_ISB_REC_EXPR   , EvalIsbRecExpr);
-    InstallPrintStatFunc( T_ASS_REC_NAME   , PrintAssRecName);
-    InstallPrintStatFunc( T_ASS_REC_EXPR   , PrintAssRecExpr);
-    InstallPrintStatFunc( T_UNB_REC_NAME   , PrintUnbRecName);
-    InstallPrintStatFunc( T_UNB_REC_EXPR   , PrintUnbRecExpr);
-    InstallPrintExprFunc( T_ELM_REC_NAME   , PrintElmRecName);
-    InstallPrintExprFunc( T_ELM_REC_EXPR   , PrintElmRecExpr);
-    InstallPrintExprFunc( T_ISB_REC_NAME   , PrintIsbRecName);
-    InstallPrintExprFunc( T_ISB_REC_EXPR   , PrintIsbRecExpr);
+    InstallExecStatFunc( STAT_ASS_REC_NAME   , ExecAssRecName);
+    InstallExecStatFunc( STAT_ASS_REC_EXPR   , ExecAssRecExpr);
+    InstallExecStatFunc( STAT_UNB_REC_NAME   , ExecUnbRecName);
+    InstallExecStatFunc( STAT_UNB_REC_EXPR   , ExecUnbRecExpr);
+    InstallEvalExprFunc( EXPR_ELM_REC_NAME   , EvalElmRecName);
+    InstallEvalExprFunc( EXPR_ELM_REC_EXPR   , EvalElmRecExpr);
+    InstallEvalExprFunc( EXPR_ISB_REC_NAME   , EvalIsbRecName);
+    InstallEvalExprFunc( EXPR_ISB_REC_EXPR   , EvalIsbRecExpr);
+    InstallPrintStatFunc( STAT_ASS_REC_NAME   , PrintAssRecName);
+    InstallPrintStatFunc( STAT_ASS_REC_EXPR   , PrintAssRecExpr);
+    InstallPrintStatFunc( STAT_UNB_REC_NAME   , PrintUnbRecName);
+    InstallPrintStatFunc( STAT_UNB_REC_EXPR   , PrintUnbRecExpr);
+    InstallPrintExprFunc( EXPR_ELM_REC_NAME   , PrintElmRecName);
+    InstallPrintExprFunc( EXPR_ELM_REC_EXPR   , PrintElmRecExpr);
+    InstallPrintExprFunc( EXPR_ISB_REC_NAME   , PrintIsbRecName);
+    InstallPrintExprFunc( EXPR_ISB_REC_EXPR   , PrintIsbRecExpr);
 
     /* install executors, evaluators, and printers for list elements       */
-    InstallExecStatFunc( T_ASS_POSOBJ       , ExecAssPosObj);
-    InstallExecStatFunc( T_UNB_POSOBJ       , ExecUnbPosObj);
-    InstallEvalExprFunc( T_ELM_POSOBJ       , EvalElmPosObj);
-    InstallEvalExprFunc( T_ISB_POSOBJ       , EvalIsbPosObj);
-    InstallPrintStatFunc( T_ASS_POSOBJ       , PrintAssPosObj);
-    InstallPrintStatFunc( T_UNB_POSOBJ       , PrintUnbPosObj);
-    InstallPrintExprFunc( T_ELM_POSOBJ       , PrintElmPosObj);
-    InstallPrintExprFunc( T_ISB_POSOBJ       , PrintIsbPosObj);
+    InstallExecStatFunc( STAT_ASS_POSOBJ       , ExecAssPosObj);
+    InstallExecStatFunc( STAT_UNB_POSOBJ       , ExecUnbPosObj);
+    InstallEvalExprFunc( EXPR_ELM_POSOBJ       , EvalElmPosObj);
+    InstallEvalExprFunc( EXPR_ISB_POSOBJ       , EvalIsbPosObj);
+    InstallPrintStatFunc( STAT_ASS_POSOBJ       , PrintAssPosObj);
+    InstallPrintStatFunc( STAT_UNB_POSOBJ       , PrintUnbPosObj);
+    InstallPrintExprFunc( EXPR_ELM_POSOBJ       , PrintElmPosObj);
+    InstallPrintExprFunc( EXPR_ISB_POSOBJ       , PrintIsbPosObj);
 
     /* install executors, evaluators, and printers for record elements     */
-    InstallExecStatFunc( T_ASS_COMOBJ_NAME  , ExecAssComObjName);
-    InstallExecStatFunc( T_ASS_COMOBJ_EXPR  , ExecAssComObjExpr);
-    InstallExecStatFunc( T_UNB_COMOBJ_NAME  , ExecUnbComObjName);
-    InstallExecStatFunc( T_UNB_COMOBJ_EXPR  , ExecUnbComObjExpr);
-    InstallEvalExprFunc( T_ELM_COMOBJ_NAME  , EvalElmComObjName);
-    InstallEvalExprFunc( T_ELM_COMOBJ_EXPR  , EvalElmComObjExpr);
-    InstallEvalExprFunc( T_ISB_COMOBJ_NAME  , EvalIsbComObjName);
-    InstallEvalExprFunc( T_ISB_COMOBJ_EXPR  , EvalIsbComObjExpr);
-    InstallPrintStatFunc( T_ASS_COMOBJ_NAME  , PrintAssComObjName);
-    InstallPrintStatFunc( T_ASS_COMOBJ_EXPR  , PrintAssComObjExpr);
-    InstallPrintStatFunc( T_UNB_COMOBJ_NAME  , PrintUnbComObjName);
-    InstallPrintStatFunc( T_UNB_COMOBJ_EXPR  , PrintUnbComObjExpr);
-    InstallPrintExprFunc( T_ELM_COMOBJ_NAME  , PrintElmComObjName);
-    InstallPrintExprFunc( T_ELM_COMOBJ_EXPR  , PrintElmComObjExpr);
-    InstallPrintExprFunc( T_ISB_COMOBJ_NAME  , PrintIsbComObjName);
-    InstallPrintExprFunc( T_ISB_COMOBJ_EXPR  , PrintIsbComObjExpr);
+    InstallExecStatFunc( STAT_ASS_COMOBJ_NAME  , ExecAssComObjName);
+    InstallExecStatFunc( STAT_ASS_COMOBJ_EXPR  , ExecAssComObjExpr);
+    InstallExecStatFunc( STAT_UNB_COMOBJ_NAME  , ExecUnbComObjName);
+    InstallExecStatFunc( STAT_UNB_COMOBJ_EXPR  , ExecUnbComObjExpr);
+    InstallEvalExprFunc( EXPR_ELM_COMOBJ_NAME  , EvalElmComObjName);
+    InstallEvalExprFunc( EXPR_ELM_COMOBJ_EXPR  , EvalElmComObjExpr);
+    InstallEvalExprFunc( EXPR_ISB_COMOBJ_NAME  , EvalIsbComObjName);
+    InstallEvalExprFunc( EXPR_ISB_COMOBJ_EXPR  , EvalIsbComObjExpr);
+    InstallPrintStatFunc( STAT_ASS_COMOBJ_NAME  , PrintAssComObjName);
+    InstallPrintStatFunc( STAT_ASS_COMOBJ_EXPR  , PrintAssComObjExpr);
+    InstallPrintStatFunc( STAT_UNB_COMOBJ_NAME  , PrintUnbComObjName);
+    InstallPrintStatFunc( STAT_UNB_COMOBJ_EXPR  , PrintUnbComObjExpr);
+    InstallPrintExprFunc( EXPR_ELM_COMOBJ_NAME  , PrintElmComObjName);
+    InstallPrintExprFunc( EXPR_ELM_COMOBJ_EXPR  , PrintElmComObjExpr);
+    InstallPrintExprFunc( EXPR_ISB_COMOBJ_NAME  , PrintIsbComObjName);
+    InstallPrintExprFunc( EXPR_ISB_COMOBJ_EXPR  , PrintIsbComObjExpr);
 
 #ifdef USE_GASMAN
     /* install before and after actions for garbage collections            */

--- a/src/vars.h
+++ b/src/vars.h
@@ -87,14 +87,14 @@ typedef struct {
 *F  FUNC_LVARS . . . . . . . . . . . function to which the given lvars belong
 **
 */
-EXPORT_INLINE Obj FUNC_LVARS_PTR(void * lvars_ptr)
+EXPORT_INLINE Obj FUNC_LVARS_PTR(const void * lvars_ptr)
 {
-    return ((LVarsHeader *)lvars_ptr)->func;
+    return ((const LVarsHeader *)lvars_ptr)->func;
 }
 
 EXPORT_INLINE Obj FUNC_LVARS(Obj lvars_obj)
 {
-    return FUNC_LVARS_PTR(ADDR_OBJ(lvars_obj));
+    return FUNC_LVARS_PTR(CONST_ADDR_OBJ(lvars_obj));
 }
 
 
@@ -103,14 +103,14 @@ EXPORT_INLINE Obj FUNC_LVARS(Obj lvars_obj)
 *F  STAT_LVARS . . . . . . . current statement in function of the given lvars
 **
 */
-EXPORT_INLINE Expr STAT_LVARS_PTR(void * lvars_ptr)
+EXPORT_INLINE Expr STAT_LVARS_PTR(const void * lvars_ptr)
 {
-    return ((LVarsHeader *)lvars_ptr)->stat;
+    return ((const LVarsHeader *)lvars_ptr)->stat;
 }
 
 EXPORT_INLINE Expr STAT_LVARS(Obj lvars_obj)
 {
-    return STAT_LVARS_PTR(ADDR_OBJ(lvars_obj));
+    return STAT_LVARS_PTR(CONST_ADDR_OBJ(lvars_obj));
 }
 
 
@@ -119,14 +119,14 @@ EXPORT_INLINE Expr STAT_LVARS(Obj lvars_obj)
 *F  PARENT_LVARS . . . . . . . . . . . . . .  parent lvars of the given lvars
 **
 */
-EXPORT_INLINE Obj PARENT_LVARS_PTR(void * lvars_ptr)
+EXPORT_INLINE Obj PARENT_LVARS_PTR(const void * lvars_ptr)
 {
-    return ((LVarsHeader *)lvars_ptr)->parent;
+    return ((const LVarsHeader *)lvars_ptr)->parent;
 }
 
 EXPORT_INLINE Obj PARENT_LVARS(Obj lvars_obj)
 {
-    return PARENT_LVARS_PTR(ADDR_OBJ(lvars_obj));
+    return PARENT_LVARS_PTR(CONST_ADDR_OBJ(lvars_obj));
 }
 
 

--- a/tst/testinstall/syntaxtree.tst
+++ b/tst/testinstall/syntaxtree.tst
@@ -51,7 +51,7 @@ gap> testit := function(f)
 >   return test_tree( f );
 > end;;
 
-# T_PROCCALL_0ARGS
+# STAT_PROCCALL_0ARGS
 gap> testit(function(x) x(); end);
 rec(
   nams := [ "x" ],
@@ -62,15 +62,15 @@ rec(
               args := [  ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_0ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_0ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_1ARGS
+# STAT_PROCCALL_1ARGS
 gap> testit(function(x) x(1); end);
 rec(
   nams := [ "x" ],
@@ -79,19 +79,19 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_1ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_1ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_2ARGS
+# STAT_PROCCALL_2ARGS
 gap> testit(function(x) x(1,2); end);
 rec(
   nams := [ "x" ],
@@ -100,21 +100,21 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_2ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_2ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_3ARGS
+# STAT_PROCCALL_3ARGS
 gap> testit(function(x) x(1,2,3); end);
 rec(
   nams := [ "x" ],
@@ -123,23 +123,23 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 3 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_3ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_3ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_4ARGS
+# STAT_PROCCALL_4ARGS
 gap> testit(function(x) x(1,2,3,4); end);
 rec(
   nams := [ "x" ],
@@ -148,25 +148,25 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 3 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 4 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_4ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_4ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_5ARGS
+# STAT_PROCCALL_5ARGS
 gap> testit(function(x) x(1,2,3,4,5); end);
 rec(
   nams := [ "x" ],
@@ -175,27 +175,27 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 3 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 4 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 5 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_5ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_5ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_6ARGS
+# STAT_PROCCALL_6ARGS
 gap> testit(function(x) x(1,2,3,4,5,6); end);
 rec(
   nams := [ "x" ],
@@ -204,29 +204,29 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 3 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 4 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 5 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 6 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_6ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_6ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_XARGS
+# STAT_PROCCALL_XARGS
 gap> testit(function(x) x(1,2,3,4,5,6,7); end);
 rec(
   nams := [ "x" ],
@@ -235,31 +235,31 @@ rec(
   stats := rec(
       statements := [ rec(
               args := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 3 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 4 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 5 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 6 ), rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 7 ) ],
               funcref := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_PROCCALL_XARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_PROCCALL_XARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROCCALL_OPTS
+# STAT_PROCCALL_OPTS
 gap> testit(function(x) x(1 : opt); end);
 rec(
   nams := [ "x" ],
@@ -269,22 +269,22 @@ rec(
       statements := [ rec(
               call := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_PROCCALL_1ARGS" ),
+                      type := "EXPR_REF_LVAR" ),
+                  type := "STAT_PROCCALL_1ARGS" ),
               opts := rec(
                   keyvalue := [ rec(
                           key := "opt",
                           value := rec(
-                              type := "T_TRUE_EXPR" ) ) ],
-                  type := "T_REC_EXPR" ),
-              type := "T_PROCCALL_OPTS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                              type := "EXPR_TRUE" ) ) ],
+                  type := "EXPR_REC" ),
+              type := "STAT_PROCCALL_OPTS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) x(1 : opt := 42); end);
@@ -296,27 +296,27 @@ rec(
       statements := [ rec(
               call := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_PROCCALL_1ARGS" ),
+                      type := "EXPR_REF_LVAR" ),
+                  type := "STAT_PROCCALL_1ARGS" ),
               opts := rec(
                   keyvalue := [ rec(
                           key := "opt",
                           value := rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 42 ) ) ],
-                  type := "T_REC_EXPR" ),
-              type := "T_PROCCALL_OPTS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REC" ),
+              type := "STAT_PROCCALL_OPTS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_EMPTY
+# STAT_EMPTY
 gap> testit(function(x) ; end);
 rec(
   nams := [ "x" ],
@@ -324,14 +324,14 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_EMPTY" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_EMPTY" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT
+# STAT_SEQ_STAT
 gap> testit(function(x) return; end);
 rec(
   nams := [ "x" ],
@@ -339,9 +339,9 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) if x then return; return; return; return; return; return; return; return; fi; end);
@@ -354,26 +354,26 @@ rec(
               branches := [ rec(
                       body := rec(
                           statements := [ rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ), rec(
-                                  type := "T_RETURN_VOID" ) ],
-                          type := "T_SEQ_STAT" ),
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ), rec(
+                                  type := "STAT_RETURN_VOID" ) ],
+                          type := "STAT_SEQ_STAT" ),
                       condition := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ) ) ],
-              type := "T_IF" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_REF_LVAR" ) ) ],
+              type := "STAT_IF" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT2
+# STAT_SEQ_STAT2
 gap> testit(function(x) return; return; end);
 rec(
   nams := [ "x" ],
@@ -381,14 +381,14 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT3
+# STAT_SEQ_STAT3
 gap> testit(function(x) return; return; return; end);
 rec(
   nams := [ "x" ],
@@ -396,15 +396,15 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT3" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT3" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT4
+# STAT_SEQ_STAT4
 gap> testit(function(x) return; return; return; return; end);
 rec(
   nams := [ "x" ],
@@ -412,16 +412,16 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT4" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT4" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT5
+# STAT_SEQ_STAT5
 gap> testit(function(x) return; return; return; return; return; end);
 rec(
   nams := [ "x" ],
@@ -429,17 +429,17 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT5" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT5" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT6
+# STAT_SEQ_STAT6
 gap> testit(function(x) return; return; return; return; return; return; end);
 rec(
   nams := [ "x" ],
@@ -447,18 +447,18 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT6" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT6" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SEQ_STAT7
+# STAT_SEQ_STAT7
 gap> testit(function(x) return; return; return; return; return; return; return; end);
 rec(
   nams := [ "x" ],
@@ -466,23 +466,23 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT7" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT7" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
 # 
-# T_IF
-# T_IF_ELSE
-# T_IF_ELIF
-# T_IF_ELIF_ELSE
+# STAT_IF
+# STAT_IF_ELSE
+# STAT_IF_ELIF
+# STAT_IF_ELIF_ELSE
 gap> testit(function(x) if x then fi; end);
 rec(
   nams := [ "x" ],
@@ -492,14 +492,14 @@ rec(
       statements := [ rec(
               branches := [ rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ) ) ],
-              type := "T_IF" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_REF_LVAR" ) ) ],
+              type := "STAT_IF" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) if x then else fi; end);
@@ -511,18 +511,18 @@ rec(
       statements := [ rec(
               branches := [ rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
-                          type := "T_TRUE_EXPR" ) ) ],
-              type := "T_IF_ELSE" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_TRUE" ) ) ],
+              type := "STAT_IF_ELSE" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x,y) if x then elif y then fi; end);
@@ -534,19 +534,19 @@ rec(
       statements := [ rec(
               branches := [ rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 2,
-                          type := "T_REFLVAR" ) ) ],
-              type := "T_IF_ELIF" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_REF_LVAR" ) ) ],
+              type := "STAT_IF_ELIF" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x,y) if x then elif y then else fi; end);
@@ -558,23 +558,23 @@ rec(
       statements := [ rec(
               branches := [ rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 2,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
-                          type := "T_TRUE_EXPR" ) ) ],
-              type := "T_IF_ELIF_ELSE" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_TRUE" ) ) ],
+              type := "STAT_IF_ELIF_ELSE" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x,y,z) if x then elif y then elif z then else fi; end);
@@ -586,34 +586,34 @@ rec(
       statements := [ rec(
               branches := [ rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 2,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
                           lvar := 3,
-                          type := "T_REFLVAR" ) ), rec(
+                          type := "EXPR_REF_LVAR" ) ), rec(
                       body := rec(
-                          type := "T_EMPTY" ),
+                          type := "STAT_EMPTY" ),
                       condition := rec(
-                          type := "T_TRUE_EXPR" ) ) ],
-              type := "T_IF_ELIF_ELSE" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_TRUE" ) ) ],
+              type := "STAT_IF_ELIF_ELSE" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FOR
-# T_FOR2
-# T_FOR3
+# STAT_FOR
+# STAT_FOR2
+# STAT_FOR3
 gap> testit(function(x) for x in x do od; end);
 rec(
   nams := [ "x" ],
@@ -622,17 +622,17 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_EMPTY" ) ],
+                      type := "STAT_EMPTY" ) ],
               collection := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_FOR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_FOR",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in x do return; od; end);
@@ -643,17 +643,17 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ) ],
               collection := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_FOR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_FOR",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in x do return; return; od; end);
@@ -664,18 +664,18 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               collection := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_FOR2",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_FOR2",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in x do return; return; return; od; end);
@@ -686,19 +686,19 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               collection := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_FOR3",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_FOR3",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in x do return; return; return; return; od; end);
@@ -710,27 +710,27 @@ rec(
       statements := [ rec(
               body := [ rec(
                       statements := [ rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ) ],
-                      type := "T_SEQ_STAT4" ) ],
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ) ],
+                      type := "STAT_SEQ_STAT4" ) ],
               collection := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_FOR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_FOR",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FOR_RANGE
-# T_FOR_RANGE2
-# T_FOR_RANGE3
+# STAT_FOR_RANGE
+# STAT_FOR_RANGE2
+# STAT_FOR_RANGE3
 gap> testit(function(x) for x in [1..2] do od; end);
 rec(
   nams := [ "x" ],
@@ -739,22 +739,22 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_EMPTY" ) ],
+                      type := "STAT_EMPTY" ) ],
               collection := rec(
                   first := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   last := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ),
-                  type := "T_RANGE_EXPR" ),
-              type := "T_FOR_RANGE",
+                  type := "EXPR_RANGE" ),
+              type := "STAT_FOR_RANGE",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in [1..2] do return; od; end);
@@ -765,22 +765,22 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ) ],
               collection := rec(
                   first := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   last := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ),
-                  type := "T_RANGE_EXPR" ),
-              type := "T_FOR_RANGE",
+                  type := "EXPR_RANGE" ),
+              type := "STAT_FOR_RANGE",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in [1..2] do return; return; od; end);
@@ -791,23 +791,23 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               collection := rec(
                   first := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   last := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ),
-                  type := "T_RANGE_EXPR" ),
-              type := "T_FOR_RANGE2",
+                  type := "EXPR_RANGE" ),
+              type := "STAT_FOR_RANGE2",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in [1..2] do return; return; return; od; end);
@@ -818,24 +818,24 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               collection := rec(
                   first := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   last := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ),
-                  type := "T_RANGE_EXPR" ),
-              type := "T_FOR_RANGE3",
+                  type := "EXPR_RANGE" ),
+              type := "STAT_FOR_RANGE3",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) for x in [1..2] do return; return; return; return; od; end);
@@ -847,32 +847,32 @@ rec(
       statements := [ rec(
               body := [ rec(
                       statements := [ rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ) ],
-                      type := "T_SEQ_STAT4" ) ],
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ) ],
+                      type := "STAT_SEQ_STAT4" ) ],
               collection := rec(
                   first := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   last := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 2 ),
-                  type := "T_RANGE_EXPR" ),
-              type := "T_FOR_RANGE",
+                  type := "EXPR_RANGE" ),
+              type := "STAT_FOR_RANGE",
               variable := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ) ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ) ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_WHILE
-# T_WHILE2
-# T_WHILE3
+# STAT_WHILE
+# STAT_WHILE2
+# STAT_WHILE3
 gap> testit(function(x) while true do od; end);
 rec(
   nams := [ "x" ],
@@ -881,13 +881,13 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_EMPTY" ) ],
+                      type := "STAT_EMPTY" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_WHILE" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_WHILE" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) while true do return; od; end);
@@ -898,13 +898,13 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_WHILE" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_WHILE" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) while true do return; return; od; end);
@@ -915,14 +915,14 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_WHILE2" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_WHILE2" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) while true do return; return; return; od; end);
@@ -933,15 +933,15 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_WHILE3" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_WHILE3" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) while true do return; return; return; return; od; end);
@@ -953,23 +953,23 @@ rec(
       statements := [ rec(
               body := [ rec(
                       statements := [ rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ) ],
-                      type := "T_SEQ_STAT4" ) ],
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ) ],
+                      type := "STAT_SEQ_STAT4" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_WHILE" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_WHILE" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_REPEAT
-# T_REPEAT2
-# T_REPEAT3
+# STAT_REPEAT
+# STAT_REPEAT2
+# STAT_REPEAT3
 gap> testit(function(x) repeat until true; end);
 rec(
   nams := [ "x" ],
@@ -978,13 +978,13 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_EMPTY" ) ],
+                      type := "STAT_EMPTY" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) repeat return; until true; end);
@@ -995,13 +995,13 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) repeat return; return; until true; end);
@@ -1012,14 +1012,14 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT2" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT2" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) repeat return; return; return; until true; end);
@@ -1030,15 +1030,15 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ), rec(
-                      type := "T_RETURN_VOID" ) ],
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ), rec(
+                      type := "STAT_RETURN_VOID" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT3" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT3" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) repeat return; return; return; return; until true; end);
@@ -1050,21 +1050,21 @@ rec(
       statements := [ rec(
               body := [ rec(
                       statements := [ rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ), rec(
-                              type := "T_RETURN_VOID" ) ],
-                      type := "T_SEQ_STAT4" ) ],
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ), rec(
+                              type := "STAT_RETURN_VOID" ) ],
+                      type := "STAT_SEQ_STAT4" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ATOMIC
+# STAT_ATOMIC
 #@if IsHPCGAP
 gap> testit(function(x) atomic x do od; end);
 rec(
@@ -1074,21 +1074,21 @@ rec(
   stats := rec(
       statements := [ rec(
               body := rec(
-                  type := "T_EMPTY" ),
+                  type := "STAT_EMPTY" ),
               locks := [ rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 0 ), rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ) ],
-              type := "T_ATOMIC" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ) ],
+              type := "STAT_ATOMIC" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 #@fi
 
-# T_BREAK
+# STAT_BREAK
 gap> testit(function(x) repeat break; until true; end);
 rec(
   nams := [ "x" ],
@@ -1097,17 +1097,17 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_BREAK" ) ],
+                      type := "STAT_BREAK" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_CONTINUE
+# STAT_CONTINUE
 gap> testit(function(x) repeat continue; until true; end);
 rec(
   nams := [ "x" ],
@@ -1116,17 +1116,17 @@ rec(
   stats := rec(
       statements := [ rec(
               body := [ rec(
-                      type := "T_CONTINUE" ) ],
+                      type := "STAT_CONTINUE" ) ],
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_REPEAT" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_REPEAT" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_RETURN_OBJ
+# STAT_RETURN_OBJ
 gap> testit(function(x) return 42; end);
 rec(
   nams := [ "x" ],
@@ -1135,15 +1135,15 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 42 ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_RETURN_VOID
+# STAT_RETURN_VOID
 gap> testit(function(x) return; end);
 rec(
   nams := [ "x" ],
@@ -1151,13 +1151,13 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_LVAR
+# STAT_ASS_LVAR
 gap> testit(function(x) x := 1; end);
 rec(
   nams := [ "x" ],
@@ -1167,16 +1167,16 @@ rec(
       statements := [ rec(
               lvar := 1,
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_LVAR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_LVAR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_LVAR
+# STAT_UNB_LVAR
 gap> testit(function(x) Unbind(x); end);
 rec(
   nams := [ "x" ],
@@ -1185,14 +1185,14 @@ rec(
   stats := rec(
       statements := [ rec(
               lvar := 1,
-              type := "T_UNB_LVAR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_LVAR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_HVAR
+# STAT_ASS_HVAR
 gap> testit(x -> function(y) x := 1; end);
 rec(
   nams := [ "x" ],
@@ -1208,20 +1208,20 @@ rec(
                       statements := [ rec(
                               hvar := 65537,
                               rhs := rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 1 ),
-                              type := "T_ASS_HVAR" ), rec(
-                              type := "T_RETURN_VOID" ) ],
-                      type := "T_SEQ_STAT2" ),
-                  type := "T_FUNC_EXPR",
+                              type := "STAT_ASS_HVAR" ), rec(
+                              type := "STAT_RETURN_VOID" ) ],
+                      type := "STAT_SEQ_STAT2" ),
+                  type := "EXPR_FUNC",
                   variadic := false ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_HVAR
+# STAT_UNB_HVAR
 gap> testit(x -> function(y) Unbind(x); end);
 rec(
   nams := [ "x" ],
@@ -1236,18 +1236,18 @@ rec(
                   stats := rec(
                       statements := [ rec(
                               hvar := 65537,
-                              type := "T_UNB_HVAR" ), rec(
-                              type := "T_RETURN_VOID" ) ],
-                      type := "T_SEQ_STAT2" ),
-                  type := "T_FUNC_EXPR",
+                              type := "STAT_UNB_HVAR" ), rec(
+                              type := "STAT_RETURN_VOID" ) ],
+                      type := "STAT_SEQ_STAT2" ),
+                  type := "EXPR_FUNC",
                   variadic := false ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_GVAR
+# STAT_ASS_GVAR
 gap> testit(function(x) testit := 1; end);
 rec(
   nams := [ "x" ],
@@ -1257,16 +1257,16 @@ rec(
       statements := [ rec(
               gvar := "testit",
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_GVAR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_GVAR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_GVAR
+# STAT_UNB_GVAR
 gap> testit(function(x) Unbind(testit); end);
 rec(
   nams := [ "x" ],
@@ -1275,14 +1275,14 @@ rec(
   stats := rec(
       statements := [ rec(
               gvar := "testit",
-              type := "T_UNB_GVAR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_GVAR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_LIST
+# STAT_ASS_LIST
 gap> testit(function(x) x[42] := 1; end);
 rec(
   nams := [ "x" ],
@@ -1292,21 +1292,21 @@ rec(
       statements := [ rec(
               list := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               pos := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 42 ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_LIST" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_LIST" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS2_LIST
+# STAT_ASS2_LIST
 gap> testit(function(x) x[42,23] := 1; end);
 rec(
   nams := [ "x" ],
@@ -1316,21 +1316,21 @@ rec(
       statements := [ rec(
               list := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               pos := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 42 ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 23 ),
-              type := "T_ASS2_LIST" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS2_LIST" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASSS_LIST
+# STAT_ASSS_LIST
 gap> testit(function(x) x{[42]} := 1; end);
 rec(
   nams := [ "x" ],
@@ -1340,23 +1340,23 @@ rec(
       statements := [ rec(
               list := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               poss := rec(
                   list := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 42 ) ],
-                  type := "T_LIST_EXPR" ),
+                  type := "EXPR_LIST" ),
               rhss := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASSS_LIST" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASSS_LIST" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_LIST_LEV
+# STAT_ASS_LIST_LEV
 gap> testit(function(x) x{[42]}[23] := 1; end);
 rec(
   nams := [ "x" ],
@@ -1368,27 +1368,27 @@ rec(
               lists := rec(
                   list := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   poss := rec(
                       list := [ rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 42 ) ],
-                      type := "T_LIST_EXPR" ),
-                  type := "T_ELMS_LIST" ),
+                      type := "EXPR_LIST" ),
+                  type := "EXPR_ELMS_LIST" ),
               pos := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 23 ),
               rhss := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_LIST_LEV" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_LIST_LEV" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASSS_LIST_LEV
+# STAT_ASSS_LIST_LEV
 gap> testit(function(x) x{[42]}{[23]} := 1; end);
 rec(
   nams := [ "x" ],
@@ -1400,29 +1400,29 @@ rec(
               lists := rec(
                   list := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   poss := rec(
                       list := [ rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 42 ) ],
-                      type := "T_LIST_EXPR" ),
-                  type := "T_ELMS_LIST" ),
+                      type := "EXPR_LIST" ),
+                  type := "EXPR_ELMS_LIST" ),
               poss := rec(
                   list := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 23 ) ],
-                  type := "T_LIST_EXPR" ),
+                  type := "EXPR_LIST" ),
               rhss := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASSS_LIST_LEV" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASSS_LIST_LEV" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_LIST
+# STAT_UNB_LIST
 gap> testit(function(x) Unbind(x[42]); end);
 rec(
   nams := [ "x" ],
@@ -1432,18 +1432,18 @@ rec(
       statements := [ rec(
               list := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               pos := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 42 ),
-              type := "T_UNB_LIST" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_LIST" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_REC_NAME
+# STAT_ASS_REC_NAME
 gap> testit(function(x) x.abc := 1; end);
 rec(
   nams := [ "x" ],
@@ -1453,19 +1453,19 @@ rec(
       statements := [ rec(
               record := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
               rnam := "abc",
-              type := "T_ASS_REC_NAME" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_REC_NAME" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_REC_EXPR
+# STAT_ASS_REC_EXPR
 gap> testit(function(x) x.("x") := 1; end);
 rec(
   nams := [ "x" ],
@@ -1474,18 +1474,18 @@ rec(
   stats := rec(
       statements := [ rec(
               expression := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "x" ),
               record := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_REC_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_REC_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) x.(1) := 1; end);
@@ -1496,22 +1496,22 @@ rec(
   stats := rec(
       statements := [ rec(
               expression := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
               record := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_REC_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_REC_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_REC_NAME
+# STAT_UNB_REC_NAME
 gap> testit(function(x) Unbind(x.abc); end);
 rec(
   nams := [ "x" ],
@@ -1521,16 +1521,16 @@ rec(
       statements := [ rec(
               record := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rnam := "abc",
-              type := "T_UNB_REC_NAME" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_REC_NAME" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_REC_EXPR
+# STAT_UNB_REC_EXPR
 gap> testit(function(x) Unbind(x.("x")); end);
 rec(
   nams := [ "x" ],
@@ -1539,15 +1539,15 @@ rec(
   stats := rec(
       statements := [ rec(
               expression := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "x" ),
               record := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_UNB_REC_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_UNB_REC_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) Unbind(x.(1)); end);
@@ -1558,19 +1558,19 @@ rec(
   stats := rec(
       statements := [ rec(
               expression := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
               record := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_UNB_REC_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_UNB_REC_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_POSOBJ
+# STAT_ASS_POSOBJ
 gap> testit(function(x) x![42] := 1; end);
 rec(
   nams := [ "x" ],
@@ -1579,22 +1579,22 @@ rec(
   stats := rec(
       statements := [ rec(
               pos := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 42 ),
               posobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_POSOBJ" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_POSOBJ" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_POSOBJ
+# STAT_UNB_POSOBJ
 gap> testit(function(x) Unbind(x![42]); end);
 rec(
   nams := [ "x" ],
@@ -1603,19 +1603,19 @@ rec(
   stats := rec(
       statements := [ rec(
               pos := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 42 ),
               posobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_UNB_POSOBJ" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_UNB_POSOBJ" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_COMOBJ_NAME
+# STAT_ASS_COMOBJ_NAME
 gap> testit(function(x) x!.abc := 1; end);
 rec(
   nams := [ "x" ],
@@ -1625,19 +1625,19 @@ rec(
       statements := [ rec(
               comobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
               rnam := "abc",
-              type := "T_ASS_COMOBJ_NAME" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_COMOBJ_NAME" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASS_COMOBJ_EXPR
+# STAT_ASS_COMOBJ_EXPR
 gap> testit(function(x) x!.("x") := 1; end);
 rec(
   nams := [ "x" ],
@@ -1647,17 +1647,17 @@ rec(
       statements := [ rec(
               comobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               expression := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "x" ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_COMOBJ_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_COMOBJ_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) x!.(1) := 1; end);
@@ -1669,21 +1669,21 @@ rec(
       statements := [ rec(
               comobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               expression := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
               rhs := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_ASS_COMOBJ_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASS_COMOBJ_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_COMOBJ_NAME
+# STAT_UNB_COMOBJ_NAME
 gap> testit(function(x) Unbind(x!.abc); end);
 rec(
   nams := [ "x" ],
@@ -1693,16 +1693,16 @@ rec(
       statements := [ rec(
               comobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               rnam := "abc",
-              type := "T_UNB_COMOBJ_NAME" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_COMOBJ_NAME" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_UNB_COMOBJ_EXPR
+# STAT_UNB_COMOBJ_EXPR
 gap> testit(function(x) Unbind(x!.("x")); end);
 rec(
   nams := [ "x" ],
@@ -1712,14 +1712,14 @@ rec(
       statements := [ rec(
               comobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               expression := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "x" ),
-              type := "T_UNB_COMOBJ_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_COMOBJ_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(x) Unbind(x!.(1)); end);
@@ -1731,18 +1731,18 @@ rec(
       statements := [ rec(
               comobj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
+                  type := "EXPR_REF_LVAR" ),
               expression := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_UNB_COMOBJ_EXPR" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_UNB_COMOBJ_EXPR" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_INFO
+# STAT_INFO
 gap> testit(function(x) Info(1, "test"); end);
 rec(
   nams := [ "x" ],
@@ -1752,19 +1752,19 @@ rec(
       statements := [ rec(
               args := [  ],
               lev := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "test" ),
               sel := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_INFO" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_INFO" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASSERT_2ARGS
+# STAT_ASSERT_2ARGS
 gap> testit(function(x) Assert(0, true); end);
 rec(
   nams := [ "x" ],
@@ -1773,18 +1773,18 @@ rec(
   stats := rec(
       statements := [ rec(
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
+                  type := "EXPR_TRUE" ),
               level := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 0 ),
-              type := "T_ASSERT_2ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASSERT_2ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ASSERT_3ARGS
+# STAT_ASSERT_3ARGS
 gap> testit(function(x) Assert(0, true, "message"); end);
 rec(
   nams := [ "x" ],
@@ -1793,17 +1793,17 @@ rec(
   stats := rec(
       statements := [ rec(
               condition := rec(
-                  type := "T_TRUE_EXPR" ),
+                  type := "EXPR_TRUE" ),
               level := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 0 ),
               message := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "message" ),
-              type := "T_ASSERT_3ARGS" ), rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT2" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_ASSERT_3ARGS" ), rec(
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT2" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
@@ -1812,7 +1812,7 @@ true
 #
 
 #
-# T_FUNCCALL_0ARGS
+# EXPR_FUNCCALL_0ARGS
 gap> testit(x -> x());
 rec(
   nams := [ "x" ],
@@ -1824,15 +1824,15 @@ rec(
                   args := [  ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_0ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_0ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_1ARGS
+# EXPR_FUNCCALL_1ARGS
 gap> testit(x -> x(1));
 rec(
   nams := [ "x" ],
@@ -1842,19 +1842,19 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_1ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_1ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_2ARGS
+# EXPR_FUNCCALL_2ARGS
 gap> testit(x -> x(1,2));
 rec(
   nams := [ "x" ],
@@ -1864,21 +1864,21 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_2ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_2ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_3ARGS
+# EXPR_FUNCCALL_3ARGS
 gap> testit(x -> x(1,2,3));
 rec(
   nams := [ "x" ],
@@ -1888,23 +1888,23 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 3 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_3ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_3ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_4ARGS
+# EXPR_FUNCCALL_4ARGS
 gap> testit(x -> x(1,2,3,4));
 rec(
   nams := [ "x" ],
@@ -1914,25 +1914,25 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 3 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 4 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_4ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_4ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_5ARGS
+# EXPR_FUNCCALL_5ARGS
 gap> testit(x -> x(1,2,3,4,5));
 rec(
   nams := [ "x" ],
@@ -1942,27 +1942,27 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 3 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 4 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 5 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_5ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_5ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_6ARGS
+# EXPR_FUNCCALL_6ARGS
 gap> testit(x -> x(1,2,3,4,5,6));
 rec(
   nams := [ "x" ],
@@ -1972,29 +1972,29 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 3 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 4 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 5 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 6 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_6ARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_6ARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_XARGS
+# EXPR_FUNCCALL_XARGS
 gap> testit(x -> x(1,2,3,4,5,6,7));
 rec(
   nams := [ "x" ],
@@ -2004,31 +2004,31 @@ rec(
       statements := [ rec(
               obj := rec(
                   args := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 3 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 4 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 5 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 6 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 7 ) ],
                   funcref := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_FUNCCALL_XARGS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_FUNCCALL_XARGS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNC_EXPR
+# EXPR_FUNC
 gap> testit(function(x) local y, z; end);
 rec(
   nams := [ "x", "y", "z" ],
@@ -2036,9 +2036,9 @@ rec(
   nloc := 2,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(function(arg) end);
@@ -2048,9 +2048,9 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := true )
 true
 gap> testit(function(x,y...) end);
@@ -2060,9 +2060,9 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := true )
 true
 gap> testit(function(x1,x2,x3,x4,x5,x6,x7,x8,x9) end);
@@ -2072,9 +2072,9 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
-              type := "T_RETURN_VOID" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_VOID" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> y -> [x,y]); # nested functions
@@ -2093,21 +2093,21 @@ rec(
                               obj := rec(
                                   list := [ rec(
                                           hvar := 65537,
-                                          type := "T_REF_HVAR" ), rec(
+                                          type := "EXPR_REF_HVAR" ), rec(
                                           lvar := 1,
-                                          type := "T_REFLVAR" ) ],
-                                  type := "T_LIST_EXPR" ),
-                              type := "T_RETURN_OBJ" ) ],
-                      type := "T_SEQ_STAT" ),
-                  type := "T_FUNC_EXPR",
+                                          type := "EXPR_REF_LVAR" ) ],
+                                  type := "EXPR_LIST" ),
+                              type := "STAT_RETURN_OBJ" ) ],
+                      type := "STAT_SEQ_STAT" ),
+                  type := "EXPR_FUNC",
                   variadic := false ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FUNCCALL_OPTS
+# EXPR_FUNCCALL_OPTS
 gap> testit(x -> x(1 : opt));
 rec(
   nams := [ "x" ],
@@ -2118,22 +2118,22 @@ rec(
               obj := rec(
                   call := rec(
                       args := [ rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 1 ) ],
                       funcref := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ),
-                      type := "T_FUNCCALL_1ARGS" ),
+                          type := "EXPR_REF_LVAR" ),
+                      type := "EXPR_FUNCCALL_1ARGS" ),
                   opts := rec(
                       keyvalue := [ rec(
                               key := "opt",
                               value := rec(
-                                  type := "T_TRUE_EXPR" ) ) ],
-                      type := "T_REC_EXPR" ),
-                  type := "T_FUNCCALL_OPTS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                                  type := "EXPR_TRUE" ) ) ],
+                      type := "EXPR_REC" ),
+                  type := "EXPR_FUNCCALL_OPTS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> x(1 : opt := 42));
@@ -2146,27 +2146,27 @@ rec(
               obj := rec(
                   call := rec(
                       args := [ rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 1 ) ],
                       funcref := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ),
-                      type := "T_FUNCCALL_1ARGS" ),
+                          type := "EXPR_REF_LVAR" ),
+                      type := "EXPR_FUNCCALL_1ARGS" ),
                   opts := rec(
                       keyvalue := [ rec(
                               key := "opt",
                               value := rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 42 ) ) ],
-                      type := "T_REC_EXPR" ),
-                  type := "T_FUNCCALL_OPTS" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REC" ),
+                  type := "EXPR_FUNCCALL_OPTS" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_OR
+# EXPR_OR
 gap> testit({x,y} -> x or y);
 rec(
   nams := [ "x", "y" ],
@@ -2177,18 +2177,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_OR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_OR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_AND
+# EXPR_AND
 gap> testit({x,y} -> x and y);
 rec(
   nams := [ "x", "y" ],
@@ -2199,18 +2199,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_AND" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_AND" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_NOT
+# EXPR_NOT
 gap> testit(x -> not x);
 rec(
   nams := [ "x" ],
@@ -2221,15 +2221,15 @@ rec(
               obj := rec(
                   op := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_NOT" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_NOT" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_EQ
+# EXPR_EQ
 gap> testit({x,y} -> x = y);
 rec(
   nams := [ "x", "y" ],
@@ -2240,18 +2240,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_EQ" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_EQ" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_NE
+# EXPR_NE
 gap> testit({x,y} -> x <> y);
 rec(
   nams := [ "x", "y" ],
@@ -2262,18 +2262,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_NE" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_NE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_LT
+# EXPR_LT
 gap> testit({x,y} -> x < y);
 rec(
   nams := [ "x", "y" ],
@@ -2284,18 +2284,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_LT" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_LT" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_GE
+# EXPR_GE
 gap> testit({x,y} -> x >= y);
 rec(
   nams := [ "x", "y" ],
@@ -2306,18 +2306,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_GE" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_GE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_GT
+# EXPR_GT
 gap> testit({x,y} -> x > y);
 rec(
   nams := [ "x", "y" ],
@@ -2328,18 +2328,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_GT" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_GT" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_LE
+# EXPR_LE
 gap> testit({x,y} -> x <= y);
 rec(
   nams := [ "x", "y" ],
@@ -2350,18 +2350,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_LE" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_LE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_IN
+# EXPR_IN
 gap> testit({x,y} -> x in y);
 rec(
   nams := [ "x", "y" ],
@@ -2372,18 +2372,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_IN" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_IN" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_SUM
+# EXPR_SUM
 gap> testit({x,y} -> x + y);
 rec(
   nams := [ "x", "y" ],
@@ -2394,18 +2394,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_SUM" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_SUM" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_AINV
+# EXPR_AINV
 gap> testit(x -> -x);
 rec(
   nams := [ "x" ],
@@ -2416,15 +2416,15 @@ rec(
               obj := rec(
                   op := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_AINV" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_AINV" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_DIFF
+# EXPR_DIFF
 gap> testit({x,y} -> x - y);
 rec(
   nams := [ "x", "y" ],
@@ -2435,18 +2435,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_DIFF" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_DIFF" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PROD
+# EXPR_PROD
 gap> testit({x,y} -> x * y);
 rec(
   nams := [ "x", "y" ],
@@ -2457,18 +2457,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_PROD" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_PROD" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_QUO
+# EXPR_QUO
 gap> testit({x,y} -> x / y);
 rec(
   nams := [ "x", "y" ],
@@ -2479,18 +2479,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_QUO" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_QUO" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_MOD
+# EXPR_MOD
 gap> testit({x,y} -> x mod y);
 rec(
   nams := [ "x", "y" ],
@@ -2501,18 +2501,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_MOD" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_MOD" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_POW
+# EXPR_POW
 gap> testit({x,y} -> x ^ y);
 rec(
   nams := [ "x", "y" ],
@@ -2523,18 +2523,18 @@ rec(
               obj := rec(
                   left := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   right := rec(
                       lvar := 2,
-                      type := "T_REFLVAR" ),
-                  type := "T_POW" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_POW" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_INTEXPR
+# EXPR_INT
 gap> testit(x -> 1);
 rec(
   nams := [ "x" ],
@@ -2543,15 +2543,15 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_INTEXPR",
+                  type := "EXPR_INT",
                   value := 1 ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_INT_EXPR
+# EXPR_INTPOS
 gap> testit(x -> 12345678901234567890);
 rec(
   nams := [ "x" ],
@@ -2560,15 +2560,15 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_INT_EXPR",
+                  type := "EXPR_INTPOS",
                   value := 12345678901234567890 ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_TRUE_EXPR
+# EXPR_TRUE
 gap> testit(x -> true);
 rec(
   nams := [ "x" ],
@@ -2577,14 +2577,14 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_TRUE_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TRUE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FALSE_EXPR
+# EXPR_FALSE
 gap> testit(x -> false);
 rec(
   nams := [ "x" ],
@@ -2593,14 +2593,14 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_FALSE_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_FALSE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_TILDE_EXPR
+# EXPR_TILDE
 gap> [ testit(x -> ~) ];
 rec(
   nams := [ "x" ],
@@ -2609,14 +2609,14 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_TILDE_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_TILDE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 [ true ]
 
-# T_CHAR_EXPR
+# EXPR_CHAR
 gap> testit(x -> 'a');
 rec(
   nams := [ "x" ],
@@ -2625,16 +2625,16 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_CHAR_EXPR",
+                  type := "EXPR_CHAR",
                   value := 'a' ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_PERM_EXPR
-# T_PERM_CYCLE
+# EXPR_PERM
+# EXPR_PERM_CYCLE
 gap> testit(x -> (1,2)(3,4,5));
 rec(
   nams := [ "x" ],
@@ -2645,27 +2645,27 @@ rec(
               obj := rec(
                   cycles := [ rec(
                           points := [ rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 1 ), rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 2 ) ],
-                          type := "T_PERM_CYCLE" ), rec(
+                          type := "EXPR_PERM_CYCLE" ), rec(
                           points := [ rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 3 ), rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 4 ), rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 5 ) ],
-                          type := "T_PERM_CYCLE" ) ],
-                  type := "T_PERM_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_PERM_CYCLE" ) ],
+                  type := "EXPR_PERM" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_LIST_EXPR
+# EXPR_LIST
 gap> testit(x -> []);
 rec(
   nams := [ "x" ],
@@ -2675,10 +2675,10 @@ rec(
       statements := [ rec(
               obj := rec(
                   list := [  ],
-                  type := "T_LIST_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> [1,2]);
@@ -2690,14 +2690,14 @@ rec(
       statements := [ rec(
               obj := rec(
                   list := [ rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 1 ), rec(
-                          type := "T_INTEXPR",
+                          type := "EXPR_INT",
                           value := 2 ) ],
-                  type := "T_LIST_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit( x -> [, [] ] );
@@ -2710,15 +2710,15 @@ rec(
               obj := rec(
                   list := [ , rec(
                           list := [  ],
-                          type := "T_LIST_EXPR" ) ],
-                  type := "T_LIST_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_LIST" ) ],
+                  type := "EXPR_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_LIST_TILDE_EXPR
+# EXPR_LIST_TILDE
 gap> testit(x -> [~]);
 rec(
   nams := [ "x" ],
@@ -2728,15 +2728,15 @@ rec(
       statements := [ rec(
               obj := rec(
                   list := [ rec(
-                          type := "T_TILDE_EXPR" ) ],
-                  type := "T_LIST_TILDE_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_TILDE" ) ],
+                  type := "EXPR_LIST_TILDE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_RANGE_EXPR
+# EXPR_RANGE
 gap> testit(x -> [1..x]);
 rec(
   nams := [ "x" ],
@@ -2746,19 +2746,19 @@ rec(
       statements := [ rec(
               obj := rec(
                   first := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   last := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_RANGE_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_RANGE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_STRING_EXPR
+# EXPR_STRING
 gap> testit(x -> "abc");
 rec(
   nams := [ "x" ],
@@ -2767,15 +2767,15 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_STRING_EXPR",
+                  type := "EXPR_STRING",
                   value := "abc" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_REC_EXPR
+# EXPR_REC
 gap> testit(x -> rec( abc := 1 ));
 rec(
   nams := [ "x" ],
@@ -2787,12 +2787,12 @@ rec(
                   keyvalue := [ rec(
                           key := "abc",
                           value := rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 1 ) ) ],
-                  type := "T_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REC" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> rec( (x) := 1 ));
@@ -2806,14 +2806,14 @@ rec(
                   keyvalue := [ rec(
                           key := rec(
                               lvar := 1,
-                              type := "T_REFLVAR" ),
+                              type := "EXPR_REF_LVAR" ),
                           value := rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 1 ) ) ],
-                  type := "T_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REC" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> rec( ("abc") := 1 ));
@@ -2826,15 +2826,15 @@ rec(
               obj := rec(
                   keyvalue := [ rec(
                           key := rec(
-                              type := "T_STRING_EXPR",
+                              type := "EXPR_STRING",
                               value := "abc" ),
                           value := rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 1 ) ) ],
-                  type := "T_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REC" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> rec( (1) := 1 )); # this gets optimized
@@ -2848,16 +2848,16 @@ rec(
                   keyvalue := [ rec(
                           key := "1",
                           value := rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 1 ) ) ],
-                  type := "T_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REC" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_REC_TILDE_EXPR
+# EXPR_REC_TILDE
 gap> testit(x -> [~]);
 rec(
   nams := [ "x" ],
@@ -2867,15 +2867,15 @@ rec(
       statements := [ rec(
               obj := rec(
                   list := [ rec(
-                          type := "T_TILDE_EXPR" ) ],
-                  type := "T_LIST_TILDE_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                          type := "EXPR_TILDE" ) ],
+                  type := "EXPR_LIST_TILDE" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FLOAT_EXPR_EAGER
+# EXPR_FLOAT_EAGER
 gap> testit(x -> 1.0_);
 rec(
   nams := [ "x" ],
@@ -2886,15 +2886,15 @@ rec(
               obj := rec(
                   mark := '\000',
                   string := "1.0",
-                  type := "T_FLOAT_EXPR_EAGER",
+                  type := "EXPR_FLOAT_EAGER",
                   value := 1. ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_FLOAT_EXPR_LAZY
+# EXPR_FLOAT_LAZY
 gap> testit(x -> 1.0);
 rec(
   nams := [ "x" ],
@@ -2903,15 +2903,15 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
-                  type := "T_FLOAT_EXPR_LAZY",
+                  type := "EXPR_FLOAT_LAZY",
                   value := "1.0" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_REFLVAR
+# EXPR_REF_LVAR
 gap> testit(x -> x);
 rec(
   nams := [ "x" ],
@@ -2921,14 +2921,14 @@ rec(
       statements := [ rec(
               obj := rec(
                   lvar := 1,
-                  type := "T_REFLVAR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_LVAR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_LVAR
+# EXPR_ISB_LVAR
 gap> testit(x -> IsBound(x));
 rec(
   nams := [ "x" ],
@@ -2938,14 +2938,14 @@ rec(
       statements := [ rec(
               obj := rec(
                   lvar := 1,
-                  type := "T_ISB_LVAR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ISB_LVAR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_REF_HVAR
+# EXPR_REF_HVAR
 gap> testit(x -> y -> x);
 rec(
   nams := [ "x" ],
@@ -2961,18 +2961,18 @@ rec(
                       statements := [ rec(
                               obj := rec(
                                   hvar := 65537,
-                                  type := "T_REF_HVAR" ),
-                              type := "T_RETURN_OBJ" ) ],
-                      type := "T_SEQ_STAT" ),
-                  type := "T_FUNC_EXPR",
+                                  type := "EXPR_REF_HVAR" ),
+                              type := "STAT_RETURN_OBJ" ) ],
+                      type := "STAT_SEQ_STAT" ),
+                  type := "EXPR_FUNC",
                   variadic := false ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_HVAR
+# EXPR_ISB_HVAR
 gap> testit(x -> y -> IsBound(x));
 rec(
   nams := [ "x" ],
@@ -2988,18 +2988,18 @@ rec(
                       statements := [ rec(
                               obj := rec(
                                   hvar := 65537,
-                                  type := "T_ISB_HVAR" ),
-                              type := "T_RETURN_OBJ" ) ],
-                      type := "T_SEQ_STAT" ),
-                  type := "T_FUNC_EXPR",
+                                  type := "EXPR_ISB_HVAR" ),
+                              type := "STAT_RETURN_OBJ" ) ],
+                      type := "STAT_SEQ_STAT" ),
+                  type := "EXPR_FUNC",
                   variadic := false ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_REF_GVAR
+# EXPR_REF_GVAR
 gap> testit(x -> testit);
 rec(
   nams := [ "x" ],
@@ -3009,14 +3009,14 @@ rec(
       statements := [ rec(
               obj := rec(
                   gvar := "testit",
-                  type := "T_REF_GVAR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_REF_GVAR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_GVAR
+# EXPR_ISB_GVAR
 gap> testit(x -> IsBound(testit));
 rec(
   nams := [ "x" ],
@@ -3026,14 +3026,14 @@ rec(
       statements := [ rec(
               obj := rec(
                   gvar := "testit",
-                  type := "T_ISB_GVAR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ISB_GVAR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_LIST
+# EXPR_ELM_LIST
 gap> testit(x -> x[42]);
 rec(
   nams := [ "x" ],
@@ -3044,18 +3044,18 @@ rec(
               obj := rec(
                   list := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   pos := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 42 ),
-                  type := "T_ELM_LIST" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ELM_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM2_LIST
+# EXPR_ELM2_LIST
 gap> testit(x -> x[42,23]);
 rec(
   nams := [ "x" ],
@@ -3066,21 +3066,21 @@ rec(
               obj := rec(
                   list := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   pos1 := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 42 ),
                   pos2 := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 23 ),
-                  type := "T_ELM2_LIST" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ELM2_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELMS_LIST
+# EXPR_ELMS_LIST
 gap> testit(x -> x{[42]});
 rec(
   nams := [ "x" ],
@@ -3091,20 +3091,20 @@ rec(
               obj := rec(
                   list := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   poss := rec(
                       list := [ rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 42 ) ],
-                      type := "T_LIST_EXPR" ),
-                  type := "T_ELMS_LIST" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_LIST" ),
+                  type := "EXPR_ELMS_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_LIST_LEV
+# EXPR_ELM_LIST_LEV
 gap> testit(x -> x{[42]}[23]);
 rec(
   nams := [ "x" ],
@@ -3114,29 +3114,29 @@ rec(
       statements := [ rec(
               obj := rec(
                   level := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 0 ),
                   lists := rec(
                       list := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ),
+                          type := "EXPR_REF_LVAR" ),
                       poss := rec(
                           list := [ rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 42 ) ],
-                          type := "T_LIST_EXPR" ),
-                      type := "T_ELMS_LIST" ),
+                          type := "EXPR_LIST" ),
+                      type := "EXPR_ELMS_LIST" ),
                   pos := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 23 ),
-                  type := "T_ELM_LIST_LEV" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ELM_LIST_LEV" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELMS_LIST_LEV
+# EXPR_ELMS_LIST_LEV
 gap> testit(x -> x{[42]}{[23]});
 rec(
   nams := [ "x" ],
@@ -3146,31 +3146,31 @@ rec(
       statements := [ rec(
               obj := rec(
                   level := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 0 ),
                   lists := rec(
                       list := rec(
                           lvar := 1,
-                          type := "T_REFLVAR" ),
+                          type := "EXPR_REF_LVAR" ),
                       poss := rec(
                           list := [ rec(
-                                  type := "T_INTEXPR",
+                                  type := "EXPR_INT",
                                   value := 42 ) ],
-                          type := "T_LIST_EXPR" ),
-                      type := "T_ELMS_LIST" ),
+                          type := "EXPR_LIST" ),
+                      type := "EXPR_ELMS_LIST" ),
                   poss := rec(
                       list := [ rec(
-                              type := "T_INTEXPR",
+                              type := "EXPR_INT",
                               value := 23 ) ],
-                      type := "T_LIST_EXPR" ),
-                  type := "T_ELMS_LIST_LEV" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_LIST" ),
+                  type := "EXPR_ELMS_LIST_LEV" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_LIST
+# EXPR_ISB_LIST
 gap> testit(x -> IsBound(x[42]));
 rec(
   nams := [ "x" ],
@@ -3181,18 +3181,18 @@ rec(
               obj := rec(
                   list := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   pos := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 42 ),
-                  type := "T_ISB_LIST" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ISB_LIST" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_REC_NAME
+# EXPR_ELM_REC_NAME
 gap> testit(x -> x.abc);
 rec(
   nams := [ "x" ],
@@ -3204,15 +3204,15 @@ rec(
                   name := "abc",
                   record := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ELM_REC_NAME" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ELM_REC_NAME" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_REC_EXPR
+# EXPR_ELM_REC_EXPR
 gap> testit(x -> x.("x"));
 rec(
   nams := [ "x" ],
@@ -3222,15 +3222,15 @@ rec(
       statements := [ rec(
               obj := rec(
                   expression := rec(
-                      type := "T_STRING_EXPR",
+                      type := "EXPR_STRING",
                       value := "x" ),
                   record := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ELM_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ELM_REC_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> x.(1));
@@ -3242,19 +3242,19 @@ rec(
       statements := [ rec(
               obj := rec(
                   expression := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   record := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ELM_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ELM_REC_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_REC_NAME
+# EXPR_ISB_REC_NAME
 gap> testit(x -> IsBound(x.abc));
 rec(
   nams := [ "x" ],
@@ -3266,15 +3266,15 @@ rec(
                   name := "abc",
                   record := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ISB_REC_NAME" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ISB_REC_NAME" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_REC_EXPR
+# EXPR_ISB_REC_EXPR
 gap> testit(x -> IsBound(x.("x")));
 rec(
   nams := [ "x" ],
@@ -3284,15 +3284,15 @@ rec(
       statements := [ rec(
               obj := rec(
                   expression := rec(
-                      type := "T_STRING_EXPR",
+                      type := "EXPR_STRING",
                       value := "x" ),
                   record := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ISB_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ISB_REC_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> IsBound(x.(1)));
@@ -3304,19 +3304,19 @@ rec(
       statements := [ rec(
               obj := rec(
                   expression := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
                   record := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ISB_REC_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ISB_REC_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_POSOBJ
+# EXPR_ELM_POSOBJ
 gap> testit(x -> x![42]);
 rec(
   nams := [ "x" ],
@@ -3326,19 +3326,19 @@ rec(
       statements := [ rec(
               obj := rec(
                   pos := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 42 ),
                   posobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ELM_POSOBJ" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ELM_POSOBJ" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_POSOBJ
+# EXPR_ISB_POSOBJ
 gap> testit(x -> IsBound(x![42]));
 rec(
   nams := [ "x" ],
@@ -3348,19 +3348,19 @@ rec(
       statements := [ rec(
               obj := rec(
                   pos := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 42 ),
                   posobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
-                  type := "T_ISB_POSOBJ" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                      type := "EXPR_REF_LVAR" ),
+                  type := "EXPR_ISB_POSOBJ" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_COMOBJ_NAME
+# EXPR_ELM_COMOBJ_NAME
 gap> testit(x -> x!.abc);
 rec(
   nams := [ "x" ],
@@ -3371,16 +3371,16 @@ rec(
               obj := rec(
                   comobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   name := "abc",
-                  type := "T_ELM_COMOBJ_NAME" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ELM_COMOBJ_NAME" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ELM_COMOBJ_EXPR
+# EXPR_ELM_COMOBJ_EXPR
 gap> testit(x -> x!.("x"));
 rec(
   nams := [ "x" ],
@@ -3391,14 +3391,14 @@ rec(
               obj := rec(
                   comobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   expression := rec(
-                      type := "T_STRING_EXPR",
+                      type := "EXPR_STRING",
                       value := "x" ),
-                  type := "T_ELM_COMOBJ_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ELM_COMOBJ_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> x!.(1));
@@ -3411,18 +3411,18 @@ rec(
               obj := rec(
                   comobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   expression := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
-                  type := "T_ELM_COMOBJ_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ELM_COMOBJ_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_COMOBJ_NAME
+# EXPR_ISB_COMOBJ_NAME
 gap> testit(x -> IsBound(x!.abc));
 rec(
   nams := [ "x" ],
@@ -3433,16 +3433,16 @@ rec(
               obj := rec(
                   comobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   name := "abc",
-                  type := "T_ISB_COMOBJ_NAME" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ISB_COMOBJ_NAME" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 
-# T_ISB_COMOBJ_EXPR
+# EXPR_ISB_COMOBJ_EXPR
 gap> testit(x -> IsBound(x!.("x")));
 rec(
   nams := [ "x" ],
@@ -3453,14 +3453,14 @@ rec(
               obj := rec(
                   comobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   expression := rec(
-                      type := "T_STRING_EXPR",
+                      type := "EXPR_STRING",
                       value := "x" ),
-                  type := "T_ISB_COMOBJ_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ISB_COMOBJ_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true
 gap> testit(x -> IsBound(x!.(1)));
@@ -3473,13 +3473,13 @@ rec(
               obj := rec(
                   comobj := rec(
                       lvar := 1,
-                      type := "T_REFLVAR" ),
+                      type := "EXPR_REF_LVAR" ),
                   expression := rec(
-                      type := "T_INTEXPR",
+                      type := "EXPR_INT",
                       value := 1 ),
-                  type := "T_ISB_COMOBJ_EXPR" ),
-              type := "T_RETURN_OBJ" ) ],
-      type := "T_SEQ_STAT" ),
-  type := "T_FUNC_EXPR",
+                  type := "EXPR_ISB_COMOBJ_EXPR" ),
+              type := "STAT_RETURN_OBJ" ) ],
+      type := "STAT_SEQ_STAT" ),
+  type := "EXPR_FUNC",
   variadic := false )
 true


### PR DESCRIPTION
(This PR is motivated by repeated experiences trying to explain to people how GAP encodes function bodies. It is meant to make this code slightly more accessible.)

A long, long time ago, the statements and expressions which make up GAP function bodies were each coded as a separate GAP object. This is very inefficient for various reasons, so it was changed; now expressions and statements were simply a bunch of bytes within a single GAP object of type `T_BODY`, with a specific format. Yet they all retained their "identity" in the form of a  type number, such as `T_WHILE` to indicate a statement representing a while loop. To these day, the kernel code refers to these as "TNUMs".

This can be rather confusing, as those TNUMs have nothing to do anymore with the GAP object TNUMs; yet they do not only still have the same name, but also they all share the same `T_` prefix. E.g. we have `T_STRING` (an object tnum) and `T_STRING_EXPR` (an expression tnum).

We discussed this on slack some time ago. The consensus seemed to be that we should rename these, turning the `T_` into either `STAT_` or `EXPR_`, depending on the type.
One alternative would be to use the same prefix for both, as there really is no difference between the two on a purely technical (low) level; the main importance for distinguishing the two cases is in validation of the coded function's structure, resp. whether in knowing which dispatch table to look when evaluating them. But for that it's not necessary to give them different names...
Alas, since a lot of code now tries hard to distinguish precisely between the two, I think it makes sense to go with the split here for now; if one day in the future we decided to unify expressions and statement terminology again, doing it for these "tnums" will be about the easiest part anyway ;-). 


To perform the actual change, I wrote a little shell script, which I put into this PR. That makes it trivial to change things around: if we want another pair of prefixes: no problem. Also, if we merge some other PRs which will conflict with this PR (e.g. @sebasguts's PR #3371 which definitely should be merged before this PR), then it is trivial for me to recreate this PR.

Before this can be merged, some steps should be taken:
- [ ] make sure everybody is OK with this change (obviously)
- [x] merge other conflicting PRs, such as PR #3371
- [ ] come up with a better term than "statement or expression tnum" and use that consistently (perhaps "statement type" and "expression type" 
- [ ] to reduce confusion further, possibly rename a few existing identifiers in the kernel code which already have the `STAT_` prefix (there are none with `EXPR_` prefix), namely:
  - [ ] `STAT_HEADER`
  - [x] `STAT_MARK_CACHE`
  - [ ] `STAT_LVARS`
  - [ ] `STAT_LVARS_PTR`


