### PR TITLE
kernel: replace some uses of Char by char

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -70,9 +70,9 @@ typedef struct GAPState {
     // begin interpreted, so the current line is outputted when profiling
     UInt InterpreterStartLine;
 
-    const Char * Prompt;
+    const char * Prompt;
 
-    Char * In;
+    char * In;
 
     /* From stats.c */
     Obj  ReturnObjStat;

--- a/src/io.c
+++ b/src/io.c
@@ -63,7 +63,7 @@ typedef struct {
     Int file;
 
     // the name of the file; this is only used in error messages
-    Char name[256];
+    char name[256];
 
     //
     UInt gapnameid;
@@ -71,7 +71,7 @@ typedef struct {
     // a buffer that holds the current input line; always terminated
     // by the character '\0'. Because 'line' holds only part of the line for
     // very long lines the last character need not be a <newline>.
-    Char line[32768];
+    char line[32768];
 
     // the next line from the stream as GAP string
     Obj sline;
@@ -89,7 +89,7 @@ typedef struct {
     // pointer to the current character within the current line. This is not
     // used for the current input file, where 'In' points to the current
     // character
-    Char * ptr;
+    char * ptr;
 
     //
     UInt symbol;
@@ -122,7 +122,7 @@ typedef struct {
     Obj  stream;
     Int  file;
 
-    Char line[MAXLENOUTPUTLINE];
+    char line[MAXLENOUTPUTLINE];
     Int  pos;
     Int  format;
     Int  indent;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -221,7 +221,7 @@ typedef struct {
 **  'GetIdent' truncates an identifier after that many characters.
 */
     Obj    ValueObj;
-    Char   Value[1024];
+    char   Value[1024];
 
     enum SCANNER_SYMBOLS Symbol;
 


### PR DESCRIPTION
... to make debugging with LLDB a bit easier: that debugger for some reason
does not treat Char and char pointers the same; the latter are printed as C
strings, the former as arrays. With this change, one can e.g. print any
`ScannerState` instance within LLDB and get a nice representation, instead of
flooding the screen with hundreds of lines, including one line for each entry
of `char Value[1024]`.

Actually, I wonder why we even bother to `typedef char Char` in the first place. I am tempted to just replace *all* occurrences of `Char` in the kernel by `char`, except for that typedef (which I'd keep for now, to ensure compatibility with a few packages whose kernel extensions use `Char`). Can anybody think of a reason not to do that (the only one I can think of is "symmetry with `UChar`", but that seems like a weak argument to me; and in any case, my answer would be "so let's get rid of `UChar` as well ;-).

Actually, I can think of one other hypothetical reason: the C standard does not define whether `char` is signed and unsigned, and in the past, implementations doing either existed; this could sometimes cause issues if code relied on `char` being signed. So perhaps the intention was to do `typedef signed char Char`? But fact is: that's not what we do, and never was. So that can't be a reason for this either.