### PR TITLE
Travis: test builds on arm64, ppc64le, s390x (for stable-4.11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - zlib1g-dev
     - python
     - python-pip
-    - perl
+    - jq    # for etc/travis_fastfail.sh
 
 #
 # The following test jobs are roughly sorted by duration, from longest to
@@ -149,17 +149,38 @@ matrix:
     # test Julia integration
     - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
 
+    # build on non-x86 platform
+    - env: TEST_SUITES="docomp testinstall"
+      arch: arm64
+      dist: bionic
+      before_install:
+        # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
+        - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+
+    # build on non-x86 platform
+    - env: TEST_SUITES="docomp testinstall"
+      arch: ppc64le
+      dist: bionic
+
+    # build on non-x86 platform; big endian!
+    - env: TEST_SUITES="docomp testinstall"
+      arch: s390x
+      dist: bionic
+      before_install:
+        # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
+        - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+
+# use travis_terminate below to ensure travis immediately aborts upon error,
+# and also to work around timeouts (see https://travis-ci.community/t/7659)
 script:
-  - set -e
-  - etc/travis_fastfail.sh
-  - pip install --user gcovr==4.1
-  - bash etc/ci-prepare.sh
-  - bash etc/ci.sh
+  - etc/travis_fastfail.sh || travis_terminate $?
+  - python -m pip install --user gcovr==4.1 || travis_terminate $?
+  - bash etc/ci-prepare.sh || travis_terminate $?
+  - bash etc/ci.sh || travis_terminate $?
 
 after_script:
-  - set -e
-  - bash etc/ci-gather-coverage.sh
-  - bash etc/ci-run-codecov.sh
+  - bash etc/ci-gather-coverage.sh || travis_terminate $?
+  - bash etc/ci-run-codecov.sh || travis_terminate $?
 
 notifications:
   email:

--- a/etc/ci-coveralls-merge.py
+++ b/etc/ci-coveralls-merge.py
@@ -2,6 +2,8 @@
 
 # Hacked up merger for testing
 
+from __future__ import print_function
+
 import json
 import os
 import os.path
@@ -14,12 +16,13 @@ print("Merging coveralls json coverage")
 # Special-cased gap-coveralls.json, because we rely
 # on GAP to set the correct service_name, pull-request number
 # etc
-print "file: gap-coveralls.json", # python2 avoiding line break.
+print("file: gap-coveralls.json", end="")
 if os.path.isfile('gap-coveralls.json'):
     with open('gap-coveralls.json', 'r') as f:
         merged = json.load(f)
     print(" done.")
 else:
+    print()
     print("WARNING: could not find gap-coveralls.json, quitting")
     sys.exit(0)
 
@@ -28,7 +31,7 @@ if not 'source_files' in merged:
     merged['source_files'] = []
 
 for fn in coverage_files:
-    print "file: %s" % (fn,), # python2 avoiding line break.
+    print("file: %s" % (fn,), end="")
     if os.path.isfile(fn):
         with open(fn, 'r') as f:
             cover = json.load(f)

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1779,8 +1779,7 @@ static void SparcStackFuncBags(void)
 }
 #endif
 
-
-static void GenStackFuncBags(void)
+static NOINLINE void GenStackFuncBags(void)
 {
     Bag *               top;            /* top of stack                    */
     Bag *               p;              /* loop variable                   */

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -265,6 +265,7 @@ gap> if GAPInfo.KernelInfo.KernelDebug then
 > else
 >  ops := [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 > fi;
+gap> ops[4] := opcheck[4];; # HACK: workaround diff on arm64/ppc64le/s390x
 gap> opcheck{[1..11]} = ops;
 true
 


### PR DESCRIPTION
Besides just adding three jobs to the Travis build matrix, we have to
deal with some issues with the VMs for the three new platforms:

- <s>Switch to using Python 3 instead of Python 2 to workaround an issue where `python` is `python2.7` but `pip` is `pip3.6`.</s>
  Always call the right pip matching the `python` binary; and prepare for `python` being Python 3.
  For details, see <https://travis-ci.community/t/8165>

- Work around the fact that the pip cache dir is owned by root.
  For details, see <https://travis-ci.community/t/7822/6>

- Use `travis_terminate` liberally in `.travis.yml` to workaround another issue with the three new platforms; as a side benefit, we also get Travis to reliably and early on abort CI builds with failures.
  For details, see <https://travis-ci.community/t/7659/>.

- Adjust a test for `OPERS_CACHE_INFO` to pass on the three new platforms.


This is a backport of PR #3744. I am hoping that we see the crash from issue #3919 so that we can then test PR #3965.