### PR TITLE
kernel: remove a bunch of useless comments

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -510,7 +510,6 @@ static Obj ElmsBlist(Obj list, Obj poss)
             }
         }
     }
-    /* return the result                                                   */
     return elms;
 }
 
@@ -922,7 +921,6 @@ static Int IsBlist(Obj list)
         isBlist = (len < i);
     }
 
-    /* return the result                                                   */
     return isBlist;
 }
 
@@ -972,7 +970,6 @@ static Int IsBlistConv(Obj list)
         }
     }
 
-    /* return the result                                                   */
     return isBlist;
 }
 
@@ -1263,7 +1260,6 @@ static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
         *ptr1++ |= *ptr2++;
     }
 
-    /* return nothing, this function is a procedure                        */
     return 0;
 }
 
@@ -1509,7 +1505,6 @@ static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
     for ( i = NUMBER_BLOCKS_BLIST(blist1); 0 < i; i-- )
         *ptr1++ &= *ptr2++;
 
-    /* return nothing, this function is a procedure                        */
     return 0;
 }
 
@@ -1543,7 +1538,6 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
     for ( i = NUMBER_BLOCKS_BLIST(blist1); 0 < i; i-- )
         *ptr1++ &= ~ *ptr2++; 
 
-    /* return nothing, this function is a procedure */
     return 0;
 }
 
@@ -1594,7 +1588,6 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
 
 static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 {
-    // get and check the arguments
     RequireBlist("FlipBlist", blist);
     RequireMutable("FlipBlist", blist, "boolean list");
 
@@ -1629,7 +1622,6 @@ static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 
 static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 {
-    // get and check the arguments
     RequireBlist("ClearAllBitsBlist", blist);
     RequireMutable("ClearAllBitsBlist", blist, "boolean list");
 
@@ -1658,7 +1650,6 @@ static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 
 static Obj FuncSET_ALL_BLIST(Obj self, Obj blist)
 {
-    // get and check the arguments
     RequireBlist("SetAllBitsBlist", blist);
     RequireMutable("SetAllBitsBlist", blist, "boolean list");
 

--- a/src/calls.c
+++ b/src/calls.c
@@ -495,7 +495,6 @@ static ALWAYS_INLINE Obj DoProfNNNargs (
     SET_STOR_WOUT_PROF( prof, STOR_WOUT_PROF(prof) + storCurr );
     StorDone += storCurr;
 
-    /* return the result from the function                                 */
     return result;
 }
 
@@ -1191,14 +1190,12 @@ Obj CallFuncList ( Obj func, Obj list )
     } else {
       result = DoOperation2Args(CallFuncListOper, func, list);
     }
-    /* return the result                                                   */
     return result;
 
 }
 
 static Obj FuncCALL_FUNC_LIST(Obj self, Obj func, Obj list)
 {
-    /* check that the second argument is a list                            */
     RequireSmallList("CallFuncList", list);
     return CallFuncList(func, list);
 }
@@ -1206,7 +1203,6 @@ static Obj FuncCALL_FUNC_LIST(Obj self, Obj func, Obj list)
 static Obj FuncCALL_FUNC_LIST_WRAP(Obj self, Obj func, Obj list)
 {
     Obj retval, retlist;
-    /* check that the second argument is a list                            */
     RequireSmallList("CallFuncListWrap", list);
     retval = CallFuncList(func, list);
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -932,7 +932,6 @@ static CVar CompUnknownBool(Expr expr)
     /* free the temporary                                                  */
     if ( IS_TEMP_CVAR( val ) )  FreeTemp( TEMP_CVAR( val ) );
 
-    /* return the result                                                   */
     return res;
 }
     
@@ -1021,7 +1020,6 @@ static CVar CompFunccall0to6Args(Expr expr)
     }
     if ( IS_TEMP_CVAR( func ) )  FreeTemp( TEMP_CVAR( func ) );
 
-    /* return the result                                                   */
     return result;
 }
 
@@ -1079,7 +1077,6 @@ static CVar CompFunccallXArgs(Expr expr)
     if ( IS_TEMP_CVAR( argl ) )  FreeTemp( TEMP_CVAR( argl ) );
     if ( IS_TEMP_CVAR( func ) )  FreeTemp( TEMP_CVAR( func ) );
 
-    /* return the result                                                   */
     return result;
 }
 
@@ -1195,7 +1192,6 @@ static CVar CompOr(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1234,7 +1230,6 @@ static CVar CompOrBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1292,7 +1287,6 @@ static CVar CompAnd(Expr expr)
     if ( IS_TEMP_CVAR( right1 ) )  FreeTemp( TEMP_CVAR( right1 ) );
     if ( IS_TEMP_CVAR( left   ) )  FreeTemp( TEMP_CVAR( left   ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1331,7 +1325,6 @@ static CVar CompAndBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1360,7 +1353,6 @@ static CVar CompNot(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( left ) )  FreeTemp( TEMP_CVAR( left ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1389,7 +1381,6 @@ static CVar CompNotBool(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( left ) )  FreeTemp( TEMP_CVAR( left ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1426,7 +1417,6 @@ static CVar CompEq(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1463,7 +1453,6 @@ static CVar CompEqBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1500,7 +1489,6 @@ static CVar CompNe(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1537,7 +1525,6 @@ static CVar CompNeBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1574,7 +1561,6 @@ static CVar CompLt(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1611,7 +1597,6 @@ static CVar CompLtBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1648,7 +1633,6 @@ static CVar CompGe(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1685,7 +1669,6 @@ static CVar CompGeBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1722,7 +1705,6 @@ static CVar CompGt(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1759,7 +1741,6 @@ static CVar CompGtBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1796,7 +1777,6 @@ static CVar CompLe(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1833,7 +1813,6 @@ static CVar CompLeBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1865,7 +1844,6 @@ static CVar CompIn(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1897,7 +1875,6 @@ static CVar CompInBool(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1942,7 +1919,6 @@ static CVar CompSum(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -1984,7 +1960,6 @@ static CVar CompAInv(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -2029,7 +2004,6 @@ static CVar CompDiff(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -2074,7 +2048,6 @@ static CVar CompProd(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -2106,7 +2079,6 @@ static CVar CompQuo(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -2143,7 +2115,6 @@ static CVar CompMod(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -2180,7 +2151,6 @@ static CVar CompPow(Expr expr)
     if ( IS_TEMP_CVAR( right ) )  FreeTemp( TEMP_CVAR( right ) );
     if ( IS_TEMP_CVAR( left  ) )  FreeTemp( TEMP_CVAR( left  ) );
 
-    /* return the result                                                   */
     return val;
 }
 
@@ -2443,7 +2413,6 @@ static CVar CompListExpr(Expr expr)
     list = CompListExpr1( expr );
     CompListExpr2( list, expr );
 
-    /* return the result                                                   */
     return list;
 }
 
@@ -2653,7 +2622,6 @@ static CVar CompRecExpr(Expr expr)
     rec = CompRecExpr1( expr );
     CompRecExpr2( rec, expr );
 
-    /* return the result                                                   */
     return rec;
 }
 
@@ -2845,7 +2813,6 @@ static CVar CompIsbLVar(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( val ) )  FreeTemp( TEMP_CVAR( val ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -2909,7 +2876,6 @@ static CVar CompIsbHVar(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( val ) )  FreeTemp( TEMP_CVAR( val ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -2998,7 +2964,6 @@ static CVar CompIsbGVar(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( val ) )  FreeTemp( TEMP_CVAR( val ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -3277,7 +3242,6 @@ static CVar CompIsbRecName(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( record ) )  FreeTemp( TEMP_CVAR( record ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -3312,7 +3276,6 @@ static CVar CompIsbRecExpr(Expr expr)
     if ( IS_TEMP_CVAR( rnam   ) )  FreeTemp( TEMP_CVAR( rnam   ) );
     if ( IS_TEMP_CVAR( record ) )  FreeTemp( TEMP_CVAR( record ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -3486,7 +3449,6 @@ static CVar CompIsbComObjName(Expr expr)
     /* free the temporaries                                                */
     if ( IS_TEMP_CVAR( record ) )  FreeTemp( TEMP_CVAR( record ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -3521,7 +3483,6 @@ static CVar CompIsbComObjExpr(Expr expr)
     if ( IS_TEMP_CVAR( rnam   ) )  FreeTemp( TEMP_CVAR( rnam   ) );
     if ( IS_TEMP_CVAR( record ) )  FreeTemp( TEMP_CVAR( record ) );
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -5435,7 +5396,6 @@ static Obj FuncCOMPILE_FUNC(Obj self, Obj arg)
     magic1 = ELM_LIST( arg, 4 );
     magic2 = ELM_LIST( arg, 5 );
 
-    // check the arguments
     RequireStringRep("CompileFunc", output);
     RequireFunction("CompileFunc", func);
     RequireStringRep("CompileFunc", name);
@@ -5471,7 +5431,6 @@ static Obj FuncCOMPILE_FUNC(Obj self, Obj arg)
         INT_INTOBJ(magic1), magic2 );
 
 
-    /* return the result                                                   */
     return INTOBJ_INT(nr);
 }
 

--- a/src/costab.c
+++ b/src/costab.c
@@ -751,7 +751,6 @@ static Obj FuncStandardizeTableC(Obj self, Obj table, Obj stan)
     /* clean out  */
     CleanOut();
 
-    /* return void                                                         */
     return 0;
 }
 
@@ -1352,7 +1351,6 @@ static Obj FuncCopyRel(Obj self, Obj rel) /* the given relator */
     Obj *               ptCopy;         /* pointer to the copy             */
     Int                 leng;           /* length of the given word        */
 
-    /* Get and check argument                                              */
     RequirePlainList(0, rel);
     leng = LEN_PLIST(rel);
 
@@ -1390,7 +1388,6 @@ static Obj FuncMakeCanonical(Obj self, Obj rel) /* the given relator */
     Int                 i, j, k, l;     /* integer variables               */
     Int                 ii, jj, kk;     /* integer variables               */
 
-    /* Get and check the argument                                          */
     RequirePlainList(0, rel);
     leng  = LEN_PLIST(rel);
     if (leng == 0) {
@@ -1522,7 +1519,6 @@ static Obj FuncMakeCanonical(Obj self, Obj rel) /* the given relator */
         }
     }
 
-    /* return nothing                                                      */
     return 0;
 }
 
@@ -1902,7 +1898,6 @@ static Obj FuncStandardizeTable2C(Obj self, Obj table, Obj table2, Obj stan)
         SET_LEN_PLIST( ptTabl2[2*j  ], lcos );
     }
 
-    /* return void                                                         */
     return 0;
 }
 
@@ -1925,7 +1920,6 @@ static Obj FuncAddAbelianRelator(Obj self,
     Int                 numrows;        /* number of relators              */
     Int                 i, j;           /* loop variables                  */
 
-    /* check the arguments                                                 */
     RequirePlainList(0, rels);
     ptRels = BASE_PTR_PLIST(rels) - 1;
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -784,7 +784,6 @@ static Obj Cyclotomic(UInt n, UInt m)
         /* 'CHANGED_BAG' not needed for last bag                           */
     }
 
-    /* return the result                                                   */
     return cyc;
 }
 
@@ -1011,7 +1010,6 @@ static Obj AInvCyc(Obj op)
     }
     CHANGED_BAG( res );
 
-    /* return the result                                                   */
     return res;
 }
 
@@ -1185,7 +1183,6 @@ static Obj ProdCycInt(Obj opL, Obj opR)
         }
     }
 
-    /* return the result                                                   */
     return hdP;
 }
 
@@ -1472,7 +1469,6 @@ static Obj PowCyc(Obj opL, Obj opR)
 
     }
 
-    /* return the result                                                   */
     return pow;
 }
 
@@ -1499,7 +1495,6 @@ static Obj FuncE(Obj self, Obj n)
         return DoOperation1Args( self, n );
     }
 
-    /* get and check the argument                                          */
     GetPositiveSmallInt("E", n);
 
     /* for $e_1$ return 1 and for $e_2$ return -1                          */
@@ -1623,7 +1618,6 @@ static Obj AttrCONDUCTOR(Obj self, Obj cyc)
         return DoAttribute( ConductorAttr, cyc );
     }
 
-    /* check the argument                                                  */
     if (!IS_CYC(cyc) && !IS_SMALL_LIST(cyc)) {
         RequireArgument("Conductor", cyc,
                         "must be a cyclotomic or a small list");
@@ -1694,7 +1688,6 @@ static Obj FuncCOEFFS_CYC(Obj self, Obj cyc)
         return DoOperation1Args( self, cyc );
     }
 
-    /* check the argument                                                  */
     if (!IS_CYC(cyc)) {
         RequireArgument("COEFFSCYC", cyc, "must be a cyclotomic");
     }
@@ -1720,7 +1713,6 @@ static Obj FuncCOEFFS_CYC(Obj self, Obj cyc)
         /* 'CHANGED_BAG' not needed for last bag                           */
     }
 
-    /* return the result                                                   */
     return list;
 }
 
@@ -1885,7 +1877,6 @@ static Obj FuncGALOIS_CYC(Obj self, Obj cyc, Obj ord)
 
     }
 
-    /* return the result                                                   */
     return gal;
 }
 
@@ -1915,7 +1906,6 @@ static Obj FuncCycList(Obj self, Obj list)
         return DoOperation1Args( self, list );
     }
 
-    /* get and check the argument                                          */
     if ( ! IS_PLIST( list ) || ! IS_DENSE_LIST( list ) ) {
         RequireArgument("CycList", list, "must be a dense plain list");
     }

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1084,7 +1084,6 @@ static Obj EvalRecExpr(Expr expr)
     rec = RecExpr1( expr );
     RecExpr2( rec, expr );
 
-    /* return the result                                                   */
     return rec;
 }
 

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -638,7 +638,6 @@ static Obj SumFFEFFE(Obj opL, Obj opR)
         if ( vR != 0 )  vR = ((qX-1) * (vR-1)) / (qR-1) + 1;
     }
 
-    /* compute and return the result                                       */
     vX = SUM_FFV( vL, vR, SUCC_FF(fX) );
     return NEW_FFE( fX, vX );
 }
@@ -668,7 +667,6 @@ static Obj SumFFEInt(Obj opL, Obj opR)
     /* get the left operand                                                */
     vL = VAL_FFE( opL );
 
-    /* compute and return the result                                       */
     vX = SUM_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
 }
@@ -698,7 +696,6 @@ static Obj SumIntFFE(Obj opL, Obj opR)
     /* get the right operand                                               */
     vR = VAL_FFE( opR );
 
-    /* compute and return the result                                       */
     vX = SUM_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
 }
@@ -715,7 +712,6 @@ static Obj ZeroFFE(Obj op)
     /* get the field for the result                                        */
     fX = FLD_FFE( op );
 
-    /* return the result                                                   */
     return NEW_FFE( fX, 0 );
 }
 
@@ -737,7 +733,6 @@ static Obj AInvFFE(Obj op)
     /* get the operand                                                     */
     v = VAL_FFE( op );
 
-    /* compute and return the result                                       */
     vX = NEG_FFV( v, sX ); 
     return NEW_FFE( fX, vX );
 }
@@ -797,7 +792,6 @@ static Obj DiffFFEFFE(Obj opL, Obj opR)
         if ( vR != 0 )  vR = ((qX-1) * (vR-1)) / (qR-1) + 1;
     }
 
