### PR TITLE
fixed ConstituentsOfCharacter for Brauer character

### DIFF
--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -1393,8 +1393,13 @@ DeclareAttribute( "ClassPositionsOfCentre", IsHomogeneousList );
 ##  <Attr Name="ConstituentsOfCharacter" Arg='[tbl, ]chi'/>
 ##
 ##  <Description>
-##  is the set of irreducible characters that occur in the decomposition of
-##  the (virtual) character <A>chi</A> with nonzero coefficient.
+##  Let <A>chi</A> be an ordinary or modular (virtual) character.
+##  If an ordinary or modular character table <A>tbl</A> is given then
+##  <A>chi</A> may also be a list of character values.
+##  <P/>
+##  <Ref Attr="ConstituentsOfCharacter"/> returns
+##  the set of those irreducible characters that occur in the decomposition
+##  of <A>chi</A> with nonzero coefficient.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> nat:= NaturalCharacter( S4 );

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -1832,11 +1832,10 @@ InstallMethod( ConstituentsOfCharacter,
     chi -> ConstituentsOfCharacter( UnderlyingCharacterTable( chi ), chi ) );
 
 InstallMethod( ConstituentsOfCharacter,
-    "for a character",
-    [ IsClassFunction and IsCharacter ],
-    function( chi )
-    local tbl,    # underlying table of `chi'
-          irr,    # irreducible characters of `tbl'
+    "for an ordinary table, and a character",
+    [ IsOrdinaryTable, IsClassFunction and IsCharacter ],
+    function( tbl, chi )
+    local irr,    # irreducible characters of `tbl'
           values, # character values
           deg,    # degree of `chi'
           const,  # list of constituents, result
@@ -1881,7 +1880,7 @@ InstallMethod( ConstituentsOfCharacter,
       scpr:= ScalarProduct( tbl, chi, i );
       if scpr <> 0 then
         Add( const, i );
-        proper:= proper and IsInt( scpr ) and ( 0 < scpr );
+        proper:= proper and IsPosInt( scpr );
       fi;
     od;
 
@@ -1897,15 +1896,18 @@ InstallMethod( ConstituentsOfCharacter,
     "for a Brauer table, and a homogeneous list",
     [ IsBrauerTable, IsHomogeneousList ],
     function( tbl, chi )
-    local irr,    # irreducible characters of `tbl'
-          dec;
+    local irr, intA, intB, dec;
 
     irr:= Irr( tbl );
-    dec:= Decomposition( irr, [ chi ], "nonnegative" )[1];
+    intA:= IntegralizedMat( irr );
+    intB:= IntegralizedMat( [ chi ], intA.inforec );
+    dec:= SolutionIntMat( intA.mat, intB.mat[1] );
     if dec = fail then
-      TryNextMethod();
+      Error( "<chi> is not a virtual character of <tbl>" );
     fi;
-    return irr{ Filtered( [ 1 .. Length( dec ) ], i -> dec[i] <> 0 ) };
+
+    return SortedList( irr{ Filtered( [ 1 .. Length( dec ) ],
+                                      i -> dec[i] <> 0 ) } );
     end );
 
 

--- a/tst/teststandard/ctblfuns.tst
+++ b/tst/teststandard/ctblfuns.tst
@@ -1,0 +1,37 @@
+#@local ordtbl, modtbl, irr, chi, const, ibr, phi
+gap> START_TEST( "ctblfuns.tst" );
+
+#
+gap> ordtbl:= CharacterTable( GL(2,3) );;
+gap> modtbl:= ordtbl mod 2;;
+gap> irr:= Irr( ordtbl );;
+gap> chi:= irr[5] * irr[5];;
+gap> const:= ConstituentsOfCharacter( chi );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1, 1, 1, 1, -1, -1, -1 ], [ 3, 0, 3, 0, -1, -1, -1, 1 ] ]
+gap> const:= ConstituentsOfCharacter( -chi );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1, 1, 1, 1, -1, -1, -1 ], [ 3, 0, 3, 0, -1, -1, -1, 1 ] ]
+gap> const:= ConstituentsOfCharacter( ordtbl, chi );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1, 1, 1, 1, -1, -1, -1 ], [ 3, 0, 3, 0, -1, -1, -1, 1 ] ]
+gap> const:= ConstituentsOfCharacter( ordtbl, ValuesOfClassFunction( chi ) );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1, 1, 1, 1, -1, -1, -1 ], [ 3, 0, 3, 0, -1, -1, -1, 1 ] ]
+gap> ibr:= Irr( modtbl );;
+gap> phi:= ibr[2] * ibr[2];;
+gap> const:= ConstituentsOfCharacter( phi );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1 ], [ 2, -1 ] ]
+gap> const:= ConstituentsOfCharacter( -phi );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1 ], [ 2, -1 ] ]
+gap> const:= ConstituentsOfCharacter( modtbl, phi );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1 ], [ 2, -1 ] ]
+gap> const:= ConstituentsOfCharacter( modtbl, ValuesOfClassFunction( phi ) );;
+gap> List( const, ValuesOfClassFunction );
+[ [ 1, 1 ], [ 2, -1 ] ]
+
+#
+gap> STOP_TEST( "ctblfuns.tst" );


### PR DESCRIPTION
# Description
The two bugs mentioned in the text for release notes (see below) are now fixed,
some tests for the variants of arguments are available,
and the documentation states which cases are admissible:
ordinary or modular characters,
ordinary or modular virtual characters.

## Text for release notes 
The result of <code class="code">ConstituentsOfCharacter</code>, when called with a Brauer character as its only argument, was not reliable.
(This bug has been reported by Gabriel Navarro.)
Also, calling <code class="code">ConstituentsOfCharacter</code> with a Brauer character table and a virtual Brauer character caused error messages. 
