### PR TITLE
julia: avoid potential inlining issue

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -532,7 +532,7 @@ ScanTaskStack(int rescan, jl_task_t * task, void * start, void * end)
     MarkFromList(stack);
 }
 
-static void TryMarkRange(void * start, void * end)
+static NOINLINE void TryMarkRange(void * start, void * end)
 {
     if (lt_ptr(end, start)) {
         SWAP(void *, start, end);


### PR DESCRIPTION
In GASMAN, we had to add NOINLINE to `GenStackFuncBags` to avoid
a bug caused by the compiler inlining it, which then breaks our trick to
use setjmp to capture the content of registers. The Julia GC code uses
a similar trick with function TryMarkRange, so let's add NOINLINE to
that as well

While I am not aware of any actual bug related to this yet, I think we
should be proactive here; after all, we didn't hear about the GASMAN bug
for a long time as it only manifests on arm64 for now; few people test
GAP on that, even fewer test GAP with the Julia GC there...
