### PR TITLE
kernel: reduce direct access to STATE(BottomLVars)

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -373,7 +373,7 @@ Bag NewBag(UInt type, UInt size)
     bag = GC_malloc(4 * sizeof(Bag *));
     if (STATE(PtrLVars)) {
         bag[2] = (void *)CURR_FUNC();
-        if (STATE(CurrLVars) != STATE(BottomLVars)) {
+        if (!IsBottomLVars(STATE(CurrLVars))) {
             Obj plvars = PARENT_LVARS(STATE(CurrLVars));
             bag[3] = (void *)(FUNC_LVARS(plvars));
         }

--- a/src/calls.c
+++ b/src/calls.c
@@ -1066,7 +1066,7 @@ void PrintFunction (
 
         // print the code
         Obj oldLVars;
-        SWITCH_TO_NEW_LVARS(func, narg, NLOC_FUNC(func), oldLVars);
+        oldLVars = SWITCH_TO_NEW_LVARS(func, narg, NLOC_FUNC(func));
         PrintStat( OFFSET_FIRST_STAT );
         SWITCH_TO_OLD_LVARS( oldLVars );
     }

--- a/src/code.c
+++ b/src/code.c
@@ -799,7 +799,6 @@ void CodeFuncExprBegin (
 {
     Obj                 fexp;           /* function expression bag         */
     Bag                 body;           /* function body                   */
-    Bag                 old;            /* old frame                       */
     Stat                stat1;          /* first statement in body         */
 
     /* remember the current offset                                         */
@@ -831,8 +830,7 @@ void CodeFuncExprBegin (
     MakeHighVars(STATE(CurrLVars));
 
     /* switch to this function                                             */
-    SWITCH_TO_NEW_LVARS( fexp, (narg >0 ? narg : -narg), nloc, old );
-    (void) old; /* please picky compilers. */
+    SWITCH_TO_NEW_LVARS(fexp, (narg > 0 ? narg : -narg), nloc);
 
     /* allocate the top level statement sequence                           */
     stat1 = NewStat( STAT_SEQ_STAT, 8*sizeof(Stat) );

--- a/src/compiled.h
+++ b/src/compiled.h
@@ -81,7 +81,8 @@ static inline void CHECK_FUNC(Obj obj)
 
 /* higher variables, should go into 'vars.c' * * * * * * * * * * * * * * * */
 
-#define SWITCH_TO_NEW_FRAME     SWITCH_TO_NEW_LVARS
+#define SWITCH_TO_NEW_FRAME(func, narg, nloc, old)                           \
+    (old) = SWITCH_TO_NEW_LVARS((func), (narg), (nloc))
 #define SWITCH_TO_OLD_FRAME     SWITCH_TO_OLD_LVARS_AND_FREE
 
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5073,7 +5073,7 @@ static void CompFunc(Obj func)
     }
 
     /* switch to this function (so that 'CONST_ADDR_STAT' and 'CONST_ADDR_EXPR' work)  */
-    SWITCH_TO_NEW_LVARS( func, narg, nloc, oldFrame );
+    oldFrame = SWITCH_TO_NEW_LVARS(func, narg, nloc);
 
     /* get the info bag                                                    */
     info = INFO_FEXP( CURR_FUNC() );

--- a/src/error.c
+++ b/src/error.c
@@ -152,8 +152,7 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
         return Fail;
     }
 
-    Obj currLVars = STATE(CurrLVars);
-    SWITCH_TO_OLD_LVARS(context);
+    Obj currLVars = SWITCH_TO_OLD_LVARS(context);
     GAP_ASSERT(call == BRK_CALL_TO());
 
     Obj retlist = Fail;
@@ -201,8 +200,7 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
         Pr("<corrupted statement> ", 0, 0);
     }
     else {
-        Obj currLVars = STATE(CurrLVars);
-        SWITCH_TO_OLD_LVARS(context);
+        Obj currLVars = SWITCH_TO_OLD_LVARS(context);
         GAP_ASSERT(call == BRK_CALL_TO());
 
         Int type = TNUM_STAT(call);

--- a/src/error.c
+++ b/src/error.c
@@ -105,7 +105,7 @@ static Obj FuncDownEnv(Obj self, Obj args)
     else {
         ErrorQuit("usage: DownEnv( [ <depth> ] )", 0, 0);
     }
-    if (STATE(ErrorLVars) == STATE(BottomLVars)) {
+    if (IsBottomLVars(STATE(ErrorLVars))) {
         Pr("not in any function\n", 0, 0);
         return (Obj)0;
     }
@@ -126,7 +126,7 @@ static Obj FuncUpEnv(Obj self, Obj args)
     else {
         ErrorQuit("usage: UpEnv( [ <depth> ] )", 0, 0);
     }
-    if (STATE(ErrorLVars) == STATE(BottomLVars)) {
+    if (IsBottomLVars(STATE(ErrorLVars))) {
         Pr("not in any function\n", 0, 0);
         return (Obj)0;
     }
@@ -137,7 +137,7 @@ static Obj FuncUpEnv(Obj self, Obj args)
 
 static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
 {
-    if (context == STATE(BottomLVars))
+    if (IsBottomLVars(context))
         return Fail;
 
     Obj func = FUNC_LVARS(context);
@@ -170,7 +170,7 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
 
 static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
 {
-    if (context == STATE(BottomLVars))
+    if (IsBottomLVars(context))
         return 0;
 
     /* HACK: we want to redirect output */

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -474,7 +474,7 @@ static ALWAYS_INLINE Obj DoExecFunc(Obj func, Int narg, const Obj *arg)
 #endif
 
     /* switch to a new values bag                                          */
-    SWITCH_TO_NEW_LVARS( func, narg, NLOC_FUNC(func), oldLvars );
+    oldLvars = SWITCH_TO_NEW_LVARS(func, narg, NLOC_FUNC(func));
 
     /* enter the arguments                                                 */
     for (Int i = 0; i < narg; i++)
@@ -557,7 +557,7 @@ static Obj DoExecFuncXargs(Obj func, Obj args)
 #endif
 
     /* switch to a new values bag                                          */
-    SWITCH_TO_NEW_LVARS( func, len, NLOC_FUNC(func), oldLvars );
+    oldLvars = SWITCH_TO_NEW_LVARS(func, len, NLOC_FUNC(func));
 
     /* enter the arguments                                                 */
     for ( i = 1; i <= len; i++ ) {
@@ -603,7 +603,7 @@ static Obj DoPartialUnWrapFunc(Obj func, Obj args)
 #endif
 
     /* switch to a new values bag                                          */
-    SWITCH_TO_NEW_LVARS( func, named+1, NLOC_FUNC(func), oldLvars );
+    oldLvars = SWITCH_TO_NEW_LVARS(func, named + 1, NLOC_FUNC(func));
 
     /* enter the arguments                                                 */
     for (i = 1; i <= named; i++) {

--- a/src/gap.c
+++ b/src/gap.c
@@ -229,8 +229,8 @@ static Obj Shell(Obj    context,
     Int depth = STATE(ErrorLLevel);
     Obj errorLVars = context;
     STATE(ErrorLLevel) = 0;
-    while (0 < depth && errorLVars != STATE(BottomLVars) &&
-           PARENT_LVARS(errorLVars) != STATE(BottomLVars)) {
+    while (0 < depth && !IsBottomLVars(errorLVars) &&
+           !IsBottomLVars(PARENT_LVARS(errorLVars))) {
         errorLVars = PARENT_LVARS(errorLVars);
         STATE(ErrorLLevel)++;
         depth--;

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -15,7 +15,6 @@
 
 #include "code.h"
 #include "exprs.h"
-#include "gapstate.h"
 #include "gaputils.h"
 #include "modules.h"
 #include "stats.h"

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -21,7 +21,6 @@
 #include "calls.h"
 #include "error.h"
 #include "fibhash.h"
-#include "gapstate.h"
 #include "gaputils.h"
 #include "gvars.h"
 #include "io.h"

--- a/src/hpc/serialize.c
+++ b/src/hpc/serialize.c
@@ -13,7 +13,6 @@
 #include "bool.h"
 #include "calls.h"
 #include "error.h"
-#include "gapstate.h"
 #include "gvars.h"
 #include "modules.h"
 #include "objset.h"

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -17,7 +17,6 @@
 #include "code.h"
 #include "error.h"
 #include "funcs.h"
-#include "gapstate.h"
 #include "gvars.h"
 #include "io.h"
 #include "lists.h"

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -438,9 +438,6 @@ static void ThreadedInterpreter(void * funcargs)
     int i;
 
     // initialize everything and begin a fresh execution context
-    STATE(ThrownObject) = 0;
-    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
-
     tmp = KEPTALIVE(funcargs);
     StopKeepAlive(funcargs);
     func = ELM_PLIST(tmp, 1);

--- a/src/lists.c
+++ b/src/lists.c
@@ -26,7 +26,6 @@
 #include "bool.h"
 #include "calls.h"
 #include "error.h"
-#include "gapstate.h"
 #include "gaputils.h"
 #include "integer.h"
 #include "io.h"

--- a/src/modules.c
+++ b/src/modules.c
@@ -159,7 +159,7 @@ Int ActivateModule(StructInitInfo * info)
             // Start a new executor to run the outer function of the module in
             // global context
             Bag oldLvars = STATE(CurrLVars);
-            SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+            SWITCH_TO_BOTTOM_LVARS();
             res = res || info->initLibrary(info);
             SWITCH_TO_OLD_LVARS(oldLvars);
         }

--- a/src/modules.c
+++ b/src/modules.c
@@ -158,8 +158,7 @@ Int ActivateModule(StructInitInfo * info)
         if (info->initLibrary) {
             // Start a new executor to run the outer function of the module in
             // global context
-            Bag oldLvars = STATE(CurrLVars);
-            SWITCH_TO_BOTTOM_LVARS();
+            Bag oldLvars = SWITCH_TO_BOTTOM_LVARS();
             res = res || info->initLibrary(info);
             SWITCH_TO_OLD_LVARS(oldLvars);
         }

--- a/src/read.c
+++ b/src/read.c
@@ -2593,15 +2593,11 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 
     // initialize everything and begin an interpreter
-    if (!context)
-        context = STATE(BottomLVars);
     rs->StackNams      = NEW_PLIST( T_PLIST, 16 );
     rs->ReadTop        = 0;
     rs->ReadTilde      = 0;
     STATE(Tilde)       = 0;
     rs->CurrLHSGVar    = 0;
-    STATE(ErrorLVars)  = context;
-    RecreateStackNams(rs, context);
 #ifdef HPCGAP
     lockSP = RegionLockSP();
 #endif
@@ -2612,7 +2608,13 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     Bag oldLVars = STATE(CurrLVars);
 
     // start an execution environment
-    SWITCH_TO_OLD_LVARS(context);
+    if (context)
+        SWITCH_TO_OLD_LVARS(context);
+    else
+        SWITCH_TO_BOTTOM_LVARS();
+
+    STATE(ErrorLVars) = STATE(CurrLVars);
+    RecreateStackNams(rs, STATE(CurrLVars));
 
     IntrBegin(&rs->intr);
 
@@ -2724,7 +2726,7 @@ UInt ReadEvalFile(Obj * evalResult)
     Bag oldLVars = STATE(CurrLVars);
 
     // start an execution environment
-    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+    SWITCH_TO_BOTTOM_LVARS();
 
     IntrBegin(&rs->intr);
 
@@ -2793,7 +2795,7 @@ Obj Call0ArgsInNewReader(Obj f)
 
     // initialize everything
     STATE(UserHasQuit) = 0;
-    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+    SWITCH_TO_BOTTOM_LVARS();
 
     GAP_TRY
     {
@@ -2826,7 +2828,7 @@ Obj Call1ArgsInNewReader(Obj f, Obj a)
 
     // initialize everything
     STATE(UserHasQuit) = 0;
-    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+    SWITCH_TO_BOTTOM_LVARS();
 
     GAP_TRY
     {

--- a/src/read.c
+++ b/src/read.c
@@ -2604,17 +2604,14 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
 
     AssGVar(GVarName("READEVALCOMMAND_LINENUMBER"), INTOBJ_INT(GetInputLineNumber()));
 
-    // remember the old execution state
-    Bag oldLVars = STATE(CurrLVars);
+    // remember the old execution state and start an execution environment
+    Bag oldLVars =
+        context ? SWITCH_TO_OLD_LVARS(context) : SWITCH_TO_BOTTOM_LVARS();
 
-    // start an execution environment
     if (context)
-        SWITCH_TO_OLD_LVARS(context);
-    else
-        SWITCH_TO_BOTTOM_LVARS();
+        RecreateStackNams(rs, context);
 
     STATE(ErrorLVars) = STATE(CurrLVars);
-    RecreateStackNams(rs, STATE(CurrLVars));
 
     IntrBegin(&rs->intr);
 
@@ -2722,11 +2719,8 @@ UInt ReadEvalFile(Obj * evalResult)
     STATE(Tilde)     = 0;
     rs->CurrLHSGVar  = 0;
 
-    // remember the old execution state
-    Bag oldLVars = STATE(CurrLVars);
-
-    // start an execution environment
-    SWITCH_TO_BOTTOM_LVARS();
+    // remember the old execution state and start an execution environment
+    Bag oldLVars = SWITCH_TO_BOTTOM_LVARS();
 
     IntrBegin(&rs->intr);
 
@@ -2790,12 +2784,12 @@ Obj Call0ArgsInNewReader(Obj f)
 {
     // remember the old state
     volatile UInt userHasQuit = STATE(UserHasQuit);
-    volatile Obj  oldLvars = STATE(CurrLVars);
+    volatile Obj  oldLvars;
     volatile Obj  result = 0;
 
     // initialize everything
     STATE(UserHasQuit) = 0;
-    SWITCH_TO_BOTTOM_LVARS();
+    oldLvars = SWITCH_TO_BOTTOM_LVARS();
 
     GAP_TRY
     {
@@ -2823,12 +2817,12 @@ Obj Call1ArgsInNewReader(Obj f, Obj a)
 {
     // remember the old state
     volatile UInt userHasQuit = STATE(UserHasQuit);
-    volatile Obj  oldLvars = STATE(CurrLVars);
+    volatile Obj  oldLvars;
     volatile Obj  result = 0;
 
     // initialize everything
     STATE(UserHasQuit) = 0;
-    SWITCH_TO_BOTTOM_LVARS();
+    oldLvars = SWITCH_TO_BOTTOM_LVARS();
 
     GAP_TRY
     {

--- a/src/read.c
+++ b/src/read.c
@@ -2593,6 +2593,8 @@ ExecStatus ReadEvalCommand(Obj context, Obj *evalResult, UInt *dualSemicolon)
     memcpy( readJmpError, STATE(ReadJmpError), sizeof(jmp_buf) );
 
     // initialize everything and begin an interpreter
+    if (!context)
+        context = STATE(BottomLVars);
     rs->StackNams      = NEW_PLIST( T_PLIST, 16 );
     rs->ReadTop        = 0;
     rs->ReadTilde      = 0;

--- a/src/read.c
+++ b/src/read.c
@@ -713,10 +713,10 @@ static LHSRef ReadVar(ReaderState * rs, TypSymbolSet follow)
     // up the static definition stack for each call function
     lvars0 = STATE(ErrorLVars);
     nest0 = 0;
-    while (ref.type == R_INVALID && lvars0 != 0 && lvars0 != STATE(BottomLVars)) {
+    while (ref.type == R_INVALID && lvars0 != 0 && !IsBottomLVars(lvars0)) {
         lvars = lvars0;
         nest = 0;
-        while (ref.type == R_INVALID && lvars != 0 && lvars != STATE(BottomLVars)) {
+        while (ref.type == R_INVALID && lvars != 0 && !IsBottomLVars(lvars)) {
             nams = NAMS_FUNC(FUNC_LVARS(lvars));
             if (nams != 0) {
                 indx = findValueInNams(nams, rs->s.Value, 1, LEN_PLIST(nams));
@@ -2523,7 +2523,7 @@ static void RecreateStackNams(ReaderState * rs, Obj context)
 {
     Obj stackNams = rs->StackNams;
     Obj lvars = context;
-    while (lvars != STATE(BottomLVars) && lvars != (Obj)0)  {
+    while (lvars && !IsBottomLVars(lvars))  {
         Obj nams = NAMS_FUNC(FUNC_LVARS(lvars));
         if (nams != (Obj) 0) {
             PushPlist(stackNams, nams);

--- a/src/stats.h
+++ b/src/stats.h
@@ -16,7 +16,7 @@
 #ifndef GAP_STATS_H
 #define GAP_STATS_H
 
-#include "gapstate.h"
+#include "common.h"
 
 /****************************************************************************
 **

--- a/src/streams.c
+++ b/src/streams.c
@@ -76,7 +76,7 @@ static Int READ_COMMAND(Obj *evalResult)
     ExecStatus    status;
 
     ClearError();
-    status = ReadEvalCommand(STATE(BottomLVars), evalResult, 0);
+    status = ReadEvalCommand(0, evalResult, 0);
     if( status == STATUS_EOF )
         return 0;
 
@@ -181,8 +181,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
             SET_LEN_STRING(outstreamString, 0);
         }
 
-        status =
-            ReadEvalCommand(STATE(BottomLVars), &evalResult, &dualSemicolon);
+        status = ReadEvalCommand(0, &evalResult, &dualSemicolon);
 
         if (!(status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))) {
             result = NEW_PLIST(T_PLIST, 5);
@@ -302,7 +301,7 @@ static void READ_INNER(void)
     while ( 1 ) {
         ClearError();
         Obj evalResult;
-        ExecStatus status = ReadEvalCommand(STATE(BottomLVars), &evalResult, 0);
+        ExecStatus status = ReadEvalCommand(0, &evalResult, 0);
         if (STATE(UserHasQuit) || STATE(UserHasQUIT))
             break;
 
@@ -491,7 +490,7 @@ Int READ_GAP_ROOT ( const Char * filename )
     if (OpenInput(path)) {
         while (1) {
             ClearError();
-            UInt type = ReadEvalCommand(STATE(BottomLVars), 0, 0);
+            UInt type = ReadEvalCommand(0, 0, 0);
             if (STATE(UserHasQuit) || STATE(UserHasQUIT))
                 break;
             if (type & (STATUS_RETURN_VAL | STATUS_RETURN_VOID)) {
@@ -963,8 +962,7 @@ static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT(Obj self,
 
 static Obj FuncREAD_STREAM_LOOP(Obj self, Obj stream, Obj catcherrstdout)
 {
-    return FuncREAD_STREAM_LOOP_WITH_CONTEXT(self, stream, catcherrstdout,
-                                             STATE(BottomLVars));
+    return FuncREAD_STREAM_LOOP_WITH_CONTEXT(self, stream, catcherrstdout, 0);
 }
 /****************************************************************************
 **

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -597,7 +597,7 @@ static Obj SyntaxTreeFunc(Obj result, Obj func)
     AssPRec(result, RNamName("nams"), NAMS_FUNC(func));
 
     /* switch to this function (so that 'READ_STAT' and 'READ_EXPR' work) */
-    SWITCH_TO_NEW_LVARS(func, narg, nloc, oldFrame);
+    oldFrame = SWITCH_TO_NEW_LVARS(func, narg, nloc);
     stats = SyntaxTreeCompiler(OFFSET_FIRST_STAT);
     SWITCH_TO_OLD_LVARS(oldFrame);
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -2014,7 +2014,7 @@ static Obj FuncContentsLVars(Obj self, Obj lvars)
   Obj nams = NAMS_FUNC(func);
   UInt len = (SIZE_BAG(lvars) - 2*sizeof(Obj) - sizeof(UInt))/sizeof(Obj);
   Obj values = NEW_PLIST_IMM(T_PLIST, len);
-  if (lvars == STATE(BottomLVars))
+  if (IsBottomLVars(lvars))
     return Fail;
   AssPRec(contents, RNamName("func"), func);
   AssPRec(contents, RNamName("names"), nams);
@@ -2023,7 +2023,7 @@ static Obj FuncContentsLVars(Obj self, Obj lvars)
       len--;
   SET_LEN_PLIST(values, len);
   AssPRec(contents, RNamName("values"), values);
-  if (ENVI_FUNC(func) != STATE(BottomLVars))
+  if (!IsBottomLVars(ENVI_FUNC(func)))
     AssPRec(contents, RNamName("higher"), ENVI_FUNC(func));
   return contents;
 }
@@ -2034,6 +2034,18 @@ static Obj FuncENVI_FUNC(Obj self, Obj func)
     Obj envi = ENVI_FUNC(func);
     return (envi && IS_LVARS_OR_HVARS(envi)) ? envi : Fail;
 }
+
+
+/****************************************************************************
+**
+*F  IsBottomLVars(<lvars>) . .  check whether some lvars are the bottom lvars
+**
+*/
+BOOL IsBottomLVars(Obj lvars)
+{
+    return lvars == STATE(BottomLVars);
+}
+
 
 /****************************************************************************
 **

--- a/src/vars.c
+++ b/src/vars.c
@@ -2049,6 +2049,16 @@ BOOL IsBottomLVars(Obj lvars)
 
 /****************************************************************************
 **
+*F  SWITCH_TO_BOTTOM_LVARS( ) . . . . .  switch to bottom local variables bag
+*/
+void SWITCH_TO_BOTTOM_LVARS(void)
+{
+    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+}
+
+
+/****************************************************************************
+**
 *F  VarsBeforeCollectBags() . . . . . . . . actions before garbage collection
 *F  VarsAfterCollectBags()  . . . . . . . .  actions after garbage collection
 */
@@ -2333,7 +2343,7 @@ static Int PostRestore (
     StructInitInfo *    module )
 {
     STATE(CurrLVars) = STATE(BottomLVars);
-    SWITCH_TO_OLD_LVARS( STATE(BottomLVars) );
+    SWITCH_TO_BOTTOM_LVARS();
 
     return 0;
 }
@@ -2367,7 +2377,7 @@ static Int InitModuleState(void)
     SET_BODY_FUNC( tmpFunc, tmpBody );
 
     STATE(CurrLVars) = STATE(BottomLVars);
-    SWITCH_TO_OLD_LVARS( STATE(BottomLVars) );
+    SWITCH_TO_BOTTOM_LVARS();
 
     return 0;
 }

--- a/src/vars.c
+++ b/src/vars.c
@@ -2051,9 +2051,9 @@ BOOL IsBottomLVars(Obj lvars)
 **
 *F  SWITCH_TO_BOTTOM_LVARS( ) . . . . .  switch to bottom local variables bag
 */
-void SWITCH_TO_BOTTOM_LVARS(void)
+Obj SWITCH_TO_BOTTOM_LVARS(void)
 {
-    SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
+    return SWITCH_TO_OLD_LVARS(STATE(BottomLVars));
 }
 
 

--- a/src/vars.h
+++ b/src/vars.h
@@ -53,6 +53,14 @@
 
 /****************************************************************************
 **
+*F  IsBottomLVars(<lvars>) . .  check whether some lvars are the bottom lvars
+**
+*/
+BOOL IsBottomLVars(Obj lvars);
+
+
+/****************************************************************************
+**
 *V  PtrLVars  . . . . . . . . . . . . . . . .  pointer to local variables bag
 **
 **  'PtrLVars' is a pointer to the 'CurrLVars' bag.  This  makes it faster to

--- a/src/vars.h
+++ b/src/vars.h
@@ -265,6 +265,13 @@ EXPORT_INLINE void SWITCH_TO_OLD_LVARS_AND_FREE(Obj old)
 
 /****************************************************************************
 **
+*F  SWITCH_TO_BOTTOM_LVARS( ) . . . . .  switch to bottom local variables bag
+*/
+void SWITCH_TO_BOTTOM_LVARS(void);
+
+
+/****************************************************************************
+**
 *F  ASS_LVAR( <lvar>, <val> ) . . . . . . . . . . .  assign to local variable
 **
 **  'ASS_LVAR' assigns the value <val> to the local variable <lvar>.

--- a/src/vars.h
+++ b/src/vars.h
@@ -195,59 +195,26 @@ EXPORT_INLINE void MakeHighVars( Bag bag ) {
 
 /****************************************************************************
 **
-*F  SWITCH_TO_NEW_LVARS( <func>, <narg>, <nloc>, <old> )  . . . . . new local
-**
-**  'SWITCH_TO_NEW_LVARS'  creates and switches  to a new local variabes bag,
-**  for  the function    <func>,   with <narg> arguments    and  <nloc> local
-**  variables.  The old local variables bag is saved in <old>.
-*/
-
-EXPORT_INLINE Obj SwitchToNewLvars(Obj func, UInt narg, UInt nloc)
-{
-  // As an optimization, we never call CHANGED_BAG on CurrLVars directly,
-  // instead a callback that is run just before any GC takes care of that.
-  // However, that means that when changing the value of CurrLVars, we must
-  // call CHANGED_BAG on the old value.
-  Obj old = STATE(CurrLVars);
-  CHANGED_BAG( old );
-
-  // create new lvars (may cause garbage collection)
-  Obj new_lvars = NewLVarsBag( narg+nloc );
-  LVarsHeader * hdr = (LVarsHeader *)ADDR_OBJ(new_lvars);
-  hdr->stat = 0;
-  hdr->func = func;
-  hdr->parent = old;
-
-  // switch to new lvars
-  STATE(CurrLVars) = new_lvars;
-  STATE(PtrLVars) = (Obj *)hdr;
-  STATE(PtrBody) = ADDR_OBJ(BODY_FUNC(func));
-
-  return old;
-}
-
-#define SWITCH_TO_NEW_LVARS(func, narg, nloc, old)     (old) = SwitchToNewLvars((func), (narg), (nloc))
-
-
-/****************************************************************************
-**
 *F  SWITCH_TO_OLD_LVARS( <old> )  . . .  switch to an old local variables bag
 **
 **  'SWITCH_TO_OLD_LVARS' switches back to the old local variables bag <old>.
 */
-EXPORT_INLINE void SWITCH_TO_OLD_LVARS(Obj old)
+EXPORT_INLINE Obj SWITCH_TO_OLD_LVARS(Obj old)
 {
     // As an optimization, we never call CHANGED_BAG on CurrLVars directly,
     // instead a callback that is run just before any GC takes care of that.
     // However, that means that when changing the value of CurrLVars, we must
-    // call CHANGED_BAG on the old value.
-    CHANGED_BAG(STATE(CurrLVars));
+    // call CHANGED_BAG on the previous value.
+    Obj prev = STATE(CurrLVars);
+    CHANGED_BAG(prev);
 
     GAP_ASSERT(IS_LVARS_OR_HVARS(old));
     LVarsHeader * hdr = (LVarsHeader *)ADDR_OBJ(old);
     STATE(CurrLVars) = old;
     STATE(PtrLVars) = (Obj *)hdr;
     STATE(PtrBody) = ADDR_OBJ(BODY_FUNC(hdr->func));
+
+    return prev;
 }
 
 EXPORT_INLINE void SWITCH_TO_OLD_LVARS_AND_FREE(Obj old)
@@ -265,9 +232,30 @@ EXPORT_INLINE void SWITCH_TO_OLD_LVARS_AND_FREE(Obj old)
 
 /****************************************************************************
 **
+*F  SWITCH_TO_NEW_LVARS( <func>, <narg>, <nloc> ) . . . . switch to new lvars
+**
+**  'SWITCH_TO_NEW_LVARS'  creates and switches  to a new local variabes bag,
+**  for  the function    <func>,   with <narg> arguments    and  <nloc> local
+**  variables.  The old local variables bag is return.
+*/
+EXPORT_INLINE Obj SWITCH_TO_NEW_LVARS(Obj func, UInt narg, UInt nloc)
+{
+    // create new lvars (may cause garbage collection)
+    Obj           new_lvars = NewLVarsBag(narg + nloc);
+    LVarsHeader * hdr = (LVarsHeader *)ADDR_OBJ(new_lvars);
+    hdr->stat = 0;
+    hdr->func = func;
+    hdr->parent = STATE(CurrLVars);
+
+    return SWITCH_TO_OLD_LVARS(new_lvars);
+}
+
+
+/****************************************************************************
+**
 *F  SWITCH_TO_BOTTOM_LVARS( ) . . . . .  switch to bottom local variables bag
 */
-void SWITCH_TO_BOTTOM_LVARS(void);
+Obj SWITCH_TO_BOTTOM_LVARS(void);
 
 
 /****************************************************************************


### PR DESCRIPTION
- add `IsBottomLVars` and `SWITCH_TO_BOTTOM_LVARS`  helper functions to avoid some access to `STATE(BottomLVars)`
- avoid some other unnecessary access to `STATE(BottomLVars)`
- remove some now unnecessary `#include "gapstate.h"`

We could now make `BottomLVars` a module internal variable of `src/vars.c`.