### PR TITLE
Various updates for the Julia integration

### DIFF
--- a/etc/ci-prepare.sh
+++ b/etc/ci-prepare.sh
@@ -30,7 +30,7 @@ fi
 if [[ $JULIA = yes ]]
 then
   pushd extern
-  wget https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz
+  wget https://julialang-s3.julialang.org/bin/linux/x64/1.4/julia-1.4.2-linux-x86_64.tar.gz
   tar xvf julia-*.tar.gz
   rm julia-*.tar.gz
   cd julia-*

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -152,12 +152,12 @@ static inline void SET_ELM_WPOBJ(Obj list, UInt pos, Obj val)
     }
     if (!IS_BAG_REF(ptr[pos])) {
         ptr[pos] = (Bag)jl_gc_new_weakref((jl_value_t *)val);
-        jl_gc_wb_back(CONST_BAG_HEADER(list));
+        jl_gc_wb_back(BAG_HEADER(list));
     }
     else {
         jl_weakref_t * wref = (jl_weakref_t *)(ptr[pos]);
         wref->value = (jl_value_t *)val;
-        jl_gc_wb(wref, CONST_BAG_HEADER(val));
+        jl_gc_wb(wref, BAG_HEADER(val));
     }
 #endif
 }


### PR DESCRIPTION
1. test against Julia 1.4.2 instead of 1.2.0
2. fix compiler constness warnings in weakptr.c
3. use `jl_threadid()` and `jl_get_current_task()` helpers to avoid access to
   `JuliaTLS` members

Point 3 is important because the layout of the `jl_ptls_t` struct  keeps
changing between Julia versions, meaning that one has to recompile GAP when
updating Julia. With this patch, we avoid accessing the `tid` and `current_task`
members.

However, we still access `root_task` and `safe_restore`. More work will be needed
to deal with those.

For `root_task` (unfortunately, Julia doesn't provide an accessor function for this -- yet) luckily this is of no consequence in many cases: namely, if GAP is used as a library (i.e. loaded from Julia), that check is never executed; and if GAP loads Julia, then it ought to load the correct version of Julia anyway (i.e., for people who have multiple Julia versions installed in parallel, the right one is picked). It still might break if the user upgrades the Julia installation in place.

For `safe_restore`, I wonder if we can perhaps get away with using JL_TRY / JL_CATCH. However, I just removed the `safe_restore` code completely, yet `testinstall` still passed, @rbehrends do you remember by chance which crash this fixed? The code was originally inserted in PR #2969 but doesn't mention explicitly what the issue was / how to reproduce it.