### PR TITLE
docs: mention FirstOp, LastOp, ForAllOp, etc.

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -2051,6 +2051,10 @@ DeclareAttribute( "UnderlyingCollection", IsListOrCollection );
 ##  same as <Ref Oper="ShallowCopy"/> (see also 
 ##  <Ref Sect="Duplication of Lists"/>).
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>ListOp</C>.
+##  <Index Key="ListOp"><C>ListOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> List( [1,2,3], i -> i^2 );
 ##  [ 1, 4, 9 ]
@@ -2084,6 +2088,10 @@ DeclareAttribute( "UnderlyingCollection", IsListOrCollection );
 ##  <!-- this is not reasonable since <C>ShallowCopy</C> need not guarantee to return-->
 ##  <!-- a constant time access list-->
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>ListOp</C>.
+##  <Index Key="ListOp"><C>ListOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> l:= List( Group( (1,2,3) ) );
 ##  [ (), (1,3,2), (1,2,3) ]
@@ -2098,8 +2106,8 @@ DeclareAttribute( "UnderlyingCollection", IsListOrCollection );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "List" );
-
 DeclareOperation( "ListOp", [ IsListOrCollection ] );
 DeclareOperation( "ListOp", [ IsListOrCollection, IsFunction ] );
 
@@ -2453,6 +2461,10 @@ DeclareGlobalFunction( "Elements" );
 ##  This is useful for example if the first argument is empty and a different
 ##  zero than <C>0</C> is desired, in which case <A>init</A> is returned.
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>SumOp</C>.
+##  <Index Key="SumOp"><C>SumOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Sum( [ 2, 3, 5, 7, 11, 13, 17, 19 ] );
 ##  77
@@ -2467,28 +2479,8 @@ DeclareGlobalFunction( "Elements" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "Sum" );
-
-
-#############################################################################
-##
-#O  SumOp( <C> )
-#O  SumOp( <C>, <func> )
-#O  SumOp( <C>, <init> )
-#O  SumOp( <C>, <func>, <init> )
-##
-##  <ManSection>
-##  <Oper Name="SumOp" Arg='C'/>
-##  <Oper Name="SumOp" Arg='C, func'/>
-##  <Oper Name="SumOp" Arg='C, init'/>
-##  <Oper Name="SumOp" Arg='C, func, init'/>
-##
-##  <Description>
-##  <C>SumOp</C> is the operation called by <C>Sum</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "SumOp", [ IsListOrCollection ] );
 
 
@@ -2531,6 +2523,10 @@ DeclareOperation( "SumOp", [ IsListOrCollection ] );
 ##  This is useful for example if the first argument is empty and a different
 ##  identity than <C>1</C> is desired, in which case <A>init</A> is returned.
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>ProductOp</C>.
+##  <Index Key="ProductOp"><C>ProductOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Product( [ 2, 3, 5, 7, 11, 13, 17, 19 ] );
 ##  9699690