-    /* compute and return the result                                       */
     vR = NEG_FFV( vR, SUCC_FF(fX) );
     vX = SUM_FFV( vL, vR, SUCC_FF(fX) );
     return NEW_FFE( fX, vX );
@@ -828,7 +822,6 @@ static Obj DiffFFEInt(Obj opL, Obj opR)
     /* get the left operand                                                */
     vL = VAL_FFE( opL );
 
-    /* compute and return the result                                       */
     vR = NEG_FFV( vR, sX );
     vX = SUM_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
@@ -859,7 +852,6 @@ static Obj DiffIntFFE(Obj opL, Obj opR)
     /* get the right operand                                               */
     vR = VAL_FFE( opR );
 
-    /* compute and return the result                                       */
     vR = NEG_FFV( vR, sX );
     vX = SUM_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
@@ -920,7 +912,6 @@ static Obj ProdFFEFFE(Obj opL, Obj opR)
         if ( vR != 0 )  vR = ((qX-1) * (vR-1)) / (qR-1) + 1;
     }
 
-    /* compute and return the result                                       */
     vX = PROD_FFV( vL, vR, SUCC_FF(fX) );
     return NEW_FFE( fX, vX );
 }
@@ -950,7 +941,6 @@ static Obj ProdFFEInt(Obj opL, Obj opR)
     /* get the left operand                                                */
     vL = VAL_FFE( opL );
 
-    /* compute and return the result                                       */
     vX = PROD_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
 }
@@ -980,7 +970,6 @@ static Obj ProdIntFFE(Obj opL, Obj opR)
     /* get the right operand                                               */
     vR = VAL_FFE( opR );
 
-    /* compute and return the result                                       */
     vX = PROD_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
 }
@@ -997,7 +986,6 @@ static Obj OneFFE(Obj op)
     /* get the field for the result                                        */
     fX = FLD_FFE( op );
 
-    /* return the result                                                   */
     return NEW_FFE( fX, 1 );
 }
 
@@ -1020,7 +1008,6 @@ static Obj InvFFE(Obj op)
     v = VAL_FFE( op );
     if ( v == 0 ) return Fail;
 
-    /* compute and return the result                                       */
     vX = QUO_FFV( 1, v, sX ); 
     return NEW_FFE( fX, vX );
 }
@@ -1080,7 +1067,6 @@ static Obj QuoFFEFFE(Obj opL, Obj opR)
         if ( vR != 0 )  vR = ((qX-1) * (vR-1)) / (qR-1) + 1;
     }
 
-    /* compute and return the result                                       */
     if ( vR == 0 ) {
         ErrorMayQuit("FFE operations: <divisor> must not be zero", 0, 0);
     }
@@ -1113,7 +1099,6 @@ static Obj QuoFFEInt(Obj opL, Obj opR)
     /* get the left operand                                                */
     vL = VAL_FFE( opL );
 
-    /* compute and return the result                                       */
     if ( vR == 0 ) {
         ErrorMayQuit("FFE operations: <divisor> must not be zero", 0, 0);
     }
@@ -1146,7 +1131,6 @@ static Obj QuoIntFFE(Obj opL, Obj opR)
     /* get the right operand                                               */
     vR = VAL_FFE( opR );
 
-    /* compute and return the result                                       */
     if ( vR == 0 ) {
         ErrorMayQuit("FFE operations: <divisor> must not be zero", 0, 0);
     }
@@ -1198,7 +1182,6 @@ static Obj PowFFEInt(Obj opL, Obj opR)
     /* reduce vR modulo the order of the multiplicative group first.       */
     vR %= *sX;
 
-    /* compute and return the result                                       */
     vX = POW_FFV( vL, vR, sX );
     return NEW_FFE( fX, vX );
 }
@@ -1215,7 +1198,6 @@ static Obj PowFFEFFE(Obj opL, Obj opR)
         ErrorMayQuit("<x> and <y> have different characteristic", 0, 0);
     }
 
-    /* compute and return the result                                       */
     return opL;
 }
 
@@ -1265,7 +1247,6 @@ static Obj FuncLOG_FFE_DEFAULT(Obj self, Obj opZ, Obj opR)
     UInt                qZ, qR, qX;     /* size  of left, right, common    */
     Int                 a, b, c, d, t;  /* temporaries                     */
 
-    /* check the arguments                                                 */
     if (!IS_FFE(opZ) || VAL_FFE(opZ) == 0) {
         ErrorMayQuit("LogFFE: <z> must be a nonzero finite field element", 0,
                      0);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -489,7 +489,6 @@ static ALWAYS_INLINE Obj DoExecFunc(Obj func, Int narg, const Obj *arg)
 
     CHECK_RECURSION_AFTER
 
-    /* return the result                                                   */
     return result;
 }
 
