### PR TITLE
Speed up building stabchain from base and strong generators

### DIFF
--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -396,23 +396,29 @@ end);
 #F  StabChainBaseStrongGenerators( <base>, <sgs>[, <one>] )
 ##
 InstallGlobalFunction(StabChainBaseStrongGenerators,function(arg)
-local   base,sgs,one,S,  T,  pnt;
+local   base,sgs,one,S,  T,  pnt, genlabels;
 
-    base:=arg[1];
-    sgs:=arg[2];
+    base:=PlainListCopy(arg[1]);
+    sgs:=PlainListCopy(arg[2]);
     if Length(arg)=3 then
       one:=arg[3];
     else
       one:= One(arg[2][1]);
     fi;
-    S := EmptyStabChain( [  ], one );
+    S := EmptyStabChain( sgs, one );
+    # Skip the identity in genlabels
+    Assert(2, S.labels[1] = ());
+    genlabels := PlainListCopy([2..Length(S.labels)]);
     T := S;
     for pnt  in base  do
         InsertTrivialStabilizer( T, pnt );
-        AddGeneratorsExtendSchreierTree( T, sgs );
-        sgs := Filtered( sgs, g -> pnt ^ g = pnt );
+        T.genlabels := genlabels;
+        T.generators := T.labels{T.genlabels};
+        AGEST(T.orbit, T.genlabels, T.labels, T.translabels, T.transversal, T.genlabels);
+        genlabels := Filtered(genlabels, x -> pnt^sgs[x] = pnt);
         T := T.stabilizer;
     od;
+
     return S;
 end);
     

--- a/tst/testinstall/stabchain.tst
+++ b/tst/testinstall/stabchain.tst
@@ -1,7 +1,7 @@
 #@local TestGens,m
 gap> START_TEST("stabchain.tst");
 gap> TestGens := function(g)
-> local m;
+> local m, sc;
 > m := SortedList(List(g));
 > if Size(m) <> Size(g) or Size(Set(m)) <> Size(m) or
 >    Group(m) <> g then Print("0"); fi;
@@ -14,10 +14,19 @@ gap> TestGens := function(g)
 > ChangeStabChain(StabChainMutable(g), [1,10,11,12,13,14,15,2,3,4,5,6,7,8], false);
 > if m <> SortedList(List(g)) then Print("5"); fi;
 > if m <> SortedList(List(g, x -> x)) then Print("4"); fi;
+> sc := StabChainBaseStrongGenerators([1,10,11,12,13,14,15,2,3,4,5,6,7,8], 
+>  StrongGeneratorsStabChain(StabChainMutable(g)), ());
+> g := Group(GeneratorsOfGroup(g), ());
+> SetStabChainMutable(g, sc);
+> if m <> SortedList(List(g)) then Print(g,"6"); fi;
+> if m <> SortedList(List(g, x -> x)) then Print(g,"7"); fi;
 > return true;
 > end;;
 gap> TestGens(Group(()));;
 gap> List([2..7],
 >       x -> List([1..NrTransitiveGroups(x)],
 >         y -> TestGens(TransitiveGroup(x,y))));;
+gap> TestGens(Group((1,2,3),(4,5,6)));;
+gap> TestGens(Group((1,2,3)(4,5,6)));;
+gap> TestGens(Group((2,4,6),(1,3,5),(1,3)));;
 gap> STOP_TEST("stabchain.tst", 1);

--- a/tst/testinstall/stabchain.tst
+++ b/tst/testinstall/stabchain.tst
@@ -29,4 +29,10 @@ gap> List([2..7],
 gap> TestGens(Group((1,2,3),(4,5,6)));;
 gap> TestGens(Group((1,2,3)(4,5,6)));;
 gap> TestGens(Group((2,4,6),(1,3,5),(1,3)));;
+gap> m := StabChainBaseStrongGenerators(
+>    [1,3..1999],
+>    List([1,3..1999], x -> (x,x+1)),
+>    ());;
+gap> Log(SizeStabChain(m), 2) = 1000;
+true
 gap> STOP_TEST("stabchain.tst", 1);


### PR DESCRIPTION
When we already have a base + strong generating set, the function StabChainBaseStrongGenerators turns this into a GAP stabilizer chain. This function scaled surprisingly badly, because it used existing functions for adding to a stabilizer chain which have "O(n^2) in number of generator" loops.

Long term it would be good to clean those up, but in this case, where we have a list of strong generators, we can just construct the stabilizer chain.

A brief benchmark:

`sc := StabChainBaseStrongGenerators([1..1000], List([1,3..999], x -> (x,x+1)));;` is sped up from 48 seconds to 45 milliseconds (that's not a unit mistake, it is 1000 times faster).


I test this with the existing tests for stabiliser chains, which use the fact that stabiliser chains are used for enumerating groups.

This includes another fix (which I could pull out) -- the function PlainListCopy didn't actually produce a plain list for types like ranges, which I needed to fix as the internal AGEST only accepts PLISTs.