### PR TITLE
Cygwin improvements for new release scripts

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -517,13 +517,20 @@ end );
 ##  <Func Name="ARCH_IS_WINDOWS" Arg=''/>
 ##
 ##  <Description>
-##  tests whether &GAP; is running on a Windows system in Cygwin.
+##  tests whether &GAP; is running on a Windows system without
+##  standard POSIX tools available (such as a shell).
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL("ARCH_IS_WINDOWS",function()
-  return POSITION_SUBSTRING (GAPInfo.Architecture, "cygwin", 0) <> fail;
+  # Exit early is we are not in Cygwin
+  if POSITION_SUBSTRING (GAPInfo.Architecture, "cygwin", 0) = fail then
+    return false;
+  fi;
+  # Check if programs we need exist in their standard Cygwin locations
+  return not IsExistingFile("/usr/bin/sh") or
+         not IsExistingFile("/usr/bin/xdg-open");
 end);
 
 #############################################################################

--- a/src/streams.c
+++ b/src/streams.c
@@ -976,12 +976,17 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 */
 static Obj FuncTmpName(Obj self)
 {
+    char name[100] = "/tmp/gaptempfile.XXXXXX";
 #ifdef SYS_IS_CYGWIN32
-    char name[] = "C:/WINDOWS/Temp/gaptempfile.XXXXXX";
-#else
-    char name[] = "/tmp/gaptempfile.XXXXXX";
+    // If /tmp is missing, write into Window's temp directory
+    DIR* dir = opendir("/tmp");
+    if(dir) {
+        closedir(dir);
+    }
+    else {
+        strcpy(name, "C:/WINDOWS/Temp/gaptempfile.XXXXXX");
+    }
 #endif
-
     int fd = mkstemp(name);
     if (fd < 0)
         return Fail;
@@ -996,14 +1001,22 @@ static Obj FuncTmpName(Obj self)
 */
 static Obj FuncTmpDirectory(Obj self)
 {
-    Obj name;
+    Obj name = 0;
     char * env_tmpdir = getenv("TMPDIR");
     if (env_tmpdir != NULL) {
         name = MakeString(env_tmpdir);
     }
     else {
 #ifdef SYS_IS_CYGWIN32
-        name = MakeString("C:/WINDOWS/Temp/");
+        // If /tmp is missing, write into Window's temp directory
+        DIR* dir = opendir("/tmp");
+        if(dir) {
+            closedir(dir);
+            name = MakeString("/tmp");
+        }
+        else {
+            name = MakeString("C:/WINDOWS/Temp/");
+        }
 #else
         name = MakeString("/tmp");
 #endif


### PR DESCRIPTION
This improves the Cygwin release in a few ways. ~~This should only be merged once we have decided we are definitely moving to my new Windows release, because this breaks the current release.~~

The improvements are:

~~1) Use 'cygstart' to open webpages. This deals with unix vs windows filenames. It doesn't let us handle anchors, but after some googling this appears impossible in windows, as `#` can appear in filenames.~~

~~2) always use `sh` to spawn external programs (`sh` can still run windows programs)~~

3) Don't try to hard-wire the temp directory (and on many computers the guess is wrong). Instead we reconfigure cygwin to tell it to bind `/tmp` to the correct temp directory (this is done by the installer).