### PR TITLE
CI: temporarily remove coverage from macOS job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,7 @@ jobs:
 
           - os: macos-latest
             test-suites: "docomp testinstall"
-            extra: "BOOTSTRAP_MINIMAL=yes"
+            extra: "BOOTSTRAP_MINIMAL=yes NO_COVERAGE=1"
 
           # test creating the manual
           # TODO: make the resulting HTML and PDF files available as build


### PR DESCRIPTION
Currently the macOS job is failing because IO is not building, which is requiring by the code coverage system, and this causes the job to fail. See #4374.

By adding `NO_COVERAGE=1` to this job, IO will no longer need to be compiled. Obviously, in the long term we want coverage on this job, and we want to be able to compile IO, but this will get the CI running for the rest of GAP in a non-controversial way in the meantime, I hope.