### PR TITLE
Add 'gap --version'

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -54,6 +54,7 @@ BIND_GLOBAL( "GAPInfo", rec(
     # for those options is correct
     CommandLineOptionData := [
       rec( short:= "h", long := "help", default := false, help := ["print this help and exit"] ),
+      rec( long := "version", default := false, help := ["print the GAP version and exit"] ),
       rec( short:= "b", long := "banner", default := false, help := ["disable/enable the banner"] ),
       rec( short:= "q", long := "quiet", default := false, help := ["enable/disable quiet mode"] ),
       rec( short:= "e", default := false, help := ["disable/enable quitting on <ctrl>-D"] ),

--- a/src/system.c
+++ b/src/system.c
@@ -632,6 +632,16 @@ static Int enableMemCheck(Char ** argv, void * dummy)
 #endif
 
 
+static Int printVersion(Char ** argv, void * dummy)
+{
+    SyFputs("GAP ", 1);
+    SyFputs(SyBuildVersion, 1);
+    SyFputs(" built on ", 1);
+    SyFputs(SyBuildDateTime, 1);
+    SyExit(0);
+}
+
+
 /* These are just the options that need kernel processing. Additional options will be 
    recognised and handled in the library */
 
@@ -674,6 +684,7 @@ static const struct optInfo options[] = {
   { 0  , "cover", enableCodeCoverageAtStartup, 0, 1}, /* enable code coverage at startup */
   { 0  , "quitonbreak", toggle, &SyQuitOnBreak, 0}, /* Quit GAP if we enter the break loop */
   { 0  , "enableMemCheck", enableMemCheck, 0, 0 },
+  { 0  , "version", printVersion, 0, 0 },
   { 0, "", 0, 0, 0}};
 
 


### PR DESCRIPTION
Resolves #3735

I guess we could try to add a test, but I am not quite sure what to test for... Perhaps a non-zero exit code, and then match the output against a regex?