### PR TITLE
Fix warnings that pop up with some GCC versions

### DIFF
--- a/src/baltree.h
+++ b/src/baltree.h
@@ -26,11 +26,6 @@
 // #define ALLOC allocation function (optional)
 // #define DEALLOC deallocation function (optional)
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
-
 #define Tree JOIN(ELEM_TYPE, Tree)
 #define Node JOIN(ELEM_TYPE, Node)
 
@@ -61,7 +56,7 @@ static Int height_to_size[MaxTreeDepth];
 static const Int alpha_hi = 3;
 static const Int alpha_lo = 2;
 
-static void InitBalancedTrees(void)
+static inline void InitBalancedTrees(void)
 {
     if (!height_to_size_init) {
         height_to_size_init = 1;
@@ -86,7 +81,7 @@ typedef struct {
     Node * root;
 } Tree;
 
-static void FN(DeleteNodes)(Node * node)
+static inline void FN(DeleteNodes)(Node * node)
 {
     if (node != NULL) {
         FN(DeleteNodes)(node->left);
@@ -96,7 +91,7 @@ static void FN(DeleteNodes)(Node * node)
 }
 
 // Linearize subtree starting at node
-static Node ** FN(Linearize)(Node ** buf, Node * node)
+static inline Node ** FN(Linearize)(Node ** buf, Node * node)
 {
     if (node->left)
         buf = FN(Linearize)(buf, node->left);
@@ -106,7 +101,7 @@ static Node ** FN(Linearize)(Node ** buf, Node * node)
     return buf;
 }
 
-static Node * FN(Treeify)(Node ** buf, Int size)
+static inline Node * FN(Treeify)(Node ** buf, Int size)
 {
     Int mid;
     switch (size) {
@@ -124,7 +119,7 @@ static Node * FN(Treeify)(Node ** buf, Int size)
     }
 }
 
-static void FN(Rebalance)(Node ** nodeaddr, Int size)
+static inline void FN(Rebalance)(Node ** nodeaddr, Int size)
 {
     const Int N = 1024;
     Node *    node = *nodeaddr;
@@ -136,7 +131,7 @@ static void FN(Rebalance)(Node ** nodeaddr, Int size)
         DEALLOC(buf);
 }
 
-static Int FN(CountAux)(Node * node)
+static inline Int FN(CountAux)(Node * node)
 {
     if (node == NULL)
         return 0;
@@ -144,12 +139,12 @@ static Int FN(CountAux)(Node * node)
         return 1 + FN(CountAux)(node->left) + FN(CountAux)(node->right);
 }
 
-static Int FN(Count)(Tree * tree)
+static inline Int FN(Count)(Tree * tree)
 {
     return FN(CountAux)(tree->root);
 }
 
-static ELEM_TYPE * FN(FindAux)(Node * node, ELEM_TYPE item)
+static inline ELEM_TYPE * FN(FindAux)(Node * node, ELEM_TYPE item)
 {
     if (node == NULL)
         return NULL;
@@ -162,7 +157,7 @@ static ELEM_TYPE * FN(FindAux)(Node * node, ELEM_TYPE item)
         return &node->item;
 }
 
-static Int FN(InsertAux)(Tree * tree, Node ** nodeaddr, ELEM_TYPE item, int d)
+static inline Int FN(InsertAux)(Tree * tree, Node ** nodeaddr, ELEM_TYPE item, int d)
 {
     Node * node = *nodeaddr;
     if (node == NULL) {
@@ -208,7 +203,7 @@ static Int FN(InsertAux)(Tree * tree, Node ** nodeaddr, ELEM_TYPE item, int d)
     return 0;
 }
 
-static void FN(RemoveNode)(Tree * tree, Node ** nodeaddr)
+static inline void FN(RemoveNode)(Tree * tree, Node ** nodeaddr)
 {
     Node * node = *nodeaddr;
     Node * del = node;
@@ -238,7 +233,7 @@ static void FN(RemoveNode)(Tree * tree, Node ** nodeaddr)
     }
 }
 
-static void FN(RemoveAux)(Tree * tree, Node ** nodeaddr, ELEM_TYPE item)
+static inline void FN(RemoveAux)(Tree * tree, Node ** nodeaddr, ELEM_TYPE item)
 {
     Node * node = *nodeaddr;
     if (!node)
@@ -253,7 +248,7 @@ static void FN(RemoveAux)(Tree * tree, Node ** nodeaddr, ELEM_TYPE item)
     }
 }
 
-static Tree * FN(Make)(void)
+static inline Tree * FN(Make)(void)
 {
     Tree * tree = ALLOC(Tree, 1);
     tree->nodes = tree->maxnodes = 0;
@@ -262,38 +257,38 @@ static Tree * FN(Make)(void)
     return tree;
 }
 
-static void FN(Delete)(Tree * tree)
+static inline void FN(Delete)(Tree * tree)
 {
     FN(DeleteNodes)(tree->root);
     DEALLOC(tree);
 }
 
 
-static void FN(Insert)(Tree * tree, ELEM_TYPE item)
+static inline void FN(Insert)(Tree * tree, ELEM_TYPE item)
 {
     FN(InsertAux)(tree, &tree->root, item, 0);
     if (tree->nodes > tree->maxnodes)
         tree->maxnodes = tree->nodes;
 }
 
-static ELEM_TYPE * FN(Find)(Tree * tree, ELEM_TYPE item)
+static inline ELEM_TYPE * FN(Find)(Tree * tree, ELEM_TYPE item)
 {
     return FN(FindAux)(tree->root, item);
 }
 
-static void FN(Remove)(Tree * tree, ELEM_TYPE item)
+static inline void FN(Remove)(Tree * tree, ELEM_TYPE item)
 {
     FN(RemoveAux)(tree, &tree->root, item);
 }
 
-static void FN(Clear)(Tree * tree)
+static inline void FN(Clear)(Tree * tree)
 {
     FN(DeleteNodes)(tree->root);
     tree->root = NULL;
     tree->nodes = tree->maxnodes = 0;
 }
 
-static Int FN(DepthAux)(Node * node)
+static inline Int FN(DepthAux)(Node * node)
 {
     if (node == NULL)
         return 0;
@@ -302,7 +297,7 @@ static Int FN(DepthAux)(Node * node)
     return (m1 < m2 ? m2 : m1) + 1;
 }
 
-static Int FN(Depth)(Tree * tree)
+static inline Int FN(Depth)(Tree * tree)
 {
     return FN(DepthAux)(tree->root);
 }
@@ -319,7 +314,3 @@ static Int FN(Depth)(Tree * tree)
 #undef COMPARE
 #undef ALLOC
 #undef DEALLOC
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif

--- a/src/dynarray.h
+++ b/src/dynarray.h
@@ -20,11 +20,6 @@
 // #define ALLOC allocation function (optional)
 // #define DEALLOC deallocation function (optional)
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
-
 #define Array JOIN(ELEM_TYPE, Array)
 
 #define FN(sym) JOIN(Array, sym)
@@ -45,7 +40,7 @@ typedef struct {
     ELEM_TYPE * items;
 } Array;
 
-static Array * FN(Make)(Int cap)
+static inline Array * FN(Make)(Int cap)
 {
     Array * arr;
     GAP_ASSERT(cap >= 0);
@@ -58,13 +53,13 @@ static Array * FN(Make)(Int cap)
     return arr;
 }
 
-static void FN(Delete)(Array * arr)
+static inline void FN(Delete)(Array * arr)
 {
     DEALLOC(arr->items);
     DEALLOC(arr);
 }
 
-static void FN(ExpandTo)(Array * arr, Int minlen)
+static inline void FN(ExpandTo)(Array * arr, Int minlen)
 {
     Int cap = arr->cap;
     GAP_ASSERT(minlen >= 0);
@@ -81,8 +76,7 @@ static void FN(ExpandTo)(Array * arr, Int minlen)
     arr->cap = cap;
 }
 
-#if 0
-static void FN(Shrink)(Array * arr)
+static inline void FN(Shrink)(Array * arr)
 {
     if (arr->cap > arr->len) {
         ELEM_TYPE * items = ALLOC(ELEM_TYPE, arr->len);
@@ -92,9 +86,8 @@ static void FN(Shrink)(Array * arr)
         arr->cap = arr->len;
     }
 }
-#endif
 
-static Array * FN(Clone)(Array * arr)
+static inline Array * FN(Clone)(Array * arr)
 {
     Array * clone = FN(Make)(arr->len);
     clone->len = arr->len;
@@ -102,38 +95,38 @@ static Array * FN(Clone)(Array * arr)
     return clone;
 }
 
-static void FN(SetLen)(Array * arr, Int len)
+static inline void FN(SetLen)(Array * arr, Int len)
 {
     GAP_ASSERT(len <= arr->len);
     if (len < arr->len)
         arr->len = len;
 }
 
-static inline Int FN(Len)(Array * arr)
+static inline inline Int FN(Len)(Array * arr)
 {
     return arr->len;
 }
 
-static inline ELEM_TYPE FN(Get)(Array * arr, Int i)
+static inline inline ELEM_TYPE FN(Get)(Array * arr, Int i)
 {
     GAP_ASSERT(i >= 0 && i < arr->len);
     return arr->items[i];
 }
 
-static inline void FN(Put)(Array * arr, Int i, ELEM_TYPE item)
+static inline inline void FN(Put)(Array * arr, Int i, ELEM_TYPE item)
 {
     GAP_ASSERT(i >= 0 && i < arr->len);
     arr->items[i] = item;
 }
 
-static inline void FN(Add)(Array * arr, ELEM_TYPE item)
+static inline inline void FN(Add)(Array * arr, ELEM_TYPE item)
 {
     FN(ExpandTo)(arr, arr->len + 1);
     arr->items[arr->len++] = item;
 }
 
 #ifdef COMPARE
-static void FN(Sort)(Array * arr)
+static inline void FN(Sort)(Array * arr)
 {
     Int len = arr->len;
     if (len <= 1)
@@ -188,7 +181,3 @@ static void FN(Sort)(Array * arr)
 #undef COMPARE
 #undef ALLOC
 #undef DEALLOC
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
With GCC 5.4 on an Ubuntu machine, I get annoying warnings like these:
```
In file included from src/julia_gc.c:246:0:
src/julia_gc.c:243:19: warning: ‘PtrArrayDelete’ defined but not used [-Wunused-function]
 #define ELEM_TYPE Ptr
                   ^
src/dynarray.h:33:23: note: in definition of macro ‘JOIN2’
 #define JOIN2(s1, s2) s1##s2
                       ^
src/dynarray.h:30:17: note: in expansion of macro ‘JOIN’
 #define FN(sym) JOIN(Array, sym)
                 ^
src/dynarray.h:32:22: note: in expansion of macro ‘JOIN2’
 #define JOIN(s1, s2) JOIN2(s1, s2)
                      ^
src/dynarray.h:28:15: note: in expansion of macro ‘JOIN’
 #define Array JOIN(ELEM_TYPE, Array)
               ^
src/dynarray.h:28:20: note: in expansion of macro ‘ELEM_TYPE’
 #define Array JOIN(ELEM_TYPE, Array)
                    ^
src/dynarray.h:30:22: note: in expansion of macro ‘Array’
 #define FN(sym) JOIN(Array, sym)
                      ^
src/dynarray.h:61:13: note: in expansion of macro ‘FN’
 static void FN(Delete)(Array * arr)
             ^
src/julia_gc.c:243:19: warning: ‘PtrArrayClone’ defined but not used [-Wunused-function]
 #define ELEM_TYPE Ptr
                   ^
src/dynarray.h:33:23: note: in definition of macro ‘JOIN2’
 #define JOIN2(s1, s2) s1##s2
                       ^
...
```

This PR makes them go away.