### PR TITLE
FIX: Storage of partial maximal subgroup lists

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -92,6 +92,11 @@ local erg,nerg,perm,i,e,c,sel;
     nerg:=[];
     for e in erg do
       sel:=Filtered(Difference([1..Length(from)],Union(e)),x->from[x]<=i);
+      c:=NrCombinations(sel);
+      if c>10^7 then 
+        Info(InfoPerformance,1,"Performance warning: Trying ",c,
+          " combinations");
+      fi;
       for c in Combinations(sel) do
         if Sum(from{c})=i then
           Add(nerg,Concatenation(e,[c]));

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -2476,7 +2476,7 @@ local G,max,dom,n,A,S,issn,p,i,j,m,k,powdec,pd,gps,v,invol,sel,mf,l,prim;
   return max;
 end);
 
-InstallMethod( TryMaximalSubgroupClassReps, "symmetric", true,
+InstallMethod( CalcMaximalSubgroupClassReps, "symmetric", true,
     [ IsNaturalSymmetricGroup and IsFinite], OVERRIDENICE,
 function ( G )
 local m;
@@ -2488,7 +2488,7 @@ local m;
   fi;
 end);
 
-InstallMethod( TryMaximalSubgroupClassReps, "alternating", true,
+InstallMethod( CalcMaximalSubgroupClassReps, "alternating", true,
     [ IsNaturalAlternatingGroup and IsFinite], OVERRIDENICE,
 function ( G )
 local m;

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1234,11 +1234,13 @@ DeclareAttribute( "MaximalSubgroups", IsGroup );
 ##
 DeclareAttribute("MaximalSubgroupClassReps",IsGroup);
 
+# functions to calculate maximal subgroups (or fail if not possible)
+DeclareOperation("CalcMaximalSubgroupClassReps",[IsGroup]);
+DeclareGlobalFunction("TryMaximalSubgroupClassReps");
 # utility attribute: Allow use with limiting options, so could hold `fail'.
-DeclareAttribute("TryMaximalSubgroupClassReps",IsGroup,"mutable");
+DeclareAttribute("StoredPartialMaxSubs",IsGroup,"mutable");
 
 # utility function in maximal subgroups code
-DeclareGlobalFunction("TryMaxSubgroupTainter");
 DeclareGlobalFunction("DoMaxesTF");
 
 # make this an operation to allow for overloading and TryNextMethod();

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1778,11 +1778,10 @@ end);
 #F  MaximalSubgroupClassReps(<G>) . . . . reps of conjugacy classes of
 #F                                                          maximal subgroups
 ##
-InstallMethod(TryMaximalSubgroupClassReps,"using lattice",true,[IsGroup],0,
+InstallMethod(CalcMaximalSubgroupClassReps,"using lattice",true,[IsGroup],0,
 function (G)
     local   maxs,lat;
 
-    TryMaxSubgroupTainter(G);
     if ValueOption("nolattice")=true then return fail;fi;
     #AH special AG treatment
     if not HasIsSolvableGroup(G) and IsSolvableGroup(G) then
@@ -3033,11 +3032,6 @@ InstallMethod(TomDataAlmostSimpleRecognition,"generic",true,
   [IsGroup],0,
 function(G)
 local T,t,hom,inf,nam,i,aut;
-  # avoid the isomorphism test falling back
-  if ValueOption("cheap")=true and IsInt(ValueOption("intersize")) and
-  ValueOption("intersize")<=Size(G) then
-    return fail;
-  fi;
 
   T:=PerfectResiduum(G);
   inf:=DataAboutSimpleGroup(T);
@@ -3090,6 +3084,12 @@ end);
 
 InstallGlobalFunction(TomDataMaxesAlmostSimple,function(G)
 local recog,m;
+  # avoid the isomorphism test falling back
+  if ValueOption("cheap")=true and IsInt(ValueOption("intersize")) and
+  ValueOption("intersize")<=Size(G) then
+    return fail;
+  fi;
+
   recog:=TomDataAlmostSimpleRecognition(G);
   if recog=fail then
     return fail;

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -685,11 +685,10 @@ GroupSeriesMethodByNiceMonomorphism( LowerCentralSeriesOfGroup,
 ##
 #M  MaximalSubgroupClassReps( <G> )
 ##
-InstallOtherMethod( TryMaximalSubgroupClassReps,
+InstallOtherMethod( CalcMaximalSubgroupClassReps,
   "handled by nice monomorphism, transfer tainter", true, [IsGroup], 0,
 function( G )
 local   nice,  img,  sub,i;
-  TryMaxSubgroupTainter(G);
   nice := NiceMonomorphism(G);
   img  := ShallowCopy(TryMaximalSubgroupClassReps( NiceObject(G) ));
   for i in [1..Length(img)] do

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -369,7 +369,6 @@ end;
 MAXSUBS_BY_PCGS:=function( G )
     local spec, first, max, i, new;
 
-    TryMaxSubgroupTainter(G);
     spec  := SpecialPcgs(G);
     first := LGFirst( spec );
     max   := [];
@@ -385,7 +384,7 @@ end;
 ##
 #M  MaximalSubgroupClassReps( <G> )
 ##
-InstallMethod( TryMaximalSubgroupClassReps,
+InstallMethod( CalcMaximalSubgroupClassReps,
     "pcgs computable groups using special pcgs",
     true, 
     [ IsGroup and CanEasilyComputePcgs and IsFinite ],
@@ -393,7 +392,7 @@ InstallMethod( TryMaximalSubgroupClassReps,
     MAXSUBS_BY_PCGS);
 
 #fallback
-InstallMethod( TryMaximalSubgroupClassReps,
+InstallMethod( CalcMaximalSubgroupClassReps,
     "pcgs computable groups using special pcgs",
     true, 
     [ IsGroup and IsSolvableGroup and IsFinite ],

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -811,7 +811,6 @@ local G,types,ff,maxes,lmax,q,d,dorb,dorbt,i,dorbc,dorba,dn,act,comb,smax,soc,
   a1emb,a2emb,anew,wnew,e1,e2,emb,a1,a2,mm;
 
   G:=arg[1];
-  TryMaxSubgroupTainter(G);
 
   # which kinds of maxes do we want to get
   if Length(arg)>1 then
@@ -999,8 +998,11 @@ end);
 InstallMethod(MaximalSubgroupClassReps,"TF method",true,
   [IsGroup and IsFinite and CanComputeFittingFree],OVERRIDENICE,DoMaxesTF);
 
-InstallMethod(TryMaximalSubgroupClassReps,"TF method",true,
-  [IsGroup and IsFinite and CanComputeFittingFree],OVERRIDENICE,DoMaxesTF);
+InstallMethod(CalcMaximalSubgroupClassReps,"TF method",true,
+  [IsGroup and IsFinite and CanComputeFittingFree],OVERRIDENICE,
+function(G)
+  return DoMaxesTF(G);
+end);
 
 #InstallMethod(MaximalSubgroupClassReps,"perm group",true,
 #  [IsPermGroup and IsFinite],0,DoMaxesTF);

--- a/lib/pcgsperm.gi
+++ b/lib/pcgsperm.gi
@@ -1424,11 +1424,10 @@ end);
 ##
 ##  method for solvable perm groups -- it is cheaper to translate to a pc
 ##  group
-InstallMethod( TryMaximalSubgroupClassReps,"solvable perm group",true, 
+InstallMethod( CalcMaximalSubgroupClassReps,"solvable perm group",true, 
     [ IsPermGroup and CanEasilyComputePcgs and IsFinite ], 0,
 function(G)
 local hom,m;
-  TryMaxSubgroupTainter(G);
   hom:=IsomorphismPcGroup(G);
   m:=MaximalSubgroupClassReps(Image(hom));
   List(m,Size); # force

--- a/tst/testbugfix/2021-04-13-TryMaximals.tst
+++ b/tst/testbugfix/2021-04-13-TryMaximals.tst
@@ -1,0 +1,5 @@
+#4395, reported by Andries Brouwer
+gap> g:=SimpleGroup("3D4(2)");;
+gap> hs:=List(IsomorphicSubgroups(g,SymmetricGroup(4)),Image);;
+gap> Length(TryMaximalSubgroupClassReps(g));
+9


### PR DESCRIPTION
Instead of storing one attribute and a flag that indicates that it might be
only a partial list, store potentially multiple lists and the restrictions
under which they were computed. This avoids a qualified result sneaking in
as true.
This fixes #4395

The correction unfortunately goes across a larger number of files, though most changes are tiny.