### PR TITLE
Disable readline if stdin is not attached to a terminal

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -243,7 +243,7 @@ GAPInfo.UseReadline := true;
 ##  are considered as word boundaries. The function is then installed as a 
 ##  macro and bound to the key sequence <B>Esc</B> <B>Q</B>. 
 ##  <P/>
-##  <Example>
+##  <Log>
 ##  gap> EditAddQuotes := function(l)
 ##  >   local str, pos, i, j, new;
 ##  >   str := l[3];
@@ -264,7 +264,7 @@ GAPInfo.UseReadline := true;
 ##  gap> InstallReadlineMacro("addquotes", EditAddQuotes);
 ##  gap> invl := InvocationReadlineMacro("addquotes");;
 ##  gap> ReadlineInitLine(Concatenation("\"\\eQ\":\"",invl,"\""));;
-##  </Example>
+##  </Log>
 ##  </Subsection>
 ##  
 ##  </Section>

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3481,8 +3481,10 @@ void InitSysFiles(void)
     setbuf(stderr, (char *)0);
 
 #ifdef HAVE_LIBREADLINE
-    rl_readline_name = "GAP";
-    rl_initialize ();
+    if (SyUseReadline) {
+        rl_readline_name = "GAP";
+        rl_initialize();
+    }
 #endif
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -741,8 +741,6 @@ void InitSystem (
     }
 #endif
 
-    InitSysFiles();
-
     if (handleSignals) {
         SyInstallAnswerIntr();
     }
@@ -816,11 +814,20 @@ void InitSystem (
         }
           
       }
-    /* adjust SyUseReadline if no readline support available or for XGAP  */
 #if !defined(HAVE_LIBREADLINE)
+    // don't use readline of readline is not available (obviously)
+    // so that e.g. the GAP banner reports this correctly.
     SyUseReadline = 0;
+#else
+    // don't use readline if in Window mode (e.g. for XGAP)
+    if (SyWindow)
+        SyUseReadline = 0;
+    // don't use readline if stdin is not attached to a terminal
+    else if (!isatty(fileno(stdin)))
+        SyUseReadline = 0;
 #endif
-    if (SyWindow) SyUseReadline = 0;
+
+    InitSysFiles();
 
     /* now that the user has had a chance to give -x and -y,
        we determine the size of the screen ourselves */


### PR DESCRIPTION
This PR should fix #4466 and I hope @hulpke can verify that. It is not an alternative to PR #4494 (which also fixes that issue) but rather complements it: IMHO this PR here fixes the "real" issue; but that's debatable. In any case, ideally both would be merged.

I hope nobody is doing weird stuff that involves piping text into GAP (such that stdin is not a terminal) while also requiring GNU readline support to be enabled. Indeed, things like the pexpect interface by SageMath most likely would want to disable readline support anyway (perhaps @dimpase can confirm this). And the GUI frontends XGAP and [GAP.app](https://cocoagap.sourceforge.io) by @RussWoodroofe use special control codes, by enabling so called "window mode", which already disables GNU readline integration. So all in all I am hopeful this is safe, and does not even need to be mentioned in the release notes.