### PR TITLE
Change the use of ", say"

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -236,8 +236,8 @@ we provide guidelines for the release preparation and its distribution.
 <Heading>Structure of a GAP Package</Heading>
 
 <Index Subkey="for a GAP package">home directory</Index>
-A &GAP; package should have an alphanumeric name (<A>packagename</A>, say);
-mixed case is fine, but there should  be  no  whitespace characters. 
+A &GAP; package should have an alphanumeric name;
+mixed case is fine, but there should be no whitespace characters.
 All files of a &GAP; package <A>packagename</A> must be collected in a 
 single directory <A>packagedir</A>, where <A>packagedir</A> should  be
 just <A>packagename</A> optionally converted to lowercase and optionally 
@@ -923,7 +923,7 @@ before the package is loaded so it will be silently overwritten.
 <Index>needed package</Index>
 <Index>suggested package</Index>
 <Index Subkey="for a GAP package">dependencies</Index>
-It is possible for one &GAP; package <C>A</C>, say,
+It is possible for one &GAP; package <C>A</C>
 to require another package <C>B</C>.
 For that, one simply adds the name and the (least) version number of the
 package <C>B</C> to the <C>NeededOtherPackages</C> component of the
@@ -1106,7 +1106,7 @@ part and implementation part does in general <E>not</E> allow one to actually
 For example,
 in the case of a <Q>cyclic dependency</Q> as in the second example above,
 suppose that <C>B</C> provides a new function <C>f</C> or a new global record
-<C>r</C>, say, which are declared in the declaration part of <C>B</C>.
+<C>r</C> which are declared in the declaration part of <C>B</C>.
 Then the code in the implementation part of <C>A</C> may contain
 calls to the functions defined in the declaration part of <C>B</C>.
 However, the implementation part of <C>A</C> may be read
@@ -1286,7 +1286,7 @@ This means that the binary is not regarded as essential for this
 package.
 <P/>
 You might also have to cope with the situation that external binaries will
-only run under UNIX (and not, say, under Windows), or may not compile with
+only run under UNIX (and not e.g. under Windows), or may not compile with
 some compilers or default compiler options.
 See&nbsp;<Ref Sect="Testing for the System Architecture"/>
 for information on how to test for the architecture.

--- a/doc/ref/grphomom.xml
+++ b/doc/ref/grphomom.xml
@@ -390,8 +390,8 @@ to form groups of automorphisms.
 <Heading>Calculating with Group Automorphisms</Heading>
 
 Usually the best way to calculate in a group of automorphisms is to
