### PR TITLE
fixed method ordering for `IsomorphismPermGroup`

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -517,8 +517,29 @@ local   nice,img,module,b;
   return nice;
 end );
 
-InstallMethod( IsomorphismPermGroup,"matrix group", true,
-  [ IsMatrixGroup ], 10,
+
+#############################################################################
+##
+#M  IsomorphismPermGroup( <mat-grp> )
+##
+##  We want to use a method based on 'NicomorphismOfGeneralMatrixGroup'
+##  for the finite matrix group <mat-grp>.
+##
+##  If <mat-grp> does not know whether it is finite,
+##  there is currently no concurrent method,
+##  thus no rank shift is necessary in the first method installation.
+##
+##  If <mat-grp> knows to be finite, we want our method to beat the one for
+##  'IsGroup and IsFinite and IsHandledByNiceMonomorphism',
+##  so we install it with the same rank shift as that method.
+##  (Note that 'IsHandledByNiceMonomorphism' is implied by
+##  'IsMatrixGroup and IsFinite'.)
+##
+##  Installing just one method (with requirement 'IsMatrixGroup') would be
+##  difficult since we do not know the rank of 'IsGroup and IsFinite'.
+##
+InstallMethod( IsomorphismPermGroup,"matrix group",
+  [ IsMatrixGroup ],
 function(G)
 local map;
   if HasNiceMonomorphism(G) and IsPermGroup(Range(NiceMonomorphism(G))) then
@@ -537,6 +558,27 @@ local map;
     return map;
   fi;
 end);
+
+InstallMethod( IsomorphismPermGroup,
+    "finite matrix group",
+    [ IsMatrixGroup and IsFinite ], 5-NICE_FLAGS,
+    function( G )
+    local map;
+
+    if HasNiceMonomorphism( G ) and
+       IsPermGroup( Range( NiceMonomorphism( G ) ) ) then
+      map:= NiceMonomorphism( G );
+      if IsIdenticalObj( Source( map ), G ) then
+        return map;
+      fi;
+      return GeneralRestrictedMapping( map, G, Image( map, G ) );
+    else
+      map:= NicomorphismOfGeneralMatrixGroup( G, false, false );
+      SetNiceMonomorphism( G, map );
+      return map;
+    fi;
+end );
+
 
 #############################################################################
 ##

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -527,19 +527,23 @@ end );
 ##
 ##  If <mat-grp> does not know whether it is finite,
 ##  there is currently no concurrent method,
-##  thus no rank shift is necessary in the first method installation.
+##  thus no rank shift is necessary for the method installation.
 ##
 ##  If <mat-grp> knows to be finite, we want our method to beat the one for
-##  'IsGroup and IsFinite and IsHandledByNiceMonomorphism',
-##  so we install it with the same rank shift as that method.
-##  (Note that 'IsHandledByNiceMonomorphism' is implied by
-##  'IsMatrixGroup and IsFinite'.)
+##  'IsGroup and IsFinite and IsHandledByNiceMonomorphism'.
 ##
-##  Installing just one method (with requirement 'IsMatrixGroup') would be
-##  difficult since we do not know the rank of 'IsGroup and IsFinite'.
+##  Installing just *one* method (with requirement 'IsMatrixGroup') would be
+##  possible via (dynamic) upranking,
+##  but here we install our method twice, with the different requirements
+##  'IsMatrixGroup' and 'IsMatrixGroup and IsFinite'.
+##  (Note that 'IsHandledByNiceMonomorphism' is implied by the latter,
+##  and that we apply the same downranking in the second installation
+##  that happens in the installation of the method for
+##  'IsGroup and IsFinite and IsHandledByNiceMonomorphism';
+##  we could get rid of the two downrankings, but this might affect code
+##  that is not distributed with GAP.)
 ##
