### PR TITLE
fixed `HELP_SEARCH_ALTERNATIVES`

### DIFF
--- a/hpcgap/lib/helpbase.gi
+++ b/hpcgap/lib/helpbase.gi
@@ -217,7 +217,7 @@ if Length(positions) > 0 then # matches found
     begin := Minimum( patterns[i].finish+1, Length(topic) );
   od;
 
-  if begin < Length( topic ) then
+  if begin <= Length( topic ) then
     Add( chop, [ topic{[begin..Length(topic)]} ] );
   fi;
 

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -214,7 +214,7 @@ if Length(positions) > 0 then # matches found
     begin := Minimum( patterns[i].finish+1, Length(topic) );
   od;
 
-  if begin < Length( topic ) then
+  if begin <= Length( topic ) then
     Add( chop, [ topic{[begin..Length(topic)]} ] );
   fi;
 


### PR DESCRIPTION
... for the case that there is exactly one character behind the pattern:

Before the change:
```
gap> HELP_SEARCH_ALTERNATIVES( "Centralizer" );
[ "Centralise", "Centralize" ]
```

After the change:
```
gap> HELP_SEARCH_ALTERNATIVES( "Centralizer" );
[ "Centraliser", "Centralizer" ]
```