### PR TITLE
improved documentation for random sources

### DIFF
--- a/doc/ref/integers.xml
+++ b/doc/ref/integers.xml
@@ -179,12 +179,17 @@ modulo 32.
 for many collections of objects. 
 On a lower level these methods use <E>random sources</E> which provide 
 random integers and random choices from lists. 
+<P/>
+See <Ref Filt="IsRandomSource"/> for the user interface for random sources,
+and Section <Ref Subsect="Implementing new kinds of random sources"/>
+for information about developing new kinds of random sources.
 
 <#Include Label="IsRandomSource">
 <#Include Label="Random">
 <#Include Label="State">
 <#Include Label="IsGlobalRandomSource">
 <#Include Label="RandomSource">
+<#Include Label="RandomSource_develop">
 
 </Section>
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->

--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -1613,8 +1613,8 @@ DeclareAttribute( "RepresentativeSmallest", IsListOrCollection );
 
 #############################################################################
 ##
-#O  Random( <C> ) . . . . . . . . . .  random element of a list or collection
-#O  Random( <list> )  . . . . . . . .  random element of a list or collection
+#O  Random( <C> ) . . . . . . . . . . random element of a nonempty collection
+#O  Random( <list> )  . . . . . . .  random element of a dense, nonempty list
 #O  Random( <from>, <to> )
 ##
 ##  <#GAPDoc Label="Random:coll">
@@ -1627,17 +1627,29 @@ DeclareAttribute( "RepresentativeSmallest", IsListOrCollection );
 ##  <Index Key="Random"><Ref Oper="Random" 
 ##                           Label="for a list or collection"/></Index> 
 ##  <Ref Oper="Random" Label="for a list or collection"/> returns a
-##  (pseudo-)random element of the list or collection <A>listorcoll</A>.
+##  (pseudo-)random element of the dense, nonempty list or nonempty
+##  collection <A>listorcoll</A>.
+##  The behaviour for non-dense or empty lists, and for empty collections
+##  (see <Ref Filt="IsDenseList"/>, <Ref Prop="IsEmpty"/>)
+##  is undefined.
 ##  <P/>
 ##  As lists or ranges are restricted in length (<M>2^{28}-1</M> or 
 ##  <M>2^{60}-1</M> depending on your system), the second form returns a
 ##  random integer in the range <A>from</A> to <A>to</A> (inclusive) for
 ##  arbitrary integers <A>from</A> and <A>to</A>.
+##  The behaviour in the case that <A>from</A> is larger than <A>to</A>
+##  is undefined.
+##  <P/>
+##  See Section <Ref Sect="Random Sources"/> for more about computing
+##  random elements, in particular for
+##  <Ref Oper="Random" Label="for random source and list"/> methods
+##  that take a random source as the first argument.
 ##  <P/>
 ##  The distribution of elements returned by
 ##  <Ref Oper="Random" Label="for a list or collection"/> depends
 ##  on the argument.
-##  For a list the distribution is uniform (all elements are equally likely).
+##  For a dense, nonempty list the distribution is uniform (all elements are
+##  equally likely).
 ##  The same holds usually for finite collections that are
 ##  not lists.
 ##  For infinite collections some reasonable distribution is used.
@@ -1669,6 +1681,8 @@ DeclareAttribute( "RepresentativeSmallest", IsListOrCollection );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+# We keep the declaration for non-dense lists
+# in order not to break existing code.
 DeclareOperation( "Random", [ IsListOrCollection ] );
 DeclareOperation( "Random", [ IS_INT, IS_INT ] );
 
@@ -1695,7 +1709,7 @@ DeclareOperation( "Random", [ IS_INT, IS_INT ] );
 
 #############################################################################
 ##
-#F  RandomList( <list> )
+#F  RandomList( [<rs>, ]<list> )
 ##
 ##  <#GAPDoc Label="RandomList">
 ##  <ManSection>
@@ -1707,11 +1721,24 @@ DeclareOperation( "Random", [ IS_INT, IS_INT ] );
 ##  <Ref Func="RandomList"/> returns a (pseudo-)random element with equal
 ##  distribution.
 ##  <P/>
