### PR TITLE
kernel: new TNAMs for {component,positional,data} objects

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -1934,9 +1934,9 @@ static Obj FuncDEBUG_TNUM_NAMES(Obj self)
 *V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
 */
 static StructBagNames BagNames[] = {
-  { T_COMOBJ,                         "object (component)"             },
-  { T_POSOBJ,                         "object (positional)"            },
-  { T_DATOBJ,                         "object (data)"                  },
+  { T_COMOBJ,                         "component object"               },
+  { T_POSOBJ,                         "positional object"              },
+  { T_DATOBJ,                         "data object"                    },
 #if !defined(USE_THREADSAFE_COPYING)
   { T_COPYING,                        "copy in progress"               },
 #endif

--- a/tst/testbugfix/2013-03-12-t00285.tst
+++ b/tst/testbugfix/2013-03-12-t00285.tst
@@ -2,4 +2,4 @@
 gap> v:=IdentityMat(28,GF(2))[1];
 <a GF2 vector of length 28>
 gap> v{[1..Length(v)]}{[1..5]};
-Error, List Elements: <lists> must be a list (not an object (data))
+Error, List Elements: <lists> must be a list (not a data object)

--- a/tst/testinstall/hpc/serialize.tst
+++ b/tst/testinstall/hpc/serialize.tst
@@ -161,7 +161,7 @@ gap> CheckSerialization(OBJ_SET([false, 0, true, 1]));
 #
 gap> x := ZmodnZObj(1,6);;
 gap> TNAM_OBJ(x);
-"object (positional)"
+"positional object"
 gap> SerializeToNativeString(x);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `SerializableRepresentation' on 1 arguments

--- a/tst/testinstall/kernel/lists.tst
+++ b/tst/testinstall/kernel/lists.tst
@@ -131,7 +131,7 @@ gap> InstallMethod(Length,[r],l->5);
 gap> t:=NewType(ListsFamily, r and IsMutable and IsPositionalObjectRep);;
 gap> l:=Objectify(t,[]);;
 gap> OnTuples(l, (1,3));
-Error, Panic: cannot convert <list> (is a object (positional)) to a plain list
+Error, Panic: cannot convert <list> (is a positional object) to a plain list
 
 #
 gap> STOP_TEST("kernel/lists.tst", 1);

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -120,8 +120,8 @@ Error, Matrix Assignment: <mat> must be a mutable matrix (not an atomic compon\
 ent object)
 #@else
 gap> m1[1,2] := 5;
-Error, Matrix Assignment: <mat> must be a mutable matrix (not an object (compo\
-nent))
+Error, Matrix Assignment: <mat> must be a mutable matrix (not a component obje\
+ct)
 #@fi
 
 #


### PR DESCRIPTION
This fits into the work we spent on making error messages nicer to read and
more helpful to people who are not kernel experts. Note that we already have
"atomic component/positional object" in HPC-GAP.
