### PR TITLE
Performance improvements to automorphisms/isomorphism

### DIFF
--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2264,7 +2264,8 @@ local m;
     return fail;
   fi;
 
-  if (AbelianRank(G)>2 or Length(SmallGeneratingSet(G))>2) and Size(RadicalGroup(G))>1 then
+  if (AbelianRank(G)>2 or Length(SmallGeneratingSet(G))>2 
+    or ValueOption("forcetest")=true) and Size(RadicalGroup(G))>1 then
     # In place until a proper implementation of Cannon/Holt isomorphism is
     # made available.
     return PatheticIsomorphism(G,H);

--- a/tst/teststandard/opers/AutomorphismGroup.tst
+++ b/tst/teststandard/opers/AutomorphismGroup.tst
@@ -1,4 +1,9 @@
 gap> START_TEST("AutomorphismGroup.tst");
+
+# Assertions at level 2 kill runtime of automorphism group computations
+gap> SetAssertionLevel(0);
+
+#
 gap> SimpleAutTest:=function(from,to)
 > local it,g,a,p;
 >   it:=SimpleGroupsIterator(from);

--- a/tst/teststandard/opers/IsomorphismGroups.tst
+++ b/tst/teststandard/opers/IsomorphismGroups.tst
@@ -1,0 +1,17 @@
+gap> START_TEST("IsomorphismGroups.tst");
+
+# Assertions at level 2 kill runtime of automorphism group computations
+gap> SetAssertionLevel(0);;
+
+#
+gap> g:=PerfectGroup(IsPermGroup,15360,1);;
+gap> h:=g^(1,2);;
+gap> Length(CharacteristicSubgroups(g));
+5
+gap> Length(CharacteristicSubgroups(h));
+5
+gap> IsomorphismGroups(g,h:forcetest)<>fail;
+true
+
+#
+gap> STOP_TEST("IsomorphismGroups.tst",1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -105,5 +105,9 @@ gap> iso:=IsomorphismPcGroup(g);;
 gap> Length(DoubleCosets(Image(iso,g),Image(iso,s),Image(iso,s)));
 24
 
+# some lattice and deductions
+gap> MinimalFaithfulPermutationDegree(PerfectGroup(IsPermGroup,7680,1));
+76
+
 #
 gap> STOP_TEST( "permgrp.tst", 1);


### PR DESCRIPTION
Use special method for automorphism lifting if M lies in the Frattini of its centralizer (see: Cannon, John J.; Holt, Derek F.
Automorphism group computation and isomorphism testing in finite groups. 
J. Symb. Comput. 35, No. 3, 241-267 (2003), p.259)

Better correspondence of characteristic subgroups to refine series.
