### PR TITLE
Upload some artifacts for "nightly releases"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           path: |
             tmp/gap-*.tar.gz*
             tmp/*json*
+            !tmp/gap-*-core.tar.gz*
 
       - name: "Make GitHub release"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: python -u ./dev/releases/make_archives.py
 
       - name: "Upload artifacts"
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') && failure() }}
         # Warning: the result is a single .zip file (so things are compressed twice)
         # To keep things from exploding, we only upload a subset of all generated files
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,17 @@ jobs:
         run: bash dev/ci-prepare.sh
       - name: "Make archives"
         run: python -u ./dev/releases/make_archives.py
+
+      - name: "Upload artifacts"
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        # Warning: the result is a single .zip file (so things are compressed twice)
+        # To keep things from exploding, we only upload a subset of all generated files
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            tmp/gap-*.tar.gz*
+            tmp/*json*
+
       - name: "Make GitHub release"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         # TODO: we should check whether the tag triggering the release


### PR DESCRIPTION
... so that we can use them for further build steps / review them
for debugging.

Not sure if I even got the syntax right. Perhaps @ssiccha or @FriedrichRober can help finishing this.

Also, right now this mixes a bunch of things together (gap-X.Y.Z.tar.gz, gap-X.Y.Z-core.tar.gz, package-info.json, and their sha256 files) -- perhaps better to upload them as multiple separate artifacts