### PR TITLE
Two workarounds for old issues.

### DIFF
--- a/benchmark/grpauto/permiso.tst
+++ b/benchmark/grpauto/permiso.tst
@@ -2,6 +2,8 @@
 ##
 ## Warning: most of the later tests need more than the default memory allocation
 
+gap> SetAssertionLevel(0);;
+
 #
 # Too hard work for permiso
 #

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -1054,7 +1054,7 @@ local clT,	# classes T
     Info(InfoHomClass,1,"fused to ",Length(newreps)," classes");
   od;
   
-  Assert(2,Sum(clout,i->Index(F,i[2]))=Size(F)-Size(M));
+  if Sum(clout,i->Index(F,i[2]))<>Size(F)-Size(M) then return fail;fi;
 
   Info(InfoHomClass,2,Length(clin)," inner classes, total size =",
         Sum(clin,i->Index(F,i[2])));


### PR DESCRIPTION
as the default assertions completely distort the cost -- all time is wasted
on checking homomorphism properties again and again.

This resolves #3533


