### PR TITLE
kernel: introduce BOOL, TRUE, FALSE

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -316,7 +316,7 @@ static Int LenBlist(Obj list)
 **
 **  'IsbBlist' is the function in 'IsbListFuncs' for boolean lists.
 */
-static Int IsbBlist(Obj list, Int pos)
+static BOOL IsbBlist(Obj list, Int pos)
 {
     return (pos <= LEN_BLIST(list));
 }
@@ -756,7 +756,7 @@ static void PlainBlist(Obj list)
 **  'IsPossBlist' returns  1 if  <list> is  empty, and 0 otherwise, since a
 **  boolean list is a positions list if and only if it is empty.
 */
-static Int IsPossBlist(Obj list)
+static BOOL IsPossBlist(Obj list)
 {
     return LEN_BLIST(list) == 0;
 }
@@ -766,7 +766,7 @@ static Int IsPossBlist(Obj list)
 **
 *F  IsHomogBlist( <list> )  . . . . . . . . . . check if <list> is homogenous
 */
-static Int IsHomogBlist(Obj list)
+static BOOL IsHomogBlist(Obj list)
 {
     return (0 < LEN_BLIST(list));
 }
@@ -776,18 +776,18 @@ static Int IsHomogBlist(Obj list)
 **
 *F  IsSSortBlist( <list> )  . . . . . . .  check if <list> is strictly sorted
 */
