### PR TITLE
support class/character names in char. table Display

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -3422,12 +3422,23 @@ DeclareGlobalFunction( "ConvertToLibraryCharacterTableNC" );
 ##    an integer or a list of integers to select a sublist of the
 ##    irreducible characters of <A>tbl</A>,
 ##    or a list of characters of <A>tbl</A>
-##    (in this case the letter <C>"X"</C> is replaced by <C>"Y"</C>),
+##    (in the latter case, the default letter <C>"X"</C> in the character
+##    names is replaced by <C>"Y"</C>),
+##  </Item>
+##  <Mark><C>charnames</C></Mark>
+##  <Item>
+##    a list of strings of length equal to the number of characters
+##    that shall be shown; they are used as labels for the characters,
 ##  </Item>
 ##  <Mark><C>classes</C></Mark>
 ##  <Item>
 ##    an integer or a list of integers to select a sublist of the
 ##    classes of <A>tbl</A>,
+##  </Item>
+##  <Mark><C>classnames</C></Mark>
+##  <Item>
+##    a list of strings of length equal to the number of classes
+##    that shall be shown; they are used as labels for the classes,
 ##  </Item>
 ##  <Mark><C>indicator</C></Mark>
 ##  <Item>
@@ -3447,7 +3458,10 @@ DeclareGlobalFunction( "ConvertToLibraryCharacterTableNC" );
 ##    <K>false</K> to suppress the printing of power maps,
 ##    or the string <C>"ATLAS"</C> to force a printing of class names and
 ##    power maps in a style similar to that used in the
-##    &ATLAS; of Finite Groups&nbsp;<Cite Key="CCN85"/>,
+##    &ATLAS; of Finite Groups&nbsp;<Cite Key="CCN85"/>
+##    (the <C>"ATLAS"</C> variant works only if the function
+##    <Ref Func="CambridgeMaps" BookName="ctbllib"/> is available,
+##    which belongs to the <Package>CTblLib</Package> package),
 ##  </Item>
 ##  <Mark><C>Display</C></Mark>
 ##  <Item>

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -4909,6 +4909,12 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
     if not IsBound( cletter ) then
       cletter:= "X";
     fi;
+    for record in options do
+      if IsBound( record.charnames ) and IsList( record.charnames ) then
+        charnames:= record.charnames;
+        break;
+      fi;
+    od;
     if not IsBound( charnames ) then
       charnames:= List( cnr,
           i -> Concatenation( cletter, ".", String( i ) ) );
@@ -4982,6 +4988,12 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
       nam:= ClassNames( tbl, "ATLAS" );
     else
       nam:= ClassNames( tbl );
+      for record in options do
+        if IsBound( record.classnames ) and IsList( record.classnames ) then
+          nam:= record.classnames;
+          break;
+        fi;
+      od;
     fi;
 
     # prepare indicator

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -44,6 +44,202 @@ CT1
 
 X.1     1
 
