### PR TITLE
Tweak README.md and INSTALL.md instructions some more

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,6 @@ Alternative installation methods which aim to simplify the installation
 mostly by offering precompiled binaries are:
 
 * GAP installer for Homebrew (package manager for macOS)
-* BOB - a tool to download and build GAP and its packages from source
 * Docker image for GAP and most of the packages
 * the rsync-based binary distribution for Linux
 
@@ -45,11 +44,13 @@ program.
 
 Installing the GAP distribution with all the packages and full data libraries
 will require (except on Windows) both a C and a C++ compiler (gcc or clang
-is recommended) to be installed on your system.
+is recommended) to be installed on your system. Please also consult
+section "Installing required dependencies" in the file `README.md`.
+
 To get maximum benefit from GAP and from various packages, we recommend
 to install a number of other free software libraries (and their associated
-development tools) although they are not required for basic operation. See
-<https://www.gap-system.org/Download/tools.html> for more details.
+development tools) although they are not required for basic operation.
+See <https://www.gap-system.org/Download/tools.html> for more details.
 
 The installation consists of five easy steps:
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,18 @@ least these:
 * a C compiler, e.g. GCC or Clang
 * a C++ compiler
 * GNU Make
-* GNU Autoconf (we recommend 2.69 or later)
+* GNU Autoconf
 * GNU Libtool
+
+In addition, we recommend that you install at least the following optional
+dependencies:
 * Development headers for GMP, the GNU Multiple Precision Arithmetic Library
-* optional: Development headers for GNU Readline
+* Development headers for zlib
+* Development headers for GNU Readline
 
 On Ubuntu or Debian, you can install these with the following command:
 
-    sudo apt install build-essential autoconf libtool libgmp-dev libreadline-dev
+    sudo apt-get install build-essential autoconf libtool libgmp-dev libreadline-dev zlib1g-dev
 
 On macOS, you can install the dependencies in several ways:
 


### PR DESCRIPTION
- suggest `apt-get` over `apt` as the latter is not present by default
  (at least on older systems)
- make sure users who follow the instructions in INSTALL.md are made
  aware of some of the information in README.md that pertains to them,
  even if they are not installing GAP from the git repository.
- don't mention the obsolete BOB tool
- list zlib as an optional dependency
- clarify that GMP is optional, too
