### PR TITLE
Travis: switch to Julia 1.2

### DIFF
--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -30,7 +30,7 @@ fi
 if [[ $JULIA = yes ]]
 then
   pushd extern
-  wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz
+  wget https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz
   tar xvf julia-*.tar.gz
   rm julia-*.tar.gz
   cd julia-*


### PR DESCRIPTION
This only affects the Julia job on Travis, nothing else (and it should not really have any effect there, either, just wanted to make sure we test against the version of Julia that is actually relevant for our GAP-Julia integration these days).