### PR TITLE
Provide a default `Unpack` method for lists

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -625,8 +625,8 @@ InstallMethod( Unpack,
             ## but avoids code duplication.
 
 InstallOtherMethod( Unpack,
-  "generic method for plain lists",
-  [ IsRowVector and IsPlistRep ],
+  "generic method for lists",
+  [ IsList ],
   ShallowCopy );
 
 InstallMethod( \{\},


### PR DESCRIPTION
The default `Unpack` method we had up to now delegates to `ShallowCopy` and requires `IsRowVector and IsPlistRep`.
However, this does not cover the rows of the matrix objects that are implemented in the `matrgrp` package, since these objects are not in `IsPlistRep`.

I think it is safe to install `ShallowCopy` as a really generic `Unpack` method that requires only `IsList`.