@@ -2545,28 +2541,8 @@ DeclareOperation( "SumOp", [ IsListOrCollection ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "Product" );
-
-
-#############################################################################
-##
-#O  ProductOp( <C> )
-#O  ProductOp( <C>, <func> )
-#O  ProductOp( <C>, <init> )
-#O  ProductOp( <C>, <func>, <init> )
-##
-##  <ManSection>
-##  <Oper Name="ProductOp" Arg='C'/>
-##  <Oper Name="ProductOp" Arg='C, func'/>
-##  <Oper Name="ProductOp" Arg='C, init'/>
-##  <Oper Name="ProductOp" Arg='C, func, init'/>
-##
-##  <Description>
-##  <C>ProductOp</C> is the operation called by <C>Product</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "ProductOp", [ IsListOrCollection ] );
 
 
@@ -2604,6 +2580,10 @@ DeclareOperation( "ProductOp", [ IsListOrCollection ] );
 ##  (see&nbsp;<Ref Sect="List Assignment"/>) can be used to extract
 ##  elements of a list according to indices given in another list.
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>FilteredOp</C>.
+##  <Index Key="FilteredOp"><C>FilteredOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Filtered( [1..20], IsPrime );
 ##  [ 2, 3, 5, 7, 11, 13, 17, 19 ]
@@ -2619,22 +2599,8 @@ DeclareOperation( "ProductOp", [ IsListOrCollection ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "Filtered" );
-
-
-#############################################################################
-##
-#O  FilteredOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="FilteredOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>FilteredOp</C> is the operation called by <C>Filtered</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "FilteredOp", [ IsListOrCollection, IsFunction ] );
 
 
@@ -2671,6 +2637,10 @@ DeclareOperation( "FilteredOp", [ IsListOrCollection, IsFunction ] );
 ##  <Ref Func="Filtered"/> allows you to extract the elements of a list
 ##  that have a certain property.
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>NumberOp</C>.
+##  <Index Key="NumberOp"><C>NumberOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Number( [ 2, 3, 5, 7 ] );
 ##  4
@@ -2690,22 +2660,8 @@ DeclareOperation( "FilteredOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "Number" );
-
-
-#############################################################################
-##
-#O  NumberOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="NumberOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>NumberOp</C> is the operation called by <C>Number</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "NumberOp", [ IsListOrCollection, IsFunction ] );
 
 
@@ -2722,6 +2678,10 @@ DeclareOperation( "NumberOp", [ IsListOrCollection, IsFunction ] );
 ##  tests whether the unary function <A>func</A> returns <K>true</K>
 ##  for all elements in the list or collection <A>listorcoll</A>.
 ##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>ForAllOp</C>.
+##  <Index Key="ForAllOp"><C>ForAllOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> ForAll( [1..20], IsPrime );
 ##  false
@@ -2736,22 +2696,8 @@ DeclareOperation( "NumberOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "ForAll" );
-
-
-#############################################################################
-##
-#O  ForAllOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="ForAllOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>ForAllOp</C> is the operation called by <C>ForAll</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "ForAllOp", [ IsListOrCollection, IsFunction ] );
 
 
@@ -2767,6 +2713,10 @@ DeclareOperation( "ForAllOp", [ IsListOrCollection, IsFunction ] );
 ##  <Description>
 ##  tests whether the unary function <A>func</A> returns <K>true</K>
 ##  for at least one element in the list or collection <A>listorcoll</A>.
+##  <P/>
+##  Developers who wish to adapt this for custom list or collection types need to
+##  install suitable methods for the operation <C>ForAnyOp</C>.
+##  <Index Key="ForAnyOp"><C>ForAnyOp</C></Index>
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> ForAny( [1..20], IsPrime );
@@ -2784,22 +2734,8 @@ DeclareOperation( "ForAllOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "ForAny" );
-
-
-#############################################################################
-##
-#O  ForAnyOp( <C>, <func> )
-##
-##  <ManSection>
-##  <Oper Name="ForAnyOp" Arg='C, func'/>
-##
-##  <Description>
-##  <C>ForAnyOp</C> is the operation called by <C>ForAny</C>
-##  if <A>C</A> is not an internal list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "ForAnyOp", [ IsListOrCollection, IsFunction ] );
 
 

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -688,11 +688,14 @@ DeclareOperation( "Position", [ IsList, IsObject, IS_INT ] );
 ##  <#GAPDoc Label="Positions">
 ##  <ManSection>
 ##  <Func Name="Positions" Arg='list, obj'/>
-##  <Oper Name="PositionsOp" Arg='list, obj'/>
 ##
 ##  <Description>
 ##  returns the set of positions of <E>all</E> occurrences of <A>obj</A> in
 ##  <A>list</A>.
+##  <P/>
+##  Developers who wish to adapt this for custom list types need to
+##  install suitable methods for the operation <C>PositionsOp</C>.
+##  <Index Key="PositionsOp"><C>PositionsOp</C></Index>
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Positions([1,2,1,2,3,2,2],2);
@@ -704,6 +707,7 @@ DeclareOperation( "Position", [ IsList, IsObject, IS_INT ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch plain lists by a function to avoid method selection:
 DeclareGlobalFunction( "Positions" );
 DeclareOperation( "PositionsOp", [ IsList, IsObject ] );
 
@@ -786,7 +790,6 @@ DeclareOperation( "PositionNthOccurrence", [ IsList, IsObject, IS_INT ] );
 ##  <Func Name="PositionSorted" Arg='list, elm[, func]'/>
 ##
 ##  <Description>
-##  <Index Key="PositionSortedOp"><C>PositionSortedOp</C></Index>
 ##  Called with two arguments, <Ref Func="PositionSorted"/> returns
 ##  the position of the element <A>elm</A> in the sorted list <A>list</A>.
 ##  <P/>
@@ -816,8 +819,9 @@ DeclareOperation( "PositionNthOccurrence", [ IsList, IsObject, IS_INT ] );
 ##  for testing whether a list is sorted,
 ##  see&nbsp;<Ref Prop="IsSortedList"/> and <Ref Prop="IsSSortedList"/>.
 ##  <P/>
-##  Specialized functions for certain kinds of lists must be installed 
-##  as methods for the operation <C>PositionSortedOp</C>.
+##  Developers who wish to adapt this for custom list types need to
+##  install suitable methods for the operation <C>PositionSortedOp</C>.
+##  <Index Key="PositionSortedOp"><C>PositionSortedOp</C></Index>
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> PositionSorted( [1,4,5,5,6,7], 0 );
@@ -839,10 +843,6 @@ DeclareOperation( "PositionNthOccurrence", [ IsList, IsObject, IS_INT ] );
 DeclareGlobalFunction( "PositionSorted" );
 DeclareOperation( "PositionSortedOp", [ IsList, IsObject ] );
 DeclareOperation( "PositionSortedOp", [ IsList, IsObject, IsFunction ] );
-#T originally was
-#T DeclareOperation( "PositionSorted", [ IsHomogeneousList, IsObject ] );
-#T note the problem with inhomogeneous lists that may be sorted
-#T (although they cannot store this and claim that they are not sorted)
 
 
 #############################################################################
@@ -854,7 +854,6 @@ DeclareOperation( "PositionSortedOp", [ IsList, IsObject, IsFunction ] );
 ##  <Func Name="PositionSortedBy" Arg='list, val, func'/>
 ##
 ##  <Description>
-##  <Index Key="PositionSortedByOp"><C>PositionSortedByOp</C></Index>
 ##  This function returns the same value that would be returned by
 ##  <C>PositionSorted(List(list, func), val)</C>, but computes it in
 ##  a more efficient way.
@@ -879,8 +878,9 @@ DeclareOperation( "PositionSortedOp", [ IsList, IsObject, IsFunction ] );
 ##  <Ref Func="PositionSortedBy"/> uses binary search.
 ##  Each <C>func(list[i])</C> is computed at most once.
 ##  <P/>
-##  Specialized functions for certain kinds of lists must be installed
-##  as methods for the operation <C>PositionSortedByOp</C>.
+##  Developers who wish to adapt this for custom list types need to
+##  install suitable methods for the operation <C>PositionSortedByOp</C>.
+##  <Index Key="PositionSortedByOp"><C>PositionSortedByOp</C></Index>
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> PositionSortedBy( [ "", "ab", ], -1, Length );
@@ -898,6 +898,7 @@ DeclareOperation( "PositionSortedOp", [ IsList, IsObject, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch plain lists by a function to avoid method selection:
 DeclareGlobalFunction( "PositionSortedBy" );
 DeclareOperation("PositionSortedByOp", [ IsList, IsObject, IsFunction ]);
 
@@ -1549,6 +1550,10 @@ DeclareOperation( "Flat", [ IsList ] );
 ##  which can also be formulated in terms of the <C>{}</C> operator
 ##  (see&nbsp;<Ref Sect="List Assignment"/>).
 ##  <P/>
+##  Developers who wish to adapt this for custom list types need to
+##  install suitable methods for the operation <C>ReversedOp</C>.
+##  <Index Key="ReversedOp"><C>ReversedOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Reversed( [ 1, 4, 9, 5, 6, 7 ] );
 ##  [ 7, 6, 5, 9, 4, 1 ]
@@ -1557,25 +1562,10 @@ DeclareOperation( "Flat", [ IsList ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "Reversed" );
-
-
-#############################################################################
-##
-#O  ReversedOp( <list> )  . . . . . . . . . .  reverse the elements in a list
-##
-##  <ManSection>
-##  <Oper Name="ReversedOp" Arg='list'/>
-##
-##  <Description>
-##  <Ref Oper="ReversedOp"/> is the operation called by
-##  <Ref Func="Reversed"/> if <A>list</A> is not an internal list.
-##  (Note that it would not make sense to turn this into an attribute
-##  because the result shall be mutable.)
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "ReversedOp", [ IsDenseList ] );
+
 
 #############################################################################
 ##
@@ -2110,6 +2100,10 @@ DeclareGlobalFunction( "IteratorList" );
 ##  position of the first element in a list that satisfies a certain
 ##  property.
 ##  <P/>
+##  Developers who wish to adapt this for custom list types need to
+##  install suitable methods for the operation <C>FirstOp</C>.
+##  <Index Key="FirstOp"><C>FirstOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> First( [10^7..10^8], IsPrime );
 ##  10000019
@@ -2125,22 +2119,8 @@ DeclareGlobalFunction( "IteratorList" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "First" );
-
-
-#############################################################################
-##
-#O  FirstOp( <list>[, <func>] )
-##
-##  <ManSection>
-##  <Oper Name="FirstOp" Arg='list[, func]'/>
-##
-##  <Description>
-##  <Ref Oper="FirstOp"/> is the operation called by <Ref Func="First"/>
-##  if <A>list</A> is not an internally represented list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "FirstOp", [ IsListOrCollection ] );
 DeclareOperation( "FirstOp", [ IsListOrCollection, IsFunction ] );
 
@@ -2163,6 +2143,10 @@ DeclareOperation( "FirstOp", [ IsListOrCollection, IsFunction ] );
 ##  If <A>func</A> returns <K>false</K> for all elements of <A>list</A>
 ##  then <Ref Func="Last"/> returns <K>fail</K>.
 ##  <P/>
+##  Developers who wish to adapt this for custom list types need to
+##  install suitable methods for the operation <C>LastOp</C>.
+##  <Index Key="LastOp"><C>LastOp</C></Index>
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> Last( [10^7..10^8], IsPrime );
 ##  99999989
@@ -2178,22 +2162,8 @@ DeclareOperation( "FirstOp", [ IsListOrCollection, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+##  We catch internal lists by a function to avoid method selection:
 DeclareGlobalFunction( "Last" );
-
-
-#############################################################################
-##
-#O  LastOp( <list>[, <func>] )
-##
-##  <ManSection>
-##  <Oper Name="LastOp" Arg='list[, func]'/>
-##
-##  <Description>
-##  <Ref Oper="LastOp"/> is the operation called by <Ref Func="Last"/>
-##  if <A>list</A> is not an internally represented list.
-##  </Description>
-##  </ManSection>
-##
 DeclareOperation( "LastOp", [ IsListOrCollection ] );
 DeclareOperation( "LastOp", [ IsListOrCollection, IsFunction ] );
 


### PR DESCRIPTION
... in the documentation entries for their non-Op counterparts First, Last,
ForAll, etc. and explain that custom methods need to be installed there.

Also explain uniformly that this is to avoid the method selection overhead
penalty for plain list inputs.

This may be helpful for some people, and it certainly would have saved me time back when I created the misguided PR #259 :-).

I am sure this could be phrased better; I am open for suggestions. I tried to write it in such a way that a regular users understand they can ignore it, yet can still have an idea what this is about. 

Finally, of course there are alternatives; e.g. we could add separate manual entries for FirstOp, ... etc.; but I thought it made sense to not do so, as they are in a sense an internal implementation detail, so it is OK to only mention them in passing (just enough so that people who stumble across them get a rough idea and developers have enough to know where to dig). But here, too, I am open to having my mind changed :-).