### PR TITLE
some more fixes and changes for matrix(obj) functions

### DIFF
--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -537,6 +537,7 @@ DeclareOperation( "ChangedBaseDomain", [IsVectorObj,IsSemiring] );
 # Changes the base domain. A copy of the row vector in the first argument is
 # created, which comes in a "similar" representation but over the new
 # base domain that is given in the second argument.
+# The result is mutable if and only if the given vector is mutable.
 # example: given a vector over GF(2),  create a new vector over GF(4) with "identical" content
 #  so it's kind of a type conversion / coercion
 # TODO: better name, e.g. VectorWithChangedBasedDomain
@@ -1123,14 +1124,6 @@ DeclareOperation( "TransposedMatMutable", [IsMatrixObj] );
 #  its transpose "by accident", and then gets modified later on
 #
 
-
-DeclareOperation( "IsDiagonalMat", [IsMatrixObj] );
-DeclareOperation( "IsUpperTriangularMat", [IsMatrixObj] );
-DeclareOperation( "IsLowerTriangularMat", [IsMatrixObj] );
-# TODO: if we allow attributes, we might just as well do the above to be
-# declared as properties, so that this information is stored; but once
-# again, we would only want to allow this for immutable matrix objects.
-# ...
 
 # TODO: what about the following (and also note the names...):
 #   - IsScalarMat, IsSquareMat, ... ?

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -64,13 +64,13 @@ DeclareProperty( "IsGeneralizedCartanMatrix", IsMatrix );
 
 #############################################################################
 ##
-#O  IsDiagonalMatrix( <mat> )
-#O  IsDiagonalMat( <mat> )
+#P  IsDiagonalMatrix( <mat> )
+#P  IsDiagonalMat( <mat> )
 ##
 ##  <#GAPDoc Label="IsDiagonalMat">
 ##  <ManSection>
-##  <Oper Name="IsDiagonalMatrix" Arg='mat'/>
-##  <Oper Name="IsDiagonalMat" Arg='mat'/>
+##  <Prop Name="IsDiagonalMatrix" Arg='mat'/>
+##  <Prop Name="IsDiagonalMat" Arg='mat'/>
 ##
 ##  <Description>
 ##  return <K>true</K> if the matrix <A>mat</A> has only zero entries
@@ -87,20 +87,20 @@ DeclareProperty( "IsGeneralizedCartanMatrix", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "IsDiagonalMatrix", [ IsMatrixObj ] );
+DeclareProperty( "IsDiagonalMatrix", IsMatrixObj );
 
 DeclareSynonym( "IsDiagonalMat", IsDiagonalMatrix );
 
 
 #############################################################################
 ##
-#O  IsUpperTriangularMatrix( <mat> )
-#O  IsUpperTriangularMat( <mat> )
+#P  IsUpperTriangularMatrix( <mat> )
+#P  IsUpperTriangularMat( <mat> )
 ##
 ##  <#GAPDoc Label="IsUpperTriangularMat">
 ##  <ManSection>
-##  <Oper Name="IsUpperTriangularMatrix" Arg='mat'/>
-##  <Oper Name="IsUpperTriangularMat" Arg='mat'/>
+##  <Prop Name="IsUpperTriangularMatrix" Arg='mat'/>
+##  <Prop Name="IsUpperTriangularMat" Arg='mat'/>
 ##
 ##  <Description>
 ##  return <K>true</K> if the matrix <A>mat</A> has only zero entries below
@@ -117,20 +117,20 @@ DeclareSynonym( "IsDiagonalMat", IsDiagonalMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "IsUpperTriangularMatrix", [ IsMatrixObj ] );
+DeclareProperty( "IsUpperTriangularMatrix", IsMatrixObj );
 
 DeclareSynonym( "IsUpperTriangularMat", IsUpperTriangularMatrix );
 
 
 #############################################################################
 ##
-#O  IsLowerTriangularMatrix( <mat> )
-#O  IsLowerTriangularMat( <mat> )
+#P  IsLowerTriangularMatrix( <mat> )
+#P  IsLowerTriangularMat( <mat> )
 ##
 ##  <#GAPDoc Label="IsLowerTriangularMat">
 ##  <ManSection>
