### PR TITLE
WIP: Turn BaseField into a synonym of BaseDomain (DO NOT MERGE)

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1170,11 +1170,6 @@ InstallMethod( ConstructingFilter, "for an 8bit vector",
 InstallMethod( ConstructingFilter, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function(v) return Is8BitMatrixRep; end );
 
-InstallMethod( BaseField, "for a compressed 8bit matrix",
-  [Is8BitMatrixRep], function(m) return DefaultFieldOfMatrix(m); end );
-InstallMethod( BaseField, "for a compressed 8bit vector",
-  [Is8BitVectorRep], function(v) return GF(Q_VEC8BIT(v)); end );
-
 InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
   [ Is8BitVectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
@@ -1228,7 +1223,7 @@ InstallMethod( IdentityMatrix, "for a compressed 8bit matrix",
   [IsInt, Is8BitMatrixRep],
   function(rows,m)
     local f,n;
-    f := BaseField(m);
+    f := BaseDomain(m);
     n := IdentityMat(rows,f);
     ConvertToMatrixRep(n,Size(f));
     return n;

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2491,11 +2491,6 @@ InstallMethod( ConstructingFilter, "for a gf2 vector",
 InstallMethod( ConstructingFilter, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function(v) return IsGF2MatrixRep; end );
 
-InstallMethod( BaseField, "for a compressed gf2 matrix",
-  [IsGF2MatrixRep], function(m) return GF(2); end );
-InstallMethod( BaseField, "for a compressed gf2 vector",
-  [IsGF2VectorRep], function(v) return GF(2); end );
-
 InstallMethod( NewVector, "for IsGF2VectorRep, GF(2), and a list",
   [ IsGF2VectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )

--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -328,7 +328,7 @@ end);
 #############################################################################
 ##
 #F  AlgExtElm      A `nicer' ObjByExtRep, that shrinks/grows a list to the 
-##                 correct length and tries to get to the BaseField
+##                 correct length and tries to get to the base field
 ##                 representation
 ##
 BindGlobal("AlgExtElm",function(fam,e)

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -679,6 +679,13 @@ DeclareAttribute( "BaseDomain", IsMatrixObj );
 # nor associative. For non-associative base domains, the behavior of
 # powering matrices is undefined.
 
+# HACK: BaseField used to be defined in matrix.gd, as a kind of predecessor
+# to BaseDomain; we keep it around here for backwards compatibility with
+# older versions of the cvec package. It should be removed eventually.
+DeclareSynonymAttr( "BaseField", BaseDomain );
+
+
+
 DeclareAttribute( "NumberRows", IsMatrixObj );
 DeclareAttribute( "NumberColumns", IsMatrixObj );
 DeclareSynonymAttr( "NrRows", NumberRows );

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -2001,24 +2001,6 @@ DeclareOperation("DefaultScalarDomainOfMatrixList",[IsListOrCollection]);
 
 #############################################################################
 ##
-#O  BaseField( <matrixorvector> )
-##
-##  <ManSection>
-##  <Oper Name="BaseField" Arg='matrixorvector'/>
-##
-##  <Description>
-##  returns the base field of a matrix or a vector. This is only defined
-##  for wrapped matrices and vectors, not for plain lists. That is, for
-##  a plain list the operation returns fail. It is guaranteed
-##  that a call to this operation is only a very fast lookup.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation("BaseField",[IsObject]);
-
-
-#############################################################################
-##
 #O  ZeroVector( <len>, <vector> )
 ##
 ##  <ManSection>

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1127,11 +1127,6 @@ InstallMethod( ConstructingFilter, "for an 8bit vector",
 InstallMethod( ConstructingFilter, "for an 8bit matrix",
   [ Is8BitMatrixRep ], function(v) return Is8BitMatrixRep; end );
 
-InstallMethod( BaseField, "for a compressed 8bit matrix",
-  [Is8BitMatrixRep], function(m) return DefaultFieldOfMatrix(m); end );
-InstallMethod( BaseField, "for a compressed 8bit vector",
-  [Is8BitVectorRep], function(v) return GF(Q_VEC8BIT(v)); end );
-
 InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
   [ Is8BitVectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
@@ -1188,7 +1183,7 @@ InstallMethod( IdentityMatrix, "for a compressed 8bit matrix",
   [IsInt, Is8BitMatrixRep],
   function(rows,m)
     local f,n;
-    f := BaseField(m);
+    f := BaseDomain(m);
     n := IdentityMat(rows,f);
     ConvertToMatrixRep(n,Size(f));
     return n;

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2314,11 +2314,6 @@ InstallMethod( ConstructingFilter, "for a gf2 vector",
 InstallMethod( ConstructingFilter, "for a gf2 matrix",
   [ IsGF2MatrixRep ], function(v) return IsGF2MatrixRep; end );
 
-InstallMethod( BaseField, "for a compressed gf2 matrix",
-  [IsGF2MatrixRep], function(m) return GF(2); end );
-InstallMethod( BaseField, "for a compressed gf2 vector",
-  [IsGF2VectorRep], function(v) return GF(2); end );
-
 InstallMethod( NewVector, "for IsGF2VectorRep, GF(2), and a list",
   [ IsGF2VectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )


### PR DESCRIPTION
Note that `BaseField` was never documented. There are two packages that reference it, though:

1. `cvec` -- I already addressed that [in a commit](https://github.com/gap-packages/cvec/commit/2d2baf1da19f512e95e972e959c966ee7ee4f65e) and will soon make another cvec release with that change in it (it should work with both GAP 4.10 and 4.11 that way)

2. `forms` (by @jdebeule et al) -- it installs a `BaseField` method  for `IsForm` objects, which however are not in `IsVectorObj` nor `IsMatrixObj`. This worked so far because we did `DeclareOperation("BaseField",[IsObject]);` but now it doesn't, leading to an error when loading the package. I submitted a PR to make it use `InstallOtherMethod` here: <https://bitbucket.org/jdebeule/forms/pull-requests/1>. However, that will only help once forms is released. In the meantime, we need another way to keep `forms` working. This is the reason why I marked his PR as "do not merge" -- I am not quite sure how to proceed best.

Of course we could just wait till there is a forms release before we apply this PR, and in the meantime, we could apply parts of it (i.e., replace any *use* of `BaseField`).

Or perhaps we remove all uses of `BaseField`, but still leave its `BaseField` declaration in, and only install a single method which delegates to `BaseDomain`. That declaration and the single method could go to `obsolete.gd/.gi` .

Or something else? 

Thoughts, comments?
