### PR TITLE
Brauer table of a permuted isoclinic table

### DIFF
--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -6353,7 +6353,8 @@ InstallMethod( CharacterTableIsoclinic,
       if p = 2 then
         irreducibles:= List( Irr( modtbl ), ValuesOfClassFunction );
       else
-        factorfusion:= GetFusionMap( reg, ordiso );
+        factorfusion:= GetFusionMap( modtbl,
+                                     OrdinaryCharacterTable( modtbl ) );
         nsg:= List( source[2], i -> Position( factorfusion, i ) );
         centre:= List( source[3], i -> Position( factorfusion, i ) );
         xpos:= Position( factorfusion, source[4] );
@@ -6365,7 +6366,8 @@ InstallMethod( CharacterTableIsoclinic,
       if p = source.p then
         irreducibles:= List( Irr( modtbl ), ValuesOfClassFunction );
       else
-        factorfusion:= GetFusionMap( reg, ordiso );
+        factorfusion:= GetFusionMap( modtbl,
+                                     OrdinaryCharacterTable( modtbl ) );
         xpos:= Position( factorfusion, source.centralElement );
         centre:= [ xpos ];
         outer:= List( source.outerClasses,
@@ -6390,11 +6392,10 @@ InstallMethod( CharacterTableIsoclinic,
     # With `IrreducibleCharactersOfIsoclinicGroup', we get irreducibles
     # that fit to t2, thus we have to apply the permutation from t2 to t3.
     if HasClassPermutation( ordiso ) then
+      fus:= GetFusionMap( modtbl, OrdinaryCharacterTable( modtbl ) );
+      inv:= InverseMap( GetFusionMap( reg, ordiso ) );
       pi:= ClassPermutation( ordiso );
-      fus:= GetFusionMap( reg, ordiso );
-      inv:= InverseMap( fus );
-      pi:= PermList( List( [ 1 .. Length( fus ) ],
-                           i -> inv[ fus[i]^pi ] ) );
+      pi:= PermList( List( fus, x -> inv[ x^pi ] ) );
       irreducibles:= List( irreducibles, x -> Permuted( x, pi ) );
     fi;
 

--- a/tst/teststandard/ctblisoc.tst
+++ b/tst/teststandard/ctblisoc.tst
@@ -1,4 +1,4 @@
-#@local g, t, iso, t3, iso3, orders, n, iso2, filt, outer, c
+#@local g, t, iso, t3, iso3, orders, n, iso2, filt, outer, c, ord, pi, sort
 gap> START_TEST( "ctblisoc.tst" );
 
 # one argument
@@ -150,6 +150,14 @@ gap> CharacterTableIsoclinic( t, n, c );;
 gap> CharacterTableIsoclinic( t mod 3,
 >        rec( normalSubgroup:= n, centralElement:= c ) );;
 gap> CharacterTableIsoclinic( t mod 3, n, c );;
+
+# argument with class permutation that does not act on p-regular classes
+gap> t:= CharacterTable( SmallGroup( 240, 90 ) );;
+gap> ord:= OrdersClassRepresentatives( t );;
+gap> iso:= CharacterTableIsoclinic( t );;
+gap> pi:= ( Position( ord, 2 ), Position( ord, 3 ) );;
+gap> sort:= CharacterTableWithSortedClasses( iso, pi );;
+gap> sort mod 3;;   # ran into an error in an older version of GAP
 
 ##
 gap> STOP_TEST( "ctblisoc.tst" );


### PR DESCRIPTION
Consider an ordinary character table t that arises from a table t1
by a class permutation pi, say, and assume t1 arises
as an isoclinic table of another table t2.
If the p-modular table of t2 is known then the p-modular table
of t can be derived from it.

Up to now, GAP ran into an error when the permutation pi did not
act on the set of p-regular classes.
(Since nobody has complained about this, apparently it did not happen.)