### PR TITLE
kernel: tweak error messages to say "an object"

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -568,7 +568,6 @@ Obj RequireArgumentEx(const char * funcname,
 {
     char msgbuf[1024] = { 0 };
     Int  arg1 = 0;
-    Int  arg2 = 0;
 
     if (funcname) {
         strlcat(msgbuf, funcname, sizeof(msgbuf));
@@ -590,11 +589,19 @@ Obj RequireArgumentEx(const char * funcname,
     else if (op == Fail)
         strlcat(msgbuf, " (not the value 'fail')", sizeof(msgbuf));
     else {
-        strlcat(msgbuf, " (not a %s)", sizeof(msgbuf));
-        arg1 = (Int)TNAM_OBJ(op);
+        const char * tnam = TNAM_OBJ(op);
+        // heuristic to choose between 'a' and 'an': use 'an' before a vowel
+        // and 'a' otherwise; however, that's not always correct, e.g. it is
+        // "an FFE", so we add a special case for that as well
+        if (TNUM_OBJ(op) == T_FFE || tnam[0] == 'a' || tnam[0] == 'e' ||
+            tnam[0] == 'i' || tnam[0] == 'o' || tnam[0] == 'u')
+            strlcat(msgbuf, " (not an %s)", sizeof(msgbuf));
+        else
+            strlcat(msgbuf, " (not a %s)", sizeof(msgbuf));
+        arg1 = (Int)tnam;
     }
 
-    ErrorMayQuit(msgbuf, arg1, arg2);
+    ErrorMayQuit(msgbuf, arg1, 0);
 }
 
 void AssertionFailure(void)

--- a/tst/testbugfix/2013-03-12-t00285.tst
+++ b/tst/testbugfix/2013-03-12-t00285.tst
@@ -2,4 +2,4 @@
 gap> v:=IdentityMat(28,GF(2))[1];
 <a GF2 vector of length 28>
 gap> v{[1..Length(v)]}{[1..5]};
-Error, List Elements: <lists> must be a list (not a object (data))
+Error, List Elements: <lists> must be a list (not an object (data))

--- a/tst/testinstall/bitfields.tst
+++ b/tst/testinstall/bitfields.tst
@@ -56,11 +56,11 @@ end
 
 #
 gap> bf.getters[1](Z(5));
-Error, Field getter: <data> must be a small integer (not a ffe)
+Error, Field getter: <data> must be a small integer (not an ffe)
 gap> bf.setters[1](1, (1,2));
 Error, Field Setter: <val> must be a small integer (not a permutation (small))
 gap> bf.setters[1]([],1);
-Error, Field Setter: <data> must be a small integer (not a empty plain list)
+Error, Field Setter: <data> must be a small integer (not an empty plain list)
 gap> BuildBitfields([1],Z(5));
 Error, Fields builder: values must be small integers
 gap> MakeBitfields(100);

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -227,8 +227,8 @@ gap> l := [];; Append(l,l); l;
 gap> l := [1,2,3,4];; Append(l,l); l;
 [ 1, 2, 3, 4, 1, 2, 3, 4 ]
 gap> Append(Immutable([1,2,3]), [1,2,3]);
-Error, Append: <list1> must be a mutable list (not a immutable plain list of c\
-yclotomics)
+Error, Append: <list1> must be a mutable list (not an immutable plain list of \
+cyclotomics)
 gap> Append([1,2,3], () );
 Error, AppendList: <list2> must be a small list (not a permutation (small))
 gap> Append( () , [1,2,3] );
@@ -273,8 +273,8 @@ gap> CopyListEntries(s,3,-1,"abc",4,-3,2);
 Error, CopyListEntries: <tolst> must be a mutable plain list (not a list (stri\
 ng))
 gap> CopyListEntries(s,3,-1,Immutable([1,2,3]),4,-3,2);
-Error, CopyListEntries: <tolst> must be a mutable plain list (not a immutable \
-plain list of cyclotomics)
+Error, CopyListEntries: <tolst> must be a mutable plain list (not an immutable\
+ plain list of cyclotomics)
 gap> CopyListEntries(s, "cheese", 1, l, 1, 1, 2);
 Error, CopyListEntries: <fromind> must be a small integer (not a list (string)\
 )

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -116,12 +116,12 @@ true
 # block matrices are immutable
 #@if IsHPCGAP
 gap> m1[1,2] := 5;
-Error, Matrix Assignment: <mat> must be a mutable matrix (not a atomic compone\
-nt object)
+Error, Matrix Assignment: <mat> must be a mutable matrix (not an atomic compon\
+ent object)
 #@else
 gap> m1[1,2] := 5;
-Error, Matrix Assignment: <mat> must be a mutable matrix (not a object (compon\
-ent))
+Error, Matrix Assignment: <mat> must be a mutable matrix (not an object (compo\
+nent))
 #@fi
 
 #

--- a/tst/testinstall/weakptr-badargs.tst
+++ b/tst/testinstall/weakptr-badargs.tst
@@ -17,30 +17,30 @@ gap> UnbindElmWPObj(w, 0);
 Error, UnbindElmWPObj: <pos> must be a positive small integer (not the integer\
  0)
 gap> UnbindElmWPObj(w, []);
-Error, UnbindElmWPObj: <pos> must be a positive small integer (not a empty pla\
-in list)
+Error, UnbindElmWPObj: <pos> must be a positive small integer (not an empty pl\
+ain list)
 gap> UnbindElmWPObj([], 2);
-Error, UnbindElmWPObj: <wp> must be a weak pointer object (not a empty plain l\
-ist)
+Error, UnbindElmWPObj: <wp> must be a weak pointer object (not an empty plain \
+list)
 gap> ElmWPObj(w, 0);
 Error, ElmWPObj: <pos> must be a positive small integer (not the integer 0)
 gap> ElmWPObj(w, []);
-Error, ElmWPObj: <pos> must be a positive small integer (not a empty plain lis\
-t)
+Error, ElmWPObj: <pos> must be a positive small integer (not an empty plain li\
+st)
 gap> ElmWPObj([], 1);
-Error, ElmWPObj: <wp> must be a weak pointer object (not a empty plain list)
+Error, ElmWPObj: <wp> must be a weak pointer object (not an empty plain list)
 gap> IsBoundElmWPObj(w, 0);
 Error, IsBoundElmWPObj: <pos> must be a positive small integer (not the intege\
 r 0)
 gap> IsBoundElmWPObj(w, []);
-Error, IsBoundElmWPObj: <pos> must be a positive small integer (not a empty pl\
-ain list)
+Error, IsBoundElmWPObj: <pos> must be a positive small integer (not an empty p\
+lain list)
 gap> IsBoundElmWPObj([], 1);
-Error, IsBoundElmWPObj: <wp> must be a weak pointer object (not a empty plain \
-list)
+Error, IsBoundElmWPObj: <wp> must be a weak pointer object (not an empty plain\
+ list)
 gap> LengthWPObj([]);
-Error, LengthWPObj: <wp> must be a weak pointer object (not a empty plain list\
-)
+Error, LengthWPObj: <wp> must be a weak pointer object (not an empty plain lis\
+t)
 gap> LengthWPObj(0);
 Error, LengthWPObj: <wp> must be a weak pointer object (not the integer 0)
 gap> STOP_TEST( "weakptr-badargs.tst", 1);


### PR DESCRIPTION
... instead of "a object", and similar.

This makes some progress on issue #3400 and is otherwise about the least import PR we had in a long time, I guess ;-).