### PR TITLE
kernel: remove last uses of ErrorReturnObj

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -1007,8 +1007,8 @@ brk> GetRecursionDepth();
 0
 brk> return;
 gap> SetRecursionTrapInterval(-1);
-SetRecursionTrapInterval( <interval> ): <interval> must be a non-negative smal\
-l integer
+Error, SetRecursionTrapInterval: <interval> must be a small integer greater than 5 (n\
+ot the integer -1)
 not in any function
 Entering break read-eval-print loop ...
 you can 'quit;' to quit to outer loop, or

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -801,11 +801,9 @@ void ExecEnd(UInt error)
 
 static Obj FuncSetRecursionTrapInterval(Obj self, Obj interval)
 {
-    while (!IS_INTOBJ(interval) || INT_INTOBJ(interval) <= 5)
-        interval = ErrorReturnObj(
-            "SetRecursionTrapInterval( <interval> ): "
-            "<interval> must be a small integer greater than 5",
-            0L, 0L, "you can replace <interval> via 'return <interval>;'");
+    if (!IS_INTOBJ(interval) || INT_INTOBJ(interval) <= 5)
+        RequireArgument("SetRecursionTrapInterval", interval,
+            "must be a small integer greater than 5");
     RecursionTrapInterval = INT_INTOBJ(interval);
     return 0;
 }

--- a/src/gap.c
+++ b/src/gap.c
@@ -643,24 +643,18 @@ static Obj FuncSizeScreen(Obj self, Obj args)
   }
   else {
     elm = ELMW_LIST(size,1);
-    if (!IS_INTOBJ(elm)) {
-        ErrorMayQuit("SizeScreen: <x> must be an integer", 0, 0);
-    }
-    len = INT_INTOBJ( elm );
+    len = GetSmallIntEx("SizeScreen", elm, "<x>");
     if ( len < 20  )  len = 20;
     if ( MAXLENOUTPUTLINE < len )  len = MAXLENOUTPUTLINE;
   }
 
   /* extract the number                                                  */
