### PR TITLE
Request required storage in one allocation in GASMAN

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -2173,9 +2173,17 @@ static Int CollectBags_Check(UInt size, UInt FullBags, UInt nrBags)
 
 
         /* get the storage we absolutely need                              */
-        while ( EndBags < stopBags
-             && SyAllocBags(512,0) )
-            EndBags += WORDS_BAG(512*1024L);
+        if (EndBags < stopBags) {
+            size_t bytes = (char *)stopBags - (char *)EndBags;
+            // Increment in blocks of 512K
+            size_t blocks = bytes / 1024 / 512;
+            if (blocks * 1024 * 512 < bytes) {
+                blocks++;
+            }
+            if (SyAllocBags(blocks * 512, 0)) {
+                EndBags += WORDS_BAG(blocks * 512 * 1024);
+            }
+        }
 
         /* if not enough storage is free, fail                             */
         if ( EndBags < stopBags )


### PR DESCRIPTION
Previously, when we failed to allocate enough memory we would
still extend the GASMAN memory space to the maximum possible size,
which would lead to massive memory usage until the next GC.

To see this, in the current master branch run the following code. The memory usage of GAP will grow massively. With this PR, the memory used by GASMAN does not grow after the failed allocation.

This PR is designed to not change things significantly, in particular it still allocates in a multiple of 512K, just because this is what has always been done.

```
gap> l := [];;
gap> l[2^50] := 1;
Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
not in any function at *stdin*:2
type 'quit;' to quit to outer loop
brk> quit;
gap> while true do List([1..10000], x -> x^2); od;
```