### PR TITLE
kernel: use RTLD_LOCAL to dlopen kernel extensions

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -213,7 +213,7 @@ static Int SyLoadModule(const Char * name, InitInfoFunc * func)
 
     *func = 0;
 
-    handle = dlopen( name, RTLD_LAZY | RTLD_GLOBAL);
+    handle = dlopen( name, RTLD_LAZY | RTLD_LOCAL);
     if ( handle == 0 ) {
       Pr("#W dlopen() error: %s\n", (long) dlerror(), 0);
       return 1;


### PR DESCRIPTION
This reduces pollution of the global symbol / name space, which might help
reduce issues when using GAP and GAP packages in an "embedded" GAP (say within
Sage or OSCAR).

I am not aware of any actual issues caused by the current used of RTLD_GLOBAL,
but it seems sensible to code this defensively.

CC @embray @ChrisJefferson 