### PR TITLE
libgap: save/restore recursion depth

### DIFF
--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -18,6 +18,7 @@
 #include "ariths.h"
 #include "bool.h"
 #include "calls.h"
+#include "funcs.h"
 #include "gap.h"
 #include "gapstate.h"
 #include "gasman.h"
@@ -482,6 +483,7 @@ jmp_buf * GAP_GetReadJmpError(void)
 
 
 static volatile sig_atomic_t EnterStackCount = 0;
+static volatile Int RecursionDepth;
 
 
 // These are wrapped by the macros GAP_EnterStack() and GAP_LeaveStack()
@@ -517,6 +519,7 @@ int GAP_Error_Prejmp_(const char * file, int line)
     if (EnterStackCount > 0) {
         return 1;
     }
+    RecursionDepth = GetRecursionDepth();
     return 0;
 }
 
@@ -535,6 +538,7 @@ void GAP_Error_Postjmp_Returning_(void)
     if (EnterStackCount > 0) {
         EnterStackCount = -EnterStackCount;
     }
+    SetRecursionDepth(RecursionDepth);
 }
 
 


### PR DESCRIPTION
# Description

At other places in GAP where `setjmp` is called, notably [GAP_TRY/CATCH](https://github.com/gap-system/gap/blob/13a00a4cc7a763330eb3ba7b877cb659b9aaa6a0/src/trycatch.h#L86) the recursion depth counter also needs to be saved/restored.

It appears libgap needs to do this as well.  If you have code like:

```c
int ok = GAP_Enter();
if (ok) {
    ...
    GAP_CallFuncArray(...);
}
GAP_Leave();
```

if an error occurs in the function being called, the recursion depth counter will not get reset.

As a result, after enough errors in GAP functions, eventually the recursion depth counter reaches its limit (default 5000) and enters [RecursionDepthTrap](https://github.com/gap-system/gap/blob/8b3c827a2b49d9912160e7acc6835f9b0c5a2635/src/funcs.c#L391).  Here something strange happens that I admit I don't fully understand, and could be something I'm doing wrong: Even though `RecursionDepthTrap` resets the recursion depth to zero before calling the error handler, at this point it actually goes into an infinite recursion and eventual stack overflow.

Here is some code in Sage and gappy that reproduced the problem:

```python
for _ in range(5000):
    try:
        # It doesn't really matter what you put here as long as it will
        # result in an error
        gap.Sum(0, 1, 2)
    except GAPError:
        pass
```

I suspect you could reproduce the problem similarly with GAP.jl.

More broadly speaking, `GAP_TRY/CATCH` are new since I last looked closely at GAP error handling.  I wonder if they couldn't be generalized a bit and used in the implementations of `GAP_Enter()` and `GAP_Leave()`.

## Text for release notes 

### Other fixed bugs

* libgap: Fixed `GAP_Enter()` macro so that GAP's recursion depth counter is saved/restored.  Without this, if too many GAP errors occurred during runtime a segmentation fault could occur in the program using libgap.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

