### PR TITLE
kernel: include hpc/guards.h in compiled.h

### DIFF
--- a/src/compiled.h
+++ b/src/compiled.h
@@ -78,6 +78,7 @@ extern "C" {
 
 #ifdef HPCGAP
 #include "hpc/aobjects.h"
+#include "hpc/guards.h"
 #include "hpc/serialize.h"
 #include "hpc/threadapi.h"
 #include "hpc/traverse.h"


### PR DESCRIPTION
... so that packages such as ZeroMQInterface can use guards in their
kernel extensions without including additional headers.

This unbreaks `ZeroMQInterface` compiled against HPC-GAP, and should be backported to 4.11