### PR TITLE
Add a tiny optimisation to Intersection2 for perm groups

### DIFF
--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2960,8 +2960,8 @@ local   Omega,  P,  rbase,  L,mg,mh,i;
     mh:=MovedPoints(H);
     Omega := Intersection(mg,mh);
 
-    # disjoint?
-    if Length(Omega)=0 then
+    # no two points moved in common?
+    if Length(Omega)<=1 then
       return TrivialSubgroup(Parent(G));
     fi;
 

--- a/tst/testinstall/stbcbckt.tst
+++ b/tst/testinstall/stbcbckt.tst
@@ -1,0 +1,11 @@
+#@local G,p
+gap> START_TEST("stbcbckt.tst");
+
+# Intersection for perm groups with a single moved point in common
+gap> G := Group(GeneratorsOfGroup(SymmetricGroup(100)));;
+gap> p := PermList(Concatenation([100 .. 199], [1 .. 99]));;
+gap> IsTrivial(Intersection(G, G ^ p));
+true
+
+#
+gap> STOP_TEST("stbcbckt.tst", 1);


### PR DESCRIPTION
In GAP `master` on my computer:
```
gap> G := Group(GeneratorsOfGroup(SymmetricGroup(100)));;
gap> p := PermList(Concatenation([100 .. 199], [1 .. 99]));;
gap> IsTrivial(Intersection(G, G ^ p));;
gap> time;
7009
```
and even when the first group already knows that it's a natural symmetric group:
```
gap> G := SymmetricGroup(100);;
gap> p := PermList(Concatenation([100 .. 199], [1 .. 99]));;
gap> IsTrivial(Intersection(G, G ^ p));;
gap> time;
1111
```
but with this PR (or in GAP `master` when **both** groups know they are natural symmetric groups):
```
gap> G := Group(GeneratorsOfGroup(SymmetricGroup(100)));;
gap> p := PermList(Concatenation([100 .. 199], [1 .. 99]));;
gap> IsTrivial(Intersection(G, G ^ p));;
gap> time;
1
```