### PR TITLE
kernel: merge READ, READ_AS_FUNC with their stream variants; fix READ_AS_FUNC for empty input; don't call CloseInput in READ_AS_FUNC

### DIFF
--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -231,7 +231,7 @@ InstallOtherMethod( Read,
     "input stream",
     [ IsInputStream ],
 function( stream )
-    READ_STREAM(stream);
+    READ(stream);
     CloseStream(stream);
 end );
 
@@ -243,7 +243,7 @@ end );
 InstallOtherMethod( ReadAsFunction,
     "input stream",
     [ IsInputStream ],
-    READ_AS_FUNC_STREAM );
+    READ_AS_FUNC );
 
 
 #############################################################################

--- a/src/gap.c
+++ b/src/gap.c
@@ -427,6 +427,9 @@ int realmain( int argc, char * argv[] )
         return 1;
       }
       func = READ_AS_FUNC();
+      if (!CloseInput()) {
+          return 2;
+      }
       crc  = SyGAPCRC(SyCompileInput);
       type = CompileFunc(
                          MakeImmString(SyCompileOutput),

--- a/src/io.c
+++ b/src/io.c
@@ -399,7 +399,7 @@ static UInt OpenDefaultInput(void)
   Obj func, stream;
   stream = TLS(DefaultInput);
   if (stream)
-      return OpenInputStream(stream, 0);
+      return OpenInputStream(stream, FALSE);
   func = GVarOptFunction(&DEFAULT_INPUT_STREAM);
   if (!func)
     return OpenInput("*stdin*");
@@ -409,7 +409,7 @@ static UInt OpenDefaultInput(void)
   if (IsStringConv(stream))
     return OpenInput(CONST_CSTR_STRING(stream));
   TLS(DefaultInput) = stream;
-  return OpenInputStream(stream, 0);
+  return OpenInputStream(stream, FALSE);
 }
 
 static UInt OpenDefaultOutput(void)
@@ -515,7 +515,7 @@ UInt OpenInput (
 **
 **  The same as 'OpenInput' but for streams.
 */
-UInt OpenInputStream(Obj stream, UInt echo)
+UInt OpenInputStream(Obj stream, BOOL echo)
 {
     /* fail if we can not handle another open input file                   */
     if (IO()->InputStackPointer == MAX_OPEN_FILES)

--- a/src/io.h
+++ b/src/io.h
@@ -82,7 +82,7 @@ UInt OpenInput(const Char * filename);
 **
 **  The same as 'OpenInput' but for streams.
 */
-UInt OpenInputStream(Obj stream, UInt echo);
+UInt OpenInputStream(Obj stream, BOOL echo);
 
 
 /****************************************************************************

--- a/src/read.c
+++ b/src/read.c
@@ -2697,11 +2697,6 @@ UInt ReadEvalFile(Obj * evalResult)
     /* get the first symbol from the input                                 */
     Match_(rs, rs->s.Symbol, "", 0);
 
-    /* if we have hit <end-of-file>, then give up                          */
-    if (rs->s.Symbol == S_EOF) {
-        return STATUS_EOF;
-    }
-
     /* print only a partial prompt from now on                             */
     SetPrompt("> ");
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -356,15 +356,10 @@ Obj READ_AS_FUNC ( void )
     ClearError();
     Obj evalResult;
     UInt type = ReadEvalFile(&evalResult);
+    ClearError();
 
     /* get the function                                                    */
     Obj func = (type == 0) ? evalResult : Fail;
-
-    /* close the input file again, and return 'true'                       */
-    if ( ! CloseInput() ) {
-        ErrorQuit("Panic: READ_AS_FUNC cannot close input", 0, 0);
-    }
-    ClearError();
 
     /* return the function                                                 */
     return func;
@@ -952,8 +947,11 @@ static Obj FuncREAD_AS_FUNC(Obj self, Obj input)
     if (!OpenInputFileOrStream(SELF_NAME, input))
         return False;
 
-    /* read the function                                                   */
-    return READ_AS_FUNC();
+    Obj func = READ_AS_FUNC();
+    if (!CloseInput()) {
+        ErrorQuit("Panic: READ_AS_FUNC cannot close input", 0, 0);
+    }
+    return func;
 }
 
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -26,7 +26,8 @@
 **
 *F  READ_AS_FUNC()  . . . . . . . . . . . . .  read current input as function
 **
-**  Read the current input as function and close the input stream.
+**  Read the current input as function. The caller is responsible for opening
+**  and closing the input.
 */
 Obj READ_AS_FUNC(void);
 

--- a/tst/testinstall/kernel/read.tst
+++ b/tst/testinstall/kernel/read.tst
@@ -214,9 +214,9 @@ gap> f();
 Syntax error: ; expected in stream:1
 fail
 
-# empty body is not supported right now
+# empty body
 gap> ReadAsFunction(InputTextString(""));
-fail
+function(  ) ... end
 
 # check what happens if the function body ends earlier than
 # anticipated (FIXME: implement a better error message)

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -98,7 +98,7 @@ e 'fail')
 gap> READ_AS_FUNC("/this/path/does/not/exist!");
 false
 gap> READ_AS_FUNC(InputTextString(""));
