### PR TITLE
HPC-GAP: Allow configuration of TLS and improve native TLS performance on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,8 @@ AX_GCC_FUNC_ATTRIBUTE([always_inline])
 AX_GCC_FUNC_ATTRIBUTE([format])
 AX_GCC_FUNC_ATTRIBUTE([noinline])
 AX_GCC_FUNC_ATTRIBUTE([noreturn])
+AX_GCC_FUNC_ATTRIBUTE([constructor])
+AX_GCC_FUNC_ATTRIBUTE([pure])
 
 dnl compiler builtins
 AC_DEFUN([CHECK_COMPILER_BUILTIN],
@@ -201,6 +203,135 @@ AS_CASE([$with_gc],
     [*],        [AC_MSG_ERROR([Invalid gc method '$with_gc', use default|none|gasman|boehm|julia])],
     )
 AC_MSG_RESULT([$with_gc])
+
+dnl
+dnl User setting: native thread-local storage (off by default)
+dnl See src/hpc/tls.h for more details on thread-local storage options.
+dnl
+
+AC_ARG_ENABLE([native-tls],
+    [AS_HELP_STRING([--enable-native-tls],
+        [use native thread-local storage implementation])],
+        [enable_native_tls=$enableval],
+        [enable_native_tls=no])
+AC_MSG_CHECKING([whether to use native tls])
+dnl
+dnl Distinguish between cases where we support __thread declarations
+dnl and situations where we use a pthread_getspecific() implementation.
+dnl Right now, we only do the latter for 64-bit macOS. See src/hpc/tls.h
+dnl for details.
+dnl
+enable_macos_tls_asm=default
+AS_IF([[test "x$enable_native_tls" == "xyes"]], [
+        case "$host" in
+            x86_64-apple-darwin*)
+                AC_DEFINE([USE_PTHREAD_TLS], [1], [define as 1 if using pthread_getspecific])
+                dnl
+                dnl Test if we can optimize pthread_getspecific() calls via
+                dnl inline assembly on macOS.
+                dnl
+                AC_RUN_IFELSE(
+                    [AC_LANG_SOURCE([[
+// The following code also occurs in src/hpc/thread.c and both need to be
+// kept in sync.
+#include <pthread.h>
+#include <string.h>
+
+#define OFFS 0x100
+#define END (-1)
+
+int cmpOpCode(unsigned char *code, int *with) {
+    int result = 0;
+    while (*with >= 0) {
+        if (*with == OFFS) {
+            result = *code;
+        } else {
+            if (*code != *with)
+                return -1;
+        }
+        code++;
+        with++;
+    }
+    return result;
+}
+
+int main() {
+    // This is an idea borrowed from Mono. We test if the implementation
+    // of pthread_getspecific() uses the assembly code below. If that is
+    // true, we can replace calls to pthread_getspecific() with the
+    // matching inline assembly, allowing a significant performance boost.
+#if defined(__APPLE__) && defined(__x86_64__)
+    // There are two possible implementations.
+    static int asm_code[] = {
+        // movq %gs:[OFFS](,%rdi,8), %rax
+        // retq
+        0x65, 0x48, 0x8b, 0x04, 0xfd, OFFS, 0x00, 0x00, 0x00, 0xc3, END
+    };
+    static int asm_code2[] = {
+        // pushq  %rbp
+        // movq   %rsp, %rbp
+        // movq   %gs:[OFFS](,%rdi,8),%rax
+        // popq   %rbp
+        // retq
+        0x55, 0x48, 0x89, 0xe5, 0x65, 0x48, 0x8b, 0x04, 0xfd, OFFS,
+        0x00, 0x00, 0x00, 0x5d, 0xc3, END
+    };
+    if (cmpOpCode((unsigned char *)pthread_getspecific, asm_code) >= 0) {
+        return 0;
+    }
+    if (cmpOpCode((unsigned char *)pthread_getspecific, asm_code2) >= 0) {
+        return 0;
+    }
+    return 1;
+#else
+#error FAIL
+#endif
+}
+                    ]])],
+                    dnl => Test succeeded
+                    [AC_DEFINE([USE_MACOS_PTHREAD_TLS_ASM], [1],
+                        [define as 1 if macOS assembly implementation supported])
+                    AC_MSG_RESULT([[yes (macOS assembly)]])
+                    enable_macos_tls_asm=yes
+                    ],
+                    dnl => Test failed
+                    [AC_MSG_RESULT([[yes (pthread-based)]])
+                    enable_macos_tls_asm=no
+                    ],
+                    dnl => Cross-compilation, test impossible
+                    [AC_MSG_RESULT([[yes (pthread-based)]])
+                    enable_macos_tls_asm=no
+                    ])
+            ;;
+            *)
+                dnl => Any other OS, --with-native-tls specified
+                AC_DEFINE([USE_NATIVE_TLS], [1], [define as 1 if using native TLS])
+                AC_MSG_RESULT([yes])
+            ;;
+        esac
+    ],
+    [
+        dnl => --without-native-tls
+        AC_MSG_RESULT([no])
+    ]
+)
+dnl
+dnl Test if pthread_getspecific() can be overridden as
+dnl __attribute__((pure)).
+dnl
+AC_MSG_CHECKING([[whether pthread_getspecific() can be made pure]])
+AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE([[
+#include <pthread.h>
+__attribute__((pure))
+void * pthread_getspecific(pthread_key_t key);
+]])], [
+    AC_MSG_RESULT(yes)
+    AC_DEFINE([ALLOW_PURE_PTHREAD_GETSPECIFIC], [1],
+        [define as 1 if pthread_getspecific() can be declared pure])
+], [
+    AC_MSG_RESULT(no)
+])
 
 dnl
 dnl User setting: Debug mode (off by default)

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -104,7 +104,6 @@ static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
   return bag;
 }
 
