### PR TITLE
Use travis-ci caching for package file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 dist: xenial
 language: c
 
+# Store downloaded package archives in ~/.gap-package-cache
+cache:
+  directories:
+    $HOME/.gap-package-cache
+
 env:
   global:
     - CFLAGS="--coverage -O2 -g"

--- a/etc/ci-download.sh
+++ b/etc/ci-download.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# This script expects a single argument, which should be an URL pointing to a
+# file for download; it then tries to download that file, into a local file
+# with the same name as the remote file.
+# If a file of the same name exists in ~/.gap-package-cache, then this file
+# is used if it has the same hash
+set -e
+
+PACKAGEDIR=~/.gap-package-cache
+
+# Get the name of the file we are downloading (everything after the final /)
+name=${*##*/}
+
+# Check if file already exists and has right hash
+if [ -f ${PACKAGEDIR}/"${name}" ] ; then
+    command -v sha256sum > /dev/null 2>&1 &&
+    {
+        hash1=$(curl --retry 5 --retry-delay 5 --max-time 10 -L "$*.sha256")
+        hash2=$(sha256sum ${PACKAGEDIR}/"${name}" | cut -d' ' -f1)
+        if [ "x$hash1" == "x$hash2" ] ; then
+            echo "Getting file from cache"
+            cp ${PACKAGEDIR}/"${name}" .
+            exit 0
+        fi
+    }
+fi
+
+if curl -L --retry 5 --retry-delay 5 --max-time 120 -O "$*" ; then
+    if [ -d ${PACKAGEDIR} ]; then
+        cp "${name}" ${PACKAGEDIR}
+    fi
+    exit 0
+fi
+exit 1

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -44,9 +44,8 @@ fi
 time "$SRCDIR/configure" --enable-Werror $CONFIGFLAGS
 time make V=1 -j4
 
-# download packages; instruct curl to retry several times if the
-# connection is refused, to work around intermittent failures
-DOWNLOAD="curl -L --retry 5 --retry-delay 5 --max-time 120 -O"
+# Use alternative downloader which retries on failure and uses the Travis cache
+DOWNLOAD="$SRCDIR/etc/ci-download.sh"
 if [[ $(uname) == Darwin ]]
 then
     # Travis OSX builders seem to have very small download bandwidth,

--- a/etc/download.sh
+++ b/etc/download.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 #
 # This script expects a single argument, which should be an URL pointing to a
 # file for download; it then tries to download that file, into a local file


### PR DESCRIPTION
This adds caching of the results of bootstrap-pkg-*, to (hopefully) reduce the number of failures we see.

I also added a timeout of 10 minutes, to try to deal with very slow downloads timing out.