### PR TITLE
FIX: Outer automorphisms of certain Chevalley groups.

### DIFF
--- a/tst/testbugfix/2006-08-28-t00151.tst
+++ b/tst/testbugfix/2006-08-28-t00151.tst
@@ -1,12 +1,12 @@
 # 2006/08/28 (FL)
 gap> time1 := 0;;
-gap> for j in [1..10] do
+gap> for j in [1..20] do
 > l:=List([1..100000],i->[i]);
 > t1:=Runtime(); for i in [1..100000] do a := PositionSorted(l,[i]); od; t2:=Runtime();
 > time1 := time1 + (t2-t1);
 > od;
 gap> time2 := 0;;
-gap> for j in [1..10] do
+gap> for j in [1..20] do
 > l := Immutable( List([1..100000],i->[i]) );
 > t1:=Runtime(); for i in [1..100000] do a := PositionSorted(l,[i]); od; t2:=Runtime();
 > time2 := time2 + (t2-t1);

--- a/tst/testbugfix/2021-03-15-chevallaut.tst
+++ b/tst/testbugfix/2021-03-15-chevallaut.tst
@@ -1,0 +1,6 @@
+# Outer automorphisms Chevalley groups miscomputed with triality, #4318
+gap> G := PrimitiveGroup(119, 1);;
+gap> S := SymmetricGroup(119);;
+gap> N := Normalizer(S, G);;
+gap> Index(N, G);
+2


### PR DESCRIPTION
Instead of tables in ATLAS (that had been misinterpreted), use the
explict presentations in Bray/Holt/Roney-Dougal.

This can lead to wrong results when calculating normalizers in S_n.

The groups affected are of type O_n-(q), n>=8 even
(and to a lesser extent -- wrong outer automorphism group structure, but that is not used in other places for deductions -- S4(4^e) )

This fixes #4318

