### PR TITLE
Add PositionSortedBy

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -1405,6 +1405,7 @@ The latter can be done also using <Ref Func="ListWithIdenticalEntries"/>.
 <#Include Label="PositionCanonical">
 <#Include Label="PositionNthOccurrence">
 <#Include Label="PositionSorted">
+<#Include Label="PositionSortedBy">
 <#Include Label="PositionSet">
 <#Include Label="PositionMaximum">
 <#Include Label="PositionProperty">

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -786,8 +786,8 @@ DeclareOperation( "PositionNthOccurrence", [ IsList, IsObject, IS_INT ] );
 ##  and <K>false</K> otherwise.
 ##  <P/>
 ##  <Ref Func="PositionSorted"/> returns <A>pos</A> such that
-##  <M><A>list</A>[<A>pos</A>-1] &lt; <A>elm</A></M> and
-##  <M><A>elm</A> \leq <A>list</A>[<A>pos</A>]</M>.
+##  <M><A>list</A>[<A>pos</A>-1] &lt; <A>elm</A> \leq
+##  <A>list</A>[<A>pos</A>]</M> holds.
 ##  That means, if <A>elm</A> appears once in <A>list</A>,
 ##  its position is returned.
 ##  If <A>elm</A> appears several times in <A>list</A>,
@@ -831,6 +831,63 @@ DeclareOperation( "PositionSortedOp", [ IsList, IsObject, IsFunction ] );
 #T DeclareOperation( "PositionSorted", [ IsHomogeneousList, IsObject ] );
 #T note the problem with inhomogeneous lists that may be sorted
 #T (although they cannot store this and claim that they are not sorted)
+
+
+#############################################################################
+##
+#F  PositionSortedBy( <list>, <val>, <func> )
+##
+##  <#GAPDoc Label="PositionSortedBy">
+##  <ManSection>
+##  <Func Name="PositionSortedBy" Arg='list, val, func'/>
+##
+##  <Description>
+##  <Index Key="PositionSortedByOp"><C>PositionSortedByOp</C></Index>
+##  This function returns the same value that would be returned by
+##  <C>PositionSorted(List(list, func), val)</C>, but computes it in
+##  a more efficient way.
+##  <P/>
+##  To be more precise, <A>func</A> must be a function on one argument which
+##  returns values that can be compared to <A>val</A>, and <A>list</A>
+##  must be a list for which <C>func(list[i]) &lt;= func(list[i+1])</C> holds
+##  for all relevant <A>i</A>. This property is not verified, and if the
+##  input violates it, then the result is undefined.
+##  <P/>
+##  <Ref Func="PositionSortedBy"/> returns <A>pos</A> such that
+##  <M><A>func</A>(<A>list</A>[<A>pos</A>-1]) &lt; <A>val</A>
+##  \leq <A>func</A>(<A>list</A>[<A>pos</A>])</M> holds.
+##  That means, if there are elements <C>elm</C> in <A>list</A>
+##  for which <M><A>func</A>(elm) = <A>val</A></M> holds, then
+##  the position of the first such element is returned.
+##  If no element of <A>list</A> satisfies this condition, then
+##  the lowest index where an element <A>elm</A> satisfying
+##  <M><A>func</A>(elm) = <A>val</A></M> must be inserted to preserve
+##  the property <C>func(list[i]) &lt;= func(list[i+1])</C> is returned.
+##  <P/>
+##  <Ref Func="PositionSortedBy"/> uses binary search.
+##  Each <C>func(list[i])</C> is computed at most once.
+##  <P/>
+##  Specialized functions for certain kinds of lists must be installed
+##  as methods for the operation <C>PositionSortedByOp</C>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> PositionSortedBy( [ "", "ab", ], -1, Length );
+##  1
+##  gap> PositionSortedBy( [ "", "ab", ], 0, Length );
+##  1
+##  gap> PositionSortedBy( [ "", "ab", ], 1, Length );
+##  2
+##  gap> PositionSortedBy( [ "", "ab", ], 2, Length );
+##  2
+##  gap> PositionSortedBy( [ "", "ab", ], 3, Length );
+##  3
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "PositionSortedBy" );
+DeclareOperation("PositionSortedByOp", [ IsList, IsObject, IsFunction ]);
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -1488,6 +1488,42 @@ InstallMethod( PositionSortedOp,
     fi;
     end );
 
