### PR TITLE
BuildPackages.sh: "make clean" before full build

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -168,7 +168,10 @@ run_configure_and_make() {
     if grep Autoconf ./configure > /dev/null
     then
       echo_run ./configure --with-gaproot="$GAPROOT" $CONFIGFLAGS
+      echo_run "$MAKE" clean
     else
+      echo_run ./configure "$GAPROOT"
+      echo_run "$MAKE" clean
       echo_run ./configure "$GAPROOT"
     fi
     echo_run "$MAKE"


### PR DESCRIPTION
This way, if a user re-runs BuildPackages.sh in order to re-build packages,
there is a higher chance that this works as expected, instead of mixing old
compilation results with new ones.

For GAP packages with non-autoconf based build systems, we re-run configure
after the `make clean`, as for many of them, the latter removes their
generated Makefile (in violation of well-established UNIX conventions).
