### PR TITLE
document DeclareCategoryCollections; document constructors;  improve reference manual; add NameOfCategoryCollections helper

### DIFF
--- a/doc/ref/coll.xml
+++ b/doc/ref/coll.xml
@@ -30,6 +30,7 @@
 <#Include Label="IsCollectionFamily">
 <#Include Label="ElementsFamily">
 <#Include Label="CategoryCollections">
+<#Include Label="DeclareCategoryCollections">
 
 </Section>
 

--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -1212,43 +1212,28 @@ Values for these functions can be installed in the implementation part
 via <Ref Func="InstallGlobalFunction"/>.
 <P/>
 Calls to the following functions belong to the declaration part.
-<P/>
-<Ref Func="DeclareAttribute"/>,
-<P/>
-<Ref Func="DeclareCategory"/>,
-<P/>
-<Ref Func="DeclareFilter"/>,
-<P/>
-<Ref Func="DeclareOperation"/>,
-<P/>
-<Ref Func="DeclareGlobalFunction"/>,
-<P/>
-<Ref Func="DeclareSynonym"/>,
-<P/>
-<Ref Func="DeclareSynonymAttr"/>,
-<P/>
-<Ref Func="DeclareProperty"/>,
-<P/>
-<Ref Func="InstallTrueMethod"/>.
-<P/>
+<List>
+<Item><Ref Func="DeclareAttribute"/>,</Item>
+<Item><Ref Func="DeclareCategory"/>,</Item>
+<Item><Ref Func="DeclareFilter"/>,</Item>
+<Item><Ref Func="DeclareOperation"/>,</Item>
+<Item><Ref Func="DeclareGlobalFunction"/>,</Item>
+<Item><Ref Func="DeclareSynonym"/>,</Item>
+<Item><Ref Func="DeclareSynonymAttr"/>,</Item>
+<Item><Ref Func="DeclareProperty"/>,</Item>
+<Item><Ref Func="InstallTrueMethod"/>.</Item>
+</List>
 Calls to the following functions belong to the implementation part.
-<P/>
-<Ref Func="DeclareRepresentation"/>,
-<P/>
-<Ref Func="InstallGlobalFunction"/>,
-<P/>
-<Ref Func="InstallMethod"/>,
-<P/>
-<Ref Func="InstallImmediateMethod"/>,
-<P/>
-<Ref Func="InstallOtherMethod"/>,
-<P/>
-<Ref Func="NewFamily"/>,
-<P/>
-<Ref Func="NewType"/>,
-<P/>
-<Ref Func="Objectify"/>.
-<P/>
+<List>
+<Item><Ref Func="DeclareRepresentation"/>,</Item>
+<Item><Ref Func="InstallGlobalFunction"/>,</Item>
+<Item><Ref Func="InstallMethod"/>,</Item>
+<Item><Ref Func="InstallImmediateMethod"/>,</Item>
+<Item><Ref Func="InstallOtherMethod"/>,</Item>
+<Item><Ref Func="NewFamily"/>,</Item>
+<Item><Ref Func="NewType"/>,</Item>
+<Item><Ref Func="Objectify"/>.</Item>
+</List>
 <Index Key="DeclareRepresentation" Subkey="belongs to implementation part">
 <C>DeclareRepresentation</C></Index>
 Whenever both a <C>New</C><A>Something</A> and a

--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -49,6 +49,7 @@ and why it is useful to have a declaration part and an implementation part.
 <Heading>Creating Categories</Heading>
 
 <#Include Label="NewCategory">
+<#Include Label="DeclareCategory">
 <#Include Label="CategoryFamily">
 
 <P/>
@@ -63,6 +64,7 @@ See also <Ref Func="CategoryCollections"/>.
 <Heading>Creating Representations</Heading>
 
 <#Include Label="NewRepresentation">
+<#Include Label="DeclareRepresentation">
 
 </Section>
 
@@ -85,6 +87,8 @@ clearly the result value is <E>not</E> stored in any of the arguments.
 
 <#Include Label="NewAttribute">
 <#Include Label="NewProperty">
+<#Include Label="DeclareAttribute">
+<#Include Label="DeclareProperty">
 
 </Section>
 
@@ -99,6 +103,7 @@ one can use logical implications
 <Ref Func="SetFilterObj"/>, <Ref Func="ResetFilterObj"/>.
 
 <#Include Label="NewFilter">
+<#Include Label="DeclareFilter">
 <#Include Label="SetFilterObj">
 <#Include Label="ResetFilterObj">
 
@@ -114,6 +119,7 @@ one can use logical implications
 <Heading>Creating Operations</Heading>
 
 <#Include Label="NewOperation">
+<#Include Label="DeclareOperation">
 
 </Section>
 
@@ -122,6 +128,7 @@ one can use logical implications
 <Heading>Creating Constructors</Heading>
 
 <#Include Label="NewConstructor">
+<#Include Label="DeclareConstructor">
 
 </Section>
 
@@ -1176,26 +1183,11 @@ avoid their being overwritten accidentally.
 
 See also Section <Ref Sect="More About Global Variables"/>.
 
