### PR TITLE
kernel: add AppendString, AppendCStr; avoid fixed size buffer in FuncTmpDirectory

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -225,15 +225,8 @@ static Obj FuncAPPEND_LIST_INTR(Obj self, Obj list1, Obj list2)
 
     /* handle the case of strings now */
     if (IS_STRING_REP(list1) && IS_STRING_REP(list2)) {
-        len1 = GET_LEN_STRING(list1);
-        len2 = GET_LEN_STRING(list2);
-        GROW_STRING(list1, len1 + len2);
-        SET_LEN_STRING(list1, len1 + len2);
-        CLEAR_FILTS_LIST(list1);
-        // copy data, including terminating zero byte
-        // Can't use memcpy, in case list1 == list2
-        SyMemmove(CHARS_STRING(list1) + len1, CONST_CHARS_STRING(list2), len2 + 1);
-        return (Obj) 0;
+        AppendString(list1, list2);
+        return 0;
     }
 
     /* check the type of the first argument                                */

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -2520,19 +2520,8 @@ static Obj WRAP_NAME(Obj name, const char *addon)
 
 static Obj PREFIX_NAME(Obj name, const char *prefix)
 {
-    UInt name_len = GET_LEN_STRING(name);
-    UInt prefix_len = strlen(prefix);
-    Obj fname = NEW_STRING( name_len + prefix_len );
-#ifdef HPCGAP
-    ImpliedWriteGuard(fname);
-#endif
-
-    char *ptr = CSTR_STRING(fname);
-    memcpy( ptr, prefix, prefix_len );
-    ptr += prefix_len;
-    memcpy( ptr, CONST_CSTR_STRING(name), name_len );
-    ptr += name_len;
-    *ptr = 0;
+    Obj fname = MakeString(prefix);
+    AppendString(fname, name);
     MakeImmutable(fname);
     return fname;
 }

--- a/src/streams.c
+++ b/src/streams.c
@@ -997,25 +997,24 @@ static Obj FuncTmpName(Obj self)
 */
 static Obj FuncTmpDirectory(Obj self)
 {
-    char   name[GAP_PATH_MAX];
+    Obj name;
     char * env_tmpdir = getenv("TMPDIR");
     if (env_tmpdir != NULL) {
-        strxcpy(name, env_tmpdir, sizeof(name));
-        strxcat(name, "/", sizeof(name));
+        name = MakeString(env_tmpdir);
     }
     else {
 #ifdef SYS_IS_CYGWIN32
-        strxcpy(name, "C:/WINDOWS/Temp/", sizeof(name));
+        name = MakeString("C:/WINDOWS/Temp/");
 #else
-        strxcpy(name, "/tmp/", sizeof(name));
+        name = MakeString("/tmp");
 #endif
     }
-    strxcat(name, "gaptempdirXXXXXX", sizeof(name));
+    const char * extra = "/gaptempdirXXXXXX";
+    AppendCStr(name, extra, strlen(extra));
 
-    char * tmp = mkdtemp(name);
-    if (tmp == 0)
+    if (mkdtemp(CSTR_STRING(name)) == 0)
         return Fail;
-    return MakeString(tmp);
+    return name;
 }
 
 

--- a/src/stringobj.c
+++ b/src/stringobj.c
@@ -558,13 +558,7 @@ void ToPrOutputter(void * data, char * strbuf, UInt len)
 // Output to a string
 void ToStringOutputter(void * data, char * buf, UInt lenbuf)
 {
-    Obj str = (Obj)data;
-    UInt lenstr = GET_LEN_STRING(str);
-    UInt newlen = lenstr + lenbuf;
-    GROW_STRING(str, newlen);
-    memcpy(CHARS_STRING(str) + lenstr, buf, lenbuf);
-    CHARS_STRING(str)[newlen] = '\0';
-    SET_LEN_STRING(str, newlen);
+    AppendCStr((Obj)data, buf, lenbuf);
 }
 
 void OutputStringGeneric(Obj list, StringOutputterType func, void * data)
@@ -1307,6 +1301,52 @@ BOOL IsStringConv(Obj obj)
     }
 
     return res;
+}
+
+
+/****************************************************************************
+**
+*F  AppendCStr( <str>, <buf>, <len> ) . . append data in a buffer to a string
+**
+**  'AppendCStr' appends <len> bytes of data taken from <buf> to <str>, where
+**  <str> must be a mutable GAP string object.
+*/
+void AppendCStr(Obj str, const char * buf, UInt len)
+{
+    GAP_ASSERT(IS_MUTABLE_OBJ(str));
+    GAP_ASSERT(IS_STRING_REP(str));
+
+    UInt len1 = GET_LEN_STRING(str);
+    UInt newlen = len1 + len;
+    GROW_STRING(str, newlen);
+    SET_LEN_STRING(str, newlen);
+    CLEAR_FILTS_LIST(str);
+    memcpy(CHARS_STRING(str) + len1, buf, len);
+    CHARS_STRING(str)[newlen] = '\0'; // add terminator
+}
+
+
+/****************************************************************************
+**
+*F  AppendString( <str1>, <str2> ) . . . . . . . append one string to another
+**
+**  'AppendString' appends <str2> to the end of <str1>. Both <str1> and <str>
+**  must be a GAP string objects, and <str1> must be mutable.
+*/
+void AppendString(Obj str1, Obj str2)
+{
+    GAP_ASSERT(IS_MUTABLE_OBJ(str1));
+    GAP_ASSERT(IS_STRING_REP(str1));
+    GAP_ASSERT(IS_STRING_REP(str2));
+
+    UInt len1 = GET_LEN_STRING(str1);
+    UInt len2 = GET_LEN_STRING(str2);
+    UInt newlen = len1 + len2;
+    GROW_STRING(str1, newlen);
+    SET_LEN_STRING(str1, newlen);
+    CLEAR_FILTS_LIST(str1);
+    memcpy(CHARS_STRING(str1) + len1, CONST_CHARS_STRING(str2), len2);
+    CHARS_STRING(str1)[newlen] = '\0'; // add terminator
 }
 
 

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -372,6 +372,26 @@ EXPORT_INLINE Obj MakeImmStringWithLen(const char * buf, size_t len)
 
 /****************************************************************************
 **
+*F  AppendCStr( <str>, <buf>, <len> ) . . append data in a buffer to a string
+**
+**  'AppendCStr' appends <len> bytes of data taken from <buf> to <str>, where
+**  <str> must be a mutable GAP string object.
+*/
+void AppendCStr(Obj str, const char * buf, UInt len);
+
+
+/****************************************************************************
+**
+*F  AppendString( <str1>, <str2> ) . . . . . . . append one string to another
+**
+**  'AppendString' appends <str2> to the end of <str1>. Both <str1> and <str>
+**  must be a GAP string objects, and <str1> must be mutable.
+*/
+void AppendString(Obj str1, Obj str2);
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 


### PR DESCRIPTION
While `AppendString`, `AppendCStr` are not used much right now, I think there is some worth in having them, because it will encourage use of dynamic buffers in other places of the GAP kernel by virtue of making it more convenient to do so.