### PR TITLE
Restore CopySubVector argument order to it original state

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -653,8 +653,8 @@ InstallMethod( ExtractSubMatrix,
 
 InstallMethod( CopySubVector,
     "generic method for vector objects",
-  [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList ],
-  function(dst, dcols, src, scols)
+  [ IsVectorObj, IsVectorObj and IsMutable, IsList, IsList ],
+  function(src, dst, scols, dcols)
     local i;
     if not Length( dcols ) = Length( scols ) then
       Error( "source and destination index lists must be of equal length" );
@@ -1544,13 +1544,6 @@ InstallMethod( DimensionsMat,
     "for a matrix object",
     [ IsMatrixObj ],
     M -> [ NumberRows( M ), NumberColumns( M ) ] );
-
-InstallMethod( CopySubVector,
-    "generic method for vector objects",
-    [ IsVectorObj, IsVectorObj and IsMutable, IsList, IsList ],
-    function( src, dst, scols, dcols )
-    CopySubVector( dst, dcols, src, scols );
-    end );
 
 InstallOtherMethod( Randomize,
     "for random source as 2nd argument: switch arguments",

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -908,11 +908,11 @@ DeclareOperation( "Randomize", [ IsRandomSource, IsMatrixObj and IsMutable ] );
 
 #############################################################################
 ##
-#O  CopySubVector( <dst>, <dcols>, <src>, <scols> )
+#O  CopySubVector( <src>, <dst>, <scols>, <dcols> )
 ##
 ##  <#GAPDoc Label="CopySubVector">
 ##  <ManSection>
-##  <Oper Name="CopySubVector" Arg='dst, dcols, src, scols'/>
+##  <Oper Name="CopySubVector" Arg='src, dst, scols, dcols'/>
 ##
 ##  <Returns>nothing</Returns>
 ##
@@ -936,7 +936,8 @@ DeclareOperation( "Randomize", [ IsRandomSource, IsMatrixObj and IsMutable ] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "CopySubVector",
-    [ IsVectorObj and IsMutable, IsList, IsVectorObj, IsList ] );
+    [ IsVectorObj, IsVectorObj and IsMutable, IsList, IsList ] );
+
 
 
 #############################################################################
@@ -1786,14 +1787,6 @@ DeclareConstructor( "NewCompanionMatrix",
 #O  NewRowVector( ... )
 ##
 DeclareSynonym( "NewRowVector", NewVector );
-
-
-#############################################################################
-##
-#O  CopySubVector( ... )
-##
-DeclareOperation( "CopySubVector",
-    [ IsVectorObj, IsVectorObj and IsMutable, IsList, IsList ] );
 
 
 #############################################################################

--- a/tst/testinstall/MatrixObj/CopySubVector.tst
+++ b/tst/testinstall/MatrixObj/CopySubVector.tst
@@ -1,4 +1,7 @@
+#@local l1, v1, l2, v2, v3, v4
 gap> START_TEST("CopySubVector.tst");
+
+#
 gap> l1 := [1,2,3,4,5,6];
 [ 1, 2, 3, 4, 5, 6 ]
 gap> v1 := Vector(IsPlistVectorRep, Rationals, l1);
@@ -7,14 +10,18 @@ gap> l2 := [1,1,1,2,2,2,3,3,3];
 [ 1, 1, 1, 2, 2, 2, 3, 3, 3 ]
 gap> v2 := Vector(IsPlistVectorRep, Rationals, l2);
 <plist vector over Rationals of length 9>
-gap> CopySubVector( v1, [2,4,6], v2, [1,2,4] );
+gap> CopySubVector( v2, v1, [1,2,4], [2,4,6] );
 gap> Unpack(v1);
 [ 1, 1, 3, 1, 5, 2 ]
+
+#
 gap> v3 := Vector(GF(5), l1*One(GF(5)));
 [ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
 gap> v4 := Vector(GF(5), l2*One(GF(5)));
 [ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3 ]
-gap> CopySubVector( v4, [2,4,6], v3, [1,2,3] );
+gap> CopySubVector( v3, v4, [1,2,3], [2,4,6] );
 gap> v4;
 [ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3, Z(5)^3 ]
-gap> STOP_TEST("CopySubVector.tst",1);
+
+#
+gap> STOP_TEST("CopySubVector.tst");


### PR DESCRIPTION
During a MatrixObj design discussion some time (... years *sighs) ago, we
decided to change the order of the arguments of `CopySubVector` to make them
fit better with the rest of the API.

The idea was to do this in a backwards compatible way, so that existing
calling code would keep working.

However, in reality, this compatibility is flawed (as soon you operate on
integer vectors, it is ambiguous), and we only changed the documentation,
added a compatibility method, and changed 1-2 other places -- but we didn't
even complete the conversion in the GAP library, let alone in any of the
packages using this (and then of course users may have code we never will see
that also uses it).

I run into this when I wanted to use CopySubVector in some GAP library code,
and run into errors...

At this point, it seems prudent to just go back to how things were: yes,
the new argument might be "better", and if this was new code, I'd go for it;
but it doesn't seem worth the hassle to do it properly. If we really care,
we should instead come up with a new name for that function... but I'll leave
that thought for someone else or at for some other day.
