### PR TITLE
changed `ViewObj` and `ViewString` for functions

### DIFF
--- a/lib/function.g
+++ b/lib/function.g
@@ -620,9 +620,6 @@ InstallMethod( ViewObj, "for a function", true, [IsFunction], 0,
         isvarg := true;
         narg := -narg;
     fi;
-    if narg = 1 and nams <> fail and nams[1] = "arg" then
-        isvarg := true;
-    fi;
     if narg <> 0 then
         if nams = fail then
             Print( "<",narg," unnamed arguments>" );

--- a/lib/function.gi
+++ b/lib/function.gi
@@ -29,9 +29,6 @@ function(func)
         isvarg := true;
         narg := -narg;
     fi;
-    if narg = 1 and nams <> fail and nams[1] = "arg" then
-        isvarg := true;
-    fi;
     if narg <> 0 then
         if nams = fail then
             Append(result, STRINGIFY("<",narg," unnamed arguments>"));

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -184,6 +184,25 @@ function (  )
     TryNextMethod();
 end
 
+# The number of arguments of a function
+# is not determined by the name "arg" of the parameter.
+gap> f:= function( arg ) return 0; end;
+function( arg... ) ... end
+gap> ViewString( f );
+"function( arg... ) ... end"
+gap> Print( f, "\n" );
+function ( arg... )
+    return 0;
+end
+gap> f:= arg -> 0;
+function( arg ) ... end
+gap> ViewString( f );
+"function( arg ) ... end"
+gap> Print( f, "\n" );
+function ( arg )
+    return 0;
+end
+
 #
 gap> InstallGlobalFunction("CheeseCakeFunction123123", function() end);
 Error, global function `CheeseCakeFunction123123' is not declared yet


### PR DESCRIPTION
I think that a function object knows best whether it takes a variable number of arguments or not, according to the result of `NARG_FUNC`, and independent of the argument name `arg`, see the examples in issue #4241.

(Let us see whether some tests fail after the change.)