### PR TITLE
kernel: fix a crash and weirdness related to 'for' loops

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -1086,12 +1086,6 @@ void CodeForBegin ( void )
 
 void CodeForIn ( void )
 {
-  Expr var = PopExpr();
-  if (TNUM_EXPR(var) == EXPR_REF_GVAR)
-    {
-      PushGlobalForLoopVariable(READ_EXPR(var, 0));
-    }
-  PushExpr(var);
 }
 
 void CodeForBeginBody ( void )
@@ -1112,9 +1106,6 @@ void CodeForEndBody (
     /* get the variable reference                                          */
     var = PopExpr();
 
-    if (TNUM_EXPR(var) == EXPR_REF_GVAR)
-      PopGlobalForLoopVariable();
-    
     /* select the type of the for-statement                                */
     if ( TNUM_EXPR(list) == EXPR_RANGE && SIZE_EXPR(list) == 2*sizeof(Expr)
       && IS_REF_LVAR(var) ) {

--- a/src/read.c
+++ b/src/read.c
@@ -105,28 +105,29 @@ static void ReadFuncExprAbbrevSingle(ScannerState * s, TypSymbolSet follow);
 
 static void ReadAtom(ScannerState * s, TypSymbolSet follow, Char mode);
 
-void PushGlobalForLoopVariable( UInt var)
+static void PushGlobalForLoopVariable(UInt var)
 {
     struct ReaderState * rs = ReaderState();
-    if (rs->CurrentGlobalForLoopDepth < 100)
+    if (rs->CurrentGlobalForLoopDepth <
+        ARRAY_SIZE(rs->CurrentGlobalForLoopVariables))
         rs->CurrentGlobalForLoopVariables[rs->CurrentGlobalForLoopDepth] = var;
     rs->CurrentGlobalForLoopDepth++;
 }
 
-void PopGlobalForLoopVariable( void )
+static void PopGlobalForLoopVariable(void)
 {
     GAP_ASSERT(ReaderState()->CurrentGlobalForLoopDepth);
     ReaderState()->CurrentGlobalForLoopDepth--;
 }
 
-static UInt GlobalComesFromEnclosingForLoop (UInt var)
+static UInt GlobalComesFromEnclosingForLoop(UInt var)
 {
     struct ReaderState * rs = ReaderState();
     for (UInt i = 0; i < rs->CurrentGlobalForLoopDepth; i++) {
-        if (i == 100)
-          return 0;
+        if (i == ARRAY_SIZE(rs->CurrentGlobalForLoopVariables))
+            return 0;
         if (rs->CurrentGlobalForLoopVariables[i] == var)
-          return 1;
+            return 1;
     }
     return 0;
 }
@@ -2061,11 +2062,15 @@ static void ReadFor(ScannerState * s, TypSymbolSet follow)
 
     /* 'do' <Statements>                                                   */
     Match(s, S_DO, "do", STATBEGIN|S_OD|follow);
+    if (ref.type == R_GVAR)
+        PushGlobalForLoopVariable(ref.var);
     ReaderState()->LoopNesting++;
     TRY_IF_NO_ERROR { IntrForBeginBody(); }
     nrs = ReadStats(s, S_OD|follow);
     TRY_IF_NO_ERROR { IntrForEndBody( nrs ); }
     ReaderState()->LoopNesting--;
+    if (ref.type == R_GVAR)
+        PopGlobalForLoopVariable();
 
     /* 'od'                                                                */
     Match(s, S_OD, "while parsing a 'for' loop: statement or 'od'", follow);

--- a/src/read.c
+++ b/src/read.c
@@ -2050,7 +2050,9 @@ static void ReadFor(ScannerState * s, TypSymbolSet follow)
     Match(s, S_FOR, "for", follow);
 
     /* <Var>                                                               */
-    ReadCallVarAss(s, follow, 'r');
+    volatile LHSRef ref = ReadVar(s, follow);
+    if (ref.type != R_INVALID)
+        EvalRef(ref, 1);
 
     /* 'in' <Expr>                                                         */
     Match(s, S_IN, "in", S_DO|S_OD|follow);

--- a/src/read.h
+++ b/src/read.h
@@ -118,14 +118,6 @@ void FinishAndCallFakeFuncExpr(void);
 
 /****************************************************************************
 **
-*/
-void PushGlobalForLoopVariable(UInt var);
-
-void PopGlobalForLoopVariable(void);
-
-
-/****************************************************************************
-**
 *F  Call0ArgsInNewReader(Obj f)  . . . . . . . . . . . . call a GAP function
 **
 **  The current reader context is saved and a new one is started.

--- a/tst/testinstall/coder.tst
+++ b/tst/testinstall/coder.tst
@@ -301,4 +301,40 @@ Error, PosObj Assignment: <position> must be a positive small integer (not the\
  value 'fail')
 
 #
+# weird corner cases in for loop index variables
+#
+gap> function() for + in [1,2,3] do od; end();
+Syntax error: Identifier expected in stream:1
+function() for + in [1,2,3] do od; end();
+               ^
+gap> function() local x; for x[1] in [1,2,3] do od; end();
+Syntax error: in expected in stream:1
+function() local x; for x[1] in [1,2,3] do od; end();
+                         ^
+gap> function() local x; for x{[1]} in [1,2,3] do od; end();
+Syntax error: in expected in stream:1
+function() local x; for x{[1]} in [1,2,3] do od; end();
+                         ^
+gap> function() for IsHPCGAP in [1,2,3] do od; end();
+Error, Variable: 'IsHPCGAP' is constant
+gap> function() for IsHPCGAP[1] in [1,2,3] do od; end();
+Syntax error: in expected in stream:1
+function() for IsHPCGAP[1] in [1,2,3] do od; end();
+                       ^
+gap> function() for IsHPCGAP{[1]} in [1,2,3] do od; end();
+Syntax error: in expected in stream:1
+function() for IsHPCGAP{[1]} in [1,2,3] do od; end();
+                       ^
+gap> function() for PrintObj in [1,2,3] do od; end();
+Error, Variable: 'PrintObj' is read only
+gap> function() for PrintObj[1] in [1,2,3] do od; end();
+Syntax error: in expected in stream:1
+function() for PrintObj[1] in [1,2,3] do od; end();
+                       ^
+gap> function() for PrintObj{[1]} in [1,2,3] do od; end();
+Syntax error: in expected in stream:1
+function() for PrintObj{[1]} in [1,2,3] do od; end();
+                       ^
+
+#
 gap> STOP_TEST("coder.tst", 1);

--- a/tst/testinstall/interpreter.tst
+++ b/tst/testinstall/interpreter.tst
@@ -253,5 +253,41 @@ Error, PosObj Assignment: <position> must be a positive small integer (not the\
  value 'fail')
 
 #
+# weird corner cases in for loop index variables
+#
+gap> for + in [1,2,3] do od;
+Syntax error: Identifier expected in stream:1
+for + in [1,2,3] do od;
+    ^
+gap> for x[1] in [1,2,3] do od;
+Syntax error: in expected in stream:1
+for x[1] in [1,2,3] do od;
+     ^
+gap> for x{[1]} in [1,2,3] do od;
+Syntax error: in expected in stream:1
+for x{[1]} in [1,2,3] do od;
+     ^
+gap> for IsHPCGAP in [1,2,3] do od;
+Error, Variable: 'IsHPCGAP' is constant
+gap> for IsHPCGAP[1] in [1,2,3] do od;
+Syntax error: in expected in stream:1
+for IsHPCGAP[1] in [1,2,3] do od;
+            ^
+gap> for IsHPCGAP{[1]} in [1,2,3] do od;
+Syntax error: in expected in stream:1
+for IsHPCGAP{[1]} in [1,2,3] do od;
+            ^
+gap> for PrintObj in [1,2,3] do od;
+Error, Variable: 'PrintObj' is read only
+gap> for PrintObj[1] in [1,2,3] do od;
+Syntax error: in expected in stream:1
+for PrintObj[1] in [1,2,3] do od;
+            ^
+gap> for PrintObj{[1]} in [1,2,3] do od;
+Syntax error: in expected in stream:1
+for PrintObj{[1]} in [1,2,3] do od;
+            ^
+
+#
 #
 gap> STOP_TEST("interpreter.tst", 1);


### PR DESCRIPTION
The reader ("parser") did not sufficiently restrict the kind of expression
permitted as index variable in `for` loops. So one could enter e.g. this:

    for x[1] in [1] do od;

The result was a nonsensical error message. Worse, one could specify a
"constant" variable, which caused a segfault; e.g.

    for IsHPCGAP in [1] do od;

## Text for release notes 

Fixed a crash when using a constant global variable (created via `MakeConstantGlobal`) as index variable of a for loop.