### PR TITLE
Install 4ti2 for Travis tests loading 4ti2Interface package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ matrix:
           - libgmp-dev
           - libreadline-dev
           - zlib1g-dev
+          - 4ti2                    # for 4ti2Interface
           - libboost-dev            # for NormalizInterface
           - libcdd-dev              # for CddInterface
           - libmpfr-dev             # for float
@@ -83,6 +84,7 @@ matrix:
           - libgmp-dev:i386
           - libreadline-dev:i386
           - zlib1g-dev:i386
+          - 4ti2:i386               # for 4ti2Interface
           - libncurses5-dev:i386    # for Browse
           - libcurl4-openssl-dev:i386 # for curlInterface
           - libboost-dev:i386       # for NormalizInterface


### PR DESCRIPTION
This responses to the changes initiated in 4ti2Interface in commit https://github.com/homalg-project/homalg_project/commit/dcf9b7d3b7288c2da7e30d2a074eaceb40e206c1#diff-6b2f7cb2ed87c1b5e7ddfe582596cb6a and  released in 4ti2Interface in May 2020.