### PR TITLE
Let IsBlockMatrixRep imply IsMatrix

### DIFF
--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -43,7 +43,7 @@
 ##  \enditems
 ##
 DeclareRepresentation( "IsBlockMatrixRep",
-    IsComponentObjectRep,
+    IsComponentObjectRep and IsMatrix,
     [ "blocks", "zero", "nrb", "ncb", "rpb", "cpb" ] );
 
 


### PR DESCRIPTION
(Note: I created this patch in late 2019 and then kinda forget about it. Right now I cleaning out old patches. I am not sure anymore this patch is the right thing to do -- I guess I had doubts back then and didn't submit it for that reason. I also forgot *why* I made it -- presumably the wrong method was called in some case(s), but unfortunately I made no note of which, nor recorded an example or test. Hrmm... Anyway, I'd like to resolve this patch: whether it gets merged or rejected; afterwards I can drop it :-) ).

This implication substantially increases the rank of IsBlockMatrixRep.

Note that a lot of code in fact only deals with IsOrdinaryMatrix and
IsBlockMatrixRep, including the constructor, which only allows creating
IsBlockMatrixRep which also are in the filter IsOrdinaryMatrix.

Presumably, one could create a block matrix in filter IsLieMatrix with
some manual intervention, but most methods for IsBlockMatrixRep
currently require IsOrdinaryMatrix for no apparent reason.
