### PR TITLE
Collection of minor updates

### DIFF
--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -340,8 +340,6 @@ local G,pool,p,comb,i,c,perm,l,isi,N,discard,ab;
     p:=c; # use only minimal ones if there is lots
   fi;
 
-  #if Length(p)>20 then Error("hier!");fi;
-
   # do the abelians extra.
   p:=Filtered(p,x->not HasAbelianFactorGroup(G,pool.ker[x]));
   
@@ -1171,7 +1169,7 @@ InstallMethod(FindActionKernel,"perm",IsIdenticalObj,
   [IsPermGroup,IsPermGroup],0,
 function(G,N)
 local pool, dom, bestdeg, blocksdone, o, s, badnormals, cnt, v, u, oo, m,
-      badcomb, idx, i, comb;
+      badcomb, idx, i, comb,act,k;
 
   if Index(G,N)<50 then
     # small index, anything is OK
@@ -1198,7 +1196,26 @@ local pool, dom, bestdeg, blocksdone, o, s, badnormals, cnt, v, u, oo, m,
 	List(s,i->NaturalHomomorphismByNormalSubgroup(G,i));
       fi;
     fi;
+
     CloseNaturalHomomorphismsPool(G,N);
+
+    # action in orbit image -- sometimes helps
+    if Length(o)>1 then
+      for i in o do
+
+        act:=ActionHomomorphism(G,i,OnPoints,"surjective");
+        k:=KernelOfMultiplicativeGeneralMapping(act);
+        k:=ClosureGroup(k,N); # pre-image of (image of normal subgroup under act)
+        u:=Image(act,N);
+        v:=NaturalHomomorphismByNormalSubgroupNC(Image(act),u);
+
+        o:=DegreeNaturalHomomorphismsPool(Image(act),u);
+        if IsInt(o) then # otherwise its solvable factor we do differently
+          AddNaturalHomomorphismsPool(G,k,act*v,o);
+        fi;
+      od;
+      CloseNaturalHomomorphismsPool(G,N);
+    fi;
 
     bestdeg:=DegreeNaturalHomomorphismsPool(G,N);
 

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -14,7 +14,7 @@
 ##
 
 InstallGlobalFunction(FittingFreeSubgroupSetup,function(G,U)
-local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r;
+local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r,pool,i,xx,inv,pregens;
   ffs:=FittingFreeLiftSetup(G);
 
   # result cached?
@@ -57,13 +57,24 @@ local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r;
     k:=ffs.pcgs;
   else
 
-    it:=CoKernelGensIterator(RestrictedInverseGeneralMapping(rest));
+    inv:=RestrictedInverseGeneralMapping(rest);
+    pregens:=List(SmallGeneratingSet(Image(rest)),
+      x->ImagesRepresentative(inv,x));
+    it:=CoKernelGensIterator(inv);
     kpc:=TrivialSubgroup(Image(pcisom));
     while not IsDoneIterator(it) do
-      x:=ImagesRepresentative(pcisom,NextIterator(it));
-      if not x in kpc then
-	kpc:=ClosureGroup(kpc,x);
-      fi;
+      x:=NextIterator(it);
+      pool:=[x];
+      for x in pool do
+        xx:=ImagesRepresentative(pcisom,x);
+        if not xx in kpc then
+          kpc:=ClosureGroup(kpc,xx);
+          for i in pregens do
+            Add(pool,x^i);
+          od;
+        fi;
+      od;
+      #Print("|pool|=",Length(pool),"\n");
     od;
     SetSize(U,Size(Image(rest))*Size(kpc));
     k:=InducedPcgs(FamilyPcgs(Image(pcisom)),kpc);

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2404,7 +2404,9 @@ local G,obj,close;
     fi;
 
     if close and not IsIdenticalObj( Parent( G ), obj ) then
-      Assert(2,IsSubset(Parent(G),obj));
+      if ValueOption("noassert")<>true then
+        Assert(2,IsSubset(Parent(G),obj));
+      fi;
       SetParent( obj, Parent( G ) );
     fi;
     return obj;

--- a/lib/grppclat.gi
+++ b/lib/grppclat.gi
@@ -251,11 +251,11 @@ end);
 ##  compute the permutation action of <P> on the subspaces of the
 ##  elementary abelian subgroup <G> of <P>. Returns
 ##  a list [<subspaces>,<action>], where <subspaces> is a list of all the
-##  subspaces and <action> a homomorphism from <P> in a permutation group,
-##  which is equal to the action homomrophism for the action of <P> on
-##  <subspaces>. If <dims> is given, only subspaces of dimension <dims> are
-##  considered.
-##  Instead of <G> also a (modulo) pcgs may be given.
+##  subspaces (as groups) and <action> a homomorphism from <P> in a 
+##  permutation group, which is equal to the action homomrophism for the
+##  action of <P> on <subspaces>. If <dims> is given, only subspaces of
+##  dimension <dims> are considered.  Instead of <G> also a (modulo) pcgs
+##  may be given, in this case <subspaces> are pre-images of the subspaces.
 ##
 InstallGlobalFunction(ActionSubspacesElementaryAbelianGroup,function(arg)
 local P,g,op,act,a,pcgs,ma,mat,d,f,i,j,new,newmat,id,p,dodim,compldim,compl,
@@ -453,7 +453,7 @@ local P,g,op,act,a,pcgs,ma,mat,d,f,i,j,new,newmat,id,p,dodim,compldim,compl,
     if kersz=1 then
       a:=SubgroupNC(par,List(i,j->pcelm(j)));
     else
-      #a:=ClosureGroup(ker,List(i,j->pcelm(j)):knownClosureSize:=asz);
+      #a:=ClosureSubgroup(ker,List(i,j->pcelm(j)):knownClosureSize:=asz);
       a:=SubgroupNC(par,Concatenation(GeneratorsOfGroup(ker),
         List(i,j->pcelm(j))));
     fi;


### PR DESCRIPTION
Add a "noassert" option to address #3418.

Improved factor group permutation representation is particular case

`FittingFreeSubgroupSetup` forms proper kernel generators. (Observed error occurrence in code requiring `matgrp` package)

Fixed comment decription of utility function