### PR TITLE
Update Travis Slack notification integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,8 +159,9 @@ after_script:
 
 notifications:
   slack:
-    secure: Nvt9q2kZ/n7HyFeEYt7rvXMBLIR3AqSbQ54UeoU2UFrF+y0vJONChfa0csneyXPApH+objSUgS8ZW3g4gRiKtnO1jzQq9XDe895HtadY4vxYrduRLiwqI4o0k9KFVBPX7uIUXT22qIaAYBFC93m36zQKIAVDFzYuPoQfTWY3Yww=
+    if: branch =~ ^(master|stable-*)$
+    secure: chHSXX/jjg393BA7W5CPiWqV+/qxXcwNbKvVAkdfFq0r9fYBnCFeIj1Af5yvIW06R3DWAv22hXyagSFO3OgINefoKXXyGirsp7qGNpKIHsNHmS0DE8uN+Qk+iap7O2HpRkJD6gf0gK6pudW1BxQhBxEoP2hSBODzq2mU5hhodr4=
     on_pull_requests: false
-    on_success: change # default: always
-    on_failure: change # default: always
+    on_success: change
+    on_failure: always
   webhooks: https://coveralls.io/webhook


### PR DESCRIPTION
This should hopefully once again deliver notification on Slack
to channel #travis if master fails; and also one time once it
starts to pass again. But no notifications for other successful
master builds, to keep the noise in the channel low.

Should ideally be merged before #3788 to give us a chance to test that it works.

EDIT: As a matter of fact, I'd suggest to merge this; then merge PR #3777 (simply because it can be merged anyway, and is ready), and observe if we see a proper "fail" message in the `#travis` channel on Slack. Once that's there, we can merge #3788.