### PR TITLE
ENHANCE: Faster MaximalAbelianQuotient for subgroups of fp groups

### DIFF
--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1090,11 +1090,11 @@ local m,s,g,i,j,rel,gen,img,fin,hom,gens;
         Add(rel,g.(i)^s.normal[i][i]);
       od;
       Append(img,ListWithIdenticalEntries(Length(gen)-s.rank,0));
-      SetAbelianInvariants(f,img);
       g:=g/rel;
       fin:=false;
     else  
-      SetAbelianInvariants(f,DiagonalOfMat(s.normal));
+      # Not `AbelianInvariantsOfList' as the structure of the group is as
+      # given by the normal form
       g:=AbelianGroup(DiagonalOfMat(s.normal));
       fin:=true;
     fi;
@@ -1207,6 +1207,8 @@ local aug,r,sec,t,expwrd,rels,ab,s,m,img,gen,i,j,t1,t2,tn;
     # TODO: Reproduce creation of infinite abelian group
     TryNextMethod();
   else
+      # Not `AbelianInvariantsOfList' as the structure of the group is as
+      # given by the normal form
     ab:=AbelianGroup(DiagonalOfMat(s.normal));
   fi;
   gen:=GeneratorsOfGroup(ab);

--- a/lib/matint.gd
+++ b/lib/matint.gd
@@ -559,3 +559,24 @@ DeclareGlobalFunction("DeterminantIntMat");
 ##  </ManSection>
 ##
 DeclareGlobalFunction("SNFofREF");
+
+#############################################################################
+##
+#O  ReducedRelationMat(<mat>)
+##
+##  <#GAPDoc Label="ReducedRelationMat">
+##  <ManSection>
+##  <Func Name="ReducedRelationMat" Arg='mat'/>
+##
+##  <Description>
+##  Let <A>mat</A> be a matrix that has been obtained as abelianized
+##  relations. Such matrices tend to have a particular form with some short
+##  vectors. This function runs a (quick) heuristic row reduction, 
+##  resulting in a matrix with the same Z-row space but fewer/shorter vectors,
+##  thus speeding up a subsequent SNF. It does not do a full HNF but should be
+##  much quicker.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("ReducedRelationMat");

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1598,10 +1598,11 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,lay,m,e,fp,old,sim,
           if hom=false or Size(m)=1 or
             false<>MatricesStabilizerOneDim(r.module.field,
               List(GeneratorsOfGroup(m),
-              x->TransposedMat(ImagesRepresentative(hom,x)))) then
-            Info(InfoExtReps,3,"Attempt index ",Index(p,m));
-            e:=LargerQuotientBySubgroupAbelianization(quot,m:cheap);
-          else Info(InfoExtReps,3,"Don't index ",Index(p,m));
+              x->TransposedMat(ImagesRepresentative(hom,x))^-1)) then
+            Info(InfoExtReps,2,"Attempt index ",Index(p,m));
+            e:=LargerQuotientBySubgroupAbelianization(quot,m);
+
+          else Info(InfoExtReps,4,"Don't index ",Index(p,m));
           fi;
         until e<>fail;
         i:=p;

--- a/tst/testinstall/grpfp.tst
+++ b/tst/testinstall/grpfp.tst
@@ -18,6 +18,8 @@ gap> Print( Collected( List( LowIndexSubgroupsFpGroup( c2, 11 ),
 # Prescribe the index and a subgroup.
 gap> e:= GQuotients( c2, PSL(2,11) );;
 gap> e:= e[1];;
+gap> Collected(AbelianInvariants(Kernel(e)));
+[ [ 0, 52 ], [ 2, 1 ], [ 5, 1 ] ]
 gap> iter:= LowIndexSubgroupsFpGroupIterator( c2, Kernel( e ), 11 );;
 gap> l:= [];;
 gap> while not IsDoneIterator( iter ) do


### PR DESCRIPTION
# Description

Use abelianized rewriting rather than go though IsomorphismFpGroup.
Also added heuristic relator matrix reduction (not full HNF)
to use before SNF to speed up.

Also use in case that Abelian Rrs (in the kernel) fails.

This also includes a cleanup for #3634 
## Text for release notes 

The performance of AbelianInvariants and MaximalAbelianQuotient for subgroups of fp groups has been improved.