-##  <Oper Name="IsLowerTriangularMatrix" Arg='mat'/>
-##  <Oper Name="IsLowerTriangularMat" Arg='mat'/>
+##  <Prop Name="IsLowerTriangularMatrix" Arg='mat'/>
+##  <Prop Name="IsLowerTriangularMat" Arg='mat'/>
 ##
 ##  <Description>
 ##  return <K>true</K> if the matrix <A>mat</A> has only zero entries above
@@ -147,7 +147,7 @@ DeclareSynonym( "IsUpperTriangularMat", IsUpperTriangularMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "IsLowerTriangularMatrix", [ IsMatrixObj ] );
+DeclareProperty( "IsLowerTriangularMatrix", IsMatrixObj );
 
 DeclareSynonym( "IsLowerTriangularMat", IsLowerTriangularMatrix );
 

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -64,77 +64,120 @@ DeclareProperty( "IsGeneralizedCartanMatrix", IsMatrix );
 
 #############################################################################
 ##
+#O  IsDiagonalMatrix( <mat> )
 #O  IsDiagonalMat( <mat> )
 ##
 ##  <#GAPDoc Label="IsDiagonalMat">
 ##  <ManSection>
+##  <Oper Name="IsDiagonalMatrix" Arg='mat'/>
 ##  <Oper Name="IsDiagonalMat" Arg='mat'/>
 ##
 ##  <Description>
-##  returns true if mat has only zero entries off the main diagonal, false
-##  otherwise.
+##  return <K>true</K> if the matrix <A>mat</A> has only zero entries
+##  off the main diagonal, and <K>false</K> otherwise.
+##  <Example><![CDATA[
+##  gap> IsDiagonalMatrix( [ [ 1 ] ] );
+##  true
+##  gap> IsDiagonalMatrix( [ [ 1, 0, 0 ], [ 0, 1, 0 ] ] );
+##  true
+##  gap> IsDiagonalMatrix( [ [ 0, 1 ], [ 1, 0 ] ] );
+##  false
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation("IsDiagonalMat",[IsMatrix]);
+DeclareOperation( "IsDiagonalMatrix", [ IsMatrixObj ] );
+
+DeclareSynonym( "IsDiagonalMat", IsDiagonalMatrix );
+
 
 #############################################################################
 ##
+#O  IsUpperTriangularMatrix( <mat> )
 #O  IsUpperTriangularMat( <mat> )
 ##
 ##  <#GAPDoc Label="IsUpperTriangularMat">
 ##  <ManSection>
+##  <Oper Name="IsUpperTriangularMatrix" Arg='mat'/>
 ##  <Oper Name="IsUpperTriangularMat" Arg='mat'/>
 ##
 ##  <Description>
-##  returns true if mat has only zero entries below the main diagonal, false
-##  otherwise.
+##  return <K>true</K> if the matrix <A>mat</A> has only zero entries below
+##  the main diagonal, and <K>false</K> otherwise.
+##  <Example><![CDATA[
+##  gap> IsUpperTriangularMatrix( [ [ 1 ] ] );
+##  true
+##  gap> IsUpperTriangularMatrix( [ [ 1, 2, 3 ], [ 0, 5, 6 ] ] );
+##  true
+##  gap> IsUpperTriangularMatrix( [ [ 0, 1 ], [ 1, 0 ] ] );
+##  false
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation("IsUpperTriangularMat",[IsMatrix]);
+DeclareOperation( "IsUpperTriangularMatrix", [ IsMatrixObj ] );
+
+DeclareSynonym( "IsUpperTriangularMat", IsUpperTriangularMatrix );
+
 
 #############################################################################
 ##
+#O  IsLowerTriangularMatrix( <mat> )
 #O  IsLowerTriangularMat( <mat> )
 ##
 ##  <#GAPDoc Label="IsLowerTriangularMat">
 ##  <ManSection>
+##  <Oper Name="IsLowerTriangularMatrix" Arg='mat'/>
 ##  <Oper Name="IsLowerTriangularMat" Arg='mat'/>
 ##
 ##  <Description>
