### PR TITLE
kernel: prevent immutable -> mutable conversion

### DIFF
--- a/src/bags.c
+++ b/src/bags.c
@@ -24,14 +24,58 @@ TNumInfoBags InfoBags[NUM_TYPES];
 UInt8 SizeAllBags;
 
 
+#ifdef GAP_KERNEL_DEBUG
+void PrecheckRetypeBag(Bag bag, UInt new_type)
+{
+    // If the new type contains an (im)mutability bit, verify that this does
+    // not remove mutability from an object that was previously mutable --
+    // something we generally don't allow
+    if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
+#if !defined(USE_THREADSAFE_COPYING)
+        // HACK: T_COPYING is used for mutable and immutable objects alike, so
+        // we can't really determine whether it is "mutable" or not. In
+        // fact, it is not even a "real" TNUM (it comes after LAST_REAL_TNUM),
+        // so asking such an object for mutability is not even supported.
+        //
+        // In the future, there are at least two ways we could get rid of this
+        // hack: Either we drop T_COPYING by adopting the copying code from
+        // HPC-GAP for regular GAP as well. Or we could add an
+        // IMMUTABLE_OBJ_FLAG which can be used to mark any object as
+        // immutable, including T_COPYING objects.
+        if (TNUM_BAG(bag) == T_COPYING)
+            return;
+#endif
+
+#ifndef HPCGAP
+        // HACK: when using `DeclareGlobalVariable`, the placeholder object of
+        // type `IsToBeDefinedObj` is immutable, while `InstallValue` also
+        // accepts mutable values, which are then copied into the placeholder
+        // *bag* itself, thus turning the placeholder (which is a T_POSOBJ)
+        // into any different kind of bag, including mutable ones.
+        if (TNUM_BAG(bag) == T_POSOBJ)
+            return;
+#endif
+        Int oldImm = !IS_MUTABLE_OBJ(bag);
+        Int newImm = new_type & IMMUTABLE;
+        if (oldImm && !newImm) {
+            ErrorMayQuit(
+                "RetypeBag: cannot change immutable object to mutable", 0, 0);
+        }
+    }
+}
+#endif
+
+
 // TODO: perhaps this should become RetypeObj ?
 void RetypeBagSM(Bag bag, UInt new_type)
 {
-   if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
+    if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
         Int oldImm = !IS_MUTABLE_OBJ(bag);
         Int newImm = new_type & IMMUTABLE;
         if (newImm)
-            ErrorMayQuit("RetypeBagSM: target tnum should not indicate immutability", 0, 0);
+            ErrorMayQuit(
+                "RetypeBagSM: target tnum should not indicate immutability",
+                0, 0);
         if (oldImm)
             new_type |= IMMUTABLE;
     }
@@ -41,11 +85,13 @@ void RetypeBagSM(Bag bag, UInt new_type)
 #ifdef HPCGAP
 void RetypeBagSMIfWritable(Bag bag, UInt new_type)
 {
-   if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
+    if (FIRST_IMM_MUT_TNUM <= new_type && new_type <= LAST_IMM_MUT_TNUM) {
         Int oldImm = !IS_MUTABLE_OBJ(bag);
         Int newImm = new_type & IMMUTABLE;
         if (newImm)
-            ErrorMayQuit("RetypeBagSM: target tnum should not indicate immutability", 0, 0);
+            ErrorMayQuit(
+                "RetypeBagSM: target tnum should not indicate immutability",
+                0, 0);
         if (oldImm)
             new_type |= IMMUTABLE;
     }

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -320,7 +320,7 @@ UInt CollectBags(UInt size, UInt full)
     return 1;
 }
 
-void RetypeBag(Bag bag, UInt new_type)
+void RetypeBagIntern(Bag bag, UInt new_type)
 {
     BagHeader * header = BAG_HEADER(bag);
     UInt        old_type = header->type;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1325,9 +1325,7 @@ Bag NewBag (
 **  If  {\Gasman} was compiled with the  option 'COUNT_BAGS' then 'RetypeBag'
 **  also updates the information in 'InfoBags' (see "InfoBags").
 */
-void            RetypeBag (
-    Bag                 bag,
-    UInt                new_type )
+void RetypeBagIntern(Bag bag, UInt new_type)
 {
     BagHeader * header = BAG_HEADER(bag);
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -449,7 +449,8 @@ EXPORT_INLINE Bag NewWordSizedBag(UInt type, UInt size)
 
 /****************************************************************************
 **
-*F  RetypeBag(<bag>,<new>)  . . . . . . . . . . . .  change the type of a bag
+*F  RetypeBag(<bag>,<new>) . . . . . . . . . . . . . change the type of a bag
+*F  RetypeBagIntern(<bag>,<new>) . . . . . . . . . . . . . internal interface
 **
 **  'RetypeBag' changes the type of the bag with identifier <bag>  to the new
 **  type <new>.  The identifier, the size,  and also the  address of the data
@@ -468,14 +469,31 @@ EXPORT_INLINE Bag NewWordSizedBag(UInt type, UInt size)
 **  It is, as usual, the responsibility of the application to ensure that the
 **  data stored in the bag makes sense when the  bag is interpreted  as a bag
 **  of type <type>.
+**
+**  'RetypeBagIntern' is the internal version of 'RetypeBag', implemented by
+**  the GC backend. It is called by 'RetypeBag'.
 */
-void RetypeBag(Bag bag, UInt new_type);
+void RetypeBagIntern(Bag bag, UInt new_type);
 
 #ifdef HPCGAP
 void RetypeBagIfWritable(Bag bag, UInt new_type);
 #else
 #define RetypeBagIfWritable(x,y)     RetypeBag(x,y)
 #endif
+
+#ifdef GAP_KERNEL_DEBUG
+// This helper tests whether the type change is "allowed". As such, it rejects
+// attempts to retype an immutable list or record into a mutable one.
+void PrecheckRetypeBag(Bag bag, UInt new_type);
+#endif
+
+EXPORT_INLINE void RetypeBag(Bag bag, UInt new_type)
+{
+#ifdef GAP_KERNEL_DEBUG
+    PrecheckRetypeBag(bag, new_type);
+#endif
+    RetypeBagIntern(bag, new_type);
+}
 
 
 /****************************************************************************

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -833,7 +833,7 @@ UInt CollectBags(UInt size, UInt full)
     return 1;
 }
 
-void RetypeBag(Bag bag, UInt new_type)
+void RetypeBagIntern(Bag bag, UInt new_type)
 {
     BagHeader * header = BAG_HEADER(bag);
     UInt        old_type = header->type;


### PR DESCRIPTION
This is inspired by PR #3848, and should help catch similar issues resp. prevent us from regressing in this area.

This imposes a small performance overhead for `RetypeBag`; however, we perform this rather rarely, so I kinda hope it doesn't matter, but I have not yet performed any benchmarks. If there turns out to be a performance issue, one could move the `RetypeBag` into a header and mark it as `inline`; and/or restrict this check to kernel debug mode (now that I think about it, I probably want to do the latter)...

But for now, I just wanted this PR out there to get some initial traction and see if it uncovers any issues in the test suite. 

