### PR TITLE
kernel: misc changes

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -409,8 +409,6 @@ int realmain( int argc, char * argv[] )
   Obj                 func;                   /* function (compiler)     */
   Int4                crc;                    /* crc of file to compile  */
 
-  SetupGAPLocation(argc, argv);
-
   /* initialize everything and read init.g which runs the GAP session */
   InitializeGap( &argc, argv, 1 );
   if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -38,6 +38,24 @@
         "must be a macfloat")
 
 
+Double VAL_MACFLOAT(Obj obj)
+{
+    Double val;
+    memcpy(&val, CONST_ADDR_OBJ(obj), sizeof(Double));
+    return val;
+}
+
+void SET_VAL_MACFLOAT(Obj obj, Double val)
+{
+    memcpy(ADDR_OBJ(obj), &val, sizeof(Double));
+}
+
+ Int IS_MACFLOAT(Obj obj)
+{
+    return TNUM_OBJ(obj) == T_MACFLOAT;
+}
+
+
 /****************************************************************************
 **
 *F  TypeMacfloat( <macfloat> )  . . . . . . . . . .  type of a macfloat value

--- a/src/macfloat.h
+++ b/src/macfloat.h
@@ -29,23 +29,9 @@ typedef double Double;
 #define MATH(name) name
 #endif
 
-EXPORT_INLINE Double VAL_MACFLOAT(Obj obj)
-{
-    Double val;
-    memcpy(&val, CONST_ADDR_OBJ(obj), sizeof(Double));
-    return val;
-}
-
-EXPORT_INLINE void SET_VAL_MACFLOAT(Obj obj, Double val)
-{
-    memcpy(ADDR_OBJ(obj), &val, sizeof(Double));
-}
-
-EXPORT_INLINE  Int IS_MACFLOAT(Obj obj)
-{
-    return TNUM_OBJ(obj) == T_MACFLOAT;
-}
-
+Double VAL_MACFLOAT(Obj obj);
+void SET_VAL_MACFLOAT(Obj obj, Double val);
+Int IS_MACFLOAT(Obj obj);
 Obj NEW_MACFLOAT(Double val);
 
 

--- a/src/read.c
+++ b/src/read.c
@@ -627,13 +627,11 @@ static LHSRef ReadVar(ScannerState * s, TypSymbolSet follow)
     // try to look up the variable on the stack of local variables
     const UInt countNams = LEN_PLIST(ReaderState()->StackNams);
     for (nest = 0; nest < countNams; nest++) {
-#ifndef SYS_IS_64_BIT
         if (nest >= MAX_FUNC_EXPR_NESTING) {
             Pr("Warning: abandoning search for %s at %dth higher frame\n",
                (Int)s->Value, MAX_FUNC_EXPR_NESTING);
             break;
         }
-#endif
         nams = ELM_PLIST(ReaderState()->StackNams, countNams - nest);
         indx = findValueInNams(nams, s->Value, 1, LEN_PLIST(nams));
         if (indx != 0) {
@@ -664,14 +662,12 @@ static LHSRef ReadVar(ScannerState * s, TypSymbolSet follow)
             }
             lvars = ENVI_FUNC(FUNC_LVARS(lvars));
             nest++;
-#ifndef SYS_IS_64_BIT
             if (nest >= MAX_FUNC_EXPR_NESTING) {
                 Pr("Warning: abandoning search for %s at %dth higher "
                    "frame\n",
                    (Int)s->Value, MAX_FUNC_EXPR_NESTING);
                 break;
             }
-#endif
         }
         lvars0 = PARENT_LVARS(lvars0);
         nest0++;

--- a/src/read.c
+++ b/src/read.c
@@ -1319,7 +1319,7 @@ static UInt ReadLocals(ScannerState * s, TypSymbolSet follow, Obj nams)
             }
             nloc += 1;
             PushPlist(nams, MakeImmString(s->Value));
-            if (LEN_PLIST(nams) >= 65536) {
+            if (LEN_PLIST(nams) >= MAX_FUNC_LVARS) {
                 SyntaxError(s, "Too many function arguments and locals");
             }
         }

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -58,20 +58,6 @@ Int4 SyGAPCRC(const Char * name);
 
 /****************************************************************************
 **
-*F * * * * * * * * * * finding location of executable * * * * * * * * * * * *
-*/
-
-// 'GAPExecLocation' is the path to the directory containing the running GAP
-// executable, terminated by a slash, or contains the empty string is it could
-// not be detect.
-extern char GAPExecLocation[GAP_PATH_MAX];
-
-// Fills in GAPExecLocation. Is called straight after 'main' starts.
-void SetupGAPLocation(int argc, char ** argv);
-
-
-/****************************************************************************
-**
 
 *F * * * * * * * * * * * * * * * window handler * * * * * * * * * * * * * * *
 */

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -529,12 +529,17 @@ Obj SyReadStringFile(Int fid);
 Obj SyReadStringFileGeneric(Int fid);
 
 
-#if !defined(SYS_IS_64_BIT) && defined(__GNU_LIBRARY__)
-#define USE_CUSTOM_MEMMOVE 1
+// A bug in memmove() provided by glibc 2.21 to 2.27 on 32bit systems can lead
+// to data corruption. We use our own memmove on affected systems. For details,
+// see <https://sourceware.org/bugzilla/show_bug.cgi?id=22644> and also
+// <https://www.cvedetails.com/cve/CVE-2017-18269/>.
+#if !defined(SYS_IS_64_BIT) && defined(__GLIBC__)
+  #if __GLIBC_PREREQ(2,21) && !__GLIBC_PREREQ(2,28)
+  #define USE_CUSTOM_MEMMOVE 1
+  #endif
 #endif
 
 #ifdef USE_CUSTOM_MEMMOVE