-##  returns true if mat has only zero entries below the main diagonal, false
-##  otherwise.
+##  return <K>true</K> if the matrix <A>mat</A> has only zero entries above
+##  the main diagonal, and <K>false</K> otherwise.
+##  <Example><![CDATA[
+##  gap> IsLowerTriangularMatrix( [ [ 1 ] ] );
+##  true
+##  gap> IsLowerTriangularMatrix( [ [ 1, 0, 0 ], [ 2, 3, 0 ] ] );
+##  true
+##  gap> IsLowerTriangularMatrix( [ [ 0, 1 ], [ 1, 0 ] ] );
+##  false
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation("IsLowerTriangularMat",[IsMatrix]);
+DeclareOperation( "IsLowerTriangularMatrix", [ IsMatrixObj ] );
+
+DeclareSynonym( "IsLowerTriangularMat", IsLowerTriangularMatrix );
+
 
 #############################################################################
 ##
-#O  DiagonalOfMat( <mat> )
+#F  DiagonalOfMatrix( <mat> )
+#F  DiagonalOfMat( <mat> )
 ##
 ##  <#GAPDoc Label="DiagonalOfMat">
 ##  <ManSection>
+##  <Func Name="DiagonalOfMatrix" Arg='mat'/>
 ##  <Func Name="DiagonalOfMat" Arg='mat'/>
 ##
 ##  <Description>
-##  returns the diagonal of the matrix <A>mat</A>. If <A>mat</A> is not a
+##  return the diagonal of the matrix <A>mat</A>. If <A>mat</A> is not a
 ##  square matrix, then the result has the same length as the rows of
 ##  <A>mat</A>, and is padded with zeros if <A>mat</A> has fewer rows than
 ##  columns.
 ##  <Example><![CDATA[
-##  gap> DiagonalOfMat([[1,2,3],[4,5,6]]);
+##  gap> DiagonalOfMatrix( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
 ##  [ 1, 5, 0 ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "DiagonalOfMat" );
+DeclareGlobalFunction( "DiagonalOfMatrix" );
+
+DeclareSynonym( "DiagonalOfMat", DiagonalOfMatrix );
 
 
 #############################################################################
@@ -1221,16 +1264,20 @@ DeclareOperation( "TriangulizeMat", [ IsMatrix and IsMutable ] );
 ##
 ##  <Description>
 ##  returns a mutable list containing the entries of the <A>pos</A>th upper
-##  subdiagonal of <A>mat</A>.
+##  subdiagonal of the matrix <A>mat</A>.
 ##  <Example><![CDATA[
-##  gap> UpperSubdiagonal(mat,1);
+##  gap> UpperSubdiagonal( [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ], 1 );
 ##  [ 2, 6 ]
