### PR TITLE
Fix bugs in RestrictedPerm

### DIFF
--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -1748,19 +1748,13 @@ static inline Obj RESTRICTED_PERM(Obj perm, Obj dom, Obj test)
       len = GET_LEN_RANGE(dom);
       p = GET_LOW_RANGE(dom);
       inc = GET_INC_RANGE(dom);
-      while (p<1) {
-        p+=inc;
-        len=-1;
+      if (p < 1 || p + inc * (len - 1) < 1) {
+          return Fail;
       }
-      i=p+(inc*len)-1;
-      while (i>deg) {
-        i-=inc;
-      }
-      p-=1;
-      i-=1;
-      while (p<=i) {
-        ptRest[p]=ptPerm[p];
-        p+=inc;
+      for (i = p; i != p + inc * len; i += inc) {
+          if (i <= deg) {
+              ptRest[i - 1] = ptPerm[i - 1];
+          }
       }
     }
 

--- a/tst/testinstall/restrictedperm.tst
+++ b/tst/testinstall/restrictedperm.tst
@@ -27,3 +27,53 @@ Error, <g> must be a permutation and <D> a plain list or range,
    consisting of a union of cycles of <g>
 gap> RestrictedPerm((1,2^17),[ 1, 2^17 ]);
 (1,131072)
+
+# Check behaviour on ranges
+gap> RestrictedPerm((1,3,5,7)(2,4,6,8)(9,10,11,12),[2,4..8]);
+(2,4,6,8)
+gap> RestrictedPerm((1,3,5,7)(2,4,6,8)(9,10,11,12),[8,6..2]);
+(2,4,6,8)
+gap> RestrictedPerm((1,3,5,7)(2,4,6,8)(9,10,11,12),[9,10..12]);
+(9,10,11,12)
+gap> RestrictedPerm((1,3,5,7)(2,4,6,8)(9,10,11,12),[12,11..9]);
+(9,10,11,12)
+
+# Check error / bounds checking on ranges
+gap> RestrictedPerm((1,2),[2,4..6]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+gap> RestrictedPerm((2,4),[2,4..6]);
+(2,4)
+gap> RestrictedPerm((4,6),[2,4..6]);
+(4,6)
+gap> RestrictedPerm((6,7),[2,4..6]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+gap> RestrictedPerm((6,7),[6,4..2]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+gap> RestrictedPerm((4,6),[6,4..2]);
+(4,6)
+gap> RestrictedPerm((2,4),[6,4..2]);
+(2,4)
+gap> RestrictedPerm((1,2),[6,4..2]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+
+# Check handling of negative inputs (and boundary cases)
+gap> RestrictedPerm((2,4),[-4,-2..4]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+gap> RestrictedPerm((2,4),[4,2..-4]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+gap> RestrictedPerm((1,5),[1,3..7]);
+(1,5)
+gap> RestrictedPerm((1,5),[7,5..1]);
+(1,5)
+gap> RestrictedPerm((2,4),[0,2..6]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>
+gap> RestrictedPerm((2,4),[6,4..0]);
+Error, <g> must be a permutation and <D> a plain list or range,
+   consisting of a union of cycles of <g>


### PR DESCRIPTION
The code in RestrictedPerm for handling ranges had a few bugs (I found issue (2) in some code I was working on, when I went to investigate I noticed issue (1))

1) If the list contained negative numbers, () was always returned
2) Ranges with steps which were not step = 1 were mishandled -- but (I believe) this would never return a wrong answer, just an Error about invalid input, when the input was value.

Rather than try to fix the old code, which was both buggy and confusing, I just wrote a (hopefully) much simpler loop, which I believe will be just as efficient (as the only one wasn't trying to do "clever skipping" anyway.
