### PR TITLE
Travis: make the `chown` workaround more resilient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,7 @@ matrix:
       dist: bionic
       before_install:
         # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
-        - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+        - test -d ~/.cache/pip/wheels && sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels || echo "all good"
 
     # build on non-x86 platform
     - env: TEST_SUITES="docomp testinstall"
@@ -174,7 +174,7 @@ matrix:
       dist: bionic
       before_install:
         # work around cache dir owned by root (see https://travis-ci.community/t/7822/6)
-        - sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels
+        - test -d ~/.cache/pip/wheels && sudo chown -fR $USER:$GROUP ~/.cache/pip/wheels || echo "all good"
 
 # use travis_terminate below to ensure travis immediately aborts upon error,
 # and also to work around timeouts (see https://travis-ci.community/t/7659)


### PR DESCRIPTION
It recently started to fail on arm64 (but not on s390x) jobs, which
might mean the underlying issue is fixed there, or it just might be that
it got even more random -- hard to tell w/o any kind of feedback from
Travis engineers. In any case, by checking whether ~/.cache/pip/wheels
exists before trying to change its owner & group, we can avoid troubles.
