### PR TITLE
Turn `IsLexicographicallyLess` into an obsolete synonym for `\<`

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -1658,7 +1658,6 @@ with possibly slightly different meaning for lists and non-list collections.
 <#Include Label="Flat">
 <#Include Label="Reversed">
 <#Include Label="Shuffle">
-<#Include Label="IsLexicographicallyLess">
 <#Include Label="Apply">
 <#Include Label="Perform">
 <#Include Label="PermListList">

--- a/doc/ref/obsolete.xml
+++ b/doc/ref/obsolete.xml
@@ -27,10 +27,6 @@ We decided to change the names to avoid confusion with the term
 <P/>
 Here are some examples of such name changes.
 <P/>
-<Index Key="Operation"><C>Operation</C></Index>
-<Index Key="RepresentativeOperation"><C>RepresentativeOperation</C></Index>
-<Index Key="OperationHomomorphism"><C>OperationHomomorphism</C></Index>
-<Index Key="FunctionOperation"><C>FunctionOperation</C></Index>
 <Table Align="l|l">
 <Row>
   <Item><E>OLD</E></Item>
@@ -38,20 +34,24 @@ Here are some examples of such name changes.
 </Row>
 <HorLine/>
 <Row>
-  <Item><C>Operation</C></Item>
+  <Item><C>Operation</C><Index Key="Operation"><C>Operation</C></Index></Item>
   <Item><Ref Func="Action" Label="for a group, an action domain, etc."/></Item>
 </Row>
 <Row>
-  <Item><C>RepresentativeOperation</C></Item>
+  <Item><C>RepresentativeOperation</C><Index Key="RepresentativeOperation"><C>RepresentativeOperation</C></Index></Item>
   <Item><Ref Func="RepresentativeAction"/></Item>
 </Row>
 <Row>
-  <Item><C>OperationHomomorphism</C></Item>
+  <Item><C>OperationHomomorphism</C><Index Key="OperationHomomorphism"><C>OperationHomomorphism</C></Index></Item>
   <Item><Ref Func="ActionHomomorphism" Label="for a group, an action domain, etc."/></Item>
 </Row>
 <Row>
-  <Item><C>FunctionOperation</C></Item>
+  <Item><C>FunctionOperation</C><Index Key="FunctionOperation"><C>FunctionOperation</C></Index></Item>
   <Item><Ref Attr="FunctionAction"/></Item>
+</Row>
+<Row>
+  <Item><C>IsLexicographicallyLess</C><Index Key="IsLexicographicallyLess"><C>IsLexicographicallyLess</C></Index></Item>
+  <Item><Ref Attr="\&lt;"/></Item>
 </Row>
 </Table>
 

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1599,29 +1599,6 @@ DeclareOperation( "ReversedOp", [ IsDenseList ] );
 ##  
 DeclareOperation( "Shuffle", [IsDenseList and IsMutable] );
 
-#############################################################################
-##
-#F  IsLexicographicallyLess( <list1>, <list2> )
-##
-##  <#GAPDoc Label="IsLexicographicallyLess">
-##  <ManSection>
-##  <Func Name="IsLexicographicallyLess" Arg='list1, list2'/>
-##
-##  <Description>
-##  Let <A>list1</A> and <A>list2</A> be two dense, but not necessarily
-##  homogeneous lists
-##  (see&nbsp;<Ref Filt="IsDenseList"/>, <Ref Filt="IsHomogeneousList"/>),
-##  such that for each <M>i</M>, the entries in both lists at position
-##  <M>i</M> can be compared via <C>&lt;</C>.
-##  <Ref Func="IsLexicographicallyLess"/> returns <K>true</K> if <A>list1</A>
-##  is smaller than <A>list2</A> w.r.t.&nbsp;lexicographical ordering,
-##  and <K>false</K> otherwise.
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-##
-DeclareSynonym( "IsLexicographicallyLess", \< );
-
 
 #############################################################################
 ##

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1620,7 +1620,7 @@ DeclareOperation( "Shuffle", [IsDenseList and IsMutable] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalFunction( "IsLexicographicallyLess" );
+DeclareSynonym( "IsLexicographicallyLess", \< );
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2385,23 +2385,6 @@ InstallOtherMethod( StableSort,
     [ IsList, IsFunction ],
     SORT_MUTABILITY_ERROR_HANDLER );
 
-#############################################################################
-##
-#F  IsLexicographicallyLess( <list1>, <list2> )
-##
-InstallGlobalFunction( IsLexicographicallyLess, function( list1, list2 )
-    local len, i;
-    len:= Minimum( Length( list1 ), Length( list2 ) );
-    for i in [ 1 .. len ]  do
-      if list1[i] < list2[i] then
-        return true;
-      elif list2[i] < list1[i] then
-        return false;
-      fi;
-    od;
-    return len < Length( list2 );
-end );
-
 
 #############################################################################
 ##

--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -95,7 +95,7 @@ InstallGlobalFunction( BlockMatrix, function( arg )
         Add( newblocks, block );
       fi;
     od;
-    Sort( newblocks, IsLexicographicallyLess );
+    Sort( newblocks );
     i:=1;
     while i+1<=Length(newblocks) do
       if newblocks[i][1] = newblocks[ i+1 ][1] and
@@ -337,7 +337,7 @@ InstallMethod( \+,
        and bm1!.cpb = bm2!.cpb then
 
       blocks:= Concatenation( bm1!.blocks, bm2!.blocks );
-      Sort( blocks, IsLexicographicallyLess );
+      Sort( blocks );
       pos:= 1;
       i:= 1;
       while i < Length( blocks ) do

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -722,3 +722,28 @@ end);
 DeclareObsoleteSynonym("GAP_EXIT_CODE", "GapExitCode", 2);
 DeclareObsoleteSynonym("QUIT_GAP", "QuitGap", 2);
 DeclareObsoleteSynonym("FORCE_QUIT_GAP", "ForceQuitGap", 2);
+
+
+#############################################################################
+##
+#F  IsLexicographicallyLess( <list1>, <list2> )
+##
+##  <#GAPDoc Label="IsLexicographicallyLess">
+##  <ManSection>
+##  <Func Name="IsLexicographicallyLess" Arg='list1, list2'/>
+##
+##  <Description>
+##  Let <A>list1</A> and <A>list2</A> be two dense, but not necessarily
+##  homogeneous lists
+##  (see&nbsp;<Ref Filt="IsDenseList"/>, <Ref Filt="IsHomogeneousList"/>),
+##  such that for each <M>i</M>, the entries in both lists at position
+##  <M>i</M> can be compared via <C>&lt;</C>.
+##  <Ref Func="IsLexicographicallyLess"/> returns <K>true</K> if <A>list1</A>
+##  is smaller than <A>list2</A> w.r.t.&nbsp;lexicographical ordering,
+##  and <K>false</K> otherwise.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+##  Not used in any redistributed package (05/2021)
+DeclareObsoleteSynonym( "IsLexicographicallyLess", "<" );


### PR DESCRIPTION
Because \< already compares lists lexicographically, just
more efficiently than what `IsLexicographicallyLess` did.

The one downside of this I can think of is now one could
abuse this to write `IsLexicographicallyLess(1,2)`

As far as I can tell, no package and no library code uses `IsLexicographicallyLess` after this PR. So perhaps we should mark it as obsolete, too?