### PR TITLE
kernel: replace ImmutableEmptyPlist by a function

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -1205,7 +1205,7 @@ static Obj FuncCALL_FUNC_LIST_WRAP(Obj self, Obj func, Obj list)
 
     if (retval == 0)
     {
-        retlist = ImmutableEmptyPlist;
+        retlist = NewImmutableEmptyPlist();
     }
     else
     {

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -446,7 +446,7 @@ static Obj FuncZERO_ATTR_MAT(Obj self, Obj mat)
   Obj res;
   len = LEN_LIST(mat);
   if (len == 0)
-    return ImmutableEmptyPlist;
+    return NewImmutableEmptyPlist();
   zrow = ZERO(ELM_LIST(mat,1));
   CheckedMakeImmutable(zrow);
   res = NEW_PLIST_IMM(T_PLIST_TAB_RECT, len);

--- a/src/plist.c
+++ b/src/plist.c
@@ -61,14 +61,6 @@
 
 /****************************************************************************
 **
-*V  ImmutableEmptyPlist . . . . . . . . . . . . an immutable empty plain list
-**
-**  'ImmutableEmptyPlist' is an immutable empty plist.
-*/
-Obj ImmutableEmptyPlist;
-
-/****************************************************************************
-**
 *F  GROW_PLIST(<list>,<plen>) . . . .  make sure a plain list is large enough
 **
 */
@@ -3307,9 +3299,6 @@ static Int InitKernel (
     /* GASMAN marking functions and GASMAN names                           */
     InitBagNamesFromTable( BagNames );
 
-    InitGlobalBag(&ImmutableEmptyPlist, "src/plist.c:ImmutableEmptyPlist");
-
-
     for ( t1 = T_PLIST;  t1 < T_PLIST_FFE ;  t1 += 2 ) {
         InitMarkFuncBags( t1                     , MarkAllButFirstSubBags );
         InitMarkFuncBags( t1 +IMMUTABLE          , MarkAllButFirstSubBags );
@@ -3720,8 +3709,6 @@ static Int InitLibrary (
     /* init filters and functions                                          */
     InitGVarFiltsFromTable( GVarFilts );
     InitGVarFuncsFromTable( GVarFuncs );
-
-    ImmutableEmptyPlist = NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
 
     /* return success                                                      */
     return 0;

--- a/src/plist.h
+++ b/src/plist.h
@@ -289,18 +289,23 @@ EXPORT_INLINE Obj PopPlist(Obj list)
 
 /****************************************************************************
 **
-*F  NewEmptyPlist() . . . . . . . . . . . . . . create a new empty plain list
-*V  ImmutableEmptyPlist . . . . . . . . . . . . an immutable empty plain list
-**
-**  ImmutableEmptyPlist is a variable rather than a function, as we can
-**  reuse the same immutable empty plist.
+*F  NewEmptyPlist() . . . . . . . . . .  create a new mutable empty plain list
 */
 EXPORT_INLINE Obj NewEmptyPlist(void)
 {
     return NEW_PLIST(T_PLIST_EMPTY, 0);
 }
 
-extern Obj ImmutableEmptyPlist;
+
+/****************************************************************************
+**
+*F  NewImmutableEmptyPlist() . . . . . create a new immutable empty plain list
+*/
+EXPORT_INLINE Obj NewImmutableEmptyPlist(void)
+{
+    return NEW_PLIST_IMM(T_PLIST_EMPTY, 0);
+}
+
 
 /****************************************************************************
 **

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -278,7 +278,7 @@ static UInt INIT_PPERM(Obj f)
     deg = DEG_PPERM<T>(f);
 
     if (deg == 0) {
-        dom = ImmutableEmptyPlist;
+        dom = NewImmutableEmptyPlist();
         SET_DOM_PPERM(f, dom);
         SET_IMG_PPERM(f, dom);
         CHANGED_BAG(f);
@@ -549,7 +549,7 @@ static Obj FuncIMAGE_PPERM(Obj self, Obj f)
 
     UInt rank = RANK_PPERM(f);
     if (rank == 0) {
-        return ImmutableEmptyPlist;
+        return NewImmutableEmptyPlist();
     }
 
     Obj dom = DOM_PPERM(f);

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -258,7 +258,7 @@ static UInt INIT_TRANS2(Obj f)
 
     if (deg == 0) {
         // special case for degree 0
-        img = ImmutableEmptyPlist;
+        img = NewImmutableEmptyPlist();
         SET_IMG_TRANS(f, img);
         SET_KER_TRANS(f, img);
         CHANGED_BAG(f);
@@ -310,7 +310,7 @@ static UInt INIT_TRANS4(Obj f)
         // T_TRANS4 and that does not have (internal) degree 65537 or greater
         // is ID_TRANS4.
 
-        img = ImmutableEmptyPlist;
+        img = NewImmutableEmptyPlist();
         SET_IMG_TRANS(f, img);
         SET_KER_TRANS(f, img);
         CHANGED_BAG(f);
@@ -1167,7 +1167,7 @@ static Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
         return FuncIMAGE_SET_TRANS(self, f);
     }
     else if (m == 0) {
-        return ImmutableEmptyPlist;
+        return NewImmutableEmptyPlist();
     }
     else if (m < deg) {
         newObj = NEW_PLIST_IMM(T_PLIST_CYC, m);
@@ -1237,7 +1237,7 @@ static Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
     m = INT_INTOBJ(n);
 
     if (m == 0) {
-        out = ImmutableEmptyPlist;
+        out = NewImmutableEmptyPlist();
         return out;
     }
 
@@ -1680,7 +1680,7 @@ static Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
     }
 
     if (len == 0) {
-        out = ImmutableEmptyPlist;
+        out = NewImmutableEmptyPlist();
         return out;
     }
     out = NEW_PLIST_IMM(T_PLIST_CYC, len);


### PR DESCRIPTION
We need a function NewImmutableEmptyPlist() for creating immutable
plists for now, as unfortunately reusing the same immutable plist
is not safe, as various functions might changes its representation
to something else (in particular: to a string rep), which then
could lead to crashes or worse.

Resolves issue #3421.

No release notes needed, as this variable was never in a released GAP version.