### PR TITLE
define GAP_MakeStringWithLen in libgap

### DIFF
--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -431,6 +431,11 @@ Obj GAP_MakeString(const char * string)
     return MakeString(string);
 }
 
+Obj GAP_MakeStringWithLen(const char * string, UInt len)
+{
+    return MakeStringWithLen(string, len);
+}
+
 Obj GAP_MakeImmString(const char * string)
 {
     return MakeImmString(string);

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -420,6 +420,10 @@ char * GAP_CSTR_STRING(Obj obj);
 // terminated C string.
 Obj GAP_MakeString(const char * string);
 
+// Returns a new mutable GAP string containing a copy of the given
+// C string of given length (in bytes).
+Obj GAP_MakeStringWithLen(const char * string, UInt len);
+
 // Returns a immutable GAP string containing a copy of the given NULL
 // terminated C string.
 Obj GAP_MakeImmString(const char * string);


### PR DESCRIPTION
The functionality is needed in the GAP-Julia integration (see oscar-system/GAP.jl/issues/527), thus it should be part of the libgap interface.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

