### PR TITLE
Allow HPC-GAP to run as a forkable server process.

### DIFF
--- a/hpcgap/lib/hpc/thread.g
+++ b/hpcgap/lib/hpc/thread.g
@@ -83,18 +83,26 @@ BindGlobal("NewInterruptID", function()
   od;
 end);
 
-CreateThread(function()
-  local handlers;
-  handlers := rec(
-    SIGINT := DEFAULT_SIGINT_HANDLER,
-    SIGCHLD := DEFAULT_SIGCHLD_HANDLER,
-    SIGVTALRM := DEFAULT_SIGVTALRM_HANDLER,
-    SIGWINCH := DEFAULT_SIGWINCH_HANDLER
-  );
-  while true do
-    SIGWAIT(handlers);
-  od;
+BindGlobal("InstallHPCGAPSignalHandling", function()
+  if not IsBound(SignalHandlerThread) then
+    BindGlobal("SignalHandlerThread", CreateThread(function()
+      local handlers;
+      handlers := rec(
+        SIGINT := DEFAULT_SIGINT_HANDLER,
+        SIGCHLD := DEFAULT_SIGCHLD_HANDLER,
+        SIGVTALRM := DEFAULT_SIGVTALRM_HANDLER,
+        SIGWINCH := DEFAULT_SIGWINCH_HANDLER
+      );
+      while true do
+        SIGWAIT(handlers);
+      od;
+    end));
+  fi;
 end);
+
+if IsHPCGAP and not SINGLE_THREAD_STARTUP() then
+  InstallHPCGAPSignalHandling();
+fi;
 
 #
 # LockCounters are per region and per thread counters

--- a/lib/system.g
+++ b/lib/system.g
@@ -192,6 +192,8 @@ if IsHPCGAP then
         rec( short:= "P", default := "0", arg := "<num>", help := ["set number of logical processors"] ),
         rec( short:= "G", default := "0", arg := "<num>", help := ["set number of GC threads"] ),
         rec( short:= "Z", default := false, help := ["enforce ordering of region locks"] ),
+        rec( long := "single-thread", default := false,
+             help := [ "enable/disable single-threaded startup" ]),
       ]);
 
     MakeImmutable(GAPInfo.CommandLineOptionData);

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -300,6 +300,7 @@ void InitBags(UInt              initial_size,
     }
 #endif
     GC_set_all_interior_pointers(0);
+    GC_set_handle_fork(1);
     GC_init();
     GC_set_free_space_divisor(1);
     TLAllocatorInit();

--- a/src/gap.c
+++ b/src/gap.c
@@ -1391,9 +1391,19 @@ static Obj FuncBREAKPOINT(Obj self, Obj arg)
 
 static Obj FuncTHREAD_UI(Obj self)
 {
-  return ThreadUI ? True : False;
+    return (ThreadUI && !SingleThreadStartup) ? True : False;
 }
 
+/****************************************************************************
+**
+*F  FuncSINGLE_THREAD_STARTUP . . whether to start up in single-threaded mode
+**
+*/
+
+static Obj FuncSINGLE_THREAD_STARTUP(Obj self)
+{
+    return SingleThreadStartup ? True : False;
+}
 
 #endif
 
@@ -1480,6 +1490,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_0ARGS(KERNEL_INFO),
 #ifdef HPCGAP
     GVAR_FUNC_0ARGS(THREAD_UI),
+    GVAR_FUNC_0ARGS(SINGLE_THREAD_STARTUP),
 #endif
     GVAR_FUNC_1ARGS(MASTER_POINTER_NUMBER, ob),
     GVAR_FUNC_1ARGS(BREAKPOINT, integer),

--- a/src/hpc/misc.c
+++ b/src/hpc/misc.c
@@ -44,6 +44,12 @@ UInt SyNumProcessors = 4;
 */
 UInt SyNumGCThreads = 0;
 
+/****************************************************************************
+**
+*V  SingleThreadStartup . . . . . . . . .  start HPC-GAP with just one thread
+**
+*/
+UInt SingleThreadStartup = 0;
 
 /****************************************************************************
 **

--- a/src/hpc/misc.h
+++ b/src/hpc/misc.h
@@ -47,6 +47,13 @@ extern UInt SyNumGCThreads;
 
 /****************************************************************************
 **
+*V  SingleThreadStartup . . . . . . . . .  start HPC-GAP with just one thread
+**
+*/
+extern UInt SingleThreadStartup;
+
+/****************************************************************************
+**
 *F  MergeSort() . . . . . . . . . . . . . . . sort an array using mergesort.
 **
 **  MergeSort() sorts an array of 'count' elements of individual size 'width'

--- a/src/system.c
+++ b/src/system.c
@@ -1024,9 +1024,10 @@ static const struct optInfo options[] = {
   { 'q', "", toggle, &SyQuiet, 0 }, /* ?? */
 #ifdef HPCGAP
   { 'S', "", toggle, &ThreadUI, 0 }, /* Thread UI */
-  { 'Z', "", toggle, &DeadlockCheck, 0 }, /* Thread UI */
-  { 'P', "", storePosInteger, &SyNumProcessors, 1 }, /* Thread UI */
-  { 'G', "", storePosInteger, &SyNumGCThreads, 1 }, /* Thread UI */
+  { 'Z', "", toggle, &DeadlockCheck, 0 }, /* Deadlock prevention */
+  { 'P', "", storePosInteger, &SyNumProcessors, 1 }, /* number of CPUs */
+  { 'G', "", storePosInteger, &SyNumGCThreads, 1 }, /* number of GC threads */
+  { 0  , "single-thread", toggle, &SingleThreadStartup, 0 }, /* startup with one thread only */
 #endif
   /* The following options must be handled in the kernel so they are set up before loading the library */
   { 0  , "prof", enableProfilingAtStartup, 0, 1},    /* enable profiling at startup */


### PR DESCRIPTION
This change is prompted by trying to make HPC-GAP work for Jupyter. Note that it changes the meaning of the `-S` command line option and therefore is labeled as WIP. I've put up the pull request so that people can test the functionality of Jupyter + HPC-GAP, even if details still needs to be settled. Note also that so far I've only tested this on macOS.

This commit includes the following changes:

1. The Boehm GC is configured to properly handle fork().
2. The -S command line option now starts HPC-GAP up in single-threaded
   mode without any other threads running.
3. Normally, signals are handled by a separate thread; this is now being
   done in the function `InstallHPCGAPSignalHandling`. If started with
   -S, this function needs to be called explicitly in order to enable
   proper handling of SIGINT etc.

Please use the following template to submit a pull request, filling
in at least the "Text for release notes" and/or "Further details".
Thank You!