-<#Include Label="DeclareCategory">
-<#Include Label="TypeOfOperation">
-<#Include Label="IsCategory">
-<#Include Label="IsRepresentation">
-<#Include Label="IsProperty">
-<#Include Label="IsAttribute">
-<#Include Label="CategoryByName">
-<#Include Label="DeclareRepresentation">
-<#Include Label="DeclareAttribute">
-<#Include Label="DeclareProperty">
-<#Include Label="DeclareFilter">
-<#Include Label="DeclareOperation">
-<#Include Label="DeclareConstructor">
-<#Include Label="DeclareGlobalFunction">
 <#Include Label="DeclareGlobalVariable">
 <#Include Label="InstallValue">
-<#Include Label="DeclareSynonym">
 <#Include Label="FlushCaches">
-<#Include Label="FilterByName">
-<#Include Label="ShowDeclarationsOfOperation">
+<#Include Label="DeclareGlobalFunction">
+<#Include Label="DeclareSynonym">
 
 </Section>
 

--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -13,12 +13,7 @@
 This chapter is divided into three parts.
 <P/>
 In the first part, it is explained how to create
-filters (see&nbsp;<Ref Sect="Creating Categories"/>, <Ref Sect="Creating Representations"/>,
-<Ref Sect="Creating Attributes and Properties"/>, <Ref Sect="Creating Other Filters"/>),
-operations (see&nbsp;<Ref Sect="Creating Operations"/>),
-families (see&nbsp;<Ref Sect="Creating Families"/>),
-types (see&nbsp;<Ref Sect="Creating Types"/>),
-and objects with given type (see&nbsp;<Ref Sect="Creating Objects"/>).
+objects with given type (see&nbsp;<Ref Sect="Creating Objects"/>).
 <P/>
 In the second part, first a few small examples are given,
 for dealing with the usual cases of
