### PR TITLE
Use colors in output of `Test`

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -31,6 +31,7 @@ do
   # restore current directory before each test suite
   cd "$BUILDDIR"
 
+  echo "Running test suite $TEST_SUITE"
   case $TEST_SUITE in
   testspecial | test-compile)
     cd $SRCDIR/tst/$TEST_SUITE
@@ -97,9 +98,9 @@ GAPInput
             Print("-----------------------------------------------------\n");
             Print("Loading $pkg ... \n");
             if LoadPackage("$pkg",false) = true then
-              Print("PASS: $pkg\n\n");
+              Print(TextAttr.2, "PASS: $pkg\n\n", TextAttr.reset);
             else
-              Print("FAIL: $pkg\n\n");
+              Print(TextAttr.1, "FAIL: $pkg\n\n", TextAttr.reset);
               AppendTo("fail.log", "Loading failed : ", "$pkg", "\n");
             fi;
 GAPInput

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -499,6 +499,44 @@ end);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##  
+DeclareGlobalName("TextAttr"); # from GAPDoc
+DeclareGlobalName("DefaultReportDiffColors"); # initialized in Test() or by the user
+BindGlobal("DefaultReportDiff", function(inp, expout, found, fnam, line, time)
+  if UserPreference("UseColorsInTerminal") = true then
+    Print(DefaultReportDiffColors.message);
+    Print("########> Diff in ");
+    if IsStream(fnam) then
+      Print("test stream, line ",line,":");
+    else
+      Print(fnam,":",line);
+    fi;
+    Print(TextAttr.reset, "\n", DefaultReportDiffColors.message);
+    Print("# Input is:", TextAttr.reset, "\n");
+    Print(DefaultReportDiffColors.input);
+    Print(inp);
+    Print(TextAttr.reset, TextAttr.delline, DefaultReportDiffColors.message);
+    Print("# Expected output:", TextAttr.reset, "\n");
+    Print(DefaultReportDiffColors.expected);
+    Print(expout);
+    Print(TextAttr.reset, TextAttr.delline, DefaultReportDiffColors.message);
+    Print("# But found:", TextAttr.reset, "\n");
+    Print(DefaultReportDiffColors.actual);
+    Print(found);
+    Print(TextAttr.reset, TextAttr.delline, DefaultReportDiffColors.message);
+    Print("########", TextAttr.reset, "\n");
+  else
+    Print("########> Diff in ");
+    if IsStream(fnam) then
+      Print("test stream, line ",line,":\n");
+    else
+      Print(fnam,":",line,"\n");
+    fi;
+    Print("# Input is:\n", inp);
+    Print("# Expected output:\n", expout);
+    Print("# But found:\n", found);
+    Print("########\n");  fi;
+end);
+
 InstallGlobalFunction("Test", function(arg)
   local fnam, nopts, opts, size, full, pf, failures, lines, ign, new,
         cT, ok, oldtimes, thr, delta, len, c, i, j, d, localdef, line;
@@ -509,6 +547,14 @@ InstallGlobalFunction("Test", function(arg)
     nopts := arg[2];
   else 
     nopts := rec();
+  fi;
+  if not IsBound(DefaultReportDiffColors) then
+    BindGlobal("DefaultReportDiffColors", rec(
+        message := TextAttr.4,  # blue text
+        input := "",
+        expected := Concatenation(TextAttr.0, TextAttr.b2), # black text on green background
+        actual := Concatenation(TextAttr.7, TextAttr.b1),   # white text on red background
+        ));
   fi;
   opts := rec(
            ignoreComments := true,
@@ -538,18 +584,7 @@ InstallGlobalFunction("Test", function(arg)
            end,
            rewriteToFile := false,
            breakOnError := false,
-           reportDiff := function(inp, expout, found, fnam, line, time)
-             Print("########> Diff in ");
-             if IsStream(fnam) then
-               Print("test stream, line ",line,":\n");
-             else
-               Print(fnam,":",line,"\n");
-             fi;
-             Print("# Input is:\n", inp);
-             Print("# Expected output:\n", expout);
-             Print("# But found:\n", found);
-             Print("########\n");
-           end,
+           reportDiff := DefaultReportDiff,
            subsWindowsLineBreaks := true,
            returnNumFailures := false,
            localdef := false,

--- a/tst/testmanuals.g
+++ b/tst/testmanuals.g
@@ -14,10 +14,7 @@
 ExamplesReportDiff := function(inp, expout, found, fnam, line, time)
     local tstf, i, loc, res;
 
-    Print("########> Diff in ");
-    if IsStream(fnam) then
-        Print("test stream, line ",line,"\n");
-    else
+    if IsString(fnam) then
         tstf := SplitString(StringFile(fnam), "\n");
         i := line;
         # Look for location marker
@@ -30,17 +27,11 @@ ExamplesReportDiff := function(inp, expout, found, fnam, line, time)
             loc := InputTextString(Concatenation(tstf[i]{[6..Length(tstf[i])]}, ";"));
             res := READ_COMMAND_REAL(loc, false);
             if res[1] = true then
-                Print(res[2][1],":",res[2][2]);
+                fnam := Concatenation(fnam,res[2][1],":",res[2][2]);
             fi;
-            Print(" (", fnam,":",line,")\n");
-        else # did not find a location marker
-            Print(fnam,":",line,"\n");
         fi;
     fi;
-    Print("# Input is:\n", inp);
-    Print("# Expected output:\n", expout);
-    Print("# But found:\n", found);
-    Print("########\n");
+    DefaultReportDiff(inp, expout, found, fnam, line, time);
 end;
 
 TestManualChapter := function(filename)

--- a/tst/testspecial/run_gap.sh
+++ b/tst/testspecial/run_gap.sh
@@ -15,6 +15,8 @@ gfile="$2"
 # 4) Set lower and upper memory limits, for consistency
 GAPROOT=$(cd ../..; pwd)
 ( echo "LogTo(\"${outfile}.tmp\");" ; cat "$gfile" ; echo "QUIT;" ) |
-    "$gap" -r -A -b -m 256m -o 512m -x 800 2>/dev/null >/dev/null
+    "$gap" -r -A -b -m 256m -o 512m -x 800 \
+           -c 'SetUserPreference("UseColorsInTerminal",false);' \
+           2>/dev/null >/dev/null
 sed -E -e "s:${GAPROOT//:/\\:}:GAPROOT:g" -e "s;(GAPROOT(/[^/]+)+):[0-9]+;\1:LINE;g" < "${outfile}.tmp"
 rm "${outfile}.tmp"


### PR DESCRIPTION
...  and some other test code, to make it easier to see and understand diffs in there.

Consider this test file:
```
gap> 1+1;
2 
gap> 2+2;
4
```
This will actually cause a test failure, due to whitespace, which makes it annoying to discover. Currently, `Test` will produce something like this:

<img width="262" alt="Screenshot 2020-11-12 at 11 48 31" src="https://user-images.githubusercontent.com/241512/98930482-0084af00-24dd-11eb-96c2-a43975a5596c.png">

With this PR, you'll get this:
<img width="253" alt="Screenshot 2020-11-12 at 11 55 41" src="https://user-images.githubusercontent.com/241512/98931174-ff07b680-24dd-11eb-8cc4-091f23198e52.png">

This change is IMHO useful beyond better understanding whitespace diffs. For example when I run the GAP test suite and there are multiple failures, it can be challenging to visually parse what is being displayed. With this PR, I find it much easier to understand what is going on.

Here is a more complex example:
```
gap> 1+1;
2 
gap> 2+2;
4
# comment in a bad place

gap> 3+3;
6
gap> Print("1\n2\n3\n");
1
2
3
gap> true
true
```
Which currently produces this, which I find hard to make sense out (basically, I resorted to trying to fix the first one and then hope I can repeat this; or I use the `rewriteFile:=true` option):
<img width="306" alt="Screenshot 2020-11-12 at 12 16 35" src="https://user-images.githubusercontent.com/241512/98933429-e9e05700-24e0-11eb-92ef-ed3854bd22db.png">

With this PR (the output could still be nicer, but it's a start):
<img width="422" alt="Screenshot 2020-11-12 at 12 17 15" src="https://user-images.githubusercontent.com/241512/98933499-02507180-24e1-11eb-8151-d6fc25e5966d.png">

```