### PR TITLE
LoadKernelExtension, IsKernelExtensionAvailable

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -143,26 +143,20 @@ $ gap4/bin/i386-ibm-linux-gcc2/gac -d test.c
 ]]></Log>
 <P/>
 This will produce a file <F>test.so</F>, which then can be loaded into &GAP;
-with <Ref Func="LoadDynamicModule"/>.
+with <Ref Func="LoadKernelExtension"/>. If the kernel module is required
+for the package to work, then its <F>PackageInfo.g</F> should define
+a <C>AvailabilityTest</C> which calls <Ref Func="IsKernelExtensionAvailable"/>,
+see <Ref Subsect="Test for the Existence of GAP Package Binaries"/> for details.
+<P/>
+Note that before GAP 4.12, <Ref Func="LoadDynamicModule"/> was used for this.
+It is still available and in fact <Ref Func="LoadKernelExtension"/> call it;
+but the latter provides a higher level abstraction and is more convenient to use.
 
 </Subsection>
 
-<ManSection>
-<Func Name="LoadDynamicModule" Arg='filename'/>
-
-<Description>
-To load a compiled file, the command <Ref Func="LoadDynamicModule"/> is used.
-This command loads <A>filename</A> as module.
-<P/>
-<Log><![CDATA[
-gap> LoadDynamicModule("./test.so");
-]]></Log>
-<P/>
-On some operating systems, once you have loaded a dynamic module with
-a certain filename, loading another with the same filename will have
-no effect, even if the file on disk has changed.
-</Description>
-</ManSection>
+<#Include Label="IsKernelExtensionAvailable">
+<#Include Label="LoadKernelExtension">
+<#Include Label="LoadDynamicModule">
 
 <Subsection Label="The PackageInfo.g File">
 <Heading>The PackageInfo.g File</Heading>
@@ -1279,6 +1273,25 @@ only run under UNIX (and not e.g. under Windows), or may not compile with
 some compilers or default compiler options.
 See&nbsp;<Ref Sect="Testing for the System Architecture"/>
 for information on how to test for the architecture.
+<P/>
+Package using a kernel module (see <Ref Subsect="Kernel modules"/>),
+one may use a test like this:
+<Listing><![CDATA[
+...
+AvailabilityTest := function()
+    # see if example.so exists and is a loadable kernel extension
+    if IsKernelExtensionAvailable("example") then
+      LogPackageLoadingMessage( PACKAGE_WARNING,
+          [ "The kernel extension `example' is unavailable,",
+            "perhaps it needs to be recompiled?",
+            "See the installation instructions;",
+            "type: ?Installing the Example package" ] );
+      return false;
+    fi;
+    return true;
+  end,
+...
+]]></Listing>
 <P/>
 <Index Key="LogPackageLoadingMessage"><C>LogPackageLoadingMessage</C></Index>
 Last but not least: do not print anything in the <C>AvailabilityTest</C> 

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -131,19 +131,6 @@ gap> GAP_CRC("foobar");
 0
 
 #
-gap> LOAD_DYN(fail);
-Error, LOAD_DYN: <filename> must be a string (not the value 'fail')
-
-#
-gap> LOAD_STAT(fail);
-Error, LOAD_STAT: <filename> must be a string (not the value 'fail')
-gap> LOAD_STAT("foobar");
-false
-
-#
-gap> LoadedModules();;
-
-#
 gap> GASMAN();
 Error, usage: GASMAN( "display"|"displayshort"|"clear"|"collect"|"message"|"pa\
 rtial" )
@@ -186,7 +173,7 @@ gap> Sleep(0);
 gap> Sleep(1);
 
 #
-gap>    MicroSleep(fail);
+gap> MicroSleep(fail);
 Error, MicroSleep: <msecs> must be a small integer (not the value 'fail')
 gap> MicroSleep(0);
 gap> MicroSleep(1);

--- a/tst/testinstall/kernel/modules.tst
+++ b/tst/testinstall/kernel/modules.tst
@@ -1,0 +1,24 @@
+#
+# Tests for functions defined in src/modules.c
+#
+gap> START_TEST("kernel/modules.tst");
+
+#
+gap> IS_LOADABLE_DYN(fail);
+Error, IS_LOADABLE_DYN: <filename> must be a string (not the value 'fail')
+
+#
+gap> LOAD_DYN(fail);
+Error, LOAD_DYN: <filename> must be a string (not the value 'fail')
+
+#
+gap> LOAD_STAT(fail);
+Error, LOAD_STAT: <filename> must be a string (not the value 'fail')
+gap> LOAD_STAT("foobar");
+false
+
+#
+gap> LoadedModules();;
+
+#
+gap> STOP_TEST("kernel/modules.tst", 1);


### PR DESCRIPTION
The idea is to provide "better" (?) APIs for packages to load kernel extensions. With `IsKernelExtensionAvailable` (and an upcoming kernel function to make it better), packages can simplify their `TestAvailability` functions, and at the same time make them more robust. Likewise, `LoadKernelExtension` simplifies `init.g` code.

The big win is that it'll then make it much easier for us to change how to locate and load kernel extensions; e.g. to better support `make install` of packages, or also better Julia integration.

Open questions:
1. perhaps I should rename these functions to `LoadKernelModule` and `IsKernelModuleAvailable`? Background: in the manual and various other places, we talk about "kernel modules". I (and some other places/people) use "kernel extension" (possibly a short hand for "kernel extension module") to distinguish it from built-in kernel modules; I guess one could also refer to it as "external kernel module" (but that would not be quite right for "static" kernel extension modules...).
2. In case of failure, perhaps `IsKernelExtensionAvailable` resp. `IS_LOADABLE_DYN` should return proper error codes (instead of just `false`) to indicate what exactly went wrong (file missing / file not a loadable module / file not a GAP kernel extension / kernel extension but built for wrong GAP version / ....). It could even be just a string; in any case, something that helps produce better error messages for `AvailabilityTest` in `PackageInfo.g`
3. Perhaps add an optional field `KernelModule` to the package info record, which when present would prompt GAP to automatically invoke `IsKernelExtensionAvailable` when checking the package availability; and `LoadKernelExtension` when loading the package (possible values: `KernelModule  := true` = use package name, `KernelModule := "modname"`; or even `KernelModule := ["mod1", "mod2"]` if someone wants to support multiple kernel modules in one package. Alas, that seems very fringe, so I'd probably not do it)