### PR TITLE
Fix a "method not found" error in `SubdirectProduct`

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -544,6 +544,11 @@ local gc,hc,S,info;
   fi;
   gh:=InverseGeneralMapping(gc)*gh;
   hh:=InverseGeneralMapping(hc)*hh;
+  # the ...Op is installed for `IsGroupHomomorphism'. So we have to enforce
+  # the filter to be set.
+  if not IsGroupHomomorphism(gh) or not IsGroupHomomorphism(hh) then
+    Error("mappings are not homomorphisms");
+  fi;
   S:=SubdirectProductOp(Image(gc,G),Image(hc,H),gh,hh);
   info:=rec(groups:=[G,H],
 	    homomorphisms:=[gh,hh],

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -4187,6 +4187,8 @@ local s, a, hom;
   hom:=EpimorphismSolvableQuotient(G,s);
   if Size(Image(hom))<>s then
     Error("group is not solvable");
+  else
+    SetIsInjective(hom, true);
   fi;
   if a<>fail then
     hom:=a*hom;

--- a/tst/testinstall/opers/SubdirectProduct.tst
+++ b/tst/testinstall/opers/SubdirectProduct.tst
@@ -1,0 +1,26 @@
+gap> START_TEST("SubdirectProduct.tst");
+gap> f:=FreeGroup("a", "b");;
+gap> g:=f/[ f.1^6, f.2^4, f.1^3*f.2^(-2), f.2^(-1)*f.1*f.2*f.1];;
+gap> Size(g);
+12
+gap> g0:=Subgroup(g, [g.1^2]);;
+gap> g1:=g/g0;;
+gap> ff:=FreeGroup("c");;
+gap> h:=ff/[ff.1^12];;
+gap> Size(h);
+12
+gap> h0:=Subgroup(h,[h.1^4]);;
+gap> h1:=h/h0;;
+gap> ng:=NaturalHomomorphismByNormalSubgroup(g,g0);;
+gap> nh:=NaturalHomomorphismByNormalSubgroup(h,h0);;
+gap> phi:=IsomorphismGroups(g1,h1);;
+gap> ghom:=CompositionMapping(phi, ng);;
+gap> hhom:=nh;;
+gap> nn:=SubdirectProduct(g,h,ghom,hhom);;
+gap> Size(nn);
+36
+gap> Projection(nn,1);
+[ f1, f2, f3, f4 ] -> [ b, a^9, a^4, <identity ...> ]
+gap> Projection(nn,2);
+[ f1, f2, f3, f4 ] -> [ c^9, c^6, <identity ...>, c^4 ]
+gap> STOP_TEST("SubdirectProduct.tst", 10000);


### PR DESCRIPTION
This is an alternative to PR #3437, with a less invasive change, which IMHO makes it more appropriate for backporting to GAP 4.10. The remaining changes in PR #3437 could of course still be added to GAP 4.11, although I remain somewhat sceptical about that.

Fixes #3431