-
 static ALWAYS_INLINE int CheckReadAccess(Bag bag)
 {
   Region *region;

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -34,7 +34,7 @@
 
 extern int PreThreadCreation;
 
-#ifndef HAVE_NATIVE_TLS
+#ifndef USE_NATIVE_TLS
 void *AllocateTLS(void);
 void FreeTLS(void *address);
 #endif

--- a/src/hpc/tls.c
+++ b/src/hpc/tls.c
@@ -9,8 +9,9 @@
 */
 
 #include "gapstate.h"
+#include "hpc/thread.h"
 
-#ifdef HAVE_NATIVE_TLS
+#ifdef USE_NATIVE_TLS
 
 __thread GAPState TLSGAPtate;
 __thread ThreadLocalStorage *TLSInstance;
@@ -19,9 +20,12 @@ __thread ThreadLocalStorage *TLSInstance;
 
 void InitializeTLS(void)
 {
-#ifdef HAVE_NATIVE_TLS
+#ifdef USE_NATIVE_TLS
     // FIXME: is this the right place to do this?
     TLSInstance = &(TLSGAPtate.tls);
+#endif
+#ifdef USE_PTHREAD_TLS
+    AllocateTLS();
 #endif
     memset(ActiveGAPState(), 0, sizeof(GAPState));
 }

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -17,6 +17,49 @@
 #error This header is only meant to be used with HPC-GAP
 #endif
 
+// This contains our implementation of thread-local storage (TLS). TLS
+// is a feature that is only to varying degrees supported by compilers
+// and operating systems. As it is critical for the performance of
+// HPC-GAP, we allow the implementation to choose between various
+// options.
+//
+// By default, we use a low-level stack-based approach. Each thread
+// stack is allocated on a memory segment whose boundaries are a
+// multiple of a fixed power of 2 (see tlsconfig.h). The pages with
+// the lowest address in that memory range are reserved for TLS,
+// the rest for the stack itself. This allows us to get the base
+// address for TLS by taking the stack or frame pointer (or any address
+// on the stack) and masking out the lowest bits. This is very fast
+// and on many platforms actually faster than global variables.
+//
+// However, this option only works when GAP is run as an application,
+// as it needs to control the creation of threads in order to force
+// thread stacks on the required boundaries. When used as a library,
+// we need a native implementation. These can be chosen by passing
+// the --enable-native-tls option to the configure script.
+//
+// By default, native TLS support will default to declaring TLS as
+// storage type __thread. This is simple, but inefficient on some
+// platforms. In particular, Cygwin and macOS require a function call
+// to a dynamically loaded library to access __thread storage, which
+// furthermore inhibits compiler optimizations.
+//
+// For these platforms, we use a different approach. As a basic
+// alternative, on platforms that support it, we use
+// pthread_getspecific() to get the base address of TLS and we
+// define pthread_getspecific() as a pure function. This is still
+// not faster than __thread by itself, but declaring
+// pthread_getspecific() as pure allows compiler optimizations such
+// as common subexpression elimination and code hoisting.
+//
+// As a further improvement, on macOS (and in the future, on Cygwin),
+// we use an assembly-based alternative implementation of
+// pthread_getspecific(). This assembly code can be treated like
+// a normal variable access. In order to check that this is safe,
+// we verify both during configuration and at runtime that the
+// assembly code for pthread_getspecific() is implemented in a way
+// consistent with such code.
+
 #include "hpc/tlsconfig.h"
 
 typedef struct Region Region;
@@ -55,28 +98,97 @@ typedef struct ThreadLocalStorage
   UInt LocksContended;
 } ThreadLocalStorage;
 
