### PR TITLE
Improve error handling for `Image`, `Images`, `PreImage`, `PreImages`

### DIFF
--- a/hpcgap/lib/mapping.gi
+++ b/hpcgap/lib/mapping.gi
@@ -158,8 +158,12 @@ InstallGlobalFunction( Image, function ( arg )
     local   map,        # mapping <map>, first argument
             elm;        # element <elm>, second argument
 
+    if Length(arg) > 0 and not IsGeneralMapping( arg[1] ) then
+      ErrorNoReturn( "<map> must be a general mapping" );
+    fi;
+
     # image of the source under <map>, which may be multi valued in this case
-    if   Length( arg ) = 1 and IsGeneralMapping(arg[1]) then
+    if Length( arg ) = 1 then
 
         return ImagesSource( arg[1] );
 
@@ -168,17 +172,21 @@ InstallGlobalFunction( Image, function ( arg )
       map := arg[1];
       elm := arg[2];
 
+      # image of a single element <elm> under the mapping <map>
       if     FamSourceEqFamElm( FamilyObj( map ), FamilyObj( elm ) ) then
-
         if not IsMapping( map ) then
-          Error( "<map> must be a mapping" );
-        elif elm in Source( map ) then
-          return ImageElm( map, elm );
+          ErrorNoReturn( "<map> must be single-valued and total" );
+        elif not elm in Source( map ) then
+          ErrorNoReturn( "<elm> must be an element of Source(<map>)" );
         fi;
+        return ImageElm( map, elm );
 
-      # image of a set or list of elments <elm> under the mapping <map>
-      elif     CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) )
-           and IsSubset( Source( map ), elm ) then
+      # image of a collection of elments <elm> under the mapping <map>
+      elif CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) ) then
+        if not IsSubset( Source( map ), elm ) then
+          ErrorNoReturn( "the collection <elm> must be contained in ",
+                         "Source(<map>)" );
+        fi;
 
         if IsDomain( elm ) or IsSSortedList( elm ) then
           if HasSource(map) and IsIdenticalObj(Source(map),elm) then
@@ -195,9 +203,15 @@ InstallGlobalFunction( Image, function ( arg )
 
         return [];
 
+      else
+        ErrorNoReturn( "the families of the element or collection <elm> ",
+                       "and Source(<map>) don't match, ",
+                       "maybe <elm> is not contained in Source(<map>) or ",
+                       "is not a homogeneous list or collection" );
       fi;
     fi;
-    Error( "usage: Image(<map>), Image(<map>,<elm>), Image(<map>,<coll>)" );
+    ErrorNoReturn( "usage: Image(<map>), Image(<map>,<elm>), ",
+                   "Image(<map>,<coll>)" );
 end );
 
 
@@ -212,6 +226,10 @@ InstallGlobalFunction( Images, function ( arg )
     local   map,        # mapping <map>, first argument
             elm;        # element <elm>, second argument
 
+    if Length(arg) > 0 and not IsGeneralMapping( arg[1] ) then
+      ErrorNoReturn( "<map> must be a general mapping" );
+    fi;
+
     # image of the source under <map>
     if Length( arg ) = 1  then
 
@@ -222,19 +240,19 @@ InstallGlobalFunction( Images, function ( arg )
         map := arg[1];
         elm := arg[2];
 
-        if not IsGeneralMapping( map ) then
-          Error( "<map> must be a general mapping" );
-        fi;
-
         # image of a single element <elm> under the mapping <map>
-        if     FamSourceEqFamElm( FamilyObj( map ), FamilyObj( elm ) )
-           and elm in Source( map ) then
-
+        if     FamSourceEqFamElm( FamilyObj( map ), FamilyObj( elm ) ) then
+          if not elm in Source( map ) then
+            ErrorNoReturn( "<elm> must be an element of Source(<map>)" );
+          fi;
           return ImagesElm( map, elm );
 
-        # image of a set or list of elments <elm> under the mapping <map>
-        elif     CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) )
-             and IsSubset( Source( map ), elm ) then
+        # image of a collection of elments <elm> under the mapping <map>
+        elif CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) ) then
+          if not IsSubset( Source( map ), elm ) then
+            ErrorNoReturn( "the collection <elm> must be contained in ",
+                           "Source(<map>)" );
+          fi;
 
           if IsDomain( elm ) or IsSSortedList( elm ) then
             return ImagesSet( map, elm );
