### PR TITLE
Use `Info` not `Print` in `Decomposition`

### DIFF
--- a/lib/zlattice.gi
+++ b/lib/zlattice.gi
@@ -307,8 +307,8 @@ InstallGlobalFunction( DecompositionInt, function( A, B, depth )
 
       # matrix is singular modulo that `p', choose another one
       p := NextPrimeInt( p );
-      Print( "#I DecompositionInt: choosing new prime : ", p, "\n" );
-#T better Info
+      Info( InfoZLattice, 1,
+            "DecompositionInt: choosing new prime ", p );
       Aqinv:= InverseMatMod( A, p );
     od;
 

--- a/tst/testinstall/zlattice.tst
+++ b/tst/testinstall/zlattice.tst
@@ -1,5 +1,16 @@
-#@local
+#@local A
 gap> START_TEST("zlattice.tst");
+
+# 'Decomposition'
+gap> A:= [ [ 82, 1 ], [ -1, 1 ] ];;
+gap> SetInfoLevel( InfoZLattice, 0 );
+gap> Decomposition( A, [ [ 82, 1 ] ], 1 );
+[ [ 1, 0 ] ]
+gap> SetInfoLevel( InfoZLattice, 1 );
+gap> Decomposition( A, [ [ 82, 1 ] ], 1 );
+#I  DecompositionInt: choosing new prime 89
+[ [ 1, 0 ] ]
+gap> SetInfoLevel( InfoZLattice, 0 );
 
 # trivial cases of `LLLReducedBasis'
 gap> LLLReducedBasis( [ ] );
@@ -7,4 +18,4 @@ rec( B := [  ], basis := [  ], mue := [  ] )
 gap> LLLReducedBasis( [ [ 0, 0 ], [ 0, 0 ] ], "linearcomb" );
 rec( B := [  ], basis := [  ], mue := [  ], 
   relations := [ [ 1, 0 ], [ 0, 1 ] ], transformation := [  ] )
-gap> STOP_TEST( "zlattice.tst", 1);
+gap> STOP_TEST( "zlattice.tst" );


### PR DESCRIPTION
Up to now, `DecompositionInt` and `Decomposition` used `Print`
for showing a message whenever a new prime had to be chosen because
the matrix in question was singular modulo the current prime.

Meanwhile I have several real-world examples where this happens, which I want to use in package tests,
and I think it is better to omit these messages by default, that is, to use `Info` instead of `Print`.

## Text for release notes 
The functions `Decomposition` and `DecompositionInt` do no longer just print a message
whenever a new prime has to be chosen because the matrix in question is singular modulo the current prime.
If one wants to see this message, one can set the info level of `InfoZLattice` to at least 1.
