### PR TITLE
buildsys: use the C++ compiler for linking

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ environment:
       CYG_ROOT: C:\cygwin64
       PACKAGES: "-P libgmp-devel,zlib-devel,python27,python27-pip"
       CFLAGS: "--coverage"
+      CXXFLAGS: "--coverage"
       LDFLAGS: "--coverage"
 # FIXME: HPC-GAP build on AppVeyor disabled for now, as it crashes
 #    - CYG_ARCH: x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,7 @@ matrix:
 
     # test Julia integration
     - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
+      dist: bionic # need GCC 6 to avoid linker error
 
 script:
   - set -e

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -358,7 +358,7 @@ obj/%.lo: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
 # Linker rules for gap executable
 ########################################################################
 
-LINK=$(LIBTOOL) --mode=link $(CC) -export-dynamic
+LINK=$(LIBTOOL) --mode=link $(CXX) -export-dynamic
 
 libgap.la: $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 	$(QUIET_LINK)$(LINK) -no-undefined -rpath $(libdir) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS) -o $@
@@ -391,8 +391,8 @@ GAP_LDFLAGS += -Wl,--allow-multiple-definition
 all: bin/$(GAPARCH)/gap.dll
 bin/$(GAPARCH)/gap.dll: symlinks libgap.la
 	cp .libs/cyggap-0.dll $@  # FIXME: HACK to support kernel extensions
-gap$(EXEEXT): libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(srcdir)/src/gapw95.c $(GAP_LIBS) libgap.la -o $@
+gap$(EXEEXT): obj/src/gapw95.lo libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) obj/src/gapw95.lo $(GAP_LIBS) libgap.la -o $@
 	@( if which peflags > /dev/null ; then peflags --cygwin-heap=2048 gap$(EXEEXT) ; fi )
 
 else
@@ -694,6 +694,9 @@ endif # BUILD_BOEHM_GC
 # ensure subprojects are built and "installed" before compiling and linking GAP
 gap$(EXEEXT): $(EXTERN_FILES)
 $(OBJS): $(EXTERN_FILES)
+ifeq ($(SYS_IS_CYGWIN32),yes)
+obj/src/gapw95.lo: $(EXTERN_FILES)
+endif
 ifeq ($(HPCGAP),yes)
 $(SOURCES): $(EXTERN_FILES)
 endif


### PR DESCRIPTION
This ensures any required C++ runtime dependencies are added. While this
doesn't seem to matter for current versions of clang and gcc (as we
don't actually use anything from the C++ standard library), it does
matter for older GCC versions, e.g. GCC 4.4 seems to need it.

Hopefully fixes #3651 
