### PR TITLE
generalize setup for CentralIdempotentsOfAlgebra

### DIFF
--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -3493,7 +3493,7 @@ InstallMethod( CentralIdempotentsOfAlgebra,
           eq,facs,hlist,c,p,g,gcd,bb,E,ei,ni,hom,qq;
 
 
-      if One( A ) = fail then TryNextMethod(); fi;
+      if MultiplicativeNeutralElement( A ) = fail then TryNextMethod(); fi;
 
       F:=LeftActingDomain(A);
       B:=Centre(A);
@@ -3502,7 +3502,7 @@ InstallMethod( CentralIdempotentsOfAlgebra,
       hom:= NaturalHomomorphismByIdeal( B, Rad );
       Q:= ImagesSource( hom );
       bQ:= BasisVectors( Basis( Q ) );
-      ids:= [ One( Q ) ];
+      ids:= [ MultiplicativeNeutralElement( Q ) ];
       ideals:= [ Q ];
 
       # The variable `k' will point to the first element of `ideals' that

--- a/lib/ideal.gi
+++ b/lib/ideal.gi
@@ -397,6 +397,26 @@ InstallMethod( ViewObj,
 
 #############################################################################
 ##
+#M  Representative( <I> ) . . . . one element of a left/right/two sided ideal
+##
+InstallMethod( Representative,
+    "for left ideal with known generators",
+    [ IsRing and HasGeneratorsOfLeftIdeal ],
+    RepresentativeFromGenerators( GeneratorsOfLeftIdeal ) );
+
+InstallMethod( Representative,
+    "for right ideal with known generators",
+    [ IsRing and HasGeneratorsOfRightIdeal ],
+    RepresentativeFromGenerators( GeneratorsOfRightIdeal ) );
+
+InstallMethod( Representative,
+    "for two-sided ideal with known generators",
+    [ IsRing and HasGeneratorsOfTwoSidedIdeal ],
+    RepresentativeFromGenerators( GeneratorsOfTwoSidedIdeal ) );
+
+
+#############################################################################
+##
 #M  Zero( <I> ) . . . . . . . . . . . . . . . . . . . . . . . .  for an ideal
 ##
 InstallOtherMethod( Zero,

--- a/tst/teststandard/algebra.tst
+++ b/tst/teststandard/algebra.tst
@@ -11,6 +11,8 @@ gap> Length( dec );
 2
 gap> ForAny( dec, IsAlgebraWithOne );
 false
+gap> List( dec, One );
+[ fail, fail ]
 gap> List( dec, CentralIdempotentsOfAlgebra );;
 
 #

--- a/tst/teststandard/algebra.tst
+++ b/tst/teststandard/algebra.tst
@@ -1,0 +1,17 @@
+#@local f, gens, a, q, dec
+gap> START_TEST( "algebra.tst" );
+
+# 'CentralIdempotentsOfAlgebra' need not require 'IsAlgebraWithOne'.
+gap> f:= GF(2);;
+gap> gens:= GeneratorsOfGroup( SymmetricGroup( 4 ) );;
+gap> a:= AlgebraWithOne( f, List( gens, x -> PermutationMat( x, 4, f ) ) );;
+gap> q:= a / RadicalOfAlgebra( a );;
+gap> dec:= DirectSumDecomposition( q );;
+gap> Length( dec );
+2
+gap> ForAny( dec, IsAlgebraWithOne );
+false
+gap> List( dec, CentralIdempotentsOfAlgebra );;
+
+#
+gap> STOP_TEST( "algebra.tst" );

--- a/tst/teststandard/ideal.tst
+++ b/tst/teststandard/ideal.tst
@@ -1,0 +1,13 @@
+#@local f, a, gens
+gap> START_TEST( "ideal.tst" );
+
+# Make sure that there is a 'Representative' method for ideals.
+gap> f:= GF(2);;
+gap> a:= f^[2,2];;
+gap> gens:= GeneratorsOfAlgebraWithOne( a );;
+gap> Representative( LeftIdeal( a, [ gens[1] ] ) );;
+gap> Representative( RightIdeal( a, [ gens[1] ] ) );;
+gap> Representative( TwoSidedIdeal( a, [ gens[1] ] ) );;
+
+#
+gap> STOP_TEST( "ideal.tst" );


### PR DESCRIPTION
# Description
Up to now, the GAP library method for `CentralIdempotentsOfAlgebra`
requires only `IsAlgebra` but the method throws an error if the argument
does not support `One`.
In fact, only `MultiplicativeNeutralElement` is needed.
Klaus Lux has observed the deficiency.

(For a meaningful test example, I have also added `Representative` methods for left/right/two sided ideals with known ideal generators. No such method had been available up to now.)

# Text for release notes 
Admit `CentralIdempotentsOfAlgebra` for algebras without `One`.