### PR TITLE
kernel: remove STATE(In)

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -59,8 +59,6 @@ typedef struct GAPState {
 
     char Prompt[80];
 
-    char * In;
-
     /* From stats.c */
     Obj  ReturnObjStat;
     UInt (**CurrExecStatFuncs)(Stat);

--- a/src/io.h
+++ b/src/io.h
@@ -333,17 +333,6 @@ UInt CloseOutput(void);
 UInt OpenAppend(const Char * filename);
 
 
-/****************************************************************************
-**
-*V  In  . . . . . . . . . . . . . . . . . pointer to current character, local
-**
-**  'In' is a  pointer to  the current  input character, i.e.,  '*In' is  the
-**  current input character.  It points into the buffer 'Input->line'.
-*/
-
-/* TL: extern Char *          In; */
-
-
 // get the filename of the current input
 const Char * GetInputFilename(void);
 


### PR DESCRIPTION
Instead, we can simply always use `IO()->Input->ptr`. This further decouples the input code from global state.
