### PR TITLE
Add equality operation for `x with objects with memory`

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -305,6 +305,12 @@ InstallMethod(\=,"objects with memory with x",IsIdenticalObj,
     return a!.el=x;
   end);
 
+InstallMethod(\=,"x with objects with memory",IsIdenticalObj,
+  [IsMultiplicativeElement,IsObjWithMemory],0,
+  function(x,a)
+    return x=a!.el;
+  end);
+
 InstallMethod(\<,"objects with memory with x",IsIdenticalObj,
   [IsObjWithMemory,IsMultiplicativeElement],0,
   function(a,x)

--- a/tst/testbugfix/2021-02-04-ObjectsWithMemoryEquality.tst
+++ b/tst/testbugfix/2021-02-04-ObjectsWithMemoryEquality.tst
@@ -1,0 +1,12 @@
+# Equality operation for x with objects with memory, Pull Request #4239
+gap> G := GroupWithMemory(GroupByGenerators([ (1,2,3,4,5), (1,2) ]));;
+gap> x := GeneratorsOfGroup(G)[1];
+<(1,2,3,4,5) with mem>
+gap> y := StripMemory(x);
+(1,2,3,4,5)
+gap> x = y;
+true
+
+# This equality check was not implemented and resulted in an error
+gap> y = x;
+true


### PR DESCRIPTION
# Description

`\=` was implemented for `IsObjWithMemory` and `IsMultiplicativeElement` (in this order), but not the other way round.

## Text for release notes 

Add equality operation for `x with objects with memory`

## Further details

The following is an example of the unexpected behaviour that is fixed by this pull request.

```
gap> G := GroupWithMemory(SymmetricGroup(5));
Group([ (1,2,3,4,5), (1,2) ])
gap> x := PseudoRandom(G);
<(1,3,2,4,5) with mem>
gap> y := StripMemory(x);
(1,3,2,4,5)
gap> x = y;
true
gap> y = x;
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `=' on 2 arguments at /usr/local/Cellar/gap/4.11.0/libexec/lib/methsel2.g:249 called from
<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
 called from read-eval loop at *stdin*:5
type 'quit;' to quit to outer loop
brk> 
```

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

