### PR TITLE
Two small fixes

### DIFF
--- a/lib/ctblgrp.gi
+++ b/lib/ctblgrp.gi
@@ -2466,6 +2466,13 @@ local G,chi,reps,r,i,gensp;
     Error("second argument must be ordinary character or character list");
   fi;
 
+  # Special case of trivial group
+  if Size(G)=1 then
+    r:=Group([[1]]);
+    r:=GroupHomomorphismByImagesNC(G,r,[One(G)],[One(r)]);
+    return List(chi,x->r);
+  fi;
+
   gensp:=fail;
   reps:=[];
   for i in chi do

--- a/lib/ghompcgs.gi
+++ b/lib/ghompcgs.gi
@@ -353,25 +353,38 @@ InversePcgs := function( hom )
       
         # add it
         hom!.rangePcgs := InducedPcgsByPcSequenceNC( pcgs, gensInv ); 
-        hom!.rangePcgsPreimages := imgsInv;
-#T better MakeImmutable
+        hom!.rangePcgsPreimages := Immutable(imgsInv);
         
-        # we have the kernel also
-        SetKernelOfMultiplicativeGeneralMapping( hom, SubgroupNC(Source(hom),
-                                                          gensKer ) );
-  
+        # we have the kernel also, if needed (or we check).
+        if not HasKernelOfMultiplicativeGeneralMapping(hom)
+          or InfoLevel(InfoAttributes)>1 then
+          #Check whether the Pcgs is for the whole group.
+          # Otherwise there is a kernel that will not be visible in
+          # the modulo pcgs that the homomorphism uses
+          tmp:=DenominatorOfModuloPcgs(hom!.sourcePcgs);
+          if tmp=fail then
+            gensKer:=AsSubgroup(Source(hom),
+              ClosureGroup(hom!.sourcePcgs!.denominator,gensKer));
+          elif Length(tmp)>0 then
+            gensKer:=SubgroupNC(Source(hom),Concatenation(tmp,gensKer));
+          else
+            gensKer:=SubgroupNC(Source(hom),gensKer);
+          fi;
+          SetKernelOfMultiplicativeGeneralMapping( hom, gensKer );
+        fi;
+
         # and return
         return;
-    fi;
-    
-    # otherwise we have to do some work
-    pcgs := Pcgs( Image( hom ) );
-    new:=MappingGeneratorsImages(hom);
-    new  := CanonicalPcgsByGeneratorsWithImages( pcgs, new[2],
-                                                       new[1] );
-    hom!.rangePcgs := new[1];
-    hom!.rangePcgsPreimages := new[2];
-end;
+      fi;
+      
+      # otherwise we have to do some work
+      pcgs := Pcgs( Image( hom ) );
+      new:=MappingGeneratorsImages(hom);
+      new  := CanonicalPcgsByGeneratorsWithImages( pcgs, new[2],
+                                                        new[1] );
+      hom!.rangePcgs := new[1];
+      hom!.rangePcgsPreimages := new[2];
+  end;
 
 #############################################################################
 ##

--- a/tst/testbugfix/2019-10-02-Irreps.tst
+++ b/tst/testbugfix/2019-10-02-Irreps.tst
@@ -1,0 +1,3 @@
+# representations for trivial group, #3681
+gap> Length(IrreducibleRepresentationsDixon( TrivialGroup( ) ));
+1


### PR DESCRIPTION
Two fixes:
a)  Ensure `inversePcgs` assigns correct kernel, but compute it only if needed. This fixes #3676

This could not lead to errors or wrong results, and thus does not need to be mentioned in release notes.

b) Special treatment for `IrreducibleRepresentationsDixon`. This fixes #3681

I don't think it merits special mention in the release announcement either.

Both could be ported to 4.11 without issue.