@@ -574,7 +573,6 @@ static Obj DoExecFuncXargs(Obj func, Obj args)
 
     CHECK_RECURSION_AFTER
 
-    /* return the result                                                   */
     return result;
 }
 
@@ -626,7 +624,6 @@ static Obj DoPartialUnWrapFunc(Obj func, Obj args)
 
     CHECK_RECURSION_AFTER
 
-    /* return the result                                                   */
     return result;
 }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -593,7 +593,6 @@ static Obj FuncSizeScreen(Obj self, Obj args)
   UInt                len;            /* length of lines on the screen   */
   UInt                nr;             /* number of lines on the screen   */
 
-  /* check the arguments                                                 */
   RequireSmallList("SizeScreen", args);
   if (1 < LEN_LIST(args)) {
       ErrorMayQuit("SizeScreen: number of arguments must be 0 or 1 (not %d)",
@@ -673,7 +672,6 @@ static Obj FuncWindowCmd(Obj self, Obj args)
   const Char *    inptr;
   const Char *    qtr;
 
-  // check arguments
   RequireSmallList("WindowCmd", args);
   tmp = ELM_LIST(args, 1);
   if (!IsStringConv(tmp)) {
@@ -803,7 +801,6 @@ static Obj FuncWindowCmd(Obj self, Obj args)
 */
 static Obj FuncGASMAN(Obj self, Obj args)
 {
-    /* check the argument                                                  */
     if ( ! IS_SMALL_LIST(args) || LEN_LIST(args) == 0 ) {
         ErrorMayQuit(
             "usage: GASMAN( \"display\"|\"displayshort\"|\"clear\"|\"collect\"|\"message\"|\"partial\" )",
@@ -921,7 +918,6 @@ static Obj FuncGASMAN(Obj self, Obj args)
 #endif // USE_GASMAN
     }
 
-    /* return nothing, this function is a procedure                        */
     return 0;
 }
 

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -821,13 +821,8 @@ void MakeThreadLocalVar (
 */
 static Obj FuncMakeReadOnlyGVar(Obj self, Obj name)
 {       
-    // check the argument
     RequireStringRep("MakeReadOnlyGVar", name);
-
-    /* get the variable and make it read only                              */
     MakeReadOnlyGVar(GVarName(CONST_CSTR_STRING(name)));
-
-    /* return void                                                         */
     return 0;
 }
 
@@ -844,13 +839,8 @@ static Obj FuncMakeReadOnlyGVar(Obj self, Obj name)
 */
 static Obj FuncMakeConstantGVar(Obj self, Obj name)
 {
-    // check the argument
     RequireStringRep("MakeConstantGVar", name);
-
-    /* get the variable and make it read only                              */
     MakeConstantGVar(GVarName(CONST_CSTR_STRING(name)));
-
-    /* return void                                                         */
     return 0;
 }
 
@@ -881,13 +871,8 @@ void MakeReadWriteGVar (
 */
 static Obj FuncMakeReadWriteGVar(Obj self, Obj name)
 {
-    // check the argument
     RequireStringRep("MakeReadWriteGVar", name);
-
-    /* get the variable and make it read write                             */
     MakeReadWriteGVar(GVarName(CONST_CSTR_STRING(name)));
-
-    /* return void                                                         */
     return 0;
 }
 
@@ -911,10 +896,7 @@ static Obj FuncIsReadOnlyGVar (
     Obj                 self,
     Obj                 name )
 {
-    // check the argument
     RequireStringRep("IsReadOnlyGVar", name);
-
-    /* get the answer                             */
     return IsReadOnlyGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
 }
 
@@ -935,10 +917,7 @@ Int IsConstantGVar(UInt gvar)
 
 static Obj FuncIsConstantGVar(Obj self, Obj name)
 {
-    // check the argument
     RequireStringRep("IsConstantGVar", name);
-
-    /* get the answer                             */
     return IsConstantGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
 }
 
@@ -988,7 +967,6 @@ static Obj FuncAUTO(Obj self, Obj args)
         CHANGED_GVAR_LIST( ExprGVars, gvar );
     }
 
-    /* return void                                                         */
     return 0;
 }
 
@@ -1118,9 +1096,7 @@ static Obj FuncIDENTS_BOUND_GVARS(Obj self)
 */
 static Obj FuncASS_GVAR(Obj self, Obj gvar, Obj val)
 {
-    // check the argument
     RequireStringRep("ASS_GVAR", gvar);
-
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), val );
     return 0;
 }
@@ -1132,7 +1108,6 @@ static Obj FuncASS_GVAR(Obj self, Obj gvar, Obj val)
 */
 static Obj FuncISB_GVAR(Obj self, Obj gvar)
 {
-    // check the argument
     RequireStringRep("ISB_GVAR", gvar);
 
     UInt gv = GVarName( CONST_CSTR_STRING(gvar) );
@@ -1157,7 +1132,6 @@ static Obj FuncISB_GVAR(Obj self, Obj gvar)
 
 static Obj FuncIS_AUTO_GVAR(Obj self, Obj gvar)
 {
-    // check the argument
     RequireStringRep("IS_AUTO_GVAR", gvar);
     Obj expr = ExprGVar(GVarName( CONST_CSTR_STRING(gvar) ) );
     return (expr && !IS_INTOBJ(expr)) ? True : False;
@@ -1173,10 +1147,8 @@ static Obj FuncVAL_GVAR(Obj self, Obj gvar)
 {
     Obj val;
 
-    // check the argument
     RequireStringRep("VAL_GVAR", gvar);
 
-    /* get the value */
     val = ValAutoGVar( GVarName( CONST_CSTR_STRING(gvar) ) );
 
     if (val == 0)
@@ -1191,12 +1163,9 @@ static Obj FuncVAL_GVAR(Obj self, Obj gvar)
 
 static Obj FuncUNB_GVAR(Obj self, Obj gvar)
 {
-    // check the argument
     RequireStringRep("UNB_GVAR", gvar);
-
-    /*  */
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), (Obj)0 );
-    return (Obj) 0;
+    return 0;
 }
 
 

--- a/src/integer.c
+++ b/src/integer.c
@@ -1552,7 +1552,6 @@ static Obj ProdIntObj ( Obj n, Obj op )
     }
   }
   
-  /* return the result                                                     */
   return res;
 }
 
@@ -1702,7 +1701,6 @@ static Obj PowObjInt(Obj op, Obj n)
     }
   }
 
-  /* return the result                                                   */
   return res;
 }
 
@@ -1837,7 +1835,6 @@ Obj ModInt(Obj opL, Obj opR)
     
   }
   
-  /* return the result                                                     */
 #if DEBUG_GMP
   assert( !IS_NEG_INT(mod) );
 #endif
@@ -1949,7 +1946,6 @@ Obj QuoInt(Obj opL, Obj opR)
                  (mp_srcptr)CONST_ADDR_INT(opR), SIZE_INT(opR) );
   }
   
-  /* normalize and return the result                                       */
   quo = GMP_NORMALIZE(quo);
   quo = GMP_REDUCE( quo );
   return quo;
@@ -2081,7 +2077,6 @@ Obj RemInt(Obj opL, Obj opR)
     
   }
   
-  /* return the result                                                     */
   CHECK_INT(rem);
   return rem;
 }

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -124,8 +124,7 @@ static Obj FuncADD_LIST3(Obj self, Obj list, Obj obj, Obj pos)
       DoOperation3Args( self, list, obj, pos);
   }
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -220,9 +219,7 @@ static Obj FuncAPPEND_LIST_INTR(Obj self, Obj list1, Obj list2)
     Obj                 elm;            /* one element of the second list  */
     Int                 i;              /* loop variable                   */
 
-    /* check the mutability of the first argument */
     RequireMutable("Append", list1, "list");
-
 
     /* handle the case of strings now */
     if (IS_STRING_REP(list1) && IS_STRING_REP(list2)) {
@@ -278,8 +275,7 @@ static Obj FuncAPPEND_LIST_INTR(Obj self, Obj list1, Obj list2)
         }
     }
 
-    /* return void                                                         */
-    return (Obj)0;
+    return 0;
 }
 
 static Obj AppendListOper;
@@ -294,8 +290,7 @@ static Obj FuncAPPEND_LIST(Obj self, Obj list, Obj obj)
         DoOperation2Args( self, list, obj );
     }
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -358,11 +353,9 @@ UInt            PositionSortedDensePlist (
 
 static Obj FuncPOSITION_SORTED_LIST(Obj self, Obj list, Obj obj)
 {
-    UInt                h;              /* position, result                */
-
-    /* check the first argument                                            */
     RequireSmallList("POSITION_SORTED_LIST", list);
-    /* dispatch                                                            */
+
+    UInt h;
     if ( IS_DENSE_PLIST(list) ) {
         h = PositionSortedDensePlist( list, obj );
     }
@@ -370,7 +363,6 @@ static Obj FuncPOSITION_SORTED_LIST(Obj self, Obj list, Obj obj)
         h = POSITION_SORTED_LIST( list, obj );
     }
 
-    /* return the result                                                   */
     return INTOBJ_INT( h );
 }
 
@@ -434,15 +426,10 @@ static UInt PositionSortedDensePlistComp(Obj list, Obj obj, Obj func)
 static Obj
 FuncPOSITION_SORTED_LIST_COMP(Obj self, Obj list, Obj obj, Obj func)
 {
-    UInt                h;              /* position, result                */
-
-    /* check the first argument                                            */
     RequireSmallList("POSITION_SORTED_LIST_COMP", list);
-
-    /* check the third argument                                            */
     RequireFunction("POSITION_SORTED_LIST_COMP", func);
 
-    /* dispatch                                                            */
+    UInt h;
     if ( IS_DENSE_PLIST(list) ) {
         h = PositionSortedDensePlistComp( list, obj, func );
     }
@@ -450,7 +437,6 @@ FuncPOSITION_SORTED_LIST_COMP(Obj self, Obj list, Obj obj, Obj func)
         h = POSITION_SORTED_LISTComp( list, obj, func );
     }
 
