### PR TITLE
BuildPackages.sh: adjust default GAP to GAPROOT

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -32,7 +32,6 @@ fi
 
 CURDIR="$(pwd)"
 GAPROOT="$(cd .. && pwd)"
-GAP="$GAPROOT/bin/gap.sh"
 COLORS=yes
 STRICT=no       # exit with non-zero exit code when encountering any failures
 PARALLEL=no
@@ -63,6 +62,8 @@ while [[ "$#" -ge 1 ]]; do
     *)                PACKAGES+=("$option") ;;
   esac
 done
+
+GAP="${GAP:-$GAPROOT/bin/gap.sh}"
 
 if [ "x$PARALLEL" = "xyes" ]; then
   export MAKEFLAGS="${MAKEFLAGS:--j3}"


### PR DESCRIPTION
The default value for GAP was based on the default value for GAPROOT; now it is
based on the actual GAPROOT we use in the script; so if --with-gaproot is used,
then this also adjusts GAP.

This is necessary for out-of-tree builds (I hope this will be the final patch needed for that ... *sigh*)