### PR TITLE
Travis: investigate diskquota failures (DO NOT MERGE OR REVIEW)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,124 +33,124 @@ addons:
 matrix:
   include:
     # general test suite (subsumes testinstall tests, too)
-    - env: TEST_SUITES="docomp teststandard"
-
-    # the same in 32 bit mode, and with debugging turned off, to (a) make it
-    # a lot faster, and (b) to make sure nobody accidentally puts some vital
-    # computing into code that is only run when debugging is on.
-    - env: TEST_SUITES="docomp teststandard" ABI=32 CONFIGFLAGS=""
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-          - zlib1g-dev:i386
-
-    # HPC-GAP builds (for efficiency, we don't build all combinations)
-    - env: TEST_SUITES="docomp teststandard" ABI=64 HPCGAP=yes
-
-    # compile packages and run GAP tests
-    # don't use --enable-debug to prevent the tests from taking too long
-    - env: TEST_SUITES="testpackages testinstall-loadall" ABI=64
-      dist: bionic # avoid 'atexit' linker error in packages using C++ code
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev
-          - libreadline-dev
-          - zlib1g-dev
-          - libboost-dev            # for NormalizInterface
-          - libcdd-dev              # for CddInterface
-          - libmpfr-dev             # for float
-          - libmpfi-dev             # for float
-          - libmpc-dev              # for float
-          #- libfplll-dev           # for float
-          - pari-gp                 # for alnuth
-          - libzmq3-dev             # for ZeroMQInterface
-          - singular                # for IO_ForHomalg
-
-    # compile packages and run GAP tests in 32 bit mode
-    # it seems profiling is having trouble collecting the coverage data here, so we
-    # use NO_COVERAGE=1
-    - env: TEST_SUITES="testpackages testinstall-loadall" ABI=32 NO_COVERAGE=1 
-      dist: bionic # avoid 'atexit' linker error in packages using C++ code
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-          - zlib1g-dev:i386
-          - libncurses5-dev:i386    # for Browse
-          - libcurl4-openssl-dev:i386 # for curlInterface
-          - libboost-dev:i386       # for NormalizInterface
-          - libcdd-dev:i386         # for CddInterface
-          - libmpfr-dev:i386        # for float
-          - libmpfi-dev:i386        # for float
-          - libmpc-dev:i386         # for float
-          #- libfplll-dev:i386      # for float
-          - pari-gp:i386            # for alnuth
-          - libzmq3-dev:i386        # for ZeroMQInterface
-          - singular:i386           # for IO_ForHomalg
-
-    # OS X builds: since those are slow and limited on Travis, we only run testinstall
-    - env: TEST_SUITES="docomp testinstall testspecial test-compile testlibgap testkernel"
-      os: osx
-      osx_image: xcode11.4
-
-    # test creating the manual
-    - env: TEST_SUITES=makemanuals
-      addons:
-        apt_packages:
-          - texlive-latex-base
-          - texlive-latex-recommended
-          - texlive-latex-extra
-          - texlive-extra-utils
-          - texlive-fonts-recommended
-          - texlive-fonts-extra
-
-    # run tests contained in the manual
-    - env: TEST_SUITES=testmanuals
-
-    # run bugfix regression tests
-    # Also Turn on '--enable-memory-checking' to make sure GAP compiles with the flag enabled.
-    # We do not actually test the memory checking, as this slows down GAP too much.
-    - env: TEST_SUITES=testbugfix CONFIGFLAGS="--enable-memory-checking"
-
-    # out of tree builds -- these are mainly done to verify that the build
-    # system work in this scenario. Since we don't expect the test results to
-    # vary compared to the in-tree builds, we turn off coverage reporting by
-    # setting NO_COVERAGE=1; this has the extra benefit of also running the
-    # tests at least once with the ReproducibleBehaviour option turned off.
-    #
-    # The '--enable-valgrind' checks that GAP builds and runs correctly when
-    # compiled with valgrind support. We do not actually run any tests using
-    # valgrind, as it is too slow.
-    #
-    # Also change the compiler to GCC 4.7, to ensure we stay compatible
-    # with that older version.
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-valgrind CC=gcc-4.7 CXX=g++-4.7"
-      addons:
-        apt_packages:
-          - gcc-4.7
-          - g++-4.7
-          - valgrind
-
-    # same as above, but in 32 bit mode, also turn off debugging (see elsewhere in this file for
-    # an explanation).
-    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS=""
-      addons:
-        apt_packages:
-          - gcc-multilib
-          - g++-multilib
-          #- libgmp-dev:i386    # do not install GMP, to test that GAP can build its own
-          #- libreadline-dev:i386  # do not install readline, to test that GAP can be compiled and run without it
-          #- zlib1g-dev::i386   # do not install zlib, to test that GAP can build its own
-
-    # test error reporting and compiling as well as libgap
-    - env: TEST_SUITES="testspecial test-compile testlibgap testkernel"
+#    - env: TEST_SUITES="docomp teststandard"
+#
+#    # the same in 32 bit mode, and with debugging turned off, to (a) make it
+#    # a lot faster, and (b) to make sure nobody accidentally puts some vital
+#    # computing into code that is only run when debugging is on.
+#    - env: TEST_SUITES="docomp teststandard" ABI=32 CONFIGFLAGS=""
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev:i386
+#          - libreadline-dev:i386
+#          - zlib1g-dev:i386
+#
+#    # HPC-GAP builds (for efficiency, we don't build all combinations)
+#    - env: TEST_SUITES="docomp teststandard" ABI=64 HPCGAP=yes
+#
+#    # compile packages and run GAP tests
+#    # don't use --enable-debug to prevent the tests from taking too long
+#    - env: TEST_SUITES="testpackages testinstall-loadall" ABI=64
+#      dist: bionic # avoid 'atexit' linker error in packages using C++ code
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev
+#          - libreadline-dev
+#          - zlib1g-dev
+#          - libboost-dev            # for NormalizInterface
+#          - libcdd-dev              # for CddInterface
+#          - libmpfr-dev             # for float
+#          - libmpfi-dev             # for float
+#          - libmpc-dev              # for float
+#          #- libfplll-dev           # for float
+#          - pari-gp                 # for alnuth
+#          - libzmq3-dev             # for ZeroMQInterface
+#          - singular                # for IO_ForHomalg
+#
+#    # compile packages and run GAP tests in 32 bit mode
+#    # it seems profiling is having trouble collecting the coverage data here, so we
+#    # use NO_COVERAGE=1
+#    - env: TEST_SUITES="testpackages testinstall-loadall" ABI=32 NO_COVERAGE=1 
+#      dist: bionic # avoid 'atexit' linker error in packages using C++ code
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          - libgmp-dev:i386
+#          - libreadline-dev:i386
+#          - zlib1g-dev:i386
+#          - libncurses5-dev:i386    # for Browse
+#          - libcurl4-openssl-dev:i386 # for curlInterface
+#          - libboost-dev:i386       # for NormalizInterface
+#          - libcdd-dev:i386         # for CddInterface
+#          - libmpfr-dev:i386        # for float
+#          - libmpfi-dev:i386        # for float
+#          - libmpc-dev:i386         # for float
+#          #- libfplll-dev:i386      # for float
+#          - pari-gp:i386            # for alnuth
+#          - libzmq3-dev:i386        # for ZeroMQInterface
+#          - singular:i386           # for IO_ForHomalg
+#
+#    # OS X builds: since those are slow and limited on Travis, we only run testinstall
+#    - env: TEST_SUITES="docomp testinstall testspecial test-compile testlibgap testkernel"
+#      os: osx
+#      osx_image: xcode11.4
+#
+#    # test creating the manual
+#    - env: TEST_SUITES=makemanuals
+#      addons:
+#        apt_packages:
+#          - texlive-latex-base
+#          - texlive-latex-recommended
+#          - texlive-latex-extra
+#          - texlive-extra-utils
+#          - texlive-fonts-recommended
+#          - texlive-fonts-extra
+#
+#    # run tests contained in the manual
+#    - env: TEST_SUITES=testmanuals
+#
+#    # run bugfix regression tests
+#    # Also Turn on '--enable-memory-checking' to make sure GAP compiles with the flag enabled.
+#    # We do not actually test the memory checking, as this slows down GAP too much.
+#    - env: TEST_SUITES=testbugfix CONFIGFLAGS="--enable-memory-checking"
+#
+#    # out of tree builds -- these are mainly done to verify that the build
+#    # system work in this scenario. Since we don't expect the test results to
+#    # vary compared to the in-tree builds, we turn off coverage reporting by
+#    # setting NO_COVERAGE=1; this has the extra benefit of also running the
+#    # tests at least once with the ReproducibleBehaviour option turned off.
+#    #
+#    # The '--enable-valgrind' checks that GAP builds and runs correctly when
+#    # compiled with valgrind support. We do not actually run any tests using
+#    # valgrind, as it is too slow.
+#    #
+#    # Also change the compiler to GCC 4.7, to ensure we stay compatible
+#    # with that older version.
+#    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=64 BUILDDIR=build CONFIGFLAGS="--enable-valgrind CC=gcc-4.7 CXX=g++-4.7"
+#      addons:
+#        apt_packages:
+#          - gcc-4.7
+#          - g++-4.7
+#          - valgrind
+#
+#    # same as above, but in 32 bit mode, also turn off debugging (see elsewhere in this file for
+#    # an explanation).
+#    - env: TEST_SUITES="docomp testinstall" NO_COVERAGE=1 ABI=32 BUILDDIR=build CONFIGFLAGS=""
+#      addons:
+#        apt_packages:
+#          - gcc-multilib
+#          - g++-multilib
+#          #- libgmp-dev:i386    # do not install GMP, to test that GAP can build its own
+#          #- libreadline-dev:i386  # do not install readline, to test that GAP can be compiled and run without it
+#          #- zlib1g-dev::i386   # do not install zlib, to test that GAP can build its own
+#
+#    # test error reporting and compiling as well as libgap
+#    - env: TEST_SUITES="testspecial test-compile testlibgap testkernel"
 
     # test Julia integration
     - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,9 @@ matrix:
 
     # test Julia integration
     - env: TEST_SUITES="testinstall" JULIA=yes CONFIGFLAGS="--disable-Werror"
