### PR TITLE
kernel: refactoring related to operations

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -527,7 +527,7 @@ void InitGVarFiltsFromTable(const StructGVarFilt * tab)
         UInt gvar = GVarName(tab[i].name);
         Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, 1, tab[i].argument);
-        AssReadOnlyGVar(gvar, NewFilter(name, 1, args, tab[i].handler));
+        AssReadOnlyGVar(gvar, NewFilter(name, args, tab[i].handler));
     }
 }
 
@@ -544,7 +544,7 @@ void InitGVarAttrsFromTable(const StructGVarAttr * tab)
         UInt gvar = GVarName(tab[i].name);
         Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, 1, tab[i].argument);
-        AssReadOnlyGVar(gvar, NewAttribute(name, 1, args, tab[i].handler));
+        AssReadOnlyGVar(gvar, NewAttribute(name, args, tab[i].handler));
     }
 }
 
@@ -560,7 +560,7 @@ void InitGVarPropsFromTable(const StructGVarProp * tab)
         UInt gvar = GVarName(tab[i].name);
         Obj  name = NameGVar(gvar);
         Obj  args = ValidatedArgList(tab[i].name, 1, tab[i].argument);
-        AssReadOnlyGVar(gvar, NewProperty(name, 1, args, tab[i].handler));
+        AssReadOnlyGVar(gvar, NewProperty(name, args, tab[i].handler));
     }
 }
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -1101,7 +1101,8 @@ Obj NewFilter (
     
     flag1 = ++CountFlags;
 
-    getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoFilter) );
+    GAP_ASSERT(hdlr);
+    getter = NewOperation(name, 1, nams, hdlr);
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(0));
     flags = NEW_FLAGS( flag1 );
@@ -1284,7 +1285,7 @@ static Obj FuncNEW_FILTER(Obj self, Obj name)
     }
 
     /* make the new operation                                              */
-    return NewFilter(name, 0, 0);
+    return NewFilter(name, 0, DoFilter);
 }
 
 
@@ -2689,8 +2690,9 @@ Obj NewAttribute (
     setter = MakeSetter(name, 0, flag2, DoSetAttribute);
     tester = MakeTester(name, 0, flag2);
 
-    getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoAttribute) ); 
-    
+    GAP_ASSERT(hdlr);
+    getter = NewOperation(name, 1, nams, hdlr);
+
     SetupAttribute(getter, setter, tester, flag2);
 
     return getter;    
@@ -2719,7 +2721,8 @@ static void ConvertOperationIntoAttribute(Obj oper, ObjFunc hdlr)
     tester = MakeTester(name, 0, flag2);
 
     /* Change the handlers */
-    SET_HDLR_FUNC(oper, 1, hdlr ? hdlr : DoAttribute);
+    GAP_ASSERT(hdlr);
+    SET_HDLR_FUNC(oper, 1, hdlr);
 
     SetupAttribute( oper, setter, tester, flag2);
 }
@@ -2921,7 +2924,8 @@ Obj NewProperty (
     setter = MakeSetter(name, flag1, flag2, DoSetProperty);
     tester = MakeTester(name, flag1, flag2);
 
-    getter = NewOperation( name, 1L, nams, (hdlr ? hdlr : DoProperty) );
+    GAP_ASSERT(hdlr);
+    getter = NewOperation(name, 1, nams, hdlr);
 
     SET_FLAG1_FILT(getter, INTOBJ_INT(flag1));
     SET_FLAG2_FILT(getter, INTOBJ_INT(flag2));
@@ -3142,8 +3146,8 @@ static Obj FuncOPER_TO_ATTRIBUTE(Obj self, Obj oper)
     }
 
     /* make the new operation                                              */
