### PR TITLE
improve the documentation concerning GASMAN; add CollectGarbage

### DIFF
--- a/doc/dev/kernel.xml
+++ b/doc/dev/kernel.xml
@@ -368,6 +368,29 @@ which does exactly this.
 
 </Subsection>
 
+<Subsection Label="The GASMAN Interface for Weak Pointer Objects">
+<Heading>The GASMAN Interface for Weak Pointer Objects</Heading>
+
+The key support for weak pointers is in the files <F>src/gasman.c</F> and
+<F>src/gasman.h</F>.
+This document assumes familiarity with the rest of the operation of GASMAN.
+A kernel type (tnum) of bags which are intended to act as weak pointers to
+their subobjects must meet three conditions.
+Firstly, the marking function installed for that tnum must use
+<C>MarkBagWeakly</C> for those subbags, rather than <C>MarkBag</C>.
+Secondly, before any access to such a subbag, it must be checked with
+<C>IsWeakDeadBag</C>.
+If that returns <K>true</K>, then the subbag has evaporated in a recent garbage
+collection and must not be accessed.
+Typically the reference to it should be removed.
+Thirdly, a <E>sweeping function</E> must be installed for that tnum
+which copies the bag, removing all references to dead weakly held subbags.
+<P/>
+The files <F>src/weakptr.c</F> and <F>src/weakptr.h</F> use this interface
+to support weak pointer objects.
+Other objects with weak behaviour could be implemented in a similar way.
+
+</Subsection>
 
 </Section>
 

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -1032,18 +1032,31 @@ Segmentation fault
 <Section Label="Global Memory Information">
 <Heading>Global Memory Information</Heading>
 
+<Subsection Label="Garbage Collection">
+<Heading>Garbage Collection</Heading>
+
 <Index Key="GASMAN"><C>GASMAN</C></Index>
 
 The &GAP; environment provides automatic memory management, so that
 the programmer does not need to concern themselves with allocating
 space for objects, or recovering space when objects are no longer
-needed. The component of the kernel which provides this is called
-<C>GASMAN</C> (&GAP; Storage MANager).  Messages reporting garbage
+needed.
+The memory manager that shall be used by &GAP; is specified at compile time.
+One of the choices is called <C>GASMAN</C> (&GAP; Storage MANager).
+(The name of the currently used garbage collector is stored in the
+variable <C>GAPInfo.KernelInfo.GC</C>.)
+
+<P/>
+
+If <C>GASMAN</C> is running then messages reporting garbage
 collections performed by <C>GASMAN</C> can be switched on
 by the <C>-g</C> command
 line option (see section <Ref Sect="Command Line Options"/>).
 There are also some
-facilities to access information from <C>GASMAN</C> from &GAP; programs.
+facilities to access information from <C>GASMAN</C> from &GAP; programs,
+see below.
+
+</Subsection>
 
 <#Include Label="GasmanStatistics">
 <#Include Label="GasmanMessageStatus">

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -1048,7 +1048,7 @@ variable <C>GAPInfo.KernelInfo.GC</C>.)
 
 <P/>
 
-If <C>GASMAN</C> is running then messages reporting garbage
+If &GAP; uses <C>GASMAN</C> then messages reporting garbage
 collections performed by <C>GASMAN</C> can be switched on
 by the <C>-g</C> command
 line option (see section <Ref Sect="Command Line Options"/>).
@@ -1058,6 +1058,7 @@ see below.
 
 </Subsection>
 
+<#Include Label="CollectGarbage">
 <#Include Label="GasmanStatistics">
 <#Include Label="GasmanMessageStatus">
 <#Include Label="GasmanLimits">

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -1062,7 +1062,8 @@ different action may be appropriate.
 If, when &GAP; is exiting due to a <K>quit</K> or end-of-file (i.e. not due
 to a <K>QUIT</K>) the variable <Ref Var="SaveOnExitFile"/> is bound
 to a string value,
-then the system will try to save the workspace to that file.
+then the system will try to save the &GAP; workspace to that file,
+see <Ref Func="SaveWorkspace"/>.
 </Description>
 </ManSection>
 

