### PR TITLE
kernel: use GAP_TRY in PRINT_OR_APPEND_TO_FILE_OR_STREAM

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -728,7 +728,6 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
     volatile Obj        arg;
     volatile Obj        destination;
     volatile UInt       i;
-    jmp_buf           readJmpError;
 
     /* first entry is the file or stream                                   */
     destination = ELM_LIST(args, 1);
@@ -762,8 +761,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
         arg = ELM_LIST(args,i);
 
         /* if an error occurs stop printing                                */
-        memcpy(readJmpError, STATE(ReadJmpError), sizeof(jmp_buf));
-        TRY_IF_NO_ERROR
+        GAP_TRY
         {
             if (IS_PLIST(arg) && 0 < LEN_PLIST(arg) && IsStringConv(arg)) {
                 PrintString1(arg);
@@ -778,13 +776,11 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
                 PrintObj(arg);
             }
         }
-        CATCH_ERROR
+        GAP_CATCH
         {
             CloseOutput();
-            memcpy( STATE(ReadJmpError), readJmpError, sizeof(jmp_buf) );
             GAP_THROW();
         }
-        memcpy(STATE(ReadJmpError), readJmpError, sizeof(jmp_buf));
     }
 
     /* close the output file again, and return nothing                     */

--- a/src/trycatch.h
+++ b/src/trycatch.h
@@ -40,11 +40,14 @@
 **       ... error handler ...
 **    }
 **
-**  Note that GAP_TRY must ALWAYS be used together with GAP_CATCH; otherwise
-**  STATE(ReadJmpError) will not be restored properly, which can lead to
-**  crashes later on. To help catch violations of this rule, we introduce the
-**  variable gap__j which is then exclusively used in GAP_CATCH. Failure to
-**  use GAP_CATCH then triggers an "unused variable" compiler warning.
+**  WARNING: it is not safe to use `return` inside a GAP_TRY block; doing so
+**  would leave STATE(ReadJmpError) in an inconsistent state, which can lead
+**  to crashes on.
+**
+**  For the same reason, GAP_TRY must ALWAYS be used followed by a GAP_CATCH
+**  block. To help catch violations of this rule, we introduce the variable
+**  gap__j which is then exclusively used in GAP_CATCH. Failure to use
+**  GAP_CATCH then triggers an "unused variable" compiler warning.
 **
 **  The implementation of these two macros (ab)uses for loops to run code
 **  at the start resp. end of the following code block; in order to have
@@ -61,9 +64,6 @@
         for (gap__i = 1; gap__i; gap__i = 0,                                 \
             gap_restore_trycatch(gap__jmp_buf, gap__recursionDepth))
 
-
-// TODO: call SetRecursionDepth(recursionDepth); in GAP_CATCH; but for that we
-// need perhaps a helper function
 #define GAP_CATCH                                                            \
     else for (gap__j = 1,                                                    \
               gap_restore_trycatch(gap__jmp_buf, gap__recursionDepth);       \


### PR DESCRIPTION
This is safe because we rethrow the exception; so if NrError matters,
the code catching the rethrown exception should update it anyway; and
if it doesn't matter there, it also shouldn't matter here.

UPDATE: also added a commit which improves the comments in `src/trycatch.h`.