-  ConvertOperationIntoAttribute( oper, (ObjFunc) 0L );
-    return (Obj) 0L;
+    ConvertOperationIntoAttribute(oper, DoAttribute);
+    return 0;
 }
 
 /****************************************************************************

--- a/src/opers.c
+++ b/src/opers.c
@@ -1027,7 +1027,7 @@ static Obj TesterAndFilter(Obj getter)
 
 /****************************************************************************
 **
-*F  NewFilter( <name>, <narg>, <nams>, <hdlr> )  . . . . .  make a new filter
+*F  NewFilter( <name>, <nams>, <hdlr> ) . . . . . . . . . . make a new filter
 */
 static Obj DoSetFilter(Obj self, Obj obj, Obj val)
 {
@@ -1091,7 +1091,6 @@ Obj DoFilter (
 
 Obj NewFilter (
     Obj                 name,
-    Int                 narg,
     Obj                 nams,
     ObjFunc             hdlr )
 {
@@ -1285,7 +1284,7 @@ static Obj FuncNEW_FILTER(Obj self, Obj name)
     }
 
     /* make the new operation                                              */
-    return NewFilter( name, 1L, (Obj)0, (ObjFunc)0 );
+    return NewFilter(name, 0, 0);
 }
 
 
@@ -2581,7 +2580,7 @@ static Obj DoVerboseMutableAttribute(Obj self, Obj obj)
 
 /****************************************************************************
 **
-*F  NewAttribute( <name>, <narg>, <nams>, <hdlr> )
+*F  NewAttribute( <name>, <nams>, <hdlr> )
 **
 ** MakeSetter, MakeTester and SetupAttribute are support functions
 */
@@ -2677,7 +2676,6 @@ static void SetupAttribute(Obj attr, Obj setter, Obj tester, Int flag2)
 
 Obj NewAttribute (
     Obj                 name,
-    Int                 narg,
     Obj                 nams,
     ObjFunc             hdlr )
 {
@@ -2903,11 +2901,10 @@ static Obj DoVerboseProperty(Obj self, Obj obj)
 
 /****************************************************************************
 **
-*F  NewProperty( <name>, <narg>, <nams>, <hdlr> )
+*F  NewProperty( <name>, <nams>, <hdlr> )
 */
 Obj NewProperty (
     Obj                 name,
-    Int                 narg,
     Obj                 nams,
     ObjFunc             hdlr )
 {
@@ -3131,7 +3128,7 @@ static Obj FuncNEW_ATTRIBUTE(Obj self, Obj name)
     }
 
     /* make the new operation                                              */
-    return NewAttribute( name, -1L, (Obj)0, DoAttribute );
+    return NewAttribute(name, 0, DoAttribute);
 }
 /****************************************************************************
 **
@@ -3178,7 +3175,7 @@ static Obj FuncNEW_MUTABLE_ATTRIBUTE(Obj self, Obj name)
     }
 
     /* make the new operation                                              */
-    return NewAttribute( name, -1L, (Obj)0, DoMutableAttribute );
+    return NewAttribute(name, 0, DoMutableAttribute);
 }
 
 
@@ -3194,7 +3191,7 @@ static Obj FuncNEW_PROPERTY(Obj self, Obj name)
     }
 
     /* make the new operation                                              */
-    return NewProperty( name, -1L, (Obj)0, DoProperty );
+    return NewProperty(name, 0, DoProperty);
 }
 
 

