### PR TITLE
lib: add AsSSortedList method ...

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -646,6 +646,12 @@ InstallOtherMethod(AsSSortedList,
      [ IsList ],
      l -> AsSSortedListList( AsPlist( l ) ) );
 
+InstallMethod( AsSSortedList,
+    "for a strictly sorted list",
+    [ IsSSortedList ],
+    SUM_FLAGS,
+    Immutable );
+
 
 #############################################################################
 ##

--- a/tst/testinstall/coll.tst
+++ b/tst/testinstall/coll.tst
@@ -338,6 +338,8 @@ gap> res:=List([AsList,AsSortedList,AsSet], f -> f(Magma(1)));
 [ [ 1 ], [ 1 ], [ 1 ] ]
 gap> List(res,IsMutable);
 [ false, false, false ]
+gap> AsSet([1..5]);
+[ 1 .. 5 ]
 
 #############################################################################
 #

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -472,5 +472,26 @@ gap> PositionsBound( [ 1,, 2 ] );
 gap> HasIsSSortedList( PositionsBound( [ 1,, 2 ] ) );
 true
 
+# AsSet
+gap> l := ["a", "b", "c"];
+[ "a", "b", "c" ]
+gap> MakeImmutable(l);;
+gap> IsSet(l);
+true
+gap> IsIdenticalObj(AsSet(l), l);
+true
+gap> l := [true, false];
+[ true, false ]
+gap> MakeImmutable(l);;
+gap> IsSet(l);
+true
+gap> IsIdenticalObj(AsSet(l), l);
+true
+gap> l := [1..3];
+[ 1 .. 3 ]
+gap> MakeImmutable(l);;
+gap> IsIdenticalObj(AsSet(l), l);
+true
+
 #
 gap> STOP_TEST("list.tst");


### PR DESCRIPTION
... for collections that already are strictly sorted lists.

This ensures that `AsSet([1..n])` returns `[1..n]` instead of creating a
new plain list.
