### PR TITLE
Revert "Temporarily add (back) a MutableCopyMat for every list" (DO NOT MERGE)

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2002,15 +2002,6 @@ InstallOtherMethod( MutableCopyMatrix, "for empty lists", [ IsList and IsEmpty ]
   mat -> [ ] );
 
 
-# FIXME: remove the following method again sometime soon (as of February
-# 2020); it is only here to work around an issue in the polycyclic package
-# which calls MutableCopyMat on a vector; once a new polycyclic release is
-# out, we should revert this again.
-InstallMethod( MutableCopyMat, "generic method", [IsList],
-    -SUM_FLAGS,
-  mat -> List( mat, ShallowCopy ) );
-
-
 #############################################################################
 ##
 #M  MutableTransposedMat( <mat> ) . . . . . . . . . .  transposed of a matrix


### PR DESCRIPTION
This reverts commit fc65b0305c15db3dd51a336e89796e1779a999e7 from PR #3895

Should only be merged once a new polycyclic release has been made and picked up by the package distribution.