### PR TITLE
Fix assertion in Factors for polynomials over cyclotomics

### DIFF
--- a/lib/cyclotom.gi
+++ b/lib/cyclotom.gi
@@ -1941,7 +1941,7 @@ InstallMethod( Factors,
     fi;
 
     # Store the factorization.
-    Assert( 2, Product( factors ) = pol );
+    Assert( 2, Product( factors ) = lc * pol * IndeterminateOfUnivariateRationalFunction( pol )^val );
     StoreFactorsPol( coeffring, pol, factors );
 
     # Return the factorization.

--- a/tst/testinstall/ratfun.tst
+++ b/tst/testinstall/ratfun.tst
@@ -104,7 +104,45 @@ gap> (t^24-1)/(t^16-1);
 gap> (t^24-1)/(t^-16-1);
 (t^32+t^24+t^16)/(-t^8-1)
 
-#
+# factor over rationals
+gap> Factors(t^0);
+[ 1 ]
+gap> Factors(t^1);
+[ t ]
+gap> Factors(t^2);
+[ t, t ]
+gap> Factors(t-1);
+[ t-1 ]
+gap> Factors((t-1)*t);
+[ t-1, t ]
+gap> Factors((t-1)*t^2);
+[ t-1, t, t ]
+gap> Factors(t^2-1);
+[ t-1, t+1 ]
+gap> Factors((t^2-1)*t);
+[ t-1, t, t+1 ]
+gap> Factors((t^2-1)*t^2);
+[ t-1, t, t, t+1 ]
+
+# factor over abelian number field
+gap> Factors(E(7)*t^0);
+[ E(7) ]
+gap> Factors(E(7)*t^1);
+[ E(7)*t ]
+gap> Factors(E(7)*t^2);
+[ E(7)*t, t ]
+gap> Factors(E(7)*(t-1));
+[ E(7)*t+(-E(7)) ]
+gap> Factors(E(7)*(t-1)*t);
+[ E(7)*t, t-1 ]
+gap> Factors(E(7)*(t-1)*t^2);
+[ E(7)*t, t, t-1 ]
+gap> Factors(E(7)*t^2-1);
+[ E(7)*t+(-E(7)^4), t+E(7)^3 ]
+gap> Factors(E(7)*(t^2-1)*t);
+[ E(7)*t+(-E(7)), t, t+1 ]
+gap> Factors(E(7)*(t^2-1)*t^2);
+[ E(7)*t+(-E(7)), t, t, t+1 ]
 gap> Gcd(t-2,t^2-2*t);
 t-2
 


### PR DESCRIPTION
The function at the start splits of all factors x^k, and `pol` is set to the
resulting polynomial. But `factors` contains all factors of the original
polynomial; so the assertion check would then fail.
