### PR TITLE
Enhancements around SmallGeneratingSet

### DIFF
--- a/doc/ref/grpperm.xml
+++ b/doc/ref/grpperm.xml
@@ -92,7 +92,7 @@ gap> Length(MovedPoints(p));
 720
 gap> q:=SmallerDegreePermutationRepresentation(p);;
 gap> NrMovedPoints(Image(q));
-6
+12
 ]]></Example>
 
 </Section>

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -4609,11 +4609,11 @@ DeclareGlobalFunction( "NormalSubgroupClasses" );
 ##    Character( CharacterTable( S4 ), [ 3, 1, -1, 0, -1 ] ), 
 ##    Character( CharacterTable( S4 ), [ 1, 1, 1, 1, 1 ] ) ]
 ##  gap> kernel:= KernelOfCharacter( irr[3] );
-##  Group([ (1,2)(3,4), (1,4)(2,3) ])
+##  Group([ (1,2)(3,4), (1,4)(2,4) ])
 ##  gap> HasNormalSubgroupClassesInfo( tbl );
 ##  true
 ##  gap> NormalSubgroupClassesInfo( tbl );
-##  rec( nsg := [ Group([ (1,2)(3,4), (1,4)(2,3) ]) ],
+##  rec( nsg := [ Group([ (1,2)(3,4), (1,3)(2,4) ]) ],
 ##    nsgclasses := [ [ 1, 3 ] ], nsgfactors := [  ] )
 ##  gap> ClassPositionsOfNormalSubgroup( tbl, kernel );
 ##  [ 1, 3 ]

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -4609,7 +4609,7 @@ DeclareGlobalFunction( "NormalSubgroupClasses" );
 ##    Character( CharacterTable( S4 ), [ 3, 1, -1, 0, -1 ] ), 
 ##    Character( CharacterTable( S4 ), [ 1, 1, 1, 1, 1 ] ) ]
 ##  gap> kernel:= KernelOfCharacter( irr[3] );
-##  Group([ (1,2)(3,4), (1,4)(2,4) ])
+##  Group([ (1,2)(3,4), (1,3)(2,4) ])
 ##  gap> HasNormalSubgroupClassesInfo( tbl );
 ##  true
 ##  gap> NormalSubgroupClassesInfo( tbl );

