### PR TITLE
Performance Enhancements for rewriting

### DIFF
--- a/lib/dict.gi
+++ b/lib/dict.gi
@@ -305,7 +305,7 @@ end);
 #F  NewDictionary(<objcoll>,<look>)
 ##
 InstallGlobalFunction(NewDictionary,function(arg)
-local hashfun,obj,dom,lookup,maxblist;
+local hashfun,obj,dom,lookup,maxblist,forcesort;
   obj:=arg[1];
   lookup:=arg[2];
   if Length(arg)>2 then
@@ -362,8 +362,9 @@ local hashfun,obj,dom,lookup,maxblist;
   fi;
 
   # can we sort the elements cheaply?
-  if CanEasilySortElements(obj) then
-    Info(InfoHash,1,obj," Sort dictionary");
+  forcesort:=ValueOption("usesortdictionary");
+  if forcesort=true or (forcesort<>false and CanEasilySortElements(obj)) then
+    Info(InfoHash,2,obj," Sort dictionary");
     return DictionaryBySort(lookup);
   fi;
 

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -2289,8 +2289,13 @@ local home,e,ser,i,j,k,pcgs,mpcgs,op,m,cs,n;
       pcgs:=InducedPcgs(home,e[i-1]);
       mpcgs:=pcgs mod InducedPcgs(home,e[i]);
       op:=LinearActionLayer(U,GeneratorsOfGroup(U),mpcgs);
-      m:=GModuleByMats(op,GF(RelativeOrderOfPcElement(mpcgs,mpcgs[1])));
-      cs:=MTX.BasesCompositionSeries(m);
+      if ForAll(op,IsOne) then
+        m:=op[1]; # identity
+        cs:=List([0..Length(m)],x->m{[Length(m)+1-x..Length(m)]});
+      else
+        m:=GModuleByMats(op,GF(RelativeOrderOfPcElement(mpcgs,mpcgs[1])));
+        cs:=MTX.BasesCompositionSeries(m);
+      fi;
       Sort(cs,function(a,b) return Length(a)>Length(b);end);
       cs:=cs{[2..Length(cs)]};
       Info(InfoPcGroup,2,Length(cs)-1," compositionFactors");

--- a/lib/pcgsind.gi
+++ b/lib/pcgsind.gi
@@ -447,7 +447,7 @@ InstallMethod( InducedPcgsByGeneratorsWithImages,
 
 function( pcgs, gens, imgs )
     local  ro, max, id, igs, chain, new, seen, old, u, uw, up, e, x, c, 
-           cw, d, i, j, f;
+           cw, d, i, j, f,nonab;
 
     # do family check here to avoid problems with the empty list
     if not IsIdenticalObj( FamilyObj(pcgs), FamilyObj(gens) )  then
@@ -459,6 +459,9 @@ function( pcgs, gens, imgs )
 
     # get the trivial case first
     if gens = AsList( pcgs ) then return [pcgs, imgs]; fi;
+
+    #catch special case: abelian
+    nonab:=not IsAbelian(Group(pcgs,OneOfPcgs(pcgs)));
 
     # get relative orders and composition length
     ro  := RelativeOrders(pcgs);
@@ -521,7 +524,7 @@ function( pcgs, gens, imgs )
                 # add the commutators with the powers of <u>
                 for u in up do
                     for x in igs do
-                        if x[1] <> id[1] 
+                        if nonab and x[1] <> id[1] 
                            and ( DepthOfPcElement(pcgs,x[1]) + 1 < chain
                               or DepthOfPcElement(pcgs,u[1]) + 1 < chain )
                         then
@@ -546,7 +549,8 @@ function( pcgs, gens, imgs )
                     chain := chain-1;
                 od;
 
-                for i  in [ chain .. max ]  do
+                if nonab then
+                  for i  in [ chain .. max ]  do
                     for j  in [ 1 .. chain-1 ]  do
                         c := Comm( igs[i][1], igs[j][1] );
                         if not c in seen  then
@@ -554,7 +558,8 @@ function( pcgs, gens, imgs )
                             AddSet( new, [c, Comm( igs[i][2], igs[j][2] )] );
                         fi;
                     od;
-                od;
+                  od;
+                fi;
             fi;
         od;
     od;

--- a/lib/pcgsmodu.gi
+++ b/lib/pcgsmodu.gi
@@ -221,7 +221,7 @@ InstallMethod( ModuloPcgsByPcSequenceNC, "generic method for pcgs mod pcgs",
 
 function( home, list, modulo )
     local   pcgs,  wm,  wp,  wd,  pcs,  filter,  new,
-    i,depthsInParent,dd,par,
+    i,depthsInParent,dd,par,sel,
     pcsexp,denexp,bascha,idx,sep,sed,mat;
 
     # <list> is a pcgs for the sum of <list> and <modulo>
@@ -381,11 +381,13 @@ function( home, list, modulo )
 	    mat:=Concatenation(pcsexp{sep}{new!.layranges[i]},
 		  denexp{sed}{new!.layranges[i]})*One(dd);
 	    mat:=ImmutableMatrix(dd,mat);
-	    while Length(mat)<Length(mat[1]) do
-	      mat:=Concatenation(mat,[First(IdentityMat(Length(mat[1]),dd),
-		x->SolutionMat(mat,x)=fail)]);
+	    if Length(mat)<Length(mat[1]) then
+              # add identity mat vectors at non-pivot positions
+              sel:=List(TriangulizedMat(mat),PositionNonZero);
+              sel:=Difference([1..Length(mat[1])],sel);
+              mat:=Concatenation(mat,IdentityMat(Length(mat[1]),dd){sel});
 	      mat:=ImmutableMatrix(dd,mat);
-	    od;
+	    fi;;
 	    bascha[i]:=mat^-1;
 	    idx[i]:=[sep,sed];
 	  fi;

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -707,7 +707,8 @@ function(G,mo)
 local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       len1,l2,m,start,formalinverse,hastail,one,zero,new,v1,v2,collectail,
       findtail,colltz,mapped,mapped2,onemat,zerovec,dict,max,mal,s,p,genkill,
-      c,nvars,htpos,zeroq,r,ogens,bds,model,q,pre,pcgs,miso,ker,solvec,rulpos;
+      c,nvars,htpos,zeroq,r,ogens,bds,model,q,pre,pcgs,miso,ker,solvec,rulpos,
+      nonone,predict,lenpre;
 
 
   # collect the word in factor group
@@ -724,7 +725,12 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       mm:=Minimum(mal,Length(a)-i+1);
       while j<mm do
         s:=s*max+a[i+j];
-        p:=LookupDictionary(dict,s);
+        #p:=LookupDictionary(dict,s);
+        if s<=lenpre then
+          p:=predict[s];
+        else
+          p:=LookupDictionary(dict,s);
+        fi;
         if p<>fail then break; fi;
         j:=j+1;
       od;
@@ -745,7 +751,9 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   local a,i;
     a:=onemat;
     for i in list do
-      a:=a*mats[i];
+      if i in nonone then
+        a:=a*mats[i];
+      fi;
     od;
     return a;
   end;
@@ -765,7 +773,12 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       mm:=Minimum(mal,Length(wrd)-i+1);
       while j<mm do
         s:=s*max+wrd[i+j];
-        p:=LookupDictionary(dict,s);
+        #p:=LookupDictionary(dict,s);
+        if s<=lenpre then
+          p:=predict[s];
+        else
+          p:=LookupDictionary(dict,s);
+        fi;
         if p<>fail and rulpos[p]<>fail then break; fi;
         j:=j+1;
       od;
@@ -818,6 +831,8 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   max:=Maximum(Union(List(tzrules,x->x[1])))+1;
   mal:=Maximum(List(tzrules,x->Length(x[1])));
   dict:=NewDictionary(max,Integers,true);
+  lenpre:=20000;
+  predict:=ListWithIdenticalEntries(lenpre,fail);
   for i in [1..mal] do
     p:=Filtered([1..Length(tzrules)],x->Length(tzrules[x][1])=i);
     for j in p do
@@ -825,7 +840,11 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       for k in [1..i] do
         s:=s*max+tzrules[j][1][k];
       od;
-      AddDictionary(dict,s,j);
+      if s<=lenpre then
+        predict[s]:=j;
+      else
+        AddDictionary(dict,s,j);
+      fi;
     od;
   od;
 
@@ -918,6 +937,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     mats:=List(GeneratorsOfMonoid(mon),
       x->ImagesRepresentative(m,
       PreImagesRepresentative(fm,x))); #Elements for monoid generators
+    nonone:=[1..Length(mats)];
     pre:=mats;
     onemat:=One(G);
     for i in [1..Length(hastail)] do
@@ -935,6 +955,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     x->ImagesRepresentative(hom,PreImagesRepresentative(fp,
     PreImagesRepresentative(fm,x)))); # matrices for monoid generators
   one:=One(mats[1]);
+  nonone:=Filtered([1..Length(mats)],x->not IsOne(mats[x]));
   zero:=zerovec;
   dim:=Length(zero);
   nvars:=dim*Length(hastail); #Number of variables
@@ -1090,7 +1111,11 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       mm:=Minimum(mal,Length(wrd)-i+1);
       while j<mm do
         s:=s*max+wrd[i+j];
-        p:=LookupDictionary(dict,s);
+        if s<=lenpre then
+          p:=predict[s];
+        else
+          p:=LookupDictionary(dict,s);
+        fi;
         if p<>fail and rulpos[p]<>fail then break; fi;
         j:=j+1;
       od;
@@ -1165,7 +1190,12 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
         mm:=Minimum(mal,Length(wrd)-i+1);
         while j<mm do
           s:=s*max+wrd[i+j];
-          p:=LookupDictionary(dict,s);
+          #p:=LookupDictionary(dict,s);
+          if s<=lenpre then
+            p:=predict[s];
+          else
+            p:=LookupDictionary(dict,s);
+          fi;
           if p<>fail and rulpos[p]<>fail then break; fi;
           j:=j+1;
         od;

--- a/tst/teststandard/pcgrp.tst
+++ b/tst/teststandard/pcgrp.tst
@@ -1,0 +1,11 @@
+gap> START_TEST("pcgrp.tst");
+
+# big abelian groups
+gap> g:=AbelianGroup(ListWithIdenticalEntries(200,3));;
+gap> p:=Pcgs(g);;
+gap> hom:=GroupHomomorphismByImages(g,g,p,Reversed(p));;
+gap> Inverse(hom);;
+gap> p mod InducedPcgsByPcSequence(p,p{[1..100]});;
+
+#############################################################################
+gap> STOP_TEST( "pcgrp.tst", 1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -22,6 +22,9 @@ gap> g:=SymmetricGroup(13);;s:=SylowSubgroup(g,13);;
 gap> ac:=AscendingChain(g,s);;
 gap> Maximum(List([2..Length(ac)],x->Index(ac[x],ac[x-1])))<600000;
 true
+gap> g:=SymmetricGroup(5);;p:=SylowSubgroup(g,5);;
+gap> Length(IntermediateSubgroups(g,p).subgroups);
+3
 gap> g:=SL(6,2);;
 gap> p:=Image(IsomorphismPermGroup(g));;
 gap> s:=SylowSubgroup(p,7);;


### PR DESCRIPTION
Performance Enhancements (mostly motivated by work with extensions) for larger cases. They are too minor to merit special mention in the release notes:

- Avoid unneccessary checks when computing a RWS for a group
- Improvements in computing induced/modulo PCGS if the groups are abelian of high (hundreds) rank
- Minor speedup of cohomology (if there are many generators)

I would like them to still go into 4.12, as they will help with examples for a paper -- thus listed as high priority