### PR TITLE
WIP: Making HPC-GAP work with Julia

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -64,9 +64,7 @@ SOURCES += src/intfuncs.c
 SOURCES += src/intrprtr.c
 SOURCES += src/io.c
 SOURCES += src/iostream.c
-ifeq ($(HPCGAP),no)             # we don't support a kernel API in HPC-GAP atm
 SOURCES += src/libgap-api.c
-endif
 SOURCES += src/listfunc.c
 SOURCES += src/listoper.c
 SOURCES += src/lists.c

--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,13 @@ AC_MSG_CHECKING([whether to use guards for race protection in HPC-GAP])
 AC_MSG_RESULT([$enable_guards])
 
 dnl
+dnl Check: --enable-guards requires --enable-hpcgap
+dnl
+
+AS_IF([[test "x$enable_guards" == "xyes" && test "x$enable_hpcgap" == "xno"]],
+  [AC_MSG_ERROR([Option --enable-guards requires --enable-hpcgap])])
+
+dnl
 dnl User setting: native thread-local storage (off by default)
 dnl See src/hpc/tls.h for more details on thread-local storage options.
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -205,6 +205,22 @@ AS_CASE([$with_gc],
 AC_MSG_RESULT([$with_gc])
 
 dnl
+dnl User setting: disable guards (race protection)
+dnl
+
+AC_ARG_ENABLE([guards],
+    [AS_HELP_STRING([--enable-guards],
+        [enable guards for race protection in HPC-GAP])],
+    [enable_guards=$enableval],
+    [enable_guards=no])
+
+AS_IF([[test "x$enable_guards" == "xyes"]], [
+    AC_DEFINE([USE_HPC_GUARDS], [1], [define as 1 if guards should be checked])
+])
+AC_MSG_CHECKING([whether to use guards for race protection in HPC-GAP])
+AC_MSG_RESULT([$enable_guards])
+
+dnl
 dnl User setting: native thread-local storage (off by default)
 dnl See src/hpc/tls.h for more details on thread-local storage options.
 dnl
@@ -915,6 +931,9 @@ AS_IF([test "x$enable_hpcgap" = xyes],[
   AS_BOX([WARNING: Experimental HPC-GAP mode enabled])
   dnl also enable backtrace, to help debug spurious crashes
   AC_DEFINE([GAP_PRINT_BACKTRACE], [1], [to enable backtraces upon crashes])
+  AS_IF([test "x$enable_guards" = xno], [
+    AS_BOX([WARNING: HPC-GAP guards (race condition protection) are disabled.])
+    ])
   ])
 
 AS_IF([test "x$enable_macos_tls_asm" = xno],[

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -23,7 +23,7 @@ BUILDDIR=$PWD
 
 if [[ $HPCGAP = yes ]]
 then
-  CONFIGFLAGS="--enable-hpcgap $CONFIGFLAGS"
+  CONFIGFLAGS="--enable-hpcgap --enable-guards $CONFIGFLAGS"
 fi
 
 
@@ -40,8 +40,22 @@ then
 fi
 
 
-# configure and make GAP
+# configure
 time "$SRCDIR/configure" --enable-Werror $CONFIGFLAGS
+
+if [[ $HPCGAP = yes ]]
+then
+  git clone https://github.com/rbehrends/unward
+  cd unward
+  ./configure CC=gcc CXX=g++ CFLAGS=-O2 CXXFLAGS=-O2
+  make
+  cd ..
+  unward/bin/unward --inplace src
+  # commit the result to prevent the docomp test from triggering
+  git commit -m "Unward" src
+fi
+
+# build GAP
 time make V=1 -j4
 
 # download packages; instruct wget to retry several times if the

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1983,8 +1983,6 @@ BIND_GLOBAL( "InstallGlobalFunction", function( arg )
     od;
 end );
 
-if not IsHPCGAP then
-
 BIND_GLOBAL( "FLUSH_ALL_METHOD_CACHES", function()
     local oper,j;
     for oper in OPERATIONS do
@@ -1993,8 +1991,6 @@ BIND_GLOBAL( "FLUSH_ALL_METHOD_CACHES", function()
         od;
     od;
 end);
-
-fi;
 
 if BASE_SIZE_METHODS_OPER_ENTRY <> 6 then
     Error("MethodsOperation must be updated for new BASE_SIZE_METHODS_OPER_ENTRY");

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -334,6 +334,9 @@ void RetypeBagIntern(Bag bag, UInt new_type)
     if (old_type == new_type)
         return;
 
+#if defined(HPCGAP) && defined(USE_HPC_GUARDS)
+    WriteGuard(bag);
+#endif
     /* change the size-type word                                           */
     header->type = new_type;
     {
@@ -456,6 +459,9 @@ UInt ResizeBag(Bag bag, UInt new_size)
     CollectBags(0, 0);
 #endif
 
+#if defined(HPCGAP) && defined(USE_HPC_GUARDS)
+    WriteGuard(bag);
+#endif
     BagHeader * header = BAG_HEADER(bag);
 
     /* get type and old size of the bag                                    */

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -299,6 +299,8 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr) {
 **  calling 'CHANGED_BAG(old)' in the above example (see "CHANGED_BAG").
 */
 #ifdef HPCGAP
+extern int ExtendedGuardCheck(Bag) PURE_FUNC;
+
 EXPORT_INLINE int ReadCheck(Bag bag)
 {
     Region *region;
@@ -309,18 +311,18 @@ EXPORT_INLINE int ReadCheck(Bag bag)
         return 1;
     if (region->readers[TLS(threadID)])
         return 1;
-    return 0;
+    return ExtendedGuardCheck(bag);
 }
 
 EXPORT_INLINE int WriteCheck(Bag bag)
 {
-    Region *region;
+    Region * region;
     region = REGION(bag);
-    return !region || region->owner == GetTLS();
+    return !region || region->owner == GetTLS() || ExtendedGuardCheck(bag);
 }
 
-extern void HandleReadGuardError(Bag);
-extern void HandleWriteGuardError(Bag);
+extern void HandleReadGuardError(Bag) NORETURN;
+extern void HandleWriteGuardError(Bag) NORETURN;
 #endif // HPCGAP
 
 EXPORT_INLINE Bag *PTR_BAG(Bag bag)

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -144,6 +144,46 @@ EXPORT_INLINE UInt TNUM_BAG(Bag bag)
     return BAG_HEADER(bag)->type;
 }
 
+/****************************************************************************
+**
+*F  ReadCheck(<bag>) . . . . . . . . . . . . . is the bag readable in HPCGAP?
+*F  WriteCheck(<bag>)  . . . . . . . . . . . . is the bag writable in HPCGAP?
+*F  HandleReadGuardError(<bag>)  . . . . . . . . . . signal read access error
+*F  HandleWriteGuardError(<bag>) . . . . . . . . .  signal write access error
+**
+**  These funtion handle access checks in HPCGAP, i.e. whether a bag can
+**  safely be read or modified without causing race conditions. These are
+**  called in functions such as PTR_BAG() and CONST_PTR_BAG(), which should
+**  implicitly or explicitly guard all object accesses. In order to access
+**  objects without triggering checks, alternative functions UNSAFE_PTR_BAG()
+**  and UNSAFE_CONST_PTR_BAG() are provided.
+*/
+#ifdef HPCGAP
+extern int ExtendedGuardCheck(Bag) PURE_FUNC;
+
+EXPORT_INLINE int ReadCheck(Bag bag)
+{
+    Region *region;
+    region = REGION(bag);
+    if (!region)
+        return 1;
+    if (region->owner == GetTLS())
+        return 1;
+    if (region->readers[TLS(threadID)])
+        return 1;
+    return ExtendedGuardCheck(bag);
+}
+
+EXPORT_INLINE int WriteCheck(Bag bag)
+{
+    Region * region;
+    region = REGION(bag);
+    return !region || region->owner == GetTLS() || ExtendedGuardCheck(bag);
+}
+
+extern void HandleReadGuardError(Bag) NORETURN;
+extern void HandleWriteGuardError(Bag) NORETURN;
+#endif // HPCGAP
 
 /****************************************************************************
 **
@@ -298,33 +338,6 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr) {
 **  the application  must inform {\Gasman}  that it  has changed  the bag, by
 **  calling 'CHANGED_BAG(old)' in the above example (see "CHANGED_BAG").
 */
-#ifdef HPCGAP
-extern int ExtendedGuardCheck(Bag) PURE_FUNC;
-
-EXPORT_INLINE int ReadCheck(Bag bag)
-{
-    Region *region;
-    region = REGION(bag);
-    if (!region)
-        return 1;
-    if (region->owner == GetTLS())
-        return 1;
-    if (region->readers[TLS(threadID)])
-        return 1;
-    return ExtendedGuardCheck(bag);
-}
-
-EXPORT_INLINE int WriteCheck(Bag bag)
-{
-    Region * region;
-    region = REGION(bag);
-    return !region || region->owner == GetTLS() || ExtendedGuardCheck(bag);
-}
-
-extern void HandleReadGuardError(Bag) NORETURN;
-extern void HandleWriteGuardError(Bag) NORETURN;
-#endif // HPCGAP
-
 EXPORT_INLINE Bag *PTR_BAG(Bag bag)
 {
     GAP_ASSERT(bag != 0);

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -38,6 +38,11 @@
 
 #include "common.h"
 
+#ifdef HPCGAP
+#include "hpc/region.h"
+#include "hpc/tls.h"
+#endif
+
 
 /****************************************************************************
 **
@@ -293,17 +298,70 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr) {
 **  the application  must inform {\Gasman}  that it  has changed  the bag, by
 **  calling 'CHANGED_BAG(old)' in the above example (see "CHANGED_BAG").
 */
+#ifdef HPCGAP
+EXPORT_INLINE int ReadCheck(Bag bag)
+{
+    Region *region;
+    region = REGION(bag);
+    if (!region)
+        return 1;
+    if (region->owner == GetTLS())
+        return 1;
+    if (region->readers[TLS(threadID)])
+        return 1;
+    return 0;
+}
+
+EXPORT_INLINE int WriteCheck(Bag bag)
+{
+    Region *region;
+    region = REGION(bag);
+    return !region || region->owner == GetTLS();
+}
+
+extern void HandleReadGuardError(Bag);
+extern void HandleWriteGuardError(Bag);
+#endif // HPCGAP
+
 EXPORT_INLINE Bag *PTR_BAG(Bag bag)
+{
+    GAP_ASSERT(bag != 0);
+#ifdef USE_HPC_GUARDS
+    if (!WriteCheck(bag))
+      HandleWriteGuardError(bag);
+#endif
+    return *(Bag**)bag;
+}
+
+#ifdef USE_HPC_GUARDS
+EXPORT_INLINE Bag *UNSAFE_PTR_BAG(Bag bag)
 {
     GAP_ASSERT(bag != 0);
     return *(Bag**)bag;
 }
+#else
+#define UNSAFE_PTR_BAG PTR_BAG
+#endif
 
 EXPORT_INLINE const Bag *CONST_PTR_BAG(Bag bag)
 {
     GAP_ASSERT(bag != 0);
+#ifdef USE_HPC_GUARDS
+    if (!ReadCheck(bag))
+      HandleReadGuardError(bag);
+#endif
     return *(const Bag * const *)bag;
 }
+
+#ifdef USE_HPC_GUARDS
+EXPORT_INLINE const Bag *UNSAFE_CONST_PTR_BAG(Bag bag)
+{
+    GAP_ASSERT(bag != 0);
+    return *(const Bag * const *)bag;
+}
+#else
+#define UNSAFE_CONST_PTR_BAG CONST_PTR_BAG
+#endif
 
 EXPORT_INLINE void SET_PTR_BAG(Bag bag, Bag *val)
 {

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1485,7 +1485,6 @@ Obj GVarFunction(GVarDescriptor *gvar)
     ErrorQuit("Global variable '%s' not initialized", (UInt)(gvar->name), 0);
   if (REGION(result))
     ErrorQuit("Global variable '%s' is not a function", (UInt)(gvar->name), 0);
-  ImpliedWriteGuard(result);
   if (TNUM_OBJ(result) != T_FUNCTION)
     ErrorQuit("Global variable '%s' is not a function", (UInt)(gvar->name), 0);
   MEMBAR_READ();
@@ -1499,7 +1498,6 @@ Obj GVarOptFunction(GVarDescriptor *gvar)
     return (Obj) 0;
   if (REGION(result))
     return (Obj) 0;
-  ImpliedWriteGuard(result);
   if (TNUM_OBJ(result) != T_FUNCTION)
     return (Obj) 0;
   MEMBAR_READ();

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -11,6 +11,7 @@
 #ifndef GAP_HPC_GUARD_H
 #define GAP_HPC_GUARD_H
 
+#include "gasman.h"
 #include "hpc/region.h"
 #include "hpc/tls.h"
 
@@ -18,101 +19,64 @@
 #error This header is only meant to be used with HPC-GAP
 #endif
 
-#ifdef VERBOSE_GUARDS
-void WriteGuardError(Bag bag,
-    const char *file, unsigned line, const char *func, const char *expr);
-void ReadGuardError(Bag bag,
-    const char *file, unsigned line, const char *func, const char *expr);
-#else
-void WriteGuardError(Bag bag);
-void ReadGuardError(Bag bag);
-#endif
-
-#ifdef VERBOSE_GUARDS
-#define WriteGuard(bag) WriteGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
-static ALWAYS_INLINE Bag WriteGuardFull(Bag bag,
-  const char *file, unsigned line, const char *func, const char *expr)
-#else
 static ALWAYS_INLINE Bag WriteGuard(Bag bag)
-#endif
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
+    if (!WriteCheck(bag))
+        HandleWriteGuardError(bag);
     return bag;
-  region = REGION(bag);
-  if (region && region->owner != GetTLS() && region->alt_owner != GetTLS())
-    WriteGuardError(bag
-#ifdef VERBOSE_GUARDS
-    , file, line, func, expr
-#endif
-    );
-  return bag;
 }
+
 
 EXPORT_INLINE Bag ImpliedWriteGuard(Bag bag)
 {
-  return bag;
+    return bag;
 }
 
 EXPORT_INLINE int CheckWriteAccess(Bag bag)
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  return !(region && region->owner != GetTLS() && region->alt_owner != GetTLS())
-    || TLS(DisableGuards) >= 2;
+    Region * region;
+    if (!IS_BAG_REF(bag))
+        return 1;
+    region = REGION(bag);
+    return !(region && region->owner != GetTLS() &&
+             region->alt_owner != GetTLS()) ||
+           TLS(DisableGuards) >= 2;
 }
 
 EXPORT_INLINE int CheckExclusiveWriteAccess(Bag bag)
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  if (!region)
-    return 0;
-  return region->owner == GetTLS() || region->alt_owner == GetTLS()
-    || TLS(DisableGuards) >= 2;
+    Region * region;
+    if (!IS_BAG_REF(bag))
+        return 1;
+    region = REGION(bag);
+    if (!region)
+        return 0;
+    return region->owner == GetTLS() || region->alt_owner == GetTLS() ||
+           TLS(DisableGuards) >= 2;
 }
 
-#ifdef VERBOSE_GUARDS
-#define ReadGuard(bag) ReadGuardFull(bag, __FILE__, __LINE__, __FUNCTION__, #bag)
-static ALWAYS_INLINE Bag ReadGuardFull(Bag bag,
-  const char *file, unsigned line, const char *func, const char *expr)
-#else
 static ALWAYS_INLINE Bag ReadGuard(Bag bag)
-#endif
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
+    if (!ReadCheck(bag))
+        HandleReadGuardError(bag);
     return bag;
-  region = REGION(bag);
-  if (region && region->owner != GetTLS() &&
-      !region->readers[TLS(threadID)] && region->alt_owner != GetTLS())
-    ReadGuardError(bag
-#ifdef VERBOSE_GUARDS
-    , file, line, func, expr
-#endif
-    );
-  return bag;
 }
-
 
 static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
 {
-  return bag;
+    return bag;
 }
 
 static ALWAYS_INLINE int CheckReadAccess(Bag bag)
 {
-  Region *region;
-  if (!IS_BAG_REF(bag))
-    return 1;
-  region = REGION(bag);
-  return !(region && region->owner != GetTLS() &&
-    !region->readers[TLS(threadID)] && region->alt_owner != GetTLS())
-    || TLS(DisableGuards) >= 2;
+    Region * region;
+    if (!IS_BAG_REF(bag))
+        return 1;
+    region = REGION(bag);
+    return !(region && region->owner != GetTLS() &&
+             !region->readers[TLS(threadID)] &&
+             region->alt_owner != GetTLS()) ||
+           TLS(DisableGuards) >= 2;
 }
 
-#endif // GAP_HPC_GUARD_H
+#endif    // GAP_HPC_GUARD_H

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -27,11 +27,6 @@ static ALWAYS_INLINE Bag WriteGuard(Bag bag)
 }
 
 
-EXPORT_INLINE Bag ImpliedWriteGuard(Bag bag)
-{
-    return bag;
-}
-
 EXPORT_INLINE int CheckWriteAccess(Bag bag)
 {
     Region * region;
@@ -59,11 +54,6 @@ static ALWAYS_INLINE Bag ReadGuard(Bag bag)
 {
     if (!ReadCheck(bag))
         HandleReadGuardError(bag);
-    return bag;
-}
-
-static ALWAYS_INLINE Bag ImpliedReadGuard(Bag bag)
-{
     return bag;
 }
 

--- a/src/hpc/guards.h
+++ b/src/hpc/guards.h
@@ -21,14 +21,17 @@
 
 static ALWAYS_INLINE Bag WriteGuard(Bag bag)
 {
+#ifdef USE_HPC_GUARDS
     if (!WriteCheck(bag))
         HandleWriteGuardError(bag);
+#endif
     return bag;
 }
 
 
 EXPORT_INLINE int CheckWriteAccess(Bag bag)
 {
+#ifdef USE_HPC_GUARDS
     Region * region;
     if (!IS_BAG_REF(bag))
         return 1;
@@ -36,10 +39,14 @@ EXPORT_INLINE int CheckWriteAccess(Bag bag)
     return !(region && region->owner != GetTLS() &&
              region->alt_owner != GetTLS()) ||
            TLS(DisableGuards) >= 2;
+#else
+    return 1;
+#endif
 }
 
 EXPORT_INLINE int CheckExclusiveWriteAccess(Bag bag)
 {
+#ifdef USE_HPC_GUARDS
     Region * region;
     if (!IS_BAG_REF(bag))
         return 1;
@@ -48,17 +55,23 @@ EXPORT_INLINE int CheckExclusiveWriteAccess(Bag bag)
         return 0;
     return region->owner == GetTLS() || region->alt_owner == GetTLS() ||
            TLS(DisableGuards) >= 2;
+#else
+    return 1;
+#endif
 }
 
 static ALWAYS_INLINE Bag ReadGuard(Bag bag)
 {
+#ifdef USE_HPC_GUARDS
     if (!ReadCheck(bag))
         HandleReadGuardError(bag);
+#endif
     return bag;
 }
 
 static ALWAYS_INLINE int CheckReadAccess(Bag bag)
 {
+#ifdef USE_HPC_GUARDS
     Region * region;
     if (!IS_BAG_REF(bag))
         return 1;
@@ -67,6 +80,9 @@ static ALWAYS_INLINE int CheckReadAccess(Bag bag)
              !region->readers[TLS(threadID)] &&
              region->alt_owner != GetTLS()) ||
            TLS(DisableGuards) >= 2;
+#else
+    return 1;
+#endif
 }
 
 #endif    // GAP_HPC_GUARD_H

--- a/src/hpc/misc.c
+++ b/src/hpc/misc.c
@@ -50,7 +50,7 @@ UInt SyNumGCThreads = 0;
 *V  SingleThreadStartup . . . . . . . . .  start HPC-GAP with just one thread
 **
 */
-UInt SingleThreadStartup = 0;
+UInt SingleThreadStartup = 1;
 
 /****************************************************************************
 **

--- a/src/hpc/region.c
+++ b/src/hpc/region.c
@@ -41,6 +41,10 @@ Region * NewRegion(void)
     result = GC_malloc(sizeof(Region) + (MAX_THREADS + 1));
     lock = GC_malloc_atomic(sizeof(*lock));
     GC_register_finalizer(lock, LockFinalizer, NULL, NULL, NULL);
+#elif defined(USE_JULIA_GC)
+    result = AllocateMemoryBlock(sizeof(Region) + (MAX_THREADS + 1));
+    lock = AllocateMemoryBlock(sizeof(*lock));
+    // NYI: finalize locks
 #else
     #error Not yet implemented for this garbage collector
 #endif
@@ -79,3 +83,4 @@ void RetypeBagIfWritable(Obj obj, UInt new_type)
     if (CheckWriteAccess(obj))
         RetypeBag(obj, new_type);
 }
+

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1317,11 +1317,20 @@ Region * CurrentRegion(void)
     return TLS(currentRegion);
 }
 
+// Kernel debugging information for guards.
+//
+// When compiled with -DDEBUG_GUARDS, the GAP variable GUARD_ERROR_STACK
+// will contain the C stack after an error, allowing us to located where
+// it occurred without having to fire up a debugger first.
+//
+// The variables NumReadErrors and NumWriteErrors track the number of
+// failed guard checks. These are used in conjunction with the low-level
+// function DISABLE_GUARDS() in order to track how many guard failures
+// occur in a given section of code.
+
 #ifdef DEBUG_GUARDS
 extern GVarDescriptor GUARD_ERROR_STACK;
 #endif
-
-// These are temporary debugging functions.
 
 static Int NumReadErrors = 0;
 static Int NumWriteErrors = 0;

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1319,9 +1319,10 @@ Region * CurrentRegion(void)
 
 // Kernel debugging information for guards.
 //
-// When compiled with -DDEBUG_GUARDS, the GAP variable GUARD_ERROR_STACK
-// will contain the C stack after an error, allowing us to located where
-// it occurred without having to fire up a debugger first.
+// When DEBUG_GUARDS is #defined, the GAP variable GUARD_ERROR_STACK
+// is set to a GAP plain list describing the C stack after an error,
+// allowing us to located where it occurred without having to fire up a
+// debugger first.
 //
 // The variables NumReadErrors and NumWriteErrors track the number of
 // failed guard checks. These are used in conjunction with the low-level

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -1369,15 +1369,20 @@ void SetGuardErrorStack(void)
 }
 #endif
 
-void HandleReadGuardError(Bag bag)
+int ExtendedGuardCheck(Bag bag)
 {
-    NumReadErrors++;
     // We shift some of the rarer checks here to
     // avoid overloading ReadCheck().
     if (REGION(bag)->alt_owner == GetTLS())
-        return;
+        return 1;
     if (TLS(DisableGuards))
-        return;
+        return 1;
+    return 0;
+}
+
+void HandleReadGuardError(Bag bag)
+{
+    NumReadErrors++;
     SetGVar(&LastInaccessibleGVar, bag);
 #ifdef DEBUG_GUARDS
     SetGuardErrorStack();
@@ -1392,10 +1397,6 @@ void HandleWriteGuardError(Bag bag)
     NumWriteErrors++;
     // We shift some of the rarer checks here to
     // avoid overloading ReadCheck().
-    if (REGION(bag)->alt_owner == GetTLS())
-        return;
-    if (TLS(DisableGuards))
-        return;
     SetGVar(&LastInaccessibleGVar, bag);
 #ifdef DEBUG_GUARDS
     SetGuardErrorStack();

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -37,6 +37,10 @@
 #  define GC_THREADS
 # endif
 # include <gc/gc.h>
+#elif USE_JULIA_GC
+# ifdef HPCGAP
+#  include "julia_gc.h"
+# endif
 #endif
 
 

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -483,6 +483,7 @@ static void ThreadedInterpreter(void * funcargs)
 
 static Obj FuncCreateThread(Obj self, Obj funcargs)
 {
+#ifndef USE_JULIA_GC
     Int  i, n;
     Obj  thread;
     Obj  templist;
@@ -502,6 +503,10 @@ static Obj FuncCreateThread(Obj self, Obj funcargs)
     if (!thread)
         return Fail;
     return thread;
+#else
+    ErrorMayQuit("CreateThread: disabled with Julia GC", 0, 0);
+    return 0; // flow control hint
+#endif
 }
 
 /****************************************************************************
@@ -2353,7 +2358,7 @@ void InitSignals(void)
     timer.it_interval.tv_usec = 10000;
     timer.it_value.tv_sec = 0;
     timer.it_value.tv_usec = 10000;
-    setitimer(ITIMER_VIRTUAL, &timer, NULL);
+    // setitimer(ITIMER_VIRTUAL, &timer, NULL);
 }
 
 static Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -957,6 +957,9 @@ static void PrintRegion(Obj);
 
 GVarDescriptor LastInaccessibleGVar;
 static GVarDescriptor MAX_INTERRUPTGVar;
+#ifdef DEBUG_GUARDS
+GVarDescriptor GUARD_ERROR_STACK;
+#endif
 
 static UInt RNAM_SIGINT;
 static UInt RNAM_SIGCHLD;
@@ -2645,6 +2648,9 @@ static Int InitKernel(StructInitInfo * module)
 
     DeclareGVar(&LastInaccessibleGVar, "LastInaccessible");
     DeclareGVar(&MAX_INTERRUPTGVar, "MAX_INTERRUPT");
+#ifdef DEBUG_GUARDS
+    DeclareGVar(&GUARD_ERROR_STACK, "GUARD_ERROR_STACK");
+#endif
 
     // install mark functions
     InitMarkFuncBags(T_THREAD, MarkNoSubBags);

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -483,7 +483,6 @@ static void ThreadedInterpreter(void * funcargs)
 
 static Obj FuncCreateThread(Obj self, Obj funcargs)
 {
-#ifndef USE_JULIA_GC
     Int  i, n;
     Obj  thread;
     Obj  templist;
@@ -503,10 +502,6 @@ static Obj FuncCreateThread(Obj self, Obj funcargs)
     if (!thread)
         return Fail;
     return thread;
-#else
-    ErrorMayQuit("CreateThread: disabled with Julia GC", 0, 0);
-    return 0; // flow control hint
-#endif
 }
 
 /****************************************************************************

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -46,6 +46,10 @@
 
 #include <pthread.h>
 
+#ifdef USE_JULIA_GC
+#include "libgap-api.h"
+#endif
+
 
 #define RequireThread(funcname, op, argname)                                 \
     RequireArgumentConditionEx(funcname, op, "<" argname ">",                \
@@ -430,6 +434,20 @@ void StopKeepAlive(Obj node)
 
 static GVarDescriptor GVarTHREAD_INIT;
 static GVarDescriptor GVarTHREAD_EXIT;
+
+#ifdef USE_JULIA_GC
+#define INTERPRETER_INIT 2
+void InitInterpreterState()
+{
+    if ((TLS(threadInit) & INTERPRETER_INIT) == 0) {
+        GAP_InitializeThread();
+    }
+    TLS(threadInit) |= INTERPRETER_INIT;
+    STATE(NrError) = 0;
+    STATE(ThrownObject) = 0;
+    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+}
+#endif
 
 static void ThreadedInterpreter(void * funcargs)
 {

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -69,6 +69,7 @@ typedef struct Region Region;
 typedef struct ThreadLocalStorage
 {
   int threadID;
+  int threadInit;
   void *threadLock;
   void *threadSignal;
   void *acquiredMonitor;

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -108,18 +108,6 @@ extern __thread ThreadLocalStorage *TLSInstance;
 
 #include <pthread.h>
 
-#ifdef HAVE_FUNC_ATTRIBUTE_PURE
-#define PURE_FUNC __attribute__((pure))
-#else
-#define PURE_FUNC
-#endif
-
-#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
-#define CONSTRUCTOR_FUNC __attribute__((constructor))
-#else
-#define CONSTRUCTOR_FUNC
-#endif
-
 #ifdef ALLOW_PURE_PTHREAD_GETSPECIFIC
 // pthread_getspecific() is not defined as pure by default; redeclaring
 // it as such works for gcc/clang and allows the compiler to hoist calls

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -37,6 +37,10 @@
 #include <julia.h>
 #include <julia_gcext.h>
 
+#ifdef HPCGAP
+#include "hpc/thread.h"
+#endif
+
 
 /****************************************************************************
 **
@@ -200,7 +204,6 @@ static size_t          max_pool_obj_size;
 static UInt            YoungRef;
 static int             FullGC;
 
-#if !defined(SCAN_STACK_FOR_MPTRS_ONLY)
 typedef struct {
     void * addr;
     size_t size;
@@ -224,6 +227,9 @@ static inline int CmpMemBlock(MemBlock m1, MemBlock m2)
 
 #include "baltree.h"
 
+static MemBlockTree * gc_roots;
+
+#if !defined(SCAN_STACK_FOR_MPTRS_ONLY)
 static size_t         bigval_startoffset;
 static MemBlockTree * bigvals;
 
@@ -564,6 +570,20 @@ void CHANGED_BAG(Bag bag)
     jl_gc_wb_back(BAG_HEADER(bag));
 }
 
+#ifdef HPCGAP
+static void ScanExtraRoots(MemBlockNode * node)
+{
+    if (node) {
+        ScanExtraRoots(node->left);
+        MemBlock mem = node->item;
+        char *start = mem.addr;
+        char *end = start + mem.size;
+        TryMarkRange(start, end);
+        ScanExtraRoots(node->right);
+    }
+}
+#endif
+
 static void GapRootScanner(int full)
 {
     // Mark our Julia module (this contains references to our custom data
@@ -591,6 +611,10 @@ static void GapRootScanner(int full)
     // The reason is that if Julia is being initialized from GAP, it
     // cannot always reliably find the top of the stack for that task,
     // so we have to fall back to GAP for that.
+#ifdef HPCGAP
+#define IsUsingLibGap() 0
+    ScanExtraRoots(gc_roots->root);
+#endif
     if (!IsUsingLibGap() && JuliaTLS->tid == 0 &&
         JuliaTLS->root_task == task) {
         stackend = (char *)GapStackBottom;
@@ -752,6 +776,7 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
     }
     // These callbacks need to be set before initialization so
     // that we can track objects allocated during `jl_init()`.
+    gc_roots = MemBlockTreeMake();
 #if !defined(SCAN_STACK_FOR_MPTRS_ONLY)
     bigvals = MemBlockTreeMake();
     jl_gc_set_cb_notify_external_alloc(alloc_bigval, 1);
@@ -761,6 +786,7 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
     max_pool_obj_size = jl_gc_max_internal_obj_size();
     jl_gc_enable_conservative_gc_support();
     jl_init();
+    jl_gc_enable(0);
 
     Module = jl_new_module(jl_symbol("ForeignGAP"));
     Module->parent = jl_main_module;
@@ -827,6 +853,10 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
     GAP_ASSERT(jl_is_datatype(datatype_bag));
     GAP_ASSERT(jl_is_datatype(datatype_largebag));
     StackAlignBags = stack_align;
+#ifdef HPCGAP
+    CreateMainRegion();
+    AddGCRoots();
+#endif
 }
 
 UInt CollectBags(UInt size, UInt full)
@@ -835,6 +865,25 @@ UInt CollectBags(UInt size, UInt full)
     jl_gc_collect(full);
     return 1;
 }
+
+/****************************************************************************
+**
+*V  DSInfoBags[<type>]  . . . .  . . . . . . . . . .  region info for bags
+*/
+
+#ifdef HPCGAP
+
+static char DSInfoBags[NUM_TYPES];
+
+#define DSI_TL 0
+#define DSI_PUBLIC 1
+
+void MakeBagTypePublic(int type)
+{
+    DSInfoBags[type] = DSI_PUBLIC;
+}
+
+#endif // HPCGAP
 
 void RetypeBagIntern(Bag bag, UInt new_type)
 {
@@ -883,6 +932,13 @@ void RetypeBagIntern(Bag bag, UInt new_type)
         Panic("cannot change bag type to one requiring a 'free' callback");
     }
     header->type = new_type;
+#ifdef HPCGAP
+    switch (DSInfoBags[new_type]) {
+    case DSI_PUBLIC:
+        SET_REGION(bag, NULL);
+        break;
+    }
+#endif // HPCGAP
 }
 
 Bag NewBag(UInt type, UInt size)
