### PR TITLE
remove an irritating `if` statement in `MethodsOperation`

### DIFF
--- a/lib/methsel.g
+++ b/lib/methsel.g
@@ -31,7 +31,6 @@ local type,fam,methods,i,j,flag,erg;
   fam:=FamilyObj(obj);
   methods:=METHODS_OPERATION(attr,1);
   for i in [1..LEN_LIST(methods)/(1+BASE_SIZE_METHODS_OPER_ENTRY)] do
-#    nam:=methods[5*(i-1)+5]; # name
     j:=(1+BASE_SIZE_METHODS_OPER_ENTRY)*(i-1);
     flag:=true;
     flag:=flag and IS_SUBSET_FLAGS(type![2],methods[j+2]);
@@ -57,15 +56,8 @@ end;
 VMETHOD_PRINT_INFO := function ( methods, i, arity)
     local offset;
     offset := (arity+BASE_SIZE_METHODS_OPER_ENTRY)*(i-1)+arity;
-    Print("#I  ", methods[offset+4]);
-    if BASE_SIZE_METHODS_OPER_ENTRY >= 5 then
-        Print(" at ", methods[offset+5][1], ":", methods[offset+5][2]);
-    elif FILENAME_FUNC(methods[offset+2]) <> fail then
-        Print(" at ",
-              FILENAME_FUNC(methods[offset+2]), ":",
-              STARTLINE_FUNC(methods[offset+2]));
-    fi;
-    Print("\n");
+    Print("#I  ", methods[offset+4],
+          " at ", methods[offset+5][1], ":", methods[offset+5][2], "\n");
 end;
 
 #############################################################################
@@ -75,13 +67,6 @@ end;
 NEXT_VMETHOD_PRINT_INFO := function ( methods, i, arity)
     local offset;
     offset := (arity+BASE_SIZE_METHODS_OPER_ENTRY)*(i-1)+arity;
-    Print("#I Trying next: ", methods[offset+4]);
-    if BASE_SIZE_METHODS_OPER_ENTRY >= 5 then
-        Print(" at ", methods[offset+5][1], ":", methods[offset+5][2]);
-    elif FILENAME_FUNC(methods[offset+2]) <> fail then
-        Print(" at ",
-              FILENAME_FUNC(methods[offset+2]), ":",
-              STARTLINE_FUNC(methods[offset+2]));
-    fi;
-    Print("\n");
+    Print("#I Trying next: ", methods[offset+4],
+          " at ", methods[offset+5][1], ":", methods[offset+5][2], "\n");
 end;

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -2025,12 +2025,10 @@ BIND_GLOBAL("MethodsOperation", function(oper, nargs)
             func    := meths[i + nargs + 2],
             rank    := meths[i + nargs + 3],
             info    := meths[i + nargs + 4],
+            location := meths[i + nargs + 5],
             rankbase := meths[i + nargs + 6],
             );
         ADD_LIST(result, m);
