### PR TITLE
CI: Do not install readline for macOS job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,7 @@ jobs:
                     singular
                     "
 
+          # this job also tests GAP without readline
           - os: macos-latest
             test-suites: "docomp testinstall"
             extra: "BOOTSTRAP_MINIMAL=yes"
@@ -183,7 +184,7 @@ jobs:
                    sudo apt-get update
                    sudo apt-get install "${packages[@]}"
                elif [ "$RUNNER_OS" == "macOS" ]; then
-                   brew install gmp readline zlib
+                   brew install gmp zlib
                else
                    echo "$RUNNER_OS not supported"
                    exit 1


### PR DESCRIPTION
Homebrew (currently) installs the readline stuff into `/usr/local/opt/readline`, but GAP does not know about this directory by default, and hence it was being compiled without readline – see https://github.com/gap-system/gap/runs/2288444515 for an example:
```
 ┌───────┐   GAP 4.12dev built on 2021-04-07 14:44:10+0000
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-apple-darwin19.6.0-default64-kv8
 Configuration:  gmp 6.2.1, GASMAN, KernelDebug
 Loading the library and packages ...
```
This is presumably counter to the intentions of whoever added the macOS job, because homebrew is being explicitly told to install readline. By adding this directory to `CONFIGFLAGS`, GAP compiles and starts with readline. Note that `CONFIGFLAGS` contains `--enable-debug` in the workflow file by default, so I've explicitly added it back in to not change that aspect of the job.

I have created this PR more as an issue than a request, because I think there's a high probability that I am not going about this in the best way, so I am hoping that someone will suggest a cleaner way. For instance: would it be better (and if so, how?) to somehow "install" Homebrew's readline so that GAP doesn't need to be told about it? (Note: I would expect `brew link readline` to do the job, but it fails on my computer because apparently macOS already provides readline. If so, why doesn't GAP see it?). I know almost nothing about compilation/build systems/what readline even is.

This also raises an administrative point: some of the CI jobs are _required_ to pass in order for a PR to be merged. This feature uses the names of certain jobs. The macOS job is one of those, however I am changing its name in this PR (the name of a job currently includes the value of any 'extra' variables). Therefore, the CI on this PR will not pass (notwithstanding #4377) until someone changes the branch protection rules for `gap-system/gap` to not require the currently-named macOS job. This is a slight annoyance and it would be good if we could come up with a solution that both provides useful and descriptive information in the GitHub interface, but which isn't as sensitive to changes like this PR contains. This of course might be impossible.