### PR TITLE
Collection of small fixes and improvements that do not merit an own PR each

### DIFF
--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -691,7 +691,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       b,fratsim,AQ,OQ,Zm,D,innC,bas,oneC,imgs,C,maut,innB,tmpAut,imM,a,A,B,
       cond,sub,AQI,AQP,AQiso,rf,res,resperm,proj,Aperm,Apa,precond,ac,
       comiso,extra,mo,rada,makeaqiso,ind,lastperm,actbase,somechar,stablim,
-      scharorb,asAutom,jorb,jorpo,substb,isBadPermrep,ma,nosucl,nosuf;
+      scharorb,asAutom,jorb,jorpo,substb,isBadPermrep,ma,nosucl,nosuf,rlgf;
 
   # criterion for when to force degree reduction
   isBadPermrep:=function(g)
@@ -799,6 +799,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 
   ff:=FittingFreeLiftSetup(G);
   r:=ff.radical;
+  rlgf:=LGFirst(SpecialPcgs(r));
   # find series through r
 
   # derived and then primes and then elementary abelian
@@ -1270,13 +1271,15 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 
     # do we use induced radical automorphisms to help next step?
     if Size(KernelOfMultiplicativeGeneralMapping(hom))>1 and
-      Size(A)>10^8 and AbelianRank(r)<10 and ValueOption("noradicalaut")<>true
+      Size(A)>10^8 
       #(
       ## potentially large GL
       #Size(GL(Length(MPcgs),RelativeOrders(MPcgs)[1]))>10^10 and
       ## automorphism size really grew from B/C-bit
       ##Size(A)/Size(AQP)*Index(AQP,sub)>10^10) )
-     then
+      ## do so for all factors
+     and ForAll([2..Length(rlgf)],x->rlgf[x]-rlgf[x-1]<10)
+     and ValueOption("noradicalaut")<>true then
 
       if rada=fail then
 	if IsElementaryAbelian(r) and Size(r)>1 then

--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -1512,3 +1512,62 @@ DeclareGlobalFunction("Bernoulli");
 ##  <#/GAPDoc>
 ##
 DeclareAttribute("Permanent", IsMatrix);
+
+
+#############################################################################
+##
+#F  AllLinearDiophantineSolutions(<n>,<max>,<sum>)
+##
+##  <#GAPDoc Label="AllLinearDiophantineSolutions">
+##  <ManSection>
+##  <Func Name="AllLinearDiophantineSolutions" Arg='n,maxx,sum'/>
+##
+##  <Description>
+##  For a list <A>n</A> of positive integers, an integer <A>sum</A>, and a list
+##  of nonnegative integers <A>max</A>, this function returns a list of all
+##  nonnegative coefficient vectors <A>v</A>, such that <M>n\cdot v=sum</M>, and
+##  <M>v\le max</M> in each entry.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> AllLinearDiophantineSolutions([6,10,15],[10,10,10],57);
+##  [ [ 7, 0, 1 ], [ 2, 3, 1 ], [ 2, 0, 3 ] ]
+##  gap> AllLinearDiophantineSolutions([6,10,15],[6,4,4],57);
+##  [ [ 2, 3, 1 ], [ 2, 0, 3 ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("AllLinearDiophantineSolutions");
+
+#############################################################################
+##
+#F  AllSubsetSummations( <to>,<from> [,<limit>] )
+##
+##  <#GAPDoc Label="AllSubsetSummations">
+##  <ManSection>
+##  <Func Name="AllSubsetSummations" Arg='to,from [,limit]'/>
+##
+##  <Description>
+##  returns a list of all partitions of the entries in <A>from</A> such that the
+##  entries in each cell sum up to the corresponding entry in <A>to</A>. If a bound
+##  <A>limit</A> is given, the function stops (and returns <A>fail</A>) if the length
+##  of the list created would exceed <A>limit</A>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> AllSubsetSummations([63,672],[21,42,42,42,42,42,168,168,168 ]);
+##  [ [ [ 1, 2 ], [ 3 .. 9 ] ], [ [ 1, 3 ], [ 2, 4, 5, 6, 7, 8, 9 ] ],
+##    [ [ 1, 4 ], [ 2, 3, 5, 6, 7, 8, 9 ] ], [ [ 1, 5 ], [ 2, 3, 4, 6, 7, 8, 9 ] ],
+##    [ [ 1, 6 ], [ 2, 3, 4, 5, 7, 8, 9 ] ] ]
+##  gap> l:=[21,42,42,42,42,42,168,168,168];;
+##  gap> Length(AllSubsetSummations([105,210,210,210],l));
+##  360
+##  gap> AllSubsetSummations([105,210,210,210],l,300);
+##  fail
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("AllSubsetSummations");
+

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -871,7 +871,7 @@ local aug,w,p,pres,f,fam,G,trace;
 
     pres:=NEWTC_PresentationMTC(aug,0,nam);
   fi;