-    /* return the result                                                   */
     return INTOBJ_INT( h );
 }
 
@@ -478,7 +464,6 @@ static Obj FuncPOSITION_SORTED_BY(Obj self, Obj list, Obj val, Obj func)
         }
     }
 
-    // return the result
     return INTOBJ_INT(h);
 }
 
@@ -793,10 +778,8 @@ UInt            RemoveDupsDensePlist (
 */
 static Obj FuncSORT_LIST(Obj self, Obj list)
 {
-    /* check the first argument                                            */
     RequireSmallList("SORT_LIST", list);
 
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlist( list );
     }
@@ -805,16 +788,13 @@ static Obj FuncSORT_LIST(Obj self, Obj list)
     }
     IS_SSORT_LIST(list);
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 static Obj FuncSTABLE_SORT_LIST(Obj self, Obj list)
 {
-    /* check the first argument                                            */
     RequireSmallList("STABLE_SORT_LIST", list);
 
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlistMerge( list );
     }
@@ -823,8 +803,7 @@ static Obj FuncSTABLE_SORT_LIST(Obj self, Obj list)
     }
     IS_SSORT_LIST(list);
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -835,13 +814,9 @@ static Obj FuncSTABLE_SORT_LIST(Obj self, Obj list)
 */
 static Obj FuncSORT_LIST_COMP(Obj self, Obj list, Obj func)
 {
-    /* check the first argument                                            */
     RequireSmallList("SORT_LIST_COMP", list);
-
-    /* check the third argument                                            */
     RequireFunction("SORT_LIST_COMP", func);
 
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlistComp( list, func );
     }
@@ -849,19 +824,14 @@ static Obj FuncSORT_LIST_COMP(Obj self, Obj list, Obj func)
         SORT_LISTComp( list, func );
     }
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 static Obj FuncSTABLE_SORT_LIST_COMP(Obj self, Obj list, Obj func)
 {
-    /* check the first argument                                            */
     RequireSmallList("STABLE_SORT_LIST_COMP", list);
-
-    /* check the third argument                                            */
     RequireFunction("STABLE_SORT_LIST_COMP", func);
 
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlistCompMerge( list, func );
     }
@@ -869,8 +839,7 @@ static Obj FuncSTABLE_SORT_LIST_COMP(Obj self, Obj list, Obj func)
         SORT_LISTCompMerge( list, func );
     }
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -880,12 +849,10 @@ static Obj FuncSTABLE_SORT_LIST_COMP(Obj self, Obj list, Obj func)
 */
 static Obj FuncSORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 {
-    /* check the first two arguments                                       */
     RequireSmallList("SORT_PARA_LIST", list);
     RequireSmallList("SORT_PARA_LIST", shadow);
     RequireSameLength("SORT_PARA_LIST", list, shadow);
 
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlist( list, shadow );
     }
@@ -894,18 +861,15 @@ static Obj FuncSORT_PARA_LIST(Obj self, Obj list, Obj shadow)
     }
     IS_SSORT_LIST(list);
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 static Obj FuncSTABLE_SORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 {
-    /* check the first two arguments                                       */
     RequireSmallList("STABLE_SORT_PARA_LIST", list);
     RequireSmallList("STABLE_SORT_PARA_LIST", shadow);
     RequireSameLength("STABLE_SORT_PARA_LIST", list, shadow);
 
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlistMerge( list, shadow );
     }
@@ -914,8 +878,7 @@ static Obj FuncSTABLE_SORT_PARA_LIST(Obj self, Obj list, Obj shadow)
     }
     IS_SSORT_LIST(list);
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -925,15 +888,11 @@ static Obj FuncSTABLE_SORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 */
 static Obj FuncSORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 {
-    /* check the first two arguments                                       */
     RequireSmallList("SORT_PARA_LIST_COMP", list);
     RequireSmallList("SORT_PARA_LIST_COMP", shadow);
     RequireSameLength("SORT_PARA_LIST_COMP", list, shadow);
-
-    /* check the third argument                                            */
     RequireFunction("SORT_PARA_LIST_COMP", func);
     
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlistComp( list, shadow, func );
     }
@@ -941,22 +900,17 @@ static Obj FuncSORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
         SORT_PARA_LISTComp( list, shadow, func );
     }
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 static Obj
 FuncSTABLE_SORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 {
-    /* check the first two arguments                                       */
     RequireSmallList("SORT_PARA_LIST_COMP", list);
     RequireSmallList("SORT_PARA_LIST_COMP", shadow);
     RequireSameLength("SORT_PARA_LIST_COMP", list, shadow);
-
-    /* check the third argument                                            */
     RequireFunction("SORT_PARA_LIST_COMP", func);
     
-    /* dispatch                                                            */
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlistCompMerge( list, shadow, func );
     }
@@ -964,8 +918,7 @@ FuncSTABLE_SORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
         SORT_PARA_LISTCompMerge( list, shadow, func );
     }
 
-    /* return nothing                                                      */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -1003,7 +956,6 @@ static Obj FuncOnPairs(Obj self, Obj pair, Obj elm)
     Obj                 img;            /* image, result                   */
     Obj                 tmp;            /* temporary                       */
 
-    /* check the type of the first argument                                */
     RequireSmallList("OnPairs", pair);
     if (LEN_LIST(pair) != 2) {
         ErrorMayQuit("OnPairs: <pair> must have length 2, not length %d",
@@ -1022,7 +974,6 @@ static Obj FuncOnPairs(Obj self, Obj pair, Obj elm)
     SET_ELM_PLIST( img, 2, tmp );
     CHANGED_BAG( img );
 
-    /* return the result                                                   */
     return img;
 }
 
@@ -1045,7 +996,6 @@ static Obj FuncOnTuples(Obj self, Obj tuple, Obj elm)
     Obj                 tmp;            /* temporary                       */
     UInt                i;              /* loop variable                   */
 
-    /* check the type of the first argument                                */
     RequireSmallList("OnTuples", tuple);
 
     /* special case for the empty list */
@@ -1086,7 +1036,6 @@ static Obj FuncOnTuples(Obj self, Obj tuple, Obj elm)
         CHANGED_BAG( img );
     }
 
-    /* return the result (must be a dense plain list, see 'FuncOnSets')    */
     return img;
 }
 
@@ -1108,7 +1057,6 @@ static Obj FuncOnSets(Obj self, Obj set, Obj elm)
     Obj                 img;            /* handle of the image, result     */
     UInt                status;        /* the elements are mutable        */
 
-    /* check the type of the first argument                                */
     if (!HAS_FILT_LIST(set, FN_IS_SSORT) && !IsSet(set)) {
         RequireArgument("OnSets", set, "must be a set");
     }

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -192,7 +192,6 @@ Obj             SumSclList (
           }
     }
 
-    /* return the result                                                   */
     return listS;
 }
 
@@ -223,7 +222,6 @@ Obj             SumListScl (
           }
     }
 
-    /* return the result                                                   */
     return listS;
 }
 
@@ -275,7 +273,6 @@ Obj             SumListList (
         }
     }
 
-    /* return the result                                                   */
     return listS;
 }
 
@@ -362,7 +359,6 @@ static Obj ZeroListDefault(Obj list)
           SET_FILT_LIST( res, FN_IS_NDENSE );
       }
 
-    /* return the result                                                   */
     return res;
 }
 
@@ -421,7 +417,6 @@ static Obj ZeroListMutDefault(Obj list)
           SET_FILT_LIST( res, FN_IS_NDENSE );
       }
 
-    /* return the result                                                   */
     return res;
 }
 
@@ -518,7 +513,6 @@ static Obj AInvMutListDefault(Obj list)
         else if (HAS_FILT_LIST(list, FN_IS_NDENSE))
           SET_FILT_LIST( res, FN_IS_NDENSE );
       }
-    /* return the result                                                   */
     return res;
 }
 
@@ -579,7 +573,6 @@ static Obj AInvListDefault(Obj list)
         else if (HAS_FILT_LIST(list, FN_IS_NDENSE))
           SET_FILT_LIST( res, FN_IS_NDENSE );
       }
-    /* return the result                                                   */
     return res;
 }
 
@@ -645,7 +638,6 @@ Obj             DiffSclList (
          else if (HAS_FILT_LIST(listR, FN_IS_NDENSE))
            SET_FILT_LIST( listD, FN_IS_NDENSE );
       }
-    /* return the result                                                   */
     return listD;
 }
 
@@ -690,7 +682,6 @@ Obj             DiffListScl (
          else if (HAS_FILT_LIST(listL, FN_IS_NDENSE))
            SET_FILT_LIST( listD, FN_IS_NDENSE );
       }
-    /* return the result                                                   */
     return listD;
 }
 
@@ -773,7 +764,6 @@ Obj             DiffListList (
              HAS_FILT_LIST(listL, FN_IS_DENSE))
       SET_FILT_LIST( listD, FN_IS_DENSE );
     
-    /* return the result                                                   */
     return listD;
 }
 
@@ -852,7 +842,6 @@ Obj             ProdSclList (
            SET_FILT_LIST( listP, FN_IS_NDENSE );
       }
 
-    /* return the result                                                   */
     return listP;
 }
 
@@ -893,7 +882,6 @@ Obj             ProdListScl (
          else if (HAS_FILT_LIST(listL, FN_IS_NDENSE))
            SET_FILT_LIST( listP, FN_IS_NDENSE );
       }
-    /* return the result                                                   */
     return listP;
 }
 
@@ -942,7 +930,6 @@ Obj             ProdListList (
     if (!listP)
       ErrorMayQuit("Inner product multiplication of lists: no summands", 0, 0);
     
-    /* return the result                                                   */
     return listP;
 }
 
@@ -1221,7 +1208,6 @@ static Obj InvMatrix(Obj mat, UInt mut)
         SHRINK_PLIST(  ELM_PLIST( res, i ), len );
     }
 
-    /* return the result                                                   */
     return res;
 }
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -715,7 +715,6 @@ Obj ElmsListDefault (
 
     }
 
