### PR TITLE
Fix 'make testlibgap'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,9 +90,8 @@ doc/gapmacrodoc.idx
 /libgap.la
 .libs/
 
+/tst/testlibgap/api
 /tst/testlibgap/basic
-/tst/testlibgap/basic.out
 /tst/testlibgap/wscreate
-/tst/testlibgap/wscreate.out
 /tst/testlibgap/wsload
-/tst/testlibgap/wsload.out
+/tst/testlibgap/*.out

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1086,9 +1086,9 @@ clean-testlibgap:
 # run all the tests in tst/testlibgap
 testlibgap: ${LIBGAPTESTS}
 	$(foreach v,$^, \
-		echo "Running $(v) ..." ; \
-		$(v) -A -l $(top_srcdir) -q -T --nointeract >$(v).out ; \
-		diff $(top_srcdir)/$(v).expect $(v).out ; )
+		echo "Running $(v) ..." && \
+		$(v) -A -l $(top_srcdir) -q -T --nointeract >$(v).out && \
+		diff $(top_srcdir)/$(v).expect $(v).out && ) :
 
 .PHONY: testlibgap
 

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -248,7 +248,7 @@ Obj GAP_CallFuncList(Obj func, Obj args);
 
 // Call the GAP object <func> as a function with arguments given
 // as an array <args> with <narg> entries.
-extern Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[]);
+Obj GAP_CallFuncArray(Obj func, UInt narg, Obj args[]);
 
 
 ////

--- a/tst/testlibgap/api.c
+++ b/tst/testlibgap/api.c
@@ -183,7 +183,7 @@ int main(int argc, char ** argv)
     operations();
     printf("success\n");
 
-    printf("# Testing global variables...");
+    printf("# Testing global variables... ");
     globalvars();
     printf("success\n");
 


### PR DESCRIPTION
- fix Makefile rules so that an error in testlibgap actually fails the build
- fix a failure in testlibgap

Also, mostly unrelated, remove one leftover use of `extern` in libgap-api.h

Once this is in, I have a PR ready which backports all recent libgap changes to `stable-4.10`.