### PR TITLE
Fix line breaks in manual.lab files

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2049,9 +2049,9 @@ InstallGlobalFunction( GAPDocManualLabFromSixFile,
     bookname:= LowercaseString( bookname );
     entries:= List( entries,
                      entry -> Concatenation( "\\makelabel{", bookname, ":",
-                                             esctex(entry[1]), "}{",
-                                             SecNumber( entry[3] ), "}{",
-                                             entry[7], "}\n" ) );
+                                       esctex(NormalizedWhitespace(entry[1])), 
+                                       "}{", SecNumber( entry[3] ), "}{",
+                                       entry[7], "}\n" ) );
     # forget entries that contain a character from "\\*+/=" in label,
     # these were never allowed, so no old manual will refer to them
     entries := Filtered(entries, entry ->


### PR DESCRIPTION
Very long section headers could lead to unwanted line breaks in
entries in manual.lab files (only needed by old-style package
documentation to resolve references).

Closes #3969
