### PR TITLE
fix DirectoriesPackageLibrary/Programs

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1198,8 +1198,9 @@ InstallGlobalFunction( DirectoriesPackagePrograms, function( name )
     if IsBound( GAPInfo.PackagesLoaded.( name ) ) then
       # The package is already loaded.
       installationpath:= GAPInfo.PackagesLoaded.( name )[1];
-    elif IsBound( GAPInfo.PackageCurrent ) then
-      # The package is currently going to be loaded.
+    elif IsBound( GAPInfo.PackageCurrent ) and
+         LowercaseString( GAPInfo.PackageCurrent.PackageName ) = name then
+      # The package in question is currently going to be loaded.
       installationpath:= GAPInfo.PackageCurrent.InstallationPath;
     elif 0 < Length( info ) then
       # Take the installed package with the highest version
@@ -1242,8 +1243,9 @@ InstallGlobalFunction( DirectoriesPackageLibrary, function( arg )
     if IsBound( GAPInfo.PackagesLoaded.( name ) ) then
       # The package is already loaded.
       installationpath:= GAPInfo.PackagesLoaded.( name )[1];
-    elif IsBound( GAPInfo.PackageCurrent ) then
-      # The package is currently going to be loaded.
+    elif IsBound( GAPInfo.PackageCurrent ) and
+         LowercaseString( GAPInfo.PackageCurrent.PackageName ) = name then
+      # The package in question is currently going to be loaded.
       installationpath:= GAPInfo.PackageCurrent.InstallationPath;
     elif 0 < Length( info ) then
       # Take the installed package with the highest version


### PR DESCRIPTION
... for the case that *another* package is the current package to be loaded at the time when the function gets called.

Apparently this did not happen until now, otherwise it would have been observed earlier.

## Text for release notes

Suppose that one of the functions `DirectoriesPackageLibrary`, `DirectoriesPackagePrograms` is called with first argument `"a"`, *and* that this call happens while another package with name `"b"`, say, gets loaded, in the sense that `GAPInfo.CurrentPackage` is bound to an info record for `"b"`.
Before the fix, the directory path in question for `"b"` was returned. After the fix, the path for `"a"` is returned. 