### PR TITLE
BuildPackages.sh: add --with-gap option

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -32,6 +32,7 @@ fi
 
 CURDIR="$(pwd)"
 GAPROOT="$(cd .. && pwd)"
+GAP="$GAPROOT/bin/gap.sh"
 COLORS=yes
 STRICT=no       # exit with non-zero exit code when encountering any failures
 PACKAGES=()
@@ -45,6 +46,9 @@ while [[ "$#" -ge 1 ]]; do
   case "$option" in
     --with-gaproot)   GAPROOT="$1"; shift ;;
     --with-gaproot=*) GAPROOT=${option#--with-gaproot=}; ;;
+
+    --with-gap)       GAP="$1"; shift ;;
+    --with-gap=*)     GAP=${option#--with-gap=}; ;;
 
     --no-color)       COLORS=no ;;
     --color)          COLORS=yes ;;
@@ -168,7 +172,7 @@ run_configure_and_make() {
   then
     if grep Autoconf ./configure > /dev/null
     then
-      local PKG_NAME=$($GAPROOT/gap -q -T -A <<GAPInput
+      local PKG_NAME=$($GAP -q -T -A <<GAPInput
 Read("PackageInfo.g");
 Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput


### PR DESCRIPTION
We call gap to parse PackageInfo.g files. To do so, so far we called
$GAPROOT/gap. But that does not work reliably with out-of-tree builds; instead
$GAPROOT/bin/gap.sh should be called (which we now do by default) But even
that might not be enough for special applications. Hence we added a --with-gap
option to allow users to override this, if they should really need to.

I'd like to backport this to stable-4.11, for use in the GAP-Julia bridge.