### PR TITLE
More thoroughly check arguments in PrintFormatted

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1398,7 +1398,7 @@ end);
 
 InstallGlobalFunction(PrintFormatted, function(args...)
     # Do some very baic argument checking
-    if not Length(args) > 1 and IsString(args[1]) then
+    if not (Length(args) > 1 and IsString(args[1])) then
         ErrorNoReturn("Usage: PrintFormatted(<string>, <data>...)");
     fi;
     

--- a/tst/testinstall/format.tst
+++ b/tst/testinstall/format.tst
@@ -62,6 +62,10 @@ gap> StringFormatted("abc{}def",[1,2]) = "abc[ 1, 2 ]def";
 true
 
 # Test alternative functions
+gap> PrintFormatted();
+Error, Usage: PrintFormatted(<string>, <data>...)
+gap> PrintFormatted(fail);
+Error, Usage: PrintFormatted(<string>, <data>...)
 gap> PrintFormatted("abc\n\n");
 Error, Usage: PrintFormatted(<string>, <data>...)
 gap> PrintFormatted("abc{}\n", 2);
@@ -72,7 +76,7 @@ gap> PrintToFormatted(OutputTextString(str, false), "abc{}\n", [1,2]);
 gap> Print(str);
 abc[ 1, 2 ]
 gap> PrintFormatted([1,2]);
-Error, Usage: StringFormatted(<string>, <data>...)
+Error, Usage: PrintFormatted(<string>, <data>...)
 gap> PrintToFormatted([1,2]);
 Error, Function: number of arguments must be at least 2 (not 1)
 gap> PrintToFormatted([1,2], "abc");


### PR DESCRIPTION
I've added some brackets that I think were meant to be there in the argument checking for `PrintFormatted`. Previous behaviour:
```
gap> PrintFormatted();
Error, List Element: <list>[1] must have an assigned value in
  Length( args ) > 1 at /Users/Wilf/gap/lib/string.gi:1401 called from
<function "PrintFormatted">( <arguments> )
```
which is not helpful, and
```
Error, Usage: StringFormatted(<string>, <data>...) at /Users/Wilf/gap/lib/string.gi:1392 called from
CallFuncList( StringFormatted, args ) at /Users/Wilf/gap/lib/string.gi:1407 called from
<function "PrintFormatted">( <arguments> )
```
which gives an error from `StringFormatted`.

The new behaviour gives the proper error message from `PrintFormatted` itself, as shown in the test file that I updated.