### PR TITLE
ReductionToFiniteField tries to change an immutable object.

### DIFF
--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -4320,7 +4320,7 @@ InstallGlobalFunction( ReductionToFiniteField, function( value, p )
 
     if k <> 1 then
 
-      primes:= PrimeDivisors( m );
+      primes:= ShallowCopy( PrimeDivisors( m ) );
       sol:= fail;
 
       while not IsEmpty( primes ) do


### PR DESCRIPTION
# Description

The `PrimeDivisors` function returns an immutable object, but `ReductionToFiniteField` attempts to change it with `IntersectSet`.  Make a `ShallowCopy` to fix the issue.

## Further details

To see the bug in action, with Browse and CTblLib both loaded, run `BrowseGapData();` and choose "Common Irrationalities (CTblLib)" from the list.  With gap 4.10.2 you will see:

```
(computing ...)
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
            Error, no 1st choice method found for `IntersectSet' on 2 arguments at /usr/lib/gap/lib/methsel2.g:250 called from
IntersectSet( primes, Factors( m ) ); at /usr/lib/gap/lib/ctblfuns.gi:4364 called from
ReductionToFiniteField( infos[i].value, p 
 ) at /usr/lib/gap/pkg/ctbllib/gap4/brirrat.g:501 called from
mainfun( t, k, j ) at /usr/lib/gap/pkg/Browse/lib/browse.gi:1601 called from
BrowseData.HeightRow( t, i ) at /usr/lib/gap/pkg/Browse/lib/browse.gi:1826 called from
BrowseData.LengthCell( t, i, "vert" 
 ) at /usr/lib/gap/pkg/Browse/lib/browse.gi:6343 called from
...  at *stdin*:1
type 'quit;' to quit to outer loop
```

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

