### PR TITLE
buildsys: improve cross compilation support

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -552,6 +552,13 @@ install-libgap: libgap.la
 # master target for external dependencies / subprojects
 EXTERN_FILES =
 
+# pass on some settings to external dependencies / subprojects which use
+# autoconf; this is helpful for cross compilation
+EXTERN_CONFIGFLAGS := \
+	CC="$(CC)" \
+	CXX="$(CXX)" \
+	--build="$(build)" \
+	--host="$(host)"
 
 #
 # GMP
@@ -573,7 +580,11 @@ EXTERN_FILES += $(GMP_FILES)
 gmp: $(GMP_FILES)
 $(GMP_FILES):
 	touch "$(abs_srcdir)/extern/gmp/doc/gmp.info"
-	MAKE=$(MAKE) CC="$(CC)" $(srcdir)/cnf/build-extern.sh gmp "$(abs_srcdir)/extern/gmp" ABI=$(ABI) --disable-static --enable-shared
+	MAKE=$(MAKE) $(srcdir)/cnf/build-extern.sh gmp "$(abs_srcdir)/extern/gmp" \
+	$(EXTERN_CONFIGFLAGS) \
+	ABI="$(ABI)" \
+	--disable-static \
+	--enable-shared
 
 .PHONY: gmp
 
@@ -642,8 +653,10 @@ EXTERN_FILES += $(LIBATOMIC_OPS_FILES)
 
 libatomic_ops: $(LIBATOMIC_OPS_FILES)
 $(LIBATOMIC_OPS_FILES):
-	MAKE=$(MAKE) CC="$(CC)"  \
-	$(srcdir)/cnf/build-extern.sh libatomic_ops "$(abs_srcdir)/hpcgap/extern/libatomic_ops" --disable-static --enable-shared
+	MAKE=$(MAKE) $(srcdir)/cnf/build-extern.sh libatomic_ops "$(abs_srcdir)/hpcgap/extern/libatomic_ops" \
+	$(EXTERN_CONFIGFLAGS) \
+	--disable-static \
+	--enable-shared
 
 # TODO: MAKEFLAGS=-j1
 
@@ -680,11 +693,13 @@ EXTERN_FILES += $(BOEHM_GC_FILES)
 boehm: gc # alias
 gc: $(BOEHM_GC_FILES)
 $(BOEHM_GC_FILES):
-	MAKE=$(MAKE) \
-	CC="$(CC)" \
-	ATOMIC_OPS_CFLAGS=$(LIBATOMIC_OPS_CPPFLAGS) \
-	ATOMIC_OPS_LIBS=$(LIBATOMIC_OPS_LDFLAGS) \
-	$(srcdir)/cnf/build-extern.sh gc "$(abs_srcdir)/hpcgap/extern/gc" --disable-static --enable-shared --enable-large-config
+	MAKE=$(MAKE) $(srcdir)/cnf/build-extern.sh gc "$(abs_srcdir)/hpcgap/extern/gc" \
+	$(EXTERN_CONFIGFLAGS) \
+	ATOMIC_OPS_CFLAGS="$(LIBATOMIC_OPS_CPPFLAGS)" \
+	ATOMIC_OPS_LIBS="$(LIBATOMIC_OPS_LDFLAGS)" \
+	--disable-static \
+	--enable-shared \
+	--enable-large-config
 
 ifeq ($(BUILD_LIBATOMIC_OPS),yes)
 $(BOEHM_GC_FILES): $(LIBATOMIC_OPS_FILES)

--- a/cnf/build-extern.sh
+++ b/cnf/build-extern.sh
@@ -30,3 +30,4 @@ $MAKE -C "$builddir" install
 
 # TODO: insert command to check whether make needs to be called at all?
 echo "=== DONE building $pkg ==="
+exit 0


### PR DESCRIPTION
When building bundled libraries, pass the C/C++ compiler and info about the host/target architecture to their build systems.

A simple precursor of this patch has already been in use for several months to produce the [cross compiled GAP binaries for Julia](https://github.com/JuliaBinaryWrappers/GAP_jll.jl/releases/tag/GAP-v400.1100.1%2B0), with [build recipe here](https://github.com/JuliaPackaging/Yggdrasil/tree/master/G/GAP).

But I went further now and tried to do it "properly", to also resolve #4154 and to simply have more uniform handling of the external libraries.