-#ifdef HAVE_NATIVE_TLS
+#ifdef USE_NATIVE_TLS
 extern __thread ThreadLocalStorage *TLSInstance;
 #endif
 
-#if defined(VERBOSE_GUARDS)
-static inline ThreadLocalStorage *GetTLS(void)
+#ifdef USE_PTHREAD_TLS
+
+#include <pthread.h>
+
+#ifdef ALLOW_PURE_PTHREAD_GETSPECIFIC
+// pthread_getspecific() is not defined as pure by default; redeclaring
+// it as such works for gcc/clang and allows the compiler to hoist calls
+// to pthread_getspecific() out of loops and perform constant
+// subexpression elimination on expressions containing TLS values.
+PURE_FUNC void * pthread_getspecific(pthread_key_t);
+#endif
+
+#ifdef USE_MACOS_PTHREAD_TLS_ASM
+static UInt TLSOffsetCopy;
+UInt GetTLSOffset(void);
 #else
-static ALWAYS_INLINE ThreadLocalStorage *GetTLS(void)
+static pthread_key_t TLSKeyCopy;
+pthread_key_t GetTLSKey(void);
+#endif
+
+// This constructor function will initialize a static variable to
+// address thread-local storage via pthread_getspecific() for each C
+// module (TLSOffset or TLSKeyCopy, depending on how thread-local
+// storage is being addressed). Making the variable static (instead of
+// having it global and initialized once) allows optimizations that a
+// global non-static variable would not permit. On some architectures,
+// it is also faster to access a static than a global non-static
+// variable, avoiding one level of indirection.
+//
+// Constructor functions are executed upon program start/library load.
+#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+#ifdef USE_MACOS_PTHREAD_TLS_ASM
+CONSTRUCTOR_FUNC static void InitTLSOffset()
+{
+    TLSOffsetCopy = GetTLSOffset();
+}
+#else
+CONSTRUCTOR_FUNC static void InitTLSKey()
+{
+    TLSKeyCopy = GetTLSKey();
+}
+#endif // USE_MACOS_PTHREAD_TLS_ASM
+#endif // HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+#endif // USE_PTHREAD_TLS
+
+#if defined(VERBOSE_GUARDS)
+static inline ThreadLocalStorage * GetTLS(void)
+#else
+static ALWAYS_INLINE ThreadLocalStorage * GetTLS(void)
 #endif
 {
-#ifdef HAVE_NATIVE_TLS
+#if defined(USE_NATIVE_TLS)
     return TLSInstance;
+#elif defined(USE_PTHREAD_TLS)
+#ifdef USE_MACOS_PTHREAD_TLS_ASM
+    long   offset;
+    void * p;
+    offset = (long)TLSOffsetCopy;
+    // The following inline assembly code is the same as that in
+    // pthread_getspecific(). That pthread_getspecific() is actually
+    // implemented in that way has been verified in the configure
+    // script and resulted in defining USE_MACOS_PTHREAD_TLS_ASM.
+    // If that test fails, we fall back to the standard implementation
+    // of pthread_getspecific().
+    asm("movq %%gs:(%1), %0"
+        : "=r"(p)  /* output = %0 */
+        : "r"(offset) /* input = %1 */
+        : /* clobber = none */);
+    return (ThreadLocalStorage *)p;
 #else
-    void *stack;
-  #ifdef __GNUC__
+#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+    return (ThreadLocalStorage *)pthread_getspecific(TLSKeyCopy);
+#else
+    return (ThreadLocalStorage *)pthread_getspecific(GetTLSKey());
+#endif
+#endif /* USE_MACOS_PTHREAD_TLS_ASM */
+#else
+    // use stack mask approach
+    void * stack;
+#ifdef __GNUC__
     stack = __builtin_frame_address(0);
-  #else
+#else
     int dummy[1];
     stack = dummy;
-  #endif
-    return (ThreadLocalStorage *) (((uintptr_t) stack) & TLS_MASK);
 #endif
+    return (ThreadLocalStorage *)(((uintptr_t)stack) & TLS_MASK);
+#endif /* USE_NATIVE_TLS, USE_PTHREAD_TLS */
 }
 
 // Convenience helper for accessing TLS members

