### PR TITLE
BuildPackages.sh: run prerequisites.sh if present

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -160,11 +160,11 @@ build_fail() {
 run_configure_and_make() {
   # We want to know if this is an autoconf configure script
   # or not, without actually executing it!
-  if [[ -f autogen.sh && ! -f configure ]]
+  if [[ -x autogen.sh && ! -x configure ]]
   then
     ./autogen.sh
   fi
-  if [[ -f "configure" ]]
+  if [[ -x configure ]]
   then
     if grep Autoconf ./configure > /dev/null
     then
@@ -197,6 +197,10 @@ build_one_package() {
   (  # start subshell
   set -e
   cd "$CURDIR/$PKG"
+  if [[ -x prerequisites.sh ]]
+  then
+    ./prerequisites.sh
+  fi
   case "$PKG" in
     # All but the last lines should end by '&&', otherwise (for some reason)
     # some packages that fail to build will not get reported in the logs.


### PR DESCRIPTION
This script is used by Semigroups. While it doesn't do anything for
released versions of the package (as far as I can tell), it seems
sensible to run it here. This way then, we can e.g. simplify some
of the code used in gap-infra.

Also check that autogen.sh resp. configure are executable,
not just merely files.
