### PR TITLE
kernel: fix OnSets to preserve immutability

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1105,10 +1105,10 @@ static Obj FuncOnSets(Obj self, Obj set, Obj elm)
         break;
         
       case 1:
-        RetypeBag( img, T_PLIST_DENSE_NHOM_SSORT );
+        RetypeBagSM( img, T_PLIST_DENSE_NHOM_SSORT );
 
       case 2:
-        RetypeBag( img, T_PLIST_HOM_SSORT );
+        RetypeBagSM( img, T_PLIST_HOM_SSORT );
 
       }
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -813,7 +813,7 @@ void MakeImmutable( Obj obj )
 void CheckedMakeImmutable( Obj obj )
 {
   if (!PreMakeImmutableCheck(obj))
-    ErrorQuit("MakeImmutable: Argument has inaccessible subobjects", 0, 0);
+    ErrorMayQuit("MakeImmutable: Argument has inaccessible subobjects", 0, 0);
   MakeImmutable(obj);
 }
 #endif

--- a/tst/testbugfix/2020-01-13-OnSets-Mutability.tst
+++ b/tst/testbugfix/2020-01-13-OnSets-Mutability.tst
@@ -1,0 +1,28 @@
+# OnSets would sometimes return a mutable list when it should have returned an
+# immutable one; in HPC-GAP this got worse, as the final object was a mutable
+# and *public* list.
+#
+# This only happened if the acting element was not internal, i.e., not a
+# permutation, partial permutation or transformation.
+gap> g:=SymmetricGroup(5);;
+gap> phi:=ConjugatorAutomorphism(g,One(g));;
+
+# mutable -> mutable
+gap> l:=OnSets([ (1,2) ], phi);
+[ (1,2) ]
+gap> IsMutable(l);
+true
+#@if IsHPCGAP
+gap> IsPublic(l);
+false
+#@fi
+
+# immutable -> immutable
+gap> l:=OnSets(Immutable([ (1,2) ]), phi);
+[ (1,2) ]
+gap> IsMutable(l);
+false
+#@if IsHPCGAP
+gap> IsPublic(l);
+true
+#@fi


### PR DESCRIPTION
OnSets would sometimes return a mutable list when it should have returned an
immutable one; in HPC-GAP this got worse, as the final object was a mutable
and *public* list, which lead to inconsistencies down the road.

Also change `CheckedMakeImmutable` to trigger a break loop when there is an
error, so that "Argument has inaccessible subobjects" errors are easier to
track down.

This is mildly annoying in GAP, but really bad in HPC-GAP, as a critical invariant is violated by this. The issue has been present since "forever", i.e., at least since GAP 4.4.