### PR TITLE
Allow function-call syntax for evaluating univariate polynomials

### DIFF
--- a/hpcgap/lib/ratfun.gi
+++ b/hpcgap/lib/ratfun.gi
@@ -1358,6 +1358,20 @@ end);
 
 #############################################################################
 ##
+#M  <upol>(<val>)
+##
+##  Method to allow univariate polynomials to be used like functions when 
+##  appropriate
+InstallMethod(CallFuncList, [IsUnivariatePolynomial, IsList], 
+  function(poly, lst) 
+    if Length(lst) <> 1 then 
+        TryNextMethod(); 
+    fi; 
+    return Value(poly, lst[1]); 
+end);
+
+#############################################################################
+##
 #M  Value
 ##                               
 InstallOtherMethod(Value,"rat.fun., with one",

--- a/lib/ratfun.gd
+++ b/lib/ratfun.gd
@@ -1077,6 +1077,8 @@ DeclareOperation( "UnivariateRationalFunctionByCoefficients",
 ##  The second version takes an univariate rational function and specializes
 ##  the value of its indeterminate to <A>val</A>.
 ##  Again, an optional argument <A>one</A> may be given.
+##  <C>Value( <A>upol</A>, <A>val</A> )</C> can also be expressed as <C>upol( 
+##  <A>val</A> )</C>.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Value(x*y+y+x^7,[x,y],[5,7]);

--- a/lib/ratfun.gi
+++ b/lib/ratfun.gi
@@ -1352,6 +1352,20 @@ end);
 
 #############################################################################
 ##
+#M  <upol>(<val>)
+##
+##  Method to allow univariate polynomials to be used like functions when 
+##  appropriate
+InstallMethod(CallFuncList, [IsUnivariatePolynomial, IsList], 
+  function(poly, lst) 
+    if Length(lst) <> 1 then 
+        TryNextMethod(); 
+    fi; 
+    return Value(poly, lst[1]); 
+end);
+
+#############################################################################
+##
 #M  Value
 ##                               
 InstallOtherMethod(Value,"rat.fun., with one",

--- a/tst/testinstall/ratfun.tst
+++ b/tst/testinstall/ratfun.tst
@@ -86,6 +86,16 @@ gap> Value(t,-1);
 -1
 
 #
+gap> t(0);
+0
+gap> t(1);
+1
+gap> (t+1)(3);
+4
+gap> data[4](3);
+4
+
+#
 gap> y1:=Indeterminate(Rationals,1);;
 gap> y2:=Indeterminate(Rationals,2);;
 gap> y3:=Indeterminate(Rationals,3);;

--- a/tst/testinstall/ratfun_gf5.tst
+++ b/tst/testinstall/ratfun_gf5.tst
@@ -72,6 +72,18 @@ gap> Value(t,-1);
 Z(5)^2
 
 #
+gap> data[1](0);
+0
+gap> 0*t(1);
+0*Z(5)
+gap> (0*t)(1);
+0
+gap> data[4](3);
+Z(5)^2
+gap> (t+Z(5)^0)(3);
+Z(5)^2
+
+#
 gap> y1:=Indeterminate(Rationals,1);;
 gap> y2:=Indeterminate(Rationals,2);;
 gap> y3:=Indeterminate(Rationals,3);;


### PR DESCRIPTION

# Description

This PR implements #4283 similarly to #3901. Specifically for a univariate polynomial `p` the call `p( x )` is treated as `Value(p,x)`.

# Checklist for pull request reviewers

- [x] proper formatting
- [x] usage of relevant labels
- [x] runnable tests
- [x] lines changed in commits are sufficiently covered by the tests
- [x] adequate pull request title
- [x] well formulated text for release notes
- [x] relevant documentation updates
- [x] sensible comments in the code

