### PR TITLE
Small changes to manual: add index entry for `\n`, and add labels to `FactorCosetAction` documentation

### DIFF
--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -153,7 +153,10 @@ The following special character sequences are currently defined.
 For any other sequence starting with a backslash, the backslash is ignored.
 <P/>
 <List>
-<Mark><C>\n</C></Mark>
+<Mark>
+<Index Key='\\n'><C>\n</C></Index>
+<Index>newline character</Index>
+<C>\n</C></Mark>
 <Item>
     <E>newline character</E>.
     This is the character that, at least on UNIX systems,

--- a/lib/factgrp.gd
+++ b/lib/factgrp.gd
@@ -130,8 +130,10 @@ DeclareAttribute("NaturalHomomorphismsPool",IsGroup,
 ##
 ##  <#GAPDoc Label="FactorCosetAction">
 ##  <ManSection>
-##  <Oper Name="FactorCosetAction" Arg='G, U[, N]'/>
-##  <Oper Name="FactorCosetAction" Arg='G, L'/>
+##  <Oper Name="FactorCosetAction" Arg='G, U[, N]'
+##    Label="for a group and subgroup"/>
+##  <Oper Name="FactorCosetAction" Arg='G, L'
+##    Label="for a group and list of subgroups"/>
 ##
 ##  <Description>
 ##  This command computes the action of the group <A>G</A> on the


### PR DESCRIPTION
@RebeccaAHW noticed that the documentation for `\n` was uniquely missing an entry in the index of the reference manual, unlike say `\"`, `\\` and `\b`.

I think this is probably because, if you follow the pattern of the other characters, and simply use `\n` itself as the index key, then you get this scary message when compiling the manuals:
```
#I Writing LaTeX file, 4 x pdflatex with bibtex and makeindex,
#W There were LaTeX errors:
! Undefined control sequence.
<argument> \string \indexentry {\n
                                   @\texttt {\texttt {\symbol {92}}n}|hyperp..\
.
____________________
```
But if I use the key `\\n` instead, then everything seems to work well.

In making this change, I also noticed and added some missing labels:
```
#W There were LaTeX Warnings:
LaTeX Warning: Label `FactorCosetAction' multiply defined.

)
____________________
LaTeX Warning: There were multiply-defined labels.
```