### PR TITLE
gac: *really* try to remove gactmp

### DIFF
--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -478,8 +478,6 @@ if [ $comp_howfar = "link" ]; then
 fi
 
 # Remove temporary directory.
-# We may assume it is empty at this stage.
 if [ "$savetemps" = "false" ]; then
-    rm -rf "${gactmp}/.libs"
-    rmdir "${gactmp}"
+    rm -rf "${gactmp}"
 fi


### PR DESCRIPTION
There can be stray files in there for whatever reason. Let's err
on the safe side here, instead or risking to run into errors in this
cleanup step.


Inspired by @jamesjr's patch at  https://src.fedoraproject.org/rpms/gap/blob/master/f/gap-gac.patch (that patch does more, but the other things it does are related to `make install` work, and will be in another PR)