### PR TITLE
kernel: put GASMAN specific code inside #ifdef USE_GASMAN

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -33,7 +33,9 @@
 #include "records.h"
 #include "stringobj.h"
 #include "sysfiles.h"
+#ifdef USE_GASMAN
 #include "sysmem.h"
+#endif
 #include "vars.h"
 
 #ifdef HPCGAP
@@ -1070,15 +1072,16 @@ static UInt ExecIntrStat(Stat stat)
     HaveInterrupt();
 
     /* and now for something completely different                          */
+#ifdef USE_GASMAN
     if ( SyStorOverrun != 0 ) {
       SyStorOverrun = 0; /* reset */
       ErrorReturnVoid(
   "reached the pre-set memory limit\n(change it with the -o command line option)",
         0L, 0L, "you can 'return;'" );
     }
-    else {
+    else
+#endif
       ErrorReturnVoid( "user interrupt", 0L, 0L, "you can 'return;'" );
-    }
 #endif
 
     /* continue at the interrupted statement                               */
@@ -1123,12 +1126,14 @@ void ClearError ( void )
           Pr("Noticed user interrupt, but you are back in main loop anyway.\n",
               0L, 0L);
         }
+#ifdef USE_GASMAN
         /* and check if maximal memory was overrun */
         if ( SyStorOverrun != 0 ) {
           SyStorOverrun = 0; /* reset */
           Pr("GAP has exceeded the permitted memory (-o option),\n", 0L, 0L);
           Pr("the maximum is now enlarged to %d kB.\n", (Int)SyStorMax, 0L);
         }
+#endif
     }
 
     /* reset <STATE(NrError)>                                                */

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -38,7 +38,9 @@ Int SyStorOverrun;
 Int SyStorKill;
 Int SyStorMin;
 
+#if defined(USE_GASMAN)
 UInt SyAllocPool;
+#endif
 
 
 /****************************************************************************
@@ -158,6 +160,7 @@ void SyMsgsBags (
 }
 
 
+#if defined(USE_GASMAN)
 
 /****************************************************************************
 **
@@ -278,9 +281,8 @@ int SyTryToIncreasePool(void)
     return -1;
 }
 
-#else
+#elif defined(HAVE_MADVISE)
 
-#ifdef HAVE_MADVISE
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
 #endif
@@ -332,8 +334,7 @@ void SyMAdviseFree(void) {
      * Maybe we do want to do this until it breaks to avoid questions
      * by users...
      */
-#ifndef NO_DIRTY_OSX_MMAP_TRICK
-#ifdef SYS_IS_DARWIN
+#if !defined(NO_DIRTY_OSX_MMAP_TRICK) && defined(SYS_IS_DARWIN)
     if (mmap(from, size, PROT_NONE,
             MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0) != from) {
         Panic("OS X trick to free pages did not work!");
@@ -342,7 +343,6 @@ void SyMAdviseFree(void) {
             MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED, -1, 0) != from) {
         Panic("OS X trick to free pages did not work!!");
     }
-#endif
 #endif
 }
 
@@ -405,8 +405,8 @@ static int SyTryToIncreasePool(void)
     return -1;   /* Refuse */
 }
 
-#endif
-#endif
+#endif // defined(GAP_MEM_CHECK)
+
 
 static int halvingsdone = 0;
 
@@ -678,3 +678,6 @@ UInt * * * SyAllocBags (
 }
 
 #endif
+
+
+#endif // defined(USE_GASMAN)

--- a/src/sysmem.h
+++ b/src/sysmem.h
@@ -88,8 +88,7 @@ extern UInt SyAllocPool;
 **
 *F * * * * * * * * * * * * * * gasman interface * * * * * * * * * * * * * * *
 */
-
-#ifdef GAP_MEM_CHECK
+#if defined(USE_GASMAN) && defined(GAP_MEM_CHECK)
 UInt   GetMembufCount(void);
 void * GetMembuf(UInt i);
 UInt   GetMembufSize(void);
@@ -116,7 +115,9 @@ void SyMsgsBags(UInt full, UInt phase, Int nr);
 **  This function is called by GASMAN after each successfully completed
 **  garbage collection.
 */
+#if defined(USE_GASMAN)
 void SyMAdviseFree(void);
+#endif
 
 /****************************************************************************
 **
@@ -145,7 +146,9 @@ void SyMAdviseFree(void);
 **  If the operating system does not support dynamic memory management, simply
 **  give 'SyAllocBags' a static buffer, from where it returns the blocks.
 */
+#if defined(USE_GASMAN)
 UInt *** SyAllocBags(Int size, UInt need);
+#endif
 
 
 #endif // GAP_SYSMEM_H


### PR DESCRIPTION
Some code in `sysmem.c` is only really used if GASMAN is used. Disable it otherwise. This makes it a bit easier to understand the code, and to see what's going on.

Perhaps it would be even better if those parts of `sysmem.c` were moved into a new file `gasman_intern.c`. I am happy to do that, if people feel that's the right way to go about it. 