### PR TITLE
Enable wider compatibility for `bin/BuildPackages.sh --parallel`

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -308,9 +308,10 @@ do
   fi
   ) &
   if [ "x$PARALLEL" = "xyes" ]; then
-    # If more than 4 background jobs are running, wait for one to finish
+    # If more than 4 background jobs are running, wait for one to finish (if
+    # <wait -n> is available) or for all to finish (if only <wait> is available)
     if [[ $(jobs -r -p | wc -l) -gt 4 ]]; then
-        wait -n
+        wait -n 2>&1 >/dev/null || wait
     fi
   else
     # wait for this package to finish building


### PR DESCRIPTION
# Description

This implements @ChrisJefferson's suggestion to my solution reported in #4289; see there for that discussion. Closes #4289.

## Further details

Currently `bin/BuildPackages.sh --parallel` fails on my computer. This is because my version of `bash`/`wait` is too old (older than `bash 4.3`), which means that the `wait -n` command currently on line 313 fails. The script now uses `wait` (without `-n`) if `wait -n` gives an error. This results in less parallelisation (four jobs are spawned, but no further jobs are spawned until all four are finished) but for me it's still nearly twice as fast as having no parallelisation.

It would be nice if someone could verify that this still gives the expected (3-4x) speedup on a system that supports `wait -n`.

Since the `--parallel` option to `bin/BuildPackages.sh` will be a new feature in GAP 4.11.1 (at least according to #4256), I think this should be backported so that this wider compatibility is available from the start.

# Checklist for pull request reviewers

- [ ] proper formatting

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