@@ -906,7 +962,11 @@ Bag NewBag(UInt type, UInt size)
         alloc_size++;
 
 #if defined(SCAN_STACK_FOR_MPTRS_ONLY)
+#ifdef HPCGAP
+    bag = jl_gc_alloc_typed(JuliaTLS, 2 * sizeof(void *), datatype_mptr);
+#else
     bag = jl_gc_alloc_typed(JuliaTLS, sizeof(void *), datatype_mptr);
+#endif
     SET_PTR_BAG(bag, 0);
 #endif
 
@@ -917,6 +977,16 @@ Bag NewBag(UInt type, UInt size)
     header->size = size;
 
 
+#ifdef HPCGAP
+    switch (DSInfoBags[type]) {
+    case DSI_TL:
+        SET_REGION(bag, CurrentRegion());
+        break;
+    case DSI_PUBLIC:
+        SET_REGION(bag, NULL);
+        break;
+    }
+#endif
 #if !defined(SCAN_STACK_FOR_MPTRS_ONLY)
     // allocate the new masterpointer
     bag = jl_gc_alloc_typed(JuliaTLS, sizeof(void *), datatype_mptr);
@@ -1047,4 +1117,22 @@ void MarkJuliaWeakRef(void * p)
     // be live regardless.
     if (JMarkTyped(p, jl_weakref_type))
         YoungRef++;
