### PR TITLE
Speed up writing to global variables

### DIFF
--- a/src/gvars.c
+++ b/src/gvars.c
@@ -773,7 +773,6 @@ void MakeReadOnlyGVar (
         ErrorMayQuit("Variable: '%g' is constant", (Int)NameGVar(gvar), 0L);
     }
     SetGVarWriteState(gvar, GVarReadOnly);
-    CHANGED_GVAR_LIST( FlagsGVars, gvar );
 }
 
 /****************************************************************************
@@ -789,7 +788,6 @@ void MakeConstantGVar(UInt gvar)
             (Int)NameGVar(gvar), 0L);
     }
     SetGVarWriteState(gvar, GVarConstant);
-    CHANGED_GVAR_LIST(FlagsGVars, gvar);
 }
 
 


### PR DESCRIPTION
This PR is based around the observation that when we assign a global variable, we have to check iExprsGVar, FopiesGVar or CopiesGVar for that global variable. However, for most global variables they are set to their default values. This PR adds a single flag which tells us, for each gvar, us if any of these 3 arrays have a non-default value.

To avoid introducing another array, we take WriteGVars (which stores one of three values, if a gvar is mutable, read-only or constant), and make it into FlagsGVars, which now stores this original information, and an extra bit that tells us if any of Exprs,FOpies or Copies is not default. As we have to read WriteGVars anyway, whenever we assign a global, this means there are no extra memory lookups, just the unpacking of the flags.

For simplicity, this new bit is never cleared once it is set. This means when it is true we don't know for certain one of exprsgvar, fopiesgvar or copiesgvar is set to a non-default value, but if it is false we know they are are default.

In a tight loop assigning a global, this PR speeds things up by about 40%

* Release Notes: Speed up writing to global variables