@@ -247,9 +265,15 @@ InstallGlobalFunction( Images, function ( arg )
 
           return [];
 
+        else
+          ErrorNoReturn( "the families of the element or collection <elm> ",
+                         "and Source(<map>) don't match, ",
+                         "maybe <elm> is not contained in Source(<map>) or ",
+                         "is not a homogeneous list or collection" );
         fi;
     fi;
-    Error("usage: Images(<map>), Images(<map>,<elm>), Images(<map>,<coll>)");
+    ErrorNoReturn( "usage: Images(<map>), Images(<map>,<elm>), ",
+                   "Images(<map>,<coll>)" );
 end );
 
 
@@ -264,6 +288,10 @@ InstallGlobalFunction( PreImage, function ( arg )
     local   map,        # gen. mapping <map>, first argument
             img;        # element <img>, second argument
 
+    if Length( arg ) > 0 and not IsGeneralMapping( arg[1] ) then
+      ErrorNoReturn( "<map> must be a general mapping" );
+    fi;
+
     # preimage of the range under <map>, which may be a general mapping
     if Length( arg ) = 1  then
 
@@ -276,16 +304,20 @@ InstallGlobalFunction( PreImage, function ( arg )
 
         # preimage of a single element <img> under <map>
         if     FamRangeEqFamElm( FamilyObj( map ), FamilyObj( img ) ) then
-          if not (     IsGeneralMapping( map ) and IsInjective( map )
-                   and IsSurjective( map ) ) then
-            Error( "<map> must be an inj. and surj. mapping" );
-          elif img in Range( map ) then
-            return PreImageElm( map, img );
+          if not ( IsInjective( map ) and IsSurjective( map ) ) then
+            ErrorNoReturn( "<map> must be an injective and surjective ",
+                           "mapping" );
+          elif not img in Range( map ) then
+            ErrorNoReturn( "<elm> must be an element of Range(<map>)" );
           fi;
+          return PreImageElm( map, img );
 
-        # preimage of a set or list of elments <img> under <map>
-        elif     CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) )
-             and IsSubset( Range( map ), img ) then
+        # preimage of a collection of elments <img> under <map>
+        elif CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) ) then
+          if not IsSubset( Range( map ), img ) then
+            ErrorNoReturn( "the collection <elm> must be contained in ",
+                           "Range(<map>)" );
+          fi;
 
           if IsDomain( img ) or IsSSortedList( img ) then
             return PreImagesSet( map, img );
@@ -298,10 +330,15 @@ InstallGlobalFunction( PreImage, function ( arg )
 
           return [];
 
+        else
+          ErrorNoReturn( "the families of the element or collection <elm> ",
+                         "and Range(<map>) don't match, ",
+                         "maybe <elm> is not contained in Range(<map>) or ",
+                         "is not a homogeneous list or collection" );
         fi;
     fi;
-    Error( "usage: PreImage(<map>), PreImage(<map>,<img>), ",
-           "PreImage(<map>,<coll>)" );
+    ErrorNoReturn( "usage: PreImage(<map>), PreImage(<map>,<img>), ",
+                   "PreImage(<map>,<coll>)" );
 end );
 
 
@@ -327,18 +364,22 @@ InstallGlobalFunction( PreImages, function ( arg )
         img := arg[2];
 
         if not IsGeneralMapping( map ) then
-          Error( "<map> must be a general mapping" );
+          ErrorNoReturn( "<map> must be a general mapping" );
         fi;
 
         # preimage of a single element <img> under <map>
-        if     FamRangeEqFamElm( FamilyObj( map ), FamilyObj( img ) )
-           and img in Range( map ) then
-
+        if     FamRangeEqFamElm( FamilyObj( map ), FamilyObj( img ) ) then
+            if not img in Range( map ) then
+                ErrorNoReturn( "<elm> must be an element of Range(<map>)" );
+            fi;
             return PreImagesElm( map, img );
 
-        # preimage of a set or list of elements <img> under <map>
-        elif     CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) )
-             and IsSubset( Range( map ), img ) then
+        # preimage of a collection of elements <img> under <map>
+        elif CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) ) then
+          if not IsSubset( Range( map ), img ) then
+            ErrorNoReturn( "the collection <elm> must be contained in ",
+                           "Range(<map>)" );
+          fi;
 
           if IsDomain( img ) or IsSSortedList( img ) then
             return PreImagesSet( map, img );
