### PR TITLE
Adjust TestPackage to return info about test result

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -980,14 +980,14 @@ InstallGlobalFunction( "TestPackage", function(pkgname)
 local testfile, str;
 if not IsBound( GAPInfo.PackagesInfo.(pkgname) ) then
     Print("#I  No package with the name ", pkgname, " is available\n");
-    return;
+    return fail;
 elif LoadPackage( pkgname ) = fail then
     Print( "#I ", pkgname, " package can not be loaded\n" );
-    return;
+    return fail;
 elif not IsBound( GAPInfo.PackagesInfo.(pkgname)[1].TestFile ) then
     Print("#I No standard tests specified in ", pkgname, " package, version ",
           GAPInfo.PackagesInfo.(pkgname)[1].Version,  "\n");
-    return;
+    return fail;
 else
     testfile := Filename( DirectoriesPackageLibrary( pkgname, "" ), 
                           GAPInfo.PackagesInfo.(pkgname)[1].TestFile );
@@ -995,21 +995,31 @@ else
     if not IsString( str ) then
         Print( "#I Test file `", testfile, "' for package `", pkgname, 
         " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, " is not readable\n" );
-        return;
+        return fail;
     fi;
     if EndsWith(testfile,".tst") then
         if Test( testfile, rec(compareFunction := "uptowhitespace") ) then
             Print( "#I  No errors detected while testing package ", pkgname,
                    " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, 
                    "\n#I  using the test file `", testfile, "'\n");
+            return true;
         else
             Print( "#I  Errors detected while testing package ", pkgname, 
                    " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, 
                    "\n#I  using the test file `", testfile, "'\n");
+            return false;
         fi;
     elif not READ( testfile ) then
         Print( "#I Test file `", testfile, "' for package `", pkgname,
         " version ", GAPInfo.PackagesInfo.(pkgname)[1].Version, " is not readable\n" );
+        return fail;
+    else
+        # At this point, the READ succeeded, but we have no idea what the
+        # outcome of that test was. Hopefully, that file printed a message of
+        # its own and then terminated GAP with a suitable error code (e.g. by
+        # using TestDirectory with exitGAP:=true); in that case we never get
+        # here and all is fine.
+        return fail;
     fi;
 fi;
 end);


### PR DESCRIPTION
... at least where possible; the value `true` indicates success, `false` means
that tests were run but failed, and `fail` that there was an error, e.g. no
tests were found or it was not possible tor run them.

This contains code which is contained in several repositories under https://github.com/gap-infra/ such as here: https://github.com/gap-infra/gap-docker-pkg-tests-master-devel/blob/master/ci.g

We could backport this to stable-4.11 -- or are there concerns about that?