### PR TITLE
kernel: refactor GASMAN globals sorting

### DIFF
--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -182,7 +182,7 @@ typedef struct {
 extern TNumGlobalBags GlobalBags;
 
 
-void SortGlobals(UInt byWhat);
+void SortGlobals(void);
 
 Bag * GlobalByCookie(const Char * cookie);
 

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -708,12 +708,7 @@ void LoadWorkspace( Char * fname )
     {
       Panic("Bad divider");
     }
-  SortGlobals(2);               /* globals by cookie for quick
-                                 lookup */
-  for (i = 0; i < GlobalBags.nr; i++)
-    {
-      GAP_ASSERT(GlobalBags.cookie[i] != NULL);
-    }
+    SortGlobals();    // globals by cookie for quick lookup
     // TODO: the goal here is to stop exporting `GlobalBags` completely...
     if (nGlobs != GlobalBags.nr) {
         Panic("Wrong number of global bags in saved workspace %d %d",


### PR DESCRIPTION
- remove sorting mode for globals; only one (by cookie) is supported anyway
- force GASMAN globals to have non-NULL cookie
- use strcmp to compare cookies (works fine as they are non-NULL)
