### PR TITLE
Irreducible Modules and Permutation Representations

### DIFF
--- a/lib/factgrp.gd
+++ b/lib/factgrp.gd
@@ -374,7 +374,7 @@ DeclareGlobalFunction("CloseNaturalHomomorphismsPool");
 
 #############################################################################
 ##
-#F  PullBackNaturalHomomorphismsPool(<hom>]) . . transfer nathoms of image
+#F  PullBackNaturalHomomorphismsPool(<hom>) . . transfer nathoms of image
 ##
 ##  <ManSection>
 ##  <Func Name="PullBackNaturalHomomorphismsPool" Arg='hom'/>
@@ -386,6 +386,23 @@ DeclareGlobalFunction("CloseNaturalHomomorphismsPool");
 ##  </ManSection>
 ##
 DeclareGlobalFunction("PullBackNaturalHomomorphismsPool");
+
+#############################################################################
+##
+#F  TryQuotientsFromFactorSubgroups(<hom>,<ker>,<bound>) 
+##
+##  <ManSection>
+##  <Func Name="TryQuotientsFromFactorSubgroups" Arg='hom,ker,bound'/>
+##
+##  <Description>
+##  For a homomorphism <A>hom</A>, this command iterates through subgroups
+##  of the image, up to index <A>bound</A>,
+##  trying to find derived subgroups that expose more of the
+##  factor modulo <A>ker</A>.
+##  </Description>
+##  </ManSection>
+##
+DeclareGlobalFunction("TryQuotientsFromFactorSubgroups");
 
 #############################################################################
 ##

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -531,8 +531,9 @@ DeclareOperation("MinimalFaithfulPermutationDegree",[IsGroup and IsFinite]);
 ##  <Description>
 ##  Iterator to
 ##  descend through (representatives of) conjugacy classes of subgroups,
-##  roughly by increasing index. Does not guaranrtee duplicate free, index
-##  might jump back.
+##  by increasing index. If the option <C>skip</C> is set to an integer, the
+##  iterator will jump to subgroups containing $U'$ if their index is at most
+##  skip and they are "nice" (In this case not all subgroups will be found.)
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1421,7 +1421,9 @@ local hom,mats,mode,m,min,i,j,mo,bas,a,l,ugens,gi,r,cy,act,k,it,p;
   k:=Length(module.generators);
   hom:=GroupHomomorphismByImagesNC(G,Group(module.generators),
     GeneratorsOfGroup(G),module.generators);
-  it:=DescSubgroupIterator(G);
+  # we allow do go immediately to normal subgroup of index up to 4.
+  # This reduces search space
+  it:=DescSubgroupIterator(G:skip:=4);
   repeat
     m:=NextIterator(it);
 
@@ -1590,8 +1592,18 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,lay,m,e,fp,old,sim,
       hom:=GroupHomomorphismByImages(r.group,Group(r.module.generators),
         GeneratorsOfGroup(r.group),r.module.generators);
       p:=Image(quot);
+      trysy:=Maximum(1000,IndexNC(p,SylowSubgroup(p,prime)));
+      # allow to enforce test coverage
+      if ValueOption("forcetest")=true then trysy:=2;fi;
+
+      mindeg:=2;
+      if IsPermGroup(p) then
+        mindeg:=Minimum(List(Orbits(p,MovedPoints(p)),Length));
+      fi;
       while Size(p)<Size(fp) do
-        it:=DescSubgroupIterator(p);
+        # we allow do go immediately to normal subgroup of index up to 4.
+        # This reduces search space
+        it:=DescSubgroupIterator(p:skip:=4);
         repeat
           m:=NextIterator(it);
           e:=fail;

--- a/tst/teststandard/opers/AutomorphismGroup.tst
+++ b/tst/teststandard/opers/AutomorphismGroup.tst
@@ -37,4 +37,10 @@ gap> StructureDescription(H);
 "PSL(3,3) : C2"
 
 #
+gap> g:=PerfectGroup(IsPermGroup,30720,1);;
+gap> h:=g^(1,153);;
+gap> IsomorphismGroups(g,h:forcetest)<>fail;
+true
+
+#
 gap> STOP_TEST("AutomorphismGroup.tst",1);

--- a/tst/teststandard/opers/IsomorphismGroups.tst
+++ b/tst/teststandard/opers/IsomorphismGroups.tst
@@ -10,7 +10,7 @@ gap> Length(CharacteristicSubgroups(g));
 5
 gap> Length(CharacteristicSubgroups(h));
 5
-gap> IsomorphismGroups(g,h:forcetest)<>fail;
+gap> IsomorphismGroups(g,h)<>fail;
 true
 
 #

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -114,6 +114,12 @@ gap> Length(DoubleCosets(Image(iso,g),Image(iso,s),Image(iso,s)));
 # some lattice and deductions
 gap> MinimalFaithfulPermutationDegree(PerfectGroup(IsPermGroup,7680,1));
 76
+gap> g:=SymmetricGroup(6);;
+gap> it:=DescSubgroupIterator(g);;
+gap> l:=[];;for i in it do Add(l,i);od;Length(l);
+56
+gap> it:=DescSubgroupIterator(g:skip:=20);;
+gap> l:=[];;for i in it do Add(l,i);od;
 
 #
 gap> STOP_TEST( "permgrp.tst", 1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -58,10 +58,16 @@ gap> Sum(ConjugacyClasses(g),Size);
 1384120320
 
 # Construct modules
-gap> g:=PerfectGroup(IsPermGroup,5376,1);;
-gap> s:=IrreducibleModules(g,GF(2),0);;
+gap> g:=PerfectGroup(IsPermGroup,7500,1);;
+gap> s:=IrreducibleModules(g,GF(2));;
 gap> Collected(List(s[2],x->x.dimension));
-[ [ 1, 1 ], [ 3, 2 ], [ 8, 1 ] ]
+[ [ 1, 1 ], [ 4, 2 ], [ 24, 5 ], [ 40, 1 ], [ 60, 1 ], [ 80, 1 ] ]
+gap> Collected(List(s[2],MTX.IsAbsolutelyIrreducible));
+[ [ true, 2 ], [ false, 9 ] ]
+gap> s:=First(s[2],x->x.dimension=24);;
+gap> p:=PermrepSemidirectModule(g,s).group;;
+gap> Size(p);
+125829120000
 
 # Condition test
 gap> g:=SymmetricGroup(10);;

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -2,7 +2,7 @@
 ##
 ##  Some tests for permutation groups and friends(takes a few seconds to run)
 ##
-#@local g, dc, ac, p, s, dc1, u, part, iso
+#@local g, dc, ac, p, s, dc1, u, part, iso,l,it,i
 gap> START_TEST("permgrp.tst");
 gap> Size(Normalizer(SymmetricGroup(100),PrimitiveGroup(100,1)));
 1209600


### PR DESCRIPTION
Performance improvement (count modules and stop if all are found, split tensor square) for computing irreducible modules.

Better determination of (factor) permutation representations,  in particular for group extensions.

Added more test examples.
