### PR TITLE
added `GO(1,q)`, `SO(1,q)`, `Omega(1,q)`, `Omega(-1,2,q)`

### DIFF
--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -432,7 +432,8 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 ##  odd, and <M>1</M> if <A>q</A> is even.)
 ##  Also interesting is the group Omega( <A>e</A>, <A>d</A>, <A>q</A> ),
 ##  see <Ref Oper="Omega" Label="construct an orthogonal group"/>,
-##  which is always of index <M>2</M> in SO( <A>e</A>, <A>d</A>, <A>q</A> ).
+##  which is of index <M>2</M> in SO( <A>e</A>, <A>d</A>, <A>q</A> ),
+##  except in the case <M><A>d</A> = 1</M>.
 ##  <P/>
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the special orthogonal group itself.
@@ -652,7 +653,8 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  (see&nbsp;<Ref Attr="InvariantQuadraticForm"/>) specified by <A>e</A>,
 ##  and that have square spinor norm in odd characteristic
 ##  or Dickson invariant <M>0</M> in even characteristic, respectively,
-##  in the category given by the filter <A>filt</A>. For odd <A>q</A>,
+##  in the category given by the filter <A>filt</A>. For odd <A>q</A>
+##  and <M><A>d</A> \geq 2</M>,
 ##  this group has always index two in the corresponding special orthogonal group,
 ##  which will be conjugate in <M>GL(d,q)</M> to the group returned by SO( <A>e</A>, <A>d</A>, <A>q</A> ),
 ##  see <Ref Func="SpecialOrthogonalGroup"/>, but may fix a different form (see <Ref Sect="Classical Groups"/>).

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -62,6 +62,12 @@ gap> GO(IsPermGroup,3,5);
 Perm_GO(0,3,5)
 
 #
+gap> IsTrivial( GO(1,3) );
+false
+gap> IsTrivial( GO(1,4) );
+true
+
+#
 gap> GO(3);
 Error, usage: GeneralOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q> )
 gap> GO(3,6);
@@ -130,6 +136,10 @@ gap> GammaL(3,6);
 Error, <subfield> must be a prime or a finite field
 
 #
+gap> Omega(1,2);
+GO(0,1,2)
+gap> Omega(1,3);
+SO(0,1,3)
 gap> Omega(3,2);
 GO(0,3,2)
 gap> Omega(3,3);
@@ -150,6 +160,10 @@ gap> Omega(+1,4,3);
 Omega(+1,4,3)
 
 #
+gap> Omega(-1,2,2);
+Omega(-1,2,2)
+gap> Omega(-1,2,3);
+Omega(-1,2,3)
 gap> Omega(-1,4,2);
 Omega(-1,4,2)
 gap> Omega(-1,4,3);
@@ -170,12 +184,8 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `OmegaCons' on 4 arguments
 
 #
-gap> Omega(1,2);
-Error, <d> must be at least 3
 gap> Omega(2,2);
 Error, sign <e> = 0 but dimension <d> is even
-gap> Omega(-1,2,2);
-Error, <d> = 2 is not supported
 
 #
 gap> STOP_TEST("classic-G.tst", 1);

--- a/tst/testinstall/grp/classic-S.tst
+++ b/tst/testinstall/grp/classic-S.tst
@@ -37,6 +37,12 @@ gap> SO(IsPermGroup,3,5);
 Perm_SO(0,3,5)
 
 #
+gap> IsTrivial( SO(1,3) );
+true
+gap> IsTrivial( SO(1,4) );
+true
+
+#
 gap> SO(3);
 Error, usage: SpecialOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q> )
 gap> SO(3,6);

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -142,7 +142,7 @@ gap> grps:=[];;
 gap> for d in [2,4,6,8] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Omega(+1,d,q));
->     if d <> 2 then Add(grps, Omega(-1,d,q)); fi;
+>     Add(grps, Omega(-1,d,q));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);


### PR DESCRIPTION
... and adjusted the relevant statements in the documentation (resolves #4321)