### PR TITLE
Components of Wreath Product Elements

### DIFF
--- a/doc/ref/grpprod.xml
+++ b/doc/ref/grpprod.xml
@@ -118,6 +118,8 @@ has to be taken.)
 <#Include Label="WreathProductImprimitiveAction">
 <#Include Label="WreathProductProductAction">
 <#Include Label="KuKGenerators">
+<#Include Label="ListWreathProductElement">
+<#Include Label="WreathProductElementList">
 
 </Section>
 

--- a/lib/gprd.gd
+++ b/lib/gprd.gd
@@ -566,3 +566,66 @@ InstallTrueMethod(IsGeneratorsOfMagmaWithInverses,
 
 DeclareRepresentation("IsWreathProductElementDefaultRep",
   IsWreathProductElement and IsPositionalObjectRep,[]);
+
+#############################################################################
+##
+#F  ListWreathProductElement
+#O  ListWreathProductElementNC
+##
+##  <#GAPDoc Label="ListWreathProductElement">
+##  <ManSection>
+##  <Func Name="ListWreathProductElement" Arg='G, x[, testDecomposition]'/>
+##  <Oper Name="ListWreathProductElementNC" Arg='G, x, testDecomposition'/>
+##
+##  <Description>
+##  Let <A>x</A> be an element of a wreath product <A>G</A>
+##  where <M>G = K \wr H</M> and <M>H</M> acts
+##  as a finite permutation group of degree <M>m</M>.
+##  We can identify the element <A>x</A> with a tuple <M>(f_1, \ldots, f_m; h)</M>,
+##  where <M>f_i \in K</M> is the <M>i</M>-th base component of <A>x</A>
+##  and <M>h \in H</M> is the top component of <A>x</A>.
+##  <P/>
+##  <Ref Func="ListWreathProductElement"/> returns a list <M>[f_1, \ldots, f_m, h]</M>
+##  containing the components of <A>x</A> or <K>fail</K> if <A>x</A> cannot be decomposed in the wreath product.
+##  <P/>
+##  If ommited, the argument <A>testDecomposition</A> defaults to true.
+##  If <A>testDecomposition</A> is true, <Ref Func="ListWreathProductElement"/> makes additional tests to ensure
+##  that the computed decomposition of <A>x</A> is correct,
+##  i.e. it checks that <A>x</A> is an element of the parent wreath product of <A>G</A>:
+##  <P/>
+##  If <M>K \leq \mathop{Sym}(l)</M>, this ensures that <M>x \in \mathop{Sym}(l) \wr \mathop{Sym}(m)</M>
+##  where the parent wreath product is considered in the same action as <A>G</A>,
+##  i.e. either in imprimitive action or product action.
+##  <P/>
+##  If <M>K \leq \mathop{GL}(n,q)</M>, this ensures that <M>x \in \mathop{GL}(n,q) \wr \mathop{Sym}(m)</M>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "ListWreathProductElement" );
+DeclareOperation( "ListWreathProductElementNC", [HasWreathProductInfo, IsObject, IsBool] );
+
+#############################################################################
+##
+#F  WreathProductElementList
+#O  WreathProductElementListNC
+##
+##  <#GAPDoc Label="WreathProductElementList">
+##  <ManSection>
+##  <Func Name="WreathProductElementList" Arg='G, list'/>
+##  <Oper Name="WreathProductElementListNC" Arg='G, list'/>
+##
+##  <Description>
+##  Let <A>list</A> be equal to <M>[f_1, \ldots, f_m, h]</M> and <A>G</A> be a wreath product
+##  where <M>G = K \wr H</M>, <M>H</M> acts
+##  as a finite permutation group of degree <M>m</M>,
+##  <M>f_i \in K</M> and <M>h \in H</M>.
+##  <P/>
+##  <Ref Func="WreathProductElementList"/> returns the element <M>x \in G</M>
+##  identified by the tuple <M>(f_1, \ldots, f_m; h)</M>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "WreathProductElementList" );
+DeclareOperation( "WreathProductElementListNC", [HasWreathProductInfo, IsList] );

--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -898,6 +898,73 @@ end);
 
 #############################################################################
 ##