--- a/src/opers.c
+++ b/src/opers.c
@@ -1279,12 +1279,7 @@ static Obj NewReturnTrueFilter(void)
 */
 static Obj FuncNEW_FILTER(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit("usage: NewFilter( <name> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
+    RequireStringRep("NewFilter", name);
     return NewFilter(name, 0, DoFilter);
 }
 
@@ -3090,13 +3085,8 @@ void LoadOperationExtras (
 */
 static Obj FuncNEW_OPERATION(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit("usage: NewOperation( <name> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
-    return NewOperation( name, -1L, (Obj)0, DoOperationXArgs );
+    RequireStringRep("NewOperation", name);
+    return NewOperation(name, -1, 0, DoOperationXArgs);
 }
 
 
@@ -3106,12 +3096,7 @@ static Obj FuncNEW_OPERATION(Obj self, Obj name)
 */
 static Obj FuncNEW_CONSTRUCTOR(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit("usage: NewConstructor( <name> )",0L,0L);
-    }
-
-    /* make the new constructor                                            */
+    RequireStringRep("NewConstructor", name);
     return NewConstructor( name );
 }
 
@@ -3126,12 +3111,7 @@ static Obj FuncIS_CONSTRUCTOR(Obj self, Obj x)
 */
 static Obj FuncNEW_ATTRIBUTE(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit("usage: NewAttribute( <name> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
+    RequireStringRep("NewAttribute", name);
     return NewAttribute(name, 0, DoAttribute);
 }
 /****************************************************************************
@@ -3140,12 +3120,7 @@ static Obj FuncNEW_ATTRIBUTE(Obj self, Obj name)
 */
 static Obj FuncOPER_TO_ATTRIBUTE(Obj self, Obj oper)
 {
-    /* check the argument                                                  */
-  if ( ! IS_OPERATION(oper) ) {
-        ErrorQuit("usage: OPER_TO_ATTRIBUTE( <oper> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
+    RequireOperation(oper);
     ConvertOperationIntoAttribute(oper, DoAttribute);
     return 0;
 }
@@ -3156,14 +3131,9 @@ static Obj FuncOPER_TO_ATTRIBUTE(Obj self, Obj oper)
 */
 static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE(Obj self, Obj oper)
 {
-    /* check the argument                                                  */
-  if ( ! IS_OPERATION(oper) ) {
-        ErrorQuit("usage: OPER_TO_MUTABLE_ATTRIBUTE( <oper> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
-  ConvertOperationIntoAttribute( oper, DoMutableAttribute );
-  return (Obj) 0L;
+    RequireOperation(oper);
+    ConvertOperationIntoAttribute(oper, DoMutableAttribute);
+    return 0;
 }
 
 
@@ -3173,12 +3143,7 @@ static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE(Obj self, Obj oper)
 */
 static Obj FuncNEW_MUTABLE_ATTRIBUTE(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit("usage: NewMutableAttribute( <name> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
+    RequireStringRep("NewMutableAttribute", name);
     return NewAttribute(name, 0, DoMutableAttribute);
 }
 
@@ -3189,12 +3154,7 @@ static Obj FuncNEW_MUTABLE_ATTRIBUTE(Obj self, Obj name)
 */
 static Obj FuncNEW_PROPERTY(Obj self, Obj name)
 {
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit("usage: NewProperty( <name> )",0L,0L);
-    }
-
-    /* make the new operation                                              */
+    RequireStringRep("NewProperty", name);
     return NewProperty(name, 0, DoProperty);
 }
 
@@ -3208,12 +3168,8 @@ static Obj FuncNEW_GLOBAL_FUNCTION(Obj self, Obj name)
     Obj                 args;           
     Obj                 list;
 
-    /* check the argument                                                  */
-    if ( ! IsStringConv(name) ) {
-        ErrorQuit( "usage: NewGlobalFunction( <name> )", 0L, 0L );
-    }
+    RequireStringRep("NewGlobalFunction", name);
 
-    /* make the new operation                                              */
     args = MakeImmString("args");
     list = NEW_PLIST( T_PLIST, 1 );
     SET_LEN_PLIST( list, 1 );

--- a/src/opers.h
+++ b/src/opers.h
@@ -492,11 +492,11 @@ extern Obj RESET_FILTER_OBJ;
 
 /****************************************************************************
 **
-*F  NewFilter( <name>, <narg>, <nams>, <hdlr> )  . . . . .  make a new filter
+*F  NewFilter( <name>, <nams>, <hdlr> ) . . . . . . . . . . make a new filter
 */
 Obj DoFilter(Obj self, Obj obj);
 
-Obj NewFilter(Obj name, Int narg, Obj nams, ObjFunc hdlr);
+Obj NewFilter(Obj name, Obj nams, ObjFunc hdlr);
 
 Obj DoTestAttribute(Obj self, Obj obj);
 
@@ -570,7 +570,7 @@ Obj NewOperation(Obj name, Int narg, Obj nams, ObjFunc hdlr);
 */
 Obj DoAttribute(Obj self, Obj obj);
 
-Obj NewAttribute(Obj name, Int narg, Obj nams, ObjFunc hdlr);
+Obj NewAttribute(Obj name, Obj nams, ObjFunc hdlr);
 
 /****************************************************************************
 **
@@ -578,7 +578,7 @@ Obj NewAttribute(Obj name, Int narg, Obj nams, ObjFunc hdlr);
 */
 Obj DoProperty(Obj self, Obj obj);
 
-Obj NewProperty(Obj name, Int narg, Obj nams, ObjFunc hdlr);
+Obj NewProperty(Obj name, Obj nams, ObjFunc hdlr);
 
 /****************************************************************************
 **

--- a/src/opers.h
+++ b/src/opers.h
@@ -492,13 +492,16 @@ extern Obj RESET_FILTER_OBJ;
 
 /****************************************************************************
 **
-*F  NewFilter( <name>, <nams>, <hdlr> ) . . . . . . . . . . make a new filter
+*F  DoFilter( <self>, <obj> ) . . . . . . . . . . default handler for filters
 */
 Obj DoFilter(Obj self, Obj obj);
 
-Obj NewFilter(Obj name, Obj nams, ObjFunc hdlr);
 
-Obj DoTestAttribute(Obj self, Obj obj);
+/****************************************************************************
+**
+*F  NewFilter( <name>, <nams>, <hdlr> ) . . . . . . . . . . make a new filter
+*/
+Obj NewFilter(Obj name, Obj nams, ObjFunc hdlr);
 
 
 /****************************************************************************
@@ -523,7 +526,7 @@ extern Obj ReturnTrueFilter;
 
 /****************************************************************************
 **
-*F  NewOperation( <name> )  . . . . . . . . . . . . . .  make a new operation
+**  Default handlers for operations
 */
 Obj DoOperation0Args(Obj oper);
 
@@ -543,6 +546,11 @@ Obj DoOperation6Args(
 
 Obj DoOperationXArgs(Obj self, Obj args);
 
+
+/****************************************************************************
+**
+**  Default handlers for verbose operations
+*/
 Obj DoVerboseOperation0Args(Obj oper);
 
 Obj DoVerboseOperation1Args(Obj oper, Obj arg1);
@@ -561,24 +569,48 @@ Obj DoVerboseOperation6Args(
 
 Obj DoVerboseOperationXArgs(Obj self, Obj args);
 
+
+/****************************************************************************
+**
+*F  NewOperation( <name> ) . . . . . . . . . . . . . . . make a new operation
+*/
 Obj NewOperation(Obj name, Int narg, Obj nams, ObjFunc hdlr);
 
 
 /****************************************************************************
 **
-*F  NewAttribute( <name> )  . . . . . . . . . . . . . .  make a new attribute
+*F  DoAttribute( <self>, <obj> ) . . . . . . . default handler for attributes
 */
 Obj DoAttribute(Obj self, Obj obj);
 
+
+/****************************************************************************
+**
+*F  DoTestAttribute( <self>, <obj> ) .  default handler for attribute testers
+*/
+Obj DoTestAttribute(Obj self, Obj obj);
+
+
+/****************************************************************************
+**
+*F  NewAttribute( <name> ) . . . . . . . . . . . . . . . make a new attribute
+*/
 Obj NewAttribute(Obj name, Obj nams, ObjFunc hdlr);
+
+
+/****************************************************************************
+**
+*F  DoProperty( <self>, <obj> ) . . . . . . .  default handler for properties
+*/
+Obj DoProperty(Obj self, Obj obj);
+
 
 /****************************************************************************
 **
 *F  NewProperty( <name> ) . . . . . . . . . . . . . . . . make a new property
 */
-Obj DoProperty(Obj self, Obj obj);
-
 Obj NewProperty(Obj name, Obj nams, ObjFunc hdlr);
+
 
 /****************************************************************************
 **
@@ -597,6 +629,7 @@ void InstallMethodArgs(Obj oper, Obj func);
 */
 void ChangeDoOperations(Obj oper, Int verb);
 
+
 /****************************************************************************
 **
 *F  SaveOperationExtras( <oper> ) . . .  additional savng for functions which
@@ -606,8 +639,8 @@ void ChangeDoOperations(Obj oper, Int verb);
 **  a simple function, and so must be an operation
 **
 */
-
 void SaveOperationExtras(Obj oper);
+
 
 /****************************************************************************
 **
@@ -618,7 +651,6 @@ void SaveOperationExtras(Obj oper);
 **  a simple function, and so must be an operation
 **
 */
-
 void LoadOperationExtras(Obj oper);
 
 

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -128,7 +128,7 @@ Error, property is already set the other way
 
 #
 gap> NEW_FILTER(fail);
-Error, usage: NewFilter( <name> )
+Error, NewFilter: <name> must be a string (not the value 'fail')
 
 #
 gap> FLAG1_FILTER(fail);
@@ -180,23 +180,24 @@ Error, Constructor: the first argument must be a filter (not the integer 1)
 
 #
 gap> NEW_OPERATION(fail);
-Error, usage: NewOperation( <name> )
+Error, NewOperation: <name> must be a string (not the value 'fail')
 gap> NEW_CONSTRUCTOR(fail);
-Error, usage: NewConstructor( <name> )
+Error, NewConstructor: <name> must be a string (not the value 'fail')
 gap> NEW_ATTRIBUTE(fail);
-Error, usage: NewAttribute( <name> )
+Error, NewAttribute: <name> must be a string (not the value 'fail')
 gap> OPER_TO_ATTRIBUTE(fail);
-Error, usage: OPER_TO_ATTRIBUTE( <oper> )
+Error, OPER_TO_ATTRIBUTE: <oper> must be an operation (not the value 'fail')
 gap> OPER_TO_MUTABLE_ATTRIBUTE(fail);
-Error, usage: OPER_TO_MUTABLE_ATTRIBUTE( <oper> )
+Error, OPER_TO_MUTABLE_ATTRIBUTE: <oper> must be an operation (not the value '\
+fail')
 gap> NEW_MUTABLE_ATTRIBUTE(fail);
-Error, usage: NewMutableAttribute( <name> )
+Error, NewMutableAttribute: <name> must be a string (not the value 'fail')
 gap> NEW_PROPERTY(fail);
-Error, usage: NewProperty( <name> )
+Error, NewProperty: <name> must be a string (not the value 'fail')
 
 #
 gap> NEW_GLOBAL_FUNCTION(fail);
-Error, usage: NewGlobalFunction( <name> )
+Error, NewGlobalFunction: <name> must be a string (not the value 'fail')
 gap> INSTALL_GLOBAL_FUNCTION(fail, fail);
 Error, INSTALL_GLOBAL_FUNCTION: <oper> must be a function (not the value 'fail\
 ')


### PR DESCRIPTION
While working on another experimental PR (which adds "dual properties": pairs of properties that share their testers; think: `IsTrivial` and `IsNonTrivial`; or `IsFinite` and `IsInfinite`), I came up with a bunch of minor code refactoring which I think could be merged right away. (That other PR is not yet ready, and I don't know when it'll be, but it'd be nice to let these other change not bitrot).

# Description

## Text for release notes 

If this pull request should be mentioned in the release notes, 
please provide a short description matching the style of the GAP
[Changes manual](https://www.gap-system.org/Manuals/doc/changes/chap0.html).

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [x] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base master)

- [x] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [x] adequate pull request title
- [ ] well formulated text for release notes
- [x] relevant documentation updates
- [x] sensible comments in the code