-    /* return the result                                                   */
     return elms;
 }
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -126,10 +126,7 @@ static void RegisterModuleState(StructInitInfo * info)
 */
 static Obj FuncGAP_CRC(Obj self, Obj filename)
 {
-    /* check the argument                                                  */
     RequireStringRep("GAP_CRC", filename);
-
-    /* compute the crc value                                               */
     return ObjInt_Int(SyGAPCRC(CONST_CSTR_STRING(filename)));
 }
 
@@ -211,7 +208,6 @@ static Int SyLoadModule(const Char * name, InitInfoFunc * func)
 */
 static Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
 {
-    /* check the argument                                                  */
     RequireStringRep("LOAD_DYN", filename);
     if (!IS_INTOBJ(crc) && crc != False) {
         RequireArgument("LOAD_DYN", crc, "must be a small integer or 'false'");
@@ -283,7 +279,6 @@ static Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
     StructInitInfo * info = 0;
     Int              k;
 
-    /* check the argument                                                  */
     RequireStringRep("LOAD_STAT", filename);
     if (!IS_INTOBJ(crc) && crc != False) {
         RequireArgument("LOAD_STAT", crc, "must be a small integer or 'false'");

--- a/src/opers.c
+++ b/src/opers.c
@@ -236,7 +236,6 @@ static Obj FuncTRUES_FLAGS(Obj self, Obj flags)
     UInt                nn;
     UInt                i;              /* loop variable                   */
 
-    /* get and check the first argument                                    */
     RequireFlags("TRUES_FLAGS", flags);
     if ( TRUES_FLAGS(flags) != 0 ) {
         return TRUES_FLAGS(flags);
@@ -281,7 +280,6 @@ static Obj FuncSIZE_FLAGS(Obj self, Obj flags)
     UInt                nrb;            /* number of blocks in flags       */
     UInt                n;              /* number of bits in flags         */
 
-    /* get and check the first argument                                    */
     RequireFlags("SIZE_FLAGS", flags);
     if ( TRUES_FLAGS(flags) != 0 ) {
         return INTOBJ_INT( LEN_PLIST( TRUES_FLAGS(flags) ) );
@@ -613,7 +611,6 @@ static Obj FuncAND_FLAGS(Obj self, Obj flags1, Obj flags2)
 #       endif
 #   endif
 
-    /* and return the result                                               */
     return flags;
 }
 
@@ -1969,7 +1966,6 @@ static ALWAYS_INLINE Obj DoOperationNArgs(Obj  oper,
         }
     } while (res == TRY_NEXT_METHOD);
 
-    /* return the result                                                   */
     return res;
 }
 
@@ -3139,7 +3135,6 @@ static Obj REREADING;
 
 static Obj FuncINSTALL_GLOBAL_FUNCTION(Obj self, Obj oper, Obj func)
 {
-    /* check the arguments                                                 */
     RequireFunction("INSTALL_GLOBAL_FUNCTION", oper);
     if ( (REREADING != True) &&
          (HDLR_FUNC(oper,0) != (ObjFunc)DoUninstalledGlobalFunction) ) {
@@ -3524,13 +3519,8 @@ void ChangeDoOperations (
 */
 static Obj FuncTRACE_METHODS(Obj self, Obj oper)
 {
-    /* check the argument                                                  */
     RequireOperation(oper);
-
-    /* install trace handler                                               */
-    ChangeDoOperations( oper, 1 );
-
-    /* return nothing                                                      */
+    ChangeDoOperations(oper, 1);
     return 0;
 }
 
@@ -3541,14 +3531,8 @@ static Obj FuncTRACE_METHODS(Obj self, Obj oper)
 */
 static Obj FuncUNTRACE_METHODS(Obj self, Obj oper)
 {
-
-    /* check the argument                                                  */
     RequireOperation(oper);
-
-    /* install trace handler                                               */
-    ChangeDoOperations( oper, 0 );
-
-    /* return nothing                                                      */
+    ChangeDoOperations(oper, 0);
     return 0;
 }
 

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -380,7 +380,6 @@ static Obj ProdPerm(Obj opL, Obj opR)
             *(ptP++) = IMAGE( ptL[ p ], ptR, degR );
     }
 
-    /* return the result                                                   */
     return prd;
 }
 
@@ -460,7 +459,6 @@ static Obj LQuoPerm(Obj opL, Obj opR)
             ptM[ *(ptL++) ] = p;
     }
 
-    /* return the result                                                   */
     return mod;
 }
 
@@ -757,7 +755,6 @@ static Obj PowPermInt(Obj opL, Obj opR)
 
     }
 
-    /* return the result                                                   */
     return pow;
 }
 
@@ -908,7 +905,6 @@ static Obj PowPerm(Obj opL, Obj opR)
             ptC[ IMAGE(p,ptR,degR) ] = IMAGE( IMAGE(p,ptL,degL), ptR, degR );
     }
 
-    /* return the result                                                   */
     return cnj;
 }
 
@@ -964,7 +960,6 @@ static Obj CommPerm(Obj opL, Obj opR)
                = IMAGE( IMAGE(p,ptL,degL), ptR, degR );
     }
 
-    /* return the result                                                   */
     return com;
 }
 
@@ -1075,7 +1070,6 @@ static inline Obj PermList(Obj list)
 
 static Obj FuncPermList(Obj self, Obj list)
 {
-    /* check the arguments                                                 */
     RequireSmallList("PermList", list);
 
     UInt len = LEN_LIST( list );
@@ -1168,8 +1162,6 @@ static Obj SmallestMovedPointPerm(Obj perm)
 */
 static Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
 {
-
-    /* check the argument                                                  */
     RequirePermutation("LargestMovedPointPerm", perm);
 
     return INTOBJ_INT(LargestMovedPointPerm(perm));
@@ -1229,7 +1221,6 @@ static Obj FuncCYCLE_LENGTH_PERM_INT(Obj self, Obj perm, Obj point)
 {
     UInt                pnt;            /* value of the point              */
 
-    /* evaluate and check the arguments                                    */
     RequirePermutation("CycleLengthPermInt", perm);
     pnt = GetPositiveSmallInt("CycleLengthPermInt", point) - 1;
 
@@ -1295,7 +1286,6 @@ static Obj FuncCYCLE_PERM_INT(Obj self, Obj perm, Obj point)
 {
     UInt                pnt;            /* value of the point              */
 
-    /* evaluate and check the arguments                                    */
     RequirePermutation("CyclePermInt", perm);
     pnt = GetPositiveSmallInt("CyclePermInt", point) - 1;
 
@@ -1408,7 +1398,6 @@ static inline Obj CYCLE_STRUCT_PERM(Obj perm)
 
 static Obj FuncCYCLE_STRUCT_PERM(Obj self, Obj perm)
 {
-    /* evaluate and check the arguments                                    */
     RequirePermutation("CycleStructPerm", perm);
 
     if (TNUM_OBJ(perm) == T_PERM2) {
@@ -1484,7 +1473,6 @@ static inline Obj ORDER_PERM(Obj perm)
 
 static Obj FuncORDER_PERM(Obj self, Obj perm)
 {
-    /* check arguments and extract permutation                             */
     RequirePermutation("OrderPerm", perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
@@ -1559,7 +1547,6 @@ static inline Obj SIGN_PERM(Obj perm)
 
 static Obj FuncSIGN_PERM(Obj self, Obj perm)
 {
-    /* check arguments and extract permutation                             */
     RequirePermutation("SignPerm", perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
@@ -1676,7 +1663,6 @@ static inline Obj SMALLEST_GENERATOR_PERM(Obj perm)
 
 static Obj FuncSMALLEST_GENERATOR_PERM(Obj self, Obj perm)
 {
-    /* check arguments and extract permutation                             */
     RequirePermutation("SmallestGeneratorPerm", perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
@@ -1791,7 +1777,6 @@ static inline Obj RESTRICTED_PERM(Obj perm, Obj dom, Obj test)
 
 static Obj FuncRESTRICTED_PERM(Obj self, Obj perm, Obj dom, Obj test)
 {
-    /* check arguments and extract permutation                             */
     RequirePermutation("RestrictedPerm", perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
@@ -1984,7 +1969,6 @@ static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
       if (tmp<res) res = tmp;
     }
 
-    /* return the result                                                   */
     return INTOBJ_INT(res);
 
 }
@@ -2143,7 +2127,6 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
         SortDensePlist(res);
     }
 
-    /* return the result                                                   */
     return res;
 }
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -1296,7 +1296,6 @@ static Obj ElmsPlist(Obj list, Obj poss)
 
     }
 
-    /* return the result                                                   */
     return elms;
 }
 
@@ -1450,7 +1449,6 @@ static Obj ElmsPlistDense(Obj list, Obj poss)
 
     }
 
-    /* return the result                                                   */
     return elms;
 }
 
@@ -2408,7 +2406,6 @@ static Obj FuncASS_PLIST_DEFAULT(Obj self, Obj plist, Obj pos, Obj val)
 {
     Int                 p;
 
-    /* check the arguments                                                 */
     p = GetPositiveSmallInt("List Assignment", pos);
     if (!IS_PLIST(plist) || !IS_PLIST_MUTABLE(plist)) {
         RequireArgumentEx(0, plist, "<list>", "must be a mutable plain list");

--- a/src/precord.c
+++ b/src/precord.c
@@ -566,7 +566,6 @@ static Obj InnerRecNames(Obj rec)
 
 static Obj FuncREC_NAMES(Obj self, Obj rec)
 {
-    /* check the argument                                                  */
     if (IS_PREC(rec)) {
         return InnerRecNames(rec);
     }
@@ -587,7 +586,6 @@ static Obj FuncREC_NAMES(Obj self, Obj rec)
 /* same as FuncREC_NAMES except for different argument check  */
 static Obj FuncREC_NAMES_COMOBJ(Obj self, Obj rec)
 {
-    /* check the argument                                                  */
     switch (TNUM_OBJ(rec)) {
       case T_COMOBJ:
         return InnerRecNames(rec);

--- a/src/range.c
+++ b/src/range.c
@@ -399,7 +399,6 @@ static Obj ElmsRange(Obj list, Obj poss)
 
     }
 
-    /* return the result                                                   */
     return elms;
 }
 
@@ -682,7 +681,6 @@ static Int IsRange(Obj list)
 
     }
 
-    /* return the result of the test                                       */
     return isRange;
 }
 

--- a/src/rational.c
+++ b/src/rational.c
@@ -252,7 +252,6 @@ static Obj SumRat(Obj opL, Obj opR)
         sum = numS;
     }
 
-    /* return the result                                                   */
     CHECK_RAT(sum);
     return sum;
 }
@@ -387,7 +386,6 @@ static Obj DiffRat(Obj opL, Obj opR)
         dif = numD;
     }
 
-    /* return the result                                                   */
     CHECK_RAT(dif);
     return dif;
 }
@@ -452,7 +450,6 @@ static Obj ProdRat(Obj opL, Obj opR)
         prd = numP;
     }
 
-    /* return the result                                                   */
     CHECK_RAT(prd);
     return prd;
 }
@@ -557,7 +554,6 @@ static Obj QuoRat(Obj opL, Obj opR)
         quo = numQ;
     }
 