+#############################################################################
+##
+#F  PositionSortedBy( <list>, <val>, <func> )
+#F  PositionSortedByOp( <list>, <val>, <func> )
+##
+InstallGlobalFunction( PositionSortedBy, function( list, val, func )
+  if IsPlistRep(list) then
+    return POSITION_SORTED_BY(list, val, func);
+  else
+    return PositionSortedByOp(list, val, func);
+  fi;
+end);
+
+InstallMethod( PositionSortedByOp,
+    "for a dense plain list, an object and a function",
+    [ IsDenseList and IsPlistRep, IsObject, IsFunction ],
+    POSITION_SORTED_BY);
+
+InstallMethod( PositionSortedByOp,
+    "for a dense list, an object and a function",
+    [ IsDenseList, IsObject, IsFunction ],
+function ( list, val, func )
+local l, h, m;
+  # simple binary search. The entry is in the range [l..h]
+  l := 0;
+  h := Length(list) + 1;
+  while l + 1 < h do        # list[l] < val && val <= list[h]
+    m := QuoInt(l + h, 2);  # l < m < h
+    if func(list[m]) < val then
+      l := m;      # it's not in [lo..m], so take the upper part.
+    else
+      h := m;      # So val<=list[m][1], so the new range is [1..m].
+    fi;
+  od;
+  return h;
+end );
 
 #############################################################################
 ##

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -457,6 +457,34 @@ FuncPOSITION_SORTED_LIST_COMP(Obj self, Obj list, Obj obj, Obj func)
 
 /****************************************************************************
 **
+**  Low-level implementations of PositionSortedBy for dense Plists and lists.
+*/
+static Obj FuncPOSITION_SORTED_BY(Obj self, Obj list, Obj val, Obj func)
+{
+    RequirePlainList("POSITION_SORTED_BY", list);
+    RequireFunction("POSITION_SORTED_BY", func);
+
+    // perform the binary search to find the position
+    UInt l = 0;
+    UInt h = LEN_PLIST(list) + 1;
+    while (l + 1 < h) {       // list[l] < val && val <= list[h]
+        UInt m = (l + h) / 2; // l < m < h
+        Obj  v = CALL_1ARGS(func, ELM_PLIST(list, m));
+        if (LT(v, val)) {
+            l = m;
+        }
+        else {
+            h = m;
+        }
+    }
+
+    // return the result
+    return INTOBJ_INT(h);
+}
+
+
+/****************************************************************************
+**
 *F  SORT_LIST( <list> )  . . . . . . . . . . . . . . . . . . . .  sort a list
 *F  SortDensePlist( <list> ) . . . . . . . . . . . . . . . . . .  sort a list
 **
@@ -1529,6 +1557,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC(APPEND_LIST_INTR, 2, "list1, list2"),
     GVAR_FUNC(POSITION_SORTED_LIST, 2, "list, obj"),
     GVAR_FUNC(POSITION_SORTED_LIST_COMP, 3, "list, obj, func"),
+    GVAR_FUNC(POSITION_SORTED_BY, 3, "list, val, func"),
     GVAR_FUNC(SORT_LIST, 1, "list"),
     GVAR_FUNC(STABLE_SORT_LIST, 1, "list"),
     GVAR_FUNC(SORT_LIST_COMP, 2, "list, func"),

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -416,6 +416,48 @@ gap> Positions( ll, 4 );
 gap> HasIsSSortedList( Positions( ll, 2 ) );
 true
 
+# PositionSortedBy on plist
+gap> ll := [ 1, 3 ];;
+gap> PositionSortedBy(ll, 0, x -> x);
+1
+gap> PositionSortedBy(ll, 1, x -> x);
+1
+gap> PositionSortedBy(ll, 2, x -> x);
+2
+gap> PositionSortedBy(ll, 3, x -> x);
+2
+gap> PositionSortedBy(ll, 4, x -> x);
+3
+gap> PositionSortedBy([], 0, x -> x);
+1
+gap> for ll in [ [1], [1,2], [1,2,3], [1,2,3,4], [1,4] ] do
+>   for a in [0..5] do
+>     p := PositionSortedBy(ll, a, x -> x);
+>     Assert(0, p = 1 or ll[p-1] < a);
+>     Assert(0, p = Length(ll) + 1 or a <= ll[p]);
+>   od;
+> od;
+
+# PositionSortedBy on range
+gap> ll := [ 1, 3 .. 3 ];;
+gap> PositionSortedBy(ll, 0, x -> x);
+1
+gap> PositionSortedBy(ll, 1, x -> x);
+1
+gap> PositionSortedBy(ll, 2, x -> x);
+2
+gap> PositionSortedBy(ll, 3, x -> x);
+2
+gap> PositionSortedBy(ll, 4, x -> x);
+3
+gap> for ll in [ [1..2], [1..3], [1..4], [1,4..4] ] do
+>   for a in [0..5] do
+>     p := PositionSortedBy(ll, a, x -> x);
+>     Assert(0, p = 1 or ll[p-1] < a);
+>     Assert(0, p = Length(ll) + 1 or a <= ll[p]);
+>   od;
+> od;
+
 # PositionsProperty
 gap> ll := [ 1, , "s" ];;
 gap> PositionsProperty( ll, ReturnTrue );


### PR DESCRIPTION
One thing to point out is that the interface is a bit different from
PositionSorted, which might be confusing: the object you pass in is
*not* a (potential) element of the list, but rather the result of
applying the "by func" to an object (or at least something that looks
like such a result). The reason: first off, replacing the element by its
func value would be the very first thing done by any implementation
anyway. And a typical application of this function is to search for an
object matching a a certain criterion -- say, the first item which is a
list whose first entry is 42. With the current model, one can write

    PositionSortedBy([ "a", "ab" ], 4, Length);

and is not forced to first construct an actual object, like here:

    PositionSortedBy([ "a", "ab" ], "abcd", Length);

In this example, that's a pretty small saving, but in bigger examples,
it can add up. In particular, this is motivated by real world usage
of this function.

---

By the way, this is perhaps my oldest still active branch for GAP: I wrote
it in early 2014, around the time I discovered `PositionFirstComponent`
and tried to get rid of that (which finally happened this year). I then never
could get myself to clean this up, but today I wanted to have such a function
in `recog`, so I finally had a good enough reason to dig in and write documentation
and tests and all that ;-)
