### PR TITLE
CI: upload gap release tarball in nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   unix:
-    name: "Create UNIX archives and data"
+    name: "Create Unix archives and data"
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
@@ -58,15 +58,17 @@ jobs:
         run: python -u ./dev/releases/make_archives.py
 
       - name: "Upload artifacts"
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') && failure() }}
+        if: ${{ (!startsWith(github.ref, 'refs/tags/v') && failure()) || github.event_name == 'schedule' }}
         # Warning: the result is a single .zip file (so things are compressed twice)
         # To keep things from exploding, we only upload a subset of all generated files
         uses: actions/upload-artifact@v2
         with:
+          name: "GAP release tarballs"
           path: |
             tmp/gap-*.tar.gz*
             tmp/*json*
             !tmp/gap-*-core.tar.gz*
+          retention-days: 1
 
       - name: "Make GitHub release"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
This modifies the "Wrap releases" Workflow to upload the (e.g.) `gap-4.12dev-880-g8840b6e.tar.gz` tarball and the `package-infos.json.gz` files as artifacts on the nightly builds of the CI.

These are retained for one day, with the idea being that after one day, you should look at the artifacts on the next night's builds.

I can add more files to the upload, if you'd like. The GAP tarball is about 500 MB.