--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -54,7 +54,7 @@ and to <C>gap -b -q -b -q</C> etc.
 &GAP; for UNIX will distinguish between upper and lower case options.
 <P/>
 As described in the &GAP; installation instructions (see the 
-<F>INSTALL</F> file in the &GAP; root directory, or at
+<F>INSTALL.md</F> file in the &GAP; root directory, or at
 <URL>https://www.gap-system.org/Download/INSTALL</URL>),
 usually you will not execute &GAP; directly. Instead  you  will
 call a (shell) script, with the name <C>gap</C>, which in turn executes  &GAP;.
@@ -155,6 +155,8 @@ toggle; you must use <C>-n</C> to disable line editing.
 <Item>
 tells &GAP; to print a message every  time  a  full  garbage
 collection is performed.
+(This is available only if the <C>GASMAN</C> garbage collector is used,
+see <Ref Subsect="Garbage Collection"/>.)
 <P/>
 <Log><![CDATA[
 #G  FULL 44580/2479kb live   57304/4392kb dead   734/4096kb free
@@ -169,8 +171,10 @@ reclaimed by it, and that 734 kilobytes from a  total  allocated  memory  of
 <C>-g -g</C></Mark>
 <Item>
 If you give the option <C>-g</C> twice, &GAP; prints  a  information  message
-every time a  partial  or  full  garbage  collection  is  performed.  The
-message,
+every time a  partial  or  full  garbage  collection  is  performed.
+(This is available only if the <C>GASMAN</C> garbage collector is used,
+see <Ref Subsect="Garbage Collection"/>.)
+The message,
 <P/>
 <Log><![CDATA[
 #G  PART 9405/961kb+live   7525/1324kb+dead   2541/4096kb free
@@ -202,6 +206,8 @@ switched off. You have to set it explicitly when you want to enable it.
 <Item>
 The option <C>-L</C> tells &GAP; to load a saved workspace. See
 section&nbsp;<Ref Sect="Saving and Loading a Workspace"/>.
+(This is available only if the <C>GASMAN</C> garbage collector is used,
+see <Ref Subsect="Garbage Collection"/>.)
 </Item>
 <Mark><Index Key="-l"><C>-l</C></Index>
 <C>-l </C><A>path_list</A></Mark>
@@ -530,6 +536,10 @@ which GAP will not recognize.
 
 &GAP; workspace files are binary files that contain the data of a &GAP;
 session.
+Currently saving and loading workspace files are supported only when the
+<C>GASMAN</C> garbage collector is used,
+see Section <Ref Subsect="Garbage Collection"/>.
+<P/>
 One can produce a workspace file with <Ref Func="SaveWorkspace"/>,
 and load it into a new &GAP; session using the <C>-L</C> command line option,
 see Section <Ref Sect="Command Line Options"/>.

--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -54,8 +54,7 @@ and to <C>gap -b -q -b -q</C> etc.
 &GAP; for UNIX will distinguish between upper and lower case options.
 <P/>
 As described in the &GAP; installation instructions (see the 
-<F>INSTALL.md</F> file in the &GAP; root directory, or at
-<URL>https://www.gap-system.org/Download/INSTALL</URL>),
+<F>INSTALL.md</F> file in the &GAP; root directory),
 usually you will not execute &GAP; directly. Instead  you  will
 call a (shell) script, with the name <C>gap</C>, which in turn executes  &GAP;.
 This  script sets some options which are necessary  to  make  &GAP;

--- a/doc/ref/weakptr.xml
+++ b/doc/ref/weakptr.xml
@@ -17,8 +17,9 @@ This chapter describes the use of the kernel feature of <E>weak pointers</E>.
 This feature is primarily intended for use only in &GAP; internals, and
 should be used extremely carefully otherwise.
 <P/>
-The GASMAN garbage collector is the part of the kernel that manages memory in
-the users workspace.  It will  normally only reclaim  the storage used by  an
+The garbage collector (see Section <Ref Subsect="Garbage Collection"/>)
+is the part of the kernel that manages memory in the user's workspace.
+It will  normally only reclaim  the storage used by  an
 object when the object cannot be reached as a subobject of any &GAP; variable,
 or from any reference in the kernel.
 We say that any link to object <M>a</M> from object <M>b</M>

--- a/doc/ref/weakptr.xml
+++ b/doc/ref/weakptr.xml
@@ -67,11 +67,11 @@ are not referenced by other objects than <C>w</C>,
 and that therefore these entries may disappear.
 <P/>
 <Log><![CDATA[
-gap> GASMAN("collect");
+gap> CollectGarbage( true );
 
 ... (perhaps more computations and garbage collections) ...
 
-gap> GASMAN("collect");
+gap> CollectGarbage( true );
 gap> w;
 WeakPointerObj( [ 1, , , fail ] )
 ]]></Log>
@@ -94,7 +94,7 @@ gap> l := [1,2,3];;
 gap> w[1] := l;;
 gap> w;
 WeakPointerObj( [ [ 1, 2, 3 ], , , fail ] )
-gap> GASMAN("collect");
+gap> CollectGarbage( true );
 gap> w;                
 WeakPointerObj( [ [ 1, 2, 3 ], , , fail ] )
 ]]></Example>
@@ -166,7 +166,7 @@ fail
 Now after some computations and garbage collections <M>\ldots</M>
 <P/>
 <Example><![CDATA[
-gap> 2;;3;;4;;GASMAN("collect"); # clear last, last2, last3
+gap> 2;; 3;; 4;; CollectGarbage( true );  # clear last, last2, last3
 ]]></Example>
 <P/>
 <M>\ldots</M> we get the following.
@@ -226,32 +226,6 @@ produces an immutable plain
 list containing immutable copies of the objects contained in the weak pointer
 object. An immutable weak pointer object is a contradiction in terms.
  
-</Section>
- 
- 
-<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
-<Section Label="The GASMAN Interface for Weak Pointer Objects">
-<Heading>The GASMAN Interface for Weak Pointer Objects</Heading>
-
-The key support for weak pointers is in the files <F>src/gasman.c</F> and
-<F>src/gasman.h</F>.
-This document assumes familiarity with the rest of the operation of GASMAN.
-A kernel type (tnum) of bags which are intended to act as weak pointers to
-their subobjects must meet three conditions.
-Firstly, the marking function installed for that tnum must use
-<C>MarkBagWeakly</C> for those subbags, rather than <C>MarkBag</C>.
-Secondly, before any access to such a subbag, it must be checked with
-<C>IsWeakDeadBag</C>.
-If that returns <K>true</K>, then the subbag has evaporated in a recent garbage
-collection and must not be accessed.
-Typically the reference to it should be removed.
-Thirdly, a <E>sweeping function</E> must be installed for that tnum
-which copies the bag, removing all references to dead weakly held subbags.
-<P/>
-The files <F>src/weakptr.c</F> and <F>src/weakptr.h</F> use this interface
-to support weak pointer objects.
-Other objects with weak behaviour could be implemented in a similar way.
-
 </Section>
 </Chapter>
 

--- a/lib/gasman.gd
+++ b/lib/gasman.gd
@@ -12,6 +12,44 @@
 ##  the GASMAN garbage collector.
 ##
 
+
+#############################################################################
+##
+#F  CollectGarbage( <full> )
+##
+##  <#GAPDoc Label="CollectGarbage">
+##  <ManSection>
+##  <Func Name="CollectGarbage" Arg='full'/>
+##
+##  <Returns>
+##  nothing.
+##  </Returns>
+##  <Description>
+##  This function forces a garbage collection.
+##  If <A>full</A> is <K>true</K> then it triggers a full garbage collection,
+##  otherwise a partial one.
+##  <P/>
+##  &GAP; invokes its garbage collector automatically, thus there is normally
+##  no need to call <Ref Func="CollectGarbage"/>.
+##  <P/>
+##  The function <Ref Func="CollectGarbage"/> was introduced in
+##  &GAP;&nbsp;4.12.
+##  In older &GAP; versions,
+##  one can use <C>GASMAN( "collect" )</C> (if <A>full</A> is <K>true</K>)
+##  or <C>GASMAN( "partial" )</C> (if <A>full</A> is not <K>true</K>)
+##  instead.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> CollectGarbage( false );
+##  gap> CollectGarbage( true );
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("CollectGarbage");
+
+
 #############################################################################
 ##
 #F  GasmanStatistics( )

--- a/lib/gasman.gd
+++ b/lib/gasman.gd
@@ -21,6 +21,10 @@
 ##  <Func Name="GasmanStatistics" Arg=''/>
 ##
 ##  <Description>
+##  This function is meaningful only if <C>GASMAN</C> is
+##  the garbage collector used by &GAP;,
+##  see Section <Ref Subsect="Garbage Collection"/>.
+##  <P/>
 ##  <Ref Func="GasmanStatistics"/> returns a record containing some
 ##  information from the garbage collection mechanism.
 ##  The record may contain up to four components:
@@ -77,6 +81,10 @@ DeclareGlobalFunction("GasmanStatistics");
 ##  <Func Name="SetGasmanMessageStatus" Arg='stat'/>
 ##
 ##  <Description>
+##  This function is meaningful only if <C>GASMAN</C> is
+##  the garbage collector used by &GAP;,
+##  see Section <Ref Subsect="Garbage Collection"/>.
+##  <P/>
 ##  <Ref Func="GasmanMessageStatus"/> returns one of the strings
 ##  <C>"none"</C>, <C>"full"</C>, or <C>"all"</C>,
 ##  depending on whether the garbage collector is currently set to print
@@ -103,13 +111,17 @@ DeclareGlobalFunction("SetGasmanMessageStatus");
 ##  <Func Name="GasmanLimits" Arg=''/>
 ##
 ##  <Description>
+##  This function is meaningful only if <C>GASMAN</C> is
+##  the garbage collector used by &GAP;,
+##  see Section <Ref Subsect="Garbage Collection"/>.
+##  <P/>
 ##  <Ref Func="GasmanLimits"/> returns a record with three components:
 ##  <C>min</C> is the minimum workspace size as set by the <C>-m</C>
 ##  command line option in kilobytes.
 ##  The workspace size will never be reduced below this by the garbage
 ##  collector.
 ##  <C>max</C> is the maximum workspace size,
-##  as set by the '-o' command line option, also in kilobytes.
+##  as set by the <C>-o</C> command line option, also in kilobytes.
 ##  If the workspace would need to grow past this point,
 ##  &GAP; will enter a break loop to warn the user.
 ##  A value of 0 indicates no limit.

--- a/lib/gasman.gi
+++ b/lib/gasman.gi
@@ -67,6 +67,11 @@ end );
 InstallGlobalFunction(SetGasmanMessageStatus,
         function(stat)
     local oldstat,newstat,i;
+    if GAPInfo.KernelInfo.GC <> "GASMAN" and stat <> "none" then
+      Info( InfoWarning, 1,
+            "SetGasmanMessageStatus makes sense only if GASMAN is running" );
+      return;
+    fi;
     oldstat := GASMAN_MESSAGE_STATUS();
     newstat := Position(["none", "full", "all"], stat);
     if newstat = fail then

--- a/lib/gasman.gi
+++ b/lib/gasman.gi
@@ -11,6 +11,22 @@
 ##  This file contains implementations of functions that report information from the
 ##  GASMAN garbage collector
 ##
+
+
+#############################################################################
+##
+#F  CollectGarbage( <full> )
+##
+##  This function works *not* only if GAP uses GASMAN.
+##
+InstallGlobalFunction( CollectGarbage, function( full )
+    if full then
+      GASMAN( "collect" );
+    else
+      GASMAN( "partial" );
+    fi;
+end );
+
 #############################################################################
 ##
 #F  GasmanStatistics( )

--- a/lib/init.g
+++ b/lib/init.g
@@ -352,6 +352,16 @@ if IsHPCGAP then
   ENABLE_AUTO_RETYPING();
 fi;
 
+
+#############################################################################
+##
+##  The command line option '-L' is supported only if GASMAN is used.
+##
+if "-L" in GAPInfo.SystemCommandLine and GAPInfo.KernelInfo.GC <> "GASMAN" then
+  Error( "workspaces (-L option) are supported only if GASMAN is used" );
+fi;
+
+
 # try to find terminal encoding
 CallAndInstallPostRestore( function()
   local env, pos, enc, a, PositionSublist;

--- a/lib/system.g
+++ b/lib/system.g
@@ -66,14 +66,14 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "y", long := "lines", default := "", arg := "<num>", help := ["set number of lines"] ),
       ,
       rec( short:= "g", long := "gasinfo", default := 0,
-           help := ["show GASMAN messages (full/all/no garbage","collections)", "(available only if GASMAN is running)"] ),
+           help := ["show GASMAN messages (full/all/no garbage","collections)", "(only available if GAP uses GASMAN)"] ),
       rec( short:= "m", long := "minworkspace", default := "128m", arg := "<mem>",
            help := ["set the initial workspace size"] ),
       rec( short:= "o", long := "maxworkspace", default := "2g", arg := "<mem>",
-           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)", "(available only if GASMAN is running)"] ),
+           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)", "(available only if GAP uses GASMAN)"] ),
       rec( short:= "K", long := "limitworkspace", default := "0", arg := "<mem>",
            help := [ "set maximal workspace size (GAP never", "allocates more)"] ),
-      rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory", "(available only if GASMAN is running)" ] ),
+      rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory", "(available only if GAP uses GASMAN)" ] ),
       rec( short:= "a", default := "0",  arg := "<mem>",help := [ "set amount to pre-malloc-ate",
              "postfix 'k' = *1024, 'm' = *1024*1024,", "'g' = *1024*1024*1024"] ),
       ,
@@ -93,7 +93,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( long := "alwaystrace", default := false, help := ["always print error traceback", "(overrides behaviour of -T)"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead", "of entering break loop"]),
       ,
-      rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace", "(available only if GASMAN is running)"] ),
+      rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace", "(available only if GAP uses GASMAN)"] ),
       rec( short:= "R", default := false, help := ["prevent restoring of workspace (ignoring -L)"] ),
       ,
       rec( short:= "p", default := false, help := ["enable/disable package output mode"] ),
@@ -390,7 +390,7 @@ CallAndInstallPostRestore( function()
     # use the same as the kernel
     CommandLineOptions.E:= GAPInfo.KernelInfo.HAVE_LIBREADLINE;
 
-    # -L is valid only if GASMAN is running.
+    # -L is valid only if GAP uses GASMAN.
     if GAPInfo.KernelInfo.GC <> "GASMAN" then
       CommandLineOptions.L:= "";
     fi;

--- a/lib/system.g
+++ b/lib/system.g
@@ -66,14 +66,14 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( short:= "y", long := "lines", default := "", arg := "<num>", help := ["set number of lines"] ),
       ,
       rec( short:= "g", long := "gasinfo", default := 0,
-           help := ["show GASMAN messages (full/all/no garbage","collections)"] ),
+           help := ["show GASMAN messages (full/all/no garbage","collections)", "(available only if GASMAN is running)"] ),
       rec( short:= "m", long := "minworkspace", default := "128m", arg := "<mem>",
            help := ["set the initial workspace size"] ),
       rec( short:= "o", long := "maxworkspace", default := "2g", arg := "<mem>",
-           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)"] ),
+           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)", "(available only if GASMAN is running)"] ),
       rec( short:= "K", long := "limitworkspace", default := "0", arg := "<mem>",
            help := [ "set maximal workspace size (GAP never", "allocates more)"] ),
-      rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory" ] ),
+      rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory", "(available only if GASMAN is running)" ] ),
       rec( short:= "a", default := "0",  arg := "<mem>",help := [ "set amount to pre-malloc-ate",
              "postfix 'k' = *1024, 'm' = *1024*1024,", "'g' = *1024*1024*1024"] ),
       ,
@@ -93,7 +93,7 @@ BIND_GLOBAL( "GAPInfo", rec(
       rec( long := "alwaystrace", default := false, help := ["always print error traceback", "(overrides behaviour of -T)"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead", "of entering break loop"]),
       ,
-      rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),
+      rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace", "(available only if GASMAN is running)"] ),
       rec( short:= "R", default := false, help := ["prevent restoring of workspace (ignoring -L)"] ),
       ,
       rec( short:= "p", default := false, help := ["enable/disable package output mode"] ),
@@ -111,7 +111,7 @@ BIND_GLOBAL( "GAPInfo", rec(
            help := [ "Disable the GAP read-evaluate-print loop (REPL)" ] ),
       rec( long := "nointeract", default := false,
            help := [ "Start GAP in non-interactive mode (disable REPL", "and break loop)" ] ),
-      rec( long := "systemfile", default := "",
+      rec( long := "systemfile", default := "", arg := "<file>",
            help := [ "Read this file after 'lib/system.g'" ] ),
       rec( long := "bare", default := false,
            help := [ "Attempt to start GAP without even needed packages", "(developer tool)" ] ),
@@ -389,6 +389,11 @@ CallAndInstallPostRestore( function()
     CommandLineOptions.g:= CommandLineOptions.g mod 3;
     # use the same as the kernel
     CommandLineOptions.E:= GAPInfo.KernelInfo.HAVE_LIBREADLINE;
+
+    # -L is valid only if GASMAN is running.
+    if GAPInfo.KernelInfo.GC <> "GASMAN" then
+      CommandLineOptions.L:= "";
+    fi;
 
     # --nointeract implies no break loop and no repl
     if CommandLineOptions.nointeract then

--- a/lib/wpobj.gd
+++ b/lib/wpobj.gd
@@ -17,7 +17,7 @@
 ##  gap> w := WeakPointerObj([[1,2]]);;
 ##  gap> IsBound(w[1]);
 ##  true
-##  gap> GASMAN("collect");
+##  gap> CollectGarbage( true );
 ##  gap> w;
 ##  WeakPointerObj([ [ ] ]);
 ##

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -591,8 +591,8 @@ Obj SaveWorkspace( Obj fname )
 *F  LoadWorkspace( <fname> )  . . . . .  load the workspace to the named file
 **
 **  'LoadWorkspace' is the entry point to the workspace saving. It is not
-**  installed as a GAP function, but instead called from InitGap when the
-**  -L commad-line flag is given
+**  installed as a GAP function, but instead called from InitializeGap when
+**  the -L command-line flag is given
 **
 **  The file saveload.tex in the dev directory describes the saved format
 **  in more detail. Most of the work will be done from inside GASMAN, because


### PR DESCRIPTION
GAP can use several garbage collectors (GASMAN, the Julia garbage collector, and the Boehm garbage collector).
Up to now, the GAP documentation mentions only GASMAN.
Several GAP functions make sense only if GASMAN is running, and several command line options make sense only in this case.

The proposed changes try to adjust the documentation to situations where GASMAN is not used.
(More changes in this direction will be needed, below is a list of open questions.)

**Details of the changes**:

- In `debug.xml`, section "Global Memory Information",
  moved the introductory part to a new subsection "Garbage Collection"
  that can be cross-referenced from places where garbage collection
  is mentioned;
  mention in this subsection that several garbage collectors
  can be used by GAP.

- In the functions `GasmanStatistics`, `GasmanMessageStatus`,
  `GasmanLimits`, mention that they work only if GASMAN is running.

- In `run.xml`, section "Saving and Loading a Workspace",
  mention that workspaces can be saved/loaded only if GASMAN is running.

- Added a cross-reference from `SaveOnExitFile` to `SaveWorkspace`.

- Changed the description of GAP's command line options:
  - In `run.xml`, mention that the options `-g`, `-L`, `-o`, `-s`
    are available only if GASMAN is used.
  - Do the same in `system.g`, variable `GAPInfo.CommandLineOptionData`.
    (I had thought about omitting the not supported options from the
    list, but such a filtered list might confuse users who want to
    understand why their options did not work as expected.)

- Call `GASMAN( "message" )` in `SetGasmanMessageStatus`
  only if GASMAN is running, in order to avoid an error message.

- In chapter "Weak Pointers", removed the word GASMAN in the introduction
  and added a reference to "Garbage Collection".
  (Weak pointer objects work also with other garbage collectors than
  GASMAN.)

**Open questions**:

- The command line options `-K` and `-m` are evaluated also when the
  Julia GC is running, but are their values really used?

- The introduction of the section "Command Line Options" refers to a file
  https://www.gap-system.org/Download/INSTALL which exists but seems to
  be outdated --which URL should be given here?
  (The corresponding file in the GAP distribution is `INSTALL.md`.)

- If GASMAN is not running, a file given with the `-L` command line option
  is currently ignored, because `LoadWorkspace` is not called when
  `GAP_ENABLE_SAVELOAD` is not defined.
  Should we better show an error message telling that no workspace
  could be loaded?
  (In earlier versions, there was such a message.)

- The function `GASMAN` is undocumented.
  (The Development manual contains a section "Garbage collection in GAP",
  where GASMAN is said to be "the GAP memory manager".
  This seems to be the right place to add documentation for alternative
  garbage collectors.
  On the other hand, this manual is not part of the GAP distribution.)

  Calling `GASMAN( "collect" )` and `GASMAN( "partial" )` work also
  with the Julia GC; if this is intentional then we should choose
  a better name for the function.
  (`GASMAN( "message" )` works only with the GASMAN GC.)

  The function `GASMAN` is shown in manual examples about weak pointer
  objects. Thus a function for forcing a garbage collection should be
  documented.

- The section "The GASMAN Interface for Weak Pointer Objects"
  in chapter "Weak Pointers" looks GASMAN specific (not only the title).
  How to reformulate it?
