### PR TITLE
Add tracing and counting of built-in operations

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -100,6 +100,7 @@ SOURCES += src/sysfiles.c
 SOURCES += src/sysmem.c
 SOURCES += src/system.c
 SOURCES += src/tietze.c
+SOURCES += src/tracing.c
 SOURCES += src/trans.cc
 SOURCES += src/vars.c
 SOURCES += src/vec8bit.c

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -87,6 +87,7 @@ afterwards.
 <#Include Label="UntraceMethods">
 <#Include Label="UntraceAllMethods">
 <#Include Label="TraceImmediateMethods">
+<#Include Label="TraceInternalMethods">
 
 </Section>
 

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -16,7 +16,7 @@
 #include "error.h"
 #include "modules.h"
 #include "opers.h"
-
+#include "tracing.h"
 
 #define RequireValue(funcname, val)                                          \
     do {                                                                     \
@@ -1357,6 +1357,44 @@ static void InstallModObject ( Int verb )
     }
 }
 
+DEFINE_OP_WRAPPER1(ZeroFuncs);
+DEFINE_OP_WRAPPER1(ZeroMutFuncs);
+DEFINE_OP_WRAPPER1(AInvFuncs);
+DEFINE_OP_WRAPPER1(AInvMutFuncs);
+DEFINE_OP_WRAPPER1(OneFuncs);
+DEFINE_OP_WRAPPER1(OneMutFuncs);
+DEFINE_OP_WRAPPER1(InvFuncs);
+DEFINE_OP_WRAPPER1(InvMutFuncs);
+
+DEFINE_OP_WRAPPER2(SumFuncs);
+DEFINE_OP_WRAPPER2(DiffFuncs);
+DEFINE_OP_WRAPPER2(ProdFuncs);
+DEFINE_OP_WRAPPER2(QuoFuncs);
+DEFINE_OP_WRAPPER2(LQuoFuncs);
+DEFINE_OP_WRAPPER2(PowFuncs);
+DEFINE_OP_WRAPPER2(CommFuncs);
+DEFINE_OP_WRAPPER2(ModFuncs);
+
+static void InstallArithWrappers(void)
+{
+    INSTALL_OP_WRAPPER(ZeroFuncs);
+    INSTALL_OP_WRAPPER(ZeroMutFuncs);
+    INSTALL_OP_WRAPPER(AInvFuncs);
+    INSTALL_OP_WRAPPER(AInvMutFuncs);
+    INSTALL_OP_WRAPPER(OneFuncs);
+    INSTALL_OP_WRAPPER(InvFuncs);
+    INSTALL_OP_WRAPPER(OneMutFuncs);
+    INSTALL_OP_WRAPPER(InvMutFuncs);
+
+    INSTALL_OP_WRAPPER(SumFuncs);
+    INSTALL_OP_WRAPPER(DiffFuncs);
+    INSTALL_OP_WRAPPER(ProdFuncs);
+    INSTALL_OP_WRAPPER(QuoFuncs);
+    INSTALL_OP_WRAPPER(LQuoFuncs);
+    INSTALL_OP_WRAPPER(PowFuncs);
+    INSTALL_OP_WRAPPER(CommFuncs);
+    INSTALL_OP_WRAPPER(ModFuncs);
+}
 
 /****************************************************************************
 **
@@ -1463,6 +1501,8 @@ static Int InitKernel (
     /* init filters and functions                                          */
     InitHdlrOpersFromTable( GVarOpers );
     InitHdlrFuncsFromTable( GVarFuncs );
