### PR TITLE
Minor fixes and performance enhancements

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -560,7 +560,7 @@ local gc,hc,S,info;
 	    homomorphisms:=[gh,hh],
 	    projections:=[Projection(S,1)*InverseGeneralMapping(gc),
 			  Projection(S,2)*InverseGeneralMapping(hc)]);
-  S:=Group(GeneratorsOfGroup(S));
+  S:=Group(GeneratorsOfGroup(S),One(S));
   SetSubdirectProductInfo(S,info);
   return S;
 end);
@@ -1127,7 +1127,7 @@ local giso,niso,P,gens,a,Go,No,i;
   i:=rec(groups:=[Go,No],
          embeddings:=[giso*Embedding(P,1),niso*Embedding(P,2)],
 	 projections:=Projection(P)*InverseGeneralMapping(giso));
-  P:=Group(GeneratorsOfGroup(P));
+  P:=Group(GeneratorsOfGroup(P),One(P));
   SetSemidirectProductInfo(P,i);
   return P;
 end );

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1416,7 +1416,7 @@ local H,a,m,i,l;
   fi;
 
   # compute anew for new group to avoid taint
-  H:=Group(GeneratorsOfGroup(G));
+  H:=Group(GeneratorsOfGroup(G),One(G));
   for i in [Size,IsNaturalAlternatingGroup,IsNaturalSymmetricGroup] do
     if Tester(i)(G) then Setter(i)(H,i(G));fi;
   od;

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1778,11 +1778,17 @@ DeclareGlobalFunction( "RandomMat" );
 ##  returns a new random mutable <A>m</A><M>\times</M><A>m</A> matrix with integer
 ##  entries that is invertible over the integers.
 ##  Optionally, a random source <A>rs</A> can be supplied.
+##  If the option <A>domain</A> is given, random selection is made from <A>domain</A>, otherwise
+##  from <A>Integers</A>
 ##  <Example><![CDATA[
 ##  gap> m := RandomUnimodularMat(3);
 ##  [ [ -5, 1, 0 ], [ 12, -2, -1 ], [ -14, 3, 0 ] ]
 ##  gap> m^-1;
 ##  [ [ -3, 0, 1 ], [ -14, 0, 5 ], [ -8, -1, 2 ] ]
+##  gap> RandomUnimodularMat(3:domain:=[-1000..1000]);
+##  [ [ 312330173, 15560030349, -125721926670 ],
+##  [ -307290, -15309014, 123693281 ],
+##  [ -684293792, -34090949551, 275448039848 ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -3650,8 +3650,13 @@ end );
 #F  RandomUnimodularMat( [rs ,] <m> )  . . . . . . . random unimodular matrix
 ##
 InstallGlobalFunction( RandomUnimodularMat, function ( arg )
-    local  rs, m, mat, c, i, j, k, l, a, b, v, w, gcd;
+local  rs, m, mat, c, i, j, k, l, a, b, v, w, gcd,dom;
     
+    dom:=ValueOption("domain");
+    if dom=fail or dom=false then
+      dom:=Integers;
+    fi;
+
     if Length(arg) >= 1 and IsRandomSource(arg[1]) then
         rs := Remove(arg, 1);
     else
@@ -3683,8 +3688,8 @@ InstallGlobalFunction( RandomUnimodularMat, function ( arg )
             j := Random(rs, 1, m);
         until j <> i;
         repeat
-            a := Random( rs, Integers );
-            b := Random( rs, Integers );
+            a := Random( rs, dom );
+            b := Random( rs, dom );
             gcd := Gcdex( a, b );
         until gcd.gcd = 1;
         v := mat[i];  w := mat[j];
@@ -3697,8 +3702,8 @@ InstallGlobalFunction( RandomUnimodularMat, function ( arg )
             l := Random(rs, 1, m);
         until l <> k;
         repeat
-            a := Random( rs, Integers );
-            b := Random( rs, Integers );
+            a := Random( rs, dom );
+            b := Random( rs, dom );
             gcd := Gcdex( a, b );
         until gcd.gcd = 1;
         for i  in [1..m]  do

--- a/lib/oprtglat.gi
+++ b/lib/oprtglat.gi
@@ -287,7 +287,8 @@ Info(InfoLattice,5,startn-n," conjugates");
     fi;
     if not all and savemem<>fail then
       p:=Size(r.representative);
-      r.representative:=Group(GeneratorsOfGroup(r.representative));
+      r.representative:=Group(GeneratorsOfGroup(r.representative),
+        One(r.representative));
       SetSize(r.representative,p);
       p:=Size(r.normalizer);
       r.normalizer:=Group(GeneratorsOfGroup(r.normalizer));


### PR DESCRIPTION
Catch case of semi/subdirect products with trivial factors and no generators (resolve  #4089)

Performance improvements to automorphism groups (reduce chance of rare case of being caught in bad random choices).
[A test for this is a repeated call of
```
g:=PerfectGroup(IsPermGroup,491520, 559);a:=AutomorphismGroup(g);
```
but it would be too slow for automated tests]

Option to create unimodular matrices with larger entries (not just -10..10)