### PR TITLE
kernel: avoid using GAP_PATH_MAX in headers; add sysroots.{c,h}

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -100,6 +100,7 @@ SOURCES += src/sysfiles.c
 SOURCES += src/sysjmp.c
 SOURCES += src/sysmem.c
 SOURCES += src/sysstr.c
+SOURCES += src/sysroots.c
 SOURCES += src/system.c
 SOURCES += src/systime.c
 SOURCES += src/tietze.c

--- a/src/gap.c
+++ b/src/gap.c
@@ -1216,7 +1216,7 @@ static Obj FuncKERNEL_INFO(Obj self)
     MakeImmutableNoRecurse(tmp);
     AssPRec(res, RNamName("GAP_ROOT_PATHS"), tmp);
 
-    AssPRec(res, RNamName("DOT_GAP_PATH"), MakeImmString(DotGapPath));
+    AssPRec(res, RNamName("DOT_GAP_PATH"), MakeImmString(SyDotGapPath()));
 
     // make command line available to GAP level
     tmp = NEW_PLIST_IMM(T_PLIST, 16);

--- a/src/gap.c
+++ b/src/gap.c
@@ -39,6 +39,7 @@
 #include "sysfiles.h"
 #include "sysmem.h"
 #include "sysopt.h"
+#include "sysroots.h"
 #include "sysstr.h"
 #include "systime.h"
 #include "vars.h"
@@ -1204,18 +1205,7 @@ static Obj FuncKERNEL_INFO(Obj self)
     AssPRec(res, RNamName("KERNEL_API_VERSION"), INTOBJ_INT(GAP_KERNEL_API_VERSION));
     AssPRec(res, RNamName("BUILD_VERSION"), MakeImmString(SyBuildVersion));
     AssPRec(res, RNamName("BUILD_DATETIME"), MakeImmString(SyBuildDateTime));
-
-    // TODO: GAP_ROOT_PATHS, do we need this? Could we rebuild it from the
-    // command line in GAP? If so, should we?
-    tmp = NEW_PLIST_IMM(T_PLIST, MAX_GAP_DIRS);
-    for (i = 0; i < MAX_GAP_DIRS; i++) {
-        if (SyGapRootPaths[i][0]) {
-            PushPlist(tmp, MakeImmString(SyGapRootPaths[i]));
-        }
-    }
-    MakeImmutableNoRecurse(tmp);
-    AssPRec(res, RNamName("GAP_ROOT_PATHS"), tmp);
-
+    AssPRec(res, RNamName("GAP_ROOT_PATHS"), SyGetGapRootPaths());
     AssPRec(res, RNamName("DOT_GAP_PATH"), MakeImmString(SyDotGapPath()));
 
     // make command line available to GAP level

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -16,35 +16,6 @@
 
 #include "system.h"
 
-/****************************************************************************
-**
-*F * * * * * * * * * * * * * * dynamic loading  * * * * * * * * * * * * * * *
-*/
-
-
-/****************************************************************************
-**
-*F  SyFindOrLinkGapRootFile( <filename>, <result> ) . . . . . .  load or link
-**
-**  'SyFindOrLinkGapRootFile'  tries to find a GAP  file in the root area and
-**  check if there is a corresponding statically linked module. If the CRC
-**  matches the statically linked module is loaded, and <result->module_info>
-**  is set to point to its StructInitInfo instance.
-**
-**  The function returns:
-**
-**  0: no file or module was found
-**  2: a statically linked module was found
-**  3: only a GAP file was found; its path is stored in  <result->path>
-*/
-
-typedef union {
-    Char             path[GAP_PATH_MAX];
-    StructInitInfo * module_info;
-} TypGRF_Data;
-
-Int SyFindOrLinkGapRootFile(const Char * filename, TypGRF_Data * result);
-
 
 /****************************************************************************
 **
@@ -440,16 +411,6 @@ Int SyRmdir(const Char * name);
 **  device 'P' for a FIFO (named pipe) and 'S' for a socket.
 */
 Obj SyIsDir(const Char * name);
