### PR TITLE
Switch from 2GB memory space to 3/4 of physical memory

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -1063,6 +1063,14 @@ void InitSystem (
 #ifdef SYS_IS_64_BIT
     SyStorMin = 128 * 1024L;
     SyStorMax = 2048*1024L;          /* This is in kB! */
+#if defined(HAVE_SYSCONF)
+#if defined(_SC_PAGESIZE) && defined(_SC_PHYS_PAGES)
+    // Set to 3/4 of memory size (in kB), if this is larger
+    Int SyStorMaxFromMem =
+        (sysconf(_SC_PAGESIZE) * sysconf(_SC_PHYS_PAGES) * 3L) / 4 / 1024;
+    SyStorMax = SyStorMaxFromMem > SyStorMax ? SyStorMaxFromMem : SyStorMax;
+#endif
+#endif
     SyAllocPool = 4096L*1024*1024;   /* Note this is in bytes! */
 #else
     SyStorMin = 64 * 1024L;

--- a/tst/testspecial/run_gap.sh
+++ b/tst/testspecial/run_gap.sh
@@ -12,8 +12,9 @@ gfile="$2"
 # 2) Combine stderr and stdout
 # 3) Rewrite the root of gap with the string GAPROOT,
 #    so the output is usable on other machines
+# 4) Set lower and upper memory limits, for consistency
 GAPROOT=$(cd ../..; pwd)
 ( echo "LogTo(\"${outfile}.tmp\");" ; cat "$gfile" ; echo "QUIT;" ) |
-    "$gap" -r -A -b -x 800 2>/dev/null >/dev/null
+    "$gap" -r -A -b -m 256m -o 512m -x 800 2>/dev/null >/dev/null
 sed "s:${GAPROOT//:/\\:}:GAPROOT:g" < "${outfile}.tmp"
 rm "${outfile}.tmp"


### PR DESCRIPTION
The current 2GB memory limit was set in 2012, and memory has grown since then.

On 64-bit OSes, this switches to a default of 3/4 of physical memory, or 2GB, whichever is larger. 32-bit OSes are left at their previous 1GB (just because I don't want to think about issues of filling up the memory space on 32-bit OSes, and most people won't be using them any more).

Tested on linux, mac and cygwin.


For release notes:

* Changed the pre-set memory limit default from 2GB to 3/4 of physical memory. Use the '-o' option if you want to change this limit.