### PR TITLE
Fix potential infinite loop or recursion when computing size of infinite cyclic groups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -73,7 +73,7 @@ InstallMethod( IsCyclic,
 
 InstallMethod( Size,
     "for a cyclic group",
-    [ IsGroup and IsCyclic and HasGeneratorsOfGroup ],
+    [ IsGroup and IsCyclic and HasGeneratorsOfGroup and CanEasilyCompareElements ],
     {} -> -RankFilter(HasGeneratorsOfGroup),
 function(G)
   local gens;

--- a/tst/testbugfix/2019-07-17-cyclic-size.tst
+++ b/tst/testbugfix/2019-07-17-cyclic-size.tst
@@ -1,0 +1,10 @@
+# Fix a bug that only occurs if all packages are loaded
+gap> F:=FreeGroup(2);;
+gap> F:=F/[F.1/F.2];;
+gap> H:=Group(F.1);;
+gap> IsCyclic(H);
+true
+gap> HasIsFinite(H);
+false
+gap>  Size(H); # should be instant, not infinite recursion / loop
+infinity


### PR DESCRIPTION
This method needs to test whether a group element is the identity; but this
can lead to an infinite recursion if the input is an fp group, as then this
equality check may end up trying to compute the group size. This currently
actually happens when all packages are loaded (with only the default set of
filters, another Size method is selected for cyclic fp groups).

We fix this by adding the `CanEasilyCompareElements` filter to the argument
filters of the method. Strictly speaking, we'd also want to check for
something like `CanEasilyComputerElementOrder`, but that doesn't exist.
