### PR TITLE
Check arguments to `FreeSemigroup` more thoroughly

### DIFF
--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -277,11 +277,10 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 
 #############################################################################
 ##
-#F  FreeSemigroup( [<wfilt>,]<rank> )
-#F  FreeSemigroup( [<wfilt>,]<rank>, <name> )
-#F  FreeSemigroup( [<wfilt>,]<name1>, <name2>, ... )
-#F  FreeSemigroup( [<wfilt>,]<names> )
-#F  FreeSemigroup( [<wfilt>,]infinity, <name>, <init> )
+#F  FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+#F  FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+#F  FreeSemigroup( [<wfilt>, ]<names> )
+#F  FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
 ##
 ##  <#GAPDoc Label="FreeSemigroup">
 ##  <ManSection>
@@ -292,17 +291,18 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##   Label="for various names"/>
 ##  <Func Name="FreeSemigroup" Arg='[wfilt, ]names'
 ##   Label="for a list of names"/>
-##  <Func Name="FreeSemigroup" Arg='[wfilt, ]infinity, name, init'
+##  <Func Name="FreeSemigroup" Arg='[wfilt, ]infinity[, name[, init]]'
 ##   Label="for infinitely many generators"/>
 ##
 ##  <Description>
 ##  Called with a positive integer <A>rank</A>,
 ##  <Ref Func="FreeSemigroup" Label="for given rank"/> returns
 ##  a free semigroup on <A>rank</A> generators.
-##  If the optional argument <A>name</A> is given then the generators are
+##  If the optional argument <A>name</A> (a string) is given,
+##  then the generators are
 ##  printed as <A>name</A><C>1</C>, <A>name</A><C>2</C> etc.,
 ##  that is, each name is the concatenation of the string <A>name</A> and an
-##  integer from <C>1</C> to <A>range</A>.
+##  integer from <C>1</C> to <A>rank</A>.
 ##  The default for <A>name</A> is the string <C>"s"</C>.
 ##  <P/>
 ##  Called in the second form,

--- a/tst/testbugfix/2021-04-08-empty-FreeSemigroup.tst
+++ b/tst/testbugfix/2021-04-08-empty-FreeSemigroup.tst
@@ -1,0 +1,11 @@
+# See https://github.com/gap-system/gap/issues/1385
+gap> FreeSemigroup();
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup([]);
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup("");
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup(0);
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup(0, "name");
+Error, free semigroups of rank zero are not supported

