### PR TITLE
etc/Makefile.gappkg: various improvements

### DIFF
--- a/etc/Makefile.gappkg
+++ b/etc/Makefile.gappkg
@@ -3,8 +3,8 @@
 # The build rules in this file are intended for use by GAP packages that
 # want to build a simple GAP kernel extensions. They are based on the
 # GAP build system, and require GNU make. To use this in your GAP
-# package, `include` this from your primary Makefile. You must also set
-# several variables beforehand:
+# package, `include` this file from your primary Makefile. You must also
+# set several variables beforehand:
 #
 # - GAPPATH must be set to the location of the GAP installation against
 #   which to build your package.
@@ -13,7 +13,9 @@
 # - KEXT_SOURCES must contain a list of .c or .cc files to be linked
 #   into your kernel extension
 # - optionally, you can set KEXT_CFLAGS, KEXT_CXXFLAGS, KEXT_LDFLAGS
-#
+# - if you are using autoconf to produce your configure script, set
+#   KEXT_USE_AUTOCONF to 1 to enable dependency rules that enable
+#   regenerating the configure script etc. when necessary
 #
 # Only GAP >= 4.11 ships with this file. In order to keep your package
 # compatible with older GAP versions, we recommend to bundle a copy of
@@ -27,15 +29,22 @@
 # package, etc.
 #
 # If you bundle this file with your package, please try not to edit it,
-# so that we can keep it identical across all GAP packages. If you still
-# find that you must edit it, please consider submitting your changes
-# back to the GAP team, so that a future version of this file can be
-# adjusted to cover your usecase without modifications.
+# so that we can keep it identical across all GAP packages. Instead, if
+# you find that you must edit it, please submit your changes back to
+# the GAP team, so that a future version of this file can be adjusted
+# to cover your usecase without modifications, thus ensuring you can
+# always easily update to newer version of it.
 #
 ########################################################################
 
 # read GAP's build settings
 include $(GAPPATH)/sysinfo.gap
+
+# hack to support GAP <= 4.9
+ifndef GAP_KERNEL_MAJOR_VERSION
+  KEXT_CFLAGS += -I$(GAP_LIB_DIR)/src
+  KEXT_CXXFLAGS += -I$(GAP_LIB_DIR)/src
+endif
 
 # various derived settings
 KEXT_BINARCHDIR = bin/$(GAParch)
@@ -46,7 +55,11 @@ GAC = $(GAPPATH)/gac
 
 # override KEXT_RECONF if your package needs a different invocation
 # for reconfiguring (e.g. `./config.status --recheck` for autoconf)
+ifdef KEXT_USE_AUTOCONF
+KEXT_RECONF ?= ./config.status Makefile
+else
 KEXT_RECONF ?= ./configure "$(GAPPATH)"
+endif
 
 # default target
 all: $(KEXT_SO)
@@ -79,13 +92,10 @@ endif
 # This is based on the GAP build system.
 ########################################################################
 
-# List of all (potential) dependency directories, derived from KEXT_OBJS
-# and KEXT_SOURCES (the latter for generated sources, which may also
-# involve dependency tracking)
-KEXT_DEPDIRS = $(sort $(dir $(KEXT_SOURCES) $(KEXT_OBJS)))
-KEXT_DEPFILES = $(wildcard $(addsuffix /*.d,$(KEXT_DEPDIRS)))
+# List of all (potential) dependency files, derived from KEXT_OBJS
+KEXT_DEPFILES = $(patsubst %.lo,%.d,$(KEXT_OBJS))
 
-# Include the dependency tracking files.
+# Include the dependency tracking files
 -include $(KEXT_DEPFILES)
 
 # Mark *.d files as PHONY. This stops make from trying to recreate them
@@ -101,22 +111,22 @@ KEXT_DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
 # build rule for C code
 # The dependency on Makefile ensures that re-running configure recompiles everything
 gen/%.lo: %.c Makefile
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -p "$(CFLAGS)" -c $< -o $@
 
 # build rule for C++ code
 # The dependency on Makefile ensures that re-running configure recompiles everything
 gen/%.lo: %.cc Makefile
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -p "$(CXXFLAGS)" -c $< -o $@
 
 # build rule for assembler code
 # The dependency on Makefile ensures that re-running configure recompiles everything
 gen/%.lo: %.s Makefile
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -p "$(CFLAGS)" -c $< -o $@
 
 # build rule for linking all object files together into a kernel extension
 $(KEXT_SO): $(KEXT_OBJS)
 	@mkdir -p $(KEXT_BINARCHDIR)
-	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" $(KEXT_OBJS) -o $@
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" -P "$(LDFLAGS)" $(KEXT_OBJS) -o $@
 
 # hook into `make clean`
 clean: clean-kext
@@ -142,6 +152,53 @@ check-kext:
 # re-run configure if configure, Makefile.in or GAP itself changed
 Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
 	$(KEXT_RECONF)
+
+ifdef KEXT_USE_AUTOCONF
+
+# react to modifications of the build system
+configure_deps = configure.ac $(wildcard m4/*.m4)
+
+ifneq ($(MAINTAINER_MODE),no)
+configure: $(configure_deps)
+	@if command -v autoconf >/dev/null 2>&1 ; then \
+	   echo "running autoconf" ; \
+	   autoconf ; \
+	 else \
+	   echo "autoconf not available, proceeding with stale configure" ; \
+	 fi
+endif # MAINTAINER_MODE
+
+# re-run configure if configure, Makefile.in or GAP itself changed
+config.status: configure $(GAPPATH)/sysinfo.gap
+	./config.status --recheck
+
+# update Makefile if config.status changed
+Makefile: config.status
+
+gen/pkgconfig.h: gen/pkgconfig.h.stamp
+	@if test ! -f $@; then rm -f $<; else :; fi
+	@if test ! -f $@; then $(MAKE) $<; else :; fi
+
+gen/pkgconfig.h.stamp: gen/pkgconfig.h.in config.status
+	@rm -f $@
+	@mkdir -p $(@D)
+	./config.status gen/pkgconfig.h
+	echo > $@
+
+ifneq ($(MAINTAINER_MODE),no)
+gen/pkgconfig.h.in: $(configure_deps)
+	@if command -v autoheader >/dev/null 2>&1 ; then \
+	   mkdir -p $(@D) ; \
+	   echo "running autoheader" ; \
+	   autoheader ; \
+	   rm -f gen/pkgconfig.h.stamp ; \
+	 else \
+	   echo "autoheader not available, proceeding with stale config.h" ; \
+	 fi
+	touch $@
+endif # MAINTAINER_MODE
+
+endif # KEXT_USE_AUTOCONF
 
 .PHONY: check clean distclean doc
 .PHONY: check-kext clean-kext distclean-kext doc-kext


### PR DESCRIPTION
- built-in autoconf support for packages that need a complex configure script;
  this adds rules which re-run autoconf or autoheader as needed, and to regenerate
  various files automatically; sometimes this can be undesired, then it can be
  turned off by setting the (environment) variable MAINTAINER_MODE to "no"
- support assembler ".s" source files (via C compiler)
- honor user supplied CFLAGS, CXXFLAGS, LDFLAGS
- little hack to ensure that when using GAP 4.9, the GAP src directory is in
  the list of include paths (as it is automatically with GAP 4.10 and later),
  so that `#include "compiled.h"` works

This covers #3973 partially.

This should be backported to stable-4.11.

I'll also submit PRs to (more) packages using this file to convince them to update