### PR TITLE
Remove OnPosIntSetsTrans from GAP

### DIFF
--- a/src/trans.cc
+++ b/src/trans.cc
@@ -1038,7 +1038,7 @@ static Obj FuncIMAGE_SET_TRANS(Obj self, Obj f)
 
 // Returns the image set of the transformation f on [1 .. n].
 
-static Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
+Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
 {
     Obj     im, newObj;
     UInt    deg, m, len, i, j, rank;
@@ -3427,76 +3427,6 @@ static Obj FuncINV_KER_TRANS(Obj self, Obj X, Obj f)
     }
 }
 
-// Returns the same value as OnSets(set, f) except if set = [0], when the
-// image
-// set of <f> on [1 .. n] is returned instead. If the argument <set> is not
-// [0], then the third argument is ignored.
-
-static Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
-{
-    const UInt2 * ptf2;
-    const UInt4 * ptf4;
-    const Obj * ptset;
-    UInt    deg;
-    Obj *   ptres, res;
-    UInt    i, k;
-
-    RequireTransformation("OnPosIntSetsTrans", f);
-
-    const UInt len = LEN_LIST(set);
-
-    if (len == 0) {
-        return set;
-    }
-
-    if (len == 1 && INT_INTOBJ(ELM_LIST(set, 1)) == 0) {
-        return FuncIMAGE_SET_TRANS_INT(self, f, n);
-    }
-
-    if (IS_PLIST(set)) {
-        res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST_CYC_SSORT, len);
-        SET_LEN_PLIST(res, len);
-    }
-    else {
-        // input is not a plain list, so we make a copy of it, and then also reuse
-        // that copy for our output
-        res = PLAIN_LIST_COPY(set);
-        if (!IS_MUTABLE_OBJ(set))
-            MakeImmutableNoRecurse(res);
-        set = res;
-    }
-
-    ptset = CONST_ADDR_OBJ(set) + len;
-    ptres = ADDR_OBJ(res) + len;
-
-    if (TNUM_OBJ(f) == T_TRANS2) {
-        ptf2 = CONST_ADDR_TRANS2(f);
-        deg = DEG_TRANS2(f);
-        for (i = len; 1 <= i; i--, ptset--, ptres--) {
-            k = INT_INTOBJ(*ptset);
-            if (k <= deg) {
-                k = ptf2[k - 1] + 1;
-            }
-            *ptres = INTOBJ_INT(k);
-        }
-    }
-    else {
-        ptf4 = CONST_ADDR_TRANS4(f);
-        deg = DEG_TRANS4(f);
-        for (i = len; 1 <= i; i--, ptset--, ptres--) {
-            k = INT_INTOBJ(*ptset);
-            if (k <= deg) {
-                k = ptf4[k - 1] + 1;
-            }
-            *ptres = INTOBJ_INT(k);
-        }
-    }
-    SortPlistByRawObj(res);
-    REMOVE_DUPS_PLIST_INTOBJ(res);
-    RetypeBagSM(res, T_PLIST_CYC_SSORT);
-    return res;
-}
-
 /*******************************************************************************
  *******************************************************************************
  * GAP kernel functions for transformations
@@ -4278,7 +4208,6 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_2ARGS(CYCLES_TRANS_LIST, f, pt),
     GVAR_FUNC_1ARGS(LEFT_ONE_TRANS, f),
     GVAR_FUNC_1ARGS(RIGHT_ONE_TRANS, f),
-    GVAR_FUNC_3ARGS(OnPosIntSetsTrans, set, f, n),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/src/trans.h
+++ b/src/trans.h
@@ -120,6 +120,14 @@ Obj OnSetsTrans(Obj set, Obj f);
 */
 Int HashFuncForTrans(Obj f);
 
