### PR TITLE
Extend BindConstant, MakeConstantGlobal to all object types

### DIFF
--- a/lib/global.gd
+++ b/lib/global.gd
@@ -197,9 +197,7 @@ DeclareGlobalFunction("MakeReadWriteGlobal");
 ##  <Description>
 ##  MakeConstantGlobal ( <A>name</A> ) marks the global variable named
 ##  by the string <A>name</A> as constant. A constant variable can never
-##  be changed or made read-write. Constant variables can only take an
-##  integer value, <C>true</C> or <C>false</C>. There is a limit on
-##  the size of allowed integers.
+##  be reassigned or made read-write again.
 ##  <P/>
 ##  A warning is given if <A>name</A> is already constant.
 ##  </Description>

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -797,12 +797,6 @@ void MakeReadOnlyGVar (
 */
 void MakeConstantGVar(UInt gvar)
 {
-    Obj val = ValGVar(gvar);
-    if (!IS_INTOBJ(val) && val != True && val != False) {
-        ErrorMayQuit(
-            "Variable: '%g' must be assigned a small integer, true or false",
-            (Int)NameGVar(gvar), 0);
-    }
     SetGVarWriteState(gvar, GVarConstant);
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -856,16 +856,19 @@ static void ReadCallVarAss(ReaderState * rs, TypSymbolSet follow, Char mode)
         if (mode == 'r' || (mode == 'x' && rs->s.Symbol != S_ASSIGN)) {
             Obj val = ValAutoGVar(ref.var);
             TRY_IF_NO_ERROR {
-                if (val == True)
+                if (val == True) {
                     IntrTrueExpr(&rs->intr);
-                else if (val == False)
+                    return;
+                }
+                else if (val == False) {
                     IntrFalseExpr(&rs->intr);
-                else if (IS_INTOBJ(val))
+                    return;
+                }
+                else if (IS_INTOBJ(val)) {
                     IntrIntObjExpr(&rs->intr, val);
-                else
-                    SyntaxError(&rs->s, "Invalid constant variable");
+                    return;
+                }
             }
-            return;
         }
     }
 

--- a/tst/testinstall/constant.tst
+++ b/tst/testinstall/constant.tst
@@ -44,12 +44,11 @@ true
 gap> Unbind(testvar);
 Error, Variable: 'testvar' is constant
 
-# Try making a global var constants whose value is not eligible
+# make a global var constants whose value is not a small integer, true or false
 gap> newtestvar := fail;;
 gap> MakeConstantGlobal("newtestvar");
-Error, Variable: 'newtestvar' must be assigned a small integer, true or false
 gap> IsConstantGlobal("newtestvar");
-false
+true
 
 # some more tests with constant gvars with boolean value
 gap> booltruevar := true;;


### PR DESCRIPTION
Currently we only support these on integer and boolean values. This patch
extends this to all object types. This would then simply be a "non-reversible"
version of `MakeReadOnlyGlobal`; i.e., unlike that, a "constant global
variables" can never be turned into a non-constant one. That is, it will
always refer to the same object.

Semantically this interpretation of `constness` is in line with other
languages, such as Julia, where `const` refers to the (re)assignability of a
variable identifier, *not* to the mutability of the object it refers to. (Note
that this is admittedly somewhat confusing in GAP, with
`MakeReadOnlyGlobal`/`MakeReadOnlyGVar` doing one thing and `MakeReadOnlyObj`
doing something orthogonal (and for now only in HPC-GAP....

Note that no further use is made of this for now; in particular, unlike for
small integer values, `true` and `false`, no attempt is made to "inline"
constant object in function definitions. However, interfaces to other
languages (such as the GAP-Julia interface) could exploit constness for
various optimizations (cc @rfourquet).