### PR TITLE
Introduce a Pluralize function for strings

### DIFF
--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -688,6 +688,7 @@ gap> HexStringInt(last);
 <#Include Label="Ordinal">
 <#Include Label="EvalString">
 <#Include Label="CrcString">
+<#Include Label="Pluralize">
 
 </Section>
 

--- a/lib/string.gd
+++ b/lib/string.gd
@@ -939,3 +939,68 @@ DeclareGlobalFunction("StringOfMemoryAmount");
 DeclareGlobalFunction("StringFormatted");
 DeclareGlobalFunction("PrintFormatted");
 DeclareGlobalFunction("PrintToFormatted");
+
+
+#############################################################################
+##
+##  <#GAPDoc Label="Pluralize">
+##  <ManSection>
+##  <Func Name="Pluralize" Arg='[count, ]string[, plural]'/>
+##  <Returns>A string</Returns>
+##
+##  <Description>
+##    This function returns an attempt at the appropriate pluralization
+##    of a string (considered as a singular English noun), using several
+##    rules and heuristics of English grammar.
+##    <P/>
+##
+##    The arguments to this function are an optional non-negative
+##    integer <A>count</A> (the number of objects in question),
+##    a non-empty string <A>string</A>
+##    (the singular form of the object in question),
+##    and an optional additional string <A>plural</A>
+##    (the plural form of <A>string</A>).
+##    <P/>
+##
+##    If <A>plural</A> is given, then <C>Pluralize</C> uses it as the
+##    plural form of <A>string</A>, otherwise <C>Pluralize</C>
+##    makes an informed guess at the plural.
+##    <P/>
+##
+##    If <A>count</A> is not given, then <C>Pluralize</C> returns this
+##    plural form of <A>string</A>.
+##    If <A>count</A> is given and has value <M>n \neq 1</M>,
+##    then this string is prepended by "\&gt;n\&lt; ";
+##    else if <A>count</A> has value <M>1</M>, then <C>Pluralize</C>
+##    returns <A>string</A>, prepended by "\&gt;1\&lt; ".
+##    <P/>
+##
+##    Note that <Ref Func="StripLineBreakCharacters" /> can be used to
+##    remove the control characters <C>\&lt;</C> and <C>\&gt;</C> from
+##    the return value.
+##
+##  </Description>
+##  </ManSection>
+##  <Example><![CDATA[
+##  gap> Pluralize( "generator" );
+##  "generators"
+##  gap> Pluralize( 1, "generator" );
+##  "\>1\< generator"
+##  gap> Pluralize( 0, "generator" );
+##  "\>0\< generators"
+##  gap> Pluralize( "man", "men" );
+##  "men"
+##  gap> Pluralize( 1, "man", "men" );
+##  "\>1\< man"
+##  gap> Print( Pluralize( 2, "man", "men" ) );
+##  2 men
+##  gap> Print( Pluralize( 2, "vertex" ) );
+##  2 vertices
+##  gap> Print( Pluralize( 3, "matrix" ) );
+##  3 matrices
+##  gap> Print( Pluralize( 4, "battery" ) );
+##  4 batteries
+##  ]]></Example>
+##  <#/GAPDoc>
+
+DeclareGlobalFunction("Pluralize");

--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1406,3 +1406,86 @@ InstallGlobalFunction(PrintFormatted, function(args...)
     # directed
     Print(CallFuncList(StringFormatted, args));
 end);
