### PR TITLE
Rename QUIT_GAP, FORCE_QUIT_GAP and GAP_EXIT_CODE to QuitGap, ForceQuitGap and GapExitCode (the old names remain available as synonyms)

### DIFF
--- a/benchmark/doublecoset/test1.g
+++ b/benchmark/doublecoset/test1.g
@@ -11,7 +11,7 @@ res := Test( "doublecoset1.tst", rec(showProgress := true) );
 Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
 
 if res then
-  QUIT_GAP(0);
+  QuitGap(0);
 else
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;

--- a/benchmark/doublecoset/test2.g
+++ b/benchmark/doublecoset/test2.g
@@ -11,7 +11,7 @@ res := Test( "doublecoset2.tst", rec(showProgress := true) );
 Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
 
 if res then
-  QUIT_GAP(0);
+  QuitGap(0);
 else
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;

--- a/benchmark/doublecoset/test3.g
+++ b/benchmark/doublecoset/test3.g
@@ -11,7 +11,7 @@ res := Test( "doublecoset3.tst", rec(showProgress := true) );
 Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
 
 if res then
-  QUIT_GAP(0);
+  QuitGap(0);
 else
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;

--- a/benchmark/grpauto/test1.g
+++ b/benchmark/grpauto/test1.g
@@ -11,7 +11,7 @@ res := Test( "permiso.tst", rec(showProgress := true) );
 Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
 
 if res then
-  QUIT_GAP(0);
+  QuitGap(0);
 else
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;

--- a/benchmark/grpauto/test2.g
+++ b/benchmark/grpauto/test2.g
@@ -11,7 +11,7 @@ res := Test( "hardiso.tst", rec(showProgress := true) );
 Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
 
 if res then
-  QUIT_GAP(0);
+  QuitGap(0);
 else
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;

--- a/benchmark/grpauto/test3.g
+++ b/benchmark/grpauto/test3.g
@@ -11,7 +11,7 @@ res := Test( "hardest.tst", rec(showProgress := true) );
 Print( "*** RUNTIME ", Runtime()-starttime, "\n" );
 
 if res then
-  QUIT_GAP(0);
+  QuitGap(0);
 else
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;

--- a/benchmark/grpconst/test1.g
+++ b/benchmark/grpconst/test1.g
@@ -19,7 +19,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/grpconst/test2.g
+++ b/benchmark/grpconst/test2.g
@@ -19,7 +19,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/grpconst/test3.g
+++ b/benchmark/grpconst/test3.g
@@ -19,7 +19,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/primgrp/test1.g
+++ b/benchmark/primgrp/test1.g
@@ -17,7 +17,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/primgrp/test2.g
+++ b/benchmark/primgrp/test2.g
@@ -17,7 +17,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/primgrp/test3.g
+++ b/benchmark/primgrp/test3.g
@@ -17,7 +17,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/smallgrp/test1.g
+++ b/benchmark/smallgrp/test1.g
@@ -18,7 +18,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/smallgrp/test2.g
+++ b/benchmark/smallgrp/test2.g
@@ -18,7 +18,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/smallgrp/test3.g
+++ b/benchmark/smallgrp/test3.g
@@ -18,7 +18,7 @@ Print("*** RUNTIME ",Runtime()-starttime,"\n");
 
 if has_errors then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/transclosure/test1.g
+++ b/benchmark/transclosure/test1.g
@@ -16,4 +16,4 @@ for i in [1..6] do
 od;
 
 Print("*** RUNTIME ",Runtime()-starttime,"\n");
-QUIT_GAP(0);
+QuitGap(0);

--- a/benchmark/transclosure/test2.g
+++ b/benchmark/transclosure/test2.g
@@ -16,4 +16,4 @@ i:=7;
   t:=TransitiveClosureBinaryRelation(r);
 
 Print("*** RUNTIME ",Runtime()-starttime,"\n");
-QUIT_GAP(0);
+QuitGap(0);

--- a/benchmark/transclosure/test3.g
+++ b/benchmark/transclosure/test3.g
@@ -16,4 +16,4 @@ i:=8;
   t:=TransitiveClosureBinaryRelation(r);
 
 Print("*** RUNTIME ",Runtime()-starttime,"\n");
