### PR TITLE
CI: detect failure to run `make docomp` nicely again

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -194,7 +194,7 @@ run_configure_and_make() {
   then
     if grep Autoconf ./configure > /dev/null
     then
-      local PKG_NAME=$($GAP -q -T -A -r <<GAPInput
+      local PKG_NAME=$($GAP -q -T -A -r -M <<GAPInput
 Read("PackageInfo.g");
 Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput


### PR DESCRIPTION
We have a test for our CI which detects if a PR should have run `make docomp`.
But we did not reach it anymore since some changes to `bin/BuildPackages.sh`
which added code to use GAP to extract the name of any given packages, by
letting GAP print it to stdout and grabbing it from there. But in this
particular failure scenario, GAP also printed a warning, which caused
`BuildPackages.sh` to fail. This patch suppresses that warning.

To verify this works, I am adding a commit which is supposed to trigger this failure mode.

UPDATE: test worked as desired, see e.g. https://github.com/gap-system/gap/runs/2394724252?check_suite_focus=true
