### PR TITLE
Small performance additions and functionality improvements

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -4115,12 +4115,9 @@ DeclareOperation( "CharacterTableIsoclinic",
 ##  gap> Length( index2 );
 ##  2
 ##  gap> tg:= CharacterTable( g );;
-##  gap> IsRecord(
-##  >        TransformingPermutationsCharacterTables( index2[1], tg ) );
-##  true
-##  gap> IsRecord(
-##  >        TransformingPermutationsCharacterTables( index2[2], tg ) );
-##  false
+##  gap> SortedList(List(index2,x->IsRecord(
+##  >       TransformingPermutationsCharacterTables(x,tg))));
+##  [ true, false ]
 ##  ]]></Example>
 ##  <P/>
 ##  Alternatively, we could construct the character table of the central
@@ -4610,11 +4607,11 @@ DeclareGlobalFunction( "NormalSubgroupClasses" );
 ##    Character( CharacterTable( S4 ), [ 1, 1, 1, 1, 1 ] ) ]
 ##  gap> kernel:= KernelOfCharacter( irr[3] );
 ##  Group([ (1,2)(3,4), (1,3)(2,4) ])
+##  gap> SetName(kernel,"V4");
 ##  gap> HasNormalSubgroupClassesInfo( tbl );
 ##  true
 ##  gap> NormalSubgroupClassesInfo( tbl );
-##  rec( nsg := [ Group([ (1,2)(3,4), (1,3)(2,4) ]) ],
-##    nsgclasses := [ [ 1, 3 ] ], nsgfactors := [  ] )
+##  rec( nsg := [ V4 ], nsgclasses := [ [ 1, 3 ] ], nsgfactors := [  ] )
 ##  gap> ClassPositionsOfNormalSubgroup( tbl, kernel );
 ##  [ 1, 3 ]
 ##  gap> G := FactorGroupNormalSubgroupClasses( tbl, [ 1, 3 ] );;

--- a/lib/factgrp.gd
+++ b/lib/factgrp.gd
@@ -131,12 +131,19 @@ DeclareAttribute("NaturalHomomorphismsPool",IsGroup,
 ##  <#GAPDoc Label="FactorCosetAction">
 ##  <ManSection>
 ##  <Oper Name="FactorCosetAction" Arg='G, U[, N]'/>
+##  <Oper Name="FactorCosetAction" Arg='G, L'/>
 ##
 ##  <Description>
 ##  This command computes the action of the group <A>G</A> on the
 ##  right cosets of the subgroup <A>U</A>.
 ##  If a normal subgroup <A>N</A> of <A>G</A> is given,
 ##  it is stored as kernel of this action.
+##  When calling <C>FactorCosetAction</C> with a list of subgroups as the
+##  second argument, an action with image isomorphic to the subdirect
+##  product of the coset actions of all subgroups is computed. (However a
+##  degree reduction may take place if some of the actions are redundant, i.e.
+##  there is no guarantee that every subgroup in the list is represented by an
+##  orbit.)
 ##  <Example><![CDATA[
 ##  gap> g:=Group((1,2,3,4,5),(1,2));;u:=SylowSubgroup(g,2);;Index(g,u);
 ##  15
@@ -144,6 +151,9 @@ DeclareAttribute("NaturalHomomorphismsPool",IsGroup,
 ##  <action epimorphism>
 ##  gap> StructureDescription(Range(last));
 ##  "S5"
+##  gap> FactorCosetAction(g,[u,SylowSubgroup(g,3)]);;
+##  gap> Size(Image(last));
+##  120
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -809,6 +809,9 @@ totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i;
 	  # interupt if we're already quite good
 	  interupt:=true;
 	fi;
+	if ForAny(badcores,x->IsSubset(nu,x)) then
+          nu:=u;
+        fi;
 	# Abbruchkriterium: Bis kein Normalteiler, es sei denn, es ist N selber
 	# (das brauchen wir, um in einigen trivialen F"allen abbrechen zu
 	# k"onnen)
@@ -816,10 +819,10 @@ totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i;
       until 
         
         # der Index ist nicht so klein, da"s wir keine Chance haben
-	not ForAny(badcores,x->IsSubset(nu,x)) and (((not bigperm or
+	((not bigperm or
 	Length(Orbit(nu,MovedPoints(G)[1]))<NrMovedPoints(G)) and 
 	(IndexNC(G,nu)>50 or Factorial(IndexNC(G,nu))>=IndexNC(G,N)) and
-	not IsNormal(G,nu)) or IsSubset(u,nu) or interupt);
+	not IsNormal(G,nu)) or IsSubset(u,nu) or interupt;
 
       Info(InfoFactor,4,"Index ",IndexNC(G,nu));
       u:=nu;

--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -532,6 +532,27 @@ local hom;
   return hom*DoFactorCosetAction(Image(hom,G),Image(hom,U),Image(hom,N));
 end);
 
+# action on lists of subgroups
+InstallOtherMethod(FactorCosetAction,
+  "On cosets of list of groups",IsElmsColls,
+  [IsGroup,IsList],0,
+function(G,L)
+local q,i,gens,imgs,d;
+  if Length(L)=0 or not ForAll(L,x->IsGroup(x) and IsSubset(G,x)) then
+    TryNextMethod();
+  fi;
+  q:=List(L,x->FactorCosetAction(G,x));
+  gens:=MappingGeneratorsImages(q[1])[1];
+  imgs:=List(q,x->List(gens,y->ImagesRepresentative(x,y)));
+  d:=imgs[1];
+  for i in [2..Length(imgs)] do
+    d:=SubdirectDiagonalPerms(d,imgs[i]);
+  od;
+  imgs:=Group(d);
+  q:=GroupHomomorphismByImagesNC(G,imgs,gens,d);
+  return q;
+end);
+
 
 #############################################################################
 ##

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1365,18 +1365,45 @@ local pcgs,iso,fp,i,j,gens,numi,ord,fm,fam,mword,k,r,addrule,a,e,m;
 end);
 
 
-BindGlobal("WeylGroupFp",function(ser,n)
-local f,rels,i,j,gens;
+# ser is a string indicating the series (A, B, C, D, E, F), n is a number. If argument `false` is added, only braid
+# relations
+BindGlobal("WeylGroupFp",function(ser,n,docox...)
+local f,rels,i,j,gens,coxrel;
+  coxrel:=function(a,b,n)
+  local m,f,g;
+    if n=2 then Add(rels,Comm(a,b));
+    else
+      if docox then 
+        # coxeter: no negative exponents
+        Add(rels,(a*b)^n); 
+      else 
+        # braid: bababa...  = ababab...
+        m:=QuoInt(n+1,2);
+        f:=Subword((b*a)^m,1,n);
+        g:=Subword((a*b)^m,1,n);
+        Add(rels,f/g);
+      fi;
+    fi;
+  end;
   f:=FreeGroup(List([1..n],x->Concatenation("s",String(x))));
   gens:=GeneratorsOfGroup(f);
-  rels:=List(gens,x->x^2);
+  if Length(docox)=0 then
+    docox:=true;
+  else
+    docox:=docox[1]=true;
+  fi;
+  if docox then
+    rels:=List(gens,x->x^2);
+  else
+    rels:=[];
+  fi;
   if ser="A" then
     for i in [1..n] do
       for j in [1..i-1] do
         if i-j>1 then
-          Add(rels,(gens[i]*gens[j])^2);
+          coxrel(gens[j],gens[i],2);
         else
-          Add(rels,(gens[i]*gens[j])^3);
+          coxrel(gens[j],gens[i],3);
         fi;
       od;
     od;
@@ -1384,68 +1411,68 @@ local f,rels,i,j,gens;
     for i in [1..n] do
       for j in [1..i-1] do
         if i-j>1 then
-          Add(rels,(gens[i]*gens[j])^2);
+          coxrel(gens[j],gens[i],2);
         elif j=1 then
-          Add(rels,(gens[i]*gens[j])^4);
+          coxrel(gens[j],gens[i],4);
         else
-          Add(rels,(gens[i]*gens[j])^3);
+          coxrel(gens[j],gens[i],3);
         fi;
       od;
     od;
   elif ser="D" and n>=4 then
-    Add(rels,(gens[1]*gens[2])^2);
-    Add(rels,(gens[1]*gens[3])^3);
-    Add(rels,(gens[2]*gens[3])^3);
+    coxrel(gens[1],gens[2],2);
+    coxrel(gens[1],gens[3],3);
+    coxrel(gens[2],gens[3],3);
     for i in [4..n] do
       for j in [1..i-1] do
         if i-j>1 then
-          Add(rels,(gens[i]*gens[j])^2);
+          coxrel(gens[j],gens[i],2);
         else
-          Add(rels,(gens[i]*gens[j])^3);
+          coxrel(gens[j],gens[i],3);
         fi;
       od;
     od;
   elif ser="E" then
-    Add(rels,(gens[1]*gens[2])^3);
-    Add(rels,(gens[2]*gens[3])^3);
-    Add(rels,(gens[3]*gens[4])^3);
-    Add(rels,(gens[3]*gens[5])^3);
-    Add(rels,(gens[5]*gens[6])^3);
+    coxrel(gens[1],gens[2],3);
+    coxrel(gens[2],gens[3],3);
+    coxrel(gens[3],gens[4],3);
+    coxrel(gens[3],gens[5],3);
+    coxrel(gens[5],gens[6],3);
 
-    Add(rels,(gens[1]*gens[3])^2);
-    Add(rels,(gens[1]*gens[4])^2);
-    Add(rels,(gens[2]*gens[4])^2);
-    Add(rels,(gens[1]*gens[5])^2);
-    Add(rels,(gens[2]*gens[5])^2);
-    Add(rels,(gens[4]*gens[5])^2);
-    Add(rels,(gens[1]*gens[6])^2);
-    Add(rels,(gens[2]*gens[6])^2);
-    Add(rels,(gens[3]*gens[6])^2);
-    Add(rels,(gens[4]*gens[6])^2);
+    coxrel(gens[1],gens[3],2);
+    coxrel(gens[1],gens[4],2);
+    coxrel(gens[2],gens[4],2);
+    coxrel(gens[1],gens[5],2);
+    coxrel(gens[2],gens[5],2);
+    coxrel(gens[4],gens[5],2);
+    coxrel(gens[1],gens[6],2);
+    coxrel(gens[2],gens[6],2);
+    coxrel(gens[3],gens[6],2);
+    coxrel(gens[4],gens[6],2);
     if n>=7 then
-      Add(rels,(gens[6]*gens[7])^3);
+      coxrel(gens[6],gens[7],3);
       for i in [1..5] do
-        Add(rels,(gens[i]*gens[7])^2);
+        coxrel(gens[i],gens[7],2);
       od;
     fi;
     if n=8 then
-      Add(rels,(gens[7]*gens[8])^3);
+      coxrel(gens[7],gens[8],3);
       for i in [1..6] do
-        Add(rels,(gens[i]*gens[7])^2);
+        coxrel(gens[i],gens[7],2);
       od;
     elif n>8 then 
       Error("E>8 does not exist");
     fi;
   elif ser="F" and n=4 then
-    Add(rels,(gens[1]*gens[2])^3);
-    Add(rels,(gens[2]*gens[3])^4);
-    Add(rels,(gens[3]*gens[4])^3);
+    coxrel(gens[1],gens[2],3);
+    coxrel(gens[2],gens[3],4);
+    coxrel(gens[3],gens[4],3);
 
-    Add(rels,(gens[1]*gens[3])^2);
-    Add(rels,(gens[1]*gens[4])^2);
-    Add(rels,(gens[2]*gens[4])^2);
+    coxrel(gens[1],gens[3],2);
+    coxrel(gens[1],gens[4],2);
+    coxrel(gens[2],gens[4],2);
   elif ser="G" and n=2 then
-    Add(rels,(gens[1]*gens[2])^6);
+    coxrel(gens[1],gens[2],6);
   else
     Error("series ",ser," not yet done");
   fi;

--- a/lib/grppcext.gi
+++ b/lib/grppcext.gi
@@ -529,6 +529,18 @@ local G, M, Mgrp, oper, A, B, D, translate, gens, genimgs, triso, K, K1,
         return false;
       end;
       K:=SubgroupProperty(Image(triso),test);
+
+      # remove redundant generators
+      B:=[1..Length(GeneratorsOfGroup(K))];
+      for i in [1..Length(GeneratorsOfGroup(K))] do
+        if Size(K)
+          =Size(SubgroupNC(K,GeneratorsOfGroup(K){Difference(B,[i])})) then
+          B:=Difference(B,[i]);
+        fi;
+      od;
+      K:=Group(GeneratorsOfGroup(K){B});
+      pool:=pool{B};
+
       B:=MTX.ModuleAutomorphisms(M);
       if Size(B)>1 then
         for i in Set(GeneratorsOfGroup(B)) do


### PR DESCRIPTION
Small additions/improvements that improve the user experience, but probably are not worth mentioning explicitly:
- FactorCosetAction now allows for computing intransitive action on sets of subgroups
- Intersection of subgroups of fp groups is faster by avoiding overly eager/costly degree reductions
- Stabilizer (through orbit/stabilizer algorithm uses cyclic factor groups if possible (as done for pc groups), this can give significant speedup or less memory use when computing with more complicated actions (such as action on subspaces).
- CompatiblePairs are given on fewer generators
- WeylGroupFp can be also used to get Braid group presentations