### PR TITLE
Increment kernel major version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -556,7 +556,7 @@ dnl Define kernel version
 dnl
 
 
-gap_kernel_major_version=7
+gap_kernel_major_version=8
 gap_kernel_minor_version=0
 AC_SUBST([gap_kernel_major_version])
 AC_SUBST([gap_kernel_minor_version])


### PR DESCRIPTION
This way, code which wants to check for GAP 4.12 kernel features
can differentiate it from GAP 4.11

This is motivated by PR #3699 resp. https://github.com/gap-packages/Semigroups/pull/625