### PR TITLE
ENHANCE: Performance improvements for certain cases in 2-cohomology

### DIFF
--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -266,7 +266,7 @@ InstallGlobalFunction( RelatorsPermGroupHom, function ( hom, gensG )
           index, inv0, iso, j, map, ndefs, next, ngens, ngens2, ni, orbit,
           order, P, perm, perms, range, regular, rel, rel2, rels, relsG,
           relsGen, relsH, relsP, S, sizeS, stabG, stabS, table, tail, tail1,
-          tail2, tietze, tzword, undefined,
+          tail2, tietze, tzword, undefined,w,
           wordsH,allnums,fam,NewRelators,newrels,chunk, one;
 
     chunk:=ValueOption("chunk");
@@ -560,7 +560,9 @@ InstallGlobalFunction( RelatorsPermGroupHom, function ( hom, gensG )
     fi;
 
     # reduce the resulting presentation
-    TzGoGo( P );
+    if ValueOption("cheap")<>true then
+      TzGoGo( P );
+    fi;
 
     # reconvert the reduced relators and return them
     relsP := tietze[TZ_RELATORS];
@@ -568,9 +570,12 @@ InstallGlobalFunction( RelatorsPermGroupHom, function ( hom, gensG )
     for tzword in relsP do
       if tzword <> [ ] then
         if allnums then
-          Add( relsG, AssocWordByLetterRep(fam,tzword ));
+          w:=AssocWordByLetterRep(fam,tzword);
         else
-          Add( relsG, AbstractWordTietzeWord( tzword, gensF ) );
+          w:=AbstractWordTietzeWord( tzword, gensF );
+        fi;
+        if not w in relsG and not w^-1 in relsG then
+          Add( relsG, w);
         fi;
       fi;
     od;

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -1855,6 +1855,12 @@ local   F,      # free group
 end);
 
 
+# use this presentation also for rewriting
+InstallMethod(IsomorphismFpGroupForRewriting,"symmetric",
+  [IsNaturalSymmetricGroup],0,
+  IsomorphismFpGroup);
+
+
 #############################################################################
 ##
 #M  ViewObj( <nat-sym-grp> )

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1757,7 +1757,14 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,old,sim,
               Info(InfoExtReps,4,"mwrd=",mwrd);
               mgens:=List(mwrd,x->ImagesRepresentative(quot,x));
               nn:=Length(mgens);
-              mfpi:=IsomorphismFpGroupByGenerators(m,mgens);
+              if IsPermGroup(m) then
+                e:=SmallerDegreePermutationRepresentation(m);
+                mfpi:=IsomorphismFpGroupByGenerators(Image(e,m),
+                  List(mgens,x->ImagesRepresentative(e,x)):cheap);
+                mfpi:=e*mfpi;
+              else
+                mfpi:=IsomorphismFpGroupByGenerators(m,mgens:cheap);
+              fi;
               mmats:=List(mgens,x->ImagesRepresentative(hom,x));
 
               i:=Concatenation(r.module.generators,


### PR DESCRIPTION
These changes add a number of performance improvements for the 2-cohomology, to avoid certain cases of unreasonably bad performance:

- Use a special (Coxeter) rewriting system for symmetric group (not one built as A_n.2)
- Ensure special methods for simple groups are used when computing a presentation
- Avoid unneeded (and complicating) use of Tietze trnsformations when using rewriting presentation.

They still should go into 4.11 and will not have impact outside the new 2-cohomology code.

The changes in twocohom.gi look larger as they are due to whitespace/ indentation when moving existing code into an `if` clause.
