### PR TITLE
MatrixObj: Add IsEmptyMatrix property

### DIFF
--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -305,6 +305,7 @@ see&nbsp;<Ref Sect="Mutability and Copyability"/>.
 <#Include Label="DeterminantMat">
 <#Include Label="DeterminantMatDestructive">
 <#Include Label="DeterminantMatDivFree">
+<#Include Label="MatObj_IsEmptyMatrix">
 <#Include Label="IsMonomialMatrix">
 <#Include Label="IsDiagonalMat">
 <#Include Label="IsUpperTriangularMat">

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -645,3 +645,12 @@ InstallOtherMethod( NumberColumns, "for a matrix",
 #
 InstallOtherMethod( DimensionsMat, "for a matrix in IsMatrixObj",
   [ IsMatrixObj ], m -> [ NumberRows( m ), NumberColumns( m ) ] );
+
+############################################################################
+##
+#M  IsEmptyMatrix( <matobj> )
+##
+InstallMethod( IsEmptyMatrix,
+  [ IsMatrixObj ],
+  mat -> NrRows(mat) = 0 or NrCols(mat) = 0
+);

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1289,6 +1289,24 @@ DeclareOperation( "^", [ IsVectorObj, IsMatrixObj ] );
 # AddCoeffs
 
 
+#############################################################################
+##
+##  IsEmptyMatrix( <matobj> )
+##
+##  <#GAPDoc Label="MatObj_IsEmptyMatrix">
+##  <ManSection>
+##    <Prop Name="IsEmptyMatrix" Arg='M' Label="for matrices"/>
+##    <Returns>A boolean</Returns>
+##    <Description>
+##      Is <K>true</K> if <A>M</A> either has zero columns or zero rows and 
+##      <K>false</K> otherwise.
+##      In other words, a matrix is empty if it has no entries.
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsEmptyMatrix", IsMatrixObj );
+
 
 # while we are at it also make the naming of following more uniform ???
 


### PR DESCRIPTION
Adds an `IsEmptyMatrix` property for `MatrixObj` objects.
As always I'm open to suggestions. 

Resolves #3567.