### PR TITLE
Bugfix and test for IsIntegralRing

### DIFF
--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -701,7 +701,7 @@ InstallMethod( IsIntegralRing,
         zero := Zero( R );
         for i  in [1..Length(elms)]  do
             if elms[i] = zero then continue; fi;
-            for k  in [i+1..Length(elms)]  do
+            for k  in [i..Length(elms)]  do
                 if elms[k] = zero then continue; fi;
                 if elms[i] * elms[k] = zero then
                     return false;

--- a/lib/zmodnz.gd
+++ b/lib/zmodnz.gd
@@ -129,13 +129,6 @@ InstallTrueMethod( IsFinite,
 
 #############################################################################
 ##
-#M  IsEuclideanRing( <R> ) . . . . . . . . . . . .  method for full ring Z/nZ
-##
-InstallTrueMethod(IsEuclideanRing, IsZmodnZObjNonprimeCollection and
-    IsWholeFamily and IsRing);
-
-#############################################################################
-##
 #V  Z_MOD_NZ
 ##
 ##  <ManSection>

--- a/tst/testinstall/ring.tst
+++ b/tst/testinstall/ring.tst
@@ -16,6 +16,10 @@ false
 gap> IsIntegralRing( SmallRing(4,3) );
 false
 
+# Zero divisors not on the diagonal
+gap> IsIntegralRing( Integers mod 6 );
+false
+
 # Integral rings
 gap> IsIntegralRing( GF(5) );
 true

--- a/tst/testinstall/ring.tst
+++ b/tst/testinstall/ring.tst
@@ -1,0 +1,30 @@
+gap> START_TEST("ring.tst");
+
+#####################################################################
+#
+# Tests for IsIntegralRing
+#
+# Trivial ring
+gap> IsIntegralRing( SmallRing(1,1) );
+false
+
+# Non-commutative ring
+gap> IsIntegralRing( SmallRing(4,7) );
+false
+
+# Zero divisors on the diagonal
+gap> IsIntegralRing( SmallRing(4,3) );
+false
+
+# Integral rings
+gap> IsIntegralRing( GF(5) );
+true
+gap> IsIntegralRing( Integers );
+true
+gap> IsIntegralRing( Rationals );
+true
+gap> IsIntegralRing( CF(4) );
+true
+
+#
+gap> STOP_TEST( "ring.tst" );


### PR DESCRIPTION
Two bugfixes and test for `IsIntegralRing`

The first one fixes an off-by-one error causing missing the case when zero appears in the diagonal in the multiplication table.

The second one removes true method for `IsEuclideanRing` which was added in commit 0f9c104 and caused `IsIntegralRing` wrongly return `true` e.g. for `Integers mod 6`,
as reported in #3975.

Closes #3975.