### PR TITLE
kernel: add PLAIN_LIST_COPY helper

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -269,8 +269,7 @@ Obj CALL_WITH_CATCH(Obj func, volatile Obj args)
         RequireArgument("CALL_WITH_CATCH", args, "must be a list");
 #ifdef HPCGAP
     if (!IS_PLIST(args)) {
-        args = SHALLOW_COPY_OBJ(args);
-        PLAIN_LIST(args);
+        args = PLAIN_LIST_COPY(args);
     }
 #endif
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -1614,6 +1614,23 @@ static void PlainListError(Obj list)
         (Int)TNAM_OBJ(list), 0L );
 }
 
+Obj PLAIN_LIST_COPY(Obj list)
+{
+    if (IS_PLIST(list)) {
+        return SHALLOW_COPY_OBJ(list);
+    }
+    const Int len = LEN_LIST(list);
+    if (len == 0)
+        return NewEmptyPlist();
+    Obj res = NEW_PLIST(T_PLIST, len);
+    SET_LEN_PLIST(res, len);
+    for (Int i = 1; i <= len; i++) {
+        SET_ELM_PLIST(res, i, ELMV0_LIST(list, i));
+        CHANGED_BAG(res);
+    }
+    return res;
+}
+
 
 /****************************************************************************
 **

--- a/src/lists.h
+++ b/src/lists.h
@@ -749,6 +749,13 @@ EXPORT_INLINE void PLAIN_LIST(Obj list)
 
 /****************************************************************************
 **
+*F  PLAIN_LIST_COPY(<list>) . . . . . . . copy a list to a mutable plain list
+*/
+Obj PLAIN_LIST_COPY(Obj list);
+
+
+/****************************************************************************
+**
 *F  TYPES_LIST_FAM(<fam>) . . . . . . .  list of types of lists over a family
 */
 Obj TYPES_LIST_FAM(Obj fam);


### PR DESCRIPTION
The function PLAIN_LIST converts any other type of internal lists (blists, strings, ranges) into plain lists. This is a powerful function that can lead to very surprising and problematic results (see e.g. issues #815, #1095; also relevant: #3155, #3373 , hence it would be good to minimize or even remove its usage.

It turns out that in quite some places, we first make a shallow copy of a list and then apply PLAIN_LIST to that. So here we introduce a new helper which combines the two tasks into one and avoids the in-place conversion altogether. This let's the remaining uses of PLAIN_LIST in the kernel stand out more.
