### PR TITLE
IsomorphismFpGroup should return a rank 1 fp group for C3

### DIFF
--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -329,6 +329,9 @@ local   F,      # free group
     mov:=MovedPoints(G);
     deg:=Length(mov);
 
+    # special case for degree 3, cyclic
+    if deg = 3 then TryNextMethod(); fi;
+
     # create the finitely presented group with <G>.degree-1 generators
     F := FreeGroup( 2, str);
     gens:=GeneratorsOfGroup(F);

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -86,6 +86,10 @@ gap> IsSymmetricGroup(h);
 true
 gap> IsomorphismFpGroup(h);;
 gap> IsomorphismFpGroup(DerivedSubgroup(h));;
+gap> IsomorphismFpGroup(Group((1,2,3)));
+[ (1,2,3) ] -> [ F1 ]
+gap> IsomorphismFpGroup(Group((4,7,3)));
+[ (3,4,7) ] -> [ F1 ]
 gap> sym:=SymmetricGroup(13);;
 gap> a:=Stabilizer(sym,[[1,2,3],[4,5,6,7]],OnTuplesSets);;Index(sym,a);
 60060


### PR DESCRIPTION
... at least to match the behaviour in GAP <= 4.10. Some package tests rely on this.

Fixes #3645.