### PR TITLE
Improve iterators for lists

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -756,8 +756,6 @@ BindGlobal( "NextIterator_List", function ( iter )
     return l[ p ];
     end );
 
-#BindGlobal( "IsDoneIterator_DenseList",
-#    iter -> not IsBound( iter!.list[ iter!.pos + 1 ] ) );
 
 BindGlobal( "NextIterator_DenseList", function ( iter )
     local p;

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -782,14 +782,13 @@ InstallGlobalFunction( IteratorList, function ( list )
 #T call `Immutable'?
                 pos  := 0,
                 len := Length(list),
+                IsDoneIterator := IsDoneIterator_List,
                 ShallowCopy := ShallowCopy_List );
 
     if IsDenseList( list ) and not IsMutable( list ) then
-      iter.IsDoneIterator := IsDoneIterator_List;
-      iter.NextIterator   := NextIterator_DenseList;
+      iter.NextIterator := NextIterator_DenseList;
     else
-      iter.IsDoneIterator := IsDoneIterator_List;
-      iter.NextIterator   := NextIterator_List;
+      iter.NextIterator := NextIterator_List;
     fi;
 
     return IteratorByFunctions( iter );

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -742,25 +742,31 @@ BindGlobal( "IsDoneIterator_List",
     iter -> ( iter!.pos >= iter!.len ) );
 
 BindGlobal( "NextIterator_List", function ( iter )
-    if iter!.pos = Length( iter!.list ) then
+    local p, l;
+    p := iter!.pos;
+    if p = iter!.len then
         Error("<iter> is exhausted");
     fi;
-    iter!.pos := iter!.pos + 1;
-    while not IsBound( iter!.list[ iter!.pos ] ) do
-        iter!.pos := iter!.pos + 1;
+    l := iter!.list;
+    p := p + 1;
+    while not IsBound( l[ p ] ) do
+        p := p + 1;
     od;
-    return iter!.list[ iter!.pos ];
+    iter!.pos := p;
+    return l[ p ];
     end );
 
 #BindGlobal( "IsDoneIterator_DenseList",
 #    iter -> not IsBound( iter!.list[ iter!.pos + 1 ] ) );
 
 BindGlobal( "NextIterator_DenseList", function ( iter )
-    iter!.pos := iter!.pos + 1;
+    local p;
+    p := iter!.pos + 1;
+    iter!.pos := p;
     #if not IsBound( iter!.list[ iter!.pos ] ) then
     #    Error("<iter> is exhausted");
     #fi;
-    return iter!.list[ iter!.pos ];
+    return iter!.list[ p ];
     end );
 
 BindGlobal( "ShallowCopy_List",

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -739,7 +739,7 @@ InstallMethod( SSortedList,
 ##  lists.)
 ##
 BindGlobal( "IsDoneIterator_List",
-    iter -> ( iter!.pos = iter!.len ) );
+    iter -> ( iter!.pos >= iter!.len ) );
 
 BindGlobal( "NextIterator_List", function ( iter )
     if iter!.pos = Length( iter!.list ) then

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -554,5 +554,61 @@ gap> MakeImmutable(l);;
 gap> IsIdenticalObj(AsSet(l), l);
 true
 
+# IteratorList
+# immutable dense list
+gap> tmp := MakeImmutable([1, 2, 3, 4]);
+[ 1, 2, 3, 4 ]
+gap> it := IteratorList(tmp);
+<iterator>
+gap> for x in it do Print(x); od; Print("\n");
+1234
+gap> IsDoneIterator(it);
+true
+gap> NextIterator(it);
+Error, List Element: <list>[5] must have an assigned value
+gap> IsDoneIterator(it);
+true
+
+# mutable dense list
+gap> tmp := [1 .. 4];;
+gap> it := IteratorList(tmp);
+<iterator>
+gap> for x in it do Print(x); od; Print("\n");
+1234
+gap> IsDoneIterator(it);
+true
+gap> NextIterator(it);
+Error, <iter> is exhausted
+gap> IsDoneIterator(it);
+true
+
+# immutable non-dense list
+gap> tmp := MakeImmutable([, 2, 3, , 5, 6,]);
+[ , 2, 3,, 5, 6 ]
+gap> it := IteratorList(tmp);
+<iterator>
+gap> for x in it do Print(x); od; Print("\n");
+2356
+gap> IsDoneIterator(it);
+true
+gap> NextIterator(it);
+Error, <iter> is exhausted
+gap> IsDoneIterator(it);
+true
+
+# mutable non-dense list
+gap> tmp := [, 2, 3, , 5, 6,];
+[ , 2, 3,, 5, 6 ]
+gap> it := IteratorList(tmp);
+<iterator>
+gap> for x in it do Print(x); od; Print("\n");
+2356
+gap> IsDoneIterator(it);
+true
+gap> NextIterator(it);
+Error, <iter> is exhausted
+gap> IsDoneIterator(it);
+true
+
 #
 gap> STOP_TEST("list.tst");


### PR DESCRIPTION
This resolves #4226, reported by @james-d-mitchell. See the discussion there for further context.

Currently, iterators behave differently for immutable dense lists as opposed to other lists w.r.t. whether `NextIterator` throws an informative error when called on a finished iterator. Moreover, in one of the cases, calling `NextIterator` on a finished iterator unnecessarily broke the value of `IsDoneIterator`.

I tried making the error-checking behaviour consistent, but this led to an unacceptable 10% slowdown. Instead I've just removed the breaking of `IsDoneIterator`, and found one or two ways to speed up the code (mostly by reducing access to record components).

If speed of iterators is important, then I think these changes are useful. If speed is not important, then I will add reinstate to `NextIterator_DenseList`...

I've added some tests, removed some commented-out code, and rearranged a bit of code too - I'm happy to remove either of the latter two for being off-topic.

Quick experiments:
```
# Mutable list
gap> for i in [1..10] do iter := Iterator([1 .. 10000000]);; for i in iter do od; od; time;
20926 # Before this PR
17429 # After this PR

# Immutable list
gap> for i in [1..10] do iter := Iterator(Immutable([1 .. 10000000]));; for i in iter do od; od; time;
13205 # Before this PR
13158 # After this PR
```