### PR TITLE
Add ARCH_IS_WSL, to detect Windows Subsystem for Linux

### DIFF
--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -586,6 +586,7 @@ or called from a break loop.
 <#Include Label="ARCH_IS_UNIX">
 <#Include Label="ARCH_IS_MAC_OS_X">
 <#Include Label="ARCH_IS_WINDOWS">
+<#Include Label="ARCH_IS_WSL">
 
 </Section>
 

--- a/lib/helpview.gi
+++ b/lib/helpview.gi
@@ -198,48 +198,78 @@ elif ARCH_IS_MAC_OS_X() then
             return;
         end
     );
- 
+
 else # UNIX but not Mac OS X
 
-  # html version with netscape
-  HELP_VIEWER_INFO.netscape := rec(
-  type := "url",
-  show := function(url)
-    Exec(Concatenation("netscape -remote \"openURL(file:", url, ")\""));
-  end
-  );
+  # Graphical systems handled differently in WSL and standard Linux
+  if ARCH_IS_WSL() then
+    HELP_VIEWER_INFO.browser := rec(
+    type := "url",
+    show := function( url )
+      # Ignoring part of the URL after '#' since we are unable
+      # to navigate to the precise location on Windows
+      url := SplitString( url, "#" )[1];
+      Exec(Concatenation("explorer.exe \"$(wslpath -a -w \"",url, "\")\""));
+    end
+    );
 
-  # html version with mozilla
-  HELP_VIEWER_INFO.mozilla := rec(
-  type := "url",
-  show := function(url)
-    Exec(Concatenation("mozilla -remote \"openURL(file:", url, ")\""));
-  end
-  );
+    HELP_VIEWER_INFO.("pdf viewer") := rec(
+        type := "pdf",
+        show := function(file)
+          local   page;
+          # unfortunately one cannot (yet?) give a start page to windows
+          page := 1;
+          if IsRecord(file) then
+            if IsBound(file.page) then
+              page := file.page;
+            fi;
+            file := file.file;
+          fi;
+          Exec(Concatenation("explorer.exe \"$(wslpath -a -w \"",file, "\")\""));
+          Print("#  see page ", page, " in PDF.\n");
+    end
+    );
+  else
+    # html version with netscape
+    HELP_VIEWER_INFO.netscape := rec(
+    type := "url",
+    show := function(url)
+      Exec(Concatenation("netscape -remote \"openURL(file:", url, ")\""));
+    end
+    );
 
-  # html version with firefox
-  HELP_VIEWER_INFO.firefox := rec(
-  type := "url",
-  show := function(url)
-    Exec(Concatenation("firefox \"file://", url,"\" >/dev/null 2>&1 &"));
-  end
-  );
+    # html version with mozilla
+    HELP_VIEWER_INFO.mozilla := rec(
+    type := "url",
+    show := function(url)
+      Exec(Concatenation("mozilla -remote \"openURL(file:", url, ")\""));
+    end
+    );
 
-  # html version with chrome
-  HELP_VIEWER_INFO.chrome := rec(
-  type := "url",
-  show := function(url)
-    Exec(Concatenation("chromium-browser \"file://", url,"\" >/dev/null 2>&1 &"));
-  end
-  );
-  
-  # html version with konqueror  - doesn't work with 'file://...#...' URLs
-  HELP_VIEWER_INFO.konqueror := rec(
-  type := "url",
-  show := function(url)
-    Exec(Concatenation("konqueror \"file://", url,"\" >/dev/null 2>&1 &"));
-  end
-  );
+    # html version with firefox
+    HELP_VIEWER_INFO.firefox := rec(
+    type := "url",
+    show := function(url)
+      Exec(Concatenation("firefox \"file://", url,"\" >/dev/null 2>&1 &"));
+    end
+    );
+
+    # html version with chrome
+    HELP_VIEWER_INFO.chrome := rec(
+    type := "url",
+    show := function(url)
+      Exec(Concatenation("chromium-browser \"file://", url,"\" >/dev/null 2>&1 &"));
+    end
+    );
+    
+    # html version with konqueror  - doesn't work with 'file://...#...' URLs
+    HELP_VIEWER_INFO.konqueror := rec(
+    type := "url",
+    show := function(url)
+      Exec(Concatenation("konqueror \"file://", url,"\" >/dev/null 2>&1 &"));
+    end
+    );
+  fi;
 
   # html version with lynx
   HELP_VIEWER_INFO.lynx := rec(

--- a/lib/system.g
+++ b/lib/system.g
@@ -517,7 +517,7 @@ end );
 ##  <Func Name="ARCH_IS_WINDOWS" Arg=''/>
 ##
 ##  <Description>