-    /* return the result */
     CHECK_RAT(quo);
     return quo;
 }
@@ -659,7 +655,6 @@ static Obj PowRat(Obj opL, Obj opR)
         pow = MakeRat(numP, denP);
     }
 
-    /* return the result                                                   */
     CHECK_RAT(pow);
     return pow;
 }
@@ -705,10 +700,8 @@ static Obj FiltIS_RAT(Obj self, Obj val)
 */
 static Obj FuncNUMERATOR_RAT(Obj self, Obj rat)
 {
-    /* check the argument                                                   */
     RequireRational("NumeratorRat", rat);
 
-    /* return the numerator                                                */
     if ( TNUM_OBJ(rat) == T_RAT ) {
         return NUM_RAT(rat);
     }
@@ -730,10 +723,8 @@ static Obj FuncNUMERATOR_RAT(Obj self, Obj rat)
 */
 static Obj FuncDENOMINATOR_RAT(Obj self, Obj rat)
 {
-    /* check the argument                                                  */
     RequireRational("DenominatorRat", rat);
 
-    /* return the denominator                                              */
     if ( TNUM_OBJ(rat) == T_RAT ) {
         return DEN_RAT(rat);
     }

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -272,7 +272,6 @@ static Obj FuncSC_TABLE_PRODUCT(Obj self, Obj table, Obj list1, Obj list2)
         }
     }
 
-    /* return the result                                                   */
     return res;
 }
 

--- a/src/set.c
+++ b/src/set.c
@@ -115,7 +115,6 @@ Int IsSet (
         isSet = 0;
     }
 
-    /* return the result                                                   */
     return isSet;
 }
 
@@ -202,7 +201,6 @@ static Obj FuncLIST_SORTED_LIST(Obj self, Obj list)
 {
     Obj                 set;            /* result                          */
 
-    /* check the argument                                                  */
     RequireSmallList("Set", list);
 
     /* if the list is empty create a new empty list                        */
@@ -268,10 +266,9 @@ static Int EqSet(Obj listL, Obj listR)
 
 static Obj FuncIS_EQUAL_SET(Obj self, Obj list1, Obj list2)
 {
-    /* check the arguments, convert to sets if necessary                   */
     RequireSmallList("IsEqualSet", list1);
-    if ( ! IsSet( list1 ) )  list1 = SetList( list1 );
     RequireSmallList("IsEqualSet", list2);
+    if ( ! IsSet( list1 ) )  list1 = SetList( list1 );
     if ( ! IsSet( list2 ) )  list2 = SetList( list2 );
 
     /* and now compare them                                                */
@@ -302,7 +299,6 @@ static Obj FuncIS_SUBSET_SET(Obj self, Obj set1, Obj set2)
     Obj                 e2;             /* element of right set            */
     UInt                pos;            /* position                        */
 
-    /* check the arguments, convert to sets if necessary                   */
     RequireSmallList("IsSubsetSet", set1);
     RequireSmallList("IsSubsetSet", set2);
     if ( ! IsSet( set1 ) )  set1 = SetList( set1 );
@@ -401,7 +397,6 @@ static Obj FuncADD_SET(Obj self, Obj set, Obj obj)
   UInt                wasNHom;
   UInt                wasTab;
     
-  /* check the arguments                                                 */
   RequireMutableSet("AddSet", set);
   len = LEN_PLIST(set);
 
@@ -485,8 +480,7 @@ static Obj FuncADD_SET(Obj self, Obj set, Obj obj)
     }
   }
 
-  /* return void, this is a procedure                                    */
-  return (Obj)0;
+  return 0;
 }
 
 
@@ -512,7 +506,6 @@ static Obj FuncREM_SET(Obj self, Obj set, Obj obj)
     UInt                len;            /* logical length of the list      */
     UInt                pos;            /* position                        */
 
-    /* check the arguments                                                 */
     RequireMutableSet("RemoveSet", set);
     len = LEN_PLIST(set);
 
@@ -533,8 +526,7 @@ static Obj FuncREM_SET(Obj self, Obj set, Obj obj)
         }
     }
 
-    /* return void, this is a procedure                                    */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -568,7 +560,6 @@ static Obj FuncUNITE_SET(Obj self, Obj set1, Obj set2)
     Obj                 e2;             /* element of right set            */
     Obj                 TmpUnion;
 
-    /* check the arguments                                                 */
     RequireMutableSet("UniteSet", set1);
     RequireSmallList("UniteSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
@@ -645,8 +636,7 @@ static Obj FuncUNITE_SET(Obj self, Obj set1, Obj set2)
         SET_ELM_PLIST( TmpUnion, i1, (Obj)0 );
     }
 
-    /* return void, this is a procedure                                    */
-    return (Obj)0;
+    return 0;
 }
 
 
@@ -733,7 +723,6 @@ static Obj FuncINTER_SET(Obj self, Obj set1, Obj set2)
     UInt                len2;           /* length  of right set            */
     UInt                lenr;           /* length  of result set           */
 
-    /* check the arguments                                                 */
     RequireMutableSet("IntersectSet", set1);
     RequireSmallList("IntersectSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
@@ -800,10 +789,8 @@ static Obj FuncINTER_SET(Obj self, Obj set1, Obj set2)
           }
       }
 
-    /* return void, this is a procedure                                    */
-    return (Obj)0;
+    return 0;
 }
-
 
 
 /****************************************************************************
@@ -898,7 +885,6 @@ static Obj FuncSUBTR_SET(Obj self, Obj set1, Obj set2)
     UInt                x;            
     UInt                ll;           
 
-    /* check the arguments                                                 */
     RequireMutableSet("SubtractSet", set1);
     RequireSmallList("SubtractSet", set2);
     if ( ! IsSet(set2) )  set2 = SetList(set2);
@@ -936,8 +922,7 @@ static Obj FuncSUBTR_SET(Obj self, Obj set1, Obj set2)
     else
       RESET_FILT_LIST(set1, FN_IS_NHOMOG);
 
