### PR TITLE
kernel: rename ELM2_LIST -> ELM_MAT, etc.

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -2365,7 +2365,7 @@ void CodeAssList ( Int narg )
     if (narg == 1)
       ass = NewStat( STAT_ASS_LIST, 3 * sizeof(Stat) );
     else /* if (narg == 2) */
-      ass = NewStat( STAT_ASS2_LIST, 4 * sizeof(Stat));
+      ass = NewStat( STAT_ASS_MAT, 4 * sizeof(Stat));
 
     /* let 'CodeAssListUniv' do the rest                                   */
     CodeAssListUniv( ass, narg );
@@ -2478,7 +2478,7 @@ void CodeElmList ( Int narg )
     if (narg == 1)
       ref = NewExpr( EXPR_ELM_LIST, 2 * sizeof(Expr) );
     else /* if (narg == 2) */
-      ref = NewExpr( EXPR_ELM2_LIST, 3 * sizeof(Expr) );
+      ref = NewExpr( EXPR_ELM_MAT, 3 * sizeof(Expr) );
       
     /* let 'CodeElmListUniv' to the rest                                   */
     CodeElmListUniv( ref, narg );

--- a/src/code.h
+++ b/src/code.h
@@ -246,7 +246,7 @@ enum STAT_TNUM {
         STAT_UNB_GVAR,
 
         STAT_ASS_LIST,
-        STAT_ASS2_LIST,
+        STAT_ASS_MAT,
         STAT_ASSS_LIST,
         STAT_ASS_LIST_LEV,
         STAT_ASSS_LIST_LEV,
@@ -498,7 +498,7 @@ enum EXPR_TNUM {
     EXPR_ISB_GVAR,
 
     EXPR_ELM_LIST,
-    EXPR_ELM2_LIST,
+    EXPR_ELM_MAT,
     EXPR_ELMS_LIST,
     EXPR_ELM_LIST_LEV,
     EXPR_ELMS_LIST_LEV,

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -2826,11 +2826,11 @@ void            IntrAssList ( Int narg )
       }
     }
     else if (narg == 2) {
-      Obj pos2 = PopObj();
-      Obj pos1 = PopObj();
+      Obj col = PopObj();
+      Obj row = PopObj();
       list = PopObj();
 
-      ASS2_LIST(list, pos1, pos2, rhs);
+      ASS_MAT(list, row, col, rhs);
     }
 
     /* push the right hand side again                                      */
@@ -2966,11 +2966,11 @@ void            IntrUnbList ( Int narg )
       }
     }
     else if (narg == 2) {
-      Obj pos2 = PopObj();
-      Obj pos1 = PopObj();
+      Obj col = PopObj();
+      Obj row = PopObj();
       list = PopObj();
 
-      UNB2_LIST(list, pos1, pos2);
+      UNB_MAT(list, row, col);
     }
 
     /* push void                                                           */
@@ -3014,11 +3014,11 @@ void            IntrElmList ( Int narg )
       }
     }
     else /*if (narg == 2)*/ {
-      Obj pos2 = PopObj();
-      Obj pos1 = PopObj();
+      Obj col = PopObj();
+      Obj row = PopObj();
       list = PopObj();
 
-      elm = ELM2_LIST(list, pos1, pos2);
+      elm = ELM_MAT(list, row, col);
     }
 
     /* push the element                                                    */
@@ -3140,11 +3140,11 @@ void            IntrIsbList ( Int narg )
       }
     }
     else /*if (narg == 2)*/ {
-      Obj pos2 = PopObj();
-      Obj pos1 = PopObj();
+      Obj col = PopObj();
+      Obj row = PopObj();
       list = PopObj();
 
-      isb = ISB2_LIST(list, pos1, pos2) ? True : False;
+      isb = ISB_MAT(list, row, col) ? True : False;
     }
 
     /* push the result                                                     */

--- a/src/lists.c
+++ b/src/lists.c
@@ -285,9 +285,9 @@ Int             ISBB_LIST (
     return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
-Int ISB2_LIST(Obj list, Obj pos1, Obj pos2)
+Int ISB_MAT(Obj list, Obj row, Obj col)
 {
-    return DoOperation3Args( IsbListOper, list, pos1, pos2 ) == True;
+    return DoOperation3Args(IsbListOper, list, row, col) == True;
 }
 
 
@@ -500,25 +500,25 @@ Obj ELMB_LIST(Obj list, Obj pos)
     return elm;
 }
 
-Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2)
+Obj ELM_MAT(Obj list, Obj row, Obj col)
 {
-    if (IS_POS_INTOBJ(pos1) && IS_POS_INTOBJ(pos2) && IS_PLIST(list)) {
-        Int p1 = INT_INTOBJ(pos1);
-        if ( p1 <= LEN_PLIST(list) ) {
-            Obj row = ELM_PLIST( list, p1 );
-            Int p2 = INT_INTOBJ(pos2);
+    if (IS_POS_INTOBJ(row) && IS_POS_INTOBJ(col) && IS_PLIST(list)) {
+        Int r = INT_INTOBJ(row);
+        if (r <= LEN_PLIST(list)) {
+            Obj rowlist = ELM_PLIST(list, r);
+            Int c = INT_INTOBJ(col);
 
-            if ( IS_PLIST(row) && p2 <= LEN_PLIST(row) ) {
-                return ELM_PLIST( row, p2 );
+            if (IS_PLIST(rowlist) && c <= LEN_PLIST(rowlist)) {
+                return ELM_PLIST(rowlist, c);
             }
 
             // fallback to generic list access code (also triggers error if
             // row isn't a list)
-            return ELM_LIST( row, p2 );
+            return ELM_LIST(rowlist, c);
         }
     }
 
-    Obj elm = DoOperation3Args( ElmListOper, list, pos1, pos2 );
+    Obj elm = DoOperation3Args(ElmListOper, list, row, col);
     if (elm == 0) {
         ErrorMayQuit("List access method must return a value", 0, 0);
     }
@@ -800,10 +800,11 @@ void            UNBB_LIST (
     DoOperation2Args( UnbListOper, list, pos );
 }
 
-void UNB2_LIST(Obj list, Obj pos1, Obj pos2)
+void UNB_MAT(Obj list, Obj row, Obj col)
 {
-    DoOperation3Args( UnbListOper, list, pos1, pos2 );
+    DoOperation3Args(UnbListOper, list, row, col);
 }
+
 
 /****************************************************************************
 **
@@ -863,23 +864,22 @@ void ASSB_LIST (
     DoOperation3Args( AssListOper, list, pos, obj );
 }
 
-void ASS2_LIST(Obj mat, Obj pos1, Obj pos2, Obj obj)
+void ASS_MAT(Obj mat, Obj row, Obj col, Obj obj)
 {
     RequireMutable("Matrix Assignment", mat, "matrix");
-    if (IS_POS_INTOBJ(pos1) && IS_POS_INTOBJ(pos2) && IS_PLIST(mat)) {
-        Int p1 = INT_INTOBJ(pos1);
-        if (p1 <= LEN_PLIST(mat)) {
-            Obj row = ELM_PLIST(mat, p1);
-            Int p2 = INT_INTOBJ(pos2);
+    if (IS_POS_INTOBJ(row) && IS_POS_INTOBJ(col) && IS_PLIST(mat)) {
+        Int r = INT_INTOBJ(row);
+        if (r <= LEN_PLIST(mat)) {
+            Obj rowlist = ELM_PLIST(mat, r);
+            Int c = INT_INTOBJ(col);
 
-            ASS_LIST( row, p2, obj );
+            ASS_LIST(rowlist, c, obj);
             return;
         }
     }
 
-    DoOperation4Args(AssListOper, mat, pos1, pos2, obj);
+    DoOperation4Args(AssListOper, mat, row, col, obj);
 }
-
 
 
 /****************************************************************************
@@ -1393,10 +1393,10 @@ void            ElmListLevel (
     Obj                 list;           /* one list from <lists>           */
     Obj                 elm;            /* selected element from <list>    */
     Int                 i;              /* loop variable                   */
-    Obj pos;
-    Obj pos1;
-    Obj pos2;
-      
+    Obj                 pos;
+    Obj                 row;
+    Obj                 col;
+
 
     /* if <level> is one, perform the replacements                         */
     if ( level == 1 ) {
@@ -1419,10 +1419,10 @@ void            ElmListLevel (
               break;
           
             case 2:
-              pos1 = ELM_PLIST(ixs,1);
-              pos2 = ELM_PLIST(ixs,2);
-              elm = ELM2_LIST(list, pos1, pos2);
-              break;
+                row = ELM_PLIST(ixs, 1);
+                col = ELM_PLIST(ixs, 2);
+                elm = ELM_MAT(list, row, col);
+                break;
 
             default:
               elm = ELMB_LIST(list, ixs);
@@ -1556,7 +1556,9 @@ void            AssListLevel (
     Obj                 list;           /* one list of <lists>             */
     Obj                 obj;            /* one value from <objs>           */
     Int                 i;              /* loop variable                   */
-    Obj pos,pos1,pos2;
+    Obj                 pos;
+    Obj                 row;
+    Obj                 col;
 
     /* check <objs>                                                        */
     RequireDenseList("List Assignments", objs);
@@ -1586,10 +1588,10 @@ void            AssListLevel (
               break;
           
             case 2:
-              pos1 = ELM_PLIST(ixs,1);
-              pos2 = ELM_PLIST(ixs,2);
-              ASS2_LIST(list, pos1, pos2, obj);
-              break;
+                row = ELM_PLIST(ixs, 1);
+                col = ELM_PLIST(ixs, 2);
+                ASS_MAT(list, row, col, obj);
+                break;
 
             default:
               ASSB_LIST(list, ixs, obj);

--- a/src/lists.h
+++ b/src/lists.h
@@ -197,7 +197,7 @@ EXPORT_INLINE Int ISB_LIST(Obj list, Int pos)
 
 Int ISBB_LIST(Obj list, Obj pos);
 
-Int ISB2_LIST(Obj list, Obj pos1, Obj pos2);
+Int ISB_MAT(Obj list, Obj row, Obj col);
 
 
 /****************************************************************************
@@ -324,14 +324,14 @@ EXPORT_INLINE Obj ELM_LIST(Obj list, Int pos)
 
 /****************************************************************************
 **
-*F  ELM2_LIST( <list>, <pos1>, <pos2> ) . . . . select an element from a list
+*F  ELM_MAT( <list>, <row>, <col> ) . . . . select an element from a list
 **
-**  'ELM2_LIST' implements 'list[pos1,pos2]', which for lists of lists is
-**  defined as 'list[pos1][pos2]', and for other kind of objects is handled
-**  by method dispatch through the GAP attribute 'ELM_LIST' with three
+**  'ELM_MAT' implements 'list[row,col]', which for lists of lists is
+**  defined as 'list[row][col]', and for other kind of objects is handled
+**  by method dispatch through the GAP operation 'ELM_LIST' with three
 **  arguments.
 */
-Obj ELM2_LIST(Obj list, Obj pos1, Obj pos2);
+Obj ELM_MAT(Obj list, Obj row, Obj col);
 
 
 /****************************************************************************
@@ -481,7 +481,7 @@ EXPORT_INLINE void UNB_LIST(Obj list, Int pos)
     (*UnbListFuncs[TNUM_OBJ(list)])(list, pos);
 }
 
-void UNB2_LIST(Obj list, Obj pos1, Obj pos2);
+void UNB_MAT(Obj list, Obj row, Obj col);
 
 
 /****************************************************************************
@@ -521,14 +521,14 @@ EXPORT_INLINE void ASS_LIST(Obj list, Int pos, Obj obj)
 
 /****************************************************************************
 **
-*F  ASS2_LIST( <list>, <pos1>, <pos2>, <obj> )
+*F  ASS_MAT( <mat>, <row>, <col>, <obj> )
 **
-**  'ASS2_LIST' implements 'list[pos1,pos2]:=obj', which for lists of lists
-**  is defined as 'list[pos1][pos2]:=obj', and for other kind of objects is
-**  handled by method dispatch through the GAP attribute 'ASS_LIST' with
+**  'ASS_MAT' implements 'mat[row,col]:=obj', which for lists of lists
+**  is defined as 'mat[row][col]:=obj', and for other kind of objects is
+**  handled by method dispatch through the GAP operation 'ASS_LIST' with
 **  three arguments.
 */
-void ASS2_LIST(Obj list, Obj pos1, Obj pos2, Obj obj);
+void ASS_MAT(Obj list, Obj row, Obj col, Obj obj);
 
 
 /****************************************************************************

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -738,7 +738,7 @@ static const CompilerT Compilers[] = {
     COMPILER_(
         STAT_ASS_LIST, ARG_EXPR_("list"), ARG_EXPR_("pos"), ARG_EXPR_("rhs")),
     COMPILER_(
-        STAT_ASS2_LIST, ARG_EXPR_("list"), ARG_EXPR_("pos"), ARG_EXPR_("rhs")),
+        STAT_ASS_MAT, ARG_EXPR_("list"), ARG_EXPR_("row"), ARG_EXPR_("col"), ARG_EXPR_("rhs")),
     COMPILER_(
         STAT_ASSS_LIST, ARG_EXPR_("list"), ARG_EXPR_("poss"), ARG_EXPR_("rhss")),
     COMPILER_(STAT_ASS_LIST_LEV,
@@ -863,7 +863,7 @@ static const CompilerT Compilers[] = {
     // TODO: can this be unified?
     COMPILER_(EXPR_ELM_LIST, ARG_EXPR_("list"), ARG_EXPR_("pos")),
     COMPILER_(
-        EXPR_ELM2_LIST, ARG_EXPR_("list"), ARG_EXPR_("pos1"), ARG_EXPR_("pos2")),
+        EXPR_ELM_MAT, ARG_EXPR_("list"), ARG_EXPR_("row"), ARG_EXPR_("col")),
     COMPILER_(EXPR_ELMS_LIST, ARG_EXPR_("list"), ARG_EXPR_("poss")),
     COMPILER_(EXPR_ELM_LIST_LEV,
               ARG_EXPR_("lists"),

--- a/src/vars.c
+++ b/src/vars.c
@@ -557,31 +557,26 @@ static UInt ExecAssList(Expr stat)
 }
 /****************************************************************************
 **
-*F  ExecAss2List(<ass>)  . . . . . . . . . . .  assign to an element of a list
+*F  ExecAssMat(<ass>) . . . . . . . . . . .  assign to an element of a matrix
 **
-**  'ExecAss2List'  executes the list  assignment statement <stat> of the form
-**  '<list>[<position>,<position>] := <rhs>;'.
+**  'ExecAssMat' executes the matrix assignment statement <stat> of the form
+**  '<mat>[<row>,<col>] := <rhs>;'.
 */
-static UInt ExecAss2List(Expr stat)
+static UInt ExecAssMat(Expr stat)
 {
-    Obj                 list;           /* list, left operand              */
-    Obj                 pos1;           /* position, left operand          */
-    Obj                 pos2;           /* position, left operand          */
-    Obj                 rhs;            /* right hand side, right operand  */
+    // evaluate the matrix (checking is done by 'ASS_MAT')
+    Obj mat = EVAL_EXPR(READ_STAT(stat, 0));
 
-    /* evaluate the list (checking is done by 'ASS_LIST')                  */
-    list = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate and check the row and column
+    Obj row = EVAL_EXPR(READ_STAT(stat, 1));
+    Obj col = EVAL_EXPR(READ_STAT(stat, 2));
 
-    /* evaluate the position                                               */
-    pos1 = EVAL_EXPR(READ_STAT(stat, 1));
-    pos2 = EVAL_EXPR(READ_STAT(stat, 2));
+    // evaluate the right hand side
+    Obj rhs = EVAL_EXPR(READ_STAT(stat, 3));
 
-    /* evaluate the right hand side                                        */
-    rhs = EVAL_EXPR(READ_STAT(stat, 3));
+    ASS_MAT(mat, row, col, rhs);
 
-    ASS2_LIST( list, pos1, pos2, rhs );
-
-    /* return 0 (to indicate that no leave-statement was executed)         */
+    // return 0 (to indicate that no leave-statement was executed)
     return 0;
 }
 
@@ -802,29 +797,22 @@ static Obj EvalElmList(Expr expr)
 
 /****************************************************************************
 **
-*F  EvalElm2List(<expr>) . . . . . . . . . . . . select an element of a list
+*F  EvalElmMat(<expr>) . . . . . . . . . . . .  select an element of a matrix
 **
-**  'EvalElm2List' evaluates the list  element expression  <expr> of the  form
-**  '<list>[<pos1>,<pos2>]'.
+**  'EvalElmMat' evaluates the matrix element expression <expr> of the form
+**  '<mat>[<row>,<col>]'.
 */
-static Obj EvalElm2List(Expr expr)
+static Obj EvalElmMat(Expr expr)
 {
-    Obj                 elm;            /* element, result                 */
-    Obj                 list;           /* list, left operand              */
-    Obj                 pos1;           /* position, right operand         */
-    Obj                 pos2;           /* position, right operand         */
+    // evaluate the matrix (checking is done by 'ELM_MAT')
+    Obj mat = EVAL_EXPR(READ_EXPR(expr, 0));
 
-    /* evaluate the list (checking is done by 'ELM2_LIST')                 */
-    list = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate and check the row and column
+    Obj row = EVAL_EXPR(READ_EXPR(expr, 1));
+    Obj col = EVAL_EXPR(READ_EXPR(expr, 2));
 
-    /* evaluate and check the positions                                    */
-    pos1 = EVAL_EXPR(READ_EXPR(expr, 1));
-    pos2 = EVAL_EXPR(READ_EXPR(expr, 2));
-
-    elm = ELM2_LIST(list, pos1, pos2);
-
-    /* return the element                                                  */
-    return elm;
+    // return the element
+    return ELM_MAT(mat, row, col);
 }
 
 
@@ -999,7 +987,7 @@ static void PrintAssList(Stat stat)
     Pr("%2<;",0L,0L);
 }
 
-static void PrintAss2List(Stat stat)
+static void PrintAssMat(Stat stat)
 {
     Pr("%4>",0L,0L);
     PrintExpr(READ_EXPR(stat, 0));
@@ -1071,7 +1059,7 @@ static void PrintElmList(Expr expr)
     Pr("%<]",0L,0L);
 }
 
-static void PrintElm2List(Expr expr)
+static void PrintElmMat(Expr expr)
 {
     Pr("%2>",0L,0L);
     PrintExpr(READ_EXPR(expr, 0));
@@ -2222,23 +2210,18 @@ static Int InitKernel (
     InstallPrintExprFunc( EXPR_REF_GVAR       , PrintRefGVar);
     InstallPrintExprFunc( EXPR_ISB_GVAR       , PrintIsbGVar);
 
-    /* install executors, evaluators, and printers for list elements       */
+    // install executors, evaluators, and printers for list elements
     InstallExecStatFunc( STAT_ASS_LIST       , ExecAssList);
     InstallExecStatFunc( STAT_ASSS_LIST      , ExecAsssList);
     InstallExecStatFunc( STAT_ASS_LIST_LEV   , ExecAssListLevel);
     InstallExecStatFunc( STAT_ASSS_LIST_LEV  , ExecAsssListLevel);
-    InstallExecStatFunc( STAT_ASS2_LIST  , ExecAss2List);
-    InstallPrintStatFunc( STAT_ASS2_LIST  , PrintAss2List);
-    
     InstallExecStatFunc( STAT_UNB_LIST       , ExecUnbList);
     InstallEvalExprFunc( EXPR_ELM_LIST       , EvalElmList);
     InstallEvalExprFunc( EXPR_ELMS_LIST      , EvalElmsList);
     InstallEvalExprFunc( EXPR_ELM_LIST_LEV   , EvalElmListLevel);
     InstallEvalExprFunc( EXPR_ELMS_LIST_LEV  , EvalElmsListLevel);
     InstallEvalExprFunc( EXPR_ISB_LIST       , EvalIsbList);
-    InstallEvalExprFunc( EXPR_ELM2_LIST      , EvalElm2List);
-    InstallPrintExprFunc( EXPR_ELM2_LIST     , PrintElm2List);
-    
+
     InstallPrintStatFunc( STAT_ASS_LIST       , PrintAssList);
     InstallPrintStatFunc( STAT_ASSS_LIST      , PrintAsssList);
     InstallPrintStatFunc( STAT_ASS_LIST_LEV   , PrintAssList);
@@ -2250,8 +2233,13 @@ static Int InitKernel (
     InstallPrintExprFunc( EXPR_ELMS_LIST_LEV  , PrintElmsList);
     InstallPrintExprFunc( EXPR_ISB_LIST       , PrintIsbList);
 
+    // install executors, evaluators, and printers for matrix elements
+    InstallExecStatFunc(STAT_ASS_MAT, ExecAssMat);
+    InstallEvalExprFunc(EXPR_ELM_MAT, EvalElmMat);
+    InstallPrintStatFunc(STAT_ASS_MAT, PrintAssMat);
+    InstallPrintExprFunc(EXPR_ELM_MAT, PrintElmMat);
 
-    /* install executors, evaluators, and printers for record elements     */
+    // install executors, evaluators, and printers for record elements
     InstallExecStatFunc( STAT_ASS_REC_NAME   , ExecAssRecName);
     InstallExecStatFunc( STAT_ASS_REC_EXPR   , ExecAssRecExpr);
     InstallExecStatFunc( STAT_UNB_REC_NAME   , ExecUnbRecName);
@@ -2269,7 +2257,7 @@ static Int InitKernel (
     InstallPrintExprFunc( EXPR_ISB_REC_NAME   , PrintIsbRecName);
     InstallPrintExprFunc( EXPR_ISB_REC_EXPR   , PrintIsbRecExpr);
 
-    /* install executors, evaluators, and printers for list elements       */
+    // install executors, evaluators, and printers for positional objects
     InstallExecStatFunc( STAT_ASS_POSOBJ       , ExecAssPosObj);
     InstallExecStatFunc( STAT_UNB_POSOBJ       , ExecUnbPosObj);
     InstallEvalExprFunc( EXPR_ELM_POSOBJ       , EvalElmPosObj);
@@ -2279,7 +2267,7 @@ static Int InitKernel (
     InstallPrintExprFunc( EXPR_ELM_POSOBJ       , PrintElmPosObj);
     InstallPrintExprFunc( EXPR_ISB_POSOBJ       , PrintIsbPosObj);
 
-    /* install executors, evaluators, and printers for record elements     */
+    // install executors, evaluators, and printers for component objects
     InstallExecStatFunc( STAT_ASS_COMOBJ_NAME  , ExecAssComObjName);
     InstallExecStatFunc( STAT_ASS_COMOBJ_EXPR  , ExecAssComObjExpr);
     InstallExecStatFunc( STAT_UNB_COMOBJ_NAME  , ExecUnbComObjName);

--- a/tst/testinstall/syntaxtree.tst
+++ b/tst/testinstall/syntaxtree.tst
@@ -1306,7 +1306,7 @@ rec(
   variadic := false )
 true
 
-# STAT_ASS2_LIST
+# STAT_ASS_MAT
 gap> testit(function(x) x[42,23] := 1; end);
 rec(
   nams := [ "x" ],
@@ -1314,16 +1314,19 @@ rec(
   nloc := 0,
   stats := rec(
       statements := [ rec(
+              col := rec(
+                  type := "EXPR_INT",
+                  value := 23 ),
               list := rec(
                   lvar := 1,
                   type := "EXPR_REF_LVAR" ),
-              pos := rec(
-                  type := "EXPR_INT",
-                  value := 42 ),
               rhs := rec(
                   type := "EXPR_INT",
-                  value := 23 ),
-              type := "STAT_ASS2_LIST" ), rec(
+                  value := 1 ),
+              row := rec(
+                  type := "EXPR_INT",
+                  value := 42 ),
+              type := "STAT_ASS_MAT" ), rec(
               type := "STAT_RETURN_VOID" ) ],
       type := "STAT_SEQ_STAT2" ),
   type := "EXPR_FUNC",
@@ -3055,7 +3058,7 @@ rec(
   variadic := false )
 true
 
-# EXPR_ELM2_LIST
+# EXPR_ELM_MAT
 gap> testit(x -> x[42,23]);
 rec(
   nams := [ "x" ],
@@ -3064,16 +3067,16 @@ rec(
   stats := rec(
       statements := [ rec(
               obj := rec(
+                  col := rec(
+                      type := "EXPR_INT",
+                      value := 23 ),
                   list := rec(
                       lvar := 1,
                       type := "EXPR_REF_LVAR" ),
-                  pos1 := rec(
+                  row := rec(
                       type := "EXPR_INT",
                       value := 42 ),
-                  pos2 := rec(
-                      type := "EXPR_INT",
-                      value := 23 ),
-                  type := "EXPR_ELM2_LIST" ),
+                  type := "EXPR_ELM_MAT" ),
               type := "STAT_RETURN_OBJ" ) ],
       type := "STAT_SEQ_STAT" ),
   type := "EXPR_FUNC",


### PR DESCRIPTION
Also fixed a minor bug in the syntax tree code for `STAT_ASS_MAT` (formerly known as `STAT_ASS2_LIST`).

I think these new names are much easier to grasp for somebody looking at the kernel code then the old ones.

I have further PRs lined up which build on this, to add libgap APIs for matrices; to restrict the row/column arguments to positive integers; and to split the "matrix" access functions into separate operations (so instead of installing a method for `ELM_LIST` resp. `\[\]`, you'd install it for `ELM_MAT` resp. `\[\,\]`;  and `MatElm` would become a synonym for that; similar for `ASS_LIST`/`ASS_MAT`/`\[\,\]\:\=`/`SetMatElm`). But those all may be more controversial; I hope this PR isn't.

Note that this doesn't affect any packages as far as I know, as no kernel extension uses `ELM2_LIST` or `ASS2_LIST`.


I also renamed `ISB2_LIST` to `ISB_MAT` and `UNB2_LIST` to `UNB_MAT`, but actually I am seriously considering that we might want to drop support for unbinding matrix entries; matrices should never have unbound entries, after all. But that, too, is a rather bigger and potentially controversial change, so...

