### PR TITLE
kernel: replace unsafe uses of 1L

### DIFF
--- a/src/bits_intern.h
+++ b/src/bits_intern.h
@@ -34,7 +34,7 @@
 /* constructs a mask that selects bits <from> to <to> inclusive of a UInt */
 static inline UInt MaskForCopyBits(UInt from, UInt to)
 {
-    return ((to == BIPEB - 1) ? 0 : (1L << (to + 1))) - (1L << from);
+    return ((to == BIPEB - 1) ? 0 : ((UInt)1 << (to + 1))) - ((UInt)1 << from);
 }
 
 /* copies a block of bits from the UInt <from> to the one pointed at

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -854,7 +854,7 @@ static Obj FuncSetCyclotomicsLimit(Obj self, Obj newlimit)
                      CyclotomicsLimit, 0);
     }
 #ifdef SYS_IS_64_BIT
-    if (ulimit >= (1L << 32)) {
+    if (ulimit >= ((UInt)1 << 32)) {
         ErrorMayQuit("Cyclotomic field size limit must be less than 2^32", 0,
                      0);
     }

--- a/src/integer.c
+++ b/src/integer.c
@@ -1524,7 +1524,7 @@ static Obj ProdIntObj ( Obj n, Obj op )
   /* <res> = 0 means that <res> is the neutral element                     */
   else if ( IS_INTOBJ(n) && INT_INTOBJ(n) >   1 ) {
     res = 0;
-    k = 1L << NR_SMALL_INT_BITS;
+    k = (Int)1 << NR_SMALL_INT_BITS;
     l = INT_INTOBJ(n);
     while ( 0 < k ) {
       res = (res == 0 ? res : SUM( res, res ));
@@ -1674,7 +1674,7 @@ static Obj PowObjInt(Obj op, Obj n)
   /* <res> = 0 means that <res> is the neutral element                   */
   else if ( IS_INTOBJ(n) && INT_INTOBJ(n) >   0 ) {
     res = 0;
-    k = 1L << NR_SMALL_INT_BITS;
+    k = (Int)1 << NR_SMALL_INT_BITS;
     l = INT_INTOBJ(n);
     while ( 0 < k ) {
       res = (res == 0 ? res : PROD( res, res ));

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -656,7 +656,7 @@ static Obj FuncMAKE_BITFIELDS(Obj self, Obj widths)
     UInt bslen = 0;
     Obj  bgetters = NEW_PLIST_IMM(T_PLIST, nfields);
     for (UInt i = 1; i <= nfields; i++) {
-        UInt mask = (1L << starts[i]) - (1L << starts[i - 1]);
+        UInt mask = ((UInt)1 << starts[i]) - ((UInt)1 << starts[i - 1]);
         Obj  s = NewFunctionT(T_FUNCTION, sizeof(BitfieldFuncBag), nameSetter,
                              2, dataValArgs, DoFieldSetter);
         SET_MASK_BITFIELD_FUNC(s, mask);

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -38,11 +38,11 @@
 
 enum {
     NR_SMALL_INT_BITS = sizeof(UInt) * 8 - 4,
-
-    // the minimal / maximal possible values of an immediate integer object:
-    INT_INTOBJ_MIN = -(1L << NR_SMALL_INT_BITS),
-    INT_INTOBJ_MAX =  (1L << NR_SMALL_INT_BITS) - 1,
 };
+
+// the minimal / maximal possible values of an immediate integer object:
+#define INT_INTOBJ_MIN  (-((Int)1 << NR_SMALL_INT_BITS))
+#define INT_INTOBJ_MAX  ( ((Int)1 << NR_SMALL_INT_BITS) - 1)
 
 // the minimal / maximal possible immediate integer objects:
 #define INTOBJ_MIN  (Obj)(((UInt)INT_INTOBJ_MIN << 2) + 0x01)

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -431,7 +431,7 @@ static Obj FuncINTFLOOR_MACFLOAT(Obj self, Obj macfloat)
 #endif
 
 
-  if (fabs(f) < (Double) (1L<<NR_SMALL_INT_BITS))
+  if (fabs(f) < (Double)((Int)1 << NR_SMALL_INT_BITS))
     return INTOBJ_INT((Int)f);
 
   int str_len = (int) (log(fabs(f)) / log(16.0)) + 3;

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -82,6 +82,7 @@ extern "C" {
 Obj             IdentityPerm;
 
 
+static const UInt MAX_DEG_PERM4 = ((Int)1 << (sizeof(UInt) == 8 ? 32 : 28)) - 1;
 
 static ModuleStateOffset PermutatStateOffset = -1;
 

--- a/src/permutat.h
+++ b/src/permutat.h
@@ -129,10 +129,6 @@ EXPORT_INLINE void CLEAR_STOREDINV_PERM(Obj perm)
 */
 #define IMAGE(i,pt,dg)  (((i) < (dg)) ? (pt)[(i)] : (i))
 
-enum {
-    MAX_DEG_PERM4 = (1L << (sizeof(UInt) == 8 ? 32 : 28)) - 1
-};
-
 #define IS_PERM2(perm)  (TNUM_OBJ(perm) == T_PERM2)
 #define IS_PERM4(perm)  (TNUM_OBJ(perm) == T_PERM4)
 


### PR DESCRIPTION
On some 64bit systems (most notably, Windows), sizeof(long) == 4, and so
expressions like `1L << 60` overflow. Moreover, an enum strictly
speaking is only guaranteed to be able to represent an int, and so using
it to represent 64bit constants is not safe; we hence turn
INT_INTOBJ_MIN and INT_INTOBJ_MAX into global static constants.


Note that there are other issues with compiling GAP on native Windows (i.e., without cygwin).