### PR TITLE
kernel: move InterpreterStartLine from GAPState to `struct IntrState`

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -56,10 +56,6 @@ typedef struct GAPState {
     UInt   NrError;
     UInt   NrErrLine;
 
-    // Used for recording the first line of the fragment of code currently
-    // begin interpreted, so the current line is outputted when profiling
-    UInt InterpreterStartLine;
-
     const char * Prompt;
 
     char * In;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -59,10 +59,10 @@
 static void INTERPRETER_PROFILE_HOOK(IntrState * intr, int ignoreLevel)
 {
     if (!intr->coding) {
-        InterpreterHook(GetInputFilenameID(), STATE(InterpreterStartLine),
+        InterpreterHook(GetInputFilenameID(), intr->startLine,
                         intr->returning || (intr->ignoring > ignoreLevel));
     }
-    STATE(InterpreterStartLine) = 0;
+    intr->startLine = 0;
 }
 
 

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -44,6 +44,11 @@ struct IntrState {
     // are ignored.
     ExecStatus returning;
 
+    // Record the first line of the fragment of code currently being
+    // interpreted in 'startLine', so we can mark interpreted code lines when
+    // profiling
+    UInt startLine;
+
     // 'StackObj' is the stack of values.
     Obj StackObj;
 

--- a/src/io.c
+++ b/src/io.c
@@ -93,10 +93,6 @@ typedef struct {
     // character
     char * ptr;
 
-    // the number of the line where the fragment of code currently being
-    // interpreted started; used for profiling
-    Int interpreterStartLine;
-
     // the number of the current line; used in error messages
     Int number;
 
@@ -510,7 +506,6 @@ UInt OpenInput (
     if (IO()->InputStackPointer > 0) {
         GAP_ASSERT(IS_CHAR_PUSHBACK_EMPTY());
         IO()->Input->ptr = STATE(In);
-        IO()->Input->interpreterStartLine = STATE(InterpreterStartLine);
     }
 
     /* enter the file identifier and the file name                         */
@@ -531,7 +526,6 @@ UInt OpenInput (
     // start with an empty line
     STATE(In) = IO()->Input->line;
     STATE(In)[0] = STATE(In)[1] = '\0';
-    STATE(InterpreterStartLine) = 0;
     IO()->Input->number = 1;
 
     /* indicate success                                                    */
@@ -555,7 +549,6 @@ UInt OpenInputStream(Obj stream, UInt echo)
     if (IO()->InputStackPointer > 0) {
         GAP_ASSERT(IS_CHAR_PUSHBACK_EMPTY());
         IO()->Input->ptr = STATE(In);
-        IO()->Input->interpreterStartLine = STATE(InterpreterStartLine);
     }
 
     /* enter the file identifier and the file name                         */
@@ -579,7 +572,6 @@ UInt OpenInputStream(Obj stream, UInt echo)
     // start with an empty line
     STATE(In) = IO()->Input->line;
     STATE(In)[0] = STATE(In)[1] = '\0';
-    STATE(InterpreterStartLine) = 0;
     IO()->Input->number = 1;
 
     /* indicate success                                                    */
@@ -634,7 +626,6 @@ UInt CloseInput ( void )
 #endif
     IO()->Input = IO()->InputStack[sp - 1];
     STATE(In) = IO()->Input->ptr;
-    STATE(InterpreterStartLine) = IO()->Input->interpreterStartLine;
 
     /* indicate success                                                    */
     return 1;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -213,10 +213,6 @@ void Match(ScannerState * s,
 {
     Char                errmsg [256];
 
-    if (STATE(InterpreterStartLine) == 0 && symbol != S_ILLEGAL) {
-        STATE(InterpreterStartLine) = s->SymbolStartLine[0];
-    }
-
     // if 's->Symbol' is the expected symbol match it away
     if (symbol == s->Symbol) {
         s->Symbol = NextSymbol(s);


### PR DESCRIPTION
This further decouples the scanner/reader/interpreter from the IO code.

<s>This is based on PR #3823, which is the first commit of this PR. Thus if anybody wants to review this PR already now, you may wish to focus on the second commit.

I am posting it already now because I want to see how my change affects code coverage.</s>

PR #3823 has been merged, so this can be reviewed.