### PR TITLE
kernel: introduce GAP_TRY/GAP_CATCH helper macros

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -43,6 +43,7 @@
 #include "sysroots.h"
 #include "sysstr.h"
 #include "systime.h"
+#include "trycatch.h"
 #include "vars.h"
 
 #ifdef HPCGAP
@@ -1675,7 +1676,7 @@ void InitializeGap (
        past here when we're about to exit. 
                                            */
     if ( SyLoadSystemInitFile ) {
-      TRY_IF_NO_ERROR {
+      GAP_TRY {
         if ( READ_GAP_ROOT("lib/init.g") == 0 ) {
                 Pr( "gap: hmm, I cannot find 'lib/init.g' maybe",
                     0, 0);
@@ -1684,7 +1685,7 @@ void InitializeGap (
                     " script instead.", 0, 0);
             }
       }
-      CATCH_ERROR {
+      GAP_CATCH {
           Panic("Caught error at top-most level, probably quit from "
                 "library loading");
       }

--- a/src/gap_all.h
+++ b/src/gap_all.h
@@ -71,6 +71,7 @@ extern "C" {
 #include "sysfiles.h"
 #include "tietze.h"
 #include "trans.h"
+#include "trycatch.h"
 #include "vars.h"
 #include "vector.h"
 #include "weakptr.h"

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -137,7 +137,7 @@ static inline int GAP_Error_Postjmp_(int JumpRet)
 //
 // * GAP_Error_Setjmp() effectively calls setjmp to the STATE(ReadJmpError)
 //   longjmp buffer, so that read errors which occur in GAP that are not
-//   otherwise "handled" by a TRY_IF_NO_ERROR { } block have a logical place
+//   otherwise "handled" by a GAP_TRY { } block have a logical place
 //   to return to.  It returns 1 if no error occurred, and 0 if returning
 //   from an error.
 #define GAP_Enter()                                                          \

--- a/src/read.c
+++ b/src/read.c
@@ -29,6 +29,7 @@
 #include "sysjmp.h"
 #include "sysopt.h"
 #include "sysstr.h"
+#include "trycatch.h"
 #include "vars.h"
 
 #ifdef HPCGAP
@@ -2740,7 +2741,6 @@ void ReadEvalError(void)
 
 struct SavedReaderState {
   UInt                userHasQuit;
-  jmp_buf           readJmpError;
   UInt                nrError;
   Bag                 oldLvars;
 };
@@ -2749,7 +2749,6 @@ static void SaveReaderState(struct SavedReaderState *s) {
   s->userHasQuit = STATE(UserHasQuit);
   s->nrError = STATE(NrError);
   s->oldLvars = STATE(CurrLVars);
-  memcpy( s->readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 }
 
 static void ClearReaderState(void ) {
@@ -2760,7 +2759,6 @@ static void ClearReaderState(void ) {
 
 static void RestoreReaderState(const struct SavedReaderState *s) {
   SWITCH_TO_OLD_LVARS(s->oldLvars);
-  memcpy( STATE(ReadJmpError), s->readJmpError, sizeof(jmp_buf) );
   STATE(UserHasQuit) = s->userHasQuit;
   STATE(NrError) = s->nrError;
 }
@@ -2783,10 +2781,10 @@ Obj Call0ArgsInNewReader(Obj f)
   // initialize everything
   ClearReaderState();
 
-  TRY_IF_NO_ERROR {
+  GAP_TRY {
     result = CALL_0ARGS(f);
   }
-  CATCH_ERROR {
+  GAP_CATCH {
     result = 0;
     ClearError();
   }
@@ -2814,10 +2812,10 @@ Obj Call1ArgsInNewReader(Obj f, Obj a)
   // initialize everything
   ClearReaderState();
 
-  TRY_IF_NO_ERROR {
+  GAP_TRY {
     result = CALL_1ARGS(f,a);
   }
-  CATCH_ERROR {
+  GAP_CATCH {
     result = 0;
     ClearError();
   }

--- a/src/read.h
+++ b/src/read.h
@@ -17,10 +17,12 @@
 
 /****************************************************************************
 **
-*F  TRY_IF_NO_ERROR / CATCH_ERROR
+*S  TRY_IF_NO_ERROR
+*S  CATCH_ERROR
 **
 **  To deal with errors found by the reader, we implement a kind of exception
-**  handling using setjmp, with the help of two macros.
+**  handling using setjmp, with the help of these two macros. See also
+**  GAP_TRY and GAP_CATCH in trycatch.h for two closely related macros.
 **
 **  To use these constructs, write code like this:
 **    TRY_IF_NO_ERROR {
@@ -39,15 +41,15 @@
 **  which in turn calls 'longjmp' to return to right after the block
 **  following TRY_IF_NO_ERROR.
 **
-**  A second effect of 'TRY_IF_NO_ERROR' is that it prevents the execution of the
-**  code it wraps if 'STATE(NrError)' is non-zero, i.e. if any errors
+**  A second effect of 'TRY_IF_NO_ERROR' is that it prevents the execution of
+**  the code it wraps if 'STATE(NrError)' is non-zero, i.e. if any errors
 **  occurred. This is key for enabling graceful error recovery in the reader,
 **  and for this reason it is crucial that all calls from the reader into
 **  the interpreter are wrapped into 'TRY_IF_NO_ERROR' blocks.
 **
-**  Note that while you can in principle nest TRY_IF_NO_ERROR constructs, to do this
-**  correctly, you must backup ReadJmpError before TRY_IF_NO_ERROR, and restore it
-**  in a matching CATCH_ERROR block.
+**  Note that while you can in principle nest TRY_IF_NO_ERROR constructs, to
+**  do this correctly, you must backup ReadJmpError before TRY_IF_NO_ERROR,
+**  and restore it in a matching CATCH_ERROR block.
 */
 /* TL: extern jmp_buf ReadJmpError; */
 

--- a/src/trycatch.h
+++ b/src/trycatch.h
@@ -1,0 +1,79 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+**
+**  This module declares the functions to read  expressions  and  statements.
+*/
+
+#ifndef GAP_TRYCATCH_H
+#define GAP_TRYCATCH_H
+
+#include "funcs.h"    // for SetRecursionDepth
+#include "gapstate.h"
+
+
+/****************************************************************************
+**
+*S  GAP_TRY
+*S  GAP_CATCH
+**
+**  These two macros implement a kind of "poor man's exception handler".
+**  See also `read.h` for the two related macros TRY_IF_NO_ERROR and
+**  CATCH_ERROR (which have special code for use in the GAP "reader",
+**  and should not be used elsewhere).
+**
+**  To use GAP_TRY and GAP_CATCH, write code like this:
+**
+**    GAP_TRY
+**    {
+**       ... code which might trigger a GAP error ...
+**    }
+**    GAP_CATCH
+**    {
+**       ... error handler ...
+**    }
+**
+**  Note that GAP_TRY must ALWAYS be used together with GAP_CATCH; otherwise
+**  STATE(ReadJmpError) will not be restored properly, which can lead to
+**  crashes later on. To help catch violations of this rule, we introduce the
+**  variable gap__j which is then exclusively used in GAP_CATCH. Failure to
+**  use GAP_CATCH then triggers an "unused variable" compiler warning.
+**
+**  The implementation of these two macros (ab)uses for loops to run code
+**  at the start resp. end of the following code block; in order to have
+**  the loop executed exactly once, auxiliary variables gap__i resp. gap__j
+**  are set to 1 initially; then used as loop condition; then in the post
+**  iteration step are set to 0 to prevent further loop iterations.
+*/
+#define GAP_TRY                                                              \
+    int          gap__i, gap__j;                                             \
+    jmp_buf      gap__jmp_buf;                                               \
+    volatile Int gap__recursionDepth = GetRecursionDepth();                  \
+    memcpy(gap__jmp_buf, STATE(ReadJmpError), sizeof(jmp_buf));              \
+    if (!setjmp(STATE(ReadJmpError)))                                        \
+        for (gap__i = 1; gap__i; gap__i = 0,                                 \
+            gap_restore_trycatch(gap__jmp_buf, gap__recursionDepth))
+
+
+// TODO: call SetRecursionDepth(recursionDepth); in GAP_CATCH; but for that we
+// need perhaps a helper function
+#define GAP_CATCH                                                            \
+    else for (gap__j = 1,                                                    \
+              gap_restore_trycatch(gap__jmp_buf, gap__recursionDepth);       \
+              gap__j; gap__j = 0)
+
+// helper function for use by GAP_TRY and GAP_CATCH
+static inline int gap_restore_trycatch(jmp_buf jb, int recursionDepth)
+{
+    memcpy(STATE(ReadJmpError), jb, sizeof(jmp_buf));
+    SetRecursionDepth(recursionDepth);
+    return 0;
+}
+
+
+#endif


### PR DESCRIPTION
This is a subset of PR #3996 (see also PRs #3997 and #3998); unlike with that PR, I am pretty sure this one is valid and safe to merge; alas, it'd be good if somebody else checked my thinking.

Here's the fulll commit message:

These are meant to replace uses of TRY_IF_NO_ERROR/CATCH_ERROR outside
of read.c, as those macros really were meant for code in the GAP
scanner/reader; for other code, they are dangerous to use because of the
way they interact with `STATE(NrError)`.

The new macros have the added benefit that they automatically save
and restore the value of `STATE(ReadJmpError)`, so it is safe to use
them recursively.

For now we only switch to GAP_TRY/GAP_CATCH in places were it is clear
that doing so is safe (as in: not touch `STATE(NrError)` is OK). To be
explicit, here are arguments why each change ought to be safe:

- gap.c, reading lib/init.g: if this catches, then we call `Panic`, so
  the value `STATE(NrError)` is irrelevant
- `FuncSERIALIZE_TO_NATIVE_STRING`: did not change `STATE(NrError)`
- `FuncDESERIALIZE_NATIVE_STRING`: did not change `STATE(NrError)`
- `ThreadedInterpreter`: this is the outermost handler for a thread;
  once we catch an error here, we exit this function, which then leads
  to the termination of the thread (for that reason, we also get rid of
  the `ClearError` and `SWITCH_TO_OLD_LVARS` at the end -- they are
  pointless
- `FuncWITH_TARGET_REGION`: did not change `STATE(NrError)`
- `Call0ArgsInNewReader`, `Call1ArgsInNewReader`: these save & restore
  the value of `STATE(NrError)` anyway
