### PR TITLE
buildsys: fix Makefile build order for GMP, zlib

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -697,6 +697,7 @@ endif # BUILD_BOEHM_GC
 # ensure subprojects are built and "installed" before compiling and linking GAP
 gap$(EXEEXT): $(EXTERN_FILES)
 $(OBJS): $(EXTERN_FILES)
+$(DEPFILES): $(EXTERN_FILES)
 ifeq ($(HPCGAP),yes)
 $(SOURCES): $(EXTERN_FILES)
 endif


### PR DESCRIPTION
When GAP is built in an environment where it can't find GMP or zlib,
it builds a bundled copy of those. When using parallel make, e.g. `make -j`,
one has to be careful to first build GMP / zlib before building any GAP
source files. This regressed compared to GAP 4.11.0; this patch fixes it.

Resolves #4266 (in case you wonder why I submitted an issue and then immediately a fix for it: well, the fix turned out to be a lot easier than I feared, otherwise I wouldn't have bothered opening an issue first; also, during GAP Days, I always multitask too much and have a high risk of forgetting an issue, so I prefer to write them down first then work on them)