### PR TITLE
Remove kernel operation Elm0List; revise Elm0ListObject

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -247,17 +247,6 @@ end);
 
 #############################################################################
 ##
-#M  ELM0_LIST( <vec> ) 
-##
-##  alternatibe element access interface, returns fail when unbound
-##
-
-InstallMethod(ELM0_LIST, "for an 8 bit vector",
-        true, [IsList and Is8BitVectorRep, IsPosInt], 0,
-        ELM0_VEC8BIT);
-
-#############################################################################
-##
 #M  DegreeFFE( <vector> )
 ##
 BindGlobal("Q_TO_DEGREE", # discrete logarithm list

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -130,19 +130,6 @@ InstallOtherMethod( Length,
 
 #############################################################################
 ##
-#M  ELM0_LIST( <gf2vec>, <pos> )  . . . . select an element from a GF2 vector
-##
-InstallMethod( ELM0_LIST,
-    "for GF2 vector",
-    true,
-    [ IsList and IsGF2VectorRep,
-      IsPosInt ],
-    0,
-    ELM0_GF2VEC );
-
-
-#############################################################################
-##
 #M  ELM_LIST( <gf2vec>, <pos> ) . . . . . select an element from a GF2 vector
 ##
 InstallOtherMethod( ELM_LIST,

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -257,15 +257,6 @@ DeclareOperationKernel( "{}",
 
 #############################################################################
 ##
-#o  Elm0List( <list>, <pos> )
-##
-DeclareOperationKernel( "Elm0List",
-    [ IsList, IS_INT ],
-    ELM0_LIST );
-
-
-#############################################################################
-##
 #O  Unbind( <list>[<n>] )
 ##
 ##  <#GAPDoc Label="Unbind_list">

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -967,21 +967,6 @@ InstallOtherMethod( ProductOp,
 
 #############################################################################
 ##
-#M  Elm0List
-##
-InstallMethod( Elm0List,
-    [ IsList, IsInt ],
-    function ( list, pos )
-    if IsBound( list[pos] ) then
-        return list[pos];
-    else
-        return fail;
-    fi;
-    end );
-
-
-#############################################################################
-##
 #M  <list>{<poss>}
 #M  <list>{<poss>}:=<objs>
 ##

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -258,22 +258,6 @@ end);
 
 #############################################################################
 ##
-#M  ELM0_LIST( <mat> ) 
-##
-##  alternative element access interface, returns fail when unbound
-##
-
-InstallMethod(ELM0_LIST, "for an 8 bit matrix",
-        true, [IsList and Is8BitMatrixRep, IsPosInt], 0,
-        function(m,p)
-    if p > m![1] then 
-        return fail;
-    fi;
-    return m![p+1];
-end);
-
-#############################################################################
-##
 #M  ConvertToMatrixRepNC( <list>, <fieldsize )
 #M  ConvertToMatrixRep( <list>[, <fieldsize> | <field>])
 ##

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -236,17 +236,6 @@ end);
 
 #############################################################################
 ##
-#M  ELM0_LIST( <vec> ) 
-##
-##  alternatibe element access interface, returns fail when unbound
-##
-
-InstallMethod(ELM0_LIST, "for an 8 bit vector",
-        true, [IsList and Is8BitVectorRep, IsPosInt], 0,
-        ELM0_VEC8BIT);
-
-#############################################################################
-##
 #M  DegreeFFE( <vector> )
 ##
 BindGlobal("Q_TO_DEGREE", # discrete logarithm list

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -130,19 +130,6 @@ InstallOtherMethod( Length,
 
 #############################################################################
 ##
-#M  ELM0_LIST( <gf2vec>, <pos> )  . . . . select an element from a GF2 vector
-##
-InstallMethod( ELM0_LIST,
-    "for GF2 vector",
-    true,
-    [ IsList and IsGF2VectorRep,
-      IsPosInt ],
-    0,
-    ELM0_GF2VEC );
-
-
-#############################################################################
-##
 #M  ELM_LIST( <gf2vec>, <pos> ) . . . . . select an element from a GF2 vector
 ##
 InstallOtherMethod( ELM_LIST,

--- a/src/blister.c
+++ b/src/blister.c
@@ -345,9 +345,9 @@ static Obj Elm0Blist(Obj list, Int pos)
 **
 *F  Elm0vBlist( <list>, <pos> ) . . . . . select an element of a boolean list
 **
-**  'Elm0vPlist' does the same thing than 'Elm0List', but need not check that
-**  <pos>  is less  than or  equal   to the length   of  <list>, this is  the
-**  responsibility of the caller.
+**  'Elm0vPlist' does the same thing as 'Elm0Blist', but does not need to
+**  check that <pos> is less than or equal to the length of <list>, this is
+**  the responsibility of the caller.
 */
 static Obj Elm0vBlist(Obj list, Int pos)
 {

--- a/src/lists.c
+++ b/src/lists.c
@@ -379,46 +379,15 @@ static Obj Elm0ListError(Obj list, Int pos)
 **  list object <list>, or 0 if <list>  has no assigned object  at <pos>.  It
 **  is the responsibility  of the caller to  ensure that <pos> is a  positive
 **  integer.
-**
-**  Note that the method   returns `Fail' if there  is  no entry  at position
-**  <pos>, in this case `Elm0ListObject' must  check if the position is bound
-**  and `Fail'  means that there realy is  the object `Fail' at this position
-**  or if it is unbound in which case 0 is returned.
 */
-static Obj Elm0ListOper;
-
 static Obj Elm0ListObject(Obj list, Int pos)
 {
-    Obj                 elm;
-
-    elm = DoOperation2Args( Elm0ListOper, list, INTOBJ_INT(pos) );
-
-    if ( elm == Fail ) {
-        if ( DoOperation2Args(IsbListOper,list,INTOBJ_INT(pos)) == True )
-            return Fail;
-        else
-            return 0;
-    } else {
-        return elm;
-    }
+    if (ISB_LIST(list, pos))
+        return ELM_LIST(list, pos);
+    else
+        return 0;
 }
 
-
-/****************************************************************************
-**
-*F  FuncELM0_LIST( <self>, <list>, <pos> )  . . . . . . operation `ELM0_LIST'
-*/
-static Obj FuncELM0_LIST(Obj self, Obj list, Obj pos)
-{
-    Obj                 elm;
-    elm = ELM0_LIST( list, INT_INTOBJ(pos) );
-    if ( elm == 0 ) {
-        return Fail;
-    }
-    else {
-        return elm;
-    }
-}
 
 /****************************************************************************
 **
@@ -1861,7 +1830,6 @@ static StructGVarOper GVarOpers[] = {
       "src/lists.c:POS_LIST" },
 
     GVAR_OPER_2ARGS(ISB_LIST, list, pos, &IsbListOper),
-    GVAR_OPER_2ARGS(ELM0_LIST, list, pos, &Elm0ListOper),
     GVAR_OPER_3ARGS(ELM_DEFAULT_LIST, list, pos, default, &ElmDefListOper),
     GVAR_OPER_2ARGS(ELM_LIST, list, pos, &ElmListOper),
     GVAR_OPER_2ARGS(ELMS_LIST, list, poss, &ElmsListOper),

--- a/src/plist.c
+++ b/src/plist.c
@@ -1067,9 +1067,9 @@ static BOOL IsbPlistDense(Obj list, Int pos)
 **  <list>, or  0  if <list> has no  assigned  object at  <pos>.   It  is the
 **  responsibility of the caller to ensure that <pos> is a positive integer.
 **
-**  'Elm0vPlist' does the same thing than 'Elm0List', but need not check that
-**  <pos>  is less  than or  equal   to the length   of  <list>, this is  the
-**  responsibility of the caller.
+**  'Elm0vPlist' does the same thing as 'Elm0Plist', but does not need to
+**  check that <pos> is less than or equal to the length of <list>, this is
+**  the responsibility of the caller.
 */
 static Obj Elm0Plist(Obj list, Int pos)
 {

--- a/tst/testinstall/kernel/lists.tst
+++ b/tst/testinstall/kernel/lists.tst
@@ -34,14 +34,6 @@ gap> UNB_LIST([1],1);
 gap> UNB_LIST([1],2);
 
 #
-gap> ELM0_LIST([1],1);
-1
-gap> ELM0_LIST([1],2);
-fail
-gap> ELM0_LIST(1,2);
-Error, List Element: <list> must be a list (not the integer 1)
-
-#
 gap> ELM_LIST([1],1);
 1
 gap> ELM_LIST([1],2);


### PR DESCRIPTION
Nothing on the GAP level ever used the kernel operation `Elm0List` / `ELM0_LIST`, other than few unit tests and a handful of methods that were installed, but never called.

At the same time, quite some kernel code call these; as a result, if one wants to implement lists as external objects, one has to provide methods for `Elm0List`, not just `ELM_LIST` / `\[\]` -- but nobody did do so.

Also `Elm0ListObject` had to go through some contortions to decide whether a GAP method returned `fail` to indicate a hole, or whether the list really contained `fail`.

We thus remove `Elm0List` form the GAP level, and instead reimplement `Elm0ListObject` in terms of the standard operations `IsBound` and `\[\]`,


This PR is motivated by PR #3873.


Release notes: I don't think we need to document this because this operation was undocumented and nothing I could find (including all deposited GAP packages plus some more) uses it.