+
+InstallGlobalFunction(Pluralize,
+function(args...)
+  local nargs, i, count, include_num, str, len, out;
+
+  #Int and one string
+  #Int and two strings
+  #One string
+  #Two strings
+
+  nargs := Length(args);
+  if nargs >= 1 and IsInt(args[1]) and args[1] >= 0 then
+    i := 2;
+    count := args[1];
+    include_num := true;
+  else
+    i := 1;
+    include_num := false; # if not given, assume pluralization is wanted.
+  fi;
+
+  if not (nargs in [i, i + 1] and
+          IsString(args[i]) and
+          (nargs = i or IsString(args[i + 1]))) then
+    ErrorNoReturn("Usage: Pluralize([<count>, ]<string>[, <plural>])");
+  fi;
+
+  str := args[i];
+  len := Length(str);
+
+  if len = 0 then
+    ErrorNoReturn("the argument <str> must be a non-empty string");
+  elif include_num and count = 1 then # no pluralization needed
+    return Concatenation("\>1\< ", str);
+  elif nargs = i + 1 then  # pluralization given
+    out := args[i + 1];
+  elif len <= 2 then
+    out := Concatenation(str, "s");
+
+  # Guess and return the plural form of <str>.
+  # Inspired by the "Ruby on Rails" inflection rules.
+
+  # Uncountable nouns
+  elif str in ["equipment", "information"] then
+    out := str;
+
+  # Irregular plurals
+  elif str = "axis" then
+    out := "axes";
+  elif str = "child" then
+    out := "children";
+  elif str = "person" then
+    out := "people";
+
+  # Peculiar endings
+  elif EndsWith(str, "ix") or EndsWith(str, "ex") then
+    out := Concatenation(str{[1 .. len - 2]}, "ices");
+  elif EndsWith(str, "x") then
+    out := Concatenation(str, "es");
+  elif EndsWith(str, "tum") or EndsWith(str, "ium") then
+    out := Concatenation(str{[1 .. len - 2]}, "a");
+  elif EndsWith(str, "sis") then
+    out := Concatenation(str{[1 .. len - 3]}, "ses");
+  elif EndsWith(str, "fe") and not EndsWith(str, "ffe") then
+    out := Concatenation(str{[1 .. len - 2]}, "ves");
+  elif EndsWith(str, "lf") or EndsWith(str, "rf") or EndsWith(str, "loaf") then
+    out := Concatenation(str{[1 .. len - 1]}, "ves");
+  elif EndsWith(str, "y") and not str[len - 1] in "aeiouy" then
+    out := Concatenation(str{[1 .. len - 1]}, "ies");
+  elif str{[len - 1, len]} in ["ch", "ss", "sh"] then
+    out := Concatenation(str, "es");
+  elif EndsWith(str, "s") then
+    out := str;
+
+  # Default to appending 's'
+  else
+    out := Concatenation(str, "s");
+  fi;
+
+  if include_num then
+    return Concatenation("\>", String(args[1]), "\< ", out);
+  fi;
+  return out;
+end);

