### PR TITLE
Add .gitattributes with `* text=auto`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This normalizes line ends, and should help avoid complications caused by people editing files on windows and inserting CRLF line ends.

In the future we could add more complicated rules, see e.g. https://rehansaeed.com/gitattributes-best-practices/