### PR TITLE
Make the Julia GC threadsafe when used from GAP.jl.

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -199,10 +199,16 @@ static jl_datatype_t * datatype_largebag;
 static UInt            StackAlignBags;
 static Bag *           GapStackBottom;
 static jl_ptls_t       JuliaTLS, SaveTLS;
+static BOOL            is_threaded;
 static jl_task_t *     RootTaskOfMainThread;
 static size_t          max_pool_obj_size;
 static UInt            YoungRef;
 static int             FullGC;
+
+void SetJuliaTLS(void)
+{
+    JuliaTLS = jl_get_ptls_states();
+}
 
 #if !defined(SCAN_STACK_FOR_MPTRS_ONLY)
 typedef struct {
@@ -724,7 +730,7 @@ static void PreGCHook(int full)
     // a thread-local variable.
     FullGC = full;
     SaveTLS = JuliaTLS;
-    JuliaTLS = jl_get_ptls_states();
+    SetJuliaTLS();
     // This is the same code as in VarsBeforeCollectBags() for GASMAN.
     // It is necessary because ASS_LVAR() and related functionality
     // does not call CHANGED_BAG() for performance reasons. CHANGED_BAG()
@@ -823,7 +829,12 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
     jl_gc_enable_conservative_gc_support();
     jl_init();
 
-    JuliaTLS = jl_get_ptls_states();
+    SetJuliaTLS();
+    // This variable is not defined in Julia headers, but its existence
+    // is relied on in the Base module. Thus, defining it as extern is
+    // portable.
+    extern int jl_n_threads;
+    is_threaded = jl_n_threads > 1;
     // These callbacks potentially require access to the Julia
     // TLS and thus need to be installed after initialization.
     jl_gc_set_cb_root_scanner(GapRootScanner, 1);
@@ -872,8 +883,6 @@ void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
     else {
         gapobj_type = jl_any_type;
     }
-
-
 
     jl_set_const(jl_main_module, jl_symbol("ForeignGAP"),
                  (jl_value_t *)Module);
@@ -973,6 +982,8 @@ Bag NewBag(UInt type, UInt size)
     if (size == 0)
         alloc_size++;
 
+    if (is_threaded)
+        SetJuliaTLS();
 #if defined(SCAN_STACK_FOR_MPTRS_ONLY)
     bag = jl_gc_alloc_typed(JuliaTLS, sizeof(void *), datatype_mptr);
     SET_PTR_BAG(bag, 0);


### PR DESCRIPTION
When running from multi-threaded Julia, we have to consider the case
that GAP can be called from more than one thread. In those cases, the
variable JuliaTLS may be incorrect. We therefore update it in NewBag(),
where it is depended upon for allocations. It had already been set when
a GC was called from a separate thread.

In order to avoid unnecessary overhead in the single-threaded case, we
do not change JuliaTLS for allocations when there is only one thread, as
determining the current thread-local state pointer can be somewhat
costly (which is why we cache it in JuliaTLS in the first place).