### PR TITLE
coverage: ignore grp/*.grp

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,3 +17,4 @@ ignore:
  - "hpcgap/extern"
  - "tst"
  - "pkg"
+ - "grp/*.grp"


### PR DESCRIPTION
Since these are data files with a huge number of lines, I think it is a bit distorting to include them. So I suggest we ignore them for the purposes of code coverage.