### PR TITLE
Add option to skip guard pages for Julia GC.

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -214,10 +214,8 @@ SYSINFO_CPPFLAGS += $(CPPFLAGS)
 GAP_CFLAGS = $(ABI_CFLAGS)
 SYSINFO_CFLAGS = $(ABI_CFLAGS)
 
-ifeq ($(HPCGAP),yes)
 GAP_CFLAGS += $(PTHREAD_CFLAGS)
 SYSINFO_CFLAGS += $(PTHREAD_CFLAGS)
-endif
 
 GAP_CFLAGS += $(JULIA_CFLAGS) # not added to SYSINFO_CFLAGS
 
@@ -231,9 +229,7 @@ SYSINFO_CFLAGS += $(CFLAGS)
 ########################################################################
 GAP_CXXFLAGS = $(ABI_CFLAGS)
 
-ifeq ($(HPCGAP),yes)
 GAP_CXXFLAGS += $(PTHREAD_CFLAGS)
-endif
 
 # Finally add user provided CXXFLAGS
 GAP_CXXFLAGS += $(CXXFLAGS)
@@ -252,9 +248,7 @@ GAP_LDFLAGS += $(JULIA_LDFLAGS)
 GAP_LDFLAGS += $(BOEHM_GC_LDFLAGS)
 GAP_LDFLAGS += $(LIBATOMIC_OPS_LDFLAGS)
 
-ifeq ($(HPCGAP),yes)
 GAP_LDFLAGS += $(PTHREAD_CFLAGS) $(PTHREAD_LIBS)
-endif
 
 # Finally add user provided flags
 GAP_LDFLAGS += $(LDFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -999,7 +999,7 @@ dnl check for non-standard math functions
 AC_CHECK_FUNCS([exp10])
 
 dnl pthreads
-AS_IF([test "x$enable_hpcgap" = xyes],[
+AS_IF([test "x$enable_hpcgap" = xyes -o "x$with_julia" != xno ],[
   AX_PTHREAD
   ])
 


### PR DESCRIPTION
This is an experimental option to allow us to skip the scanning of guard pages rather than relying on intercepting segmentation faults if the task stack scanner encounters one.

It is currently enabled to facilitate testing, but should probably be disabled by default and only be used if changes in the Julia implementation necessitate it, as intercepting segmentation faults relies on fewer assumptions about stack layout.

It also needs more testing, especially in the context of actual GAP.jl uses.