### PR TITLE
Remove `Autoload` for package documentation from PackageInfo.g example

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -577,7 +577,7 @@ SetPackageInfo( rec(
   PackageDoc := rec(
       BookName  := "test",
       SixFile   := "doc/manual.six",
-      Autoload  := true ),
+  ),
   Dependencies := rec(
       GAP       := "4.9",
       NeededOtherPackages := [ ["GAPDoc", "1.6"] ],


### PR DESCRIPTION
It's not been in use for a long time.