### PR TITLE
Revert some Semigroups-related downrankings of Matrix methods

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -184,9 +184,6 @@ InstallMethod( Matrix,
 #
 InstallMethod( Matrix,
   [IsSemiring, IsList, IsInt],
-  # FIXME: Remove this downranking, it was introduced to prevent
-  #        Semigroups from breaking ahead of the 4.10 release
-  -SUM_FLAGS,
   function( basedomain, list, nrCols )
     local rep;
     rep := DefaultMatrixRepForBaseDomain(basedomain);
@@ -195,9 +192,6 @@ InstallMethod( Matrix,
 
 InstallMethod( Matrix,
   [IsSemiring, IsList],
-  # FIXME: Remove this downranking, it was introduced to prevent
-  #        Semigroups from breaking ahead of the 4.10 release
-  -SUM_FLAGS,
   function( basedomain, list )
     local rep;
     if Length(list) = 0 then Error("list must be not empty"); fi;

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1244,9 +1244,6 @@ end );
 InstallOtherMethod( BaseDomain,
     "generic method for a row vector",
     [ IsRowVector ],
-    # FIXME: Remove this downranking, it was introduced to prevent
-    #        Semigroups from breaking ahead of the 4.10 release
-    -SUM_FLAGS,
     DefaultRing );
 
 InstallOtherMethod( OneOfBaseDomain,


### PR DESCRIPTION
Three downrankings of `Matrix` methods were added in advance of GAP 4.10, along with one for `BaseDomain`, in order to make sure that GAP 4.10 did not break the Semigroups package. This was supposed to be temporary, and #2758 exists to revert this change.

In fact, only one of these downrankings is required to keep Semigroups happy. This commit reverts the others. Once it is merged, I will update #2758 accordingly.

At some point (separately from this PR) I will try to see about removing the remaining downranking of a `Matrix` method.