### PR TITLE
kernel: reduce usage of IO() inside of io.c

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -290,7 +290,7 @@ Stat NewStatOrExpr (
 
 static Stat NewStat(UInt type, UInt size)
 {
-    return NewStatOrExpr(type, size, GetInputLineNumber());
+    return NewStatOrExpr(type, size, GetInputLineNumber(GetCurrentInput()));
 }
 
 
@@ -820,7 +820,7 @@ void CodeFuncExprBegin (
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
-    SET_GAPNAMEID_BODY(body, GetInputFilenameID());
+    SET_GAPNAMEID_BODY(body, GetInputFilenameID(GetCurrentInput()));
     SET_STARTLINE_BODY(body, startLine);
     CS(OffsBody) = sizeof(BodyHeader);
 
@@ -898,7 +898,7 @@ Expr CodeFuncExprEnd(UInt nr, UInt pushExpr)
 
     /* make the body smaller                                               */
     ResizeBag(BODY_FUNC(fexp), CS(OffsBody));
-    SET_ENDLINE_BODY(BODY_FUNC(fexp), GetInputLineNumber());
+    SET_ENDLINE_BODY(BODY_FUNC(fexp), GetInputLineNumber(GetCurrentInput()));
 
     /* switch back to the previous function                                */
     SWITCH_TO_OLD_LVARS( ENVI_FUNC(fexp) );

--- a/src/common.h
+++ b/src/common.h
@@ -200,4 +200,14 @@ enum { BIPEB = sizeof(UInt) * 8, LBIPEB = (BIPEB == 64) ? 6 : 5 };
 typedef const struct init_info StructInitInfo;
 
 
+/****************************************************************************
+**
+*T  TypInputFile  . . . . . . . . . .  structure of an open input file, local
+**
+**  This is a forward declaration so that TypInputFile can be used in header
+**  files. The actual declaration is in io.c and is private.
+*/
+typedef struct TypInputFile TypInputFile;
+
+
 #endif // GAP_COMMON_H

--- a/src/gap.c
+++ b/src/gap.c
@@ -187,7 +187,9 @@ static Obj Shell(Obj    context,
       CloseOutput();
       ErrorQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
-  
+
+  TypInputFile * input = GetCurrentInput();
+
   oldPrintObjState = SetPrintObjState(0);
 
   while ( 1 ) {
@@ -238,7 +240,7 @@ static Obj Shell(Obj    context,
     STATE(ErrorLVars) = errorLVars;
 
     /* now  read and evaluate and view one command  */
-    status = ReadEvalCommand(errorLVars, &evalResult, &dualSemicolon);
+    status = ReadEvalCommand(errorLVars, input, &evalResult, &dualSemicolon);
     if (STATE(UserHasQUIT))
       break;
 
@@ -293,7 +295,7 @@ static Obj Shell(Obj    context,
 
     if (STATE(UserHasQuit))
       {
-        FlushRestOfInputLine();
+        FlushRestOfInputLine(input);
         STATE(UserHasQuit) = 0;        /* quit has done its job if we are here */
       }
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -59,7 +59,8 @@
 static void INTERPRETER_PROFILE_HOOK(IntrState * intr, int ignoreLevel)
 {
     if (!intr->coding) {
-        InterpreterHook(GetInputFilenameID(), intr->startLine,
+        InterpreterHook(GetInputFilenameID(GetCurrentInput()),
+                        intr->startLine,
                         intr->returning || (intr->ignoring > ignoreLevel));
     }
     intr->startLine = 0;
@@ -875,7 +876,8 @@ void IntrAtomicBegin(IntrState * intr, Obj stackNams)
     SKIP_IF_IGNORING();
 
     if (intr->coding == 0)
-        StartFakeFuncExpr(intr, stackNams, GetInputLineNumber());
+        StartFakeFuncExpr(intr, stackNams,
+                          GetInputLineNumber(GetCurrentInput()));
 
     intr->coding++;
 
@@ -954,7 +956,8 @@ void IntrRepeatBegin(IntrState * intr, Obj stackNams)
     SKIP_IF_IGNORING();
 
     if (intr->coding == 0)
-        StartFakeFuncExpr(intr, stackNams, GetInputLineNumber());
+        StartFakeFuncExpr(intr, stackNams,
+                          GetInputLineNumber(GetCurrentInput()));
 
     intr->coding++;
 

--- a/src/io.c
+++ b/src/io.c
@@ -953,16 +953,16 @@ UInt OpenOutput (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    IO()->Output = PushNewOutput();
-    IO()->Output->file = file;
-    IO()->Output->line[0] = '\0';
-    IO()->Output->pos = 0;
-    IO()->Output->indent = 0;
-    IO()->Output->isstream = 0;
-    IO()->Output->format = 1;
+    TypOutputFile * output = IO()->Output = PushNewOutput();
+    output->file = file;
+    output->line[0] = '\0';
+    output->pos = 0;
+    output->indent = 0;
+    output->isstream = 0;
+    output->format = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    IO()->Output->hints[0] = -1;
+    output->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -985,19 +985,17 @@ UInt OpenOutputStream (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    IO()->Output = PushNewOutput();
-    IO()->Output->stream = stream;
-    IO()->Output->isstringstream =
-        (CALL_1ARGS(IsStringStream, stream) == True);
-    IO()->Output->format =
-        (CALL_1ARGS(PrintFormattingStatus, stream) == True);
-    IO()->Output->line[0] = '\0';
-    IO()->Output->pos = 0;
-    IO()->Output->indent = 0;
-    IO()->Output->isstream = 1;
+    TypOutputFile * output = IO()->Output = PushNewOutput();
+    output->stream = stream;
+    output->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    output->format = (CALL_1ARGS(PrintFormattingStatus, stream) == True);
+    output->line[0] = '\0';
+    output->pos = 0;
+    output->indent = 0;
+    output->isstream = 1;
 
     /* variables related to line splitting, very bad place to split        */
-    IO()->Output->hints[0] = -1;
+    output->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;
@@ -1023,16 +1021,18 @@ UInt OpenOutputStream (
 */
 UInt CloseOutput ( void )
 {
+    TypOutputFile * output = IO()->Output;
+
     // silently refuse to close the test output file; this is probably an
     // attempt to close *errout* which is silently not opened, so let's
     // silently not close it
-    if (IO()->IgnoreStdoutErrout == IO()->Output)
+    if (IO()->IgnoreStdoutErrout == output)
         return 1;
 
     /* refuse to close the initial output file '*stdout*'                  */
 #ifdef HPCGAP
-    if (IO()->OutputStackPointer <= 1 && IO()->Output->isstream &&
-        TLS(DefaultOutput) == IO()->Output->stream)
+    if (IO()->OutputStackPointer <= 1 && output->isstream &&
+        TLS(DefaultOutput) == output->stream)
         return 0;
 #else
     if (IO()->OutputStackPointer <= 1)
@@ -1041,8 +1041,8 @@ UInt CloseOutput ( void )
 
     /* flush output and close the file                                     */
     Pr("%c", (Int)'\03', 0);
-    if (!IO()->Output->isstream) {
-        SyFclose(IO()->Output->file);
+    if (!output->isstream) {
+        SyFclose(output->file);
     }
 
     /* revert to previous output file and indicate success                 */
@@ -1084,15 +1084,15 @@ UInt OpenAppend (
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
-    IO()->Output = PushNewOutput();
-    IO()->Output->file = file;
-    IO()->Output->line[0] = '\0';
-    IO()->Output->pos = 0;
-    IO()->Output->indent = 0;
-    IO()->Output->isstream = 0;
+    TypOutputFile * output = IO()->Output = PushNewOutput();
+    output->file = file;
+    output->line[0] = '\0';
+    output->pos = 0;
+    output->indent = 0;
+    output->isstream = 0;
 
     /* variables related to line splitting, very bad place to split        */
-    IO()->Output->hints[0] = -1;
+    output->hints[0] = -1;
 
     /* indicate success                                                    */
     return 1;

--- a/src/io.h
+++ b/src/io.h
@@ -24,16 +24,6 @@
 
 #include "common.h"
 
-
-Char GET_NEXT_CHAR(void);
-Char GET_NEXT_CHAR_NO_LC(void);
-Char PEEK_NEXT_CHAR(void);
-Char PEEK_CURR_CHAR(void);
-
-// skip the rest of the current line, ignoring line continuations
-// (used to handle comments)
-void SKIP_TO_END_OF_LINE(void);
-
 /****************************************************************************
 **
 *F * * * * * * * * * * * open input/output functions  * * * * * * * * * * * *
@@ -333,20 +323,31 @@ UInt CloseOutput(void);
 UInt OpenAppend(const Char * filename);
 
 
+TypInputFile * GetCurrentInput(void);
+
+Char GetNextChar(TypInputFile * input);
+Char GET_NEXT_CHAR_NO_LC(TypInputFile * input);
+Char PEEK_NEXT_CHAR(TypInputFile * input);
+Char PEEK_CURR_CHAR(TypInputFile * input);
+
+// skip the rest of the current line, ignoring line continuations
+// (used to handle comments)
+void SKIP_TO_END_OF_LINE(TypInputFile * input);
+
 // get the filename of the current input
-const Char * GetInputFilename(void);
+const Char * GetInputFilename(TypInputFile * input);
 
 // get the number of the current line in the current thread's input
-Int GetInputLineNumber(void);
+Int GetInputLineNumber(TypInputFile * input);
 
 //
-const Char * GetInputLineBuffer(void);
+const Char * GetInputLineBuffer(TypInputFile * input);
 
 //
-Int GetInputLinePosition(void);
+Int GetInputLinePosition(TypInputFile * input);
 
 // get the filenameid (if any) of the current input
-UInt GetInputFilenameID(void);
+UInt GetInputFilenameID(TypInputFile * input);
 
 // get the filename (as GAP string object) with the given id
 Obj GetCachedFilename(UInt id);
@@ -419,7 +420,7 @@ void SPrTo(
 *F  FlushRestOfInputLine()  . . . . . . . . . . . . discard remainder of line
 */
 
-void FlushRestOfInputLine(void);
+void FlushRestOfInputLine(TypInputFile * input);
 
 
 StructInitInfo * InitInfoIO(void);

--- a/src/read.h
+++ b/src/read.h
@@ -34,7 +34,10 @@
 **  will be set to 1 if the command was followed by a double semicolon, else
 **  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
 */
-UInt ReadEvalCommand(Obj context, Obj * evalResult, UInt * dualSemicolon);
+UInt ReadEvalCommand(Obj            context,
+                     TypInputFile * input,
+                     Obj *          evalResult,
+                     UInt *         dualSemicolon);
 
 
 /****************************************************************************
@@ -47,7 +50,7 @@ UInt ReadEvalCommand(Obj context, Obj * evalResult, UInt * dualSemicolon);
 **  It does not expect the first symbol of its input already read and reads
 **  to the end of the input (unless an error happens).
 */
-UInt ReadEvalFile(Obj * evalResult);
+UInt ReadEvalFile(TypInputFile * input, Obj * evalResult);
 
 
 /****************************************************************************

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -193,6 +193,9 @@ typedef UInt            TypSymbolSet;
 */
 typedef struct {
 
+    //
+    TypInputFile * input;
+
 /****************************************************************************
 **
 *V  Value . . . . . . . . . . . . . value of the identifier, float or integer


### PR DESCRIPTION
This is refactoring with the long-term hope of getting rid of some of the global state inside of IO(). But I think it's useful on its own, too.