### PR TITLE
Revert accidentally-reintroduced downranking of a MatrixObj method

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -304,9 +304,6 @@ InstallMethod( Matrix,
 
 InstallMethod( Matrix,
     [ IsSemiring, IsMatrixObj ],
-  # FIXME: Remove this downranking, it was introduced to prevent
-  #        Semigroups from breaking ahead of the 4.10 release
-  -SUM_FLAGS,
     function( R, M )
     if IsPlistRep( M ) then
       TryNextMethod();


### PR DESCRIPTION
* In August 2018, a change related to `MatrixObj` broke the Semigroups package in PR #2640.
* Four methods were temporarily downranked to fix this problem in PR #2754 / 6f629ba74465abb559bbaed01d85326ed78a6188.
* Three of these downrankings were reverted in September 2019 in PR #3674 / 72494b239b7cab7f7492a58e2be423a536720504
* The final downranking was reverted in December 2019 in PR #2758 / ef9f5eefea3946c9d7a3b1e01eb087cb2972b705.
* But this final reversion was itself reverted (I presume accidentally) in February 2020 in PR #3643 / 52509bb9811247da6c8ed96c163572d02b6c973d.
* So let's revert the incorrect reversion of a reversion!

I can confirm that the Semigroups package works fine with this PR.