### PR TITLE
Fix passing invalid rnams to records

### DIFF
--- a/src/records.c
+++ b/src/records.c
@@ -33,6 +33,17 @@ static Obj HashRNam;
 
 static Obj NamesRNam;
 
+/****************************************************************************
+**
+*F  IS_VALID_RNAM(<rnam>) . . . . . . . . . . . . .  check if <rnam> is valid
+**
+**  'IS_VALID_RNAM' returns if <rnam> is a valid record name.
+*/
+static Int IS_VALID_RNAM(UInt rnam)
+{
+    return rnam != 0 && rnam <= LEN_PLIST(NamesRNam);
+}
+
 extern inline Obj NAME_RNAM(UInt rnam)
 {
     return ELM_PLIST(NamesRNam, rnam);
@@ -274,6 +285,19 @@ static Obj FuncRNamObj(Obj self, Obj obj)
 
 /****************************************************************************
 **
+*F  GetValidRNam( <funcname>, <rnam> ) . check if <rnam> is a valid prec rnam
+*/
+UInt GetValidRNam(const char * funcname, Obj rnam)
+{
+    UInt val = GetPositiveSmallInt(funcname, rnam);
+    RequireArgumentCondition(funcname, rnam, IS_VALID_RNAM(val),
+                             "must be a valid rnam");
+    return val;
+}
+
+
+/****************************************************************************
+**
 *F  FuncNameRNam(<self>,<rnam>)  . . . . convert a record name to a string
 **
 **  'FuncNameRNam' implements the internal function 'NameRName'.
@@ -334,7 +358,7 @@ static Obj ElmRecOper;
 
 static Obj ElmRecHandler(Obj self, Obj rec, Obj rnam)
 {
-    return ELM_REC( rec, INT_INTOBJ(rnam) );
+    return ELM_REC(rec, GetValidRNam("Record Element", rnam));
 }
 
 static Obj ElmRecError(Obj rec, UInt rnam)
@@ -368,7 +392,8 @@ static Obj IsbRecOper;
 
 static Obj IsbRecHandler(Obj self, Obj rec, Obj rnam)
 {
-    return (ISB_REC( rec, INT_INTOBJ(rnam) ) ? True : False);
+    return (ISB_REC(rec, GetValidRNam("Record IsBound", rnam)) ? True
+                                                               : False);
 }
 
 static Int IsbRecError(Obj rec, UInt rnam)
@@ -397,7 +422,7 @@ static Obj AssRecOper;
 
 static Obj AssRecHandler(Obj self, Obj rec, Obj rnam, Obj obj)
 {
-    ASS_REC( rec, INT_INTOBJ(rnam), obj );
+    ASS_REC(rec, GetValidRNam("Record Assignment", rnam), obj);
     return 0;
 }
 
@@ -426,7 +451,7 @@ static Obj UnbRecOper;
 
 static Obj UnbRecHandler(Obj self, Obj rec, Obj rnam)
 {
-    UNB_REC( rec, INT_INTOBJ(rnam) );
+    UNB_REC(rec, GetValidRNam("Record Unbind", rnam));
     return 0;
 }
 

--- a/src/records.c
+++ b/src/records.c
@@ -300,24 +300,17 @@ UInt GetValidRNam(const char * funcname, Obj rnam)
 **
 *F  FuncNameRNam(<self>,<rnam>)  . . . . convert a record name to a string
 **
-**  'FuncNameRNam' implements the internal function 'NameRName'.
+**  'FuncNameRNam' implements the internal function 'NameRNam'.
 **
-**  'NameRName( <rnam> )'
+**  'NameRNam( <rnam> )'
 **
-**  'NameRName' returns the string corresponding to the record name <rnam>.
+**  'NameRNam' returns the string corresponding to the record name <rnam>.
 */
 static Obj FuncNameRNam(Obj self, Obj rnam)
 {
-    Obj                 name;
-    Obj                 oname;
-    const UInt          countRNam = LEN_PLIST(NamesRNam);
-    Int                 inam = GetPositiveSmallInt("NameRName", rnam);
-    if (countRNam < inam) {
-        ErrorMayQuit("NameRName: <rnam> is not a valid record name", 0, 0);
-    }
-    oname = NAME_RNAM(inam);
-    name = CopyToStringRep(oname);
-    return name;
+    Int inam = GetValidRNam("NameRNam", rnam);
+    Obj oname = NAME_RNAM(inam);
+    return CopyToStringRep(oname);
 }
 
 

--- a/tst/testinstall/kernel/records.tst
+++ b/tst/testinstall/kernel/records.tst
@@ -24,10 +24,12 @@ a boolean or fail)
 gap> ForAll([1,-1,"abc"], x -> NameRNam(RNamObj(x)) = String(x));
 true
 gap> NameRNam(-1);
-Error, NameRName: <rnam> must be a positive small integer (not the integer -1)
+Error, NameRNam: <rnam> must be a positive small integer (not the integer -1)
 gap> NameRNam(fail);
