### PR TITLE
Deprecate undocumented extra arguments for DeclareGlobalFunction and InstallGlobalFunction

### DIFF
--- a/lib/dict.gd
+++ b/lib/dict.gd
@@ -467,7 +467,7 @@ DeclareRepresentation( "IsDenseHashRep",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "DenseHashTable", [] );
+DeclareGlobalFunction( "DenseHashTable" );
 
 
 #############################################################################
@@ -530,7 +530,7 @@ BindGlobal("DefaultSparseHashWithIKRepType",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "SparseHashTable", [] );
+DeclareGlobalFunction( "SparseHashTable" );
 
 #############################################################################
 ##
@@ -547,7 +547,7 @@ DeclareGlobalFunction( "SparseHashTable", [] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "DoubleHashDictSize", [ IsSparseHashRep ] );
+DeclareGlobalFunction( "DoubleHashDictSize" );
 DeclareSynonym("DoubleHashArraySize", DoubleHashDictSize);
 
 # almost duplicate without any extras - thus faster
@@ -575,7 +575,7 @@ DeclareSynonym("DoubleHashArraySize", DoubleHashDictSize);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "IntegerHashFunction", [ IsInt, IsInt, IsInt ] );
+DeclareGlobalFunction( "IntegerHashFunction" );
 DeclareSynonym( "HashFunct", IntegerHashFunction);
 
 #############################################################################

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -3462,7 +3462,7 @@ KeyDependentOperation( "HallSubgroup", IsGroup, IsList, ReturnTrue );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "NormalHallSubgroupsFromSylows", [ IsGroup ] );
+DeclareGlobalFunction( "NormalHallSubgroupsFromSylows" );
 
 
 #############################################################################

--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -56,8 +56,7 @@ DeclareOperation( "IsTrivialNormalIntersection",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "IsTrivialNormalIntersectionInList",
-                  [ IsList, IsGroup, IsGroup ] );
+DeclareGlobalFunction( "IsTrivialNormalIntersectionInList" );
 
 #############################################################################
 ##
@@ -74,7 +73,7 @@ DeclareGlobalFunction( "IsTrivialNormalIntersectionInList",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
+DeclareGlobalFunction( "UnionIfCanEasilySortElements" );
 
 #############################################################################
 ##
@@ -92,7 +91,7 @@ DeclareGlobalFunction( "UnionIfCanEasilySortElements", IsList );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "AddSetIfCanEasilySortElements", IsList );
+DeclareGlobalFunction( "AddSetIfCanEasilySortElements" );
 
 #############################################################################
 ##
@@ -283,8 +282,7 @@ DeclareAttribute( "CharacteristicFactorsOfGroup", IsGroup );
 ##   and where it is in the b-sequence if any. Then the
 ##   linear algorithm above may be used.
 ##
-DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
-                        [ IsGroup, IsList, IsList ] );
+DeclareGlobalFunction( "DirectFactorsOfGroupFromList" );
 
 #############################################################################
 ##
@@ -305,7 +303,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupFromList",
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "DirectFactorsOfGroupByKN", IsGroup );
+DeclareGlobalFunction( "DirectFactorsOfGroupByKN" );
 
 #############################################################################
 ##
@@ -346,7 +344,7 @@ DeclareGlobalFunction( "DirectFactorsOfGroupByKN", IsGroup );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction( "SemidirectDecompositionsOfFiniteGroup", IsGroup );
+DeclareGlobalFunction( "SemidirectDecompositionsOfFiniteGroup" );
 
 #############################################################################
 ##

--- a/lib/grpperm.gd
+++ b/lib/grpperm.gd
@@ -301,9 +301,9 @@ DeclareGlobalFunction( "TransitiveGroupsAvailable" );
 
 # dummy declarations to satisfy library references to transitive groups
 # library
-DeclareGlobalFunction( "NrTransitiveGroups", "placeholder for transgrp package" );
-DeclareGlobalFunction( "TransitiveGroup", "placeholder for transgrp package" );
-DeclareGlobalFunction( "TRANSProperties", "placeholder for transgrp package" );
+DeclareGlobalFunction( "NrTransitiveGroups" );
+DeclareGlobalFunction( "TransitiveGroup" );
+DeclareGlobalFunction( "TRANSProperties" );
 
 #############################################################################
 ##

