### PR TITLE
Fix PermList for descending ranges

### DIFF
--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -1080,8 +1080,6 @@ static Obj FuncPermList(Obj self, Obj list)
         if (IS_RANGE(list)) {
             if (GET_LOW_RANGE(list) == 1 && GET_INC_RANGE(list) == 1)
                 return IdentityPerm;
-            else
-                return Fail;
         }
         list = PLAIN_LIST_COPY(list);
     }

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -301,6 +301,10 @@ gap> ForAll(checklens, n -> not(
 >  PermList(Concatenation([1..n-1], [n+1,n,n+2,n+4,n+3])) =
 >  PermList(Concatenation([1..n-1], [n+1,n+2,n,n+4,n+3]))));
 true
+gap> PermList([1..5]);
+()
+gap> PermList([5,4..1]);
+(1,5)(2,4)
 
 # PermList error handling
 gap> PermList(1);


### PR DESCRIPTION
This fixes a regression in the GAP kernel function `PermList` on `master`; luckily this affects no released version.

Based on a bug report (via personal email) by @heikodietrich -- thank you!