### PR TITLE
buildsys: change bootstrap targets to fetch from GitHub

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1135,7 +1135,7 @@ testkernel: ${KERNELTESTS}
 
 # change PKG_BRANCH to stable-X.Y in the stable branch
 PKG_BRANCH = master
-PKG_BOOTSTRAP_URL = https://files.gap-system.org/gap4pkgs/
+PKG_BOOTSTRAP_URL = https://github.com/gap-system/gap-distribution/releases/download/package-archives/
 PKG_MINIMAL = packages-required-$(PKG_BRANCH).tar.gz
 PKG_FULL = packages-$(PKG_BRANCH).tar.gz
 DOWNLOAD = $(abs_srcdir)/cnf/download.sh


### PR DESCRIPTION
This should be more reliable than the GAP website; and perhaps
is also more efficient for GitHub actions.
