### PR TITLE
Add implication IsRowModule => IsFreeLeftModule

### DIFF
--- a/lib/module.gd
+++ b/lib/module.gd
@@ -662,6 +662,7 @@ DeclareGlobalFunction( "SubmoduleNC" );
 ##  <#/GAPDoc>
 ##
 DeclareProperty( "IsRowModule", IsFreeLeftModule );
+InstallTrueMethod( IsFreeLeftModule, IsRowModule );
 
 InstallTrueMethod( IsRowModule, IsFullRowModule );
 


### PR DESCRIPTION
This fixes some ranking issues in package resclasses when GAP is
started with the -N option. I.e., this is related to issue #2818.