### PR TITLE
kernel: simplify SET_TYPE_OBJ, remove SetTypeObjFuncs

### DIFF
--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -90,36 +90,6 @@ static Obj TypeTLRecord(Obj obj)
   return TYPE_TLREC;
 }
 
-static void SetTypeAList(Obj obj, Obj kind)
-{
-  switch (TNUM_OBJ(obj)) {
-    case T_ALIST:
-    case T_FIXALIST:
-      HashLock(obj);
-      ADDR_OBJ(obj)[1] = kind;
-      CHANGED_BAG(obj);
-      RetypeBag(obj, T_APOSOBJ);
-      HashUnlock(obj);
-      break;
-    case T_APOSOBJ:
-      HashLock(obj);
-      ADDR_OBJ(obj)[1] = kind;
-      CHANGED_BAG(obj);
-      HashUnlock(obj);
-      break;
-  }
-  MEMBAR_WRITE();
-}
-
-static void SetTypeARecord(Obj obj, Obj kind)
-{
-  ADDR_OBJ(obj)[0] = kind;
-  CHANGED_BAG(obj);
-  RetypeBag(obj, T_ACOMOBJ);
-  MEMBAR_WRITE();
-}
-
-
 static void ArgumentError(const char *message)
 {
     ErrorQuit(message, 0, 0);
@@ -1856,11 +1826,6 @@ static Int InitKernel (
   TypeObjFuncs[ T_AREC ] = TypeARecord;
   TypeObjFuncs[ T_ACOMOBJ ] = TypeARecord;
   TypeObjFuncs[ T_TLREC ] = TypeTLRecord;
-  SetTypeObjFuncs[ T_ALIST ] = SetTypeAList;
-  SetTypeObjFuncs[ T_FIXALIST ] = SetTypeAList;
-  SetTypeObjFuncs[ T_APOSOBJ ] = SetTypeAList;
-  SetTypeObjFuncs[ T_AREC ] = SetTypeARecord;
-  SetTypeObjFuncs[ T_ACOMOBJ ] = SetTypeARecord;
   /* install global variables */
   InitCopyGVar("TYPE_ALIST", &TYPE_ALIST);
   InitCopyGVar("TYPE_AREC", &TYPE_AREC);

--- a/src/objects.h
+++ b/src/objects.h
@@ -491,16 +491,13 @@ EXPORT_INLINE Obj TYPE_OBJ(Obj obj)
 
 /****************************************************************************
 **
-*F  SET_TYPE_OBJ( <obj>, <kind> ) . . . . . . . . . . . set kind of an object
+*F  SET_TYPE_OBJ( <obj>, <type> ) . . . . . . . . . . . set type of an object
 **
-**  'SET_TYPE_OBJ' sets the kind <kind>of the object <obj>.
+**  'SET_TYPE_OBJ' sets the type of the object <obj> to <type>; if <obj>
+**  is not a posobj/comobj/datobj, attempts to first convert it to one; if
+**  that fails, an error is raised.
 */
-extern void (*SetTypeObjFuncs[ LAST_REAL_TNUM+1 ]) ( Obj obj, Obj kind );
-EXPORT_INLINE void SET_TYPE_OBJ(Obj obj, Obj type)
-{
-    UInt tnum = TNUM_OBJ(obj);
-    (*SetTypeObjFuncs[tnum])(obj, type);
-}
+void SET_TYPE_OBJ(Obj obj, Obj type);
 
 
 /****************************************************************************

--- a/src/plist.c
+++ b/src/plist.c
@@ -766,18 +766,6 @@ static Obj TypePlistFfe(Obj list)
 
 /****************************************************************************
 **
-*F  SetTypePlistToPosObj(<list>, <kind>) .  convert list to positional object
-**
-*/
-static void SetTypePlistToPosObj(Obj list, Obj kind)
-{
-    RetypeBag(list, T_POSOBJ);
-    SET_TYPE_POSOBJ(list, kind);
-    CHANGED_BAG(list);
-}
-
-/****************************************************************************
-**
 *F  ShallowCopyPlist( <list> )  . . . . . . . .  shallow copy of a plain list
 **
 **  'ShallowCopyPlist' makes a copy of a plain list.
@@ -3363,10 +3351,6 @@ static Int InitKernel (
     TypeObjFuncs[ T_PLIST_DENSE_NHOM_NSORT +IMMUTABLE ] = TypePlistDenseNHomNSort;
     TypeObjFuncs[ T_PLIST_EMPTY                 ] = TypePlistEmpty;
     TypeObjFuncs[ T_PLIST_EMPTY      +IMMUTABLE ] = TypePlistEmpty;
-
-    for ( t1 = T_PLIST;  t1 <= LAST_PLIST_TNUM;  t1 += 2 ) {
-        SetTypeObjFuncs[ t1 ] = SetTypePlistToPosObj;
-    }
 
     for ( t1 = T_PLIST_HOM; t1 <= T_PLIST_TAB_RECT_SSORT; t1 += 2 ) {
         TypeObjFuncs[ t1            ] = TypePlistHom;

--- a/src/precord.c
+++ b/src/precord.c
@@ -68,17 +68,6 @@ static Obj TypePRec(Obj prec)
     return IS_MUTABLE_OBJ(prec) ? TYPE_PREC_MUTABLE : TYPE_PREC_IMMUTABLE;
 }
 
-/****************************************************************************
-**
-*F  SetTypePRecToComObj( <rec>, <kind> )  convert record to component object
-**
-*/
-static void SetTypePRecToComObj(Obj rec, Obj kind)
-{
-    RetypeBag(rec, T_COMOBJ);
-    SET_TYPE_COMOBJ(rec, kind);
-    CHANGED_BAG(rec);
-}
 
 /****************************************************************************
 **
@@ -868,8 +857,6 @@ static Int InitKernel (
 
     TypeObjFuncs[ T_PREC            ] = TypePRec;
     TypeObjFuncs[ T_PREC +IMMUTABLE ] = TypePRec;
-
-    SetTypeObjFuncs[ T_PREC ] = SetTypePRecToComObj;
 
     MakeImmutableObjFuncs[ T_PREC   ] = MakeImmutablePRec;
 


### PR DESCRIPTION
So far, the code for converting plists and precords to external objects,
resp. changing the type of external objects, was rather convoluted,
spread over multiple files and functions.

This patch moves all the code behind the kernel function SET_TYPE_OBJ
into a single place. Now it is much easier to compare it to the GAP
function with the same name, and to see and analyze differences between
the two.

I plan to follow this up with a PR which tries to reduce the differences between different code paths for setting the type, I think at least some of them may fix latent bugs in HPC-GAP (ping @rbehrends)