-        if IsBound(meths[i + nargs + 5]) then
-            m.location := meths[i + nargs + 5];
-        fi;
     od;
     return result;
 end );

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -268,16 +268,9 @@ BIND_GLOBAL( "INSTALL_METHOD_FLAGS",
     # install the method
     methods[i+(narg+2)] := method;
     methods[i+(narg+3)] := rank;
-
     methods[i+(narg+4)] := IMMUTABLE_COPY_OBJ(info);
-
-    if BASE_SIZE_METHODS_OPER_ENTRY >= 5 then
-        methods[i+(narg+5)] := MakeImmutable([INPUT_FILENAME(), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER()]);
-    fi;
-
-    if BASE_SIZE_METHODS_OPER_ENTRY >= 6 then
-        methods[i+(narg+6)] := baserank;
-    fi;
+    methods[i+(narg+5)] := MakeImmutable([INPUT_FILENAME(), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER()]);
+    methods[i+(narg+6)] := baserank;
 
     # flush the cache
     if IsHPCGAP then

--- a/src/c_oper1.c
+++ b/src/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-76837766"
+#define FILE_CRC  "-53205842"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -1526,65 +1526,51 @@ static Obj  HdlrFunc3 (
  CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
- /* if 6 >= 5 then */
- t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(6)) >= ((Int)INTOBJ_INT(5)));
- if ( t_1 ) {
-  
-  /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
-  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
-  C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 );
-  t_3 = GF_MakeImmutable;
-  t_4 = NEW_PLIST( T_PLIST, 3 );
-  SET_LEN_PLIST( t_4, 3 );
-  t_6 = GF_INPUT__FILENAME;
-  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
-   t_5 = CALL_0ARGS( t_6 );
-  }
-  else {
-   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
-  }
-  CHECK_FUNC_RESULT( t_5 );
-  SET_ELM_PLIST( t_4, 1, t_5 );
-  CHANGED_BAG( t_4 );
-  t_5 = GC_READEVALCOMMAND__LINENUMBER;
-  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
-  SET_ELM_PLIST( t_4, 2, t_5 );
-  CHANGED_BAG( t_4 );
-  t_6 = GF_INPUT__LINENUMBER;
-  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
-   t_5 = CALL_0ARGS( t_6 );
-  }
-  else {
-   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
-  }
-  CHECK_FUNC_RESULT( t_5 );
-  SET_ELM_PLIST( t_4, 3, t_5 );
-  CHANGED_BAG( t_4 );
-  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
-   t_2 = CALL_1ARGS( t_3, t_4 );
-  }
-  else {
-   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
-  }
-  CHECK_FUNC_RESULT( t_2 );
-  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
-  
+ /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
+ C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
+ C_SUM_FIA( t_1, l_i, t_2 )
+ CHECK_INT_POS( t_1 );
+ t_3 = GF_MakeImmutable;
+ t_4 = NEW_PLIST( T_PLIST, 3 );
+ SET_LEN_PLIST( t_4, 3 );
+ t_6 = GF_INPUT__FILENAME;
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_0ARGS( t_6 );
  }
- /* fi */
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+ }
+ CHECK_FUNC_RESULT( t_5 );
+ SET_ELM_PLIST( t_4, 1, t_5 );
+ CHANGED_BAG( t_4 );
+ t_5 = GC_READEVALCOMMAND__LINENUMBER;
+ CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
+ SET_ELM_PLIST( t_4, 2, t_5 );
+ CHANGED_BAG( t_4 );
+ t_6 = GF_INPUT__LINENUMBER;
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_0ARGS( t_6 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+ }
+ CHECK_FUNC_RESULT( t_5 );
+ SET_ELM_PLIST( t_4, 3, t_5 );
+ CHANGED_BAG( t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
- /* if 6 >= 6 then */
- t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(6)) >= ((Int)INTOBJ_INT(6)));
- if ( t_1 ) {
-  
-  /* methods[i + (narg + 6)] := baserank; */
-  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
-  C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 );
-  C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
-  
- }
- /* fi */
+ /* methods[i + (narg + 6)] := baserank; */
+ C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
+ C_SUM_FIA( t_1, l_i, t_2 )
+ CHECK_INT_POS( t_1 );
+ C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
  
  /* CHANGED_METHODS_OPERATION( opr, narg ); */
  t_1 = GF_CHANGED__METHODS__OPERATION;
