### PR TITLE
Tweak package-infos.json format

### DIFF
--- a/dev/releases/PackageInfos-to-JSON.g
+++ b/dev/releases/PackageInfos-to-JSON.g
@@ -7,5 +7,13 @@ function(o, x)
 end);
 
 out := OutputTextUser();
-GapToJsonStream(out, GAPInfo.PackagesInfo);;
+r := rec();
+for n in RecNames(GAPInfo.PackagesInfo) do
+  x := GAPInfo.PackagesInfo.(n);
+  Assert(0, Length(x) = 1);
+  x := x[1];
+  Unbind(x.InstallationPath);
+  r.(n) := x;
+od;
+GapToJsonStream(out, r);;
 QUIT;


### PR DESCRIPTION
- at the top level, instead of outputting lists with a single package info
  record, just output that record
- remove the InstallationPath from the package info record to avoid exporting
  paths specific to the machine on which the scripts were run
