### PR TITLE
Improve argument checking and documentation for `FreeGroup`, `FreeMonoid`, `FreeSemigroup`, `FreeMagmaWithOne`, and `FreeMagma`

### DIFF
--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -101,12 +101,14 @@ calculations.
 
 <Subsection Label="Generator Names">
 <Heading>Generator Names</Heading>
-For groups created as finitely presented groups, including polycyclic groups, the
-generators are labelled, by default, with a letter and a number. Using the
-option <C>generatorNames</C> it is possible to influcence this naming. If
-this option holds a string, the generators are named with this string and
-numbers, if a list of strings of sufficient length is given, the generator
-names are taken from this list of strings.
+For groups created as finitely presented groups, including polycyclic groups,
+the generators are labelled, by default, with a letter and a number.
+It is possible to influence this naming with the option <C>generatorNames</C>,
+see Section&nbsp;<Ref Sect="Function Call With Options"/>.
+If this option holds a string, then the generators are named with this
+string and sequential numbers starting with <C>1</C>.
+If this option holds a list of sufficient length consisting of
+nonempty strings, then the generator names are taken from this list, in order.
 <P/>
 <Example><![CDATA[
 gap> GeneratorsOfGroup(AbelianGroup([5,7]));

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5729,4 +5729,4 @@ InstallMethod( IndependentGeneratorsOfAbelianGroup,
   [ IsFpGroup and IsAbelian ],
   IndependentGeneratorsOfMaximalAbelianQuotientOfFpGroup );
 
-BindGlobal("TRIVIAL_FP_GROUP",FreeGroup(0,"TrivGp")/[]);
+BindGlobal( "TRIVIAL_FP_GROUP", FreeGroup(0) / [] );

--- a/lib/grpfree.gd
+++ b/lib/grpfree.gd
@@ -32,62 +32,124 @@ DeclareSynonym( "IsElementOfFreeGroupFamily",IsAssocWordWithInverseFamily );
 
 #############################################################################
 ##
-#F  FreeGroup( [<wfilt>,]<rank> )
-#F  FreeGroup( [<wfilt>,]<rank>, <name> )
-#F  FreeGroup( [<wfilt>,]<name1>, <name2>, ... )
+#F  FreeGroup( [<wfilt>,]<rank>[, <name>] )
+#F  FreeGroup( [<wfilt>,][<name1>[, <name2>[, ...]]] )
 #F  FreeGroup( [<wfilt>,]<names> )
-#F  FreeGroup( [<wfilt>,]infinity, <name>, <init> )
+#F  FreeGroup( [<wfilt>,]infinity[, <name>][, <init>] )
 ##
 ##  <#GAPDoc Label="FreeGroup">
 ##  <ManSection>
 ##  <Heading>FreeGroup</Heading>
 ##  <Func Name="FreeGroup" Arg='[wfilt, ]rank[, name]'
 ##   Label="for given rank"/>
-##  <Func Name="FreeGroup" Arg='[wfilt, ]name1, name2, ...'
+##  <Func Name="FreeGroup" Arg='[wfilt, ][name1[, name2[, ...]]]'
 ##   Label="for various names"/>
 ##  <Func Name="FreeGroup" Arg='[wfilt, ]names'
 ##   Label="for a list of names"/>
-##  <Func Name="FreeGroup" Arg='[wfilt, ]infinity, name, init'
+##  <Func Name="FreeGroup" Arg='[wfilt, ]infinity[, name][, init]'
 ##   Label="for infinitely many generators"/>
 ##
 ##  <Description>
-##  Called with a positive integer <A>rank</A>,
-##  <Ref Func="FreeGroup" Label="for given rank"/> returns
-##  a free group on <A>rank</A> generators.
-##  If the optional argument <A>name</A> is given then the generators are
-##  printed as <A>name</A><C>1</C>, <A>name</A><C>2</C> etc.,
-##  that is, each name is the concatenation of the string <A>name</A> and an
-##  integer from <C>1</C> to <A>range</A>.
-##  The default for <A>name</A> is the string <C>"f"</C>.
-##  <P/>
-##  Called in the second form,
-##  <Ref Func="FreeGroup" Label="for various names"/> returns
-##  a free group on as many generators as arguments, printed as
-##  <A>name1</A>, <A>name2</A> etc.
-##  <P/>
-##  Called in the third form,
-##  <Ref Func="FreeGroup" Label="for a list of names"/> returns
-##  a free group on as many generators as the length of the list
-##  <A>names</A>, the <M>i</M>-th generator being printed as
-##  <A>names</A><C>[</C><M>i</M><C>]</C>.
-##  <P/>
-##  Called in the fourth form,
-##  <Ref Func="FreeGroup" Label="for infinitely many generators"/>
-##  returns a free group on infinitely many generators, where the first
-##  generators are printed by the names in the list <A>init</A>,
-##  and the other generators by <A>name</A> and an appended number.
-##  <P/>
-##  If the extra argument <A>wfilt</A> is given, it must be either
-##  <C>IsSyllableWordsFamily</C> or <C>IsLetterWordsFamily</C> or
-##  <C>IsWLetterWordsFamily</C> or <C>IsBLetterWordsFamily</C>.
-##  This filter then specifies the representation used for the elements of
+##  <C>FreeGroup</C> returns a free group. The number of
+##  generators, and the labels given to the generators, can be specified in
+##  several different ways.
+##  Warning: the labels of generators are only an aid for printing,
+##  and do not necessarily distinguish generators;
+##  see the examples at the end of
+##  <Ref Func="FreeSemigroup" Label="for given rank"/>
+##  for more information.
+##  <List>
+##    <Mark>
+##      1: For a given rank, and an optional generator name prefix
+##    </Mark>
+##    <Item>
+##      Called with a nonnegative integer <A>rank</A>,
+##      <Ref Func="FreeGroup" Label="for given rank"/> returns
+##      a free group on <A>rank</A> generators.
+##      The optional argument <A>name</A> must be a string;
+##      its default value is <C>"f"</C>. <P/>
+##
+##      If <A>name</A> is not given but the <C>generatorNames</C> option is,
+##      then this option is respected as described in
+##      Section&nbsp;<Ref Sect="Generator Names"/>. <P/>
+##
+##      Otherwise, the generators of the returned free group are labelled
+##      <A>name</A><C>1</C>, ..., <A>name</A><C>k</C>,
+##      where <C>k</C> is the value of <A>rank</A>. <P/>
+##    </Item>
+##    <Mark>2: For given generator names</Mark>
+##    <Item>
+##      Called with various nonempty strings,
+##      <Ref Func="FreeGroup" Label="for various names"/> returns
+##      a free group on as many generators as arguments, which are labelled
+##      <A>name1</A>, <A>name2</A>, etc.
+##    </Item>
+##    <Mark>3: For a given list of generator names</Mark>
+##    <Item>
+##      Called with a finite list <A>names</A> of
+##      nonempty strings,
+##      <Ref Func="FreeGroup" Label="for a list of names"/> returns
+##      a free group on <C>Length(<A>names</A>)</C> generators, whose
+##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
+##    </Item>
+##    <Mark>
+##      4: For the rank <K>infinity</K>,
+##         an optional default generator name prefix,
+##         and an optional finite list of generator names
+##    </Mark>
+##    <Item>
+##      Called in the fourth form,
+##      <Ref Func="FreeGroup" Label="for infinitely many generators"/>
+##      returns a free group on infinitely many generators.
+##      The optional argument <A>name</A> must be a string; its default value is
+##      <C>"f"</C>,
+##      and the optional argument <A>init</A> must be a finite list of
+##      nonempty strings; its default value is an empty list.
+##      The generators are initially labelled according to the list <A>init</A>,
+##      followed by
+##      <A>name</A><C>i</C> for each <C>i</C> in the range from
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##    </Item>
+##  </List>
+##  If the optional first argument <A>wfilt</A> is given, then it must be either
+##  <C>IsSyllableWordsFamily</C>, <C>IsLetterWordsFamily</C>,
+##  <C>IsWLetterWordsFamily</C>, or <C>IsBLetterWordsFamily</C>.
+##  This filter specifies the representation used for the elements of
 ##  the free group
 ##  (see&nbsp;<Ref Sect="Representations for Associative Words"/>).
 ##  If no such filter is given, a letter representation is used.
 ##  <P/>
 ##  (For interfacing to old code that omits the representation flag, use of
 ##  the syllable representation is also triggered by setting the option
-##  <C>FreeGroupFamilyType</C> to the string <C>"syllable"</C>.)
+##  <C>FreeGroupFamilyType</C> to the string <C>"syllable"</C>; this is
+##  overwritten by the optional first argument if it is given.)
+##
+##  <Example><![CDATA[
+##  gap> FreeGroup(5);
+##  <free group on the generators [ f1, f2, f3, f4, f5 ]>
+##  gap> FreeGroup(4, "gen");
+##  <free group on the generators [ gen1, gen2, gen3, gen4 ]>
+##  gap> FreeGroup(3 : generatorNames := "ack");
+##  <free group on the generators [ ack1, ack2, ack3 ]>
+##  gap> FreeGroup(2 : generatorNames := ["u", "v", "w"]);
+##  <free group on the generators [ u, v ]>
+##  gap> FreeGroup();
+##  <free group of rank zero>
+##  gap> FreeGroup("a", "b", "c");
+##  <free group on the generators [ a, b, c ]>
+##  gap> FreeGroup(["x", "y"]);
+##  <free group on the generators [ x, y ]>
+##  gap> FreeGroup(infinity);
+##  <free group with infinity generators>
+##  gap> F := FreeGroup(infinity, "g", ["a", "b"]);
+##  <free group with infinity generators>
+##  gap> GeneratorsOfGroup(F){[1..4]};
+##  [ a, b, g3, g4 ]
+##  gap> GeneratorsOfGroup(FreeGroup(infinity, "gen")){[1..3]};
+##  [ gen1, gen2, gen3 ]
+##  gap> FreeGroup(IsSyllableWordsFamily, 50);
+##  <free group with 50 generators>
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/grpfree.gi
+++ b/lib/grpfree.gi
@@ -591,7 +591,9 @@ InstallMethod( ViewObj,
     [ IsFreeGroup ],
 function(G)
   if IsGroupOfFamily(G) then
-    if Length(GeneratorsOfGroup(G)) > GAPInfo.ViewLength * 10 then
+    if IsEmpty(GeneratorsOfGroup(G)) then
+      Print("<free group of rank zero>");
+    elif Length(GeneratorsOfGroup(G)) > GAPInfo.ViewLength * 10 then
       Print("<free group with ",Length(GeneratorsOfGroup(G))," generators>");
     else
       Print("<free group on the generators ",GeneratorsOfGroup(G),">");

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -763,6 +763,11 @@ InParentFOA( "Centralizer", IsMagma, IsObject, DeclareAttribute );
 DeclareOperation( "SquareRoots", [ IsMagma, IsMultiplicativeElement ] );
 
 
+################################################################################
+##
+DeclareGlobalFunction("FreeXArgumentProcessor");
+
+
 #############################################################################
 ##
 #F  FreeMagma( <rank>[, <name>] )

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -771,48 +771,109 @@ DeclareGlobalFunction("FreeXArgumentProcessor");
 #############################################################################
 ##
 #F  FreeMagma( <rank>[, <name>] )
-#F  FreeMagma( <name1>, <name2>, ... )
+#F  FreeMagma( <name1>[, <name2>[, ...]] )
 #F  FreeMagma( <names> )
-#F  FreeMagma( infinity, <name>, <init> )
+#F  FreeMagma( infinity[, <name>][, <init>] )
 ##
 ##  <#GAPDoc Label="FreeMagma">
 ##  <ManSection>
 ##  <Heading>FreeMagma</Heading>
 ##  <Func Name="FreeMagma" Arg='rank[, name]'
 ##   Label="for given rank"/>
-##  <Func Name="FreeMagma" Arg='name1, name2, ...'
+##  <Func Name="FreeMagma" Arg='name1[, name2[, ...]]'
 ##   Label="for various names"/>
 ##  <Func Name="FreeMagma" Arg='names'
 ##   Label="for a list of names"/>
-##  <Func Name="FreeMagma" Arg='infinity, name, init'
+##  <Func Name="FreeMagma" Arg='infinity[, name][, init]'
 ##   Label="for infinitely many generators"/>
 ##
 ##  <Description>
-##  Called with a positive integer <A>rank</A>,
-##  <Ref Func="FreeMagma" Label="for given rank"/> returns
-##  a free magma on <A>rank</A> generators.
-##  If the optional argument <A>name</A> is given then the generators are
-##  printed as <A>name</A><C>1</C>, <A>name</A><C>2</C> etc.,
-##  that is, each name is the concatenation of the string <A>name</A> and an
-##  integer from <C>1</C> to <A>range</A>.
-##  The default for <A>name</A> is the string <C>"m"</C>.
-##  <P/>
-##  Called in the second form,
-##  <Ref Func="FreeMagma" Label="for various names"/> returns
-##  a free magma on as many generators as arguments, printed as
-##  <A>name1</A>, <A>name2</A> etc.
-##  <P/>
-##  Called in the third form,
-##  <Ref Func="FreeMagma" Label="for a list of names"/> returns
-##  a free magma on as many generators as the length of the list
-##  <A>names</A>, the <M>i</M>-th generator being printed as
-##  <A>names</A><C>[</C><M>i</M><C>]</C>.
-##  <P/>
-##  Called in the fourth form,
-##  <Ref Func="FreeMagma" Label="for infinitely many generators"/>
-##  returns a free magma on infinitely many generators, where the first
-##  generators are printed by the names in the list <A>init</A>,
-##  and the other generators by <A>name</A> and an appended number.
+##  <C>FreeMagma</C> returns a free magma. The number of
+##  generators, and the labels given to the generators, can be specified in
+##  several different ways.
+##  Warning: the labels of generators are only an aid for printing,
+##  and do not necessarily distinguish generators;
+##  see the examples at the end of
+##  <Ref Func="FreeSemigroup" Label="for given rank"/>
+##  for more information.
+##  <List>
+##    <Mark>
+##      1: For a given rank, and an optional generator name prefix
+##    </Mark>
+##    <Item>
+##      Called with a positive integer <A>rank</A>,
+##      <Ref Func="FreeMagma" Label="for given rank"/> returns
+##      a free magma on <A>rank</A> generators.
+##      The optional argument <A>name</A> must be a string;
+##      its default value is <C>"x"</C>. <P/>
+##
+##      If <A>name</A> is not given but the <C>generatorNames</C> option is,
+##      then this option is respected as described in
+##      Section&nbsp;<Ref Sect="Generator Names"/>. <P/>
+##
+##      Otherwise, the generators of the returned free magma are labelled
+##      <A>name</A><C>1</C>, ..., <A>name</A><C>k</C>,
+##      where <C>k</C> is the value of <A>rank</A>. <P/>
+##    </Item>
+##    <Mark>2: For given generator names</Mark>
+##    <Item>
+##      Called with various (at least one) nonempty strings,
+##      <Ref Func="FreeMagma" Label="for various names"/> returns
+##      a free magma on as many generators as arguments, which are labelled
+##      <A>name1</A>, <A>name2</A>, etc.
+##    </Item>
+##    <Mark>3: For a given list of generator names</Mark>
+##    <Item>
+##      Called with a finite nonempty list <A>names</A> of
+##      nonempty strings,
+##      <Ref Func="FreeMagma" Label="for a list of names"/> returns
+##      a free magma on <C>Length(<A>names</A>)</C> generators, whose
+##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
+##    </Item>
+##    <Mark>
+##      4: For the rank <K>infinity</K>,
+##         an optional default generator name prefix,
+##         and an optional finite list of generator names
+##    </Mark>
+##    <Item>
+##      Called in the fourth form,
+##      <Ref Func="FreeMagma" Label="for infinitely many generators"/>
+##      returns a free magma on infinitely many generators.
+##      The optional argument <A>name</A> must be a string; its default value is
+##      <C>"x"</C>,
+##      and the optional argument <A>init</A> must be a finite list of
+##      nonempty strings; its default value is an empty list.
+##      The generators are initially labelled according to the list <A>init</A>,
+##      followed by
+##      <A>name</A><C>i</C> for each <C>i</C> in the range from
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##    </Item>
+##  </List>
+##  <Example><![CDATA[
+##  gap> FreeMagma( 4 );
+##  <free magma on the generators [ x1, x2, x3, x4 ]>
+##  gap> FreeMagma( 3, "a" );
+##  <free magma on the generators [ a1, a2, a3 ]>
+##  gap> FreeMagma( "a", "b" );
+##  <free magma on the generators [ a, b ]>
+##  gap> FreeMagma( [ "a", "b" ] );
+##  <free magma on the generators [ a, b ]>
+##  gap> FreeMagma( infinity );
+##  <free magma with infinity generators>
+##  gap> F := FreeMagma( infinity, "gen" );;
+##  gap> GeneratorsOfMagma( F ){[ 1 .. 4 ]};
+##  [ gen1, gen2, gen3, gen4 ]
+##  gap> F := FreeMagma( infinity, [ "z", "a" ] );;
+##  gap> GeneratorsOfMagma( F ){[ 1 .. 3 ]};
+##  [ z, a, x3 ]
+##  gap> F := FreeMagma( infinity, "y", [ "z", "a" ] );;
+##  gap> GeneratorsOfMagma( F ){[ 1 .. 4 ]};
+##  [ z, a, y3, y4 ]
+##  gap> FreeMagma( 3 : generatorNames := "elt" );
+##  <free magma on the generators [ elt1, elt2, elt3 ]>
+##  gap> FreeMagma( 2 : generatorNames := [ "u", "v", "w" ] );
+##  <free magma on the generators [ u, v ]>
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -823,74 +884,110 @@ DeclareGlobalFunction( "FreeMagma" );
 #############################################################################
 ##
 #F  FreeMagmaWithOne( <rank>[, <name>] )
-#F  FreeMagmaWithOne( <name1>, <name2>, ... )
+#F  FreeMagmaWithOne( [<name1>[, <name2>[, ...]]] )
 #F  FreeMagmaWithOne( <names> )
-#F  FreeMagmaWithOne( infinity, <name>, <init> )
+#F  FreeMagmaWithOne( infinity[, <name>][, <init>] )
 ##
 ##  <#GAPDoc Label="FreeMagmaWithOne">
 ##  <ManSection>
 ##  <Heading>FreeMagmaWithOne</Heading>
 ##  <Func Name="FreeMagmaWithOne" Arg='rank[, name]'
 ##   Label="for given rank"/>
-##  <Func Name="FreeMagmaWithOne" Arg='name1, name2, ...'
+##  <Func Name="FreeMagmaWithOne" Arg='[name1[, name2[, ...]]]'
 ##   Label="for various names"/>
 ##  <Func Name="FreeMagmaWithOne" Arg='names'
 ##   Label="for a list of names"/>
-##  <Func Name="FreeMagmaWithOne" Arg='infinity, name, init'
+##  <Func Name="FreeMagmaWithOne" Arg='infinity[, name][, init]'
 ##   Label="for infinitely many generators"/>
 ##
 ##  <Description>
-##  Called with a positive integer <A>rank</A>,
-##  <Ref Func="FreeMagmaWithOne" Label="for given rank"/> returns
-##  a free magma-with-one on <A>rank</A> generators.
-##  If the optional argument <A>name</A> is given then the generators are
-##  printed as <A>name</A><C>1</C>, <A>name</A><C>2</C> etc.,
-##  that is, each name is the concatenation of the string <A>name</A> and an
-##  integer from <C>1</C> to <A>range</A>.
-##  The default for <A>name</A> is the string <C>"m"</C>.
-##  <P/>
-##  Called in the second form,
-##  <Ref Func="FreeMagmaWithOne" Label="for various names"/> returns
-##  a free magma-with-one on as many generators as arguments, printed as
-##  <A>name1</A>, <A>name2</A> etc.
-##  <P/>
-##  Called in the third form,
-##  <Ref Func="FreeMagmaWithOne" Label="for a list of names"/> returns
-##  a free magma-with-one on as many generators as the length of the list
-##  <A>names</A>, the <M>i</M>-th generator being printed as
-##  <A>names</A><C>[</C><M>i</M><C>]</C>.
-##  <P/>
-##  Called in the fourth form,
-##  <Ref Func="FreeMagmaWithOne" Label="for infinitely many generators"/>
-##  returns a free magma-with-one on infinitely many generators, where the
-##  first generators are printed by the names in the list <A>init</A>,
-##  and the other generators by <A>name</A> and an appended number.
-##  <P/>
+##  <C>FreeMagmaWithOne</C> returns a free magma-with-one. The number of
+##  generators, and the labels given to the generators, can be specified in
+##  several different ways.
+##  Warning: the labels of generators are only an aid for printing,
+##  and do not necessarily distinguish generators;
+##  see the examples at the end of
+##  <Ref Func="FreeSemigroup" Label="for given rank"/>
+##  for more information.
+##  <List>
+##    <Mark>
+##      1: For a given rank, and an optional generator name prefix
+##    </Mark>
+##    <Item>
+##      Called with a nonnegative integer <A>rank</A>,
+##      <Ref Func="FreeMagmaWithOne" Label="for given rank"/> returns
+##      a free magma-with-one on <A>rank</A> generators.
+##      The optional argument <A>name</A> must be a string;
+##      its default value is <C>"x"</C>. <P/>
+##
+##      If <A>name</A> is not given but the <C>generatorNames</C> option is,
+##      then this option is respected as described in
+##      Section&nbsp;<Ref Sect="Generator Names"/>. <P/>
+##
+##      Otherwise, the generators of the returned free magma-with-one are
+##      labelled <A>name</A><C>1</C>, ..., <A>name</A><C>k</C>,
+##      where <C>k</C> is the value of <A>rank</A>. <P/>
+##    </Item>
+##    <Mark>2: For given generator names</Mark>
+##    <Item>
+##      Called with various nonempty strings,
+##      <Ref Func="FreeMagmaWithOne" Label="for various names"/> returns
+##      a free magma-with-one on as many generators as arguments, which are
+##      labelled <A>name1</A>, <A>name2</A>, etc.
+##    </Item>
+##    <Mark>3: For a given list of generator names</Mark>
+##    <Item>
+##      Called with a finite list <A>names</A> of
+##      nonempty strings,
+##      <Ref Func="FreeMagmaWithOne" Label="for a list of names"/> returns
+##      a free magma-with-one on <C>Length(<A>names</A>)</C> generators, whose
+##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
+##    </Item>
+##    <Mark>
+##      4: For the rank <K>infinity</K>,
+##         an optional default generator name prefix,
+##         and an optional finite list of generator names
+##    </Mark>
+##    <Item>
+##      Called in the fourth form,
+##      <Ref Func="FreeMagmaWithOne" Label="for infinitely many generators"/>
+##      returns a free magma-with-one on infinitely many generators.
+##      The optional argument <A>name</A> must be a string; its default value is
+##      <C>"x"</C>,
+##      and the optional argument <A>init</A> must be a finite list of
+##      nonempty strings; its default value is an empty list.
+##      The generators are initially labelled according to the list <A>init</A>,
+##      followed by
+##      <A>name</A><C>i</C> for each <C>i</C> in the range from
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##    </Item>
+##  </List>
 ##  <Example><![CDATA[
-##  gap> FreeMagma( 3 );
-##  <free magma on the generators [ x1, x2, x3 ]>
-##  gap> FreeMagma( "a", "b" );
-##  <free magma on the generators [ a, b ]>
-##  gap> FreeMagma( infinity );
-##  <free magma with infinity generators>
-##  gap> FreeMagmaWithOne( 3 );
-##  <free magma-with-one on the generators [ x1, x2, x3 ]>
+##  gap> FreeMagmaWithOne( 4 );
+##  <free magma-with-one on the generators [ x1, x2, x3, x4 ]>
+##  gap> FreeMagmaWithOne( 3, "a" );
+##  <free magma-with-one on the generators [ a1, a2, a3 ]>
 ##  gap> FreeMagmaWithOne( "a", "b" );
+##  <free magma-with-one on the generators [ a, b ]>
+##  gap> FreeMagmaWithOne( [ "a", "b" ] );
 ##  <free magma-with-one on the generators [ a, b ]>
 ##  gap> FreeMagmaWithOne( infinity );
 ##  <free magma-with-one with infinity generators>
-##  ]]></Example>
-##  <P/>
-##  Remember that the names of generators used for printing
-##  do not necessarily distinguish letters of the alphabet;
-##  so it is possible to create arbitrarily weird
-##  situations by choosing strange letter names.
-##  <P/>
-##  <Example><![CDATA[
-##  gap> m:= FreeMagma( "x", "x" );  gens:= GeneratorsOfMagma( m );;
-##  <free magma on the generators [ x, x ]>
-##  gap> gens[1] = gens[2];
-##  false
+##  gap> F := FreeMagmaWithOne( infinity, "gen" );;
+##  gap> GeneratorsOfMagmaWithOne( F ){[ 1 .. 4 ]};
+##  [ gen1, gen2, gen3, gen4 ]
+##  gap> F := FreeMagmaWithOne( infinity, [ "z", "a" ] );;
+##  gap> GeneratorsOfMagmaWithOne( F ){[ 1 .. 3 ]};
+##  [ z, a, x3 ]
+##  gap> F := FreeMagmaWithOne( infinity, "y", [ "z", "a" ] );;
+##  gap> GeneratorsOfMagmaWithOne( F ){[ 1 .. 4 ]};
+##  [ z, a, y3, y4 ]
+##  gap> FreeMagmaWithOne( 0 );
+##  <free group of rank zero>
+##  gap> FreeMagmaWithOne( 3 : generatorNames := "elt" );
+##  <free magma-with-one on the generators [ elt1, elt2, elt3 ]>
+##  gap> FreeMagmaWithOne( 2 : generatorNames := [ "u", "v", "w" ] );
+##  <free magma-with-one on the generators [ u, v ]>
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/mgmfree.gi
+++ b/lib/mgmfree.gi
@@ -468,52 +468,27 @@ end );
 
 #############################################################################
 ##
-#F  FreeMagma( <rank> )
-#F  FreeMagma( <rank>, <name> )
-#F  FreeMagma( <name1>, <name2>, ... )
+#F  FreeMagma( <rank>[, <name>] )
+#F  FreeMagma( <name1>[, <name2>[, ...]] )
 #F  FreeMagma( <names> )
-#F  FreeMagma( infinity, <name>, <init> )
+#F  FreeMagma( infinity[, <name>][, <init>] )
 ##
-InstallGlobalFunction( FreeMagma,
-    function( arg )
-    local   names,      # list of generators names
-            F,          # family of free magma element objects
-            M;          # free magma, result
+InstallGlobalFunction( FreeMagma, function( arg )
+    local processed,
+          F,          # family of free magma element objects
+          M;          # free magma, result
 
-    # Get and check the argument list, and construct names if necessary.
-    if   Length( arg ) = 1 and arg[1] = infinity then
-      names:= InfiniteListOfNames( "x" );
-    elif Length( arg ) = 2 and arg[1] = infinity then
-      names:= InfiniteListOfNames( arg[2] );
-    elif Length( arg ) = 3 and arg[1] = infinity then
-      names:= InfiniteListOfNames( arg[2], arg[3] );
-    elif Length( arg ) = 1 and IsInt( arg[1] ) and 0 < arg[1] then
-      names:= List( [ 1 .. arg[1] ],
-                    i -> Concatenation( "x", String(i) ) );
-      MakeImmutable( names );
-    elif Length( arg ) = 2 and IsInt( arg[1] ) and 0 < arg[1] then
-      names:= List( [ 1 .. arg[1] ],
-                    i -> Concatenation( arg[2], String(i) ) );
-      MakeImmutable( names );
-    elif 1 <= Length( arg ) and ForAll( arg, IsString ) then
-      names:= arg;
-    elif Length( arg ) = 1 and IsList( arg[1] )
-                           and not IsEmpty( arg[1] )
-                           and ForAll( arg[1], IsString ) then
-      names:= arg[1];
-    else
-      Error("usage: FreeMagma(<name1>,<name2>..),FreeMagma(<rank>)");
-    fi;
+    processed := FreeXArgumentProcessor( "FreeMagma", "x", arg, false, false );
 
     # Construct the family of element objects of our magma.
     F:= NewFamily( "FreeMagmaElementsFamily", IsNonassocWord );
 
     # Store the names and the default type.
-    F!.names:= names;
+    F!.names:= processed.names;
     F!.defaultType:= NewType( F, IsNonassocWord and IsBracketRep );
 
     # Make the magma.
-    if IsFinite( names ) then
+    if IsFinite( processed.names ) then
       M:= MagmaByGenerators( MagmaGeneratorsOfFamily( F ) );
     else
       M:= MagmaByGenerators( InfiniteListOfGenerators( F ) );
@@ -527,43 +502,20 @@ end );
 
 #############################################################################
 ##
-#F  FreeMagmaWithOne( <rank> )
-#F  FreeMagmaWithOne( <rank>, <name> )
-#F  FreeMagmaWithOne( <name1>, <name2>, ... )
+#F  FreeMagmaWithOne( <rank>[, <name>] )
+#F  FreeMagmaWithOne( [<name1>[, <name2>[, ...]]] )
 #F  FreeMagmaWithOne( <names> )
-#F  FreeMagmaWithOne( infinity, <name>, <init> )
+#F  FreeMagmaWithOne( infinity[, <name>][, <init>] )
 ##
 InstallGlobalFunction( FreeMagmaWithOne,
     function( arg )
-    local   names,      # list of generators names
-            F,          # family of free magma element objects
-            M;          # free magma, result
+    local names,      # list of generators names
+          F,          # family of free magma element objects
+          M,          # free magma, result
+          processed;
 
-    # Get and check the argument list, and construct names if necessary.
-    if   Length( arg ) = 1 and arg[1] = infinity then
-      names:= InfiniteListOfNames( "x" );
-    elif Length( arg ) = 2 and arg[1] = infinity then
-      names:= InfiniteListOfNames( arg[2] );
-    elif Length( arg ) = 3 and arg[1] = infinity then
-      names:= InfiniteListOfNames( arg[2], arg[3] );
-    elif Length( arg ) = 1 and IsInt( arg[1] ) and 0 < arg[1] then
-      names:= List( [ 1 .. arg[1] ],
-                    i -> Concatenation( "x", String(i) ) );
-      MakeImmutable( names );
-    elif Length( arg ) = 2 and IsInt( arg[1] ) and 0 < arg[1] then
-      names:= List( [ 1 .. arg[1] ],
-                    i -> Concatenation( arg[2], String(i) ) );
-      MakeImmutable( names );
-    elif 1 <= Length( arg ) and ForAll( arg, IsString ) then
-      names:= arg;
-    elif Length( arg ) = 1 and IsList( arg[1] )
-                           and not IsEmpty( arg[1])
-                           and ForAll( arg[1], IsString ) then
-      names:= arg[1];
-    else
-      Error( "usage: FreeMagmaWithOne(<name1>,<name2>..),",
-             "FreeMagmaWithOne(<rank>)" );
-    fi;
+    processed := FreeXArgumentProcessor( "FreeMagmaWithOne", "x", arg, false, true );
+    names := processed.names;
 
     # Handle the trivial case.
     if IsEmpty( names ) then

--- a/lib/monofree.gi
+++ b/lib/monofree.gi
@@ -284,7 +284,9 @@ InstallMethod( ViewObj,
     "for a free monoid containing the whole family",
     [ IsMonoid and IsAssocWordCollection and IsWholeFamily ],
     function( M )
-    if GAPInfo.ViewLength * 10 < Length( GeneratorsOfMagmaWithOne( M ) ) then
+    if IsEmpty( GeneratorsOfMagmaWithOne( M ) ) then
+      Print( "<free monoid of rank zero>" );
+    elif GAPInfo.ViewLength * 10 < Length( GeneratorsOfMagmaWithOne( M ) ) then
       Print( "<free monoid with ", Length( GeneratorsOfMagmaWithOne( M ) ),
              " generators>" );
     else

--- a/lib/monoid.gd
+++ b/lib/monoid.gd
@@ -184,62 +184,127 @@ DeclareSynonymAttr( "TrivialSubmonoid", TrivialSubmagmaWithOne );
 
 #############################################################################
 ##
-#F  FreeMonoid( [<wfilt>,]<rank> )
-#F  FreeMonoid( [<wfilt>,]<rank>, <name> )
-#F  FreeMonoid( [<wfilt>,]<name1>, <name2>, ... )
+#F  FreeMonoid( [<wfilt>,]<rank>[, <name>] )
+#F  FreeMonoid( [<wfilt>,][<name1>[, <name2>[, ...]]] )
 #F  FreeMonoid( [<wfilt>,]<names> )
-#F  FreeMonoid( [<wfilt>,]infinity, <name>, <init> )
+#F  FreeMonoid( [<wfilt>,]infinity[, <name>][, <init>] )
 ##
 ##  <#GAPDoc Label="FreeMonoid">
 ##  <ManSection>
 ##  <Heading>FreeMonoid</Heading>
 ##  <Func Name="FreeMonoid" Arg='[wfilt, ]rank[, name]'
 ##   Label="for given rank"/>
-##  <Func Name="FreeMonoid" Arg='[wfilt, ]name1, name2, ...'
+##  <Func Name="FreeMonoid" Arg='[wfilt, ][name1[, name2[, ...]]]'
 ##   Label="for various names"/>
 ##  <Func Name="FreeMonoid" Arg='[wfilt, ]names'
 ##   Label="for a list of names"/>
-##  <Func Name="FreeMonoid" Arg='[wfilt, ]infinity, name, init'
+##  <Func Name="FreeMonoid" Arg='[wfilt, ]infinity[, name][, init]'
 ##   Label="for infinitely many generators"/>
 ##
 ##  <Description>
-##  Called with a positive integer <A>rank</A>,
-##  <Ref Func="FreeMonoid" Label="for given rank"/> returns
-##  a free monoid on <A>rank</A> generators.
-##  If the optional argument <A>name</A> is given then the generators are
-##  printed as <A>name</A><C>1</C>, <A>name</A><C>2</C> etc.,
-##  that is, each name is the concatenation of the string <A>name</A> and an
-##  integer from <C>1</C> to <A>range</A>.
-##  The default for <A>name</A> is the string <C>"m"</C>.
-##  <P/>
-##  Called in the second form,
-##  <Ref Func="FreeMonoid" Label="for various names"/> returns
-##  a free monoid on as many generators as arguments, printed as
-##  <A>name1</A>, <A>name2</A> etc.
-##  <P/>
-##  Called in the third form,
-##  <Ref Func="FreeMonoid" Label="for a list of names"/> returns
-##  a free monoid on as many generators as the length of the list
-##  <A>names</A>, the <M>i</M>-th generator being printed as
-##  <A>names</A><C>[</C><M>i</M><C>]</C>.
-##  <P/>
-##  Called in the fourth form,
-##  <Ref Func="FreeMonoid" Label="for infinitely many generators"/>
-##  returns a free monoid on infinitely many generators, where the first
-##  generators are printed by the names in the list <A>init</A>,
-##  and the other generators by <A>name</A> and an appended number.
-##  <P/>
-##  If the extra argument <A>wfilt</A> is given, it must be either
-##  <Ref Filt="IsSyllableWordsFamily"/> or <Ref Filt="IsLetterWordsFamily"/>
-##  or <Ref Filt="IsWLetterWordsFamily"/> or
-##  <Ref Filt="IsBLetterWordsFamily"/>.
-##  This filter then specifies the representation used for the elements of
+##  <C>FreeMonoid</C> returns a free monoid. The number of
+##  generators, and the labels given to the generators, can be specified in
+##  several different ways.
+##  Warning: the labels of generators are only an aid for printing,
+##  and do not necessarily distinguish generators;
+##  see the examples at the end of
+##  <Ref Func="FreeSemigroup" Label="for given rank"/>
+##  for more information.
+##  <List>
+##    <Mark>
+##      1: For a given rank, and an optional generator name prefix
+##    </Mark>
+##    <Item>
+##      Called with a nonnegative integer <A>rank</A>,
+##      <Ref Func="FreeMonoid" Label="for given rank"/> returns
+##      a free monoid on <A>rank</A> generators.
+##      The optional argument <A>name</A> must be a string;
+##      its default value is <C>"m"</C>. <P/>
+##
+##      If <A>name</A> is not given but the <C>generatorNames</C> option is,
+##      then this option is respected as described in
+##      Section&nbsp;<Ref Sect="Generator Names"/>. <P/>
+##
+##      Otherwise, the generators of the returned free monoid are labelled
+##      <A>name</A><C>1</C>, ..., <A>name</A><C>k</C>,
+##      where <C>k</C> is the value of <A>rank</A>. <P/>
+##    </Item>
+##    <Mark>2: For given generator names</Mark>
+##    <Item>
+##      Called with various nonempty strings,
+##      <Ref Func="FreeMonoid" Label="for various names"/> returns
+##      a free monoid on as many generators as arguments, which are labelled
+##      <A>name1</A>, <A>name2</A>, etc.
+##    </Item>
+##    <Mark>3: For a given list of generator names</Mark>
+##    <Item>
+##      Called with a finite list <A>names</A> of
+##      nonempty strings,
+##      <Ref Func="FreeMonoid" Label="for a list of names"/> returns
+##      a free monoid on <C>Length(<A>names</A>)</C> generators, whose
+##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
+##    </Item>
+##    <Mark>
+##      4: For the rank <K>infinity</K>,
+##         an optional default generator name prefix,
+##         and an optional finite list of generator names
+##    </Mark>
+##    <Item>
+##      Called in the fourth form,
+##      <Ref Func="FreeMonoid" Label="for infinitely many generators"/>
+##      returns a free monoid on infinitely many generators.
+##      The optional argument <A>name</A> must be a string; its default value is
+##      <C>"m"</C>,
+##      and the optional argument <A>init</A> must be a finite list of
+##      nonempty strings; its default value is an empty list.
+##      The generators are initially labelled according to the list <A>init</A>,
+##      followed by
+##      <A>name</A><C>i</C> for each <C>i</C> in the range from
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##    </Item>
+##  </List>
+##
+##  If the optional first argument <A>wfilt</A> is given, then it must be either
+##  <C>IsSyllableWordsFamily</C>, <C>IsLetterWordsFamily</C>,
+##  <C>IsWLetterWordsFamily</C>, or <C>IsBLetterWordsFamily</C>.
+##  This filter specifies the representation used for the elements of
 ##  the free monoid
 ##  (see&nbsp;<Ref Sect="Representations for Associative Words"/>).
 ##  If no such filter is given, a letter representation is used.
 ##  <P/>
 ##  For more on associative words see 
 ##  Chapter&nbsp;<Ref Chap="Associative Words"/>.
+##
+##  <Example><![CDATA[
+##  gap> FreeMonoid(5);
+##  <free monoid on the generators [ m1, m2, m3, m4, m5 ]>
+##  gap> FreeMonoid(4, "gen");
+##  <free monoid on the generators [ gen1, gen2, gen3, gen4 ]>
+##  gap> FreeMonoid(3 : generatorNames := "turbo");
+##  <free monoid on the generators [ turbo1, turbo2, turbo3 ]>
+##  gap> FreeMonoid(2 : generatorNames := ["u", "v", "w"]);
+##  <free monoid on the generators [ u, v ]>
+##  gap> FreeMonoid(); FreeMonoid(0); FreeMonoid([]);
+##  <free monoid of rank zero>
+##  <free monoid of rank zero>
+##  <free monoid of rank zero>
+##  gap> FreeMonoid("a", "b", "c");
+##  <free monoid on the generators [ a, b, c ]>
+##  gap> FreeMonoid(["x", "y"]);
+##  <free monoid on the generators [ x, y ]>
+##  gap> FreeMonoid(infinity);
+##  <free monoid with infinity generators>
+##  gap> F := FreeMonoid(infinity, "g", ["a", "b"]);
+##  <free monoid with infinity generators>
+##  gap> GeneratorsOfMonoid(F){[1..4]};
+##  [ a, b, g3, g4 ]
+##  gap> GeneratorsOfMonoid(FreeMonoid(infinity, "gen")){[1..3]};
+##  [ gen1, gen2, gen3 ]
+##  gap> GeneratorsOfMonoid(FreeMonoid(infinity, [ "f", "g" ])){[1..3]};
+##  [ f, g, m3 ]
+##  gap> FreeMonoid(IsSyllableWordsFamily, 50);
+##  <free monoid with 50 generators>
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -279,59 +279,96 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 #############################################################################
 ##
 #F  FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-#F  FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+#F  FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
 #F  FreeSemigroup( [<wfilt>, ]<names> )
-#F  FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+#F  FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 ##
 ##  <#GAPDoc Label="FreeSemigroup">
 ##  <ManSection>
 ##  <Heading>FreeSemigroup</Heading>
 ##  <Func Name="FreeSemigroup" Arg='[wfilt, ]rank[, name]'
 ##   Label="for given rank"/>
-##  <Func Name="FreeSemigroup" Arg='[wfilt, ]name1, name2, ...'
+##  <Func Name="FreeSemigroup" Arg='[wfilt, ]name1[, name2[, ...]]'
 ##   Label="for various names"/>
 ##  <Func Name="FreeSemigroup" Arg='[wfilt, ]names'
 ##   Label="for a list of names"/>
-##  <Func Name="FreeSemigroup" Arg='[wfilt, ]infinity[, name[, init]]'
+##  <Func Name="FreeSemigroup" Arg='[wfilt, ]infinity[, name][, init]'
 ##   Label="for infinitely many generators"/>
 ##
 ##  <Description>
-##  Called with a positive integer <A>rank</A>,
-##  <Ref Func="FreeSemigroup" Label="for given rank"/> returns
-##  a free semigroup on <A>rank</A> generators.
-##  If the optional argument <A>name</A> (a string) is given,
-##  then the generators are
-##  printed as <A>name</A><C>1</C>, <A>name</A><C>2</C> etc.,
-##  that is, each name is the concatenation of the string <A>name</A> and an
-##  integer from <C>1</C> to <A>rank</A>.
-##  The default for <A>name</A> is the string <C>"s"</C>.
-##  <P/>
-##  Called in the second form,
-##  <Ref Func="FreeSemigroup" Label="for various names"/> returns
-##  a free semigroup on as many generators as arguments, printed as
-##  <A>name1</A>, <A>name2</A> etc.
-##  <P/>
-##  Called in the third form,
-##  <Ref Func="FreeSemigroup" Label="for a list of names"/> returns
-##  a free semigroup on as many generators as the length of the list
-##  <A>names</A>, the <M>i</M>-th generator being printed as
-##  <A>names</A><M>[i]</M>.
-##  <P/>
-##  Called in the fourth form,
-##  <Ref Func="FreeSemigroup" Label="for infinitely many generators"/>
-##  returns a free semigroup on infinitely many generators, where the first
-##  generators are printed by the names in the list <A>init</A>,
-##  and the other generators by <A>name</A> and an appended number.
-##  <P/>
-##  If the extra argument <A>wfilt</A> is given, it must be either
-##  <Ref Filt="IsSyllableWordsFamily"/> or <Ref Filt="IsLetterWordsFamily"/>
-##  or <Ref Filt="IsWLetterWordsFamily"/> or
-##  <Ref Filt="IsBLetterWordsFamily"/>.
-##  This filter then specifies the representation used for the elements of
+##  <C>FreeSemigroup</C> returns a free semigroup. The number of
+##  generators, and the labels given to the generators, can be specified in
+##  several different ways.
+##  Warning: the labels of generators are only an aid for printing,
+##  and do not necessarily distinguish generators;
+##  see the examples at the end for more information.
+##  <List>
+##    <Mark>
+##      1: For a given rank, and an optional generator name prefix
+##    </Mark>
+##    <Item>
+##      Called with a positive integer <A>rank</A>,
+##      <Ref Func="FreeSemigroup" Label="for given rank"/> returns
+##      a free semigroup on <A>rank</A> generators.
+##      The optional argument <A>name</A> must be a string;
+##      its default value is <C>"s"</C>. <P/>
+##
+##      If <A>name</A> is not given but the <C>generatorNames</C> option is,
+##      then this option is respected as described in
+##      Section&nbsp;<Ref Sect="Generator Names"/>. <P/>
+##
+##      Otherwise, the generators of the returned free semigroup are labelled
+##      <A>name</A><C>1</C>, ..., <A>name</A><C>k</C>,
+##      where <C>k</C> is the value of <A>rank</A>. <P/>
+##    </Item>
+##    <Mark>2: For given generator names</Mark>
+##    <Item>
+##      Called with various (at least one) nonempty strings,
+##      <Ref Func="FreeSemigroup" Label="for various names"/> returns
+##      a free semigroup on as many generators as arguments, which are labelled
+##      <A>name1</A>, <A>name2</A>, etc.
+##    </Item>
+##    <Mark>3: For a given list of generator names</Mark>
+##    <Item>
+##      Called with a nonempty finite list <A>names</A> of
+##      nonempty strings,
+##      <Ref Func="FreeSemigroup" Label="for a list of names"/> returns
+##      a free semigroup on <C>Length(<A>names</A>)</C> generators, whose
+##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
+##    </Item>
+##    <Mark>
+##      4: For the rank <K>infinity</K>,
+##         an optional default generator name prefix,
+##         and an optional finite list of generator names
+##    </Mark>
+##    <Item>
+##      Called in the fourth form,
+##      <Ref Func="FreeSemigroup" Label="for infinitely many generators"/>
+##      returns a free semigroup on infinitely many generators.
+##      The optional argument <A>name</A> must be a string; its default value is
+##      <C>"s"</C>,
+##      and the optional argument <A>init</A> must be a finite list of
+##      nonempty strings; its default value is an empty list.
+##      The generators are initially labelled according to the list <A>init</A>,
+##      followed by
+##      <A>name</A><C>i</C> for each <C>i</C> in the range from
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>; such a label is not
+##      allowed to appear in <A>init</A>.
+##    </Item>
+##  </List>
+##
+##  If the optional first argument <A>wfilt</A> is given, then it must be either
+##  <C>IsSyllableWordsFamily</C>, <C>IsLetterWordsFamily</C>,
+##  <C>IsWLetterWordsFamily</C>, or <C>IsBLetterWordsFamily</C>.
+##  This filter specifies the representation used for the elements of
 ##  the free semigroup
 ##  (see&nbsp;<Ref Sect="Representations for Associative Words"/>).
 ##  If no such filter is given, a letter representation is used.
 ##  <P/>
+##
+##  For more on associative words see 
+##  Chapter&nbsp;<Ref Chap="Associative Words"/>.  <P/>
+##
 ##  <Example><![CDATA[
 ##  gap> f1 := FreeSemigroup( 3 );
 ##  <free semigroup on the generators [ s1, s2, s3 ]>
@@ -342,20 +379,32 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##  <free semigroup on the generators [ gen1, gen2 ]>
 ##  gap> f4 := FreeSemigroup( ["gen1" , "gen2"] );
 ##  <free semigroup on the generators [ gen1, gen2 ]>
+##  gap> FreeSemigroup( 3 : generatorNames := "boom" );
+##  <free semigroup on the generators [ boom1, boom2, boom3 ]>
+##  gap> FreeSemigroup( 2 : generatorNames := [ "u", "v", "w" ] );
+##  <free semigroup on the generators [ u, v ]>
+##  gap> FreeSemigroup( infinity ) ;
+##  <free semigroup on the generators [ s1, s2, ... ]>
+##  gap> F := FreeSemigroup( infinity, "g", [ "a", "b" ]);
+##  <free semigroup on the generators [ a, b, ... ]>
+##  gap> GeneratorsOfSemigroup( F ){[1..4]};
+##  [ a, b, g3, g4 ]
+##  gap> GeneratorsOfSemigroup( FreeSemigroup( infinity, "gen" ) ){[1..3]};
+##  [ gen1, gen2, gen3 ]
+##  gap> GeneratorsOfSemigroup( FreeSemigroup( infinity, [ "f" ] ) ){[1..3]};
+##  [ f, s2, s3 ]
+##  gap> FreeSemigroup(IsSyllableWordsFamily, 5);
+##  <free semigroup on the generators [ s1, s2, s3, s4, s5 ]>
 ##  ]]></Example>
-##  <P/>
-##  For more on associative words see 
-##  Chapter&nbsp;<Ref Chap="Associative Words"/>.
 ##  <P/>
 ##  Each free object defines a unique alphabet (and a unique family of words).
 ##  Its generators are the letters of this alphabet,
-##  thus words of length one.
-##  <P/>
+##  thus words of length one. <P/>
 ##  <Example><![CDATA[
-##  gap> FreeGroup( 5 );
-##  <free group on the generators [ f1, f2, f3, f4, f5 ]>
-##  gap> FreeGroup( "a", "b" );
-##  <free group on the generators [ a, b ]>
+##  gap> FreeSemigroup( 5 );
+##  <free semigroup on the generators [ s1, s2, s3, s4, s5 ]>
+##  gap> FreeMonoid( "a", "b" );
+##  <free monoid on the generators [ a, b ]>
 ##  gap> FreeGroup( infinity );
 ##  <free group with infinity generators>
 ##  gap> FreeSemigroup( "x", "y" );
@@ -370,18 +419,20 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##  names for the letters.
 ##  <P/>
 ##  <Example><![CDATA[
-##  gap> f:= FreeGroup( "x", "x" );  gens:= GeneratorsOfGroup( f );;
+##  gap> f := FreeGroup( "x", "x" );
 ##  <free group on the generators [ x, x ]>
+##  gap> gens := GeneratorsOfGroup( f );
+##  [ x, x ]
 ##  gap> gens[1] = gens[2];
 ##  false
 ##  gap> f:= FreeGroup( "f1*f2", "f2^-1", "Group( [ f1, f2 ] )" );
 ##  <free group on the generators [ f1*f2, f2^-1, Group( [ f1, f2 ] ) ]>
 ##  gap> gens:= GeneratorsOfGroup( f );;
-##  gap> gens[1]*gens[2];
+##  gap> gens[1] * gens[2];
 ##  f1*f2*f2^-1
-##  gap> gens[1]/gens[3];
+##  gap> gens[1] / gens[3];
 ##  f1*f2*Group( [ f1, f2 ] )^-1
-##  gap> gens[3]/gens[1]/gens[2];
+##  gap> gens[3] / gens[1] / gens[2];
 ##  Group( [ f1, f2 ] )*f1*f2^-1*f2^-1^-1
 ##  ]]></Example>
 ##  </Description>

--- a/lib/smgrpfre.gi
+++ b/lib/smgrpfre.gi
@@ -378,136 +378,30 @@ InstallMethod( GeneratorsSmallest,
 #############################################################################
 ##
 #F  FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-#F  FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+#F  FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
 #F  FreeSemigroup( [<wfilt>, ]<names> )
-#F  FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+#F  FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 ##
 InstallGlobalFunction( FreeSemigroup, function( arg )
-    local names,      # list of generators names
+    local rank,       # number of generators
           F,          # family of free semigroup element objects
-          zarg,
-          lesy,       # filter for letter or syllable words family
           S,          # free semigroup, result
-          err,        # string; helpful error message
-          form,       # string: assumed argument form of call to FreeSemigroup
-          rank,
-          name,
-          init;
+          processed;
 
-  lesy:=IsLetterWordsFamily; # default:
-  if not IsEmpty(arg) and IsFilter(arg[1]) then
-    lesy:=arg[1];
-    zarg:=arg{[2..Length(arg)]};
-  else
-    zarg:=arg;
-  fi;
-
-    # Process and validate the argument list, constructing names if necessary
-    err := "";
-
-    if Length( zarg ) = 0 or zarg[1] = 0
-        or (Length(zarg) = 1 and IsList( zarg[1] ) and IsEmpty( zarg[1] )) then
-      Error("free semigroups of rank zero are not supported");
-
-    # FreeSemigroup( <rank>[, <name> ] )
-    elif IsPosInt( zarg[1] ) and Length( zarg ) <= 2 then
-
-      # Get default and optional arguments
-      rank := zarg[1];
-      if Length( zarg ) = 1 then
-        name := "s";
-      else
-        name := zarg[2];
-      fi;
-
-      # Error checking
-      if not IsString( name ) then
-        form := "<rank>, <name>";
-        err := "<name> must be a string";
-
-      # Construct names
-      else
-        names:= List( [ 1 .. rank ], i -> Concatenation( name, String(i) ) );
-        MakeImmutable( names );
-      fi;
-
-    # FreeSemigroup( <name1>[, <name2>, ...] ), or a list of such arguments
-    elif ForAll( zarg, IsString ) or Length( zarg ) = 1 and IsList( zarg[1] ) then
-      if Length( zarg ) = 1 and not IsString( zarg[1] ) then
-        form := "[ <name1>, <name2>, ... ]";
-        names:= zarg[1];
-      else
-        form := "<name1>, <name2>, ...";
-        names:= zarg;
-      fi;
-      if not ForAll( names, s -> IsString(s) and not IsEmpty(s) ) then
-        err := "the names must be nonempty strings";
-      fi;
-
-    # FreeSemigroup( infinity[, <name>[, <init>]] )
-    elif zarg[1] = infinity and Length( zarg ) <= 3 then
-
-      # Get default and optional arguments
-      name := "s";
-      init := [];
-      if Length( zarg ) = 3 then
-        form := "infinity, <name>, <init>";
-        name := zarg[2];
-        init := zarg[3];
-      elif Length( zarg ) = 2 then
-        form := "infinity, <name>";
-        name := zarg[2];
-      fi;
-
-      # Error checking
-      if not IsString( name ) then
-        err := "<name> must be a string";
-      fi;
-      if not ( IsList( init ) and ForAll( init, s -> IsString(s) and not IsEmpty(s) ) ) then
-        if not IsEmpty(err) then
-          Append(err, " and ");
-        fi;
-        Append(err, "<init> must be a list of nonempty strings");
-      fi;
-
-      # Construct names
-      if IsEmpty(err) then
-        names:= InfiniteListOfNames( name, init );
-      fi;
-
-    else
-      ErrorNoReturn("""usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
-              FreeSemigroup( [<wfilt>, ]<names> )
-              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )""");
-    fi;
-
-    if not IsEmpty(err) then
-      ErrorNoReturn(StringFormatted("FreeSemigroup( {} ): {}", form, err));
-    fi;
-
-    # deal with letter words family types
-    if lesy=IsLetterWordsFamily then
-      if Length(names)>127 then
-	lesy:=IsWLetterWordsFamily;
-      else
-	lesy:=IsBLetterWordsFamily;
-      fi;
-    elif lesy=IsBLetterWordsFamily and Length(names)>127 then
-      lesy:=IsWLetterWordsFamily;
-    fi;
+    processed := FreeXArgumentProcessor( "FreeSemigroup", "s", arg, true, false );
+    rank := Length( processed.names );
 
     # Construct the family of element objects of our semigroup.
-    F:= NewFamily( "FreeSemigroupElementsFamily", IsAssocWord,
-			  CanEasilySortElements, # the free group can.
-			  CanEasilySortElements # the free group can.
-			  and lesy);
+    F := NewFamily( "FreeSemigroupElementsFamily",
+          IsAssocWord,
+          CanEasilySortElements,
+          CanEasilySortElements and processed.lesy );
 
     # Install the data (names, no. of bits available for exponents, types).
-    StoreInfoFreeMagma( F, names, IsAssocWord );
+    StoreInfoFreeMagma( F, processed.names, IsAssocWord );
 
     # Make the semigroup.
-    if IsFinite( names ) then
+    if rank < infinity then
       S:= SemigroupByGenerators( MagmaGeneratorsOfFamily( F ) );
     else
       S:= SemigroupByGenerators( InfiniteListOfGenerators( F ) );
@@ -517,10 +411,14 @@ InstallGlobalFunction( FreeSemigroup, function( arg )
     FamilyObj(S)!.wholeSemigroup:= S;
     F!.freeSemigroup:=S;
 
-    SetIsFreeSemigroup(S,true);
+    SetIsFreeSemigroup( S, true );
     SetIsWholeFamily( S, true );
     SetIsTrivial( S, false );
-    SetIsCommutative( S, Length(names) = 1 );
+    # Following is written defensively in case 0-generator free semigroups ever
+    # become supported in the future.
+    SetIsFinite( S, rank = 0 );
+    SetIsEmpty( S, rank = 0 );
+    SetIsCommutative( S, rank <= 1 );
     return S;
 end );
 

--- a/tst/testbugfix/2021-04-08-empty-FreeSemigroup.tst
+++ b/tst/testbugfix/2021-04-08-empty-FreeSemigroup.tst
@@ -1,11 +1,31 @@
 # See https://github.com/gap-system/gap/issues/1385
 gap> FreeSemigroup();
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup([]);
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup("");
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup(0);
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup(0, "name");
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )

--- a/tst/testinstall/grpfree.tst
+++ b/tst/testinstall/grpfree.tst
@@ -69,5 +69,190 @@ gap> H / rho;
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 2nd choice method found for `FactorSemigroup' on 2 arguments
 
+# FreeGroup
+gap> FreeGroup(fail);
+Error, usage: FreeGroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeGroup( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeGroup( [<wfilt>, ]<names> )
+              FreeGroup( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# FreeGroup: rank 0
+gap> FreeGroup();
+<free group of rank zero>
+gap> FreeGroup([]);
+<free group of rank zero>
+gap> FreeGroup("");
+<free group of rank zero>
+gap> FreeGroup(0);
+<free group of rank zero>
+gap> FreeGroup(0, "name");
+<free group of rank zero>
+
+# FreeGroup(infinity[, name[, init]])
+gap> FreeGroup(infinity);
+<free group with infinity generators>
+gap> FreeGroup(infinity, fail);
+Error, FreeGroup( infinity, <name> ): <name> must be a string
+gap> FreeGroup(infinity, []);
+<free group with infinity generators>
+gap> FreeGroup(infinity, "");
+<free group with infinity generators>
+gap> FreeGroup(infinity, "nicename");
+<free group with infinity generators>
+gap> FreeGroup(infinity, fail, fail);
+Error, FreeGroup( infinity, <name>, <init> ): <name> must be a string
+gap> FreeGroup(infinity, "nicename", fail);
+Error, FreeGroup( infinity, <name>, <init> ): <init> must be a finite list
+gap> FreeGroup(infinity, "gen", []);
+<free group with infinity generators>
+gap> FreeGroup(infinity, "gen", [""]);
+Error, FreeGroup( infinity, <name>, <init> ): <init> must consist of nonempty \
+strings
+gap> FreeGroup(infinity, "gen", ["starter"]);
+<free group with infinity generators>
+gap> FreeGroup(infinity, "gen", ["starter", ""]);
+Error, FreeGroup( infinity, <name>, <init> ): <init> must consist of nonempty \
+strings
+gap> F := FreeGroup(infinity, "gen", ["starter", "second", "third"]);
+<free group with infinity generators>
+gap> GeneratorsOfGroup(F){[1 .. 4]};
+[ starter, second, third, gen4 ]
+gap> FreeGroup(infinity, "gen", ["starter"], fail);
+Error, usage: FreeGroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeGroup( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeGroup( [<wfilt>, ]<names> )
+              FreeGroup( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# FreeGroup(rank[, name])
+gap> F := FreeGroup(1);
+<free group on the generators [ f1 ]>
+gap> HasIsCommutative(F) and IsCommutative(F);
+true
+gap> F := FreeGroup(2);
+<free group on the generators [ f1, f2 ]>
+gap> HasIsCommutative(F) and not IsCommutative(F);
+true
+gap> F := FreeGroup(10);
+<free group on the generators [ f1, f2, f3, f4, f5, f6, f7, f8, f9, f10 ]>
+gap> F := FreeGroup(3, fail);
+Error, FreeGroup( <rank>, <name> ): <name> must be a string
+gap> F := FreeGroup(4, "");
+<free group on the generators [ 1, 2, 3, 4 ]>
+gap> F := FreeGroup(5, []);
+<free group on the generators [ 1, 2, 3, 4, 5 ]>
+gap> F := FreeGroup(4, "cheese");
+<free group on the generators [ cheese1, cheese2, cheese3, cheese4 ]>
+gap> FreeGroup(3, "car", fail);
+Error, usage: FreeGroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeGroup( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeGroup( [<wfilt>, ]<names> )
+              FreeGroup( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# FreeGroup( <name1>, <name2>, ... )
+gap> FreeGroup("", "second");
+Error, FreeGroup( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeGroup("first", "");
+Error, FreeGroup( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeGroup("first", []);
+Error, FreeGroup( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeGroup([], []);
+Error, FreeGroup( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeGroup("bacon", "eggs", "beans");
+<free group on the generators [ bacon, eggs, beans ]>
+gap> FreeGroup("shed");
+<free group on the generators [ shed ]>
+
+# FreeGroup( [ <name1>, <name2>, ... ] )
+gap> FreeGroup(InfiniteListOfNames("a"));
+Error, FreeGroup( [<name1>, <name2>, ...] ): there must be only finitely many \
+names
+gap> FreeGroup(["", "second"]);
+Error, FreeGroup( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeGroup(["first", ""]);
+Error, FreeGroup( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeGroup(["first", []]);
+Error, FreeGroup( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeGroup([[], []]);
+Error, FreeGroup( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeGroup(["bacon", "eggs", "beans"]);
+<free group on the generators [ bacon, eggs, beans ]>
+gap> FreeGroup(["grid"]);
+<free group on the generators [ grid ]>
+gap> FreeGroup(["grid"], fail);
+Error, usage: FreeGroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeGroup( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeGroup( [<wfilt>, ]<names> )
+              FreeGroup( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# wfilt
+gap> F := FreeGroup(4 : FreeGroupFamilyType := "syllable");
+<free group on the generators [ f1, f2, f3, f4 ]>
+gap> "IsSyllableWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> F := FreeGroup(4 : FreeGroupFamilyType := "something else");;
+gap> "IsSyllableWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+gap> F := FreeGroup(IsSyllableWordsFamily, 6);;
+gap> "IsSyllableWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> F := FreeGroup(IsSyllableWordsFamily, 136);;
+gap> "IsSyllableWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> FreeGroup(IsGroup, 3);
+Error, the optional first argument <wfilt> must be one of IsSyllableWordsFamil\
+y, IsLetterWordsFamily, IsWLetterWordsFamily, and IsBLetterWordsFamily
+gap> F := FreeGroup(IsLetterWordsFamily, 200);
+<free group with 200 generators>
+gap> "IsLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsWLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsBLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+gap> F := FreeGroup(IsLetterWordsFamily, 100);
+<free group with 100 generators>
+gap> "IsLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsWLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+gap> "IsBLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> F := FreeGroup(IsBLetterWordsFamily, 200);
+<free group with 200 generators>
+gap> "IsLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsWLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsBLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+gap> F := FreeGroup(IsBLetterWordsFamily, 100);
+<free group with 100 generators>
+gap> "IsLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsWLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+gap> "IsBLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> F := FreeGroup(IsWLetterWordsFamily, 200);
+<free group with 200 generators>
+gap> "IsLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsWLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsBLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+gap> F := FreeGroup(IsWLetterWordsFamily, 100);
+<free group with 100 generators>
+gap> "IsLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsWLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+true
+gap> "IsBLetterWordsFamily" in CategoriesOfObject(FamilyObj(F.1));
+false
+
 #
 gap> STOP_TEST( "grpfree.tst", 1);

--- a/tst/testinstall/mgmfree.tst
+++ b/tst/testinstall/mgmfree.tst
@@ -1,0 +1,275 @@
+#@local M
+gap> START_TEST("mgmfree.tst");
+
+# FreeMagma
+gap> FreeMagma(fail);
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+
+# FreeMagma: rank 0
+gap> FreeMagma();
+#I  FreeMagma cannot make an object with no generators
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+gap> FreeMagma([]);
+#I  FreeMagma cannot make an object with no generators
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+gap> FreeMagma("");
+#I  FreeMagma cannot make an object with no generators
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+gap> FreeMagma(0);
+#I  FreeMagma cannot make an object with no generators
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+gap> FreeMagma(0, "name");
+#I  FreeMagma cannot make an object with no generators
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+
+# FreeMagma(infinity[, name[, init]])
+gap> FreeMagma(infinity);
+<free magma with infinity generators>
+gap> FreeMagma(infinity, fail);
+Error, FreeMagma( infinity, <name> ): <name> must be a string
+gap> FreeMagma(infinity, []);
+<free magma with infinity generators>
+gap> FreeMagma(infinity, "");
+<free magma with infinity generators>
+gap> FreeMagma(infinity, "nicename");
+<free magma with infinity generators>
+gap> FreeMagma(infinity, fail, fail);
+Error, FreeMagma( infinity, <name>, <init> ): <name> must be a string
+gap> FreeMagma(infinity, "nicename", fail);
+Error, FreeMagma( infinity, <name>, <init> ): <init> must be a finite list
+gap> FreeMagma(infinity, "gen", []);
+<free magma with infinity generators>
+gap> FreeMagma(infinity, "gen", [""]);
+Error, FreeMagma( infinity, <name>, <init> ): <init> must consist of nonempty \
+strings
+gap> FreeMagma(infinity, "gen", ["starter"]);
+<free magma with infinity generators>
+gap> FreeMagma(infinity, "gen", ["starter", ""]);
+Error, FreeMagma( infinity, <name>, <init> ): <init> must consist of nonempty \
+strings
+gap> M := FreeMagma(infinity, "gen", ["starter", "second", "third"]);
+<free magma with infinity generators>
+gap> GeneratorsOfMagma(M){[1 .. 4]};
+[ starter, second, third, gen4 ]
+gap> FreeMagma(infinity, "gen", ["starter"], fail);
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+
+# FreeMagma(rank[, name])
+gap> M := FreeMagma(1);
+<free magma on the generators [ x1 ]>
+gap> HasIsTrivial(M) and not IsTrivial(M);
+true
+gap> M := FreeMagma(2);
+<free magma on the generators [ x1, x2 ]>
+gap> HasIsTrivial(M) and not IsTrivial(M);
+true
+gap> M := FreeMagma(10);
+<free magma on the generators [ x1, x2, x3, x4, x5, x6, x7, x8, x9, x10 ]>
+gap> M := FreeMagma(3, fail);
+Error, FreeMagma( <rank>, <name> ): <name> must be a string
+gap> M := FreeMagma(4, "");
+<free magma on the generators [ 1, 2, 3, 4 ]>
+gap> M := FreeMagma(5, []);
+<free magma on the generators [ 1, 2, 3, 4, 5 ]>
+gap> M := FreeMagma(4, "cheese");
+<free magma on the generators [ cheese1, cheese2, cheese3, cheese4 ]>
+gap> FreeMagma(3, "car", fail);
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+
+# FreeMagma( <name1>[, <name2>, ...] )
+gap> FreeMagma("", "second");
+Error, FreeMagma( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMagma("first", "");
+Error, FreeMagma( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMagma("first", []);
+Error, FreeMagma( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMagma([], []);
+Error, FreeMagma( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMagma("bacon", "eggs", "beans");
+<free magma on the generators [ bacon, eggs, beans ]>
+gap> FreeMagma("shed");
+<free magma on the generators [ shed ]>
+
+# FreeMagma( [ <name1>[, <name2>, ...] ] )
+gap> FreeMagma(InfiniteListOfNames("a"));
+Error, FreeMagma( [<name1>, <name2>, ...] ): there must be only finitely many \
+names
+gap> FreeMagma(["", "second"]);
+Error, FreeMagma( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeMagma(["first", ""]);
+Error, FreeMagma( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeMagma(["first", []]);
+Error, FreeMagma( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeMagma([[], []]);
+Error, FreeMagma( [<name1>, <name2>, ...] ): the names must be nonempty string\
+s
+gap> FreeMagma(["bacon", "eggs", "beans"]);
+<free magma on the generators [ bacon, eggs, beans ]>
+gap> FreeMagma(["grid"]);
+<free magma on the generators [ grid ]>
+gap> FreeMagma(["grid"], fail);
+Error, usage: FreeMagma( <rank>[, <name>] )
+              FreeMagma( <name1>[, <name2>[, ...]] )
+              FreeMagma( <names> )
+              FreeMagma( infinity[, <name>][, <init>] )
+
+# FreeMagmaWithOne
+gap> FreeMagmaWithOne(fail);
+Error, usage: FreeMagmaWithOne( <rank>[, <name>] )
+              FreeMagmaWithOne( [<name1>[, <name2>[, ...]]] )
+              FreeMagmaWithOne( <names> )
+              FreeMagmaWithOne( infinity[, <name>][, <init>] )
+
+# FreeMagmaWithOne: rank 0
+gap> FreeMagmaWithOne();
+<free group of rank zero>
+gap> FreeMagmaWithOne([]);
+<free group of rank zero>
+gap> FreeMagmaWithOne("");
+<free group of rank zero>
+gap> FreeMagmaWithOne(0);
+<free group of rank zero>
+gap> FreeMagmaWithOne(0, "name");
+<free group of rank zero>
+
+# FreeMagmaWithOne(infinity[, name[, init]])
+gap> FreeMagmaWithOne(infinity);
+<free magma-with-one with infinity generators>
+gap> FreeMagmaWithOne(infinity, fail);
+Error, FreeMagmaWithOne( infinity, <name> ): <name> must be a string
+gap> FreeMagmaWithOne(infinity, []);
+<free magma-with-one with infinity generators>
+gap> FreeMagmaWithOne(infinity, "");
+<free magma-with-one with infinity generators>
+gap> FreeMagmaWithOne(infinity, "nicename");
+<free magma-with-one with infinity generators>
+gap> FreeMagmaWithOne(infinity, fail, fail);
+Error, FreeMagmaWithOne( infinity, <name>, <init> ): <name> must be a string
+gap> FreeMagmaWithOne(infinity, "nicename", fail);
+Error, FreeMagmaWithOne( infinity, <name>, <init> ): <init> must be a finite l\
+ist
+gap> FreeMagmaWithOne(infinity, "gen", []);
+<free magma-with-one with infinity generators>
+gap> FreeMagmaWithOne(infinity, "gen", [""]);
+Error, FreeMagmaWithOne( infinity, <name>, <init> ): <init> must consist of no\
+nempty strings
+gap> FreeMagmaWithOne(infinity, "gen", ["starter"]);
+<free magma-with-one with infinity generators>
+gap> FreeMagmaWithOne(infinity, "gen", ["starter", ""]);
+Error, FreeMagmaWithOne( infinity, <name>, <init> ): <init> must consist of no\
+nempty strings
+gap> M := FreeMagmaWithOne(infinity, "gen", ["starter", "second", "third"]);
+<free magma-with-one with infinity generators>
+gap> GeneratorsOfMagmaWithOne(M){[1 .. 4]};
+[ starter, second, third, gen4 ]
+gap> FreeMagmaWithOne(infinity, "gen", ["starter"], fail);
+Error, usage: FreeMagmaWithOne( <rank>[, <name>] )
+              FreeMagmaWithOne( [<name1>[, <name2>[, ...]]] )
+              FreeMagmaWithOne( <names> )
+              FreeMagmaWithOne( infinity[, <name>][, <init>] )
+
+# FreeMagmaWithOne(rank[, name])
+gap> M := FreeMagmaWithOne(1);
+<free magma-with-one on the generators [ x1 ]>
+gap> HasIsTrivial(M) and not IsTrivial(M);
+true
+gap> M := FreeMagmaWithOne(2);
+<free magma-with-one on the generators [ x1, x2 ]>
+gap> HasIsTrivial(M) and not IsTrivial(M);
+true
+gap> M := FreeMagmaWithOne(10);
+<free magma-with-one on the generators [ x1, x2, x3, x4, x5, x6, x7, x8, x9, 
+  x10 ]>
+gap> M := FreeMagmaWithOne(3, fail);
+Error, FreeMagmaWithOne( <rank>, <name> ): <name> must be a string
+gap> M := FreeMagmaWithOne(4, "");
+<free magma-with-one on the generators [ 1, 2, 3, 4 ]>
+gap> M := FreeMagmaWithOne(5, []);
+<free magma-with-one on the generators [ 1, 2, 3, 4, 5 ]>
+gap> M := FreeMagmaWithOne(4, "cheese");
+<free magma-with-one on the generators [ cheese1, cheese2, cheese3, cheese4 ]>
+gap> FreeMagmaWithOne(3, "car", fail);
+Error, usage: FreeMagmaWithOne( <rank>[, <name>] )
+              FreeMagmaWithOne( [<name1>[, <name2>[, ...]]] )
+              FreeMagmaWithOne( <names> )
+              FreeMagmaWithOne( infinity[, <name>][, <init>] )
+
+# FreeMagmaWithOne( <name1>[, <name2>, ...] )
+gap> FreeMagmaWithOne("", "second");
+Error, FreeMagmaWithOne( <name1>, <name2>, ... ): the names must be nonempty s\
+trings
+gap> FreeMagmaWithOne("first", "");
+Error, FreeMagmaWithOne( <name1>, <name2>, ... ): the names must be nonempty s\
+trings
+gap> FreeMagmaWithOne("first", []);
+Error, FreeMagmaWithOne( <name1>, <name2>, ... ): the names must be nonempty s\
+trings
+gap> FreeMagmaWithOne([], []);
+Error, FreeMagmaWithOne( <name1>, <name2>, ... ): the names must be nonempty s\
+trings
+gap> FreeMagmaWithOne("bacon", "eggs", "beans");
+<free magma-with-one on the generators [ bacon, eggs, beans ]>
+gap> FreeMagmaWithOne("shed");
+<free magma-with-one on the generators [ shed ]>
+
+# FreeMagmaWithOne( [ <name1>[, <name2>, ...] ] )
+gap> FreeMagmaWithOne(InfiniteListOfNames("a"));
+Error, FreeMagmaWithOne( [<name1>, <name2>, ...] ): there must be only finitel\
+y many names
+gap> FreeMagmaWithOne(["", "second"]);
+Error, FreeMagmaWithOne( [<name1>, <name2>, ...] ): the names must be nonempty\
+ strings
+gap> FreeMagmaWithOne(["first", ""]);
+Error, FreeMagmaWithOne( [<name1>, <name2>, ...] ): the names must be nonempty\
+ strings
+gap> FreeMagmaWithOne(["first", []]);
+Error, FreeMagmaWithOne( [<name1>, <name2>, ...] ): the names must be nonempty\
+ strings
+gap> FreeMagmaWithOne([[], []]);
+Error, FreeMagmaWithOne( [<name1>, <name2>, ...] ): the names must be nonempty\
+ strings
+gap> FreeMagmaWithOne(["bacon", "eggs", "beans"]);
+<free magma-with-one on the generators [ bacon, eggs, beans ]>
+gap> FreeMagmaWithOne(["grid"]);
+<free magma-with-one on the generators [ grid ]>
+gap> FreeMagmaWithOne(["grid"], fail);
+Error, usage: FreeMagmaWithOne( <rank>[, <name>] )
+              FreeMagmaWithOne( [<name1>[, <name2>[, ...]]] )
+              FreeMagmaWithOne( <names> )
+              FreeMagmaWithOne( infinity[, <name>][, <init>] )
+
+# wfilt
+gap> FreeMagma(IsSyllableWordsFamily, 4);
+Error, the first argument must not be a filter
+gap> FreeMagmaWithOne(IsLetterWordsFamily, 3);
+Error, the first argument must not be a filter
+
+#
+gap> STOP_TEST( "mgmfree.tst", 1);

--- a/tst/testinstall/monofree.tst
+++ b/tst/testinstall/monofree.tst
@@ -1,7 +1,7 @@
 #@local F,M,M2,a,b,enum,first50,firstfifty,gens,iter,i
 gap> START_TEST("monofree.tst");
 gap> M := FreeMonoid(0);
-<free monoid on the generators [  ]>
+<free monoid of rank zero>
 gap> IsFreeMonoid(M); IsTrivial(M); IsWholeFamily(M);
 true
 true
@@ -40,6 +40,125 @@ gap> ForAll([0,1,2,3,infinity], n -> (n < infinity) = IsFinitelyGeneratedMonoid(
 true
 gap> ForAll([0,1,2,3,infinity], n -> (n < 2) = IsCommutative(FreeMonoid(n)));
 true
+
+# FreeMonoid
+gap> FreeMonoid(fail);
+Error, usage: FreeMonoid( [<wfilt>, ]<rank>[, <name>] )
+              FreeMonoid( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeMonoid( [<wfilt>, ]<names> )
+              FreeMonoid( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# FreeMonoid: rank 0
+gap> FreeMonoid();
+<free monoid of rank zero>
+gap> FreeMonoid([]);
+<free monoid of rank zero>
+gap> FreeMonoid("");
+<free monoid of rank zero>
+gap> FreeMonoid(0);
+<free monoid of rank zero>
+gap> FreeMonoid(0, "name");
+<free monoid of rank zero>
+
+# FreeMonoid(infinity[, name[, init]])
+gap> FreeMonoid(infinity);
+<free monoid with infinity generators>
+gap> FreeMonoid(infinity, fail);
+Error, FreeMonoid( infinity, <name> ): <name> must be a string
+gap> FreeMonoid(infinity, []);
+<free monoid with infinity generators>
+gap> FreeMonoid(infinity, "");
+<free monoid with infinity generators>
+gap> FreeMonoid(infinity, "nicename");
+<free monoid with infinity generators>
+gap> FreeMonoid(infinity, fail, fail);
+Error, FreeMonoid( infinity, <name>, <init> ): <name> must be a string
+gap> FreeMonoid(infinity, "nicename", fail);
+Error, FreeMonoid( infinity, <name>, <init> ): <init> must be a finite list
+gap> FreeMonoid(infinity, "gen", []);
+<free monoid with infinity generators>
+gap> FreeMonoid(infinity, "gen", [""]);
+Error, FreeMonoid( infinity, <name>, <init> ): <init> must consist of nonempty\
+ strings
+gap> FreeMonoid(infinity, "gen", ["starter"]);
+<free monoid with infinity generators>
+gap> FreeMonoid(infinity, "gen", ["starter", ""]);
+Error, FreeMonoid( infinity, <name>, <init> ): <init> must consist of nonempty\
+ strings
+gap> F := FreeMonoid(infinity, "gen", ["starter", "second", "third"]);
+<free monoid with infinity generators>
+gap> GeneratorsOfMonoid(F){[1 .. 4]};
+[ starter, second, third, gen4 ]
+gap> FreeMonoid(infinity, "gen", ["starter"], fail);
+Error, usage: FreeMonoid( [<wfilt>, ]<rank>[, <name>] )
+              FreeMonoid( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeMonoid( [<wfilt>, ]<names> )
+              FreeMonoid( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# FreeMonoid(rank[, name])
+gap> F := FreeMonoid(1);
+<free monoid on the generators [ m1 ]>
+gap> HasIsCommutative(F) and IsCommutative(F);
+true
+gap> F := FreeMonoid(2);
+<free monoid on the generators [ m1, m2 ]>
+gap> HasIsCommutative(F) and not IsCommutative(F);
+true
+gap> F := FreeMonoid(10);
+<free monoid on the generators [ m1, m2, m3, m4, m5, m6, m7, m8, m9, m10 ]>
+gap> F := FreeMonoid(3, fail);
+Error, FreeMonoid( <rank>, <name> ): <name> must be a string
+gap> F := FreeMonoid(4, "");
+<free monoid on the generators [ 1, 2, 3, 4 ]>
+gap> F := FreeMonoid(5, []);
+<free monoid on the generators [ 1, 2, 3, 4, 5 ]>
+gap> F := FreeMonoid(4, "cheese");
+<free monoid on the generators [ cheese1, cheese2, cheese3, cheese4 ]>
+gap> FreeMonoid(3, "car", fail);
+Error, usage: FreeMonoid( [<wfilt>, ]<rank>[, <name>] )
+              FreeMonoid( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeMonoid( [<wfilt>, ]<names> )
+              FreeMonoid( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# FreeMonoid( <name1>, <name2>, ... )
+gap> FreeMonoid("", "second");
+Error, FreeMonoid( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMonoid("first", "");
+Error, FreeMonoid( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMonoid("first", []);
+Error, FreeMonoid( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMonoid([], []);
+Error, FreeMonoid( <name1>, <name2>, ... ): the names must be nonempty strings
+gap> FreeMonoid("bacon", "eggs", "beans");
+<free monoid on the generators [ bacon, eggs, beans ]>
+gap> FreeMonoid("shed");
+<free monoid on the generators [ shed ]>
+
+# FreeMonoid( [ <name1>, <name2>, ... ] )
+gap> FreeMonoid(InfiniteListOfNames("a"));
+Error, FreeMonoid( [<name1>, <name2>, ...] ): there must be only finitely many\
+ names
+gap> FreeMonoid(["", "second"]);
+Error, FreeMonoid( [<name1>, <name2>, ...] ): the names must be nonempty strin\
+gs
+gap> FreeMonoid(["first", ""]);
+Error, FreeMonoid( [<name1>, <name2>, ...] ): the names must be nonempty strin\
+gs
+gap> FreeMonoid(["first", []]);
+Error, FreeMonoid( [<name1>, <name2>, ...] ): the names must be nonempty strin\
+gs
+gap> FreeMonoid([[], []]);
+Error, FreeMonoid( [<name1>, <name2>, ...] ): the names must be nonempty strin\
+gs
+gap> FreeMonoid(["bacon", "eggs", "beans"]);
+<free monoid on the generators [ bacon, eggs, beans ]>
+gap> FreeMonoid(["grid"]);
+<free monoid on the generators [ grid ]>
+gap> FreeMonoid(["grid"], fail);
+Error, usage: FreeMonoid( [<wfilt>, ]<rank>[, <name>] )
+              FreeMonoid( [<wfilt>, ][<name1>[, <name2>[, ...]]] )
+              FreeMonoid( [<wfilt>, ]<names> )
+              FreeMonoid( [<wfilt>, ]infinity[, <name>][, <init>] )
 
 #
 gap> STOP_TEST( "grpfree.tst", 1);

--- a/tst/testinstall/smgrpfre.tst
+++ b/tst/testinstall/smgrpfre.tst
@@ -4,21 +4,41 @@ gap> START_TEST("smgrpfre.tst");
 # FreeSemigroup
 gap> FreeSemigroup(fail);
 Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
               FreeSemigroup( [<wfilt>, ]<names> )
-              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 
 # FreeSemigroup: rank 0
 gap> FreeSemigroup();
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup([]);
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup("");
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup(0);
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 gap> FreeSemigroup(0, "name");
-Error, free semigroups of rank zero are not supported
+#I  FreeSemigroup cannot make an object with no generators
+Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
+              FreeSemigroup( [<wfilt>, ]<names> )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 
 # FreeSemigroup(infinity[, name[, init]])
 gap> FreeSemigroup(infinity);
@@ -32,30 +52,28 @@ gap> FreeSemigroup(infinity, "");
 gap> FreeSemigroup(infinity, "nicename");
 <free semigroup on the generators [ nicename1, nicename2, ... ]>
 gap> FreeSemigroup(infinity, fail, fail);
-Error, FreeSemigroup( infinity, <name>, <init> ): <name> must be a string and \
-<init> must be a list of nonempty strings
+Error, FreeSemigroup( infinity, <name>, <init> ): <name> must be a string
 gap> FreeSemigroup(infinity, "nicename", fail);
-Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a list of non\
-empty strings
+Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a finite list
 gap> FreeSemigroup(infinity, "gen", []);
 <free semigroup on the generators [ gen1, gen2, ... ]>
 gap> FreeSemigroup(infinity, "gen", [""]);
-Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a list of non\
-empty strings
+Error, FreeSemigroup( infinity, <name>, <init> ): <init> must consist of nonem\
+pty strings
 gap> FreeSemigroup(infinity, "gen", ["starter"]);
 <free semigroup on the generators [ starter, gen2, ... ]>
 gap> FreeSemigroup(infinity, "gen", ["starter", ""]);
-Error, FreeSemigroup( infinity, <name>, <init> ): <init> must be a list of non\
-empty strings
+Error, FreeSemigroup( infinity, <name>, <init> ): <init> must consist of nonem\
+pty strings
 gap> F := FreeSemigroup(infinity, "gen", ["starter", "second", "third"]);
 <free semigroup on the generators [ starter, second, ... ]>
 gap> GeneratorsOfSemigroup(F){[1 .. 4]};
 [ starter, second, third, gen4 ]
 gap> FreeSemigroup(infinity, "gen", ["starter"], fail);
 Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
               FreeSemigroup( [<wfilt>, ]<names> )
-              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 
 # FreeSemigroup(rank[, name])
 gap> F := FreeSemigroup(1);
@@ -78,11 +96,11 @@ gap> F := FreeSemigroup(4, "cheese");
 <free semigroup on the generators [ cheese1, cheese2, cheese3, cheese4 ]>
 gap> FreeSemigroup(3, "car", fail);
 Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
               FreeSemigroup( [<wfilt>, ]<names> )
-              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
 
-# FreeSemigroup( <name1>[, <name2>, ...] )
+# FreeSemigroup( <name1>, <name2>, ... )
 gap> FreeSemigroup("", "second");
 Error, FreeSemigroup( <name1>, <name2>, ... ): the names must be nonempty stri\
 ngs
@@ -100,28 +118,57 @@ gap> FreeSemigroup("bacon", "eggs", "beans");
 gap> FreeSemigroup("shed");
 <free semigroup on the generators [ shed ]>
 
-# FreeSemigroup( [ <name1>[, <name2>, ...] ] )
+# FreeSemigroup( [ <name1>, <name2>, ... ] )
+gap> FreeSemigroup(InfiniteListOfNames("a"));
+Error, FreeSemigroup( [<name1>, <name2>, ...] ): there must be only finitely m\
+any names
 gap> FreeSemigroup(["", "second"]);
-Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
-strings
+Error, FreeSemigroup( [<name1>, <name2>, ...] ): the names must be nonempty st\
+rings
 gap> FreeSemigroup(["first", ""]);
-Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
-strings
+Error, FreeSemigroup( [<name1>, <name2>, ...] ): the names must be nonempty st\
+rings
 gap> FreeSemigroup(["first", []]);
-Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
-strings
+Error, FreeSemigroup( [<name1>, <name2>, ...] ): the names must be nonempty st\
+rings
 gap> FreeSemigroup([[], []]);
-Error, FreeSemigroup( [ <name1>, <name2>, ... ] ): the names must be nonempty \
-strings
+Error, FreeSemigroup( [<name1>, <name2>, ...] ): the names must be nonempty st\
+rings
 gap> FreeSemigroup(["bacon", "eggs", "beans"]);
 <free semigroup on the generators [ bacon, eggs, beans ]>
 gap> FreeSemigroup(["grid"]);
 <free semigroup on the generators [ grid ]>
 gap> FreeSemigroup(["grid"], fail);
 Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
-              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>, ...] )
+              FreeSemigroup( [<wfilt>, ]<name1>[, <name2>[, ...]] )
               FreeSemigroup( [<wfilt>, ]<names> )
-              FreeSemigroup( [<wfilt>, ]infinity[, <name>[, <init>]] )
+              FreeSemigroup( [<wfilt>, ]infinity[, <name>][, <init>] )
+
+# generatorNames
+gap> FreeSemigroup(5 : generatorNames := false);
+Error, Cannot process the `generatorNames` option: the value must be either a \
+single string, or a list of sufficiently many nonempty strings (at least 5, in\
+ this case)
+gap> PushOptions( rec( generatorNames := fail ) );
+gap> FreeSemigroup(3 : generatorNames := "");
+<free semigroup on the generators [ 1, 2, 3 ]>
+gap> FreeSemigroup(2 : generatorNames := "cool");
+<free semigroup on the generators [ cool1, cool2 ]>
+gap> FreeSemigroup(2 : generatorNames := ["red"]);
+Error, Cannot process the `generatorNames` option: the value must be either a \
+single string, or a list of sufficiently many nonempty strings (at least 2, in\
+ this case)
+gap> PushOptions( rec( generatorNames := fail ) );
+gap> FreeSemigroup(2 : generatorNames := ["red", "yellow"]);
+<free semigroup on the generators [ red, yellow ]>
+gap> FreeSemigroup(2 : generatorNames := ["red", "yellow", "green"]);
+<free semigroup on the generators [ red, yellow ]>
+gap> FreeSemigroup(2 : generatorNames := ["red", "yellow", "green", fail]);
+<free semigroup on the generators [ red, yellow ]>
+gap> FreeSemigroup("gen" : generatorNames := false);
+<free semigroup on the generators [ gen ]>
+gap> FreeSemigroup("gen" : generatorNames := "string");
+<free semigroup on the generators [ gen ]>
 
 #
 gap> STOP_TEST( "smgrpfre.tst", 1);


### PR DESCRIPTION
This PR introduces a function `FreeXArgumentProcessor` to unify the argument processing for the following functions:
* `FreeSemigroup`
* `FreeMonoid`
* `FreeMagma`
* `FreeMagmaWithOne`
* `FreeGroup`

This resolves the remaining problems raised in #1385. This also builds on #4111.