@@ -3687,8 +3673,8 @@ static Obj  HdlrFunc7 (
    t_6 = NewFunction( NameFunc[8], 1, ArgStringToList("obj"), HdlrFunc8 );
    SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
    t_7 = NewFunctionBody();
-   SET_STARTLINE_BODY(t_7, 694);
-   SET_ENDLINE_BODY(t_7, 712);
+   SET_STARTLINE_BODY(t_7, 687);
+   SET_ENDLINE_BODY(t_7, 705);
    SET_FILENAME_BODY(t_7, FileName);
    SET_BODY_FUNC(t_6, t_7);
    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4391,8 +4377,8 @@ static Obj  HdlrFunc11 (
   t_1 = NewFunction( NameFunc[12], 1, ArgStringToList("key"), HdlrFunc12 );
   SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
   t_2 = NewFunctionBody();
-  SET_STARTLINE_BODY(t_2, 891);
-  SET_ENDLINE_BODY(t_2, 895);
+  SET_STARTLINE_BODY(t_2, 884);
+  SET_ENDLINE_BODY(t_2, 888);
   SET_FILENAME_BODY(t_2, FileName);
   SET_BODY_FUNC(t_1, t_2);
   ASS_LVAR( 2, t_1 );
@@ -4510,8 +4496,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[13], 1, ArgStringToList("D"), HdlrFunc13 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 912);
- SET_ENDLINE_BODY(t_7, 912);
+ SET_STARTLINE_BODY(t_7, 905);
+ SET_ENDLINE_BODY(t_7, 905);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4597,8 +4583,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[14], 2, ArgStringToList("D,key"), HdlrFunc14 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 934);
- SET_ENDLINE_BODY(t_7, 957);
+ SET_STARTLINE_BODY(t_7, 927);
+ SET_ENDLINE_BODY(t_7, 950);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4665,8 +4651,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[15], 2, ArgStringToList("D,key"), HdlrFunc15 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 967);
- SET_ENDLINE_BODY(t_7, 975);
+ SET_STARTLINE_BODY(t_7, 960);
+ SET_ENDLINE_BODY(t_7, 968);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4746,8 +4732,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[16], 3, ArgStringToList("D,key,obj"), HdlrFunc16 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 984);
- SET_ENDLINE_BODY(t_7, 997);
+ SET_STARTLINE_BODY(t_7, 977);
+ SET_ENDLINE_BODY(t_7, 990);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5165,8 +5151,8 @@ static Obj  HdlrFunc17 (
  t_4 = NewFunction( NameFunc[18], -1, ArgStringToList("arg"), HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewFunctionBody();
- SET_STARTLINE_BODY(t_5, 1063);
- SET_ENDLINE_BODY(t_5, 1079);
+ SET_STARTLINE_BODY(t_5, 1056);
+ SET_ENDLINE_BODY(t_5, 1072);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5388,12 +5374,8 @@ static Obj  HdlrFunc1 (
       methods[i + (narg + 2)] := method;
       methods[i + (narg + 3)] := rank;
       methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info );
-      if 6 >= 5 then
-          methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] );
-      fi;
-      if 6 >= 6 then
-          methods[i + (narg + 6)] := baserank;
-      fi;
+      methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] );
+      methods[i + (narg + 6)] := baserank;
       CHANGED_METHODS_OPERATION( opr, narg );
       return;
   end ); */
@@ -5403,7 +5385,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
  SET_STARTLINE_BODY(t_4, 147);
