### PR TITLE
Fix NrCols for empty matrices in IsMatrix

### DIFF
--- a/lib/algmat.gi
+++ b/lib/algmat.gi
@@ -1474,23 +1474,23 @@ InstallGlobalFunction( EmptyMatrix, function( char )
     fi;
 
     # Construct the matrix.
-    mat:= Objectify( NewType( Fam,
-                                  IsList
-                              and IsEmpty
-                              and IsOrdinaryMatrix
-                              and IsZero
-                              and IsAssociativeElement
-                              and IsCommutativeElement
-                              and IsJacobianElement
-                              and IsAttributeStoringRep ),
-                     rec() );
-
-    SetName( mat, Concatenation( "EmptyMatrix( ", String( char ), " )" ) );
+    mat := ObjectifyWithAttributes( rec(),
+             NewType( Fam,
+                          IsList
+                      and IsEmpty
+                      and IsOrdinaryMatrix
+                      and IsZero
+                      and IsAssociativeElement
+                      and IsCommutativeElement
+                      and IsJacobianElement
+                      and IsAttributeStoringRep ),
+             Name,          Concatenation("EmptyMatrix( ", String(char), " )" ),
+             DimensionsMat, [ 0, 0 ],
+             Length,        0,
+             NrRows,        0,
+             NrCols,        0) ;
     SetInverse( mat, mat );
     SetAdditiveInverse( mat, mat );
-    SetDimensionsMat( mat, [ 0, 0 ] );
-    SetLength( mat, 0 );
-
     return mat;
 end );
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -629,10 +629,16 @@ InstallMethod( RowsOfMatrix,
     Immutable );
 
 
-InstallOtherMethod( NumberRows, "for a plist matrix",
+InstallOtherMethod( NumberRows, "for a matrix",
   [ IsMatrix ], Length);
-InstallOtherMethod( NumberColumns, "for a plist matrix",
-  [ IsMatrix ], m -> Length(m[1]) );
+InstallOtherMethod( NumberColumns, "for a matrix",
+  [ IsMatrix ],
+  function(m)
+    if Length(m) = 0 then
+      return 0;
+    fi;
+    return Length(m[1]);
+  end );
 
 #
 # Compatibility code: Generic methods for IsMatrixObj

--- a/tst/testbugfix/2019-07-14-NrCols-for-empty-IsMatrix.tst
+++ b/tst/testbugfix/2019-07-14-NrCols-for-empty-IsMatrix.tst
@@ -1,0 +1,6 @@
+# https://github.com/gap-system/gap/issues/3570
+gap> M := EmptyMatrix(2);;
+gap> NrRows(M);
+0
+gap> NrCols(M);
+0


### PR DESCRIPTION
Closes #3570.

## Text for release notes

Fix `NrCols` and `NumberColumns` for empty matrices in `IsMatrix`.