### PR TITLE
WIP Stop system setters storing attribute values in mutable objects

### DIFF
--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -917,6 +917,21 @@ DeclareRepresentation( "IsPresentationDefaultRep",
 
 #############################################################################
 ##
+#M  One( <pres> )  . . . . . . . . . . . . . . . . . . . . for a presentation
+##
+InstallOtherMethod(One, [IsPresentationDefaultRep],
+        T -> T!.identity);
+
+#############################################################################
+##
+#M  PrimaryGeneratorWords( <pres> )  . . . . . . . . . . . for a presentation
+##
+InstallOtherMethod(PrimaryGeneratorWords, [IsPresentationDefaultRep],
+        T -> T!.primaryGeneratorWords);
+
+
+#############################################################################
+##
 #M  \.( <pres>, <nam> )  . . . . . . . . . . . . . . . . . for a presentation
 ##
 InstallMethod( \.,
@@ -1069,7 +1084,6 @@ InstallGlobalFunction( PresentationAugmentedCosetTable,
     T!.components := comps;
     T!.nextFree := numgens + 1;
     T!.identity := One( fgens[1] );
-    SetOne(T,One( fgens[1] ));
 
     # save the tree as component of the Tietze record.
     tree[TR_TREENUMS] := treeNums;
@@ -1079,8 +1093,8 @@ InstallGlobalFunction( PresentationAugmentedCosetTable,
 
     # save the definitions of the primary generators as words in the original
     # group generators.
-    SetPrimaryGeneratorWords(T,aug.primaryGeneratorWords);
-
+    T!.primaryGeneratorWords := aug.primaryGeneratorWords;
+    
     # handle relators of length 1 or 2, but do not eliminate any primary
     # generators.
     TzOptions(T).protected := tree[TR_PRIMARY];

--- a/src/opers.c
+++ b/src/opers.c
@@ -3371,36 +3371,41 @@ static Obj DoSetterFunction(Obj self, Obj obj, Obj value)
     int                 atomic = 0;
 #endif
 
+    /* System setter does not store attribute values in mutable objects */
+    if (IS_MUTABLE_OBJ(obj)) {
+        return 0;
+    }
+
     switch (TNUM_OBJ(obj)) {
 #ifdef HPCGAP
-      case T_ACOMOBJ:
+    case T_ACOMOBJ:
         atomic = 1;
 #endif
-      case T_COMOBJ:
+    case T_COMOBJ:
         break;
-      default:
-        ErrorQuit( "<obj> must be a component object", 0L, 0L );
+    default:
+        ErrorQuit("<obj> must be a component object", 0L, 0L);
         return 0L;
     }
 
     /* if the attribute is already there *do not* chage it                 */
     tmp = ENVI_FUNC(self);
-    tester = ELM_PLIST( tmp, 2 );
-    flag2  = INT_INTOBJ( FLAG2_FILT(tester) );
-    type   = TYPE_OBJ_FEO(obj);
-    flags  = FLAGS_TYPE(type);
-    if ( SAFE_C_ELM_FLAGS(flags,flag2) ) {
+    tester = ELM_PLIST(tmp, 2);
+    flag2 = INT_INTOBJ(FLAG2_FILT(tester));
+    type = TYPE_OBJ_FEO(obj);
+    flags = FLAGS_TYPE(type);
+    if (SAFE_C_ELM_FLAGS(flags, flag2)) {
         return 0;
     }
 
     /* set the value                                                       */
-    UInt rnam = (UInt)INT_INTOBJ(ELM_PLIST(tmp,1));
+    UInt rnam = (UInt)INT_INTOBJ(ELM_PLIST(tmp, 1));
 #ifdef HPCGAP
     if (atomic)
-      SetARecordField( obj, rnam, CopyObj(value,0) );
+        SetARecordField(obj, rnam, CopyObj(value, 0));
     else
 #endif
-      AssPRec( obj, rnam, CopyObj(value,0) );
+        AssPRec(obj, rnam, CopyObj(value, 0));
     CALL_2ARGS( SET_FILTER_OBJ, obj, tester );
     return 0;
 }


### PR DESCRIPTION
Please use the following template to submit a pull request, filling
in at least the "Text for release notes" and/or "Further details".
Thank You!

# Description

The system setters used for objects in `IsAttributeStoringRep` did not check the objects for mutability. 
This leads to unsafe behaviour where attribute values were stored in mutable objects. Mutable objects in `IsAttributeStoringRep` are thankfully rare, but they are not impossible or unreasonable, especially for objects that may be made immutable by `MakeImmutable` in the future (whereupon they should start storing attribute values). 

This addresses #1371 and questions that arose in #3560 

At this stage this PR is just a proof of concept to get comment an wider testing

## Text for release notes 

The values of computed Attributes will no longer be stored automatically in mutable attribute-storing
objects, since they may become out of date as the object mutates. If you wish to store such a value and know that it is safe to do so, then you can address this by defining a custom setter method for your object.

## Further details
Still needed before merge:
- [ ] documentation
- [ ] tests


One of the diffs is a bit bigger than it could be because I clang-formatted a bit too much code.


# Checklist for pull request reviewers