@@ -42,213 +37,6 @@ of &GAP; packages is outlined (see&nbsp;<Ref Sect="Declaration and Implementatio
 See also Chapter&nbsp;<Ref Chap="An Example -- Residue Class Rings"/> for examples
 how the functions from the first part are used,
 and why it is useful to have a declaration part and an implementation part.
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Categories">
-<Heading>Creating Categories</Heading>
-
-<#Include Label="NewCategory">
-<#Include Label="DeclareCategory">
-<#Include Label="CategoryFamily">
-
-<P/>
-
-See also <Ref Func="CategoryCollections"/>.
-
-</Section>
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Representations">
-<Heading>Creating Representations</Heading>
-
-<#Include Label="NewRepresentation">
-<#Include Label="DeclareRepresentation">
-
-</Section>
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Attributes and Properties">
-<Heading>Creating Attributes and Properties</Heading>
-
-Each method that is installed for an attribute or a property
-via <Ref Func="InstallMethod"/> must require exactly one argument,
-and this must lie in the filter <A>filter</A> that was entered as second
-argument of <Ref Func="NewAttribute"/> resp. <Ref Func="NewProperty"/>.
-<P/>
-As for any operation (see&nbsp;<Ref Sect="Creating Operations"/>),
-for attributes and properties one can install a method taking an argument
-that does not lie in <A>filt</A> via <Ref Func="InstallOtherMethod"/>,
-or a method for more than one argument;
-in the latter case,
-clearly the result value is <E>not</E> stored in any of the arguments.
-
-<#Include Label="NewAttribute">
-<#Include Label="NewProperty">
-<#Include Label="DeclareAttribute">
-<#Include Label="DeclareProperty">
-
-</Section>
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Other Filters">
-<Heading>Creating Other Filters</Heading>
-
-In order to change the value of <A>filt</A> for an object <A>obj</A>,
-one can use logical implications
-(see&nbsp;<Ref Sect="Logical Implications"/>) or
-<Ref Func="SetFilterObj"/>, <Ref Func="ResetFilterObj"/>.
-
-<#Include Label="NewFilter">
-<#Include Label="DeclareFilter">
-<#Include Label="SetFilterObj">
-<#Include Label="ResetFilterObj">
-
-<!-- %T Categories and representations should not be operations, -->
-<!-- %T the same for filters made by <C>NewFilter</C>! -->
-<!-- %AK Now everything is displayed properly -->
-
-</Section>
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Operations">
-<Heading>Creating Operations</Heading>
-
-<#Include Label="NewOperation">
-<#Include Label="DeclareOperation">
-
-</Section>
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Constructors">
-<Heading>Creating Constructors</Heading>
-
-<#Include Label="NewConstructor">
-<#Include Label="DeclareConstructor">
-
-</Section>
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Families">
-<Heading>Creating Families</Heading>
-
-Families are probably the least obvious part of the &GAP; type system,
-so some remarks about the role of families are necessary.
-When one uses &GAP; as it is, one will (better: should) not meet
-families at all.
-The two situations where families come into play are the following.
-<P/>
-First, since families are used to describe relations between arguments of
-operations in the method selection mechanism
-(see Chapter&nbsp;<Ref Chap="Method Selection"/>,
-and also Chapter&nbsp;<Ref Chap="Types of Objects"/>),
-one has to prescribe such a relation in each method installation
-(see&nbsp;<Ref Sect="Method Installation"/>);
-usual relations are <Ref Func="ReturnTrue"/>
-(which means that any relation of the actual arguments is admissible),
-<Ref Func="IsIdenticalObj"/> (which means that
-there are two arguments that lie in the same family),
-and <C>IsCollsElms</C>
-(which means that there are two arguments,
-the first being a collection of elements that lie in the same family
-as the second argument).
-<P/>
-Second &ndash;and this is the more complicated situation&ndash;
-whenever one creates a new kind of objects,
-one has to decide what its family shall be.
-If the new object shall be equal to existing objects,
-for example if it is just represented in a different way,
-there is no choice:
-The new object must lie in the same family as all objects
-that shall be equal to it.
-So only if the new object is different
-(w.r.t.&nbsp;the equality <Q><C>=</C></Q>)
-from all other &GAP; objects, we are likely to create a new family
-for it.
-Note that enlarging an existing family by such new objects
-may be problematic because of implications that have been
-installed for all  objects of the family in question.
-The choice of families depends on the applications one has in mind.
-For example, if the new objects in question are not likely to be
-arguments of operations for which family relations are relevant
-(for example binary arithmetic operations),
-one could create one family for all such objects,
-and regard it as <Q>the family of all those &GAP; objects that would
-in fact not need a family</Q>.
-On the other extreme, if one wants to create domains of the new objects
-then one has to choose the family in such a way that all intended
-elements of a domain do in fact lie in the same family.
-(Remember that a domain is a collection,
-see Chapter&nbsp;<Ref Sect="Domains"/>,
-and that a collection consists of elements in the same family,
-see Chapter&nbsp;<Ref Chap="Collections"/>
-and Section&nbsp;<Ref Sect="Families"/>.)
-<P/>
-Let us look at an example.
-Suppose that no permutations are available in &GAP;,
-and that we want to implement permutations.
-Clearly we want to support permutation groups,
-but it is not a priori clear how to distribute the new permutations
-into families.
-We can put all permutations into one family;
-this is how in fact permutations are implemented in &GAP;.
-But it would also be possible to put all permutations of a given degree
-into a family of their own;
-this would for example mean that for each degree,
-there would be distinguished trivial permutations,
-and that the stabilizer of the point <C>5</C> in the symmetric group on the
-points <C>1</C>, <C>2</C>, <M>\ldots</M>, <C>5</C> is not regarded as equal to the
-symmetric group on <C>1</C>, <C>2</C>, <C>3</C>, <C>4</C>.
-Note that the latter approach would have the advantage that it is
-no problem to construct permutations and permutation groups acting on
-arbitrary (finite) sets,
-for example by constructing first the symmetric group on the set
-and then generating any desired permutation group as a subgroup of this
-symmetric group.
-<P/>
-So one aspect concerning a reasonable choice of families is
-to make the families large enough for being able to form interesting
-domains of elements in the family.
-But on the other hand,
-it is useful to choose the families small enough for admitting
-meaningful relations between objects.
-For example, the elements of different free groups in &GAP;
-lie in different families;
-the multiplication of free group elements is installed only for the
-case that the two operands lie in the same family,
-with the effect that one cannot erroneously form the product of
-elements from different free groups.
-In this case, families appear as a tool for providing useful
-restrictions.
-<P/>
-As another example, note that an element and a collection containing
-this element never lie in the same family,
-by the general implementation of collections;
-namely, the family of a collection of elements in the family <A>Fam</A>
-is the collections family of <A>Fam</A> (see&nbsp;<Ref Attr="CollectionsFamily"/>).
-This means that for a collection, we need not (because we cannot)
-decide about its family.
-<P/>
-A few functions in &GAP; return families,
-see <Ref Attr="CollectionsFamily"/> and <Ref Attr="ElementsFamily"/>.
-
-<#Include Label="NewFamily">
-
-</Section>
-
-
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Creating Types">
-<Heading>Creating Types</Heading>
-
-<#Include Label="NewType">
-
-</Section>
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
@@ -307,7 +95,7 @@ in order to keep the information stored in <A>cobj</A> consistent.
 <P/>
 First of all, in the access or assignment to a component as shown above,
 <A>name</A> must be among the admissible component names
-for the representation of <A>cobj</A>, see&nbsp;<Ref Sect="Creating Representations"/>.
+for the representation of <A>cobj</A>, see&nbsp;<Ref Func="NewRepresentation"/>.
 Second, preferably only few low level functions should use <C>!.</C>,
 whereas this operator should not occur in <Q>user interactions</Q>.
 <P/>
@@ -415,7 +203,7 @@ in order to keep the information stored in <A>pobj</A> consistent.
 <P/>
 First of all, in the access or assignment to a position as shown above,
 <A>pos</A> must be among the admissible positions
-for the representation of <A>pobj</A>, see&nbsp;<Ref Sect="Creating Representations"/>.
+for the representation of <A>pobj</A>, see&nbsp;<Ref Func="NewRepresentation"/>.
 Second, preferably only few low level functions should use <C>![]</C>,
 whereas this operator should not occur in <Q>user interactions</Q>.
 <P/>

--- a/doc/ref/domain.xml
+++ b/doc/ref/domain.xml
@@ -605,8 +605,8 @@ The functions <Ref Func="InstallSubsetMaintenance"/>,
 <Ref Func="InstallFactorMaintenance"/> are used to tell &GAP;
 under what conditions an attribute is maintained under taking subsets,
 or forming factor structures or isomorphic domains.
-This is used only when a new attribute is created,
-see&nbsp;<Ref Sect="Creating Attributes and Properties"/>.
+This is used only when a new attribute or property is created,
+see&nbsp;<Ref Func="NewAttribute"/> and <Ref Func="NewProperty"/>.
 For the attributes already available,
 such as <Ref Prop="IsFinite"/> and <Ref Prop="IsCommutative"/>,
 the maintenances are already notified.
@@ -680,8 +680,7 @@ and <Ref Filt="IsLieMatrix"/>.
 
 The following categories of elements are to be understood mainly as
 categories for all objects in a family,
-they are usually used as third argument of <C>NewFamily</C>
-(see&nbsp;<Ref Sect="Creating Families"/>).
+they are usually used as third argument of <Ref Func="NewFamily"/>.
 The purpose of each of the following categories is then to guarantee that
 each collection of its elements automatically lies in its collections
 category (see&nbsp;<Ref Func="CategoryCollections"/>).

--- a/doc/ref/function.xml
+++ b/doc/ref/function.xml
@@ -77,7 +77,6 @@ So <Ref Func="ReturnTrue"/> is often used as family predicate in
 Functions are &GAP; objects and thus have categories and a family.
 
 <#Include Label="IsFunction">
-<#Include Label="IsOperation">
 <#Include Label="FunctionsFamily">
 
 </Section>

--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -76,6 +76,77 @@ and then set the attribute tester for the object to <K>true</K>.
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="Constructors">
+<Heading>Constructors</Heading>
+
+Constructors are a special type of operation used to make new objects. The key
+difference compared to regular operations is that method selection works
+slightly differently for them: The first argument in a call to a constructor
+must always be a filter <Ref Sect="Filters"/>. The result of a method is
+expected to lie in that filter. Moreover, while normally method selection
+matches on the type of each argument, for a constructor the first argument is
+treated differently: instead of matching its type, the argument itself (which
+is a filter) must be a subset of the filter specified by the method which is
+being tested for match. In other words, the argument filter must imply the
+method filter.
+<P/>
+
+Also, method ranking works differently: instead of the sum of the ranks of the
+types of all arguments, only the rank of the filter given as first argument is
+considered; and for it, the normal ranking order is reversed. This ensures
+that if multiple constructor methods match, the <Q>>most general</Q> method is
+selected.
+
+<Example><![CDATA[
+gap> DeclareConstructor("XCons",[IsMagma,IsInt]);
+gap> InstallMethod(XCons, [IsGroup, IsInt], function(t,x) return CyclicGroup(x); end);
+gap> InstallMethod(XCons, [IsPermGroup, IsInt], function(t,x) return SymmetricGroup(x); end);
+gap> InstallMethod(XCons, [IsSemigroup, IsInt], function(t,x) return FullTransformationMonoid(x); end);
+gap> XCons(IsGroup,3);
+<pc group of size 3 with 1 generators>
+gap> XCons(IsPermGroup,3);
+Sym( [ 1 .. 3 ] )
+gap> XCons(IsSemigroup,4);
+<full transformation monoid of degree 4>
+gap> # if multiple methods match, the most general is selected:
+gap> XCons(IsMagma,3);
+<full transformation monoid of degree 3>
+]]></Example>
+
+The example above shows some basic examples (usually a constructor will
+produce isomorphic objects in different representations, not different objects
+as in this case).
+<P/>
+
+If no method has been installed which guarantees to produce a suitable
+objecty, a "No Method Found" error will be returned.
+<Log><![CDATA[
+gap> XCons(IsFullTransformationMonoid,4);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `XCons' on 2 arguments called from
+<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
+ called from read-eval loop at line 8 of *stdin*
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> quit;
+gap> XCons(IsNilpotentGroup,4);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `XCons' on 2 arguments called from
+<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
+ called from read-eval loop at line 9 of *stdin*
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk>
+]]></Log>
+
+Note that in both these cases there are methods that actually produce results
+of the required types, but they have not been installed with this information,
+so are not selected.
+
+</Section>
+
+
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="Method Installation">
 <Heading>Method Installation</Heading>
 

--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -68,6 +68,10 @@ Depending on the type of the object,
 there may be another method to store the value in a suitable way,
 and then set the attribute tester for the object to <K>true</K>.
 
+<#Include Label="IsOperation">
+<#Include Label="TypeOfOperation">
+<#Include Label="ShowDeclarationsOfOperation">
+
 </Section>
 
 

--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -71,6 +71,8 @@ and then set the attribute tester for the object to <K>true</K>.
 <#Include Label="IsOperation">
 <#Include Label="TypeOfOperation">
 <#Include Label="ShowDeclarationsOfOperation">
+<#Include Label="NewOperation">
+<#Include Label="DeclareOperation">
 
 </Section>
 
@@ -143,6 +145,9 @@ Note that in both these cases there are methods that actually produce results
 of the required types, but they have not been installed with this information,
 so are not selected.
 
+<#Include Label="NewConstructor">
+<#Include Label="DeclareConstructor">
+
 </Section>
 
 
@@ -211,7 +216,7 @@ relative to other methods for <A>opr</A>.
 <P/>
 Note that for operations which are constructors special rules with respect
 to applicability and rank of the corresponding methods apply
-(see section <Ref Func="NewConstructor"/>).
+(see <Ref Func="NewConstructor"/>).
 <P/>
 Note that from the applicable methods
 an efficient one shall be selected.

--- a/doc/ref/types.xml
+++ b/doc/ref/types.xml
@@ -73,6 +73,8 @@ representations.  For example, a sparsely represented matrix can be
 equal to a densely represented matrix.  Similarly, each domain is
 equal w.r.t. <C>=</C> to the sorted list of its elements, but a domain
 is not a list, and a list is not a domain.
+<P/>
+For information on how to create families, see <Ref Sect="Creating Families"/>.
 
 <#Include Label="FamilyObj">
 
@@ -159,6 +161,7 @@ as well as sections&nbsp;<Ref Sect="Logical Implications"/>,
 </Description>
 </ManSection>
 
+<#Include Label="FilterByName">
 <#Include Label="ShowImpliedFilters">
 <#Include Label="FiltersType">
 
@@ -197,6 +200,7 @@ in is fixed.
 <P/>
 All categories in the library are created during initialization, in
 particular they are not created dynamically at runtime.
+For information on how to create categories, see <Ref Sect="Creating Categories"/>.
 <P/>
 The following list gives an overview of important categories of
 arithmetic objects.  Indented categories are to be understood as
@@ -283,7 +287,9 @@ inverses by some elements, but to generate it as a magma with one it
 may be necessary to take the union of these generators and their
 inverses.
 
+<#Include Label="IsCategory">
 <#Include Label="CategoriesOfObject">
+<#Include Label="CategoryByName">
 
 </Section>
 
@@ -333,6 +339,7 @@ of characters can be converted into a string.
 <P/>
 All representations in the library are created during initialization,
 in particular they are not created dynamically at runtime.
+For information on how to create representations, see <Ref Sect="Creating Representations"/>.
 <P/>
 Examples of subrepresentations of <C>IsPositionalObjectRep</C> are
 <C>IsModulusRep</C>, which is used for residue classes in the ring of
@@ -344,6 +351,7 @@ An important subrepresentation of <C>IsComponentObjectRep</C> is
 objects.  It provides automatic storing of all attribute values (see
 below).
 
+<#Include Label="IsRepresentation">
 <#Include Label="RepresentationsOfObject">
 
 </Section>
@@ -395,6 +403,9 @@ return value is not stored in any of the arguments.
 Properties are a special form of attributes that have the value <K>true</K>
 or <K>false</K>, see section&nbsp;<Ref Sect="Properties"/>.
 <P/>
+For information on how to create attributes and properties, see
+<Ref Sect="Creating Attributes and Properties"/>.
+<P/>
 Examples of attributes for multiplicative elements are
 <Ref Attr="Inverse"/>, <Ref Attr="One"/>,
 and <Ref Attr="Order"/>.
@@ -402,6 +413,7 @@ and <Ref Attr="Order"/>.
 <Ref Attr="Centre"/> is an attribute for magmas,
 and <Ref Attr="DerivedSubgroup"/> is an attribute for groups.
 
+<#Include Label="IsAttribute">
 <#Include Label="KnownAttributesOfObject">
 
 </Section>
@@ -448,9 +460,7 @@ sets <A>val</A> as size of the
 object <A>obj</A> if the size was not yet known.
 <P/>
 For each attribute <A>attr</A> that is declared with
-<Ref Func="DeclareAttribute"/>
-resp.&nbsp;<Ref Func="DeclareProperty"/>
-(see&nbsp;<Ref Sect="Global Variables in the Library"/>),
+<Ref Func="DeclareAttribute"/> resp.&nbsp;<Ref Func="DeclareProperty"/>,
 tester and setter are automatically made accessible by the names
 <C>Has<A>attr</A></C> and <C>Set<A>attr</A></C>, respectively.
 For example, the tester for <Ref Attr="Size"/> is called <C>HasSize</C>,
@@ -570,6 +580,7 @@ which mean that the multiplication of elements in the domain satisfies
 and <M>( a + b ) * c = a * c + b * c</M>, respectively,
 for all <M>a</M>, <M>b</M>, <M>c</M> in the domain.
 <P/>
+<#Include Label="IsProperty">
 <#Include Label="KnownPropertiesOfObject">
 <#Include Label="KnownTruePropertiesOfObject">
 

--- a/doc/ref/types.xml
+++ b/doc/ref/types.xml
@@ -74,9 +74,108 @@ equal to a densely represented matrix.  Similarly, each domain is
 equal w.r.t. <C>=</C> to the sorted list of its elements, but a domain
 is not a list, and a list is not a domain.
 <P/>
-For information on how to create families, see <Ref Sect="Creating Families"/>.
+Families are probably the least obvious part of the &GAP; type system,
+so some remarks about the role of families are necessary.
+When one uses &GAP; as it is, one will (better: should) not meet
+families at all.
+The two situations where families come into play are the following.
+<P/>
+First, since families are used to describe relations between arguments of
+operations in the method selection mechanism
+(see Chapter&nbsp;<Ref Chap="Method Selection"/>,
+and also Chapter&nbsp;<Ref Chap="Types of Objects"/>),
+one has to prescribe such a relation in each method installation
+(see&nbsp;<Ref Sect="Method Installation"/>);
+usual relations are <Ref Func="ReturnTrue"/>
+(which means that any relation of the actual arguments is admissible),
+<Ref Func="IsIdenticalObj"/> (which means that
+there are two arguments that lie in the same family),
+and <C>IsCollsElms</C>
+(which means that there are two arguments,
+the first being a collection of elements that lie in the same family
+as the second argument).
+<P/>
+Second &ndash;and this is the more complicated situation&ndash;
+whenever one creates a new kind of objects,
+one has to decide what its family shall be.
+If the new object shall be equal to existing objects,
+for example if it is just represented in a different way,
+there is no choice:
+The new object must lie in the same family as all objects
+that shall be equal to it.
+So only if the new object is different
+(w.r.t.&nbsp;the equality <Q><C>=</C></Q>)
+from all other &GAP; objects, we are likely to create a new family
+for it.
+Note that enlarging an existing family by such new objects
+may be problematic because of implications that have been
+installed for all  objects of the family in question.
+The choice of families depends on the applications one has in mind.
+For example, if the new objects in question are not likely to be
+arguments of operations for which family relations are relevant
+(for example binary arithmetic operations),
+one could create one family for all such objects,
+and regard it as <Q>the family of all those &GAP; objects that would
+in fact not need a family</Q>.
+On the other extreme, if one wants to create domains of the new objects
+then one has to choose the family in such a way that all intended
+elements of a domain do in fact lie in the same family.
+(Remember that a domain is a collection,
+see Chapter&nbsp;<Ref Sect="Domains"/>,
+and that a collection consists of elements in the same family,
+see Chapter&nbsp;<Ref Chap="Collections"/>
+and Section&nbsp;<Ref Sect="Families"/>.)
+<P/>
+Let us look at an example.
+Suppose that no permutations are available in &GAP;,
+and that we want to implement permutations.
+Clearly we want to support permutation groups,
+but it is not a priori clear how to distribute the new permutations
+into families.
+We can put all permutations into one family;
+this is how in fact permutations are implemented in &GAP;.
+But it would also be possible to put all permutations of a given degree
+into a family of their own;
+this would for example mean that for each degree,
+there would be distinguished trivial permutations,
+and that the stabilizer of the point <C>5</C> in the symmetric group on the
+points <C>1</C>, <C>2</C>, <M>\ldots</M>, <C>5</C> is not regarded as equal to the
+symmetric group on <C>1</C>, <C>2</C>, <C>3</C>, <C>4</C>.
+Note that the latter approach would have the advantage that it is
+no problem to construct permutations and permutation groups acting on
+arbitrary (finite) sets,
+for example by constructing first the symmetric group on the set
+and then generating any desired permutation group as a subgroup of this
+symmetric group.
+<P/>
+So one aspect concerning a reasonable choice of families is
+to make the families large enough for being able to form interesting
+domains of elements in the family.
+But on the other hand,
+it is useful to choose the families small enough for admitting
+meaningful relations between objects.
+For example, the elements of different free groups in &GAP;
+lie in different families;
+the multiplication of free group elements is installed only for the
+case that the two operands lie in the same family,
+with the effect that one cannot erroneously form the product of
+elements from different free groups.
+In this case, families appear as a tool for providing useful
+restrictions.
+<P/>
+As another example, note that an element and a collection containing
+this element never lie in the same family,
+by the general implementation of collections;
+namely, the family of a collection of elements in the family <A>Fam</A>
+is the collections family of <A>Fam</A> (see&nbsp;<Ref Attr="CollectionsFamily"/>).
+This means that for a collection, we need not (because we cannot)
+decide about its family.
+<P/>
+A few functions in &GAP; return families,
+see <Ref Attr="CollectionsFamily"/> and <Ref Attr="ElementsFamily"/>.
 
 <#Include Label="FamilyObj">
+<#Include Label="NewFamily">
 
 </Section>
 
@@ -130,10 +229,11 @@ The rank of a filter can be accessed with <Ref Func="RankFilter"/>.
 <Description>
 For simple filters, an <E>incremental rank</E> is defined when the filter is
 created, see the sections about the creation of filters:
-<Ref Sect="Creating Categories"/>,
-<Ref Sect="Creating Representations"/>,
-<Ref Sect="Creating Attributes and Properties"/>,
-<Ref Sect="Creating Other Filters"/>.
+<Ref Func="NewCategory"/>,
+<Ref Func="NewRepresentation"/>,
+<Ref Func="NewAttribute"/>,
+<Ref Func="NewProperty"/>,
+<Ref Func="NewFilter"/>.
 For an arbitrary filter, its rank is given by the sum of the incremental
 ranks of the <E>involved</E> simple filters;
 in addition to the implied filters, these are also the required filters
@@ -155,9 +255,10 @@ these are all those simple filters <C>imp</C> such that every object in
 <A>filt</A> also lies in <C>imp</C>.
 For implications between filters, see <Ref Func="ShowImpliedFilters"/>
 as well as sections&nbsp;<Ref Sect="Logical Implications"/>,
-<Ref Sect="Creating Categories"/>,
-<Ref Sect="Creating Representations"/>,
-<Ref Sect="Creating Attributes and Properties"/>.
+<Ref Func="NewCategory"/>,
+<Ref Func="NewRepresentation"/>,
+<Ref Func="NewAttribute"/>,
+<Ref Func="NewProperty"/>.
 </Description>
 </ManSection>
 
@@ -200,7 +301,6 @@ in is fixed.
 <P/>
 All categories in the library are created during initialization, in
 particular they are not created dynamically at runtime.
-For information on how to create categories, see <Ref Sect="Creating Categories"/>.
 <P/>
 The following list gives an overview of important categories of
 arithmetic objects.  Indented categories are to be understood as
@@ -291,6 +391,14 @@ inverses.
 <#Include Label="CategoriesOfObject">
 <#Include Label="CategoryByName">
 
+<#Include Label="NewCategory">
+<#Include Label="DeclareCategory">
+<#Include Label="CategoryFamily">
+
+<P/>
+
+See also <Ref Func="CategoryCollections"/>.
+
 </Section>
 
 
@@ -339,7 +447,6 @@ of characters can be converted into a string.
 <P/>
 All representations in the library are created during initialization,
 in particular they are not created dynamically at runtime.
-For information on how to create representations, see <Ref Sect="Creating Representations"/>.
 <P/>
 Examples of subrepresentations of <C>IsPositionalObjectRep</C> are
 <C>IsModulusRep</C>, which is used for residue classes in the ring of
@@ -353,6 +460,8 @@ below).
 
 <#Include Label="IsRepresentation">
 <#Include Label="RepresentationsOfObject">
