### PR TITLE
Makefile.rules: don't install 'tst/'

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -504,7 +504,6 @@ install-gaproot:
 	cp -r $(srcdir)/doc $(DESTDIR)$(datarootdir)/gap/  # FIXME: don't use `cp -r`
 	cp -r $(srcdir)/grp $(DESTDIR)$(datarootdir)/gap/  # FIXME: don't use `cp -r`
 	cp -r $(srcdir)/lib $(DESTDIR)$(datarootdir)/gap/  # FIXME: don't use `cp -r`
-	cp -r $(srcdir)/tst $(DESTDIR)$(datarootdir)/gap/  # FIXME: don't use `cp -r`
 	# TODO: what about CITATION, CONTRIBUTING.md, COPYRIGHT, INSTALL.md,
 	# LICENSE, README* ? Copy them also here? Or into some other path?
 	# TODO: also copy bin/BuildPackage.sh, as it is very useful?


### PR DESCRIPTION
There is no need to install that; running the tests for the installed version can be done by using the tst from the source.
