### PR TITLE
Make TmpNameAllArchs obsolete by enhancing TmpName

### DIFF
--- a/lib/files.gd
+++ b/lib/files.gd
@@ -477,14 +477,6 @@ BIND_GLOBAL( "DirectoryTemporary", function( arg )
   if dir = fail  then
     return fail;
   fi;
-  if ARCH_IS_WINDOWS() then
-    # We want to deliver a Windows path
-    if dir{[1..10]} = "/cygdrive/" then
-        drive := dir[11];
-        dir := Concatenation("C:",dir{[12..Length(dir)]});
-        dir[1] := drive;
-    fi;
-  fi;
 
   # remember directory name
   Add( GAPInfo.DirectoriesTemporary, dir );

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -1028,3 +1028,12 @@ end );
 ##
 BindGlobal("R_N", fail);
 BindGlobal("R_X", fail);
+
+
+
+#############################################################################
+##
+#F  TmpNameAllArchs( )
+##
+##  Still used in guava (10/2019)
+DeclareObsoleteSynonym( "TmpNameAllArchs", "TmpName" );

--- a/lib/process.gd
+++ b/lib/process.gd
@@ -153,15 +153,6 @@ DeclareOperation( "Process",
 
 #############################################################################
 ##
-#F  TmpNameAllArchs( )
-##
-##  returns a temporary file name based on the output of a call to TmpName
-##  but with adjusted temporary directory path for Window architectures
-##
-DeclareGlobalFunction("TmpNameAllArchs");
-
-#############################################################################
-##
 #F  Exec( <cmd>, <option1>, ..., <optionN> )  . . . . . . . execute a command
 ##
 ##  <#GAPDoc Label="Exec">

--- a/lib/process.gi
+++ b/lib/process.gi
@@ -170,7 +170,7 @@ function( dir, prg, input, output, args )
 	  PROCESS_INPUT_TEMPORARY:=fail;
 	fi;
         while PROCESS_INPUT_TEMPORARY = fail do
-            PROCESS_INPUT_TEMPORARY := TmpNameAllArchs();
+            PROCESS_INPUT_TEMPORARY := TmpName();
         od;
 	name_input := PROCESS_INPUT_TEMPORARY;
         new := OutputTextFile( name_input, true );
@@ -191,7 +191,7 @@ function( dir, prg, input, output, args )
 	  PROCESS_OUTPUT_TEMPORARY:=fail;
 	fi;
         while PROCESS_OUTPUT_TEMPORARY = fail do
-            PROCESS_OUTPUT_TEMPORARY := TmpNameAllArchs();
+            PROCESS_OUTPUT_TEMPORARY := TmpName();
         od;
         name_output := PROCESS_OUTPUT_TEMPORARY;
         new_output  := OutputTextFile( name_output, true );
@@ -224,24 +224,6 @@ function( dir, prg, input, output, args )
 
 end );
 
-#############################################################################
-##
-#F  TmpNameAllArchs( )
-##
-InstallGlobalFunction( TmpNameAllArchs, function( )
-    local filename, a;
-
-    filename := TmpName( );
-    if ARCH_IS_WINDOWS( ) then
-        # replace leading /tmp/ by C:/WINDOWS/Temp/
-        a := SplitString(filename, "/");
-        a := a[Length(a)]; # is "/tmp/gaptempfile.kS4uyj", get rid of /tmp/ bit
-
-        filename := Concatenation("C:/WINDOWS/Temp/", a);
-    fi;
-
-    return filename;
-end);
 
 #############################################################################
 ##

--- a/src/streams.c
+++ b/src/streams.c
@@ -1038,7 +1038,11 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 */
 static Obj FuncTmpName(Obj self)
 {
+#ifdef SYS_IS_CYGWIN32
+    char name[] = "C:/WINDOWS/Temp/gaptempfile.XXXXXX";
+#else
     char name[] = "/tmp/gaptempfile.XXXXXX";
+#endif
     close(mkstemp(name));
     return MakeString(name);
 }
@@ -1058,7 +1062,7 @@ static Obj FuncTmpDirectory(Obj self)
     }
     else {
 #ifdef SYS_IS_CYGWIN32
-        strxcpy(name, "/cygdrive/c/WINDOWS/Temp/", sizeof(name));
+        strxcpy(name, "C:/WINDOWS/Temp/", sizeof(name));
 #else
         strxcpy(name, "/tmp/", sizeof(name));
 #endif

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -8,7 +8,7 @@ gap> CLOSE_LOG_TO();
 Error, LogTo: can not close the logfile
 gap> LOG_TO(fail);
 Error, LogTo: <filename> must be a string (not the value 'fail')
-gap> LOG_TO(TmpNameAllArchs());
+gap> LOG_TO(TmpName());
 true
 gap> CLOSE_LOG_TO();
 true
@@ -25,7 +25,7 @@ gap> CLOSE_INPUT_LOG_TO();
 Error, InputLogTo: can not close the logfile
 gap> INPUT_LOG_TO(fail);
 Error, InputLogTo: <filename> must be a string (not the value 'fail')
-gap> INPUT_LOG_TO(TmpNameAllArchs());
+gap> INPUT_LOG_TO(TmpName());
 true
 gap> CLOSE_INPUT_LOG_TO();
 true
@@ -42,7 +42,7 @@ gap> CLOSE_OUTPUT_LOG_TO();
 Error, OutputLogTo: can not close the logfile
 gap> OUTPUT_LOG_TO(fail);
 Error, OutputLogTo: <filename> must be a string (not the value 'fail')
-gap> OUTPUT_LOG_TO(TmpNameAllArchs());
+gap> OUTPUT_LOG_TO(TmpName());
 true
 gap> CLOSE_OUTPUT_LOG_TO();
 true


### PR DESCRIPTION
Back in 2011, a new library function `TmpNameAllArchs` was added which wraps the kernel function `TmpName` and adds some Windows specific sauce to it. This PR enhances `TmpName` so that `TmpNameAllArchs` can be turned into a simple synonym for `TmpName`. It does so by aligning the code of `FuncTmpName` and `FuncTmpDirectory` more closely. (They still differ in that the latter honors the the `TMPDIR` env var, the former does not; we might want to change that, but I didn't want to make too big a change in one go.

There is another difference between the old and new code: the old used `C:/WINDOWS/Temp/`, the new uses `/cygdrive/c/WINDOWS/Temp/`. I *hope* that doesn't matter or even is an improvement, *but* it would be really good if somebody with Windows access could verify that (beyond what little the tests in our test suite do).

Resolves #3328

The other change in this PR is the removal of the library function `ShortFileNameWindows` which @hulpke added in 2009 but which hasn't ever been used by GAP or any package, as far as I can tell. It's also undocumented, and it seems not so useful to access 8.3 filenames these days. But perhaps I am mistaken, and there are usecases (in particular, I have no idea what the motivation for adding it back then was).