-// Internal implementation of memmove, to avoid issues with glibc
 void * SyMemmove(void * dst, const void * src, size_t size);
 #else
 #define SyMemmove memmove

--- a/src/system.c
+++ b/src/system.c
@@ -41,6 +41,9 @@
 
 #include <sys/stat.h>
 
+#ifdef SYS_IS_DARWIN
+#include <mach-o/dyld.h>
+#endif
 
 #ifdef HAVE_LIBREADLINE
 #include <readline/readline.h>
@@ -317,6 +320,114 @@ void Panic_(const char * file, int line, const char * fmt, ...)
     fputs("\n", stderr);
     SyExit(1);
 }
+
+
+/****************************************************************************
+**
+*F * * * * * * * * * * finding location of executable * * * * * * * * * * * *
+*/
+
+/****************************************************************************
+** The function 'find_yourself' is based on code (C) 2015 Mark Whitis, under
+** the MIT License : https://stackoverflow.com/a/34271901/928031
+*/
+
+static void
+find_yourself(const char * argv0, char * result, size_t resultsize)
+{
+    GAP_ASSERT(resultsize >= GAP_PATH_MAX);
+
+    char tmpbuf[GAP_PATH_MAX];
+
+    // absolute path, like '/usr/bin/gap'
+    if (argv0[0] == '/') {
+        if (realpath(argv0, result) && !access(result, F_OK)) {
+            return;    // success
+        }
+    }
+    // relative path, like 'bin/gap.sh'
+    else if (strchr(argv0, '/')) {
+        if (!getcwd(tmpbuf, sizeof(tmpbuf)))
+            return;
+        strlcat(tmpbuf, "/", sizeof(tmpbuf));
+        strlcat(tmpbuf, argv0, sizeof(tmpbuf));
+        if (realpath(tmpbuf, result) && !access(result, F_OK)) {
+            return;    // success
+        }
+    }
+    // executable name, like 'gap'
+    else {
+        char pathenv[GAP_PATH_MAX], *saveptr, *pathitem;
+        strlcpy(pathenv, getenv("PATH"), sizeof(pathenv));
+        pathitem = strtok_r(pathenv, ":", &saveptr);
+        for (; pathitem; pathitem = strtok_r(NULL, ":", &saveptr)) {
+            strlcpy(tmpbuf, pathitem, sizeof(tmpbuf));
+            strlcat(tmpbuf, "/", sizeof(tmpbuf));
+            strlcat(tmpbuf, argv0, sizeof(tmpbuf));
+            if (realpath(tmpbuf, result) && !access(result, F_OK)) {
+                return;    // success
+            }
+        }
+    }
+
+    *result = 0;    // reset buffer after error
+}
+
+
+static char GAPExecLocation[GAP_PATH_MAX] = "";
+
+static void SetupGAPLocation(const char * argv0)
+{
+    // In the code below, we keep reseting locBuf, as some of the methods we
+    // try do not promise to leave the buffer empty on a failed return.
+    char locBuf[GAP_PATH_MAX] = "";
+    Int4 length = 0;
+
+#ifdef SYS_IS_DARWIN
+    uint32_t len = sizeof(locBuf);
+    if (_NSGetExecutablePath(locBuf, &len) != 0) {
+        *locBuf = 0;    // reset buffer after error
+    }
+#endif
+
+    // try Linux procfs
+    if (!*locBuf) {
+        ssize_t ret = readlink("/proc/self/exe", locBuf, sizeof(locBuf));
+        if (ret < 0)
+            *locBuf = 0;    // reset buffer after error
+    }
+
+    // try FreeBSD / DragonFly BSD procfs
+    if (!*locBuf) {
+        ssize_t ret = readlink("/proc/curproc/file", locBuf, sizeof(locBuf));
+        if (ret < 0)
+            *locBuf = 0;    // reset buffer after error
+    }
+
+    // try NetBSD procfs
+    if (!*locBuf) {
+        ssize_t ret = readlink("/proc/curproc/exe", locBuf, sizeof(locBuf));
+        if (ret < 0)
+            *locBuf = 0;    // reset buffer after error
+    }
+
+    // if we are still failing, go and search the path
+    if (!*locBuf) {
+        find_yourself(argv0, locBuf, GAP_PATH_MAX);
+    }
+
+    // resolve symlinks (if present)
+    if (!realpath(locBuf, GAPExecLocation))
+        *GAPExecLocation = 0;    // reset buffer after error
+
+    // now strip the executable name off
+    length = strlen(GAPExecLocation);
+    while (length > 0 && GAPExecLocation[length] != '/') {
+        GAPExecLocation[length] = 0;
+        length--;
+    }
+}
+
 
 /****************************************************************************
 **
@@ -749,6 +860,7 @@ void InitSystem (
 #if defined(SYS_DEFAULT_PATHS)
     SySetGapRootPath( SYS_DEFAULT_PATHS );
 #else
+    SetupGAPLocation(argv[0]);
     SySetInitialGapRootPaths();
 #endif
 


### PR DESCRIPTION
These are all minor tweaks.

<strike>
The 1UL -> (UInt)1 changes are done because on some 64bit systems, "unsigned long" is actually just 32bit, so something like `1UL << 44` won't work right (it'll be zero) while `(UInt)1 << 44` will work.

I am not super happy about the name `ALL_BITS_UINT`, better suggestions welcome.

Lastly, as always I am happy to split this PR if it helps, though it should be possible to review it commit-by-commit.</strike>

I moved parts of this PR to #3812 and #3813