### PR TITLE
Add default IsBound on small lists for large integers

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -3006,6 +3006,20 @@ InstallMethod( IsBound\[\],
     return index <= Length( list );
     end );
 
+#############################################################################
+##
+#M  IsBound( list[i] ) . . . . . IsBound for small lists with large arguments
+##
+InstallMethod( IsBound\[\],
+    "for a small list and large positive integer",
+    [ IsSmallList, IsPosInt ],
+    function( list, index )
+    if IsSmallIntRep(index) then
+        TryNextMethod();
+    else
+        return false;
+    fi;
+    end );
 
 #############################################################################
 ##

--- a/tst/testinstall/hpc/atomic_list.tst
+++ b/tst/testinstall/hpc/atomic_list.tst
@@ -65,6 +65,8 @@ gap> IsBound(a[3]);
 false
 gap> IsBound(a[9]);
 false
+gap> IsBound(a[2^100]);
+false
 gap> GetWithDefault(a, 2, -1);
 7
 gap> GetWithDefault(a, 3, -1);

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -100,6 +100,17 @@ gap> Unbind(a[1,1,1]);
 Syntax error: '[]' only supports 1 or 2 indices in stream:1
 Unbind(a[1,1,1]);
               ^
+gap> a := [1,,3];;
+gap> IsBound(a[1]);
+true
+gap> IsBound(a[2]);
+false
+gap> IsBound(a[3]);
+true
+gap> IsBound(a[4]);
+false
+gap> IsBound(a[2^100]);
+false
 
 #
 # slices


### PR DESCRIPTION
This provides an implementation of IsBound for small lists when they are given an integer which is too large to index the list.

This adds support for IsBound to a few list types, including non-dense lists and atomic lists. The atomic list support fixes the master branch ( #3772 ). The reason this works in non-HPC gap is atomic lists are just implemented as plists, and dense plists support operations like `IsBound(x[2^100])` already.