- SET_ENDLINE_BODY(t_4, 289);
+ SET_ENDLINE_BODY(t_4, 282);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5422,8 +5404,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[4], -1, ArgStringToList("arg"), HdlrFunc4 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 338);
- SET_ENDLINE_BODY(t_4, 340);
+ SET_STARTLINE_BODY(t_4, 331);
+ SET_ENDLINE_BODY(t_4, 333);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5442,8 +5424,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[5], -1, ArgStringToList("arg"), HdlrFunc5 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 365);
- SET_ENDLINE_BODY(t_4, 367);
+ SET_STARTLINE_BODY(t_4, 358);
+ SET_ENDLINE_BODY(t_4, 360);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5637,8 +5619,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[6], 2, ArgStringToList("arglist,check"), HdlrFunc6 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 378);
- SET_ENDLINE_BODY(t_4, 633);
+ SET_STARTLINE_BODY(t_4, 371);
+ SET_ENDLINE_BODY(t_4, 626);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5700,8 +5682,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[7], 6, ArgStringToList("name,filter,getter,setter,tester,mutflag"), HdlrFunc7 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewFunctionBody();
- SET_STARTLINE_BODY(t_3, 652);
- SET_ENDLINE_BODY(t_3, 716);
+ SET_STARTLINE_BODY(t_3, 645);
+ SET_ENDLINE_BODY(t_3, 709);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5719,8 +5701,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[9], 6, ArgStringToList("name,filter,getter,setter,tester,mutflag"), HdlrFunc9 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewFunctionBody();
- SET_STARTLINE_BODY(t_3, 719);
- SET_ENDLINE_BODY(t_3, 725);
+ SET_STARTLINE_BODY(t_3, 712);
+ SET_ENDLINE_BODY(t_3, 718);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5752,8 +5734,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[10], 2, ArgStringToList("list,elm"), HdlrFunc10 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 738);
- SET_ENDLINE_BODY(t_4, 762);
+ SET_STARTLINE_BODY(t_4, 731);
+ SET_ENDLINE_BODY(t_4, 755);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5841,8 +5823,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[11], 4, ArgStringToList("name,domreq,keyreq,keytest"), HdlrFunc11 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 887);
- SET_ENDLINE_BODY(t_4, 998);
+ SET_STARTLINE_BODY(t_4, 880);
+ SET_ENDLINE_BODY(t_4, 991);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5897,8 +5879,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[17], -1, ArgStringToList("arg"), HdlrFunc17 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 1033);
- SET_ENDLINE_BODY(t_4, 1080);
+ SET_STARTLINE_BODY(t_4, 1026);
+ SET_ENDLINE_BODY(t_4, 1073);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5935,8 +5917,8 @@ static Obj  HdlrFunc1 (
  t_1 = NewFunction( NameFunc[19], 3, ArgStringToList("obj,name,val"), HdlrFunc19 );
  SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
  t_2 = NewFunctionBody();
- SET_STARTLINE_BODY(t_2, 1096);
- SET_ENDLINE_BODY(t_2, 1096);
+ SET_STARTLINE_BODY(t_2, 1089);
+ SET_ENDLINE_BODY(t_2, 1089);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
  AssGVar( G_CHECK__REPEATED__ATTRIBUTE__SET, t_1 );
@@ -6236,7 +6218,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = -76837766,
+ .crc         = -53205842,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/src/hpc/c_oper1.c
+++ b/src/hpc/c_oper1.c
@@ -1,7 +1,7 @@
 #ifndef AVOID_PRECOMPILED
 /* C file produced by GAC */
 #include "compiled.h"
-#define FILE_CRC  "-76837766"
+#define FILE_CRC  "-53205842"
 
 /* global variables used in handlers */
 static GVar G_REREADING;
@@ -1568,65 +1568,51 @@ static Obj  HdlrFunc3 (
  CHECK_FUNC_RESULT( t_2 );
  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
- /* if 6 >= 5 then */
- t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(6)) >= ((Int)INTOBJ_INT(5)));
- if ( t_1 ) {
-  
-  /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
-  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
-  C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 );
-  t_3 = GF_MakeImmutable;
-  t_4 = NEW_PLIST( T_PLIST, 3 );
-  SET_LEN_PLIST( t_4, 3 );
-  t_6 = GF_INPUT__FILENAME;
-  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
-   t_5 = CALL_0ARGS( t_6 );
-  }
-  else {
-   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
-  }
-  CHECK_FUNC_RESULT( t_5 );
-  SET_ELM_PLIST( t_4, 1, t_5 );
-  CHANGED_BAG( t_4 );
-  t_5 = GC_READEVALCOMMAND__LINENUMBER;
-  CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
-  SET_ELM_PLIST( t_4, 2, t_5 );
-  CHANGED_BAG( t_4 );
-  t_6 = GF_INPUT__LINENUMBER;
-  if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
-   t_5 = CALL_0ARGS( t_6 );
-  }
-  else {
-   t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
-  }
-  CHECK_FUNC_RESULT( t_5 );
-  SET_ELM_PLIST( t_4, 3, t_5 );
-  CHANGED_BAG( t_4 );
-  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
-   t_2 = CALL_1ARGS( t_3, t_4 );
-  }
-  else {
-   t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
-  }
-  CHECK_FUNC_RESULT( t_2 );
-  C_ASS_LIST_FPL( l_methods, t_1, t_2 )
-  
+ /* methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] ); */
+ C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(5) )
+ C_SUM_FIA( t_1, l_i, t_2 )
+ CHECK_INT_POS( t_1 );
+ t_3 = GF_MakeImmutable;
+ t_4 = NEW_PLIST( T_PLIST, 3 );
+ SET_LEN_PLIST( t_4, 3 );
+ t_6 = GF_INPUT__FILENAME;
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_0ARGS( t_6 );
  }
