### PR TITLE
Add a few more tests

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2731,6 +2731,7 @@ UInt ReadEvalFile(Obj * evalResult)
 
     /* we now want to be at <end-of-file>                                  */
     if (rs->s.Symbol != S_EOF) {
+        FlushRestOfInputLine();
         SyntaxError(&rs->s, "<end-of-file> expected");
     }
 

--- a/tst/testinstall/compressed.tst
+++ b/tst/testinstall/compressed.tst
@@ -72,6 +72,8 @@ gap> stream := OutputTextFile( fname, false );;
 gap> PrintTo( stream, "1");
 gap> AppendTo( stream, "2");
 gap> PrintTo( stream, "3");
+gap> WriteLine(stream, "abc");
+true
 gap> CloseStream(stream);
 gap> stream;
 closed-stream
@@ -81,7 +83,7 @@ true
 # verify it
 gap> stream := InputTextFile( fname );;
 gap> ReadAll(stream);
-"123"
+"123abc\n"
 gap> CloseStream(stream);
 gap> stream;
 closed-stream
@@ -96,8 +98,8 @@ closed-stream
 
 # too long partial read
 gap> stream := InputTextFile( fname );;
-gap> ReadAll(stream, 5);
-"123"
+gap> ReadAll(stream, 10);
+"123abc\n"
 gap> CloseStream(stream);
 gap> stream;
 closed-stream
@@ -118,7 +120,7 @@ gap> CloseStream(stream);
 # verify it
 gap> stream := InputTextFile( fname );;
 gap> ReadAll(stream);
-"1234"
+"123abc\n4"
 gap> CloseStream(stream);
 gap> stream;
 closed-stream

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -65,6 +65,14 @@ rec("a":=1);
     ^^^
 
 #
+# ReadFactor
+#
+gap> 2^3^4;
+Syntax error: '^' is not associative in stream:1
+2^3^4;
+   ^
+
+#
 # ReadAtomic
 #
 gap> f := atomic function() end;;
@@ -204,6 +212,16 @@ local x; x := function(a) return a end;; return x(1);
 gap> f:={} -> ReadAsFunction(InputTextString("return 1"));;
 gap> f();
 Syntax error: ; expected in stream:1
+fail
+
+# empty body is not supported right now
+gap> ReadAsFunction(InputTextString(""));
+fail
+
+# check what happens if the function body ends earlier than
+# anticipated (FIXME: implement a better error message)
+gap> ReadAsFunction(InputTextString("return 1; end"));
+Syntax error: <end-of-file> expected in stream:1
 fail
 
 #

--- a/tst/testinstall/kernel/scanner.tst
+++ b/tst/testinstall/kernel/scanner.tst
@@ -4,6 +4,43 @@
 gap> START_TEST("kernel/scanner.tst");
 
 #
+#
+#
+gap> 	&;
+Syntax error: expression expected in stream:1
+	&;
+	^
+
+#
+# test weird things about GetIdent
+#
+
+#
+gap> x\ay := function() end;;
+gap> NameFunction(x\ay);
+"xay"
+
+#
+gap> x\ny := function() end;;
+gap> NameFunction(x\ny);
+"x\ny"
+
+#
+gap> x\ty := function() end;;
+gap> NameFunction(x\ty);
+"x\ty"
+
+#
+gap> x\ry := function() end;;
+gap> NameFunction(x\ry);
+"x\ry"
+
+#
+gap> x\by := function() end;;
+gap> NameFunction(x\by);
+"x\by"
+
+#
 # test long gvar names: at most 1023 chars are supported
 #
 gap> x1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111 := 1;
@@ -155,19 +192,20 @@ a.x111111111111111111111111111111111111111111111111111111111111111111111111111\
 #
 # test EOF inside a string literal
 #
-gap> EvalString("\"123");
+gap> Read(InputTextString("\"123"));
 Syntax error: String must end with " before end of file in stream:1
-Syntax error: ; expected in stream:1
-Error, Could not evaluate string.
-
-gap> EvalString("\"\"\"123");
+gap> Read(InputTextString("\"\"\"123"));
 Syntax error: String must end with """ before end of file in stream:1
-Syntax error: ; expected in stream:1
-Error, Could not evaluate string.
-
 gap> obj := """
 Syntax error: String must end with """ before end of file in stream:2
 Syntax error: ; expected in stream:2
+
+#
+# test EOF inside a pragma
+#
+gap> Read(InputTextString("#% pragma"));
+gap> Read(InputTextString("1 #% pragma"));
+gap> Read(InputTextString("1 #% pragma;"));
 
 #
 # cover some border cases in NextSymbol

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -14,6 +14,8 @@ gap> stream := OutputTextFile( fname, false );;
 gap> PrintTo( stream, "1");
 gap> AppendTo( stream, "2");
 gap> PrintTo( stream, "3");
+gap> WriteLine(stream, "abc");
+true
 gap> CloseStream(stream);
 gap> stream;
 closed-stream
@@ -21,7 +23,7 @@ closed-stream
 # verify it
 gap> stream := InputTextFile( fname );;
 gap> ReadAll(stream);
-"123"
+"123abc\n"
 gap> CloseStream(stream);
 gap> stream;
 closed-stream
@@ -36,8 +38,8 @@ closed-stream
 
 # too long partial read
 gap> stream := InputTextFile( fname );;
-gap> ReadAll(stream, 5);
-"123"
+gap> ReadAll(stream, 10);
+"123abc\n"
 gap> CloseStream(stream);
 gap> stream;
 closed-stream
@@ -58,7 +60,7 @@ gap> CloseStream(stream);
 # verify it
 gap> stream := InputTextFile( fname );;
 gap> ReadAll(stream);
-"1234"
+"123abc\n4"
 gap> CloseStream(stream);
 gap> stream;
 closed-stream


### PR DESCRIPTION
Also avoid garbage output in syntax error triggered by ReadAsFunction if
the input file ends the function body prematurely, i.e. by inserting an
`end` in the wrong place.
