### PR TITLE
README.md: link Travis build status button to Travis "build history" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis build Status](https://travis-ci.org/gap-system/gap.svg?branch=master)](https://travis-ci.org/gap-system/gap)
+[![Travis build Status](https://travis-ci.org/gap-system/gap.svg?branch=master)](https://travis-ci.org/gap-system/gap/builds)
 [![AppVeyor build Status](https://ci.appveyor.com/api/projects/status/github/gap-system/gap?branch=master&svg=true)](https://ci.appveyor.com/project/gap-system/gap)
 [![Code Coverage](https://codecov.io/github/gap-system/gap/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-system/gap)
 [![Coverage Status](https://coveralls.io/repos/github/gap-system/gap/badge.svg)](https://coveralls.io/github/gap-system/gap)


### PR DESCRIPTION
I find the behaviour of the Travis "build status" button in the `README` a little weird: the displayed status corresponds to the most recent build from the `master` branch, but clicking the button takes you to the single most recent job, no matter what branch it was from; it is often a pull request.

In particular, there is often a mismatch between the displayed build status of the button, and the build status of the most recent Travis job. I don't like this.

Instead, I think we should link directly to the Travis "build history" page, which shows the list of most recent builds for branches actually on the `gap-system/gap` repository. Almost always therefore, it shows that most recent `master` and `stable-4.11` builds, and so the build button shows that something is wrong, clicking the link now will almost always take you to somewhere where you can immediately see which build has failed.