### PR TITLE
turn the package name to lowercase

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1193,6 +1193,7 @@ InstallGlobalFunction( DirectoriesPackagePrograms, function( name )
 
     # We are not allowed to call
     # `InstalledPackageVersion', `TestPackageAvailability' etc.
+    name:= LowercaseString( name );
     info:= PackageInfo( name );
     if IsBound( GAPInfo.PackagesLoaded.( name ) ) then
       # The package is already loaded.


### PR DESCRIPTION
`DirectoriesPackagePrograms( <name> )` wants to check
whether the package `<name>` is already available,
but it does not make sure that `<name>` is in lowercase.
Thus the package may be erroneously regarded as not yet loaded,
and if several versions of the package are installed
then the path for the highest such version is taken,
which may be wrong.