### PR TITLE
kernel: remove C_NEW_STRING_DYN and MakeImmutableString, deprecate C_NEW_STRING

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -192,7 +192,7 @@ Obj GET_FILENAME_BODY(Obj body)
 void SET_FILENAME_BODY(Obj body, Obj val)
 {
     GAP_ASSERT(IS_STRING_REP(val));
-    MakeImmutableString(val);
+    MakeImmutable(val);
     BODY_HEADER(body)->filename_or_id = val;
 }
 
@@ -220,7 +220,7 @@ Obj GET_LOCATION_BODY(Obj body)
 void SET_LOCATION_BODY(Obj body, Obj val)
 {
     GAP_ASSERT(IS_STRING_REP(val));
-    MakeImmutableString(val);
+    MakeImmutable(val);
     BODY_HEADER(body)->startline_or_location = val;
 }
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -394,7 +394,7 @@ void AssGVarWithoutReadOnlyCheck(UInt gvar, Obj val)
 #endif
     if ( val != 0 && TNUM_OBJ(val) == T_FUNCTION && NAME_FUNC(val) == 0 ) {
         onam = CopyToStringRep(NameGVar(gvar));
-        MakeImmutableString(onam);
+        MakeImmutable(onam);
         SET_NAME_FUNC(val, onam);
         CHANGED_BAG(val);
     }

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -302,7 +302,7 @@ static Obj MakeImmString2(const Char * cstr1, const Char * cstr2)
     result = NEW_STRING(len1 + len2);
     memcpy(CSTR_STRING(result), cstr1, len1);
     memcpy(CSTR_STRING(result) + len1, cstr2, len2);
-    MakeImmutableString(result);
+    MakeImmutableNoRecurse(result);
     return result;
 }
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -2605,7 +2605,7 @@ static Obj WRAP_NAME(Obj name, const char *addon)
     ptr += name_len;
     *ptr++ = ')';
     *ptr = 0;
-    MakeImmutableString(fname);
+    MakeImmutable(fname);
     return fname;
 }
 
@@ -2622,7 +2622,7 @@ static Obj PREFIX_NAME(Obj name, const char *prefix)
     memcpy( ptr, CONST_CSTR_STRING(name), name_len );
     ptr += name_len;
     *ptr = 0;
-    MakeImmutableString(fname);
+    MakeImmutable(fname);
     return fname;
 }
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -1197,7 +1197,7 @@ Obj ImmutableString(Obj string)
 {
     if (!IS_STRING_REP(string) || IS_MUTABLE_OBJ(string)) {
         string = CopyToStringRep(string);
-        MakeImmutableString(string);
+        MakeImmutableNoRecurse(string);
     }
     return string;
 }
@@ -2116,9 +2116,9 @@ static Int InitKernel (
            UnbListFuncs    [ t1            ] = UnbString;
     }
 
-    MakeImmutableObjFuncs[ T_STRING       ] = MakeImmutableString;
-    MakeImmutableObjFuncs[ T_STRING_SSORT ] = MakeImmutableString;
-    MakeImmutableObjFuncs[ T_STRING_NSORT ] = MakeImmutableString;
+    MakeImmutableObjFuncs[ T_STRING       ] = MakeImmutableNoRecurse;
+    MakeImmutableObjFuncs[ T_STRING_SSORT ] = MakeImmutableNoRecurse;
+    MakeImmutableObjFuncs[ T_STRING_NSORT ] = MakeImmutableNoRecurse;
 
     /* return success                                                      */
     return 0;

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -325,16 +325,6 @@ void ConvString(Obj string);
 Int IsStringConv(Obj obj);
 
 
-/****************************************************************************
-**
-*F  MakeImmutableString( <str> ) . . . . . . make a string immutable in place
-*/
-EXPORT_INLINE void MakeImmutableString(Obj str)
-{
-    MakeImmutableNoRecurse(str);
-}
-
-
 // Functions to create mutable and immutable GAP strings from C strings.
 // MakeString and MakeImmString are inlineable so 'strlen' can be optimised
 // away for constant strings.
@@ -354,14 +344,14 @@ EXPORT_INLINE Obj MakeString(const char * cstr)
 EXPORT_INLINE Obj MakeImmString(const char * cstr)
 {
     Obj result = MakeString(cstr);
-    MakeImmutableString(result);
+    MakeImmutableNoRecurse(result);
     return result;
 }
 
 EXPORT_INLINE Obj MakeImmStringWithLen(const char * buf, size_t len)
 {
     Obj result = MakeStringWithLen(buf, len);
-    MakeImmutableString(result);
+    MakeImmutableNoRecurse(result);
     return result;
 }
 

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -369,6 +369,10 @@ EXPORT_INLINE Obj MakeImmStringWithLen(const char * buf, size_t len)
 /****************************************************************************
 **
 *F  C_NEW_STRING( <string>, <len>, <cstring> )  . . . . . . create GAP string
+**
+**  This macro is deprecated and only provided for backwards compatibility
+**  with some package kernel extensions. Use 'MakeStringWithLen' and
+**  'MakeImmStringWithLen' instead.
 */
 #define C_NEW_STRING(string,len,cstr) \
     string = MakeStringWithLen( (cstr), (len) )

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -376,21 +376,6 @@ EXPORT_INLINE Obj MakeImmStringWithLen(const char * buf, size_t len)
 
 /****************************************************************************
 **
-*F  C_NEW_STRING_DYN( <string>, <cstring> ) . . . . . . . . create GAP string
-**
-**  The cstring is assumed to be allocated on the heap, hence its length
-**  is dynamic and must be computed during runtime using strlen.
-**
-**  This macro is provided for backwards compatibility of packages.
-**  'MakeString' and 'MakeImmString' are as efficient and should be used
-**  instead.
-*/
-#define C_NEW_STRING_DYN(string,cstr) \
-  C_NEW_STRING(string, strlen(cstr), cstr)
-
-
-/****************************************************************************
-**
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 


### PR DESCRIPTION
The only reason I am not outright removing `C_NEW_STRING` is that Digraphs recently started to use it; but see also https://github.com/gap-packages/Digraphs/pull/198

For details, please also refer to the commit messages.