### PR TITLE
kernel: refactor SET_TYPE_OBJ, add some input validation and tests

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -330,6 +330,10 @@ void RetypeBagIntern(Bag bag, UInt new_type)
     BagHeader * header = BAG_HEADER(bag);
     UInt        old_type = header->type;
 
+    // exit early if nothing is to be done
+    if (old_type == new_type)
+        return;
+
     /* change the size-type word                                           */
     header->type = new_type;
     {

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1394,14 +1394,17 @@ Bag NewBag (
 void RetypeBagIntern(Bag bag, UInt new_type)
 {
     BagHeader * header = BAG_HEADER(bag);
+    UInt        old_type = header->type;
+
+    // exit early if nothing is to be done
+    if (old_type == new_type)
+        return;
 
 #ifdef COUNT_BAGS
     /* update the statistics      */
     {
-          UInt                old_type;       /* old type of the bag */
           UInt                size;
 
-          old_type = header->type;
           size = header->size;
           InfoBags[old_type].nrLive   -= 1;
           InfoBags[new_type].nrLive   += 1;

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -838,6 +838,10 @@ void RetypeBagIntern(Bag bag, UInt new_type)
     BagHeader * header = BAG_HEADER(bag);
     UInt        old_type = header->type;
 
+    // exit early if nothing is to be done
+    if (old_type == new_type)
+        return;
+
 #ifdef COUNT_BAGS
     /* update the statistics      */
     {

--- a/src/objects.c
+++ b/src/objects.c
@@ -1540,10 +1540,7 @@ static Obj FuncSET_TYPE_DATOBJ(Obj self, Obj obj, Obj type)
     ReadGuard( obj );
 #endif
     SET_TYPE_DATOBJ(obj, type);
-#ifdef HPCGAP
-    if (TNUM_OBJ(obj) != T_DATOBJ)
-#endif
-      RetypeBag( obj, T_DATOBJ );
+    RetypeBag( obj, T_DATOBJ );
     CHANGED_BAG( obj );
     return obj;
 #endif

--- a/src/objects.c
+++ b/src/objects.c
@@ -230,7 +230,10 @@ void SET_TYPE_OBJ(Obj obj, Obj type)
         break;
 
     default:
-        if (IS_PLIST(obj)) {
+        if (IS_STRING_REP(obj)) {
+            // FIXME/TODO: Hap calls Objectify on a string...
+        }
+        else if (IS_PLIST(obj)) {
 #ifdef HPCGAP
             MEMBAR_WRITE();
 #endif
@@ -1337,7 +1340,10 @@ static Obj FuncSET_TYPE_POSOBJ(Obj self, Obj obj, Obj type)
     case T_POSOBJ:
         break;
     default:
-        if (!IS_PLIST(obj)) {
+        if (IS_STRING_REP(obj)) {
+            // FIXME/TODO: Hap calls Objectify on a string...
+        }
+        else if (!IS_PLIST(obj)) {
             ErrorMayQuit("You can't make a positional object from a %s",
                          (Int)TNAM_OBJ(obj), 0);
         }

--- a/src/objects.c
+++ b/src/objects.c
@@ -239,7 +239,7 @@ void SET_TYPE_OBJ(Obj obj, Obj type)
             CHANGED_BAG(obj);
         }
         else {
-            ErrorQuit("cannot change type of a %s", (Int)TNAM_OBJ(obj), 0);
+            ErrorMayQuit("cannot change type of a %s", (Int)TNAM_OBJ(obj), 0);
         }
         break;
     }
@@ -1201,27 +1201,19 @@ static Obj FuncIS_COMOBJ(Obj self, Obj obj)
 */
 static Obj FuncSET_TYPE_COMOBJ(Obj self, Obj obj, Obj type)
 {
-#ifdef HPCGAP
     switch (TNUM_OBJ(obj)) {
-      case T_PREC:
-      case T_COMOBJ:
-      case T_AREC:
-      case T_ACOMOBJ:
-        SET_TYPE_OBJ( obj, type );
+    case T_PREC:
+    case T_COMOBJ:
+#ifdef HPCGAP
+    case T_AREC:
+    case T_ACOMOBJ:
+#endif
+        SET_TYPE_OBJ(obj, type);
         break;
-      default:
-        ErrorMayQuit("You can't make component object from a %s.",
+    default:
+        ErrorMayQuit("You can't make a component object from a %s",
                      (Int)TNAM_OBJ(obj), 0);
     }
-#else
-    if (TNUM_OBJ(obj) == T_PREC+IMMUTABLE)
-        ErrorMayQuit(
-            "You can't make a component object from an immutable object", 0,
-            0);
-    SET_TYPE_COMOBJ(obj, type);
-    RetypeBag( obj, T_COMOBJ );
-    CHANGED_BAG( obj );
-#endif
     return obj;
 }
 
@@ -1336,25 +1328,24 @@ static Obj FuncIS_POSOBJ(Obj self, Obj obj)
 */
 static Obj FuncSET_TYPE_POSOBJ(Obj self, Obj obj, Obj type)
 {
-#ifdef HPCGAP
     switch (TNUM_OBJ(obj)) {
-      case T_APOSOBJ:
-      case T_ALIST:
-      case T_FIXALIST:
-      case T_POSOBJ:
-        SET_TYPE_OBJ( obj, type );
+#ifdef HPCGAP
+    case T_APOSOBJ:
+    case T_ALIST:
+    case T_FIXALIST:
+#endif
+    case T_POSOBJ:
         break;
-      default:
-        SET_TYPE_POSOBJ(obj, type);
-        RetypeBag( obj, T_POSOBJ );
-        CHANGED_BAG( obj );
+    default:
+        if (!IS_PLIST(obj)) {
+            ErrorMayQuit("You can't make a positional object from a %s",
+                         (Int)TNAM_OBJ(obj), 0);
+        }
+        // TODO: we should also reject immutable plists, but that risks
+        // breaking existing code
         break;
     }
-#else
-    RetypeBag( obj, T_POSOBJ );
-    SET_TYPE_POSOBJ(obj, type);
-    CHANGED_BAG( obj );
-#endif
+    SET_TYPE_OBJ(obj, type);
     return obj;
 }
 

--- a/tst/testinstall/kernel/objects.tst
+++ b/tst/testinstall/kernel/objects.tst
@@ -1,0 +1,24 @@
+#
+# Tests for functions defined in src/objects.c
+#
+gap> START_TEST("kernel/objects.tst");
+
+# SET_TYPE_COMOBJ
+gap> SET_TYPE_COMOBJ(fail, fail);
+Error, You can't make a component object from a boolean or fail
+gap> SET_TYPE_COMOBJ([], fail);
+Error, You can't make a component object from a empty plain list
+gap> SET_TYPE_COMOBJ(MakeImmutable(rec()), fail);
+Error, You can't make a component object from a record (plain,imm)
+
+# SET_TYPE_POSOBJ
+gap> SET_TYPE_POSOBJ(fail, fail);
+Error, You can't make a positional object from a boolean or fail
+gap> SET_TYPE_POSOBJ(rec(), fail);
+Error, You can't make a positional object from a record (plain)
+
+# TODO: the following should also fail, but for now we allow it
+gap> #SET_TYPE_POSOBJ(MakeImmutable([]), fail);
+
+#
+gap> STOP_TEST("kernel/objects.tst", 1);


### PR DESCRIPTION
This touches upon a particular dark corner (IMHO) of the code, were I always wondered why certain checks were done one way in one place, and a different way in another place; and why there was no input validation at all.