### PR TITLE
ENHANCE: Added `IsNonabelianSimpleGroup`

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -22,7 +22,7 @@ local H,hom,d,cl;
     IsNaturalSymmetricGroup(G)) then
     return ConjugacyClasses(G); # there is a method for this
   fi;
-  if not IsSimpleGroup(PerfectResiduum(G)) then
+  if not IsNonabelianSimpleGroup(PerfectResiduum(G)) then
     return fail;
   fi;
   d:=DataAboutSimpleGroup(PerfectResiduum(G));
@@ -3077,7 +3077,7 @@ local cl;
     return cl;
   elif IsSolvableGroup( G ) and CanEasilyComputePcgs(G) then
     return ConjugacyClassesForSolvableGroup(G);
-  elif IsSimpleGroup( G ) then
+  elif IsNonabelianSimpleGroup( G ) then
     cl:=ClassesFromClassical(G);
     if cl=fail then
       cl:=ConjugacyClassesByRandomSearch( G );

--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -684,7 +684,7 @@ totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i;
   # what is a good degree:
   goodi:=Minimum(Int(knowi*9/10),LogInt(IndexNC(G,N),2)^2);
 
-  simple:=HasIsSimpleGroup(G) and IsSimpleGroup(G) and Size(N)=2;
+  simple:=HasIsNonabelianSimpleGroup(G) and IsNonabelianSimpleGroup(G) and Size(N)=2;
   uc:=TrivialSubgroup(G);
   # look if it is worth to look at action on N
   # if not abelian: later replace by abelian Normal subgroup

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -899,7 +899,7 @@ local s,o,a,n,d,f,fn,j,b,i;
 
   d:=[];
   for i in f do
-    if IsSimpleGroup(i) then
+    if IsNonabelianSimpleGroup(i) then
       Add(d,i);
     else
       n:=Filtered(NormalSubgroups(i),x->Size(x)>1);
@@ -908,7 +908,7 @@ local s,o,a,n,d,f,fn,j,b,i;
       if ForAny(n,x->IsPrimePowerInt(Size(x))) then
 	return fail;
       fi;
-      n:=Filtered(n,IsSimpleGroup);
+      n:=Filtered(n,IsNonabelianSimpleGroup);
       Append(d,n);
     fi;
   od;

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -67,8 +67,8 @@ function(G,str)
   return IsomorphismFpGroupByPcgs( Pcgs(G), str );
 end);
 
