### PR TITLE
Remove redundant workaround in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,7 +199,6 @@ jobs:
                        packages+=(gcc-multilib g++-multilib)
                    fi
                    sudo apt-get update
-                   sudo apt-get remove libzmq5 || : # workaround https://github.com/actions/virtual-environments/issues/3317
                    sudo apt-get install "${packages[@]}"
                elif [ "$RUNNER_OS" == "macOS" ]; then
                    brew install gmp zlib


### PR DESCRIPTION
The `ubuntu-18.04` runner [was updated to version 20210510](https://github.com/actions/virtual-environments/releases/tag/ubuntu18%2F20210510.0) which means the workaround is no longer needed.

It _seems_ like this new virtual environment has fully propagated, but just to be extra safe we could wait an extra day or two before merging this.