### PR TITLE
Unbreak out-of-tree builds

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1312,7 +1312,16 @@ $(srcdir)/src/config.h.in: $(configure_deps)
 	 fi
 	touch $@
 
-%: $(srcdir)/%.in config.status
+doc/versiondata: $(srcdir)/doc/versiondata.in config.status
+	@$(SHELL) ./config.status $@
+
+doc/make_doc: $(srcdir)/doc/make_doc.in config.status
+	@$(SHELL) ./config.status $@
+
+CITATION: $(srcdir)/CITATION.in config.status
+	@$(SHELL) ./config.status $@
+
+gac: $(srcdir)/cnf/gac.in config.status
 	@$(SHELL) ./config.status $@
 
 libtool: config.status


### PR DESCRIPTION
Fixes a flaw in #3874 that breaks incremental out of tree builds -- initial builds work (which is why Travis didn't test this) but if a file goes missing or needs updating, then the scripts failed to regenerate them.

Also the rule for regenerating `gac` was completely broken, even for in-tree builds