### PR TITLE
kernel: merge SyTmpname, SyTmpdir into callers

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -1036,14 +1036,10 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 */
 static Obj FuncTmpName(Obj self)
 {
-    Char *              tmp;
-    Obj                 name;
-
-    tmp = SyTmpname();
-    if ( tmp == 0 )
-        return Fail;
-    name = MakeString(tmp);
-    return name;
+    static char name[1024];
+    strxcat(name, "/tmp/gaptempfile.XXXXXX", sizeof(name));
+    close(mkstemp(name));
+    return MakeString(name);
 }
 
 
@@ -1053,14 +1049,25 @@ static Obj FuncTmpName(Obj self)
 */
 static Obj FuncTmpDirectory(Obj self)
 {
-    Char *              tmp;
-    Obj                 name;
+    static char name[1024];
+    char *      env_tmpdir = getenv("TMPDIR");
+    if (env_tmpdir != NULL) {
+        strxcpy(name, env_tmpdir, sizeof(name));
+        strxcat(name, "/", sizeof(name));
+    }
+    else {
+#ifdef SYS_IS_CYGWIN32
+        strxcpy(name, "/cygdrive/c/WINDOWS/Temp/", sizeof(name));
+#else
+        strxcpy(name, "/tmp/", sizeof(name));
+#endif
+    }
+    strxcat(name, "gaptempdirXXXXXX", sizeof(name));
 
-    tmp = SyTmpdir("tm");
-    if ( tmp == 0 )
+    char * tmp = mkdtemp(name);
+    if (tmp == 0)
         return Fail;
-    name = MakeString(tmp);
-    return name;
+    return MakeString(tmp);
 }
 
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -1036,8 +1036,7 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 */
 static Obj FuncTmpName(Obj self)
 {
-    static char name[1024];
-    strxcat(name, "/tmp/gaptempfile.XXXXXX", sizeof(name));
+    char name[] = "/tmp/gaptempfile.XXXXXX";
     close(mkstemp(name));
     return MakeString(name);
 }
@@ -1049,8 +1048,8 @@ static Obj FuncTmpName(Obj self)
 */
 static Obj FuncTmpDirectory(Obj self)
 {
-    static char name[1024];
-    char *      env_tmpdir = getenv("TMPDIR");
+    char   name[GAP_PATH_MAX];
+    char * env_tmpdir = getenv("TMPDIR");
     if (env_tmpdir != NULL) {
         strxcpy(name, env_tmpdir, sizeof(name));
         strxcat(name, "/", sizeof(name));

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3217,60 +3217,6 @@ Obj SyIsDir ( const Char * name )
 *F * * * * * * * * * * * * * * * directories  * * * * * * * * * * * * * * * *
 */
 
-
-/****************************************************************************
-**
-*F  SyTmpname() . . . . . . . . . . . . . . . . . return a temporary filename
-**
-**  'SyTmpname' creates and returns  a new temporary name.  Subsequent  calls
-**  to 'SyTmpname'  should  produce different  file names  *even* if no files
-**  were created.
-*/
-Char *SyTmpname ( void )
-{
-  static char name[1024];
-  strxcpy(name, "/tmp/gaptempfile.XXXXXX", sizeof(name));
-  close(mkstemp(name));
-  return name;
-}
-
-
-/****************************************************************************
-**
-*F  SyTmpdir( <hint> )  . . . . . . . . . . . .  return a temporary directory
-**
-**  'SyTmpdir'  returns the directory   for  a temporary directory.  This  is
-**  guaranteed  to be newly  created and empty  immediately after the call to
-**  'SyTmpdir'. <hint> should be used by 'SyTmpdir' to  construct the name of
-**  the directory (but 'SyTmpdir' is free to use only  a part of <hint>), and
-**  must be a string of at most 8 alphanumerical characters.  Under UNIX this
-**  would   usually   represent   '/usr/tmp/<hint>_<proc_id>_<cnt>/',   e.g.,
-**  '/usr/tmp/guava_17188_1/'.
-*/
-Char * SyTmpdir( const Char * hint )
-{
-#ifdef SYS_IS_CYGWIN32
-#define TMPDIR_BASE "/cygdrive/c/WINDOWS/Temp/"
-#else
-#define TMPDIR_BASE "/tmp/"
-#endif
-  static char name[1024];
-  static const char *base = TMPDIR_BASE;
-  char * env_tmpdir = getenv("TMPDIR");
-  if (env_tmpdir != NULL) {
-    strxcpy(name, env_tmpdir, sizeof(name));
-    strxcat(name, "/", sizeof(name));
-  }
-  else
-    strxcpy(name, base, sizeof(name));
-  if (hint)
-    strxcat(name, hint, sizeof(name));
-  else
-    strxcat(name, "gaptempdir", sizeof(name));
-  strxcat(name, "XXXXXX", sizeof(name));
-  return mkdtemp(name);
-}
-
 /****************************************************************************
 **
 *F  SyReadStringFile( <fid> ) . . . . . . . . read file content into a string

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -421,30 +421,6 @@ Obj SyIsDir(const Char * name);
 
 /****************************************************************************
 **
-*F  SyTmpname() . . . . . . . . . . . . . . . . . return a temporary filename
-**
-**  'SyTmpname' creates and returns a new temporary name.
-*/
-Char * SyTmpname(void);
-
-
-/****************************************************************************
-**
-*F  SyTmpdir( <hint> )  . . . . . . . . . . . .  return a temporary directory
-**
-**  'SyTmpdir'  returns the directory   for  a temporary directory.  This  is
-**  guaranteed  to be newly  created and empty  immediately after the call to
-**  'SyTmpdir'. <hint> should be used by 'SyTmpdir' to  construct the name of
-**  the directory (but 'SyTmpdir' is free to use only  a part of <hint>), and
-**  must be a string of at most 8 alphanumerical characters.  Under UNIX this
-**  would   usually   represent   '/usr/tmp/<hint>_<proc_id>_<cnt>/',   e.g.,
-**  '/usr/tmp/guava_17188_1/'.
-*/
-Char * SyTmpdir(const Char * hint);
-
-
-/****************************************************************************
-**
 *F  void getwindowsize( void )  . probe the OS for the window size and
 **                               set SyNrRows and SyNrCols accordingly
 */


### PR DESCRIPTION
The "portability abstraction" provided by sysfiles.c doesn't help
us these days, it just makes it harder to reason about this code.

This is an hopefully uncontroversial part of PR #3702, which has stalled; I hope this bit can be merged now, so that PR #3702 can be reduced to its essential / controversial bits, to facilitate a resolution there.

UPDATE: while the first commit just moves code, I just added a second commit which also fixes an obvious issue when using these functions in multi threaded code (I replaced two static buffers). This was a trivial fix thanks to the refactoring in the first commit.