### PR TITLE
Don't freak out if a package has an empty or short Date

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -246,7 +246,7 @@ BindGlobal( "AddPackageInfos", function( files, pkgdir, ignore )
           # then we change it to dd/mm/yyyy. When other tools have adapted to
           # the yyyy-mm-dd format we can normalize to that format and at some
           # point in the future get rid of this code.
-          if record.Date{[5,8]} = "--" then
+          if Length(record.Date) = 10 and record.Date{[5,8]} = "--" then
             date := List( SplitString( record.Date, "-" ), Int);
             date := Permuted(date, (1,3)); # date = [dd,mm,yyyy]
             # generate the day and month strings


### PR DESCRIPTION
Fixes a regression from PR #3355.

I've had a package prototype sitting around with an empty Date field.
While of course the validator rejects that, the package loading code
should not, or at least should not run into a break loop.

No test case, but I think the problem and fix are obvious.