### PR TITLE
[WIP] Python script to get package status reports

### DIFF
--- a/dev/releases/package_status.py
+++ b/dev/releases/package_status.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Usage:
+#     ./package_status.py
+# or
+#     ./package_status.py pkg-name
+# or
+#     ./package_status.py account/pkg-name
+# 
+
+import sys
+import json
+import os.path
+from github import Github
+from datetime import datetime
+import utils
+
+
+def usage():
+    print("""Usage:
+        ./package_status.py
+    or
+        ./package_status.py pkg-name
+    or
+        ./package_status.py account/pkg-name""")
+    sys.exit(1)
+
+
+def package_report(repo):
+
+    # could be a string or a repo object
+    if type(repo)==str:
+         repo = g.get_repo("gap-packages/"+repo)
+
+    print("#", repo.name)
+
+    # report lates release
+    nr_releases = repo.get_releases().totalCount
+    if nr_releases > 0:
+        latest_release = repo.get_latest_release()
+        print("Latest release", latest_release.tag_name, "on", latest_release.published_at)        
+    else:
+        print("No releases")
+        return
+ 
+    # count commits since the last release (TODO: check to which branch)
+    new_commits = repo.get_commits(since = latest_release.published_at)
+    nr_new_commits = 0
+    for c in new_commits:
+            nr_new_commits = nr_new_commits +1
+    print("Commits since latest release:", nr_new_commits)
+
+    # find approved PRs and PRs awaiting for the review to start
+    approved_prs = []
+    unseen_prs = []
+    nr_open_prs = 0 
+    # TODO: what if branch is 'main'
+    prs = repo.get_pulls(state='open', sort='created', base='master')
+    for pr in prs:
+        nr_open_prs = nr_open_prs + 1
+        approve_count = 0
+        for review in pr.get_reviews():
+            if review.state == 'APPROVED':
+                approve_count = approve_count + 1
+        if approve_count > 0:  
+            approved_prs.append([pr.number,pr.title,approve_count])
+    print("Open pull requests:", nr_open_prs)
+    print("- of them approved:", len(approved_prs))
+
+                    
+def full_report():
+    # TODO: way to take repositories from gap-distribution list instead, in alphabetic order
+    # below, most recently updated repositories will be listed first
+    repos = g.search_repositories(query="org:gap-packages", sort = "updated", order ="desc")
+    for repo in repos:
+        package_report(repo)
+        print()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        usage()
+    else:
+        utils.initialize_github()
+        g = utils.GITHUB_INSTANCE
+        print("Current GitHub API capacity", g.rate_limiting, "at", datetime.now().isoformat(), "\n" )
+
+        if len(sys.argv) == 1:
+            full_report()
+        if len(sys.argv) == 2:
+            package_report(sys.argv[1])
+
+        print("Remaining GitHub API capacity", g.rate_limiting, "at", datetime.now().isoformat(), "\n" )


### PR DESCRIPTION
Working on a script to get quick overview of packages. The plan is that it can produce a report for one package, or for all packages from the gap-packages organisation, or (to be added in the next revision) for all packages redistributed with GAP. This script is submitted to the main GAP repository since it uses the same mechanism for GitHub authentication as other release related scripts from the same directory.

I envisage that before the release, it can help us to see better if there are any "low hanging fruits" - i.e. packages which already have changes since their last release, and/or approved open pull requests waiting to be merged. Those can be checked, and maybe quickly released after such checks, if they are release ready and there is a desire to include them in the next GAP release.

A few examples:

1) individual reports:

```
releases $ ./package_status.py recog   
Accessing repository gap-system/gap
Current GitHub API capacity (3103, 5000) at 2021-04-22T23:35:34.807310 

# recog
Latest release v1.3.2 on 2019-04-15 10:55:44
Commits since latest release: 234
Open pull requests: 11
- of them approved: 1
Remaining GitHub API capacity (3077, 5000) at 2021-04-22T23:35:42.129035 

releases $ ./package_status.py example
Accessing repository gap-system/gap
Current GitHub API capacity (3075, 5000) at 2021-04-22T23:35:53.175867 

# example
Latest release v4.3.0 on 2021-02-22 19:01:09
Commits since latest release: 2
Open pull requests: 2
- of them approved: 0
Remaining GitHub API capacity (3068, 5000) at 2021-04-22T23:35:54.846051 

releases $ ./package_status.py wedderga
Accessing repository gap-system/gap
Current GitHub API capacity (3067, 5000) at 2021-04-22T23:36:02.523015 

# wedderga
Latest release v4.10.0 on 2020-05-14 19:05:08
Commits since latest release: 3
Open pull requests: 0
- of them approved: 0
Remaining GitHub API capacity (3062, 5000) at 2021-04-22T23:36:03.542803 
```

2) full report for gap-packages: most recently updated packages listed first:
```
releases $ ./package_status.py         
Accessing repository gap-system/gap
Current GitHub API capacity (3061, 5000) at 2021-04-22T23:38:02.918766 

# 4ti2gap
No releases

# curlInterface
Latest release v2.2.1 on 2020-04-03 14:38:58
Commits since latest release: 11
Open pull requests: 0
- of them approved: 0

# resclasses
Latest release v4.7.2 on 2019-03-24 13:02:07
Commits since latest release: 8
Open pull requests: 0
- of them approved: 0

# example
Latest release v4.3.0 on 2021-02-22 19:01:09
Commits since latest release: 2
Open pull requests: 2
- of them approved: 0

# laguna
Latest release v3.9.3 on 2019-05-19 16:58:16
Commits since latest release: 6
Open pull requests: 2
- of them approved: 1

# img
Latest release v0.2.3 on 2019-03-19 12:52:24
Commits since latest release: 24
Open pull requests: 1
- of them approved: 1

# primgrp
Latest release v3.4.1 on 2020-05-05 13:37:06
Commits since latest release: 14
Open pull requests: 2
- of them approved: 0

# HeLP
Latest release v3.5 on 2019-12-20 18:17:37
Commits since latest release: 2
Open pull requests: 0
- of them approved: 0

# rds
Latest release v1.7 on 2019-02-22 23:38:33
Commits since latest release: 6
Open pull requests: 0
- of them approved: 0

...
...
...

# crystcat
No releases

# subsemi
Latest release v0.76 on 2016-02-27 11:31:26
Commits since latest release: 234
Open pull requests: 0
- of them approved: 0

# FrancyMonoids
No releases

# itc
Latest release v1.5 on 2018-06-13 14:02:53
Commits since latest release: 2
Open pull requests: 0
- of them approved: 0

# matrixss
No releases

# happrime
No releases

# PythonInterface
No releases

# recogbase
Latest release v1.3 on 2018-09-16 21:57:57
Commits since latest release: 0
Open pull requests: 0
- of them approved: 0

# GAPQuickcheck
No releases

# biogap
No releases

# gapbench
No releases

# semirings
No releases

# ve
No releases

Remaining GitHub API capacity (2464, 5000) at 2021-04-22T23:40:14.272519 

releases $ 
```