### PR TITLE
Provide NrRows/NrCols methods for block matrices

### DIFF
--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -141,6 +141,26 @@ InstallOtherMethod( Length,
 
 #############################################################################
 ##
+#M  NrRows( <blockmat> )  . . . . . . . . . . . . . . . .  for a block matrix
+##
+InstallMethod( NrRows,
+    "for an ordinary block matrix",
+    [ IsOrdinaryMatrix and IsBlockMatrixRep ],
+    blockmat -> blockmat!.nrb * blockmat!.rpb );
+
+
+#############################################################################
+##
+#M  NrCols( <blockmat> )  . . . . . . . . . . . . . . . .  for a block matrix
+##
+InstallMethod( NrCols,
+    "for an ordinary block matrix",
+    [ IsOrdinaryMatrix and IsBlockMatrixRep ],
+    blockmat -> blockmat!.ncb * blockmat!.cpb );
+
+
+#############################################################################
+##
 #M  \[\]( <blockmat>, <n> ) . . . . . . . . . . . . . . .  for a block matrix
 ##
 InstallOtherMethod( \[\],
@@ -663,13 +683,3 @@ InstallMethod( PrintObj,
     Print( "BlockMatrix( ", m!.blocks, ",", m!.nrb, ",", m!.ncb,
            ",", m!.rpb, ",", m!.cpb, ",", m!.zero, " )" );
     end );
-
-
-#############################################################################
-##
-#M  DimensionsMat( <blockmat> ) . . . . . . . . . . . . .  for a block matrix
-##
-InstallOtherMethod( DimensionsMat,
-    "for an ordinary block matrix",
-    [ IsOrdinaryMatrix and IsBlockMatrixRep ],
-    m -> [ m!.nrb * m!.rpb, m!.ncb * m!.cpb ] );

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -13,16 +13,20 @@ gap> m3 := AsBlockMatrix( m2, 2, 2 );
 <block matrix of dimensions (2*3)x(2*3)>
 gap> z  := BlockMatrix( [], 3, 3, 2, 2, 0 );
 <block matrix of dimensions (3*2)x(3*2)>
-gap> Length( m1 ); DimensionsMat( m1 );
+gap> NrRows( m1 ); NrCols( m1 ); DimensionsMat( m1 );
 6
+8
 [ 6, 8 ]
-gap> Length( m2 ); DimensionsMat( m2 );
+gap> NrRows( m2 ); NrCols( m2 ); DimensionsMat( m2 );
+6
 6
 [ 6, 6 ]
-gap> Length( m3 ); DimensionsMat( m3 );
+gap> NrRows( m3 ); NrCols( m3 ); DimensionsMat( m3 );
+6
 6
 [ 6, 6 ]
-gap> Length( z );  DimensionsMat( z );
+gap> NrRows( z ); NrCols( z );  DimensionsMat( z );
+6
 6
 [ 6, 6 ]
 gap> m1[3];


### PR DESCRIPTION
This also allows us to remove the custom DimensionsMat method.
