### PR TITLE
Profile pausing for syntax tree

### DIFF
--- a/src/profile.h
+++ b/src/profile.h
@@ -19,7 +19,8 @@
 Int enableProfilingAtStartup(Char ** argv, void * dummy);
 Int enableMemoryProfilingAtStartup(Char ** argv, void * dummy);
 Int enableCodeCoverageAtStartup(Char ** argv, void * dummy);
-
+void pauseProfiling(void);
+void unpauseProfiling(void);
 
 // When a child is forked off, we force profile information to be stored
 // in a new file for the child, to avoid corruption.

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -22,6 +22,7 @@
 #include "opers.h"
 #include "plist.h"
 #include "precord.h"
+#include "profile.h"
 #include "records.h"
 #include "stats.h"
 #include "stringobj.h"
@@ -324,7 +325,10 @@ static Expr SyntaxTreeCodeRefLVar(Obj node)
 
 static Obj SyntaxTreeEvalCompiler(Obj result, Expr expr)
 {
-    AssPRec(result, RNamName("value"), EVAL_EXPR(expr));
+    pauseProfiling();
+    Obj o = EVAL_EXPR(expr);
+    unpauseProfiling();
+    AssPRec(result, RNamName("value"), o);
     return result;
 }
 


### PR DESCRIPTION
This adds the ability to 'pause' profiling, to stop spurious coverage caused by syntaxtree.

Will see how this effects coverage.

Fixes #3519