### PR TITLE
admit specifying a form for classical groups

### DIFF
--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -224,6 +224,13 @@ DeclareConstructor( "GeneralOrthogonalGroupCons",
 ##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
 ##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines <A>e</A> and <A>d</A>, and also <A>q</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
 ##  If <A>form</A> is not given then a default is chosen as described in the
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
@@ -334,6 +341,13 @@ DeclareConstructor( "GeneralUnitaryGroupCons",
 ##  or a form object in <Ref Filt="IsHermitianForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantSesquilinearForm"/> value
 ##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines <A>d</A>, and also <A>q</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
 ##  If <A>form</A> is not given then a default is chosen as described in the
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
@@ -521,6 +535,13 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 ##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
 ##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines <A>e</A> and <A>d</A>, and also <A>q</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
 ##  If <A>form</A> is not given then a default is chosen as described in the
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
@@ -620,6 +641,13 @@ DeclareConstructor( "SpecialUnitaryGroupCons",
 ##  or a form object in <Ref Filt="IsHermitianForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantSesquilinearForm"/> value
 ##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines <A>d</A>, and also <A>q</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
 ##  If <A>form</A> is not given then a default is chosen as described in the
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
@@ -730,6 +758,13 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  or a form object in <Ref Filt="IsBilinearForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantBilinearForm"/> value
 ##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines and <A>d</A>, and also <A>q</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
 ##  If <A>form</A> is not given then a default is chosen as described in the
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
@@ -841,6 +876,13 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
 ##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines <A>e</A> and <A>d</A>, and also <A>q</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
 ##  If <A>form</A> is not given then a default is chosen as described in the
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
@@ -857,6 +899,8 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  gap> g:= Omega( IsPermGroup, 1, 6, 2 );  StructureDescription( g );
 ##  Perm_Omega(+1,6,2)
 ##  "A8"
+##  gap> IsSubset( GO( 3, 5 ), Omega( 3, 5 ) );  # different forms!
+##  false
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -66,9 +66,9 @@
 ##  Note that due to the different sources for the generators,
 ##  the invariant forms for the groups <M>\Omega(e,d,q)</M> are in general
 ##  different from the forms for SO<M>(e,d,q)</M> and GO<M>(e,d,q)</M>.
-##  If the <Package>Forms</Package> package is loaded then compatible groups
-##  can be created by specifying the desired form,
-##  see the sections below.
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded then compatible groups can be created by specifying the desired
+##  form, see the sections below.
 ##  <#/GAPDoc>
 ##
 
@@ -218,8 +218,8 @@ DeclareConstructor( "GeneralOrthogonalGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the general orthogonal group itself.
 ##  <P/>
-##  If the <Package>Forms</Package> package is loaded then
-##  the desired quadratic form can be specified via <A>form</A>,
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded then the desired quadratic form can be specified via <A>form</A>,
 ##  which can be either a matrix
 ##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
@@ -335,9 +335,9 @@ DeclareConstructor( "GeneralUnitaryGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the general unitary group itself.
 ##  <P/>
-##  If the <Package>Forms</Package> package is loaded then
-##  the desired sesquilinear form can be specified via <A>form</A>,
-##  which can be either a matrix
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded then the desired sesquilinear form can be specified via
+##  <A>form</A>, which can be either a matrix
 ##  or a form object in <Ref Filt="IsHermitianForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantSesquilinearForm"/> value
 ##  (and then this form is taken).
@@ -529,8 +529,8 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the special orthogonal group itself.
 ##  <P/>
-##  If the <Package>Forms</Package> package is loaded then
-##  the desired quadratic form can be specified via <A>form</A>,
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded then the desired quadratic form can be specified via <A>form</A>,
 ##  which can be either a matrix
 ##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
@@ -635,9 +635,9 @@ DeclareConstructor( "SpecialUnitaryGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the special unitary group itself.
 ##  <P/>
-##  If the <Package>Forms</Package> package is loaded then
-##  the desired sesquilinear form can be specified via <A>form</A>,
-##  which can be either a matrix
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded then the desired sesquilinear form can be specified via
+##  <A>form</A>, which can be either a matrix
 ##  or a form object in <Ref Filt="IsHermitianForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantSesquilinearForm"/> value
 ##  (and then this form is taken).
@@ -751,8 +751,8 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  <C>Integers mod <A>q</A></C>, with <A>q</A> an odd prime power, are
 ##  supported.
 ##  <P/>
-##  If the <Package>Forms</Package> package is loaded and the arguments
-##  describe a matrix group over a finite field then
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded and the arguments describe a matrix group over a finite field then
 ##  the desired bilinear form can be specified via <A>form</A>,
 ##  which can be either a matrix
 ##  or a form object in <Ref Filt="IsBilinearForm" BookName="Forms"/>
@@ -870,8 +870,8 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  and the returned group is the group
 ##  <M>\Omega</M>( <A>e</A>, <A>d</A>, <A>q</A> ) itself.
 ##  <P/>
-##  If the <Package>Forms</Package> package is loaded then
-##  the desired quadratic form can be specified via <A>form</A>,
+##  If version at least 1.2.6 of the <Package>Forms</Package> package is
+##  loaded then the desired quadratic form can be specified via <A>form</A>,
 ##  which can be either a matrix
 ##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
 ##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value

--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -231,64 +231,59 @@ DeclareConstructor( "GeneralOrthogonalGroupCons",
 ##  GO is defined as the stabilizer
 ##  <M>\Delta(V, F, \kappa)</M> of the quadratic form, up to scalars,
 ##  whereas our GO is called <M>I(V, F, \kappa)</M> there.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> GeneralOrthogonalGroup( 5, 3 );
+##  GO(0,5,3)
+##  gap> GeneralOrthogonalGroup( -1, 8, 2 );
+##  GO(-1,8,2)
+##  gap> GeneralOrthogonalGroup( IsPermGroup, -1, 8, 2 );
+##  Perm_GO(-1,8,2)
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+BindGlobal( "DescribesInvariantQuadraticForm",
+    obj -> IsMatrixObj( obj ) or
+           ( IsBoundGlobal( "IsQuadraticForm" ) and
+             ValueGlobal( "IsQuadraticForm" )( obj ) ) or
+           ( IsGroup( obj ) and HasInvariantQuadraticForm( obj ) ) );
+
 BindGlobal( "GeneralOrthogonalGroup", function ( arg )
-  if   Length( arg ) = 1 then
-    # form (matrix, form object, or group with stored form)
-    return GeneralOrthogonalGroupCons( IsMatrixGroup, arg[1] );
-  elif Length( arg ) = 2 and IsInt( arg[1] ) then
-    # (d, q) or (d, R)
-    return GeneralOrthogonalGroupCons( IsMatrixGroup, 0, arg[1], arg[2] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
-    (IsInt(arg[3]) or IsRing(arg[3])) then
-    # (e, d, q) or (e, d, R)
-    return GeneralOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and
-    (IsInt(arg[2]) or IsRing(arg[2])) and
-    (IsMatrixObj(arg[3]) or
-     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[3])) or
-     HasInvariantQuadraticForm(arg[3])) then
-    # (d, q, form) or (d, R, form)
-    return GeneralOrthogonalGroupCons( IsMatrixGroup,0,arg[1],arg[2],arg[3] );
-  elif Length( arg ) = 4 and IsInt(arg[1]) and IsInt(arg[2]) and
-    (IsInt(arg[3]) or IsRing(arg[3])) and
-    (IsMatrixObj(arg[4]) or
-     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
-     HasInvariantQuadraticForm(arg[4])) then
-    # (e, d, q, form) or (e, d, R, form)
-    return GeneralOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3],arg[4] );
-  elif IsOperation( arg[1] ) then
-    if   Length( arg ) = 2 then
-      # (filter, form)
-      return GeneralOrthogonalGroupCons( arg[1], arg[2] );
-    elif Length( arg ) = 3 then
-      # (filter, d, q) or (filter, d, R)
-      return GeneralOrthogonalGroupCons( arg[1], 0, arg[2], arg[3] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsInt(arg[4]) or IsRing(arg[4])) then
-      # (filter, e, d, q) or (filter, e, d, R)
-      return GeneralOrthogonalGroupCons( arg[1], arg[2], arg[3], arg[4] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and
-      (IsInt(arg[3]) or IsRing(arg[3])) and
-      (IsMatrixObj(arg[4]) or
-       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
-       HasInvariantQuadraticForm(arg[4])) then
-      # (filter, d, q, form) or (filter, d, R, form)
-      return GeneralOrthogonalGroupCons( arg[1], 0, arg[2], arg[3], arg[4] );
-    elif Length( arg ) = 5 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsInt(arg[4]) or IsRing(arg[4])) and
-      (IsMatrixObj(arg[5]) or
-       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[5])) or
-       HasInvariantQuadraticForm(arg[5])) then
-      # (filter, e, d, q, form) or (filter, e, d, GF(q), form)
-      return GeneralOrthogonalGroupCons( arg[1],arg[2],arg[3],arg[4],arg[5] );
-    fi;
+  local filt, form;
+
+  if IsFilter( First( arg ) ) then
+    filt:= Remove( arg, 1 );
+  else
+    filt:= IsMatrixGroup;
   fi;
-  Error( "usage: GeneralOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q>[, <form>] )\n",
-         "or GeneralOrthogonalGroup( [<filter>, ]<form> )" );
+  if DescribesInvariantQuadraticForm( Last( arg ) ) then
+    form:= Remove( arg );
+    if Length( arg ) = 0 then
+      # ( [<filt>, ]<form> )
+      return GeneralOrthogonalGroupCons( filt, form );
+    elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                           and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
+      # ( [<filt>, ]<d>, <q>, form ) or ( [<filt>, ]<d>, <R>, form )
+      return GeneralOrthogonalGroupCons( filt, 0, arg[1], arg[2], form );
+    elif Length( arg ) = 3 and IsInt( arg[1] ) and IsPosInt( arg[2] )
+                           and ( IsPosInt( arg[3] ) or IsRing( arg[3] ) ) then
+      # ( [<filt>, ]<e>, <d>, <q>, form ) or ( [<filt>, ]<e>, <d>, <R>, form )
+      return GeneralOrthogonalGroupCons( filt, arg[1], arg[2], arg[3], form );
+    fi;
+  elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                         and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
+    # ( [<filt>, ]<d>, <q> ) or ( [<filt>, ]<d>, <R> )
+    return GeneralOrthogonalGroupCons( filt, 0, arg[1], arg[2] );
+  elif Length( arg ) = 3 and IsInt( arg[1] ) and IsPosInt( arg[2] )
+                         and ( IsPosInt( arg[3] ) or IsRing( arg[3] ) ) then
+    # ( [<filt>, ]<e>, <d>, <q> ) or ( [<filt>, ]<e>, <d>, <R> )
+    return GeneralOrthogonalGroupCons( filt, arg[1], arg[2], arg[3] );
+  fi;
+  Error( "usage: GeneralOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )\n",
+         "or GeneralOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )\n",
+         "or GeneralOrthogonalGroup( [<filt>, ]<form> )" );
 end );
 
 DeclareSynonym( "GO", GeneralOrthogonalGroup );
@@ -345,41 +340,42 @@ DeclareConstructor( "GeneralUnitaryGroupCons",
 ##  <Example><![CDATA[
 ##  gap> GeneralUnitaryGroup( 3, 5 );
 ##  GU(3,5)
+##  gap> GeneralUnitaryGroup( IsPermGroup, 3, 5 );
+##  Perm_GU(3,5)
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+BindGlobal( "DescribesInvariantHermitianForm",
+    obj -> IsMatrixObj( obj ) or
+           ( IsBoundGlobal( "IsHermitianForm" ) and
+             ValueGlobal( "IsHermitianForm" )( obj ) ) or
+           ( IsGroup( obj ) and HasInvariantSesquilinearForm( obj ) ) );
+
 BindGlobal( "GeneralUnitaryGroup", function ( arg )
-  if Length( arg ) = 1 then
-    # form (matrix, form object, or group with stored form)
-    return GeneralUnitaryGroupCons( IsMatrixGroup, arg[1] );
-  elif Length( arg ) = 2 and IsInt( arg[1] ) then
-    # (d, q)
-    return GeneralUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
-    (IsMatrixObj(arg[3]) or
-     (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[3])) or
-     HasInvariantSesquilinearForm(arg[3])) then
-    # (d, q, form)
-    return GeneralUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2], arg[3] );
-  elif IsOperation( arg[1] ) then
-    if Length( arg ) = 2 then
-      # filter, form
-      return GeneralUnitaryGroupCons( arg[1], arg[2] );
-    elif Length( arg ) = 3 then
-      # filter, d, q
-      return GeneralUnitaryGroupCons( arg[1], arg[2], arg[3] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsMatrixObj(arg[4]) or
-       (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[4])) or
-       HasInvariantSesquilinearForm(arg[4])) then
-      # (filter, d, q, form)
-      return GeneralUnitaryGroupCons( arg[1], arg[2], arg[3], arg[4] );
-    fi;
+  local filt, form;
+
+  if IsFilter( First( arg ) ) then
+    filt:= Remove( arg, 1 );
+  else
+    filt:= IsMatrixGroup;
   fi;