-fail
+function(  ) ... end
 
 #
 gap> READ_GAP_ROOT(fail);

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -4,6 +4,10 @@
 gap> START_TEST("kernel/streams.tst");
 
 #
+gap> LastSystemError();
+rec( message := "no error", number := 0 )
+
+#
 gap> CLOSE_LOG_TO();
 Error, LogTo: can not close the logfile
 gap> LOG_TO(fail);
@@ -60,27 +64,43 @@ true
 gap> READ_COMMAND_REAL(true, fail);
 Error, READ_COMMAND_REAL: <stream> must be an input stream (not the value 'tru\
 e')
+
+#
 gap> READ(fail);
-Error, READ: <filename> must be a string (not the value 'fail')
+Error, READ: <input> must be a string or an input stream (not the value 'fail'\
+)
+gap> READ("/this/path/does/not/exist!");
+false
+gap> READ(InputTextString(""));
+true
+
+#
 gap> READ_NORECOVERY(fail);
-fail
-gap> READ_STREAM(fail);
-Error, READ_STREAM: <stream> must be an input stream (not the value 'fail')
+Error, READ_NORECOVERY: <input> must be a string or an input stream (not the v\
+alue 'fail')
+gap> READ_NORECOVERY("/this/path/does/not/exist!");
+false
+gap> READ_NORECOVERY(InputTextString(""));
+true
+
+#
 gap> READ_STREAM_LOOP_WITH_CONTEXT(fail, fail, fail);
 Error, READ_STREAM_LOOP_WITH_CONTEXT: <instream> must be an input stream (not \
 the value 'fail')
 gap> READ_STREAM_LOOP_WITH_CONTEXT(InputTextString(""), fail, fail);
 Error, READ_STREAM_LOOP_WITH_CONTEXT: <outstream> must be an output stream (no\
 t the value 'fail')
+
+#
 gap> READ_AS_FUNC(fail);
-Error, READ_AS_FUNC: <filename> must be a string (not the value 'fail')
-gap> READ_AS_FUNC_STREAM(false);
-Error, READ_AS_FUNC_STREAM: <stream> must be an input stream (not the value 'f\
-alse')
-gap> READ_STREAM(fail);
-Error, READ_STREAM: <stream> must be an input stream (not the value 'fail')
-gap> READ_STREAM(fail);
-Error, READ_STREAM: <stream> must be an input stream (not the value 'fail')
+Error, READ_AS_FUNC: <input> must be a string or an input stream (not the valu\
+e 'fail')
+gap> READ_AS_FUNC("/this/path/does/not/exist!");
+false
+gap> READ_AS_FUNC(InputTextString(""));
+fail
+
+#
 gap> READ_GAP_ROOT(fail);
 Error, READ_GAP_ROOT: <filename> must be a string (not the value 'fail')
 
@@ -93,10 +113,6 @@ gap> RemoveDir(fail);
 Error, RemoveDir: <filename> must be a string (not the value 'fail')
 gap> IsDir(fail);
 Error, IsDir: <filename> must be a string (not the value 'fail')
-
-#
-gap> LastSystemError();; LastSystemError();
-rec( message := "no error", number := 0 )
 
 #
 gap> IsExistingFile(fail);

--- a/tst/testspecial/funccall-ReadEvalError.g
+++ b/tst/testspecial/funccall-ReadEvalError.g
@@ -1,5 +1,5 @@
-Read(InputTextString("quit;")); # trigger ReadEvalError in EvalOrExecCall
+Read(InputTextString("quit;")); # trigger GAP_THROW in EvalOrExecCall
 1+1;
 
-READ_STREAM(InputTextString("quit;")); # trigger ReadEvalError in IntrFuncCallEnd
+READ(InputTextString("quit;")); # trigger GAP_THROW in IntrFuncCallEnd
 1+1;

--- a/tst/testspecial/funccall-ReadEvalError.g.out
+++ b/tst/testspecial/funccall-ReadEvalError.g.out
@@ -1,8 +1,8 @@
-gap> Read(InputTextString("quit;")); # trigger ReadEvalError in EvalOrExecCall
+gap> Read(InputTextString("quit;")); # trigger GAP_THROW in EvalOrExecCall
 gap> 1+1;
 2
 gap> 
-gap> READ_STREAM(InputTextString("quit;")); # trigger ReadEvalError in IntrFuncCallEnd
+gap> READ(InputTextString("quit;")); # trigger GAP_THROW in IntrFuncCallEnd
 gap> 1+1;
 2
 gap> QUIT;


### PR DESCRIPTION
Some cleanup in mostly `src/streams.c`.

I think we are close to being able to eliminate the global `InputStack` in `src/io.c`, by instead allocating instances of `struct TypInputFile` on the stack in the right spots. That's relevant insofar as that this stack with a fixed capacity (16 inputs)  consumes 0.5 MB per thread of memory, and is by far the largest part in the global `GAPState`. Yet in most regular use cases, we just need a few (<= 4?) `TypInputFile` instances at a time. Moving these onto the regular stack conserves memory (in HPC-GAP, that memory is part of the TLS state.