### PR TITLE
gac: add rudimentary assembler support

### DIFF
--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -327,7 +327,7 @@ while [ $# -gt 0 ]; do
 
     -L|--addlibs)         shift; c_addlibs="${c_addlibs} $1";;
 
-    *.g|*.gap|*.gd|*.gi|*.c|*.cc|*.cpp|*.o|*.lo)
+    *.g|*.gap|*.gd|*.gi|*.c|*.cc|*.cpp|*.cxx|*.s|*.o|*.lo)
                           inputs="${inputs} $1";;
 
     *)                    echo "$0: cannot handle this argument '$1'"
@@ -432,6 +432,10 @@ for input in ${inputs}; do
         *.cxx) # compile '.cxx' source files (also C++)
             name=$(basename ${input} .cxx)
             process_cxx_file $name $input;;
+
+        *.s) # compile '.s' source files (assembler)
+            name=$(basename ${input} .s)
+            process_c_file $name $input;; # HACK: just use the C compiler
 
         *.o) # look over '.o' source files
             name=$(basename ${input} .o)

--- a/etc/Makefile.gappkg
+++ b/etc/Makefile.gappkg
@@ -57,7 +57,10 @@ all: $(KEXT_SO)
 # For each file FOO.c in SOURCES, add gen/FOO.lo to KEXT_OBJS; similar
 # for .cc files
 ########################################################################
-KEXT_OBJS = $(patsubst %.cc,gen/%.lo,$(patsubst %.c,gen/%.lo,$(KEXT_SOURCES)))
+KEXT_OBJS = $(patsubst %.s,gen/%.lo, \
+            $(patsubst %.cc,gen/%.lo, \
+            $(patsubst %.c,gen/%.lo, \
+                $(KEXT_SOURCES))))
 
 ########################################################################
 # Quiet rules.
@@ -104,6 +107,11 @@ gen/%.lo: %.c Makefile
 # The dependency on Makefile ensures that re-running configure recompiles everything
 gen/%.lo: %.cc Makefile
 	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
+
+# build rule for assembler code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.s Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
 
 # build rule for linking all object files together into a kernel extension
 $(KEXT_SO): $(KEXT_OBJS)


### PR DESCRIPTION
This is potentially useful for meataxe64, as with this it could use `gac` instead of autotools.

A more sophisticated implementation would add dedicated ASFLAGS / ASMFLAGS, and perhaps also use `$(AS)` instead of the C compiler. But for now, this works quite well.

I'd like to backport this to `stable-4.11`