### PR TITLE
buildsys: fix --enable-debug regression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -382,7 +382,7 @@ dnl User setting: Debug mode (off by default)
 dnl
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug], [enable debug mode])],
-    []
+    [],
     [enable_debug=no]
     )
 AC_MSG_CHECKING([whether to enable debug mode])


### PR DESCRIPTION
A missing comma introduced in PR #4117 caused enable-debug to default to being active.

Thanks to @wilfwilson for catching the resulting performance regression on Travis CI; without him we might not have spotted this for weeks or months to come!