### PR TITLE
Fix compatibility with some old glibc versions

### DIFF
--- a/src/iostream.c
+++ b/src/iostream.c
@@ -316,8 +316,22 @@ static Obj FuncDEFAULT_SIGCHLD_HANDLER(Obj self)
 #undef HAVE_POSIX_SPAWN
 #endif
 
+// if neither posix_spawn_file_actions_addchdir nor O_CLOEXEC are available,
+// our posix_spawn code should not be used. This affects e.g. Linux systems
+// with an old glibc, see https://github.com/gap-system/gap/issues/3918.
+#if !defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR) && !defined(O_CLOEXEC)
+#undef HAVE_POSIX_SPAWN
+#endif
+
 
 #ifdef HAVE_POSIX_SPAWN
+
+// O_DIRECTORY is not available in old Linux / glibc versions, but the way we
+// use it below, it is optional anyway
+#ifndef O_DIRECTORY
+#define O_DIRECTORY 0
+#endif
+
 
 // The following function behaves like posix_spawn, but also
 // changes the working directory temporarily to 'dir'.

--- a/src/profile.c
+++ b/src/profile.c
@@ -334,13 +334,11 @@ static void leaveFunction(Obj func)
 ** of GAP's execution, before anything else is done.
 */
 
-#ifdef HAVE_POPEN
 static BOOL endsWithgz(const char * s)
 {
   s = strrchr(s, '.');
   return s && streq(s, ".gz");
 }
-#endif
 
 static void fopenMaybeCompressed(const char* name, struct ProfileState* ps)
 {


### PR DESCRIPTION
On some old glibc versions, `posix_spawn` is present but not `O_DIRECTORY` nor
`O_CLOEXEC`, leading to a compilation error.

Also avoid another compilation error that happens if `popen` is not available.

Fixes #3918.

@alex-konovalov @raemarina  can you confirm that this helps?
