### PR TITLE
lib: add warning to BIND_GLOBAL

### DIFF
--- a/lib/global.gi
+++ b/lib/global.gi
@@ -57,12 +57,29 @@ end);
 ##
 
 CheckGlobalName := function( name )
+    local pos;
     if not IsString( name ) then
-      Error("CheckGlobalName: the argument must be a string");
+        Error("CheckGlobalName: the argument must be a string");
     fi;
-    if ForAny(name, l -> not l in IdentifierLetters) then
-        Info(InfoWarning + InfoGlobal, 2, 
-             "suspicious global variable name ", name);
+    pos := 1;
+    # This function is used early in the initialization process, so we need to
+    # do PositionProperty manually.
+    while pos <= Length(name) do
+        if name[pos] in IdentifierLetters then
+            pos := pos + 1;
+        else
+            break;
+        fi;
+    od;
+    if pos <= Length(name) then
+        Info(InfoWarning + InfoGlobal, 1,
+             "suspicious global variable name \"", name, "\", ",
+             "non-identifier character found at position ", pos);
+    fi;
+    if Length(name) = 0 then
+        Info(InfoWarning + InfoGlobal, 1,
+             "suspicious global variable name \"", name, "\", ",
+             "name is the empty string");
     fi;
 end;
 

--- a/tst/testinstall/global.tst
+++ b/tst/testinstall/global.tst
@@ -1,0 +1,6 @@
+# test CheckGlobalName
+gap> CheckGlobalName(" ");
+#I  suspicious global variable name " ", non-identifier character found at position 1
+gap> CheckGlobalName("");
+#I  suspicious global variable name "", name is the empty string
+gap> CheckGlobalName("name");


### PR DESCRIPTION
# Description
This PR adds a warning to `BIND_GLOBAL`. A warning is printed if `BIND_GLOBAL(name, val)` is called with a `name` which starts with a whitespace. 

It is possible to do `BIND_GLOBAL(" x", 1);` (notice the whitespace) but this variable won't be (?) accessible from the command line. Or is there a way to access such a variable?

# Checklist for pull request reviewers

- [ ] proper formatting
- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

