### PR TITLE
Remove '-a', other small input cleanups

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -457,8 +457,8 @@ to do something which required more memory than you have (as listing all
 elements of S_15 for example). You can use the command line option `-g` (see
 Section "Command Line Options" of the GAP Reference manual) to display how
 much memory GAP uses. If this is below what your machine has available
-extending the workspace is impossible. Start GAP with more memory or use
-the `-a` option to pre-allocate initially a large piece of workspace.
+extending the workspace is impossible. Start GAP with more memory using the
+`-o` option.
 
 ### GAP is not able to allocate memory above a certain limit
 

--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -80,26 +80,6 @@ which can be useful for debugging or testing.
 The needed packages (and their needed packages, and so on)
 are loaded in any case.
 </Item>
-<Mark><Index Key="-a"><C>-a</C></Index>
-<C>-a </C><A>memory</A></Mark>
-<Item>
-GASMAN, the storage manager of &GAP; uses <C>sbrk</C> to get blocks of memory
-from (certain) operating systems and it is required that subsequent calls
-to <C>sbrk</C> produce adjacent blocks of memory in this case  because  &GAP;
-only wants to deal with one large block of  memory.  If  the  C  function
-<C>malloc</C> is called for whatever reason, it is likely that 
-<C>sbrk</C> will  no
-longer produce adjacent blocks, therefore &GAP; does  not  use  <C>malloc</C>
-itself.
-<P/>
-However some operating systems insist on calling  <C>malloc</C>  to  create  a
-buffer when a file is opened, or for some other reason. In order to catch
-these cases &GAP; preallocates a block of memory with <C>malloc</C> which  is
-immediately freed. The amount preallocated can  be  controlled  with  the
-<C>-a</C> option. (Most users do not need this option.)
-<P/>
-The option argument <A>memory</A> is specified as with the <C>-m</C> option.
-</Item>
 <Mark><Index Key="-B"><C>-B</C></Index>
 <C>-B </C><A>architecture</A></Mark>
 <Item>

--- a/lib/system.g
+++ b/lib/system.g
@@ -75,7 +75,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "m", long := "minworkspace", default := "128m", arg := "<mem>",
            help := ["set the initial workspace size"] ),
       rec( short:= "o", long := "maxworkspace", default := "2g", arg := "<mem>",
-           help := [ "set hint for maximal workspace size (GAP may", "allocate more)"] ),
+           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)"] ),
       rec( short:= "K", long := "limitworkspace", default := "0", arg := "<mem>",
            help := [ "set maximal workspace size (GAP never", "allocates more)"] ),
       rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory" ] ),

