### PR TITLE
Add scheduled and manual triggers for the CI GitHub Actions workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,8 +2,12 @@ name: CI
 
 # Trigger the workflow on push or pull request
 on:
-  - push
-  - pull_request
+  workflow_dispatch:
+  pull_request:
+  push:
+  schedule:
+    # Every day at 2:30 AM UTC
+    - cron: '30 2 * * *'
 
 env:
   CFLAGS: "--coverage -O2 -g"


### PR DESCRIPTION
Now that #4389 has been merged, these triggers are in place for the "Wrap releases" workflow, so we may as well do the same for the "CI" workflow, too.