### PR TITLE
Speed up printing of large permutations

### DIFF
--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -742,24 +742,24 @@ local   str,  i,  j;
   else
       str := "";
       for i  in [ 1 .. LargestMovedPoint( perm ) ]  do
-	  j := i ^ perm;
-	  while j > i  do j := j ^ perm;  od;
-	  if j = i and i ^ perm <> i  then
-	      Append( str, "(" );
-	      Append( str, String( i ) );
-	      j := i ^ perm;
-	      while j > i do
-		  Append( str, "," );
-		  if hint then Append(str,"\<\>"); fi;
-		  Append( str, String( j ) );
-		  j := j ^ perm;
-	      od;
-	      Append( str, ")" );
-	      if hint then Append(str,"\<\<\>\>"); fi;
-	  fi;
+      j := i ^ perm;
+      while j > i  do j := j ^ perm;  od;
+      if j = i and i ^ perm <> i  then
+          Append( str, "(" );
+          Append( str, String( i ) );
+          j := i ^ perm;
+          while j > i do
+          Append( str, "," );
+          if hint then Append(str,"\<\>"); fi;
+          Append( str, String( j ) );
+          j := j ^ perm;
+          od;
+          Append( str, ")" );
+          if hint then Append(str,"\<\<\>\>"); fi;
+      fi;
       od;
       if Length(str)>4 and str{[Length(str)-3..Length(str)]}="\<\<\>\>" then
-	str:=str{[1..Length(str)-4]}; # remove tailing line breaker
+          str:=str{[1..Length(str)-4]}; # remove tailing line breaker
       fi;
       ConvertToStringRep( str );
   fi;

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -735,20 +735,22 @@ end );
 #m  String( <perm> )  . . . . . . . . . . . . . . . . . . . for a permutation
 ##
 BIND_GLOBAL("DoStringPerm",function( perm,hint )
-local   str,  i,  j;
+local   str,  i,  j, maxpnt, blist;
 
   if IsOne( perm ) then
       str := "()";
   else
       str := "";
+      maxpnt := LargestMovedPoint( perm );
+      blist := BlistList([1..maxpnt], []);
       for i  in [ 1 .. LargestMovedPoint( perm ) ]  do
-      j := i ^ perm;
-      while j > i  do j := j ^ perm;  od;
-      if j = i and i ^ perm <> i  then
+      if not blist[i] and i ^ perm <> i  then
+          blist[i] := true;
           Append( str, "(" );
           Append( str, String( i ) );
           j := i ^ perm;
           while j > i do
+          blist[j] := true;
           Append( str, "," );
           if hint then Append(str,"\<\>"); fi;
           Append( str, String( j ) );

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -1,4 +1,4 @@
-#@local checklens,n,permAll,permBig,permSml,x,y, moved
+#@local checklens,n,permAll,permBig,permSml,x,y,moved,p
 gap> START_TEST("perm.tst");
 
 # Permutations come in two flavors in GAP, with two TNUMs: T_PERM2 for
@@ -86,6 +86,17 @@ gap> Print(permBig * (5,999999), "\n");
 [ (    5,999999), (    2,    3)(    5,999999), (    1,    2)(    5,999999), 
   (    1,    2,    3)(    5,999999), (    1,    3,    2)(    5,999999), 
   (    1,    3)(    5,999999) ]
+
+# Check String of large permutation
+# Check length, beginning and end, as the string is too long to include in
+# a test file
+gap> p := String(PermList(Concatenation([2..2^20], [1])));;
+gap> Length(p) = 7277505;
+true
+gap> p{[1..40]};
+"(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,"
+gap> p{[Length(p)-40..Length(p)]};
+",1048572,1048573,1048574,1048575,1048576)"
 
 #
 # EqPerm


### PR DESCRIPTION
GAP is very slow at printing large permutations (say on the order of 2^20), it can take several minutes. This is because it uses a silly O(n^2) algorithm.

This improves the two places where we print permutations to instead use an O(n) algorithm.