### PR TITLE
Enable SaveAndRestoreHistory by default

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -455,7 +455,7 @@ arbitrarily many lines.",
     "These preferences are ignored if GAP was not compiled with \
 readline support.",
     ],
-  default:= [1000, false],
+  default:= [10000, true],
   check:= function(max, save) 
     return ((IsInt( max ) and 0 <= max) or max = infinity) 
            and save in [true, false];


### PR DESCRIPTION
I think a lot of people are missing out of this; and it should be safe for most. If this turns out to be wrong (as in: we get lots of complaints from people where it broke), we can still go back to the old default.

But perhaps I am missing other reasons that speak against it? @frankluebeck might have some suggestions.

Should IMHO be added to release notes, and even to the "top tier" news, because while being trivial and minor, I think many people will benefit from this (so many people to whom I taught this option reacted like "whaaaat??? I wish I had known about this years ago).

I am also tempted to raise the default number of lines from 1000 to 10000...

## Text for release notes 

#### Save and restore input history by default

GAP has supported saving and restoring the interactive input history for a long time, but this feature was off by default. With this release, it is now on by default. That means that if you run GAP, enter some commands, then exit it, and start it again, you can reach the commands entered in the previous session by the usual means of accessing the command history, e.g. by pressing the up-arrow key. Should you prefer the old behaviour, you can get it back by setting the `SaveAndRestoreHistory ` user preference to false. For example, by entering these commands: `SetUserPreference( "SaveAndRestoreHistory", false ); WriteGapIniFile();`

In addition, the default limit on how many lines are preserved was increased from 1000 to 10000. This can be adjusted via the `HistoryMaxLines` user preference.
