### PR TITLE
Undocument second argument for `DeclareGlobalFunction"

### DIFF
--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1794,12 +1794,12 @@ end );
 
 #############################################################################
 ##
-#F  DeclareGlobalFunction( <name>, <info> ) . .  create a new global function
+#F  DeclareGlobalFunction( <name> ) . . . . . .  create a new global function
 #F  InstallGlobalFunction( <oper>, <func> )
 ##
 ##  <#GAPDoc Label="DeclareGlobalFunction">
 ##  <ManSection>
-##  <Func Name="DeclareGlobalFunction" Arg='name, info'/>
+##  <Func Name="DeclareGlobalFunction" Arg='name'/>
 ##  <Func Name="InstallGlobalFunction" Arg='oper, func'/>
 ##
 ##  <Description>


### PR DESCRIPTION

# Description

The header of the manual entry for `DeclarelGlobalFunction` suggests it takes a second argument `info`
This is not mentioned in the remainder of the entry, and if passed, is discarded. This PR adjusts the documentation header.

## Text for release notes 
not needed
## Further details


