### PR TITLE
kernel: make MarkAllSubBagsDefault private, use in Julia GC

### DIFF
--- a/src/bags.inc
+++ b/src/bags.inc
@@ -55,8 +55,3 @@ void MarkAllButFirstSubBags(Bag bag)
 {
     MarkArrayOfBags(CONST_PTR_BAG(bag) + 1, SIZE_BAG(bag) / sizeof(Bag) - 1);
 }
-
-void MarkAllSubBagsDefault(Bag bag)
-{
-    MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag));
-}

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -554,19 +554,24 @@ void InitSweepFuncBags (
 
 /****************************************************************************
 **
+*F  MarkAllSubBagsDefault(<bag>) . . . marking function that marks everything
+**
+**  'MarkAllSubBagsDefault' is the same  as 'MarkAllSubBags' but is used as
+**  the initial default marking function. This allows to catch cases where
+**  'InitMarkFuncBags' is called twice for the same type: the first time is
+**  accepted because the marking function is still 'MarkAllSubBagsDefault';
+**  the second time raises a warning, because a non-default marking function
+**  is being replaced.
+*/
+static void MarkAllSubBagsDefault(Bag bag)
+{
+    MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag));
+}
+
+
+/****************************************************************************
+**
 *F  InitMarkFuncBags(<type>,<mark-func>)  . . . . .  install marking function
-*F  MarkNoSubBags(<bag>)  . . . . . . . . marking function that marks nothing
-*F  MarkOneSubBags(<bag>) . . . . . .  marking function that marks one subbag
-*F  MarkTwoSubBags(<bag>) . . . . . . marking function that marks two subbags
-*F  MarkThreeSubBags(<bag>) . . . . marking function that marks three subbags
-*F  MarkFourSubBags(<bag>)  . . . .  marking function that marks four subbags
-*F  MarkAllSubBags(<bag>) . . . . . .  marking function that marks everything
-**
-**  'InitMarkFuncBags', 'MarkNoSubBags', 'MarkOneSubBags',  'MarkTwoSubBags',
-**  and 'MarkAllSubBags' are really too simple for an explanation.
-**
-**  'MarkAllSubBagsDefault' is the same  as 'MarkAllSubBags' but is only used
-**  by GASMAN as default.  This will allow to catch type clashes.
 */
 
 TNumMarkFuncBags TabMarkFuncBags [ NUM_TYPES ];

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -693,9 +693,13 @@ void MarkFourSubBags(Bag bag);
 */
 void MarkAllSubBags(Bag bag);
 
-void MarkAllSubBagsDefault(Bag);
 
+/****************************************************************************
+**
+*F  MarkAllButFirstSubBags(<bag>) . . . .  marks all subbags except the first
+*/
 void MarkAllButFirstSubBags(Bag bag);
+
 
 /****************************************************************************
 **


### PR DESCRIPTION
MarkAllSubBagsDefault is an implementation detail of GASMAN (and
now also Julia GC), and should not be used by client code ever. As such,
it seems sensible to hide its implementation.

Also update/remove/add some comments.

This PR conflicts with PR #3840, but resolving the clash should be trivial. I'll happily do it for this PR if PR #3840 gets merged first.