### PR TITLE
kernel: drop stackAlign argument from InitBags

### DIFF
--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -257,9 +257,7 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func)
     Panic("SetExtraMarkFuncBags not implemented for Boehm GC");
 }
 
-void InitBags(UInt              initial_size,
-              Bag *             stack_bottom,
-              UInt              stack_align)
+void InitBags(UInt initial_size, Bag * stack_bottom)
 {
     UInt i; /* loop variable                   */
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1466,8 +1466,7 @@ void InitializeGap (
 #else
         0,
 #endif
-             (Bag *)(((UInt)pargc / C_STACK_ALIGN) * C_STACK_ALIGN),
-             C_STACK_ALIGN);
+             (Bag *)(((UInt)pargc / C_STACK_ALIGN) * C_STACK_ALIGN));
 
     STATE(ThrownObject) = 0;
     STATE(UserHasQUIT) = 0;

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1197,13 +1197,11 @@ void FinishBags( void )
 **
 *F  InitBags(...) . . . . . . . . . . . . . . . . . . . . . initialize Gasman
 **
-**  'InitBags' remembers <stack-func>, <stack-bottom>, and <stack-align>
-**  in global variables. It also allocates the initial workspace, and sets up
-**  the linked list of available masterpointer.
+**  'InitBags' stores <stack-bottom> in a global variable. It also allocates
+**  the initial workspace, and sets up the linked list of available
+**  masterpointers.
 */
 static Bag * StackBottomBags;
-
-static UInt StackAlignBags;
 
 static TNumExtraMarkFuncBags ExtraMarkFuncBags;
 void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func)
@@ -1220,10 +1218,7 @@ void SetStackBottomBags(void * StackBottom)
 }
 
 
-void            InitBags (
-    UInt                initial_size,
-    Bag *               stack_bottom,
-    UInt                stack_align )
+void InitBags(UInt initial_size, Bag * stack_bottom)
 {
     Bag *               p;              /* loop variable                   */
     UInt                i;              /* loop variable                   */
@@ -1235,7 +1230,6 @@ void            InitBags (
 
     // install the stack values
     StackBottomBags = stack_bottom;
-    StackAlignBags  = stack_align;
 
     /* first get some storage from the operating system                    */
     initial_size    = (initial_size + 511) & ~(511);
@@ -1872,7 +1866,7 @@ static NOINLINE void GenStackFuncBags(void)
 
     top = (Bag*)((void*)&top);
     if ( StackBottomBags < top ) {
-        for ( i = 0; i < sizeof(Bag*); i += StackAlignBags ) {
+        for (i = 0; i < sizeof(Bag *); i += C_STACK_ALIGN) {
             for (p = (Bag *)((char *)StackBottomBags + i); p < top; p++) {
                 Bag * pcpy = p;
 #if defined(GAP_MEMORY_CANARY)
@@ -1884,7 +1878,7 @@ static NOINLINE void GenStackFuncBags(void)
         }
     }
     else {
-        for ( i = 0; i < sizeof(Bag*); i += StackAlignBags ) {
+        for (i = 0; i < sizeof(Bag *); i += C_STACK_ALIGN) {
             for (p = (Bag *)((char *)StackBottomBags - i); top < p; p--) {
                 Bag * pcpy = p;
 #if defined(GAP_MEMORY_CANARY)

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -850,7 +850,7 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func);
 
 /****************************************************************************
 **
-*F  InitBags(<initialSize>,<stackStart>,<stackAlign>) . . . initialize Gasman
+*F  InitBags(<initialSize>, <stackStart>) . . . . . . . . . initialize Gasman
 **
 **  'InitBags'  initializes {\Gasman}.  It  must be called from a application
 **  using {\Gasman} before any bags can be allocated.
@@ -864,15 +864,8 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func);
 **  the stack grows upward or downward. A value that usually works is the
 **  address of the argument 'argc' of the 'main' function of the application,
 **  i.e., '(Bag\*)\&argc'.
-**
-**  <stackAlign> must be the alignment of items of type 'Bag' on the stack.
-**  It must be a divisor of 'sizeof(Bag)'. The addresses of all identifiers
-**  on the stack must be a multiple of <stackAlign>. If it is 1, identifiers
-**  may be anywhere on the stack, and if it is 'sizeof(Bag)', identifiers may
-**  only be at addresses that are a multiple of 'sizeof(Bag)'. This value
-**  depends on the machine, the operating system, and the compiler.
 */
-void InitBags(UInt initialSize, Bag * stackStart, UInt stackAlign);
+void InitBags(UInt initialSize, Bag * stackStart);
 
 
 /****************************************************************************

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -202,7 +202,6 @@ static void JFinalizer(jl_value_t * obj)
 static jl_datatype_t * datatype_mptr;
 static jl_datatype_t * datatype_bag;
 static jl_datatype_t * datatype_largebag;
-static UInt            StackAlignBags = sizeof(void *);
 static Bag *           GapStackBottom;
 static jl_ptls_t       JuliaTLS, SaveTLS;
 static BOOL            is_threaded;
@@ -498,7 +497,7 @@ static void FindLiveRangeReverse(PtrArray * arr, void * start, void * end)
             jl_typeis(addr, datatype_mptr)) {
             PtrArrayAdd(arr, addr);
         }
-        q -= StackAlignBags;
+        q -= C_STACK_ALIGN;
     }
 }
 
@@ -660,7 +659,7 @@ static NOINLINE void TryMarkRange(void * start, void * end)
         SWAP(void *, start, end);
     }
     char * p = (char *)align_ptr(start);
-    char * q = (char *)end - sizeof(void *) + StackAlignBags;
+    char * q = (char *)end - sizeof(void *) + C_STACK_ALIGN;
     while (lt_ptr(p, q)) {
         void * addr = *(void **)p;
         if (addr) {
@@ -672,7 +671,7 @@ static NOINLINE void TryMarkRange(void * start, void * end)
             }
 #endif
         }
-        p += StackAlignBags;
+        p += C_STACK_ALIGN;
     }
 }
 
@@ -970,9 +969,8 @@ void GAP_InitJuliaMemoryInterface(jl_module_t *   module,
 
 }
 
-void InitBags(UInt initial_size, Bag * stack_bottom, UInt stack_align)
+void InitBags(UInt initial_size, Bag * stack_bottom)
 {
-    StackAlignBags = stack_align;
     GapStackBottom = stack_bottom;
     totalTime = 0;
 


### PR DESCRIPTION
It was always set to C_STACK_ALIGN; so just use that instead. This simplifies
some code, should result in a very tiny performance improvement, and allows
getting rid of a hack in the Julia GC code.
