### PR TITLE
Minor grammar changes to documentation and comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -299,7 +299,7 @@ These changes are also listed on the
 
   - `LatticeViaRadical` called `ClosureSubgroupNC` assuming that the
     parent contained all generators. It now calls `ClosureSubgroup`
-    instead, since this can not be always guaranteed (this could
+    instead, since this cannot always be guaranteed (this could
     happen, for example, in perfect subgroup computation). Also
     added an assertion to `ClosureSubgroupNC` to catch this
     situation in other cases. (Reported by Serge Bouc)
@@ -3798,7 +3798,7 @@ an introduction to GAP 4.5, accompanying its release announcement.
 
   - Due to improvements for vectors over finite fields, certain objects
     have more limitations on changing their base field. For example, one
-    can not create a compressed matrix over GF(2) and then assign an
+    cannot create a compressed matrix over GF(2) and then assign an
     element of GF(4) to one of its entries.
 
 ### No longer supported:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -511,7 +511,7 @@ files in the `bin` directory: `gap.bat` and `gapcmd.bat`. Also,
 
 ### GAP does not work in the remote desktop
 
-GAP can not be started in the Windows Command Prompt shell (via `gapcmd.bat`)
+GAP cannot be started in the Windows Command Prompt shell (via `gapcmd.bat`)
 in the remote desktop. To start GAP in the remote desktop, use the script
 `gap.bat` which should work in such setting.
 

--- a/cnf/GAP-VERSION-GEN
+++ b/cnf/GAP-VERSION-GEN
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script generates a version string for GAP based on the the VERSION file
+# This script generates a version string for GAP based on the VERSION file
 # (if any) and the output of `git describe` (if inside a git working tree).
 #
 # The result is printed into cnf/GAP-VERSION-FILE, but only if the version

--- a/configure.ac
+++ b/configure.ac
@@ -237,7 +237,7 @@ AS_CASE([$with_gc],
                  AC_DEFINE([USE_BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
                 ],
     [gasman],   [AS_IF([test "x$enable_hpcgap" = xyes],
-                    [AC_MSG_ERROR([GASMAN can not be used with HPC-GAP])])
+                    [AC_MSG_ERROR([GASMAN cannot be used with HPC-GAP])])
                  AC_SUBST([GC_SOURCES], ["src/gasman.c src/sysmem.c"])
                  AC_DEFINE([USE_GASMAN],    [1], [define as 1 if GASMAN is used])
                 ],

--- a/doc/dev/kernel.xml
+++ b/doc/dev/kernel.xml
@@ -628,7 +628,7 @@ object to a &C; integer. These functions do NOT check for overflows.
 <P/>
 
 The other two integer types are <C>T_INTPOS</C> and <C>T_INTNEG</C> for
-positive (respectively, negative) integer values  that  can  not  be
+positive (respectively, negative) integer values  that  cannot  be
 represented  by  immediate  integers. See comments in <F>integer.c</F>
 for details.
 <P/>

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -1007,7 +1007,7 @@ The <E>previous</E> exit code is returned.
 
 <Description>
 <Ref Func="QuitGap"/> acts similarly to the keyword <C>QUIT</C>, except
-<C>QUIT</C> can not be called from a function. It exits
+<C>QUIT</C> cannot be called from a function. It exits
 &GAP; cleanly, calling any function installed using <Ref Func="InstallAtExit"/>.
 The optional argument <A>ret</A> will be passed to <Ref Func="GapExitCode"/>.
 <P/>

--- a/doc/ref/ratfun.xml
+++ b/doc/ref/ratfun.xml
@@ -669,7 +669,7 @@ They are represented by lists, using numbers
 <#Include Label="[4]{ratfun}">
 <#Include Label="[1]{ratfun}">
 <P/>
-The attributes that give a representation of a a rational function as a Laurent polynomial are
+The attributes that give a representation of a rational function as a Laurent polynomial are
 <Ref Attr="CoefficientsOfLaurentPolynomial"/>
 and <Ref Attr="IndeterminateNumberOfUnivariateRationalFunction"/>.
 <P/>

--- a/doc/ref/rws.xml
+++ b/doc/ref/rws.xml
@@ -42,7 +42,7 @@ we can replace the subterm <M>l</M> of <M>u</M> by the term <M>r</M>
 and obtain a new word <M>v</M>.
 We say that we have <E>rewritten</E> <M>u</M> as <M>v</M>. 
 Note that <M>u</M> and <M>v</M> represent the same element of <M>A</M>.
-If <M>u</M> can not be rewritten using any rule of the rewriting system
+If <M>u</M> cannot be rewritten using any rule of the rewriting system
 we sat that <M>u</M> is <E>reduced</E>. 
 
 

--- a/doc/ref/types.xml
+++ b/doc/ref/types.xml
@@ -722,7 +722,7 @@ one can use logical implications
 <Heading>Types</Heading>
 
 We stated above (see <Ref Chap="Types of Objects"/>) that, for an object <A>obj</A>,
-its <E>type</E> is formed from its family and its filters.  There is a also
+its <E>type</E> is formed from its family and its filters.  There is also
 a third component, used in a few situations, namely defining data of
 the type.
 

--- a/hpcgap/demo/karatsuba.g
+++ b/hpcgap/demo/karatsuba.g
@@ -139,7 +139,7 @@ KaratsubaPolynomialMultiplicationExtRep:=function( f, g )
 local degf, degg, deg, n, halfn, nr, f1, f0, g1, g0, u, v, w, wuv, k, pos, pos1, val;
 # Zero polynomial will be represented as [ [  ], 0 ]
 # We took care that other representations of zero, for example [ [ 0, 0 ], 0 ] 
-# or [ [ 0, 0 ], 1 ], or [ [ 0 ], 1 ], can not occur, because we reduce
+# or [ [ 0, 0 ], 1 ], or [ [ 0 ], 1 ], cannot occur, because we reduce
 # the presentation after adding polynomials in PlusLaurentPolynomialsExtRep
 # and subtracting them in MinusLaurentPolynomialsExtRep. Note that degree
 # determination is also based on this feature.

--- a/hpcgap/lib/distributed/dist_tasks.g
+++ b/hpcgap/lib/distributed/dist_tasks.g
@@ -412,7 +412,7 @@ WaitTask := function(arg)
   for task in arg do
     atomic readonly task do 
       if task.async then
-        Error("Cannot wait for a asynchronous task");
+        Error("Cannot wait for an asynchronous task");
       fi;
     od;
   od;
@@ -460,7 +460,7 @@ WaitAnyTask := function(arg)
     LOCK (task, false);
     if task.async then
       UNLOCK(task);
-      Error("Cannot wait for a async task");
+      Error("Cannot wait for an async task");
     fi;
     if not task.started then
       UNLOCK(task);
@@ -487,7 +487,7 @@ TaskResult := function(task)
   toFetch := false;
   atomic readonly task do
     if task.async then
-      Error("Cannot obtain the result of a asynchronous task");
+      Error("Cannot obtain the result of an asynchronous task");
     fi;
     if task.offloaded then 
       toFetch := true;

--- a/hpcgap/lib/hpc/tasks.g
+++ b/hpcgap/lib/hpc/tasks.g
@@ -338,7 +338,7 @@ WaitTask := function(arg)
   for task in arg do
     atomic readonly task do 
       if task.async then
-        Error("Cannot wait for a asynchronous task");
+        Error("Cannot wait for an asynchronous task");
       fi;
     od;
   od;
@@ -383,7 +383,7 @@ WaitAnyTask := function(arg)
     WRITE_LOCK(task,false);
     if task.async then
       UNLOCK(task);
-      Error("Cannot wait for a async task");
+      Error("Cannot wait for an async task");
     fi;
     if not task.started then
       UNLOCK(task);
@@ -411,7 +411,7 @@ TaskResult := function(task)
   
   atomic readonly task do
     if task.async then
-      Error("Cannot obtain the result of a asynchronous task");
+      Error("Cannot obtain the result of an asynchronous task");
     fi;
     
     if not task.started then

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -1441,13 +1441,13 @@ InstallGlobalFunction(CopyToVectorRep,function( v, q )
                 # vector needs a field > 256, so can't be compressed
                 # or vector contains non-ffes or no common characteristic
                 #
-                return fail; # v can not be written over GF(q)
+                return fail; # v cannot be written over GF(q)
             fi;
             if not IsMutable(v) then
                 MakeImmutable(vc);
             fi;
         else
-            return fail; # v can not be written over GF(q)
+            return fail; # v cannot be written over GF(q)
         fi;
     else
         common := COMMON_FIELD_VECFFE(v);
@@ -1479,7 +1479,7 @@ InstallGlobalFunction(CopyToVectorRep,function( v, q )
         if not IsMutable(v) then MakeImmutable(res); fi;
         return res;
     else    
-        return fail; # vector can not be written over GF(q)
+        return fail; # vector cannot be written over GF(q)
     fi;
 end);
 

--- a/lib/addmagma.gi
+++ b/lib/addmagma.gi
@@ -643,7 +643,7 @@ BindGlobal( "ClosureAdditiveMagmaDefault", function( A, elm )
 
     gens:= GeneratorsOfAdditiveMagma( A );
 
-    # try to avoid adding an element to a add. magma that already contains it
+    # try to avoid adding an element to an add. magma that already contains it
     if   elm in gens
       or ( HasAsSSortedList( A ) and elm in AsSSortedList( A ) )
     then

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -1306,7 +1306,7 @@ InstallMethod( AsFLMLORWithOne,
 
 #############################################################################
 ##
-#M  AsFLMLORWithOne( <F>, <V> ) . .  view a left module as a algebra-with-one
+#M  AsFLMLORWithOne( <F>, <V> ) . . view a left module as an algebra-with-one
 ##
 InstallMethod( AsFLMLORWithOne,
     "for a division ring and a free left module",
@@ -1376,7 +1376,7 @@ InstallMethod( AsFLMLORWithOne,
 
 #############################################################################
 ##
-#M  AsFLMLORWithOne( <F>, <D> ) . . . . view an algebra as a algebra-with-one
+#M  AsFLMLORWithOne( <F>, <D> ) . . .  view an algebra as an algebra-with-one
 ##
 InstallMethod( AsFLMLORWithOne,
     "for a division ring and an algebra",
@@ -1440,7 +1440,7 @@ InstallMethod( AsFLMLORWithOne,
 #M  AsFLMLORWithOne( <F>, <D> ) . . view an alg.-with-one as an alg.-with-one
 ##
 InstallMethod( AsFLMLORWithOne,
-    "for a division ring and a algebra-with-one",
+    "for a division ring and an algebra-with-one",
     [ IsDivisionRing, IsFLMLORWithOne ],
     function( F, D )
     local L, A;
@@ -2209,7 +2209,7 @@ InstallMethod( AsSubalgebraWithOne,
     end );
 
 InstallMethod( AsSubalgebraWithOne,
-    "for an algebra and a algebra-with-one",
+    "for an algebra and an algebra-with-one",
     IsIdenticalObj,
     [ IsAlgebra, IsAlgebraWithOne ],
     function( A, U )

--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -1254,8 +1254,8 @@ end );
 
 #############################################################################
 ##
-#M  \/( <V>, <W> )  . . . . . . .factor of a an algebra module by a submodule
-#M  \/( <V>, <vectors> )  . . . .factor of a an algebra module by a submodule
+#M  \/( <V>, <W> )  . . . . . . .  factor of an algebra module by a submodule
+#M  \/( <V>, <vectors> )  . . . .  factor of an algebra module by a submodule
 ##
 InstallOtherMethod( \/,
         "for an algebra module and collection",

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -1506,7 +1506,7 @@ end);
 ##  partitions    are  nonincreasing.   Also    '<part>[<i>]' must    be  \<=
 ##  '<n>+1-<k>', since  we need at   least  <k>-1  ones  to  fill the   <k>-1
 ##  positions of <part> remaining after  filling '<part>[<i>]'.  On the other
-##  hand '<part>[<i>]'  must be  >=  '<n>/<k>', because otherwise we  can not
+##  hand '<part>[<i>]'  must be  >=  '<n>/<k>', because otherwise  we  cannot
 ##  fill the <k>-1 remaining positions nonincreasingly.   It is not difficult
 ##  to show  that for  each  candidate satisfying these properties   there is
 ##  indeed a partition, i.e., we never run into a dead end.

--- a/lib/float.gi
+++ b/lib/float.gi
@@ -902,7 +902,7 @@ end );
 
 InstallOtherMethod( Indeterminate, [IsFloatFamily,IsPosInt],
         function(fam,ind)
-    Error("`Indeterminate(<family>,<ind>)' can not be used with floats; use `Indeterminate(<float pseudofield>,<ind>)'");
+    Error("`Indeterminate(<family>,<ind>)' cannot be used with floats; use `Indeterminate(<float pseudofield>,<ind>)'");
 end);
 
 InstallOtherMethod( Indeterminate,"number", true, [ IsFloatPseudoField,IsPosInt ],0,

--- a/lib/gpprmsya.gd
+++ b/lib/gpprmsya.gd
@@ -61,7 +61,7 @@ InstallTrueMethod( IsPermGroup, IsNaturalAlternatingGroup );
 ##  <Prop Name="IsAlternatingGroup" Arg='group'/>
 ##
 ##  <Description>
-##  is <K>true</K> if the group <A>group</A> is isomorphic to a
+##  is <K>true</K> if the group <A>group</A> is isomorphic to an
 ##  alternating group.
 ##  </Description>
 ##  </ManSection>

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -5860,7 +5860,7 @@ function(G,elm)
 
 
   # no pool needed: If the length of w is n, and g is a generator, the
-  # length of w/g can not be less than n-1 (otherwise (w/g)*g is a shorter
+  # length of w/g cannot be less than n-1 (otherwise (w/g)*g is a shorter
   # word) and cannot be more than n+1 (otherwise w/g is a shorter word for
   # it). Thus, if the length of w/g is OK mod 3, it is the right path.
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1316,7 +1316,7 @@ InstallMethod( Characteristic,
 ##  prescribed mutability return a matrix object compatible with <A>M</A>,
 ##  provided that <A>M</A> is invertible.
 ##  <!-- over its base domain? -->
-##  (If <A>M</A> is not invertible the the operations return <K>fail</K>.)
+##  (If <A>M</A> is not invertible then the operations return <K>fail</K>.)
 ##  <P/>
 ##  <Ref Prop="IsZero" Label="for matrix object"/> returns <K>true</K> if
 ##  all entries in <A>M</A> are zero, and <K>false</K> otherwise.

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -1843,7 +1843,7 @@ end;
 ## FieldGenCentMat( ) should only be applied to modules that have already
 ## been proved irreducible using IsIrreducible. It then tests for absolute
 ## irreducibility (if not already known) and does nothing if module is
-## absolutely irreducible. Otherwise, it returns a a matrix that generates
+## absolutely irreducible. Otherwise, it returns a matrix that generates
 ## (multiplicatively) the centralizing field (i.e. its multiplicative order
 ## is q^e - 1, where e is the degree of the centralizing field. This is not
 ## yet used, but maybe in future, if we wish to reduce the group to matrices

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -1448,7 +1448,7 @@ BIND_GLOBAL( "DeclareAttribute", function ( name, filter, args... )
             req := GET_OPER_FLAGS( Setter(gvar) );
             STORE_OPER_FLAGS( Setter(gvar), [ FLAGS_FILTER( filter), req[1][2] ] );
         else
-            # gvar is a an existing non-attribute operation, try to convert it
+            # gvar is an existing non-attribute operation, try to convert it
             # into an attribute
             ConvertToAttribute(name, gvar, filter, rank, mutflag);
         fi;

--- a/lib/orders.gi
+++ b/lib/orders.gi
@@ -154,7 +154,7 @@ InstallOtherMethod( OrderingByLessThanOrEqualFunctionNC,
 #A  LessThanOrEqualFunction( <ord> )
 ##
 InstallMethod( LessThanOrEqualFunction,
-  "for an ordering which has a a LessThanFunction", true,
+  "for an ordering which has a LessThanFunction", true,
   [IsOrdering and HasLessThanFunction], 0,
   function( ord)
     local fun;
@@ -172,7 +172,7 @@ end);
 #A  LessThanFunction( <ord> )
 ##
 InstallMethod( LessThanFunction,
-  "for an ordering which has a a LessThanOrEqualFunction", true,
+  "for an ordering which has a LessThanOrEqualFunction", true,
   [IsOrdering and HasLessThanOrEqualFunction], 0,
   function( ord)
     local fun;

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -1042,7 +1042,7 @@ DeclareGlobalFunction( "DeclareAutoreadableVariables" );
 ##  <P/>
 ##  The argument <A>info</A> must be either a record as is contained in a
 ##  <F>PackageInfo.g</F> file
-##  or a a string which describes the path to such a file.
+##  or a string which describes the path to such a file.
 ##  The result is <K>true</K> if the record or the contents of the file,
 ##  respectively, has correct format, and <K>false</K> otherwise;
 ##  in the latter case information about the incorrect components is printed.

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -435,7 +435,7 @@ SetOne( PermutationsFamily, () );
 ##  or if <A>list</A> contains a positive integer twice,
 ##  or if <A>list</A> contains an
 ##  integer not in the range <C>[ 1 .. Length( <A>list</A> ) ]</C>,
-##  of if <A>list</A> contains non-integer entries, etc.
+##  or if <A>list</A> contains non-integer entries, etc.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -801,7 +801,7 @@ InstallMethod( Order,
 ##  <Description>
 ##  returns the number of points for which <A>perm1</A> and <A>perm2</A> 
 ##  have different images. This should always produce the same result as
-##  <C>NrMovePoints(<A>perm1</A>/<A>perm2</A>)</C> but some methods may be
+##  <C>NrMovedPoints(<A>perm1</A>/<A>perm2</A>)</C> but some methods may be
 ##  much faster than this form, since no new permutation needs to be created.
 ##  </Description>
 ##  </ManSection>

--- a/lib/randiso.gd
+++ b/lib/randiso.gd
@@ -152,8 +152,8 @@ DeclareGlobalFunction( "RandomSpecialPcgsCoded" );
 ##  The integer <A>n</A> gives a certain amount of control over the 
 ##  probability to detect all isomorphisms. If it is <M>0</M>, then nothing 
 ##  will be done at all. The larger <A>n</A> is, the larger is the probability
-##  of finding all isomorphisms. However, due to the underlying method we can
-##  not guarantee that the algorithm finds all isomorphisms, no matter how
+##  of finding all isomorphisms. However, due to the underlying method we
+##  cannot guarantee that the algorithm finds all isomorphisms, no matter how
 ##  large <A>n</A> is.
 ##  </Description>
 ##  </ManSection>

--- a/lib/relation.gd
+++ b/lib/relation.gd
@@ -95,7 +95,7 @@ DeclareSynonym("IsBinaryRelation",IsEndoGeneralMapping);
 ##  this function constructs a binary relation such that <M>1</M> is related
 ##  to <A>list</A><C>[1]</C>, <M>2</M> to <A>list</A><C>[2]</C> and so on.
 ##  The first version checks whether the list supplied is valid.
-##  The the <C>NC</C> version skips this check.
+##  The <C>NC</C> version skips this check.
 ##  <Example><![CDATA[
 ##  gap> R:=BinaryRelationOnPoints([[1,2],[2],[3]]);
 ##  Binary Relation on 3 points

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -987,7 +987,7 @@ if not IsBound( GAPInfo.PackagesInfo.(pkgname) ) then
     Print("#I  No package with the name ", pkgname, " is available\n");
     return fail;
 elif LoadPackage( pkgname ) = fail then
-    Print( "#I ", pkgname, " package can not be loaded\n" );
+    Print( "#I ", pkgname, " package cannot be loaded\n" );
     return fail;
 elif not IsBound( GAPInfo.PackagesInfo.(pkgname)[1].TestFile ) then
     Print("#I No standard tests specified in ", pkgname, " package, version ",

--- a/lib/wordass.gd
+++ b/lib/wordass.gd
@@ -516,12 +516,12 @@ DeclareOperation( "AssignGeneratorVariables", [IsDomain] );
 ##
 ##  <#GAPDoc Label="Length:wordass">
 ##  <ManSection>
-##  <Attr Name="Length" Arg='w' Label="for a associative word"/>
+##  <Attr Name="Length" Arg='w' Label="for an associative word"/>
 ##
 ##  <Description>
 ##  <Index Subkey="of a word">length</Index>
 ##  For an associative word <A>w</A>,
-##  <Ref Attr="Length" Label="for a associative word"/> returns
+##  <Ref Attr="Length" Label="for an associative word"/> returns
 ##  the number of letters in <A>w</A>.
 ##  <P/>
 ##  <Example><![CDATA[

--- a/src/code.c
+++ b/src/code.c
@@ -1141,19 +1141,19 @@ void CodeForEnd ( void )
 *F  CodeAtomicEndBody( <nr> ) . . . . . .  code atomic-statement, end of body
 *F  CodeAtomicEnd() . . . . . . . . . code atomic-statement, end of statement
 **
-**  'CodeAtomicBegin' is an action to code a atomic-statement. It is called
+**  'CodeAtomicBegin' is an action to code an atomic-statement. It is called
 **  when the reader encounters the 'atomic', i.e., *before* the condition is
 **  read.
 **
-**  'CodeAtomicBeginBody' is an action  to code a atomic-statement. It is
+**  'CodeAtomicBeginBody' is an action  to code an atomic-statement. It is
 **  called when the reader encounters the beginning of the statement body,
 **  i.e., *after* the condition is read.
 **
-**  'CodeAtomicEndBody' is an action to code a atomic-statement. It is called
+**  'CodeAtomicEndBody' is an action to code an atomic-statement. It is called
 **  when the reader encounters the end of the statement body. <nr> is the
 **  number of statements in the body.
 **
-**  'CodeAtomicEnd' is an action to code a atomic-statement. It is called
+**  'CodeAtomicEnd' is an action to code an atomic-statement. It is called
 **  when the reader encounters the end of the statement, i.e., immediate
 **  after 'CodeAtomicEndBody'.
 */

--- a/src/code.h
+++ b/src/code.h
@@ -819,15 +819,15 @@ void CodeForEnd(void);
 **  when the reader encounters the 'atomic', i.e., *before* the condition is
 **  read.
 **
-**  'CodeAtomicBeginBody' is an action to code a atomic-statement. It is
+**  'CodeAtomicBeginBody' is an action to code an atomic-statement. It is
 **  called when the reader encounters the beginning of the statement body,
 **  i.e., *after* the condition is read.
 **
-**  'CodeAtomicEndBody' is an action to code a atomic-statement. It is called
+**  'CodeAtomicEndBody' is an action to code an atomic-statement. It is called
 **  when the reader encounters the end of the statement body. <nr> is the
 **  number of statements in the body.
 **
-**  'CodeAtomicEnd' is an action to code a atomic-statement. It is called
+**  'CodeAtomicEnd' is an action to code an atomic-statement. It is called
 **  when the reader encounters the end of the statement, i.e., immediately
 **  after 'CodeAtomicEndBody'.
 */

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -601,7 +601,7 @@ static void ConvertToBase(UInt n)
 **  <m> must be a divisor of $n$ and  gives a  hint about possible subfields.
 **  If a prime $p$ divides <m> then no  reduction into a subfield whose order
 **  is $n /  p$  is possible.   In the  arithmetic   functions  you can  take
-**  $lcm(n_l,n_r) / gcd(n_l,n_r) = n / gcd(n_l,n_r)$.  If you can not provide
+**  $lcm(n_l,n_r) / gcd(n_l,n_r) = n / gcd(n_l,n_r)$.  If you cannot provide
 **  such a hint just pass 1.
 **
 **  A special case of the  reduction is the case that  the  cyclotomic  is  a

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -490,7 +490,7 @@ static Obj EvalSum(Expr expr)
 
 /****************************************************************************
 **
-*F  EvalAInv(<expr>)  . . . . . . . . . . . . . . evaluate a additive inverse
+*F  EvalAInv(<expr>)  . . . . . . . . . . . . .  evaluate an additive inverse
 **
 **  'EvalAInv' evaluates  the additive  inverse-expression  and  returns  its
 **  value, i.e., the  additive inverse of  the operand.  'EvalAInv' is called

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -852,7 +852,7 @@ void SetExtraMarkFuncBags(TNumExtraMarkFuncBags func);
 **
 *F  InitBags(<initialSize>,<stackStart>,<stackAlign>) . . . initialize Gasman
 **
-**  'InitBags'  initializes {\Gasman}.  It  must be called from a application
+**  'InitBags'  initializes {\Gasman}.  It must be called from an application
 **  using {\Gasman} before any bags can be allocated.
 **
 **  <initialSize> must be the size of  the initial workspace that 'InitBags'

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -169,7 +169,7 @@ EXPORT_INLINE UInt TNUM_BAG(Bag bag)
 **
 **      if (TEST_BAG_FLAG(obj, FLAG1 | FLAG2 ) == FLAG1) ...
 **
-**  Each flag must be a an integer with exactly one bit set, e.g. a value
+**  Each flag must be an integer with exactly one bit set, e.g. a value
 **  of the form (1 << i). Currently, 'i' must be in the range from 0 to
 **  7 (inclusive).
 */

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -511,7 +511,7 @@ void AssGVarWithoutReadOnlyCheck(UInt gvar, Obj val)
 
 /****************************************************************************
 **
-*F  ValAutoGVar(<gvar>) . . . . . . . .  value of a automatic global variable
+*F  ValAutoGVar(<gvar>) . . . . . . . . value of an automatic global variable
 **
 **  'ValAutoGVar' returns the value of the global variable <gvar>.  This will
 **  be 0 if  <gvar> has  no assigned value.    It will also cause a  function

--- a/src/gvars.h
+++ b/src/gvars.h
@@ -81,7 +81,7 @@ extern void AssGVarWithoutReadOnlyCheck(UInt gvar, Obj val);
 
 /****************************************************************************
 **
-*F  ValAutoGVar(<gvar>) . . . . . . . .  value of a automatic global variable
+*F  ValAutoGVar(<gvar>) . . . . . . . . value of an automatic global variable
 **
 **  'ValAutoGVar' returns the value of the global variable <gvar>.  This will
 **  be 0 if  <gvar> has  no assigned value.    It will also cause a  function

--- a/src/integer.c
+++ b/src/integer.c
@@ -40,7 +40,7 @@
 **  a small integer value and its representation as immediate integer handle.
 **
 **  'T_INTPOS' and 'T_INTNEG' are the types of positive respectively negative
-**  integer values that can not be represented by immediate integers.
+**  integer values that cannot be represented by immediate integers.
 **
 **  These large integers values are represented as low-level GMP integer
 **  objects, that is, in base 2^N. That means that the bag of a large integer

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -297,20 +297,20 @@ void IntrQualifiedExprEnd(IntrState * intr);
 *F  IntrAtomicEndBody(<nr>) . . . . . interpret atomic-statement, end of body
 *F  IntrAtomicEnd() . . . . . .  interpret atomic-statement, end of statement
 **
-**  'IntrAtomicBegin' is an action to interpret a atomic-statement. It is
+**  'IntrAtomicBegin' is an action to interpret an atomic-statement. It is
 **  called when the reader encounters the 'atomic', i.e., *before* the
 **  condition is read.
 **
-**  'IntrAtomicBeginBody' is an action to interpret a atomic-statement. It is
+**  'IntrAtomicBeginBody' is an action to interpret an atomic-statement. It is
 **  called when the reader encounters the beginning of the statement body,
 **  i.e., *after* the expressions to be locked have been read. <nrexprs> is
 **  the number of such  expressions.
 **
-**  'IntrAtomicEndBody' is an action to interpret a atomic-statement. It is
+**  'IntrAtomicEndBody' is an action to interpret an atomic-statement. It is
 **  called when the reader encounters the end of the statement body. <nr> is
 **  the number of statements in the body.
 **
-**  'IntrAtomicEnd' is an action to interpret a atomic-statement. It is
+**  'IntrAtomicEnd' is an action to interpret an atomic-statement. It is
 **  called when the reader encounters the end of the statement, i.e.,
 **  lyimmediate after 'IntrAtomicEndBody'.
 **

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -391,7 +391,7 @@ static Obj ProdPerm(Obj opL, Obj opR)
 **  'QuoPerm' returns the quotient of the permutations <opL> and <opR>, i.e.,
 **  the product '<opL>\*<opR>\^-1'.
 **
-**  Unfortunatly this can not be done in <degree> steps, we need 2 * <degree>
+**  Unfortunately this cannot be done in <degree> steps, we need 2 * <degree>
 **  steps.
 */
 static Obj QuoPerm(Obj opL, Obj opR)

--- a/src/range.c
+++ b/src/range.c
@@ -558,7 +558,7 @@ Obj             PosRange (
         }
     }
 
-    /* otherwise it can not be an element of the range                     */
+    /* otherwise it cannot be an element of the range                     */
     else {
         k = 0;
     }

--- a/src/stats.c
+++ b/src/stats.c
@@ -1313,7 +1313,7 @@ static void PrintWhile(Stat stat)
 
 /****************************************************************************
 **
-*F  PrintAtomic(<stat>)  . . . . . . . . . . . . . . . . .  print a atomic loop
+*F  PrintAtomic(<stat>)  . . . . . . . . . . . . . . . . print an atomic loop
 **
 **  'PrintAtomic' prints the atomic-loop <stat>.
 **

--- a/src/streams.c
+++ b/src/streams.c
@@ -520,7 +520,7 @@ Int READ_GAP_ROOT ( const Char * filename )
 static Obj FuncCLOSE_LOG_TO(Obj self)
 {
     if ( ! CloseLog() ) {
-        ErrorQuit("LogTo: can not close the logfile", 0, 0);
+        ErrorQuit("LogTo: cannot close the logfile", 0, 0);
     }
     return True;
 }
@@ -582,7 +582,7 @@ static Obj FuncLOG_TO_STREAM(Obj self, Obj stream)
 static Obj FuncCLOSE_INPUT_LOG_TO(Obj self)
 {
     if ( ! CloseInputLog() ) {
-        ErrorQuit("InputLogTo: can not close the logfile", 0, 0);
+        ErrorQuit("InputLogTo: cannot close the logfile", 0, 0);
     }
     return True;
 }
@@ -643,7 +643,7 @@ static Obj FuncINPUT_LOG_TO_STREAM(Obj self, Obj stream)
 static Obj FuncCLOSE_OUTPUT_LOG_TO(Obj self)
 {
     if ( ! CloseOutputLog() ) {
-        ErrorQuit("OutputLogTo: can not close the logfile", 0, 0);
+        ErrorQuit("OutputLogTo: cannot close the logfile", 0, 0);
     }
     return True;
 }

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -82,7 +82,7 @@ static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count);
 **
 *V  syBuf . . . . . . . . . . . . . .  buffer and other info for files, local
 **
-**  'syBuf' is  a array used as  buffers for  file I/O to   prevent the C I/O
+**  'syBuf' is an array used as  buffers for  file I/O to   prevent the C I/O
 **  routines  from   allocating their  buffers  using  'malloc',  which would
 **  otherwise confuse Gasman.
 **

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1484,7 +1484,7 @@ static Obj FuncCOPY_GF2VEC(Obj self, Obj list)
 **
 *F FuncCONV_GF2MAT (<self>, <list> ) . . . convert into a GF2 matrix rep
 **
-** <list> should be a a list of compressed GF2 vectors
+** <list> should be a list of compressed GF2 vectors
 **
 */
 static Obj FuncCONV_GF2MAT(Obj self, Obj list)

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -117,7 +117,7 @@
 
 /****************************************************************************
 **
-*F  ELM_GF2VEC( <list>, <pos> ) . . . . . . . . . . element of a a GF2 vector
+*F  ELM_GF2VEC( <list>, <pos> ) . . . . . . . . . . . element of a GF2 vector
 **
 **  'ELM_GF2VEC' return the <pos>-th element of  the GF2 vector <list>, which
 **  is either 'Z(2)' or '0*Z(2)'.  <pos> must be a positive integer less than
@@ -159,7 +159,7 @@
 
 /****************************************************************************
 **
-*F  ELM_GF2MAT( <list>, <pos> ) . . . . . . . . . . element of a a GF2 matrix
+*F  ELM_GF2MAT( <list>, <pos> ) . . . . . . . . . . . element of a GF2 matrix
 **
 **  'ELM_GF2MAT' returns the <pos>-th element of the GF2 matrix <list>, which
 **  is a GF2 vector.  <pos> must be a positive  integer less than or equal to
@@ -173,7 +173,7 @@
 
 /****************************************************************************
 **
-*F  SET_ELM_GF2MAT( <list>, <pos>, <elm> )  . . set element of a a GF2 matrix
+*F  SET_ELM_GF2MAT( <list>, <pos>, <elm> )  . . . set element of a GF2 matrix
 **
 **  'SET_ELM_GF2MAT'  sets the <pos>-th element   of  the GF2 matrix  <list>,
 **  which must be a  GF2 vector.  <pos> must  be a positive integer less than

--- a/tst/testbugfix/2012-10-26-t00261.tst
+++ b/tst/testbugfix/2012-10-26-t00261.tst
@@ -2,5 +2,5 @@
 # Fix a crash when a logfile opened with LogTo() is closed with LogInputTo()  
 gap> LogTo( Filename( DirectoryTemporary(), "foo" ) );
 gap> LogInputTo();
-Error, InputLogTo: can not close the logfile
+Error, InputLogTo: cannot close the logfile
 gap> LogTo();

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -9,7 +9,7 @@ rec( message := "no error", number := 0 )
 
 #
 gap> CLOSE_LOG_TO();
-Error, LogTo: can not close the logfile
+Error, LogTo: cannot close the logfile
 gap> LOG_TO(fail);
 Error, LOG_TO: <filename> must be a string (not the value 'fail')
 gap> LOG_TO(TmpName());
@@ -26,7 +26,7 @@ true
 
 #
 gap> CLOSE_INPUT_LOG_TO();
-Error, InputLogTo: can not close the logfile
+Error, InputLogTo: cannot close the logfile
 gap> INPUT_LOG_TO(fail);
 Error, INPUT_LOG_TO: <filename> must be a string (not the value 'fail')
 gap> INPUT_LOG_TO(TmpName());
@@ -44,7 +44,7 @@ true
 
 #
 gap> CLOSE_OUTPUT_LOG_TO();
-Error, OutputLogTo: can not close the logfile
+Error, OutputLogTo: cannot close the logfile
 gap> OUTPUT_LOG_TO(fail);
 Error, OUTPUT_LOG_TO: <filename> must be a string (not the value 'fail')
 gap> OUTPUT_LOG_TO(TmpName());


### PR DESCRIPTION
There are four separate commits describing the types of changes that I've made. Three of the commits fix mistakes and should be totally non-controversial.

The fourth commit standardises on 'cannot' rather than 'can not'; although 'can not' is not incorrect English, it's far less common in both general English, and in GAP (it occurred around 20 times less frequently).