-  Error( "usage: GeneralUnitaryGroup( [<filter>, ]<d>, <q>[, <form>] )\n",
-         "or GeneralUnitaryGroup( [<filter>, ]<form> )" );
+  if DescribesInvariantHermitianForm( Last( arg ) ) then
+    form:= Remove( arg );
+    if Length( arg ) = 0 then
+      # ( [<filt>, ]<form> )
+      return GeneralUnitaryGroupCons( filt, form );
+    elif Length( arg ) = 2 and IsPosInt( arg[1] ) and IsPosInt( arg[2] ) then
+      # ( [<filt>, ]<d>, <q>, <form> )
+      return GeneralUnitaryGroupCons( filt, arg[1], arg[2], form );
+    fi;
+  elif Length( arg ) = 2 and IsPosInt( arg[1] ) and IsPosInt( arg[2] ) then
+    # ( [<filt>, ]<d>, <q> )
+    return GeneralUnitaryGroupCons( filt, arg[1], arg[2] );
+  fi;
+  Error( "usage: GeneralUnitaryGroup( [<filt>, ]<d>, <q>[, <form>] )\n",
+         "or GeneralUnitaryGroup( [<filt>, ]<form> )" );
 end );
 
 DeclareSynonym( "GU", GeneralUnitaryGroup );
@@ -529,71 +525,50 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 ##  introduction to Section <Ref Sect="Classical Groups"/>.
 ##  <P/>
 ##  <Example><![CDATA[
