### PR TITLE
Matrices with memory: add BaseDomain & NrRows/Cols, remove DimensionsMat

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -367,12 +367,6 @@ InstallOtherMethod(CycleStructurePerm,
 
 # Matrix methods:
 
-InstallOtherMethod( DimensionsMat, "for a matrix with memory",
-  [ IsMatrix and IsObjWithMemory ],
-  function(M)
-    return DimensionsMat(M!.el);
-  end);
-
 InstallOtherMethod( NumberRows, "for a matrix with memory",
   [ IsMatrix and IsObjWithMemory ],
   M -> NumberRows(M!.el) );

--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -31,6 +31,9 @@ InstallGlobalFunction( GeneratorsWithMemory,
       if IsMatrix(o) then
           SetFilterObj(r,IsMatrix);
       fi;
+      if IsMatrixObj(o) then
+          SetFilterObj(r,IsMatrixObj);
+      fi;
       Add(ll,r);
     od;
     return ll;
@@ -194,6 +197,9 @@ InstallMethod( \*, "objects with memory", true,
     if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
     fi;
+    if IsMatrixObj(a) then
+        SetFilterObj(r,IsMatrixObj);
+    fi;
     return r;
   end);
 
@@ -206,6 +212,9 @@ InstallMethod( One, "objects with memory", true,
     if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
     fi;
+    if IsMatrixObj(a) then
+        SetFilterObj(r,IsMatrixObj);
+    fi;
     return r;
   end);
 
@@ -217,6 +226,9 @@ InstallMethod( OneOp, "objects with memory", true,
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
     if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
+    fi;
+    if IsMatrixObj(a) then
+        SetFilterObj(r,IsMatrixObj);
     fi;
     return r;
   end);
@@ -237,6 +249,9 @@ InstallMethod( InverseOp, "objects with memory", true,
     if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
     fi;
+    if IsMatrixObj(a) then
+        SetFilterObj(r,IsMatrixObj);
+    fi;
     return r;
   end);
 
@@ -254,6 +269,9 @@ InstallMethod( \^, "objects with memory", true,
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
     if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
+    fi;
+    if IsMatrixObj(a) then
+        SetFilterObj(r,IsMatrixObj);
     fi;
     return r;
   end);

--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -373,6 +373,14 @@ InstallOtherMethod( DimensionsMat, "for a matrix with memory",
     return DimensionsMat(M!.el);
   end);
 
+InstallOtherMethod( NumberRows, "for a matrix with memory",
+  [ IsMatrix and IsObjWithMemory ],
+  M -> NumberRows(M!.el) );
+
+InstallOtherMethod( NumberColumns, "for a matrix with memory",
+  [ IsMatrix and IsObjWithMemory ],
+  M -> NumberColumns(M!.el) );
+
 InstallOtherMethod( Length, "for a matrix with memory",
   [ IsMatrix and IsObjWithMemory ], M -> Length(M!.el) ) ;
 

--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -406,6 +406,10 @@ InstallOtherMethod( \*, "for a matrix with memory and a scalar",true,
     return M!.el * s;
   end);
 
+InstallOtherMethod( BaseDomain, "for a matrix with memory", true,
+  [ IsMatrix and IsObjWithMemory ], 0,
+  M -> BaseDomain(M!.el) );
+
 InstallOtherMethod(ProjectiveOrder,"object with memory",true, 
   [IsObjWithMemory],0,
   function(a)

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -59,3 +59,5 @@ gap> NrCols(m);
 2
 gap> NumberColumns(m);
 2
+gap> DimensionsMat(m);
+[ 2, 2 ]

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -51,3 +51,11 @@ gap> m := Z(5)^0 * [[0, 1], [1, 0]];;
 gap> m := GeneratorsWithMemory([m])[1];;
 gap> BaseDomain(m) = GF(5);
 true
+gap> NrRows(m);
+2
+gap> NumberRows(m);
+2
+gap> NrCols(m);
+2
+gap> NumberColumns(m);
+2

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -45,3 +45,9 @@ gap> IsLowerTriangularMat([[1,0],[1,1]]);
 true
 gap> IsLowerTriangularMat([[1,1],[0,1]]);
 false
+
+#
+gap> m := Z(5)^0 * [[0, 1], [1, 0]];;
+gap> m := GeneratorsWithMemory([m])[1];;
+gap> BaseDomain(m) = GF(5);
+true


### PR DESCRIPTION
This allows one to, for instance, call `IsDiagonalMat` on a matrix with memory. I'm unsure whether this works against your current goals with matrix stuff, @fingolfin.

I came across this while working on https://github.com/gap-packages/recog/pull/154.