### PR TITLE
kernel: add new header gap_all.h

### DIFF
--- a/src/compiled.h
+++ b/src/compiled.h
@@ -18,71 +18,7 @@
 extern "C" {
 #endif
 
-#include "ariths.h"
-#include "blister.h"
-#include "bool.h"
-#include "calls.h"
-#include "code.h"
-#include "collectors.h"
-#include "compiler.h"
-#include "compstat.h"
-#include "costab.h"
-#include "cyclotom.h"
-#include "dt.h"
-#include "dteval.h"
-#include "error.h"
-#include "exprs.h"
-#include "finfield.h"
-#include "funcs.h"
-#include "gap.h"
-#include "gapstate.h"
-#include "gasman.h"
-#include "gvars.h"
-#include "info.h"
-#include "integer.h"
-#include "intrprtr.h"
-#include "io.h"
-#include "iostream.h"
-#include "listfunc.h"
-#include "listoper.h"
-#include "lists.h"
-#include "macfloat.h"
-#include "modules.h"
-#include "objcftl.h"
-#include "objects.h"
-#include "objfgelm.h"
-#include "objpcgel.h"
-#include "opers.h"
-#include "permutat.h"
-#include "plist.h"
-#include "pperm.h"
-#include "precord.h"
-#include "range.h"
-#include "rational.h"
-#include "read.h"
-#include "records.h"
-#include "saveload.h"
-#include "scanner.h"
-#include "sctable.h"
-#include "set.h"
-#include "stats.h"
-#include "streams.h"
-#include "stringobj.h"
-#include "sysfiles.h"
-#include "system.h"
-#include "tietze.h"
-#include "trans.h"
-#include "vars.h"
-#include "vector.h"
-#include "weakptr.h"
-
-#ifdef HPCGAP
-#include "hpc/aobjects.h"
-#include "hpc/guards.h"
-#include "hpc/serialize.h"
-#include "hpc/threadapi.h"
-#include "hpc/traverse.h"
-#endif
+#include "gap_all.h"
 
 extern Obj InfoDecision;
 
@@ -237,5 +173,5 @@ void C_SET_LIMB8(Obj bag, UInt limbnumber, UInt8 value);
 #ifdef __cplusplus
 } // extern "C"
 #endif
-    
+
 #endif // GAP_COMPILED_H

--- a/src/gap_all.h
+++ b/src/gap_all.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This header includes most of the other GAP headers, and is meant to be
+**  included by GAP kernel extensions.
+*/
+
+#ifndef GAP_ALL_H
+#define GAP_ALL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ariths.h"
+#include "blister.h"
+#include "bool.h"
+#include "calls.h"
+#include "code.h"
+#include "collectors.h"
+#include "compiler.h"
+#include "compstat.h"
+#include "costab.h"
+#include "cyclotom.h"
+#include "dt.h"
+#include "dteval.h"
+#include "error.h"
+#include "exprs.h"
+#include "finfield.h"
+#include "funcs.h"
+#include "gap.h"
+#include "gapstate.h"
+#include "gasman.h"
+#include "gvars.h"
+#include "info.h"
+#include "integer.h"
+#include "intrprtr.h"
+#include "io.h"
+#include "iostream.h"
+#include "listfunc.h"
+#include "listoper.h"
+#include "lists.h"
+#include "macfloat.h"
+#include "modules.h"
+#include "objcftl.h"
+#include "objects.h"
+#include "objfgelm.h"
+#include "objpcgel.h"
+#include "opers.h"
+#include "permutat.h"
+#include "plist.h"
+#include "pperm.h"
+#include "precord.h"
+#include "range.h"
+#include "rational.h"
+#include "read.h"
+#include "records.h"
+#include "saveload.h"
+#include "scanner.h"
+#include "sctable.h"
+#include "set.h"
+#include "stats.h"
+#include "streams.h"
+#include "stringobj.h"
+#include "sysfiles.h"
+#include "system.h"
+#include "tietze.h"
+#include "trans.h"
+#include "vars.h"
+#include "vector.h"
+#include "weakptr.h"
+
+#ifdef HPCGAP
+#include "hpc/aobjects.h"
+#include "hpc/guards.h"
+#include "hpc/serialize.h"
+#include "hpc/threadapi.h"
+#include "hpc/traverse.h"
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // GAP_ALL_H

--- a/src/modules_builtin.c
+++ b/src/modules_builtin.c
@@ -10,7 +10,7 @@
 
 #include "modules_builtin.h"
 
-#include "compiled.h"
+#include "gap_all.h"
 #include "gap.h"
 #include "hookintrprtr.h"
 #include "info.h"
@@ -24,13 +24,6 @@
 #include "vec8bit.h"
 #include "vecffe.h"
 #include "vecgf2.h"
-
-#ifdef HPCGAP
-#include "hpc/aobjects.h"
-#include "hpc/serialize.h"
-#include "hpc/threadapi.h"
-#include "hpc/traverse.h"
-#endif
 
 /****************************************************************************
 **


### PR DESCRIPTION
So far, most package kernel extensions `#include "compiled.h"` in order
to conveniently get access to (almost) all source headers of GAP at once
(which is nice for us because it means we are free to rename headers or
move stuff around between them without breaking kernel extensions).

But the result is rather counterintuitive: if one is not familiar with
this, seeing `#include "compiled.h"` in code is not at all clear. Also,
the original of `compiled.h` was to be included by C code generated by
`gac`, and it contains stuff we'd rather not encourage others to use.

Thus, add a new header `gap_all.h` containing all `#include` statements
formerly found in `compiled.h` -- this resolves all concerns.

---

Of course it will take time for kernel extensions to switch to this new header, especially if they care about staying compatible with older GAP versions. But the sooner we add this, the sooner such a switch could happen. Hence it would be nice to backport this (any objections).