-##  gap> GeneralOrthogonalGroup( 3, 7 );
-##  GO(0,3,7)
-##  gap> GeneralOrthogonalGroup( -1, 4, 3 );
-##  GO(-1,4,3)
-##  gap> SpecialOrthogonalGroup( 1, 4, 4 );
-##  GO(+1,4,4)
+##  gap> SpecialOrthogonalGroup( 5, 3 );
+##  SO(0,5,3)
+##  gap> SpecialOrthogonalGroup( -1, 8, 2 );  # here SO and GO coincide
+##  GO(-1,8,2)
+##  gap> SpecialOrthogonalGroup( IsPermGroup, 5, 3 );
+##  Perm_SO(0,5,3)
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BindGlobal( "SpecialOrthogonalGroup", function ( arg )
-  if   Length( arg ) = 1 then
-    # form (matrix, form object, or group with stored form)
-    return SpecialOrthogonalGroupCons( IsMatrixGroup, arg[1] );
-  elif Length( arg ) = 2 and IsInt( arg[1] ) then
-    # (d, q) or (d, R)
-    return SpecialOrthogonalGroupCons( IsMatrixGroup, 0, arg[1], arg[2] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
-    (IsInt(arg[3]) or IsRing(arg[3])) then
-    # (e, d, q) or (e, d, GF(q))
-    return SpecialOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and
-    (IsInt(arg[2]) or IsRing(arg[2])) and
-    (IsMatrixObj(arg[3]) or
-     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[3])) or
-     HasInvariantQuadraticForm(arg[3])) then
-    # (d, q, form) or (d, GF(q), form)
-    return SpecialOrthogonalGroupCons( IsMatrixGroup,0,arg[1],arg[2],arg[3] );
-  elif Length( arg ) = 4 and IsInt(arg[1]) and IsInt(arg[2]) and
-    (IsInt(arg[3]) or IsRing(arg[3])) and
-    (IsMatrixObj(arg[4]) or
-     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
-     HasInvariantQuadraticForm(arg[4])) then
-    # (e, d, q, form) or (e, d, GF(q), form)
-    return SpecialOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3],arg[4] );
-  elif IsOperation( arg[1] ) then
-    if   Length( arg ) = 2 then
-      # filter, form
-      return SpecialOrthogonalGroupCons( arg[1], arg[2] );
-    elif Length( arg ) = 3 then
-      # filter, d, q
-      return SpecialOrthogonalGroupCons( arg[1], 0, arg[2], arg[3] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsInt(arg[4]) or IsRing(arg[4])) then
-      # (filter, e, d, q) or (filter, e, d, R)
-      return SpecialOrthogonalGroupCons( arg[1], arg[2], arg[3], arg[4] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and
-      (IsInt(arg[3]) or IsRing(arg[3])) and
-      (IsMatrixObj(arg[4]) or
-       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
-      HasInvariantQuadraticForm(arg[4])) then
-      # (filter, d, q, form) or (filter, d, R, form)
-      return SpecialOrthogonalGroupCons( arg[1], 0, arg[2], arg[3], arg[4] );
-    elif Length( arg ) = 5 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsInt(arg[4]) or IsRing(arg[4])) and
-      (IsMatrixObj(arg[5]) or
-       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[5])) or
-       HasInvariantQuadraticForm(arg[5])) then
-      # (filter, e, d, q, form) or (filter, e, d, GF(q), form)
-      return SpecialOrthogonalGroupCons( arg[1],arg[2],arg[3],arg[4],arg[5] );
-    fi;
+  local filt, form;
+
+  if IsFilter( First( arg ) ) then
+    filt:= Remove( arg, 1 );
+  else
+    filt:= IsMatrixGroup;
   fi;
-  Error( "usage: SpecialOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q>[, <form>] )\n",
-         "or SpecialOrthogonalGroup( [<filter>, ]<form> )" );
+  if DescribesInvariantQuadraticForm( Last( arg ) ) then
+    form:= Remove( arg );
+    if Length( arg ) = 0 then
+      # ( [<filt>, ]<form> )
+      return SpecialOrthogonalGroupCons( filt, form );
+    elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                           and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
+      # ( [<filt>, ]<d>, <q>, form ) or ( [<filt>, ]<d>, <R>, form )
+      return SpecialOrthogonalGroupCons( filt, 0, arg[1], arg[2], form );
+    elif Length( arg ) = 3 and IsInt( arg[1] ) and IsPosInt( arg[2] )
+                           and ( IsPosInt( arg[3] ) or IsRing( arg[3] ) ) then
+      # ( [<filt>, ]<e>, <d>, <q>, form ) or ( [<filt>, ]<e>, <d>, <R>, form )
+      return SpecialOrthogonalGroupCons( filt, arg[1], arg[2], arg[3], form );
+    fi;
+  elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                         and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
+    # ( [<filt>, ]<d>, <q> ) or ( [<filt>, ]<d>, <R> )
+    return SpecialOrthogonalGroupCons( filt, 0, arg[1], arg[2] );
+  elif Length( arg ) = 3 and IsInt( arg[1] ) and IsPosInt( arg[2] )
+                         and ( IsPosInt( arg[3] ) or IsRing( arg[3] ) ) then
+    # ( [<filt>, ]<e>, <d>, <q> ) or ( [<filt>, ]<e>, <d>, <R> )
+    return SpecialOrthogonalGroupCons( filt, arg[1], arg[2], arg[3] );
+  fi;
+  Error( "usage: SpecialOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )\n",
+         "or SpecialOrthogonalGroup( [<filt>, ]<form> )" );
 end );
 
 DeclareSynonym( "SO", SpecialOrthogonalGroup );
@@ -651,41 +626,37 @@ DeclareConstructor( "SpecialUnitaryGroupCons",
 ##  <Example><![CDATA[
 ##  gap> SpecialUnitaryGroup( 3, 5 );
 ##  SU(3,5)
+##  gap> SpecialUnitaryGroup( IsPermGroup, 3, 5 );
+##  Perm_SU(3,5)
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 BindGlobal( "SpecialUnitaryGroup", function ( arg )
-  if Length( arg ) = 1 then
-    # form (matrix, form object, or group with stored form)
-    return SpecialUnitaryGroupCons( IsMatrixGroup, arg[1] );
-  elif Length( arg ) = 2 and IsInt( arg[1] ) then
-    # (d, q)
-    return SpecialUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
-    (IsMatrixObj(arg[3]) or
-     (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[3])) or
-     HasInvariantSesquilinearForm(arg[3])) then
-    # (d, q, form)
-    return SpecialUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2], arg[3] );
-  elif IsOperation( arg[1] ) then
-    if Length( arg ) = 2 then
-      # filter, form
-      return SpecialUnitaryGroupCons( arg[1], arg[2] );
-    elif Length( arg ) = 3 then
-      # filter, d, q
-      return SpecialUnitaryGroupCons( arg[1], arg[2], arg[3] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsMatrixObj(arg[4]) or
-       (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[4])) or
-       HasInvariantSesquilinearForm(arg[4])) then
-      # (filter, d, q, form)
-      return SpecialUnitaryGroupCons( arg[1], arg[2], arg[3], arg[4] );
-    fi;
+  local filt, form;
+
+  if IsFilter( First( arg ) ) then
+    filt:= Remove( arg, 1 );
+  else
+    filt:= IsMatrixGroup;
   fi;
-  Error( "usage: SpecialUnitaryGroup( [<filter>, ]<d>, <q>[, <form>] )\n",
-         "or SpecialUnitaryGroup( [<filter>, ]<form> )" );
+  if DescribesInvariantHermitianForm( Last( arg ) ) then
+    form:= Remove( arg );
+    if Length( arg ) = 0 then
+      # ( [<filt>, ]<form> )
+      return SpecialUnitaryGroupCons( filt, form );
+    elif Length( arg ) = 2 and IsPosInt( arg[1] ) and IsPosInt( arg[2] ) then
+      # ( [<filt>, ]<d>, <q>, form)
+      return SpecialUnitaryGroupCons( filt, arg[1], arg[2], form );
+    fi;
+
+  elif Length( arg ) = 2 and IsPosInt( arg[1] ) and IsPosInt( arg[2] ) then
+    # ( [<filt>, ]<d>, <q> )
+    return SpecialUnitaryGroupCons( filt, arg[1], arg[2] );
+  fi;
+  Error( "usage: SpecialUnitaryGroup( [<filt>, ]<d>, <q>[, <form>] )\n",
+         "or SpecialUnitaryGroup( [<filt>, ]<form> )" );
 end );
 
 DeclareSynonym( "SU", SpecialUnitaryGroup );
@@ -769,42 +740,45 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  Sp(6,Z/9Z)
 ##  gap> Size(g);
 ##  95928796265538862080
