### PR TITLE
Temporarily add (back) a MutableCopyMat for every list

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2002,6 +2002,15 @@ InstallOtherMethod( MutableCopyMatrix, "for empty lists", [ IsList and IsEmpty ]
   mat -> [ ] );
 
 
+# FIXME: remove the following method again sometime soon (as of February
+# 2020); it is only here to work around an issue in the polycyclic package
+# which calls MutableCopyMat on a vector; once a new polycyclic release is
+# out, we should revert this again.
+InstallMethod( MutableCopyMat, "generic method", [IsList],
+    -SUM_FLAGS,
+  mat -> List( mat, ShallowCopy ) );
+
+
 #############################################################################
 ##
 #M  MutableTransposedMat( <mat> ) . . . . . . . . . .  transposed of a matrix


### PR DESCRIPTION
This is done to work around an issue in the polycyclic package which calls `MutableCopyMat` on a vector (see #3889). Once a new polycyclic release is out (which unfortunately will take a bit longer than I hoped for), we can and should revert this patch again. I'll open a PR reverting this one as soon as this PR here is merged
