### PR TITLE
FIX: Induced fitting free setup requires own pcisom

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -2474,7 +2474,7 @@ local r,	#radical
 	Info(InfoHomClass,3,"central step");
 	new:=LiftClassesEANonsolvCentral(G,mpcgs,i,hom,pcisom,solvtriv,fran);
       elif Length(fants)>0 and Order(i[1])=1 then
-	# special case for trivial representetive
+	# special case for trivial representative
 	new:=LiftClassesEATrivRep(G,mpcgs,i,fants,hom,pcisom,solvtriv);
 	if new=fail then
 	  new:=LiftClassesEANonsolvGeneral(G,mpcgs,i,hom,pcisom,solvtriv,fran);

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -109,7 +109,7 @@ local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r,pool,i,xx,inv,pregens;
 end);
 
 InstallGlobalFunction(SubgroupByFittingFreeData,function(G,gens,imgs,ipcgs)
-local ffs,hom,U,rest,ker,r,p,l,i,depths;
+local ffs,hom,U,rest,ker,r,p,l,i,depths,pcisom;
 
   ffs:=FittingFreeLiftSetup(G);
   # get back to initial group -- dont induce of induce
@@ -204,10 +204,13 @@ local ffs,hom,U,rest,ker,r,p,l,i,depths;
 
   # FittingFreeLiftSetup for U, if correct
   if Size(RadicalGroup(Image(rest,U)))=1 then
+    pcisom:=List(ipcgs,x->ImagesRepresentative(ffs.pcisom,x));
+    pcisom:=GroupHomomorphismByImagesNC(U,SubgroupNC(Range(ffs.pcisom),pcisom),
+      ipcgs,pcisom);
     r:=rec(inducedfrom:=ffs,
           pcgs:=ipcgs,
           depths:=depths,
-          pcisom:=ffs.pcisom,
+          pcisom:=pcisom,
           radical:=ker,
           factorhom:=rest
           );
@@ -567,17 +570,12 @@ local stabilizergen,st,stabrsub,stabrsubsz,ratio,subsz,sz,vp,stabrad,
 	Add(stabrad,rep);
 #Print("increased ",stabrsubsz," by ",relo,"\n");
 	stabrsubsz:=stabrsubsz*relo;
-	#rep:=ImageElm(pcisom,rep);
-	#stabrsub:=ClosureGroup(stabrsub,rep);
-#if Size(stabrsub)<>stabrzubsz then Error("HUH10");fi;
 	subsz:=stabrsubsz;
 	ratio:=gpsz/subsz/Length(orb);
       fi;
 
     od;
     stabrad:=Reversed(stabrad);
-
-#if Length(orb)<>Length(Orbit(Group(pcgsimgs),orb[1],actfun)) then Error("HUH9");fi;
 
     subsz:=stabrsubsz;
     if  solvsz>subsz*Length(orb) then

--- a/tst/testbugfix/2020-01-22-SubgroupByFittingFreeData.tst
+++ b/tst/testbugfix/2020-01-22-SubgroupByFittingFreeData.tst
@@ -1,0 +1,6 @@
+# Induced FFLS, Issue #3864
+gap> g:= Group( (1,2,3)(7,8)(12,13), (1,3)(2,4,5)(6,7,9,12,11,8,10,13),
+>               (1,4,3)(6,7)(8,11)(9,13)(10,12) );;
+gap> max:=MaximalSubgroupClassReps(g);;
+gap> Length(ConjugacyClasses(max[1]));
+26


### PR DESCRIPTION
If we simply copy the pcisom, some routines that use the source get the
wrong group. This causes problem is using such algorithms on subgroups
obtained the same way.

This fixes #3864

## Text for release notes 

A bug in setting up a subgroup data structure by the solvable radical method has been fixed.
