### PR TITLE
kernel: make PrintFunction static

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -985,8 +985,7 @@ static Obj TypeFunction(Obj func)
 
 static Obj PrintOperation;
 
-void PrintFunction (
-    Obj                 func )
+static void PrintFunction(Obj func)
 {
     Int                 narg;           /* number of arguments             */
     Int                 nloc;           /* number of locals                */

--- a/src/calls.h
+++ b/src/calls.h
@@ -473,14 +473,6 @@ Obj ArgStringToList(const Char * nams_c);
 *F * * * * * * * * * * * * * type and print function  * * * * * * * * * * * *
 */
 
-/****************************************************************************
-**
-*F  PrintFunction( <func> )   . . . . . . . . . . . . . . .  print a function
-**
-**  'PrintFunction' prints  the   function  <func> .
-*/
-void PrintFunction(Obj func);
-
 void PrintKernelFunction(Obj func);
 
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -697,7 +697,7 @@ static void PrintFuncExpr(Expr expr)
 {
     /* get the function expression bag                                     */
     Obj fexp = GET_VALUE_FROM_CURRENT_BODY(READ_EXPR(expr, 0));
-    PrintFunction( fexp );
+    PrintObj( fexp );
 }
 
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -714,9 +714,6 @@ static Obj FuncPrint(Obj self, Obj args)
         else if ( IS_STRING_REP(arg) ) {
             PrintString1(arg);
         }
-        else if ( TNUM_OBJ( arg ) == T_FUNCTION ) {
-            PrintFunction( arg );
-        }
         else {
             PrintObj( arg );
         }
@@ -771,9 +768,6 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
             }
             else if (IS_STRING_REP(arg)) {
                 PrintString1(arg);
-            }
-            else if (IS_FUNC(arg)) {
-                PrintFunction(arg);
             }
             else {
                 PrintObj(arg);


### PR DESCRIPTION
I was/am looking into getting rid of the global stack of input/output streams, and while doing so, noticed that we can make PrintFunction private.