### PR TITLE
buildsys: change how ABI_CFLAGS are handled; export GAP_CXX in sysinfo.gap

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -721,6 +721,7 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 	@echo "GAP_LIB_DIR=\"$(abs_srcdir)\"" >> $@
 	@echo "" >> $@
 	@echo "GAP_CC=\"$(CC)\"" >> $@
+	@echo "GAP_CXX=\"$(CXX)\"" >> $@
 	@echo "GAP_CFLAGS=\"$(GAP_CFLAGS)\"" >> $@
 	@echo "GAP_CXXFLAGS=\"$(GAP_CXXFLAGS)\"" >> $@
 	@echo "GAP_CPPFLAGS=\"$(GAP_PKG_CPPFLAGS)\"" >> $@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -178,7 +178,7 @@ GAP_PKG_CPPFLAGS += $(CPPFLAGS)
 ########################################################################
 # C compiler flags
 ########################################################################
-GAP_CFLAGS = $(ABI_CFLAGS)
+GAP_CFLAGS =
 
 ifeq ($(HPCGAP),yes)
 GAP_CFLAGS += $(PTHREAD_CFLAGS)
@@ -191,7 +191,7 @@ GAP_CFLAGS += $(CFLAGS)
 ########################################################################
 # C++ compiler flags
 ########################################################################
-GAP_CXXFLAGS = $(ABI_CFLAGS)
+GAP_CXXFLAGS =
 
 ifeq ($(HPCGAP),yes)
 GAP_CXXFLAGS += $(PTHREAD_CFLAGS)
@@ -204,7 +204,7 @@ GAP_CXXFLAGS += $(CXXFLAGS)
 ########################################################################
 # Linker flags
 ########################################################################
-GAP_LDFLAGS = $(ABI_CFLAGS)
+GAP_LDFLAGS =
 
 # Add flags for dependencies
 GAP_LDFLAGS += $(GMP_LDFLAGS)
@@ -601,12 +601,12 @@ EXTERN_FILES += $(ZLIB_FILES)
 zlib: $(ZLIB_FILES)
 ifeq ($(SYS_IS_CYGWIN32),yes)
 $(ZLIB_FILES):
-	MAKE=$(MAKE) CFLAGS="$(CFLAGS) $(ABI_CFLAGS)" $(srcdir)/cnf/build-cygwin-zlib.sh
+	MAKE=$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" $(srcdir)/cnf/build-cygwin-zlib.sh
 
 else
 
 $(ZLIB_FILES):
-	MAKE=$(MAKE) CFLAGS="$(CFLAGS) $(ABI_CFLAGS)" $(srcdir)/cnf/build-extern.sh zlib "$(abs_srcdir)/extern/zlib"
+	MAKE=$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" $(srcdir)/cnf/build-extern.sh zlib "$(abs_srcdir)/extern/zlib"
 
 endif # SYS_IS_CYGWIN32
 
@@ -638,7 +638,7 @@ EXTERN_FILES += $(LIBATOMIC_OPS_FILES)
 
 libatomic_ops: $(LIBATOMIC_OPS_FILES)
 $(LIBATOMIC_OPS_FILES):
-	MAKE=$(MAKE) CFLAGS=$(ABI_CFLAGS) LDFLAGS=$(ABI_CFLAGS) \
+	MAKE=$(MAKE) CC="$(CC)"  \
 	$(srcdir)/cnf/build-extern.sh libatomic_ops "$(abs_srcdir)/hpcgap/extern/libatomic_ops" --disable-static --enable-shared
 
 # TODO: MAKEFLAGS=-j1
@@ -677,8 +677,7 @@ boehm: gc # alias
 gc: $(BOEHM_GC_FILES)
 $(BOEHM_GC_FILES):
 	MAKE=$(MAKE) \
-	CFLAGS=$(ABI_CFLAGS) \
-	LDFLAGS=$(ABI_CFLAGS) \
+	CC="$(CC)" \
 	ATOMIC_OPS_CFLAGS=$(LIBATOMIC_OPS_CPPFLAGS) \
 	ATOMIC_OPS_LIBS=$(LIBATOMIC_OPS_LDFLAGS) \
 	$(srcdir)/cnf/build-extern.sh gc "$(abs_srcdir)/hpcgap/extern/gc" --disable-static --enable-shared --enable-large-config

--- a/configure.ac
+++ b/configure.ac
@@ -48,11 +48,11 @@ fi
 AC_MSG_RESULT([$ABI_CFLAGS])
 AC_SUBST([ABI_CFLAGS])
 
-dnl Add ABI_CFLAGS to CFLAGS *now*, so that all config tests we
+dnl Start using ABI_CFLAGS *now*, so that all configure tests we
 dnl run from here on use it.
 AS_IF([test -n $ABI_CFLAGS],[
-  CFLAGS="$CFLAGS $ABI_CFLAGS"
-  LDFLAGS="$LDFLAGS $ABI_CFLAGS"
+  CC="$CC $ABI_CFLAGS"
+  CXX="$CXX $ABI_CFLAGS"
 
   dnl Verify that the ABI_CFLAGS didn't break anything
     AC_LINK_IFELSE(


### PR DESCRIPTION
This is a subset of PR #3652, which I split out for two reasons:
1. Running this on Travis helps me narrow down the remaining issues with PR #3652 (kind of like bisecting the issue...)
2. I think the changes in here are independently useful, and so it's useful to merge this ASAP, so it gets more testing, while completing PR #3652 might take longer (or I might even have to go with a completely different approach for it in the end).