### PR TITLE
Use internal PLAIN_LIST_COPY to implement PlainListCopy, and document

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -1873,6 +1873,16 @@ handled more efficiently,
 for example when one installs a method for a particular operation,
 where an argument is required to be a list in a particular representation.
 
+<ManSection>
+<Func Name="PlainListCopy" Arg='list'/>
+<Description>
+This function returns a list equal to its argument, in a plain list
+representation (see <Ref Filt="IsPlistRep"/>).
+This is intended for use in certain rare situations,
+such as before objectifying, or calling some kernel functions.
+</Description>
+</ManSection>
+
 <#Include Label="IsPlistRep">
 
 </Section>

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -231,19 +231,6 @@ InstallMethod( \+, "for an 8 bit vector of char 2 and a GF2 vector",
     fi;
 end);
 
-#############################################################################
-##
-#M  `PlainListCopyOp( <vec> ) 
-##
-##  Make the vector into a plain list (in place)
-##
-
-InstallMethod( PlainListCopyOp, "for an 8 bit vector",
-        true, [IsSmallList and Is8BitVectorRep], 0,
-        function (v)
-    PLAIN_VEC8BIT(v);
-    return v;
-end);
 
 #############################################################################
 ##

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -1767,32 +1767,6 @@ function(f,v)
   return Immutable(v);
 end);
 
-
-#############################################################################
-##
-#M  PlainListCopyOp( <v> )
-##
-
-InstallMethod( PlainListCopyOp, "for a GF2 vector",
-        true, [IsGF2VectorRep and IsSmallList ],
-        0, function( v )
-    PLAIN_GF2VEC(v);
-    return v;
-end);
-
-#############################################################################
-##
-#M  PlainListCopyOp( <m> )
-##
-
-InstallMethod( PlainListCopyOp, "for a GF2 matrix",
-        true, [IsSmallList and IsGF2MatrixRep ],
-        0, function( m )
-    PLAIN_GF2MAT(m);
-    return m;
-end);
-
-
 #############################################################################
 ##
 #M  MultVector( <vl>, <mul>)

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -2371,41 +2371,6 @@ DeclareGlobalFunction( "IntersectionBlist" );
 ##
 DeclareGlobalFunction( "ListWithIdenticalEntries" );
 
-
-#############################################################################
-##
-#F  PlainListCopy( <list> ) . . . . . . . .  make a plain list copy of a list
-##
-##  <ManSection>
-##  <Func Name="PlainListCopy" Arg='list'/>
-##
-##  <Description>
-##  This is intended for use in certain rare situations,
-##  such as before objectifying.
-##  Normally, <C>ConstantAccessTimeList</C> should be enough.
-##  </Description>
-##  </ManSection>
-##
-DeclareGlobalFunction("PlainListCopy");
-
-
-#############################################################################
-##
-#O  PlainListCopyOp( <list> ) . . . . . . . .return a plain version of a list
-##
-##  <ManSection>
-##  <Oper Name="PlainListCopyOp" Arg='list'/>
-##
-##  <Description>
-##  This operation returns a list equal to its argument, in a plain list
-##  representation. This may be the argument converted in place, or
-##  may be new. It is only intended to be called by <C>PlainListCopy</C>.
-##  </Description>
-##  </ManSection>
-##
-DeclareOperation("PlainListCopyOp", [IsSmallList]);
-
-
 #############################################################################
 ##
 #O  PositionNot( <list>, <val>[, <from>] )  . . . . . . . . .  find not <val>

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -3890,39 +3890,6 @@ InstallMethod( ViewObj,
     Print( " ]" );
     end );
 
-
-#############################################################################
-##
-#F  PlainListCopy( <list> ) . . . . . . . . . . make a plain list copy of
-##                                          a list
-##
-##  This is intended for use in certain rare situations, such as before
-##  Objectifying. Normally, ConstantAccessTimeList should be enough
-##
-##  This function guarantees that the result will be a plain list, distinct
-##  from the input object.
-##
-InstallGlobalFunction(PlainListCopy, function( list )
-    local tnum, copy;
-
-    if not IsSmallList( list ) then
-        Error("PlainListCopy: argument must be a small list");
-    fi;
-
-    # This is enough much of the time
-    copy := ShallowCopy(list);
-
-    # now do a cheap check on copy
-    tnum := TNUM_OBJ(copy);
-    if FIRST_LIST_TNUM > tnum or LAST_LIST_TNUM < tnum then
-        copy := PlainListCopyOp( copy );
-    fi;
-    Assert(2, not IsIdenticalObj(list,copy));
-    Assert(2, TNUM_OBJ(copy) >= FIRST_LIST_TNUM);
-    Assert(2, TNUM_OBJ(copy) <= LAST_LIST_TNUM);
-    return copy;
-end);
-
 #############################################################################
 ##
 #M  PositionNot( <list>, <obj>, <from-minus-one> ) . . . . . . default method

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -243,21 +243,6 @@ InstallMethod( \-, "for two 8 bit matrices in same characteristic",
 
 #############################################################################
 ##
-#M  `PlainListCopyOp( <mat> ) 
-##
-##  Make the matrix into a plain list 
-##
-
-InstallMethod( PlainListCopyOp, "for an 8 bit vector",
-        true, [IsSmallList and Is8BitMatrixRep], 0,
-        function (m)
-    PLAIN_MAT8BIT(m);
-    return m;
-end);
-
-
-#############################################################################
-##
 #M  ConvertToMatrixRepNC( <list>, <fieldsize )
 #M  ConvertToMatrixRep( <list>[, <fieldsize> | <field>])
 ##

--- a/lib/sparselistgen.gi
+++ b/lib/sparselistgen.gi
@@ -96,30 +96,6 @@ end);
 
 #############################################################################
 ##
