### PR TITLE
FIX: Bug in MinimalFaithfulPermutationDegree

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -329,36 +329,44 @@ local   F,      # free group
     mov:=MovedPoints(G);
     deg:=Length(mov);
 
-    # create the finitely presented group with <G>.degree-1 generators
-    F := FreeGroup( 2, str);
-    gens:=GeneratorsOfGroup(F);
+    #special case for degree 3, cyclic
+    if deg=3 then
+      F := FreeGroup( 1, str);
+      imgs:=[(mov[1],mov[2],mov[3])];
+      relators:=[F.1^3];
 
-    # add the relations according to the presentation by Coxeter
-    # (see Coxeter/Moser)
-    r:=F.1;
-    s:=F.2;
-    if IsOddInt(deg) then
-      m:=(deg-1)/2;
-      relators:=[r^deg/s^deg,r^deg/(r*s)^m];
-      for j in [2..m] do
-        Add(relators,(r^-j*s^j)^2);
-      od;
-      #(1,2,3,..deg) and (1,3,2,4,5,..deg)
-      p:=MappingPermListList(mov,Concatenation(mov{[2..deg]},[mov[1]]));
-      imgs:=[p,p^(mov[2],mov[3])];
     else
-      m:=deg/2;
-      relators:=[r^(deg-1)/s^(deg-1),r^(deg-1)/(r*s)^m];
-      for j in [1..m-1] do
-        Add(relators,(r^-j*s^-1*r*s^j)^2);
-      od;
-      # (1,2,3,4..,deg-2,deg),(1,2,3,4,deg-3,deg-1,deg);
-      d:=Concatenation(mov{[1..deg-2]},[mov[deg]]);
-      p:=MappingPermListList(d,Concatenation(d{[2..deg-1]},[d[1]]));
-      imgs:=[p];
-      d:=Concatenation(mov{[1..deg-3]},mov{[deg-1,deg]});
-      p:=MappingPermListList(d,Concatenation(d{[2..deg-1]},[d[1]]));
-      Add(imgs,p);
+      # create the finitely presented group with <G>.degree-1 generators
+      F := FreeGroup( 2, str);
+      gens:=GeneratorsOfGroup(F);
+
+      # add the relations according to the presentation by Coxeter
+      # (see Coxeter/Moser)
+      r:=F.1;
+      s:=F.2;
+      if IsOddInt(deg) then
+        m:=(deg-1)/2;
+        relators:=[r^deg/s^deg,r^deg/(r*s)^m];
+        for j in [2..m] do
+          Add(relators,(r^-j*s^j)^2);
+        od;
+        #(1,2,3,..deg) and (1,3,2,4,5,..deg)
+        p:=MappingPermListList(mov,Concatenation(mov{[2..deg]},[mov[1]]));
+        imgs:=[p,p^(mov[2],mov[3])];
+      else
+        m:=deg/2;
+        relators:=[r^(deg-1)/s^(deg-1),r^(deg-1)/(r*s)^m];
+        for j in [1..m-1] do
+          Add(relators,(r^-j*s^-1*r*s^j)^2);
+        od;
+        # (1,2,3,4..,deg-2,deg),(1,2,3,4,deg-3,deg-1,deg);
+        d:=Concatenation(mov{[1..deg-2]},[mov[deg]]);
+        p:=MappingPermListList(d,Concatenation(d{[2..deg-1]},[d[1]]));
+        imgs:=[p];
+        d:=Concatenation(mov{[1..deg-3]},mov{[deg-1,deg]});
+        p:=MappingPermListList(d,Concatenation(d{[2..deg-1]},[d[1]]));
+        Add(imgs,p);
+      fi;
     fi;
 
     F:=F/relators;

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3296,12 +3296,7 @@ local c,n,deg,ind,core,i,j,sum;
   for i in [2..Length(c)-1] do # exclude trivial subgroup and whole group
     ind:=IndexNC(G,c[i]);
 
-    if ind<deg[Length(n)][1] then # otherwise degree too big for new optimal
-      core:=First([2..Length(n)],x->IsSubset(c[i],n[x])); # position of core
-      if ind<deg[core][1] then # new smaller degree from subgroups
-        deg[core]:=[ind,[i]];
-      fi;
-    elif IsNormal(G,c[i]) then # subgroup normal, must be in other case
+    if IsNormal(G,c[i]) then # subgroup normal, must be in other case
       core:=Position(n,c[i]);
       for j in [2..core-1] do # Intersect with all prior normals
         sum:=deg[core][1]+deg[j][1];
@@ -3312,6 +3307,11 @@ local c,n,deg,ind,core,i,j,sum;
           fi;
         fi;
       od;
+    elif ind<deg[Length(n)][1] then # otherwise degree too big for new optimal
+      core:=First([2..Length(n)],x->IsSubset(c[i],n[x])); # position of core
+      if ind<deg[core][1] then # new smaller degree from subgroups
+        deg[core]:=[ind,[i]];
+      fi;
     fi;
 
   od;

--- a/tst/testbugfix/2019-08-31-MinialFaithfulPermutationDegree.tst
+++ b/tst/testbugfix/2019-08-31-MinialFaithfulPermutationDegree.tst
@@ -1,0 +1,6 @@
+# Fix a bug in `MinimalFaithfulPermutationDegree`, #3636
+gap> D:=DirectProduct(AlternatingGroup(5),SmallGroup(46,1));;
+gap> D:=Image(IsomorphismPermGroup(D));;
+gap> D:=Image(SmallerDegreePermutationRepresentation(D));;
+gap> MinimalFaithfulPermutationDegree(D);
+28


### PR DESCRIPTION
This fixes #3636 and also adds a cyclic presentation for A3 which had been requested (fixes #3645).

Release notes: A bug in `MinimalFaithfulPermutationDegree`, that reported a too large degree for certain groups representable as subdirect product, has been fixed.