-static Int IsSSortBlist(Obj list)
+static BOOL IsSSortBlist(Obj list)
 {
-    Int                 isSort;
+    BOOL isSort;
 
     if ( LEN_BLIST(list) <= 1 ) {
-        isSort = 1;
+        isSort = TRUE;
     }
     else if ( LEN_BLIST(list) == 2 ) {
         isSort = (TEST_BIT_BLIST(list, 1) && !TEST_BIT_BLIST(list, 2));
     }
     else {
-        isSort = 0;
+        isSort = FALSE;
     }
     SET_FILT_LIST( list, (isSort ? FN_IS_SSORT : FN_IS_NSORT) );
 
@@ -894,20 +894,20 @@ UInt COUNT_TRUES_BLOCKS(const UInt * ptr, UInt nblocks)
 **  list that   has no holes  and contains  only  'true' and  'false',  and 0
 **  otherwise.
 */
-static Int IsBlist(Obj list)
+static BOOL IsBlist(Obj list)
 {
-    UInt                isBlist;        /* result of the test              */
+    BOOL                isBlist;        /* result of the test              */
     Int                 len;            /* logical length of the list      */
     UInt                i;              /* loop variable                   */
 
     /* if <list> is known to be a boolean list, it is very easy            */
     if ( IS_BLIST_REP(list) ) {
-        isBlist = 1;
+        isBlist = TRUE;
     }
 
     /* if <list> is not a small list, it isn't a boolean list (convert to list)   */
     else if ( ! IS_SMALL_LIST( list ) ) {
-        isBlist = 0;
+        isBlist = FALSE;
     }
 
     /* otherwise test if there are holes and if all elements are boolean   */
@@ -940,20 +940,20 @@ static Int IsBlist(Obj list)
 **  boolean lists into the compact representation of type 'T_BLIST' described
 **  above.
 */
-static Int IsBlistConv(Obj list)
+static BOOL IsBlistConv(Obj list)
 {
-    UInt                isBlist;        /* result of the test              */
+    BOOL                isBlist;        /* result of the test              */
     Int                 len;            /* logical length of the list      */
     UInt                i;              /* loop variable                   */
 
     /* if <list> is known to be a boolean list, it is very easy            */
     if ( IS_BLIST_REP(list) ) {
-        isBlist = 1;
+        isBlist = TRUE;
     }
 
     /* if <list> is not a list, it isn't a boolean list (convert to list)  */
     else if ( ! IS_SMALL_LIST(list) ) {
-        isBlist = 0;
+        isBlist = FALSE;
     }
 
     /* otherwise test if there are holes and if all elements are boolean   */

--- a/src/blister.h
+++ b/src/blister.h
@@ -27,7 +27,7 @@
 **
 *F  IS_BLIST_REP( <list> )  . . . . .  check if <list> is in boolean list rep
 */
-EXPORT_INLINE Int IS_BLIST_REP(Obj list)
+EXPORT_INLINE BOOL IS_BLIST_REP(Obj list)
 {
     return T_BLIST <= TNUM_OBJ(list) &&
            TNUM_OBJ(list) <= T_BLIST_SSORT + IMMUTABLE;
@@ -47,6 +47,7 @@ EXPORT_INLINE Int SIZE_PLEN_BLIST(Int plen)
     GAP_ASSERT(plen >= 0);
     return sizeof(Obj) + (plen + BIPEB - 1) / BIPEB * sizeof(UInt);
 }
+
 
 /****************************************************************************
 **

--- a/src/calls.c
+++ b/src/calls.c
@@ -991,9 +991,9 @@ void PrintFunction (
     Int                 narg;           /* number of arguments             */
     Int                 nloc;           /* number of locals                */
     UInt                i;              /* loop variable                   */
-    UInt                isvarg;         /* does function have varargs?     */
+    BOOL                isvarg;         /* does function have varargs?     */
 
-    isvarg = 0;
+    isvarg = FALSE;
 
     if ( IS_OPERATION(func) ) {
       CALL_1ARGS( PrintOperation, func );
@@ -1014,7 +1014,7 @@ void PrintFunction (
     /* print the arguments                                                 */
     narg = NARG_FUNC(func);
     if (narg < 0) {
-      isvarg = 1;
+      isvarg = TRUE;
       narg = -narg;
     }
     
@@ -1527,7 +1527,7 @@ static Obj FuncIsKernelFunction(Obj self, Obj func)
     return IsKernelFunction(func) ? True : False;
 }
 
-Int IsKernelFunction(Obj func)
+BOOL IsKernelFunction(Obj func)
 {
     GAP_ASSERT(IS_FUNC(func));
     return (BODY_FUNC(func) == 0) ||

--- a/src/calls.h
+++ b/src/calls.h
@@ -223,7 +223,7 @@ EXPORT_INLINE void SET_LCKS_FUNC(Obj func, Obj locks)
 **  'IsKernelFunction' returns 1 if <func> is a kernel function (i.e.
 **  compiled from C code), and 0 otherwise.
 */
-Int IsKernelFunction(Obj func);
+BOOL IsKernelFunction(Obj func);
 
 
 EXPORT_INLINE ObjFunc_0ARGS HDLR_0ARGS(Obj func)
@@ -271,7 +271,7 @@ EXPORT_INLINE ObjFunc_1ARGS HDLR_XARGS(Obj func)
 **
 *F  IS_FUNC( <obj> )  . . . . . . . . . . . . . check if object is a function
 */
-EXPORT_INLINE int IS_FUNC(Obj obj)
+EXPORT_INLINE BOOL IS_FUNC(Obj obj)
 {
     return TNUM_OBJ(obj) == T_FUNCTION;
 }

--- a/src/code.h
+++ b/src/code.h
@@ -381,7 +381,7 @@ void SET_VISITED_STAT(Stat stat);
 **  'LVAR_REF_LVAR' returns the local variable (by its index) to which <expr>
 **  is a (immediate) reference.
 */
-EXPORT_INLINE Int IS_REF_LVAR(Expr expr)
+EXPORT_INLINE BOOL IS_REF_LVAR(Expr expr)
 {
     return ((Int)expr & 0x03) == 0x03;
 }
@@ -412,7 +412,7 @@ EXPORT_INLINE Int LVAR_REF_LVAR(Expr expr)
 **  'INT_INTEXPR' converts the (immediate) integer  expression <expr> to a  C
 **  integer.
 */
-EXPORT_INLINE Int IS_INTEXPR(Expr expr)
+EXPORT_INLINE BOOL IS_INTEXPR(Expr expr)
 {
     return ((Int)expr & 0x03) == 0x01;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -84,6 +84,11 @@ typedef uintptr_t UInt;
 GAP_STATIC_ASSERT(sizeof(void *) == sizeof(Int), "sizeof(Int) is wrong");
 GAP_STATIC_ASSERT(sizeof(void *) == sizeof(UInt), "sizeof(UInt) is wrong");
 
+// FIXME: workaround a conflict with the Semigroups package
+#undef BOOL
+typedef Int BOOL; // TODO: should be changed to `char` once packages adapted
+enum { FALSE = 0, TRUE = 1 };
+
 
 /****************************************************************************
 **

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -320,22 +320,22 @@ static void MergeInfoCVars(Bag dst, Bag src)
     }
 }
 
-static Int IsEqInfoCVars(Bag dst, Bag src)
+static BOOL IsEqInfoCVars(Bag dst, Bag src)
 {
     Int                 i;
     if ( SIZE_BAG(dst) < SIZE_BAG(src) )  ResizeBag( dst, SIZE_BAG(src) );
     if ( SIZE_BAG(src) < SIZE_BAG(dst) )  ResizeBag( src, SIZE_BAG(dst) );
     for ( i = 1; i <= NLVAR_INFO(src); i++ ) {
         if ( TNUM_LVAR_INFO(dst,i) != TNUM_LVAR_INFO(src,i) ) {
-            return 0;
+            return FALSE;
         }
     }
     for ( i = 1; i <= NTEMP_INFO(dst) && i <= NTEMP_INFO(src); i++ ) {
         if ( TNUM_TEMP_INFO(dst,i) != TNUM_TEMP_INFO(src,i) ) {
-            return 0;
+            return FALSE;
         }
     }
-    return 1;
+    return TRUE;
 }
 
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -634,7 +634,7 @@ static Obj Cyclotomic(UInt n, UInt m)
     UInt                p;              /* prime factor                    */
     static UInt         lastN;          /* rember last n, dont recompute:  */
     static UInt         phi;            /* Euler phi(n)                    */
-    static UInt         isSqfree;       /* is n squarefree?                */
+    static BOOL         isSqfree;       /* is n squarefree?                */
     static UInt         nrp;            /* number of its prime factors     */
 
     /* get a pointer to the cyclotomic and a copy of n to factor           */
@@ -672,12 +672,13 @@ static Obj Cyclotomic(UInt n, UInt m)
     if ( n != lastN ) {
         lastN = n;
         phi = n;  k = n;
-        isSqfree = 1;
+        isSqfree = TRUE;
         nrp = 0;
         for ( p = 2; p <= k; p++ ) {
             if ( k % p == 0 ) {
                 phi = phi * (p-1) / p;
-                if ( k % (p*p) == 0 )  isSqfree = 0;
+                if (k % (p * p) == 0)
+                    isSqfree = FALSE;
                 nrp++;
                 while ( k % p == 0 )  k = k / p;
             }

--- a/src/cyclotom.h
+++ b/src/cyclotom.h
@@ -24,7 +24,7 @@
 **  'IS_CYC' returns 1 if the argument object's tnum indicates that it is an
 **  internal integer, rational or (proper) cyclotomic object, otherwise 0.
 */
-EXPORT_INLINE Int IS_CYC(Obj o)
+EXPORT_INLINE BOOL IS_CYC(Obj o)
 {
     return TNUM_OBJ(o) <= T_CYC;
 }

--- a/src/gap.h
+++ b/src/gap.h
@@ -106,7 +106,7 @@ enum {
 **
 *F  IsUsingLibGap()  . . . . . . . . 1 if GAP is being used a library, else 0
 */
-int IsUsingLibGap(void);
+BOOL IsUsingLibGap(void);
 
 /****************************************************************************
 **

--- a/src/gaputils.h
+++ b/src/gaputils.h
@@ -30,7 +30,14 @@
 #define ARRAY_SIZE(arr)     ( sizeof(arr) / sizeof((arr)[0]) )
 
 
-EXPORT_INLINE Int AlwaysYes(Obj obj) { return 1; }
-EXPORT_INLINE Int AlwaysNo(Obj obj) { return 0; }
+EXPORT_INLINE BOOL AlwaysYes(Obj obj)
+{
+    return TRUE;
+}
+
+EXPORT_INLINE BOOL AlwaysNo(Obj obj)
+{
+    return FALSE;
+}
 
 #endif // GAP_UTILS_H

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -442,7 +442,7 @@ UInt                    NrHalfDeadBags;
 **
 *F  IS_BAG_ID -- check if a value looks like a masterpointer id
 */
-static inline UInt IS_BAG_ID(void * ptr)
+static inline BOOL IS_BAG_ID(void * ptr)
 {
     return (((void *)MptrBags <= ptr) && (ptr < (void *)MptrEndBags) &&
             ((UInt)ptr & (sizeof(Bag) - 1)) == 0);
@@ -452,7 +452,7 @@ static inline UInt IS_BAG_ID(void * ptr)
 **
 *F  IS_BAG_BODY -- check if value like a pointer to a bag body
 */
-static inline UInt IS_BAG_BODY(void * ptr)
+static inline BOOL IS_BAG_BODY(void * ptr)
 {
     return (((void *)OldBags <= ptr) && (ptr < (void *)AllocBags) &&
             ((UInt)ptr & (sizeof(Bag) - 1)) == 0);
@@ -606,17 +606,17 @@ static inline Bag MARKED_HALFDEAD(Bag x)
     return (Bag)((UInt)x | HALFDEAD);
 }
 
-static inline Int IS_MARKED_DEAD(Bag x)
+static inline BOOL IS_MARKED_DEAD(Bag x)
 {
     return LINK_BAG(x) == MARKED_DEAD(x);
 }
 
-// static inline Int IS_MARKED_ALIVE(Bag x)
+// static inline BOOL IS_MARKED_ALIVE(Bag x)
 // {
 //     return LINK_BAG(x) == MARKED_ALIVE(x);
 // }
 
-static inline Int IS_MARKED_HALFDEAD(Bag x)
+static inline BOOL IS_MARKED_HALFDEAD(Bag x)
 {
     return LINK_BAG(x) == MARKED_HALFDEAD(x);
 }
@@ -685,12 +685,12 @@ void MarkBagWeakly(Bag bag)
     }
 }
 
-Int IsWeakDeadBag(Bag bag)
+BOOL IsWeakDeadBag(Bag bag)
 {
     CANARY_DISABLE_VALGRIND();
-    Int isWeakDeadBag = (((UInt)bag & (sizeof(Bag) - 1)) == 0) &&
-                        (Bag)MptrBags <= bag && bag < (Bag)MptrEndBags &&
-                        (((UInt)*bag) & (sizeof(Bag) - 1)) == 1;
+    BOOL isWeakDeadBag = (((UInt)bag & (sizeof(Bag) - 1)) == 0) &&
+                         (Bag)MptrBags <= bag && bag < (Bag)MptrEndBags &&
+                         (((UInt)*bag) & (sizeof(Bag) - 1)) == 1;
     CANARY_ENABLE_VALGRIND();
     return isWeakDeadBag;
 }
@@ -708,7 +708,7 @@ void CallbackForAllBags(void (*func)(Bag))
 {
     for (Bag bag = (Bag)MptrBags; bag < (Bag)MptrEndBags; bag++) {
         CANARY_DISABLE_VALGRIND();
-        Int is_bag = IS_BAG_BODY(*bag);
+        BOOL is_bag = IS_BAG_BODY(*bag);
         CANARY_ENABLE_VALGRIND();
         if (is_bag) {
             (*func)(bag);

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -190,7 +190,7 @@ EXPORT_INLINE void CLEAR_BAG_FLAG(Bag bag, uint8_t flag)
 **
 **  See also 'IS_INTOBJ' and 'IS_FFE'.
 */
-EXPORT_INLINE Int IS_BAG_REF(Obj bag)
+EXPORT_INLINE BOOL IS_BAG_REF(Obj bag)
 {
     return bag && !((Int)bag & 0x03);
 }
@@ -358,7 +358,7 @@ EXPORT_INLINE void CHANGED_BAG(Bag bag)
 
 void CHANGED_BAG(Bag bag);
 
-int IsGapObj(void *);
+BOOL IsGapObj(void *);
 
 #elif defined(GAP_MEMORY_CANARY)
 

--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -122,7 +122,7 @@ void MarkBagWeakly(Bag bag);
 **  an object which was freed as the only references to it were weak.
 **  This is used for implement weak pointer references.
 */
-Int IsWeakDeadBag(Bag bag);
+BOOL IsWeakDeadBag(Bag bag);
 
 /****************************************************************************
 **

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -880,8 +880,7 @@ static Obj FuncMakeReadWriteGVar(Obj self, Obj name)
 **
 *F  IsReadOnlyGVar( <gvar> ) . . . . . . return status of a global variable
 */
-Int IsReadOnlyGVar (
-    UInt                gvar )
+BOOL IsReadOnlyGVar(UInt gvar)
 {
     return GetGVarFlagInfo(gvar).gvarWriteFlag == GVarReadOnly;
 }
@@ -904,7 +903,7 @@ static Obj FuncIsReadOnlyGVar (
 **
 *F  IsConstantGVar( <gvar> ) . . . . . . return if a variable is a constant
 */
-Int IsConstantGVar(UInt gvar)
+BOOL IsConstantGVar(UInt gvar)
 {
     return GetGVarFlagInfo(gvar).gvarWriteFlag == GVarConstant;
 }
@@ -976,9 +975,7 @@ static Obj FuncAUTO(Obj self, Obj args)
 *F  iscomplete( <name>, <len> ) . . . . . . . .  find the completions of name
 *F  completion( <name>, <len> ) . . . . . . . .  find the completions of name
 */
-UInt            iscomplete_gvar (
-    Char *              name,
-    UInt                len )
+BOOL iscomplete_gvar(Char * name, UInt len)
 {
     const Char *        curr;
     UInt                i, k;
@@ -988,9 +985,10 @@ UInt            iscomplete_gvar (
     for ( i = 1; i <= numGVars; i++ ) {
         curr = CONST_CSTR_STRING( NameGVar( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
-        if ( k == len && curr[k] == '\0' )  return 1;
+        if (k == len && curr[k] == '\0')
+            return TRUE;
     }
-    return 0;
+    return FALSE;
 }
 
 UInt            completion_gvar (

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -135,7 +135,7 @@ UInt GVarName(const Char * name);
 **
 *F  iscomplete_gvar( <name>, <len> )  . . . . . . . . . . . . .  check <name>
 */
-UInt iscomplete_gvar(Char * name, UInt len);
+BOOL iscomplete_gvar(Char * name, UInt len);
 
 
 /****************************************************************************
@@ -165,9 +165,9 @@ void MakeConstantGVar(UInt gvar);
 void MakeThreadLocalVar(UInt gvar, UInt rnam);
 #endif
 
-Int IsReadOnlyGVar(UInt gvar);
+BOOL IsReadOnlyGVar(UInt gvar);
 
-Int IsConstantGVar(UInt gvar);
+BOOL IsConstantGVar(UInt gvar);
 
 
 /****************************************************************************

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -895,7 +895,7 @@ void UnbARecord(Obj record, UInt rnam) {
    SetARecordField(record, rnam, Undefined);
 }
 
-Int IsbARecord(Obj record, UInt rnam)
+BOOL IsbARecord(Obj record, UInt rnam)
 {
   return GetARecordField(record, rnam) != (Obj) 0;
 }
@@ -1032,7 +1032,7 @@ static void UnbTLRecord(Obj record, UInt rnam)
 }
 
 
-static Int IsbTLRecord(Obj record, UInt rnam)
+static BOOL IsbTLRecord(Obj record, UInt rnam)
 {
   return GetTLRecordField(record, rnam) != (Obj) 0;
 }
@@ -1244,7 +1244,8 @@ Obj ElmAList(Obj list, Int pos)
   return result;
 }
 
-static Int IsbAList(Obj list, Int pos) {
+static BOOL IsbAList(Obj list, Int pos)
+{
   const AtomicObj *addr = CONST_ADDR_ATOM(list);
   UInt len;
   MEMBAR_READ();

--- a/src/hpc/aobjects.h
+++ b/src/hpc/aobjects.h
@@ -23,7 +23,7 @@ Obj NewAtomicRecord(UInt capacity);
 Obj SetARecordField(Obj record, UInt field, Obj obj);
 Obj GetARecordField(Obj record, UInt field);
 Obj ElmARecord(Obj record, UInt rnam);
-Int IsbARecord(Obj record, UInt rnam);
+BOOL IsbARecord(Obj record, UInt rnam);
 void AssARecord(Obj record, UInt rnam, Obj value);
 void UnbARecord(Obj record, UInt rnam);
 

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -251,7 +251,7 @@ static Obj DeserializeBinary(UInt tnum)
     return result;
 }
 
-static inline int IsBasicObj(Obj obj)
+static inline BOOL IsBasicObj(Obj obj)
 {
     // FIXME: hard coding T_MACFLOAT like this seems like a bad idea
     return !obj || TNUM_OBJ(obj) <= T_MACFLOAT;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -1344,7 +1344,7 @@ static Obj FuncCreateChannel(Obj self, Obj args)
     return CreateChannel(capacity);
 }
 
-static int IsChannel(Obj obj)
+static BOOL IsChannel(Obj obj)
 {
     return obj && TNUM_OBJ(obj) == T_CHANNEL;
 }
@@ -1427,7 +1427,7 @@ static Obj FuncReceiveChannel(Obj self, Obj channel)
     return ReceiveChannel(ObjPtr(channel));
 }
 
-static int IsChannelList(Obj list)
+static BOOL IsChannelList(Obj list)
 {
     int len = LEN_PLIST(list);
     int i;
@@ -1632,7 +1632,7 @@ static Obj FuncCreateBarrier(Obj self)
     return CreateBarrier();
 }
 
-static int IsBarrier(Obj obj)
+static BOOL IsBarrier(Obj obj)
 {
     return obj && TNUM_OBJ(obj) == T_BARRIER;
 }
@@ -1712,7 +1712,7 @@ static Obj SyncIsBound(SyncVar * var)
     return var->value ? True : False;
 }
 
-static int IsSyncVar(Obj var)
+static BOOL IsSyncVar(Obj var)
 {
     return var && TNUM_OBJ(var) == T_SYNCVAR;
 }

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -35,7 +35,7 @@ struct TraversalState {
     UInt                    hashBits;
     Region *                region;
     int                     border;
-    int (*traversalCheck)(TraversalState *, Obj);
+    BOOL (*traversalCheck)(TraversalState *, Obj);
 };
 
 static Obj NewList(UInt size)
@@ -159,7 +159,7 @@ void QueueForTraversal(TraversalState * traversal, Obj obj)
 
 static void TraverseRegionFrom(TraversalState * traversal,
                         Obj              obj,
-                        int (*traversalCheck)(TraversalState *, Obj))
+                        BOOL (*traversalCheck)(TraversalState *, Obj))
 {
     GAP_ASSERT(IS_BAG_REF(obj));
     GAP_ASSERT(REGION(obj) != NULL);
@@ -204,24 +204,24 @@ static void TraverseRegionFrom(TraversalState * traversal,
 //   return CheckReadAccess(obj);
 // }
 
-static int IsSameRegion(TraversalState * traversal,Obj obj)
+static BOOL IsSameRegion(TraversalState * traversal, Obj obj)
 {
     return REGION(obj) == traversal->region;
 }
 
-static int IsMutable(TraversalState * traversal, Obj obj)
+static BOOL IsMutable(TraversalState * traversal, Obj obj)
 {
     return CheckReadAccess(obj) && IS_MUTABLE_OBJ(obj);
 }
 
-static int IsWritableOrImmutable(TraversalState * traversal, Obj obj)
+static BOOL IsWritableOrImmutable(TraversalState * traversal, Obj obj)
 {
     int writable = CheckExclusiveWriteAccess(obj);
     if (!writable && IS_MUTABLE_OBJ(obj)) {
         traversal->border = 1;
-        return 0;
+        return FALSE;
     }
-    return 1;
+    return TRUE;
 }
 
 Obj ReachableObjectsFrom(Obj obj)

--- a/src/integer.c
+++ b/src/integer.c
@@ -455,15 +455,15 @@ Obj GMP_REDUCE(Obj op)
 **
 */
 #if DEBUG_GMP
-static int IS_NORMALIZED_AND_REDUCED(Obj op, const char * func, int line)
+static BOOL IS_NORMALIZED_AND_REDUCED(Obj op, const char * func, int line)
 {
   mp_size_t size;
   if ( IS_INTOBJ( op ) ) {
-    return 1;
+    return TRUE;
   }
   if ( !IS_LARGEINT( op ) ) {
     /* ignore non-integers */
-    return 0;
+    return FALSE;
   }
   for ( size = SIZE_INT(op); size != (mp_size_t)1; size-- ) {
     if ( CONST_ADDR_INT(op)[(size - 1)] != 0 ) {
@@ -478,15 +478,15 @@ static int IS_NORMALIZED_AND_REDUCED(Obj op, const char * func, int line)
          ( IS_INTNEG(op) && VAL_LIMB0(op) == -INT_INTOBJ_MIN ) ) {
       if ( IS_INTNEG(op) ) {
         Pr("WARNING: non-reduced negative gmp value (%s:%d)\n",(Int)func,line);
-        return 0;
+        return FALSE;
       }
       else {
         Pr("WARNING: non-reduced positive gmp value (%s:%d)\n",(Int)func,line);
-        return 0;
+        return FALSE;
       }
     }
   }
-  return 1;
+  return TRUE;
 }
 #endif
 

--- a/src/integer.h
+++ b/src/integer.h
@@ -21,7 +21,7 @@
 **  'IS_LARGEINT' returns 1 if 'obj' is large positive or negative integer
 **  object, and 0 for all other kinds of objects.
 */
-EXPORT_INLINE Int IS_LARGEINT(Obj obj)
+EXPORT_INLINE BOOL IS_LARGEINT(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return tnum == T_INTPOS || tnum == T_INTNEG;
@@ -33,7 +33,7 @@ EXPORT_INLINE Int IS_LARGEINT(Obj obj)
 **  'IS_INT' returns 1 if 'obj' is either a large or an immediate integer
 **  object, and 0 for all other kinds of objects.
 */
-EXPORT_INLINE Int IS_INT(Obj obj)
+EXPORT_INLINE BOOL IS_INT(Obj obj)
 {
     return IS_INTOBJ(obj) || IS_LARGEINT(obj);
 }
@@ -73,7 +73,7 @@ EXPORT_INLINE UInt SIZE_INT(Obj obj)
 **  'IS_NEG_INT' returns 1 if 'obj' is a negative large or immediate
 **  integer object, and 0 for all other kinds of objects.
 */
-EXPORT_INLINE Int IS_NEG_INT(Obj obj)
+EXPORT_INLINE BOOL IS_NEG_INT(Obj obj)
 {
     if (IS_INTOBJ(obj))
         return (Int)obj < (Int)INTOBJ_INT(0);
@@ -85,7 +85,7 @@ EXPORT_INLINE Int IS_NEG_INT(Obj obj)
 **  'IS_POS_INT' returns 1 if 'obj' is a positive large or immediate
 **  integer object, and 0 for all other kinds of objects.
 */
-EXPORT_INLINE Int IS_POS_INT(Obj obj)
+EXPORT_INLINE BOOL IS_POS_INT(Obj obj)
 {
     if (IS_INTOBJ(obj))
         return (Int)obj > (Int)INTOBJ_INT(0);
@@ -97,7 +97,7 @@ EXPORT_INLINE Int IS_POS_INT(Obj obj)
 **  'IS_ODD_INT' returns 1 if 'obj' is an odd large or immediate integer
 **  object, and 0 for all other kinds of objects.
 */
-EXPORT_INLINE Int IS_ODD_INT(Obj obj)
+EXPORT_INLINE BOOL IS_ODD_INT(Obj obj)
 {
     if (IS_INTOBJ(obj))
         return ((Int)obj & 4) != 0;
@@ -110,7 +110,7 @@ EXPORT_INLINE Int IS_ODD_INT(Obj obj)
 **  'IS_EVEN_INT' returns 1 if 'obj' is an even large or immediate integer
 **  object, and 0 for all other kinds of objects.
 */
-EXPORT_INLINE Int IS_EVEN_INT(Obj obj)
+EXPORT_INLINE BOOL IS_EVEN_INT(Obj obj)
 {
     return !IS_ODD_INT(obj);
 }

--- a/src/intobj.h
+++ b/src/intobj.h
@@ -56,7 +56,7 @@ enum {
 **  'IS_INTOBJ' returns 1 if the object <o> is an (immediate) integer object,
 **  and 0 otherwise.
 */
-EXPORT_INLINE Int IS_INTOBJ(Obj o)
+EXPORT_INLINE BOOL IS_INTOBJ(Obj o)
 {
     return (Int)o & 0x01;
 }
@@ -69,7 +69,7 @@ EXPORT_INLINE Int IS_INTOBJ(Obj o)
 **  'IS_POS_INTOBJ' returns 1 if the object <o> is an (immediate) integer
 **  object encoding a positive integer, and 0 otherwise.
 */
-EXPORT_INLINE Int IS_POS_INTOBJ(Obj o)
+EXPORT_INLINE BOOL IS_POS_INTOBJ(Obj o)
 {
     return ((Int)o & 0x01) && ((Int)o > 0x01);
 }
@@ -81,7 +81,7 @@ EXPORT_INLINE Int IS_POS_INTOBJ(Obj o)
 **  'IS_NONNEG_INTOBJ' returns 1 if the object <o> is an (immediate) integer
 **  object encoding a non-negative integer, and 0 otherwise.
 */
-EXPORT_INLINE Int IS_NONNEG_INTOBJ(Obj o)
+EXPORT_INLINE BOOL IS_NONNEG_INTOBJ(Obj o)
 {
     return ((Int)o & 0x01) && ((Int)o > 0);
 }

--- a/src/io.c
+++ b/src/io.c
@@ -50,10 +50,10 @@
 */
 typedef struct {
     // non-zero if input comes from a stream
-    UInt isstream;
+    BOOL isstream;
 
     // non-zero if input come from a string stream
-    UInt isstringstream;
+    BOOL isstringstream;
 
     // if input comes from a stream, this points to a GAP IsInputStream object
     Obj stream;
@@ -80,7 +80,7 @@ typedef struct {
     Int spos;
 
     //
-    UInt echo;
+    BOOL echo;
 
 
     // The following variables are used to store the state of the interpreter
@@ -114,8 +114,8 @@ typedef struct {
 /* the maximal number of used line break hints */
 #define MAXHINTS 100
 typedef struct {
-    UInt isstream;
-    UInt isstringstream;
+    BOOL isstream;
+    BOOL isstringstream;
     Obj  stream;
     Int  file;
 
@@ -218,7 +218,7 @@ void LockCurrentOutput(Int lock)
 */
 
 
-static inline Int IS_CHAR_PUSHBACK_EMPTY(void)
+static inline BOOL IS_CHAR_PUSHBACK_EMPTY(void)
 {
     return STATE(In) != &IO()->Pushback;
 }

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -534,7 +534,7 @@ static void TryMarkRange(void * start, void * end)
     }
 }
 
-int IsGapObj(void * p)
+BOOL IsGapObj(void * p)
 {
     return jl_typeis(p, datatype_mptr);
 }

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -36,9 +36,9 @@
 #include "streams.h"
 #include "stringobj.h"
 
-static int UsingLibGap = 0;
+static BOOL UsingLibGap = FALSE;
 
-int IsUsingLibGap(void)
+BOOL IsUsingLibGap(void)
 {
     return UsingLibGap;
 }
@@ -53,7 +53,7 @@ void GAP_Initialize(int              argc,
                     GAP_CallbackFunc errorCallback,
                     int              handleSignals)
 {
-    UsingLibGap = 1;
+    UsingLibGap = TRUE;
 
     InitializeGap(&argc, argv, handleSignals);
     SetExtraMarkFuncBags(markBagsCallback);

--- a/src/lists.c
+++ b/src/lists.c
@@ -51,7 +51,7 @@
 **  'IS_LIST' only calls the function pointed  to  by  'IsListFuncs[<type>]',
 **  passing <obj> as argument.
 */
-Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 static Obj IsListFilt;
 
@@ -60,7 +60,7 @@ static Obj FiltIS_LIST(Obj self, Obj obj)
     return (IS_LIST( obj ) ? True : False);
 }
 
-static Int IsListObject(Obj obj)
+static BOOL IsListObject(Obj obj)
 {
     return (DoFilter( IsListFilt, obj ) == True);
 }
@@ -77,18 +77,18 @@ static Int IsListObject(Obj obj)
 **  This is, in some sense, a workaround for the not yet implemented features
 **  below (see LENGTH).
 */
-Int             (*IsSmallListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 static Obj IsSmallListFilt;
 static Obj HasIsSmallListFilt;
 static Obj LengthAttr;
 static Obj SetIsSmallList;
 
-static Int IsSmallListObject(Obj obj)
+static BOOL IsSmallListObject(Obj obj)
 {
   Obj len;
   if (DoFilter(IsListFilt, obj) != True)
-    return 0;
+    return FALSE;
   if (DoFilter(HasIsSmallListFilt, obj) == True)
     return DoFilter(IsSmallListFilt, obj) == True;
   if (DoTestAttribute(LengthAttr, obj) == True)
@@ -97,12 +97,12 @@ static Int IsSmallListObject(Obj obj)
       if (IS_INTOBJ(len))
         {
           CALL_2ARGS(SetIsSmallList, obj, True);
-          return 1;
+          return TRUE;
         }
       else
         {
           CALL_2ARGS(SetIsSmallList, obj, False);
-          return 0;
+          return FALSE;
         }
     }
   return 0;
@@ -256,7 +256,7 @@ static Obj LengthInternal(Obj obj)
 **  list, then 'IsbListFuncs[<type>]' points to 'IsbListError', which signals
 **  the error.
 */
-Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
+BOOL (*IsbListFuncs[LAST_REAL_TNUM + 1])(Obj list, Int pos);
 
 static Obj             IsbListOper;
 
@@ -268,24 +268,22 @@ static Obj FuncISB_LIST(Obj self, Obj list, Obj pos)
         return ISBB_LIST( list, pos ) ? True : False;
 }
 
-static Int IsbListError(Obj list, Int pos)
+static BOOL IsbListError(Obj list, Int pos)
 {
     RequireArgument("IsBound", list, "must be a list");
 }
 
-static Int IsbListObject(Obj list, Int pos)
+static BOOL IsbListObject(Obj list, Int pos)
 {
     return DoOperation2Args( IsbListOper, list, INTOBJ_INT(pos) ) == True;
 }
 
-Int             ISBB_LIST (
-    Obj                 list,
-    Obj                 pos )
+BOOL ISBB_LIST(Obj list, Obj pos)
 {
     return DoOperation2Args( IsbListOper, list, pos ) == True;
 }
 
-Int ISB_MAT(Obj mat, Obj row, Obj col)
+BOOL ISB_MAT(Obj mat, Obj row, Obj col)
 {
     return DoOperation3Args(IsbListOper, mat, row, col) == True;
 }
@@ -996,7 +994,7 @@ static Obj FuncASSS_LIST_DEFAULT(Obj self, Obj list, Obj poss, Obj objs)
 **  the   type  of  a    list,  then  'IsDenseListFuncs[<type>]'  points   to
 **  'AlwaysNo', which just returns 0.
 */
-Int             (*IsDenseListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 static Obj IsDenseListFilt;
 
@@ -1005,7 +1003,7 @@ static Obj FiltIS_DENSE_LIST(Obj self, Obj obj)
     return (IS_DENSE_LIST( obj ) ? True : False);
 }
 
-static Int IsDenseListObject(Obj obj)
+static BOOL IsDenseListObject(Obj obj)
 {
     return (DoFilter( IsDenseListFilt, obj ) == True);
 }
@@ -1022,7 +1020,7 @@ static Int IsDenseListObject(Obj obj)
 **  'AlwaysNo', which just returns 0.
 **
 */
-Int             (*IsHomogListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 static Obj IsHomogListFilt;
 
@@ -1031,7 +1029,7 @@ static Obj FiltIS_HOMOG_LIST(Obj self, Obj obj)
     return (IS_HOMOG_LIST( obj ) ? True : False);
 }
 
-static Int IsHomogListObject(Obj obj)
+static BOOL IsHomogListObject(Obj obj)
 {
     return (DoFilter( IsHomogListFilt, obj ) == True);
 }
@@ -1047,7 +1045,7 @@ static Int IsHomogListObject(Obj obj)
 **  the type of a list, then 'IsTableListFuncs[<type>]' points to
 **  'AlwaysNo', which just returns 0.
 */
-Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsTableListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 static Obj IsTableListFilt;
 
@@ -1056,7 +1054,7 @@ static Obj FiltIS_TABLE_LIST(Obj self, Obj obj)
     return (IS_TABLE_LIST( obj ) ? True : False);
 }
 
-static Int IsTableListObject(Obj obj)
+static BOOL IsTableListObject(Obj obj)
 {
     return (DoFilter( IsTableListFilt, obj ) == True);
 }
@@ -1073,7 +1071,7 @@ static Int IsTableListObject(Obj obj)
 **  points to 'AlwaysNo', which just returns 0.
 **
 */
-Int (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsSSortListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 static Obj IsSSortListProp;
 
@@ -1082,8 +1080,7 @@ static Obj PropIS_SSORT_LIST(Obj self, Obj obj)
     return (IS_SSORT_LIST( obj ) ? True : False);
 }
 
-static Int IsSSortListDefault (
-    Obj                 list )
+static BOOL IsSSortListDefault(Obj list)
 {
     Int                 lenList;
     Obj                 elm1;
@@ -1095,33 +1092,33 @@ static Int IsSSortListDefault (
 
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
-        return 2;
+        return TRUE;
     }
 
     /* get the first element                                               */
     elm1 = ELM0_LIST(list, 1);
 
     if (!elm1) {
-        return 0;
+        return FALSE;
     }
 
     /* compare each element with its precursor                             */
     for ( i = 2; i <= lenList; i++ ) {
         elm2 = ELM0_LIST(list, i);
         if (!elm2) {
-            return 0;
+            return FALSE;
         }
         if ( ! LT( elm1, elm2 ) ) {
-            return 0;
+            return FALSE;
         }
         elm1 = elm2;
     }
 
     /* the list is strictly sorted                                         */
-    return 2;
+    return TRUE;
 }
 
-static Int IsSSortListObject(Obj obj)
+static BOOL IsSSortListObject(Obj obj)
 {
     return (DoProperty( IsSSortListProp, obj ) == True);
 }
@@ -1142,7 +1139,7 @@ static Obj FuncIS_SSORT_LIST_DEFAULT(Obj self, Obj obj)
 **  the   type    of a   list,    then  'IsPossListFuncs[<type>]'   points to
 **  'NotIsPossList', which just returns 0.
 */
-Int             (*IsPossListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+BOOL (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
 static Obj IsPossListProp;
 
@@ -1151,7 +1148,7 @@ static Obj PropIS_POSS_LIST(Obj self, Obj obj)
     return (IS_POSS_LIST(obj) ? True : False);
 }
 
-static Int IsPossListDefault(Obj list)
+static BOOL IsPossListDefault(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -1166,25 +1163,25 @@ static Int IsPossListDefault(Obj list)
 
         /* if it has a hole then it isn't a poss list */
         if ( elm == 0)
-          return 0;
+          return FALSE;
 
         /* if it's a small integer and non-positive then
            it's not a poss list */
         if ( IS_INTOBJ(elm)) {
           if (INT_INTOBJ(elm) <= 0)
-            return 0;
+            return FALSE;
         }
         /* or if it's not a small integer or a positive large integer then it's
            not a poss list */
         else if (TNUM_OBJ(elm) != T_INTPOS)
-          return 0;
+          return FALSE;
     }
 
     /* the list is a positions list                                        */
-    return 1;
+    return TRUE;
 }
 
-static Int IsPossListObject(Obj obj)
+static BOOL IsPossListObject(Obj obj)
 {
     return (DoProperty( IsPossListProp, obj ) == True);
 }

--- a/src/lists.h
+++ b/src/lists.h
@@ -35,9 +35,9 @@
 **  vector type must set  it to '2'.  A  package implementing a matrix  type
 **  must set it to '3'.
 */
-extern  Int             (*IsListFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-EXPORT_INLINE Int IS_LIST(Obj obj)
+EXPORT_INLINE BOOL IS_LIST(Obj obj)
 {
     return (*IsListFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -57,9 +57,9 @@ EXPORT_INLINE Int IS_LIST(Obj obj)
 **  instead it will check if the object HasIsSmallList and IsSmallList, or
 **  HasLength in which case Length will be checked
 */
-extern Int (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
+extern BOOL (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-EXPORT_INLINE Int IS_SMALL_LIST(Obj obj)
+EXPORT_INLINE BOOL IS_SMALL_LIST(Obj obj)
 {
     return (*IsSmallListFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -78,9 +78,9 @@ EXPORT_INLINE Int IS_SMALL_LIST(Obj obj)
 **  already that the list is dense (e.g. for sets).
 */
 
-extern Int (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+extern BOOL (*IsDenseListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-EXPORT_INLINE Int IS_DENSE_LIST(Obj list)
+EXPORT_INLINE BOOL IS_DENSE_LIST(Obj list)
 {
     return (*IsDenseListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -101,9 +101,9 @@ EXPORT_INLINE Int IS_DENSE_LIST(Obj list)
 **  homogeneous (e.g. for sets).
 */
 
-extern Int (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+extern BOOL (*IsHomogListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-EXPORT_INLINE Int IS_HOMOG_LIST(Obj list)
+EXPORT_INLINE BOOL IS_HOMOG_LIST(Obj list)
 {
     return (*IsHomogListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -125,9 +125,9 @@ EXPORT_INLINE Int IS_HOMOG_LIST(Obj list)
 **  acceptable (e.g. a range with positive <low> and <high> values).
 */
 
-extern Int (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
+extern BOOL (*IsPossListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-EXPORT_INLINE Int IS_POSS_LIST(Obj list)
+EXPORT_INLINE BOOL IS_POSS_LIST(Obj list)
 {
     return (*IsPossListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -182,16 +182,16 @@ EXPORT_INLINE Obj LENGTH(Obj list)
 **
 */
 
-extern  Int             (*IsbListFuncs[LAST_REAL_TNUM+1]) ( Obj list, Int pos );
+extern BOOL (*IsbListFuncs[LAST_REAL_TNUM + 1])(Obj list, Int pos);
 
-EXPORT_INLINE Int ISB_LIST(Obj list, Int pos)
+EXPORT_INLINE BOOL ISB_LIST(Obj list, Int pos)
 {
     return (*IsbListFuncs[TNUM_OBJ(list)])(list, pos);
 }
 
-Int ISBB_LIST(Obj list, Obj pos);
+BOOL ISBB_LIST(Obj list, Obj pos);
 
-Int ISB_MAT(Obj list, Obj row, Obj col);
+BOOL ISB_MAT(Obj list, Obj row, Obj col);
 
 
 /****************************************************************************
@@ -580,9 +580,9 @@ void AssListObject(Obj list, Int pos, Obj obj);
 **  guarantees already that the list has this property.
 */
 
-extern  Int             (*IsTableListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+extern BOOL (*IsTableListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-EXPORT_INLINE Int IS_TABLE_LIST(Obj list)
+EXPORT_INLINE BOOL IS_TABLE_LIST(Obj list)
 {
     return (*IsTableListFuncs[TNUM_OBJ(list)])(list);
 }
@@ -592,7 +592,7 @@ EXPORT_INLINE Int IS_TABLE_LIST(Obj list)
 *F  IS_SSORT_LIST(<list>) . . . . . . . . . .  test for strictly sorted lists
 *V  IsSSortListFuncs[<type>]  .  table of strictly sorted list test functions
 **
-**  'IS_SSORT_LIST' returns 2 if the list <list> is  a strictly  sorted  list
+**  'IS_SSORT_LIST' returns 1 if the list <list> is  a strictly  sorted  list
 **  and 0 otherwise,  i.e., if either <list>  is not a list,  or if it is not
 **  strictly sorted.
 **
@@ -602,9 +602,9 @@ EXPORT_INLINE Int IS_TABLE_LIST(Obj list)
 **  of the list guarantees already that the list is strictly sorted.
 */
 
-extern  Int             (*IsSSortListFuncs[LAST_REAL_TNUM+1]) ( Obj list );
+extern BOOL (*IsSSortListFuncs[LAST_REAL_TNUM + 1])(Obj list);
 
-EXPORT_INLINE Int IS_SSORT_LIST(Obj list)
+EXPORT_INLINE BOOL IS_SSORT_LIST(Obj list)
 {
     return (*IsSSortListFuncs[TNUM_OBJ(list)])(list);
 }

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -50,7 +50,7 @@ void SET_VAL_MACFLOAT(Obj obj, Double val)
     memcpy(ADDR_OBJ(obj), &val, sizeof(Double));
 }
 
- Int IS_MACFLOAT(Obj obj)
+BOOL IS_MACFLOAT(Obj obj)
 {
     return TNUM_OBJ(obj) == T_MACFLOAT;
 }

--- a/src/macfloat.h
+++ b/src/macfloat.h
@@ -31,7 +31,7 @@ typedef double Double;
 
 Double VAL_MACFLOAT(Obj obj);
 void SET_VAL_MACFLOAT(Obj obj, Double val);
-Int IS_MACFLOAT(Obj obj);
+BOOL IS_MACFLOAT(Obj obj);
 Obj NEW_MACFLOAT(Double val);
 
 

--- a/src/modules.h
+++ b/src/modules.h
@@ -60,17 +60,17 @@ enum {
     MODULE_DYNAMIC = GAP_KERNEL_API_VERSION * 10 + 2,
 };
 
-EXPORT_INLINE Int IS_MODULE_BUILTIN(UInt type)
+EXPORT_INLINE BOOL IS_MODULE_BUILTIN(UInt type)
 {
     return type % 10 == 0;
 }
 
-EXPORT_INLINE Int IS_MODULE_STATIC(UInt type)
+EXPORT_INLINE BOOL IS_MODULE_STATIC(UInt type)
 {
     return type % 10 == 1;
 }
 
-EXPORT_INLINE Int IS_MODULE_DYNAMIC(UInt type)
+EXPORT_INLINE BOOL IS_MODULE_DYNAMIC(UInt type)
 {
     return type % 10 == 2;
 }

--- a/src/objects.c
+++ b/src/objects.c
@@ -261,22 +261,22 @@ static Obj FuncSET_TYPE_OBJ(Obj self, Obj obj, Obj type)
 **
 **  'IS_MUTABLE_OBJ' is defined in the declaration part of this package.
 */
-Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsMutableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 static Obj IsMutableObjFilt;
 
-static Int IsMutableObjError(Obj obj)
+static BOOL IsMutableObjError(Obj obj)
 {
     ErrorQuit("Panic: tried to test mutability of unsupported type '%s'",
               (Int)TNAM_OBJ(obj), 0);
-    return 0;
+    return FALSE;
 }
 
-static Int IsMutableObjObject(Obj obj)
+static BOOL IsMutableObjObject(Obj obj)
 {
 #ifdef HPCGAP
     if (RegionBag(obj) == ReadOnlyRegion)
-        return 0;
+        return FALSE;
 #endif
     return (DoFilter( IsMutableObjFilt, obj ) == True);
 }
@@ -307,7 +307,8 @@ static Obj FiltIS_INTERNALLY_MUTABLE_OBJ(Obj self, Obj obj)
       DoFilter( IsInternallyMutableObjFilt, obj) == True) ? True : False;
 }
 
-Int IsInternallyMutableObj(Obj obj) {
+BOOL IsInternallyMutableObj(Obj obj)
+{
     return TNUM_OBJ(obj) == T_DATOBJ &&
       RegionBag(obj) != ReadOnlyRegion &&
       DoFilter( IsInternallyMutableObjFilt, obj) == True;
@@ -325,18 +326,18 @@ Int IsInternallyMutableObj(Obj obj) {
 **
 **  'IS_COPYABLE_OBJ' is defined in the declaration part of this package.
 */
-Int (*IsCopyableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsCopyableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 static Obj IsCopyableObjFilt;
 
-static Int IsCopyableObjError(Obj obj)
+static BOOL IsCopyableObjError(Obj obj)
 {
     ErrorQuit("Panic: tried to test copyability of unsupported type '%s'",
               (Int)TNAM_OBJ(obj), 0);
-    return 0;
+    return FALSE;
 }
 
-static Int IsCopyableObjObject(Obj obj)
+static BOOL IsCopyableObjObject(Obj obj)
 {
     return (DoFilter( IsCopyableObjFilt, obj ) == True);
 }
@@ -885,15 +886,15 @@ static Obj FuncGET_TNAM_FROM_TNUM(Obj self, Obj obj)
 
 // This function is used to keep track of which objects are already
 // being printed or viewed to trigger the use of ~ when needed.
-static inline UInt IS_ON_PRINT_STACK(const ObjectsModuleState * os, Obj obj)
+static inline BOOL IS_ON_PRINT_STACK(const ObjectsModuleState * os, Obj obj)
 {
     if (!(FIRST_RECORD_TNUM <= TNUM_OBJ(obj) &&
           TNUM_OBJ(obj) <= LAST_LIST_TNUM))
-        return 0;
+        return FALSE;
     for (UInt i = 0; i < os->PrintObjDepth; i++)
         if (os->PrintObjThiss[i] == obj)
-            return 1;
-    return 0;
+            return TRUE;
+    return FALSE;
 }
 
 #ifdef HPCGAP
@@ -1281,7 +1282,7 @@ Obj ElmComObj(Obj obj, UInt rnam)
     }
 }
 
-Int IsbComObj(Obj obj, UInt rnam)
+BOOL IsbComObj(Obj obj, UInt rnam)
 {
     switch (TNUM_OBJ(obj)) {
     case T_COMOBJ:
@@ -1488,9 +1489,9 @@ Obj ElmPosObj(Obj obj, Int idx)
     return elm;
 }
 
-Int IsbPosObj(Obj obj, Int idx)
+BOOL IsbPosObj(Obj obj, Int idx)
 {
-    Int isb;
+    BOOL isb;
     if (TNUM_OBJ(obj) == T_POSOBJ) {
 #ifdef HPCGAP
         // Because BindOnce() functions can reallocate the list even if they
@@ -1498,7 +1499,7 @@ Int IsbPosObj(Obj obj, Int idx)
         // positional objects.
         const Bag * contents = CONST_PTR_BAG(obj);
         if (idx > SIZE_BAG_CONTENTS(contents) / sizeof(Obj) - 1)
-            isb = 0;
+            isb = FALSE;
         else
             isb = contents[idx] != 0;
 #else

--- a/src/objects.h
+++ b/src/objects.h
@@ -44,7 +44,7 @@
 **  'IS_FFE'  returns 1  if the  object <o>  is  an  (immediate) finite field
 **  element and 0 otherwise.
 */
-EXPORT_INLINE Int IS_FFE(Obj o)
+EXPORT_INLINE BOOL IS_FFE(Obj o)
 {
     return (Int)o & 0x02;
 }
@@ -562,12 +562,12 @@ void CheckedMakeImmutable(Obj obj);
 **  'IS_MUTABLE_OBJ' returns   1 if the object  <obj> is mutable   (i.e., can
 **  change due to assignments), and 0 otherwise.
 */
-extern Int (*IsMutableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
-EXPORT_INLINE Int IS_MUTABLE_OBJ(Obj obj)
+extern BOOL (*IsMutableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
+EXPORT_INLINE BOOL IS_MUTABLE_OBJ(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     if (/*FIRST_CONSTANT_TNUM <= tnum &&*/ tnum <= LAST_CONSTANT_TNUM)
-        return 0;
+        return FALSE;
     if (FIRST_IMM_MUT_TNUM <= tnum && tnum <= LAST_IMM_MUT_TNUM)
         return !(tnum & IMMUTABLE);
     return ((*IsMutableObjFuncs[tnum])(obj));
@@ -585,7 +585,7 @@ EXPORT_INLINE Int IS_MUTABLE_OBJ(Obj obj)
 */
 
 #ifdef HPCGAP
-Int IsInternallyMutableObj(Obj obj);
+BOOL IsInternallyMutableObj(Obj obj);
 #endif
 
 /****************************************************************************
@@ -638,8 +638,8 @@ void LoadObjError(Obj obj);
 **  'IS_COPYABLE_OBJ' returns 1 if the object <obj> is copyable (i.e., can be
 **  copied into a mutable object), and 0 otherwise.
 */
-extern Int (*IsCopyableObjFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
-EXPORT_INLINE Int IS_COPYABLE_OBJ(Obj obj)
+extern BOOL (*IsCopyableObjFuncs[LAST_REAL_TNUM + 1])(Obj obj);
+EXPORT_INLINE BOOL IS_COPYABLE_OBJ(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return (IsCopyableObjFuncs[tnum])(obj);
@@ -816,7 +816,7 @@ EXPORT_INLINE void PRINT_PATH(Obj obj, Int idx)
 **
 *F  IS_COMOBJ( <obj> )  . . . . . . . . . . . is an object a component object
 */
-EXPORT_INLINE Int IS_COMOBJ(Obj obj)
+EXPORT_INLINE BOOL IS_COMOBJ(Obj obj)
 {
     return TNUM_OBJ(obj) == T_COMOBJ;
 }
@@ -852,14 +852,14 @@ EXPORT_INLINE void SET_TYPE_COMOBJ(Obj obj, Obj val)
 void AssComObj(Obj obj, UInt rnam, Obj val);
 void UnbComObj(Obj obj, UInt rnam);
 Obj  ElmComObj(Obj obj, UInt rnam);
-Int  IsbComObj(Obj obj, UInt rnam);
+BOOL IsbComObj(Obj obj, UInt rnam);
 
 
 /****************************************************************************
 **
 *F  IS_POSOBJ( <obj> )  . . . . . . . . . .  is an object a positional object
 */
-EXPORT_INLINE Int IS_POSOBJ(Obj obj)
+EXPORT_INLINE BOOL IS_POSOBJ(Obj obj)
 {
     return TNUM_OBJ(obj) == T_POSOBJ;
 }
@@ -895,14 +895,14 @@ EXPORT_INLINE void SET_TYPE_POSOBJ(Obj obj, Obj val)
 void AssPosObj(Obj obj, Int idx, Obj val);
 void UnbPosObj(Obj obj, Int idx);
 Obj  ElmPosObj(Obj obj, Int idx);
-Int  IsbPosObj(Obj obj, Int idx);
+BOOL IsbPosObj(Obj obj, Int idx);
 
 
 /****************************************************************************
 **
 *F  IS_DATOBJ( <obj> )  . . . . . . . . . . . . .  is an object a data object
 */
-EXPORT_INLINE Int IS_DATOBJ(Obj obj)
+EXPORT_INLINE BOOL IS_DATOBJ(Obj obj)
 {
     return TNUM_OBJ(obj) == T_DATOBJ;
 }

--- a/src/objset.c
+++ b/src/objset.c
@@ -40,13 +40,13 @@ static Obj TypeObjMap(Obj obj)
     return TYPE_OBJMAP;
 }
 
-static inline int IS_OBJSET(Obj obj)
+static inline BOOL IS_OBJSET(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return tnum == T_OBJSET || tnum == T_OBJSET + IMMUTABLE;
 }
 
-static inline int IS_OBJMAP(Obj obj)
+static inline BOOL IS_OBJMAP(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return tnum == T_OBJMAP || tnum == T_OBJMAP + IMMUTABLE;

--- a/src/opers.c
+++ b/src/opers.c
@@ -371,7 +371,7 @@ static Int IsSubsetFlagsCalls;
 **
 *F  IS_SUBSET_FLAGS( <flags1>, <flags2> ) . subset test with no safety check
 */
-Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
+BOOL IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
 {
     Int    len1;
     Int    len2;

--- a/src/opers.h
+++ b/src/opers.h
@@ -78,7 +78,7 @@ extern Obj TRY_NEXT_METHOD;
 **
 *F  IS_OPERATION( <obj> ) . . . . . . . . . . check if object is an operation
 */
-EXPORT_INLINE Int IS_OPERATION(Obj obj)
+EXPORT_INLINE BOOL IS_OPERATION(Obj obj)
 {
     return TNUM_OBJ(obj) == T_FUNCTION && SIZE_OBJ(obj) == sizeof(OperBag);
 }
@@ -243,7 +243,7 @@ EXPORT_INLINE void SET_ENABLED_ATTR(Obj oper, Int on)
 **
 *F  IS_FILTER( <oper> ) . . . . . . . . . . . . . check if object is a filter
 */
-EXPORT_INLINE Int IS_FILTER(Obj oper)
+EXPORT_INLINE BOOL IS_FILTER(Obj oper)
 {
     if (!IS_OPERATION(oper))
         return 0;
@@ -467,7 +467,7 @@ EXPORT_INLINE void SET_ELM_FLAGS(Obj list, UInt pos)
 **
 *F  IS_SUBSET_FLAGS( <self>, <flags1>, <flags2> ) . . . . . . . . subset test
 */
-Int IS_SUBSET_FLAGS(Obj flags1, Obj flags2);
+BOOL IS_SUBSET_FLAGS(Obj flags1, Obj flags2);
 
 
 /****************************************************************************

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -173,7 +173,7 @@ static void PrintPerm(Obj perm)
     UInt                degPerm;        /* degree of the permutation       */
     const T *           ptPerm;         /* pointer to the permutation      */
     UInt                p,  q;          /* loop variables                  */
-    UInt                isId;           /* permutation is the identity?    */
+    BOOL                isId;           /* permutation is the identity?    */
     const char *        fmt1;           /* common formats to print points  */
     const char *        fmt2;           /* common formats to print points  */
 
@@ -193,13 +193,13 @@ static void PrintPerm(Obj perm)
     memset(ptSeen, 0, DEG_PERM<T>(perm) * sizeof(T));
 
     /* run through all points                                              */
-    isId = 1;
+    isId = TRUE;
     ptPerm = CONST_ADDR_PERM<T>(perm);
     for ( p = 0; p < degPerm; p++ ) {
         /* if the smallest is the one we started with lets print the cycle */
         if (!ptSeen[p] && ptPerm[p] != p) {
             ptSeen[p] = 1;
-            isId = 0;
+            isId = FALSE;
             Pr(fmt1,(Int)(p+1), 0);
             ptPerm = CONST_ADDR_PERM<T>(perm);
             for ( q = ptPerm[p]; q != p; q = ptPerm[q] ) {
@@ -2078,7 +2078,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
     const T *           ptPrm;          /* pointer to the permutation      */
     Obj                 tmp;            /* temporary handle                */
     UInt                lmp;            /* largest moved point             */
-    UInt                isint;          /* <set> only holds integers       */
+    BOOL                isint;          /* <set> only holds integers       */
     UInt                i, k;           /* loop variables                  */
 
     GAP_ASSERT(IS_PLIST(set));
@@ -2097,7 +2097,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
     lmp = DEG_PERM<T>(perm);
 
     /* loop over the entries of the tuple                              */
-    isint = 1;
+    isint = TRUE;
     for ( i = len; 1 <= i; i--, ptTup--, ptRes-- ) {
         if (IS_POS_INTOBJ(*ptTup)) {
             k = INT_INTOBJ( *ptTup );
@@ -2108,7 +2108,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
             *ptRes = tmp;
         }
         else {
-            isint = 0;
+            isint = FALSE;
             tmp = POW( *ptTup, perm );
             ptTup = CONST_ADDR_OBJ(set) + i;
             ptRes = ADDR_OBJ(res) + i;

--- a/src/permutat.h
+++ b/src/permutat.h
@@ -133,7 +133,7 @@ EXPORT_INLINE void CLEAR_STOREDINV_PERM(Obj perm)
 #define IS_PERM4(perm)  (TNUM_OBJ(perm) == T_PERM4)
 
 
-EXPORT_INLINE int IS_PERM(Obj f)
+EXPORT_INLINE BOOL IS_PERM(Obj f)
 {
     return (TNUM_OBJ(f) == T_PERM2 || TNUM_OBJ(f) == T_PERM4);
 }

--- a/src/plist.c
+++ b/src/plist.c
@@ -209,27 +209,25 @@ static Obj TypePlistWithKTNum( Obj list, UInt *ktnum );
 
 static Int KTNumPlist(Obj list, Obj * famfirst)
 {
-    Int                 isHom   = 1;    /* is <list> homogeneous           */
-    Int                 isDense = 1;    /* is <list> dense                 */
-    Int                 isTable = 0;    /* are <list>s elms all lists      */
-    Int                 isRect  = 0;    /* are lists elms of equal length
-                                     only test this one for PLIST elements */
-    Int                 areMut  = 0;    /* are <list>s elms mutable        */
-    Int                 len     = 0;    /* if so, this is the length       */
-    Obj                 typeObj = 0;    /* type of <list>s elements        */
-    Obj                 family  = 0;    /* family of <list>s elements      */
-    Int                 lenList;        /* length of <list>                */
-    Obj                 elm, x;         /* one element of <list>           */
-    Int                 i;              /* loop variable                   */
-    Int                 testing;        /* to test or not to test type     */
-    Int                 res;            /* result                          */
-    Int                 knownDense;     /* set true if the list is already
-                                           known to be dense */
-    Int                 knownNDense;    /* set true if the list is already
-                                           known not to be dense */
-    UInt                ktnumFirst;
+    BOOL isHom   = TRUE;    // is <list> homogeneous
+    BOOL isDense = TRUE;    // is <list> dense
+    BOOL isTable = FALSE;   // are <list>s elms all lists
+    BOOL isRect  = FALSE;   // are lists elms of equal length only test this
+                            // one for PLIST elements
+    BOOL areMut  = FALSE;   // are <list>s elms mutable
+    Int  len     = 0;       // if so, this is the length
+    Obj  typeObj = 0;       // type of <list>s elements
+    Obj  family  = 0;       // family of <list>s elements
+    Int  lenList;           // length of <list>
+    Obj  elm, x;            // one element of <list>
+    Int  i;                 // loop variable
+    Int  testing;           // to test or not to test type
+    Int  res;               // result
+    Int  knownDense;        // set true if the list is already known to be dense
+    Int  knownNDense;       // set true if the list is already known not to be dense
+    UInt ktnumFirst;
 
-    Obj                 loopTypeObj = 0; /* typeObj in loop               */
+    Obj  loopTypeObj = 0; // typeObj in loop
 
 #ifdef HPCGAP
     if (!CheckWriteAccess(list)) {
@@ -442,15 +440,15 @@ static Int KTNumPlist(Obj list, Obj * famfirst)
 
 static Int KTNumHomPlist(Obj list)
 {
-    Int                 isTable = 0;    /* are <list>s elms all lists   */
-    Int                 isRect  = 0;    /* are <list>s elms all equal length */
-    Int                 len     = 0;    /* if so, this is the length       */
-    Int                 lenList;        /* length of list                  */
-    Obj                 elm, x;         /* one element of <list>           */
-    Int                 i;              /* loop variable                   */
-    Int                 res;            /* result                          */
-    Int                 isSSort;        /* list is (known to be) SSorted   */
-    Int                 isNSort;        /* list is (known to be) non-sorted*/
+    BOOL isTable = FALSE;   // are <list>s elms all lists
+    BOOL isRect  = FALSE;   // are <list>s elms all equal length
+    Int  len     = 0;       // if so, this is the length
+    Int  lenList;           // length of list
+    Obj  elm, x;            // one element of <list>
+    Int  i;                 // loop variable
+    Int  res;               // result
+    Int  isSSort;           // list is (known to be) SSorted
+    Int  isNSort;           // list is (known to be) non-sorted
 
 #ifdef HPCGAP
     if (!CheckWriteAccess(list)) {
@@ -1049,12 +1047,12 @@ static Int LenPlistEmpty(Obj list)
 **  and 0 otherwise.  It is the responsibility of the caller to  ensure  that
 **  <pos> is a positive integer.
 */
-static Int IsbPlist(Obj list, Int pos)
+static BOOL IsbPlist(Obj list, Int pos)
 {
     return (pos <= LEN_PLIST( list ) && ELM_PLIST( list, pos ) != 0);
 }
 
-static Int IsbPlistDense(Obj list, Int pos)
+static BOOL IsbPlistDense(Obj list, Int pos)
 {
     return (pos <= LEN_PLIST( list ));
 }
@@ -1911,7 +1909,7 @@ static void AsssPlistXXX(Obj list, Obj poss, Obj vals)
 **
 **  'IsDensePlist' is the function in 'IsDenseListFuncs' for plain lists.
 */
-static Int IsDensePlist(Obj list)
+static BOOL IsDensePlist(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Int                 i;              /* loop variable                   */
@@ -1922,20 +1920,20 @@ static Int IsDensePlist(Obj list)
     /* special case for empty list                                         */
     if ( lenList == 0 ) {
         RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
-        return 1;
+        return TRUE;
     }
 
     /* loop over the entries of the list                                   */
     for ( i = 1; i <= lenList; i++ ) {
         if ( ELM_PLIST( list, i ) == 0 )
-            return 0;
+            return FALSE;
     }
 
     /* set the dense flag (even if the elements are mutable)               */
     SET_FILT_LIST( list, FN_IS_DENSE );
 
     /* no hole found                                                       */
-    return 1;
+    return TRUE;
 }
 
 
@@ -1948,7 +1946,7 @@ static Int IsDensePlist(Obj list)
 **
 **  'IsHomogPlist' is the function in 'IsHomogListFuncs' for plain lists.
 */
-static Int IsHomogPlist(Obj list)
+static BOOL IsHomogPlist(Obj list)
 {
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
@@ -1965,7 +1963,7 @@ static Int IsHomogPlist(Obj list)
 **
 **  'IsTablePlist' is the function in 'IsTableListFuncs' for plain lists.
 */
-static Int IsTablePlist(Obj list)
+static BOOL IsTablePlist(Obj list)
 {
     Int                 tnum;
     tnum = KTNumPlist( list, (Obj *)0 );
@@ -1977,13 +1975,13 @@ static Int IsTablePlist(Obj list)
 **
 *F  IsSSortPlist(<list>)  . . . . . sorted list test function for plain lists
 **
-**  'IsSSortPlist'  returns 2  if the  plain  list <list>  is strictly sorted
+**  'IsSSortPlist'  returns 1  if the  plain  list <list>  is strictly sorted
 **  (each element is strictly smaller than the next one), and 0 otherwise.
 **
 **  'IsSSortPlist' is the function in 'IsSSortListFuncs' for plain lists.
 */
 
-static Int IsSSortPlist(Obj list)
+static BOOL IsSSortPlist(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -1999,7 +1997,7 @@ static Int IsSSortPlist(Obj list)
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
         RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
-        return 2;
+        return TRUE;
     }
 
     /* get the first element                                               */
@@ -2008,7 +2006,7 @@ static Int IsSSortPlist(Obj list)
       goto notDense;
 #ifdef HPCGAP
     if (!CheckReadAccess(elm1))
-      return 0;
+      return FALSE;
 #endif
     areMut   = IS_MUTABLE_OBJ( elm1 );
     if (!SyInitializing)
@@ -2026,7 +2024,7 @@ static Int IsSSortPlist(Obj list)
         goto notDense;
 #ifdef HPCGAP
       if (!CheckReadAccess(elm2))
-        return 0;
+        return FALSE;
 #endif
       if ( ! LT( elm1, elm2 ) )
         break;
@@ -2054,22 +2052,22 @@ static Int IsSSortPlist(Obj list)
           SET_FILT_LIST( list, FN_IS_NHOMOG);
         SET_FILT_LIST( list, FN_IS_SSORT );
       }
-      return 2;
+      return TRUE;
     }
     else {
       if ( ! areMut ) {
         SET_FILT_LIST( list, FN_IS_NSORT );
       }
-      return 0;
+      return FALSE;
 
     }
 
  notDense:
     SET_FILT_LIST( list, FN_IS_NDENSE );
-    return 0;
+    return FALSE;
 }
 
-static Int IsSSortPlistDense(Obj list)
+static BOOL IsSSortPlistDense(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2085,14 +2083,14 @@ static Int IsSSortPlistDense(Obj list)
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
         RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
-        return 2;
+        return TRUE;
     }
 
     /* get the first element                                               */
     elm1    = ELM_PLIST( list, 1 );
 #ifdef HPCGAP
     if (!CheckReadAccess(elm1))
-      return 0;
+      return FALSE;
 #endif
     areMut   = IS_MUTABLE_OBJ( elm1 );
     if (!SyInitializing)
@@ -2108,7 +2106,7 @@ static Int IsSSortPlistDense(Obj list)
       elm2 = ELM_PLIST( list, i );
 #ifdef HPCGAP
       if (!CheckReadAccess(elm2))
-        return 0;
+        return FALSE;
 #endif
       if ( ! LT( elm1, elm2 ) )
         break;
@@ -2128,18 +2126,18 @@ static Int IsSSortPlistDense(Obj list)
           SET_FILT_LIST( list, FN_IS_NHOMOG);
         SET_FILT_LIST( list, FN_IS_SSORT );
       }
-      return 2;
+      return TRUE;
     }
     else {
         if ( ! areMut ) {
           SET_FILT_LIST( list, FN_IS_NSORT );
         }
-        return 0;
+        return FALSE;
     }
 
 }
 
-static Int IsSSortPlistHom(Obj list)
+static BOOL IsSSortPlistHom(Obj list)
 {
     Int                 lenList;
     Obj elm1;
@@ -2152,14 +2150,14 @@ static Int IsSSortPlistHom(Obj list)
     /* special case for the empty list                                     */
     if ( lenList == 0 ) {
         RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
-        return 2;
+        return TRUE;
     }
 
     /* get the first element                                               */
     elm1    = ELM_PLIST( list, 1 );
 #ifdef HPCGAP
     if (!CheckReadAccess(elm1))
-      return 0;
+      return FALSE;
 #endif
 
     /* loop over the other elements                                        */
@@ -2167,7 +2165,7 @@ static Int IsSSortPlistHom(Obj list)
       elm2 = ELM_PLIST( list, i );
 #ifdef HPCGAP
       if (!CheckReadAccess(elm2))
-        return 0;
+        return FALSE;
 #endif
       if ( ! LT( elm1, elm2 ) )
         break;
@@ -2177,11 +2175,11 @@ static Int IsSSortPlistHom(Obj list)
 
     if ( lenList < i ) {
       SET_FILT_LIST( list, FN_IS_SSORT );
-      return 2;
+      return TRUE;
     }
     else {
       SET_FILT_LIST( list, FN_IS_NSORT );
-      return 0;
+      return FALSE;
     }
 
 }
@@ -2203,7 +2201,7 @@ static Obj FuncSET_IS_SSORTED_PLIST(Obj self, Obj list)
 **
 **  'IsPossPlist' is the function in 'IsPossListFuncs' for plain lists.
 */
-static Int IsPossPlist(Obj list)
+static BOOL IsPossPlist(Obj list)
 {
     Int                 lenList;        /* length of <list>                */
     Obj                 elm;            /* one element of <list>           */
@@ -2216,23 +2214,23 @@ static Int IsPossPlist(Obj list)
     for ( i = 1; i <= lenList; i++ ) {
         elm = ELM_PLIST( list, i );
         if (elm == 0)
-          return 0;
+          return FALSE;
 #ifdef HPCGAP
         if ( !CheckReadAccess(elm) )
-          return 0;
+          return FALSE;
 #endif
         if (IS_INTOBJ(elm))
           {
             if (INT_INTOBJ(elm) <= 0 )
-              return 0;
+              return FALSE;
           }
         else
           if (TNUM_OBJ(elm) != T_INTPOS)
-            return 0;
+            return FALSE;
     }
 
     /* no problems found                                                   */
-    return 1;
+    return TRUE;
 }
 
 

--- a/src/plist.h
+++ b/src/plist.h
@@ -62,7 +62,7 @@ EXPORT_INLINE Obj NEW_PLIST_WITH_MUTABILITY(Int mut, UInt type, Int plen)
 **
 *F  IS_PLIST( <list> )  . . . . . . . . . . . check if <list> is a plain list
 */
-EXPORT_INLINE Int IS_PLIST(Obj list)
+EXPORT_INLINE BOOL IS_PLIST(Obj list)
 {
     return FIRST_PLIST_TNUM <= TNUM_OBJ(list) &&
            TNUM_OBJ(list) <= LAST_PLIST_TNUM;
@@ -80,7 +80,7 @@ EXPORT_INLINE Int IS_PLIST(Obj list)
 **  (which have the same memory layout as plists), as the plist APIs using it
 **  for assertion checks are in practice invoked on such objects, too.
 */
-EXPORT_INLINE Int IS_PLIST_OR_POSOBJ(Obj list)
+EXPORT_INLINE BOOL IS_PLIST_OR_POSOBJ(Obj list)
 {
     UInt tnum = TNUM_OBJ(list);
     return (FIRST_PLIST_TNUM <= tnum && tnum <= LAST_PLIST_TNUM) ||
@@ -224,7 +224,7 @@ EXPORT_INLINE Obj * BASE_PTR_PLIST(Obj list)
 **  whether they are dense or not (i.e. of type 'T_PLIST'),
 **  use 'IS_DENSE_LIST' instead.
 */
-EXPORT_INLINE Int IS_DENSE_PLIST(Obj list)
+EXPORT_INLINE BOOL IS_DENSE_PLIST(Obj list)
 {
     return T_PLIST_DENSE <= TNUM_OBJ(list) &&
            TNUM_OBJ(list) <= LAST_PLIST_TNUM;
@@ -234,7 +234,7 @@ EXPORT_INLINE Int IS_DENSE_PLIST(Obj list)
 **
 *F  IS_PLIST_MUTABLE( <list> )  . . . . . . . . . . . is a plain list mutable
 */
-EXPORT_INLINE Int IS_PLIST_MUTABLE(Obj list)
+EXPORT_INLINE BOOL IS_PLIST_MUTABLE(Obj list)
 {
     GAP_ASSERT(IS_PLIST(list));
     return !((TNUM_OBJ(list) - T_PLIST) % 2);

--- a/src/pperm.h
+++ b/src/pperm.h
@@ -13,7 +13,7 @@
 
 #include "objects.h"
 
-EXPORT_INLINE int IS_PPERM(Obj f)
+EXPORT_INLINE BOOL IS_PPERM(Obj f)
 {
     return (TNUM_OBJ(f) == T_PPERM2 || TNUM_OBJ(f) == T_PPERM4);
 }

--- a/src/precord.c
+++ b/src/precord.c
@@ -298,9 +298,7 @@ UInt PositionPRec(Obj rec, UInt rnam, int cleanup)
 **  'IsbPRec' returns 1 if the record <rec> has a component with  the  record
 **  name <rnam>, and 0 otherwise.
 */
-Int IsbPRec (
-    Obj                 rec,
-    UInt                rnam )
+BOOL IsbPRec(Obj rec, UInt rnam)
 {
     return PositionPRec(rec, rnam, 1) != 0;
 }

--- a/src/precord.h
+++ b/src/precord.h
@@ -36,7 +36,7 @@ Obj NEW_PREC(UInt len);
 **
 *F  IS_PREC( <rec> ) . . . . . . . . .  check if <rec> is in plain record rep
 */
-EXPORT_INLINE Int IS_PREC(Obj rec)
+EXPORT_INLINE BOOL IS_PREC(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
     return tnum == T_PREC || tnum == T_PREC+IMMUTABLE;
@@ -55,7 +55,7 @@ EXPORT_INLINE Int IS_PREC(Obj rec)
 **  the same memory layout as precs), as the precs APIs using it for
 **  assertion checks are in practice invoked on such objects, too.
 */
-EXPORT_INLINE Int IS_PREC_OR_COMOBJ(Obj rec)
+EXPORT_INLINE BOOL IS_PREC_OR_COMOBJ(Obj rec)
 {
     UInt tnum = TNUM_OBJ(rec);
     return tnum == T_PREC || tnum == T_PREC+IMMUTABLE || tnum == T_COMOBJ;
@@ -212,7 +212,7 @@ Obj ElmPRec(Obj rec, UInt rnam);
 **  'IsbPRec' returns 1 if the record <rec> has a component with  the  record
 **  name <rnam>, and 0 otherwise.
 */
-Int IsbPRec(Obj rec, UInt rnam);
+BOOL IsbPRec(Obj rec, UInt rnam);
 
 
 /****************************************************************************

--- a/src/range.c
+++ b/src/range.c
@@ -232,7 +232,7 @@ static Int LenRange(Obj list)
 **
 **  'IsbRange' is the function in 'IsbListFuncs' for ranges.
 */
-static Int IsbRange(Obj list, Int pos)
+static BOOL IsbRange(Obj list, Int pos)
 {
     return (pos <= GET_LEN_RANGE(list));
 }
@@ -492,18 +492,18 @@ static void AsssRange(Obj list, Obj poss, Obj vals)
 **
 **  'IsPossRange' is the function in 'IsPossListFuncs' for ranges.
 */
-static Int IsPossRange(Obj list)
+static BOOL IsPossRange(Obj list)
 {
     /* test if the first element is positive                               */
     if ( GET_LOW_RANGE( list ) <= 0 )
-        return 0;
+        return FALSE;
 
     /* test if the last element is positive                                */
     if ( INT_INTOBJ( GET_ELM_RANGE( list, GET_LEN_RANGE(list) ) ) <= 0 )
-        return 0;
+        return FALSE;
 
     /* otherwise <list> is a positions list                                */
-    return 1;
+    return TRUE;
 }
 
 
@@ -610,9 +610,9 @@ static void PlainRange(Obj list)
 */
 static Obj IsRangeFilt;
 
-static Int IsRange(Obj list)
+static BOOL IsRange(Obj list)
 {
-    Int                 isRange;        /* result of the test              */
+    BOOL                isRange;        /* result of the test              */
     Int                 len;            /* logical length of list          */
     Int                 low;            /* value of first element of range */
     Int                 inc;            /* increment                       */
@@ -621,38 +621,38 @@ static Int IsRange(Obj list)
     /* if <list> is represented as a range, it is of course a range      */
     if ( TNUM_OBJ(list) == T_RANGE_NSORT
       || TNUM_OBJ(list) == T_RANGE_SSORT ) {
-        isRange = 1;
+        isRange = TRUE;
     }
 
     /* if <list> is not a list, it is not a range at the moment        */
     else if ( ! IS_SMALL_LIST( list ) ) {
-       /* isRange = 0; */
+       /* isRange = FALSE; */
        isRange = (DoFilter(IsRangeFilt, list) == True);
     }
 
     /* if <list> is the empty list, it is a range by definition          */
     else if ( LEN_LIST(list) == 0 ) {
-        isRange = 1;
+        isRange = TRUE;
     }
 
     /* if <list> is a list with just one integer, it is also a range     */
     else if ( LEN_LIST(list)==1 && IS_INTOBJ(ELMW_LIST(list,1)) ) {
-        isRange = 1;
+        isRange = TRUE;
     }
 
     /* if the first element is not an integer, it is not a range           */
     else if ( ELMV0_LIST(list,1)==0 || !IS_INTOBJ(ELMW_LIST(list,1)) ) {
-        isRange = 0;
+        isRange = FALSE;
     }
 
     /* if the second element is not an integer, it is not a range          */
     else if ( ELMV0_LIST(list,2)==0 || !IS_INTOBJ(ELMW_LIST(list,2)) ) {
-        isRange = 0;
+        isRange = FALSE;
     }
 
     /* if the first and the second element are equal it is also not a range*/
     else if ( ELMW_LIST(list,1) == ELMW_LIST(list,2) ) {
-        isRange = 0;
+        isRange = FALSE;
     }
 
     /* otherwise, test if the elements are consecutive integers            */

--- a/src/range.h
+++ b/src/range.h
@@ -53,7 +53,7 @@ EXPORT_INLINE Obj NEW_RANGE_SSORT(void)
 **  a range, but  the kernel does not know  this yet.  Use  'IsRange' to test
 **  whether a list is a range.
 */
-EXPORT_INLINE Int IS_RANGE(Obj val)
+EXPORT_INLINE BOOL IS_RANGE(Obj val)
 {
     return TNUM_OBJ(val) >= T_RANGE_NSORT &&
            TNUM_OBJ(val) <= T_RANGE_SSORT + IMMUTABLE;

--- a/src/read.c
+++ b/src/read.c
@@ -1079,7 +1079,7 @@ static void ReadRecExpr(ReaderState * rs, TypSymbolSet follow)
 typedef struct {
     Int        narg;           /* number of arguments             */
     Obj        nams;           /* list of local variables names   */
-    UInt       isvarg;         /* does function have varargs?     */
+    BOOL       isvarg;         /* does function have varargs?     */
 #ifdef HPCGAP
     Obj        locks;          /* locks of the function (HPC-GAP) */
 #endif
@@ -1117,7 +1117,7 @@ static ArgList ReadFuncArgList(ReaderState * rs,
     LockQual   lockqual;
     Bag        locks = 0;      /* locks of the function */
 #endif
-    UInt       isvarg = 0;     /* does function have varargs?     */
+    BOOL       isvarg = FALSE; // does function have varargs?
 
 #ifdef HPCGAP
     if (is_atomic)
@@ -1183,7 +1183,7 @@ static ArgList ReadFuncArgList(ReaderState * rs,
             SyntaxError(&rs->s, "Three dots required for variadic argument list");
         }
         if (rs->s.Symbol == S_DOTDOTDOT) {
-            isvarg = 1;
+            isvarg = TRUE;
             Match(&rs->s, S_DOTDOTDOT, "...", follow);
         }
     }
@@ -1191,7 +1191,7 @@ static ArgList ReadFuncArgList(ReaderState * rs,
 
     // Special case for function(arg)
     if ( narg == 1 && ! strcmp( "arg", CONST_CSTR_STRING( ELM_PLIST(nams, narg) ) )) {
-        isvarg = 1;
+        isvarg = TRUE;
     }
 
     ArgList args;
@@ -1392,7 +1392,7 @@ static void ReadFuncExprAbbrevSingle(ReaderState * rs, TypSymbolSet follow)
     ArgList args;
     args.narg = 1;
     args.nams = nams;
-    args.isvarg = 0;
+    args.isvarg = FALSE;
 #ifdef HPCGAP
     args.locks = 0;
 #endif

--- a/src/records.c
+++ b/src/records.c
@@ -39,7 +39,7 @@ static Obj NamesRNam;
 **
 **  'IS_VALID_RNAM' returns if <rnam> is a valid record name.
 */
-static Int IS_VALID_RNAM(UInt rnam)
+static BOOL IS_VALID_RNAM(UInt rnam)
 {
     return rnam != 0 && rnam <= LEN_PLIST(NamesRNam);
 }
@@ -320,7 +320,7 @@ static Obj FuncNameRNam(Obj self, Obj rnam)
 **  'IS_REC' returns a nonzero value if the object <obj> is a  record  and  0
 **  otherwise.
 */
-Int             (*IsRecFuncs[LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsRecFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 static Obj IsRecFilt;
 
@@ -329,7 +329,7 @@ static Obj FiltIS_REC(Obj self, Obj obj)
     return (IS_REC(obj) ? True : False);
 }
 
-static Int IsRecObject(Obj obj)
+static BOOL IsRecObject(Obj obj)
 {
     return (DoFilter( IsRecFilt, obj ) == True);
 }
@@ -376,7 +376,7 @@ static Obj ElmRecObject(Obj obj, UInt rnam)
 **  name <rnam> and 0 otherwise.  An error is signalled if  <rec>  is  not  a
 **  record.
 */
-Int             (*IsbRecFuncs[LAST_REAL_TNUM+1]) ( Obj rec, UInt rnam );
+BOOL (*IsbRecFuncs[LAST_REAL_TNUM + 1])(Obj rec, UInt rnam);
 
 static Obj IsbRecOper;
 
@@ -386,12 +386,12 @@ static Obj IsbRecHandler(Obj self, Obj rec, Obj rnam)
                                                                : False);
 }
 
-static Int IsbRecError(Obj rec, UInt rnam)
+static BOOL IsbRecError(Obj rec, UInt rnam)
 {
     RequireArgument("Record IsBound", rec, "must be a record");
 }
 
-static Int IsbRecObject(Obj obj, UInt rnam)
+static BOOL IsbRecObject(Obj obj, UInt rnam)
 {
     return (DoOperation2Args( IsbRecOper, obj, INTOBJ_INT(rnam) ) == True);
 }
@@ -459,9 +459,7 @@ static void UnbRecObject(Obj obj, UInt rnam)
 *F  iscomplete( <name>, <len> ) . . . . . . . .  find the completions of name
 *F  completion( <name>, <len> ) . . . . . . . .  find the completions of name
 */
-UInt            iscomplete_rnam (
-    Char *              name,
-    UInt                len )
+BOOL iscomplete_rnam(Char * name, UInt len)
 {
     const Char *        curr;
     UInt                i, k;
@@ -470,9 +468,10 @@ UInt            iscomplete_rnam (
     for ( i = 1; i <= countRNam; i++ ) {
         curr = CONST_CSTR_STRING( NAME_RNAM( i ) );
         for ( k = 0; name[k] != 0 && curr[k] == name[k]; k++ ) ;
-        if ( k == len && curr[k] == '\0' )  return 1;
+        if (k == len && curr[k] == '\0')
+            return TRUE;
     }
-    return 0;
+    return FALSE;
 }
 
 UInt            completion_rnam (

--- a/src/records.h
+++ b/src/records.h
@@ -63,9 +63,9 @@ UInt RNamObj(Obj obj);
 *F  IS_REC(<obj>) . . . . . . . . . . . . . . . . . . . is an object a record
 *V  IsRecFuncs[<type>]  . . . . . . . . . . . . . . . . table of record tests
 */
-extern Int (*IsRecFuncs[LAST_REAL_TNUM + 1])(Obj obj);
+extern BOOL (*IsRecFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-EXPORT_INLINE Int IS_REC(Obj obj)
+EXPORT_INLINE BOOL IS_REC(Obj obj)
 {
     return (*IsRecFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -95,9 +95,9 @@ EXPORT_INLINE Obj ELM_REC(Obj rec, UInt rnam)
 **  name <rnam> and 0 otherwise.  An error is signalled if  <rec>  is  not  a
 **  record.
 */
-extern Int (*IsbRecFuncs[LAST_REAL_TNUM + 1])(Obj rec, UInt rnam);
+extern BOOL (*IsbRecFuncs[LAST_REAL_TNUM + 1])(Obj rec, UInt rnam);
 
-EXPORT_INLINE Int ISB_REC(Obj rec, UInt rnam)
+EXPORT_INLINE BOOL ISB_REC(Obj rec, UInt rnam)
 {
     return (*IsbRecFuncs[TNUM_OBJ(rec)])(rec, rnam);
 }
@@ -136,7 +136,7 @@ EXPORT_INLINE void UNB_REC(Obj rec, UInt rnam)
 **
 *F  iscomplete_rnam( <name>, <len> )  . . . . . . . . . . . . .  check <name>
 */
-UInt iscomplete_rnam(Char * name, UInt len);
+BOOL iscomplete_rnam(Char * name, UInt len);
 
 
 /****************************************************************************

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1071,14 +1071,14 @@ static const char * AllKeywords[] = {
     "IsBound", "Unbind",   "TryNextMethod", "Info",     "Assert",
 };
 
-int IsKeyword(const char * str)
+BOOL IsKeyword(const char * str)
 {
     for (UInt i = 0; i < ARRAY_SIZE(AllKeywords); i++) {
         if (strcmp(str, AllKeywords[i]) == 0) {
-            return 1;
+            return TRUE;
         }
     }
-    return 0;
+    return FALSE;
 }
 
 static Obj FuncALL_KEYWORDS(Obj self)

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -251,7 +251,7 @@ typedef struct {
 /* TL: extern  UInt            NrErrLine; */
 
 
-int IsKeyword(const char * str);
+BOOL IsKeyword(const char * str);
 
 
 /****************************************************************************

--- a/src/set.c
+++ b/src/set.c
@@ -59,10 +59,9 @@
 ** 
 */
 
-Int IsSet ( 
-    Obj                 list )
+BOOL IsSet(Obj list)
 {
-    Int                 isSet;          /* result                          */
+    BOOL isSet = FALSE;
 
     /* if <list> is a plain list                                           */
     if ( IS_PLIST( list ) ) {
@@ -70,17 +69,12 @@ Int IsSet (
         /* if <list> is the empty list, it is a set (:-)                     */
         if ( LEN_PLIST(list) == 0 ) {
             RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
-            isSet = 1;
+            isSet = TRUE;
         }
 
         /* if <list>  strictly sorted, it is a set            */
         else if ( IS_SSORT_LIST(list) ) {
-            isSet = 1;
-        }
-
-        /* otherwise it is not a set                                       */
-        else {
-            isSet = 0;
+            isSet = TRUE;
         }
 
     }
@@ -92,7 +86,7 @@ Int IsSet (
         if ( LEN_LIST(list) == 0 ) {
             PLAIN_LIST( list );
             RetypeBagSMIfWritable(list, T_PLIST_EMPTY);
-            isSet = 1;
+            isSet = TRUE;
         }
 
         /* if <list> strictly sorted, it is a set            */
@@ -100,19 +94,9 @@ Int IsSet (
             PLAIN_LIST( list );
             /* SET_FILT_LIST( list, FN_IS_HOMOG ); */
             SET_FILT_LIST( list, FN_IS_SSORT );
-            isSet = 1;
+            isSet = TRUE;
         }
 
-        /* otherwise it is not a set                                       */
-        else {
-            isSet = 0;
-        }
-
-    }
-
-    /* otherwise it is certainly not a set                                 */
-    else {
-        isSet = 0;
     }
 
     return isSet;
@@ -389,7 +373,7 @@ static Obj FuncADD_SET(Obj self, Obj set, Obj obj)
 {
   UInt                len;            /* logical length of the list      */
   UInt                pos;            /* position                        */
-  UInt                isCyc;          /* True if the set being added to consists
+  BOOL                isCyc;          /* True if the set being added to consists
                                          of kernel cyclotomics           */
   UInt                notpos;         /* position of an original element
                                          (not the new one)               */

--- a/src/set.h
+++ b/src/set.h
@@ -48,7 +48,7 @@ Obj SetList(Obj list);
 **  to reflect this. If it is not then 'SetList' is called to make a copy of
 **  'list', remove the holes, sort the copy, and remove the duplicates.
 */
-Int IsSet(Obj list);
+BOOL IsSet(Obj list);
 
 
 /****************************************************************************

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -748,7 +748,7 @@ static Int LenString(Obj list)
 **
 **  'IsbString'  is the function in 'IsbListFuncs'  for strings.
 */
-static Int IsbString(Obj list, Int pos)
+static BOOL IsbString(Obj list, Int pos)
 {
     /* since strings are dense, this must only test for the length         */
     return (pos <= GET_LEN_STRING(list));
@@ -1042,7 +1042,7 @@ static void AsssString(Obj list, Obj poss, Obj vals)
 **
 **  'IsSSortString' is the function in 'IsSSortListFuncs' for strings.
 */
-static Int IsSSortString(Obj list)
+static BOOL IsSSortString(Obj list)
 {
     Int                 len;
     Int                 i;
@@ -1068,7 +1068,7 @@ static Int IsSSortString(Obj list)
 **
 **  'IsPossString' is the function in 'IsPossListFuncs' for strings.
 */
-static Int IsPossString(Obj list)
+static BOOL IsPossString(Obj list)
 {
     return GET_LEN_STRING( list ) == 0;
 }
@@ -1157,11 +1157,11 @@ static void PlainString(Obj list)
 **  'IS_STRING' returns 1  if the object <obj>  is a string  and 0 otherwise.
 **  It does not change the representation of <obj>.
 */
-Int (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+BOOL (*IsStringFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
 static Obj IsStringFilt;
 
-static Int IsStringList(Obj list)
+static BOOL IsStringList(Obj list)
 {
     Int                 lenList;
     Obj                 elm;
@@ -1183,12 +1183,12 @@ static Int IsStringList(Obj list)
     return (lenList < i);
 }
 
-static Int IsStringListHom(Obj list)
+static BOOL IsStringListHom(Obj list)
 {
     return (TNUM_OBJ( ELM_LIST(list,1) ) == T_CHAR);
 }
 
-static Int IsStringObject(Obj obj)
+static BOOL IsStringObject(Obj obj)
 {
     return (DoFilter( IsStringFilt, obj ) != False);
 }
@@ -1294,8 +1294,7 @@ void ConvString (
 **  otherwise.   If <obj> is a  string it  changes  its representation to the
 **  string representation.
 */
-Int IsStringConv (
-    Obj                 obj )
+BOOL IsStringConv(Obj obj)
 {
     Int                 res;
 

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -96,7 +96,7 @@ EXPORT_INLINE UInt1 CHAR_SINT(Int n)
 **
 *F  IS_STRING_REP( <list> ) . . . . . . . .  check if <list> is in string rep
 */
-EXPORT_INLINE Int IS_STRING_REP(Obj list)
+EXPORT_INLINE BOOL IS_STRING_REP(Obj list)
 {
     return (T_STRING <= TNUM_OBJ(list) &&
             TNUM_OBJ(list) <= T_STRING_SSORT + IMMUTABLE);
@@ -266,9 +266,9 @@ void PrintString1(Obj list);
 **  'IS_STRING' returns 1  if the object <obj>  is a string  and 0 otherwise.
 **  It does not change the representation of <obj>.
 */
-extern  Int             (*IsStringFuncs [LAST_REAL_TNUM+1]) ( Obj obj );
+extern BOOL (*IsStringFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 
-EXPORT_INLINE Int IS_STRING(Obj obj)
+EXPORT_INLINE BOOL IS_STRING(Obj obj)
 {
     return (*IsStringFuncs[TNUM_OBJ(obj)])(obj);
 }
@@ -281,7 +281,7 @@ EXPORT_INLINE Int IS_STRING(Obj obj)
 **  'IsString' returns 1 if the object <obj> is a string and 0 otherwise.  It
 **  does not change the representation of <obj>.
 */
-Int IsString(Obj obj);
+BOOL IsString(Obj obj);
 
 
 /****************************************************************************
@@ -322,7 +322,7 @@ void ConvString(Obj string);
 **  otherwise.   If <obj> is a  string it  changes  its representation to the
 **  string representation.
 */
-Int IsStringConv(Obj obj);
+BOOL IsStringConv(Obj obj);
 
 
 // Functions to create mutable and immutable GAP strings from C strings.

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -83,7 +83,7 @@ int SyBufFileno(Int fid);
 **
 **  Given a 'syBuf' buffer id, return 1 if it references a TTY, else 0
 */
-Int SyBufIsTTY(Int fid);
+BOOL SyBufIsTTY(Int fid);
 
 
 // HACK: set 'ateof' to true for the given 'syBuf' entry

--- a/src/sysstr.h
+++ b/src/sysstr.h
@@ -46,7 +46,7 @@
 **  'IsIdent' returns 1 if its character argument can be used unquoted inside
 **  a GAP identifier, i.e., is in the range 'a..zA..Z0-9_@', and 0 otherwise.
 */
-EXPORT_INLINE int IsIdent(char ch)
+EXPORT_INLINE BOOL IsIdent(char ch)
 {
     return isalnum((unsigned int)ch) || ch == '_' || ch == '@';
 }

--- a/src/system.c
+++ b/src/system.c
@@ -43,6 +43,8 @@
 #include <sys/stat.h>
 
 #ifdef SYS_IS_DARWIN
+// Workaround: TRUE / FALSE are also defined by the OS X Mach-O headers
+#define ENUM_DYLD_BOOL
 #include <mach-o/dyld.h>
 #endif
 

--- a/src/trans.h
+++ b/src/trans.h
@@ -13,7 +13,7 @@
 
 #include "objects.h"
 
-EXPORT_INLINE int IS_TRANS(Obj f)
+EXPORT_INLINE BOOL IS_TRANS(Obj f)
 {
     return (TNUM_OBJ(f) == T_TRANS2 || TNUM_OBJ(f) == T_TRANS4);
 }

--- a/src/vars.h
+++ b/src/vars.h
@@ -69,7 +69,7 @@
 *F  IS_LVARS_OR_HVARS()
 **
 */
-EXPORT_INLINE int IS_LVARS_OR_HVARS(Obj obj)
+EXPORT_INLINE BOOL IS_LVARS_OR_HVARS(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     return tnum == T_LVARS || tnum == T_HVARS;

--- a/src/vec8bit.h
+++ b/src/vec8bit.h
@@ -37,7 +37,7 @@ Obj CopyVec8Bit(Obj list, UInt mut);
 */
 extern Obj IsVec8bitRep;
 
-EXPORT_INLINE int IS_VEC8BIT_REP(Obj obj)
+EXPORT_INLINE BOOL IS_VEC8BIT_REP(Obj obj)
 {
     return TNUM_OBJ(obj) == T_DATOBJ && True == DoFilter(IsVec8bitRep, obj);
 }

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -33,29 +33,29 @@
 **
 **  One may think of this as an optimized special case of 'KTNumPlist'.
 */
-static Int IsVecFFE(Obj obj)
+static BOOL IsVecFFE(Obj obj)
 {
     UInt tnum = TNUM_OBJ(obj);
     if (tnum == T_PLIST_FFE || tnum == T_PLIST_FFE + IMMUTABLE)
-        return 1;
+        return TRUE;
 
     // must be a plain list of length >= 1
     if (!IS_PLIST(obj) || LEN_PLIST(obj) == 0)
-        return 0;
+        return FALSE;
 
     Obj x = ELM_PLIST(obj, 1);
     if (!IS_FFE(x))
-        return 0;
+        return FALSE;
 
     const FF  fld = FLD_FFE(x);
     const Int len = LEN_PLIST(obj);
     for (Int i = 2; i <= len; i++) {
         x = ELM_PLIST(obj, i);
         if (!IS_FFE(x) || FLD_FFE(x) != fld)
-            return 0;
+            return FALSE;
     }
     RetypeBagSM(obj, T_PLIST_FFE);
-    return 1;
+    return TRUE;
 }
 
 
@@ -886,7 +886,7 @@ static Obj FuncSMALLEST_FIELD_VECFFE(Obj self, Obj vec)
 {
     Obj elm;
     UInt deg, deg1, deg2, i, len, p, q;
-    UInt isVecFFE;
+    BOOL isVecFFE;
     if (!IS_PLIST(vec))
         return Fail;
     isVecFFE = IsVecFFE(vec);

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -370,7 +370,7 @@ static Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 ** */
 
 
-static Int IsBoundElmWPObj(Obj wp, Obj pos)
+static BOOL IsBoundElmWPObj(Obj wp, Obj pos)
 {
     RequireWPObj("IsBoundElmWPObj", wp);
     UInt ipos = GetPositiveSmallInt("IsBoundElmWPObj", pos);


### PR DESCRIPTION
This is a resurrected version of PR #1883.

This adds `typedef UChar BOOL`; the resulting C type `BOOL` can be used to
indicate that the return type of a function is supposed to be a boolean.
Matching integer constants TRUE=1 and FALSE=0 are also added.

The reason we are not using type `bool` from stdbool.h and the constants
`true` and `false`, all available in C99, is the following: in C99, a pointer
is automatically converted to type bool if necessary. That means that if one
by accident writes `return False` instead of `return false` in a function with
return type `BOOL`, then no compiler warning is issued. Instead, a bug is
introduced, as `False` is a non-NULL pointer, and thus is cast to the `bool`
value `true`.

With this commit, we get warnings similar to the following if we mix up
TRUE/True or FALSE/False; while if using `bool`, we'd only get the latter two
warnings, but not the first one.

    src/objects.c:897:12: error: incompatible pointer to integer conversion
          returning 'Obj' (aka 'unsigned long **') from a function with result
          type 'BOOL' (aka 'unsigned char') [-Werror,-Wint-conversion]
        return False;
               ^~~~~

    src/objects.c:1185:39: error: pointer/integer type mismatch in conditional
          expression ('int' and 'Obj' (aka 'unsigned long **'))
          [-Werror,-Wconditional-type-mismatch]
        return (TNUM_OBJ(obj) == T_COMOBJ ? TRUE : False);
                                          ^ ~~~~   ~~~~~

    src/objects.c:1337:16: error: incompatible integer to pointer conversion
          returning 'int' from a function with result type 'Obj' (aka
          'unsigned long **') [-Werror,-Wint-conversion]
            return TRUE;
                   ^~~~