@@ -351,10 +392,15 @@ InstallGlobalFunction( PreImages, function ( arg )
 
           return [];
 
+        else
+          ErrorNoReturn( "the families of the element or collection <elm> ",
+                         "and Range(<map>) don't match, ",
+                         "maybe <elm> is not contained in Range(<map>) or ",
+                         "is not a homogeneous list or collection" );
         fi;
     fi;
-    Error( "usage: PreImages(<map>), PreImages(<map>,<img>), ",
-           "PreImages(<map>,<coll>)" );
+    ErrorNoReturn( "usage: PreImages(<map>), PreImages(<map>,<img>), ",
+                   "PreImages(<map>,<coll>)" );
 end );
 
 

--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -155,8 +155,12 @@ InstallGlobalFunction( Image, function ( arg )
     local   map,        # mapping <map>, first argument
             elm;        # element <elm>, second argument
 
+    if Length(arg) > 0 and not IsGeneralMapping( arg[1] ) then
+      ErrorNoReturn( "<map> must be a general mapping" );
+    fi;
+
     # image of the source under <map>, which may be multi valued in this case
-    if   Length( arg ) = 1 and IsGeneralMapping(arg[1]) then
+    if Length( arg ) = 1 then
 
         return ImagesSource( arg[1] );
 
@@ -165,17 +169,21 @@ InstallGlobalFunction( Image, function ( arg )
       map := arg[1];
       elm := arg[2];
 
+      # image of a single element <elm> under the mapping <map>
       if     FamSourceEqFamElm( FamilyObj( map ), FamilyObj( elm ) ) then
-
         if not IsMapping( map ) then
-          Error( "<map> must be a mapping" );
-        elif elm in Source( map ) then
-          return ImageElm( map, elm );
+          ErrorNoReturn( "<map> must be single-valued and total" );
+        elif not elm in Source( map ) then
+          ErrorNoReturn( "<elm> must be an element of Source(<map>)" );
         fi;
+        return ImageElm( map, elm );
 
-      # image of a set or list of elments <elm> under the mapping <map>
-      elif     CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) )
-           and IsSubset( Source( map ), elm ) then
+      # image of a collection of elments <elm> under the mapping <map>
+      elif CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) ) then
+        if not IsSubset( Source( map ), elm ) then
+          ErrorNoReturn( "the collection <elm> must be contained in ",
+                         "Source(<map>)" );
+        fi;
 
         if IsDomain( elm ) or IsSSortedList( elm ) then
           if HasSource(map) and IsIdenticalObj(Source(map),elm) then
@@ -192,9 +200,15 @@ InstallGlobalFunction( Image, function ( arg )
 
         return [];
 
+      else
+        ErrorNoReturn( "the families of the element or collection <elm> ",
+                       "and Source(<map>) don't match, ",
+                       "maybe <elm> is not contained in Source(<map>) or ",
+                       "is not a homogeneous list or collection" );
       fi;
     fi;
-    Error( "usage: Image(<map>), Image(<map>,<elm>), Image(<map>,<coll>)" );
+    ErrorNoReturn( "usage: Image(<map>), Image(<map>,<elm>), ",
+                   "Image(<map>,<coll>)" );
 end );
 
 
