### PR TITLE
Add new kernel operations ELM_MAT, ASS_MAT

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -106,7 +106,7 @@ InstallValue( TYPE_FIELDINFO_8BIT, TYPE_KERNEL_OBJECT);
 #M  Length( <vec> )
 ##
 
-InstallOtherMethod( Length, "For a compressed VecFFE", 
+InstallOtherMethod( Length, "for a compressed VecFFE", 
         true, [IsList and Is8BitVectorRep], 0, LEN_VEC8BIT);
 
 #############################################################################
@@ -114,7 +114,7 @@ InstallOtherMethod( Length, "For a compressed VecFFE",
 #M  <vec> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "For a compressed VecFFE", 
+InstallOtherMethod( \[\],  "for a compressed VecFFE", 
         true, [IsList and Is8BitVectorRep, IsPosInt], 0, ELM_VEC8BIT);
 
 #############################################################################
@@ -127,7 +127,7 @@ InstallOtherMethod( \[\],  "For a compressed VecFFE",
 ##  <vec> may also be converted back into vector rep over a bigger field.
 ##
                
-InstallOtherMethod( \[\]\:\=,  "For a compressed VecFFE", 
+InstallOtherMethod( \[\]\:\=,  "for a compressed VecFFE", 
         true, [IsMutable and IsList and Is8BitVectorRep, IsPosInt, IsObject], 
         0, ASS_VEC8BIT);
 
@@ -139,7 +139,7 @@ InstallOtherMethod( \[\]\:\=,  "For a compressed VecFFE",
 ##  turning into a plain list
 ##
 
-InstallMethod( Unbind\[\], "For a compressed VecFFE",
+InstallMethod( Unbind\[\], "for a compressed VecFFE",
         true, [IsMutable and IsList and Is8BitVectorRep, IsPosInt],
         0, UNB_VEC8BIT);
 
@@ -151,7 +151,7 @@ InstallMethod( Unbind\[\], "For a compressed VecFFE",
 ##  description is printed
 ##
 
-InstallMethod( ViewObj, "For a compressed VecFFE",
+InstallMethod( ViewObj, "for a compressed VecFFE",
         true, [Is8BitVectorRep and IsSmallList], 0,
         function( vec )
     local len;
@@ -175,7 +175,7 @@ end);
 ##  Same method as for lists in internal rep. 
 ##
 
-InstallMethod( PrintObj, "For a compressed VecFFE",
+InstallMethod( PrintObj, "for a compressed VecFFE",
         true, [Is8BitVectorRep and IsSmallList], 0,
         function( vec )
     local i,l;
@@ -198,7 +198,7 @@ end);
 ##  kernel method produces a copy in the same representation
 ##
 
-InstallMethod(ShallowCopy, "For a compressed VecFFE",
+InstallMethod(ShallowCopy, "for a compressed VecFFE",
         true, [Is8BitVectorRep and IsSmallList], 0,
         SHALLOWCOPY_VEC8BIT);
 
@@ -211,12 +211,12 @@ InstallMethod(ShallowCopy, "For a compressed VecFFE",
 ##  characteristic. Compatability of fields and vector lengths is
 ##  handled in the method
 
-InstallMethod( \+, "For two 8 bit vectors in same characteristic",
+InstallMethod( \+, "for two 8 bit vectors in same characteristic",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         SUM_VEC8BIT_VEC8BIT);
 
-InstallMethod( \+, "For a GF2 vector and an 8 bit vector of char 2",
+InstallMethod( \+, "for a GF2 vector and an 8 bit vector of char 2",
         IsIdenticalObj, [IsRowVector  and IsGF2VectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         function(v,w)
@@ -227,7 +227,7 @@ InstallMethod( \+, "For a GF2 vector and an 8 bit vector of char 2",
     fi;
 end);
 
-InstallMethod( \+, "For an 8 bit vector of char 2 and a GF2 vector",
+InstallMethod( \+, "for an 8 bit vector of char 2 and a GF2 vector",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and IsGF2VectorRep ], 0,
         function(w,v)
@@ -245,7 +245,7 @@ end);
 ##  Make the vector into a plain list (in place)
 ##
 
-InstallMethod( PlainListCopyOp, "For an 8 bit vector",
+InstallMethod( PlainListCopyOp, "for an 8 bit vector",
         true, [IsSmallList and Is8BitVectorRep], 0,
         function (v)
     PLAIN_VEC8BIT(v);
@@ -259,7 +259,7 @@ end);
 ##  alternatibe element access interface, returns fail when unbound
 ##
 
-InstallMethod(ELM0_LIST, "For an 8 bit vector",
+InstallMethod(ELM0_LIST, "for an 8 bit vector",
         true, [IsList and Is8BitVectorRep, IsPosInt], 0,
         ELM0_VEC8BIT);
 
@@ -304,12 +304,12 @@ end );
 ##
 ##  multi-element access
 ##
-InstallOtherMethod(ELMS_LIST, "For an 8 bit vector and a plain list",
+InstallOtherMethod(ELMS_LIST, "for an 8 bit vector and a plain list",
         true, [IsList and Is8BitVectorRep, 
                IsPlistRep and IsDenseList ], 0,
         ELMS_VEC8BIT);
 
-InstallOtherMethod(ELMS_LIST, "For an 8 bit vector and a range",
+InstallOtherMethod(ELMS_LIST, "for an 8 bit vector and a range",
         true, [IsList and Is8BitVectorRep, 
                IsRange and IsInternalRep ], 0,
         ELMS_VEC8BIT_RANGE);
@@ -319,7 +319,7 @@ InstallOtherMethod(ELMS_LIST, "For an 8 bit vector and a range",
 #M  <vec>*<ffe>
 ##
 
-InstallMethod(\*, "For an 8 bit vector and an FFE",
+InstallMethod(\*, "for an 8 bit vector and an FFE",
         IsCollsElms, [IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep], 0,
         PROD_VEC8BIT_FFE);
@@ -329,7 +329,7 @@ InstallMethod(\*, "For an 8 bit vector and an FFE",
 #M  <vec>*<mat>
 ##
 
-InstallMethod(\*, "For an 8 bit vector and a compatible matrix",
+InstallMethod(\*, "for an 8 bit vector and a compatible matrix",
         IsElmsColls, [IsRowVector and Is8BitVectorRep and IsSmallList
                 and IsRingElementList,
                 IsRingElementTable and IsPlistRep], 0,
@@ -363,7 +363,7 @@ end );
 #M <ffe>*<vec>
 ##
 
-InstallMethod(\*, "For an FFE and an 8 bit vector ",
+InstallMethod(\*, "for an FFE and an 8 bit vector ",
         IsElmsColls, [IsFFE and IsInternalRep, 
                 IsRowVector and Is8BitVectorRep], 
         0,
@@ -397,13 +397,13 @@ end );
 ##
 #M  <vecl> - <vecr>
 ##
-InstallMethod(\-, "For two 8bit vectors",
+InstallMethod(\-, "for two 8bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 
         0,
         DIFF_VEC8BIT_VEC8BIT );
 
-InstallMethod( \-, "For a GF2 vector and an 8 bit vector of char 2",
+InstallMethod( \-, "for a GF2 vector and an 8 bit vector of char 2",
         IsIdenticalObj, [IsRowVector and IsGF2VectorRep ,
                 IsRowVector and Is8BitVectorRep], 0,
         function(v,w)
@@ -414,7 +414,7 @@ InstallMethod( \-, "For a GF2 vector and an 8 bit vector of char 2",
     fi;
 end);
 
-InstallMethod( \-, "For an 8 bit vector of char 2 and a GF2 vector",
+InstallMethod( \-, "for an 8 bit vector of char 2 and a GF2 vector",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep ,
                 IsRowVector and IsGF2VectorRep], 0,
         function(w,v)
@@ -430,7 +430,7 @@ end);
 #M  -<vec>
 ##
 
-InstallMethod( AdditiveInverseOp, "For an 8 bit vector",
+InstallMethod( AdditiveInverseOp, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         AINV_VEC8BIT_MUTABLE);
@@ -440,7 +440,7 @@ InstallMethod( AdditiveInverseOp, "For an 8 bit vector",
 #M  -<vec>
 ##
 
-InstallMethod( AdditiveInverseSameMutability, "For an 8 bit vector",
+InstallMethod( AdditiveInverseSameMutability, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         AINV_VEC8BIT_SAME_MUTABILITY );
@@ -450,7 +450,7 @@ InstallMethod( AdditiveInverseSameMutability, "For an 8 bit vector",
 #M  -<vec>
 ##
 
-InstallMethod( AdditiveInverseImmutable, "For an 8 bit vector",
+InstallMethod( AdditiveInverseImmutable, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         AINV_VEC8BIT_IMMUTABLE );
@@ -462,7 +462,7 @@ InstallMethod( AdditiveInverseImmutable, "For an 8 bit vector",
 ##  A  mutable zero vector of the same field and length 
 ##
 
-InstallMethod( ZeroOp, "For an 8 bit vector",
+InstallMethod( ZeroOp, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         ZERO_VEC8BIT);
@@ -474,7 +474,7 @@ InstallMethod( ZeroOp, "For an 8 bit vector",
 ##  A  zero vector of the same field and length and mutability
 ##
 
-InstallMethod( ZeroSameMutability, "For an 8 bit vector",
+InstallMethod( ZeroSameMutability, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         function(v)
@@ -491,7 +491,7 @@ end );
 #M  <vec1> = <vec2>
 ##
 
-InstallMethod( \=, "For 2 8 bit vectors",
+InstallMethod( \=, "for 2 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -504,7 +504,7 @@ InstallMethod( \=, "For 2 8 bit vectors",
 ##  Usual lexicographic ordering
 ##
 
-InstallMethod( \<, "For 2 8 bit vectors",
+InstallMethod( \<, "for 2 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -516,13 +516,13 @@ InstallMethod( \<, "For 2 8 bit vectors",
 ##
 ##  scalar product
 #'
-InstallMethod( \*, "For 2 8 bit vectors",
+InstallMethod( \*, "for 2 8 bit vectors",
         IsIdenticalObj, [IsRingElementList and Is8BitVectorRep,
                 IsRingElementList and Is8BitVectorRep],
         0,
         PROD_VEC8BIT_VEC8BIT);
 
-InstallMethod( \*, "For a GF2 vector and an 8 bit vector of char 2",
+InstallMethod( \*, "for a GF2 vector and an 8 bit vector of char 2",
         IsIdenticalObj, [IsRowVector and IsGF2VectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         function(v,w)
@@ -533,7 +533,7 @@ InstallMethod( \*, "For a GF2 vector and an 8 bit vector of char 2",
     fi;
 end);
 
-InstallMethod( \*, "For an 8 bit vector of char 2 and a GF2 vector",
+InstallMethod( \*, "for an 8 bit vector of char 2 and a GF2 vector",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and IsGF2VectorRep ], 0,
         function(w,v)
@@ -551,7 +551,7 @@ end);
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element and from and to",
+InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element and from and to",
         IsCollsCollsElmsXX, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep, IsPosInt, IsPosInt ], 0,
@@ -564,7 +564,7 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element and f
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element",
+InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element",
         IsCollsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep ], 0,
@@ -577,7 +577,7 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element",
 ##  add <vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "For 2 8 bit vectors",
+InstallOtherMethod( AddRowVector, "for 2 8 bit vectors",
         IsIdenticalObj, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         ADD_ROWVECTOR_VEC8BITS_2);
@@ -589,7 +589,7 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors",
 ##  multiply <vec> by <ffe> in place
 ##
 
-InstallOtherMethod( MultVector, "For an 8 bit vector and an ffe",
+InstallOtherMethod( MultVector, "for an 8 bit vector and an ffe",
         IsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep], 0,
         MULT_VECTOR_VEC8BITS);

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1074,7 +1074,7 @@ InstallMethod( MatElm, "for an 8bit matrix and two integers",
   [ Is8BitMatrixRep, IsPosInt, IsPosInt ],
   MAT_ELM_MAT8BIT );
 InstallMethod( SetMatElm, "for an 8bit matrix, two integers, and a ffe",
-  [ Is8BitMatrixRep, IsPosInt, IsPosInt, IsFFE ],
+  [ Is8BitMatrixRep and IsMutable, IsPosInt, IsPosInt, IsFFE ],
   SET_MAT_ELM_MAT8BIT );
 InstallMethod( Matrix, "for a list of vecs, an integer, and an 8bit mat",
   [IsList, IsInt, Is8BitMatrixRep],

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -586,11 +586,6 @@ InstallOtherMethod( \[\], "for GF2 matrix",
       IsPosInt ],
     ELM_GF2MAT );
 
-InstallMethod( \[\], "for GF2 matrix",
-    [ IsGF2MatrixRep,
-      IsPosInt, IsPosInt ],
-    MAT_ELM_GF2MAT );
-
 
 #############################################################################
 ##
@@ -609,13 +604,6 @@ InstallOtherMethod( \[\]\:\=,
       IsPosInt,
       IsObject ],
     ASS_GF2MAT );
-
-InstallMethod( \[\]\:\=,
-    "for GF2 matrix",
-    [ IsGF2MatrixRep,
-      IsPosInt, IsPosInt,
-      IsObject ],
-    SET_MAT_ELM_GF2MAT );
 
 
 #############################################################################
@@ -2383,7 +2371,7 @@ InstallMethod( MatElm, "for a gf2 matrix and two integers",
   [ IsGF2MatrixRep, IsPosInt, IsPosInt ],
   MAT_ELM_GF2MAT );
 InstallMethod( SetMatElm, "for a gf2 matrix, two integers, and a ffe",
-  [ IsGF2MatrixRep, IsPosInt, IsPosInt, IsFFE ],
+  [ IsGF2MatrixRep and IsMutable, IsPosInt, IsPosInt, IsFFE ],
   SET_MAT_ELM_GF2MAT );
 
 InstallMethod( Matrix, "for a list of vecs, an integer, and a gf2 mat",

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -200,7 +200,7 @@ end);
 ## output methods
 ##
 
-InstallMethod(String,"For large finite field elements",
+InstallMethod(String,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     local   started,  coeffs,  fam,  s,  str,  i;
@@ -281,17 +281,17 @@ BindGlobal( "DisplayStringForLargeFiniteFieldElements",
     return s;
   end );
 
-InstallMethod(DisplayString,"For large finite field elements",
+InstallMethod(DisplayString,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         DisplayStringForLargeFiniteFieldElements );
 
-InstallMethod(Display,"For large finite field elements",
+InstallMethod(Display,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     Print(DisplayString(x));
 end);
 
-InstallMethod(ViewString,"For large finite field elements",
+InstallMethod(ViewString,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     local   s;
@@ -306,7 +306,7 @@ InstallMethod(ViewString,"For large finite field elements",
     fi;
 end);
 
-InstallMethod(ViewObj, "For large finite field elements",
+InstallMethod(ViewObj, "for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     Print(ViewString(x));
@@ -1469,7 +1469,7 @@ end);
 #M Coefficients of an element wrt the canonical basis -- are stored in the 
 ##                                                       element
 InstallMethod(Coefficients,
-        "For a FFE in Conway polynomial represntation wrt the canonical basis of its natural field",
+        "for a FFE in Conway polynomial represntation wrt the canonical basis of its natural field",
         IsCollsElms,
         [IsCanonicalBasis and IsBasisFiniteFieldRep, IsFFE and IsCoeffsModConwayPolRep],
         function(cb,x)

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5661,7 +5661,7 @@ IndependentGeneratorsOfMaximalAbelianQuotientOfFpGroup := function( G )
 end;
 
 InstallMethod( IndependentGeneratorsOfAbelianGroup,
-  "For abelian fpgroup, use Smith normal form",
+  "for abelian fpgroup, use Smith normal form",
   [ IsFpGroup and IsAbelian ],
   IndependentGeneratorsOfMaximalAbelianQuotientOfFpGroup );
 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -70,7 +70,7 @@ end);
 #M  Length( <mat> )
 ##
 
-InstallOtherMethod( Length, "For a compressed MatFFE",
+InstallOtherMethod( Length, "for a compressed MatFFE",
         true, [IsList and Is8BitMatrixRep], 0, m->m![1]);
 
 #############################################################################
@@ -78,7 +78,7 @@ InstallOtherMethod( Length, "For a compressed MatFFE",
 #M  <mat> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "For a compressed MatFFE",
+InstallOtherMethod( \[\],  "for a compressed MatFFE",
         [IsList and Is8BitMatrixRep, IsPosInt],
         ELM_MAT8BIT
         );
@@ -88,7 +88,7 @@ InstallOtherMethod( \[\],  "For a compressed MatFFE",
 #M  <mat> [ <pos1>, <pos2> ]
 ##
 
-InstallMethod( \[\,\],  "For a compressed MatFFE",
+InstallMethod( \[\,\],  "for a compressed MatFFE",
         [Is8BitMatrixRep, IsPosInt, IsPosInt],
         MAT_ELM_MAT8BIT
         );
@@ -101,7 +101,7 @@ InstallMethod( \[\,\],  "For a compressed MatFFE",
 ##  not lie in the appropriate field.
 ##
 
-InstallOtherMethod( \[\]\:\=,  "For a compressed MatFFE",
+InstallOtherMethod( \[\]\:\=,  "for a compressed MatFFE",
         [IsMutable and IsList and Is8BitMatrixRep, IsPosInt, IsObject],
         ASS_MAT8BIT
         );
@@ -111,7 +111,7 @@ InstallOtherMethod( \[\]\:\=,  "For a compressed MatFFE",
 #M  <mat> [ <pos1>, <pos2> ] := <val>
 ##
 
-InstallMethod( \[\,\]\:\=,  "For a compressed MatFFE",
+InstallMethod( \[\,\]\:\=,  "for a compressed MatFFE",
         [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
         SET_MAT_ELM_MAT8BIT
         );
@@ -124,7 +124,7 @@ InstallMethod( \[\,\]\:\=,  "For a compressed MatFFE",
 ##  turning into a plain list
 ##
 
-InstallOtherMethod( Unbind\[\], "For a compressed MatFFE",
+InstallOtherMethod( Unbind\[\], "for a compressed MatFFE",
         true, [IsMutable and IsList and Is8BitMatrixRep, IsPosInt],
         0, function(m,p)
     if p = 1 or  p <> m![1] then
@@ -144,7 +144,7 @@ end);
 ##  description is printed
 ##
 
-InstallMethod( ViewObj, "For a compressed MatFFE",
+InstallMethod( ViewObj, "for a compressed MatFFE",
         true, [Is8BitMatrixRep and IsSmallList], 0,
         function( m )
     local r,c;
@@ -168,7 +168,7 @@ end);
 ##  Same method as for lists in internal rep. 
 ##
 
-InstallMethod( PrintObj, "For a compressed MatFFE",
+InstallMethod( PrintObj, "for a compressed MatFFE",
         true, [Is8BitMatrixRep and IsSmallList], 0,
         function( mat )
     local i,l;
@@ -190,7 +190,7 @@ end);
 ##
 ##
 
-InstallMethod(ShallowCopy, "For a compressed MatFFE", 
+InstallMethod(ShallowCopy, "for a compressed MatFFE", 
         true, [Is8BitMatrixRep and IsSmallList], 0, 
         function(m) 
     local c,i,l; 
@@ -223,7 +223,7 @@ end );
 #M  <mat1> + <mat2>
 ##
 
-InstallMethod( \+, "For two 8 bit matrices in same characteristic",
+InstallMethod( \+, "for two 8 bit matrices in same characteristic",
         IsIdenticalObj, [IsMatrix and Is8BitMatrixRep,
                 IsMatrix and Is8BitMatrixRep], 0,
         SUM_MAT8BIT_MAT8BIT
@@ -234,7 +234,7 @@ InstallMethod( \+, "For two 8 bit matrices in same characteristic",
 #M  <mat1> - <mat2>
 ##
 
-InstallMethod( \-, "For two 8 bit matrices in same characteristic",
+InstallMethod( \-, "for two 8 bit matrices in same characteristic",
         IsIdenticalObj, [IsMatrix and Is8BitMatrixRep,
                 IsMatrix and Is8BitMatrixRep], 0,
         DIFF_MAT8BIT_MAT8BIT
@@ -248,7 +248,7 @@ InstallMethod( \-, "For two 8 bit matrices in same characteristic",
 ##  Make the matrix into a plain list 
 ##
 
-InstallMethod( PlainListCopyOp, "For an 8 bit vector",
+InstallMethod( PlainListCopyOp, "for an 8 bit vector",
         true, [IsSmallList and Is8BitMatrixRep], 0,
         function (m)
     PLAIN_MAT8BIT(m);
@@ -263,7 +263,7 @@ end);
 ##  alternative element access interface, returns fail when unbound
 ##
 
-InstallMethod(ELM0_LIST, "For an 8 bit matrix",
+InstallMethod(ELM0_LIST, "for an 8 bit matrix",
         true, [IsList and Is8BitMatrixRep, IsPosInt], 0,
         function(m,p)
     if p > m![1] then 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -101,7 +101,7 @@ InstallMethod( \[\,\],  "For a compressed MatFFE",
 ##  not lie in the appropriate field.
 ##
 
-InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE",
+InstallOtherMethod( \[\]\:\=,  "For a compressed MatFFE",
         [IsMutable and IsList and Is8BitMatrixRep, IsPosInt, IsObject],
         ASS_MAT8BIT
         );
@@ -111,7 +111,7 @@ InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE",
 #M  <mat> [ <pos1>, <pos2> ] := <val>
 ##
 
-InstallMethod( \[\,\]\:\=,  "For a compressed MatFE",
+InstallMethod( \[\,\]\:\=,  "For a compressed MatFFE",
         [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
         SET_MAT_ELM_MAT8BIT
         );

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -88,7 +88,7 @@ InstallOtherMethod( \[\],  "For a compressed MatFFE",
 #M  <mat> [ <pos1>, <pos2> ]
 ##
 
-InstallMethod( \[\],  "For a compressed MatFFE",
+InstallMethod( \[\,\],  "For a compressed MatFFE",
         [Is8BitMatrixRep, IsPosInt, IsPosInt],
         MAT_ELM_MAT8BIT
         );
@@ -111,7 +111,7 @@ InstallOtherMethod( \[\]\:\=,  "For a compressed MatFE",
 #M  <mat> [ <pos1>, <pos2> ] := <val>
 ##
 
-InstallMethod( \[\]\:\=,  "For a compressed MatFE",
+InstallMethod( \[\,\]\:\=,  "For a compressed MatFE",
         [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
         SET_MAT_ELM_MAT8BIT
         );

--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -190,9 +190,9 @@ InstallOtherMethod( \[\],
 
 #############################################################################
 ##
-#M  \[\]( <blockmat>, <row>, <col> ) . . . . . . . . . . . for a block matrix
+#M  \[\,\]( <blockmat>, <row>, <col> ) . . . . . . . . . . for a block matrix
 ##
-InstallOtherMethod( \[\],
+InstallMethod( \[\,\],
     "for an ordinary block matrix and two positive integers",
     [ IsOrdinaryMatrix and IsBlockMatrixRep, IsPosInt, IsPosInt ],
     function( blockmat, row, col )

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -15,21 +15,23 @@
 #
 
 
-# Install fallback methods for m[i,j] which delegate MatElm resp. SetMatElm,
-# for old MatrixObj implementation which don't provide them. We lower the rank
-# so that these are only used as a last resort.
-InstallMethod( \[\], "for a matrix object and two positions",
+# Install fallback methods for m[i,j] which delegate to ASS_LIST / ELM_LIST
+# for code using an intermediate version of the (unfinished) MatrixObj
+# specification (any package installing methods for MatElm resp. SetMatElm
+# should be fine without these). We lower the rank so that these are only
+# used as a last resort.
+InstallMethod( \[\,\], "for a matrix object and two positions",
   [ IsMatrixObj, IsPosInt, IsPosInt ],
   {} -> -RankFilter(IsMatrixObj),
   function( m, row, col )
-    return MatElm( m, row, col );
+    return ELM_LIST( m, row, col );
   end );
 
-InstallMethod( \[\]\:\=, "for a matrix object, two positions, and an object",
+InstallMethod( \[\,\]\:\=, "for a matrix object, two positions, and an object",
   [ IsMatrixObj and IsMutable, IsPosInt, IsPosInt, IsObject ],
   {} -> -RankFilter(IsMatrixObj),
   function( m, row, col, obj )
-    SetMatElm( m, row, col, obj );
+    ASS_LIST( m, row, col, obj );
   end );
 
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -812,14 +812,36 @@ DeclareOperation( "CopySubMatrix", [IsMatrixObj,IsMatrixObj,
 # New element access for matrices
 ############################################################################
 
-DeclareOperation( "MatElm", [IsMatrixObj,IsPosInt,IsPosInt] );
+#############################################################################
+##
+#o  <mat>[<row>,<col>] . . . . . . . . . . .  select an element from a matrix
+##
+DeclareOperationKernel( "[,]",
+    [ IsMatrixObj, IS_INT, IS_INT ],
+    ELM_MAT );
+DeclareSynonym( "MatElm", ELM_MAT );
+
+# TODO: the following is deprecated, and to be removed once packages needing
+# it are updated (specifically, cvec )
 DeclareOperation( "[]", [IsMatrixObj,IsPosInt,IsPosInt] );
-# second and third arguments are row and column index
 
-DeclareOperation( "SetMatElm", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
+#############################################################################
+##
+#o  <mat>[<row>,<col>] := <obj>
+##
+##  TODO: the first argument filter should be 'IsMatrixObj and IsMutable',
+##  but there is legacy code in packages which does not specify this filter
+##  for its 'SetMatElm' methods and would thus run into an error with this
+##  more restrictive filter. We therefore omit it for now, at least until
+##  all deposited packages providing such methods are fixed.
+DeclareOperationKernel( "[,]:=",
+    [ IsMatrixObj, IS_INT, IS_INT, IsObject ],
+    ASS_MAT );
+DeclareSynonym( "SetMatElm", ASS_MAT );
+
+# TODO: the following is deprecated, and to be removed once packages needing
+# it are updated (specifically, cvec)
 DeclareOperation( "[]:=", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
-# second and third arguments are row and column index
-
 
 ############################################################################
 # Standard operations for all objects:

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -826,19 +826,6 @@ InstallMethod( SetMatElm, "for a plist matrix, two positions, and an object",
     m![ROWSPOS][row]![ELSPOS][col] := ob;
   end );
 
-InstallMethod( \[\], "for a plist matrix and two positions",
-  [ IsPlistMatrixRep, IsPosInt, IsPosInt ],
-  function( m, row, col )
-    return m![ROWSPOS][row]![ELSPOS][col];
-  end );
-
-InstallMethod( \[\]\:\=, "for a plist matrix, two positions, and an object",
-  [ IsPlistMatrixRep and IsMutable, IsPosInt, IsPosInt, IsObject ],
-  function( m, row, col, ob )
-    m![ROWSPOS][row]![ELSPOS][col] := ob;
-  end );
-
-
 
 ############################################################################
 # Printing and viewing methods:

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -87,7 +87,7 @@ InstallValue( TYPE_FIELDINFO_8BIT, TYPE_KERNEL_OBJECT);
 #M  Length( <vec> )
 ##
 
-InstallOtherMethod( Length, "For a compressed VecFFE", 
+InstallOtherMethod( Length, "for a compressed VecFFE", 
         true, [IsList and Is8BitVectorRep], 0, LEN_VEC8BIT);
 
 #############################################################################
@@ -95,7 +95,7 @@ InstallOtherMethod( Length, "For a compressed VecFFE",
 #M  <vec> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "For a compressed VecFFE", 
+InstallOtherMethod( \[\],  "for a compressed VecFFE", 
         true, [IsList and Is8BitVectorRep, IsPosInt], 0, ELM_VEC8BIT);
 
 #############################################################################
@@ -108,7 +108,7 @@ InstallOtherMethod( \[\],  "For a compressed VecFFE",
 ##  <vec> may also be converted back into vector rep over a bigger field.
 ##
                
-InstallOtherMethod( \[\]\:\=,  "For a compressed VecFFE", 
+InstallOtherMethod( \[\]\:\=,  "for a compressed VecFFE", 
         true, [IsMutable and IsList and Is8BitVectorRep, IsPosInt, IsObject], 
         0, ASS_VEC8BIT);
 
@@ -120,7 +120,7 @@ InstallOtherMethod( \[\]\:\=,  "For a compressed VecFFE",
 ##  turning into a plain list
 ##
 
-InstallMethod( Unbind\[\], "For a compressed VecFFE",
+InstallMethod( Unbind\[\], "for a compressed VecFFE",
         true, [IsMutable and IsList and Is8BitVectorRep, IsPosInt],
         0, UNB_VEC8BIT);
 
@@ -132,7 +132,7 @@ InstallMethod( Unbind\[\], "For a compressed VecFFE",
 ##  description is printed
 ##
 
-InstallMethod( ViewObj, "For a compressed VecFFE",
+InstallMethod( ViewObj, "for a compressed VecFFE",
         true, [Is8BitVectorRep and IsSmallList], 0,
         function( vec )
     local len;
@@ -156,7 +156,7 @@ end);
 ##  Same method as for lists in internal rep. 
 ##
 
-InstallMethod( PrintObj, "For a compressed VecFFE",
+InstallMethod( PrintObj, "for a compressed VecFFE",
         true, [Is8BitVectorRep and IsSmallList], 0,
         function( vec )
     local i,l;
@@ -179,7 +179,7 @@ end);
 ##  kernel method produces a copy in the same representation
 ##
 
-InstallMethod(ShallowCopy, "For a compressed VecFFE",
+InstallMethod(ShallowCopy, "for a compressed VecFFE",
         true, [Is8BitVectorRep and IsSmallList], 0,
         SHALLOWCOPY_VEC8BIT);
 
@@ -192,12 +192,12 @@ InstallMethod(ShallowCopy, "For a compressed VecFFE",
 ##  characteristic. Compatability of fields and vector lengths is
 ##  handled in the method
 
-InstallMethod( \+, "For two 8 bit vectors in same characteristic",
+InstallMethod( \+, "for two 8 bit vectors in same characteristic",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         SUM_VEC8BIT_VEC8BIT);
 
-InstallMethod( \+, "For a GF2 vector and an 8 bit vector of char 2",
+InstallMethod( \+, "for a GF2 vector and an 8 bit vector of char 2",
         IsIdenticalObj, [IsRowVector  and IsGF2VectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         function(v,w)
@@ -209,7 +209,7 @@ InstallMethod( \+, "For a GF2 vector and an 8 bit vector of char 2",
     fi;
 end);
 
-InstallMethod( \+, "For an 8 bit vector of char 2 and a GF2 vector",
+InstallMethod( \+, "for an 8 bit vector of char 2 and a GF2 vector",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and IsGF2VectorRep ], 0,
         function(w,v)
@@ -228,7 +228,7 @@ end);
 ##  Make the vector into a plain list (in place)
 ##
 
-InstallMethod( PlainListCopyOp, "For an 8 bit vector",
+InstallMethod( PlainListCopyOp, "for an 8 bit vector",
         true, [IsSmallList and Is8BitVectorRep], 0,
         function (v)
     PLAIN_VEC8BIT(v);
@@ -242,7 +242,7 @@ end);
 ##  alternatibe element access interface, returns fail when unbound
 ##
 
-InstallMethod(ELM0_LIST, "For an 8 bit vector",
+InstallMethod(ELM0_LIST, "for an 8 bit vector",
         true, [IsList and Is8BitVectorRep, IsPosInt], 0,
         ELM0_VEC8BIT);
 
@@ -287,12 +287,12 @@ end );
 ##
 ##  multi-element access
 ##
-InstallOtherMethod(ELMS_LIST, "For an 8 bit vector and a plain list",
+InstallOtherMethod(ELMS_LIST, "for an 8 bit vector and a plain list",
         true, [IsList and Is8BitVectorRep, 
                IsPlistRep and IsDenseList ], 0,
         ELMS_VEC8BIT);
 
-InstallOtherMethod(ELMS_LIST, "For an 8 bit vector and a range",
+InstallOtherMethod(ELMS_LIST, "for an 8 bit vector and a range",
         true, [IsList and Is8BitVectorRep, 
                IsRange and IsInternalRep ], 0,
         ELMS_VEC8BIT_RANGE);
@@ -302,7 +302,7 @@ InstallOtherMethod(ELMS_LIST, "For an 8 bit vector and a range",
 #M  <vec>*<ffe>
 ##
 
-InstallMethod(\*, "For an 8 bit vector and an FFE",
+InstallMethod(\*, "for an 8 bit vector and an FFE",
         IsCollsElms, [IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep], 0,
         PROD_VEC8BIT_FFE);
@@ -312,7 +312,7 @@ InstallMethod(\*, "For an 8 bit vector and an FFE",
 #M  <vec>*<mat>
 ##
 
-InstallMethod(\*, "For an 8 bit vector and a compatible matrix",
+InstallMethod(\*, "for an 8 bit vector and a compatible matrix",
         IsElmsColls, [IsRowVector and Is8BitVectorRep and IsSmallList
                 and IsRingElementList,
                 IsRingElementTable and IsPlistRep], 0,
@@ -347,7 +347,7 @@ end );
 #M <ffe>*<vec>
 ##
 
-InstallMethod(\*, "For an FFE and an 8 bit vector ",
+InstallMethod(\*, "for an FFE and an 8 bit vector ",
         IsElmsColls, [IsFFE and IsInternalRep, 
                 IsRowVector and Is8BitVectorRep], 
         0,
@@ -382,13 +382,13 @@ end );
 ##
 #M  <vecl> - <vecr>
 ##
-InstallMethod(\-, "For two 8bit vectors",
+InstallMethod(\-, "for two 8bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 
         0,
         DIFF_VEC8BIT_VEC8BIT );
 
-InstallMethod( \-, "For a GF2 vector and an 8 bit vector of char 2",
+InstallMethod( \-, "for a GF2 vector and an 8 bit vector of char 2",
         IsIdenticalObj, [IsRowVector and IsGF2VectorRep ,
                 IsRowVector and Is8BitVectorRep], 0,
         function(v,w)
@@ -400,7 +400,7 @@ InstallMethod( \-, "For a GF2 vector and an 8 bit vector of char 2",
     fi;
 end);
 
-InstallMethod( \-, "For an 8 bit vector of char 2 and a GF2 vector",
+InstallMethod( \-, "for an 8 bit vector of char 2 and a GF2 vector",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep ,
                 IsRowVector and IsGF2VectorRep], 0,
         function(w,v)
@@ -417,7 +417,7 @@ end);
 #M  -<vec>
 ##
 
-InstallMethod( AdditiveInverseOp, "For an 8 bit vector",
+InstallMethod( AdditiveInverseOp, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         AINV_VEC8BIT_MUTABLE);
@@ -427,7 +427,7 @@ InstallMethod( AdditiveInverseOp, "For an 8 bit vector",
 #M  -<vec>
 ##
 
-InstallMethod( AdditiveInverseSameMutability, "For an 8 bit vector",
+InstallMethod( AdditiveInverseSameMutability, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         AINV_VEC8BIT_SAME_MUTABILITY );
@@ -437,7 +437,7 @@ InstallMethod( AdditiveInverseSameMutability, "For an 8 bit vector",
 #M  -<vec>
 ##
 
-InstallMethod( AdditiveInverseImmutable, "For an 8 bit vector",
+InstallMethod( AdditiveInverseImmutable, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         AINV_VEC8BIT_IMMUTABLE );
@@ -449,7 +449,7 @@ InstallMethod( AdditiveInverseImmutable, "For an 8 bit vector",
 ##  A  mutable zero vector of the same field and length 
 ##
 
-InstallMethod( ZeroOp, "For an 8 bit vector",
+InstallMethod( ZeroOp, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         ZERO_VEC8BIT);
@@ -461,7 +461,7 @@ InstallMethod( ZeroOp, "For an 8 bit vector",
 ##  A  zero vector of the same field and length and mutability
 ##
 
-InstallMethod( ZeroSameMutability, "For an 8 bit vector",
+InstallMethod( ZeroSameMutability, "for an 8 bit vector",
         true, [IsRowVector and Is8BitVectorRep],
         0,
         function(v)
@@ -478,7 +478,7 @@ end );
 #M  <vec1> = <vec2>
 ##
 
-InstallMethod( \=, "For 2 8 bit vectors",
+InstallMethod( \=, "for 2 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -491,7 +491,7 @@ InstallMethod( \=, "For 2 8 bit vectors",
 ##  Usual lexicographic ordering
 ##
 
-InstallMethod( \<, "For 2 8 bit vectors",
+InstallMethod( \<, "for 2 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -503,13 +503,13 @@ InstallMethod( \<, "For 2 8 bit vectors",
 ##
 ##  scalar product
 #'
-InstallMethod( \*, "For 2 8 bit vectors",
+InstallMethod( \*, "for 2 8 bit vectors",
         IsIdenticalObj, [IsRingElementList and Is8BitVectorRep,
                 IsRingElementList and Is8BitVectorRep],
         0,
         PROD_VEC8BIT_VEC8BIT);
 
-InstallMethod( \*, "For a GF2 vector and an 8 bit vector of char 2",
+InstallMethod( \*, "for a GF2 vector and an 8 bit vector of char 2",
         IsIdenticalObj, [IsRowVector and IsGF2VectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         function(v,w)
@@ -521,7 +521,7 @@ InstallMethod( \*, "For a GF2 vector and an 8 bit vector of char 2",
     fi;
 end);
 
-InstallMethod( \*, "For an 8 bit vector of char 2 and a GF2 vector",
+InstallMethod( \*, "for an 8 bit vector of char 2 and a GF2 vector",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and IsGF2VectorRep ], 0,
         function(w,v)
@@ -540,7 +540,7 @@ end);
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element and from and to",
+InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element and from and to",
         IsCollsCollsElmsXX, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep, IsPosInt, IsPosInt ], 0,
@@ -553,7 +553,7 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element and f
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element",
+InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element",
         IsCollsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep ], 0,
@@ -566,7 +566,7 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors and a field element",
 ##  add <vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "For 2 8 bit vectors",
+InstallOtherMethod( AddRowVector, "for 2 8 bit vectors",
         IsIdenticalObj, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         ADD_ROWVECTOR_VEC8BITS_2);
@@ -578,7 +578,7 @@ InstallOtherMethod( AddRowVector, "For 2 8 bit vectors",
 ##  multiply <vec> by <ffe> in place
 ##
 
-InstallOtherMethod( MultVector, "For an 8 bit vector and an ffe",
+InstallOtherMethod( MultVector, "for an 8 bit vector and an ffe",
         IsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep], 0,
         MULT_VECTOR_VEC8BITS);

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1031,7 +1031,7 @@ InstallMethod( MatElm, "for an 8bit matrix and two integers",
   [ Is8BitMatrixRep, IsPosInt, IsPosInt ],
   MAT_ELM_MAT8BIT );
 InstallMethod( SetMatElm, "for an 8bit matrix, two integers, and a ffe",
-  [ Is8BitMatrixRep, IsPosInt, IsPosInt, IsFFE ],
+  [ Is8BitMatrixRep and IsMutable, IsPosInt, IsPosInt, IsFFE ],
   SET_MAT_ELM_MAT8BIT );
 InstallMethod( Matrix, "for a list of vecs, an integer, and an 8bit mat",
   [IsList, IsInt, Is8BitMatrixRep],

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -586,7 +586,7 @@ InstallOtherMethod( \[\], "for GF2 matrix",
       IsPosInt ],
     ELM_GF2MAT );
 
-InstallMethod( \[\], "for GF2 matrix",
+InstallMethod( \[\,\], "for GF2 matrix",
     [ IsGF2MatrixRep,
       IsPosInt, IsPosInt ],
     MAT_ELM_GF2MAT );
@@ -610,9 +610,9 @@ InstallOtherMethod( \[\]\:\=,
       IsObject ],
     ASS_GF2MAT );
 
-InstallMethod( \[\]\:\=,
+InstallMethod( \[\,\]\:\=,
     "for GF2 matrix",
-    [ IsGF2MatrixRep,
+    [ IsGF2MatrixRep and IsMutable,
       IsPosInt, IsPosInt,
       IsObject ],
     SET_MAT_ELM_GF2MAT );
@@ -2194,7 +2194,7 @@ InstallMethod( MatElm, "for a gf2 matrix and two integers",
   [ IsGF2MatrixRep, IsPosInt, IsPosInt ],
   MAT_ELM_GF2MAT );
 InstallMethod( SetMatElm, "for a gf2 matrix, two integers, and a ffe",
-  [ IsGF2MatrixRep, IsPosInt, IsPosInt, IsFFE ],
+  [ IsGF2MatrixRep and IsMutable, IsPosInt, IsPosInt, IsFFE ],
   SET_MAT_ELM_GF2MAT );
 
 InstallMethod( Matrix, "for a list of vecs, an integer, and a gf2 mat",

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1136,7 +1136,7 @@ InstallMethod( \*,
 ##                    of compressed GF2 vectors, otherwise falls through
 ##
 
-InstallMethod(\*, "For a GF2 vector and a compatible matrix",
+InstallMethod(\*, "for a GF2 vector and a compatible matrix",
         IsElmsColls, [IsRowVector and IsGF2VectorRep and IsSmallList
                 and IsRingElementList,
                 IsRingElementTable and IsPlistRep], 0,

--- a/src/lists.c
+++ b/src/lists.c
@@ -285,9 +285,9 @@ Int             ISBB_LIST (
     return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
-Int ISB_MAT(Obj list, Obj row, Obj col)
+Int ISB_MAT(Obj mat, Obj row, Obj col)
 {
-    return DoOperation3Args(IsbListOper, list, row, col) == True;
+    return DoOperation3Args(IsbListOper, mat, row, col) == True;
 }
 
 
@@ -500,12 +500,24 @@ Obj ELMB_LIST(Obj list, Obj pos)
     return elm;
 }
 
-Obj ELM_MAT(Obj list, Obj row, Obj col)
+
+/****************************************************************************
+**
+*F  FuncELM_MAT( <self>, <mat>, <row>, <col> ) . . . . .  operation `ELM_MAT'
+*/
+static Obj FuncELM_MAT(Obj self, Obj mat, Obj row, Obj col)
 {
-    if (IS_POS_INTOBJ(row) && IS_POS_INTOBJ(col) && IS_PLIST(list)) {
+    return ELM_MAT(mat, row, col);
+}
+
+static Obj ElmMatOper;
+
+Obj ELM_MAT(Obj mat, Obj row, Obj col)
+{
+    if (IS_POS_INTOBJ(row) && IS_POS_INTOBJ(col) && IS_PLIST(mat)) {
         Int r = INT_INTOBJ(row);
-        if (r <= LEN_PLIST(list)) {
-            Obj rowlist = ELM_PLIST(list, r);
+        if (r <= LEN_PLIST(mat)) {
+            Obj rowlist = ELM_PLIST(mat, r);
             Int c = INT_INTOBJ(col);
 
             if (IS_PLIST(rowlist) && c <= LEN_PLIST(rowlist)) {
@@ -518,9 +530,9 @@ Obj ELM_MAT(Obj list, Obj row, Obj col)
         }
     }
 
-    Obj elm = DoOperation3Args(ElmListOper, list, row, col);
+    Obj elm = DoOperation3Args(ElmMatOper, mat, row, col);
     if (elm == 0) {
-        ErrorMayQuit("List access method must return a value", 0, 0);
+        ErrorMayQuit("Matrix access method must return a value", 0, 0);
     }
     return elm;
 }
@@ -800,9 +812,9 @@ void            UNBB_LIST (
     DoOperation2Args( UnbListOper, list, pos );
 }
 
-void UNB_MAT(Obj list, Obj row, Obj col)
+void UNB_MAT(Obj mat, Obj row, Obj col)
 {
-    DoOperation3Args(UnbListOper, list, row, col);
+    DoOperation3Args(UnbListOper, mat, row, col);
 }
 
 
@@ -864,6 +876,14 @@ void ASSB_LIST (
     DoOperation3Args( AssListOper, list, pos, obj );
 }
 
+static Obj AssMatOper;
+
+static Obj FuncASS_MAT(Obj self, Obj mat, Obj row, Obj col, Obj obj)
+{
+    ASS_MAT(mat, row, col, obj);
+    return 0;
+}
+
 void ASS_MAT(Obj mat, Obj row, Obj col, Obj obj)
 {
     RequireMutable("Matrix Assignment", mat, "matrix");
@@ -878,7 +898,7 @@ void ASS_MAT(Obj mat, Obj row, Obj col, Obj obj)
         }
     }
 
-    DoOperation4Args(AssListOper, mat, row, col, obj);
+    DoOperation4Args(AssMatOper, mat, row, col, obj);
 }
 
 
@@ -1958,6 +1978,10 @@ static StructGVarOper GVarOpers[] = {
     GVAR_OPER(UNB_LIST, 2, "list, pos", &UnbListOper),
     GVAR_OPER(ASS_LIST, 3, "list, pos, obj", &AssListOper),
     GVAR_OPER(ASSS_LIST, 3, "list, poss, objs", &AsssListOper),
+
+    GVAR_OPER(ASS_MAT, 4, "mat, row, col, obj", &AssMatOper),
+    GVAR_OPER(ELM_MAT, 3, "mat, row, col", &ElmMatOper),
+
     { 0, 0, 0, 0, 0, 0 }
 
 };

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -30,10 +30,10 @@ gap> InstallOtherMethod(GetWithDefault, [r and IsMutable, IsInt, IsObject], func
 > end);
 
 #
-gap> InstallOtherMethod(\[\],[r,IsPosInt,IsPosInt],function(l,i,j) 
+gap> InstallOtherMethod(\[\,\],[r,IsPosInt,IsPosInt],function(l,i,j)
 >     return [i,j];
 > end);
-gap> InstallOtherMethod(\[\]\:\=,[r and IsMutable,IsPosInt,IsPosInt, IsObject],function(l,i,j,x) 
+gap> InstallOtherMethod(\[\,\]\:\=,[r and IsMutable,IsPosInt,IsPosInt, IsObject],function(l,i,j,x)
 >     Print ("Assign [",i,"][",j,"] := ",x,"\n");
 > end);
 gap> InstallOtherMethod(Unbind\[\],[r and IsMutable,IsPosInt,IsPosInt],function(l,i,j) 

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -176,11 +176,13 @@ gap> l := [[1]];; f := {} -> l[2,1];;
 gap> f();
 Error, List Element: <list>[2] must have an assigned value in
   return m[i][j]; at GAPROOT/lib/matrix.gi:26 called from 
+ELM_LIST( m, row, col ) at GAPROOT/lib/matobj.gi:27 called from
 return l[2, 1]; at *stdin*:39 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:40
 type 'quit;' to quit to outer loop
 brk> Where();
+ELM_LIST( m, row, col ) at GAPROOT/lib/matobj.gi:27 called from
 return l[2, 1]; at *stdin*:39 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1

--- a/tst/testspecial/bad-array-double-1.g.out
+++ b/tst/testspecial/bad-array-double-1.g.out
@@ -4,7 +4,7 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 3 arguments at GAPROOT/lib/methsel2.g:249 called from
+Error, no 1st choice method found for `[,]' on 3 arguments at GAPROOT/lib/methsel2.g:249 called from
 return "abc"[1, 1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5


### PR DESCRIPTION
This continues the work begun in PR #3550.

The kernel functions with the same name now delegate to these operations instead of `ELM_LIST`, `ASS_LIST`.

Also turned `MatElm`, `SetMatElm` into synonyms for `ELM_MAT`, `ASS_MAT`.

Code which already used MatrixObj for a long time and thus installed methods for `MatElm`, `SetMatElm` will thus work unchanged. Code which adapted to the recommendation in GAP 4.10 and thus instead installed methods for `ELM_LIST`, `ASS_LIST` with 3 resp. 4 arguments now should be adapted to (again) install methods for `MatElm`, `SetMatElm` for maximal compatibility. To ensure this code
works after this change, though, we provide low ranked fallback methods in `ELM_MAT`, `ASS_MAT` which delegate to `ELM_LIST`, `ASS_LIST`. At the same time, we remove the low-ranked delegations from `ELM_LIST`, `ASS_LIST` to `MatElm`, `SetMatElm` to ensure we don't end up delegating back and forth endlessly.

As far as I could tell, the only package which is (mildly) impacted by this is `cvec`; I'll shortly release an update of that which addresses all those concerns, though, and which should work seamlessly with and without this PR. Of course there might be further code out there which is not in deposited packages, and which I thus can't test, but I am confident it'll be OK, too -- though of course I can't be sure without being able to look at that code.