### PR TITLE
`Random` for non-dense lists and empty intervals

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -254,7 +254,7 @@ InstallMethod( RepresentativeSmallest,
 # RandomList is not an operation to avoid the (often expensive) cost of
 # dispatch for lists
 InstallGlobalFunction( RandomList, function(args...)
-  local len, source, list;
+  local len, source, list, nr;
   len := Length(args);
   if len = 1 then
     source := GlobalMersenneTwister;
@@ -266,7 +266,11 @@ InstallGlobalFunction( RandomList, function(args...)
     Error(" Usage: RandomList([rs], list))");
   fi;
 
-  return list[Random(source, 1, Length(list))];
+  repeat
+    nr:= Random( source, 1, Length( list ) );
+  until IsBound( list[ nr ] );
+
+  return list[ nr ];
 end );
 
 

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -8,6 +8,7 @@ gap> randomTest([1..100], RandomList);
 gap> randomTest("abcdef", RandomList);
 gap> randomTest(BlistList([1..100],[1,3..99]), RandomList);
 gap> randomTest([1], RandomList);
+gap> randomTest( [ 1,,,,,,, 2 ], RandomList );
 
 #
 # fields and rings
@@ -150,6 +151,21 @@ gap> randomTest([1..2], Random);
 gap> randomTest([0, 10..1000], Random);
 gap> randomTest("cheese", Random);
 gap> randomTest([1,-6,"cheese", Group(())], Random);
+gap> randomTest( [ 1,,,,,,, 2 ], Random );
+
+# non-dense lists (there should not be an error)
+gap> List( [ 1 .. 1000 ], i -> Random( [ 1,,,,,,, 2 ] ) );;
+gap> List( [ 1 .. 1000 ],
+>          i -> Random( RandomSource( IsMersenneTwister ), [ 1,,,,,,, 2 ] ) );;
+
+# unusual bounds
+gap> R:= RandomSource( IsMersenneTwister );;
+gap> Random( R, 1, -1 ) = fail;
+true
+gap> Random( R, 1, 0 ) = fail;
+true
+gap> Random( R, 1, 1 ) = 1;
+true
 
 #
 gap> randomTest(PadicExtensionNumberFamily(3, 5, [1,1,1], [1,1]), Random, function(x,y) return IsPadicExtensionNumber(x); end);


### PR DESCRIPTION
- Admit `Random` for non-dense lists:
  The documentation has always allowed this,
  the IO package has a correct method for non-dense lists (thus we cannot simply require `IsDenseList`),
  just the methods in the GAP library did not catch this case.

- Improved `Random( RandomSource( IsMersenneTwister ), 1, 0 )`:
  This had returned `1`, now it returns `fail`.
  Note that the documentation does not state what happens
  if the given interval is empty,
  thus I do not claim that the change is a bugfix.

(resolves #4379)