### PR TITLE
Change some declarations IsGroup → IsSemigroup

### DIFF
--- a/lib/gprd.gd
+++ b/lib/gprd.gd
@@ -83,7 +83,7 @@
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "DirectProduct" );
-DeclareOperation( "DirectProductOp", [ IsList, IsGroup ] );
+DeclareOperation( "DirectProductOp", [ IsList, IsSemigroup ] );
 
 #############################################################################
 ##

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -2150,7 +2150,7 @@ DeclareAttribute( "LargestElementGroup", IsGroup );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "MinimalGeneratingSet", IsGroup );
+DeclareAttribute( "MinimalGeneratingSet", IsSemigroup );
 
 
 #############################################################################
@@ -2175,7 +2175,7 @@ DeclareAttribute( "MinimalGeneratingSet", IsGroup );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "SmallGeneratingSet", IsGroup );
+DeclareAttribute( "SmallGeneratingSet", IsSemigroup );
 
 
 #############################################################################


### PR DESCRIPTION
Namely, this broadens the declarations for:
* `DirectProductOp`
* `SmallGeneratingSet`
* `MinimalGeneratingSet`

These concepts apply just as well to semigroups as to groups. Currently, the Semigroups and/or Smallsemi packages have to
declare these separately for `IsSemigroup`, which then leads to warnings when further methods are installed with the filter `IsGroup`, since they match both the `IsGroup` and `IsSemigroup` declarations.

With this change, the packages will no longer need to make such declarations. In the interim (before they require a GAP version that includes this change), I will attempt to update Semigroups and Smallsemi so that they only make their declarations if the relevant operations/attributes are not already declared for `IsSemigroup`, e.g. I will check for:
```
[FLAGS_FILTER(IsSemigroup)] in GET_OPER_FLAGS(SmallGeneratingSet)
```
Does this seem like a proper and sensible way to proceed?

Although there is no actual problem, it's always nice to get rid of warnings. This is what happens for me if, for example, I load `polycyclic` after loading Semigroups and Smallsemi:
```
gap> LoadPackage("polycyclic", false);;
#I  method installed for DirectProductOp matches more than one declaration
#I  method installed for MinimalGeneratingSet matches more than one declaration
#I  method installed for SmallGeneratingSet matches more than one declaration
```

Note that I can't add tests for this PR, because there are, of course, no methods installed in GAP for these operations/attributes for semigroups.

The corresponding PRs to Semigroups and Smallsemi are https://github.com/semigroups/Semigroups/pull/756 and https://github.com/gap-packages/smallsemi/pull/19, respectively.


# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