@@ -209,6 +223,10 @@ InstallGlobalFunction( Images, function ( arg )
     local   map,        # mapping <map>, first argument
             elm;        # element <elm>, second argument
 
+    if Length(arg) > 0 and not IsGeneralMapping( arg[1] ) then
+      ErrorNoReturn( "<map> must be a general mapping" );
+    fi;
+
     # image of the source under <map>
     if Length( arg ) = 1  then
 
@@ -219,19 +237,19 @@ InstallGlobalFunction( Images, function ( arg )
         map := arg[1];
         elm := arg[2];
 
-        if not IsGeneralMapping( map ) then
-          Error( "<map> must be a general mapping" );
-        fi;
-
         # image of a single element <elm> under the mapping <map>
-        if     FamSourceEqFamElm( FamilyObj( map ), FamilyObj( elm ) )
-           and elm in Source( map ) then
-
+        if     FamSourceEqFamElm( FamilyObj( map ), FamilyObj( elm ) ) then
+          if not elm in Source( map ) then
+            ErrorNoReturn( "<elm> must be an element of Source(<map>)" );
+          fi;
           return ImagesElm( map, elm );
 
-        # image of a set or list of elments <elm> under the mapping <map>
-        elif     CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) )
-             and IsSubset( Source( map ), elm ) then
+        # image of a collection of elments <elm> under the mapping <map>
+        elif CollFamSourceEqFamElms( FamilyObj( map ), FamilyObj(elm) ) then
+          if not IsSubset( Source( map ), elm ) then
+            ErrorNoReturn( "the collection <elm> must be contained in ",
+                           "Source(<map>)" );
+          fi;
 
           if IsDomain( elm ) or IsSSortedList( elm ) then
             return ImagesSet( map, elm );
@@ -244,9 +262,15 @@ InstallGlobalFunction( Images, function ( arg )
 
           return [];
 
+        else
+          ErrorNoReturn( "the families of the element or collection <elm> ",
+                         "and Source(<map>) don't match, ",
+                         "maybe <elm> is not contained in Source(<map>) or ",
+                         "is not a homogeneous list or collection" );
         fi;
     fi;
-    Error("usage: Images(<map>), Images(<map>,<elm>), Images(<map>,<coll>)");
+    ErrorNoReturn( "usage: Images(<map>), Images(<map>,<elm>), ",
+                   "Images(<map>,<coll>)" );
 end );
 
 
@@ -261,6 +285,10 @@ InstallGlobalFunction( PreImage, function ( arg )
     local   map,        # gen. mapping <map>, first argument
             img;        # element <img>, second argument
 
+    if Length( arg ) > 0 and not IsGeneralMapping( arg[1] ) then
+      ErrorNoReturn( "<map> must be a general mapping" );
+    fi;
+
     # preimage of the range under <map>, which may be a general mapping
     if Length( arg ) = 1  then
 
@@ -273,16 +301,20 @@ InstallGlobalFunction( PreImage, function ( arg )
 
         # preimage of a single element <img> under <map>
         if     FamRangeEqFamElm( FamilyObj( map ), FamilyObj( img ) ) then
-          if not (     IsGeneralMapping( map ) and IsInjective( map )
-                   and IsSurjective( map ) ) then
-            Error( "<map> must be an inj. and surj. mapping" );
-          elif img in Range( map ) then
-            return PreImageElm( map, img );
+          if not ( IsInjective( map ) and IsSurjective( map ) ) then
+            ErrorNoReturn( "<map> must be an injective and surjective ",
+                           "mapping" );
+          elif not img in Range( map ) then
+            ErrorNoReturn( "<elm> must be an element of Range(<map>)" );
           fi;
+          return PreImageElm( map, img );
 
-        # preimage of a set or list of elments <img> under <map>
-        elif     CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) )
-             and IsSubset( Range( map ), img ) then
+        # preimage of a collection of elments <img> under <map>
+        elif CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) ) then
+          if not IsSubset( Range( map ), img ) then
+            ErrorNoReturn( "the collection <elm> must be contained in ",
+                           "Range(<map>)" );
+          fi;
 
           if IsDomain( img ) or IsSSortedList( img ) then
             return PreImagesSet( map, img );
@@ -295,10 +327,15 @@ InstallGlobalFunction( PreImage, function ( arg )
 
           return [];
 
+        else
+          ErrorNoReturn( "the families of the element or collection <elm> ",
+                         "and Range(<map>) don't match, ",
+                         "maybe <elm> is not contained in Range(<map>) or ",
+                         "is not a homogeneous list or collection" );
         fi;
     fi;
-    Error( "usage: PreImage(<map>), PreImage(<map>,<img>), ",
-           "PreImage(<map>,<coll>)" );
+    ErrorNoReturn( "usage: PreImage(<map>), PreImage(<map>,<img>), ",
+                   "PreImage(<map>,<coll>)" );
 end );
 
 