-##  tests whether &GAP; is running on a Windows system.
+##  tests whether &GAP; is running on a Windows system in Cygwin.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -562,6 +562,33 @@ end);
 ##
 BIND_GLOBAL("ARCH_IS_UNIX",function()
   return not ARCH_IS_WINDOWS();
+end);
+
+#############################################################################
+##
+#F  ARCH_IS_WSL()
+##
+##  <#GAPDoc Label="ARCH_IS_WSL">
+##  <ManSection>
+##  <Func Name="ARCH_IS_WSL" Arg=''/>
+##
+##  <Description>
+##  tests whether &GAP; is running on a Windows system inside the
+##  'Windows Subsystem for Linux'. Note that in this case
+##  <Ref Func="ARCH_IS_UNIX"/> will be <K>true</K>, and in most situations
+##  WSL can be treated identically to Linux.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+BIND_GLOBAL("ARCH_IS_WSL",function()
+  # There is no official way to detect this, but this method is
+  # suggested: https://github.com/microsoft/WSL/issues/423
+  # Note that at some point the string was changed from 'Microsoft' to
+  # 'microsoft'.
+  return ARCH_IS_UNIX() and IsBound(GAPInfo.KernelInfo.uname.release) and (
+    POSITION_SUBSTRING(GAPInfo.KernelInfo.uname.release, "Microsoft", 0) <> fail or
+    POSITION_SUBSTRING(GAPInfo.KernelInfo.uname.release, "microsoft", 0) <> fail);
 end);
 
 #############################################################################

--- a/src/gap.c
+++ b/src/gap.c
@@ -1090,6 +1090,9 @@ static Obj FuncKERNEL_INFO(Obj self)
     AssPRec(res, RNamName("GAP_ROOT_PATHS"), SyGetGapRootPaths());
     AssPRec(res, RNamName("DOT_GAP_PATH"), MakeImmString(SyDotGapPath()));
 
+    // Get OS Kernel Release info
+    AssPRec(res, RNamName("uname"), SyGetOsRelease());
+
     // make command line available to GAP level
     tmp = NEW_PLIST_IMM(T_PLIST, 16);
     for (i = 0; SyOriginalArgv[i]; i++) {

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -23,6 +23,7 @@
 #include "lists.h"
 #include "modules.h"
 #include "plist.h"
+#include "precord.h"
 #include "read.h"
 #include "records.h"
 #include "stats.h"
@@ -80,6 +81,7 @@ typedef void sig_handler_t ( int );
 
 #include <zlib.h>
 
+#include <sys/utsname.h>
 
 static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count);
 
@@ -339,6 +341,22 @@ static Obj FuncCrcString(Obj self, Obj str)
     return INTOBJ_INT(((Int4) crc) >> 4);
 }
 
+// Get OS Kernel version. Used to discover if GAP is running inside
+// 'Windows Subystem for Linux'
+Obj SyGetOsRelease(void)
+{
+    Obj            r = NEW_PREC(0);
+    struct utsname buf;
+    if (!uname(&buf)) {
+        AssPRec(r, RNamName("sysname"), MakeImmString(buf.sysname));
+        AssPRec(r, RNamName("nodename"), MakeImmString(buf.nodename));
+        AssPRec(r, RNamName("release"), MakeImmString(buf.release));
+        AssPRec(r, RNamName("version"), MakeImmString(buf.version));
+        AssPRec(r, RNamName("machine"), MakeImmString(buf.machine));
+    }
+
+    return r;
+}
 
 /****************************************************************************
 **

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -28,6 +28,13 @@
 */
 Int4 SyGAPCRC(const Char * name);
 
+/****************************************************************************
+**
+*F  SyGetOsRelease( )  . . . . . . . . . . . . . . . . . . . . get name of OS
+**
+**  Get the release of the operating system kernel.
+*/
+Obj SyGetOsRelease(void);
 
 /****************************************************************************
 **


### PR DESCRIPTION
This lets us detect the "Windows Subsystem for Linux".

I realise in some ways the naming has gotten weird now, we call Cygwin (one linux in windows) "ARCH_IS_WINDOWS", which WSL is not. While that is weird, I think it makes sense, WSL is a complete install of Linux (usually Ubuntu).

The only time we need ARCH_IS_WSL is when we want to open GUI programs -- I've added help viewers (unfortunately it doesn't seem possible to open either anchors in HTML, which makes this much less useful. I spent some time searching the internet, but everything people say seems to not work in practice, except making a new webpage which just forwards to the anchor, and I didn't want to do that as it would create lots of new temp files/directories).

I plan on using this in the 'profiling' package too, to automatically open HTML pages (I originally wrote this in that package, then thought I might be generally useful).