### PR TITLE
Add a MatElm method for matrices with memory

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -382,6 +382,12 @@ InstallOtherMethod( ELM_LIST, "for a matrix with memory",
     return M!.el[i];
   end);
 
+InstallOtherMethod( MatElm, "for a matrix with memory",
+  [ IsMatrix and IsObjWithMemory, IsPosInt, IsPosInt ],
+  function(M,i,j)
+    return M!.el[i,j];
+  end);
+
 InstallOtherMethod( \*, "for a row vector and a matrix with memory",true,
   [ IsListDefault and IsSmallList, IsMatrix and IsObjWithMemory ], 0,
   function(v,M)


### PR DESCRIPTION
I just stumbled over this by accident while preparing PR #3551. I think this change might be beneficial to `recog`, if only in a tiny, tiny way.