### PR TITLE
Fix InvariantQuadraticForm for Omega(-1, 2*d, 2^n)

### DIFF
--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -1789,10 +1789,8 @@ BindGlobal( "OmegaMinus", function( d, q )
       x[i,d-i+1] := o;
     od;
     x[m,d-m+1] := -nu - nubar;
-    if q mod 2 = 1 then
-      x[m,d-m] := -o;
-      x[m+1,d-m+1] := xi^( (q+1)/2 );
-    fi;
+    x[m,d-m] := -o;
+    x[m+1,d-m+1] := -xi;
     x:= ImmutableMatrix( f, x, true );
     SetInvariantQuadraticFormFromMatrix( g, x );
 

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -21,10 +21,14 @@ gap> CheckBilinearForm := function(G)
 >               g -> g*M*TransposedMat(g) = M);
 > end;;
 gap> CheckQuadraticForm := function(G)
->   local M, Q;
+>   local M, Q, V, vecs;
 >   M := InvariantBilinearForm(G).matrix;
 >   Q := InvariantQuadraticForm(G).matrix;
->   return Q+TransposedMat(Q) = M;
+>   V := FieldOfMatrixGroup(G)^DegreeOfMatrixGroup(G);
+>   vecs:=List([1..100], i->Random(V));
+>   return (Q+TransposedMat(Q) = M) and ForAll(vecs,
+>          v->ForAll(GeneratorsOfGroup(G),
+>               g -> v*Q*v = (v*g)*Q*(v*g)));
 > end;;
 gap> frob := function(g,aut)
 >   return List(g,row->List(row,x->x^aut));


### PR DESCRIPTION
Also add proper tests to check that the quadratic forms are indeed correct
(the existing tests were too weak).

Fixes #4323 

Some background: We didn't even store the `InvariantQuadraticForm` for these groups up to GAP 4.9; it was only added in 4.10, via my PR #2577. In there, I also added tests to verify the quadratic form, but those tests were insufficient (rather obviously so, in retrospect *sigh*). This adds a test similar to what Thomas used to highlight the issue in his bug report.
