### PR TITLE
ctags: handle BindGlobal, BIND_GLOBAL, DeclareSynonymAttr

### DIFF
--- a/dev/ctags_for_gap
+++ b/dev/ctags_for_gap
@@ -1,6 +1,8 @@
 --langdef=GAP
 --langmap=GAP:.g.gd.gi.gap
 --regex-GAP=/([a-zA-Z0-9_]+) *:= *function/\1/f,function/
+--regex-GAP=/BindGlobal *\( *"([a-zA-Z0-9_]+)"/\1/v,value/
+--regex-GAP=/BIND_GLOBAL *\( *"([a-zA-Z0-9_]+)"/\1/v,value/
 --regex-GAP=/InstallMethod *\( *([a-zA-Z0-9_]+) *,/\1/m,method/
 --regex-GAP=/InstallOtherMethod *\( *([a-zA-Z0-9_]+) *,/\1/m,method/
 --regex-GAP=/InstallGlobalFunction *\( *([a-zA-Z0-9_]+) *,/\1/g,gfunction/
@@ -14,5 +16,6 @@
 --regex-GAP=/DeclareAttribute *\( *"([a-zA-Z0-9_]+)"/\1/a,attribute/
 --regex-GAP=/DeclareProperty *\( *"([a-zA-Z0-9_]+)"/\1/p,property/
 --regex-GAP=/DeclareSynonym *\( *"([a-zA-Z0-9_]+)"/\1/s,synonym/
+--regex-GAP=/DeclareSynonymAttr *\( *"([a-zA-Z0-9_]+)"/\1/s,synonym/
 --regex-GAP=/DeclareGlobalFunction *\( *"([a-zA-Z0-9_]+)"/\1/g,gfunction/
 --regex-GAP=/DeclareOperation *\( *"([a-zA-Z0-9_]+)"/\1/o,operation/


### PR DESCRIPTION
With this patch, the `tags` file generated by `make tags` will cover
additional symbols, namely those defined by `BindGlobal`, `BIND_GLOBAL`
and `DeclareSynonymAttr`.
