### PR TITLE
kernel: improve float literal parsing, fix some inconsistencies in it

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -388,7 +388,6 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
   UInt symbol = S_ILLEGAL;
   UInt i = 0;
   UInt seenADigit = 0;
-  UInt seenExp = 0;
   UInt seenExpDigit = 0;
 
   s->ValueObj = 0;
@@ -502,12 +501,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
     }
 
     // If the next thing is the start of the exponential notation, read it now.
-
     if (IsAlpha(c)) {
-      if (!seenADigit)
-        SyntaxError(s, "Badly formed number: need a digit before or after "
-                    "the decimal point");
-      seenExp = 1;
       i = AddCharToValue(s, i, c);
       c = GET_NEXT_CHAR();
       if (c == '+' || c == '-') {
@@ -515,13 +509,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
         c = GET_NEXT_CHAR();
       }
     }
-
-    // Either we saw an exponent indicator, or we hit end of token deal with
-    // the end of token case
-    if (!seenExp) {
-      if (!seenADigit)
-        SyntaxError(s, "Badly formed number: need a digit before or after "
-                    "the decimal point");
+    else {
       // Might be a conversion marker
       if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' &&
           c != 'q' && c != 'Q') {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -510,29 +510,8 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
       }
     }
     else {
-      // Might be a conversion marker
-      if (IsAlpha(c) && c != 'e' && c != 'E' && c != 'd' && c != 'D' &&
-          c != 'q' && c != 'Q') {
-        i = AddCharToValue(s, i, c);
-        c = GET_NEXT_CHAR();
-      }
-      // independently of that, we allow an _ signalling immediate conversion
-      if (c == '_') {
-        i = AddCharToValue(s, i, c);
-        c = GET_NEXT_CHAR();
-        // After which there may be one character signifying the
-        // conversion style
-        if (IsAlpha(c))
-          i = AddCharToValue(s, i, c);
-        c = GET_NEXT_CHAR();
-      }
-      // Now if the next character is alphanumerical, or an identifier type
-      // symbol then we really do have an error, otherwise we return a result
-      if (!IsIdent(c)) {
-        symbol = S_FLOAT;
-        goto finish;
-      }
-      SyntaxError(s, "Badly formed number");
+      symbol = S_FLOAT;
+      goto finish;
     }
 
   // Here we are into the unsigned exponent of a number in scientific

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -455,6 +455,10 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
   // When we get here we have read possibly some digits, a . and possibly
   // some more digits, but not an e,E,d,D,q or Q
 
+  // In any case, from now on, we know we are dealing with a float literal
+  symbol = S_FLOAT;
+
+
     // read digits
     while (IsDigit(c)) {
       i = AddCharToValue(s, i, c);
@@ -491,7 +495,6 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
         if (IsAlpha(c)) {
           i = AddCharToValue(s, i, c);
           c = GET_NEXT_CHAR();
-          symbol = S_FLOAT;
           goto finish;
         }
         if (c == '_') {
@@ -503,7 +506,6 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
             i = AddCharToValue(s, i, c);
             c = GET_NEXT_CHAR();
           }
-          symbol = S_FLOAT;
           goto finish;
         }
       }
@@ -541,8 +543,6 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
       }
     }
 
-
-  symbol = S_FLOAT;
 
 finish:
   i = AddCharToValue(s, i, '\0');

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -501,18 +501,13 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
     }
 
     // If the next thing is the start of the exponential notation, read it now.
-    if (IsAlpha(c)) {
+    if (c == 'e' || c == 'E' || c == 'd' || c == 'D' || c == 'q' || c == 'Q') {
       i = AddCharToValue(s, i, c);
       c = GET_NEXT_CHAR();
       if (c == '+' || c == '-') {
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
       }
-    }
-    else {
-      symbol = S_FLOAT;
-      goto finish;
-    }
 
   // Here we are into the unsigned exponent of a number in scientific
   // notation, so we just read digits
@@ -550,6 +545,8 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
   if (!seenExpDigit)
     SyntaxError(s, 
         "Badly formed number: need at least one digit in the exponent");
+} // end of `IsAlpha(c)`
+
   symbol = S_FLOAT;
 
 finish:

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -387,8 +387,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
 {
   UInt symbol = S_ILLEGAL;
   UInt i = 0;
-  UInt seenADigit = 0;
-  UInt seenExpDigit = 0;
+  BOOL seenADigit = FALSE;
 
   s->ValueObj = 0;
 
@@ -399,7 +398,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
     // read initial sequence of digits into 'Value'
     while (IsDigit(c)) {
       i = AddCharToValue(s, i, c);
-      seenADigit = 1;
+      seenADigit = TRUE;
       c = GET_NEXT_CHAR();
     }
 
@@ -443,7 +442,6 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
       i = AddCharToValue(s, i, '.');
       c = GET_NEXT_CHAR();
     }
