### PR TITLE
Fix power maps in result of CharacterTableIsoclinic

### DIFF
--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -6226,7 +6226,7 @@ InstallMethod( CharacterTableIsoclinic,
 
         for i in [ 1 .. p-1 ] do
           # Deal with the classes in the 'i'-th coset.
-          ypos:= PowerMap( tbl, ( k * QuoInt( i * q, p ) ) mod p, xpos );
+          ypos:= PowerMap( tbl, ( k * QuoInt( i * q, p ) ), xpos );
           for class in outer[i] do
             old:= map[ class ];
             images:= invfusion[ factorfusion[ old ] ];

--- a/tst/teststandard/ctblisoc.tst
+++ b/tst/teststandard/ctblisoc.tst
@@ -113,6 +113,10 @@ gap> if TestPackageAvailability( "ctbllib" ) <> fail and
 >        # that the *first* generator of the centre appears first.
 >        Error( "wrong ordering of classes for isoclinic table" );
 >      fi;
+>      if ForAny( PrimeDivisors( Size( iso ) ),
+>           p -> not PowerMap( iso, p ) in PossiblePowerMaps( iso, p ) ) then
+>        Error( "wrong power map for isoclinic table" );
+>      fi;
 >    fi;
 
 # optional arguments:


### PR DESCRIPTION
The following bug gets fixed that had been introduced in commit 2013da192c1b6bea588e1803a67e72bda1db6c22:
The result of `CharacterTableIsoclinic` in the case of a central subgroup of order four (a rare situation ...) can store wrong power maps.

This bug was not present in released GAP versions (up to 4.10.2);
if the fix makes it into GAP 4.11 then it need not be mentioned in release notes.