+
+    InstallArithWrappers();
 
     /* make and install the 'ZERO' arithmetic operation                    */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {

--- a/src/ariths.h
+++ b/src/ariths.h
@@ -173,6 +173,7 @@ extern ArithMethod1 OneFuncs[LAST_REAL_TNUM + 1];
 EXPORT_INLINE Obj ONE(Obj op)
 {
     UInt tnum = TNUM_OBJ(op);
+
     return (*OneFuncs[tnum])(op);
 }
 

--- a/src/modules_builtin.c
+++ b/src/modules_builtin.c
@@ -21,6 +21,7 @@
 #include "objset.h"
 #include "profile.h"
 #include "syntaxtree.h"
+#include "tracing.h"
 #include "vec8bit.h"
 #include "vecffe.h"
 #include "vecgf2.h"
@@ -44,95 +45,57 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
     InitInfoObjects,
 
     /* profiling and interpreter hooking information */
-    InitInfoProfile,
-    InitInfoHookIntrprtr,
+    InitInfoProfile, InitInfoHookIntrprtr, InitInfoTracing,
 
     /* scanner, reader, interpreter, coder, caller, compiler               */
-    InitInfoIO,
-    InitInfoScanner,
-    InitInfoRead,
-    InitInfoCalls,
-    InitInfoExprs,
-    InitInfoStats,
-    InitInfoCode,
-    InitInfoVars,       /* must come after InitExpr and InitStats */
-    InitInfoFuncs,
-    InitInfoOpers,
-    InitInfoInfo,
-    InitInfoIntrprtr,
+    InitInfoIO, InitInfoScanner, InitInfoRead, InitInfoCalls, InitInfoExprs,
+    InitInfoStats, InitInfoCode,
+    InitInfoVars, /* must come after InitExpr and InitStats */
+    InitInfoFuncs, InitInfoOpers, InitInfoInfo, InitInfoIntrprtr,
     InitInfoCompiler,
 
     /* arithmetic operations                                               */
     InitInfoAriths,
 
     /* record packages                                                     */
-    InitInfoRecords,
-    InitInfoPRecord,
+    InitInfoRecords, InitInfoPRecord,
 
     /* internal types                                                      */
-    InitInfoInt,
-    InitInfoIntFuncs,
-    InitInfoRat,
-    InitInfoCyc,
-    InitInfoFinfield,
-    InitInfoPermutat,
-    InitInfoTrans,
-    InitInfoPPerm,
-    InitInfoBool,
+    InitInfoInt, InitInfoIntFuncs, InitInfoRat, InitInfoCyc, InitInfoFinfield,
+    InitInfoPermutat, InitInfoTrans, InitInfoPPerm, InitInfoBool,
     InitInfoMacfloat,
 
     /* list packages                                                       */
-    InitInfoLists,
-    InitInfoListOper,
-    InitInfoListFunc,
-    InitInfoPlist,
-    InitInfoSet,
-    InitInfoVector,
-    InitInfoVecFFE,
-    InitInfoBlist,
-    InitInfoRange,
-    InitInfoString,
-    InitInfoGF2Vec,
-    InitInfoVec8bit,
+    InitInfoLists, InitInfoListOper, InitInfoListFunc, InitInfoPlist,
+    InitInfoSet, InitInfoVector, InitInfoVecFFE, InitInfoBlist, InitInfoRange,
+    InitInfoString, InitInfoGF2Vec, InitInfoVec8bit,
 
     /* free and presented groups                                           */
-    InitInfoFreeGroupElements,
-    InitInfoCosetTable,
-    InitInfoTietze,
-    InitInfoPcElements,
-    InitInfoCollectors,
-    InitInfoPcc,
-    InitInfoDeepThought,
+    InitInfoFreeGroupElements, InitInfoCosetTable, InitInfoTietze,
+    InitInfoPcElements, InitInfoCollectors, InitInfoPcc, InitInfoDeepThought,
     InitInfoDTEvaluation,
 
     /* algebras                                                            */
     InitInfoSCTable,
 
     /* save and load workspace, weak pointers                              */
-    InitInfoWeakPtr,
-    InitInfoSaveLoad,
+    InitInfoWeakPtr, InitInfoSaveLoad,
 
     /* syntax and parser tools */
     InitInfoSyntaxTree,
 
     /* input and output                                                    */
-    InitInfoStreams,
-    InitInfoSysFiles,
-    InitInfoIOStream,
+    InitInfoStreams, InitInfoSysFiles, InitInfoIOStream,
 
     /* main module                                                         */
-    InitInfoModules,
-    InitInfoGap,
-    InitInfoError,
+    InitInfoModules, InitInfoGap, InitInfoError,
 
     // objsets / objmaps
     InitInfoObjSets,
 
 #ifdef HPCGAP
     /* threads                                                             */
-    InitInfoThreadAPI,
-    InitInfoAObjects,
-    InitInfoSerialize,
+    InitInfoThreadAPI, InitInfoAObjects, InitInfoSerialize,
 #else
     // libgap API
     InitInfoLibGapApi,

--- a/src/objects.c
+++ b/src/objects.c
@@ -875,6 +875,12 @@ static Obj FuncMakeImmutable(Obj self, Obj obj)
   return obj;
 }
 
