### PR TITLE
CI: update to gcovr 4.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@ build_script:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
   - SET "PATH=%CYG_ROOT%\bin;%PATH%"
-  - python -m pip install gcovr==4.1 # for coverage reporting later on
+  - python -m pip install gcovr==4.2 # for coverage reporting later on
   - bash -lc "gcc --version"
   - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./etc/ci-prepare.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ matrix:
 # and also to work around timeouts (see https://travis-ci.community/t/7659)
 script:
   - etc/travis_fastfail.sh || travis_terminate $?
-  - python -m pip install --user gcovr==4.1 || travis_terminate $?
+  - python -m pip install --user gcovr==4.2 || travis_terminate $?
   - bash etc/ci-prepare.sh || travis_terminate $?
   - bash etc/ci.sh || travis_terminate $?
 

--- a/etc/ci-gcovr-coverage.py
+++ b/etc/ci-gcovr-coverage.py
@@ -32,29 +32,39 @@
 # generator. I will try to get some changes pushed upstream
 #
 
-import locale
 import os
 import re
 import sys
-import json
-import mmap
-import hashlib
+import io
+import json  # added for GAP
+import mmap  # added for GAP
+import hashlib  # added for GAP
 
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import ArgumentParser
 from os.path import normpath
-from multiprocessing import cpu_count
 from tempfile import mkdtemp
 from shutil import rmtree
 
