### PR TITLE
Fix some unexpected error when inverting or computing random elements of algebraic extensions of finite fields of size > 256

### DIFF
--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -94,7 +94,6 @@ local fam,i,cof,red,rchar,impattr,deg,tmp;
   else
     rchar:=0;
   fi;
-  fam!.rchar:=rchar;
 
   fam!.poly:=p;
   fam!.polCoeffs:=CoefficientsOfUnivariatePolynomial(p);
@@ -608,7 +607,7 @@ local i,fam,f,g,t,h,rf,rg,rh,z;
     #od;
   od;
   rf:=1/f[Length(f)]*rf;
-  rf:=ImmutableVector(fam!.rchar, rf, true);
+  rf:=ImmutableVector(fam!.baseField, rf, true);
   return AlgExtElm(fam,rf);
 end);
 
@@ -907,7 +906,7 @@ function(rs,e)
 local fam,l;
   fam:=e!.extFam;
   l:=List([1..fam!.deg],i->Random(rs,fam!.baseField));
-  l:=ImmutableVector(fam!.rchar,l,true);
+  l:=ImmutableVector(fam!.baseField,l,true);
   return AlgExtElm(fam,l);
 end);
 

--- a/tst/teststandard/algext.tst
+++ b/tst/teststandard/algext.tst
@@ -2,7 +2,7 @@
 ##
 ##  Test of algebraic extensions.
 ##
-#@local t, f0, p1, f1, p2, f2, p3, f3, p4, f4, x, l, a, ll, b
+#@local t, f0, p1, f1, p2, f2, p3, f3, p4, f4, x, l, a, ll, b, pol, K, xinv, c
 gap> START_TEST("algext.tst");
 gap> t := Runtime();;
 gap> f0 := GF(3);;
@@ -24,6 +24,13 @@ gap> ll := AlgebraicExtension(l, x^5-2, "beta");;
 gap> b := RootOfDefiningPolynomial(ll);;
 gap> (a+b)^5-(a-b)^5;
 20*alpha^2*beta^3+(10*alpha^2-10)*beta+!4
+
+#
+gap> pol := UnivariatePolynomial(GF(293), Z(293)^0 * ConwayPol(293,8));;
+gap> K := AlgebraicExtension(GF(293), pol);;
+gap> xinv := 1/PrimitiveElement(K);
+Z(293)^145*a^7+Z(293)^274*a^3+Z(293)^120*a^2+Z(293)^134*a+Z(293)^179
+gap> c := Random(K);;
 
 #
 gap> STOP_TEST("algext.tst",1);


### PR DESCRIPTION
The code for algebraic extensions passed fam!.rchar to ImmutableVector;
but that value was 0 if the characteristic exceeded 256.

This is an alternative to PR #4107.

Close #4107
