### PR TITLE
Improve DataAboutSimpleGroup

### DIFF
--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -1000,8 +1000,8 @@ nam,e,EFactors,par,expo,prime,result,aut,i,classical,classaut,shortname;
               [ 24, "S4" ] ];
         return dd;
       else
-        Error("mixed triality not yet done");
-        return false;
+        Info(InfoWarning, "DataAboutSimpleGroup: mixed triality not yet done");
+        return fail;
       fi;
     fi;
 


### PR DESCRIPTION
This commit does two things:
- it turns an Error into an InfoWarning
- it changes the return value of the subfunction EFactors to fail.

The latter should make EFactors be more in line with how
DataAboutSimpleGroup handles the case "simple group tom
nonidentified/not yet done", where it assigns fail to the
components `nam` and `e`.

Turning the `return false;` into `return fail;` should not break any
existing code because of the following. Previously, `e` could have the
values fail or also, if the user `return;`s on the `Error` this commit
deletes, false (or the extensions of course). Thus previously a user had
to check for both false and fail.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

