### PR TITLE
Close streams which are created in PrintCSV

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -943,12 +943,14 @@ local nohead,file,sep,f, line, fields, l, r, i,s,t,add,dir;
 end);
 
 InstallGlobalFunction(PrintCSV,function(arg)
-  local stream,l,printEntry, rf, r, i, j, oldStreamFormattingStatus;
+  local stream,l,printEntry, rf, r, i, j, oldStreamFormattingStatus, close;
 
   if IsString(arg[1]) then
     stream:=OutputTextFile(arg[1],false);
+    close:=true;
   elif IsOutputStream(arg[1]) then
     stream:=arg[1];
+    close:=false;
   else
     Error("PrintCSV: filename must be a string or an output stream");
   fi;
@@ -1045,6 +1047,9 @@ InstallGlobalFunction(PrintCSV,function(arg)
     AppendTo(stream,"\n");
   od;
   SetPrintFormattingStatus(stream,oldStreamFormattingStatus);
+  if close then
+    CloseStream(stream);
+  fi;
 end);
 
 

--- a/tst/testinstall/stringobj.tst
+++ b/tst/testinstall/stringobj.tst
@@ -3,7 +3,7 @@
 ##  This file tests various aspects of strings in IsStringRep
 ##
 #@local OldCopyToStringRep,a2000,a3000,at2000,at3000,cp1,cp2,cp3
-#@local ret2000,ret3000,s,tmp,tmpdir,fname,dir,filename,sstream,fstream,t,u
+#@local ret2000,ret3000,s,tmp,tmpdir,fname,dir,filename,sstream,fstream,t,u,i
 gap> START_TEST("stringobj.tst");
 
 # RemoveCharacters
@@ -119,10 +119,13 @@ gap> s := ReadCSV( filename{[1..Length(filename)-4]}, ";" );
 [ rec( f := 2, f1 := 1, f_2 := 3 ), rec( f1 := 4, f_2 := 6 ), rec( f1 := 7 ), 
   rec( f := 11, f_2 := 12 ), rec( f := "yy", f1 := "x", f_2 := "zzz" ) ]
 gap> tmpdir := DirectoryTemporary();;
-gap> fname := Filename(tmpdir, "output.csv");;
-gap> PrintCSV( fname, s );
-gap> s = ReadCSV( fname );
-true
+
+# Output many CSVs, to check we correctly close streams
+gap> for i in [1..1000] do
+>   fname := Filename(tmpdir, "output.csv");;
+>   PrintCSV( fname, s );
+>   if s <> ReadCSV( fname ) then Print("failed loop", i,"\n"); fi;
+> od;
 gap> s[2].emil:="\"Alas, poor Yorick\", the call went";;
 gap> s[3].empty:="";;
 gap> PrintCSV(fname,s);


### PR DESCRIPTION
Code which calls PrintCSV many times with a filename will eventually start failing, as PrintCSV did not close files after it was finished with them.