### PR TITLE
Fix StandardAssociateUnit for polynomial rings

### DIFF
--- a/hpcgap/lib/ringpoly.gi
+++ b/hpcgap/lib/ringpoly.gi
@@ -635,7 +635,7 @@ InstallMethod(StandardAssociateUnit,
 function(R,f)
   local c;
   c:=LeadingCoefficient(f);
-  return StandardAssociateUnit(CoefficientsRing(R),c);
+  return StandardAssociateUnit(CoefficientsRing(R),c) * One(R);
 end);
 
 InstallMethod(FunctionField,"indetlist",true,[IsRing,IsList],

--- a/lib/ratfunul.gi
+++ b/lib/ratfunul.gi
@@ -1031,7 +1031,7 @@ InstallMethod(StandardAssociateUnit,"laurent",
   IsCollsElms,[IsPolynomialRing, IsLaurentPolynomial],0,
 function(R,f)
   # get standard associate of leading term
-  return StandardAssociateUnit(CoefficientsRing(R), LeadingCoefficient(f));
+  return StandardAssociateUnit(CoefficientsRing(R), LeadingCoefficient(f)) * One(R);
 end);
 
 #############################################################################

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -633,7 +633,7 @@ InstallMethod(StandardAssociateUnit,
 function(R,f)
   local c;
   c:=LeadingCoefficient(f);
-  return StandardAssociateUnit(CoefficientsRing(R),c);
+  return StandardAssociateUnit(CoefficientsRing(R),c) * One(R);
 end);
 
 InstallMethod(FunctionField,"indetlist",true,[IsRing,IsList],

--- a/tst/testinstall/associate.tst
+++ b/tst/testinstall/associate.tst
@@ -1,4 +1,4 @@
-#@local checkStandardAssociate
+#@local checkStandardAssociate, A, x, R
 gap> START_TEST("associate.tst");
 
 # test StandardAssociate, StandardAssociateUnit, IsAssociated
@@ -47,6 +47,14 @@ gap> checkStandardAssociate(Integers mod ((2*3*5*7)^2));
 true
 gap> checkStandardAssociate(Integers mod ((2*3*5*7)^3));
 true
+
+# polynomial rings
+gap> for A in [ GF(5), Integers, Rationals ] do
+>      for x in [1,3] do
+>        R:=PolynomialRing(A, x);
+>        checkStandardAssociate(R, List([1..30],i->PseudoRandom(R)));
+>      od;
+>    od;
 
 #
 gap> STOP_TEST("associate.tst", 1);


### PR DESCRIPTION
By definition in the documentation, the returned unit must be an element of the ring.

The drawback of this is that it makes `StandardAssociateUnit` a bit less efficient: converting the unit into a polynomial introduces overhead in terms of memory and runtime. And for typical applications of this (e.g. implementing row reductions in a matrix), it doesn't matter, as all we really need is that for inputs `a` and `b` we get a "unit" `u` such that `a  * u = b` and `a = b * u^-1` hold.

So an alternative to this PR would be to adjust the documentation, and also `checkStandardAssociate`.

Thoughts, anybody?