### PR TITLE
Fix zero-dimensional hom_component and non-field left acting ring

### DIFF
--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -3381,8 +3381,8 @@ BindGlobal( "FreeAlgebraConstructor", function( name, magma )
         od;
         x := Zero(R);
         y := [One(R)];
-        return VectorSpace(R, List(B[degree+1],
-                       p->ElementOfMagmaRing( F, x, y, [p] )));
+        return FreeLeftModule(R, List(B[degree+1],
+                       p->ElementOfMagmaRing( F, x, y, [p] )), Zero(A));
     end));
 
     # Return the result.

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -3752,7 +3752,7 @@ InstallGlobalFunction( FreeLieAlgebra, function( arg )
                 od; od;
             od;
         od;
-	if degree<1 then B := []; else B := B[degree]; fi;
+        if degree<1 then B := []; else B := B[degree]; fi;
         return FreeLeftModule( R, List( B,
 		p->ElementOfMagmaRing( F, zero, [ one ], [ p[3] ] )), Zero(L));
     end) );

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -3752,8 +3752,9 @@ InstallGlobalFunction( FreeLieAlgebra, function( arg )
                 od; od;
             od;
         od;
-        return VectorSpace( R, List( B[degree],
-                       p->ElementOfMagmaRing( F, zero, [ one ], [ p[3] ] )));
+	if degree<1 then B := []; else B := B[degree]; fi;
+        return FreeLeftModule( R, List( B,
+		p->ElementOfMagmaRing( F, zero, [ one ], [ p[3] ] )), Zero(L));
     end) );
     # Return the ring.
     return L;

--- a/tst/testbugfix/2021-02-04-zero-dim-hom_components.tst
+++ b/tst/testbugfix/2021-02-04-zero-dim-hom_components.tst
@@ -1,0 +1,13 @@
+# zero-dimensional hom_components #4245
+gap> l := FreeLieAlgebra(Integers,1);
+<free left module over Integers, and ring, with 1 generators>
+gap> List([0..2],Grading(l).hom_components);
+[ <free left module over Integers, with 0 generators>, 
+  <free left module over Integers, with 1 generators>, 
+  <free left module over Integers, with 0 generators> ]
+gap> a := FreeAssociativeAlgebra(Integers,2);
+<free left module over Integers, and ring, with 2 generators>
+gap> List([0..2],Grading(a).hom_components);
+[ <free left module over Integers, with 0 generators>, 
+  <free left module over Integers, with 2 generators>, 
+  <free left module over Integers, with 4 generators> ]


### PR DESCRIPTION
This PR fixes two problems:
```gap> l := FreeLieAlgebra(Rationals,1);;
gap> Grading(l).hom_components(2); # ka-boom
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
gap> a := FreeAssociativeAlgebra(Rationals,1);;
gap> Grading(a).hom_components(0); # ka-boom
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
```
which is fixed by supplying a zero element in case there are no generators to the component; and

```gap> l := FreeLieAlgebra(Integers,1);;
gap> Grading(l).hom_components(2); # ka-boom
Error, usage: VectorSpace( <F>, <gens>[, <zero>][, "basis"] ) at /usr/local/Cellar/gap/4.11.0/libexec
```

granted, there is now little working functionality with these left modules; but I'm working on improving this situation within a package.