### PR TITLE
Two corrections in recently changed code

### DIFF
--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3367,7 +3367,7 @@ local d,ind,i,ma,ab,a,p,b,c,e,n;
   ma:=NaturalHomomorphismByNormalSubgroup(G,d);
   a:=Image(ma,G);
   ab:=AbelianInvariants(a);
-  if Length(Set(ab))>1 then
+  if ForAny(ab,x->not IsPrimeInt(x)) then
     e:=LogInt(Exponent(a),p);
     b:=fail;
     i:=1;
@@ -3393,7 +3393,8 @@ local d,ind,i,ma,ab,a,p,b,c,e,n;
   fi;
   n:=Normalizer(P,G);
   ab:=ModuloPcgs(G,d);
-  a:=GModuleByMats(LinearActionLayer(n,ab),GF(p));
+  a:=LinearActionLayer(n,ab);
+  a:=GModuleByMats(a,GF(p));
   if not MTX.IsIrreducible(a) then
     b:=ShallowCopy(MTX.BasesMaximalSubmodules(a));
     SortBy(b,Length);

--- a/lib/matint.gi
+++ b/lib/matint.gi
@@ -1127,6 +1127,11 @@ local n,zero,nv,new,pip,piv,i,v,p,w,g,nov,pin,now,rat,extra,clean,assign,try;
 
   od;
 
-  return Filtered(Concatenation(mat,new),x->not IsZero(x));
+  mat:=Filtered(Concatenation(mat,new),x->not IsZero(x));
+
+  # need to keep one line.
+  if Length(mat)=0 then mat:=[zero];fi;
+
+  return mat;
 
 end);

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -256,7 +256,8 @@ gap> g:=PerfectGroup(IsPermGroup,3840,1);;
 gap> cf:=IrreducibleModules(g,GF(2),0)[2];;
 gap> List(cf,x->x.dimension);
 [ 1, 4, 4 ]
-gap> coh:=TwoCohomologyGeneric(g,cf[2]);;
+gap> pos:=PositionProperty(cf,x->Size(MTX.ModuleAutomorphisms(x))=3);;
+gap> coh:=TwoCohomologyGeneric(g,cf[pos]);;
 gap> Length(coh.cohomology);
 2
 gap> e:=Elements(VectorSpace(GF(2),coh.cohomology));;


### PR DESCRIPTION
These are two fixes of (stupid, and they are mine) bugs in recently changed (4.11) code, both of which cause subsequent code to give error messages. While I ran into both I don't have easy examples to test the situation. The errors are:

a) In BoundedIndexAbelianized the test for being elementary was wrong.
b) `ReducedRelationMat` could delete the whole matrix (if it was 0), resulting in a subsequent error for lack of columns.
c) Also changed is an example imn testextra that was not spotted before (but now was noted in #3702)