+<#Include Label="NewRepresentation">
+<#Include Label="DeclareRepresentation">
 
 </Section>
 
@@ -393,7 +502,14 @@ attribute value, and just removing the value might leave the data
 structures in an inconsistent state. If necessary, a new object can be
 constructed.
 <P/>
-Several attributes have methods for more than one argument.  For example
+Each method that is installed for an attribute via <Ref Func="InstallMethod"/>
+must require exactly one argument, and this must lie in the filter
+<A>filter</A> that was entered as second argument of <Ref Func="NewAttribute"/>
+resp. <Ref Func="NewProperty"/>.
+<P/>
+As for any operation, for attributes one can install a method taking an
+argument that does not lie in <A>filt</A> via <Ref Func="InstallOtherMethod"/>,
+or a method for more than one argument. For example,
 <Ref Oper="IsTransitive" Label="for a group, an action domain, etc."/>
 is an attribute for a <M>G</M>-set that
 can also be called for the two arguments, being a group <M>G</M> and its action
@@ -402,9 +518,6 @@ return value is not stored in any of the arguments.
 <P/>
 Properties are a special form of attributes that have the value <K>true</K>
 or <K>false</K>, see section&nbsp;<Ref Sect="Properties"/>.
-<P/>
-For information on how to create attributes and properties, see
-<Ref Sect="Creating Attributes and Properties"/>.
 <P/>
 Examples of attributes for multiplicative elements are
 <Ref Attr="Inverse"/>, <Ref Attr="One"/>,