@@ -324,18 +361,22 @@ InstallGlobalFunction( PreImages, function ( arg )
         img := arg[2];
 
         if not IsGeneralMapping( map ) then
-          Error( "<map> must be a general mapping" );
+          ErrorNoReturn( "<map> must be a general mapping" );
         fi;
 
         # preimage of a single element <img> under <map>
-        if     FamRangeEqFamElm( FamilyObj( map ), FamilyObj( img ) )
-           and img in Range( map ) then
-
+        if     FamRangeEqFamElm( FamilyObj( map ), FamilyObj( img ) ) then
+            if not img in Range( map ) then
+                ErrorNoReturn( "<elm> must be an element of Range(<map>)" );
+            fi;
             return PreImagesElm( map, img );
 
-        # preimage of a set or list of elements <img> under <map>
-        elif     CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) )
-             and IsSubset( Range( map ), img ) then
+        # preimage of a collection of elements <img> under <map>
+        elif CollFamRangeEqFamElms( FamilyObj( map ), FamilyObj( img ) ) then
+          if not IsSubset( Range( map ), img ) then
+            ErrorNoReturn( "the collection <elm> must be contained in ",
+                           "Range(<map>)" );
+          fi;
 
           if IsDomain( img ) or IsSSortedList( img ) then
             return PreImagesSet( map, img );
@@ -348,10 +389,15 @@ InstallGlobalFunction( PreImages, function ( arg )
 
           return [];
 
+        else
+          ErrorNoReturn( "the families of the element or collection <elm> ",
+                         "and Range(<map>) don't match, ",
+                         "maybe <elm> is not contained in Range(<map>) or ",
+                         "is not a homogeneous list or collection" );
         fi;
     fi;
-    Error( "usage: PreImages(<map>), PreImages(<map>,<img>), ",
-           "PreImages(<map>,<coll>)" );
+    ErrorNoReturn( "usage: PreImages(<map>), PreImages(<map>,<img>), ",
+                   "PreImages(<map>,<coll>)" );
 end );
 
 

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -1,6 +1,8 @@
-#@local A,B,C,M,anticomp,com,comp,conj,d,g,g2,i,i2,inv,j,map,map1,map2,nice
-#@local res,t,t1,t2,tuples
+#@local A,B,C,M,anticomp,com,comp,conj,d,g,g2,i,i2,inv,j,map,map1,map2
+#@local mapBijective,nice,res,t,t1,t2,tuples
 gap> START_TEST("mapping.tst");
+
+# Init
 gap> M:= GF(3);
 GF(3)
 gap> tuples:= List( Tuples( AsList( M ), 2 ), DirectProductElement );;
@@ -11,6 +13,9 @@ gap> Print(tuples,"\n");
     Z(3)^0 ] ), DirectProductElement( [ Z(3)^0, Z(3) ] ), 
   DirectProductElement( [ Z(3), 0*Z(3) ] ), DirectProductElement( [ Z(3),
     Z(3)^0 ] ), DirectProductElement( [ Z(3), Z(3) ] ) ]
+
+# General Mappings
+# Empty map
 gap> map:= GeneralMappingByElements( M, M, [] );
 <general mapping: GF(3) -> GF(3) >
 gap> IsInjective( map );
@@ -21,6 +26,9 @@ gap> IsSurjective( map );
 false
 gap> IsTotal( map );
 false
+
+# InverseGeneralMapping and CompositionMapping for
+# IsTotal but not IsSingleValued
 gap> map:= GeneralMappingByElements( M, M, tuples{ [ 1, 2, 4, 7 ] } );
 <general mapping: GF(3) -> GF(3) >
 gap> IsInjective( map );
@@ -79,6 +87,9 @@ gap> IsSurjective( anticomp );
 false
 gap> IsTotal( anticomp );
 false