- /* fi */
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+ }
+ CHECK_FUNC_RESULT( t_5 );
+ SET_ELM_PLIST( t_4, 1, t_5 );
+ CHANGED_BAG( t_4 );
+ t_5 = GC_READEVALCOMMAND__LINENUMBER;
+ CHECK_BOUND( t_5, "READEVALCOMMAND_LINENUMBER" );
+ SET_ELM_PLIST( t_4, 2, t_5 );
+ CHANGED_BAG( t_4 );
+ t_6 = GF_INPUT__LINENUMBER;
+ if ( TNUM_OBJ( t_6 ) == T_FUNCTION ) {
+  t_5 = CALL_0ARGS( t_6 );
+ }
+ else {
+  t_5 = DoOperation2Args( CallFuncListOper, t_6, NewPlistFromArgs( ) );
+ }
+ CHECK_FUNC_RESULT( t_5 );
+ SET_ELM_PLIST( t_4, 3, t_5 );
+ CHANGED_BAG( t_4 );
+ if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
+  t_2 = CALL_1ARGS( t_3, t_4 );
+ }
+ else {
+  t_2 = DoOperation2Args( CallFuncListOper, t_3, NewPlistFromArgs( t_4 ) );
+ }
+ CHECK_FUNC_RESULT( t_2 );
+ C_ASS_LIST_FPL( l_methods, t_1, t_2 )
  
- /* if 6 >= 6 then */
- t_1 = (Obj)(UInt)(((Int)INTOBJ_INT(6)) >= ((Int)INTOBJ_INT(6)));
- if ( t_1 ) {
-  
-  /* methods[i + (narg + 6)] := baserank; */
-  C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
-  C_SUM_FIA( t_1, l_i, t_2 )
-  CHECK_INT_POS( t_1 );
-  C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
-  
- }
- /* fi */
+ /* methods[i + (narg + 6)] := baserank; */
+ C_SUM_INTOBJS( t_2, l_narg, INTOBJ_INT(6) )
+ C_SUM_FIA( t_1, l_i, t_2 )
+ CHECK_INT_POS( t_1 );
+ C_ASS_LIST_FPL( l_methods, t_1, a_baserank )
  
  /* SET_METHODS_OPERATION( opr, narg, MakeReadOnlySingleObj( methods ) ); */
  t_1 = GF_SET__METHODS__OPERATION;
