### PR TITLE
Some GASMAN related refactoring; allow multiple before/after GC callbacks

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -43,8 +43,6 @@
 **
 *T  Bag . . . . . . . . . . . . . . . . . . . type of the identifier of a bag
 **
-**  'Bag'
-**
 **  Each bag is identified by its  *bag identifier*.  That  is each bag has a
 **  bag identifier and no  two live bags have the  same identifier.  'Bag' is
 **  the type of bag identifiers.
@@ -207,8 +205,6 @@ EXPORT_INLINE Int IS_BAG_REF(Obj bag)
 **
 *F  SIZE_BAG(<bag>) . . . . . . . . . . . . . . . . . . . . . . size of a bag
 **
-**  'SIZE_BAG( <bag> )'
-**
 **  'SIZE_BAG' returns  the  size of the bag   with the identifier  <bag> in
 **  bytes.
 **
@@ -254,8 +250,6 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr) {
 /****************************************************************************
 **
 *F  PTR_BAG(<bag>)  . . . . . . . . . . . . . . . . . . . .  pointer to a bag
-**
-**  'PTR_BAG( <bag> )'
 **
 **  'PTR_BAG' returns the address of the data area of the bag with identifier
 **  <bag>.  Using  this pointer the application  can then  read data from the
@@ -326,8 +320,6 @@ EXPORT_INLINE void SET_PTR_BAG(Bag bag, Bag *val)
 /****************************************************************************
 **
 *F  CHANGED_BAG(<bag>)  . . . . . . . .  notify Gasman that a bag has changed
-**
-**  'CHANGED_BAG( <bag> )'
 **
 **  'CHANGED_BAG'  informs {\Gasman} that the bag   with identifier <bag> has
 **  been changed by an assignment of another bag identifier.
@@ -410,8 +402,6 @@ EXPORT_INLINE void CHANGED_BAG(Bag bag)
 **
 *F  NewBag(<type>,<size>) . . . . . . . . . . . . . . . .  allocate a new bag
 **
-**  'NewBag( <type>, <size> )'
-**
 **  'NewBag' allocates a new bag  of type <type> and  <size> bytes.  'NewBag'
 **  returns the  identifier  of the new  bag,  which must be  passed as first
 **  argument to all other {\Gasman} functions.
@@ -466,8 +456,6 @@ EXPORT_INLINE Bag NewWordSizedBag(UInt type, UInt size)
 **
 *F  RetypeBag(<bag>,<new>)  . . . . . . . . . . . .  change the type of a bag
 **
-**  'RetypeBag( <bag>, <new> )'
-**
 **  'RetypeBag' changes the type of the bag with identifier <bag>  to the new
 **  type <new>.  The identifier, the size,  and also the  address of the data
 **  area of the bag do not change.
@@ -515,8 +503,6 @@ void RetypeBagSMIfWritable(Bag bag, UInt new_type);
 **
 *F  ResizeBag(<bag>,<new>)  . . . . . . . . . . . .  change the size of a bag
 **
-**  'ResizeBag( <bag>, <new> )'
-**
 **  'ResizeBag' changes the size of the bag with  identifier <bag> to the new
 **  size <new>.  The identifier  of the bag  does not change, but the address
 **  of the data area  of the bag  may change.  If  the new size <new> is less
@@ -560,8 +546,6 @@ EXPORT_INLINE UInt ResizeWordSizedBag(Bag bag, UInt size)
 **
 *F  CollectBags(<size>,<full>)  . . . . . . . . . . . . . . collect dead bags
 **
-**  'CollectBags( <size>, <full> )'
-**
 **  'CollectBags' performs a  garbage collection.  This means  it deallocates
 **  the dead   bags and  compacts the  live   bags at the  beginning   of the
 **  workspace.   If    <full>  is 0, then   only   the  dead young  bags  are
@@ -602,8 +586,6 @@ extern UInt8 SizeAllBags;
 **
 *V  InfoBags[<type>]  . . . . . . . . . . . . . . . . .  information for bags
 **
-**  'InfoBags[<type>]'
-**
 **  'InfoBags[<type>]'  is a structure containing information for bags of the
 **  type <type>.
 **
@@ -643,8 +625,6 @@ Bag  MakeBagReadOnly(Bag bag);
 /****************************************************************************
 **
 *F  InitMsgsFuncBags(<msgs-func>) . . . . . . . . .  install message function
-**
-**  'InitMsgsFuncBags( <msgs-func> )'
 **
 **  'InitMsgsFuncBags' installs the function <msgs-func> as function used  by
 **  {\Gasman} to print messages during garbage collections.  <msgs-func> must
@@ -775,8 +755,6 @@ void MarkFourSubBags(Bag bag);
 **
 *F  MarkAllSubBags(<bag>) . . . . . .  marking function that marks everything
 **
-**  'MarkAllSubBags( <bag> )'
-**
 **  'MarkAllSubBags'  is  the marking function  for  types whose bags contain
 **  only identifier of other bags.  It marks every entry of such a bag.  Note
 **  that 'MarkAllSubBags' assumes that  all  identifiers are at offsets  from
@@ -829,9 +807,7 @@ extern void MarkArrayOfBags(const Bag array[], UInt count);
 
 /****************************************************************************
 **
-*F  InitGlobalBag(<addr>) . . . . . inform Gasman about global bag identifier
-**
-**  'InitGlobalBag( <addr>, <cookie> )'
+*F  InitGlobalBag(<addr>,<cookie>)  inform Gasman about global bag identifier
 **
 **  'InitGlobalBag'  informs {\Gasman} that there is  a bag identifier at the
 **  address <addr>, which must be of  type '(Bag\*)'.  {\Gasman} will look at
@@ -859,8 +835,6 @@ void InitGlobalBag(Bag * addr, const Char * cookie);
 **
 *F  InitFreeFuncBag(<type>,<free-func>) . . . . . .  install freeing function
 **
-**  'InitFreeFuncBag( <type>, <free-func> )'
-**
 **  'InitFreeFuncBag' installs  the function <free-func>  as freeing function
 **  for bags of type <type>.
 **
@@ -885,8 +859,6 @@ void InitFreeFuncBag(UInt type, TNumFreeFuncBags free_func);
 /****************************************************************************
 **
 *F  InitCollectFuncBags(<bfr-func>,<aft-func>) . install collection functions
-**
-**  'InitCollectFuncBags( <before-func>, <after-func> )'
 **
 **  'InitCollectFuncBags' installs       the   functions  <before-func>   and
 **  <after-func> as collection functions.
@@ -916,9 +888,7 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func);
 
 /****************************************************************************
 **
-*F  InitBags(...) . . . . . . . . . . . . . . . . . . . . . initialize Gasman
-**
-**  InitBags( <initialSize>, <stackStart>, <stackAlign> )
+*F  InitBags(<initialSize>,<stackStart>,<stackAlign>) . . . initialize Gasman
 **
 **  'InitBags'  initializes {\Gasman}.  It  must be called from a application
 **  using {\Gasman} before any bags can be allocated.
@@ -942,11 +912,11 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func);
 */
 void InitBags(UInt initialSize, Bag * stackStart, UInt stackAlign);
 
+
 /****************************************************************************
 **
 *F  FinishBags() end GASMAN and free memory
 */
-
 void FinishBags(void);
 
 #if !defined(USE_GASMAN)

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -858,24 +858,28 @@ void InitFreeFuncBag(UInt type, TNumFreeFuncBags free_func);
 
 /****************************************************************************
 **
-*F  InitCollectFuncBags(<bfr-func>,<aft-func>) . install collection functions
+*F  RegisterBeforeCollectFuncBags(<func>)  install before-collection function
+*F  RegisterAfterCollectFuncBags(<func>) .  install after-collection function
 **
-**  'InitCollectFuncBags' installs       the   functions  <before-func>   and
-**  <after-func> as collection functions.
+**  Register a callback to be called before respectively after each garbage
+**  collection.
 **
-**  The  <before-func> will be  called   before each garbage collection,  the
-**  <after-func>  will be called after each  garbage  collection.  One use of
-**  the   <before-func> is to  call 'CHANGED_BAG'  for bags  that change very
-**  often, so you do not have to call 'CHANGED_BAG'  for them every time they
-**  change.  One use of the <after-func> is to update a pointer for a bag, so
-**  you do not have to update that pointer after every operation that might
-**  cause a garbage collection.
+**  One use of a <before-func> is to call 'CHANGED_BAG' for bags that change
+**  very often, so you do not have to call 'CHANGED_BAG' for them every time
+**  they change.
+**
+**  One use of after-collection callbacks is to update a pointer for a bag,
+**  so you do not have to update that pointer after every operation that
+**  might cause a garbage collection.
+**
+**  The number of callbacks which can be registered is limited. If the
+**  callback was successfully registered, 0 is returned, otherwise 1.
 */
 #ifdef USE_GASMAN
 typedef void            (* TNumCollectFuncBags) ( void );
 
-void InitCollectFuncBags(TNumCollectFuncBags before_func,
-                         TNumCollectFuncBags after_func);
+int RegisterBeforeCollectFuncBags(TNumCollectFuncBags func);
+int RegisterAfterCollectFuncBags(TNumCollectFuncBags func);
 #endif
 
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -907,10 +907,6 @@ void InitCollectFuncBags(TNumCollectFuncBags before_func,
 #endif
 
 
-#ifdef USE_GASMAN
-extern void SetStackBottomBags(void * StackBottom);
-#endif
-
 // ExtraMarkFuncBags, if not NULL, is called during garbage collection
 // This is used for integrating GAP (possibly linked as a shared library) with
 // other code bases which use their own form of garbage collection. For
@@ -955,11 +951,6 @@ void FinishBags(void);
 
 #if !defined(USE_GASMAN)
 void * AllocateMemoryBlock(UInt size);
-#endif
-
-
-#ifdef GAP_MEM_CHECK
-Int enableMemCheck(Char ** argv, void * dummy);
 #endif
 
 #endif // GAP_GASMAN_H

--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -21,18 +21,16 @@
 /****************************************************************************
 **
 *V  NrAllBags . . . . . . . . . . . . . . . . .  number of all bags allocated
-*V  SizeAllBags . . . . . . . . . . . . . .  total size of all bags allocated
-*V  NrLiveBags  . . . . . . . . . .  number of bags that survived the last gc
-*V  SizeLiveBags  . . . . . . .  total size of bags that survived the last gc
-*V  NrDeadBags  . . . . . . . number of bags that died since the last full gc
-*V  SizeDeadBags  . . . . total size of bags that died since the last full gc
-**
-**  'NrAllBags'
 **
 **  'NrAllBags' is the number of bags allocated since Gasman was initialized.
 **  It is incremented for each 'NewBag' call.
+*/
+extern  UInt                    NrAllBags;
+
+
+/****************************************************************************
 **
-**  'NrLiveBags'
+*V  NrLiveBags  . . . . . . . . . .  number of bags that survived the last gc
 **
 **  'NrLiveBags' is the number of bags that were  live after the last garbage
 **  collection.  So after a full  garbage collection it is simply  the number
@@ -43,8 +41,13 @@
 **  which is  the number of live   young  bags.   This  value  is used in the
 **  information messages,  and to find  out  how  many  free  identifiers are
 **  available.
+*/
+extern  UInt                    NrLiveBags;
+
+
+/****************************************************************************
 **
-**  'SizeLiveBags'
+*V  SizeLiveBags  . . . . . . .  total size of bags that survived the last gc
 **
 **  'SizeLiveBags' is  the total size of bags  that were  live after the last
 **  garbage collection.  So after a full garbage  collection it is simply the
@@ -54,16 +57,26 @@
 **  bags, and the total size of bags that have been found to be still live by
 **  this garbage  collection,  which is  the  total size of  live young bags.
 **  This value is used in the information messages.
+*/
+extern  UInt                    SizeLiveBags;
+
+
+/****************************************************************************
 **
-**  'NrDeadBags'
+*V  NrDeadBags  . . . . . . . number of bags that died since the last full gc
 **
 **  'NrDeadBags' is  the number of bags that died since the last full garbage
 **  collection.   So after a  full garbage  collection this is zero.  After a
 **  partial  garbage  collection it  is  the  sum  of the  previous value  of
 **  'NrDeadBags' and the  number of bags that  have been found to be dead  by
 **  this garbage collection.  This value is used in the information messages.
+*/
+extern  UInt                    NrDeadBags;
+
+
+/****************************************************************************
 **
-**  'SizeDeadBags'
+*V  SizeDeadBags  . . . . total size of bags that died since the last full gc
 **
 **  'SizeDeadBags' is  the total size  of bags that  died since the last full
 **  garbage collection.  So  after a full   garbage collection this  is zero.
@@ -71,20 +84,19 @@
 **  'SizeDeadBags' and the total size of bags that have been found to be dead
 **  by  this garbage  collection.   This  value  is used  in the  information
 **  message.
+*/
+extern  UInt8                   SizeDeadBags;
+
+
+/****************************************************************************
 **
-**  'NrHalfDeadBags'
+*V  NrDeadBags . . . . . . . . . . number of bags only reachable by weak ptrs
 **
 **  'NrHalfDeadBags'  is  the number of  bags  that  have  been  found to  be
 **  reachable only by way of weak pointers since the last garbage collection.
 **  The bodies of these bags are deleted, but their identifiers are marked so
 **  that weak pointer objects can recognize this situation.
 */
-
-extern  UInt                    NrAllBags;
-extern  UInt                    NrLiveBags;
-extern  UInt                    SizeLiveBags;
-extern  UInt                    NrDeadBags;
-extern  UInt8                   SizeDeadBags;
 extern  UInt                    NrHalfDeadBags;
 
 
@@ -114,6 +126,8 @@ Int IsWeakDeadBag(Bag bag);
 
 /****************************************************************************
 **
+**  Internal variables exported for the sake of the code in saveload.c
+**
 */
 extern  Bag *                   MptrBags;
 extern  Bag *                   MptrEndBags;
@@ -123,8 +137,6 @@ extern  Bag *                   AllocBags;
 /****************************************************************************
 **
 *F  InitSweepFuncBags(<type>,<sweep-func>)  . . . . install sweeping function
-**
-**  'InitSweepFuncBags( <type>, <sweep-func> )'
 **
 **  'InitSweepFuncBags' installs the function <sweep-func> as sweeping
 **  function for bags of type <type>.

--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -214,8 +214,23 @@ void CheckMasterPointers(void);
 void CallbackForAllBags(void (*func)(Bag));
 
 
+/****************************************************************************
+**
+*/
 #ifdef GAP_MEM_CHECK
+Int enableMemCheck(Char ** argv, void * dummy);
 extern Int EnableMemCheck;
 #endif
+
+
+/****************************************************************************
+**
+*F  SetStackBottomBags(<stackBottom>)
+**
+**  Helper for the libgap API.
+**
+*/
+void SetStackBottomBags(void * stackBottom);
+
 
 #endif

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -87,7 +87,7 @@ static Obj * PtrGVars[GVAR_BUCKETS];
 **  access global variables.
 **
 **  Since a   garbage  collection may move   this  bag around,    the pointer
-**  'PtrGVars' must be  revalculated afterwards.   This is done in function
+**  'PtrGVars' must be  recalculated afterwards.   This is done in function
 **  'GVarsAfterCollectBags' which is called by 'VarsAfterCollectBags'.
 */
 static Obj   ValGVars;

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1355,7 +1355,7 @@ static void RemoveCopyFopyInfo( void )
 /****************************************************************************
 **
 */
-void GVarsAfterCollectBags(void)
+static void GVarsAfterCollectBags(void)
 {
 #ifdef USE_GVAR_BUCKETS
   for (int i = 0; i < GVAR_BUCKETS; i++) {
@@ -1562,6 +1562,11 @@ static Int InitKernel (
                      "src/gvars.c:ErrorMustEvalToFuncHandler" );
     InitHandlerFunc( ErrorMustHaveAssObjHandler,
                      "src/gvars.c:ErrorMustHaveAssObjHandler" );
+
+#ifdef USE_GASMAN
+    // install post-GC callback
+    RegisterAfterCollectFuncBags(GVarsAfterCollectBags);
+#endif
 
     /* init filters and functions                                          */
     InitHdlrFuncsFromTable( GVarFuncs );

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -239,13 +239,6 @@ void UpdateCopyFopyInfo(void);
 
 /****************************************************************************
 **
-*F  GVarsAfterCollectBags()
-*/
-void GVarsAfterCollectBags(void);
-
-
-/****************************************************************************
-**
 *F  DeclareGVar(<gvar>, <name>) . . . . . .  declare global variable by name
 *F  GVarValue(<gvar>) . . . . . . . . . return value of <gvar>, 0 if unbound
 *F  GVarObj(<gvar>) . . . . . . . . return value of <gvar>, error if unbound

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -20,6 +20,9 @@
 #include "gap.h"
 #include "gapstate.h"
 #include "gasman.h"
+#ifdef USE_GASMAN
+#include "gasman_intern.h"
+#endif
 #include "gvars.h"
 #include "integer.h"
 #include "lists.h"

--- a/src/system.c
+++ b/src/system.c
@@ -17,7 +17,7 @@
 
 #include "gaputils.h"
 #ifdef GAP_MEM_CHECK
-#include "gasman.h"
+#include "gasman_intern.h"
 #endif
 #include "profile.h"
 #include "sysfiles.h"

--- a/src/vars.c
+++ b/src/vars.c
@@ -2061,7 +2061,6 @@ static void VarsAfterCollectBags(void)
       STATE(PtrLVars) = PTR_BAG( STATE(CurrLVars) );
       STATE(PtrBody)  = PTR_BAG( BODY_FUNC( CURR_FUNC() ) );
     }
-  GVarsAfterCollectBags();
 }
 
 #endif
@@ -2300,7 +2299,8 @@ static Int InitKernel (
 
 #ifdef USE_GASMAN
     /* install before and after actions for garbage collections            */
-    InitCollectFuncBags( VarsBeforeCollectBags, VarsAfterCollectBags );
+    RegisterBeforeCollectFuncBags(VarsBeforeCollectBags);
+    RegisterAfterCollectFuncBags(VarsAfterCollectBags);
 #endif
 
     /* init filters and functions                                          */


### PR DESCRIPTION
This is needed to get SingularInterface to work again. That package previously copied the old values of `BeforeCollectFuncBags` and `AfterCollectFuncBags` and then installed its own callbacks, which called the original ones. But then we made these two variables static, which broke that hack. So the easiest fix would have been to export them again. But it seems better to keep them static, and instead provide a slightly more generic API. As a bonus, we can actually make use of that ourselves in a minor way.

Also cleanup some other stuff (mostly comments) I noticed while looking at `gasman.h` to implement this.