--- a/lib/system.g
+++ b/lib/system.g
@@ -434,9 +434,9 @@ CallAndInstallPostRestore( function()
             PRINT_TO("*errout*", " -", opt.short);
             if(IsBound(opt.long)) then
               PRINT_TO("*errout*", ", --", opt.long);
-              padspace(4+LENGTH(opt.long), 16);
+              padspace(4+LENGTH(opt.long), 18);
             else
-              padspace(0, 16);
+              padspace(0, 18);
             fi;
             if(IsBound(opt.arg)) then
               PRINT_TO("*errout*", " ", opt.arg);
@@ -449,7 +449,7 @@ CallAndInstallPostRestore( function()
             # opt.short unbound, opt.long bound
 
             PRINT_TO("*errout*", "  --", opt.long);
-            padspace(4+LENGTH(opt.long), 16);
+            padspace(4+LENGTH(opt.long), 18);
             if(IsBound(opt.arg)) then
               PRINT_TO("*errout*", " ", opt.arg);
               padspace(LENGTH(opt.arg)+1, 8);
@@ -457,16 +457,16 @@ CallAndInstallPostRestore( function()
               padspace(0, 8);
             fi;
           fi;
-          if IsBound(opt.long) and LENGTH(opt.long) > 12 then
+          if IsBound(opt.long) and LENGTH(opt.long) > 14 then
             PRINT_TO("*errout*", "\n");
-            padspace(0, 3+16+8+3);
+            padspace(0, 3+18+8+3);
           else
             PRINT_TO("*errout*", "   ");
           fi;
 
           PRINT_TO("*errout*", opt.help[1], "\n");
           for j in [2..LENGTH(opt.help)] do
-            padspace(0, 3+16+8+3);
+            padspace(0, 3+18+8+3);
             PRINT_TO("*errout*", opt.help[j],"\n");
           od;
         else

--- a/lib/system.g
+++ b/lib/system.g
@@ -478,8 +478,8 @@ CallAndInstallPostRestore( function()
 
       PRINT_TO("*errout*",
        "\n",
-       "  Boolean options (b,q,e,r,A,D,E,M,N,T,X,Y) toggle the current value\n",
-       "  each time they are called. Default actions are indicated first.\n",
+       "  Boolean options toggle the current value each time they are called.\n",
+       "  Default actions are indicated first.\n",
        "\n" );
       QUIT_GAP();
     fi;

--- a/src/system.c
+++ b/src/system.c
@@ -990,8 +990,6 @@ static Int enableMemCheck(Char ** argv, void * dummy)
 #endif
 
 
-static Int preAllocAmount;
-
 /* These are just the options that need kernel processing. Additional options will be 
    recognised and handled in the library */
 
@@ -1006,7 +1004,6 @@ static struct optInfo options[] = {
   { 'L', "", storeString, &SyRestoring, 1}, /* must be handled in kernel  */
   { 'M', "", toggle, &SyUseModule, 0}, /* must be handled in kernel */
   { 'R', "", unsetString, &SyRestoring, 0}, /* kernel */
-  { 'a', "", storeMemory, &preAllocAmount, 1 }, /* kernel -- is this still useful */
   { 'e', "", toggle, &SyCTRD, 0 }, /* kernel */
   { 'f', "", forceLineEditing, (void *)2, 0 }, /* probably library now */
   { 'E', "", toggle, &SyUseReadline, 0 }, /* kernel */
@@ -1043,7 +1040,6 @@ void InitSystem (
     Char *              argv [],
     UInt                handleSignals )
 {
-    Char *              *ptrlist;
     UInt                i;             /* loop variable                   */
     Int res;                       /* return from option processing function */
 
@@ -1084,8 +1080,6 @@ void InitSystem (
         SyGasmanNumbers[i][j] = 0;
       }
     }
-
-    preAllocAmount = 4*1024*1024;
 
     InitSysFiles();
 
@@ -1197,27 +1191,6 @@ void InitSystem (
                  SyCTRD       = 1; */
         SyRedirectStderrToStdOut();
         syWinPut( 0, "@p", "1." );
-    }
-   
-
-    if (SyAllocPool == 0) {
-      /* premalloc stuff                                                     */
-      /* allocate in small chunks, and write something to them
-       * (the GNU clib uses mmap for large chunks and give it back to the
-       * system after free'ing; also it seems that memory is only really 
-       * allocated (pagewise) when it is first used)                     */
-      ptrlist = (Char **)malloc((1+preAllocAmount/1000)*sizeof(Char*));
-      for (i = 1; i*1000 < preAllocAmount; i++) {
-        ptrlist[i-1] = (Char *)malloc( 1000 );
-        if (ptrlist[i-1] != NULL) ptrlist[i-1][900] = 13;
-      }
-      for (i = 1; (i+1)*1000 < preAllocAmount; i++) 
-        if (ptrlist[i-1] != NULL) free(ptrlist[i-1]);
-      free(ptrlist);
-       
-     /* ptr = (Char *)malloc( preAllocAmount );
-      ptr1 = (Char *)malloc(4);
-      if ( ptr != 0 )  free( ptr ); */
     }
 
     /* should GAP load 'init/lib.g' on initialization */

--- a/src/system.c
+++ b/src/system.c
@@ -1024,7 +1024,7 @@ static struct optInfo options[] = {
   { 'P', "", storePosInteger, &SyNumProcessors, 1 }, /* Thread UI */
   { 'G', "", storePosInteger, &SyNumGCThreads, 1 }, /* Thread UI */
 #endif
-  /* The following three options must be handled in the kernel so they happen early enough */
+  /* The following options must be handled in the kernel so they are set up before loading the library */
   { 0  , "prof", enableProfilingAtStartup, 0, 1},    /* enable profiling at startup */
   { 0  , "memprof", enableMemoryProfilingAtStartup, 0, 1 }, /* enable memory profiling at startup */
   { 0  , "cover", enableCodeCoverageAtStartup, 0, 1}, /* enable code coverage at startup */


### PR DESCRIPTION
This performs some small cleanups to GAP's command line arguments. The main visible difference is removing `-a`, which didn't actually do anything useful on modern OSes (it allocated, then freed, a bunch of memory).

For release notes:

* Remove obsolete '-a' option