### PR TITLE
Make further use of `Pluralize` in the GAP library

### DIFF
--- a/lib/methsel2.g
+++ b/lib/methsel2.g
@@ -232,7 +232,10 @@ end;
   APPEND_LIST(no_method_found,NAME_FUNC(INF.Operation));
   APPEND_LIST(no_method_found,"' on ");
   APPEND_LIST(no_method_found,STRING_INT(LENGTH(INF.Arguments)));
-  APPEND_LIST(no_method_found," arguments");
+  APPEND_LIST(no_method_found," argument");
+  if LENGTH(INF.Arguments) <> 1 then
+    APPEND_LIST(no_method_found,"s");
+  fi;
 
   linebreak := true;
   for i in [ 1 .. LENGTH(INF.Arguments) ] do

--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -107,15 +107,9 @@ function(S)
     suffix := Concatenation("\>of\< ", suffix);
   fi;
   Append(str, suffix);
-
-  Append(str, "\>with\< \>");
-  Append(str, ViewString(nrgens));
-  Append(str, "\< \>generator");
-  if nrgens > 1 or nrgens = 0 then
-    Append(str, "s");
-  fi;
-  Append(str, "\<>\<");
-
+  Append(str, "\>with\< ");
+  Append(str, Pluralize(nrgens, "generator"));
+  Append(str, ">\<");
   return str;
 end);
 
@@ -187,13 +181,8 @@ function(S)
   fi;
 
   if IsBound(gens) then
-    Append(str, "with\> ");
-    Append(str, ViewString(Length(gens)));
-    Append(str, "\< generator");
-
-    if Length(gens) > 1 or Length(gens) = 0 then
-      Append(str, "s");
-    fi;
+    Append(str, "with ");
+    Append(str, Pluralize(Length(gens), "generator"));
   else
     Remove(str, Length(str));
   fi;

--- a/tst/testbugfix/2007-07-02-t00180.tst
+++ b/tst/testbugfix/2007-07-02-t00180.tst
@@ -3,4 +3,4 @@ gap> GeneratorsOfRing(Rationals);
 Error, cannot compute elements list of infinite domain <V>
 gap> GeneratorsOfRingWithOne(Rationals);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `GeneratorsOfRingWithOne' on 1 arguments
+Error, no 2nd choice method found for `GeneratorsOfRingWithOne' on 1 argument

--- a/tst/testbugfix/2017-10-19-IsomorphismPartialPermSemigroup.tst
+++ b/tst/testbugfix/2017-10-19-IsomorphismPartialPermSemigroup.tst
@@ -3,23 +3,23 @@
 # Examples reported on issue #1783 on github.com/gap-system/gap
 gap> iso := [];;
 gap> iso[1] := IsomorphismPartialPermSemigroup(SymmetricGroup(1));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> iso[2] := IsomorphismPartialPermSemigroup(Group([()]));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> iso[3] := IsomorphismPartialPermSemigroup(Group([], ()));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> iso[4] := IsomorphismPartialPermMonoid(SymmetricGroup(1));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> iso[5] := IsomorphismPartialPermMonoid(Group([()]));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> iso[6] := IsomorphismPartialPermMonoid(Group([], ()));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> ForAll(iso, map -> () ^ map = EmptyPartialPerm());
 true
 gap> inv := List(iso, InverseGeneralMapping);;

--- a/tst/testbugfix/2018-02-21-int-mul-pow.tst
+++ b/tst/testbugfix/2018-02-21-int-mul-pow.tst
@@ -59,10 +59,10 @@ gap> [1..3]^4;
 196
 gap> [1..3]^0;
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 3rd choice method found for `OneSameMutability' on 1 arguments
+Error, no 3rd choice method found for `OneSameMutability' on 1 argument
 gap> [1..3]^-1;
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `InverseSameMutability' on 1 arguments
+Error, no 2nd choice method found for `InverseSameMutability' on 1 argument
 
 # multiplication of int*float and float*int used to behave inconsistently
 gap> 10^400 * 10.^-300; # used to return 1.e+100

