### PR TITLE
Disable automatic compression of .gz files in stable-4.11 again

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -851,7 +851,7 @@ Int SyFopen (
 #endif
 
     /* try to open the file                                                */
-    if (endsgz && (syBuf[fid].gzfp = gzopen(name, mode))) {
+    if (*mode == 'r' && endsgz && (syBuf[fid].gzfp = gzopen(name, mode))) {
         syBuf[fid].type = gzip_socket;
         syBuf[fid].fp = -1;
         syBuf[fid].bufno = -1;

--- a/tst/testinstall/compressed.tst
+++ b/tst/testinstall/compressed.tst
@@ -17,9 +17,9 @@ gap> str := "hello\ngoodbye\n";;
 gap> FileString( fname, str ) = Length(str);
 true
 
-# Check file really is compressed
+# Check file really is compressed (FIXME: disabled in stable-4.11)
 gap> isGzippedFile(dir, "test.g.gz");
-true
+false
 
 # Check reading compressed file
 gap> StringFile( fname ) = str;
@@ -76,7 +76,7 @@ gap> CloseStream(stream);
 gap> stream;
 closed-stream
 gap> isGzippedFile(dir, "test.g.gz");
-true
+false
 
 # verify it
 gap> stream := InputTextFile( fname );;


### PR DESCRIPTION
This caused a regression in PackageManager and possibly elsewhere; so it is not suitable for the stable-4.11 branch. To clarify: this feature was *not* in GAP 4.11.0, we just backported it there. This PR adjusts that backport: we retain the improved to reading .gz files, but not the new behavior for automatically compression every file whose name ends with .gz.

See also discussion in PR #4128