### PR TITLE
Use locale variables in accordance with POSIX requirements.

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -381,11 +381,11 @@ CallAndInstallPostRestore( function()
       env := GAPInfo.SystemEnvironment;
     fi;
     enc := fail;
-    if IsBound(env.LC_CTYPE) then
-      enc := env.LC_CTYPE;
-    fi;
-    if enc = fail and IsBound(env.LC_ALL) then
+    if IsBound(env.LC_ALL) then
       enc := env.LC_ALL;
+    fi;
+    if enc = fail and IsBound(env.LC_CTYPE) then
+      enc := env.LC_CTYPE;
     fi;
     if enc = fail and IsBound(env.LANG) then
       enc := env.LANG;


### PR DESCRIPTION
Per the [POSIX spec](https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html), the `LC_ALL` environment variable should override all other locale settings if set. However, in `lib/init.g`, `LC_CTYPE` had priority over `LC_ALL`. This change checks these variables in the proper order.