### PR TITLE
Allow function-call syntax for general mappings.

### DIFF
--- a/lib/mapping.gd
+++ b/lib/mapping.gd
@@ -882,7 +882,7 @@ DeclareOperation( "ImageElm", [ IsMapping, IsObject ] );
 ##  <A>elm</A> of the source of the mapping <A>map</A> under <A>map</A>,
 ##  i.e., the unique element of the range to which <A>map</A> maps
 ##  <A>elm</A>.
-##  This can also be expressed as <A>elm</A><C>^</C><A>map</A>.
+##  This can also be expressed as <A>elm</A><C>^</C><A>map</A> or as 
 ##  Note that <A>map</A> must be total and single valued,
 ##  a multi valued general mapping is not allowed
 ##  (see&nbsp;<Ref Func="Images" Label="set of images of the source of a general mapping"/>).
@@ -890,13 +890,19 @@ DeclareOperation( "ImageElm", [ IsMapping, IsObject ] );
 ##  <C>Image( <A>map</A>, <A>coll</A> )</C> is the image of the subset
 ##  <A>coll</A> of the source of the mapping <A>map</A> under <A>map</A>,
 ##  i.e., the subset of the range to which <A>map</A> maps elements of
-##  <A>coll</A>.
+##  <A>coll</A>. <P/> 
 ##  <A>coll</A> may be a proper set or a domain.
 ##  The result will be either a proper set or a domain.
 ##  Note that in this case <A>map</A> may also be multi-valued.
 ##  (If <A>coll</A> and the result are lists then the positions of
 ##  entries do in general <E>not</E> correspond.)
 ##  <P/>
+##  <C>Image( <A>map</A>, <A>coll</A> )</C> can also be expressed as <C><A>map</A>(<A>coll</A>)</C> and
+##  <C>Image( <A>map</A>, <A>elm</A> )</C> as  <C><A>map</A>(<A>elm</A>)</C>.
+##  Those using this notation should remember that composition of mappings in &GAP;
+##  still follows the conventions appropriate for mapping acting from the right, so that 
+##  <C>(<A>map1</A>*<A>map2</A>)(<A>x</A>)</C> is equivalent to 
+##  <C><A>map2</A>(<A>map1</A>(<A>x</A>))</C>    <P/>
 ##  <Ref Func="Image" Label="set of images of the source of a general mapping"/>
 ##  delegates to <Ref Attr="ImagesSource"/> when called
 ##  with one argument, and to <Ref Oper="ImageElm"/> resp.

--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -152,6 +152,21 @@ InstallGlobalFunction( Image, function ( arg )
                    "Image(<map>,<coll>)" );
 end );
 
+#############################################################################
+##
+#M  <map>(<elm>)
+#M  <map>(<coll>)
+##
+##  Method to alow mappings to be used like functions when appropriate
+
+InstallMethod(CallFuncList, [IsGeneralMapping, IsList],
+        function(map, lst) 
+    if Length(lst) <> 1 then 
+        TryNextMethod(); 
+    fi; 
+    return Image(map, lst[1]); 
+end);
+
 
 #############################################################################
 ##

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -271,9 +271,13 @@ gap> IsTotal( map );
 true
 gap> Image( map, Z(3) );
 0*Z(3)
+gap> map(Z(3));
+0*Z(3)
 gap> ImageElm( map, Z(3) );
 0*Z(3)
 gap> Image( map, [ Z(3) ] );
+[ 0*Z(3) ]
+gap> map( [ Z(3) ] );
 [ 0*Z(3) ]
 gap> ImagesElm( map, Z(3) );
 [ 0*Z(3) ]
@@ -344,6 +348,18 @@ list or collection
 gap> Image(mapBijective, Z(9));
 Error, <elm> must be an element of Source(<map>)
 gap> Image(map, [Z(3), Z(9)]);
+Error, the collection <elm> must be contained in Source(<map>)
+
+# Image in alternative syntax
+gap> map(0*Z(3));
+Error, <map> must be single-valued and total
+gap> mapBijective(Z(5));
+Error, the families of the element or collection <elm> and Source(<map>) don't\
+ match, maybe <elm> is not contained in Source(<map>) or is not a homogeneous \
+list or collection
+gap> mapBijective(Z(9));
+Error, <elm> must be an element of Source(<map>)
+gap> map([Z(3), Z(9)]);
 Error, the collection <elm> must be contained in Source(<map>)
 
 # Images


### PR DESCRIPTION
#2006 Description
Inspired by a recent GAP Forum request. This PR allows a function-call like syntax for taking images of general mappings. Specifically `map( x )` is treated as `Image( map, x)` whenever `map` is a general mapping. 

It's really just for comments. The change is just a couple of lines, plus tests and a note in the manual,
so it seemed better to demonstrate the idea before discussing, but I'd not wedded to it.
## Text for release notes 
Allows a function-call like syntax for taking images of general mappings.

Incorporates #3902 which should be addressed first.

If this pull request should be mentioned in the release notes, 
please provide a short description matching the style of the GAP
`CHANGES.md` file in the root directory.

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [x ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [x] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [x] runnable tests
- [x] lines changed in commits are sufficiently covered by the tests
- [x] adequate pull request title
- [ ] well formulated text for release notes
- [x] relevant documentation updates
- [x] sensible comments in the code

