### PR TITLE
kernel: introduce streq() helper

### DIFF
--- a/src/calls.c
+++ b/src/calls.c
@@ -53,6 +53,7 @@
 #include "saveload.h"
 #include "stats.h"
 #include "stringobj.h"
+#include "sysstr.h"
 #include "vars.h"
 
 #ifdef HPCGAP
@@ -642,7 +643,7 @@ void InitHandlerFunc (
     }
 
     for (UInt i = 0; i < NHandlerFuncs; i++)
-        if (!strcmp(HandlerFuncs[i].cookie, cookie))
+        if (streq(HandlerFuncs[i].cookie, cookie))
             Pr("Duplicate cookie %s\n", (Int)cookie, 0);
 
     HandlerFuncs[NHandlerFuncs].hdlr   = hdlr;
@@ -770,7 +771,7 @@ ObjFunc HandlerOfCookie(
     {
       for (i = 0; i < NHandlerFuncs; i++)
         {
-          if (strcmp(cookie, HandlerFuncs[i].cookie) == 0)
+          if (streq(cookie, HandlerFuncs[i].cookie))
             return HandlerFuncs[i].hdlr;
         }
       return (ObjFunc)0;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5350,7 +5350,7 @@ Int CompileFunc (
     /* emit the initialization code                                        */
     Emit( "\n/* <name> returns the description of this module */\n" );
     Emit( "static StructInitInfo module = {\n" );
-    if ( ! strcmp( "Init_Dynamic", CONST_CSTR_STRING(name) ) ) {
+    if (streq("Init_Dynamic", CONST_CSTR_STRING(name))) {
         Emit( ".type        = MODULE_DYNAMIC,\n" );
     }
     else {

--- a/src/gap.c
+++ b/src/gap.c
@@ -740,12 +740,12 @@ static Obj FuncGASMAN(Obj self, Obj args)
         RequireStringRep(SELF_NAME, cmd);
 
         // perform full garbage collection
-        if ( strcmp( CONST_CSTR_STRING(cmd), "collect" ) == 0 ) {
+        if (streq(CONST_CSTR_STRING(cmd), "collect")) {
             CollectBags(0,1);
         }
 
         // perform partial garbage collection
-        else if ( strcmp( CONST_CSTR_STRING(cmd), "partial" ) == 0 ) {
+        else if (streq(CONST_CSTR_STRING(cmd), "partial")) {
             CollectBags(0,0);
         }
 
@@ -758,7 +758,7 @@ static Obj FuncGASMAN(Obj self, Obj args)
 #else
 
         /* if request display the statistics                               */
-        else if ( strcmp( CONST_CSTR_STRING(cmd), "display" ) == 0 ) {
+        else if (streq(CONST_CSTR_STRING(cmd), "display")) {
 #ifdef COUNT_BAGS
             Pr("%40s ", (Int)"type", 0);
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
@@ -779,7 +779,7 @@ static Obj FuncGASMAN(Obj self, Obj args)
         }
 
         /* if request give a short display of the statistics                */
-        else if ( strcmp( CONST_CSTR_STRING(cmd), "displayshort" ) == 0 ) {
+        else if (streq(CONST_CSTR_STRING(cmd), "displayshort")) {
 #ifdef COUNT_BAGS
             Pr("%40s ", (Int)"type", 0);
             Pr( "%8s %8s ",  (Int)"alive", (Int)"kbyte" );
@@ -804,7 +804,7 @@ static Obj FuncGASMAN(Obj self, Obj args)
         }
 
         /* if request display the statistics                               */
-        else if ( strcmp( CONST_CSTR_STRING(cmd), "clear" ) == 0 ) {
+        else if (streq(CONST_CSTR_STRING(cmd), "clear")) {
 #ifdef COUNT_BAGS
             for ( UInt k = 0; k < NUM_TYPES; k++ ) {
 #ifdef GASMAN_CLEAR_TO_LIVE
@@ -819,7 +819,7 @@ static Obj FuncGASMAN(Obj self, Obj args)
         }
 
         /* or display information about global bags                        */
-        else if ( strcmp( CONST_CSTR_STRING(cmd), "global" ) == 0 ) {
+        else if (streq(CONST_CSTR_STRING(cmd), "global")) {
             for ( i = 0;  i < GlobalBags.nr;  i++ ) {
                 Bag bag = *(GlobalBags.addr[i]);
                 if (bag != 0) {
@@ -833,7 +833,7 @@ static Obj FuncGASMAN(Obj self, Obj args)
         }
 
         /* or finally toggle Gasman messages                               */
-        else if ( strcmp( CONST_CSTR_STRING(cmd), "message" ) == 0 ) {
+        else if (streq(CONST_CSTR_STRING(cmd), "message")) {
             SyMsgsFlagBags = (SyMsgsFlagBags + 1) % 3;
         }
 
@@ -1248,19 +1248,19 @@ static Obj FuncUPDATE_STAT(Obj self, Obj name, Obj newStat)
     RequireStringRep(SELF_NAME, name);
 
     const char * cname = CONST_CSTR_STRING(name);
-    if (strcmp(cname, "time") == 0) {
+    if (streq(cname, "time")) {
         AssGVarWithoutReadOnlyCheck(Time, newStat);
     }
-    else if (strcmp(cname, "last") == 0) {
+    else if (streq(cname, "last")) {
         AssGVarWithoutReadOnlyCheck(Last, newStat);
     }
-    else if (strcmp(cname, "last2") == 0) {
+    else if (streq(cname, "last2")) {
         AssGVarWithoutReadOnlyCheck(Last2, newStat);
     }
-    else if (strcmp(cname, "last3") == 0) {
+    else if (streq(cname, "last3")) {
         AssGVarWithoutReadOnlyCheck(Last3, newStat);
     }
-    else if (strcmp(cname, "memory_allocated") == 0) {
+    else if (streq(cname, "memory_allocated")) {
         AssGVarWithoutReadOnlyCheck(MemoryAllocated, newStat);
     }
     else {

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -119,6 +119,7 @@
 #include "io.h"
 #include "sysfiles.h"
 #include "sysmem.h"
+#include "sysstr.h"
 
 #include "bags.inc"
 
@@ -833,7 +834,7 @@ void InitGlobalBag (
     }
 
     for (UInt i = 0; i < GlobalBags.nr; i++) {
-        if (0 == strcmp(GlobalBags.cookie[i], cookie)) {
+        if (streq(GlobalBags.cookie[i], cookie)) {
             if (GlobalBags.addr[i] == addr)
                 Pr("Duplicate global bag entry %s\n", (Int)cookie, 0);
             else
@@ -889,7 +890,7 @@ Bag * GlobalByCookie(
   if (!GlobalsAreSorted) {
       for (i = 0; i < GlobalBags.nr; i++)
         {
-          if (strcmp(cookie, GlobalBags.cookie[i]) == 0)
+          if (streq(cookie, GlobalBags.cookie[i]))
             return GlobalBags.addr[i];
         }
       return (Bag *)0;

--- a/src/io.c
+++ b/src/io.c
@@ -473,8 +473,8 @@ UInt OpenInput (
 #ifdef HPCGAP
     /* Handle *defin*; redirect *errin* to *defin* if the default
      * channel is already open. */
-    if (! strcmp(filename, "*defin*") ||
-        (! strcmp(filename, "*errin*") && TLS(DefaultInput)) )
+    if (streq(filename, "*defin*") ||
+        (streq(filename, "*errin*") && TLS(DefaultInput)))
         return OpenDefaultInput();
 #endif
 
@@ -490,7 +490,7 @@ UInt OpenInput (
     input->name[0] = '\0';
 
     // enable echo for stdin and errin
-    if (!strcmp("*errin*", filename) || !strcmp("*stdin*", filename))
+    if (streq("*errin*", filename) || streq("*stdin*", filename))
         input->echo = 1;
     else
         input->echo = 0;
@@ -930,8 +930,7 @@ UInt OpenOutput (
 
     // do nothing for stdout and errout if caught
     if (IO()->Output != NULL && IO()->IgnoreStdoutErrout == IO()->Output &&
-        (strcmp(filename, "*errout*") == 0 ||
-         strcmp(filename, "*stdout*") == 0)) {
+        (streq(filename, "*errout*") || streq(filename, "*stdout*"))) {
         return 1;
     }
 
@@ -942,8 +941,8 @@ UInt OpenOutput (
 #ifdef HPCGAP
     /* Handle *defout* specially; also, redirect *errout* if we already
      * have a default channel open. */
-    if ( ! strcmp( filename, "*defout*" ) ||
-         (! strcmp( filename, "*errout*" ) && TLS(threadID) != 0) )
+    if (streq(filename, "*defout*") ||
+        (streq(filename, "*errout*") && TLS(threadID) != 0))
         return OpenDefaultOutput();
 #endif
 
@@ -1074,7 +1073,7 @@ UInt OpenAppend (
         return 0;
 
 #ifdef HPCGAP
-    if ( ! strcmp( filename, "*defout*") )
+    if (streq(filename, "*defout*"))
         return OpenDefaultOutput();
 #endif
 
@@ -1606,7 +1605,7 @@ static const char * AllKeywords[] = {
 static BOOL IsKeyword(const char * str)
 {
     for (UInt i = 0; i < ARRAY_SIZE(AllKeywords); i++) {
-        if (strcmp(str, AllKeywords[i]) == 0) {
+        if (streq(str, AllKeywords[i])) {
             return TRUE;
         }
     }

--- a/src/modules.c
+++ b/src/modules.c
@@ -35,6 +35,7 @@
 #include "stringobj.h"
 #include "sysfiles.h"
 #include "sysopt.h"
+#include "sysstr.h"
 #include "vars.h"
 
 #ifdef HAVE_DLOPEN
@@ -183,7 +184,7 @@ StructInitInfo * LookupStaticModule(const char * name)
 {
     for (int k = 0; CompInitFuncs[k]; k++) {
         StructInitInfo * info = (*(CompInitFuncs[k]))();
-        if (info && strcmp(name, info->name) == 0) {
+        if (info && streq(name, info->name)) {
             return info;
         }
     }

--- a/src/profile.c
+++ b/src/profile.c
@@ -335,13 +335,10 @@ static void leaveFunction(Obj func)
 */
 
 #ifdef HAVE_POPEN
-static int endsWithgz(const char* s)
+static BOOL endsWithgz(const char * s)
 {
   s = strrchr(s, '.');
-  if(s)
-    return strcmp(s, ".gz") == 0;
-  else
-    return 0;
+  return s && streq(s, ".gz");
 }
 #endif
 

--- a/src/read.c
+++ b/src/read.c
@@ -213,7 +213,7 @@ static UInt findValueInNams(Obj nams, const Char * val, UInt start, UInt end)
 {
     GAP_ASSERT(LEN_PLIST(nams) < MAX_FUNC_LVARS);
     for (UInt i = start; i <= end; i++) {
-        if (strcmp(CONST_CSTR_STRING(ELM_PLIST(nams, i)), val) == 0) {
+        if (streq(CONST_CSTR_STRING(ELM_PLIST(nams, i)), val)) {
             return i;
         }
     }
@@ -1265,7 +1265,7 @@ static ArgList ReadFuncArgList(ReaderState * rs,
     Match_(rs, symbol, symbolstr, S_LOCAL|STATBEGIN|S_END|follow);
 
     // Special case for function(arg)
-    if ( narg == 1 && ! strcmp( "arg", CONST_CSTR_STRING( ELM_PLIST(nams, narg) ) )) {
+    if (narg == 1 && streq("arg", CONST_CSTR_STRING(ELM_PLIST(nams, narg)))) {
         isvarg = TRUE;
     }
 

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -30,6 +30,7 @@
 #include "stringobj.h"
 #include "sysfiles.h"
 #include "sysopt.h"
+#include "sysstr.h"
 
 #include <stdio.h>
 #include <unistd.h>
@@ -614,19 +615,19 @@ void LoadWorkspace( Char * fname )
      Panic("File %s does not appear to be a GAP workspace", fname);
   }
 
-  if (strcmp (buf, "GAP workspace") == 0) {
+  if (streq(buf, "GAP workspace")) {
 
      LoadCStr(buf,256);
-     if (strcmp(buf, GetKernelDescription()) != 0) {
+     if (!streq(buf, GetKernelDescription())) {
          Panic("This workspace is not compatible with GAP kernel (%s, present: "
             "%s)", buf, GetKernelDescription());
      }
 
      LoadCStr(buf,256);
 #ifdef SYS_IS_64_BIT             
-     if (strcmp(buf,"64 bit") != 0)
+     if (!streq(buf,"64 bit"))
 #else
-     if (strcmp(buf,"32 bit") != 0)
+     if (!streq(buf,"32 bit"))
 #endif
         {
            Panic("This workspace was created by a %s version of GAP", buf);
@@ -638,7 +639,7 @@ void LoadWorkspace( Char * fname )
   CheckEndiannessMarker();
   
   LoadCStr(buf,256);
-  if (strcmp(buf,"Counts and Sizes") != 0)
+  if (!streq(buf,"Counts and Sizes"))
     {
       Panic("Bad divider");
     }
@@ -654,7 +655,7 @@ void LoadWorkspace( Char * fname )
   /* The restoring kernel must have at least as many compiled modules
      as the saving one. */
   LoadCStr(buf,256);
-  if (strcmp(buf,"Loaded Modules") != 0)
+  if (!streq(buf,"Loaded Modules"))
     {
       Panic("Bad divider");
     }
@@ -662,7 +663,7 @@ void LoadWorkspace( Char * fname )
 
   /* Now the kernel variables that point into the workspace */
   LoadCStr(buf,256);
-  if (strcmp(buf,"Kernel to WS refs") != 0)
+  if (!streq(buf,"Kernel to WS refs"))
     {
       Panic("Bad divider");
     }
@@ -686,7 +687,7 @@ void LoadWorkspace( Char * fname )
     }
 
   LoadCStr(buf,256);
-  if (strcmp(buf,"Bag data") != 0)
+  if (!streq(buf,"Bag data"))
     {
       Panic("Bad divider");
     }
@@ -726,16 +727,16 @@ static Obj FuncDumpWorkspace(Obj self, Obj fname)
   CheckEndiannessMarker();
   LoadCStr(buf,256);
   Pr("Divider string: %s\n", (Int)buf, 0);
-  if (strcmp(buf,"Counts and Sizes") != 0)
-    ErrorQuit("Bad divider", 0, 0);
+  if (!streq(buf, "Counts and Sizes"))
+      ErrorQuit("Bad divider", 0, 0);
   Pr("Loaded modules: %d\n", nMods = LoadUInt(), 0);
   Pr("Global Bags   : %d\n", nGlobs = LoadUInt(), 0);
   Pr("Total Bags    : %d\n", nBags = LoadUInt(), 0);
   Pr("Maximum Size  : %d\n", sizeof(Bag) * LoadUInt(), 0);
   LoadCStr(buf,256);
   Pr("Divider string: %s\n", (Int)buf, 0);
-  if (strcmp(buf,"Loaded Modules") != 0)
-    ErrorQuit("Bad divider", 0, 0);
+  if (!streq(buf, "Loaded Modules"))
+      ErrorQuit("Bad divider", 0, 0);
   for (i = 0; i < nMods; i++)
     {
       UInt type;
@@ -751,8 +752,8 @@ static Obj FuncDumpWorkspace(Obj self, Obj fname)
     }
   LoadCStr(buf,256);
   Pr("Divider string: %s\n", (Int)buf, 0);
-  if (strcmp(buf,"Kernel to WS refs") != 0)
-    ErrorQuit("Bad divider", 0, 0);
+  if (!streq(buf, "Kernel to WS refs"))
+      ErrorQuit("Bad divider", 0, 0);
   for (i = 0; i < nGlobs; i++)
     {
       LoadCStr(buf,256);
@@ -761,8 +762,8 @@ static Obj FuncDumpWorkspace(Obj self, Obj fname)
     }
   LoadCStr(buf,256);
   Pr("Divider string: %s\n", (Int)buf, 0);
-  if (strcmp(buf,"Bag data") != 0)
-    ErrorQuit("Bad divider", 0, 0);
+  if (!streq(buf, "Bag data"))
+      ErrorQuit("Bad divider", 0, 0);
   CloseAfterLoad();
   return (Obj) 0;
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -56,7 +56,7 @@ static void SyntaxErrorOrWarning(ScannerState * s,
             Pr("Syntax warning: %s", (Int)msg, 0);
 
         // ... and the filename + line, unless it is '*stdin*'
-        if (strcmp("*stdin*", GetInputFilename(s->input)) != 0)
+        if (!streq("*stdin*", GetInputFilename(s->input)))
             Pr(" in %s:%d", (Int)GetInputFilename(s->input),
                GetInputLineNumber(s->input));
         Pr("\n", 0, 0);
@@ -306,41 +306,41 @@ static UInt GetIdent(ScannerState * s, Int i, Char c)
     // now check if 's->Value' holds a keyword
     const Char * v = s->Value;
     switch ( 256*v[0]+v[i-1] ) {
-    case 256*'a'+'d': if(!strcmp(v,"and"))           return S_AND;
-    case 256*'a'+'c': if(!strcmp(v,"atomic"))        return S_ATOMIC;
-    case 256*'b'+'k': if(!strcmp(v,"break"))         return S_BREAK;
-    case 256*'c'+'e': if(!strcmp(v,"continue"))      return S_CONTINUE;
-    case 256*'d'+'o': if(!strcmp(v,"do"))            return S_DO;
-    case 256*'e'+'f': if(!strcmp(v,"elif"))          return S_ELIF;
-    case 256*'e'+'e': if(!strcmp(v,"else"))          return S_ELSE;
-    case 256*'e'+'d': if(!strcmp(v,"end"))           return S_END;
-    case 256*'f'+'e': if(!strcmp(v,"false"))         return S_FALSE;
-    case 256*'f'+'i': if(!strcmp(v,"fi"))            return S_FI;
-    case 256*'f'+'r': if(!strcmp(v,"for"))           return S_FOR;
-    case 256*'f'+'n': if(!strcmp(v,"function"))      return S_FUNCTION;
-    case 256*'i'+'f': if(!strcmp(v,"if"))            return S_IF;
-    case 256*'i'+'n': if(!strcmp(v,"in"))            return S_IN;
-    case 256*'l'+'l': if(!strcmp(v,"local"))         return S_LOCAL;
-    case 256*'m'+'d': if(!strcmp(v,"mod"))           return S_MOD;
-    case 256*'n'+'t': if(!strcmp(v,"not"))           return S_NOT;
-    case 256*'o'+'d': if(!strcmp(v,"od"))            return S_OD;
-    case 256*'o'+'r': if(!strcmp(v,"or"))            return S_OR;
-    case 256*'r'+'e': if(!strcmp(v,"readwrite"))     return S_READWRITE;
-    case 256*'r'+'y': if(!strcmp(v,"readonly"))      return S_READONLY;
-    case 256*'r'+'c': if(!strcmp(v,"rec"))           return S_REC;
-    case 256*'r'+'t': if(!strcmp(v,"repeat"))        return S_REPEAT;
-    case 256*'r'+'n': if(!strcmp(v,"return"))        return S_RETURN;
-    case 256*'t'+'n': if(!strcmp(v,"then"))          return S_THEN;
-    case 256*'t'+'e': if(!strcmp(v,"true"))          return S_TRUE;
-    case 256*'u'+'l': if(!strcmp(v,"until"))         return S_UNTIL;
-    case 256*'w'+'e': if(!strcmp(v,"while"))         return S_WHILE;
-    case 256*'q'+'t': if(!strcmp(v,"quit"))          return S_QUIT;
-    case 256*'Q'+'T': if(!strcmp(v,"QUIT"))          return S_QQUIT;
-    case 256*'I'+'d': if(!strcmp(v,"IsBound"))       return S_ISBOUND;
-    case 256*'U'+'d': if(!strcmp(v,"Unbind"))        return S_UNBIND;
-    case 256*'T'+'d': if(!strcmp(v,"TryNextMethod")) return S_TRYNEXT;
-    case 256*'I'+'o': if(!strcmp(v,"Info"))          return S_INFO;
-    case 256*'A'+'t': if(!strcmp(v,"Assert"))        return S_ASSERT;
+    case 256*'a'+'d': if(streq(v,"and"))           return S_AND;
+    case 256*'a'+'c': if(streq(v,"atomic"))        return S_ATOMIC;
+    case 256*'b'+'k': if(streq(v,"break"))         return S_BREAK;
+    case 256*'c'+'e': if(streq(v,"continue"))      return S_CONTINUE;
+    case 256*'d'+'o': if(streq(v,"do"))            return S_DO;
+    case 256*'e'+'f': if(streq(v,"elif"))          return S_ELIF;
+    case 256*'e'+'e': if(streq(v,"else"))          return S_ELSE;
+    case 256*'e'+'d': if(streq(v,"end"))           return S_END;
+    case 256*'f'+'e': if(streq(v,"false"))         return S_FALSE;
+    case 256*'f'+'i': if(streq(v,"fi"))            return S_FI;
+    case 256*'f'+'r': if(streq(v,"for"))           return S_FOR;
+    case 256*'f'+'n': if(streq(v,"function"))      return S_FUNCTION;
+    case 256*'i'+'f': if(streq(v,"if"))            return S_IF;
+    case 256*'i'+'n': if(streq(v,"in"))            return S_IN;
+    case 256*'l'+'l': if(streq(v,"local"))         return S_LOCAL;
+    case 256*'m'+'d': if(streq(v,"mod"))           return S_MOD;
+    case 256*'n'+'t': if(streq(v,"not"))           return S_NOT;
+    case 256*'o'+'d': if(streq(v,"od"))            return S_OD;
+    case 256*'o'+'r': if(streq(v,"or"))            return S_OR;
+    case 256*'r'+'e': if(streq(v,"readwrite"))     return S_READWRITE;
+    case 256*'r'+'y': if(streq(v,"readonly"))      return S_READONLY;
+    case 256*'r'+'c': if(streq(v,"rec"))           return S_REC;
+    case 256*'r'+'t': if(streq(v,"repeat"))        return S_REPEAT;
+    case 256*'r'+'n': if(streq(v,"return"))        return S_RETURN;
+    case 256*'t'+'n': if(streq(v,"then"))          return S_THEN;
+    case 256*'t'+'e': if(streq(v,"true"))          return S_TRUE;
+    case 256*'u'+'l': if(streq(v,"until"))         return S_UNTIL;
+    case 256*'w'+'e': if(streq(v,"while"))         return S_WHILE;
+    case 256*'q'+'t': if(streq(v,"quit"))          return S_QUIT;
+    case 256*'Q'+'T': if(streq(v,"QUIT"))          return S_QQUIT;
+    case 256*'I'+'d': if(streq(v,"IsBound"))       return S_ISBOUND;
+    case 256*'U'+'d': if(streq(v,"Unbind"))        return S_UNBIND;
+    case 256*'T'+'d': if(streq(v,"TryNextMethod")) return S_TRYNEXT;
+    case 256*'I'+'o': if(streq(v,"Info"))          return S_INFO;
+    case 256*'A'+'t': if(streq(v,"Assert"))        return S_ASSERT;
     }
 
     return S_IDENT;

--- a/src/streams.c
+++ b/src/streams.c
@@ -738,7 +738,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
         i = append ? OpenAppend(CONST_CSTR_STRING(destination))
                    : OpenOutput(CONST_CSTR_STRING(destination));
         if (!i) {
-            if (strcmp(CSTR_STRING(destination), "*errout*") == 0) {
+            if (streq(CSTR_STRING(destination), "*errout*")) {
                 Panic("Failed to open *errout*!");
             }
             ErrorQuit("%s: cannot open '%g' for output", (Int)funcname,

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -617,34 +617,20 @@ Int SyFopen (
     int                 flags = 0;
 
     Char * terminator = strrchr(name, '.');
-    BOOL endsgz = terminator && (strcmp(terminator, ".gz") == 0);
+    BOOL   endsgz = terminator && (streq(terminator, ".gz"));
 
     /* handle standard files                                               */
-    if ( strcmp( name, "*stdin*" ) == 0 ) {
-        if ( strcmp( mode, "r" ) != 0 )
-          return -1;
-        else
-          return 0;
+    if (streq(name, "*stdin*")) {
+        return streq(mode, "r") ? 0 : -1;
     }
-    else if ( strcmp( name, "*stdout*" ) == 0 ) {
-        if ( strcmp( mode, "w" ) != 0 && strcmp( mode, "a" ) != 0 )
-          return -1;
-        else
-          return 1;
+    else if (streq(name, "*stdout*")) {
+        return streq(mode, "w") || streq(mode, "a") ? 1 : -1;
     }
-    else if ( strcmp( name, "*errin*" ) == 0 ) {
-        if ( strcmp( mode, "r" ) != 0 )
-          return -1;
-        else if ( !SyBufInUse( 2 ) )
-          return -1;
-        else
-          return 2;
+    else if (streq(name, "*errin*")) {
+        return (streq(mode, "r") && SyBufInUse(2)) ? 2 : -1;
     }
-    else if ( strcmp( name, "*errout*" ) == 0 ) {
-        if ( strcmp( mode, "w" ) != 0 && strcmp( mode, "a" ) != 0 )
-          return -1;
-        else
-          return 3;
+    else if (streq(name, "*errout*")) {
+        return streq(mode, "w") || streq(mode, "a") ? 3 : -1;
     }
 
     HashLock(&syBuf);
@@ -675,8 +661,8 @@ Int SyFopen (
     }
 
 #ifdef SYS_IS_CYGWIN32
-    if(strlen(mode) >= 2 && mode[1] == 'b')
-       flags |= O_BINARY;
+    if (strlen(mode) >= 2 && mode[1] == 'b')
+        flags |= O_BINARY;
 #endif
 
     /* try to open the file                                                */

--- a/src/sysstr.h
+++ b/src/sysstr.h
@@ -54,6 +54,20 @@ EXPORT_INLINE BOOL IsIdent(char ch)
 
 /****************************************************************************
 **
+*F  streq( <s1>, <s2> ) . . . . . . . .  test whether two C strings are equal
+**
+**  'streq' is a simple wrapper around the standard C function 'strcmp', with
+**  the advantage that code using it is often easier to understand for human
+**  beings.
+*/
+EXPORT_INLINE BOOL streq(const char * s1, const char * s2)
+{
+    return 0 == strcmp(s1, s2);
+}
+
+
+/****************************************************************************
+**
 *F  strlcpy( <dst>, <src>, <len> )
 **
 **  Copy <src> to buffer <dst> of size <len>. At most <len>-1 characters will


### PR DESCRIPTION
`streq` is a simple wrapper around the standard C function `strcmp`, with
the advantage that code using it is often easier to understand for human
beings. For example, compare

    if (!strcmp("*errin*", filename) || !strcmp("*stdin*", filename))

to

    if (streq("*errin*", filename) || streq("*stdin*", filename))

I am open to bikeshedding on the name, e.g. `strequals`, str_equals`, `equal_strs`, ... 