### PR TITLE
Fix BuildPackages.sh

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -168,7 +168,7 @@ run_configure_and_make() {
   then
     if grep Autoconf ./configure > /dev/null
     then
-      local PKG_NAME=$($GAPROOT/gap -q -T <<GAPInput
+      local PKG_NAME=$($GAPROOT/gap -q -T -A <<GAPInput
 Read("PackageInfo.g");
 Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput


### PR DESCRIPTION
Add the "-A" option to the gap invocation for determining the package
name. Otherwise, output from automatically loaded packages can create
problems.