### PR TITLE
Switch strings to store their length as an intobj

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -199,19 +199,19 @@ typedef UInt4           LVar;
 
 #define INFO_FEXP(fexp)         PROF_FUNC(fexp)
 #define SET_INFO_FEXP(fexp,x)   SET_PROF_FUNC(fexp,x)
-#define NEXT_INFO(info)         PTR_BAG(info)[0]
-#define NR_INFO(info)           (*((Int*)(PTR_BAG(info)+1)))
-#define NLVAR_INFO(info)        (*((Int*)(PTR_BAG(info)+2)))
-#define NHVAR_INFO(info)        (*((Int*)(PTR_BAG(info)+3)))
-#define NTEMP_INFO(info)        (*((Int*)(PTR_BAG(info)+4)))
-#define NLOOP_INFO(info)        (*((Int*)(PTR_BAG(info)+5)))
-#define CTEMP_INFO(info)        (*((Int*)(PTR_BAG(info)+6)))
-#define TNUM_LVAR_INFO(info,i)  (*((Int*)(PTR_BAG(info)+7+(i))))
+#define NEXT_INFO(info)         PTR_BAG(info)[1]
+#define NR_INFO(info)           (*((Int*)(PTR_BAG(info)+2)))
+#define NLVAR_INFO(info)        (*((Int*)(PTR_BAG(info)+3)))
+#define NHVAR_INFO(info)        (*((Int*)(PTR_BAG(info)+4)))
+#define NTEMP_INFO(info)        (*((Int*)(PTR_BAG(info)+5)))
+#define NLOOP_INFO(info)        (*((Int*)(PTR_BAG(info)+6)))
+#define CTEMP_INFO(info)        (*((Int*)(PTR_BAG(info)+7)))
+#define TNUM_LVAR_INFO(info,i)  (*((Int*)(PTR_BAG(info)+8+(i))))
 
 #define TNUM_TEMP_INFO(info,i)  \
-    (*((Int*)(PTR_BAG(info)+7+NLVAR_INFO(info)+(i))))
+    (*((Int*)(PTR_BAG(info)+8+NLVAR_INFO(info)+(i))))
 
-#define SIZE_INFO(nlvar,ntemp)  (sizeof(Int) * (8 + (nlvar) + (ntemp)))
+#define SIZE_INFO(nlvar,ntemp)  (sizeof(Int) * (1 + 8 + (nlvar) + (ntemp)))
 
 #define W_UNUSED                0       /* TEMP is currently unused        */
 #define W_HIGHER                (1L<<0) /* LVAR is used as higher variable */
@@ -5094,7 +5094,7 @@ static void CompFunc(Obj func)
 
         UInt nr = PushPlist( CompFunctions, func );
 
-        info = NewBag( T_STRING, SIZE_INFO(narg+nloc,8) );
+        info = NewKernelBuffer(SIZE_INFO(narg+nloc,8));
         NEXT_INFO(info)  = INFO_FEXP( CURR_FUNC() );
         NR_INFO(info)    = nr;
         NLVAR_INFO(info) = narg + nloc;

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -415,10 +415,14 @@ static Obj FuncREVNEG_STRING(Obj self, Obj val)
 Obj NEW_STRING ( Int len )
 {
   Obj res;
-  if (len < 0)
-       ErrorQuit(
-           "NEW_STRING: Cannot create string of negative length %d",
-           (Int)len, 0L);
+  if (len < 0) {
+      ErrorQuit("NEW_STRING: cannot create string of negative length %d",
+                (Int)len, 0L);
+  }
+  if (len > INT_INTOBJ_MAX) {
+      ErrorQuit("NEW_STRING: length must be a small integer", 0L, 0L);
+  }
+
   res = NewBag( T_STRING, SIZEBAG_STRINGLEN(len)  ); 
   SET_LEN_STRING(res, len);
   /* it may be sometimes useful to have trailing zero characters */
@@ -441,8 +445,13 @@ Int             GrowString (
     UInt                len;            /* new physical length             */
     UInt                good;           /* good new physical length        */
 
+    if (need > INT_INTOBJ_MAX)
+        ErrorMayQuit("GrowString: string length too large", 0, 0);
+
     /* find out how large the data area  should become                     */
     good = 5 * (GET_LEN_STRING(list)+3) / 4 + 1;
+    if (good > INT_INTOBJ_MAX)
+        good = INT_INTOBJ_MAX;
 
     /* but maybe we need more                                              */
     if ( need < good ) { len = good; }

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -161,7 +161,7 @@ EXPORT_INLINE const UChar * CONST_CHARS_STRING(Obj list)
 EXPORT_INLINE UInt GET_LEN_STRING(Obj list)
 {
     GAP_ASSERT(IS_STRING_REP(list));
-    return *((const UInt *)CONST_ADDR_OBJ(list));
+    return INT_INTOBJ(CONST_ADDR_OBJ(list)[0]);
 }
 
 /****************************************************************************
@@ -176,7 +176,7 @@ EXPORT_INLINE void SET_LEN_STRING(Obj list, Int len)
     GAP_ASSERT(IS_STRING_REP(list));
     GAP_ASSERT(len >= 0);
     GAP_ASSERT(SIZEBAG_STRINGLEN(len) <= SIZE_OBJ(list));
-    (*((UInt *)ADDR_OBJ(list)) = (UInt)(len));
+    ADDR_OBJ(list)[0] = INTOBJ_INT(len);
 }
 
 /****************************************************************************


### PR DESCRIPTION
Switch strings to use an intobj as their length.

This should not be a visible change, as no kernel programmer should be accessing the length directly, and if anyone was creating strings on a 32-bit machine with length longer than fits in an intobj, GAP often crashed anyway.