### PR TITLE
Fix some sort keys

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -1072,7 +1072,7 @@ one chosen for &GAP;.
 The unary <C>+</C> is ignored. The unary <C>-</C> returns the additive inverse of
 its operand; over the integers it is equivalent to multiplication by <C>-1</C>.
 <P/>
-<Index Subkey="for two group elements">^</Index>
+<Index Subkey="for two group elements" Key="^"><C>^</C></Index>
 <Index Subkey="with a group element">conjugation</Index>
 <C>^</C> denotes powering of a multiplicative element if the right operand  is
 an integer, and is also used to denote the action of a group element on a

--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -162,7 +162,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     the cursor down one line and back to the beginning of the line.
 </Item>
 <Mark>
-<Index><C>\"</C></Index>
+<Index Key='\"'><C>\"</C></Index>
 <Index>doublequote character</Index>
 <C>\"</C></Mark>
 <Item>
@@ -171,7 +171,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     because it is otherwise interpreted as end of the string.
 </Item>
 <Mark>
-<Index><C>\'</C></Index>
+<Index Key="\'"><C>\'</C></Index>
 <Index>singlequote character</Index>
 <C>\'</C></Mark>
 <Item>
@@ -180,7 +180,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     because it is otherwise interpreted as end of the character.
 </Item>
 <Mark>
-<Index><C>\\</C></Index>
+<Index Key='\\'><C>\\</C></Index>
 <Index>backslash character</Index>
 <C>\\</C></Mark>
 <Item>
@@ -190,7 +190,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     an escape sequence.
 </Item>
 <Mark>
-<Index><C>\b</C></Index>
+<Index Key='\b'><C>\b</C></Index>
 <Index>backspace character</Index>
 <C>\b</C></Mark>
 <Item>
@@ -200,7 +200,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     and should not be relied upon.
 </Item>
 <Mark>
-<Index><C>\r</C></Index>
+<Index Key='\r'><C>\r</C></Index>
 <Index>carriage return character</Index>
 <C>\r</C></Mark>
 <Item>
@@ -210,7 +210,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     is again system dependent.
 </Item>
 <Mark>
-<Index><C>\c</C></Index>
+<Index Key='\c'><C>\c</C></Index>
 <Index>flush character</Index>
 <C>\c</C></Mark>
 <Item>
@@ -223,7 +223,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     use <C>\c</C>.
 </Item>
 <Mark>
-<Index><C>\XYZ</C></Index>
+<Index Key='\\XYZ'><C>\XYZ</C></Index>
 <Index>octal character codes</Index>
 <C>\XYZ</C></Mark>
 <Item>
@@ -235,7 +235,7 @@ For any other sequence starting with a backslash, the backslash is ignored.
     in &GAP;.
 </Item>
 <Mark>
-<Index><C>\0xYZ</C></Index>
+<Index Key='\\0xYZ'><C>\0xYZ</C></Index>
 <Index>hexadecimal character codes</Index>
 <C>\0xYZ</C></Mark>
 <Item>

--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -526,7 +526,7 @@ DeclareAttribute( "ValuesOfClassFunction", IsClassFunction );
 ##  <P/>
 ##  <Index Subkey="of group element using powering operator">character value</Index>
 ##  <Index Subkey="meaning for class functions">power</Index>
-##  <Index Subkey="for class functions"><C>^</C></Index>
+##  <Index Key="^" Subkey="for class functions"><C>^</C></Index>
 ##  The <E>powering</E> operator <Ref Oper="\^"/> has several meanings
 ##  for class functions.
 ##  The power of a class function by a nonnegative integer is clearly the


### PR DESCRIPTION
If the content of an `<Index>` element contains markup, then the
'Key' attribute should be specified for correct sorting.