+##  gap> SymplecticGroup( IsPermGroup, 4, 2 );
+##  Perm_Sp(4,2)
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+BindGlobal( "DescribesInvariantBilinearForm",
+    obj -> IsMatrixObj( obj ) or
+           ( IsBoundGlobal( "IsBilinearForm" ) and
+             ValueGlobal( "IsBilinearForm" )( obj ) ) or
+           ( IsGroup( obj ) and HasInvariantBilinearForm( obj ) ) );
+
 BindGlobal( "SymplecticGroup", function ( arg )
-  if Length( arg ) = 1 then
-    # form (matrix, form object, or group with stored form)
-    return SymplecticGroupCons( IsMatrixGroup, arg[1] );
-  elif Length( arg ) = 2 and IsInt( arg[1] ) then
-    # (d, q) or (d, R)
-    return SymplecticGroupCons( IsMatrixGroup, arg[1], arg[2] );
-  elif Length( arg ) = 3 and IsInt(arg[1]) and
-    (IsInt(arg[2]) or IsRing(arg[2])) and
-    (IsMatrixObj(arg[3]) or
-     (IsBoundGlobal( "IsBilinearForm" ) and ValueGlobal( "IsBilinearForm" )(arg[3])) or
-     HasInvariantBilinearForm(arg[3])) then
-    # (d, q, form)
-    return SymplecticGroupCons( IsMatrixGroup, arg[1], arg[2], arg[3] );
-  elif IsOperation( arg[1] ) then
-    if Length( arg ) = 2 then
-      # (filter, form)
-      return SymplecticGroupCons( arg[1], arg[2] );
-    elif Length( arg ) = 3 then
-      # (filter, d, q)
-      return SymplecticGroupCons( arg[1], arg[2], arg[3] );
-    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
-      (IsMatrixObj(arg[4]) or
-       (IsBoundGlobal( "IsBilinearForm" ) and ValueGlobal( "IsBilinearForm" )(arg[4])) or
-       HasInvariantBilinearForm(arg[4])) then
-      # (filter, d, q, form)
-      return SymplecticGroupCons( arg[1], arg[2], arg[3], arg[4] );
-    fi;
+  local filt, form;
+
+  if IsFilter( First( arg ) ) then
+    filt:= Remove( arg, 1 );
+  else
+    filt:= IsMatrixGroup;
   fi;
-  Error( "usage: SymplecticGroup( [<filter>, ]<d>, <q>[, <form>] )\n",
-         "or SymplecticGroup( [<filter>, ]<form> )" );
+  if DescribesInvariantBilinearForm( Last( arg ) ) then
+    form:= Remove( arg );
+    if Length( arg ) = 0 then
+      # ( [<filt>, ]<form> )
+      return SymplecticGroupCons( filt, form );
+    elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                           and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
+      # ( [<filt>, ]<d>, <q>, <form> ) or ( [<filt>, ]<d>, <R>, <form> )
+      return SymplecticGroupCons( filt, arg[1], arg[2], form );
+    fi;
+  elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                         and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
+    # ( [<filt>, ]<d>, <q> ) or ( [<filt>, ]<d>, <R> )
+    return SymplecticGroupCons( filt, arg[1], arg[2] );
+  fi;
+  Error( "usage: SymplecticGroup( [<filt>, ]<d>, <q>[, <form>] )\n",
+         "or SymplecticGroup( [<filt>, ]<d>, <R>[, <form>] )\n",
+         "or SymplecticGroup( [<filt>, ]<form> )" );
 end );
 
 DeclareSynonym( "Sp", SymplecticGroup );
@@ -880,6 +854,9 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  gap> g:= Omega( -1, 4, 3 );  StructureDescription( g );
 ##  Omega(-1,4,3)
 ##  "A6"
+##  gap> g:= Omega( IsPermGroup, 1, 6, 2 );  StructureDescription( g );
+##  Perm_Omega(+1,6,2)
+##  "A8"
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -889,6 +866,11 @@ DeclareOperation( "Omega", [ IsPosInt, IsPosInt ] );
 DeclareOperation( "Omega", [ IsInt, IsPosInt, IsPosInt ] );
 DeclareOperation( "Omega", [ IsFunction, IsPosInt, IsPosInt ] );
 DeclareOperation( "Omega", [ IsFunction, IsInt, IsPosInt, IsPosInt ] );
+
+DeclareOperation( "Omega", [ IsPosInt, IsRing ] );
+DeclareOperation( "Omega", [ IsInt, IsPosInt, IsRing ] );
+DeclareOperation( "Omega", [ IsFunction, IsPosInt, IsRing ] );
+DeclareOperation( "Omega", [ IsFunction, IsInt, IsPosInt, IsRing ] );
 
 
 #############################################################################

--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -66,10 +66,9 @@
 ##  Note that due to the different sources for the generators,
 ##  the invariant forms for the groups <M>\Omega(e,d,q)</M> are in general
 ##  different from the forms for SO<M>(e,d,q)</M> and GO<M>(e,d,q)</M>.
-##  <!--
-##  If the <Package>Forms</Package> is loaded then compatible groups can be
-##  created by specifying the desired form, see the examples below.
-##  -->
+##  If the <Package>Forms</Package> package is loaded then compatible groups
+##  can be created by specifying the desired form,
+##  see the sections below.
 ##  <#/GAPDoc>
 ##
 
@@ -193,13 +192,17 @@ DeclareConstructor( "GeneralOrthogonalGroupCons",
 
 #############################################################################
 ##
-#F  GeneralOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q> ) .  gen. orthog. group
-#F  GO( [<filt>, ][<e>, ]<d>, <q> )
+#F  GeneralOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+#F  GeneralOrthogonalGroup( [<filt>, ]<form> )
+#F  GO( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+#F  GO( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="GeneralOrthogonalGroup">
 ##  <ManSection>
-##  <Func Name="GeneralOrthogonalGroup" Arg='[filt, ][e, ]d, q'/>
-##  <Func Name="GO" Arg='[filt, ][e, ]d, q'/>
+##  <Func Name="GeneralOrthogonalGroup" Arg='[filt, ][e, ]d, q[, form]'/>
+##  <Func Name="GeneralOrthogonalGroup" Arg='[filt, ]form'/>
+##  <Func Name="GO" Arg='[filt, ][e, ]d, q[, form]'/>
+##  <Func Name="GO" Arg='[filt, ]form'/>
 ##
 ##  <Description>
 ##  constructs a group isomorphic to the
@@ -215,9 +218,15 @@ DeclareConstructor( "GeneralOrthogonalGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the general orthogonal group itself.
 ##  <P/>
-##  <!--
-##  If the &GAP; package <Package>Forms</Package> is loaded then one can also
-##  specify the desired invariant quadratic form respected by the group. -->
+##  If the <Package>Forms</Package> package is loaded then
+##  the desired quadratic form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
+##  (and then this form is taken).
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
 ##  Note that in&nbsp;<Cite Key="KleidmanLiebeck90"/>,
 ##  GO is defined as the stabilizer
 ##  <M>\Delta(V, F, \kappa)</M> of the quadratic form, up to scalars,
@@ -227,19 +236,59 @@ DeclareConstructor( "GeneralOrthogonalGroupCons",
 ##  <#/GAPDoc>
 ##
 BindGlobal( "GeneralOrthogonalGroup", function ( arg )
-  if   Length( arg ) = 2 then
+  if   Length( arg ) = 1 then
+    # form (matrix, form object, or group with stored form)
+    return GeneralOrthogonalGroupCons( IsMatrixGroup, arg[1] );
+  elif Length( arg ) = 2 and IsInt( arg[1] ) then
+    # (d, q) or (d, R)
     return GeneralOrthogonalGroupCons( IsMatrixGroup, 0, arg[1], arg[2] );
   elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
     (IsInt(arg[3]) or IsRing(arg[3])) then
+    # (e, d, q) or (e, d, R)
     return GeneralOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3] );
+  elif Length( arg ) = 3 and IsInt(arg[1]) and
+    (IsInt(arg[2]) or IsRing(arg[2])) and
+    (IsMatrixObj(arg[3]) or
+     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[3])) or
+     HasInvariantQuadraticForm(arg[3])) then
+    # (d, q, form) or (d, R, form)
+    return GeneralOrthogonalGroupCons( IsMatrixGroup,0,arg[1],arg[2],arg[3] );
+  elif Length( arg ) = 4 and IsInt(arg[1]) and IsInt(arg[2]) and
+    (IsInt(arg[3]) or IsRing(arg[3])) and
+    (IsMatrixObj(arg[4]) or
+     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
+     HasInvariantQuadraticForm(arg[4])) then
+    # (e, d, q, form) or (e, d, R, form)
+    return GeneralOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3],arg[4] );
   elif IsOperation( arg[1] ) then
