### PR TITLE
Allow registering global handlers for GAP_TRY/GAP_CATCH.

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1090,7 +1090,7 @@ testbugfix: all
 check: all
 	$(TESTGAP) $(top_srcdir)/tst/testinstall.g
 
-LIBGAPTESTS := $(addprefix tst/testlibgap/,basic api wscreate wsload)
+LIBGAPTESTS := $(addprefix tst/testlibgap/,basic api wscreate wsload trycatch)
 
 # run a test in tst/testlibgap
 tst/testlibgap/%: build/obj/tst/testlibgap/%.c.lo build/obj/tst/testlibgap/common.c.lo libgap.la

--- a/src/sysjmp.c
+++ b/src/sysjmp.c
@@ -28,10 +28,9 @@ enum { signalSyLongjmpFuncsLen = 16 };
 
 static voidfunc signalSyLongjmpFuncs[signalSyLongjmpFuncsLen];
 
-Int RegisterSyLongjmpObserver(voidfunc func)
+int RegisterSyLongjmpObserver(voidfunc func)
 {
-    Int i;
-    for (i = 0; i < signalSyLongjmpFuncsLen; ++i) {
+    for (int i = 0; i < signalSyLongjmpFuncsLen; ++i) {
         if (signalSyLongjmpFuncs[i] == func) {
             return 1;
         }
@@ -43,10 +42,33 @@ Int RegisterSyLongjmpObserver(voidfunc func)
     return 0;
 }
 
+enum { tryCatchFuncsLen = 16 };
+
+static TryCatchHandler tryCatchFuncs[tryCatchFuncsLen];
+
+int RegisterTryCatchHandler(TryCatchHandler func)
+{
+    for (int i = 0; i < tryCatchFuncsLen; ++i) {
+        if (tryCatchFuncs[i] == func) {
+            return 1;
+        }
+        if (tryCatchFuncs[i] == 0) {
+            tryCatchFuncs[i] = func;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+void InvokeTryCatchHandler(TryCatchMode mode)
+{
+    for (int i = 0; i < tryCatchFuncsLen && tryCatchFuncs[i]; ++i)
+        (tryCatchFuncs[i])(mode);
+}
+
 void GAP_THROW(void)
 {
-    Int i;
-    for (i = 0; i < signalSyLongjmpFuncsLen && signalSyLongjmpFuncs[i]; ++i)
+    for (int i = 0; i < signalSyLongjmpFuncsLen && signalSyLongjmpFuncs[i]; ++i)
         (signalSyLongjmpFuncs[i])();
     longjmp(STATE(ReadJmpError), 1);
 }

--- a/src/sysjmp.h
+++ b/src/sysjmp.h
@@ -25,6 +25,6 @@
 **  This function is idempotent -- if a function is passed multiple times
 **  it is still only registered once.
 */
-Int RegisterSyLongjmpObserver(voidfunc);
+int RegisterSyLongjmpObserver(voidfunc);
 
 #endif    // GAP_SYSJMP_H

--- a/tst/testlibgap/trycatch.c
+++ b/tst/testlibgap/trycatch.c
@@ -1,0 +1,42 @@
+/*
+ * Small program to test libgap linkability and basic working
+ */
+#include "trycatch.h"
+#include "common.h"
+
+static int level = 0;
+
+static void handle_trycatch(TryCatchMode mode)
+{
+    switch (mode) {
+    case TryEnter:
+        level++;
+        if (level == 1)
+            printf("Entering GAP_TRY section\n");
+        break;
+    case TryLeave:
+        if (level == 1)
+            printf("Leaving GAP_TRY section\n");
+        level--;
+        break;
+    case TryCatch:
+        if (level == 1)
+            printf("Caught error in GAP_TRY section\n");
+        level--;
+        break;
+    }
+}
+
+int main(int argc, char ** argv)
+{
+    printf("# Initializing GAP...\n");
+    GAP_Initialize(argc, argv, 0, 0, 1);
+    RegisterTryCatchHandler(handle_trycatch);
+    test_eval("OnBreak := false;;");
+    // Necessary to redirect error printing to stdout.
+    test_eval("MakeReadWriteGVar(\"ERROR_OUTPUT\");");
+    test_eval("ERROR_OUTPUT := MakeImmutable(\"*stdout*\");;");
+    test_eval("Display(CALL_WITH_CATCH(function() return 314; end, []));;");
+    test_eval("Display(CALL_WITH_CATCH(function() return [][1]; end, []));;");
+    return 0;
+}

--- a/tst/testlibgap/trycatch.expect
+++ b/tst/testlibgap/trycatch.expect
@@ -1,0 +1,18 @@
+# Initializing GAP...
+gap> OnBreak := false;;
+
+gap> MakeReadWriteGVar("ERROR_OUTPUT");
+
+gap> ERROR_OUTPUT := MakeImmutable("*stdout*");;
+
+gap> Display(CALL_WITH_CATCH(function() return 314; end, []));;
+Entering GAP_TRY section
+Leaving GAP_TRY section
+[ true, 314 ]
+
+gap> Display(CALL_WITH_CATCH(function() return [][1]; end, []));;
+Entering GAP_TRY section
+Error, List Element: <list>[1] must have an assigned value
+Caught error in GAP_TRY section
+[ false, 0 ]
+


### PR DESCRIPTION
This change allows packages to register global handlers in order to be notified when a `GAP_TRY` statement is started, when it succeeds, or when it results in an error.

The main motivation here is the GAP-Julia integration, where this change would allow us to handle GAP errors without creating unnecessary overhead by wrapping lots of short calls into GAP in `GAP_TRY/GAP_CATCH` sections.

Such a feature might also be useful in other situations.