### PR TITLE
Enable color prompt by default

### DIFF
--- a/lib/colorprompt.g
+++ b/lib/colorprompt.g
@@ -205,7 +205,7 @@ DeclareUserPreference( rec(
 run GAP such that the prompts, the input and output are distinguished \
 by colors. Options are 'true', 'false' or some record as explained in \
 the help section for 'ColorPrompt'." ],
-  default:= false,
+  default:= true,
   check:= val -> val in [ true, false ] or IsRecord( val ),
   ) );
 


### PR DESCRIPTION
I think a lot of people are missing out of this; and it should be safe for most. If this turns out to be wrong (as in: we get lots of complaints from people where it broke), we can still go back to the old default.

But perhaps I am missing other reasons that speak against it? @frankluebeck might have some suggestions.

Should IMHO be added to release notes because while being trivial and minor, it
has a very user visible effect, so people *will* notice, and may wonder.


## Text for release notes 


#### Enable colorized input prompts by default
GAP has supported colorized input prompts for a long time, but this feature was off by default. With this release, it is now on by default. Should you prefer the old behaviour, you can get it back by setting the `UseColorPrompt` user preference to false. For example, by entering these commands: `SetUserPreference( "UseColorPrompt", false ); WriteGapIniFile();`

