### PR TITLE
Add more IsSimpleGroup-related implication; cleanup

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -624,11 +624,17 @@ InstallTrueMethod( IsPerfectGroup, IsGroup and IsTrivial );
 ##  <#/GAPDoc>
 ##
 DeclareProperty( "IsSimpleGroup", IsGroup );
-InstallTrueMethod( IsGroup, IsSimpleGroup );
+InstallTrueMethod( IsGroup and IsNonTrivial, IsSimpleGroup );
 DeclareSynonymAttr( "IsNonabelianSimpleGroup", IsSimpleGroup and IsPerfectGroup );
-InstallTrueMethod( IsSimpleGroup, IsNonabelianSimpleGroup );
+InstallTrueMethod( HasIsAbelian, IsNonabelianSimpleGroup );
 
 InstallIsomorphismMaintenance( IsSimpleGroup, IsGroup, IsGroup );
+
+# abelian simple groups are cyclic p-groups and not perfect
+InstallTrueMethod( IsCyclic, IsSimpleGroup and IsAbelian );
+InstallTrueMethod( IsPGroup, IsSimpleGroup and IsAbelian );
+InstallTrueMethod( HasIsPerfectGroup, IsSimpleGroup and IsAbelian );
+InstallTrueMethod( HasIsNonabelianSimpleGroup, IsSimpleGroup and IsAbelian );
 
 #############################################################################
 ##
@@ -654,7 +660,7 @@ InstallIsomorphismMaintenance( IsSimpleGroup, IsGroup, IsGroup );
 ##  </ManSection>
 ##
 DeclareProperty( "IsSporadicSimpleGroup", IsGroup );
-InstallTrueMethod( IsSimpleGroup, IsSporadicSimpleGroup );
+InstallTrueMethod( IsNonabelianSimpleGroup, IsSporadicSimpleGroup );
 
 InstallIsomorphismMaintenance( IsSporadicSimpleGroup, IsGroup, IsGroup );
 
@@ -709,11 +715,10 @@ InstallIsomorphismMaintenance( IsSporadicSimpleGroup, IsGroup, IsGroup );
 ##  <#/GAPDoc>
 ##
 DeclareProperty( "IsAlmostSimpleGroup", IsGroup );
-InstallTrueMethod( IsGroup, IsAlmostSimpleGroup );
+InstallTrueMethod( IsGroup and IsNonTrivial, IsAlmostSimpleGroup );
 
-# a simple group is almost simple
+# nonabelian simple groups are almost simple
 InstallTrueMethod( IsAlmostSimpleGroup, IsNonabelianSimpleGroup );
-
 
 #############################################################################
 ##

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -608,34 +608,6 @@ InstallTrueMethod( IsPerfectGroup, IsGroup and IsTrivial );
 
 #############################################################################
 ##
-#P  IsSporadicSimpleGroup( <G> )
-##
-##  <ManSection>
-##  <Prop Name="IsSporadicSimpleGroup" Arg='G'/>
-##
-##  <Description>
-##  A group is <E>sporadic simple</E> if it is one of the
-##  <M>26</M> sporadic simple groups;
-##  these are (in &ATLAS; notation, see&nbsp;<Cite Key="CCN85"/>)
-##  <M>M_{11}</M>, <M>M_{12}</M>, <M>J_1</M>, <M>M_{22}</M>, <M>J_2</M>,
-##  <M>M_{23}</M>, <M>HS</M>, <M>J_3</M>, <M>M_{24}</M>, <M>M^cL</M>,
-##  <M>He</M>, <M>Ru</M>, <M>Suz</M>, <M>O'N</M>, <M>Co_3</M>, <M>Co_2</M>,
-##  <M>Fi_{22}</M>, <M>HN</M>, <M>Ly</M>, <M>Th</M>, <M>Fi_{23}</M>,
-##  <M>Co_1</M>, <M>J_4</M>, <M>Fi_{24}'</M>, <M>B</M>, and <M>M</M>.
-##  <P/>
-##  This property can be used for example for selecting the character tables
-##  of the sporadic simple groups,
-##  see the documentation of the &GAP; package <Package>CTblLib</Package>.
-##  </Description>
-##  </ManSection>
-##
-DeclareProperty( "IsSporadicSimpleGroup", IsGroup );
-InstallTrueMethod( IsGroup, IsSporadicSimpleGroup );
-
-InstallIsomorphismMaintenance( IsSporadicSimpleGroup, IsGroup, IsGroup );
-
-#############################################################################
-##
 #P  IsSimpleGroup( <G> )
 #P  IsNonabelianSimpleGroup( <G> )
 ##
