### PR TITLE
line breaking hints in the `ViewString` method for lists

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -363,14 +363,21 @@ local   str,ls, i;
     fi;
   od;
 
-  str := "[ ";
+  # The line break hints are consistent with those
+  # that appear in the kernel function 'PrintListDefault'
+  # and in the 'ViewObj' method for finite lists.
+  str:= "\>\>[ \>\>";
   for i in [ 1 .. Length( list ) ]  do
-    Append(str,ls[i]);
-    if i<>Length(list)  then
-      Append(str,",\<\> ");
+    if ls[i] <> "" then
+      if 1 < i then
+        Append( str, "\<,\< \>\>" );
+      fi;
+      Append( str, ls[i] );
+    elif 1 < i then
+      Append( str, "\<,\<\>\>" );
     fi;
   od;
-  Append( str, " ]" );
+  Append( str, " \<\<\<\<]" );
   ConvertToStringRep( str );
   return str;
 end );
@@ -3787,6 +3794,10 @@ LIST_WITH_IDENTICAL_ENTRIES );
 ##  This is  a very naive  method which will view   the sub-objects. A better
 ##  method is needed eventually looking out for long list or homogeneous list
 ##  or dense list, etc.
+##
+##  The line break hints are consistent with those
+##  that appear in the kernel function 'PrintListDefault'
+##  and in the 'ViewString' method for finite lists.
 ##
 InstallMethod( ViewObj,
     "for finite lists",

--- a/src/lists.c
+++ b/src/lists.c
@@ -1742,7 +1742,9 @@ Obj             TYPES_LIST_FAM (
 *F  PrintListDefault(<list>)  . . . . . . . . . . . . . . . . .  print a list
 *F  PrintPathList(<list>,<indx>)  . . . . . . . . . . . . . print a list path
 **
-**  'PrintList' simply prints the list.
+**  'PrintListDefault' simply prints the elements in the given list.
+**  The line break hints are consistent with those
+**  that appear in the 'ViewObj' and 'ViewString' methods for finite lists.
 */
 static void PrintListDefault(Obj list)
 {

--- a/tst/testinstall/ctblfuns.tst
+++ b/tst/testinstall/ctblfuns.tst
@@ -6,9 +6,9 @@ gap> V4:= Group( (1,2)(3,4), (1,3)(2,4) );
 Group([ (1,2)(3,4), (1,3)(2,4) ])
 gap> irr:= Irr( V4 );
 [ Character( CharacterTable( Group([ (1,2)(3,4), (1,3)(2,4) ]) ),
-  [ 1, 1, 1, 1 ] ), Character( CharacterTable( Group([ (1,2)(3,4), (1,3)
-  (2,4) ]) ), [ 1, -1, -1, 1 ] ), Character( CharacterTable( Group([ (1,2)
-  (3,4), (1,3)(2,4) ]) ), [ 1, -1, 1, -1 ] ), 
+  [ 1, 1, 1, 1 ] ), Character( CharacterTable( Group([ (1,2)(3,4), (1,3)(2,4) 
+     ]) ), [ 1, -1, -1, 1 ] ), Character( CharacterTable( Group(
+    [ (1,2)(3,4), (1,3)(2,4) ]) ), [ 1, -1, 1, -1 ] ), 
   Character( CharacterTable( Group([ (1,2)(3,4), (1,3)(2,4) ]) ),
   [ 1, 1, -1, -1 ] ) ]
 gap> List( irr, x -> InertiaSubgroup( S4, x ) );

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -114,8 +114,8 @@ false
 gap> inv:= InverseGeneralMapping( map );
 InverseGeneralMapping( <general mapping: GF(3) -> GF(3) > )
 gap> AsList( UnderlyingRelation( inv ) );
-[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), DirectProductElement( [ 0*Z(3),
-    Z(3)^0 ] ) ]
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), 
+  DirectProductElement( [ 0*Z(3), Z(3)^0 ] ) ]
 gap> IsInjective( inv );
 true
 gap> IsSingleValued( inv );

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -114,7 +114,7 @@ gap> PrintString(x);
 gap> String(x);
 "[ ]"
 
-# List
+# Dense list
 gap> x:=[1,2,3];
 [ 1, 2, 3 ]
 gap> Display(x);
