### PR TITLE
CI: send Slack notifications on manual & scheduled runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -267,12 +267,12 @@ jobs:
         shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
         run: dev/ci.sh
 
-  slack-notification-on-failure:
-    name: Send slack notification on CI failure
+  slack-notification:
+    name: Send Slack notification on status change
     needs:
       - test-unix
       - test-cygwin
-    if: ${{ always() && github.event_name == 'push' && github.repository == 'gap-system/gap' }}
+    if: ${{ always() && github.event_name != 'pull_request' && github.repository == 'gap-system/gap' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -289,7 +289,7 @@ jobs:
           notify_on_changed_status: true
       - name: Send slack notification
         uses: act10ns/slack@e4e71685b9b239384b0f676a63c32367f59c2522
-        if: steps.should_notify.outputs.should_send_message == 'yes'
+        if: ${{ steps.should_notify.outputs.should_send_message == 'yes' }}
         with:
           status: ${{ steps.should_notify.outputs.current_status }}
         env:


### PR DESCRIPTION
Currently, the CI only thinks about whether to send a notification if there is a push. However, there are now more triggers where it would be appropriate to send notifications: the newly-added scheduled runs, and any manually-dispatched runs. I didn't think to add them in #4434.

Indeed, the existence of these runs might cause weirdness if we _don't_ send notifications for them: I think they count as runs on the `master` branch (unless a workflow is manually dispatched for a non-`master` branch), and so the following can happen:
- A push to `master` newly fails. A failure notification is sent to Slack.
- Things are fixed in a scheduled job. No notification is sent, because it's not yet implemented.
- The next push to `master` also passes, and the CI checks the status of the previous run on the `master` branch. The previous run was the scheduled job, which also passed, so again, no notification is sent.

So in this scenario, the failure notification is sent, but the success notification is not.

(Note: ultimately we'll want to add these notifications to the `Wrap releases` workflow too, but I propose we only do that when things settle down with the initial implementation.)