### PR TITLE
Revert "Add Ubuntu singular to deps for testpackages" (DO NOT MERGE)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ matrix:
           #- libfplll-dev           # for float
           - pari-gp                 # for alnuth
           - libzmq3-dev             # for ZeroMQInterface
-          - singular                # for IO_ForHomalg
 
     # compile packages and run GAP tests in 32 bit mode
     # it seems profiling is having trouble collecting the coverage data here, so we
@@ -87,7 +86,6 @@ matrix:
           #- libfplll-dev:i386      # for float
           - pari-gp:i386            # for alnuth
           - libzmq3-dev:i386        # for ZeroMQInterface
-          - singular:i386           # for IO_ForHomalg
 
     # OS X builds: since those are slow and limited on Travis, we only run testinstall
     - env: TEST_SUITES="docomp testinstall"


### PR DESCRIPTION
This reverts PR #3904, for the reason mention there: that commit papers over a regression in some packages (but I don't know which packages exactly are at fault).

To recap: loading `NumericalSgps` (CC @pedritomelenas) when "singular" is not available in the system can lead to a break loop, which it shouldn't:
```
#I  Loaded interface to Normaliz (NormalizInterface)
#I  Loaded interface to 4ti2 (4ti2Interface)
Error, found no Singular executable in PATH while searching the following list:
[ "Singular" ]
 at GAPROOT/pkg/IO_ForHomalg-2019.09.02/gap/IO_ForHomalg.gi:309 called from
CallFuncList( LaunchCAS_IO_ForHomalg, Concatenation( [ HOMALG_IO_CAS ], arg{[ 2 .. nargs ]} )
 ) at GAPROOT/pkg/HomalgToCAS-2019.12.08/gap/IO.gi:126 called from
LaunchCAS( HOMALG_IO_CAS
 ) at GAPROOT/pkg/HomalgToCAS-2019.12.08/gap/HomalgExternalRing.gi:448 called from
CallFuncList( CreateHomalgExternalRing, ar
 ) at GAPROOT/pkg/RingsForHomalg-2019.12.08/gap/Singular.gi:1137 called from
CallFuncList( RingForHomalgInSingular, R
 ) at GAPROOT/pkg/RingsForHomalg-2019.12.08/gap/Singular.gi:1358 called from
<function "HomalgFieldOfRationalsInSingular">( <arguments> )
 called from read-eval loop at GAPROOT/pkg/NumericalSgps-1.2.1/gap/affine-extra-gm.gi:9
```

This started to happen in February, at some point between roughly the 15th and 18th (perhaps a day earlier/later). Most likely, some package update was picked up then which was released before that time. @alex-konovalov identified some candidates (see comments on PR #3904), but no obvious smoking gun).

The trigger for this is likely the following line in NumericalSgps' file `gap/affine-extra-gm.gi`:
```
BindGlobal("NumSgpsRationals",HomalgFieldOfRationalsInSingular());
```
This eventually runs code from the `IO_ForHomalg` (CC @mohamed-barakat)  which runs into the error (some further details again can be found on PR #3904). The odd thing is: this didn't seem to cause issues in the past. So what changed? Perhaps also something in the Travis VM changed?

Anyway, some ideas for avoiding the issue:
- get rid of `NumSgpsRationals` altogether and just call `HomalgFieldOfRationalsInSingular()` directly (that would create a new ring each time it is called. Not sure if that's a problem, though? Or perhaps it might even fix potential issues)
- delay initialization of `NumSgpsRationals` by ... 
  - ... using `DeclareGlobalVariable("NumSgpsRationals");` and `InstallFlushableValueFromFunction("NumSgpsRationals ", HomalgFieldOfRationalsInSingular);` 
  - ... using `DeclareAutoreadableVariables`.


Anyway, once this problem is resolved, we could merge this PR (or not).