-
-/****************************************************************************
-**
-*F  SyFindGapRootFile( <filename>, <buffer>, <bufferSize> ) . . .  find file in system area
-**
-**  <buffer> must point to a buffer of at least <bufferSize> characters.
-**  The returned pointer will either be NULL, or <buffer>
-*/
-Char *
-SyFindGapRootFile(const Char * filename, Char * buffer, size_t bufferSize);
 
 
 /****************************************************************************

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -110,7 +110,12 @@ extern Int SyDebugLoading;
 */
 enum { MAX_GAP_DIRS = 16 };
 extern Char SyGapRootPaths[MAX_GAP_DIRS][GAP_PATH_MAX];
-extern Char DotGapPath[GAP_PATH_MAX];
+
+/****************************************************************************
+**
+*F  SyDotGapPath()
+*/
+const Char * SyDotGapPath(void);
 
 /****************************************************************************
 **

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -70,30 +70,6 @@ extern Int SyDebugLoading;
 
 /****************************************************************************
 **
-*V  SyGapRootPaths  . . . . . . . . . . . . . . . . . . . array of root paths
-**
-**  'SyGapRootPaths' conatins the  names   of the directories where   the GAP
-**  files are located.
-**
-**  It is modified by the command line option -l.
-**
-**  It is copied into the GAP variable 'GAPInfo.RootPaths' and used by
-**  'SyFindGapRootFile'.
-**
-**  Each entry must end  with the pathname seperator, eg.  if 'init.g' is the
-**  name of a library file 'strcat( SyGapRootPaths[i], "lib/init.g" );'  must
-**  be a valid filename.
-**
-**  In addition we store the path to the users ~/.gap directory, if available,
-**  in 'DotGapPath'.
-**
-**  Put in this package because the command line processing takes place here.
-*/
-enum { MAX_GAP_DIRS = 16 };
-extern Char SyGapRootPaths[MAX_GAP_DIRS][GAP_PATH_MAX];
-
-/****************************************************************************
-**
 *F  SyDotGapPath()
 */
 const Char * SyDotGapPath(void);

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -49,37 +49,18 @@ extern UInt SyCTRD;
 
 /****************************************************************************
 **
-*V  SyCompileInput  . . . . . . . . . . . . . . . . . .  from this input file
-*/
-extern Char SyCompileInput[GAP_PATH_MAX];
-
-
-/****************************************************************************
-**
-*V  SyCompileMagic1 . . . . . . . . . . . . . . . . . . and this magic number
-*/
-extern Char * SyCompileMagic1;
-
-
-/****************************************************************************
-**
-*V  SyCompileName . . . . . . . . . . . . . . . . . . . . . .  with this name
-*/
-extern Char SyCompileName[256];
-
-
-/****************************************************************************
-**
-*V  SyCompileOutput . . . . . . . . . . . . . . . . . . into this output file
-*/
-extern Char SyCompileOutput[GAP_PATH_MAX];
-
-
-/****************************************************************************
-**
 *V  SyCompilePlease . . . . . . . . . . . . . . .  tell GAP to compile a file
+*V  SyCompileOutput . . . . . . . . . . . . . . . . . . into this output file
+*V  SyCompileInput  . . . . . . . . . . . . . . . . . .  from this input file
+*V  SyCompileName . . . . . . . . . . . . . . . . . . . . . .  with this name
+*V  SyCompileMagic1 . . . . . . . . . . . . . . . . . . and this magic string
 */
 extern Int SyCompilePlease;
