### PR TITLE
Improve errors messages for various set operations

### DIFF
--- a/lib/set.gi
+++ b/lib/set.gi
@@ -222,3 +222,22 @@ InstallMethod( SubtractSet,
       RemoveSet( set, obj );
     od;
     end );
+
+
+#############################################################################
+##
+##  Fallback methods to give better user feedback if the first argument is
+##  not mutable or not a set
+##
+BindGlobal("_REQUIRE_MUTABLE_SET",
+    function( set, obj )
+    if not IsMutable(set) or not IsSSortedList( set ) then
+      Error( "<set> must be a mutable proper set" );
+    fi;
+    TryNextMethod();
+    end );
+InstallOtherMethod( AddSet, "for two objects", [ IsObject, IsObject ], _REQUIRE_MUTABLE_SET);
+InstallOtherMethod( RemoveSet, "for two objects", [ IsObject, IsObject ], _REQUIRE_MUTABLE_SET);
+InstallOtherMethod( UniteSet, "for two objects", [ IsObject, IsObject ], _REQUIRE_MUTABLE_SET);
+InstallOtherMethod( IntersectSet, "for two objects", [ IsObject, IsObject ], _REQUIRE_MUTABLE_SET);
+InstallOtherMethod( SubtractSet, "for two objects", [ IsObject, IsObject ], _REQUIRE_MUTABLE_SET);

--- a/tst/testinstall/set.tst
+++ b/tst/testinstall/set.tst
@@ -25,6 +25,48 @@ gap> HasIsSSortedList(c) and IsSSortedList(c);
 true
 gap> AddSet(a,(5,6));
 
+#
+gap> AddSet(Immutable([]), 1);
+Error, <set> must be a mutable proper set
+gap> AddSet(fail, 1);
+Error, <set> must be a mutable proper set
+gap> AddSet([2,1], 1);
+Error, ADD_SET: <set> must be a mutable proper set (not a non-strictly-sorted \
+plain list of cyclotomics)
+
+#
+gap> RemoveSet(Immutable([]), 1);
+Error, <set> must be a mutable proper set
+gap> RemoveSet(fail, 1);
+Error, <set> must be a mutable proper set
+gap> RemoveSet([2,1], 1);
+Error, REM_SET: <set> must be a mutable proper set (not a non-strictly-sorted \
+plain list of cyclotomics)
+
+#
+gap> UniteSet(Immutable([]), 1);
+Error, <set> must be a mutable proper set
+gap> UniteSet(fail, 1);
+Error, <set> must be a mutable proper set
+gap> UniteSet([2,1], 1);
+Error, <set> must be a mutable proper set
+
+#
+gap> IntersectSet(Immutable([]), 1);
+Error, <set> must be a mutable proper set
+gap> IntersectSet(fail, 1);
+Error, <set> must be a mutable proper set
+gap> IntersectSet([2,1], 1);
+Error, <set> must be a mutable proper set
+
+#
+gap> SubtractSet(Immutable([]), 1);
+Error, <set> must be a mutable proper set
+gap> SubtractSet(fail, 1);
+Error, <set> must be a mutable proper set
+gap> SubtractSet([2,1], 1);
+Error, <set> must be a mutable proper set
+
 #gap> HasIsSSortedList(a) and IsSSortedList(a);
 #true
 gap> c:=Union(a,[(1,2),(1,2,3)]);


### PR DESCRIPTION
AddSet, RemoveSet, UniteSet, IntersectSet, SubtractSet now print a helpful error if the first argument is not mutable, or not a set.

I would argue that this resolves #3597 but not everybody might agree with that? @ChrisJefferson ?