--- a/lib/factgrp.gd
+++ b/lib/factgrp.gd
@@ -224,7 +224,7 @@ DeclareSynonym( "ImproveOperationDegreeByBlocks",
 ##  24
 ##  gap> small:= SmallerDegreePermutationRepresentation( image );;
 ##  gap> Image( small );
-##  Group([ (2,3), (2,3,4), (1,2)(3,4), (1,3)(2,4) ])
+##  Group([ (2,3), (1,2,3), (1,3)(2,4), (1,2)(3,4) ])
 ##  gap> g:=Image(IsomorphismPermGroup(GL(4,5)));;
 ##  gap> sm:=SmallerDegreePermutationRepresentation(g:cheap);;
 ##  gap> NrMovedPoints(Range(sm));

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1944,7 +1944,7 @@ local p,dat,lev,l,sub,c,s,r,dc;
     sub:=ComplementClassesRepresentatives(l,s); # torus
     if Length(sub)>0 and Size(sub[1])>1 then
       s:=Normalizer(G,sub[1]);
-      r:=Complementclasses(s,sub[1]);
+      r:=ComplementClassesRepresentatives(s,sub[1]);
       if Length(r)>0 then
         s:=r[1];
       fi;

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4391,7 +4391,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##    [ [ 0, 1, 0, 0, 0 ], [ 0, 0, 1, 0, 0 ], [ 0, 0, 0, 1, 0 ], 
 ##        [ 1, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 1 ] ] ]
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens );;
-##  #I  the image group has 2 gens and 10 rels of total length 118
+##  #I  the image group has 2 gens and 10 rels of total length 132
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens : 
 ##  >                                           method := "regular");;
 ##  #I  the image group has 2 gens and 6 rels of total length 56

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1949,62 +1949,30 @@ end );
 # return e is a^e=b or false otherwise
 InstallGlobalFunction("LogPerm",
 function(a,b)
-local oa,ob,q,ma,mb,tofix,locpow,i,c,l,divisor,step,goal,exp,nc,j,new,k,gcd;
+local oa,ob,q,aa,m,e,tst,s,c,p,g;
   oa:=Order(a);
   ob:=Order(b);
   if oa mod ob<>0 then Info(InfoGroup,20,"1"); return false;fi;
   q:=oa/ob;
-  ma:=MovedPoints(a);
-  mb:=MovedPoints(b);
-  if not IsSubset(ma,mb) then Info(InfoGroup,20,"2"); return false;fi;
-  tofix:=Difference(ma,mb);
-  ma:=ShallowCopy(ma); # to allow removing elements
-  Sort(ma);
-  IsSet(ma);
-  locpow:=[];
+  aa:=a^q;
 
-  # reversed, as subgroup constructions naturally pick stabilizers first
-  for i in [Maximum(ma),Maximum(ma)-1..Minimum(ma)] do
-    if i in ma then #we're removing from ma on the way
-      c:=Cycle(a,i);
-      l:=Length(c);
-      divisor:=l/Gcd(l,q); # length of cycles
-      step:=l/divisor; # resulting number of cycles
-      #nc:=[];
-      if i in tofix and divisor>1 or divisor=1 and not i in tofix 
-        then Info(InfoGroup,20,"3"); return false;fi;
-      if divisor=1 then # all fixed
-	if ForAny(c,x->x in mb) then
-          Info(InfoGroup,20,"4");return false;
-	fi;
-        #for j in c do
-        #  Add(nc,[j]);
-        #od;
-      else
-        for j in [1..step] do
-          new:=c{j+([0,q..(divisor-1)*q] mod l)}; # cycle for q-th power
-          goal:=new[1]^b;
-          exp:=Position(new,goal);
-          if exp=fail then Info(InfoGroup,20,"5");return false;fi;
-          exp:=exp-1;
-	  for k in locpow do
-	    gcd:=Gcd(k[1],Length(new));
-	    if k[2] mod gcd<>exp mod gcd then Info(InfoGroup,20,"6");return false;fi;# cannot both hold
-	  od;
-          AddSet(locpow,[Length(new),exp]);
-          new:=new{1+(exp*[0..divisor-1] mod divisor)};
-          if new<>Cycle(b,new[1]) then Info(InfoGroup,20,"7");return false;fi;
-          #Add(nc,new);
-        od;
-      fi;
-      SubtractSet(ma,c);
+  m:=1; # order modulo which power is OK so far
+  e:=1;
+  while m<ob do
+    tst:=aa^e/b; 
+    s:=SmallestMovedPoint(tst); # a point on which there might be a difference
+    if s=infinity then # found it
+      return q*e mod oa;
     fi;
+    c:=Cycle(aa,s);
+    g:=Gcd(m,Length(c));
+    p:=Position(c,s^b);
+    if p=fail or (e mod g<>(p-1) mod g) then return false;fi;
+    e:=ChineseRem([m,Length(c)],[e,p-1]);
+    m:=Lcm(m,Length(c));
   od;
-  if Length(locpow)=0 then exp:=0;
-  else
-    exp:=ChineseRem(List(locpow,x->x[1]),List(locpow,x->x[2])); # power afterwards
-  fi;
-  return q*exp mod oa;
+  if aa^e<>b then return false;fi;
+  return q*e mod oa;
 end);
 
 

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -2044,7 +2044,6 @@ local  i, j, U, gens,o,v,a,sel,min,orb,orp,ok;
               ForAll(orp,x->IsPrimitive(U,orb[x]));
         fi;
 
