### PR TITLE
Fixed bug with Cycles((),[])

### DIFF
--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2188,8 +2188,12 @@ InstallMethod( CyclesOp, true, [ IsObject, IsList, IsFunction ], 1,
     IsSSortedList(D);
     blist := BlistList( [ 1 .. Length( D ) ], [  ] );
     orbs := [  ];
-    next := 1;
-    while next <> fail do
+    next := 0;
+    while true do
+        next := Position( blist, false, next );
+        if next = fail then
+            return Immutable( orbs );
+        fi;
         pnt := D[ next ];
         orb := CycleOp( g, D[ next ], act );
         Add( orbs, orb );
@@ -2199,9 +2203,7 @@ InstallMethod( CyclesOp, true, [ IsObject, IsList, IsFunction ], 1,
                 blist[ pos ] := true;
             fi;
         od;
-        next := Position( blist, false, next );
     od;
-    return Immutable( orbs );
 end );
 
 #############################################################################

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -374,6 +374,10 @@ l')
 #
 # CycleLengthPermInt, CyclePermInt
 #
+gap> Cycles((),[]);
+[  ]
+gap> Cycles((),[1]);
+[ [ 1 ] ]
 gap> Cycles((1,2,3)(4,5)(6,70),[4..7]);
 [ [ 4, 5 ], [ 6, 70 ], [ 7 ] ]
 gap> CycleLengths((1,2,3)(4,5)(6,70),[4..7]);


### PR DESCRIPTION
# Description

There is a case of Emptyophobia with CyclesOp:

in the previous version, 'Cycles((),[])' triggers an error. It now correctly returns '[]'.