### PR TITLE
Fix crashes when accessing `mat[i,j]` and `mat[i]` is unbound

### DIFF
--- a/src/lists.c
+++ b/src/lists.c
@@ -480,14 +480,22 @@ static Obj ElmMatOper;
 
 Obj ELM_MAT(Obj mat, Obj row, Obj col)
 {
+    Obj elm;
     if (IS_POS_INTOBJ(row) && IS_POS_INTOBJ(col) && IS_PLIST(mat)) {
         Int r = INT_INTOBJ(row);
         if (r <= LEN_PLIST(mat)) {
             Obj rowlist = ELM_PLIST(mat, r);
             Int c = INT_INTOBJ(col);
 
+            if (!rowlist)
+                ErrorMayQuit("Matrix Element: <mat>[%d] must have an assigned value",
+                             (Int)r, (Int)c);
             if (IS_PLIST(rowlist) && c <= LEN_PLIST(rowlist)) {
-                return ELM_PLIST(rowlist, c);
+                elm = ELM_PLIST(rowlist, c);
+                if (!elm)
+                    ErrorMayQuit("Matrix Element: <mat>[%d,%d] must have an assigned value",
+                                 (Int)r, (Int)c);
+                return elm;
             }
 
             // fallback to generic list access code (also triggers error if
@@ -496,7 +504,7 @@ Obj ELM_MAT(Obj mat, Obj row, Obj col)
         }
     }
 
-    Obj elm = DoOperation3Args(ElmMatOper, mat, row, col);
+    elm = DoOperation3Args(ElmMatOper, mat, row, col);
     if (elm == 0) {
         ErrorMayQuit("Matrix access method must return a value", 0, 0);
     }
@@ -840,6 +848,9 @@ void ASS_MAT(Obj mat, Obj row, Obj col, Obj obj)
             Obj rowlist = ELM_PLIST(mat, r);
             Int c = INT_INTOBJ(col);
 
+            if (!rowlist)
+                ErrorMayQuit("Matrix Assignment: <mat>[%d] must have an assigned value",
+                             (Int)r, (Int)c);
             ASS_LIST(rowlist, c, obj);
             return;
         }

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -324,21 +324,48 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]:=' on 3 arguments
 
 # Indexing into plain lists
-gap> l := [[]];;
-gap> l[1,2] := 4;
+gap> l := [,[,4]];
+[ , [ , 4 ] ]
+gap> l[0,1];  # row is out of bounds
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `MatElm' on 3 arguments
+gap> l[1,1];  # row is in bounds but missing
+Error, Matrix Element: <mat>[1] must have an assigned value
+gap> l[2,1];  # row is there but entry is missing
+Error, Matrix Element: <mat>[2,1] must have an assigned value
+gap> l[3,1];  # row is out of bounds
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `MatElm' on 3 arguments
+gap> l[2,0];  # column is out of bounds
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `MatElm' on 3 arguments
+gap> l[2,2];  # OK
+4
+gap> l[2,3];  # column is out of bounds
+Error, List Element: <list>[3] must have an assigned value
+gap> l[2,2] := 4;
 4
 gap> l;
-[ [ , 4 ] ]
-gap> l[1,1] := 3;;
+[ , [ , 4 ] ]
+gap> l[0,1] := 3; # error, row out of bounds
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `SetMatElm' on 4 arguments
+gap> l[1,1] := 3; # error, row is missing
+Error, Matrix Assignment: <mat>[1] must have an assigned value
+gap> l[2,1] := 3; # OK
+3
+gap> l[3,1] := 3; # error, row out of bounds
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `SetMatElm' on 4 arguments
 gap> l;
-[ [ 3, 4 ] ]
+[ , [ 3, 4 ] ]
 gap> l[2,1];
-Error, List Element: <list>[2] must have an assigned value
-gap> MakeImmutable(l[1]);;
-gap> l[1,1] := 2;;
+3
+gap> MakeImmutable(l[2]);;
+gap> l[2,1] := 2;;
 Error, List Assignment: <list> must be a mutable list
 gap> l;
-[ [ 3, 4 ] ]
+[ , [ 3, 4 ] ]
 
 # that's all, folks
 gap> STOP_TEST( "listindex.tst", 1);


### PR DESCRIPTION
For a plist-of-plists matrix `mat`, accessing `mat[i,j]` crashed if `mat[i]`
was unbound and i in [1..Length(mat)].

Also, if `mat[i,j]` is not bound, then it now raises an error instead of
returning nothing.
