### PR TITLE
changed an `IsGeneratorsOfMagmaWithInverses` method ...

### DIFF
--- a/lib/grptbl.gi
+++ b/lib/grptbl.gi
@@ -99,16 +99,18 @@ end );
 
 #############################################################################
 ##
-#M  IsGeneratorsOfMagmaWithInverses( <elms> ) a collection of magma by 
-##   multiplication table elements will always be acceptable
-##   as generators, provided each one individually has an inverse.    
+#M  IsGeneratorsOfMagmaWithInverses( <elms> )
+##
+##  Under the assumption that the multiplication for <elms> is associative
+##  (cf. the discussion for issue 4480),
+##  a collection of magma by multiplication table elements will always be
+##  acceptable as generators, provided each one individually has an inverse.
 ##    
-
 InstallMethod( IsGeneratorsOfMagmaWithInverses, 
         "for a collection of magma by mult table elements",
         [IsCollection],
         function(c)
-    if ForAll(c, x-> IsMagmaByMultiplicationTableObj(x) and IsMultiplicativeElementWithInverse(x)) then
+    if ForAll(c, x-> IsMagmaByMultiplicationTableObj(x) and Inverse(x) <> fail) then
         return true;
     fi;
     TryNextMethod();

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -459,6 +459,8 @@ DeclareAttribute( "GeneratorsOfMagmaWithInverses", IsMagmaWithInverses );
 ##  inverses, and <K>false</K> otherwise.
 ##  </Description>
 ##  </ManSection>
+#TODO: Decide: Is this property meaningful in nonassociative situations?
+##     (cf. the discussion for issue 4480)
 ##
 DeclareProperty( "IsGeneratorsOfMagmaWithInverses", IsListOrCollection );
 

--- a/tst/testinstall/magma.tst
+++ b/tst/testinstall/magma.tst
@@ -1,0 +1,9 @@
+gap> START_TEST( "magma.tst" );
+
+#
+gap> M:= MagmaByMultiplicationTable( [ [ 1, 1 ], [ 1, 1 ] ] );;
+gap> IsGeneratorsOfMagmaWithInverses( Elements( M ) );
+false
+
+#
+gap> STOP_TEST( "magma.tst" );


### PR DESCRIPTION
... that deals with collections of `IsMagmaByMultiplicationTableObj`:
Really check that the given elements are invertible. Up to now, the method was wrong.

I stumbled over the problem in the context of pull request #4373 and issue #4480.
Here is an example.
```
gap> M:= MagmaByMultiplicationTable( [[1,1],[1,1]] );
<magma with 2 generators>
gap> elms:= Elements( M );;
gap> IsGeneratorsOfMagmaWithInverses( elms );
true
gap> List( elms, IsMultiplicativeElementWithInverse );
[ true, true ]
gap> List( elms, Inverse );
[ fail, fail ]
```
Note that the filter `IsMultiplicativeElementWithInverse` does not mean that the element in question necessarily has an inverse, see the documentation.

After the change, the method can still give a wrong answer if it is called in the case of nonassociative multiplication. Currently (see issue #4480) there is a discussion how to deal with this situation.

(We have quite a few correct methods for `IsGeneratorsOfMagmaWithInverses`; the default method prints a warning if it cannot return `false`. The interpretation is that one should provide a meaningful method for the concrete situation if one sees this warning. The method which is now to be changed serves the purpose to avoid the warning. Eventually it would be good to turn it into a safe method.)