### PR TITLE
Insert GAP_VERSION into sysinfo.gap

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -720,6 +720,7 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 	@echo "GAP_ABI=$(ABI)" >> $@
 	@echo "GAP_HPCGAP=$(HPCGAP)" >> $@
 	@echo "" >> $@
+	@echo "GAP_VERSION=\"$(GAP_VERSION)\"" >> $@
 	@echo "GAP_KERNEL_MAJOR_VERSION=$(GAP_KERNEL_MAJOR_VERSION)" >> $@
 	@echo "GAP_KERNEL_MINOR_VERSION=$(GAP_KERNEL_MINOR_VERSION)" >> $@
 	@echo "" >> $@


### PR DESCRIPTION
This is useful for package build systems which want to verify the GAP version.

This is a minor change but potentially quite useful for packages, yet clearly won't interfere with anything badly, so I'd really like to backport it. At the same time, it is relevant for package authors, so I'd like to mention it in the release notes, together with other stuff relevant for package authors.