### PR TITLE
Switch from setjmp/longjmp to _setjmp/_longjmp

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1940,7 +1940,7 @@ static UInt CollectBags_Mark(UInt FullBags)
     }
 
     /* mark from the stack                                                 */
-    setjmp( RegsBags );
+    _setjmp(RegsBags);
 #if defined(SPARC)
     SparcStackFuncBags();
 #endif

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -651,7 +651,7 @@ static void GapRootScanner(int full)
     // towards the stack bottom, ensuring that we also scan any
     // references stored in registers.
     jmp_buf registers;
-    setjmp(registers);
+    _setjmp(registers);
     TryMarkRange(registers, (char *)registers + sizeof(jmp_buf));
     TryMarkRange((char *)registers + sizeof(jmp_buf), stackend);
 

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -100,7 +100,7 @@ static inline int GAP_Error_Postjmp_(int JumpRet)
 
 #define GAP_Error_Setjmp()                                                   \
     (GAP_unlikely(GAP_Error_Prejmp_(__FILE__, __LINE__)) ||                  \
-     GAP_Error_Postjmp_(setjmp(*GAP_GetReadJmpError())))
+     GAP_Error_Postjmp_(_setjmp(*GAP_GetReadJmpError())))
 
 
 // Code which uses the GAP API exposed by this header file should sandwich

--- a/src/read.c
+++ b/src/read.c
@@ -77,7 +77,7 @@
 #define TRY_IF_NO_ERROR \
     if (!rs->s.NrError) { \
         volatile Int recursionDepth = GetRecursionDepth();  \
-        if (setjmp(STATE(ReadJmpError))) { \
+        if (_setjmp(STATE(ReadJmpError))) { \
             SetRecursionDepth(recursionDepth);  \
             rs->s.NrError++; \
         }\

--- a/src/sysjmp.c
+++ b/src/sysjmp.c
@@ -70,5 +70,5 @@ void GAP_THROW(void)
 {
     for (int i = 0; i < signalSyLongjmpFuncsLen && signalSyLongjmpFuncs[i]; ++i)
         (signalSyLongjmpFuncs[i])();
-    longjmp(STATE(ReadJmpError), 1);
+    _longjmp(STATE(ReadJmpError), 1);
 }

--- a/src/trycatch.h
+++ b/src/trycatch.h
@@ -89,7 +89,7 @@ void InvokeTryCatchHandler(TryCatchMode mode);
     volatile Int gap__recursionDepth = GetRecursionDepth();                  \
     memcpy(gap__jmp_buf, STATE(ReadJmpError), sizeof(jmp_buf));              \
     InvokeTryCatchHandler(TryEnter);                                         \
-    if (!setjmp(STATE(ReadJmpError)))                                        \
+    if (!_setjmp(STATE(ReadJmpError)))                                       \
         for (gap__i = 1; gap__i; gap__i = 0,                                 \
             InvokeTryCatchHandler(TryLeave),                                 \
             gap_restore_trycatch(gap__jmp_buf, gap__recursionDepth))


### PR DESCRIPTION
This fixes a performance regression on macOS compared to GAP 4.11 (introduced in PR #3938).

Before this patch:

    $ time ./gap -A -b -c 'QUIT;'

    real    0m2.111s
    user    0m1.658s
    sys     0m0.446s

After this patch:

    $ time ./gap -A -b -c 'QUIT;'

    real    0m0.846s
    user    0m0.762s
    sys     0m0.082s

Please use the following template to submit a pull request, filling
in at least the "Text for release notes" and/or "Further details".
Thank You!

# Description

## Text for release notes 

If this pull request should be mentioned in the release notes, 
please provide a short description matching the style of the GAP
`CHANGES.md` file in the root directory.

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

