### PR TITLE
Add GitHub Action for automatic release generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+# This workflow takes care of creating release archives for the
+# GAP distribution. It is run for all PR and branch pushes as usual,
+# but also on tags named `vX.Y.Z` with X, Y, Z numbers.
+#
+# For builds triggered by a tag, the tag is turned into a GitHub release and
+# the produced archives are attached to that.
+name: release
+
+# Trigger the workflow on push or pull request
+on:
+  pull_request:
+  push:
+    tags: v[1-9]+.[0-9]+.[0-9]+
+    branches:
+      - master
+      - stable-*
+
+jobs:
+  release:
+    name: Release
+    # Don't run this twice on PRs for branches pushed to the same repository
+    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    env:
+      NO_COVERAGE: "1"
+      BOOTSTRAP_MINIMAL: "yes"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # when an annotated tag is pushed, then for some reason we don't see it
+      # in this action; instead an unannotated tag with the same is present;
+      # resolve this by force-fetching tags
+      - name: "Force fetch tags"
+        run: git fetch --tags --force
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v2
+      - name: "Install Python modules"
+        run: pip3 install PyGithub requests python-dateutil
+      - name: "Install latex"
+        run: sudo apt-get install texlive texlive-latex-extra texlive-extra-utils texlive-fonts-extra
+      - name: "Compile GAP and download packages"
+        run: bash dev/ci-prepare.sh
+      - name: "Make archives"
+        run: python -u ./dev/releases/make_archives.py
+      - name: "Make GitHub release"
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        # TODO: we should check whether the tag triggering the release
+        # has the right name
+        run: python -u ./dev/releases/make_github_release.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Supersedes PR #4282

Hopefully it works now...
- [Test run without a tag (so for a "nightly release")](https://github.com/gap-system/gap/runs/2000467047?check_suite_focus=true)
- [Test run with a tag](https://github.com/fingolfin/gap/runs/2000466729?check_suite_focus=true)

Note that the tests are of course on the master branch. not stable-4.11, so even if the tag build succeeds, we need some more testing based on the `stable-4.11` branch. In principle it should work there (esp. now that I backported most of the new stuff), but the devil is in the details...