### PR TITLE
GitHub Actions: re-enable coveralls integration (WIP)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,4 +51,4 @@ test_script:
 on_success:
   # make sure to use AppVeyor's Python (not Cygwin's) in the next step
   - bash -lc "export PATH="/cygdrive/c/Python27:/cygdrive/c/Python27/Scripts:$PATH" ; cd $APPVEYOR_BUILD_FOLDER && ./dev/ci-gather-coverage.sh"
-  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./dev/ci-run-codecov.sh"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./dev/ci-upload-coverage.sh"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -209,25 +209,16 @@ jobs:
             doc/*/*.css
             doc/*/*.js
       - name: "Gather coverage data"
-        run: ${{ matrix.extra }} bash dev/ci-gather-coverage.sh
+        run: ${{ matrix.extra }} COVERALLS_FLAG_NAME="${{ matrix.test-suites }}" bash dev/ci-gather-coverage.sh
       - name: "Upload coverage data"
         run: ${{ matrix.extra }} bash dev/ci-upload-coverage.sh
-      # - uses: codecov/codecov-action@v1
 
-      # TODO: fix coveralls integration
-      #- name: Coveralls Parallel
-      #  uses: coverallsapp/github-action@master
-      #  with:
-      #    github-token: ${{ secrets.github_token }}
-      #    flag-name: run-${{ matrix.test_number }}
-      #    parallel: true
-
-#  finish:
-#    needs: test
-#    runs-on: ubuntu-18.04
-#    steps:
-#      - name: Coveralls Finished
-#        uses: coverallsapp/github-action@master
-#        with:
-#          github-token: ${{ secrets.github_token }}
-#          parallel-finished: true
+  finish:
+    needs: test
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -208,10 +208,10 @@ jobs:
             doc/*/*.html
             doc/*/*.css
             doc/*/*.js
-      - name: "Gather coverage"
+      - name: "Gather coverage data"
         run: ${{ matrix.extra }} bash dev/ci-gather-coverage.sh
-      - name: "Upload coverage data to codecov"
-        run: ${{ matrix.extra }} bash dev/ci-run-codecov.sh
+      - name: "Upload coverage data"
+        run: ${{ matrix.extra }} bash dev/ci-upload-coverage.sh
       # - uses: codecov/codecov-action@v1
 
       # TODO: fix coveralls integration

--- a/dev/ci-gather-coverage.sh
+++ b/dev/ci-gather-coverage.sh
@@ -114,11 +114,3 @@ then
 
   python dev/ci-coveralls-merge.py
 fi
-
-# upload to coveralls.io
-# TODO: perhaps fold into python script?
-if [[ -f merged-coveralls.json ]]
-then
-  curl -F json_file=@merged-coveralls.json "https://coveralls.io/api/v1/jobs"
-fi
-

--- a/dev/ci-gather-coverage.sh
+++ b/dev/ci-gather-coverage.sh
@@ -76,21 +76,15 @@ env := GAPInfo.SystemEnvironment;;
 if IsBound(env.GITHUB_ACTIONS) then
     opt := rec(
         service_name := "github",
-        # The build number. Will default to chronological numbering from builds on repo
-        service_number := env.GITHUB_RUN_NUMBER,
-        # A unique identifier of the job on the service specified by service_name
-        # FIXME: there seems to be no unique per-job id; the GITHUB_RUN_ID is
-        # shared by all jobs in a single build :-(
-        #service_job_id := env.GITHUB_RUN_ID,
-        service_branch := env.GITHUB_REF{[Length("refs/heads/")..Length(env.GITHUB_REF)]},
-        commit_sha := env.GITHUB_SHA,
-#         service_build_url := Concatenation(
-#             "https://ci.appveyor.com/project/",
-#             env.APPVEYOR_REPO_NAME,
-#             "/build/",
-#             env.APPVEYOR_BUILD_VERSION),
+        service_job_id := env.GITHUB_RUN_ID,
     );
 
+    if IsBound(env.COVERALLS_FLAG_NAME) then
+        opt.flag_name := env.COVERALLS_FLAG_NAME;
+    fi;
+
+    # FIXME: should parse the JSON file GITHUB_EVENT_PATH points to
+    # instead to get the PR number
     # GITHUB_REF has the form refs/pull/12345/merge
     if IsBound(env.GITHUB_REF) and StartsWith(env.GITHUB_REF, "refs/pull/") then
         tmp := SplitString(env.GITHUB_REF, "/");
@@ -106,6 +100,11 @@ else
     OutputCoverallsJsonCoverage(r, "gap-coveralls.json", prefix);
 fi;
 GAPInput
+
+
+echo "####  GITHUB_EVENT_PATH ###"
+echo $GITHUB_EVENT_PATH
+cat $GITHUB_EVENT_PATH
 
 if [[ -f gap-coveralls.json ]]
 then

--- a/dev/ci-run-codecov.sh
+++ b/dev/ci-run-codecov.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set +ex
-set +H
-
-curl -s https://codecov.io/bash > codecov.sh
-chmod +x codecov.sh
-./codecov.sh -f '!./pkg/*' -f '!./extern/*' -f '!./build/*'
-

--- a/dev/ci-upload-coverage.sh
+++ b/dev/ci-upload-coverage.sh
@@ -4,13 +4,14 @@ set +ex
 set +H
 
 # upload to coveralls.io
-# TODO: perhaps fold into python script?
 if [[ -f merged-coveralls.json ]]
 then
+head -n 50 merged-coveralls.json
   curl -F json_file=@merged-coveralls.json "https://coveralls.io/api/v1/jobs"
 fi
 
-# upload to Codecov
+# upload to codecov
 curl -s https://codecov.io/bash > codecov.sh
 chmod +x codecov.sh
 ./codecov.sh -f '!./pkg/*' -f '!./extern/*' -f '!./build/*'
+

--- a/dev/ci-upload-coverage.sh
+++ b/dev/ci-upload-coverage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set +ex
+set +H
+
+# upload to coveralls.io
+# TODO: perhaps fold into python script?
+if [[ -f merged-coveralls.json ]]
+then
+  curl -F json_file=@merged-coveralls.json "https://coveralls.io/api/v1/jobs"
+fi
+
+# upload to Codecov
+curl -s https://codecov.io/bash > codecov.sh
+chmod +x codecov.sh
+./codecov.sh -f '!./pkg/*' -f '!./extern/*' -f '!./build/*'


### PR DESCRIPTION
This is work in progress to restore the Coveralls integration using GitHub Actions. Also, to switch codecov reporting to use the official codecov action.

See also https://github.com/marketplace/actions/coveralls-github-action