### PR TITLE
WIP: Trivial `SubmagmaWithOneNC` has generators set to a list containing the trivial element

### DIFF
--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -475,7 +475,7 @@ InstallGlobalFunction( SubmagmaWithOneNC, function( M, gens )
                    and IsTrivial
                    and IsAttributeStoringRep );
       S:= Objectify( K, rec() );
-      SetGeneratorsOfMagmaWithInverses( S, [] );
+      SetGeneratorsOfMagmaWithInverses( S, [One(M)] );
       SetSize( S, 1 );
 #T should be unnecessary since `IsTrivial' implies a good `Size' method
     else


### PR DESCRIPTION
# Description

The group returned by `TrivialSubgroup` had its generators set to an empty list. This is a problem for algorithms that want to access the generators of a group. Therefore I suggest to change the generators to be a list containing the trivial element in this case.

Old Behaviour:
```
gap> grp := TrivialSubgroup(Group((1,2,3,4),(1,2)));
Group(())
gap> GeneratorsOfGroup(grp);
[  ]
gap> GeneratorsOfGroup(Group(()));
[ () ]
```

## Text for release notes 

Calling `SubmagmaWithOneNC` with an empty list returns a group with generators set to a list containing the trivial element.

## Further details

This issue was brought up by @DominikBernhardt in one of my repositories. FriedrichRober/WreathProductElements#14

# Checklist for pull request reviewers

- [ ] proper formatting
- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

