### PR TITLE
cosmetic change for `PAGER_BUILTIN`

### DIFF
--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -135,7 +135,7 @@ BindGlobal("PAGER_BUILTIN", function( lines )
   size   := SizeScreen();
   wd := QuoInt(size[1]+2, 2);
   # really print line without breaking it
-  pl := function(l)
+  pl := function(l, final)
     local   r;
     r := 1;
     while r*wd<=Length(l) do
@@ -145,7 +145,7 @@ BindGlobal("PAGER_BUILTIN", function( lines )
     if (r-1)*wd < Length(l) then
       PrintTo(out, l{[(r-1)*wd+1..Length(l)]});
     fi;
-    PrintTo(out, "\n");
+    PrintTo(out, final);
   end;
   
   if not formatted then
@@ -191,17 +191,17 @@ BindGlobal("PAGER_BUILTIN", function( lines )
   emptyline:= String( "", size[1]-2 );
   repeat
     for i in [from..Minimum(len, from+size[2]-2)] do
-      pl(lines[i]);
+      pl(lines[i], "\n");
     od;
     if len = i then
       if exitAtEnd then
         break;
       fi;
       for i in [ len+1 .. from+size[2]-2 ] do
-        pl( emptyline );
+        pl( emptyline, "\n" );
       od;
     fi;
-    PrintTo(out, halt);
+    pl(halt, "");
     repeat
       char := ReadByte(stream);
       if char = fail then


### PR DESCRIPTION
When the screen width is smaller than 76 then currently the footer line shown by `PAGER_BUILTIN` gets wrapped, with a trailing backslash. Other too long lines get wrapped without backslashes.

```
gap> SizeScreen( [ 75 ] );;
gap> ?Size
...
[50] RCWA (not loaded): Size for an rcwa group
  -- <space> page, <n> next line, <b> back, <p> back line, <q> quit -\
-
```

With the change proposed here, the footer line is treated like the other lines.

(Note that `PAGER_BUILTIN` is not always called in GAP help requests. For example, one has to disable the pager from the Browse package.)