### PR TITLE
Require gcovr 4.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ build_script:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
   - SET "PATH=%CYG_ROOT%\bin;%PATH%"
-  - python -m pip install gcovr # for coverage reporting later on
+  - python -m pip install gcovr==4.1 # for coverage reporting later on
   - bash -lc "gcc --version"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./etc/ci-prepare.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ matrix:
 script:
   - set -e
   - etc/travis_fastfail.sh
-  - pip install --user gcovr
+  - pip install --user gcovr==4.1
   - bash etc/ci-prepare.sh
   - bash etc/ci.sh
 


### PR DESCRIPTION
Version 4.2, released yesterday, causes the problem and breaks Travis tests
```
> > > gap> gap> Scanning for coverage data...
gap> gap> > > > > >   coverage/testtravis.coverage
gap> > Merging 1 coverage files...
> > > > > > > > > > Outputting JSON for Codecov...
> > > Outputting JSON for Coveralls...
> > > > > > > gap> +[[ -f gap-coveralls.json ]]
+python etc/ci-gcovr-coverage.py -r . --output c-coveralls.json --exclude-directories pkg/ --exclude-directories extern/
Traceback (most recent call last):
  File "etc/ci-gcovr-coverage.py", line 49, in <module>
    from gcovr.gcov import get_datafiles, process_existing_gcov_file, process_datafile
ImportError: cannot import name get_datafiles
```

