### PR TITLE
Performance additions to generic 2-cohomology and Automorphism group/Isomorphism test

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -330,8 +330,6 @@ local o,b,img,G1,c,m,mt,hardlimit,gens,t,k,intersize;
     return fail;
   fi;
 
-  # old code -- obsolete
-
   c:=ValueOption("refineChainActionLimit");
   if IsInt(c) then
     hardlimit:=c;
@@ -339,7 +337,22 @@ local o,b,img,G1,c,m,mt,hardlimit,gens,t,k,intersize;
     hardlimit:=1000000;
   fi;
 
-  if Index(G,U)>hardlimit then return fail;fi;
+  if Index(G,U)>hardlimit/10
+   and ValueOption("callinintermediategroup")<>true then
+    # try the `AscendingChain` mechanism
+    c:=AscendingChain(G,U:cheap,refineIndex:=QuoInt(IndexNC(G,U),2),
+      callinintermediategroup);
+    if Length(c)>2 then
+      return First(c,x->Size(x)>Size(U));
+    fi;
+  fi;
+
+  if Index(G,U)>hardlimit then 
+    Info(InfoWarning,1,
+      "will have to use permutation action of degree bigger than ", hardlimit);
+  fi;
+
+  # old code -- obsolete
 
   if IsPermGroup(G) and Length(GeneratorsOfGroup(G))>3 then
     G1:=Group(SmallGeneratingSet(G));

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1124,7 +1124,6 @@ local iso,fp,n,dec,homs,mos,i,j,ffp,imo,m,k,gens,fm,mgens,rules,
 
     reduce:=function(w)
     local red,i,p,pool,wn;
-#ow:=w;
       w:=LetterRepAssocWord(w);
       repeat
         i:=1;
@@ -1288,7 +1287,7 @@ end);
 
 # special method for pc groups, basically just writing down the pc
 # presentation
-InstallMethod(ConfluentMonoidPresentationForGroup,"generic",
+InstallMethod(ConfluentMonoidPresentationForGroup,"pc",
   [IsGroup and IsFinite and IsPcGroup],
 function(G)
 local pcgs,iso,fp,i,j,gens,numi,ord,fm,fam,mword,k,r,addrule,a,e,m;

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1035,20 +1035,26 @@ DeclareAttribute( "CommutatorFactorGroup", IsGroup );
 #############################################################################
 ##
 #A  CompositionSeries( <G> )
+#A  CompositionSeriesThrough( <G>, <normals> )
 ##
 ##  <#GAPDoc Label="CompositionSeries">
 ##  <ManSection>
 ##  <Attr Name="CompositionSeries" Arg='G'/>
+##  <Oper Name="CompositionSeriesThrough" Arg='G, normals'/>
 ##
 ##  <Description>
 ##  A composition series is a subnormal series which cannot be refined.
 ##  This attribute returns <E>one</E> composition series (of potentially many
-##  possibilities).
+##  possibilities). The variant <Ref Oper="CompositionSeriesThrough"/> takes
+##  as second argument a list <A>normals</A> of normal subgroups of the
+##  group, and returns a composition series that incorporates these normal
+##  subgroups.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "CompositionSeries", IsGroup );
+DeclareOperation( "CompositionSeriesThrough", [IsGroup,IsList] );
 #T and for module?
 
 

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -449,21 +449,29 @@ DeclareGlobalFunction("LowLayerSubgroups");
 
 #############################################################################
 ##
-#O  ContainedConjugates(<G>,<A>,<B>)
+#O  ContainedConjugates(<G>,<A>,<B>[,<onlyone>])
 ##
 ##  <#GAPDoc Label="ContainedConjugates">
 ##  <ManSection>
-##  <Oper Name="ContainedConjugates" Arg='G, A, B'/>
+##  <Oper Name="ContainedConjugates" Arg='G, A, B [,onlyone]'/>
 ##
 ##  <Description>
 ##  For <M>A,B \leq G</M> this operation returns representatives of the <A>A</A>
 ##  conjugacy classes of subgroups that are conjugate to <A>B</A> under <A>G</A>.
 ##  The function returns a list of pairs of subgroup and conjugating element.
+##  If the optional fourth argument <A>onlyone</A> is given as <A>true</A>,
+##  then only one pair (or <A>fail</A> if none exists) is returned.
 ##  <Example><![CDATA[
 ##  gap> g:=SymmetricGroup(8);;
-##  gap> a:=TransitiveGroup(8,47);;b:=TransitiveGroup(8,7);;
+##  gap> a:=TransitiveGroup(8,47);;b:=TransitiveGroup(8,9);;
 ##  gap> ContainedConjugates(g,a,b);
-##  [ [ Group([ (1,4,2,5,3,6,8,7), (1,3)(2,8) ]), (2,4,5,3)(7,8) ] ]
+##  [ [ Group([ (1,8)(2,3)(4,5)(6,7), (1,3)(2,8)(4,6)(5,7), (1,5)(2,6)(3,7)(4,8),
+##          (4,5)(6,7) ]), () ],
+##    [ Group([ (1,8)(2,3)(4,5)(6,7), (1,5)(2,6)(3,7)(4,8), (1,3)(2,8)(4,6)(5,7),
+##          (2,3)(6,7) ]), (2,4)(3,5) ] ]
+##  gap> ContainedConjugates(g,a,b,true);
+##  [ Group([ (1,8)(2,3)(4,5)(6,7), (1,3)(2,8)(4,6)(5,7), (1,5)(2,6)(3,7)(4,8),
+##      (4,5)(6,7) ]), () ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3187,13 +3187,13 @@ local act,offset,G,lim,cond,dosub,all,m,i,j,new,old;
   return all;
 end);
 
-#############################################################################
-##
-#F  ContainedConjugates( <G>, <A>, <B> )
-##
-InstallMethod(ContainedConjugates,"finite groups",IsFamFamFam,[IsGroup,IsGroup,IsGroup],0,
-function(G,A,B)
-local l,N,dc,gens,i;
+DoContainedConjugates:=function(arg)
+local G,A,B,onlyone,l,N,dc,gens,i;
+  G:=arg[1];
+  A:=arg[2];
+  B:=arg[3];
+  if Length(arg)>3 then onlyone:=arg[4]; else onlyone:=false;fi;
+
   if not IsFinite(G) and IsFinite(A) and IsFinite(B) then
      TryNextMethod();
   fi;
@@ -3201,7 +3201,8 @@ local l,N,dc,gens,i;
     Error("A and B must be subgroups of G");
   fi;
   if Size(A) mod Size(B)<>0 then
-    return []; # cannot be contained by order
+    # cannot be contained by order
+    if onlyone then return fail;else return [];fi;
   fi;
 
   l:=[];
@@ -3211,15 +3212,30 @@ local l,N,dc,gens,i;
     gens:=SmallGeneratingSet(B);
     for i in dc do
       if ForAll(gens,x->x^i[1] in A) then
+        if onlyone then return [B^i[1],i[1]];fi;
         Add(l,[B^i[1],i[1]]);
       fi;
     od;
+    if onlyone then return fail;fi;
     return l;
+  elif onlyone then
+    l:=DoConjugateInto(G,A,B,true);
+    if IsIdenticalObj(FamilyObj(l),FamilyObj(One(G))) then return [B^l,l];
+    else return fail;fi;
   else
     l:=DoConjugateInto(G,A,B,false);
     return List(l,x->[B^x,x]);
   fi;
-end);
+end;
+
+#############################################################################
+##
+#F  ContainedConjugates( <G>, <A>, <B> )
+##
+InstallMethod(ContainedConjugates,"finite groups",IsFamFamFam,
+  [IsGroup,IsGroup,IsGroup],0,DoContainedConjugates);
+InstallOtherMethod(ContainedConjugates,"onlyone",IsFamFamFamX,
+  [IsGroup,IsGroup,IsGroup,IsBool],0,DoContainedConjugates);
 
 #############################################################################
 ##

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2675,7 +2675,8 @@ local m;
       # the group is a good part
       # sizeable radical
       or Size(RadicalGroup(G))^2>Size(G)
-      or ValueOption("forcetest")=true) then
+      or ValueOption("forcetest")=true) and 
+      ValueOption("forcetest")<>"old" then
     # In place until a proper implementation of Cannon/Holt isomorphism is
     # done
     return PatheticIsomorphism(G,H);

