### PR TITLE
Call GAP with `-r` option ...

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -191,7 +191,7 @@ run_configure_and_make() {
   then
     if grep Autoconf ./configure > /dev/null
     then
-      local PKG_NAME=$($GAP -q -T -A <<GAPInput
+      local PKG_NAME=$($GAP -q -T -A -r <<GAPInput
 Read("PackageInfo.g");
 Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput


### PR DESCRIPTION
... when asking for printed output, since `~/.gap/gaprc` may contain `Print` statements.

(I have stumbled over this, see a comment of mine in oscar-system/GAP.jl/pull/550.)