### PR TITLE
Fix QuickUnsolvabilityTestPerm for trivial groups

### DIFF
--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1244,6 +1244,7 @@ BindGlobal("QuickUnsolvabilityTestPerm",function(G)
 local som,elvth,fct,gens,new,l,i,j,a,b,bound;
   # a few moved points
   som:=MovedPoints(G);
+  if Length(som) = 0 then SetIsTrivial(G,true); return true; fi;
   bound:=Int(LogInt(Length(som)^5,3)/2); #Dixon Bound
   if Length(som)>100 then
     som:=som{List([1..100],x->Random(1, Length(som)))};


### PR DESCRIPTION
Normally, we should not even call `QuickUnsolvabilityTestPerm` with trivial
inputs, because `QuickUnsolvabilityTestPerm` is only used in a solvability
check, and `IsTrivial and IsGroup` implies `IsSolvableGroup`. But there are
ways to create trivial permutation groups which do not yet know that they are
trivial, e.g. when dealign with automorphism groups, and that can lead to an
error without this fix.

Please use the following template to submit a pull request, filling
in at least the "Text for release notes" and/or "Further details".
Thank You!

# Description

## Text for release notes 

If this pull request should be mentioned in the release notes, 
please provide a short description matching the style of the GAP
[Changes manual](https://www.gap-system.org/Manuals/doc/changes/chap0.html).

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

