### PR TITLE
Silence `gcc -fsanitize=undefined` warnings

### DIFF
--- a/src/opers.c
+++ b/src/opers.c
@@ -1831,8 +1831,8 @@ static ALWAYS_INLINE Obj DoOperationNArgs(Obj  oper,
                  Obj  arg5,
                  Obj  arg6)
 {
-    Obj types[n];
-    Obj ids[n];
+    Obj types[n > 0 ? n : 1];
+    Obj ids[n > 0 ? n : 1];
     Int prec;
     Obj method;
     Obj res;
@@ -1916,7 +1916,7 @@ static ALWAYS_INLINE Obj DoOperationNArgs(Obj  oper,
         /* If there was no method found, then pass the information needed
            for the error reporting. This function rarely returns */
         if (method == Fail) {
-            Obj args[n];
+            Obj args[n > 0 ? n : 1];
             /* It is intentional that each case in this case statement except
                0 drops through */
             switch (n) {


### PR DESCRIPTION
Reported by Bill Allombert on the GAP mailing list: Variable length arrays with length 0 are not permitted by the C standard. Change `DoOperationNArgs` to avoid them.

Note however that these VLAs are never accessed if n=0, so no problem in
practice should exist. Except that of course C compilers increasingly abuse
undefined behavior to mean "do whatever you want to look good on benchmarks,
e.g. produce NOPs or format the hard drive". So best to avoid this.
