### PR TITLE
Sync some diffs between hpcgap/lib and lib

### DIFF
--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -213,7 +213,7 @@ end);
 ## output methods
 ##
 
-InstallMethod(String,"For large finite field elements",
+InstallMethod(String,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     local   started,  coeffs,  fam,  s,  str,  i;
@@ -294,17 +294,17 @@ BindGlobal( "DisplayStringForLargeFiniteFieldElements",
     return s;
   end );
 
-InstallMethod(DisplayString,"For large finite field elements",
+InstallMethod(DisplayString,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         DisplayStringForLargeFiniteFieldElements );
 
-InstallMethod(Display,"For large finite field elements",
+InstallMethod(Display,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     Print(DisplayString(x));
 end);
 
-InstallMethod(ViewString,"For large finite field elements",
+InstallMethod(ViewString,"for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     local   s;
@@ -319,7 +319,7 @@ InstallMethod(ViewString,"For large finite field elements",
     fi;
 end);
 
-InstallMethod(ViewObj, "For large finite field elements",
+InstallMethod(ViewObj, "for large finite field elements",
         [IsFFE and IsCoeffsModConwayPolRep], 
         function(x)
     Print(ViewString(x));
@@ -1499,7 +1499,7 @@ end);
 #M Coefficients of an element wrt the canonical basis -- are stored in the 
 ##                                                       element
 InstallMethod(Coefficients,
-        "For a FFE in Conway polynomial represntation wrt the canonical basis of its natural field",
+        "for a FFE in Conway polynomial representation wrt the canonical basis of its natural field",
         IsCollsElms,
         [IsCanonicalBasis and IsBasisFiniteFieldRep, IsFFE and IsCoeffsModConwayPolRep],
         function(cb,x)

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -49,43 +49,35 @@ MakeReadOnlyObj(TYPES_VEC8BIT);
 
 InstallGlobalFunction(TYPE_VEC8BIT,
   function( q, mut)
-    local col,filts, type;
+    local col,filts;
     if mut then col := 1; else col := 2; fi;
-    if IsBound(TYPES_VEC8BIT[col][q]) then
-      return TYPES_VEC8BIT[col][q];
-    fi;
-    filts := IsHomogeneousList and IsListDefault and IsCopyable and
-             Is8BitVectorRep and IsSmallList and
-             IsNoImmediateMethodsObject and
-             IsRingElementList and HasLength;
-    if mut then filts := filts and IsMutable; fi;
-    type := NewType(FamilyObj(GF(q)),filts);
     if not IsBound(TYPES_VEC8BIT[col][q]) then
-      InstallTypeSerializationTag(type, SERIALIZATION_BASE_VEC8BIT +
-        SERIALIZATION_TAG_BASE * (q * 4 + col - 1));
-      TYPES_VEC8BIT[col][q] := type;
+        filts := IsHomogeneousList and IsListDefault and IsCopyable and
+                 Is8BitVectorRep and IsSmallList and
+                 IsNoImmediateMethodsObject and
+                 IsRingElementList and HasLength;
+        if mut then filts := filts and IsMutable; fi;
+        TYPES_VEC8BIT[col][q] := NewType(FamilyObj(GF(q)),filts);
+        InstallTypeSerializationTag(TYPES_VEC8BIT[col][q],
+            SERIALIZATION_BASE_VEC8BIT + SERIALIZATION_TAG_BASE * (q * 4 + col - 1));
     fi;
     return TYPES_VEC8BIT[col][q];
 end);
 
 InstallGlobalFunction(TYPE_VEC8BIT_LOCKED,
   function( q, mut)
-    local col,filts, type;
+    local col,filts;
     if mut then col := 3; else col := 4; fi;
-    if IsBound(TYPES_VEC8BIT[col][q]) then
-      return TYPES_VEC8BIT[col][q];
-    fi;
-    filts := IsHomogeneousList and IsListDefault and IsCopyable and
-             Is8BitVectorRep and IsSmallList and
-             IsNoImmediateMethodsObject and
-             IsLockedRepresentationVector and
-             IsRingElementList and HasLength;
-    if mut then filts := filts and IsMutable; fi;
-    type := NewType(FamilyObj(GF(q)),filts);
     if not IsBound(TYPES_VEC8BIT[col][q]) then
-      InstallTypeSerializationTag(type, SERIALIZATION_BASE_VEC8BIT +
-        SERIALIZATION_TAG_BASE * (q * 4 + col - 1));
-      TYPES_VEC8BIT[col][q] := type;
+        filts := IsHomogeneousList and IsListDefault and IsCopyable and
+                 Is8BitVectorRep and IsSmallList and
+                 IsNoImmediateMethodsObject and
+                 IsLockedRepresentationVector and
+                 IsRingElementList and HasLength;
+        if mut then filts := filts and IsMutable; fi;
+        TYPES_VEC8BIT[col][q] := NewType(FamilyObj(GF(q)),filts);
+        InstallTypeSerializationTag(TYPES_VEC8BIT[col][q],
+            SERIALIZATION_BASE_VEC8BIT + SERIALIZATION_TAG_BASE * (q * 4 + col - 1));
     fi;
     return TYPES_VEC8BIT[col][q];
 end);
@@ -126,7 +118,7 @@ InstallOtherMethod( \[\],  "for a compressed VecFFE",
 ##
 ##  <vec> may also be converted back into vector rep over a bigger field.
 ##
-               
+
 InstallOtherMethod( \[\]\:\=,  "for a compressed VecFFE", 
         true, [IsMutable and IsList and Is8BitVectorRep, IsPosInt, IsObject], 
         0, ASS_VEC8BIT);
@@ -223,7 +215,8 @@ InstallMethod( \+, "for a GF2 vector and an 8 bit vector of char 2",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return CopyToVectorRep(v,Q_VEC8BIT(w)) + w;
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return v+w;
     fi;
 end);
 
@@ -234,7 +227,8 @@ InstallMethod( \+, "for an 8 bit vector of char 2 and a GF2 vector",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return w + CopyToVectorRep(v,Q_VEC8BIT(w));
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return w+v;
     fi;
 end);
 
@@ -354,7 +348,8 @@ function( a, b )
     if DegreeFFE(a) > 8 or IsLockedRepresentationVector(b) then
         TryNextMethod();
     else
-        return a*CopyToVectorRep(b,Size(Field(a)));
+        b := CopyToVectorRep(b,Size(Field(a)));
+        return a*b;
     fi;
 end );
 
@@ -388,7 +383,8 @@ function( b, a )
     if DegreeFFE(b) > 8 or IsLockedRepresentationVector(a) then
         TryNextMethod();
     else
-        return b*CopyToVectorRep(a,Size(Field(b)));
+        a := CopyToVectorRep(a,Size(Field(b)));
+        return b*a;
     fi;
 end );
 
@@ -410,7 +406,8 @@ InstallMethod( \-, "for a GF2 vector and an 8 bit vector of char 2",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return CopyToVectorRep(v,Q_VEC8BIT(w))-w;
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return v-w;
     fi;
 end);
 
@@ -421,7 +418,8 @@ InstallMethod( \-, "for an 8 bit vector of char 2 and a GF2 vector",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return w-CopyToVectorRep(v,Q_VEC8BIT(w));
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return w-v;
     fi;
 end);
 
@@ -529,7 +527,8 @@ InstallMethod( \*, "for a GF2 vector and an 8 bit vector of char 2",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return CopyToVectorRep(v,Q_VEC8BIT(w))*w;
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return v*w;
     fi;
 end);
 
@@ -540,7 +539,8 @@ InstallMethod( \*, "for an 8 bit vector of char 2 and a GF2 vector",
     if IsLockedRepresentationVector(v) then
         TryNextMethod();
     else
-        return w*CopyToVectorRep(v,Q_VEC8BIT(w));
+        v := CopyToVectorRep(v,Q_VEC8BIT(w));
+        return w*v;
     fi;
 end);
 
@@ -633,7 +633,6 @@ InstallMethod( Append, "for 8bitm vectors",
         IsIdenticalObj, [Is8BitVectorRep and IsMutable and IsList,
                 Is8BitVectorRep and IsList], 0,
         APPEND_VEC8BIT);
-        
 
 #############################################################################
 ##
@@ -694,7 +693,8 @@ InstallOtherMethod( AddCoeffs, "8 bit vector and GF2 vector", IsCollsCollsElms,
     if IsLockedRepresentationVector(w) then
         TryNextMethod();
     else
-        return ADD_COEFFS_VEC8BIT_3(v,CopyToVectorRep(w, Q_VEC8BIT(v)),x);
+        w := CopyToVectorRep(w, Q_VEC8BIT(v));
+        return ADD_COEFFS_VEC8BIT_3(v,w,x);
     fi;
 end);
 
@@ -727,7 +727,8 @@ InstallOtherMethod( AddCoeffs, "8 bit vector and GF2 vector", IsIdenticalObj,
     if IsLockedRepresentationVector(w) then
         TryNextMethod();
     else
-        return ADD_COEFFS_VEC8BIT_2(v,CopyToVectorRep(w, Q_VEC8BIT(v)));
+        w := CopyToVectorRep(w, Q_VEC8BIT(v));
+        return ADD_COEFFS_VEC8BIT_2(v,w);
     fi;
 end);
 
@@ -818,7 +819,7 @@ InstallMethod( ProductCoeffs, "8 bit vectors, kernel method", IsFamXFamY,
         [Is8BitVectorRep and IsRowVector, IsInt, Is8BitVectorRep and
          IsRowVector, IsInt ], 0,
         PROD_COEFFS_VEC8BIT);
-        
+
 InstallOtherMethod( ProductCoeffs, "8 bit vectors, kernel method (2 arg)", 
         IsIdenticalObj,
         [Is8BitVectorRep and IsRowVector, Is8BitVectorRep and
@@ -854,7 +855,7 @@ function(v,w)
     if w1 = fail then
         return fail;
     fi;
-    
+
     return [v1, w1];
 
   else
@@ -875,20 +876,20 @@ InstallMethod( ReduceCoeffs, "8 bit vectors, kernel method", IsFamXFamY,
             SWITCH_OBJ(vl, adjust[1]);
             vr:=adjust[2];    
         fi;
-    	res := REDUCE_COEFFS_VEC8BIT( vl, ll, 
-			MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
-	    if res = fail then 
-		    TryNextMethod();
-	    else
-		    return res;
-	    fi;
+        res := REDUCE_COEFFS_VEC8BIT( vl, ll, 
+            MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
+        if res = fail then 
+            TryNextMethod();
+        else
+            return res;
+        fi;
 end);
 
 InstallOtherMethod( ReduceCoeffs, "8 bit vectors, kernel method (2 arg)", 
         IsIdenticalObj,
         [Is8BitVectorRep and IsRowVector and IsMutable, Is8BitVectorRep and
          IsRowVector ], 0,
-    function(v,w) 
+        function(v,w) 
     local adjust;
     adjust := ADJUST_FIELDS_VEC8BIT(v,w);   
     if adjust = fail then
@@ -918,13 +919,13 @@ InstallMethod( QuotRemCoeffs, "8 bit vectors, kernel method", IsFamXFamY,
             SWITCH_OBJ(vl,adjust[1]);
             vr:=adjust[2];    
         fi;
-    	res := QUOTREM_COEFFS_VEC8BIT( vl, ll, 
-			MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
-	    if res = fail then 
-		    TryNextMethod();
-	    else
-		    return res;
-	    fi;
+        res := QUOTREM_COEFFS_VEC8BIT( vl, ll, 
+            MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
+        if res = fail then 
+            TryNextMethod();
+        else
+            return res;
+        fi;
 end);
 
 InstallOtherMethod( QuotRemCoeffs, "8 bit vectors, kernel method (2 arg)", 
@@ -967,7 +968,7 @@ InstallMethod( PowerModCoeffs,
         v:=adjust[1];    
         w:=adjust[2];    
     fi;
-    
+
     if exp = 1 then
         pow := ShallowCopy(v);
         ReduceCoeffs(pow,lv,w,lw);
@@ -1000,8 +1001,7 @@ InstallMethod( PowerModCoeffs,
     od;
     return pow;
 end);
-            
-            
+
 #############################################################################
 ##
 #M  ZeroVector( len, <vector> )

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -586,6 +586,11 @@ InstallOtherMethod( \[\], "for GF2 matrix",
       IsPosInt ],
     ELM_GF2MAT );
 
+InstallMethod( \[\,\], "for GF2 matrix",
+    [ IsGF2MatrixRep,
+      IsPosInt, IsPosInt ],
+    MAT_ELM_GF2MAT );
+
 
 #############################################################################
 ##
@@ -604,6 +609,13 @@ InstallOtherMethod( \[\]\:\=,
       IsPosInt,
       IsObject ],
     ASS_GF2MAT );
+
+InstallMethod( \[\,\]\:\=,
+    "for GF2 matrix",
+    [ IsGF2MatrixRep and IsMutable,
+      IsPosInt, IsPosInt,
+      IsObject ],
+    SET_MAT_ELM_GF2MAT );
 
 
 #############################################################################
@@ -1124,7 +1136,7 @@ InstallMethod( \*,
 ##                    of compressed GF2 vectors, otherwise falls through
 ##
 
-InstallMethod(\*, "For a GF2 vector and a compatible matrix",
+InstallMethod(\*, "for a GF2 vector and a compatible matrix",
         IsElmsColls, [IsRowVector and IsGF2VectorRep and IsSmallList
                 and IsRingElementList,
                 IsRingElementTable and IsPlistRep], 0,
@@ -2392,7 +2404,7 @@ InstallMethod( PositionLastNonZero, "for a row vector obj",
     while i >= 1 and IsZero(l[i]) do i := i - 1; od;
     return i;
   end );
-        
+
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
   [IsGF2MatrixRep, IsList, IsList],
   function( m, rows, cols )

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -1469,7 +1469,7 @@ end);
 #M Coefficients of an element wrt the canonical basis -- are stored in the 
 ##                                                       element
 InstallMethod(Coefficients,
-        "for a FFE in Conway polynomial represntation wrt the canonical basis of its natural field",
+        "for a FFE in Conway polynomial representation wrt the canonical basis of its natural field",
         IsCollsElms,
         [IsCanonicalBasis and IsBasisFiniteFieldRep, IsFFE and IsCoeffsModConwayPolRep],
         function(cb,x)

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -107,7 +107,7 @@ InstallOtherMethod( \[\],  "for a compressed VecFFE",
 ##
 ##  <vec> may also be converted back into vector rep over a bigger field.
 ##
-               
+
 InstallOtherMethod( \[\]\:\=,  "for a compressed VecFFE", 
         true, [IsMutable and IsList and Is8BitVectorRep, IsPosInt, IsObject], 
         0, ASS_VEC8BIT);
@@ -622,7 +622,6 @@ InstallMethod( Append, "for 8bitm vectors",
         IsIdenticalObj, [Is8BitVectorRep and IsMutable and IsList,
                 Is8BitVectorRep and IsList], 0,
         APPEND_VEC8BIT);
-        
 
 #############################################################################
 ##
@@ -809,7 +808,7 @@ InstallMethod( ProductCoeffs, "8 bit vectors, kernel method", IsFamXFamY,
         [Is8BitVectorRep and IsRowVector, IsInt, Is8BitVectorRep and
          IsRowVector, IsInt ], 0,
         PROD_COEFFS_VEC8BIT);
-        
+
 InstallOtherMethod( ProductCoeffs, "8 bit vectors, kernel method (2 arg)", 
         IsIdenticalObj,
         [Is8BitVectorRep and IsRowVector, Is8BitVectorRep and
@@ -827,7 +826,7 @@ end);
 ##
 
 BindGlobal("ADJUST_FIELDS_VEC8BIT",
-        function(v,w) 
+function(v,w) 
     local p,e;
     if Q_VEC8BIT(v)<>Q_VEC8BIT(w) then
       p:=Characteristic(v);
@@ -850,13 +849,13 @@ InstallMethod( ReduceCoeffs, "8 bit vectors, kernel method", IsFamXFamY,
         if ADJUST_FIELDS_VEC8BIT(vl, vr) = fail then
             TryNextMethod();
         fi;
-    	res := REDUCE_COEFFS_VEC8BIT( vl, ll, 
-			MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
-	if res = fail then 
-		TryNextMethod();
-	else
-		return res;
-	fi;
+        res := REDUCE_COEFFS_VEC8BIT( vl, ll, 
+            MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
+        if res = fail then 
+            TryNextMethod();
+        else
+            return res;
+        fi;
 end);
 
 InstallOtherMethod( ReduceCoeffs, "8 bit vectors, kernel method (2 arg)", 
@@ -884,13 +883,13 @@ InstallMethod( QuotRemCoeffs, "8 bit vectors, kernel method", IsFamXFamY,
         if ADJUST_FIELDS_VEC8BIT(vl, vr) = fail then
             TryNextMethod();
         fi;
-    	res := QUOTREM_COEFFS_VEC8BIT( vl, ll, 
-			MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
-	if res = fail then 
-		TryNextMethod();
-	else
-		return res;
-	fi;
+        res := QUOTREM_COEFFS_VEC8BIT( vl, ll, 
+            MAKE_SHIFTED_COEFFS_VEC8BIT(vr, lr));
+        if res = fail then 
+            TryNextMethod();
+        else
+            return res;
+        fi;
 end);
 
 InstallOtherMethod( QuotRemCoeffs, "8 bit vectors, kernel method (2 arg)", 
@@ -924,7 +923,7 @@ InstallMethod( PowerModCoeffs,
     if ADJUST_FIELDS_VEC8BIT(v, w) = fail then
         TryNextMethod();
     fi;
-    
+
     if exp = 1 then
         pow := ShallowCopy(v);
         ReduceCoeffs(pow,lv,w,lw);
@@ -957,8 +956,7 @@ InstallMethod( PowerModCoeffs,
     od;
     return pow;
 end);
-            
-            
+
 #############################################################################
 ##
 #M  ZeroVector( len, <vector> )


### PR DESCRIPTION
Also fix what looks like a race condition in TYPE_VEC8BIT resp.
TYPE_VEC8BIT_LOCKED: if two threads called these at the same time, they
might create two different type object A and B for the same parameters.
Then the first thread might call InstallTypeSerializationTag with type
A, which installs that type; then execution switches to the second
thread, which also calls InstallTypeSerializationTag (overriding the
installed value with B); the execution switches back to the first
thread, which sets TYPES_VEC8BIT[col][q] to A; and then thread 2
resumes; it also tries to set TYPES_VEC8BIT[col][q], but since there is
already a value in this write-once atomic list, it does nothing.

In the end, A is in TYPES_VEC8BIT and B in DESERIALIZATION_TAG_INT_NEW,
which is not what we want.

So instead, we first set TYPES_VEC8BIT[col][q]; then read back the value
from there and pass that to InstallTypeSerializationTag.

Please use the following template to submit a pull request, filling
in at least the "Text for release notes" and/or "Further details".
Thank You!

# Description

## Text for release notes 

If this pull request should be mentioned in the release notes, 
please provide a short description matching the style of the GAP
[Changes manual](https://www.gap-system.org/Manuals/doc/changes/chap0.html).

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

