### PR TITLE
FIX: Printing of assoc. words if there are iterated powers

### DIFF
--- a/lib/wordrep.gi
+++ b/lib/wordrep.gi
@@ -219,9 +219,9 @@ local a,n,t,
    or (IsInt(PRINTWORDPOWERS) and Length(l)<PRINTWORDPOWERS)) and
      ValueOption("printnopowers")<>true then
     if Length(l)>0 and n=infinity then
-      n:=2*(AbsInt(Maximum(l))+1); 
+      n:=2*(Maximum(List(l,AbsInt))+1);
     fi;
-    a:=FindSubstringPowers(l,n);
+    a:=FindSubstringPowers(l,n+Length(tseed)); # tseed numbers are used already
   else
     a:=[l,[]];
   fi;

--- a/tst/testbugfix/2020-01-13-wordprint.tst
+++ b/tst/testbugfix/2020-01-13-wordprint.tst
@@ -1,0 +1,4 @@
+# Assoc. word printing, #3845
+gap> f:=FreeGroup("x","y");;AssignGeneratorVariables(f);
+gap> y^4*(y^2*(y*x)^2)^2*y^-7*x*y^16;
+y^4*(y^2*(y*x)^2)^2*y^-7*x*y^16

--- a/tst/testbugfix/2020-01-13-wordprint.tst
+++ b/tst/testbugfix/2020-01-13-wordprint.tst
@@ -1,4 +1,4 @@
 # Assoc. word printing, #3845
-gap> f:=FreeGroup("x","y");;AssignGeneratorVariables(f);
+gap> f:=FreeGroup("x","y");;x:=f.1;;y:=f.2;;
 gap> y^4*(y^2*(y*x)^2)^2*y^-7*x*y^16;
 y^4*(y^2*(y*x)^2)^2*y^-7*x*y^16


### PR DESCRIPTION
Re-indexing with temporary letters went wrong if there were already powers
stored.

close #3845


## Text for release notes 

An error in printing certain words in free groups (if subexpressions occur as powers iteratedly) was fixed