### PR TITLE
libgap API: expose minimal interface to garbage collector

### DIFF
--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -75,7 +75,7 @@ void GAP_MarkBag(Obj obj)
     MarkBag(obj);
 }
 
-UInt GAP_CollectBags(UInt full)
+void GAP_CollectBags(BOOL full)
 {
     CollectBags(0, full);
 }

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -68,6 +68,20 @@ void GAP_Initialize(int              argc,
 
 
 ////
+//// Garbage collector interface
+////
+void GAP_MarkBag(Obj obj)
+{
+    MarkBag(obj);
+}
+
+UInt GAP_CollectBags(UInt full)
+{
+    CollectBags(0, full);
+}
+
+
+////
 //// program evaluation and execution
 ////
 

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -175,10 +175,10 @@ void GAP_MarkBag(Obj obj);
 // Manually run the garbage collector.
 // A <full> collection checks all previously allocated objects, including those
 // that have survived at least one previous garbage collection.
-// A partial collection will attempt to clean up only recently-allocated
+// A partial collection will attempt to clean up only recently allocated
 // objects which have not been garbage-collected yet, and is hence normally
 // a faster operation.
-UInt GAP_CollectBags(UInt full);
+void GAP_CollectBags(BOOL full);
 
 
 ////

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -162,6 +162,26 @@ void GAP_Initialize(int              argc,
 
 
 ////
+//// Garbage collector
+////
+
+// Manual management of the GAP garbage collector: for cases where you want
+// a GAP object to be long-lived beyond the context of the stack frame where
+// it was created, it is necessary to call GAP_MarkBag on the object when
+// the garbage collector is run by the markBagsCallback function passed to
+// GAP_Initialize.
+void GAP_MarkBag(Obj obj);
+
+// Manually run the garbage collector.
+// A <full> collection checks all previously allocated objects, including those
+// that have survived at least one previous garbage collection.
+// A partial collection will attempt to clean up only recently-allocated
+// objects which have not been garbage-collected yet, and is hence normally
+// a faster operation.
+UInt GAP_CollectBags(UInt full);
+
+
+////
 //// program evaluation and execution
 ////
 


### PR DESCRIPTION
Add libgap interfaces to the garbage collector.  As discussed in #3030 
these are probably the minimal interfaces that need to be exposed, and
are compatible with all current GC implementations.

As suggested at https://github.com/gap-system/gap/issues/3030#issuecomment-440259263
GAP_CollectBags only takes a `full` argument, but not `size`.

Copy-editing may be needed on the documentation the header.