### PR TITLE
Add optimised SmallestMovedPoint implementation

### DIFF
--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -649,6 +649,12 @@ InstallMethod( SmallestMovedPoint,
 end );
 
 
+InstallMethod( SmallestMovedPoint,
+    "for an internal permutation",
+    [ IsPerm and IsInternalRep ],
+    SMALLEST_MOVED_POINT_PERM );
+
+
 #############################################################################
 ##
 #m  LargestMovedPoint( <perm> ) . . . . . . . .  for internal permutation

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -1125,6 +1125,40 @@ UInt LargestMovedPointPerm(Obj perm)
         return LargestMovedPointPerm_<UInt4>(perm);
 }
 
+/****************************************************************************
+**
+*F  SmallestMovedPointPerm( <perm> ) smallest point moved by perm
+**
+**  'SmallestMovedPointPerm' implements 'SmallestMovedPoint' for internal
+**  permutations.
+*/
+
+// Import 'Infinity', as a return value for the identity permutation
+static Obj Infinity;
+
+template <typename T>
+static inline Obj SmallestMovedPointPerm_(Obj perm)
+{
+    const T * ptPerm = CONST_ADDR_PERM<T>(perm);
+    UInt      deg = DEG_PERM<T>(perm);
+
+    for (UInt i = 1; i <= deg; i++) {
+        if (ptPerm[i - 1] != i - 1)
+            return INTOBJ_INT(i);
+    }
+    return Infinity;
+}
+
+static Obj SmallestMovedPointPerm(Obj perm)
+{
+    GAP_ASSERT(TNUM_OBJ(perm) == T_PERM2 || TNUM_OBJ(perm) == T_PERM4);
+
+    if (TNUM_OBJ(perm) == T_PERM2)
+        return SmallestMovedPointPerm_<UInt2>(perm);
+    else
+        return SmallestMovedPointPerm_<UInt4>(perm);
+}
+
 
 /****************************************************************************
 **
@@ -1141,6 +1175,18 @@ static Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
     return INTOBJ_INT(LargestMovedPointPerm(perm));
 }
 
+/****************************************************************************
+**
+*F  FuncSMALLEST_MOVED_POINT_PERM( <self>, <perm> )
+**
+**  GAP-level wrapper for 'SmallestMovedPointPerm'.
+*/
+static Obj FuncSMALLEST_MOVED_POINT_PERM(Obj self, Obj perm)
+{
+    RequirePermutation("SmallestMovedPointPerm", perm);
+
+    return SmallestMovedPointPerm(perm);
+}
 
 /****************************************************************************
 **
@@ -2736,6 +2782,7 @@ static StructGVarFunc GVarFuncs [] = {
 
     GVAR_FUNC_1ARGS(PermList, list),
     GVAR_FUNC_1ARGS(LARGEST_MOVED_POINT_PERM, perm),
+    GVAR_FUNC_1ARGS(SMALLEST_MOVED_POINT_PERM, perm),
     GVAR_FUNC_2ARGS(CYCLE_LENGTH_PERM_INT, perm, point),
     GVAR_FUNC_2ARGS(CYCLE_PERM_INT, perm, point),
     GVAR_FUNC_1ARGS(CYCLE_STRUCT_PERM, perm),
@@ -2783,6 +2830,9 @@ static Int InitKernel (
 #endif
 
     ImportGVarFromLibrary("PERM_INVERSE_THRESHOLD", &PERM_INVERSE_THRESHOLD);
+
+    /* needed for SmallestMovedPoint                                       */
+    ImportGVarFromLibrary("infinity", &Infinity);
 
     /* install the type functions                                           */
     ImportGVarFromLibrary( "TYPE_PERM2", &TYPE_PERM2 );

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -1,4 +1,4 @@
-#@local checklens,n,permAll,permBig,permSml,x,y
+#@local checklens,n,permAll,permBig,permSml,x,y, moved
 gap> START_TEST("perm.tst");
 
 # Permutations come in two flavors in GAP, with two TNUMs: T_PERM2 for
@@ -314,12 +314,38 @@ gap> PermList(Concatenation([1..70000],[70001,1,70003]));
 fail
 
 #
-# LARGEST_MOVED_POINT_PERM
+# SmallestMovedPoint, LargestMovedPoint, MovedPoints, NrMovedPoints
 #
-gap> LARGEST_MOVED_POINT_PERM((2,3));
-3
-gap> LARGEST_MOVED_POINT_PERM((2,70000));
-70000
+gap> moved := {p} -> [SmallestMovedPoint(p), LargestMovedPoint(p), MovedPoints(p), NrMovedPoints(p)];;
+gap> moved((2,3));
+[ 2, 3, [ 2, 3 ], 2 ]
+gap> moved((2,70000));
+[ 2, 70000, [ 2, 70000 ], 2 ]
+gap> moved((70000, 70001));
+[ 70000, 70001, [ 70000, 70001 ], 2 ]
+gap> moved((1,2,3,4));
+[ 1, 4, [ 1, 2, 3, 4 ], 4 ]
+gap> moved(());
+[ infinity, 0, [  ], 0 ]
+gap> moved((1,2,3,4)^4);
+[ infinity, 0, [  ], 0 ]
+gap> moved([]);
+[ infinity, 0, [  ], 0 ]
+gap> moved([()]);
+[ infinity, 0, [  ], 0 ]
+gap> moved([(1,2),(5,6)]);
+[ 1, 6, [ 1, 2, 5, 6 ], 4 ]
+gap> moved(SymmetricGroup([5,7,9]));
+[ 5, 9, [ 5, 7 .. 9 ], 3 ]
+gap> moved(SymmetricGroup([5,7,9,70000]));
+[ 5, 70000, [ 5, 7, 9, 70000 ], 4 ]
+gap> moved(SymmetricGroup(1));
+[ infinity, 0, [  ], 0 ]
+gap> moved(Group((8,9,10),(13,15,19)));
+[ 8, 19, [ 8, 9, 10, 13, 15, 19 ], 6 ]
+gap> SMALLEST_MOVED_POINT_PERM(fail);
+Error, SmallestMovedPointPerm: <perm> must be a permutation (not the value 'fa\
+il')
 gap> LARGEST_MOVED_POINT_PERM(fail);
 Error, LargestMovedPointPerm: <perm> must be a permutation (not the value 'fai\
 l')


### PR DESCRIPTION
This just adds a SmallestMovedPoint C implementation, as I had a case where the time taken mattered.

We leave a GAP-level implementation for permutations which aren't PERM2s or PERM4s, as SmallestMovedPoint is used on permutations which aren't internal rep.

Note (if interested) we don't have a GAP-level implementation for LargestMovedPoint, as there isn't a sensible algorithm for arbitrary permutation implementations (as we don't have a "largest candidate" to start from, as we do with internal permutations).