### PR TITLE
Document RootFFE

### DIFF
--- a/doc/ref/fieldfin.xml
+++ b/doc/ref/fieldfin.xml
@@ -54,6 +54,7 @@ and&nbsp;<Ref Sect="Matrices over Finite Fields"/>).
 <#Include Label="IntFFESymm">
 <#Include Label="IntVecFFE">
 <#Include Label="AsInternalFFE">
+<#Include Label="RootFFE">
 
 </Section>
 

--- a/lib/ffe.gd
+++ b/lib/ffe.gd
@@ -668,7 +668,7 @@ DeclareAttribute( "AsInternalFFE", IsFFE);
 ##
 ##  <Description>
 ##  <Ref Func="RootFFE"/> returns a finite field element 
-##  <A>r</A> from <F> whose <A>k</A>-th power is <A>z</A>.
+##  <A>r</A> from <A>F</A> whose <A>k</A>-th power is <A>z</A>.
 ##  If no such element exists
 ##  then
 ##  <K>fail</K> is returned.


### PR DESCRIPTION
I came across the function `RootFFE` and noticed that it wasn't properly documented. 

This PR fixes a mistake in the documentation and adds it to the manual.