+#M  ListWreathProductElement(<G>, <x>[, <testMembership>])
+##
+InstallGlobalFunction( ListWreathProductElement,
+function(G, x, testDecomposition...)
+  local info;
+  if Length(testDecomposition) = 0 then
+    testDecomposition := true;
+  elif Length(testDecomposition) = 1 then
+    testDecomposition := testDecomposition[1];
+  elif Length(testDecomposition) > 1 then
+    ErrorNoReturn("too many arguments");
+  fi;
+  if not HasWreathProductInfo(G) then
+    ErrorNoReturn("usage: <G> must be a wreath product");
+  fi;
+  return ListWreathProductElementNC(G, x, testDecomposition);
+end);
+
+InstallMethod( ListWreathProductElementNC, "generic wreath product", true,
+ [ HasWreathProductInfo, IsWreathProductElement, IsBool ], 0,
+function(G, x, testDecomposition)
+  local info, list, i;
+  info := WreathProductInfo(G);
+  list := EmptyPlist(info!.degI + 1);
+  for i in [1 .. info!.degI + 1] do
+    list[i] := StructuralCopy(x![i]);
+  od;
+  return list;
+end);
+
+#############################################################################
+##
+#M  WreathProductElementList(<G>, <list>)
+##
+InstallGlobalFunction( WreathProductElementList,
+function(G, list)
+  local info, i;
+
+  if not HasWreathProductInfo(G) then
+    ErrorNoReturn("usage: <G> must be a wreath product");
+  fi;
+  info := WreathProductInfo(G);
+  if Length(list) <> info.degI + 1 then
+    ErrorNoReturn("usage: <list> must have ",
+                  "length 1 + <WreathProductInfo(G).degI>");
+  fi;
+  for i in [1 .. info.degI] do
+    if not list[i] in info.groups[1] then
+      ErrorNoReturn("usage: <list{[1 .. Length(list) - 1]}> must contain ",
+                    "elements of <WreathProductInfo(G).groups[1]>");
+    fi;
+  od;
+  if not list[info.degI + 1] in info.groups[2] then
+    ErrorNoReturn("usage: <list[Length(list)]> must be ",
+                  "an element of <WreathProductInfo(G).groups[2]>");
+  fi;
+  return WreathProductElementListNC(G, list);
+end);
+
+InstallMethod( WreathProductElementListNC, "generic wreath product", true,
+ [ HasWreathProductInfo, IsList ], 0,
+function(G, list)
+  return Objectify(FamilyObj(One(G))!.defaultType, StructuralCopy(list));
+end);
+
+#############################################################################
+##
 #M  PrintObj(<x>)
 ##
 InstallMethod(PrintObj,"wreath elements",true,[IsWreathProductElement],0,

--- a/lib/gprdmat.gi
+++ b/lib/gprdmat.gi
@@ -406,14 +406,38 @@ end );
 InstallOtherMethod( Projection,"matrix wreath product", true,
   [ IsMatrixGroup and HasWreathProductInfo ],0,
 function( W )
-local  info,proj,H;
+local  info, degI, dimA, zero, projFunc;
   info := WreathProductInfo( W );
   if IsBound( info.projection ) then return info.projection; fi;
 
-  proj:=Error("TODO");
+  degI := info.degI;
+  dimA := info.dimA;
+  zero := Zero(info.field);
 
-  info.projection:=proj;
-  return proj;
+  projFunc := function(x)
+    local topImages, k, l, a;
+    topImages := [];
+    for k in [1 .. degI] do
+      for l in [1 .. degI] do
+        for a in [1 .. dimA] do
+          if x[dimA * (k - 1) + a, dimA * (l - 1) + a] <> zero then
+            Add(topImages, l);
+            break;
+          fi;
+        od;
+        if Length(topImages) = k then
+          break;
+        fi;
+      od;
+      if Length(topImages) <> k then
+        return fail;
+      fi;
+    od;
+    return PermList(topImages);
+  end;
+
+  info.projection := GroupHomomorphismByFunction(W, info.groups[2], projFunc);
+  return info.projection;
 end);
 
 # tensor wreath -- dimension d^e This is not a faithful representation of

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -620,6 +620,21 @@ InstallMethod( ExtractSubMatrix,
     [ IsMatrixObj, IsList, IsList ],
     { M, rowpos, colpos } -> Matrix( Unpack( M ){ rowpos }{ colpos }, M ) );
 
