### PR TITLE
kernel: don't use PLAIN_LIST in OnTuples, OnSets

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1009,19 +1009,16 @@ static Obj FuncOnTuples(Obj self, Obj tuple, Obj elm)
     }
     /* special case for permutations                                       */
     if (IS_PERM(elm)) {
-        PLAIN_LIST( tuple );
         return OnTuplesPerm( tuple, elm );
     }
 
     /* special case for transformations                                       */
     if (IS_TRANS(elm)) {
-        PLAIN_LIST( tuple );
         return OnTuplesTrans( tuple, elm );
     }
 
     /* special case for partial perms */
     if (IS_PPERM(elm)) {
-        PLAIN_LIST( tuple );
         return OnTuplesPPerm( tuple, elm );
     }
 
@@ -1073,19 +1070,16 @@ static Obj FuncOnSets(Obj self, Obj set, Obj elm)
         
     /* special case for permutations                                       */
     if (IS_PERM(elm)) {
-        PLAIN_LIST( set );
         return OnSetsPerm( set, elm );
     }
 
     /* special case for transformations */
     if (IS_TRANS(elm)){
-      PLAIN_LIST(set);
       return OnSetsTrans( set, elm);
     }
     
     /* special case for partial perms */
     if (IS_PPERM(elm)){
-      PLAIN_LIST(set);
       return OnSetsPPerm( set, elm);
     }
 

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -3487,21 +3487,19 @@ Obj OnSetsPPerm(Obj set, Obj f)
     UInt2 *     ptf2;
     UInt4 *     ptf4;
     UInt        deg;
-    const Obj * ptset;
-    Obj *       ptres, res;
+    Obj         res;
+    const Obj * ptres;
+    Obj *       ptresOut;
     UInt        i, k, reslen;
+    Obj         tmp;
 
-    GAP_ASSERT(IS_PLIST(set));
-    GAP_ASSERT(LEN_PLIST(set) > 0);
-    GAP_ASSERT(IS_PPERM(f));
-
-    const UInt len = LEN_PLIST(set);
-
-    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST, len);
+    // copy the list into a mutable plist, which we will then modify in place
+    res = PLAIN_LIST_COPY(set);
+    const UInt len = LEN_PLIST(res);
 
     /* get the pointer                                                 */
