### PR TITLE
fixed a family relation in a method installation

### DIFF
--- a/lib/rwsgrp.gi
+++ b/lib/rwsgrp.gi
@@ -234,11 +234,8 @@ end );
 ##
 InstallMethod( \^,
     "rws-element ^ int",
-    IsIdenticalObj,
     [ IsMultiplicativeElementWithInverseByRws,
       IsInt ],
-    0,
-
 function( left, right )
     local   fam;
 


### PR DESCRIPTION
The method `"rws-element ^ int"` had been installed with the family predicate `IsIdenticalObj`, thus it was never applicable.

After the change, this method gets tested in `testinstall/dt.tst`;
up to now, the generic `\^` method had been used in these tests.