### PR TITLE
Add a RedispatchOnCondition to  SubdirectProductOp

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -522,6 +522,12 @@ end);
 ##
 #M  SubdirectProduct( <G1>, <G2>, <phi1>, <phi2> )
 ##
+
+RedispatchOnCondition(SubdirectProductOp, "check mappings", true, 
+        [IsGroup, IsGroup, IsGeneralMapping, IsGeneralMapping],
+        [IsObject, IsObject, IsGroupHomomorphism, IsGroupHomomorphism],
+        10);
+   
 InstallMethod( SubdirectProductOp,"groups", true,
   [ IsGroup, IsGroup, IsGroupHomomorphism, IsGroupHomomorphism ], 0,
 function( G, H, gh, hh )


### PR DESCRIPTION
# Description

`SubdirectProductOp` methods generally require `IsGroupHomomorphsm` of their third and fourth
arguments, but this includes filters which are Properties rather than Categories and  may not be known.

This PR Adds a `RedisptachOnCondition` to deal with this, and also adds some family predicates that should make code more robust, and a test. 

## Text for release notes 

Fix a bug with in calculating SubdirectProducts which could sometimes fail on valid input.

## Further details

Bug was reported by Harry Braden.


# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

