### PR TITLE
Do not name functions with automatically generated names

### DIFF
--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -73,6 +73,21 @@ gap> READ("/this/path/does/not/exist!");
 false
 gap> READ(InputTextString(""));
 true
+gap> stream := InputTextString("function() end;");
+InputTextString(0,15)
+gap> READ(stream);
+true
+gap> LastReadValue;
+function(  ) ... end
+gap> NameFunction(LastReadValue);
+"unknown"
+gap> stream := InputTextString("function() end;");
+InputTextString(0,15)
+gap> READ(stream);
+true
+gap> func := LastReadValue;;
+gap> NameFunction(func);
+"func"
 
 #
 gap> READ_NORECOVERY(fail);
@@ -97,8 +112,10 @@ Error, READ_AS_FUNC: <input> must be a string or an input stream (not the valu\
 e 'fail')
 gap> READ_AS_FUNC("/this/path/does/not/exist!");
 false
-gap> READ_AS_FUNC(InputTextString(""));
+gap> func := READ_AS_FUNC(InputTextString(""));
 function(  ) ... end
+gap> NameFunction(func);
+"func"
 
 #
 gap> READ_GAP_ROOT(fail);


### PR DESCRIPTION
Functions are usually named using the first variable they are
assigned to. Disable this for automatically assigned variables
like Last and LastReadValue

Added some brief documentation to some internal functions at the same time.

Fixes #4223 
