### PR TITLE
WIP lib: add SetAsDomain

### DIFF
--- a/lib/domain.gd
+++ b/lib/domain.gd
@@ -136,6 +136,7 @@ InstallTrueMethod( IsDuplicateFree, IsDomain );
 ##  <#GAPDoc Label="GeneratorsOfDomain">
 ##  <ManSection>
 ##  <Attr Name="GeneratorsOfDomain" Arg='D'/>
+##  <Attr Name="GeneratorsOfSetAsDomain" Arg='D'/>
 ##
 ##  <Description>
 ##  For a domain <A>D</A>, <Ref Attr="GeneratorsOfDomain"/> returns a list
@@ -158,6 +159,9 @@ InstallTrueMethod( IsDuplicateFree, IsDomain );
 ##  <A>D</A>, <C><A>D</A>.i</C> returns the <M>i</M>-th generator if 
 ##  <M>i</M> is a positive integer, and if <C>name</C> is the name of a 
 ##  generator of <A>D</A> then <C><A>D</A>.name</C> returns this generator. 
+##  <P/>
+##  <Ref Attr="GeneratorsOfSetAsDomain"/> is a synonym for
+##  <Ref Attr="GeneratorsOfDomain"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/set.gd
+++ b/lib/set.gd
@@ -242,3 +242,9 @@ DeclareOperation( "IntersectSet", [ IsList and IsMutable, IsList ] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "SubtractSet", [ IsList and IsMutable, IsList ] );
+
+#############################################################################
+##
+# MOVE THIS TO domain.gd
+DeclareSynonym("IsSetAsDomain", IsDomain);
+DeclareSynonym("SetAsDomain", Domain);

--- a/lib/set.gi
+++ b/lib/set.gi
@@ -222,3 +222,50 @@ InstallMethod( SubtractSet,
       RemoveSet( set, obj );
     od;
     end );
+
+
+#############################################################################
+##
+InstallMethod(SetAsDomain,
+"for a set & collection",
+[IsSet and IsCollection],
+function(set)
+    local copy, type, domain;
+    copy := Immutable(set);
+    type := NewType(FamilyObj(copy),
+                    IsSetAsDomain and IsAttributeStoringRep);
+    return ObjectifyWithAttributes(rec(), type,
+                                   GeneratorsOfDomain, copy,
+                                   AsList, copy,
+                                   AsSet, copy);
+end);
+
+# Provide family of objects `fam`. Then the resulting domain lives in the same
+# family as a domain created from a non-empty set of objects of `fam`.
+InstallOtherMethod(SetAsDomain,
+"for a family and an empty list",
+[IsFamily, IsEmpty and IsList],
+function(family, set)
+    local copy, type;
+    copy := Immutable([]);
+    type := NewType(CollectionsFamily(family),
+                    IsSetAsDomain and IsAttributeStoringRep);
+    return ObjectifyWithAttributes(rec(), type,
+                                   GeneratorsOfDomain, copy,
+                                   AsList, copy,
+                                   AsSet, copy);
+end);
+
+InstallMethod(\in,
+"for an IsSetAsDomain",
+[IsObject, IsSetAsDomain],
+function(elm, set)
+    return elm in AsList(set);
+end);
+
+InstallMethod(PrintObj,
+"for an IsSetAsDomain",
+[IsSetAsDomain],
+function( setAsDomain )
+    Print("SetAsDomain(", AsList(setAsDomain), ")");
+end);


### PR DESCRIPTION
TODO
- move new code into domain.g?
- add tests!!
- text for release notes

# Description
Currently there is no filter that specifies explicitly that a domain is created as a _set with no operational structure_. This PR introduces the filter `IsSetAsDomain`. The motivation is to be able to use e.g. `SetAsDomain([1..n])` as a domain for `MappingByFunction`:
```
gap> MappingByFunction(SetAsDomain([1..5]), SetAsDomain([1..5]), x -> x);
MappingByFunction( SetAsDomain([ 1 .. 5 ]), SetAsDomain([ 1 .. 5 ]), function( x ) ... end )
gap> Image(last);
[ 1, 2, 3, 4, 5 ]
```

One thing that is not entirely clear to me yet: As `IsPermGroup` already implies `IsDomain`, should it also imply `IsSetAsDomain` or not? I think it should. Methods for e.g. `IsPermGroup` would then outrank methods for `IsSetAsDomain` anyways.