### PR TITLE
Avoid calling ConvertToVectorRep(v, 0)

### DIFF
--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1521,13 +1521,19 @@ end);
 ##
 InstallMethod( ImmutableVector,"general,2",[IsObject,IsRowVector],0,
 function(f,v)
-  ConvertToVectorRepNC(v,f);
+  if f <> 0 then
+    # method is called with f=0 for finite fields with large characteristic
+    ConvertToVectorRepNC(v,f);
+  fi;
   return Immutable(v);
 end);
 
 InstallOtherMethod( ImmutableVector,"general,3",[IsObject,IsRowVector,IsBool],0,
 function(f,v,change)
-  ConvertToVectorRepNC(v,f);
+  if f <> 0 then
+    # method is called with f=0 for finite fields with large characteristic
+    ConvertToVectorRepNC(v,f);
+  fi;
   if change then
     MakeImmutable(v);
     return v;

--- a/tst/teststandard/algext.tst
+++ b/tst/teststandard/algext.tst
@@ -2,7 +2,7 @@
 ##
 ##  Test of algebraic extensions.
 ##
-#@local t, f0, p1, f1, p2, f2, p3, f3, p4, f4, x, l, a, ll, b
+#@local t, f0, p1, f1, p2, f2, p3, f3, p4, f4, x, l, a, ll, b, pol, K, xinv, c
 gap> START_TEST("algext.tst");
 gap> t := Runtime();;
 gap> f0 := GF(3);;
@@ -24,6 +24,11 @@ gap> ll := AlgebraicExtension(l, x^5-2, "beta");;
 gap> b := RootOfDefiningPolynomial(ll);;
 gap> (a+b)^5-(a-b)^5;
 20*alpha^2*beta^3+(10*alpha^2-10)*beta+!4
+gap> pol := UnivariatePolynomial(GF(293), Z(293)^0 * ConwayPol(293,8));;
+gap> K := AlgebraicExtension(GF(293), pol);;
+gap> xinv := 1/PrimitiveElement(K);
+Z(293)^145*a^7+Z(293)^274*a^3+Z(293)^120*a^2+Z(293)^134*a+Z(293)^179
+gap> c := Random(K);;
 
 #
 gap> STOP_TEST("algext.tst",1);


### PR DESCRIPTION
The family of finite fields of size >= 256 sets
!.rchar = 0, which leads to calls of 'ConvertToVectorRep'
with second argument 0 in various places.

Added a test which demonstrates the problem.

# Description
The problem is described above.

The bug addressed here can be seen in this example:
```
gap> pol := UnivariatePolynomial(GF(293), Z(293)^0 * ConwayPol(293,8));;
gap> K := AlgebraicExtension(GF(293), pol);;
gap> xinv := 1/PrimitiveElement(K);
Error, <n> must be a positive integer at /export/home/luebeck/gap4/lib/integer.gi:991 called from
LogInt( q, common ) at /export/home/luebeck/gap4/lib/vecmat.gi:1365 called from
ConvertToVectorRepNC( v, f ); at /export/home/luebeck/gap4/lib/vecmat.gi:1530 called from
ImmutableVector( fam!.rchar, rf, true 
 ) at /export/home/luebeck/gap4/lib/algfld.gi:611 called from
InverseOp( elm ) at /export/home/luebeck/gap4/lib/arith.gi:392 called from
<function "InverseSameMutability for an (immutable) object">( <arguments> )
 called from read-eval loop at *stdin*:3
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk> 
gap> c := Random(K);;
Error, <n> must be a positive integer at /export/home/luebeck/gap4/lib/integer.gi:991 called from
LogInt( q, common ) at /export/home/luebeck/gap4/lib/vecmat.gi:1365 called from
ConvertToVectorRepNC( v, f ); at /export/home/luebeck/gap4/lib/vecmat.gi:1530 called from
ImmutableVector( fam!.rchar, l, true 
 ) at /export/home/luebeck/gap4/lib/algfld.gi:910 called from
func( GlobalMersenneTwister, x 
 ) at /export/home/luebeck/gap4/lib/random.gi:299 called from
<function "Random for an algebraic extension">( <arguments> )
 called from read-eval loop at *stdin*:3
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk> 
```

I'm not sure, if this pull request catches all instances of the problem. It is at least a quick fix which should never be bad.

A better fix would probably try to avoid that for larger finite fields its family has a component `!.rchar` which is set to `0` (instead of the characteristic of the field).

## Text for release notes 

A bug in the arithmetic of larger finite fields was fixed.


