### PR TITLE
Point to package archives for stable-4.11 branch

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1121,7 +1121,7 @@ testkernel: ${KERNELTESTS}
 ########################################################################
 
 # change PKG_BRANCH to stable-X.Y in the stable branch
-PKG_BRANCH = master
+PKG_BRANCH = stable-4.11
 PKG_BOOTSTRAP_URL = https://www.gap-system.org/pub/gap/gap4pkgs/
 PKG_MINIMAL = packages-required-$(PKG_BRANCH).tar.gz
 PKG_FULL = packages-$(PKG_BRANCH).tar.gz


### PR DESCRIPTION
This should only be switched away from draft mode, and later merged, *after* those archives actually exist (and then probably before that, we'll want to restart the Travis jobs for this PR)