### PR TITLE
Two small cleanups

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -397,16 +397,6 @@ CallAndInstallPostRestore( function()
     MakeImmutable( CommandLineOptions );
     MakeImmutable( InitFiles );
 
-    if CommandLineOptions.L = "" or CommandLineOptions.R then
-      # start without a workspace
-      GAPInfo.CommandLineOptionsPrev:= [];
-      GAPInfo.InitFilesPrev:= [];
-    else
-      # start with a workspace
-      ADD_LIST_DEFAULT( GAPInfo.CommandLineOptionsPrev,
-                        GAPInfo.CommandLineOptions );
-      ADD_LIST_DEFAULT( GAPInfo.InitFilesPrev, GAPInfo.InitFiles );
-    fi;
     GAPInfo.CommandLineOptions:= CommandLineOptions;
     GAPInfo.InitFiles:= InitFiles;
 

--- a/tst/testbugfix/2017-10-20-runprocess.tst
+++ b/tst/testbugfix/2017-10-20-runprocess.tst
@@ -24,7 +24,7 @@ gap> func1 := function()
 >  end;;
 gap>  for i in [1..1000] do func1(); od;
 
-# Here we might only get part of the line
+# Here we might only get part of the line, or fail
 # This is mainly to check we kill the process when it still has output
 gap> func2 := function()
 >    local line,s;
@@ -35,7 +35,9 @@ gap> func2 := function()
 >      fi;
 >      SetPrintFormattingStatus(s,false);
 >      AppendTo(s,"The cat sat on the mat\n");
->      if not StartsWith("The cat sat on the mat\n", ReadLine(s)) then
+>      AppendTo(s,"The cat sat on the mat\n");
+>      line := ReadLine(s);
+>      if line <> fail and not StartsWith("The cat sat on the mat\n", line) then
 >        Print( "There is a problem concerning a cat on a mat.\n" );
 >      fi;
 >      CloseStream(s);

--- a/tst/testbugfix/2017-10-20-runprocess.tst
+++ b/tst/testbugfix/2017-10-20-runprocess.tst
@@ -2,7 +2,7 @@
 # We want to check two cases:
 # Firstly we ensure we read a whole line, by using a while loop
 gap> d := DirectoryCurrent();;
-gap> f := Filename(DirectoriesSystemPrograms(), "rev");;
+gap> f := Filename(DirectoriesSystemPrograms(), "cat");;
 gap> func1 := function()
 >    local line,s;
 >    if f <> fail then
@@ -16,7 +16,7 @@ gap> func1 := function()
 >      while line[Length(line)] <> '\n' do
 >        line := Concatenation(line, ReadLine(s));
 >      od;
->      if line <> "tam eht no tas tac ehT\n" then
+>      if line <> "The cat sat on the mat\n" then
 >        Print( "There is a problem concerning a cat on a mat.\n" );
 >      fi;
 >      CloseStream(s);
@@ -35,7 +35,7 @@ gap> func2 := function()
 >      fi;
 >      SetPrintFormattingStatus(s,false);
 >      AppendTo(s,"The cat sat on the mat\n");
->      if not StartsWith("tam eht no tas tac ehT\n", ReadLine(s)) then
+>      if not StartsWith("The cat sat on the mat\n", ReadLine(s)) then
 >        Print( "There is a problem concerning a cat on a mat.\n" );
 >      fi;
 >      CloseStream(s);


### PR DESCRIPTION
* Use `cat` instead of `rev` in a test, as `rev` sometimes crashes (due to a bug in some versions of `rev`).

* Remove two members of GAPInfo which have never been used since their introduction