### PR TITLE
kernel: simplify FuncDownEnv/UpEnv, and remove some global state

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -91,33 +91,6 @@ UInt OpenErrorOutput( void )
 **
 *F  FuncDownEnv( <self>, <level> )  . . . . . . . . .  change the environment
 */
-
-static void DownEnvInner(Int depth)
-{
-    /* if we are asked to go up ... */
-    if (depth < 0) {
-        /* ... we determine which level we are supposed to end up on ... */
-        depth = STATE(ErrorLLevel) + depth;
-        if (depth < 0) {
-            depth = 0;
-        }
-        /* ... then go back to the top, and later go down to the appropriate
-         * level. */
-        STATE(ErrorLVars) = STATE(BaseShellContext);
-        STATE(ErrorLLevel) = 0;
-        STATE(ShellContext) = STATE(BaseShellContext);
-    }
-
-    /* now go down */
-    while (0 < depth && STATE(ErrorLVars) != STATE(BottomLVars) &&
-           PARENT_LVARS(STATE(ErrorLVars)) != STATE(BottomLVars)) {
-        STATE(ErrorLVars) = PARENT_LVARS(STATE(ErrorLVars));
-        STATE(ErrorLLevel)++;
-        STATE(ShellContext) = PARENT_LVARS(STATE(ShellContext));
-        depth--;
-    }
-}
-
 static Obj FuncDownEnv(Obj self, Obj args)
 {
     Int depth;
@@ -136,7 +109,7 @@ static Obj FuncDownEnv(Obj self, Obj args)
         return (Obj)0;
     }
 
-    DownEnvInner(depth);
+    STATE(ErrorLLevel) += depth;;
     return (Obj)0;
 }
 
@@ -157,7 +130,7 @@ static Obj FuncUpEnv(Obj self, Obj args)
         return (Obj)0;
     }
 
-    DownEnvInner(-depth);
+    STATE(ErrorLLevel) -= depth;
     return (Obj)0;
 }
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -82,10 +82,8 @@ typedef struct GAPState {
     Obj  ThrownObject;
     UInt UserHasQuit;
     UInt UserHasQUIT;
-    Obj  ShellContext;
-    Obj  BaseShellContext;
     Obj  ErrorLVars;        // ErrorLVars as modified by DownEnv / UpEnv
-    Int  ErrorLLevel;       // record where on the stack ErrorLVars is relative to the top, i.e. BaseShellContext
+    Int  ErrorLLevel;       // record where on the stack ErrorLVars is relative to the top
     void (*JumpToCatchCallback)(void); // This callback is called in FuncJUMP_TO_CATCH,
                                    // this is not used by GAP itself but by programs
                                    // that use GAP as a library to handle errors


### PR DESCRIPTION
We get rid of STATE(ShellContext) and STATE(BaseShellContext) and further
simplify how the context for the break loop gets computed; the resulting code
is a lot easier to reason about.
