### PR TITLE
Improve an AsList method for domains with stored GeneratorsOfDomain

### DIFF
--- a/lib/domain.gi
+++ b/lib/domain.gi
@@ -244,12 +244,19 @@ InstallImmediateMethod( Enumerator,
 InstallMethod( AsList,
     "for a domain with stored domain generators",
     [ IsDomain and HasGeneratorsOfDomain ],
-    D -> DuplicateFreeList( GeneratorsOfDomain( D ) ) );
+    function( D )
+        if HasIsDuplicateFreeList( GeneratorsOfDomain( D ) )
+                and IsDuplicateFreeList( GeneratorsOfDomain( D ) ) then
+            return GeneratorsOfDomain( D );
+        else
+            return DuplicateFreeList( GeneratorsOfDomain( D ) );
+        fi;
+    end );
 
 InstallMethod( Enumerator,
     "for a domain with stored domain generators",
     [ IsDomain and HasGeneratorsOfDomain ],
-    D -> DuplicateFreeList( GeneratorsOfDomain( D ) ) );
+    AsList );
 
 
 #############################################################################

--- a/tst/testinstall/domain.tst
+++ b/tst/testinstall/domain.tst
@@ -27,5 +27,21 @@ Domain([ 1 .. 5 ])
 gap> Domain(FamilyObj(1), []);
 Domain([  ])
 
+# AsList and Enumerator for domains which know their GeneratorsOfDomain
+gap> r := Immutable([1..3]);;
+gap> d := Domain(r);;
+gap> IsIdenticalObj(AsList(d), r);
+true
+gap> IsIdenticalObj(Enumerator(d), r);
+true
+gap> r := Immutable([1,2,3,1]);;
+gap> d := Domain(r);;
+gap> IsIdenticalObj(GeneratorsOfDomain(d), r);
+true
+gap> IsIdenticalObj(AsList(d), r);
+false
+gap> IsIdenticalObj(Enumerator(d), r);
+false
+
 #
 gap> STOP_TEST("domain.tst");


### PR DESCRIPTION
The new method ensures that no copy of GeneratorsOfDomain is created if
GeneratorsOfDomain already is a duplicate free list.