### PR TITLE
kernel: include gaptime.h in gap_all.h

### DIFF
--- a/src/gap_all.h
+++ b/src/gap_all.h
@@ -36,6 +36,7 @@ extern "C" {
 #include "funcs.h"
 #include "gap.h"
 #include "gapstate.h"
+#include "gaptime.h"
 #include "gasman.h"
 #include "gvars.h"
 #include "info.h"


### PR DESCRIPTION
This fixes the Ferret package which currently doesn't build, as it calls
`SyNanosecondsSinceEpoch`
