### PR TITLE
Fix #3474  wrong result from \< for equal but not identical large integers

### DIFF
--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -1,6 +1,6 @@
 #@local POWERMODINT_GAP,b,bigPos,bigNeg,checkPValuationInt,data,dataHex
 #@local dataInv,dataNonZero,e,f,g,i,k,m,mysource,pow,r,smlNeg,smlPos,x,y
-#@local naivQM,ps,checkROOT_INT,P,a,n,p
+#@local naivQM,ps,checkROOT_INT,P,a,n,p,x1,x2
 gap> START_TEST("intarith.tst");
 gap> 1 + 1;
 2
@@ -69,6 +69,18 @@ gap> List(data, x -> smlPos = x);
 [ false, false, false, false, false, false, true, false, false ]
 gap> List(data, x -> bigPos = x);
 [ false, false, false, false, false, false, false, true, false ]
+
+# Check for < on equal, but not identical large numbers
+# See issue #3474
+gap> x1 := 2^80;; x2 := 2^80;;
+gap> x1 < x2;
+false
+gap> x1 = x2;
+true
+gap> -x1 < -x2;
+false
+gap> -x1 = -x2;
+true
 
 # check symmetry
 gap> ForAll(data, x -> ForAll(data, y -> (x=y) = (y=x)));


### PR DESCRIPTION
# Description
Fix issue #3474 with \< for equal but not identical large integers

## Text for release notes 
This release fixes a **dangerous** bug in the comparison of large negative integers. If 'x' and 'y' are
equal, but not identical, large negative numbers then `x < y` returned `true` instead of `false`. This error was introduced in GAP 4.10.1 on ????? 

## Further details

Also introduces tests.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

