### PR TITLE
kernel: fix OnSets for pperms producing an empty list

### DIFF
--- a/src/plist.c
+++ b/src/plist.c
@@ -1035,6 +1035,7 @@ static Int LenPlist(Obj list)
 
 static Int LenPlistEmpty(Obj list)
 {
+    GAP_ASSERT(LEN_PLIST(list) == 0);
     return 0;
 }
 

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -3550,16 +3550,17 @@ Obj OnSetsPPerm(Obj set, Obj f)
             }
         }
     }
-    if (reslen == 0) {
-        RetypeBagSM(res, T_PLIST_EMPTY);
-        return res;
-    }
+
     SET_LEN_PLIST(res, reslen);
     SHRINK_PLIST(res, reslen);
 
-    // sort the result
-    SortPlistByRawObj(res);
-    RetypeBagSM(res, T_PLIST_CYC_SSORT);
+    if (reslen == 0) {
+        RetypeBagSM(res, T_PLIST_EMPTY);
+    }
+    else {
+        SortPlistByRawObj(res);
+        RetypeBagSM(res, T_PLIST_CYC_SSORT);
+    }
 
     return res;
 }

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -4075,6 +4075,16 @@ Error, <set> must be a list of positive small integers
 gap> OnTuples(["a"], PPerm4([1, 2, 3, 4, 5, 7], [6, 4, 5, 3, 8, 2]));
 Error, <tup> must be a list of small integers
 
+# Test regression for OnSets and OnTuples on empty sets
+gap> OnSets([], PartialPerm([])) = [];
+true
+gap> OnTuples([], PartialPerm([])) = [];
+true
+gap> OnSets([1], PartialPerm([])) = [];
+true
+gap> OnTuples([1], PartialPerm([])) = [];
+true
+
 #
 gap> SetUserPreference("PartialPermDisplayLimit", display);;
 gap> SetUserPreference("NotationForPartialPerm", notationpp);;


### PR DESCRIPTION
We sometimes ended up producing an "empty plist of length > 0"; that is, on
the GAP level, length 0 was shown thanks to `LenPlistEmpty` being called; but
the actual *stored* length still was 1. As a result, comparing such a broken
"empty" plist again an actual empty plist returned false.

We fix this by always setting the plist length in OnSetsPPerm.

Fixes https://github.com/gap-packages/orb/issues/52