+extern Char * SyCompileOutput;
+extern Char * SyCompileInput;
+extern Char * SyCompileName;
+extern Char * SyCompileMagic1;
+
 
 /****************************************************************************
 **

--- a/src/sysroots.c
+++ b/src/sysroots.c
@@ -1,0 +1,225 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+*/
+
+#include "sysroots.h"
+
+#include "gaputils.h"
+#include "plist.h"
+#include "stringobj.h"
+#include "sysfiles.h"
+#include "sysstr.h"
+
+
+/****************************************************************************
+**
+*V  SyGapRootPaths  . . . . . . . . . . . . . . . . . . . array of root paths
+**
+**  'SyGapRootPaths' conatins the  names   of the directories where   the GAP
+**  files are located.
+**
+**  It is modified by the command line option -l.
+**
+**  It is copied into the GAP variable 'GAPInfo.RootPaths' and used by
+**  'SyFindGapRootFile'.
+**
+**  Each entry must end  with the pathname seperator, eg.  if 'init.g' is the
+**  name of a library file 'strcat( SyGapRootPaths[i], "lib/init.g" );'  must
+**  be a valid filename.
+*/
+enum { MAX_GAP_DIRS = 16 };
+static Char SyGapRootPaths[MAX_GAP_DIRS][GAP_PATH_MAX];
+
+
+/****************************************************************************
+**
+*F  SyFindGapRootFile( <filename>, <buf>, <size> ) . find file in system area
+**
+**  <buf> must point to a buffer of at least <size> characters. This function
+**  then searches for a readable file with the name <filename> in the system
+**  area. If sich a file is found then its absolute path is copied into
+**  <buf>, and <buf> is returned. If no file is found or if <buf> is not big
+**  enough, then <buf> is set to an empty string and NULL is returned.
+*/
+Char * SyFindGapRootFile(const Char * filename, Char * buf, size_t size)
+{
+    for (int k = 0; k < ARRAY_SIZE(SyGapRootPaths); k++) {
+        if (SyGapRootPaths[k][0]) {
+            if (strlcpy(buf, SyGapRootPaths[k], size) >= size)
+                continue;
+            if (strlcat(buf, filename, size) >= size)
+                continue;
+            if (SyIsReadableFile(buf) == 0) {
+                return buf;
+            }
+        }
+    }
+    buf[0] = '\0';
+    return 0;
+}
+
+
+/****************************************************************************
+**
+*F  SySetGapRootPath( <string> )  . . . . . . . . .  set the root directories
+**
+**  'SySetGapRootPath' takes a string and modifies a list of root directories
+**  in 'SyGapRootPaths'.
+**
+**  A  leading semicolon in  <string> means  that the list  of directories in
+**  <string> is  appended  to the  existing list  of  root paths.  A trailing
+**  semicolon means they are prepended.   If there is  no leading or trailing
+**  semicolon, then the root paths are overwritten.
+**
+**  This function assumes that the system uses '/' as path separator.
+**  Currently, we support nothing else. For Windows (or rather: Cygwin), we
+**  rely on a small hack which converts the path separator '\' used there
+**  on '/' on the fly. Put differently: Systems that use completely different
+**  path separators, or none at all, are currently not supported.
+*/
+void SySetGapRootPath(const Char * string)
+{
+    const Char * p;
+    Char *       q;
+    Int          i;
+    Int          n;
+
+    /* set string to a default value if unset                              */
+    if (string == 0 || *string == 0) {
+        string = "./";
+    }
+
+    /*
+    ** check if we append, prepend or overwrite.
+    */
+    if (string[0] == ';') {
+        /* Count the number of root directories already present.           */
+        n = 0;
+        while (SyGapRootPaths[n][0] != '\0')
+            n++;
+
+        /* Skip leading semicolon.                                        */
+        string++;
+    }
+    else if (string[strlen(string) - 1] == ';') {
+        /* Count the number of directories in 'string'.                    */
+        n = 0;
+        p = string;
+        while (*p)
+            if (*p++ == ';')
+                n++;
+
+        /* Find last root path.                                            */
+        for (i = 0; i < MAX_GAP_DIRS; i++)
+            if (SyGapRootPaths[i][0] == '\0')
+                break;
+        i--;
+
+#ifdef HPCGAP
+        n *= 2;    // for each root <ROOT> we also add <ROOT/hpcgap> as a root
+#endif
+
+        /* Move existing root paths to the back                            */
+        if (i + n >= MAX_GAP_DIRS)
+            return;
+        while (i >= 0) {
+            memcpy(SyGapRootPaths[i + n], SyGapRootPaths[i],
+                   sizeof(SyGapRootPaths[i + n]));
+            i--;
+        }
+
+        n = 0;
+    }
+    else {
+        /* Make sure to wipe out all possibly existing root paths          */
+        for (i = 0; i < MAX_GAP_DIRS; i++)
+            SyGapRootPaths[i][0] = '\0';
+        n = 0;
+    }
+
+    /* unpack the argument                                                 */
+    p = string;
+    while (*p) {
+        if (n >= MAX_GAP_DIRS)
+            return;
+
+        q = SyGapRootPaths[n];
+        while (*p && *p != ';') {
+            *q = *p++;
+
+#ifdef SYS_IS_CYGWIN32
+            // change backslash to slash for Windows
+            if (*q == '\\')
+                *q = '/';
+#endif
+
+            q++;
+        }
+        if (q == SyGapRootPaths[n]) {
+            strxcpy(SyGapRootPaths[n], "./", sizeof(SyGapRootPaths[n]));
+        }
+        else if (q[-1] != '/') {
+            *q++ = '/';
+            *q = '\0';
+        }
+        else {
+            *q = '\0';
+        }
+        if (*p) {
+            p++;
+        }
+        n++;
+#ifdef HPCGAP
+        // for each root <ROOT> to be added, we first add <ROOT/hpcgap> as a root
+        if (n < MAX_GAP_DIRS) {
+            strlcpy(SyGapRootPaths[n], SyGapRootPaths[n - 1],
+                    sizeof(SyGapRootPaths[n]));
+        }
+        strxcat(SyGapRootPaths[n - 1], "hpcgap/",
+                sizeof(SyGapRootPaths[n - 1]));
+        n++;
+#endif
+    }
+
+    // replace leading tilde ~ by HOME environment variable
+    // TODO; instead of iterating over all entries each time, just
+    // do this for the new entries
+    char * userhome = getenv("HOME");
+    if (!userhome || !*userhome)
+        return;
+    const UInt userhomelen = strlen(userhome);
+    for (i = 0; i < MAX_GAP_DIRS && SyGapRootPaths[i][0]; i++) {
+        const UInt pathlen = strlen(SyGapRootPaths[i]);
+        if (SyGapRootPaths[i][0] == '~' &&
+            userhomelen + pathlen < sizeof(SyGapRootPaths[i])) {
+            SyMemmove(SyGapRootPaths[i] + userhomelen,
+                      /* don't copy the ~ but the trailing '\0' */
+                      SyGapRootPaths[i] + 1, pathlen);
+            memcpy(SyGapRootPaths[i], userhome, userhomelen);
+        }
+    }
+}
+
+
+/****************************************************************************
+**
+*F  SyGetGapRootPaths()
+*/
+Obj SyGetGapRootPaths(void)
+{
+    Obj tmp = NEW_PLIST_IMM(T_PLIST, MAX_GAP_DIRS);
+    for (int i = 0; i < MAX_GAP_DIRS; i++) {
+        if (SyGapRootPaths[i][0]) {
+            PushPlist(tmp, MakeImmString(SyGapRootPaths[i]));
+        }
+    }
+    MakeImmutableNoRecurse(tmp);
+    return tmp;
+}

