### PR TITLE
Add DirectProductOfPermGroupsWithMovedPoints helper

### DIFF
--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -12,20 +12,12 @@
 
 #############################################################################
 ##
-#M  DirectProductOp( <grps>, <G> )  . . . . . . direct product of perm groups
+#F  DirectProductOfPermGroupsWithMovedPoints( <grps>, <pnts> )
 ##
-InstallMethod( DirectProductOp,
-    "for a list of permutation groups, and a permutation group",
-    IsCollsElms,
-    [ IsList and IsPermCollColl, IsPermGroup ], 0,
-    function( grps, G )
-    local   oldgrps,  olds,  news,  perms,  gens,
+BindGlobal("DirectProductOfPermGroupsWithMovedPoints",
+    function( grps, pnts )
+    local   i,  oldgrps,  olds,  news,  perms,  gens,
             deg,  grp,  old,  new,  perm,  gen,  D, info;
-
-    # Check the arguments.
-    if not ForAll( grps, IsGroup ) then
-      TryNextMethod();
-    fi;
 
     oldgrps := [  ];
     olds    := [  ];
@@ -35,10 +27,11 @@ InstallMethod( DirectProductOp,
     deg     := 0;
     
     # loop over the groups
-    for grp  in grps  do
+    for i in [1..Length(grps)] do
 
         # find old domain, new domain, and conjugating permutation
-        old  := MovedPoints( grp );
+        grp  := grps[i];
+        old  := pnts[i];
         new  := [deg+1..deg+Length(old)];
         perm := MappingPermListList( old, new );
         deg  := deg + Length(old);
@@ -63,6 +56,25 @@ InstallMethod( DirectProductOp,
 
     SetDirectProductInfo( D, info );
     return D;
+    end );
+
+
+#############################################################################
+##
+#M  DirectProductOp( <grps>, <G> )  . . . . . . direct product of perm groups
+##
+InstallMethod( DirectProductOp,
+    "for a list of permutation groups, and a permutation group",
+    IsCollsElms,
+    [ IsList and IsPermCollColl, IsPermGroup ], 0,
+    function( grps, G )
+
+    # Check the arguments.
+    if not ForAll( grps, IsGroup ) then
+      TryNextMethod();
+    fi;
+
+    return DirectProductOfPermGroupsWithMovedPoints(grps, List(grps, MovedPoints));
     end );
 
 

--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -31,8 +31,8 @@ BindGlobal("DirectProductOfPermGroupsWithMovedPoints",
 
         # find old domain, new domain, and conjugating permutation
         grp  := grps[i];
-        old  := pnts[i];
-        new  := [deg+1..deg+Length(old)];
+        old  := Immutable(pnts[i]);
+        new  := MakeImmutable([deg+1..deg+Length(old)]);
         perm := MappingPermListList( old, new );
         deg  := deg + Length(old);
         Add( oldgrps, grp );

--- a/tst/testinstall/gprd.tst
+++ b/tst/testinstall/gprd.tst
@@ -46,4 +46,11 @@ gap> HasIsFinite(d4) and not IsFinite(d4);
 true
 
 #
+gap> d1 := DirectProductOfPermGroupsWithMovedPoints([g1, g1, g1], [[1..4], [1..4], [1..4]]);;
+gap> MovedPoints(d1);
+[ 1, 2, 3, 5, 6, 7, 9, 10, 11 ]
+gap> HasIsFinite(d1) and IsFinite(d1);
+true
+
+#
 gap> STOP_TEST("gprd.tst");


### PR DESCRIPTION
This is basically what DirectProduct does for a set of permutation groups,
except that one can override the moved points for each factor. This is useful
if one needs to compute "sums of G-sets": If e.g. we have a trivial group
acting on 3 points, and a Sym(4), then DirectProduct just gives back the
Sym(4). But if we need the result to act on 3+4=7 points, with the Sym(4)
acting on points acting on [4..7], then this new helper allows us to do that.

For now, I left this deliberately undocumented, as it is quite niche.