@@ -415,6 +528,8 @@ and <Ref Attr="DerivedSubgroup"/> is an attribute for groups.
 
 <#Include Label="IsAttribute">
 <#Include Label="KnownAttributesOfObject">
+<#Include Label="NewAttribute">
+<#Include Label="DeclareAttribute">
 
 </Section>
 
@@ -583,6 +698,8 @@ for all <M>a</M>, <M>b</M>, <M>c</M> in the domain.
 <#Include Label="IsProperty">
 <#Include Label="KnownPropertiesOfObject">
 <#Include Label="KnownTruePropertiesOfObject">
+<#Include Label="NewProperty">
+<#Include Label="DeclareProperty">
 
 </Section>
 
@@ -631,6 +748,19 @@ the only difference is that <A>filt</A> does not refer to an attribute value;
 note that <A>filt</A> is also used in the same way as an attribute tester;
 namely, the <K>true</K> value may be required for certain methods to be
 applicable.
+<P/>
+In order to change the value of <A>filt</A> for an object <A>obj</A>,
+one can use logical implications
+(see&nbsp;<Ref Sect="Logical Implications"/>) or
+<Ref Func="SetFilterObj"/>, <Ref Func="ResetFilterObj"/>.
+
+<#Include Label="NewFilter">
+<#Include Label="DeclareFilter">
+<#Include Label="SetFilterObj">
+<#Include Label="ResetFilterObj">
+
+<!-- %T Categories and representations should not be operations, -->
+<!-- %T the same for filters made by <C>NewFilter</C>! -->
 
 </Section>
 