-    if   Length( arg ) = 3 then
+    if   Length( arg ) = 2 then
+      # (filter, form)
+      return GeneralOrthogonalGroupCons( arg[1], arg[2] );
+    elif Length( arg ) = 3 then
+      # (filter, d, q) or (filter, d, R)
       return GeneralOrthogonalGroupCons( arg[1], 0, arg[2], arg[3] );
-    elif Length( arg ) = 4 then
+    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsInt(arg[4]) or IsRing(arg[4])) then
+      # (filter, e, d, q) or (filter, e, d, R)
       return GeneralOrthogonalGroupCons( arg[1], arg[2], arg[3], arg[4] );
+    elif Length( arg ) = 4 and IsInt(arg[2]) and
+      (IsInt(arg[3]) or IsRing(arg[3])) and
+      (IsMatrixObj(arg[4]) or
+       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
+       HasInvariantQuadraticForm(arg[4])) then
+      # (filter, d, q, form) or (filter, d, R, form)
+      return GeneralOrthogonalGroupCons( arg[1], 0, arg[2], arg[3], arg[4] );
+    elif Length( arg ) = 5 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsInt(arg[4]) or IsRing(arg[4])) and
+      (IsMatrixObj(arg[5]) or
+       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[5])) or
+       HasInvariantQuadraticForm(arg[5])) then
+      # (filter, e, d, q, form) or (filter, e, d, GF(q), form)
+      return GeneralOrthogonalGroupCons( arg[1],arg[2],arg[3],arg[4],arg[5] );
     fi;
   fi;
-  Error( "usage: GeneralOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q> )" );
+  Error( "usage: GeneralOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q>[, <form>] )\n",
+         "or GeneralOrthogonalGroup( [<filter>, ]<form> )" );
 end );
 
 DeclareSynonym( "GO", GeneralOrthogonalGroup );
@@ -262,13 +311,17 @@ DeclareConstructor( "GeneralUnitaryGroupCons",
 
 #############################################################################
 ##
-#F  GeneralUnitaryGroup( [<filt>, ]<d>, <q> ) . . . . . general unitary group
-#F  GU( [<filt>, ]<d>, <q> )
+#F  GeneralUnitaryGroup( [<filt>, ]<d>, <q>[, <form>] )
+#F  GeneralUnitaryGroup( [<filt>, ]<form> )
+#F  GU( [<filt>, ]<d>, <q>[, <form>] )
+#F  GU( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="GeneralUnitaryGroup">
 ##  <ManSection>
-##  <Func Name="GeneralUnitaryGroup" Arg='[filt, ]d, q'/>
-##  <Func Name="GU" Arg='[filt, ]d, q'/>
+##  <Func Name="GeneralUnitaryGroup" Arg='[filt, ]d, q[, form]'/>
+##  <Func Name="GeneralUnitaryGroup" Arg='[filt, ]form'/>
+##  <Func Name="GU" Arg='[filt, ]d, q[, form]'/>
+##  <Func Name="GU" Arg='[filt, ]form'/>
 ##
 ##  <Description>
 ##  constructs a group isomorphic to the general unitary group
@@ -280,9 +333,15 @@ DeclareConstructor( "GeneralUnitaryGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the general unitary group itself.
 ##  <P/>
-##  <!--
-##  If the &GAP; package <Package>Forms</Package> is loaded then one can also
-##  specify the desired invariant sesquilinear form respected by the group. -->
+##  If the <Package>Forms</Package> package is loaded then
+##  the desired sesquilinear form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsHermitianForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantSesquilinearForm"/> value
+##  (and then this form is taken).
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> GeneralUnitaryGroup( 3, 5 );
 ##  GU(3,5)
@@ -292,17 +351,35 @@ DeclareConstructor( "GeneralUnitaryGroupCons",
 ##  <#/GAPDoc>
 ##
 BindGlobal( "GeneralUnitaryGroup", function ( arg )
-
-  if Length( arg ) = 2 then
+  if Length( arg ) = 1 then
+    # form (matrix, form object, or group with stored form)
+    return GeneralUnitaryGroupCons( IsMatrixGroup, arg[1] );
+  elif Length( arg ) = 2 and IsInt( arg[1] ) then
+    # (d, q)
     return GeneralUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2] );
+  elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
+    (IsMatrixObj(arg[3]) or
+     (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[3])) or
+     HasInvariantSesquilinearForm(arg[3])) then
+    # (d, q, form)
+    return GeneralUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2], arg[3] );
   elif IsOperation( arg[1] ) then
-
-    if Length( arg ) = 3 then
+    if Length( arg ) = 2 then
+      # filter, form
+      return GeneralUnitaryGroupCons( arg[1], arg[2] );
+    elif Length( arg ) = 3 then
+      # filter, d, q
       return GeneralUnitaryGroupCons( arg[1], arg[2], arg[3] );
+    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsMatrixObj(arg[4]) or
+       (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[4])) or
+       HasInvariantSesquilinearForm(arg[4])) then
+      # (filter, d, q, form)
+      return GeneralUnitaryGroupCons( arg[1], arg[2], arg[3], arg[4] );
     fi;
   fi;
-  Error( "usage: GeneralUnitaryGroup( [<filter>, ]<d>, <q> )" );
-
+  Error( "usage: GeneralUnitaryGroup( [<filter>, ]<d>, <q>[, <form>] )\n",
+         "or GeneralUnitaryGroup( [<filter>, ]<form> )" );
 end );
 
 DeclareSynonym( "GU", GeneralUnitaryGroup );
@@ -413,16 +490,20 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 
 #############################################################################
 ##
-#F  SpecialOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q> ) . spec. orthog. group
-#F  SO( [<filt>, ][<e>, ]<d>, <q> )
+#F  SpecialOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+#F  SpecialOrthogonalGroup( [<filt>, ]<form> )
+#F  SO( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+#F  SO( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="SpecialOrthogonalGroup">
 ##  <ManSection>
-##  <Func Name="SpecialOrthogonalGroup" Arg='[filt, ][e, ]d, q'/>
-##  <Func Name="SO" Arg='[filt, ][e, ]d, q'/>
+##  <Func Name="SpecialOrthogonalGroup" Arg='[filt, ][e, ]d, q[, form]'/>
+##  <Func Name="SpecialOrthogonalGroup" Arg='[filt, ]form'/>
+##  <Func Name="SO" Arg='[filt, ][e, ]d, q[, form]'/>
+##  <Func Name="SO" Arg='[filt, ]form'/>
 ##
 ##  <Description>
-##  <Ref Func="SpecialOrthogonalGroup"/> returns a group isomorphic to the 
+##  constructs a group isomorphic to the
 ##  special orthogonal group SO( <A>e</A>, <A>d</A>, <A>q</A> ),
 ##  which is the subgroup of all those matrices in the general orthogonal
 ##  group (see&nbsp;<Ref Func="GeneralOrthogonalGroup"/>) that have
@@ -438,9 +519,15 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the special orthogonal group itself.
 ##  <P/>
