### PR TITLE
kernel: move ScannerState out of GAPState

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -17,7 +17,6 @@
 
 #include "system.h"
 
-#include "scanner.h"
 #include "sysjmp.h"
 
 #if defined(HPCGAP)
@@ -58,11 +57,6 @@ typedef struct GAPState {
     syJmp_buf ReadJmpError;
 
     /* From scanner.c */
-    // TODO: eventually, ScannerState should be removed from GAPState
-    // (and then also #include "scanner.h" at the top), and instead code
-    // using a caller should dynamically allocate a ScannerState on the stack.
-    // But for now, we can't really do that.
-    ScannerState Scanner;
     UInt   NrError;
     UInt   NrErrLine;
 

--- a/src/io.c
+++ b/src/io.c
@@ -91,9 +91,6 @@ typedef struct {
     // character
     Char * ptr;
 
-    //
-    UInt symbol;
-
     // the number of the line where the fragment of code currently being
     // interpreted started; used for profiling
     Int interpreterStartLine;
@@ -472,10 +469,6 @@ static UInt OpenDefaultOutput(void)
 **  may  also fail if  you have too  many files open at once.   It  is system
 **  dependent how many are  too many, but  16  files should  work everywhere.
 **
-**  Directely after the 'OpenInput' call the variable  'Symbol' has the value
-**  'S_ILLEGAL' to indicate that no symbol has yet been  read from this file.
-**  The first symbol is read by 'Read' in the first call to 'Match' call.
-**
 **  You can open  '*stdin*' to  read  from the standard  input file, which is
 **  usually the terminal, or '*errin*' to  read from the standard error file,
 **  which  is  the  terminal  even if '*stdin*'  is  redirected from  a file.
@@ -515,7 +508,6 @@ UInt OpenInput (
     if (IO()->InputStackPointer > 0) {
         GAP_ASSERT(IS_CHAR_PUSHBACK_EMPTY());
         IO()->Input->ptr = STATE(In);
-        IO()->Input->symbol = STATE(Scanner).Symbol;
         IO()->Input->interpreterStartLine = STATE(InterpreterStartLine);
     }
 
@@ -534,10 +526,9 @@ UInt OpenInput (
     strlcpy(IO()->Input->name, filename, sizeof(IO()->Input->name));
     IO()->Input->gapnameid = 0;
 
-    /* start with an empty line and no symbol                              */
+    // start with an empty line
     STATE(In) = IO()->Input->line;
     STATE(In)[0] = STATE(In)[1] = '\0';
-    STATE(Scanner).Symbol = S_ILLEGAL;
     STATE(InterpreterStartLine) = 0;
     IO()->Input->number = 1;
 
@@ -562,7 +553,6 @@ UInt OpenInputStream(Obj stream, UInt echo)
     if (IO()->InputStackPointer > 0) {
         GAP_ASSERT(IS_CHAR_PUSHBACK_EMPTY());
         IO()->Input->ptr = STATE(In);
-        IO()->Input->symbol = STATE(Scanner).Symbol;
         IO()->Input->interpreterStartLine = STATE(InterpreterStartLine);
     }
 
@@ -584,10 +574,9 @@ UInt OpenInputStream(Obj stream, UInt echo)
     strlcpy(IO()->Input->name, "stream", sizeof(IO()->Input->name));
     IO()->Input->gapnameid = 0;
 
-    /* start with an empty line and no symbol                              */
+    // start with an empty line
     STATE(In) = IO()->Input->line;
     STATE(In)[0] = STATE(In)[1] = '\0';
-    STATE(Scanner).Symbol = S_ILLEGAL;
     STATE(InterpreterStartLine) = 0;
     IO()->Input->number = 1;
 
@@ -643,7 +632,6 @@ UInt CloseInput ( void )
 #endif
     IO()->Input = IO()->InputStack[sp - 1];
     STATE(In) = IO()->Input->ptr;
-    STATE(Scanner).Symbol = IO()->Input->symbol;
     STATE(InterpreterStartLine) = IO()->Input->interpreterStartLine;
 
     /* indicate success                                                    */
@@ -658,8 +646,6 @@ UInt CloseInput ( void )
 void FlushRestOfInputLine( void )
 {
   STATE(In)[0] = STATE(In)[1] = '\0';
-  /* IO()->Input->number = 1; */
-  STATE(Scanner).Symbol = S_ILLEGAL;
 }
 
 /****************************************************************************

--- a/src/read.c
+++ b/src/read.c
@@ -2529,7 +2529,10 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
 #endif
 
     struct ReaderState * volatile rs = ReaderState();
-    ScannerState * volatile       s = &STATE(Scanner);
+
+    ScannerState scanner;
+    ScannerState * volatile s = &scanner;
+    memset(s, 0, sizeof(ScannerState));
 
     /* get the first symbol from the input                                 */
     Match(s, s->Symbol, "", 0UL);
@@ -2660,7 +2663,10 @@ UInt ReadEvalFile(Obj *evalResult)
 #endif
 
     struct ReaderState * volatile rs = ReaderState();
-    ScannerState * volatile       s = &STATE(Scanner);
+
+    ScannerState scanner;
+    ScannerState * volatile s = &scanner;
+    memset(s, 0, sizeof(ScannerState));
 
     /* get the first symbol from the input                                 */
     Match(s, s->Symbol, "", 0UL);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1123,8 +1123,6 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
     InitHdlrFuncsFromTable( GVarFuncs );
-
-    InitGlobalBag(&STATE(Scanner).ValueObj, "ValueObj");
     return 0;
 }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -82,7 +82,7 @@ static void SyntaxErrorOrWarning(ScannerState * s,
             pos = GetInputLinePosition();
         }
 
-        if (startPos <= pos) {
+        if (0 <= pos && startPos <= pos) {
             Int i;
             for (i = 0; i <= startPos; i++) {
                 if (line[i] == '\t')

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -195,11 +195,6 @@ typedef UInt            TypSymbolSet;
 *T  ScannerState
 **
 **  The struct 'ScannerState' encapsulates the state of the scanner.
-**
-**  In the future, it is planned to allow use of multiple instances of the
-**  scanner simultaneously within a single thread. However, this is not yet
-**  ready, and currently only once instance of 'ScannerState' is used, which
-**  is stored inside the global instance of struct 'GAPState'.
 */
 typedef struct {
 

--- a/tst/testbugfix/2013-08-21-t00295.tst
+++ b/tst/testbugfix/2013-08-21-t00295.tst
@@ -5,4 +5,3 @@ int in stream:1
 . . . .
 ^
 Syntax error: Record component name expected in stream:2
-

--- a/tst/testinstall/help.tst
+++ b/tst/testinstall/help.tst
@@ -8,7 +8,6 @@ if true then ?what fi;
 Syntax error: while parsing an 'if' statement: statement or 'fi' expected in s\
 tream:2
 
-
 #
 gap> if false then ?what fi;
 Syntax error: '?' cannot be used in this context in stream:1
@@ -16,7 +15,6 @@ if false then ?what fi;
               ^^^^^^^^^
 Syntax error: while parsing an 'if' statement: statement or 'fi' expected in s\
 tream:2
-
 
 #
 gap> f := function()
@@ -26,7 +24,6 @@ Syntax error: '?' cannot be used in this context in stream:2
 ^^^^^
 Syntax error: while parsing a function: statement or 'end' expected in stream:\
 3
-
 
 #
 gap> old_help := HELP;;

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -101,25 +101,21 @@ Syntax error: Character literal must not include <newline> in stream:1
 s := '
      ^
 Syntax error: ; expected in stream:2
-
 gap> s := 'x
 Syntax error: Missing single quote in character constant in stream:1
 s := 'x
      ^^
 Syntax error: ; expected in stream:2
-
 gap> s := "
 Syntax error: String must not include <newline> in stream:1
 s := "
      ^
 Syntax error: ; expected in stream:2
-
 gap> s := "x
 Syntax error: String must not include <newline> in stream:1
 s := "x
      ^^
 Syntax error: ; expected in stream:2
-
 
 # errors in the middle of parsing a float literal
 gap> 12.34\56;
@@ -185,11 +181,9 @@ gap> f();
 # with syntax errors
 gap> f:=ReadAsFunction(InputTextString("return 1"));;
 Syntax error: ; expected in stream:1
-
 gap> f:={} -> ReadAsFunction(InputTextString("return 1"));;
 gap> f();
 Syntax error: ; expected in stream:1
-
 fail
 
 # with execution errors
@@ -210,7 +204,6 @@ local x; x := function(a) return a end;; return x(1);
 gap> f:={} -> ReadAsFunction(InputTextString("return 1"));;
 gap> f();
 Syntax error: ; expected in stream:1
-
 fail
 
 #

--- a/tst/testinstall/kernel/scanner.tst
+++ b/tst/testinstall/kernel/scanner.tst
@@ -125,19 +125,16 @@ a.x111111111111111111111111111111111111111111111111111111111111111111111111111\
 gap> EvalString("\"123");
 Syntax error: String must end with " before end of file in stream:1
 Syntax error: ; expected in stream:1
-
 Error, Could not evaluate string.
 
 gap> EvalString("\"\"\"123");
 Syntax error: String must end with """ before end of file in stream:1
 Syntax error: ; expected in stream:1
-
 Error, Could not evaluate string.
 
 gap> obj := """
 Syntax error: String must end with """ before end of file in stream:2
 Syntax error: ; expected in stream:2
-
 
 #
 gap> STOP_TEST("kernel/scanner.tst", 1);


### PR DESCRIPTION
This simplifies the code overall.

The next step will be to move the `ReaderState` out of GAPState and onto the stack, too. That's a much bigger change, though, both in terms of the size of the diff as well as the complications it involves. But it also has a bigger payoff, as it will allow us to remove some code that deal with "recursion" in the reader/coder/... and will open up further refactoring opportunities towards a more modular codebase that one can reason about ore easily as well.