### PR TITLE
Do not put a link to HPC-GAP manual

### DIFF
--- a/doc/ref/preface.xml
+++ b/doc/ref/preface.xml
@@ -18,8 +18,11 @@ Welcome to &GAP;.
 This is one of the manuals documenting the core part of &GAP;,
 the others being the <E>&GAP; Tutorial</E>
 <Alt Only="HTML">(see <Ref BookName="tut" Label="Preface"/>)</Alt>
-and  <E>HPC-GAP Reference Manual</E>
+and <E>HPC-GAP Reference Manual</E>.
+<!--
 <Alt Only="HTML">(see <Ref BookName="hpc" Label="Tasks"/>)</Alt>.
+-->
+<P/>
 
 There is also a document <F>CHANGES.md</F> on the 
 changes from earlier versions in the root directory.

--- a/doc/tut/preface.xml
+++ b/doc/tut/preface.xml
@@ -28,7 +28,9 @@ In addition to this manual, there are <E>&GAP; Reference Manual</E>
 containing detailed documentation of the mathematical functionality of &GAP;,
 and
 <E>HPC-GAP Reference Manual</E>
+<!--
 <Alt Only="HTML">(see <Ref BookName="hpc" Label="Tasks"/>)</Alt>
+-->
 documenting a multi-threaded version of GAP.
 <P/>
 


### PR DESCRIPTION
It is only available if GAP is compiled with HPC-GAP support,
otherwise the cross-reference is unresolved.
