### PR TITLE
Make curl follow redirects, fixes 'make bootstrap-pkg-*'

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1134,7 +1134,7 @@ testkernel: ${KERNELTESTS}
 
 # change PKG_BRANCH to stable-X.Y in the stable branch
 PKG_BRANCH = master
-PKG_BOOTSTRAP_URL = https://www.gap-system.org/pub/gap/gap4pkgs/
+PKG_BOOTSTRAP_URL = https://files.gap-system.org/gap4pkgs/
 PKG_MINIMAL = packages-required-$(PKG_BRANCH).tar.gz
 PKG_FULL = packages-$(PKG_BRANCH).tar.gz
 DOWNLOAD = $(abs_srcdir)/etc/download.sh

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -44,9 +44,9 @@ fi
 time "$SRCDIR/configure" --enable-Werror $CONFIGFLAGS
 time make V=1 -j4
 
-# download packages; instruct wget to retry several times if the
+# download packages; instruct curl to retry several times if the
 # connection is refused, to work around intermittent failures
-DOWNLOAD="curl --retry 5 --retry-delay 5 -O"
+DOWNLOAD="curl -L --retry 5 --retry-delay 5 -O"
 if [[ $(uname) == Darwin ]]
 then
     # Travis OSX builders seem to have very small download bandwidth,

--- a/etc/download.sh
+++ b/etc/download.sh
@@ -6,7 +6,7 @@
 set -e
 
 # check whether curl is available, and if so, delegate to it
-command -v curl >/dev/null 2>&1 && exec curl -O "$@"
+command -v curl >/dev/null 2>&1 && exec curl -L -O "$@"
 
 # check whether wget is available, and if so, delegate to it
 command -v wget >/dev/null 2>&1 && exec wget -N "$@"


### PR DESCRIPTION
When rearranging files on www.gap-system.org, we have introduced some 301 redirects. Curl needs an explicit flag (-L) to make it follow these redirects. wget follows them by default.