### PR TITLE
kernel: use posix_spawn in iostreams if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -685,9 +685,10 @@ AC_CHECK_HEADERS([signal.h])
 AC_CHECK_FUNCS([select])
 
 dnl various functions to deal with child processes
+AC_CHECK_HEADERS([spawn.h])
 AC_HEADER_SYS_WAIT
 AC_FUNC_FORK
-AC_CHECK_FUNCS([popen])
+AC_CHECK_FUNCS([popen posix_spawn])
 
 dnl signal handling
 AC_CHECK_TYPE([sig_atomic_t], [],


### PR DESCRIPTION
This should perform much better than fork() on Windows, and not worse than it on Unix variants.

Actually, to be safe, we probably will want to keep `fork()` as default. I mainly made `posix_spawn` default so that we can more easily test it.

This needs some more testing, esp. the part which changes the working directory.

In the meantime, I wonder if @alex-konovalov could test it on Windows to see if it helps with the performance of the `children.tst` file discussed in issue #3506