### PR TITLE
kernel: avoid Intr{Begin,End} calls, remove Exec{Begin,End}

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -43,7 +43,6 @@ static ModuleStateOffset FuncsStateOffset = -1;
 
 struct FuncsModuleState {
     Int RecursionDepth;
-    Obj ExecState;
 };
 
 extern inline struct FuncsModuleState *FuncsState(void)
@@ -766,28 +765,6 @@ static void PrintFunccallOpts(Expr call)
     Pr(" %4<)", 0, 0);
 }
 
-  
-
-/****************************************************************************
-**
-*F  ExecBegin() . . . . . . . . . . . . . . . . . . . . .  begin an execution
-*F  ExecEnd(<error>)  . . . . . . . . . . . . . . . . . . .  end an execution
-*/
-
-void ExecBegin(Obj frame)
-{
-    // remember the old execution state
-    PushPlist(FuncsState()->ExecState, STATE(CurrLVars));
-
-    // set up new state
-    SWITCH_TO_OLD_LVARS( frame );
-}
-
-void ExecEnd(UInt error)
-{
-    // switch back to the old state
-    SWITCH_TO_OLD_LVARS(PopPlist(FuncsState()->ExecState));
-}
 
 /****************************************************************************
 **
@@ -850,9 +827,6 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
     RecursionTrapInterval = 5000;
-
-    /* make the global variable known to Gasman                            */
-    InitGlobalBag( &FuncsState()->ExecState, "src/funcs.c:ExecState" );
 
     /* Register the handler for our exported function                      */
     InitHdlrFuncsFromTable( GVarFuncs );
@@ -920,7 +894,6 @@ static Int InitKernel (
 
 static Int InitModuleState(void)
 {
-    FuncsState()->ExecState = NEW_PLIST(T_PLIST_EMPTY, 16);
     FuncsState()->RecursionDepth = 0;
 
     return 0;

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -27,16 +27,6 @@
 */
 Obj MakeFunction(Obj fexp);
 
-/****************************************************************************
-**
-*F  ExecBegin( <frame> ) . . . . . . . .  begin an execution in context frame
-**  if in doubt, pass STATE(BottomLVars) as <frame>
-**
-*F  ExecEnd(<error>)  . . . . . . . . . . . . . . . . . . .  end an execution
-*/
-void ExecBegin(Obj frame);
-void ExecEnd(UInt error);
-
 
 /****************************************************************************
 **

--- a/src/gap.c
+++ b/src/gap.c
@@ -45,7 +45,6 @@
 #include "vars.h"
 
 #ifdef HPCGAP
-#include "intrprtr.h"
 #include "hpc/misc.h"
 #include "hpc/thread.h"
 #include "hpc/threadapi.h"

--- a/src/gap.h
+++ b/src/gap.h
@@ -51,8 +51,8 @@ void ViewObjHandler(Obj obj);
 **                      subroutines, explaining why evaluation, or execution
 **                      has terminated.
 **
-**  Values are powers of two, although I do not currently know of any
-**  cirumstances where they can get combined
+**  Values are powers of two; this is used to test a given status for
+**  multiple possible values simultaneously.
 */
 
 typedef UInt ExecStatus;

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -39,13 +39,18 @@ struct IntrState {
     // directly interpret, such as loops or function bodies.
     UInt coding;
 
-    // If 'IntrReturning' is non-zero, the interpreter is currently exiting
+    // If 'returning' is non-zero, the interpreter is currently exiting
     // statements enclosing a return statement. Actions from these statements
     // are ignored.
     ExecStatus returning;
 
     // 'StackObj' is the stack of values.
     Obj StackObj;
+
+    // 'IntrBegin' stores in 'oldLVars' the previous value of
+    // 'STATE(CurrLVars)', and 'IntrEnd' restores it from there by calling
+    // 'SWITCH_TO_OLD_LVARS'.
+    Bag oldLVars;
 };
 
 typedef struct IntrState IntrState;
@@ -878,13 +883,6 @@ void IntrAssertEnd3Args(IntrState * intr);
 *F  IntrContinue() . . . . . . . . . . . . . . . interpret continue-statement
 */
 void IntrContinue(IntrState * intr);
-
-
-/****************************************************************************
-**
-*F  PushVoidObj() . . . . . . . . . . . . . .  push void value onto the stack
-*/
-void PushVoidObj(IntrState * intr);
 
 
 /****************************************************************************

--- a/src/modules.c
+++ b/src/modules.c
@@ -35,6 +35,7 @@
 #include "stringobj.h"
 #include "sysfiles.h"
 #include "sysopt.h"
+#include "vars.h"
 
 #ifdef HAVE_DLOPEN
 #include <dlfcn.h>
@@ -155,9 +156,10 @@ Int ActivateModule(StructInitInfo * info)
         if (info->initLibrary) {
             // Start a new executor to run the outer function of the module in
             // global context
-            ExecBegin(STATE(BottomLVars));
+            Bag oldLvars = STATE(CurrLVars);
+            SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
             res = res || info->initLibrary(info);
-            ExecEnd(res);
+            SWITCH_TO_OLD_LVARS(oldLvars);
         }
     }
 


### PR DESCRIPTION
Also remove FuncsState()->ExecState. We can instead store the old lvars on the
stack resp. in the interpreter state.