### PR TITLE
Replace "sanity" by "consistency" in the GAP test suite

### DIFF
--- a/tst/consistency.g
+++ b/tst/consistency.g
@@ -7,7 +7,7 @@
 ##
 ##  SPDX-License-Identifier: GPL-2.0-or-later
 ##
-##  This file runs a vast number of sanity checks on a large number of
+##  This file runs a vast number of consistency checks on a large number of
 ##  groups.
 
 SetAssertionLevel(2);
@@ -82,7 +82,7 @@ local u,cs,ncs,n,rep,i,au,hom,cl,co;
 
 end;
 
-Sanity:=function(arg)
+ConsistencyChecksForGroups:=function(arg)
 local deg,sz,anzdeg,anzsz,i,j;
   deg:=2;
   sz:=2;

--- a/tst/testbugfix/2005-07-21-t00085.tst
+++ b/tst/testbugfix/2005-07-21-t00085.tst
@@ -3,9 +3,9 @@ gap> G:=PerfectGroup(IsPermGroup,734832,1);;
 gap> H:=PerfectGroup(IsPermGroup,734832,2);;
 gap> K:=PerfectGroup(IsPermGroup,734832,3);;
 gap> Assert(0,H<>K); # Fails in 4.4.5
-gap> Assert(0,Size(G)=734832 and IsPerfectGroup(G)); # Sanity check
-gap> Assert(0,Size(H)=734832 and IsPerfectGroup(H)); # Sanity check
-gap> Assert(0,Size(K)=734832 and IsPerfectGroup(K)); # Sanity check
+gap> Assert(0,Size(G)=734832 and IsPerfectGroup(G)); # Consistency check
+gap> Assert(0,Size(H)=734832 and IsPerfectGroup(H)); # Consistency check
+gap> Assert(0,Size(K)=734832 and IsPerfectGroup(K)); # Consistency check
 gap> Assert(0,Size(ComplementClassesRepresentatives(G,SylowSubgroup(FittingSubgroup(G),3)))=1); # Iso check
 gap> Assert(0,Size(ComplementClassesRepresentatives(H,SylowSubgroup(FittingSubgroup(H),3)))=3); # Iso check
 gap> Assert(0,Size(ComplementClassesRepresentatives(K,SylowSubgroup(FittingSubgroup(K),3)))=0); # Iso check

--- a/tst/teststandard/sort.tst
+++ b/tst/teststandard/sort.tst
@@ -135,7 +135,7 @@ gap> for i in [0..100] do
 >      od;
 >    od;
 
-# Just sanity check I really am making string reps
+# Just consistency check I really am making string reps
 gap> IsStringRep(lowAlpha{[1..0]}) and IsStringRep(lowAlpha{[1..10]});
 true
 gap> for i in [0..26] do

--- a/tst/teststandard/stablesort.tst
+++ b/tst/teststandard/stablesort.tst
@@ -148,7 +148,7 @@ gap> for i in [0..100] do
 >      od;
 >    od;
 
-# Just sanity check I really am making string reps
+# Just consistency check I really am making string reps
 gap> IsStringRep(lowAlpha{[1..0]}) and IsStringRep(lowAlpha{[1..10]});
 true
 gap> for i in [0..26] do


### PR DESCRIPTION
There was a `sanity.g` file which is used for a weekly tests using Jenkins instance in St Andrews. I have renamed it to `consistency.g` and also improved some other wording in `tst` files, following the [Google style guide on writing inclusive documentation](https://developers.google.com/style/inclusive-documentation).