### PR TITLE
Workaround for GMP crash on Cygwin (regression introduced by PR #3434)

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -553,6 +553,18 @@ EXPORT_INLINE UInt ResizeWordSizedBag(Bag bag, UInt size)
 }
 
 
+#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT)
+EXPORT_INLINE void ENSURE_BAG(Bag bag)
+{
+    memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
+}
+#else
+EXPORT_INLINE void ENSURE_BAG(Bag bag)
+{
+}
+#endif
+
+
 /****************************************************************************
 **
 *F  CollectBags(<size>,<full>)  . . . . . . . . . . . . . . collect dead bags

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -553,18 +553,6 @@ EXPORT_INLINE UInt ResizeWordSizedBag(Bag bag, UInt size)
 }
 
 
-#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT)
-EXPORT_INLINE void ENSURE_BAG(Bag bag)
-{
-    memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
-}
-#else
-EXPORT_INLINE void ENSURE_BAG(Bag bag)
-{
-}
-#endif
-
-
 /****************************************************************************
 **
 *F  CollectBags(<size>,<full>)  . . . . . . . . . . . . . . collect dead bags

--- a/src/integer.c
+++ b/src/integer.c
@@ -161,7 +161,8 @@ GAP_STATIC_ASSERT( sizeof(mp_limb_t) == sizeof(UInt), "gmp limb size incompatibl
 */
 static inline void ENSURE_BAG(Bag bag)
 {
-#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT)
+// Note: This workaround is only required with the original GMP and not with MPIR
+#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT) && !defined(__MPIR_VERSION)
     memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
 #endif
 }

--- a/src/integer.c
+++ b/src/integer.c
@@ -142,6 +142,23 @@ static Obj ObjInt_UIntInv( UInt i );
 GAP_STATIC_ASSERT( sizeof(mp_limb_t) == sizeof(UInt), "gmp limb size incompatible with GAP word size");
 
 
+/* This ensures that all memory underlying a bag is actually committed
+** to physical memory and can be written to.
+** This is a workaround to a bug specific to Cygwin 64-bit and bad
+** interaction with GMP, so this is only needed specifically for new
+** bags created in this module to hold the outputs of GMP routines.
+**
+** Thus, any time NewBag is called, it is also necessary to call
+** ENSURE_BAG(bag) on the newly created bag if some GMP function will be
+** the first place that bag's data is written to.
+**
+** To give a counter-example, ENSURE_BAG is *not* needed in ObjInt_Int,
+** because it just creates a bag to hold a single mp_limb_t, and
+** immediately assigns it a value.
+**
+** The bug this works around is explained more in
+** https://github.com/gap-system/gap/issues/3434
+*/
 static inline void ENSURE_BAG(Bag bag)
 {
 #if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT)

--- a/src/integer.c
+++ b/src/integer.c
@@ -141,7 +141,15 @@ static Obj ObjInt_UIntInv( UInt i );
 
 GAP_STATIC_ASSERT( sizeof(mp_limb_t) == sizeof(UInt), "gmp limb size incompatible with GAP word size");
 
-    
+
+static inline void ENSURE_BAG(Bag bag)
+{
+#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT)
+    memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
+#endif
+}
+
+
 /* for fallbacks to library */
 static Obj String;
 static Obj OneAttr;

--- a/src/integer.c
+++ b/src/integer.c
@@ -274,6 +274,7 @@ static void NEW_FAKEMPZ( fake_mpz_t fake, UInt size )
   }
   else {
     fake->obj = NewBag( T_INTPOS, size * sizeof(mp_limb_t) );
+    ENSURE_BAG(fake->obj);
   }
 }
 
@@ -1789,9 +1790,11 @@ Obj ModInt(Obj opL, Obj opR)
     }
     
     mod = NewBag( TNUM_OBJ(opL), (SIZE_INT(opL)+1)*sizeof(mp_limb_t) );
+    ENSURE_BAG(mod);
 
     quo = NewBag( T_INTPOS,
                    (SIZE_INT(opL)-SIZE_INT(opR)+1)*sizeof(mp_limb_t) );
+    ENSURE_BAG(quo);
 
     /* and let gmp do the work                                             */
     mpn_tdiv_qr( (mp_ptr)ADDR_INT(quo), (mp_ptr)ADDR_INT(mod), 0,
@@ -1888,6 +1891,8 @@ Obj QuoInt(Obj opL, Obj opR)
       quo = NewBag( T_INTPOS, SIZE_OBJ(opL) );
     else
       quo = NewBag( T_INTNEG, SIZE_OBJ(opL) );
+
+    ENSURE_BAG(quo);
     
     if ( k < 0 ) k = -k;
 
@@ -1906,6 +1911,7 @@ Obj QuoInt(Obj opL, Obj opR)
     
     /* create a new bag for the remainder                                  */
     rem = NewBag( TNUM_OBJ(opL), (SIZE_INT(opL)+1)*sizeof(mp_limb_t) );
+    ENSURE_BAG(rem);
 
     /* allocate a bag for the quotient                                     */
     if ( TNUM_OBJ(opL) == TNUM_OBJ(opR) )
@@ -1914,6 +1920,7 @@ Obj QuoInt(Obj opL, Obj opR)
     else
       quo = NewBag( T_INTNEG,
                     (SIZE_INT(opL)-SIZE_INT(opR)+1)*sizeof(mp_limb_t) );
+    ENSURE_BAG(quo);
 
     mpn_tdiv_qr( (mp_ptr)ADDR_INT(quo), (mp_ptr)ADDR_INT(rem), 0,
                  (mp_srcptr)CONST_ADDR_INT(opL), SIZE_INT(opL),
@@ -2035,9 +2042,11 @@ Obj RemInt(Obj opL, Obj opR)
       return opL;
     
     rem = NewBag( TNUM_OBJ(opL), (SIZE_INT(opL)+1)*sizeof(mp_limb_t) );
+    ENSURE_BAG(rem);
     
     quo = NewBag( T_INTPOS,
                   (SIZE_INT(opL)-SIZE_INT(opR)+1)*sizeof(mp_limb_t) );
+    ENSURE_BAG(quo);
     
     /* and let gmp do the work                                             */
     mpn_tdiv_qr( (mp_ptr)ADDR_INT(quo),  (mp_ptr)ADDR_INT(rem), 0,

--- a/src/integer.c
+++ b/src/integer.c
@@ -161,8 +161,10 @@ GAP_STATIC_ASSERT( sizeof(mp_limb_t) == sizeof(UInt), "gmp limb size incompatibl
 */
 static inline void ENSURE_BAG(Bag bag)
 {
-// Note: This workaround is only required with the original GMP and not with MPIR
-#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT) && !defined(__MPIR_VERSION)
+// Note: This workaround is only required with the original GMP and not with
+// MPIR
+#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT) &&                    \
+    !defined(__MPIR_VERSION)
     memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
 #endif
 }


### PR DESCRIPTION
# Description

Adds `ENSURE_BAG` which on the relevant platform (Cygwin 64-bit, at least) simply zero-fills the contents of a bag before using it.

This is perhaps a naive attempt and I'm not sure it covers every possible case, but it does at least fix the test case from #3434 using `Bernoulli()`.

Needs proper documentation, but I'll add that if/when this approach is approved.

## Text for release notes 

Fixed crash on 64-bit Cygwin that could occur in some integer operations.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

