### PR TITLE
Fix program cleanup logic

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -1015,8 +1015,9 @@ if GAPInfo.CommandLineOptions.norepl then
 elif IsHPCGAP and THREAD_UI() then
   ReadLib("hpc/consoleui.g");
   MULTI_SESSION();
+  PROGRAM_CLEAN_UP();
 else
   SESSION();
+  PROGRAM_CLEAN_UP();
 fi;
 
-PROGRAM_CLEAN_UP();

--- a/lib/session.g
+++ b/lib/session.g
@@ -25,10 +25,15 @@ InstallAtExit( function()
 end);
 
 BIND_GLOBAL("PROGRAM_CLEAN_UP", function()
-    local f;
+    local f, funcs;
     if IsBound( GAPInfo.AtExitFuncs ) and IsList( GAPInfo.AtExitFuncs ) then
-        while not IsEmpty(GAPInfo.AtExitFuncs) do
-            f := Remove(GAPInfo.AtExitFuncs);
+        if IsHPCGAP then
+            funcs := FromAtomicList(GAPInfo.AtExitFuncs);
+        else
+            funcs := GAPInfo.AtExitFuncs;
+        fi;
+        while not IsEmpty(funcs) do
+            f := Remove(funcs);
             if IsFunction(f) then
                 CALL_WITH_CATCH(f,[]);
             fi;


### PR DESCRIPTION
This change accomplishes two things. One is that it moves the call to PROGRAM_CLEAN_UP() so that it isn't invoked by libgap during startup. The other is that it fixes the PROGRAM_CLEAN_UP() for HPC-GAP, where the list of functions to be run at exit is stored in an atomic list.

One thing that is missing is that there is currently no functionality (that I can see) for a libgap client to do that cleanup when it is about to exit.