### PR TITLE
Add safety checks for objects with memory

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -147,6 +147,9 @@ InstallGlobalFunction( SLPOfElms,
   function(elms)
     # Returns a straight line program to write elm as in the original 
     # generators.
+    if ForAny(elms{[2..Length(elms)]}, x -> not IsIdenticalObj(elms[1]!.slp, x!.slp)) then
+        ErrorNoReturn("SLPOfElms: the slp components of all elements must be identical");
+    fi;
     return IntermediateResultsOfSLPWithoutOverwrite( 
                [elms[1]!.slp.prog,elms[1]!.slp.nogens], List(elms,x->x!.n) );
   end);
@@ -184,6 +187,9 @@ InstallMethod( \*, "objects with memory", true,
   function(a,b)
     local r,slp;
     slp := a!.slp;
+    if not IsIdenticalObj(a!.slp, b!.slp) then
+        ErrorNoReturn("\\* for objects with memory: a!.slp and b!.slp must be identical");
+    fi;
     if a!.n = 0 then   # the identity!
         r := rec(slp := slp, n := b!.n, el := b!.el);
     elif b!.n = 0 then   # the identity!

--- a/tst/testinstall/memory.tst
+++ b/tst/testinstall/memory.tst
@@ -1,0 +1,37 @@
+#@local G, H, g, h, tmp, stabChain, s1, s2
+gap> G := GroupWithMemory(GroupByGenerators([ (1,2,3,4,5), (1,2) ]));;
+gap> H := GroupWithMemory(GL(IsMatrixGroup, 3, 3));;
+gap> g := H.1 ^ 2;; h := H.2 ^ 2;;
+gap> StripMemory(g);
+[ [ Z(3)^0, 0*Z(3), 0*Z(3) ], [ 0*Z(3), Z(3)^0, 0*Z(3) ], 
+  [ 0*Z(3), 0*Z(3), Z(3)^0 ] ]
+gap> StripMemory([g, h]);
+[ [ [ Z(3)^0, 0*Z(3), 0*Z(3) ], [ 0*Z(3), Z(3)^0, 0*Z(3) ], 
+      [ 0*Z(3), 0*Z(3), Z(3)^0 ] ], 
+  [ [ Z(3)^0, Z(3), Z(3) ], [ Z(3)^0, 0*Z(3), Z(3) ], 
+      [ Z(3)^0, 0*Z(3), 0*Z(3) ] ] ]
+gap> ForgetMemory(1);
+Error, This object does not allow forgetting memory.
+gap> ForgetMemory(H.1 ^ 2);
+Error, You probably mean "StripMemory" instead of "ForgetMemory".
+gap> ForgetMemory([g, h]);
+gap> tmp := GroupWithMemory(GroupByGenerators([ (1,2,3,4,5), (1,2) ]));;
+gap> stabChain := StabChainMutable(tmp);;
+gap> stabChain.labels[1];
+<() with mem>
+gap> StripStabChain(stabChain);;
+gap> stabChain.labels[1];
+()
+gap> s1 := SLPOfElm(g);;
+gap> g = ResultOfStraightLineProgram(s1, GeneratorsOfGroup(H));
+true
+gap> s2 := SLPOfElms([g, h]);;
+gap> [g, h] = ResultOfStraightLineProgram(s2, GeneratorsOfGroup(H));
+true
+gap> SLPOfElms([G.1, H.1]);
+Error, SLPOfElms: the slp components of all elements must be identical
+gap> g * h;
+<[ [ Z(3)^0, Z(3), Z(3) ], [ Z(3)^0, 0*Z(3), Z(3) ], 
+  [ Z(3)^0, 0*Z(3), 0*Z(3) ] ] with mem>
+gap> g * G.1;
+Error, \* for objects with memory: a!.slp and b!.slp must be identical


### PR DESCRIPTION
Functions, which take several objects with memory as their inputs,
assume that the `!.slp` components of said objects all are identical.
This commit adds checks to verify that assumption.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels
   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`
- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

