### PR TITLE
Improvements in using RWS for multiplication in group extensions given as FpGroups

### DIFF
--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -1000,7 +1000,8 @@ local nam,e,efactors,par,expo,prime,result,aut,i,classical,classaut,shortname,
 
   # fix O5 to SP4
   if id.series="B" and id.parameter[1]=2 then
-    id:=rec(name:=id.name,series:="C",parameter:=id.parameter);
+    id:=rec(name:=id.name,series:="C",parameter:=id.parameter,
+      shortname:=Concatenation("S4(",String(id.parameter[2]),")"));
   fi;
 
   if IsBound(id.parameter) then

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1029,7 +1029,7 @@ local hom;
   return hom;
 end);
 
-BindGlobal("MakeFpGroupToMonoidHomType1",function(fp,m)
+InstallGlobalFunction(MakeFpGroupToMonoidHomType1,function(fp,m)
 local fam,mfam,fpfam,mfpfam,hom;
   fam:=FamilyObj(UnderlyingElement(One(fp)));
   mfam:=FamilyObj(UnderlyingElement(One(m)));

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -2085,7 +2085,6 @@ local isob,isos,iso,gens,u,a,rels,l,i,j,bgens,cb,cs,b,f,k,w,monoid,
   i:=Length(rels);
   Info(InfoFpGroup,2,"have ",i," rules");
   a:=KnuthBendixRewritingSystem(f/rels,ord);
-  #Error("HUH2");
   MakeConfluent(a);
   Info(InfoFpGroup,1,"confluent RWS ",i," -> ",Length(Rules(a)),"\n");
   b:=f/Rules(a); # make once more for the fp monoid.
@@ -2221,7 +2220,8 @@ function(G)
 local a,f,iso;
 
   a:=DataAboutSimpleGroup(G);
-  if not IsBound(a.classicalId) then
+  if not IsBound(a.classicalId) 
+    or ValueOption(NO_PRECOMPUTED_DATA_OPTION)=true then
     TryNextMethod();
   fi;
   iso:=ShallowCopy(a.idSimple);

--- a/lib/grpfp.gd
+++ b/lib/grpfp.gd
@@ -1352,5 +1352,8 @@ DeclareGlobalFunction("StringFactorizationWord");
 # used to test whether abeliniazation can be mapped in GQuotients
 DeclareGlobalFunction("CanMapFiniteAbelianInvariants");
 
+# map fpgrp->fpmon creator
+DeclareGlobalFunction("MakeFpGroupToMonoidHomType1");
+
 # used in homomorphisms
 DeclareGlobalName("TRIVIAL_FP_GROUP");

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5128,27 +5128,28 @@ end);
 InstallMethod(FpElementNFFunction,true,[IsElementOfFpGroupFamily],0,
 # default reduction -- 
 function(fam)
-local iso,k,id,f;
-  # first try whether the group is ``small''
-  iso:=FPFaithHom(fam);
-  if iso<>fail and Size(Image(iso))<50000 then
-    k:=ImagesSource(iso);
-  #return function(w)
-  #  if not w in FreeGroupOfFpGroup(Source(iso)) then Error("flasch");fi;
-  #  w:=ElementOfFpGroup(fam,w);
-  #  Print("wa=",w,"\n");
-  #  w:=ImageElm(iso,w);
-  #  Print("wb=",w,"\n");
-  #  w:=Factorization(k,w);
-  #  Print("wc=",w,"\n");
-  #  return UnderlyingElement(w);
-  #end;
-    return w->UnderlyingElement(Factorization(k,Image(iso,ElementOfFpGroup(fam,w))));
+local iso,k,id,f,ran,g;
+  g:=CollectionsFamily(fam)!.wholeGroup;
+  if not (HasIsomorphismFpMonoid(g) and
+    HasReducedConfluentRewritingSystem(Image(IsomorphismFpMonoid(g)))) then
+    # first try whether the group is ``small''
+    iso:=FPFaithHom(fam);
+    if iso<>fail and Size(Image(iso))<50000 then
+      k:=ImagesSource(iso);
+      return w->UnderlyingElement(Factorization(k,
+        Image(iso,ElementOfFpGroup(fam,w))));
+    fi;
   fi;
-  iso:=IsomorphismFpMonoidGeneratorsFirst(CollectionsFamily(fam)!.wholeGroup);
-  f:=FreeMonoidOfFpMonoid(Range(iso));
-  k:=ReducedConfluentRewritingSystem(Range(iso),
-	BasicWreathProductOrdering(f,GeneratorsOfMonoid(f)));
+
+  iso:=IsomorphismFpMonoidGeneratorsFirst(g);
+  ran:=Range(iso);
+  f:=FreeMonoidOfFpMonoid(ran);
+  if HasReducedConfluentRewritingSystem(ran) then
+    k:=ReducedConfluentRewritingSystem(ran);
+  else
+    k:=ReducedConfluentRewritingSystem(ran,
+          BasicWreathProductOrdering(f,GeneratorsOfMonoid(f)));
+  fi;
   id:=UnderlyingElement(Image(iso,One(fam)));
   return w->MonwordToGroupword(UnderlyingElement(One(fam)),
 	       ReducedForm(k,GroupwordToMonword(id,w)));

--- a/lib/kbsemi.gi
+++ b/lib/kbsemi.gi
@@ -183,6 +183,22 @@ function(rws)
   fi;
 end);
 
+# use bit lists to reduce the numbers of rules to test
+# this should ultimately become part of the kernel routine
+BindGlobal("ReduceLetterRepWordsRewSysNew",function(tzrules,w,geli,bits)
+local old,pat,cf;
+  if geli=false then
+    return ReduceLetterRepWordsRewSys(tzrules,w);
+  fi;
+  repeat
+    old:=w;
+    pat:=BlistList(geli,Set(w));
+    w:=ReduceLetterRepWordsRewSys(tzrules{Filtered([1..Length(tzrules)],
+      x->IsSubsetBlist(pat,bits[1][x]))},w);
+  until old=w;
+  return w;
+end);
+
 
 #############################################################################
 ##
@@ -299,8 +315,10 @@ function(kbrws,v)
       #use rules available to reduce both sides of rule
       u:=s[1];
       s:=s{[2..Length(s)]};
-      a:=ReduceLetterRepWordsRewSys(kbrws!.tzrules,u[1]);
-      b:=ReduceLetterRepWordsRewSys(kbrws!.tzrules,u[2]);
+      a:=ReduceLetterRepWordsRewSysNew(kbrws!.tzrules,u[1],
+        geli,kbrws!.bitrules);
+      b:=ReduceLetterRepWordsRewSysNew(kbrws!.tzrules,u[2],
+        geli,kbrws!.bitrules);
 
       #if both sides reduce to different words
       #have to adjoin a new rule to the set of rules

--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -210,8 +210,9 @@ DeclareOperation( "TwoCohomology", [ IsPcGroup, IsObject ] );
 ##  routine, this generating system corresponds to the components
 ##  <C>group</C> and <C>module</C> of the record returned.
 ##  The extension corresponding to a cocyle <C>c</C> can be constructed as
-##  <C>Extension(r,c)</C> where <C>r</C> is the cohomology record. This is
+##  <C>FpGroupCocycle(r,c)</C> where <C>r</C> is the cohomology record. This is
 ##  currently done as a finitely presented group.
+##
 ##  <Example><![CDATA[
 ##  gap> g:=Group((1,2,3,4,5),(1,2,3));;
 ##  gap> mats:=[[[2,0,0,1],[1,2,1,0],[2,1,1,1],[2,1,1,0]],
@@ -274,6 +275,8 @@ DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
 ##  If the optional parameter <A>doperm</A> is given as <A>true</A>, a
 ##  faithful permutation representation is computed and stored in the
 ##  attribute <Ref Attr="IsomorphismPermGroup"/> of the computed group.
+##  If the option <C>normalform</C> is given as <C>true</C>, arithmetic in
+##  the resulting finitely presented group will bring words into normal form.
 ##  <Example><![CDATA[
 ##  gap> g:=Group((2,15,8,16)(3,17,14,21)(4,23,20,6)(5,9,22,11)(7,13,19,25),
 ##  > (2,12,7,17)(3,18,13,23)(4,24,19,9)(5,10,25,15)(6,11,16,21));;
@@ -299,6 +302,9 @@ DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
 ##  [ [ 480, 3 ], [ 3888, 1 ], [ 6480, 1 ], [ 7776, 1 ], [ 19440, 1 ] ]
 ##  gap> Collected(List(MaximalSubgroupClassReps(g2),Size));
 ##  [ [ 3888, 1 ], [ 6480, 1 ], [ 7776, 1 ], [ 19440, 1 ] ]
+##  gap> p:=FpGroupCocycle(coh,coh.cohomology[1],true:normalform);;
+##  gap> p.7*p.1; # i.e. m1*F1, but in normal form
+##  F1*m2^-1
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>


### PR DESCRIPTION
Allow the result of `FpGroupCocycle` to use rewriting for a normal form when multiplying.
Some related minor enghancements with handling rewriting systems.