### PR TITLE
kernel: verify some invariants in debug mode

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -274,7 +274,10 @@ Stat NewStatOrExpr (
         bodySize = CS(OffsBody);
     while (bodySize < CS(OffsBody))
         bodySize *= 2;
+    GAP_ASSERT(STATE(PtrBody) == PTR_BAG(body));
     ResizeBag(body, bodySize);
+    // resize a bag can change its address, even without a GC taking place;
+    // so we must update PtrBody here
     STATE(PtrBody) = PTR_BAG(body);
 
     /* enter type and size                                                 */

--- a/src/gap.c
+++ b/src/gap.c
@@ -1597,7 +1597,7 @@ void InitializeGap (
              (Bag *)(((UInt)pargc / C_STACK_ALIGN) * C_STACK_ALIGN),
              C_STACK_ALIGN);
 
-    STATE(NrError)      = 0;
+    GAP_ASSERT(STATE(NrError) == 0);
     STATE(ThrownObject) = 0;
     STATE(UserHasQUIT) = 0;
     STATE(UserHasQuit) = 0;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -438,7 +438,7 @@ static void ThreadedInterpreter(void * funcargs)
     int i;
 
     // initialize everything and begin a fresh execution context
-    STATE(NrError) = 0;
+    GAP_ASSERT(STATE(NrError) == 0);
     STATE(ThrownObject) = 0;
     oldLVars = STATE(CurrLVars);
     SWITCH_TO_OLD_LVARS(STATE(BottomLVars));

--- a/src/read.c
+++ b/src/read.c
@@ -2514,6 +2514,10 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     int                 lockSP;
 #endif
 
+    // invariant: before any call to ReadEvalCommand, there must have been
+    // a call to ClearError, and thus NrError == 0 holds
+    GAP_ASSERT(STATE(NrError) == 0);
+
     ReaderState reader;
     ReaderState * volatile rs = &reader;
     memset(rs, 0, sizeof(ReaderState));
@@ -2633,6 +2637,10 @@ UInt ReadEvalFile(Obj * evalResult)
     volatile int        lockSP;
 #endif
 
+    // invariant: before any call to ReadEvalFile, there must have been
+    // a call to ClearError, and thus NrError == 0 holds
+    GAP_ASSERT(STATE(NrError) == 0);
+
     ReaderState reader;
     ReaderState * volatile rs = &reader;
     memset(rs, 0, sizeof(ReaderState));
@@ -2723,8 +2731,8 @@ UInt ReadEvalFile(Obj * evalResult)
 */
 void ReadEvalError(void)
 {
-    STATE(PtrBody)  = PTR_BAG(BODY_FUNC(CURR_FUNC()));
-    STATE(PtrLVars) = PTR_BAG(STATE(CurrLVars));
+    GAP_ASSERT(STATE(PtrBody) == PTR_BAG(BODY_FUNC(CURR_FUNC())));
+    GAP_ASSERT(STATE(PtrLVars) == PTR_BAG(STATE(CurrLVars)));
     syLongjmp( &(STATE(ReadJmpError)), 1 );
 }
 


### PR DESCRIPTION
- NrError is always 0 in a fresh GAP state;
- NrError is always 0 when entering ReadEval{Command,File}
- verify some invariants in ReadEvalError instead of "enforcing" them

This is motivated by PR #3996: I want to test some hypothesis I formed about the kernel code. Locally this passes the test suite. Of course that doesn't *prove* I am right, but it at least supports my theory. Let's see if it still works with the full test run here on Travis.