-    /* return void, this is a procedure                                    */
-    return (Obj)0;
+    return 0;
 }
 
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -861,7 +861,6 @@ static Obj FuncAPPEND_TO_STREAM(Obj self, Obj args)
 */
 static Obj FuncREAD(Obj self, Obj filename)
 {
-   /* check the argument                                                  */
     RequireStringRep("READ", filename);
 
     /* try to open the file                                                */
@@ -978,7 +977,6 @@ static Obj FuncREAD_STREAM_LOOP(Obj self, Obj stream, Obj catcherrstdout)
 */
 static Obj FuncREAD_AS_FUNC(Obj self, Obj filename)
 {
-    // check the argument
     RequireStringRep("READ_AS_FUNC", filename);
 
     /* try to open the file                                                */
@@ -1017,7 +1015,6 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 {
     Char filenamecpy[GAP_PATH_MAX];
 
-    // check the argument
     RequireStringRep("READ", filename);
 
     /* Copy to avoid garbage collection moving string                      */
@@ -1067,7 +1064,6 @@ static Obj FuncTmpDirectory(Obj self)
 */
 static Obj FuncRemoveFile(Obj self, Obj filename)
 {
-    // check the argument
     RequireStringRep("RemoveFile", filename);
     
     /* call the system dependent function                                  */
@@ -1080,7 +1076,6 @@ static Obj FuncRemoveFile(Obj self, Obj filename)
 */
 static Obj FuncCreateDir(Obj self, Obj filename)
 {
-    // check the argument
     RequireStringRep("CreateDir", filename);
     
     /* call the system dependent function                                  */
@@ -1093,7 +1088,6 @@ static Obj FuncCreateDir(Obj self, Obj filename)
 */
 static Obj FuncRemoveDir(Obj self, Obj filename)
 {
-    // check the argument
     RequireStringRep("RemoveDir", filename);
     
     /* call the system dependent function                                  */
@@ -1163,7 +1157,6 @@ static Obj FuncIsExistingFile(Obj self, Obj filename)
 {
     Int             res;
 
-    // check the argument
     RequireStringRep("IsExistingFile", filename);
     
     /* call the system dependent function                                  */
@@ -1180,7 +1173,6 @@ static Obj FuncIsReadableFile(Obj self, Obj filename)
 {
     Int             res;
 
-    // check the argument
     RequireStringRep("IsReadableFile", filename);
     
     /* call the system dependent function                                  */
@@ -1197,7 +1189,6 @@ static Obj FuncIsWritableFile(Obj self, Obj filename)
 {
     Int             res;
 
-    // check the argument
     RequireStringRep("IsWritableFile", filename);
     
     /* call the system dependent function                                  */
@@ -1214,7 +1205,6 @@ static Obj FuncIsExecutableFile(Obj self, Obj filename)
 {
     Int             res;
 
-    // check the argument
     RequireStringRep("IsExecutableFile", filename);
     
     /* call the system dependent function                                  */
@@ -1231,7 +1221,6 @@ static Obj FuncIsDirectoryPathString(Obj self, Obj filename)
 {
     Int             res;
 
-    // check the argument
     RequireStringRep("IsDirectoryPathString", filename);
     
     /* call the system dependent function                                  */
@@ -1257,7 +1246,6 @@ static Obj FuncLIST_DIR(Obj self, Obj dirname)
     struct dirent *entry;
     Obj res;
 
-    // check the argument
     RequireStringRep("LIST_DIR", dirname);
     
     SyClearErrorNo();
@@ -1285,7 +1273,6 @@ static Obj FuncLIST_DIR(Obj self, Obj dirname)
 */
 static Obj FuncCLOSE_FILE(Obj self, Obj fid)
 {
-    // check the argument
     Int ifid = GetSmallInt("CLOSE_FILE", fid);
     
     /* call the system dependent function                                  */
@@ -1302,7 +1289,6 @@ static Obj FuncINPUT_TEXT_FILE(Obj self, Obj filename)
 {
     Int             fid;
 
-    // check the argument
     RequireStringRep("INPUT_TEXT_FILE", filename);
     
     /* call the system dependent function                                  */
@@ -1320,7 +1306,6 @@ static Obj FuncINPUT_TEXT_FILE(Obj self, Obj filename)
 */
 static Obj FuncIS_END_OF_FILE(Obj self, Obj fid)
 {
-    // check the argument
     Int ifid = GetSmallInt("IS_END_OF_FILE", fid);
     
     Int ret = SyIsEndOfFile( ifid );
@@ -1336,7 +1321,6 @@ static Obj FuncOUTPUT_TEXT_FILE(Obj self, Obj filename, Obj append)
 {
     Int             fid;
 
-    // check the argument
     RequireStringRep("OUTPUT_TEXT_FILE", filename);
     RequireTrueOrFalse("OUTPUT_TEXT_FILE", append);
     
@@ -1360,7 +1344,6 @@ static Obj FuncOUTPUT_TEXT_FILE(Obj self, Obj filename, Obj append)
 */
 static Obj FuncPOSITION_FILE(Obj self, Obj fid)
 {
-    // check the argument
     Int ifid = GetSmallInt("POSITION_FILE", fid);
 
     Int ret = SyFtell(ifid);
@@ -1381,7 +1364,6 @@ static Obj FuncPOSITION_FILE(Obj self, Obj fid)
 */
 static Obj FuncREAD_BYTE_FILE(Obj self, Obj fid)
 {
-    // check the argument
     Int ifid = GetSmallInt("READ_BYTE_FILE", fid);
     
     /* call the system dependent function                                  */
@@ -1405,7 +1387,6 @@ static Obj FuncREAD_LINE_FILE(Obj self, Obj fid)
     UInt            lstr;
     Obj             str;
 
-    // check the argument
     Int ifid = GetSmallInt("READ_LINE_FILE", fid);
 
     /* read <fid> until we see a newline or eof or we've read at least
@@ -1455,9 +1436,7 @@ static Obj FuncREAD_ALL_FILE(Obj self, Obj fid, Obj limit)
     Obj             str;
     UInt            csize;
 
-    // check the argument
     Int ifid = GetSmallInt("READ_ALL_FILE", fid);
-
     Int ilim = GetSmallInt("READ_ALL_FILE", limit);
 
     /* read <fid> until we see  eof or we've read at least
@@ -1541,7 +1520,6 @@ static Obj FuncSEEK_POSITION_FILE(Obj self, Obj fid, Obj pos)
 {
     Int             ret;
 
-    // check the argument
     Int ifid = GetSmallInt("SEEK_POSITION_FILE", fid);
     Int ipos = GetSmallInt("SEEK_POSITION_FILE", pos);
     
@@ -1556,7 +1534,6 @@ static Obj FuncSEEK_POSITION_FILE(Obj self, Obj fid, Obj pos)
 */
 static Obj FuncWRITE_BYTE_FILE(Obj self, Obj fid, Obj ch)
 {
-    // check the argument
     Int ifid = GetSmallInt("WRITE_BYTE_FILE", fid);
     Int ich = GetSmallInt("WRITE_BYTE_FILE", ch);
     
@@ -1593,7 +1570,6 @@ static Obj FuncWRITE_STRING_FILE_NC(Obj self, Obj fid, Obj str)
 
 static Obj FuncREAD_STRING_FILE(Obj self, Obj fid)
 {
-    // check the argument
     Int ifid = GetSmallInt("READ_STRING_FILE", fid);
     return SyReadStringFid(ifid);
 }
@@ -1741,7 +1717,6 @@ FuncExecuteProcess(Obj self, Obj dir, Obj prg, Obj in, Obj out, Obj args)
     Int                 res;
     Int                 i;
 
-    // check the argument
     RequireStringRep("ExecuteProcess", dir);
     RequireStringRep("ExecuteProcess", prg);
     Int iin = GetSmallInt("ExecuteProcess", in);

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -953,7 +953,6 @@ static Obj ElmsString(Obj list, Obj poss)
 
     }
 
-    /* return the result                                                   */
     return elms;
 }
 
@@ -1305,7 +1304,6 @@ Int IsStringConv (
         ConvString( obj );
     }
 
-    /* return the result                                                   */
     return res;
 }
 
@@ -1342,7 +1340,6 @@ static Obj FuncIS_STRING_CONV(Obj self, Obj obj)
 */
 static Obj FuncCONV_STRING(Obj self, Obj string)
 {
-    /* check whether <string> is a string                                  */
     if (!IS_STRING(string)) {
         RequireArgument("ConvString", string, "must be a string");
     }
@@ -1350,7 +1347,6 @@ static Obj FuncCONV_STRING(Obj self, Obj string)
     /* convert to the string representation                                */
     ConvString( string );
 
-    /* return nothing                                                      */
     return 0;
 }
 
@@ -1372,7 +1368,6 @@ static Obj FiltIS_STRING_REP(Obj self, Obj obj)
 */
 static Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
 {
-    /* check whether <string> is a string                                 */
     if (!IS_STRING(string)) {
         RequireArgument("CopyToStringRep", string, "must be a string");
     }
@@ -1394,14 +1389,10 @@ static Obj FuncPOSITION_SUBSTRING(Obj self, Obj string, Obj substr, Obj off)
   Int    ipos, i, j, lens, lenss, max;
   const UInt1  *s, *ss;
 
-  /* check whether <string> is a string                                  */
   RequireStringRep("POSITION_SUBSTRING", string);
-  
-  /* check whether <substr> is a string                        */
   RequireStringRep("POSITION_SUBSTRING", substr);
-
-  /* check wether <off> is a non-negative integer  */
   RequireNonnegativeSmallInt("POSITION_SUBSTRING", off);
+
   ipos = INT_INTOBJ(off);
 
   /* special case for the empty string */
@@ -1444,7 +1435,6 @@ static Obj FuncNormalizeWhitespace(Obj self, Obj string)
   UInt1  *s, c;
   Int i, j, len, white;
 
-  /* check whether <string> is a string                                  */
   RequireStringRep("NormalizeWhitespace", string);
   
   len = GET_LEN_STRING(string);
@@ -1491,10 +1481,7 @@ static Obj FuncREMOVE_CHARACTERS(Obj self, Obj string, Obj rem)
   Int i, j, len;
   UInt1 REMCHARLIST[256] = {0};
 
-  /* check whether <string> is a string                                  */
   RequireStringRep("RemoveCharacters", string);
-  
-  /* check whether <rem> is a string                                  */
   RequireStringRep("RemoveCharacters", rem);
   
   /* set REMCHARLIST by setting positions of characters in rem to 1 */
@@ -1531,10 +1518,7 @@ static Obj FuncTranslateString(Obj self, Obj string, Obj trans)
 {
   Int j, len;
 
-  /* check whether <string> is a string                                  */
   RequireStringRep("TranslateString", string);
-  
-  // check whether <trans> is a string of length at least 256
   RequireStringRep("TranslateString", trans);
   if ( GET_LEN_STRING( trans ) < 256 ) {
       ErrorMayQuit("TranslateString: <trans> must have length >= 256",
@@ -1569,13 +1553,8 @@ static Obj FuncSplitStringInternal(Obj self, Obj string, Obj seps, Obj wspace)
   UInt1 SPLITSTRINGSEPS[256] = { 0 };
   UInt1 SPLITSTRINGWSPACE[256] = { 0 };
 
-  /* check whether <string> is a string                                  */
   RequireStringRep("SplitString", string);
-
-  /* check whether <seps> is a string                                  */
   RequireStringRep("SplitString", seps);
-
-  /* check whether <wspace> is a string                                  */
   RequireStringRep("SplitString", wspace);
 
   /* set SPLITSTRINGSEPS by setting positions of characters in rem to 1 */

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -363,7 +363,6 @@ static Obj FuncCrcString(Obj self, Obj str)
     Int4        ch;
     Int         seen_nl;
 
-    // check the argument
     RequireStringRep("CrcString", str);
 
     ptr = CONST_CSTR_STRING(str);

--- a/src/tietze.c
+++ b/src/tietze.c
@@ -793,7 +793,6 @@ static Obj FuncTzOccurrences(Obj self, Obj args)
         SET_LEN_PLIST( lens, k );
     }
 
-    /* return the result                                                   */
     return res;
 }
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -1307,7 +1307,6 @@ static Obj EvalIsbRecName(Expr expr)
     /* get the name (stored immediately in the expression)                 */
     rnam = READ_EXPR(expr, 1);
 
-    /* return the result                                                   */
     return (ISB_REC( record, rnam ) ? True : False);
 }
 
@@ -1330,7 +1329,6 @@ static Obj EvalIsbRecExpr(Expr expr)
     /* evaluate the name and convert it to a record name                   */
     rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
-    /* return the result                                                   */
     return (ISB_REC( record, rnam ) ? True : False);
 }
 
@@ -1566,7 +1564,6 @@ static Obj EvalIsbPosObj(Expr expr)
     /* get the result                                                      */
     isb = IsbPosObj(list, p) ? True : False;
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -1822,7 +1819,6 @@ static Obj EvalIsbComObjName(Expr expr)
     /* select the element of the record                                    */
     isb = IsbComObj( record, rnam ) ? True : False;
 
-    /* return the result                                                   */
     return isb;
 }
 
@@ -1849,7 +1845,6 @@ static Obj EvalIsbComObjExpr(Expr expr)
     /* select the element of the record                                    */
     isb = IsbComObj( record, rnam ) ? True : False;
 
-    /* return the result                                                   */
     return isb;
 }
 

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -999,7 +999,6 @@ void PlainVec8Bit(Obj list)
 */
 static Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
 {
-    // check whether <list> is an 8bit vector
     if (!IS_VEC8BIT_REP(list)) {
         RequireArgument("PLAIN_VEC8BIT", list, "must be an 8bit vector");
     }
@@ -1010,7 +1009,6 @@ static Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
     }
     PlainVec8Bit(list);
 
-    // return nothing
     return 0;
 }
 
@@ -5215,7 +5213,6 @@ static Obj FuncSEMIECHELON_LIST_VEC8BITS(Obj self, Obj mat)
     UInt i, len, width;
     Obj  row;
     UInt q;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5252,7 +5249,6 @@ static Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(Obj self, Obj mat)
     Obj  row;
     UInt q;
     UInt width;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5289,7 +5285,6 @@ static Obj FuncTRIANGULIZE_LIST_VEC8BITS(Obj self, Obj mat)
     UInt i, len, width;
     Obj  row;
     UInt q;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5326,7 +5321,6 @@ static Obj FuncRANK_LIST_VEC8BITS(Obj self, Obj mat)
     UInt i, len, width;
     Obj  row;
     UInt q;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5363,7 +5357,6 @@ static Obj FuncDETERMINANT_LIST_VEC8BITS(Obj self, Obj mat)
     Obj  row;
     UInt q;
     Obj  det;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -5466,7 +5459,6 @@ static Obj FuncTRANSPOSED_MAT8BIT(Obj self, Obj mat)
     const UInt1 * gettab = 0, *settab = 0;
     Obj     type;
 
-    // check argument
     if (TNUM_OBJ(mat) != T_POSOBJ) {
         ErrorMayQuit("TRANSPOSED_MAT8BIT: Need compressed matrix", 0, 0);
     }

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -113,7 +113,6 @@ static Obj SumFFEVecFFE(Obj elmL, Obj vecR)
         ptrS[i] = NEW_FFE(fld, valS);
     }
 
-    /* return the result                                                   */
     return vecS;
 }
 
@@ -172,7 +171,6 @@ static Obj SumVecFFEFFE(Obj vecL, Obj elmR)
         ptrS[i] = NEW_FFE(fld, valS);
     }
 
-    /* return the result                                                   */
     return vecS;
 }
 
@@ -248,7 +246,6 @@ static Obj SumVecFFEVecFFE(Obj vecL, Obj vecR)
         for (; i <= len; i++)
             ptrS[i] = ptrL[i];
 
-    /* return the result                                                   */
     return vecS;
 }
 
@@ -307,7 +304,6 @@ static Obj DiffFFEVecFFE(Obj elmL, Obj vecR)
         valD = SUM_FFV(valL, valR, succ);
         ptrD[i] = NEW_FFE(fld, valD);
     }
-    /* return the result                                                   */
     return vecD;
 }
 
@@ -368,7 +364,6 @@ static Obj DiffVecFFEFFE(Obj vecL, Obj elmR)
         ptrD[i] = NEW_FFE(fld, valD);
     }
 
-    /* return the result                                                   */
     return vecD;
 }
 
@@ -450,7 +445,6 @@ static Obj DiffVecFFEVecFFE(Obj vecL, Obj vecR)
         for (; i <= len; i++)
             ptrD[i] = ptrL[i];
 
-    /* return the result                                                   */
     return vecD;
 }
 
@@ -509,7 +503,6 @@ static Obj ProdFFEVecFFE(Obj elmL, Obj vecR)
         ptrP[i] = NEW_FFE(fld, valP);
     }
 
-    /* return the result                                                   */
     return vecP;
 }
 
