### PR TITLE
kernel: move BottomLVars out of TLS

### DIFF
--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -46,7 +46,6 @@ typedef struct GAPState {
     Obj CurrNamespace;
 
     /* From vars.c */
-    Bag   BottomLVars;
     Bag   CurrLVars;
     Obj * PtrLVars;
     Bag   LVarsPool[16];

--- a/src/vars.h
+++ b/src/vars.h
@@ -41,20 +41,7 @@
 
 /****************************************************************************
 **
-*V  BottomLVars . . . . . . . . . . . . . . . . .  bottom local variables bag
-**
-**  'BottomLVars' is the local variables bag at the bottom of the call stack.
-**  Without   such a dummy  frame at  the bottom, 'SWITCH_TO_NEW_LVARS' would
-**  have to check for the bottom, slowing it down.
-**
-*/
-/* TL: extern  Bag             BottomLVars; */
-
-
-/****************************************************************************
-**
-*F  IsBottomLVars(<lvars>) . .  check whether some lvars are the bottom lvars
-**
+*F  IsBottomLVars(<lvars>) . . test whether lvars is at the call stack bottom
 */
 BOOL IsBottomLVars(Obj lvars);
 


### PR DESCRIPTION
A single global BottomLVars shared by all TLS suffices. Note that really only
the address stored in BottomLVars matters, the actual object behind it is
essentially never accessed.
