### PR TITLE
kernel: move NrError into ScannerState

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1597,7 +1597,6 @@ void InitializeGap (
              (Bag *)(((UInt)pargc / C_STACK_ALIGN) * C_STACK_ALIGN),
              C_STACK_ALIGN);
 
-    GAP_ASSERT(STATE(NrError) == 0);
     STATE(ThrownObject) = 0;
     STATE(UserHasQUIT) = 0;
     STATE(UserHasQuit) = 0;

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -55,7 +55,6 @@ typedef struct GAPState {
     jmp_buf ReadJmpError;
 
     /* From scanner.c */
-    UInt   NrError;
     UInt   NrErrLine;
 
     char Prompt[80];

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -438,7 +438,6 @@ static void ThreadedInterpreter(void * funcargs)
     int i;
 
     // initialize everything and begin a fresh execution context
-    GAP_ASSERT(STATE(NrError) == 0);
     STATE(ThrownObject) = 0;
     SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
 

--- a/src/read.h
+++ b/src/read.h
@@ -17,58 +17,6 @@
 
 /****************************************************************************
 **
-*S  TRY_IF_NO_ERROR
-*S  CATCH_ERROR
-**
-**  To deal with errors found by the reader, we implement a kind of exception
-**  handling using setjmp, with the help of these two macros. See also
-**  GAP_TRY and GAP_CATCH in trycatch.h for two closely related macros.
-**
-**  To use these constructs, write code like this:
-**    TRY_IF_NO_ERROR {
-**       ... code which might trigger reader error ...
-**    }
-**  or
-**    TRY_IF_NO_ERROR {
-**       ... code which might trigger reader error ...
-**    }
-**    CATCH_ERROR {
-**       ... error handler ...
-**    }
-**
-**  Then, if the reader encounters an error, or if the interpretation of an
-**  expression or statement leads to an error, 'GAP_THROW' is invoked,
-**  which in turn calls 'longjmp' to return to right after the block
-**  following TRY_IF_NO_ERROR.
-**
-**  A second effect of 'TRY_IF_NO_ERROR' is that it prevents the execution of
-**  the code it wraps if 'STATE(NrError)' is non-zero, i.e. if any errors
-**  occurred. This is key for enabling graceful error recovery in the reader,
-**  and for this reason it is crucial that all calls from the reader into
-**  the interpreter are wrapped into 'TRY_IF_NO_ERROR' blocks.
-**
-**  Note that while you can in principle nest TRY_IF_NO_ERROR constructs, to
-**  do this correctly, you must backup ReadJmpError before TRY_IF_NO_ERROR,
-**  and restore it in a matching CATCH_ERROR block.
-*/
-/* TL: extern jmp_buf ReadJmpError; */
-
-#define TRY_IF_NO_ERROR \
-    if (!STATE(NrError)) { \
-        volatile Int recursionDepth = GetRecursionDepth();  \
-        if (setjmp(STATE(ReadJmpError))) { \
-            SetRecursionDepth(recursionDepth);  \
-            STATE(NrError)++; \
-        }\
-    }\
-    if (!STATE(NrError))
-
-#define CATCH_ERROR \
-    else
-
-
-/****************************************************************************
-**
 *F * * * * * * * * * * * * read and evaluate symbols  * * * * * * * * * * * *
 */
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -100,7 +100,7 @@ static void SyntaxErrorOrWarning(ScannerState * s,
 
     if (error) {
         // one more error
-        STATE(NrError)++;
+        s->NrError++;
         STATE(NrErrLine)++;
     }
 }

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -223,8 +223,7 @@ typedef struct {
     // Track the last three symbols, for 'Unbound global' warnings
     UInt   SymbolStartPos[3];
     UInt   SymbolStartLine[3];
-} ScannerState;
-
+    
 /****************************************************************************
 **
 *V  NrError . . . . . . . . . . . . . . . .  number of errors in current expr
@@ -247,8 +246,10 @@ typedef struct {
 **  one line, since they  probabely  just reflect  the  fact that the  parser
 **  has not resynchronized yet.
 */
-/* TL: extern  UInt            NrError; */
+    UInt NrError;
 /* TL: extern  UInt            NrErrLine; */
+
+} ScannerState;
 
 
 /****************************************************************************

--- a/src/stats.c
+++ b/src/stats.c
@@ -1146,9 +1146,6 @@ void ClearError ( void )
         }
 #endif
     }
-
-    /* reset <STATE(NrError)>                                                */
-    STATE(NrError) = 0;
 }
 
 /****************************************************************************

--- a/src/stats.h
+++ b/src/stats.h
@@ -135,11 +135,7 @@ extern  void            (* PrintStatFuncs[256] ) ( Stat stat );
  **
  *F  ClearError()  . . . . . . . . . . . . . .  reset execution and error flag
  *
- * FIXME: This function accesses NrError which is state of the scanner, so
- *        scanner should have an API for this.
- * 
  */
-
 void ClearError(void);
 
 

--- a/src/trycatch.h
+++ b/src/trycatch.h
@@ -25,7 +25,7 @@
 *S  GAP_CATCH
 **
 **  These two macros implement a kind of "poor man's exception handler".
-**  See also `read.h` for the two related macros TRY_IF_NO_ERROR and
+**  See also `read.c` for the two related macros TRY_IF_NO_ERROR and
 **  CATCH_ERROR (which have special code for use in the GAP "reader",
 **  and should not be used elsewhere).
 **


### PR DESCRIPTION
UPDATE: This has now been slimmed down to a single commit (thanks to a ton of other PRs that are now merged), and is ready for review!


This is work in progress on overhauling the error handling mechanism in the GAP kernel. Here, I am trying to untangle the general error handling from the special case of handling errors in the scanner/reader (resp. interpreter/coder), by adding two new macro `GAP_TRY` and `GAP_CATCH` (might also add a `GAP_THROW` later) for use in general code; and then moving `NrError` out of the global GAP state into `ScannerState`. This makes reasoning about the code *much* easier.

But first we need to convince ourselves that this change in itself is correct and safe! This is the difficult part. And while the tests passed locally for me, I am not yet convinced that the changes are OK, as our test suite for error handling is not that comprehensive to start with. So we'll have to very carefully reason about this. I'll try to through every place I touched which uses try/catch and try to discuss for each (via comments here on this PR) why I think it is "safe". Well, after I convinced myself that it is... as I said, I am not yet convinced ;-)). I might also write some more tests.

I might also write a complementing PR or two which adds assertions to test hypothesis I have formed about this code, to verify whether they are true (at least for our test suites).

In the meantime, any "evil" ideas and suggestions for breaking what I did here are welcome ;-).