### PR TITLE
add the groups PGammaL, PSigmaL

### DIFF
--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -148,6 +148,9 @@ gap> AsSSortedList(DihedralGroup(12:generatorNames:=["a","b","c"]));
 <#Include Label="ProjectiveSpecialUnitaryGroup">
 <#Include Label="ProjectiveSymplecticGroup">
 <#Include Label="ProjectiveOmega">
+<#Include Label="ProjectiveGeneralSemilinearGroup">
+<#Include Label="ProjectiveSpecialSemilinearGroup">
+
 
 </Section>
 

--- a/tst/testinstall/grp/classic-PG.tst
+++ b/tst/testinstall/grp/classic-PG.tst
@@ -1,5 +1,5 @@
 #
-# Tests for the "projective general" group constructors: PGL, POmega, PGU
+# Tests for the "projective general" group constructors: PGL, POmega, PGU, PGammaL
 #
 gap> START_TEST("classic-PG.tst");
 
@@ -71,6 +71,28 @@ gap> PGU(3);
 Error, usage: ProjectiveGeneralUnitaryGroup( [<filter>, ]<d>, <q> )
 gap> PGU(3,6);
 Error, <subfield> must be a prime or a finite field
+
+#
+gap> PGammaL( 2, 5 );
+GL(2,5)
+gap> Size( PGammaL( 2, 25 ) );
+31200
+gap> Size( PGammaL( 1, 9 ) ) = Size( PGL( 1, 9 ) ) * 2;
+true
+gap> Size( PGammaL( 2, 9 ) ) = Size( PGL( 2, 9 ) ) * 2;
+true
+gap> Size( PGammaL( 3, 9 ) ) = Size( PGL( 3, 9 ) ) * 2;
+true
+gap> PGammaL( IsPermGroup, 3, 9) = PGammaL( 3, 9 );
+true
+gap> PGammaL( 3, GF(9) );
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ProjectiveGeneralSemilinearGroupCons' o\
+n 3 arguments
+gap> PGammaL( 3 );
+Error, usage: ProjectiveGeneralSemilinearGroup( [<filter>, ]<d>, <q> )
+gap> PGammaL( 3, 6 );
+Error, usage: GeneralLinearGroup( [<filter>, ]<d>, <R> )
 
 #
 gap> STOP_TEST("classic-PG.tst", 1);

--- a/tst/testinstall/grp/classic-PS.tst
+++ b/tst/testinstall/grp/classic-PS.tst
@@ -1,5 +1,5 @@
 #
-# Tests for the "projective special" group constructors: PSL, PSU, PSp
+# Tests for the "projective special" group constructors: PSL, PSU, PSp, PSigmaL
 #
 gap> START_TEST("classic-PS.tst");
 
@@ -46,6 +46,28 @@ gap> PSp(4);
 Error, usage: ProjectiveSymplecticGroup( [<filter>, ]<d>, <q> )
 gap> PSp(4,6);
 Error, <subfield> must be a prime or a finite field
+
+#
+gap> PSigmaL( 3, 5 );
+SL(3,5)
+gap> Size( PSigmaL( 3, 9 ) );
+84913920
+gap> Size( PSigmaL( 1, 9 ) ) = Size( PSL( 1, 9 ) ) * 2;
+true
+gap> Size( PSigmaL( 2, 9 ) ) = Size( PSL( 2, 9 ) ) * 2;
+true
+gap> Size( PSigmaL( 3, 9 ) ) = Size( PSL( 3, 9 ) ) * 2;
+true
+gap> PSigmaL( IsPermGroup, 3, 9 ) = PSigmaL( 3, 9 );
+true
+gap> PSigmaL( 3, GF(9) );
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `ProjectiveSpecialSemilinearGroupCons' o\
+n 3 arguments
+gap> PSigmaL( 3 );
+Error, usage: ProjectiveSpecialSemilinearGroup( [<filter>, ]<d>, <q> )
+gap> PSigmaL( 3, 6 );
+Error, usage: SpecialLinearGroup( [<filter>, ]<d>, <R> )
 
 #
 gap> STOP_TEST("classic.tst-PS", 1);


### PR DESCRIPTION
These groups are sometimes useful.
For example their names occur in the library of primitive groups,
and also the character table library can take advantage of these names
and then the groups themselves.

Currently only constructions as permutation groups are available,
as for the case of PGL and PSL;
this is sufficient in the abovementioned contexts, where both the dimension and the field are small.

## Text for release notes

The functions `PGammaL` and `PSigmaL` can be used to create groups isomorphic with the projective general semilinear group and the projective special semilinear group, respectively, over finite fields.
