### PR TITLE
Fix buffer overflow in TransformationListListNC

### DIFF
--- a/src/trans.cc
+++ b/src/trans.cc
@@ -476,8 +476,12 @@ static Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
             ptf2[i] = i;
         }
         for (i = LEN_LIST(src); 1 <= i; i--) {
-            ptf2[INT_INTOBJ(ELM_LIST(src, i)) - 1] =
-                INT_INTOBJ(ELM_LIST(ran, i)) - 1;
+            s = INT_INTOBJ(ELM_LIST(src, i));
+            r = INT_INTOBJ(ELM_LIST(ran, i));
+            // deg may be smaller than s if s = r
+            if (s != r) {
+                ptf2[s - 1] = r - 1;
+            }
         }
     }
     else {
@@ -487,8 +491,11 @@ static Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
             ptf4[i] = i;
         }
         for (i = LEN_LIST(src); 1 <= i; i--) {
-            ptf4[INT_INTOBJ(ELM_LIST(src, i)) - 1] =
-                INT_INTOBJ(ELM_LIST(ran, i)) - 1;
+            s = INT_INTOBJ(ELM_LIST(src, i));
+            r = INT_INTOBJ(ELM_LIST(ran, i));
+            if (s != r) {
+                ptf4[s - 1] = r - 1;
+            }
         }
     }
     return f;

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -57,6 +57,12 @@ Error, TransformationListListNC: <ran> must be a small list (not a permutation\
  (small))
 gap> TransformationListListNC([], []);
 IdentityTransformation
+gap> TransformationListListNC([1..100000], [1..100000]);
+IdentityTransformation
+gap> TransformationListList([1..1000000], Concatenation([100000], [2..1000000]));
+<transformation on 100000 pts with rank 99999>
+gap> TransformationListList([1..1000000], Concatenation([2], [2..1000000]));
+Transformation( [ 2, 2 ] )
 
 # Test DegreeOfTransformation
 gap> f := TransformationListListNC([1, 2], [1, 1]) ^ (3, 4);;


### PR DESCRIPTION
Fix a buffer overflow in TransformationListList. This bug is in 4.10 (might be in earlier releases too)

## Text for release notes 

* Fix bug in TransformationListList which could cause a crash.

