### PR TITLE
some release notes entries for 4.11.1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,27 @@ Thank You!
 
 ## Text for release notes 
 
-If this pull request should be mentioned in the release notes, 
-please provide a short description matching the style of the GAP
-`CHANGES.md` file in the root directory.
+If this pull request shall **not** be mentioned in the release notes
+(to be distributed in the file `CHANGES.md`),
+please add the label `release notes: not needed`.
+
+Otherwise, please proceed in one of the following ways:
+
+- Choose a title that can serve as text for the release notes,
+  and add the label `release notes: use title`.
+
+- Put the text for the release notes **here**,
+  that is, between the markers `Text for release notes`
+  and `(End of text for release notes)`.
+
+The first variant is recommended whenever the text for release notes
+is suitable as title.
+
+In both cases, please follow the style of the GAP `CHANGES.md` file
+in the root directory.
+In particular, please surround the names of GAP functions with backquotes.
+
+## (End of text for release notes)
 
 ## Further details
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,7 +82,7 @@ The label "release notes: added" has already been attached to them.
 ## GAP 4.11.1 (February 2021)
 
 These changes are also listed on the
-[Wiki page](https://github.com/gap-system/GAP/wiki/gap-4.11-release-notes)
+[Wiki page](https://github.com/gap-system/gap/wiki/GAP-4.11-release-notes)
 
 ### Fixed bugs that could lead to incorrect results
 
@@ -118,7 +118,7 @@ These changes are also listed on the
 
 ### Fixes and improvements for the **Julia** integration
 
-- [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by useing `jl_threadid()` and `jl_get_current_task()` helpers, fix compiler constness warnings in weakptr.c
+- [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by using `jl_threadid()` and `jl_get_current_task()` helpers, fix compiler constness warnings in weakptr.c
 - [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
 - [#4058](https://github.com/gap-system/gap/pull/4058) Refine the logic for scanning Julia stacks
 - [#4071](https://github.com/gap-system/gap/pull/4071) Make the Julia GC threadsafe when used from GAP.jl

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ The following is an unstructured list of all those merged pull requests
 for GAP 4.12.0 until February 17th, 2021, that are relevant for release notes.
 The label "release notes: added" has already been attached to them.
 
+### New features and major changes
+
+- **Added the missing perfect groups of order up to a million**
+
+  Added perfect groups of orders that had been missing in the Holt/Plesken book
+  (newly computed).
+  This increases the number of groups in the perfect groups library by a factor
+  close to 6.
+  Also added five groups that were found missing in the existing lists.
+  See PR [#3925](https://github.com/gap-system/gap/pull/3925) for details.
+
 - [#3628](https://github.com/gap-system/gap/pull/3628) When the info level of `InfoAttributes` is at least 3, warn about attempts to set an attribute value that is different from an already stored value
 - [#3643](https://github.com/gap-system/gap/pull/3643) The manual chapter "Vector and Matrix Objects", which had been marked as preliminary in earlier versions, is now regarded as official
 - [#3664](https://github.com/gap-system/gap/pull/3664) Removed `Matrix` as an attribute (the operation `Matrix` remains as it was)
@@ -73,17 +84,6 @@ The label "release notes: added" has already been attached to them.
 These changes are also listed on the
 [Wiki page](https://github.com/gap-system/GAP/wiki/gap-4.11-release-notes)
 
-### New features and major changes
-
-- **Added the missing perfect groups of order up to a million**
-
-  Added perfect groups of orders that had been missing in the Holt/Plesken book
-  (newly computed).
-  This increases the number of groups in the perfect groups library by a factor
-  close to 6.
-  Also added five groups that were found missing in the existing lists.
-  See PR [#3925](https://github.com/gap-system/gap/pull/3925) for details.
-
 ### Fixed bugs that could lead to incorrect results
 
 - [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range
@@ -91,7 +91,6 @@ These changes are also listed on the
 ### Fixed bugs that could lead to crashes
 
 - [#3965](https://github.com/gap-system/gap/pull/3965) Fix potential garbage collector crashes on 64bit ARM systems
-- [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
 - [#4076](https://github.com/gap-system/gap/pull/4076) Fix an infinite loop in `BoundedRefinementEANormalSeries` if large factors could not be refined, fix protected option of `IsomorphismSimplifiedFpGroup`, improve documentation of `IsAutomorphismGroup`
 
 ### Fixed bugs that could lead to error messages
@@ -117,9 +116,10 @@ These changes are also listed on the
 
 - [#4081](https://github.com/gap-system/gap/pull/4081) Enhance `GAP_ValueGlobalVariable` to supported automatic variables (see `DeclareAutoreadableVariables`)
 
-### Fixes and improvements in for the **Julia** integration
+### Fixes and improvements for the **Julia** integration
 
 - [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by useing `jl_threadid()` and `jl_get_current_task()` helpers, fix compiler constness warnings in weakptr.c
+- [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
 - [#4058](https://github.com/gap-system/gap/pull/4058) Refine the logic for scanning Julia stacks
 - [#4071](https://github.com/gap-system/gap/pull/4071) Make the Julia GC threadsafe when used from GAP.jl
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,108 @@
 # GAP - history of changes
 
-## GAP 4.11.0 (February 2020)
+## GAP 4.11.1 or GAP 4.12.0 (February 2021)
 
 These changes are also listed on the
 [Wiki page](https://github.com/gap-system/GAP/wiki/gap-4.11-release-notes)
+
+### New features and major changes
+
+- **Added the missing perfect groups of order up to a million**
+
+  Added perfect groups of orders that had been missing in the Holt/Plesken book
+  (newly computed).
+  This increases the number of groups in the perfect groups library by a factor
+  close to 6.
+  Also added five groups that were found missing in the existing lists.
+  See PR [#3925](https://github.com/gap-system/gap/pull/3925) for details.
+
+### Unstructured list of merged pull requests for GAP 4.12.0
+
+- [#3628](https://github.com/gap-system/gap/pull/3628) When the info level of `InfoAttributes` is at least 3, warn about attempts to set an attribute value that is different from an already stored value
+- [#3643](https://github.com/gap-system/gap/pull/3643) The manual chapter "Vector and Matrix Objects", which had been marked as preliminary in earlier versions, is now regarded as official
+- [#3664](https://github.com/gap-system/gap/pull/3664) Removed `Matrix` as an attribute (the operation `Matrix` remains as it was)
+- [#3668](https://github.com/gap-system/gap/pull/3668) If several instances of a package, with the same version number, are found in the root directories, and if the first such instance cannot be loaded (because a compiled module is missing or does not fit) then the other instances are considered for being loaded.  In earlier versions, only the first instance of a given package version was considered
+- [#3693](https://github.com/gap-system/gap/pull/3693) Improve `ViewString` so strings are correctly escaped
+- [#3694](https://github.com/gap-system/gap/pull/3694) Deprecate undocumented extra arguments for DeclareGlobalFunction and InstallGlobalFunction
+- [#3695](https://github.com/gap-system/gap/pull/3695) Fix issue with test outputs which do not end with a newline when using the rewriteToFile option of Test
+- [#3702](https://github.com/gap-system/gap/pull/3702) Make TmpNameAllArchs obsolete by enhancing TmpName
+- [#3713](https://github.com/gap-system/gap/pull/3713) Add tracing and counting of built-in operations
+- [#3721](https://github.com/gap-system/gap/pull/3721) Add optimised SmallestMovedPoint implementation
+- [#3740](https://github.com/gap-system/gap/pull/3740) Speed up printing of large permutations
+- [#3747](https://github.com/gap-system/gap/pull/3747) Fix unexpected error when testing permutation groups for conjugacy
+- [#3759](https://github.com/gap-system/gap/pull/3759) Fix an issue with error reporting in parallel threads
+- [#3761](https://github.com/gap-system/gap/pull/3761) Fix bugs in HPC-GAP serialization code and improve its tests
+- [#3792](https://github.com/gap-system/gap/pull/3792) Use `Info` not `Print` in `Decomposition`
+- [#3796](https://github.com/gap-system/gap/pull/3796) Remove `-B` command line option for overriding the architecture
+- [#3808](https://github.com/gap-system/gap/pull/3808) Fixed a crash when using a constant global variable (created via `MakeConstantGlobal`) as index variable of a for loop
+- [#3822](https://github.com/gap-system/gap/pull/3822) HPC-GAP: Make the assertion level (which controls `Assert` statements) thread local
+- [#3858](https://github.com/gap-system/gap/pull/3858) Add `DeclareGlobalName` (to replace `DeclareGlobalVariable` where possible)
+- [#3861](https://github.com/gap-system/gap/pull/3861) The range of `SimpleGroupsIterator` has been extended to about 10^27
+- [#3862](https://github.com/gap-system/gap/pull/3862) Rename `QUIT_GAP`, `FORCE_QUIT_GAP` and `GAP_EXIT_CODE` to `QuitGap`, `ForceQuitGap` and `GapExitCode` (the old names remain available as synonyms)
+- [#3901](https://github.com/gap-system/gap/pull/3901) Allow function-call syntax for general mappings
+- [#3903](https://github.com/gap-system/gap/pull/3903) Bug Fix: `Cycles((),[])` now correctly returns `[]`
+- [#3911](https://github.com/gap-system/gap/pull/3911) PageSource now gives a hint, that ApplicableMethod can be used to find the methods installed for an operation
+- [#3912](https://github.com/gap-system/gap/pull/3912) Update of GMP from version 6.1.2 (December 2016) to version 6.2.0 (January 2020)
+- [#3914](https://github.com/gap-system/gap/pull/3914) Added the attribute `InnerAutomorphismGroup` for groups
+- [#3920](https://github.com/gap-system/gap/pull/3920) Admit `CentralIdempotentsOfAlgebra` for algebras without `One`
+- [#3931](https://github.com/gap-system/gap/pull/3931) Bug Fix: Do not ignore `#@` comments after a empty line at start of test file
+- [#3933](https://github.com/gap-system/gap/pull/3933) `libgap` (shared library): Added libtool versioning
+- [#3986](https://github.com/gap-system/gap/pull/3986) Add some missing methods for machine floats (`Sinh`, `Cosh`, `Tanh`, `Asinh`, `Acosh`, `Atanh`, `CubeRoot`, `Erf`, `Gamma`)
+- [#3992](https://github.com/gap-system/gap/pull/3992) Introduced a function `Pluralize` for strings
+- [#4000](https://github.com/gap-system/gap/pull/4000) NormalClosure: Accept a list of normal generators as second argument
+- [#4023](https://github.com/gap-system/gap/pull/4006) Improve float literal parsing, fix some inconsistencies in it
+- [#4026](https://github.com/gap-system/gap/pull/4026) For the buildsystem now only .d files that exist are included
+- [#4035](https://github.com/gap-system/gap/pull/4035) Normalize package name to all-lowercase in `DirectoriesPackagePrograms`
+- [#4037](https://github.com/gap-system/gap/pull/4037) Normalize package name to all-lowercase in `IsPackageLoaded` and `GAPInfo.PackagesInfo`
+- [#4074](https://github.com/gap-system/gap/pull/4074) Add `IteratorOfPartitionsSet` an iterator for all unordered partitions of a set into pairwise disjoint nonempty sets
+- [#4080](https://github.com/gap-system/gap/pull/4080) Allow registering global handlers for GAP_TRY/GAP_CATCH
+- [#4099](https://github.com/gap-system/gap/pull/4099) Passing a `.tst` file as argument to `gap` will now invoke `Test` on it, instead of trying to `Read` it (which will fail)
+- [#4104](https://github.com/gap-system/gap/pull/4104) Add `TaylorSeriesRationalFunction` and improve `Derivative` for univariate rational functions
+- [#4105](https://github.com/gap-system/gap/pull/4105) The function `OrderMod` now admits an optional third argument that is a multiple of the order one wants to compute
+- [#4108](https://github.com/gap-system/gap/pull/4108) Fix some unexpected error when inverting or computing random elements of algebraic extensions of finite fields of size > 256
+- [#4111](https://github.com/gap-system/gap/pull/4111) In `FreeGroup`, support the option `generatorNames` to prescribe the names of the generators
+- [#4126](https://github.com/gap-system/gap/pull/4126) Added a command line option `--version`
+- [#4128](https://github.com/gap-system/gap/pull/4128) Added `OutputGzipFile`, in order to create a gzip compressed file
+- [#4132](https://github.com/gap-system/gap/pull/4132) Fixed a long standing bug which prevented `SetPrintFormattingStatus( "*stdout*", false );` from working as expected
+- [#4142](https://github.com/gap-system/gap/pull/4142) Extend `BindConstant`, `MakeConstantGlobal` to all object types
+- [#4145](https://github.com/gap-system/gap/pull/4145) Improved some errors messages for various set operations (`AddSet`, `UniteSet`, ...)
+- [#4146](https://github.com/gap-system/gap/pull/4146) Fixed `Cite` w.r.t. the encoding used; let `BibEntry` always use encoding "UTF-8"
+- [#4168](https://github.com/gap-system/gap/pull/4168) Improved the documentation concerning GASMAN, added `CollectGarbage`
+- [#4186](https://github.com/gap-system/gap/pull/4186) Improved the performance of `CoeffientsQadic` for long results
+- [#4201](https://github.com/gap-system/gap/pull/4201) Support an optional `transformFunction` in `Test()`, similarto `compareFunction`
+- [#4206](https://github.com/gap-system/gap/pull/4206) Fixed `DirectoriesPackageLibrary`, `DirectoriesPackagePrograms` when they are called during package loading
+- [#4207](https://github.com/gap-system/gap/pull/4207) Added the group constructors `PGammaL`, `PSigmaL`, and their methods for permutation groups
+- [#4215](https://github.com/gap-system/gap/pull/4215) `libgap` API: Expose a minimal interface to the garbage collector, via `GAP_MarkBag`, `GAP_CollectBags`
+- [#4219](https://github.com/gap-system/gap/pull/4219) Fixed `IntermediateGroup`: For large indices, it might have returned `fail` although subgroups exist, instead of issuing an error message or warning about a hard calculation
+- [#4232](https://github.com/gap-system/gap/pull/4232) Iterators for lists: fixed `IsDoneIterator`, improved the performance
+- [#4239](https://github.com/gap-system/gap/pull/4239) Added missing comparison w.r.t. equality of something and an object with memory (`IsObjWithMemory`)
+- [#4245](https://github.com/gap-system/gap/pull/4245) Free (associative or Lie) algebras: admit non-fields as left acting domains, fixed the zero-dimensional case
+
+### Unstructured list of merged pull requests for GAP 4.11.1
+
+- [#3790](https://github.com/gap-system/gap/pull/3790) Add further information to the library of simple groups
+- [#3840](https://github.com/gap-system/gap/pull/3840) Speed up garbage collection
+- [#3922](https://github.com/gap-system/gap/pull/3922) New feature to execute BuildPackages.sh in parallel mode by adding --parallel
+- [#3944](https://github.com/gap-system/gap/pull/3944) Bug Fix: The error checking in `PartialPerm` has been corrected such that invalid inputs (numbers < 1) are detected
+- [#3963](https://github.com/gap-system/gap/pull/3963) Provide automatic compression/decompression of filenames ending `.gz` (as is claimed for example in the documentation of `InputTextFile`)
+- [#3965](https://github.com/gap-system/gap/pull/3965) Fix potential garbage collector crashes on 64bit ARM systems
+- [#3980](https://github.com/gap-system/gap/pull/3980) Fixed `Gcd` for rational polynomials
+- [#4006](https://github.com/gap-system/gap/pull/4006) Fix gac to ensure that binaries it creates on Linux can load and run, even if a GAP package with a compiled kernel extension (such as IO) is present
+- [#4016](https://github.com/gap-system/gap/pull/4016) Improved `etc/Makefile.gappkg` (used by GAP packages that want to build a simple GAP kernel extension)
+- [#4041](https://github.com/gap-system/gap/pull/4041) Fix `make check` in out-of-tree builds
+- [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by useing jl_threadid() and jl_get_current_task() helpers
+- [#4042](https://github.com/gap-system/gap/pull/4042) Fix compiler constness warnings in weakptr.c
+- [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
+- [#4058](https://github.com/gap-system/gap/pull/4058) Refine the logic for scanning Julia stacks
+- [#4071](https://github.com/gap-system/gap/pull/4071) Make the Julia GC threadsafe when used from GAP.jl
+- [#4076](https://github.com/gap-system/gap/pull/4076) Fix an infinite loop in `BoundedRefinementEANormalSeries` if large factors could not be refined
+- [#4076](https://github.com/gap-system/gap/pull/4076) Improve documentation of `IsAutomorphismGroup`
+- [#4076](https://github.com/gap-system/gap/pull/4076) Fix protected option of `IsomorphismSimplifiedFpGroup`
+- [#4081](https://github.com/gap-system/gap/pull/4081) libgap: Enhance GAP_ValueGlobalVariable to supported automatic variables (see `DeclareAutoreadableVariables`)
+- [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range
+
+
+## GAP 4.11.0 (February 2020)
 
 ### New features and major changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,9 +81,6 @@ The label "release notes: added" has already been attached to them.
 
 ## GAP 4.11.1 (February 2021)
 
-These changes are also listed on the
-[Wiki page](https://github.com/gap-system/gap/wiki/GAP-4.11-release-notes)
-
 ### Fixed bugs that could lead to incorrect results
 
 - [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,22 +1,10 @@
 # GAP - history of changes
 
-## GAP 4.11.1 or GAP 4.12.0 (February 2021)
+<!--
 
-These changes are also listed on the
-[Wiki page](https://github.com/gap-system/GAP/wiki/gap-4.11-release-notes)
-
-### New features and major changes
-
-- **Added the missing perfect groups of order up to a million**
-
-  Added perfect groups of orders that had been missing in the Holt/Plesken book
-  (newly computed).
-  This increases the number of groups in the perfect groups library by a factor
-  close to 6.
-  Also added five groups that were found missing in the existing lists.
-  See PR [#3925](https://github.com/gap-system/gap/pull/3925) for details.
-
-### Unstructured list of merged pull requests for GAP 4.12.0
+The following is an unstructured list of all those merged pull requests
+for GAP 4.12.0 until February 17th, 2021, that are relevant for release notes.
+The label "release notes: added" has already been attached to them.
 
 - [#3628](https://github.com/gap-system/gap/pull/3628) When the info level of `InfoAttributes` is at least 3, warn about attempts to set an attribute value that is different from an already stored value
 - [#3643](https://github.com/gap-system/gap/pull/3643) The manual chapter "Vector and Matrix Objects", which had been marked as preliminary in earlier versions, is now regarded as official
@@ -78,28 +66,79 @@ These changes are also listed on the
 - [#4239](https://github.com/gap-system/gap/pull/4239) Added missing comparison w.r.t. equality of something and an object with memory (`IsObjWithMemory`)
 - [#4245](https://github.com/gap-system/gap/pull/4245) Free (associative or Lie) algebras: admit non-fields as left acting domains, fixed the zero-dimensional case
 
-### Unstructured list of merged pull requests for GAP 4.11.1
+-->
+
+## GAP 4.11.1 (February 2021)
+
+These changes are also listed on the
+[Wiki page](https://github.com/gap-system/GAP/wiki/gap-4.11-release-notes)
+
+### New features and major changes
+
+- **Added the missing perfect groups of order up to a million**
+
+  Added perfect groups of orders that had been missing in the Holt/Plesken book
+  (newly computed).
+  This increases the number of groups in the perfect groups library by a factor
+  close to 6.
+  Also added five groups that were found missing in the existing lists.
+  See PR [#3925](https://github.com/gap-system/gap/pull/3925) for details.
+
+### Fixed bugs that could lead to crashes
+
+- [#3965](https://github.com/gap-system/gap/pull/3965) Fix potential garbage collector crashes on 64bit ARM systems
+- [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
+- [#4076](https://github.com/gap-system/gap/pull/4076) Fix an infinite loop in `BoundedRefinementEANormalSeries` if large factors could not be refined
+
+### Fixed bugs that could lead to incorrect results
+
+- [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range
+
+### Fixed bugs that could lead to error messages
+
+- [#3980](https://github.com/gap-system/gap/pull/3980) Fixed `Gcd` for rational polynomials
+
+### Other fixed bugs
+
+- [#3963](https://github.com/gap-system/gap/pull/3963) Provide automatic compression/decompression of filenames ending `.gz` (as is claimed for example in the documentation of `InputTextFile`)
+- [#3944](https://github.com/gap-system/gap/pull/3944) Bug Fix: The error checking in `PartialPerm` has been corrected such that invalid inputs (numbers < 1) are detected
+- [#4006](https://github.com/gap-system/gap/pull/4006) Fix gac to ensure that binaries it creates on Linux can load and run, even if a GAP package with a compiled kernel extension (such as IO) is present
+- [#4076](https://github.com/gap-system/gap/pull/4076) Fix protected option of `IsomorphismSimplifiedFpGroup`
+
+### Improved and extended functionality
 
 - [#3790](https://github.com/gap-system/gap/pull/3790) Add further information to the library of simple groups
 - [#3840](https://github.com/gap-system/gap/pull/3840) Speed up garbage collection
-- [#3922](https://github.com/gap-system/gap/pull/3922) New feature to execute BuildPackages.sh in parallel mode by adding --parallel
-- [#3944](https://github.com/gap-system/gap/pull/3944) Bug Fix: The error checking in `PartialPerm` has been corrected such that invalid inputs (numbers < 1) are detected
-- [#3963](https://github.com/gap-system/gap/pull/3963) Provide automatic compression/decompression of filenames ending `.gz` (as is claimed for example in the documentation of `InputTextFile`)
-- [#3965](https://github.com/gap-system/gap/pull/3965) Fix potential garbage collector crashes on 64bit ARM systems
-- [#3980](https://github.com/gap-system/gap/pull/3980) Fixed `Gcd` for rational polynomials
-- [#4006](https://github.com/gap-system/gap/pull/4006) Fix gac to ensure that binaries it creates on Linux can load and run, even if a GAP package with a compiled kernel extension (such as IO) is present
+
+### Changed documentation
+
+- [#4076](https://github.com/gap-system/gap/pull/4076) Improve documentation of `IsAutomorphismGroup`
+
+### Packages
+
 - [#4016](https://github.com/gap-system/gap/pull/4016) Improved `etc/Makefile.gappkg` (used by GAP packages that want to build a simple GAP kernel extension)
-- [#4041](https://github.com/gap-system/gap/pull/4041) Fix `make check` in out-of-tree builds
+
+### Fixes/improvements in the experimental way to allow 3rd party code to link GAP as a library (libgap)
+
+- [#4081](https://github.com/gap-system/gap/pull/4081) Enhance `GAP_ValueGlobalVariable` to supported automatic variables (see `DeclareAutoreadableVariables`)
+
+### Fixes and improvements in for the **Julia** integration
+
 - [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by useing jl_threadid() and jl_get_current_task() helpers
 - [#4042](https://github.com/gap-system/gap/pull/4042) Fix compiler constness warnings in weakptr.c
-- [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
 - [#4058](https://github.com/gap-system/gap/pull/4058) Refine the logic for scanning Julia stacks
 - [#4071](https://github.com/gap-system/gap/pull/4071) Make the Julia GC threadsafe when used from GAP.jl
-- [#4076](https://github.com/gap-system/gap/pull/4076) Fix an infinite loop in `BoundedRefinementEANormalSeries` if large factors could not be refined
-- [#4076](https://github.com/gap-system/gap/pull/4076) Improve documentation of `IsAutomorphismGroup`
-- [#4076](https://github.com/gap-system/gap/pull/4076) Fix protected option of `IsomorphismSimplifiedFpGroup`
-- [#4081](https://github.com/gap-system/gap/pull/4081) libgap: Enhance GAP_ValueGlobalVariable to supported automatic variables (see `DeclareAutoreadableVariables`)
-- [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range
+
+### Other changes
+
+- [#3922](https://github.com/gap-system/gap/pull/3922) Build system: New feature to execute BuildPackages.sh in parallel mode by adding `--parallel`
+- [#4041](https://github.com/gap-system/gap/pull/4041) Build system: Fix `make check` in out-of-tree builds
+
+### New packages redistributed with GAP
+
+
+### Updated packages redistributed with GAP
+
 
 
 ## GAP 4.11.0 (February 2020)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,7 @@ The label "release notes: added" has already been attached to them.
 ### Fixes/improvements in the experimental way to allow 3rd party code to link GAP as a library (libgap)
 
 - [#4081](https://github.com/gap-system/gap/pull/4081) Enhance `GAP_ValueGlobalVariable` to supported automatic variables (see `DeclareAutoreadableVariables`)
+- [#4258](https://github.com/gap-system/gap/pull/4258) Fixed `GAP_Enter` macro so that GAP's recursion depth counter is saved/restored. Without this, if too many GAP errors occurred during runtime a segmentation fault could occur in the program using libgap
 
 ### Fixes and improvements for the **Julia** integration
 
@@ -125,11 +126,61 @@ The label "release notes: added" has already been attached to them.
 - [#3922](https://github.com/gap-system/gap/pull/3922) Build system: New feature to execute `BuildPackages.sh` in parallel mode by adding `--parallel`
 - [#4041](https://github.com/gap-system/gap/pull/4041) Build system: Fix `make check` in out-of-tree builds
 
-### New packages redistributed with GAP
+### Packages no longer redistributed with GAP
 
+**PolymakeInterface**: Following the withdrawal of the package **Convex** in GAP 4.11.0 because of being superseded by **NConvex**, the **PolymakeInterface** has also been withdrawn. These two packages are now replaced by **NormalizInterface** and **NConvex**.
 
 ### Updated packages redistributed with GAP
 
+[**4ti2Interface**](https://homalg-project.github.io/homalg_project/4ti2Interface/): 2019.09.02 -> 2020.10-02
+[**AGT**](https://github.com/rhysje00/agt): 0.1 -> 0.2
+[**AutoDoc**](https://gap-packages.github.io/AutoDoc): 2019.09.04 -> 2020.08.11
+[**Browse**](http://www.math.rwth-aachen.de/~Browse): 1.8.8 -> 1.8.11
+[**CAP**](http://homalg-project.github.io/CAP_project/CAP/): 2019.06.07 -> 2020.10-01
+[**CddInterface**](https://homalg-project.github.io/CddInterface): 2020.01.01 -> 2020.06.24
+[**CTblLib**](http://www.math.rwth-aachen.de/~Thomas.Breuer/ctbllib): 1.2.2 -> 1.3.1
+[**curlInterface**](https://gap-packages.github.io/curlInterface/): 2.1.1 -> 2.2.1
+[**Digraphs**](https://gap-packages.github.io/Digraphs): 1.1.1 -> 1.3.1
+[**ExamplesForHomalg**](https://homalg-project.github.io/homalg_project/ExamplesForHomalg/): 2019.09.02 -> 2020.10-02
+[**ferret**](https://gap-packages.github.io/ferret/): 1.0.2 -> 1.0.3
+[**GAPDoc**](http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc): 1.6.3 -> 1.6.4
+[**Gauss**](https://homalg-project.github.io/homalg_project/Gauss/): 2019.09.02 -> 2020.10-02
+[**GaussForHomalg**](https://homalg-project.github.io/homalg_project/GaussForHomalg/): 2019.09.02 -> 2020.10-02
+[**GeneralizedMorphismsForCAP**](http://homalg-project.github.io/CAP_project/GeneralizedMorphismsForCAP/): 2019.01.16 -> 2020.10-01
+[**GradedModules**](https://homalg-project.github.io/homalg_project/GradedModules/): 2020.01.02 -> 2020.10-02
+[**GradedRingForHomalg**](https://homalg-project.github.io/homalg_project/GradedRingForHomalg/): 2020.01.02 -> 2020.10-02
+[**HAP**](https://gap-packages.github.io/hap): 1.25 -> 1.29
+[**homalg**](https://homalg-project.github.io/homalg_project/homalg/): 2019.09.01 -> 2020.10-02
+[**HomalgToCAS**](https://homalg-project.github.io/homalg_project/HomalgToCAS/): 2019.12.08 -> 2020.10-02
+[**IO_ForHomalg**](https://homalg-project.github.io/homalg_project/IO_ForHomalg/): 2019.09.02 -> 2020.10-02
+[**IRREDSOL**](http://www.icm.tu-bs.de/~bhoeflin/irredsol/index.html): 1.4 -> 1.4.1
+[**json**](https://gap-packages.github.io/json/): 2.0.1 -> 2.0.2
+[**kan**](https://gap-packages.github.io/kan/): 1.29 -> 1.32
+[**LinearAlgebraForCAP**](http://homalg-project.github.io/CAP_project/LinearAlgebraForCAP/): 2019.01.16 -> 2020.10-01
+[**LocalizeRingForHomalg**](https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/): 2019.09.02 -> 2020.10-02
+[**matgrp**](http://www.math.colostate.edu/~hulpke/matgrp): 0.63 -> 0.64
+[**MatricesForHomalg**](https://homalg-project.github.io/homalg_project/MatricesForHomalg/): 2020.01.02 -> 2020.10-04
+[**ModulePresentationsForCAP**](http://homalg-project.github.io/CAP_project/ModulePresentationsForCAP/): 2019.01.16 -> 2020.10-01
+[**Modules**](https://homalg-project.github.io/homalg_project/Modules/): 2019.09.02 -> 2020.10-02
+[**MonoidalCategories**](http://homalg-project.github.io/CAP_project/MonoidalCategories/): 2019.06.07 -> 2020.10-01
+[**NConvex**](https://homalg-project.github.io/NConvex): 2019.12.10 -> 2020.11-04
+[**NumericalSgps**](https://gap-packages.github.io/numericalsgps): 1.2.1 -> 1.2.2
+[**PackageManager**](https://gap-packages.github.io/PackageManager/): 1.0 -> 1.1
+[**Polycyclic**](https://gap-packages.github.io/polycyclic/): 2.15.1 -> 2.16
+[**PrimGrp**](https://gap-packages.github.io/primgrp/): 3.4.0 -> 3.4.1
+[**profiling**](https://gap-packages.github.io/profiling/): 2.2.1 -> 2.3
+[**QPA**](https://folk.ntnu.no/oyvinso/QPA/): 1.30 -> 1.31
+[**RingsForHomalg**](https://homalg-project.github.io/homalg_project/RingsForHomalg/): 2019.12.08 -> 2020.11-01
+[**SCO**](https://homalg-project.github.io/homalg_project/SCO/): 2019.09.02 -> 2020.10-02
+[**Semigroups**](https://gap-packages.github.io/Semigroups): 3.2.3 -> 3.4.0
+[**singular**](https://gap-packages.github.io/singular/): 2019.10.01 -> 2020.12.18
+[**SmallGrp**](https://gap-packages.github.io/smallgrp/): 1.4.1 -> 1.4.2
+[**ToolsForHomalg**](https://homalg-project.github.io/homalg_project/ToolsForHomalg/): 2019.09.02 -> 2020.10-03
+[**ToricVarieties**](https://homalg-project.github.io/homalg_project/ToricVarieties/): 2019.12.05 -> 2021.01.12
+[**TransGrp**](https://www.math.colostate.edu/~hulpke/transgrp): 2.0.5 -> 3.0
+[**Wedderga**](https://gap-packages.github.io/wedderga): 4.9.5 -> 4.10.0
+[**XMod**](https://gap-packages.github.io/xmod/): 2.77 -> 2.82
+[**XModAlg**](https://gap-packages.github.io/xmodalg/): 1.17 -> 1.18
 
 
 ## GAP 4.11.0 (February 2020)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,15 +84,15 @@ These changes are also listed on the
   Also added five groups that were found missing in the existing lists.
   See PR [#3925](https://github.com/gap-system/gap/pull/3925) for details.
 
+### Fixed bugs that could lead to incorrect results
+
+- [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range
+
 ### Fixed bugs that could lead to crashes
 
 - [#3965](https://github.com/gap-system/gap/pull/3965) Fix potential garbage collector crashes on 64bit ARM systems
 - [#4053](https://github.com/gap-system/gap/pull/4053) Fix the logic for scanning tasks in the Julia GC
-- [#4076](https://github.com/gap-system/gap/pull/4076) Fix an infinite loop in `BoundedRefinementEANormalSeries` if large factors could not be refined
-
-### Fixed bugs that could lead to incorrect results
-
-- [#4178](https://github.com/gap-system/gap/pull/4178) Fixed bugs in `RestrictedPerm` with second argument a range
+- [#4076](https://github.com/gap-system/gap/pull/4076) Fix an infinite loop in `BoundedRefinementEANormalSeries` if large factors could not be refined, fix protected option of `IsomorphismSimplifiedFpGroup`, improve documentation of `IsAutomorphismGroup`
 
 ### Fixed bugs that could lead to error messages
 
@@ -101,18 +101,13 @@ These changes are also listed on the
 ### Other fixed bugs
 
 - [#3963](https://github.com/gap-system/gap/pull/3963) Provide automatic compression/decompression of filenames ending `.gz` (as is claimed for example in the documentation of `InputTextFile`)
-- [#3944](https://github.com/gap-system/gap/pull/3944) Bug Fix: The error checking in `PartialPerm` has been corrected such that invalid inputs (numbers < 1) are detected
-- [#4006](https://github.com/gap-system/gap/pull/4006) Fix gac to ensure that binaries it creates on Linux can load and run, even if a GAP package with a compiled kernel extension (such as IO) is present
-- [#4076](https://github.com/gap-system/gap/pull/4076) Fix protected option of `IsomorphismSimplifiedFpGroup`
+- [#3944](https://github.com/gap-system/gap/pull/3944) The error checking in `PartialPerm` has been corrected such that invalid inputs (numbers < 1) are detected
+- [#4006](https://github.com/gap-system/gap/pull/4006) Fix `gac` to ensure that binaries it creates on Linux can load and run, even if a GAP package with a compiled kernel extension (such as `IO`) is present
 
 ### Improved and extended functionality
 
 - [#3790](https://github.com/gap-system/gap/pull/3790) Add further information to the library of simple groups
 - [#3840](https://github.com/gap-system/gap/pull/3840) Speed up garbage collection
-
-### Changed documentation
-
-- [#4076](https://github.com/gap-system/gap/pull/4076) Improve documentation of `IsAutomorphismGroup`
 
 ### Packages
 
@@ -124,14 +119,13 @@ These changes are also listed on the
 
 ### Fixes and improvements in for the **Julia** integration
 
-- [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by useing jl_threadid() and jl_get_current_task() helpers
-- [#4042](https://github.com/gap-system/gap/pull/4042) Fix compiler constness warnings in weakptr.c
+- [#4042](https://github.com/gap-system/gap/pull/4042) Avoid access to JuliaTLS members by useing `jl_threadid()` and `jl_get_current_task()` helpers, fix compiler constness warnings in weakptr.c
 - [#4058](https://github.com/gap-system/gap/pull/4058) Refine the logic for scanning Julia stacks
 - [#4071](https://github.com/gap-system/gap/pull/4071) Make the Julia GC threadsafe when used from GAP.jl
 
 ### Other changes
 
-- [#3922](https://github.com/gap-system/gap/pull/3922) Build system: New feature to execute BuildPackages.sh in parallel mode by adding `--parallel`
+- [#3922](https://github.com/gap-system/gap/pull/3922) Build system: New feature to execute `BuildPackages.sh` in parallel mode by adding `--parallel`
 - [#4041](https://github.com/gap-system/gap/pull/4041) Build system: Fix `make check` in out-of-tree builds
 
 ### New packages redistributed with GAP

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -132,6 +132,8 @@ The label "release notes: added" has already been attached to them.
 
 ### Updated packages redistributed with GAP
 
+The GAP 4.11.1 distribution contains 151 packages, of which 49 have been updated since GAP 4.11.0. The changes include extending the Transitive Groups Library with representatives for all transitive permutation groups of degree at most 47 (due to Derek Holt), and fixing the ordering of groups of orders 3^7, 5^7, 7^7, 11^7 in the Small Groups Library. For other changes, we refer to the documentation of the packages. The full list of updated packages in the GAP 4.11.1 distribution is given below:
+
 [**4ti2Interface**](https://homalg-project.github.io/homalg_project/4ti2Interface/): 2019.09.02 -> 2020.10-02
 [**AGT**](https://github.com/rhysje00/agt): 0.1 -> 0.2
 [**AutoDoc**](https://gap-packages.github.io/AutoDoc): 2019.09.04 -> 2020.08.11
@@ -176,7 +178,7 @@ The label "release notes: added" has already been attached to them.
 [**singular**](https://gap-packages.github.io/singular/): 2019.10.01 -> 2020.12.18
 [**SmallGrp**](https://gap-packages.github.io/smallgrp/): 1.4.1 -> 1.4.2
 [**ToolsForHomalg**](https://homalg-project.github.io/homalg_project/ToolsForHomalg/): 2019.09.02 -> 2020.10-03
-[**ToricVarieties**](https://homalg-project.github.io/homalg_project/ToricVarieties/): 2019.12.05 -> 2021.01.12
+[**ToricVarieties**](https://homalg-project.github.io/ToricVarieties_project/ToricVarieties/): 2019.12.05 -> 2021.01.12
 [**TransGrp**](https://www.math.colostate.edu/~hulpke/transgrp): 2.0.5 -> 3.0
 [**Wedderga**](https://gap-packages.github.io/wedderga): 4.9.5 -> 4.10.0
 [**XMod**](https://gap-packages.github.io/xmod/): 2.77 -> 2.82

--- a/dev/release_notes.readme.md
+++ b/dev/release_notes.readme.md
@@ -33,7 +33,7 @@ Besides the list of relevant pull requests, the release notes contain also the l
 For each package in question, there is one entry that shows package name (with a link to the package homepage), version, authors, abstract,
 
 Note that the information about packages cannot be extracted from pull requests. It depends on the archives of packages that are distributed with GAP.
-(It would be easy to put this information together if there woud be a text file for each archive that lists which package versions are contained in the archive.)
+(Since the release of GAP 4.11.1, scripts in `dev/releases` can be used to extract the metadata of all packages that belong to a given version of GAP or to a given package archive, hence the differences between two releases can be computed.)
 
 
 ## How are release notes created from the github pull requests?

--- a/dev/release_notes.readme.md
+++ b/dev/release_notes.readme.md
@@ -12,12 +12,12 @@ that describe the changes.
 
 Up to version 4.11.1, the relevant part of `CHANGES.md` has been put together manually, by evaluating the pull merged requests in question and then structuring this information.
 
-Since then, we intend to extend `CHANGES.md` as automatic as possible, and this file shall help to achieve this.
+Since then, we intend to extend `CHANGES.md` as automatically as possible, and this file shall help to achieve this.
 
 (Up to version 4.10.0, GAP release notes were available also via the GAPDoc book "Changes".  We have stopped providing this format of release notes because preparing it was very time consuming.  However, this format had for example the advantage that its HTML links into the GAP Reference Manual or into package manuals allowed one to easily access information about new or changed GAP functions etc.  It would be good to revive this feature of the "CHANGES" manual, provided it can be achieved essentially automatically.)
 
 
-## How shall GAP release notes look like?
+## How shall GAP release notes look?
 
 The aim of GAP release notes is to give users an overview of **important** changes since the previous version.  This means that this overview does not show a complete list of **all** changes (if one is interested in a complete list then one can consult the history in github), and that the listed changes are shown in a structured way.
 
@@ -45,8 +45,7 @@ Currently the following labels are regarded as relevant for the creation of rele
   Thus the release notes are composed from all those merged pull requests that belong to the release in question (are assigned to the release branch or have a `backport-to-...-DONE` label for the release) AND do NOT have the label `release notes: not needed`.
 
 - For pull requests with the label `release notes: use title`, the text for the release notes is given by the title of the pull request.
-  For all other pull requests, the text for the release notes can be extracted from the pull request body.
-  (The pull request template contains `## Text for release notes`, thus the relevant text is expected there; but where is the end of this text? We have to define a convention to mark the release notes text, then this text can be extracted automatically.)
+  For all other pull requests, the text for the release notes can be extracted from the pull request body.  The pull request template (see `.github/pull_request_template.md) contains the markers `## Text for release notes` and `## (End of text for release notes)`, thus the relevant text is expected between these markers, and can be extracted automatically.
 
 - Up to now, also the labels `release notes: needed` and `release notes: added` have been used.
   The first one means that the text for release notes can be found in the body and has not yet been added to `CHANGES.md`, the second one means that the text has been added to `CHANGES.md`.
@@ -81,7 +80,7 @@ Currently the following labels are regarded as relevant for the creation of rele
   Note that `CHANGES.md` is just **one** way to present the changes, eventually we should put the source data (pull request number, release notes text, labels) into the GAP distribution, and provide a tool for evaluating the data inside a GAP session.
 
 - For convenience, consistency checks can be executed, via suitable queries (restricted to the merged pull requests that belong to the forthcoming release), for example:
-  - There should be no pull request without the labels `release notes: not needed` and `release notes: use title` AND without release notes text in the body.
+  - There should be no pull requests without the labels `release notes: not needed` and `release notes: use title` AND without release notes text in the body.
 
 - The three sections on changes packages in the forthcomiing release (see above) will appear below the groups of pull requests that are defined by the above labels.
   (There will be a script that extracts the information from suitable text files related to the package archives.)
@@ -93,7 +92,7 @@ The following is intended for those who create or review pull requests.
 
 - If your pull request should not be mentioned in the release notes then add the label `release notes: not needed`, and you are done.
 
-- Otherwise, try to find a short title that describes the pull request in the release notes; use appropriate maarkup in the title (e.g., backquotes for surrounding function names).  In this case, add the label `release notes: use title`.
+- Otherwise, try to find a short title that describes the pull request in the release notes; use appropriate markup in the title (e.g., backquotes for surrounding function names).  In this case, add the label `release notes: use title`.
 
 - Otherwise, make sure that the body of the pull request contains the relevant text below the line `## Text for release notes`.
   (In the old workflow, the label `release notes: needed` should be added. I think this should be abolished.)

--- a/dev/release_notes.readme.md
+++ b/dev/release_notes.readme.md
@@ -45,7 +45,7 @@ Currently the following labels are regarded as relevant for the creation of rele
   Thus the release notes are composed from all those merged pull requests that belong to the release in question (are assigned to the release branch or have a `backport-to-...-DONE` label for the release) AND do NOT have the label `release notes: not needed`.
 
 - For pull requests with the label `release notes: use title`, the text for the release notes is given by the title of the pull request.
-  For all other pull requests, the text for the release notes can be extracted from the pull request body.  The pull request template (see `.github/pull_request_template.md) contains the markers `## Text for release notes` and `## (End of text for release notes)`, thus the relevant text is expected between these markers, and can be extracted automatically.
+  For all other pull requests, the text for the release notes can be extracted from the pull request body.  The pull request template (see `.github/pull_request_template.md`) contains the markers `## Text for release notes` and `## (End of text for release notes)`, thus the relevant text is expected between these markers, and can be extracted automatically.
 
 - Up to now, also the labels `release notes: needed` and `release notes: added` have been used.
   The first one means that the text for release notes can be found in the body and has not yet been added to `CHANGES.md`, the second one means that the text has been added to `CHANGES.md`.

--- a/dev/release_notes.readme.md
+++ b/dev/release_notes.readme.md
@@ -1,0 +1,102 @@
+# How to produce release notes for GAP essentially automatically
+
+(This text arose from discussions and experiments during the
+GAP Days "Spring" in February 2021.)
+
+## What are GAP release notes?
+
+For each release of GAP since version 4.3, we provide **release notes** in the file `CHANGES.md` of the GAP root directory.  This file contains one section about each release.
+
+Since GAP 4.8, these notes contain references to the github pull requests
+that describe the changes.
+
+Up to version 4.11.1, the relevant part of `CHANGES.md` has been put together manually, by evaluating the pull merged requests in question and then structuring this information.
+
+Since then, we intend to extend `CHANGES.md` as automatic as possible, and this file shall help to achieve this.
+
+(Up to version 4.10.0, GAP release notes were available also via the GAPDoc book "Changes".  We have stopped providing this format of release notes because preparing it was very time consuming.  However, this format had for example the advantage that its HTML links into the GAP Reference Manual or into package manuals allowed one to easily access information about new or changed GAP functions etc.  It would be good to revive this feature of the "CHANGES" manual, provided it can be achieved essentially automatically.)
+
+
+## How shall GAP release notes look like?
+
+The aim of GAP release notes is to give users an overview of **important** changes since the previous version.  This means that this overview does not show a complete list of **all** changes (if one is interested in a complete list then one can consult the history in github), and that the listed changes are shown in a structured way.
+
+We show the subset of those merged pull requests that belong to the release in question and are regarded as relevant for the release notes.  For each of these pull requests, one line is shown, containing the number (as a link to the pull request in github) and the title.  Pull requests with related topics are grouped together under suitable subheadings.  These groups are ordered according to decreasing "severity".  Of course it is not possible to define such a general linear ordering, but we want each pull request to appear **only once** in the release notes, not in several groups according to several aspects it belongs to.
+
+Note that a file with release notes that is expected to be **read** must be **short**; other tools would be needed for **evaluating** the release notes (searching/filtering facilities according to various aspects).
+
+Besides the list of relevant pull requests, the release notes contain also the lists of changed GAP packages:
+- omitted packages (which had been distributed with the previous GAP version but are not distributed with the current one),
+- changed packages (which are distributed with both the previous and the current GAP version, but with different package versions),
+- new packages (which had not been distributed with the previous GAP version but are distributed with the current one).
+
+For each package in question, there is one entry that shows package name (with a link to the package homepage), version, authors, abstract,
+
+Note that the information about packages cannot be extracted from pull requests. It depends on the archives of packages that are distributed with GAP.
+(It would be easy to put this information together if there woud be a text file for each archive that lists which package versions are contained in the archive.)
+
+
+## How are release notes created from the github pull requests?
+
+The main idea is to use the *labels* that are assigned to the pull requests.
+Currently the following labels are regarded as relevant for the creation of release notes.
+
+- Pull requests with the label `release notes: not needed` shall **not** be listed in the release notes.
+  Thus the release notes are composed from all those merged pull requests that belong to the release in question (are assigned to the release branch or have a `backport-to-...-DONE` label for the release) AND do NOT have the label `release notes: not needed`.
+
+- For pull requests with the label `release notes: use title`, the text for the release notes is given by the title of the pull request.
+  For all other pull requests, the text for the release notes can be extracted from the pull request body.
+  (The pull request template contains `## Text for release notes`, thus the relevant text is expected there; but where is the end of this text? We have to define a convention to mark the release notes text, then this text can be extracted automatically.)
+
+- Up to now, also the labels `release notes: needed` and `release notes: added` have been used.
+  The first one means that the text for release notes can be found in the body and has not yet been added to `CHANGES.md`, the second one means that the text has been added to `CHANGES.md`.
+  I think that these two labels are obsolete in the new workflow where one can automatically create the current state of the `CHANGES.md` section about the forthcoming release **at any time**.
+
+- The above labels describe whether a pull request is relevant at all, and if yes then how it is treated.
+  The following labels describe the ordering of the groups of pull requests and the subheadings of these groups.  Each pull request gets assigned to the **first** group/subheading that corresponds to one of its labels.
+
+| | subheading | labels | meaning |
+| - |------------- | ------- | -------- |
+| 1 | New features and major changes | `release notes: highlight` | PRs introducing changes that should be highlighted at the top of the release notes |
+| 2 | Fixed bugs that could lead to incorrect results | `kind: bug: wrong result` | PRs fixing bugs that result in mathematically or otherwise wrong results |
+| 3 | Removed or obsolete functionality | `topic: obsolete functionality` | PRs changing `lib/obsolete.g*` (move functions there or remove something from there) |
+| 4 | Fixed bugs that could lead to crashes or unexpected error messages | `kind: bug: crash` | PRs fixing bugs that may cause GAP to crash |
+| 4 | Fixed bugs that could lead to crashes or unexpected error messages | `kind: bug: unexpected error` | PRs fixing bugs that may cause GAP to run into an unexpected error |
+| 5 | Other fixed bugs | `kind: bug:` | PRs fixing bugs |
+| 6 | Improved and extended functionality | `kind: enhancement` OR `kind: new feature` OR `kind: performance` | PRs implementing enhancements |
+| 7 | Improvements in the experimental way to allow 3rd party code to link GAP as a library (libgap) | `topic: libgap` | PRs that are related to libgap |
+| 8 | Improvements in for the **Julia** integration | `topic: julia` | PRs that are related to the Julia integration |
+| 9 | Changed documentation | `topic: documentation` | PRs improving the documentation |
+| 10 | Packages | `topic: packages` | PRs related to package handling, or specific to a package (for packages w/o issue tracker) |
+| 11 | Other changes | `release notes: needed` OR `release notes: added` | PRs relevant for the release notes but without a label that fits --in each case, think about assigning such a label or introducing a new one |
+
+- For empty groups of pull requests, the subheading need not appear in `CHANGES.md`.
+
+- If the group "Other changes" is too large then we should decide whether other labels (most likely some `topic: ...` labels) can be used to define useful groups; in this case, a subheading has to be defined for this label.
+  (There will be a script for creating the current `CHANGES.md` section in the `dev` subdirectory of the main GAP directory, the change of the rules should be made in this script.)
+
+- Concerning the ordering, I think that somebody who reads the release notes of a new GAP version will be first interested in highlights, then in bugs which may affect one's computations (wrong results), then in removed functionality (which may break old private code), then in general improvements.
+
+  I think there is no way to satisfy all perspectives of what is most important, in particular concerning the `topic: ...` labels.
+  Note that `CHANGES.md` is just **one** way to present the changes, eventually we should put the source data (pull request number, release notes text, labels) into the GAP distribution, and provide a tool for evaluating the data inside a GAP session.
+
+- For convenience, consistency checks can be executed, via suitable queries (restricted to the merged pull requests that belong to the forthcoming release), for example:
+  - There should be no pull request without the labels `release notes: not needed` and `release notes: use title` AND without release notes text in the body.
+
+- The three sections on changes packages in the forthcomiing release (see above) will appear below the groups of pull requests that are defined by the above labels.
+  (There will be a script that extracts the information from suitable text files related to the package archives.)
+
+
+## How to deal with github pull requests in a release notes friendly way?
+
+The following is intended for those who create or review pull requests.
+
+- If your pull request should not be mentioned in the release notes then add the label `release notes: not needed`, and you are done.
+
+- Otherwise, try to find a short title that describes the pull request in the release notes; use appropriate maarkup in the title (e.g., backquotes for surrounding function names).  In this case, add the label `release notes: use title`.
+
+- Otherwise, make sure that the body of the pull request contains the relevant text below the line `## Text for release notes`.
+  (In the old workflow, the label `release notes: needed` should be added. I think this should be abolished.)
+
+- Choose as many suitable (release notes relevant) labels as you want. Keep in mind that the pull request will appear just in the first applicable group of pull requests in `CHANGES.md`.
+


### PR DESCRIPTION
The file `CHANGES.md` now contains the entries about the merged pull requests for GAP 4.11.1, categorized in the same way as for GAP 4.11.0.

What is now *MISSING* is the information about new and updated GAP packages in 4.11.1, compared to 4.11.0.

~~... currently unstructured, taken from the subset of pull request obtained today with the query~~

~~https://github.com/gap-system/gap/pulls?q=is%3Apr+-label%3A%22release+notes%3A+not+needed%22+-label%3A%22release+notes%3A+added%22+is%3Aclosed+merged%3A2019-09-10..2033-12-31+base%3Amaster+is%3Amerged~~

~~(It remains to deal with the entries which are still returned by this query. Those entries which are proposed here for addition to `CHANGES.md` do no longer match the query because now they have the label "release notes: added".)~~

