### PR TITLE
kernel: avoid using vfork

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3106,7 +3106,7 @@ UInt SyExecuteProcess (
       func2 = &NullSignalHandler;
 
     /* clone the process                                                   */
-    pid = vfork();
+    pid = fork();
     if ( pid == -1 ) {
         return -1;
     }


### PR DESCRIPTION
Calling chdir in the child process after vfork can corrupt the
state of the parent process.

Reported by clang static analyzer <https://clang-analyzer.llvm.org>.

I don't think this actually ever caused problems, but then I can't be sure. But I *am* sure the code can't cause correctness regressions (at worst: a minor performance impact on some OSes, but I doubt it; there is no impact on Linux, where `fork` is blindingly fast anyway). I don't think it needs to be mentioned in release notes: if there was a problem, then it was around for years w/o anybody ever reporting it, or anything that sounded remotely like it could be related to this.