### PR TITLE
Remove AVOID_PRECOMPILED from kernel and gac

### DIFF
--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -357,20 +357,16 @@ make_compstat () {
         echo     "/* made by 'gac', can be thrown away */"
         echo     "#include \"compiled.h\""
 
-        echo     "#ifndef AVOID_PRECOMPILED"
         echo     "extern StructInitInfo * Init__type1 ( void );"
         echo     "extern StructInitInfo * Init__oper1( void );"
-        echo     "#endif"
 
         for name in ${names}; do
             echo "extern StructInitInfo * Init__${name} ( void );"
         done
 
         echo     "InitInfoFunc CompInitFuncs[] = {"
-        echo     "#ifndef AVOID_PRECOMPILED"
         echo     "    Init__type1,"
         echo     "    Init__oper1,"
-        echo     "#endif"
 
         for name in ${names}; do
             echo "    Init__${name},"

--- a/cnf/gap-c-gen.sh
+++ b/cnf/gap-c-gen.sh
@@ -17,12 +17,10 @@ then
 fi
 
 # invoke GAP in compiler mode
-echo "#ifndef AVOID_PRECOMPILED" > "$C_FILE.tmp"
-"$GAPBIN" -C "*stdout*" \
+"$GAPBIN" -E -C "$C_FILE.tmp" \
           "$GAP_FILE" \
           "Init_$STEM" \
           GAPROOT/lib/$STEM.g >> "$C_FILE.tmp"
-echo "#endif" >> "$C_FILE.tmp"
 
 # if the new file differs from the old one, overwrite
 if cmp -s "$C_FILE.tmp" "$C_FILE"

--- a/src/compstat.c
+++ b/src/compstat.c
@@ -11,24 +11,17 @@
 #include "compstat.h"
 #include "common.h"
 
-// #define AVOID_PRECOMPILED
-
-
 /****************************************************************************
 **
 *V  CompInitFuncs . . . . . . . . . .  list of compiled module init functions
 **
 **  This a dummy list in case no module is statically linked.
 */
-#ifndef AVOID_PRECOMPILED
 extern StructInitInfo * Init__type1(void);
 extern StructInitInfo * Init__oper1(void);
-#endif
 
 InitInfoFunc CompInitFuncs[] = {
-#ifndef AVOID_PRECOMPILED
     Init__type1,
     Init__oper1,
-#endif
     0
 };


### PR DESCRIPTION
I am not aware of anything or anyone using it recently. If one wants to test
GAP without the "precompiled" versions of type1.g and oper1.g, one can use the
`-M` command line option. If one really, *really* wants to compile GAP without
these, one can either use the `build/gap-nocomp` binary that we are now
producing for internal use; or simplify manually modify the source code.

This should fix #4466 but I'd like to also add a second fix, so please don't merge this yet (but @hulpke feel free to verify if this PR helps with the issue -- note that I am also interested in learning whether the patch in https://github.com/gap-system/gap/issues/4466#issuecomment-842397169 helps.