### PR TITLE
`?Group` shows first info about the library function

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -3686,6 +3686,7 @@ DeclareGlobalFunction("MakeGroupyType");
 ##
 ##  <#GAPDoc Label="Group">
 ##  <ManSection>
+##  <Heading>Group</Heading>
 ##  <Func Name="Group" Arg='gen, ...' Label="for several generators"/>
 ##  <Func Name="Group" Arg='gens[, id]'
 ##   Label="for a list of generators (and an identity element)"/>


### PR DESCRIPTION
Adding an explicit `Heading` to the manual section for `Group` has the effect that `?Group` lists this section more prominently.
Note that the sections for `Monoid` and `Semigroup` had already an explicit `Heading`, and the three functions should behave similarly, see issue #4480.