### PR TITLE
kernel: simplify {GET,PEEK}_NEXT_CHAR and more

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -327,9 +327,7 @@ const Char * GetInputLineBuffer(void)
 Int GetInputLinePosition(void)
 {
     GAP_ASSERT(IO()->Input);
-    // first byte of Input->line is reserved for the pushback buffer, so add 1
-    // subtract 1 from STATE(In) because TODO/FIXME
-    return (STATE(In) - 1) - (IO()->Input->line + 1);
+    return STATE(In) - GetInputLineBuffer();
 }
 
 UInt GetInputFilenameID(void)

--- a/src/io.c
+++ b/src/io.c
@@ -1144,15 +1144,6 @@ static Int GetLine2 (
     Char *                  buffer,
     UInt                    length )
 {
-#ifdef HPCGAP
-    if ( ! input ) {
-        input = IO()->Input;
-        if (!input)
-            OpenDefaultInput();
-        input = IO()->Input;
-    }
-#endif
-
     if ( input->isstream ) {
         if (input->sline == 0 ||
             (IS_STRING(input->sline) &&
@@ -1260,6 +1251,11 @@ static Char GetLine(void)
     *STATE(In)++ = '\0';    // init the pushback buffer and skip over it
     *STATE(In) = '\0';      // empty line buffer
     STATE(NrErrLine) = 0;
+
+#ifdef HPCGAP
+    if (!IO()->Input)
+        OpenDefaultInput();
+#endif
 
     /* try to read a line                                              */
     if (!GetLine2(IO()->Input, IO()->Input->line + 1,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -76,20 +76,20 @@ static void SyntaxErrorOrWarning(ScannerState * s,
             pos = s->SymbolStartPos[tokenoffset - 1];
 
         if (s->SymbolStartLine[tokenoffset] != GetInputLineNumber()) {
-            startPos = 0;
+            startPos = 1;
             pos = GetInputLinePosition();
         }
 
-        if (0 <= pos && startPos <= pos) {
+        if (0 < pos && startPos <= pos) {
             Int i;
-            for (i = 0; i <= startPos; i++) {
+            for (i = 0; i < startPos; i++) {
                 if (line[i] == '\t')
                     Pr("\t", 0, 0);
                 else
                     Pr(" ", 0, 0);
             }
 
-            for (; i <= pos; i++)
+            for (; i < pos; i++)
                 Pr("^", 0, 0);
             Pr("\n", 0, 0);
         }


### PR DESCRIPTION
... by getting back of the `Pushback` buffer and `RealIn`. This is
achieved by reserving the first byte of the `Input->line` buffer;
thus there is always one available byte before the current position
stored in `STATE(In)`, which we can use for pushback.


I hope this will enable some further tweaks and perhaps a minor optimization in startup speed (we spend a big part of that in GET_NEXT_CHAR)