--- a/src/calls.c
+++ b/src/calls.c
@@ -159,7 +159,7 @@ static Obj DoWrap0args(Obj self)
 
 /****************************************************************************
 **
-*F  DoWrap1args( <self>, <arg1> ) . . . . . . . wrap up 1 arguments in a list
+*F  DoWrap1args( <self>, <arg1> ) . . . . . . . wrap up 1 argument in a list
 */
 static Obj DoWrap1args(Obj self, Obj arg1)
 {
@@ -333,7 +333,7 @@ static Obj DoFail0args(Obj self)
 
 /****************************************************************************
 **
-*F  DoFail1args( <self>,<arg1> ) . . .  fail a function call with 1 arguments
+*F  DoFail1args( <self>,<arg1> ) . . .  fail a function call with 1 argument
 */
 static Obj DoFail1args(Obj self, Obj arg1)
 {
@@ -507,7 +507,7 @@ static Obj DoProf0args (
 
 /****************************************************************************
 **
-*F  DoProf1args( <self>, <arg1>)  . . . . profile a function with 1 arguments
+*F  DoProf1args( <self>, <arg1>)  . . . . profile a function with 1 argument
 */
 static Obj DoProf1args (
     Obj                 self,

--- a/src/calls.h
+++ b/src/calls.h
@@ -345,7 +345,7 @@ EXPORT_INLINE Obj CALL_XARGS(Obj f, Obj as)
 /****************************************************************************
 **
 *F  CALL_0ARGS_PROF( <func>, <arg1> ) . . . . .  call a prof func with 0 args
-*F  CALL_1ARGS_PROF( <func>, <arg1>, ... )  . .  call a prof func with 1 args
+*F  CALL_1ARGS_PROF( <func>, <arg1>, ... )  . .  call a prof func with 1 arg
 *F  CALL_2ARGS_PROF( <func>, <arg1>, ... )  . .  call a prof func with 2 args
 *F  CALL_3ARGS_PROF( <func>, <arg1>, ... )  . .  call a prof func with 3 args
 *F  CALL_4ARGS_PROF( <func>, <arg1>, ... )  . .  call a prof func with 4 args

--- a/tst/testinstall/pluralize.tst
+++ b/tst/testinstall/pluralize.tst
@@ -1,0 +1,234 @@
+gap> START_TEST("pluralize.tst");
+
+#
+gap> Pluralize(0);
+Error, Usage: Pluralize([<count>, ]<string>[, <plural>])
+gap> Pluralize(0, fail);
+Error, Usage: Pluralize([<count>, ]<string>[, <plural>])
+gap> Pluralize(0, "");
+Error, the argument <str> must be a non-empty string
+gap> Pluralize(1, "");
+Error, the argument <str> must be a non-empty string
+gap> Pluralize(0, "str", fail);
+Error, Usage: Pluralize([<count>, ]<string>[, <plural>])
+gap> Pluralize(0, "", "str");
+Error, the argument <str> must be a non-empty string
+gap> Pluralize(1, "", "str");
+Error, the argument <str> must be a non-empty string
+gap> Pluralize(-1, "str1", "str2");
+Error, Usage: Pluralize([<count>, ]<string>[, <plural>])
+gap> Pluralize(-1, "str1", "str2");
+Error, Usage: Pluralize([<count>, ]<string>[, <plural>])
+gap> Pluralize(0, "str1", "str2", fail);
+Error, Usage: Pluralize([<count>, ]<string>[, <plural>])
+
+#
+gap> Pluralize(0, "A");
+"\>0\< As"
+gap> Pluralize(1, "A");
+"\>1\< A"
+gap> Pluralize("A");
+"As"
+
+#
+gap> Pluralize(0, "ox", "oxen");
+"\>0\< oxen"
+gap> Pluralize(1, "ox", "oxen");
+"\>1\< ox"
+gap> Pluralize("ox", "oxen");
+"oxen"
+
+#
+gap> Pluralize(1, "loaf");
+"\>1\< loaf"
+gap> Pluralize(2, "loaf");
+"\>2\< loaves"
+gap> Pluralize("loaf");
+"loaves"
+
+#
+gap> Pluralize(1, "wharf");
+"\>1\< wharf"
+gap> Pluralize(2, "wharf");
+"\>2\< wharves"
+gap> Pluralize("wharf");
+"wharves"
+
+#
+gap> Pluralize(1, "calf");
+"\>1\< calf"
+gap> Pluralize(2, "calf");
+"\>2\< calves"
+gap> Pluralize("calf");
+"calves"
+
+#
+gap> Pluralize("matrix");
+"matrices"
+gap> Pluralize(2, "matrix");
+"\>2\< matrices"
+
+#
+gap> Pluralize("vertex");
+"vertices"
+gap> Pluralize(3, "vertex");
+"\>3\< vertices"
+
+#
+gap> Pluralize("index");
+"indices"
+gap> Pluralize(4, "index");
+"\>4\< indices"
+
+#
+gap> Pluralize("ash");
+"ashes"
+gap> Pluralize(5, "ash");
+"\>5\< ashes"
+
+#
+gap> Pluralize("success");
+"successes"
+gap> Pluralize(6, "success");
+"\>6\< successes"
+
+#
+gap> Pluralize("box");
+"boxes"
+gap> Pluralize(7, "box");
+"\>7\< boxes"
+
+#
+gap> Pluralize("axis");
+"axes"
+gap> Pluralize(8, "axis");
+"\>8\< axes"
+
+#
+gap> Pluralize("child");
+"children"
+gap> Pluralize(9, "child");
+"\>9\< children"
+
+#
+gap> Pluralize("person");
+"people"
+gap> Pluralize(8, "person");
+"\>8\< people"
+
+#
+gap> Pluralize("equipment");
+"equipment"
+gap> Pluralize(7, "equipment");
+"\>7\< equipment"
+
+#
+gap> Pluralize("information");
+"information"
+gap> Pluralize(6, "information");
+"\>6\< information"
+
+#
+gap> Pluralize("series");
+"series"
+gap> Pluralize(5, "series");
+"\>5\< series"
+
+#
+gap> Pluralize("species");
+"species"
+gap> Pluralize(4, "species");
+"\>4\< species"
+
+#
+gap> Pluralize("gaffe");
+"gaffes"
+gap> Pluralize(3, "gaffe");
+"\>3\< gaffes"
+
+#
+gap> Pluralize("life");
+"lives"
+gap> Pluralize(2, "life");
+"\>2\< lives"
+
+#
+gap> Pluralize("try");
+"tries"
+gap> Pluralize(0, "try");
+"\>0\< tries"
+
+#
+gap> Pluralize("bay");
+"bays"
+gap> Pluralize(2, "bay");
+"\>2\< bays"
+
+#
+gap> Pluralize("money");
+"moneys"
+gap> Pluralize(3, "money");
+"\>3\< moneys"
+
+#
+gap> Pluralize("toy");
+"toys"
+gap> Pluralize(4, "toy");
+"\>4\< toys"
+
+#
+gap> Pluralize("guy");
+"guys"
+gap> Pluralize(5, "guy");
+"\>5\< guys"
+
+#
+gap> Pluralize("church");
+"churches"
+gap> Pluralize(6, "church");
+"\>6\< churches"
+
+#
+gap> Pluralize("billiards");
+"billiards"
+gap> Pluralize(7, "billiards");
+"\>7\< billiards"
+
+#
+gap> Pluralize("train");
+"trains"
+gap> Pluralize(8, "train");
+"\>8\< trains"
+
+#
+gap> Pluralize("tractor");
+"tractors"
+gap> Pluralize(9, "tractor");
+"\>9\< tractors"
+
+#
+gap> Pluralize("datum");
+"data"
+gap> Pluralize(8, "datum");
+"\>8\< data"
+
+#
+gap> Pluralize("quantum");
+"quanta"
+gap> Pluralize(7, "quantum");
+"\>7\< quanta"
+
+#
+gap> Pluralize("equilibrium");
+"equilibria"
+gap> Pluralize(6, "equilibrium");
+"\>6\< equilibria"
+
+#
+gap> Pluralize("millennium");
+"millennia"
+gap> Pluralize(5, "millennium");
+"\>5\< millennia"
+
+#
+gap> STOP_TEST("format.tst",1);


### PR DESCRIPTION
I've done some work towards making objects correctly pluralise the word 'generator' in GAP, especially in `ViewString` methods.

In English, you say that you have `0 generators`, `1 generator`, or `n generators`, in the case that `n > 1`. Most (all?) of the methods for `ViewString` or `ViewObj` in the library do not special case `1 generator`, and instead write `1 generators`.

So we get, for example:
```
<magma with 1 generators>
```
rather than
```
<magma with 1 generator>
```

The wrongness grates on me, and makes GAP seem that little bit less professional. Therefore, I've gone some way to addressing this. However, I have not spent the time to finish and polish this work, because:

1. Is there a good reason that I've missed for GAP to be this way?

2. Will changing all of these methods break the tests of so many packages that it's not worth doing?

3. My 'fixes' are ugly and repetitive. Really, I want a function that I can use from anyway in GAP, to return the string "generator" if the number of generators is 1, or "generators" otherwise. Any suggestions? How general should this be? That way I could adjust the string construction code to be something like:
```
"<group with ", nrgens, FUNC(" generator", "s", nrgens <> 1), ">";
```
where `FUNC` would print the concatenation of the first two arguments if the third is `true`, and only prints the first argument otherwise.