### PR TITLE
Fix issue with test outputs which do not end with a newline when using the rewriteToFile option of Test

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -633,6 +633,12 @@ InstallGlobalFunction("Test", function(arg)
       od; 
       if PositionSublist(pf.inp[i], "STOP_TEST") <> 1 then
         Append(new[pf.pos[i]], pf.cmp[i]);
+        if pf.cmp[i] <> "" and Last(pf.cmp[i]) <> '\n' then
+            Info(InfoWarning, 1, "An output in the .tst file does not end with a newline. GAP does not support this.");
+            Info(InfoWarning, 1, "A newline will be inserted to make the file valid, but the test will fail.");
+            Info(InfoWarning, 1, "The location of this problem is marked with '# Newline inserted here'.");
+            Append(new[pf.pos[i]], "# Newline inserted here by 'rewriteToFile'\n");
+        fi;
       fi;
     od;
     new := Concatenation(Compacted(new));


### PR DESCRIPTION
Given a statement in a .tst file which does not end in a newline, rewriteToFile gets very confused, and in particular can "lose" lines of output if run over and over again. This just prints a warning, and inserts a newline.

As an example of the problem, consider this test file:

```
gap> Print(x -> x);
gap> 1;
gap> 2;
gap> 3;
```

Running test with rewriteToFile gives:

```
gap> Print(x->x);
function ( x )
    return x;
endgap> 1;
1
gap> 2;
2
gap> 3;
3
```

Running again on this gives the following, where the `1` has been lost

```
gap> Print(x->x);
function ( x )
    return x;
endgap> 2;
2
gap> 3;
3
```