### PR TITLE
Fix optimization of writing to string-based streams

### DIFF
--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -68,6 +68,23 @@ DeclareRepresentation(
 
 #############################################################################
 ##
+#R  IsOutputTextStringRep   (used in kernel)
+##
+##  <ManSection>
+##  <Filt Name="IsOutputTextStringRep" Arg='obj' Type='Representation'/>
+##
+##  <Description>
+##  </Description>
+##  </ManSection>
+##
+DeclareRepresentation(
+    "IsOutputTextStringRep",
+    IsPositionalObjectRep,
+    ["string", "format"] );
+
+
+#############################################################################
+##
 #C  IsClosedStream( <obj> ) . . . . . . . . . . .  category of closed streams
 ##
 ##  <#GAPDoc Label="IsClosedStream">

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -925,17 +925,6 @@ InstallMethod( SeekPositionStream,
 
 #############################################################################
 ##
-
-#R  IsOutputTextStringRep
-##
-DeclareRepresentation(
-    "IsOutputTextStringRep",
-    IsPositionalObjectRep,
-    ["string", "format"] );
-
-
-#############################################################################
-##
 #V  OutputTextStringType
 ##
 OutputTextStringType := NewType(

--- a/src/io.c
+++ b/src/io.c
@@ -1094,6 +1094,7 @@ static void PutLine2(TypOutputFile * output, const Char * line, UInt len)
     /* special handling of string streams, where we can copy directly */
     if (output->isstringstream) {
       str = CONST_ADDR_OBJ(output->stream)[1];
+      ConvString(str);
       lstr = GET_LEN_STRING(str);
       GROW_STRING(str, lstr+len);
       memcpy(CHARS_STRING(str) + lstr, line, len);

--- a/src/io.c
+++ b/src/io.c
@@ -49,7 +49,8 @@ static void PutLine2(TypOutputFile * output, const Char * line, UInt len);
 
 static Obj ReadLineFunc;
 static Obj WriteAllFunc;
-static Obj IsStringStream;
+static Obj IsInputStringStream;
+static Obj IsOutputStringStream;
 static Obj PrintPromptHook = 0;
 Obj EndLineHook = 0;
 static Obj PrintFormattingStatus;
@@ -407,7 +408,7 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
     input->prev = IO()->Input;
     input->isstream = TRUE;
     input->stream = stream;
-    input->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    input->isstringstream = (CALL_1ARGS(IsInputStringStream, stream) == True);
     if (input->isstringstream) {
         input->sline = CONST_ADDR_OBJ(stream)[2];
         input->spos = INT_INTOBJ(CONST_ADDR_OBJ(stream)[1]);
@@ -855,7 +856,7 @@ UInt OpenOutputStream(TypOutputFile * output, Obj stream)
     output->prev = IO()->Output;
     IO()->Output = output;
     output->isstream = TRUE;
-    output->isstringstream = (CALL_1ARGS(IsStringStream, stream) == True);
+    output->isstringstream = (CALL_1ARGS(IsOutputStringStream, stream) == True);
     output->stream = stream;
     output->line[0] = '\0';
     output->pos = 0;
@@ -1964,7 +1965,8 @@ static Int InitKernel (
     /* import functions from the library                                   */
     ImportFuncFromLibrary( "ReadLine", &ReadLineFunc );
     ImportFuncFromLibrary( "WriteAll", &WriteAllFunc );
-    ImportFuncFromLibrary( "IsInputTextStringRep", &IsStringStream );
+    ImportFuncFromLibrary( "IsInputTextStringRep", &IsInputStringStream );
+    ImportFuncFromLibrary( "IsOutputTextStringRep", &IsOutputStringStream );
     InitCopyGVar( "PrintPromptHook", &PrintPromptHook );
     InitCopyGVar( "EndLineHook", &EndLineHook );
     InitFopyGVar( "PrintFormattingStatus", &PrintFormattingStatus);


### PR DESCRIPTION
# Description

Just a little bug I noticed while trying to better understand how streams work.

The existing code failed to distinguish between IsOutputTextStringRep
and IsInputTextStringRep.

I don't know if there is a good way to test this (there are not many C tests in the test suite to begin with).  I confirmed in gdb that with this change writes to an OutputTextString stream go through the intended code path in [PutLine2](https://github.com/gap-system/gap/blob/7a57e8cf45b635423b48ad5864d1eaad45e76f51/src/io.c#L1088)


## Text for release notes 

Not sure if needed since it's not normally user-visible, but it's still a bug.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