+
+# InverseGeneralMapping and CompositionMapping for
+# General mappings of groups which actually are mappings
 gap> t1:= DirectProductElement( [ (), () ] );;  t2:= DirectProductElement( [ (1,2), (1,2) ] );;
 gap> g:= Group( (1,2) );;
 gap> t:= TrivialSubgroup( g );;
@@ -101,6 +112,9 @@ gap> IsSingleValued( com );
 true
 gap> IsInjective( com );
 true
+
+# =, <, and IdentityMapping for
+# IsSingleValued but not IsTotal
 gap> map:= GeneralMappingByElements( M, M, tuples{ [ 1, 4 ] } );
 <general mapping: GF(3) -> GF(3) >
 gap> IsInjective( map );
@@ -169,6 +183,32 @@ gap> One( map );
 IdentityMapping( GF(3) )
 gap> Z(3) / IdentityMapping( GF(3) );
 Z(3)
+
+# Image, Image(s)Elm, ImagesSet for neither IsSingleValued nor IsTotal
+gap> map:= GeneralMappingByElements( M, M, tuples{ [ 1, 4 ] } );
+<general mapping: GF(3) -> GF(3) >
+gap> IsInjective( map );
+false
+gap> IsSingleValued( map );
+true
+gap> IsSurjective( map );
+false
+gap> IsTotal( map );
+false
+gap> Image( map, [ Z(3) ] );
+[  ]
+gap> ImagesElm( map, Z(3) );
+[  ]
+gap> ImagesSet( map, [ 0*Z(3), Z(3) ] );
+[ 0*Z(3) ]
+gap> ImagesSet( map, GF(3) );
+[ 0*Z(3) ]
+gap> ImagesRepresentative( map, 0*Z(3) );
+0*Z(3)
+gap> ImagesRepresentative( map, Z(3) );
+fail
+
+# Image(s)Elm, ImagesSet for IsMapping
 gap> map:= GeneralMappingByElements( M, M, tuples{ [ 1, 4, 8 ] } );
 <general mapping: GF(3) -> GF(3) >
 gap> IsInjective( map );
@@ -191,6 +231,9 @@ gap> ImagesRepresentative( map, Z(3) );
 Z(3)^0
 gap> (0*Z(3)) ^ map;
 0*Z(3)
+
+# PreImage(s)Elm, PreImagesSet for
+# bijective but neither IsSingleValued nor IsTotal
 gap> map:= InverseGeneralMapping( map );
 InverseGeneralMapping( <mapping: GF(3) -> GF(3) > )
 gap> Print(AsList( UnderlyingRelation( map ) ),"\n");
@@ -214,6 +257,8 @@ gap> PreImagesSet( map, GF(3) );
 [ 0*Z(3), Z(3)^0 ]
 gap> PreImagesRepresentative( map, Z(3) );
 Z(3)^0
+
+# ImageElm, ImagesSet for IsMapping
 gap> map:= GeneralMappingByElements( M, M, tuples{ [ 2, 6, 7 ] } );
 <general mapping: GF(3) -> GF(3) >
 gap> IsInjective( map );
@@ -224,8 +269,12 @@ gap> IsSurjective( map );
 true
 gap> IsTotal( map );
 true
+gap> Image( map, Z(3) );
+0*Z(3)
 gap> ImageElm( map, Z(3) );
 0*Z(3)
+gap> Image( map, [ Z(3) ] );
+[ 0*Z(3) ]
 gap> ImagesElm( map, Z(3) );
 [ 0*Z(3) ]
 gap> ImagesSet( map, [ 0*Z(3), Z(3) ] );
@@ -234,6 +283,8 @@ gap> ImagesSet( map, GF(3) );
 [ 0*Z(3), Z(3)^0, Z(3) ]
 gap> ImagesRepresentative( map, Z(3) );
 0*Z(3)
+
+# PreImagesElm, PreImagesSet, etc for IsMapping
 gap> map:= InverseGeneralMapping( map );
 InverseGeneralMapping( <mapping: GF(3) -> GF(3) > )
 gap> Print(AsList( UnderlyingRelation( map ) ),"\n");