-  if ( LEN_LIST(size) < 2 || ELM0_LIST(size,2) == 0 ) {
+  elm = ELM0_LIST(size, 2);
+  if ( elm == 0 ) {
     nr = 0;
   }
   else {
-    elm = ELMW_LIST(size,2);
-    if (!IS_INTOBJ(elm)) {
-        ErrorMayQuit("SizeScreen: <y> must be an integer", 0, 0);
-    }
-    nr = INT_INTOBJ( elm );
+    nr = GetSmallIntEx("SizeScreen", elm, "<y>");
     if ( nr < 10 )  nr = 10;
   }
 

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -634,9 +634,6 @@ static Obj ProdVecFFEVecFFE(Obj vecL, Obj vecR)
 *F  FuncADD_ROWVECTOR_VECFFES_3( <self>, <vecL>, <vecR>, <mult> )
 **
 */
-
-static Obj AddRowVectorOp;   /* BH changed to static */
-
 static Obj FuncADD_ROWVECTOR_VECFFES_3(Obj self, Obj vecL, Obj vecR, Obj mult)
 {
     Obj *ptrL;
@@ -662,16 +659,9 @@ static Obj FuncADD_ROWVECTOR_VECFFES_3(Obj self, Obj vecL, Obj vecR, Obj mult)
     if (!IsVecFFE(vecR))
         return TRY_NEXT_METHOD;
 
-
     /* check the lengths                                                   */
+    CheckSameLength("AddRowVector", "dst", "src", vecL, vecR);
     len = LEN_PLIST(vecL);
-    if (len != LEN_PLIST(vecR)) {
-        vecR = ErrorReturnObj(
-            "AddRowVector: vector lengths differ <left> %d,  <right> %d",
-            (Int)len, (Int)LEN_PLIST(vecR),
-            "you can replace vector <right> via 'return <right>;'");
-        return CALL_3ARGS(AddRowVectorOp, vecL, vecR, mult);
-    }
 
     /* check the fields                                                    */
     fld = FLD_FFE(ELM_PLIST(vecL, 1));
@@ -680,22 +670,14 @@ static Obj FuncADD_ROWVECTOR_VECFFES_3(Obj self, Obj vecL, Obj vecR, Obj mult)
         if (CHAR_FF(fld) == CHAR_FF(FLD_FFE(ELM_PLIST(vecR, 1))))
             return TRY_NEXT_METHOD;
 
-        vecR = ErrorReturnObj(
-            "AddRowVector: vectors have different fields",
-            0L, 0L,
-            "you can replace vector <right> via 'return <right>;'");
-        return CALL_3ARGS(AddRowVectorOp, vecL, vecR, mult);
+        ErrorMayQuit("AddRowVector: vectors have different fields", 0, 0);
     }
 
     /* Now check the multiplier field */
     if (FLD_FFE(mult) != fld) {
         /* check the characteristic                                        */
         if (CHAR_FF(fld) != CHAR_FF(FLD_FFE(mult))) {
-            mult = ErrorReturnObj(
-                "AddRowVector: <multiplier> has different field",
-                0L, 0L,
-                "you can replace <multiplier> via 'return <multiplier>;'");
-            return CALL_3ARGS(AddRowVectorOp, vecL, vecR, mult);
+            ErrorMayQuit("AddRowVector: <multiplier> has different field", 0, 0);
         }
 
         /* if the multiplier is over a non subfield then redispatch */
@@ -738,8 +720,6 @@ static Obj FuncADD_ROWVECTOR_VECFFES_3(Obj self, Obj vecL, Obj vecR, Obj mult)
 **
 */
 
-static Obj MultVectorLeftOp; /* BH changed to static */
-
 static Obj FuncMULT_VECTOR_VECFFES(Obj self, Obj vec, Obj mult)
 {
     Obj *ptr;
@@ -768,11 +748,7 @@ static Obj FuncMULT_VECTOR_VECFFES(Obj self, Obj vec, Obj mult)
     if (FLD_FFE(mult) != fld) {
         /* check the characteristic                                        */
         if (CHAR_FF(fld) != CHAR_FF(FLD_FFE(mult))) {
-            mult = ErrorReturnObj(
-                "MultVector: <multiplier> has different field",
-                0L, 0L,
-                "you can replace <multiplier> via 'return <multiplier>;'");
-            return CALL_2ARGS(MultVectorLeftOp, vec, mult);
+            ErrorMayQuit("MultVector: <multiplier> has different field", 0, 0);
         }
 
         /* if the multiplier is over a non subfield then redispatch */
@@ -830,14 +806,8 @@ static Obj FuncADD_ROWVECTOR_VECFFES_2(Obj self, Obj vecL, Obj vecR)
         return TRY_NEXT_METHOD;
 
     /* check the lengths                                                   */
+    CheckSameLength("AddRowVector", "dst", "src", vecL, vecR);
     len = LEN_PLIST(vecL);
-    if (len != LEN_PLIST(vecR)) {
-        vecR = ErrorReturnObj(
-            "Vector *: vector lengths differ <left> %d,  <right> %d",
-            (Int)len, (Int)LEN_PLIST(vecR),
-            "you can replace vector <right> via 'return <right>;'");
-        return CALL_2ARGS(AddRowVectorOp, vecL, vecR);
-    }
 
     /* check the fields                                                    */
     fld = FLD_FFE(ELM_PLIST(vecL, 1));
@@ -846,11 +816,7 @@ static Obj FuncADD_ROWVECTOR_VECFFES_2(Obj self, Obj vecL, Obj vecR)
         if (CHAR_FF(fld) == CHAR_FF(FLD_FFE(ELM_PLIST(vecR, 1))))
             return TRY_NEXT_METHOD;
 
-        vecR = ErrorReturnObj(
-            "AddRowVector: vectors have different fields",
-            0L, 0L,
-            "you can replace vector <right> via 'return <right>;'");
-        return CALL_2ARGS(AddRowVectorOp, vecL, vecR);
+        ErrorMayQuit("AddRowVector: vectors have different fields", 0, 0);
     }
 
     succ = SUCC_FF(fld);
@@ -929,8 +895,11 @@ static Obj FuncSMALLEST_FIELD_VECFFE(Obj self, Obj vec)
 {
     Obj elm;
     UInt deg, deg1, deg2, i, len, p, q;
-    UInt isVecFFE = IsVecFFE(vec);
-    len  = LEN_PLIST(vec);
+    UInt isVecFFE;
+    if (!IS_PLIST(vec))
+        return Fail;
+    isVecFFE = IsVecFFE(vec);
+    len = LEN_PLIST(vec);
     if (len == 0)
         return Fail;
     elm = ELM_PLIST(vec, 1);
@@ -1008,7 +977,6 @@ static Int InitKernel (
 
     InitHdlrFuncsFromTable(GVarFuncs);
 
-    InitFopyGVar("AddRowVector", &AddRowVectorOp);
     /* return success                                                      */
     return 0;
 }

--- a/tst/testinstall/kernel/funcs.tst
+++ b/tst/testinstall/kernel/funcs.tst
@@ -1,3 +1,3 @@
 gap> SetRecursionTrapInterval(fail);
-Error, SetRecursionTrapInterval( <interval> ): <interval> must be a small inte\
-ger greater than 5
+Error, SetRecursionTrapInterval: <interval> must be a small integer greater th\
+an 5 (not the value 'fail')

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -49,9 +49,9 @@ Error, SizeScreen: number of arguments must be 0 or 1 (not 2)
 gap> SizeScreen(100);
 Error, SizeScreen: <size> must be a list of length at most 2
 gap> SizeScreen([fail,fail]);
-Error, SizeScreen: <x> must be an integer
+Error, SizeScreen: <x> must be a small integer (not the value 'fail')
 gap> SizeScreen([100,fail]);
-Error, SizeScreen: <y> must be an integer
+Error, SizeScreen: <y> must be a small integer (not the value 'fail')
 
 #
 gap> WindowCmd(fail);

--- a/tst/testinstall/kernel/vecffe.tst
+++ b/tst/testinstall/kernel/vecffe.tst
@@ -1,0 +1,139 @@
+#
+# Tests for functions defined in src/vecffe.c
+#
+gap> START_TEST("kernel/vecffe.tst");
+
+#
+# ADD_ROWVECTOR_VECFFES_3
+#
+gap> ADD_ROWVECTOR_VECFFES_3(fail, fail, fail);
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_3(fail, fail, 0*Z(2));
+gap> ADD_ROWVECTOR_VECFFES_3([1], fail, Z(2));
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_3(fail, [1], Z(2));
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_3([1], [1], Z(2));
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_3([Z(3)], [Z(3), Z(3)], Z(3));
+Error, AddRowVector: <dst> must have the same length as <src> (lengths are 1 a\
+nd 2)
+gap> ADD_ROWVECTOR_VECFFES_3([Z(3)], [Z(2)], Z(3));
+Error, AddRowVector: vectors have different fields
+gap> ADD_ROWVECTOR_VECFFES_3([Z(3)], [Z(9)], Z(3));
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_3([Z(3)], [Z(3)], Z(2));
+Error, AddRowVector: <multiplier> has different field
+gap> v:=[Z(3)];; ADD_ROWVECTOR_VECFFES_3(v, v, Z(3)^0);
+gap> v;
+[ Z(3)^0 ]
+gap> v:=[Z(9)];; ADD_ROWVECTOR_VECFFES_3(v, v, Z(3)^0);
+gap> v;
+[ Z(3^2)^5 ]
+
+#
+# MULT_VECTOR_VECFFES
+#
+gap> MULT_VECTOR_VECFFES(fail, fail);
+"TRY_NEXT_METHOD"
+gap> MULT_VECTOR_VECFFES(fail, 0);
+"TRY_NEXT_METHOD"
+gap> MULT_VECTOR_VECFFES(fail, 0*Z(2));
+"TRY_NEXT_METHOD"
+gap> MULT_VECTOR_VECFFES([1], 0*Z(2));
+"TRY_NEXT_METHOD"
+gap> MULT_VECTOR_VECFFES([Z(3)], 0*Z(2));
+Error, MultVector: <multiplier> has different field
+gap> v:=[Z(3)];; MULT_VECTOR_VECFFES(v, Z(3));
+gap> v;
+[ Z(3)^0 ]
+gap> v:=[Z(9)];; MULT_VECTOR_VECFFES(v, Z(3));
+gap> v;
+[ Z(3^2)^5 ]
+gap> v:=[Z(9)];; MULT_VECTOR_VECFFES(v, 0*Z(3));
+gap> v;
+[ 0*Z(3) ]
+
+#
+# ADD_ROWVECTOR_VECFFES_2
+#
+gap> ADD_ROWVECTOR_VECFFES_2(fail, fail);
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_2(fail, fail);
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_2([1], fail);
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_2(fail, [1]);
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_2([1], [1]);
+"TRY_NEXT_METHOD"
+gap> ADD_ROWVECTOR_VECFFES_2([Z(3)], [Z(3), Z(3)]);
+Error, AddRowVector: <dst> must have the same length as <src> (lengths are 1 a\
+nd 2)
+gap> ADD_ROWVECTOR_VECFFES_2([Z(3)], [Z(2)]);
+Error, AddRowVector: vectors have different fields
+gap> ADD_ROWVECTOR_VECFFES_2([Z(3)], [Z(9)]);
+"TRY_NEXT_METHOD"
+gap> v:=[Z(3)];; ADD_ROWVECTOR_VECFFES_2(v, v);
+gap> v;
+[ Z(3)^0 ]
+
+#
+# IS_VECFFE
+#
+gap> IS_VECFFE(fail);
+false
+gap> IS_VECFFE([]);
+false
+gap> IS_VECFFE([1]);
+false
+gap> IS_VECFFE([Z(2), Z(3)]);
+false
+gap> IS_VECFFE([Z(2), Z(4)]);
+false
+gap> IS_VECFFE([Z(3)]);
+true
+
+# ensure we get to test a T_PLIST_FFE
+gap> v:=[Z(2)];;
+gap> TNAM_OBJ(v);
+"plain list"
+gap> IS_VECFFE(v); # this retypes the plist to T_PLIST_FFE
+true
+gap> TNAM_OBJ(v);
+"plain list of small finite field elements"
+gap> IS_VECFFE(v);
+true
+
+#
+# COMMON_FIELD_VECFFE
+#
+gap> COMMON_FIELD_VECFFE(fail);
+fail
+gap> COMMON_FIELD_VECFFE([Z(3)]);
+3
+gap> COMMON_FIELD_VECFFE([Z(4), Z(4)^2]);
+4
+gap> COMMON_FIELD_VECFFE([Z(4), Z(8)]);
+fail
+
+#
+# SMALLEST_FIELD_VECFFE
+#
+gap> SMALLEST_FIELD_VECFFE(fail);
+fail
+gap> SMALLEST_FIELD_VECFFE([]);
+fail
+gap> SMALLEST_FIELD_VECFFE([1]);
+fail
+gap> SMALLEST_FIELD_VECFFE([Z(2)]);
+2
+gap> SMALLEST_FIELD_VECFFE([Z(2), Z(3)]);
+fail
+gap> SMALLEST_FIELD_VECFFE([Z(2), Z(4)]);
+4
+gap> SMALLEST_FIELD_VECFFE([Z(8), Z(4)]);
+64
+
+#
+gap> STOP_TEST("kernel/vecffe.tst", 1);


### PR DESCRIPTION
A few package still use `ErrorReturnObj`, though:
- Browse
- io (see https://github.com/gap-packages/io/commit/2130f337e930d12bf74d42ab5480f32ac8a2a654) 
- float (see https://github.com/gap-packages/float/pull/50)
- img (see https://github.com/gap-packages/img/pull/20)

I will send patches to the respective package owner (or, in the case of io, apply that myself).

This PR also tweaks `FuncSizeScreen` to use `GetSmallIntEx`