### PR TITLE
Silence InfoDebug in a test that loads Crisp package

### DIFF
--- a/tst/testbugfix/2005-05-03-t00324.tst
+++ b/tst/testbugfix/2005-05-03-t00324.tst
@@ -1,4 +1,6 @@
 # 2005/05/03 (BH)
+gap> INFO_DEBUG_CURRENT := InfoLevel(InfoDebug);;
+gap> SetInfoLevel(InfoDebug,0);
 gap> if TestPackageAvailability("crisp") <> fail and
 >       LoadPackage("crisp", false) <> fail then
 >      F:=FreeGroup("a","b","c");;
@@ -34,3 +36,4 @@ gap> if TestPackageAvailability("crisp") <> fail and
 >        Print( "problem with crisp (6)\n" );
 >      fi;
 >    fi;
+gap> SetInfoLevel(InfoDebug, INFO_DEBUG_CURRENT);


### PR DESCRIPTION
After https://github.com/gap-system/gap/pull/3694, a warning

    DeclareGlobalFunction: too many arguments

is shown when Crisp is loaded. This PR temporary tweaks `InfoDebug` to silence it.
  