-QUIT_GAP(0);
+QuitGap(0);

--- a/benchmark/transgrp/test1.g
+++ b/benchmark/transgrp/test1.g
@@ -12,7 +12,7 @@ l:=Length(MakeTransitiveGroups(12));
 Print("*** RUNTIME ",Runtime()-starttime,"\n");
 if l<>301 then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/transgrp/test2.g
+++ b/benchmark/transgrp/test2.g
@@ -12,7 +12,7 @@ l:=Length(MakeTransitiveGroups(16));
 Print("*** RUNTIME ",Runtime()-starttime,"\n");
 if l<>1954 then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/benchmark/transgrp/test3.g
+++ b/benchmark/transgrp/test3.g
@@ -12,7 +12,7 @@ l:=Length(MakeTransitiveGroups(20));
 Print("*** RUNTIME ",Runtime()-starttime,"\n");
 if l<>1117 then
   Print("*** FAIL\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 else
-  QUIT_GAP(0);
+  QuitGap(0);
 fi;

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -986,14 +986,19 @@ or <C>brk></C> or <C>brk_<A>nn</A>></C> prompt.
 </ManSection>
 
 <ManSection>
-<Func Name="GapExitCode" Arg='ret'/>
+<Func Name="GapExitCode" Arg='[ret]'/>
 
 <Description>
-A <C>GapExitCode</C> sets the return value which will be used when
-&GAP; exits. This may be an integer, or a boolean (where
-<K>true</K> is interpreted as 0, and
-<K>false</K> is interpreted as 1.
+<Ref Func="GapExitCode"/> sets the exit value which is returned
+to the operating system (or parent process) when &GAP; exits.
+This may be an integer in the range [-128..127] (other values
+are reduced modulo 256), or a boolean. <K>true</K> corresponds
+to the return value 0, which by convention is treated as "success".
+<K>false</K> corresponds to the return value 1, which by convention
+is treated as "failure". The exit value is not changed if no argument
+is given.
 <P/>
+The <E>previous</E> exit code is returned.
 </Description>
 </ManSection>
 
@@ -1001,9 +1006,10 @@ A <C>GapExitCode</C> sets the return value which will be used when
 <Func Name="QuitGap" Arg='[ret]'/>
 
 <Description>
-A <C>QuitGap</C> acts similarly to the keyword <C>quit</C>. It exits
-&GAP; cleanly, calling any function installed using <C>InstallAtExit</C>.
-The optional argument will be passed to <C>GapExitCode</C>.
+<Ref Func="QuitGap"/> acts similarly to the keyword <C>QUIT</C>, except
+<C>QUIT</C> can not be called from a function. It exits
+&GAP; cleanly, calling any function installed using <Ref Func="InstallAtExit"/>.
+The optional argument <A>ret</A> will be passed to <Ref Func="GapExitCode"/>.
 <P/>
 </Description>
 </ManSection>
@@ -1012,10 +1018,11 @@ The optional argument will be passed to <C>GapExitCode</C>.
 <Func Name="ForceQuitGap" Arg='[ret]'/>
 
 <Description>
-A <C>ForceQuitGap</C> is similar to <C>QuitGap</C>, except it ignores any
-functions installed with <C>InstallAtExit</C>, or any other functions
-normally run at GAP exit, and exits GAP immediately.
-The optional argument will be passed to <C>GapExitCode</C>.
+<Ref Func="ForceQuitGap"/> is similar to <Ref Func="QuitGap"/>, except it ignores any
+functions installed with <Ref Func="InstallAtExit"/>, or any other functions
+normally run at GAP exit, such as flushing any partially outputted lines
+to both the screen and files, and exits GAP immediately.
+The optional argument <A>ret</A> will be passed to <Ref Func="GapExitCode"/>.
 <P/>
 </Description>
 </ManSection>
@@ -1027,7 +1034,7 @@ The optional argument will be passed to <C>GapExitCode</C>.
 
 <Description>
 Before actually terminating, &GAP; will call (with no arguments) all
-of the functions that have been installed using <C>InstallAtExit</C>. These
+of the functions that have been installed using <Ref Func="InstallAtExit"/>. These
 typically perform tasks such as cleaning up temporary files created
 during the session, and closing open files. If an error occurs during
 the execution of one of these functions, that function is simply
@@ -1434,4 +1441,3 @@ interpret.
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <!-- %% -->
 <!-- %E -->
-

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -986,10 +986,10 @@ or <C>brk></C> or <C>brk_<A>nn</A>></C> prompt.
 </ManSection>
 
 <ManSection>
-<Func Name="GAP_EXIT_CODE" Arg='ret'/>
+<Func Name="GapExitCode" Arg='ret'/>
 
 <Description>
-A <C>GAP_EXIT_CODE</C> sets the return value which will be used when
+A <C>GapExitCode</C> sets the return value which will be used when
 &GAP; exits. This may be an integer, or a boolean (where
 <K>true</K> is interpreted as 0, and
 <K>false</K> is interpreted as 1.
@@ -998,24 +998,24 @@ A <C>GAP_EXIT_CODE</C> sets the return value which will be used when
 </ManSection>
 
 <ManSection>
-<Func Name="QUIT_GAP" Arg='[ret]'/>
+<Func Name="QuitGap" Arg='[ret]'/>
 
 <Description>
-A <C>QUIT_GAP</C> acts similarly to the keyword <C>quit</C>. It exits
+A <C>QuitGap</C> acts similarly to the keyword <C>quit</C>. It exits
 &GAP; cleanly, calling any function installed using <C>InstallAtExit</C>.
-The optional argument will be passed to <C>GAP_EXIT_CODE</C>.
+The optional argument will be passed to <C>GapExitCode</C>.
 <P/>
 </Description>
 </ManSection>
 
 <ManSection>
-<Func Name="FORCE_QUIT_GAP" Arg='[ret]'/>
+<Func Name="ForceQuitGap" Arg='[ret]'/>
 
 <Description>
-A <C>FORCE_QUIT_GAP</C> is similar to <C>QUIT_GAP</C>, except it ignores any
+A <C>ForceQuitGap</C> is similar to <C>QuitGap</C>, except it ignores any
 functions installed with <C>InstallAtExit</C>, or any other functions
 normally run at GAP exit, and exits GAP immediately.
-The optional argument will be passed to <C>GAP_EXIT_CODE</C>.
+The optional argument will be passed to <C>GapExitCode</C>.
 <P/>
 </Description>
 </ManSection>

--- a/doc/ref/testconsistency.g
+++ b/doc/ref/testconsistency.g
@@ -240,6 +240,6 @@ end;
 
 # Uncomment next line to add ManSections without examples to the test log
 # CheckDocCoverage(doc);
-QUIT_GAP( CheckManSectionTypes(doc) );
+QuitGap( CheckManSectionTypes(doc) );
 
 

--- a/etc/bisect.sh
+++ b/etc/bisect.sh
@@ -99,13 +99,13 @@ echo '
 # if ErrorLevel is not defined, something is very wrong, so skip the commit
 if not IsBound(ErrorLevel) then
   Print("Panic, ErrorLevel not defined, skipping this commit\\n");
-  FORCE_QUIT_GAP(125);
+  ForceQuitGap(125);
 fi;
 
 # intercept any further break loops and again, bail out
 OnBreak:=function()
   Print("Panic, break loop was triggered, skipping this commit\\n");
-  FORCE_QUIT_GAP(125);
+  ForceQuitGap(125);
 end;
 
 # check if we are in an error handler...
@@ -119,16 +119,16 @@ if ErrorLevel > 0 then
   else
     # ... for any other error: tell git to skip this commit
     Print("Panic, GAP run into an error during startup, skipping this commit\\n");
-    FORCE_QUIT_GAP(125);
+    ForceQuitGap(125);
   fi;
 fi;
 
 # run the actual test
 if Test("'${TESTFILE}'") then
   Print("Commit is good\\n");
-  QUIT_GAP(0);
+  QuitGap(0);
 else
   Print("Commit is bad\\n");
-  QUIT_GAP(1);
+  QuitGap(1);
 fi;
 ' | bin/gap.sh -A -b -q

--- a/etc/ci-gather-coverage.sh
+++ b/etc/ci-gather-coverage.sh
@@ -36,7 +36,7 @@ ls -l "$COVDIR" # for debugging
 $GAP -a 500M -m 500M -q <<GAPInput
 if LoadPackage("profiling") <> true then
     Print("ERROR: could not load profiling package");
-    FORCE_QUIT_GAP(1);
+    ForceQuitGap(1);
 fi;
 d := Directory("$COVDIR");;
 Print("Scanning for coverage data...\n");

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -59,7 +59,7 @@ else
 fi
 
 # check that GAP is at least able to start
-echo 'Print("GAP started successfully\n");QUIT_GAP(0);' | ./gap -T
+echo 'Print("GAP started successfully\n");QuitGap(0);' | ./gap -T
 
 # packages must be placed inside SRCDIR, as only that
 # is a GAP root, while BUILDDIR is not.

--- a/etc/ci.sh
+++ b/etc/ci.sh
@@ -89,7 +89,7 @@ do
         $GAP -b <<GAPInput
         SaveWorkspace("testpackagesload.wsp");
         PrintTo("packagenames", JoinStringsWithSeparator( SortedList(RecNames( GAPInfo.PackagesInfo )),"\n") );
-        QUIT_GAP(0);
+        QuitGap(0);
 GAPInput
         for pkg in $(cat packagenames)
         do
@@ -208,7 +208,7 @@ GAPInput
         SetUserPreference("ReproducibleBehaviour", true);
         Read("$SRCDIR/tst/testmanuals.g");
         SaveWorkspace("testmanuals.wsp");
-        QUIT_GAP(0);
+        QuitGap(0);
 GAPInput
 
     TESTMANUALSPASS=yes
@@ -216,7 +216,7 @@ GAPInput
     do
         $GAP -b -L testmanuals.wsp --cover $COVDIR/$(basename $ch).coverage <<GAPInput || TESTMANUALSPASS=no
         TestManualChapter("$ch");
-        QUIT_GAP(0);
+        QuitGap(0);
 GAPInput
     done
 
@@ -229,7 +229,7 @@ GAPInput
         # Also test a package banner
         LoadPackage("polycyclic");
         SaveWorkspace("test.wsp");
-        QUIT_GAP(0);
+        QuitGap(0);
 GAPInput
 
     ;;

--- a/hpcgap/demo/unittest.g
+++ b/hpcgap/demo/unittest.g
@@ -8,10 +8,10 @@ end;
 TestReportAndExit := function()
   if NumTestErrors = 1 then
     Print("*** 1 error occurred.\n");
-    GAP_EXIT_CODE(1);
+    GapExitCode(1);
   elif NumTestErrors > 1 then
     Print("*** ", NumTestErrors, " errors occurred.\n");
-    GAP_EXIT_CODE(1);
+    GapExitCode(1);
   else
     Print("*** No errors occurred.\n");
   fi;

--- a/hpcgap/lib/hpc/consoleui.g
+++ b/hpcgap/lib/hpc/consoleui.g
@@ -819,7 +819,7 @@ end);
 
 BindGlobal("CommandQUIT@", function(line)
   TERMINAL_CLOSE();
-  FORCE_QUIT_GAP();
+  ForceQuitGap();
 end);
 
 BindGlobal("InitializeCommands@", function()
@@ -1087,7 +1087,7 @@ BindGlobal("MULTI_SESSION", function()
   CompleteHandShake(ProgramShutdown@);
   PROGRAM_CLEAN_UP();
   TERMINAL_CLOSE();
-  QUIT_GAP();
+  QuitGap();
 end);
 
 BindGlobal("ConsoleUIRegisterCommand", function(name, func)

--- a/lib/error.g
+++ b/lib/error.g
@@ -328,7 +328,7 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
             and IsBound(OnBreak) and IsFunction(OnBreak) then
             OnBreak();
         fi;
-        FORCE_QUIT_GAP(1);
+        ForceQuitGap(1);
     fi;
 
     # OnBreak() is set to Where() by default, which prints the traceback.

--- a/lib/init.g
+++ b/lib/init.g
@@ -61,7 +61,7 @@ Error := function( arg )
     od;
     Print("\n");
     if SHOULD_QUIT_ON_BREAK() then
-        FORCE_QUIT_GAP(1);
+        ForceQuitGap(1);
     fi;
     JUMP_TO_CATCH("early error");
 end;
@@ -73,7 +73,7 @@ ErrorInner := function(options, message)
     Print("Error before error-handling is initialized: ");
     Print(message);
     if SHOULD_QUIT_ON_BREAK() then
-        FORCE_QUIT_GAP(1);
+        ForceQuitGap(1);
     fi;
     JUMP_TO_CATCH("early error");
 end;

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -760,3 +760,12 @@ BindGlobal("STRING_LIST_DIR", function(dirname)
       return JoinStringsWithSeparator( list, "\000" );
     fi;
 end);
+
+
+#############################################################################
+##
+##
+##  Used in many packages, documented CamelCase versions introduced (04/2020)
+DeclareObsoleteSynonym("GAP_EXIT_CODE", "GapExitCode", 2);
+DeclareObsoleteSynonym("QUIT_GAP", "QuitGap", 2);
+DeclareObsoleteSynonym("FORCE_QUIT_GAP", "ForceQuitGap", 2);

--- a/lib/system.g
+++ b/lib/system.g
@@ -475,7 +475,7 @@ CallAndInstallPostRestore( function()
        "  Boolean options toggle the current value each time they are called.\n",
        "  Default actions are indicated first.\n",
        "\n" );
-      QUIT_GAP();
+      QuitGap();
     fi;
 end );
 

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -809,7 +809,7 @@ InstallGlobalFunction( "TestDirectory", function(arg)
   opts.testOptions.returnNumFailures := true;
   
   if opts.exitGAP then
-    GAP_EXIT_CODE(1);
+    GapExitCode(1);
   fi;
   
   files := [];
@@ -882,7 +882,7 @@ InstallGlobalFunction( "TestDirectory", function(arg)
         Print( "#I  Errors detected while testing\n\n" );
       fi;
       if opts.exitGAP then
-        QUIT_GAP(1);
+        QuitGap(1);
       fi;
       return false;
     fi;
@@ -932,9 +932,9 @@ InstallGlobalFunction( "TestDirectory", function(arg)
 
   if opts.exitGAP then
     if testTotalFailures = 0 then
-      QUIT_GAP(0);
+      QuitGap(0);
     else
-      QUIT_GAP(1);
+      QuitGap(1);
     fi;
   fi;
   

--- a/src/gap.c
+++ b/src/gap.c
@@ -1002,32 +1002,41 @@ static int SetExitValue(Obj code)
 
 /****************************************************************************
 **
-*F  FuncGAP_EXIT_CODE() . . . . . . . . Set the code with which GAP exits.
+*F  FuncGapExitCode() . . . . . . . . Set the code with which GAP exits.
 **
 */
 
-static Obj FuncGAP_EXIT_CODE(Obj self, Obj code)
+static Obj FuncGapExitCode(Obj self, Obj args)
 {
-  if (!SetExitValue(code))
-    ErrorQuit("GAP_EXIT_CODE: Argument must be boolean or integer", 0, 0);
-  return (Obj) 0;
+    if (LEN_LIST(args) > 1) {
+        ErrorQuit("usage: QuitGap( [ <return value> ] )", 0, 0);
+    }
+
+    Obj prev_exit_value = ObjInt_Int(SystemErrorCode);
+
+    if (LEN_LIST(args) == 1) {
+        Obj code = ELM_PLIST(args, 1);
+        RequireArgumentCondition("GapExitCode", code, SetExitValue(code),
+                                 "Argument must be boolean or integer");
+    }
+    return (Obj)prev_exit_value;
 }
 
 
 /****************************************************************************
 **
-*F  FuncQUIT_GAP()
+*F  FuncQuitGap()
 **
 */
 
-static Obj FuncQUIT_GAP(Obj self, Obj args)
+static Obj FuncQuitGap(Obj self, Obj args)
 {
   if ( LEN_LIST(args) == 0 ) {
     SystemErrorCode = 0;
   }
   else if ( LEN_LIST(args) != 1 
             || !SetExitValue(ELM_PLIST(args, 1) ) ) {
-    ErrorQuit( "usage: QUIT_GAP( [ <return value> ] )", 0, 0);
+    ErrorQuit( "usage: QuitGap( [ <return value> ] )", 0, 0);
   }
   STATE(UserHasQUIT) = 1;
   GAP_THROW();
@@ -1036,11 +1045,11 @@ static Obj FuncQUIT_GAP(Obj self, Obj args)
 
 /****************************************************************************
 **
-*F  FuncFORCE_QUIT_GAP()
+*F  FuncForceQuitGap()
 **
 */
 
-static Obj FuncFORCE_QUIT_GAP(Obj self, Obj args)
+static Obj FuncForceQuitGap(Obj self, Obj args)
 {
   if ( LEN_LIST(args) == 0 )
   {
@@ -1048,7 +1057,7 @@ static Obj FuncFORCE_QUIT_GAP(Obj self, Obj args)
   }
   else if ( LEN_LIST(args) != 1 
             || !SetExitValue(ELM_PLIST(args, 1) ) ) {
-    ErrorQuit( "usage: FORCE_QUIT_GAP( [ <return value> ] )", 0, 0);
+    ErrorQuit( "usage: ForceQuitGap( [ <return value> ] )", 0, 0);
   }
   SyExit(SystemErrorCode);
 }
@@ -1295,9 +1304,9 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_1ARGS(OBJ_HANDLE, handle),
     GVAR_FUNC_1ARGS(HANDLE_OBJ, object),
     GVAR_FUNC_1ARGS(WindowCmd, args),
-    GVAR_FUNC_1ARGS(GAP_EXIT_CODE, exitCode),
-    GVAR_FUNC(QUIT_GAP, -1, "args"),
-    GVAR_FUNC(FORCE_QUIT_GAP, -1, "args"),
+    GVAR_FUNC(GapExitCode, -1, "exitCode"),
+    GVAR_FUNC(QuitGap, -1, "args"),
+    GVAR_FUNC(ForceQuitGap, -1, "args"),
     GVAR_FUNC_0ARGS(SHOULD_QUIT_ON_BREAK),
     GVAR_FUNC(SHELL,
               10,

--- a/src/system.c
+++ b/src/system.c
@@ -264,7 +264,7 @@ UInt SyWindow;
 **  If ret is 0 'SyExit' should signal to a calling process that all is  ok.
 **  If ret is 1 'SyExit' should signal a  failure  to  the  calling process.
 **
-**  If the user calls 'QUIT_GAP' with a value, then the global variable
+**  If the user calls 'QuitGap' with a value, then the global variable
 **  'UserHasQUIT' will be set, and their requested return value will be
 **  in 'SystemErrorCode'. If the return value would be 0, we check
 **  this value and use it instead.

--- a/tst/extractmanuals.g
+++ b/tst/extractmanuals.g
@@ -65,4 +65,4 @@ GAPInfo.ManualDataTut.pathtoroot := DirectoriesLibrary("");
 WriteExamplesTst( testdir, GAPInfo.ManualDataTut );
 
 #
-QUIT_GAP(0);
+QuitGap(0);

--- a/tst/mockpkg/tst/testall.g
+++ b/tst/mockpkg/tst/testall.g
@@ -9,4 +9,4 @@ LoadPackage( "mockpkg" );
 TestDirectory(DirectoriesPackageLibrary( "mockpkg", "tst" ),
   rec(exitGAP := true));
 
-FORCE_QUIT_GAP(1); # if we ever get here, there was an error
+ForceQuitGap(1); # if we ever get here, there was an error

--- a/tst/testbugfix.g
+++ b/tst/testbugfix.g
@@ -17,4 +17,4 @@ TestDirectory( [ DirectoriesLibrary( "tst/testbugfix") ] ,
                rec(exitGAP := true, testOptions := rec( width := 80 ) ) );
 
 # Should never get here
-FORCE_QUIT_GAP(1);
+ForceQuitGap(1);

--- a/tst/testextra.g
+++ b/tst/testextra.g
@@ -20,4 +20,4 @@ dirs := [
 TestDirectory( dirs, rec(exitGAP := true) );
   
 # Should never get here
-FORCE_QUIT_GAP(1);
+ForceQuitGap(1);

--- a/tst/testinstall.g
+++ b/tst/testinstall.g
@@ -31,4 +31,4 @@ TestDirectory( dirs, rec(exitGAP := true) );
 
   
 # Should never get here
-FORCE_QUIT_GAP(1);
+ForceQuitGap(1);

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -214,23 +214,37 @@ gap> MicroSleep(0);
 gap> MicroSleep(1);
 
 #
-gap> GAP_EXIT_CODE("invalid");
-Error, GAP_EXIT_CODE: Argument must be boolean or integer
-gap> GAP_EXIT_CODE(fail);
-gap> GAP_EXIT_CODE(false);
-gap> GAP_EXIT_CODE(true);
+gap> exitCode := GapExitCode();;
+gap> GapExitCode(0);;
+gap> GapExitCode();
+0
+gap> GapExitCode("invalid");
+Error, GapExitCode: <code> Argument must be boolean or integer (not a list (st\
+ring))
+gap> GapExitCode(fail);
+0
+gap> GapExitCode(false);
+1
+gap> GapExitCode(true);
+1
+gap> GapExitCode(6);
+0
+gap> GapExitCode();
+6
+gap> GapExitCode(exitCode);
+6
 
 #
-gap> QUIT_GAP("invald");
-Error, usage: QUIT_GAP( [ <return value> ] )
-gap> QUIT_GAP(1, 2);
-Error, usage: QUIT_GAP( [ <return value> ] )
+gap> QuitGap("invald");
+Error, usage: QuitGap( [ <return value> ] )
+gap> QuitGap(1, 2);
+Error, usage: QuitGap( [ <return value> ] )
 
 #
-gap> FORCE_QUIT_GAP("invald");
-Error, usage: FORCE_QUIT_GAP( [ <return value> ] )
-gap> FORCE_QUIT_GAP(1, 2);
-Error, usage: FORCE_QUIT_GAP( [ <return value> ] )
+gap> ForceQuitGap("invald");
+Error, usage: ForceQuitGap( [ <return value> ] )
+gap> ForceQuitGap(1, 2);
+Error, usage: ForceQuitGap( [ <return value> ] )
 
 #
 gap> BREAKPOINT(0);

--- a/tst/testmanuals.g
+++ b/tst/testmanuals.g
@@ -46,12 +46,12 @@ end;
 TestManualChapter := function(filename)
     local testResult;
     
-    GAP_EXIT_CODE(1);
+    GapExitCode(1);
     testResult := Test(filename, rec( width := 72,
 		        compareFunction := "uptowhitespace",
 		        reportDiff := ExamplesReportDiff ) );
     if not(testResult) then
-        QUIT_GAP(1);
+        QuitGap(1);
     fi;
-    QUIT_GAP(0);
+    QuitGap(0);
 end;

--- a/tst/testprofiling.g
+++ b/tst/testprofiling.g
@@ -11,4 +11,4 @@ TestDirectory( [ DirectoriesLibrary( "tst/testprofiling" ) ],
   rec(exitGAP := true) );
   
 # Should never get here
-FORCE_QUIT_GAP(1);
+ForceQuitGap(1);

--- a/tst/testspecial/run_all.sh
+++ b/tst/testspecial/run_all.sh
@@ -8,7 +8,7 @@ GAPDIR=${GAPDIR:-../..}
 
 retvalue=0
 gap="$GAPDIR/bin/gap.sh"
-if "${gap}" -A -b -c 'QUIT_GAP(GAPInfo.BytesPerVariable - 8);'; then
+if "${gap}" -A -b -c 'QuitGap(GAPInfo.BytesPerVariable - 8);'; then
     echo "Running 64-bit special tests"
     tocheck="*.g 64bit/*.g"
 else

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -23,4 +23,4 @@ dirs := [
 TestDirectory( dirs, rec(exitGAP := true) );
   
 # Should never get here
-FORCE_QUIT_GAP(1);
+ForceQuitGap(1);


### PR DESCRIPTION
A usual gap rule is CamelCase functions are for users, and ALL_CAPS are internal.

I think enough people are now using QUIT_GAP, FORCE_QUIT_GAP and GAP_EXIT_CODE that they should be moved to CamelCase (obviously leaving the old ALL_CAPS versions as obsolete).