### PR TITLE
Add InnerAutomorphismGroup for groups

### DIFF
--- a/doc/ref/grphomom.xml
+++ b/doc/ref/grphomom.xml
@@ -377,6 +377,7 @@ to form groups of automorphisms.
 <#Include Label="AutomorphismDomain">
 <#Include Label="IsAutomorphismGroup">
 <#Include Label="InnerAutomorphismsAutomorphismGroup">
+<#Include Label="InnerAutomorphismGroup">
 <#Include Label="InducedAutomorphism">
 
 <!-- %%  The code for automorphism groups was designed and implemented by Bettina -->

--- a/lib/morpheus.gd
+++ b/lib/morpheus.gd
@@ -172,6 +172,27 @@ DeclareAttribute("InnerAutomorphismsAutomorphismGroup",IsGroup);
 
 #############################################################################
 ##
+#A  InnerAutomorphismGroup(<G>)
+##
+##  <#GAPDoc Label="InnerAutomorphismGroup">
+##  <ManSection>
+##  <Attr Name="InnerAutomorphismGroup" Arg='G'/>
+##
+##  <Description>
+##  For a group <A>G</A> this attribute stores the group of inner
+##  automorphisms (automorphisms induced by conjugation) of the original group.
+##  <Example><![CDATA[
+##  gap> InnerAutomorphismGroup(SymmetricGroup(5));
+##  <group with 2 generators>
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareAttribute("InnerAutomorphismGroup", IsGroup);
+
+#############################################################################
+##
 #F  AssignNiceMonomorphismAutomorphismGroup(<autgrp>,<group>)   local
 ##
 ##  <#GAPDoc Label="AssignNiceMonomorphismAutomorphismGroup">

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2589,6 +2589,28 @@ InstallMethod( InnerAutomorphismsAutomorphismGroup,
 
 #############################################################################
 ##
+#M  InnerAutomorphismGroup( <G> )
+##
+InstallMethod( InnerAutomorphismGroup,
+    "for groups",
+    true,
+    [ IsGroup and HasGeneratorsOfGroup ], 0,
+    function( G )
+    local gens, A;
+    if HasAutomorphismGroup( G ) or IsTrivial( G ) then
+        return InnerAutomorphismsAutomorphismGroup( AutomorphismGroup( G ) );
+    fi;
+    gens:= GeneratorsOfGroup( G );
+    # get the non-central generators
+    gens:= Filtered( gens, i -> not ForAll( gens, j -> i*j = j*i ) );
+    A := Group( List( gens, i -> InnerAutomorphism( G, i ) ) );
+    SetIsGroupOfAutomorphismsFiniteGroup( A, true );
+    return A;
+    end );
+
+
+#############################################################################
+##
 #F  IsomorphismGroups(<G>,<H>) . . . . . . . . . .  isomorphism from G onto H
 ##
 InstallGlobalFunction(IsomorphismGroups,function(G,H)

--- a/tst/testinstall/morpheus.tst
+++ b/tst/testinstall/morpheus.tst
@@ -2,11 +2,14 @@
 ##
 ##  This  file  tests the automorphism routines
 ##
-#@local a,autd8,d8,g,inn,iso1,iso2,iso3,iso4,p,r,s4
+#@local a,autd8,d8,g,inn,inn2,iso1,iso2,iso3,iso4,p,r,s4
 gap> START_TEST("morpheus.tst");
 gap> g:=Group((1,2,3,4),(1,3));;
+gap> inn2:=InnerAutomorphismGroup(g);;
 gap> a:=AutomorphismGroup(g);;
 gap> inn:=InnerAutomorphismsAutomorphismGroup(a);;
+gap> inn = inn2;
+true
 gap> iso1:=IsomorphismGroups(a,g);;
 gap> iso1=fail;
 false


### PR DESCRIPTION
If the automorphism group is known, calls InnerAutomorphismsAutomorphismGroup;
otherwise creates the InnerAutomorphismGroup from scratch.

I suspect that there is a reason `InnerAutomorphismGroup` does not exist right now (i.e. this PR might be too naive); hopefully @hulpke knows about that. So please don't merge this before he had a chance to comment.