### PR TITLE
support a new command line option `systemfile`

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -574,7 +574,10 @@ end);
 ##
 #T really ???
 
-if GAPInfo.CommandLineOptions.systemfile <> "" and
-   IsReadableFile( GAPInfo.CommandLineOptions.systemfile ) then
-  READ( GAPInfo.CommandLineOptions.systemfile );
+if GAPInfo.CommandLineOptions.systemfile <> ""
+   and not READ( GAPInfo.CommandLineOptions.systemfile ) then
+  PRINT_TO( "*errout*", "Could not read file \"",
+            GAPInfo.CommandLineOptions.systemfile,
+            "\" (command line option --systemfile).\n" );
+  QuitGap(1);
 fi;

--- a/lib/system.g
+++ b/lib/system.g
@@ -111,6 +111,8 @@ BIND_GLOBAL( "GAPInfo", rec(
            help := [ "Disable the GAP read-evaluate-print loop (REPL)" ] ),
       rec( long := "nointeract", default := false,
            help := [ "Start GAP in non-interactive mode (disable REPL", "and break loop)" ] ),
+      rec( long := "systemfile", default := "",
+           help := [ "Read this file after 'lib/system.g'" ] ),
       rec( long := "bare", default := false,
            help := [ "Attempt to start GAP without even needed packages", "(developer tool)" ] ),
       ,
@@ -571,3 +573,8 @@ end);
 ##  </ManSection>
 ##
 #T really ???
+
+if GAPInfo.CommandLineOptions.systemfile <> "" and
+   IsReadableFile( GAPInfo.CommandLineOptions.systemfile ) then
+  READ( GAPInfo.CommandLineOptions.systemfile );
+fi;


### PR DESCRIPTION
... which allows one to read a given file during GAP's initialization,
after the file `lib/system.g` has been read.

The idea is that at this point, the command line options have been
evaluated, and it is a suitable place for customizing the GAP session
beyond command line options.
The motivation for this proposal is oscar-system/GAP.jl/issues/518,
see the discussion there for the background.

P.S.:
Each of the files `lib/system.g` and `src/system.c` claims that the
command line options listed there must be kept in sync with those listed
in the other file.
Apparently they are aleady out of sync.
If the claims are still relevant then of course
the new command line option should be mentioned also in `src/system.c`.