### PR TITLE
Add associativity check to `AsSemigroup` & declare `IsCommutative`/`IsAssociative` for `IsCollection`

### DIFF
--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -485,14 +485,16 @@ DeclareAttribute( "TrivialSubmagmaWithOne", IsMagmaWithOne );
 
 #############################################################################
 ##
-#P  IsAssociative( <M> )  . . . . . . . . test whether a magma is associative
+#P  IsAssociative( <M> )  . . . . .  test whether a collection is associative
 ##
 ##  <#GAPDoc Label="IsAssociative">
 ##  <ManSection>
 ##  <Prop Name="IsAssociative" Arg='M'/>
 ##
 ##  <Description>
-##  A magma <A>M</A> is <E>associative</E> if for all elements
+##  A collection <A>M</A> of elements that can be multiplied via
+##  <Ref Oper="\*"/>
+##  is <E>associative</E> if for all elements
 ##  <M>a, b, c \in</M> <A>M</A> the equality
 ##  <M>(a</M><C> * </C><M>b)</M><C> * </C><M>c =
 ##  a</M><C> * </C><M>(b</M><C> * </C><M>c)</M> holds.
@@ -507,10 +509,9 @@ DeclareAttribute( "TrivialSubmagmaWithOne", IsMagmaWithOne );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsAssociative", IsMagma );
+DeclareProperty( "IsAssociative", IsCollection );
 
-InstallTrueMethod( IsAssociative,
-    IsAssociativeElementCollection and IsMagma );
+InstallTrueMethod( IsAssociative, IsAssociativeElementCollection );
 
 InstallSubsetMaintenance( IsAssociative,
     IsMagma and IsAssociative, IsMagma );

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -524,7 +524,7 @@ InstallTrueMethod( IsAssociative, IsMagma and IsTrivial );
 
 #############################################################################
 ##
-#P  IsCommutative( <M> )  . . . . . . . . test whether a magma is commutative
+#P  IsCommutative( <M> )  . . . . .  test whether a collection is commutative
 #P  IsAbelian( <M> )
 ##
 ##  <#GAPDoc Label="IsCommutative">
@@ -533,7 +533,9 @@ InstallTrueMethod( IsAssociative, IsMagma and IsTrivial );
 ##  <Prop Name="IsAbelian" Arg='M'/>
 ##
 ##  <Description>
-##  A magma <A>M</A> is <E>commutative</E> if for all elements
+##  A collection <A>M</A> of elements that can be multiplied via
+##  <Ref Oper="\*"/>
+##  is <E>commutative</E> if for all elements
 ##  <M>a, b \in</M> <A>M</A> the
 ##  equality <M>a</M><C> * </C><M>b = b</M><C> * </C><M>a</M> holds.
 ##  <Ref Prop="IsAbelian"/> is a synonym of <Ref Prop="IsCommutative"/>.
@@ -545,12 +547,11 @@ InstallTrueMethod( IsAssociative, IsMagma and IsTrivial );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsCommutative", IsMagma );
+DeclareProperty( "IsCommutative", IsCollection );
 
 DeclareSynonymAttr( "IsAbelian", IsCommutative );
 
-InstallTrueMethod( IsCommutative,
-    IsCommutativeElementCollection and IsMagma );
+InstallTrueMethod( IsCommutative, IsCommutativeElementCollection );
 
 InstallSubsetMaintenance( IsCommutative,
     IsMagma and IsCommutative, IsMagma );