-##  <!--
-##  If the &GAP; package <Package>Forms</Package> is loaded then one can also
-##  specify the desired invariant quadratic form respected by the group. -->
+##  If the <Package>Forms</Package> package is loaded then
+##  the desired quadratic form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
+##  (and then this form is taken).
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> GeneralOrthogonalGroup( 3, 7 );
 ##  GO(0,3,7)
@@ -454,21 +541,59 @@ DeclareConstructor( "SpecialOrthogonalGroupCons",
 ##  <#/GAPDoc>
 ##
 BindGlobal( "SpecialOrthogonalGroup", function ( arg )
-
-  if   Length( arg ) = 2 then
+  if   Length( arg ) = 1 then
+    # form (matrix, form object, or group with stored form)
+    return SpecialOrthogonalGroupCons( IsMatrixGroup, arg[1] );
+  elif Length( arg ) = 2 and IsInt( arg[1] ) then
+    # (d, q) or (d, R)
     return SpecialOrthogonalGroupCons( IsMatrixGroup, 0, arg[1], arg[2] );
   elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
     (IsInt(arg[3]) or IsRing(arg[3])) then
+    # (e, d, q) or (e, d, GF(q))
     return SpecialOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3] );
+  elif Length( arg ) = 3 and IsInt(arg[1]) and
+    (IsInt(arg[2]) or IsRing(arg[2])) and
+    (IsMatrixObj(arg[3]) or
+     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[3])) or
+     HasInvariantQuadraticForm(arg[3])) then
+    # (d, q, form) or (d, GF(q), form)
+    return SpecialOrthogonalGroupCons( IsMatrixGroup,0,arg[1],arg[2],arg[3] );
+  elif Length( arg ) = 4 and IsInt(arg[1]) and IsInt(arg[2]) and
+    (IsInt(arg[3]) or IsRing(arg[3])) and
+    (IsMatrixObj(arg[4]) or
+     (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
+     HasInvariantQuadraticForm(arg[4])) then
+    # (e, d, q, form) or (e, d, GF(q), form)
+    return SpecialOrthogonalGroupCons( IsMatrixGroup,arg[1],arg[2],arg[3],arg[4] );
   elif IsOperation( arg[1] ) then
-    if   Length( arg ) = 3 then
+    if   Length( arg ) = 2 then
+      # filter, form
+      return SpecialOrthogonalGroupCons( arg[1], arg[2] );
+    elif Length( arg ) = 3 then
+      # filter, d, q
       return SpecialOrthogonalGroupCons( arg[1], 0, arg[2], arg[3] );
-    elif Length( arg ) = 4 then
+    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsInt(arg[4]) or IsRing(arg[4])) then
+      # (filter, e, d, q) or (filter, e, d, R)
       return SpecialOrthogonalGroupCons( arg[1], arg[2], arg[3], arg[4] );
+    elif Length( arg ) = 4 and IsInt(arg[2]) and
+      (IsInt(arg[3]) or IsRing(arg[3])) and
+      (IsMatrixObj(arg[4]) or
+       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[4])) or
+      HasInvariantQuadraticForm(arg[4])) then
+      # (filter, d, q, form) or (filter, d, R, form)
+      return SpecialOrthogonalGroupCons( arg[1], 0, arg[2], arg[3], arg[4] );
+    elif Length( arg ) = 5 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsInt(arg[4]) or IsRing(arg[4])) and
+      (IsMatrixObj(arg[5]) or
+       (IsBoundGlobal( "IsQuadraticForm" ) and ValueGlobal( "IsQuadraticForm" )(arg[5])) or
+       HasInvariantQuadraticForm(arg[5])) then
+      # (filter, e, d, q, form) or (filter, e, d, GF(q), form)
+      return SpecialOrthogonalGroupCons( arg[1],arg[2],arg[3],arg[4],arg[5] );
     fi;
   fi;
-  Error( "usage: SpecialOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q> )" );
-
+  Error( "usage: SpecialOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q>[, <form>] )\n",
+         "or SpecialOrthogonalGroup( [<filter>, ]<form> )" );
 end );
 
 DeclareSynonym( "SO", SpecialOrthogonalGroup );
@@ -491,18 +616,22 @@ DeclareConstructor( "SpecialUnitaryGroupCons",
 
 #############################################################################
 ##
-#F  SpecialUnitaryGroup( [<filt>, ]<d>, <q> ) . . . . . general unitary group
-#F  SU( [<filt>, ]<d>, <q> )
+#F  SpecialUnitaryGroup( [<filt>, ]<d>, <q>[, <form>] )
+#F  SpecialUnitaryGroup( [<filt>, ]<form> )
+#F  SU( [<filt>, ]<d>, <q>[, <form>] )
+#F  SU( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="SpecialUnitaryGroup">
 ##  <ManSection>
-##  <Func Name="SpecialUnitaryGroup" Arg='[filt, ]d, q'/>
-##  <Func Name="SU" Arg='[filt, ]d, q'/>
+##  <Func Name="SpecialUnitaryGroup" Arg='[filt, ]d, q[, form]'/>
+##  <Func Name="SpecialUnitaryGroup" Arg='[filt, ]form'/>
+##  <Func Name="SU" Arg='[filt, ]d, q[, form]'/>
+##  <Func Name="SU" Arg='[filt, ]form'/>
 ##
 ##  <Description>
 ##  constructs a group isomorphic to the special unitary group
-##  GU(<A>d</A>, <A>q</A>) of those <M><A>d</A> \times <A>d</A></M> matrices
-##  over the field with <M><A>q</A>^2</M> elements
+##  SU( <A>d</A>, <A>q</A> ) of those <M><A>d</A> \times <A>d</A></M>
+##  matrices over the field with <M><A>q</A>^2</M> elements
 ##  whose determinant is the identity of the field and that respect a fixed
 ##  nondegenerate sesquilinear form,
 ##  in the category given by the filter <A>filt</A>.
@@ -510,9 +639,15 @@ DeclareConstructor( "SpecialUnitaryGroupCons",
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the special unitary group itself.
 ##  <P/>
-##  <!--
-##  If the &GAP; package <Package>Forms</Package> is loaded then one can also
-##  specify the desired invariant sesquilinear form respected by the group. -->
+##  If the <Package>Forms</Package> package is loaded then
+##  the desired sesquilinear form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsHermitianForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantSesquilinearForm"/> value
+##  (and then this form is taken).
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> SpecialUnitaryGroup( 3, 5 );
 ##  SU(3,5)
@@ -522,17 +657,35 @@ DeclareConstructor( "SpecialUnitaryGroupCons",
 ##  <#/GAPDoc>
 ##
 BindGlobal( "SpecialUnitaryGroup", function ( arg )
-
-  if Length( arg ) = 2 then
+  if Length( arg ) = 1 then
+    # form (matrix, form object, or group with stored form)
+    return SpecialUnitaryGroupCons( IsMatrixGroup, arg[1] );
+  elif Length( arg ) = 2 and IsInt( arg[1] ) then
+    # (d, q)
     return SpecialUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2] );
+  elif Length( arg ) = 3 and IsInt(arg[1]) and IsInt(arg[2]) and
+    (IsMatrixObj(arg[3]) or
+     (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[3])) or
+     HasInvariantSesquilinearForm(arg[3])) then
+    # (d, q, form)
+    return SpecialUnitaryGroupCons( IsMatrixGroup, arg[1], arg[2], arg[3] );
   elif IsOperation( arg[1] ) then
-
-    if Length( arg ) = 3 then
+    if Length( arg ) = 2 then
+      # filter, form
+      return SpecialUnitaryGroupCons( arg[1], arg[2] );
+    elif Length( arg ) = 3 then
+      # filter, d, q
       return SpecialUnitaryGroupCons( arg[1], arg[2], arg[3] );
+    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsMatrixObj(arg[4]) or
+       (IsBoundGlobal( "IsHermitianForm" ) and ValueGlobal( "IsHermitianForm" )(arg[4])) or
+       HasInvariantSesquilinearForm(arg[4])) then
+      # (filter, d, q, form)
+      return SpecialUnitaryGroupCons( arg[1], arg[2], arg[3], arg[4] );
     fi;
   fi;
