### PR TITLE
Fix output redirection for firefox other browsers

### DIFF
--- a/lib/helpview.gi
+++ b/lib/helpview.gi
@@ -221,7 +221,7 @@ else # UNIX but not Mac OS X
   HELP_VIEWER_INFO.firefox := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("firefox \"file://", url,"\" >/dev/null 2>1 &"));
+    Exec(Concatenation("firefox \"file://", url,"\" >/dev/null 2>&1 &"));
   end
   );
 
@@ -229,7 +229,7 @@ else # UNIX but not Mac OS X
   HELP_VIEWER_INFO.chrome := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("chromium-browser \"file://", url,"\" >/dev/null 2>1 &"));
+    Exec(Concatenation("chromium-browser \"file://", url,"\" >/dev/null 2>&1 &"));
   end
   );
   
@@ -237,7 +237,7 @@ else # UNIX but not Mac OS X
   HELP_VIEWER_INFO.konqueror := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("konqueror \"file://", url,"\" >/dev/null 2>1 &"));
+    Exec(Concatenation("konqueror \"file://", url,"\" >/dev/null 2>&1 &"));
   end
   );
 


### PR DESCRIPTION
... when they are used as help viewers. In the old version of the code,
output from stderr was redirect into a file named "1"; now it is redirected
to stdout, as likely was the intention.

It is still not clear to me how useful that is: Will the user see the output
on stdout? If so, won't they also see the output to stderr? So why do we
need to redirect it? But I have no way to test any of this right now, so
I went with the minimal "obvious" fix.

Perhaps @frankluebeck has some insight into this?

Fixes #4087