### PR TITLE
kernel: change ViewObjHandler to use GAP_TRY

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -131,14 +131,12 @@ UInt ViewObjGVar;
 void ViewObjHandler ( Obj obj )
 {
   volatile Obj        func;
-  jmp_buf             readJmpError;
 
   /* get the functions                                                   */
   func = ValAutoGVar(ViewObjGVar);
 
   /* if non-zero use this function, otherwise use `PrintObj'             */
-  memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
-  TRY_IF_NO_ERROR {
+  GAP_TRY {
     if ( func != 0 && TNUM_OBJ(func) == T_FUNCTION ) {
       ViewObj(obj);
     }
@@ -147,7 +145,8 @@ void ViewObjHandler ( Obj obj )
     }
     Pr("\n", 0, 0);
   }
-  memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
+  GAP_CATCH {
+  }
 }
 
 


### PR DESCRIPTION
This means that now if the `ViewObj` method we call raises an error that
we catch, we won't increment `STATE(NrError)` anymore. But this makes no
difference as there are just two places that call `ViewObjHandler`:

1. `READ_TEST_OR_LOOP`: calls `ClearError` at the start of each loop
   iteration and before exiting, so the change does not matter.

2. `Shell`: calls `ClearError` at the start of each loop iteration;
   and in the code path which calls `ViewObjHandler`, we do not leave
   the loop and are guaranteed to start a new loop iteration, which
   then clears `NrError`.
