### PR TITLE
kernel: change STRING_LIST_DIR to return a plist

### DIFF
--- a/lib/files.gd
+++ b/lib/files.gd
@@ -299,7 +299,7 @@ DeclareOperation( "ReadAsFunction", [ IsString ] );
 ##  the directory <A>dir</A>. The argument <A>dir</A> can either be given as 
 ##  a string indicating the name of the directory or as a directory object
 ##  (see <Ref Filt="IsDirectory"/>).
-##  It is an error, if such a directory does not exist. 
+##  If the specified directory does not exist, <K>fail</K> is returned.
 ##  <P/>
 ##  The ordering of the list entries can depend on the operating system.
 ##  <P/>

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -174,18 +174,14 @@ InstallMethod( ExternalFilename, "for a directory list and a string",
 #F  DirectoryContents(<name>)
 ## 
 InstallGlobalFunction(DirectoryContents, function(dirname)
-  local list;
+  local str;
   if IsDirectory(dirname) then
     dirname := dirname![1];
   else
     # to make ~/mydir work
     dirname := UserHomeExpand(dirname);
   fi;
-  list := LIST_DIR(dirname);
-  if list = fail then
-    Error("Could not open ", dirname, " as directory,\nsee LastSystemError();");
-  fi;
-  return list;
+  return LIST_DIR(dirname);
 end);
 
 

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -174,19 +174,18 @@ InstallMethod( ExternalFilename, "for a directory list and a string",
 #F  DirectoryContents(<name>)
 ## 
 InstallGlobalFunction(DirectoryContents, function(dirname)
-  local str;
+  local list;
   if IsDirectory(dirname) then
     dirname := dirname![1];
   else
     # to make ~/mydir work
     dirname := UserHomeExpand(dirname);
   fi;
-  str := STRING_LIST_DIR(dirname);
-  if str = fail then
+  list := LIST_DIR(dirname);
+  if list = fail then
     Error("Could not open ", dirname, " as directory,\nsee LastSystemError();");
   fi;
-  # Why is this file read before string.gd ???
-  return SplitStringInternal(str, "", "\000");
+  return list;
 end);
 
 

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -744,3 +744,12 @@ DeclareGlobalFunction("HideGlobalVariables");
 ##
 ##  Still used in anupq (04/2019)
 DeclareGlobalFunction("UnhideGlobalVariables");
+
+
+#############################################################################
+##
+##
+##  Still used in Browse (06/2019)
+BindGlobal("STRING_LIST_DIR", function(dirname)
+    return JoinStringsWithSeparator(LIST_DIR(dirname), "\000");
+end);

--- a/src/streams.c
+++ b/src/streams.c
@@ -1264,46 +1264,35 @@ static Obj FuncIsDirectoryPathString(Obj self, Obj filename)
 
 /****************************************************************************
 **
-*F  FuncSTRING_LIST_DIR( <self>, <dirname> ) . . . read names of files in dir
+*F  FuncLIST_DIR( <self>, <dirname> ) . . . read names of files in dir
 **
-**  This function returns a GAP string which contains the names of all files
-**  contained in a directory <dirname>. The file names are separated by zero 
-**  characters (which are not allowed in file names). 
+**  This function returns a GAP list which contains the names of all files
+**  contained in a directory <dirname>.
 **
 **  If <dirname> could not be opened as a directory 'fail' is returned. The
 **  reason for the error can be found with 'LastSystemError();' in GAP.
 **
 */
-static Obj FuncSTRING_LIST_DIR(Obj self, Obj dirname)
+static Obj FuncLIST_DIR(Obj self, Obj dirname)
 {
     DIR *dir;
     struct dirent *entry;
     Obj res;
-    Int len, sl;
 
     // check the argument
-    RequireStringRep("STRING_LIST_DIR", dirname);
+    RequireStringRep("LIST_DIR", dirname);
     
     SyClearErrorNo();
     dir = opendir(CONST_CSTR_STRING(dirname));
     if (dir == NULL) {
-      SySetErrorNo();
-      return Fail;
+        SySetErrorNo();
+        return Fail;
     }
-    res = NEW_STRING(256);
-    len = 0;
-    entry = readdir(dir);
-    while (entry != NULL) {
-      sl = strlen(entry->d_name);
-      GROW_STRING(res, len + sl + 1);
-      memcpy(CHARS_STRING(res) + len, entry->d_name, sl + 1);
-      len = len + sl + 1;
-      entry = readdir(dir);
+    res = NEW_PLIST(T_PLIST, 16);
+    while ((entry = readdir(dir))) {
+        PushPlist(res, MakeImmString(entry->d_name));
     }
     closedir(dir);
-    /* tell the result string its length and terminate by 0 char */
-    SET_LEN_STRING(res, len);
-    *(CHARS_STRING(res) + len) = 0;
     return res;
 }
 
@@ -1857,7 +1846,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(IsWritableFile, 1, "filename"),
     GVAR_FUNC(IsExecutableFile, 1, "filename"),
     GVAR_FUNC(IsDirectoryPathString, 1, "filename"),
-    GVAR_FUNC(STRING_LIST_DIR, 1, "dirname"),
+    GVAR_FUNC(LIST_DIR, 1, "dirname"),
     GVAR_FUNC(CLOSE_FILE, 1, "fid"),
     GVAR_FUNC(INPUT_TEXT_FILE, 1, "filename"),
     GVAR_FUNC(OUTPUT_TEXT_FILE, 2, "filename, append"),

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -108,8 +108,8 @@ Error, IsExecutableFile: <filename> must be a string (not the value 'fail')
 gap> IsDirectoryPathString(fail);
 Error, IsDirectoryPathString: <filename> must be a string (not the value 'fail\
 ')
-gap> STRING_LIST_DIR(fail);
-Error, STRING_LIST_DIR: <dirname> must be a string (not the value 'fail')
+gap> LIST_DIR(fail);
+Error, LIST_DIR: <dirname> must be a string (not the value 'fail')
 
 #
 gap> CLOSE_FILE(fail);


### PR DESCRIPTION
This actually results in simpler kernel code, and means that GAP does not have to split a string into a list.
