### PR TITLE
LibGAP API: Add `GAP_AssignGlobalVariable` and `GAP_CanAssignGlobalVariable`

### DIFF
--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -95,6 +95,17 @@ Obj GAP_ValueGlobalVariable(const char * name)
     }
 }
 
+int GAP_CanAssignGlobalVariable(const char * name)
+{
+    UInt gvar = GVarName(name);
+    return !(IsReadOnlyGVar(gvar) || IsConstantGVar(gvar));
+}
+
+void GAP_AssignGlobalVariable(const char * name, Obj value)
+{
+    UInt gvar = GVarName(name);
+    AssGVar(gvar, value);
+}
 
 ////
 //// arithmetic

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -163,7 +163,7 @@ void GAP_Initialize(int              argc,
 //// program evaluation and execution
 ////
 
-// Evaluate a string of GAP commands
+// Evaluate a string of GAP commands.
 //
 // To see an example of how to use this function see tst/testlibgap/basic.c
 //
@@ -175,10 +175,17 @@ Obj GAP_EvalString(const char * cmd);
 //// variables
 ////
 
-// Combines GVarName and ValGVar. For a given string, it returns the value
-// of the gvar with name <name>, or NULL if the global variable is not
-// defined.
+// Returns the value of the global GAP variable with name <name>, or NULL if
+// no global variable with this this name is defined.
 Obj GAP_ValueGlobalVariable(const char * name);
+
+// Checks if assigning to the global GAP variable <name> is possible, by
+// verifying that <name> is not the name of a read-only or constant variable.
+int GAP_CanAssignGlobalVariable(const char * name);
+
+// Assign <value> to the global GAP variable <name>. If <name> is the name of
+// a readonly or constant variable, an error is raised.
+void GAP_AssignGlobalVariable(const char * name, Obj value);
 
 
 ////
@@ -278,7 +285,7 @@ int GAP_IsLargeInt(Obj obj);
 // `integer.c`). The absolute value of <size> determines the number of limbs.
 // If <size> is zero, then `INTOBJ_INT(0)` is returned. Otherwise, the sign
 // of the returned integer object is determined by the sign of <size>.
-// //
+//
 // Note that GAP automatically reduces and normalized the integer object,
 // i.e., it will discard any leading zeros; and if the integer fits into a
 // small integer, it will be returned as such.

--- a/tst/testlibgap/api.c
+++ b/tst/testlibgap/api.c
@@ -138,6 +138,7 @@ void operations(void)
 void globalvars(void)
 {
     Obj a;
+    int x;
 
     a = GAP_ValueGlobalVariable("yaddayaddayadda");
     assert(a == 0);
@@ -145,6 +146,16 @@ void globalvars(void)
     // Hopefully this always exists.
     a = GAP_ValueGlobalVariable("GAPInfo");
     assert(GAP_IsRecord(a) != 0);
+
+    x = GAP_CanAssignGlobalVariable("GAPInfo");
+    assert(x == 0);
+
+    x = GAP_CanAssignGlobalVariable("GAPInfo_copy");
+    assert(x != 0);
+
+    GAP_AssignGlobalVariable("GAPInfo_copy", a);
+    a = GAP_ValueGlobalVariable("GAPInfo_copy");
+    assert(a != 0);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
# Description

Adds `GAP_AssignGlobalVariable` and `GAP_IsNameOfWritableGlobalVariable` to the libgap API, to assign a global variable to a value and check if a name belongs to a writable gvar.

## Text for release notes 

LibGAP API: `GAP_AssignGlobalVariable` and `GAP_IsNameOfWritableGlobalVariable` added

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

