### PR TITLE
buildsys: fix two regressions and add more tests

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -247,9 +247,6 @@ GAP_LIBS += $(LIBS)
 # build/obj/FOO/bar.c.lo resp. build/obj/FOO/bar.cc.lo
 OBJS = $(patsubst %,build/obj/%.lo,$(SOURCES))
 
-# ensure config.h is built before the compilers gets invoked
-$(OBJS): build/config.h
-
 
 ########################################################################
 # Quiet rules.
@@ -307,7 +304,7 @@ OBJFILE = build/obj/$(*D)/$(<F).lo
 # TODO: use configure to compute DEPFLAGS, so that we can
 # disable it for compilers that don't support it, resp. replace it
 # something that works for that compiler
-DEPFLAGS = -MQ "$@" -MMD -MP -MF $(DEPFILE)
+DEPFLAGS = -MQ $(OBJFILE) -MMD -MP -MF $(DEPFILE)
 
 
 ########################################################################
@@ -327,13 +324,13 @@ DEPFLAGS = -MQ "$@" -MMD -MP -MF $(DEPFILE)
 # careful to not put these into GAP_CXXFLAGS, as kernel extensions may want to
 # use GAP_CXXFLAGS but also may have a  need to interface with C++ code in
 # libraries that use exceptions.
-build/obj/%.cc.lo build/deps/%.cc.d: %.cc cnf/GAP-CXXFLAGS cnf/GAP-CPPFLAGS libtool
+build/obj/%.cc.lo build/deps/%.cc.d: %.cc cnf/GAP-CXXFLAGS cnf/GAP-CPPFLAGS libtool build/config.h
 	@$(MKDIR_P) build/obj/$(*D) build/deps/$(*D)
 	$(QUIET_CXX)$(LIBTOOL) --mode=compile --tag CXX $(CXX) $(DEPFLAGS) $(GAP_CXXFLAGS) -fno-exceptions -fno-rtti $(WARN_CXXFLAGS) $(GAP_CPPFLAGS) -c $< -o $(OBJFILE)
 	@echo "$<:" >> $(DEPFILE)
 
 # Build rule for C source files
-build/obj/%.c.lo build/deps/%.c.d: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool
+build/obj/%.c.lo build/deps/%.c.d: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS libtool build/config.h
 	@$(MKDIR_P) build/obj/$(*D) build/deps/$(*D)
 	$(QUIET_CC)$(LIBTOOL) --mode=compile --tag CC $(CC) $(DEPFLAGS) $(GAP_CFLAGS) $(WARN_CFLAGS) $(GAP_CPPFLAGS) -c $< -o $(OBJFILE)
 	@echo "$<:" >> $(DEPFILE)


### PR DESCRIPTION
That first change modified $DEPFLAGS to ensure that .d files contain
targets for .lo files and not for the .d files -- the bug here was use
of the $@ variable which can have two values: the name of the .lo file
or the name of the .d file, depending on why the combined build rule for
the .lo/.d pair was triggered. This is easily fixed by using $OBJFILE
instead.

This bug meant that e.g. `make print-VAR` which should never lead to
anything being compiled could trigger compilation of stuff anyway.

Secondly, we want all *.lo files to depend on config.h; but the old way
to do that, which was to just let $(OBJS) depend on config.h, does not
work reliably anymore due to our combined .lo/.d rule: if the
compilation is triggered by the .d file being regenerated, we end up
calling the C compiler before config.h was regenerated. We could have
fixed this by adding a dependency from $(DEPFILES) to config.h, but it
seemed more natural to add config.h as a dependency to the rules which
actually invoke the compiler.

Finally we add a bunch of tests to `testbuildsys`, which ought to have
caught the two issues fixed above, plus some more.


Sorry for the mess I created, but at least with the new tests being added I am hopeful similar issues can be avoided (or at least fairly minimized) in the future.