### PR TITLE
kernel: fix GetLine2 to correctly check for a stringrep

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -954,7 +954,7 @@ static Int GetLine2(TypInputFile * input)
 
     if ( input->isstream ) {
         if (input->sline == 0 ||
-            (IS_STRING(input->sline) &&
+            (IS_STRING_REP(input->sline) &&
              GET_LEN_STRING(input->sline) <= input->spos)) {
             input->sline = CALL_1ARGS( ReadLineFunc, input->stream );
             input->spos  = 0;


### PR DESCRIPTION
If input->sline somehow ever is turned into a string not in stringrep, the old
code could hypothetically run into a crash or worse, data corruption (which
would most likely quickly be detected due to resulting syntax errors etc.).

In practice, I don't think we can ever reach this code in such a situation,
but I might be wrong, and also future changes to the code might change this,
so let's fix this anyway.
