### PR TITLE
Fix recovering with fg after Ctrl-z

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2062,7 +2062,7 @@ static void initreadline(void)
   /* this should pipe signals through to GAP  */
   rl_already_prompted = 1 ;
 
-  rl_catch_signals = 0;
+  rl_catch_signals = 1;
   rl_catch_sigwinch = 1;
   /* hook to read from other channels */
   rl_event_hook = 0;


### PR DESCRIPTION
At some stage GAP changed its behaviour when the user pressed  `Ctrl-z` (which stops GAP and allows for entering shell commands) and wanted to get back into the GAP session with `fg`. There was no GAP prompt, and input was echoed but not read.

This is fixed by this pull request. Now `fg` reenters the GAP session as expected. I have tested this for quite a while and did not experience any problems.

Checking the readline documentation indicates that the setting `rl_catch_signals = 1;` is correct. I don't know why former versions of GAP (which had this variable set to `0`) worked as expected.

## Text for release notes 
Pressing Ctrl-z in a GAP session and fg in the shell brings the user back into the interrupted GAP session.