-  Error( "usage: SpecialUnitaryGroup( [<filter>, ]<d>, <q> )" );
-
+  Error( "usage: SpecialUnitaryGroup( [<filter>, ]<d>, <q>[, <form>] )\n",
+         "or SpecialUnitaryGroup( [<filter>, ]<form> )" );
 end );
 
 DeclareSynonym( "SU", SpecialUnitaryGroup );
@@ -555,25 +708,34 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 
 #############################################################################
 ##
-#F  SymplecticGroup( [<filt>, ]<d>, <q> ) . . . . . . . . .  symplectic group
-#F  Sp( [<filt>, ]<d>, <q> )
-#F  SP( [<filt>, ]<d>, <q> )
+#F  SymplecticGroup( [<filt>, ]<d>, <q>[, <form>] ) . . . .  symplectic group
+#F  SymplecticGroup( [<filt>, ]<form> ) . . . . . . . . . .  symplectic group
+#F  Sp( [<filt>, ]<d>, <q>[, <form>] )
+#F  Sp( [<filt>, ]<form> )
+#F  SP( [<filt>, ]<d>, <q>[, <form>] )
+#F  SP( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="SymplecticGroup">
 ##  <ManSection>
 ##  <Heading>SymplecticGroup</Heading>
-##  <Func Name="SymplecticGroup" Arg='[filt, ]d, q'
+##  <Func Name="SymplecticGroup" Arg='[filt, ]d, q[, form]'
 ##   Label="for dimension and field size"/>
-##  <Func Name="SymplecticGroup" Arg='[filt, ]d, ring'
+##  <Func Name="SymplecticGroup" Arg='[filt, ]d, ring[, form]'
 ##   Label="for dimension and a ring"/>
-##  <Func Name="Sp" Arg='[filt, ]d, q'
+##  <Func Name="SymplecticGroup" Arg='[filt, ]form'
+##   Label="for form"/>
+##  <Func Name="Sp" Arg='[filt, ]d, q[, form]'
 ##   Label="for dimension and field size"/>
-##  <Func Name="Sp" Arg='[filt, ]d, ring'
+##  <Func Name="Sp" Arg='[filt, ]d, ring[, form]'
 ##   Label="for dimension and a ring"/>
-##  <Func Name="SP" Arg='[filt, ]d, q'
+##  <Func Name="Sp" Arg='[filt, ]form'
+##   Label="for form"/>
+##  <Func Name="SP" Arg='[filt, ]d, q[, form]'
 ##   Label="for dimension and field size"/>
-##  <Func Name="SP" Arg='[filt, ]d, ring'
+##  <Func Name="SP" Arg='[filt, ]d, ring[, form]'
 ##   Label="for dimension and a ring"/>
+##  <Func Name="SP" Arg='[filt, ]form'
+##   Label="for form"/>
 ##
 ##  <Description>
 ##  constructs a group isomorphic to the symplectic group
@@ -586,12 +748,20 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the symplectic group itself.
 ##  <P/>
-##  At the moment finite fields or residue class rings 
-##  <C>Integers mod <A>q</A></C>, with <A>q</A> an odd prime power are
+##  At the moment finite fields or residue class rings
+##  <C>Integers mod <A>q</A></C>, with <A>q</A> an odd prime power, are
 ##  supported.
-##  <!--
-##  If the &GAP; package <Package>Forms</Package> is loaded then one can also
-##  specify the desired invariant symplectic form respected by the group. -->
+##  <P/>
+##  If the <Package>Forms</Package> package is loaded and the arguments
+##  describe a matrix group over a finite field then
+##  the desired bilinear form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsBilinearForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantBilinearForm"/> value
+##  (and then this form is taken).
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> SymplecticGroup( 4, 2 );
 ##  Sp(4,2)
@@ -605,17 +775,36 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  <#/GAPDoc>
 ##
 BindGlobal( "SymplecticGroup", function ( arg )
-
-  if Length( arg ) = 2 then
+  if Length( arg ) = 1 then
+    # form (matrix, form object, or group with stored form)
+    return SymplecticGroupCons( IsMatrixGroup, arg[1] );
+  elif Length( arg ) = 2 and IsInt( arg[1] ) then
+    # (d, q) or (d, R)
     return SymplecticGroupCons( IsMatrixGroup, arg[1], arg[2] );
+  elif Length( arg ) = 3 and IsInt(arg[1]) and
+    (IsInt(arg[2]) or IsRing(arg[2])) and
+    (IsMatrixObj(arg[3]) or
+     (IsBoundGlobal( "IsBilinearForm" ) and ValueGlobal( "IsBilinearForm" )(arg[3])) or
+     HasInvariantBilinearForm(arg[3])) then
+    # (d, q, form)
+    return SymplecticGroupCons( IsMatrixGroup, arg[1], arg[2], arg[3] );
   elif IsOperation( arg[1] ) then
-
-    if Length( arg ) = 3 then
+    if Length( arg ) = 2 then
+      # (filter, form)
+      return SymplecticGroupCons( arg[1], arg[2] );
+    elif Length( arg ) = 3 then
+      # (filter, d, q)
       return SymplecticGroupCons( arg[1], arg[2], arg[3] );
+    elif Length( arg ) = 4 and IsInt(arg[2]) and IsInt(arg[3]) and
+      (IsMatrixObj(arg[4]) or
+       (IsBoundGlobal( "IsBilinearForm" ) and ValueGlobal( "IsBilinearForm" )(arg[4])) or
+       HasInvariantBilinearForm(arg[4])) then
+      # (filter, d, q, form)
+      return SymplecticGroupCons( arg[1], arg[2], arg[3], arg[4] );
     fi;
   fi;
-  Error( "usage: SymplecticGroup( [<filter>, ]<d>, <q> )" );
-
+  Error( "usage: SymplecticGroup( [<filter>, ]<d>, <q>[, <form>] )\n",
+         "or SymplecticGroup( [<filter>, ]<form> )" );
 end );
 
 DeclareSynonym( "Sp", SymplecticGroup );
@@ -638,12 +827,15 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 
 #############################################################################
 ##
-#O  Omega( [<filt>, ][<e>, ]<d>, <q> )
+#O  Omega( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+#O  Omega( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="Omega_orthogonal_groups">
 ##  <ManSection>
-##  <Oper Name="Omega" Arg='[filt, ][e, ]d, q'
+##  <Oper Name="Omega" Arg='[filt, ][e, ]d, q[, form]'
 ##   Label="construct an orthogonal group"/>
+##  <Oper Name="Omega" Arg='[filt, ]form'
+##   Label="construct an orthogonal group for a given quadratic form"/>
 ##
 ##  <Description>
 ##  constructs a group isomorphic to the
@@ -653,11 +845,14 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  (see&nbsp;<Ref Attr="InvariantQuadraticForm"/>) specified by <A>e</A>,
 ##  and that have square spinor norm in odd characteristic
 ##  or Dickson invariant <M>0</M> in even characteristic, respectively,
-##  in the category given by the filter <A>filt</A>. For odd <A>q</A>
-##  and <M><A>d</A> \geq 2</M>,
-##  this group has always index two in the corresponding special orthogonal group,
-##  which will be conjugate in <M>GL(d,q)</M> to the group returned by SO( <A>e</A>, <A>d</A>, <A>q</A> ),
-##  see <Ref Func="SpecialOrthogonalGroup"/>, but may fix a different form (see <Ref Sect="Classical Groups"/>).
+##  in the category given by the filter <A>filt</A>.
+##  <P/>
+##  For odd <A>q</A> and <M><A>d</A> \geq 2</M>, this group has always
+##  index two in the corresponding special orthogonal group,
+##  which will be conjugate in <M>GL(d,q)</M> to the group returned by
+##  SO( <A>e</A>, <A>d</A>, <A>q</A> ),
+##  see <Ref Func="SpecialOrthogonalGroup"/>,
+##  but may fix a different form (see <Ref Sect="Classical Groups"/>).
 ##  <P/>
 ##  The value of <A>e</A> must be <M>0</M> for odd <A>d</A> (and can
 ##  optionally be omitted in this case), respectively one of <M>1</M> or