@@ -261,6 +312,79 @@ gap> ImagesSource( map );
 [ 0*Z(3), Z(3)^0, Z(3) ]
 gap> PreImagesRange( map );
 [ 0*Z(3), Z(3)^0, Z(3) ]
+
+# Test error handling
+# Define mappings
+gap> tuples{[1,2,6]};
+[ DirectProductElement( [ 0*Z(3), 0*Z(3) ] ), 
+  DirectProductElement( [ 0*Z(3), Z(3)^0 ] ), 
+  DirectProductElement( [ Z(3)^0, Z(3) ] ) ]
+gap> map:= GeneralMappingByElements( M, M, tuples{ [ 1, 2, 5 ] } );
+<general mapping: GF(3) -> GF(3) >
+gap> IsSingleValued(map) or IsTotal(map);
+false
+gap> mapBijective := GeneralMappingByElements( M, M, tuples{ [ 1, 5, 9] } );
+<general mapping: GF(3) -> GF(3) >
+gap> IsSingleValued(mapBijective) or IsTotal(mapBijective);
+true
+gap> IsBijective(mapBijective);
+true
+
+# Image
+gap> Image(x -> x, 1);
+Error, <map> must be a general mapping
+gap> Image(map, 0*Z(3));
+Error, <map> must be single-valued and total
+gap> 0*Z(3) ^ map;
+Error, <map> must be single-valued and total
+gap> Image(mapBijective, Z(5));
+Error, the families of the element or collection <elm> and Source(<map>) don't\
+ match, maybe <elm> is not contained in Source(<map>) or is not a homogeneous \
+list or collection
+gap> Image(mapBijective, Z(9));
+Error, <elm> must be an element of Source(<map>)
+gap> Image(map, [Z(3), Z(9)]);
+Error, the collection <elm> must be contained in Source(<map>)
+
+# Images
+gap> Images(x -> x, 1);
+Error, <map> must be a general mapping
+gap> Images(mapBijective, Z(9));
+Error, <elm> must be an element of Source(<map>)
+gap> Images(map, [Z(3), Z(9)]);
+Error, the collection <elm> must be contained in Source(<map>)
+gap> Image(mapBijective, Z(5));
+Error, the families of the element or collection <elm> and Source(<map>) don't\
+ match, maybe <elm> is not contained in Source(<map>) or is not a homogeneous \
+list or collection
+
+# PreImage
+gap> PreImage(x -> x, 1);
+Error, <map> must be a general mapping
+gap> PreImage(map, Z(3));
+Error, <map> must be an injective and surjective mapping
+gap> PreImage(mapBijective, Z(9));
+Error, <elm> must be an element of Range(<map>)
+gap> PreImage(mapBijective, [Z(3), Z(9)]);
+Error, the collection <elm> must be contained in Range(<map>)
+gap> PreImage(mapBijective, Z(5));
+Error, the families of the element or collection <elm> and Range(<map>) don't \
+match, maybe <elm> is not contained in Range(<map>) or is not a homogeneous li\
+st or collection
+
+# PreImages
+gap> PreImages(x -> x, 1);
+Error, <map> must be a general mapping
+gap> PreImages(mapBijective, Z(9));
+Error, <elm> must be an element of Range(<map>)
+gap> PreImages(mapBijective, [Z(3), Z(9)]);
+Error, the collection <elm> must be contained in Range(<map>)
+gap> PreImages(mapBijective, Z(5));
+Error, the families of the element or collection <elm> and Range(<map>) don't \
+match, maybe <elm> is not contained in Range(<map>) or is not a homogeneous li\
+st or collection
+
+# NiceMonomorphism, RestrictedMapping for matrix groups
 gap> g := Group((1,2),(3,4));;
 gap> i := IdentityMapping( g );;
 gap> i2 := AsGroupGeneralMappingByImages(i);;
@@ -278,4 +402,6 @@ gap> IsGroupHomomorphism(res);
 true
 gap> IsInjective(res);        
 true
+
+#
 gap> STOP_TEST( "mapping.tst", 1);


### PR DESCRIPTION
..., PreImage, and PreImages.

If one of these functions figures out that the second argument is not an
element or subset of the Range or the Source, it now tells the user.