-#M  PlainListCopyOp( <sl> ) make a copy which will really be a plain list
-##
-
-InstallMethod(PlainListCopyOp, "sparse list", [IsSparseList and IsSmallList], 
-        function(sl)
-    local   l,  i, ss;
-    ss := SparseStructureOfList(sl);
-    if IsBound(ss[1]) then
-        l := ListWithIdenticalEntries(Length(sl), ss[1]);
-    else
-        l := [];
-    fi;
-    for i in [1..Length(ss[2])] do
-        if IsBound(ss[3][i]) then
-            l[ss[2][i]] := ss[3][i];
-        else
-            Unbind(l[ss[2][i]]);
-        fi;
-    od;
-    return l;
-end);
-
-#############################################################################
-##
 #F PLAIN_SL ( <sl> ) convert a sparse list in place to a plain list
 ##
 ##  

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -222,20 +222,6 @@ end);
 
 #############################################################################
 ##
-#M  `PlainListCopyOp( <vec> ) 
-##
-##  Make the vector into a plain list (in place)
-##
-
-InstallMethod( PlainListCopyOp, "for an 8 bit vector",
-        true, [IsSmallList and Is8BitVectorRep], 0,
-        function (v)
-    PLAIN_VEC8BIT(v);
-    return v;
-end);
-
-#############################################################################
-##
 #M  DegreeFFE( <vector> )
 ##
 BindGlobal("Q_TO_DEGREE", # discrete logarithm list

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1581,31 +1581,6 @@ end);
 
 #############################################################################
 ##
-#M  PlainListCopyOp( <v> )
-##
-
-InstallMethod( PlainListCopyOp, "for a GF2 vector",
-        true, [IsGF2VectorRep and IsSmallList ],
-        0, function( v )
-    PLAIN_GF2VEC(v);
-    return v;
-end);
-
-#############################################################################
-##
-#M  PlainListCopyOp( <m> )
-##
-
-InstallMethod( PlainListCopyOp, "for a GF2 matrix",
-        true, [IsSmallList and IsGF2MatrixRep ],
-        0, function( m )
-    PLAIN_GF2MAT(m);
-    return m;
-end);
-
-
-#############################################################################
-##
 #M  MultVector( <vl>, <mul>)
 ##
 

--- a/src/lists.c
+++ b/src/lists.c
@@ -1590,6 +1590,12 @@ Obj PLAIN_LIST_COPY(Obj list)
     return res;
 }
 
+Obj FuncPlainListCopy(Obj self, Obj list)
+{
+    RequireSmallList(SELF_NAME, list);
+    return PLAIN_LIST_COPY(list);
+}
+
 
 /****************************************************************************
 **
@@ -1856,6 +1862,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC_1ARGS(IS_SSORT_LIST_DEFAULT, list),
     GVAR_FUNC_1ARGS(IS_POSS_LIST_DEFAULT, list),
     GVAR_FUNC_3ARGS(POS_LIST_DEFAULT, list, obj, start),
+    GVAR_FUNC_1ARGS(PlainListCopy, list),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -309,6 +309,44 @@ gap> l;
 gap> TNAM_OBJ(l);
 "plain list (rectangular table)"
 
+# Check PlainListCopy
+gap> checkPlainListCopy := function(l)
+>   local copy, tnum;
+>   tnum := TNUM_OBJ(l);
+>   copy := PlainListCopy(l);
+>   return IsPlistRep(copy) and l = copy and
+>          not IsIdenticalObj(l,copy) and TNUM_OBJ(l) = tnum;
+> end;;
+gap> checkPlainListCopy([]);
+true
+gap> checkPlainListCopy([1, ,()]);
+true
+gap> checkPlainListCopy([1..5]);
+true
+gap> checkPlainListCopy([10,8..-4]);
+true
+gap> checkPlainListCopy("");
+true
+gap> checkPlainListCopy("abc");
+true
+gap> checkPlainListCopy(ListWithIdenticalEntries(3, false));
+true
+gap> checkPlainListCopy(NewZeroVector(IsGF2VectorRep, GF(2), 10));
+true
+gap> checkPlainListCopy(NewZeroVector(Is8BitVectorRep, GF(3), 10));
+true
+gap> PlainListCopy(6);
+Error, PlainListCopy: <list> must be a small list (not the integer 6)
+gap> PlainListCopy((1,2,3));
+Error, PlainListCopy: <list> must be a small list (not a permutation (small))
+#@if IsHPCGAP
+gap> PlainListCopy(Group((1,2)));
+Error, PlainListCopy: <list> must be a small list (not an atomic component object)
+#@else
+gap> PlainListCopy(Group((1,2)));
+Error, PlainListCopy: <list> must be a small list (not a component object)
+#@fi
+
 # Check TNUM behaviours
 gap> x := [1,,"cheese"];;
 gap> x[2] := 2;;


### PR DESCRIPTION
After looking at uses of PlainListCopy, I decided the internal kernel function PLAIN_LIST_COPY does everything it is supposed to do, and the best idea was to delegate to it.

While PlainListCopy could (by it's docs) sometimes copy and sometimes not, none of the uses we relying on the behaviour of not copying, or changing the original.

This mainly involved removing the now unused PlainListCopyOp.

This PR is required for #4331