### PR TITLE
kernel: simplify OnPosIntSetsPartialPerm

### DIFF
--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -3658,67 +3658,16 @@ static Obj FuncOnPosIntSetsPartialPerm(Obj self, Obj set, Obj f)
     RequireSmallList("OnPosIntSetsPartialPerm", set);
     RequirePartialPerm("OnPosIntSetsPartialPerm", f);
 
-    UInt2 *     ptf2;
-    UInt4 *     ptf4;
-    UInt        deg;
-    const Obj * ptset;
-    Obj *       ptres, tmp, res;
-    UInt        i, k, reslen;
+    const UInt len = LEN_LIST(set);
 
-    if (LEN_LIST(set) == 0)
+    if (len == 0)
         return set;
 
-    if (LEN_LIST(set) == 1 && ELM_LIST(set, 1) == INTOBJ_INT(0)) {
+    if (len == 1 && ELM_LIST(set, 1) == INTOBJ_INT(0)) {
         return FuncIMAGE_SET_PPERM(self, f);
     }
 
-    PLAIN_LIST(set);
-    res = NEW_PLIST_WITH_MUTABILITY(IS_PLIST_MUTABLE(set), T_PLIST_CYC_SSORT,
-                                    LEN_PLIST(set));
-
-    /* get the pointer                                                 */
-    ptset = CONST_ADDR_OBJ(set) + LEN_LIST(set);
-    ptres = ADDR_OBJ(res) + 1;
-    reslen = 0;
-
-    if (TNUM_OBJ(f) == T_PPERM2) {
-        ptf2 = ADDR_PPERM2(f);
-        deg = DEG_PPERM2(f);
-        /* loop over the entries of the tuple                              */
-        for (i = LEN_LIST(set); 1 <= i; i--, ptset--) {
-            k = INT_INTOBJ(*ptset);
-            if (k <= deg && ptf2[k - 1] != 0) {
-                tmp = INTOBJ_INT(ptf2[k - 1]);
-                reslen++;
-                *ptres++ = tmp;
-            }
-        }
-    }
-    else {
-        ptf4 = ADDR_PPERM4(f);
-        deg = DEG_PPERM4(f);
-        /* loop over the entries of the tuple                              */
-        for (i = LEN_LIST(set); 1 <= i; i--, ptset--) {
-            k = INT_INTOBJ(*ptset);
-            if (k <= deg && ptf4[k - 1] != 0) {
-                tmp = INTOBJ_INT(ptf4[k - 1]);
-                reslen++;
-                *ptres++ = tmp;
-            }
-        }
-    }
-    ResizeBag(res, (reslen + 1) * sizeof(Obj));
-    SET_LEN_PLIST(res, reslen);
-
-    if (reslen == 0) {
-        RetypeBagSM(res, T_PLIST_EMPTY);
-    }
-    else {
-        SortPlistByRawObj(res);
-        RetypeBagSM(res, T_PLIST_CYC_SSORT);
-    }
-
-    return res;
+    return OnSetsPPerm(set, f);
 }
 
 /****************************************************************************/


### PR DESCRIPTION
This function seems to do the same as OnSets, except that it allows for the
input value `[ 0 ]` (contrary to its name), and it omits all kinds of argument
validations.

We change it to delegate in most cases to OnSetsPPerm. This adds a tiny bit of
overhead in the core loop(s), but in general I would hope this is not much of
an issue, while the extra input validation ought to help in finding and
preventing certain bugs.

@james-d-mitchell this really should be reviewed by you and not somebody else. In particular, I wonder if I missed some subtle difference. Also, while in "small" examples, the performance penalty seems to be negligible, I do wonder if you have computations where it is not.

The main point behind this PR is that I want to get rid of the `PLAIN_LIST` call here. If this PR is not good for merging, I can provide an alternate one which changes less code, but still gets rid of `PLAIN_LIST`.