+# Hack from recog package
+InstallOtherMethod( ExtractSubMatrix, "hack: for lists of compressed vectors",
+[ IsList, IsList, IsList ],
+function( m, poss1, poss2 )
+  local i,n;
+  n := [];
+  for i in poss1 do
+      Add(n,ShallowCopy(m[i]{poss2}));
+  od;
+  if IsFFE(m[1,1]) then
+      ConvertToMatrixRep(n);
+  fi;
+  return n;
+end );
+
 InstallMethod( CopySubVector,
     "generic method for vector objects",
   [ IsVectorObj, IsVectorObj and IsMutable, IsList, IsList ],

--- a/tst/testinstall/opers/ListWreathProductElement.tst
+++ b/tst/testinstall/opers/ListWreathProductElement.tst
@@ -1,0 +1,215 @@
+#
+gap> START_TEST("ListWreathProductElement.tst");
+
+#
+# Perm Wreath Product In Imprimitive Action
+#
+
+#
+gap> K := SymmetricGroup(3);;
+gap> H := SymmetricGroup(5);;
+gap> G := WreathProduct(K, H);;
+
+#
+gap> list := [(1,2), (1,2,3), (), (1,2,3), (), (1,2)(3,4)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> list := [(1,2), (1,2,3), (), (1,2,3), (), (1,2,3)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> x := (1,5,9,12,13)(2,4,8,11,15,3,6,7,10,14);;
+gap> list := ListWreathProductElement(G, x);;
+gap> x = WreathProductElementList(G, list);
+true
+
+# Top Component fails
+gap> x := (1,5);;
+gap> x ^ Projection(G);
+fail
+gap> ListWreathProductElement(G, x);
+fail
+
+# Base Component fails
+gap> x := (1,2,3,4,5);;
+gap> x ^ Projection(G);
+()
+gap> ListWreathProductElement(G, x);
+fail
+
+#
+# Perm Wreath Product In Product Action
+#
+
+#
+gap> K := SymmetricGroup(3);;
+gap> H := SymmetricGroup(5);;
+gap> G := WreathProductProductAction(K, H);;
+
+#
+gap> list := [(1,2), (1,2,3), (), (1,2,3), (), (1,2)(3,4)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> list := [(1,2), (1,2,3), (), (1,2,3), (), (1,2,3)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> x :=
+> (  1, 25, 24, 12, 17,  5)(  2,  7, 22, 21, 18, 14)(  3, 16, 23)(  4, 19, 27, 15, 11,  8)(  6, 10, 26)(  9, 13, 20)
+> ( 28,106, 78,174, 44, 86, 55,187, 51, 93, 71,167)( 29, 88, 76,183, 45, 95, 56,169, 49,102, 72,176)
+> ( 30, 97, 77,165, 43,104, 57,178, 50, 84, 70,185)( 31,100, 81,177, 38, 89, 58,181, 54, 96, 65,170)
+> ( 32, 82, 79,186, 39, 98, 59,163, 52,105, 66,179)( 33, 91, 80,168, 37,107, 60,172, 53, 87, 64,188)
+> ( 34,103, 75,180, 41, 83, 61,184, 48, 99, 68,164)( 35, 85, 73,189, 42, 92, 62,166, 46,108, 69,173)
+> ( 36, 94, 74,171, 40,101, 63,175, 47, 90, 67,182)(109,160,240,201,125,140,217,214,132,147,233,194)
+> (110,142,238,210,126,149,218,196,130,156,234,203)(111,151,239,192,124,158,219,205,131,138,232,212)
+> (112,154,243,204,119,143,220,208,135,150,227,197)(113,136,241,213,120,152,221,190,133,159,228,206)
+> (114,145,242,195,118,161,222,199,134,141,226,215)(115,157,237,207,122,137,223,211,129,153,230,191)
+> (116,139,235,216,123,146,224,193,127,162,231,200)(117,148,236,198,121,155,225,202,128,144,229,209);;
+gap> list := ListWreathProductElement(G, x);;
+gap> x = WreathProductElementList(G, list);
+true
+
+# Top Projection fails
+gap> x := (4,16);;
+gap> x ^ Projection(G);
+fail
+gap> ListWreathProductElement(G, x);
+fail
+
+# Base Decomposition fails
+gap> x := (1,2,3,4,5);;
+gap> x ^ Projection(G);
+()
+gap> ListWreathProductElement(G, x);
+fail
+
+#
+# Matrix Wreath Product
+#
+
+#
+gap> K := GL(3,3);;
+gap> H := SymmetricGroup(5);;
+gap> G := WreathProduct(K, H);;
+
+#
+gap> list := [K.1, K.2, One(K), K.2, One(K), (1,2)(3,4)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> list := [K.1, K.2, One(K), K.2, One(K), (1,2,3)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> x := [
+> [ 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3)^0, 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3)^0, Z(3)^0 ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ Z(3)^0, Z(3)^0, Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), Z(3)^0, Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3)^0, Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ] ];;
+gap> list := ListWreathProductElement(G, x);;
+gap> x = WreathProductElementList(G, list);
+true
+gap> ConvertToMatrixRep(x);;
+gap> list := ListWreathProductElement(G, x);;
+gap> x = WreathProductElementList(G, list);
+true
+
+# Top Projection fails
+gap> x := [
+> [ Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3)^0, Z(3)^0, Z(3)^0, Z(3), Z(3), Z(3)^0, 0*Z(3), 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0 ],
+> [ Z(3), Z(3), Z(3)^0, 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0, Z(3)^0, Z(3)^0, Z(3), Z(3)^0, 0*Z(3), Z(3)^0, Z(3), Z(3) ],
+> [ 0*Z(3), Z(3)^0, 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0, Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3)^0, Z(3)^0, 0*Z(3), 0*Z(3), Z(3)^0 ],
+> [ Z(3), 0*Z(3), Z(3), 0*Z(3), Z(3), Z(3), Z(3)^0, Z(3), Z(3), Z(3), Z(3), Z(3), Z(3)^0, 0*Z(3), 0*Z(3) ],
+> [ Z(3)^0, Z(3), Z(3)^0, 0*Z(3), 0*Z(3), Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3), 0*Z(3), Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3)^0, 0*Z(3), Z(3)^0, Z(3), 0*Z(3), Z(3), Z(3)^0, 0*Z(3) ],
+> [ Z(3)^0, 0*Z(3), Z(3)^0, Z(3)^0, 0*Z(3), Z(3), Z(3)^0, Z(3)^0, 0*Z(3), Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3), Z(3)^0 ],
+> [ Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3), Z(3)^0, Z(3), Z(3)^0, 0*Z(3), 0*Z(3), Z(3), Z(3)^0, Z(3)^0, Z(3), Z(3), 0*Z(3) ],
+> [ Z(3), Z(3)^0, Z(3)^0, Z(3), Z(3)^0, 0*Z(3), Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), Z(3)^0, 0*Z(3) ],
+> [ Z(3), 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3), 0*Z(3), Z(3), Z(3), Z(3), Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3) ],
+> [ 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3), Z(3)^0, Z(3) ],
+> [ 0*Z(3), Z(3)^0, 0*Z(3), Z(3), Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3), Z(3), Z(3)^0, Z(3)^0, 0*Z(3), Z(3)^0, Z(3)^0, Z(3) ],
+> [ Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3), Z(3), 0*Z(3), Z(3), 0*Z(3), Z(3), Z(3), 0*Z(3), Z(3)^0, Z(3)^0 ],
+> [ 0*Z(3), 0*Z(3), Z(3), Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3), Z(3)^0, Z(3), Z(3), 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0, Z(3) ],
+> [ 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3), Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3)^0, 0*Z(3), Z(3), Z(3)^0 ] ];;
+gap> x ^ Projection(G);
+fail
+gap> ListWreathProductElement(G, x);
+fail
+gap> ConvertToMatrixRep(x);;
+gap> x ^ Projection(G);
+fail
+gap> ListWreathProductElement(G, x);
+fail
+
+# Base Decomposition fails
+gap> x := [
+> [ Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3)^0, Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), Z(3), 0*Z(3), Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3), 0*Z(3), Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3), Z(3)^0, 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3)^0, Z(3), 0*Z(3), 0*Z(3), 0*Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3), Z(3)^0 ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, 0*Z(3), Z(3) ],
+> [ 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), 0*Z(3), Z(3)^0, Z(3)^0 ] ];;
+gap> x ^ Projection(G);
+()
+gap> ListWreathProductElement(G, x);
+fail
+gap> ConvertToMatrixRep(x);;
+gap> x ^ Projection(G);
+()
+gap> ListWreathProductElement(G, x);
+fail
+
+#
+# Generic Wreath Product
+#
+
+#
+gap> K := DihedralGroup(12);;
+gap> H := SymmetricGroup(5);;
+gap> G := WreathProduct(K, H);;
+
+#
+gap> list := [K.1, K.2, One(K), K.2, One(K), (1,2)(3,4)];;
+gap> x := WreathProductElementList(G, list);;
+gap> list = ListWreathProductElement(G, x);
+true
+
+#
+gap> x := G.1 * G.5 * G.2 * G.5 ^ ((G.4 * G.5) ^ 2) * G.2;;
+gap> list := ListWreathProductElement(G, x);;
+gap> x = WreathProductElementList(G, list);
+true


