### PR TITLE
Add descriptive message to declared but not defined global functions

### DIFF
--- a/tst/testinstall/declarefunction.tst
+++ b/tst/testinstall/declarefunction.tst
@@ -1,0 +1,49 @@
+#@local name, testfunctionA, func
+
+gap> START_TEST("declarefunction.tst");
+
+# We avoid the use of DeclareGlobalFunction here so the test can be run
+# more than once.
+gap> testfunctionA := NEW_GLOBAL_FUNCTION("testfunctionA");;
+gap> testfunctionA;
+function( args... ) ... end
+gap> Print(testfunctionA,"\n");
+function ( args... )
+    <<kernel code>> from the global function "testfunctionA" is not yet define\
+d:
+end
+gap> InstallGlobalFunction(testfunctionA, x -> x);
+gap> testfunctionA;
+function( x ) ... end
+gap> Print(testfunctionA,"\n");
+function ( x )
+    return x;
+end
+gap> name := List([1..100], x -> 'a');;
+gap> func := NEW_GLOBAL_FUNCTION(name);;
+gap> Print(func,"\n");
+function ( args... )
+    <<kernel code>> from the global function "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is not y\
+et defined:
+end
+gap> name := List([1..1000], x -> 'a');;
+gap> func := NEW_GLOBAL_FUNCTION(name);;
+gap> Print(func,"\n");
+function ( args... )
+    <<kernel code>> from the global function "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is not yet defined:
+end
+gap> STOP_TEST("declarefunction.tst");


### PR DESCRIPTION
Fixes #2926

Basically adds a location to declared but not defined functions, to help users know what they have. This is a bit of an abuse, but anything else would require more major surgery I think.