--- a/src/sysroots.h
+++ b/src/sysroots.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+*/
+
+#ifndef GAP_SYSROOTS_H
+#define GAP_SYSROOTS_H
+
+#include "common.h"
+
+
+/****************************************************************************
+**
+*F  SySetGapRootPath( <string> )  . . . . . . . . .  set the root directories
+**
+**  'SySetGapRootPath' takes a string and modifies a list of root directories
+**  in 'SyGapRootPaths'.
+**
+**  A  leading semicolon in  <string> means  that the list  of directories in
+**  <string> is  appended  to the  existing list  of  root paths.  A trailing
+**  semicolon means they are prepended.   If there is  no leading or trailing
+**  semicolon, then the root paths are overwritten.
+*/
+void SySetGapRootPath(const Char * string);
+
+
+/****************************************************************************
+**
+*F  SyFindGapRootFile( <filename>, <buf>, <size> ) . find file in system area
+**
+**  <buf> must point to a buffer of at least <size> characters. This function
+**  then searches for a readable file with the name <filename> in the system
+**  area. If sich a file is found then its absolute path is copied into
+**  <buf>, and <buf> is returned. If no file is found or if <buf> is not big
+**  enough, then <buf> is set to an empty string and NULL is returned.
+*/
+Char * SyFindGapRootFile(const Char * filename, Char * buf, size_t size);
+
+
+/****************************************************************************
+**
+*F  SyGetGapRootPaths() . . . . . . . . . return the list of root directories
+**
+**  Returns a plain list containing absolute paths of the root directories as
+**  string objects.
+*/
+Obj SyGetGapRootPaths(void);
+
+
+#endif    // GAP_SYSROOTS_H