@@ -3790,8 +3776,8 @@ static Obj  HdlrFunc7 (
    t_6 = NewFunction( NameFunc[8], 1, ArgStringToList("obj"), HdlrFunc8 );
    SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
    t_7 = NewFunctionBody();
-   SET_STARTLINE_BODY(t_7, 694);
-   SET_ENDLINE_BODY(t_7, 712);
+   SET_STARTLINE_BODY(t_7, 687);
+   SET_ENDLINE_BODY(t_7, 705);
    SET_FILENAME_BODY(t_7, FileName);
    SET_BODY_FUNC(t_6, t_7);
    if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4494,8 +4480,8 @@ static Obj  HdlrFunc11 (
   t_1 = NewFunction( NameFunc[12], 1, ArgStringToList("key"), HdlrFunc12 );
   SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
   t_2 = NewFunctionBody();
-  SET_STARTLINE_BODY(t_2, 891);
-  SET_ENDLINE_BODY(t_2, 895);
+  SET_STARTLINE_BODY(t_2, 884);
+  SET_ENDLINE_BODY(t_2, 888);
   SET_FILENAME_BODY(t_2, FileName);
   SET_BODY_FUNC(t_1, t_2);
   ASS_LVAR( 2, t_1 );
@@ -4613,8 +4599,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[13], 1, ArgStringToList("D"), HdlrFunc13 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 912);
- SET_ENDLINE_BODY(t_7, 912);
+ SET_STARTLINE_BODY(t_7, 905);
+ SET_ENDLINE_BODY(t_7, 905);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4722,8 +4708,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[14], 2, ArgStringToList("D,key"), HdlrFunc14 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 934);
- SET_ENDLINE_BODY(t_7, 957);
+ SET_STARTLINE_BODY(t_7, 927);
+ SET_ENDLINE_BODY(t_7, 950);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4790,8 +4776,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[15], 2, ArgStringToList("D,key"), HdlrFunc15 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 967);
- SET_ENDLINE_BODY(t_7, 975);
+ SET_STARTLINE_BODY(t_7, 960);
+ SET_ENDLINE_BODY(t_7, 968);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -4871,8 +4857,8 @@ static Obj  HdlrFunc11 (
  t_6 = NewFunction( NameFunc[16], 3, ArgStringToList("D,key,obj"), HdlrFunc16 );
  SET_ENVI_FUNC( t_6, STATE(CurrLVars) );
  t_7 = NewFunctionBody();
- SET_STARTLINE_BODY(t_7, 984);
- SET_ENDLINE_BODY(t_7, 997);
+ SET_STARTLINE_BODY(t_7, 977);
+ SET_ENDLINE_BODY(t_7, 990);
  SET_FILENAME_BODY(t_7, FileName);
  SET_BODY_FUNC(t_6, t_7);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5290,8 +5276,8 @@ static Obj  HdlrFunc17 (
  t_4 = NewFunction( NameFunc[18], -1, ArgStringToList("arg"), HdlrFunc18 );
  SET_ENVI_FUNC( t_4, STATE(CurrLVars) );
  t_5 = NewFunctionBody();
- SET_STARTLINE_BODY(t_5, 1063);
- SET_ENDLINE_BODY(t_5, 1079);
+ SET_STARTLINE_BODY(t_5, 1056);
+ SET_ENDLINE_BODY(t_5, 1072);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5532,12 +5518,8 @@ static Obj  HdlrFunc1 (
       methods[i + (narg + 2)] := method;
       methods[i + (narg + 3)] := rank;
       methods[i + (narg + 4)] := IMMUTABLE_COPY_OBJ( info );
-      if 6 >= 5 then
-          methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] );
-      fi;
-      if 6 >= 6 then
-          methods[i + (narg + 6)] := baserank;
-      fi;
+      methods[i + (narg + 5)] := MakeImmutable( [ INPUT_FILENAME(  ), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER(  ) ] );
+      methods[i + (narg + 6)] := baserank;
       SET_METHODS_OPERATION( opr, narg, MakeReadOnlySingleObj( methods ) );
       UNLOCK( lk );
       return;
@@ -5548,7 +5530,7 @@ static Obj  HdlrFunc1 (
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
  SET_STARTLINE_BODY(t_4, 147);
- SET_ENDLINE_BODY(t_4, 289);
+ SET_ENDLINE_BODY(t_4, 282);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5567,8 +5549,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[4], -1, ArgStringToList("arg"), HdlrFunc4 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 338);
- SET_ENDLINE_BODY(t_4, 340);
+ SET_STARTLINE_BODY(t_4, 331);
+ SET_ENDLINE_BODY(t_4, 333);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5587,8 +5569,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[5], -1, ArgStringToList("arg"), HdlrFunc5 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 365);
- SET_ENDLINE_BODY(t_4, 367);
+ SET_STARTLINE_BODY(t_4, 358);
+ SET_ENDLINE_BODY(t_4, 360);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5782,8 +5764,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[6], 2, ArgStringToList("arglist,check"), HdlrFunc6 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 378);
- SET_ENDLINE_BODY(t_4, 633);
+ SET_STARTLINE_BODY(t_4, 371);
+ SET_ENDLINE_BODY(t_4, 626);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5845,8 +5827,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[7], 6, ArgStringToList("name,filter,getter,setter,tester,mutflag"), HdlrFunc7 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewFunctionBody();
- SET_STARTLINE_BODY(t_3, 652);
- SET_ENDLINE_BODY(t_3, 716);
+ SET_STARTLINE_BODY(t_3, 645);
+ SET_ENDLINE_BODY(t_3, 709);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5864,8 +5846,8 @@ static Obj  HdlrFunc1 (
  t_2 = NewFunction( NameFunc[9], 6, ArgStringToList("name,filter,getter,setter,tester,mutflag"), HdlrFunc9 );
  SET_ENVI_FUNC( t_2, STATE(CurrLVars) );
  t_3 = NewFunctionBody();
- SET_STARTLINE_BODY(t_3, 719);
- SET_ENDLINE_BODY(t_3, 725);
+ SET_STARTLINE_BODY(t_3, 712);
+ SET_ENDLINE_BODY(t_3, 718);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5897,8 +5879,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[10], 2, ArgStringToList("list,elm"), HdlrFunc10 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 738);
- SET_ENDLINE_BODY(t_4, 762);
+ SET_STARTLINE_BODY(t_4, 731);
+ SET_ENDLINE_BODY(t_4, 755);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -5986,8 +5968,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[11], 4, ArgStringToList("name,domreq,keyreq,keytest"), HdlrFunc11 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 887);
- SET_ENDLINE_BODY(t_4, 998);
+ SET_STARTLINE_BODY(t_4, 880);
+ SET_ENDLINE_BODY(t_4, 991);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -6042,8 +6024,8 @@ static Obj  HdlrFunc1 (
  t_3 = NewFunction( NameFunc[17], -1, ArgStringToList("arg"), HdlrFunc17 );
  SET_ENVI_FUNC( t_3, STATE(CurrLVars) );
  t_4 = NewFunctionBody();
- SET_STARTLINE_BODY(t_4, 1033);
- SET_ENDLINE_BODY(t_4, 1080);
+ SET_STARTLINE_BODY(t_4, 1026);
+ SET_ENDLINE_BODY(t_4, 1073);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -6080,8 +6062,8 @@ static Obj  HdlrFunc1 (
  t_1 = NewFunction( NameFunc[19], 3, ArgStringToList("obj,name,val"), HdlrFunc19 );
  SET_ENVI_FUNC( t_1, STATE(CurrLVars) );
  t_2 = NewFunctionBody();
- SET_STARTLINE_BODY(t_2, 1096);
- SET_ENDLINE_BODY(t_2, 1096);
+ SET_STARTLINE_BODY(t_2, 1089);
+ SET_ENDLINE_BODY(t_2, 1089);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
  AssGVar( G_CHECK__REPEATED__ATTRIBUTE__SET, t_1 );
@@ -6397,7 +6379,7 @@ static Int InitLibrary ( StructInitInfo * module )
 static StructInitInfo module = {
  .type        = MODULE_STATIC,
  .name        = "GAPROOT/lib/oper1.g",
- .crc         = -76837766,
+ .crc         = -53205842,
  .initKernel  = InitKernel,
  .initLibrary = InitLibrary,
  .postRestore = PostRestore,

--- a/tst/testinstall/varargs.tst
+++ b/tst/testinstall/varargs.tst
@@ -88,7 +88,7 @@ function ( opr, info, rel, flags, baserank, method )
 end
 gap> Display(InstallMethod);
 function ( arg... )
-    <<compiled GAP code>> from GAPROOT/lib/oper1.g:338
+    <<compiled GAP code>> from GAPROOT/lib/oper1.g:331
 end
 gap> [1..2];
 [ 1, 2 ]


### PR DESCRIPTION
The component `location` in the records returned by `MethodsOperation` is always bound.
Note that the check before the definition of `MethodsOperation` guarantees that the list returned by `METHODS_OPERATION` has the right format.