### PR TITLE
Refactor some of the release scripts

### DIFF
--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -53,11 +53,18 @@ with utils.working_directory(PATH_TO_RELEASE):
     manifest_filename = "MANIFEST"
     with open(manifest_filename, 'r') as manifest_file:
         manifest = manifest_file.read().splitlines()
+
+    utils.notice(f"Contents of {manifest_filename}:")
+    for filename in manifest:
+        print(filename)
+
     # Now check that TAG_NAME and the created archives belong together
     main_archive_name = "gap-" + TAG_NAME[1:] + ".tar.gz"
     if not main_archive_name in manifest:
-        utils.error(f"Expected a file {main_archive_name} but it does not exist!")
+        utils.error(f"Expected to find {main_archive_name} in MANIFEST, but did not!")
+
     # Upload all assets to release
+    utils.notice("Uploading release assets")
     try:
         for filename in manifest:
             utils.notice("Uploading " + filename)

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -8,23 +8,16 @@
 # If we do import * from utils, then initialize_github can't overwrite the
 # global GITHUB_INSTANCE and CURRENT_REPO variables.
 import utils
-import github
-import os
 import sys
-import re
 
 if len(sys.argv) != 3:
     utils.error("usage: "+sys.argv[0]+" <tag_name> <path_to_release>")
 
-utils.verify_git_clean()
-
 TAG_NAME = sys.argv[1]
 PATH_TO_RELEASE = sys.argv[2]
 
-if re.fullmatch( r"v[1-9]+\.[0-9]+\.[0-9]+", TAG_NAME) == None:
-    utils.error("This does not look like a release version")
-
-# Initialize GITHUB_INSTANCE and CURRENT_REPO
+utils.verify_git_clean()
+utils.verify_is_possible_gap_release_tag(TAG_NAME)
 utils.initialize_github()
 
 # Error if the tag TAG_NAME hasn't been pushed to CURRENT_REPO yet.
@@ -65,9 +58,5 @@ with utils.working_directory(PATH_TO_RELEASE):
 
     # Upload all assets to release
     utils.notice("Uploading release assets")
-    try:
-        for filename in manifest:
-            utils.notice("Uploading " + filename)
-            RELEASE.upload_asset(filename)
-    except github.GithubException:
-        utils.error("Error: The upload failed")
+    for filename in manifest:
+        utils.upload_asset_with_checksum(RELEASE, filename)


### PR DESCRIPTION
I have broken this out of #4389, just to make that PR smaller, and this stuff is ready to go.

> The first two commits make some fairly superficial changes to the pre-existing dev/releases scripts `utils.py`, `make_archives.py`, and `make_github_release.py`. Please see the commit messages for more information about this. These changes were helpful for the subsequent commit, one way or another (even if just for easier debugging).