### PR TITLE
another change for `PAGER_BUILTIN`

### DIFF
--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -131,6 +131,10 @@ BindGlobal("PAGER_BUILTIN", function( lines )
   elif not formatted then
     lines := ShallowCopy(lines);
   fi;
+
+  if Length( lines ) = 0 then
+    return;
+  fi;
   
   size   := SizeScreen();
   wd := QuoInt(size[1]+2, 2);


### PR DESCRIPTION
When the argument of `PAGER_BUILTIN` is an empty list
then one runs into an error.
This does not happen for example with `PAGER_EXTERNAL` and preference `more`.