-    ptset = CONST_ADDR_OBJ(set) + len;
-    ptres = ADDR_OBJ(res) + 1;
+    ptres = CONST_ADDR_OBJ(res) + 1;
+    ptresOut = ADDR_OBJ(res) + 1;
     reslen = 0;
 
     if (TNUM_OBJ(f) == T_PPERM2) {
@@ -3509,12 +3507,13 @@ Obj OnSetsPPerm(Obj set, Obj f)
         deg = DEG_PPERM2(f);
 
         /* loop over the entries of the tuple                              */
-        for (i = len; 1 <= i; i--, ptset--) {
-            if (IS_POS_INTOBJ(*ptset)) {
-                k = INT_INTOBJ(*ptset);
+        for (i = 1; i <= len; i++, ptres++) {
+            tmp = *ptres;
+            if (IS_POS_INTOBJ(tmp)) {
+                k = INT_INTOBJ(tmp);
                 if (k <= deg && ptf2[k - 1] != 0) {
                     reslen++;
-                    *ptres++ = INTOBJ_INT(ptf2[k - 1]);
+                    *ptresOut++ = INTOBJ_INT(ptf2[k - 1]);
                 }
             }
             else {
@@ -3533,12 +3532,13 @@ Obj OnSetsPPerm(Obj set, Obj f)
         deg = DEG_PPERM4(f);
 
         /* loop over the entries of the tuple                              */
-        for (i = len; 1 <= i; i--, ptset--) {
-            if (IS_POS_INTOBJ(*ptset)) {
-                k = INT_INTOBJ(*ptset);
+        for (i = 1; i <= len; i++, ptres++) {
+            tmp = *ptres;
+            if (IS_POS_INTOBJ(tmp)) {
+                k = INT_INTOBJ(tmp);
                 if (k <= deg && ptf4[k - 1] != 0) {
                     reslen++;
-                    *ptres++ = INTOBJ_INT(ptf4[k - 1]);
+                    *ptresOut++ = INTOBJ_INT(ptf4[k - 1]);
                 }
             }
             else {
@@ -3581,21 +3581,21 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
     UInt2 *     ptf2;
     UInt4 *     ptf4;
     UInt        deg;
-    const Obj * pttup;
-    Obj *       ptres, res;
+    Obj         res;
+    const Obj * ptres;
+    Obj *       ptresOut;
     UInt        i, k, reslen;
+    Obj         tmp;
 
-    GAP_ASSERT(IS_PLIST(tup));
-    GAP_ASSERT(LEN_PLIST(tup) > 0);
-    GAP_ASSERT(IS_PPERM(f));
-
-    const UInt len = LEN_PLIST(tup);
-
-    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(tup), T_PLIST_CYC, len);
+    // copy the list into a mutable plist, which we will then modify in place
+    res = PLAIN_LIST_COPY(tup);
+    RESET_FILT_LIST(res, FN_IS_SSORT);
+    RESET_FILT_LIST(res, FN_IS_NSORT);
+    const UInt len = LEN_PLIST(res);
 
     /* get the pointer                                                 */
-    pttup = CONST_ADDR_OBJ(tup) + 1;
-    ptres = ADDR_OBJ(res) + 1;
+    ptres = CONST_ADDR_OBJ(res) + 1;
+    ptresOut = ADDR_OBJ(res) + 1;
     reslen = 0;
 
     if (TNUM_OBJ(f) == T_PPERM2) {
@@ -3603,12 +3603,13 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
         deg = DEG_PPERM2(f);
 
         /* loop over the entries of the tuple                              */
-        for (i = 1; i <= len; i++, pttup++) {
-            if (IS_POS_INTOBJ(*pttup)) {
-                k = INT_INTOBJ(*pttup);
+        for (i = 1; i <= len; i++, ptres++) {
+            tmp = *ptres;
+            if (IS_POS_INTOBJ(tmp)) {
+                k = INT_INTOBJ(tmp);
                 if (k <= deg && ptf2[k - 1] != 0) {
                     reslen++;
-                    *ptres++ = INTOBJ_INT(ptf2[k - 1]);
+                    *ptresOut++ = INTOBJ_INT(ptf2[k - 1]);
                 }
             }
             else {
@@ -3627,12 +3628,13 @@ Obj OnTuplesPPerm(Obj tup, Obj f)
         deg = DEG_PPERM4(f);
 
         /* loop over the entries of the tuple                              */
-        for (i = 1; i <= len; i++, pttup++) {
-            if (IS_POS_INTOBJ(*pttup)) {
-                k = INT_INTOBJ(*pttup);
+        for (i = 1; i <= len; i++, ptres++) {
+            tmp = *ptres;
+            if (IS_POS_INTOBJ(tmp)) {
+                k = INT_INTOBJ(tmp);
                 if (k <= deg && ptf4[k - 1] != 0) {
                     reslen++;
-                    *ptres++ = INTOBJ_INT(ptf4[k - 1]);
+                    *ptresOut++ = INTOBJ_INT(ptf4[k - 1]);
                 }
             }
             else {

--- a/tst/testinstall/kernel/lists.tst
+++ b/tst/testinstall/kernel/lists.tst
@@ -119,10 +119,12 @@ fail
 
 # PlainListError
 gap> r:=NewCategory("ListTestObject",IsSmallList);;
-gap> InstallMethod(Length,[r],l->5);
 gap> t:=NewType(ListsFamily, r and IsMutable and IsPositionalObjectRep);;
+gap> InstallMethod(IsBound\[\],[r,IsPosInt],{l,i}->true);
+gap> InstallMethod(\[\],[r,IsPosInt],{l,i}->i);
+gap> InstallMethod(Length,[r],l->3); # hard code length
 gap> l:=Objectify(t,[]);;
-gap> OnTuples(l, (1,3));
+gap> ADD_SET(l, [1]);
 Error, Panic: cannot convert <list> (is a positional object) to a plain list
 
 #

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -1,4 +1,4 @@
-#@local checklens,n,permAll,permBig,permSml,x,y,moved,p
+#@local checklens,n,permAll,permBig,permSml,x,y,moved,p,r,t,l
 gap> START_TEST("perm.tst");
 
 # Permutations come in two flavors in GAP, with two TNUMs: T_PERM2 for
@@ -471,9 +471,9 @@ gap> OnTuples([(1,2),(1,3)],(1,2,70000));
 
 #
 gap> OnTuples([,1],());
-Error, OnTuples for perm: list must not contain holes
+Error, OnTuples: <tup> must not contain holes
 gap> OnTuples([,1],(70000,70001));
-Error, OnTuples for perm: list must not contain holes
+Error, OnTuples: <tup> must not contain holes
 
 #
 # OnSets for permutations
@@ -496,6 +496,20 @@ gap> OnSets([(3,4),(1,2)],(1,2,70000));
 [ (3,4), (2,70000) ]
 gap> OnSets([(1,2),(1,3)],(1,2,70000));
 [ (2,3), (2,70000) ]
+
+#
+# OnTuples and OnSets for a non-internal list
+#
+gap> r:=NewCategory("ListTestObject",IsSmallList);;
+gap> t:=NewType(ListsFamily, r and IsMutable and IsPositionalObjectRep);;
+gap> InstallMethod(IsBound\[\],[r,IsPosInt],{l,i}->true);
+gap> InstallMethod(\[\],[r,IsPosInt],{l,i}->i);
+gap> InstallMethod(Length,[r],l->3); # hard code length
+gap> l:=Objectify(t,[]);;
+gap> OnTuples(l, (1,3));
+[ 3, 2, 1 ]
+gap> OnSets(l, (1,3));
+[ 1, 2, 3 ]
 
 #
 # MappingPermListList

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -2665,9 +2665,9 @@ gap> OnTuples([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 19, 324, 4124, 123124, 2 ^ 60]
 [ 10, 7, 10, 8, 8, 7, 5, 9, 1, 9, 11, 19, 324, 4124, 123124, 
   1152921504606846976 ]
 gap> OnTuples([1, , 3], Transformation([1, 1]));
-Error, OnTuples for transformation: list must not contain holes
+Error, OnTuples: <tup> must not contain holes
 gap> OnTuples([1, , 3], Transformation([1], [65537]));
-Error, OnTuples for transformation: list must not contain holes
+Error, OnTuples: <tup> must not contain holes
 gap> f := Transformation([2, 6, 7, 2, 6, 9, 9, 1, 1, 5]);;
 gap> OnTuples([1 .. 10], f);
 [ 2, 6, 7, 2, 6, 9, 9, 1, 1, 5 ]


### PR DESCRIPTION
... by changing OnSets{Perm,Trans,PPerm} resp. OnTuples{Perm,Trans,PPerm} to accept non-plain list arguments, which then are copied, and modified in place
