### PR TITLE
`STRING_LIST_DIR`: `LIST_DIR` may return `fail`

### DIFF
--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -751,5 +751,12 @@ DeclareGlobalFunction("UnhideGlobalVariables");
 ##
 ##  Still used in Browse (06/2019)
 BindGlobal("STRING_LIST_DIR", function(dirname)
-    return JoinStringsWithSeparator(LIST_DIR(dirname), "\000");
+    local list;
+
+    list:= LIST_DIR( dirname );
+    if list = fail then
+      return fail;
+    else
+      return JoinStringsWithSeparator( list, "\000" );
+    fi;
 end);


### PR DESCRIPTION
As long as the now obsolete `STRING_LIST_DIR` is available,
it must handle also the case that the argument is not a directory path.