### PR TITLE
Add parts for GAP package build systems

### DIFF
--- a/etc/Makefile.gappkg
+++ b/etc/Makefile.gappkg
@@ -1,0 +1,146 @@
+########################################################################
+#
+# The build rules in this file are intended for use by GAP packages that
+# want to build a simple GAP kernel extensions. They are based on the
+# GAP build system, and require GNU make. To use this in your GAP
+# package, `include` this from your primary Makefile. You must also set
+# several variables beforehand:
+#
+# - GAPPATH must be set to the location of the GAP installation against
+#   which to build your package.
+# - KEXT_NAME should be the name of your kernel extension (without
+#   file extensions like .so or .dll)
+# - KEXT_SOURCES must contain a list of .c or .cc files to be linked
+#   into your kernel extension
+# - optionally, you can set KEXT_CFLAGS, KEXT_CXXFLAGS, KEXT_LDFLAGS
+#
+#
+# Only GAP >= 4.11 ships with this file. In order to keep your package
+# compatible with older GAP versions, we recommend to bundle a copy of
+# it with your package, but only as a fallback. So, your configure
+# scripts should check if GAP ships with this file, and use it then, and
+# only fall back to your own copy as a last resort. This way, you will
+# benefit from any fixes and improvements made by the GAP team.
+#
+# The contents of this file are released into the public domain; hence
+# you may edit this file as you wish, bundle and distribute it with your
+# package, etc.
+#
+# If you bundle this file with your package, please try not to edit it,
+# so that we can keep it identical across all GAP packages. If you still
+# find that you must edit it, please consider submitting your changes
+# back to the GAP team, so that a future version of this file can be
+# adjusted to cover your usecase without modifications.
+#
+########################################################################
+
+# read GAP's build settings
+include $(GAPPATH)/sysinfo.gap
+
+# various derived settings
+KEXT_BINARCHDIR = bin/$(GAParch)
+KEXT_SO = $(KEXT_BINARCHDIR)/$(KEXT_NAME).so
+
+GAP = $(GAPPATH)/gap
+GAC = $(GAPPATH)/gac
+
+# override KEXT_RECONF if your package needs a different invocation
+# for reconfiguring (e.g. `./config.status --recheck` for autoconf)
+KEXT_RECONF ?= ./configure "$(GAPPATH)"
+
+# default target
+all: $(KEXT_SO)
+.PHONY: all
+
+########################################################################
+# Object files
+# For each file FOO.c in SOURCES, add gen/FOO.lo to KEXT_OBJS; similar
+# for .cc files
+########################################################################
+KEXT_OBJS = $(patsubst %.cc,gen/%.lo,$(patsubst %.c,gen/%.lo,$(KEXT_SOURCES)))
+
+########################################################################
+# Quiet rules.
+#
+# Replace regular output with quiet messages, unless V is set,
+# e.g. "make V=1"
+########################################################################
+ifneq ($(findstring $(MAKEFLAGS),s),s)
+ifndef V
+QUIET_GAC     = @echo "   GAC     $< => $@";
+endif
+endif
+
+########################################################################
+# Rules for automatic header dependency tracking.
+# This is based on the GAP build system.
+########################################################################
+
+# List of all (potential) dependency directories, derived from KEXT_OBJS
+# and KEXT_SOURCES (the latter for generated sources, which may also
+# involve dependency tracking)
+KEXT_DEPDIRS = $(sort $(dir $(KEXT_SOURCES) $(KEXT_OBJS)))
+KEXT_DEPFILES = $(wildcard $(addsuffix /*.d,$(KEXT_DEPDIRS)))
+
+# Include the dependency tracking files.
+-include $(KEXT_DEPFILES)
+
+# Mark *.d files as PHONY. This stops make from trying to recreate them
+# (which it can't), and in particular from looking for potential source
+# files. This can save quite a bit of disk access time.
+.PHONY: $(KEXT_DEPFILES)
+
+# The following flags instruct the compiler to enable advanced
+# dependency tracking. Supported by GCC 3 and newer; clang; Intel C
+# compiler; and more.
+KEXT_DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
+
+# build rule for C code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.c Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
+
+# build rule for C++ code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.cc Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
+
+# build rule for linking all object files together into a kernel extension
+$(KEXT_SO): $(KEXT_OBJS)
+	@mkdir -p $(KEXT_BINARCHDIR)
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" $(KEXT_OBJS) -o $@
+
+# hook into `make clean`
+clean: clean-kext
+clean-kext:
+	rm -rf $(KEXT_BINARCHDIR) gen
+
+# hook into `make distclean`
+distclean: clean-kext
+distclean-kext:
+	rm -rf bin gen Makefile
+	(cd doc && ./clean)
+
+# hook into `make doc`
+doc: doc-kext
+doc-kext:
+	$(GAP) makedoc.g
+
+# hook into `make check`
+check: check-kext
+check-kext:
+	$(GAP) tst/testall.g
+
+# re-run configure if configure, Makefile.in or GAP itself changed
+Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
+	$(KEXT_RECONF)
+
+.PHONY: check clean distclean doc
+.PHONY: check-kext clean-kext distclean-kext doc-kext
+
+########################################################################
+# Makefile debugging trick:
+# call print-VARIABLE to see the runtime value of any variable
+########################################################################
+print-%:
+	@echo '$*=$($*)'


### PR DESCRIPTION
## Summary

The file `Makefile.gappkg` provides the core of a build system for GAP packages with a kernel extension, with nice features, such as automatic recompilation if any source files or parts of the build system changed, or if GAP itself changed.

It is already use by several GAP packages. By shipping it with GAP, it gets easier for new GAP packages to provide simple kernel extensions. 

## Goals and questions

There are two ways this could be used:
1. We simply bundle it with GAP, as a reference implementation, so that package authors have a definitive place to look for the "newest" version of this file.
2. Or, we could in addition strongly encourage package authors to use the copy of this file bundled with GAP, not with their package. If they want to be compatible with GAP < 4.11, they can of course still bundle a copy of `Makefile.gappkg` in their package, but should have a line like this in their `configure` script:
```bash
test -r $GAPPATH/Makefile.gappkg && cp $GAPPATH/Makefile.gappkg .
```

The two approaches balance work between the GAP team, and package maintainers:

Approach 1 is more defensive; it means that in order to benefit from improvements to this file, package authors will have to copy the file over to their package from time to time (but carefully so, as newer versions might not be compatible with older versions of GAP; right now, this file is compatible with at least GAP 4.9, 4.10 and 4.11, but I already have an improvement in mind that would require a new `gac` version and thus would not be backwards compatible). After copying the file, they also need to make a release. Based on past experience, this may never happen, or only with a delay of several years, unless somebody from the GAP team actively pushes all involved packages resp. their maintainers to action, which means a lot of work.

Approach 2 requires virtually no effort from package maintainers. It does, however, slightly increase the strain on the GAP team itself, as we'd have to be careful with any change so as not to break existing packages relaying on `Makefile.gappkg`. However, we already have CI tests which build and test all deposited packages; so we should notice regressions quickly. In the worst case, a change may need to be coordinated with updates to some packages, but that is still less work than with approach 1.

Hence, overall I prefer approach 2, but would be interested to learn what others think.

## Other considerations

The name `Makefile.gappkg` is not set in stone. Alternative suggestions are welcome.

I marked this as `backport-to-4.11`, and referenced 4.11 in the code comments, because (a) there is no risk of regression when adding a completely new file like this, and (b) the sooner this is in a GAP release, the sooner people can use it, and the sooner they can drop backwards compatibility code (I'd still expect that to take a couple years, but reducing from N to N-1 years still is good ;-).

Some packages need to build other things than just a GAP kernel extension. I tried to write `Makefile.gappkg` with this in mind; hence most variables are prefixed with `KEXT_` to avoid clashes, build rules are set up to be extensible, and so on). However, this may require some further tweaking based on experience with integrating this into packages with more complex build requirements.

Ideally I'd like to use this in the [Example](https://github.com/gap-packages/example) package, so that people can see how to use it there; and of course also in [PackageMaker](https://github.com/gap-system/PackageMaker).

## Affected packages

Packages that use (a version of) this file, resp. for which I submitted a PR to use a copy of it, include these:
- https://github.com/gap-packages/Char0Gauss/pull/7
- https://github.com/gap-packages/crypting/pull/12
- https://github.com/gap-packages/cvec/pull/30
- https://github.com/gap-packages/datastructures/pull/122
- https://github.com/gap-packages/json/pull/16
- https://github.com/gap-packages/orb/pull/49
- https://github.com/gap-packages/PARIInterface/pull/24

A few other packages either use older versions of the build rules in here, or could otherwise easily be adapted to use them, if so desired, including:
- Browse
- EDIM
- GaloisGroups
- Gauss
- (Example) (doesn't currently build a kernel extension, but has a TODO for it)
- (PackageMaker: could use it in its default kernel extension template)
- profiling

Packages that could perhaps use it (I didn't look closely), but might still require more complicated configure scripts (autoconf based?) to check for required 3rd party dependencies include:
- BlissInterface
- Digraphs
- NautyTracesInterface
- NormalizInterface
- PythonInterface
- Semigroups
- ZeroMQInterface
- curlInterface
- ferret
- float
- io
- meataxe64
