### PR TITLE
Add Travis tests on arm64, ppc64le, s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - zlib1g-dev
     - python
     - python-pip
-    - perl
+    - jq    # for etc/travis_fastfail.sh
 
 #
 # The following test jobs are roughly sorted by duration, from longest to
@@ -149,17 +149,38 @@ matrix:
     # test Julia integration
     - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
 
+    # build on non-x86 platform
+    - env: TEST_SUITES="docomp testinstall"
+      arch: arm64
+      dist: bionic
+      before_install:
+        # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
+        - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+
+    # build on non-x86 platform
+    - env: TEST_SUITES="docomp testinstall"
+      arch: ppc64le
+      dist: bionic
+
+    # build on non-x86 platform; big endian!
+    - env: TEST_SUITES="docomp testinstall"
+      arch: s390x
+      dist: bionic
+      before_install:
+        # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
+        - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+
+# use travis_terminate below to ensure travis immediately aborts upon error,
+# and also to work around timeouts (see https://travis-ci.community/t/7659)
 script:
-  - set -e
-  - etc/travis_fastfail.sh
-  - pip install --user gcovr==4.1
-  - bash etc/ci-prepare.sh
-  - bash etc/ci.sh
+  - etc/travis_fastfail.sh || travis_terminate $?
+  - python -m pip install --user gcovr==4.1 || travis_terminate $?
+  - bash etc/ci-prepare.sh || travis_terminate $?
+  - bash etc/ci.sh || travis_terminate $?
 
 after_script:
-  - set -e
-  - bash etc/ci-gather-coverage.sh
-  - bash etc/ci-run-codecov.sh
+  - bash etc/ci-gather-coverage.sh || travis_terminate $?
+  - bash etc/ci-run-codecov.sh || travis_terminate $?
 
 notifications:
   email:

--- a/etc/ci-coveralls-merge.py
+++ b/etc/ci-coveralls-merge.py
@@ -2,6 +2,8 @@
 
 # Hacked up merger for testing
 
+from __future__ import print_function
+
 import json
 import os
 import os.path
@@ -14,12 +16,13 @@ print("Merging coveralls json coverage")
 # Special-cased gap-coveralls.json, because we rely
 # on GAP to set the correct service_name, pull-request number
 # etc
-print "file: gap-coveralls.json", # python2 avoiding line break.
+print("file: gap-coveralls.json", end="")
 if os.path.isfile('gap-coveralls.json'):
     with open('gap-coveralls.json', 'r') as f:
         merged = json.load(f)
     print(" done.")
 else:
+    print()
     print("WARNING: could not find gap-coveralls.json, quitting")
     sys.exit(0)
 
@@ -28,7 +31,7 @@ if not 'source_files' in merged:
     merged['source_files'] = []
 
 for fn in coverage_files:
-    print "file: %s" % (fn,), # python2 avoiding line break.
+    print("file: %s" % (fn,), end="")
     if os.path.isfile(fn):
         with open(fn, 'r') as f:
             cover = json.load(f)


### PR DESCRIPTION
Note that `s390x` is big endian which would be really nice in light of issue #2362.

And testing on arm64 might help with debugging issue #3919.

Resolves #2362.