-  # check that we have the exat generators as we want and no rearrangement
+  # check that we have the exact generators as we want and no rearrangement
   # or so happened.
   Assert(0,Length(GeneratorsOfPresentation(pres))=Length(gens) 
     and pres!.primarywords=[1..Length(gens)]);

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -871,7 +871,10 @@ local aug,w,p,pres,f,fam,G,trace;
 
     pres:=NEWTC_PresentationMTC(aug,0,nam);
   fi;
-  Assert(0,Length(GeneratorsOfPresentation(pres))=Length(gens));
+  # check that we have the exat generators as we want and no rearrangement
+  # or so happened.
+  Assert(0,Length(GeneratorsOfPresentation(pres))=Length(gens) 
+    and pres!.primarywords=[1..Length(gens)]);
 
   # new free group
   f:=FpGroupPresentation(pres);

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -3053,6 +3053,9 @@ InstallMethod( RankAction,"via ophom",
     local   hom;
 
     hom := ActionHomomorphism( G, D, gens, acts, act );
+    if NrMovedPoints(Image(hom))<>Length(D) then
+      Error("RankAction: action must be transitive");
+    fi;
     return RankAction( Image( hom ), [ 1 .. Length( D ) ] );
 end );
 
@@ -3064,12 +3067,24 @@ InstallMethod( RankAction,
       IsList,
       IsFunction ], 0,
     function( G, D, gens, acts, act )
+    local S,olen;
     if    act <> OnPoints
        or not IsIdenticalObj( gens, acts )  then
         TryNextMethod();
     fi;
-    return Length( OrbitsDomain( Stabilizer( G, D, D[ 1 ], act ),
-                   D, act ) );
+
+    if IsFinite(G) then
+      S:=Stabilizer( G, D, D[ 1 ], act);
+      olen:=IndexNC(G,S);
+    else
+      S:=OrbitStabilizer(G,D,D[1],gens,acts,act);
+      olen:=Length(S.orbit);
+      S:=S.stabilizer;
+    fi;
+    if olen<>Length(D) then
+      Error("RankAction: action must be transitive");
+    fi;
+    return Length( OrbitsDomain( S, D, act ) );
 end );
 
 InstallMethod( RankAction,

--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -3585,12 +3585,16 @@ local DATA,rels,i,j,w,f,r,s,fam,new,ri,a,offset,p,rset,re,start,stack,pres,
       od;
       r:=AssocWordByLetterRep(fam,Concatenation(r,[-i]));
       AddRelator(pres,r);
-      TzSearch(pres);
+      #TzSearch(pres); Do *not* search, as this might kill the relator we
+      #just added.
       TzEliminate(pres,i);
     od;
     Assert(1,Length(GeneratorsOfPresentation(pres))=subnum);
     
   fi;
+  r:=List(GeneratorsOfPresentation(pres){[1..subnum]},
+    x->LetterRepAssocWord(x)[1]);
+  pres!.primarywords:=r;
   r:=List(GeneratorsOfPresentation(pres){
       [subnum+1..Length(GeneratorsOfPresentation(pres))]},
         x->LetterRepAssocWord(x)[1]);

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1877,6 +1877,10 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,old,sim,
     SetIsomorphismPermGroup(fp,new);
   fi;
 
+  if HasIsSolvableGroup(r.group) then
+    SetIsSolvableGroup(fp,IsSolvableGroup(r.group));
+  fi;
+
   return fp;
 end);
 

--- a/tst/testextra/grplatt.tst
+++ b/tst/testextra/grplatt.tst
@@ -188,6 +188,12 @@ gap> Length(ConjugacyClassesSubgroups(SymmetricGroup(7):NoPrecomputedData));
 #I  Using (despite option) data library of perfect groups, as the perfect
 #I  subgroups otherwise cannot be obtained!
 96
+gap> g:=SimpleGroup("3D4(2)");;
+gap> hs:=List(IsomorphicSubgroups(g,SymmetricGroup(4)),Image);;
+gap> h:=First(hs,x->48=Length(Orbits(x,MovedPoints(g))));;
+gap> sub:=IntermediateSubgroups(g,h);;
+gap> Length(sub.subgroups);
+19
 
 # thats all, folks
 gap> STOP_TEST( "grplatt.tst", 1);


### PR DESCRIPTION
Partial backport of my work branch to master

* Performance improvement to automorphism group/group isomorphism *
- Clean away the messy EFactors function in `DataAboutSimpleGroup`
- Store Solvability of extensions, if known
- Have RankAction test transitivity (was requested)
* FIX: Improvements in how MTC deletes superfluous generators -- avoid error message in ghomomorphisms for FpGroups. *
* Performance improvement in `IntermediateSubgroups` if the smaller subgroup has many orbits *

(The ones with * merit mentioning in the release notes)