### PR TITLE
Fix the user preference SaveAndRestoreHistory

### DIFF
--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -1029,12 +1029,20 @@ The optional argument <A>ret</A> will be passed to <Ref Func="GapExitCode"/>.
 
 
 <ManSection>
-<Func Name="InstallAtExit" Arg='func'/>
+<Func Name="InstallAtExit" Arg='func, [args]'/>
 <Var Name="QUITTING"/>
 
 <Description>
-Before actually terminating, &GAP; will call (with no arguments) all
-of the functions that have been installed using <Ref Func="InstallAtExit"/>. These
+Before actually terminating, &GAP; will call all
+of the functions that have been installed using <Ref Func="InstallAtExit"/>.
+If the optional parameter <A>args</A> was given, then it is passed as the list
+of argmuments to <A>func</A> when it is executed.
+Otherwise <A>func</A> is executed without arguments.
+A function can only be installed once via <Ref Func="InstallAtExit"/>.
+All subsequent calls of <Ref Func="InstallAtExit"/> with the same function as
+first argument will be ignored.
+<P/>
+The installed functions
 typically perform tasks such as cleaning up temporary files created
 during the session, and closing open files. If an error occurs during
 the execution of one of these functions, that function is simply

--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -700,28 +700,38 @@ BindKeysToGAPHandler("\022");
 BindGlobal("SaveCommandLineHistory", function(arg)
   local  fnam, append, hist, out;
 
-  if Length(arg) > 0 then
+  if Length(arg) = 1 then
+    if IsString(arg[1]) then
+      fnam := arg[1];
+      append := false;
+    elif arg[1] in [false, true] then
+      append := arg[1];
+    fi;
+  elif Length(arg) = 2 then
     fnam := arg[1];
-  else
+    append := arg[2];
+  elif Length(arg) > 2 then
+    ErrorNoReturn("Usage: SaveCommandLineHistory([fname, ][app])");
+  fi;
+  if not IsBound(fname) then
     if IsExistingFile(GAPInfo.UserGapRoot) then
       fnam := Concatenation(GAPInfo.UserGapRoot, "/history");
     else
       fnam := UserHomeExpand("~/.gap_hist");
     fi;
   fi;
-  if true in arg then
-    append := true;
-  else
-    append := false;
-  fi;
   hist := GAPInfo.History.Lines;
+  hist := hist{[GAPInfo.History.StartPosition + 1
+                .. Length(GAPInfo.History.Lines)]};
   out := OutputTextFile(fnam, append);
   if out = fail then
     return fail;
   fi;
   SetPrintFormattingStatus(out, false);
   WriteAll(out,JoinStringsWithSeparator(hist,"\n"));
-  WriteAll(out,"\n");
+  if Length(hist) > 0 then
+    WriteAll(out,"\n");
+  fi;
   CloseStream(out);
   return Length(hist);
 end);

--- a/lib/init.g
+++ b/lib/init.g
@@ -763,8 +763,8 @@ end );
 ##  
 CallAndInstallPostRestore( function()
   if UserPreference("SaveAndRestoreHistory") = true then
-    InstallAtExit(SaveCommandLineHistory);
-    ReadCommandLineHistory();
+    InstallAtExit(SaveCommandLineHistory, [true]);
+    GAPInfo.History.StartPosition := ReadCommandLineHistory();
   fi;
 end );
 

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1672,15 +1672,17 @@ end );
 ##
 #F  InstallAtExit( <func> ) . . . . . . . . . . function to call when exiting
 ##
-BIND_GLOBAL( "InstallAtExit", function( func )
-    local f;
+BIND_GLOBAL( "InstallAtExit", function( func, args... )
+    local f, arguments;
+    if LEN_LIST(args) > 1 then
+        Error("Usage: InstallAtExit(func[, args])");
+    elif LEN_LIST(args) = 1 then
+        arguments := args[1];
+    else
+        arguments := [];
+    fi;
     if not IS_FUNCTION(func)  then
         Error( "<func> must be a function" );
-    fi;
-    if CHECK_INSTALL_METHOD  then
-        if not NARG_FUNC(func) in [ -1, 0 ]  then
-            Error( "<func> must accept zero arguments" );
-        fi;
     fi;
     # Return if function has already been installed
     # Use this long form to support both List and AtomicList
@@ -1690,6 +1692,7 @@ BIND_GLOBAL( "InstallAtExit", function( func )
         fi;
     od;
     ADD_LIST( GAPInfo.AtExitFuncs, func );
+    ADD_LIST( GAPInfo.AtExitArgs, arguments );
 end );
 
 

--- a/lib/session.g
+++ b/lib/session.g
@@ -25,19 +25,29 @@ InstallAtExit( function()
 end);
 
 BIND_GLOBAL("PROGRAM_CLEAN_UP", function()
-    local f, funcs;
+    local funcs, arguments, f, a;
     if IsBound( GAPInfo.AtExitFuncs ) and IsList( GAPInfo.AtExitFuncs ) then
         if IsHPCGAP then
             funcs := FromAtomicList(GAPInfo.AtExitFuncs);
+            arguments := FromAtomicList(GAPInfo.AtExitArgs);
         else
             funcs := GAPInfo.AtExitFuncs;
+            arguments := GAPInfo.AtExitArgs;
         fi;
         while not IsEmpty(funcs) do
             f := Remove(funcs);
+            # funcs and arguments should have the same length
+            if IsEmpty(arguments) then
+                ErrorNoReturn("GAPInfo.AtExitArgs corrupt!");
+            fi;
+            a := Remove(arguments);
             if IsFunction(f) then
-                CALL_WITH_CATCH(f,[]);
+                CALL_WITH_CATCH(f, a);
             fi;
         od;
+        if not IsEmpty(arguments) then
+            ErrorNoReturn("GAPInfo.AtExitArgs corrupt!");
+        fi;
     fi;
 end);
 

--- a/lib/system.g
+++ b/lib/system.g
@@ -43,6 +43,7 @@ BIND_GLOBAL( "GAPInfo", rec(
 
     # caches of functions that are needed also with a workspace
     AtExitFuncs:= [],
+    AtExitArgs:= [],
     PostRestoreFuncs:= [],
 
     TestData:= rec(),
@@ -180,6 +181,7 @@ if IsHPCGAP then
     GAPInfo := AtomicRecord(GAPInfo);
     MakeReadOnlyGVar("GAPInfo");
     GAPInfo.AtExitFuncs:= AtomicList([]);
+    GAPInfo.AtExitArgs:= AtomicList([]);
     GAPInfo.PostRestoreFuncs:= AtomicList([]);
     GAPInfo.TestData:= ThreadLocalRecord( rec() );
     APPEND_LIST_INTR(GAPInfo.CommandLineOptionData, [


### PR DESCRIPTION
Fixes the user preference `SaveAndRestoreHistory` by extending `InstallAtExit` to pass arguments and by fixing the behaviour of `SaveCommandLineHistory`.

The latter promises to either append to or overwrite the line history file with the line history of the current session. Instead it took both the old line history and the line history of the current session, and wrote into or appended it to the line history file.

GAP by default used the overwriting version of `SaveCommandLineHistory`. This led to incorrect history files if two or more gap sessions were started simultaneously. After closing all sessions only the line history of the most recently closed session ended up in the line history file.