+}
+
+void *AllocateMemoryBlock(UInt size)
+{
+    return calloc(1, size);
+}
+
+
+void GC_add_roots(void *start, void *end)
+{
+    MemBlock mem = { start, (char *) end - (char *) start };
+    MemBlockTreeInsert(gc_roots, mem);
+}
+
+void GC_remove_roots(void *start, void *end)
+{
+    MemBlock mem = { start, (char *) end - (char *) start };
+    MemBlockTreeRemove(gc_roots, mem);
 }

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -785,6 +785,10 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
 #endif
     max_pool_obj_size = jl_gc_max_internal_obj_size();
     jl_gc_enable_conservative_gc_support();
+#ifdef HPCGAP
+    if (!getenv("JULIA_NUM_THREADS"))
+        setenv("JULIA_NUM_THREADS", "16", 0); // TODO: make configurable
+#endif
     jl_init();
     jl_gc_enable(0);
 

--- a/src/julia_gc.h
+++ b/src/julia_gc.h
@@ -45,4 +45,15 @@ void MarkJuliaObjSafe(void * obj);
 
 void MarkJuliaWeakRef(void * obj);
 
+/****************************************************************************
+**
+*F  GC_add_roots(<start>, <end>)  . . . . . . . . . . . . . . .  add GC roots
+*F  GC_remove_roots(<start>, <end>) . . . . . . . . . . . . . remove GC roots
+**
+**  Add or remove additional roots for the Julia GC.
+*/
+
+void GC_add_roots(void * start, void * end);
+void GC_remove_roots(void * start, void * end);
+
 #endif

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -56,6 +56,12 @@ void GAP_Initialize(int              argc,
                     int              handleSignals)
 {
     UsingLibGap = TRUE;
+#ifdef HPCGAP
+#if !defined(USE_NATIVE_TLS) && !defined(USE_PTHREAD_TLS)
+    Panic("The HPC-GAP version of libgap requires --enable-native-tls");
+#endif
+    InitializeTLS();
+#endif
 
     InitializeGap(&argc, argv, handleSignals);
     SetExtraMarkFuncBags(markBagsCallback);
@@ -65,6 +71,16 @@ void GAP_Initialize(int              argc,
     GAP_False = False;
     GAP_Fail = Fail;
 }
+
+#ifdef HPCGAP
+void GAP_InitializeThread(void)
+{
+    if (!TLS(threadInit)) {
+        TLS(threadInit) = 1;
+        InitializeTLS();
+    }
+}
+#endif
 
 
 ////

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -159,6 +159,9 @@ void GAP_Initialize(int              argc,
                     GAP_CallbackFunc errorCallback,
                     int              handleSignals);
 
+#ifdef HPCGAP
+void GAP_InitializeThread(void);
+#endif
 
 ////
 //// program evaluation and execution

--- a/src/lists.c
+++ b/src/lists.c
@@ -146,7 +146,6 @@ static Obj AttrLENGTH(Obj self, Obj list)
     /* internal list types                                                 */
 #ifdef HPCGAP
     ReadGuard(list);
-    ImpliedWriteGuard(list);
     if ( (FIRST_LIST_TNUM<=TNUM_OBJ(list) && TNUM_OBJ(list)<=LAST_LIST_TNUM)
          || TNUM_OBJ(list) == T_ALIST || TNUM_OBJ(list) == T_FIXALIST) {
         return ObjInt_Int( LEN_LIST(list) );

--- a/src/lists.c
+++ b/src/lists.c
@@ -145,7 +145,6 @@ static Obj AttrLENGTH(Obj self, Obj list)
 {
     /* internal list types                                                 */
 #ifdef HPCGAP
-    ReadGuard(list);
     if ( (FIRST_LIST_TNUM<=TNUM_OBJ(list) && TNUM_OBJ(list)<=LAST_LIST_TNUM)
          || TNUM_OBJ(list) == T_ALIST || TNUM_OBJ(list) == T_FIXALIST) {
         return ObjInt_Int( LEN_LIST(list) );

--- a/src/objects.c
+++ b/src/objects.c
@@ -210,18 +210,10 @@ void SET_TYPE_OBJ(Obj obj, Obj type)
         CHANGED_BAG(obj);
         break;
     case T_COMOBJ:
-#ifdef HPCGAP
-        ReadGuard(obj);
-        MEMBAR_WRITE();
-#endif
         SET_TYPE_COMOBJ(obj, type);
         CHANGED_BAG(obj);
         break;
     case T_POSOBJ:
-#ifdef HPCGAP
-        ReadGuard(obj);
-        MEMBAR_WRITE();
-#endif
         SET_TYPE_POSOBJ(obj, type);
         CHANGED_BAG(obj);
         break;

--- a/src/objects.h
+++ b/src/objects.h
@@ -841,7 +841,13 @@ EXPORT_INLINE Obj TYPE_COMOBJ(Obj obj)
 */
 EXPORT_INLINE void SET_TYPE_COMOBJ(Obj obj, Obj val)
 {
+#ifdef HPCGAP
+    MEMBAR_WRITE();
+    // Only require a read guard
+    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+#else
     ADDR_OBJ(obj)[0] = val;
+#endif
 }
 
 
@@ -884,7 +890,13 @@ EXPORT_INLINE Obj TYPE_POSOBJ(Obj obj)
 */
 EXPORT_INLINE void SET_TYPE_POSOBJ(Obj obj, Obj val)
 {
+#ifdef HPCGAP
+    MEMBAR_WRITE();
+    // Only require a read guard
+    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+#else
     ADDR_OBJ(obj)[0] = val;
+#endif
 }
 
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -831,7 +831,11 @@ EXPORT_INLINE BOOL IS_COMOBJ(Obj obj)
 */
 EXPORT_INLINE Obj TYPE_COMOBJ(Obj obj)
 {
-    return CONST_ADDR_OBJ(obj)[0];
+    Obj result = CONST_ADDR_OBJ(obj)[0];
+#ifdef HPCGAP
+    MEMBAR_READ();
+#endif
+    return result;
 }
 
 
@@ -843,8 +847,7 @@ EXPORT_INLINE void SET_TYPE_COMOBJ(Obj obj, Obj val)
 {
 #ifdef HPCGAP
     MEMBAR_WRITE();
-    // Only require a read guard
-    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+    UNSAFE_PTR_BAG(obj)[0] = val;
 #else
     ADDR_OBJ(obj)[0] = val;
 #endif
@@ -880,7 +883,11 @@ EXPORT_INLINE BOOL IS_POSOBJ(Obj obj)
 */
 EXPORT_INLINE Obj TYPE_POSOBJ(Obj obj)
 {
-    return CONST_ADDR_OBJ(obj)[0];
+    Obj result = CONST_ADDR_OBJ(obj)[0];
+#ifdef HPCGAP
+    MEMBAR_READ();
+#endif
+    return result;
 }
 
 
@@ -892,8 +899,7 @@ EXPORT_INLINE void SET_TYPE_POSOBJ(Obj obj, Obj val)
 {
 #ifdef HPCGAP
     MEMBAR_WRITE();
-    // Only require a read guard
-    ((Obj *) CONST_ADDR_OBJ(obj))[0] = val;
+    UNSAFE_PTR_BAG(obj)[0] = val;
 #else
     ADDR_OBJ(obj)[0] = val;
 #endif
@@ -929,7 +935,11 @@ EXPORT_INLINE BOOL IS_DATOBJ(Obj obj)
 */
 EXPORT_INLINE Obj TYPE_DATOBJ(Obj obj)
 {
-    return CONST_ADDR_OBJ(obj)[0];
+    Obj result = CONST_ADDR_OBJ(obj)[0];
+#ifdef HPCGAP
+    MEMBAR_READ();
+#endif
+    return result;
 }
 
 
@@ -941,7 +951,12 @@ EXPORT_INLINE Obj TYPE_DATOBJ(Obj obj)
 */
 EXPORT_INLINE void SET_TYPE_DATOBJ(Obj obj, Obj val)
 {
+#ifdef HPCGAP
+    MEMBAR_WRITE();
+    UNSAFE_PTR_BAG(obj)[0] = val;
+#else
     ADDR_OBJ(obj)[0] = val;
+#endif
 }
 
 void SetTypeDatObj(Obj obj, Obj type);

--- a/src/opers.c
+++ b/src/opers.c
@@ -1492,10 +1492,6 @@ static Obj FuncCOMPACT_TYPE_IDS(Obj self)
 // TYPE_OBJ
 static inline Obj TYPE_OBJ_FEO(Obj obj)
 {
-#ifdef HPCGAP
-    /* TODO: We need to be able to automatically derive this. */
-    ImpliedWriteGuard(obj);
-#endif
     switch ( TNUM_OBJ( obj ) ) {
     case T_COMOBJ:
         return TYPE_COMOBJ(obj);
@@ -2524,9 +2520,6 @@ static Obj WRAP_NAME(Obj name, const char *addon)
     UInt name_len = GET_LEN_STRING(name);
     UInt addon_len = strlen(addon);
     Obj fname = NEW_STRING( name_len + addon_len + 2 );
-#ifdef HPCGAP
-    ImpliedWriteGuard(fname);
-#endif
 
     char *ptr = CSTR_STRING(fname);
     memcpy( ptr, addon, addon_len );
@@ -2545,9 +2538,6 @@ static Obj PREFIX_NAME(Obj name, const char *prefix)
     UInt name_len = GET_LEN_STRING(name);
     UInt prefix_len = strlen(prefix);
     Obj fname = NEW_STRING( name_len + prefix_len );
-#ifdef HPCGAP
-    ImpliedWriteGuard(fname);
-#endif
 
     char *ptr = CSTR_STRING(fname);
     memcpy( ptr, prefix, prefix_len );

--- a/src/system.h
+++ b/src/system.h
@@ -25,6 +25,12 @@
 #endif
 
 
+// If we are not running HPC-GAP, disable read and write guards.
+
+#ifndef HPCGAP
+#undef USE_HPC_GUARDS
+#endif
+
 /****************************************************************************
 **
 *S  GAP_PATH_MAX . . . . . . . . . . . .  size for buffers storing file paths

--- a/src/system.h
+++ b/src/system.h
@@ -25,10 +25,12 @@
 #endif
 
 
-// If we are not running HPC-GAP, disable read and write guards.
+// If we are not running HPC-GAP, guards should be disabled
 
 #ifndef HPCGAP
-#undef USE_HPC_GUARDS
+#ifdef USE_HPC_GUARDS
+#error Do not use --enable-guards without --enable-hpcgap.
+#endif
 #endif
 
 /****************************************************************************

--- a/src/system.h
+++ b/src/system.h
@@ -75,6 +75,18 @@ enum {
 #define NORETURN
 #endif
 
+#ifdef HAVE_FUNC_ATTRIBUTE_PURE
+#define PURE_FUNC __attribute__((pure))
+#else
+#define PURE_FUNC
+#endif
+
+#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+#define CONSTRUCTOR_FUNC __attribute__((constructor))
+#else
+#define CONSTRUCTOR_FUNC
+#endif
+
 
 /****************************************************************************
 **

--- a/src/system.h
+++ b/src/system.h
@@ -25,14 +25,6 @@
 #endif
 
 
-// If we are not running HPC-GAP, guards should be disabled
-
-#ifndef HPCGAP
-#ifdef USE_HPC_GUARDS
-#error Do not use --enable-guards without --enable-hpcgap.
-#endif
-#endif
-
 /****************************************************************************
 **
 *S  GAP_PATH_MAX . . . . . . . . . . . .  size for buffers storing file paths

--- a/src/system.h
+++ b/src/system.h
@@ -16,7 +16,6 @@
 
 #include "common.h"
 
-
 /* check if we are on a 64 bit machine                                     */
 #if SIZEOF_VOID_P == 8
 # define SYS_IS_64_BIT          1


### PR DESCRIPTION
This is still very raw and has a number of hacks (such as using `calloc()` for `AllocateMemoryBlock()`). The PR is currently an FYI/progress tracker, as a lot of the implementation is still subject to change. It also relies on previous HPC-GAP related PRs (namely https://github.com/gap-system/gap/pull/3502 and https://github.com/gap-system/gap/pull/2845).

Aside from making HPC-GAP work with Julia, it also aims at allowing HPC-GAP to be used as a library (which is necessary for GAP.jl, but also allows other code to link to it).

It currently runs only with `gap --single-thread`, as `CreateThread()` is disabled due to limitations in Julia. (It's also not a priority, as we are currently more concerned with calling GAP from Julia rather than having yet another GC for GAP.)

Configuration needs to happen with:

```
./configure --with-gc=julia --with-julia=/path/to/julia --enable-hpcgap --enable-native-tls
```

Remaining issues that I am working on are:

* [ ] Proper initialization of thread-local state. This involves refactoring of `RunThread()` and `DispatchThread()`.
* [ ] Thread creation/initialization for the libgap version, building on the previous bullet point. This is necessary for GAP.jl.
* [ ] Fixing errors in root scanning. Currently, we're seemingly missing out on some global variables, leading to eventual crashes.
* [ ] Clean implementation of `AllocateMemoryBlock()`; this may require an internal API change for that function to permit a type parameter. `AllocateMemoryBlock()` presumes that a conservative GC is being used, which may not be the best decision, anyway.
* [ ] Make `CreateThread()` work via the task system (Julia only recognizes its own preallocated threads, all other thread activity needs to be mapped to Julia tasks that are then being run by threads. This is how the Julia macro `@threads` works, for example.).
* [ ] Insert GC safepoints around I/O (the Julia GC requires that for multi-threaded GC to work). This is necessary primarily for console I/O, which can block indefinitely while computations are running (I am currently not so much worried about a pause while reading a file, as GAP tends to read files only once, so a pause is more acceptable).