### PR TITLE
missing `Representative` method for abelian number fields

### DIFF
--- a/hpcgap/lib/fldabnum.gi
+++ b/hpcgap/lib/fldabnum.gi
@@ -2024,4 +2024,6 @@ InstallMethod( GaloisGroup,
 end );
     
 
-InstallMethod( Representative, [IsCyclotomicField], f->0);
+InstallMethod( Representative,
+    [ IsAdditiveMagmaWithZero and IsCyclotomicCollection ],
+    f -> 0 );

--- a/lib/fldabnum.gi
+++ b/lib/fldabnum.gi
@@ -2013,4 +2013,6 @@ InstallMethod( GaloisGroup,
 end );
     
 
-InstallMethod( Representative, [IsCyclotomicField], f->0);
+InstallMethod( Representative,
+    [ IsAdditiveMagmaWithZero and IsCyclotomicCollection ],
+    f -> 0 );

--- a/tst/testinstall/fldabnum.tst
+++ b/tst/testinstall/fldabnum.tst
@@ -56,6 +56,10 @@ gap> Z(5) in NF( 3, [ 2 ] );
 false
 gap> EY(5) in NF( 5, [ 4 ] );
 true
+gap> Representative( CF(12) );
+0
+gap> Representative( NF( 15, [ 14 ] ) );
+0
 gap> Intersection( CF(12), CF(15) );
 CF(3)
 gap> Intersection( CF(12), NF( 15, [ 14 ] ) );


### PR DESCRIPTION
- made the `Representative` method for cycl. fields applicable
  to more general collections of cyclotomics
- added a test;
  up to now, one got a "no method found" error when the argument of `Representative`
  was an abelian number field not being a cycl. field
