### PR TITLE
Avoid setting attributes twice

### DIFF
--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -1694,29 +1694,26 @@ InstallMethod( IsSurjective,
 
 #############################################################################
 ##
-#M  GeneralRestrictedMapping( <map>, <source>,<range> ) 
+#M  GeneralRestrictedMapping( <map>, <source>, <range> ) 
 ##
 InstallGlobalFunction(GeneralRestrictedMapping,
 function( map, s,r )
-local res, prop;      
+local filter, res, prop;      
 
   # Make the general mapping.
   if IsSPGeneralMapping( map )  then
-    res:= Objectify( TypeOfDefaultGeneralMapping( s,r,
-		      IsGeneralRestrictedMappingRep and IsSPGeneralMapping ),
-		    rec() );
+    filter := IsSPGeneralMapping;
   else
-    res:= Objectify( TypeOfDefaultGeneralMapping( s,r,
-		      IsGeneralRestrictedMappingRep and IsNonSPGeneralMapping ),
-		    rec() );
+    filter := IsNonSPGeneralMapping;
   fi;
+  res:= Objectify( TypeOfDefaultGeneralMapping( s,r,
+            IsGeneralRestrictedMappingRep and filter ),
+          rec() );
 
   # Enter the identifying information.
   res!.map:= map;
-  SetSource(res,s);
-  SetRange(res,r);
 
-  for prop in [IsSingleValued, IsTotal, IsInjective, RespectsMultiplication, , RespectsInverses,
+  for prop in [IsSingleValued, IsTotal, IsInjective, RespectsMultiplication, RespectsInverses,
 	  RespectsAddition, RespectsAdditiveInverses, RespectsScalarMultiplication] do
 	if Tester(prop)(map) and prop(map) then
 		Setter(prop)(res, true);

--- a/lib/pcgs.gi
+++ b/lib/pcgs.gi
@@ -1414,7 +1414,7 @@ InstallPcgsSeriesFromIndices:=function(series,indices)
     for i in [2..Length(l)-1] do
       ipcgs:=InducedPcgsByPcSequenceNC(home,pcgs{[l[i]..Length(pcgs)]});
       h:=SubgroupByPcgs(p,ipcgs);
-      SetInducedPcgs(home,p,ipcgs);
+      SetInducedPcgs(home,h,ipcgs);
       Add(g,h);
     od;
     Add(g,TrivialSubgroup(p));

--- a/lib/pcgsperm.gi
+++ b/lib/pcgsperm.gi
@@ -424,7 +424,9 @@ InstallGlobalFunction(TryPcgsPermGroup,function(arg)
     if whole  then
         SetIsSolvableGroup( grp, true );
         SetPcgs( grp, pcgs );
-        SetHomePcgs( grp, pcgs );
+        if not HasHomePcgs( grp ) then
+          SetHomePcgs( grp, pcgs );
+        fi;
         SetGroupOfPcgs (pcgs, grp);
         if cent  then
             SetIsNilpotentGroup( grp, true );

--- a/lib/pcgsspec.gi
+++ b/lib/pcgsspec.gi
@@ -688,7 +688,7 @@ function( group )
     if HasPcgs(group)  then
         spec := SpecialPcgs( Pcgs( group ) );
     else
-        spec := SpecialPcgs( Pcgs( group ) );
+        spec := SpecialPcgs( AttributeValueNotSet( Pcgs, group ) );
         SetPcgs( group, spec );
     fi;
     SetGroupOfPcgs (spec, group);


### PR DESCRIPTION
This fixes a few places which cause Info messages when using PR #3628 and a high enough InfoAttributes level. In the case of GeneralRestrictedMapping, it avoids a warning for an attribute where HasFOO is set (here: HasSource and HasRange), but no actual value is stored in the object: for mappings, we do this intentionally, as the Source/Range are stored in the family object.

This touches Pcgs and mappings code. Many further things could be fixed, but these seem fairly "obvious" to me.