### PR TITLE
Clarify, fix and test semantics of Quotient(R,a,b)

### DIFF
--- a/hpcgap/lib/integer.gi
+++ b/hpcgap/lib/integer.gi
@@ -1514,6 +1514,9 @@ InstallMethod( Quotient,
     [ IsIntegers, IsInt, IsInt ], 0,
     function ( Integers, n, m )
     local   q;
+    if m = 0 then
+        return fail;
+    fi;
     q := QuoInt( n, m );
     if n <> q * m  then
         q := fail;

--- a/lib/field.gi
+++ b/lib/field.gi
@@ -1033,6 +1033,9 @@ InstallMethod( Quotient,
     IsCollsElmsElms,
     [ IsDivisionRing, IsRingElement, IsRingElement ],
     function ( F, r, s )
+    if IsZero(s) then
+        return fail;
+    fi;
     return r/s;
     end );
 

--- a/lib/gaussian.gi
+++ b/lib/gaussian.gi
@@ -119,6 +119,9 @@ InstallMethod( Quotient,
     [ IsGaussianIntegers, IsCyc, IsCyc ],
     function ( GaussianIntegers, x, y )
     local   q;
+    if y = 0 then
+        return fail;
+    fi;
     q := x / y;
     if not IsCycInt( q )  then
         q := fail;

--- a/lib/integer.gi
+++ b/lib/integer.gi
@@ -1506,6 +1506,9 @@ InstallMethod( Quotient,
     [ IsIntegers, IsInt, IsInt ], 0,
     function ( Integers, n, m )
     local   q;
+    if m = 0 then
+        return fail;
+    fi;
     q := QuoInt( n, m );
     if n <> q * m  then
         q := fail;

--- a/lib/ring.gd
+++ b/lib/ring.gd
@@ -917,12 +917,15 @@ DeclareOperation( "InterpolatedPolynomial",
 ##  <Oper Name="Quotient" Arg='[R, ]r, s'/>
 ##
 ##  <Description>
-##  <Ref Oper="Quotient"/> returns the quotient of the two ring elements
+##  <Ref Oper="Quotient"/> returns a (right) quotient of the two ring elements
 ##  <A>r</A> and <A>s</A> in the ring <A>R</A>, if given,
 ##  and otherwise in their default ring
 ##  (see <Ref Func="DefaultRing" Label="for ring elements"/>).
-##  It returns <K>fail</K> if the quotient does not exist in the respective
-##  ring.
+##  More specifically, it returns a ring element <M>q</M> such that
+##  <M>r = q * s</M> holds, or <K>fail</K> if no such elements exists in the
+##  respective ring.
+##  <P/>
+##  The result may not be unique if the ring contains zero divisors.
 ##  <P/>
 ##  (To perform the division in the quotient field of a ring, use the
 ##  quotient operator <C>/</C>.)

--- a/tst/testinstall/opers/Quotient.tst
+++ b/tst/testinstall/opers/Quotient.tst
@@ -1,0 +1,128 @@
+gap> START_TEST("Quotient.tst");
+
+#
+gap> Quotient(2, 1);
+2
+gap> Quotient(1, 2);
+fail
+gap> Quotient(1, 0);
+fail
+gap> Quotient(Integers, 2, 1);
+2
+gap> Quotient(Integers, 1, 2);
+fail
+gap> Quotient(Integers, 1, 0);
+fail
+gap> Quotient(GaussianIntegers, 2, 1);
+2
+gap> Quotient(GaussianIntegers, 1, 2);
+fail
+gap> Quotient(GaussianIntegers, 1, 0);
+fail
+gap> Quotient(Rationals, 2, 1);
+2
+gap> Quotient(Rationals, 1, 2);
+1/2
+gap> Quotient(Rationals, 1, 0);
+fail
+gap> Quotient(GaussianRationals, 2, 1);
+2
+gap> Quotient(GaussianRationals, 1, 2);
+1/2
+gap> Quotient(GaussianRationals, 1, 0);
+fail
+
+#
+gap> R := GF(7);;
+gap> Quotient(Z(7)^2, Z(7));
+Z(7)
+gap> Quotient(Z(7), Z(7)^2);
+Z(7)^5
+gap> Quotient(Z(7), 0*Z(7));
+fail
+gap> Quotient(R, Z(7)^2, Z(7));
+Z(7)
+gap> Quotient(R, Z(7), Z(7)^2);
+Z(7)^5
+gap> Quotient(R, Z(7), 0*Z(7));
+fail
+
+#
+gap> R := Integers mod 6;;
+gap> a := ZmodnZObj(2, 6);;
+gap> b := ZmodnZObj(5, 6);;
+gap> Quotient(a, b);
+ZmodnZObj( 4, 6 )
+gap> Quotient(b, a);
+fail
+gap> Quotient(b, 0*a);
+fail
+gap> Quotient(R, a, b);
+ZmodnZObj( 4, 6 )
+gap> Quotient(R, b, a);
+fail
+gap> Quotient(R, b, 0*a);
+fail
+
+#
+gap> R:=PolynomialRing(Integers, 1);; t:=R.1;;
+gap> Quotient(2*t, t);
+2
+gap> Quotient(t, 2*t);
+1/2
+gap> Quotient(t, 0*t);
+fail
+gap> Quotient(R, 2*t, t);
+2
+gap> Quotient(R, t, 2*t); # FIXME: result is NOT contained in R; bug in polynomial quotient code
+1/2
+gap> Quotient(R, t, 0*t);
+fail
+
+#
+gap> R:=PolynomialRing(Rationals, 1);; t:=R.1;;
+gap> Quotient(2*t, t);
+2
+gap> Quotient(t, 2*t);
+1/2
+gap> Quotient(t, 0*t);
+fail
+gap> Quotient(R, 2*t, t);
+2
+gap> Quotient(R, t, 2*t);
+1/2
+gap> Quotient(R, t, 0*t);
+fail
+
+#
+gap> R:=PolynomialRing(GF(7), 1);; t:=R.1;;
+gap> Quotient(2*t, t);
+Z(7)^2
+gap> Quotient(t, 2*t);
+Z(7)^4
+gap> Quotient(t, 0*t);
+fail
+gap> Quotient(R, 2*t, t);
+Z(7)^2
+gap> Quotient(R, t, 2*t);
+Z(7)^4
+gap> Quotient(R, t, 0*t);
+fail
+
+#
+# the following case has some issues, as the polynomial
+# division code 
+gap> R:=PolynomialRing(Integers mod 6, 1);; t:=R.1;;
+gap> Quotient(2*t, t);
+ZmodnZObj(2,6)
+gap> #Quotient(t, 2*t); # FIXME: should return fail, but doesn't; bug in polynomial quotient code
+gap> Quotient(t, 0*t);
+fail
+gap> Quotient(R, 2*t, t);
+ZmodnZObj(2,6)
+gap> #Quotient(R, t, 2*t); # FIXME: should return fail, but doesn't; bug in polynomial quotient code
+gap> Quotient(R, t, 0*t);
+fail
+
+#
+gap> STOP_TEST("Quotient.tst", 1);

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -118,7 +118,7 @@ gap>
 gap> 
 gap> f:=function() local i; for i in 1 do return 1; od; return 2; end;;
 gap> f();
-Error, You cannot loop over the integer 1 did you mean the range [1..1] at GAPROOT/lib/integer.gi:1737 called from
+Error, You cannot loop over the integer 1 did you mean the range [1..1] at GAPROOT/lib/integer.gi:1740 called from
 for i in 1 do
     return 1;
 od; at *stdin*:24 called from


### PR DESCRIPTION
This improves the documentation of `Quotient` to make it sensible for non-commutative rings, and rings with zero divisors; it also fixes some methods for `Quotient` which violated the documentation of `Quotient` (before and after my changes to it).

In particular `Quotient(R, x, Zero(R))` should return fail, not run into an error.

Also add some tests for various `Quotient` methods. It turns out that those for
polynomials still are broken, which should be fixed in the future.