### PR TITLE
Fix error checking in PartialPerm

### DIFF
--- a/lib/pperm.gi
+++ b/lib/pperm.gi
@@ -518,8 +518,8 @@ function(arg)
                     "duplicate-free,");
     fi;
   elif Length(arg) = 2 then
-    if IsSSortedList(arg[1]) and ForAll(arg[1], IsSmallIntRep)
-        and IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsSmallIntRep)
+    if IsSSortedList(arg[1]) and ForAll(arg[1], IsPosInt and IsSmallIntRep)
+        and IsDuplicateFreeList(arg[2]) and ForAll(arg[2], IsPosInt and IsSmallIntRep)
         and Length(arg[1]) = Length(arg[2]) then
       return SparsePartialPermNC(arg[1], arg[2]);
     else

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -3333,8 +3333,40 @@ gap> MultiplicativeZeroOp(x);
 gap> MultiplicativeZero(x);
 <empty partial perm>
 
-# Test PartialPerm (for sparse incorrect arg)
+# Test PartialPerm
 gap> PartialPerm([1,2,8],[3,4,1,2]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([0,1],[2,3]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([2,3],[0,1]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([-2,-3],[5,6]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([5,6],[-2,-3]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([5,2^100], [5,6]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([5,6],[5,2^100]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([5,5],[5,6]);
+Error, usage: the 1st argument must be a set of positive integers and the 2nd \
+argument must be a duplicate-free list of positive integers of equal length to\
+ the first
+gap> PartialPerm([5,6],[5,5]);
 Error, usage: the 1st argument must be a set of positive integers and the 2nd \
 argument must be a duplicate-free list of positive integers of equal length to\
  the first


### PR DESCRIPTION
Fixes #3943 , corruption caused by invalid inputs (numbers < 1) to PartialPerm