### PR TITLE
kernel: restrict STATE(In) access to io.c

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -294,7 +294,15 @@ Char PEEK_NEXT_CHAR(void)
 
 Char PEEK_CURR_CHAR(void)
 {
-    return *STATE(In);
+    Char c = *STATE(In);
+
+    // if no character is available then get one
+    if (c == '\0') {
+        STATE(In)--;
+        c = GET_NEXT_CHAR();
+    }
+
+    return c;
 }
 
 void SKIP_TO_END_OF_LINE(void)

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -739,7 +739,7 @@ static Char GetStr(ScannerState * s, Char c)
         SyntaxError(s, "String must not include <newline>");
 
     if (c == '\377') {
-        *STATE(In) = '\0';
+        FlushRestOfInputLine();
         SyntaxError(s, "String must end with \" before end of file");
     }
 
@@ -764,7 +764,7 @@ static void GetPragma(ScannerState * s, Char c)
     s->ValueObj = AppendBufToString(string, buf, i);
 
     if (c == '\377') {
-        *STATE(In) = '\0';
+        FlushRestOfInputLine();
     }
 }
 
@@ -815,7 +815,7 @@ static Char GetTripStr(ScannerState * s, Char c)
     s->ValueObj = AppendBufToString(string, buf, i);
 
     if (c == '\377') {
-        *STATE(In) = '\0';
+        FlushRestOfInputLine();
         SyntaxError(s, "String must end with \"\"\" before end of file");
     }
 
@@ -955,12 +955,6 @@ static UInt NextSymbol(ScannerState * s)
 
     Char c = PEEK_CURR_CHAR();
 
-    // if no character is available then get one
-    if (c == '\0') {
-        STATE(In)--;
-        c = GET_NEXT_CHAR();
-    }
-
     // skip over <spaces>, <tabs>, <newlines> and comments
     while (c == ' ' || c == '\t' || c== '\n' || c== '\r' || c == '\f' || c=='#') {
         if (c == '#') {
@@ -1042,7 +1036,7 @@ static UInt NextSymbol(ScannerState * s)
     case '5': case '6': case '7': case '8': case '9':
                       return GetNumber(s, 0, c);
 
-    case '\377':      symbol = S_EOF;           *STATE(In) = '\0'; break;
+    case '\377':      symbol = S_EOF;  FlushRestOfInputLine(); break;
 
     default:          symbol = S_ILLEGAL;       GET_NEXT_CHAR(); break;
     }


### PR DESCRIPTION
With this, I finally reached my "secret goal" of removing all uses of `STATE` from `scanner.c`. The only remaining uses are inside `SyntaxErrorOrWarning`, to access `STATE(NrError)` and `STATE(NrErrLine)`. I am going to get those eventually, too ;-).

Of course this in turn has its own motivation: Not relying on global state makes it easier to reason about the program logic, and we made great strides in this regard already.
And then there is this pipe dream of mine, where `scanner.c` is completely stand-alone and usable in other projects. Not sure we'll ever quite get there, but we certainly are MUCH closer to that than we used to be a few years ago.