@@ -661,6 +791,8 @@ The defining data of the type <A>type</A> can be accessed via
 <Ref Func="DataType"/>.
 </Description>
 </ManSection>
+
+<#Include Label="NewType">
 
 </Section>
 </Chapter>

--- a/doc/ref/xtndxmpl.xml
+++ b/doc/ref/xtndxmpl.xml
@@ -245,8 +245,7 @@ Note that the only difference between <Ref Func="DeclareCategory"/> and
 <Ref Func="NewCategory"/>
 is that in a call to <Ref Func="DeclareCategory"/>,
 a variable corresponding to the
-first argument is set to the new category, and this variable is read-only
-(see&nbsp;<Ref Sect="Global Variables in the Library"/>).
+first argument is set to the new category, and this variable is read-only.
 The same holds for <Ref Func="DeclareRepresentation"/> and
 <Ref Func="NewRepresentation"/> etc.
 <P/>

--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -303,7 +303,7 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BIND_GLOBAL( "DeclareCategoryCollections", function( name )
+BIND_GLOBAL( "NameOfCategoryCollections", function( name )
     local len, coll_name;
 
     len:= LEN_LIST( name );
@@ -317,7 +317,12 @@ BIND_GLOBAL( "DeclareCategoryCollections", function( name )
       coll_name:= SHALLOW_COPY_OBJ( name );
       APPEND_LIST_INTR( coll_name, "Collection" );
     fi;
+    return coll_name;
+end );
 
+BIND_GLOBAL( "DeclareCategoryCollections", function( name )
+    local coll_name;
+    coll_name := NameOfCategoryCollections( name );
     BIND_GLOBAL( coll_name, CategoryCollections( VALUE_GLOBAL( name ) ) );
 end );
 

--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -285,14 +285,23 @@ end );
 ##
 #f  DeclareCategoryCollections( <name> )
 ##
-##  binds the collections category of the category that is bound to the
-##  global variable with name <name> to the global variable associated to the
-##  name <nname>.
-##  If <name> is of the form `<initname>Collection' then <nname> is equal to
-##  `<initname>CollColl',
-##  if <name> is of the form `<initname>Coll' then <nname> is equal to
-##  `<initname>CollColl',
-##  otherwise we have <nname> equal to `<name>Collection'.
+##  <#GAPDoc Label="DeclareCategoryCollections">
+##  <ManSection>
+##  <Func Name="DeclareCategoryCollections" Arg='filter'/>
+##
+##  <Description>
+##  Calls <Ref Func="CategoryCollections"/> on the category that is bound to
+##  the global variable with name <A>name</A> to obtain its collections
+##  category, and binds the latter to the global variable with name
+##  <C>nname</C>. This name is defined as follows: If <A>name</A> is of the
+##  form <C><A>Something</A>Collection</C> then <C>nname</C> is set to
+##  <C><A>Something</A>CollColl</C>, if <A>name</A> is of the form
+##  <C><A>Something</A>Coll</C> then <C>nname</C> is set to
+##  <C><A>Something</A>CollColl</C>, otherwise we set <C>nname</C> to
+##  <C><A>name</A>Collection</C>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "DeclareCategoryCollections", function( name )
     local len, coll_name;

--- a/lib/domain.gd
+++ b/lib/domain.gd
@@ -364,8 +364,7 @@ DeclareGlobalFunction( "InstallAccessToGenerators" );
 ##  <Ref Oper="Index" Label="for a group and its subgroup"/> 
 ##  and <C>IndexOp</C> methods
 ##  for a number of arguments different from two,
-##  with <Ref Func="InstallOtherMethod"/>,
-##  see <Ref Sect="Creating Attributes and Properties"/>).
+##  with <Ref Func="InstallOtherMethod"/>, see <Ref Sect="Attributes"/>).
 ##  <P/>
 ##  The call of <Ref Func="InParentFOA"/> declares the operations and the
 ##  attribute as described above,

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -786,7 +786,7 @@ end);
 ##  course of a &GAP; session,
 ##  whenever a newly-computed Sylow subgroup is put into the list.
 ##  Therefore, this is a <E>mutable attribute</E>
-##  (see <Ref Sect="Creating Attributes and Properties"/>).
+##  (see <Ref Sect="Attributes"/>).
 ##  The list contains primes in each bound odd position and a corresponding
 ##  Sylow subgroup in the following even position.
 ##  More precisely, if

--- a/lib/type.g
+++ b/lib/type.g
@@ -455,7 +455,7 @@ fi;
 ##  of <A>cat</A>.
 ##  This is a category in which all families lie that know from their
 ##  creation that all their elements are in the category <A>cat</A>,
-##  see&nbsp;<Ref Sect="Creating Families"/>.
+##  see&nbsp;<Ref Sect="Families"/>.
 ##  <P/>
 ##  For example, a family of associative words is in the category
 ##  <C>CategoryFamily( IsAssocWord )</C>,

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-114334241"
+#define FILE_CRC  "50470712"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -6201,7 +6201,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = -114334241,
+ .crc         = 50470712,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-114334241"
+#define FILE_CRC  "50470712"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -6362,7 +6362,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = -114334241,
+ .crc         = 50470712,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,


### PR DESCRIPTION
The commit adding an explanation for constructors is stolen from @stevelinton's PR #611, albeit in slightly modified form. If this PR here is merged, I'll update PR #611 accordingly.
