### PR TITLE
Don't hardcode `lib/oper1.g` line numbers in tests

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -435,10 +435,9 @@ Int READ_GAP_ROOT ( const Char * filename )
     // try to find compiled version of the GAP file
     if (SyUseModule) {
         // This code section covers transparently loading GAC compiled
-        // versions of GAP source files, by running code similar to
-        // that in FuncLOAD_STAT. For example, lib/oper1.g is compiled
-        // into C code which is stored in src/c_oper1.c; when reading
-        // lib/oper1.g, we instead will load its compiled version.
+        // versions of GAP source files, by running code similar to that in
+        // FuncLOAD_STAT. For example, lib/oper1.g is compiled into C code;
+        // when reading lib/oper1.g, we instead load its compiled version.
         Char module[GAP_PATH_MAX];
         strxcpy(module, "GAPROOT/", sizeof(module));
         strxcat(module, filename, sizeof(module));

--- a/tst/testinstall/opers/LocationFunc.tst
+++ b/tst/testinstall/opers/LocationFunc.tst
@@ -10,8 +10,15 @@ gap> PositionSublist(LocationFunc(Where),"/lib/error.g:") <> fail;
 true
 
 # GAP function which was compiled to C code by gac
-gap> LocationFunc(INSTALL_METHOD_FLAGS);
-"GAPROOT/lib/oper1.g:147"
+# this yields something like "GAPROOT/lib/oper1.g:147"
+# but we don't want to depend on the changing line numbers,
+# so we invest some extra work to test the format without
+# relying on the specific content
+gap> loc:=LocationFunc(INSTALL_METHOD_FLAGS);;
+gap> StartsWith(loc, "GAPROOT/lib/oper1.g:");
+true
+gap> ForAll(loc{[21..Length(loc)]}, IsDigitChar);
+true
 
 # proper kernel function
 gap> LocationFunc(APPEND_LIST_INTR);

--- a/tst/testinstall/varargs.tst
+++ b/tst/testinstall/varargs.tst
@@ -74,21 +74,9 @@ gap> function(a,b....) end;
 Syntax error: ) expected in stream:1
 function(a,b....) end;
                ^
-gap> f := function(a,b..) end;
-Syntax error: Three dots required for variadic argument list in stream:1
-f := function(a,b..) end;
-                 ^^
 gap> Display(RETURN_FIRST);
 function ( first, rest... )
     <<kernel code>> from src/gap.c:RETURN_FIRST
-end
-gap> Print(INSTALL_METHOD_FLAGS,"\n");
-function ( opr, info, rel, flags, baserank, method )
-    <<compiled GAP code>> from GAPROOT/lib/oper1.g:147
-end
-gap> Display(InstallMethod);
-function ( arg... )
-    <<compiled GAP code>> from GAPROOT/lib/oper1.g:331
 end
 gap> [1..2];
 [ 1, 2 ]

--- a/tst/testspecial/print-compiled-func.g
+++ b/tst/testspecial/print-compiled-func.g
@@ -1,0 +1,2 @@
+Print(INSTALL_METHOD_FLAGS,"\n");
+Display(InstallMethod);

--- a/tst/testspecial/print-compiled-func.g.out
+++ b/tst/testspecial/print-compiled-func.g.out
@@ -1,0 +1,9 @@
+gap> Print(INSTALL_METHOD_FLAGS,"\n");
+function ( opr, info, rel, flags, baserank, method )
+    <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE
+end
+gap> Display(InstallMethod);
+function ( arg... )
+    <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE
+end
+gap> QUIT;


### PR DESCRIPTION
Also update a kernel comment which was still referencing `src/c_oper1.c`.

Resolves #4417