### PR TITLE
changed the definition of `Randomize`

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1046,17 +1046,11 @@ InstallMethod( Vector, "for a plist of finite field elements and an 8bitvector",
     ConvertToVectorRep(r,Q_VEC8BIT(v));
     return r;
   end );
-InstallMethod( Randomize, "for a mutable 8bit vector",
-  [ Is8BitVectorRep and IsMutable ],
-  function( v ) 
-    local f,i;
-    f := GF(Q_VEC8BIT(v));
-    for i in [1..Length(v)] do v[i] := Random(f); od;
-    return v;
-  end );
-InstallMethod( Randomize, "for a mutable 8bit vector and a random source",
-  [ Is8BitVectorRep and IsMutable, IsRandomSource ],
-  function( v, rs )
+
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable 8bit vector",
+    [ IsRandomSource, Is8BitVectorRep and IsMutable ],
+  function( rs, v )
     local l,i;
     l := AsSSortedList(GF(Q_VEC8BIT(v)));
     for i in [1..Length(v)] do v[i] := Random(rs,l); od;
@@ -1116,19 +1110,12 @@ InstallMethod( CopySubMatrix, "for two 8bit matrices, and four lists",
     b{trows}{tcols} := a{frows}{fcols};
   end );
 
-InstallMethod( Randomize, "for a mutable 8bit matrix",
-  [Is8BitMatrixRep and IsMutable],
-  function( m )
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable 8bit matrix",
+  [ IsRandomSource, Is8BitMatrixRep and IsMutable ],
+  function( rs, m )
     local v;
-    for v in m do Randomize(v); od;
-    return m;
-  end );
-
-InstallMethod( Randomize, "for a mutable 8bit matrix, and a random source",
-  [Is8BitMatrixRep and IsMutable, IsRandomSource],
-  function( m, rs )
-    local v;
-    for v in m do Randomize(v,rs); od;
+    for v in m do Randomize( rs, v ); od;
     return m;
   end );
 

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2338,19 +2338,11 @@ InstallMethod( Vector, "for a list of gf2 elements and a gf2 vector",
     ConvertToVectorRep(r,2);
     return r;
   end );
-InstallMethod( Randomize, "for a mutable gf2 vector",
-  [ IsGF2VectorRep and IsMutable ],
-  function( v ) 
-    local i;
-    MultVector(v,0);
-    for i in [1..Length(v)] do 
-        if Random(0,1) = 1 then v[i] := Z(2); fi;
-    od;
-    return v;
-  end );
-InstallMethod( Randomize, "for a mutable gf2 vector and a random source",
-  [ IsGF2VectorRep and IsMutable, IsRandomSource ],
-  function( v, rs ) 
+
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable gf2 vector",
+    [ IsRandomSource, IsGF2VectorRep and IsMutable ],
+  function( rs, v )
     local i;
     MultVector(v,0);
     for i in [1..Length(v)] do 
@@ -2358,6 +2350,7 @@ InstallMethod( Randomize, "for a mutable gf2 vector and a random source",
     od;
     return v;
   end );
+
 InstallMethod( MutableCopyMat, "for a gf2 matrix",
   [ IsGF2MatrixRep ],
   function( m )
@@ -2457,19 +2450,12 @@ end );
 
 
 
-InstallMethod( Randomize, "for a mutable gf2 matrix",
-  [IsGF2MatrixRep and IsMutable],
-  function( m )
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable gf2 matrix",
+    [ IsRandomSource, IsGF2MatrixRep and IsMutable ],
+  function( rs, m )
     local v;
-    for v in m do Randomize(v); od;
-    return m;
-  end );
-
-InstallMethod( Randomize, "for a mutable gf2 matrix, and a random source",
-  [IsGF2MatrixRep and IsMutable, IsRandomSource],
-  function( m, rs )
-    local v;
-    for v in m do Randomize(v,rs); od;
+    for v in m do Randomize( rs, v ); od;
     return m;
   end );
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -538,26 +538,30 @@ InstallMethod( CopySubVector,
     CopySubVector(dst,dcols,src,scols);
 end );
 
-InstallMethod( Randomize,
-  "generic method for a vector",
-  [ IsVectorObj and IsMutable ],
-  function(vec)
-    local basedomain, i;
-    basedomain := BaseDomain( vec );
-    for i in [ 1 .. Length( vec ) ] do
-        vec[ i ] := Random( basedomain );
-    od;
-end );
-
-InstallMethod( Randomize,
-  "generic method for a vector and a random source",
-  [ IsVectorObj and IsMutable, IsRandomSource ],
-  function(vec, rs)
+InstallMethodWithRandomSource( Randomize,
+  "for a random source and a vector object",
+  [ IsRandomSource, IsVectorObj and IsMutable ],
+  function( rs, vec )
     local basedomain, i;
     basedomain := BaseDomain( vec );
     for i in [ 1 .. Length( vec ) ] do
         vec[ i ] := Random( rs, basedomain );
     od;
+    return vec;
+end );
+
+InstallMethodWithRandomSource( Randomize,
+  "for a random source and a matrix object",
+  [ IsRandomSource, IsMatrixObj and IsMutable ],
+  function( rs, mat )
+    local basedomain, i, j;
+    basedomain := BaseDomain( mat );
+    for i in [ 1 .. NrRows( mat ) ] do
+      for j in [ 1 .. NrCols( mat ) ] do
+        mat[i][j]:= Random( rs, basedomain );
+      od;
+    od;
+    return mat;
 end );
 
 ############################################################################
@@ -654,3 +658,14 @@ InstallMethod( IsEmptyMatrix,
   [ IsMatrixObj ],
   mat -> NrRows(mat) = 0 or NrCols(mat) = 0
 );
+
+
+#
+# Compatibility code: old variants of arguments (to become obsolete)
+#
+
+InstallOtherMethod( Randomize,
+    "backwards compatibility: swap arguments",
+    [ IsObject and IsMutable, IsRandomSource ],
+    { obj, rs } -> Randomize( rs, obj ) );
+

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -329,7 +329,7 @@ InstallMethod( CompanionMatrix, "for a polynomial and a matrix",
     ll[n] := l;
     for i in [1..n-1] do
         ll[i] := ZeroMutable(l);
-        ll[i][i+1] := one;
+        ll[i,i+1] := one;
     od;
     return Matrix(ll,n,m);
   end );
@@ -355,7 +355,7 @@ InstallMethod( KroneckerProduct, "for two matrices",
 
     for i in [1..rowsA] do
       for j in [1..colsA] do
-        CopySubMatrix( A[i][j] * B, AxB,
+        CopySubMatrix( A[i,j] * B, AxB,
                 [ 1 .. rowsB ], [ rowsB * (i-1) + 1 .. rowsB * i ],
                 [ 1 .. colsB ], [ (j-1) * colsB + 1 .. j * colsB ] );
       od;
@@ -558,7 +558,7 @@ InstallMethodWithRandomSource( Randomize,
     basedomain := BaseDomain( mat );
     for i in [ 1 .. NrRows( mat ) ] do
       for j in [ 1 .. NrCols( mat ) ] do
-        mat[i][j]:= Random( rs, basedomain );
+        mat[i,j]:= Random( rs, basedomain );
       od;
     od;
     return mat;

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -562,28 +562,38 @@ DeclareGlobalFunction( "MakeVector" );
 # Some things that fit nowhere else:
 ############################################################################
 
+############################################################################
+##
 ##  <#GAPDoc Label="MatObj_Randomize_Vectors">
 ##  <ManSection>
-##    <Oper Arg="V" Name="Randomize" Label="for IsVectorObj"/>
-##    <Oper Arg="V,Rs" Name="Randomize" Label="for IsVectorObj,IsRandomSources"/>
+##    <Heading>Randomize</Heading>
+##    <Oper Arg="[Rs,]v" Name="Randomize" Label="for a vector object"/>
+##    <Oper Arg="[Rs,]m" Name="Randomize" Label="for a matrix object"/>
 ##    <Description>
-##      Replaces every entry in <A>V</A> with a random one from the base
-##      domain. If given, the random source <A>Rs</A> is used to compute the
-##      random elements. Note that in this case, the random function for the
-##      base domain must support the random source argument.
+##      Replaces every entry in the mutable vector object <A>v</A>
+##      or matrix object <A>m</A>, respectively, with
+##      a random one from the base domain of <A>v</A> or <A>m</A>,
+##      respectively, and returns the argument.
+##      <P/>
+##      If given, the random source <A>Rs</A> is used to compute the
+##      random elements.
+##      Note that in this case,
+##      a <Ref Oper="Random" Label="for random source and collection"/>
+##      method must be available that takes a random source as its first
+##      argument and the base domain as its second argument.
 ##    </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-DeclareOperation( "Randomize", [IsVectorObj and IsMutable] );
-DeclareOperation( "Randomize", [IsVectorObj and IsMutable,IsRandomSource] );
-# Changes the mutable argument in place, every entry is replaced
-# by a random element from BaseDomain.
-# The second argument is used to provide "randomness".
-# The vector argument is also returned by the function.
+DeclareOperation( "Randomize", [ IsVectorObj and IsMutable ] );
+DeclareOperation( "Randomize", [ IsRandomSource, IsVectorObj and IsMutable ] );
 
-# TODO: change this to use InstallMethodWithRandomSource; for this, we'll have
-# to change the argument order (a method for the old order, to ensure backwards
-# compatibility, could remain).
+DeclareOperation( "Randomize", [ IsMatrixObj and IsMutable ] );
+DeclareOperation( "Randomize", [ IsRandomSource, IsMatrixObj and IsMutable ] );
+
+# for backwards compatibility with the cvec package
+DeclareOperation( "Randomize", [ IsVectorObj and IsMutable, IsRandomSource ] );
+DeclareOperation( "Randomize", [ IsMatrixObj and IsMutable, IsRandomSource ] );
+
 
 #############################################################################
 ##
@@ -1106,15 +1116,6 @@ DeclareOperation( "ChangedBaseDomain", [IsMatrixObj,IsSemiring] );
 ############################################################################
 # Some things that fit nowhere else:
 ############################################################################
-
-DeclareOperation( "Randomize", [IsMatrixObj and IsMutable] );
-DeclareOperation( "Randomize", [IsMatrixObj and IsMutable,IsRandomSource] );
-# Changes the mutable argument in place, every entry is replaced
-# by a random element from BaseDomain.
-# The second version will come when we have random sources.
-
-# TODO: only keep the first operation and suggest using InstallMethodWithRandomSource
-
 
 DeclareAttribute( "TransposedMatImmutable", IsMatrixObj );
 DeclareOperation( "TransposedMatMutable", [IsMatrixObj] );

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -529,14 +529,16 @@ InstallMethod( IsZero, "for a plist vector", [ IsPlistVectorRep ],
     return IsZero( v![ELSPOS] );
   end );
 
-InstallMethod( Randomize, "for a mutable plist vector",
-  [ IsPlistVectorRep and IsMutable ],
-  function( v )
+InstallMethodWithRandomSource( Randomize,
+  "for a random source and a mutable plist vector",
+  [ IsRandomSource, IsPlistVectorRep and IsMutable ],
+  function( rs, v )
     local bd,i;
     bd := v![BDPOS];
     for i in [1..Length(v![ELSPOS])] do
-        v![ELSPOS][i] := Random(bd);
+        v![ELSPOS][i] := Random( rs, bd );
     od;
+    return v;
   end );
 
 InstallMethod( CopySubVector, "for two plist vectors and two lists",
@@ -1170,13 +1172,15 @@ InstallMethod( RankMat, "for a plist matrix",
   end);
 
 
-InstallMethod( Randomize, "for a mutable plist matrix",
-  [ IsPlistMatrixRep and IsMutable ],
-  function( m )
+InstallMethodWithRandomSource( Randomize,
+  "for a random source and a mutable plist matrix",
+  [ IsRandomSource, IsPlistMatrixRep and IsMutable ],
+  function( rs, m )
     local v;
     for v in m![ROWSPOS] do
-        Randomize(v);
+        Randomize( rs, v );
     od;
+    return m;
   end );
 
 InstallMethod( TransposedMatMutable, "for a plist matrix",

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -52,13 +52,16 @@ DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 ##  <#GAPDoc Label="Random">
 ##  <ManSection>
 ##  <Oper Name="Random" Arg='rs, list' Label="for random source and list"/>
+##  <Oper Name="Random" Arg='rs, coll'
+##   Label="for random source and collection"/>
 ##  <Oper Name="Random" Arg='rs, low, high' 
 ##                      Label="for random source and two integers"/>
 ##
 ##  <Description>
-##  This operation returns a random element from list <A>list</A>, or an integer 
-##  in the range from the given (possibly large) integers <A>low</A> to <A>high</A>,
-##  respectively. 
+##  This operation returns a random element from the list <A>list</A>
+##  or the collection <A>coll</A>,
+##  or an integer in the range from the given (possibly large) integers
+##  <A>low</A> to <A>high</A>, respectively.
 ##  <P/>
 ##  The choice should only depend on the random source <A>rs</A> and have no 
 ##  effect on other random sources.
@@ -245,9 +248,10 @@ DeclareOperation( "RandomSource", [IsOperation, IsObject] );
 ##
 ##  <Description>
 ##  These functions are designed to simplify adding new methods for
-##  <Ref Oper="Random" Label="for a list or collection"/> and
-##  <Ref Oper="PseudoRandom"/> to GAP which can
-##  be called both with, and without, a random source.
+##  <Ref Oper="Random" Label="for a list or collection"/>,
+##  <Ref Oper="PseudoRandom"/>,
+##  and <Ref Oper="Randomize" Label="for a vector object"/> to &GAP;
+##  which can be called both with, and without, a random source.
 ##  <P/>
 ##  They accept the same arguments as <Ref Func="InstallMethod"/> and
 ##  <Ref Func="InstallOtherMethod"/>, with

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1003,17 +1003,11 @@ InstallMethod( Vector, "for a plist of finite field elements and an 8bitvector",
     ConvertToVectorRep(r,Q_VEC8BIT(v));
     return r;
   end );
-InstallMethod( Randomize, "for a mutable 8bit vector",
-  [ Is8BitVectorRep and IsMutable ],
-  function( v ) 
-    local f,i;
-    f := GF(Q_VEC8BIT(v));
-    for i in [1..Length(v)] do v[i] := Random(f); od;
-    return v;
-  end );
-InstallMethod( Randomize, "for a mutable 8bit vector and a random source",
-  [ Is8BitVectorRep and IsMutable, IsRandomSource ],
-  function( v, rs )
+
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable 8bit vector",
+    [ IsRandomSource, Is8BitVectorRep and IsMutable ],
+  function( rs, v )
     local l,i;
     l := AsSSortedList(GF(Q_VEC8BIT(v)));
     for i in [1..Length(v)] do v[i] := Random(rs,l); od;
@@ -1073,19 +1067,12 @@ InstallMethod( CopySubMatrix, "for two 8bit matrices, and four lists",
     b{trows}{tcols} := a{frows}{fcols};
   end );
 
-InstallMethod( Randomize, "for a mutable 8bit matrix",
-  [Is8BitMatrixRep and IsMutable],
-  function( m )
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable 8bit matrix",
+  [ IsRandomSource, Is8BitMatrixRep and IsMutable ],
+  function( rs, m )
     local v;
-    for v in m do Randomize(v); od;
-    return m;
-  end );
-
-InstallMethod( Randomize, "for a mutable 8bit matrix, and a random source",
-  [Is8BitMatrixRep and IsMutable, IsRandomSource],
-  function( m, rs )
-    local v;
-    for v in m do Randomize(v,rs); od;
+    for v in m do Randomize( rs, v ); od;
     return m;
   end );
 

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2161,19 +2161,11 @@ InstallMethod( Vector, "for a list of gf2 elements and a gf2 vector",
     ConvertToVectorRep(r,2);
     return r;
   end );
-InstallMethod( Randomize, "for a mutable gf2 vector",
-  [ IsGF2VectorRep and IsMutable ],
-  function( v ) 
-    local i;
-    MultVector(v,0);
-    for i in [1..Length(v)] do 
-        if Random(0,1) = 1 then v[i] := Z(2); fi;
-    od;
-    return v;
-  end );
-InstallMethod( Randomize, "for a mutable gf2 vector and a random source",
-  [ IsGF2VectorRep and IsMutable, IsRandomSource ],
-  function( v, rs ) 
+
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable gf2 vector",
+    [ IsRandomSource, IsGF2VectorRep and IsMutable ],
+  function( rs, v )
     local i;
     MultVector(v,0);
     for i in [1..Length(v)] do 
@@ -2181,6 +2173,7 @@ InstallMethod( Randomize, "for a mutable gf2 vector and a random source",
     od;
     return v;
   end );
+
 InstallMethod( MutableCopyMat, "for a gf2 matrix",
   [ IsGF2MatrixRep ],
   function( m )
@@ -2222,7 +2215,7 @@ InstallMethod( PositionLastNonZero, "for a row vector obj",
     while i >= 1 and IsZero(l[i]) do i := i - 1; od;
     return i;
   end );
-        
+
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
   [IsGF2MatrixRep, IsList, IsList],
   function( m, rows, cols )
@@ -2280,19 +2273,12 @@ end );
 
 
 
-InstallMethod( Randomize, "for a mutable gf2 matrix",
-  [IsGF2MatrixRep and IsMutable],
-  function( m )
+InstallMethodWithRandomSource( Randomize,
+    "for a random source and a mutable gf2 matrix",
+    [ IsRandomSource, IsGF2MatrixRep and IsMutable ],
+  function( rs, m )
     local v;
-    for v in m do Randomize(v); od;
-    return m;
-  end );
-
-InstallMethod( Randomize, "for a mutable gf2 matrix, and a random source",
-  [IsGF2MatrixRep and IsMutable, IsRandomSource],
-  function( m, rs )
-    local v;
-    for v in m do Randomize(v,rs); od;
+    for v in m do Randomize( rs, v ); od;
     return m;
   end );
 

--- a/tst/testinstall/MatrixObj/Randomize.tst
+++ b/tst/testinstall/MatrixObj/Randomize.tst
@@ -4,19 +4,21 @@ gap> ll := [1,2,3,4,5,6];
 gap> v1 := Vector(IsPlistVectorRep, Rationals, ll);
 <plist vector over Rationals of length 6>
 gap> Randomize( v1 );
+<plist vector over Rationals of length 6>
 gap> Unpack( v1 );
 [ -2/3, 2, 1, -4, 0, 1 ]
 gap> Randomize( v1 );
+<plist vector over Rationals of length 6>
 gap> Unpack( v1 );
 [ -1, -1, 1/2, 0, -2, 1/2 ]
 gap> v2 := Vector(GF(5), ll*One(GF(5)));
 [ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
 gap> Randomize( v2 );
-[ 0*Z(5), Z(5)^2, Z(5)^0, Z(5)^2, 0*Z(5), Z(5)^0 ]
+[ Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^2, Z(5)^3, 0*Z(5) ]
 gap> v2;
-[ 0*Z(5), Z(5)^2, Z(5)^0, Z(5)^2, 0*Z(5), Z(5)^0 ]
+[ Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^2, Z(5)^3, 0*Z(5) ]
 gap> Randomize( v2 );
-[ Z(5), Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
+[ Z(5)^0, 0*Z(5), Z(5)^3, Z(5), Z(5), Z(5) ]
 gap> v2;
-[ Z(5), Z(5)^0, 0*Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
-gap> STOP_TEST( "Randomize.tst", 1);
+[ Z(5)^0, 0*Z(5), Z(5)^3, Z(5), Z(5), Z(5) ]
+gap> STOP_TEST( "Randomize.tst" );


### PR DESCRIPTION
As proposed in `lib/matobj2.gd`:
For a random source `rs`,
document `Randomize( rs, obj )` instead of `Randomize( obj, rs )`,
and then use `InstallMethodWithRandomSource` to install methods.

The release notes should mention this change mainly because `Randomize` is used in a few packages.
Another aspect is that after the change, results of `Randomize` from older GAP sessions may not be reproducible because former calls of the form `Random( C )` are now executed as `Random( GlobalMersenneTwister, C )`.

Details:

- added an `<Oper Name="Random" .../>` declaration for
  random source and collection, to be used in cross-references;
  note that the `DeclareOperation` calls had covered this already.

- added `Randomize` to the documented operations for which
  the function `InstallMethodWithRandomSource` is intended

- used `InstallMethodWithRandomSource` in order to replace
  two method installations by just one (as was proposed in
  `matobj2.gd`) for all installations of `Randomize` methods
  in the GAP library

- make sure that all `Randomize` methods return the changed object

- adjusted outputs of the testfile
  `testinstall/MatrixObj/Randomize.tst`
  (one instance of the changed outputs mentioned above)

Resolves #2018