--- a/tst/testbugfix/2021-02-07-IntermediateGroup.tst
+++ b/tst/testbugfix/2021-02-07-IntermediateGroup.tst
@@ -1,0 +1,6 @@
+# IntermediateGroup in large index, reported in Forum (Breuer/Anvita) on 2/7/21
+gap> L:=PSL(2,7^3);;
+gap> S:=SylowSubgroup(L,2);;
+gap> u:=IntermediateGroup(L,S);;
+gap> IsGroup(u) and Size(u)>Size(S);
+true

--- a/tst/teststandard/grpprmcs.tst
+++ b/tst/teststandard/grpprmcs.tst
@@ -312,6 +312,10 @@ Group
 Group
 gap> List( ChiefSeriesOfGroup( g ), Size );
 [ 1215506, 607753, 31987, 1103, 1 ]
+gap> u:=NormalClosure(g,SylowSubgroup(g,2));;
+gap> cs:=ChiefSeriesThrough(g,[u]);;
+gap> List(cs,Size);
+[ 1215506, 63974, 2206, 1103, 1 ]
 
 # $Co_2$ on 2300 points
 gap> g:=

--- a/tst/teststandard/grpprmcs.tst
+++ b/tst/teststandard/grpprmcs.tst
@@ -316,6 +316,9 @@ gap> u:=NormalClosure(g,SylowSubgroup(g,2));;
 gap> cs:=ChiefSeriesThrough(g,[u]);;
 gap> List(cs,Size);
 [ 1215506, 63974, 2206, 1103, 1 ]
+gap> cs:=CompositionSeriesThrough(g,[u]);;
+gap> List(cs,Size);
+[ 1215506, 63974, 2206, 1103, 1 ]
 
 # $Co_2$ on 2300 points
 gap> g:=


### PR DESCRIPTION
Changes for Release notes:

- `IntermediateGroup` might have returned `fail` if the index was large but subgroups exist  (instead of issuing an error message or warning about a hard calculation)

Changes that do not require release notes:

- Speed up collection process for 2-cohomology
- If factor permrep is large, do first try for stabilizer
- when computing permdegree, avoid the bold first attempt to be too bad.

- Better composition series choice in `SubgroupConditionAbove` -- move known parts on bottom.
- Introduces `CompositionSeriesThrough` as a tool
- Improvements in normalizers in `SubgroupConditionAbove`. Use NormalizerViaRadical if there is huge radical bit.
- Delay bottom permrep, if bounded orbit algorithms will do the job.
- Allow forcing old isomorphism test
- Redo generators when searching for trick relators
- Require to stabilize sets of normal subgroups (may reduce in factor)
- Also added option for `ContainedConjugates` (does not merit mentioning in release notes)

Also Typo fix/remove outdated comment in gpfpiso

Resolves #4240.