### PR TITLE
Added some redundant methods for more unified user interface.

### DIFF
--- a/lib/kbsemi.gi
+++ b/lib/kbsemi.gi
@@ -199,6 +199,14 @@ local old,pat,cf;
   return w;
 end);
 
+InstallOtherMethod(AddRule,
+  "Fallback Method, call AddRuleReduced", true,
+  [ IsKnuthBendixRewritingSystem and IsMutable 
+     and IsKnuthBendixRewritingSystemRep, IsList ], -1,
+function(kbrws,v)
+  Info(InfoWarning,1,"Fallback method -- calling `AddRuleReduced` instead");
+  AddRuleReduced(kbrws,v);
+end);
 
 #############################################################################
 ##
@@ -217,11 +225,18 @@ end);
 ##  See Sims: "Computation with finitely presented groups".
 ##
 InstallOtherMethod(AddRuleReduced,
-"for a Knuth Bendix rewriting system and a rule", true,
-[ IsKnuthBendixRewritingSystem and IsMutable and IsKnuthBendixRewritingSystemRep, IsList ], 0,
+  "for a Knuth Bendix rewriting system and a rule", true,
+  [ IsKnuthBendixRewritingSystem and IsMutable 
+     and IsKnuthBendixRewritingSystemRep, IsList ], 0,
 function(kbrws,v)
 
   local u,a,b,c,k,n,s,add_rule,remove_rule,fam,ptc,geli,abi;
+
+    # allow to give rule also as words in free monoid
+    if ForAll(v,IsAssocWord) and
+      IsIdenticalObj(kbrws!.freefam,FamilyObj(v[1])) then
+      v:=List(v,LetterRepAssocWord);
+    fi;
 
     ptc:=IsBound(kbrws!.pairs2check);
     if IsBound(kbrws!.bitrules) then

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1029,7 +1029,11 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
 
   
   eqs:=Filtered(TriangulizedMat(eqs),x->not IsZero(x));
-  eqs:=NullspaceMat(TransposedMat(eqs)); # basis of cocycles
+  if Length(eqs)=0 then
+    eqs:=IdentityMat(Length(rules),field);
+  else
+    eqs:=NullspaceMat(TransposedMat(eqs)); # basis of cocycles
+  fi;
 
   # Now get Coboundaries
 
@@ -1985,8 +1989,12 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,old,sim,
 
     fi;
     # if we used factor perm rep, be bolder
-    new:=new*SmallerDegreePermutationRepresentation(p:cheap:=wasbold<>true);
-    SetIsomorphismPermGroup(fp,new);
+    if IsPermGroup(p) then
+      new:=new*SmallerDegreePermutationRepresentation(p:cheap:=wasbold<>true);
+      SetIsomorphismPermGroup(fp,new);
+    elif IsPcGroup(p) then
+      SetIsomorphismPcGroup(fp,new);
+    fi;
   fi;
 
   if HasIsSolvableGroup(r.group) then
@@ -2012,3 +2020,28 @@ local bas,ran,mats,o;
   o:=List(o,x->x[1]*coh.cohomology);
   return o;
 end);
+
+#############################################################################
+##
+#M  Extensions( G, M )
+##
+InstallOtherMethod(Extensions,"generic method for finite groups",
+    true,[IsGroup and IsFinite,IsObject],
+    -RankFilter(IsGroup and IsFinite),
+function(G,M)
+local coh;
+  coh:=TwoCohomologyGeneric(G,M);
+  return List(Elements(VectorSpace(coh.module.field,coh.cohomology)),
+    x->FpGroupCocycle(coh,x,true:normalform));
+end);
+
+InstallOtherMethod(ExtensionRepresentatives,"generic method for finite groups",
+  true,[IsGroup and IsFinite,IsObject,IsGroup],
+    -RankFilter(IsGroup and IsFinite),
+function(G,M,P)
+local coh;
+  coh:=TwoCohomologyGeneric(G,M);
+  return List(CompatiblePairOrbitRepsGeneric(P,coh),
+    x->FpGroupCocycle(coh,x,true:normalform));
+end);
+

--- a/tst/teststandard/twocohom.tst
+++ b/tst/teststandard/twocohom.tst
@@ -59,6 +59,13 @@ gap> cp:=CompatiblePairs(g,mo);
 gap> Length(ExtensionRepresentatives(g,mo,cp));
 2
 
+# New code for Pc groups
+gap> g:=AbelianGroup([2,2]);;
+gap> mo:=TrivialModule(2,GF(2));;
+gap> coh:=TwoCohomologyGeneric(g,mo);;
+gap> List(Elements(VectorSpace(GF(2),coh.cohomology)),
+> x->FpGroupCocycle(coh,x,true:normalform));;
+
 # routines used for rewriting
 gap> WeylGroupFp("A",3);
 <fp group on the generators [ s1, s2, s3 ]>

--- a/tst/teststandard/twocohom.tst
+++ b/tst/teststandard/twocohom.tst
@@ -47,6 +47,18 @@ gap> ConfluentMonoidPresentationForGroup(p);;
 gap> Length(ConjugacyClasses(p));
 119
 
+# Extensions nonsolvable
+gap> g:=Group((1,2,3,4,5),(3,4,5));;
+gap> mats:=[[[0,1,0,0],[0,0,1,0],[0,0,0,1],[2,2,2,2]],
+> [[1,0,0,0],[0,1,1,0],[0,0,0,1],[0,0,2,2]]];;
+gap> mo:=GModuleByMats(mats*Z(3)^0,GF(3));;
+gap> Length(Extensions(g,mo));
+3
+gap> cp:=CompatiblePairs(g,mo);
+<group of size 240 with 4 generators>
+gap> Length(ExtensionRepresentatives(g,mo,cp));
+2
+
 # routines used for rewriting
 gap> WeylGroupFp("A",3);
 <fp group on the generators [ s1, s2, s3 ]>


### PR DESCRIPTION
Made new 2-cohomology code also work for solvable groups. Added methods for `Extensions` for non-solvable groups

The manual documents `AddRule`, but provides only a method for
`AddRuleReduced`. Add a fallback method for `AddRule` that issues a warning
and calls `AddRuleReduced`.