### PR TITLE
Fix warning about checking unsigned < 0 by making signed

### DIFF
--- a/src/opers.cc
+++ b/src/opers.cc
@@ -1613,7 +1613,7 @@ static UInt CacheMissStatistics[CACHE_SIZE + 1][7];
 // This function actually searches the cache. Normally it should be
 // called with n a compile-time constant to allow the optimiser to tidy
 // things up.
-template <UInt n>
+template <Int n>
 static Obj GetMethodCached(Obj cacheBag, Int prec, Obj ids[])
 {
     UInt  typematch;
@@ -1823,7 +1823,7 @@ static Int OperationNext;
 #endif
 
 
-template <UInt n, BOOL verbose, BOOL constructor>
+template <Int n, BOOL verbose, BOOL constructor>
 static Obj
 DoOperationNArgs(Obj oper, Obj a1, Obj a2, Obj a3, Obj a4, Obj a5, Obj a6)
 {


### PR DESCRIPTION
gcc 10.2.0 (on cygwin 32) warns about code which compares unsigned integers < 0. I could not fix this by putting the loop in an 'if(n > 0)'.

This makes the relevant variables signed, which gets rid of the warnings.