--- a/tst/testinstall/smgrpfre.tst
+++ b/tst/testinstall/smgrpfre.tst
@@ -1,0 +1,127 @@
+#@local F
+gap> START_TEST("smgrpfre.tst");
+
+# FreeSemigroup
+gap> FreeSemigroup(fail);
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+
+# FreeSemigroup: rank 0
+gap> FreeSemigroup();
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup([]);
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup("");
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup(0);
+Error, free semigroups of rank zero are not supported
+gap> FreeSemigroup(0, "name");
+Error, free semigroups of rank zero are not supported
+
+# FreeSemigroup(infinity[, name[, init]])
+gap> FreeSemigroup(infinity);
+<free semigroup on the generators [ s1, s2, ... ]>
+gap> FreeSemigroup(infinity, fail);
+Error, FreeSemigroup( infinity, <name> ): <name> must be a string
+gap> FreeSemigroup(infinity, []);
+<free semigroup on the generators [ 1, 2, ... ]>
+gap> FreeSemigroup(infinity, "");
+<free semigroup on the generators [ 1, 2, ... ]>
+gap> FreeSemigroup(infinity, "nicename");
+<free semigroup on the generators [ nicename1, nicename2, ... ]>
+gap> FreeSemigroup(infinity, fail, fail);
+Error, FreeSemigroup( infinity, <name>, <init> ): <name> must be a string and \
+<init> must be a list of nonempty strings
+gap> FreeSemigroup(infinity, "nicename", fail);
+Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a list of non\
+empty strings
+gap> FreeSemigroup(infinity, "gen", []);
+<free semigroup on the generators [ gen1, gen2, ... ]>
+gap> FreeSemigroup(infinity, "gen", [""]);
+Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a list of non\
+empty strings
+gap> FreeSemigroup(infinity, "gen", ["starter"]);
+<free semigroup on the generators [ starter, gen2, ... ]>
+gap> FreeSemigroup(infinity, "gen", ["starter", ""]);
+Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a list of non\
+empty strings
+gap> F := FreeSemigroup(infinity, "gen", ["starter", "second", "third"]);
+<free semigroup on the generators [ starter, second, ... ]>
+gap> GeneratorsOfSemigroup(F){[1 .. 4]};
+[ starter, second, third, gen4 ]
+gap> FreeSemigroup(infinity, "gen", ["starter"], fail);
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+
+# FreeSemigroup(rank[, name])
+gap> F := FreeSemigroup(1);
+<free semigroup on the generators [ s1 ]>
+gap> HasIsCommutative(F) and IsCommutative(F);
+true
+gap> F := FreeSemigroup(2);
+<free semigroup on the generators [ s1, s2 ]>
+gap> HasIsCommutative(F) and not IsCommutative(F);
+true
+gap> F := FreeSemigroup(10);
+<free semigroup on the generators [ s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 ]>
+gap> F := FreeSemigroup(3, fail);
+Error, FreeSemigroup( <rank>, <name> ): <name> must be a string
+gap> F := FreeSemigroup(4, "");
+<free semigroup on the generators [ 1, 2, 3, 4 ]>
+gap> F := FreeSemigroup(5, []);
+<free semigroup on the generators [ 1, 2, 3, 4, 5 ]>
+gap> F := FreeSemigroup(4, "cheese");
+<free semigroup on the generators [ cheese1, cheese2, cheese3, cheese4 ]>
+gap> FreeSemigroup(3, "car", fail);
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+
+# FreeSemigroup( <name1>[, <name2>, ...] )
+gap> FreeSemigroup("", "second");
+Error, FreeSemigroup( <name1>, <name2>, ... ): the names must be nonempty stri\
+ngs
+gap> FreeSemigroup("first", "");
+Error, FreeSemigroup( <name1>, <name2>, ... ): the names must be nonempty stri\
+ngs
+gap> FreeSemigroup("first", []);
+Error, FreeSemigroup( <name1>, <name2>, ... ): the names must be nonempty stri\
+ngs
+gap> FreeSemigroup([], []);
+Error, FreeSemigroup( <name1>, <name2>, ... ): the names must be nonempty stri\
+ngs
+gap> FreeSemigroup("bacon", "eggs", "beans");
+<free semigroup on the generators [ bacon, eggs, beans ]>
+gap> FreeSemigroup("shed");
+<free semigroup on the generators [ shed ]>
+
+# FreeSemigroup( [ <name1>[, <name2>, ...] ] )
+gap> FreeSemigroup(["", "second"]);
+Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
+strings
+gap> FreeSemigroup(["first", ""]);
+Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
+strings
+gap> FreeSemigroup(["first", []]);
+Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
+strings
+gap> FreeSemigroup([[], []]);
+Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
+strings
+gap> FreeSemigroup(["bacon", "eggs", "beans"]);
+<free semigroup on the generators [ bacon, eggs, beans ]>
+gap> FreeSemigroup(["grid"]);
+<free semigroup on the generators [ grid ]>
+gap> FreeSemigroup(["grid"], fail);
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+
+#
+gap> STOP_TEST( "smgrpfre.tst", 1);


### PR DESCRIPTION
See https://github.com/gap-system/gap/issues/1385.

It was previously possible to use `FreeSemigroup` to create a seemingly free semigroup with zero generators (rank zero), but this object believed itself to be infinite, and to contain elements (such a semigroup would be empty). Note that free semigroups of rank zero are not documented as being supported.

Some other ways that one might want to create free semigroups of rank zero led to unhelpful error messages, and in general, the argument checking of `FreeSemigroup` was not very thorough and gave sometimes unhelpful error messages.

In this commit, I overhaul the way that `FreeSemigroup` checks its arguments, in particular always disallowing a free semigroup of rank zero, and overall making the checking more robust, and making the error messages more descriptive.

This addresses the _bugs_ reported in issue #1385, although it does not address the _feature request_ in that issue to support free semigroups of rank zero.

I also took the opportunity to fix a typo in the documentation for `FreeSemigroup`, and to make a clarification. Further improvements could be made to this documentation, but I leave that to the future.

# Description

## Text for release notes

Fix bugs caused when calling `FreeSemigroup` with incorrect arguments.

## (End of text for release notes)