### PR TITLE
Travis: switch OSX build to Xcode 11.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
     # OS X builds: since those are slow and limited on Travis, we only run testinstall
     - env: TEST_SUITES="docomp testinstall"
       os: osx
-      compiler: clang
+      osx_image: xcode11.4
 
     # test creating the manual
     - env: TEST_SUITES=makemanuals


### PR DESCRIPTION
This should fix a bug in the coverage computation in older clang
versions (before LLVM 8) where the function signature is marked as
uncovered: clang instruments incorrectly marks it as code. That is:

    void foo(void) // <- this line is marked as uncovered code
    {
        return 0;
    }

See also
- <https://stackoverflow.com/q/31507084>
- <https://stackoverflow.com/q/47960954>
- <https://github.com/linux-test-project/lcov/issues/30>
