### PR TITLE
gac: fix calling non-standard functions

### DIFF
--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -224,8 +224,8 @@ static Obj  HdlrFunc2 (
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -239,10 +239,10 @@ static Obj  HdlrFunc2 (
  /* if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then */
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
- CHECK_BOUND( t_4, "IMM_FLAGS" )
+ CHECK_BOUND( t_4, "IMM_FLAGS" );
  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -256,18 +256,18 @@ static Obj  HdlrFunc2 (
  /* flags := SUB_FLAGS( flags, IMM_FLAGS ); */
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
- CHECK_BOUND( t_3, "IMM_FLAGS" )
+ CHECK_BOUND( t_3, "IMM_FLAGS" );
  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flagspos = t_1;
  
  /* tried := [  ]; */
@@ -278,7 +278,7 @@ static Obj  HdlrFunc2 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* flags := type![2]; */
@@ -287,14 +287,14 @@ static Obj  HdlrFunc2 (
  
  /* RUN_IMMEDIATE_METHODS_RUNS := RUN_IMMEDIATE_METHODS_RUNS + 1; */
  t_2 = GC_RUN__IMMEDIATE__METHODS__RUNS;
- CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" )
+ CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_RUN__IMMEDIATE__METHODS__RUNS, t_1 );
  
  /* if TRACE_IMMEDIATE_METHODS then */
  t_2 = GC_TRACE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -331,26 +331,26 @@ static Obj  HdlrFunc2 (
   
   /* if IsBound( IMMEDIATES[j] ) then */
   t_7 = GC_IMMEDIATES;
-  CHECK_BOUND( t_7, "IMMEDIATES" )
-  CHECK_INT_POS( l_j )
+  CHECK_BOUND( t_7, "IMMEDIATES" );
+  CHECK_INT_POS( l_j );
   t_6 = C_ISB_LIST( t_7, l_j );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* imm := IMMEDIATES[j]; */
    t_6 = GC_IMMEDIATES;
-   CHECK_BOUND( t_6, "IMMEDIATES" )
+   CHECK_BOUND( t_6, "IMMEDIATES" );
    C_ELM_LIST_FPL( t_5, t_6, l_j )
    l_imm = t_5;
    
    /* for i in [ 0, SIZE_IMMEDIATE_METHOD_ENTRY .. LEN_LIST( imm ) - SIZE_IMMEDIATE_METHOD_ENTRY ] do */
    t_9 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    t_12 = GF_LEN__LIST;
    t_11 = CALL_1ARGS( t_12, l_imm );
-   CHECK_FUNC_RESULT( t_11 )
+   CHECK_FUNC_RESULT( t_11 );
    t_12 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    C_DIFF_FIA( t_10, t_11, t_12 )
    t_8 = Range3Check( INTOBJ_INT(0), t_9, t_10 );
    if ( IS_SMALL_LIST(t_8) ) {
@@ -377,21 +377,21 @@ static Obj  HdlrFunc2 (
     /* if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then */
     t_13 = GF_IS__SUBSET__FLAGS;
     C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
-    CHECK_INT_POS( t_15 )
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_14, l_imm, t_15 )
     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
-    CHECK_FUNC_RESULT( t_12 )
-    CHECK_BOOL( t_12 )
+    CHECK_FUNC_RESULT( t_12 );
+    CHECK_BOOL( t_12 );
     t_11 = (Obj)(UInt)(t_12 != False);
     t_10 = t_11;
     if ( t_10 ) {
      t_15 = GF_IS__SUBSET__FLAGS;
      C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
-     CHECK_INT_POS( t_17 )
+     CHECK_INT_POS( t_17 );
      C_ELM_LIST_FPL( t_16, l_imm, t_17 )
      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
-     CHECK_FUNC_RESULT( t_14 )
-     CHECK_BOOL( t_14 )
+     CHECK_FUNC_RESULT( t_14 );
+     CHECK_BOOL( t_14 );
      t_13 = (Obj)(UInt)(t_14 != False);
      t_12 = (Obj)(UInt)( ! ((Int)t_13) );
      t_10 = t_12;
@@ -399,7 +399,7 @@ static Obj  HdlrFunc2 (
     t_9 = t_10;
     if ( t_9 ) {
      C_SUM_FIA( t_14, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_14 )
+     CHECK_INT_POS( t_14 );
      C_ELM_LIST_FPL( t_13, l_imm, t_14 )
      t_12 = (Obj)(UInt)(IN( t_13, l_tried ));
      t_11 = (Obj)(UInt)( ! ((Int)t_12) );
@@ -409,37 +409,37 @@ static Obj  HdlrFunc2 (
      
      /* meth := IMMEDIATE_METHODS[imm[i + 6]]; */
      t_10 = GC_IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" )
+     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" );
      C_SUM_FIA( t_12, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_12 )
+     CHECK_INT_POS( t_12 );
      C_ELM_LIST_FPL( t_11, l_imm, t_12 )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_9, t_10, t_11 )
      l_meth = t_9;
      
      /* res := meth( obj ); */
-     CHECK_FUNC( l_meth )
+     CHECK_FUNC( l_meth );
      t_9 = CALL_1ARGS( l_meth, a_obj );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      l_res = t_9;
      
      /* ADD_LIST( tried, imm[i + 6] ); */
      t_9 = GF_ADD__LIST;
      C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
      CALL_2ARGS( t_9, l_tried, t_10 );
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
-     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" )
+     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" );
      C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
      AssGVar( G_RUN__IMMEDIATE__METHODS__CHECKS, t_9 );
      
      /* if TRACE_IMMEDIATE_METHODS then */
      t_10 = GC_TRACE__IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" )
-     CHECK_BOOL( t_10 )
+     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" );
+     CHECK_BOOL( t_10 );
      t_9 = (Obj)(UInt)(t_10 != False);
      if ( t_9 ) {
       
@@ -448,15 +448,15 @@ static Obj  HdlrFunc2 (
       t_10 = MakeString( "#I  immediate: " );
       t_12 = GF_NAME__FUNC;
       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_14 )
+      CHECK_INT_POS( t_14 );
       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
       t_11 = CALL_1ARGS( t_12, t_13 );
-      CHECK_FUNC_RESULT( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
       CALL_2ARGS( t_9, t_10, t_11 );
       
       /* if imm[i + 7] <> false then */
       C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
-      CHECK_INT_POS( t_11 )
+      CHECK_INT_POS( t_11 );
       C_ELM_LIST_FPL( t_10, l_imm, t_11 )
       t_11 = False;
       t_9 = (Obj)(UInt)( ! EQ( t_10, t_11 ));
@@ -466,7 +466,7 @@ static Obj  HdlrFunc2 (
        t_9 = GF_Print;
        t_10 = MakeString( ": " );
        C_SUM_FIA( t_12, l_i, INTOBJ_INT(7) )
-       CHECK_INT_POS( t_12 )
+       CHECK_INT_POS( t_12 );
        C_ELM_LIST_FPL( t_11, l_imm, t_12 )
        CALL_2ARGS( t_9, t_10, t_11 );
        
@@ -477,12 +477,12 @@ static Obj  HdlrFunc2 (
       t_9 = GF_Print;
       t_10 = MakeString( " at " );
       C_SUM_FIA( t_13, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_13 )
+      CHECK_INT_POS( t_13 );
       C_ELM_LIST_FPL( t_12, l_imm, t_13 )
       C_ELM_LIST_FPL( t_11, t_12, INTOBJ_INT(1) )
       t_12 = MakeString( ":" );
       C_SUM_FIA( t_15, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_15 )
+      CHECK_INT_POS( t_15 );
       C_ELM_LIST_FPL( t_14, l_imm, t_15 )
       C_ELM_LIST_FPL( t_13, t_14, INTOBJ_INT(2) )
       t_14 = MakeString( "\n" );
@@ -493,7 +493,7 @@ static Obj  HdlrFunc2 (
      
      /* if res <> TRY_NEXT_METHOD then */
      t_10 = GC_TRY__NEXT__METHOD;
-     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" )
+     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" );
      t_9 = (Obj)(UInt)( ! EQ( l_res, t_10 ));
      if ( t_9 ) {
       
@@ -503,9 +503,9 @@ static Obj  HdlrFunc2 (
       
       /* imm[i + 2]( obj, res ); */
       C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
-      CHECK_INT_POS( t_10 )
+      CHECK_INT_POS( t_10 );
       C_ELM_LIST_FPL( t_9, l_imm, t_10 )
-      CHECK_FUNC( t_9 )
+      CHECK_FUNC( t_9 );
       CALL_2ARGS( t_9, a_obj, l_res );
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
@@ -514,7 +514,7 @@ static Obj  HdlrFunc2 (
       
       /* RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1; */
       t_10 = GC_RUN__IMMEDIATE__METHODS__HITS;
-      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" )
+      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" );
       C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
       AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, t_9 );
       
@@ -522,10 +522,10 @@ static Obj  HdlrFunc2 (
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
       t_13 = CALL_1ARGS( t_14, a_obj );
-      CHECK_FUNC_RESULT( t_13 )
+      CHECK_FUNC_RESULT( t_13 );
       t_11 = CALL_2ARGS( t_12, t_13, l_type );
-      CHECK_FUNC_RESULT( t_11 )
-      CHECK_BOOL( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
+      CHECK_BOOL( t_11 );
       t_10 = (Obj)(UInt)(t_11 != False);
       t_9 = (Obj)(UInt)( ! ((Int)t_10) );
       if ( t_9 ) {
@@ -533,29 +533,29 @@ static Obj  HdlrFunc2 (
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
        t_9 = CALL_1ARGS( t_10, a_obj );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_type = t_9;
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
        t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
-       CHECK_BOUND( t_12, "IMM_FLAGS" )
+       CHECK_BOUND( t_12, "IMM_FLAGS" );
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
        t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 )
+       CHECK_FUNC_RESULT( t_10 );
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
@@ -635,15 +635,15 @@ static Obj  HdlrFunc3 (
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_baserank );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* rank := baserank(  ); */
-  CHECK_FUNC( a_baserank )
+  CHECK_FUNC( a_baserank );
   t_1 = CALL_0ARGS( a_baserank );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_rank = t_1;
   
  }
@@ -660,15 +660,15 @@ static Obj  HdlrFunc3 (
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
  t_2 = CALL_1ARGS( t_3, a_opr );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if 0 = LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_flags );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -676,7 +676,7 @@ static Obj  HdlrFunc3 (
    t_1 = GF_Error;
    t_3 = GF_NAME__FUNC;
    t_2 = CALL_1ARGS( t_3, a_opr );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_3 = MakeString( ": constructors must have at least one argument" );
    CALL_2ARGS( t_1, t_2, t_3 );
    
@@ -687,7 +687,7 @@ static Obj  HdlrFunc3 (
   t_3 = GF_RankFilter;
   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_DIFF_FIA( t_1, l_rank, t_2 )
   l_rank = t_1;
   
@@ -722,7 +722,7 @@ static Obj  HdlrFunc3 (
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
    t_6 = CALL_1ARGS( t_7, l_i );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
    
@@ -735,13 +735,13 @@ static Obj  HdlrFunc3 (
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_flags );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_methods = t_1;
  
  /* if info = false then */
@@ -752,7 +752,7 @@ static Obj  HdlrFunc3 (
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
   t_1 = CALL_1ARGS( t_2, a_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   a_info = t_1;
   
  }
@@ -764,9 +764,9 @@ static Obj  HdlrFunc3 (
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
   t_3 = CALL_1ARGS( t_4, a_opr );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
@@ -795,13 +795,13 @@ static Obj  HdlrFunc3 (
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_methods );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
   if ( t_1 ) {
    C_SUM_FIA( t_6, l_narg, INTOBJ_INT(3) )
    C_SUM_FIA( t_5, l_i, t_6 )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ELM_LIST_FPL( t_4, l_methods, t_5 )
    t_3 = (Obj)(UInt)(LT( l_rank, t_4 ));
    t_1 = t_3;
@@ -822,8 +822,8 @@ static Obj  HdlrFunc3 (
  
  /* if REREADING then */
  t_2 = GC_REREADING;
- CHECK_BOUND( t_2, "REREADING" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "REREADING" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -834,13 +834,13 @@ static Obj  HdlrFunc3 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_methods );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
     C_SUM_FIA( t_6, l_k, l_narg )
     C_SUM_FIA( t_5, t_6, INTOBJ_INT(3) )
-    CHECK_INT_POS( t_5 )
+    CHECK_INT_POS( t_5 );
     C_ELM_LIST_FPL( t_4, l_methods, t_5 )
     t_3 = (Obj)(UInt)(EQ( l_rank, t_4 ));
     t_1 = t_3;
@@ -850,7 +850,7 @@ static Obj  HdlrFunc3 (
    /* if info = methods[k + narg + 4] then */
    C_SUM_FIA( t_4, l_k, l_narg )
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(4) )
-   CHECK_INT_POS( t_3 )
+   CHECK_INT_POS( t_3 );
    C_ELM_LIST_FPL( t_2, l_methods, t_3 )
    t_1 = (Obj)(UInt)(EQ( a_info, t_2 ));
    if ( t_1 ) {
@@ -860,7 +860,7 @@ static Obj  HdlrFunc3 (
     l_match = t_1;
     
     /* for j in [ 1 .. narg ] do */
-    CHECK_INT_SMALL( l_narg )
+    CHECK_INT_SMALL( l_narg );
     t_2 = l_narg;
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
@@ -874,7 +874,7 @@ static Obj  HdlrFunc3 (
      else if ( l_match == True ) {
       C_SUM_FIA( t_7, l_k, l_j )
       C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_6 )
+      CHECK_INT_POS( t_6 );
       C_ELM_LIST_FPL( t_5, l_methods, t_6 )
       C_ELM_LIST_FPL( t_6, a_flags, l_j )
       t_4 = (EQ( t_5, t_6 ) ? True : False);
@@ -883,7 +883,7 @@ static Obj  HdlrFunc3 (
      else if (IS_FILTER( l_match ) ) {
       C_SUM_FIA( t_8, l_k, l_j )
       C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_7 )
+      CHECK_INT_POS( t_7 );
       C_ELM_LIST_FPL( t_6, l_methods, t_7 )
       C_ELM_LIST_FPL( t_7, a_flags, l_j )
       t_5 = (EQ( t_6, t_7 ) ? True : False);
@@ -899,7 +899,7 @@ static Obj  HdlrFunc3 (
     /* od */
     
     /* if match then */
-    CHECK_BOOL( l_match )
+    CHECK_BOOL( l_match );
     t_1 = (Obj)(UInt)(l_match != False);
     if ( t_1 ) {
      
@@ -932,8 +932,8 @@ static Obj  HdlrFunc3 (
  
  /* if not REREADING or not replace then */
  t_4 = GC_REREADING;
- CHECK_BOUND( t_4, "REREADING" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "REREADING" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
  t_1 = t_2;
@@ -964,7 +964,7 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_2, 6, INTOBJ_INT(1) );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_methods );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_DIFF_FIA( t_3, t_4, l_i )
   SET_ELM_PLIST( t_2, 7, t_3 );
   CHANGED_BAG( t_2 );
@@ -980,7 +980,7 @@ static Obj  HdlrFunc3 (
   
   /* rel := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_rel = t_1;
   
  }
@@ -993,7 +993,7 @@ static Obj  HdlrFunc3 (
    
    /* rel := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_rel = t_1;
    
   }
@@ -1002,28 +1002,28 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_rel );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD then */
     t_2 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_2 )
+    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_rel );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1042,7 +1042,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <famrel> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1062,7 +1062,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1078,7 +1078,7 @@ static Obj  HdlrFunc3 (
   
   /* method := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_method = t_1;
   
  }
@@ -1091,7 +1091,7 @@ static Obj  HdlrFunc3 (
    
    /* method := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_method = t_1;
    
   }
@@ -1100,22 +1100,22 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_method );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then */
     t_3 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_3 )
+    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
      t_5 = CALL_1ARGS( t_6, a_method );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      t_1 = t_3;
@@ -1125,13 +1125,13 @@ static Obj  HdlrFunc3 (
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_method );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1150,7 +1150,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <method> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1170,7 +1170,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1181,11 +1181,11 @@ static Obj  HdlrFunc3 (
  
  /* methods[i + 1] := rel; */
  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_rel )
  
  /* for k in [ 1 .. narg ] do */
- CHECK_INT_SMALL( l_narg )
+ CHECK_INT_SMALL( l_narg );
  t_2 = l_narg;
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
@@ -1195,7 +1195,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + k + 1] := flags[k]; */
   C_SUM_FIA( t_4, l_i, l_k )
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_3 )
+  CHECK_INT_POS( t_3 );
   C_ELM_LIST_FPL( t_4, a_flags, l_k )
   C_ASS_LIST_FPL( l_methods, t_3, t_4 )
   
@@ -1205,22 +1205,22 @@ static Obj  HdlrFunc3 (
  /* methods[i + (narg + 2)] := method; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_method )
  
  /* methods[i + (narg + 3)] := rank; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(3) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, l_rank )
  
  /* methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info ); */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(4) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  t_3 = GF_IMMUTABLE__COPY__OBJ;
  t_2 = CALL_1ARGS( t_3, a_info );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
  /* if 6 >= 5 then */
@@ -1230,26 +1230,26 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_MakeImmutable;
   t_4 = NEW_PLIST( T_PLIST, 3 );
   SET_LEN_PLIST( t_4, 3 );
   t_6 = GF_INPUT__FILENAME;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_READEVALCOMMAND__LINENUMBER;
-  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" )
+  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_INPUT__LINENUMBER;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 3, t_5 );
   CHANGED_BAG( t_4 );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
  }
@@ -1262,7 +1262,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 6)] := baserank; */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
   
  }
@@ -1400,7 +1400,7 @@ static Obj  HdlrFunc6 (
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_arglist );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_len = t_1;
  
  /* if len < 3 then */
@@ -1422,8 +1422,8 @@ static Obj  HdlrFunc6 (
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
  t_3 = CALL_1ARGS( t_4, l_opr );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1440,8 +1440,8 @@ static Obj  HdlrFunc6 (
  t_4 = GF_IS__STRING__REP;
  C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( ! t_1 ) {
@@ -1483,8 +1483,8 @@ static Obj  HdlrFunc6 (
   t_5 = GF_IS__FUNCTION;
   C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
   t_4 = CALL_1ARGS( t_5, t_6 );
-  CHECK_FUNC_RESULT( t_4 )
-  CHECK_BOOL( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
+  CHECK_BOOL( t_4 );
   t_3 = (Obj)(UInt)(t_4 != False);
   t_1 = t_3;
  }
@@ -1511,7 +1511,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_4 = C_ISB_LIST( a_arglist, l_pos );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
@@ -1520,8 +1520,8 @@ static Obj  HdlrFunc6 (
   t_6 = GF_IS__LIST;
   C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = (Obj)(UInt)( ! ((Int)t_4) );
   t_1 = t_3;
@@ -1543,11 +1543,11 @@ static Obj  HdlrFunc6 (
  
  /* if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then */
  t_3 = GC_GAPInfo;
- CHECK_BOUND( t_3, "GAPInfo" )
+ CHECK_BOUND( t_3, "GAPInfo" );
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_filters );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1555,7 +1555,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_2 = MakeString( "methods can have at most " );
   t_4 = GC_GAPInfo;
-  CHECK_BOUND( t_4, "GAPInfo" )
+  CHECK_BOUND( t_4, "GAPInfo" );
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   t_4 = MakeString( " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1566,7 +1566,7 @@ static Obj  HdlrFunc6 (
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, l_filters );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
   
@@ -1581,8 +1581,8 @@ static Obj  HdlrFunc6 (
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, l_filters );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(1);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1592,8 +1592,8 @@ static Obj  HdlrFunc6 (
    t_5 = GF_IS__STRING__REP;
    C_ELM_LIST_FPL( t_6, l_filters, l_i )
    t_4 = CALL_1ARGS( t_5, t_6 );
-   CHECK_FUNC_RESULT( t_4 )
-   CHECK_BOOL( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
+   CHECK_BOOL( t_4 );
    t_3 = (Obj)(UInt)(t_4 != False);
    if ( t_3 ) {
     
@@ -1611,15 +1611,15 @@ static Obj  HdlrFunc6 (
     t_4 = GF_EvalString;
     C_ELM_LIST_FPL( t_5, l_filters, l_i )
     t_3 = CALL_1ARGS( t_4, t_5 );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
     C_ELM_LIST_FPL( t_7, l_filters, l_i )
     t_5 = CALL_1ARGS( t_6, t_7 );
-    CHECK_FUNC_RESULT( t_5 )
-    CHECK_BOOL( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
+    CHECK_BOOL( t_5 );
     t_4 = (Obj)(UInt)(t_5 != False);
     t_3 = (Obj)(UInt)( ! ((Int)t_4) );
     if ( t_3 ) {
@@ -1663,17 +1663,17 @@ static Obj  HdlrFunc6 (
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_info1 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[32];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
    t_1 = CALL_1ARGS( t_2, l_info1 );
-   CHECK_FUNC_RESULT( t_1 )
-   CHECK_INT_POS( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[93];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
@@ -1722,14 +1722,14 @@ static Obj  HdlrFunc6 (
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
   t_6 = CALL_1ARGS( t_7, l_i );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   CALL_2ARGS( t_5, l_flags, t_6 );
   
  }
  /* od */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1747,23 +1747,23 @@ static Obj  HdlrFunc6 (
   t_4 = GF_IS__INT;
   C_ELM_LIST_FPL( t_5, a_arglist, l_pos )
   t_3 = CALL_1ARGS( t_4, t_5 );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = t_2;
   if ( ! t_1 ) {
    t_7 = GF_IS__FUNCTION;
    C_ELM_LIST_FPL( t_8, a_arglist, l_pos )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
-   CHECK_BOOL( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
+   CHECK_BOOL( t_6 );
    t_5 = (Obj)(UInt)(t_6 != False);
    t_4 = t_5;
    if ( t_4 ) {
     t_8 = GF_NARG__FUNC;
     C_ELM_LIST_FPL( t_9, a_arglist, l_pos )
     t_7 = CALL_1ARGS( t_8, t_9 );
-    CHECK_FUNC_RESULT( t_7 )
+    CHECK_FUNC_RESULT( t_7 );
     t_6 = (Obj)(UInt)(EQ( t_7, INTOBJ_INT(0) ));
     t_4 = t_6;
    }
@@ -1771,7 +1771,7 @@ static Obj  HdlrFunc6 (
    if ( t_3 ) {
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, a_arglist );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_5 = (Obj)(UInt)(LT( l_pos, t_6 ));
     t_3 = t_5;
    }
@@ -1800,7 +1800,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1821,7 +1821,7 @@ static Obj  HdlrFunc6 (
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
  t_5 = CALL_1ARGS( t_6, l_opr );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
  if ( t_3 ) {
@@ -1830,7 +1830,7 @@ static Obj  HdlrFunc6 (
   t_5 = t_6;
   if ( ! t_5 ) {
    t_8 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_8, "RETURN_TRUE" )
+   CHECK_BOUND( t_8, "RETURN_TRUE" );
    t_7 = (Obj)(UInt)(EQ( l_rel, t_8 ));
    t_5 = t_7;
   }
@@ -1840,7 +1840,7 @@ static Obj  HdlrFunc6 (
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_filters );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
  }
@@ -1851,7 +1851,7 @@ static Obj  HdlrFunc6 (
   t_3 = t_4;
   if ( ! t_3 ) {
    t_6 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_6, "RETURN_TRUE" )
+   CHECK_BOUND( t_6, "RETURN_TRUE" );
    t_5 = (Obj)(UInt)(EQ( l_method, t_6 ));
    t_3 = t_5;
   }
@@ -1863,7 +1863,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -1872,12 +1872,12 @@ static Obj  HdlrFunc6 (
  
  /* if CHECK_INSTALL_METHOD and check then */
  t_3 = GC_CHECK__INSTALL__METHOD;
- CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
- CHECK_BOOL( t_3 )
+ CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( t_1 ) {
-  CHECK_BOOL( a_check )
+  CHECK_BOOL( a_check );
   t_3 = (Obj)(UInt)(a_check != False);
   t_1 = t_3;
  }
@@ -1885,7 +1885,7 @@ static Obj  HdlrFunc6 (
   
   /* if opr in WRAPPER_OPERATIONS then */
   t_2 = GC_WRAPPER__OPERATIONS;
-  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
   t_1 = (Obj)(UInt)(IN( l_opr, t_2 ));
   if ( t_1 ) {
    
@@ -1894,7 +1894,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_4 = MakeString( "\n" );
    t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
    t_6 = MakeString( "#I  underlying operation(s)" );
@@ -1906,12 +1906,12 @@ static Obj  HdlrFunc6 (
   /* req := GET_OPER_FLAGS( opr ); */
   t_2 = GF_GET__OPER__FLAGS;
   t_1 = CALL_1ARGS( t_2, l_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_req = t_1;
   
   /* if req = fail then */
   t_2 = GC_fail;
-  CHECK_BOUND( t_2, "fail" )
+  CHECK_BOUND( t_2, "fail" );
   t_1 = (Obj)(UInt)(EQ( l_req, t_2 ));
   if ( t_1 ) {
    
@@ -1920,7 +1920,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    CALL_2ARGS( t_1, t_2, t_3 );
    
   }
@@ -1956,10 +1956,10 @@ static Obj  HdlrFunc6 (
    
    /* if not GAPInfo.CommandLineOptions.N then */
    t_9 = GC_GAPInfo;
-   CHECK_BOUND( t_9, "GAPInfo" )
+   CHECK_BOUND( t_9, "GAPInfo" );
    t_8 = ELM_REC( t_9, R_CommandLineOptions );
    t_7 = ELM_REC( t_8, R_N );
-   CHECK_BOOL( t_7 )
+   CHECK_BOOL( t_7 );
    t_6 = (Obj)(UInt)(t_7 != False);
    t_5 = (Obj)(UInt)( ! ((Int)t_6) );
    if ( t_5 ) {
@@ -1968,7 +1968,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -1980,7 +1980,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -2003,7 +2003,7 @@ static Obj  HdlrFunc6 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
@@ -2018,17 +2018,17 @@ static Obj  HdlrFunc6 (
    l_j = t_1;
    
    /* reqs := req[j]; */
-   CHECK_INT_POS( l_j )
+   CHECK_INT_POS( l_j );
    C_ELM_LIST_FPL( t_1, l_req, l_j )
    l_reqs = t_1;
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_reqs );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_imp );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
     
@@ -2039,8 +2039,8 @@ static Obj  HdlrFunc6 (
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, l_reqs );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_INT_SMALL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_INT_SMALL( t_2 );
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
           t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2051,8 +2051,8 @@ static Obj  HdlrFunc6 (
      C_ELM_LIST_FPL( t_7, l_imp, l_i )
      C_ELM_LIST_FPL( t_8, l_reqs, l_i )
      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      if ( t_3 ) {
@@ -2100,10 +2100,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2113,7 +2113,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( "the number of arguments does not match a declaration of " );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      CALL_2ARGS( t_1, t_2, t_3 );
      
     }
@@ -2127,7 +2127,7 @@ static Obj  HdlrFunc6 (
      t_3 = MakeString( "match a declaration of " );
      t_5 = GF_NAME__FUNC;
      t_4 = CALL_1ARGS( t_5, l_opr );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      t_5 = MakeString( "\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
      
@@ -2141,10 +2141,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2153,18 +2153,18 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Error;
      t_2 = MakeString( "required filters " );
      t_4 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
      t_3 = CALL_1ARGS( t_4, t_5 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( "\nfor " );
      t_6 = GF_Ordinal;
      t_5 = CALL_1ARGS( t_6, l_notmatch );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_6 = MakeString( " argument do not match a declaration of " );
      t_8 = GF_NAME__FUNC;
      t_7 = CALL_1ARGS( t_8, l_opr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
      
     }
@@ -2181,7 +2181,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 2, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "(\03" );
@@ -2189,7 +2189,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__FILENAME;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 4, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "\03 +" );
@@ -2197,7 +2197,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__LINENUMBER;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 6, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( ") \03" );
@@ -2210,10 +2210,10 @@ static Obj  HdlrFunc6 (
      
      /* for j in NamesFilter( imp[notmatch] ) do */
      t_5 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_6, l_imp, l_notmatch )
      t_4 = CALL_1ARGS( t_5, t_6 );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      if ( IS_SMALL_LIST(t_4) ) {
       t_3 = (Obj)(UInt)1;
       t_1 = INTOBJ_INT(1);
@@ -2248,7 +2248,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( " for " );
      t_4 = GF_Ordinal;
      t_3 = CALL_1ARGS( t_4, l_notmatch );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( " argument do not match \03a " );
      t_5 = MakeString( "declaration\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
@@ -2269,28 +2269,28 @@ static Obj  HdlrFunc6 (
    
    /* for k in [ j + 1 .. LEN_LIST( req ) ] do */
    C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
-   CHECK_INT_SMALL( t_2 )
+   CHECK_INT_SMALL( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_INT_SMALL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_INT_SMALL( t_3 );
    for ( t_1 = t_2;
          ((Int)t_1) <= ((Int)t_3);
          t_1 = (Obj)(((UInt)t_1)+4) ) {
     l_k = t_1;
     
     /* reqs := req[k]; */
-    CHECK_INT_POS( l_k )
+    CHECK_INT_POS( l_k );
     C_ELM_LIST_FPL( t_4, l_req, l_k )
     l_reqs = t_4;
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
     t_5 = CALL_1ARGS( t_6, l_reqs );
-    CHECK_FUNC_RESULT( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, l_imp );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
      
@@ -2301,8 +2301,8 @@ static Obj  HdlrFunc6 (
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
      t_5 = CALL_1ARGS( t_6, l_reqs );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_INT_SMALL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_INT_SMALL( t_5 );
      for ( t_4 = INTOBJ_INT(1);
            ((Int)t_4) <= ((Int)t_5);
            t_4 = (Obj)(((UInt)t_4)+4) ) {
@@ -2313,8 +2313,8 @@ static Obj  HdlrFunc6 (
       C_ELM_LIST_FPL( t_10, l_imp, l_i )
       C_ELM_LIST_FPL( t_11, l_reqs, l_i )
       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-      CHECK_FUNC_RESULT( t_8 )
-      CHECK_BOOL( t_8 )
+      CHECK_FUNC_RESULT( t_8 );
+      CHECK_BOOL( t_8 );
       t_7 = (Obj)(UInt)(t_8 != False);
       t_6 = (Obj)(UInt)( ! ((Int)t_7) );
       if ( t_6 ) {
@@ -2346,7 +2346,7 @@ static Obj  HdlrFunc6 (
       t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
-      CHECK_FUNC_RESULT( t_6 )
+      CHECK_FUNC_RESULT( t_6 );
       t_7 = MakeString( " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
@@ -2367,7 +2367,7 @@ static Obj  HdlrFunc6 (
  
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
- CHECK_BOUND( l_rank, "rank" )
+ CHECK_BOUND( l_rank, "rank" );
  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
  
  /* return; */
@@ -2410,7 +2410,7 @@ static Obj  HdlrFunc8 (
  
  /* for prop in props do */
  t_4 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_4, "props" )
+ CHECK_BOUND( t_4, "props" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -2435,11 +2435,11 @@ static Obj  HdlrFunc8 (
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
   t_8 = CALL_1ARGS( t_9, l_prop );
-  CHECK_FUNC_RESULT( t_8 )
-  CHECK_FUNC( t_8 )
+  CHECK_FUNC_RESULT( t_8 );
+  CHECK_FUNC( t_8 );
   t_7 = CALL_1ARGS( t_8, a_obj );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_BOOL( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (Obj)(UInt)( ! ((Int)t_6) );
   if ( t_5 ) {
@@ -2449,20 +2449,20 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop )
+   CHECK_FUNC( l_prop );
    t_8 = CALL_1ARGS( l_prop, a_obj );
-   CHECK_FUNC_RESULT( t_8 )
-   CHECK_BOOL( t_8 )
+   CHECK_FUNC_RESULT( t_8 );
+   CHECK_BOOL( t_8 );
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
     t_10 = CALL_1ARGS( t_11, l_prop );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_FUNC( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_FUNC( t_10 );
     t_9 = CALL_1ARGS( t_10, a_obj );
-    CHECK_FUNC_RESULT( t_9 )
-    CHECK_BOOL( t_9 )
+    CHECK_FUNC_RESULT( t_9 );
+    CHECK_BOOL( t_9 );
     t_8 = (Obj)(UInt)(t_9 != False);
     t_6 = t_8;
    }
@@ -2471,7 +2471,7 @@ static Obj  HdlrFunc8 (
     
     /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
-    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
+    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
     
@@ -2490,10 +2490,10 @@ static Obj  HdlrFunc8 (
   
   /* return getter( obj ); */
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "getter" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "getter" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_1ARGS( t_2, a_obj );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2504,7 +2504,7 @@ static Obj  HdlrFunc8 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2559,10 +2559,10 @@ static Obj  HdlrFunc7 (
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2570,7 +2570,7 @@ static Obj  HdlrFunc7 (
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_flags = t_1;
   
   /* rank := 0; */
@@ -2578,7 +2578,7 @@ static Obj  HdlrFunc7 (
   
   /* cats := IS_OBJECT; */
   t_1 = GC_IS__OBJECT;
-  CHECK_BOUND( t_1, "IS_OBJECT" )
+  CHECK_BOUND( t_1, "IS_OBJECT" );
   l_cats = t_1;
   
   /* props := [  ]; */
@@ -2589,7 +2589,7 @@ static Obj  HdlrFunc7 (
   /* for i in TRUES_FLAGS( flags ) do */
   t_5 = GF_TRUES__FLAGS;
   t_4 = CALL_1ARGS( t_5, l_flags );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
    t_1 = INTOBJ_INT(1);
@@ -2613,11 +2613,11 @@ static Obj  HdlrFunc7 (
    
    /* if INFO_FILTERS[i] in FNUM_CATS_AND_REPS then */
    t_7 = GC_INFO__FILTERS;
-   CHECK_BOUND( t_7, "INFO_FILTERS" )
-   CHECK_INT_POS( l_i )
+   CHECK_BOUND( t_7, "INFO_FILTERS" );
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_6, t_7, l_i )
    t_7 = GC_FNUM__CATS__AND__REPS;
-   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" )
+   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" );
    t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
    if ( t_5 ) {
     
@@ -2627,14 +2627,14 @@ static Obj  HdlrFunc7 (
     }
     else if ( l_cats == True ) {
      t_7 = GC_FILTERS;
-     CHECK_BOUND( t_7, "FILTERS" )
+     CHECK_BOUND( t_7, "FILTERS" );
      C_ELM_LIST_FPL( t_6, t_7, l_i )
-     CHECK_BOOL( t_6 )
+     CHECK_BOOL( t_6 );
      t_5 = t_6;
     }
     else if (IS_FILTER( l_cats ) ) {
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      t_5 = NewAndFilter( l_cats, t_7 );
     }
@@ -2647,10 +2647,10 @@ static Obj  HdlrFunc7 (
     /* rank := rank - RankFilter( FILTERS[i] ); */
     t_7 = GF_RankFilter;
     t_9 = GC_FILTERS;
-    CHECK_BOUND( t_9, "FILTERS" )
+    CHECK_BOUND( t_9, "FILTERS" );
     C_ELM_LIST_FPL( t_8, t_9, l_i )
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     C_DIFF_FIA( t_5, l_rank, t_6 )
     l_rank = t_5;
     
@@ -2659,19 +2659,19 @@ static Obj  HdlrFunc7 (
    /* elif INFO_FILTERS[i] in FNUM_PROS then */
    else {
     t_7 = GC_INFO__FILTERS;
-    CHECK_BOUND( t_7, "INFO_FILTERS" )
+    CHECK_BOUND( t_7, "INFO_FILTERS" );
     C_ELM_LIST_FPL( t_6, t_7, l_i )
     t_7 = GC_FNUM__PROS;
-    CHECK_BOUND( t_7, "FNUM_PROS" )
+    CHECK_BOUND( t_7, "FNUM_PROS" );
     t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
     if ( t_5 ) {
      
      /* ADD_LIST( props, FILTERS[i] ); */
      t_5 = GF_ADD__LIST;
      t_6 = OBJ_LVAR( 2 );
-     CHECK_BOUND( t_6, "props" )
+     CHECK_BOUND( t_6, "props" );
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      CALL_2ARGS( t_5, t_6, t_7 );
      
@@ -2685,15 +2685,15 @@ static Obj  HdlrFunc7 (
   /* MakeImmutable( props ); */
   t_1 = GF_MakeImmutable;
   t_2 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_2, "props" )
+  CHECK_BOUND( t_2, "props" );
   CALL_1ARGS( t_1, t_2 );
   
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_4, "props" )
+  CHECK_BOUND( t_4, "props" );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -2717,7 +2717,7 @@ static Obj  HdlrFunc7 (
   end ); */
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
-   CHECK_BOUND( t_2, "getter" )
+   CHECK_BOUND( t_2, "getter" );
    t_3 = MakeString( "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -2775,15 +2775,15 @@ static Obj  HdlrFunc9 (
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 2, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
- CHECK_BOUND( t_5, "DO_NOTHING_SETTER" )
+ CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
@@ -2821,7 +2821,7 @@ static Obj  HdlrFunc10 (
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_list );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
  
@@ -2851,13 +2851,13 @@ static Obj  HdlrFunc10 (
   C_SUM_FIA( t_6, l_i, l_k )
   C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_j = t_1;
   
   /* if list[j] < elm then */
-  CHECK_INT_POS( l_j )
+  CHECK_INT_POS( l_j );
   C_ELM_LIST_FPL( t_2, a_list, l_j )
   t_1 = (Obj)(UInt)(LT( t_2, a_elm ));
   if ( t_1 ) {
@@ -2905,8 +2905,8 @@ static Obj  HdlrFunc12 (
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
  t_3 = CALL_1ARGS( t_4, a_key );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2914,7 +2914,7 @@ static Obj  HdlrFunc12 (
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "name" )
+  CHECK_BOUND( t_2, "name" );
   t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -2976,32 +2976,32 @@ static Obj  HdlrFunc14 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3010,26 +3010,26 @@ static Obj  HdlrFunc14 (
   
   /* erg := oper( D, key ); */
   t_2 = OBJ_HVAR( (1 << 16) | 3 );
-  CHECK_BOUND( t_2, "oper" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "oper" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
   t_1 = CALL_2ARGS( t_2, l_known, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
   if ( ! t_1 ) {
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_4, l_known, l_i )
    t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
    t_1 = t_3;
@@ -3040,29 +3040,29 @@ static Obj  HdlrFunc14 (
    C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
    AsssListCheck( l_known, t_1, t_2 );
    
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    t_2 = GF_IMMUTABLE__COPY__OBJ;
    t_1 = CALL_1ARGS( t_2, a_key );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
    /* known[i + 1] := IMMUTABLE_COPY_OBJ( erg ); */
    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_3 = GF_IMMUTABLE__COPY__OBJ;
    t_2 = CALL_1ARGS( t_3, l_erg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
   }
@@ -3073,7 +3073,7 @@ static Obj  HdlrFunc14 (
  
  /* return known[i + 1]; */
  C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_2 )
+ CHECK_INT_POS( t_2 );
  C_ELM_LIST_FPL( t_1, l_known, t_2 )
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3105,34 +3105,34 @@ static Obj  HdlrFunc15 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (EQ( t_4, a_key ) ? True : False);
   t_1 = t_3;
@@ -3177,32 +3177,32 @@ static Obj  HdlrFunc16 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3213,29 +3213,29 @@ static Obj  HdlrFunc16 (
   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
   AsssListCheck( l_known, t_1, t_2 );
   
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   t_2 = GF_IMMUTABLE__COPY__OBJ;
   t_1 = CALL_1ARGS( t_2, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
   /* known[i + 1] := IMMUTABLE_COPY_OBJ( obj ); */
   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_IMMUTABLE__COPY__OBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
  }
@@ -3279,7 +3279,7 @@ static Obj  HdlrFunc11 (
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_2, "keytest" )
+ CHECK_BOUND( t_2, "keytest" );
  t_3 = MakeString( "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
@@ -3305,9 +3305,9 @@ static Obj  HdlrFunc11 (
  /* str := SHALLOW_COPY_OBJ( name ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_3, "name" )
+ CHECK_BOUND( t_3, "name" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
@@ -3328,7 +3328,7 @@ static Obj  HdlrFunc11 (
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
@@ -3338,7 +3338,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* APPEND_LIST_INTR( str, "s" ); */
@@ -3354,7 +3354,7 @@ static Obj  HdlrFunc11 (
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 4, t_1 );
  
  /* InstallMethod( attr, "default method", true, [ domreq ], 0, function ( D )
@@ -3362,7 +3362,7 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
- CHECK_BOUND( t_2, "attr" )
+ CHECK_BOUND( t_2, "attr" );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -3381,7 +3381,7 @@ static Obj  HdlrFunc11 (
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, a_domreq );
@@ -3393,12 +3393,12 @@ static Obj  HdlrFunc11 (
  /* ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_WRAPPER__OPERATIONS;
- CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+ CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_5, "name" )
+ CHECK_BOUND( t_5, "name" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
@@ -3420,9 +3420,9 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_4, "name" )
+ CHECK_BOUND( t_4, "name" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3447,7 +3447,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3470,7 +3470,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3495,7 +3495,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
@@ -3507,7 +3507,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
  t_3 = GC_IS__OBJECT;
- CHECK_BOUND( t_3, "IS_OBJECT" )
+ CHECK_BOUND( t_3, "IS_OBJECT" );
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
  CALL_2ARGS( t_1, l_str, t_2 );
@@ -3527,7 +3527,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
@@ -3537,7 +3537,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], 3, ArgStringToList("D,key,obj"), HdlrFunc16 );
@@ -3593,9 +3593,9 @@ static Obj  HdlrFunc18 (
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_7, "reqs" )
+ CHECK_BOUND( t_7, "reqs" );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -3620,37 +3620,37 @@ static Obj  HdlrFunc18 (
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
   t_7 = OBJ_HVAR( (1 << 16) | 4 );
-  CHECK_BOUND( t_7, "re" )
-  CHECK_BOOL( t_7 )
+  CHECK_BOUND( t_7, "re" );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
    t_12 = OBJ_HVAR( (1 << 16) | 3 );
-   CHECK_BOUND( t_12, "cond" )
+   CHECK_BOUND( t_12, "cond" );
    t_13 = OBJ_HVAR( (1 << 16) | 5 );
-   CHECK_BOUND( t_13, "i" )
-   CHECK_INT_POS( t_13 )
+   CHECK_BOUND( t_13, "i" );
+   CHECK_INT_POS( t_13 );
    t_11 = C_ISB_LIST( t_12, t_13 );
    t_10 = (Obj)(UInt)(t_11 != False);
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
     t_17 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_17, "cond" )
+    CHECK_BOUND( t_17, "cond" );
     t_18 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_18, "i" )
-    CHECK_INT_POS( t_18 )
+    CHECK_BOUND( t_18, "i" );
+    CHECK_INT_POS( t_18 );
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
-    CHECK_FUNC_RESULT( t_14 )
-    CHECK_FUNC( t_14 )
+    CHECK_FUNC_RESULT( t_14 );
+    CHECK_FUNC( t_14 );
     t_16 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_16, "i" )
-    CHECK_INT_POS( t_16 )
+    CHECK_BOUND( t_16, "i" );
+    CHECK_INT_POS( t_16 );
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
     t_13 = CALL_1ARGS( t_14, t_15 );
-    CHECK_FUNC_RESULT( t_13 )
-    CHECK_BOOL( t_13 )
+    CHECK_FUNC_RESULT( t_13 );
+    CHECK_BOOL( t_13 );
     t_12 = (Obj)(UInt)(t_13 != False);
     t_11 = (Obj)(UInt)( ! ((Int)t_12) );
     t_9 = t_11;
@@ -3658,19 +3658,19 @@ static Obj  HdlrFunc18 (
    t_8 = t_9;
    if ( t_8 ) {
     t_13 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_13, "cond" )
+    CHECK_BOUND( t_13, "cond" );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
-    CHECK_FUNC( t_12 )
+    CHECK_FUNC( t_12 );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_BOOL( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_BOOL( t_11 );
     t_10 = (Obj)(UInt)(t_11 != False);
     t_8 = t_10;
    }
@@ -3678,21 +3678,21 @@ static Obj  HdlrFunc18 (
    if ( t_7 ) {
     t_12 = GF_Tester;
     t_14 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_14, "cond" )
+    CHECK_BOUND( t_14, "cond" );
     t_15 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_15, "i" )
-    CHECK_INT_POS( t_15 )
+    CHECK_BOUND( t_15, "i" );
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_FUNC( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_FUNC( t_11 );
     t_13 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_13, "i" )
-    CHECK_INT_POS( t_13 )
+    CHECK_BOUND( t_13, "i" );
+    CHECK_INT_POS( t_13 );
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
     t_10 = CALL_1ARGS( t_11, t_12 );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_BOOL( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_BOOL( t_10 );
     t_9 = (Obj)(UInt)(t_10 != False);
     t_7 = t_9;
    }
@@ -3705,17 +3705,17 @@ static Obj  HdlrFunc18 (
  
  /* if re then */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "re" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "re" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
   t_3 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_3, "oper" )
+  CHECK_BOUND( t_3, "oper" );
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3726,7 +3726,7 @@ static Obj  HdlrFunc18 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3770,7 +3770,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
   
@@ -3804,7 +3804,7 @@ static Obj  HdlrFunc17 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
    
@@ -3848,7 +3848,7 @@ static Obj  HdlrFunc17 (
  
  /* for i in reqs do */
  t_4 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_4, "reqs" )
+ CHECK_BOUND( t_4, "reqs" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -3871,12 +3871,12 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 5, t_2 );
   
   /* val := val - RankFilter( i ); */
-  CHECK_BOUND( l_val, "val" )
+  CHECK_BOUND( l_val, "val" );
   t_7 = GF_RankFilter;
   t_8 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_8, "i" )
+  CHECK_BOUND( t_8, "i" );
   t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
   
@@ -3897,11 +3897,11 @@ static Obj  HdlrFunc17 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "oper" )
- CHECK_BOUND( l_info, "info" )
- CHECK_BOUND( l_fampred, "fampred" )
+ CHECK_BOUND( t_2, "oper" );
+ CHECK_BOUND( l_info, "info" );
+ CHECK_BOUND( l_fampred, "fampred" );
  t_3 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_3, "reqs" )
+ CHECK_BOUND( t_3, "reqs" );
  t_4 = NewFunction( NameFunc[18], -1, ArgStringToList("arg"), HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewFunctionBody();
@@ -4318,7 +4318,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -4554,17 +4554,17 @@ static Obj  HdlrFunc1 (
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
- CHECK_BOUND( t_2, "ViewObj" )
+ CHECK_BOUND( t_2, "ViewObj" );
  t_3 = MakeString( "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 1, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
- CHECK_BOUND( t_6, "PRINT_OBJ" )
+ CHECK_BOUND( t_6, "PRINT_OBJ" );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -240,7 +240,12 @@ static Obj  HdlrFunc2 (
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
  CHECK_BOUND( t_4, "IMM_FLAGS" );
- t_2 = CALL_2ARGS( t_3, t_4, a_flags );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -257,16 +262,31 @@ static Obj  HdlrFunc2 (
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
  CHECK_BOUND( t_3, "IMM_FLAGS" );
- t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_flags, t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
- t_3 = CALL_1ARGS( t_4, a_flags );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_flags );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_flagspos = t_1;
  
@@ -277,7 +297,12 @@ static Obj  HdlrFunc2 (
  
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
- t_1 = CALL_1ARGS( t_2, a_obj );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_obj );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
@@ -301,7 +326,12 @@ static Obj  HdlrFunc2 (
   /* Print( "#I RunImmediateMethods\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "#I RunImmediateMethods\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -347,7 +377,12 @@ static Obj  HdlrFunc2 (
    t_9 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
    CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    t_12 = GF_LEN__LIST;
-   t_11 = CALL_1ARGS( t_12, l_imm );
+   if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+    t_11 = CALL_1ARGS( t_12, l_imm );
+   }
+   else {
+    t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( l_imm ) );
+   }
    CHECK_FUNC_RESULT( t_11 );
    t_12 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
    CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" );
@@ -379,7 +414,12 @@ static Obj  HdlrFunc2 (
     C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
     CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_14, l_imm, t_15 )
-    t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
+    if ( TNUM_OBJ( t_13 ) == T_FUNCTION ) {
+     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
+    }
+    else {
+     t_12 = DoOperation2Args( CallFuncListOper, t_13, NewPlistFromArgs( a_flags, t_14 ) );
+    }
     CHECK_FUNC_RESULT( t_12 );
     CHECK_BOOL( t_12 );
     t_11 = (Obj)(UInt)(t_12 != False);
@@ -389,7 +429,12 @@ static Obj  HdlrFunc2 (
      C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
      CHECK_INT_POS( t_17 );
      C_ELM_LIST_FPL( t_16, l_imm, t_17 )
-     t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
+     if ( TNUM_OBJ( t_15 ) == T_FUNCTION ) {
+      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
+     }
+     else {
+      t_14 = DoOperation2Args( CallFuncListOper, t_15, NewPlistFromArgs( a_flags, t_16 ) );
+     }
      CHECK_FUNC_RESULT( t_14 );
      CHECK_BOOL( t_14 );
      t_13 = (Obj)(UInt)(t_14 != False);
@@ -418,8 +463,12 @@ static Obj  HdlrFunc2 (
      l_meth = t_9;
      
      /* res := meth( obj ); */
-     CHECK_FUNC( l_meth );
-     t_9 = CALL_1ARGS( l_meth, a_obj );
+     if ( TNUM_OBJ( l_meth ) == T_FUNCTION ) {
+      t_9 = CALL_1ARGS( l_meth, a_obj );
+     }
+     else {
+      t_9 = DoOperation2Args( CallFuncListOper, l_meth, NewPlistFromArgs( a_obj ) );
+     }
      CHECK_FUNC_RESULT( t_9 );
      l_res = t_9;
      
@@ -428,7 +477,12 @@ static Obj  HdlrFunc2 (
      C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
      CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
-     CALL_2ARGS( t_9, l_tried, t_10 );
+     if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_9, l_tried, t_10 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( l_tried, t_10 ) );
+     }
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
@@ -450,9 +504,19 @@ static Obj  HdlrFunc2 (
       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
       CHECK_INT_POS( t_14 );
       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
-      t_11 = CALL_1ARGS( t_12, t_13 );
+      if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+       t_11 = CALL_1ARGS( t_12, t_13 );
+      }
+      else {
+       t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13 ) );
+      }
       CHECK_FUNC_RESULT( t_11 );
-      CALL_2ARGS( t_9, t_10, t_11 );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       CALL_2ARGS( t_9, t_10, t_11 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11 ) );
+      }
       
       /* if imm[i + 7] <> false then */
       C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
@@ -468,7 +532,12 @@ static Obj  HdlrFunc2 (
        C_SUM_FIA( t_12, l_i, INTOBJ_INT(7) )
        CHECK_INT_POS( t_12 );
        C_ELM_LIST_FPL( t_11, l_imm, t_12 )
-       CALL_2ARGS( t_9, t_10, t_11 );
+       if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+        CALL_2ARGS( t_9, t_10, t_11 );
+       }
+       else {
+        DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11 ) );
+       }
        
       }
       /* fi */
@@ -486,7 +555,12 @@ static Obj  HdlrFunc2 (
       C_ELM_LIST_FPL( t_14, l_imm, t_15 )
       C_ELM_LIST_FPL( t_13, t_14, INTOBJ_INT(2) )
       t_14 = MakeString( "\n" );
-      CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11, t_12, t_13, t_14 ) );
+      }
       
      }
      /* fi */
@@ -505,8 +579,12 @@ static Obj  HdlrFunc2 (
       C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
       CHECK_INT_POS( t_10 );
       C_ELM_LIST_FPL( t_9, l_imm, t_10 )
-      CHECK_FUNC( t_9 );
-      CALL_2ARGS( t_9, a_obj, l_res );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       CALL_2ARGS( t_9, a_obj, l_res );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_obj, l_res ) );
+      }
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
       t_9 = False;
@@ -521,9 +599,19 @@ static Obj  HdlrFunc2 (
       /* if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type ) then */
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
-      t_13 = CALL_1ARGS( t_14, a_obj );
+      if ( TNUM_OBJ( t_14 ) == T_FUNCTION ) {
+       t_13 = CALL_1ARGS( t_14, a_obj );
+      }
+      else {
+       t_13 = DoOperation2Args( CallFuncListOper, t_14, NewPlistFromArgs( a_obj ) );
+      }
       CHECK_FUNC_RESULT( t_13 );
-      t_11 = CALL_2ARGS( t_12, t_13, l_type );
+      if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+       t_11 = CALL_2ARGS( t_12, t_13, l_type );
+      }
+      else {
+       t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13, l_type ) );
+      }
       CHECK_FUNC_RESULT( t_11 );
       CHECK_BOOL( t_11 );
       t_10 = (Obj)(UInt)(t_11 != False);
@@ -532,7 +620,12 @@ static Obj  HdlrFunc2 (
        
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
-       t_9 = CALL_1ARGS( t_10, a_obj );
+       if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+        t_9 = CALL_1ARGS( t_10, a_obj );
+       }
+       else {
+        t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( a_obj ) );
+       }
        CHECK_FUNC_RESULT( t_9 );
        l_type = t_9;
        
@@ -541,22 +634,42 @@ static Obj  HdlrFunc2 (
        t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
        CHECK_BOUND( t_12, "IMM_FLAGS" );
-       t_9 = CALL_2ARGS( t_10, t_11, t_12 );
+       if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
+       }
+       else {
+        t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( t_11, t_12 ) );
+       }
        CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
-       t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
+       if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
+       }
+       else {
+        t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( l_newflags, a_flags ) );
+       }
        CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
-       t_10 = CALL_1ARGS( t_11, l_newflags );
+       if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+        t_10 = CALL_1ARGS( t_11, l_newflags );
+       }
+       else {
+        t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( l_newflags ) );
+       }
        CHECK_FUNC_RESULT( t_10 );
-       CALL_2ARGS( t_9, l_flagspos, t_10 );
+       if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+        CALL_2ARGS( t_9, l_flagspos, t_10 );
+       }
+       else {
+        DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( l_flagspos, t_10 ) );
+       }
        
        /* flags := type![2]; */
        t_9 = ElmPosObj( l_type, 2 );
@@ -634,15 +747,24 @@ static Obj  HdlrFunc3 (
  
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
- t_2 = CALL_1ARGS( t_3, a_baserank );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_baserank );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_baserank ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* rank := baserank(  ); */
-  CHECK_FUNC( a_baserank );
-  t_1 = CALL_0ARGS( a_baserank );
+  if ( TNUM_OBJ( a_baserank ) == T_FUNCTION ) {
+   t_1 = CALL_0ARGS( a_baserank );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, a_baserank, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_rank = t_1;
   
@@ -659,7 +781,12 @@ static Obj  HdlrFunc3 (
  
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
- t_2 = CALL_1ARGS( t_3, a_opr );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_opr );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -667,7 +794,12 @@ static Obj  HdlrFunc3 (
   
   /* if 0 = LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_flags );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_flags );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_flags ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
@@ -675,10 +807,20 @@ static Obj  HdlrFunc3 (
    /* Error( NAME_FUNC( opr ), ": constructors must have at least one argument" ); */
    t_1 = GF_Error;
    t_3 = GF_NAME__FUNC;
-   t_2 = CALL_1ARGS( t_3, a_opr );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_opr );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    t_3 = MakeString( ": constructors must have at least one argument" );
-   CALL_2ARGS( t_1, t_2, t_3 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, t_2, t_3 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+   }
    
   }
   /* fi */
@@ -686,7 +828,12 @@ static Obj  HdlrFunc3 (
   /* rank := rank - RankFilter( flags[1] ); */
   t_3 = GF_RankFilter;
   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
-  t_2 = CALL_1ARGS( t_3, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   C_DIFF_FIA( t_1, l_rank, t_2 )
   l_rank = t_1;
@@ -721,7 +868,12 @@ static Obj  HdlrFunc3 (
    
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
-   t_6 = CALL_1ARGS( t_7, l_i );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, l_i );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
@@ -734,13 +886,23 @@ static Obj  HdlrFunc3 (
  
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
- t_1 = CALL_1ARGS( t_2, a_flags );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_flags );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
- t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_opr, l_narg ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_methods = t_1;
  
@@ -751,7 +913,12 @@ static Obj  HdlrFunc3 (
   
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
-  t_1 = CALL_1ARGS( t_2, a_opr );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_opr );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_opr ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   a_info = t_1;
   
@@ -763,27 +930,52 @@ static Obj  HdlrFunc3 (
   /* k := SHALLOW_COPY_OBJ( NAME_FUNC( opr ) ); */
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
-  t_3 = CALL_1ARGS( t_4, a_opr );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, a_opr );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_opr ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
-  t_1 = CALL_1ARGS( t_2, t_3 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, t_3 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
   t_1 = GF_APPEND__LIST__INTR;
   t_2 = MakeString( ": " );
-  CALL_2ARGS( t_1, l_k, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_k, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_k, t_2 ) );
+  }
   
   /* APPEND_LIST_INTR( k, info ); */
   t_1 = GF_APPEND__LIST__INTR;
-  CALL_2ARGS( t_1, l_k, a_info );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_k, a_info );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_k, a_info ) );
+  }
   
   /* info := k; */
   a_info = l_k;
   
   /* CONV_STRING( info ); */
   t_1 = GF_CONV__STRING;
-  CALL_1ARGS( t_1, a_info );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, a_info );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_info ) );
+  }
   
  }
  /* fi */
@@ -794,7 +986,12 @@ static Obj  HdlrFunc3 (
  /* while i < LEN_LIST( methods ) and rank < methods[i + (narg + 3)] do */
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_methods );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, l_methods );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_methods ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
@@ -833,7 +1030,12 @@ static Obj  HdlrFunc3 (
   /* while k < LEN_LIST( methods ) and rank = methods[k + narg + 3] do */
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_methods );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_methods );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_methods ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
@@ -963,12 +1165,22 @@ static Obj  HdlrFunc3 (
   CHANGED_BAG( t_2 );
   SET_ELM_PLIST( t_2, 6, INTOBJ_INT(1) );
   t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_methods );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_methods );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_methods ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   C_DIFF_FIA( t_3, t_4, l_i )
   SET_ELM_PLIST( t_2, 7, t_3 );
   CHANGED_BAG( t_2 );
-  CALL_XARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_XARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, t_2 );
+  }
   
  }
  /* fi */
@@ -1001,7 +1213,12 @@ static Obj  HdlrFunc3 (
   /* elif IS_FUNCTION( rel ) then */
   else {
    t_3 = GF_IS__FUNCTION;
-   t_2 = CALL_1ARGS( t_3, a_rel );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_rel );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_rel ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -1016,13 +1233,23 @@ static Obj  HdlrFunc3 (
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
-     t_1 = CALL_1ARGS( t_2, a_rel );
+     if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+      t_1 = CALL_1ARGS( t_2, a_rel );
+     }
+     else {
+      t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_rel ) );
+     }
      CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
-     t_4 = CALL_1ARGS( t_5, l_narg );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, l_narg );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_narg ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
@@ -1041,11 +1268,21 @@ static Obj  HdlrFunc3 (
       /* Error( NAME_FUNC( opr ), ": <famrel> must accept ", narg, " arguments" ); */
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
-      t_2 = CALL_1ARGS( t_3, a_opr );
+      if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+       t_2 = CALL_1ARGS( t_3, a_opr );
+      }
+      else {
+       t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+      }
       CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <famrel> must accept " );
       t_4 = MakeString( " arguments" );
-      CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, l_narg, t_4 ) );
+      }
       
      }
      /* fi */
@@ -1061,10 +1298,20 @@ static Obj  HdlrFunc3 (
     /* Error( NAME_FUNC( opr ), ": <famrel> must be a function, `true', or `false'" ); */
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
-    t_2 = CALL_1ARGS( t_3, a_opr );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_opr );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
-    CALL_2ARGS( t_1, t_2, t_3 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, t_2, t_3 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+    }
     
    }
   }
@@ -1099,7 +1346,12 @@ static Obj  HdlrFunc3 (
   /* elif IS_FUNCTION( method ) then */
   else {
    t_3 = GF_IS__FUNCTION;
-   t_2 = CALL_1ARGS( t_3, a_method );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_method );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_method ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -1113,7 +1365,12 @@ static Obj  HdlrFunc3 (
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
-     t_5 = CALL_1ARGS( t_6, a_method );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, a_method );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( a_method ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
@@ -1124,13 +1381,23 @@ static Obj  HdlrFunc3 (
      
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
-     t_1 = CALL_1ARGS( t_2, a_method );
+     if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+      t_1 = CALL_1ARGS( t_2, a_method );
+     }
+     else {
+      t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_method ) );
+     }
      CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
-     t_4 = CALL_1ARGS( t_5, l_narg );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, l_narg );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_narg ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
@@ -1149,11 +1416,21 @@ static Obj  HdlrFunc3 (
       /* Error( NAME_FUNC( opr ), ": <method> must accept ", narg, " arguments" ); */
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
-      t_2 = CALL_1ARGS( t_3, a_opr );
+      if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+       t_2 = CALL_1ARGS( t_3, a_opr );
+      }
+      else {
+       t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+      }
       CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <method> must accept " );
       t_4 = MakeString( " arguments" );
-      CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, l_narg, t_4 ) );
+      }
       
      }
      /* fi */
@@ -1169,10 +1446,20 @@ static Obj  HdlrFunc3 (
     /* Error( NAME_FUNC( opr ), ": <method> must be a function, `true', or `false'" ); */
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
-    t_2 = CALL_1ARGS( t_3, a_opr );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_opr );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
-    CALL_2ARGS( t_1, t_2, t_3 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, t_2, t_3 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+    }
     
    }
   }
@@ -1219,7 +1506,12 @@ static Obj  HdlrFunc3 (
  C_SUM_FIA( t_1, l_i, t_2 )
  CHECK_INT_POS( t_1 );
  t_3 = GF_IMMUTABLE__COPY__OBJ;
- t_2 = CALL_1ARGS( t_3, a_info );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_info );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_info ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
@@ -1235,7 +1527,12 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 3 );
   SET_LEN_PLIST( t_4, 3 );
   t_6 = GF_INPUT__FILENAME;
-  t_5 = CALL_0ARGS( t_6 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_0ARGS( t_6 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
@@ -1244,11 +1541,21 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_INPUT__LINENUMBER;
-  t_5 = CALL_0ARGS( t_6 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_0ARGS( t_6 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 3, t_5 );
   CHANGED_BAG( t_4 );
-  t_2 = CALL_1ARGS( t_3, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
@@ -1270,7 +1577,12 @@ static Obj  HdlrFunc3 (
  
  /* CHANGED_METHODS_OPERATION( opr, narg ); */
  t_1 = GF_CHANGED__METHODS__OPERATION;
- CALL_2ARGS( t_1, a_opr, l_narg );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_opr, l_narg );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_opr, l_narg ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1296,7 +1608,12 @@ static Obj  HdlrFunc4 (
  /* INSTALL_METHOD( arg, true ); */
  t_1 = GF_INSTALL__METHOD;
  t_2 = True;
- CALL_2ARGS( t_1, a_arg, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_arg, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_arg, t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1322,7 +1639,12 @@ static Obj  HdlrFunc5 (
  /* INSTALL_METHOD( arg, false ); */
  t_1 = GF_INSTALL__METHOD;
  t_2 = False;
- CALL_2ARGS( t_1, a_arg, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_arg, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_arg, t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1399,7 +1721,12 @@ static Obj  HdlrFunc6 (
  
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
- t_1 = CALL_1ARGS( t_2, a_arglist );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_arglist );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_arglist ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_len = t_1;
  
@@ -1410,7 +1737,12 @@ static Obj  HdlrFunc6 (
   /* Error( "too few arguments given in <arglist>" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "too few arguments given in <arglist>" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -1421,7 +1753,12 @@ static Obj  HdlrFunc6 (
  
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
- t_3 = CALL_1ARGS( t_4, l_opr );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_opr );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1431,7 +1768,12 @@ static Obj  HdlrFunc6 (
   /* Error( "<opr> is not an operation" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<opr> is not an operation" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -1439,7 +1781,12 @@ static Obj  HdlrFunc6 (
  /* if IS_STRING_REP( arglist[2] ) or arglist[2] = false then */
  t_4 = GF_IS__STRING__REP;
  C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1482,7 +1829,12 @@ static Obj  HdlrFunc6 (
  if ( ! t_1 ) {
   t_5 = GF_IS__FUNCTION;
   C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
-  t_4 = CALL_1ARGS( t_5, t_6 );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, t_6 );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6 ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   CHECK_BOOL( t_4 );
   t_3 = (Obj)(UInt)(t_4 != False);
@@ -1519,7 +1871,12 @@ static Obj  HdlrFunc6 (
  if ( ! t_1 ) {
   t_6 = GF_IS__LIST;
   C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
-  t_5 = CALL_1ARGS( t_6, t_7 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, t_7 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
@@ -1532,7 +1889,12 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_2 = MakeString( "<arglist>[" );
   t_3 = MakeString( "] must be a list of filters" );
-  CALL_3ARGS( t_1, t_2, l_pos, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_3ARGS( t_1, t_2, l_pos, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, l_pos, t_3 ) );
+  }
   
  }
  /* fi */
@@ -1546,7 +1908,12 @@ static Obj  HdlrFunc6 (
  CHECK_BOUND( t_3, "GAPInfo" );
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_filters );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_filters );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_filters ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
@@ -1558,14 +1925,24 @@ static Obj  HdlrFunc6 (
   CHECK_BOUND( t_4, "GAPInfo" );
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   t_4 = MakeString( " arguments" );
-  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_3ARGS( t_1, t_2, t_3, t_4 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+  }
   
  }
  /* fi */
  
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, l_filters );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_filters );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_filters ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
@@ -1580,7 +1957,12 @@ static Obj  HdlrFunc6 (
   
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, l_filters );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, l_filters );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_filters ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(1);
@@ -1591,7 +1973,12 @@ static Obj  HdlrFunc6 (
    /* if IS_STRING_REP( filters[i] ) then */
    t_5 = GF_IS__STRING__REP;
    C_ELM_LIST_FPL( t_6, l_filters, l_i )
-   t_4 = CALL_1ARGS( t_5, t_6 );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, t_6 );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6 ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
    CHECK_BOOL( t_4 );
    t_3 = (Obj)(UInt)(t_4 != False);
@@ -1600,24 +1987,44 @@ static Obj  HdlrFunc6 (
     /* APPEND_LIST_INTR( info1, filters[i] ); */
     t_3 = GF_APPEND__LIST__INTR;
     C_ELM_LIST_FPL( t_4, l_filters, l_i )
-    CALL_2ARGS( t_3, l_info1, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_3, l_info1, t_4 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_info1, t_4 ) );
+    }
     
     /* APPEND_LIST_INTR( info1, ", " ); */
     t_3 = GF_APPEND__LIST__INTR;
     t_4 = MakeString( ", " );
-    CALL_2ARGS( t_3, l_info1, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_3, l_info1, t_4 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_info1, t_4 ) );
+    }
     
     /* filters[i] := EvalString( filters[i] ); */
     t_4 = GF_EvalString;
     C_ELM_LIST_FPL( t_5, l_filters, l_i )
-    t_3 = CALL_1ARGS( t_4, t_5 );
+    if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+     t_3 = CALL_1ARGS( t_4, t_5 );
+    }
+    else {
+     t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+    }
     CHECK_FUNC_RESULT( t_3 );
     C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
     C_ELM_LIST_FPL( t_7, l_filters, l_i )
-    t_5 = CALL_1ARGS( t_6, t_7 );
+    if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+     t_5 = CALL_1ARGS( t_6, t_7 );
+    }
+    else {
+     t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+    }
     CHECK_FUNC_RESULT( t_5 );
     CHECK_BOOL( t_5 );
     t_4 = (Obj)(UInt)(t_5 != False);
@@ -1627,7 +2034,12 @@ static Obj  HdlrFunc6 (
      /* Error( "string does not evaluate to a function" ); */
      t_3 = GF_Error;
      t_4 = MakeString( "string does not evaluate to a function" );
-     CALL_1ARGS( t_3, t_4 );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      CALL_1ARGS( t_3, t_4 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+     }
      
     }
     /* fi */
@@ -1662,7 +2074,12 @@ static Obj  HdlrFunc6 (
    
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
-   t_2 = CALL_1ARGS( t_3, l_info1 );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, l_info1 );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_info1 ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
    CHECK_INT_POS( t_1 );
@@ -1671,7 +2088,12 @@ static Obj  HdlrFunc6 (
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
-   t_1 = CALL_1ARGS( t_2, l_info1 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_1ARGS( t_2, l_info1 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_info1 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[93];
@@ -1721,9 +2143,19 @@ static Obj  HdlrFunc6 (
   /* ADD_LIST( flags, FLAGS_FILTER( i ) ); */
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
-  t_6 = CALL_1ARGS( t_7, l_i );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, l_i );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
-  CALL_2ARGS( t_5, l_flags, t_6 );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_5, l_flags, t_6 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_flags, t_6 ) );
+  }
   
  }
  /* od */
@@ -1738,7 +2170,12 @@ static Obj  HdlrFunc6 (
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "the method is missing in <arglist>" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -1746,7 +2183,12 @@ static Obj  HdlrFunc6 (
  else {
   t_4 = GF_IS__INT;
   C_ELM_LIST_FPL( t_5, a_arglist, l_pos )
-  t_3 = CALL_1ARGS( t_4, t_5 );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, t_5 );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
@@ -1754,7 +2196,12 @@ static Obj  HdlrFunc6 (
   if ( ! t_1 ) {
    t_7 = GF_IS__FUNCTION;
    C_ELM_LIST_FPL( t_8, a_arglist, l_pos )
-   t_6 = CALL_1ARGS( t_7, t_8 );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, t_8 );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    CHECK_BOOL( t_6 );
    t_5 = (Obj)(UInt)(t_6 != False);
@@ -1762,7 +2209,12 @@ static Obj  HdlrFunc6 (
    if ( t_4 ) {
     t_8 = GF_NARG__FUNC;
     C_ELM_LIST_FPL( t_9, a_arglist, l_pos )
-    t_7 = CALL_1ARGS( t_8, t_9 );
+    if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+     t_7 = CALL_1ARGS( t_8, t_9 );
+    }
+    else {
+     t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+    }
     CHECK_FUNC_RESULT( t_7 );
     t_6 = (Obj)(UInt)(EQ( t_7, INTOBJ_INT(0) ));
     t_4 = t_6;
@@ -1770,7 +2222,12 @@ static Obj  HdlrFunc6 (
    t_3 = t_4;
    if ( t_3 ) {
     t_7 = GF_LEN__LIST;
-    t_6 = CALL_1ARGS( t_7, a_arglist );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, a_arglist );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_arglist ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     t_5 = (Obj)(UInt)(LT( l_pos, t_6 ));
     t_3 = t_5;
@@ -1809,7 +2266,12 @@ static Obj  HdlrFunc6 (
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "the method is missing in <arglist>" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -1820,7 +2282,12 @@ static Obj  HdlrFunc6 (
  
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
- t_5 = CALL_1ARGS( t_6, l_opr );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, l_opr );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_opr ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
@@ -1839,7 +2306,12 @@ static Obj  HdlrFunc6 (
  t_2 = t_3;
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
-  t_5 = CALL_1ARGS( t_6, l_filters );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, l_filters );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_filters ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
@@ -1862,10 +2334,20 @@ static Obj  HdlrFunc6 (
   /* Error( NAME_FUNC( opr ), ": use `InstallTrueMethod' for <opr>" ); */
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
-  t_2 = CALL_1ARGS( t_3, l_opr );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, l_opr );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_opr ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
-  CALL_2ARGS( t_1, t_2, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, t_2, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+  }
   
  }
  /* fi */
@@ -1893,19 +2375,34 @@ static Obj  HdlrFunc6 (
    t_1 = GF_INFO__DEBUG;
    t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
-   t_3 = CALL_1ARGS( t_4, l_opr );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_opr );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_4 = MakeString( "\n" );
    t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
    t_6 = MakeString( "#I  underlying operation(s)" );
-   CALL_6ARGS( t_1, INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_6ARGS( t_1, INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 ) );
+   }
    
   }
   /* fi */
   
   /* req := GET_OPER_FLAGS( opr ); */
   t_2 = GF_GET__OPER__FLAGS;
-  t_1 = CALL_1ARGS( t_2, l_opr );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, l_opr );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_opr ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_req = t_1;
   
@@ -1919,9 +2416,19 @@ static Obj  HdlrFunc6 (
    t_1 = GF_Error;
    t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
-   t_3 = CALL_1ARGS( t_4, l_opr );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_opr );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
-   CALL_2ARGS( t_1, t_2, t_3 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, t_2, t_3 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+   }
    
   }
   /* fi */
@@ -1967,9 +2474,19 @@ static Obj  HdlrFunc6 (
     /* ADD_LIST( imp, WITH_HIDDEN_IMPS_FLAGS( i ) ); */
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
-    t_6 = CALL_1ARGS( t_7, l_i );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_i );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
-    CALL_2ARGS( t_5, l_imp, t_6 );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_5, l_imp, t_6 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_imp, t_6 ) );
+    }
     
    }
    
@@ -1979,9 +2496,19 @@ static Obj  HdlrFunc6 (
     /* ADD_LIST( imp, WITH_IMPS_FLAGS( i ) ); */
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__IMPS__FLAGS;
-    t_6 = CALL_1ARGS( t_7, l_i );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_i );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
-    CALL_2ARGS( t_5, l_imp, t_6 );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_5, l_imp, t_6 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_imp, t_6 ) );
+    }
     
    }
    /* fi */
@@ -2002,7 +2529,12 @@ static Obj  HdlrFunc6 (
   /* while j < LEN_LIST( req ) and not match do */
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_req );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_req );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_req ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
@@ -2024,10 +2556,20 @@ static Obj  HdlrFunc6 (
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
-   t_2 = CALL_1ARGS( t_3, l_reqs );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, l_reqs );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_reqs ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_imp );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_imp );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_imp ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
@@ -2038,7 +2580,12 @@ static Obj  HdlrFunc6 (
     
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
-    t_2 = CALL_1ARGS( t_3, l_reqs );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, l_reqs );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_reqs ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     CHECK_INT_SMALL( t_2 );
     for ( t_1 = INTOBJ_INT(1);
@@ -2050,7 +2597,12 @@ static Obj  HdlrFunc6 (
      t_6 = GF_IS__SUBSET__FLAGS;
      C_ELM_LIST_FPL( t_7, l_imp, l_i )
      C_ELM_LIST_FPL( t_8, l_reqs, l_i )
-     t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
@@ -2112,9 +2664,19 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Error;
      t_2 = MakeString( "the number of arguments does not match a declaration of " );
      t_4 = GF_NAME__FUNC;
-     t_3 = CALL_1ARGS( t_4, l_opr );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, l_opr );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
-     CALL_2ARGS( t_1, t_2, t_3 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_1, t_2, t_3 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+     }
      
     }
     
@@ -2126,10 +2688,20 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( "InstallMethod warning:  nr of args does not " );
      t_3 = MakeString( "match a declaration of " );
      t_5 = GF_NAME__FUNC;
-     t_4 = CALL_1ARGS( t_5, l_opr );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, l_opr );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      t_5 = MakeString( "\n" );
-     CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5 ) );
+     }
      
     }
     /* fi */
@@ -2155,17 +2727,37 @@ static Obj  HdlrFunc6 (
      t_4 = GF_NamesFilter;
      CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
-     t_3 = CALL_1ARGS( t_4, t_5 );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, t_5 );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( "\nfor " );
      t_6 = GF_Ordinal;
-     t_5 = CALL_1ARGS( t_6, l_notmatch );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, l_notmatch );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_notmatch ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      t_6 = MakeString( " argument do not match a declaration of " );
      t_8 = GF_NAME__FUNC;
-     t_7 = CALL_1ARGS( t_8, l_opr );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, l_opr );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, t_6, t_7 ) );
+     }
      
     }
     
@@ -2180,7 +2772,12 @@ static Obj  HdlrFunc6 (
      SET_ELM_PLIST( t_2, 1, t_3 );
      CHANGED_BAG( t_2 );
      t_4 = GF_NAME__FUNC;
-     t_3 = CALL_1ARGS( t_4, l_opr );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, l_opr );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 2, t_3 );
      CHANGED_BAG( t_2 );
@@ -2188,7 +2785,12 @@ static Obj  HdlrFunc6 (
      SET_ELM_PLIST( t_2, 3, t_3 );
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__FILENAME;
-     t_3 = CALL_0ARGS( t_4 );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_0ARGS( t_4 );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 4, t_3 );
      CHANGED_BAG( t_2 );
@@ -2196,7 +2798,12 @@ static Obj  HdlrFunc6 (
      SET_ELM_PLIST( t_2, 5, t_3 );
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__LINENUMBER;
-     t_3 = CALL_0ARGS( t_4 );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_0ARGS( t_4 );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 6, t_3 );
      CHANGED_BAG( t_2 );
@@ -2206,13 +2813,23 @@ static Obj  HdlrFunc6 (
      t_3 = MakeString( "required filters \03" );
      SET_ELM_PLIST( t_2, 8, t_3 );
      CHANGED_BAG( t_2 );
-     CALL_XARGS( t_1, t_2 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_XARGS( t_1, t_2 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, t_2 );
+     }
      
      /* for j in NamesFilter( imp[notmatch] ) do */
      t_5 = GF_NamesFilter;
      CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_6, l_imp, l_notmatch )
-     t_4 = CALL_1ARGS( t_5, t_6 );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, t_6 );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6 ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      if ( IS_SMALL_LIST(t_4) ) {
       t_3 = (Obj)(UInt)1;
@@ -2238,7 +2855,12 @@ static Obj  HdlrFunc6 (
       /* Print( j, "/\c" ); */
       t_5 = GF_Print;
       t_6 = MakeString( "/\03" );
-      CALL_2ARGS( t_5, l_j, t_6 );
+      if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+       CALL_2ARGS( t_5, l_j, t_6 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_j, t_6 ) );
+      }
       
      }
      /* od */
@@ -2247,11 +2869,21 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Print;
      t_2 = MakeString( " for " );
      t_4 = GF_Ordinal;
-     t_3 = CALL_1ARGS( t_4, l_notmatch );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, l_notmatch );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_notmatch ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( " argument do not match \03a " );
      t_5 = MakeString( "declaration\n" );
-     CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5 ) );
+     }
      
     }
     /* fi */
@@ -2271,7 +2903,12 @@ static Obj  HdlrFunc6 (
    C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
    CHECK_INT_SMALL( t_2 );
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_req );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_req );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_req ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    CHECK_INT_SMALL( t_3 );
    for ( t_1 = t_2;
@@ -2286,10 +2923,20 @@ static Obj  HdlrFunc6 (
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
-    t_5 = CALL_1ARGS( t_6, l_reqs );
+    if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+     t_5 = CALL_1ARGS( t_6, l_reqs );
+    }
+    else {
+     t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_reqs ) );
+    }
     CHECK_FUNC_RESULT( t_5 );
     t_7 = GF_LEN__LIST;
-    t_6 = CALL_1ARGS( t_7, l_imp );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_imp );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_imp ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
@@ -2300,7 +2947,12 @@ static Obj  HdlrFunc6 (
      
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
-     t_5 = CALL_1ARGS( t_6, l_reqs );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, l_reqs );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_reqs ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      CHECK_INT_SMALL( t_5 );
      for ( t_4 = INTOBJ_INT(1);
@@ -2312,7 +2964,12 @@ static Obj  HdlrFunc6 (
       t_9 = GF_IS__SUBSET__FLAGS;
       C_ELM_LIST_FPL( t_10, l_imp, l_i )
       C_ELM_LIST_FPL( t_11, l_reqs, l_i )
-      t_8 = CALL_2ARGS( t_9, t_10, t_11 );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
+      }
+      else {
+       t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11 ) );
+      }
       CHECK_FUNC_RESULT( t_8 );
       CHECK_BOOL( t_8 );
       t_7 = (Obj)(UInt)(t_8 != False);
@@ -2345,10 +3002,20 @@ static Obj  HdlrFunc6 (
       t_4 = GF_INFO__DEBUG;
       t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
-      t_6 = CALL_1ARGS( t_7, l_opr );
+      if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+       t_6 = CALL_1ARGS( t_7, l_opr );
+      }
+      else {
+       t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_opr ) );
+      }
       CHECK_FUNC_RESULT( t_6 );
       t_7 = MakeString( " matches more than one declaration" );
-      CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
+      if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( INTOBJ_INT(1), t_5, t_6, t_7 ) );
+      }
       
      }
      /* fi */
@@ -2368,7 +3035,12 @@ static Obj  HdlrFunc6 (
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
  CHECK_BOUND( l_rank, "rank" );
- CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_opr, l_info, l_rel, l_flags, l_rank, l_method ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -2434,10 +3106,19 @@ static Obj  HdlrFunc8 (
   
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
-  t_8 = CALL_1ARGS( t_9, l_prop );
+  if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+   t_8 = CALL_1ARGS( t_9, l_prop );
+  }
+  else {
+   t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( l_prop ) );
+  }
   CHECK_FUNC_RESULT( t_8 );
-  CHECK_FUNC( t_8 );
-  t_7 = CALL_1ARGS( t_8, a_obj );
+  if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+   t_7 = CALL_1ARGS( t_8, a_obj );
+  }
+  else {
+   t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_7 );
   CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
@@ -2449,18 +3130,31 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop );
-   t_8 = CALL_1ARGS( l_prop, a_obj );
+   if ( TNUM_OBJ( l_prop ) == T_FUNCTION ) {
+    t_8 = CALL_1ARGS( l_prop, a_obj );
+   }
+   else {
+    t_8 = DoOperation2Args( CallFuncListOper, l_prop, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_8 );
    CHECK_BOOL( t_8 );
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
-    t_10 = CALL_1ARGS( t_11, l_prop );
+    if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+     t_10 = CALL_1ARGS( t_11, l_prop );
+    }
+    else {
+     t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( l_prop ) );
+    }
     CHECK_FUNC_RESULT( t_10 );
-    CHECK_FUNC( t_10 );
-    t_9 = CALL_1ARGS( t_10, a_obj );
+    if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+     t_9 = CALL_1ARGS( t_10, a_obj );
+    }
+    else {
+     t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( a_obj ) );
+    }
     CHECK_FUNC_RESULT( t_9 );
     CHECK_BOOL( t_9 );
     t_8 = (Obj)(UInt)(t_9 != False);
@@ -2491,8 +3185,12 @@ static Obj  HdlrFunc8 (
   /* return getter( obj ); */
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "getter" );
-  CHECK_FUNC( t_2 );
-  t_1 = CALL_1ARGS( t_2, a_obj );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_obj );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -2560,7 +3258,12 @@ static Obj  HdlrFunc7 (
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
  CHECK_BOUND( t_5, "IS_OBJECT" );
- t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_filter, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2569,7 +3272,12 @@ static Obj  HdlrFunc7 (
   
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
-  t_1 = CALL_1ARGS( t_2, a_filter );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_filter );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_filter ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_flags = t_1;
   
@@ -2588,7 +3296,12 @@ static Obj  HdlrFunc7 (
   
   /* for i in TRUES_FLAGS( flags ) do */
   t_5 = GF_TRUES__FLAGS;
-  t_4 = CALL_1ARGS( t_5, l_flags );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_flags );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_flags ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -2649,7 +3362,12 @@ static Obj  HdlrFunc7 (
     t_9 = GC_FILTERS;
     CHECK_BOUND( t_9, "FILTERS" );
     C_ELM_LIST_FPL( t_8, t_9, l_i )
-    t_6 = CALL_1ARGS( t_7, t_8 );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, t_8 );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     C_DIFF_FIA( t_5, l_rank, t_6 )
     l_rank = t_5;
@@ -2673,7 +3391,12 @@ static Obj  HdlrFunc7 (
      t_8 = GC_FILTERS;
      CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
-     CALL_2ARGS( t_5, t_6, t_7 );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_5, t_6, t_7 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6, t_7 ) );
+     }
      
     }
    }
@@ -2686,13 +3409,23 @@ static Obj  HdlrFunc7 (
   t_1 = GF_MakeImmutable;
   t_2 = OBJ_LVAR( 2 );
   CHECK_BOUND( t_2, "props" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
   CHECK_BOUND( t_4, "props" );
-  t_2 = CALL_1ARGS( t_3, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
@@ -2731,7 +3464,12 @@ static Obj  HdlrFunc7 (
    SET_ENDLINE_BODY(t_7, 689);
    SET_FILENAME_BODY(t_7, FileName);
    SET_BODY_FUNC(t_6, t_7);
-   CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, l_rank, t_6 ) );
+   }
    
   }
   /* fi */
@@ -2784,7 +3522,12 @@ static Obj  HdlrFunc9 (
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
  CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
- CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -2820,7 +3563,12 @@ static Obj  HdlrFunc10 (
  
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_list );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_list );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_list ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
@@ -2850,7 +3598,12 @@ static Obj  HdlrFunc10 (
   t_4 = GF_QUO__INT;
   C_SUM_FIA( t_6, l_i, l_k )
   C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
-  t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5, INTOBJ_INT(4) ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
@@ -2904,7 +3657,12 @@ static Obj  HdlrFunc12 (
  
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
- t_3 = CALL_1ARGS( t_4, a_key );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_key );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_key ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2916,7 +3674,12 @@ static Obj  HdlrFunc12 (
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "name" );
   t_3 = MakeString( ": <p> must be a prime" );
-  CALL_2ARGS( t_1, t_2, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, t_2, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+  }
   
  }
  /* fi */
@@ -2977,26 +3740,44 @@ static Obj  HdlrFunc14 (
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
- CALL_1ARGS( t_1, a_key );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, a_key );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_key ) );
+ }
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
- t_1 = CALL_1ARGS( t_2, a_D );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_D );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
- t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_known );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_known );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
@@ -3011,20 +3792,34 @@ static Obj  HdlrFunc14 (
   /* erg := oper( D, key ); */
   t_2 = OBJ_HVAR( (1 << 16) | 3 );
   CHECK_BOUND( t_2, "oper" );
-  CHECK_FUNC( t_2 );
-  t_1 = CALL_2ARGS( t_2, a_D, a_key );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, a_D, a_key );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D, a_key ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
-  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, l_known, a_key );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_known );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, l_known );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
@@ -3039,12 +3834,22 @@ static Obj  HdlrFunc14 (
    /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
    C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
-   t_4 = CALL_1ARGS( t_5, l_known );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, l_known );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
-   t_4 = CALL_1ARGS( t_5, l_known );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, l_known );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
@@ -3053,7 +3858,12 @@ static Obj  HdlrFunc14 (
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
    CHECK_INT_POS( l_i );
    t_2 = GF_IMMUTABLE__COPY__OBJ;
-   t_1 = CALL_1ARGS( t_2, a_key );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_1ARGS( t_2, a_key );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_key ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
@@ -3061,7 +3871,12 @@ static Obj  HdlrFunc14 (
    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
    CHECK_INT_POS( t_1 );
    t_3 = GF_IMMUTABLE__COPY__OBJ;
-   t_2 = CALL_1ARGS( t_3, l_erg );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, l_erg );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_erg ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
@@ -3106,26 +3921,44 @@ static Obj  HdlrFunc15 (
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
- CALL_1ARGS( t_1, a_key );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, a_key );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_key ) );
+ }
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
- t_1 = CALL_1ARGS( t_2, a_D );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_D );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
- t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_known );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_known );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
@@ -3178,26 +4011,44 @@ static Obj  HdlrFunc16 (
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
- CALL_1ARGS( t_1, a_key );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, a_key );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_key ) );
+ }
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
- t_1 = CALL_1ARGS( t_2, a_D );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_D );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
- t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_known );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_known );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
@@ -3212,12 +4063,22 @@ static Obj  HdlrFunc16 (
   /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_known );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_known );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_known );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_known );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
@@ -3226,7 +4087,12 @@ static Obj  HdlrFunc16 (
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
   CHECK_INT_POS( l_i );
   t_2 = GF_IMMUTABLE__COPY__OBJ;
-  t_1 = CALL_1ARGS( t_2, a_key );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_key );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_key ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
@@ -3234,7 +4100,12 @@ static Obj  HdlrFunc16 (
   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
   CHECK_INT_POS( t_1 );
   t_3 = GF_IMMUTABLE__COPY__OBJ;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
@@ -3306,14 +4177,24 @@ static Obj  HdlrFunc11 (
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_3, "name" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = MakeString( "Op" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
@@ -3323,11 +4204,21 @@ static Obj  HdlrFunc11 (
  CHANGED_BAG( t_2 );
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
- t_1 = CALL_1ARGS( t_2, l_str );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, l_str );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 3, t_1 );
  
@@ -3339,21 +4230,41 @@ static Obj  HdlrFunc11 (
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_2, "name" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* APPEND_LIST_INTR( str, "s" ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = MakeString( "s" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareAttribute( str, domreq, "mutable" ); */
  t_1 = GF_DeclareAttribute;
  t_2 = MakeString( "mutable" );
- CALL_3ARGS( t_1, l_str, a_domreq, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, l_str, a_domreq, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, a_domreq, t_2 ) );
+ }
  
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
- t_1 = CALL_1ARGS( t_2, l_str );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, l_str );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 4, t_1 );
  
@@ -3376,7 +4287,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 889);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
@@ -3388,7 +4304,12 @@ static Obj  HdlrFunc11 (
  CHANGED_BAG( t_3 );
  SET_ELM_PLIST( t_3, 2, a_keyreq );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) ); */
  t_1 = GF_ADD__LIST;
@@ -3397,9 +4318,19 @@ static Obj  HdlrFunc11 (
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_5, "name" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
       local known, i, erg;
@@ -3421,7 +4352,12 @@ static Obj  HdlrFunc11 (
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_4, "name" );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
@@ -3438,7 +4374,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 934);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* str := "Has"; */
  t_1 = MakeString( "Has" );
@@ -3448,7 +4389,12 @@ static Obj  HdlrFunc11 (
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_2, "name" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
@@ -3458,7 +4404,12 @@ static Obj  HdlrFunc11 (
  CHANGED_BAG( t_2 );
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
       local known, i;
@@ -3469,7 +4420,12 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
- t_2 = CALL_1ARGS( t_3, l_str );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_str );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
@@ -3486,7 +4442,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 952);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* str := "Set"; */
  t_1 = MakeString( "Set" );
@@ -3496,7 +4457,12 @@ static Obj  HdlrFunc11 (
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_2, "name" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
  t_1 = GF_DeclareOperation;
@@ -3510,7 +4476,12 @@ static Obj  HdlrFunc11 (
  CHECK_BOUND( t_3, "IS_OBJECT" );
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
       local known, i;
@@ -3526,7 +4497,12 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
- t_2 = CALL_1ARGS( t_3, l_str );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_str );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
@@ -3547,7 +4523,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 974);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -3594,7 +4575,12 @@ static Obj  HdlrFunc18 (
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_7, "reqs" );
- t_5 = CALL_1ARGS( t_6, t_7 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
@@ -3641,14 +4627,23 @@ static Obj  HdlrFunc18 (
     CHECK_BOUND( t_18, "i" );
     CHECK_INT_POS( t_18 );
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
-    t_14 = CALL_1ARGS( t_15, t_16 );
+    if ( TNUM_OBJ( t_15 ) == T_FUNCTION ) {
+     t_14 = CALL_1ARGS( t_15, t_16 );
+    }
+    else {
+     t_14 = DoOperation2Args( CallFuncListOper, t_15, NewPlistFromArgs( t_16 ) );
+    }
     CHECK_FUNC_RESULT( t_14 );
-    CHECK_FUNC( t_14 );
     t_16 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_16, "i" );
     CHECK_INT_POS( t_16 );
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
-    t_13 = CALL_1ARGS( t_14, t_15 );
+    if ( TNUM_OBJ( t_14 ) == T_FUNCTION ) {
+     t_13 = CALL_1ARGS( t_14, t_15 );
+    }
+    else {
+     t_13 = DoOperation2Args( CallFuncListOper, t_14, NewPlistFromArgs( t_15 ) );
+    }
     CHECK_FUNC_RESULT( t_13 );
     CHECK_BOOL( t_13 );
     t_12 = (Obj)(UInt)(t_13 != False);
@@ -3663,12 +4658,16 @@ static Obj  HdlrFunc18 (
     CHECK_BOUND( t_14, "i" );
     CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
-    CHECK_FUNC( t_12 );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_14, "i" );
     CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
-    t_11 = CALL_1ARGS( t_12, t_13 );
+    if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+     t_11 = CALL_1ARGS( t_12, t_13 );
+    }
+    else {
+     t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13 ) );
+    }
     CHECK_FUNC_RESULT( t_11 );
     CHECK_BOOL( t_11 );
     t_10 = (Obj)(UInt)(t_11 != False);
@@ -3683,14 +4682,23 @@ static Obj  HdlrFunc18 (
     CHECK_BOUND( t_15, "i" );
     CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
-    t_11 = CALL_1ARGS( t_12, t_13 );
+    if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+     t_11 = CALL_1ARGS( t_12, t_13 );
+    }
+    else {
+     t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13 ) );
+    }
     CHECK_FUNC_RESULT( t_11 );
-    CHECK_FUNC( t_11 );
     t_13 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_13, "i" );
     CHECK_INT_POS( t_13 );
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
-    t_10 = CALL_1ARGS( t_11, t_12 );
+    if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+     t_10 = CALL_1ARGS( t_11, t_12 );
+    }
+    else {
+     t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( t_12 ) );
+    }
     CHECK_FUNC_RESULT( t_10 );
     CHECK_BOOL( t_10 );
     t_9 = (Obj)(UInt)(t_10 != False);
@@ -3714,7 +4722,12 @@ static Obj  HdlrFunc18 (
   t_2 = GF_CallFuncList;
   t_3 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_3, "oper" );
-  t_1 = CALL_2ARGS( t_2, t_3, a_arg );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -3769,7 +4782,12 @@ static Obj  HdlrFunc17 (
  
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
@@ -3803,7 +4821,12 @@ static Obj  HdlrFunc17 (
  /* elif LEN_LIST( arg ) = 6 then */
  else {
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_arg );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_arg );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
@@ -3840,7 +4863,12 @@ static Obj  HdlrFunc17 (
    /* Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" ); */
    t_1 = GF_Error;
    t_2 = MakeString( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
-   CALL_1ARGS( t_1, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_1ARGS( t_1, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+   }
    
   }
  }
@@ -3875,7 +4903,12 @@ static Obj  HdlrFunc17 (
   t_7 = GF_RankFilter;
   t_8 = OBJ_LVAR( 5 );
   CHECK_BOUND( t_8, "i" );
-  t_6 = CALL_1ARGS( t_7, t_8 );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, t_8 );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
@@ -3909,7 +4942,12 @@ static Obj  HdlrFunc17 (
  SET_ENDLINE_BODY(t_5, 1056);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
- CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, l_info, l_fampred, t_3, l_val, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -4005,7 +5043,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 127);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, baserank, method )
       local methods, narg, i, k, tmp, replace, match, j, lk, rank;
@@ -4115,7 +5158,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 289);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "InstallMethod", function ( arg... )
       INSTALL_METHOD( arg, true );
@@ -4130,7 +5178,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 340);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "InstallOtherMethod", function ( arg... )
       INSTALL_METHOD( arg, false );
@@ -4145,12 +5198,22 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 367);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* DeclareGlobalFunction( "EvalString" ); */
  t_1 = GF_DeclareGlobalFunction;
  t_2 = MakeString( "EvalString" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( INSTALL_METHOD ); */
  AssGVar( G_INSTALL__METHOD, 0 );
@@ -4314,7 +5377,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 610);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
@@ -4372,7 +5440,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 693);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
       InstallOtherMethod( setter, "default method, does nothing", true, [ IS_OBJECT, IS_OBJECT ], 0, DO_NOTHING_SETTER );
@@ -4386,7 +5459,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 702);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
       local i, j, k;
@@ -4414,7 +5492,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 739);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* IsPrimeInt := "2b defined"; */
  t_1 = MakeString( "2b defined" );
@@ -4498,7 +5581,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 975);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CallFuncList := "2b defined"; */
  t_1 = MakeString( "2b defined" );
@@ -4549,7 +5637,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 1057);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
@@ -4565,7 +5658,12 @@ static Obj  HdlrFunc1 (
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
  CHECK_BOUND( t_6, "PRINT_OBJ" );
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -236,9 +236,19 @@ static Obj  HdlrFunc2 (
  t_5 = GC_GETTER__FLAGS;
  CHECK_BOUND( t_5, "GETTER_FLAGS" );
  t_7 = GF_GETTER__FUNCTION;
- t_6 = CALL_1ARGS( t_7, a_name );
+ if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+  t_6 = CALL_1ARGS( t_7, a_name );
+ }
+ else {
+  t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_name ) );
+ }
  CHECK_FUNC_RESULT( t_6 );
- CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_getter, t_2, t_3, t_4, t_5, t_6 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -271,7 +281,12 @@ static Obj  HdlrFunc4 (
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_2, "tester" );
- CALL_2ARGS( t_1, a_obj, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_obj, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -338,7 +353,12 @@ static Obj  HdlrFunc3 (
   SET_ENDLINE_BODY(t_6, 43);
   SET_FILENAME_BODY(t_6, FileName);
   SET_BODY_FUNC(t_5, t_6);
-  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 ) );
+  }
   
  }
  
@@ -364,9 +384,19 @@ static Obj  HdlrFunc3 (
   CHECK_BOUND( t_7, "name" );
   t_8 = OBJ_LVAR( 2 );
   CHECK_BOUND( t_8, "tester" );
-  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
-  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 ) );
+  }
   
  }
  /* fi */
@@ -412,9 +442,19 @@ static Obj  HdlrFunc5 (
  /* imp_filter := WITH_IMPS_FLAGS( AND_FLAGS( imp_filter, req_filter ) ); */
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
- t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_imp__filter, a_req__filter ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  a_imp__filter = t_1;
  
@@ -422,7 +462,12 @@ static Obj  HdlrFunc5 (
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
  CHECK_BOUND( t_3, "IsAttributeStoringRep" );
- t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
@@ -453,7 +498,12 @@ static Obj  HdlrFunc5 (
   /* if IS_SUBSET_FLAGS( imp_filter, pair[1] ) then */
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
-  t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_imp__filter, t_8 ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
@@ -462,7 +512,12 @@ static Obj  HdlrFunc5 (
    /* type := Subtype( type, pair[2] ); */
    t_6 = GF_Subtype;
    C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
-   t_5 = CALL_2ARGS( t_6, l_type, t_7 );
+   if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
+   }
+   else {
+    t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_type, t_7 ) );
+   }
    CHECK_FUNC_RESULT( t_5 );
    l_type = t_5;
    
@@ -480,11 +535,21 @@ static Obj  HdlrFunc5 (
  
  /* SET_TYPE_COMOBJ( family, type ); */
  t_1 = GF_SET__TYPE__COMOBJ;
- CALL_2ARGS( t_1, l_family, l_type );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_family, l_type );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_family, l_type ) );
+ }
  
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
- t_1 = CALL_1ARGS( t_2, a_name );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_name );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_name ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_NAME, t_1 );
  
@@ -544,7 +609,12 @@ static Obj  HdlrFunc6 (
  CHECK_BOUND( t_3, "EMPTY_FLAGS" );
  t_4 = GC_EMPTY__FLAGS;
  CHECK_BOUND( t_4, "EMPTY_FLAGS" );
- t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, a_name, t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -573,11 +643,21 @@ static Obj  HdlrFunc7 (
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
- t_3 = CALL_1ARGS( t_4, a_req );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_req );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_req ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_EMPTY__FLAGS;
  CHECK_BOUND( t_4, "EMPTY_FLAGS" );
- t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, a_name, t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -608,12 +688,27 @@ static Obj  HdlrFunc8 (
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
- t_3 = CALL_1ARGS( t_4, a_req );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_req );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_req ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
- t_4 = CALL_1ARGS( t_5, a_imp );
+ if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+  t_4 = CALL_1ARGS( t_5, a_imp );
+ }
+ else {
+  t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_imp ) );
+ }
  CHECK_FUNC_RESULT( t_4 );
- t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, a_name, t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -646,15 +741,35 @@ static Obj  HdlrFunc9 (
  /* return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
- t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_typeOfFamilies, a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
- t_4 = CALL_1ARGS( t_5, a_req );
+ if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+  t_4 = CALL_1ARGS( t_5, a_req );
+ }
+ else {
+  t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_req ) );
+ }
  CHECK_FUNC_RESULT( t_4 );
  t_6 = GF_FLAGS__FILTER;
- t_5 = CALL_1ARGS( t_6, a_imp );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, a_imp );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( a_imp ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, a_name, t_4, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -683,7 +798,12 @@ static Obj  HdlrFunc10 (
  
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
@@ -693,7 +813,12 @@ static Obj  HdlrFunc10 (
   t_3 = GC_TypeOfFamilies;
   CHECK_BOUND( t_3, "TypeOfFamilies" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
-  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -703,7 +828,12 @@ static Obj  HdlrFunc10 (
  /* elif LEN_LIST( arg ) = 2 then */
  else {
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_arg );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_arg );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
@@ -714,7 +844,12 @@ static Obj  HdlrFunc10 (
    CHECK_BOUND( t_3, "TypeOfFamilies" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
-   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
@@ -724,7 +859,12 @@ static Obj  HdlrFunc10 (
   /* elif LEN_LIST( arg ) = 3 then */
   else {
    t_3 = GF_LEN__LIST;
-   t_2 = CALL_1ARGS( t_3, a_arg );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_arg );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
@@ -736,7 +876,12 @@ static Obj  HdlrFunc10 (
     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
-    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+    if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+    }
+    else {
+     t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6 ) );
+    }
     CHECK_FUNC_RESULT( t_1 );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
@@ -746,7 +891,12 @@ static Obj  HdlrFunc10 (
    /* elif LEN_LIST( arg ) = 4 then */
    else {
     t_3 = GF_LEN__LIST;
-    t_2 = CALL_1ARGS( t_3, a_arg );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_arg );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
@@ -759,7 +909,12 @@ static Obj  HdlrFunc10 (
      C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
      C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
-     t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
+     if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
+     }
+     else {
+      t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_1 );
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
@@ -772,7 +927,12 @@ static Obj  HdlrFunc10 (
      /* Error( "usage: NewFamily( <name> [, <req> [, <imp> [, <famfilter> ] ] ] )" ); */
      t_1 = GF_Error;
      t_2 = MakeString( "usage: NewFamily( <name> [, <req> [, <imp> [, <famfilter> ] ] ] )" );
-     CALL_1ARGS( t_1, t_2 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_1ARGS( t_1, t_2 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+     }
      
     }
    }
@@ -839,7 +999,12 @@ static Obj  HdlrFunc11 (
  
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
- t_3 = CALL_1ARGS( t_4, a_flags );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_flags );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = ElmComObj( a_family, R_HASH__SIZE );
  t_2 = MOD( t_3, t_4 );
@@ -859,7 +1024,12 @@ static Obj  HdlrFunc11 (
   /* if IS_EQUAL_FLAGS( flags, cached![2] ) then */
   t_3 = GF_IS__EQUAL__FLAGS;
   t_4 = ElmPosObj( l_cached, 2 );
-  t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_flags, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -872,7 +1042,12 @@ static Obj  HdlrFunc11 (
    /* if IS_IDENTICAL_OBJ( data, cached![3] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_5 = ElmPosObj( l_cached, 3 );
-   t_3 = CALL_2ARGS( t_4, a_data, t_5 );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_data, t_5 ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    CHECK_BOOL( t_3 );
    t_2 = (Obj)(UInt)(t_3 != False);
@@ -880,9 +1055,19 @@ static Obj  HdlrFunc11 (
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
-    t_6 = CALL_1ARGS( t_7, l_cached );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_cached );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_cached ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
-    t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
+    }
+    else {
+     t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_typeOfTypes, t_6 ) );
+    }
     CHECK_FUNC_RESULT( t_4 );
     CHECK_BOOL( t_4 );
     t_3 = (Obj)(UInt)(t_4 != False);
@@ -894,7 +1079,12 @@ static Obj  HdlrFunc11 (
     t_3 = GF_IS__IDENTICAL__OBJ;
     t_4 = GC_fail;
     CHECK_BOUND( t_4, "fail" );
-    t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent, t_4 ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
@@ -906,7 +1096,12 @@ static Obj  HdlrFunc11 (
      
      /* for i in [ 5 .. LEN_POSOBJ( cached ) ] do */
      t_3 = GF_LEN__POSOBJ;
-     t_2 = CALL_1ARGS( t_3, l_cached );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      t_2 = CALL_1ARGS( t_3, l_cached );
+     }
+     else {
+      t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_cached ) );
+     }
      CHECK_FUNC_RESULT( t_2 );
      CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
@@ -954,10 +1149,20 @@ static Obj  HdlrFunc11 (
     
     /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
     t_3 = GF_LEN__POSOBJ;
-    t_2 = CALL_1ARGS( t_3, a_parent );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_parent );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_4 = GF_LEN__POSOBJ;
-    t_3 = CALL_1ARGS( t_4, l_cached );
+    if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+     t_3 = CALL_1ARGS( t_4, l_cached );
+    }
+    else {
+     t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_cached ) );
+    }
     CHECK_FUNC_RESULT( t_3 );
     t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
     if ( t_1 ) {
@@ -968,7 +1173,12 @@ static Obj  HdlrFunc11 (
      
      /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
      t_3 = GF_LEN__POSOBJ;
-     t_2 = CALL_1ARGS( t_3, a_parent );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      t_2 = CALL_1ARGS( t_3, a_parent );
+     }
+     else {
+      t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent ) );
+     }
      CHECK_FUNC_RESULT( t_2 );
      CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
@@ -1006,7 +1216,12 @@ static Obj  HdlrFunc11 (
        t_8 = GF_IS__IDENTICAL__OBJ;
        t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
        t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
-       t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+       if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+       }
+       else {
+        t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9, t_10 ) );
+       }
        CHECK_FUNC_RESULT( t_7 );
        CHECK_BOOL( t_7 );
        t_6 = (Obj)(UInt)(t_7 != False);
@@ -1080,15 +1295,30 @@ static Obj  HdlrFunc11 (
   /* GASMAN( "collect" ); */
   t_1 = GF_GASMAN;
   t_2 = MakeString( "collect" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
   /* FLUSH_ALL_METHOD_CACHES(  ); */
   t_1 = GF_FLUSH__ALL__METHOD__CACHES;
-  CALL_0ARGS( t_1 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_0ARGS( t_1 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+  }
   
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
-  t_1 = CALL_0ARGS( t_2 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_0ARGS( t_2 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
@@ -1116,7 +1346,12 @@ static Obj  HdlrFunc11 (
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_fail;
  CHECK_BOUND( t_5, "fail" );
- t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_parent, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1125,7 +1360,12 @@ static Obj  HdlrFunc11 (
   
   /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
   t_3 = GF_LEN__POSOBJ;
-  t_2 = CALL_1ARGS( t_3, a_parent );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_parent );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(5);
@@ -1160,7 +1400,12 @@ static Obj  HdlrFunc11 (
  
  /* SET_TYPE_POSOBJ( type, typeOfTypes ); */
  t_1 = GF_SET__TYPE__POSOBJ;
- CALL_2ARGS( t_1, l_type, a_typeOfTypes );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_type, a_typeOfTypes );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type, a_typeOfTypes ) );
+ }
  
  /* if 3 * family!.nTYPES > family!.HASH_SIZE then */
  t_3 = ElmComObj( a_family, R_nTYPES );
@@ -1206,7 +1451,12 @@ static Obj  HdlrFunc11 (
    /* ncache[HASH_FLAGS( t![2] ) mod ncl + 1] := t; */
    t_8 = GF_HASH__FLAGS;
    t_9 = ElmPosObj( l_t, 2 );
-   t_7 = CALL_1ARGS( t_8, t_9 );
+   if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+    t_7 = CALL_1ARGS( t_8, t_9 );
+   }
+   else {
+    t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+   }
    CHECK_FUNC_RESULT( t_7 );
    t_6 = MOD( t_7, l_ncl );
    C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
@@ -1224,7 +1474,12 @@ static Obj  HdlrFunc11 (
   
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
-  t_3 = CALL_1ARGS( t_4, a_flags );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, a_flags );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_flags ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = MOD( t_3, l_ncl );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
@@ -1283,17 +1538,37 @@ static Obj  HdlrFunc12 (
  t_6 = GF_AND__FLAGS;
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" );
  t_5 = GC_fail;
  CHECK_BOUND( t_5, "fail" );
- t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfTypes, a_family, t_3, t_4, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1331,15 +1606,35 @@ static Obj  HdlrFunc13 (
  t_6 = GF_AND__FLAGS;
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" );
- t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfTypes, a_family, t_3, a_data, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1370,7 +1665,12 @@ static Obj  HdlrFunc14 (
  /* if not IsFamily( arg[1] ) then */
  t_4 = GF_IsFamily;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1380,14 +1680,24 @@ static Obj  HdlrFunc14 (
   /* Error( "<family> must be a family" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<family> must be a family" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
@@ -1398,7 +1708,12 @@ static Obj  HdlrFunc14 (
   CHECK_BOUND( t_3, "TypeOfTypes" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
-  t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
@@ -1407,7 +1722,12 @@ static Obj  HdlrFunc14 (
  /* elif LEN_LIST( arg ) = 3 then */
  else {
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_arg );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_arg );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
@@ -1419,7 +1739,12 @@ static Obj  HdlrFunc14 (
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
-   t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    l_type = t_1;
    
@@ -1431,7 +1756,12 @@ static Obj  HdlrFunc14 (
    /* Error( "usage: NewType( <family>, <filter> [, <data> ] )" ); */
    t_1 = GF_Error;
    t_2 = MakeString( "usage: NewType( <family>, <filter> [, <data> ] )" );
-   CALL_1ARGS( t_1, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_1ARGS( t_1, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+   }
    
   }
  }
@@ -1478,14 +1808,34 @@ static Obj  HdlrFunc15 (
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
- t_10 = CALL_1ARGS( t_11, a_filter );
+ if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+  t_10 = CALL_1ARGS( t_11, a_filter );
+ }
+ else {
+  t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_10 );
- t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ }
+ else {
+  t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9, t_10 ) );
+ }
  CHECK_FUNC_RESULT( t_7 );
- t_5 = CALL_1ARGS( t_6, t_7 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1527,13 +1877,33 @@ static Obj  HdlrFunc16 (
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
- t_10 = CALL_1ARGS( t_11, a_filter );
+ if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+  t_10 = CALL_1ARGS( t_11, a_filter );
+ }
+ else {
+  t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_10 );
- t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ }
+ else {
+  t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9, t_10 ) );
+ }
  CHECK_FUNC_RESULT( t_7 );
- t_5 = CALL_1ARGS( t_6, t_7 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, a_data, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1565,7 +1935,12 @@ static Obj  HdlrFunc17 (
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1575,14 +1950,24 @@ static Obj  HdlrFunc17 (
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<type> must be a type" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
@@ -1591,7 +1976,12 @@ static Obj  HdlrFunc17 (
   t_2 = GF_Subtype2;
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
-  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
@@ -1605,7 +1995,12 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
-  t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
@@ -1649,12 +2044,27 @@ static Obj  HdlrFunc18 (
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1693,11 +2103,26 @@ static Obj  HdlrFunc19 (
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, a_data, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1725,7 +2150,12 @@ static Obj  HdlrFunc20 (
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1735,14 +2165,24 @@ static Obj  HdlrFunc20 (
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<type> must be a type" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
@@ -1751,7 +2191,12 @@ static Obj  HdlrFunc20 (
   t_2 = GF_SupType2;
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
-  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -1766,7 +2211,12 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
-  t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -1886,9 +2336,19 @@ static Obj  HdlrFunc25 (
  /* return FlagsType( TypeObj( obj ) ); */
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
- t_3 = CALL_1ARGS( t_4, a_obj );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_obj );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1915,9 +2375,19 @@ static Obj  HdlrFunc26 (
  /* return DataType( TypeObj( obj ) ); */
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
- t_3 = CALL_1ARGS( t_4, a_obj );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_obj );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1946,7 +2416,12 @@ static Obj  HdlrFunc27 (
  
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
- t_3 = CALL_1ARGS( t_4, a_type );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_type );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_type ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1956,14 +2431,24 @@ static Obj  HdlrFunc27 (
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<type> must be a type" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -1971,14 +2456,24 @@ static Obj  HdlrFunc27 (
   
   /* SET_TYPE_POSOBJ( obj, type ); */
   t_1 = GF_SET__TYPE__POSOBJ;
-  CALL_2ARGS( t_1, a_obj, a_type );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, a_type );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, a_type ) );
+  }
   
  }
  
  /* elif IS_REC( obj ) then */
  else {
   t_3 = GF_IS__REC;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -1986,7 +2481,12 @@ static Obj  HdlrFunc27 (
    
    /* SET_TYPE_COMOBJ( obj, type ); */
    t_1 = GF_SET__TYPE__COMOBJ;
-   CALL_2ARGS( t_1, a_obj, a_type );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, a_type );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, a_type ) );
+   }
    
   }
  }
@@ -1994,7 +2494,12 @@ static Obj  HdlrFunc27 (
  
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
- t_3 = CALL_1ARGS( t_4, a_obj );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_obj );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2004,7 +2509,12 @@ static Obj  HdlrFunc27 (
   /* RunImmediateMethods( obj, type![2] ); */
   t_1 = GF_RunImmediateMethods;
   t_2 = ElmPosObj( a_type, 2 );
-  CALL_2ARGS( t_1, a_obj, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+  }
   
  }
  /* fi */
@@ -2041,19 +2551,34 @@ static Obj  HdlrFunc28 (
  
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
- t_1 = CALL_1ARGS( t_2, a_obj );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_obj );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* newtype := Subtype2( type, filter ); */
  t_2 = GF_Subtype2;
- t_1 = CALL_2ARGS( t_2, l_type, a_filter );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_type, a_filter );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_type, a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_newtype = t_1;
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2061,14 +2586,24 @@ static Obj  HdlrFunc28 (
   
   /* SET_TYPE_POSOBJ( obj, newtype ); */
   t_1 = GF_SET__TYPE__POSOBJ;
-  CALL_2ARGS( t_1, a_obj, l_newtype );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, l_newtype );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, l_newtype ) );
+  }
   
  }
  
  /* elif IS_COMOBJ( obj ) then */
  else {
   t_3 = GF_IS__COMOBJ;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2076,14 +2611,24 @@ static Obj  HdlrFunc28 (
    
    /* SET_TYPE_COMOBJ( obj, newtype ); */
    t_1 = GF_SET__TYPE__COMOBJ;
-   CALL_2ARGS( t_1, a_obj, l_newtype );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, l_newtype );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, l_newtype ) );
+   }
    
   }
   
   /* elif IS_DATOBJ( obj ) then */
   else {
    t_3 = GF_IS__DATOBJ;
-   t_2 = CALL_1ARGS( t_3, a_obj );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_obj );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -2091,7 +2636,12 @@ static Obj  HdlrFunc28 (
     
     /* SET_TYPE_DATOBJ( obj, newtype ); */
     t_1 = GF_SET__TYPE__DATOBJ;
-    CALL_2ARGS( t_1, a_obj, l_newtype );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, a_obj, l_newtype );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, l_newtype ) );
+    }
     
    }
    
@@ -2101,7 +2651,12 @@ static Obj  HdlrFunc28 (
     /* ErrorNoReturn( "cannot set filter for internal object" ); */
     t_1 = GF_ErrorNoReturn;
     t_2 = MakeString( "cannot set filter for internal object" );
-    CALL_1ARGS( t_1, t_2 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, t_2 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+    }
     
    }
   }
@@ -2116,7 +2671,12 @@ static Obj  HdlrFunc28 (
  t_2 = t_3;
  if ( ! t_2 ) {
   t_6 = GF_IsNoImmediateMethodsObject;
-  t_5 = CALL_1ARGS( t_6, a_obj );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, a_obj );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
@@ -2130,9 +2690,19 @@ static Obj  HdlrFunc28 (
   t_3 = GF_SUB__FLAGS;
   t_4 = ElmPosObj( l_newtype, 2 );
   t_5 = ElmPosObj( l_type, 2 );
-  t_2 = CALL_2ARGS( t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, t_4, t_5 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
-  CALL_2ARGS( t_1, a_obj, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+  }
   
  }
  /* fi */
@@ -2164,7 +2734,12 @@ static Obj  HdlrFunc29 (
  
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
- t_2 = CALL_1ARGS( t_3, a_filter );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_filter );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2173,14 +2748,24 @@ static Obj  HdlrFunc29 (
   /* Error( "You can't reset an \"and-filter\". Reset components individually." ); */
   t_1 = GF_Error;
   t_2 = MakeString( "You can't reset an \"and-filter\". Reset components individually." );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2190,18 +2775,38 @@ static Obj  HdlrFunc29 (
   t_1 = GF_SET__TYPE__POSOBJ;
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
-  t_4 = CALL_1ARGS( t_5, a_obj );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, a_obj );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
-  t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_filter ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
-  CALL_2ARGS( t_1, a_obj, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+  }
   
  }
  
  /* elif IS_COMOBJ( obj ) then */
  else {
   t_3 = GF_IS__COMOBJ;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2211,18 +2816,38 @@ static Obj  HdlrFunc29 (
    t_1 = GF_SET__TYPE__COMOBJ;
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
-   t_4 = CALL_1ARGS( t_5, a_obj );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, a_obj );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
-   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_filter ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
-   CALL_2ARGS( t_1, a_obj, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+   }
    
   }
   
   /* elif IS_DATOBJ( obj ) then */
   else {
    t_3 = GF_IS__DATOBJ;
-   t_2 = CALL_1ARGS( t_3, a_obj );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_obj );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -2232,11 +2857,26 @@ static Obj  HdlrFunc29 (
     t_1 = GF_SET__TYPE__DATOBJ;
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
-    t_4 = CALL_1ARGS( t_5, a_obj );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     t_4 = CALL_1ARGS( t_5, a_obj );
+    }
+    else {
+     t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_obj ) );
+    }
     CHECK_FUNC_RESULT( t_4 );
-    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_filter ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
-    CALL_2ARGS( t_1, a_obj, t_2 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, a_obj, t_2 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+    }
     
    }
    
@@ -2246,7 +2886,12 @@ static Obj  HdlrFunc29 (
     /* Error( "cannot reset filter for internal object" ); */
     t_1 = GF_Error;
     t_2 = MakeString( "cannot reset filter for internal object" );
-    CALL_1ARGS( t_1, t_2 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, t_2 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+    }
     
    }
   }
@@ -2309,7 +2954,12 @@ static Obj  HdlrFunc30 (
  
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
- t_1 = CALL_1ARGS( t_2, l_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, l_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
@@ -2322,7 +2972,12 @@ static Obj  HdlrFunc30 (
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
  CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
- t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2331,7 +2986,12 @@ static Obj  HdlrFunc30 (
   
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, a_arg );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, a_arg );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
@@ -2341,11 +3001,21 @@ static Obj  HdlrFunc30 (
   t_1 = GF_INFO__OWA;
   t_2 = MakeString( "#W ObjectifyWithAttributes called " );
   t_3 = MakeString( "for non-attribute storing rep\n" );
-  CALL_2ARGS( t_1, t_2, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, t_2, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+  }
   
   /* Objectify( type, obj ); */
   t_1 = GF_Objectify;
-  CALL_2ARGS( t_1, l_type, l_obj );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_type, l_obj );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type, l_obj ) );
+  }
   
  }
  
@@ -2359,7 +3029,12 @@ static Obj  HdlrFunc30 (
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
-  t_6 = CALL_1ARGS( t_7, a_arg );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, a_arg );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
@@ -2397,7 +3072,12 @@ static Obj  HdlrFunc30 (
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
-   t_6 = CALL_1ARGS( t_7, l_attr );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, l_attr );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_attr ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
@@ -2410,9 +3090,19 @@ static Obj  HdlrFunc30 (
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( attr ) ); */
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
-     t_7 = CALL_1ARGS( t_8, l_attr );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, l_attr );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_nflags, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
@@ -2425,11 +3115,26 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
-     t_9 = CALL_1ARGS( t_10, l_attr );
+     if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+      t_9 = CALL_1ARGS( t_10, l_attr );
+     }
+     else {
+      t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_9 );
-     t_7 = CALL_1ARGS( t_8, t_9 );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, t_9 );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_nflags, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
@@ -2443,11 +3148,26 @@ static Obj  HdlrFunc30 (
     t_7 = GF_LEN__LIST;
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
-    t_10 = CALL_1ARGS( t_11, l_attr );
+    if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+     t_10 = CALL_1ARGS( t_11, l_attr );
+    }
+    else {
+     t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( l_attr ) );
+    }
     CHECK_FUNC_RESULT( t_10 );
-    t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
+    if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
+    }
+    else {
+     t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, INTOBJ_INT(2) ) );
+    }
     CHECK_FUNC_RESULT( t_8 );
-    t_6 = CALL_1ARGS( t_7, t_8 );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, t_8 );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     t_7 = GC_LENGTH__SETTER__METHODS__2;
     CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
@@ -2456,11 +3176,21 @@ static Obj  HdlrFunc30 (
      
      /* ADD_LIST( extra, attr ); */
      t_5 = GF_ADD__LIST;
-     CALL_2ARGS( t_5, l_extra, l_attr );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_5, l_extra, l_attr );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_extra, l_attr ) );
+     }
      
      /* ADD_LIST( extra, val ); */
      t_5 = GF_ADD__LIST;
-     CALL_2ARGS( t_5, l_extra, l_val );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_5, l_extra, l_val );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_extra, l_val ) );
+     }
      
     }
     
@@ -2469,10 +3199,20 @@ static Obj  HdlrFunc30 (
      
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
-     t_5 = CALL_1ARGS( t_6, l_attr );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, l_attr );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      t_7 = GF_IMMUTABLE__COPY__OBJ;
-     t_6 = CALL_1ARGS( t_7, l_val );
+     if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+      t_6 = CALL_1ARGS( t_7, l_val );
+     }
+     else {
+      t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_val ) );
+     }
      CHECK_FUNC_RESULT( t_6 );
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
@@ -2480,11 +3220,26 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
-     t_9 = CALL_1ARGS( t_10, l_attr );
+     if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+      t_9 = CALL_1ARGS( t_10, l_attr );
+     }
+     else {
+      t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_9 );
-     t_7 = CALL_1ARGS( t_8, t_9 );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, t_9 );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_nflags, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
@@ -2497,7 +3252,12 @@ static Obj  HdlrFunc30 (
   
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
-  t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, l_nflags ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
@@ -2507,9 +3267,19 @@ static Obj  HdlrFunc30 (
    /* flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) ); */
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
-   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, l_nflags ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
-   t_1 = CALL_1ARGS( t_2, t_3 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_1ARGS( t_2, t_3 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    l_flags = t_1;
    
@@ -2519,16 +3289,36 @@ static Obj  HdlrFunc30 (
    t_4 = GC_TypeOfTypes;
    CHECK_BOUND( t_4, "TypeOfTypes" );
    t_6 = GF_FamilyType;
-   t_5 = CALL_1ARGS( t_6, l_type );
+   if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+    t_5 = CALL_1ARGS( t_6, l_type );
+   }
+   else {
+    t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_type ) );
+   }
    CHECK_FUNC_RESULT( t_5 );
    t_7 = GF_DataType;
-   t_6 = CALL_1ARGS( t_7, l_type );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, l_type );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_type ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    t_7 = GC_fail;
    CHECK_BOUND( t_7, "fail" );
-   t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, t_5, l_flags, t_6, t_7 ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
-   CALL_2ARGS( t_1, t_2, l_obj );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, t_2, l_obj );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, l_obj ) );
+   }
    
   }
   
@@ -2537,7 +3327,12 @@ static Obj  HdlrFunc30 (
    
    /* Objectify( type, obj ); */
    t_1 = GF_Objectify;
-   CALL_2ARGS( t_1, l_type, l_obj );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, l_type, l_obj );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type, l_obj ) );
+   }
    
   }
   /* fi */
@@ -2547,7 +3342,12 @@ static Obj  HdlrFunc30 (
  
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
- t_6 = CALL_1ARGS( t_7, l_extra );
+ if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+  t_6 = CALL_1ARGS( t_7, l_extra );
+ }
+ else {
+  t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_extra ) );
+ }
  CHECK_FUNC_RESULT( t_6 );
  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
@@ -2576,10 +3376,19 @@ static Obj  HdlrFunc30 (
   t_8 = GF_Tester;
   CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_9, l_extra, l_i )
-  t_7 = CALL_1ARGS( t_8, t_9 );
+  if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+   t_7 = CALL_1ARGS( t_8, t_9 );
+  }
+  else {
+   t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+  }
   CHECK_FUNC_RESULT( t_7 );
-  CHECK_FUNC( t_7 );
-  t_6 = CALL_1ARGS( t_7, l_obj );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, l_obj );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_obj ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
@@ -2590,18 +3399,38 @@ static Obj  HdlrFunc30 (
    t_6 = MakeString( "#W  Supplied type has tester of " );
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
-   t_7 = CALL_1ARGS( t_8, t_9 );
+   if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+    t_7 = CALL_1ARGS( t_8, t_9 );
+   }
+   else {
+    t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+   }
    CHECK_FUNC_RESULT( t_7 );
    t_8 = MakeString( "with non-standard setter\n" );
-   CALL_3ARGS( t_5, t_6, t_7, t_8 );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    CALL_3ARGS( t_5, t_6, t_7, t_8 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6, t_7, t_8 ) );
+   }
    
    /* ResetFilterObj( obj, Tester( extra[i] ) ); */
    t_5 = GF_ResetFilterObj;
    t_7 = GF_Tester;
    C_ELM_LIST_FPL( t_8, l_extra, l_i )
-   t_6 = CALL_1ARGS( t_7, t_8 );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, t_8 );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
-   CALL_2ARGS( t_5, l_obj, t_6 );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_5, l_obj, t_6 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_obj, t_6 ) );
+   }
    
   }
   /* fi */
@@ -2609,13 +3438,22 @@ static Obj  HdlrFunc30 (
   /* Setter( extra[i] )( obj, extra[i + 1] ); */
   t_6 = GF_Setter;
   C_ELM_LIST_FPL( t_7, l_extra, l_i )
-  t_5 = CALL_1ARGS( t_6, t_7 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, t_7 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
-  CHECK_FUNC( t_5 );
   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
   CHECK_INT_POS( t_7 );
   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
-  CALL_2ARGS( t_5, l_obj, t_6 );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_5, l_obj, t_6 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_obj, t_6 ) );
+  }
   
  }
  /* od */
@@ -2655,7 +3493,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 27);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
@@ -2684,7 +3527,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 53);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Subtype := "defined below"; */
  t_1 = MakeString( "defined below" );
@@ -2723,7 +3571,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 143);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily2", function ( typeOfFamilies, name )
       return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS );
@@ -2737,7 +3590,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 151);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily3", function ( typeOfFamilies, name, req )
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS );
@@ -2751,7 +3609,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 159);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily4", function ( typeOfFamilies, name, req, imp )
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
@@ -2765,7 +3628,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 167);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily5", function ( typeOfFamilies, name, req, imp, filter )
       return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
@@ -2779,7 +3647,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 176);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily", function ( arg... )
       if LEN_LIST( arg ) = 1 then
@@ -2804,7 +3677,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 202);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* NEW_TYPE_CACHE_MISS := 0; */
  AssGVar( G_NEW__TYPE__CACHE__MISS, INTOBJ_INT(0) );
@@ -2902,7 +3780,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 347);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail );
@@ -2916,7 +3799,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 358);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail );
@@ -2930,7 +3818,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 368);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewType", function ( arg... )
       local type;
@@ -2955,7 +3848,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 395);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type );
@@ -2969,7 +3867,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 415);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type );
@@ -2983,7 +3886,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 425);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Unbind( Subtype ); */
  AssGVar( G_Subtype, 0 );
@@ -3011,7 +3919,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 451);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type );
@@ -3025,7 +3938,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 472);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type );
@@ -3039,7 +3957,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 482);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SupType", function ( arg... )
       if not IsType( arg[1] ) then
@@ -3061,7 +3984,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 499);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FamilyType", function ( K )
       return K![1];
@@ -3075,7 +4003,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 513);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FlagsType", function ( K )
       return K![2];
@@ -3089,7 +4022,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 527);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "DataType", function ( K )
       return K![3];
@@ -3103,7 +4041,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 543);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SetDataType", function ( K, data )
       K![3] := data;
@@ -3118,21 +4061,36 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 551);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
  CHECK_BOUND( t_3, "TYPE_OBJ" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
  CHECK_BOUND( t_3, "FAMILY_OBJ" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
       return FlagsType( TypeObj( obj ) );
@@ -3146,7 +4104,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 650);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "DataObj", function ( obj )
       return DataType( TypeObj( obj ) );
@@ -3160,7 +4123,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 664);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3168,9 +4136,19 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
  CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3178,9 +4156,19 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
  CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3188,9 +4176,19 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
  CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
       local flags;
@@ -3218,7 +4216,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 720);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Unbind( SetFilterObj ); */
  AssGVar( G_SetFilterObj, 0 );
@@ -3250,14 +4253,24 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 762);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
  CHECK_BOUND( t_3, "SetFilterObj" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
       if IS_AND_FILTER( filter ) then
@@ -3283,14 +4296,24 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 798);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
  CHECK_BOUND( t_3, "ResetFilterObj" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3298,21 +4321,41 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
  CHECK_BOUND( t_3, "Ignore" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */
  t_1 = GF_MAKE__READ__WRITE__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* BIND_GLOBAL( "ObjectifyWithAttributes", function ( arg... )
       local obj, type, flags, attr, val, i, extra, nflags;
@@ -3368,7 +4411,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 914);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/src/c_type1.c
+++ b/src/c_type1.c
@@ -216,12 +216,12 @@ static Obj  HdlrFunc2 (
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
  t_6 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_6, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_6, "IsAttributeStoringRep" );
  if ( t_6 == False ) {
   t_5 = t_6;
  }
  else if ( t_6 == True ) {
-  CHECK_BOOL( a_tester )
+  CHECK_BOOL( a_tester );
   t_5 = a_tester;
  }
  else if (IS_FILTER( t_6 ) ) {
@@ -234,10 +234,10 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_GETTER__FLAGS;
- CHECK_BOUND( t_5, "GETTER_FLAGS" )
+ CHECK_BOUND( t_5, "GETTER_FLAGS" );
  t_7 = GF_GETTER__FUNCTION;
  t_6 = CALL_1ARGS( t_7, a_name );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
@@ -264,13 +264,13 @@ static Obj  HdlrFunc4 (
  
  /* obj!.(name) := val; */
  t_1 = OBJ_HVAR( (1 << 16) | 1 );
- CHECK_BOUND( t_1, "name" )
+ CHECK_BOUND( t_1, "name" );
  AssComObj( a_obj, RNamObj(t_1), a_val );
  
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_2, "tester" )
+ CHECK_BOUND( t_2, "tester" );
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
@@ -309,7 +309,7 @@ static Obj  HdlrFunc3 (
  ASS_LVAR( 2, a_tester );
  
  /* if mutflag then */
- CHECK_BOOL( a_mutflag )
+ CHECK_BOOL( a_mutflag );
  t_1 = (Obj)(UInt)(a_mutflag != False);
  if ( t_1 ) {
   
@@ -324,11 +324,11 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], 2, ArgStringToList("obj,val"), HdlrFunc4 );
@@ -352,20 +352,20 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_SETTER__FUNCTION;
   t_7 = OBJ_LVAR( 1 );
-  CHECK_BOUND( t_7, "name" )
+  CHECK_BOUND( t_7, "name" );
   t_8 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_8, "tester" )
+  CHECK_BOUND( t_8, "tester" );
   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -413,22 +413,22 @@ static Obj  HdlrFunc5 (
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_imp__filter = t_1;
  
  /* type := Subtype( typeOfFamilies, IsAttributeStoringRep ); */
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_3, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_3, "IsAttributeStoringRep" );
  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* for pair in CATEGORIES_FAMILY do */
  t_4 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_4, "CATEGORIES_FAMILY" )
+ CHECK_BOUND( t_4, "CATEGORIES_FAMILY" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -454,8 +454,8 @@ static Obj  HdlrFunc5 (
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -463,7 +463,7 @@ static Obj  HdlrFunc5 (
    t_6 = GF_Subtype;
    C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    l_type = t_5;
    
   }
@@ -485,7 +485,7 @@ static Obj  HdlrFunc5 (
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
  t_1 = CALL_1ARGS( t_2, a_name );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_NAME, t_1 );
  
  /* family!.REQ_FLAGS := req_filter; */
@@ -541,11 +541,11 @@ static Obj  HdlrFunc6 (
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_3 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_3, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_3, "EMPTY_FLAGS" );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -574,11 +574,11 @@ static Obj  HdlrFunc7 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -609,12 +609,12 @@ static Obj  HdlrFunc8 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_imp );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -647,15 +647,15 @@ static Obj  HdlrFunc9 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_req );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_6 = GF_FLAGS__FILTER;
  t_5 = CALL_1ARGS( t_6, a_imp );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -684,17 +684,17 @@ static Obj  HdlrFunc10 (
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
   
   /* return NewFamily2( TypeOfFamilies, arg[1] ); */
   t_2 = GF_NewFamily2;
   t_3 = GC_TypeOfFamilies;
-  CHECK_BOUND( t_3, "TypeOfFamilies" )
+  CHECK_BOUND( t_3, "TypeOfFamilies" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -704,18 +704,18 @@ static Obj  HdlrFunc10 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
    
    /* return NewFamily3( TypeOfFamilies, arg[1], arg[2] ); */
    t_2 = GF_NewFamily3;
    t_3 = GC_TypeOfFamilies;
-   CHECK_BOUND( t_3, "TypeOfFamilies" )
+   CHECK_BOUND( t_3, "TypeOfFamilies" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
    
@@ -725,19 +725,19 @@ static Obj  HdlrFunc10 (
   else {
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, a_arg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
     
     /* return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] ); */
     t_2 = GF_NewFamily4;
     t_3 = GC_TypeOfFamilies;
-    CHECK_BOUND( t_3, "TypeOfFamilies" )
+    CHECK_BOUND( t_3, "TypeOfFamilies" );
     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-    CHECK_FUNC_RESULT( t_1 )
+    CHECK_FUNC_RESULT( t_1 );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
     
@@ -747,20 +747,20 @@ static Obj  HdlrFunc10 (
    else {
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, a_arg );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
      
      /* return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] ); */
      t_2 = GF_NewFamily5;
      t_3 = GC_TypeOfFamilies;
-     CHECK_BOUND( t_3, "TypeOfFamilies" )
+     CHECK_BOUND( t_3, "TypeOfFamilies" );
      C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
      C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
      C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
      
@@ -840,14 +840,14 @@ static Obj  HdlrFunc11 (
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = ElmComObj( a_family, R_HASH__SIZE );
  t_2 = MOD( t_3, t_4 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_hash = t_1;
  
  /* if IsBound( cache[hash] ) then */
- CHECK_INT_POS( l_hash )
+ CHECK_INT_POS( l_hash );
  t_2 = C_ISB_LIST( l_cache, l_hash );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
@@ -860,8 +860,8 @@ static Obj  HdlrFunc11 (
   t_3 = GF_IS__EQUAL__FLAGS;
   t_4 = ElmPosObj( l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -873,18 +873,18 @@ static Obj  HdlrFunc11 (
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_5 = ElmPosObj( l_cached, 3 );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_BOOL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_BOOL( t_3 );
    t_2 = (Obj)(UInt)(t_3 != False);
    t_1 = t_2;
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
     t_6 = CALL_1ARGS( t_7, l_cached );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
-    CHECK_FUNC_RESULT( t_4 )
-    CHECK_BOOL( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
+    CHECK_BOOL( t_4 );
     t_3 = (Obj)(UInt)(t_4 != False);
     t_1 = t_3;
    }
@@ -893,10 +893,10 @@ static Obj  HdlrFunc11 (
     /* if IS_IDENTICAL_OBJ( parent, fail ) then */
     t_3 = GF_IS__IDENTICAL__OBJ;
     t_4 = GC_fail;
-    CHECK_BOUND( t_4, "fail" )
+    CHECK_BOUND( t_4, "fail" );
     t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_BOOL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -907,8 +907,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( cached ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, l_cached );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -938,7 +938,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -955,10 +955,10 @@ static Obj  HdlrFunc11 (
     /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
     t_3 = GF_LEN__POSOBJ;
     t_2 = CALL_1ARGS( t_3, a_parent );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_4 = GF_LEN__POSOBJ;
     t_3 = CALL_1ARGS( t_4, l_cached );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
     if ( t_1 ) {
      
@@ -969,8 +969,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, a_parent );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1007,8 +1007,8 @@ static Obj  HdlrFunc11 (
        t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
        t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-       CHECK_FUNC_RESULT( t_7 )
-       CHECK_BOOL( t_7 )
+       CHECK_FUNC_RESULT( t_7 );
+       CHECK_BOOL( t_7 );
        t_6 = (Obj)(UInt)(t_7 != False);
        t_5 = (Obj)(UInt)( ! ((Int)t_6) );
        t_3 = t_5;
@@ -1034,7 +1034,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -1056,7 +1056,7 @@ static Obj  HdlrFunc11 (
   
   /* NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1; */
   t_2 = GC_NEW__TYPE__CACHE__MISS;
-  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" )
+  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   AssGVar( G_NEW__TYPE__CACHE__MISS, t_1 );
   
@@ -1065,15 +1065,15 @@ static Obj  HdlrFunc11 (
  
  /* NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1; */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
  
  /* if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  t_3 = GC_NEW__TYPE__ID__LIMIT;
- CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" )
+ CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" );
  t_1 = (Obj)(UInt)(! LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1089,7 +1089,7 @@ static Obj  HdlrFunc11 (
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
   t_1 = CALL_0ARGS( t_2 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
  }
@@ -1109,16 +1109,16 @@ static Obj  HdlrFunc11 (
  
  /* type[4] := NEW_TYPE_NEXT_ID; */
  t_1 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" );
  C_ASS_LIST_FPL( l_type, INTOBJ_INT(4), t_1 )
  
  /* if not IS_IDENTICAL_OBJ( parent, fail ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1126,8 +1126,8 @@ static Obj  HdlrFunc11 (
   /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
   t_3 = GF_LEN__POSOBJ;
   t_2 = CALL_1ARGS( t_3, a_parent );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(5);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1207,10 +1207,10 @@ static Obj  HdlrFunc11 (
    t_8 = GF_HASH__FLAGS;
    t_9 = ElmPosObj( l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_6 = MOD( t_7, l_ncl );
    C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ASS_LIST_FPL( l_ncache, t_5, l_t )
    
   }
@@ -1225,10 +1225,10 @@ static Obj  HdlrFunc11 (
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
   t_3 = CALL_1ARGS( t_4, a_flags );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = MOD( t_3, l_ncl );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_ncache, t_1, l_type )
   
  }
@@ -1284,17 +1284,17 @@ static Obj  HdlrFunc12 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1332,15 +1332,15 @@ static Obj  HdlrFunc13 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1371,8 +1371,8 @@ static Obj  HdlrFunc14 (
  t_4 = GF_IsFamily;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1388,18 +1388,18 @@ static Obj  HdlrFunc14 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* type := NewType3( TypeOfTypes, arg[1], arg[2] ); */
   t_2 = GF_NewType3;
   t_3 = GC_TypeOfTypes;
-  CHECK_BOUND( t_3, "TypeOfTypes" )
+  CHECK_BOUND( t_3, "TypeOfTypes" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1408,19 +1408,19 @@ static Obj  HdlrFunc14 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
    
    /* type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] ); */
    t_2 = GF_NewType4;
    t_3 = GC_TypeOfTypes;
-   CHECK_BOUND( t_3, "TypeOfTypes" )
+   CHECK_BOUND( t_3, "TypeOfTypes" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_type = t_1;
    
   }
@@ -1438,7 +1438,7 @@ static Obj  HdlrFunc14 (
  /* fi */
  
  /* return type; */
- CHECK_BOUND( l_type, "type" )
+ CHECK_BOUND( l_type, "type" );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
@@ -1472,21 +1472,21 @@ static Obj  HdlrFunc15 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1521,20 +1521,20 @@ static Obj  HdlrFunc16 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1566,8 +1566,8 @@ static Obj  HdlrFunc17 (
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1583,7 +1583,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1592,7 +1592,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1606,7 +1606,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1644,18 +1644,18 @@ static Obj  HdlrFunc18 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1688,17 +1688,17 @@ static Obj  HdlrFunc19 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1726,8 +1726,8 @@ static Obj  HdlrFunc20 (
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1743,7 +1743,7 @@ static Obj  HdlrFunc20 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1752,7 +1752,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1767,7 +1767,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1887,9 +1887,9 @@ static Obj  HdlrFunc25 (
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1916,9 +1916,9 @@ static Obj  HdlrFunc26 (
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1947,8 +1947,8 @@ static Obj  HdlrFunc27 (
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1964,8 +1964,8 @@ static Obj  HdlrFunc27 (
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -1979,8 +1979,8 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -1995,8 +1995,8 @@ static Obj  HdlrFunc27 (
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2042,20 +2042,20 @@ static Obj  HdlrFunc28 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* newtype := Subtype2( type, filter ); */
  t_2 = GF_Subtype2;
  t_1 = CALL_2ARGS( t_2, l_type, a_filter );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_newtype = t_1;
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2069,8 +2069,8 @@ static Obj  HdlrFunc28 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2084,8 +2084,8 @@ static Obj  HdlrFunc28 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2110,15 +2110,15 @@ static Obj  HdlrFunc28 (
  
  /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
  t_4 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = t_3;
  if ( ! t_2 ) {
   t_6 = GF_IsNoImmediateMethodsObject;
   t_5 = CALL_1ARGS( t_6, a_obj );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_2 = t_4;
  }
@@ -2131,7 +2131,7 @@ static Obj  HdlrFunc28 (
   t_4 = ElmPosObj( l_newtype, 2 );
   t_5 = ElmPosObj( l_type, 2 );
   t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2165,8 +2165,8 @@ static Obj  HdlrFunc29 (
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2181,8 +2181,8 @@ static Obj  HdlrFunc29 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2191,9 +2191,9 @@ static Obj  HdlrFunc29 (
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
   t_4 = CALL_1ARGS( t_5, a_obj );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2202,8 +2202,8 @@ static Obj  HdlrFunc29 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2212,9 +2212,9 @@ static Obj  HdlrFunc29 (
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
    t_4 = CALL_1ARGS( t_5, a_obj );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2223,8 +2223,8 @@ static Obj  HdlrFunc29 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2233,9 +2233,9 @@ static Obj  HdlrFunc29 (
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
     t_4 = CALL_1ARGS( t_5, a_obj );
-    CHECK_FUNC_RESULT( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     CALL_2ARGS( t_1, a_obj, t_2 );
     
    }
@@ -2310,7 +2310,7 @@ static Obj  HdlrFunc30 (
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* extra := [  ]; */
@@ -2321,10 +2321,10 @@ static Obj  HdlrFunc30 (
  /* if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then */
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
- CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2332,7 +2332,7 @@ static Obj  HdlrFunc30 (
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, a_arg );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
   l_extra = t_1;
@@ -2354,13 +2354,13 @@ static Obj  HdlrFunc30 (
   
   /* nflags := EMPTY_FLAGS; */
   t_1 = GC_EMPTY__FLAGS;
-  CHECK_BOUND( t_1, "EMPTY_FLAGS" )
+  CHECK_BOUND( t_1, "EMPTY_FLAGS" );
   l_nflags = t_1;
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_6 = CALL_1ARGS( t_7, a_arg );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
@@ -2385,25 +2385,25 @@ static Obj  HdlrFunc30 (
    l_i = t_2;
    
    /* attr := arg[i]; */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_5, a_arg, l_i )
    l_attr = t_5;
    
    /* val := arg[i + 1]; */
    C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_6 )
+   CHECK_INT_POS( t_6 );
    C_ELM_LIST_FPL( t_5, a_arg, t_6 )
    l_val = t_5;
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
    t_6 = CALL_1ARGS( t_7, l_attr );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
     
     /* if val then */
-    CHECK_BOOL( l_val )
+    CHECK_BOOL( l_val );
     t_5 = (Obj)(UInt)(l_val != False);
     if ( t_5 ) {
      
@@ -2411,9 +2411,9 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_7 = CALL_1ARGS( t_8, l_attr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2426,11 +2426,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2444,13 +2444,13 @@ static Obj  HdlrFunc30 (
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
     t_10 = CALL_1ARGS( t_11, l_attr );
-    CHECK_FUNC_RESULT( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
-    CHECK_FUNC_RESULT( t_8 )
+    CHECK_FUNC_RESULT( t_8 );
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_7 = GC_LENGTH__SETTER__METHODS__2;
-    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" )
+    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
     t_5 = (Obj)(UInt)( ! EQ( t_6, t_7 ));
     if ( t_5 ) {
      
@@ -2470,10 +2470,10 @@ static Obj  HdlrFunc30 (
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
      t_5 = CALL_1ARGS( t_6, l_attr );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_7 = GF_IMMUTABLE__COPY__OBJ;
      t_6 = CALL_1ARGS( t_7, l_val );
-     CHECK_FUNC_RESULT( t_6 )
+     CHECK_FUNC_RESULT( t_6 );
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) ); */
@@ -2481,11 +2481,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2498,8 +2498,8 @@ static Obj  HdlrFunc30 (
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = (Obj)(UInt)( ! ((Int)t_2) );
   if ( t_1 ) {
@@ -2508,26 +2508,26 @@ static Obj  HdlrFunc30 (
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = CALL_1ARGS( t_2, t_3 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_flags = t_1;
    
    /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
-   CHECK_BOUND( t_4, "TypeOfTypes" )
+   CHECK_BOUND( t_4, "TypeOfTypes" );
    t_6 = GF_FamilyType;
    t_5 = CALL_1ARGS( t_6, l_type );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_7 = GC_fail;
-   CHECK_BOUND( t_7, "fail" )
+   CHECK_BOUND( t_7, "fail" );
    t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, t_2, l_obj );
    
   }
@@ -2548,7 +2548,7 @@ static Obj  HdlrFunc30 (
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_extra );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
@@ -2574,14 +2574,14 @@ static Obj  HdlrFunc30 (
   
   /* if Tester( extra[i] )( obj ) then */
   t_8 = GF_Tester;
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_9, l_extra, l_i )
   t_7 = CALL_1ARGS( t_8, t_9 );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_FUNC( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_FUNC( t_7 );
   t_6 = CALL_1ARGS( t_7, l_obj );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -2591,7 +2591,7 @@ static Obj  HdlrFunc30 (
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_8 = MakeString( "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
@@ -2600,7 +2600,7 @@ static Obj  HdlrFunc30 (
    t_7 = GF_Tester;
    C_ELM_LIST_FPL( t_8, l_extra, l_i )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -2610,10 +2610,10 @@ static Obj  HdlrFunc30 (
   t_6 = GF_Setter;
   C_ELM_LIST_FPL( t_7, l_extra, l_i )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_FUNC( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC( t_5 );
   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_7 )
+  CHECK_INT_POS( t_7 );
   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
   CALL_2ARGS( t_5, l_obj, t_6 );
   
@@ -2659,7 +2659,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -3124,14 +3124,14 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
- CHECK_BOUND( t_3, "TYPE_OBJ" )
+ CHECK_BOUND( t_3, "TYPE_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
- CHECK_BOUND( t_3, "FAMILY_OBJ" )
+ CHECK_BOUND( t_3, "FAMILY_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
@@ -3167,9 +3167,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
- CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
+ CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
@@ -3177,9 +3177,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
- CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
@@ -3187,9 +3187,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
- CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
@@ -3256,7 +3256,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
- CHECK_BOUND( t_3, "SetFilterObj" )
+ CHECK_BOUND( t_3, "SetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
@@ -3289,7 +3289,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
- CHECK_BOUND( t_3, "ResetFilterObj" )
+ CHECK_BOUND( t_3, "ResetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -3297,16 +3297,16 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
- CHECK_BOUND( t_3, "Ignore" )
+ CHECK_BOUND( t_3, "Ignore" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -111,11 +111,15 @@ typedef UInt    RNam;
     if (!IS_POS_INT(obj))                                                    \
         RequireArgumentEx(0, obj, "<obj>", "must be a positive integer");
 
-#define CHECK_BOOL(obj)                                                      \
-    if (obj != True && obj != False)                                         \
-        RequireArgumentEx(0, obj, "<obj>", "must be 'true' or 'false'");
+static inline void CHECK_BOOL(Obj expr)
+{
+    RequireTrueOrFalse(0, expr); // use <expr> to match interpreter error
+}
 
-#define CHECK_FUNC(obj) RequireFunction(0, obj);
+static inline void CHECK_FUNC(Obj obj)
+{
+    RequireFunction(0, obj);
+}
 
 #define CHECK_NR_ARGS(narg, args)                                            \
     if (narg != LEN_PLIST(args))                                             \

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -781,7 +781,7 @@ static void CompCheckBound(CVar obj, Obj name)
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_BOUND( %c, \"%g\" )\n", obj, name );
+            Emit( "CHECK_BOUND( %c, \"%g\" );\n", obj, name );
         }
         SetInfoCVar( obj, W_BOUND );
     }
@@ -796,7 +796,7 @@ static void CompCheckFuncResult(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_BOUND ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_FUNC_RESULT( %c )\n", obj );
+            Emit( "CHECK_FUNC_RESULT( %c );\n", obj );
         }
         SetInfoCVar( obj, W_BOUND );
     }
@@ -811,7 +811,7 @@ static void CompCheckIntSmall(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_INT_SMALL( %c )\n", obj );
+            Emit( "CHECK_INT_SMALL( %c );\n", obj );
         }
         SetInfoCVar( obj, W_INT_SMALL );
     }
@@ -827,7 +827,7 @@ static void CompCheckIntSmallPos(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_SMALL_POS ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_INT_SMALL_POS( %c )\n", obj );
+            Emit( "CHECK_INT_SMALL_POS( %c );\n", obj );
         }
         SetInfoCVar( obj, W_INT_SMALL_POS );
     }
@@ -841,7 +841,7 @@ static void CompCheckIntPos(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_INT_POS ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_INT_POS( %c )\n", obj );
+            Emit( "CHECK_INT_POS( %c );\n", obj );
         }
         SetInfoCVar( obj, W_INT_POS );
     }
@@ -856,7 +856,7 @@ static void CompCheckBool(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_BOOL ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_BOOL( %c )\n", obj );
+            Emit( "CHECK_BOOL( %c );\n", obj );
         }
         SetInfoCVar( obj, W_BOOL );
     }
@@ -872,7 +872,7 @@ static void CompCheckFunc(CVar obj)
 {
     if ( ! HasInfoCVar( obj, W_FUNC ) ) {
         if ( CompCheckTypes ) {
-            Emit( "CHECK_FUNC( %c )\n", obj );
+            Emit( "CHECK_FUNC( %c );\n", obj );
         }
         SetInfoCVar( obj, W_FUNC );
     }

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -240,8 +240,8 @@ static Obj  HdlrFunc2 (
  
  /* if IGNORE_IMMEDIATE_METHODS then */
  t_2 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -255,10 +255,10 @@ static Obj  HdlrFunc2 (
  /* if IS_SUBSET_FLAGS( IMM_FLAGS, flags ) then */
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
- CHECK_BOUND( t_4, "IMM_FLAGS" )
+ CHECK_BOUND( t_4, "IMM_FLAGS" );
  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -272,18 +272,18 @@ static Obj  HdlrFunc2 (
  /* flags := SUB_FLAGS( flags, IMM_FLAGS ); */
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
- CHECK_BOUND( t_3, "IMM_FLAGS" )
+ CHECK_BOUND( t_3, "IMM_FLAGS" );
  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flagspos = t_1;
  
  /* tried := [  ]; */
@@ -294,7 +294,7 @@ static Obj  HdlrFunc2 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* flags := type![2]; */
@@ -303,14 +303,14 @@ static Obj  HdlrFunc2 (
  
  /* RUN_IMMEDIATE_METHODS_RUNS := RUN_IMMEDIATE_METHODS_RUNS + 1; */
  t_2 = GC_RUN__IMMEDIATE__METHODS__RUNS;
- CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" )
+ CHECK_BOUND( t_2, "RUN_IMMEDIATE_METHODS_RUNS" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_RUN__IMMEDIATE__METHODS__RUNS, t_1 );
  
  /* if TRACE_IMMEDIATE_METHODS then */
  t_2 = GC_TRACE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "TRACE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -347,26 +347,26 @@ static Obj  HdlrFunc2 (
   
   /* if IsBound( IMMEDIATES[j] ) then */
   t_7 = GC_IMMEDIATES;
-  CHECK_BOUND( t_7, "IMMEDIATES" )
-  CHECK_INT_POS( l_j )
+  CHECK_BOUND( t_7, "IMMEDIATES" );
+  CHECK_INT_POS( l_j );
   t_6 = C_ISB_LIST( t_7, l_j );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
    /* imm := IMMEDIATES[j]; */
    t_6 = GC_IMMEDIATES;
-   CHECK_BOUND( t_6, "IMMEDIATES" )
+   CHECK_BOUND( t_6, "IMMEDIATES" );
    C_ELM_LIST_FPL( t_5, t_6, l_j )
    l_imm = t_5;
    
    /* for i in [ 0, SIZE_IMMEDIATE_METHOD_ENTRY .. LEN_LIST( imm ) - SIZE_IMMEDIATE_METHOD_ENTRY ] do */
    t_9 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    t_12 = GF_LEN__LIST;
    t_11 = CALL_1ARGS( t_12, l_imm );
-   CHECK_FUNC_RESULT( t_11 )
+   CHECK_FUNC_RESULT( t_11 );
    t_12 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
-   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" )
+   CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    C_DIFF_FIA( t_10, t_11, t_12 )
    t_8 = Range3Check( INTOBJ_INT(0), t_9, t_10 );
    if ( IS_SMALL_LIST(t_8) ) {
@@ -393,21 +393,21 @@ static Obj  HdlrFunc2 (
     /* if IS_SUBSET_FLAGS( flags, imm[i + 4] ) and not IS_SUBSET_FLAGS( flags, imm[i + 3] ) and not imm[i + 6] in tried then */
     t_13 = GF_IS__SUBSET__FLAGS;
     C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
-    CHECK_INT_POS( t_15 )
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_14, l_imm, t_15 )
     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
-    CHECK_FUNC_RESULT( t_12 )
-    CHECK_BOOL( t_12 )
+    CHECK_FUNC_RESULT( t_12 );
+    CHECK_BOOL( t_12 );
     t_11 = (Obj)(UInt)(t_12 != False);
     t_10 = t_11;
     if ( t_10 ) {
      t_15 = GF_IS__SUBSET__FLAGS;
      C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
-     CHECK_INT_POS( t_17 )
+     CHECK_INT_POS( t_17 );
      C_ELM_LIST_FPL( t_16, l_imm, t_17 )
      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
-     CHECK_FUNC_RESULT( t_14 )
-     CHECK_BOOL( t_14 )
+     CHECK_FUNC_RESULT( t_14 );
+     CHECK_BOOL( t_14 );
      t_13 = (Obj)(UInt)(t_14 != False);
      t_12 = (Obj)(UInt)( ! ((Int)t_13) );
      t_10 = t_12;
@@ -415,7 +415,7 @@ static Obj  HdlrFunc2 (
     t_9 = t_10;
     if ( t_9 ) {
      C_SUM_FIA( t_14, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_14 )
+     CHECK_INT_POS( t_14 );
      C_ELM_LIST_FPL( t_13, l_imm, t_14 )
      t_12 = (Obj)(UInt)(IN( t_13, l_tried ));
      t_11 = (Obj)(UInt)( ! ((Int)t_12) );
@@ -425,37 +425,37 @@ static Obj  HdlrFunc2 (
      
      /* meth := IMMEDIATE_METHODS[imm[i + 6]]; */
      t_10 = GC_IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" )
+     CHECK_BOUND( t_10, "IMMEDIATE_METHODS" );
      C_SUM_FIA( t_12, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_12 )
+     CHECK_INT_POS( t_12 );
      C_ELM_LIST_FPL( t_11, l_imm, t_12 )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_9, t_10, t_11 )
      l_meth = t_9;
      
      /* res := meth( obj ); */
-     CHECK_FUNC( l_meth )
+     CHECK_FUNC( l_meth );
      t_9 = CALL_1ARGS( l_meth, a_obj );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      l_res = t_9;
      
      /* ADD_LIST( tried, imm[i + 6] ); */
      t_9 = GF_ADD__LIST;
      C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
-     CHECK_INT_POS( t_11 )
+     CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
      CALL_2ARGS( t_9, l_tried, t_10 );
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
-     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" )
+     CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_CHECKS" );
      C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
      AssGVar( G_RUN__IMMEDIATE__METHODS__CHECKS, t_9 );
      
      /* if TRACE_IMMEDIATE_METHODS then */
      t_10 = GC_TRACE__IMMEDIATE__METHODS;
-     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" )
-     CHECK_BOOL( t_10 )
+     CHECK_BOUND( t_10, "TRACE_IMMEDIATE_METHODS" );
+     CHECK_BOOL( t_10 );
      t_9 = (Obj)(UInt)(t_10 != False);
      if ( t_9 ) {
       
@@ -464,15 +464,15 @@ static Obj  HdlrFunc2 (
       t_10 = MakeString( "#I  immediate: " );
       t_12 = GF_NAME__FUNC;
       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_14 )
+      CHECK_INT_POS( t_14 );
       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
       t_11 = CALL_1ARGS( t_12, t_13 );
-      CHECK_FUNC_RESULT( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
       CALL_2ARGS( t_9, t_10, t_11 );
       
       /* if imm[i + 7] <> false then */
       C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
-      CHECK_INT_POS( t_11 )
+      CHECK_INT_POS( t_11 );
       C_ELM_LIST_FPL( t_10, l_imm, t_11 )
       t_11 = False;
       t_9 = (Obj)(UInt)( ! EQ( t_10, t_11 ));
@@ -482,7 +482,7 @@ static Obj  HdlrFunc2 (
        t_9 = GF_Print;
        t_10 = MakeString( ": " );
        C_SUM_FIA( t_12, l_i, INTOBJ_INT(7) )
-       CHECK_INT_POS( t_12 )
+       CHECK_INT_POS( t_12 );
        C_ELM_LIST_FPL( t_11, l_imm, t_12 )
        CALL_2ARGS( t_9, t_10, t_11 );
        
@@ -493,12 +493,12 @@ static Obj  HdlrFunc2 (
       t_9 = GF_Print;
       t_10 = MakeString( " at " );
       C_SUM_FIA( t_13, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_13 )
+      CHECK_INT_POS( t_13 );
       C_ELM_LIST_FPL( t_12, l_imm, t_13 )
       C_ELM_LIST_FPL( t_11, t_12, INTOBJ_INT(1) )
       t_12 = MakeString( ":" );
       C_SUM_FIA( t_15, l_i, INTOBJ_INT(8) )
-      CHECK_INT_POS( t_15 )
+      CHECK_INT_POS( t_15 );
       C_ELM_LIST_FPL( t_14, l_imm, t_15 )
       C_ELM_LIST_FPL( t_13, t_14, INTOBJ_INT(2) )
       t_14 = MakeString( "\n" );
@@ -509,7 +509,7 @@ static Obj  HdlrFunc2 (
      
      /* if res <> TRY_NEXT_METHOD then */
      t_10 = GC_TRY__NEXT__METHOD;
-     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" )
+     CHECK_BOUND( t_10, "TRY_NEXT_METHOD" );
      t_9 = (Obj)(UInt)( ! EQ( l_res, t_10 ));
      if ( t_9 ) {
       
@@ -519,9 +519,9 @@ static Obj  HdlrFunc2 (
       
       /* imm[i + 2]( obj, res ); */
       C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
-      CHECK_INT_POS( t_10 )
+      CHECK_INT_POS( t_10 );
       C_ELM_LIST_FPL( t_9, l_imm, t_10 )
-      CHECK_FUNC( t_9 )
+      CHECK_FUNC( t_9 );
       CALL_2ARGS( t_9, a_obj, l_res );
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
@@ -530,7 +530,7 @@ static Obj  HdlrFunc2 (
       
       /* RUN_IMMEDIATE_METHODS_HITS := RUN_IMMEDIATE_METHODS_HITS + 1; */
       t_10 = GC_RUN__IMMEDIATE__METHODS__HITS;
-      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" )
+      CHECK_BOUND( t_10, "RUN_IMMEDIATE_METHODS_HITS" );
       C_SUM_FIA( t_9, t_10, INTOBJ_INT(1) )
       AssGVar( G_RUN__IMMEDIATE__METHODS__HITS, t_9 );
       
@@ -538,10 +538,10 @@ static Obj  HdlrFunc2 (
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
       t_13 = CALL_1ARGS( t_14, a_obj );
-      CHECK_FUNC_RESULT( t_13 )
+      CHECK_FUNC_RESULT( t_13 );
       t_11 = CALL_2ARGS( t_12, t_13, l_type );
-      CHECK_FUNC_RESULT( t_11 )
-      CHECK_BOOL( t_11 )
+      CHECK_FUNC_RESULT( t_11 );
+      CHECK_BOOL( t_11 );
       t_10 = (Obj)(UInt)(t_11 != False);
       t_9 = (Obj)(UInt)( ! ((Int)t_10) );
       if ( t_9 ) {
@@ -549,29 +549,29 @@ static Obj  HdlrFunc2 (
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
        t_9 = CALL_1ARGS( t_10, a_obj );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_type = t_9;
        
        /* newflags := SUB_FLAGS( type![2], IMM_FLAGS ); */
        t_10 = GF_SUB__FLAGS;
        t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
-       CHECK_BOUND( t_12, "IMM_FLAGS" )
+       CHECK_BOUND( t_12, "IMM_FLAGS" );
        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
-       CHECK_FUNC_RESULT( t_9 )
+       CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
        t_10 = CALL_1ARGS( t_11, l_newflags );
-       CHECK_FUNC_RESULT( t_10 )
+       CHECK_FUNC_RESULT( t_10 );
        CALL_2ARGS( t_9, l_flagspos, t_10 );
        
        /* flags := type![2]; */
@@ -651,23 +651,23 @@ static Obj  HdlrFunc3 (
  /* lk := WRITE_LOCK( METHODS_OPERATION_REGION ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_METHODS__OPERATION__REGION;
- CHECK_BOUND( t_3, "METHODS_OPERATION_REGION" )
+ CHECK_BOUND( t_3, "METHODS_OPERATION_REGION" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
  t_2 = CALL_1ARGS( t_3, a_baserank );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* rank := baserank(  ); */
-  CHECK_FUNC( a_baserank )
+  CHECK_FUNC( a_baserank );
   t_1 = CALL_0ARGS( a_baserank );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_rank = t_1;
   
  }
@@ -684,15 +684,15 @@ static Obj  HdlrFunc3 (
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
  t_2 = CALL_1ARGS( t_3, a_opr );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if 0 = LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_flags );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -700,7 +700,7 @@ static Obj  HdlrFunc3 (
    t_1 = GF_Error;
    t_3 = GF_NAME__FUNC;
    t_2 = CALL_1ARGS( t_3, a_opr );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_3 = MakeString( ": constructors must have at least one argument" );
    CALL_2ARGS( t_1, t_2, t_3 );
    
@@ -711,7 +711,7 @@ static Obj  HdlrFunc3 (
   t_3 = GF_RankFilter;
   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_DIFF_FIA( t_1, l_rank, t_2 )
   l_rank = t_1;
   
@@ -746,7 +746,7 @@ static Obj  HdlrFunc3 (
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
    t_6 = CALL_1ARGS( t_7, l_i );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
    
@@ -759,19 +759,19 @@ static Obj  HdlrFunc3 (
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_flags );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_methods = t_1;
  
  /* methods := methods{[ 1 .. LEN_LIST( methods ) ]}; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_methods );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = Range2Check( INTOBJ_INT(1), t_3 );
  t_1 = ElmsListCheck( l_methods, t_2 );
  l_methods = t_1;
@@ -784,7 +784,7 @@ static Obj  HdlrFunc3 (
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
   t_1 = CALL_1ARGS( t_2, a_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   a_info = t_1;
   
  }
@@ -796,9 +796,9 @@ static Obj  HdlrFunc3 (
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
   t_3 = CALL_1ARGS( t_4, a_opr );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
@@ -827,13 +827,13 @@ static Obj  HdlrFunc3 (
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_methods );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
   if ( t_1 ) {
    C_SUM_FIA( t_6, l_narg, INTOBJ_INT(3) )
    C_SUM_FIA( t_5, l_i, t_6 )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ELM_LIST_FPL( t_4, l_methods, t_5 )
    t_3 = (Obj)(UInt)(LT( l_rank, t_4 ));
    t_1 = t_3;
@@ -854,8 +854,8 @@ static Obj  HdlrFunc3 (
  
  /* if REREADING then */
  t_2 = GC_REREADING;
- CHECK_BOUND( t_2, "REREADING" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "REREADING" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -866,13 +866,13 @@ static Obj  HdlrFunc3 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_methods );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
     C_SUM_FIA( t_6, l_k, l_narg )
     C_SUM_FIA( t_5, t_6, INTOBJ_INT(3) )
-    CHECK_INT_POS( t_5 )
+    CHECK_INT_POS( t_5 );
     C_ELM_LIST_FPL( t_4, l_methods, t_5 )
     t_3 = (Obj)(UInt)(EQ( l_rank, t_4 ));
     t_1 = t_3;
@@ -882,7 +882,7 @@ static Obj  HdlrFunc3 (
    /* if info = methods[k + narg + 4] then */
    C_SUM_FIA( t_4, l_k, l_narg )
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(4) )
-   CHECK_INT_POS( t_3 )
+   CHECK_INT_POS( t_3 );
    C_ELM_LIST_FPL( t_2, l_methods, t_3 )
    t_1 = (Obj)(UInt)(EQ( a_info, t_2 ));
    if ( t_1 ) {
@@ -892,7 +892,7 @@ static Obj  HdlrFunc3 (
     l_match = t_1;
     
     /* for j in [ 1 .. narg ] do */
-    CHECK_INT_SMALL( l_narg )
+    CHECK_INT_SMALL( l_narg );
     t_2 = l_narg;
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
@@ -906,7 +906,7 @@ static Obj  HdlrFunc3 (
      else if ( l_match == True ) {
       C_SUM_FIA( t_7, l_k, l_j )
       C_SUM_FIA( t_6, t_7, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_6 )
+      CHECK_INT_POS( t_6 );
       C_ELM_LIST_FPL( t_5, l_methods, t_6 )
       C_ELM_LIST_FPL( t_6, a_flags, l_j )
       t_4 = (EQ( t_5, t_6 ) ? True : False);
@@ -915,7 +915,7 @@ static Obj  HdlrFunc3 (
      else if (IS_FILTER( l_match ) ) {
       C_SUM_FIA( t_8, l_k, l_j )
       C_SUM_FIA( t_7, t_8, INTOBJ_INT(1) )
-      CHECK_INT_POS( t_7 )
+      CHECK_INT_POS( t_7 );
       C_ELM_LIST_FPL( t_6, l_methods, t_7 )
       C_ELM_LIST_FPL( t_7, a_flags, l_j )
       t_5 = (EQ( t_6, t_7 ) ? True : False);
@@ -931,7 +931,7 @@ static Obj  HdlrFunc3 (
     /* od */
     
     /* if match then */
-    CHECK_BOOL( l_match )
+    CHECK_BOOL( l_match );
     t_1 = (Obj)(UInt)(l_match != False);
     if ( t_1 ) {
      
@@ -964,8 +964,8 @@ static Obj  HdlrFunc3 (
  
  /* if not REREADING or not replace then */
  t_4 = GC_REREADING;
- CHECK_BOUND( t_4, "REREADING" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "REREADING" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
  t_1 = t_2;
@@ -996,7 +996,7 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_2, 6, INTOBJ_INT(1) );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_methods );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_DIFF_FIA( t_3, t_4, l_i )
   SET_ELM_PLIST( t_2, 7, t_3 );
   CHANGED_BAG( t_2 );
@@ -1012,7 +1012,7 @@ static Obj  HdlrFunc3 (
   
   /* rel := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_rel = t_1;
   
  }
@@ -1025,7 +1025,7 @@ static Obj  HdlrFunc3 (
    
    /* rel := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_rel = t_1;
    
   }
@@ -1034,28 +1034,28 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_rel );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD then */
     t_2 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_2 )
+    CHECK_BOUND( t_2, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_rel );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1074,7 +1074,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <famrel> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1094,7 +1094,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1110,7 +1110,7 @@ static Obj  HdlrFunc3 (
   
   /* method := RETURN_TRUE; */
   t_1 = GC_RETURN__TRUE;
-  CHECK_BOUND( t_1, "RETURN_TRUE" )
+  CHECK_BOUND( t_1, "RETURN_TRUE" );
   a_method = t_1;
   
  }
@@ -1123,7 +1123,7 @@ static Obj  HdlrFunc3 (
    
    /* method := RETURN_FALSE; */
    t_1 = GC_RETURN__FALSE;
-   CHECK_BOUND( t_1, "RETURN_FALSE" )
+   CHECK_BOUND( t_1, "RETURN_FALSE" );
    a_method = t_1;
    
   }
@@ -1132,22 +1132,22 @@ static Obj  HdlrFunc3 (
   else {
    t_3 = GF_IS__FUNCTION;
    t_2 = CALL_1ARGS( t_3, a_method );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then */
     t_3 = GC_CHECK__INSTALL__METHOD;
-    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
-    CHECK_BOOL( t_3 )
+    CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
      t_5 = CALL_1ARGS( t_6, a_method );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      t_1 = t_3;
@@ -1157,13 +1157,13 @@ static Obj  HdlrFunc3 (
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
      t_1 = CALL_1ARGS( t_2, a_method );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
      t_4 = CALL_1ARGS( t_5, l_narg );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
      t_1 = t_2;
@@ -1182,7 +1182,7 @@ static Obj  HdlrFunc3 (
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
       t_2 = CALL_1ARGS( t_3, a_opr );
-      CHECK_FUNC_RESULT( t_2 )
+      CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <method> must accept " );
       t_4 = MakeString( " arguments" );
       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
@@ -1202,7 +1202,7 @@ static Obj  HdlrFunc3 (
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
     t_2 = CALL_1ARGS( t_3, a_opr );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
     CALL_2ARGS( t_1, t_2, t_3 );
     
@@ -1213,11 +1213,11 @@ static Obj  HdlrFunc3 (
  
  /* methods[i + 1] := rel; */
  C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_rel )
  
  /* for k in [ 1 .. narg ] do */
- CHECK_INT_SMALL( l_narg )
+ CHECK_INT_SMALL( l_narg );
  t_2 = l_narg;
  for ( t_1 = INTOBJ_INT(1);
        ((Int)t_1) <= ((Int)t_2);
@@ -1227,7 +1227,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + k + 1] := flags[k]; */
   C_SUM_FIA( t_4, l_i, l_k )
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_3 )
+  CHECK_INT_POS( t_3 );
   C_ELM_LIST_FPL( t_4, a_flags, l_k )
   C_ASS_LIST_FPL( l_methods, t_3, t_4 )
   
@@ -1237,22 +1237,22 @@ static Obj  HdlrFunc3 (
  /* methods[i + (narg + 2)] := method; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(2) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, a_method )
  
  /* methods[i + (narg + 3)] := rank; */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(3) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL( l_methods, t_1, l_rank )
  
  /* methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info ); */
  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(4) )
  C_SUM_FIA( t_1, l_i, t_2 )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  t_3 = GF_IMMUTABLE__COPY__OBJ;
  t_2 = CALL_1ARGS( t_3, a_info );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
  /* if 6 >= 5 then */
@@ -1262,26 +1262,26 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_MakeImmutable;
   t_4 = NEW_PLIST( T_PLIST, 3 );
   SET_LEN_PLIST( t_4, 3 );
   t_6 = GF_INPUT__FILENAME;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_READEVALCOMMAND__LINENUMBER;
-  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" )
+  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_INPUT__LINENUMBER;
   t_5 = CALL_0ARGS( t_6 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 3, t_5 );
   CHANGED_BAG( t_4 );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
  }
@@ -1294,7 +1294,7 @@ static Obj  HdlrFunc3 (
   /* methods[i + (narg + 6)] := baserank; */
   C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
   C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
   
  }
@@ -1304,7 +1304,7 @@ static Obj  HdlrFunc3 (
  t_1 = GF_SET__METHODS__OPERATION;
  t_3 = GF_MakeReadOnlySingleObj;
  t_2 = CALL_1ARGS( t_3, l_methods );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_3ARGS( t_1, a_opr, l_narg, t_2 );
  
  /* UNLOCK( lk ); */
@@ -1439,15 +1439,15 @@ static Obj  HdlrFunc6 (
  /* lk := READ_LOCK( OPERATIONS_REGION ); */
  t_2 = GF_READ__LOCK;
  t_3 = GC_OPERATIONS__REGION;
- CHECK_BOUND( t_3, "OPERATIONS_REGION" )
+ CHECK_BOUND( t_3, "OPERATIONS_REGION" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
  t_1 = CALL_1ARGS( t_2, a_arglist );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_len = t_1;
  
  /* if len < 3 then */
@@ -1469,8 +1469,8 @@ static Obj  HdlrFunc6 (
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
  t_3 = CALL_1ARGS( t_4, l_opr );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1487,8 +1487,8 @@ static Obj  HdlrFunc6 (
  t_4 = GF_IS__STRING__REP;
  C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( ! t_1 ) {
@@ -1530,8 +1530,8 @@ static Obj  HdlrFunc6 (
   t_5 = GF_IS__FUNCTION;
   C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
   t_4 = CALL_1ARGS( t_5, t_6 );
-  CHECK_FUNC_RESULT( t_4 )
-  CHECK_BOOL( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
+  CHECK_BOOL( t_4 );
   t_3 = (Obj)(UInt)(t_4 != False);
   t_1 = t_3;
  }
@@ -1558,7 +1558,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) or not IS_LIST( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_4 = C_ISB_LIST( a_arglist, l_pos );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (Obj)(UInt)( ! ((Int)t_3) );
@@ -1567,8 +1567,8 @@ static Obj  HdlrFunc6 (
   t_6 = GF_IS__LIST;
   C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_3 = (Obj)(UInt)( ! ((Int)t_4) );
   t_1 = t_3;
@@ -1590,11 +1590,11 @@ static Obj  HdlrFunc6 (
  
  /* if GAPInfo.MaxNrArgsMethod < LEN_LIST( filters ) then */
  t_3 = GC_GAPInfo;
- CHECK_BOUND( t_3, "GAPInfo" )
+ CHECK_BOUND( t_3, "GAPInfo" );
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_filters );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1602,7 +1602,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_2 = MakeString( "methods can have at most " );
   t_4 = GC_GAPInfo;
-  CHECK_BOUND( t_4, "GAPInfo" )
+  CHECK_BOUND( t_4, "GAPInfo" );
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   t_4 = MakeString( " arguments" );
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1613,7 +1613,7 @@ static Obj  HdlrFunc6 (
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, l_filters );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
   
@@ -1628,8 +1628,8 @@ static Obj  HdlrFunc6 (
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, l_filters );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(1);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1639,8 +1639,8 @@ static Obj  HdlrFunc6 (
    t_5 = GF_IS__STRING__REP;
    C_ELM_LIST_FPL( t_6, l_filters, l_i )
    t_4 = CALL_1ARGS( t_5, t_6 );
-   CHECK_FUNC_RESULT( t_4 )
-   CHECK_BOOL( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
+   CHECK_BOOL( t_4 );
    t_3 = (Obj)(UInt)(t_4 != False);
    if ( t_3 ) {
     
@@ -1658,15 +1658,15 @@ static Obj  HdlrFunc6 (
     t_4 = GF_EvalString;
     C_ELM_LIST_FPL( t_5, l_filters, l_i )
     t_3 = CALL_1ARGS( t_4, t_5 );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
     C_ELM_LIST_FPL( t_7, l_filters, l_i )
     t_5 = CALL_1ARGS( t_6, t_7 );
-    CHECK_FUNC_RESULT( t_5 )
-    CHECK_BOOL( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
+    CHECK_BOOL( t_5 );
     t_4 = (Obj)(UInt)(t_5 != False);
     t_3 = (Obj)(UInt)( ! ((Int)t_4) );
     if ( t_3 ) {
@@ -1710,17 +1710,17 @@ static Obj  HdlrFunc6 (
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_info1 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[32];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
    t_1 = CALL_1ARGS( t_2, l_info1 );
-   CHECK_FUNC_RESULT( t_1 )
-   CHECK_INT_POS( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
+   CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[93];
    C_ASS_LIST_FPL( l_info1, t_1, t_2 )
    
@@ -1769,14 +1769,14 @@ static Obj  HdlrFunc6 (
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
   t_6 = CALL_1ARGS( t_7, l_i );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   CALL_2ARGS( t_5, l_flags, t_6 );
   
  }
  /* od */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1794,23 +1794,23 @@ static Obj  HdlrFunc6 (
   t_4 = GF_IS__INT;
   C_ELM_LIST_FPL( t_5, a_arglist, l_pos )
   t_3 = CALL_1ARGS( t_4, t_5 );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = t_2;
   if ( ! t_1 ) {
    t_7 = GF_IS__FUNCTION;
    C_ELM_LIST_FPL( t_8, a_arglist, l_pos )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
-   CHECK_BOOL( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
+   CHECK_BOOL( t_6 );
    t_5 = (Obj)(UInt)(t_6 != False);
    t_4 = t_5;
    if ( t_4 ) {
     t_8 = GF_NARG__FUNC;
     C_ELM_LIST_FPL( t_9, a_arglist, l_pos )
     t_7 = CALL_1ARGS( t_8, t_9 );
-    CHECK_FUNC_RESULT( t_7 )
+    CHECK_FUNC_RESULT( t_7 );
     t_6 = (Obj)(UInt)(EQ( t_7, INTOBJ_INT(0) ));
     t_4 = t_6;
    }
@@ -1818,7 +1818,7 @@ static Obj  HdlrFunc6 (
    if ( t_3 ) {
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, a_arglist );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_5 = (Obj)(UInt)(LT( l_pos, t_6 ));
     t_3 = t_5;
    }
@@ -1847,7 +1847,7 @@ static Obj  HdlrFunc6 (
  /* fi */
  
  /* if not IsBound( arglist[pos] ) then */
- CHECK_INT_POS( l_pos )
+ CHECK_INT_POS( l_pos );
  t_3 = C_ISB_LIST( a_arglist, l_pos );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
@@ -1868,7 +1868,7 @@ static Obj  HdlrFunc6 (
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
  t_5 = CALL_1ARGS( t_6, l_opr );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
  if ( t_3 ) {
@@ -1877,7 +1877,7 @@ static Obj  HdlrFunc6 (
   t_5 = t_6;
   if ( ! t_5 ) {
    t_8 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_8, "RETURN_TRUE" )
+   CHECK_BOUND( t_8, "RETURN_TRUE" );
    t_7 = (Obj)(UInt)(EQ( l_rel, t_8 ));
    t_5 = t_7;
   }
@@ -1887,7 +1887,7 @@ static Obj  HdlrFunc6 (
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
   t_5 = CALL_1ARGS( t_6, l_filters );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
  }
@@ -1898,7 +1898,7 @@ static Obj  HdlrFunc6 (
   t_3 = t_4;
   if ( ! t_3 ) {
    t_6 = GC_RETURN__TRUE;
-   CHECK_BOUND( t_6, "RETURN_TRUE" )
+   CHECK_BOUND( t_6, "RETURN_TRUE" );
    t_5 = (Obj)(UInt)(EQ( l_method, t_6 ));
    t_3 = t_5;
   }
@@ -1910,7 +1910,7 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
   t_2 = CALL_1ARGS( t_3, l_opr );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -1919,12 +1919,12 @@ static Obj  HdlrFunc6 (
  
  /* if CHECK_INSTALL_METHOD and check then */
  t_3 = GC_CHECK__INSTALL__METHOD;
- CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" )
- CHECK_BOOL( t_3 )
+ CHECK_BOUND( t_3, "CHECK_INSTALL_METHOD" );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = t_2;
  if ( t_1 ) {
-  CHECK_BOOL( a_check )
+  CHECK_BOOL( a_check );
   t_3 = (Obj)(UInt)(a_check != False);
   t_1 = t_3;
  }
@@ -1932,7 +1932,7 @@ static Obj  HdlrFunc6 (
   
   /* if opr in WRAPPER_OPERATIONS then */
   t_2 = GC_WRAPPER__OPERATIONS;
-  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+  CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
   t_1 = (Obj)(UInt)(IN( l_opr, t_2 ));
   if ( t_1 ) {
    
@@ -1941,7 +1941,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_4 = MakeString( "\n" );
    t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
    t_6 = MakeString( "#I  underlying operation(s)" );
@@ -1953,12 +1953,12 @@ static Obj  HdlrFunc6 (
   /* req := GET_OPER_FLAGS( opr ); */
   t_2 = GF_GET__OPER__FLAGS;
   t_1 = CALL_1ARGS( t_2, l_opr );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_req = t_1;
   
   /* if req = fail then */
   t_2 = GC_fail;
-  CHECK_BOUND( t_2, "fail" )
+  CHECK_BOUND( t_2, "fail" );
   t_1 = (Obj)(UInt)(EQ( l_req, t_2 ));
   if ( t_1 ) {
    
@@ -1967,7 +1967,7 @@ static Obj  HdlrFunc6 (
    t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
    t_3 = CALL_1ARGS( t_4, l_opr );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    CALL_2ARGS( t_1, t_2, t_3 );
    
   }
@@ -2003,10 +2003,10 @@ static Obj  HdlrFunc6 (
    
    /* if not GAPInfo.CommandLineOptions.N then */
    t_9 = GC_GAPInfo;
-   CHECK_BOUND( t_9, "GAPInfo" )
+   CHECK_BOUND( t_9, "GAPInfo" );
    t_8 = ELM_REC( t_9, R_CommandLineOptions );
    t_7 = ELM_REC( t_8, R_N );
-   CHECK_BOOL( t_7 )
+   CHECK_BOOL( t_7 );
    t_6 = (Obj)(UInt)(t_7 != False);
    t_5 = (Obj)(UInt)( ! ((Int)t_6) );
    if ( t_5 ) {
@@ -2015,7 +2015,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -2027,7 +2027,7 @@ static Obj  HdlrFunc6 (
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__IMPS__FLAGS;
     t_6 = CALL_1ARGS( t_7, l_i );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     CALL_2ARGS( t_5, l_imp, t_6 );
     
    }
@@ -2050,7 +2050,7 @@ static Obj  HdlrFunc6 (
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
    if ( t_1 ) {
@@ -2065,17 +2065,17 @@ static Obj  HdlrFunc6 (
    l_j = t_1;
    
    /* reqs := req[j]; */
-   CHECK_INT_POS( l_j )
+   CHECK_INT_POS( l_j );
    C_ELM_LIST_FPL( t_1, l_req, l_j )
    l_reqs = t_1;
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, l_reqs );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_imp );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
     
@@ -2086,8 +2086,8 @@ static Obj  HdlrFunc6 (
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, l_reqs );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_INT_SMALL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_INT_SMALL( t_2 );
     for ( t_1 = INTOBJ_INT(1);
           ((Int)t_1) <= ((Int)t_2);
           t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -2098,8 +2098,8 @@ static Obj  HdlrFunc6 (
      C_ELM_LIST_FPL( t_7, l_imp, l_i )
      C_ELM_LIST_FPL( t_8, l_reqs, l_i )
      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_BOOL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
      t_3 = (Obj)(UInt)( ! ((Int)t_4) );
      if ( t_3 ) {
@@ -2147,10 +2147,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2160,7 +2160,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( "the number of arguments does not match a declaration of " );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      CALL_2ARGS( t_1, t_2, t_3 );
      
     }
@@ -2174,7 +2174,7 @@ static Obj  HdlrFunc6 (
      t_3 = MakeString( "match a declaration of " );
      t_5 = GF_NAME__FUNC;
      t_4 = CALL_1ARGS( t_5, l_opr );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      t_5 = MakeString( "\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
      
@@ -2188,10 +2188,10 @@ static Obj  HdlrFunc6 (
     
     /* if not GAPInfo.CommandLineOptions.N then */
     t_5 = GC_GAPInfo;
-    CHECK_BOUND( t_5, "GAPInfo" )
+    CHECK_BOUND( t_5, "GAPInfo" );
     t_4 = ELM_REC( t_5, R_CommandLineOptions );
     t_3 = ELM_REC( t_4, R_N );
-    CHECK_BOOL( t_3 )
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2200,18 +2200,18 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Error;
      t_2 = MakeString( "required filters " );
      t_4 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
      t_3 = CALL_1ARGS( t_4, t_5 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( "\nfor " );
      t_6 = GF_Ordinal;
      t_5 = CALL_1ARGS( t_6, l_notmatch );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_6 = MakeString( " argument do not match a declaration of " );
      t_8 = GF_NAME__FUNC;
      t_7 = CALL_1ARGS( t_8, l_opr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
      
     }
@@ -2228,7 +2228,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_NAME__FUNC;
      t_3 = CALL_1ARGS( t_4, l_opr );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 2, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "(\03" );
@@ -2236,7 +2236,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__FILENAME;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 4, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( "\03 +" );
@@ -2244,7 +2244,7 @@ static Obj  HdlrFunc6 (
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__LINENUMBER;
      t_3 = CALL_0ARGS( t_4 );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 6, t_3 );
      CHANGED_BAG( t_2 );
      t_3 = MakeString( ") \03" );
@@ -2257,10 +2257,10 @@ static Obj  HdlrFunc6 (
      
      /* for j in NamesFilter( imp[notmatch] ) do */
      t_5 = GF_NamesFilter;
-     CHECK_INT_POS( l_notmatch )
+     CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_6, l_imp, l_notmatch )
      t_4 = CALL_1ARGS( t_5, t_6 );
-     CHECK_FUNC_RESULT( t_4 )
+     CHECK_FUNC_RESULT( t_4 );
      if ( IS_SMALL_LIST(t_4) ) {
       t_3 = (Obj)(UInt)1;
       t_1 = INTOBJ_INT(1);
@@ -2295,7 +2295,7 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( " for " );
      t_4 = GF_Ordinal;
      t_3 = CALL_1ARGS( t_4, l_notmatch );
-     CHECK_FUNC_RESULT( t_3 )
+     CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( " argument do not match \03a " );
      t_5 = MakeString( "declaration\n" );
      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
@@ -2316,28 +2316,28 @@ static Obj  HdlrFunc6 (
    
    /* for k in [ j + 1 .. LEN_LIST( req ) ] do */
    C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
-   CHECK_INT_SMALL( t_2 )
+   CHECK_INT_SMALL( t_2 );
    t_4 = GF_LEN__LIST;
    t_3 = CALL_1ARGS( t_4, l_req );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_INT_SMALL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_INT_SMALL( t_3 );
    for ( t_1 = t_2;
          ((Int)t_1) <= ((Int)t_3);
          t_1 = (Obj)(((UInt)t_1)+4) ) {
     l_k = t_1;
     
     /* reqs := req[k]; */
-    CHECK_INT_POS( l_k )
+    CHECK_INT_POS( l_k );
     C_ELM_LIST_FPL( t_4, l_req, l_k )
     l_reqs = t_4;
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
     t_5 = CALL_1ARGS( t_6, l_reqs );
-    CHECK_FUNC_RESULT( t_5 )
+    CHECK_FUNC_RESULT( t_5 );
     t_7 = GF_LEN__LIST;
     t_6 = CALL_1ARGS( t_7, l_imp );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
      
@@ -2348,8 +2348,8 @@ static Obj  HdlrFunc6 (
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
      t_5 = CALL_1ARGS( t_6, l_reqs );
-     CHECK_FUNC_RESULT( t_5 )
-     CHECK_INT_SMALL( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
+     CHECK_INT_SMALL( t_5 );
      for ( t_4 = INTOBJ_INT(1);
            ((Int)t_4) <= ((Int)t_5);
            t_4 = (Obj)(((UInt)t_4)+4) ) {
@@ -2360,8 +2360,8 @@ static Obj  HdlrFunc6 (
       C_ELM_LIST_FPL( t_10, l_imp, l_i )
       C_ELM_LIST_FPL( t_11, l_reqs, l_i )
       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
-      CHECK_FUNC_RESULT( t_8 )
-      CHECK_BOOL( t_8 )
+      CHECK_FUNC_RESULT( t_8 );
+      CHECK_BOOL( t_8 );
       t_7 = (Obj)(UInt)(t_8 != False);
       t_6 = (Obj)(UInt)( ! ((Int)t_7) );
       if ( t_6 ) {
@@ -2393,7 +2393,7 @@ static Obj  HdlrFunc6 (
       t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
       t_6 = CALL_1ARGS( t_7, l_opr );
-      CHECK_FUNC_RESULT( t_6 )
+      CHECK_FUNC_RESULT( t_6 );
       t_7 = MakeString( " matches more than one declaration" );
       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
       
@@ -2414,7 +2414,7 @@ static Obj  HdlrFunc6 (
  
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
- CHECK_BOUND( l_rank, "rank" )
+ CHECK_BOUND( l_rank, "rank" );
  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
  
  /* UNLOCK( lk ); */
@@ -2461,7 +2461,7 @@ static Obj  HdlrFunc8 (
  
  /* for prop in props do */
  t_4 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_4, "props" )
+ CHECK_BOUND( t_4, "props" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -2486,11 +2486,11 @@ static Obj  HdlrFunc8 (
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
   t_8 = CALL_1ARGS( t_9, l_prop );
-  CHECK_FUNC_RESULT( t_8 )
-  CHECK_FUNC( t_8 )
+  CHECK_FUNC_RESULT( t_8 );
+  CHECK_FUNC( t_8 );
   t_7 = CALL_1ARGS( t_8, a_obj );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_BOOL( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (Obj)(UInt)( ! ((Int)t_6) );
   if ( t_5 ) {
@@ -2500,20 +2500,20 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop )
+   CHECK_FUNC( l_prop );
    t_8 = CALL_1ARGS( l_prop, a_obj );
-   CHECK_FUNC_RESULT( t_8 )
-   CHECK_BOOL( t_8 )
+   CHECK_FUNC_RESULT( t_8 );
+   CHECK_BOOL( t_8 );
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
     t_10 = CALL_1ARGS( t_11, l_prop );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_FUNC( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_FUNC( t_10 );
     t_9 = CALL_1ARGS( t_10, a_obj );
-    CHECK_FUNC_RESULT( t_9 )
-    CHECK_BOOL( t_9 )
+    CHECK_FUNC_RESULT( t_9 );
+    CHECK_BOOL( t_9 );
     t_8 = (Obj)(UInt)(t_9 != False);
     t_6 = t_8;
    }
@@ -2522,7 +2522,7 @@ static Obj  HdlrFunc8 (
     
     /* TryNextMethod(); */
     t_5 = GC_TRY__NEXT__METHOD;
-    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" )
+    CHECK_BOUND( t_5, "TRY_NEXT_METHOD" );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_5;
     
@@ -2541,10 +2541,10 @@ static Obj  HdlrFunc8 (
   
   /* return getter( obj ); */
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "getter" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "getter" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_1ARGS( t_2, a_obj );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2555,7 +2555,7 @@ static Obj  HdlrFunc8 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -2610,10 +2610,10 @@ static Obj  HdlrFunc7 (
  /* if not IS_IDENTICAL_OBJ( filter, IS_OBJECT ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2621,7 +2621,7 @@ static Obj  HdlrFunc7 (
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
   t_1 = CALL_1ARGS( t_2, a_filter );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_flags = t_1;
   
   /* rank := 0; */
@@ -2629,7 +2629,7 @@ static Obj  HdlrFunc7 (
   
   /* cats := IS_OBJECT; */
   t_1 = GC_IS__OBJECT;
-  CHECK_BOUND( t_1, "IS_OBJECT" )
+  CHECK_BOUND( t_1, "IS_OBJECT" );
   l_cats = t_1;
   
   /* props := [  ]; */
@@ -2640,15 +2640,15 @@ static Obj  HdlrFunc7 (
   /* lk := READ_LOCK( FILTER_REGION ); */
   t_2 = GF_READ__LOCK;
   t_3 = GC_FILTER__REGION;
-  CHECK_BOUND( t_3, "FILTER_REGION" )
+  CHECK_BOUND( t_3, "FILTER_REGION" );
   t_1 = CALL_1ARGS( t_2, t_3 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_lk = t_1;
   
   /* for i in TRUES_FLAGS( flags ) do */
   t_5 = GF_TRUES__FLAGS;
   t_4 = CALL_1ARGS( t_5, l_flags );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
    t_1 = INTOBJ_INT(1);
@@ -2672,11 +2672,11 @@ static Obj  HdlrFunc7 (
    
    /* if INFO_FILTERS[i] in FNUM_CATS_AND_REPS then */
    t_7 = GC_INFO__FILTERS;
-   CHECK_BOUND( t_7, "INFO_FILTERS" )
-   CHECK_INT_POS( l_i )
+   CHECK_BOUND( t_7, "INFO_FILTERS" );
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_6, t_7, l_i )
    t_7 = GC_FNUM__CATS__AND__REPS;
-   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" )
+   CHECK_BOUND( t_7, "FNUM_CATS_AND_REPS" );
    t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
    if ( t_5 ) {
     
@@ -2686,14 +2686,14 @@ static Obj  HdlrFunc7 (
     }
     else if ( l_cats == True ) {
      t_7 = GC_FILTERS;
-     CHECK_BOUND( t_7, "FILTERS" )
+     CHECK_BOUND( t_7, "FILTERS" );
      C_ELM_LIST_FPL( t_6, t_7, l_i )
-     CHECK_BOOL( t_6 )
+     CHECK_BOOL( t_6 );
      t_5 = t_6;
     }
     else if (IS_FILTER( l_cats ) ) {
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      t_5 = NewAndFilter( l_cats, t_7 );
     }
@@ -2706,10 +2706,10 @@ static Obj  HdlrFunc7 (
     /* rank := rank - RankFilter( FILTERS[i] ); */
     t_7 = GF_RankFilter;
     t_9 = GC_FILTERS;
-    CHECK_BOUND( t_9, "FILTERS" )
+    CHECK_BOUND( t_9, "FILTERS" );
     C_ELM_LIST_FPL( t_8, t_9, l_i )
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     C_DIFF_FIA( t_5, l_rank, t_6 )
     l_rank = t_5;
     
@@ -2718,19 +2718,19 @@ static Obj  HdlrFunc7 (
    /* elif INFO_FILTERS[i] in FNUM_PROS then */
    else {
     t_7 = GC_INFO__FILTERS;
-    CHECK_BOUND( t_7, "INFO_FILTERS" )
+    CHECK_BOUND( t_7, "INFO_FILTERS" );
     C_ELM_LIST_FPL( t_6, t_7, l_i )
     t_7 = GC_FNUM__PROS;
-    CHECK_BOUND( t_7, "FNUM_PROS" )
+    CHECK_BOUND( t_7, "FNUM_PROS" );
     t_5 = (Obj)(UInt)(IN( t_6, t_7 ));
     if ( t_5 ) {
      
      /* ADD_LIST( props, FILTERS[i] ); */
      t_5 = GF_ADD__LIST;
      t_6 = OBJ_LVAR( 2 );
-     CHECK_BOUND( t_6, "props" )
+     CHECK_BOUND( t_6, "props" );
      t_8 = GC_FILTERS;
-     CHECK_BOUND( t_8, "FILTERS" )
+     CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
      CALL_2ARGS( t_5, t_6, t_7 );
      
@@ -2748,15 +2748,15 @@ static Obj  HdlrFunc7 (
   /* MakeImmutable( props ); */
   t_1 = GF_MakeImmutable;
   t_2 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_2, "props" )
+  CHECK_BOUND( t_2, "props" );
   CALL_1ARGS( t_1, t_2 );
   
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_4, "props" )
+  CHECK_BOUND( t_4, "props" );
   t_2 = CALL_1ARGS( t_3, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
    
@@ -2780,7 +2780,7 @@ static Obj  HdlrFunc7 (
   end ); */
    t_1 = GF_InstallOtherMethod;
    t_2 = OBJ_LVAR( 1 );
-   CHECK_BOUND( t_2, "getter" )
+   CHECK_BOUND( t_2, "getter" );
    t_3 = MakeString( "default method requiring categories and checking properties" );
    t_4 = True;
    t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -2838,15 +2838,15 @@ static Obj  HdlrFunc9 (
  t_4 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_4, 2 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_IS__OBJECT;
- CHECK_BOUND( t_5, "IS_OBJECT" )
+ CHECK_BOUND( t_5, "IS_OBJECT" );
  SET_ELM_PLIST( t_4, 2, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
- CHECK_BOUND( t_5, "DO_NOTHING_SETTER" )
+ CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
  
  /* return; */
@@ -2884,7 +2884,7 @@ static Obj  HdlrFunc10 (
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_list );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
  
@@ -2914,13 +2914,13 @@ static Obj  HdlrFunc10 (
   C_SUM_FIA( t_6, l_i, l_k )
   C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
   l_j = t_1;
   
   /* if list[j] < elm then */
-  CHECK_INT_POS( l_j )
+  CHECK_INT_POS( l_j );
   C_ELM_LIST_FPL( t_2, a_list, l_j )
   t_1 = (Obj)(UInt)(LT( t_2, a_elm ));
   if ( t_1 ) {
@@ -2968,8 +2968,8 @@ static Obj  HdlrFunc12 (
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
  t_3 = CALL_1ARGS( t_4, a_key );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2977,7 +2977,7 @@ static Obj  HdlrFunc12 (
   /* Error( name, ": <p> must be a prime" ); */
   t_1 = GF_Error;
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_2, "name" )
+  CHECK_BOUND( t_2, "name" );
   t_3 = MakeString( ": <p> must be a prime" );
   CALL_2ARGS( t_1, t_2, t_3 );
   
@@ -3039,32 +3039,32 @@ static Obj  HdlrFunc14 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3073,26 +3073,26 @@ static Obj  HdlrFunc14 (
   
   /* erg := oper( D, key ); */
   t_2 = OBJ_HVAR( (1 << 16) | 3 );
-  CHECK_BOUND( t_2, "oper" )
-  CHECK_FUNC( t_2 )
+  CHECK_BOUND( t_2, "oper" );
+  CHECK_FUNC( t_2 );
   t_1 = CALL_2ARGS( t_2, a_D, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
   t_1 = CALL_2ARGS( t_2, l_known, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, l_known );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
   if ( ! t_1 ) {
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_4, l_known, l_i )
    t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
    t_1 = t_3;
@@ -3103,29 +3103,29 @@ static Obj  HdlrFunc14 (
    C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
    t_4 = CALL_1ARGS( t_5, l_known );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
    AsssListCheck( l_known, t_1, t_2 );
    
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    t_2 = GF_IMMUTABLE__COPY__OBJ;
    t_1 = CALL_1ARGS( t_2, a_key );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
    /* known[i + 1] := IMMUTABLE_COPY_OBJ( erg ); */
    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_1 )
+   CHECK_INT_POS( t_1 );
    t_3 = GF_IMMUTABLE__COPY__OBJ;
    t_2 = CALL_1ARGS( t_3, l_erg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
   }
@@ -3136,7 +3136,7 @@ static Obj  HdlrFunc14 (
  
  /* return known[i + 1]; */
  C_SUM_FIA( t_2, l_i, INTOBJ_INT(1) )
- CHECK_INT_POS( t_2 )
+ CHECK_INT_POS( t_2 );
  C_ELM_LIST_FPL( t_1, l_known, t_2 )
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -3168,34 +3168,34 @@ static Obj  HdlrFunc15 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (EQ( t_4, a_key ) ? True : False);
   t_1 = t_3;
@@ -3240,32 +3240,32 @@ static Obj  HdlrFunc16 (
  
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_1, "keytest" )
- CHECK_FUNC( t_1 )
+ CHECK_BOUND( t_1, "keytest" );
+ CHECK_FUNC( t_1 );
  CALL_1ARGS( t_1, a_key );
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "attr" )
- CHECK_FUNC( t_2 )
+ CHECK_BOUND( t_2, "attr" );
+ CHECK_FUNC( t_2 );
  t_1 = CALL_1ARGS( t_2, a_D );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
  t_1 = CALL_2ARGS( t_2, l_known, a_key );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
  t_3 = CALL_1ARGS( t_4, l_known );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
  if ( ! t_1 ) {
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_4, l_known, l_i )
   t_3 = (Obj)(UInt)( ! EQ( t_4, a_key ));
   t_1 = t_3;
@@ -3276,29 +3276,29 @@ static Obj  HdlrFunc16 (
   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
   t_4 = CALL_1ARGS( t_5, l_known );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
   AsssListCheck( l_known, t_1, t_2 );
   
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   t_2 = GF_IMMUTABLE__COPY__OBJ;
   t_1 = CALL_1ARGS( t_2, a_key );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
   /* known[i + 1] := IMMUTABLE_COPY_OBJ( obj ); */
   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   t_3 = GF_IMMUTABLE__COPY__OBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
  }
@@ -3342,7 +3342,7 @@ static Obj  HdlrFunc11 (
  
  /* if keytest = "prime" then */
  t_2 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_2, "keytest" )
+ CHECK_BOUND( t_2, "keytest" );
  t_3 = MakeString( "prime" );
  t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
  if ( t_1 ) {
@@ -3368,9 +3368,9 @@ static Obj  HdlrFunc11 (
  /* str := SHALLOW_COPY_OBJ( name ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_3, "name" )
+ CHECK_BOUND( t_3, "name" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
@@ -3391,7 +3391,7 @@ static Obj  HdlrFunc11 (
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 3, t_1 );
  
  /* str := "Computed"; */
@@ -3401,7 +3401,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* APPEND_LIST_INTR( str, "s" ); */
@@ -3417,7 +3417,7 @@ static Obj  HdlrFunc11 (
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
  t_1 = CALL_1ARGS( t_2, l_str );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 4, t_1 );
  
  /* InstallMethod( attr, "default method", true, [ domreq ], 0, function ( D )
@@ -3425,7 +3425,7 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallMethod;
  t_2 = OBJ_LVAR( 4 );
- CHECK_BOUND( t_2, "attr" )
+ CHECK_BOUND( t_2, "attr" );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
@@ -3444,7 +3444,7 @@ static Obj  HdlrFunc11 (
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, a_domreq );
@@ -3456,20 +3456,20 @@ static Obj  HdlrFunc11 (
  /* lk := WRITE_LOCK( OPERATIONS_REGION ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_OPERATIONS__REGION;
- CHECK_BOUND( t_3, "OPERATIONS_REGION" )
+ CHECK_BOUND( t_3, "OPERATIONS_REGION" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* ADD_LIST( WRAPPER_OPERATIONS, VALUE_GLOBAL( name ) ); */
  t_1 = GF_ADD__LIST;
  t_2 = GC_WRAPPER__OPERATIONS;
- CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" )
+ CHECK_BOUND( t_2, "WRAPPER_OPERATIONS" );
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_5, "name" )
+ CHECK_BOUND( t_5, "name" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* UNLOCK( lk ); */
@@ -3495,9 +3495,9 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_4, "name" )
+ CHECK_BOUND( t_4, "name" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3522,7 +3522,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
@@ -3545,7 +3545,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 2 );
@@ -3570,7 +3570,7 @@ static Obj  HdlrFunc11 (
  /* APPEND_LIST_INTR( str, name ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "name" )
+ CHECK_BOUND( t_2, "name" );
  CALL_2ARGS( t_1, l_str, t_2 );
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
@@ -3582,7 +3582,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
  t_3 = GC_IS__OBJECT;
- CHECK_BOUND( t_3, "IS_OBJECT" )
+ CHECK_BOUND( t_3, "IS_OBJECT" );
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
  CALL_2ARGS( t_1, l_str, t_2 );
@@ -3602,7 +3602,7 @@ static Obj  HdlrFunc11 (
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
  t_2 = CALL_1ARGS( t_3, l_str );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 3 );
@@ -3612,7 +3612,7 @@ static Obj  HdlrFunc11 (
  SET_ELM_PLIST( t_5, 2, a_keyreq );
  CHANGED_BAG( t_5 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 3, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = NewFunction( NameFunc[16], 3, ArgStringToList("D,key,obj"), HdlrFunc16 );
@@ -3668,9 +3668,9 @@ static Obj  HdlrFunc18 (
  /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_7, "reqs" )
+ CHECK_BOUND( t_7, "reqs" );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
@@ -3695,37 +3695,37 @@ static Obj  HdlrFunc18 (
   
   /* re := re or IsBound( cond[i] ) and not Tester( cond[i] )( arg[i] ) and cond[i]( arg[i] ) and Tester( cond[i] )( arg[i] ); */
   t_7 = OBJ_HVAR( (1 << 16) | 4 );
-  CHECK_BOUND( t_7, "re" )
-  CHECK_BOOL( t_7 )
+  CHECK_BOUND( t_7, "re" );
+  CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
   t_5 = (t_6 ? True : False);
   if ( t_5 == False ) {
    t_12 = OBJ_HVAR( (1 << 16) | 3 );
-   CHECK_BOUND( t_12, "cond" )
+   CHECK_BOUND( t_12, "cond" );
    t_13 = OBJ_HVAR( (1 << 16) | 5 );
-   CHECK_BOUND( t_13, "i" )
-   CHECK_INT_POS( t_13 )
+   CHECK_BOUND( t_13, "i" );
+   CHECK_INT_POS( t_13 );
    t_11 = C_ISB_LIST( t_12, t_13 );
    t_10 = (Obj)(UInt)(t_11 != False);
    t_9 = t_10;
    if ( t_9 ) {
     t_15 = GF_Tester;
     t_17 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_17, "cond" )
+    CHECK_BOUND( t_17, "cond" );
     t_18 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_18, "i" )
-    CHECK_INT_POS( t_18 )
+    CHECK_BOUND( t_18, "i" );
+    CHECK_INT_POS( t_18 );
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
     t_14 = CALL_1ARGS( t_15, t_16 );
-    CHECK_FUNC_RESULT( t_14 )
-    CHECK_FUNC( t_14 )
+    CHECK_FUNC_RESULT( t_14 );
+    CHECK_FUNC( t_14 );
     t_16 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_16, "i" )
-    CHECK_INT_POS( t_16 )
+    CHECK_BOUND( t_16, "i" );
+    CHECK_INT_POS( t_16 );
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
     t_13 = CALL_1ARGS( t_14, t_15 );
-    CHECK_FUNC_RESULT( t_13 )
-    CHECK_BOOL( t_13 )
+    CHECK_FUNC_RESULT( t_13 );
+    CHECK_BOOL( t_13 );
     t_12 = (Obj)(UInt)(t_13 != False);
     t_11 = (Obj)(UInt)( ! ((Int)t_12) );
     t_9 = t_11;
@@ -3733,19 +3733,19 @@ static Obj  HdlrFunc18 (
    t_8 = t_9;
    if ( t_8 ) {
     t_13 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_13, "cond" )
+    CHECK_BOUND( t_13, "cond" );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
-    CHECK_FUNC( t_12 )
+    CHECK_FUNC( t_12 );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_14, "i" )
-    CHECK_INT_POS( t_14 )
+    CHECK_BOUND( t_14, "i" );
+    CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_BOOL( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_BOOL( t_11 );
     t_10 = (Obj)(UInt)(t_11 != False);
     t_8 = t_10;
    }
@@ -3753,21 +3753,21 @@ static Obj  HdlrFunc18 (
    if ( t_7 ) {
     t_12 = GF_Tester;
     t_14 = OBJ_HVAR( (1 << 16) | 3 );
-    CHECK_BOUND( t_14, "cond" )
+    CHECK_BOUND( t_14, "cond" );
     t_15 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_15, "i" )
-    CHECK_INT_POS( t_15 )
+    CHECK_BOUND( t_15, "i" );
+    CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
     t_11 = CALL_1ARGS( t_12, t_13 );
-    CHECK_FUNC_RESULT( t_11 )
-    CHECK_FUNC( t_11 )
+    CHECK_FUNC_RESULT( t_11 );
+    CHECK_FUNC( t_11 );
     t_13 = OBJ_HVAR( (1 << 16) | 5 );
-    CHECK_BOUND( t_13, "i" )
-    CHECK_INT_POS( t_13 )
+    CHECK_BOUND( t_13, "i" );
+    CHECK_INT_POS( t_13 );
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
     t_10 = CALL_1ARGS( t_11, t_12 );
-    CHECK_FUNC_RESULT( t_10 )
-    CHECK_BOOL( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
+    CHECK_BOOL( t_10 );
     t_9 = (Obj)(UInt)(t_10 != False);
     t_7 = t_9;
    }
@@ -3780,17 +3780,17 @@ static Obj  HdlrFunc18 (
  
  /* if re then */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
- CHECK_BOUND( t_2, "re" )
- CHECK_BOOL( t_2 )
+ CHECK_BOUND( t_2, "re" );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* return CallFuncList( oper, arg ); */
   t_2 = GF_CallFuncList;
   t_3 = OBJ_HVAR( (1 << 16) | 1 );
-  CHECK_BOUND( t_3, "oper" )
+  CHECK_BOUND( t_3, "oper" );
   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3801,7 +3801,7 @@ static Obj  HdlrFunc18 (
   
   /* TryNextMethod(); */
   t_1 = GC_TRY__NEXT__METHOD;
-  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" )
+  CHECK_BOUND( t_1, "TRY_NEXT_METHOD" );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -3845,7 +3845,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
   
@@ -3879,7 +3879,7 @@ static Obj  HdlrFunc17 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
    
@@ -3923,7 +3923,7 @@ static Obj  HdlrFunc17 (
  
  /* for i in reqs do */
  t_4 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_4, "reqs" )
+ CHECK_BOUND( t_4, "reqs" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -3946,12 +3946,12 @@ static Obj  HdlrFunc17 (
   ASS_LVAR( 5, t_2 );
   
   /* val := val - RankFilter( i ); */
-  CHECK_BOUND( l_val, "val" )
+  CHECK_BOUND( l_val, "val" );
   t_7 = GF_RankFilter;
   t_8 = OBJ_LVAR( 5 );
-  CHECK_BOUND( t_8, "i" )
+  CHECK_BOUND( t_8, "i" );
   t_6 = CALL_1ARGS( t_7, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
   
@@ -3972,11 +3972,11 @@ static Obj  HdlrFunc17 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_2 = OBJ_LVAR( 1 );
- CHECK_BOUND( t_2, "oper" )
- CHECK_BOUND( l_info, "info" )
- CHECK_BOUND( l_fampred, "fampred" )
+ CHECK_BOUND( t_2, "oper" );
+ CHECK_BOUND( l_info, "info" );
+ CHECK_BOUND( l_fampred, "fampred" );
  t_3 = OBJ_LVAR( 2 );
- CHECK_BOUND( t_3, "reqs" )
+ CHECK_BOUND( t_3, "reqs" );
  t_4 = NewFunction( NameFunc[18], -1, ArgStringToList("arg"), HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewFunctionBody();
@@ -4088,7 +4088,7 @@ static Obj  HdlrFunc1 (
  t_4 = GF_NewSpecialRegion;
  t_5 = MakeString( "operation methods" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, baserank, method )
@@ -4403,7 +4403,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -4639,17 +4639,17 @@ static Obj  HdlrFunc1 (
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
  t_2 = GC_ViewObj;
- CHECK_BOUND( t_2, "ViewObj" )
+ CHECK_BOUND( t_2, "ViewObj" );
  t_3 = MakeString( "default method using `PrintObj'" );
  t_4 = True;
  t_5 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_5, 1 );
  t_6 = GC_IS__OBJECT;
- CHECK_BOUND( t_6, "IS_OBJECT" )
+ CHECK_BOUND( t_6, "IS_OBJECT" );
  SET_ELM_PLIST( t_5, 1, t_6 );
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
- CHECK_BOUND( t_6, "PRINT_OBJ" )
+ CHECK_BOUND( t_6, "PRINT_OBJ" );
  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
  
  /* return; */

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -256,7 +256,12 @@ static Obj  HdlrFunc2 (
  t_3 = GF_IS__SUBSET__FLAGS;
  t_4 = GC_IMM__FLAGS;
  CHECK_BOUND( t_4, "IMM_FLAGS" );
- t_2 = CALL_2ARGS( t_3, t_4, a_flags );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_2ARGS( t_3, t_4, a_flags );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -273,16 +278,31 @@ static Obj  HdlrFunc2 (
  t_2 = GF_SUB__FLAGS;
  t_3 = GC_IMM__FLAGS;
  CHECK_BOUND( t_3, "IMM_FLAGS" );
- t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, a_flags, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_flags, t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  a_flags = t_1;
  
  /* flagspos := SHALLOW_COPY_OBJ( TRUES_FLAGS( flags ) ); */
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_4 = GF_TRUES__FLAGS;
- t_3 = CALL_1ARGS( t_4, a_flags );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_flags );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_flagspos = t_1;
  
@@ -293,7 +313,12 @@ static Obj  HdlrFunc2 (
  
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
- t_1 = CALL_1ARGS( t_2, a_obj );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_obj );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
@@ -317,7 +342,12 @@ static Obj  HdlrFunc2 (
   /* Print( "#I RunImmediateMethods\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "#I RunImmediateMethods\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -363,7 +393,12 @@ static Obj  HdlrFunc2 (
    t_9 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
    CHECK_BOUND( t_9, "SIZE_IMMEDIATE_METHOD_ENTRY" );
    t_12 = GF_LEN__LIST;
-   t_11 = CALL_1ARGS( t_12, l_imm );
+   if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+    t_11 = CALL_1ARGS( t_12, l_imm );
+   }
+   else {
+    t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( l_imm ) );
+   }
    CHECK_FUNC_RESULT( t_11 );
    t_12 = GC_SIZE__IMMEDIATE__METHOD__ENTRY;
    CHECK_BOUND( t_12, "SIZE_IMMEDIATE_METHOD_ENTRY" );
@@ -395,7 +430,12 @@ static Obj  HdlrFunc2 (
     C_SUM_FIA( t_15, l_i, INTOBJ_INT(4) )
     CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_14, l_imm, t_15 )
-    t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
+    if ( TNUM_OBJ( t_13 ) == T_FUNCTION ) {
+     t_12 = CALL_2ARGS( t_13, a_flags, t_14 );
+    }
+    else {
+     t_12 = DoOperation2Args( CallFuncListOper, t_13, NewPlistFromArgs( a_flags, t_14 ) );
+    }
     CHECK_FUNC_RESULT( t_12 );
     CHECK_BOOL( t_12 );
     t_11 = (Obj)(UInt)(t_12 != False);
@@ -405,7 +445,12 @@ static Obj  HdlrFunc2 (
      C_SUM_FIA( t_17, l_i, INTOBJ_INT(3) )
      CHECK_INT_POS( t_17 );
      C_ELM_LIST_FPL( t_16, l_imm, t_17 )
-     t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
+     if ( TNUM_OBJ( t_15 ) == T_FUNCTION ) {
+      t_14 = CALL_2ARGS( t_15, a_flags, t_16 );
+     }
+     else {
+      t_14 = DoOperation2Args( CallFuncListOper, t_15, NewPlistFromArgs( a_flags, t_16 ) );
+     }
      CHECK_FUNC_RESULT( t_14 );
      CHECK_BOOL( t_14 );
      t_13 = (Obj)(UInt)(t_14 != False);
@@ -434,8 +479,12 @@ static Obj  HdlrFunc2 (
      l_meth = t_9;
      
      /* res := meth( obj ); */
-     CHECK_FUNC( l_meth );
-     t_9 = CALL_1ARGS( l_meth, a_obj );
+     if ( TNUM_OBJ( l_meth ) == T_FUNCTION ) {
+      t_9 = CALL_1ARGS( l_meth, a_obj );
+     }
+     else {
+      t_9 = DoOperation2Args( CallFuncListOper, l_meth, NewPlistFromArgs( a_obj ) );
+     }
      CHECK_FUNC_RESULT( t_9 );
      l_res = t_9;
      
@@ -444,7 +493,12 @@ static Obj  HdlrFunc2 (
      C_SUM_FIA( t_11, l_i, INTOBJ_INT(6) )
      CHECK_INT_POS( t_11 );
      C_ELM_LIST_FPL( t_10, l_imm, t_11 )
-     CALL_2ARGS( t_9, l_tried, t_10 );
+     if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_9, l_tried, t_10 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( l_tried, t_10 ) );
+     }
      
      /* RUN_IMMEDIATE_METHODS_CHECKS := RUN_IMMEDIATE_METHODS_CHECKS + 1; */
      t_10 = GC_RUN__IMMEDIATE__METHODS__CHECKS;
@@ -466,9 +520,19 @@ static Obj  HdlrFunc2 (
       C_SUM_FIA( t_14, l_i, INTOBJ_INT(1) )
       CHECK_INT_POS( t_14 );
       C_ELM_LIST_FPL( t_13, l_imm, t_14 )
-      t_11 = CALL_1ARGS( t_12, t_13 );
+      if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+       t_11 = CALL_1ARGS( t_12, t_13 );
+      }
+      else {
+       t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13 ) );
+      }
       CHECK_FUNC_RESULT( t_11 );
-      CALL_2ARGS( t_9, t_10, t_11 );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       CALL_2ARGS( t_9, t_10, t_11 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11 ) );
+      }
       
       /* if imm[i + 7] <> false then */
       C_SUM_FIA( t_11, l_i, INTOBJ_INT(7) )
@@ -484,7 +548,12 @@ static Obj  HdlrFunc2 (
        C_SUM_FIA( t_12, l_i, INTOBJ_INT(7) )
        CHECK_INT_POS( t_12 );
        C_ELM_LIST_FPL( t_11, l_imm, t_12 )
-       CALL_2ARGS( t_9, t_10, t_11 );
+       if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+        CALL_2ARGS( t_9, t_10, t_11 );
+       }
+       else {
+        DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11 ) );
+       }
        
       }
       /* fi */
@@ -502,7 +571,12 @@ static Obj  HdlrFunc2 (
       C_ELM_LIST_FPL( t_14, l_imm, t_15 )
       C_ELM_LIST_FPL( t_13, t_14, INTOBJ_INT(2) )
       t_14 = MakeString( "\n" );
-      CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       CALL_5ARGS( t_9, t_10, t_11, t_12, t_13, t_14 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11, t_12, t_13, t_14 ) );
+      }
       
      }
      /* fi */
@@ -521,8 +595,12 @@ static Obj  HdlrFunc2 (
       C_SUM_FIA( t_10, l_i, INTOBJ_INT(2) )
       CHECK_INT_POS( t_10 );
       C_ELM_LIST_FPL( t_9, l_imm, t_10 )
-      CHECK_FUNC( t_9 );
-      CALL_2ARGS( t_9, a_obj, l_res );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       CALL_2ARGS( t_9, a_obj, l_res );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_obj, l_res ) );
+      }
       
       /* IGNORE_IMMEDIATE_METHODS := false; */
       t_9 = False;
@@ -537,9 +615,19 @@ static Obj  HdlrFunc2 (
       /* if not IS_IDENTICAL_OBJ( TYPE_OBJ( obj ), type ) then */
       t_12 = GF_IS__IDENTICAL__OBJ;
       t_14 = GF_TYPE__OBJ;
-      t_13 = CALL_1ARGS( t_14, a_obj );
+      if ( TNUM_OBJ( t_14 ) == T_FUNCTION ) {
+       t_13 = CALL_1ARGS( t_14, a_obj );
+      }
+      else {
+       t_13 = DoOperation2Args( CallFuncListOper, t_14, NewPlistFromArgs( a_obj ) );
+      }
       CHECK_FUNC_RESULT( t_13 );
-      t_11 = CALL_2ARGS( t_12, t_13, l_type );
+      if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+       t_11 = CALL_2ARGS( t_12, t_13, l_type );
+      }
+      else {
+       t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13, l_type ) );
+      }
       CHECK_FUNC_RESULT( t_11 );
       CHECK_BOOL( t_11 );
       t_10 = (Obj)(UInt)(t_11 != False);
@@ -548,7 +636,12 @@ static Obj  HdlrFunc2 (
        
        /* type := TYPE_OBJ( obj ); */
        t_10 = GF_TYPE__OBJ;
-       t_9 = CALL_1ARGS( t_10, a_obj );
+       if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+        t_9 = CALL_1ARGS( t_10, a_obj );
+       }
+       else {
+        t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( a_obj ) );
+       }
        CHECK_FUNC_RESULT( t_9 );
        l_type = t_9;
        
@@ -557,22 +650,42 @@ static Obj  HdlrFunc2 (
        t_11 = ElmPosObj( l_type, 2 );
        t_12 = GC_IMM__FLAGS;
        CHECK_BOUND( t_12, "IMM_FLAGS" );
-       t_9 = CALL_2ARGS( t_10, t_11, t_12 );
+       if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+        t_9 = CALL_2ARGS( t_10, t_11, t_12 );
+       }
+       else {
+        t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( t_11, t_12 ) );
+       }
        CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* newflags := SUB_FLAGS( newflags, flags ); */
        t_10 = GF_SUB__FLAGS;
-       t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
+       if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+        t_9 = CALL_2ARGS( t_10, l_newflags, a_flags );
+       }
+       else {
+        t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( l_newflags, a_flags ) );
+       }
        CHECK_FUNC_RESULT( t_9 );
        l_newflags = t_9;
        
        /* APPEND_LIST_INTR( flagspos, TRUES_FLAGS( newflags ) ); */
        t_9 = GF_APPEND__LIST__INTR;
        t_11 = GF_TRUES__FLAGS;
-       t_10 = CALL_1ARGS( t_11, l_newflags );
+       if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+        t_10 = CALL_1ARGS( t_11, l_newflags );
+       }
+       else {
+        t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( l_newflags ) );
+       }
        CHECK_FUNC_RESULT( t_10 );
-       CALL_2ARGS( t_9, l_flagspos, t_10 );
+       if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+        CALL_2ARGS( t_9, l_flagspos, t_10 );
+       }
+       else {
+        DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( l_flagspos, t_10 ) );
+       }
        
        /* flags := type![2]; */
        t_9 = ElmPosObj( l_type, 2 );
@@ -652,21 +765,35 @@ static Obj  HdlrFunc3 (
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_METHODS__OPERATION__REGION;
  CHECK_BOUND( t_3, "METHODS_OPERATION_REGION" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* if IS_FUNCTION( baserank ) then */
  t_3 = GF_IS__FUNCTION;
- t_2 = CALL_1ARGS( t_3, a_baserank );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_baserank );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_baserank ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* rank := baserank(  ); */
-  CHECK_FUNC( a_baserank );
-  t_1 = CALL_0ARGS( a_baserank );
+  if ( TNUM_OBJ( a_baserank ) == T_FUNCTION ) {
+   t_1 = CALL_0ARGS( a_baserank );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, a_baserank, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_rank = t_1;
   
@@ -683,7 +810,12 @@ static Obj  HdlrFunc3 (
  
  /* if IS_CONSTRUCTOR( opr ) then */
  t_3 = GF_IS__CONSTRUCTOR;
- t_2 = CALL_1ARGS( t_3, a_opr );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_opr );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -691,7 +823,12 @@ static Obj  HdlrFunc3 (
   
   /* if 0 = LEN_LIST( flags ) then */
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_flags );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_flags );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_flags ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
@@ -699,10 +836,20 @@ static Obj  HdlrFunc3 (
    /* Error( NAME_FUNC( opr ), ": constructors must have at least one argument" ); */
    t_1 = GF_Error;
    t_3 = GF_NAME__FUNC;
-   t_2 = CALL_1ARGS( t_3, a_opr );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_opr );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    t_3 = MakeString( ": constructors must have at least one argument" );
-   CALL_2ARGS( t_1, t_2, t_3 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, t_2, t_3 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+   }
    
   }
   /* fi */
@@ -710,7 +857,12 @@ static Obj  HdlrFunc3 (
   /* rank := rank - RankFilter( flags[1] ); */
   t_3 = GF_RankFilter;
   C_ELM_LIST_FPL( t_4, a_flags, INTOBJ_INT(1) )
-  t_2 = CALL_1ARGS( t_3, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   C_DIFF_FIA( t_1, l_rank, t_2 )
   l_rank = t_1;
@@ -745,7 +897,12 @@ static Obj  HdlrFunc3 (
    
    /* rank := rank + RankFilter( i ); */
    t_7 = GF_RankFilter;
-   t_6 = CALL_1ARGS( t_7, l_i );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, l_i );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    C_SUM_FIA( t_5, l_rank, t_6 )
    l_rank = t_5;
@@ -758,19 +915,34 @@ static Obj  HdlrFunc3 (
  
  /* narg := LEN_LIST( flags ); */
  t_2 = GF_LEN__LIST;
- t_1 = CALL_1ARGS( t_2, a_flags );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_flags );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_narg = t_1;
  
  /* methods := METHODS_OPERATION( opr, narg ); */
  t_2 = GF_METHODS__OPERATION;
- t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, a_opr, l_narg );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_opr, l_narg ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_methods = t_1;
  
  /* methods := methods{[ 1 .. LEN_LIST( methods ) ]}; */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_methods );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_methods );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_methods ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = Range2Check( INTOBJ_INT(1), t_3 );
  t_1 = ElmsListCheck( l_methods, t_2 );
@@ -783,7 +955,12 @@ static Obj  HdlrFunc3 (
   
   /* info := NAME_FUNC( opr ); */
   t_2 = GF_NAME__FUNC;
-  t_1 = CALL_1ARGS( t_2, a_opr );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_opr );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_opr ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   a_info = t_1;
   
@@ -795,27 +972,52 @@ static Obj  HdlrFunc3 (
   /* k := SHALLOW_COPY_OBJ( NAME_FUNC( opr ) ); */
   t_2 = GF_SHALLOW__COPY__OBJ;
   t_4 = GF_NAME__FUNC;
-  t_3 = CALL_1ARGS( t_4, a_opr );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, a_opr );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_opr ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
-  t_1 = CALL_1ARGS( t_2, t_3 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, t_3 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_k = t_1;
   
   /* APPEND_LIST_INTR( k, ": " ); */
   t_1 = GF_APPEND__LIST__INTR;
   t_2 = MakeString( ": " );
-  CALL_2ARGS( t_1, l_k, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_k, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_k, t_2 ) );
+  }
   
   /* APPEND_LIST_INTR( k, info ); */
   t_1 = GF_APPEND__LIST__INTR;
-  CALL_2ARGS( t_1, l_k, a_info );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_k, a_info );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_k, a_info ) );
+  }
   
   /* info := k; */
   a_info = l_k;
   
   /* CONV_STRING( info ); */
   t_1 = GF_CONV__STRING;
-  CALL_1ARGS( t_1, a_info );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, a_info );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_info ) );
+  }
   
  }
  /* fi */
@@ -826,7 +1028,12 @@ static Obj  HdlrFunc3 (
  /* while i < LEN_LIST( methods ) and rank < methods[i + (narg + 3)] do */
  while ( 1 ) {
   t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_methods );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, l_methods );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_methods ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( l_i, t_3 ));
   t_1 = t_2;
@@ -865,7 +1072,12 @@ static Obj  HdlrFunc3 (
   /* while k < LEN_LIST( methods ) and rank = methods[k + narg + 3] do */
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_methods );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_methods );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_methods ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_k, t_3 ));
    t_1 = t_2;
@@ -995,12 +1207,22 @@ static Obj  HdlrFunc3 (
   CHANGED_BAG( t_2 );
   SET_ELM_PLIST( t_2, 6, INTOBJ_INT(1) );
   t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_methods );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_methods );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_methods ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   C_DIFF_FIA( t_3, t_4, l_i )
   SET_ELM_PLIST( t_2, 7, t_3 );
   CHANGED_BAG( t_2 );
-  CALL_XARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_XARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, t_2 );
+  }
   
  }
  /* fi */
@@ -1033,7 +1255,12 @@ static Obj  HdlrFunc3 (
   /* elif IS_FUNCTION( rel ) then */
   else {
    t_3 = GF_IS__FUNCTION;
-   t_2 = CALL_1ARGS( t_3, a_rel );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_rel );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_rel ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -1048,13 +1275,23 @@ static Obj  HdlrFunc3 (
      
      /* tmp := NARG_FUNC( rel ); */
      t_2 = GF_NARG__FUNC;
-     t_1 = CALL_1ARGS( t_2, a_rel );
+     if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+      t_1 = CALL_1ARGS( t_2, a_rel );
+     }
+     else {
+      t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_rel ) );
+     }
      CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
-     t_4 = CALL_1ARGS( t_5, l_narg );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, l_narg );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_narg ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
@@ -1073,11 +1310,21 @@ static Obj  HdlrFunc3 (
       /* Error( NAME_FUNC( opr ), ": <famrel> must accept ", narg, " arguments" ); */
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
-      t_2 = CALL_1ARGS( t_3, a_opr );
+      if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+       t_2 = CALL_1ARGS( t_3, a_opr );
+      }
+      else {
+       t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+      }
       CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <famrel> must accept " );
       t_4 = MakeString( " arguments" );
-      CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, l_narg, t_4 ) );
+      }
       
      }
      /* fi */
@@ -1093,10 +1340,20 @@ static Obj  HdlrFunc3 (
     /* Error( NAME_FUNC( opr ), ": <famrel> must be a function, `true', or `false'" ); */
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
-    t_2 = CALL_1ARGS( t_3, a_opr );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_opr );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <famrel> must be a function, `true', or `false'" );
-    CALL_2ARGS( t_1, t_2, t_3 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, t_2, t_3 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+    }
     
    }
   }
@@ -1131,7 +1388,12 @@ static Obj  HdlrFunc3 (
   /* elif IS_FUNCTION( method ) then */
   else {
    t_3 = GF_IS__FUNCTION;
-   t_2 = CALL_1ARGS( t_3, a_method );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_method );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_method ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -1145,7 +1407,12 @@ static Obj  HdlrFunc3 (
     t_1 = t_2;
     if ( t_1 ) {
      t_6 = GF_IS__OPERATION;
-     t_5 = CALL_1ARGS( t_6, a_method );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, a_method );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( a_method ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
@@ -1156,13 +1423,23 @@ static Obj  HdlrFunc3 (
      
      /* tmp := NARG_FUNC( method ); */
      t_2 = GF_NARG__FUNC;
-     t_1 = CALL_1ARGS( t_2, a_method );
+     if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+      t_1 = CALL_1ARGS( t_2, a_method );
+     }
+     else {
+      t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_method ) );
+     }
      CHECK_FUNC_RESULT( t_1 );
      l_tmp = t_1;
      
      /* if tmp < AINV( narg ) - 1 or tmp >= 0 and tmp <> narg then */
      t_5 = GF_AINV;
-     t_4 = CALL_1ARGS( t_5, l_narg );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, l_narg );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_narg ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      C_DIFF_FIA( t_3, t_4, INTOBJ_INT(1) )
      t_2 = (Obj)(UInt)(LT( l_tmp, t_3 ));
@@ -1181,11 +1458,21 @@ static Obj  HdlrFunc3 (
       /* Error( NAME_FUNC( opr ), ": <method> must accept ", narg, " arguments" ); */
       t_1 = GF_Error;
       t_3 = GF_NAME__FUNC;
-      t_2 = CALL_1ARGS( t_3, a_opr );
+      if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+       t_2 = CALL_1ARGS( t_3, a_opr );
+      }
+      else {
+       t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+      }
       CHECK_FUNC_RESULT( t_2 );
       t_3 = MakeString( ": <method> must accept " );
       t_4 = MakeString( " arguments" );
-      CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+       CALL_4ARGS( t_1, t_2, t_3, l_narg, t_4 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, l_narg, t_4 ) );
+      }
       
      }
      /* fi */
@@ -1201,10 +1488,20 @@ static Obj  HdlrFunc3 (
     /* Error( NAME_FUNC( opr ), ": <method> must be a function, `true', or `false'" ); */
     t_1 = GF_Error;
     t_3 = GF_NAME__FUNC;
-    t_2 = CALL_1ARGS( t_3, a_opr );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_opr );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_opr ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_3 = MakeString( ": <method> must be a function, `true', or `false'" );
-    CALL_2ARGS( t_1, t_2, t_3 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, t_2, t_3 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+    }
     
    }
   }
@@ -1251,7 +1548,12 @@ static Obj  HdlrFunc3 (
  C_SUM_FIA( t_1, l_i, t_2 )
  CHECK_INT_POS( t_1 );
  t_3 = GF_IMMUTABLE__COPY__OBJ;
- t_2 = CALL_1ARGS( t_3, a_info );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_info );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_info ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
@@ -1267,7 +1569,12 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 3 );
   SET_LEN_PLIST( t_4, 3 );
   t_6 = GF_INPUT__FILENAME;
-  t_5 = CALL_0ARGS( t_6 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_0ARGS( t_6 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
@@ -1276,11 +1583,21 @@ static Obj  HdlrFunc3 (
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_INPUT__LINENUMBER;
-  t_5 = CALL_0ARGS( t_6 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_0ARGS( t_6 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   SET_ELM_PLIST( t_4, 3, t_5 );
   CHANGED_BAG( t_4 );
-  t_2 = CALL_1ARGS( t_3, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_methods, t_1, t_2 )
   
@@ -1303,13 +1620,28 @@ static Obj  HdlrFunc3 (
  /* SET_METHODS_OPERATION( opr, narg, MakeReadOnlySingleObj( methods ) ); */
  t_1 = GF_SET__METHODS__OPERATION;
  t_3 = GF_MakeReadOnlySingleObj;
- t_2 = CALL_1ARGS( t_3, l_methods );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_methods );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_methods ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
- CALL_3ARGS( t_1, a_opr, l_narg, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, a_opr, l_narg, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_opr, l_narg, t_2 ) );
+ }
  
  /* UNLOCK( lk ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_lk );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_lk );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lk ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1335,7 +1667,12 @@ static Obj  HdlrFunc4 (
  /* INSTALL_METHOD( arg, true ); */
  t_1 = GF_INSTALL__METHOD;
  t_2 = True;
- CALL_2ARGS( t_1, a_arg, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_arg, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_arg, t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1361,7 +1698,12 @@ static Obj  HdlrFunc5 (
  /* INSTALL_METHOD( arg, false ); */
  t_1 = GF_INSTALL__METHOD;
  t_2 = False;
- CALL_2ARGS( t_1, a_arg, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_arg, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_arg, t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1440,13 +1782,23 @@ static Obj  HdlrFunc6 (
  t_2 = GF_READ__LOCK;
  t_3 = GC_OPERATIONS__REGION;
  CHECK_BOUND( t_3, "OPERATIONS_REGION" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
  /* len := LEN_LIST( arglist ); */
  t_2 = GF_LEN__LIST;
- t_1 = CALL_1ARGS( t_2, a_arglist );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_arglist );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_arglist ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_len = t_1;
  
@@ -1457,7 +1809,12 @@ static Obj  HdlrFunc6 (
   /* Error( "too few arguments given in <arglist>" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "too few arguments given in <arglist>" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -1468,7 +1825,12 @@ static Obj  HdlrFunc6 (
  
  /* if not IS_OPERATION( opr ) then */
  t_4 = GF_IS__OPERATION;
- t_3 = CALL_1ARGS( t_4, l_opr );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_opr );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1478,7 +1840,12 @@ static Obj  HdlrFunc6 (
   /* Error( "<opr> is not an operation" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<opr> is not an operation" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -1486,7 +1853,12 @@ static Obj  HdlrFunc6 (
  /* if IS_STRING_REP( arglist[2] ) or arglist[2] = false then */
  t_4 = GF_IS__STRING__REP;
  C_ELM_LIST_FPL( t_5, a_arglist, INTOBJ_INT(2) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1529,7 +1901,12 @@ static Obj  HdlrFunc6 (
  if ( ! t_1 ) {
   t_5 = GF_IS__FUNCTION;
   C_ELM_LIST_FPL( t_6, a_arglist, l_pos )
-  t_4 = CALL_1ARGS( t_5, t_6 );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, t_6 );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6 ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   CHECK_BOOL( t_4 );
   t_3 = (Obj)(UInt)(t_4 != False);
@@ -1566,7 +1943,12 @@ static Obj  HdlrFunc6 (
  if ( ! t_1 ) {
   t_6 = GF_IS__LIST;
   C_ELM_LIST_FPL( t_7, a_arglist, l_pos )
-  t_5 = CALL_1ARGS( t_6, t_7 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, t_7 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
@@ -1579,7 +1961,12 @@ static Obj  HdlrFunc6 (
   t_1 = GF_Error;
   t_2 = MakeString( "<arglist>[" );
   t_3 = MakeString( "] must be a list of filters" );
-  CALL_3ARGS( t_1, t_2, l_pos, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_3ARGS( t_1, t_2, l_pos, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, l_pos, t_3 ) );
+  }
   
  }
  /* fi */
@@ -1593,7 +1980,12 @@ static Obj  HdlrFunc6 (
  CHECK_BOUND( t_3, "GAPInfo" );
  t_2 = ELM_REC( t_3, R_MaxNrArgsMethod );
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_filters );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_filters );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_filters ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_1 = (Obj)(UInt)(LT( t_2, t_3 ));
  if ( t_1 ) {
@@ -1605,14 +1997,24 @@ static Obj  HdlrFunc6 (
   CHECK_BOUND( t_4, "GAPInfo" );
   t_3 = ELM_REC( t_4, R_MaxNrArgsMethod );
   t_4 = MakeString( " arguments" );
-  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_3ARGS( t_1, t_2, t_3, t_4 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+  }
   
  }
  /* fi */
  
  /* if 0 < LEN_LIST( filters ) then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, l_filters );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_filters );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_filters ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
  if ( t_1 ) {
@@ -1627,7 +2029,12 @@ static Obj  HdlrFunc6 (
   
   /* for i in [ 1 .. LEN_LIST( filters ) ] do */
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, l_filters );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, l_filters );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_filters ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(1);
@@ -1638,7 +2045,12 @@ static Obj  HdlrFunc6 (
    /* if IS_STRING_REP( filters[i] ) then */
    t_5 = GF_IS__STRING__REP;
    C_ELM_LIST_FPL( t_6, l_filters, l_i )
-   t_4 = CALL_1ARGS( t_5, t_6 );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, t_6 );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6 ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
    CHECK_BOOL( t_4 );
    t_3 = (Obj)(UInt)(t_4 != False);
@@ -1647,24 +2059,44 @@ static Obj  HdlrFunc6 (
     /* APPEND_LIST_INTR( info1, filters[i] ); */
     t_3 = GF_APPEND__LIST__INTR;
     C_ELM_LIST_FPL( t_4, l_filters, l_i )
-    CALL_2ARGS( t_3, l_info1, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_3, l_info1, t_4 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_info1, t_4 ) );
+    }
     
     /* APPEND_LIST_INTR( info1, ", " ); */
     t_3 = GF_APPEND__LIST__INTR;
     t_4 = MakeString( ", " );
-    CALL_2ARGS( t_3, l_info1, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_3, l_info1, t_4 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_info1, t_4 ) );
+    }
     
     /* filters[i] := EvalString( filters[i] ); */
     t_4 = GF_EvalString;
     C_ELM_LIST_FPL( t_5, l_filters, l_i )
-    t_3 = CALL_1ARGS( t_4, t_5 );
+    if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+     t_3 = CALL_1ARGS( t_4, t_5 );
+    }
+    else {
+     t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+    }
     CHECK_FUNC_RESULT( t_3 );
     C_ASS_LIST_FPL( l_filters, l_i, t_3 )
     
     /* if not IS_FUNCTION( filters[i] ) then */
     t_6 = GF_IS__FUNCTION;
     C_ELM_LIST_FPL( t_7, l_filters, l_i )
-    t_5 = CALL_1ARGS( t_6, t_7 );
+    if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+     t_5 = CALL_1ARGS( t_6, t_7 );
+    }
+    else {
+     t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+    }
     CHECK_FUNC_RESULT( t_5 );
     CHECK_BOOL( t_5 );
     t_4 = (Obj)(UInt)(t_5 != False);
@@ -1674,7 +2106,12 @@ static Obj  HdlrFunc6 (
      /* Error( "string does not evaluate to a function" ); */
      t_3 = GF_Error;
      t_4 = MakeString( "string does not evaluate to a function" );
-     CALL_1ARGS( t_3, t_4 );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      CALL_1ARGS( t_3, t_4 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+     }
      
     }
     /* fi */
@@ -1709,7 +2146,12 @@ static Obj  HdlrFunc6 (
    
    /* info1[LEN_LIST( info1 ) - 1] := ' '; */
    t_3 = GF_LEN__LIST;
-   t_2 = CALL_1ARGS( t_3, l_info1 );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, l_info1 );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_info1 ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
    CHECK_INT_POS( t_1 );
@@ -1718,7 +2160,12 @@ static Obj  HdlrFunc6 (
    
    /* info1[LEN_LIST( info1 )] := ']'; */
    t_2 = GF_LEN__LIST;
-   t_1 = CALL_1ARGS( t_2, l_info1 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_1ARGS( t_2, l_info1 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_info1 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    CHECK_INT_POS( t_1 );
    t_2 = ObjsChar[93];
@@ -1768,9 +2215,19 @@ static Obj  HdlrFunc6 (
   /* ADD_LIST( flags, FLAGS_FILTER( i ) ); */
   t_5 = GF_ADD__LIST;
   t_7 = GF_FLAGS__FILTER;
-  t_6 = CALL_1ARGS( t_7, l_i );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, l_i );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
-  CALL_2ARGS( t_5, l_flags, t_6 );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_5, l_flags, t_6 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_flags, t_6 ) );
+  }
   
  }
  /* od */
@@ -1785,7 +2242,12 @@ static Obj  HdlrFunc6 (
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "the method is missing in <arglist>" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -1793,7 +2255,12 @@ static Obj  HdlrFunc6 (
  else {
   t_4 = GF_IS__INT;
   C_ELM_LIST_FPL( t_5, a_arglist, l_pos )
-  t_3 = CALL_1ARGS( t_4, t_5 );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, t_5 );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
@@ -1801,7 +2268,12 @@ static Obj  HdlrFunc6 (
   if ( ! t_1 ) {
    t_7 = GF_IS__FUNCTION;
    C_ELM_LIST_FPL( t_8, a_arglist, l_pos )
-   t_6 = CALL_1ARGS( t_7, t_8 );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, t_8 );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    CHECK_BOOL( t_6 );
    t_5 = (Obj)(UInt)(t_6 != False);
@@ -1809,7 +2281,12 @@ static Obj  HdlrFunc6 (
    if ( t_4 ) {
     t_8 = GF_NARG__FUNC;
     C_ELM_LIST_FPL( t_9, a_arglist, l_pos )
-    t_7 = CALL_1ARGS( t_8, t_9 );
+    if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+     t_7 = CALL_1ARGS( t_8, t_9 );
+    }
+    else {
+     t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+    }
     CHECK_FUNC_RESULT( t_7 );
     t_6 = (Obj)(UInt)(EQ( t_7, INTOBJ_INT(0) ));
     t_4 = t_6;
@@ -1817,7 +2294,12 @@ static Obj  HdlrFunc6 (
    t_3 = t_4;
    if ( t_3 ) {
     t_7 = GF_LEN__LIST;
-    t_6 = CALL_1ARGS( t_7, a_arglist );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, a_arglist );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_arglist ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     t_5 = (Obj)(UInt)(LT( l_pos, t_6 ));
     t_3 = t_5;
@@ -1856,7 +2338,12 @@ static Obj  HdlrFunc6 (
   /* Error( "the method is missing in <arglist>" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "the method is missing in <arglist>" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -1867,7 +2354,12 @@ static Obj  HdlrFunc6 (
  
  /* if FLAG1_FILTER( opr ) <> 0 and (rel = true or rel = RETURN_TRUE) and LEN_LIST( filters ) = 1 and (method = true or method = RETURN_TRUE) then */
  t_6 = GF_FLAG1__FILTER;
- t_5 = CALL_1ARGS( t_6, l_opr );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, l_opr );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_opr ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_4 = (Obj)(UInt)( ! EQ( t_5, INTOBJ_INT(0) ));
  t_3 = t_4;
@@ -1886,7 +2378,12 @@ static Obj  HdlrFunc6 (
  t_2 = t_3;
  if ( t_2 ) {
   t_6 = GF_LEN__LIST;
-  t_5 = CALL_1ARGS( t_6, l_filters );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, l_filters );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_filters ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   t_4 = (Obj)(UInt)(EQ( t_5, INTOBJ_INT(1) ));
   t_2 = t_4;
@@ -1909,10 +2406,20 @@ static Obj  HdlrFunc6 (
   /* Error( NAME_FUNC( opr ), ": use `InstallTrueMethod' for <opr>" ); */
   t_1 = GF_Error;
   t_3 = GF_NAME__FUNC;
-  t_2 = CALL_1ARGS( t_3, l_opr );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, l_opr );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_opr ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_3 = MakeString( ": use `InstallTrueMethod' for <opr>" );
-  CALL_2ARGS( t_1, t_2, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, t_2, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+  }
   
  }
  /* fi */
@@ -1940,19 +2447,34 @@ static Obj  HdlrFunc6 (
    t_1 = GF_INFO__DEBUG;
    t_2 = MakeString( "a method is installed for the wrapper operation " );
    t_4 = GF_NAME__FUNC;
-   t_3 = CALL_1ARGS( t_4, l_opr );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_opr );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_4 = MakeString( "\n" );
    t_5 = MakeString( "#I  probably it should be installed for (one of) its\n" );
    t_6 = MakeString( "#I  underlying operation(s)" );
-   CALL_6ARGS( t_1, INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_6ARGS( t_1, INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), t_2, t_3, t_4, t_5, t_6 ) );
+   }
    
   }
   /* fi */
   
   /* req := GET_OPER_FLAGS( opr ); */
   t_2 = GF_GET__OPER__FLAGS;
-  t_1 = CALL_1ARGS( t_2, l_opr );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, l_opr );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_opr ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_req = t_1;
   
@@ -1966,9 +2488,19 @@ static Obj  HdlrFunc6 (
    t_1 = GF_Error;
    t_2 = MakeString( "unknown operation " );
    t_4 = GF_NAME__FUNC;
-   t_3 = CALL_1ARGS( t_4, l_opr );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_opr );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
-   CALL_2ARGS( t_1, t_2, t_3 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, t_2, t_3 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+   }
    
   }
   /* fi */
@@ -2014,9 +2546,19 @@ static Obj  HdlrFunc6 (
     /* ADD_LIST( imp, WITH_HIDDEN_IMPS_FLAGS( i ) ); */
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__HIDDEN__IMPS__FLAGS;
-    t_6 = CALL_1ARGS( t_7, l_i );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_i );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
-    CALL_2ARGS( t_5, l_imp, t_6 );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_5, l_imp, t_6 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_imp, t_6 ) );
+    }
     
    }
    
@@ -2026,9 +2568,19 @@ static Obj  HdlrFunc6 (
     /* ADD_LIST( imp, WITH_IMPS_FLAGS( i ) ); */
     t_5 = GF_ADD__LIST;
     t_7 = GF_WITH__IMPS__FLAGS;
-    t_6 = CALL_1ARGS( t_7, l_i );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_i );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_i ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
-    CALL_2ARGS( t_5, l_imp, t_6 );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_5, l_imp, t_6 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_imp, t_6 ) );
+    }
     
    }
    /* fi */
@@ -2049,7 +2601,12 @@ static Obj  HdlrFunc6 (
   /* while j < LEN_LIST( req ) and not match do */
   while ( 1 ) {
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_req );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_req );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_req ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_2 = (Obj)(UInt)(LT( l_j, t_3 ));
    t_1 = t_2;
@@ -2071,10 +2628,20 @@ static Obj  HdlrFunc6 (
    
    /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
    t_3 = GF_LEN__LIST;
-   t_2 = CALL_1ARGS( t_3, l_reqs );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, l_reqs );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_reqs ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_imp );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_imp );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_imp ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
    if ( t_1 ) {
@@ -2085,7 +2652,12 @@ static Obj  HdlrFunc6 (
     
     /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
     t_3 = GF_LEN__LIST;
-    t_2 = CALL_1ARGS( t_3, l_reqs );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, l_reqs );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_reqs ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     CHECK_INT_SMALL( t_2 );
     for ( t_1 = INTOBJ_INT(1);
@@ -2097,7 +2669,12 @@ static Obj  HdlrFunc6 (
      t_6 = GF_IS__SUBSET__FLAGS;
      C_ELM_LIST_FPL( t_7, l_imp, l_i )
      C_ELM_LIST_FPL( t_8, l_reqs, l_i )
-     t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      CHECK_BOOL( t_5 );
      t_4 = (Obj)(UInt)(t_5 != False);
@@ -2159,9 +2736,19 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Error;
      t_2 = MakeString( "the number of arguments does not match a declaration of " );
      t_4 = GF_NAME__FUNC;
-     t_3 = CALL_1ARGS( t_4, l_opr );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, l_opr );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
-     CALL_2ARGS( t_1, t_2, t_3 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_1, t_2, t_3 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+     }
      
     }
     
@@ -2173,10 +2760,20 @@ static Obj  HdlrFunc6 (
      t_2 = MakeString( "InstallMethod warning:  nr of args does not " );
      t_3 = MakeString( "match a declaration of " );
      t_5 = GF_NAME__FUNC;
-     t_4 = CALL_1ARGS( t_5, l_opr );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, l_opr );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      t_5 = MakeString( "\n" );
-     CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5 ) );
+     }
      
     }
     /* fi */
@@ -2202,17 +2799,37 @@ static Obj  HdlrFunc6 (
      t_4 = GF_NamesFilter;
      CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_5, l_imp, l_notmatch )
-     t_3 = CALL_1ARGS( t_4, t_5 );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, t_5 );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( "\nfor " );
      t_6 = GF_Ordinal;
-     t_5 = CALL_1ARGS( t_6, l_notmatch );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, l_notmatch );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_notmatch ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      t_6 = MakeString( " argument do not match a declaration of " );
      t_8 = GF_NAME__FUNC;
-     t_7 = CALL_1ARGS( t_8, l_opr );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, l_opr );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, t_6, t_7 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, t_6, t_7 ) );
+     }
      
     }
     
@@ -2227,7 +2844,12 @@ static Obj  HdlrFunc6 (
      SET_ELM_PLIST( t_2, 1, t_3 );
      CHANGED_BAG( t_2 );
      t_4 = GF_NAME__FUNC;
-     t_3 = CALL_1ARGS( t_4, l_opr );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, l_opr );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_opr ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 2, t_3 );
      CHANGED_BAG( t_2 );
@@ -2235,7 +2857,12 @@ static Obj  HdlrFunc6 (
      SET_ELM_PLIST( t_2, 3, t_3 );
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__FILENAME;
-     t_3 = CALL_0ARGS( t_4 );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_0ARGS( t_4 );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 4, t_3 );
      CHANGED_BAG( t_2 );
@@ -2243,7 +2870,12 @@ static Obj  HdlrFunc6 (
      SET_ELM_PLIST( t_2, 5, t_3 );
      CHANGED_BAG( t_2 );
      t_4 = GF_INPUT__LINENUMBER;
-     t_3 = CALL_0ARGS( t_4 );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_0ARGS( t_4 );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      SET_ELM_PLIST( t_2, 6, t_3 );
      CHANGED_BAG( t_2 );
@@ -2253,13 +2885,23 @@ static Obj  HdlrFunc6 (
      t_3 = MakeString( "required filters \03" );
      SET_ELM_PLIST( t_2, 8, t_3 );
      CHANGED_BAG( t_2 );
-     CALL_XARGS( t_1, t_2 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_XARGS( t_1, t_2 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, t_2 );
+     }
      
      /* for j in NamesFilter( imp[notmatch] ) do */
      t_5 = GF_NamesFilter;
      CHECK_INT_POS( l_notmatch );
      C_ELM_LIST_FPL( t_6, l_imp, l_notmatch )
-     t_4 = CALL_1ARGS( t_5, t_6 );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      t_4 = CALL_1ARGS( t_5, t_6 );
+     }
+     else {
+      t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6 ) );
+     }
      CHECK_FUNC_RESULT( t_4 );
      if ( IS_SMALL_LIST(t_4) ) {
       t_3 = (Obj)(UInt)1;
@@ -2285,7 +2927,12 @@ static Obj  HdlrFunc6 (
       /* Print( j, "/\c" ); */
       t_5 = GF_Print;
       t_6 = MakeString( "/\03" );
-      CALL_2ARGS( t_5, l_j, t_6 );
+      if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+       CALL_2ARGS( t_5, l_j, t_6 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_j, t_6 ) );
+      }
       
      }
      /* od */
@@ -2294,11 +2941,21 @@ static Obj  HdlrFunc6 (
      t_1 = GF_Print;
      t_2 = MakeString( " for " );
      t_4 = GF_Ordinal;
-     t_3 = CALL_1ARGS( t_4, l_notmatch );
+     if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+      t_3 = CALL_1ARGS( t_4, l_notmatch );
+     }
+     else {
+      t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_notmatch ) );
+     }
      CHECK_FUNC_RESULT( t_3 );
      t_4 = MakeString( " argument do not match \03a " );
      t_5 = MakeString( "declaration\n" );
-     CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_4ARGS( t_1, t_2, t_3, t_4, t_5 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5 ) );
+     }
      
     }
     /* fi */
@@ -2318,7 +2975,12 @@ static Obj  HdlrFunc6 (
    C_SUM_FIA( t_2, l_j, INTOBJ_INT(1) )
    CHECK_INT_SMALL( t_2 );
    t_4 = GF_LEN__LIST;
-   t_3 = CALL_1ARGS( t_4, l_req );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_1ARGS( t_4, l_req );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_req ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    CHECK_INT_SMALL( t_3 );
    for ( t_1 = t_2;
@@ -2333,10 +2995,20 @@ static Obj  HdlrFunc6 (
     
     /* if LEN_LIST( reqs ) = LEN_LIST( imp ) then */
     t_6 = GF_LEN__LIST;
-    t_5 = CALL_1ARGS( t_6, l_reqs );
+    if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+     t_5 = CALL_1ARGS( t_6, l_reqs );
+    }
+    else {
+     t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_reqs ) );
+    }
     CHECK_FUNC_RESULT( t_5 );
     t_7 = GF_LEN__LIST;
-    t_6 = CALL_1ARGS( t_7, l_imp );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_imp );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_imp ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     t_4 = (Obj)(UInt)(EQ( t_5, t_6 ));
     if ( t_4 ) {
@@ -2347,7 +3019,12 @@ static Obj  HdlrFunc6 (
      
      /* for i in [ 1 .. LEN_LIST( reqs ) ] do */
      t_6 = GF_LEN__LIST;
-     t_5 = CALL_1ARGS( t_6, l_reqs );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, l_reqs );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_reqs ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      CHECK_INT_SMALL( t_5 );
      for ( t_4 = INTOBJ_INT(1);
@@ -2359,7 +3036,12 @@ static Obj  HdlrFunc6 (
       t_9 = GF_IS__SUBSET__FLAGS;
       C_ELM_LIST_FPL( t_10, l_imp, l_i )
       C_ELM_LIST_FPL( t_11, l_reqs, l_i )
-      t_8 = CALL_2ARGS( t_9, t_10, t_11 );
+      if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+       t_8 = CALL_2ARGS( t_9, t_10, t_11 );
+      }
+      else {
+       t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, t_11 ) );
+      }
       CHECK_FUNC_RESULT( t_8 );
       CHECK_BOOL( t_8 );
       t_7 = (Obj)(UInt)(t_8 != False);
@@ -2392,10 +3074,20 @@ static Obj  HdlrFunc6 (
       t_4 = GF_INFO__DEBUG;
       t_5 = MakeString( "method installed for " );
       t_7 = GF_NAME__FUNC;
-      t_6 = CALL_1ARGS( t_7, l_opr );
+      if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+       t_6 = CALL_1ARGS( t_7, l_opr );
+      }
+      else {
+       t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_opr ) );
+      }
       CHECK_FUNC_RESULT( t_6 );
       t_7 = MakeString( " matches more than one declaration" );
-      CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
+      if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+       CALL_4ARGS( t_4, INTOBJ_INT(1), t_5, t_6, t_7 );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( INTOBJ_INT(1), t_5, t_6, t_7 ) );
+      }
       
      }
      /* fi */
@@ -2415,11 +3107,21 @@ static Obj  HdlrFunc6 (
  /* INSTALL_METHOD_FLAGS( opr, info, rel, flags, rank, method ); */
  t_1 = GF_INSTALL__METHOD__FLAGS;
  CHECK_BOUND( l_rank, "rank" );
- CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, l_opr, l_info, l_rel, l_flags, l_rank, l_method );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_opr, l_info, l_rel, l_flags, l_rank, l_method ) );
+ }
  
  /* UNLOCK( lk ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_lk );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_lk );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lk ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -2485,10 +3187,19 @@ static Obj  HdlrFunc8 (
   
   /* if not Tester( prop )( obj ) then */
   t_9 = GF_Tester;
-  t_8 = CALL_1ARGS( t_9, l_prop );
+  if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+   t_8 = CALL_1ARGS( t_9, l_prop );
+  }
+  else {
+   t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( l_prop ) );
+  }
   CHECK_FUNC_RESULT( t_8 );
-  CHECK_FUNC( t_8 );
-  t_7 = CALL_1ARGS( t_8, a_obj );
+  if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+   t_7 = CALL_1ARGS( t_8, a_obj );
+  }
+  else {
+   t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_7 );
   CHECK_BOOL( t_7 );
   t_6 = (Obj)(UInt)(t_7 != False);
@@ -2500,18 +3211,31 @@ static Obj  HdlrFunc8 (
    l_found = t_5;
    
    /* if not (prop( obj ) and Tester( prop )( obj )) then */
-   CHECK_FUNC( l_prop );
-   t_8 = CALL_1ARGS( l_prop, a_obj );
+   if ( TNUM_OBJ( l_prop ) == T_FUNCTION ) {
+    t_8 = CALL_1ARGS( l_prop, a_obj );
+   }
+   else {
+    t_8 = DoOperation2Args( CallFuncListOper, l_prop, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_8 );
    CHECK_BOOL( t_8 );
    t_7 = (Obj)(UInt)(t_8 != False);
    t_6 = t_7;
    if ( t_6 ) {
     t_11 = GF_Tester;
-    t_10 = CALL_1ARGS( t_11, l_prop );
+    if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+     t_10 = CALL_1ARGS( t_11, l_prop );
+    }
+    else {
+     t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( l_prop ) );
+    }
     CHECK_FUNC_RESULT( t_10 );
-    CHECK_FUNC( t_10 );
-    t_9 = CALL_1ARGS( t_10, a_obj );
+    if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+     t_9 = CALL_1ARGS( t_10, a_obj );
+    }
+    else {
+     t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( a_obj ) );
+    }
     CHECK_FUNC_RESULT( t_9 );
     CHECK_BOOL( t_9 );
     t_8 = (Obj)(UInt)(t_9 != False);
@@ -2542,8 +3266,12 @@ static Obj  HdlrFunc8 (
   /* return getter( obj ); */
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "getter" );
-  CHECK_FUNC( t_2 );
-  t_1 = CALL_1ARGS( t_2, a_obj );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_obj );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -2611,7 +3339,12 @@ static Obj  HdlrFunc7 (
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_IS__OBJECT;
  CHECK_BOUND( t_5, "IS_OBJECT" );
- t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_filter, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_filter, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2620,7 +3353,12 @@ static Obj  HdlrFunc7 (
   
   /* flags := FLAGS_FILTER( filter ); */
   t_2 = GF_FLAGS__FILTER;
-  t_1 = CALL_1ARGS( t_2, a_filter );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_filter );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_filter ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_flags = t_1;
   
@@ -2641,13 +3379,23 @@ static Obj  HdlrFunc7 (
   t_2 = GF_READ__LOCK;
   t_3 = GC_FILTER__REGION;
   CHECK_BOUND( t_3, "FILTER_REGION" );
-  t_1 = CALL_1ARGS( t_2, t_3 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, t_3 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_lk = t_1;
   
   /* for i in TRUES_FLAGS( flags ) do */
   t_5 = GF_TRUES__FLAGS;
-  t_4 = CALL_1ARGS( t_5, l_flags );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_flags );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_flags ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   if ( IS_SMALL_LIST(t_4) ) {
    t_3 = (Obj)(UInt)1;
@@ -2708,7 +3456,12 @@ static Obj  HdlrFunc7 (
     t_9 = GC_FILTERS;
     CHECK_BOUND( t_9, "FILTERS" );
     C_ELM_LIST_FPL( t_8, t_9, l_i )
-    t_6 = CALL_1ARGS( t_7, t_8 );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, t_8 );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     C_DIFF_FIA( t_5, l_rank, t_6 )
     l_rank = t_5;
@@ -2732,7 +3485,12 @@ static Obj  HdlrFunc7 (
      t_8 = GC_FILTERS;
      CHECK_BOUND( t_8, "FILTERS" );
      C_ELM_LIST_FPL( t_7, t_8, l_i )
-     CALL_2ARGS( t_5, t_6, t_7 );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_5, t_6, t_7 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6, t_7 ) );
+     }
      
     }
    }
@@ -2743,19 +3501,34 @@ static Obj  HdlrFunc7 (
   
   /* UNLOCK( lk ); */
   t_1 = GF_UNLOCK;
-  CALL_1ARGS( t_1, l_lk );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, l_lk );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lk ) );
+  }
   
   /* MakeImmutable( props ); */
   t_1 = GF_MakeImmutable;
   t_2 = OBJ_LVAR( 2 );
   CHECK_BOUND( t_2, "props" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
   /* if 0 < LEN_LIST( props ) then */
   t_3 = GF_LEN__LIST;
   t_4 = OBJ_LVAR( 2 );
   CHECK_BOUND( t_4, "props" );
-  t_2 = CALL_1ARGS( t_3, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(LT( INTOBJ_INT(0), t_2 ));
   if ( t_1 ) {
@@ -2794,7 +3567,12 @@ static Obj  HdlrFunc7 (
    SET_ENDLINE_BODY(t_7, 689);
    SET_FILENAME_BODY(t_7, FileName);
    SET_BODY_FUNC(t_6, t_7);
-   CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, l_rank, t_6 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, l_rank, t_6 ) );
+   }
    
   }
   /* fi */
@@ -2847,7 +3625,12 @@ static Obj  HdlrFunc9 (
  CHANGED_BAG( t_4 );
  t_5 = GC_DO__NOTHING__SETTER;
  CHECK_BOUND( t_5, "DO_NOTHING_SETTER" );
- CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -2883,7 +3666,12 @@ static Obj  HdlrFunc10 (
  
  /* k := LEN_LIST( list ) + 1; */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_list );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_list );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_list ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_k = t_1;
@@ -2913,7 +3701,12 @@ static Obj  HdlrFunc10 (
   t_4 = GF_QUO__INT;
   C_SUM_FIA( t_6, l_i, l_k )
   C_SUM_FIA( t_5, t_6, INTOBJ_INT(2) )
-  t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_2ARGS( t_4, t_5, INTOBJ_INT(4) );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5, INTOBJ_INT(4) ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   C_PROD_FIA( t_2, INTOBJ_INT(2), t_3 )
   C_DIFF_FIA( t_1, t_2, INTOBJ_INT(1) )
@@ -2967,7 +3760,12 @@ static Obj  HdlrFunc12 (
  
  /* if not IsPrimeInt( key ) then */
  t_4 = GF_IsPrimeInt;
- t_3 = CALL_1ARGS( t_4, a_key );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_key );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_key ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2979,7 +3777,12 @@ static Obj  HdlrFunc12 (
   t_2 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_2, "name" );
   t_3 = MakeString( ": <p> must be a prime" );
-  CALL_2ARGS( t_1, t_2, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, t_2, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+  }
   
  }
  /* fi */
@@ -3040,26 +3843,44 @@ static Obj  HdlrFunc14 (
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
- CALL_1ARGS( t_1, a_key );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, a_key );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_key ) );
+ }
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
- t_1 = CALL_1ARGS( t_2, a_D );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_D );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
- t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_known );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_known );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
@@ -3074,20 +3895,34 @@ static Obj  HdlrFunc14 (
   /* erg := oper( D, key ); */
   t_2 = OBJ_HVAR( (1 << 16) | 3 );
   CHECK_BOUND( t_2, "oper" );
-  CHECK_FUNC( t_2 );
-  t_1 = CALL_2ARGS( t_2, a_D, a_key );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, a_D, a_key );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D, a_key ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_erg = t_1;
   
   /* i := PositionSortedOddPositions( known, key ); */
   t_2 = GF_PositionSortedOddPositions;
-  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, l_known, a_key );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_i = t_1;
   
   /* if LEN_LIST( known ) < i or known[i] <> key then */
   t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, l_known );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, l_known );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = (Obj)(UInt)(LT( t_3, l_i ));
   t_1 = t_2;
@@ -3102,12 +3937,22 @@ static Obj  HdlrFunc14 (
    /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
    C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
    t_5 = GF_LEN__LIST;
-   t_4 = CALL_1ARGS( t_5, l_known );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, l_known );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
    C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
    t_1 = Range2Check( t_2, t_3 );
    t_5 = GF_LEN__LIST;
-   t_4 = CALL_1ARGS( t_5, l_known );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, l_known );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
    t_3 = Range2Check( l_i, t_4 );
    t_2 = ElmsListCheck( l_known, t_3 );
@@ -3116,7 +3961,12 @@ static Obj  HdlrFunc14 (
    /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
    CHECK_INT_POS( l_i );
    t_2 = GF_IMMUTABLE__COPY__OBJ;
-   t_1 = CALL_1ARGS( t_2, a_key );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_1ARGS( t_2, a_key );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_key ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    C_ASS_LIST_FPL( l_known, l_i, t_1 )
    
@@ -3124,7 +3974,12 @@ static Obj  HdlrFunc14 (
    C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
    CHECK_INT_POS( t_1 );
    t_3 = GF_IMMUTABLE__COPY__OBJ;
-   t_2 = CALL_1ARGS( t_3, l_erg );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, l_erg );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_erg ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    C_ASS_LIST_FPL( l_known, t_1, t_2 )
    
@@ -3169,26 +4024,44 @@ static Obj  HdlrFunc15 (
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
- CALL_1ARGS( t_1, a_key );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, a_key );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_key ) );
+ }
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
- t_1 = CALL_1ARGS( t_2, a_D );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_D );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
- t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* return i <= LEN_LIST( known ) and known[i] = key; */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_known );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_known );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = (LT( t_3, l_i ) ?  False : True);
  if ( t_2 == False ) {
@@ -3241,26 +4114,44 @@ static Obj  HdlrFunc16 (
  /* keytest( key ); */
  t_1 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_1, "keytest" );
- CHECK_FUNC( t_1 );
- CALL_1ARGS( t_1, a_key );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, a_key );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_key ) );
+ }
  
  /* known := attr( D ); */
  t_2 = OBJ_HVAR( (1 << 16) | 4 );
  CHECK_BOUND( t_2, "attr" );
- CHECK_FUNC( t_2 );
- t_1 = CALL_1ARGS( t_2, a_D );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_D );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_D ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_known = t_1;
  
  /* i := PositionSortedOddPositions( known, key ); */
  t_2 = GF_PositionSortedOddPositions;
- t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_known, a_key );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_known, a_key ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_i = t_1;
  
  /* if LEN_LIST( known ) < i or known[i] <> key then */
  t_4 = GF_LEN__LIST;
- t_3 = CALL_1ARGS( t_4, l_known );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, l_known );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_known ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_2 = (Obj)(UInt)(LT( t_3, l_i ));
  t_1 = t_2;
@@ -3275,12 +4166,22 @@ static Obj  HdlrFunc16 (
   /* known{[ i + 2 .. LEN_LIST( known ) + 2 ]} := known{[ i .. LEN_LIST( known ) ]}; */
   C_SUM_FIA( t_2, l_i, INTOBJ_INT(2) )
   t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_known );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_known );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   C_SUM_FIA( t_3, t_4, INTOBJ_INT(2) )
   t_1 = Range2Check( t_2, t_3 );
   t_5 = GF_LEN__LIST;
-  t_4 = CALL_1ARGS( t_5, l_known );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, l_known );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_known ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
   t_3 = Range2Check( l_i, t_4 );
   t_2 = ElmsListCheck( l_known, t_3 );
@@ -3289,7 +4190,12 @@ static Obj  HdlrFunc16 (
   /* known[i] := IMMUTABLE_COPY_OBJ( key ); */
   CHECK_INT_POS( l_i );
   t_2 = GF_IMMUTABLE__COPY__OBJ;
-  t_1 = CALL_1ARGS( t_2, a_key );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_1ARGS( t_2, a_key );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_key ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   C_ASS_LIST_FPL( l_known, l_i, t_1 )
   
@@ -3297,7 +4203,12 @@ static Obj  HdlrFunc16 (
   C_SUM_FIA( t_1, l_i, INTOBJ_INT(1) )
   CHECK_INT_POS( t_1 );
   t_3 = GF_IMMUTABLE__COPY__OBJ;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   C_ASS_LIST_FPL( l_known, t_1, t_2 )
   
@@ -3369,14 +4280,24 @@ static Obj  HdlrFunc11 (
  t_2 = GF_SHALLOW__COPY__OBJ;
  t_3 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_3, "name" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_str = t_1;
  
  /* APPEND_LIST_INTR( str, "Op" ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = MakeString( "Op" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
@@ -3386,11 +4307,21 @@ static Obj  HdlrFunc11 (
  CHANGED_BAG( t_2 );
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* oper := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
- t_1 = CALL_1ARGS( t_2, l_str );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, l_str );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 3, t_1 );
  
@@ -3402,21 +4333,41 @@ static Obj  HdlrFunc11 (
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_2, "name" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* APPEND_LIST_INTR( str, "s" ); */
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = MakeString( "s" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareAttribute( str, domreq, "mutable" ); */
  t_1 = GF_DeclareAttribute;
  t_2 = MakeString( "mutable" );
- CALL_3ARGS( t_1, l_str, a_domreq, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, l_str, a_domreq, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, a_domreq, t_2 ) );
+ }
  
  /* attr := VALUE_GLOBAL( str ); */
  t_2 = GF_VALUE__GLOBAL;
- t_1 = CALL_1ARGS( t_2, l_str );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, l_str );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  ASS_LVAR( 4, t_1 );
  
@@ -3439,7 +4390,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 889);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* DeclareOperation( name, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
@@ -3451,13 +4407,23 @@ static Obj  HdlrFunc11 (
  CHANGED_BAG( t_3 );
  SET_ELM_PLIST( t_3, 2, a_keyreq );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* lk := WRITE_LOCK( OPERATIONS_REGION ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_OPERATIONS__REGION;
  CHECK_BOUND( t_3, "OPERATIONS_REGION" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_lk = t_1;
  
@@ -3468,13 +4434,28 @@ static Obj  HdlrFunc11 (
  t_4 = GF_VALUE__GLOBAL;
  t_5 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_5, "name" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* UNLOCK( lk ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_lk );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_lk );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lk ) );
+ }
  
  /* InstallOtherMethod( VALUE_GLOBAL( name ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
       local known, i, erg;
@@ -3496,7 +4477,12 @@ static Obj  HdlrFunc11 (
  t_3 = GF_VALUE__GLOBAL;
  t_4 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_4, "name" );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
@@ -3513,7 +4499,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 934);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* str := "Has"; */
  t_1 = MakeString( "Has" );
@@ -3523,7 +4514,12 @@ static Obj  HdlrFunc11 (
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_2, "name" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareOperation( str, [ domreq, keyreq ] ); */
  t_1 = GF_DeclareOperation;
@@ -3533,7 +4529,12 @@ static Obj  HdlrFunc11 (
  CHANGED_BAG( t_2 );
  SET_ELM_PLIST( t_2, 2, a_keyreq );
  CHANGED_BAG( t_2 );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq ], 0, function ( D, key )
       local known, i;
@@ -3544,7 +4545,12 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
- t_2 = CALL_1ARGS( t_3, l_str );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_str );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
@@ -3561,7 +4567,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 952);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* str := "Set"; */
  t_1 = MakeString( "Set" );
@@ -3571,7 +4582,12 @@ static Obj  HdlrFunc11 (
  t_1 = GF_APPEND__LIST__INTR;
  t_2 = OBJ_LVAR( 1 );
  CHECK_BOUND( t_2, "name" );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* DeclareOperation( str, [ domreq, keyreq, IS_OBJECT ] ); */
  t_1 = GF_DeclareOperation;
@@ -3585,7 +4601,12 @@ static Obj  HdlrFunc11 (
  CHECK_BOUND( t_3, "IS_OBJECT" );
  SET_ELM_PLIST( t_2, 3, t_3 );
  CHANGED_BAG( t_2 );
- CALL_2ARGS( t_1, l_str, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_str, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_str, t_2 ) );
+ }
  
  /* InstallOtherMethod( VALUE_GLOBAL( str ), "default method", true, [ domreq, keyreq, IS_OBJECT ], 0, function ( D, key, obj )
       local known, i;
@@ -3601,7 +4622,12 @@ static Obj  HdlrFunc11 (
   end ); */
  t_1 = GF_InstallOtherMethod;
  t_3 = GF_VALUE__GLOBAL;
- t_2 = CALL_1ARGS( t_3, l_str );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, l_str );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_str ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "default method" );
  t_4 = True;
@@ -3622,7 +4648,12 @@ static Obj  HdlrFunc11 (
  SET_ENDLINE_BODY(t_7, 974);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -3669,7 +4700,12 @@ static Obj  HdlrFunc18 (
  t_6 = GF_LEN__LIST;
  t_7 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_7, "reqs" );
- t_5 = CALL_1ARGS( t_6, t_7 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_4 = Range2Check( INTOBJ_INT(1), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
@@ -3716,14 +4752,23 @@ static Obj  HdlrFunc18 (
     CHECK_BOUND( t_18, "i" );
     CHECK_INT_POS( t_18 );
     C_ELM_LIST_FPL( t_16, t_17, t_18 )
-    t_14 = CALL_1ARGS( t_15, t_16 );
+    if ( TNUM_OBJ( t_15 ) == T_FUNCTION ) {
+     t_14 = CALL_1ARGS( t_15, t_16 );
+    }
+    else {
+     t_14 = DoOperation2Args( CallFuncListOper, t_15, NewPlistFromArgs( t_16 ) );
+    }
     CHECK_FUNC_RESULT( t_14 );
-    CHECK_FUNC( t_14 );
     t_16 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_16, "i" );
     CHECK_INT_POS( t_16 );
     C_ELM_LIST_FPL( t_15, a_arg, t_16 )
-    t_13 = CALL_1ARGS( t_14, t_15 );
+    if ( TNUM_OBJ( t_14 ) == T_FUNCTION ) {
+     t_13 = CALL_1ARGS( t_14, t_15 );
+    }
+    else {
+     t_13 = DoOperation2Args( CallFuncListOper, t_14, NewPlistFromArgs( t_15 ) );
+    }
     CHECK_FUNC_RESULT( t_13 );
     CHECK_BOOL( t_13 );
     t_12 = (Obj)(UInt)(t_13 != False);
@@ -3738,12 +4783,16 @@ static Obj  HdlrFunc18 (
     CHECK_BOUND( t_14, "i" );
     CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_12, t_13, t_14 )
-    CHECK_FUNC( t_12 );
     t_14 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_14, "i" );
     CHECK_INT_POS( t_14 );
     C_ELM_LIST_FPL( t_13, a_arg, t_14 )
-    t_11 = CALL_1ARGS( t_12, t_13 );
+    if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+     t_11 = CALL_1ARGS( t_12, t_13 );
+    }
+    else {
+     t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13 ) );
+    }
     CHECK_FUNC_RESULT( t_11 );
     CHECK_BOOL( t_11 );
     t_10 = (Obj)(UInt)(t_11 != False);
@@ -3758,14 +4807,23 @@ static Obj  HdlrFunc18 (
     CHECK_BOUND( t_15, "i" );
     CHECK_INT_POS( t_15 );
     C_ELM_LIST_FPL( t_13, t_14, t_15 )
-    t_11 = CALL_1ARGS( t_12, t_13 );
+    if ( TNUM_OBJ( t_12 ) == T_FUNCTION ) {
+     t_11 = CALL_1ARGS( t_12, t_13 );
+    }
+    else {
+     t_11 = DoOperation2Args( CallFuncListOper, t_12, NewPlistFromArgs( t_13 ) );
+    }
     CHECK_FUNC_RESULT( t_11 );
-    CHECK_FUNC( t_11 );
     t_13 = OBJ_HVAR( (1 << 16) | 5 );
     CHECK_BOUND( t_13, "i" );
     CHECK_INT_POS( t_13 );
     C_ELM_LIST_FPL( t_12, a_arg, t_13 )
-    t_10 = CALL_1ARGS( t_11, t_12 );
+    if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+     t_10 = CALL_1ARGS( t_11, t_12 );
+    }
+    else {
+     t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( t_12 ) );
+    }
     CHECK_FUNC_RESULT( t_10 );
     CHECK_BOOL( t_10 );
     t_9 = (Obj)(UInt)(t_10 != False);
@@ -3789,7 +4847,12 @@ static Obj  HdlrFunc18 (
   t_2 = GF_CallFuncList;
   t_3 = OBJ_HVAR( (1 << 16) | 1 );
   CHECK_BOUND( t_3, "oper" );
-  t_1 = CALL_2ARGS( t_2, t_3, a_arg );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, a_arg );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -3844,7 +4907,12 @@ static Obj  HdlrFunc17 (
  
  /* if LEN_LIST( arg ) = 5 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(5) ));
  if ( t_1 ) {
@@ -3878,7 +4946,12 @@ static Obj  HdlrFunc17 (
  /* elif LEN_LIST( arg ) = 6 then */
  else {
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_arg );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_arg );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(6) ));
   if ( t_1 ) {
@@ -3915,7 +4988,12 @@ static Obj  HdlrFunc17 (
    /* Error( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" ); */
    t_1 = GF_Error;
    t_2 = MakeString( "Usage: RedispatchOnCondition(oper[,info],fampred,reqs,cond,val)" );
-   CALL_1ARGS( t_1, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_1ARGS( t_1, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+   }
    
   }
  }
@@ -3950,7 +5028,12 @@ static Obj  HdlrFunc17 (
   t_7 = GF_RankFilter;
   t_8 = OBJ_LVAR( 5 );
   CHECK_BOUND( t_8, "i" );
-  t_6 = CALL_1ARGS( t_7, t_8 );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, t_8 );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, l_val, t_6 )
   l_val = t_5;
@@ -3984,7 +5067,12 @@ static Obj  HdlrFunc17 (
  SET_ENDLINE_BODY(t_5, 1056);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
- CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, l_info, l_fampred, t_3, l_val, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, l_info, l_fampred, t_3, l_val, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -4080,16 +5168,31 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 127);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "METHODS_OPERATION_REGION", NewSpecialRegion( "operation methods" ) ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "METHODS_OPERATION_REGION" );
  t_4 = GF_NewSpecialRegion;
  t_5 = MakeString( "operation methods" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "INSTALL_METHOD_FLAGS", function ( opr, info, rel, flags, baserank, method )
       local methods, narg, i, k, tmp, replace, match, j, lk, rank;
@@ -4200,7 +5303,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 289);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "InstallMethod", function ( arg... )
       INSTALL_METHOD( arg, true );
@@ -4215,7 +5323,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 340);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "InstallOtherMethod", function ( arg... )
       INSTALL_METHOD( arg, false );
@@ -4230,12 +5343,22 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 367);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* DeclareGlobalFunction( "EvalString" ); */
  t_1 = GF_DeclareGlobalFunction;
  t_2 = MakeString( "EvalString" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( INSTALL_METHOD ); */
  AssGVar( G_INSTALL__METHOD, 0 );
@@ -4399,7 +5522,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 610);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
@@ -4457,7 +5585,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 693);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* InstallAttributeFunction( function ( name, filter, getter, setter, tester, mutflag )
       InstallOtherMethod( setter, "default method, does nothing", true, [ IS_OBJECT, IS_OBJECT ], 0, DO_NOTHING_SETTER );
@@ -4471,7 +5604,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 702);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* BIND_GLOBAL( "PositionSortedOddPositions", function ( list, elm )
       local i, j, k;
@@ -4499,7 +5637,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 739);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* IsPrimeInt := "2b defined"; */
  t_1 = MakeString( "2b defined" );
@@ -4583,7 +5726,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 975);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CallFuncList := "2b defined"; */
  t_1 = MakeString( "2b defined" );
@@ -4634,7 +5782,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 1057);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* InstallMethod( ViewObj, "default method using `PrintObj'", true, [ IS_OBJECT ], 0, PRINT_OBJ ); */
  t_1 = GF_InstallMethod;
@@ -4650,7 +5803,12 @@ static Obj  HdlrFunc1 (
  CHANGED_BAG( t_5 );
  t_6 = GC_PRINT__OBJ;
  CHECK_BOUND( t_6, "PRINT_OBJ" );
- CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4, t_5, INTOBJ_INT(0), t_6 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -275,9 +275,19 @@ static Obj  HdlrFunc2 (
  t_5 = GC_GETTER__FLAGS;
  CHECK_BOUND( t_5, "GETTER_FLAGS" );
  t_7 = GF_GETTER__FUNCTION;
- t_6 = CALL_1ARGS( t_7, a_name );
+ if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+  t_6 = CALL_1ARGS( t_7, a_name );
+ }
+ else {
+  t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_name ) );
+ }
  CHECK_FUNC_RESULT( t_6 );
- CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_getter, t_2, t_3, t_4, t_5, t_6 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -310,7 +320,12 @@ static Obj  HdlrFunc4 (
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_HVAR( (1 << 16) | 2 );
  CHECK_BOUND( t_2, "tester" );
- CALL_2ARGS( t_1, a_obj, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, a_obj, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -377,7 +392,12 @@ static Obj  HdlrFunc3 (
   SET_ENDLINE_BODY(t_6, 43);
   SET_FILENAME_BODY(t_6, FileName);
   SET_BODY_FUNC(t_5, t_6);
-  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 ) );
+  }
   
  }
  
@@ -403,9 +423,19 @@ static Obj  HdlrFunc3 (
   CHECK_BOUND( t_7, "name" );
   t_8 = OBJ_LVAR( 2 );
   CHECK_BOUND( t_8, "tester" );
-  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
-  CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 ) );
+  }
   
  }
  /* fi */
@@ -451,9 +481,19 @@ static Obj  HdlrFunc5 (
  /* imp_filter := WITH_IMPS_FLAGS( AND_FLAGS( imp_filter, req_filter ) ); */
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
- t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_imp__filter, a_req__filter ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  a_imp__filter = t_1;
  
@@ -461,7 +501,12 @@ static Obj  HdlrFunc5 (
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
  CHECK_BOUND( t_3, "IsAttributeStoringRep" );
- t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
@@ -469,7 +514,12 @@ static Obj  HdlrFunc5 (
  t_2 = GF_READ__LOCK;
  t_3 = GC_CATEGORIES__FAMILY;
  CHECK_BOUND( t_3, "CATEGORIES_FAMILY" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
@@ -500,7 +550,12 @@ static Obj  HdlrFunc5 (
   /* if IS_SUBSET_FLAGS( imp_filter, pair[1] ) then */
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
-  t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_imp__filter, t_8 ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
@@ -509,7 +564,12 @@ static Obj  HdlrFunc5 (
    /* type := Subtype( type, pair[2] ); */
    t_6 = GF_Subtype;
    C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
-   t_5 = CALL_2ARGS( t_6, l_type, t_7 );
+   if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
+   }
+   else {
+    t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_type, t_7 ) );
+   }
    CHECK_FUNC_RESULT( t_5 );
    l_type = t_5;
    
@@ -521,21 +581,41 @@ static Obj  HdlrFunc5 (
  
  /* UNLOCK( lock ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_lock );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_lock );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lock ) );
+ }
  
  /* family := AtomicRecord(  ); */
  t_2 = GF_AtomicRecord;
- t_1 = CALL_0ARGS( t_2 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_0ARGS( t_2 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_family = t_1;
  
  /* SET_TYPE_COMOBJ( family, type ); */
  t_1 = GF_SET__TYPE__COMOBJ;
- CALL_2ARGS( t_1, l_family, l_type );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_family, l_type );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_family, l_type ) );
+ }
  
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
- t_1 = CALL_1ARGS( t_2, a_name );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_name );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_name ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_NAME, t_1 );
  
@@ -555,7 +635,12 @@ static Obj  HdlrFunc5 (
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_DS__TYPE__CACHE;
  CHECK_BOUND( t_3, "DS_TYPE_CACHE" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
@@ -565,20 +650,40 @@ static Obj  HdlrFunc5 (
  SET_LEN_PLIST( t_3, 0 );
  t_4 = GC_DS__TYPE__CACHE;
  CHECK_BOUND( t_4, "DS_TYPE_CACHE" );
- t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_TYPES, t_1 );
  
  /* UNLOCK( lock ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_lock );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_lock );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lock ) );
+ }
  
  /* family!.TYPES_LIST_FAM := MakeWriteOnceAtomic( AtomicList( 27 ) ); */
  t_2 = GF_MakeWriteOnceAtomic;
  t_4 = GF_AtomicList;
- t_3 = CALL_1ARGS( t_4, INTOBJ_INT(27) );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, INTOBJ_INT(27) );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( INTOBJ_INT(27) ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_TYPES__LIST__FAM, t_1 );
  
@@ -612,7 +717,12 @@ static Obj  HdlrFunc6 (
  CHECK_BOUND( t_3, "EMPTY_FLAGS" );
  t_4 = GC_EMPTY__FLAGS;
  CHECK_BOUND( t_4, "EMPTY_FLAGS" );
- t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, a_name, t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -641,11 +751,21 @@ static Obj  HdlrFunc7 (
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
- t_3 = CALL_1ARGS( t_4, a_req );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_req );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_req ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_EMPTY__FLAGS;
  CHECK_BOUND( t_4, "EMPTY_FLAGS" );
- t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, a_name, t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -676,12 +796,27 @@ static Obj  HdlrFunc8 (
  /* return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
- t_3 = CALL_1ARGS( t_4, a_req );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_req );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_req ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
- t_4 = CALL_1ARGS( t_5, a_imp );
+ if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+  t_4 = CALL_1ARGS( t_5, a_imp );
+ }
+ else {
+  t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_imp ) );
+ }
  CHECK_FUNC_RESULT( t_4 );
- t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfFamilies, a_name, t_3, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -714,15 +849,35 @@ static Obj  HdlrFunc9 (
  /* return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) ); */
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
- t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_typeOfFamilies, a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
- t_4 = CALL_1ARGS( t_5, a_req );
+ if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+  t_4 = CALL_1ARGS( t_5, a_req );
+ }
+ else {
+  t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_req ) );
+ }
  CHECK_FUNC_RESULT( t_4 );
  t_6 = GF_FLAGS__FILTER;
- t_5 = CALL_1ARGS( t_6, a_imp );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, a_imp );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( a_imp ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, a_name, t_4, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -751,7 +906,12 @@ static Obj  HdlrFunc10 (
  
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
@@ -761,7 +921,12 @@ static Obj  HdlrFunc10 (
   t_3 = GC_TypeOfFamilies;
   CHECK_BOUND( t_3, "TypeOfFamilies" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
-  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -771,7 +936,12 @@ static Obj  HdlrFunc10 (
  /* elif LEN_LIST( arg ) = 2 then */
  else {
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_arg );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_arg );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
@@ -782,7 +952,12 @@ static Obj  HdlrFunc10 (
    CHECK_BOUND( t_3, "TypeOfFamilies" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
-   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
@@ -792,7 +967,12 @@ static Obj  HdlrFunc10 (
   /* elif LEN_LIST( arg ) = 3 then */
   else {
    t_3 = GF_LEN__LIST;
-   t_2 = CALL_1ARGS( t_3, a_arg );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_arg );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
@@ -804,7 +984,12 @@ static Obj  HdlrFunc10 (
     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
-    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+    if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+    }
+    else {
+     t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6 ) );
+    }
     CHECK_FUNC_RESULT( t_1 );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
@@ -814,7 +999,12 @@ static Obj  HdlrFunc10 (
    /* elif LEN_LIST( arg ) = 4 then */
    else {
     t_3 = GF_LEN__LIST;
-    t_2 = CALL_1ARGS( t_3, a_arg );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_arg );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
@@ -827,7 +1017,12 @@ static Obj  HdlrFunc10 (
      C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
      C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
-     t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
+     if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
+     }
+     else {
+      t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_1 );
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
@@ -840,7 +1035,12 @@ static Obj  HdlrFunc10 (
      /* Error( "usage: NewFamily( <name> [, <req> [, <imp> [, <famfilter> ] ] ] )" ); */
      t_1 = GF_Error;
      t_2 = MakeString( "usage: NewFamily( <name> [, <req> [, <imp> [, <famfilter> ] ] ] )" );
-     CALL_1ARGS( t_1, t_2 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_1ARGS( t_1, t_2 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+     }
      
     }
    }
@@ -905,7 +1105,12 @@ static Obj  HdlrFunc11 (
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_DS__TYPE__CACHE;
  CHECK_BOUND( t_3, "DS_TYPE_CACHE" );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
@@ -915,7 +1120,12 @@ static Obj  HdlrFunc11 (
  
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
- t_3 = CALL_1ARGS( t_4, a_flags );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_flags );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_flags ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = ElmComObj( a_family, R_HASH__SIZE );
  t_2 = MOD( t_3, t_4 );
@@ -935,7 +1145,12 @@ static Obj  HdlrFunc11 (
   /* if IS_EQUAL_FLAGS( flags, cached![2] ) then */
   t_3 = GF_IS__EQUAL__FLAGS;
   t_4 = ElmPosObj( l_cached, 2 );
-  t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_flags, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -948,7 +1163,12 @@ static Obj  HdlrFunc11 (
    /* if IS_IDENTICAL_OBJ( data, cached![3] ) and IS_IDENTICAL_OBJ( typeOfTypes, TYPE_OBJ( cached ) ) then */
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_5 = ElmPosObj( l_cached, 3 );
-   t_3 = CALL_2ARGS( t_4, a_data, t_5 );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_data, t_5 ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
    CHECK_BOOL( t_3 );
    t_2 = (Obj)(UInt)(t_3 != False);
@@ -956,9 +1176,19 @@ static Obj  HdlrFunc11 (
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
-    t_6 = CALL_1ARGS( t_7, l_cached );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, l_cached );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_cached ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
-    t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
+    }
+    else {
+     t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_typeOfTypes, t_6 ) );
+    }
     CHECK_FUNC_RESULT( t_4 );
     CHECK_BOOL( t_4 );
     t_3 = (Obj)(UInt)(t_4 != False);
@@ -970,7 +1200,12 @@ static Obj  HdlrFunc11 (
     t_3 = GF_IS__IDENTICAL__OBJ;
     t_4 = GC_fail;
     CHECK_BOUND( t_4, "fail" );
-    t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent, t_4 ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
@@ -982,7 +1217,12 @@ static Obj  HdlrFunc11 (
      
      /* for i in [ 5 .. LEN_POSOBJ( cached ) ] do */
      t_3 = GF_LEN__POSOBJ;
-     t_2 = CALL_1ARGS( t_3, l_cached );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      t_2 = CALL_1ARGS( t_3, l_cached );
+     }
+     else {
+      t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_cached ) );
+     }
      CHECK_FUNC_RESULT( t_2 );
      CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
@@ -1020,7 +1260,12 @@ static Obj  HdlrFunc11 (
       
       /* UNLOCK( lock ); */
       t_1 = GF_UNLOCK;
-      CALL_1ARGS( t_1, l_lock );
+      if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+       CALL_1ARGS( t_1, l_lock );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lock ) );
+      }
       
       /* return cached; */
       SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1034,10 +1279,20 @@ static Obj  HdlrFunc11 (
     
     /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
     t_3 = GF_LEN__POSOBJ;
-    t_2 = CALL_1ARGS( t_3, a_parent );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_1ARGS( t_3, a_parent );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     t_4 = GF_LEN__POSOBJ;
-    t_3 = CALL_1ARGS( t_4, l_cached );
+    if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+     t_3 = CALL_1ARGS( t_4, l_cached );
+    }
+    else {
+     t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_cached ) );
+    }
     CHECK_FUNC_RESULT( t_3 );
     t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
     if ( t_1 ) {
@@ -1048,7 +1303,12 @@ static Obj  HdlrFunc11 (
      
      /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
      t_3 = GF_LEN__POSOBJ;
-     t_2 = CALL_1ARGS( t_3, a_parent );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      t_2 = CALL_1ARGS( t_3, a_parent );
+     }
+     else {
+      t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent ) );
+     }
      CHECK_FUNC_RESULT( t_2 );
      CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
@@ -1086,7 +1346,12 @@ static Obj  HdlrFunc11 (
        t_8 = GF_IS__IDENTICAL__OBJ;
        t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
        t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
-       t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+       if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+       }
+       else {
+        t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9, t_10 ) );
+       }
        CHECK_FUNC_RESULT( t_7 );
        CHECK_BOOL( t_7 );
        t_6 = (Obj)(UInt)(t_7 != False);
@@ -1120,7 +1385,12 @@ static Obj  HdlrFunc11 (
       
       /* UNLOCK( lock ); */
       t_1 = GF_UNLOCK;
-      CALL_1ARGS( t_1, l_lock );
+      if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+       CALL_1ARGS( t_1, l_lock );
+      }
+      else {
+       DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lock ) );
+      }
       
       /* return cached; */
       SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1164,15 +1434,30 @@ static Obj  HdlrFunc11 (
   /* GASMAN( "collect" ); */
   t_1 = GF_GASMAN;
   t_2 = MakeString( "collect" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
   /* FLUSH_ALL_METHOD_CACHES(  ); */
   t_1 = GF_FLUSH__ALL__METHOD__CACHES;
-  CALL_0ARGS( t_1 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_0ARGS( t_1 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+  }
   
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
-  t_1 = CALL_0ARGS( t_2 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_0ARGS( t_2 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
@@ -1190,7 +1475,12 @@ static Obj  HdlrFunc11 (
  
  /* data := MakeReadOnlyObj( data ); */
  t_2 = GF_MakeReadOnlyObj;
- t_1 = CALL_1ARGS( t_2, a_data );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_data );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_data ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  a_data = t_1;
  
@@ -1206,7 +1496,12 @@ static Obj  HdlrFunc11 (
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_fail;
  CHECK_BOUND( t_5, "fail" );
- t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_parent, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1215,7 +1510,12 @@ static Obj  HdlrFunc11 (
   
   /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
   t_3 = GF_LEN__POSOBJ;
-  t_2 = CALL_1ARGS( t_3, a_parent );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_parent );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_parent ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(5);
@@ -1250,7 +1550,12 @@ static Obj  HdlrFunc11 (
  
  /* SET_TYPE_POSOBJ( type, typeOfTypes ); */
  t_1 = GF_SET__TYPE__POSOBJ;
- CALL_2ARGS( t_1, l_type, a_typeOfTypes );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_type, a_typeOfTypes );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type, a_typeOfTypes ) );
+ }
  
  /* if 3 * family!.nTYPES > family!.HASH_SIZE then */
  t_3 = ElmComObj( a_family, R_nTYPES );
@@ -1268,7 +1573,12 @@ static Obj  HdlrFunc11 (
   t_1 = GF_MIGRATE__RAW;
   t_2 = GC_DS__TYPE__CACHE;
   CHECK_BOUND( t_2, "DS_TYPE_CACHE" );
-  CALL_2ARGS( t_1, l_ncache, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_ncache, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_ncache, t_2 ) );
+  }
   
   /* ncl := 3 * family!.HASH_SIZE + 1; */
   t_3 = ElmComObj( a_family, R_HASH__SIZE );
@@ -1302,7 +1612,12 @@ static Obj  HdlrFunc11 (
    /* ncache[HASH_FLAGS( t![2] ) mod ncl + 1] := t; */
    t_8 = GF_HASH__FLAGS;
    t_9 = ElmPosObj( l_t, 2 );
-   t_7 = CALL_1ARGS( t_8, t_9 );
+   if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+    t_7 = CALL_1ARGS( t_8, t_9 );
+   }
+   else {
+    t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+   }
    CHECK_FUNC_RESULT( t_7 );
    t_6 = MOD( t_7, l_ncl );
    C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
@@ -1320,7 +1635,12 @@ static Obj  HdlrFunc11 (
   
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
-  t_3 = CALL_1ARGS( t_4, a_flags );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, a_flags );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_flags ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = MOD( t_3, l_ncl );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
@@ -1345,11 +1665,21 @@ static Obj  HdlrFunc11 (
  
  /* MakeReadOnlySingleObj( type ); */
  t_1 = GF_MakeReadOnlySingleObj;
- CALL_1ARGS( t_1, l_type );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_type );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type ) );
+ }
  
  /* UNLOCK( lock ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_lock );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_lock );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_lock ) );
+ }
  
  /* return type; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1387,17 +1717,37 @@ static Obj  HdlrFunc12 (
  t_6 = GF_AND__FLAGS;
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" );
  t_5 = GC_fail;
  CHECK_BOUND( t_5, "fail" );
- t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfTypes, a_family, t_3, t_4, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1435,15 +1785,35 @@ static Obj  HdlrFunc13 (
  t_6 = GF_AND__FLAGS;
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
  CHECK_BOUND( t_4, "fail" );
- t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_typeOfTypes, a_family, t_3, a_data, t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1474,7 +1844,12 @@ static Obj  HdlrFunc14 (
  /* if not IsFamily( arg[1] ) then */
  t_4 = GF_IsFamily;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1484,14 +1859,24 @@ static Obj  HdlrFunc14 (
   /* Error( "<family> must be a family" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<family> must be a family" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
@@ -1502,7 +1887,12 @@ static Obj  HdlrFunc14 (
   CHECK_BOUND( t_3, "TypeOfTypes" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
-  t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
@@ -1511,7 +1901,12 @@ static Obj  HdlrFunc14 (
  /* elif LEN_LIST( arg ) = 3 then */
  else {
   t_3 = GF_LEN__LIST;
-  t_2 = CALL_1ARGS( t_3, a_arg );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_arg );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
@@ -1523,7 +1918,12 @@ static Obj  HdlrFunc14 (
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
-   t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    l_type = t_1;
    
@@ -1535,7 +1935,12 @@ static Obj  HdlrFunc14 (
    /* Error( "usage: NewType( <family>, <filter> [, <data> ] )" ); */
    t_1 = GF_Error;
    t_2 = MakeString( "usage: NewType( <family>, <filter> [, <data> ] )" );
-   CALL_1ARGS( t_1, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_1ARGS( t_1, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+   }
    
   }
  }
@@ -1582,14 +1987,34 @@ static Obj  HdlrFunc15 (
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
- t_10 = CALL_1ARGS( t_11, a_filter );
+ if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+  t_10 = CALL_1ARGS( t_11, a_filter );
+ }
+ else {
+  t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_10 );
- t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ }
+ else {
+  t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9, t_10 ) );
+ }
  CHECK_FUNC_RESULT( t_7 );
- t_5 = CALL_1ARGS( t_6, t_7 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1631,13 +2056,33 @@ static Obj  HdlrFunc16 (
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
- t_10 = CALL_1ARGS( t_11, a_filter );
+ if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+  t_10 = CALL_1ARGS( t_11, a_filter );
+ }
+ else {
+  t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_10 );
- t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
+ }
+ else {
+  t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9, t_10 ) );
+ }
  CHECK_FUNC_RESULT( t_7 );
- t_5 = CALL_1ARGS( t_6, t_7 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, a_data, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1668,14 +2113,24 @@ static Obj  HdlrFunc17 (
  
  /* p := READ_LOCK( arg ); */
  t_2 = GF_READ__LOCK;
- t_1 = CALL_1ARGS( t_2, a_arg );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_arg );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_p = t_1;
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1685,14 +2140,24 @@ static Obj  HdlrFunc17 (
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<type> must be a type" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
@@ -1701,7 +2166,12 @@ static Obj  HdlrFunc17 (
   t_2 = GF_Subtype2;
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
-  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
@@ -1715,7 +2185,12 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
-  t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
@@ -1724,7 +2199,12 @@ static Obj  HdlrFunc17 (
  
  /* UNLOCK( p ); */
  t_1 = GF_UNLOCK;
- CALL_1ARGS( t_1, l_p );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_p );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_p ) );
+ }
  
  /* return type; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1763,12 +2243,27 @@ static Obj  HdlrFunc18 (
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, t_6, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1807,11 +2302,26 @@ static Obj  HdlrFunc19 (
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
- t_8 = CALL_1ARGS( t_9, a_filter );
+ if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+  t_8 = CALL_1ARGS( t_9, a_filter );
+ }
+ else {
+  t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_8 );
- t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7, t_8 ) );
+ }
  CHECK_FUNC_RESULT( t_5 );
- t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5, a_data, a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -1839,7 +2349,12 @@ static Obj  HdlrFunc20 (
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -1849,14 +2364,24 @@ static Obj  HdlrFunc20 (
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<type> must be a type" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
- t_2 = CALL_1ARGS( t_3, a_arg );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_arg );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_arg ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
@@ -1865,7 +2390,12 @@ static Obj  HdlrFunc20 (
   t_2 = GF_SupType2;
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
-  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -1880,7 +2410,12 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
-  t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
+  }
+  else {
+   t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
@@ -1977,9 +2512,19 @@ static Obj  HdlrFunc24 (
  /* StrictBindOnce( K, 3, MakeImmutable( data ) ); */
  t_1 = GF_StrictBindOnce;
  t_3 = GF_MakeImmutable;
- t_2 = CALL_1ARGS( t_3, a_data );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_data );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_data ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
- CALL_3ARGS( t_1, a_K, INTOBJ_INT(3), t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, a_K, INTOBJ_INT(3), t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_K, INTOBJ_INT(3), t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -2007,9 +2552,19 @@ static Obj  HdlrFunc25 (
  /* return FlagsType( TypeObj( obj ) ); */
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
- t_3 = CALL_1ARGS( t_4, a_obj );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_obj );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2036,9 +2591,19 @@ static Obj  HdlrFunc26 (
  /* return DataType( TypeObj( obj ) ); */
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
- t_3 = CALL_1ARGS( t_4, a_obj );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_obj );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -2068,7 +2633,12 @@ static Obj  HdlrFunc27 (
  
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
- t_3 = CALL_1ARGS( t_4, a_type );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_type );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_type ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2078,20 +2648,35 @@ static Obj  HdlrFunc27 (
   /* Error( "<type> must be a type" ); */
   t_1 = GF_Error;
   t_2 = MakeString( "<type> must be a type" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
- t_1 = CALL_1ARGS( t_2, a_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2101,7 +2686,12 @@ static Obj  HdlrFunc27 (
   t_3 = GF_IS__SUBSET__FLAGS;
   t_4 = GC_IsAtomicPositionalObjectRepFlags;
   CHECK_BOUND( t_4, "IsAtomicPositionalObjectRepFlags" );
-  t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_flags, t_4 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2110,9 +2700,19 @@ static Obj  HdlrFunc27 (
    /* FORCE_SWITCH_OBJ( obj, FixedAtomicList( obj ) ); */
    t_1 = GF_FORCE__SWITCH__OBJ;
    t_3 = GF_FixedAtomicList;
-   t_2 = CALL_1ARGS( t_3, a_obj );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_obj );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
-   CALL_2ARGS( t_1, a_obj, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+   }
    
   }
   /* fi */
@@ -2122,7 +2722,12 @@ static Obj  HdlrFunc27 (
  /* elif IS_REC( obj ) then */
  else {
   t_3 = GF_IS__REC;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2130,7 +2735,12 @@ static Obj  HdlrFunc27 (
    
    /* if IS_ATOMIC_RECORD( obj ) then */
    t_3 = GF_IS__ATOMIC__RECORD;
-   t_2 = CALL_1ARGS( t_3, a_obj );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_obj );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -2140,7 +2750,12 @@ static Obj  HdlrFunc27 (
     t_3 = GF_IS__SUBSET__FLAGS;
     t_4 = GC_IsNonAtomicComponentObjectRepFlags;
     CHECK_BOUND( t_4, "IsNonAtomicComponentObjectRepFlags" );
-    t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( l_flags, t_4 ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
     CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
@@ -2149,9 +2764,19 @@ static Obj  HdlrFunc27 (
      /* FORCE_SWITCH_OBJ( obj, FromAtomicRecord( obj ) ); */
      t_1 = GF_FORCE__SWITCH__OBJ;
      t_3 = GF_FromAtomicRecord;
-     t_2 = CALL_1ARGS( t_3, a_obj );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      t_2 = CALL_1ARGS( t_3, a_obj );
+     }
+     else {
+      t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+     }
      CHECK_FUNC_RESULT( t_2 );
-     CALL_2ARGS( t_1, a_obj, t_2 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_1, a_obj, t_2 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+     }
      
     }
     /* fi */
@@ -2163,7 +2788,12 @@ static Obj  HdlrFunc27 (
     t_4 = GF_IS__SUBSET__FLAGS;
     t_5 = GC_IsNonAtomicComponentObjectRepFlags;
     CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRepFlags" );
-    t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
+    if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+     t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
+    }
+    else {
+     t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, t_5 ) );
+    }
     CHECK_FUNC_RESULT( t_3 );
     CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
@@ -2173,9 +2803,19 @@ static Obj  HdlrFunc27 (
      /* FORCE_SWITCH_OBJ( obj, AtomicRecord( obj ) ); */
      t_1 = GF_FORCE__SWITCH__OBJ;
      t_3 = GF_AtomicRecord;
-     t_2 = CALL_1ARGS( t_3, a_obj );
+     if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+      t_2 = CALL_1ARGS( t_3, a_obj );
+     }
+     else {
+      t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+     }
      CHECK_FUNC_RESULT( t_2 );
-     CALL_2ARGS( t_1, a_obj, t_2 );
+     if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_1, a_obj, t_2 );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+     }
      
     }
    }
@@ -2187,7 +2827,12 @@ static Obj  HdlrFunc27 (
  
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2195,14 +2840,24 @@ static Obj  HdlrFunc27 (
   
   /* SET_TYPE_POSOBJ( obj, type ); */
   t_1 = GF_SET__TYPE__POSOBJ;
-  CALL_2ARGS( t_1, a_obj, a_type );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, a_type );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, a_type ) );
+  }
   
  }
  
  /* elif IS_REC( obj ) then */
  else {
   t_3 = GF_IS__REC;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2210,7 +2865,12 @@ static Obj  HdlrFunc27 (
    
    /* SET_TYPE_COMOBJ( obj, type ); */
    t_1 = GF_SET__TYPE__COMOBJ;
-   CALL_2ARGS( t_1, a_obj, a_type );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, a_type );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, a_type ) );
+   }
    
   }
  }
@@ -2218,7 +2878,12 @@ static Obj  HdlrFunc27 (
  
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
- t_3 = CALL_1ARGS( t_4, a_obj );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, a_obj );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2228,14 +2893,24 @@ static Obj  HdlrFunc27 (
   /* RunImmediateMethods( obj, type![2] ); */
   t_1 = GF_RunImmediateMethods;
   t_2 = ElmPosObj( a_type, 2 );
-  CALL_2ARGS( t_1, a_obj, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if IsReadOnlyPositionalObjectRep( obj ) then */
  t_3 = GF_IsReadOnlyPositionalObjectRep;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2243,7 +2918,12 @@ static Obj  HdlrFunc27 (
   
   /* MakeReadOnlySingleObj( obj ); */
   t_1 = GF_MakeReadOnlySingleObj;
-  CALL_1ARGS( t_1, a_obj );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, a_obj );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj ) );
+  }
   
  }
  /* fi */
@@ -2280,19 +2960,34 @@ static Obj  HdlrFunc28 (
  
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
- t_1 = CALL_1ARGS( t_2, a_obj );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, a_obj );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* newtype := Subtype2( type, filter ); */
  t_2 = GF_Subtype2;
- t_1 = CALL_2ARGS( t_2, l_type, a_filter );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, l_type, a_filter );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_type, a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_newtype = t_1;
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2300,14 +2995,24 @@ static Obj  HdlrFunc28 (
   
   /* SET_TYPE_POSOBJ( obj, newtype ); */
   t_1 = GF_SET__TYPE__POSOBJ;
-  CALL_2ARGS( t_1, a_obj, l_newtype );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, l_newtype );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, l_newtype ) );
+  }
   
  }
  
  /* elif IS_COMOBJ( obj ) then */
  else {
   t_3 = GF_IS__COMOBJ;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2315,14 +3020,24 @@ static Obj  HdlrFunc28 (
    
    /* SET_TYPE_COMOBJ( obj, newtype ); */
    t_1 = GF_SET__TYPE__COMOBJ;
-   CALL_2ARGS( t_1, a_obj, l_newtype );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, l_newtype );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, l_newtype ) );
+   }
    
   }
   
   /* elif IS_DATOBJ( obj ) then */
   else {
    t_3 = GF_IS__DATOBJ;
-   t_2 = CALL_1ARGS( t_3, a_obj );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_obj );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -2330,7 +3045,12 @@ static Obj  HdlrFunc28 (
     
     /* SET_TYPE_DATOBJ( obj, newtype ); */
     t_1 = GF_SET__TYPE__DATOBJ;
-    CALL_2ARGS( t_1, a_obj, l_newtype );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, a_obj, l_newtype );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, l_newtype ) );
+    }
     
    }
    
@@ -2340,7 +3060,12 @@ static Obj  HdlrFunc28 (
     /* ErrorNoReturn( "cannot set filter for internal object" ); */
     t_1 = GF_ErrorNoReturn;
     t_2 = MakeString( "cannot set filter for internal object" );
-    CALL_1ARGS( t_1, t_2 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, t_2 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+    }
     
    }
   }
@@ -2355,7 +3080,12 @@ static Obj  HdlrFunc28 (
  t_2 = t_3;
  if ( ! t_2 ) {
   t_6 = GF_IsNoImmediateMethodsObject;
-  t_5 = CALL_1ARGS( t_6, a_obj );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, a_obj );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
   CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
@@ -2369,9 +3099,19 @@ static Obj  HdlrFunc28 (
   t_3 = GF_SUB__FLAGS;
   t_4 = ElmPosObj( l_newtype, 2 );
   t_5 = ElmPosObj( l_type, 2 );
-  t_2 = CALL_2ARGS( t_3, t_4, t_5 );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, t_4, t_5 );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, t_5 ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
-  CALL_2ARGS( t_1, a_obj, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+  }
   
  }
  /* fi */
@@ -2403,7 +3143,12 @@ static Obj  HdlrFunc29 (
  
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
- t_2 = CALL_1ARGS( t_3, a_filter );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_filter );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_filter ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2412,14 +3157,24 @@ static Obj  HdlrFunc29 (
   /* Error( "You can't reset an \"and-filter\". Reset components individually." ); */
   t_1 = GF_Error;
   t_2 = MakeString( "You can't reset an \"and-filter\". Reset components individually." );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
- t_2 = CALL_1ARGS( t_3, a_obj );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, a_obj );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
@@ -2429,18 +3184,38 @@ static Obj  HdlrFunc29 (
   t_1 = GF_SET__TYPE__POSOBJ;
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
-  t_4 = CALL_1ARGS( t_5, a_obj );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   t_4 = CALL_1ARGS( t_5, a_obj );
+  }
+  else {
+   t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_4 );
-  t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_filter ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
-  CALL_2ARGS( t_1, a_obj, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, a_obj, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+  }
   
  }
  
  /* elif IS_COMOBJ( obj ) then */
  else {
   t_3 = GF_IS__COMOBJ;
-  t_2 = CALL_1ARGS( t_3, a_obj );
+  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+   t_2 = CALL_1ARGS( t_3, a_obj );
+  }
+  else {
+   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+  }
   CHECK_FUNC_RESULT( t_2 );
   CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
@@ -2450,18 +3225,38 @@ static Obj  HdlrFunc29 (
    t_1 = GF_SET__TYPE__COMOBJ;
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
-   t_4 = CALL_1ARGS( t_5, a_obj );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    t_4 = CALL_1ARGS( t_5, a_obj );
+   }
+   else {
+    t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_4 );
-   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_filter ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
-   CALL_2ARGS( t_1, a_obj, t_2 );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, a_obj, t_2 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+   }
    
   }
   
   /* elif IS_DATOBJ( obj ) then */
   else {
    t_3 = GF_IS__DATOBJ;
-   t_2 = CALL_1ARGS( t_3, a_obj );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_1ARGS( t_3, a_obj );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( a_obj ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
    CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
@@ -2471,11 +3266,26 @@ static Obj  HdlrFunc29 (
     t_1 = GF_SET__TYPE__DATOBJ;
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
-    t_4 = CALL_1ARGS( t_5, a_obj );
+    if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+     t_4 = CALL_1ARGS( t_5, a_obj );
+    }
+    else {
+     t_4 = DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( a_obj ) );
+    }
     CHECK_FUNC_RESULT( t_4 );
-    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+    if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
+    }
+    else {
+     t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, a_filter ) );
+    }
     CHECK_FUNC_RESULT( t_2 );
-    CALL_2ARGS( t_1, a_obj, t_2 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_2ARGS( t_1, a_obj, t_2 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( a_obj, t_2 ) );
+    }
     
    }
    
@@ -2485,7 +3295,12 @@ static Obj  HdlrFunc29 (
     /* Error( "cannot reset filter for internal object" ); */
     t_1 = GF_Error;
     t_2 = MakeString( "cannot reset filter for internal object" );
-    CALL_1ARGS( t_1, t_2 );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, t_2 );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+    }
     
    }
   }
@@ -2548,7 +3363,12 @@ static Obj  HdlrFunc30 (
  
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
- t_1 = CALL_1ARGS( t_2, l_type );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, l_type );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_type ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
@@ -2561,7 +3381,12 @@ static Obj  HdlrFunc30 (
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
  CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
- t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
  CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
@@ -2570,7 +3395,12 @@ static Obj  HdlrFunc30 (
   
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
-  t_3 = CALL_1ARGS( t_4, a_arg );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_1ARGS( t_4, a_arg );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
@@ -2580,11 +3410,21 @@ static Obj  HdlrFunc30 (
   t_1 = GF_INFO__OWA;
   t_2 = MakeString( "#W ObjectifyWithAttributes called " );
   t_3 = MakeString( "for non-attribute storing rep\n" );
-  CALL_2ARGS( t_1, t_2, t_3 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, t_2, t_3 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+  }
   
   /* Objectify( type, obj ); */
   t_1 = GF_Objectify;
-  CALL_2ARGS( t_1, l_type, l_obj );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_1, l_type, l_obj );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type, l_obj ) );
+  }
   
  }
  
@@ -2598,7 +3438,12 @@ static Obj  HdlrFunc30 (
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
-  t_6 = CALL_1ARGS( t_7, a_arg );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, a_arg );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( a_arg ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
@@ -2636,7 +3481,12 @@ static Obj  HdlrFunc30 (
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
-   t_6 = CALL_1ARGS( t_7, l_attr );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, l_attr );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_attr ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
@@ -2649,9 +3499,19 @@ static Obj  HdlrFunc30 (
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( attr ) ); */
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
-     t_7 = CALL_1ARGS( t_8, l_attr );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, l_attr );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_nflags, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
@@ -2664,11 +3524,26 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
-     t_9 = CALL_1ARGS( t_10, l_attr );
+     if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+      t_9 = CALL_1ARGS( t_10, l_attr );
+     }
+     else {
+      t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_9 );
-     t_7 = CALL_1ARGS( t_8, t_9 );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, t_9 );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_nflags, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
@@ -2682,11 +3557,26 @@ static Obj  HdlrFunc30 (
     t_7 = GF_LEN__LIST;
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
-    t_10 = CALL_1ARGS( t_11, l_attr );
+    if ( TNUM_OBJ( t_11 ) == T_FUNCTION ) {
+     t_10 = CALL_1ARGS( t_11, l_attr );
+    }
+    else {
+     t_10 = DoOperation2Args( CallFuncListOper, t_11, NewPlistFromArgs( l_attr ) );
+    }
     CHECK_FUNC_RESULT( t_10 );
-    t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
+    if ( TNUM_OBJ( t_9 ) == T_FUNCTION ) {
+     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
+    }
+    else {
+     t_8 = DoOperation2Args( CallFuncListOper, t_9, NewPlistFromArgs( t_10, INTOBJ_INT(2) ) );
+    }
     CHECK_FUNC_RESULT( t_8 );
-    t_6 = CALL_1ARGS( t_7, t_8 );
+    if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+     t_6 = CALL_1ARGS( t_7, t_8 );
+    }
+    else {
+     t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+    }
     CHECK_FUNC_RESULT( t_6 );
     t_7 = GC_LENGTH__SETTER__METHODS__2;
     CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
@@ -2695,11 +3585,21 @@ static Obj  HdlrFunc30 (
      
      /* ADD_LIST( extra, attr ); */
      t_5 = GF_ADD__LIST;
-     CALL_2ARGS( t_5, l_extra, l_attr );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_5, l_extra, l_attr );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_extra, l_attr ) );
+     }
      
      /* ADD_LIST( extra, val ); */
      t_5 = GF_ADD__LIST;
-     CALL_2ARGS( t_5, l_extra, l_val );
+     if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+      CALL_2ARGS( t_5, l_extra, l_val );
+     }
+     else {
+      DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_extra, l_val ) );
+     }
      
     }
     
@@ -2708,10 +3608,20 @@ static Obj  HdlrFunc30 (
      
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
-     t_5 = CALL_1ARGS( t_6, l_attr );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_1ARGS( t_6, l_attr );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      t_7 = GF_IMMUTABLE__COPY__OBJ;
-     t_6 = CALL_1ARGS( t_7, l_val );
+     if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+      t_6 = CALL_1ARGS( t_7, l_val );
+     }
+     else {
+      t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_val ) );
+     }
      CHECK_FUNC_RESULT( t_6 );
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
@@ -2719,11 +3629,26 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
-     t_9 = CALL_1ARGS( t_10, l_attr );
+     if ( TNUM_OBJ( t_10 ) == T_FUNCTION ) {
+      t_9 = CALL_1ARGS( t_10, l_attr );
+     }
+     else {
+      t_9 = DoOperation2Args( CallFuncListOper, t_10, NewPlistFromArgs( l_attr ) );
+     }
      CHECK_FUNC_RESULT( t_9 );
-     t_7 = CALL_1ARGS( t_8, t_9 );
+     if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+      t_7 = CALL_1ARGS( t_8, t_9 );
+     }
+     else {
+      t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+     }
      CHECK_FUNC_RESULT( t_7 );
-     t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
+     }
+     else {
+      t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_nflags, t_7 ) );
+     }
      CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
@@ -2736,7 +3661,12 @@ static Obj  HdlrFunc30 (
   
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
-  t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+  if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+  }
+  else {
+   t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, l_nflags ) );
+  }
   CHECK_FUNC_RESULT( t_3 );
   CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
@@ -2746,9 +3676,19 @@ static Obj  HdlrFunc30 (
    /* flags := WITH_IMPS_FLAGS( AND_FLAGS( flags, nflags ) ); */
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
-   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+   if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
+   }
+   else {
+    t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( l_flags, l_nflags ) );
+   }
    CHECK_FUNC_RESULT( t_3 );
-   t_1 = CALL_1ARGS( t_2, t_3 );
+   if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+    t_1 = CALL_1ARGS( t_2, t_3 );
+   }
+   else {
+    t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+   }
    CHECK_FUNC_RESULT( t_1 );
    l_flags = t_1;
    
@@ -2758,16 +3698,36 @@ static Obj  HdlrFunc30 (
    t_4 = GC_TypeOfTypes;
    CHECK_BOUND( t_4, "TypeOfTypes" );
    t_6 = GF_FamilyType;
-   t_5 = CALL_1ARGS( t_6, l_type );
+   if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+    t_5 = CALL_1ARGS( t_6, l_type );
+   }
+   else {
+    t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( l_type ) );
+   }
    CHECK_FUNC_RESULT( t_5 );
    t_7 = GF_DataType;
-   t_6 = CALL_1ARGS( t_7, l_type );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, l_type );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_type ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
    t_7 = GC_fail;
    CHECK_BOUND( t_7, "fail" );
-   t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
+   if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+    t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
+   }
+   else {
+    t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4, t_5, l_flags, t_6, t_7 ) );
+   }
    CHECK_FUNC_RESULT( t_2 );
-   CALL_2ARGS( t_1, t_2, l_obj );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, t_2, l_obj );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, l_obj ) );
+   }
    
   }
   
@@ -2776,7 +3736,12 @@ static Obj  HdlrFunc30 (
    
    /* Objectify( type, obj ); */
    t_1 = GF_Objectify;
-   CALL_2ARGS( t_1, l_type, l_obj );
+   if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_1, l_type, l_obj );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_type, l_obj ) );
+   }
    
   }
   /* fi */
@@ -2786,7 +3751,12 @@ static Obj  HdlrFunc30 (
  
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
- t_6 = CALL_1ARGS( t_7, l_extra );
+ if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+  t_6 = CALL_1ARGS( t_7, l_extra );
+ }
+ else {
+  t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_extra ) );
+ }
  CHECK_FUNC_RESULT( t_6 );
  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
@@ -2815,10 +3785,19 @@ static Obj  HdlrFunc30 (
   t_8 = GF_Tester;
   CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_9, l_extra, l_i )
-  t_7 = CALL_1ARGS( t_8, t_9 );
+  if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+   t_7 = CALL_1ARGS( t_8, t_9 );
+  }
+  else {
+   t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+  }
   CHECK_FUNC_RESULT( t_7 );
-  CHECK_FUNC( t_7 );
-  t_6 = CALL_1ARGS( t_7, l_obj );
+  if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+   t_6 = CALL_1ARGS( t_7, l_obj );
+  }
+  else {
+   t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( l_obj ) );
+  }
   CHECK_FUNC_RESULT( t_6 );
   CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
@@ -2829,18 +3808,38 @@ static Obj  HdlrFunc30 (
    t_6 = MakeString( "#W  Supplied type has tester of " );
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
-   t_7 = CALL_1ARGS( t_8, t_9 );
+   if ( TNUM_OBJ( t_8 ) == T_FUNCTION ) {
+    t_7 = CALL_1ARGS( t_8, t_9 );
+   }
+   else {
+    t_7 = DoOperation2Args( CallFuncListOper, t_8, NewPlistFromArgs( t_9 ) );
+   }
    CHECK_FUNC_RESULT( t_7 );
    t_8 = MakeString( "with non-standard setter\n" );
-   CALL_3ARGS( t_5, t_6, t_7, t_8 );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    CALL_3ARGS( t_5, t_6, t_7, t_8 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( t_6, t_7, t_8 ) );
+   }
    
    /* ResetFilterObj( obj, Tester( extra[i] ) ); */
    t_5 = GF_ResetFilterObj;
    t_7 = GF_Tester;
    C_ELM_LIST_FPL( t_8, l_extra, l_i )
-   t_6 = CALL_1ARGS( t_7, t_8 );
+   if ( TNUM_OBJ( t_7 ) == T_FUNCTION ) {
+    t_6 = CALL_1ARGS( t_7, t_8 );
+   }
+   else {
+    t_6 = DoOperation2Args( CallFuncListOper, t_7, NewPlistFromArgs( t_8 ) );
+   }
    CHECK_FUNC_RESULT( t_6 );
-   CALL_2ARGS( t_5, l_obj, t_6 );
+   if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+    CALL_2ARGS( t_5, l_obj, t_6 );
+   }
+   else {
+    DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_obj, t_6 ) );
+   }
    
   }
   /* fi */
@@ -2848,13 +3847,22 @@ static Obj  HdlrFunc30 (
   /* Setter( extra[i] )( obj, extra[i + 1] ); */
   t_6 = GF_Setter;
   C_ELM_LIST_FPL( t_7, l_extra, l_i )
-  t_5 = CALL_1ARGS( t_6, t_7 );
+  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+   t_5 = CALL_1ARGS( t_6, t_7 );
+  }
+  else {
+   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+  }
   CHECK_FUNC_RESULT( t_5 );
-  CHECK_FUNC( t_5 );
   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
   CHECK_INT_POS( t_7 );
   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
-  CALL_2ARGS( t_5, l_obj, t_6 );
+  if ( TNUM_OBJ( t_5 ) == T_FUNCTION ) {
+   CALL_2ARGS( t_5, l_obj, t_6 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_5, NewPlistFromArgs( l_obj, t_6 ) );
+  }
   
  }
  /* od */
@@ -2894,7 +3902,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 27);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
@@ -2923,7 +3936,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_3, 53);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Subtype := "defined below"; */
  t_1 = MakeString( "defined below" );
@@ -2933,7 +3951,12 @@ static Obj  HdlrFunc1 (
  t_2 = GF_ShareSpecialObj;
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- t_1 = CALL_1ARGS( t_2, t_3 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_1ARGS( t_2, t_3 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3 ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  AssGVar( G_DS__TYPE__CACHE, t_1 );
  
@@ -2970,7 +3993,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 143);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily2", function ( typeOfFamilies, name )
       return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS );
@@ -2984,7 +4012,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 151);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily3", function ( typeOfFamilies, name, req )
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), EMPTY_FLAGS );
@@ -2998,7 +4031,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 159);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily4", function ( typeOfFamilies, name, req, imp )
       return NEW_FAMILY( typeOfFamilies, name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
@@ -3012,7 +4050,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 167);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily5", function ( typeOfFamilies, name, req, imp, filter )
       return NEW_FAMILY( Subtype( typeOfFamilies, filter ), name, FLAGS_FILTER( req ), FLAGS_FILTER( imp ) );
@@ -3026,7 +4069,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 176);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewFamily", function ( arg... )
       if LEN_LIST( arg ) = 1 then
@@ -3051,7 +4099,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 202);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* NEW_TYPE_CACHE_MISS := 0; */
  AssGVar( G_NEW__TYPE__CACHE__MISS, INTOBJ_INT(0) );
@@ -3150,7 +4203,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 347);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewType3", function ( typeOfTypes, family, filter )
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), fail, fail );
@@ -3164,7 +4222,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 358);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewType4", function ( typeOfTypes, family, filter, data )
       return NEW_TYPE( typeOfTypes, family, WITH_IMPS_FLAGS( AND_FLAGS( family!.IMP_FLAGS, FLAGS_FILTER( filter ) ) ), data, fail );
@@ -3178,7 +4241,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 368);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "NewType", function ( arg... )
       local type;
@@ -3203,7 +4271,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 395);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "Subtype2", function ( type, filter )
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type );
@@ -3217,7 +4290,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 415);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "Subtype3", function ( type, filter, data )
       return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type );
@@ -3231,7 +4309,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 425);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Unbind( Subtype ); */
  AssGVar( G_Subtype, 0 );
@@ -3259,7 +4342,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 451);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SupType2", function ( type, filter )
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type );
@@ -3273,7 +4361,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 472);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SupType3", function ( type, filter, data )
       return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type );
@@ -3287,7 +4380,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 482);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SupType", function ( arg... )
       if not IsType( arg[1] ) then
@@ -3309,7 +4407,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 499);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FamilyType", function ( K )
       return K![1];
@@ -3323,7 +4426,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 513);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FlagsType", function ( K )
       return K![2];
@@ -3337,7 +4445,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 527);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "DataType", function ( K )
       return K![3];
@@ -3351,7 +4464,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 543);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SetDataType", function ( K, data )
       StrictBindOnce( K, 3, MakeImmutable( data ) );
@@ -3366,21 +4484,36 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 551);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "TypeObj", TYPE_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
  CHECK_BOUND( t_3, "TYPE_OBJ" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
  CHECK_BOUND( t_3, "FAMILY_OBJ" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
       return FlagsType( TypeObj( obj ) );
@@ -3394,7 +4527,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 650);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "DataObj", function ( obj )
       return DataType( TypeObj( obj ) );
@@ -3408,7 +4546,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 664);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsNonAtomicComponentObjectRepFlags", FLAGS_FILTER( IsNonAtomicComponentObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3416,9 +4559,19 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
  CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3426,9 +4579,19 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
  CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3436,9 +4599,19 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
  CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
       local flags;
@@ -3481,7 +4654,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 720);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Unbind( SetFilterObj ); */
  AssGVar( G_SetFilterObj, 0 );
@@ -3513,14 +4691,24 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 762);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "SET_FILTER_OBJ", SetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
  CHECK_BOUND( t_3, "SetFilterObj" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
       if IS_AND_FILTER( filter ) then
@@ -3546,14 +4734,24 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 798);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "RESET_FILTER_OBJ", ResetFilterObj ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
  CHECK_BOUND( t_3, "ResetFilterObj" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
  t_1 = GF_BIND__GLOBAL;
@@ -3561,21 +4759,41 @@ static Obj  HdlrFunc1 (
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
- t_3 = CALL_1ARGS( t_4, t_5 );
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_1ARGS( t_4, t_5 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5 ) );
+ }
  CHECK_FUNC_RESULT( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
  CHECK_BOUND( t_3, "Ignore" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */
  t_1 = GF_MAKE__READ__WRITE__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* BIND_GLOBAL( "ObjectifyWithAttributes", function ( arg... )
       local obj, type, flags, attr, val, i, extra, nflags;
@@ -3631,7 +4849,12 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_4, 914);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/src/hpc/c_type1.c
+++ b/src/hpc/c_type1.c
@@ -255,12 +255,12 @@ static Obj  HdlrFunc2 (
  t_4 = NEW_PLIST( T_PLIST, 1 );
  SET_LEN_PLIST( t_4, 1 );
  t_6 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_6, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_6, "IsAttributeStoringRep" );
  if ( t_6 == False ) {
   t_5 = t_6;
  }
  else if ( t_6 == True ) {
-  CHECK_BOOL( a_tester )
+  CHECK_BOOL( a_tester );
   t_5 = a_tester;
  }
  else if (IS_FILTER( t_6 ) ) {
@@ -273,10 +273,10 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_4, 1, t_5 );
  CHANGED_BAG( t_4 );
  t_5 = GC_GETTER__FLAGS;
- CHECK_BOUND( t_5, "GETTER_FLAGS" )
+ CHECK_BOUND( t_5, "GETTER_FLAGS" );
  t_7 = GF_GETTER__FUNCTION;
  t_6 = CALL_1ARGS( t_7, a_name );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  CALL_6ARGS( t_1, a_getter, t_2, t_3, t_4, t_5, t_6 );
  
  /* return; */
@@ -303,13 +303,13 @@ static Obj  HdlrFunc4 (
  
  /* obj!.(name) := val; */
  t_1 = OBJ_HVAR( (1 << 16) | 1 );
- CHECK_BOUND( t_1, "name" )
+ CHECK_BOUND( t_1, "name" );
  AssComObj( a_obj, RNamObj(t_1), a_val );
  
  /* SetFilterObj( obj, tester ); */
  t_1 = GF_SetFilterObj;
  t_2 = OBJ_HVAR( (1 << 16) | 2 );
- CHECK_BOUND( t_2, "tester" )
+ CHECK_BOUND( t_2, "tester" );
  CALL_2ARGS( t_1, a_obj, t_2 );
  
  /* return; */
@@ -348,7 +348,7 @@ static Obj  HdlrFunc3 (
  ASS_LVAR( 2, a_tester );
  
  /* if mutflag then */
- CHECK_BOOL( a_mutflag )
+ CHECK_BOOL( a_mutflag );
  t_1 = (Obj)(UInt)(a_mutflag != False);
  if ( t_1 ) {
   
@@ -363,11 +363,11 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = NewFunction( NameFunc[4], 2, ArgStringToList("obj,val"), HdlrFunc4 );
@@ -391,20 +391,20 @@ static Obj  HdlrFunc3 (
   t_4 = NEW_PLIST( T_PLIST, 2 );
   SET_LEN_PLIST( t_4, 2 );
   t_5 = GC_IsAttributeStoringRep;
-  CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+  CHECK_BOUND( t_5, "IsAttributeStoringRep" );
   SET_ELM_PLIST( t_4, 1, t_5 );
   CHANGED_BAG( t_4 );
   t_5 = GC_IS__OBJECT;
-  CHECK_BOUND( t_5, "IS_OBJECT" )
+  CHECK_BOUND( t_5, "IS_OBJECT" );
   SET_ELM_PLIST( t_4, 2, t_5 );
   CHANGED_BAG( t_4 );
   t_6 = GF_SETTER__FUNCTION;
   t_7 = OBJ_LVAR( 1 );
-  CHECK_BOUND( t_7, "name" )
+  CHECK_BOUND( t_7, "name" );
   t_8 = OBJ_LVAR( 2 );
-  CHECK_BOUND( t_8, "tester" )
+  CHECK_BOUND( t_8, "tester" );
   t_5 = CALL_2ARGS( t_6, t_7, t_8 );
-  CHECK_FUNC_RESULT( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
   CALL_6ARGS( t_1, a_setter, t_2, t_3, t_4, INTOBJ_INT(0), t_5 );
   
  }
@@ -452,30 +452,30 @@ static Obj  HdlrFunc5 (
  t_2 = GF_WITH__IMPS__FLAGS;
  t_4 = GF_AND__FLAGS;
  t_3 = CALL_2ARGS( t_4, a_imp__filter, a_req__filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_imp__filter = t_1;
  
  /* type := Subtype( typeOfFamilies, IsAttributeStoringRep ); */
  t_2 = GF_Subtype;
  t_3 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_3, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_3, "IsAttributeStoringRep" );
  t_1 = CALL_2ARGS( t_2, a_typeOfFamilies, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* lock := READ_LOCK( CATEGORIES_FAMILY ); */
  t_2 = GF_READ__LOCK;
  t_3 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_3, "CATEGORIES_FAMILY" )
+ CHECK_BOUND( t_3, "CATEGORIES_FAMILY" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
  /* for pair in CATEGORIES_FAMILY do */
  t_4 = GC_CATEGORIES__FAMILY;
- CHECK_BOUND( t_4, "CATEGORIES_FAMILY" )
+ CHECK_BOUND( t_4, "CATEGORIES_FAMILY" );
  if ( IS_SMALL_LIST(t_4) ) {
   t_3 = (Obj)(UInt)1;
   t_1 = INTOBJ_INT(1);
@@ -501,8 +501,8 @@ static Obj  HdlrFunc5 (
   t_7 = GF_IS__SUBSET__FLAGS;
   C_ELM_LIST_FPL( t_8, l_pair, INTOBJ_INT(1) )
   t_6 = CALL_2ARGS( t_7, a_imp__filter, t_8 );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -510,7 +510,7 @@ static Obj  HdlrFunc5 (
    t_6 = GF_Subtype;
    C_ELM_LIST_FPL( t_7, l_pair, INTOBJ_INT(2) )
    t_5 = CALL_2ARGS( t_6, l_type, t_7 );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    l_type = t_5;
    
   }
@@ -526,7 +526,7 @@ static Obj  HdlrFunc5 (
  /* family := AtomicRecord(  ); */
  t_2 = GF_AtomicRecord;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_family = t_1;
  
  /* SET_TYPE_COMOBJ( family, type ); */
@@ -536,7 +536,7 @@ static Obj  HdlrFunc5 (
  /* family!.NAME := IMMUTABLE_COPY_OBJ( name ); */
  t_2 = GF_IMMUTABLE__COPY__OBJ;
  t_1 = CALL_1ARGS( t_2, a_name );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_NAME, t_1 );
  
  /* family!.REQ_FLAGS := req_filter; */
@@ -554,9 +554,9 @@ static Obj  HdlrFunc5 (
  /* lock := WRITE_LOCK( DS_TYPE_CACHE ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_DS__TYPE__CACHE;
- CHECK_BOUND( t_3, "DS_TYPE_CACHE" )
+ CHECK_BOUND( t_3, "DS_TYPE_CACHE" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
  /* family!.TYPES := MIGRATE_RAW( [  ], DS_TYPE_CACHE ); */
@@ -564,9 +564,9 @@ static Obj  HdlrFunc5 (
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  t_4 = GC_DS__TYPE__CACHE;
- CHECK_BOUND( t_4, "DS_TYPE_CACHE" )
+ CHECK_BOUND( t_4, "DS_TYPE_CACHE" );
  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_TYPES, t_1 );
  
  /* UNLOCK( lock ); */
@@ -577,9 +577,9 @@ static Obj  HdlrFunc5 (
  t_2 = GF_MakeWriteOnceAtomic;
  t_4 = GF_AtomicList;
  t_3 = CALL_1ARGS( t_4, INTOBJ_INT(27) );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssComObj( l_family, R_TYPES__LIST__FAM, t_1 );
  
  /* return family; */
@@ -609,11 +609,11 @@ static Obj  HdlrFunc6 (
  /* return NEW_FAMILY( typeOfFamilies, name, EMPTY_FLAGS, EMPTY_FLAGS ); */
  t_2 = GF_NEW__FAMILY;
  t_3 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_3, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_3, "EMPTY_FLAGS" );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -642,11 +642,11 @@ static Obj  HdlrFunc7 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_EMPTY__FLAGS;
- CHECK_BOUND( t_4, "EMPTY_FLAGS" )
+ CHECK_BOUND( t_4, "EMPTY_FLAGS" );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -677,12 +677,12 @@ static Obj  HdlrFunc8 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_FLAGS__FILTER;
  t_3 = CALL_1ARGS( t_4, a_req );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_imp );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_1 = CALL_4ARGS( t_2, a_typeOfFamilies, a_name, t_3, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -715,15 +715,15 @@ static Obj  HdlrFunc9 (
  t_2 = GF_NEW__FAMILY;
  t_4 = GF_Subtype;
  t_3 = CALL_2ARGS( t_4, a_typeOfFamilies, a_filter );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_5 = GF_FLAGS__FILTER;
  t_4 = CALL_1ARGS( t_5, a_req );
- CHECK_FUNC_RESULT( t_4 )
+ CHECK_FUNC_RESULT( t_4 );
  t_6 = GF_FLAGS__FILTER;
  t_5 = CALL_1ARGS( t_6, a_imp );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_4ARGS( t_2, t_3, a_name, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -752,17 +752,17 @@ static Obj  HdlrFunc10 (
  /* if LEN_LIST( arg ) = 1 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(1) ));
  if ( t_1 ) {
   
   /* return NewFamily2( TypeOfFamilies, arg[1] ); */
   t_2 = GF_NewFamily2;
   t_3 = GC_TypeOfFamilies;
-  CHECK_BOUND( t_3, "TypeOfFamilies" )
+  CHECK_BOUND( t_3, "TypeOfFamilies" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -772,18 +772,18 @@ static Obj  HdlrFunc10 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
   if ( t_1 ) {
    
    /* return NewFamily3( TypeOfFamilies, arg[1], arg[2] ); */
    t_2 = GF_NewFamily3;
    t_3 = GC_TypeOfFamilies;
-   CHECK_BOUND( t_3, "TypeOfFamilies" )
+   CHECK_BOUND( t_3, "TypeOfFamilies" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    SWITCH_TO_OLD_FRAME(oldFrame);
    return t_1;
    
@@ -793,19 +793,19 @@ static Obj  HdlrFunc10 (
   else {
    t_3 = GF_LEN__LIST;
    t_2 = CALL_1ARGS( t_3, a_arg );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
    if ( t_1 ) {
     
     /* return NewFamily4( TypeOfFamilies, arg[1], arg[2], arg[3] ); */
     t_2 = GF_NewFamily4;
     t_3 = GC_TypeOfFamilies;
-    CHECK_BOUND( t_3, "TypeOfFamilies" )
+    CHECK_BOUND( t_3, "TypeOfFamilies" );
     C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
     C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
     C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
     t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-    CHECK_FUNC_RESULT( t_1 )
+    CHECK_FUNC_RESULT( t_1 );
     SWITCH_TO_OLD_FRAME(oldFrame);
     return t_1;
     
@@ -815,20 +815,20 @@ static Obj  HdlrFunc10 (
    else {
     t_3 = GF_LEN__LIST;
     t_2 = CALL_1ARGS( t_3, a_arg );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(4) ));
     if ( t_1 ) {
      
      /* return NewFamily5( TypeOfFamilies, arg[1], arg[2], arg[3], arg[4] ); */
      t_2 = GF_NewFamily5;
      t_3 = GC_TypeOfFamilies;
-     CHECK_BOUND( t_3, "TypeOfFamilies" )
+     CHECK_BOUND( t_3, "TypeOfFamilies" );
      C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
      C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
      C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
      C_ELM_LIST_FPL( t_7, a_arg, INTOBJ_INT(4) )
      t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, t_7 );
-     CHECK_FUNC_RESULT( t_1 )
+     CHECK_FUNC_RESULT( t_1 );
      SWITCH_TO_OLD_FRAME(oldFrame);
      return t_1;
      
@@ -904,9 +904,9 @@ static Obj  HdlrFunc11 (
  /* lock := WRITE_LOCK( DS_TYPE_CACHE ); */
  t_2 = GF_WRITE__LOCK;
  t_3 = GC_DS__TYPE__CACHE;
- CHECK_BOUND( t_3, "DS_TYPE_CACHE" )
+ CHECK_BOUND( t_3, "DS_TYPE_CACHE" );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_lock = t_1;
  
  /* cache := family!.TYPES; */
@@ -916,14 +916,14 @@ static Obj  HdlrFunc11 (
  /* hash := HASH_FLAGS( flags ) mod family!.HASH_SIZE + 1; */
  t_4 = GF_HASH__FLAGS;
  t_3 = CALL_1ARGS( t_4, a_flags );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = ElmComObj( a_family, R_HASH__SIZE );
  t_2 = MOD( t_3, t_4 );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  l_hash = t_1;
  
  /* if IsBound( cache[hash] ) then */
- CHECK_INT_POS( l_hash )
+ CHECK_INT_POS( l_hash );
  t_2 = C_ISB_LIST( l_cache, l_hash );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
@@ -936,8 +936,8 @@ static Obj  HdlrFunc11 (
   t_3 = GF_IS__EQUAL__FLAGS;
   t_4 = ElmPosObj( l_cached, 2 );
   t_2 = CALL_2ARGS( t_3, a_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -949,18 +949,18 @@ static Obj  HdlrFunc11 (
    t_4 = GF_IS__IDENTICAL__OBJ;
    t_5 = ElmPosObj( l_cached, 3 );
    t_3 = CALL_2ARGS( t_4, a_data, t_5 );
-   CHECK_FUNC_RESULT( t_3 )
-   CHECK_BOOL( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
+   CHECK_BOOL( t_3 );
    t_2 = (Obj)(UInt)(t_3 != False);
    t_1 = t_2;
    if ( t_1 ) {
     t_5 = GF_IS__IDENTICAL__OBJ;
     t_7 = GF_TYPE__OBJ;
     t_6 = CALL_1ARGS( t_7, l_cached );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_4 = CALL_2ARGS( t_5, a_typeOfTypes, t_6 );
-    CHECK_FUNC_RESULT( t_4 )
-    CHECK_BOOL( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
+    CHECK_BOOL( t_4 );
     t_3 = (Obj)(UInt)(t_4 != False);
     t_1 = t_3;
    }
@@ -969,10 +969,10 @@ static Obj  HdlrFunc11 (
     /* if IS_IDENTICAL_OBJ( parent, fail ) then */
     t_3 = GF_IS__IDENTICAL__OBJ;
     t_4 = GC_fail;
-    CHECK_BOUND( t_4, "fail" )
+    CHECK_BOUND( t_4, "fail" );
     t_2 = CALL_2ARGS( t_3, a_parent, t_4 );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_BOOL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -983,8 +983,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( cached ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, l_cached );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1014,7 +1014,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -1035,10 +1035,10 @@ static Obj  HdlrFunc11 (
     /* if LEN_POSOBJ( parent ) = LEN_POSOBJ( cached ) then */
     t_3 = GF_LEN__POSOBJ;
     t_2 = CALL_1ARGS( t_3, a_parent );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     t_4 = GF_LEN__POSOBJ;
     t_3 = CALL_1ARGS( t_4, l_cached );
-    CHECK_FUNC_RESULT( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
     t_1 = (Obj)(UInt)(EQ( t_2, t_3 ));
     if ( t_1 ) {
      
@@ -1049,8 +1049,8 @@ static Obj  HdlrFunc11 (
      /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
      t_3 = GF_LEN__POSOBJ;
      t_2 = CALL_1ARGS( t_3, a_parent );
-     CHECK_FUNC_RESULT( t_2 )
-     CHECK_INT_SMALL( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
+     CHECK_INT_SMALL( t_2 );
      for ( t_1 = INTOBJ_INT(5);
            ((Int)t_1) <= ((Int)t_2);
            t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1087,8 +1087,8 @@ static Obj  HdlrFunc11 (
        t_9 = ElmPosObj( a_parent, INT_INTOBJ(l_i) );
        t_10 = ElmPosObj( l_cached, INT_INTOBJ(l_i) );
        t_7 = CALL_2ARGS( t_8, t_9, t_10 );
-       CHECK_FUNC_RESULT( t_7 )
-       CHECK_BOOL( t_7 )
+       CHECK_FUNC_RESULT( t_7 );
+       CHECK_BOOL( t_7 );
        t_6 = (Obj)(UInt)(t_7 != False);
        t_5 = (Obj)(UInt)( ! ((Int)t_6) );
        t_3 = t_5;
@@ -1114,7 +1114,7 @@ static Obj  HdlrFunc11 (
       
       /* NEW_TYPE_CACHE_HIT := NEW_TYPE_CACHE_HIT + 1; */
       t_2 = GC_NEW__TYPE__CACHE__HIT;
-      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" )
+      CHECK_BOUND( t_2, "NEW_TYPE_CACHE_HIT" );
       C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
       AssGVar( G_NEW__TYPE__CACHE__HIT, t_1 );
       
@@ -1140,7 +1140,7 @@ static Obj  HdlrFunc11 (
   
   /* NEW_TYPE_CACHE_MISS := NEW_TYPE_CACHE_MISS + 1; */
   t_2 = GC_NEW__TYPE__CACHE__MISS;
-  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" )
+  CHECK_BOUND( t_2, "NEW_TYPE_CACHE_MISS" );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
   AssGVar( G_NEW__TYPE__CACHE__MISS, t_1 );
   
@@ -1149,15 +1149,15 @@ static Obj  HdlrFunc11 (
  
  /* NEW_TYPE_NEXT_ID := NEW_TYPE_NEXT_ID + 1; */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
  AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
  
  /* if NEW_TYPE_NEXT_ID >= NEW_TYPE_ID_LIMIT then */
  t_2 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_2, "NEW_TYPE_NEXT_ID" );
  t_3 = GC_NEW__TYPE__ID__LIMIT;
- CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" )
+ CHECK_BOUND( t_3, "NEW_TYPE_ID_LIMIT" );
  t_1 = (Obj)(UInt)(! LT( t_2, t_3 ));
  if ( t_1 ) {
   
@@ -1173,7 +1173,7 @@ static Obj  HdlrFunc11 (
   /* NEW_TYPE_NEXT_ID := COMPACT_TYPE_IDS(  ); */
   t_2 = GF_COMPACT__TYPE__IDS;
   t_1 = CALL_0ARGS( t_2 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   AssGVar( G_NEW__TYPE__NEXT__ID, t_1 );
   
  }
@@ -1191,7 +1191,7 @@ static Obj  HdlrFunc11 (
  /* data := MakeReadOnlyObj( data ); */
  t_2 = GF_MakeReadOnlyObj;
  t_1 = CALL_1ARGS( t_2, a_data );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  a_data = t_1;
  
  /* type[3] := data; */
@@ -1199,16 +1199,16 @@ static Obj  HdlrFunc11 (
  
  /* type[4] := NEW_TYPE_NEXT_ID; */
  t_1 = GC_NEW__TYPE__NEXT__ID;
- CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" )
+ CHECK_BOUND( t_1, "NEW_TYPE_NEXT_ID" );
  C_ASS_LIST_FPL( l_type, INTOBJ_INT(4), t_1 )
  
  /* if not IS_IDENTICAL_OBJ( parent, fail ) then */
  t_4 = GF_IS__IDENTICAL__OBJ;
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_3 = CALL_2ARGS( t_4, a_parent, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1216,8 +1216,8 @@ static Obj  HdlrFunc11 (
   /* for i in [ 5 .. LEN_POSOBJ( parent ) ] do */
   t_3 = GF_LEN__POSOBJ;
   t_2 = CALL_1ARGS( t_3, a_parent );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_INT_SMALL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_INT_SMALL( t_2 );
   for ( t_1 = INTOBJ_INT(5);
         ((Int)t_1) <= ((Int)t_2);
         t_1 = (Obj)(((UInt)t_1)+4) ) {
@@ -1267,7 +1267,7 @@ static Obj  HdlrFunc11 (
   /* MIGRATE_RAW( ncache, DS_TYPE_CACHE ); */
   t_1 = GF_MIGRATE__RAW;
   t_2 = GC_DS__TYPE__CACHE;
-  CHECK_BOUND( t_2, "DS_TYPE_CACHE" )
+  CHECK_BOUND( t_2, "DS_TYPE_CACHE" );
   CALL_2ARGS( t_1, l_ncache, t_2 );
   
   /* ncl := 3 * family!.HASH_SIZE + 1; */
@@ -1303,10 +1303,10 @@ static Obj  HdlrFunc11 (
    t_8 = GF_HASH__FLAGS;
    t_9 = ElmPosObj( l_t, 2 );
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_6 = MOD( t_7, l_ncl );
    C_SUM_FIA( t_5, t_6, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_5 )
+   CHECK_INT_POS( t_5 );
    C_ASS_LIST_FPL( l_ncache, t_5, l_t )
    
   }
@@ -1321,10 +1321,10 @@ static Obj  HdlrFunc11 (
   /* ncache[HASH_FLAGS( flags ) mod ncl + 1] := type; */
   t_4 = GF_HASH__FLAGS;
   t_3 = CALL_1ARGS( t_4, a_flags );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = MOD( t_3, l_ncl );
   C_SUM_FIA( t_1, t_2, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_1 )
+  CHECK_INT_POS( t_1 );
   C_ASS_LIST_FPL( l_ncache, t_1, l_type )
   
  }
@@ -1388,17 +1388,17 @@ static Obj  HdlrFunc12 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_5 = GC_fail;
- CHECK_BOUND( t_5, "fail" )
+ CHECK_BOUND( t_5, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, t_4, t_5 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1436,15 +1436,15 @@ static Obj  HdlrFunc13 (
  t_7 = ElmComObj( a_family, R_IMP__FLAGS );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_4 = GC_fail;
- CHECK_BOUND( t_4, "fail" )
+ CHECK_BOUND( t_4, "fail" );
  t_1 = CALL_5ARGS( t_2, a_typeOfTypes, a_family, t_3, a_data, t_4 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1475,8 +1475,8 @@ static Obj  HdlrFunc14 (
  t_4 = GF_IsFamily;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1492,18 +1492,18 @@ static Obj  HdlrFunc14 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
   /* type := NewType3( TypeOfTypes, arg[1], arg[2] ); */
   t_2 = GF_NewType3;
   t_3 = GC_TypeOfTypes;
-  CHECK_BOUND( t_3, "TypeOfTypes" )
+  CHECK_BOUND( t_3, "TypeOfTypes" );
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1512,19 +1512,19 @@ static Obj  HdlrFunc14 (
  else {
   t_3 = GF_LEN__LIST;
   t_2 = CALL_1ARGS( t_3, a_arg );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(3) ));
   if ( t_1 ) {
    
    /* type := NewType4( TypeOfTypes, arg[1], arg[2], arg[3] ); */
    t_2 = GF_NewType4;
    t_3 = GC_TypeOfTypes;
-   CHECK_BOUND( t_3, "TypeOfTypes" )
+   CHECK_BOUND( t_3, "TypeOfTypes" );
    C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(1) )
    C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(2) )
    C_ELM_LIST_FPL( t_6, a_arg, INTOBJ_INT(3) )
    t_1 = CALL_4ARGS( t_2, t_3, t_4, t_5, t_6 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_type = t_1;
    
   }
@@ -1542,7 +1542,7 @@ static Obj  HdlrFunc14 (
  /* fi */
  
  /* return type; */
- CHECK_BOUND( l_type, "type" )
+ CHECK_BOUND( l_type, "type" );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return l_type;
  
@@ -1576,21 +1576,21 @@ static Obj  HdlrFunc15 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1625,20 +1625,20 @@ static Obj  HdlrFunc16 (
  /* return NEW_TYPE( TypeOfTypes, type![1], WITH_IMPS_FLAGS( AND_FLAGS( type![2], FLAGS_FILTER( filter ) ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_WITH__IMPS__FLAGS;
  t_8 = GF_AND__FLAGS;
  t_9 = ElmPosObj( a_type, 2 );
  t_11 = GF_FLAGS__FILTER;
  t_10 = CALL_1ARGS( t_11, a_filter );
- CHECK_FUNC_RESULT( t_10 )
+ CHECK_FUNC_RESULT( t_10 );
  t_7 = CALL_2ARGS( t_8, t_9, t_10 );
- CHECK_FUNC_RESULT( t_7 )
+ CHECK_FUNC_RESULT( t_7 );
  t_5 = CALL_1ARGS( t_6, t_7 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1669,15 +1669,15 @@ static Obj  HdlrFunc17 (
  /* p := READ_LOCK( arg ); */
  t_2 = GF_READ__LOCK;
  t_1 = CALL_1ARGS( t_2, a_arg );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_p = t_1;
  
  /* if not IsType( arg[1] ) then */
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1693,7 +1693,7 @@ static Obj  HdlrFunc17 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1702,7 +1702,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1716,7 +1716,7 @@ static Obj  HdlrFunc17 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   l_type = t_1;
   
  }
@@ -1758,18 +1758,18 @@ static Obj  HdlrFunc18 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), type![3], type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_6 = ElmPosObj( a_type, 3 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, t_6, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1802,17 +1802,17 @@ static Obj  HdlrFunc19 (
  /* return NEW_TYPE( TypeOfTypes, type![1], SUB_FLAGS( type![2], FLAGS_FILTER( filter ) ), data, type ); */
  t_2 = GF_NEW__TYPE;
  t_3 = GC_TypeOfTypes;
- CHECK_BOUND( t_3, "TypeOfTypes" )
+ CHECK_BOUND( t_3, "TypeOfTypes" );
  t_4 = ElmPosObj( a_type, 1 );
  t_6 = GF_SUB__FLAGS;
  t_7 = ElmPosObj( a_type, 2 );
  t_9 = GF_FLAGS__FILTER;
  t_8 = CALL_1ARGS( t_9, a_filter );
- CHECK_FUNC_RESULT( t_8 )
+ CHECK_FUNC_RESULT( t_8 );
  t_5 = CALL_2ARGS( t_6, t_7, t_8 );
- CHECK_FUNC_RESULT( t_5 )
+ CHECK_FUNC_RESULT( t_5 );
  t_1 = CALL_5ARGS( t_2, t_3, t_4, t_5, a_data, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -1840,8 +1840,8 @@ static Obj  HdlrFunc20 (
  t_4 = GF_IsType;
  C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(1) )
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -1857,7 +1857,7 @@ static Obj  HdlrFunc20 (
  /* if LEN_LIST( arg ) = 2 then */
  t_3 = GF_LEN__LIST;
  t_2 = CALL_1ARGS( t_3, a_arg );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_1 = (Obj)(UInt)(EQ( t_2, INTOBJ_INT(2) ));
  if ( t_1 ) {
   
@@ -1866,7 +1866,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_3, a_arg, INTOBJ_INT(1) )
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   t_1 = CALL_2ARGS( t_2, t_3, t_4 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1881,7 +1881,7 @@ static Obj  HdlrFunc20 (
   C_ELM_LIST_FPL( t_4, a_arg, INTOBJ_INT(2) )
   C_ELM_LIST_FPL( t_5, a_arg, INTOBJ_INT(3) )
   t_1 = CALL_3ARGS( t_2, t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_1 )
+  CHECK_FUNC_RESULT( t_1 );
   SWITCH_TO_OLD_FRAME(oldFrame);
   return t_1;
   
@@ -1978,7 +1978,7 @@ static Obj  HdlrFunc24 (
  t_1 = GF_StrictBindOnce;
  t_3 = GF_MakeImmutable;
  t_2 = CALL_1ARGS( t_3, a_data );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_3ARGS( t_1, a_K, INTOBJ_INT(3), t_2 );
  
  /* return; */
@@ -2008,9 +2008,9 @@ static Obj  HdlrFunc25 (
  t_2 = GF_FlagsType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -2037,9 +2037,9 @@ static Obj  HdlrFunc26 (
  t_2 = GF_DataType;
  t_4 = GF_TypeObj;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -2069,8 +2069,8 @@ static Obj  HdlrFunc27 (
  /* if not IsType( type ) then */
  t_4 = GF_IsType;
  t_3 = CALL_1ARGS( t_4, a_type );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2086,24 +2086,24 @@ static Obj  HdlrFunc27 (
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, a_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
   /* if IS_SUBSET_FLAGS( flags, IsAtomicPositionalObjectRepFlags ) then */
   t_3 = GF_IS__SUBSET__FLAGS;
   t_4 = GC_IsAtomicPositionalObjectRepFlags;
-  CHECK_BOUND( t_4, "IsAtomicPositionalObjectRepFlags" )
+  CHECK_BOUND( t_4, "IsAtomicPositionalObjectRepFlags" );
   t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2111,7 +2111,7 @@ static Obj  HdlrFunc27 (
    t_1 = GF_FORCE__SWITCH__OBJ;
    t_3 = GF_FixedAtomicList;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2123,26 +2123,26 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
    /* if IS_ATOMIC_RECORD( obj ) then */
    t_3 = GF_IS__ATOMIC__RECORD;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
     /* if IS_SUBSET_FLAGS( flags, IsNonAtomicComponentObjectRepFlags ) then */
     t_3 = GF_IS__SUBSET__FLAGS;
     t_4 = GC_IsNonAtomicComponentObjectRepFlags;
-    CHECK_BOUND( t_4, "IsNonAtomicComponentObjectRepFlags" )
+    CHECK_BOUND( t_4, "IsNonAtomicComponentObjectRepFlags" );
     t_2 = CALL_2ARGS( t_3, l_flags, t_4 );
-    CHECK_FUNC_RESULT( t_2 )
-    CHECK_BOOL( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
+    CHECK_BOOL( t_2 );
     t_1 = (Obj)(UInt)(t_2 != False);
     if ( t_1 ) {
      
@@ -2150,7 +2150,7 @@ static Obj  HdlrFunc27 (
      t_1 = GF_FORCE__SWITCH__OBJ;
      t_3 = GF_FromAtomicRecord;
      t_2 = CALL_1ARGS( t_3, a_obj );
-     CHECK_FUNC_RESULT( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
      CALL_2ARGS( t_1, a_obj, t_2 );
      
     }
@@ -2162,10 +2162,10 @@ static Obj  HdlrFunc27 (
    else {
     t_4 = GF_IS__SUBSET__FLAGS;
     t_5 = GC_IsNonAtomicComponentObjectRepFlags;
-    CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRepFlags" )
+    CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRepFlags" );
     t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
-    CHECK_FUNC_RESULT( t_3 )
-    CHECK_BOOL( t_3 )
+    CHECK_FUNC_RESULT( t_3 );
+    CHECK_BOOL( t_3 );
     t_2 = (Obj)(UInt)(t_3 != False);
     t_1 = (Obj)(UInt)( ! ((Int)t_2) );
     if ( t_1 ) {
@@ -2174,7 +2174,7 @@ static Obj  HdlrFunc27 (
      t_1 = GF_FORCE__SWITCH__OBJ;
      t_3 = GF_AtomicRecord;
      t_2 = CALL_1ARGS( t_3, a_obj );
-     CHECK_FUNC_RESULT( t_2 )
+     CHECK_FUNC_RESULT( t_2 );
      CALL_2ARGS( t_1, a_obj, t_2 );
      
     }
@@ -2188,8 +2188,8 @@ static Obj  HdlrFunc27 (
  /* if IS_LIST( obj ) then */
  t_3 = GF_IS__LIST;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2203,8 +2203,8 @@ static Obj  HdlrFunc27 (
  else {
   t_3 = GF_IS__REC;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2219,8 +2219,8 @@ static Obj  HdlrFunc27 (
  /* if not IsNoImmediateMethodsObject( obj ) then */
  t_4 = GF_IsNoImmediateMethodsObject;
  t_3 = CALL_1ARGS( t_4, a_obj );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2236,8 +2236,8 @@ static Obj  HdlrFunc27 (
  /* if IsReadOnlyPositionalObjectRep( obj ) then */
  t_3 = GF_IsReadOnlyPositionalObjectRep;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2281,20 +2281,20 @@ static Obj  HdlrFunc28 (
  /* type := TYPE_OBJ( obj ); */
  t_2 = GF_TYPE__OBJ;
  t_1 = CALL_1ARGS( t_2, a_obj );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_type = t_1;
  
  /* newtype := Subtype2( type, filter ); */
  t_2 = GF_Subtype2;
  t_1 = CALL_2ARGS( t_2, l_type, a_filter );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_newtype = t_1;
  
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2308,8 +2308,8 @@ static Obj  HdlrFunc28 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2323,8 +2323,8 @@ static Obj  HdlrFunc28 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2349,15 +2349,15 @@ static Obj  HdlrFunc28 (
  
  /* if not (IGNORE_IMMEDIATE_METHODS or IsNoImmediateMethodsObject( obj )) then */
  t_4 = GC_IGNORE__IMMEDIATE__METHODS;
- CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" )
- CHECK_BOOL( t_4 )
+ CHECK_BOUND( t_4, "IGNORE_IMMEDIATE_METHODS" );
+ CHECK_BOOL( t_4 );
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = t_3;
  if ( ! t_2 ) {
   t_6 = GF_IsNoImmediateMethodsObject;
   t_5 = CALL_1ARGS( t_6, a_obj );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_BOOL( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_BOOL( t_5 );
   t_4 = (Obj)(UInt)(t_5 != False);
   t_2 = t_4;
  }
@@ -2370,7 +2370,7 @@ static Obj  HdlrFunc28 (
   t_4 = ElmPosObj( l_newtype, 2 );
   t_5 = ElmPosObj( l_type, 2 );
   t_2 = CALL_2ARGS( t_3, t_4, t_5 );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2404,8 +2404,8 @@ static Obj  HdlrFunc29 (
  /* if IS_AND_FILTER( filter ) then */
  t_3 = GF_IS__AND__FILTER;
  t_2 = CALL_1ARGS( t_3, a_filter );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2420,8 +2420,8 @@ static Obj  HdlrFunc29 (
  /* if IS_POSOBJ( obj ) then */
  t_3 = GF_IS__POSOBJ;
  t_2 = CALL_1ARGS( t_3, a_obj );
- CHECK_FUNC_RESULT( t_2 )
- CHECK_BOOL( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
+ CHECK_BOOL( t_2 );
  t_1 = (Obj)(UInt)(t_2 != False);
  if ( t_1 ) {
   
@@ -2430,9 +2430,9 @@ static Obj  HdlrFunc29 (
   t_3 = GF_SupType2;
   t_5 = GF_TYPE__OBJ;
   t_4 = CALL_1ARGS( t_5, a_obj );
-  CHECK_FUNC_RESULT( t_4 )
+  CHECK_FUNC_RESULT( t_4 );
   t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-  CHECK_FUNC_RESULT( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
   CALL_2ARGS( t_1, a_obj, t_2 );
   
  }
@@ -2441,8 +2441,8 @@ static Obj  HdlrFunc29 (
  else {
   t_3 = GF_IS__COMOBJ;
   t_2 = CALL_1ARGS( t_3, a_obj );
-  CHECK_FUNC_RESULT( t_2 )
-  CHECK_BOOL( t_2 )
+  CHECK_FUNC_RESULT( t_2 );
+  CHECK_BOOL( t_2 );
   t_1 = (Obj)(UInt)(t_2 != False);
   if ( t_1 ) {
    
@@ -2451,9 +2451,9 @@ static Obj  HdlrFunc29 (
    t_3 = GF_SupType2;
    t_5 = GF_TYPE__OBJ;
    t_4 = CALL_1ARGS( t_5, a_obj );
-   CHECK_FUNC_RESULT( t_4 )
+   CHECK_FUNC_RESULT( t_4 );
    t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, a_obj, t_2 );
    
   }
@@ -2462,8 +2462,8 @@ static Obj  HdlrFunc29 (
   else {
    t_3 = GF_IS__DATOBJ;
    t_2 = CALL_1ARGS( t_3, a_obj );
-   CHECK_FUNC_RESULT( t_2 )
-   CHECK_BOOL( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
+   CHECK_BOOL( t_2 );
    t_1 = (Obj)(UInt)(t_2 != False);
    if ( t_1 ) {
     
@@ -2472,9 +2472,9 @@ static Obj  HdlrFunc29 (
     t_3 = GF_SupType2;
     t_5 = GF_TYPE__OBJ;
     t_4 = CALL_1ARGS( t_5, a_obj );
-    CHECK_FUNC_RESULT( t_4 )
+    CHECK_FUNC_RESULT( t_4 );
     t_2 = CALL_2ARGS( t_3, t_4, a_filter );
-    CHECK_FUNC_RESULT( t_2 )
+    CHECK_FUNC_RESULT( t_2 );
     CALL_2ARGS( t_1, a_obj, t_2 );
     
    }
@@ -2549,7 +2549,7 @@ static Obj  HdlrFunc30 (
  /* flags := FlagsType( type ); */
  t_2 = GF_FlagsType;
  t_1 = CALL_1ARGS( t_2, l_type );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  l_flags = t_1;
  
  /* extra := [  ]; */
@@ -2560,10 +2560,10 @@ static Obj  HdlrFunc30 (
  /* if not IS_SUBSET_FLAGS( flags, IsAttributeStoringRepFlags ) then */
  t_4 = GF_IS__SUBSET__FLAGS;
  t_5 = GC_IsAttributeStoringRepFlags;
- CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRepFlags" );
  t_3 = CALL_2ARGS( t_4, l_flags, t_5 );
- CHECK_FUNC_RESULT( t_3 )
- CHECK_BOOL( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
+ CHECK_BOOL( t_3 );
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (Obj)(UInt)( ! ((Int)t_2) );
  if ( t_1 ) {
@@ -2571,7 +2571,7 @@ static Obj  HdlrFunc30 (
   /* extra := arg{[ 3 .. LEN_LIST( arg ) ]}; */
   t_4 = GF_LEN__LIST;
   t_3 = CALL_1ARGS( t_4, a_arg );
-  CHECK_FUNC_RESULT( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
   t_2 = Range2Check( INTOBJ_INT(3), t_3 );
   t_1 = ElmsListCheck( a_arg, t_2 );
   l_extra = t_1;
@@ -2593,13 +2593,13 @@ static Obj  HdlrFunc30 (
   
   /* nflags := EMPTY_FLAGS; */
   t_1 = GC_EMPTY__FLAGS;
-  CHECK_BOUND( t_1, "EMPTY_FLAGS" )
+  CHECK_BOUND( t_1, "EMPTY_FLAGS" );
   l_nflags = t_1;
   
   /* for i in [ 3, 5 .. LEN_LIST( arg ) - 1 ] do */
   t_7 = GF_LEN__LIST;
   t_6 = CALL_1ARGS( t_7, a_arg );
-  CHECK_FUNC_RESULT( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
   C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
   t_4 = Range3Check( INTOBJ_INT(3), INTOBJ_INT(5), t_5 );
   if ( IS_SMALL_LIST(t_4) ) {
@@ -2624,25 +2624,25 @@ static Obj  HdlrFunc30 (
    l_i = t_2;
    
    /* attr := arg[i]; */
-   CHECK_INT_POS( l_i )
+   CHECK_INT_POS( l_i );
    C_ELM_LIST_FPL( t_5, a_arg, l_i )
    l_attr = t_5;
    
    /* val := arg[i + 1]; */
    C_SUM_FIA( t_6, l_i, INTOBJ_INT(1) )
-   CHECK_INT_POS( t_6 )
+   CHECK_INT_POS( t_6 );
    C_ELM_LIST_FPL( t_5, a_arg, t_6 )
    l_val = t_5;
    
    /* if 0 <> FLAG1_FILTER( attr ) then */
    t_7 = GF_FLAG1__FILTER;
    t_6 = CALL_1ARGS( t_7, l_attr );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_5 = (Obj)(UInt)( ! EQ( INTOBJ_INT(0), t_6 ));
    if ( t_5 ) {
     
     /* if val then */
-    CHECK_BOOL( l_val )
+    CHECK_BOOL( l_val );
     t_5 = (Obj)(UInt)(l_val != False);
     if ( t_5 ) {
      
@@ -2650,9 +2650,9 @@ static Obj  HdlrFunc30 (
      t_6 = GF_AND__FLAGS;
      t_8 = GF_FLAGS__FILTER;
      t_7 = CALL_1ARGS( t_8, l_attr );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2665,11 +2665,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2683,13 +2683,13 @@ static Obj  HdlrFunc30 (
     t_9 = GF_METHODS__OPERATION;
     t_11 = GF_Setter;
     t_10 = CALL_1ARGS( t_11, l_attr );
-    CHECK_FUNC_RESULT( t_10 )
+    CHECK_FUNC_RESULT( t_10 );
     t_8 = CALL_2ARGS( t_9, t_10, INTOBJ_INT(2) );
-    CHECK_FUNC_RESULT( t_8 )
+    CHECK_FUNC_RESULT( t_8 );
     t_6 = CALL_1ARGS( t_7, t_8 );
-    CHECK_FUNC_RESULT( t_6 )
+    CHECK_FUNC_RESULT( t_6 );
     t_7 = GC_LENGTH__SETTER__METHODS__2;
-    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" )
+    CHECK_BOUND( t_7, "LENGTH_SETTER_METHODS_2" );
     t_5 = (Obj)(UInt)( ! EQ( t_6, t_7 ));
     if ( t_5 ) {
      
@@ -2709,10 +2709,10 @@ static Obj  HdlrFunc30 (
      /* obj.(NAME_FUNC( attr )) := IMMUTABLE_COPY_OBJ( val ); */
      t_6 = GF_NAME__FUNC;
      t_5 = CALL_1ARGS( t_6, l_attr );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      t_7 = GF_IMMUTABLE__COPY__OBJ;
      t_6 = CALL_1ARGS( t_7, l_val );
-     CHECK_FUNC_RESULT( t_6 )
+     CHECK_FUNC_RESULT( t_6 );
      ASS_REC( l_obj, RNamObj(t_5), t_6 );
      
      /* nflags := AND_FLAGS( nflags, FLAGS_FILTER( Tester( attr ) ) ); */
@@ -2720,11 +2720,11 @@ static Obj  HdlrFunc30 (
      t_8 = GF_FLAGS__FILTER;
      t_10 = GF_Tester;
      t_9 = CALL_1ARGS( t_10, l_attr );
-     CHECK_FUNC_RESULT( t_9 )
+     CHECK_FUNC_RESULT( t_9 );
      t_7 = CALL_1ARGS( t_8, t_9 );
-     CHECK_FUNC_RESULT( t_7 )
+     CHECK_FUNC_RESULT( t_7 );
      t_5 = CALL_2ARGS( t_6, l_nflags, t_7 );
-     CHECK_FUNC_RESULT( t_5 )
+     CHECK_FUNC_RESULT( t_5 );
      l_nflags = t_5;
      
     }
@@ -2737,8 +2737,8 @@ static Obj  HdlrFunc30 (
   /* if not IS_SUBSET_FLAGS( flags, nflags ) then */
   t_4 = GF_IS__SUBSET__FLAGS;
   t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-  CHECK_FUNC_RESULT( t_3 )
-  CHECK_BOOL( t_3 )
+  CHECK_FUNC_RESULT( t_3 );
+  CHECK_BOOL( t_3 );
   t_2 = (Obj)(UInt)(t_3 != False);
   t_1 = (Obj)(UInt)( ! ((Int)t_2) );
   if ( t_1 ) {
@@ -2747,26 +2747,26 @@ static Obj  HdlrFunc30 (
    t_2 = GF_WITH__IMPS__FLAGS;
    t_4 = GF_AND__FLAGS;
    t_3 = CALL_2ARGS( t_4, l_flags, l_nflags );
-   CHECK_FUNC_RESULT( t_3 )
+   CHECK_FUNC_RESULT( t_3 );
    t_1 = CALL_1ARGS( t_2, t_3 );
-   CHECK_FUNC_RESULT( t_1 )
+   CHECK_FUNC_RESULT( t_1 );
    l_flags = t_1;
    
    /* Objectify( NEW_TYPE( TypeOfTypes, FamilyType( type ), flags, DataType( type ), fail ), obj ); */
    t_1 = GF_Objectify;
    t_3 = GF_NEW__TYPE;
    t_4 = GC_TypeOfTypes;
-   CHECK_BOUND( t_4, "TypeOfTypes" )
+   CHECK_BOUND( t_4, "TypeOfTypes" );
    t_6 = GF_FamilyType;
    t_5 = CALL_1ARGS( t_6, l_type );
-   CHECK_FUNC_RESULT( t_5 )
+   CHECK_FUNC_RESULT( t_5 );
    t_7 = GF_DataType;
    t_6 = CALL_1ARGS( t_7, l_type );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    t_7 = GC_fail;
-   CHECK_BOUND( t_7, "fail" )
+   CHECK_BOUND( t_7, "fail" );
    t_2 = CALL_5ARGS( t_3, t_4, t_5, l_flags, t_6, t_7 );
-   CHECK_FUNC_RESULT( t_2 )
+   CHECK_FUNC_RESULT( t_2 );
    CALL_2ARGS( t_1, t_2, l_obj );
    
   }
@@ -2787,7 +2787,7 @@ static Obj  HdlrFunc30 (
  /* for i in [ 1, 3 .. LEN_LIST( extra ) - 1 ] do */
  t_7 = GF_LEN__LIST;
  t_6 = CALL_1ARGS( t_7, l_extra );
- CHECK_FUNC_RESULT( t_6 )
+ CHECK_FUNC_RESULT( t_6 );
  C_DIFF_FIA( t_5, t_6, INTOBJ_INT(1) )
  t_4 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(3), t_5 );
  if ( IS_SMALL_LIST(t_4) ) {
@@ -2813,14 +2813,14 @@ static Obj  HdlrFunc30 (
   
   /* if Tester( extra[i] )( obj ) then */
   t_8 = GF_Tester;
-  CHECK_INT_POS( l_i )
+  CHECK_INT_POS( l_i );
   C_ELM_LIST_FPL( t_9, l_extra, l_i )
   t_7 = CALL_1ARGS( t_8, t_9 );
-  CHECK_FUNC_RESULT( t_7 )
-  CHECK_FUNC( t_7 )
+  CHECK_FUNC_RESULT( t_7 );
+  CHECK_FUNC( t_7 );
   t_6 = CALL_1ARGS( t_7, l_obj );
-  CHECK_FUNC_RESULT( t_6 )
-  CHECK_BOOL( t_6 )
+  CHECK_FUNC_RESULT( t_6 );
+  CHECK_BOOL( t_6 );
   t_5 = (Obj)(UInt)(t_6 != False);
   if ( t_5 ) {
    
@@ -2830,7 +2830,7 @@ static Obj  HdlrFunc30 (
    t_8 = GF_NAME__FUNC;
    C_ELM_LIST_FPL( t_9, l_extra, l_i )
    t_7 = CALL_1ARGS( t_8, t_9 );
-   CHECK_FUNC_RESULT( t_7 )
+   CHECK_FUNC_RESULT( t_7 );
    t_8 = MakeString( "with non-standard setter\n" );
    CALL_3ARGS( t_5, t_6, t_7, t_8 );
    
@@ -2839,7 +2839,7 @@ static Obj  HdlrFunc30 (
    t_7 = GF_Tester;
    C_ELM_LIST_FPL( t_8, l_extra, l_i )
    t_6 = CALL_1ARGS( t_7, t_8 );
-   CHECK_FUNC_RESULT( t_6 )
+   CHECK_FUNC_RESULT( t_6 );
    CALL_2ARGS( t_5, l_obj, t_6 );
    
   }
@@ -2849,10 +2849,10 @@ static Obj  HdlrFunc30 (
   t_6 = GF_Setter;
   C_ELM_LIST_FPL( t_7, l_extra, l_i )
   t_5 = CALL_1ARGS( t_6, t_7 );
-  CHECK_FUNC_RESULT( t_5 )
-  CHECK_FUNC( t_5 )
+  CHECK_FUNC_RESULT( t_5 );
+  CHECK_FUNC( t_5 );
   C_SUM_FIA( t_7, l_i, INTOBJ_INT(1) )
-  CHECK_INT_POS( t_7 )
+  CHECK_INT_POS( t_7 );
   C_ELM_LIST_FPL( t_6, l_extra, t_7 )
   CALL_2ARGS( t_5, l_obj, t_6 );
   
@@ -2898,7 +2898,7 @@ static Obj  HdlrFunc1 (
  
  /* LENGTH_SETTER_METHODS_2 := LENGTH_SETTER_METHODS_2 + (6 + 2); */
  t_2 = GC_LENGTH__SETTER__METHODS__2;
- CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" )
+ CHECK_BOUND( t_2, "LENGTH_SETTER_METHODS_2" );
  C_SUM_INTOBJS( t_3, INTOBJ_INT(6), INTOBJ_INT(2) )
  C_SUM_FIA( t_1, t_2, t_3 )
  AssGVar( G_LENGTH__SETTER__METHODS__2, t_1 );
@@ -2934,7 +2934,7 @@ static Obj  HdlrFunc1 (
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  t_1 = CALL_1ARGS( t_2, t_3 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  AssGVar( G_DS__TYPE__CACHE, t_1 );
  
  /* BIND_GLOBAL( "NEW_FAMILY", function ( typeOfFamilies, name, req_filter, imp_filter )
@@ -3372,14 +3372,14 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "TypeObj" );
  t_3 = GC_TYPE__OBJ;
- CHECK_BOUND( t_3, "TYPE_OBJ" )
+ CHECK_BOUND( t_3, "TYPE_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FamilyObj", FAMILY_OBJ ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "FamilyObj" );
  t_3 = GC_FAMILY__OBJ;
- CHECK_BOUND( t_3, "FAMILY_OBJ" )
+ CHECK_BOUND( t_3, "FAMILY_OBJ" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "FlagsObj", function ( obj )
@@ -3415,9 +3415,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsNonAtomicComponentObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsNonAtomicComponentObjectRep;
- CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" )
+ CHECK_BOUND( t_5, "IsNonAtomicComponentObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAtomicPositionalObjectRepFlags", FLAGS_FILTER( IsAtomicPositionalObjectRep ) ); */
@@ -3425,9 +3425,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAtomicPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAtomicPositionalObjectRep;
- CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsAtomicPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsReadOnlyPositionalObjectRepFlags", FLAGS_FILTER( IsReadOnlyPositionalObjectRep ) ); */
@@ -3435,9 +3435,9 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsReadOnlyPositionalObjectRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsReadOnlyPositionalObjectRep;
- CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" )
+ CHECK_BOUND( t_5, "IsReadOnlyPositionalObjectRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "Objectify", function ( type, obj )
@@ -3519,7 +3519,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "SET_FILTER_OBJ" );
  t_3 = GC_SetFilterObj;
- CHECK_BOUND( t_3, "SetFilterObj" )
+ CHECK_BOUND( t_3, "SetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "ResetFilterObj", function ( obj, filter )
@@ -3552,7 +3552,7 @@ static Obj  HdlrFunc1 (
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "RESET_FILTER_OBJ" );
  t_3 = GC_ResetFilterObj;
- CHECK_BOUND( t_3, "ResetFilterObj" )
+ CHECK_BOUND( t_3, "ResetFilterObj" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "IsAttributeStoringRepFlags", FLAGS_FILTER( IsAttributeStoringRep ) ); */
@@ -3560,16 +3560,16 @@ static Obj  HdlrFunc1 (
  t_2 = MakeString( "IsAttributeStoringRepFlags" );
  t_4 = GF_FLAGS__FILTER;
  t_5 = GC_IsAttributeStoringRep;
- CHECK_BOUND( t_5, "IsAttributeStoringRep" )
+ CHECK_BOUND( t_5, "IsAttributeStoringRep" );
  t_3 = CALL_1ARGS( t_4, t_5 );
- CHECK_FUNC_RESULT( t_3 )
+ CHECK_FUNC_RESULT( t_3 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* BIND_GLOBAL( "INFO_OWA", Ignore ); */
  t_1 = GF_BIND__GLOBAL;
  t_2 = MakeString( "INFO_OWA" );
  t_3 = GC_Ignore;
- CHECK_BOUND( t_3, "Ignore" )
+ CHECK_BOUND( t_3, "Ignore" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* MAKE_READ_WRITE_GLOBAL( "INFO_OWA" ); */

--- a/tst/test-compile/and_filter.g
+++ b/tst/test-compile/and_filter.g
@@ -15,4 +15,7 @@ CALL_WITH_CATCH({} -> Center and IsAssociative, []);
 # trigger error 2:
 CALL_WITH_CATCH({} -> IsAssociative and Center, []);
 
+CALL_WITH_CATCH({} -> 1 and false, []);
+CALL_WITH_CATCH({} -> 1 or true, []);
+
 end;

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -37,7 +37,7 @@ static Obj  HdlrFunc3 (
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_1 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_2 ) ) {
@@ -72,7 +72,7 @@ static Obj  HdlrFunc4 (
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (t_2 ? True : False);
  if ( t_1 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_3 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_1 = (t_3 ? True : False);
  }
@@ -99,19 +99,19 @@ static Obj  HdlrFunc5 (
  
  /* return Center and IsAssociative; */
  t_2 = GC_Center;
- CHECK_BOUND( t_2, "Center" )
+ CHECK_BOUND( t_2, "Center" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_IsAssociative;
-  CHECK_BOUND( t_3, "IsAssociative" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "IsAssociative" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
+  CHECK_BOUND( t_4, "IsAssociative" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -141,19 +141,19 @@ static Obj  HdlrFunc6 (
  
  /* return IsAssociative and Center; */
  t_2 = GC_IsAssociative;
- CHECK_BOUND( t_2, "IsAssociative" )
+ CHECK_BOUND( t_2, "IsAssociative" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_Center;
-  CHECK_BOUND( t_3, "Center" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "Center" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_Center;
-  CHECK_BOUND( t_4, "Center" )
+  CHECK_BOUND( t_4, "Center" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -189,7 +189,7 @@ static Obj  HdlrFunc2 (
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_2 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_3 ) ) {
@@ -208,7 +208,7 @@ static Obj  HdlrFunc2 (
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (t_3 ? True : False);
  if ( t_2 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_4 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_2 = (t_4 ? True : False);
  }
@@ -227,7 +227,7 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -243,26 +243,26 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( IsAssociative and IsAssociative, "\n" ); */
  t_1 = GF_Print;
  t_3 = GC_IsAssociative;
- CHECK_BOUND( t_3, "IsAssociative" )
+ CHECK_BOUND( t_3, "IsAssociative" );
  if ( t_3 == False ) {
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
-  CHECK_BOOL( t_4 )
+  CHECK_BOUND( t_4, "IsAssociative" );
+  CHECK_BOOL( t_4 );
   t_2 = t_4;
  }
  else if (IS_FILTER( t_3 ) ) {
   t_5 = GC_IsAssociative;
-  CHECK_BOUND( t_5, "IsAssociative" )
+  CHECK_BOUND( t_5, "IsAssociative" );
   t_2 = NewAndFilter( t_3, t_5 );
  }
  else {

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -266,7 +266,12 @@ static Obj  HdlrFunc2 (
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( true or 1, "\n" ); */
  t_1 = GF_Print;
@@ -279,7 +284,12 @@ static Obj  HdlrFunc2 (
   t_2 = (t_4 ? True : False);
  }
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( function (  )
         return false and 1;
@@ -292,10 +302,20 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_4, 5);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( function (  )
         return true or 1;
@@ -308,10 +328,20 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_4, 6);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( IsAssociative and IsAssociative, "\n" ); */
  t_1 = GF_Print;
@@ -336,7 +366,12 @@ static Obj  HdlrFunc2 (
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BreakOnError := false; */
  t_1 = False;
@@ -355,7 +390,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return IsAssociative and Center;
@@ -370,7 +410,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return 1 and false;
@@ -385,7 +430,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return 1 or true;
@@ -400,7 +450,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -1,6 +1,6 @@
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-49920958"
+#define FILE_CRC  "-101028112"
 
 /* global variables used in handlers */
 static GVar G_Print;
@@ -17,7 +17,7 @@ static Obj  GC_Center;
 /* record names used in handlers */
 
 /* information for the functions */
-static Obj  NameFunc[7];
+static Obj  NameFunc[9];
 static Obj FileName;
 
 /* handler for function 3 */
@@ -168,6 +168,72 @@ static Obj  HdlrFunc6 (
  return 0;
 }
 
+/* handler for function 7 */
+static Obj  HdlrFunc7 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 and false; */
+ if ( INTOBJ_INT(1) == False ) {
+  t_1 = INTOBJ_INT(1);
+ }
+ else if ( INTOBJ_INT(1) == True ) {
+  t_2 = False;
+  t_1 = t_2;
+ }
+ else if (IS_FILTER( INTOBJ_INT(1) ) ) {
+  t_3 = False;
+  t_1 = NewAndFilter( INTOBJ_INT(1), t_3 );
+ }
+ else {
+  RequireArgumentEx(0, INTOBJ_INT(1), "<expr>",
+  "must be 'true' or 'false' or a filter" );
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 8 */
+static Obj  HdlrFunc8 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 or true; */
+ CHECK_BOOL( INTOBJ_INT(1) );
+ t_2 = (Obj)(UInt)(INTOBJ_INT(1) != False);
+ t_1 = (t_2 ? True : False);
+ if ( t_1 == False ) {
+  t_4 = True;
+  t_3 = (Obj)(UInt)(t_4 != False);
+  t_1 = (t_3 ? True : False);
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
 /* handler for function 2 */
 static Obj  HdlrFunc2 (
  Obj  self )
@@ -306,6 +372,36 @@ static Obj  HdlrFunc2 (
  SET_LEN_PLIST( t_3, 0 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
+ /* CALL_WITH_CATCH( function (  )
+      return 1 and false;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[7], 0, 0, HdlrFunc7 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 18);
+ SET_ENDLINE_BODY(t_3, 18);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
+ /* CALL_WITH_CATCH( function (  )
+      return 1 or true;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[8], 0, 0, HdlrFunc8 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 19);
+ SET_ENDLINE_BODY(t_3, 19);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
@@ -343,13 +439,19 @@ static Obj  HdlrFunc1 (
       CALL_WITH_CATCH( function (  )
             return IsAssociative and Center;
         end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 and false;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 or true;
+        end, [  ] );
       return;
   end; */
  t_1 = NewFunction( NameFunc[2], 0, 0, HdlrFunc2 );
  SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
  t_2 = NewFunctionBody();
  SET_STARTLINE_BODY(t_2, 1);
- SET_ENDLINE_BODY(t_2, 18);
+ SET_ENDLINE_BODY(t_2, 21);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
  AssGVar( G_runtest, t_1 );
@@ -384,6 +486,8 @@ static Int PostRestore ( StructInitInfo * module )
  NameFunc[4] = 0;
  NameFunc[5] = 0;
  NameFunc[6] = 0;
+ NameFunc[7] = 0;
+ NameFunc[8] = 0;
  
  /* return success */
  return 0;
@@ -415,6 +519,10 @@ static Int InitKernel ( StructInitInfo * module )
  InitGlobalBag( &(NameFunc[5]), "and_filter.g:NameFunc[5]("FILE_CRC")" );
  InitHandlerFunc( HdlrFunc6, "and_filter.g:HdlrFunc6("FILE_CRC")" );
  InitGlobalBag( &(NameFunc[6]), "and_filter.g:NameFunc[6]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc7, "and_filter.g:HdlrFunc7("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[7]), "and_filter.g:NameFunc[7]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc8, "and_filter.g:HdlrFunc8("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[8]), "and_filter.g:NameFunc[8]("FILE_CRC")" );
  
  /* return success */
  return 0;
@@ -449,7 +557,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_DYNAMIC,
  .name        = "and_filter.g",
- .crc         = -49920958,
+ .crc         = -101028112,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/tst/test-compile/and_filter.g.out
+++ b/tst/test-compile/and_filter.g.out
@@ -5,3 +5,5 @@ true
 <Property "IsAssociative">
 Error, <expr> must be 'true' or 'false' or a filter (not a function)
 Error, <oper2> must be a filter (not a function)
+Error, <expr> must be 'true' or 'false' or a filter (not the integer 1)
+Error, <expr> must be 'true' or 'false' (not the integer 1)

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -37,7 +37,7 @@ static Obj  HdlrFunc3 (
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_1 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_2 ) ) {
@@ -72,7 +72,7 @@ static Obj  HdlrFunc4 (
  t_2 = (Obj)(UInt)(t_3 != False);
  t_1 = (t_2 ? True : False);
  if ( t_1 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_3 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_1 = (t_3 ? True : False);
  }
@@ -99,19 +99,19 @@ static Obj  HdlrFunc5 (
  
  /* return Center and IsAssociative; */
  t_2 = GC_Center;
- CHECK_BOUND( t_2, "Center" )
+ CHECK_BOUND( t_2, "Center" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_IsAssociative;
-  CHECK_BOUND( t_3, "IsAssociative" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "IsAssociative" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
+  CHECK_BOUND( t_4, "IsAssociative" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -141,19 +141,19 @@ static Obj  HdlrFunc6 (
  
  /* return IsAssociative and Center; */
  t_2 = GC_IsAssociative;
- CHECK_BOUND( t_2, "IsAssociative" )
+ CHECK_BOUND( t_2, "IsAssociative" );
  if ( t_2 == False ) {
   t_1 = t_2;
  }
  else if ( t_2 == True ) {
   t_3 = GC_Center;
-  CHECK_BOUND( t_3, "Center" )
-  CHECK_BOOL( t_3 )
+  CHECK_BOUND( t_3, "Center" );
+  CHECK_BOOL( t_3 );
   t_1 = t_3;
  }
  else if (IS_FILTER( t_2 ) ) {
   t_4 = GC_Center;
-  CHECK_BOUND( t_4, "Center" )
+  CHECK_BOUND( t_4, "Center" );
   t_1 = NewAndFilter( t_2, t_4 );
  }
  else {
@@ -189,7 +189,7 @@ static Obj  HdlrFunc2 (
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_2 = INTOBJ_INT(1);
  }
  else if (IS_FILTER( t_3 ) ) {
@@ -208,7 +208,7 @@ static Obj  HdlrFunc2 (
  t_3 = (Obj)(UInt)(t_4 != False);
  t_2 = (t_3 ? True : False);
  if ( t_2 == False ) {
-  CHECK_BOOL( INTOBJ_INT(1) )
+  CHECK_BOOL( INTOBJ_INT(1) );
   t_4 = (Obj)(UInt)(INTOBJ_INT(1) != False);
   t_2 = (t_4 ? True : False);
  }
@@ -227,7 +227,7 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -243,26 +243,26 @@ static Obj  HdlrFunc2 (
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( IsAssociative and IsAssociative, "\n" ); */
  t_1 = GF_Print;
  t_3 = GC_IsAssociative;
- CHECK_BOUND( t_3, "IsAssociative" )
+ CHECK_BOUND( t_3, "IsAssociative" );
  if ( t_3 == False ) {
   t_2 = t_3;
  }
  else if ( t_3 == True ) {
   t_4 = GC_IsAssociative;
-  CHECK_BOUND( t_4, "IsAssociative" )
-  CHECK_BOOL( t_4 )
+  CHECK_BOUND( t_4, "IsAssociative" );
+  CHECK_BOOL( t_4 );
   t_2 = t_4;
  }
  else if (IS_FILTER( t_3 ) ) {
   t_5 = GC_IsAssociative;
-  CHECK_BOUND( t_5, "IsAssociative" )
+  CHECK_BOUND( t_5, "IsAssociative" );
   t_2 = NewAndFilter( t_3, t_5 );
  }
  else {

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -1,6 +1,6 @@
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-49920958"
+#define FILE_CRC  "-101028112"
 
 /* global variables used in handlers */
 static GVar G_Print;
@@ -17,7 +17,7 @@ static Obj  GC_Center;
 /* record names used in handlers */
 
 /* information for the functions */
-static Obj  NameFunc[7];
+static Obj  NameFunc[9];
 static Obj FileName;
 
 /* handler for function 3 */
@@ -168,6 +168,72 @@ static Obj  HdlrFunc6 (
  return 0;
 }
 
+/* handler for function 7 */
+static Obj  HdlrFunc7 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 and false; */
+ if ( INTOBJ_INT(1) == False ) {
+  t_1 = INTOBJ_INT(1);
+ }
+ else if ( INTOBJ_INT(1) == True ) {
+  t_2 = False;
+  t_1 = t_2;
+ }
+ else if (IS_FILTER( INTOBJ_INT(1) ) ) {
+  t_3 = False;
+  t_1 = NewAndFilter( INTOBJ_INT(1), t_3 );
+ }
+ else {
+  RequireArgumentEx(0, INTOBJ_INT(1), "<expr>",
+  "must be 'true' or 'false' or a filter" );
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 8 */
+static Obj  HdlrFunc8 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return 1 or true; */
+ CHECK_BOOL( INTOBJ_INT(1) );
+ t_2 = (Obj)(UInt)(INTOBJ_INT(1) != False);
+ t_1 = (t_2 ? True : False);
+ if ( t_1 == False ) {
+  t_4 = True;
+  t_3 = (Obj)(UInt)(t_4 != False);
+  t_1 = (t_3 ? True : False);
+ }
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return t_1;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
 /* handler for function 2 */
 static Obj  HdlrFunc2 (
  Obj  self )
@@ -306,6 +372,36 @@ static Obj  HdlrFunc2 (
  SET_LEN_PLIST( t_3, 0 );
  CALL_2ARGS( t_1, t_2, t_3 );
  
+ /* CALL_WITH_CATCH( function (  )
+      return 1 and false;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[7], 0, 0, HdlrFunc7 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 18);
+ SET_ENDLINE_BODY(t_3, 18);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
+ /* CALL_WITH_CATCH( function (  )
+      return 1 or true;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[8], 0, 0, HdlrFunc8 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 19);
+ SET_ENDLINE_BODY(t_3, 19);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ CALL_2ARGS( t_1, t_2, t_3 );
+ 
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
  return 0;
@@ -343,13 +439,19 @@ static Obj  HdlrFunc1 (
       CALL_WITH_CATCH( function (  )
             return IsAssociative and Center;
         end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 and false;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            return 1 or true;
+        end, [  ] );
       return;
   end; */
  t_1 = NewFunction( NameFunc[2], 0, 0, HdlrFunc2 );
  SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
  t_2 = NewFunctionBody();
  SET_STARTLINE_BODY(t_2, 1);
- SET_ENDLINE_BODY(t_2, 18);
+ SET_ENDLINE_BODY(t_2, 21);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
  AssGVar( G_runtest, t_1 );
@@ -384,6 +486,8 @@ static Int PostRestore ( StructInitInfo * module )
  NameFunc[4] = 0;
  NameFunc[5] = 0;
  NameFunc[6] = 0;
+ NameFunc[7] = 0;
+ NameFunc[8] = 0;
  
  /* return success */
  return 0;
@@ -415,6 +519,10 @@ static Int InitKernel ( StructInitInfo * module )
  InitGlobalBag( &(NameFunc[5]), "and_filter.g:NameFunc[5]("FILE_CRC")" );
  InitHandlerFunc( HdlrFunc6, "and_filter.g:HdlrFunc6("FILE_CRC")" );
  InitGlobalBag( &(NameFunc[6]), "and_filter.g:NameFunc[6]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc7, "and_filter.g:HdlrFunc7("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[7]), "and_filter.g:NameFunc[7]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc8, "and_filter.g:HdlrFunc8("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[8]), "and_filter.g:NameFunc[8]("FILE_CRC")" );
  
  /* return success */
  return 0;
@@ -449,7 +557,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "and_filter.g",
- .crc         = -49920958,
+ .crc         = -101028112,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/tst/test-compile/and_filter.g.static.c
+++ b/tst/test-compile/and_filter.g.static.c
@@ -266,7 +266,12 @@ static Obj  HdlrFunc2 (
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( true or 1, "\n" ); */
  t_1 = GF_Print;
@@ -279,7 +284,12 @@ static Obj  HdlrFunc2 (
   t_2 = (t_4 ? True : False);
  }
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( function (  )
         return false and 1;
@@ -292,10 +302,20 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_4, 5);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( function (  )
         return true or 1;
@@ -308,10 +328,20 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_4, 6);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( IsAssociative and IsAssociative, "\n" ); */
  t_1 = GF_Print;
@@ -336,7 +366,12 @@ static Obj  HdlrFunc2 (
   "must be 'true' or 'false' or a filter" );
  }
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* BreakOnError := false; */
  t_1 = False;
@@ -355,7 +390,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return IsAssociative and Center;
@@ -370,7 +410,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return 1 and false;
@@ -385,7 +430,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return 1 or true;
@@ -400,7 +450,12 @@ static Obj  HdlrFunc2 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/assert.g.dynamic.c
+++ b/tst/test-compile/assert.g.dynamic.c
@@ -32,10 +32,20 @@ static Obj  HdlrFunc2 (
  /* Print( AssertionLevel(  ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Assert( ... ); */
  if ( ! LT(CurrentAssertionLevel, INTOBJ_INT(1)) ) {
@@ -87,15 +97,30 @@ static Obj  HdlrFunc2 (
  
  /* SetAssertionLevel( 2 ); */
  t_1 = GF_SetAssertionLevel;
- CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2) ) );
+ }
  
  /* Print( AssertionLevel(  ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Assert( ... ); */
  if ( ! LT(CurrentAssertionLevel, INTOBJ_INT(3)) ) {
@@ -163,7 +188,12 @@ static Obj  HdlrFunc2 (
  /* Print( "end of function\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "end of function\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/assert.g.dynamic.c
+++ b/tst/test-compile/assert.g.dynamic.c
@@ -33,7 +33,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -93,7 +93,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/assert.g.static.c
+++ b/tst/test-compile/assert.g.static.c
@@ -32,10 +32,20 @@ static Obj  HdlrFunc2 (
  /* Print( AssertionLevel(  ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Assert( ... ); */
  if ( ! LT(CurrentAssertionLevel, INTOBJ_INT(1)) ) {
@@ -87,15 +97,30 @@ static Obj  HdlrFunc2 (
  
  /* SetAssertionLevel( 2 ); */
  t_1 = GF_SetAssertionLevel;
- CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2) ) );
+ }
  
  /* Print( AssertionLevel(  ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
- t_2 = CALL_0ARGS( t_3 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Assert( ... ); */
  if ( ! LT(CurrentAssertionLevel, INTOBJ_INT(3)) ) {
@@ -163,7 +188,12 @@ static Obj  HdlrFunc2 (
  /* Print( "end of function\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "end of function\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/assert.g.static.c
+++ b/tst/test-compile/assert.g.static.c
@@ -33,7 +33,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -93,7 +93,7 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_AssertionLevel;
  t_2 = CALL_0ARGS( t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -216,49 +216,49 @@ static Obj  HdlrFunc3 (
  /* Print( vararg_fun(  ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -274,7 +274,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -295,7 +295,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -308,7 +308,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -322,7 +322,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -988,7 +988,7 @@ static Obj  HdlrFunc9 (
  
  /* l[1 + 1] := 2; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL_INTOBJ( l_l, t_1, INTOBJ_INT(2) )
  
  /* l![3] := 3; */
@@ -996,7 +996,7 @@ static Obj  HdlrFunc9 (
  
  /* l![2 + 2] := 4; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_1 )
+ CHECK_INT_SMALL_POS( t_1 );
  AssPosObj( l_l, INT_INTOBJ(t_1), INTOBJ_INT(4) );
  
  /* Display( l ); */
@@ -1014,7 +1014,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[2] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_4 )
+ CHECK_INT_POS( t_4 );
  C_ELM_LIST_FPL( t_3, l_l, t_4 )
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1030,7 +1030,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[4] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_4 )
+ CHECK_INT_SMALL_POS( t_4 );
  t_3 = ElmPosObj( l_l, INT_INTOBJ(t_4) );
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -65,7 +65,12 @@ static Obj  HdlrFunc2 (
  /* Print( x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_x, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_x, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x, t_2 ) );
+ }
  
  /* y := 100000; */
  l_y = INTOBJ_INT(100000);
@@ -73,13 +78,23 @@ static Obj  HdlrFunc2 (
  /* Print( y, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_y, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_y, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_y, t_2 ) );
+ }
  
  /* Print( x = y, "\n" ); */
  t_1 = GF_Print;
  t_2 = (EQ( l_x, l_y ) ? True : False);
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* x := 10 ^ 10; */
  t_1 = POW( INTOBJ_INT(10), INTOBJ_INT(10) );
@@ -88,7 +103,12 @@ static Obj  HdlrFunc2 (
  /* Print( x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_x, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_x, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x, t_2 ) );
+ }
  
  /* y := 10000000000; */
  l_y = ObjInt_Int8(10000000000);
@@ -96,13 +116,23 @@ static Obj  HdlrFunc2 (
  /* Print( y, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_y, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_y, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_y, t_2 ) );
+ }
  
  /* Print( x = y, "\n" ); */
  t_1 = GF_Print;
  t_2 = (EQ( l_x, l_y ) ? True : False);
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* x := 10 ^ 20; */
  t_1 = POW( INTOBJ_INT(10), INTOBJ_INT(20) );
@@ -111,7 +141,12 @@ static Obj  HdlrFunc2 (
  /* Print( x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_x, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_x, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x, t_2 ) );
+ }
  
  /* y := 100000000000000000000; */
  t_1 = NewWordSizedBag(T_INTPOS, 16);
@@ -122,13 +157,23 @@ static Obj  HdlrFunc2 (
  /* Print( y, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_y, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_y, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_y, t_2 ) );
+ }
  
  /* Print( x = y, "\n" ); */
  t_1 = GF_Print;
  t_2 = (EQ( l_x, l_y ) ? True : False);
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -175,7 +220,12 @@ static Obj  HdlrFunc5 (
  /* Display( Length( args ) ); */
  t_1 = GF_Display;
  C_LEN_LIST_FPL( t_2, a_args )
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -215,52 +265,122 @@ static Obj  HdlrFunc3 (
  
  /* Print( vararg_fun(  ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6, 7 ), "\n" ); */
  t_1 = GF_Print;
@@ -273,10 +393,20 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
- t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, t_3 );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( "x", true, vararg_fun, 4, 5, 6, 7 ), "\n" ); */
  t_1 = GF_Print;
@@ -294,10 +424,20 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
- t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, t_3 );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun(  : myopt := true ), "\n" ); */
  t_1 = GF_Print;
@@ -307,11 +447,21 @@ static Obj  HdlrFunc3 (
  AssPRec( t_2, (UInt)t_3, t_4 );
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
- t_2 = CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun(  : myopt := "value" ), "\n" ); */
  t_1 = GF_Print;
@@ -321,11 +471,21 @@ static Obj  HdlrFunc3 (
  AssPRec( t_2, (UInt)t_3, t_4 );
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
- t_2 = CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* vararg_fun := function ( args... )
       Display( Length( args ) );
@@ -341,25 +501,60 @@ static Obj  HdlrFunc3 (
  l_vararg__fun = t_1;
  
  /* vararg_fun(  ); */
- CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  
  /* vararg_fun( 1 ); */
- CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
  
  /* vararg_fun( 1, 2 ); */
- CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  
  /* vararg_fun( 1, 2, 3 ); */
- CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4 ); */
- CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4, 5 ); */
- CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4, 5, 6 ); */
- CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4, 5, 6, 7 ); */
  t_1 = NEW_PLIST( T_PLIST, 7 );
@@ -371,7 +566,12 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_1, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_1, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_1, 7, INTOBJ_INT(7) );
- CALL_XARGS( l_vararg__fun, t_1 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_XARGS( l_vararg__fun, t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, t_1 );
+ }
  
  /* vararg_fun( "x", true, vararg_fun, 4, 5, 6, 7 ); */
  t_1 = NEW_PLIST( T_PLIST, 7 );
@@ -388,7 +588,12 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_1, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_1, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_1, 7, INTOBJ_INT(7) );
- CALL_XARGS( l_vararg__fun, t_1 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_XARGS( l_vararg__fun, t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, t_1 );
+ }
  t_1 = NEW_PREC( 1 );
  t_2 = (Obj)R_myopt;
  t_3 = True;
@@ -397,7 +602,12 @@ static Obj  HdlrFunc3 (
  CALL_1ARGS( GF_PushOptions, t_1 );
  
  /* vararg_fun(  ); */
- CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CALL_0ARGS( GF_PopOptions );
  t_1 = NEW_PREC( 1 );
  t_2 = (Obj)R_myopt;
@@ -407,7 +617,12 @@ static Obj  HdlrFunc3 (
  CALL_1ARGS( GF_PushOptions, t_1 );
  
  /* vararg_fun(  ); */
- CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CALL_0ARGS( GF_PopOptions );
  
  /* return; */
@@ -437,7 +652,12 @@ static Obj  HdlrFunc6 (
  /* Print( "setting x to 2 ...\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "setting x to 2 ...\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 2; */
  l_x = INTOBJ_INT(2);
@@ -447,19 +667,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 = 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)INTOBJ_INT(2))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 = x is ", 1 = x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 = x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)l_x)) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 = 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 = 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 = 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) == ((Int)INTOBJ_INT(2)));
@@ -468,7 +703,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -478,7 +718,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -486,7 +731,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 = x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 = x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 = x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) == ((Int)l_x));
@@ -495,7 +745,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -505,7 +760,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -515,19 +775,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 <> 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)INTOBJ_INT(2))) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <> x is ", 1 <> x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <> x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)l_x)) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <> 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <> 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <> 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) != ((Int)INTOBJ_INT(2)));
@@ -536,7 +811,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -546,7 +826,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -554,7 +839,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 <> x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <> x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <> x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) != ((Int)l_x));
@@ -563,7 +853,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -573,7 +868,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -583,19 +883,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 < 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)INTOBJ_INT(2))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 < x is ", 1 < x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 < x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)l_x)) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 < 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 < 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 < 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) < ((Int)INTOBJ_INT(2)));
@@ -604,7 +919,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -614,7 +934,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -622,7 +947,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 < x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 < x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 < x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) < ((Int)l_x));
@@ -631,7 +961,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -641,7 +976,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -651,19 +991,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 <= 2 is " );
  t_3 = ((((Int)INTOBJ_INT(2)) < ((Int)INTOBJ_INT(1))) ?  False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <= x is ", 1 <= x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <= x is " );
  t_3 = ((((Int)l_x) < ((Int)INTOBJ_INT(1))) ?  False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <= 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <= 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <= 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(2)) >= ((Int)INTOBJ_INT(1)));
@@ -672,7 +1027,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -682,7 +1042,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -690,7 +1055,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 <= x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <= x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <= x then */
  t_1 = (Obj)(UInt)(((Int)l_x) >= ((Int)INTOBJ_INT(1)));
@@ -699,7 +1069,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -709,7 +1084,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -719,19 +1099,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 > 2 is " );
  t_3 = ((((Int)INTOBJ_INT(2)) < ((Int)INTOBJ_INT(1))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 > x is ", 1 > x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 > x is " );
  t_3 = ((((Int)l_x) < ((Int)INTOBJ_INT(1))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 > 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 > 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 > 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(2)) < ((Int)INTOBJ_INT(1)));
@@ -740,7 +1135,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -750,7 +1150,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -758,7 +1163,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 > x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 > x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 > x then */
  t_1 = (Obj)(UInt)(((Int)l_x) < ((Int)INTOBJ_INT(1)));
@@ -767,7 +1177,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -777,7 +1192,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -787,19 +1207,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 >= 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)INTOBJ_INT(2))) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 >= x is ", 1 >= x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 >= x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)l_x)) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 >= 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 >= 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 >= 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) >= ((Int)INTOBJ_INT(2)));
@@ -808,7 +1243,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -818,7 +1258,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -826,7 +1271,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 >= x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 >= x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 >= x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) >= ((Int)l_x));
@@ -835,7 +1285,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -845,7 +1300,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -938,7 +1398,12 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Display;
  t_2 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_2, 0 );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 1, 2, 3 ] ); */
  t_1 = GF_Display;
@@ -947,7 +1412,12 @@ static Obj  HdlrFunc9 (
  SET_ELM_PLIST( t_2, 1, INTOBJ_INT(1) );
  SET_ELM_PLIST( t_2, 2, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_2, 3, INTOBJ_INT(3) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 1,, 3, [ 4, 5 ], rec(
         x := [ 6, rec(
@@ -976,7 +1446,12 @@ static Obj  HdlrFunc9 (
  CHANGED_BAG( t_5 );
  SortPRecRNam( t_6, 0 );
  SortPRecRNam( t_3, 0 );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* l := [  ]; */
  t_1 = NEW_PLIST( T_PLIST, 0 );
@@ -1001,14 +1476,24 @@ static Obj  HdlrFunc9 (
  
  /* Display( l ); */
  t_1 = GF_Display;
- CALL_1ARGS( t_1, l_l );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_l );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_l ) );
+ }
  
  /* Print( "l[1] = ", l[1], "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "l[1] = " );
  C_ELM_LIST_FPL( t_3, l_l, INTOBJ_INT(1) )
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "l[2] = ", l[1 + 1], "\n" ); */
  t_1 = GF_Print;
@@ -1017,14 +1502,24 @@ static Obj  HdlrFunc9 (
  CHECK_INT_POS( t_4 );
  C_ELM_LIST_FPL( t_3, l_l, t_4 )
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "l[3] = ", l![3], "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "l[3] = " );
  t_3 = ElmPosObj( l_l, 3 );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "l[4] = ", l![2 + 2], "\n" ); */
  t_1 = GF_Print;
@@ -1033,7 +1528,12 @@ static Obj  HdlrFunc9 (
  CHECK_INT_SMALL_POS( t_4 );
  t_3 = ElmPosObj( l_l, INT_INTOBJ(t_4) );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1063,14 +1563,24 @@ static Obj  HdlrFunc9 (
  
  /* Display( x ); */
  t_1 = GF_Display;
- CALL_1ARGS( t_1, l_x );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_x );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x ) );
+ }
  
  /* Print( "x.a = ", x.a, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "x.a = " );
  t_3 = ELM_REC( l_x, R_a );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "x.b = ", x.("b"), "\n" ); */
  t_1 = GF_Print;
@@ -1078,14 +1588,24 @@ static Obj  HdlrFunc9 (
  t_4 = MakeString( "b" );
  t_3 = ELM_REC( l_x, RNamObj(t_4) );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "x.d = ", x!.d, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "x.d = " );
  t_3 = ElmComObj( l_x, R_d );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "x.e = ", x!.("e"), "\n" ); */
  t_1 = GF_Print;
@@ -1093,7 +1613,12 @@ static Obj  HdlrFunc9 (
  t_4 = MakeString( "e" );
  t_3 = ElmComObj( l_x, RNamObj(t_4) );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1121,7 +1646,12 @@ static Obj  HdlrFunc10 (
  /* Print( "Testing IsBound and Unbind for lvar\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for lvar\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 42; */
  l_x = INTOBJ_INT(42);
@@ -1129,7 +1659,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x ) ); */
  t_1 = GF_Display;
  t_2 = ((l_x != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x ); */
  l_x = 0;
@@ -1137,12 +1672,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x ) ); */
  t_1 = GF_Display;
  t_2 = ((l_x != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for gvar\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for gvar\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* myglobal := 42; */
  AssGVar( G_myglobal, INTOBJ_INT(42) );
@@ -1151,7 +1696,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = GC_myglobal;
  t_2 = ((t_3 != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( myglobal ); */
  AssGVar( G_myglobal, 0 );
@@ -1160,12 +1710,22 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = GC_myglobal;
  t_2 = ((t_3 != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for list\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for list\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := [ 1, 2, 3 ]; */
  t_1 = NEW_PLIST( T_PLIST, 3 );
@@ -1178,7 +1738,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x[2] ) ); */
  t_1 = GF_Display;
  t_2 = C_ISB_LIST( l_x, INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x[2] ); */
  C_UNB_LIST( l_x, INTOBJ_INT(2) );
@@ -1186,12 +1751,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x[2] ) ); */
  t_1 = GF_Display;
  t_2 = C_ISB_LIST( l_x, INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for list with bang\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for list with bang\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := [ 1, 2, 3 ]; */
  t_1 = NEW_PLIST( T_PLIST, 3 );
@@ -1204,7 +1779,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
  t_2 = IsbPosObj( l_x, 2 ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x![2] ); */
  UnbPosObj( l_x, 2 );
@@ -1212,12 +1792,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
  t_2 = IsbPosObj( l_x, 2 ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1230,7 +1820,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x.a ) ); */
  t_1 = GF_Display;
  t_2 = (ISB_REC( l_x, R_a ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x.a ); */
  UNB_REC( l_x, R_a );
@@ -1238,12 +1833,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x.a ) ); */
  t_1 = GF_Display;
  t_2 = (ISB_REC( l_x, R_a ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record with expr\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record with expr\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1257,7 +1862,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = (ISB_REC( l_x, RNamObj(t_3) ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x.("a") ); */
  t_1 = MakeString( "a" );
@@ -1267,12 +1877,22 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = (ISB_REC( l_x, RNamObj(t_3) ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record with bang\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record with bang\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1285,7 +1905,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x!.a ) ); */
  t_1 = GF_Display;
  t_2 = IsbComObj( l_x, R_a ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x!.a ); */
  UnbComObj( l_x, R_a );
@@ -1293,12 +1918,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x!.a ) ); */
  t_1 = GF_Display;
  t_2 = IsbComObj( l_x, R_a ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record with bang and expr\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record with bang and expr\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1312,7 +1947,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = IsbComObj( l_x, RNamObj(t_3) ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x!.("a") ); */
  t_1 = MakeString( "a" );
@@ -1322,7 +1962,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = IsbComObj( l_x, RNamObj(t_3) ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1349,7 +1994,12 @@ static Obj  HdlrFunc11 (
  /* Display( "testing repeat loop" ); */
  t_1 = GF_Display;
  t_2 = MakeString( "testing repeat loop" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 0; */
  l_x = INTOBJ_INT(0);
@@ -1385,7 +2035,12 @@ static Obj  HdlrFunc11 (
     
     /* Display( x ); */
     t_1 = GF_Display;
-    CALL_1ARGS( t_1, l_x );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, l_x );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x ) );
+    }
     
    }
   }
@@ -1399,7 +2054,12 @@ static Obj  HdlrFunc11 (
  /* Display( "testing while loop" ); */
  t_1 = GF_Display;
  t_2 = MakeString( "testing while loop" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 0; */
  l_x = INTOBJ_INT(0);
@@ -1437,7 +2097,12 @@ static Obj  HdlrFunc11 (
     
     /* Display( x ); */
     t_1 = GF_Display;
-    CALL_1ARGS( t_1, l_x );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, l_x );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x ) );
+    }
     
    }
   }
@@ -1449,7 +2114,12 @@ static Obj  HdlrFunc11 (
  /* Display( "testing for loop" ); */
  t_1 = GF_Display;
  t_2 = MakeString( "testing for loop" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* for x in [ 1 .. 100 ] do */
  for ( t_1 = INTOBJ_INT(1);
@@ -1481,7 +2151,12 @@ static Obj  HdlrFunc11 (
     
     /* Display( x ); */
     t_2 = GF_Display;
-    CALL_1ARGS( t_2, l_x );
+    if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_2, l_x );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_x ) );
+    }
     
    }
   }
@@ -1512,40 +2187,85 @@ static Obj  HdlrFunc12 (
  
  /* test_int_constants(  ); */
  t_1 = GF_test__int__constants;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_func_calls(  ); */
  t_1 = GF_test__func__calls;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_cmp_ops(  ); */
  t_1 = GF_test__cmp__ops;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_arith(  ); */
  t_1 = GF_test__arith;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_tilde(  ); */
  t_1 = GF_test__tilde;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_list_rec_exprs(  ); */
  t_1 = GF_test__list__rec__exprs;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_IsBound_Unbind(  ); */
  t_1 = GF_test__IsBound__Unbind;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_loops(  ); */
  t_1 = GF_test__loops;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* Display( () ); */
  t_1 = GF_Display;
  t_2 = IdentityPerm;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -216,49 +216,49 @@ static Obj  HdlrFunc3 (
  /* Print( vararg_fun(  ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6 ), "\n" ); */
  t_1 = GF_Print;
  t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -274,7 +274,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -295,7 +295,7 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
@@ -308,7 +308,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -322,7 +322,7 @@ static Obj  HdlrFunc3 (
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
  t_2 = CALL_0ARGS( l_vararg__fun );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
@@ -988,7 +988,7 @@ static Obj  HdlrFunc9 (
  
  /* l[1 + 1] := 2; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_1 )
+ CHECK_INT_POS( t_1 );
  C_ASS_LIST_FPL_INTOBJ( l_l, t_1, INTOBJ_INT(2) )
  
  /* l![3] := 3; */
@@ -996,7 +996,7 @@ static Obj  HdlrFunc9 (
  
  /* l![2 + 2] := 4; */
  C_SUM_INTOBJS( t_1, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_1 )
+ CHECK_INT_SMALL_POS( t_1 );
  AssPosObj( l_l, INT_INTOBJ(t_1), INTOBJ_INT(4) );
  
  /* Display( l ); */
@@ -1014,7 +1014,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[2] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(1), INTOBJ_INT(1) )
- CHECK_INT_POS( t_4 )
+ CHECK_INT_POS( t_4 );
  C_ELM_LIST_FPL( t_3, l_l, t_4 )
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );
@@ -1030,7 +1030,7 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Print;
  t_2 = MakeString( "l[4] = " );
  C_SUM_INTOBJS( t_4, INTOBJ_INT(2), INTOBJ_INT(2) )
- CHECK_INT_SMALL_POS( t_4 )
+ CHECK_INT_SMALL_POS( t_4 );
  t_3 = ElmPosObj( l_l, INT_INTOBJ(t_4) );
  t_4 = MakeString( "\n" );
  CALL_3ARGS( t_1, t_2, t_3, t_4 );

--- a/tst/test-compile/basics.g.static.c
+++ b/tst/test-compile/basics.g.static.c
@@ -65,7 +65,12 @@ static Obj  HdlrFunc2 (
  /* Print( x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_x, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_x, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x, t_2 ) );
+ }
  
  /* y := 100000; */
  l_y = INTOBJ_INT(100000);
@@ -73,13 +78,23 @@ static Obj  HdlrFunc2 (
  /* Print( y, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_y, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_y, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_y, t_2 ) );
+ }
  
  /* Print( x = y, "\n" ); */
  t_1 = GF_Print;
  t_2 = (EQ( l_x, l_y ) ? True : False);
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* x := 10 ^ 10; */
  t_1 = POW( INTOBJ_INT(10), INTOBJ_INT(10) );
@@ -88,7 +103,12 @@ static Obj  HdlrFunc2 (
  /* Print( x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_x, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_x, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x, t_2 ) );
+ }
  
  /* y := 10000000000; */
  l_y = ObjInt_Int8(10000000000);
@@ -96,13 +116,23 @@ static Obj  HdlrFunc2 (
  /* Print( y, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_y, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_y, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_y, t_2 ) );
+ }
  
  /* Print( x = y, "\n" ); */
  t_1 = GF_Print;
  t_2 = (EQ( l_x, l_y ) ? True : False);
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* x := 10 ^ 20; */
  t_1 = POW( INTOBJ_INT(10), INTOBJ_INT(20) );
@@ -111,7 +141,12 @@ static Obj  HdlrFunc2 (
  /* Print( x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_x, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_x, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x, t_2 ) );
+ }
  
  /* y := 100000000000000000000; */
  t_1 = NewWordSizedBag(T_INTPOS, 16);
@@ -122,13 +157,23 @@ static Obj  HdlrFunc2 (
  /* Print( y, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, l_y, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, l_y, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_y, t_2 ) );
+ }
  
  /* Print( x = y, "\n" ); */
  t_1 = GF_Print;
  t_2 = (EQ( l_x, l_y ) ? True : False);
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -175,7 +220,12 @@ static Obj  HdlrFunc5 (
  /* Display( Length( args ) ); */
  t_1 = GF_Display;
  C_LEN_LIST_FPL( t_2, a_args )
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -215,52 +265,122 @@ static Obj  HdlrFunc3 (
  
  /* Print( vararg_fun(  ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6 ), "\n" ); */
  t_1 = GF_Print;
- t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( 1, 2, 3, 4, 5, 6, 7 ), "\n" ); */
  t_1 = GF_Print;
@@ -273,10 +393,20 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
- t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, t_3 );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun( "x", true, vararg_fun, 4, 5, 6, 7 ), "\n" ); */
  t_1 = GF_Print;
@@ -294,10 +424,20 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_3, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
- t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_XARGS( l_vararg__fun, t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, t_3 );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun(  : myopt := true ), "\n" ); */
  t_1 = GF_Print;
@@ -307,11 +447,21 @@ static Obj  HdlrFunc3 (
  AssPRec( t_2, (UInt)t_3, t_4 );
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
- t_2 = CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( vararg_fun(  : myopt := "value" ), "\n" ); */
  t_1 = GF_Print;
@@ -321,11 +471,21 @@ static Obj  HdlrFunc3 (
  AssPRec( t_2, (UInt)t_3, t_4 );
  SortPRecRNam( t_2, 0 );
  CALL_1ARGS( GF_PushOptions, t_2 );
- t_2 = CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  CALL_0ARGS( GF_PopOptions );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* vararg_fun := function ( args... )
       Display( Length( args ) );
@@ -341,25 +501,60 @@ static Obj  HdlrFunc3 (
  l_vararg__fun = t_1;
  
  /* vararg_fun(  ); */
- CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  
  /* vararg_fun( 1 ); */
- CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_1ARGS( l_vararg__fun, INTOBJ_INT(1) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
  
  /* vararg_fun( 1, 2 ); */
- CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_2ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  
  /* vararg_fun( 1, 2, 3 ); */
- CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_3ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4 ); */
- CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_4ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4, 5 ); */
- CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_5ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4, 5, 6 ); */
- CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_6ARGS( l_vararg__fun, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4), INTOBJ_INT(5), INTOBJ_INT(6) ) );
+ }
  
  /* vararg_fun( 1, 2, 3, 4, 5, 6, 7 ); */
  t_1 = NEW_PLIST( T_PLIST, 7 );
@@ -371,7 +566,12 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_1, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_1, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_1, 7, INTOBJ_INT(7) );
- CALL_XARGS( l_vararg__fun, t_1 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_XARGS( l_vararg__fun, t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, t_1 );
+ }
  
  /* vararg_fun( "x", true, vararg_fun, 4, 5, 6, 7 ); */
  t_1 = NEW_PLIST( T_PLIST, 7 );
@@ -388,7 +588,12 @@ static Obj  HdlrFunc3 (
  SET_ELM_PLIST( t_1, 5, INTOBJ_INT(5) );
  SET_ELM_PLIST( t_1, 6, INTOBJ_INT(6) );
  SET_ELM_PLIST( t_1, 7, INTOBJ_INT(7) );
- CALL_XARGS( l_vararg__fun, t_1 );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_XARGS( l_vararg__fun, t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, t_1 );
+ }
  t_1 = NEW_PREC( 1 );
  t_2 = (Obj)R_myopt;
  t_3 = True;
@@ -397,7 +602,12 @@ static Obj  HdlrFunc3 (
  CALL_1ARGS( GF_PushOptions, t_1 );
  
  /* vararg_fun(  ); */
- CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CALL_0ARGS( GF_PopOptions );
  t_1 = NEW_PREC( 1 );
  t_2 = (Obj)R_myopt;
@@ -407,7 +617,12 @@ static Obj  HdlrFunc3 (
  CALL_1ARGS( GF_PushOptions, t_1 );
  
  /* vararg_fun(  ); */
- CALL_0ARGS( l_vararg__fun );
+ if ( TNUM_OBJ( l_vararg__fun ) == T_FUNCTION ) {
+  CALL_0ARGS( l_vararg__fun );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, l_vararg__fun, NewPlistFromArgs( ) );
+ }
  CALL_0ARGS( GF_PopOptions );
  
  /* return; */
@@ -437,7 +652,12 @@ static Obj  HdlrFunc6 (
  /* Print( "setting x to 2 ...\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "setting x to 2 ...\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 2; */
  l_x = INTOBJ_INT(2);
@@ -447,19 +667,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 = 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)INTOBJ_INT(2))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 = x is ", 1 = x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 = x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)l_x)) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 = 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 = 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 = 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) == ((Int)INTOBJ_INT(2)));
@@ -468,7 +703,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -478,7 +718,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -486,7 +731,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 = x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 = x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 = x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) == ((Int)l_x));
@@ -495,7 +745,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -505,7 +760,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -515,19 +775,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 <> 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)INTOBJ_INT(2))) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <> x is ", 1 <> x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <> x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) == ((Int)l_x)) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <> 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <> 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <> 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) != ((Int)INTOBJ_INT(2)));
@@ -536,7 +811,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -546,7 +826,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -554,7 +839,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 <> x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <> x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <> x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) != ((Int)l_x));
@@ -563,7 +853,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -573,7 +868,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -583,19 +883,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 < 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)INTOBJ_INT(2))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 < x is ", 1 < x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 < x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)l_x)) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 < 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 < 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 < 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) < ((Int)INTOBJ_INT(2)));
@@ -604,7 +919,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -614,7 +934,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -622,7 +947,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 < x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 < x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 < x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) < ((Int)l_x));
@@ -631,7 +961,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -641,7 +976,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -651,19 +991,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 <= 2 is " );
  t_3 = ((((Int)INTOBJ_INT(2)) < ((Int)INTOBJ_INT(1))) ?  False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <= x is ", 1 <= x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <= x is " );
  t_3 = ((((Int)l_x) < ((Int)INTOBJ_INT(1))) ?  False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 <= 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <= 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <= 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(2)) >= ((Int)INTOBJ_INT(1)));
@@ -672,7 +1027,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -682,7 +1042,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -690,7 +1055,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 <= x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 <= x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 <= x then */
  t_1 = (Obj)(UInt)(((Int)l_x) >= ((Int)INTOBJ_INT(1)));
@@ -699,7 +1069,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -709,7 +1084,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -719,19 +1099,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 > 2 is " );
  t_3 = ((((Int)INTOBJ_INT(2)) < ((Int)INTOBJ_INT(1))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 > x is ", 1 > x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 > x is " );
  t_3 = ((((Int)l_x) < ((Int)INTOBJ_INT(1))) ? True : False);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 > 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 > 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 > 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(2)) < ((Int)INTOBJ_INT(1)));
@@ -740,7 +1135,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -750,7 +1150,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -758,7 +1163,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 > x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 > x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 > x then */
  t_1 = (Obj)(UInt)(((Int)l_x) < ((Int)INTOBJ_INT(1)));
@@ -767,7 +1177,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -777,7 +1192,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -787,19 +1207,34 @@ static Obj  HdlrFunc6 (
  t_2 = MakeString( "1 >= 2 is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)INTOBJ_INT(2))) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 >= x is ", 1 >= x, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 >= x is " );
  t_3 = ((((Int)INTOBJ_INT(1)) < ((Int)l_x)) ? False : True);
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "1 >= 2 via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 >= 2 via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 >= 2 then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) >= ((Int)INTOBJ_INT(2)));
@@ -808,7 +1243,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -818,7 +1258,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -826,7 +1271,12 @@ static Obj  HdlrFunc6 (
  /* Print( "1 >= x via if is " ); */
  t_1 = GF_Print;
  t_2 = MakeString( "1 >= x via if is " );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* if 1 >= x then */
  t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(1)) >= ((Int)l_x));
@@ -835,7 +1285,12 @@ static Obj  HdlrFunc6 (
   /* Print( "true\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "true\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  
@@ -845,7 +1300,12 @@ static Obj  HdlrFunc6 (
   /* Print( "false\n" ); */
   t_1 = GF_Print;
   t_2 = MakeString( "false\n" );
-  CALL_1ARGS( t_1, t_2 );
+  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+   CALL_1ARGS( t_1, t_2 );
+  }
+  else {
+   DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+  }
   
  }
  /* fi */
@@ -938,7 +1398,12 @@ static Obj  HdlrFunc9 (
  t_1 = GF_Display;
  t_2 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_2, 0 );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 1, 2, 3 ] ); */
  t_1 = GF_Display;
@@ -947,7 +1412,12 @@ static Obj  HdlrFunc9 (
  SET_ELM_PLIST( t_2, 1, INTOBJ_INT(1) );
  SET_ELM_PLIST( t_2, 2, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_2, 3, INTOBJ_INT(3) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 1,, 3, [ 4, 5 ], rec(
         x := [ 6, rec(
@@ -976,7 +1446,12 @@ static Obj  HdlrFunc9 (
  CHANGED_BAG( t_5 );
  SortPRecRNam( t_6, 0 );
  SortPRecRNam( t_3, 0 );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* l := [  ]; */
  t_1 = NEW_PLIST( T_PLIST, 0 );
@@ -1001,14 +1476,24 @@ static Obj  HdlrFunc9 (
  
  /* Display( l ); */
  t_1 = GF_Display;
- CALL_1ARGS( t_1, l_l );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_l );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_l ) );
+ }
  
  /* Print( "l[1] = ", l[1], "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "l[1] = " );
  C_ELM_LIST_FPL( t_3, l_l, INTOBJ_INT(1) )
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "l[2] = ", l[1 + 1], "\n" ); */
  t_1 = GF_Print;
@@ -1017,14 +1502,24 @@ static Obj  HdlrFunc9 (
  CHECK_INT_POS( t_4 );
  C_ELM_LIST_FPL( t_3, l_l, t_4 )
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "l[3] = ", l![3], "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "l[3] = " );
  t_3 = ElmPosObj( l_l, 3 );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "l[4] = ", l![2 + 2], "\n" ); */
  t_1 = GF_Print;
@@ -1033,7 +1528,12 @@ static Obj  HdlrFunc9 (
  CHECK_INT_SMALL_POS( t_4 );
  t_3 = ElmPosObj( l_l, INT_INTOBJ(t_4) );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1063,14 +1563,24 @@ static Obj  HdlrFunc9 (
  
  /* Display( x ); */
  t_1 = GF_Display;
- CALL_1ARGS( t_1, l_x );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_x );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x ) );
+ }
  
  /* Print( "x.a = ", x.a, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "x.a = " );
  t_3 = ELM_REC( l_x, R_a );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "x.b = ", x.("b"), "\n" ); */
  t_1 = GF_Print;
@@ -1078,14 +1588,24 @@ static Obj  HdlrFunc9 (
  t_4 = MakeString( "b" );
  t_3 = ELM_REC( l_x, RNamObj(t_4) );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "x.d = ", x!.d, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "x.d = " );
  t_3 = ElmComObj( l_x, R_d );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* Print( "x.e = ", x!.("e"), "\n" ); */
  t_1 = GF_Print;
@@ -1093,7 +1613,12 @@ static Obj  HdlrFunc9 (
  t_4 = MakeString( "e" );
  t_3 = ElmComObj( l_x, RNamObj(t_4) );
  t_4 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1121,7 +1646,12 @@ static Obj  HdlrFunc10 (
  /* Print( "Testing IsBound and Unbind for lvar\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for lvar\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 42; */
  l_x = INTOBJ_INT(42);
@@ -1129,7 +1659,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x ) ); */
  t_1 = GF_Display;
  t_2 = ((l_x != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x ); */
  l_x = 0;
@@ -1137,12 +1672,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x ) ); */
  t_1 = GF_Display;
  t_2 = ((l_x != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for gvar\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for gvar\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* myglobal := 42; */
  AssGVar( G_myglobal, INTOBJ_INT(42) );
@@ -1151,7 +1696,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = GC_myglobal;
  t_2 = ((t_3 != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( myglobal ); */
  AssGVar( G_myglobal, 0 );
@@ -1160,12 +1710,22 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = GC_myglobal;
  t_2 = ((t_3 != 0) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for list\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for list\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := [ 1, 2, 3 ]; */
  t_1 = NEW_PLIST( T_PLIST, 3 );
@@ -1178,7 +1738,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x[2] ) ); */
  t_1 = GF_Display;
  t_2 = C_ISB_LIST( l_x, INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x[2] ); */
  C_UNB_LIST( l_x, INTOBJ_INT(2) );
@@ -1186,12 +1751,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x[2] ) ); */
  t_1 = GF_Display;
  t_2 = C_ISB_LIST( l_x, INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for list with bang\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for list with bang\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := [ 1, 2, 3 ]; */
  t_1 = NEW_PLIST( T_PLIST, 3 );
@@ -1204,7 +1779,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
  t_2 = IsbPosObj( l_x, 2 ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x![2] ); */
  UnbPosObj( l_x, 2 );
@@ -1212,12 +1792,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x![2] ) ); */
  t_1 = GF_Display;
  t_2 = IsbPosObj( l_x, 2 ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1230,7 +1820,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x.a ) ); */
  t_1 = GF_Display;
  t_2 = (ISB_REC( l_x, R_a ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x.a ); */
  UNB_REC( l_x, R_a );
@@ -1238,12 +1833,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x.a ) ); */
  t_1 = GF_Display;
  t_2 = (ISB_REC( l_x, R_a ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record with expr\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record with expr\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1257,7 +1862,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = (ISB_REC( l_x, RNamObj(t_3) ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x.("a") ); */
  t_1 = MakeString( "a" );
@@ -1267,12 +1877,22 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = (ISB_REC( l_x, RNamObj(t_3) ) ? True : False);
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record with bang\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record with bang\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1285,7 +1905,12 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x!.a ) ); */
  t_1 = GF_Display;
  t_2 = IsbComObj( l_x, R_a ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x!.a ); */
  UnbComObj( l_x, R_a );
@@ -1293,12 +1918,22 @@ static Obj  HdlrFunc10 (
  /* Display( IsBound( x!.a ) ); */
  t_1 = GF_Display;
  t_2 = IsbComObj( l_x, R_a ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Print( "Testing IsBound and Unbind for record with bang and expr\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "Testing IsBound and Unbind for record with bang and expr\n" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := rec(
     a := 1 ); */
@@ -1312,7 +1947,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = IsbComObj( l_x, RNamObj(t_3) ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Unbind( x!.("a") ); */
  t_1 = MakeString( "a" );
@@ -1322,7 +1962,12 @@ static Obj  HdlrFunc10 (
  t_1 = GF_Display;
  t_3 = MakeString( "a" );
  t_2 = IsbComObj( l_x, RNamObj(t_3) ) ? True : False;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -1349,7 +1994,12 @@ static Obj  HdlrFunc11 (
  /* Display( "testing repeat loop" ); */
  t_1 = GF_Display;
  t_2 = MakeString( "testing repeat loop" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 0; */
  l_x = INTOBJ_INT(0);
@@ -1385,7 +2035,12 @@ static Obj  HdlrFunc11 (
     
     /* Display( x ); */
     t_1 = GF_Display;
-    CALL_1ARGS( t_1, l_x );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, l_x );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x ) );
+    }
     
    }
   }
@@ -1399,7 +2054,12 @@ static Obj  HdlrFunc11 (
  /* Display( "testing while loop" ); */
  t_1 = GF_Display;
  t_2 = MakeString( "testing while loop" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* x := 0; */
  l_x = INTOBJ_INT(0);
@@ -1437,7 +2097,12 @@ static Obj  HdlrFunc11 (
     
     /* Display( x ); */
     t_1 = GF_Display;
-    CALL_1ARGS( t_1, l_x );
+    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_1, l_x );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_x ) );
+    }
     
    }
   }
@@ -1449,7 +2114,12 @@ static Obj  HdlrFunc11 (
  /* Display( "testing for loop" ); */
  t_1 = GF_Display;
  t_2 = MakeString( "testing for loop" );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* for x in [ 1 .. 100 ] do */
  for ( t_1 = INTOBJ_INT(1);
@@ -1481,7 +2151,12 @@ static Obj  HdlrFunc11 (
     
     /* Display( x ); */
     t_2 = GF_Display;
-    CALL_1ARGS( t_2, l_x );
+    if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+     CALL_1ARGS( t_2, l_x );
+    }
+    else {
+     DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( l_x ) );
+    }
     
    }
   }
@@ -1512,40 +2187,85 @@ static Obj  HdlrFunc12 (
  
  /* test_int_constants(  ); */
  t_1 = GF_test__int__constants;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_func_calls(  ); */
  t_1 = GF_test__func__calls;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_cmp_ops(  ); */
  t_1 = GF_test__cmp__ops;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_arith(  ); */
  t_1 = GF_test__arith;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_tilde(  ); */
  t_1 = GF_test__tilde;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_list_rec_exprs(  ); */
  t_1 = GF_test__list__rec__exprs;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_IsBound_Unbind(  ); */
  t_1 = GF_test__IsBound__Unbind;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* test_loops(  ); */
  t_1 = GF_test__loops;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* Display( () ); */
  t_1 = GF_Display;
  t_2 = IdentityPerm;
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/callfunc.g
+++ b/tst/test-compile/callfunc.g
@@ -1,0 +1,72 @@
+# proc calls
+p0 := function(f)
+    Print("p0\n");
+    f();
+end;
+
+p1 := function(f)
+    Print("p1\n");
+    f(1);
+end;
+
+p7 := function(f)
+    Print("p7\n");
+    f(1,2,3,4,5,6,7);
+end;
+
+# func calls
+f0 := function(f)
+    Print("f0\n");
+    Display(f());
+end;
+
+f1 := function(f)
+    Print("f1\n");
+    Display(f(1));
+end;
+
+f7 := function(f)
+    Print("f7\n");
+    Display(f(1,2,3,4,5,6,7));
+end;
+
+runtest := function()
+    local IsCustomFunction, f;
+
+    Print("test with a regular function\n");
+    f := ReturnTrue;
+
+    p0(f);
+    p1(f);
+    p7(f);
+
+    f0(f);
+    f1(f);
+    f7(f);
+
+    Print("test with a custom function\n");
+    IsCustomFunction := NewCategory("IsCustomFunction", IsFunction);;
+    InstallMethod(CallFuncList, [IsCustomFunction, IsList], {func, args} -> args);
+    f := Objectify(NewType(NewFamily("CustomFunctionFamily"),
+                           IsCustomFunction and IsPositionalObjectRep), []);;
+
+    p0(f);
+    p1(f);
+    p7(f);
+
+    f0(f);
+    f1(f);
+    f7(f);
+
+    BreakOnError := false;
+
+    Print("test with a non-function\n");
+    CALL_WITH_CATCH(function() p0(fail); end, []);
+    CALL_WITH_CATCH(function() p1(fail); end, []);
+    CALL_WITH_CATCH(function() p7(fail); end, []);
+
+    CALL_WITH_CATCH(function() f0(fail); end, []);
+    CALL_WITH_CATCH(function() f1(fail); end, []);
+    CALL_WITH_CATCH(function() f7(fail); end, []);
+
+end;

--- a/tst/test-compile/callfunc.g.dynamic.c
+++ b/tst/test-compile/callfunc.g.dynamic.c
@@ -1,0 +1,1250 @@
+/* C file produced by GAC */
+#include "compiled.h"
+#define FILE_CRC  "6760218"
+
+/* global variables used in handlers */
+static GVar G_ReturnTrue;
+static Obj  GC_ReturnTrue;
+static GVar G_fail;
+static Obj  GC_fail;
+static GVar G_Print;
+static Obj  GF_Print;
+static GVar G_CALL__WITH__CATCH;
+static Obj  GF_CALL__WITH__CATCH;
+static GVar G_p0;
+static Obj  GF_p0;
+static GVar G_p1;
+static Obj  GF_p1;
+static GVar G_p7;
+static Obj  GF_p7;
+static GVar G_f0;
+static Obj  GF_f0;
+static GVar G_Display;
+static Obj  GF_Display;
+static GVar G_f1;
+static Obj  GF_f1;
+static GVar G_f7;
+static Obj  GF_f7;
+static GVar G_runtest;
+static GVar G_NewCategory;
+static Obj  GF_NewCategory;
+static GVar G_IsFunction;
+static Obj  GC_IsFunction;
+static GVar G_InstallMethod;
+static Obj  GF_InstallMethod;
+static GVar G_CallFuncList;
+static Obj  GC_CallFuncList;
+static GVar G_IsList;
+static Obj  GC_IsList;
+static GVar G_Objectify;
+static Obj  GF_Objectify;
+static GVar G_NewType;
+static Obj  GF_NewType;
+static GVar G_NewFamily;
+static Obj  GF_NewFamily;
+static GVar G_IsPositionalObjectRep;
+static Obj  GC_IsPositionalObjectRep;
+static GVar G_BreakOnError;
+
+/* record names used in handlers */
+
+/* information for the functions */
+static Obj  NameFunc[16];
+static Obj FileName;
+
+/* handler for function 2 */
+static Obj  HdlrFunc2 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "p0\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "p0\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f(  ); */
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  CALL_0ARGS( a_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 3 */
+static Obj  HdlrFunc3 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "p1\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "p1\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f( 1 ); */
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  CALL_1ARGS( a_f, INTOBJ_INT(1) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 4 */
+static Obj  HdlrFunc4 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "p7\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "p7\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f( 1, 2, 3, 4, 5, 6, 7 ); */
+ t_1 = NEW_PLIST( T_PLIST, 7 );
+ SET_LEN_PLIST( t_1, 7 );
+ SET_ELM_PLIST( t_1, 1, INTOBJ_INT(1) );
+ SET_ELM_PLIST( t_1, 2, INTOBJ_INT(2) );
+ SET_ELM_PLIST( t_1, 3, INTOBJ_INT(3) );
+ SET_ELM_PLIST( t_1, 4, INTOBJ_INT(4) );
+ SET_ELM_PLIST( t_1, 5, INTOBJ_INT(5) );
+ SET_ELM_PLIST( t_1, 6, INTOBJ_INT(6) );
+ SET_ELM_PLIST( t_1, 7, INTOBJ_INT(7) );
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  CALL_XARGS( a_f, t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, a_f, t_1 );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 5 */
+static Obj  HdlrFunc5 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "f0\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "f0\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* Display( f(  ) ); */
+ t_1 = GF_Display;
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( a_f );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( ) );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 6 */
+static Obj  HdlrFunc6 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "f1\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "f1\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* Display( f( 1 ) ); */
+ t_1 = GF_Display;
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( a_f, INTOBJ_INT(1) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 7 */
+static Obj  HdlrFunc7 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "f7\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "f7\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* Display( f( 1, 2, 3, 4, 5, 6, 7 ) ); */
+ t_1 = GF_Display;
+ t_3 = NEW_PLIST( T_PLIST, 7 );
+ SET_LEN_PLIST( t_3, 7 );
+ SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
+ SET_ELM_PLIST( t_3, 2, INTOBJ_INT(2) );
+ SET_ELM_PLIST( t_3, 3, INTOBJ_INT(3) );
+ SET_ELM_PLIST( t_3, 4, INTOBJ_INT(4) );
+ SET_ELM_PLIST( t_3, 5, INTOBJ_INT(5) );
+ SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
+ SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  t_2 = CALL_XARGS( a_f, t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, a_f, t_3 );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 9 */
+static Obj  HdlrFunc9 (
+ Obj  self,
+ Obj  a_func,
+ Obj  a_args )
+{
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return args; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return a_args;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 10 */
+static Obj  HdlrFunc10 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p0( fail ); */
+ t_1 = GF_p0;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 11 */
+static Obj  HdlrFunc11 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p1( fail ); */
+ t_1 = GF_p1;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 12 */
+static Obj  HdlrFunc12 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p7( fail ); */
+ t_1 = GF_p7;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 13 */
+static Obj  HdlrFunc13 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* f0( fail ); */
+ t_1 = GF_f0;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 14 */
+static Obj  HdlrFunc14 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* f1( fail ); */
+ t_1 = GF_f1;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 15 */
+static Obj  HdlrFunc15 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* f7( fail ); */
+ t_1 = GF_f7;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 8 */
+static Obj  HdlrFunc8 (
+ Obj  self )
+{
+ Obj l_IsCustomFunction = 0;
+ Obj l_f = 0;
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Obj t_5 = 0;
+ Obj t_6 = 0;
+ Obj t_7 = 0;
+ Obj t_8 = 0;
+ (void)l_IsCustomFunction;
+ (void)l_f;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "test with a regular function\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "test with a regular function\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f := ReturnTrue; */
+ t_1 = GC_ReturnTrue;
+ CHECK_BOUND( t_1, "ReturnTrue" );
+ l_f = t_1;
+ 
+ /* p0( f ); */
+ t_1 = GF_p0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p1( f ); */
+ t_1 = GF_p1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p7( f ); */
+ t_1 = GF_p7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f0( f ); */
+ t_1 = GF_f0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f1( f ); */
+ t_1 = GF_f1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f7( f ); */
+ t_1 = GF_f7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* Print( "test with a custom function\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "test with a custom function\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* IsCustomFunction := NewCategory( "IsCustomFunction", IsFunction ); */
+ t_2 = GF_NewCategory;
+ t_3 = MakeString( "IsCustomFunction" );
+ t_4 = GC_IsFunction;
+ CHECK_BOUND( t_4, "IsFunction" );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+ }
+ CHECK_FUNC_RESULT( t_1 );
+ l_IsCustomFunction = t_1;
+ 
+ /* InstallMethod( CallFuncList, [ IsCustomFunction, IsList ], function ( func, args )
+      return args;
+  end ); */
+ t_1 = GF_InstallMethod;
+ t_2 = GC_CallFuncList;
+ CHECK_BOUND( t_2, "CallFuncList" );
+ t_3 = NEW_PLIST( T_PLIST, 2 );
+ SET_LEN_PLIST( t_3, 2 );
+ SET_ELM_PLIST( t_3, 1, l_IsCustomFunction );
+ CHANGED_BAG( t_3 );
+ t_4 = GC_IsList;
+ CHECK_BOUND( t_4, "IsList" );
+ SET_ELM_PLIST( t_3, 2, t_4 );
+ CHANGED_BAG( t_3 );
+ t_4 = NewFunction( NameFunc[9], 2, ArgStringToList("func,args"), HdlrFunc9 );
+ SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
+ t_5 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_5, 49);
+ SET_ENDLINE_BODY(t_5, 49);
+ SET_FILENAME_BODY(t_5, FileName);
+ SET_BODY_FUNC(t_4, t_5);
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
+ 
+ /* f := Objectify( NewType( NewFamily( "CustomFunctionFamily" ), IsCustomFunction and IsPositionalObjectRep ), [  ] ); */
+ t_2 = GF_Objectify;
+ t_4 = GF_NewType;
+ t_6 = GF_NewFamily;
+ t_7 = MakeString( "CustomFunctionFamily" );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
+ CHECK_FUNC_RESULT( t_5 );
+ if ( l_IsCustomFunction == False ) {
+  t_6 = l_IsCustomFunction;
+ }
+ else if ( l_IsCustomFunction == True ) {
+  t_7 = GC_IsPositionalObjectRep;
+  CHECK_BOUND( t_7, "IsPositionalObjectRep" );
+  CHECK_BOOL( t_7 );
+  t_6 = t_7;
+ }
+ else if (IS_FILTER( l_IsCustomFunction ) ) {
+  t_8 = GC_IsPositionalObjectRep;
+  CHECK_BOUND( t_8, "IsPositionalObjectRep" );
+  t_6 = NewAndFilter( l_IsCustomFunction, t_8 );
+ }
+ else {
+  RequireArgumentEx(0, l_IsCustomFunction, "<expr>",
+  "must be 'true' or 'false' or a filter" );
+ }
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, t_5, t_6 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5, t_6 ) );
+ }
+ CHECK_FUNC_RESULT( t_3 );
+ t_4 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_4, 0 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+ }
+ CHECK_FUNC_RESULT( t_1 );
+ l_f = t_1;
+ 
+ /* p0( f ); */
+ t_1 = GF_p0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p1( f ); */
+ t_1 = GF_p1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p7( f ); */
+ t_1 = GF_p7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f0( f ); */
+ t_1 = GF_f0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f1( f ); */
+ t_1 = GF_f1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f7( f ); */
+ t_1 = GF_f7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* BreakOnError := false; */
+ t_1 = False;
+ AssGVar( G_BreakOnError, t_1 );
+ 
+ /* Print( "test with a non-function\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "test with a non-function\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      p0( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[10], 0, 0, HdlrFunc10 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 64);
+ SET_ENDLINE_BODY(t_3, 64);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      p1( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[11], 0, 0, HdlrFunc11 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 65);
+ SET_ENDLINE_BODY(t_3, 65);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      p7( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[12], 0, 0, HdlrFunc12 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 66);
+ SET_ENDLINE_BODY(t_3, 66);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      f0( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[13], 0, 0, HdlrFunc13 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 68);
+ SET_ENDLINE_BODY(t_3, 68);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      f1( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[14], 0, 0, HdlrFunc14 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 69);
+ SET_ENDLINE_BODY(t_3, 69);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      f7( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[15], 0, 0, HdlrFunc15 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 70);
+ SET_ENDLINE_BODY(t_3, 70);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 1 */
+static Obj  HdlrFunc1 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p0 := function ( f )
+      Print( "p0\n" );
+      f(  );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[2], 1, ArgStringToList("f"), HdlrFunc2 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 2);
+ SET_ENDLINE_BODY(t_2, 5);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_p0, t_1 );
+ 
+ /* p1 := function ( f )
+      Print( "p1\n" );
+      f( 1 );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[3], 1, ArgStringToList("f"), HdlrFunc3 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 7);
+ SET_ENDLINE_BODY(t_2, 10);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_p1, t_1 );
+ 
+ /* p7 := function ( f )
+      Print( "p7\n" );
+      f( 1, 2, 3, 4, 5, 6, 7 );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[4], 1, ArgStringToList("f"), HdlrFunc4 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 12);
+ SET_ENDLINE_BODY(t_2, 15);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_p7, t_1 );
+ 
+ /* f0 := function ( f )
+      Print( "f0\n" );
+      Display( f(  ) );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[5], 1, ArgStringToList("f"), HdlrFunc5 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 18);
+ SET_ENDLINE_BODY(t_2, 21);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_f0, t_1 );
+ 
+ /* f1 := function ( f )
+      Print( "f1\n" );
+      Display( f( 1 ) );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[6], 1, ArgStringToList("f"), HdlrFunc6 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 23);
+ SET_ENDLINE_BODY(t_2, 26);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_f1, t_1 );
+ 
+ /* f7 := function ( f )
+      Print( "f7\n" );
+      Display( f( 1, 2, 3, 4, 5, 6, 7 ) );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[7], 1, ArgStringToList("f"), HdlrFunc7 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 28);
+ SET_ENDLINE_BODY(t_2, 31);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_f7, t_1 );
+ 
+ /* runtest := function (  )
+      local IsCustomFunction, f;
+      Print( "test with a regular function\n" );
+      f := ReturnTrue;
+      p0( f );
+      p1( f );
+      p7( f );
+      f0( f );
+      f1( f );
+      f7( f );
+      Print( "test with a custom function\n" );
+      IsCustomFunction := NewCategory( "IsCustomFunction", IsFunction );
+      InstallMethod( CallFuncList, [ IsCustomFunction, IsList ], function ( func, args )
+            return args;
+        end );
+      f := Objectify( NewType( NewFamily( "CustomFunctionFamily" ), IsCustomFunction and IsPositionalObjectRep ), [  ] );
+      p0( f );
+      p1( f );
+      p7( f );
+      f0( f );
+      f1( f );
+      f7( f );
+      BreakOnError := false;
+      Print( "test with a non-function\n" );
+      CALL_WITH_CATCH( function (  )
+            p0( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            p1( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            p7( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            f0( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            f1( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            f7( fail );
+            return;
+        end, [  ] );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[8], 0, 0, HdlrFunc8 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 33);
+ SET_ENDLINE_BODY(t_2, 72);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_runtest, t_1 );
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* 'PostRestore' restore gvars, rnams, functions */
+static Int PostRestore ( StructInitInfo * module )
+{
+ 
+ /* global variables used in handlers */
+ G_ReturnTrue = GVarName( "ReturnTrue" );
+ G_fail = GVarName( "fail" );
+ G_Print = GVarName( "Print" );
+ G_CALL__WITH__CATCH = GVarName( "CALL_WITH_CATCH" );
+ G_p0 = GVarName( "p0" );
+ G_p1 = GVarName( "p1" );
+ G_p7 = GVarName( "p7" );
+ G_f0 = GVarName( "f0" );
+ G_Display = GVarName( "Display" );
+ G_f1 = GVarName( "f1" );
+ G_f7 = GVarName( "f7" );
+ G_runtest = GVarName( "runtest" );
+ G_NewCategory = GVarName( "NewCategory" );
+ G_IsFunction = GVarName( "IsFunction" );
+ G_InstallMethod = GVarName( "InstallMethod" );
+ G_CallFuncList = GVarName( "CallFuncList" );
+ G_IsList = GVarName( "IsList" );
+ G_Objectify = GVarName( "Objectify" );
+ G_NewType = GVarName( "NewType" );
+ G_NewFamily = GVarName( "NewFamily" );
+ G_IsPositionalObjectRep = GVarName( "IsPositionalObjectRep" );
+ G_BreakOnError = GVarName( "BreakOnError" );
+ 
+ /* record names used in handlers */
+ 
+ /* information for the functions */
+ NameFunc[1] = 0;
+ NameFunc[2] = 0;
+ NameFunc[3] = 0;
+ NameFunc[4] = 0;
+ NameFunc[5] = 0;
+ NameFunc[6] = 0;
+ NameFunc[7] = 0;
+ NameFunc[8] = 0;
+ NameFunc[9] = 0;
+ NameFunc[10] = 0;
+ NameFunc[11] = 0;
+ NameFunc[12] = 0;
+ NameFunc[13] = 0;
+ NameFunc[14] = 0;
+ NameFunc[15] = 0;
+ 
+ /* return success */
+ return 0;
+ 
+}
+
+
+/* 'InitKernel' sets up data structures, fopies, copies, handlers */
+static Int InitKernel ( StructInitInfo * module )
+{
+ 
+ /* global variables used in handlers */
+ InitCopyGVar( "ReturnTrue", &GC_ReturnTrue );
+ InitCopyGVar( "fail", &GC_fail );
+ InitFopyGVar( "Print", &GF_Print );
+ InitFopyGVar( "CALL_WITH_CATCH", &GF_CALL__WITH__CATCH );
+ InitFopyGVar( "p0", &GF_p0 );
+ InitFopyGVar( "p1", &GF_p1 );
+ InitFopyGVar( "p7", &GF_p7 );
+ InitFopyGVar( "f0", &GF_f0 );
+ InitFopyGVar( "Display", &GF_Display );
+ InitFopyGVar( "f1", &GF_f1 );
+ InitFopyGVar( "f7", &GF_f7 );
+ InitFopyGVar( "NewCategory", &GF_NewCategory );
+ InitCopyGVar( "IsFunction", &GC_IsFunction );
+ InitFopyGVar( "InstallMethod", &GF_InstallMethod );
+ InitCopyGVar( "CallFuncList", &GC_CallFuncList );
+ InitCopyGVar( "IsList", &GC_IsList );
+ InitFopyGVar( "Objectify", &GF_Objectify );
+ InitFopyGVar( "NewType", &GF_NewType );
+ InitFopyGVar( "NewFamily", &GF_NewFamily );
+ InitCopyGVar( "IsPositionalObjectRep", &GC_IsPositionalObjectRep );
+ 
+ /* information for the functions */
+ InitGlobalBag( &FileName, "callfunc.g:FileName("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc1, "callfunc.g:HdlrFunc1("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[1]), "callfunc.g:NameFunc[1]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc2, "callfunc.g:HdlrFunc2("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[2]), "callfunc.g:NameFunc[2]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc3, "callfunc.g:HdlrFunc3("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[3]), "callfunc.g:NameFunc[3]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc4, "callfunc.g:HdlrFunc4("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[4]), "callfunc.g:NameFunc[4]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc5, "callfunc.g:HdlrFunc5("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[5]), "callfunc.g:NameFunc[5]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc6, "callfunc.g:HdlrFunc6("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[6]), "callfunc.g:NameFunc[6]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc7, "callfunc.g:HdlrFunc7("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[7]), "callfunc.g:NameFunc[7]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc8, "callfunc.g:HdlrFunc8("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[8]), "callfunc.g:NameFunc[8]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc9, "callfunc.g:HdlrFunc9("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[9]), "callfunc.g:NameFunc[9]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc10, "callfunc.g:HdlrFunc10("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[10]), "callfunc.g:NameFunc[10]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc11, "callfunc.g:HdlrFunc11("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[11]), "callfunc.g:NameFunc[11]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc12, "callfunc.g:HdlrFunc12("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[12]), "callfunc.g:NameFunc[12]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc13, "callfunc.g:HdlrFunc13("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[13]), "callfunc.g:NameFunc[13]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc14, "callfunc.g:HdlrFunc14("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[14]), "callfunc.g:NameFunc[14]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc15, "callfunc.g:HdlrFunc15("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[15]), "callfunc.g:NameFunc[15]("FILE_CRC")" );
+ 
+ /* return success */
+ return 0;
+ 
+}
+
+/* 'InitLibrary' sets up gvars, rnams, functions */
+static Int InitLibrary ( StructInitInfo * module )
+{
+ Obj func1;
+ Obj body1;
+ 
+ /* Complete Copy/Fopy registration */
+ UpdateCopyFopyInfo();
+ FileName = MakeImmString( "callfunc.g" );
+ PostRestore(module);
+ 
+ /* create all the functions defined in this module */
+ func1 = NewFunction(NameFunc[1],0,0,HdlrFunc1);
+ SET_ENVI_FUNC( func1, STATE(CurrLVars) );
+ body1 = NewFunctionBody();
+ SET_BODY_FUNC( func1, body1 );
+ CHANGED_BAG( func1 );
+ CALL_0ARGS( func1 );
+ 
+ /* return success */
+ return 0;
+ 
+}
+
+/* <name> returns the description of this module */
+static StructInitInfo module = {
+ .type        = MODULE_DYNAMIC,
+ .name        = "callfunc.g",
+ .crc         = 6760218,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
+};
+
+StructInitInfo * Init__Dynamic ( void )
+{
+ return &module;
+}
+
+/* compiled code ends here */

--- a/tst/test-compile/callfunc.g.out
+++ b/tst/test-compile/callfunc.g.out
@@ -1,0 +1,51 @@
+test with a regular function
+p0
+p1
+p7
+f0
+true
+f1
+true
+f7
+true
+test with a custom function
+p0
+p1
+p7
+f0
+[  ]
+f1
+[ 1 ]
+f7
+[ 1, 2, 3, 4, 5, 6, 7 ]
+test with a non-function
+p0
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+
+p1
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+
+p7
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+
+f0
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+
+f1
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+
+f7
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+The 1st argument is 'fail' which might point to an earlier problem
+

--- a/tst/test-compile/callfunc.g.static.c
+++ b/tst/test-compile/callfunc.g.static.c
@@ -1,0 +1,1250 @@
+/* C file produced by GAC */
+#include "compiled.h"
+#define FILE_CRC  "6760218"
+
+/* global variables used in handlers */
+static GVar G_ReturnTrue;
+static Obj  GC_ReturnTrue;
+static GVar G_fail;
+static Obj  GC_fail;
+static GVar G_Print;
+static Obj  GF_Print;
+static GVar G_CALL__WITH__CATCH;
+static Obj  GF_CALL__WITH__CATCH;
+static GVar G_p0;
+static Obj  GF_p0;
+static GVar G_p1;
+static Obj  GF_p1;
+static GVar G_p7;
+static Obj  GF_p7;
+static GVar G_f0;
+static Obj  GF_f0;
+static GVar G_Display;
+static Obj  GF_Display;
+static GVar G_f1;
+static Obj  GF_f1;
+static GVar G_f7;
+static Obj  GF_f7;
+static GVar G_runtest;
+static GVar G_NewCategory;
+static Obj  GF_NewCategory;
+static GVar G_IsFunction;
+static Obj  GC_IsFunction;
+static GVar G_InstallMethod;
+static Obj  GF_InstallMethod;
+static GVar G_CallFuncList;
+static Obj  GC_CallFuncList;
+static GVar G_IsList;
+static Obj  GC_IsList;
+static GVar G_Objectify;
+static Obj  GF_Objectify;
+static GVar G_NewType;
+static Obj  GF_NewType;
+static GVar G_NewFamily;
+static Obj  GF_NewFamily;
+static GVar G_IsPositionalObjectRep;
+static Obj  GC_IsPositionalObjectRep;
+static GVar G_BreakOnError;
+
+/* record names used in handlers */
+
+/* information for the functions */
+static Obj  NameFunc[16];
+static Obj FileName;
+
+/* handler for function 2 */
+static Obj  HdlrFunc2 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "p0\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "p0\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f(  ); */
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  CALL_0ARGS( a_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 3 */
+static Obj  HdlrFunc3 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "p1\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "p1\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f( 1 ); */
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  CALL_1ARGS( a_f, INTOBJ_INT(1) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 4 */
+static Obj  HdlrFunc4 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "p7\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "p7\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f( 1, 2, 3, 4, 5, 6, 7 ); */
+ t_1 = NEW_PLIST( T_PLIST, 7 );
+ SET_LEN_PLIST( t_1, 7 );
+ SET_ELM_PLIST( t_1, 1, INTOBJ_INT(1) );
+ SET_ELM_PLIST( t_1, 2, INTOBJ_INT(2) );
+ SET_ELM_PLIST( t_1, 3, INTOBJ_INT(3) );
+ SET_ELM_PLIST( t_1, 4, INTOBJ_INT(4) );
+ SET_ELM_PLIST( t_1, 5, INTOBJ_INT(5) );
+ SET_ELM_PLIST( t_1, 6, INTOBJ_INT(6) );
+ SET_ELM_PLIST( t_1, 7, INTOBJ_INT(7) );
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  CALL_XARGS( a_f, t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, a_f, t_1 );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 5 */
+static Obj  HdlrFunc5 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "f0\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "f0\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* Display( f(  ) ); */
+ t_1 = GF_Display;
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  t_2 = CALL_0ARGS( a_f );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( ) );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 6 */
+static Obj  HdlrFunc6 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "f1\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "f1\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* Display( f( 1 ) ); */
+ t_1 = GF_Display;
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( a_f, INTOBJ_INT(1) );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, a_f, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 7 */
+static Obj  HdlrFunc7 (
+ Obj  self,
+ Obj  a_f )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "f7\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "f7\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* Display( f( 1, 2, 3, 4, 5, 6, 7 ) ); */
+ t_1 = GF_Display;
+ t_3 = NEW_PLIST( T_PLIST, 7 );
+ SET_LEN_PLIST( t_3, 7 );
+ SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
+ SET_ELM_PLIST( t_3, 2, INTOBJ_INT(2) );
+ SET_ELM_PLIST( t_3, 3, INTOBJ_INT(3) );
+ SET_ELM_PLIST( t_3, 4, INTOBJ_INT(4) );
+ SET_ELM_PLIST( t_3, 5, INTOBJ_INT(5) );
+ SET_ELM_PLIST( t_3, 6, INTOBJ_INT(6) );
+ SET_ELM_PLIST( t_3, 7, INTOBJ_INT(7) );
+ if ( TNUM_OBJ( a_f ) == T_FUNCTION ) {
+  t_2 = CALL_XARGS( a_f, t_3 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, a_f, t_3 );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 9 */
+static Obj  HdlrFunc9 (
+ Obj  self,
+ Obj  a_func,
+ Obj  a_args )
+{
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* return args; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return a_args;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 10 */
+static Obj  HdlrFunc10 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p0( fail ); */
+ t_1 = GF_p0;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 11 */
+static Obj  HdlrFunc11 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p1( fail ); */
+ t_1 = GF_p1;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 12 */
+static Obj  HdlrFunc12 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p7( fail ); */
+ t_1 = GF_p7;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 13 */
+static Obj  HdlrFunc13 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* f0( fail ); */
+ t_1 = GF_f0;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 14 */
+static Obj  HdlrFunc14 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* f1( fail ); */
+ t_1 = GF_f1;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 15 */
+static Obj  HdlrFunc15 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* f7( fail ); */
+ t_1 = GF_f7;
+ t_2 = GC_fail;
+ CHECK_BOUND( t_2, "fail" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 8 */
+static Obj  HdlrFunc8 (
+ Obj  self )
+{
+ Obj l_IsCustomFunction = 0;
+ Obj l_f = 0;
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Obj t_3 = 0;
+ Obj t_4 = 0;
+ Obj t_5 = 0;
+ Obj t_6 = 0;
+ Obj t_7 = 0;
+ Obj t_8 = 0;
+ (void)l_IsCustomFunction;
+ (void)l_f;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* Print( "test with a regular function\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "test with a regular function\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* f := ReturnTrue; */
+ t_1 = GC_ReturnTrue;
+ CHECK_BOUND( t_1, "ReturnTrue" );
+ l_f = t_1;
+ 
+ /* p0( f ); */
+ t_1 = GF_p0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p1( f ); */
+ t_1 = GF_p1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p7( f ); */
+ t_1 = GF_p7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f0( f ); */
+ t_1 = GF_f0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f1( f ); */
+ t_1 = GF_f1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f7( f ); */
+ t_1 = GF_f7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* Print( "test with a custom function\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "test with a custom function\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* IsCustomFunction := NewCategory( "IsCustomFunction", IsFunction ); */
+ t_2 = GF_NewCategory;
+ t_3 = MakeString( "IsCustomFunction" );
+ t_4 = GC_IsFunction;
+ CHECK_BOUND( t_4, "IsFunction" );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+ }
+ CHECK_FUNC_RESULT( t_1 );
+ l_IsCustomFunction = t_1;
+ 
+ /* InstallMethod( CallFuncList, [ IsCustomFunction, IsList ], function ( func, args )
+      return args;
+  end ); */
+ t_1 = GF_InstallMethod;
+ t_2 = GC_CallFuncList;
+ CHECK_BOUND( t_2, "CallFuncList" );
+ t_3 = NEW_PLIST( T_PLIST, 2 );
+ SET_LEN_PLIST( t_3, 2 );
+ SET_ELM_PLIST( t_3, 1, l_IsCustomFunction );
+ CHANGED_BAG( t_3 );
+ t_4 = GC_IsList;
+ CHECK_BOUND( t_4, "IsList" );
+ SET_ELM_PLIST( t_3, 2, t_4 );
+ CHANGED_BAG( t_3 );
+ t_4 = NewFunction( NameFunc[9], 2, ArgStringToList("func,args"), HdlrFunc9 );
+ SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
+ t_5 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_5, 49);
+ SET_ENDLINE_BODY(t_5, 49);
+ SET_FILENAME_BODY(t_5, FileName);
+ SET_BODY_FUNC(t_4, t_5);
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, t_3, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3, t_4 ) );
+ }
+ 
+ /* f := Objectify( NewType( NewFamily( "CustomFunctionFamily" ), IsCustomFunction and IsPositionalObjectRep ), [  ] ); */
+ t_2 = GF_Objectify;
+ t_4 = GF_NewType;
+ t_6 = GF_NewFamily;
+ t_7 = MakeString( "CustomFunctionFamily" );
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_1ARGS( t_6, t_7 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( t_7 ) );
+ }
+ CHECK_FUNC_RESULT( t_5 );
+ if ( l_IsCustomFunction == False ) {
+  t_6 = l_IsCustomFunction;
+ }
+ else if ( l_IsCustomFunction == True ) {
+  t_7 = GC_IsPositionalObjectRep;
+  CHECK_BOUND( t_7, "IsPositionalObjectRep" );
+  CHECK_BOOL( t_7 );
+  t_6 = t_7;
+ }
+ else if (IS_FILTER( l_IsCustomFunction ) ) {
+  t_8 = GC_IsPositionalObjectRep;
+  CHECK_BOUND( t_8, "IsPositionalObjectRep" );
+  t_6 = NewAndFilter( l_IsCustomFunction, t_8 );
+ }
+ else {
+  RequireArgumentEx(0, l_IsCustomFunction, "<expr>",
+  "must be 'true' or 'false' or a filter" );
+ }
+ if ( TNUM_OBJ( t_4 ) == T_FUNCTION ) {
+  t_3 = CALL_2ARGS( t_4, t_5, t_6 );
+ }
+ else {
+  t_3 = DoOperation2Args( CallFuncListOper, t_4, NewPlistFromArgs( t_5, t_6 ) );
+ }
+ CHECK_FUNC_RESULT( t_3 );
+ t_4 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_4, 0 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, t_3, t_4 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( t_3, t_4 ) );
+ }
+ CHECK_FUNC_RESULT( t_1 );
+ l_f = t_1;
+ 
+ /* p0( f ); */
+ t_1 = GF_p0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p1( f ); */
+ t_1 = GF_p1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* p7( f ); */
+ t_1 = GF_p7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f0( f ); */
+ t_1 = GF_f0;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f1( f ); */
+ t_1 = GF_f1;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* f7( f ); */
+ t_1 = GF_f7;
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, l_f );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( l_f ) );
+ }
+ 
+ /* BreakOnError := false; */
+ t_1 = False;
+ AssGVar( G_BreakOnError, t_1 );
+ 
+ /* Print( "test with a non-function\n" ); */
+ t_1 = GF_Print;
+ t_2 = MakeString( "test with a non-function\n" );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      p0( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[10], 0, 0, HdlrFunc10 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 64);
+ SET_ENDLINE_BODY(t_3, 64);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      p1( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[11], 0, 0, HdlrFunc11 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 65);
+ SET_ENDLINE_BODY(t_3, 65);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      p7( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[12], 0, 0, HdlrFunc12 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 66);
+ SET_ENDLINE_BODY(t_3, 66);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      f0( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[13], 0, 0, HdlrFunc13 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 68);
+ SET_ENDLINE_BODY(t_3, 68);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      f1( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[14], 0, 0, HdlrFunc14 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 69);
+ SET_ENDLINE_BODY(t_3, 69);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* CALL_WITH_CATCH( function (  )
+      f7( fail );
+      return;
+  end, [  ] ); */
+ t_1 = GF_CALL__WITH__CATCH;
+ t_2 = NewFunction( NameFunc[15], 0, 0, HdlrFunc15 );
+ SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
+ t_3 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_3, 70);
+ SET_ENDLINE_BODY(t_3, 70);
+ SET_FILENAME_BODY(t_3, FileName);
+ SET_BODY_FUNC(t_2, t_3);
+ t_3 = NEW_PLIST( T_PLIST, 0 );
+ SET_LEN_PLIST( t_3, 0 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* handler for function 1 */
+static Obj  HdlrFunc1 (
+ Obj  self )
+{
+ Obj t_1 = 0;
+ Obj t_2 = 0;
+ Bag oldFrame;
+ 
+ /* allocate new stack frame */
+ SWITCH_TO_NEW_FRAME(self,0,0,oldFrame);
+ 
+ /* p0 := function ( f )
+      Print( "p0\n" );
+      f(  );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[2], 1, ArgStringToList("f"), HdlrFunc2 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 2);
+ SET_ENDLINE_BODY(t_2, 5);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_p0, t_1 );
+ 
+ /* p1 := function ( f )
+      Print( "p1\n" );
+      f( 1 );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[3], 1, ArgStringToList("f"), HdlrFunc3 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 7);
+ SET_ENDLINE_BODY(t_2, 10);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_p1, t_1 );
+ 
+ /* p7 := function ( f )
+      Print( "p7\n" );
+      f( 1, 2, 3, 4, 5, 6, 7 );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[4], 1, ArgStringToList("f"), HdlrFunc4 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 12);
+ SET_ENDLINE_BODY(t_2, 15);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_p7, t_1 );
+ 
+ /* f0 := function ( f )
+      Print( "f0\n" );
+      Display( f(  ) );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[5], 1, ArgStringToList("f"), HdlrFunc5 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 18);
+ SET_ENDLINE_BODY(t_2, 21);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_f0, t_1 );
+ 
+ /* f1 := function ( f )
+      Print( "f1\n" );
+      Display( f( 1 ) );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[6], 1, ArgStringToList("f"), HdlrFunc6 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 23);
+ SET_ENDLINE_BODY(t_2, 26);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_f1, t_1 );
+ 
+ /* f7 := function ( f )
+      Print( "f7\n" );
+      Display( f( 1, 2, 3, 4, 5, 6, 7 ) );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[7], 1, ArgStringToList("f"), HdlrFunc7 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 28);
+ SET_ENDLINE_BODY(t_2, 31);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_f7, t_1 );
+ 
+ /* runtest := function (  )
+      local IsCustomFunction, f;
+      Print( "test with a regular function\n" );
+      f := ReturnTrue;
+      p0( f );
+      p1( f );
+      p7( f );
+      f0( f );
+      f1( f );
+      f7( f );
+      Print( "test with a custom function\n" );
+      IsCustomFunction := NewCategory( "IsCustomFunction", IsFunction );
+      InstallMethod( CallFuncList, [ IsCustomFunction, IsList ], function ( func, args )
+            return args;
+        end );
+      f := Objectify( NewType( NewFamily( "CustomFunctionFamily" ), IsCustomFunction and IsPositionalObjectRep ), [  ] );
+      p0( f );
+      p1( f );
+      p7( f );
+      f0( f );
+      f1( f );
+      f7( f );
+      BreakOnError := false;
+      Print( "test with a non-function\n" );
+      CALL_WITH_CATCH( function (  )
+            p0( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            p1( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            p7( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            f0( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            f1( fail );
+            return;
+        end, [  ] );
+      CALL_WITH_CATCH( function (  )
+            f7( fail );
+            return;
+        end, [  ] );
+      return;
+  end; */
+ t_1 = NewFunction( NameFunc[8], 0, 0, HdlrFunc8 );
+ SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
+ t_2 = NewFunctionBody();
+ SET_STARTLINE_BODY(t_2, 33);
+ SET_ENDLINE_BODY(t_2, 72);
+ SET_FILENAME_BODY(t_2, FileName);
+ SET_BODY_FUNC(t_1, t_2);
+ AssGVar( G_runtest, t_1 );
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+ 
+ /* return; */
+ SWITCH_TO_OLD_FRAME(oldFrame);
+ return 0;
+}
+
+/* 'PostRestore' restore gvars, rnams, functions */
+static Int PostRestore ( StructInitInfo * module )
+{
+ 
+ /* global variables used in handlers */
+ G_ReturnTrue = GVarName( "ReturnTrue" );
+ G_fail = GVarName( "fail" );
+ G_Print = GVarName( "Print" );
+ G_CALL__WITH__CATCH = GVarName( "CALL_WITH_CATCH" );
+ G_p0 = GVarName( "p0" );
+ G_p1 = GVarName( "p1" );
+ G_p7 = GVarName( "p7" );
+ G_f0 = GVarName( "f0" );
+ G_Display = GVarName( "Display" );
+ G_f1 = GVarName( "f1" );
+ G_f7 = GVarName( "f7" );
+ G_runtest = GVarName( "runtest" );
+ G_NewCategory = GVarName( "NewCategory" );
+ G_IsFunction = GVarName( "IsFunction" );
+ G_InstallMethod = GVarName( "InstallMethod" );
+ G_CallFuncList = GVarName( "CallFuncList" );
+ G_IsList = GVarName( "IsList" );
+ G_Objectify = GVarName( "Objectify" );
+ G_NewType = GVarName( "NewType" );
+ G_NewFamily = GVarName( "NewFamily" );
+ G_IsPositionalObjectRep = GVarName( "IsPositionalObjectRep" );
+ G_BreakOnError = GVarName( "BreakOnError" );
+ 
+ /* record names used in handlers */
+ 
+ /* information for the functions */
+ NameFunc[1] = 0;
+ NameFunc[2] = 0;
+ NameFunc[3] = 0;
+ NameFunc[4] = 0;
+ NameFunc[5] = 0;
+ NameFunc[6] = 0;
+ NameFunc[7] = 0;
+ NameFunc[8] = 0;
+ NameFunc[9] = 0;
+ NameFunc[10] = 0;
+ NameFunc[11] = 0;
+ NameFunc[12] = 0;
+ NameFunc[13] = 0;
+ NameFunc[14] = 0;
+ NameFunc[15] = 0;
+ 
+ /* return success */
+ return 0;
+ 
+}
+
+
+/* 'InitKernel' sets up data structures, fopies, copies, handlers */
+static Int InitKernel ( StructInitInfo * module )
+{
+ 
+ /* global variables used in handlers */
+ InitCopyGVar( "ReturnTrue", &GC_ReturnTrue );
+ InitCopyGVar( "fail", &GC_fail );
+ InitFopyGVar( "Print", &GF_Print );
+ InitFopyGVar( "CALL_WITH_CATCH", &GF_CALL__WITH__CATCH );
+ InitFopyGVar( "p0", &GF_p0 );
+ InitFopyGVar( "p1", &GF_p1 );
+ InitFopyGVar( "p7", &GF_p7 );
+ InitFopyGVar( "f0", &GF_f0 );
+ InitFopyGVar( "Display", &GF_Display );
+ InitFopyGVar( "f1", &GF_f1 );
+ InitFopyGVar( "f7", &GF_f7 );
+ InitFopyGVar( "NewCategory", &GF_NewCategory );
+ InitCopyGVar( "IsFunction", &GC_IsFunction );
+ InitFopyGVar( "InstallMethod", &GF_InstallMethod );
+ InitCopyGVar( "CallFuncList", &GC_CallFuncList );
+ InitCopyGVar( "IsList", &GC_IsList );
+ InitFopyGVar( "Objectify", &GF_Objectify );
+ InitFopyGVar( "NewType", &GF_NewType );
+ InitFopyGVar( "NewFamily", &GF_NewFamily );
+ InitCopyGVar( "IsPositionalObjectRep", &GC_IsPositionalObjectRep );
+ 
+ /* information for the functions */
+ InitGlobalBag( &FileName, "callfunc.g:FileName("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc1, "callfunc.g:HdlrFunc1("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[1]), "callfunc.g:NameFunc[1]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc2, "callfunc.g:HdlrFunc2("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[2]), "callfunc.g:NameFunc[2]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc3, "callfunc.g:HdlrFunc3("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[3]), "callfunc.g:NameFunc[3]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc4, "callfunc.g:HdlrFunc4("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[4]), "callfunc.g:NameFunc[4]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc5, "callfunc.g:HdlrFunc5("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[5]), "callfunc.g:NameFunc[5]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc6, "callfunc.g:HdlrFunc6("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[6]), "callfunc.g:NameFunc[6]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc7, "callfunc.g:HdlrFunc7("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[7]), "callfunc.g:NameFunc[7]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc8, "callfunc.g:HdlrFunc8("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[8]), "callfunc.g:NameFunc[8]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc9, "callfunc.g:HdlrFunc9("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[9]), "callfunc.g:NameFunc[9]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc10, "callfunc.g:HdlrFunc10("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[10]), "callfunc.g:NameFunc[10]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc11, "callfunc.g:HdlrFunc11("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[11]), "callfunc.g:NameFunc[11]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc12, "callfunc.g:HdlrFunc12("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[12]), "callfunc.g:NameFunc[12]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc13, "callfunc.g:HdlrFunc13("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[13]), "callfunc.g:NameFunc[13]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc14, "callfunc.g:HdlrFunc14("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[14]), "callfunc.g:NameFunc[14]("FILE_CRC")" );
+ InitHandlerFunc( HdlrFunc15, "callfunc.g:HdlrFunc15("FILE_CRC")" );
+ InitGlobalBag( &(NameFunc[15]), "callfunc.g:NameFunc[15]("FILE_CRC")" );
+ 
+ /* return success */
+ return 0;
+ 
+}
+
+/* 'InitLibrary' sets up gvars, rnams, functions */
+static Int InitLibrary ( StructInitInfo * module )
+{
+ Obj func1;
+ Obj body1;
+ 
+ /* Complete Copy/Fopy registration */
+ UpdateCopyFopyInfo();
+ FileName = MakeImmString( "callfunc.g" );
+ PostRestore(module);
+ 
+ /* create all the functions defined in this module */
+ func1 = NewFunction(NameFunc[1],0,0,HdlrFunc1);
+ SET_ENVI_FUNC( func1, STATE(CurrLVars) );
+ body1 = NewFunctionBody();
+ SET_BODY_FUNC( func1, body1 );
+ CHANGED_BAG( func1 );
+ CALL_0ARGS( func1 );
+ 
+ /* return success */
+ return 0;
+ 
+}
+
+/* <name> returns the description of this module */
+static StructInitInfo module = {
+ .type        = MODULE_STATIC,
+ .name        = "callfunc.g",
+ .crc         = 6760218,
+ .initKernel  = InitKernel,
+ .initLibrary = InitLibrary,
+ .postRestore = PostRestore,
+};
+
+StructInitInfo * Init__callfunc ( void )
+{
+ return &module;
+}
+
+/* compiled code ends here */

--- a/tst/test-compile/function_types.g.dynamic.c
+++ b/tst/test-compile/function_types.g.dynamic.c
@@ -161,7 +161,7 @@ static Obj  HdlrFunc7 (
  /* return f1(  ); */
  t_2 = GF_f1;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -184,7 +184,7 @@ static Obj  HdlrFunc8 (
  /* return f1( 1, 2 ); */
  t_2 = GF_f1;
  t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -207,7 +207,7 @@ static Obj  HdlrFunc9 (
  /* return f2( 1, 2, 3 ); */
  t_2 = GF_f2;
  t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -230,7 +230,7 @@ static Obj  HdlrFunc10 (
  /* return f4(  ); */
  t_2 = GF_f4;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  

--- a/tst/test-compile/function_types.g.dynamic.c
+++ b/tst/test-compile/function_types.g.dynamic.c
@@ -41,7 +41,12 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_2 = MakeString( "f1:" );
  t_3 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -72,7 +77,12 @@ static Obj  HdlrFunc3 (
  t_2 = MakeString( "f2:" );
  t_3 = MakeString( ":" );
  t_4 = MakeString( "\n" );
- CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3, a_b, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -100,7 +110,12 @@ static Obj  HdlrFunc4 (
  t_1 = GF_Print;
  t_2 = MakeString( "f3:" );
  t_3 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -136,7 +151,12 @@ static Obj  HdlrFunc5 (
  t_2 = MakeString( "f4:" );
  t_3 = MakeString( ":" );
  t_4 = MakeString( "\n" );
- CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3, a_b, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -160,7 +180,12 @@ static Obj  HdlrFunc7 (
  
  /* return f1(  ); */
  t_2 = GF_f1;
- t_1 = CALL_0ARGS( t_2 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_0ARGS( t_2 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -183,7 +208,12 @@ static Obj  HdlrFunc8 (
  
  /* return f1( 1, 2 ); */
  t_2 = GF_f1;
- t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -206,7 +236,12 @@ static Obj  HdlrFunc9 (
  
  /* return f2( 1, 2, 3 ); */
  t_2 = GF_f2;
- t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -229,7 +264,12 @@ static Obj  HdlrFunc10 (
  
  /* return f4(  ); */
  t_2 = GF_f4;
- t_1 = CALL_0ARGS( t_2 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_0ARGS( t_2 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -253,35 +293,75 @@ static Obj  HdlrFunc6 (
  
  /* f1( 2 ); */
  t_1 = GF_f1;
- CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2) ) );
+ }
  
  /* f2( 2, 3 ); */
  t_1 = GF_f2;
- CALL_2ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  
  /* f3(  ); */
  t_1 = GF_f3;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* f3( 2 ); */
  t_1 = GF_f3;
- CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2) ) );
+ }
  
  /* f3( 2, 3, 4 ); */
  t_1 = GF_f3;
- CALL_3ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) ) );
+ }
  
  /* f4( 1 ); */
  t_1 = GF_f4;
- CALL_1ARGS( t_1, INTOBJ_INT(1) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(1) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
  
  /* f4( 1, 2 ); */
  t_1 = GF_f4;
- CALL_2ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  
  /* f4( 1, 2, 3 ); */
  t_1 = GF_f4;
- CALL_3ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  
  /* BreakOnError := false; */
  t_1 = False;
@@ -300,7 +380,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return f1( 1, 2 );
@@ -315,7 +400,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return f2( 1, 2, 3 );
@@ -330,7 +420,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return f4(  );
@@ -345,7 +440,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/function_types.g.static.c
+++ b/tst/test-compile/function_types.g.static.c
@@ -161,7 +161,7 @@ static Obj  HdlrFunc7 (
  /* return f1(  ); */
  t_2 = GF_f1;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -184,7 +184,7 @@ static Obj  HdlrFunc8 (
  /* return f1( 1, 2 ); */
  t_2 = GF_f1;
  t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -207,7 +207,7 @@ static Obj  HdlrFunc9 (
  /* return f2( 1, 2, 3 ); */
  t_2 = GF_f2;
  t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  
@@ -230,7 +230,7 @@ static Obj  HdlrFunc10 (
  /* return f4(  ); */
  t_2 = GF_f4;
  t_1 = CALL_0ARGS( t_2 );
- CHECK_FUNC_RESULT( t_1 )
+ CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
  

--- a/tst/test-compile/function_types.g.static.c
+++ b/tst/test-compile/function_types.g.static.c
@@ -41,7 +41,12 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_2 = MakeString( "f1:" );
  t_3 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -72,7 +77,12 @@ static Obj  HdlrFunc3 (
  t_2 = MakeString( "f2:" );
  t_3 = MakeString( ":" );
  t_4 = MakeString( "\n" );
- CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3, a_b, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -100,7 +110,12 @@ static Obj  HdlrFunc4 (
  t_1 = GF_Print;
  t_2 = MakeString( "f3:" );
  t_3 = MakeString( "\n" );
- CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, t_2, a_a, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -136,7 +151,12 @@ static Obj  HdlrFunc5 (
  t_2 = MakeString( "f4:" );
  t_3 = MakeString( ":" );
  t_4 = MakeString( "\n" );
- CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_5ARGS( t_1, t_2, a_a, t_3, a_b, t_4 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, a_a, t_3, a_b, t_4 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);
@@ -160,7 +180,12 @@ static Obj  HdlrFunc7 (
  
  /* return f1(  ); */
  t_2 = GF_f1;
- t_1 = CALL_0ARGS( t_2 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_0ARGS( t_2 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -183,7 +208,12 @@ static Obj  HdlrFunc8 (
  
  /* return f1( 1, 2 ); */
  t_2 = GF_f1;
- t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_2ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -206,7 +236,12 @@ static Obj  HdlrFunc9 (
  
  /* return f2( 1, 2, 3 ); */
  t_2 = GF_f2;
- t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_3ARGS( t_2, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -229,7 +264,12 @@ static Obj  HdlrFunc10 (
  
  /* return f4(  ); */
  t_2 = GF_f4;
- t_1 = CALL_0ARGS( t_2 );
+ if ( TNUM_OBJ( t_2 ) == T_FUNCTION ) {
+  t_1 = CALL_0ARGS( t_2 );
+ }
+ else {
+  t_1 = DoOperation2Args( CallFuncListOper, t_2, NewPlistFromArgs( ) );
+ }
  CHECK_FUNC_RESULT( t_1 );
  SWITCH_TO_OLD_FRAME(oldFrame);
  return t_1;
@@ -253,35 +293,75 @@ static Obj  HdlrFunc6 (
  
  /* f1( 2 ); */
  t_1 = GF_f1;
- CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2) ) );
+ }
  
  /* f2( 2, 3 ); */
  t_1 = GF_f2;
- CALL_2ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  
  /* f3(  ); */
  t_1 = GF_f3;
- CALL_0ARGS( t_1 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_0ARGS( t_1 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( ) );
+ }
  
  /* f3( 2 ); */
  t_1 = GF_f3;
- CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2) ) );
+ }
  
  /* f3( 2, 3, 4 ); */
  t_1 = GF_f3;
- CALL_3ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(2), INTOBJ_INT(3), INTOBJ_INT(4) ) );
+ }
  
  /* f4( 1 ); */
  t_1 = GF_f4;
- CALL_1ARGS( t_1, INTOBJ_INT(1) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, INTOBJ_INT(1) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1) ) );
+ }
  
  /* f4( 1, 2 ); */
  t_1 = GF_f4;
- CALL_2ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2) ) );
+ }
  
  /* f4( 1, 2, 3 ); */
  t_1 = GF_f4;
- CALL_3ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_3ARGS( t_1, INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(3) ) );
+ }
  
  /* BreakOnError := false; */
  t_1 = False;
@@ -300,7 +380,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return f1( 1, 2 );
@@ -315,7 +400,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return f2( 1, 2, 3 );
@@ -330,7 +420,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( function (  )
       return f4(  );
@@ -345,7 +440,12 @@ static Obj  HdlrFunc6 (
  SET_BODY_FUNC(t_2, t_3);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/info.g.dynamic.c
+++ b/tst/test-compile/info.g.dynamic.c
@@ -37,10 +37,20 @@ static Obj  HdlrFunc2 (
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
  CHECK_BOUND( t_4, "InfoDebug" );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
@@ -72,17 +82,32 @@ static Obj  HdlrFunc2 (
  t_1 = GF_SetInfoLevel;
  t_2 = GC_InfoDebug;
  CHECK_BOUND( t_2, "InfoDebug" );
- CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, INTOBJ_INT(2) ) );
+ }
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
  CHECK_BOUND( t_4, "InfoDebug" );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;

--- a/tst/test-compile/info.g.dynamic.c
+++ b/tst/test-compile/info.g.dynamic.c
@@ -36,15 +36,15 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -57,7 +57,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -71,22 +71,22 @@ static Obj  HdlrFunc2 (
  /* SetInfoLevel( InfoDebug, 2 ); */
  t_1 = GF_SetInfoLevel;
  t_2 = GC_InfoDebug;
- CHECK_BOUND( t_2, "InfoDebug" )
+ CHECK_BOUND( t_2, "InfoDebug" );
  CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(3) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -99,7 +99,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -112,7 +112,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );

--- a/tst/test-compile/info.g.static.c
+++ b/tst/test-compile/info.g.static.c
@@ -37,10 +37,20 @@ static Obj  HdlrFunc2 (
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
  CHECK_BOUND( t_4, "InfoDebug" );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
@@ -72,17 +82,32 @@ static Obj  HdlrFunc2 (
  t_1 = GF_SetInfoLevel;
  t_2 = GC_InfoDebug;
  CHECK_BOUND( t_2, "InfoDebug" );
- CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, INTOBJ_INT(2) ) );
+ }
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
  CHECK_BOUND( t_4, "InfoDebug" );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;

--- a/tst/test-compile/info.g.static.c
+++ b/tst/test-compile/info.g.static.c
@@ -36,15 +36,15 @@ static Obj  HdlrFunc2 (
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -57,7 +57,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -71,22 +71,22 @@ static Obj  HdlrFunc2 (
  /* SetInfoLevel( InfoDebug, 2 ); */
  t_1 = GF_SetInfoLevel;
  t_2 = GC_InfoDebug;
- CHECK_BOUND( t_2, "InfoDebug" )
+ CHECK_BOUND( t_2, "InfoDebug" );
  CALL_2ARGS( t_1, t_2, INTOBJ_INT(2) );
  
  /* Print( InfoLevel( InfoDebug ), "\n" ); */
  t_1 = GF_Print;
  t_3 = GF_InfoLevel;
  t_4 = GC_InfoDebug;
- CHECK_BOUND( t_4, "InfoDebug" )
+ CHECK_BOUND( t_4, "InfoDebug" );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(3) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -99,7 +99,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(2) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );
@@ -112,7 +112,7 @@ static Obj  HdlrFunc2 (
  
  /* Info( ... ); */
  t_1 = GC_InfoDebug;
- CHECK_BOUND( t_1, "InfoDebug" )
+ CHECK_BOUND( t_1, "InfoDebug" );
  t_3 = InfoCheckLevel( t_1, INTOBJ_INT(1) );
  if ( t_3 == True ) {
   t_2 = NEW_PLIST( T_PLIST, 1 );

--- a/tst/test-compile/print_various.g.dynamic.c
+++ b/tst/test-compile/print_various.g.dynamic.c
@@ -95,7 +95,7 @@ static Obj  HdlrFunc2 (
  CHANGED_BAG( t_5 );
  t_4 = Array2Perm( t_6 );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/print_various.g.dynamic.c
+++ b/tst/test-compile/print_various.g.dynamic.c
@@ -33,13 +33,23 @@ static Obj  HdlrFunc2 (
  /* Print( 1, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, INTOBJ_INT(1), t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, INTOBJ_INT(1), t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), t_2 ) );
+ }
  
  /* Print( "abc", "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "abc" );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( (1,2)(5,6), "\n" ); */
  t_1 = GF_Print;
@@ -64,7 +74,12 @@ static Obj  HdlrFunc2 (
  CHANGED_BAG( t_3 );
  t_2 = Array2Perm( t_4 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( [ 1, "abc" ], "\n" ); */
  t_1 = GF_Print;
@@ -75,7 +90,12 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_2, 2, t_3 );
  CHANGED_BAG( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( Group( (1,2,3) ), "\n" ); */
  t_1 = GF_Print;
@@ -94,10 +114,20 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_5, 3, INTOBJ_INT(3) );
  CHANGED_BAG( t_5 );
  t_4 = Array2Perm( t_6 );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/print_various.g.static.c
+++ b/tst/test-compile/print_various.g.static.c
@@ -95,7 +95,7 @@ static Obj  HdlrFunc2 (
  CHANGED_BAG( t_5 );
  t_4 = Array2Perm( t_6 );
  t_2 = CALL_1ARGS( t_3, t_4 );
- CHECK_FUNC_RESULT( t_2 )
+ CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
  CALL_2ARGS( t_1, t_2, t_3 );
  

--- a/tst/test-compile/print_various.g.static.c
+++ b/tst/test-compile/print_various.g.static.c
@@ -33,13 +33,23 @@ static Obj  HdlrFunc2 (
  /* Print( 1, "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "\n" );
- CALL_2ARGS( t_1, INTOBJ_INT(1), t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, INTOBJ_INT(1), t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( INTOBJ_INT(1), t_2 ) );
+ }
  
  /* Print( "abc", "\n" ); */
  t_1 = GF_Print;
  t_2 = MakeString( "abc" );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( (1,2)(5,6), "\n" ); */
  t_1 = GF_Print;
@@ -64,7 +74,12 @@ static Obj  HdlrFunc2 (
  CHANGED_BAG( t_3 );
  t_2 = Array2Perm( t_4 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( [ 1, "abc" ], "\n" ); */
  t_1 = GF_Print;
@@ -75,7 +90,12 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_2, 2, t_3 );
  CHANGED_BAG( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Print( Group( (1,2,3) ), "\n" ); */
  t_1 = GF_Print;
@@ -94,10 +114,20 @@ static Obj  HdlrFunc2 (
  SET_ELM_PLIST( t_5, 3, INTOBJ_INT(3) );
  CHANGED_BAG( t_5 );
  t_4 = Array2Perm( t_6 );
- t_2 = CALL_1ARGS( t_3, t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
  CHECK_FUNC_RESULT( t_2 );
  t_3 = MakeString( "\n" );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/ranges.g.dynamic.c
+++ b/tst/test-compile/ranges.g.dynamic.c
@@ -93,7 +93,12 @@ static Obj  HdlrFunc4 (
  t_4 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
  SET_ELM_PLIST( t_3, 2, t_4 );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range2, [ - 2 ^ 80, 0 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -106,7 +111,12 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, t_4 );
  CHANGED_BAG( t_3 );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(0) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 1, 2, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -119,7 +129,12 @@ static Obj  HdlrFunc4 (
  t_4 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
  SET_ELM_PLIST( t_3, 3, t_4 );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ - 2 ^ 80, 0, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -133,7 +148,12 @@ static Obj  HdlrFunc4 (
  CHANGED_BAG( t_3 );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(0) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(1) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 0, 2 ^ 80, 2 ^ 81 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -148,12 +168,22 @@ static Obj  HdlrFunc4 (
  t_4 = POW( INTOBJ_INT(2), INTOBJ_INT(81) );
  SET_ELM_PLIST( t_3, 3, t_4 );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 1, 2 .. 2 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 2, 2, 2 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -164,12 +194,22 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(2) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 2, 4 .. 6 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), INTOBJ_INT(6) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 2, 4, 7 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -180,17 +220,32 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(4) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(7) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 2, 4 .. 2 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 2, 4 .. 0 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), INTOBJ_INT(0) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 4, 2, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -201,17 +256,32 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(4) );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(1) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 4, 2 .. 0 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(4), INTOBJ_INT(2), INTOBJ_INT(0) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 4, 2 .. 8 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(4), INTOBJ_INT(2), INTOBJ_INT(8) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/ranges.g.dynamic.c
+++ b/tst/test-compile/ranges.g.dynamic.c
@@ -86,7 +86,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ 1, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -98,7 +98,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ - 2 ^ 80, 0 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -111,7 +111,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 1, 2, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -124,7 +124,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ - 2 ^ 80, 0, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -138,7 +138,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 0, 2 ^ 80, 2 ^ 81 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(0) );
@@ -158,7 +158,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 2, 2 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -174,7 +174,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 4, 7 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -195,7 +195,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 4, 2, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(4) );

--- a/tst/test-compile/ranges.g.static.c
+++ b/tst/test-compile/ranges.g.static.c
@@ -93,7 +93,12 @@ static Obj  HdlrFunc4 (
  t_4 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
  SET_ELM_PLIST( t_3, 2, t_4 );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range2, [ - 2 ^ 80, 0 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -106,7 +111,12 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, t_4 );
  CHANGED_BAG( t_3 );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(0) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 1, 2, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -119,7 +129,12 @@ static Obj  HdlrFunc4 (
  t_4 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
  SET_ELM_PLIST( t_3, 3, t_4 );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ - 2 ^ 80, 0, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -133,7 +148,12 @@ static Obj  HdlrFunc4 (
  CHANGED_BAG( t_3 );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(0) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(1) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 0, 2 ^ 80, 2 ^ 81 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -148,12 +168,22 @@ static Obj  HdlrFunc4 (
  t_4 = POW( INTOBJ_INT(2), INTOBJ_INT(81) );
  SET_ELM_PLIST( t_3, 3, t_4 );
  CHANGED_BAG( t_3 );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 1, 2 .. 2 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(1), INTOBJ_INT(2), INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 2, 2, 2 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -164,12 +194,22 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(2) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 2, 4 .. 6 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), INTOBJ_INT(6) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 2, 4, 7 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -180,17 +220,32 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(4) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(7) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 2, 4 .. 2 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), INTOBJ_INT(2) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 2, 4 .. 0 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(2), INTOBJ_INT(4), INTOBJ_INT(0) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* CALL_WITH_CATCH( range3, [ 4, 2, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
@@ -201,17 +256,32 @@ static Obj  HdlrFunc4 (
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(4) );
  SET_ELM_PLIST( t_3, 2, INTOBJ_INT(2) );
  SET_ELM_PLIST( t_3, 3, INTOBJ_INT(1) );
- CALL_2ARGS( t_1, t_2, t_3 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_2ARGS( t_1, t_2, t_3 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2, t_3 ) );
+ }
  
  /* Display( [ 4, 2 .. 0 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(4), INTOBJ_INT(2), INTOBJ_INT(0) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* Display( [ 4, 2 .. 8 ] ); */
  t_1 = GF_Display;
  t_2 = Range3Check( INTOBJ_INT(4), INTOBJ_INT(2), INTOBJ_INT(8) );
- CALL_1ARGS( t_1, t_2 );
+ if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
+  CALL_1ARGS( t_1, t_2 );
+ }
+ else {
+  DoOperation2Args( CallFuncListOper, t_1, NewPlistFromArgs( t_2 ) );
+ }
  
  /* return; */
  SWITCH_TO_OLD_FRAME(oldFrame);

--- a/tst/test-compile/ranges.g.static.c
+++ b/tst/test-compile/ranges.g.static.c
@@ -86,7 +86,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ 1, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -98,7 +98,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range2, [ - 2 ^ 80, 0 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range2;
- CHECK_BOUND( t_2, "range2" )
+ CHECK_BOUND( t_2, "range2" );
  t_3 = NEW_PLIST( T_PLIST, 2 );
  SET_LEN_PLIST( t_3, 2 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -111,7 +111,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 1, 2, 2 ^ 80 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(1) );
@@ -124,7 +124,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ - 2 ^ 80, 0, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  t_5 = POW( INTOBJ_INT(2), INTOBJ_INT(80) );
@@ -138,7 +138,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 0, 2 ^ 80, 2 ^ 81 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(0) );
@@ -158,7 +158,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 2, 2 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -174,7 +174,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 2, 4, 7 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(2) );
@@ -195,7 +195,7 @@ static Obj  HdlrFunc4 (
  /* CALL_WITH_CATCH( range3, [ 4, 2, 1 ] ); */
  t_1 = GF_CALL__WITH__CATCH;
  t_2 = GC_range3;
- CHECK_BOUND( t_2, "range3" )
+ CHECK_BOUND( t_2, "range3" );
  t_3 = NEW_PLIST( T_PLIST, 3 );
  SET_LEN_PLIST( t_3, 3 );
  SET_ELM_PLIST( t_3, 1, INTOBJ_INT(4) );


### PR DESCRIPTION
Previously, gac only supported functions calls using the `f()` syntax for internal functions, i.e., objects of type `T_FUNCTION`. But GAP allows custom functions, meaning that one can install methods that allow "calling" almost arbitrary objects.

This commit adds this functionality to gac, too, so that it matches the interpreter and executor.

This PR contains PR #3419.