### PR TITLE
CI: revise coverage gathering and uploading

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -219,9 +219,13 @@ jobs:
             doc/*/*.js
       - name: "Gather coverage data"
         run: ${{ matrix.extra }} dev/ci-gather-coverage.sh
-      - name: "Upload coverage data"
-        run: ${{ matrix.extra }} dev/ci-upload-coverage.sh
-      # - uses: codecov/codecov-action@v1
+      - name: "Upload coverage data to Codecov"
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "!./pkg/**,!./extern/**"
+          gcov_path_exclude: "./pkg/**"
+
 
   # Based on https://github.com/mit-plv/fiat-crypto/blob/master/.github/workflows/coq-windows.yml
   test-cygwin:

--- a/dev/ci-gather-coverage.sh
+++ b/dev/ci-gather-coverage.sh
@@ -31,13 +31,7 @@ BUILDDIR=$PWD
 # We need to compile the profiling package in order to generate coverage
 # reports; and also the IO package, as the profiling package depends on it.
 pushd "$SRCDIR/pkg"
-
-# Compile io and profiling packages
-# we deliberately reset CFLAGS, CXXFLAGS, LDFLAGS to prevent them from being
-# compiled with coverage gathering, because otherwise gcov may confuse
-# IO's src/io.c with GAP's.
-CFLAGS= CXXFLAGS= LDFLAGS= "$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR" io* profiling*
-
+"$SRCDIR/bin/BuildPackages.sh" --strict --with-gaproot="$BUILDDIR" io* profiling*
 popd
 
 

--- a/dev/ci-upload-coverage.sh
+++ b/dev/ci-upload-coverage.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set +ex
-set +H
-
-# upload to Codecov
-curl -s https://codecov.io/bash > codecov.sh
-chmod +x codecov.sh
-./codecov.sh -f '!./pkg/**' -f '!./extern/**' -g './pkg/**' -g './extern/**'


### PR DESCRIPTION
- use the codecov/codecov-action action
- remove the now obsolete dev/ci-upload-coverage.sh
- simplify dev/ci-gather-coverage.sh


DO NOT MERGE before we've verified that this does not disturb coverage collection.

UPDATE: coverage report seems OK...