### PR TITLE
kernel: use posix_spawn_file_actions_addchdir if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -845,6 +845,8 @@ AC_CHECK_HEADERS([spawn.h])
 AC_HEADER_SYS_WAIT
 AC_FUNC_FORK
 AC_CHECK_FUNCS([popen posix_spawn])
+AC_CHECK_FUNCS([posix_spawn_file_actions_addchdir])
+AC_CHECK_FUNCS([posix_spawn_file_actions_addchdir_np])
 
 dnl signal handling
 AC_CHECK_TYPE([sig_atomic_t], [],


### PR DESCRIPTION
This allows us to avoid a race condition when using posix_spawn in a multi-threaded environment, i.e., it allows us to use posix_spawn in HPC-GAP.

I've verified this works on a Fedora 30 system with glibc. I don't have macOS 10.15 in use yet, but I don't expect any serious issues as long as it works on at least one system providing `posix_spawn_file_actions_addchdir` or `posix_spawn_file_actions_addchdir_np`.