-Error, NameRName: <rnam> must be a positive small integer (not the value 'fail\
-')
+Error, NameRNam: <rnam> must be a positive small integer (not the value 'fail'\
+)
+gap> NameRNam(2^26);
+Error, NameRNam: <rnam> must be a valid rnam (not the integer 67108864)
 
 # ElmRecHandler
 gap> ELM_REC(r, RNamObj(1));

--- a/tst/testinstall/recordname.tst
+++ b/tst/testinstall/recordname.tst
@@ -71,4 +71,99 @@ Syntax error: Identifiers in GAP must consist of at most 1023 characters. in s\
 tream:2
 aaaxyz := 1; # 1024 chars
  ^^^^^
+
+##
+gap> r := rec(y := 2);
+rec( y := 2 )
+gap> \.(r, RNamObj("y"));
+2
+gap> \.(r, RNamObj("x"));
+Error, Record Element: '<rec>.x' must have an assigned value
+gap> \.(r, 0);
+Error, Record Element: <rnam> must be a positive small integer (not the intege\
+r 0)
+gap> \.(r, -1);
+Error, Record Element: <rnam> must be a positive small integer (not the intege\
+r -1)
+gap> \.(r, 2^1000);
+Error, Record Element: <rnam> must be a positive small integer (not a large po\
+sitive integer)
+gap> \.(r, "a");
+Error, Record Element: <rnam> must be a positive small integer (not a list (st\
+ring))
+gap> \.(r, 1000000);
+Error, Record Element: <rnam> must be a valid rnam (not the integer 1000000)
+
+##
+gap> IsBound\.(r, RNamObj("y"));
+true
+gap> IsBound\.(r, RNamObj("x"));
+false
+gap> IsBound\.(r, 0);
+Error, Record IsBound: <rnam> must be a positive small integer (not the intege\
+r 0)
+gap> IsBound\.(r, -1);
+Error, Record IsBound: <rnam> must be a positive small integer (not the intege\
+r -1)
+gap> IsBound\.(r, 2^1000);
+Error, Record IsBound: <rnam> must be a positive small integer (not a large po\
+sitive integer)
+gap> IsBound\.(r, "a");
+Error, Record IsBound: <rnam> must be a positive small integer (not a list (st\
+ring))
+gap> IsBound\.(r, 1000000);
+Error, Record IsBound: <rnam> must be a valid rnam (not the integer 1000000)
+
+##
+gap> r;
+rec( y := 2 )
+gap> Unbind\.(r, RNamObj("y"));
+gap> r;
+rec(  )
+gap> Unbind\.(r, RNamObj("y"));
+gap> r;
+rec(  )
+gap> Unbind\.(r, RNamObj("x"));
+gap> Unbind\.(r, 0);
+Error, Record Unbind: <rnam> must be a positive small integer (not the integer\
+ 0)
+gap> Unbind\.(r, -1);
+Error, Record Unbind: <rnam> must be a positive small integer (not the integer\
+ -1)
+gap> Unbind\.(r, 2^1000);
+Error, Record Unbind: <rnam> must be a positive small integer (not a large pos\
+itive integer)
+gap> Unbind\.(r, "a");
+Error, Record Unbind: <rnam> must be a positive small integer (not a list (str\
+ing))
+gap> Unbind\.(r, 1000000);
+Error, Record Unbind: <rnam> must be a valid rnam (not the integer 1000000)
+
+##
+gap> r;
+rec(  )
+gap> \.\:\=(r,RNamObj("y"), 2);
+gap> r;
+rec( y := 2 )
+gap> \.\:\=(r,RNamObj("y"), 4);
+gap> r;
+rec( y := 4 )
+gap> \.\:\=(r,RNamObj("x"), 5);
+gap> r;
+rec( x := 5, y := 4 )
+gap> \.\:\=(r, 0, 1);
+Error, Record Assignment: <rnam> must be a positive small integer (not the int\
+eger 0)
+gap> \.\:\=(r, -1, 1);
+Error, Record Assignment: <rnam> must be a positive small integer (not the int\
+eger -1)
+gap> \.\:\=(r, 2^1000, 1);
+Error, Record Assignment: <rnam> must be a positive small integer (not a large\
+ positive integer)
+gap> \.\:\=(r, "a", 1);
+Error, Record Assignment: <rnam> must be a positive small integer (not a list \
+(string))
+gap> \.\:\=(r, 1000000, 1);
+Error, Record Assignment: <rnam> must be a valid rnam (not the integer 1000000\
+)
 gap> STOP_TEST( "recordname.tst", 1);


### PR DESCRIPTION
Fixes #3489 

This could be backported to 4.10, but seeing how long it has been around for, I don't think that is required.

## Text for release notes

Fix crashes when passing invalid arguments to functions for records: \\., IsBound\\., Unbind\\. and \\.\\:\\=