### PR DESCRIPTION
# Description

## Notation
I am working on a package that aims to improve the performance of certain operations in wreath products.
Let $W = K \wr H$ be a wreath product and $H \leq \Sym(m)$. (I am not really interested in top actions that are not faithful or actions on an infinite set.)
We identify elements $w = (f, h) \in W$ by a tuple $(f_1, ..., f_m; h)$ where $f_i \in K$ is the $i$-th base component and $h \in H$ is the top component of $w$.

## My Package and Computational Advantages of this Tuple Notation
This generic representation of an element can be exploited to solve the following problems (hopefully efficiently) by using a *wreath cycle decomposition* and breaking the problems down to the groups $K$ and $H$:

- Given $w, v \in W$, determine if $w$ and $v$ are conjugate in $W$ and if so, compute an element $a \in W$ such that $w^a = v$.
- Given $w \in W$, enumerate the conjugacy class $w^W$ and determine its size.
- Given $W$, enumerate representatives for all conjugacy classes of $W$ and determine the number of conjugacy classes of $W$.
- Given $w \in W$, enumerate (generators of) $C_W(w)$ and determine its size.
In my package, I aim to provide implementations to solve these problems and hope that they will perform quite well in comparison with generic methods that do not exploit the wreath product structure.

[Package WreathProductElements](https://github.com/FriedrichRober/WreathProductElements)

The theory behind this will be described in a paper that is work in progress, by Alice C. Niemeyer, Sebastian Krammer, @DominikBernhardt, @FriedrichRober and @wucas.

## Interface for Wreath Product Elements in *GAP*
For my package I need an interface that allows me to work with elements of a wreath product in this tuple notation efficiently.
Note that it is easy to access $F = (f, 1)$ and $h$ via the current interface of a wreath product, namely by `h := w ^ Projection(W)` and `F := w * (h ^ (-1)) ^ Embedding(W, m + 1)`, but there is no convenient way known to me to access the components of $f$.

@hulpke suggested that this interface should be implemented on the `GAP`-side, which has the advantage that we could use the (undocumented) internal data stored in wreath products for the implementation. There are several ways how to realise such an interface, I include an implementation of such an interface in this pull request:

In analogy to `PermList` and `ListPerm`, I add two methods that translate between elements of wreath products in various representations to a list/tuple representation:
- `WreathProductElementList`
- `ListWreathProductElement`

In a follow-up pull request I suggest to document the record returned by the function `WreathProductInfo` partially and thus to provide some of the stored data that is shared by all wreath product representations to users and package authors.

I am very interested in other suggestions how such an interface can be realized and improved.

## Further details

I fixed `Projection` for perm wreath products in product action,
but there are still other issues with `Projection`, which I have to investigate further.
For example `Projection` is not implemented yet for matrix wreath products.
I also need to add tests, where the top domain or the base domain gets `compressed/renamed` by calling `WreathProduct`, for example I observe the following behavior which is expected to result in issues with my implementation:
```
gap> G := WreathProduct(SymmetricGroup(3), SymmetricGroup([11,12,13,14,15]));;
gap> Image(Projection(G));
Group([ (), (), (), (), (), (), (), (), (), (), (1,2,3,4,5), (1,2) ])
gap> Source(Embedding(G, 6));
Sym( [ 11 .. 15 ] )
```
There are also issues where generators of wreath products are inconvenient, for example we have in the above example:
```
gap> GeneratorsOfGroup(G);
[ (1,2,3), (1,2), (4,5,6), (4,5), (7,8,9), (7,8), (10,11,12), (10,11), (13,14,15), (13,14),
  (1,4,7,10,13)(2,5,8,11,14)(3,6,9,12,15), (1,4)(2,5)(3,6) ]
```
But it is only necessary to store base generators for each orbit under the top action, so in this case
`[ (1,2,3), (1,2), (1,4,7,10,13)(2,5,8,11,14)(3,6,9,12,15), (1,4)(2,5)(3,6) ]` is a more convenient generating set of `G`.
I will try to solve these issues (maybe in a separate pull request).

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

