### PR TITLE
Fix gac to ensure that binaries it creates on Linux can load and run, even if a GAP package with a compiled kernel extension (such as IO) is present

### DIFF
--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -75,10 +75,10 @@ libtool="$SHELL ${abs_top_builddir}/libtool"
 # These three should be filled in by the standard autoconf procedures
 c_compiler="$libtool --mode=compile $GAP_CC"
 cxx_compiler="$libtool --mode=compile $GAP_CXX"
-c_linker="$libtool --mode=link $GAP_CXX"
+c_linker="$libtool --mode=link $GAP_CC -export-dynamic"
 
 # These will need special care
-c_dyn_linker="$libtool --mode=link $GAP_CXX -module -avoid-version -rpath $libdir"
+c_dyn_linker="$libtool --mode=link $GAP_CC -module -avoid-version -rpath $libdir"
 c_addlibs=""
 
 SYS_IS_CYGWIN32=@SYS_IS_CYGWIN32@


### PR DESCRIPTION
Reported by Bill Allombert: compiling a simple test program via, say,
`gac catp.g -o catp`, and then running it results in an error like this:

    [... GAP banner here ...]
    Loading the library and packages ...
    #W dlopen() error:
    SOMEPATH/pkg/io/bin/x86_64-pc-linux-gnu-default64-kv7/io.so:\
    undefined symbol: ChangedBags

This was caused by the linker invocation in gac missing the `-export-dynamic`
flag

This patch also fixes a second issue: While GAP deliberately links using the C
compiler, the linker command in gac used the C++ compiler for linking. Now
both use the C compiler, ensuring consistent behavior.

Note that we quite deliberately use the C compiler to link, despite GAP
containing C++ code: that code that is careful not to use the C++ standard
library and for which RTTI and exceptions are disabled
