### PR TITLE
Restructure the output of --help

### DIFF
--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -400,10 +400,9 @@ If a file cannot be opened &GAP; will print an error message and will abort.
 </List>
 <P/>
 <Index Subkey="command line, internal">options</Index>
-<Index Key="-P"><C>-P</C></Index><Index Key="-W"><C>-W</C></Index>
-<Index Key="-z"><C>-z</C></Index><Index Key="-p"><C>-p</C></Index>
-Additional options, <C>-C</C>, <C>-P</C>, <C>-W</C>, <C>-p</C>
-and <C>-z</C> are  used  
+<Index Key="-C"><C>-C</C></Index>
+<Index Key="-P"><C>-P</C></Index><Index Key="-p"><C>-p</C></Index>
+Additional options, such as <C>-C</C>, <C>-P</C> and<C>-p</C> are used
 internally by the <Package>gac</Package> script (see <Ref Label="Kernel modules"/>)
 and/or on specific operating systems.
 

--- a/lib/system.g
+++ b/lib/system.g
@@ -53,10 +53,16 @@ BIND_GLOBAL( "GAPInfo", rec(
     # These options must be kept in sync with those in system.c, so the help output
     # for those options is correct
     CommandLineOptionData := [
+      rec( section:= ["Startup:"] ),
       rec( short:= "h", long := "help", default := false, help := ["print this help and exit"] ),
       rec( long := "version", default := false, help := ["print the GAP version and exit"] ),
       rec( long := "print-gaproot", default := false, help := ["print the primary GAP root and exit"] ),
       rec( short:= "b", long := "banner", default := false, help := ["disable/enable the banner"] ),
+      rec( short:= "c", default := "", arg := "<expr>", help := [ "execute the expression <expr>"] ),
+      rec( long := "systemfile", default := "", arg := "<file>",
+           help := [ "read this file after 'lib/system.g'" ] ),
+      ,
+      rec( section:= ["Input/output:"] ),
       rec( short:= "q", long := "quiet", default := false, help := ["enable/disable quiet mode"] ),
       rec( short:= "e", default := false, help := ["disable/enable quitting on <ctrl>-D"] ),
       rec( short:= "f", default := false, help := ["force line editing"] ),
@@ -65,19 +71,23 @@ BIND_GLOBAL( "GAPInfo", rec(
            help := ["disable/enable use of readline library (if", "possible)"] ),
       rec( short:= "x", long := "width", default := "", arg := "<num>", help := ["set line width"] ),
       rec( short:= "y", long := "lines", default := "", arg := "<num>", help := ["set number of lines"] ),
+      rec( short:= "p", default := false, help := ["enable/disable package output mode", "(for use by XGAP and similar interfaces)"] ),
+      ,
+      rec( section:= ["Memory:",
+                      "  (may use postfix 'k' = *1024, 'm' = *1024*1024,",
+                      "                   'g' = *1024*1024*1024):"] ),
       ,
       rec( short:= "g", long := "gasinfo", default := 0,
            help := ["show GASMAN messages (full/all/no garbage","collections)", "(only available if GAP uses GASMAN)"] ),
       rec( short:= "m", long := "minworkspace", default := "128m", arg := "<mem>",
            help := ["set the initial workspace size"] ),
       rec( short:= "o", long := "maxworkspace", default := "2g", arg := "<mem>",
-           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)", "(available only if GAP uses GASMAN)"] ),
+           help := [ "set workspace size where GAP will warn about", "excessive memory usage (GAP may allocate more)", "(only available if GAP uses GASMAN)"] ),
       rec( short:= "K", long := "limitworkspace", default := "0", arg := "<mem>",
            help := [ "set maximal workspace size (GAP never", "allocates more)"] ),
-      rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory", "(available only if GAP uses GASMAN)" ] ),
-      rec( short:= "a", default := "0",  arg := "<mem>",help := [ "set amount to pre-malloc-ate",
-             "postfix 'k' = *1024, 'm' = *1024*1024,", "'g' = *1024*1024*1024"] ),
+      rec( short:= "s", default := "4g", arg := "<mem>", help := [ "set the initially mapped virtual memory", "(only available if GAP uses GASMAN)" ] ),
       ,
+      rec( section:= ["Roots:"] ),
       rec( short:= "l", long := "roots", default := [], arg := "<paths>",
            help := [ "set or modify the GAP root paths",
                      "Directories are separated using ';'.",
@@ -85,39 +95,39 @@ BIND_GLOBAL( "GAPInfo", rec(
                      "directories to the end/start of existing list",
                      "of root paths" ] ),
       rec( short:= "r", default := false, help := ["disable/enable user GAP root dir", "GAPInfo.UserGapRoot"] ),
+      ,
+      rec( section:= ["Loading:"] ),
       rec( short:= "A", default := false, help := ["disable/enable autoloading of suggested", "GAP packages"] ),
       rec( short:= "D", default := false, help := ["enable/disable debugging the loading of files"] ),
       rec( short:= "M", default := false, help := ["disable/enable loading of compiled modules"] ),
-      rec( short:= "N", default := false, help := ["do not use hidden implications"] ),
-      rec( short:= "O", default := false, help := ["disable/enable loading of obsolete files"] ),
+      ,
+      rec( section:= ["Error handling, REPL:"] ),
       rec( short:= "T", long := "nobreakloop", default := false, help := ["disable/enable break loop and error traceback"] ),
       rec( long := "alwaystrace", default := false, help := ["always print error traceback", "(overrides behaviour of -T)"] ),
       rec( long := "quitonbreak", default := false, help := ["quit GAP with non-zero return value instead", "of entering break loop"]),
+      rec( long := "norepl", default := false,
+           help := [ "Disable the GAP read-evaluate-print loop (REPL)" ] ),
+      rec( long := "nointeract", default := false,
+           help := [ "Start GAP in non-interactive mode (disable REPL", "and break loop)" ] ),
       ,
-      rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace", "(available only if GAP uses GASMAN)"] ),
+      rec( section:= ["Workspaces:", "  (only available if GAP uses GASMAN)"] ),
+      rec( short:= "L", default := "", arg := "<file>", help := [ "restore a saved workspace"] ),
       rec( short:= "R", default := false, help := ["prevent restoring of workspace (ignoring -L)"] ),
       ,
-      rec( short:= "p", default := false, help := ["enable/disable package output mode"] ),
-      rec( short := "E", default :=false ),
-      rec( short := "s", default := "4g" ),
-      rec( short := "z", default := "20" ),
+      rec( section:= ["Profiling:"] ),
       rec( long := "prof", default := "", arg := "<file>",
            help := [ "Run ProfileLineByLine(<file>) on GAP start"] ),
       rec( long := "memprof", default := "", arg := "<file>",
            help := [ "Run ProfileLineByLine(<file>) on GAP start", "with recordMem := true"] ),
       rec( long := "cover", default := "", arg := "<file>",
            help := [ "Run CoverageLineByLine(<file>) on GAP start"] ),
-      rec( long := "enableMemCheck", default := false),
-      rec( long := "norepl", default := false,
-           help := [ "Disable the GAP read-evaluate-print loop (REPL)" ] ),
-      rec( long := "nointeract", default := false,
-           help := [ "Start GAP in non-interactive mode (disable REPL", "and break loop)" ] ),
-      rec( long := "systemfile", default := "", arg := "<file>",
-           help := [ "Read this file after 'lib/system.g'" ] ),
-      rec( long := "bare", default := false,
-           help := [ "Attempt to start GAP without even needed", "packages (developer tool)" ] ),
+      rec( long := "enableMemCheck", default := false), # TODO: document this?
       ,
-      rec( short:= "c", default := "", arg := "<expr>", help := [ "execute the expression <expr>"] ),
+      rec( section:= ["Internal developer tools"] ),
+      rec( short:= "N", default := false, help := ["do not use hidden implications"] ),
+      rec( short:= "O", default := false, help := ["disable/enable loading of obsolete files"] ),
+      rec( long := "bare", default := false,
+           help := [ "Attempt to start GAP without even needed", "packages" ] ),
     ],
     ) );
 
@@ -185,6 +195,7 @@ if IsHPCGAP then
     GAPInfo.TestData:= ThreadLocalRecord( rec() );
     APPEND_LIST_INTR(GAPInfo.CommandLineOptionData, [
         ,
+        rec( section:= ["HPC-GAP:"] ),
         rec( short:= "S", default := false, help := ["disable/enable multi-threaded interface"] ),
         rec( short:= "P", default := "0", arg := "<num>", help := ["set number of logical processors"] ),
         rec( short:= "G", default := "0", arg := "<num>", help := ["set number of GC threads"] ),
@@ -257,7 +268,7 @@ CallAndInstallPostRestore( function()
       if IsBound(option.long) then
         GAPInfo.CommandLineOptionCanonicalName.(option.long) := option.short;
       fi;
-    else
+    elif IsBound(option.long) then
         GAPInfo.CommandLineOptionCanonicalName.(option.long) := option.long;
     fi;
   od;
@@ -337,7 +348,7 @@ CallAndInstallPostRestore( function()
     for opt in GAPInfo.CommandLineOptionData do
       if IsBound(opt.short) then
         CommandLineOptions.( opt.short ):= SHALLOW_COPY_OBJ( opt.default );
-      else
+      elif IsBound(opt.long) then
         CommandLineOptions.( opt.long ):= SHALLOW_COPY_OBJ( opt.default );
       fi;
     od;
@@ -428,13 +439,16 @@ CallAndInstallPostRestore( function()
         GAPInfo.KernelVersion, "\n\n" );
 
       for i in [ 1 .. LENGTH( GAPInfo.CommandLineOptionData ) ] do
-        if IsBound( GAPInfo.CommandLineOptionData[i] ) and
-           IsBound( GAPInfo.CommandLineOptionData[i].help ) then
-          opt:= GAPInfo.CommandLineOptionData[i];
+        if not IsBound(GAPInfo.CommandLineOptionData[i]) then
+          PRINT_TO( "*stdout*", "\n" );
+          continue;
+        fi;
+        opt:= GAPInfo.CommandLineOptionData[i];
+        if IsBound( opt.help ) then
 
           # At least one of opt.short or opt.long must be bound
           if(IsBound(opt.short)) then
-            PRINT_TO("*stdout*", " -", opt.short);
+            PRINT_TO("*stdout*", "  -", opt.short);
             if(IsBound(opt.long)) then
               PRINT_TO("*stdout*", ", --", opt.long);
               padspace(4+LENGTH(opt.long), 18);
@@ -448,7 +462,7 @@ CallAndInstallPostRestore( function()
               padspace(0, 8);
             fi;
           else
-            PRINT_TO("*stdout*", "   ");
+            PRINT_TO("*stdout*", "    ");
             # opt.short unbound, opt.long bound
 
             PRINT_TO("*stdout*", "  --", opt.long);
@@ -469,13 +483,15 @@ CallAndInstallPostRestore( function()
 
           PRINT_TO("*stdout*", opt.help[1], "\n");
           for j in [2..LENGTH(opt.help)] do
-            padspace(0, 3+18+8+3 + 2);
+            padspace(0, 4+18+8+3 + 2);
             PRINT_TO("*stdout*", opt.help[j],"\n");
           od;
-        else
-          if not IsBound(GAPInfo.CommandLineOptionData[i]) then
-            PRINT_TO( "*stdout*", "\n" );
-          fi;
+        elif IsBound(opt.section) then
+          PRINT_TO( "*stdout*", opt.section[1], "\n" );
+          for j in [2..LENGTH(opt.section)] do
+            #padspace(0, 3);
+            PRINT_TO("*stdout*", opt.section[j],"\n");
+          od;
         fi;
       od;
 


### PR DESCRIPTION
... by grouping it in various categories; this makes it arguably easier to find something in the list (at least it does help *me*, but YMMV). Also remove mentions of command line options that are not actually supported anymore, like `-a` (which @ChrisJefferson removed some time ago, but we forgot one mention in `system.g`) and `-z` (for which I could not figure what it ever did -- or perhaps it still does something and I just couldn't find it?).

To better show what's going on, here is the output of `gap --help` with this PR:
```
usage: gap [OPTIONS] [FILES]
       run the Groups, Algorithms and Programming system, Version 4.12dev

Startup:
  -h, --help                     print this help and exit
      --version                  print the GAP version and exit
      --print-gaproot            print the primary GAP root and exit
  -b, --banner                   disable/enable the banner
  -c                   <expr>    execute the expression <expr>
      --systemfile     <file>    read this file after 'lib/system.g'

Input/output:
  -q, --quiet                    enable/disable quiet mode
  -e                             disable/enable quitting on <ctrl>-D
  -f                             force line editing
  -n                             prevent line editing
  -E, --readline                 disable/enable use of readline library (if
                                   possible)
  -x, --width          <num>     set line width
  -y, --lines          <num>     set number of lines
  -p                             enable/disable package output mode
                                   (for use by XGAP and similar interfaces)

Memory:
  (may use postfix 'k' = *1024, 'm' = *1024*1024,
                   'g' = *1024*1024*1024):

  -g, --gasinfo                  show GASMAN messages (full/all/no garbage
                                   collections)
                                   (only available if GAP uses GASMAN)
  -m, --minworkspace   <mem>     set the initial workspace size
  -o, --maxworkspace   <mem>     set workspace size where GAP will warn about
                                   excessive memory usage (GAP may allocate more)
                                   (only available if GAP uses GASMAN)
  -K, --limitworkspace <mem>     set maximal workspace size (GAP never
                                   allocates more)
  -s                   <mem>     set the initially mapped virtual memory
                                   (only available if GAP uses GASMAN)

Roots:
  -l, --roots          <paths>   set or modify the GAP root paths
                                   Directories are separated using ';'.
                                   Putting ';' on the start/end of list appends
                                   directories to the end/start of existing list
                                   of root paths
  -r                             disable/enable user GAP root dir
                                   GAPInfo.UserGapRoot

Loading:
  -A                             disable/enable autoloading of suggested
                                   GAP packages
  -D                             enable/disable debugging the loading of files
  -M                             disable/enable loading of compiled modules

Error handling, REPL:
  -T, --nobreakloop              disable/enable break loop and error traceback
      --alwaystrace              always print error traceback
                                   (overrides behaviour of -T)
      --quitonbreak              quit GAP with non-zero return value instead
                                   of entering break loop
      --norepl                   Disable the GAP read-evaluate-print loop (REPL)
      --nointeract               Start GAP in non-interactive mode (disable REPL
                                   and break loop)

Workspaces:
  (only available if GAP uses GASMAN)
  -L                   <file>    restore a saved workspace
  -R                             prevent restoring of workspace (ignoring -L)

Profiling:
      --prof           <file>    Run ProfileLineByLine(<file>) on GAP start
      --memprof        <file>    Run ProfileLineByLine(<file>) on GAP start
                                   with recordMem := true
      --cover          <file>    Run CoverageLineByLine(<file>) on GAP start

Internal developer tools
  -N                             do not use hidden implications
  -O                             disable/enable loading of obsolete files
      --bare                     Attempt to start GAP without even needed
                                   packages

  Boolean options toggle the current value each time they are called.
  Default actions are indicated first.
```

For reference, this is what it looks like right now:
```
usage: gap [OPTIONS] [FILES]
       run the Groups, Algorithms and Programming system, Version 4.12dev

 -h, --help                     print this help and exit
     --version                  print the GAP version and exit
     --print-gaproot            print the primary GAP root and exit
 -b, --banner                   disable/enable the banner
 -q, --quiet                    enable/disable quiet mode
 -e                             disable/enable quitting on <ctrl>-D
 -f                             force line editing
 -n                             prevent line editing
 -E, --readline                 disable/enable use of readline library (if
                                  possible)
 -x, --width          <num>     set line width
 -y, --lines          <num>     set number of lines

 -g, --gasinfo                  show GASMAN messages (full/all/no garbage
                                  collections)
                                  (only available if GAP uses GASMAN)
 -m, --minworkspace   <mem>     set the initial workspace size
 -o, --maxworkspace   <mem>     set workspace size where GAP will warn about
                                  excessive memory usage (GAP may allocate more)
                                  (available only if GAP uses GASMAN)
 -K, --limitworkspace <mem>     set maximal workspace size (GAP never
                                  allocates more)
 -s                   <mem>     set the initially mapped virtual memory
                                  (available only if GAP uses GASMAN)
 -a                   <mem>     set amount to pre-malloc-ate
                                  postfix 'k' = *1024, 'm' = *1024*1024,
                                  'g' = *1024*1024*1024

 -l, --roots          <paths>   set or modify the GAP root paths
                                  Directories are separated using ';'.
                                  Putting ';' on the start/end of list appends
                                  directories to the end/start of existing list
                                  of root paths
 -r                             disable/enable user GAP root dir
                                  GAPInfo.UserGapRoot
 -A                             disable/enable autoloading of suggested
                                  GAP packages
 -D                             enable/disable debugging the loading of files
 -M                             disable/enable loading of compiled modules
 -N                             do not use hidden implications
 -O                             disable/enable loading of obsolete files
 -T, --nobreakloop              disable/enable break loop and error traceback
     --alwaystrace              always print error traceback
                                  (overrides behaviour of -T)
     --quitonbreak              quit GAP with non-zero return value instead
                                  of entering break loop

 -L                   <file>    restore a saved workspace
                                  (available only if GAP uses GASMAN)
 -R                             prevent restoring of workspace (ignoring -L)

 -p                             enable/disable package output mode
     --prof           <file>    Run ProfileLineByLine(<file>) on GAP start
     --memprof        <file>    Run ProfileLineByLine(<file>) on GAP start
                                  with recordMem := true
     --cover          <file>    Run CoverageLineByLine(<file>) on GAP start
     --norepl                   Disable the GAP read-evaluate-print loop (REPL)
     --nointeract               Start GAP in non-interactive mode (disable REPL
                                  and break loop)
     --systemfile     <file>    Read this file after 'lib/system.g'
     --bare                     Attempt to start GAP without even needed
                                  packages (developer tool)

 -c                   <expr>    execute the expression <expr>

  Boolean options toggle the current value each time they are called.
  Default actions are indicated first.
```
