### PR TITLE
Slack Notifications: send current status, not previous

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -299,6 +299,6 @@ jobs:
         uses: act10ns/slack@e4e71685b9b239384b0f676a63c32367f59c2522
         if: steps.should_notify.outputs.should_send_message == 'yes'
         with:
-          status: ${{ steps.should_notify.outputs.last_status }}
+          status: ${{ steps.should_notify.outputs.current_status }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Although the Action was sending the notification at (pretty much) the right time, it was not always (not ever?) sending the correct message. This also required that I make the following PR https://github.com/gap-actions/should-i-notify-action/pull/1 which is now merged.

I have spent today testing this on the repository here, and I have satisfied myself that it now sends the right notification at the right time.