### PR TITLE
Improve our use of InstallIsomorphismMaintenance

### DIFF
--- a/lib/field.gd
+++ b/lib/field.gd
@@ -124,8 +124,7 @@ DeclareAttribute( "PrimeField", IsDivisionRing );
 DeclareProperty( "IsPrimeField", IsDivisionRing );
 InstallTrueMethod( IsField, IsPrimeField );
 
-InstallIsomorphismMaintenance( IsPrimeField,
-    IsField and IsPrimeField, IsField );
+InstallIsomorphismMaintenance( IsPrimeField, IsField, IsField );
 
 
 #############################################################################

--- a/lib/fldabnum.gd
+++ b/lib/fldabnum.gd
@@ -81,8 +81,7 @@ InstallTrueMethod( IsField, IsNumberField );
 InstallSubsetMaintenance( IsNumberField,
     IsField and IsNumberField, IsField );
 
-InstallIsomorphismMaintenance( IsNumberField,
-    IsField and IsNumberField, IsField );
+InstallIsomorphismMaintenance( IsNumberField, IsField, IsField );
 
 
 #############################################################################
@@ -110,8 +109,7 @@ InstallTrueMethod( IsNumberField, IsAbelianNumberField );
 InstallSubsetMaintenance( IsAbelianNumberField,
     IsField and IsAbelianNumberField, IsField );
 
-InstallIsomorphismMaintenance( IsAbelianNumberField,
-    IsField and IsAbelianNumberField, IsField );
+InstallIsomorphismMaintenance( IsAbelianNumberField, IsField, IsField );
 
 
 #############################################################################
@@ -120,8 +118,7 @@ InstallIsomorphismMaintenance( IsAbelianNumberField,
 ##
 ##  The attribute is defined in `cyclotom.g'.
 ##
-InstallIsomorphismMaintenance( Conductor,
-    IsField and IsAbelianNumberField, IsField );
+InstallIsomorphismMaintenance( Conductor, IsField, IsField );
 
 
 #############################################################################
@@ -172,8 +169,7 @@ DeclareProperty( "IsCyclotomicField", IsField );
 
 InstallTrueMethod( IsAbelianNumberField, IsCyclotomicField );
 
-InstallIsomorphismMaintenance( IsCyclotomicField,
-    IsField and IsCyclotomicField, IsField );
+InstallIsomorphismMaintenance( IsCyclotomicField, IsField, IsField );
 
 
 #############################################################################

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -599,6 +599,8 @@ InstallTrueMethod( IsNilpotentGroup, IsGroup and IsPGroup and IsFinite );
 DeclareProperty( "IsPerfectGroup", IsGroup );
 InstallTrueMethod( IsGroup, IsPerfectGroup );
 
+InstallIsomorphismMaintenance( IsPerfectGroup, IsGroup, IsGroup );
+
 InstallFactorMaintenance( IsPerfectGroup,
     IsGroup and IsPerfectGroup, IsObject, IsGroup );
 
@@ -630,8 +632,7 @@ InstallTrueMethod( IsPerfectGroup, IsGroup and IsTrivial );
 DeclareProperty( "IsSporadicSimpleGroup", IsGroup );
 InstallTrueMethod( IsGroup, IsSporadicSimpleGroup );
 
-InstallIsomorphismMaintenance( IsSporadicSimpleGroup,
-    IsGroup and IsSporadicSimpleGroup, IsGroup );
+InstallIsomorphismMaintenance( IsSporadicSimpleGroup, IsGroup, IsGroup );
 
 #############################################################################
 ##
@@ -655,10 +656,7 @@ InstallTrueMethod( IsGroup, IsSimpleGroup );
 DeclareSynonymAttr( "IsNonabelianSimpleGroup", IsSimpleGroup and IsPerfectGroup );
 InstallTrueMethod( IsSimpleGroup, IsNonabelianSimpleGroup );
 
-InstallIsomorphismMaintenance( IsSimpleGroup,
-    IsGroup and IsSimpleGroup, IsGroup );
-
-InstallIsomorphismMaintenance( IsPerfectGroup, IsGroup, IsGroup );
+InstallIsomorphismMaintenance( IsSimpleGroup, IsGroup, IsGroup );
 
 InstallTrueMethod( IsSimpleGroup, IsSporadicSimpleGroup );
 
@@ -1451,9 +1449,7 @@ DeclareAttribute( "DerivedLength", IsGroup );
 ##  </ManSection>
 ##
 DeclareAttribute( "HirschLength", IsGroup );
-InstallIsomorphismMaintenance( HirschLength, 
-                               IsGroup and HasHirschLength,
-                               IsGroup );
+InstallIsomorphismMaintenance( HirschLength, IsGroup, IsGroup );
 
 
 #############################################################################
@@ -1637,7 +1633,7 @@ DeclareAttribute( "ElementaryAbelianSeriesLargeSteps", IsGroup );
 ##
 DeclareAttribute( "Exponent", IsGroup );
 
-InstallIsomorphismMaintenance( Exponent, IsGroup and HasExponent, IsGroup );
+InstallIsomorphismMaintenance( Exponent, IsGroup, IsGroup );
 
 
 #############################################################################


### PR DESCRIPTION
Unlike for factors and subsets, an isomorphism can transfer also *false*
properties. Despite this, most of our uses of InstallIsomorphismMaintenance
restricted it to true values. We change that, and and also transfer
some attributes for which it makes sense.

Many more InstallIsomorphismMaintenance could be added to complement
existing factor and subset maintenance installations.