-
     else {
       // Anything else we see tells us that the token is done
       symbol = S_INT;
@@ -451,18 +449,15 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
     }
   }
 
-
   // When we get here we have read possibly some digits, a . and possibly
   // some more digits, but not an e,E,d,D,q or Q
-
   // In any case, from now on, we know we are dealing with a float literal
   symbol = S_FLOAT;
-
 
     // read digits
     while (IsDigit(c)) {
       i = AddCharToValue(s, i, c);
-      seenADigit = 1;
+      seenADigit = TRUE;
       c = GET_NEXT_CHAR();
     }
     if (!seenADigit)
@@ -482,15 +477,13 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
 
       // Here we are into the unsigned exponent of a number in scientific
       // notation, so we just read digits
-
-      while (IsDigit(c)) {
-        i = AddCharToValue(s, i, c);
-        seenExpDigit = 1;
-        c = GET_NEXT_CHAR();
-      }
-      if (!seenExpDigit)
+      if (!IsDigit(c))
         SyntaxError(s, 
             "Badly formed number: need at least one digit in the exponent");
+      while (IsDigit(c)) {
+        i = AddCharToValue(s, i, c);
+        c = GET_NEXT_CHAR();
+      }
     }
 
       // Allow one letter at the end of the number, which is a conversion
@@ -505,7 +498,7 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
         // After which there may be one character signifying the
-        // conversion style
+        // conversion styles
         if (IsAlpha(c)) {
           i = AddCharToValue(s, i, c);
           c = GET_NEXT_CHAR();
@@ -516,7 +509,6 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
       if (IsIdent(c)) {
         SyntaxError(s, "Badly formed number");
       }
-
 
 finish:
   i = AddCharToValue(s, i, '\0');

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -488,44 +488,19 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
         seenExpDigit = 1;
         c = GET_NEXT_CHAR();
       }
-
-      // Look out for a single alphabetic character on the end
-      // which could be a conversion marker
-      if (seenExpDigit) {
-        if (IsAlpha(c)) {
-          i = AddCharToValue(s, i, c);
-          c = GET_NEXT_CHAR();
-          goto finish;
-        }
-        if (c == '_') {
-          i = AddCharToValue(s, i, c);
-          c = GET_NEXT_CHAR();
-          // After which there may be one character signifying the
-          // conversion style
-          if (IsAlpha(c)) {
-            i = AddCharToValue(s, i, c);
-            c = GET_NEXT_CHAR();
-          }
-          goto finish;
-        }
-      }
-
-      // Otherwise this is the end of the token
       if (!seenExpDigit)
         SyntaxError(s, 
             "Badly formed number: need at least one digit in the exponent");
     }
-    // If we found an identifier type character in this context could be an
-    // error or the start of one of the allowed trailing marker sequences
-    else if (IsIdent(c)) {
 
-      // Allow one letter on the end of the numbers -- could be an i, C99
-      // style
+      // Allow one letter at the end of the number, which is a conversion
+      // marker; e.g. an `i` as in C99, to indicate an imaginary value.
       if (IsAlpha(c)) {
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
       }
-      // independently of that, we allow an _ signalling immediate conversion
+
+      // independently of that, we allow an _ signalling immediate or "eager" conversion
       if (c == '_') {
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
@@ -536,12 +511,11 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
           c = GET_NEXT_CHAR();
         }
       }
-      // Now if the next character is alphanumerical, or an identifier type
-      // symbol then we really do have an error, otherwise we return a result
+
+      // Now if the next character is an identifier symbol then we have an error
       if (IsIdent(c)) {
         SyntaxError(s, "Badly formed number");
       }
