### PR TITLE
kernel: add SELF_NAME, use SELF_NAME in RequireFOO calls where possible

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -1068,7 +1068,7 @@ static Obj FiltIS_BLIST_REP(Obj self, Obj obj)
 */
 static Obj FuncSIZE_BLIST(Obj self, Obj blist)
 {
-    RequireBlist("SizeBlist", blist);
+    RequireBlist(SELF_NAME, blist);
     return INTOBJ_INT(SizeBlist(blist));
 }
 
@@ -1094,8 +1094,8 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub);
 
 static Obj FuncBLIST_LIST(Obj self, Obj list, Obj sub)
 {
-    RequireSmallList("BlistList", list);
-    RequireSmallList("BlistList", sub);
+    RequireSmallList(SELF_NAME, list);
+    RequireSmallList(SELF_NAME, sub);
 
     Int lenList = LEN_LIST( list );
     Obj blist = NewBag( T_BLIST, SIZE_PLEN_BLIST( lenList ) );
@@ -1129,9 +1129,9 @@ static Obj FuncLIST_BLIST(Obj self, Obj list, Obj blist)
     UInt                nn;
     UInt                i;              /* loop variable                   */
 
-    RequireSmallList("ListBlist", list);
-    RequireBlist("ListBlist", blist);
-    RequireSameLength("ListBlist", blist, list);
+    RequireSmallList(SELF_NAME, list);
+    RequireBlist(SELF_NAME, blist);
+    RequireSameLength(SELF_NAME, blist, list);
 
     /* compute the number of 'true'-s                                      */
     n = SizeBlist(blist);
@@ -1171,7 +1171,7 @@ static Obj FuncPositionNthTrueBlist(
     const UInt *        ptr;
 
     /* Check the arguments. */
-    RequireBlist("ListBlist", blist);
+    RequireBlist(SELF_NAME, blist);
     Int nth = GetPositiveSmallIntEx("Position", Nth, "<nth>");
 
     nrb = NUMBER_BLOCKS_BLIST(blist);
@@ -1216,9 +1216,9 @@ static Obj FuncIS_SUB_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    RequireBlist("IsSubsetBlist", blist1);
-    RequireBlist("IsSubsetBlist", blist2);
-    RequireSameLength("IsSubsetBlist", blist1, blist2);
+    RequireBlist(SELF_NAME, blist1);
+    RequireBlist(SELF_NAME, blist2);
+    RequireSameLength(SELF_NAME, blist1, blist2);
 
     /* test for subset property blockwise                                  */
     ptr1 = CONST_BLOCKS_BLIST(blist1);
@@ -1253,10 +1253,10 @@ static Obj FuncUNITE_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    RequireBlist("UniteBlist", blist1);
-    RequireMutable("UniteBlist", blist1, "boolean list");
-    RequireBlist("UniteBlist", blist2);
-    RequireSameLength("UniteBlist", blist1, blist2);
+    RequireBlist(SELF_NAME, blist1);
+    RequireMutable(SELF_NAME, blist1, "boolean list");
+    RequireBlist(SELF_NAME, blist2);
+    RequireSameLength(SELF_NAME, blist1, blist2);
 
     /* compute the union by *or*-ing blockwise                             */
     ptr1 = BLOCKS_BLIST(blist1);
@@ -1291,11 +1291,11 @@ static Obj FuncUNITE_BLIST_LIST(Obj self, Obj list, Obj blist, Obj sub)
     Int                 i, j, k, l;     /* loop variables                  */
     Int                 s, t;           /* elements of a range             */
 
-    RequireSmallList("UniteBlistList", list);
-    RequireBlist("UniteBlistList", blist);
-    RequireMutable("UniteBlistList", blist, "boolean list");
-    RequireSameLength("UniteBlistList", blist, list);
-    RequireSmallList("UniteBlistList", sub);
+    RequireSmallList(SELF_NAME, list);
+    RequireBlist(SELF_NAME, blist);
+    RequireMutable(SELF_NAME, blist, "boolean list");
+    RequireSameLength(SELF_NAME, blist, list);
+    RequireSmallList(SELF_NAME, sub);
 
     lenList  = LEN_LIST( list );
     lenSub   = LEN_LIST( sub );
@@ -1502,10 +1502,10 @@ static Obj FuncINTER_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    RequireBlist("IntersectBlist", blist1);
-    RequireMutable("IntersectBlist", blist1, "boolean list");
-    RequireBlist("IntersectBlist", blist2);
-    RequireSameLength("IntersectBlist", blist1, blist2);
+    RequireBlist(SELF_NAME, blist1);
+    RequireMutable(SELF_NAME, blist1, "boolean list");
+    RequireBlist(SELF_NAME, blist2);
+    RequireSameLength(SELF_NAME, blist1, blist2);
 
     /* compute the intersection by *and*-ing blockwise                     */
     ptr1 = BLOCKS_BLIST(blist1);
@@ -1535,10 +1535,10 @@ static Obj FuncSUBTR_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    RequireBlist("SubtractBlist", blist1);
-    RequireMutable("SubtractBlist", blist1, "boolean list");
-    RequireBlist("SubtractBlist", blist2);
-    RequireSameLength("SubtractBlist", blist1, blist2);
+    RequireBlist(SELF_NAME, blist1);
+    RequireMutable(SELF_NAME, blist1, "boolean list");
+    RequireBlist(SELF_NAME, blist2);
+    RequireSameLength(SELF_NAME, blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
     ptr1 = BLOCKS_BLIST(blist1);
@@ -1569,9 +1569,9 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
     const UInt *        ptr2;           /* pointer to the second argument  */
     UInt                i;              /* loop variable                   */
 
-    RequireBlist("MeetBlist", blist1);
-    RequireBlist("MeetBlist", blist2);
-    RequireSameLength("MeetBlist", blist1, blist2);
+    RequireBlist(SELF_NAME, blist1);
+    RequireBlist(SELF_NAME, blist2);
+    RequireSameLength(SELF_NAME, blist1, blist2);
 
     /* compute the difference by operating blockwise                       */
     ptr1 = CONST_BLOCKS_BLIST(blist1);
@@ -1596,8 +1596,8 @@ static Obj FuncMEET_BLIST(Obj self, Obj blist1, Obj blist2)
 
 static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 {
-    RequireBlist("FlipBlist", blist);
-    RequireMutable("FlipBlist", blist, "boolean list");
+    RequireBlist(SELF_NAME, blist);
+    RequireMutable(SELF_NAME, blist, "boolean list");
 
     if (LEN_BLIST(blist) == 0) {
         return 0;
@@ -1630,8 +1630,8 @@ static Obj FuncFLIP_BLIST(Obj self, Obj blist)
 
 static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 {
-    RequireBlist("ClearAllBitsBlist", blist);
-    RequireMutable("ClearAllBitsBlist", blist, "boolean list");
+    RequireBlist(SELF_NAME, blist);
+    RequireMutable(SELF_NAME, blist, "boolean list");
 
     if (LEN_BLIST(blist) == 0) {
         return 0;
@@ -1658,8 +1658,8 @@ static Obj FuncCLEAR_ALL_BLIST(Obj self, Obj blist)
 
 static Obj FuncSET_ALL_BLIST(Obj self, Obj blist)
 {
-    RequireBlist("SetAllBitsBlist", blist);
-    RequireMutable("SetAllBitsBlist", blist, "boolean list");
+    RequireBlist(SELF_NAME, blist);
+    RequireMutable(SELF_NAME, blist, "boolean list");
 
     if (LEN_BLIST(blist) == 0) {
         return 0;

--- a/src/calls.c
+++ b/src/calls.c
@@ -1196,13 +1196,13 @@ Obj CallFuncList ( Obj func, Obj list )
 
 static Obj FuncCALL_FUNC_LIST(Obj self, Obj func, Obj list)
 {
-    RequireSmallList("CallFuncList", list);
+    RequireSmallList(SELF_NAME, list);
     return CallFuncList(func, list);
 }
 
 static Obj FuncCALL_FUNC_LIST_WRAP(Obj self, Obj func, Obj list)
 {
-    RequireSmallList("CallFuncListWrap", list);
+    RequireSmallList(SELF_NAME, list);
     Obj retval = CallFuncList(func, list);
     return (retval == 0) ? NewImmutableEmptyPlist()
                          : NewPlistFromArgs(retval);
@@ -1240,7 +1240,7 @@ static Obj AttrNAME_FUNC(Obj self, Obj func)
 
 static Obj FuncSET_NAME_FUNC(Obj self, Obj func, Obj name)
 {
-    RequireStringRep("SET_NAME_FUNC", name);
+    RequireStringRep(SELF_NAME, name);
 
   if (TNUM_OBJ(func) == T_FUNCTION ) {
     SET_NAME_FUNC(func, ImmutableString(name));
@@ -1345,7 +1345,7 @@ static Obj FuncCLEAR_PROFILE_FUNC(Obj self, Obj func)
 {
     Obj                 prof;
 
-    RequireFunction("CLEAR_PROFILE_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     /* clear profile info                                                  */
     prof = PROF_FUNC(func);
@@ -1377,7 +1377,7 @@ static Obj FuncPROFILE_FUNC(Obj self, Obj func)
     Obj                 prof;
     Obj                 copy;
 
-    RequireFunction("PROFILE_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     /* uninstall trace handler                                             */
     ChangeDoOperations( func, 0 );
@@ -1423,13 +1423,13 @@ static Obj FuncPROFILE_FUNC(Obj self, Obj func)
 */
 static Obj FuncIS_PROFILED_FUNC(Obj self, Obj func)
 {
-    RequireFunction("IS_PROFILED_FUNC", func);
+    RequireFunction(SELF_NAME, func);
     return ( TNUM_OBJ(PROF_FUNC(func)) != T_FUNCTION ) ? False : True;
 }
 
 static Obj FuncFILENAME_FUNC(Obj self, Obj func)
 {
-    RequireFunction("FILENAME_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     if (BODY_FUNC(func)) {
         Obj fn =  GET_FILENAME_BODY(BODY_FUNC(func));
@@ -1441,7 +1441,7 @@ static Obj FuncFILENAME_FUNC(Obj self, Obj func)
 
 static Obj FuncSTARTLINE_FUNC(Obj self, Obj func)
 {
-    RequireFunction("STARTLINE_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     if (BODY_FUNC(func)) {
         UInt sl = GET_STARTLINE_BODY(BODY_FUNC(func));
@@ -1453,7 +1453,7 @@ static Obj FuncSTARTLINE_FUNC(Obj self, Obj func)
 
 static Obj FuncENDLINE_FUNC(Obj self, Obj func)
 {
-    RequireFunction("ENDLINE_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     if (BODY_FUNC(func)) {
         UInt el = GET_ENDLINE_BODY(BODY_FUNC(func));
@@ -1465,7 +1465,7 @@ static Obj FuncENDLINE_FUNC(Obj self, Obj func)
 
 static Obj FuncLOCATION_FUNC(Obj self, Obj func)
 {
-    RequireFunction("LOCATION_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     if (BODY_FUNC(func)) {
         Obj sl = GET_LOCATION_BODY(BODY_FUNC(func));
@@ -1483,7 +1483,7 @@ static Obj FuncUNPROFILE_FUNC(Obj self, Obj func)
 {
     Obj                 prof;
 
-    RequireFunction("UNPROFILE_FUNC", func);
+    RequireFunction(SELF_NAME, func);
 
     /* uninstall trace handler                                             */
     ChangeDoOperations( func, 0 );
@@ -1526,7 +1526,7 @@ BOOL IsKernelFunction(Obj func)
 /* Returns a measure of the size of a GAP function */
 static Obj FuncFUNC_BODY_SIZE(Obj self, Obj func)
 {
-    RequireFunction("FUNC_BODY_SIZE", func);
+    RequireFunction(SELF_NAME, func);
     Obj body = BODY_FUNC(func);
     if (body == 0)
         return INTOBJ_INT(0);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5403,11 +5403,11 @@ static Obj FuncCOMPILE_FUNC(Obj self, Obj arg)
     magic1 = ELM_LIST( arg, 4 );
     magic2 = ELM_LIST( arg, 5 );
 
-    RequireStringRep("CompileFunc", output);
-    RequireFunction("CompileFunc", func);
-    RequireStringRep("CompileFunc", name);
-    RequireSmallInt("CompileFunc", magic1);
-    RequireStringRep("CompileFunc", magic2);
+    RequireStringRep(SELF_NAME, output);
+    RequireFunction(SELF_NAME, func);
+    RequireStringRep(SELF_NAME, name);
+    RequireSmallInt(SELF_NAME, magic1);
+    RequireStringRep(SELF_NAME, magic2);
 
     /* possible optimiser flags                                            */
     CompFastIntArith        = 1;

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1620,7 +1620,7 @@ static Obj AttrCONDUCTOR(Obj self, Obj cyc)
     }
 
     if (!IS_CYC(cyc) && !IS_SMALL_LIST(cyc)) {
-        RequireArgument("Conductor", cyc,
+        RequireArgument(SELF_NAME, cyc,
                         "must be a cyclotomic or a small list");
     }
 
@@ -1690,7 +1690,7 @@ static Obj FuncCOEFFS_CYC(Obj self, Obj cyc)
     }
 
     if (!IS_CYC(cyc)) {
-        RequireArgument("COEFFSCYC", cyc, "must be a cyclotomic");
+        RequireArgument(SELF_NAME, cyc, "must be a cyclotomic");
     }
 
     /* if <cyc> is rational just put it in a list of length 1              */
@@ -1908,7 +1908,7 @@ static Obj FuncCycList(Obj self, Obj list)
     }
 
     if ( ! IS_PLIST( list ) || ! IS_DENSE_LIST( list ) ) {
-        RequireArgument("CycList", list, "must be a dense plain list");
+        RequireArgument(SELF_NAME, list, "must be a dense plain list");
     }
 
     /* enlarge the buffer if necessary                                     */
@@ -1923,7 +1923,7 @@ static Obj FuncCycList(Obj self, Obj list)
             // reset ResultCyc, otherwise the next operation using it will see
             // our left-over garbage data
             SET_LEN_PLIST( ResultCyc, 0 );
-            RequireArgumentEx("CycList", val, 0,
+            RequireArgumentEx(SELF_NAME, val, 0,
                               "each entry must be a rational");
         }
         res[i] = val;

--- a/src/error.c
+++ b/src/error.c
@@ -555,6 +555,12 @@ void RequireArgumentEx(const char * funcname,
     ErrorMayQuit(msgbuf, arg1, 0);
 }
 
+const char * SELF_NAME_HELPER(Obj self, const char * func)
+{
+    if (self && NAME_FUNC(self))
+        return CONST_CSTR_STRING(NAME_FUNC(self));
+    return func;
+}
 
 void ErrorBoundedInt(
     const char * funcname, Obj op, const char * argname, int min, int max)

--- a/src/error.h
+++ b/src/error.h
@@ -94,6 +94,9 @@ void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);
 **
 **  If funcname is 0, then 'funcname: ' is omitted from the message.
 **  If argname is 0, then '<argname> ' is omitted from the message.
+**
+**  All string arguments are copied to a buffer before a garbage collection
+**  may be triggered, hence it is safe to pass pointers into string objects.
 */
 void RequireArgumentEx(const char * funcname,
                        Obj          op,
@@ -101,6 +104,13 @@ void RequireArgumentEx(const char * funcname,
                        const char * msg) NORETURN;
 
 #define NICE_ARGNAME(op) "<" #op ">"
+
+/****************************************************************************
+**
+*F  SELF_NAME
+*/
+#define SELF_NAME SELF_NAME_HELPER(self, __func__)
+const char * SELF_NAME_HELPER(Obj self, const char * func);
 
 /****************************************************************************
 **

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1424,13 +1424,13 @@ static Obj FuncZ(Obj self, Obj q)
       return CALL_1ARGS(ZOp, q);
     
     if ( !IS_INTOBJ(q) || INT_INTOBJ(q)<=1 ) {
-        RequireArgument("Z", q, "must be a positive prime power");
+        RequireArgument(SELF_NAME, q, "must be a positive prime power");
     }
 
     ff = FiniteFieldBySize(INT_INTOBJ(q));
 
     if (!ff) {
-        RequireArgument("Z", q, "must be a positive prime power");
+        RequireArgument(SELF_NAME, q, "must be a positive prime power");
     }
 
     /* make the root                                                       */
@@ -1455,7 +1455,7 @@ static Obj FuncZ2(Obj self, Obj p, Obj d)
                 ff = FiniteField(ip, id);
 
                 if (ff == 0 || CHAR_FF(ff) != ip)
-                    RequireArgument("Z", p, "must be a prime");
+                    RequireArgument(SELF_NAME, p, "must be a prime");
 
                 /* make the root */
                 return NEW_FFE(ff, (ip == 2 && id == 1 ? 1 : 2));

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -778,8 +778,8 @@ static void PrintFunccallOpts(Expr call)
 static Obj FuncSetRecursionTrapInterval(Obj self, Obj interval)
 {
     if (!IS_INTOBJ(interval) || INT_INTOBJ(interval) <= 5)
-        RequireArgument("SetRecursionTrapInterval", interval,
-            "must be a small integer greater than 5");
+        RequireArgument(SELF_NAME, interval,
+                        "must be a small integer greater than 5");
     RecursionTrapInterval = INT_INTOBJ(interval);
     return 0;
 }

--- a/src/gap.c
+++ b/src/gap.c
@@ -357,13 +357,13 @@ static Obj FuncSHELL(Obj self, Obj args)
   
   context = ELM_PLIST(args,1);
   if (!IS_LVARS_OR_HVARS(context))
-    RequireArgument("SHELL", context, "must be a local variables bag");
+    RequireArgument(SELF_NAME, context, "must be a local variables bag");
   
   canReturnVoid = ELM_PLIST(args, 2);
-  RequireTrueOrFalse("SHELL", canReturnVoid);
+  RequireTrueOrFalse(SELF_NAME, canReturnVoid);
 
   canReturnObj = ELM_PLIST(args, 3);
-  RequireTrueOrFalse("SHELL", canReturnObj);
+  RequireTrueOrFalse(SELF_NAME, canReturnObj);
 
   lastDepth = GetSmallIntEx("SHELL", ELM_PLIST(args,4), "lastDepth");
   if (lastDepth < 0 )
@@ -378,10 +378,10 @@ static Obj FuncSHELL(Obj self, Obj args)
     }
 
   setTime = ELM_PLIST(args, 5);
-  RequireTrueOrFalse("SHELL", setTime);
+  RequireTrueOrFalse(SELF_NAME, setTime);
 
   prompt = ELM_PLIST(args,6);
-  RequireStringRep("SHELL", prompt);
+  RequireStringRep(SELF_NAME, prompt);
   if (GET_LEN_STRING(prompt) > 80)
     ErrorMayQuit("SHELL: <prompt> must be a string of length at most 80", 0, 0);
   promptBuffer[0] = '\0';
@@ -392,16 +392,16 @@ static Obj FuncSHELL(Obj self, Obj args)
   if (preCommandHook == False)
     preCommandHook = 0;
   else if (!IS_FUNC(preCommandHook))
-    RequireArgument("SHELL", preCommandHook, "must be function or false");
+    RequireArgument(SELF_NAME, preCommandHook, "must be function or false");
   
   infile = ELM_PLIST(args,8);
-  RequireStringRep("SHELL", infile);
+  RequireStringRep(SELF_NAME, infile);
 
   outfile = ELM_PLIST(args,9);
-  RequireStringRep("SHELL", outfile);
+  RequireStringRep(SELF_NAME, outfile);
 
   catchQUIT = ELM_PLIST(args, 10);
-  RequireTrueOrFalse("SHELL", catchQUIT);
+  RequireTrueOrFalse(SELF_NAME, catchQUIT);
 
   res = Shell(context, canReturnVoid == True, canReturnObj == True,
               lastDepth, setTime == True, promptBuffer, preCommandHook,
@@ -513,7 +513,7 @@ static Obj FuncSizeScreen(Obj self, Obj args)
   UInt                len;            /* length of lines on the screen   */
   UInt                nr;             /* number of lines on the screen   */
 
-  RequireSmallList("SizeScreen", args);
+  RequireSmallList(SELF_NAME, args);
   if (1 < LEN_LIST(args)) {
       ErrorMayQuit("SizeScreen: number of arguments must be 0 or 1 (not %d)",
                    LEN_LIST(args), 0);
@@ -592,10 +592,10 @@ static Obj FuncWindowCmd(Obj self, Obj args)
   const Char *    inptr;
   const Char *    qtr;
 
-  RequireSmallList("WindowCmd", args);
+  RequireSmallList(SELF_NAME, args);
   tmp = ELM_LIST(args, 1);
   if (!IsStringConv(tmp)) {
-      RequireArgumentEx("WindowCmd", tmp, "<cmd>", "must be a string");
+      RequireArgumentEx(SELF_NAME, tmp, "<cmd>", "must be a string");
   }
     if ( 3 != LEN_LIST(tmp) ) {
         ErrorMayQuit("WindowCmd: <cmd> must be a string of length 3", 0, 0);
@@ -732,7 +732,7 @@ static Obj FuncGASMAN(Obj self, Obj args)
 
         /* evaluate and check the command                                  */
         Obj cmd = ELM_PLIST( args, i );
-        RequireStringRep("GASMAN", cmd);
+        RequireStringRep(SELF_NAME, cmd);
 
         // perform full garbage collection
         if ( strcmp( CONST_CSTR_STRING(cmd), "collect" ) == 0 ) {
@@ -943,8 +943,7 @@ static Obj FuncTNAM_OBJ(Obj self, Obj obj)
 static Obj FuncOBJ_HANDLE(Obj self, Obj handle)
 {
     if (handle != INTOBJ_INT(0) && !IS_POS_INT(handle))
-        RequireArgument("OBJ_HANDLE", handle,
-                        "must be a non-negative integer");
+        RequireArgument(SELF_NAME, handle, "must be a non-negative integer");
     return (Obj)UInt_ObjInt(handle);
 }
 
@@ -1232,7 +1231,7 @@ void UpdateTime(UInt startTime)
 // usual.
 static Obj FuncUPDATE_STAT(Obj self, Obj name, Obj newStat)
 {
-    RequireStringRep("UPDATE_STAT", name);
+    RequireStringRep(SELF_NAME, name);
 
     const char * cname = CONST_CSTR_STRING(name);
     if (strcmp(cname, "time") == 0) {
@@ -1259,7 +1258,7 @@ static Obj FuncUPDATE_STAT(Obj self, Obj name, Obj newStat)
 
 static Obj FuncSetAssertionLevel(Obj self, Obj level)
 {
-    RequireNonnegativeSmallInt("SetAssertionLevel", level);
+    RequireNonnegativeSmallInt(SELF_NAME, level);
     STATE(CurrentAssertionLevel) = INT_INTOBJ(level);
     return 0;
 }

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -585,7 +585,7 @@ Obj             ValGVarTL (
 
 static Obj FuncIsThreadLocalGVar(Obj self, Obj name)
 {
-    RequireStringRep("IsThreadLocalGVar", name);
+    RequireStringRep(SELF_NAME, name);
 
   UInt gvar = GVarName(CONST_CSTR_STRING(name));
   return (VAL_GVAR_INTERN(gvar) == 0 && IS_INTOBJ(ExprGVar(gvar))) ?
@@ -853,8 +853,8 @@ Obj FuncDeclareGlobalName(Obj self, Obj name)
 **  must be a GAP string) read only.
 */
 static Obj FuncMakeReadOnlyGVar(Obj self, Obj name)
-{       
-    RequireStringRep("MakeReadOnlyGVar", name);
+{
+    RequireStringRep(SELF_NAME, name);
     MakeReadOnlyGVar(GVarName(CONST_CSTR_STRING(name)));
     return 0;
 }
@@ -872,7 +872,7 @@ static Obj FuncMakeReadOnlyGVar(Obj self, Obj name)
 */
 static Obj FuncMakeConstantGVar(Obj self, Obj name)
 {
-    RequireStringRep("MakeConstantGVar", name);
+    RequireStringRep(SELF_NAME, name);
     MakeConstantGVar(GVarName(CONST_CSTR_STRING(name)));
     return 0;
 }
@@ -904,7 +904,7 @@ void MakeReadWriteGVar (
 */
 static Obj FuncMakeReadWriteGVar(Obj self, Obj name)
 {
-    RequireStringRep("MakeReadWriteGVar", name);
+    RequireStringRep(SELF_NAME, name);
     MakeReadWriteGVar(GVarName(CONST_CSTR_STRING(name)));
     return 0;
 }
@@ -928,7 +928,7 @@ static Obj FuncIsReadOnlyGVar (
     Obj                 self,
     Obj                 name )
 {
-    RequireStringRep("IsReadOnlyGVar", name);
+    RequireStringRep(SELF_NAME, name);
     return IsReadOnlyGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
 }
 
@@ -949,7 +949,7 @@ BOOL IsConstantGVar(UInt gvar)
 
 static Obj FuncIsConstantGVar(Obj self, Obj name)
 {
-    RequireStringRep("IsConstantGVar", name);
+    RequireStringRep(SELF_NAME, name);
     return IsConstantGVar(GVarName(CONST_CSTR_STRING(name))) ? True : False;
 }
 
@@ -980,7 +980,7 @@ static Obj FuncAUTO(Obj self, Obj args)
 
     /* get and check the function                                          */
     func = ELM_LIST( args, 1 );
-    RequireFunction("AUTO", func);
+    RequireFunction(SELF_NAME, func);
 
     /* get the argument                                                    */
     arg = ELM_LIST( args, 2 );
@@ -991,7 +991,7 @@ static Obj FuncAUTO(Obj self, Obj args)
     /* make the global variables automatic                                 */
     for ( i = 3; i <= LEN_LIST(args); i++ ) {
         name = ELM_LIST( args, i );
-        RequireStringRep("AUTO", name);
+        RequireStringRep(SELF_NAME, name);
         gvar = GVarName( CONST_CSTR_STRING(name) );
         SET_ELM_GVAR_LIST( ValGVars, gvar, 0 );
         SET_ELM_GVAR_LIST( ExprGVars, gvar, list );
@@ -1127,7 +1127,7 @@ static Obj FuncIDENTS_BOUND_GVARS(Obj self)
 */
 static Obj FuncASS_GVAR(Obj self, Obj gvar, Obj val)
 {
-    RequireStringRep("ASS_GVAR", gvar);
+    RequireStringRep(SELF_NAME, gvar);
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), val );
     return 0;
 }
@@ -1139,7 +1139,7 @@ static Obj FuncASS_GVAR(Obj self, Obj gvar, Obj val)
 */
 static Obj FuncISB_GVAR(Obj self, Obj gvar)
 {
-    RequireStringRep("ISB_GVAR", gvar);
+    RequireStringRep(SELF_NAME, gvar);
 
     UInt gv = GVarName( CONST_CSTR_STRING(gvar) );
     if (VAL_GVAR_INTERN(gv))
@@ -1163,7 +1163,7 @@ static Obj FuncISB_GVAR(Obj self, Obj gvar)
 
 static Obj FuncIS_AUTO_GVAR(Obj self, Obj gvar)
 {
-    RequireStringRep("IS_AUTO_GVAR", gvar);
+    RequireStringRep(SELF_NAME, gvar);
     Obj expr = ExprGVar(GVarName( CONST_CSTR_STRING(gvar) ) );
     return (expr && !IS_INTOBJ(expr)) ? True : False;
 }
@@ -1178,7 +1178,7 @@ static Obj FuncVAL_GVAR(Obj self, Obj gvar)
 {
     Obj val;
 
-    RequireStringRep("VAL_GVAR", gvar);
+    RequireStringRep(SELF_NAME, gvar);
 
     val = ValAutoGVar( GVarName( CONST_CSTR_STRING(gvar) ) );
 
@@ -1194,7 +1194,7 @@ static Obj FuncVAL_GVAR(Obj self, Obj gvar)
 
 static Obj FuncUNB_GVAR(Obj self, Obj gvar)
 {
-    RequireStringRep("UNB_GVAR", gvar);
+    RequireStringRep(SELF_NAME, gvar);
     AssGVar( GVarName( CONST_CSTR_STRING(gvar) ), (Obj)0 );
     return 0;
 }

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -210,13 +210,13 @@ static Obj FuncMakeFixedAtomicList(Obj self, Obj list) {
           return list;
         default:
           HashUnlock(list);
-          RequireArgument("MakeFixedAtomicList", list, "must be an atomic list");
+          RequireArgument(SELF_NAME, list, "must be an atomic list");
           return (Obj) 0; /* flow control hint */
       }
       HashUnlock(list);
       break;
     default:
-      RequireArgument("MakeFixedAtomicList", list, "must be an atomic list");
+      RequireArgument(SELF_NAME, list, "must be an atomic list");
   }
   return (Obj) 0; /* flow control hint */
 }
@@ -243,7 +243,7 @@ static Obj FuncGET_ATOMIC_LIST(Obj self, Obj list, Obj index)
   UInt len;
   const AtomicObj *addr;
   if (TNUM_OBJ(list) != T_ALIST && TNUM_OBJ(list) != T_FIXALIST)
-    RequireArgument("GET_ATOMIC_LIST", list, "must be an atomic list");
+    RequireArgument(SELF_NAME, list, "must be an atomic list");
   addr = CONST_ADDR_ATOM(list);
   len = ALIST_LEN((UInt) addr[0].atom);
   n = GetBoundedInt("GET_ATOMIC_LIST", index, 1, len);
@@ -288,7 +288,7 @@ static Obj FuncSET_ATOMIC_LIST(Obj self, Obj list, Obj index, Obj value)
   UInt len;
   AtomicObj *addr;
   if (TNUM_OBJ(list) != T_ALIST && TNUM_OBJ(list) != T_FIXALIST)
-    RequireArgument("SET_ATOMIC_LIST", list, "must be an atomic list");
+    RequireArgument(SELF_NAME, list, "must be an atomic list");
   addr = ADDR_ATOM(list);
   len = ALIST_LEN((UInt) addr[0].atom);
   n = GetBoundedInt("SET_ATOMIC_LIST", index, 1, len);
@@ -357,12 +357,12 @@ static Obj FuncATOMIC_ADDITION(Obj self, Obj list, Obj index, Obj inc)
     case T_APOSOBJ:
       break;
     default:
-      RequireArgument("ATOMIC_ADDITION", list, "must be a fixed atomic list");
+      RequireArgument(SELF_NAME, list, "must be a fixed atomic list");
   }
   addr = ADDR_ATOM(list);
   len = ALIST_LEN((UInt) addr[0].atom);
   n = GetBoundedInt("ATOMIC_ADDITION", index, 1, len);
-  RequireSmallInt("ATOMIC_ADDITION", index);
+  RequireSmallInt(SELF_NAME, index);
   do
   {
     aold = addr[n+1];
@@ -377,7 +377,7 @@ static Obj FuncATOMIC_ADDITION(Obj self, Obj list, Obj index, Obj inc)
 static Obj FuncAddAtomicList(Obj self, Obj list, Obj obj)
 {
     if (TNUM_OBJ(list) != T_ALIST)
-        RequireArgument("AddAtomicList", list, "must be a non-fixed atomic list");
+        RequireArgument(SELF_NAME, list, "must be a non-fixed atomic list");
     return INTOBJ_INT(AddAList(list, obj));
 }
 
@@ -400,7 +400,7 @@ Obj FromAtomicList(Obj list)
 static Obj FuncFromAtomicList(Obj self, Obj list)
 {
     if (TNUM_OBJ(list) != T_FIXALIST && TNUM_OBJ(list) != T_ALIST)
-        RequireArgument("FromAtomicList", list, "must be an atomic list");
+        RequireArgument(SELF_NAME, list, "must be an atomic list");
     return FromAtomicList(list);
 }
 
@@ -810,14 +810,15 @@ Obj FromAtomicRecord(Obj record)
 static Obj FuncFromAtomicRecord(Obj self, Obj record)
 {
     if (TNUM_OBJ(record) != T_AREC)
-        RequireArgument("FromAtomicRecord", record, "must be an atomic record");
+        RequireArgument(SELF_NAME, record, "must be an atomic record");
     return FromAtomicRecord(record);
 }
 
 static Obj FuncFromAtomicComObj(Obj self, Obj comobj)
 {
     if (TNUM_OBJ(comobj) != T_ACOMOBJ)
-        RequireArgument("FromAtomicComObj", comobj, "must be an atomic component object");
+        RequireArgument(SELF_NAME, comobj,
+                        "must be an atomic component object");
     return FromAtomicRecord(comobj);
 }
 
@@ -1065,8 +1066,8 @@ static Obj FuncGET_ATOMIC_RECORD(Obj self, Obj record, Obj field, Obj def)
   UInt fieldname;
   Obj result;
   if (TNUM_OBJ(record) != T_AREC)
-    RequireArgument("GET_ATOMIC_RECORD", record, "must be an atomic record");
-  RequireStringRep("GET_ATOMIC_RECORD", field);
+    RequireArgument(SELF_NAME, record, "must be an atomic record");
+  RequireStringRep(SELF_NAME, field);
   fieldname = RNamName(CONST_CSTR_STRING(field));
   result = GetARecordField(record, fieldname);
   return result ? result : def;
@@ -1077,8 +1078,8 @@ static Obj FuncSET_ATOMIC_RECORD(Obj self, Obj record, Obj field, Obj value)
   UInt fieldname;
   Obj result;
   if (TNUM_OBJ(record) != T_AREC)
-    RequireArgument("SET_ATOMIC_RECORD", record, "must be an atomic record");
-  RequireStringRep("SET_ATOMIC_RECORD", field);
+    RequireArgument(SELF_NAME, record, "must be an atomic record");
+  RequireStringRep(SELF_NAME, field);
   fieldname = RNamName(CONST_CSTR_STRING(field));
   result = SetARecordField(record, fieldname, value);
   if (!result)
@@ -1092,8 +1093,8 @@ static Obj FuncUNBIND_ATOMIC_RECORD(Obj self, Obj record, Obj field)
   UInt fieldname;
   Obj exists;
   if (TNUM_OBJ(record) != T_AREC)
-    RequireArgument("UNBIND_ATOMIC_RECORD", record, "must be an atomic record");
-  RequireStringRep("UNBIND_ATOMIC_RECORD", field);
+    RequireArgument(SELF_NAME, record, "must be an atomic record");
+  RequireStringRep(SELF_NAME, field);
   fieldname = RNamName(CONST_CSTR_STRING(field));
   if (GetARecordUpdatePolicy(record) != AREC_RW)
     ErrorQuit("UNBIND_ATOMIC_RECORD: Record elements cannot be changed",
@@ -1169,8 +1170,8 @@ static Obj FuncThreadLocalRecord(Obj self, Obj args)
 
     defaults = (narg >= 1) ? ELM_PLIST(args, 1) : NEW_PREC(0);
     constructors = (narg >= 2) ? ELM_PLIST(args, 2) : NEW_PREC(0);
-    RequirePlainRec("ThreadLocalRecord", defaults);
-    RequirePlainRec("ThreadLocalRecord", constructors);
+    RequirePlainRec(SELF_NAME, defaults);
+    RequirePlainRec(SELF_NAME, constructors);
 
     if (!OnlyConstructors(constructors))
         ArgumentError("ThreadLocalRecord: <constructors> must be a record containing parameterless functions");
@@ -1181,9 +1182,9 @@ static Obj FuncThreadLocalRecord(Obj self, Obj args)
 static Obj FuncSetTLDefault(Obj self, Obj record, Obj name, Obj value)
 {
   if (TNUM_OBJ(record) != T_TLREC)
-    RequireArgument("SetTLDefault", record, "must be a thread-local record");
+    RequireArgument(SELF_NAME, record, "must be a thread-local record");
   if (!IS_STRING(name) && !IS_INTOBJ(name))
-    RequireArgument("SetTLDefault", value, "must be a string or an integer");
+    RequireArgument(SELF_NAME, value, "must be a string or an integer");
   SetTLDefault(record, RNamObj(name), value);
   return (Obj) 0;
 }
@@ -1191,10 +1192,10 @@ static Obj FuncSetTLDefault(Obj self, Obj record, Obj name, Obj value)
 static Obj FuncSetTLConstructor(Obj self, Obj record, Obj name, Obj function)
 {
   if (TNUM_OBJ(record) != T_TLREC)
-    RequireArgument("SetTLConstructor", record, "must be a thread-local record");
+    RequireArgument(SELF_NAME, record, "must be a thread-local record");
   if (!IS_STRING(name) && !IS_INTOBJ(name))
-    RequireArgument("SetTLConstructor", name, "must be a string or an integer");
-  RequireFunction("SetTLConstructor", function);
+    RequireArgument(SELF_NAME, name, "must be a string or an integer");
+  RequireFunction(SELF_NAME, function);
   SetTLConstructor(record, RNamObj(name), function);
   return (Obj) 0;
 }

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -309,7 +309,7 @@ static Obj FuncCOMPARE_AND_SWAP(Obj self, Obj list, Obj index, Obj old, Obj new)
     AtomicObj * addr;
     Obj         result;
 
-    UInt n = GetPositiveSmallInt(CONST_CSTR_STRING(NAME_FUNC(self)), index);
+    UInt n = GetPositiveSmallInt(SELF_NAME, index);
 
     switch (TNUM_OBJ(list)) {
     case T_FIXALIST:
@@ -318,12 +318,12 @@ static Obj FuncCOMPARE_AND_SWAP(Obj self, Obj list, Obj index, Obj old, Obj new)
     case T_ALIST:
         return AtomicCompareSwapAList(list, n, old, new);
     default:
-      RequireArgument(CONST_CSTR_STRING(NAME_FUNC(self)), list, "must be an atomic list");
+        RequireArgument(SELF_NAME, list, "must be an atomic list");
   }
   addr = ADDR_ATOM(list);
   len = ALIST_LEN((UInt)addr[0].atom);
 
-  RequireBoundedInt(CONST_CSTR_STRING(NAME_FUNC(self)), index, 1, len);
+  RequireBoundedInt(SELF_NAME, index, 1, len);
   aold.obj = old;
   anew.obj = new;
   result = COMPARE_AND_SWAP(&(addr[n+1].atom), aold.atom, anew.atom) ?

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -511,7 +511,7 @@ static Obj FuncCreateThread(Obj self, Obj funcargs)
 static Obj FuncWaitThread(Obj self, Obj obj)
 {
     const char * error = NULL;
-    RequireThread("WaitThread", obj, "thread");
+    RequireThread(SELF_NAME, obj, "thread");
     LockThreadControl(1);
     ThreadObject *thread = (ThreadObject *)ADDR_OBJ(obj);
     if (thread->status & THREAD_JOINED)
@@ -544,7 +544,7 @@ static Obj FuncCurrentThread(Obj self)
 
 static Obj FuncThreadID(Obj self, Obj thread)
 {
-    RequireThread("ThreadID", thread, "thread");
+    RequireThread(SELF_NAME, thread, "thread");
     return INTOBJ_INT(ThreadID(thread));
 }
 
@@ -571,7 +571,7 @@ static Obj FuncKillThread(Obj self, Obj thread)
 static Obj FuncInterruptThread(Obj self, Obj thread, Obj handler)
 {
     int id = GetThreadID("InterruptThread", thread);
-    RequireBoundedInt("InterruptThread", handler, 0, MAX_INTERRUPT);
+    RequireBoundedInt(SELF_NAME, handler, 0, MAX_INTERRUPT);
     InterruptThread(id, (int)(INT_INTOBJ(handler)));
     return (Obj)0;
 }
@@ -584,14 +584,14 @@ static Obj FuncInterruptThread(Obj self, Obj thread, Obj handler)
 
 static Obj FuncSetInterruptHandler(Obj self, Obj handler, Obj func)
 {
-    RequireBoundedInt("SetInterruptHandler", handler, 0, MAX_INTERRUPT);
+    RequireBoundedInt(SELF_NAME, handler, 0, MAX_INTERRUPT);
     if (func == Fail) {
         SetInterruptHandler((int)(INT_INTOBJ(handler)), (Obj)0);
         return (Obj)0;
     }
     if (TNUM_OBJ(func) != T_FUNCTION || NARG_FUNC(func) != 0 ||
         !BODY_FUNC(func))
-        RequireArgument("SetInterruptHandler", func,
+        RequireArgument(SELF_NAME, func,
                         "must be a parameterless function or 'fail'");
     SetInterruptHandler((int)(INT_INTOBJ(handler)), func);
     return (Obj)0;
@@ -657,7 +657,7 @@ static Obj FuncSetRegionName(Obj self, Obj obj, Obj name)
     if (!region)
         ArgumentError(
             "SetRegionName: Cannot change name of the public region");
-    RequireStringRep("SetRegionName", name);
+    RequireStringRep(SELF_NAME, name);
     SetRegionName(region, name);
     return (Obj)0;
 }
@@ -850,7 +850,7 @@ static Obj FuncDISABLE_GUARDS(Obj self, Obj flag)
     else if (IS_INTOBJ(flag))
         TLS(DisableGuards) = (int)(INT_INTOBJ(flag));
     else
-        RequireArgument("DISABLE_GUARDS", flag,
+        RequireArgument(SELF_NAME, flag,
                         "must be a boolean or a small integer");
     return (Obj)0;
 }
@@ -860,7 +860,7 @@ static Obj FuncWITH_TARGET_REGION(Obj self, Obj obj, Obj func)
     Region * volatile oldRegion = TLS(currentRegion);
     Region * volatile region = GetRegionOf(obj);
 
-    RequireFunction("WITH_TARGET_REGION", func);
+    RequireFunction(SELF_NAME, func);
     if (!region || !CheckExclusiveWriteAccess(obj))
         return ArgumentError(
             "WITH_TARGET_REGION: Requires write access to target region");
@@ -1326,7 +1326,7 @@ static BOOL IsChannel(Obj obj)
 
 static Obj FuncDestroyChannel(Obj self, Obj channel)
 {
-    RequireChannel("DestroyChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     if (!DestroyChannel(ObjPtr(channel)))
         ErrorQuit("DestroyChannel: Channel is in use", 0, 0);
     return (Obj)0;
@@ -1334,71 +1334,71 @@ static Obj FuncDestroyChannel(Obj self, Obj channel)
 
 static Obj FuncTallyChannel(Obj self, Obj channel)
 {
-    RequireChannel("TallyChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     return INTOBJ_INT(TallyChannel(ObjPtr(channel)));
 }
 
 static Obj FuncSendChannel(Obj self, Obj channel, Obj obj)
 {
-    RequireChannel("SendChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     SendChannel(ObjPtr(channel), obj, 1);
     return (Obj)0;
 }
 
 static Obj FuncTransmitChannel(Obj self, Obj channel, Obj obj)
 {
-    RequireChannel("TransmitChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     SendChannel(ObjPtr(channel), obj, 0);
     return (Obj)0;
 }
 
 static Obj FuncMultiSendChannel(Obj self, Obj channel, Obj list)
 {
-    RequireChannel("MultiSendChannel", channel);
-    RequireDenseList("MultiSendChannel", list);
+    RequireChannel(SELF_NAME, channel);
+    RequireDenseList(SELF_NAME, list);
     MultiSendChannel(ObjPtr(channel), list, 1);
     return (Obj)0;
 }
 
 static Obj FuncMultiTransmitChannel(Obj self, Obj channel, Obj list)
 {
-    RequireChannel("MultiTransmitChannel", channel);
-    RequireDenseList("MultiTransmitChannel", list);
+    RequireChannel(SELF_NAME, channel);
+    RequireDenseList(SELF_NAME, list);
     MultiSendChannel(ObjPtr(channel), list, 0);
     return (Obj)0;
 }
 
 static Obj FuncTryMultiSendChannel(Obj self, Obj channel, Obj list)
 {
-    RequireChannel("TryMultiSendChannel", channel);
-    RequireDenseList("TryMultiSendChannel", list);
+    RequireChannel(SELF_NAME, channel);
+    RequireDenseList(SELF_NAME, list);
     return INTOBJ_INT(TryMultiSendChannel(ObjPtr(channel), list, 1));
 }
 
 
 static Obj FuncTryMultiTransmitChannel(Obj self, Obj channel, Obj list)
 {
-    RequireChannel("TryMultiTransmitChannel", channel);
-    RequireDenseList("TryMultiTransmitChannel", list);
+    RequireChannel(SELF_NAME, channel);
+    RequireDenseList(SELF_NAME, list);
     return INTOBJ_INT(TryMultiSendChannel(ObjPtr(channel), list, 0));
 }
 
 
 static Obj FuncTrySendChannel(Obj self, Obj channel, Obj obj)
 {
-    RequireChannel("TrySendChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     return TrySendChannel(ObjPtr(channel), obj, 1) ? True : False;
 }
 
 static Obj FuncTryTransmitChannel(Obj self, Obj channel, Obj obj)
 {
-    RequireChannel("TryTransmitChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     return TrySendChannel(ObjPtr(channel), obj, 0) ? True : False;
 }
 
 static Obj FuncReceiveChannel(Obj self, Obj channel)
 {
-    RequireChannel("ReceiveChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     return ReceiveChannel(ObjPtr(channel));
 }
 
@@ -1444,20 +1444,20 @@ static Obj FuncReceiveAnyChannelWithIndex(Obj self, Obj args)
 
 static Obj FuncMultiReceiveChannel(Obj self, Obj channel, Obj count)
 {
-    RequireChannel("MultiReceiveChannel", channel);
-    RequireNonnegativeSmallInt("MultiReceiveChannel", count);
+    RequireChannel(SELF_NAME, channel);
+    RequireNonnegativeSmallInt(SELF_NAME, count);
     return MultiReceiveChannel(ObjPtr(channel), INT_INTOBJ(count));
 }
 
 static Obj FuncInspectChannel(Obj self, Obj channel)
 {
-    RequireChannel("InspectChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     return InspectChannel(ObjPtr(channel));
 }
 
 static Obj FuncTryReceiveChannel(Obj self, Obj channel, Obj obj)
 {
-    RequireChannel("TryReceiveChannel", channel);
+    RequireChannel(SELF_NAME, channel);
     return TryReceiveChannel(ObjPtr(channel), obj);
 }
 
@@ -1500,7 +1500,7 @@ static Obj FuncCreateSemaphore(Obj self, Obj args)
 static Obj FuncSignalSemaphore(Obj self, Obj semaphore)
 {
     Semaphore * sem;
-    RequireSemaphore("SignalSemaphore", semaphore);
+    RequireSemaphore(SELF_NAME, semaphore);
     sem = ObjPtr(semaphore);
     LockMonitor(ObjPtr(sem->monitor));
     sem->count++;
@@ -1513,7 +1513,7 @@ static Obj FuncSignalSemaphore(Obj self, Obj semaphore)
 static Obj FuncWaitSemaphore(Obj self, Obj semaphore)
 {
     Semaphore * sem;
-    RequireSemaphore("WaitSemaphore", semaphore);
+    RequireSemaphore(SELF_NAME, semaphore);
     sem = ObjPtr(semaphore);
     LockMonitor(ObjPtr(sem->monitor));
     sem->waiting++;
@@ -1531,7 +1531,7 @@ static Obj FuncTryWaitSemaphore(Obj self, Obj semaphore)
 {
     Semaphore * sem;
     int         success;
-    RequireSemaphore("TryWaitSemaphore", semaphore);
+    RequireSemaphore(SELF_NAME, semaphore);
     sem = ObjPtr(semaphore);
     LockMonitor(ObjPtr(sem->monitor));
     success = (sem->count > 0);
@@ -1614,7 +1614,7 @@ static BOOL IsBarrier(Obj obj)
 
 static Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
 {
-    RequireBarrier("StartBarrier", barrier);
+    RequireBarrier(SELF_NAME, barrier);
     Int c = GetSmallInt("StartBarrier", count);
     StartBarrier(ObjPtr(barrier), c);
     return (Obj)0;
@@ -1622,7 +1622,7 @@ static Obj FuncStartBarrier(Obj self, Obj barrier, Obj count)
 
 static Obj FuncWaitBarrier(Obj self, Obj barrier)
 {
-    RequireBarrier("WaitBarrier", barrier);
+    RequireBarrier(SELF_NAME, barrier);
     WaitBarrier(ObjPtr(barrier));
     return (Obj)0;
 }
@@ -1699,26 +1699,26 @@ static Obj FuncCreateSyncVar(Obj self)
 
 static Obj FuncSyncWrite(Obj self, Obj syncvar, Obj value)
 {
-    RequireSyncVar("SyncWrite", syncvar);
+    RequireSyncVar(SELF_NAME, syncvar);
     SyncWrite(ObjPtr(syncvar), value);
     return (Obj)0;
 }
 
 static Obj FuncSyncTryWrite(Obj self, Obj syncvar, Obj value)
 {
-    RequireSyncVar("SyncTryWrite", syncvar);
+    RequireSyncVar(SELF_NAME, syncvar);
     return SyncTryWrite(ObjPtr(syncvar), value) ? True : False;
 }
 
 static Obj FuncSyncRead(Obj self, Obj syncvar)
 {
-    RequireSyncVar("SyncRead", syncvar);
+    RequireSyncVar(SELF_NAME, syncvar);
     return SyncRead(ObjPtr(syncvar));
 }
 
 static Obj FuncSyncIsBound(Obj self, Obj syncvar)
 {
-    RequireSyncVar("SyncIsBound", syncvar);
+    RequireSyncVar(SELF_NAME, syncvar);
     return SyncIsBound(ObjPtr(syncvar));
 }
 
@@ -1929,7 +1929,7 @@ static Obj FuncTRYLOCK(Obj self, Obj args)
 
 static Obj FuncUNLOCK(Obj self, Obj sp)
 {
-    RequireNonnegativeSmallInt("UNLOCK", sp);
+    RequireNonnegativeSmallInt(SELF_NAME, sp);
     PopRegionLocks(INT_INTOBJ(sp));
     return (Obj)0;
 }
@@ -1974,7 +1974,7 @@ static Obj FuncCLONE_DELIMITED(Obj self, Obj obj)
 static Obj FuncNEW_REGION(Obj self, Obj name, Obj prec)
 {
     if (name != Fail && !IsStringConv(name))
-        RequireArgument("NEW_REGION", name, "must be a string or fail");
+        RequireArgument(SELF_NAME, name, "must be a string or fail");
     Int p = GetSmallInt("NEW_REGION", prec);
     Region * region = NewRegion();
     region->prec = p;
@@ -2033,7 +2033,7 @@ MigrateObjects(int count, Obj * objects, Region * target, int retype)
 static Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
 {
     if (name != Fail && !IsStringConv(name))
-        RequireArgument("SHARE", name, "must be a string or fail");
+        RequireArgument(SELF_NAME, name, "must be a string or fail");
     Int p = GetSmallInt("SHARE", prec);
     Region * region = NewRegion();
     region->prec = p;
@@ -2051,7 +2051,7 @@ static Obj FuncSHARE(Obj self, Obj obj, Obj name, Obj prec)
 static Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
 {
     if (name != Fail && !IsStringConv(name))
-        RequireArgument("SHARE_RAW", name, "must be a string or fail");
+        RequireArgument(SELF_NAME, name, "must be a string or fail");
     Int p = GetSmallInt("SHARE_RAW", prec);
     Region * region = NewRegion();
     region->prec = p;
@@ -2069,7 +2069,7 @@ static Obj FuncSHARE_RAW(Obj self, Obj obj, Obj name, Obj prec)
 static Obj FuncSHARE_NORECURSE(Obj self, Obj obj, Obj name, Obj prec)
 {
     if (name != Fail && !IsStringConv(name))
-        RequireArgument("SHARE_NORECURSE", name, "must be a string or fail");
+        RequireArgument(SELF_NAME, name, "must be a string or fail");
     Int p = GetSmallInt("SHARE_NORECURSE", prec);
     Region * region = NewRegion();
     region->prec = p;
@@ -2176,7 +2176,7 @@ static Obj FuncMakeThreadLocal(Obj self, Obj var)
     char * name;
     UInt   gvar;
     if (!IsStringConv(var) || GET_LEN_STRING(var) == 0)
-        RequireArgument("MakeThreadLocal", var, "must be a variable name");
+        RequireArgument(SELF_NAME, var, "must be a variable name");
     name = CSTR_STRING(var);
     gvar = GVarName(name);
     name = CSTR_STRING(NameGVar(gvar)); /* to apply namespace scopes where needed. */
@@ -2332,8 +2332,8 @@ void InitSignals(void)
 static Obj FuncPERIODIC_CHECK(Obj self, Obj count, Obj func)
 {
     UInt n;
-    RequireNonnegativeSmallInt("PERIODIC_CHECK", count);
-    RequireFunction("PERIODIC_CHECK", func);
+    RequireNonnegativeSmallInt(SELF_NAME, count);
+    RequireFunction(SELF_NAME, func);
     /*
      * The following read of SigVTALRMCounter is a dirty read. We don't
      * need to synchronize access to it because it's a monotonically

--- a/src/info.c
+++ b/src/info.c
@@ -42,7 +42,7 @@ static Obj ShowUsedInfoClassesHandler;
 
 static Obj FuncShowUsedInfoClasses(Obj self, Obj choice)
 {
-    RequireTrueOrFalse("ShowUsedInfoClasses", choice);
+    RequireTrueOrFalse(SELF_NAME, choice);
 
     if (choice == True) {
         STATE(ShowUsedInfoClassesActive) = 1;

--- a/src/integer.c
+++ b/src/integer.c
@@ -123,11 +123,12 @@ static Obj ObjInt_UIntInv( UInt i );
 
 #define SIZE_INT_OR_INTOBJ(obj) (IS_INTOBJ(obj) ? 1 : SIZE_INT(obj))
 
-#define RequireNonzero(funcname, op, argname) \
-    do { \
-      if (op == INTOBJ_INT(0) ) { \
-        ErrorMayQuit(funcname ": <" argname "> must be nonzero", 0, 0); \
-      } \
+#define RequireNonzero(funcname, op, argname)                                \
+    do {                                                                     \
+        if (op == INTOBJ_INT(0)) {                                           \
+            RequireArgumentEx(funcname, op, "<" argname ">",                 \
+                              "must be a nonzero integer");                  \
+        }                                                                    \
     } while (0)
 
 
@@ -839,7 +840,7 @@ static Obj StringIntBase(Obj op, int base)
 */
 static Obj FuncHexStringInt(Obj self, Obj n)
 {
-    RequireInt("HexStringInt", n);
+    RequireInt(SELF_NAME, n);
     return StringIntBase(n, 16);
 }
 
@@ -872,6 +873,7 @@ static mp_limb_t hexstr2int( const UInt1 *p, UInt len )
 
 static Obj FuncIntHexString(Obj self,  Obj str)
 {
+    RequireStringRep(SELF_NAME, str);
     return IntHexString(str);
 }
 
@@ -883,7 +885,7 @@ Obj IntHexString(Obj str)
   const UInt1 *p;
   UInt *limbs;
 
-  RequireStringRep("IntHexString", str);
+  GAP_ASSERT(IS_STRING_REP(str));
 
   len = GET_LEN_STRING(str);
   if (len == 0) {
@@ -1009,7 +1011,7 @@ Int CLog2Int(Int a)
 */
 static Obj FuncLog2Int(Obj self, Obj n)
 {
-    RequireInt("Log2Int", n);
+    RequireInt(SELF_NAME, n);
 
     if (IS_INTOBJ(n)) {
         return INTOBJ_INT(CLog2Int(INT_INTOBJ(n)));
@@ -1039,7 +1041,7 @@ static Obj FuncLog2Int(Obj self, Obj n)
 */
 static Obj FuncSTRING_INT(Obj self, Obj n)
 {
-    RequireInt("STRING_INT", n);
+    RequireInt(SELF_NAME, n);
     return StringIntBase(n, 10);
 }
 
@@ -1380,7 +1382,7 @@ Obj AbsInt( Obj op )
 
 static Obj FuncABS_INT(Obj self, Obj n)
 {
-    RequireInt("AbsInt", n);
+    RequireInt(SELF_NAME, n);
     Obj res = AbsInt(n);
     CHECK_INT(res);
     return res;
@@ -1411,7 +1413,7 @@ Obj SignInt( Obj op )
 
 static Obj FuncSIGN_INT(Obj self, Obj n)
 {
-    RequireInt("SignInt", n);
+    RequireInt(SELF_NAME, n);
     Obj res = SignInt(n);
     CHECK_INT(res);
     return res;
@@ -1965,8 +1967,8 @@ Obj QuoInt(Obj opL, Obj opR)
 */
 static Obj FuncQUO_INT(Obj self, Obj a, Obj b)
 {
-    RequireInt("QuoInt", a);
-    RequireInt("QuoInt", b);
+    RequireInt(SELF_NAME, a);
+    RequireInt(SELF_NAME, b);
     return QuoInt(a, b);
 }
 
@@ -2094,8 +2096,8 @@ Obj RemInt(Obj opL, Obj opR)
 */
 static Obj FuncREM_INT(Obj self, Obj a, Obj b)
 {
-    RequireInt("RemInt", a);
-    RequireInt("RemInt", b);
+    RequireInt(SELF_NAME, a);
+    RequireInt(SELF_NAME, b);
     return RemInt(a, b);
 }
 
@@ -2167,8 +2169,8 @@ Obj GcdInt ( Obj opL, Obj opR )
 */
 static Obj FuncGCD_INT(Obj self, Obj a, Obj b)
 {
-    RequireInt("GcdInt", a);
-    RequireInt("GcdInt", b);
+    RequireInt(SELF_NAME, a);
+    RequireInt(SELF_NAME, b);
     return GcdInt(a, b);
 }
 
@@ -2220,8 +2222,8 @@ Obj LcmInt(Obj opL, Obj opR)
 
 static Obj FuncLCM_INT(Obj self, Obj a, Obj b)
 {
-    RequireInt("LcmInt", a);
-    RequireInt("LcmInt", b);
+    RequireInt(SELF_NAME, a);
+    RequireInt(SELF_NAME, b);
     return LcmInt(a, b);
 }
 
@@ -2230,7 +2232,7 @@ static Obj FuncLCM_INT(Obj self, Obj a, Obj b)
 */
 static Obj FuncFACTORIAL_INT(Obj self, Obj n)
 {
-    RequireNonnegativeSmallInt("Factorial", n);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
 
     mpz_t mpzResult;
     mpz_init(mpzResult);
@@ -2332,8 +2334,8 @@ Obj BinomialInt(Obj n, Obj k)
 
 static Obj FuncBINOMIAL_INT(Obj self, Obj n, Obj k)
 {
-    RequireInt("Binomial", n);
-    RequireInt("Binomial", k);
+    RequireInt(SELF_NAME, n);
+    RequireInt(SELF_NAME, k);
     return BinomialInt(n, k);
 }
 
@@ -2346,8 +2348,8 @@ static Obj FuncJACOBI_INT(Obj self, Obj n, Obj m)
   fake_mpz_t mpzL, mpzR;
   int result;
 
-  RequireInt("Jacobi", n);
-  RequireInt("Jacobi", m);
+  RequireInt(SELF_NAME, n);
+  RequireInt(SELF_NAME, m);
 
   CHECK_INT(n);
   CHECK_INT(m);
@@ -2372,13 +2374,13 @@ static Obj FuncPVALUATION_INT(Obj self, Obj n, Obj p)
   mpz_t mpzResult;
   int k;
 
-  RequireInt("PValuation", n);
-  RequireInt("PValuation", p);
+  RequireInt(SELF_NAME, n);
+  RequireInt(SELF_NAME, p);
 
   CHECK_INT(n);
   CHECK_INT(p);
 
-  RequireNonzero("PValuation", p, "p");
+  RequireNonzero(SELF_NAME, p, "p");
 
   if (SIZE_INT_OR_INTOBJ(n) == 1 && SIZE_INT_OR_INTOBJ(p) == 1) {
     UInt N = AbsOfSmallInt(n);
@@ -2418,8 +2420,8 @@ static Obj FuncROOT_INT(Obj self, Obj n, Obj k)
 {
     fake_mpz_t n_mpz, result_mpz;
 
-    RequireInt("Root", n);
-    RequireInt("Root", k);
+    RequireInt(SELF_NAME, n);
+    RequireInt(SELF_NAME, k);
 
     if (!IS_POS_INT(k))
         ErrorMayQuit("Root: <k> must be a positive integer", 0, 0);
@@ -2476,10 +2478,9 @@ Obj InverseModInt(Obj base, Obj mod)
     CHECK_INT(base);
     CHECK_INT(mod);
 
-    RequireNonzero("InverseModInt", mod, "mod");
     if (mod == INTOBJ_INT(1) || mod == INTOBJ_INT(-1))
         return INTOBJ_INT(0);
-    if (base == INTOBJ_INT(0))
+    if (base == INTOBJ_INT(0) || mod == INTOBJ_INT(0))
         return Fail;
 
     // handle small inputs separately
@@ -2531,8 +2532,9 @@ Obj InverseModInt(Obj base, Obj mod)
 */
 static Obj FuncINVMODINT(Obj self, Obj base, Obj mod)
 {
-    RequireInt("InverseModInt", base);
-    RequireInt("InverseModInt", mod);
+    RequireInt(SELF_NAME, base);
+    RequireInt(SELF_NAME, mod);
+    RequireNonzero(SELF_NAME, mod, "mod");
     return InverseModInt(base, mod);
 }
 
@@ -2544,15 +2546,15 @@ static Obj FuncPOWERMODINT(Obj self, Obj base, Obj exp, Obj mod)
 {
   fake_mpz_t base_mpz, exp_mpz, mod_mpz, result_mpz;
 
-  RequireInt("PowerModInt", base);
-  RequireInt("PowerModInt", exp);
-  RequireInt("PowerModInt", mod);
+  RequireInt(SELF_NAME, base);
+  RequireInt(SELF_NAME, exp);
+  RequireInt(SELF_NAME, mod);
 
   CHECK_INT(base);
   CHECK_INT(exp);
   CHECK_INT(mod);
 
-  RequireNonzero("PowerModInt", mod, "mod");
+  RequireNonzero(SELF_NAME, mod, "mod");
   if ( mod == INTOBJ_INT(1) || mod == INTOBJ_INT(-1) )
     return INTOBJ_INT(0);
 
@@ -2588,7 +2590,7 @@ static Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
   fake_mpz_t n_mpz;
   Int res;
 
-  RequireInt("IsProbablyPrimeInt", n);
+  RequireInt(SELF_NAME, n);
   UInt r = GetPositiveSmallInt("IsProbablyPrimeInt", reps);
 
   CHECK_INT(n);
@@ -2633,13 +2635,13 @@ static Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
   Int i, n, q, r, qoff, len;
   UInt4 *mt;
   UInt4 *pt;
-  RequireStringRep("RandomIntegerMT", mtstr);
+  RequireStringRep(SELF_NAME, mtstr);
   if (GET_LEN_STRING(mtstr) < 2500) {
      ErrorMayQuit(
          "RandomIntegerMT: <mtstr> must be a string with at least 2500 characters",
          0, 0);
   }
-  RequireNonnegativeSmallInt("RandomIntegerMT", nrbits);
+  RequireNonnegativeSmallInt(SELF_NAME, nrbits);
   n = INT_INTOBJ(nrbits);
 
   /* small int case */

--- a/src/intfuncs.c
+++ b/src/intfuncs.c
@@ -91,7 +91,7 @@ static Obj FuncInitRandomMT(Obj self, Obj initstr)
   UInt4 *mt, key_length, byte_key_length, i, j, k, N = 624;
 
   /* check the seed, given as string */
-  RequireStringRep("InitRandomMT", initstr);
+  RequireStringRep(SELF_NAME, initstr);
 
   /* store array of 624 UInt4 and one UInt4 as counter "mti" and an
      endianness marker */
@@ -602,7 +602,7 @@ static Obj FuncBUILD_BITFIELDS(Obj self, Obj args)
     GAP_ASSERT(IS_PLIST(args));
     GAP_ASSERT(LEN_PLIST(args) >= 1 && ELM_PLIST(args, 1));
     Obj widths = ELM_PLIST(args, 1);
-    RequireSmallList("MAKE_BITFIELDS", widths);
+    RequireSmallList(SELF_NAME, widths);
     UInt nfields = LEN_LIST(widths);
     if (LEN_PLIST(args) != nfields + 1)
         ErrorMayQuit(
@@ -628,7 +628,7 @@ static Obj FuncBUILD_BITFIELDS(Obj self, Obj args)
 
 static Obj FuncMAKE_BITFIELDS(Obj self, Obj widths)
 {
-    RequireSmallList("MAKE_BITFIELDS", widths);
+    RequireSmallList(SELF_NAME, widths);
     UInt nfields = LEN_LIST(widths);
     UInt starts[nfields + 1];
     starts[0] = 0;

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -219,9 +219,9 @@ static Obj FuncAPPEND_LIST_INTR(Obj self, Obj list1, Obj list2)
     Obj                 elm;            /* one element of the second list  */
     Int                 i;              /* loop variable                   */
 
-    RequireMutable("Append", list1, "list");
-    RequireSmallList("Append", list1);
-    RequireSmallList("Append", list2);
+    RequireMutable(SELF_NAME, list1, "list");
+    RequireSmallList(SELF_NAME, list1);
+    RequireSmallList(SELF_NAME, list2);
 
     /* handle the case of strings now */
     if (IS_STRING_REP(list1) && IS_STRING_REP(list2)) {
@@ -353,7 +353,7 @@ UInt            PositionSortedDensePlist (
 
 static Obj FuncPOSITION_SORTED_LIST(Obj self, Obj list, Obj obj)
 {
-    RequireSmallList("POSITION_SORTED_LIST", list);
+    RequireSmallList(SELF_NAME, list);
 
     UInt h;
     if ( IS_DENSE_PLIST(list) ) {
@@ -426,8 +426,8 @@ static UInt PositionSortedDensePlistComp(Obj list, Obj obj, Obj func)
 static Obj
 FuncPOSITION_SORTED_LIST_COMP(Obj self, Obj list, Obj obj, Obj func)
 {
-    RequireSmallList("POSITION_SORTED_LIST_COMP", list);
-    RequireFunction("POSITION_SORTED_LIST_COMP", func);
+    RequireSmallList(SELF_NAME, list);
+    RequireFunction(SELF_NAME, func);
 
     UInt h;
     if ( IS_DENSE_PLIST(list) ) {
@@ -447,8 +447,8 @@ FuncPOSITION_SORTED_LIST_COMP(Obj self, Obj list, Obj obj, Obj func)
 */
 static Obj FuncPOSITION_SORTED_BY(Obj self, Obj list, Obj val, Obj func)
 {
-    RequirePlainList("POSITION_SORTED_BY", list);
-    RequireFunction("POSITION_SORTED_BY", func);
+    RequirePlainList(SELF_NAME, list);
+    RequireFunction(SELF_NAME, func);
 
     // perform the binary search to find the position
     UInt l = 0;
@@ -778,7 +778,7 @@ UInt            RemoveDupsDensePlist (
 */
 static Obj FuncSORT_LIST(Obj self, Obj list)
 {
-    RequireSmallList("SORT_LIST", list);
+    RequireSmallList(SELF_NAME, list);
 
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlist( list );
@@ -793,7 +793,7 @@ static Obj FuncSORT_LIST(Obj self, Obj list)
 
 static Obj FuncSTABLE_SORT_LIST(Obj self, Obj list)
 {
-    RequireSmallList("STABLE_SORT_LIST", list);
+    RequireSmallList(SELF_NAME, list);
 
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlistMerge( list );
@@ -814,8 +814,8 @@ static Obj FuncSTABLE_SORT_LIST(Obj self, Obj list)
 */
 static Obj FuncSORT_LIST_COMP(Obj self, Obj list, Obj func)
 {
-    RequireSmallList("SORT_LIST_COMP", list);
-    RequireFunction("SORT_LIST_COMP", func);
+    RequireSmallList(SELF_NAME, list);
+    RequireFunction(SELF_NAME, func);
 
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlistComp( list, func );
@@ -829,8 +829,8 @@ static Obj FuncSORT_LIST_COMP(Obj self, Obj list, Obj func)
 
 static Obj FuncSTABLE_SORT_LIST_COMP(Obj self, Obj list, Obj func)
 {
-    RequireSmallList("STABLE_SORT_LIST_COMP", list);
-    RequireFunction("STABLE_SORT_LIST_COMP", func);
+    RequireSmallList(SELF_NAME, list);
+    RequireFunction(SELF_NAME, func);
 
     if ( IS_DENSE_PLIST(list) ) {
         SortDensePlistCompMerge( list, func );
@@ -849,9 +849,9 @@ static Obj FuncSTABLE_SORT_LIST_COMP(Obj self, Obj list, Obj func)
 */
 static Obj FuncSORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 {
-    RequireSmallList("SORT_PARA_LIST", list);
-    RequireSmallList("SORT_PARA_LIST", shadow);
-    RequireSameLength("SORT_PARA_LIST", list, shadow);
+    RequireSmallList(SELF_NAME, list);
+    RequireSmallList(SELF_NAME, shadow);
+    RequireSameLength(SELF_NAME, list, shadow);
 
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlist( list, shadow );
@@ -866,9 +866,9 @@ static Obj FuncSORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 
 static Obj FuncSTABLE_SORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 {
-    RequireSmallList("STABLE_SORT_PARA_LIST", list);
-    RequireSmallList("STABLE_SORT_PARA_LIST", shadow);
-    RequireSameLength("STABLE_SORT_PARA_LIST", list, shadow);
+    RequireSmallList(SELF_NAME, list);
+    RequireSmallList(SELF_NAME, shadow);
+    RequireSameLength(SELF_NAME, list, shadow);
 
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlistMerge( list, shadow );
@@ -888,11 +888,11 @@ static Obj FuncSTABLE_SORT_PARA_LIST(Obj self, Obj list, Obj shadow)
 */
 static Obj FuncSORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 {
-    RequireSmallList("SORT_PARA_LIST_COMP", list);
-    RequireSmallList("SORT_PARA_LIST_COMP", shadow);
-    RequireSameLength("SORT_PARA_LIST_COMP", list, shadow);
-    RequireFunction("SORT_PARA_LIST_COMP", func);
-    
+    RequireSmallList(SELF_NAME, list);
+    RequireSmallList(SELF_NAME, shadow);
+    RequireSameLength(SELF_NAME, list, shadow);
+    RequireFunction(SELF_NAME, func);
+
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlistComp( list, shadow, func );
     }
@@ -906,11 +906,11 @@ static Obj FuncSORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 static Obj
 FuncSTABLE_SORT_PARA_LIST_COMP(Obj self, Obj list, Obj shadow, Obj func)
 {
-    RequireSmallList("SORT_PARA_LIST_COMP", list);
-    RequireSmallList("SORT_PARA_LIST_COMP", shadow);
-    RequireSameLength("SORT_PARA_LIST_COMP", list, shadow);
-    RequireFunction("SORT_PARA_LIST_COMP", func);
-    
+    RequireSmallList(SELF_NAME, list);
+    RequireSmallList(SELF_NAME, shadow);
+    RequireSameLength(SELF_NAME, list, shadow);
+    RequireFunction(SELF_NAME, func);
+
     if ( IS_DENSE_PLIST(list) && IS_DENSE_PLIST(shadow) ) {
         SortParaDensePlistCompMerge( list, shadow, func );
     }
@@ -956,7 +956,7 @@ static Obj FuncOnPairs(Obj self, Obj pair, Obj elm)
     Obj                 img;            /* image, result                   */
     Obj                 tmp;            /* temporary                       */
 
-    RequireSmallList("OnPairs", pair);
+    RequireSmallList(SELF_NAME, pair);
     if (LEN_LIST(pair) != 2) {
         ErrorMayQuit("OnPairs: <pair> must have length 2, not length %d",
                      LEN_LIST(pair), 0);
@@ -996,7 +996,7 @@ static Obj FuncOnTuples(Obj self, Obj tuple, Obj elm)
     Obj                 tmp;            /* temporary                       */
     UInt                i;              /* loop variable                   */
 
-    RequireSmallList("OnTuples", tuple);
+    RequireSmallList(SELF_NAME, tuple);
 
     /* special case for the empty list */
     if (LEN_LIST(tuple) == 0) {
@@ -1055,7 +1055,7 @@ static Obj FuncOnSets(Obj self, Obj set, Obj elm)
     UInt                status;        /* the elements are mutable        */
 
     if (!HAS_FILT_LIST(set, FN_IS_SSORT) && !IS_SSORT_LIST(set)) {
-        RequireArgument("OnSets", set, "must be a set");
+        RequireArgument(SELF_NAME, set, "must be a set");
     }
 
     /* special case for the empty list */
@@ -1295,7 +1295,7 @@ static Obj FuncCOPY_LIST_ENTRIES(Obj self, Obj args)
   srclist = ELM_PLIST(args, 1);
   GAP_ASSERT(srclist != 0);
   if (!IS_PLIST(srclist))
-      RequireArgumentEx("CopyListEntries", srclist, "<fromlst>",
+      RequireArgumentEx(SELF_NAME, srclist, "<fromlst>",
                         "must be a plain list");
 
   srcstart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 2), "<fromind>");
@@ -1303,7 +1303,7 @@ static Obj FuncCOPY_LIST_ENTRIES(Obj self, Obj args)
   dstlist = ELM_PLIST(args,4);
   GAP_ASSERT(dstlist != 0);
   if (!IS_PLIST(dstlist) || !IS_MUTABLE_OBJ(dstlist))
-      RequireArgumentEx("CopyListEntries", dstlist, "<tolst>",
+      RequireArgumentEx(SELF_NAME, dstlist, "<tolst>",
                         "must be a mutable plain list");
   dststart = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 5), "<toind>");
   dstinc = GetSmallIntEx("CopyListEntries", ELM_PLIST(args, 6), "<tostep>");
@@ -1416,7 +1416,7 @@ static Obj FuncCOPY_LIST_ENTRIES(Obj self, Obj args)
 
 static Obj FuncLIST_WITH_IDENTICAL_ENTRIES(Obj self, Obj n, Obj obj)
 {
-    RequireNonnegativeSmallInt("LIST_WITH_IDENTICAL_ENTRIES", n);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
 
     Obj  list = 0;
     Int  len = INT_INTOBJ(n);

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -1309,7 +1309,7 @@ static Obj FuncADD_ROW_VECTOR_3(Obj self, Obj list1, Obj list2, Obj mult)
   UInt i;
   UInt len = LEN_LIST(list1);
   Obj el1, el2;
-  RequireSameLength("AddRowVector", list1, list2);
+  RequireSameLength(SELF_NAME, list1, list2);
   for (i = 1; i <= len; i++)
     {
       el1 = ELMW_LIST(list1,i);
@@ -1337,7 +1337,7 @@ static Obj FuncADD_ROW_VECTOR_3_FAST(Obj self, Obj list1, Obj list2, Obj mult)
   UInt i;
   Obj e1,e2, prd, sum;
   UInt len = LEN_PLIST(list1);
-  RequireSameLength("AddRowVector", list1, list2);
+  RequireSameLength(SELF_NAME, list1, list2);
   for (i = 1; i <= len; i++)
     {
       e1 = ELM_PLIST(list1,i);
@@ -1373,7 +1373,7 @@ static Obj FuncADD_ROW_VECTOR_2(Obj self, Obj list1, Obj list2)
   UInt i;
   Obj el1,el2;
   UInt len = LEN_LIST(list1);
-  RequireSameLength("AddRowVector", list1, list2);
+  RequireSameLength(SELF_NAME, list1, list2);
   for (i = 1; i <= len; i++)
     {
       el1 = ELMW_LIST(list1,i);
@@ -1400,7 +1400,7 @@ static Obj FuncADD_ROW_VECTOR_2_FAST(Obj self, Obj list1, Obj list2)
   UInt i;
   Obj e1,e2, sum;
   UInt len = LEN_PLIST(list1);
-  RequireSameLength("AddRowVector", list1, list2);
+  RequireSameLength(SELF_NAME, list1, list2);
   for (i = 1; i <= len; i++)
     {
       e1 = ELM_PLIST(list1,i);
@@ -1757,10 +1757,10 @@ static Obj  FuncMONOM_TOT_DEG_LEX ( Obj self, Obj u, Obj  v ) {
   Obj  lexico;
 
   if (!IS_PLIST(u) || !IS_DENSE_LIST(u)) {
-      RequireArgument("MONOM_TOT_DEG_LEX", u, "must be a dense plain list");
+      RequireArgument(SELF_NAME, u, "must be a dense plain list");
   }
   if (!IS_PLIST(v) || !IS_DENSE_LIST(v)) {
-      RequireArgument("MONOM_TOT_DEG_LEX", v, "must be a dense plain list");
+      RequireArgument(SELF_NAME, v, "must be a dense plain list");
   }
     
   lu = LEN_PLIST( u );
@@ -1833,10 +1833,10 @@ static Obj  FuncMONOM_GRLEX( Obj self, Obj u, Obj  v ) {
   Obj  total,ai,bi;
 
   if (!IS_PLIST(u) || !IS_DENSE_LIST(u)) {
-      RequireArgument("MONOM_GRLEX", u, "must be a dense plain list");
+      RequireArgument(SELF_NAME, u, "must be a dense plain list");
   }
   if (!IS_PLIST(v) || !IS_DENSE_LIST(v)) {
-      RequireArgument("MONOM_GRLEX", v, "must be a dense plain list");
+      RequireArgument(SELF_NAME, v, "must be a dense plain list");
   }
     
   lu = LEN_PLIST( u );

--- a/src/lists.c
+++ b/src/lists.c
@@ -1184,7 +1184,7 @@ static Obj PosListHandler2(Obj self, Obj list, Obj obj)
 static Obj PosListHandler3(Obj self, Obj list, Obj obj, Obj start)
 {
     if (TNUM_OBJ(start) != T_INTPOS && !IS_NONNEG_INTOBJ(start)) {
-        RequireArgument("Position", start, "must be a non-negative integer");
+        RequireArgument(SELF_NAME, start, "must be a non-negative integer");
     }
     return POS_LIST( list, obj, start );
 }

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -352,7 +352,7 @@ static Obj FuncMACFLOAT_INT(Obj self, Obj i)
 
 static Obj FuncMACFLOAT_STRING(Obj self, Obj s)
 {
-    RequireStringRep("MACFLOAT_STRING", s);
+    RequireStringRep(SELF_NAME, s);
 
   char * endptr;
   UChar *sp = CHARS_STRING(s);
@@ -446,7 +446,7 @@ static Obj FuncSIGNBIT_MACFLOAT(Obj self, Obj f)
 
 static Obj FuncINTFLOOR_MACFLOAT(Obj self, Obj macfloat)
 {
-    RequireMacFloat("INTFLOOR_MACFLOAT", macfloat);
+    RequireMacFloat(SELF_NAME, macfloat);
 
     Double f = VAL_MACFLOAT(macfloat);
     if (isnan(f))

--- a/src/modules.c
+++ b/src/modules.c
@@ -129,7 +129,7 @@ static void RegisterModuleState(StructInitInfo * info)
 */
 static Obj FuncGAP_CRC(Obj self, Obj filename)
 {
-    RequireStringRep("GAP_CRC", filename);
+    RequireStringRep(SELF_NAME, filename);
     return ObjInt_Int(SyGAPCRC(CONST_CSTR_STRING(filename)));
 }
 
@@ -232,9 +232,9 @@ static Int SyLoadModule(const Char * name, InitInfoFunc * func)
 */
 static Obj FuncLOAD_DYN(Obj self, Obj filename, Obj crc)
 {
-    RequireStringRep("LOAD_DYN", filename);
+    RequireStringRep(SELF_NAME, filename);
     if (!IS_INTOBJ(crc) && crc != False) {
-        RequireArgument("LOAD_DYN", crc, "must be a small integer or 'false'");
+        RequireArgument(SELF_NAME, crc, "must be a small integer or 'false'");
     }
 
 #if !defined(HAVE_DLOPEN)
@@ -302,9 +302,9 @@ static Obj FuncLOAD_STAT(Obj self, Obj filename, Obj crc)
 {
     StructInitInfo * info = 0;
 
-    RequireStringRep("LOAD_STAT", filename);
+    RequireStringRep(SELF_NAME, filename);
     if (!IS_INTOBJ(crc) && crc != False) {
-        RequireArgument("LOAD_STAT", crc, "must be a small integer or 'false'");
+        RequireArgument(SELF_NAME, crc, "must be a small integer or 'false'");
     }
 
     /* try to find the module                                              */

--- a/src/objfgelm.cc
+++ b/src/objfgelm.cc
@@ -1288,8 +1288,8 @@ static Obj FuncMULT_WOR_LETTREP(Obj self, Obj a, Obj b)
   Obj *q;
 
   /* short check */
-  RequirePlainList("MULT_WOR_LETTREP", a);
-  RequirePlainList("MULT_WOR_LETTREP", b);
+  RequirePlainList(SELF_NAME, a);
+  RequirePlainList(SELF_NAME, b);
 
   /* Find overlap */
   /* l:=Length(a); */
@@ -1386,9 +1386,9 @@ static Obj FuncMULT_BYT_LETTREP(Obj self, Obj a, Obj b)
   const Char *p,*q;
   
   /* short check, if necessary strings are compacted */
-  RequireStringRep("MULT_BYT_LETTREP", a);
-  RequireStringRep("MULT_BYT_LETTREP", b);
-  
+  RequireStringRep(SELF_NAME, a);
+  RequireStringRep(SELF_NAME, b);
+
   /* Find overlap */
   /* l:=Length(a); */
   l=GET_LEN_STRING(a);

--- a/src/objset.c
+++ b/src/objset.c
@@ -812,7 +812,7 @@ static Obj FuncOBJ_SET(Obj self, Obj arg)
 
 static Obj FuncADD_OBJ_SET(Obj self, Obj set, Obj obj)
 {
-    RequireArgumentCondition("ADD_OBJ_SET", set, TNUM_OBJ(set) == T_OBJSET,
+    RequireArgumentCondition(SELF_NAME, set, TNUM_OBJ(set) == T_OBJSET,
                              "must be a mutable object set");
 
     AddObjSet(set, obj);
@@ -828,7 +828,7 @@ static Obj FuncADD_OBJ_SET(Obj self, Obj set, Obj obj)
 
 static Obj FuncREMOVE_OBJ_SET(Obj self, Obj set, Obj obj)
 {
-    RequireArgumentCondition("REMOVE_OBJ_SET", set, TNUM_OBJ(set) == T_OBJSET,
+    RequireArgumentCondition(SELF_NAME, set, TNUM_OBJ(set) == T_OBJSET,
                              "must be a mutable object set");
 
     RemoveObjSet(set, obj);
@@ -845,8 +845,7 @@ static Obj FuncREMOVE_OBJ_SET(Obj self, Obj set, Obj obj)
 
 static Obj FuncFIND_OBJ_SET(Obj self, Obj set, Obj obj)
 {
-    RequireArgumentCondition("FIND_OBJ_SET", set,
-                             IS_OBJSET(set),
+    RequireArgumentCondition(SELF_NAME, set, IS_OBJSET(set),
                              "must be an object set");
 
     Int pos = FindObjSet(set, obj);
@@ -862,7 +861,7 @@ static Obj FuncFIND_OBJ_SET(Obj self, Obj set, Obj obj)
 
 static Obj FuncCLEAR_OBJ_SET(Obj self, Obj set)
 {
-    RequireArgumentCondition("CLEAR_OBJ_SET", set, TNUM_OBJ(set) == T_OBJSET,
+    RequireArgumentCondition(SELF_NAME, set, TNUM_OBJ(set) == T_OBJSET,
                              "must be a mutable object set");
 
     ClearObjSet(set);
@@ -878,8 +877,7 @@ static Obj FuncCLEAR_OBJ_SET(Obj self, Obj set)
 
 static Obj FuncOBJ_SET_VALUES(Obj self, Obj set)
 {
-    RequireArgumentCondition("OBJ_SET_VALUES", set,
-                             IS_OBJSET(set),
+    RequireArgumentCondition(SELF_NAME, set, IS_OBJSET(set),
                              "must be an object set");
 
     return ObjSetValues(set);
@@ -933,7 +931,7 @@ static Obj FuncOBJ_MAP(Obj self, Obj arg)
 
 static Obj FuncADD_OBJ_MAP(Obj self, Obj map, Obj key, Obj value)
 {
-    RequireArgumentCondition("ADD_OBJ_MAP", map, TNUM_OBJ(map) == T_OBJMAP,
+    RequireArgumentCondition(SELF_NAME, map, TNUM_OBJ(map) == T_OBJMAP,
                              "must be a mutable object map");
 
     AddObjMap(map, key, value);
@@ -951,8 +949,7 @@ static Obj FuncADD_OBJ_MAP(Obj self, Obj map, Obj key, Obj value)
 
 static Obj FuncFIND_OBJ_MAP(Obj self, Obj map, Obj key, Obj defvalue)
 {
-    RequireArgumentCondition("FIND_OBJ_MAP", map,
-                             IS_OBJMAP(map),
+    RequireArgumentCondition(SELF_NAME, map, IS_OBJMAP(map),
                              "must be an object map");
 
     Int pos = FindObjMap(map, key);
@@ -971,8 +968,7 @@ static Obj FuncFIND_OBJ_MAP(Obj self, Obj map, Obj key, Obj defvalue)
 
 static Obj FuncCONTAINS_OBJ_MAP(Obj self, Obj map, Obj key)
 {
-    RequireArgumentCondition("CONTAINS_OBJ_MAP", map,
-                             IS_OBJMAP(map),
+    RequireArgumentCondition(SELF_NAME, map, IS_OBJMAP(map),
                              "must be an object map");
 
     Int pos = FindObjMap(map, key);
@@ -989,7 +985,7 @@ static Obj FuncCONTAINS_OBJ_MAP(Obj self, Obj map, Obj key)
 
 static Obj FuncREMOVE_OBJ_MAP(Obj self, Obj map, Obj key)
 {
-    RequireArgumentCondition("REMOVE_OBJ_MAP", map, TNUM_OBJ(map) == T_OBJMAP,
+    RequireArgumentCondition(SELF_NAME, map, TNUM_OBJ(map) == T_OBJMAP,
                              "must be a mutable object map");
 
     RemoveObjMap(map, key);
@@ -1005,7 +1001,7 @@ static Obj FuncREMOVE_OBJ_MAP(Obj self, Obj map, Obj key)
 
 static Obj FuncCLEAR_OBJ_MAP(Obj self, Obj map)
 {
-    RequireArgumentCondition("CLEAR_OBJ_MAP", map, TNUM_OBJ(map) == T_OBJMAP,
+    RequireArgumentCondition(SELF_NAME, map, TNUM_OBJ(map) == T_OBJMAP,
                              "must be a mutable object map");
 
     ClearObjMap(map);
@@ -1021,8 +1017,7 @@ static Obj FuncCLEAR_OBJ_MAP(Obj self, Obj map)
 
 static Obj FuncOBJ_MAP_VALUES(Obj self, Obj map)
 {
-    RequireArgumentCondition("OBJ_MAP_VALUES", map,
-                             IS_OBJMAP(map),
+    RequireArgumentCondition(SELF_NAME, map, IS_OBJMAP(map),
                              "must be an object map");
 
     return ObjMapValues(map);
@@ -1038,8 +1033,7 @@ static Obj FuncOBJ_MAP_VALUES(Obj self, Obj map)
 
 static Obj FuncOBJ_MAP_KEYS(Obj self, Obj map)
 {
-    RequireArgumentCondition("OBJ_MAP_KEYS", map,
-                             IS_OBJMAP(map),
+    RequireArgumentCondition(SELF_NAME, map, IS_OBJMAP(map),
                              "must be an object map");
 
     return ObjMapKeys(map);

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -198,7 +198,7 @@ static Obj FuncHASH_FLAGS(Obj self, Obj flags)
     Int                  i;
 
     /* do some trivial checks                                              */
-    RequireFlags("HASH_FLAGS", flags);
+    RequireFlags(SELF_NAME, flags);
     if ( HASH_FLAGS(flags) != 0 ) {
         return HASH_FLAGS(flags);
     }
@@ -260,7 +260,7 @@ static Obj FuncTRUES_FLAGS(Obj self, Obj flags)
     UInt                nn;
     UInt                i;              /* loop variable                   */
 
-    RequireFlags("TRUES_FLAGS", flags);
+    RequireFlags(SELF_NAME, flags);
     if ( TRUES_FLAGS(flags) != 0 ) {
         return TRUES_FLAGS(flags);
     }
@@ -304,7 +304,7 @@ static Obj FuncSIZE_FLAGS(Obj self, Obj flags)
     UInt                nrb;            /* number of blocks in flags       */
     UInt                n;              /* number of bits in flags         */
 
-    RequireFlags("SIZE_FLAGS", flags);
+    RequireFlags(SELF_NAME, flags);
     if ( TRUES_FLAGS(flags) != 0 ) {
         return INTOBJ_INT( LEN_PLIST( TRUES_FLAGS(flags) ) );
     }
@@ -376,8 +376,8 @@ static Int EqFlags(Obj flags1, Obj flags2)
 static Obj FuncIS_EQUAL_FLAGS(Obj self, Obj flags1, Obj flags2)
 {
     /* do some trivial checks                                              */
-    RequireFlags("IS_EQUAL_FLAGS", flags1);
-    RequireFlags("IS_EQUAL_FLAGS", flags2);
+    RequireFlags(SELF_NAME, flags1);
+    RequireFlags(SELF_NAME, flags2);
 
     return EqFlags(flags1, flags2) ? True : False;
 }
@@ -436,9 +436,9 @@ BOOL IS_SUBSET_FLAGS(Obj flags1, Obj flags2)
 static Obj FuncIS_SUBSET_FLAGS(Obj self, Obj flags1, Obj flags2)
 {
     /* do some correctness checks                                            */
-    RequireFlags("IS_SUBSET_FLAGS", flags1);
-    RequireFlags("IS_SUBSET_FLAGS", flags2);
-    
+    RequireFlags(SELF_NAME, flags1);
+    RequireFlags(SELF_NAME, flags2);
+
     return IS_SUBSET_FLAGS(flags1, flags2) ? True : False;
 }
 
@@ -459,8 +459,8 @@ static Obj FuncSUB_FLAGS(Obj self, Obj flags1, Obj flags2)
     Int                 i;
 
     /* do some trivial checks                                              */
-    RequireFlags("SUB_FLAGS", flags1);
-    RequireFlags("SUB_FLAGS", flags2);
+    RequireFlags(SELF_NAME, flags1);
+    RequireFlags(SELF_NAME, flags2);
 
     /* do the real work                                                    */
     len1   = LEN_FLAGS(flags1);
@@ -526,8 +526,8 @@ static Obj FuncAND_FLAGS(Obj self, Obj flags1, Obj flags2)
 #endif
 
     /* do some trivial checks                                              */
-    RequireFlags("AND_FLAGS", flags1);
-    RequireFlags("AND_FLAGS", flags2);
+    RequireFlags(SELF_NAME, flags1);
+    RequireFlags(SELF_NAME, flags2);
 
     if (flags1 == flags2)
         return flags1;
@@ -706,7 +706,7 @@ static Int WITH_HIDDEN_IMPS_HIT=0;
 static Obj FuncWITH_HIDDEN_IMPS_FLAGS(Obj self, Obj flags)
 {
     // do some trivial checks, so we can use IS_SUBSET_FLAGS
-    RequireFlags("WITH_HIDDEN_IMPS_FLAGS", flags);
+    RequireFlags(SELF_NAME, flags);
 
 #ifdef HPCGAP
     RegionWriteLock(REGION(WITH_HIDDEN_IMPS_FLAGS_CACHE));
@@ -823,7 +823,7 @@ static Int WITH_IMPS_FLAGS_HIT=0;
 static Obj FuncWITH_IMPS_FLAGS(Obj self, Obj flags)
 {
     // do some trivial checks, so we can use IS_SUBSET_FLAGS
-    RequireFlags("WITH_IMPS_FLAGS", flags);
+    RequireFlags(SELF_NAME, flags);
 
     Int changed, lastand, i, j, stop, imps_length;
     Int base_hash = INT_INTOBJ(FuncHASH_FLAGS(0, flags)) % IMPS_CACHE_LENGTH;
@@ -1298,7 +1298,7 @@ static Obj NewReturnTrueFilter(void)
 */
 static Obj FuncNEW_FILTER(Obj self, Obj name)
 {
-    RequireStringRep("NewFilter", name);
+    RequireStringRep(SELF_NAME, name);
     return NewFilter(name, 0, DoFilter);
 }
 
@@ -3012,7 +3012,7 @@ void LoadOperationExtras (
 */
 static Obj FuncNEW_OPERATION(Obj self, Obj name)
 {
-    RequireStringRep("NewOperation", name);
+    RequireStringRep(SELF_NAME, name);
     return NewOperation(name, -1, 0, (ObjFunc)DoOperationXArgs);
 }
 
@@ -3023,7 +3023,7 @@ static Obj FuncNEW_OPERATION(Obj self, Obj name)
 */
 static Obj FuncNEW_CONSTRUCTOR(Obj self, Obj name)
 {
-    RequireStringRep("NewConstructor", name);
+    RequireStringRep(SELF_NAME, name);
     return NewConstructor( name );
 }
 
@@ -3038,7 +3038,7 @@ static Obj FuncIS_CONSTRUCTOR(Obj self, Obj x)
 */
 static Obj FuncNEW_ATTRIBUTE(Obj self, Obj name)
 {
-    RequireStringRep("NewAttribute", name);
+    RequireStringRep(SELF_NAME, name);
     return NewAttribute(name, 0, DoAttribute);
 }
 /****************************************************************************
@@ -3070,7 +3070,7 @@ static Obj FuncOPER_TO_MUTABLE_ATTRIBUTE(Obj self, Obj oper)
 */
 static Obj FuncNEW_MUTABLE_ATTRIBUTE(Obj self, Obj name)
 {
-    RequireStringRep("NewMutableAttribute", name);
+    RequireStringRep(SELF_NAME, name);
     return NewAttribute(name, 0, DoMutableAttribute);
 }
 
@@ -3081,7 +3081,7 @@ static Obj FuncNEW_MUTABLE_ATTRIBUTE(Obj self, Obj name)
 */
 static Obj FuncNEW_PROPERTY(Obj self, Obj name)
 {
-    RequireStringRep("NewProperty", name);
+    RequireStringRep(SELF_NAME, name);
     return NewProperty(name, 0, DoProperty);
 }
 
@@ -3095,7 +3095,7 @@ static Obj FuncNEW_GLOBAL_FUNCTION(Obj self, Obj name)
     Obj                 args;           
     Obj                 list;
 
-    RequireStringRep("NewGlobalFunction", name);
+    RequireStringRep(SELF_NAME, name);
 
     args = MakeImmString("args");
     list = NEW_PLIST( T_PLIST, 1 );
@@ -3114,12 +3114,12 @@ static Obj REREADING;
 
 static Obj FuncINSTALL_GLOBAL_FUNCTION(Obj self, Obj oper, Obj func)
 {
-    RequireFunction("INSTALL_GLOBAL_FUNCTION", oper);
+    RequireFunction(SELF_NAME, oper);
     if ( (REREADING != True) &&
          (HDLR_FUNC(oper,0) != (ObjFunc)DoUninstalledGlobalFunction) ) {
         ErrorQuit("operation already installed", 0, 0);
     }
-    RequireFunction("INSTALL_GLOBAL_FUNCTION", func);
+    RequireFunction(SELF_NAME, func);
     if ( IS_OPERATION(func) ) {
         ErrorQuit("<func> must not be an operation", 0, 0);
     }

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -97,8 +97,8 @@ static Obj TesterAndFilter(Obj getter);
                                "must be a filter")
 
 #define RequireOperation(op)                                                 \
-    RequireArgumentCondition(CONST_CSTR_STRING(NAME_FUNC(self)), op,         \
-                             IS_OPERATION(op), "must be an operation")
+    RequireArgumentCondition(SELF_NAME, op, IS_OPERATION(op),                \
+                             "must be an operation")
 
 
 /****************************************************************************

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -1069,7 +1069,7 @@ static inline Obj PermList(Obj list)
 
 static Obj FuncPermList(Obj self, Obj list)
 {
-    RequireSmallList("PermList", list);
+    RequireSmallList(SELF_NAME, list);
 
     UInt len = LEN_LIST( list );
     if (len == 0)
@@ -1173,7 +1173,7 @@ static Obj SmallestMovedPointPerm(Obj perm)
 */
 static Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
 {
-    RequirePermutation("LargestMovedPointPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     return INTOBJ_INT(LargestMovedPointPerm(perm));
 }
@@ -1186,7 +1186,7 @@ static Obj FuncLARGEST_MOVED_POINT_PERM(Obj self, Obj perm)
 */
 static Obj FuncSMALLEST_MOVED_POINT_PERM(Obj self, Obj perm)
 {
-    RequirePermutation("SmallestMovedPointPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     return SmallestMovedPointPerm(perm);
 }
@@ -1232,7 +1232,7 @@ static Obj FuncCYCLE_LENGTH_PERM_INT(Obj self, Obj perm, Obj point)
 {
     UInt                pnt;            /* value of the point              */
 
-    RequirePermutation("CycleLengthPermInt", perm);
+    RequirePermutation(SELF_NAME, perm);
     pnt = GetPositiveSmallInt("CycleLengthPermInt", point) - 1;
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
@@ -1297,7 +1297,7 @@ static Obj FuncCYCLE_PERM_INT(Obj self, Obj perm, Obj point)
 {
     UInt                pnt;            /* value of the point              */
 
-    RequirePermutation("CyclePermInt", perm);
+    RequirePermutation(SELF_NAME, perm);
     pnt = GetPositiveSmallInt("CyclePermInt", point) - 1;
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
@@ -1409,7 +1409,7 @@ static inline Obj CYCLE_STRUCT_PERM(Obj perm)
 
 static Obj FuncCYCLE_STRUCT_PERM(Obj self, Obj perm)
 {
-    RequirePermutation("CycleStructPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     if (TNUM_OBJ(perm) == T_PERM2) {
         return CYCLE_STRUCT_PERM<UInt2>(perm);
@@ -1484,7 +1484,7 @@ static inline Obj ORDER_PERM(Obj perm)
 
 static Obj FuncORDER_PERM(Obj self, Obj perm)
 {
-    RequirePermutation("OrderPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
         return ORDER_PERM<UInt2>(perm);
@@ -1558,7 +1558,7 @@ static inline Obj SIGN_PERM(Obj perm)
 
 static Obj FuncSIGN_PERM(Obj self, Obj perm)
 {
-    RequirePermutation("SignPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
         return SIGN_PERM<UInt2>(perm);
@@ -1674,7 +1674,7 @@ static inline Obj SMALLEST_GENERATOR_PERM(Obj perm)
 
 static Obj FuncSMALLEST_GENERATOR_PERM(Obj self, Obj perm)
 {
-    RequirePermutation("SmallestGeneratorPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
         return SMALLEST_GENERATOR_PERM<UInt2>(perm);
@@ -1788,7 +1788,7 @@ static inline Obj RESTRICTED_PERM(Obj perm, Obj dom, Obj test)
 
 static Obj FuncRESTRICTED_PERM(Obj self, Obj perm, Obj dom, Obj test)
 {
-    RequirePermutation("RestrictedPerm", perm);
+    RequirePermutation(SELF_NAME, perm);
 
     if ( TNUM_OBJ(perm) == T_PERM2 ) {
         return RESTRICTED_PERM<UInt2>(perm, dom, test);
@@ -1807,8 +1807,8 @@ static Obj FuncRESTRICTED_PERM(Obj self, Obj perm, Obj dom, Obj test)
 */
 static Obj FuncTRIM_PERM(Obj self, Obj perm, Obj n)
 {
-    RequirePermutation("TRIM_PERM", perm);
-    RequireNonnegativeSmallInt("TRIM_PERM", n);
+    RequirePermutation(SELF_NAME, perm);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
     UInt newDeg = INT_INTOBJ(n);
     UInt oldDeg =
         (TNUM_OBJ(perm) == T_PERM2) ? DEG_PERM2(perm) : DEG_PERM4(perm);
@@ -2471,9 +2471,9 @@ static Obj FuncMappingPermListList(Obj self, Obj src, Obj dst)
     Int mytabs[DEGREELIMITONSTACK+1];
     Int mytabd[DEGREELIMITONSTACK+1];
 
-    RequireDenseList("AddRowVector", src);
-    RequireDenseList("AddRowVector", dst);
-    RequireSameLength("AddRowVector", src, dst);
+    RequireDenseList(SELF_NAME, src);
+    RequireDenseList(SELF_NAME, dst);
+    RequireSameLength(SELF_NAME, src, dst);
 
     l = LEN_LIST(src);
     d = 0;
@@ -2702,8 +2702,8 @@ static Obj SCR_SIFT_HELPER(Obj stb, Obj g, UInt nn)
 static Obj FuncSCR_SIFT_HELPER(Obj self, Obj stb, Obj g, Obj n)
 {
     if (!IS_PREC(stb))
-        RequireArgument("SCR_SIFT_HELPER", stb, "must be a plain record");
-    RequirePermutation("SCR_SIFT_HELPER", g);
+        RequireArgument(SELF_NAME, stb, "must be a plain record");
+    RequirePermutation(SELF_NAME, g);
     UInt nn = GetSmallInt("SCR_SIFT_HELPER", n);
 
     /* Setup the result, sort out which rep we are going to work in  */

--- a/src/plist.c
+++ b/src/plist.c
@@ -799,7 +799,7 @@ Obj             ShallowCopyPlist (
 */
 static Obj FuncEmptyPlist(Obj self, Obj len)
 {
-    RequireNonnegativeSmallInt("EmptyPlist", len);
+    RequireNonnegativeSmallInt(SELF_NAME, len);
     return NEW_PLIST(T_PLIST_EMPTY, INT_INTOBJ(len));
 }
 
@@ -812,7 +812,7 @@ static Obj FuncEmptyPlist(Obj self, Obj len)
 */
 static Obj FuncShrinkAllocationPlist(Obj self, Obj plist)
 {
-    RequirePlainList("ShrinkAllocationPlist", plist);
+    RequirePlainList(SELF_NAME, plist);
     SHRINK_PLIST(plist, LEN_PLIST(plist));
     return (Obj)0;
 }

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -502,7 +502,7 @@ static Obj FuncSparsePartialPermNC(Obj self, Obj dom, Obj img)
 /* the degree of pperm is the maximum point where it is defined */
 static Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
 {
-    RequirePartialPerm("DegreeOfPartialPerm", f);
+    RequirePartialPerm(SELF_NAME, f);
     return INTOBJ_INT(DEG_PPERM(f));
 }
 
@@ -510,14 +510,14 @@ static Obj FuncDegreeOfPartialPerm(Obj self, Obj f)
 
 static Obj FuncCoDegreeOfPartialPerm(Obj self, Obj f)
 {
-    RequirePartialPerm("CoDegreeOfPartialPerm", f);
+    RequirePartialPerm(SELF_NAME, f);
     return INTOBJ_INT(CODEG_PPERM(f));
 }
 
 /* the rank is the number of points where it is defined */
 static Obj FuncRankOfPartialPerm(Obj self, Obj f)
 {
-    RequirePartialPerm("RankOfPartialPerm", f);
+    RequirePartialPerm(SELF_NAME, f);
     return INTOBJ_INT(RANK_PPERM(f));
 }
 
@@ -574,7 +574,7 @@ static Obj FuncIMAGE_PPERM(Obj self, Obj f)
 /* image set of partial perm */
 static Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
 {
-    RequirePartialPerm("IMAGE_SET_PPERM", f);
+    RequirePartialPerm(SELF_NAME, f);
 
     if (IMG_PPERM(f) == NULL) {
         INIT_PPERM(f);
@@ -589,8 +589,8 @@ static Obj FuncIMAGE_SET_PPERM(Obj self, Obj f)
 /* preimage under a partial perm */
 static Obj FuncPREIMAGE_PPERM_INT(Obj self, Obj f, Obj pt)
 {
-    RequirePartialPerm("PREIMAGE_PPERM_INT", f);
-    RequireSmallInt("PREIMAGE_PPERM_INT", pt);
+    RequirePartialPerm(SELF_NAME, f);
+    RequireSmallInt(SELF_NAME, pt);
     if (TNUM_OBJ(f) == T_PPERM2)
         return PreImagePPermInt<UInt2>(pt, f);
     else
@@ -1609,8 +1609,8 @@ static Obj NaturalLeqPartialPerm(Obj f, Obj g)
 
 static Obj FuncNaturalLeqPartialPerm(Obj self, Obj f, Obj g)
 {
-    RequirePartialPerm("NaturalLeqPartialPerm", f);
-    RequirePartialPerm("NaturalLeqPartialPerm", g);
+    RequirePartialPerm(SELF_NAME, f);
+    RequirePartialPerm(SELF_NAME, g);
 
     if (TNUM_OBJ(f) == T_PPERM2 && TNUM_OBJ(g) == T_PPERM2) {
         return NaturalLeqPartialPerm<UInt2, UInt2>(f, g);
@@ -2221,8 +2221,8 @@ static Obj FuncShortLexLeqPartialPerm(Obj self, Obj f, Obj g)
     UInt2 *ptf2, *ptg2;
     UInt4 *ptf4, *ptg4;
 
-    RequirePartialPerm("ShortLexLeqPartialPerm", f);
-    RequirePartialPerm("ShortLexLeqPartialPerm", g);
+    RequirePartialPerm(SELF_NAME, f);
+    RequirePartialPerm(SELF_NAME, g);
 
     if (TNUM_OBJ(f) == T_PPERM2) {
         if (DEG_PPERM2(f) == 0)

--- a/src/precord.c
+++ b/src/precord.c
@@ -574,7 +574,7 @@ static Obj FuncREC_NAMES(Obj self, Obj rec)
         return InnerRecNames(FromAtomicRecord(rec));
     }
 #endif
-    RequireArgument("RecNames", rec, "must be a record");
+    RequireArgument(SELF_NAME, rec, "must be a record");
     return Fail;
 }
 
@@ -594,7 +594,7 @@ static Obj FuncREC_NAMES_COMOBJ(Obj self, Obj rec)
         return InnerRecNames(FromAtomicRecord(rec));
 #endif
     }
-    RequireArgument("RecNames", rec, "must be a component object");
+    RequireArgument(SELF_NAME, rec, "must be a component object");
     return Fail;
 }
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -696,7 +696,7 @@ static Obj FuncACTIVATE_PROFILING(Obj self,
     OutputtedFilenameList = NEW_PLIST(T_PLIST, 0);
     profileState.visitedDepths = NEW_PLIST(T_PLIST, 0);
 
-    RequireStringRep("ACTIVATE_PROFILING", filename);
+    RequireStringRep(SELF_NAME, filename);
 
     if(coverage != True && coverage != False) {
       ErrorMayQuit("<coverage> must be a boolean",0,0);
@@ -727,7 +727,7 @@ static Obj FuncACTIVATE_PROFILING(Obj self,
 
     profileState.lastOutputtedTime = getTicks();
 
-    RequireNonnegativeSmallInt("ACTIVATE_PROFILING", resolution);
+    RequireNonnegativeSmallInt(SELF_NAME, resolution);
 
     HashLock(&profileState);
 

--- a/src/range.c
+++ b/src/range.c
@@ -865,10 +865,9 @@ static Obj FuncINTER_RANGE(Obj self, Obj r1, Obj r2)
   UInt len1, len2, leni;
   
   if (!IS_RANGE(r1) || !IS_MUTABLE_OBJ(r1))
-      RequireArgumentEx("INTER_RANGE", r1, "<range1>",
-                        "must be a mutable range");
+      RequireArgumentEx(SELF_NAME, r1, "<range1>", "must be a mutable range");
   if (!IS_RANGE(r2))
-      RequireArgumentEx("INTER_RANGE", r2, "<range2>", "must be a range");
+      RequireArgumentEx(SELF_NAME, r2, "<range2>", "must be a range");
 
   low1 = GET_LOW_RANGE(r1);
   low2 = GET_LOW_RANGE(r2);

--- a/src/rational.c
+++ b/src/rational.c
@@ -304,7 +304,7 @@ static Obj AbsRat(Obj op)
 
 static Obj FuncABS_RAT(Obj self, Obj op)
 {
-    RequireRational("AbsRat", op);
+    RequireRational(SELF_NAME, op);
     return (TNUM_OBJ(op) == T_RAT) ? AbsRat(op) : AbsInt(op);
 }
 
@@ -320,7 +320,7 @@ static Obj SignRat(Obj op)
 
 static Obj FuncSIGN_RAT(Obj self, Obj op)
 {
-    RequireRational("SignRat", op);
+    RequireRational(SELF_NAME, op);
     return (TNUM_OBJ(op) == T_RAT) ? SignRat(op) : SignInt(op);
 }
 
@@ -700,7 +700,7 @@ static Obj FiltIS_RAT(Obj self, Obj val)
 */
 static Obj FuncNUMERATOR_RAT(Obj self, Obj rat)
 {
-    RequireRational("NumeratorRat", rat);
+    RequireRational(SELF_NAME, rat);
 
     if ( TNUM_OBJ(rat) == T_RAT ) {
         return NUM_RAT(rat);
@@ -723,7 +723,7 @@ static Obj FuncNUMERATOR_RAT(Obj self, Obj rat)
 */
 static Obj FuncDENOMINATOR_RAT(Obj self, Obj rat)
 {
-    RequireRational("DenominatorRat", rat);
+    RequireRational(SELF_NAME, rat);
 
     if ( TNUM_OBJ(rat) == T_RAT ) {
         return DEN_RAT(rat);

--- a/src/sctable.c
+++ b/src/sctable.c
@@ -63,7 +63,7 @@ static Obj FuncSC_TABLE_ENTRY(Obj self, Obj table, Obj i, Obj j, Obj k)
     Int                 l;              /* loop variable                   */
 
     /* check the table                                                     */
-    RequireSmallList("SCTableEntry", table);
+    RequireSmallList(SELF_NAME, table);
     dim = LEN_LIST(table) - 2;
     if ( dim <= 0 ) {
         ErrorMayQuit(
@@ -72,7 +72,7 @@ static Obj FuncSC_TABLE_ENTRY(Obj self, Obj table, Obj i, Obj j, Obj k)
     }
 
     /* check <i>                                                           */
-    RequireBoundedInt("SCTableEntry", i, 1, dim);
+    RequireBoundedInt(SELF_NAME, i, 1, dim);
 
     /* get and check the relevant row                                      */
     tmp = ELM_LIST( table, INT_INTOBJ(i) );
@@ -83,7 +83,7 @@ static Obj FuncSC_TABLE_ENTRY(Obj self, Obj table, Obj i, Obj j, Obj k)
     }
 
     /* check <j>                                                           */
-    RequireBoundedInt("SCTableEntry", j, 1, dim);
+    RequireBoundedInt(SELF_NAME, j, 1, dim);
 
     /* get and check the basis and coefficients list                       */
     tmp = ELM_LIST( tmp, INT_INTOBJ(j) );
@@ -116,7 +116,7 @@ static Obj FuncSC_TABLE_ENTRY(Obj self, Obj table, Obj i, Obj j, Obj k)
     }
 
     /* check <k>                                                           */
-    RequireBoundedInt("SCTableEntry", k, 1, dim);
+    RequireBoundedInt(SELF_NAME, k, 1, dim);
 
     /* look for the (i,j,k) entry                                          */
     for ( l = 1; l <= len; l++ ) {
@@ -182,7 +182,7 @@ static Obj FuncSC_TABLE_PRODUCT(Obj self, Obj table, Obj list1, Obj list2)
     Int                 i, j;           /* loop variables                  */
 
     /* check the arguments a bit                                           */
-    RequireSmallList("SCTableProduct", table);
+    RequireSmallList(SELF_NAME, table);
     dim = LEN_LIST(table) - 2;
     if ( dim <= 0 ) {
         ErrorMayQuit(

--- a/src/set.c
+++ b/src/set.c
@@ -166,7 +166,7 @@ static Obj FuncLIST_SORTED_LIST(Obj self, Obj list)
 {
     Obj                 set;            /* result                          */
 
-    RequireSmallList("Set", list);
+    RequireSmallList(SELF_NAME, list);
 
     /* if the list is empty create a new empty list                        */
     if ( LEN_LIST(list) == 0 ) {
@@ -231,8 +231,8 @@ static Int EqSet(Obj listL, Obj listR)
 
 static Obj FuncIS_EQUAL_SET(Obj self, Obj list1, Obj list2)
 {
-    RequireSmallList("IsEqualSet", list1);
-    RequireSmallList("IsEqualSet", list2);
+    RequireSmallList(SELF_NAME, list1);
+    RequireSmallList(SELF_NAME, list2);
     if (!IsPlainSet(list1)) list1 = SetList(list1);
     if (!IsPlainSet(list2)) list2 = SetList(list2);
 
@@ -263,8 +263,8 @@ static Obj FuncIS_SUBSET_SET(Obj self, Obj set1, Obj set2)
     Obj                 e1;             /* element of left  set            */
     Obj                 e2;             /* element of right set            */
 
-    RequireSmallList("IsSubsetSet", set1);
-    RequireSmallList("IsSubsetSet", set2);
+    RequireSmallList(SELF_NAME, set1);
+    RequireSmallList(SELF_NAME, set2);
     if (!IsPlainSet(set1)) set1 = SetList(set1);
     if (!IsPlainSet(set2)) set2 = SetList(set2);
 
@@ -328,8 +328,8 @@ static Obj FuncADD_SET(Obj self, Obj set, Obj obj)
   UInt                wasHom;
   UInt                wasNHom;
   UInt                wasTab;
-    
-  RequireMutableSet("AddSet", set);
+
+  RequireMutableSet(SELF_NAME, set);
   len = LEN_PLIST(set);
 
   /* perform the binary search to find the position                      */
@@ -438,7 +438,7 @@ static Obj FuncREM_SET(Obj self, Obj set, Obj obj)
     UInt                len;            /* logical length of the list      */
     UInt                pos;            /* position                        */
 
-    RequireMutableSet("RemoveSet", set);
+    RequireMutableSet(SELF_NAME, set);
     len = LEN_PLIST(set);
 
     /* perform the binary search to find the position                      */
@@ -491,8 +491,8 @@ static Obj FuncUNITE_SET(Obj self, Obj set1, Obj set2)
     Obj                 e2;             /* element of right set            */
     Obj                 TmpUnion;
 
-    RequireMutableSet("UniteSet", set1);
-    RequireSmallList("UniteSet", set2);
+    RequireMutableSet(SELF_NAME, set1);
+    RequireSmallList(SELF_NAME, set2);
     if (!IsPlainSet(set2)) set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */
@@ -640,8 +640,8 @@ static Obj FuncINTER_SET(Obj self, Obj set1, Obj set2)
     UInt                len2;           /* length  of right set            */
     UInt                lenr;           /* length  of result set           */
 
-    RequireMutableSet("IntersectSet", set1);
-    RequireSmallList("IntersectSet", set2);
+    RequireMutableSet(SELF_NAME, set1);
+    RequireSmallList(SELF_NAME, set2);
     if (!IsPlainSet(set2)) set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */
@@ -800,10 +800,10 @@ static Obj FuncSUBTR_SET(Obj self, Obj set1, Obj set2)
     UInt                len2;           /* length  of right set            */
     UInt                lenr;           /* length  of result set           */
     UInt                x;            
-    UInt                ll;           
+    UInt                ll;
 
-    RequireMutableSet("SubtractSet", set1);
-    RequireSmallList("SubtractSet", set2);
+    RequireMutableSet(SELF_NAME, set1);
+    RequireSmallList(SELF_NAME, set2);
     if (!IsPlainSet(set2)) set2 = SetList(set2);
 
     /* get the logical lengths and the pointer                             */

--- a/src/streams.c
+++ b/src/streams.c
@@ -242,7 +242,7 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     Obj result;
     Obj evalResult;
 
-    RequireInputStream("READ_COMMAND_REAL", stream);
+    RequireInputStream(SELF_NAME, stream);
 
     result = NEW_PLIST( T_PLIST, 2 );
     SET_LEN_PLIST(result, 1);
@@ -546,7 +546,7 @@ static Obj FuncCLOSE_LOG_TO(Obj self)
 */
 static Obj FuncLOG_TO(Obj self, Obj filename)
 {
-    RequireStringRep("LogTo", filename);
+    RequireStringRep(SELF_NAME, filename);
     if ( ! OpenLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid("LogTo: cannot log to %g", (Int)filename, 0,
                         "you can 'return;'");
@@ -562,7 +562,7 @@ static Obj FuncLOG_TO(Obj self, Obj filename)
 */
 static Obj FuncLOG_TO_STREAM(Obj self, Obj stream)
 {
-    RequireOutputStream("LogTo", stream);
+    RequireOutputStream(SELF_NAME, stream);
     if ( ! OpenLogStream(stream) ) {
         ErrorReturnVoid("LogTo: cannot log to stream", 0, 0,
                         "you can 'return;'");
@@ -607,7 +607,7 @@ static Obj FuncCLOSE_INPUT_LOG_TO(Obj self)
 */
 static Obj FuncINPUT_LOG_TO(Obj self, Obj filename)
 {
-    RequireStringRep("InputLogTo", filename);
+    RequireStringRep(SELF_NAME, filename);
     if ( ! OpenInputLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid("InputLogTo: cannot log to %g", (Int)filename, 0,
                         "you can 'return;'");
@@ -623,7 +623,7 @@ static Obj FuncINPUT_LOG_TO(Obj self, Obj filename)
 */
 static Obj FuncINPUT_LOG_TO_STREAM(Obj self, Obj stream)
 {
-    RequireOutputStream("InputLogTo", stream);
+    RequireOutputStream(SELF_NAME, stream);
     if ( ! OpenInputLogStream(stream) ) {
         ErrorReturnVoid("InputLogTo: cannot log to stream", 0, 0,
                         "you can 'return;'");
@@ -668,7 +668,7 @@ static Obj FuncCLOSE_OUTPUT_LOG_TO(Obj self)
 */
 static Obj FuncOUTPUT_LOG_TO(Obj self, Obj filename)
 {
-    RequireStringRep("OutputLogTo", filename);
+    RequireStringRep(SELF_NAME, filename);
     if ( ! OpenOutputLog( CONST_CSTR_STRING(filename) ) ) {
         ErrorReturnVoid("OutputLogTo: cannot log to %g", (Int)filename, 0,
                         "you can 'return;'");
@@ -684,7 +684,7 @@ static Obj FuncOUTPUT_LOG_TO(Obj self, Obj filename)
 */
 static Obj FuncOUTPUT_LOG_TO_STREAM(Obj self, Obj stream)
 {
-    RequireOutputStream("OutputLogTo", stream);
+    RequireOutputStream(SELF_NAME, stream);
     if ( ! OpenOutputLogStream(stream) ) {
         ErrorReturnVoid("OutputLogTo: cannot log to stream", 0, 0,
                         "you can 'return;'");
@@ -856,7 +856,7 @@ static Obj FuncAPPEND_TO_STREAM(Obj self, Obj args)
 */
 static Obj FuncREAD(Obj self, Obj filename)
 {
-    RequireStringRep("READ", filename);
+    RequireStringRep(SELF_NAME, filename);
 
     /* try to open the file                                                */
     if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
@@ -909,7 +909,7 @@ static Obj FuncREAD_NORECOVERY(Obj self, Obj input)
 */
 static Obj FuncREAD_STREAM(Obj self, Obj stream)
 {
-    RequireInputStream("READ_STREAM", stream);
+    RequireInputStream(SELF_NAME, stream);
 
     /* try to open the file                                                */
     if (!OpenInputStream(stream, 0)) {
@@ -935,8 +935,8 @@ static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT(Obj self,
 {
     Int res;
 
-    RequireInputStream("READ_STREAM_LOOP", instream);
-    RequireOutputStream("READ_STREAM_LOOP", outstream);
+    RequireInputStream(SELF_NAME, instream);
+    RequireOutputStream(SELF_NAME, outstream);
 
     if (!OpenInputStream(instream, 0)) {
         return False;
@@ -972,7 +972,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self, Obj stream, Obj catcherrstdout)
 */
 static Obj FuncREAD_AS_FUNC(Obj self, Obj filename)
 {
-    RequireStringRep("READ_AS_FUNC", filename);
+    RequireStringRep(SELF_NAME, filename);
 
     /* try to open the file                                                */
     if ( ! OpenInput( CONST_CSTR_STRING(filename) ) ) {
@@ -990,7 +990,7 @@ static Obj FuncREAD_AS_FUNC(Obj self, Obj filename)
 */
 static Obj FuncREAD_AS_FUNC_STREAM(Obj self, Obj stream)
 {
-    RequireInputStream("READ_AS_FUNC_STREAM", stream);
+    RequireInputStream(SELF_NAME, stream);
 
     /* try to open the file                                                */
     if (!OpenInputStream(stream, 0)) {
@@ -1010,7 +1010,7 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 {
     Char filenamecpy[GAP_PATH_MAX];
 
-    RequireStringRep("READ", filename);
+    RequireStringRep(SELF_NAME, filename);
 
     /* Copy to avoid garbage collection moving string                      */
     strlcpy(filenamecpy, CONST_CSTR_STRING(filename), GAP_PATH_MAX);
@@ -1069,8 +1069,8 @@ static Obj FuncTmpDirectory(Obj self)
 */
 static Obj FuncRemoveFile(Obj self, Obj filename)
 {
-    RequireStringRep("RemoveFile", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     return SyRemoveFile( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
 }
@@ -1081,8 +1081,8 @@ static Obj FuncRemoveFile(Obj self, Obj filename)
 */
 static Obj FuncCreateDir(Obj self, Obj filename)
 {
-    RequireStringRep("CreateDir", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     return SyMkdir( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
 }
@@ -1093,8 +1093,8 @@ static Obj FuncCreateDir(Obj self, Obj filename)
 */
 static Obj FuncRemoveDir(Obj self, Obj filename)
 {
-    RequireStringRep("RemoveDir", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     return SyRmdir( CONST_CSTR_STRING(filename) ) == -1 ? Fail : True;
 }
@@ -1105,7 +1105,7 @@ static Obj FuncRemoveDir(Obj self, Obj filename)
 */
 static Obj FuncIsDir(Obj self, Obj filename)
 {
-    RequireStringRep("IsDir", filename);
+    RequireStringRep(SELF_NAME, filename);
 
     /* call the system dependent function                                  */
     return SyIsDir( CONST_CSTR_STRING(filename) );
@@ -1162,8 +1162,8 @@ static Obj FuncIsExistingFile(Obj self, Obj filename)
 {
     Int             res;
 
-    RequireStringRep("IsExistingFile", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     res = SyIsExistingFile( CONST_CSTR_STRING(filename) );
     return res == -1 ? False : True;
@@ -1178,8 +1178,8 @@ static Obj FuncIsReadableFile(Obj self, Obj filename)
 {
     Int             res;
 
-    RequireStringRep("IsReadableFile", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     res = SyIsReadableFile( CONST_CSTR_STRING(filename) );
     return res == -1 ? False : True;
@@ -1194,8 +1194,8 @@ static Obj FuncIsWritableFile(Obj self, Obj filename)
 {
     Int             res;
 
-    RequireStringRep("IsWritableFile", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     res = SyIsWritableFile( CONST_CSTR_STRING(filename) );
     return res == -1 ? False : True;
@@ -1210,8 +1210,8 @@ static Obj FuncIsExecutableFile(Obj self, Obj filename)
 {
     Int             res;
 
-    RequireStringRep("IsExecutableFile", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     res = SyIsExecutableFile( CONST_CSTR_STRING(filename) );
     return res == -1 ? False : True;
@@ -1226,8 +1226,8 @@ static Obj FuncIsDirectoryPathString(Obj self, Obj filename)
 {
     Int             res;
 
-    RequireStringRep("IsDirectoryPathString", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     res = SyIsDirectoryPath( CONST_CSTR_STRING(filename) );
     return res == -1 ? False : True;
@@ -1251,8 +1251,8 @@ static Obj FuncLIST_DIR(Obj self, Obj dirname)
     struct dirent *entry;
     Obj res;
 
-    RequireStringRep("LIST_DIR", dirname);
-    
+    RequireStringRep(SELF_NAME, dirname);
+
     SyClearErrorNo();
     dir = opendir(CONST_CSTR_STRING(dirname));
     if (dir == NULL) {
@@ -1294,8 +1294,8 @@ static Obj FuncINPUT_TEXT_FILE(Obj self, Obj filename)
 {
     Int             fid;
 
-    RequireStringRep("INPUT_TEXT_FILE", filename);
-    
+    RequireStringRep(SELF_NAME, filename);
+
     /* call the system dependent function                                  */
     SyClearErrorNo();
     fid = SyFopen( CONST_CSTR_STRING(filename), "r" );
@@ -1326,9 +1326,9 @@ static Obj FuncOUTPUT_TEXT_FILE(Obj self, Obj filename, Obj append)
 {
     Int             fid;
 
-    RequireStringRep("OUTPUT_TEXT_FILE", filename);
-    RequireTrueOrFalse("OUTPUT_TEXT_FILE", append);
-    
+    RequireStringRep(SELF_NAME, filename);
+    RequireTrueOrFalse(SELF_NAME, append);
+
     /* call the system dependent function                                  */
     SyClearErrorNo();
     if ( append == True ) {
@@ -1617,9 +1617,9 @@ static Obj FuncUNIXSelect(Obj self,
   Int i,j;
   Obj o;
 
-  RequirePlainList("UNIXSelect", inlist);
-  RequirePlainList("UNIXSelect", outlist);
-  RequirePlainList("UNIXSelect", exclist);
+  RequirePlainList(SELF_NAME, inlist);
+  RequirePlainList(SELF_NAME, outlist);
+  RequirePlainList(SELF_NAME, exclist);
 
   FD_ZERO(&infds);
   FD_ZERO(&outfds);
@@ -1722,18 +1722,18 @@ FuncExecuteProcess(Obj self, Obj dir, Obj prg, Obj in, Obj out, Obj args)
     Int                 res;
     Int                 i;
 
-    RequireStringRep("ExecuteProcess", dir);
-    RequireStringRep("ExecuteProcess", prg);
+    RequireStringRep(SELF_NAME, dir);
+    RequireStringRep(SELF_NAME, prg);
     Int iin = GetSmallInt("ExecuteProcess", in);
     Int iout = GetSmallInt("ExecuteProcess", out);
-    RequireSmallList("ExecuteProcess", args);
+    RequireSmallList(SELF_NAME, args);
 
     /* create an argument array                                            */
     for ( i = 1;  i <= LEN_LIST(args);  i++ ) {
         if ( i == 1023 )
             break;
         tmp = ELM_LIST( args, i );
-        RequireStringRep("ExecuteProcess", tmp);
+        RequireStringRep(SELF_NAME, tmp);
         ExecArgs[i] = tmp;
     }
     ExecCArgs[0]   = CSTR_STRING(prg);

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -204,7 +204,7 @@ static void LoadChar(Obj c)
 static Obj FuncEmptyString(Obj self, Obj len)
 {
     Obj                 new;
-    RequireNonnegativeSmallInt("EmptyString", len);
+    RequireNonnegativeSmallInt(SELF_NAME, len);
     new = NEW_STRING(INT_INTOBJ(len));
     SET_LEN_STRING(new, 0);
     return new;
@@ -220,7 +220,7 @@ static Obj FuncEmptyString(Obj self, Obj len)
 */
 static Obj FuncShrinkAllocationString(Obj self, Obj str)
 {
-    RequireStringRep("ShrinkAllocationString", str);
+    RequireStringRep(SELF_NAME, str);
     SHRINK_STRING(str);
     return (Obj)0;
 }
@@ -249,7 +249,7 @@ static Obj FuncINT_CHAR(Obj self, Obj val)
 {
     /* get and check the character                                         */
     if (TNUM_OBJ(val) != T_CHAR) {
-        RequireArgument("INT_CHAR", val, "must be a character");
+        RequireArgument(SELF_NAME, val, "must be a character");
     }
 
     /* return the character                                                */
@@ -280,7 +280,7 @@ static Obj FuncSINT_CHAR(Obj self, Obj val)
 {
     /* get and check the character                                         */
     if (TNUM_OBJ(val) != T_CHAR) {
-        RequireArgument("SINT_CHAR", val, "must be a character");
+        RequireArgument(SELF_NAME, val, "must be a character");
     }
 
     /* return the character                                                */
@@ -298,7 +298,7 @@ static Obj FuncINTLIST_STRING(Obj self, Obj val, Obj sign)
   const UInt1 *p;
 
   /* test whether val is a string, convert to compact rep if necessary */
-  RequireStringRep("INTLIST_STRING", val);
+  RequireStringRep(SELF_NAME, val);
 
   l=GET_LEN_STRING(val);
   n=NEW_PLIST(T_PLIST,l);
@@ -343,7 +343,7 @@ static Obj FuncSTRING_SINTLIST(Obj self, Obj val)
   /* general code */
   if (!IS_RANGE(val) && !IS_PLIST(val)) {
   again:
-      RequireArgument("STRING_SINTLIST", val,
+      RequireArgument(SELF_NAME, val,
                       "must be a plain list of small integers or a range");
   }
   if (! IS_RANGE(val) ) {
@@ -385,7 +385,7 @@ static Obj FuncREVNEG_STRING(Obj self, Obj val)
   UInt1 *q;
 
   /* test whether val is a string, convert to compact rep if necessary */
-  RequireStringRep("REVNEG_STRING", val);
+  RequireStringRep(SELF_NAME, val);
 
   l=GET_LEN_STRING(val);
   n=NEW_STRING(l);
@@ -647,7 +647,7 @@ void PrintString(Obj list)
 Obj FuncVIEW_STRING_FOR_STRING(Obj self, Obj string)
 {
     if (!IS_STRING(string)) {
-        RequireArgument("VIEW_STRING_FOR_STRING", string, "must be a string");
+        RequireArgument(SELF_NAME, string, "must be a string");
     }
 
     if (!IS_STRING_REP(string)) {
@@ -1343,7 +1343,7 @@ static Obj FuncIS_STRING_CONV(Obj self, Obj obj)
 static Obj FuncCONV_STRING(Obj self, Obj string)
 {
     if (!IS_STRING(string)) {
-        RequireArgument("ConvString", string, "must be a string");
+        RequireArgument(SELF_NAME, string, "must be a string");
     }
 
     /* convert to the string representation                                */
@@ -1371,7 +1371,7 @@ static Obj FiltIS_STRING_REP(Obj self, Obj obj)
 static Obj FuncCOPY_TO_STRING_REP(Obj self, Obj string)
 {
     if (!IS_STRING(string)) {
-        RequireArgument("CopyToStringRep", string, "must be a string");
+        RequireArgument(SELF_NAME, string, "must be a string");
     }
     return CopyToStringRep(string);
 }
@@ -1391,9 +1391,9 @@ static Obj FuncPOSITION_SUBSTRING(Obj self, Obj string, Obj substr, Obj off)
   Int    ipos, i, j, lens, lenss, max;
   const UInt1  *s, *ss;
 
-  RequireStringRep("POSITION_SUBSTRING", string);
-  RequireStringRep("POSITION_SUBSTRING", substr);
-  RequireNonnegativeSmallInt("POSITION_SUBSTRING", off);
+  RequireStringRep(SELF_NAME, string);
+  RequireStringRep(SELF_NAME, substr);
+  RequireNonnegativeSmallInt(SELF_NAME, off);
 
   ipos = INT_INTOBJ(off);
 
@@ -1437,8 +1437,8 @@ static Obj FuncNormalizeWhitespace(Obj self, Obj string)
   UInt1  *s, c;
   Int i, j, len, white;
 
-  RequireStringRep("NormalizeWhitespace", string);
-  
+  RequireStringRep(SELF_NAME, string);
+
   len = GET_LEN_STRING(string);
   s = CHARS_STRING(string);
   i = -1;
@@ -1483,9 +1483,9 @@ static Obj FuncREMOVE_CHARACTERS(Obj self, Obj string, Obj rem)
   Int i, j, len;
   UInt1 REMCHARLIST[256] = {0};
 
-  RequireStringRep("RemoveCharacters", string);
-  RequireStringRep("RemoveCharacters", rem);
-  
+  RequireStringRep(SELF_NAME, string);
+  RequireStringRep(SELF_NAME, rem);
+
   /* set REMCHARLIST by setting positions of characters in rem to 1 */
   len = GET_LEN_STRING(rem);
   s = CHARS_STRING(rem);
@@ -1520,8 +1520,8 @@ static Obj FuncTranslateString(Obj self, Obj string, Obj trans)
 {
   Int j, len;
 
-  RequireStringRep("TranslateString", string);
-  RequireStringRep("TranslateString", trans);
+  RequireStringRep(SELF_NAME, string);
+  RequireStringRep(SELF_NAME, trans);
   if ( GET_LEN_STRING( trans ) < 256 ) {
       ErrorMayQuit("TranslateString: <trans> must have length >= 256",
                    0, 0 );
@@ -1555,9 +1555,9 @@ static Obj FuncSplitStringInternal(Obj self, Obj string, Obj seps, Obj wspace)
   UInt1 SPLITSTRINGSEPS[256] = { 0 };
   UInt1 SPLITSTRINGWSPACE[256] = { 0 };
 
-  RequireStringRep("SplitString", string);
-  RequireStringRep("SplitString", seps);
-  RequireStringRep("SplitString", wspace);
+  RequireStringRep(SELF_NAME, string);
+  RequireStringRep(SELF_NAME, seps);
+  RequireStringRep(SELF_NAME, wspace);
 
   /* set SPLITSTRINGSEPS by setting positions of characters in rem to 1 */
   len = GET_LEN_STRING(seps);

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -637,7 +637,7 @@ static Expr SyntaxTreeCodeFunc(Obj node)
 
 static Obj FuncSYNTAX_TREE_CODE(Obj self, Obj tree)
 {
-    RequirePlainRec("SYNTAX_TREE_CODE", tree);
+    RequirePlainRec(SELF_NAME, tree);
     CodeBegin();
     UInt nr_stats = SyntaxTreeCodeFunc_Internal(tree);
     CodeFuncExprEnd(nr_stats, 0);
@@ -902,7 +902,7 @@ static Obj FuncSYNTAX_TREE(Obj self, Obj func)
     Obj result;
 
     if (!IS_FUNC(func) || IsKernelFunction(func) || IS_OPERATION(func)) {
-        RequireArgument("SYNTAX_TREE", func, "must be a plain GAP function");
+        RequireArgument(SELF_NAME, func, "must be a plain GAP function");
     }
 
     result = NewSyntaxTreeNode(EXPR_FUNC);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -305,7 +305,7 @@ static Obj FuncCrcString(Obj self, Obj str)
     Int4        ch;
     Int         seen_nl;
 
-    RequireStringRep("CrcString", str);
+    RequireStringRep(SELF_NAME, str);
 
     ptr = CONST_CSTR_STRING(str);
     len = GET_LEN_STRING(str);

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -463,9 +463,9 @@ static Obj FuncTransformationListListNC(Obj self, Obj src, Obj ran)
     UInt2 * ptf2;
     UInt4 * ptf4;
 
-    RequireSmallList("TransformationListListNC", src);
-    RequireSmallList("TransformationListListNC", ran);
-    RequireSameLength("TransformationListListNC", src, ran);
+    RequireSmallList(SELF_NAME, src);
+    RequireSmallList(SELF_NAME, ran);
+    RequireSameLength(SELF_NAME, src, ran);
 
     deg = 0;
     for (i = LEN_LIST(src); 1 <= i; i--) {
@@ -621,7 +621,7 @@ static Obj FuncLEFT_ONE_TRANS(Obj self, Obj f)
     Obj  ker, img;
     UInt rank, n, i;
 
-    RequireTransformation("LEFT_ONE_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     rank = RANK_TRANS(f);
     ker = KER_TRANS(f);
@@ -646,7 +646,7 @@ static Obj FuncRIGHT_ONE_TRANS(Obj self, Obj f)
     Obj  ker, img;
     UInt deg, len, i, j, n;
 
-    RequireTransformation("RIGHT_ONE_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     deg = DEG_TRANS(f);
     img = FuncIMAGE_SET_TRANS(self, f);
@@ -678,7 +678,7 @@ static Obj FuncDegreeOfTransformation(Obj self, Obj f)
     const UInt2 * ptf2;
     const UInt4 * ptf4;
 
-    RequireTransformation("DegreeOfTransformation", f);
+    RequireTransformation(SELF_NAME, f);
 
     if (EXT_TRANS(f) == NULL) {
         n = DEG_TRANS(f);
@@ -727,7 +727,7 @@ static Obj FuncDegreeOfTransformation(Obj self, Obj f)
 
 static Obj FuncRANK_TRANS(Obj self, Obj f)
 {
-    RequireTransformation("RANK_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
     return SumInt(INTOBJ_INT(RANK_TRANS(f) - DEG_TRANS(f)),
                   FuncDegreeOfTransformation(self, f));
 }
@@ -742,8 +742,8 @@ static Obj FuncRANK_TRANS_INT(Obj self, Obj f, Obj n)
     const UInt4 * ptf4;
     UInt4 * pttmp;
 
-    RequireTransformation("RANK_TRANS_INT", f);
-    RequireNonnegativeSmallInt("RANK_TRANS_INT", n);
+    RequireTransformation(SELF_NAME, f);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
 
     m = INT_INTOBJ(n);
     deg = DEG_TRANS(f);
@@ -787,8 +787,8 @@ static Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list)
     const UInt4 * ptf4;
     UInt4 * pttmp;
 
-    RequireTransformation("RANK_TRANS_LIST", f);
-    RequireSmallList("RANK_TRANS_LIST", list);
+    RequireTransformation(SELF_NAME, f);
+    RequireSmallList(SELF_NAME, list);
 
     len = LEN_LIST(list);
     rank = 0;
@@ -841,7 +841,7 @@ static Obj FuncRANK_TRANS_LIST(Obj self, Obj f, Obj list)
 
 static Obj FuncFLAT_KERNEL_TRANS(Obj self, Obj f)
 {
-    RequireTransformation("FLAT_KERNEL_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     if (KER_TRANS(f) == NULL) {
         INIT_TRANS(f);
@@ -857,8 +857,8 @@ static Obj FuncFLAT_KERNEL_TRANS_INT(Obj self, Obj f, Obj n)
     const Obj *ptker;
     UInt deg, m, i;
 
-    RequireTransformation("FLAT_KERNEL_TRANS_INT", f);
-    RequireNonnegativeSmallInt("FLAT_KERNEL_TRANS_INT", n);
+    RequireTransformation(SELF_NAME, f);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
 
     m = INT_INTOBJ(n);
     if (m == 0) {
@@ -905,8 +905,8 @@ static Obj FuncKERNEL_TRANS(Obj self, Obj f, Obj n)
     UInt    i, j, deg, nr, m, rank, min;
     UInt4 * pttmp;
 
-    RequireNonnegativeSmallInt("KERNEL_TRANS", n);
-    RequireTransformation("KERNEL_TRANS", f);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
+    RequireTransformation(SELF_NAME, f);
 
     m = INT_INTOBJ(n);
 
@@ -958,7 +958,7 @@ static Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
     UInt deg, nr, i, j;
     Obj  out;
 
-    RequireTransformation("PREIMAGES_TRANS_INT", f);
+    RequireTransformation(SELF_NAME, f);
     i = GetPositiveSmallInt("PREIMAGES_TRANS_INT", pt) - 1;
 
     deg = DEG_TRANS(f);
@@ -1002,7 +1002,7 @@ static Obj FuncPREIMAGES_TRANS_INT(Obj self, Obj f, Obj pt)
 
 static Obj FuncUNSORTED_IMAGE_SET_TRANS(Obj self, Obj f)
 {
-    RequireTransformation("UNSORTED_IMAGE_SET_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     if (IMG_TRANS(f) == NULL) {
         INIT_TRANS(f);
@@ -1038,8 +1038,8 @@ static Obj FuncIMAGE_SET_TRANS_INT(Obj self, Obj f, Obj n)
     const UInt4 * ptf4;
     const UInt2 * ptf2;
 
-    RequireNonnegativeSmallInt("IMAGE_SET_TRANS_INT", n);
-    RequireTransformation("IMAGE_SET_TRANS_INT", f);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
+    RequireTransformation(SELF_NAME, f);
 
     m = INT_INTOBJ(n);
     deg = DEG_TRANS(f);
@@ -1112,8 +1112,8 @@ static Obj FuncIMAGE_LIST_TRANS_INT(Obj self, Obj f, Obj n)
     UInt    i, deg, m;
     Obj     out;
 
-    RequireNonnegativeSmallInt("IMAGE_LIST_TRANS_INT", n);
-    RequireTransformation("IMAGE_LIST_TRANS_INT", f);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
+    RequireTransformation(SELF_NAME, f);
 
     m = INT_INTOBJ(n);
 
@@ -1156,7 +1156,7 @@ static Obj FuncIS_ID_TRANS(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt    deg, i;
 
-    RequireTransformation("IS_ID_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);
@@ -1188,7 +1188,7 @@ static Obj FuncIS_IDEM_TRANS(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt    deg, i;
 
-    RequireTransformation("IS_IDEM_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         deg = DEG_TRANS2(f);
@@ -1227,7 +1227,7 @@ static Obj FuncIndexPeriodOfTransformation(Obj self, Obj f)
     Obj     ord;
     Int     cyc;
 
-    RequireTransformation("IndexPeriodOfTransformation", f);
+    RequireTransformation(SELF_NAME, f);
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
@@ -1372,9 +1372,9 @@ static Obj FuncIsInjectiveListTrans(Obj self, Obj list, Obj obj)
     const UInt4 * ptt4;
     UInt4 * pttmp = 0;
 
-    RequireSmallList("IsInjectiveListTrans", list);
+    RequireSmallList(SELF_NAME, list);
     if (!IS_TRANS(obj) && !IS_LIST(obj)) {
-        RequireArgument("IsInjectiveListTrans", obj, "must be a transformation or a list");
+        RequireArgument(SELF_NAME, obj, "must be a transformation or a list");
     }
     // init buffer
     n = (IS_TRANS(obj) ? DEG_TRANS(obj) : LEN_LIST(obj));
@@ -1440,7 +1440,7 @@ static Obj FuncInverseOfTransformation(Obj self, Obj f)
     UInt   deg, i;
     Obj    g;
 
-    RequireTransformation("InverseOfTransformation", f);
+    RequireTransformation(SELF_NAME, f);
     if (FuncIS_ID_TRANS(self, f) == True) {
         return f;
     }
@@ -1497,9 +1497,9 @@ static Obj FuncON_KERNEL_ANTI_ACTION(Obj self, Obj ker, Obj f, Obj n)
     UInt    deg, i, j, rank, len;
     Obj     out;
 
-    RequireSmallList("ON_KERNEL_ANTI_ACTION", ker);
-    RequireTransformation("ON_KERNEL_ANTI_ACTION", f);
-    RequireNonnegativeSmallInt("ON_KERNEL_ANTI_ACTION", n);
+    RequireSmallList(SELF_NAME, ker);
+    RequireTransformation(SELF_NAME, f);
+    RequireNonnegativeSmallInt(SELF_NAME, n);
 
     len = LEN_LIST(ker);
     if (len == 1 && ELM_LIST(ker, 1) == INTOBJ_INT(0)) {
@@ -1576,8 +1576,8 @@ static Obj FuncAS_TRANS_PERM_INT(Obj self, Obj p, Obj deg)
     Obj    f;
     UInt   def, dep, i, min, n;
 
-    RequireNonnegativeSmallInt("AS_TRANS_PERM_INT", deg);
-    RequirePermutation("AS_TRANS_PERM_INT", p);
+    RequireNonnegativeSmallInt(SELF_NAME, deg);
+    RequirePermutation(SELF_NAME, p);
 
     n = INT_INTOBJ(deg);
 
@@ -1659,7 +1659,7 @@ static Obj FuncAS_TRANS_PERM(Obj self, Obj p)
     const UInt4 * ptPerm4;
     UInt    sup;
 
-    RequirePermutation("AS_TRANS_PERM", p);
+    RequirePermutation(SELF_NAME, p);
 
     // find largest moved point
     if (TNUM_OBJ(p) == T_PERM2) {
@@ -1699,7 +1699,7 @@ static Obj FuncAS_PERM_TRANS(Obj self, Obj f)
     UInt   deg, i;
     Obj    p;
 
-    RequireTransformation("AS_PERM_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     deg = DEG_TRANS(f);
     if (RANK_TRANS(f) != deg) {
@@ -1738,7 +1738,7 @@ static Obj FuncPermutationOfImage(Obj self, Obj f)
     UInt   deg, rank, i, j;
     Obj    p, img;
 
-    RequireTransformation("PermutationOfImage", f);
+    RequireTransformation(SELF_NAME, f);
 
     rank = RANK_TRANS(f);
     deg = DEG_TRANS(f);
@@ -1804,8 +1804,8 @@ static Obj FuncPermLeftQuoTransformationNC(Obj self, Obj f, Obj g)
     UInt   def, deg, i, min, max;
     Obj    perm;
 
-    RequireTransformation("PermLeftQuoTransformationNC", f);
-    RequireTransformation("PermLeftQuoTransformationNC", g);
+    RequireTransformation(SELF_NAME, f);
+    RequireTransformation(SELF_NAME, g);
 
     def = DEG_TRANS(f);
     deg = DEG_TRANS(g);
@@ -1914,8 +1914,8 @@ static Obj FuncRestrictedTransformation(Obj self, Obj f, Obj list)
     UInt4 *ptg4;
     Obj    g;
 
-    RequireTransformation("RestrictedTransformation", f);
-    RequireSmallList("RestrictedTransformation", list);
+    RequireTransformation(SELF_NAME, f);
+    RequireSmallList(SELF_NAME, list);
 
     len = LEN_LIST(list);
 
@@ -1979,8 +1979,8 @@ static Obj FuncAS_TRANS_TRANS(Obj self, Obj f, Obj m)
     UInt   i, n, def;
     Obj    g;
 
-    RequireTransformation("AS_TRANS_TRANS", f);
-    RequireNonnegativeSmallInt("AS_TRANS_TRANS", m);
+    RequireTransformation(SELF_NAME, f);
+    RequireNonnegativeSmallInt(SELF_NAME, m);
 
     n = INT_INTOBJ(m);
 
@@ -2039,8 +2039,8 @@ static Obj FuncTRIM_TRANS(Obj self, Obj f, Obj m)
     UInt    deg, i;
     UInt4 * ptf;
 
-    RequireTransformation("TRIM_TRANS", f);
-    RequireNonnegativeSmallInt("TRIM_TRANS", m);
+    RequireTransformation(SELF_NAME, f);
+    RequireNonnegativeSmallInt(SELF_NAME, m);
 
     deg = INT_INTOBJ(m);
 
@@ -2121,7 +2121,7 @@ static Obj FuncLARGEST_MOVED_PT_TRANS(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt    i;
 
-    RequireTransformation("LARGEST_MOVED_PT_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         ptf2 = CONST_ADDR_TRANS2(f);
@@ -2150,7 +2150,7 @@ static Obj FuncLARGEST_IMAGE_PT(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt    i, max, def;
 
-    RequireTransformation("LARGEST_IMAGE_PT", f);
+    RequireTransformation(SELF_NAME, f);
     max = 0;
     if (TNUM_OBJ(f) == T_TRANS2) {
         def = DEG_TRANS2(f);
@@ -2199,7 +2199,7 @@ static Obj FuncSMALLEST_MOVED_PT_TRANS(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt    i, deg;
 
-    RequireTransformation("SMALLEST_MOVED_PTS_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
     if (FuncIS_ID_TRANS(self, f) == True) {
         return Fail;
     }
@@ -2236,7 +2236,7 @@ static Obj FuncSMALLEST_IMAGE_PT(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt    i, min, deg;
 
-    RequireTransformation("SMALLEST_IMAGE_PT", f);
+    RequireTransformation(SELF_NAME, f);
     if (FuncIS_ID_TRANS(self, f) == True) {
         return Fail;
     }
@@ -2274,7 +2274,7 @@ static Obj FuncNR_MOVED_PTS_TRANS(Obj self, Obj f)
     const UInt2 * ptf2;
     const UInt4 * ptf4;
 
-    RequireTransformation("NR_MOVED_PTS_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     nr = 0;
     if (TNUM_OBJ(f) == T_TRANS2) {
@@ -2308,7 +2308,7 @@ static Obj FuncMOVED_PTS_TRANS(Obj self, Obj f)
     const UInt2 * ptf2;
     const UInt4 * ptf4;
 
-    RequireTransformation("MOVED_PTS_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     len = 0;
     if (TNUM_OBJ(f) == T_TRANS2) {
@@ -2359,7 +2359,7 @@ static Obj FuncCOMPONENT_REPS_TRANS(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt4 * seen;
 
-    RequireTransformation("COMPONENT_REPS_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
@@ -2495,7 +2495,7 @@ static Obj FuncNR_COMPONENTS_TRANS(Obj self, Obj f)
     const UInt4 * ptf4;
     UInt4 * ptseen;
 
-    RequireTransformation("NR_COMPONENTS_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
     ptseen = ResizeInitTmpTrans(deg);
@@ -2544,7 +2544,7 @@ static Obj FuncCOMPONENTS_TRANS(Obj self, Obj f)
     UInt    deg, i, pt, csize, nr, index, pos;
     Obj     out, comp;
 
-    RequireTransformation("COMPONENTS_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
@@ -2659,7 +2659,7 @@ static Obj FuncCOMPONENT_TRANS_INT(Obj self, Obj f, Obj pt)
     const UInt4 * ptf4;
     UInt4 * ptseen;
 
-    RequireTransformation("COMPONENT_TRANS_INT", f);
+    RequireTransformation(SELF_NAME, f);
     cpt = GetPositiveSmallInt("COMPONENT_TRANS_INT", pt) - 1;
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
@@ -2711,7 +2711,7 @@ static Obj FuncCYCLE_TRANS_INT(Obj self, Obj f, Obj pt)
     const UInt4 * ptf4;
     UInt4 * ptseen;
 
-    RequireTransformation("CYCLE_TRANS_INT", f);
+    RequireTransformation(SELF_NAME, f);
     cpt = GetPositiveSmallInt("CYCLE_TRANS_INT", pt) - 1;
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
@@ -2771,7 +2771,7 @@ static Obj FuncCYCLES_TRANS(Obj self, Obj f)
     UInt    deg, i, pt, nr;
     Obj     out, comp;
 
-    RequireTransformation("CYCLES_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
     if (deg == 0) {
@@ -2862,8 +2862,8 @@ static Obj FuncCYCLES_TRANS_LIST(Obj self, Obj f, Obj list)
     UInt    deg, i, j, pt, nr;
     Obj     out, comp;
 
-    RequireTransformation("CYCLES_TRANS_LIST", f);
-    RequireSmallList("CYCLES_TRANS_LIST", list);
+    RequireTransformation(SELF_NAME, f);
+    RequireSmallList(SELF_NAME, list);
 
     deg = INT_INTOBJ(FuncDegreeOfTransformation(self, f));
 
@@ -2979,8 +2979,8 @@ static Obj FuncINV_LIST_TRANS(Obj self, Obj list, Obj f)
     UInt   deg, i, j;
     Obj    g;
 
-    RequireDenseList("INV_LIST_TRANS", list);
-    RequireTransformation("INV_LIST_TRANS", f);
+    RequireDenseList(SELF_NAME, list);
+    RequireTransformation(SELF_NAME, f);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
         deg = DEG_TRANS2(f);
@@ -3038,8 +3038,8 @@ static Obj FuncTRANS_IMG_CONJ(Obj self, Obj f, Obj g)
     UInt4 *ptsrc, *ptdst, *ptp;
     UInt   def, deg, i, j, max, min;
 
-    RequireTransformation("TRANS_IMG_CONJ", f);
-    RequireTransformation("TRANS_IMG_CONJ", g);
+    RequireTransformation(SELF_NAME, f);
+    RequireTransformation(SELF_NAME, g);
 
     def = DEG_TRANS(f);
     deg = DEG_TRANS(g);
@@ -3188,7 +3188,7 @@ static Obj FuncPOW_KER_PERM(Obj self, Obj ker, Obj p)
     const UInt4 * ptp4;
     const UInt2 * ptp2;
 
-    RequirePermutation("POW_KER_TRANS", p);
+    RequirePermutation(SELF_NAME, p);
 
     len = LEN_LIST(ker);
 
@@ -3319,7 +3319,7 @@ static Obj INV_KER_TRANS(Obj X, Obj f)
 
 static Obj FuncINV_KER_TRANS(Obj self, Obj X, Obj f)
 {
-    RequireTransformation("INV_KER_TRANS", f);
+    RequireTransformation(SELF_NAME, f);
     UInt len = LEN_LIST(X);
 
     if (TNUM_OBJ(f) == T_TRANS2) {
@@ -3354,7 +3354,7 @@ static Obj FuncOnPosIntSetsTrans(Obj self, Obj set, Obj f, Obj n)
     Obj *   ptres, res;
     UInt    i, k;
 
-    RequireTransformation("OnPosIntSetsTrans", f);
+    RequireTransformation(SELF_NAME, f);
 
     const UInt len = LEN_LIST(set);
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -1998,7 +1998,7 @@ static Obj FuncGetBottomLVars(Obj self)
 static Obj FuncParentLVars(Obj self, Obj lvars)
 {
   if (!IS_LVARS_OR_HVARS(lvars)) {
-      RequireArgument("ParentLVars", lvars, "must be an lvars");
+      RequireArgument(SELF_NAME, lvars, "must be an lvars");
   }
   Obj parent = PARENT_LVARS(lvars);
   return parent ? parent : Fail;
@@ -2007,7 +2007,7 @@ static Obj FuncParentLVars(Obj self, Obj lvars)
 static Obj FuncContentsLVars(Obj self, Obj lvars)
 {
   if (!IS_LVARS_OR_HVARS(lvars)) {
-      RequireArgument("ContentsLVars", lvars, "must be an lvars");
+      RequireArgument(SELF_NAME, lvars, "must be an lvars");
   }
   Obj contents = NEW_PREC(0);
   Obj func = FUNC_LVARS(lvars);
@@ -2030,7 +2030,7 @@ static Obj FuncContentsLVars(Obj self, Obj lvars)
 
 static Obj FuncENVI_FUNC(Obj self, Obj func)
 {
-    RequireFunction("ENVI_FUNC", func);
+    RequireFunction(SELF_NAME, func);
     Obj envi = ENVI_FUNC(func);
     return (envi && IS_LVARS_OR_HVARS(envi)) ? envi : Fail;
 }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1000,7 +1000,7 @@ void PlainVec8Bit(Obj list)
 static Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
 {
     if (!IS_VEC8BIT_REP(list)) {
-        RequireArgument("PLAIN_VEC8BIT", list, "must be an 8bit vector");
+        RequireArgument(SELF_NAME, list, "must be an 8bit vector");
     }
     if (DoFilter(IsLockedRepresentationVector, list) == True) {
         ErrorMayQuit("You cannot convert a locked vector compressed over "
@@ -1416,7 +1416,7 @@ static Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 static Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
 {
     UInt iq = GetPositiveSmallInt("ZERO_VEC8BIT_2", q);
-    RequireNonnegativeSmallInt("ZERO_VEC8BIT_2", len);
+    RequireNonnegativeSmallInt(SELF_NAME, len);
     return ZeroVec8Bit(iq, INT_INTOBJ(len), 1);
 }
 
@@ -2308,8 +2308,8 @@ static Obj FuncA_CLOSEST_VEC8BIT(
     UInt len;
     UInt q;
 
-    RequireNonnegativeSmallInt("A_CLOSEST_VEC8BIT", cnt);
-    RequireNonnegativeSmallInt("A_CLOSEST_VEC8BIT", stop);
+    RequireNonnegativeSmallInt(SELF_NAME, cnt);
+    RequireNonnegativeSmallInt(SELF_NAME, stop);
 
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
@@ -2348,8 +2348,8 @@ static Obj FuncA_CLOSEST_VEC8BIT_COORDS(
     Obj  res;
 
 
-    RequireNonnegativeSmallInt("A_CLOSEST_VEC8BIT_COORDS", cnt);
-    RequireNonnegativeSmallInt("A_CLOSEST_VEC8BIT_COORDS", stop);
+    RequireNonnegativeSmallInt(SELF_NAME, cnt);
+    RequireNonnegativeSmallInt(SELF_NAME, stop);
 
     q = FIELD_VEC8BIT(vec);
     len = LEN_VEC8BIT(vec);
@@ -2567,8 +2567,8 @@ static Obj FuncCOSET_LEADERS_INNER_8BITS(
     Obj  v, w;
     UInt lenv, lenw, q;
 
-    RequireSmallInt("COSET_LEADERS_INNER_8BITS", weight);
-    RequireSmallInt("COSET_LEADERS_INNER_8BITS", tofind);
+    RequireSmallInt(SELF_NAME, weight);
+    RequireSmallInt(SELF_NAME, tofind);
 
     lenv = LEN_PLIST(veclis);
     q = LEN_PLIST(felts);
@@ -4412,8 +4412,8 @@ static Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
 static Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 {
     if (!IS_MUTABLE_OBJ(vec))
-        RequireArgument("SHIFT_VEC8BIT_LEFT", vec, "must be mutable");
-    RequireNonnegativeSmallInt("SHIFT_VEC8BIT_LEFT", amount);
+        RequireArgument(SELF_NAME, vec, "must be mutable");
+    RequireNonnegativeSmallInt(SELF_NAME, amount);
     ShiftLeftVec8Bit(vec, INT_INTOBJ(amount));
     return (Obj)0;
 }
@@ -4427,8 +4427,8 @@ static Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 static Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 {
     if (!IS_MUTABLE_OBJ(vec))
-        RequireArgument("SHIFT_VEC8BIT_RIGHT", vec, "must be mutable");
-    RequireNonnegativeSmallInt("SHIFT_VEC8BIT_RIGHT", amount);
+        RequireArgument(SELF_NAME, vec, "must be mutable");
+    RequireNonnegativeSmallInt(SELF_NAME, amount);
     ShiftRightVec8Bit(vec, INT_INTOBJ(amount));
     return (Obj)0;
 }
@@ -4441,8 +4441,8 @@ static Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 
 static Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
 {
-    RequireMutable("RESIZE_VEC8BIT", vec, "vector");
-    RequireNonnegativeSmallInt("RESIZE_VEC8BIT", newsize);
+    RequireMutable(SELF_NAME, vec, "vector");
+    RequireNonnegativeSmallInt(SELF_NAME, newsize);
     ResizeVec8Bit(vec, INT_INTOBJ(newsize), 0);
     return (Obj)0;
 }
@@ -4670,8 +4670,8 @@ static Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
         q = q0;
     }
 
-    RequireNonnegativeSmallInt("PROD_COEFFS_VEC8BIT", ll);
-    RequireNonnegativeSmallInt("PROD_COEFFS_VEC8BIT", lr);
+    RequireNonnegativeSmallInt(SELF_NAME, ll);
+    RequireNonnegativeSmallInt(SELF_NAME, lr);
     ll1 = INT_INTOBJ(ll);
     lr1 = INT_INTOBJ(lr);
     if (0 > ll1 || ll1 > LEN_VEC8BIT(vl))
@@ -4876,7 +4876,7 @@ static void ReduceCoeffsVec8Bit(Obj vl, Obj vrshifted, Obj quot)
 
 static Obj FuncMAKE_SHIFTED_COEFFS_VEC8BIT(Obj self, Obj vr, Obj lr)
 {
-    RequireNonnegativeSmallInt("ReduceCoeffs", lr);
+    RequireNonnegativeSmallInt(SELF_NAME, lr);
     if (INT_INTOBJ(lr) > LEN_VEC8BIT(vr)) {
         ErrorQuit("ReduceCoeffs: given length <lr> of right argt (%d)\n is "
                   "longer than the argt (%d)",
@@ -4893,7 +4893,7 @@ static Obj FuncREDUCE_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
     q = FIELD_VEC8BIT(vl);
     if (q != FIELD_VEC8BIT(ELM_PLIST(vrshifted, 1)))
         return Fail;
-    RequireNonnegativeSmallInt("ReduceCoeffs", ll);
+    RequireNonnegativeSmallInt(SELF_NAME, ll);
     if (INT_INTOBJ(ll) > LEN_VEC8BIT(vl)) {
         ErrorQuit("ReduceCoeffs: given length <ll> of left argt (%d)\n is "
                   "longer than the argt (%d)",
@@ -4917,7 +4917,7 @@ static Obj FuncQUOTREM_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
     q = FIELD_VEC8BIT(vl);
     if (q != FIELD_VEC8BIT(ELM_PLIST(vrshifted, 1)))
         return Fail;
-    RequireNonnegativeSmallInt("QuotRemCoeffs", ll);
+    RequireNonnegativeSmallInt(SELF_NAME, ll);
     if (INT_INTOBJ(ll) > LEN_VEC8BIT(vl)) {
         ErrorQuit("QuotRemCoeffs: given length <ll> of left argt (%d)\n is "
                   "longer than the argt (%d)",

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1529,7 +1529,7 @@ static Obj FuncCONV_GF2MAT(Obj self, Obj list)
 static Obj FuncPLAIN_GF2VEC(Obj self, Obj list)
 {
     if (!IS_GF2VEC_REP(list)) {
-        RequireArgument("PLAIN_GF2VEC", list, "must be a GF2 vector");
+        RequireArgument(SELF_NAME, list, "must be a GF2 vector");
     }
     PlainGF2Vec(list);
     return 0;
@@ -2051,7 +2051,7 @@ static Obj FuncZERO_GF2VEC(Obj self, Obj mat)
 static Obj FuncZERO_GF2VEC_2(Obj self, Obj len)
 {
     Obj zero;
-    RequireNonnegativeSmallInt("ZERO_GF2VEC_2", len);
+    RequireNonnegativeSmallInt(SELF_NAME, len);
     NEW_GF2VEC(zero, TYPE_LIST_GF2VEC, INT_INTOBJ(len));
     return zero;
 }
@@ -2467,10 +2467,10 @@ static Obj FuncCOPY_SECTION_GF2VECS(
     Int ihowmany = GetSmallInt("COPY_SECTION_GF2VECS", howmany);
 
     if (!IS_GF2VEC_REP(src)) {
-        RequireArgument("COPY_SECTION_GF2VECS", src, "must be a GF2 vector");
+        RequireArgument(SELF_NAME, src, "must be a GF2 vector");
     }
     if (!IS_GF2VEC_REP(dest)) {
-        RequireArgument("COPY_SECTION_GF2VECS", dest, "must be a GF2 vector");
+        RequireArgument(SELF_NAME, dest, "must be a GF2 vector");
     }
 
     UInt lens = LEN_GF2VEC(src);
@@ -2478,7 +2478,7 @@ static Obj FuncCOPY_SECTION_GF2VECS(
     if (ihowmany < 0 ||
         ifrom + ihowmany - 1 > lens || ito + ihowmany - 1 > lend)
         ErrorMayQuit("Bad argument values", 0, 0);
-    RequireMutable("COPY_SECTION_GF2VECS", dest, "vector");
+    RequireMutable(SELF_NAME, dest, "vector");
 
     CopySection_GF2Vecs(src, dest, (UInt)ifrom, (UInt)ito, (UInt)ihowmany);
     return (Obj)0;
@@ -3059,8 +3059,8 @@ static Obj FuncA_CLOS_VEC(
 
     len = LEN_GF2VEC(vec);
 
-    RequireNonnegativeSmallInt("A_CLOS_VEC", cnt);
-    RequireNonnegativeSmallInt("A_CLOS_VEC", stop);
+    RequireNonnegativeSmallInt(SELF_NAME, cnt);
+    RequireNonnegativeSmallInt(SELF_NAME, stop);
 
     // get space for sum vector and zero out
     NEW_GF2VEC(sum, TYPE_LIST_GF2VEC, len);
@@ -3092,8 +3092,8 @@ static Obj FuncA_CLOS_VEC_COORDS(
     len = LEN_GF2VEC(vec);
     len2 = LEN_PLIST(veclis);
 
-    RequireNonnegativeSmallInt("A_CLOS_VEC_COORDS", cnt);
-    RequireNonnegativeSmallInt("A_CLOS_VEC_COORDS", stop);
+    RequireNonnegativeSmallInt(SELF_NAME, cnt);
+    RequireNonnegativeSmallInt(SELF_NAME, stop);
 
     // get space for sum vector and zero out
     NEW_GF2VEC(sum, TYPE_LIST_GF2VEC, len);
@@ -3196,8 +3196,8 @@ static Obj FuncCOSET_LEADERS_INNER_GF2(
     Obj  v, w;
     UInt lenv, lenw;
 
-    RequireSmallInt("COSET_LEADERS_INNER_GF2", weight);
-    RequireSmallInt("COSET_LEADERS_INNER_GF2", tofind);
+    RequireSmallInt(SELF_NAME, weight);
+    RequireSmallInt(SELF_NAME, tofind);
 
     lenv = LEN_PLIST(veclis);
     NEW_GF2VEC(v, TYPE_LIST_GF2VEC, lenv);
@@ -3294,8 +3294,8 @@ static void ResizeGF2Vec(Obj vec, UInt newlen)
 
 static Obj FuncRESIZE_GF2VEC(Obj self, Obj vec, Obj newlen)
 {
-    RequireMutable("RESIZE_GF2VEC", vec, "vector");
-    RequireNonnegativeSmallInt("RESIZE_GF2VEC", newlen);
+    RequireMutable(SELF_NAME, vec, "vector");
+    RequireNonnegativeSmallInt(SELF_NAME, newlen);
     ResizeGF2Vec(vec, INT_INTOBJ(newlen));
     return (Obj)0;
 }
@@ -3353,8 +3353,8 @@ static void ShiftLeftGF2Vec(Obj vec, UInt amount)
 
 static Obj FuncSHIFT_LEFT_GF2VEC(Obj self, Obj vec, Obj amount)
 {
-    RequireMutable("SHIFT_LEFT_GF2VEC", vec, "vector");
-    RequireNonnegativeSmallInt("SHIFT_LEFT_GF2VEC", amount);
+    RequireMutable(SELF_NAME, vec, "vector");
+    RequireNonnegativeSmallInt(SELF_NAME, amount);
     ShiftLeftGF2Vec(vec, INT_INTOBJ(amount));
     return (Obj)0;
 }
@@ -3416,8 +3416,8 @@ static void ShiftRightGF2Vec(Obj vec, UInt amount)
 
 static Obj FuncSHIFT_RIGHT_GF2VEC(Obj self, Obj vec, Obj amount, Obj zero)
 {
-    RequireMutable("SHIFT_RIGHT_GF2VEC", vec, "vector");
-    RequireNonnegativeSmallInt("SHIFT_RIGHT_GF2VEC", amount);
+    RequireMutable(SELF_NAME, vec, "vector");
+    RequireNonnegativeSmallInt(SELF_NAME, amount);
     ShiftRightGF2Vec(vec, INT_INTOBJ(amount));
     return (Obj)0;
 }
@@ -3478,8 +3478,8 @@ static void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
 static Obj
 FuncADD_GF2VEC_GF2VEC_SHIFTED(Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
 {
-    RequireNonnegativeSmallInt("ADD_GF2VEC_GF2VEC_SHIFTED", off);
-    RequireNonnegativeSmallInt("ADD_GF2VEC_GF2VEC_SHIFTED", len2);
+    RequireNonnegativeSmallInt(SELF_NAME, off);
+    RequireNonnegativeSmallInt(SELF_NAME, len2);
     Int off1 = INT_INTOBJ(off);
     Int len2a = INT_INTOBJ(len2);
     if (len2a >= LEN_GF2VEC(vec2)) {
@@ -3551,8 +3551,8 @@ FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
     Obj  prod;
     UInt last;
 
-    RequireSmallInt("PROD_COEFFS_GF2VEC", len1);
-    RequireSmallInt("PROD_COEFFS_GF2VEC", len2);
+    RequireSmallInt(SELF_NAME, len1);
+    RequireSmallInt(SELF_NAME, len2);
     len2a = INT_INTOBJ(len2);
     if (len2a > LEN_GF2VEC(vec2))
         ErrorMayQuit("PROD_COEFFS_GF2VEC: <len2> must not be more than the "
@@ -3618,8 +3618,8 @@ FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     UInt last;
     Int  len2a;
-    RequireNonnegativeSmallInt("ReduceCoeffs", len1);
-    RequireNonnegativeSmallInt("ReduceCoeffs", len2);
+    RequireNonnegativeSmallInt(SELF_NAME, len1);
+    RequireNonnegativeSmallInt(SELF_NAME, len2);
     if (INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
         ErrorMayQuit("ReduceCoeffs: given length <len1> of left argt "
                      "(%d)\nis longer than the argt (%d)",
@@ -3663,8 +3663,8 @@ FuncQUOTREM_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
     Int len2a;
     Int len1a = INT_INTOBJ(len1);
     Obj quotv, remv, ret;
-    RequireNonnegativeSmallInt("QuotremCoeffs", len1);
-    RequireNonnegativeSmallInt("QuotremCoeffs", len2);
+    RequireNonnegativeSmallInt(SELF_NAME, len1);
+    RequireNonnegativeSmallInt(SELF_NAME, len2);
     if (INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
         ErrorMayQuit("QuotremCoeffs: given length <len1> of left argt "
                      "(%d)\nis longer than the argt (%d)",
@@ -4020,7 +4020,8 @@ FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
         BLOCK_ELM_GF2VEC(vec, c) &= ~MASK_POS_GF2VEC(c);
     }
     else {
-        RequireArgumentEx("SET_MAT_ELM_GF2MAT", elm, 0, "assigned element must be a GF(2) element");
+        RequireArgumentEx(SELF_NAME, elm, 0,
+                          "assigned element must be a GF(2) element");
     }
 
     return 0;

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -313,7 +313,7 @@ static Int LengthWPObj(Obj wp)
 
 static Obj FuncLengthWPObj(Obj self, Obj wp)
 {
-    RequireWPObj("LengthWPObj", wp);
+    RequireWPObj(SELF_NAME, wp);
     return INTOBJ_INT(LengthWPObj(wp));
 }
 
@@ -328,7 +328,7 @@ static Obj FuncLengthWPObj(Obj self, Obj wp)
 
 static Obj FuncSetElmWPObj(Obj self, Obj wp, Obj pos, Obj val)
 {
-    RequireWPObj("SetElmWPObj", wp);
+    RequireWPObj(SELF_NAME, wp);
     UInt ipos = GetPositiveSmallInt("SetElmWPObj", pos);
 
 #ifdef USE_BOEHM_GC
@@ -417,7 +417,7 @@ static Obj FuncIsBoundElmWPObj(Obj self, Obj wp, Obj pos)
 
 static Obj FuncUnbindElmWPObj(Obj self, Obj wp, Obj pos)
 {
-    RequireWPObj("UnbindElmWPObj", wp);
+    RequireWPObj(SELF_NAME, wp);
     UInt ipos = GetPositiveSmallInt("UnbindElmWPObj", pos);
 
   Int len = LengthWPObj(wp);
@@ -493,7 +493,7 @@ static Obj ElmDefWPList(Obj wp, Int ipos, Obj def)
 */
 static Obj FuncElmWPObj(Obj self, Obj wp, Obj pos)
 {
-    RequireWPObj("ElmWPObj", wp);
+    RequireWPObj(SELF_NAME, wp);
     UInt ipos = GetPositiveSmallInt("ElmWPObj", pos);
 
     return ElmDefWPList(wp, ipos, Fail);

--- a/tst/testinstall/MatrixObj/IdentityMatrix.tst
+++ b/tst/testinstall/MatrixObj/IdentityMatrix.tst
@@ -62,17 +62,17 @@ gap> m:=IdentityMatrix( Integers, 0 ); Display(m);
 
 # some error checking
 gap> m:=IdentityMatrix( GF(2), -1 );
-Error, LIST_WITH_IDENTICAL_ENTRIES: <n> must be a non-negative small integer (\
-not the integer -1)
+Error, ListWithIdenticalEntries: <n> must be a non-negative small integer (not\
+ the integer -1)
 gap> m:=IdentityMatrix( GF(3), -1 );
-Error, LIST_WITH_IDENTICAL_ENTRIES: <n> must be a non-negative small integer (\
-not the integer -1)
+Error, ListWithIdenticalEntries: <n> must be a non-negative small integer (not\
+ the integer -1)
 gap> m:=IdentityMatrix( GF(4), -1 );
-Error, LIST_WITH_IDENTICAL_ENTRIES: <n> must be a non-negative small integer (\
-not the integer -1)
+Error, ListWithIdenticalEntries: <n> must be a non-negative small integer (not\
+ the integer -1)
 gap> m:=IdentityMatrix( Integers mod 4, -1 );
-Error, LIST_WITH_IDENTICAL_ENTRIES: <n> must be a non-negative small integer (\
-not the integer -1)
+Error, ListWithIdenticalEntries: <n> must be a non-negative small integer (not\
+ the integer -1)
 
 #
 gap> STOP_TEST("IdentityMatrix.tst");

--- a/tst/testinstall/cyclotom.tst
+++ b/tst/testinstall/cyclotom.tst
@@ -317,7 +317,7 @@ Error, Conductor: <list>[2] must be a cyclotomic (not a boolean or fail)
 
 #
 gap> COEFFS_CYC(false);
-Error, COEFFSCYC: <cyc> must be a cyclotomic (not the value 'false')
+Error, COEFFS_CYC: <cyc> must be a cyclotomic (not the value 'false')
 
 #
 gap> CycList([1,fail]);

--- a/tst/testinstall/intarith.tst
+++ b/tst/testinstall/intarith.tst
@@ -239,13 +239,17 @@ gap> List(data, x -> x mod bigPos);
 
 #
 gap> bigNeg mod 0;
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> smlNeg mod 0;
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> smlPos mod 0;
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> bigPos mod 0;
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 
 # test optimization for moduli which are a power of 2
 gap> x:=2^80;
@@ -315,17 +319,21 @@ gap> List(data, x -> QuoInt(x, bigPos));
 
 #
 gap> QuoInt(bigNeg, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> QuoInt(smlNeg, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> QuoInt(smlPos, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> QuoInt(bigPos, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> QuoInt(fail,1);
-Error, QuoInt: <a> must be an integer (not the value 'fail')
+Error, QUO_INT: <a> must be an integer (not the value 'fail')
 gap> QuoInt(1,fail);
-Error, QuoInt: <b> must be an integer (not the value 'fail')
+Error, QUO_INT: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> QuoInt(-2^28, -1);
@@ -365,17 +373,21 @@ gap> List(data, x -> RemInt(x, bigPos));
 
 #
 gap> RemInt(bigNeg, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> RemInt(smlNeg, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> RemInt(smlPos, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> RemInt(bigPos, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 gap> RemInt(fail,1);
-Error, RemInt: <a> must be an integer (not the value 'fail')
+Error, REM_INT: <a> must be an integer (not the value 'fail')
 gap> RemInt(1,fail);
-Error, RemInt: <b> must be an integer (not the value 'fail')
+Error, REM_INT: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> RemInt(-2^28, 2^28);
@@ -446,9 +458,9 @@ true
 
 #
 gap> GcdInt(fail,1);
-Error, GcdInt: <a> must be an integer (not the value 'fail')
+Error, GCD_INT: <a> must be an integer (not the value 'fail')
 gap> GcdInt(1,fail);
-Error, GcdInt: <b> must be an integer (not the value 'fail')
+Error, GCD_INT: <b> must be an integer (not the value 'fail')
 
 # corner cases
 gap> GcdInt(0, 0);
@@ -525,9 +537,9 @@ true
 gap> AbsInt(-2^60) = 2^60;  # corner case on 64bit systems
 true
 gap> AbsInt(fail);
-Error, AbsRat: <op> must be a rational (not the value 'fail')
+Error, AbsInt: <op> must be a rational (not the value 'fail')
 gap> ABS_INT(fail);
-Error, AbsInt: <n> must be an integer (not the value 'fail')
+Error, ABS_INT: <n> must be an integer (not the value 'fail')
 
 #
 # SignInt
@@ -535,9 +547,9 @@ Error, AbsInt: <n> must be an integer (not the value 'fail')
 gap> List(data, SignInt);
 [ -1, -1, -1, -1, 0, 1, 1, 1, 1 ]
 gap> SignInt(fail);
-Error, SignRat: <op> must be a rational (not the value 'fail')
+Error, SignInt: <op> must be a rational (not the value 'fail')
 gap> SIGN_INT(fail);
-Error, SignInt: <n> must be an integer (not the value 'fail')
+Error, SIGN_INT: <n> must be an integer (not the value 'fail')
 
 #
 # QuotientMod
@@ -559,7 +571,8 @@ gap> Set([1..12], f);
 
 # test that m = 0 is forbidden
 gap> QuotientMod(5, 4, 0);
-Error, Integer operations: <divisor> must be nonzero
+Error, Integer operations: <divisor> must be a nonzero integer (not the intege\
+r 0)
 
 # some old test cases, to show case that issue #149 is resolved
 gap> QuotientMod(2, 4, 6);
@@ -1263,7 +1276,7 @@ gap> for m in [1..100] do
 
 #
 gap> INVMODINT(1,0);
-Error, InverseModInt: <mod> must be nonzero
+Error, INVMODINT: <mod> must be a nonzero integer (not the integer 0)
 gap> INVMODINT(2,10);
 fail
 gap> INVMODINT(2,-10);
@@ -1288,7 +1301,7 @@ gap> for m in [1..100] do
 
 #
 gap> PowerModInt(1,1,0);
-Error, PowerModInt: <mod> must be nonzero
+Error, PowerModInt: <mod> must be a nonzero integer (not the integer 0)
 gap> PowerModInt(0,-1,5);
 Error, PowerModInt: negative <exp> but <base> is not invertible modulo <mod>
 gap> PowerModInt(2,-1,5);
@@ -1383,13 +1396,13 @@ gap> List([2..6], p->List(data, n->PVALUATION_INT(n,p)));
   [ 0, 10, 2, 0, 0, 0, 2, 10, 0 ], [ 0, 20, 4, 0, 0, 0, 4, 20, 0 ], 
   [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ] ]
 gap> PVALUATION_INT(10,0);
-Error, PValuation: <p> must be nonzero
+Error, PVALUATION_INT: <p> must be a nonzero integer (not the integer 0)
 gap> PVALUATION_INT(0,0);
-Error, PValuation: <p> must be nonzero
+Error, PVALUATION_INT: <p> must be a nonzero integer (not the integer 0)
 gap> PVALUATION_INT(fail,1);
-Error, PValuation: <n> must be an integer (not the value 'fail')
+Error, PVALUATION_INT: <n> must be an integer (not the value 'fail')
 gap> PVALUATION_INT(1,fail);
-Error, PValuation: <p> must be an integer (not the value 'fail')
+Error, PVALUATION_INT: <p> must be an integer (not the value 'fail')
 
 #
 # test ROOT_INT
@@ -1428,9 +1441,9 @@ Error, Root: <n> is negative but <k> is even
 gap> RootInt(0, 0);
 Error, Root: <k> must be a positive integer
 gap> RootInt(fail, 1);
-Error, Root: <n> must be an integer (not the value 'fail')
+Error, ROOT_INT: <n> must be an integer (not the value 'fail')
 gap> RootInt(1, fail);
-Error, Root: <k> must be an integer (not the value 'fail')
+Error, ROOT_INT: <k> must be an integer (not the value 'fail')
 
 #
 # test IS_PROBAB_PRIME_INT
@@ -1442,7 +1455,7 @@ gap> Filtered([-100..100], n -> false <> IS_PROBAB_PRIME_INT(2^255+n, 5));
 gap> Filtered([-100..100], n -> false <> IsProbablyPrimeInt(2^255+n));
 [ -31, -19, 95 ]
 gap> IS_PROBAB_PRIME_INT(fail, 1);
-Error, IsProbablyPrimeInt: <n> must be an integer (not the value 'fail')
+Error, IS_PROBAB_PRIME_INT: <n> must be an integer (not the value 'fail')
 gap> IS_PROBAB_PRIME_INT(1, fail);
 Error, IsProbablyPrimeInt: <reps> must be a positive small integer (not the va\
 lue 'fail')

--- a/tst/testinstall/kernel/blister.tst
+++ b/tst/testinstall/kernel/blister.tst
@@ -157,9 +157,9 @@ gap> List(l, SizeBlist);
 # FuncBLIST_LIST
 #
 gap> BlistList(fail, fail);
-Error, BlistList: <list> must be a small list (not the value 'fail')
+Error, BLIST_LIST: <list> must be a small list (not the value 'fail')
 gap> BlistList([1,2,3], fail);
-Error, BlistList: <sub> must be a small list (not the value 'fail')
+Error, BLIST_LIST: <sub> must be a small list (not the value 'fail')
 gap> BlistList([1,2,3], [1,3]);
 [ true, false, true ]
 
@@ -188,12 +188,12 @@ gap> BlistList(vec, [Z(2)]);
 # FuncLIST_BLIST
 #
 gap> ListBlist(fail, fail);
-Error, ListBlist: <list> must be a small list (not the value 'fail')
+Error, LIST_BLIST: <list> must be a small list (not the value 'fail')
 gap> ListBlist([1,2,3], fail);
-Error, ListBlist: <blist> must be a boolean list (not the value 'fail')
+Error, LIST_BLIST: <blist> must be a boolean list (not the value 'fail')
 gap> ListBlist([1,2,3], [true,false]);
-Error, ListBlist: <blist> must have the same length as <list> (lengths are 2 a\
-nd 3)
+Error, LIST_BLIST: <blist> must have the same length as <list> (lengths are 2 \
+and 3)
 gap> ListBlist([1,2,3], [true,false,true]);
 [ 1, 3 ]
 
@@ -201,12 +201,12 @@ gap> ListBlist([1,2,3], [true,false,true]);
 # FuncIS_SUB_BLIST
 #
 gap> IsSubsetBlist(fail, fail);
-Error, IsSubsetBlist: <blist1> must be a boolean list (not the value 'fail')
+Error, IS_SUB_BLIST: <blist1> must be a boolean list (not the value 'fail')
 gap> IsSubsetBlist([true,false], fail);
-Error, IsSubsetBlist: <blist2> must be a boolean list (not the value 'fail')
+Error, IS_SUB_BLIST: <blist2> must be a boolean list (not the value 'fail')
 gap> IsSubsetBlist([true,false,true], [true,false]);
-Error, IsSubsetBlist: <blist1> must have the same length as <blist2> (lengths \
-are 3 and 2)
+Error, IS_SUB_BLIST: <blist1> must have the same length as <blist2> (lengths a\
+re 3 and 2)
 gap> IsSubsetBlist([true,false,true], [true,false,false]);
 true
 gap> IsSubsetBlist([true,false,true], [true,true,false]);
@@ -216,16 +216,16 @@ false
 # FuncUNITE_BLIST
 #
 gap> UniteBlist(fail, fail);
-Error, UniteBlist: <blist1> must be a boolean list (not the value 'fail')
+Error, UNITE_BLIST: <blist1> must be a boolean list (not the value 'fail')
 gap> UniteBlist([true,false], fail);
-Error, UniteBlist: <blist2> must be a boolean list (not the value 'fail')
+Error, UNITE_BLIST: <blist2> must be a boolean list (not the value 'fail')
 gap> UniteBlist([true,false,true], [true,false]);
-Error, UniteBlist: <blist1> must have the same length as <blist2> (lengths are\
- 3 and 2)
+Error, UNITE_BLIST: <blist1> must have the same length as <blist2> (lengths ar\
+e 3 and 2)
 gap> x:= [false,true,true,false];;
 gap> UniteBlist(Immutable(x), [true,true,false,false]);
-Error, UniteBlist: <blist1> must be a mutable boolean list (not a list (boolea\
-n,imm))
+Error, UNITE_BLIST: <blist1> must be a mutable boolean list (not a list (boole\
+an,imm))
 gap> x;
 [ false, true, true, false ]
 gap> UniteBlist(x, [true,true,false,false]);
@@ -236,18 +236,18 @@ gap> x;
 # FuncUNITE_BLIST_LIST
 #
 gap> UniteBlistList(fail, fail, fail);
-Error, UniteBlistList: <list> must be a small list (not the value 'fail')
+Error, UNITE_BLIST_LIST: <list> must be a small list (not the value 'fail')
 gap> UniteBlistList([1,2], fail, fail);
-Error, UniteBlistList: <blist> must be a boolean list (not the value 'fail')
+Error, UNITE_BLIST_LIST: <blist> must be a boolean list (not the value 'fail')
 gap> UniteBlistList([1,2], [true], fail);
-Error, UniteBlistList: <blist> must have the same length as <list> (lengths ar\
-e 1 and 2)
+Error, UNITE_BLIST_LIST: <blist> must have the same length as <list> (lengths \
+are 1 and 2)
 gap> UniteBlistList([1,2], [true,false], fail);
-Error, UniteBlistList: <sub> must be a small list (not the value 'fail')
+Error, UNITE_BLIST_LIST: <sub> must be a small list (not the value 'fail')
 gap> x:= [true,true,false];;
 gap> UniteBlistList([1,2,3], Immutable(x), [2,3]);
-Error, UniteBlistList: <blist> must be a mutable boolean list (not a list (boo\
-lean,imm))
+Error, UNITE_BLIST_LIST: <blist> must be a mutable boolean list (not a list (b\
+oolean,imm))
 gap> x;
 [ true, true, false ]
 gap> UniteBlistList([1,2,3], x, [2,3]);
@@ -269,16 +269,16 @@ true
 # FuncINTER_BLIST
 #
 gap> IntersectBlist(fail, fail);
-Error, IntersectBlist: <blist1> must be a boolean list (not the value 'fail')
+Error, INTER_BLIST: <blist1> must be a boolean list (not the value 'fail')
 gap> IntersectBlist([true,false], fail);
-Error, IntersectBlist: <blist2> must be a boolean list (not the value 'fail')
+Error, INTER_BLIST: <blist2> must be a boolean list (not the value 'fail')
 gap> IntersectBlist([true,false,true], [true,false]);
-Error, IntersectBlist: <blist1> must have the same length as <blist2> (lengths\
- are 3 and 2)
+Error, INTER_BLIST: <blist1> must have the same length as <blist2> (lengths ar\
+e 3 and 2)
 gap> x:= [false,true,true,false];;
 gap> IntersectBlist(Immutable(x), [true,true,false,false]);
-Error, IntersectBlist: <blist1> must be a mutable boolean list (not a list (bo\
-olean,imm))
+Error, INTER_BLIST: <blist1> must be a mutable boolean list (not a list (boole\
+an,imm))
 gap> x;
 [ false, true, true, false ]
 gap> IntersectBlist(x, [true,true,false,false]);
@@ -287,16 +287,16 @@ gap> x;
 
 # FuncSUBTR_BLIST
 gap> SubtractBlist(fail, fail);
-Error, SubtractBlist: <blist1> must be a boolean list (not the value 'fail')
+Error, SUBTR_BLIST: <blist1> must be a boolean list (not the value 'fail')
 gap> SubtractBlist([true,false], fail);
-Error, SubtractBlist: <blist2> must be a boolean list (not the value 'fail')
+Error, SUBTR_BLIST: <blist2> must be a boolean list (not the value 'fail')
 gap> SubtractBlist([true,false,true], [true,false]);
-Error, SubtractBlist: <blist1> must have the same length as <blist2> (lengths \
-are 3 and 2)
+Error, SUBTR_BLIST: <blist1> must have the same length as <blist2> (lengths ar\
+e 3 and 2)
 gap> x:= [false,true,true,false];;
 gap> SubtractBlist(Immutable(x), [true,true,false,false]);
-Error, SubtractBlist: <blist1> must be a mutable boolean list (not a list (boo\
-lean,imm))
+Error, SUBTR_BLIST: <blist1> must be a mutable boolean list (not a list (boole\
+an,imm))
 gap> x;
 [ false, true, true, false ]
 gap> SubtractBlist(x, [true,true,false,false]);
@@ -305,12 +305,12 @@ gap> x;
 
 # FuncMEET_BLIST
 gap> MEET_BLIST(fail, fail);
-Error, MeetBlist: <blist1> must be a boolean list (not the value 'fail')
+Error, MEET_BLIST: <blist1> must be a boolean list (not the value 'fail')
 gap> MEET_BLIST([true,false], fail);
-Error, MeetBlist: <blist2> must be a boolean list (not the value 'fail')
+Error, MEET_BLIST: <blist2> must be a boolean list (not the value 'fail')
 gap> MEET_BLIST([true,false,true], [true,false]);
-Error, MeetBlist: <blist1> must have the same length as <blist2> (lengths are \
-3 and 2)
+Error, MEET_BLIST: <blist1> must have the same length as <blist2> (lengths are\
+ 3 and 2)
 gap> x:= [false,true,true,false];;
 gap> MEET_BLIST(x, [true,true,false,false]);
 true
@@ -319,11 +319,11 @@ false
 
 # FuncFLIP_BLIST
 gap> FLIP_BLIST(fail);
-Error, FlipBlist: <blist> must be a boolean list (not the value 'fail')
+Error, FLIP_BLIST: <blist> must be a boolean list (not the value 'fail')
 gap> x:= [false,true,true,false];;
 gap> FlipBlist(Immutable(x));
-Error, FlipBlist: <blist> must be a mutable boolean list (not a list (boolean,\
-imm))
+Error, FLIP_BLIST: <blist> must be a mutable boolean list (not a list (boolean\
+,imm))
 gap> x;
 [ false, true, true, false ]
 gap> FLIP_BLIST(x);
@@ -343,11 +343,11 @@ gap> for i in [0..200] do
 
 # FuncSET_ALL_BLIST
 gap> SET_ALL_BLIST(fail);
-Error, SetAllBitsBlist: <blist> must be a boolean list (not the value 'fail')
+Error, SET_ALL_BLIST: <blist> must be a boolean list (not the value 'fail')
 gap> x:= [false,true,true,false];;
 gap> SET_ALL_BLIST(Immutable(x));
-Error, SetAllBitsBlist: <blist> must be a mutable boolean list (not a list (bo\
-olean,imm))
+Error, SET_ALL_BLIST: <blist> must be a mutable boolean list (not a list (bool\
+ean,imm))
 gap> x;
 [ false, true, true, false ]
 gap> SET_ALL_BLIST(x);
@@ -365,12 +365,11 @@ gap> for i in [0..200] do
 
 # FuncCLEAR_ALL_BLIST
 gap> CLEAR_ALL_BLIST(fail);
-Error, ClearAllBitsBlist: <blist> must be a boolean list (not the value 'fail'\
-)
+Error, CLEAR_ALL_BLIST: <blist> must be a boolean list (not the value 'fail')
 gap> x:= [false,true,true,false];;
 gap> CLEAR_ALL_BLIST(Immutable(x));
-Error, ClearAllBitsBlist: <blist> must be a mutable boolean list (not a list (\
-boolean,imm))
+Error, CLEAR_ALL_BLIST: <blist> must be a mutable boolean list (not a list (bo\
+olean,imm))
 gap> x;
 [ false, true, true, false ]
 gap> CLEAR_ALL_BLIST(x);

--- a/tst/testinstall/kernel/integer.tst
+++ b/tst/testinstall/kernel/integer.tst
@@ -21,8 +21,8 @@ gap> SIGN_INT(-100000000000);
 
 #
 gap> FACTORIAL_INT(fail);
-Error, Factorial: <n> must be a non-negative small integer (not the value 'fai\
-l')
+Error, FACTORIAL_INT: <n> must be a non-negative small integer (not the value \
+'fail')
 
 #
 #

--- a/tst/testinstall/kernel/listfunc.tst
+++ b/tst/testinstall/kernel/listfunc.tst
@@ -21,9 +21,9 @@ Error, Remove: <list> must not be empty
 
 #
 gap> APPEND_LIST_INTR(fail, fail);
-Error, Append: <list1> must be a mutable list (not the value 'fail')
+Error, APPEND_LIST_INTR: <list1> must be a mutable list (not the value 'fail')
 gap> APPEND_LIST_INTR(rec(), fail);
-Error, Append: <list1> must be a small list (not a record (plain))
+Error, APPEND_LIST_INTR: <list1> must be a small list (not a record (plain))
 
 #
 gap> POSITION_SORTED_LIST(fail, fail);

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -128,7 +128,7 @@ Error, property is already set the other way
 
 #
 gap> NEW_FILTER(fail);
-Error, NewFilter: <name> must be a string (not the value 'fail')
+Error, NEW_FILTER: <name> must be a string (not the value 'fail')
 
 #
 gap> FLAG1_FILTER(fail);
@@ -170,24 +170,24 @@ Error, Constructor: the first argument must be a filter (not the integer 1)
 
 #
 gap> NEW_OPERATION(fail);
-Error, NewOperation: <name> must be a string (not the value 'fail')
+Error, NEW_OPERATION: <name> must be a string (not the value 'fail')
 gap> NEW_CONSTRUCTOR(fail);
-Error, NewConstructor: <name> must be a string (not the value 'fail')
+Error, NEW_CONSTRUCTOR: <name> must be a string (not the value 'fail')
 gap> NEW_ATTRIBUTE(fail);
-Error, NewAttribute: <name> must be a string (not the value 'fail')
+Error, NEW_ATTRIBUTE: <name> must be a string (not the value 'fail')
 gap> OPER_TO_ATTRIBUTE(fail);
 Error, OPER_TO_ATTRIBUTE: <oper> must be an operation (not the value 'fail')
 gap> OPER_TO_MUTABLE_ATTRIBUTE(fail);
 Error, OPER_TO_MUTABLE_ATTRIBUTE: <oper> must be an operation (not the value '\
 fail')
 gap> NEW_MUTABLE_ATTRIBUTE(fail);
-Error, NewMutableAttribute: <name> must be a string (not the value 'fail')
+Error, NEW_MUTABLE_ATTRIBUTE: <name> must be a string (not the value 'fail')
 gap> NEW_PROPERTY(fail);
-Error, NewProperty: <name> must be a string (not the value 'fail')
+Error, NEW_PROPERTY: <name> must be a string (not the value 'fail')
 
 #
 gap> NEW_GLOBAL_FUNCTION(fail);
-Error, NewGlobalFunction: <name> must be a string (not the value 'fail')
+Error, NEW_GLOBAL_FUNCTION: <name> must be a string (not the value 'fail')
 gap> INSTALL_GLOBAL_FUNCTION(fail, fail);
 Error, INSTALL_GLOBAL_FUNCTION: <oper> must be a function (not the value 'fail\
 ')

--- a/tst/testinstall/kernel/sctable.tst
+++ b/tst/testinstall/kernel/sctable.tst
@@ -10,27 +10,27 @@ gap> T := EmptySCTable(2,0*Z(2));
 
 #
 gap> SCTableEntry(false, false, false, false);
-Error, SCTableEntry: <table> must be a small list (not the value 'false')
+Error, SC_TABLE_ENTRY: <table> must be a small list (not the value 'false')
 gap> SCTableEntry([], false, false, false);
 Error, SCTableEntry: <table> must be a list with at least 3 elements
 gap> SCTableEntry(T, false, false, false);
-Error, SCTableEntry: <i> must be an integer between 1 and 2 (not the value 'fa\
-lse')
+Error, SC_TABLE_ENTRY: <i> must be an integer between 1 and 2 (not the value '\
+false')
 gap> SCTableEntry(T, 10, false, false);
-Error, SCTableEntry: <i> must be an integer between 1 and 2 (not the integer 1\
-0)
+Error, SC_TABLE_ENTRY: <i> must be an integer between 1 and 2 (not the integer\
+ 10)
 gap> SCTableEntry(T, 1, false, false);
-Error, SCTableEntry: <j> must be an integer between 1 and 2 (not the value 'fa\
-lse')
+Error, SC_TABLE_ENTRY: <j> must be an integer between 1 and 2 (not the value '\
+false')
 gap> SCTableEntry(T, 1, 10, false);
-Error, SCTableEntry: <j> must be an integer between 1 and 2 (not the integer 1\
-0)
+Error, SC_TABLE_ENTRY: <j> must be an integer between 1 and 2 (not the integer\
+ 10)
 gap> SCTableEntry(T, 1, 1, false);
-Error, SCTableEntry: <k> must be an integer between 1 and 2 (not the value 'fa\
-lse')
+Error, SC_TABLE_ENTRY: <k> must be an integer between 1 and 2 (not the value '\
+false')
 gap> SCTableEntry(T, 1, 1, 10);
-Error, SCTableEntry: <k> must be an integer between 1 and 2 (not the integer 1\
-0)
+Error, SC_TABLE_ENTRY: <k> must be an integer between 1 and 2 (not the integer\
+ 10)
 gap> SCTableEntry(T, 1, 1, 1);
 0*Z(2)
 gap> SCTableEntry([], 1, 1, 1);

--- a/tst/testinstall/kernel/set.tst
+++ b/tst/testinstall/kernel/set.tst
@@ -7,15 +7,15 @@ gap> START_TEST("kernel/set.tst");
 gap> IsSet(1);
 false
 gap> LIST_SORTED_LIST(1);
-Error, Set: <list> must be a small list (not the integer 1)
+Error, LIST_SORTED_LIST: <list> must be a small list (not the integer 1)
 
 #
 gap> IS_EQUAL_SET;
 function( list1, list2 ) ... end
 gap> IS_EQUAL_SET(1,1);
-Error, IsEqualSet: <list1> must be a small list (not the integer 1)
+Error, IS_EQUAL_SET: <list1> must be a small list (not the integer 1)
 gap> IS_EQUAL_SET([],1);
-Error, IsEqualSet: <list2> must be a small list (not the integer 1)
+Error, IS_EQUAL_SET: <list2> must be a small list (not the integer 1)
 gap> IS_EQUAL_SET([],[]);
 true
 
@@ -23,9 +23,9 @@ true
 gap> IS_SUBSET_SET;
 function( set1, set2 ) ... end
 gap> IS_SUBSET_SET(1,1);
-Error, IsSubsetSet: <set1> must be a small list (not the integer 1)
+Error, IS_SUBSET_SET: <set1> must be a small list (not the integer 1)
 gap> IS_SUBSET_SET([],1);
-Error, IsSubsetSet: <set2> must be a small list (not the integer 1)
+Error, IS_SUBSET_SET: <set2> must be a small list (not the integer 1)
 gap> IS_SUBSET_SET([],[]);
 true
 gap> IS_SUBSET_SET([1,2,3],[1,2]);
@@ -45,39 +45,39 @@ false
 gap> ADD_SET;
 function( set, val ) ... end
 gap> ADD_SET(1,1);
-Error, AddSet: <set> must be a mutable proper set (not the integer 1)
+Error, ADD_SET: <set> must be a mutable proper set (not the integer 1)
 
 #
 gap> REM_SET;
 function( set, val ) ... end
 gap> REM_SET(1,1);
-Error, RemoveSet: <set> must be a mutable proper set (not the integer 1)
+Error, REM_SET: <set> must be a mutable proper set (not the integer 1)
 
 #
 gap> UNITE_SET;
 function( set1, set2 ) ... end
 gap> UNITE_SET(1,1);
-Error, UniteSet: <set1> must be a mutable proper set (not the integer 1)
+Error, UNITE_SET: <set1> must be a mutable proper set (not the integer 1)
 gap> UNITE_SET([],1);
-Error, UniteSet: <set2> must be a small list (not the integer 1)
+Error, UNITE_SET: <set2> must be a small list (not the integer 1)
 gap> UNITE_SET([],[]);
 
 #
 gap> INTER_SET;
 function( set1, set2 ) ... end
 gap> INTER_SET(1,1);
-Error, IntersectSet: <set1> must be a mutable proper set (not the integer 1)
+Error, INTER_SET: <set1> must be a mutable proper set (not the integer 1)
 gap> INTER_SET([],1);
-Error, IntersectSet: <set2> must be a small list (not the integer 1)
+Error, INTER_SET: <set2> must be a small list (not the integer 1)
 gap> INTER_SET([],[]);
 
 #
 gap> SUBTR_SET;
 function( set1, set2 ) ... end
 gap> SUBTR_SET(1,1);
-Error, SubtractSet: <set1> must be a mutable proper set (not the integer 1)
+Error, SUBTR_SET: <set1> must be a mutable proper set (not the integer 1)
 gap> SUBTR_SET([],1);
-Error, SubtractSet: <set2> must be a small list (not the integer 1)
+Error, SUBTR_SET: <set2> must be a small list (not the integer 1)
 gap> SUBTR_SET([],[]);
 
 #

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -7,13 +7,13 @@ gap> START_TEST("kernel/streams.tst");
 gap> CLOSE_LOG_TO();
 Error, LogTo: can not close the logfile
 gap> LOG_TO(fail);
-Error, LogTo: <filename> must be a string (not the value 'fail')
+Error, LOG_TO: <filename> must be a string (not the value 'fail')
 gap> LOG_TO(TmpName());
 true
 gap> CLOSE_LOG_TO();
 true
 gap> LOG_TO_STREAM(fail);
-Error, LogTo: <stream> must be an output stream (not the value 'fail')
+Error, LOG_TO_STREAM: <stream> must be an output stream (not the value 'fail')
 gap> str := "";; s:=OutputTextString(str, false);;
 gap> LOG_TO_STREAM(s);
 true
@@ -24,13 +24,14 @@ true
 gap> CLOSE_INPUT_LOG_TO();
 Error, InputLogTo: can not close the logfile
 gap> INPUT_LOG_TO(fail);
-Error, InputLogTo: <filename> must be a string (not the value 'fail')
+Error, INPUT_LOG_TO: <filename> must be a string (not the value 'fail')
 gap> INPUT_LOG_TO(TmpName());
 true
 gap> CLOSE_INPUT_LOG_TO();
 true
 gap> INPUT_LOG_TO_STREAM(fail);
-Error, InputLogTo: <stream> must be an output stream (not the value 'fail')
+Error, INPUT_LOG_TO_STREAM: <stream> must be an output stream (not the value '\
+fail')
 gap> str := "";; s:=OutputTextString(str, false);;
 gap> INPUT_LOG_TO_STREAM(s);
 true
@@ -41,13 +42,14 @@ true
 gap> CLOSE_OUTPUT_LOG_TO();
 Error, OutputLogTo: can not close the logfile
 gap> OUTPUT_LOG_TO(fail);
-Error, OutputLogTo: <filename> must be a string (not the value 'fail')
+Error, OUTPUT_LOG_TO: <filename> must be a string (not the value 'fail')
 gap> OUTPUT_LOG_TO(TmpName());
 true
 gap> CLOSE_OUTPUT_LOG_TO();
 true
 gap> OUTPUT_LOG_TO_STREAM(fail);
-Error, OutputLogTo: <stream> must be an output stream (not the value 'fail')
+Error, OUTPUT_LOG_TO_STREAM: <stream> must be an output stream (not the value \
+'fail')
 gap> str := "";; s:=OutputTextString(str, false);;
 gap> OUTPUT_LOG_TO_STREAM(s);
 true
@@ -65,11 +67,11 @@ fail
 gap> READ_STREAM(fail);
 Error, READ_STREAM: <stream> must be an input stream (not the value 'fail')
 gap> READ_STREAM_LOOP_WITH_CONTEXT(fail, fail, fail);
-Error, READ_STREAM_LOOP: <instream> must be an input stream (not the value 'fa\
-il')
+Error, READ_STREAM_LOOP_WITH_CONTEXT: <instream> must be an input stream (not \
+the value 'fail')
 gap> READ_STREAM_LOOP_WITH_CONTEXT(InputTextString(""), fail, fail);
-Error, READ_STREAM_LOOP: <outstream> must be an output stream (not the value '\
-fail')
+Error, READ_STREAM_LOOP_WITH_CONTEXT: <outstream> must be an output stream (no\
+t the value 'fail')
 gap> READ_AS_FUNC(fail);
 Error, READ_AS_FUNC: <filename> must be a string (not the value 'fail')
 gap> READ_AS_FUNC_STREAM(false);
@@ -80,7 +82,7 @@ Error, READ_STREAM: <stream> must be an input stream (not the value 'fail')
 gap> READ_STREAM(fail);
 Error, READ_STREAM: <stream> must be an input stream (not the value 'fail')
 gap> READ_GAP_ROOT(fail);
-Error, READ: <filename> must be a string (not the value 'fail')
+Error, READ_GAP_ROOT: <filename> must be a string (not the value 'fail')
 
 #
 gap> RemoveFile(fail);

--- a/tst/testinstall/kernel/stringobj.tst
+++ b/tst/testinstall/kernel/stringobj.tst
@@ -59,7 +59,7 @@ Error, INTLIST_STRING: <val> must be a string (not the integer 1)
 gap> SINTLIST_STRING("ABC");
 [ 65, 66, 67 ]
 gap> SINTLIST_STRING(1);
-Error, INTLIST_STRING: <val> must be a string (not the integer 1)
+Error, SINTLIST_STRING: <val> must be a string (not the integer 1)
 
 #
 gap> STRING_SINTLIST([ 65, 66, 67 ]);
@@ -79,11 +79,11 @@ Error, REVNEG_STRING: <val> must be a string (not the integer 1)
 
 #
 gap> CONV_STRING(1);
-Error, ConvString: <string> must be a string (not the integer 1)
+Error, CONV_STRING: <string> must be a string (not the integer 1)
 
 #
 gap> COPY_TO_STRING_REP(1);
-Error, CopyToStringRep: <string> must be a string (not the integer 1)
+Error, COPY_TO_STRING_REP: <string> must be a string (not the integer 1)
 
 #
 gap> POSITION_SUBSTRING("abc","x",0);
@@ -110,9 +110,9 @@ Error, NormalizeWhitespace: <string> must be a string (not the integer 1)
 gap> s:="abcdabcd";; REMOVE_CHARACTERS(s, "db"); s;
 "acac"
 gap> REMOVE_CHARACTERS(1,1);
-Error, RemoveCharacters: <string> must be a string (not the integer 1)
+Error, REMOVE_CHARACTERS: <string> must be a string (not the integer 1)
 gap> REMOVE_CHARACTERS(s,1);
-Error, RemoveCharacters: <rem> must be a string (not the integer 1)
+Error, REMOVE_CHARACTERS: <rem> must be a string (not the integer 1)
 
 #
 gap> s:="abc";; TranslateString(s,UPPERCASETRANSTABLE); s;

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -190,11 +190,11 @@ Error, List Elements: <list>[4] must have an assigned value
 
 # ListWithIdenticalEntries: errors
 gap> ListWithIdenticalEntries(fail, true);
-Error, LIST_WITH_IDENTICAL_ENTRIES: <n> must be a non-negative small integer (\
-not the value 'fail')
+Error, ListWithIdenticalEntries: <n> must be a non-negative small integer (not\
+ the value 'fail')
 gap> ListWithIdenticalEntries(-1, fail);
-Error, LIST_WITH_IDENTICAL_ENTRIES: <n> must be a non-negative small integer (\
-not the integer -1)
+Error, ListWithIdenticalEntries: <n> must be a non-negative small integer (not\
+ the integer -1)
 
 # ListWithIdenticalEntries: 0 length
 gap> l := ListWithIdenticalEntries(0, 'w');

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -227,12 +227,14 @@ gap> l := [];; Append(l,l); l;
 gap> l := [1,2,3,4];; Append(l,l); l;
 [ 1, 2, 3, 4, 1, 2, 3, 4 ]
 gap> Append(Immutable([1,2,3]), [1,2,3]);
-Error, Append: <list1> must be a mutable list (not an immutable plain list of \
-cyclotomics)
+Error, FuncAPPEND_LIST_INTR: <list1> must be a mutable list (not an immutable \
+plain list of cyclotomics)
 gap> Append([1,2,3], () );
-Error, Append: <list2> must be a small list (not a permutation (small))
+Error, FuncAPPEND_LIST_INTR: <list2> must be a small list (not a permutation (\
+small))
 gap> Append( () , [1,2,3] );
-Error, Append: <list1> must be a mutable list (not a permutation (small))
+Error, FuncAPPEND_LIST_INTR: <list1> must be a mutable list (not a permutation\
+ (small))
 gap> s;
 [  ]
 
@@ -268,13 +270,13 @@ gap> CopyListEntries(l,1,1,l,3,2,2); l;
 gap> CopyListEntries();
 Error, Function: number of arguments must be 7 (not 0)
 gap> CopyListEntries("abc",3,-1,l,4,-3,2);
-Error, CopyListEntries: <fromlst> must be a plain list (not a list (string))
+Error, COPY_LIST_ENTRIES: <fromlst> must be a plain list (not a list (string))
 gap> CopyListEntries(s,3,-1,"abc",4,-3,2);
-Error, CopyListEntries: <tolst> must be a mutable plain list (not a list (stri\
-ng))
+Error, COPY_LIST_ENTRIES: <tolst> must be a mutable plain list (not a list (st\
+ring))
 gap> CopyListEntries(s,3,-1,Immutable([1,2,3]),4,-3,2);
-Error, CopyListEntries: <tolst> must be a mutable plain list (not an immutable\
- plain list of cyclotomics)
+Error, COPY_LIST_ENTRIES: <tolst> must be a mutable plain list (not an immutab\
+le plain list of cyclotomics)
 gap> CopyListEntries(s, "cheese", 1, l, 1, 1, 2);
 Error, CopyListEntries: <fromind> must be a small integer (not a list (string)\
 )

--- a/tst/testinstall/numtheor.tst
+++ b/tst/testinstall/numtheor.tst
@@ -75,9 +75,9 @@ gap> JACOBI_INT_GAP := function ( n, m )
 gap> ForAll([-100 .. 100], a-> ForAll([1 .. 100], b -> JACOBI_INT_GAP(a,b)=JACOBI_INT(a,b)));
 true
 gap> JACOBI_INT(fail, 1);
-Error, Jacobi: <n> must be an integer (not the value 'fail')
+Error, JACOBI_INT: <n> must be an integer (not the value 'fail')
 gap> JACOBI_INT(1, fail);
-Error, Jacobi: <m> must be an integer (not the value 'fail')
+Error, JACOBI_INT: <m> must be an integer (not the value 'fail')
 
 #
 gap> STOP_TEST( "numtheor.tst", 1);

--- a/tst/testinstall/opers/ListBlist.tst
+++ b/tst/testinstall/opers/ListBlist.tst
@@ -2,11 +2,11 @@ gap> START_TEST("ListBlist.tst");
 
 #
 gap> ListBlist([],[false,true]);
-Error, ListBlist: <blist> must have the same length as <list> (lengths are 2 a\
-nd 0)
+Error, LIST_BLIST: <blist> must have the same length as <list> (lengths are 2 \
+and 0)
 gap> ListBlist([],[1,2]);
-Error, ListBlist: <blist> must be a boolean list (not a plain list of cyclotom\
-ics)
+Error, LIST_BLIST: <blist> must be a boolean list (not a plain list of cycloto\
+mics)
 gap> ListBlist([],[]);
 [  ]
 gap> ListBlist([1,2],[false,true]);

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -369,11 +369,11 @@ gap> moved(SymmetricGroup(1));
 gap> moved(Group((8,9,10),(13,15,19)));
 [ 8, 19, [ 8, 9, 10, 13, 15, 19 ], 6 ]
 gap> SMALLEST_MOVED_POINT_PERM(fail);
-Error, SmallestMovedPointPerm: <perm> must be a permutation (not the value 'fa\
-il')
+Error, SMALLEST_MOVED_POINT_PERM: <perm> must be a permutation (not the value \
+'fail')
 gap> LARGEST_MOVED_POINT_PERM(fail);
-Error, LargestMovedPointPerm: <perm> must be a permutation (not the value 'fai\
-l')
+Error, LARGEST_MOVED_POINT_PERM: <perm> must be a permutation (not the value '\
+fail')
 
 #
 # CycleLengthPermInt, CyclePermInt
@@ -415,7 +415,7 @@ gap> Order( (1,2,3,4)(70,71,72) );
 gap> Order( (1,2,3,4)(70000,71000,72000) );
 12
 gap> ORDER_PERM(fail);
-Error, OrderPerm: <perm> must be a permutation (not the value 'fail')
+Error, ORDER_PERM: <perm> must be a permutation (not the value 'fail')
 
 #
 # SignPerm
@@ -425,13 +425,14 @@ gap> List(permSml, SignPerm);
 gap> List(permBig, SignPerm);
 [ 1, -1, -1, 1, 1, -1 ]
 gap> SIGN_PERM(fail);
-Error, SignPerm: <perm> must be a permutation (not the value 'fail')
+Error, SIGN_PERM: <perm> must be a permutation (not the value 'fail')
 
 #
 # SmallestGeneratorPerm
 #
 gap> SMALLEST_GENERATOR_PERM( 1 );
-Error, SmallestGeneratorPerm: <perm> must be a permutation (not the integer 1)
+Error, SMALLEST_GENERATOR_PERM: <perm> must be a permutation (not the integer \
+1)
 gap> SmallestGeneratorPerm( (1,3,2) );
 (1,2,3)
 gap> SmallestGeneratorPerm( (1,2,3) );
@@ -549,12 +550,14 @@ fail
 gap> MappingPermListList([1,2], [1000,1000]);
 fail
 gap> MappingPermListList((), []);
-Error, AddRowVector: <src> must be a dense list (not a permutation (small))
+Error, MappingPermListList: <src> must be a dense list (not a permutation (sma\
+ll))
 gap> MappingPermListList([], ());
-Error, AddRowVector: <dst> must be a dense list (not a permutation (small))
+Error, MappingPermListList: <dst> must be a dense list (not a permutation (sma\
+ll))
 gap> MappingPermListList("cheese", "cake");
-Error, AddRowVector: <src> must have the same length as <dst> (lengths are 6 a\
-nd 4)
+Error, MappingPermListList: <src> must have the same length as <dst> (lengths \
+are 6 and 4)
 gap> MappingPermListList("cheese", "cakeba");
 Error, <src> must be a dense list of positive small integers
 gap> MappingPermListList([1,2], [3,[]]);

--- a/tst/testinstall/rationals.tst
+++ b/tst/testinstall/rationals.tst
@@ -6,9 +6,9 @@ gap> NumeratorRat(x);
 gap> DenominatorRat(x);
 3
 gap> NumeratorRat('c');
-Error, NumeratorRat: <rat> must be a rational (not a character)
+Error, NUMERATOR_RAT: <rat> must be a rational (not a character)
 gap> DenominatorRat('c');
-Error, DenominatorRat: <rat> must be a rational (not a character)
+Error, DENOMINATOR_RAT: <rat> must be a rational (not a character)
 
 #
 gap> IsRat(x);

--- a/tst/testinstall/recordname.tst
+++ b/tst/testinstall/recordname.tst
@@ -45,9 +45,10 @@ gap> RecNames( () );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RecNames' on 1 arguments
 gap> REC_NAMES( () );
-Error, RecNames: <rec> must be a record (not a permutation (small))
+Error, REC_NAMES: <rec> must be a record (not a permutation (small))
 gap> REC_NAMES_COMOBJ( () );
-Error, RecNames: <rec> must be a component object (not a permutation (small))
+Error, REC_NAMES_COMOBJ: <rec> must be a component object (not a permutation (\
+small))
 gap> rec() < rec(x := 1);
 true
 gap> rec(x := 1) = rec(x := 2);

--- a/tst/testinstall/trans.tst
+++ b/tst/testinstall/trans.tst
@@ -169,8 +169,8 @@ gap> SMALLEST_MOVED_PT_TRANS(Transformation([1, 2, 1, 4, 5]));
 gap> SMALLEST_MOVED_PT_TRANS(Transformation([65537], [1]));
 65537
 gap> SMALLEST_MOVED_PT_TRANS("a");
-Error, SMALLEST_MOVED_PTS_TRANS: <f> must be a transformation (not a list (str\
-ing))
+Error, SMALLEST_MOVED_PT_TRANS: <f> must be a transformation (not a list (stri\
+ng))
 
 # Test SMALLEST_IMAGE_PT
 gap> SMALLEST_IMAGE_PT(IdentityTransformation);
@@ -281,8 +281,7 @@ gap> IMAGE_SET_TRANS(Transformation([65537 .. 70000], [65537 .. 70000] * 0 + 1))
 > = [1 .. 65536];
 true
 gap> IMAGE_SET_TRANS("a");
-Error, UNSORTED_IMAGE_SET_TRANS: <f> must be a transformation (not a list (str\
-ing))
+Error, IMAGE_SET_TRANS: <f> must be a transformation (not a list (string))
 gap> IMAGE_SET_TRANS(Transformation([2, 1, 2, 4, 5]));
 [ 1, 2, 4, 5 ]
 gap> IsSet(last);
@@ -1128,9 +1127,9 @@ true
 gap> POW_KER_PERM([1 .. 100] * 0 + 1, (1,2,3)(65537, 65538)) = [1 .. 100] * 0 + 1;
 true
 gap> POW_KER_PERM([1, 2], 1);
-Error, POW_KER_TRANS: <p> must be a permutation (not the integer 1)
+Error, POW_KER_PERM: <p> must be a permutation (not the integer 1)
 gap> POW_KER_PERM(1, 2);
-Error, POW_KER_TRANS: <p> must be a permutation (not the integer 2)
+Error, POW_KER_PERM: <p> must be a permutation (not the integer 2)
 gap> Set(SymmetricGroup(3), p -> POW_KER_PERM([1, 1, 2], p)); 
 [ [ 1, 1, 2 ], [ 1, 2, 1 ], [ 1, 2, 2 ] ]
 gap> Set(SymmetricGroup(3), p -> POW_KER_PERM([1, 2, 3], p)); 


### PR DESCRIPTION
`SELF_NAME` is a convenience helper to access the name of GAP a kernel function as a C     string, which can be passed to `RequireArgumentEx` and its variants.

The advantage is that one does not have to duplicate function names in lots of places; and if the function is renamed, the errors are automatically adjusted. In a few places, this actually fixes error messages; in a few places, it introduces regressions, but arguably most of those hint at cases where should perhaps just rename the kernel function instead of having a kernel function with one name and an identical GAP function with another name (e.g. `NumeratorRat` vs. `NUMERATOR`). Otherwise, one could just change the affected functions back to not using `SELF_NAME`. 

BTW, we could think about exposing SELF_NAME() as a GAP function (which would have to rely on some hackery to determine the *caller function* and then get the name of *that*) to be used for similar features.