+static Obj FuncGET_TNAM_FROM_TNUM(Obj self, Obj obj)
+{
+    UInt         tnum = GetBoundedInt("GET_TNAM_FROM_TNUM", obj, 0, 255);
+    const char * name = TNAM_TNUM(tnum);
+    return MakeImmString(name ? name : "<unnamed tnum>");
+}
 
 
 // This function is used to keep track of which objects are already
@@ -2050,7 +2056,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_2ARGS(FORCE_SWITCH_OBJ, obj1, obj2),
     GVAR_FUNC_1ARGS(SET_PRINT_OBJ_INDEX, index),
     GVAR_FUNC_1ARGS(MakeImmutable, obj),
-
+    GVAR_FUNC_1ARGS(GET_TNAM_FROM_TNUM, obj),
     GVAR_FUNC_0ARGS(DEBUG_TNUM_NAMES),
 
     { 0, 0, 0, 0, 0 }

--- a/src/tracing.c
+++ b/src/tracing.c
@@ -1,0 +1,204 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This file contains functionality for tracing operations
+**
+*/
+
+#include "tracing.h"
+
+#include "bool.h"
+#include "integer.h"
+#include "lists.h"
+#include "modules.h"
+#include "plist.h"
+#include "precord.h"
+#include "records.h"
+
+// This file contains functionality which stores how often internal operations
+// (like +, ^, -) are executed on each TNUM.
+
+
+static Obj RecordedStats;
+
+// Report the 1 argument operation 'name' was applied to 'op'
+void ReportWrappedOperation1(const char * cname, Obj op)
+{
+    UInt name = RNamName(cname);
+    if (!ISB_REC(RecordedStats, name)) {
+        Obj list = NEW_PLIST(T_PLIST, 0);
+        ASS_REC(RecordedStats, name, list);
+    }
+    Obj list = ELM_REC(RecordedStats, name);
+
+    UInt tnam = TNUM_OBJ(op) + 1;
+    Obj  val = ELM0_LIST(list, tnam);
+    if (!val) {
+        val = INTOBJ_INT(0);
+    }
+
+    UInt8 intval = Int8_ObjInt(val);
+    intval++;
+    val = ObjInt_Int8(intval);
+
+    ASS_LIST(list, tnam, val);
+}
+
+// Report the 2 argument operation 'name' was applied to 'op1' and 'op2'
+void ReportWrappedOperation2(const char * cname, Obj op1, Obj op2)
+{
+    UInt name = RNamName(cname);
+    if (!ISB_REC(RecordedStats, name)) {
+        Obj list = NEW_PLIST(T_PLIST, 0);
+        ASS_REC(RecordedStats, name, list);
+    }
+    Obj list = ELM_REC(RecordedStats, name);
+
+    UInt tnam1 = TNUM_OBJ(op1) + 1;
+    Obj  pos = ELM0_LIST(list, tnam1);
+    if (!pos) {
+        pos = NEW_PLIST(T_PLIST, 0);
+        ASS_LIST(list, tnam1, pos);
+    }
+
+    UInt tnam2 = TNUM_OBJ(op2) + 1;
+    Obj  val = ELM0_LIST(pos, tnam2);
+    if (!val) {
+        val = INTOBJ_INT(0);
+    }
+
+    UInt8 intval = Int8_ObjInt(val);
+    intval++;
+    val = ObjInt_Int8(intval);
+
+    ASS_LIST(pos, tnam2, val);
+}
+
+typedef struct {
+    voidfunc activate;
+    voidfunc deactivate;
+} voidfuncs;
+
+// Store the list of operators which can have tracing enabled and disabled
+static voidfuncs controllers[64];
+static int       tracking_active;
+
+void InstallOpWrapper(voidfunc activate, voidfunc deactivate)
+{
+    int pos = 0;
+    while (pos < 64 && controllers[pos].activate != 0) {
+        pos++;
+    }
+    assert(pos < 64);
+    voidfuncs val = { activate, deactivate };
+    controllers[pos] = val;
+}
+
+static Obj FuncTraceInternalMethods(Obj self)
+{
+    if (tracking_active) {
+        return Fail;
+    }
+    int pos = 0;
+    while (pos < 64 && controllers[pos].activate != 0) {
+        controllers[pos].activate();
+        pos++;
+    }
+    tracking_active = 1;
+    RecordedStats = NEW_PREC(0);
+    return True;
+}
+
+static Obj FuncUntraceInternalMethods(Obj self)
+{
+    if (!tracking_active) {
+        return Fail;
+    }
+    int pos = 0;
+    while (pos < 64 && controllers[pos].deactivate != 0) {
+        controllers[pos].deactivate();
+        pos++;
+    }
+    tracking_active = 0;
+    return 0;
+}
+static Obj FuncGET_TRACED_INTERNAL_METHODS_COUNTS(Obj self)
+{
+    return RecordedStats;
+}
+
+static Obj FuncClearTraceInternalMethodsCounts(Obj self)
+{
+    RecordedStats = NEW_PREC(0);
+    return 0;
+}
+
+
+/****************************************************************************
+**
+*F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
+*/
+
+/****************************************************************************
+**
+*V  GVarFuncs . . . . . . . . . . . . . . . . . . list of functions to export
+*/
+static StructGVarFunc GVarFuncs[] = {
+
+    GVAR_FUNC_0ARGS(TraceInternalMethods),
+    GVAR_FUNC_0ARGS(UntraceInternalMethods),
+    GVAR_FUNC_0ARGS(GET_TRACED_INTERNAL_METHODS_COUNTS),
+    GVAR_FUNC_0ARGS(ClearTraceInternalMethodsCounts),
+    { 0, 0, 0, 0, 0 }
+};
+
+
+/****************************************************************************
+**
+*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+*/
+static Int InitLibrary(StructInitInfo * module)
+{
+    /* init filters and functions                                          */
+    InitGVarFuncsFromTable(GVarFuncs);
+
+    RecordedStats = NEW_PREC(0);
+    /* return success                                                      */
+    return 0;
+}
+
+/****************************************************************************
+**
+*F  InitKernel( <module> )  . . . . . . . . initialise kernel data structures
+*/
+static Int InitKernel(StructInitInfo * module)
+{
+    InitHdlrFuncsFromTable(GVarFuncs);
+    InitGlobalBag(&RecordedStats, "src/tracing.c:RecordedStats");
+    return 0;
+}
+
+
+/****************************************************************************
+**
+*F  InitInfoStats() . . . . . . . . . . . . . . . . . table of init functions
+*/
+static StructInitInfo module = {
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "stats",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+};
+
+StructInitInfo * InitInfoTracing(void)
+{
+    return &module;
+}

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -1,0 +1,82 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This file defines the functions for tracing operations.
+*/
+
+#include "objects.h"
+
+
+void ReportWrappedOperation1(const char *, Obj op);
+void ReportWrappedOperation2(const char *, Obj op1, Obj op2);
+void InstallOpWrapper(voidfunc, voidfunc);
+
+
+// These are macros which make it simple to wrap
+
+#define DEFINE_OP_WRAPPER1(Array)                                            \
+    static ObjFunc_0ARGS Wrap##Array[LAST_REAL_TNUM + 1];                    \
+    Obj                  Wrap##Array##Func(Obj op)                           \
+    {                                                                        \
+        ReportWrappedOperation1(#Array, op);                                 \
+        return Wrap##Array[TNUM_OBJ(op)](op);                                \
+    }                                                                        \
+    void Array##HookActivate(void)                                           \
+    {                                                                        \
+        for (int i = 0; i < LAST_REAL_TNUM; ++i) {                           \
+            Wrap##Array[i] = Array[i];                                       \
+            Array[i] = Wrap##Array##Func;                                    \
+        }                                                                    \
+    }                                                                        \
+                                                                             \
+    void Array##HookDeactivate(void)                                         \
+    {                                                                        \
+        for (int i = 0; i < LAST_REAL_TNUM; ++i) {                           \
+            Array[i] = Wrap##Array[i];                                       \
+            Wrap##Array[i] = 0;                                              \
+        }                                                                    \
+    }
+
+#define DEFINE_OP_WRAPPER2(Array)                                            \
+    static ObjFunc_1ARGS Wrap##Array[LAST_REAL_TNUM + 1]                     \
+                                    [LAST_REAL_TNUM + 1];                    \
+    Obj Wrap##Array##Func(Obj op1, Obj op2)                                  \
+    {                                                                        \
+        ReportWrappedOperation2(#Array, op1, op2);                           \
+        return Wrap##Array[TNUM_OBJ(op1)][TNUM_OBJ(op2)](op1, op2);          \
+    }                                                                        \
+    void Array##HookActivate(void)                                           \
+    {                                                                        \
+        for (int i = 0; i < LAST_REAL_TNUM; ++i) {                           \
+            for (int j = 0; j < LAST_REAL_TNUM; ++j) {                       \
+                Wrap##Array[i][j] = Array[i][j];                             \
+                Array[i][j] = Wrap##Array##Func;                             \
+            }                                                                \
+        }                                                                    \
+    }                                                                        \
+                                                                             \
+    void Array##HookDeactivate(void)                                         \
+    {                                                                        \
+        for (int i = 0; i < LAST_REAL_TNUM; ++i) {                           \
+            for (int j = 0; j < LAST_REAL_TNUM; ++j) {                       \
+                Array[i][j] = Wrap##Array[i][j];                             \
+                Wrap##Array[i][j] = 0;                                       \
+            }                                                                \
+        }                                                                    \
+    }
+
+#define INSTALL_OP_WRAPPER(Array)                                            \
+    InstallOpWrapper(Array##HookActivate, Array##HookDeactivate);
+
+
+/****************************************************************************
+**
+*F  InitInfoTracing() . . . . . . . . . . . . . . . . table of init functions
+*/
+StructInitInfo * InitInfoTracing(void);

--- a/tst/testinstall/trace.tst
+++ b/tst/testinstall/trace.tst
@@ -1,4 +1,4 @@
-#@local fam,cat,type,a
+#@local fam,cat,type,a,testTrace
 gap> START_TEST("trace.tst");
 
 #
@@ -46,4 +46,65 @@ gap> Size(a);
 gap> TraceImmediateMethods(false);
 
 #
+gap> testTrace := function(f)
+> TraceInternalMethods();
+> f();
+> UntraceInternalMethods();
+> return GetTraceInternalMethodsCounts();
+> end;;
+gap> testTrace({} -> [1,2]+[3,4]);
+rec( Sum := rec( ("dense plain list") := rec( ("dense plain list") := 1 ), 
+      integer := rec( integer := 2 ) ) )
+gap> testTrace({} -> 2^(3,4,5));
+rec( Pow := rec( integer := rec( ("permutation (small)") := 1 ) ) )
+gap> testTrace({} -> [4,3] - [2,3]);
+rec( AInv := rec( ("dense plain list") := 1, integer := 2 ), 
+  Diff := rec( ("dense plain list") := rec( ("dense plain list") := 1 ) ), 
+  Sum := rec( ("dense plain list") := rec( ("dense plain list") := 1 ), 
+      integer := rec( integer := 2 ) ) )
+gap> testTrace({} -> Inverse(3));
+rec( Inv := rec( integer := 1 ) )
+gap> testTrace({} -> Inverse(PartialPerm([1,2,3])));
+rec( Inv := rec( ("partial perm (small)") := 1 ) )
+gap> testTrace({} -> AdditiveInverse(2/3));
+rec( AInvMut := rec( rational := 1 ), 
+  Quo := rec( integer := rec( integer := 1 ) ) )
+gap> testTrace({} -> AdditiveInverse([2,3,4]));
+rec( AInvMut := rec( integer := 3, ("plain list of cyclotomics") := 1 ) )
+gap> testTrace({} -> Inverse([[1,0],[0,1]]));
+rec( AInv := rec( integer := 4 ), 
+  Inv := rec( ("dense plain list") := 1, integer := 2 ), 
+  Mod := rec( integer := rec( integer := 1 ) ), One := rec( integer := 1 ), 
+  Prod := rec( integer := rec( integer := 8 ) ), Zero := rec( integer := 1 ) )
+gap> testTrace({} -> 55/2 mod 7);
+rec( Mod := rec( rational := rec( integer := 1 ) ), 
+  Quo := rec( integer := rec( integer := 1 ) ) )
+gap> testTrace({} -> Comm(Transformation([1,2,3]), Transformation([3,2,1])));
+rec( 
+  Comm := 
+    rec( ("transformation (small)") := rec( ("transformation (small)") := 1 ) 
+     ), Inv := rec( ("transformation (small)") := 1 ), 
+  InvMut := rec( ("transformation (small)") := 1 ), 
+  LQuo := 
+    rec( ("transformation (small)") := rec( ("transformation (small)") := 1 ) 
+     ), 
+  Prod := 
+    rec( ("transformation (small)") := rec( ("transformation (small)") := 3 ) 
+     ) )
+gap> testTrace({} -> OneMutable(1/2));
+rec( One := rec( rational := 1 ), 
+  Quo := rec( integer := rec( integer := 1 ) ) )
+gap> testTrace({} -> OneMutable([[1,2],[3,4]]));
+rec( Mod := rec( integer := rec( integer := 1 ) ), 
+  One := rec( ("dense plain list") := 1, integer := 1 ), 
+  Zero := rec( integer := 1 ) )
+gap> testTrace({} -> ZeroMutable(1/2));
+rec( Quo := rec( integer := rec( integer := 1 ) ), 
+  ZeroMut := rec( rational := 1 ) )
+gap> testTrace({} -> ZeroMutable([[1,2],[3,4]]));
+rec( ZeroMut := rec( ("dense plain list") := 3, integer := 4 ) )
+gap> testTrace({} -> LeftQuotient(4,2));
+rec( InvMut := rec( integer := 1 ), 
+  LQuo := rec( integer := rec( integer := 1 ) ), 
+  Prod := rec( rational := rec( integer := 1 ) ) )
 gap> STOP_TEST("trace.tst", 1);


### PR DESCRIPTION
This is some code I've had a branch of a long time, cleaned up.

Sometimes, for papers and general research it is interesting to know things like how many times + is applied to integers, or * or ^ is applied to permutations.

This can't be done by any of GAP's normal tracing functionality at present. Also, printing a message every time one of these functions is called would be far too much.

This adds `TraceInternalMethods`, which produces a record which contains how many times each operation is applied to each tnum (or each pair of tnums for 2-argument methods).

This doesn't try to catch when kernel functions add integers, only when these operations are performed at the GAP level.

This still needs tests, but before I put more work into polishing I wanted to see if other people found it useful.