-    }
 
 
 finish:

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -385,138 +385,144 @@ static UInt AddCharToValue(ScannerState * s, UInt pos, Char c)
 
 static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
 {
-  UInt symbol = S_ILLEGAL;
-  UInt i = 0;
-  BOOL seenADigit = FALSE;
+    UInt symbol = S_ILLEGAL;
+    UInt i = 0;
+    BOOL seenADigit = FALSE;
 
-  s->ValueObj = 0;
+    s->ValueObj = 0;
 
-  if (readDecimalPoint) {
-    s->Value[i++] = '.';
-  }
-  else {
-    // read initial sequence of digits into 'Value'
-    while (IsDigit(c)) {
-      i = AddCharToValue(s, i, c);
-      seenADigit = TRUE;
-      c = GET_NEXT_CHAR();
-    }
-
-    // maybe we saw an identifier character and realised that this is an
-    // identifier we are reading
-    if (IsIdent(c) || c == '\\') {
-      // if necessary, copy back from s->ValueObj to s->Value
-      if (s->ValueObj) {
-        i = GET_LEN_STRING(s->ValueObj);
-        GAP_ASSERT(i >= MAX_VALUE_LEN - 1);
-        memcpy(s->Value, CONST_CSTR_STRING(s->ValueObj), MAX_VALUE_LEN);
-        s->ValueObj = 0;
-      }
-      // this looks like an identifier, scan the rest of it
-      return GetIdent(s, i, c);
-    }
-
-    // Or maybe we saw a '.' which could indicate one of three things:
-    // - a float literal: 12.345
-    // - S_DOT, i.e., '.' used to access a record entry: r.12.345
-    // - S_DDOT, i.e., '..' in a range expression:  [12..345]
-    if (c == '.') {
-      GAP_ASSERT(i < MAX_VALUE_LEN - 1);
-
-      // If the symbol before this integer was S_DOT then we must be in
-      // a nested record element expression, so don't look for a float.
-      // This is a bit fragile
-      if (s->Symbol == S_DOT || s->Symbol == S_BDOT) {
-        symbol = S_INT;
-        goto finish;
-      }
-
-      // peek ahead to decide if we are looking at a range expression
-      if (PEEK_NEXT_CHAR() == '.') {
-        // we are looking at '..' and are probably inside a range expression
-        symbol = S_INT;
-        goto finish;
-      }
-
-      // Now the '.' must be part of our number; store it and move on
-      i = AddCharToValue(s, i, '.');
-      c = GET_NEXT_CHAR();
+    if (readDecimalPoint) {
+        s->Value[i++] = '.';
     }
     else {
-      // Anything else we see tells us that the token is done
-      symbol = S_INT;
-      goto finish;
-    }
-  }
+        // read initial sequence of digits into 'Value'
+        while (IsDigit(c)) {
+            i = AddCharToValue(s, i, c);
+            seenADigit = TRUE;
+            c = GET_NEXT_CHAR();
+        }
 
-  // When we get here we have read possibly some digits, a . and possibly
-  // some more digits, but not an e,E,d,D,q or Q
-  // In any case, from now on, we know we are dealing with a float literal
-  symbol = S_FLOAT;
+        // maybe we saw an identifier character and realised that this is an
+        // identifier we are reading
+        if (IsIdent(c) || c == '\\') {
+            // if necessary, copy back from s->ValueObj to s->Value
+            if (s->ValueObj) {
+                i = GET_LEN_STRING(s->ValueObj);
+                GAP_ASSERT(i >= MAX_VALUE_LEN - 1);
+                memcpy(s->Value, CONST_CSTR_STRING(s->ValueObj),
+                       MAX_VALUE_LEN);
+                s->ValueObj = 0;
+            }
+            // this looks like an identifier, scan the rest of it
+            return GetIdent(s, i, c);
+        }
+
+        // Or maybe we saw a '.' which could indicate one of three things:
+        // - a float literal: 12.345
+        // - S_DOT, i.e., '.' used to access a record entry: r.12.345
+        // - S_DDOT, i.e., '..' in a range expression:  [12..345]
+        if (c == '.') {
+            GAP_ASSERT(i < MAX_VALUE_LEN - 1);
+
+            // If the symbol before this integer was S_DOT then we must be in
+            // a nested record element expression, so don't look for a float.
+            // This is a bit fragile
+            if (s->Symbol == S_DOT || s->Symbol == S_BDOT) {
+                symbol = S_INT;
+                goto finish;
+            }
+
+            // peek ahead to decide if we are looking at a range expression
+            if (PEEK_NEXT_CHAR() == '.') {
+                // we are looking at '..' and are probably inside a range
+                // expression
+                symbol = S_INT;
+                goto finish;
+            }
+
+            // Now the '.' must be part of our number; store it and move on
+            i = AddCharToValue(s, i, '.');
+            c = GET_NEXT_CHAR();
+        }
+        else {
+            // Anything else we see tells us that the token is done
+            symbol = S_INT;
+            goto finish;
+        }
+    }
+
+    // When we get here we have read possibly some digits, a . and possibly
+    // some more digits, but not an e,E,d,D,q or Q
+    // In any case, from now on, we know we are dealing with a float literal
+    symbol = S_FLOAT;
 
     // read digits
     while (IsDigit(c)) {
-      i = AddCharToValue(s, i, c);
-      seenADigit = TRUE;
-      c = GET_NEXT_CHAR();
+        i = AddCharToValue(s, i, c);
+        seenADigit = TRUE;
+        c = GET_NEXT_CHAR();
     }
     if (!seenADigit)
-      SyntaxError(s, "Badly formed number: need a digit before or after the "
-                  "decimal point");
+        SyntaxError(s,
+                    "Badly formed number: need a digit before or after the "
+                    "decimal point");
     if (c == '\\')
-      SyntaxError(s, "Badly formed number");
+        SyntaxError(s, "Badly formed number");
 
-    // If the next thing is the start of the exponential notation, read it now.
-    if (c == 'e' || c == 'E' || c == 'd' || c == 'D' || c == 'q' || c == 'Q') {
-      i = AddCharToValue(s, i, c);
-      c = GET_NEXT_CHAR();
-      if (c == '+' || c == '-') {
+    // If the next thing is the start of the exponential notation, read it
+    // now.
+    if (c == 'e' || c == 'E' || c == 'd' || c == 'D' || c == 'q' ||
+        c == 'Q') {
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
-      }
+        if (c == '+' || c == '-') {
+            i = AddCharToValue(s, i, c);
+            c = GET_NEXT_CHAR();
+        }
 
-      // Here we are into the unsigned exponent of a number in scientific
-      // notation, so we just read digits
-      if (!IsDigit(c))
-        SyntaxError(s, 
-            "Badly formed number: need at least one digit in the exponent");
-      while (IsDigit(c)) {
-        i = AddCharToValue(s, i, c);
-        c = GET_NEXT_CHAR();
-      }
+        // Here we are into the unsigned exponent of a number in scientific
+        // notation, so we just read digits
+        if (!IsDigit(c))
+            SyntaxError(s, "Badly formed number: need at least one digit in "
+                           "the exponent");
+        while (IsDigit(c)) {
+            i = AddCharToValue(s, i, c);
+            c = GET_NEXT_CHAR();
+        }
     }
 
-      // Allow one letter at the end of the number, which is a conversion
-      // marker; e.g. an `i` as in C99, to indicate an imaginary value.
-      if (IsAlpha(c)) {
+    // Allow one letter at the end of the number, which is a conversion
+    // marker; e.g. an `i` as in C99, to indicate an imaginary value.
+    if (IsAlpha(c)) {
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
-      }
+    }
 
-      // independently of that, we allow an _ signalling immediate or "eager" conversion
-      if (c == '_') {
+    // independently of that, we allow an _ signalling immediate or "eager"
+    // conversion
+    if (c == '_') {
         i = AddCharToValue(s, i, c);
         c = GET_NEXT_CHAR();
         // After which there may be one character signifying the
         // conversion styles
         if (IsAlpha(c)) {
-          i = AddCharToValue(s, i, c);
-          c = GET_NEXT_CHAR();
+            i = AddCharToValue(s, i, c);
+            c = GET_NEXT_CHAR();
         }
-      }
+    }
 
-      // Now if the next character is an identifier symbol then we have an error
-      if (IsIdent(c)) {
+    // Now if the next character is an identifier symbol then we have an error
+    if (IsIdent(c)) {
         SyntaxError(s, "Badly formed number");
-      }
+    }
 
 finish:
-  i = AddCharToValue(s, i, '\0');
-  if (s->ValueObj) {
-    // flush buffer
-    AppendBufToString(s->ValueObj, s->Value, i - 1);
-  }
-  return symbol;
+    i = AddCharToValue(s, i, '\0');
+    if (s->ValueObj) {
+        // flush buffer
+        AppendBufToString(s->ValueObj, s->Value, i - 1);
+    }
+    return symbol;
 }
 
 

--- a/tst/testinstall/kernel/scanner.tst
+++ b/tst/testinstall/kernel/scanner.tst
@@ -233,29 +233,25 @@ stream:1
 gap> 1.e0i;
 "std:1.e0i"
 gap> 1.e0ix;
-Syntax error: ; expected in stream:1
+Syntax error: Badly formed number in stream:1
 1.e0ix;
-     ^
+^^^^^
 gap> 1.e0_;
 "std:1.e0"
 gap> 1.e0_y;
 "eager:1.e0"
 gap> 1.e0_yx;
-Syntax error: ; expected in stream:1
+Syntax error: Badly formed number in stream:1
 1.e0_yx;
-      ^
+^^^^^^
 gap> 1.e0i_;
-Syntax error: ; expected in stream:1
-1.e0i_;
-     ^
+"std:1.e0i"
 gap> 1.e0i_y;
-Syntax error: ; expected in stream:1
-1.e0i_y;
-     ^^
+"eager:1.e0i"
 gap> 1.e0i_yx;
-Syntax error: ; expected in stream:1
+Syntax error: Badly formed number in stream:1
 1.e0i_yx;
-     ^^^
+^^^^^^^
 
 #
 gap> 1.0i;
@@ -327,29 +323,25 @@ stream:1
 gap> 1.0e0i;
 "std:1.0e0i"
 gap> 1.0e0ix;
-Syntax error: ; expected in stream:1
+Syntax error: Badly formed number in stream:1
 1.0e0ix;
-      ^
+^^^^^^
 gap> 1.0e0_;
 "std:1.0e0"
 gap> 1.0e0_y;
 "eager:1.0e0"
 gap> 1.0e0_yx;
-Syntax error: ; expected in stream:1
+Syntax error: Badly formed number in stream:1
 1.0e0_yx;
-       ^
+^^^^^^^
 gap> 1.0e0i_;
-Syntax error: ; expected in stream:1
-1.0e0i_;
-      ^
+"std:1.0e0i"
 gap> 1.0e0i_y;
-Syntax error: ; expected in stream:1
-1.0e0i_y;
-      ^^
+"eager:1.0e0i"
 gap> 1.0e0i_yx;
-Syntax error: ; expected in stream:1
+Syntax error: Badly formed number in stream:1
 1.0e0i_yx;
-      ^^^
+^^^^^^^^
 
 # restore float handlers
 gap> Unbind(EAGER_FLOAT_LITERAL_CONVERTERS.y);

--- a/tst/testinstall/kernel/scanner.tst
+++ b/tst/testinstall/kernel/scanner.tst
@@ -153,6 +153,209 @@ a.x111111111111111111111111111111111111111111111111111111111111111111111111111\
 ^^^^^^^^^^^^
 
 #
+# floating point oddities
+#
+
+# temporarily set up fake float handlers
+gap> IsBound(EAGER_FLOAT_LITERAL_CONVERTERS.y);
+false
+gap> EAGER_FLOAT_LITERAL_CONVERTERS.y := x->Concatenation("eager:",x);;
+gap> old_FLOAT_STRING := FLOAT_STRING;;
+gap> FLOAT_STRING := x->Concatenation("std:",x);;
+
+#
+gap> 1.i;
+"std:1.i"
+gap> 1.ix;
+Syntax error: Badly formed number in stream:1
+1.ix;
+^^^
+gap> 1._;
+"std:1."
+gap> 1._y;
+"eager:1."
+gap> 1._yx;
+Syntax error: Badly formed number in stream:1
+1._yx;
+^^^^
+gap> 1.i_;
+"std:1.i"
+gap> 1.i_y;
+"eager:1.i"
+gap> 1.i_yx;
+Syntax error: Badly formed number in stream:1
+1.i_yx;
+^^^^^
+
+#
+gap> 1.ei;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.ei;
+^^^
+gap> 1.eix;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.eix;
+^^^
+gap> 1.e_;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.e_;
+^^^
+gap> 1.e_y;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.e_y;
+^^^
+gap> 1.e_yx;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.e_yx;
+^^^
+gap> 1.ei_;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.ei_;
+^^^
+gap> 1.ei_y;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.ei_y;
+^^^
+gap> 1.ei_yx;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.ei_yx;
+^^^
+
+#
+gap> 1.e0i;
+"std:1.e0i"
+gap> 1.e0ix;
+Syntax error: ; expected in stream:1
+1.e0ix;
+     ^
+gap> 1.e0_;
+"std:1.e0"
+gap> 1.e0_y;
+"eager:1.e0"
+gap> 1.e0_yx;
+Syntax error: ; expected in stream:1
+1.e0_yx;
+      ^
+gap> 1.e0i_;
+Syntax error: ; expected in stream:1
+1.e0i_;
+     ^
+gap> 1.e0i_y;
+Syntax error: ; expected in stream:1
+1.e0i_y;
+     ^^
+gap> 1.e0i_yx;
+Syntax error: ; expected in stream:1
+1.e0i_yx;
+     ^^^
+
+#
+gap> 1.0i;
+"std:1.0i"
+gap> 1.0ix;
+Syntax error: Badly formed number in stream:1
+1.0ix;
+^^^^
+gap> 1.0_;
+"std:1.0"
+gap> 1.0_y;
+"eager:1.0"
+gap> 1.0_yx;
+Syntax error: Badly formed number in stream:1
+1.0_yx;
+^^^^^
+gap> 1.0i_;
+"std:1.0i"
+gap> 1.0i_y;
+"eager:1.0i"
+gap> 1.0i_yx;
+Syntax error: Badly formed number in stream:1
+1.0i_yx;
+^^^^^^
+
+#
+gap> 1.0ei;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0ei;
+^^^^
+gap> 1.0eix;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0eix;
+^^^^
+gap> 1.0e_;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0e_;
+^^^^
+gap> 1.0e_y;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0e_y;
+^^^^
+gap> 1.0e_yx;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0e_yx;
+^^^^
+gap> 1.0ei_;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0ei_;
+^^^^
+gap> 1.0ei_y;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0ei_y;
+^^^^
+gap> 1.0ei_yx;
+Syntax error: Badly formed number: need at least one digit in the exponent in \
+stream:1
+1.0ei_yx;
+^^^^
+
+#
+gap> 1.0e0i;
+"std:1.0e0i"
+gap> 1.0e0ix;
+Syntax error: ; expected in stream:1
+1.0e0ix;
+      ^
+gap> 1.0e0_;
+"std:1.0e0"
+gap> 1.0e0_y;
+"eager:1.0e0"
+gap> 1.0e0_yx;
+Syntax error: ; expected in stream:1
+1.0e0_yx;
+       ^
+gap> 1.0e0i_;
+Syntax error: ; expected in stream:1
+1.0e0i_;
+      ^
+gap> 1.0e0i_y;
+Syntax error: ; expected in stream:1
+1.0e0i_y;
+      ^^
+gap> 1.0e0i_yx;
+Syntax error: ; expected in stream:1
+1.0e0i_yx;
+      ^^^
+
+# restore float handlers
+gap> Unbind(EAGER_FLOAT_LITERAL_CONVERTERS.y);
+gap> FLOAT_STRING := old_FLOAT_STRING;;
+
+#
 # test EOF inside a string literal
 #
 gap> EvalString("\"123");


### PR DESCRIPTION
I had a look at the code coverage for the kernel function `GetNumber` which parses integers and floats. There was some code I could not get coverage for, and after some thinking about, determined that it was dead. Yay! This PR first adds some test to increase coverage for the float parsing code (they pass on their own). It then contains a bunch of commits which refactor the code gradually, in an attempt to make it "obvious" that the refactoring is correct (but the reviewers of the PR be the judge of whether I managed that ;-). Please read the commit messages, they are meant to explain my reasoning at each step.

The result is much simple and also more consistent (as the changes to tests added at the start in one of the later commits highlight).


