### PR TITLE
kernel: make ViewObjHandler more robust

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -374,14 +374,17 @@ static void READ_TEST_OR_LOOP(Obj context)
     UInt                type;
     UInt                oldtime;
     UInt                dualSemicolon;
+    UInt                oldPrintObjState;
 
     /* get the starting time                                               */
     oldtime = SyTime();
+    oldPrintObjState = SetPrintObjState(0);
 
     /* now do the reading                                                  */
     while ( 1 ) {
 
         /* read and evaluate the command                                   */
+        SetPrintObjState(0);
         ClearError();
         Obj evalResult;
         type = ReadEvalCommand(context, &evalResult, &dualSemicolon);
@@ -397,9 +400,7 @@ static void READ_TEST_OR_LOOP(Obj context)
 
             /* print the result                                            */
             if ( ! dualSemicolon ) {
-                Bag currLVars = STATE(CurrLVars); /* in case view runs into error */
                 ViewObjHandler( evalResult );
-                SWITCH_TO_OLD_LVARS(currLVars);
             }
         }
 
@@ -416,6 +417,7 @@ static void READ_TEST_OR_LOOP(Obj context)
 
     }
 
+    SetPrintObjState(oldPrintObjState);
     ClearError();
 }
 

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -1,4 +1,29 @@
 #
+# Tests for functions defined in src/gap.c
+#
+gap> START_TEST("kernel/gap.tst");
+
+# stress test the kernel helper `ViewObjHandler`: force an error
+# in ViewObj; afterwards everything should still work as before
+gap> l := [ ~ ];; r := rec(a:=~);;
+gap> cat := NewCategory("IsMockObject", IsObject);;
+gap> type := NewType(NewFamily("MockFamily"), cat);;
+gap> InstallMethod(ViewObj, [cat], function(s) Error("oops"); end);
+gap> InstallMethod(PrintObj, [cat], function(s) Error("uups"); end);
+gap> x:=Objectify(type,[]); r; Print(l, "\n");
+Error, oops
+rec( a := ~ )
+[ ~ ]
+gap> ViewObj(x); r; Print(l, "\n");
+Error, oops
+rec( a := ~ )
+[ ~ ]
+gap> PrintObj(x); r; Print(l, "\n");
+Error, uups
+rec( a := ~ )
+[ ~ ]
+
+#
 gap> SHELL();
 Error, Function: number of arguments must be 10 (not 0)
 gap> SHELL(1,2,3,4,5,6,7,8,9,10);
@@ -215,3 +240,6 @@ gap> UPDATE_STAT(fail, fail);
 Error, UPDATE_STAT: <name> must be a string (not the value 'fail')
 gap> UPDATE_STAT("foobar", fail);
 Error, UPDATE_STAT: unsupported <name> value 'foobar'
+
+#
+gap> STOP_TEST("kernel/gap.tst", 1);


### PR DESCRIPTION
READ_TEST_OR_LOOP used to invoke SWITCH_TO_OLD_LVARS after invoking
ViewObjHandler, but I don't see how that could ever be necessary; and if
it is necessary, why it wouldn't be required for the other call to
ViewObjHandler the main REPL.

So let's replace it by an assertion that verifies it is not necessary,
then let's run some more tests.


If this PR passes all tests, let's not merge it; instead, we can simply remove the checks in question.