### PR TITLE
CI: rename a script, tweak phrasing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,4 +51,4 @@ test_script:
 on_success:
   # make sure to use AppVeyor's Python (not Cygwin's) in the next step
   - bash -lc "export PATH="/cygdrive/c/Python27:/cygdrive/c/Python27/Scripts:$PATH" ; cd $APPVEYOR_BUILD_FOLDER && ./dev/ci-gather-coverage.sh"
-  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./dev/ci-run-codecov.sh"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./dev/ci-upload-coverage.sh"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -208,10 +208,10 @@ jobs:
             doc/*/*.html
             doc/*/*.css
             doc/*/*.js
-      - name: "Gather coverage"
+      - name: "Gather coverage data"
         run: ${{ matrix.extra }} bash dev/ci-gather-coverage.sh
-      - name: "Upload coverage data to codecov"
-        run: ${{ matrix.extra }} bash dev/ci-run-codecov.sh
+      - name: "Upload coverage data"
+        run: ${{ matrix.extra }} bash dev/ci-upload-coverage.sh
       # - uses: codecov/codecov-action@v1
 
       # TODO: fix coveralls integration

--- a/dev/ci-gather-coverage.sh
+++ b/dev/ci-gather-coverage.sh
@@ -114,11 +114,3 @@ then
 
   python dev/ci-coveralls-merge.py
 fi
-
-# upload to coveralls.io
-# TODO: perhaps fold into python script?
-if [[ -f merged-coveralls.json ]]
-then
-  curl -F json_file=@merged-coveralls.json "https://coveralls.io/api/v1/jobs"
-fi
-

--- a/dev/ci-run-codecov.sh
+++ b/dev/ci-run-codecov.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set +ex
-set +H
-
-curl -s https://codecov.io/bash > codecov.sh
-chmod +x codecov.sh
-./codecov.sh -f '!./pkg/*' -f '!./extern/*' -f '!./build/*'
-

--- a/dev/ci-upload-coverage.sh
+++ b/dev/ci-upload-coverage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set +ex
+set +H
+
+# upload to coveralls.io
+# TODO: perhaps fold into python script?
+if [[ -f merged-coveralls.json ]]
+then
+  curl -F json_file=@merged-coveralls.json "https://coveralls.io/api/v1/jobs"
+fi
+
+# upload to Codecov
+curl -s https://codecov.io/bash > codecov.sh
+chmod +x codecov.sh
+./codecov.sh -f '!./pkg/*' -f '!./extern/*' -f '!./build/*'


### PR DESCRIPTION
Instead of referring to Codecov all the time, leave it a bit open; after all, we hopefully can add back Coveralls integration, then this is more appropriate.

Also move the code for uploading coverage data to coveralls.io into the (now) appropriate script.