### PR TITLE
GH Actions: automate release tarball creation (WIP)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# This workflow takes care of creating release archives for the
+# GAP distribution. It is run for all PR and branch pushes as usual,
+# but also on tags named `vX.Y.Z` with X, Y, Z numbers.
+#
+# For builds triggered by a tag, the tag is turned into a GitHub release and
+# the produced archives are attached to that.
+name: release
+
+# Trigger the workflow on push or pull request
+on:
+  pull_request:
+  push:
+    tags: v[1-9]+.[0-9]+.[0-9]+
+    branches:
+      - master
+      - stable-*
+
+jobs:
+  release:
+    name: Release
+    # Don't run this twice on PRs for branches pushed to the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    env:
+      NO_COVERAGE: "1"
+      BOOTSTRAP_MINIMAL: "yes"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: "Set up Python"
+        uses: actions/setup-python@v2
+      - name: "Install Python modules"
+        run: pip3 install PyGithub requests python-dateutil
+      - name: "Install latex"
+        run: sudo apt-get install texlive texlive-latex-extra texlive-extra-utils texlive-fonts-extra
+      - name: "Compile GAP and download packages"
+        run: bash dev/ci-prepare.sh
+      - name: "Make archives"
+        run: python -u ./dev/releases/make_archives.py
+      - name: "Make GitHub release"
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        # TODO: we should check whether the tag triggering the release
+        # has the right name
+        run: python -u ./dev/releases/make_github_release.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: "Check tags"
+        run: git tag -n
+      - name: "Show head"
+        run: git show -s --pretty=fuller
       - name: "Set up Python"
         uses: actions/setup-python@v2
       - name: "Install Python modules"

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -30,7 +30,7 @@ verify_git_repo()
 verify_git_clean()
 
 # fetch tags, so we can properly detect
-safe_git_fetch_tags()
+#safe_git_fetch_tags()  # FIXME: disabled as it causes issues in GH Actions
 
 # Creating tmp directory
 tmpdir = os.getcwd() + "/tmp"

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -14,6 +14,7 @@
 import utils
 import github
 import os
+import re
 
 # Identify GAP release version
 try:
@@ -22,6 +23,9 @@ except:
     utils.error("Could not get GAP version")
 
 utils.notice(f"Detected GAP version {GAPVERSION}")
+if re.fullmatch( r"[1-9]+\.[0-9]+\.[0-9]+", gapversion) == None:
+    utils.error("This does not look a release version")
+
 
 utils.initialize_github()
 


### PR DESCRIPTION
This is based on work by @FriedrichRober and @ssiccha . Still needs some refinement.

For now the CI job added here will only run in my repo, so you can see the state here: https://github.com/fingolfin/gap/actions/

For a run with a tag, see here https://github.com/fingolfin/gap/actions/runs/594082465 and check the list of releases for the result: https://github.com/fingolfin/gap/releases  -- so this immediately shows a bug: the tag which triggered the CI job was named v6.7.8, but the script ended up creating and populating a v4.12dev tag. Reason: the v6.7.8 tag, created via the GitHub web interface, is not an annotated tag... 

Some possible TODOs (all up for debate, though):

- [ ] if the tag triggering the CI action does not match the version in GAP, perhaps abort?
  - [ ] to facilitate this, the tag name detected by the action could be passed as an (optional!) argument to the `make_github_release.py` script
- [ ] the `make_github_release.py` should perhaps only accept tags matching the pattern `vX.Y.Z` with X,Y,Z all numbers, and thus reject `v4.12dev` (
- [ ] the artifact uploading right now uploads all .zip and .tar.gz as a single artifact... so as a single file... that's not at all what we want. we can resolve this by duplicating the `actions/upload-artifact@v2` multiple times (using some regex to avoid having to deal with GAP version numbers), but right now there are 11 archives, so we would need 11 such steps (twice as many if you also want the .sha256 files). So this is cumbersome. Also, `upload-artifact` [always zips all artifacts](https://github.com/actions/upload-artifact#zipped-artifact-downloads), even those which are already zips. Looking at the [API docs](https://docs.github.com/en/rest/reference/actions#artifacts) I suspect this is even a limitation of the GitHub Actions artifacts system -- so perhaps we should drop the idea of using these "artifacts". But in that case, we'd need another place to upload nightlies -- e.g. a fixed tag `nightlies` (but then we also must make sure to clear out obsolete tarballs from time to time -- or just always delete all before uploading new ones; which is a bit of a pity, as being able to download a bunch of nightly builds to find the one where a regression was introduced can be powerful... OTOH as long as we don't provide any binaries, one can just do that with `git bisect`...) aaaaanyway, what I really care about for now is doing an actual *release*, making nightly builds available is "just" a bonus