### PR TITLE
Fix \< for equal but not identical large integers

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -1199,18 +1199,18 @@ Int LtInt(Obj opL, Obj opR)
 
     /* signs are equal; compare sizes and absolute values */
     if (SIZE_INT(opL) < SIZE_INT(opR))
-        res = 1;
+        res = -1;
     else if (SIZE_INT(opL) > SIZE_INT(opR))
-        res = 0;
+        res = +1;
     else
         res = mpn_cmp((mp_srcptr)CONST_ADDR_INT(opL),
-                      (mp_srcptr)CONST_ADDR_INT(opR), SIZE_INT(opL)) < 0;
+                      (mp_srcptr)CONST_ADDR_INT(opR), SIZE_INT(opL));
 
     /* if both arguments are negative, flip the result */
     if (IS_INTNEG(opL))
-        res = !res;
+        res = -res;
 
-    return res;
+    return res < 0;
 }
 
 

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -1,6 +1,6 @@
 #@local POWERMODINT_GAP,b,bigPos,bigNeg,checkPValuationInt,data,dataHex
 #@local dataInv,dataNonZero,e,f,g,i,k,m,mysource,pow,r,smlNeg,smlPos,x,y
-#@local naivQM,ps,checkROOT_INT,P,a,n,p
+#@local naivQM,ps,checkROOT_INT,P,a,n,p,x1,x2
 gap> START_TEST("intarith.tst");
 gap> 1 + 1;
 2
@@ -69,6 +69,18 @@ gap> List(data, x -> smlPos = x);
 [ false, false, false, false, false, false, true, false, false ]
 gap> List(data, x -> bigPos = x);
 [ false, false, false, false, false, false, false, true, false ]
+
+# Check for < on equal, but not identical large numbers
+# See issue #3474
+gap> x1 := 2^80;; x2 := 2^80;;
+gap> x1 < x2;
+false
+gap> x1 = x2;
+true
+gap> -x1 < -x2;
+false
+gap> -x1 = -x2;
+true
 
 # check symmetry
 gap> ForAll(data, x -> ForAll(data, y -> (x=y) = (y=x)));


### PR DESCRIPTION
This is an alternative to PR #3476 which changes less code, which reduces the risk of further regressions.

Fixes #3474 
Closes #3476

I have another PR which also simplifies `EqInt` further, but since that bears again a risk of regressions, I'll submit it separately.