### PR TITLE
Allow SyAllocPool to be smaller than SyStorMax

### DIFF
--- a/src/sysmem.h
+++ b/src/sysmem.h
@@ -66,6 +66,20 @@ extern Int SyStorMin;
 /****************************************************************************
 **
 *V  SyAllocPool
+**
+**  'SyAllocPool' is the size of the OS memory block which Gasman is using
+**  to store its workspace.
+**
+**  Gasman's workspace must be a single continuous block, and can only be
+**  extended. Extending this memory block after GAP has been running for a
+**  while requires the OS does not allocate any memory immediately after the
+**  current location of the workspace. On 64-bit systems using mmap this is
+**  usually possible as GAP's workspace starts at memory location 16TB. On
+**  32-bit systems it may not be possible to extend so this acts as the
+**  maximum workspace size. The main reason extending the workspace on 32-bit
+**  fails is if code calls malloc (or new in C++), which many packages do.
+**
+**  This option can be changed with -s.
 */
 extern UInt SyAllocPool;
 

--- a/src/system.c
+++ b/src/system.c
@@ -1188,10 +1188,6 @@ void InitSystem (
                             SyAllocPool > 1024 * SyStorKill ) {
         SyAllocPool = SyStorKill * 1024;
     }
-    /* fix pool size if it is given and lower than SyStorMax */
-    if ( SyAllocPool != 0 && SyAllocPool < SyStorMax * 1024) {
-        SyAllocPool = SyStorMax * 1024;
-    }
 
     /* when running in package mode set ctrl-d and line editing            */
     if ( SyWindow ) {


### PR DESCRIPTION
Fixes #3509 

In practice, this sets SyAllocPool back to the value it had before I recently increased SyStorMax. This should make no difference to 64-bit users, except GAP will appear to reserve less memory up front.

These two variables handle difference cases -- SyStorMax
sets the amount of memory at which a warning is printed,
while SyAllocPool sets how much memory we ask the OS
for at startup. If SyAllocPool is more than half of
physical memory, then we cannot fork on machines with
overcommit turned off.

A low SyAllocPool can only cause problems of GASMAN
tries to allocate more memory and fails. This should
never be a problem on 64-bit OSes as we place memory
at a high memory address


This (in my opinion) doesn't need adding to the release notes, as it is part of the earlier "increase GAP's default memory limit", and trying to explain exactly how the various ways GAP measures memory interact is understood by very few people.