### PR TITLE
kernel: remove input stream stack

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -205,7 +205,7 @@ typedef const struct init_info StructInitInfo;
 *T  TypInputFile  . . . . . . . . . .  structure of an open input file, local
 **
 **  This is a forward declaration so that TypInputFile can be used in header
-**  files. The actual declaration is in io.c and is private.
+**  files. The actual declaration is in io.h.
 */
 typedef struct TypInputFile TypInputFile;
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -197,13 +197,12 @@ static Obj Shell(Obj    context,
   if (!OpenOutput(outFile, FALSE))
       ErrorQuit("SHELL: can't open outfile %s",(Int)outFile,0);
 
-  if(!OpenInput(inFile))
+  TypInputFile input = { 0 };
+  if (!OpenInput(&input, inFile))
     {
       CloseOutput();
       ErrorQuit("SHELL: can't open infile %s",(Int)inFile,0);
     }
-
-  TypInputFile * input = GetCurrentInput();
 
   oldPrintObjState = SetPrintObjState(0);
 
@@ -255,7 +254,7 @@ static Obj Shell(Obj    context,
     STATE(ErrorLVars) = errorLVars;
 
     /* now  read and evaluate and view one command  */
-    status = ReadEvalCommand(errorLVars, input, &evalResult, &dualSemicolon);
+    status = ReadEvalCommand(errorLVars, &input, &evalResult, &dualSemicolon);
     if (STATE(UserHasQUIT))
       break;
 
@@ -310,14 +309,14 @@ static Obj Shell(Obj    context,
 
     if (STATE(UserHasQuit))
       {
-        FlushRestOfInputLine(input);
+        FlushRestOfInputLine(&input);
         STATE(UserHasQuit) = 0;        /* quit has done its job if we are here */
       }
 
   }
   
   SetPrintObjState(oldPrintObjState);
-  CloseInput();
+  CloseInput(&input);
   CloseOutput();
   STATE(ErrorLLevel) = oldErrorLLevel;
   SetRecursionDepth(oldRecursionDepth);
@@ -402,11 +401,12 @@ int realmain( int argc, char * argv[] )
                                    read of init.g  somehow*/
     /* maybe compile in which case init.g got skipped */
     if ( SyCompilePlease ) {
-      if ( ! OpenInput(SyCompileInput) ) {
+      TypInputFile input = { 0 };
+      if ( ! OpenInput(&input, SyCompileInput) ) {
         return 1;
       }
-      func = READ_AS_FUNC();
-      if (!CloseInput()) {
+      func = READ_AS_FUNC(&input);
+      if (!CloseInput(&input)) {
           return 2;
       }
       crc  = SyGAPCRC(SyCompileInput);

--- a/src/io.h
+++ b/src/io.h
@@ -24,6 +24,60 @@
 
 #include "common.h"
 
+
+/****************************************************************************
+**
+*T  TypInputFile  . . . . . . . . . .  structure of an open input file, local
+**
+**  'TypInputFile' describes the information stored for open input files.
+*/
+struct TypInputFile {
+    // pointer to the previously active input
+    struct TypInputFile * prev;
+
+    // non-zero if input comes from a stream
+    BOOL isstream;
+
+    // non-zero if input come from a string stream
+    BOOL isstringstream;
+
+    // if input comes from a stream, this points to a GAP IsInputStream object
+    Obj stream;
+
+    // holds the file identifier received from 'SyFopen' and which is passed
+    // to 'SyFgets' and 'SyFclose' to identify this file
+    Int file;
+
+    // the name of the file; this is only used in error messages
+    char name[256];
+
+    //
+    UInt gapnameid;
+
+    // a buffer that holds the current input line; always terminated
+    // by the character '\0'. Because 'line' holds only part of the line for
+    // very long lines the last character need not be a <newline>.
+    // The actual line data starts in line[1]; the first byte line[0]
+    // is reserved for the "pushback buffer" used by PEEK_NEXT_CHAR.
+    char line[32768];
+
+    // the next line from the stream as GAP string
+    Obj sline;
+
+    //
+    Int spos;
+
+    //
+    BOOL echo;
+
+    // pointer to the current character within the current line
+    char * ptr;
+
+    // the number of the current line; used in error messages
+    Int number;
+};
+
+
 /****************************************************************************
 **
 *F * * * * * * * * * * * open input/output functions  * * * * * * * * * * * *
@@ -63,7 +117,7 @@
 **  '*stdin*' for  that purpose.  This  file on   the other   hand  cannot be
 **  closed by 'CloseInput'.
 */
-UInt OpenInput(const Char * filename);
+UInt OpenInput(TypInputFile * input, const Char * filename);
 
 
 /****************************************************************************
@@ -72,7 +126,7 @@ UInt OpenInput(const Char * filename);
 **
 **  The same as 'OpenInput' but for streams.
 */
-UInt OpenInputStream(Obj stream, BOOL echo);
+UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo);
 
 
 /****************************************************************************
@@ -90,7 +144,7 @@ UInt OpenInputStream(Obj stream, BOOL echo);
 **  Calling 'CloseInput' if the  corresponding  'OpenInput' call failed  will
 **  close the current output file, which will lead to very strange behaviour.
 */
-UInt CloseInput(void);
+UInt CloseInput(TypInputFile * input);
 
 
 /****************************************************************************

--- a/src/read.c
+++ b/src/read.c
@@ -2600,10 +2600,7 @@ ExecStatus ReadEvalCommand(Obj            context,
 
     // initialize everything and begin an interpreter
     rs->StackNams      = NEW_PLIST( T_PLIST, 16 );
-    rs->ReadTop        = 0;
-    rs->ReadTilde      = 0;
     STATE(Tilde)       = 0;
-    rs->CurrLHSGVar    = 0;
 #ifdef HPCGAP
     lockSP = RegionLockSP();
 #endif
@@ -2719,10 +2716,7 @@ UInt ReadEvalFile(TypInputFile * input, Obj * evalResult)
 
     // initialize everything and begin an interpreter
     rs->StackNams    = NEW_PLIST( T_PLIST, 16 );
-    rs->ReadTop      = 0;
-    rs->ReadTilde    = 0;
     STATE(Tilde)     = 0;
-    rs->CurrLHSGVar  = 0;
 
     // remember the old execution state and start an execution environment
     Bag oldLVars = SWITCH_TO_BOTTOM_LVARS();

--- a/src/streams.h
+++ b/src/streams.h
@@ -29,7 +29,7 @@
 **  Read the current input as function. The caller is responsible for opening
 **  and closing the input.
 */
-Obj READ_AS_FUNC(void);
+Obj READ_AS_FUNC(TypInputFile * input);
 
 
 /****************************************************************************


### PR DESCRIPTION
Instead of pre-allocating a fixed number of TypInputFile instances on each
thread, we allocate the required storage dynamically on the stack. This
arguably makes it easier to reason about the global state of GAP.

It also enables future simplifications and improvements, e.g. further
decoupling the input file code from the line buffering and potential
optimizations resulting from that.

Next step: minimize or ideally eliminate usage of `IO()->Input` resp. `GetCurrentInput`.