### PR TITLE
Add a `PrintObj` method for general domains which know their `GeneratorsOfDomain`

### DIFF
--- a/lib/domain.gi
+++ b/lib/domain.gi
@@ -207,6 +207,18 @@ InstallMethod( GeneratorsOfDomain,
 
 #############################################################################
 ##
+##  PrintObj
+##
+InstallMethod( PrintObj,
+    "for a domain with GeneratorsOfDomain",
+    [ HasGeneratorsOfDomain and IsDomain ],
+    function( dom )
+    Print( "Domain(", GeneratorsOfDomain( dom ), ")" );
+    end );
+
+
+#############################################################################
+##
 #M  AsList( <D> ) . . . . . . . . . . . . . . .  list of elements of a domain
 #M  Enumerator( <D> ) . . . . . . . . . . . . .  list of elements of a domain
 ##

--- a/lib/relation.gd
+++ b/lib/relation.gd
@@ -144,7 +144,7 @@ DeclareGlobalFunction("RandomBinaryRelationOnPoints");
 ##  <A>domain</A>.
 ##  <Example><![CDATA[
 ##  gap> IdentityBinaryRelation(5);
-##  <equivalence relation on <object> >
+##  <equivalence relation on Domain([ 1 .. 5 ]) >
 ##  gap> s4:=SymmetricGroup(4);
 ##  Sym( [ 1 .. 4 ] )
 ##  gap> IdentityBinaryRelation(s4);
@@ -171,7 +171,7 @@ DeclareGlobalFunction("IdentityBinaryRelation");
 ##  where the source and range are the same set.
 ##  <Example><![CDATA[
 ##  gap> r:=BinaryRelationByElements(Domain([1..3]),[Tuple([1,2]),Tuple([1,3])]);
-##  <general mapping: <object> -> <object> >
+##  <general mapping: Domain([ 1 .. 3 ]) -> Domain([ 1 .. 3 ]) >
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -794,7 +794,7 @@ DeclareAttribute("GeneratorsOfEquivalenceRelationPartition",
 ##  they contain only elements of the domain.
 ##  <Example><![CDATA[
 ##  gap> er:=EquivalenceRelationByPartition(Domain([1..10]),[[1,3,5,7,9],[2,4,6,8,10]]);
-##  <equivalence relation on <object> >
+##  <equivalence relation on Domain([ 1 .. 10 ]) >
 ##  gap> IsEquivalenceRelation(er);
 ##  true
 ##  ]]></Example>
@@ -932,7 +932,7 @@ DeclareAttribute("EquivalenceClassRelation", IsEquivalenceClass);
 ##  </M><C>EquivalenceClasses</C><M>( c2 )</M>.
 ##  <Example><![CDATA[
 ##  gap> er:=EquivalenceRelationByPartition(Domain([1..10]),[[1,3,5,7,9],[2,4,6,8,10]]);
-##  <equivalence relation on <object> >
+##  <equivalence relation on Domain([ 1 .. 10 ]) >
 ##  gap> classes := EquivalenceClasses(er);
 ##  [ {1}, {2} ]
 ##  ]]></Example>

--- a/tst/testinstall/domain.tst
+++ b/tst/testinstall/domain.tst
@@ -21,5 +21,11 @@ false
 gap> M = J;
 Error, no method found for comparing two infinite domains
 
+# PrintObj method
+gap> Domain([1..5]);
+Domain([ 1 .. 5 ])
+gap> Domain(FamilyObj(1), []);
+Domain([  ])
+
 #
 gap> STOP_TEST("domain.tst");


### PR DESCRIPTION
Supersedes #3460.

This enables nicer printing of mappings between sets:
```
gap> MappingByFunction(Domain([1..5]), Domain([1..5]), x -> x);
MappingByFunction( Domain([ 1 .. 5 ]), Domain([ 1 .. 5 ]), function( x ) ... end )
```