### PR TITLE
kernel: merge OpenAppend into OpenOutput

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5204,7 +5204,7 @@ Int CompileFunc (
     UInt                compFunctionsNr;
 
     /* open the output file                                                */
-    if ( ! OpenOutput( CONST_CSTR_STRING(output) ) ) {
+    if (!OpenOutput(CONST_CSTR_STRING(output), FALSE)) {
         return 0;
     }
     col = SyNrCols;

--- a/src/error.c
+++ b/src/error.c
@@ -62,7 +62,7 @@ UInt OpenErrorOutput( void )
 
     if (ERROR_OUTPUT != NULL) {
         if (IsStringConv(ERROR_OUTPUT)) {
-            ret = OpenOutput(CONST_CSTR_STRING(ERROR_OUTPUT));
+            ret = OpenOutput(CONST_CSTR_STRING(ERROR_OUTPUT), FALSE);
         }
         else {
             if (CALL_1ARGS(IsOutputStream, ERROR_OUTPUT) == True) {
@@ -75,7 +75,7 @@ UInt OpenErrorOutput( void )
         /* It may be we already tried and failed to open *errout* above but
          * but this is an extreme case so it can't hurt to try again
          * anyways */
-        ret = OpenOutput("*errout*");
+        ret = OpenOutput("*errout*", FALSE);
         if (ret) {
             Pr("failed to open error stream\n", 0, 0);
         }
@@ -173,9 +173,10 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
 
     /* HACK: we want to redirect output */
     /* Try to print the output to stream. Use *errout* as a fallback. */
-    if ((IsStringConv(stream) && !OpenOutput(CONST_CSTR_STRING(stream))) ||
+    if ((IsStringConv(stream) &&
+         !OpenOutput(CONST_CSTR_STRING(stream), FALSE)) ||
         (!IS_STRING(stream) && !OpenOutputStream(stream))) {
-        if (OpenOutput("*errout*")) {
+        if (OpenOutput("*errout*", FALSE)) {
             Pr("PRINT_CURRENT_STATEMENT: failed to open error stream\n", 0, 0);
         }
         else {

--- a/src/gap.c
+++ b/src/gap.c
@@ -179,7 +179,7 @@ static Obj Shell(Obj    context,
   Int oldRecursionDepth = GetRecursionDepth();
   
   /* read-eval-print loop                                                */
-  if (!OpenOutput(outFile))
+  if (!OpenOutput(outFile, FALSE))
       ErrorQuit("SHELL: can't open outfile %s",(Int)outFile,0);
 
   if(!OpenInput(inFile))

--- a/src/io.h
+++ b/src/io.h
@@ -273,18 +273,21 @@ UInt CloseOutputLog(void);
 **  '*errout*' when 'LockCurrentOutput(1)' is in effect (used for testing
 **  purposes).
 **
-**  It is not neccessary to open the initial output file, 'InitScanner' opens
-**  '*stdout*' for that purpose.  This  file  on the other hand   can not  be
-**  closed by 'CloseOutput'.
+**  It is not neccessary to open the initial output file; '*stdout'* is
+**  opened for that purpose during startup. This file on the other hand  can
+**  not be closed by 'CloseOutput'.
+**
+**  If <append> is set to true, then 'OpenOutput' does not truncate the file
+**  to size 0 if it exists.
 */
-UInt OpenOutput(const Char * filename);
+UInt OpenOutput(const Char * filename, BOOL append);
 
 
 /****************************************************************************
 **
 *F  OpenOutputStream( <stream> )  . . . . . . open a stream as current output
 **
-**  The same as 'OpenOutput' (and also 'OpenAppend') but for streams.
+**  The same as 'OpenOutput' but for streams.
 */
 UInt OpenOutputStream(Obj stream);
 
@@ -307,20 +310,6 @@ UInt OpenOutputStream(Obj stream);
 **  'PrintTo' call or an error will not yield much better results.
 */
 UInt CloseOutput(void);
-
-
-/****************************************************************************
-**
-*F  OpenAppend( <filename> )  . . open a file as current output for appending
-**
-**  'OpenAppend' opens the file  with the name  <filename> as current output.
-**  All subsequent output will go  to that file, until either   it is  closed
-**  again  with 'CloseOutput' or  another  file is  opened with 'OpenOutput'.
-**  Unlike 'OpenOutput' 'OpenAppend' does not truncate the file to size 0  if
-**  it exists.  Appart from that 'OpenAppend' is equal to 'OpenOutput' so its
-**  description applies to 'OpenAppend' too.
-*/
-UInt OpenAppend(const Char * filename);
 
 
 TypInputFile * GetCurrentInput(void);

--- a/src/streams.c
+++ b/src/streams.c
@@ -735,8 +735,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
     /* try to open the output and handle failures                          */
     if (file) {
         RequireStringRep(funcname, destination);
-        i = append ? OpenAppend(CONST_CSTR_STRING(destination))
-                   : OpenOutput(CONST_CSTR_STRING(destination));
+        i = OpenOutput(CONST_CSTR_STRING(destination), append);
         if (!i) {
             if (streq(CSTR_STRING(destination), "*errout*")) {
                 Panic("Failed to open *errout*!");


### PR DESCRIPTION
This reduces code duplication, and in fact aligns the behavior of these two functions which really should behave virtually the same.