### PR TITLE
Invalid use of / on ZmodnZObjs (e.g. dividing a unit by a zero divisor) produces an error, instead of returning fail

### DIFF
--- a/lib/zmodnz.gi
+++ b/lib/zmodnz.gi
@@ -414,7 +414,7 @@ InstallMethod( \/,
     q := QuotientMod( Integers, x![1], y![1],
                  Fam!.Characteristic );
     if q = fail then
-        return fail;
+        Error("invalid division");
     fi;
     return ZmodnZObj( Fam, q );
     end );
@@ -428,7 +428,7 @@ InstallMethod( \/,
     q := QuotientMod( Integers, x![1], y,
                  Fam!.Characteristic );
     if q = fail then
-        return fail;
+        Error("invalid division");
     fi;
     return ZmodnZObj( Fam, q );
     end );
@@ -442,7 +442,7 @@ InstallMethod( \/,
     q := QuotientMod( Integers, x, y![1],
                  Fam!.Characteristic );
     if q = fail then
-        return fail;
+        Error("invalid division");
     fi;
     return ZmodnZObj( Fam, q );
     end );

--- a/tst/testinstall/zmodnz.tst
+++ b/tst/testinstall/zmodnz.tst
@@ -322,7 +322,7 @@ ZmodnZObj( 4, 6 )
 gap> Quotient(R, ZmodnZObj(2,6), ZmodnZObj(5,6));
 ZmodnZObj( 4, 6 )
 gap> ZmodnZObj(5,6) / ZmodnZObj(2,6);
-fail
+Error, invalid division
 gap> Quotient(R, ZmodnZObj(5,6), ZmodnZObj(2,6));
 fail
 
@@ -332,7 +332,7 @@ ZmodnZObj( 2, 6 )
 gap> Quotient(R, ZmodnZObj(0,6), ZmodnZObj(2,6));
 ZmodnZObj( 0, 6 )
 gap> ZmodnZObj(2,6) / ZmodnZObj(0,6);
-fail
+Error, invalid division
 gap> Quotient(R, ZmodnZObj(2,6), ZmodnZObj(0,6));
 fail
 
@@ -482,21 +482,21 @@ ZmodnZObj( 2, 10 )
 gap> y := ZmodnZObj(0,10);
 ZmodnZObj( 0, 10 )
 gap> x/y;
-fail
+Error, invalid division
 gap> y/x;
 ZmodnZObj( 0, 10 )
 gap> 0/x;
 ZmodnZObj( 0, 10 )
 gap> x/0;
-fail
+Error, invalid division
 gap> x/3;
 ZmodnZObj( 4, 10 )
 gap> 3/x;
-fail
+Error, invalid division
 gap> y/3;
 ZmodnZObj( 0, 10 )
 gap> 3/y;
-fail
+Error, invalid division
 
 #
 gap> R := Integers mod 4;;


### PR DESCRIPTION
If you want `fail`, use `Quotient`, which was made for that.