### PR TITLE
Fix UnderlyingSemigroup self-reference in the documentation

### DIFF
--- a/doc/ref/reesmat.xml
+++ b/doc/ref/reesmat.xml
@@ -434,7 +434,8 @@ gap> Columns(R);
       Label="for a Rees 0-matrix semigroup"/>
     <Returns>A semigroup.</Returns>
     <Description>
-      <Ref Attr="UnderlyingSemigroup"/> returns the underlying semigroup of the Rees
+      <Ref Attr="UnderlyingSemigroup" Label="for a Rees matrix semigroup" />
+      returns the underlying semigroup of the Rees
       matrix or 0-matrix semigroup <A>R</A>. <P/>
       
       Arbitrary subsemigroups of Rees matrix or 0-matrix semigroups do not have


### PR DESCRIPTION
The necessary label of the `Ref` was missing. This was causing the following warning while compiling the reference manual:
```
#W WARNING: non resolved reference: rec(
  Attr := "UnderlyingSemigroup" )
```
Closes #4001.