### PR TITLE
Clear stored inverse when calling TrimPerm

### DIFF
--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2238,6 +2238,7 @@ Obj Array2Perm (
 
 void TrimPerm(Obj perm, UInt m)
 {
+    CLEAR_STOREDINV_PERM(perm);
     if (TNUM_OBJ(perm) == T_PERM2) {
         GAP_ASSERT(m <= DEG_PERM2(perm));
         ResizeBag(perm, SIZEBAG_PERM2(m));

--- a/src/permutat.h
+++ b/src/permutat.h
@@ -76,7 +76,12 @@ EXPORT_INLINE const UInt4 * CONST_ADDR_PERM4(Obj perm)
 
 EXPORT_INLINE Obj STOREDINV_PERM(Obj perm)
 {
-    return ADDR_OBJ(perm)[0];
+    Obj inv = ADDR_OBJ(perm)[0];
+    /* Check inv has the same TNAM as perm
+      This is checked below in SET_STOREDINV_PERM, but could
+      be invalidated if either perm or inv is changed in-place */
+    GAP_ASSERT(!inv || (TNUM_OBJ(perm) == TNUM_OBJ(inv)));
+    return inv;
 }
 
 /* SET_STOREDINV_PERM should only be used in neither perm, nor inv has
@@ -95,6 +100,18 @@ EXPORT_INLINE void SET_STOREDINV_PERM(Obj perm, Obj inv)
         CHANGED_BAG(perm);
         ADDR_OBJ(inv)[0] = perm;
         CHANGED_BAG(inv);
+    }
+}
+
+/* Clear the stored inverse. This is required if 'perm' changes TNUM.
+   Also clears the stored inverse of the stored inverse (which should be
+   perm). */
+EXPORT_INLINE void CLEAR_STOREDINV_PERM(Obj perm)
+{
+    Obj inv = ADDR_OBJ(perm)[0];
+    if (inv) {
+        ADDR_OBJ(inv)[0] = 0;
+        ADDR_OBJ(perm)[0] = 0;
     }
 }
 

--- a/tst/testbugfix/2019-07-15-StoredInv.tst
+++ b/tst/testbugfix/2019-07-15-StoredInv.tst
@@ -1,0 +1,40 @@
+# When TRIM_PERM causes a permutation 'p' to change TNAM, the stored inverse
+# must be cleared, as the stored inverse of 'p' must have the
+# same TNAM as 'p'
+
+# Make p a Perm4
+gap> p := (1,2,3,4)*(2^16,2^16+1)*(2^16,2^16+1);
+(1,2,3,4)
+gap> IsPerm4Rep(p);
+true
+
+# Force inverse calculation
+gap> q := p^-1;
+(1,4,3,2)
+gap> IsPerm4Rep(q);
+true
+
+# Now trim
+gap> TRIM_PERM(p, 4);
+gap> IsPerm2Rep(p);
+true
+
+# Check inverse is also a perm2
+gap> IsPerm2Rep(p^-1);
+true
+
+# But this has not changed q
+gap> IsPerm4Rep(q);
+true
+
+# and it's inverse is the correct type
+gap> IsPerm4Rep(q^-1);
+true
+
+# Check some calculations that use the inverse
+gap> List([1..5], x -> x/p);
+[ 4, 1, 2, 3, 5 ]
+
+# And on q (to ensure it's inverse is not still 'p')
+gap> List([1..5], x -> x/q);
+[ 2, 3, 4, 1, 5 ]


### PR DESCRIPTION
Fixes #3574 , although this is actually an old bug which was only recently discovered by an interaction between semigroups and a recent change.

This is a minimal fix, so it can be backported (if another release of 4.10 is made). I would like to investigate removing/changing TrimPerm/TRIM_PERM, because it's very easy to abuse and break things, but that's for another PR.

The problem we definitely have: If TrimPerm turns a Perm4 into a Perm2, we need to remove the stored inverse, as a permutation and it's store inverse must have the same TNUM. I think the only place this actually causes a problem is calculating x/p for an integer x and permutation p, after p has been trimmed, but there could be other places.

The reason this PR always throw away the stored inverse: If TrimPerm was used to produce a logically different permutation (say trimming (1,2)(3,4) to just (1,2)), then we also have to remove the inverse. It's unclear to me if that is supposed allowed by TrimPerm. It seems like a terrible idea as permutations are immutable, so I think should be banned.


* Fix bug in calculating x/p for an integer x and permutation p, if p has been 'trimmed'.