### PR TITLE
kernel: avoids some uses of TRY_IF_NO_ERROR

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -1649,9 +1649,7 @@ void InitializeGap (
         /* Call POST_RESTORE which is a GAP function that now takes control, 
            calls the post restore functions and then runs a GAP session */
         if (POST_RESTORE != 0 && IS_FUNC(POST_RESTORE)) {
-          TRY_IF_NO_ERROR {
-            CALL_0ARGS(POST_RESTORE);
-          }
+          Call0ArgsInNewReader(POST_RESTORE);
         }
 
         return;

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -801,39 +801,17 @@ static Obj FuncHASH_UNLOCK_SHARED(Obj self, Obj target)
 
 static Obj FuncHASH_SYNCHRONIZED(Obj self, Obj target, Obj function)
 {
-    volatile int locked = 0;
-    jmp_buf      readJmpError;
-    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
-    TRY_IF_NO_ERROR
-    {
-        HashLock(target);
-        locked = 1;
-        CALL_0ARGS(function);
-        locked = 0;
-        HashUnlock(target);
-    }
-    if (locked)
-        HashUnlock(target);
-    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
+    HashLock(target);
+    Call0ArgsInNewReader(function);
+    HashUnlock(target);
     return (Obj)0;
 }
 
 static Obj FuncHASH_SYNCHRONIZED_SHARED(Obj self, Obj target, Obj function)
 {
-    volatile int locked = 0;
-    jmp_buf      readJmpError;
-    memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
-    TRY_IF_NO_ERROR
-    {
-        HashLockShared(target);
-        locked = 1;
-        CALL_0ARGS(function);
-        locked = 0;
-        HashUnlockShared(target);
-    }
-    if (locked)
-        HashUnlockShared(target);
-    memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
+    HashLockShared(target);
+    Call0ArgsInNewReader(function);
+    HashUnlockShared(target);
     return (Obj)0;
 }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -700,7 +700,6 @@ static Obj FuncPrint(Obj self, Obj args)
 {
     volatile Obj        arg;
     volatile UInt       i;
-    jmp_buf           readJmpError;
 
     /* print all the arguments, take care of strings and functions         */
     for ( i = 1;  i <= LEN_PLIST(args);  i++ ) {
@@ -715,17 +714,7 @@ static Obj FuncPrint(Obj self, Obj args)
             PrintFunction( arg );
         }
         else {
-            memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
-
-            /* if an error occurs stop printing                            */
-            TRY_IF_NO_ERROR {
-                PrintObj( arg );
-            }
-            CATCH_ERROR {
-                memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
-                ReadEvalError();
-            }
-            memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
+            PrintObj( arg );
         }
     }
 


### PR DESCRIPTION
In `FuncPrint`, we catch an exception only to immediately re-throw it.
Clearly this is pointless.

Three places using `TRY_IF_NO_ERROR` simply want to perform a call to a
GAP function but ignoring any error this might raise; we change them to
use `Call0ArgsInNewReader` instead. Note that this arguably even might
fix bugs in some corners, as we now call `ClearError` which the previous
code did not.

@rbehrends please take a look at the HPC specific bits, in case I missed some subtlety about them in my analysis?
