### PR TITLE
Improve ViewString so Strings are correctly escaped

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -345,7 +345,7 @@ local   str,ls, i;
   fi;
 
   if IsString( list ) then
-    return Concatenation(CHUNK_ESCAPE_STRING(list));
+    return VIEW_STRING_FOR_STRING(list);
   fi;
 
   # make strings for objects in l

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -345,7 +345,7 @@ local   str,ls, i;
   fi;
 
   if IsString( list ) then
-    return Concatenation("\"", list, "\"");
+    return Concatenation(CHUNK_ESCAPE_STRING(list));
   fi;
 
   # make strings for objects in l

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -530,11 +530,11 @@ static Obj CopyString(Obj list, Int mut)
 /****************************************************************************
 **
 *F  PrintString(<list>) . . . . . . . . . . . . . . . . . . .  print a string
-*F  FuncCHUNK_ESCAPE_STRING(<list>) . . . . . . . escape a string as a string
+*F  FuncVIEW_STRING_FOR_STRING(<list>) . . . . . .  view a string as a string
 **
 **  'PrintString' prints the string with the handle <list>.
-**  'CHUNK_ESCAPE_STRING' returns a list of strings which, when concatenated,
-**  produce a String containing what PrintString outputs.
+**  'VIEW_STRING_FOR_STRING' returns a string containing what PrintString
+**  outputs.
 **
 **  No linebreaks are  allowed, if one must be inserted  anyhow, it must
 **  be escaped by a backslash '\', which is done in 'Pr'.
@@ -557,14 +557,16 @@ void ToPrOutputter(void * data, char * strbuf, UInt len)
     Pr("%s", (Int)strbuf, 0L);
 }
 
-// Output to a list of Strings
-void ToStringOutputter(void * data, char * strbuf, UInt len)
+// Output to a string
+void ToStringOutputter(void * data, char * buf, UInt lenbuf)
 {
-    Obj list = (Obj)data;
-
-    strbuf[len++] = '\0';
-    AddPlist(list, MakeImmString(strbuf));
-    CHANGED_BAG(list);
+    Obj str = (Obj)data;
+    UInt lenstr = GET_LEN_STRING(str);
+    UInt newlen = lenstr + lenbuf;
+    GROW_STRING(str, newlen);
+    memcpy(CHARS_STRING(str) + lenstr, buf, lenbuf);
+    CHARS_STRING(str)[newlen] = '\0';
+    SET_LEN_STRING(str, newlen);
 }
 
 void OutputStringGeneric(Obj list, StringOutputterType func, void * data)
@@ -644,19 +646,19 @@ void PrintString(Obj list)
     OutputStringGeneric(list, ToPrOutputter, (void *)0);
 }
 
-Obj FuncCHUNK_ESCAPE_STRING(Obj self, Obj string)
+Obj FuncVIEW_STRING_FOR_STRING(Obj self, Obj string)
 {
     if (!IS_STRING(string)) {
-        RequireArgument("ConvString", string, "must be a string");
+        RequireArgument("VIEW_STRING_FOR_STRING", string, "must be a string");
     }
 
     if (!IS_STRING_REP(string)) {
         string = CopyToStringRep(string);
     }
 
-    Obj list = NEW_PLIST(T_PLIST, 1);
-    OutputStringGeneric(string, ToStringOutputter, list);
-    return list;
+    Obj output = NEW_STRING(0);
+    OutputStringGeneric(string, ToStringOutputter, output);
+    return output;
 }
 
 /****************************************************************************
@@ -1951,7 +1953,7 @@ static StructGVarFilt GVarFilts [] = {
 *V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
 */
 static StructGVarFunc GVarFuncs [] = {
-    GVAR_FUNC_1ARGS(CHUNK_ESCAPE_STRING, string),
+    GVAR_FUNC_1ARGS(VIEW_STRING_FOR_STRING, string),
     GVAR_FUNC_1ARGS(IS_STRING_CONV, string),
     GVAR_FUNC_1ARGS(CONV_STRING, string),
     GVAR_FUNC_1ARGS(COPY_TO_STRING_REP, string),

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -2,7 +2,7 @@
 ##
 ##  This file tests output methods (mainly for strings)
 ##
-#@local x
+#@local x, str
 gap> START_TEST("strings.tst");
 
 # FFE
@@ -42,10 +42,28 @@ gap> String(x);
 "abc"
 gap> x:="\0xFF";
 "\377"
+gap> PrintString(x);
+"\377"
+gap> ViewString(x);
+"\"\\377\""
 gap> x:="\0x42\0x23\0x10\0x10\0x10";
 "B#\020\020\020"
+gap> PrintString(x);
+"B#\020\020\020"
+gap> ViewString(x);
+"\"B#\\020\\020\\020\""
 gap> x:="A string with \0xFF Hex stuff \0x42 in it";
 "A string with \377 Hex stuff B in it"
+gap> PrintString(x);
+"A string with \377 Hex stuff B in it"
+gap> ViewString(x);
+"\"A string with \\377 Hex stuff B in it\""
+gap> x := "\n\t\c\\\"'";
+"\n\t\c\\\"'"
+gap> PrintString(x);
+"\n\t\c\\\"'"
+gap> ViewString(x);
+"\"\\n\\t\\c\\\\\\\"'\""
 gap> "\0yab";
 Syntax error: Expecting hexadecimal escape, or two more octal digits in stream\
 :1
@@ -173,6 +191,13 @@ gap> x:='\0xFF';
 '\377'
 gap> x:='\0xab';
 '\253'
+
+# Huge strings
+gap> for len in [10,100,1000,10000,100000] do
+> str := List([1..len], x -> 'a');
+> Assert(0, Concatenation("\"",str,"\"") = ViewString(str));
+> Assert(0, Concatenation(str,"\n") = DisplayString(str));
+> od;;
 
 #
 gap> STOP_TEST( "strings.tst", 1);


### PR DESCRIPTION
Fixes #2884

This fixes ViewString not correctly escaping strings. This is done by making the function which prints strings to the terminal generic, so we can print a string (with escape characters) to a buffer.

Note that, to make the kernel level stuff easier, I print to a plist of strings which have to be concatenated together, which then actually gets done back at the GAP level. If this offends anyone I could make a growing string and do this in one go, but this seemed easier.