### PR TITLE
Update ctags.readme.txt

### DIFF
--- a/etc/ctags.readme.md
+++ b/etc/ctags.readme.md
@@ -1,0 +1,69 @@
+# Ctags for GAP
+
+This file describes how to set up Ctags to work with GAP source files.
+Ctags is a tool that can be used to generate an index file of names found in
+source files. This index file can then be used by editors to jump to the
+definition of any indexed name.
+
+Note that if you have Exuberant Ctags installed (if in doubt, run `ctags --version`)
+and only want to generate tags for the gap-system/gap repository, then you do
+not need set up anything. The symlink `.ctags` in the GAP root folder already
+tells ctags all it needs to know, and you can create and update the tags by
+running:
+
+    make tags
+
+If you want to use ctags in another GAP project or have Universal Ctags
+installed, read on.
+
+Run
+
+  ctags --version
+
+to see whether you are running Exuberant Ctags or Universal Ctags.
+Append the content of the file `ctags_for_gap` to the file
+
+    ~/.ctags
+
+if you are running Exuberant Ctags. If you are running Universal Ctags then
+append the content of the file `ctags_for_gap` to the file
+
+    $XDG_CONFIG_HOME/ctags/gap.ctags
+
+or
+
+    $HOME/.config/ctags/gap.ctags
+
+if `$XDG_CONFIG_HOME` is not defined.
+Then run
+
+    ctags --recurse lib/ src/
+
+in the GAP installation directory. If you are running ctags in another project,
+you may have to do
+
+    ctags --recurse gap/ src/
+
+instead. This creates a file
+
+    tags
+
+Many editors support ctags either natively or via a plugin (e.g. vim, emacs,
+BBEdit, ...). For example, to use it in vim, start vim in the GAP root directory and
+do
+
+    :tag <function-name>
+
+or, while your cursor is on the name of that function, press `<CTRL-]>`
+to jump to the first definition of that function. If for example an operation has
+several several methods installed, you can also do
+
+    :ts <function-name>
+
+or press `<g]>` or to get an overview over all tags found.
+
+For instructions on how to regenerate tags automatically via git-hooks, for example
+when running git commit, git clone, etc., you can have a look at:
+
+    https://tbaggery.com/2011/08/08/effortless-ctags-with-git.html
+

--- a/etc/ctags.readme.txt
+++ b/etc/ctags.readme.txt
@@ -1,9 +1,0 @@
-Append the content of the file ctags_for_gap to ~/.ctags and then run
-  ctags --sort=no lib/*.g lib/*.gi lib/*.gd src/*
-in the GAP installation directory. Start your editor
-in that directory and then do (for vim e.g.):
-  :tag DerivedSubgroup
-(say). You can also use
-  :ts DerivedSubgroup
-to get an overview over all tags found (which is useful since it shows
-for example all method installations).

--- a/etc/ctags.readme.txt
+++ b/etc/ctags.readme.txt
@@ -1,4 +1,4 @@
-Copy the file ctags_for_gap to ~/.ctags and then run
+Append the content of the file ctags_for_gap to ~/.ctags and then run
   ctags --sort=no lib/*.g lib/*.gi lib/*.gd src/*
 in the GAP installation directory. Start your editor
 in that directory and then do (for vim e.g.):


### PR DESCRIPTION
- Clarify ctags.readme.txt

Clarify that the content of ctags_for_gap goes into a file `~/.ctags`.
The previous explanation could also be read as "copy the file
ctags_for_gap into a directory ~/.ctags".

- Update ctags.readme.txt

Add instructions for usage with Universal Ctags.

Add a link to instructions on how to create tags via git hooks.

# Description

## Further details

I misread the instruction in `etc/ctags.readme.txt`. While that was my mistake, I think the formulation I suggest in the first commit makes it more clear that `~/.ctags` should be a file and not a directory.

In the second commit I update the instructions such that they also apply to Universal Ctags.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code


