### PR TITLE
Reduce varnames.tst sensitivity to the list of loaded packages

### DIFF
--- a/tst/teststandard/varnames.tst
+++ b/tst/teststandard/varnames.tst
@@ -4,9 +4,9 @@
 ##
 gap> START_TEST("varnames.tst");
 gap> Filtered( NamesSystemGVars(), x -> not x in ALL_KEYWORDS() and
->            ( Length(x)=1 or (IsLowerAlphaChar(x[1]) and Length(x) < 12) ) );
-[ "*", "+", "-", ".", "/", "<", "=", "E", "X", "Z", "^", "fail", "infinity", 
-  "last", "last2", "last3", "time" ]
+>            ( Length(x)=1 or (IsLowerAlphaChar(x[1]) and Length(x) < 5) ) );
+[ "*", "+", "-", ".", "/", "<", "=", "E", "X", "Z", "^", "fail", "last", 
+  "time" ]
 gap> Filtered(NamesSystemGVars(),name->IsSubset(LETTERS,name));;
 gap> IsSubset(IDENTS_GVAR(), IDENTS_BOUND_GVARS() );
 true


### PR DESCRIPTION
Loading recog package made the output containing some more global
variables, see https://github.com/gap-packages/recog/issues/61
