### PR TITLE
Switch PLISTS and WeakPointerObjs to use IntObj to store the size

### DIFF
--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -374,10 +374,10 @@ static pthread_mutex_t KeepAliveLock;
 
 Obj KeepAlive(Obj obj)
 {
-    Obj newKeepAlive = NewBag(T_PLIST, 4 * sizeof(Obj));
+    Obj newKeepAlive = NEW_PLIST(T_PLIST, 4);
     SET_REGION(newKeepAlive, NULL);    // public region
     pthread_mutex_lock(&KeepAliveLock);
-    ADDR_OBJ(newKeepAlive)[0] = (Obj)3; /* Length 3 */
+    SET_LEN_PLIST(newKeepAlive, 3);
     KEPTALIVE(newKeepAlive) = obj;
     PREV_KEPT(newKeepAlive) = LastKeepAlive;
     NEXT_KEPT(newKeepAlive) = (Obj)0;

--- a/src/plist.h
+++ b/src/plist.h
@@ -41,7 +41,9 @@ EXPORT_INLINE Obj NEW_PLIST(UInt type, Int plen)
     GAP_ASSERT(plen >= 0);
     GAP_ASSERT(plen <= INT_INTOBJ_MAX);
     GAP_ASSERT(FIRST_PLIST_TNUM <= type && type <= LAST_PLIST_TNUM);
-    return NewBag(type, (plen + 1) * sizeof(Obj));
+    Obj bag = NewBag(type, (plen + 1) * sizeof(Obj));
+    ADDR_OBJ(bag)[0] = INTOBJ_INT(0);
+    return bag;
 }
 
 EXPORT_INLINE Obj NEW_PLIST_IMM(UInt type, Int plen)
@@ -147,7 +149,7 @@ EXPORT_INLINE void SET_LEN_PLIST(Obj list, Int len)
     GAP_ASSERT(IS_PLIST_OR_POSOBJ(list));
     GAP_ASSERT(len >= 0);
     GAP_ASSERT(len <= CAPACITY_PLIST(list));
-    ADDR_OBJ(list)[0] = (Obj)len;
+    ADDR_OBJ(list)[0] = INTOBJ_INT(len);
 }
 
 
@@ -161,7 +163,7 @@ EXPORT_INLINE void SET_LEN_PLIST(Obj list, Int len)
 EXPORT_INLINE Int LEN_PLIST(Obj list)
 {
     GAP_ASSERT(IS_PLIST_OR_POSOBJ(list));
-    return ((Int)(CONST_ADDR_OBJ(list)[0]));
+    return INT_INTOBJ(CONST_ADDR_OBJ(list)[0]);
 }
 
 

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -636,7 +636,7 @@ static Obj CopyObjWPObj(Obj obj, Int mut)
         ADDR_OBJ(copy)[0] = CONST_ADDR_OBJ(obj)[0];
     }
     else {
-        copy = NewBag( T_PLIST+IMMUTABLE, SIZE_OBJ(obj) );
+        copy = NEW_PLIST( T_PLIST+IMMUTABLE, LengthWPObj(obj) );
         SET_LEN_PLIST(copy,LengthWPObj(obj));
     }
 
@@ -674,7 +674,7 @@ static void MakeImmutableWPObj(Obj obj)
 #ifdef USE_BOEHM_GC
   UInt i;
   UInt len = 0;
-  Obj copy = NewBag(T_PLIST, SIZE_BAG(obj));
+  Obj copy = NEW_PLIST(T_PLIST, STORED_LEN_WPOBJ(obj));
   for (i = 1; i <= STORED_LEN_WPOBJ(obj); i++) {
 #ifdef HPCGAP
     volatile Obj tmp = ELM_WPOBJ(obj, i);

--- a/tst/testspecial/copy-weakpointerobj.g
+++ b/tst/testspecial/copy-weakpointerobj.g
@@ -1,0 +1,32 @@
+# This test is in 'testspecial' as it allocates large objects
+# so can cause a memory overflow in normal testing
+
+f := function(l)
+    l := List([1..l], x -> List([1..x], x -> x*x));
+    return WeakPointerObj(l);
+end;
+
+tryImmutable := function(len)
+    local w,l;
+    GASMAN("collect");
+    w := f(len);
+    # Hope a GC occurs during this call
+    l := Immutable(w);
+    if Size(l) < len then
+        # Caught mid-GC
+        if ForAny([1..len], i -> IsBound(l[i]) and IsBound(w[i]) and l[i]<>w[i]) then
+            Print("Invalid copy!\n");
+        fi;
+        # Exit test early
+        QUIT_GAP();
+    fi;
+end;
+
+len := 1000;
+for loop in [1..10] do
+    tryImmutable(len);
+    len := len * 3;
+od;
+
+# If we never found a GC mid-copy, just exit. This could be bad luck,
+# or we are not using GASMAN.

--- a/tst/testspecial/copy-weakpointerobj.g.out
+++ b/tst/testspecial/copy-weakpointerobj.g.out
@@ -1,0 +1,32 @@
+gap> # This test is in 'testspecial' as it allocates large objects
+gap> # so can cause a memory overflow in normal testing
+gap> 
+gap> f := function(l)
+>     l := List([1..l], x -> List([1..x], x -> x*x));
+>     return WeakPointerObj(l);
+> end;
+function( l ) ... end
+gap> 
+gap> tryImmutable := function(len)
+>     local w,l;
+>     GASMAN("collect");
+>     w := f(len);
+>     # Hope a GC occurs during this call
+>     l := Immutable(w);
+>     if Size(l) < len then
+>         # Caught mid-GC
+>         if ForAny([1..len], i -> IsBound(l[i]) and IsBound(w[i]) and l[i]<>w[i]) then
+>             Print("Invalid copy!\n");
+>         fi;
+>         # Exit test early
+>         QUIT_GAP();
+>     fi;
+> end;
+function( len ) ... end
+gap> 
+gap> len := 1000;
+1000
+gap> for loop in [1..10] do
+>     tryImmutable(len);
+>     len := len * 3;
+> od;


### PR DESCRIPTION
This switches PLISTS and WeakPointerObjs to use an IntObj to store their size.

This is part of a cleanup towards making all the builtin data types use IntObj to store their size.

The only notable problem is that now a compeletely zeroed block of memory isn't a valid Plist, as it needs to store INTOBJ_INT(0) as it's size.

There are two reasons to do this:

* It helps make clearer these datastructures can only be as big as an intobj (which was already true anyway in practice)
* It is required to get rid of a bug in saveworkspace (in a neat way; see #3505).