--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -162,7 +162,7 @@ InstallMethod( IsAssociative,
 
 #############################################################################
 ##
-#M  IsCommutative( <M> )  . . . . . . . . test whether a magma is commutative
+#M  IsCommutative( <M> )  . . . . .  test whether a collection is commutative
 ##
 InstallImmediateMethod( IsCommutative,
     IsMagma and IsAssociative and HasGeneratorsOfMagma, 0,
@@ -196,6 +196,26 @@ InstallMethod( IsCommutative,true,
       TryNextMethod();
     fi;
     end );
+
+InstallMethod( IsCommutative,
+    "for a collection",
+    [ IsCollection ],
+    function( C )
+      local elms, n, x, y, i, j;
+
+      elms:= Enumerator( C );
+      n := Length( elms );
+      for i in [ 1 .. n ] do
+        for j in [ i + 1 .. n ] do
+          x := elms[ i ];
+          y := elms[ j ];
+          if x * y <> y * x then
+            return false;
+          fi;
+        od;
+      od;
+      return true;
+    end);
 
 InstallMethod( IsCommutative,
     "for a magma",

--- a/lib/magma.gi
+++ b/lib/magma.gi
@@ -133,12 +133,11 @@ InstallMethod( IsTrivial,
 
 #############################################################################
 ##
-#M  IsAssociative( <M> )  . . . . . . . . test whether a magma is associative
+#M  IsAssociative( <M> )  . . . . .  test whether a collection is associative
 ##
 InstallMethod( IsAssociative,
-    "for a magma",
-    true,
-    [ IsMagma ], 0,
+    "for a collection",
+    [ IsCollection ],
     function( M )
 
     local elms,      # list of elements

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -175,6 +175,7 @@ DeclareOperation( "SemigroupByGenerators", [ IsCollection ] );
 ##
 ##  <Description>
 ##  If <A>C</A> is a collection whose elements form a semigroup
+##  under <Ref Oper="\*"/>
 ##  (see&nbsp;<Ref Filt="IsSemigroup"/>) then <Ref Oper="AsSemigroup"/>
 ##  returns this semigroup.
 ##  Otherwise <K>fail</K> is returned.

--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -544,6 +544,10 @@ InstallMethod( AsSemigroup,
     function ( D )
     local   S,  L;
 
+    if not IsAssociative( D ) then
+      return fail;
+    fi;
+
     D := AsSSortedList( D );
     L := ShallowCopy( D );
     S := Submagma( SemigroupByGenerators( D ), [] );

--- a/tst/testbugfix/2021-04-08-non-associative-semigroup.tst
+++ b/tst/testbugfix/2021-04-08-non-associative-semigroup.tst
@@ -1,0 +1,52 @@
+# https://github.com/gap-system/gap/issues/4030
+#
+gap> T := [
+>   [ 1, 2, 6, 5, 4, 3 ],
+>   [ 2, 1, 4, 2, 2, 5 ],
+>   [ 6, 5, 1, 6, 6, 4 ],
+>   [ 5, 6, 3, 4, 1, 2 ],
+>   [ 4, 3, 2, 1, 5, 6 ],
+>   [ 3, 4, 5, 3, 3, 1 ]
+> ];;
+gap> M := MagmaByMultiplicationTable(T);
+<magma with 6 generators>
+gap> IsAssociative(M);
+false
+gap> AsSemigroup(M);
+fail
+gap> M := MagmaByMultiplicationTable(T);
+<magma with 6 generators>
+gap> AsSemigroup(M);
+fail
+gap> AsSemigroup(Elements(M));
+fail
+
+#
+gap> T := [
+>   [ 1, 2, 3, 4, 5 ],
+>   [ 2, 2, 2, 5, 5 ],
+>   [ 3, 2, 3, 4, 5 ],
+>   [ 4, 2, 4, 3, 5 ],
+>   [ 5, 2, 5, 2, 5 ]
+> ];;
+gap> M := MagmaByMultiplicationTable(T);
+<magma with 5 generators>
+gap> IsAssociative(M);
+true
+gap> S := AsSemigroup(M);;
+gap> IsSemigroup(S);
+true
+gap> Size(S);
+5
+gap> M := MagmaByMultiplicationTable(T);
+<magma with 5 generators>
+gap> S := AsSemigroup(M);;
+gap> IsSemigroup(S);
+true
+gap> Size(S);
+5
+gap> S := AsSemigroup(Elements(M));;
+gap> IsSemigroup(S);
+true
+gap> Size(S);
+5

--- a/tst/testinstall/magma.tst
+++ b/tst/testinstall/magma.tst
@@ -6,7 +6,7 @@ gap> M:= MagmaByMultiplicationTable( [ [ 1, 1 ], [ 1, 1 ] ] );;
 gap> IsGeneratorsOfMagmaWithInverses( Elements( M ) );
 false
 
-# IsAssociative
+# IsAssociative and IsCommutative
 gap> T := [
 >   [ 2, 4, 3, 4, 5 ],
 >   [ 3, 3, 2, 3, 3 ],
@@ -16,10 +16,12 @@ gap> T := [
 > ];;
 gap> M := MagmaByMultiplicationTable(T);
 <magma with 5 generators>
-gap> IsAssociative(M);
+gap> IsAssociative(M) or IsCommutative(M);
 false
 gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsAssociative(x));
 [ [ m5 ] ]
+gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsCommutative(x));
+[ [ m1 ], [ m1, m5 ], [ m2 ], [ m2, m5 ], [ m3 ], [ m3, m4 ], [ m4 ], [ m5 ] ]
 gap> T := [
 >   [ 1, 4, 3, 3, 2 ],
 >   [ 4, 2, 4, 4, 2 ],
@@ -29,15 +31,22 @@ gap> T := [
 > ];;
 gap> M := MagmaByMultiplicationTable(T);
 <magma with 5 generators>
-gap> IsAssociative(M);
+gap> IsAssociative(M) or IsCommutative(M);
 false
 gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsAssociative(x));
 [ [ m1 ], [ m1, m3 ], [ m2 ], [ m2, m4 ], [ m3 ], [ m4 ] ]
+gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsCommutative(x));
+[ [ m1 ], [ m1, m2 ], [ m1, m2, m3 ], [ m1, m2, m5 ], [ m1, m3 ], [ m1, m5 ], 
+  [ m2 ], [ m2, m3 ], [ m2, m4 ], [ m2, m5 ], [ m3 ], [ m4 ], [ m5 ] ]
 
 #
 gap> F := Elements( GL(2,2) );;
 gap> IsAssociative( F );
 true
+gap> IsCommutative( F );
+false
+gap> Number( Combinations( F, 3 ), IsCommutative );
+1
 
 #
 gap> STOP_TEST( "magma.tst" );

--- a/tst/testinstall/magma.tst
+++ b/tst/testinstall/magma.tst
@@ -1,9 +1,43 @@
+#@local M,T
 gap> START_TEST( "magma.tst" );
 
 #
 gap> M:= MagmaByMultiplicationTable( [ [ 1, 1 ], [ 1, 1 ] ] );;
 gap> IsGeneratorsOfMagmaWithInverses( Elements( M ) );
 false
+
+# IsAssociative
+gap> T := [
+>   [ 2, 4, 3, 4, 5 ],
+>   [ 3, 3, 2, 3, 3 ],
+>   [ 5, 5, 5, 4, 4 ],
+>   [ 5, 1, 4, 1, 1 ],
+>   [ 5, 3, 3, 4, 5 ]
+> ];;
+gap> M := MagmaByMultiplicationTable(T);
+<magma with 5 generators>
+gap> IsAssociative(M);
+false
+gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsAssociative(x));
+[ [ m5 ] ]
+gap> T := [
+>   [ 1, 4, 3, 3, 2 ],
+>   [ 4, 2, 4, 4, 2 ],
+>   [ 3, 4, 3, 4, 1 ],
+>   [ 1, 4, 5, 4, 3 ],
+>   [ 2, 2, 3, 5, 3 ]
+> ];;
+gap> M := MagmaByMultiplicationTable(T);
+<magma with 5 generators>
+gap> IsAssociative(M);
+false
+gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsAssociative(x));
+[ [ m1 ], [ m1, m3 ], [ m2 ], [ m2, m4 ], [ m3 ], [ m4 ] ]
+
+#
+gap> F := Elements( GL(2,2) );;
+gap> IsAssociative( F );
+true
 
 #
 gap> STOP_TEST( "magma.tst" );

--- a/tst/testinstall/magma.tst
+++ b/tst/testinstall/magma.tst
@@ -1,4 +1,4 @@
-#@local M,T
+#@local F,M,T
 gap> START_TEST( "magma.tst" );
 
 #
@@ -35,6 +35,10 @@ gap> IsAssociative(M) or IsCommutative(M);
 false
 gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsAssociative(x));
 [ [ m1 ], [ m1, m3 ], [ m2 ], [ m2, m4 ], [ m3 ], [ m4 ] ]
+gap> AsSemigroup([Elements(M)[1], Elements(M)[2]]);
+fail
+gap> AsSemigroup([Elements(M)[1], Elements(M)[3]]);
+<semigroup of size 2, with 2 generators>
 gap> Filtered(Combinations(Elements(M)), x -> Size(x) > 0 and IsCommutative(x));
 [ [ m1 ], [ m1, m2 ], [ m1, m2, m3 ], [ m1, m2, m5 ], [ m1, m3 ], [ m1, m5 ], 
   [ m2 ], [ m2, m3 ], [ m2, m4 ], [ m2, m5 ], [ m3 ], [ m4 ], [ m5 ] ]
@@ -47,6 +51,8 @@ gap> IsCommutative( F );
 false
 gap> Number( Combinations( F, 3 ), IsCommutative );
 1
+gap> AsSemigroup( F );
+<semigroup of size 6, with 2 generators>
 
 #
 gap> STOP_TEST( "magma.tst" );


### PR DESCRIPTION
See https://github.com/gap-system/gap/issues/4030.

It might not be fast, but I think it is necessary.

I thought about adding a similar check to `SemigroupByGenerators`, but that (via the documentation for `Semigroup`) is explicitly documented as not checking for associativity.

Fixes #4030.

## Text for release notes 

* Check for  associativity in `AsSemigroup`, and correctly return `fail` for non-associative collections, such as non-associative magmas.
* Declare `IsCommutative` and `IsAssociative` more generally for `IsCollection`, rather than just for `IsMagma`.

## (End of text for release notes)