--- a/tst/testbugfix/2018-03-21-MagmaWithInversesByGenerators.tst
+++ b/tst/testbugfix/2018-03-21-MagmaWithInversesByGenerators.tst
@@ -6,7 +6,6 @@ gap> M:=MagmaWithInversesByMultiplicationTable(A);
 <magma-with-inverses with 4 generators>
 gap> IsFinitelyGeneratedGroup(M);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 2nd choice method found for `IsFinitelyGeneratedGroup' on 1 argument\
-s
+Error, no 2nd choice method found for `IsFinitelyGeneratedGroup' on 1 argument
 gap> IsGroup(M);
 false

--- a/tst/testinstall/constructor.tst
+++ b/tst/testinstall/constructor.tst
@@ -13,7 +13,7 @@ gap> c(c);
 Error, Constructor: the first argument must be a filter (not a function)
 gap> c(IsInt);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `foobar' on 1 arguments
+Error, no 1st choice method found for `foobar' on 1 argument
 gap> InstallMethod(c,[IsInt],x->x);
 gap> c(IsInt);
 <Category "IsInt">

--- a/tst/testinstall/depth.tst
+++ b/tst/testinstall/depth.tst
@@ -27,7 +27,7 @@ Depth 80
 # Just want an error to occur to check the depth is reset correctly
 gap> IsAbelian(2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `IsCommutative' on 1 arguments
+Error, no 1st choice method found for `IsCommutative' on 1 argument
 gap> dive(80);
 Depth 80
 gap> STOP_TEST( "depth.tst", 1);

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -26,7 +26,7 @@ gap> TrivialGroup(1);
 Error, usage: TrivialGroup( [<filter>] )
 gap> TrivialGroup(IsRing);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `TrivialGroupCons' on 1 arguments
+Error, no 1st choice method found for `TrivialGroupCons' on 1 argument
 
 #
 # abelian groups

--- a/tst/testinstall/hpc/serialize.tst
+++ b/tst/testinstall/hpc/serialize.tst
@@ -170,8 +170,7 @@ gap> TNAM_OBJ(x);
 "positional object"
 gap> SerializeToNativeString(x);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `SerializableRepresentation' on 1 argume\
-nts
+Error, no 1st choice method found for `SerializableRepresentation' on 1 argument
 
 #
 # data object
@@ -204,8 +203,7 @@ gap> TNAM_OBJ(G);
 "atomic component object"
 gap> SerializeToNativeString(G);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `SerializableRepresentation' on 1 argume\
-nts
+Error, no 1st choice method found for `SerializableRepresentation' on 1 argument
 
 #
 # TODO: atomic positional object

--- a/tst/testinstall/kernel/calls.tst
+++ b/tst/testinstall/kernel/calls.tst
@@ -79,7 +79,7 @@ gap> UnprofileFunctions([o]);
 #
 gap> PROF_FUNC(1);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `PROF_FUNC' on 1 arguments
+Error, no 1st choice method found for `PROF_FUNC' on 1 argument
 gap> PROF_FUNC(x->x);
 [ 0, 0, 0, 0, 0 ]
 gap> CLEAR_PROFILE_FUNC(fail);

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -451,7 +451,7 @@ gap> Last([0..3]);
 3
 gap> Last(Enumerator(Integers));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `LastOp' on 1 arguments
+Error, no 1st choice method found for `LastOp' on 1 argument
 gap> Last([0,1,2,3], IsFFE);
 fail
 gap> Last([0..3], IsFFE);

--- a/tst/testinstall/pperm.tst
+++ b/tst/testinstall/pperm.tst
@@ -3327,7 +3327,7 @@ gap> CodegreeOfPartialPerm(x / x);
 gap> x := PartialPerm([1, 2, 4, 7, 9], [5, 3, 7, 4, 9]);;
 gap> Zero(x);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+Error, no 1st choice method found for `ZeroMutable' on 1 argument
 gap> MultiplicativeZeroOp(x);
 <empty partial perm>
 gap> MultiplicativeZero(x);

--- a/tst/testinstall/recordname.tst
+++ b/tst/testinstall/recordname.tst
@@ -43,7 +43,7 @@ gap> SortedList(names) = [str1021, str1022a, str1023, str1022b, "x", "y"];
 true
 gap> RecNames( () );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `RecNames' on 1 arguments
+Error, no 1st choice method found for `RecNames' on 1 argument
 gap> REC_NAMES( () );
 Error, REC_NAMES: <rec> must be a record (not a permutation (small))
 gap> REC_NAMES_COMOBJ( () );

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -230,8 +230,8 @@ false
 gap> S := Semigroup([Transformation([1, 1]), Transformation([2, 2])]);
 <transformation semigroup of degree 2 with 2 generators>
 gap> R := ReesMatrixSemigroup(S, [[S.1, S.2]]);
-<Rees matrix semigroup 2x1 over <transformation semigroup of degree 2 with 2 
-  generators>>
+<Rees matrix semigroup 2x1 over <transformation semigroup of degree 2 with 
+  2 generators>>
 gap> IsSimpleSemigroup(R);
 true
 gap> T := Semigroup(RMSElement(R, 2, S.1, 1));

--- a/tst/testinstall/semipperm.tst
+++ b/tst/testinstall/semipperm.tst
@@ -14,8 +14,8 @@ gap> SetUserPreference("NotationForPartialPerms", "component");
 gap> S := Semigroup(PartialPerm([1, 2, 3], [4, 5, 11]), 
 >                   PartialPerm([1], [3]));;
 gap> DisplayString(S);
-"\><\>partial perm\< \>semigroup\< \>of\< \>rank \>3\<\< \>with\< \>2\< \>gene\
-rators\<>\<"
+"\><\>partial perm\< \>semigroup\< \>of\< \>rank \>3\<\< \>with\< \>2\< genera\
+tors>\<"
 
 # Test  One for a partial perm semigroup without generators
 gap> S := SymmetricInverseMonoid(3);;
@@ -325,43 +325,43 @@ Error, the argument must be an inverse semigroup
 
 # Test IsomorphismPartialPermSemigroup for a perm group
 gap> IsomorphismPartialPermSemigroup(Group((1,2,3)));
-MappingByFunction( Group([ (1,2,3) ]), <partial perm group of rank 3 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group([ (1,2,3) ]), <partial perm group of rank 3 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
 true
 gap> IsomorphismPartialPermSemigroup(Group([()]));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
 true
 gap> IsomorphismPartialPermSemigroup(Group([], ()));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
 true
 gap> IsomorphismPartialPermMonoid(Group((1,2,3)));
-MappingByFunction( Group([ (1,2,3) ]), <partial perm group of rank 3 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group([ (1,2,3) ]), <partial perm group of rank 3 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
 true
 gap> IsomorphismPartialPermMonoid(Group([()]));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
 true
 gap> IsomorphismPartialPermMonoid(Group([], ()));
-MappingByFunction( Group(()), <trivial partial perm group of rank 0 with
-  1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
+MappingByFunction( Group(()), <trivial partial perm group of rank 0 with 
+ 1 generator>, function( p ) ... end, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);

--- a/tst/testinstall/semipperm.tst
+++ b/tst/testinstall/semipperm.tst
@@ -134,7 +134,7 @@ gap> S := InverseSemigroup(x);
 <inverse partial perm semigroup of rank 7 with 1 generator>
 gap> Zero(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+Error, no 1st choice method found for `ZeroMutable' on 1 argument
 gap> MultiplicativeZero(S);
 fail
 
@@ -157,17 +157,17 @@ gap> S := SymmetricInverseMonoid(5);
 <symmetric inverse monoid of degree 5>
 gap> ZeroMutable(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+Error, no 1st choice method found for `ZeroMutable' on 1 argument
 gap> ZeroImmutable(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+Error, no 1st choice method found for `ZeroMutable' on 1 argument
 gap> S := Monoid(PartialPerm([2, 1]));;
 gap> ZeroImmutable(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+Error, no 1st choice method found for `ZeroMutable' on 1 argument
 gap> ZeroMutable(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `ZeroMutable' on 1 arguments
+Error, no 1st choice method found for `ZeroMutable' on 1 argument
 
 # Test GeneratorsOfInverseSemigroup
 gap> S := Semigroup(PartialPerm([1, 3], [3, 5]), 

--- a/tst/testinstall/semitran.tst
+++ b/tst/testinstall/semitran.tst
@@ -282,8 +282,8 @@ Error, the argument must be a semigroup with a multiplicative neutral element
 # Test IsomorphismTransformationSemigroup for a transformation semigroup
 gap> S := Semigroup(Transformation([1, 4, 6, 2, 5, 3, 7, 8, 9, 9]));;
 gap> IsomorphismTransformationSemigroup(S);
-IdentityMapping( <commutative transformation semigroup of degree 10 with 1 
- generator> )
+IdentityMapping( <commutative transformation semigroup of degree 10 with 
+ 1 generator> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);
@@ -311,8 +311,8 @@ true
 
 # Test IsomorphismTransformationSemigroup for a perm group
 gap> IsomorphismTransformationSemigroup(Group((1,2,3)));
-MappingByFunction( Group([ (1,2,3) ]), <transformation group of degree 3 with
-  1 generator>, <Attribute "AsTransformation">, <Attribute "AsPermutation"> )
+MappingByFunction( Group([ (1,2,3) ]), <transformation group of degree 3 with 
+ 1 generator>, <Attribute "AsTransformation">, <Attribute "AsPermutation"> )
 gap> BruteForceIsoCheck(last);
 true
 gap> BruteForceInverseCheck(last2);

--- a/tst/testinstall/trace.tst
+++ b/tst/testinstall/trace.tst
@@ -23,7 +23,7 @@ gap> InstallImmediateMethod( Size, "for abelian mockobj", cat and IsAbelian, 0, 
 gap> a := Objectify(type,rec());;
 gap> Size(a);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Size' on 1 arguments
+Error, no 1st choice method found for `Size' on 1 argument
 gap> SetIsAbelian(a, true);
 #I RunImmediateMethods
 #I  immediate: Size: for abelian mockobj at stream:1

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -154,7 +154,7 @@ gap> ###########################################################################
 gap> f:=function() local i; for i in true do return 1; od; return 2; end;;
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `Iterator' on 1 argument at GAPROOT/lib/methsel2.g:LINE called from
 for i in true do
     return 1;
 od; at *stdin*:33 called from
@@ -182,7 +182,7 @@ gap>
 gap> f:=function(x) local i,j; for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `Iterator' on 1 argument at GAPROOT/lib/methsel2.g:LINE called from
 for i in true do
     return 1;
 od; at *stdin*:35 called from
@@ -212,7 +212,7 @@ gap>
 gap> f:=function(x) local i,j; Unbind(x); for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `Iterator' on 1 argument at GAPROOT/lib/methsel2.g:LINE called from
 for i in true do
     return 1;
 od; at *stdin*:37 called from
@@ -242,7 +242,7 @@ gap>
 gap> f:=function(x) local i,j; Unbind(x); j := 4; for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `Iterator' on 1 argument at GAPROOT/lib/methsel2.g:LINE called from
 for i in true do
     return 1;
 od; at *stdin*:39 called from

--- a/tst/testspecial/backtrace2.g.out
+++ b/tst/testspecial/backtrace2.g.out
@@ -152,7 +152,7 @@ gap> test:= function( n )
 > end;;
 gap> test( 1 );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `IsCommutative' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `IsCommutative' on 1 argument at GAPROOT/lib/methsel2.g:LINE called from
 IsAbelian( 1 ) at *stdin*:47 called from
 test( n + 1 ); at *stdin*:49 called from
 test( n + 1 ); at *stdin*:49 called from

--- a/tst/testspecial/bad-minus.g.out
+++ b/tst/testspecial/bad-minus.g.out
@@ -4,7 +4,7 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `AdditiveInverseMutable' on 1 argument at GAPROOT/lib/methsel2.g:LINE called from
 AdditiveInverseMutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
 AdditiveInverseAttr( elm ) at GAPROOT/lib/arith.gi:LINE called from
 1 - "abc" at *stdin*:3 called from

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -788,22 +788,22 @@ gap> MultiplicativeZero(UUU);
 0
 gap> One(R);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OneMutable' on 1 arguments
+Error, no 1st choice method found for `OneMutable' on 1 argument
 gap> One(U);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OneMutable' on 1 arguments
+Error, no 1st choice method found for `OneMutable' on 1 argument
 gap> One(UU);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OneMutable' on 1 arguments
+Error, no 1st choice method found for `OneMutable' on 1 argument
 gap> One(UUU);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OneMutable' on 1 arguments
+Error, no 1st choice method found for `OneMutable' on 1 argument
 gap> One(S);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OneMutable' on 1 arguments
+Error, no 1st choice method found for `OneMutable' on 1 argument
 gap> One(V);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OneMutable' on 1 arguments
+Error, no 1st choice method found for `OneMutable' on 1 argument
 gap> ParentAttr(R);
 <Rees 0-matrix semigroup 7x6 over Group([ (1,2) ])>
 gap> ParentAttr(U);

--- a/tst/teststandard/reesmat.tst
+++ b/tst/teststandard/reesmat.tst
@@ -908,8 +908,8 @@ gap> mat:=[ [ Transformation( [ 7, 7, 2, 6, 6, 4, 2, 8, 9, 11, 10, 4 ] ),
 >      Transformation( [ 8, 8, 9, 9, 9, 11, 10, 6, 7, 2, 4, 8 ] ), 
 >      Transformation( [ 4, 4, 4, 1, 1, 6, 7, 9, 8, 10, 11, 1 ] ) ] ];;
 gap> R:=ReesMatrixSemigroup(S, mat);               
-<Rees matrix semigroup 4x3 over <transformation semigroup of degree 12 with 7 
-  generators>>
+<Rees matrix semigroup 4x3 over <transformation semigroup of degree 12 with 
+  7 generators>>
 gap> IsSimpleSemigroup(R);
 true
 gap> IsWholeFamily(R);


### PR DESCRIPTION
This is a follow-on pull request #4050, although it doesn't require that PR.

I describe the changes below, but as mentioned below, this PR will break the tests of some packages in a way that might be annoying/time consuming/tricky to fix, so it might not be worth ever merging this. However, I've made the commits, and so I may as well at least put them here as a PR (if for no other reason than to save anyone else making an independent PR to do this).

### 1. Use `Pluralize` in semigroup `ViewString`s rather than manually constructing the correct pluralisation

This reduces code duplication slightly.

Unfortunately, this will break the tests in (at least) the Semigroups package. The current `ViewString` behaviour adds control characters around the word `generator{s}`, i.e. `\>generators\<`, but `Pluralize` does not do this. Perhaps someone more knowledge with control characters than me can tell me which of these behaviours is preferable. The result of this difference can sometimes be seen with the final "n generators" in the `ViewStrings` here:

In `master`:
```
<Rees matrix semigroup 2x1 over <transformation semigroup of degree 2 with 2 
  generators>>
```
With this PR:
```
<Rees matrix semigroup 2x1 over <transformation semigroup of degree 2 with 
  2 generators>>
```
To make this change compatible with the Semigroups package, either a _lot_ of output needs to be suppressed in its tests, or Semigroups needs to test up to whitespace only. There are possibly other, more hacky, solutions.

This may well affect other packages too, so perhaps it is not worth making this change.


### 2. Use the correct pluralisation of "argument" in the message given for a 'no method found' error

Like the changes #4050, this makes GAP more grammatically correct. Unfortunately, it will break the tests of any package that tests for a 'no method found' error for a function on 1 argument (GAP itself has several such tests, which I update in this PR). In particular, this will break the tests of the Semigroups and Digraphs packages.

It is not see easy to work around this in packages, since 'argument' → 'arguments' is not a whitespace change, and suppressing the output of an error message is neither useful nor possible, as far as I'm aware. You could argue that testing for a 'no method found' error is not a useful test, but I'm not so sure about that.

So again, perhaps it is not worth making this change.