### PR TITLE
Revert "buildsys: use the C++ compiler for linking"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,6 @@ environment:
       CYG_ROOT: C:\cygwin64
       PACKAGES: "-P libgmp-devel,zlib-devel,python27,python27-pip"
       CFLAGS: "--coverage"
-      CXXFLAGS: "--coverage"
       LDFLAGS: "--coverage"
 # FIXME: HPC-GAP build on AppVeyor disabled for now, as it crashes
 #    - CYG_ARCH: x86_64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ environment:
       CYG_ROOT: C:\cygwin64
       PACKAGES: "-P libgmp-devel,zlib-devel,python27,python27-pip"
       CFLAGS: "--coverage"
+      CXXFLAGS: "--coverage"
       LDFLAGS: "--coverage"
 # FIXME: HPC-GAP build on AppVeyor disabled for now, as it crashes
 #    - CYG_ARCH: x86_64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,6 +42,7 @@ build_script:
         throw "There are newer queued builds for this pull request, failing early." }
   - SET "PATH=%CYG_ROOT%\bin;%PATH%"
   - python -m pip install gcovr # for coverage reporting later on
+  - bash -lc "gcc --version"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./etc/ci-prepare.sh"
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,6 @@ matrix:
 
     # test Julia integration
     - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
-      dist: bionic # need GCC 6 to avoid linker error
 
 script:
   - set -e

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -342,9 +342,15 @@ $(srcdir)/src/pperm.c:
 $(srcdir)/src/trans.c:
 
 # Build rule for C++ source files
+#
+# We disable support for exceptions and RTTI as we don't use them and they
+# cause compiler/linker issues in some build configurations; but we are
+# careful to not put these into GAP_CXXFLAGS, as kernel extensions may want to
+# use GAP_CXXFLAGS but also may have a  need to interface with C++ code in
+# libraries that use exceptions.
 obj/%.lo: %.cc cnf/GAP-CXXFLAGS cnf/GAP-CPPFLAGS libtool
 	@$(MKDIR_P) $(@D)/$(DEPDIRNAME)
-	$(QUIET_CXX)$(LIBTOOL) --mode=compile --tag CXX $(CXX) $(DEPFLAGS) $(GAP_CXXFLAGS) $(WARN_CXXFLAGS) $(GAP_CPPFLAGS) -c $< -o $@
+	$(QUIET_CXX)$(LIBTOOL) --mode=compile --tag CXX $(CXX) $(DEPFLAGS) $(GAP_CXXFLAGS) -fno-exceptions -fno-rtti $(WARN_CXXFLAGS) $(GAP_CPPFLAGS) -c $< -o $@
 	@echo "$<:" >> $(DEPFILE)
 
 # Build rule for C source files

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -358,7 +358,7 @@ obj/%.lo: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
 # Linker rules for gap executable
 ########################################################################
 
-LINK=$(LIBTOOL) --mode=link $(CXX) -export-dynamic
+LINK=$(LIBTOOL) --mode=link $(CC) -export-dynamic
 
 libgap.la: $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 	$(QUIET_LINK)$(LINK) -no-undefined -rpath $(libdir) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS) -o $@
@@ -391,8 +391,8 @@ GAP_LDFLAGS += -Wl,--allow-multiple-definition
 all: bin/$(GAPARCH)/gap.dll
 bin/$(GAPARCH)/gap.dll: symlinks libgap.la
 	cp .libs/cyggap-0.dll $@  # FIXME: HACK to support kernel extensions
-gap$(EXEEXT): obj/src/gapw95.lo libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) obj/src/gapw95.lo $(GAP_LIBS) libgap.la -o $@
+gap$(EXEEXT): libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(srcdir)/src/gapw95.c $(GAP_LIBS) libgap.la -o $@
 	@( if which peflags > /dev/null ; then peflags --cygwin-heap=2048 gap$(EXEEXT) ; fi )
 
 else
@@ -694,9 +694,6 @@ endif # BUILD_BOEHM_GC
 # ensure subprojects are built and "installed" before compiling and linking GAP
 gap$(EXEEXT): $(EXTERN_FILES)
 $(OBJS): $(EXTERN_FILES)
-ifeq ($(SYS_IS_CYGWIN32),yes)
-obj/src/gapw95.lo: $(EXTERN_FILES)
-endif
 ifeq ($(HPCGAP),yes)
 $(SOURCES): $(EXTERN_FILES)
 endif


### PR DESCRIPTION
This essentially reverts PR #3652, which was meant to fix issue #3651 for @hulpke which was caused by a bug in GCC 4.4.7.

The problem with that fix is that it causes severe linker issues when using GAP with Julia on Ubuntu 16.04, due to that system using GCC 5 (more specifically any other Linux installation with GCC <= 6.0 as its primary compiler is affected, only GCC >= 6.1 are safe to use). I myself can workaround that there by updating the compiler to GCC 6, but that is really problematic for people who can't modify their systems like that for some reason or another. The only fix I could come up with so far is switching back to linking with the C compiler by default, which *ought* to work as we don't use the standard C++ library.

Of course this would open up issue #3651 again, but I hope that we can workaround it in another way. Specifically, I hope that @hulpke can work around his problems there with this:

    ./configure LIBS=-lstdc++    # ... plus any other configure options you want/need
    make

If @hulpke can confirm that this also fixes the issue for him (with this PR merged, I mean), then I think we can safely go ahead with merging this, and backporting it to stable-4.11

CC @wbhart