### PR TITLE
FIX for #3934

### DIFF
--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -612,6 +612,22 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
     SortBy(d,Size); # in case reversed order....
   fi;
 
+  # now go up in series if elementary abelian to avoid too many tiny steps
+  u:=1; # last group in the series to be used
+  i:=2;
+  while i<Length(d) do
+    p:=IndexNC(d[i+1],d[u]);
+    # should we skip group i?
+    if p<100 and IsPrimePowerInt(p) and
+       HasElementaryAbelianFactorGroup(d[i+1],d[u]) then
+       d:=Concatenation(d{[1..i-1]},d{[i+1..Length(d)]});
+       # i stays the same, as it now is the next subgroup
+    else
+      u:=i;
+      i:=i+1;
+    fi;
+  od;
+
   # avoid small central subgroups, as the factor will be hard to represent
   u:=Centre(G);
   if Size(u)>1 then

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -469,6 +469,9 @@ local hom, allinner, gens, c, ran, r, cen, img, dom, u, subs, orbs, cnt,
   bestdeg:=infinity;
   # what degree would we consider immediately acceptable?
   if actbase<>fail then
+    if ForAny(actbase,x->not IsSubset(g,x)) then
+      Error("illegal actbase given!");
+    fi;
     baddegree:=RootInt(Sum(actbase,Size)^2,3);
   else
     baddegree:=RootInt(Size(g)^3,4);
@@ -2242,7 +2245,7 @@ local a,b,c,p;
       # the degree looks rather big. Can we do better?
       Info(InfoMorph,2,"test automorphism domain ",p);
       c:=GroupByGenerators(GeneratorsOfGroup(a.aut),One(a.aut));
-      AssignNiceMonomorphismAutomorphismGroup(c,G); 
+      AssignNiceMonomorphismAutomorphismGroup(c,G:autactbase:=fail); 
       if IsPermGroup(Range(NiceMonomorphism(c))) and
 	LargestMovedPoint(Range(NiceMonomorphism(c)))<p then
         Info(InfoMorph,1,"improved domain ",

--- a/tst/teststandard/opers/IsomorphismGroups.tst
+++ b/tst/teststandard/opers/IsomorphismGroups.tst
@@ -4,12 +4,10 @@ gap> START_TEST("IsomorphismGroups.tst");
 gap> SetAssertionLevel(0);;
 
 #
-gap> g:=PerfectGroup(IsPermGroup,15360,1);;
+gap> g:=PerfectGroup(IsPermGroup,7680,1);;
 gap> h:=g^(1,2);;
-gap> Length(CharacteristicSubgroups(g));
-5
-gap> Length(CharacteristicSubgroups(h));
-5
+gap> CharacteristicSubgroups(g);;
+gap> CharacteristicSubgroups(h);;
 gap> IsomorphismGroups(g,h)<>fail;
 true
 


### PR DESCRIPTION
Make sure an `autactbase' is not inherited wrongly. Can happen when using the old automorphism group code within an isomorphism test.

Also prune small steps in elementary abelian series to make example run through in reasonable time. No bugfix file provided, as the full test takes a few minutes.

This does not affect 4.11 or earlier, thus no release note needed.

This fixes #3934


