### PR TITLE
kernel: fix two warnings reported by clang 10

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1895,10 +1895,11 @@ static void GenStackFuncBags(void)
         }
     }
 
-    /* mark from registers, dirty dirty hack                               */
-    for ( p = (Bag*)((void*)RegsBags);
-          p < (Bag*)((void*)RegsBags)+sizeof(RegsBags)/sizeof(Bag);
-          p++ )
+    // mark from registers, dirty dirty hack: we treat the jmp_buf as a
+    // sequence of Bag values. Note that sizeof(jmp_buf) need not be a
+    // multiple of sizeof(Bag), hence the end condition looks slightly.
+    // unusual.
+    for (p = (Bag *)RegsBags; p + 1 <= (Bag *)(RegsBags + 1); p++)
         MarkBag( *p );
 
 #ifdef DEBUG_GASMAN_MARKING

--- a/src/plist.c
+++ b/src/plist.c
@@ -3657,7 +3657,7 @@ static Int InitKernel (
       MakeImmutableObjFuncs[ t1 ] = MakeImmutablePlistNoMutElms;
 
     /* mutable tables may have mutable rows */
-      MakeImmutableObjFuncs[T_PLIST_TAB] = MakeImmutablePlistInHom;
+    MakeImmutableObjFuncs[T_PLIST_TAB] = MakeImmutablePlistInHom;
 
 #ifdef HPCGAP
     for ( t1 = T_PLIST; t1 <= LAST_PLIST_TNUM; t1 += 2 ) {


### PR DESCRIPTION
For the record, the one in gasman.c was:
```
src/gasman.c:1900:55: error: expression does not compute the number
      of elements in this array; element type is 'int', not 'Bag'
      (aka 'unsigned long **') [-Werror,-Wsizeof-array-div]
          p < (Bag*)((void*)RegsBags)+sizeof(RegsBags)/sizeof(Bag);
                                             ~~~~~~~~ ^
```
But that code simply wants to skip to the end of RegsBag, which we can do in a
much simper fashion
