### PR TITLE
ENHANCE: Rewriting systems for groups

### DIFF
--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1018,7 +1018,8 @@ InstallMethod(ConfluentMonoidPresentationForGroup,"generic",
   [IsGroup and IsFinite],
 function(G)
 local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
-      loff,off,monreps,left,right,fmgens,r,diff,monreal,nums,reduce,hom,dept;
+      loff,off,monreps,left,right,fmgens,r,diff,monreal,nums,reduce,hom,dept,
+      lode;
   IsSimpleGroup(G);
   if IsSymmetricGroup(G) then
     i:=SymmetricGroup(SymmetricDegree(G));
@@ -1077,6 +1078,7 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
     mos:=[];
     off:=Length(mgens);
     dept:=[];
+    lode:=[];
     # go up so we may reduce tails
     for i in [Length(homs),Length(homs)-1..1] do
       Add(dept,off);
@@ -1112,6 +1114,11 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
         k:=m!.rewritingSystem;
       else
         k:=KnuthBendixRewritingSystem(m);
+      fi;
+      if HasLevelsOfGenerators(k!.ordering) then
+        Add(lode,LevelsOfGenerators(k!.ordering));
+      else
+        Add(lode,fail);
       fi;
       MakeConfluent(k);
       # convert rules
@@ -1156,6 +1163,20 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
     dept:=dept+1;
     dept:=List([1..Length(mgens)],
       x->PositionProperty(dept,y->x>=y)-1);
+
+    # are there local levels to keep? First make them fractional additions
+    off:=10^(1+LogInt(Length(dept),10)); # cent level for local depths
+    for i in [1..Maximum(dept)] do
+      if lode[i]<>fail then
+        diff:=Filtered([1..Length(dept)],x->dept[x]=i);
+        dept{diff}:=dept{diff}+lode[i]/off;
+      fi;
+    od;
+    if ForAny(dept,x->not IsInt(x)) then
+      # reintegralize
+      diff:=Set(dept);
+      dept:=List(dept,x->Position(diff,x));
+    fi;
 
     if ForAny(rules,x->x[2]<>reduce(x[2])) then Error("irreduced right");fi;
 

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1032,7 +1032,7 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
     rules:=Rules(k);
     dept:=fail;
   else
-    iso:=IsomorphismFpGroupByChiefSeries(G:rewrite,abelianlimit:=10);
+    iso:=IsomorphismFpGroupByChiefSeries(G:rewrite);
 
     fp:=Range(iso);
     gens:=GeneratorsOfGroup(fp);
@@ -1172,7 +1172,6 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
 
   # finally create 
   m:=FactorFreeMonoidByRelations(fm,rules);
-  mgens:=GeneratorsOfMonoid(m);
   hom:=MakeFpGroupToMonoidHomType1(fp,m);
 
   j:=rec(fphom:=iso,monhom:=hom);
@@ -1181,6 +1180,8 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
   else
     j.ordering:=WreathProductOrdering(fm,dept);
   fi;
+  k:=KnuthBendixRewritingSystem(FamilyObj(One(m)),j.ordering);
+  MakeConfluent(k); # will store in monoid as reducedConfluent
   return j;
 end);
 

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1201,7 +1201,7 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
   else
     j.ordering:=WreathProductOrdering(fm,dept);
   fi;
-  k:=KnuthBendixRewritingSystem(FamilyObj(One(m)),j.ordering);
+  k:=KnuthBendixRewritingSystem(FamilyObj(One(m)),j.ordering:isconfluent);
   MakeConfluent(k); # will store in monoid as reducedConfluent
   return j;
 end);

--- a/lib/kbsemi.gi
+++ b/lib/kbsemi.gi
@@ -122,6 +122,10 @@ local r,kbrws,rwsfam,relations_with_correct_order,CantorList,relwco,
     ordering:=wordord,
     freefam:=freefam));
 
+  if ValueOption("isconfluent")=true then
+    kbrws!.createdconfluent:=true;
+  fi;
+
   if HasLetterRepWordsLessFunc(wordord) then
     kbrws!.tzordering:=LetterRepWordsLessFunc(wordord);
   else
@@ -150,15 +154,24 @@ InstallMethod(ReduceRules,
 function(rws)
   local
         r,      # local copy of the rules
+        ptc,    # do we need to check pairs
         v;      # a rule
 
+  ptc:=not (IsBound(rws!.createdconfluent) and rws!.createdconfluent);
   r := ShallowCopy(rws!.tzrules);
   rws!.tzrules:=[];
-  rws!.pairs2check:=[];
+  if ptc then
+    rws!.pairs2check:=[];
+  else
+    Unbind(rws!.pairs2check);
+  fi;
   rws!.reduced := true;
   for v in r do
     AddRuleReduced(rws, v);
   od;
+  if not ptc then
+    rws!.pairs2check:=[];
+  fi;
 end);
 
 


### PR DESCRIPTION
Improvements in computing confluent RWS for groups.
Properly carry through levels if factor has RWS in wreath ordering.
Avoid unneeded confluence checks.
Small adjustment and data caching as relevant for the hybrid quotient algorithm. 