### PR TITLE
doc: fix ref manual list of special characters

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -134,7 +134,7 @@ Digits, uppercase and lowercase letters, <B>Space</B>, <B>Tab</B>,
 <B>Newline</B>, <B>Return</B> and the special characters
 <P/>
 <Listing><![CDATA[
-"    `    (    )    *    +    ,    -    #
+"    '    (    )    *    +    ,    -    #
 .    /    :    ;    <    =    >    ~    
 [    \    ]    ^    _    {    }    ! 
 ]]></Listing>


### PR DESCRIPTION
The manual lists characters that occur in regular GAP code; it contains
a backtick, which is not used by GAP, but is missing a single quotation
mark, which *is* used, for character constants. This is likely a typo,
and this commit fixes it.
