### PR TITLE
kernel: tweak sysstr.h, IsIdent()

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1926,7 +1926,7 @@ static inline void FormatOutput(
         prec--;
       }
       for ( const Char * q = (const Char *)arg1; *q != '\0'; q++ ) {
-        if ( !IsIdent(*q) && !IsDigit(*q) ) {
+        if ( !IsIdent(*q) ) {
           prec--;
         }
         prec--;
@@ -1943,7 +1943,7 @@ static inline void FormatOutput(
       for ( Int i = 0; ((const Char *)arg1)[i] != '\0'; i++ ) {
         Char c = ((const Char *)arg1)[i];
 
-        if ( !IsIdent(c) && !IsDigit(c) ) {
+        if ( !IsIdent(c) ) {
           put_a_char(state, '\\');
         }
         put_a_char(state, c);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -271,7 +271,7 @@ static UInt GetIdent(ScannerState * s, Int i)
 
     // read all characters into 's->Value'
     Char c = PEEK_CURR_CHAR();
-    for (; IsIdent(c) || IsDigit(c) || c == '\\'; i++) {
+    for (; IsIdent(c) || c == '\\'; i++) {
 
         // handle escape sequences
         if (c == '\\') {
@@ -498,7 +498,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint)
       }
       // Now if the next character is alphanumerical, or an identifier type
       // symbol then we really do have an error, otherwise we return a result
-      if (IsIdent(c) || IsDigit(c)) {
+      if (IsIdent(c)) {
         SyntaxError(s, "Badly formed number");
       }
       else {
@@ -546,7 +546,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint)
       }
       // Now if the next character is alphanumerical, or an identifier type
       // symbol then we really do have an error, otherwise we return a result
-      if (!IsIdent(c) && !IsDigit(c)) {
+      if (!IsIdent(c)) {
         symbol = S_FLOAT;
         goto finish;
       }

--- a/src/sysstr.c
+++ b/src/sysstr.c
@@ -7,6 +7,8 @@
 **
 **  SPDX-License-Identifier: GPL-2.0-or-later
 **
+**  This file implements low-level functions dealing with C strings and
+**  characters.
 */
 
 #include "sysstr.h"

--- a/src/sysstr.h
+++ b/src/sysstr.h
@@ -7,6 +7,8 @@
 **
 **  SPDX-License-Identifier: GPL-2.0-or-later
 **
+**  This file declares low-level functions dealing with C strings and
+**  characters.
 */
 
 #ifndef GAP_SYSSTR_H
@@ -14,13 +16,15 @@
 
 #include "system.h"
 
+#include <ctype.h>
+#include <string.h>
 
 /****************************************************************************
 **
 *F  IsAlpha( <ch> ) . . . . . . . . . . . . .  is a character a normal letter
 **
-**  'IsAlpha' returns 1 if its character argument is a normal character  from
-**  the range 'a..zA..Z' and 0 otherwise.
+**  'IsAlpha' returns 1 if its character argument is a character from the
+**  range 'a..zA..Z' and 0 otherwise.
 */
 #define IsAlpha(ch) (isalpha((unsigned int)ch))
 
@@ -37,11 +41,14 @@
 
 /****************************************************************************
 **
-*F  IsIdent( <ch> )
+*F  IsIdent( <ch> ) . . . . . . . .  is a character valid in a GAP identifier
+**
+**  'IsIdent' returns 1 if its character argument can be used unquoted inside
+**  a GAP identifier, i.e., is in the range 'a..zA..Z0-9_@', and 0 otherwise.
 */
 EXPORT_INLINE int IsIdent(char ch)
 {
-    return IsAlpha(ch) || ch == '_' || ch == '@';
+    return isalnum((unsigned int)ch) || ch == '_' || ch == '@';
 }
 
 

--- a/src/system.h
+++ b/src/system.h
@@ -21,7 +21,6 @@
 #include "config.h"
 
 #include <assert.h>
-#include <ctype.h>
 #include <limits.h>
 #include <setjmp.h>
 #include <stdint.h>


### PR DESCRIPTION
- move #include <ctype.h> from system.h to sysstr.h
- add #include <string.h> to sysstr.h (for strlcpy, strlcat on BSD and macOS)
- IsIdent now also accept digits, by using isalnum() instead of IsAlpha; this
  is sightly more efficient. In a few places were we are using IsIdent, we
  strictly speaking don't want to accept digits; but there, digits never can
  be the input anyway, so all is good
- add a file description comment to the top of sysstr.c and sysstr.h

Partially motivated by PR #3807