+/****************************************************************************
+**
+*F  IMAGE_SET_TRANS_INT( <f>, <n>) . . .
+**
+**  Returns the image set of the transformation f on [1 .. n].
+*/
+
+Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n);
 
 /****************************************************************************
 **

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -2671,63 +2671,6 @@ gap> f := Transformation([2, 6, 7, 2, 6, 9, 9, 1, 1, 5]);;
 gap> OnTuples([1 .. 10], f);
 [ 2, 6, 7, 2, 6, 9, 9, 1, 1, 5 ]
 
-# OnPosIntSetsTrans: for a transformation
-gap> OnPosIntSetsTrans([], Transformation([1, 1]), 0);
-[  ]
-gap> OnPosIntSetsTrans([1, 2], Transformation([1, 1]), 0);
-[ 1 ]
-gap> OnPosIntSetsTrans([1, 2, 10], Transformation([1, 1]), 0);
-[ 1, 10 ]
-gap> OnPosIntSetsTrans([1, 2, 10], Transformation([65535], [65537]), 0);
-[ 1, 2, 10 ]
-gap> OnPosIntSetsTrans([1, 65535, 65538], Transformation([65535], [65537]), 0);
-[ 1, 65537, 65538 ]
-gap> OnPosIntSetsTrans([1, 2, 10, 65537], Transformation([65537], [1]), 0);
-[ 1, 2, 10 ]
-gap> OnPosIntSetsTrans([1, 2, 10, 65535], Transformation([65535], [5]), 0);
-[ 1, 2, 5, 10 ]
-gap> OnPosIntSetsTrans([1 .. 20], 
->                      Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 0);
-[ 1, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
-gap> OnPosIntSetsTrans([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 19, 324, 4124, 123124],
->                      Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 0);
-[ 1, 5, 7, 8, 9, 10, 11, 19, 324, 4124, 123124 ]
-gap> OnPosIntSetsTrans([], Transformation([1, 1]), 10);
-[  ]
-gap> OnPosIntSetsTrans([1, 2], Transformation([1, 1]), 10);
-[ 1 ]
-gap> OnPosIntSetsTrans([1, 2, 10], Transformation([1, 1]), 10);
-[ 1, 10 ]
-gap> OnPosIntSetsTrans([1, 2, 10], Transformation([65535], [65537]), 10);
-[ 1, 2, 10 ]
-gap> OnPosIntSetsTrans([1, 65535, 65538], Transformation([65535], [65537]), 10);
-[ 1, 65537, 65538 ]
-gap> OnPosIntSetsTrans([1, 2, 10, 65537], Transformation([65537], [1]), 12);
-[ 1, 2, 10 ]
-gap> OnPosIntSetsTrans([1, 2, 10, 65535], Transformation([65535], [5]), 130);
-[ 1, 2, 5, 10 ]
-gap> OnPosIntSetsTrans([1 .. 20], 
->                      Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 10);
-[ 1, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
-gap> OnPosIntSetsTrans([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 19, 324, 4124, 123124],
->                      Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 10);
-[ 1, 5, 7, 8, 9, 10, 11, 19, 324, 4124, 123124 ]
-gap> OnPosIntSetsTrans([0],
->           Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 0);
-[  ]
-gap> OnPosIntSetsTrans([0],
->           Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 10);
-[ 1, 5, 7, 8, 9, 10 ]
-gap> OnPosIntSetsTrans([0],
->           Transformation([10, 7, 10, 8, 8, 7, 5, 9, 1, 9]), 20);
-[ 1, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
-gap> OnPosIntSetsTrans([1], "a", 20);
-Error, OnPosIntSetsTrans: <f> must be a transformation (not a list (string))
-gap> OnPosIntSetsTrans([0], "a", 20);
-Error, OnPosIntSetsTrans: <f> must be a transformation (not a list (string))
-gap> OnPosIntSetsTrans(1, "a", 20);
-Error, OnPosIntSetsTrans: <f> must be a transformation (not a list (string))
-
 # MarkSubbags2
 gap> f := Transformation([2, 2, 4, 2, 8, 5, 10, 10, 4, 3, 9, 9]);;
 gap> ImageSetOfTransformation(f);


### PR DESCRIPTION
# Description
This PR removes the kernel function `OnPosIntSetsTrans` from GAP as requested by @fingolfin here:

https://github.com/gap-packages/Semigroups/issues/623


## Text for release notes 

None: this function is not documented or used anywhere outside the Semigroups package. 

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