--- a/lib/lierep.gd
+++ b/lib/lierep.gd
@@ -203,7 +203,7 @@ DeclareGlobalFunction( "ValueCochain" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "LieCoboundaryOperator", "Lie coboundary operator" );
+DeclareGlobalFunction( "LieCoboundaryOperator" );
 
 #############################################################################
 ##

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1097,7 +1097,7 @@ DeclareOperation( "PositionBound", [ IsList ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "PositionsBound", [IsList] );
+DeclareGlobalFunction( "PositionsBound" );
 
 
 #############################################################################
@@ -1566,7 +1566,7 @@ DeclareOperation( "Flat", [ IsList ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "Reversed", [ IsDenseList ] );
+DeclareGlobalFunction( "Reversed" );
 
 
 #############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -334,7 +334,7 @@ DeclareOperation( "ExtractSubVector", [IsVectorObj,IsList] );
 
 # DeclareOperation( "ShallowCopy", [IsVectorObj] );
 
-# DeclareGlobalFunction( "StructuralCopy", [IsVectorObj] );
+# DeclareGlobalFunction( "StructuralCopy" );
 
 # DeclareOperation( "ViewObj", [IsVectorObj] );
 
@@ -870,7 +870,7 @@ DeclareOperation( "[]:=", [IsMatrixObj,IsPosInt,IsPosInt,IsObject] );
 # then StructuralCopy will return a new list of vectors, which again contains the
 # same (identical) immutable vectors, and mutable copies of the other vectors.
 # Whereas with MutableCopyMat, all new rows will be mutable
-# DeclareGlobalFunction( "StructuralCopy", [IsMatrixObj] );
+# DeclareGlobalFunction( "StructuralCopy" );
 
 # DeclareOperation( "ViewObj", [IsMatrixObj] );
 

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1856,6 +1856,10 @@ BIND_GLOBAL( "DeclareGlobalFunction", function( arg )
     local   name;
 
     name := arg[1];
+    if LEN_LIST(arg) > 1 then
+        INFO_DEBUG(1, "DeclareGlobalFunction: too many arguments in ",
+            INPUT_FILENAME(), ":", STRING_INT(INPUT_LINENUMBER()));
+    fi;
     atomic GLOBAL_FUNCTION_NAMES do
     ADD_SET( GLOBAL_FUNCTION_NAMES, IMMUTABLE_COPY_OBJ(name) );
     od;
@@ -1865,6 +1869,10 @@ end );
 BIND_GLOBAL( "InstallGlobalFunction", function( arg )
     local   oper,  info,  func;
 
+    if LEN_LIST(arg) > 2  then
+        INFO_DEBUG(1, "InstallGlobalFunction: too many arguments in ",
+            INPUT_FILENAME(), ":", STRING_INT(INPUT_LINENUMBER()));
+    fi;
     if LEN_LIST(arg) = 3  then
         oper := arg[1];
         info := arg[2];

--- a/lib/tuples.gd
+++ b/lib/tuples.gd
@@ -225,5 +225,4 @@ DeclareOperation( "DirectProductElementNC",
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-DeclareGlobalFunction( "DirectProductFamily",
-                       "for a dense list of collection families" );
+DeclareGlobalFunction( "DirectProductFamily" );


### PR DESCRIPTION
The extra argument was never documented for `InstallGlobalFunction`. In
contrast, for `DeclareGlobalFunction`, the documentation for a long time
claimed that it required exactly (!) two arguments, although all
examples only showed one argument, and the documentation never said what
the other argument was supposed to do. Various people then made
differing guesses as to the supposed meaning of the extra arguments:
some put in an info string; some put in a list of input filters; some
just a single filter. This PR removes several of these from the GAP
library itself.

Various packages still use these extra arguments, and loading them will
trigger the warnings. Some already fixed it in their repositories and
just need to make releases. When the time comes for releasing GAP 4.12,
we can see if all packages are adapted, and then depending on that
either turn the warning into an error; or conversely, increase the
warning level to 2, to hide it from regular users who might be confused
by the message.