@@ -658,7 +630,33 @@ InstallTrueMethod( IsSimpleGroup, IsNonabelianSimpleGroup );
 
 InstallIsomorphismMaintenance( IsSimpleGroup, IsGroup, IsGroup );
 
+#############################################################################
+##
+#P  IsSporadicSimpleGroup( <G> )
+##
+##  <ManSection>
+##  <Prop Name="IsSporadicSimpleGroup" Arg='G'/>
+##
+##  <Description>
+##  A group is <E>sporadic simple</E> if it is one of the
+##  <M>26</M> sporadic simple groups;
+##  these are (in &ATLAS; notation, see&nbsp;<Cite Key="CCN85"/>)
+##  <M>M_{11}</M>, <M>M_{12}</M>, <M>J_1</M>, <M>M_{22}</M>, <M>J_2</M>,
+##  <M>M_{23}</M>, <M>HS</M>, <M>J_3</M>, <M>M_{24}</M>, <M>M^cL</M>,
+##  <M>He</M>, <M>Ru</M>, <M>Suz</M>, <M>O'N</M>, <M>Co_3</M>, <M>Co_2</M>,
+##  <M>Fi_{22}</M>, <M>HN</M>, <M>Ly</M>, <M>Th</M>, <M>Fi_{23}</M>,
+##  <M>Co_1</M>, <M>J_4</M>, <M>Fi_{24}'</M>, <M>B</M>, and <M>M</M>.
+##  <P/>
+##  This property can be used for example for selecting the character tables
+##  of the sporadic simple groups,
+##  see the documentation of the &GAP; package <Package>CTblLib</Package>.
+##  </Description>
+##  </ManSection>
+##
+DeclareProperty( "IsSporadicSimpleGroup", IsGroup );
 InstallTrueMethod( IsSimpleGroup, IsSporadicSimpleGroup );
+
+InstallIsomorphismMaintenance( IsSporadicSimpleGroup, IsGroup, IsGroup );
 
 #############################################################################
 ##

--- a/tst/testbugfix/2019-06-25-IsAlmostSimpleGroup.tst
+++ b/tst/testbugfix/2019-06-25-IsAlmostSimpleGroup.tst
@@ -1,0 +1,18 @@
+# IsSimpleGroup does *not* imply IsAlmostSimpleGroup, as the latter only
+# holds for certain extensions of *nonabelian* simple groups.
+
+#
+gap> RankFilter(IsSimpleGroup) < RankFilter(IsAlmostSimpleGroup and IsSimpleGroup);
+true
+gap> RankFilter(IsAlmostSimpleGroup) < RankFilter(IsAlmostSimpleGroup and IsSimpleGroup);
+true
+
+#
+gap> G:=CyclicGroup(5);
+<pc group of size 5 with 1 generators>
+gap> IsAlmostSimpleGroup(G);
+false
+gap> IsSimpleGroup(G);
+true
+gap> IsAlmostSimpleGroup(G);
+false


### PR DESCRIPTION
In GAP, IsAlmostSimpleGroup only applies to *nonabelian* simple groups,
whereas IsSimpleGroup also is true for abelian simple groups.

Instead, we add two weaker implications from IsSporadicSimpleGroup
resp. from IsSimpleGroup and IsPerfectGroup, to IsAlmostSimpleGroup.

UPDATE: the original issue got fixed in PR #3522; this PR now adds a test for it, and performs some related cleanup. Best to review this on a per-commit basis.