### PR TITLE
FIX: Made ConfluentMonoidPresentationForGroup an attribute

### DIFF
--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -323,3 +323,26 @@ DeclareGlobalFunction("FpGroupCocycle");
 ##
 DeclareGlobalFunction("CompatiblePairOrbitRepsGeneric");
 
+
+#############################################################################
+##
+#A  ConfluentMonoidPresentationForGroup( <G> )
+##
+##  <#GAPDoc Label="ConfluentMonoidPresentationForGroup">
+##  <ManSection>
+##  <Attr Name="ConfluentMonoidPresentationForGroup" Arg='G'/>
+##
+##  <Description>
+##  This attribute holds, for a (finite) group <A>G</A>, a record that holds
+##  information about a confluent monoid presentation, namely a homomorphism
+##  from <A>G</A> to a finitely presented group, a homomorphism from this
+##  finitely presented group to a finitely presented monoid, whose presentation
+##  is a confluent rewriting system, and an ordering wrt. which this system is
+##  confluent.  It is made an attribute
+##  to ensure that iterated cohomology computations use the same presentation.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareAttribute( "ConfluentMonoidPresentationForGroup", IsGroup );
+

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -671,7 +671,9 @@ end );
 
 # return isomorphism G-fp and fp->mon, such that presentation of monoid is
 # confluent (wrt wreath order). Returns list [fphom,monhom,ordering]
-BindGlobal("ConfluentMonoidPresentationForGroup",function(G)
+InstallMethod(ConfluentMonoidPresentationForGroup,"generic",
+  [IsGroup and IsFinite],
+function(G)
 local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
       loff,off,monreps,left,right,fmgens,r,diff,monreal,nums,reduce,hom,dept;
   if IsSymmetricGroup(G) then
@@ -840,11 +842,13 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
   if not HasIsomorphismFpMonoid(G) then
     SetIsomorphismFpMonoid(G,hom);
   fi;
+  j:=rec(fphom:=iso,monhom:=hom);
   if dept=fail then
-    return [iso,hom,k!.ordering];
+    j.ordering:=k!.ordering;
   else
-    return [iso,hom,WreathProductOrdering(fm,dept)];
+    j.ordering:=WreathProductOrdering(fm,dept);
   fi;
+  return j;
 end);
 
 #############################################################################
@@ -984,9 +988,9 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   else
     # new approach with RWS from chief series
     mon:=ConfluentMonoidPresentationForGroup(G);
-    fp:=mon[1];
+    fp:=mon.fphom;
     fpg:=Range(fp);
-    fm:=mon[2];
+    fm:=mon.monhom;
     mon:=Range(fm);
     tzrules:=List(RelationsOfFpMonoid(mon),x->List(x,LetterRepAssocWord));
   fi;


### PR DESCRIPTION
to ensure that always the same presentation is used in subsequent cohomology
calculations.