-translate all calculations to an isomorphic group in a representation, for
-which better algorithms are available, say a permutation group. This
+translate all calculations to an isomorphic group in a representation for
+which better algorithms are available, such as a permutation group. This
 translation can be done automatically using <Ref Attr="NiceMonomorphism"/>.
 <P/>
 Once a group knows to be a group of automorphisms (this can be achieved

--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -573,7 +573,7 @@ just consists of the <M>&QQ;</M>-classes of i.m.f.&nbsp;subgroups of <M>GL_n(&QQ
 <P/>
 Secondly, there is the set <M>Q_2(n)</M> of the  <M>&QQ;</M>-classes of the remaining
 i.m.f.&nbsp;subgroups of <M>GL_n(&ZZ;)</M>, i.e.,  of   those which are  not  maximal
-finite subgroups of <M>GL_n(&QQ;)</M>. For any such group  <M>G</M>, say, there is at
+finite subgroups of <M>GL_n(&QQ;)</M>. For any such group <M>G</M>, there is at
 least one class <M>C \in Q_1(n)</M> such that <M>G</M> is conjugate under <M>&QQ;</M> to a
 proper subgroup of some   group <M>H \in C</M>.   In  fact, the class <M>C</M>   is
 uniquely determined for any group   <M>G</M> occurring in the library  (though
@@ -587,7 +587,7 @@ of i.m.f.&nbsp;subgroups  of <M>GL_4(&ZZ;)</M>   with representative subgroups  
 \ldots,  G_6</M> of isomorphism types  <M>G_1 \cong W(F_4)</M>, <M>G_2 \cong D_{12}
 \wr C_2</M>, <M>G_3 \cong  G_4 \cong C_2 \times  S_5</M>, <M>G_5 \cong W(B_4)</M>, and
 <M>G_6  \cong (D_{12}  </M><C>Y</C><M>  D_{12})   \!:\! C_2</M>.  The    corresponding
-<M>&QQ;</M>-classes, <M>R_1, \ldots, R_6</M>, say, are pairwise different except that
+<M>&QQ;</M>-classes, which we denote <M>R_1, \ldots, R_6</M>, are pairwise different except that
 <M>R_3</M> coincides  with <M>R_4</M>.   The  groups <M>G_1</M>,  <M>G_2</M>, and  <M>G_3</M>  are
 i.m.f.&nbsp;subgroups of <M>GL_4(&QQ;)</M>, but <M>G_5</M>  and <M>G_6</M> are not because they
 are  conjugate under <M>GL_4(&QQ;)</M> to proper  subgroups  of <M>G_1</M> and <M>G_2</M>,

--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -1815,7 +1815,7 @@ An <E>enumerator</E> is an immutable list that need not store its elements
 explicitly but knows, from a set of basic data,
 how to determine the <M>i</M>-th element and the position of a given object.
 A typical example of this is a vector space over a finite field with <M>q</M>
-elements, say, for which it is very easy to enumerate all elements
+elements for which it is very easy to enumerate all elements
 using <M>q</M>-adic expansions of integers.
 <P/>
 Using this enumeration can be even quicker than a binary search in a sorted

--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -140,7 +140,7 @@ or the product of a finite field element and an integer matrix.
 returns the product of the row vector <A>vec</A> and the matrix <A>mat</A>.
 Probably the most usual situation is that <A>vec</A> and <A>mat</A> have the same
 lengths and are defined over a common field,
-and that all rows of <A>mat</A> have the same length <M>m</M>, say;
+and that all rows of <A>mat</A> have some common length <M>m</M>;
 in this case the product is a new row vector of length <M>m</M> over the same
 field which is the sum of the scalar multiples of the rows of <A>mat</A> with the
 corresponding entries of <A>vec</A>.
@@ -173,7 +173,7 @@ This form evaluates to the (Cauchy) product of the two matrices <A>mat1</A> and
 Probably the most usual situation is that the number of columns of <A>mat1</A>
 equals the number of rows of <A>mat2</A>,
 and that the elements of <A>mat</A> and <A>vec</A> lie in a common field;
-if <A>mat1</A> is a matrix with <M>m</M> rows and <M>n</M> columns, say, and <A>mat2</A> is a
+if <A>mat1</A> is a matrix with <M>m</M> rows and <M>n</M> columns and <A>mat2</A> is a
 matrix with <M>n</M> rows and <M>o</M> columns, the result is a new matrix with <M>m</M>
 rows and <M>o</M> columns.
 The element in row <M>i</M> at position <M>j</M> of the product is the sum of
@@ -551,7 +551,7 @@ written over finite fields.
 
 The following operations deal with matrices over a ring,
 but only care about the residues of their entries modulo some ring element.
-In the case of the integers and a prime number <M>p</M>, say,
+In the case of the integers and a prime number <M>p</M>,
 this is effectively computation in a matrix over the prime field
 in characteristic <M>p</M>.
 
@@ -567,7 +567,7 @@ in characteristic <M>p</M>.
 <Heading>Special Multiplication Algorithms for Matrices over GF(2)</Heading>
 
 When multiplying two compressed matrices <M>M</M> and <M>N</M> over GF(2) of dimensions
-<M>a \times b</M> and <M>b \times c</M>, say,
+<M>a \times b</M> and <M>b \times c</M>,
 where <M>a</M>, <M>b</M> and <M>c</M> are all
 greater than or equal to 128, &GAP; by default uses a more
 sophisticated matrix multiplication algorithm, in which linear

--- a/doc/ref/pcgs.xml
+++ b/doc/ref/pcgs.xml
@@ -415,7 +415,7 @@ subgroup of <M>G_{{i-1}}</M> with nilpotent factor. To obtain the LG-series
 of <A>G</A> we need to refine this series.
 Thus consider a factor <M>F_i := G_i / G_{{i+1}}</M>.
 Since <M>F_i</M> is finite nilpotent, it is a direct
-product of its Sylow subgroups, say <M>F_i = P_{{i,1}} \cdots P_{{i,r_i}}</M>.
+product of its Sylow subgroups <M>F_i = P_{{i,1}} \cdots P_{{i,r_i}}</M>.
 For each Sylow <M>p_j</M>-subgroup <M>P_{{i,j}}</M> we can consider its
 lower <M>p_j</M>-central series. To obtain a characteristic central series
 with elementary abelian factors of <M>F_i</M> we loop over its Sylow subgroups.

--- a/doc/ref/pres.xml
+++ b/doc/ref/pres.xml
@@ -88,7 +88,7 @@ numbering of generators in a family of associative words.
 <Section Label="Printing Presentations">
 <Heading>Printing Presentations</Heading>
 
-Whenever you create a presentation <M>P</M>, say, or assign it to a variable,
+Whenever you create a presentation <M>P</M>, or assign it to a variable,
 &GAP; will respond by printing <M>P</M>.
 However, as <M>P</M> may contain a lot of generators and many relators
 of large length, it would be annoying if the standard print facilities

--- a/doc/ref/reesmat.xml
+++ b/doc/ref/reesmat.xml
@@ -38,9 +38,9 @@
   semigroup elements is created from a specific Rees matrix semigroup, which
   contains the whole family of its elements.  So, it is not possible to
   multiply or compare elements belonging to distinct Rees matrix semigroups, 
-  since they belong to different families. This situation is similar to, say,
-  free groups, and different to, say, permutations, which belong to a single
-  family, and where arbitrary permutations can be compared and multiplied
+  since they belong to different families. For example, this situation is
+  similar to free groups, but it is different to permutations, which belong to a
+  single family, and where arbitrary permutations can be compared and multiplied
   without reference to any group containing them. <P/>
 
   A subsemigroup of a Rees matrix semigroup is not necessarily a Rees matrix

--- a/doc/tut/opers.xml
+++ b/doc/tut/opers.xml
@@ -169,7 +169,7 @@ of other  attribute   values. Details  of   this <E>method selection</E>   are
 described in chapter&nbsp;<Ref Chap="Method Selection" BookName="ref"/>.
 <P/>
 We  only present the following  rule  of  thumb here:
-Each installed method for an attribute, say <Ref Func="Size" BookName="ref"/>,
+Each installed method for an attribute, for example <Ref Func="Size" BookName="ref"/>,
 has a <Q>required filter</Q>, which is made  up from certain simple filters
 which must yield <K>true</K> for the argument <A>obj</A> for this method to be
 applicable.

--- a/grp/imf.gd
+++ b/grp/imf.gd
@@ -52,10 +52,10 @@ DeclareAttribute( "ImfRecord", IsGroup, "mutable" );
 ##
 #F  BaseShortVectors( <orbit> ) . . . . . . . . . . . . . . . . . . . . . . .
 ##
-##  'BaseShortVectors'  expects as argument an  orbit of short vectors  under
+##  'BaseShortVectors' expects as argument an  orbit of short vectors  under
 ##  some  imf  matrix  group  of  dimension  dim,  say.  This  orbit  can  be
 ##  considered  as  a set of generatos  of a  dim-dimensional  Q-vectorspace.
-##  'BaseShortVectors' determines a subset B, say, of <orbit> which is a base
+##  'BaseShortVectors' determines a subset B of <orbit> which is a base
 ##  of that vectorspace, and it returns a list of two lists containing
 ##
 ##  - a list of the position numbers with respect to <orbit> of the  elements

--- a/hpcgap/demo/Echelon.g
+++ b/hpcgap/demo/Echelon.g
@@ -48,7 +48,7 @@ end;
 ##  
 ##  TrigonalizeSubset(mat, pivots, inds)  
 ##  
-##  Arguments: matrix mat with, say, n rows;
+##  Arguments: matrix mat with n rows;
 ##             list pivots of length n, such that 
 ##                  pivots[i] = PositionNonZero(mat[i]) or = 0;
 ##             inds is a sublist of [1..n].

--- a/hpcgap/lib/basis.gd
+++ b/hpcgap/lib/basis.gd
@@ -225,7 +225,7 @@ InstallTrueMethod( IsSmallList,
 ##  <Prop Name="IsIntegralBasis" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M>, say, for a subfield <M>S</M> of <M>F</M>,
+##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M> for a subfield <M>S</M> of <M>F</M>,
 ##  and let <M>R</M> and <M>M</M> be the rings of algebraic integers in <M>S</M> and <M>F</M>,
 ##  respectively.
 ##  <C>IsIntegralBasis</C> returns <K>true</K> if <A>B</A> is also an <M>R</M>-basis of <M>M</M>,
@@ -246,7 +246,7 @@ DeclareProperty( "IsIntegralBasis", IsBasis );
 ##  <Prop Name="IsNormalBasis" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M>, say,
+##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M>
 ##  for a subfield <M>S</M> of <M>F</M>.
 ##  <C>IsNormalBasis</C> returns <K>true</K> if <A>B</A> is invariant under
 ##  the Galois group
@@ -275,7 +275,7 @@ DeclareProperty( "IsNormalBasis", IsBasis );
 ##  <Prop Name="IsSemiEchelonized" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be a basis of a Gaussian row or matrix space <M>V</M>, say
+##  Let <A>B</A> be a basis of a Gaussian row or matrix space <M>V</M>
 ##  (see&nbsp;<Ref Filt="IsGaussianSpace"/>) over the field <M>F</M>.
 ##  <P/>
 ##  If <M>V</M> is a row space then <A>B</A> is semi-echelonized if the matrix formed
@@ -339,7 +339,7 @@ DeclareAttribute( "BasisVectors", IsBasis );
 ##  <Attr Name="EnumeratorByBasis" Arg='B'/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>, say,
+##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>,
 ##  <C>EnumeratorByBasis</C> returns an enumerator that loops over the elements of
 ##  <M>V</M> as linear combinations of the vectors of <A>B</A> with coefficients the
 ##  row vectors in the full row space (see&nbsp;<Ref Func="FullRowSpace"/>) of dimension <M>n</M>
@@ -373,7 +373,7 @@ DeclareAttribute( "EnumeratorByBasis", IsBasis );
 ##  <Attr Name="StructureConstantsTable" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be a basis of a free left module <M>R</M>, say,
+##  Let <A>B</A> be a basis of a free left module <M>R</M>
 ##  that is also a ring.
 ##  In this case <Ref Attr="StructureConstantsTable"/> returns
 ##  a structure constants table <M>T</M> in sparse representation,
@@ -438,7 +438,7 @@ DeclareAttribute( "StructureConstantsTable", IsBasis );
 ##  <Attr Name="UnderlyingLeftModule" Arg='B'/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of a free left module <M>V</M>, say,
+##  For a basis <A>B</A> of a free left module <M>V</M>,
 ##  <Ref Attr="UnderlyingLeftModule"/> returns <M>V</M>.
 ##  <P/>
 ##  The reason why a basis stores a free left module is that otherwise one
@@ -498,7 +498,7 @@ DeclareOperation( "Coefficients", [ IsBasis, IsVector ] );
 ##
 ##  <Description>
 ##  If <A>B</A> is a basis object (see <Ref Filt="IsBasis"/>)
-##  or a homogeneous list of length <M>n</M>, say,
+##  or a homogeneous list of length <M>n</M>
 ##  and <A>coeff</A> is a row vector of the same length,
 ##  <Ref Oper="LinearCombination"/> returns the vector
 ##  <M>\sum_{{i = 1}}^n <A>coeff</A>[i] * <A>B</A>[i]</M>.
@@ -561,7 +561,7 @@ DeclareOperation( "SiftedVector", [ IsBasis, IsVector ] );
 ##  <Oper Name="IteratorByBasis" Arg='B'/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>, say,
+##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>,
 ##  <C>IteratorByBasis</C> returns an iterator that loops over the elements of <M>V</M>
 ##  as linear combinations of the vectors of <A>B</A> with coefficients the row
 ##  vectors in the full row space (see&nbsp;<Ref Func="FullRowSpace"/>) of dimension <M>n</M> over
@@ -749,8 +749,8 @@ DeclareOperation( "RelativeBasisNC", [ IsBasis, IsHomogeneousList ] );
 ##  and analogously for each vector in <M>W</M>,
 ##  one can compute the preimage in <M>V</M>.
 ##  <P/>
-##  This allows one to delegate computations w.r.t.&nbsp;a basis <M>B</M>,
-##  say, of <M>V</M> to the corresponding basis <M>C</M>, say, of <M>W</M>.
+##  This allows one to delegate computations w.r.t.&nbsp;a basis <M>B</M>
+##  of <M>V</M> to the corresponding basis <M>C</M> of <M>W</M>.
 ##  We call <M>W</M> the <E>nice free left module</E> of <M>V</M>,
 ##  and <M>C</M> the <E>nice basis</E> of <M>B</M>.
 ##  (Note that it may happen that also <M>C</M> delegates questions to a

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -337,7 +337,7 @@ DeclareAttribute( "PowerSubalgebraSeries", IsAlgebra );
 ##
 ##  <Description>
 ##  The <E>adjoint map</E> <M>ad(x)</M> of an element <M>x</M> in an
-##  <M>F</M>-algebra <M>A</M>, say, is the left multiplication by <M>x</M>.
+##  <M>F</M>-algebra <M>A</M> is the left multiplication by <M>x</M>.
 ##  This map is <M>F</M>-linear and thus, w.r.t. the given basis
 ##  <A>B</A><M> = (x_1, x_2, \ldots, x_n)</M> of <M>A</M>,
 ##  <M>ad(x)</M> can be represented by a matrix over <M>F</M>.
@@ -603,7 +603,7 @@ DeclareOperation( "DirectSumOfAlgebras", [ IsDenseList ] );
 ##
 ##  <Description>
 ##  Let <A>lst</A>  be a nonempty list of square matrices of the same
-##  dimension <M>n</M>, say, with entries in the field <A>F</A>.
+##  dimension <M>n</M> with entries in the field <A>F</A>.
 ##  <Ref Func="FullMatrixAlgebraCentralizer"/> returns
 ##  the (pointwise) centralizer of all matrices in <A>lst</A>, inside
 ##  the full matrix algebra of <M>n \times n</M> matrices over <A>F</A>.

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -2443,7 +2443,7 @@ InstallMethod( CentralizerOp,
 ##
 #F  CentreFromSCTable( <T> )
 ##
-##  Given a structure constants table <T> w.r.t. a basis $B$, say,
+##  Given a structure constants table <T> w.r.t. a basis $B$,
 ##  `CentreFromSCTable' returns a list of $B$-coefficients vectors
 ##  of a basis for the centre of an $F$-algebra with s.c. table <T>,
 ##  where $F$ is assumed to be commutative.

--- a/lib/alghom.gd
+++ b/lib/alghom.gd
@@ -409,7 +409,7 @@ DeclareSynonymAttr( "IsomorphismMatrixAlgebra", IsomorphismMatrixFLMLOR );
 ##  <Attr Name="IsomorphismSCAlgebra" Arg='A' Label="for an algebra"/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of an algebra <M>A</M>, say,
+##  For a basis <A>B</A> of an algebra <M>A</M>,
 ##  <Ref Attr="IsomorphismSCAlgebra" Label="w.r.t. a given basis"/> returns
 ##  an algebra isomorphism from <M>A</M> to an algebra <M>S</M> given by
 ##  structure constants

--- a/lib/algsc.gd
+++ b/lib/algsc.gd
@@ -11,7 +11,7 @@
 ##  This file contains the design of elements of algebras given by structure
 ##  constants (s.~c.).
 ##
-##  An s.~c. algebra is a free left module $A$ of fixed dimension $n$, say,
+##  An s.~c. algebra is a free left module $A$ of fixed dimension $n$
 ##  over a ring-with-one $R$, with multiplication defined on the vectors of
 ##  the standard basis $B$ of $A$ by the structure constants table.
 ##

--- a/lib/algsc.gi
+++ b/lib/algsc.gi
@@ -517,7 +517,7 @@ InstallMethod( \in,
 #F  AlgebraByStructureConstants( <R>, <sctable>, <name1>, <name2>, ... )
 ##
 ##  is an algebra $A$ over the ring <R>, defined by the structure constants
-##  table <sctable> of length $n$, say.
+##  table <sctable> of length $n$.
 ##
 ##  The generators of $A$ are linearly independent abstract space generators
 ##  $x_1, x_2, \ldots, x_n$ which are multiplied according to the formula

--- a/lib/basis.gd
+++ b/lib/basis.gd
@@ -225,7 +225,7 @@ InstallTrueMethod( IsSmallList,
 ##  <Prop Name="IsIntegralBasis" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M>, say, for a subfield <M>S</M> of <M>F</M>,
+##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M> for a subfield <M>S</M> of <M>F</M>,
 ##  and let <M>R</M> and <M>M</M> be the rings of algebraic integers in <M>S</M> and <M>F</M>,
 ##  respectively.
 ##  <C>IsIntegralBasis</C> returns <K>true</K> if <A>B</A> is also an <M>R</M>-basis of <M>M</M>,
@@ -246,7 +246,7 @@ DeclareProperty( "IsIntegralBasis", IsBasis );
 ##  <Prop Name="IsNormalBasis" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M>, say,
+##  Let <A>B</A> be an <M>S</M>-basis of a <E>field</E> <M>F</M>
 ##  for a subfield <M>S</M> of <M>F</M>.
 ##  <C>IsNormalBasis</C> returns <K>true</K> if <A>B</A> is invariant under
 ##  the Galois group
@@ -275,7 +275,7 @@ DeclareProperty( "IsNormalBasis", IsBasis );
 ##  <Prop Name="IsSemiEchelonized" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be a basis of a Gaussian row or matrix space <M>V</M>, say
+##  Let <A>B</A> be a basis of a Gaussian row or matrix space <M>V</M>
 ##  (see&nbsp;<Ref Filt="IsGaussianSpace"/>) over the field <M>F</M>.
 ##  <P/>
 ##  If <M>V</M> is a row space then <A>B</A> is semi-echelonized if the matrix formed
@@ -339,7 +339,7 @@ DeclareAttribute( "BasisVectors", IsBasis );
 ##  <Attr Name="EnumeratorByBasis" Arg='B'/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>, say,
+##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>,
 ##  <C>EnumeratorByBasis</C> returns an enumerator that loops over the elements of
 ##  <M>V</M> as linear combinations of the vectors of <A>B</A> with coefficients the
 ##  row vectors in the full row space (see&nbsp;<Ref Func="FullRowSpace"/>) of dimension <M>n</M>
@@ -373,7 +373,7 @@ DeclareAttribute( "EnumeratorByBasis", IsBasis );
 ##  <Attr Name="StructureConstantsTable" Arg='B'/>
 ##
 ##  <Description>
-##  Let <A>B</A> be a basis of a free left module <M>R</M>, say,
+##  Let <A>B</A> be a basis of a free left module <M>R</M>
 ##  that is also a ring.
 ##  In this case <Ref Attr="StructureConstantsTable"/> returns
 ##  a structure constants table <M>T</M> in sparse representation,
@@ -438,7 +438,7 @@ DeclareAttribute( "StructureConstantsTable", IsBasis );
 ##  <Attr Name="UnderlyingLeftModule" Arg='B'/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of a free left module <M>V</M>, say,
+##  For a basis <A>B</A> of a free left module <M>V</M>,
 ##  <Ref Attr="UnderlyingLeftModule"/> returns <M>V</M>.
 ##  <P/>
 ##  The reason why a basis stores a free left module is that otherwise one
@@ -498,7 +498,7 @@ DeclareOperation( "Coefficients", [ IsBasis, IsVector ] );
 ##
 ##  <Description>
 ##  If <A>B</A> is a basis object (see <Ref Filt="IsBasis"/>)
-##  or a homogeneous list of length <M>n</M>, say,
+##  or a homogeneous list of length <M>n</M>,
 ##  and <A>coeff</A> is a row vector of the same length,
 ##  <Ref Oper="LinearCombination"/> returns the vector
 ##  <M>\sum_{{i = 1}}^n <A>coeff</A>[i] * <A>B</A>[i]</M>.
@@ -561,7 +561,7 @@ DeclareOperation( "SiftedVector", [ IsBasis, IsVector ] );
 ##  <Oper Name="IteratorByBasis" Arg='B'/>
 ##
 ##  <Description>
-##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>, say,
+##  For a basis <A>B</A> of the free left <M>F</M>-module <M>V</M> of dimension <M>n</M>,
 ##  <C>IteratorByBasis</C> returns an iterator that loops over the elements of <M>V</M>
 ##  as linear combinations of the vectors of <A>B</A> with coefficients the row
 ##  vectors in the full row space (see&nbsp;<Ref Func="FullRowSpace"/>) of dimension <M>n</M> over
@@ -749,8 +749,8 @@ DeclareOperation( "RelativeBasisNC", [ IsBasis, IsHomogeneousList ] );
 ##  and analogously for each vector in <M>W</M>,
 ##  one can compute the preimage in <M>V</M>.
 ##  <P/>
-##  This allows one to delegate computations w.r.t.&nbsp;a basis <M>B</M>,
-##  say, of <M>V</M> to the corresponding basis <M>C</M>, say, of <M>W</M>.
+##  This allows one to delegate computations w.r.t.&nbsp;a basis <M>B</M>
+##  of <M>V</M> to the corresponding basis <M>C</M> of <M>W</M>.
 ##  We call <M>W</M> the <E>nice free left module</E> of <M>V</M>,
 ##  and <M>C</M> the <E>nice basis</E> of <M>B</M>.
 ##  (Note that it may happen that also <M>C</M> delegates questions to a

--- a/lib/basismut.gd
+++ b/lib/basismut.gd
@@ -180,7 +180,7 @@ DeclareOperation( "NrBasisVectors", [ IsMutableBasis ] );
 ##  <Oper Name="ImmutableBasis" Arg='MB[, V]'/>
 ##
 ##  <Description>
-##  <Ref Oper="ImmutableBasis"/> returns the immutable basis <M>B</M>, say,
+##  <Ref Oper="ImmutableBasis"/> returns the immutable basis <M>B</M>
 ##  with the same basis vectors as in the mutable basis <A>MB</A>.
 ##  <P/>
 ##  If the second argument <A>V</A> is present then <A>V</A> is the value of
@@ -217,7 +217,7 @@ DeclareOperation( "ImmutableBasis", [ IsMutableBasis, IsFreeLeftModule ] );
 ##  <Oper Name="CloseMutableBasis" Arg='MB, v'/>
 ##
 ##  <Description>
-##  For a mutable basis <A>MB</A> over the coefficient ring <M>R</M>, say,
+##  For a mutable basis <A>MB</A> over the coefficient ring <M>R</M>
 ##  and a vector <A>v</A>, <Ref Oper="CloseMutableBasis"/> changes <A>MB</A>
 ##  such that afterwards it describes the <M>R</M>-span of the former
 ##  basis vectors together with <A>v</A>.
@@ -263,7 +263,7 @@ DeclareOperation( "CloseMutableBasis",
 ##  <Oper Name="IsContainedInSpan" Arg='MB, v'/>
 ##
 ##  <Description>
-##  For a mutable basis <A>MB</A> over the coefficient ring <M>R</M>, say,
+##  For a mutable basis <A>MB</A> over the coefficient ring <M>R</M>
 ##  and a vector <A>v</A>, <C>IsContainedInSpan</C> returns <K>true</K> is <A>v</A> lies in the
 ##  <M>R</M>-span of the current basis vectors of <A>MB</A>,
 ##  and <K>false</K> otherwise.

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -90,7 +90,7 @@
 ##  themselves (which are not domains in the sense of &GAP;).
 ##  <P/>
 ##  For computations with characters of a finite group <M>G</M> with <M>n</M>
-##  conjugacy classes, say, we fix an ordering of the classes, and then
+##  conjugacy classes, we fix an ordering of the classes, and then
 ##  identify each class with its position according to this ordering.
 ##  Each character of <M>G</M> can be represented by a list of length
 ##  <M>n</M> in which the character value for elements of the <M>i</M>-th
@@ -2697,7 +2697,7 @@ DeclareSynonym( "ComputedIsPSolubleCharacterTables",
 ##
 ##  <Description>
 ##  For two ordinary character tables <A>tbl</A> and <A>subtbl</A> of a group
-##  <M>G</M> and its subgroup <M>U</M>, say,
+##  <M>G</M> and its subgroup <M>U</M>
 ##  and a list <A>fus</A> of positive integers that describes the class
 ##  fusion of <M>U</M> into <M>G</M>,
 ##  <Ref Func="IsClassFusionOfNormalSubgroup"/> returns <K>true</K>
@@ -3870,7 +3870,7 @@ DeclareOperation( "CharacterTableFactorGroup",
 ##
 ##  <Description>
 ##  Let <A>tbl</A> be the (ordinary or modular) character table of a group
-##  <M>H</M>, say, with the structure <M>p.G.p</M> for some prime <M>p</M>,
+##  <M>H</M> with the structure <M>p.G.p</M> for some prime <M>p</M>,
 ##  that is, <M>H/Z</M> has a normal subgroup <M>N</M> of index <M>p</M>
 ##  and a central subgroup <M>Z</M> of order <M>p</M> contained in <M>N</M>.
 ##  <P/>
@@ -4148,7 +4148,7 @@ DeclareGlobalFunction( "CharacterTableOfNormalSubgroup" );
 ##   Arg='tbl, chars, degree, norm, galois'/>
 ##
 ##  <Description>
-##  returns a permutation <M>\pi</M>, say, that can be applied to the list
+##  returns a permutation <M>\pi</M> that can be applied to the list
 ##  <A>chars</A> of characters of the character table <A>tbl</A> in order to
 ##  sort this list w.r.t.&nbsp;increasing degree, norm, or both.
 ##  The arguments <A>degree</A>, <A>norm</A>, and <A>galois</A> must be
@@ -4253,7 +4253,7 @@ DeclareOperation( "SortedCharacters",
 ##   Arg='tbl, classes, orders, galois'/>
 ##
 ##  <Description>
-##  returns a permutation <M>\pi</M>, say, that can be applied to the columns
+##  returns a permutation <M>\pi</M> that can be applied to the columns
 ##  in the character table <A>tbl</A> in order to sort this table
 ##  w.r.t.&nbsp;increasing class length, element order, or both.
 ##  <A>classes</A> and <A>orders</A> must be Booleans.

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -1312,7 +1312,7 @@ InstallMethod( IsSimpleCharacterTable,
 ##  a simple group of prime order by outer automorphisms.
 ##  (These groups are not regarded as almost simple.)
 ##  Namely, such a group has a unique minimal normal subgroup <M>N</M> of
-##  prime order <M>p</M>, say,
+##  prime order <M>p</M>
 ##  and all nontrivial conjugacy classes of <M>G</M> inside <M>N</M>
 ##  have length <M>[G:N]</M>.
 ##
@@ -2204,7 +2204,7 @@ InstallMethod( ClassPositionsOfSolvableRadical,
 ##
 #M  ClassPositionsOfLowerCentralSeries( <tbl> )
 ##
-##  Let <A>tbl</A> be the character table of the group <M>G</M>, say.
+##  Let <A>tbl</A> be the character table of a group <M>G</M>.
 ##  The lower central series <M>[ K_1, K_2, \ldots, K_n ]</M> of <M>G</M>
 ##  is defined by <M>K_1 = G</M>, and <M>K_{i+1} = [ K_i, G ]</M>.
 ##  <C>ClassPositionsOfLowerCentralSeries( <A>tbl</A> )</C> is a list
@@ -5919,7 +5919,7 @@ InstallMethod( CharacterTableIsoclinic,
 ##  class positions of the i-th coset of the relevant normal subgroup 'N'
 ##  in 'H' that is given by <p>.G' or '4.G',
 ##  and <xpos> is the class position in 'H' of a generating element of the
-##  relevant central subgroup 'C', say, of order <p> or 4 in 'N'.
+##  relevant central subgroup 'C' of order <p> or 4 in 'N'.
 ##  <center> is a list that describes 'C', as follows;
 ##  if 'H' has the structure '4.G.2' then <center> contains the class
 ##  positions in 'H' of elements of the orders 2 and 4 in 'C',

--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -285,7 +285,7 @@ DeclareGlobalFunction( "CharacterString" );
 ##  <Attr Name="UnderlyingCharacterTable" Arg='psi'/>
 ##
 ##  <Description>
-##  For a class function <A>psi</A> of the group <M>G</M>, say,
+##  For a class function <A>psi</A> of a group <M>G</M>
 ##  the character table of <M>G</M> is stored as value of
 ##  <Ref Attr="UnderlyingCharacterTable"/>.
 ##  The ordering of entries in the list <A>psi</A>
@@ -1283,7 +1283,7 @@ DeclareOperation( "MatScalarProducts",
 ##
 ##  <Description>
 ##  <Index Subkey="of character" Key="Norm"><C>Norm</C></Index>
-##  For an ordinary class function <A>chi</A> of the group <M>G</M>, say,
+##  For an ordinary class function <A>chi</A> of a group <M>G</M>
 ##  we have <M><A>chi</A> = \sum_{{\chi \in Irr(G)}} a_{\chi} \chi</M>,
 ##  with complex coefficients <M>a_{\chi}</M>.
 ##  The <E>norm</E> of <A>chi</A> is defined as
@@ -1332,7 +1332,7 @@ DeclareOperation( "Norm", [ IsOrdinaryTable, IsHomogeneousList ] );
 ##
 ##  <Description>
 ##  <Index Subkey="of a character">centre</Index>
-##  For a character <A>chi</A> of the group <M>G</M>, say,
+##  For a character <A>chi</A> of a group <M>G</M>,
 ##  <Ref Attr="CentreOfCharacter"/> returns the <E>centre</E> of <A>chi</A>,
 ##  that is, the normal subgroup of all those elements of <M>G</M> for which
 ##  the quotient of the value of <A>chi</A> by the degree of <A>chi</A> is
@@ -1453,7 +1453,7 @@ DeclareAttribute( "DegreeOfCharacter", IsClassFunction );
 ##  <Oper Name="InertiaSubgroup" Arg='[tbl, ]G, chi'/>
 ##
 ##  <Description>
-##  Let <A>chi</A> be a character of the group <M>H</M>, say,
+##  Let <A>chi</A> be a character of a group <M>H</M>
 ##  and <A>tbl</A> the character table of <M>H</M>;
 ##  if the argument <A>tbl</A> is not given then the underlying character
 ##  table of <A>chi</A> (see&nbsp;<Ref Attr="UnderlyingCharacterTable"/>) is
@@ -1492,7 +1492,7 @@ DeclareOperation( "InertiaSubgroup",
 ##  <Attr Name="KernelOfCharacter" Arg='[tbl, ]chi'/>
 ##
 ##  <Description>
-##  For a class function <A>chi</A> of the group <M>G</M>, say,
+##  For a class function <A>chi</A> of a group <M>G</M>,
 ##  <Ref Attr="KernelOfCharacter"/> returns the normal subgroup of <M>G</M>
 ##  that is formed by those conjugacy classes for which the value of
 ##  <A>chi</A> equals the degree of <A>chi</A>.
@@ -1640,7 +1640,7 @@ DeclareOperation( "Transitivity", [ IsOrdinaryTable, IsHomogeneousList ] );
 ##
 ##  <Description>
 ##  <Index>central character</Index>
-##  For a character <A>chi</A> of the group <M>G</M>, say,
+##  For a character <A>chi</A> of a group <M>G</M>,
 ##  <Ref Attr="CentralCharacter"/> returns
 ##  the <E>central character</E> of <A>chi</A>.
 ##  <P/>
@@ -1703,7 +1703,7 @@ DeclareOperation( "DeterminantOfCharacter",
 ##  <Oper Name="EigenvaluesChar" Arg='[tbl, ]chi, class'/>
 ##
 ##  <Description>
-##  Let <A>chi</A> be a character of the group <M>G</M>, say.
+##  Let <A>chi</A> be a character of a group <M>G</M>.
 ##  For an element <M>g \in G</M> in the <A>class</A>-th conjugacy class,
 ##  of order <M>n</M>, let <M>M</M> be a matrix of a representation affording
 ##  <A>chi</A>.
@@ -1819,7 +1819,7 @@ DeclareOperation( "Tensored", [ IsHomogeneousList, IsHomogeneousList ] );
 ##  <Oper Name="RestrictedClassFunction" Arg='[tbl, ]chi, target'/>
 ##
 ##  <Description>
-##  Let <A>chi</A> be a class function of the group <M>G</M>, say,
+##  Let <A>chi</A> be a class function of a group <M>G</M>
 ##  and let <A>target</A> be either a subgroup <M>H</M> of <M>G</M>
 ##  or an injective homomorphism from <M>H</M> to <M>G</M>
 ##  or the character table of <A>H</A>.
@@ -1951,7 +1951,7 @@ DeclareSynonym( "Inflated", Restricted );
 ##   Label="for the character table of a supergroup"/>
 ##
 ##  <Description>
-##  Let <A>chi</A> be a class function of the group <M>G</M>, say,
+##  Let <A>chi</A> be a class function of a group <M>G</M>
 ##  and let <A>target</A> be either a supergroup <M>H</M> of <M>G</M>
 ##  or an injective homomorphism from <M>H</M> to <M>G</M>
 ##  or the character table of <A>H</A>.
@@ -2158,7 +2158,7 @@ DeclareOperation( "InducedCyclic", [ IsOrdinaryTable, IsList, IsString ] );
 ##
 ##  <Description>
 ##  Let <A>reducibles</A> be a list of ordinary virtual characters
-##  of the group <M>G</M>, say.
+##  of a group <M>G</M>.
 ##  If <A>constituents</A> is given then it must also be a list of ordinary
 ##  virtual characters of <M>G</M>,
 ##  otherwise we have <A>constituents</A> equal to <A>reducibles</A>

--- a/lib/ctblmaps.gd
+++ b/lib/ctblmaps.gd
@@ -191,7 +191,7 @@ DeclareAttributeSuppCT( "ComputedPowerMaps",
 ##  <Oper Name="PossiblePowerMaps" Arg='tbl, p[, options]'/>
 ##
 ##  <Description>
-##  For the ordinary character table <A>tbl</A> of the group <M>G</M>, say,
+##  For the ordinary character table <A>tbl</A> of a group <M>G</M>
 ##  and a prime integer <A>p</A>,
 ##  <Ref Oper="PossiblePowerMaps"/> returns the list of all maps that have
 ##  the following properties of the <M>p</M>-th power map of <A>tbl</A>.
@@ -865,7 +865,7 @@ DeclareAttributeSuppCT( "NamesOfFusionSources",
 ##
 ##  <Description>
 ##  For two ordinary character tables <A>subtbl</A> and <A>tbl</A> of the
-##  groups <M>H</M> and <M>G</M>, say,
+##  groups <M>H</M> and <M>G</M>,
 ##  <Ref Oper="PossibleClassFusions"/> returns the list of all maps that have
 ##  the following properties of class fusions from <A>subtbl</A> to
 ##  <A>tbl</A>.

--- a/lib/ctblmono.gd
+++ b/lib/ctblmono.gd
@@ -229,7 +229,7 @@ DeclareProperty( "IsBergerCondition", IsClassFunction );
 ##  <Func Name="TestHomogeneous" Arg='chi, N'/>
 ##
 ##  <Description>
-##  For a group character <A>chi</A> of the group <M>G</M>, say,
+##  For a group character <A>chi</A> of a group <M>G</M>
 ##  and a normal subgroup <A>N</A> of <M>G</M>,
 ##  <Ref Func="TestHomogeneous"/> returns a record with information whether
 ##  the restriction of <A>chi</A> to <A>N</A> is homogeneous,
@@ -380,7 +380,7 @@ DeclareProperty( "IsQuasiPrimitive", IsClassFunction );
 ##  <Description>
 ##  <Ref Func="TestInducedFromNormalSubgroup"/> returns a record with
 ##  information whether the irreducible character <A>chi</A> of the group
-##  <M>G</M>, say, is induced from a proper normal subgroup of <M>G</M>.
+##  <M>G</M> is induced from a proper normal subgroup of <M>G</M>.
 ##  If the second argument <A>N</A> is present,
 ##  which must be a normal subgroup of <M>G</M>
 ##  or the list of class positions of a normal subgroup of <M>G</M>,

--- a/lib/ctblpope.gd
+++ b/lib/ctblpope.gd
@@ -255,10 +255,10 @@ DeclareGlobalFunction( "PermCharInfo" );
 ##  <A>permchars</A>.
 ##  The degrees and distinguishing letters of the constituents refer to
 ##  the irreducibles of <A>tbl</A>, as follows.
-##  The two irreducible characters of <A>tbl2</A> of degree <M>N</M>, say,
+##  The two irreducible characters of <A>tbl2</A> of degree <M>N</M>
 ##  that extend the irreducible character <M>N</M> <C>a</C> of <A>tbl</A>
 ##  are denoted by <M>N</M> <C>a</C><M>^+</M> and <M>N </M><C>a</C><M>^-</M>.
-##  The irreducible character of <A>tbl2</A> of degree <M>2N</M>, say, whose
+##  The irreducible character of <A>tbl2</A> of degree <M>2N</M> whose
 ##  restriction to <A>tbl</A> is the sum of the irreducible characters
 ##  <M>N</M> <C>a</C> and <M>N</M> <C>b</C> is denoted as <M>N</M> <C>ab</C>.
 ##  Multiplicities larger than <M>1</M> of constituents are denoted by
@@ -314,7 +314,7 @@ DeclareGlobalFunction( "PermCharInfoRelative" );
 ##  possible permutation characters listed in
 ##  Section&nbsp;<Ref Sect="Possible Permutation Characters"/>,
 ##  The other two implement test of additional properties.
-##  Let <A>tbl</A> be the ordinary character table of a group <M>G</M>, say,
+##  Let <A>tbl</A> be the ordinary character table of a group <M>G</M>,
 ##  <A>char</A> a rational character of <A>tbl</A>,
 ##  and <A>chars</A> a list of rational characters of <A>tbl</A>.
 ##  For applying <Ref Func="TestPerm5"/>, the knowledge of a <M>p</M>-modular

--- a/lib/ctblsymm.gd
+++ b/lib/ctblsymm.gd
@@ -253,7 +253,7 @@ DeclareGlobalVariable( "CharTableWeylD",
 ##  <Func Name="CharacterValueWreathSymmetric" Arg='tbl, n, beta, pi'/>
 ##
 ##  <Description>
-##  Let <A>tbl</A> be the ordinary character table of a group <M>G</M>, say.
+##  Let <A>tbl</A> be the ordinary character table of a group <M>G</M>.
 ##  The aim of this function is to compute a single character value
 ##  from the character table of the wreath product of <M>G</M>
 ##  with the full symmetric group on <A>n</A> points.

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -549,7 +549,7 @@ end );
 ##  <P/>
 ##  <Ref Func="CrcFile"/> computes a checksum value for the file with
 ##  filename <A>filename</A> and returns this value as an integer.
-##  The function returns <K>fail</K> if a system error occurred, say,
+##  The function returns <K>fail</K> if a system error occurred,
 ##  for example, if <A>filename</A> does not exist.
 ##  In this case the function <Ref Func="LastSystemError"/>
 ##  can be used to get information about the error.

--- a/lib/ghom.gd
+++ b/lib/ghom.gd
@@ -463,7 +463,7 @@ DeclareOperation( "InnerAutomorphismNC",
 ##
 ##  <Description>
 ##  Let <A>hom</A> be a group general mapping
-##  (see&nbsp;<Ref Filt="IsGroupGeneralMapping"/>) with source <M>G</M>, say.
+##  (see&nbsp;<Ref Filt="IsGroupGeneralMapping"/>) with source <M>G</M>.
 ##  <Ref Prop="IsConjugatorIsomorphism"/> returns <K>true</K> if <A>hom</A>
 ##  is induced by conjugation of <M>G</M> by an element <M>g</M> that lies in
 ##  <M>G</M> or in a group into which <M>G</M> is naturally embedded

--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -271,7 +271,7 @@ end );
 #F  SizePolynomialUnipotentClassGL( <la> ) . . . . . . centralizer order of
 #F  unipotent elements in GL_n( q )
 ##  
-##  <la> must be a partition of, say, n.
+##  <la> must be a partition of the natural number n.
 ##  
 ##  This function returns a  pair [coefficient list, valuation] defining a
 ##  polynomial over the integers, having the following property: The order

--- a/lib/grpfree.gi
+++ b/lib/grpfree.gi
@@ -28,7 +28,7 @@
 ##  So the iterator for a free group of rank $n$ uses the following ordering.
 ##  Enumerate signless words (that is, forget about the signs of exponents)
 ##  as given by the enumerator of free monoids, and for each such word
-##  consisting of $k$, say, pairs of generators/exponents, enumerate all
+##  consisting of $k$ pairs of generators/exponents, enumerate all
 ##  $2^k$ possibilities of signs for the exponents.
 ##
 ##  The enumerator for a free group uses a different succession, in order to

--- a/lib/grpmat.gd
+++ b/lib/grpmat.gd
@@ -366,7 +366,7 @@ InstallTrueMethod( IsGroup, IsFullSubgroupGLorSLRespectingBilinearForm );
 ##  <Description>
 ##  This attribute describes a sesquilinear form that is invariant under the
 ##  matrix group <A>matgrp</A> over the field <M>F</M> with <M>q^2</M>
-##  elements, say.
+##  elements.
 ##  The form is given by a record with the component <C>matrix</C>
 ##  which is is a matrix <M>M</M> such that for every generator <M>g</M> of
 ##  <A>matgrp</A>
@@ -528,7 +528,7 @@ DeclareGlobalFunction( "AffineActionByMatrixGroup" );
 ##
 ##  <Description>
 ##  For a matrix group <A>matgrp</A> and a basis <A>B</A> of a field
-##  extension <M>L / K</M>, say, such that the entries of all matrices in
+##  extension <M>L / K</M> such that the entries of all matrices in
 ##  <A>matgrp</A> lie in <M>L</M>,
 ##  <Ref Func="BlowUpIsomorphism"/> returns the isomorphism with source
 ##  <A>matgrp</A> that is defined by mapping the matrix <M>A</M> to

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1084,7 +1084,7 @@ DeclareOperation( "ConstructingFilter", [IsMatrixObj] );
 # Implementation: given an n x m matrix <m>, create a new zero vector <v> of
 # length n (= NrRows) in a representation "compatible" with that of <m>, i.e.
 # there "should be" a fast action  <v>*<m>
-# FIXME: is this really useful? Compare to, say, `ExtractRow(mat,1)` etc. ???
+# FIXME: is this really useful? For example, compare to `ExtractRow(mat,1)` etc. ???
 DeclareOperation( "CompatibleVector", [IsMatrixObj] );
 
 DeclareOperation( "ChangedBaseDomain", [IsMatrixObj,IsSemiring] );

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1370,7 +1370,7 @@ DeclareGlobalFunction( "BaseSteinitzVectors" );
 ##  <P/>
 ##  More precisely,
 ##  regard <A>mat</A> as the matrix of a linear transformation on the row space
-##  <M>F^n</M> w.r.t.&nbsp;the <M>F</M>-basis with vectors <M>(v_1, ldots, v_n)</M>, say,
+##  <M>F^n</M> w.r.t.&nbsp;the <M>F</M>-basis with vectors <M>(v_1, ldots, v_n)</M>
 ##  and suppose that the basis <A>B</A> consists of the vectors
 ##  <M>(b_1,  \ldots, b_m)</M>;
 ##  then the returned matrix is the matrix of the linear transformation
@@ -1637,7 +1637,7 @@ DeclareGlobalFunction( "DiagonalMat" );
 ##  vector.
 ##  <P/>
 ##  More precisely, if <A>coeffs</A> is the coefficients list of a vector
-##  <M>v</M> w.r.t. a basis <M>B</M> (see&nbsp;<Ref Attr="Basis"/>), say,
+##  <M>v</M> w.r.t. a basis <M>B</M> (see&nbsp;<Ref Attr="Basis"/>)
 ##  then the returned matrix describes the
 ##  reflection in <M>v</M> w.r.t. <M>B</M> as a map on a row space,
 ##  with action from the right.
@@ -1763,7 +1763,7 @@ DeclareGlobalFunction( "RandomUnimodularMat" );
 ##  <C>GF(<A>q</A>^<A>r</A>)</C> for some <A>r</A> are powers of an element
 ##  <M>\xi</M> in the splitting field, which is of order <A>expo</A>.
 ##  <Ref Func="SimultaneousEigenvalues"/> returns a matrix of
-##  integers mod <A>expo</A>, say <M>(a_{{i,j}})</M>, such that the power
+##  integers mod <A>expo</A> <M>(a_{{i,j}})</M>, such that the power
 ##  <M>\xi^{{a_{{i,j}}}}</M> is an eigenvalue of the <A>i</A>-th matrix in
 ##  <A>matlist</A> and the eigenspaces of the different matrices to the
 ##  eigenvalues <M>\xi^{{a_{{i,j}}}}</M> for fixed <A>j</A> are equal.

--- a/lib/mgmfree.gi
+++ b/lib/mgmfree.gi
@@ -42,12 +42,12 @@ InstallMethod( IsWholeFamily,
 ##
 #M  Enumerator( <M> ) . . . . . . . . . . . . . . enumerator for a free magma
 ##
-##  Let <M> be a free magma on $N$ generators $x_1, x_2, \ldots, x_N$, say.
+##  Let <M> be a free magma on $N$ generators $x_1, x_2, \ldots, x_N$.
 ##  Each element in <M> is uniquely determined by an element in a free
 ##  semigroup $S$ over $s_1, s_2, \ldots, s_N$ (which is obtained by mapping
 ##  $x_i$ to $s_i$) plus the ``bracketing of the element.
 ##  Thus we can describe each element $x$ in <M> by a quadruple $[N,l,p,q]$
-##  where $l$ is the length of the corresponding associative word $s$, say,
+##  where $l$ is the length of the corresponding associative word $s$,
 ##  $p$ is the position of $s$ among the associative words of length $l$ in
 ##  $S$ (so $0 \leq p < N^l$),
 ##  and $q$ is the position of the bracketing of $x$

--- a/lib/morpheus.gd
+++ b/lib/morpheus.gd
@@ -59,7 +59,7 @@ DeclareAttribute("AutomorphismGroup",IsDomain);
 ##
 ##  <Description>
 ##  indicates whether <A>G</A> consists of automorphisms of another group
-##  <M>H</M>, say.
+##  <M>H</M>.
 ##  The group <M>H</M> can be obtained from <A>G</A> via the attribute
 ##  <Ref Attr="AutomorphismDomain"/>.
 ##  </Description>

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -496,7 +496,7 @@ DeclareGlobalFunction( "LogPackageLoadingMessage" );
 ##  <Func Name="IsPackageMarkedForLoading" Arg='name, version'/>
 ##
 ##  <Description>
-##  This function can be used in the code of a package <M>A</M>, say,
+##  This function can be used in the code of a package <M>A</M>
 ##  for testing whether the package <A>name</A> in version <A>version</A>
 ##  will be loaded after the <Ref Func="LoadPackage"/> call for the package
 ##  <M>A</M> has been executed.
@@ -539,7 +539,7 @@ DeclareGlobalFunction( "DefaultPackageBannerString" );
 ##  <Description>
 ##  <Index Key="GAPInfo.Architecture"><C>GAPInfo.Architecture</C></Index>
 ##  returns a list that is either empty or contains one directory object
-##  <C>dir</C>, say, that describes the place where external binaries of the
+##  <C>dir</C> that describes the place where external binaries of the
 ##  &GAP; package <A>name</A> should be located.
 ##  <P/>
 ##  In the latter case,
@@ -582,7 +582,7 @@ DeclareGlobalFunction( "DirectoriesPackagePrograms" );
 ##  <Description>
 ##  takes the string <A>name</A>, a name of a &GAP; package,
 ##  and returns a list that is either empty or contains one directory object
-##  <C>dir</C>, say, that describes the place where the library functions of
+##  <C>dir</C> that describes the place where the library functions of
 ##  this &GAP; package should be located.
 ##  <P/>
 ##  In the latter case,

--- a/lib/ring.gd
+++ b/lib/ring.gd
@@ -891,7 +891,7 @@ DeclareOperation( "IsUnit", [ IsRing, IsRingElement ] );
 ##
 ##  <Description>
 ##  <Ref Oper="InterpolatedPolynomial"/> returns, for given lists <A>x</A>,
-##  <A>y</A> of elements in a ring <A>R</A> of the same length <M>n</M>, say,
+##  <A>y</A> of elements in a ring <A>R</A> of the same length <M>n</M>
 ##  the unique  polynomial of  degree less than <M>n</M> which has value
 ##  <A>y</A>[<M>i</M>] at <A>x</A><M>[i]</M>,
 ##  for all <M>i \in \{ 1, \ldots, n \}</M>. 

--- a/lib/ringpoly.gd
+++ b/lib/ringpoly.gd
@@ -208,7 +208,7 @@ DeclareAttribute( "CoefficientsRing", IsPolynomialRing );
 ##  specially to always denote the variable with internal number <A>nr</A>.)
 ##  <P/>
 ##  The indeterminate names have not necessarily any relations to variable
-##  names: this means that an indeterminate whose name is, say,  <Q><C>x</C></Q>
+##  names: this means that an indeterminate whose name is <Q><C>x</C></Q>
 ##  cannot be accessed using the variable <C>x</C>, unless <C>x</C> was defined to
 ##  be that indeterminate.
 ##  <#/GAPDoc>

--- a/lib/ringsc.gi
+++ b/lib/ringsc.gi
@@ -329,7 +329,7 @@ end );
 #F  RingByStructureConstants( <moduli>, <sctable>, <name1>, <name2>, ... )
 ##
 ##  is an Z-module $M$ defined by the structure constants
-##  table <sctable> of length $n$, say.
+##  table <sctable> of length $n$.
 ##
 ##  The generators of $M$ are linearly independent abstract space generators
 ##  $x_1, x_2, \ldots, x_n$ whose additive orders is given by the list

--- a/lib/sgpres.gd
+++ b/lib/sgpres.gd
@@ -450,7 +450,7 @@ DeclareGlobalFunction("PresentationAugmentedCosetTable");
 ##
 ##  <Description>
 ##  uses the Reduced Reidemeister-Schreier method to compute a presentation
-##  <M>P</M>, say, for the normal closure of a subgroup <A>H</A> of a
+##  <M>P</M> for the normal closure of a subgroup <A>H</A> of a
 ##  finitely presented group <A>G</A>.
 ##  The generators in the resulting presentation will be named
 ##  <A>string</A><C>1</C>, <A>string</A><C>2</C>, <M>\ldots</M>,
@@ -492,7 +492,7 @@ PresentationNormalClosure := PresentationNormalClosureRrs;
 ##
 ##  <Description>
 ##  uses the Modified Todd-Coxeter coset representative enumeration method
-##  to compute a presentation <M>P</M>, say, for a subgroup <A>H</A> of a
+##  to compute a presentation <M>P</M> for a subgroup <A>H</A> of a
 ##  finitely presented group <A>G</A>.
 ##  The presentation returned is in generators corresponding to the
 ##  generators of <A>H</A>. The generators in the resulting
@@ -623,7 +623,7 @@ DeclareGlobalFunction("PresentationSubgroupMtc");
 ##
 ##  <Description>
 ##  uses the  Reduced Reidemeister-Schreier method to compute a presentation
-##  <A>P</A>, say, for a subgroup <A>H</A> of a finitely presented group
+##  <A>P</A> for a subgroup <A>H</A> of a finitely presented group
 ##  <A>G</A>.
 ##  The generators in the resulting presentation will be named
 ##  <A>string</A><C>1</C>, <A>string</A><C>2</C>, <M>\ldots</M>,

--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -1127,7 +1127,7 @@ end );
 ##
 ##  'PresentationNormalClosureRrs'  uses  the  Reduced  Reidemeister-Schreier
 ##  method  to compute a  presentation  (i.e. a presentation record)  for the
-##  normal closure  N, say,  of a subgroup H of a finitely presented group G.
+##  normal closure  N of a subgroup H of a finitely presented group G.
 ##  The  generators in the  resulting presentation  will be named  <string>1,
 ##  <string>2, ... , the default string is `\"_x\"'.
 ##

--- a/lib/straight.gd
+++ b/lib/straight.gd
@@ -444,8 +444,8 @@ DeclareGlobalFunction( "CompositionOfStraightLinePrograms" );
 ##
 ##  <Description>
 ##  For a nonempty dense list <A>listofprogs</A> of straight line programs
-##  <M>p_1, p_2, \ldots, p_m</M>, say,
-##  that have the same number <M>n</M>, say, of inputs
+##  <M>p_1, p_2, \ldots, p_m</M>
+##  that have the same number <M>n</M> of inputs
 ##  (see&nbsp;<Ref Attr="NrInputsOfStraightLineProgram"/>),
 ##  <Ref Func="IntegratedStraightLineProgram"/> returns a straight line
 ##  program <M>prog</M> with <M>n</M> inputs such that for each

--- a/lib/tietze.gd
+++ b/lib/tietze.gd
@@ -231,7 +231,7 @@ DeclareGlobalFunction("AddRelator");
 ##  redundant list of generators of <A>H</A> which consists of an (in general
 ##  small) list of <Q>primary</Q> generators, followed by an (in general
 ##  large) list of <Q>secondary</Q> generators, and then construct a
-##  presentation <M>P_0</M>, say,
+##  presentation <M>P_0</M>
 ##  <E>on a sublist of these generators</E> by rewriting
 ##  the defining relators of <A>G</A>.
 ##  This sublist contains all primary, but, at least in general,
@@ -273,7 +273,7 @@ DeclareGlobalFunction("AddRelator");
 ##  Starting from <M>P = P_0</M>, it runs through a number of steps in each
 ##  of which it eliminates the current <Q>last</Q> generator (with respect to
 ##  the list of all primary and secondary generators). If the last generator
-##  <A>g</A>, say, is a primary generator, then the procedure terminates.
+##  <A>g</A> is a primary generator, then the procedure terminates.
 ##  Otherwise it checks whether there is a relator in the current
 ##  presentation which can be used to substitute <A>g</A> by a Tietze
 ##  transformation. If so, this is done.
@@ -1745,7 +1745,7 @@ DeclareGlobalFunction("TzRemoveGenerators");
 ##  <M>l_1</M> and <M>l_2</M>, respectively,
 ##  such that <M>l_1 \leq l_2</M> and <M>r_1</M> and <M>r_2</M>
 ##  coincide (possibly after inverting or conjugating one of them) in some
-##  maximal subword <M>w</M>, say, of length greater than <M>l_1/2</M>,
+##  maximal subword <M>w</M> of length greater than <M>l_1/2</M>,
 ##  and then to substitute each copy of <M>w</M> in <M>r_2</M> by the inverse
 ##  complement of <M>w</M> in <M>r_1</M>.
 ##  <P/>
@@ -1778,7 +1778,7 @@ DeclareGlobalFunction("TzRemoveGenerators");
 ##  <P/>
 ##  As this subroutine performs a very expensive process, it has been
 ##  implemented as a C routine in the &GAP; kernel. For the given relator
-##  <M>r_1</M> of length <M>l_1</M>, say, it first determines the
+##  <M>r_1</M> of length <M>l_1</M> it first determines the
 ##  <E>minimal match length</E> <M>l</M> which is <M>l_1/2+1</M>,
 ##  if <M>l_1</M> is even, or <M>(l_1+1)/2</M>, otherwise.
 ##  Then it builds up a hash list for all subwords of length <M>l</M>
@@ -1826,7 +1826,7 @@ DeclareGlobalFunction("TzSearch");
 ##  <M>l_1</M> and <M>l_2</M>, respectively, such that <M>l_1</M> is even,
 ##  <M>l_1 \leq l_2</M>, and <M>r_1</M> and <M>r_2</M> coincide (possibly 
 ##  after inverting or conjugating one of them) in some maximal subword
-##  <M>w</M>, say, of length at least <M>l_1/2</M>.
+##  <M>w</M> of length at least <M>l_1/2</M>.
 ##  Let <M>l</M> be the length of <M>w</M>. Then, if <M>l > l_1/2</M>,
 ##  the pair is handled as in <Ref Func="TzSearch"/>.
 ##  Otherwise, if <M>l = l_1/2</M>, then <Ref Func="TzSearchEqual"/>
@@ -2136,7 +2136,7 @@ DeclareGlobalFunction("TzSubstitute");
 ##  <Func Name="TzSubstituteCyclicJoins" Arg='P'/>
 ##
 ##  <Description>
-##  tries to find pairs of commuting generators <M>a</M> and <M>b</M>, say,
+##  tries to find pairs of commuting generators <M>a</M> and <M>b</M>
 ##  such that the exponent of <M>a</M> (i. e. the least currently known
 ##  positive integer <M>n</M> such that <M>a^n</M> is a relator in <A>P</A>)
 ##  is prime to the exponent of <M>b</M>.

--- a/lib/tietze.gi
+++ b/lib/tietze.gi
@@ -36,7 +36,7 @@ end;
 ##
 ##  Let i be the smallest positive integer which has not yet been used as
 ##  a generator number and for which no component T!.i exists so far in the
-##  given presentation T, say. `AddGenerator' defines a new abstract
+##  given presentation T. `AddGenerator' defines a new abstract
 ##  generator _xi and adds it, as component T!.i, to the given presentation.
 ##
 InstallGlobalFunction( AddGenerator, function ( T )
@@ -3717,7 +3717,7 @@ InstallGlobalFunction( TzSubstitute, function ( arg )
         return;
     fi;
 
-    # get the nth pair [ a, b ], say, from the list.
+    # get the nth pair, say [ a, b ], from the list.
     i := pairs[n][2];
     j := pairs[n][3];
     k := pairs[n][4];
@@ -3766,7 +3766,7 @@ end );
 #M  TzSubstituteCyclicJoins( <Tietze record> ) . . common roots of generators
 ##
 ##  `TzSubstituteCyclicJoins'  tries to find pairs of  commuting generators a
-##  and b, say, such that exponent(a) is prime to exponent(b).  For each such
+##  and b such that exponent(a) is prime to exponent(b).  For each such
 ##  pair, their product a * b is substituted as a new generator,  and a and b
 ##  are eliminated.
 ##
@@ -3819,7 +3819,7 @@ InstallGlobalFunction( TzSubstituteCyclicJoins, function ( T )
 
             # If there are relators a^m and b^n with m prime to n, then
             # a = (a*b)^n,  b = (a*b)^m,  and  (a*b)^(m*n) = 1.  Hence we
-            # may define a new generator g, say, by a*b together with the
+            # may define a new generator g by a*b together with the
             # two relations  a = g^n  and  b = g^m,  and then eliminate a
             # and b.  (Note that we can take a^-1 instead of a or b^-1
             # instead of b.)

--- a/lib/tom.gd
+++ b/lib/tom.gd
@@ -1405,7 +1405,7 @@ DeclareAttribute( "DerivedSubgroupsTomUnique", IsTableOfMarks );
 ##  <Attr Name="NormalizersTom" Arg='tom'/>
 ##
 ##  <Description>
-##  Let <A>tom</A> be the table of marks of a group <M>G</M>, say.
+##  Let <A>tom</A> be the table of marks of a group <M>G</M>.
 ##  <Ref Oper="NormalizerTom"/> tries to find the conjugacy class of the
 ##  normalizer <M>N</M> in <M>G</M> of a subgroup <M>U</M> in the
 ##  <A>sub</A>-th class of <A>tom</A>.
@@ -1577,7 +1577,7 @@ DeclareOperation( "CyclicExtensionsTomOp", [ IsTableOfMarks, IsList ] );
 ##  <Oper Name="DecomposedFixedPointVector" Arg='tom, fix'/>
 ##
 ##  <Description>
-##  Let <A>tom</A> be the table of marks of the group <M>G</M>, say,
+##  Let <A>tom</A> be the table of marks of a group <M>G</M>
 ##  and let <A>fix</A> be a vector of fixed point numbers w.r.t.&nbsp;an
 ##  action of <M>G</M>, i.e., a vector which contains for each class of
 ##  subgroups the number of fixed points under the given action.
@@ -1689,7 +1689,7 @@ DeclareOperation( "IntersectionsTom",
 ##  <Oper Name="FactorGroupTom" Arg='tom, n'/>
 ##
 ##  <Description>
-##  For a table of marks <A>tom</A> of the group <M>G</M>, say,
+##  For a table of marks <A>tom</A> of a group <M>G</M>
 ##  and the normal subgroup <M>N</M> of <M>G</M> corresponding to the
 ##  <A>n</A>-th class of subgroups of <A>tom</A>,
 ##  <Ref Oper="FactorGroupTom"/> returns the table of marks of the factor

--- a/lib/upoly.gd
+++ b/lib/upoly.gd
@@ -166,7 +166,7 @@ DeclareGlobalFunction( "CyclotomicPolynomial" );
 ##  <Description>
 ##  For a univariate polynomial <A>pol</A> of degree <M>d</M> in the
 ##  indeterminate <M>X</M>,
-##  with coefficients in a finite field <A>F</A> with <M>q</M> elements, say,
+##  with coefficients in a finite field <A>F</A> with <M>q</M> elements,
 ##  <Ref Oper="IsPrimitivePolynomial"/> returns <K>true</K> if
 ##  <Enum>
 ##  <Item>

--- a/lib/vspc.gd
+++ b/lib/vspc.gd
@@ -98,7 +98,7 @@ InstallTrueMethod( IsFreeLeftModule,
 ##  The filter <Ref Filt="IsGaussianSpace"/> (see&nbsp;<Ref Sect="Filters"/>)
 ##  for the row space (see&nbsp;<Ref Filt="IsRowSpace"/>)
 ##  or matrix space (see&nbsp;<Ref Filt="IsMatrixSpace"/>) <A>V</A>
-##  over the field <M>F</M>, say,
+##  over a field <M>F</M>
 ##  indicates that the entries of all row vectors or matrices in <A>V</A>,
 ##  respectively, are all contained in <M>F</M>.
 ##  In this case, <A>V</A> is called a <E>Gaussian</E> vector space.

--- a/lib/vspchom.gd
+++ b/lib/vspchom.gd
@@ -44,7 +44,7 @@
 ##
 ##  <Description>
 ##  Let <A>V</A> and <A>W</A> be two left modules over the same left acting
-##  domain <M>R</M>, say, and <A>gens</A> and <A>imgs</A> lists
+##  domain <M>R</M> and <A>gens</A> and <A>imgs</A> lists
 ##  (of the same length) of elements in <A>V</A> and <A>W</A>, respectively.
 ##  <Ref Oper="LeftModuleGeneralMappingByImages"/> returns
 ##  the general mapping with source <A>V</A> and range <A>W</A>
@@ -85,7 +85,7 @@ DeclareOperation( "LeftModuleGeneralMappingByImages",
 ##
 ##  <Description>
 ##  Let <A>V</A> and <A>W</A> be two left modules over the same left acting
-##  domain <M>R</M>, say, and <A>gens</A> and <A>imgs</A> lists (of the same
+##  domain <M>R</M> and <A>gens</A> and <A>imgs</A> lists (of the same
 ##  length) of elements in <A>V</A> and <A>W</A>, respectively.
 ##  <Ref Func="LeftModuleHomomorphismByImages"/> returns
 ##  the left <M>R</M>-module homomorphism with source <A>V</A> and range

--- a/lib/wordass.gd
+++ b/lib/wordass.gd
@@ -1055,7 +1055,7 @@ DeclareGlobalFunction( "StoreInfoFreeMagma" );
 ##  If the only argument is a string <A>string</A> then
 ##  <Ref Func="InfiniteListOfNames"/> returns an infinite list with the
 ##  string <A>string</A><M>i</M> at position <M>i</M>.
-##  If a finite list <A>initnames</A> of length <M>n</M>, say,
+##  If a finite list <A>initnames</A> of length <M>n</M>
 ##  is given as second argument,
 ##  the <M>i</M>-th entry of the returned infinite list is equal to
 ##  <A>initnames</A><C>[</C><M>i</M><C>]</C> if <M>i \leq n</M>,
@@ -1078,7 +1078,7 @@ DeclareGlobalFunction( "InfiniteListOfNames" );
 ##  <Ref Func="InfiniteListOfGenerators"/> returns an infinite list
 ##  containing at position <M>i</M> the element in <A>Fam</A>
 ##  obtained as <C>ObjByExtRep( <A>Fam</A>, [ </C><M>i</M><C>, 1 ] )</C>.
-##  If a finite list <A>init</A> of length <M>n</M>, say,
+##  If a finite list <A>init</A> of length <M>n</M>
 ##  is given as second argument, the <M>i</M>-th entry of the returned
 ##  infinite list is equal to
 ##  <A>init</A><C>[</C><M>i</M><C>]</C> if <M>i \leq n</M>,


### PR DESCRIPTION
This PR originated from discussions in #3780 .
It aims at replacing formulations containing `, say` as an implicit way of defining variables in explanations. 