### PR TITLE
FIX: Maximal subgroups will work also if no tomlib available

### DIFF
--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3149,7 +3149,7 @@ local act,offset,G,lim,cond,dosub,all,m,i,j,new,old;
     new:=[];
     for j in m do
       if dosub(j) then
-	m:=MaximalSubgroupClassReps(j);
+	m:=MaximalSubgroupClassReps(j:cheap:=false);
 	Append(new,m);
       fi;
     od;

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -548,7 +548,7 @@ end);
 
 InstallMethod(MaxesAlmostSimple,"table of marks and linear",true,[IsGroup],0,
 function(G)
-local m,id,epi;
+local m,id,epi,H;
 
   # does the table of marks have it?
   m:=TomDataMaxesAlmostSimple(G);
@@ -559,6 +559,11 @@ local m,id,epi;
     id:=DataAboutSimpleGroup(G);
     if id.idSimple.series="A" then
       Info(InfoPerformance,1,"Alternating recognition needed!");
+      H:=AlternatingGroup(id.idSimple.parameter);
+      m:=MaximalSubgroupClassReps(H); # library, natural
+      epi:=IsomorphismGroups(G,H);
+      m:=List(m,x->PreImage(epi,x));
+      return m;
     elif id.idSimple.series="L" then
       m:=ClassicalMaximals("L",id.idSimple.parameter[1],id.idSimple.parameter[2]);
       if m<>fail then

--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -295,8 +295,8 @@ DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
 ##  [ F1, F2, F3, F4, F5, F6, m1, m2, m3, m4 ]>
 ##  gap> g2:=Image(IsomorphismPermGroup(p));
 ##  <permutation group with 10 generators>
-##  gap> List(MaximalSubgroupClassReps(g1),Size);
-##  [ 480, 480, 480, 19440, 3888, 7776, 6480 ]
+##  gap> Collected(List(MaximalSubgroupClassReps(g1),Size));
+##  [ [ 480, 3 ], [ 3888, 1 ], [ 6480, 1 ], [ 7776, 1 ], [ 19440, 1 ] ]
 ##  gap> Collected(List(MaximalSubgroupClassReps(g2),Size));
 ##  [ [ 3888, 1 ], [ 6480, 1 ], [ 7776, 1 ], [ 19440, 1 ] ]
 ##  ]]></Example>

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -264,8 +264,8 @@ gap> p:=List(e,x->FpGroupCocycle(coh,x,true));;
 gap> Length(p);
 4
 gap> p:=List(p,x->Image(IsomorphismPermGroup(x)));
-[ <permutation group with 13 generators>,
-  <permutation group with 13 generators>,
-  <permutation group with 13 generators>,
+[ <permutation group with 13 generators>, 
+  <permutation group with 13 generators>, 
+  <permutation group with 13 generators>, 
   <permutation group with 13 generators> ]
 gap> STOP_TEST( "grpperm.tst", 1);


### PR DESCRIPTION
This extracts a commit from PR #3494 by @hulpke

Fixes #3498