### PR TITLE
re-added a method to compute `IsDiagonalMat` for `[]`

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -181,6 +181,24 @@ InstallTrueMethod( IsDiagonalMatrix, IsMatrixObj and IsEmptyMatrix );
 
 #############################################################################
 ##
+##  Note that an empty list is not a matrix,
+##  but 'IsDiagonalMat(rix)' used to return 'true' for it.
+##
+##  Note also that there was no such hack for other operations such as
+##  'IsUpperTriangularMat(rix)' or 'IsLowerTriangularMat(rix)'.
+##
+##  And note that installing an implication from 'IsList and IsEmpty' to
+##  'IsDiagonalMatrix' does not work because the type of an empty plain list
+##  cannot store the information.
+##  Furthermore, we cannot simply install 'ReturnTrue' as a method because
+##  then the method installation would complain that one should just install
+##  an implication.
+##
+InstallOtherMethod( IsDiagonalMatrix, [ IsList and IsEmpty ], x -> true );
+
+
+#############################################################################
+##
 #M  IsUpperTriangularMatrix(<mat>)
 ##
 InstallMethod( IsUpperTriangularMatrix,


### PR DESCRIPTION
I had replaced the method in question by an implication because GAP had told me that would be appropriate. However, this is not true in this situation because plain lists do not benefit from implications.
Thus I have now re-added the old method.

(This is intended to fix #3640.)