### PR TITLE
Add libtool versioning to libgap shared library

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -27,9 +27,13 @@ GC_SOURCES = @GC_SOURCES@
 COMPAT_MODE = @COMPAT_MODE@
 GAPARCH = @GAPARCH@
 
-#
+# GAP version and release date
 GAP_VERSION = @GAP_VERSION@
 GAP_RELEASEDAY = @GAP_RELEASEDAY@
+
+# libtool library version
+GAP_LIBTOOL_CURRENT = @GAP_LIBTOOL_CURRENT@
+GAP_LIBTOOL_AGE = @GAP_LIBTOOL_AGE@
 
 # GAP kernel version
 GAP_KERNEL_MINOR_VERSION = @gap_kernel_minor_version@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -372,7 +372,7 @@ obj/%.lo: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
 LINK=$(LIBTOOL) --mode=link $(CC) -export-dynamic
 
 libgap.la: $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) -no-undefined -rpath $(libdir) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS) -o $@
+	$(QUIET_LINK)$(LINK) -no-undefined -version-info $(GAP_LIBTOOL_CURRENT):0:$(GAP_LIBTOOL_AGE) -rpath $(libdir) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS) -o $@
 
 ifeq ($(SYS_IS_CYGWIN32),yes)
 
@@ -400,8 +400,15 @@ GAP_LDFLAGS += -Wl,--allow-multiple-definition
 # GAP's standard main function is renamed. And gap.exe is a tiny binary which
 # loads that DLL and calls the renamed main function.
 all: bin/$(GAPARCH)/gap.dll
+
 bin/$(GAPARCH)/gap.dll: symlinks libgap.la
-	cp .libs/cyggap-0.dll $@  # FIXME: HACK to support kernel extensions
+	# FIXME: HACK to support kernel extensions; this is necessary
+	# because we don't use `libtool --mode=install` and so we have to
+	# work with the libtool wrappers for shared libraries meant for
+	# using during development, not for what we actually use them for.
+	# See also `LTINSTALL` and `install-libgap`.
+	cp .libs/cyggap-*.dll $@
+
 gap$(EXEEXT): libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(srcdir)/src/gapw95.c $(GAP_LIBS) libgap.la -o $@
 	@( if which peflags > /dev/null ; then peflags --cygwin-heap=2048 gap$(EXEEXT) ; fi )
@@ -727,6 +734,8 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 	@echo "" >> $@
 	@echo "GAP_VERSION=\"$(GAP_VERSION)\"" >> $@
 	@echo "GAP_BUILD_VERSION=\"$(GAP_BUILD_VERSION)\"" >> $@
+	@echo "GAP_LIBTOOL_CURRENT=$(GAP_LIBTOOL_CURRENT)" >> $@
+	@echo "GAP_LIBTOOL_AGE=$(GAP_LIBTOOL_AGE)" >> $@
 	@echo "GAP_KERNEL_MAJOR_VERSION=$(GAP_KERNEL_MAJOR_VERSION)" >> $@
 	@echo "GAP_KERNEL_MINOR_VERSION=$(GAP_KERNEL_MINOR_VERSION)" >> $@
 	@echo "" >> $@

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,28 @@ m4_define([gap_releaseyear], [this year])
 
 m4_define([gap_tarname], [gap-gap_version])
 
+dnl
+dnl libtool library version
+dnl
+dnl The version of the libgap shared library as well as the kernel
+dnl version are derived from libtool_current and libtool_age.
+dnl When making a new GAP release, these values need to be adjusted, based on
+dnl the following rules:
+dnl
+dnl 1. If any interfaces have been added, removed, or changed since the last
+dnl    update, increment current.
+dnl 2. If any interfaces have been added since the last public release, then
+dnl    increment age.
+dnl 3. If any interfaces have been removed or changed since the last public
+dnl    release, then set age to 0.
+dnl
+dnl For further details, refer to the Libtool manual chapter on "Library
+dnl interface versions", available at
+dnl <https://www.gnu.org/software/libtool/manual/html_node/Versioning.html>
+m4_define([libtool_current], [8])
+m4_define([libtool_age], [0])
+
+
 AC_INIT([GAP],
         gap_version,
         [support@gap-system.org],
@@ -724,11 +746,15 @@ AS_IF([test "x$with_gc" = xboehm],
 )
 
 dnl
-dnl Define kernel version
+dnl Export library and kernel version
 dnl
+AC_SUBST([GAP_LIBTOOL_CURRENT], "libtool_current")
+AC_SUBST([GAP_LIBTOOL_AGE], "libtool_age")
 
-gap_kernel_major_version=8
-gap_kernel_minor_version=0
+dnl kernel version is derived from the libtool library version
+gap_kernel_major_version=$(( libtool_current - libtool_age ))
+gap_kernel_minor_version=libtool_age
+
 AC_SUBST([gap_kernel_major_version])
 AC_SUBST([gap_kernel_minor_version])
 

--- a/src/modules.h
+++ b/src/modules.h
@@ -34,13 +34,14 @@
 **
 **  The kernel will not load a module compiled for a different major version.
 **
-**  The minor version should be incremented when new backwards-compatible
-**  functionality is added. The major version should be incremented when
-**  a backwards-incompatible change is made.
+**  The kernel version is set in `configure.ac`. As a rule, when new
+**  backwards-compatible functionality is added, the major version stays the
+**  same and the minor version is incremented. When a backwards-incompatible
+**  change is made, the major version is increased and the minor version reset
+**  to zero.
 **
-**  The kernel version is a macro so it can be used by packages
-**  to optionally compile support for new functionality.
-**
+**  The kernel version is a macro so it can be used by packages for
+**  conditional compilation of code using new kernel functionality.
 */
 
 // GAP_KERNEL_MAJOR_VERSION and GAP_KERNEL_MINOR_VERSION are defined in


### PR DESCRIPTION
We set up a libtool library version using the `current:revision:age`
format employed by libtool (see the libtool manual for details). We
currently do not use the `revision` value and use 0 instead. To avoid an
ever increasing number of versions, the kernel version is derived from
the libtool versioning info as follow:

    kernel_major := current - age
    kernel_minor := age

This provides the right semantics, provided we diligently follow the
rules for adjusting the values of `current` and `age` during releases,
as outlined in a comment in `configure.ac`.

Closes #3928


We could backport this to stabe-4.11, but that creates a somewhat iffy situation, as technically it would break the ABI going from 4.11.0 to 4.11.1; something we promised not to do. Yet one of the people who specifically asked whether we guarantee ABI stability in the 4.11 series, namely Bill Allombert from Debian, apparently is suggesting on the GAP mailing list that we do just that (however, I should qualify that this is just my understanding of what he said -- I may have misunderstood and don't want to misrepresent him). While that is all good and fine, I am not sure how other people packaging GAP would like this (e.g. @jamesjer working Fedora packages). Right now I think I'd prefer if we did not backport this, and just tell upstream packagers who want to know that GAP 4.12 will use the library version 8, so they can set any lower value for GAP 4.11, should they want to.