-InstallMethod( IsomorphismPermGroup,"matrix group",
-  [ IsMatrixGroup ],
+BindGlobal( "IsomorphismPermGroupForMatrixGroup",
 function(G)
 local map;
   if HasNiceMonomorphism(G) and IsPermGroup(Range(NiceMonomorphism(G))) then
@@ -560,24 +564,18 @@ local map;
 end);
 
 InstallMethod( IsomorphismPermGroup,
-    "finite matrix group",
-    [ IsMatrixGroup and IsFinite ], 5-NICE_FLAGS,
-    function( G )
-    local map;
+    "matrix group",
+    [ IsMatrixGroup ],
+    IsomorphismPermGroupForMatrixGroup );
 
-    if HasNiceMonomorphism( G ) and
-       IsPermGroup( Range( NiceMonomorphism( G ) ) ) then
-      map:= NiceMonomorphism( G );
-      if IsIdenticalObj( Source( map ), G ) then
-        return map;
-      fi;
-      return GeneralRestrictedMapping( map, G, Image( map, G ) );
-    else
-      map:= NicomorphismOfGeneralMatrixGroup( G, false, false );
-      SetNiceMonomorphism( G, map );
-      return map;
-    fi;
-end );
+InstallMethod( IsomorphismPermGroup,
+    "finite matrix group",
+    [ IsMatrixGroup and IsFinite and IsHandledByNiceMonomorphism ],
+    # The downranking is compatible with that for the method for
+    # 'IsGroup and IsFinite and IsHandledByNiceMonomorphism'
+    # (see 'lib/grpnice.gi').
+    5-NICE_FLAGS,
+    IsomorphismPermGroupForMatrixGroup );
 
 
 #############################################################################

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -570,8 +570,10 @@ PropertyMethodByNiceMonomorphism( IsSupersolvableGroup,
 ##
 InstallMethod(IsomorphismPermGroup,"via niceomorphisms",true,
   [IsGroup and IsFinite and IsHandledByNiceMonomorphism],
-  # this is intended to be better than the generic ``action on element''
-  # method. However for example for matrix groups there are better methods
+  # This is intended to be better than the generic ``action on element''
+  # method. However for example for matrix groups there are better methods.
+  # The downranking is compatible with that for the method for finite
+  # matrix groups in 'lib/grpmat.gi'.
   -NICE_FLAGS+5,
 function(g)
 local mon,iso;

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -46,6 +46,8 @@ gap> Size(img);
 67010895544320000
 gap> IsNaturalGL( TrivialSubgroup( GL(2,2) ) );
 false
+gap> IsTransitive( Image( IsomorphismPermGroup( SO( 1, 8, 2 ) ) ) );
+true
 
 #
 gap> STOP_TEST( "grpmat.tst", 1);


### PR DESCRIPTION
When starting GAP without packages, currently I get the following.

```
gap> meths:= ApplicableMethod( IsomorphismPermGroup, [ SO(1,8,2) ], 1, "all" );;
#I  Searching Method for IsomorphismPermGroup with 1 arguments:
#I  Total: 16 entries
#I  Method 10: ``IsomorphismPermGroup: matrix group'' at /.../lib/grpmat.gi:520 , value: 55
#I  Skipped:
#I  Method 11: ``IsomorphismPermGroup: via niceomorphisms'' at /.../lib/grpnice.gi:572 , value: 54
[...]
```

Starting GAP with autoloaded packages yields the following:

```
gap> meths:= ApplicableMethod( IsomorphismPermGroup, [ SO(1,8,2) ], 1, "all" );;
#I  Searching Method for IsomorphismPermGroup with 1 arguments:
#I  Total: 16 entries
#I  Method 10: ``IsomorphismPermGroup: via niceomorphisms'' at /.../lib/grpnice.gi:572 , value: 56
#I  Skipped:
#I  Method 11: ``IsomorphismPermGroup: matrix group'' at /.../lib/grpmat.gi:520 , value: 55
[...]
```

(This difference was not present in GAP 4.10, see below.)

The comments for the `IsomorphismPermGroup` method in `lib/grpnice.gi` say that the method from `lib/grpmat.gi` is regarded as better; for example, it often yields permutation groups of smaller degree.
(One could argue that the method from `lib/grpnice` could achieve this if `NiceMonomorphism` would call `NicomorphismOfGeneralMatrixGroup` instead of the "falling back on GL" method, but this call would be more expensive.  It depends on the later computations what is better.)

The reason for this unwanted difference is as follows:

- The method from `grpnice.gi` requires `IsGroup and IsFinite`.
- The method from `grpmat.gi` does not require `IsGroup and IsFinite`.
- A package (`Polycyclic`, but this does not matter) declares a new property   and an implication from `IsGroup and IsFinite` to this new property,   with the effect that the rank of `IsGroup and IsFinite` grows by 2   (1 for the tester filter, 1 for the getter filter of the new property).

```
gap> RankFilter( IsGroup and IsFinite );
45
gap> DeclareProperty( "IsJustForRankingUp", IsGroup );
gap> InstallTrueMethod( IsJustForRankingUp, IsGroup and IsFinite );
gap> RankFilter( IsGroup and IsFinite );
47
```

- After loading packages, GAP adjusts the method installations according   to the current ranks, using `ResumeMethodReordering`.
  This has the effect that the method from `grpnice.gi` gets ranked higher than the method from `grpmat.gi`.
  (This feature was introduced in GAP 4.11.0, thus the problem was not yet present in GAP 4.10.)