### PR TITLE
Slack notifications for GH Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -274,3 +274,31 @@ jobs:
         run: |
           SET CHERE_INVOKING=1
           C:\cygwin64\bin\bash -l -c "bash dev/ci.sh"
+
+  slack-notification-on-failure:
+    name: Send slack notification on CI failure
+    needs:
+      - test-unix
+      - test-cygwin
+    if: ${{ always() && github.event_name == 'push' && github.repository == 'gap-system/gap' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get branch name
+        id: get-branch
+        run: echo ::set-output name=branch::${GITHUB_REF#refs/*/}
+      - name: Determine whether CI status changed
+        uses: gap-actions/should-i-notify-action@v1
+        id: should_notify
+        with:
+          branch: ${{ steps.get-branch.outputs.branch }}
+          needs_context: ${{ toJson(needs) }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          notify_on_changed_status: true
+      - name: Send slack notification
+        uses: act10ns/slack@e4e71685b9b239384b0f676a63c32367f59c2522
+        if: steps.should_notify.outputs.should_send_message == 'yes'
+        with:
+          status: ${{ steps.should_notify.outputs.last_status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Adds a job to the CI workflow which is triggered whenever the test-unix or the
test-cygwin jobs fail. That job then sends a message into the #status channel
of the gap-system slack workspace.

For a test run on my fork see:
- [a run without errors](https://github.com/ssiccha/gap/actions/runs/744321276)
- [a run where I added an error to hpcgap](https://github.com/ssiccha/gap/actions/runs/744348237)

Fixes #4390