### PR TITLE
buildsys: overhaul `make distclean`

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -446,8 +446,9 @@ etags:
 # Rules for 'make clean'
 ########################################################################
 distclean: clean
-	rm -f config.log config.status libtool GNUmakefile configure
+	rm -f config.log config.status libtool GNUmakefile
 	rm -f doc/make_doc
+	rm -f doc/*/*.aux doc/*/*.bbl doc/*/*.blg doc/*/*.brf doc/*/*.idx doc/*/*.ilg doc/*/*.ind doc/*/*.log doc/*/*.out doc/*/*.pnr doc/*/*.tex doc/*/*.toc
 	rm -rf dev/log
 	rm -rf tags
 	rm -rf TAGS


### PR DESCRIPTION
The purpose of this target is to delete files that are not wanted in a
"distribution" / release tarball.

- do not delete `configure`, as it is required for release tarballs
- delete some auxiliary files created by LaTeX (but NOT the HTML and PDF files)


I stumbled over this while working on the new release script(s). Should be backported!