+# Display with unusual parameters
+gap> t:= CharacterTable( SymmetricGroup( 3 ) );;  Irr( t );;
+gap> Display( t, rec( centralizers:= false ) );
+CT2
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+X.1     1 -1  1
+X.2     2  . -1
+X.3     1  1  1
+gap> Display( t, rec( centralizers:= "ATLAS" ) );
+CT2
+
+        6  2  3
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+X.1     1 -1  1
+X.2     2  . -1
+X.3     1  1  1
+gap> Display( t, rec( chars:= 1 ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+X.1     1 -1  1
+gap> Display( t, rec( chars:= [ 2, 3 ] ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+X.2     2  . -1
+X.3     1  1  1
+gap> Display( t, rec( chars:= PermChars( t ) ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+Y.1     1  1  1
+Y.2     2  .  2
+Y.3     3  1  .
+Y.4     6  .  .
+gap> Display( t, rec( chars:= PermChars( t ), letter:= "P" ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+P.1     1  1  1
+P.2     2  .  2
+P.3     3  1  .
+P.4     6  .  .
+gap> Display( t, rec( classes:= 1 ) );
+CT2
+
+     2  1
+     3  1
+
+       1a
+    2P 1a
+    3P 1a
+
+X.1     1
+X.2     2
+X.3     1
+gap> Display( t, rec( classes:= [ 2, 3 ] ) );
+CT2
+
+     2  1  .
+     3  .  1
+
+       2a 3a
+    2P 1a 3a
+    3P 2a 1a
+
+X.1    -1  1
+X.2     . -1
+X.3     1  1
+gap> Display( t, rec( indicator:= true ) );
+CT2
+
+        2  1  1  .
+        3  1  .  1
+
+          1a 2a 3a
+       2P 1a 1a 3a
+       3P 1a 2a 1a
+       2
+X.1    +   1 -1  1
+X.2    +   2  . -1
+X.3    +   1  1  1
+gap> Display( t, rec( indicator:= [ 2, 3 ] ) );
+CT2
+
+          2  1  1  .
+          3  1  .  1
+
+            1a 2a 3a
+         2P 1a 1a 3a
+         3P 1a 2a 1a
+       2 3
+X.1    + 0   1 -1  1
+X.2    + 1   2  . -1
+X.3    + 1   1  1  1
+gap> Display( t, rec( powermap:= false ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+
+X.1     1 -1  1
+X.2     2  . -1
+X.3     1  1  1
+gap> Display( t, rec( powermap:= 2 ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+    2P 1a 1a 3a
+
+X.1     1 -1  1
+X.2     2  . -1
+X.3     1  1  1
+gap> Display( t, rec( powermap:= [ 2, 3 ] ) );
+CT2
+
+     2  1  1  .
+     3  1  .  1
+
+       1a 2a 3a
+    2P 1a 1a 3a
+    3P 1a 2a 1a
+
+X.1     1 -1  1
+X.2     2  . -1
+X.3     1  1  1
+gap> # Note that the 'ATLAS' option for power maps has the desired effect
+gap> # only if the function 'CambridgeMaps' is bound during the tests,
+gap> # which depends on the loaded packages; we omit this test.
+gap> # Display( t, rec( powermap:= "ATLAS" ) );
+gap> Display( t,
+>        rec( charnames:= List( CharacterParameters( t ), String ) ) );
+CT2
+
+                    2  1  1  .
+                    3  1  .  1
+
+                      1a 2a 3a
+                   2P 1a 1a 3a
+                   3P 1a 2a 1a
+
+[ 1, [ 1, 1, 1 ] ]     1 -1  1
+[ 1, [ 2, 1 ] ]        2  . -1
+[ 1, [ 3 ] ]           1  1  1
+gap> Display( t,
+>        rec( classnames:= List( ClassParameters( t ), String ) ) );
+CT2
+
+     2                  1                  1                  .
+     3                  1                  .                  1
+
+       [ 1, [ 1, 1, 1 ] ]    [ 1, [ 2, 1 ] ]       [ 1, [ 3 ] ]
+    2P [ 1, [ 1, 1, 1 ] ] [ 1, [ 1, 1, 1 ] ]       [ 1, [ 3 ] ]
+    3P [ 1, [ 1, 1, 1 ] ]    [ 1, [ 2, 1 ] ] [ 1, [ 1, 1, 1 ] ]
+
+X.1                     1                 -1                  1
+X.2                     2                  .                 -1
+X.3                     1                  1                  1
+
 # viewing and printing of character tables with stored groups
 gap> t:= CharacterTable( DihedralGroup( 8 ) );;
 gap> View( t ); Print( "\n" );


### PR DESCRIPTION
(This extension had been suggested in the GAP Forum by David Madore.)

- Support components `charnames` and `classnames`
  in the second argument of `CharacterTableDisplayDefault`,
  in order to prescribe explicit row and column labels
  when displaying character tables with `Display`.

- Added some tests for `CharacterTableDisplayDefault`.
