### PR TITLE
Refactor CI Workflow, unifying with Cygwin CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,27 +15,54 @@ env:
   LDFLAGS: "--coverage"
   # default config flags: enable debug asserts
   CONFIGFLAGS: "--enable-debug"
+  # CHERE_INVOKING=1 lets us start a 'login shell' (to set paths) in Windows without changing directory
+  CHERE_INVOKING: 1
 
 jobs:
-  test-unix:
+  test:
     name: ${{ matrix.test-suites }} - ${{ matrix.extra }} - ${{ matrix.os }}
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     strategy:
       fail-fast: false
       matrix:
-        # base test: fast first test
         os: [ubuntu-18.04]
-        test-suites: ["testinstall"]
+        shell: [bash]
+        test-suites:
+          [
+            # base test: fast first test
+            "testinstall",
+
+            "teststandard",
+
+            # run tests contained in the manual
+            "testmanuals",
+
+            # test error reporting and compiling as well as libgap
+            "testspecial test-compile testlibgap testkernel",
+
+            # compile packages and run GAP tests
+            # don't use --enable-debug to prevent the tests from taking too long
+            "testpackages testinstall-loadall",
+
+            # test creating the manual
+            # TODO: make the resulting HTML and PDF files available as build
+            # artifacts so that one can read the latest documentation (or even
+            # preview doc changes for PRs). Use the `upload-artifact` action and
+            # make it conditional. Or perhaps move the `makemanuals` job into
+            # a separate workflow job?
+            "makemanuals",
+          ]
         extra: [""]
 
         # add a few extra tests
         include:
           - os: ubuntu-18.04
-            test-suites: "teststandard"
-
-          - os: ubuntu-18.04
+            shell: bash
             test-suites: "teststandard"
             extra: "ABI=32 CONFIGFLAGS=\"\""
 
@@ -44,81 +71,31 @@ jobs:
           # hours (!) to complete instead of 25 minutes. So for now we just
           # run testinstall.
           - os: ubuntu-18.04
+            shell: bash
             test-suites: "testinstall"
             extra: "HPCGAP=yes ABI=64"
-
-          # compile packages and run GAP tests
-          # don't use --enable-debug to prevent the tests from taking too long
-          - os: ubuntu-18.04
-            test-suites: "testpackages testinstall-loadall"
-            extra: "ABI=64"
-            packages: "
-                    4ti2
-                    libboost-dev
-                    libcdd-dev
-                    libcurl4-openssl-dev
-                    libfplll-dev
-                    libmpc-dev
-                    libmpfi-dev
-                    libmpfr-dev
-                    libncurses5-dev
-                    libzmq3-dev
-                    pari-gp
-                    singular
-                    "
 
           # compile packages and run GAP tests in 32 bit mode
           # it seems profiling is having trouble collecting the coverage data
           # here, so we use NO_COVERAGE=1
           - os: ubuntu-18.04
+            shell: bash
             test-suites: "testpackages testinstall-loadall"
             extra: "ABI=32 NO_COVERAGE=1"
-            packages: "
-                    4ti2
-                    libboost-dev
-                    libcdd-dev
-                    libcurl4-openssl-dev
-                    libfplll-dev
-                    libmpc-dev
-                    libmpfi-dev
-                    libmpfr-dev
-                    libncurses5-dev
-                    libzmq3-dev
-                    pari-gp
-                    singular
-                    "
 
           # this job also tests GAP without readline
           - os: macos-latest
+            shell: bash
             test-suites: "testinstall"
             extra: "BOOTSTRAP_MINIMAL=yes"
-
-          # test creating the manual
-          # TODO: make the resulting HTML and PDF files available as build
-          # artifacts so that one can read the latest documentation (or even
-          # preview doc changes for PRs). Use the `upload-artifact` action and
-          # make it conditional. Or perhaps move the `makemanuals` job into
-          # a separate workflow job?
-          - os: ubuntu-18.04
-            test-suites: "makemanuals"
-            packages: "
-                    texlive-latex-base
-                    texlive-latex-recommended
-                    texlive-latex-extra
-                    texlive-extra-utils
-                    texlive-fonts-recommended
-                    texlive-fonts-extra
-                    "
-
-          # run tests contained in the manual. Also check ubuntu-latest works.
-          - os: ubuntu-latest
-            test-suites: "testmanuals"
 
           # run bugfix regression tests
           # Also turn on '--enable-memory-checking' to make sure GAP compiles
           # with the flag enabled. We do not actually test the memory
           # checking, as this slows down GAP too much.
-          - os: ubuntu-18.04
+          # Also check ubuntu-latest works.
+          - os: ubuntu-latest
+            shell: bash
             test-suites: "testbugfix"
             extra: "CONFIGFLAGS=\"--enable-memory-checking\""
 
@@ -133,6 +110,7 @@ jobs:
           # when compiled with valgrind support. We do not actually run any
           # tests using valgrind, as it is too slow.
           - os: ubuntu-18.04
+            shell: bash
             test-suites: "testbuildsys testinstall"
             extra: "NO_COVERAGE=1 ABI=64 BUILDDIR=out-of-tree
                     CONFIGFLAGS=\"--enable-valgrind\""
@@ -141,17 +119,23 @@ jobs:
           # same as above, but in 32 bit mode, also turn off debugging (see
           # elsewhere in this file for an explanation).
           - os: ubuntu-18.04
