### PR TITLE
Adds `make html` that does not build the manual as pdf

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -783,6 +783,9 @@ manuals: doc
 doc: gap$(EXEEXT) doc/make_doc
 	doc/make_doc
 
+html: gap$(EXEEXT) doc/make_doc
+	doc/make_doc nopdf
+
 clean-doc:
 	rm -f doc/*/chap*.html doc/*/chap*.txt doc/*/*.css doc/*/*.js
 	rm -f doc/*/chooser.html doc/*/manual*.pdf

--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -5,7 +5,11 @@ set -o pipefail
 
 GAP=@abs_top_builddir@/bin/gap.sh
 GAPARGS="-b -m 1g -x 80 -q -r --quitonbreak"
-
+if [ "$1" == "nopdf" ]; then
+  NOPDF=", \"nopdf\""
+else
+  NOPDF=""
+fi
 echo "--------------------"
 echo "Building GAP manuals"
 echo "--------------------"
@@ -41,7 +45,7 @@ for run in [1,2] do
     if run = 2 then
         # create black&white version of manual (but only on second run)
         SetGapDocLaTeXOptions("nocolor", latexOpts);
-        MakeGAPDocDoc( path, "main.xml", files, book, "../..", "MathJax" );;
+        MakeGAPDocDoc( path, "main.xml", files, book, "../..", "MathJax" $NOPDF );;
 
         # Rename the generated black&white PDF
         f1 := Filename(dir, "manual.pdf");
@@ -58,7 +62,7 @@ for run in [1,2] do
 
     # create manuals with color
     SetGapDocLaTeXOptions("color", latexOpts);
-    MakeGAPDocDoc( path, "main.xml", files, book, "../..", "MathJax" );;
+    MakeGAPDocDoc( path, "main.xml", files, book, "../..", "MathJax" $NOPDF);;
   od;
 od;
 EOF


### PR DESCRIPTION
The new version of GAPDoc provides a `nodpf` option that builds the manual 
without generating a `.pdf`-file. 
This PR allows the user to call `make html` and no `.pdf` files are created.

This PR is a collaboration with @wilfwilson.
Fixes #3609 
**Text for release notes**: 
Adds `make html` that does not build the manual as pdf