+      before_install:
+        - df -a
+        - ls -al /tmp
 
     # build on non-x86 platform
     - env: TEST_SUITES="docomp testinstall"
@@ -162,11 +165,16 @@ matrix:
       before_install:
         # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
         - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+        - df -a
+        - ls -al /tmp
 
     # build on non-x86 platform
     - env: TEST_SUITES="docomp testinstall"
       arch: ppc64le
       dist: bionic
+      before_install:
+        - df -a
+        - ls -al /tmp
 
     # build on non-x86 platform; big endian!
     - env: TEST_SUITES="docomp testinstall"
@@ -175,6 +183,8 @@ matrix:
       before_install:
         # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
         - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+        - df -a
+        - ls -al /tmp
 
 # use travis_terminate below to ensure travis immediately aborts upon error,
 # and also to work around timeouts (see https://travis-ci.community/t/7659)

--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -55,7 +55,12 @@ then
     git clone https://github.com/gap-packages/io "$SRCDIR/pkg/io"
     git clone https://github.com/gap-packages/profiling "$SRCDIR/pkg/profiling"
 else
-    make bootstrap-pkg-full DOWNLOAD="$DOWNLOAD"
+    if ! make bootstrap-pkg-full DOWNLOAD="$DOWNLOAD"
+    then
+      df
+      ls -l /tmp
+      exit 1
+    fi
 fi
 
 # check that GAP is at least able to start


### PR DESCRIPTION
See also https://travis-ci.community/t/s390x-adding-apt-sources-no-usable-temporary-directory-found-tmp-enospc/8635/2

Perhaps we can figure out the source of the disk being full and implement a counter; that would help us avoid the barrage of temporary failures of the ppc64le/arm64/s390x failures on Travis.