### PR TITLE
Passing a `.tst` file as argument to `gap` will now invoke `Test` on it, instead of trying to `Read` it (which will fail)

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -937,6 +937,9 @@ InstallAndCallPostRestore( function()
         f := GAPInfo.InitFiles[i];
         if IsRecord(f) then
             status := READ_NORECOVERY(InputTextString(f.command));
+        elif EndsWith(f, ".tst") then
+            Test(f);
+            status := true;
         else
             status := READ_NORECOVERY(f);
         fi;


### PR DESCRIPTION
... instead of Read / READ_NORECOVERY. This is purely a convenience
feature: now one can for example run

    gap tst/testinstall/perm.tst

which is equivalent to

    gap -c 'Test("tst/testinstall/perm.tst");'

but shorter and easier to enter via shell command completion.
