### PR TITLE
kernel: change TNAM for weak pointer objects

### DIFF
--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -811,8 +811,8 @@ static void LoadWPObj(Obj wpobj)
 *V  BagNames  . . . . . . . . . . . . . . . . . . . . . . . list of bag names
 */
 static StructBagNames BagNames[] = {
-  { T_WPOBJ,                          "object (weakptr)"               },
-  { -1,                               ""                               }
+  { T_WPOBJ, "weak pointer object" },
+  { -1,      ""                    }
 };
 
 


### PR DESCRIPTION
This completes the change of TNAMs to more human readable versions (see PR #3394 and PR #3692 for previous work).