### PR TITLE
fixed `HELP_SEARCH_ALTERNATIVES` again

### DIFF
--- a/hpcgap/lib/helpbase.gi
+++ b/hpcgap/lib/helpbase.gi
@@ -214,7 +214,7 @@ if Length(positions) > 0 then # matches found
   for i in [1..Length(positions)] do
     Add( chop, [ topic{[begin..patterns[i].start-1 ]} ] );
     Add( chop, patterns[i].pattern );
-    begin := Minimum( patterns[i].finish+1, Length(topic) );
+    begin := Minimum( patterns[i].finish, Length(topic) )+1;
   od;
 
   if begin <= Length( topic ) then

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -211,7 +211,7 @@ if Length(positions) > 0 then # matches found
   for i in [1..Length(positions)] do
     Add( chop, [ topic{[begin..patterns[i].start-1 ]} ] );
     Add( chop, patterns[i].pattern );
-    begin := Minimum( patterns[i].finish+1, Length(topic) );
+    begin := Minimum( patterns[i].finish, Length(topic) )+1;
   od;
 
   if begin <= Length( topic ) then

--- a/tst/teststandard/helptools.tst
+++ b/tst/teststandard/helptools.tst
@@ -16,6 +16,12 @@ gap> HELP_SEARCH_ALTERNATIVES("setismapping");
 [ "hasismapping", "ismapping", "setismapping" ]
 gap> HELP_SEARCH_ALTERNATIVES("ismapping");
 [ "ismapping" ]
+gap> HELP_SEARCH_ALTERNATIVES( "Centralize" );   # pattern at the end
+[ "Centralise", "Centralize" ]
+gap> HELP_SEARCH_ALTERNATIVES( "Centralizer" );  # one character behind pattern
+[ "Centraliser", "Centralizer" ]
+gap> HELP_SEARCH_ALTERNATIVES( "Centralizers" ); # two characters
+[ "Centralisers", "Centralizers" ]
 
 # Testing the code from `lib/helpt2t.g{d,i}` which converts TeX source code
 # in `gapmacro.tex` format into text for the "screen" online help viewer.


### PR DESCRIPTION
Apparently there were two errors, and #4213 had dealt only with one of them.
Now the second one is fixed, and there are also tests for the relevant cases.

(This resolves #4229.)
