### PR TITLE
Further work on dev/releases/update_website.py (and related changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 /src/config.h.in
 /src/config.h.in~
 
-/__pycache__/
+**/__pycache__/
 
 /build/
 /extern/build/

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -31,7 +31,7 @@ if utils.check_whether_github_release_exists("v"+GAPVERSION):
 
 # Create release
 CURRENT_BRANCH = utils.get_makefile_var("PKG_BRANCH")
-RELEASE_NOTE = f"For an overview of changes in GAP {GAPVERSION} see" \
+RELEASE_NOTE = f"For an overview of changes in GAP {GAPVERSION} see the " \
     + "[CHANGES.md](https://github.com/gap-system/gap/blob/master/CHANGES.md) file."
 utils.notice(f"Creating release v{GAPVERSION}")
 RELEASE = utils.CURRENT_REPO.create_git_release("v"+GAPVERSION, "v"+GAPVERSION,

--- a/dev/releases/update_website.py
+++ b/dev/releases/update_website.py
@@ -407,7 +407,7 @@ except:
 try:
     verify_git_clean()
 except:
-    error("")
+    error("files have changed that we didn't expect (check git status)")
 
 try:
     # TODO push with token!
@@ -422,8 +422,6 @@ except:
 
 notice("TODO: create pull request")
 
-# TODO Delete the temporary gap directory and log files, when we are finished with it
-# The above todo is not needed, users are warned in ReleaseREADME that tmp folders were created and need to be removed manually if required.
 # TODO Download all package tarballs, and compute their sizes and sha256 checksums
 # TODO sftp tarballs from GitHub release system to gap-system.org
 # TODO sftp package manuals

--- a/dev/releases/utils.py
+++ b/dev/releases/utils.py
@@ -158,10 +158,17 @@ def check_whether_github_release_exists(tag):
 def initialize_github(token=None):
     global GITHUB_INSTANCE, CURRENT_REPO
     if GITHUB_INSTANCE != None or CURRENT_REPO != None:
-        error("Global variables GITHUB_INSTANCE and CURRENT_REPO "
+        error("Global variables GITHUB_INSTANCE and CURRENT_REPO"
               + " are already initialized.")
     if token == None and "GITHUB_TOKEN" in os.environ:
         token = os.environ["GITHUB_TOKEN"]
+    if token == None:
+        temp = subprocess.run(["git", "config", "--get", "github.token"], text=True, capture_output=True)
+        if temp.returncode == 0:
+            token = temp.stdout.strip()
+    if token == None and os.path.isfile(os.path.expanduser('~') + '/.github_shell_token'):
+        with open(os.path.expanduser('~') + '/.github_shell_token', 'r') as token_file:
+            token = token_file.read().strip()
     if token == None:
         error("Error: no access token found or provided")
     g = github.Github(token)

--- a/dev/releases/utils.py
+++ b/dev/releases/utils.py
@@ -40,11 +40,14 @@ def verify_git_repo():
         error("current directory is not a git root directory")
 
 # check for uncommitted changes
-def verify_git_clean():
+def is_git_clean():
     res = subprocess.run(["git", "update-index", "--refresh"])
     if res.returncode == 0:
         res = subprocess.run(["git", "diff-index", "--quiet", "HEAD", "--"])
-    if res.returncode != 0:
+    return res.returncode == 0
+
+def verify_git_clean():
+    if not is_git_clean():
         error("uncommitted changes detected")
 
 # from https://code.activestate.com/recipes/576620-changedirectory-context-manager/


### PR DESCRIPTION
I've spent some time this evening doing working on the release scripts, especially the `update_website.py` script. I've also made a few tweaks to the `utils.py` scratch.

The main changes in this PR:

* Use PyGithub to access the information about GAP releases
* Use the release date defined in `configure.ac` of the GAP release tarball
* Most of the diffs are because I've standardised on double quotes for strings, rather than single quotes. (Sorry to any potential reviewers).

I'm aware that we'd like to release GAP 4.11.1 this week (or ASAP afterwards). I also realise that there are significant changes that we want to make to the way that the GAP website works and is updated. So hopefully the script we use fo GAP 4.12.0 will be quite different.

I'll only push things here that leave the `update_website.py` script in a working state. So it can be merged whenever, from my point of view, and still be usable for the GAP 4.11.1 release. I might have time to work on this further this week, but I might not.

The main missing bits of important functionality:
* Pushing the new branch with proper GitHub token-based authentication. (Currently, just `git push <remote> <branch>` is run.)
* Creating a PR to gap-system/GapWWW. (Currently, this has to be done manually.)