@@ -666,9 +861,15 @@ DeclareConstructor( "OmegaCons", [ IsGroup, IsInt, IsPosInt, IsPosInt ] );
 ##  and the returned group is the group
 ##  <M>\Omega</M>( <A>e</A>, <A>d</A>, <A>q</A> ) itself.
 ##  <P/>
-##  <!--
-##  If the &GAP; package <Package>Forms</Package> is loaded then one can also
-##  specify the desired invariant quadratic form respected by the group. -->
+##  If the <Package>Forms</Package> package is loaded then
+##  the desired quadratic form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsQuadraticForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantQuadraticForm"/> value
+##  (and then this form is taken).
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> g:= Omega( 3, 5 );  StructureDescription( g );
 ##  Omega(0,3,5)
@@ -770,7 +971,7 @@ DeclareConstructor( "SpecialSemilinearGroupCons",
 ##  <Ref Func="SpecialSemilinearGroup"/> returns a group isomorphic to the
 ##  special semilinear group <M>\Sigma</M>L( <A>d</A>, <A>q</A> ) of those
 ##  semilinear mappings of the vector space
-##  <C>GF( </C><A>q</A><C> )^</C><A>d</A> 
+##  <C>GF( </C><A>q</A><C> )^</C><A>d</A>
 ##  (see <Ref Func="GeneralSemilinearGroup"/>)
 ##  whose linear part has determinant one.
 ##  <P/>

--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -1898,6 +1898,27 @@ InstallMethod( Omega,
 
 #############################################################################
 ##
+#M  Omega( [<filt>, ][<e>, ]<d>, <F_q> )
+##
+InstallMethod( Omega,
+    [ IsPosInt, IsField and IsFinite ],
+    { d, R } -> OmegaCons( IsMatrixGroup, 0, d, Size( R ) ) );
+
+InstallMethod( Omega,
+    [ IsInt, IsPosInt, IsField and IsFinite ],
+    { e, d, R } -> OmegaCons( IsMatrixGroup, e, d, Size( R ) ) );
+
+InstallMethod( Omega,
+    [ IsFunction, IsPosInt, IsField and IsFinite ],
+    { filt, d, R } -> OmegaCons( filt, 0, d, Size( R ) ) );
+
+InstallMethod( Omega,
+    [ IsFunction, IsInt, IsPosInt, IsField and IsFinite ],
+    { filt, e, d, R } -> OmegaCons( filt, e, d, Size( R ) ) );
+
+
+#############################################################################
+##
 #F  WreathProductOfMatrixGroup( <M>, <P> )  . . . . . . . . .  wreath product
 ##
 BindGlobal( "WreathProductOfMatrixGroup", function( M, P )
@@ -1951,5 +1972,5 @@ PermConstructor(SpecialUnitaryGroupCons,[IsPermGroup,IsInt,IsObject],
 PermConstructor(SymplecticGroupCons,[IsPermGroup,IsInt,IsObject],
   IsMatrixGroup and IsFinite);
 
-PermConstructor(OmegaCons,[IsPermGroup,IsInt,IsObject],
+PermConstructor(OmegaCons,[IsPermGroup,IsInt,IsInt,IsObject],
   IsMatrixGroup and IsFinite);

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -71,7 +71,9 @@ true
 
 #
 gap> GO(3);
-Error, usage: GeneralOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q> )
+Error, usage: GeneralOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+or GeneralOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+or GeneralOrthogonalGroup( [<filt>, ]<form> )
 gap> GO(3,6);
 Error, <subfield> must be a prime or a finite field
 gap> GO(-1,3,5);
@@ -109,7 +111,8 @@ GU(3,5)
 gap> GU(IsPermGroup,3,4);
 Perm_GU(3,4)
 gap> GU(3);
-Error, usage: GeneralUnitaryGroup( [<filter>, ]<d>, <q> )
+Error, usage: GeneralUnitaryGroup( [<filt>, ]<d>, <q>[, <form>] )
+or GeneralUnitaryGroup( [<filt>, ]<form> )
 gap> GU(3,6);
 Error, <subfield> must be a prime or a finite field
 
@@ -150,6 +153,8 @@ gap> Omega(5,2);
 GO(0,5,2)
 gap> Omega(5,3);
 Omega(0,5,3)
+gap> Omega( 5, GF(3) );
+Omega(0,5,3)
 
 #
 gap> Omega(+1,2,2);
@@ -159,6 +164,8 @@ Omega(+1,2,3)
 gap> Omega(+1,4,2);
 Omega(+1,4,2)
 gap> Omega(+1,4,3);
+Omega(+1,4,3)
+gap> Omega( +1, 4, GF(3) );
 Omega(+1,4,3)
 
 #
@@ -172,18 +179,18 @@ gap> Omega(-1,4,3);
 Omega(-1,4,3)
 
 #
+gap> Omega( IsPermGroup, 5, GF(3) );
+Perm_Omega(0,5,3)
+gap> Omega( IsPermGroup, +1, 4, GF(3) );
+Perm_Omega(+1,4,3)
+
+#
 gap> Omega(0,2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Omega' on 2 arguments
 gap> Omega(-1,0,2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Omega' on 3 arguments
-gap> Omega(IsPermGroup,3,2);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OmegaCons' on 4 arguments
-gap> Omega(IsPermGroup,0,3,2);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `OmegaCons' on 4 arguments
 
 #
 gap> Omega(2,2);

--- a/tst/testinstall/grp/classic-S.tst
+++ b/tst/testinstall/grp/classic-S.tst
@@ -44,7 +44,8 @@ true
 
 #
 gap> SO(3);
-Error, usage: SpecialOrthogonalGroup( [<filter>, ][<e>, ]<d>, <q> )
+Error, usage: SpecialOrthogonalGroup( [<filt>, ][<e>, ]<d>, <q>[, <form>] )
+or SpecialOrthogonalGroup( [<filt>, ]<form> )
 gap> SO(3,6);
 Error, <subfield> must be a prime or a finite field
 gap> SO(-1,3,5);
@@ -82,7 +83,8 @@ SU(3,5)
 gap> SU(IsPermGroup,3,4);
 Perm_SU(3,4)
 gap> SU(3);
-Error, usage: SpecialUnitaryGroup( [<filter>, ]<d>, <q> )
+Error, usage: SpecialUnitaryGroup( [<filt>, ]<d>, <q>[, <form>] )
+or SpecialUnitaryGroup( [<filt>, ]<form> )
 gap> SU(3,6);
 Error, <subfield> must be a prime or a finite field
 
@@ -96,7 +98,9 @@ Perm_Sp(4,5)
 gap> Sp(3,5);
 Error, the dimension <d> must be even
 gap> Sp(4);
-Error, usage: SymplecticGroup( [<filter>, ]<d>, <q> )
+Error, usage: SymplecticGroup( [<filt>, ]<d>, <q>[, <form>] )
+or SymplecticGroup( [<filt>, ]<d>, <R>[, <form>] )
+or SymplecticGroup( [<filt>, ]<form> )
 gap> Sp(4,6);
 Error, <subfield> must be a prime or a finite field
 


### PR DESCRIPTION
## Text for release notes 
The documentation and the code of the functions `GO`, `GU`, `Omega`, `SO`, `SU`, and `Sp` have been extended such that one can specify an invariant form for the group in question. The methods that do the work will be provided via the Forms package.
## (End of text for release notes)

See gap-packages/forms/pull/4 for the proposed corresponding changes in the Forms package.
The pull request is intended to resolve issue #500.