--- a/src/hpc/tlsconfig.h
+++ b/src/hpc/tlsconfig.h
@@ -18,7 +18,7 @@
 #endif
 
 
-#ifndef HAVE_NATIVE_TLS
+#ifndef USE_NATIVE_TLS
 
 enum {
     TLS_SIZE = (sizeof(UInt) == 8) ? (1L << 20) : (1L << 18),
@@ -28,6 +28,6 @@ enum {
 GAP_STATIC_ASSERT((TLS_SIZE & (TLS_SIZE - 1)) == 0,
                   "TLS_SIZE must be a power of 2");
 
-#endif // HAVE_NATIVE_TLS
+#endif // USE_NATIVE_TLS
 
 #endif // GAP_TLSCONFIG_H

--- a/src/objfgelm.cc
+++ b/src/objfgelm.cc
@@ -120,7 +120,7 @@ Obj NewWord(Obj type, UInt npairs)
     ADDR_OBJ(word)[1] = INTOBJ_INT(npairs);
     SetTypeDatObj(word, type);
 #ifdef HPCGAP
-    MakeBagReadOnly(word);
+    MakeBagPublic(word);
 #endif
     return word;
 }

--- a/src/system.h
+++ b/src/system.h
@@ -119,6 +119,19 @@ enum {
 #define NORETURN
 #endif
 
+#ifdef HAVE_FUNC_ATTRIBUTE_PURE
+#define PURE_FUNC __attribute__((pure))
+#else
+#define PURE_FUNC
+#endif
+
+#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+#define CONSTRUCTOR_FUNC __attribute__((constructor))
+#else
+#define CONSTRUCTOR_FUNC
+#endif
+
+
 /****************************************************************************
 **
 *T  Char, Int1, Int2, Int4, Int, UChar, UInt1, UInt2, UInt4, UInt .  integers


### PR DESCRIPTION
This is a tracking PR for progress on HPC-GAP changes. Aside from older changes in [this PR](https://github.com/gap-system/gap/pull/2845), we also aim at improving our implementations of thread-local storage, specifically so that HPC-GAP can be used as a library.

Our current implementation requires HPC-GAP to be run as the main program, which in particular prevents its use as a library. Alternative portable implementations are considerably slower on systems that do not properly support efficient thread-local storage (such as macOS and CygWin).

We're attempting to address this problem in two ways.

One issue is implementations that rely on `pthread_getspecific()` directly or indirectly do not treat such function calls as pure functions and thus do not get used for common subexpression elimination or hoisted out of loops. As those systems all rely on gcc/clang, we can tag `pthread_getspecific()` as `__attribute__((pure))`, which will immediately lead to a measurable performance improvement.

On macOS, we can go one step further. While there is no guaranteed stable ABI, `pthread_getspecific()` has consistently been implemented by `movq %gs:(,%rdi, 8), %rax`. We therefore can verify that `pthread_getspecific()` actually uses this implementation (`memcmp()` against the machine code) and then use a direct assembly language implementation that has nearly the same performance characteristics as our current implementation.

In addition, we store the key in a static variable that is initialized with an `__attribute__((constructor)__` function. This is generally slightly faster than putting it in a non-static variable on macOS in particular, as we're saving one level of indirection.

Also, in the worst case, this code functions with just `pthread_getspecific()` and no other mechanism available, it is just slower.

Todo:
* [x] Configure check for `__attribute__((pure))` and definition of a macro for it.
* [x] Configure check for `__attribute__((constructor))` and definition of a macro for it.
* [x] Configure check for it being acceptable to define `__pthread_getspecific()` as pure.
* [x] Configure check for macOS supporting this particular implementation.
* [x] Potentially distinguish between building HPC-GAP as a library and a standalone program?
* [ ] Efficient Cygwin implementation.