### PR TITLE
Computation of Omega groups of arbitrary p groups is supported.

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1972,7 +1972,6 @@ DeclareAttribute( "NrConjugacyClasses", IsGroup );
 ##  \{ g \in <A>G</A> \mid g^{{<A>p</A>^{<A>n</A>}}} = 1 \}</M>.
 ##  The default value for <A>n</A> is <C>1</C>.
 ##  <P/>
-##  <E>@At the moment methods exist only for abelian <A>G</A> and <A>n</A>=1.@</E>
 ##  <Example><![CDATA[
 ##  gap> h:=SmallGroup(16,10);
 ##  <pc group of size 16 with 4 generators>

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -2659,8 +2659,7 @@ end);
 
 # Omega_Search is a brute force search for Omega.
 # One can search by coset if Omega(G) = { g in G : g^(p^e) = 1 }
-# This is the case in regular p-groups, and if nilclass(G) < p
-# then G is regular.
+# This is the case in regular p groups.
 # Assumed: G is a p-group, e is a positive integer
 BindGlobal("Omega_Search",
 function(G,p,e)

--- a/tst/testinstall/grppc.tst
+++ b/tst/testinstall/grppc.tst
@@ -166,6 +166,11 @@ gap> RepresentativeAction(G,x,x^2)<>fail;
 true
 gap> RepresentativeAction(G,x,x^2);
 f1*f2
+gap> g := SmallGroup(243,27);;
+gap> AsSet(Omega(g,3,1)) = Set(Filtered(g, g -> IsOne(g^3)));
+true
+gap> AsSet(Omega(g,3,2)) = Set(Filtered(g, g -> IsOne(g^9)));
+true
 
 # that's all, folks
 gap> STOP_TEST( "grppc.tst", 1);


### PR DESCRIPTION
The manual claims GAP can only compute Omega-groups of abelian p groups. In my opinion, this is not true, see `lib/grppc.gi`. This PR removes the corresponding line in the manual.
Also, a part of the comment in the code was redundant: Any p-group with nilpotency class at most `p` is regular, so I clarified this part in the documentation.

I put Release notes: To be added. Feel free to change this if you want to.