-from gcovr.gcov import get_datafiles, process_existing_gcov_file, process_datafile
-from gcovr.utils import (get_global_stats, build_filter, AlwaysMatchFilter,
+from gcovr.configuration import (
+    argument_parser_setup, merge_options_and_set_defaults,
+    parse_config_file, parse_config_into_dict, OutputOrDefault)
+from gcovr.gcov import (find_existing_gcov_files, find_datafiles,
+                   process_existing_gcov_file, process_datafile)
+from gcovr.json_generator import (gcovr_json_files_to_coverage)
+from gcovr.utils import (get_global_stats, AlwaysMatchFilter,
                     DirectoryPrefixFilter, Logger)
 from gcovr.version import __version__
 from gcovr.workers import Workers
-from gcovr.coverage import CoverageData
 
 # generators
+# from .cobertura_xml_generator import print_xml_report
+# from .html_generator import print_html_report
+# from .txt_generator import print_text_report
+# from .summary_generator import print_summary
+# from .sonarqube_generator import print_sonarqube_report
+# from .json_generator import print_json_report
 
+# BEGIN GAP MOD
 # count the number of lines in a file
 def mapcount(filename):
     f = open(filename, "r+")
@@ -83,8 +93,11 @@ def write_coveralls_json(covdata, options):
         nlines = mapcount(file)
         coverage = [ None ] * nlines
 
-        for line in data.all_lines:
-            hits = data.covered.get(line, 0)
+        for line in sorted(data.lines):
+            line_cov = data.lines[line]
+            if not line_cov.is_covered and not line_cov.is_uncovered:
+                continue
+            hits = line_cov.count
             if line - 1 < len(coverage):
                 coverage[line-1] = hits 
             else:
@@ -113,6 +126,7 @@ def write_coveralls_json(covdata, options):
     if options.output:
         output.close()
 
+# END GAP MOD
 
 #
 # Exits with status 2 if below threshold
@@ -133,18 +147,6 @@ def fail_under(covdata, threshold_line, threshold_branch):
         sys.exit(4)
 
 
-# helper for percentage actions
-def check_percentage(value):
-    try:
-        x = float(value)
-        if not (0.0 <= x <= 100.0):
-            raise ValueError()
-    except ValueError:
-        raise ArgumentTypeError(
-            "{value} not in range [0.0, 100.0]".format(value=value))
-    return x
-
-
 def create_argument_parser():
     """Create the argument parser."""
 
@@ -154,13 +156,6 @@ def create_argument_parser():
         "A utility to run gcov and summarize the coverage in simple reports."
 
     parser.epilog = "See <http://gcovr.com/> for the full manual."
-
-    # Style guide for option help messages:
-    # - Prefer complete sentences.
-    # - Phrase first sentence as a command:
-    #   “Print report”, not “Prints report”.
-    # - Must be readable on the command line,
-    #   AND parse as reStructured Text.
 
     options = parser.add_argument_group('Options')
     options.add_argument(
@@ -175,326 +170,9 @@ def create_argument_parser():
         dest="version",
         default=False
     )
-    options.add_argument(
-        "-v", "--verbose",
-        help="Print progress messages. "
-             "Please include this output in bug reports.",
-        action="store_true",
-        dest="verbose",
-        default=False
-    )
-    options.add_argument(
-        "-r", "--root",
-        help="The root directory of your source files. "
-             "Defaults to '%(default)s', the current directory. "
-             "File names are reported relative to this root. "
-             "The --root is the default --filter.",
-        action="store",
-        dest="root",
-        default='.'
-    )
-    options.add_argument(
-        'search_paths',
-        help="Search these directories for coverage files. "
-             "Defaults to --root and --object-directory.",
-        nargs='*',
-    )
-    options.add_argument(
-        "--fail-under-line",
-        type=check_percentage,
-        metavar="MIN",
-        help="Exit with a status of 2 "
-             "if the total line coverage is less than MIN. "
-             "Can be ORed with exit status of '--fail-under-branch' option.",
-        action="store",
-        dest="fail_under_line",
-        default=0.0
-    )
-    options.add_argument(
-        "--fail-under-branch",
-        type=check_percentage,
-        metavar="MIN",
-        help="Exit with a status of 4 "
-             "if the total branch coverage is less than MIN. "
-             "Can be ORed with exit status of '--fail-under-line' option.",
-        action="store",
-        dest="fail_under_branch",
-        default=0.0
-    )
-    options.add_argument(
-        '--source-encoding',
-        help="Select the source file encoding. "
-             "Defaults to the system default encoding (%(default)s).",
-        action='store',
-        dest='source_encoding',
-        default=locale.getpreferredencoding()
-    )
 
-    output_options = parser.add_argument_group(
-        "Output Options",
-        description="Gcovr prints a text report by default, "
-                    "but can switch to XML or HTML."
-    )
-    output_options.add_argument(
-        "-o", "--output",
-        help="Print output to this filename. Defaults to stdout. "
-             "Required for --html-details.",
-        action="store",
-        dest="output",
-        default=None
-    )
-    output_options.add_argument(
-        "-b", "--branches",
-        help="Report the branch coverage instead of the line coverage. "
-             "For text report only.",
-        action="store_true",
-        dest="show_branch",
-        default=None
-    )
-    output_options.add_argument(
-        "-u", "--sort-uncovered",
-        help="Sort entries by increasing number of uncovered lines. "
-             "For text and HTML report.",
-        action="store_true",
-        dest="sort_uncovered",
-        default=None
-    )
-    output_options.add_argument(
-        "-p", "--sort-percentage",
-        help="Sort entries by increasing percentage of uncovered lines. "
-             "For text and HTML report.",
-        action="store_true",
-        dest="sort_percent",
-        default=None
-    )
-    output_options.add_argument(
-        "-x", "--xml",
-        help="Generate a Cobertura XML report.",
-        action="store_true",
-        dest="xml",
-        default=False
-    )
-    output_options.add_argument(
-        "--xml-pretty",
-        help="Pretty-print the XML report. Implies --xml. Default: %(default)s.",
-        action="store_true",
-        dest="prettyxml",
-        default=False
-    )
-    output_options.add_argument(
-        "--html",
-        help="Generate a HTML report.",
-        action="store_true",
-        dest="html",
-        default=False
-    )
-    output_options.add_argument(
-        "--html-details",
-        help="Add annotated source code reports to the HTML report. "
-             "Requires --output as a basename for the reports. "
-             "Implies --html.",
-        action="store_true",
-        dest="html_details",
-        default=False
-    )
-    output_options.add_argument(
-        "--html-title",
-        metavar="TITLE",
-        help="Use TITLE as title for the HTML report. Default is %(default)s.",
-        action="store",
-        dest="html_title",
-        default="Head"
-    )
-    options.add_argument(
-        "--html-medium-threshold",
-        type=check_percentage,
-        metavar="MEDIUM",
-        help="If the coverage is below MEDIUM, the value is marked "
-             "as low coverage in the HTML report. "
-             "MEDIUM has to be lower than or equal to value of --html-high-threshold. "
-             "If MEDIUM is equal to value of --html-high-threshold the report has "
-             "only high and low coverage. Default is %(default)s.",
-        action="store",
-        dest="html_medium_threshold",
-        default=75.0
-    )
-    options.add_argument(
-        "--html-high-threshold",
-        type=check_percentage,
-        metavar="HIGH",
-        help="If the coverage is below HIGH, the value is marked "
-             "as medium coverage in the HTML report. "
-             "HIGH has to be greater than or equal to value of --html-medium-threshold. "
-             "If HIGH is equal to value of --html-medium-threshold the report has "
-             "only high and low coverage. Default is %(default)s.",
-        action="store",
-        dest="html_high_threshold",
-        default=90.0
-    )
-    output_options.add_argument(
-        "--html-absolute-paths",
-        help="Use absolute paths to link the --html-details reports. "
-             "Defaults to relative links.",
-        action="store_false",
-        dest="relative_anchors",
-        default=True
-    )
-    output_options.add_argument(
-        '--html-encoding',
-        help="Override the declared HTML report encoding. "
-             "Defaults to %(default)s. "
-             "See also --source-encoding.",
-        action='store',
-        dest='html_encoding',
-        default='UTF-8'
-    )
-    output_options.add_argument(
-        "-s", "--print-summary",
-        help="Print a small report to stdout "
-             "with line & branch percentage coverage. "
-             "This is in addition to other reports. "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="print_summary",
-        default=False
-    )
+    argument_parser_setup(parser, options)
 
-    filter_options = parser.add_argument_group(
-        "Filter Options",
-        description="Filters decide which files are included in the report. "
-                    "Any filter must match, and no exclude filter must match. "
-                    "A filter is a regular expression that matches a path. "
-                    "Filter paths use forward slashes, even on Windows."
-    )
-    filter_options.add_argument(
-        "-f", "--filter",
-        help="Keep only source files that match this filter. "
-             "Can be specified multiple times. "
-             "If no filters are provided, defaults to --root.",
-        action="append",
-        dest="filter",
-        default=[]
-    )
-    filter_options.add_argument(
-        "-e", "--exclude",
-        help="Exclude source files that match this filter. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="exclude",
-        default=[]
-    )
-    filter_options.add_argument(
-        "--gcov-filter",
-        help="Keep only gcov data files that match this filter. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="gcov_filter",
-        default=[]
-    )
-    filter_options.add_argument(
-        "--gcov-exclude",
-        help="Exclude gcov data files that match this filter. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="gcov_exclude",
-        default=[]
-    )
-    filter_options.add_argument(
-        "--exclude-directories",
-        help="Exclude directories that match this regex "
-             "while searching raw coverage files. "
-             "Can be specified multiple times.",
-        action="append",
-        dest="exclude_dirs",
-        default=[]
-    )
-
-    gcov_options = parser.add_argument_group(
-        "GCOV Options",
-        "The 'gcov' tool turns raw coverage files (.gcda and .gcno) "
-        "into .gcov files that are then processed by gcovr. "
-        "The gcno files are generated by the compiler. "
-        "The gcda files are generated when the instrumented program is executed."
-    )
-    gcov_options.add_argument(
-        "--gcov-executable",
-        help="Use a particular gcov executable. "
-             "Must match the compiler you are using, "
-             "e.g. 'llvm-cov gcov' for Clang. "
-             "Can include additional arguments. "
-             "Defaults to the GCOV environment variable, "
-             "or 'gcov': '%(default)s'.",
-        action="store",
-        dest="gcov_cmd",
-        default=os.environ.get('GCOV', 'gcov')
-    )
-    gcov_options.add_argument(
-        "--exclude-unreachable-branches",
-        help="Exclude branch coverage with LCOV/GCOV exclude markers. "
-             "Additionally, exclude branch coverage from lines "
-             "without useful source code "
-             "(often, compiler-generated \"dead\" code). "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="exclude_unreachable_branches",
-        default=False
-    )
-    gcov_options.add_argument(
-        "-g", "--use-gcov-files",
-        help="Use existing gcov files for analysis. Default: %(default)s.",
-        action="store_true",
-        dest="gcov_files",
-        default=False
-    )
-    gcov_options.add_argument(
-        '--gcov-ignore-parse-errors',
-        help="Skip lines with parse errors in GCOV files "
-             "instead of exiting with an error. "
-             "A report will be shown on stderr. "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="gcov_ignore_parse_errors",
-        default=False
-    )
-    gcov_options.add_argument(
-        '--object-directory',
-        help="Override normal working directory detection. "
-             "Gcovr needs to identify the path between gcda files "
-             "and the directory where the compiler was originally run. "
-             "Normally, gcovr can guess correctly. "
-             "This option specifies either "
-             "the path from gcc to the gcda file (i.e. gcc's '-o' option), "
-             "or the path from the gcda file to gcc's working directory.",
-        action="store",
-        dest="objdir",
-        default=None
-    )
-    gcov_options.add_argument(
-        "-k", "--keep",
-        help="Keep gcov files after processing. "
-             "This applies both to files that were generated by gcovr, "
-             "or were supplied via the --use-gcov-files option. "
-             "Default: %(default)s.",
-        action="store_true",
-        dest="keep",
-        default=False
-    )
-    gcov_options.add_argument(
-        "-d", "--delete",
-        help="Delete gcda files after processing. Default: %(default)s.",
-        action="store_true",
-        dest="delete",
-        default=False
-    )
-    gcov_options.add_argument(
-        "-j",
-        help="Set the number of threads to use in parallel.",
-        nargs="?",
-        const=cpu_count(),
-        type=int,
-        dest="gcov_parallel",
-        default=1
-    )
     return parser
 
 
@@ -506,13 +184,47 @@ COPYRIGHT = (
 )
 
 
+def find_config_name(partial_options):
+    cfg_name = getattr(partial_options, 'config', None)
+    if cfg_name is not None:
+        return cfg_name
+
+    root = getattr(partial_options, 'root', '')
+    if root:
+        cfg_name = os.path.join(root, 'gcovr.cfg')
+    else:
+        cfg_name = 'gcovr.cfg'
+
+    if os.path.isfile(cfg_name):
+        return cfg_name
+
+    return None
+
+
+class Options(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
 def main(args=None):
     parser = create_argument_parser()
-    options = parser.parse_args(args=args)
+    cli_options = parser.parse_args(args=args)
+
+    # load the config
+    cfg_name = find_config_name(cli_options)
+    cfg_options = {}
+    if cfg_name is not None:
+        with io.open(cfg_name, encoding='UTF-8') as cfg_file:
+            cfg_options = parse_config_into_dict(
+                parse_config_file(cfg_file, filename=cfg_name))
+
+    options_dict = merge_options_and_set_defaults(
+        [cfg_options, cli_options.__dict__])
+    options = Options(**options_dict)
 
     logger = Logger(options.verbose)
 
-    if options.version:
+    if cli_options.version:
         logger.msg(
             "gcovr {version}\n"
             "\n"
@@ -572,17 +284,16 @@ def main(args=None):
 
     if options.exclude_dirs is not None:
         options.exclude_dirs = [
-            build_filter(logger, f) for f in options.exclude_dirs]
+            f.build_filter(logger) for f in options.exclude_dirs]
 
-    options.exclude = [build_filter(logger, f) for f in options.exclude]
-    options.filter = [build_filter(logger, f) for f in options.filter]
+    options.exclude = [f.build_filter(logger) for f in options.exclude]
+    options.filter = [f.build_filter(logger) for f in options.filter]
     if not options.filter:
         options.filter = [DirectoryPrefixFilter(options.root_dir)]
 
     options.gcov_exclude = [
-        build_filter(logger, f) for f in options.gcov_exclude]
-    options.gcov_filter = [
-        build_filter(logger, f) for f in options.gcov_filter]
+        f.build_filter(logger) for f in options.gcov_exclude]
+    options.gcov_filter = [f.build_filter(logger) for f in options.gcov_filter]
     if not options.gcov_filter:
         options.gcov_filter = [AlwaysMatchFilter()]
 
@@ -599,13 +310,57 @@ def main(args=None):
         for f in filters:
             logger.verbose_msg('- {}', f)
 
+    covdata = dict()
+    if options.add_tracefile:
+        collect_coverage_from_tracefiles(covdata, options, logger)
+    else:
+        collect_coverage_from_gcov(covdata, options, logger)
+
+    logger.verbose_msg("Gathered coveraged data for {} files", len(covdata))
+
+    # BEGIN GAP MOD
+    logger.verbose_msg("e {} files", len(covdata))
+    write_coveralls_json(covdata, options)
+    # Print reports
+    #print_reports(covdata, options, logger)
+
+    #if options.fail_under_line > 0.0 or options.fail_under_branch > 0.0:
+    #    fail_under(covdata, options.fail_under_line, options.fail_under_branch)
+    # END GAP MOD
+
+
+def collect_coverage_from_tracefiles(covdata, options, logger):
+    datafiles = set()
+
+    for trace_file in options.add_tracefile:
+        if not os.path.exists(normpath(trace_file)):
+            logger.error(
+                "Bad --add-tracefile option.\n"
+                "\tThe specified file does not exist.")
+            sys.exit(1)
+        datafiles.add(trace_file)
+    options.root_dir = os.path.abspath(options.root)
+    gcovr_json_files_to_coverage(datafiles, covdata, options)
+
+
+def collect_coverage_from_gcov(covdata, options, logger):
+    datafiles = set()
+
+    find_files = find_datafiles
+    process_file = process_datafile
+    if options.gcov_files:
+        find_files = find_existing_gcov_files
+        process_file = process_existing_gcov_file
+
     # Get data files
     if not options.search_paths:
         options.search_paths = [options.root]
 
         if options.objdir is not None:
             options.search_paths.append(options.objdir)
-    datafiles = get_datafiles(options.search_paths, options)
+
+    for search_path in options.search_paths:
+        datafiles.update(find_files(search_path, logger, options.exclude_dirs))
 
     # Get coverage data
     with Workers(options.gcov_parallel, lambda: {
@@ -615,32 +370,86 @@ def main(args=None):
                  'options': options}) as pool:
         logger.verbose_msg("Pool started with {} threads", pool.size())
         for file_ in datafiles:
-            if options.gcov_files:
-                pool.add(process_existing_gcov_file, file_)
-            else:
-                pool.add(process_datafile, file_)
+            pool.add(process_file, file_)
         contexts = pool.wait()
 
-    covdata = dict()
     toerase = set()
     for context in contexts:
         for fname, cov in context['covdata'].items():
             if fname not in covdata:
-                covdata[fname] = CoverageData(fname)
-            covdata[fname].update(
-                uncovered=cov.uncovered,
-                uncovered_exceptional=cov.uncovered_exceptional,
-                covered=cov.covered,
-                branches=cov.branches,
-                noncode=cov.noncode)
+                covdata[fname] = cov
+            else:
+                covdata[fname].update(cov)
         toerase.update(context['toerase'])
         rmtree(context['workdir'])
     for filepath in toerase:
         if os.path.exists(filepath):
             os.remove(filepath)
 
-    logger.verbose_msg("Gathered coveraged data for {} files", len(covdata))
-    write_coveralls_json(covdata, options)
 
-main()
+def print_reports(covdata, options, logger):
+    reports_were_written = False
+    default_output = OutputOrDefault(options.output)
 
+    generators = []
+
+    generators.append((
+        lambda: options.xml or options.prettyxml,
+        [options.xml],
+        print_xml_report,
+        lambda: logger.warn(
+            "Cobertura output skipped - "
+            "consider providing an output file with `--xml=OUTPUT`.")))
+
+    generators.append((
+        lambda: options.html or options.html_details,
+        [options.html, options.html_details],
+        print_html_report,
+        lambda: logger.warn(
+            "HTML output skipped - "
+            "consider providing an output file with `--html=OUTPUT`.")))
+
+    generators.append((
+        lambda: options.sonarqube,
+        [options.sonarqube],
+        print_sonarqube_report,
+        lambda: logger.warn(
+            "Sonarqube output skipped - "
+            "consider providing output file with `--sonarqube=OUTPUT`.")))
+
+    generators.append((
+        lambda: options.json or options.prettyjson,
+        [options.json],
+        print_json_report,
+        lambda: logger.warn(
+            "JSON output skipped - "
+            "consider providing output file with `--json=OUTPUT`.")))
+
+    generators.append((
+        lambda: not reports_were_written,
+        [],
+        print_text_report,
+        lambda: None))
+
+    for should_run, output_choices, generator, on_no_output in generators:
+        if should_run():
+            output = OutputOrDefault.choose(output_choices,
+                                            default=default_output)
+            if output is default_output:
+                default_output = None
+            if output is not None:
+                generator(covdata, output.value, options)
+                reports_were_written = True
+            else:
+                on_no_output()
+
+    if default_output is not None and default_output.value is not None:
+        logger.warn("--output={!r} option was provided but not used.",
+                    default_output.value)
+
+    if options.print_summary:
+        print_summary(covdata)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Note that gcovr 4.2 apparently already contains code for generating a JSON
file. So if possible we might be better off replacing our modified copy of the
gcovr main file by a script that runs unpatched gcovr to generate json data,
and then merge that with the data we got from profiling. That should require
less maintenance on the long run.

Alas, for now it was less work to migrate our patches to gcovr 4.2...

Once this works, should be backported to 4.11

Motivated by https://github.com/gap-system/gap/pull/3744