### PR TITLE
Add OpenExternal, a function for opening files in the OS

### DIFF
--- a/doc/ref/streams.xml
+++ b/doc/ref/streams.xml
@@ -298,6 +298,19 @@ separation character (usually a comma).
 <#Include Label="PrintCSV">
 
 </Section>
+
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="Opening files in the Operating System">
+<Heading>Opening files in the Operating System</Heading>
+
+In some situations it can be desirable to open a file outside of &GAP;,
+for example HTML files, PDFs, or pictures.
+
+<#Include Label="OpenExternal">
+
+</Section>
+
+
 </Chapter>
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->

--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -1232,3 +1232,21 @@ DeclareGlobalFunction( "UnInstallCharReadHookFunc" );
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "InputFromUser" );
+
+#############################################################################
+##
+#F  OpenExternal( <filename> )
+##
+##  <#GAPDoc Label="OpenExternal">
+##  <ManSection>
+##  <Func Name="OpenExternal" Arg='filename'/>
+##
+##  <Description>
+##  Open the file <A>filename</A> using the default application for this file
+##  in the operating system. This can be used to open files like HTML and PDF
+##  files in the GUI.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "OpenExternal" );

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1388,6 +1388,29 @@ InstallGlobalFunction( InputFromUser,
   end );
 
 
+#############################################################################
+##
+#M  OpenExternal(filename)  . . . . . . . . . . . . open file in external GUI
+##
+InstallGlobalFunction( OpenExternal, function(filename)
+    local file;
+    if ARCH_IS_MAC_OS_X() then
+      Exec(Concatenation("open \"",filename,"\""));
+    elif ARCH_IS_WINDOWS() then
+      Exec(Concatenation("cmd /c start \"",filename,"\""));
+    elif ARCH_IS_WSL() then
+      # If users pass a URL, make sure if does not get mangled.
+      if ForAny(["https://", "http://"], {pre} -> StartsWith(filename, pre)) then
+        file := filename;
+      else
+        file := Concatenation("$(wslpath -a -w \"",filename,"\")");
+      fi;
+      Exec(Concatenation("explorer.exe \"", file, "\""));
+    else
+      Exec(Concatenation("xdg-open \"",filename,"\""));
+    fi;
+end );
+
 
 #############################################################################
 ##


### PR DESCRIPTION
Add a function "OpenExternal", which opens files in other apps in the file system. While I like the names used by existing packages (like Splash), I also don't want to clash with those existing packages.

Rather than base this on the existing code used for help, I wrote a new function. This does remove the customizability, but also means we can open any file type. Also, in my experience, nowadays the "default" operating system method of opening files is what I want.

This also does not implement the functionality provided by (for example) semigroups, where files such as '.dot' and '.tex' files are compiled before being opened.

I'm very happy for suggestions on naming / functionality / etc. I thought having a PR would give a place to discuss such issues.

Discussed in #4272