### PR TITLE
Fix broken references in the reference manual

### DIFF
--- a/doc/ref/function.xml
+++ b/doc/ref/function.xml
@@ -34,10 +34,8 @@ functions.
 
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="Calling a function with a list argument that is interpreted as
-several arguments">
-<Heading>Calling a function with a list argument that is interpreted as
-several arguments</Heading>
+<Section Label="Calling a function with a list argument that is interpreted as several arguments">
+<Heading>Calling a function with a list argument that is interpreted as several arguments</Heading>
 
 <#Include Label="CallFuncList">
 

--- a/doc/ref/pperm.xml
+++ b/doc/ref/pperm.xml
@@ -441,8 +441,7 @@ gap> EmptyPartialPerm();
 
   <ManSection><Heading>RandomPartialPerm</Heading>
     <Func Name="RandomPartialPerm" Arg="n" Label="for a positive integer"/>
-    <Func Name="RandomPartialPerm" Arg="set" Label="for a set of positive
-      integers"/>
+    <Func Name="RandomPartialPerm" Arg="set" Label="for a set of positive integers"/>
     <Func Name="RandomPartialPerm" Arg="dom, img" Label="for domain and image"/>
     <Returns>A random partial permutation.</Returns>
     <Description>
@@ -1013,8 +1012,7 @@ gap> MultiplicativeZero(f);
   in &GAP; into partial permutations. 
   
   <ManSection>
-  <Oper Name="AsPartialPerm" Arg="f, set" Label="for a permutation and a set of
-    positive integers"/>
+  <Oper Name="AsPartialPerm" Arg="f, set" Label="for a permutation and a set of positive integers"/>
   <Meth Name="AsPartialPerm" Arg="f" Label="for a permutation"/>
   <Meth Name="AsPartialPerm" Arg="f, n" Label="for a permutation and a positive integer"/>
   <Returns>A partial permutation.</Returns>
@@ -1165,8 +1163,7 @@ gap> AsPartialPerm(f, [ 2 .. 4 ] );
     
     <Mark><C>LQUO(<A>g</A>, <A>f</A>)</C></Mark>
     <Item>
-      <Index Key="LQUO" Subkey="for a permutation or partial permutation
-        and partial permutation"><C>LQUO</C></Index>
+      <Index Key="LQUO" Subkey="for a permutation or partial permutation and partial permutation"><C>LQUO</C></Index>
       returns <C><A>g</A>^-1*<A>f</A></C>
       when <A>f</A> is a partial permutation and
       <A>g</A> is a permutation or partial permutation. 


### PR DESCRIPTION
This is a patch taken from the Fedora package by @jamesjer; see
https://src.fedoraproject.org/rpms/gap/blob/master/f/gap-ref.patch