+##  gap> UpperSubdiagonal( [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ], 1 );
+##  [ 2 ]
+##  gap> UpperSubdiagonal( [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ] ], 1 );
+##  [ 2, 7 ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "UpperSubdiagonal", [ IsMatrix, IsPosInt ] );
+DeclareOperation( "UpperSubdiagonal", [ IsMatrixObj, IsPosInt ] );
 
 
 #############################################################################

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -158,9 +158,9 @@ InstallMethod( IsGeneralizedCartanMatrix,
 
 #############################################################################
 ##
-#M  IsDiagonalMat(<mat>)
+#M  IsDiagonalMatrix(<mat>)
 ##
-InstallMethod( IsDiagonalMat,
+InstallMethod( IsDiagonalMatrix,
     "for a matrix",
     [ IsMatrixObj ],
     function( mat )
@@ -176,14 +176,14 @@ InstallMethod( IsDiagonalMat,
     return true;
     end);
 
-InstallOtherMethod( IsDiagonalMat, [ IsEmpty ], ReturnTrue );
+InstallTrueMethod( IsDiagonalMatrix, IsMatrixObj and IsEmptyMatrix );
 
 
 #############################################################################
 ##
-#M  IsUpperTriangularMat(<mat>)
+#M  IsUpperTriangularMatrix(<mat>)
 ##
-InstallMethod( IsUpperTriangularMat,
+InstallMethod( IsUpperTriangularMatrix,
     "for a matrix",
     [ IsMatrixObj ],
     function( mat )
@@ -202,9 +202,9 @@ InstallMethod( IsUpperTriangularMat,
 
 #############################################################################
 ##
-#M  IsLowerTriangularMat(<mat>)
+#M  IsLowerTriangularMatrix(<mat>)
 ##
-InstallMethod( IsLowerTriangularMat,
+InstallMethod( IsLowerTriangularMatrix,
     "for a matrix",
     [ IsMatrixObj ],
     function( mat )
@@ -223,9 +223,9 @@ InstallMethod( IsLowerTriangularMat,
 
 #############################################################################
 ##
-#M  DiagonalOfMat(<mat>)  . . . . . . . . . . . . . . . .  diagonal of matrix
+#M  DiagonalOfMatrix(<mat>) . . . . . . . . . . . . . . .  diagonal of matrix
 ##
-InstallGlobalFunction( DiagonalOfMat, function ( mat )
+InstallGlobalFunction( DiagonalOfMatrix, function ( mat )
     local   diag, i;
 
     diag := [];
@@ -3271,6 +3271,12 @@ InstallGlobalFunction( NullMat, function ( arg )
         Error("usage: NullMat( <m>, <n> [, <R>] )");
     fi;
     zero := Zero(f);
+
+#    # special treatment for 0-dimensional spaces
+#    if m = 0 or n = 0 then
+#      return NullMapMatrix;
+#    fi;
+#T Adding this would break a test.
 
     # make an empty row
     row := ListWithIdenticalEntries(n,zero);

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2679,7 +2679,7 @@ end );
 
 #############################################################################
 ##
-#M  ExteriorPower( <mat1>, <mat2> )
+#M  ExteriorPower( <mat>, <m> )
 ##
 InstallOtherMethod(ExteriorPower,
   "for matrices", true,[IsMatrix,IsPosInt],
@@ -2691,7 +2691,7 @@ end);
 
 #############################################################################
 ##
-#M  SymmetricPower( <mat1>, <mat2> )
+#M  SymmetricPower( <mat>, <m> )
 ##
 InstallOtherMethod(SymmetricPower,
   "for matrices", true,[IsMatrix,IsPosInt],
@@ -2700,6 +2700,7 @@ local  basis, f;
   f := j->Product( List( Collected( j ), x->x[2]), Factorial );
   basis := UnorderedTuples( [ 1 .. NrRows( A ) ], m );
   return List( basis, i-> List( basis, j->Permanent( A{i}{j}) / f( i )));
+#T This code makes sense only in characteristic zero.
 end);
 
 
@@ -3013,22 +3014,10 @@ mat -> []);
 #M  UpperSubdiagonal( <mat>, <pos> )
 ##
 InstallMethod( UpperSubdiagonal,
-    [ IsMatrix,
-      IsPosInt ],
+    [ IsMatrixObj, IsPosInt ],
 function( mat, l )
-    local   dim,  exp,  i;
-
-    # collect exponents in <e>
-    dim := NrRows(mat);
-    exp := [];
-
-    # run through the diagonal
-    for i  in [ 1 .. dim-l ]  do
-        Add( exp, mat[i,l+i] );
-    od;
-
-    # and return
-    return exp;
+    return List( [ 1 .. Minimum( NrRows( mat ), NrCols( mat ) - l ) ],
+                 i -> mat[ i, l+i ] );
 end );
 
 


### PR DESCRIPTION
- renamed `IsDiagonalMat`, `IsUpperTriangularMat`, `IsLowerTriangularMat`,
  `DiagonalOfMat`
  to `IsDiagonalMatrix`, `IsUpperTriangularMatrix`, `IsLowerTriangularMatrix`,
  `DiagonalOfMatrix`;
  the old names are available via synonyms

  (This is how I interpret the "new plan" statement in `matobj2.gd`.
  Or should the old names better just be kept but become undocumented?
  In that case, the declarations of synonyms should be moved to
  `obsolete.gd`, and test files and cross-references in the documentation
  must be adjusted.)

- in the declarations of `IsDiagonalMatrix`, `IsUpperTriangularMatrix`,
  `IsLowerTriangularMatrix`,
  expect the first argument to be in `IsMatrixObj` not in `IsMatrix`

- fixed wrong documentation of `IsLowerTriangularMatrix`

- fixed GAPDoc syntax for `IsDiagonalMatrix`,
  `IsUpperTriangularMatrix`, `IsLowerTriangularMatrix`

- fixed `UpperSubdiagonal` for non-square matrices, added manual examples

(Concerning "release notes: not needed":
I regard this pull request as a test case for more changes for matrix objects.
In the end, the release notes should mention the relevant changes as a whole.)