@@ -567,7 +560,6 @@ static Obj ProdVecFFEFFE(Obj vecL, Obj elmR)
         ptrP[i] = NEW_FFE(fld, valP);
     }
 
-    /* return the result                                                   */
     return vecP;
 }
 
@@ -625,7 +617,6 @@ static Obj ProdVecFFEVecFFE(Obj vecL, Obj vecR)
         valS = SUM_FFV(valS, valP, succ);
     }
 
-    /* return the result                                                   */
     return NEW_FFE(fld, valS);
 }
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -257,7 +257,6 @@ static Obj AddPartialGF2VecGF2Vec(Obj sum, Obj vl, Obj vr, UInt n)
         while (ptS < end)
             *ptS++ = *ptL++ ^ *ptR++;
 
-    // return the result
     return sum;
 }
 
@@ -340,7 +339,6 @@ static Obj ProdGF2VecGF2Vec(Obj vl, Obj vr)
         mask <<= 1;
     }
 
-    // return the result
     return (n & 1) ? GF2One : GF2Zero;
 }
 
@@ -407,7 +405,6 @@ static Obj ProdGF2VecGF2Mat(Obj vl, Obj vr)
         }
     }
 
-    // return the result
     return prod;
 }
 
@@ -479,7 +476,6 @@ static Obj ProdGF2MatGF2Vec(Obj ml, Obj vr)
             BLOCK_ELM_GF2VEC(prod, j) |= MASK_POS_GF2VEC(j);
     }
 
-    // return the result
     return prod;
 }
 
@@ -1393,10 +1389,7 @@ static void ConvGF2Vec(Obj list)
 */
 static Obj FuncCONV_GF2VEC(Obj self, Obj list)
 {
-    // check whether <list> is a GF2 vector
     ConvGF2Vec(list);
-
-    // return nothing
     return 0;
 }
 
@@ -1483,9 +1476,7 @@ static Obj NewGF2Vec(Obj list)
 */
 static Obj FuncCOPY_GF2VEC(Obj self, Obj list)
 {
-    // check whether <list> is a GF2 vector
     list = NewGF2Vec(list);
-
     return list;
 }
 
@@ -1537,13 +1528,10 @@ static Obj FuncCONV_GF2MAT(Obj self, Obj list)
 */
 static Obj FuncPLAIN_GF2VEC(Obj self, Obj list)
 {
-    // check whether <list> is a GF2 vector
     if (!IS_GF2VEC_REP(list)) {
         RequireArgument("PLAIN_GF2VEC", list, "must be a GF2 vector");
     }
     PlainGF2Vec(list);
-
-    // return nothing
     return 0;
 }
 
@@ -1826,7 +1814,6 @@ static Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
         }
     }
 
-    // return the result
     return elms;
 }
 
@@ -1890,8 +1877,6 @@ static Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
 static Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
 {
     PlainGF2Mat(list);
-
-    // return nothing
     return 0;
 }
 
@@ -2642,7 +2627,6 @@ static Obj FuncTRANSPOSED_GF2MAT(Obj self, Obj mat)
     UInt imod, nrb, nstart;
     UInt i, j, k, n;
 
-    // check argument
     if (TNUM_OBJ(mat) != T_POSOBJ) {
         ErrorMayQuit("TRANSPOSED_GF2MAT: Need compressed matrix over GF(2)\n",
                      0, 0);
@@ -3771,7 +3755,6 @@ static Obj FuncSEMIECHELON_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3806,7 +3789,6 @@ static Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3837,7 +3819,6 @@ static Obj FuncTRIANGULIZE_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3869,7 +3850,6 @@ static Obj FuncRANK_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3900,7 +3880,6 @@ static Obj FuncDETERMINANT_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
-    // check argts
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;

--- a/src/vector.c
+++ b/src/vector.c
@@ -66,7 +66,6 @@ static Obj SumIntVector(Obj elmL, Obj vecR)
             ptrS[i] = elmS;
     }
 
-    /* return the result                                                   */
     return vecS;
 }
 
@@ -113,7 +112,6 @@ static Obj SumVectorInt(Obj vecL, Obj elmR)
             ptrS[i] = elmS;
     }
 
-    /* return the result                                                   */
     return vecS;
 }
 
@@ -182,7 +180,6 @@ static Obj SumVectorVector(Obj vecL, Obj vecR)
             ptrS[i] = ptrL[i];
         }
 
-    /* return the result                                                   */
     return vecS;
 }
 
@@ -229,7 +226,6 @@ static Obj DiffIntVector(Obj elmL, Obj vecR)
             ptrD[i] = elmD;
     }
 
-    /* return the result                                                   */
     return vecD;
 }
 
@@ -276,7 +272,6 @@ static Obj DiffVectorInt(Obj vecL, Obj elmR)
             ptrD[i] = elmD;
     }
 
-    /* return the result                                                   */
     return vecD;
 }
 
@@ -354,7 +349,6 @@ static Obj DiffVectorVector(Obj vecL, Obj vecR)
             ptrD[i] = ptrL[i];
         }
 
-    /* return the result                                                   */
     return vecD;
 }
 
@@ -401,7 +395,6 @@ static Obj ProdIntVector(Obj elmL, Obj vecR)
             ptrP[i] = elmP;
     }
 
-    /* return the result                                                   */
     return vecP;
 }
 
@@ -448,7 +441,6 @@ static Obj ProdVectorInt(Obj vecL, Obj elmR)
             ptrP[i] = elmP;
     }
 
-    /* return the result                                                   */
     return vecP;
 }
 
@@ -508,7 +500,6 @@ static Obj ProdVectorVector(Obj vecL, Obj vecR)
         elmP = elmS;
     }
 
-    /* return the result                                                   */
     return elmP;
 }
 
@@ -626,7 +617,6 @@ static Obj ProdVectorMatrix(Obj vecL, Obj matR)
         }
     }
 
-    /* return the result                                                   */
     return vecP;
 }
 


### PR DESCRIPTION
Most of the removed comments are similar to one of these:
- 'return the result'
- 'return nothing'
- 'return void'
- 'check the argument'
- 'dispatch