-
 	StabChainOptions(U).random:=100; # randomized size
 #Print("A:",i,",",j," ",Size(G)/Size(U),"\n");
         if ok and Size(U)=Size(G) then
@@ -2061,18 +2060,14 @@ local  i, j, U, gens,o,v,a,sel,min,orb,orp,ok;
     i:=i+1;
   fi;
   while i <= Length(gens) and Length(gens)>min do
-    # random did not improve much, try subsets
+    # random did not improve much, try removing generators one by one
     U:=Subgroup(G,gens{Difference([1..Length(gens)],[i])});
-
-    ok:=true;
-    # first test orbits
-    if ok then
-      ok:=Length(orb)=Length(Orbits(U,MovedPoints(U))) and
-          ForAll(orp,x->IsPrimitive(U,orb[x]));
-    fi;
-
     StabChainOptions(U).random:=100; # randomized size
-    if Size(U)<Size(G) then
+
+    # first test orbits
+    ok:=Length(orb)=Length(Orbits(U,MovedPoints(G)));
+
+    if not ok or Size(U)<Size(G) then
       i:=i+1;
     else
       gens:=Set(GeneratorsOfGroup(U));

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -192,7 +192,7 @@ DeclareGlobalFunction("CosetDecomposition");
 ##  <Func Name="AllHomomorphismClasses" Arg='G,H'/>
 ##
 ##  <Description>
-##  For two groups <A>G</A> and <A>H</A>, this function returns
+##  For two finite groups <A>G</A> and <A>H</A>, this function returns
 ##  representatives of all homomorphisms <M><A>G</A> to <A>H</A></M> up to
 ##  <A>H</A>-conjugacy.
 ##  <Example><![CDATA[
@@ -218,7 +218,7 @@ DeclareGlobalFunction("AllHomomorphismClasses");
 ##  <Func Name="AllAutomorphisms" Arg='G'/>
 ##
 ##  <Description>
-##  For two groups <A>G</A> and <A>H</A>, this function returns
+##  For two finite groups <A>G</A> and <A>H</A>, this function returns
 ##  all homomorphisms <M><A>G</A> to <A>H</A></M>. Since this number will
 ##  grow quickly, <Ref Func="AllHomomorphismClasses"/> should be used in most
 ##  cases.
@@ -918,6 +918,13 @@ end);
 # up to G-conjugacy
 InstallGlobalFunction(AllHomomorphismClasses,function(H,G)
 local cl,cnt,bg,bw,bo,bi,k,gens,go,imgs,params,emb,clg,sg,vsu,c,i;
+
+  if not HasIsFinite(H) then
+    Info(InfoPerformance,1,"Forcing finiteness test -- might not terminate");
+    if not IsFinite(H) then
+      Error("First argument must be finite group");
+    fi;
+  fi;
 
   if IsAbelian(G) and not IsAbelian(H) then
     k:=NaturalHomomorphismByNormalSubgroup(H,DerivedSubgroup(H));

--- a/tst/teststandard/opers/AutomorphismGroup.tst
+++ b/tst/teststandard/opers/AutomorphismGroup.tst
@@ -37,8 +37,8 @@ gap> StructureDescription(H);
 "PSL(3,3) : C2"
 
 #
-gap> g:=PerfectGroup(IsPermGroup,30720,1);;
-gap> h:=g^(1,153);;
+gap> g:=PerfectGroup(IsPermGroup,15360,1);;
+gap> h:=g^(1,129);;
 gap> AutomorphismGroup(g);; # pull out of isom. test (reduce timeout risk)
 gap> AutomorphismGroup(h);;
 gap> IsomorphismGroups(g,h:forcetest)<>fail;


### PR DESCRIPTION
These are functionally equivalent cleanups and speedups of the operations `SmallGeneratingSet` (and `LogPerm` that is uses) and `SmallerDegreePermutationRepresentation` (which now uses the former).

These operations are used throughout the library, so no extra tests needed.

Also added a safety finiteness test that had been requested for `AllHomomorphisms`.
