### PR TITLE
keep the ordering of characters/classes

### DIFF
--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -5997,7 +5997,7 @@ InstallOtherMethod( CharacterTableIsoclinic,
     "for an ordinary character table and two lists of class positions",
     [ IsOrdinaryTable, IsObject, IsObject ],
     function( tbl, nsg, center )
-    local size, classes, r;
+    local size, classes, orders, max, r;
 
     size:= Size( tbl );
     classes:= SizesConjugacyClasses( tbl );
@@ -6011,9 +6011,9 @@ InstallOtherMethod( CharacterTableIsoclinic,
 
     if IsList( center ) then
       # find an element of largest order
-      center:= ShallowCopy( center );
-      SortParallel( OrdersClassRepresentatives( tbl ){ center }, center );
-      center:= center[ Length( center ) ];
+      orders:= OrdersClassRepresentatives( tbl );
+      max:= Maximum( orders{ center } );
+      center:= First( center, i -> orders[i] = max );
     fi;
 
     r:= rec();
@@ -6354,9 +6354,12 @@ InstallMethod( CharacterTableIsoclinic,
         irreducibles:= List( Irr( modtbl ), ValuesOfClassFunction );
       else
         factorfusion:= GetFusionMap( reg, ordiso );
-        xpos:= source.centralElement;
+        xpos:= Position( factorfusion, source.centralElement );
         centre:= [ xpos ];
-        outer:= source.outerClasses;
+        outer:= List( source.outerClasses,
+                      l -> Filtered( List( l,
+                                           i -> Position( factorfusion, i ) ),
+                                     IsInt ) );
         irreducibles:= IrreducibleCharactersOfIsoclinicGroup( Irr( modtbl ),
                           centre, outer, xpos, source.p, source.k ).all;
       fi;

--- a/tst/teststandard/ctblisoc.tst
+++ b/tst/teststandard/ctblisoc.tst
@@ -1,4 +1,4 @@
-#@local g, t, iso, t3, iso3, orders, n, iso2, filt, c
+#@local g, t, iso, t3, iso3, orders, n, iso2, filt, outer, c
 gap> START_TEST( "ctblisoc.tst" );
 
 # one argument
@@ -100,6 +100,20 @@ gap> Length( filt );
 1
 gap> IdGroup( filt[1] ) = IdGroup( g );
 false
+gap> if TestPackageAvailability( "ctbllib" ) <> fail and
+>       LoadPackage( "ctbllib", false ) <> fail then
+>      t:= CharacterTable( "4_1.L3(4).2_3" );
+>      iso:= CharacterTableIsoclinic( t, [ 1 .. 4 ] );
+>      outer:= Difference( [ 1 .. NrConjugacyClasses( t ) ],
+>                          ClassPositionsOfDerivedSubgroup( t ) );
+>      if PowerMap( iso, 2 ){ outer{ [ 1 .. 4 ] } } <> [ 2, 4, 2, 4 ] then
+>        # If the power map is [ ..., 4, 2, 4, 2, ... ] then
+>        # the table can be correct, but we want
+>        # --for example for the library table "4_1.L3(4).2_3*"--
+>        # that the *first* generator of the centre appears first.
+>        Error( "wrong ordering of classes for isoclinic table" );
+>      fi;
+>    fi;
 
 # optional arguments:
 # normal subgroup specified, ...


### PR DESCRIPTION
The changes from pull request #3253 had the effect that the orderings
of characters and classes in the result of `CharacterTableIsoclinic`
were different from those in released versions of GAP.

With the current change, we return to the previous orderings.