-InstallOtherMethod( IsomorphismFpGroup,"for simple permutation groups",true,
-  [IsPermGroup and IsSimpleGroup,IsString],0,
+InstallOtherMethod( IsomorphismFpGroup,"for nonabelian simple permutation groups",
+  true, [IsPermGroup and IsNonabelianSimpleGroup,IsString],0,
 function(G,str)
 local l,iso,fp,stbc,gens;
   # use the perfect groups library
@@ -131,7 +131,7 @@ function( G, str )
     #     gensH := Filtered( gensH, x -> x <> One(H) );
     # fi;
 
-    IsSimpleGroup(H); #ensure H knows to be simple, thus the call to
+    IsNonabelianSimpleGroup(H); #ensure H knows to be simple, thus the call to
     # `IsomorphismFpGroup' will not yield an infinite recursion.
     IsNaturalAlternatingGroup(H); # We have quite often a factor A_n for
     # which GAP knows better presentations. Thus this test is worth doing.
@@ -162,7 +162,7 @@ function( G, str )
         # fi;
 
 	# compute presentation of H
-	IsSimpleGroup(H);
+	IsNonabelianSimpleGroup(H);
 	IsNaturalAlternatingGroup(H);
 	new:=IsomorphismFpGroup(H,"@");
 	gensH:=List(GeneratorsOfGroup(Image(new)),
@@ -278,7 +278,7 @@ function(g,str,N)
       IsOne(hom);
       f:=Image(hom);
       # knowing simplicity makes it easy to test whether a map is faithful
-      if IsSimpleGroup(f) then
+      if IsNonabelianSimpleGroup(f) then
         if DataAboutSimpleGroup(f).idSimple.series="A" and
           not IsNaturalAlternatingGroup(f) then
           # force natural alternating 
@@ -320,7 +320,7 @@ function(g,str,N)
       od;
 
       # we know sf is simple
-      SetIsSimpleGroup(sf,true);
+      SetIsNonabelianSimpleGroup(sf,true);
       IsNaturalAlternatingGroup(sf);
       if ValueOption("rewrite")=true then
         a:=IsomorphismFpGroupForRewriting(sf:noassert);

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -2393,7 +2393,7 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
     k:=Factorial(n)/2;
     l:=CallFuncList(ValueGlobal("AllPrimitiveGroups"),
               [DegreeOperation,n,
-                          i->Size(i)<k and IsSimpleGroup(Socle(i))
+                          i->Size(i)<k and IsNonabelianSimpleGroup(Socle(i))
                           and not IsAbelian(Socle(i)),true,
                           SignPermGroup,SignPermGroup(G)]);
 

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -636,23 +636,29 @@ InstallIsomorphismMaintenance( IsSporadicSimpleGroup,
 #############################################################################
 ##
 #P  IsSimpleGroup( <G> )
+#P  IsNonabelianSimpleGroup( <G> )
 ##
 ##  <#GAPDoc Label="IsSimpleGroup">
 ##  <ManSection>
 ##  <Prop Name="IsSimpleGroup" Arg='G'/>
+##  <Prop Name="IsNonabelianSimpleGroup" Arg='G'/>
 ##
 ##  <Description>
 ##  A group is <E>simple</E> if it is nontrivial and has no nontrivial normal
-##  subgroups.
+##  subgroups. A <E>nonabelian simple</E> group is simple and not abelian.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareProperty( "IsSimpleGroup", IsGroup );
 InstallTrueMethod( IsGroup, IsSimpleGroup );
+DeclareSynonymAttr( "IsNonabelianSimpleGroup", IsSimpleGroup and IsPerfectGroup );
+InstallTrueMethod( IsSimpleGroup, IsNonabelianSimpleGroup );
 
 InstallIsomorphismMaintenance( IsSimpleGroup,
     IsGroup and IsSimpleGroup, IsGroup );
+
+InstallIsomorphismMaintenance( IsPerfectGroup, IsGroup, IsGroup );
 
 InstallTrueMethod( IsSimpleGroup, IsSporadicSimpleGroup );
 
@@ -710,7 +716,7 @@ DeclareProperty( "IsAlmostSimpleGroup", IsGroup );
 InstallTrueMethod( IsGroup, IsAlmostSimpleGroup );
 
 # a simple group is almost simple
-InstallTrueMethod( IsAlmostSimpleGroup, IsSimpleGroup );
+InstallTrueMethod( IsAlmostSimpleGroup, IsNonabelianSimpleGroup );
 
 
 #############################################################################
@@ -1877,7 +1883,7 @@ DeclareAttribute( "MinimalNormalSubgroups", IsGroup );
 ##  <Example><![CDATA[
 ##  gap> g:=SymmetricGroup(4);;NormalSubgroups(g);
 ##  [ Sym( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ),
-##    Group([ (1,4)(2,3), (1,2)(3,4) ]), Group(()) ]
+##    Group([ (1,4)(2,3), (1,3)(2,4) ]), Group(()) ]
 ##  ]]></Example>
 ##  <P/>
 ##  The algorithm for the computation of normal subgroups is described in

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -901,7 +901,7 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
       or Size(G)<=cefastersize then
       # in the simple case we cannot go back into trivial fitting case
       # or cyclic extension is faster as group is small
-      if IsSimpleGroup(G) then
+      if IsNonabelianSimpleGroup(G) then
 	c:=TomDataSubgroupsAlmostSimple(G);
 	if c<>fail then
 	  c:=makesubgroupclasses(G,c);
@@ -923,7 +923,7 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
       HN:=Image(hom,H);
       c:=LatticeByCyclicExtension(f,
 	  [u->IsSubset(HN,u),u->IsSubset(HN,u)])!.conjugacyClassesSubgroups;
-    elif select<>fail and (select=IsPerfectGroup  or select=IsSimpleGroup) then
+    elif select=IsPerfectGroup or select=IsNonabelianSimpleGroup then
       c:=ConjugacyClassesPerfectSubgroups(f);
       c:=Filtered(c,x->Size(Representative(x))>1);
       fselect:=U->not IsSolvableGroup(U);
@@ -1003,7 +1003,7 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
 	# by setting up `act' as fail, we force a different selection later
 	act:=[nts,fail];
 
-      elif select=IsSimpleGroup then
+      elif select=IsNonabelianSimpleGroup then
 	# simple -> no extensions, only the trivial subgroup is valid.
 	act:=[[ser[i]],GroupHomomorphismByImagesNC(G,Group(()),
 	    GeneratorsOfGroup(G),
@@ -1341,7 +1341,7 @@ local badsizes,n,un,cl,r,i,l,u,bw,cnt,gens,go,imgs,bg,bi,emb,nu,k,j,
     D:=LatticeViaRadical(G,IsPerfectGroup);
     D:=List(D!.conjugacyClassesSubgroups,Representative);
     if simple then
-      D:=Filtered(D,IsSimpleGroup);
+      D:=Filtered(D,IsNonabelianSimpleGroup);
     else
       D:=Filtered(D,IsPerfectGroup);
     fi;
@@ -1360,7 +1360,7 @@ local badsizes,n,un,cl,r,i,l,u,bw,cnt,gens,go,imgs,bg,bi,emb,nu,k,j,
 		 and i<n/4);
 
     # if D is simple, we can limit indices further
-    if IsSimpleGroup(D) then
+    if IsNonabelianSimpleGroup(D) then
       k:=4;
       l:=120;
       while l<n do
@@ -1406,7 +1406,7 @@ local badsizes,n,un,cl,r,i,l,u,bw,cnt,gens,go,imgs,bg,bi,emb,nu,k,j,
 	  Info(InfoLattice,1,"trying group ",i,",",j,": ",u);
 
 	  # test whether there is a chance to embed
-	  might:=simple=false or IsSimpleGroup(u);
+	  might:=simple=false or IsNonabelianSimpleGroup(u);
 	  cnt:=0;
 	  while might and cnt<20 do
 	    bg:=Order(Random(u));
@@ -1502,7 +1502,7 @@ InstallMethod(RepresentativesSimpleSubgroups,"using Holt/Plesken library",
 
 InstallMethod(RepresentativesSimpleSubgroups,"if perfect subs are known",
   true,[IsGroup and HasRepresentativesPerfectSubgroups],0,
-  G->Filtered(RepresentativesPerfectSubgroups(G),IsSimpleGroup));
+  G->Filtered(RepresentativesPerfectSubgroups(G),IsNonabelianSimpleGroup));
 
 #############################################################################
 ##
@@ -2865,7 +2865,7 @@ InstallGlobalFunction("SubgroupsTrivialFitting",function(G)
   for i in n do
     if not IsSubgroup(a,i) then
       a:=ClosureGroup(a,i);
-      if not IsSimpleGroup(i) then
+      if not IsNonabelianSimpleGroup(i) then
 	TryNextMethod();
       fi;
       t:=ClassicalIsomorphismTypeFiniteSimpleGroup(i);

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -2223,7 +2223,7 @@ local dom,s,cs,t,ts,o,m,stb;
   s:=Socle(G);
   if IsAbelian(s) then
     return "1";
-  elif IsSimpleGroup(s) then
+  elif IsNonabelianSimpleGroup(s) then
     return "2";
   elif Length(dom)=Size(s) then
     return "5";

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -554,7 +554,7 @@ local m,id,epi,H;
   m:=TomDataMaxesAlmostSimple(G);
   if m<>fail then return m;fi;
 
-  if IsSimpleGroup(G) then 
+  if IsNonabelianSimpleGroup(G) then 
     # following is stopgap for L
     id:=DataAboutSimpleGroup(G);
     if id.idSimple.series="A" then

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -492,7 +492,7 @@ v, val, o, i, comb, best,actbase,action;
 	  end);
       fi;
 
-      if hom=fail and not IsAbelian(Socle(g)) and IsSimpleGroup(Socle(g)) then
+      if hom=fail and IsNonabelianSimpleGroup(Socle(g)) then
 	Info(InfoMorph,1,"Try ARG");
 	img:=AutomorphismRepresentingGroup(g,GeneratorsOfGroup(au));
 	# make a hom from auts to perm group
@@ -1527,7 +1527,7 @@ local len,combi,Gr,Gcl,Ggc,Hr,Hcl,bg,bpri,x,dat,
 
     # catch case of simple groups to get outer automorphism orders
     # automorphism suffices.
-    if IsSimpleGroup(H) then
+    if IsNonabelianSimpleGroup(H) then
       dat:=DataAboutSimpleGroup(H);
       if IsBound(dat.fullAutGroup) then
 	if dat.fullAutGroup[1]=1 then
@@ -1709,7 +1709,7 @@ end);
 
 BindGlobal("OuterAutomorphismGeneratorsSimple",function(G)
 local d,id,H,iso,aut,auts,i,all,hom,field,dim,P,diag,mats,gens,gal;
-  if not IsSimpleGroup(G) then
+  if not IsNonabelianSimpleGroup(G) then
     return fail;
   fi;
   gens:=GeneratorsOfGroup(G);
@@ -1831,7 +1831,7 @@ end);
 
 BindGlobal("AutomorphismGroupMorpheus",function(G)
 local a,b,c,p;
-  if IsSimpleGroup(G) then
+  if IsNonabelianSimpleGroup(G) then
     c:=DataAboutSimpleGroup(G);
     b:=List(GeneratorsOfGroup(G),x->InnerAutomorphism(G,x));
     a:=OuterAutomorphismGeneratorsSimple(G);
@@ -1902,7 +1902,7 @@ InstallGlobalFunction(AutomorphismGroupFittingFree,function(g)
   #write g in a nice form
   count:=ValueOption("count");if count=fail then count:=0;fi;
   s:=Socle(g);
-  if IsSimpleGroup(s) then
+  if IsNonabelianSimpleGroup(s) then
     return AutomorphismGroupMorpheus(g);
   fi;
   c:=ChiefSeriesThrough(g,[s]);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -88,6 +88,13 @@ gap> Size(u);
 gap> Size(g)/Length(Orbit(g,part,OnTuplesSets));
 4608
 
+# simplicity
+gap> g:=PerfectGroup(IsPermGroup,360,1);;
+gap> IsSimpleGroup(g);
+true
+gap> IsNonabelianSimpleGroup(g);
+true
+
 # Unbind variables so we can GC memory
 gap> Unbind(g); Unbind(dc); Unbind(ac); Unbind(g); Unbind(p); Unbind(s);
 gap> STOP_TEST( "permgrp.tst", 1);


### PR DESCRIPTION
and use it in library wherever this is intended in place of `IsSimpleGroup`.

There were places in the code which uses `IsSimpleGroup` intending nonabelian simple. While thy did not cause obvious errors, it is cleaner to use a dedicated filter and will also inherit the `IsAlmostSimpleGroup` implication.

Release Notes:
Clarified definition and use of `IsSimpleGroup` to allow for abelian simple groups and introduced `IsNonabelianSimpleGroup`.