### PR TITLE
Increase robustness of a test relying on timing

### DIFF
--- a/tst/testbugfix/2006-08-28-t00151.tst
+++ b/tst/testbugfix/2006-08-28-t00151.tst
@@ -1,13 +1,17 @@
 # 2006/08/28 (FL)
 gap> time1 := 0;;
+gap> CollectGarbage(true);
 gap> for j in [1..20] do
 > l:=List([1..100000],i->[i]);
+> CollectGarbage(false);
 > t1:=Runtime(); for i in [1..100000] do a := PositionSorted(l,[i]); od; t2:=Runtime();
 > time1 := time1 + (t2-t1);
 > od;
 gap> time2 := 0;;
+gap> CollectGarbage(true);
 gap> for j in [1..20] do
 > l := Immutable( List([1..100000],i->[i]) );
+> CollectGarbage(false);
 > t1:=Runtime(); for i in [1..100000] do a := PositionSorted(l,[i]); od; t2:=Runtime();
 > time2 := time2 + (t2-t1);
 > od;


### PR DESCRIPTION
The test modified by this patch executes two similar loops several times and
compares the resulting timings; if they differ too much, the test fails.
However, garbage collections can have quite an impact, which lead to an
incorrect failure.

So trigger explicit full and partial garbage collections at specific points,
to reduce seemingly random difference between the two.

This may or may not help with issue #4368...