### PR TITLE
Fix stack scanning for the Julia GC when GAP is used as a library.

### DIFF
--- a/src/gap.h
+++ b/src/gap.h
@@ -129,6 +129,12 @@ enum {
 
 /****************************************************************************
 **
+*F  IsUsingLibGap()  . . . . . . . . 1 if GAP is being used a library, else 0
+*/
+int IsUsingLibGap(void);
+
+/****************************************************************************
+**
 *F  InitializeGap( <argc>, <argv>, <handleSignals> )  . . . . . . .  init GAP
 */
 void InitializeGap(int * pargc, char * argv[], UInt handleSignals);

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -31,6 +31,13 @@
 #include "streams.h"
 #include "stringobj.h"
 
+static int UsingLibGap = 0;
+
+int IsUsingLibGap(void)
+{
+    return UsingLibGap;
+}
+
 
 //
 // Setup and initialisation
@@ -41,6 +48,8 @@ void GAP_Initialize(int              argc,
                     GAP_CallbackFunc errorCallback,
                     int              handleSignals)
 {
+    UsingLibGap = 1;
+
     InitializeGap(&argc, argv, handleSignals);
     SetExtraMarkFuncBags(markBagsCallback);
     STATE(JumpToCatchCallback) = errorCallback;


### PR DESCRIPTION
# Fix stack scanning for the Julia GC when GAP is used as a library.

When GAP is being initialized from `GAP.jl`, we cannot use `GapStackBottom` to figure out the start of the stack, but have to query Julia for it. Conversely, when GAP is the main program, we cannot rely on Julia knowing the start and end of the stack of the main thread.

This pull request introduces a flag, called `UsingLibGap`, which allows us to distinguish between the two cases and then calculates the stack extent accordingly.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [x] sensible comments in the code