+            shell: bash
             test-suites: "testbuildsys testinstall"
             extra: "NO_COVERAGE=1 ABI=32 BUILDDIR=out-of-tree CONFIGFLAGS=\"\""
 
-          # test error reporting and compiling as well as libgap
-          - os: ubuntu-18.04
-            test-suites: "testspecial test-compile testlibgap testkernel"
-
           # test Julia integration
           - os: ubuntu-18.04
+            shell: bash
             test-suites: "testinstall"
             extra: "JULIA=yes CONFIGFLAGS=\"--enable-debug --disable-Werror\""
+
+          - os: windows-latest
+            # The 'run' steps in this job use Cygwin's bash, once it is set up.
+            #   --login: make a login shell (so PATH is set up)
+            #   -o igncr: Accept windows line endings
+            #   {0} : Pass any extra arguments from CI
+            shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
+            test-suites: "testinstall"
 
           # TODO: add back big endian test (we had s390x on Travis)
           # TODO: add back test with an older GCC, e.g. 4.7
@@ -168,6 +152,9 @@ jobs:
         with:
           python-version: 3.7
 
+      - uses: gap-actions/setup-cygwin@v1
+        if: ${{ runner.os == 'Windows' }}
+
       - name: "Install dependencies"
         run: |
                ${{ matrix.extra }}
@@ -177,6 +164,32 @@ jobs:
                        sudo apt-get remove libgmp-dev libreadline-dev zlib1g-dev
                    else
                        packages+=(libgmp-dev libreadline-dev zlib1g-dev)
+                   fi
+                   if [[ $TEST_SUITES == *testpackages* ]] ; then
+                       packages+=(            # For:
+                         4ti2                   # 4ti2Interface
+                         libboost-dev           # NormalizInterface
+                         libcdd-dev             # CddInterface
+                         libcurl4-openssl-dev   # curlInterface
+                         libfplll-dev           # float
+                         libmpc-dev             # float
+                         libmpfi-dev            # float
+                         libmpfr-dev            # float
+                         libncurses5-dev        # browse
+                         libzmq3-dev            # ZeroMQInterface
+                         pari-gp                # alnuth
+                         singular               # singular
+                       )
+                   fi
+                   if [[ $TEST_SUITES == *makemanuals* ]] ; then
+                       packages+=(
+                         texlive-latex-base
+                         texlive-latex-recommended
+                         texlive-latex-extra
+                         texlive-extra-utils
+                         texlive-fonts-recommended
+                         texlive-fonts-extra
+                       )
                    fi
                    if [[ $ABI == 32 ]] ; then
                        sudo dpkg --add-architecture i386
@@ -190,9 +203,6 @@ jobs:
                    sudo apt-get install "${packages[@]}"
                elif [ "$RUNNER_OS" == "macOS" ]; then
                    brew install gmp zlib
-               else
-                   echo "$RUNNER_OS not supported"
-                   exit 1
                fi
                python -m pip install gcovr
 
@@ -232,47 +242,10 @@ jobs:
           files: "!./pkg/**,!./extern/**"
           gcov_path_exclude: "./pkg/**"
 
-
-  # Based on https://github.com/mit-plv/fiat-crypto/blob/master/.github/workflows/coq-windows.yml
-  test-cygwin:
-    name: cygwin64 - testinstall
-    # Don't run this twice on PRs for branches pushed to the same repository
-    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
-    runs-on: windows-latest
-
-    env:
-      TEST_SUITES: testinstall
-      # CHERE_INVOKING=1 lets us start a 'login shell' (to set paths) without changing directory
-      CHERE_INVOKING: 1
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: gap-actions/setup-cygwin-for-gap@v1
-
-        # The following actions use cygwin's bash.
-        # --login: make a login shell (so PATH is set up)
-        # -o igncr: Accept windows line endings
-        # {0} : Pass any extra arguments from CI
-
-      - name: "Configure GAP"
-        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
-        run: dev/ci-configure-gap.sh
-      - name: "Build GAP"
-        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
-        run: dev/ci-build-gap.sh
-      - name: "Download packages"
-        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
-        run: dev/ci-download-pkgs.sh
-      - name: "Run tests"
-        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
-        run: dev/ci.sh
-
   slack-notification:
     name: Send Slack notification on status change
     needs:
-      - test-unix
-      - test-cygwin
+      - test
     if: ${{ always() && github.event_name != 'pull_request' && github.repository == 'gap-system/gap' }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Hopefully it is clear from the diff what I have done.

The primary change is that the separate Cygwin/Windows job is now unified with the main Unix jobs. This has the additional benefit that code coverage is now captured for the Cygwin job. This was made possible through the use of the setting:
```
defaults:
  run:
    shell:
```
The Unix jobs are set to always use `bash` (which is their default, anyway), but we want the Windows job to use a special `bash` (the Windows default is `cmd`).

I would be nice if the workflow files were 'cleverer', so that we could program the Linux/Mac jobs to always use `bash`, without having to repeat `shell: bash` all over the place, but I don't see how this is currently possible.

I also noticed that I could put more jobs into the 'matrix' directly, which saves some code duplication. To do so, I have:
* Changed the `ubuntu-latest` job from being the `testmanuals` to being the `testbugfix` job, which I think is harmless.
* Moved the lists of required additional packages (for the `testpackages` and the `makemanuals` jobs) into the `Install dependencies` step. I think this is more natural anyway, and again, it reduces code duplication.