### PR TITLE
Fix an implication to `IsSemiband`

### DIFF
--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -655,38 +655,68 @@ DeclareAttribute("NilpotencyDegree", IsSemigroup);
 DeclareOperation("IsSubsemigroup", [IsSemigroup, IsSemigroup]);
 
 DeclareProperty("IsBand", IsSemigroup);
+
 DeclareProperty("IsBrandtSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsBrandtSemigroup);
+
 DeclareProperty("IsCliffordSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsCliffordSemigroup);
+
 DeclareProperty("IsCommutativeSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsCommutativeSemigroup);
+
 DeclareProperty("IsCompletelyRegularSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsCompletelyRegularSemigroup);
+
 DeclareProperty("IsCompletelySimpleSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsCompletelySimpleSemigroup);
+
 DeclareProperty("IsGroupAsSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsGroupAsSemigroup);
+
 DeclareProperty("IsIdempotentGenerated", IsSemigroup);
+
 DeclareProperty("IsLeftZeroSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsLeftZeroSemigroup);
+
 DeclareProperty("IsMonogenicSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsMonogenicSemigroup);
+
 DeclareProperty("IsMonoidAsSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsMonoidAsSemigroup);
+
 DeclareProperty("IsNilpotentSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsNilpotentSemigroup);
+
 DeclareProperty("IsOrthodoxSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsOrthodoxSemigroup);
+
 DeclareProperty("IsRectangularBand", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsRectangularBand);
+
 DeclareProperty("IsRightZeroSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsRightZeroSemigroup);
+
 DeclareProperty("IsSemiband", IsSemigroup);
 InstallTrueMethod(IsSemigroup, IsSemiband);
 
 DeclareProperty("IsSemilattice", IsSemigroup);
+
 DeclareProperty("IsZeroSemigroup", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsZeroSemigroup);
 
 InstallTrueMethod(IsMonoidAsSemigroup, IsMagmaWithOne and IsSemigroup);
 InstallTrueMethod(IsGroupAsSemigroup, IsMagmaWithInverses and IsSemigroup);
 InstallTrueMethod(IsGroupAsSemigroup, IsInverseSemigroup and IsSimpleSemigroup and IsFinite);
 InstallTrueMethod(IsGroupAsSemigroup, IsCommutative and IsSimpleSemigroup);
-InstallTrueMethod(IsBand, IsSemilattice);
+InstallTrueMethod(IsBand, IsSemilattice and IsSemigroup);
 InstallTrueMethod(IsBrandtSemigroup, IsInverseSemigroup and IsZeroSimpleSemigroup);
-InstallTrueMethod(IsCliffordSemigroup, IsSemilattice);
+InstallTrueMethod(IsCliffordSemigroup, IsSemilattice and IsSemigroup);
 InstallTrueMethod(IsCompletelyRegularSemigroup, IsCliffordSemigroup);
 InstallTrueMethod(IsCompletelyRegularSemigroup, IsSimpleSemigroup);
 InstallTrueMethod(IsCompletelySimpleSemigroup, IsSimpleSemigroup and IsFinite);
-InstallTrueMethod(IsIdempotentGenerated, IsBand);
-InstallTrueMethod(IsInverseSemigroup, IsSemilattice);
+InstallTrueMethod(IsIdempotentGenerated, IsBand and IsSemigroup);
+InstallTrueMethod(IsInverseSemigroup, IsSemilattice and IsSemigroup);
 InstallTrueMethod(IsInverseSemigroup, IsCliffordSemigroup);
 InstallTrueMethod(IsInverseSemigroup, IsGroupAsSemigroup);
 InstallTrueMethod(IsLeftZeroSemigroup, IsInverseSemigroup and IsTrivial);
@@ -695,7 +725,7 @@ InstallTrueMethod(IsRegularSemigroup, IsSimpleSemigroup);
 InstallTrueMethod(IsOrthodoxSemigroup, IsInverseSemigroup);
 InstallTrueMethod(IsRightZeroSemigroup, IsInverseSemigroup and IsTrivial);
 InstallTrueMethod(IsSemiband, IsIdempotentGenerated and IsSemigroup);
-InstallTrueMethod(IsSemilattice, IsCommutative and IsBand);
+InstallTrueMethod(IsSemilattice, IsSemigroup and IsCommutative and IsBand);
 InstallTrueMethod(IsSimpleSemigroup, IsGroupAsSemigroup);
 InstallTrueMethod(IsZeroSemigroup, IsInverseSemigroup and IsTrivial);
 

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -670,6 +670,8 @@ DeclareProperty("IsOrthodoxSemigroup", IsSemigroup);
 DeclareProperty("IsRectangularBand", IsSemigroup);
 DeclareProperty("IsRightZeroSemigroup", IsSemigroup);
 DeclareProperty("IsSemiband", IsSemigroup);
+InstallTrueMethod(IsSemigroup, IsSemiband);
+
 DeclareProperty("IsSemilattice", IsSemigroup);
 DeclareProperty("IsZeroSemigroup", IsSemigroup);
 
@@ -692,7 +694,7 @@ InstallTrueMethod(IsRegularSemigroup, IsInverseSemigroup);
 InstallTrueMethod(IsRegularSemigroup, IsSimpleSemigroup);
 InstallTrueMethod(IsOrthodoxSemigroup, IsInverseSemigroup);
 InstallTrueMethod(IsRightZeroSemigroup, IsInverseSemigroup and IsTrivial);
-InstallTrueMethod(IsSemiband, IsIdempotentGenerated);
+InstallTrueMethod(IsSemiband, IsIdempotentGenerated and IsSemigroup);
 InstallTrueMethod(IsSemilattice, IsCommutative and IsBand);
 InstallTrueMethod(IsSimpleSemigroup, IsGroupAsSemigroup);
 InstallTrueMethod(IsZeroSemigroup, IsInverseSemigroup and IsTrivial);

--- a/tst/testbugfix/2021-03-25-IsSemiband.tst
+++ b/tst/testbugfix/2021-03-25-IsSemiband.tst
@@ -1,0 +1,12 @@
+#
+gap> tab := [[4, 2, 1, 4], [2, 2, 2, 3], [2, 4, 3, 1], [4, 1, 1, 4]];;
+gap> m := MagmaByMultiplicationTable(tab);;
+gap> m = Submagma(m, Filtered(m, IsIdempotent));
+true
+gap> SetIsIdempotentGenerated(m, true);
+gap> not (HasIsSemiband(m) and IsSemiband(m));
+true
+gap> IsAssociative(m);
+false
+gap> IsSemigroup(m);
+false


### PR DESCRIPTION
...and add implications of semigroup-only properties to `IsSemigroup`.

Previously, there was a true method:
```
InstallTrueMethod(IsSemiband, IsIdempotentGenerated);
```
since if a semigroup is idempotent generated, it is a semiband (in fact, in and only if - but I'll deal with that later), and `IsIdempotentGenerated` is _currently_ only declared for `IsSemigroup`. So currently this _should_ only ever set `IsSemiband` to be `true` for idempotent generated semigroups. But someone may well want to declare it for `IsMagma`, and a non-associative magma cannot be a semiband, whether or not it is idempotent generated. That's because a semiband is a special kind of semigroup.

Currently, you can force this mathematically incorrect situation to happen:
```
gap> tab := [[4, 2, 1, 4], [2, 2, 2, 3], [2, 4, 3, 1], [4, 1, 1, 4]];;
gap> m := MagmaByMultiplicationTable(tab);;
gap> m = Submagma(m, Filtered(m, IsIdempotent));
true
gap> SetIsIdempotentGenerated(m, true);
gap> IsSemigroup(m);
false
gap> IsSemiband(m);
true
```
In this first commit of this PR, I change the true method to:
```
InstallTrueMethod(IsSemiband, IsIdempotentGenerated and IsSemigroup);
```
and added a bugfix test file.

I don't think this needs to be mentioned in the release notes (it's arguably more a potential bug than a bug...) but I'm happy to change the label and add some text for the release notes if you prefer.

In a second commit, I added `InstallTrueMethod(IsSemigroup, <property>);` for all the remaining semigroup properties in `lib/semigrp.gd` to which it mathematically applies – which was in fact all of them, except for `IsIdempotentGenerated` – even though some of them are surely redundant because of the other true methods installed at the bottom of the file.

I will review and probably clean up/add to those latter true methods in a later PR.