### PR TITLE
Remove sySetjmp / Syjmp_buf (was Enable _POSIX_C_SOURCE)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -903,24 +903,6 @@ AC_SEARCH_LIBS([cos], [m], [], [
 dnl check for math functions
 AC_CHECK_FUNCS([log2 log10 log1p exp2 expm1 exp10 trunc])
 
-dnl sigsetjmp is a macro on some platforms, cannot use AC_CHECK_FUNCS
-AC_MSG_CHECKING([for sigsetjmp])
-AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM([[#include <setjmp.h>]],
-      [[sigjmp_buf t; sigsetjmp(t, 0)]])],
-  [AC_MSG_RESULT([yes])
-   AC_DEFINE([HAVE_SIGSETJMP], [1], [Define to 1 if you have the `sigsetjmp' function.])],
-  [AC_MSG_RESULT([no])])
-
-dnl _setjmp is a macro on some platforms, cannot use AC_CHECK_FUNCS
-AC_MSG_CHECKING([for _setjmp])
-AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM([[#include <setjmp.h>]],
-      [[sigjmp_buf t; _setjmp(t, 0)]])],
-  [AC_MSG_RESULT([yes])
-   AC_DEFINE([HAVE__SETJMP], [1], [Define to 1 if you have the `_setjmp' function.])],
-  [AC_MSG_RESULT([no])])
-
 dnl pthreads
 AS_IF([test "x$enable_hpcgap" = xyes],[
   AX_PTHREAD

--- a/src/error.c
+++ b/src/error.c
@@ -234,7 +234,7 @@ static Obj FuncCALL_WITH_CATCH(Obj self, Obj func, Obj args)
 
 Obj CALL_WITH_CATCH(Obj func, volatile Obj args)
 {
-    volatile syJmp_buf readJmpError;
+    volatile jmp_buf readJmpError;
     volatile Obj       res;
     volatile Obj       currLVars;
     volatile Obj       tilde;
@@ -250,7 +250,7 @@ Obj CALL_WITH_CATCH(Obj func, volatile Obj args)
 #endif
 
     memcpy((void *)&readJmpError, (void *)&STATE(ReadJmpError),
-           sizeof(syJmp_buf));
+           sizeof(jmp_buf));
     currLVars = STATE(CurrLVars);
 #ifdef GAP_KERNEL_DEBUG
     volatile Stat currStat = BRK_CALL_TO();
@@ -262,7 +262,7 @@ Obj CALL_WITH_CATCH(Obj func, volatile Obj args)
     int      lockSP = RegionLockSP();
     Region * savedRegion = TLS(currentRegion);
 #endif
-    if (sySetjmp(STATE(ReadJmpError))) {
+    if (setjmp(STATE(ReadJmpError))) {
         SET_LEN_PLIST(res, 2);
         SET_ELM_PLIST(res, 1, False);
         SET_ELM_PLIST(res, 2, STATE(ThrownObject));
@@ -300,7 +300,7 @@ Obj CALL_WITH_CATCH(Obj func, volatile Obj args)
             SET_LEN_PLIST(res, 1);
     }
     memcpy((void *)&STATE(ReadJmpError), (void *)&readJmpError,
-           sizeof(syJmp_buf));
+           sizeof(jmp_buf));
     return res;
 }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -130,13 +130,13 @@ UInt ViewObjGVar;
 void ViewObjHandler ( Obj obj )
 {
   volatile Obj        func;
-  syJmp_buf             readJmpError;
+  jmp_buf             readJmpError;
 
   /* get the functions                                                   */
   func = ValAutoGVar(ViewObjGVar);
 
   /* if non-zero use this function, otherwise use `PrintObj'             */
-  memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
+  memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
   TRY_IF_NO_ERROR {
     if ( func != 0 && TNUM_OBJ(func) == T_FUNCTION ) {
       ViewObj(obj);
@@ -146,7 +146,7 @@ void ViewObjHandler ( Obj obj )
     }
     Pr("\n", 0, 0);
   }
-  memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+  memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
 }
 
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -50,7 +50,7 @@ typedef struct GAPState {
     Bag   LVarsPool[16];
 
     /* From read.c */
-    syJmp_buf ReadJmpError;
+    jmp_buf ReadJmpError;
 
     /* From scanner.c */
     UInt   NrError;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1848,7 +1848,7 @@ UInt ResizeBag (
 **  identifiers can exist, and so 'CollectBags' frees these masterpointers.
 */
 
-static syJmp_buf RegsBags;
+static jmp_buf RegsBags;
 
 #if defined(SPARC)
 static void SparcStackFuncBags(void)
@@ -1940,7 +1940,7 @@ static UInt CollectBags_Mark(UInt FullBags)
     }
 
     /* mark from the stack                                                 */
-    sySetjmp( RegsBags );
+    setjmp( RegsBags );
 #if defined(SPARC)
     SparcStackFuncBags();
 #endif

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -1031,12 +1031,12 @@ static Obj FuncSERIALIZE_TO_NATIVE_STRING(Obj self, Obj obj)
 {
     Obj                         result;
     volatile SerializeModuleState state;
-    syJmp_buf                   readJmpError;
+    jmp_buf                   readJmpError;
     SaveSerializationState(&state);
     InitNativeStringSerializer(NEW_STRING(0));
-    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
-    if (sySetjmp(STATE(ReadJmpError))) {
-        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
+    if (setjmp(STATE(ReadJmpError))) {
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
         RestoreSerializationState(&state);
         syLongjmp(&(STATE(ReadJmpError)), 1);
     }
@@ -1044,7 +1044,7 @@ static Obj FuncSERIALIZE_TO_NATIVE_STRING(Obj self, Obj obj)
     while (LEN_PLIST(MODULE_STATE(Serialize).stack) > 0)
         SerializeObj(PopObj());
     result = MODULE_STATE(Serialize).obj;
-    memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
     RestoreSerializationState(&state);
     return result;
 }
@@ -1053,22 +1053,22 @@ static Obj FuncDESERIALIZE_NATIVE_STRING(Obj self, Obj string)
 {
     Obj                         result;
     volatile SerializeModuleState state;
-    syJmp_buf                   readJmpError;
+    jmp_buf                   readJmpError;
 
     SaveSerializationState(&state);
 
     if (!IS_STRING(string))
         ErrorQuit("DESERIALIZE_NATIVE_STRING: argument must be a string", 0,
                   0);
-    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
-    if (sySetjmp(STATE(ReadJmpError))) {
-        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
+    if (setjmp(STATE(ReadJmpError))) {
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
         RestoreSerializationState(&state);
         syLongjmp(&(STATE(ReadJmpError)), 1);
     }
     InitNativeStringDeserializer(string);
     result = DeserializeObj();
-    memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
     RestoreSerializationState(&state);
     return result;
 }

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -371,7 +371,7 @@ static void RunThreadedMain2(int (*mainFunction)(int, char **),
     thread_data[0].state = TSTATE_RUNNING;
     thread_data[0].tls = GetTLS();
     InitSignals();
-    if (sySetjmp(TLS(threadExit)))
+    if (setjmp(TLS(threadExit)))
         exit(0);
     exit((*mainFunction)(argc, argv));
 }

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -454,7 +454,7 @@ static void ThreadedInterpreter(void * funcargs)
     TRY_IF_NO_ERROR
     {
         Obj init, exit;
-        if (sySetjmp(TLS(threadExit)))
+        if (setjmp(TLS(threadExit)))
             return;
         init = GVarOptFunction(&GVarTHREAD_INIT);
         if (init)
@@ -884,21 +884,21 @@ static Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func)
 {
     Region * volatile oldRegion = TLS(currentRegion);
     Region * volatile region = GetRegionOf(obj);
-    syJmp_buf readJmpError;
+    jmp_buf readJmpError;
 
     RequireFunction("WITH_TARGET_REGION", func);
     if (!region || !CheckExclusiveWriteAccess(obj))
         return ArgumentError(
             "WITH_TARGET_REGION: Requires write access to target region");
-    memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
-    if (sySetjmp(STATE(ReadJmpError))) {
-        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
+    if (setjmp(STATE(ReadJmpError))) {
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
         TLS(currentRegion) = oldRegion;
         syLongjmp(&(STATE(ReadJmpError)), 1);
     }
     TLS(currentRegion) = region;
     CALL_0ARGS(func);
-    memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
     TLS(currentRegion) = oldRegion;
     return (Obj)0;
 }

--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -88,7 +88,7 @@ typedef struct ThreadLocalStorage
   UInt PeriodicCheckCount;
 
   /* From read.c */
-  syJmp_buf threadExit;
+  jmp_buf threadExit;
 
   /* From scanner.c */
   Obj DefaultOutput;

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -604,10 +604,10 @@ static void GapRootScanner(int full)
         (*ExtraMarkFuncBags)();
 
     // scan the stack for further object references, and mark them
-    syJmp_buf registers;
-    sySetjmp(registers);
-    TryMarkRange(registers, (char *)registers + sizeof(syJmp_buf));
-    TryMarkRange((char *)registers + sizeof(syJmp_buf), stackend);
+    jmp_buf registers;
+    setjmp(registers);
+    TryMarkRange(registers, (char *)registers + sizeof(jmp_buf));
+    TryMarkRange((char *)registers + sizeof(jmp_buf), stackend);
 
     // mark all global objects
     for (Int i = 0; i < GlobalCount; i++) {

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -461,7 +461,7 @@ Obj GAP_CharWithValue(UChar obj)
     return ObjsChar[obj];
 }
 
-syJmp_buf * GAP_GetReadJmpError(void)
+jmp_buf * GAP_GetReadJmpError(void)
 {
     return &(STATE(ReadJmpError));
 }

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -29,7 +29,7 @@
 #endif
 
 
-extern syJmp_buf * GAP_GetReadJmpError(void);
+extern jmp_buf * GAP_GetReadJmpError(void);
 extern void GAP_EnterDebugMessage_(char * message, char * file, int line);
 extern void GAP_EnterStack_(void *);
 extern void GAP_LeaveStack_(void);
@@ -99,7 +99,7 @@ static inline int GAP_Error_Postjmp_(int JumpRet)
 
 #define GAP_Error_Setjmp()                                                   \
     (GAP_unlikely(GAP_Error_Prejmp_(__FILE__, __LINE__)) ||                  \
-     GAP_Error_Postjmp_(sySetjmp(*GAP_GetReadJmpError())))
+     GAP_Error_Postjmp_(setjmp(*GAP_GetReadJmpError())))
 
 
 // Code which uses the GAP API exposed by this header file should sandwich

--- a/src/read.c
+++ b/src/read.c
@@ -2499,7 +2499,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     volatile ExecStatus          type;
     volatile Obj                 tilde;
     volatile Obj                 errorLVars;
-    syJmp_buf           readJmpError;
+    jmp_buf           readJmpError;
 #ifdef HPCGAP
     int                 lockSP;
 #endif
@@ -2528,7 +2528,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     /* remember the old reader context                                     */
     tilde       = STATE(Tilde);
     errorLVars  = STATE(ErrorLVars);
-    memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
+    memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 
     // initialize everything and begin an interpreter
     rs->StackNams      = NEW_PLIST( T_PLIST, 16 );
@@ -2593,7 +2593,7 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     GAP_ASSERT(rs->LoopNesting == 0);
 
     /* switch back to the old reader context                               */
-    memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+    memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
     STATE(Tilde)       = tilde;
     STATE(ErrorLVars)  = errorLVars;
 
@@ -2615,7 +2615,7 @@ UInt ReadEvalFile(Obj * evalResult)
 {
     volatile ExecStatus type;
     volatile Obj        tilde;
-    syJmp_buf           readJmpError;
+    jmp_buf           readJmpError;
     volatile UInt       nr;
     volatile Obj        nams;
     volatile Int        nloc;
@@ -2643,7 +2643,7 @@ UInt ReadEvalFile(Obj * evalResult)
 #ifdef HPCGAP
     lockSP      = RegionLockSP();
 #endif
-    memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
+    memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 
     // initialize everything and begin an interpreter
     rs->StackNams    = NEW_PLIST( T_PLIST, 16 );
@@ -2694,7 +2694,7 @@ UInt ReadEvalFile(Obj * evalResult)
     }
 
     /* switch back to the old reader context                               */
-    memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+    memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
 #ifdef HPCGAP
     PopRegionLocks(lockSP);
     if (TLS(CurrentHashLock))
@@ -2730,7 +2730,7 @@ void ReadEvalError(void)
 
 struct SavedReaderState {
   UInt                userHasQuit;
-  syJmp_buf           readJmpError;
+  jmp_buf           readJmpError;
   UInt                nrError;
   Bag                 oldLvars;
 };
@@ -2739,7 +2739,7 @@ static void SaveReaderState(struct SavedReaderState *s) {
   s->userHasQuit = STATE(UserHasQuit);
   s->nrError = STATE(NrError);
   s->oldLvars = STATE(CurrLVars);
-  memcpy( s->readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
+  memcpy( s->readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 }
 
 static void ClearReaderState(void ) {
@@ -2750,7 +2750,7 @@ static void ClearReaderState(void ) {
 
 static void RestoreReaderState(const struct SavedReaderState *s) {
   SWITCH_TO_OLD_LVARS(s->oldLvars);
-  memcpy( STATE(ReadJmpError), s->readJmpError, sizeof(syJmp_buf) );
+  memcpy( STATE(ReadJmpError), s->readJmpError, sizeof(jmp_buf) );
   STATE(UserHasQuit) = s->userHasQuit;
   STATE(NrError) = s->nrError;
 }

--- a/src/read.h
+++ b/src/read.h
@@ -49,12 +49,12 @@
 **  correctly, you must backup ReadJmpError before TRY_IF_NO_ERROR, and restore it
 **  in a matching CATCH_ERROR block.
 */
-/* TL: extern syJmp_buf ReadJmpError; */
+/* TL: extern jmp_buf ReadJmpError; */
 
 #define TRY_IF_NO_ERROR \
     if (!STATE(NrError)) { \
         volatile Int recursionDepth = GetRecursionDepth();  \
-        if (sySetjmp(STATE(ReadJmpError))) { \
+        if (setjmp(STATE(ReadJmpError))) { \
             SetRecursionDepth(recursionDepth);  \
             STATE(NrError)++; \
         }\

--- a/src/streams.c
+++ b/src/streams.c
@@ -700,7 +700,7 @@ static Obj FuncPrint(Obj self, Obj args)
 {
     volatile Obj        arg;
     volatile UInt       i;
-    syJmp_buf           readJmpError;
+    jmp_buf           readJmpError;
 
     /* print all the arguments, take care of strings and functions         */
     for ( i = 1;  i <= LEN_PLIST(args);  i++ ) {
@@ -715,17 +715,17 @@ static Obj FuncPrint(Obj self, Obj args)
             PrintFunction( arg );
         }
         else {
-            memcpy( readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf) );
+            memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 
             /* if an error occurs stop printing                            */
             TRY_IF_NO_ERROR {
                 PrintObj( arg );
             }
             CATCH_ERROR {
-                memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+                memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
                 ReadEvalError();
             }
-            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
         }
     }
 
@@ -738,7 +738,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
     volatile Obj        arg;
     volatile Obj        destination;
     volatile UInt       i;
-    syJmp_buf           readJmpError;
+    jmp_buf           readJmpError;
 
     /* first entry is the file or stream                                   */
     destination = ELM_LIST(args, 1);
@@ -772,7 +772,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
         arg = ELM_LIST(args,i);
 
         /* if an error occurs stop printing                                */
-        memcpy(readJmpError, STATE(ReadJmpError), sizeof(syJmp_buf));
+        memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
         TRY_IF_NO_ERROR
         {
             if (IS_PLIST(arg) && 0 < LEN_PLIST(arg) && IsStringConv(arg)) {
@@ -791,10 +791,10 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
         CATCH_ERROR
         {
             CloseOutput();
-            memcpy( STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf) );
+            memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
             ReadEvalError();
         }
-        memcpy(STATE(ReadJmpError), readJmpError, sizeof(syJmp_buf));
+        memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
     }
 
     /* close the output file again, and return nothing                     */

--- a/src/sysjmp.c
+++ b/src/sysjmp.c
@@ -43,10 +43,10 @@ Int RegisterSyLongjmpObserver(voidfunc func)
     return 0;
 }
 
-void syLongjmp(syJmp_buf * buf, int val)
+void syLongjmp(jmp_buf * buf, int val)
 {
     Int i;
     for (i = 0; i < signalSyLongjmpFuncsLen && signalSyLongjmpFuncs[i]; ++i)
         (signalSyLongjmpFuncs[i])();
-    syLongjmpInternal(*buf, val);
+    longjmp(*buf, val);
 }

--- a/src/sysjmp.h
+++ b/src/sysjmp.h
@@ -18,27 +18,13 @@
 
 /****************************************************************************
 **
-*F  sySetjmp( <jump buffer> )
 *F  syLongjmp( <jump buffer>, <value> )
 **
-**  macros and functions, defining our selected longjump mechanism
+**  A wrapper around longjmp, so other functions can do work before longjmp
+**  is called
 */
 
-#if defined(HAVE_SIGSETJMP)
-#define sySetjmp(buff) (sigsetjmp((buff), 0))
-#define syLongjmpInternal siglongjmp
-#define syJmp_buf sigjmp_buf
-#elif defined(HAVE__SETJMP)
-#define sySetjmp _setjmp
-#define syLongjmpInternal _longjmp
-#define syJmp_buf jmp_buf
-#else
-#define sySetjmp setjmp
-#define syLongjmpInternal longjmp
-#define syJmp_buf jmp_buf
-#endif
-
-void syLongjmp(syJmp_buf * buf, int val) NORETURN;
+void syLongjmp(jmp_buf * buf, int val) NORETURN;
 
 /****************************************************************************
 **


### PR DESCRIPTION
This is required to build NormalizInterface on Cygwin, but could be useful in other situations.

I explictly mentioned the Cygwin case in the comment, just because someone finding this in 5 years might wonder what the heck it is there for. If it annoys people, I could put it in the commit message instead.