### PR TITLE
Travis: add a timeout to curl downloads

### DIFF
--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -46,7 +46,7 @@ time make V=1 -j4
 
 # download packages; instruct curl to retry several times if the
 # connection is refused, to work around intermittent failures
-DOWNLOAD="curl -L --retry 5 --retry-delay 5 -O"
+DOWNLOAD="curl -L --retry 5 --retry-delay 5 --max-time 120 -O"
 if [[ $(uname) == Darwin ]]
 then
     # Travis OSX builders seem to have very small download bandwidth,


### PR DESCRIPTION
Normally Travis downloads the bootstraps in under 20 seconds; we give it 2 minutes before we retry

This should hopefully help with all those runaway Travis jobs that timeout after 50 minutes because curl is stuck. With this PR, ideally builds should complete (because I expect that if a slow download is retried, it becomes fast). At worst, we'll get a timeout after ~12 minutes ((5+1) times 2 minutes), so the Travis job will end quicker.

Note that PR #3947 also does something similar, but also does a lot more; I hope that this PR is uncontroversial and can be merged soon.