--- a/src/system.c
+++ b/src/system.c
@@ -79,37 +79,17 @@ UInt SyCTRD;
 
 /****************************************************************************
 **
+*V  SyCompilePlease . . . . . . . . . . . . . . .  tell GAP to compile a file
+*V  SyCompileOutput . . . . . . . . . . . . . . . . . . into this output file
 *V  SyCompileInput  . . . . . . . . . . . . . . . . . .  from this input file
-*/
-Char SyCompileInput[GAP_PATH_MAX];
-
-
-/****************************************************************************
-**
+*V  SyCompileName . . . . . . . . . . . . . . . . . . . . . .  with this name
 *V  SyCompileMagic1 . . . . . . . . . . . . . . . . . . and this magic string
 */
-Char * SyCompileMagic1;
-
-
-/****************************************************************************
-**
-*V  SyCompileName . . . . . . . . . . . . . . . . . . . . . .  with this name
-*/
-Char SyCompileName[256];
-
-
-/****************************************************************************
-**
-*V  SyCompileOutput . . . . . . . . . . . . . . . . . . into this output file
-*/
-Char SyCompileOutput[GAP_PATH_MAX];
-
-
-/****************************************************************************
-**
-*V  SyCompilePlease . . . . . . . . . . . . . . .  tell GAP to compile a file
-*/
 Int SyCompilePlease;
+Char * SyCompileOutput;
+Char * SyCompileInput;
+Char * SyCompileName;
+Char * SyCompileMagic1;
 
 
 /****************************************************************************
@@ -717,12 +697,12 @@ static Int storeMemory2( Char **argv, void *Where )
 
 static Int processCompilerArgs( Char **argv, void * dummy)
 {
-  SyCompilePlease = 1;
-  strxcat( SyCompileOutput, argv[0], sizeof(SyCompileOutput) );
-  strxcat( SyCompileInput, argv[1], sizeof(SyCompileInput) );
-  strxcat( SyCompileName, argv[2], sizeof(SyCompileName) );
-  SyCompileMagic1 = argv[3];
-  return 4;
+    SyCompilePlease = 1;
+    SyCompileOutput = argv[0];
+    SyCompileInput = argv[1];
+    SyCompileName = argv[2];
+    SyCompileMagic1 = argv[3];
+    return 4;
 }
 
 static Int unsetString( Char **argv, void *Where)

--- a/src/system.c
+++ b/src/system.c
@@ -125,7 +125,14 @@ Int SyDebugLoading;
 **
 */
 Char SyGapRootPaths[MAX_GAP_DIRS][GAP_PATH_MAX];
-Char DotGapPath[GAP_PATH_MAX];
+
+
+/****************************************************************************
+**
+*V  DotGapPath
+*/
+static Char DotGapPath[GAP_PATH_MAX];
+
 
 /****************************************************************************
 **
@@ -426,6 +433,16 @@ static void SetupGAPLocation(const char * argv0)
         GAPExecLocation[length] = 0;
         length--;
     }
+}
+
+
+/****************************************************************************
+**
+*F  SyDotGapPath()
+*/
+const Char * SyDotGapPath(void)
+{
+    return DotGapPath;
 }
 
 


### PR DESCRIPTION
Since the definition of `GAP_PATH_MAX` is system dependent, avoiding its use in headers helps to stabilize the ABI of GAP, and removes one (very minor) obstacle for `make install`. That said, we probably could have gotten this also by simply always defining `GAP_PATH_MAX` to be 4096 or so, but I think there is independent value in these changes:
- consolidating code dealing with `SyGapRootPaths` in `sysroots.c` allows us to make `SyGapRootPaths` static and thus hide an implementation detail, allow for future refactoring there
- similarly it is good that `DotGapPath` is now hidden
- the changes to `SyCompileInput` etc. simplify the code and avoid pointless copying around of data in buffers, and also nicely sidesteps the problem of using appropriate buffer sizes.