### PR TITLE
Remove -B option for overriding the architecture

### DIFF
--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -80,16 +80,6 @@ which can be useful for debugging or testing.
 The needed packages (and their needed packages, and so on)
 are loaded in any case.
 </Item>
-<Mark><Index Key="-B"><C>-B</C></Index>
-<C>-B </C><A>architecture</A></Mark>
-<Item>
-Executable binary files that form part of &GAP; or of  a &GAP;  package
-are kept in a subdirectory of the <F>bin</F> directory within  the  &GAP; or
-package root directory. The subdirectory  name  is  determined  from  the
-operating system, processor and compiler details when &GAP;  (resp.  the
-package) is installed. Under rare circumstances, it may be  necessary  to
-override this name, and this can be done using the <C>-B</C> option.
-</Item>
 <Mark><Index Key="-b"><C>-b</C></Index>
 <C>-b</C></Mark>
 <Item>

--- a/lib/system.g
+++ b/lib/system.g
@@ -90,7 +90,6 @@ BIND_GLOBAL( "GAPInfo", rec(
                      "of root paths" ] ),
       rec( short:= "r", default := false, help := ["disable/enable user GAP root dir", "GAPInfo.UserGapRoot"] ),
       rec( short:= "A", default := false, help := ["disable/enable autoloading of suggested", "GAP packages"] ),
-      rec( short:= "B", default := "",    arg := "<name>", help := [ "current architecture"] ),
       rec( short:= "D", default := false, help := ["enable/disable debugging the loading of files"] ),
       rec( short:= "M", default := false, help := ["disable/enable loading of compiled modules"] ),
       rec( short:= "N", default := false, help := ["do not use hidden implications"] ),

--- a/src/gap.c
+++ b/src/gap.c
@@ -1209,7 +1209,7 @@ static Obj FuncKERNEL_INFO(Obj self)
     Obj  tmp;
     UInt i;
 
-    AssPRec(res, RNamName("GAP_ARCHITECTURE"), MakeImmString(SyArchitecture));
+    AssPRec(res, RNamName("GAP_ARCHITECTURE"), MakeImmString(GAPARCH));
     AssPRec(res, RNamName("KERNEL_VERSION"), MakeImmString(SyKernelVersion));
     AssPRec(res, RNamName("KERNEL_API_VERSION"), INTOBJ_INT(GAP_KERNEL_API_VERSION));
     AssPRec(res, RNamName("BUILD_VERSION"), MakeImmString(SyBuildVersion));

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -22,13 +22,6 @@
 *F * * * * * * * * * * * command line settable options  * * * * * * * * * * *
 */
 
-
-/****************************************************************************
-**
-*V  SyArchitecture  . . . . . . . . . . . . . . . .  name of the architecture
-*/
-extern const Char * SyArchitecture;
-
 /****************************************************************************
 **
 *V  SyKernelVersion  . . . . . . . . . . . . . . . .  kernel version number

--- a/src/system.c
+++ b/src/system.c
@@ -72,13 +72,6 @@ const Char * SyKernelVersion = "4.dev";
 
 /****************************************************************************
 **
-*V  SyArchitecture  . . . . . . . . . . . . . . . .  name of the architecture
-*/
-const Char * SyArchitecture = GAPARCH;
-
-
-/****************************************************************************
-**
 *V  SyCTRD  . . . . . . . . . . . . . . . . . . .  true if '<ctr>-D' is <eof>
 */
 UInt SyCTRD;
@@ -999,8 +992,6 @@ static Int enableMemCheck(Char ** argv, void * dummy)
 /* These options must be kept in sync with those in system.g, so the help output
    is correct */
 static const struct optInfo options[] = {
-  { 'B',  "architecture", storeString, &SyArchitecture, 1}, /* default architecture needs to be passed from kernel 
-                                                                  to library. Might be needed for autoload of compiled files */
   { 'C',  "", processCompilerArgs, 0, 4}, /* must handle in kernel */
   { 'D',  "debug-loading", toggle, &SyDebugLoading, 0}, /* must handle in kernel */
   { 'K',  "maximal-workspace", storeMemory2, &SyStorKill, 1}, /* could handle from library with new interface */


### PR DESCRIPTION
The documentation for it claimed that "[u]nder rare circumstances, it
may be necessary to override this name" but I simply can't come up
with any that are not contrived and highly dangerous, and which are not
more easily resolved by renaming or copying a few `bin` subdirectories
inside packages.

That of course just means my imagination might be limited. I wonder if
some of the people who were around (?) when this was added might
know the original motivation and whether there could be circumstances
now where this would still be useful.