### PR TITLE
Add version command line option / #3735

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -60,6 +60,7 @@ BIND_GLOBAL( "GAPInfo", rec(
     # for those options is correct
     CommandLineOptionData := [
       rec( short:= "h", long := "help", default := false, help := ["print this help and exit"] ),
+      rec( short:= "v", long := "version", default := false, help := ["print the version and exit"] ),
       rec( short:= "b", long := "banner", default := false, help := ["disable/enable the banner"] ),
       rec( short:= "q", long := "quiet", default := false, help := ["enable/disable quiet mode"] ),
       rec( short:= "e", default := false, help := ["disable/enable quitting on <ctr>-D"] ),
@@ -479,6 +480,13 @@ CallAndInstallPostRestore( function()
        "  Boolean options toggle the current value each time they are called.\n",
        "  Default actions are indicated first.\n",
        "\n" );
+      QUIT_GAP();
+    elif GAPInfo.CommandLineOptions.v then
+      PRINT_TO( "*errout*",
+        "KernelVersion ", GAPInfo.KernelVersion, "\n",
+        "BuildVersion ", GAPInfo.BuildVersion, "\n",
+        "\n" );
+      # PRINT_TO( "*errout*",GAPInfo.KernelVersion);
       QUIT_GAP();
     fi;
 end );


### PR DESCRIPTION
# Description

> Add --version command line option which prints out the GAP version and exits. This command should be fast, i.e., be handled by the kernel before the library is loaded.

> This would be helpful for scripts that just want to test if the installed GAP version is new enough.

Reffer to: https://github.com/gap-system/gap/issues/3735
Thanks to @fingolfin @hulpke 

## Further details

#### $ ./gap -v
```
KernelVersion 4.dev
BuildVersion 4.12dev-333-gfc65b03-dirty

```

# Checklist for pull request reviewers

- [x] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [x] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [x] runnable tests
- [x] lines changed in commits are sufficiently covered by the tests
- [x] adequate pull request title
- [x] well formulated text for release notes
- [x] relevant documentation updates
- [x] sensible comments in the code