-##  The random source <A>rs</A> is used to choose a random number.
+##  The random source <A>rs</A> (see <Ref Sect="Random Sources"/>)
+##  is used to choose a random number.
 ##  If <A>rs</A> is absent,
 ##  this function uses the <Ref Var="GlobalMersenneTwister"/> to produce the
 ##  random elements (a source of high quality random numbers).
 ##  <P/>
+##  <Example><![CDATA[
+##  gap> RandomList( [ 1 .. 6 ] );
+##  3
+##  gap> elms:= AsList( Group( (1,2,3) ) );;
+##  gap> RandomList( elms );  RandomList( elms );
+##  (1,2,3)
+##  (1,3,2)
+##  gap> rs:= RandomSource( IsMersenneTwister, 1 );
+##  <RandomSource in IsMersenneTwister>
+##  gap> RandomList( rs, elms );
+##  (1,2,3)
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -248,7 +248,7 @@ InstallMethod( RepresentativeSmallest,
 ##
 ##  The default function for random selection in a finite collection computes
 ##  an enumerator of <C> and selects a random element of this list using the
-##  function `RandomList', which is a pseudo random number generator.
+##  function `RandomList', which uses a pseudo random number generator.
 ##
 
 # RandomList is not an operation to avoid the (often expensive) cost of
@@ -263,7 +263,7 @@ InstallGlobalFunction( RandomList, function(args...)
     source := args[1];
     list := args[2];
   else
-    Error(" Usage: RandomList([rs], list))");
+    Error( "usage: RandomList( [<rs>], <list> ) for a dense list <list>" );
   fi;
 
   return list[Random(source, 1, Length(list))];

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1069,8 +1069,8 @@ end);
 ##
 START_TEST := function( name )
     FlushCaches();
-    Reset(GlobalRandomSource, 1);
-    Reset(GlobalMersenneTwister, 1);
+    Reset(GlobalRandomSource);
+    Reset(GlobalMersenneTwister);
     CollectGarbage(true);
     GAPInfo.TestData.START_TIME := Runtime();
     GAPInfo.TestData.START_NAME := name;

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -21,15 +21,23 @@
 ##  <Filt Name="IsRandomSource" Arg='obj' Type='Category'/>
 ##
 ##  <Description>
-##  This is the category of random source objects which are defined to have,
-##  for  an  object  <A>rs</A>  in  this  category,  methods  available  for
-##  the  following operations  which  are explained  in  more detail  below:
-##  <C>Random( <A>rs</A>,  <A>list</A> )</C>  giving a  random element  of a
-##  list,  <C>Random(  <A>rs</A>,  <A>low</A>, <A>high</A>  )</C>  giving  a
-##  random  integer between  <A>low</A>  and  <A>high</A> (inclusive),  <Ref
-##  Oper="Init"/>, <Ref Oper="State"/> and <Ref Oper="Reset"/>.
+##  This is the category of random source objects.
+##  The <E>user interface</E> for these objects consists of the following
+##  functions.
 ##  <P/>
-##  Use <Ref Oper="RandomSource"/> to construct new random sources.
+##  <Ref Oper="RandomSource"/> creates a new random source <A>rs</A>, say.
+##  <P/>
+##  <C>Random( <A>rs</A>, <A>list</A> )</C> yields a random element of the
+##  list <A>list</A>, and
+##  <C>Random( <A>rs</A>, <A>low</A>, <A>high</A> )</C> yields a random
+##  integer between <A>low</A> and <A>high</A> (inclusive),
+##  see <Ref Oper="Random" Label="for random source and list"/>.
+##  <P/>
+##  If <A>rs</A> supports resetting (see <Ref Oper="State"/>) then
+##  <C>State( <A>rs</A> )</C> yields a copy <A>state</A>, say,
+##  of the current state of <A>rs</A> such that
+##  <C>Reset( <A>rs</A>, <A>state</A> )</C> resets <A>rs</A> to the given
+##  state.
 ##  <P/>
 ##  One idea behind providing several independent (pseudo) random sources is
 ##  to make algorithms which use some sort of random choices deterministic.
@@ -44,10 +52,11 @@
 BIND_GLOBAL( "RandomSourcesFamily", NewFamily( "RandomSourcesFamily" ) );
 DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 
+
 #############################################################################
 ##  
-#O  Random( <rs>, <list> ) . . . . . . . . . . for random source and a list
-#O  Random( <rs>, <low>, <high> )  . . . for random source and two integers
+#O  Random( <rs>, <list> ) . . . for random source and a dense, nonempty list
+#O  Random( <rs>, <low>, <high> )  . . . . for random source and two integers
 ##
 ##  <#GAPDoc Label="Random">
 ##  <ManSection>
@@ -58,13 +67,16 @@ DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 ##                      Label="for random source and two integers"/>
 ##
 ##  <Description>
-##  This operation returns a random element from the list <A>list</A>
-##  or the collection <A>coll</A>,
+##  This operation returns a random element from the dense, nonempty list
+##  <A>list</A> or the nonempty collection <A>coll</A>,
 ##  or an integer in the range from the given (possibly large) integers
 ##  <A>low</A> to <A>high</A>, respectively.
 ##  <P/>
 ##  The choice should only depend on the random source <A>rs</A> and have no 
 ##  effect on other random sources.
+##  <P/>
+##  It is not defined what happens if <A>list</A> or <A>coll</A> is empty,
+##  <A>list</A> is not dense, or <A>low</A> is larger than <A>high</A>.
 ##  <Example>
 ##  gap> mysource := RandomSource(IsMersenneTwister, 42);;
 ##  gap> Random(mysource, 1, 10^60);
@@ -74,47 +86,46 @@ DeclareCategory( "IsRandomSource", IsComponentObjectRep );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+# We keep the declaration for non-dense lists
+# in order not to break existing code.
 DeclareOperation( "Random", [IsRandomSource, IsListOrCollection] );
 DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
 
+
 #############################################################################
 ##  
-#O  State( <rs> ) . . . . . . . . . . . . . . . state of random source
-#O  Reset( <rs> )
-#O  Reset( <rs>, <seed> ) . . . . . . . . . . . reset a random source
-#O  Init( <rs> )
-#O  Init( <prers>, <seed> )  . . . . . . . initialize a random source
+#O  State( <rs> )  . . . . . . . . . . . . . . . . . . state of random source
+#O  Reset( <rs>[, <seed>] )  . . . . . . . . . . . . .  reset a random source
 ##
 ##  <#GAPDoc Label="State">
 ##  <ManSection>
+##  <Heading>State and Reset for Random Sources</Heading>
 ##  <Oper Name="State" Arg='rs'/>
 ##  <Oper Name="Reset" Arg='rs[, seed]'/>
-##  <Oper Name="Init" Arg='prers[, seed]'/>
 ##
 ##  <Description>
-##  These are the basic operations for which random sources (see
-##  <Ref Filt="IsRandomSource"/>) must have methods. 
+##  These are the basic operations for random sources (see
+##  <Ref Filt="IsRandomSource"/>).
 ##  <P/>
-##  <Ref Oper="State"/> should return a data structure which allows to recover the state
-##  of the random source such that a sequence of random calls using this 
-##  random source can be reproduced. If a random source cannot be reset 
-##  (say, it uses truly random physical data) then <Ref Oper="State"/>
-##  should return  <K>fail</K>.
+##  <Ref Oper="State"/> returns a data structure which admits recovering
+##  the state of the random source such that a sequence of random calls
+##  using this random source can be reproduced.
+##  If a random source cannot be reset (say, it uses truly random physical
+##  data) then <Ref Oper="State"/> returns <K>fail</K>.
 ##  <P/>
-##  <C>Reset( <A>rs</A>, <A>seed</A> )</C> resets the random source <A>rs</A> to a state described
-##  by <A>seed</A>, if the random source can be reset (otherwise it should do
-##  nothing). Here <A>seed</A> can be an output of <Ref Oper="State"/> and then should reset
-##  to that state. Also, the methods should always allow integers as <A>seed</A>.
-##  Without the <A>seed</A> argument the default <M><A>seed</A> = 1</M> is used.
+##  <C>Reset( <A>rs</A>, <A>seed</A> )</C> resets the random source <A>rs</A>
+##  to a state described by <A>seed</A>, if the random source can be reset;
+##  otherwise it does nothing.
+##  Here <A>seed</A> can be an output of <Ref Oper="State"/> and then
+##  <A>rs</A> gets reset to that state.
+##  Also integers are allowed as <A>seed</A>.
+##  Without the <A>seed</A> argument the default <M><A>seed</A> = 1</M> is
+##  used.
+##  <Ref Oper="Reset"/> returns the state of <A>rs</A> before the call.
 ##  <P/>
-##  <Ref Oper="Init"/> is the constructor of a random source, it gets an empty component 
-##  object <A>prers</A> which has already the correct type and should fill in the actual 
-##  data which are needed. Optionally, it should allow one to specify a 
-##  <A>seed</A> for the initial state, as explained for <Ref Oper="Reset"/>.
-##  <P/>
-##  Most methods for <Ref Oper="Random" Label="for a list or collection"/> 
-##  in the &GAP; library use the 
-##  <Ref Var="GlobalMersenneTwister"/> as random source. It can be reset 
+##  Most methods for <Ref Oper="Random" Label="for a list or collection"/>
+##  in the &GAP; library that do not take a random source as argument use the
+##  <Ref Var="GlobalMersenneTwister"/> as random source. It can be reset
 ##  into a known state as in the following example.
 ##  <Example><![CDATA[
 ##  gap> seed := Reset(GlobalMersenneTwister);;
@@ -135,7 +146,6 @@ DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
 DeclareOperation( "State", [IsRandomSource] );
 DeclareOperation( "Reset", [IsRandomSource] );
 DeclareOperation( "Reset", [IsRandomSource, IsObject] );
-DeclareOperation( "Init", [IsRandomSource] );
 DeclareOperation( "Init", [IsRandomSource, IsObject] );
 
 #############################################################################
@@ -147,7 +157,8 @@ DeclareOperation( "Init", [IsRandomSource, IsObject] );
 #V  GlobalMersenneTwister
 ##
 ##  <#GAPDoc Label="IsGlobalRandomSource">
-##  <ManSection>
+##  <ManSection Label="Kinds of Random Sources">
+##  <Heading>Kinds of Random Sources</Heading>
 ##  <Filt Name="IsMersenneTwister" Arg='rs' Type='Category'/>
 ##  <Filt Name="IsGAPRandomSource" Arg='rs' Type='Category'/>
 ##  <Filt Name="IsGlobalRandomSource" Arg='rs' Type='Category'/>
@@ -169,8 +180,10 @@ DeclareOperation( "Init", [IsRandomSource, IsObject] );
 ##  large random integers. 
 ##  <P/>
 ##  There is also a predefined global random source 
-##  <Ref Var="GlobalMersenneTwister"/> which is used by most of the library
-##  methods for <Ref Oper="Random" Label="for a list or collection"/>.
+##  <Ref Var="GlobalMersenneTwister"/> which is used as the default
+##  random source by those library
+##  methods for <Ref Oper="Random" Label="for a list or collection"/>
+##  that do not take a random source as an argument.
 ##  <P/>
 ##  <Ref Filt="IsGAPRandomSource"/> uses the same number generator as 
 ##  <Ref Filt="IsGlobalRandomSource"/>, but you can create several of these 
@@ -185,6 +198,7 @@ DeclareOperation( "Init", [IsRandomSource, IsObject] );
 ##  generator described in  <Cite Key="TACP2"/> (Algorithm A in&nbsp;3.2.2 
 ##  with lag <M>30</M>).
 ##  <P/>
+##  Other kinds of random sources are implemented by &GAP; packages.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -211,22 +225,30 @@ fi;
 ##  <Oper Name="RandomSource" Arg='cat[, seed]'/>
 ##
 ##  <Description>
-##  This operation is used to create new random sources. The first argument 
-##  <A>cat</A> is the category describing the type of the random generator, 
-##  an optional <A>seed</A> which can be an integer or a type specific data 
-##  structure can be given to specify the initial state.
+##  This operation is used to create new random sources. The first argument
+##  <A>cat</A> is the category describing the type of the random generator,
+##  for example one of the categories listed in
+##  Section <Ref Subsect="Kinds of Random Sources"/>.
+##  <P/>
+##  An optional <A>seed</A> can be given to specify the initial state.
+##  It can be an integer or a type specific data structure.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> rs1 := RandomSource(IsMersenneTwister);
 ##  <RandomSource in IsMersenneTwister>
+##  gap> l1 := List([1..10000], i-> Random(rs1, [1..6]));;
 ##  gap> state1 := State(rs1);;
-##  gap> l1 := List([1..10000], i-> Random(rs1, [1..6]));;  
 ##  gap> rs2 := RandomSource(IsMersenneTwister);;
 ##  gap> l2 := List([1..10000], i-> Random(rs2, [1..6]));;
 ##  gap> l1 = l2;
 ##  true
-##  gap> l1 = List([1..10000], i-> Random(rs1, [1..6])); 
+##  gap> l3 := List([1..10000], i-> Random(rs1, [1..6]));;
+##  gap> l1 = l3;
 ##  false
+##  gap> rs3 := RandomSource(IsMersenneTwister, state1);;
+##  gap> l4 := List([1..10000], i-> Random(rs3, [1..6]));;
+##  gap> l3 = l4;
+##  true
 ##  gap> n := Random(rs1, 1, 2^220);
 ##  1077726777923092117987668044202944212469136000816111066409337432400
 ##  ]]></Example>
@@ -236,6 +258,70 @@ fi;
 ##
 DeclareOperation( "RandomSource", [IsOperation] );
 DeclareOperation( "RandomSource", [IsOperation, IsObject] );
+
+
+##############################################################################
+##
+##  <#GAPDoc Label="RandomSource_develop">
+##  <Subsection Label="Implementing new kinds of random sources">
+##  <Heading>Implementing new kinds of random sources</Heading>
+##
+##  If one wants to implement a new kind of random sources then
+##  the first step is the declaration of a new category <C>C</C>, say,
+##  that implies <Ref Filt="IsRandomSource"/>, analogous to the categories
+##  listed in Section <Ref Subsect="Kinds of Random Sources"/>.
+##  <P/>
+##  Then the following method installations are needed.
+##  <P/>
+##  <Index Key="Init"><C>Init</C> (initialize a random source object)</Index>
+##  <C>InstallMethod( Init, [ C, IsObject ], function( prers, seed_or_state )
+##  ... end );</C>
+##  <P/>
+##  Here <C>prers</C> is an empty component object (which has already the
+##  filter <C>C</C>), and <C>seed_or_state</C> is an integer or a state value
+##  as returned by <Ref Oper="State"/> that describes the initial state of
+##  the random source.
+##  The function should fill in the actual data and then return the
+##  (now initialized) object <C>prers</C>.
+##  The default used for <C>seed_or_state</C> is the integer <C>1</C>.
+##  A given state value need not be copied by the function.
+##  <P/>
+##  <C>InstallMethod( Random, [ C, IsInt, IsInt ], function( rs, low, high )
+##  ... end );</C>
+##  <P/>
+##  Here <C>rs</C> is an already initialized random source object in the
+##  category <C>C</C>, and the function returns an integer between <C>low</C>
+##  and <C>high</C> (inclusive).
+##  It is not defined what happens when <C>low</C> is larger than <C>high</C>.
+##  <P/>
+##  <C>InstallMethod( State, [ C ], function( rs ) ... end );</C>
+##  <P/>
+##  If <C>rs</C> supports resetting then the function must return an object
+##  that describes the current state of <C>rs</C>.
+##  This object must be an independent copy, that is,
+##  calling <Ref Oper="Random" Label="for random source and list"/>
+##  for <C>rs</C> must not change the object that was returned by
+##  <Ref Oper="State"/>;
+##  otherwise <Ref Func="ReturnFail"/> should be installed.
+##  <P/>
+##  <C>InstallMethod( Reset, [ C, IsObject ], function( rs, seed_or_state )
+##  ... end );</C>
+##  <P/>
+##  If <C>rs</C> supports resetting then the function must reinitialize
+##  <C>rs</C> to the integer or <Ref Oper="State"/> value <C>seed_or_state</C>
+##  and must return the <Ref Oper="State"/> value of <C>rs</C> before these
+##  changes; if resetting is not supported then <Ref Func="ReturnNothing"/>
+##  should be installed.
+##  Reset need not copy a given state.
+##  Note that the generic unary <Ref Oper="Reset"/> method uses the default
+##  seed <C>1</C>.
+##  <P/>
+##  An example of an implementation as described here is given by the
+##  random sources with defining filter <C>IsRealRandomSource</C>,
+##  see <Ref Meth="RandomSource" BookName="io"/> in the &GAP; package
+##  <Package>IO</Package>.
+##  </Subsection>
+##  <#/GAPDoc>
 
 ##############################################################################
 ##

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -98,7 +98,7 @@ DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
 #O  Reset( <rs>[, <seed>] )  . . . . . . . . . . . . .  reset a random source
 ##
 ##  <#GAPDoc Label="State">
-##  <ManSection>
+##  <ManSection Label="State and Reset for Random Sources">
 ##  <Heading>State and Reset for Random Sources</Heading>
 ##  <Oper Name="State" Arg='rs'/>
 ##  <Oper Name="Reset" Arg='rs[, seed]'/>
@@ -118,9 +118,11 @@ DeclareOperation( "Random", [IsRandomSource, IsInt, IsInt] );
 ##  otherwise it does nothing.
 ##  Here <A>seed</A> can be an output of <Ref Oper="State"/> and then
 ##  <A>rs</A> gets reset to that state.
-##  Also integers are allowed as <A>seed</A>.
-##  Without the <A>seed</A> argument the default <M><A>seed</A> = 1</M> is
-##  used.
+##  For historical reasons, random sources accept integer values as
+##  <A>seed</A>.
+##  We recommend that new code should not rely on this; always use the output
+##  of a prior call to <Ref Oper="State"/> as <A>seed</A>, or omit it.
+##  Without the <A>seed</A> argument a fixed default seed is used.
 ##  <Ref Oper="Reset"/> returns the state of <A>rs</A> before the call.
 ##  <P/>
 ##  Most methods for <Ref Oper="Random" Label="for a list or collection"/>
@@ -217,8 +219,7 @@ fi;
 
 #############################################################################
 ##  
-#O  RandomSource( <cat> )
-#O  RandomSource( <cat>, <seed> )
+#O  RandomSource( <cat>[, <seed>] )
 ##
 ##  <#GAPDoc Label="RandomSource">
 ##  <ManSection>
@@ -231,7 +232,8 @@ fi;
 ##  Section <Ref Subsect="Kinds of Random Sources"/>.
 ##  <P/>
 ##  An optional <A>seed</A> can be given to specify the initial state.
-##  It can be an integer or a type specific data structure.
+##  For details,
+##  see Section <Ref Subsect="State and Reset for Random Sources"/>.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> rs1 := RandomSource(IsMersenneTwister);
@@ -269,21 +271,24 @@ DeclareOperation( "RandomSource", [IsOperation, IsObject] );
 ##  If one wants to implement a new kind of random sources then
 ##  the first step is the declaration of a new category <C>C</C>, say,
 ##  that implies <Ref Filt="IsRandomSource"/>, analogous to the categories
-##  listed in Section <Ref Subsect="Kinds of Random Sources"/>.
+##  listed in Section <Ref Subsect="Kinds of Random Sources"/>,
+##  as follows.
+##  <P/>
+##  <C>DeclareCategory( "C", IsRandomSource );</C>.
 ##  <P/>
 ##  Then the following method installations are needed.
 ##  <P/>
 ##  <Index Key="Init"><C>Init</C> (initialize a random source object)</Index>
-##  <C>InstallMethod( Init, [ C, IsObject ], function( prers, seed_or_state )
+##  <C>InstallMethod( Init, [ C, IsObject ], function( prers, seed )
 ##  ... end );</C>
 ##  <P/>
 ##  Here <C>prers</C> is an empty component object (which has already the
-##  filter <C>C</C>), and <C>seed_or_state</C> is an integer or a state value
+##  filter <C>C</C>), and <C>seed</C> is an integer or a state value
 ##  as returned by <Ref Oper="State"/> that describes the initial state of
 ##  the random source.
 ##  The function should fill in the actual data and then return the
 ##  (now initialized) object <C>prers</C>.
-##  The default used for <C>seed_or_state</C> is the integer <C>1</C>.
+##  The default used for <C>seed</C> is the integer <C>1</C>.
 ##  A given state value need not be copied by the function.
 ##  <P/>
 ##  <C>InstallMethod( Random, [ C, IsInt, IsInt ], function( rs, low, high )
@@ -304,11 +309,11 @@ DeclareOperation( "RandomSource", [IsOperation, IsObject] );
 ##  <Ref Oper="State"/>;
 ##  otherwise <Ref Func="ReturnFail"/> should be installed.
 ##  <P/>
-##  <C>InstallMethod( Reset, [ C, IsObject ], function( rs, seed_or_state )
+##  <C>InstallMethod( Reset, [ C, IsObject ], function( rs, seed )
 ##  ... end );</C>
 ##  <P/>
 ##  If <C>rs</C> supports resetting then the function must reinitialize
-##  <C>rs</C> to the integer or <Ref Oper="State"/> value <C>seed_or_state</C>
+##  <C>rs</C> to the integer or <Ref Oper="State"/> value <C>seed</C>
 ##  and must return the <Ref Oper="State"/> value of <C>rs</C> before these
 ##  changes; if resetting is not supported then <Ref Func="ReturnNothing"/>
 ##  should be installed.
@@ -316,10 +321,11 @@ DeclareOperation( "RandomSource", [IsOperation, IsObject] );
 ##  Note that the generic unary <Ref Oper="Reset"/> method uses the default
 ##  seed <C>1</C>.
 ##  <P/>
-##  An example of an implementation as described here is given by the
-##  random sources with defining filter <C>IsRealRandomSource</C>,
-##  see <Ref Meth="RandomSource" BookName="io"/> in the &GAP; package
-##  <Package>IO</Package>.
+##  Examples of implementations as described here are given by the
+##  random sources with defining filter <Ref Filt="IsMersenneTwister"/>
+##  or <C>IsRealRandomSource</C>.
+##  (For the latter, see <Ref Meth="RandomSource" BookName="io"/>
+##  in the &GAP; package <Package>IO</Package>.)
 ##  </Subsection>
 ##  <#/GAPDoc>
 

--- a/lib/random.gi
+++ b/lib/random.gi
@@ -56,7 +56,8 @@ InstallMethod(Random, [IsRandomSource, IsInt, IsInt], function(rs, a, b)
   fi;
 end);
 
-InstallMethod(Random, [IsRandomSource, IsList], function(rs, list)
+InstallMethod(Random, [IsRandomSource, IsList and IsDenseList],
+  function(rs, list)
   return list[Random(rs, 1, Length(list))];
 end);
 
@@ -122,7 +123,8 @@ InstallMethod(Reset, [IsGAPRandomSource, IsObject], function(rs, seed)
   return old;
 end);
 
-InstallMethod(Random, [IsGAPRandomSource, IsList], function(rs, list)
+InstallMethod(Random, [IsGAPRandomSource, IsList and IsDenseList],
+  function(rs, list)
   local rx, rn;
   if Length(list) < 2^28 then
     rx := rs!.R_X;
@@ -201,18 +203,18 @@ InstallMethod(Reset, [IsMersenneTwister, IsObject], function(rs, seed)
   return old;
 end);
 
-InstallMethod(Random, [IsMersenneTwister, IsList], function(rs, list)
-  return list[Random(rs, 1, Length(list))];
-end);
+# We do not need a 'Random' method for 'IsMersenneTwister' and a dense list,
+# the default method for 'IsRandomSource' is enough.
 
 InstallMethod(Random, [IsMersenneTwister, IsInt, IsInt], function(rs, a, b)
   local d, nrbits, res;
   d := b-a+1;
-  if d < 0 then
+  if d <= 0 then
     return fail;
-  elif d = 0 then
-    return a;
   fi;
+  # Here we could return 'a' in the case 'd = 1'.
+  # However, this would change the sequence of random numbers
+  # w.r.t. earlier GAP versions.
   nrbits := Log2Int(d) + 1;
   repeat
     res := RandomIntegerMT(rs!.state, nrbits);
@@ -231,9 +233,9 @@ fi;
 
 # default random method for lists and pairs of integers using the Mersenne
 # twister
-InstallMethod( Random, "for an internal list",
-    [ IsList and IsInternalRep ], 100, function(l) 
-  return l[Random(GlobalMersenneTwister, 1, Length(l))]; 
+InstallMethod( Random, "for a dense internal list",
+    [ IsList and IsDenseList and IsInternalRep ], 100, function(l)
+  return l[Random(GlobalMersenneTwister, 1, Length(l))];
 end );
 
 InstallMethod( Random,

--- a/tst/testinstall/random.tst
+++ b/tst/testinstall/random.tst
@@ -1,4 +1,4 @@
-#@local R,a,rm,g,orbs,orb,getOneInt
+#@local R,a,rm,g,orbs,orb,i,getOneInt
 gap> START_TEST("random.tst");
 gap> ReadGapRoot( "tst/testrandom.g" );
 
@@ -150,6 +150,20 @@ gap> randomTest([1..2], Random);
 gap> randomTest([0, 10..1000], Random);
 gap> randomTest("cheese", Random);
 gap> randomTest([1,-6,"cheese", Group(())], Random);
+
+# unusual bounds
+gap> R:= RandomSource( IsMersenneTwister );;
+gap> Random( R, 1, -1 ) = fail;
+true
+gap> Random( R, 1, 0 ) = fail;
+true
+gap> Random( R, 1, 1 ) = 1;
+true
+
+# only dense lists are supported
+gap> for i in [ 1 .. 1000 ] do Random( R, [1,,,,,,,,,,2] ); od;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Random' on 2 arguments
 
 #
 gap> randomTest(PadicExtensionNumberFamily(3, 5, [1,1,1], [1,1]), Random, function(x,y) return IsPadicExtensionNumber(x); end);


### PR DESCRIPTION
- document that `Random` for a list is defined only for nonempty and
  dense lists; the declaration for arbitrary lists is kept in order
  not to break code in the IO package

- install `Random` methods for lists with the requirement `IsDenseList`
  (thus we get a "no method found" error if a non-dense list is given)

- document that `Random` for two integers is defined only if the first
  is not larger than the second

- describe the user interface for random sources in the subsection
  about `IsRandomSource`

- added a subsection on developing new kinds of random sources

- point to the user interface and the developer interface in the
  manual section about random sources

- added a manual example for `RandomList`

- added some cross-references

- call `Reset` with one argument in `START_TEST`
  (does not change the behaviour)

- document `Init` only via an index entry, since is not needed by users,
  removed the unary version of `Init`, as it is apparently not used

- removed the `Random` method for `IsMersenneTwister` and `IsList`,
  because the generic method is sufficient

- fixed `Random( IsMersenneTwister, 1, 0 )` and added a few tests;
  in general, we do not promise error messages if the arguments do not fit,
  thus we do not need tests for this situation

(resolves #4379 and #4403;
replaces #4415: in a discussion with @fingolfin, we decided better not to extend the documentation of `Random` to non-dense lists)