@@ -126,11 +126,29 @@ gap> PrintObj(x);Print("\n");
 gap> DisplayString(x);
 "<object>\n"
 gap> ViewString(x);
-"[ 1,\<\> 2,\<\> 3 ]"
+"\>\>[ \>\>1\<,\< \>\>2\<,\< \>\>3 \<\<\<\<]"
 gap> PrintString(x);
 "[ 1, 2, 3 ]"
 gap> String(x);
 "[ 1, 2, 3 ]"
+
+# Non-dense list
+gap> x:= [ 1,, 3 ];
+[ 1,, 3 ]
+gap> Display( x );
+[ 1,, 3 ]
+gap> ViewObj( x ); Print( "\n" );
+[ 1,, 3 ]
+gap> PrintObj( x ); Print( "\n" );
+[ 1,, 3 ]
+gap> DisplayString( x );
+"<object>\n"
+gap> ViewString( x );
+"\>\>[ \>\>1\<,\<\>\>\<,\< \>\>3 \<\<\<\<]"
+gap> PrintString( x );
+"[ 1, , 3 ]"
+gap> String( x );
+"[ 1, , 3 ]"
 
 # Character
 gap> x:='a';

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -31,8 +31,8 @@ gap> mat:=
 >      (1,6)(2,5)(3,4), 0, 0, 0, 0, 0 ] ];;
 gap> R:=ReesZeroMatrixSemigroup(Group([ (1,2)(3,5)(4,6), (1,3)(2,4)(5,6) ]), 
 > mat);
-<Rees 0-matrix semigroup 25x10 over Group([ (1,2)(3,5)(4,6), (1,3)(2,4)
-(5,6) ])>
+<Rees 0-matrix semigroup 25x10 over Group([ (1,2)(3,5)(4,6), (1,3)(2,4)(5,6) 
+  ])>
 gap> Size(R);
 1501
 gap> ForAll(R, x-> x in R);
@@ -294,8 +294,8 @@ Group([ (1,2,3) ])
 gap> HasIsSimpleSemigroup(g);
 true
 gap> R;
-<Rees 0-matrix semigroup 25x10 over Group([ (1,2)(3,5)(4,6), (1,3)(2,4)
-(5,6) ])>
+<Rees 0-matrix semigroup 25x10 over Group([ (1,2)(3,5)(4,6), (1,3)(2,4)(5,6) 
+  ])>
 gap> mat:=[[0,0,0], [(1,2), 0, (3,4)]];
 [ [ 0, 0, 0 ], [ (1,2), 0, (3,4) ] ]
 gap> R:=ReesZeroMatrixSemigroup(SymmetricGroup(4), mat);                    
@@ -383,8 +383,8 @@ gap> mat:=
 >       (1,3,5,7)(2,4,6,8), (1,4,7,2,5,8,3,6), (1,3,5,7)(2,4,6,8), 
 >       (1,8,7,6,5,4,3,2), (1,4,7,2,5,8,3,6), (1,2,3,4,5,6,7,8) ] ];;
 gap> R:=ReesMatrixSemigroup(DihedralGroup(IsPermGroup, 16), mat); 
-<Rees matrix semigroup 9x11 over Group([ (1,2,3,4,5,6,7,8), (2,8)(3,7)
-(4,6) ])>
+<Rees matrix semigroup 9x11 over Group([ (1,2,3,4,5,6,7,8), (2,8)(3,7)(4,6) 
+  ])>
 gap> Size(R);
 1584
 gap> Representative(R);


### PR DESCRIPTION
# Description

Up to now, `ViewObj` and `ViewString` behaved differently for lists,
due to the prescribed line breaking hints `\<` and `\>`.
This was a reason why new `ViewString` methods for complicated GAP objects
were likely to produce output that looked different from `ViewObj` output.

With the proposed change, the line breaking hints in the `ViewObj` and `ViewString` methods
for finite lists are made consistent with those that appear in the kernel function `PrintListDefault`.

Only a few test examples are affected by this change, they have been adjusted.

(I think that after this change, it will make sense to add more `ViewString` methods.)

An open problem is that `ViewString` cannot handle self-referential objects.
Note that the GAP kernel does some bookkeeping in the case of `ViewObj`;
an analogous mechanism would be possible also for `ViewString`.

## Text for release notes

Fixed the line breaking hints in the `ViewString` method for finite lists.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

