### PR TITLE
kernel: fix bug when printing objects is interrupted

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -196,8 +196,7 @@ static Obj Shell(Obj    context,
       ErrorQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
   
-  oldPrintDepth = STATE(PrintObjDepth);
-  STATE(PrintObjDepth) = 0;
+  oldPrintDepth = SetPrintObjState(0);
 
   while ( 1 ) {
 
@@ -210,7 +209,7 @@ static Obj Shell(Obj    context,
     /* read and evaluate one command                                   */
     STATE(Prompt) = prompt;
     ClearError();
-    STATE(PrintObjDepth) = 0;
+    SetPrintObjState(0);
     ResetOutputIndent();
     SetRecursionDepth(0);
       
@@ -291,7 +290,7 @@ static Obj Shell(Obj    context,
 
   }
   
-  STATE(PrintObjDepth) = oldPrintDepth;
+  SetPrintObjState(oldPrintDepth);
   CloseInput();
   CloseOutput();
   STATE(BaseShellContext) = oldBaseShellContext;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -99,9 +99,6 @@ typedef struct GAPState {
                                    // this is not used by GAP itself but by programs
                                    // that use GAP as a library to handle errors
 
-    /* From objects.c */
-    Int PrintObjDepth;
-
     /* From info.c */
     Int ShowUsedInfoClassesActive;
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -839,8 +839,8 @@ static inline UInt IS_ON_PRINT_STACK(const ObjectsModuleState * os, Obj obj)
   if (!(FIRST_RECORD_TNUM <= TNUM_OBJ(obj)
         && TNUM_OBJ(obj) <= LAST_LIST_TNUM))
     return 0;
-  for (i = 0; i < os->PrintObjDepth-1; i++)
-    if (os->PrintObjThiss[i] == obj)
+  for (i = 1; i < os->PrintObjDepth; i++)
+    if (os->PrintObjThiss[i-1] == obj)
       return 1;
   return 0;
 }

--- a/src/objects.h
+++ b/src/objects.h
@@ -757,6 +757,11 @@ void PrintObj(Obj obj);
 
 extern Obj PrintObjOper;
 
+/****************************************************************************
+**
+**
+*/
+UInt SetPrintObjState(UInt state); // returns the old state
 void SetPrintObjIndex(Int index);
 
 

--- a/tst/testspecial/bugfix-2019-09-27-LastPV.g
+++ b/tst/testspecial/bugfix-2019-09-27-LastPV.g
@@ -1,0 +1,18 @@
+filt:=NewFilter("BreakPrint");;
+InstallMethod(ViewObj, [filt], SUM_FLAGS, x -> 0/0);;
+badgroup := Group(());
+SetFilterObj(badgroup, filt);
+old_OnBreak:=OnBreak;;
+OnBreak:=fail;; # prevent backtrace with line numbers that keep chaning
+View([[badgroup]]); # <- trigger break loop
+quit;
+OnBreak:=old_OnBreak;;
+l := [1,2,3];
+l;
+Print(l,"\n");
+l;
+Print(l,"\n");
+Print(l,"\n");
+2;
+Print(l,"\n");
+Print(l,"\n");

--- a/tst/testspecial/bugfix-2019-09-27-LastPV.g.out
+++ b/tst/testspecial/bugfix-2019-09-27-LastPV.g.out
@@ -1,0 +1,33 @@
+gap> filt:=NewFilter("BreakPrint");;
+gap> InstallMethod(ViewObj, [filt], SUM_FLAGS, x -> 0/0);;
+gap> badgroup := Group(());
+Group(())
+gap> SetFilterObj(badgroup, filt);
+gap> old_OnBreak:=OnBreak;;
+gap> OnBreak:=fail;; # prevent backtrace with line numbers that keep chaning
+gap> View([[badgroup]]); # <- trigger break loop
+Error, Rational operations: <divisor> must not be zero in
+  0 / 0 at *stdin*:3 called from 
+type 'quit;' to quit to outer loop
+brk> quit;
+[ [ 
+gap> OnBreak:=old_OnBreak;;
+gap> l := [1,2,3];
+[ 1, 2, 3 ]
+gap> l;
+[ 1, 2, 3 ]
+gap> Print(l,"\n");
+[ 1, 2, 3 ]
+gap> l;
+[ 1, 2, 3 ]
+gap> Print(l,"\n");
+[ 1, 2, 3 ]
+gap> Print(l,"\n");
+[ 1, 2, 3 ]
+gap> 2;
+2
+gap> Print(l,"\n");
+[ 1, 2, 3 ]
+gap> Print(l,"\n");
+[ 1, 2, 3 ]
+gap> QUIT;


### PR DESCRIPTION
... by a break loop, for deeply recursive objects. In that case, the global
kernel variable LastPV, which normally should be 0 when not printing, could be
left in a non-zero state. If it ever is left in a non-zero state (which can
happen if printing is interrupted at an inconvenient moment), then it is
virtually impossible to reset it to 0, leaving one in a broken state.

There was also another issue regarding to LastPV: as it was not thread local,
printing recursive objects in HPC-GAP on two different threads could have been
badly broken (didn't verify this experimentally, but seems plausible).

Fixes #3677 