### PR TITLE
ENHANCE: Default representation for perfect groups

### DIFF
--- a/grp/perf.gd
+++ b/grp/perf.gd
@@ -165,7 +165,7 @@ DeclareSynonym("NrPerfectLibraryGroups",NumberPerfectLibraryGroups);
 ##  <Ref Filt="IsSubgroupFpGroup"/>.
 ##  In the latter case, the  generators and relators used coincide with those
 ##  given in&nbsp;<Cite Key="HP89"/>.
-##  The default filter is <Ref Filt="IsSubgroupFpGroup"/>.
+##  The default filter is <Ref Filt="IsPermGroup"/>.
 ##  <Example><![CDATA[
 ##  gap> G := PerfectGroup(IsPermGroup,6048,1);
 ##  U3(3)

--- a/grp/perf.grp
+++ b/grp/perf.grp
@@ -428,12 +428,13 @@ InstallGlobalFunction( PerfectGroup, function(arg)
 local func,sz,p;
   PerfGrpLoad(0); # force loading
   if not IsFunction(arg[1]) then 
-    func:=IsSubgroupFpGroup;
+    func:=IsPermGroup;
     sz:=arg;
   else
     func:=arg[1];
     sz:=arg{[2..Length(arg)]};
   fi;
+  if func=IsFpGroup then func:=IsSubgroupFpGroup;fi;
   # list given
   if Length(sz)=1 then
     if not IsList(sz[1]) then

--- a/lib/tietze.gd
+++ b/lib/tietze.gd
@@ -158,7 +158,7 @@ DeclareSynonym("AbstractWordTzWord",AssocWordByLetterRep);
 ##  generator is to write
 ##  <C>GeneratorsOfPresentation(P)[Length(GeneratorsOfPresentation(P))]</C>.
 ##  <Example><![CDATA[
-##  gap> G := PerfectGroup( 120 );;
+##  gap> G := PerfectGroup(IsFpGroup, 120 );;
 ##  gap> H := Subgroup( G, [ G.1^G.2, G.3 ] );;
 ##  gap> P := PresentationSubgroup( G, H );
 ##  <presentation with 4 gens and 7 rels of total length 21>

--- a/tst/testinstall/opers/HallSubgroup.tst
+++ b/tst/testinstall/opers/HallSubgroup.tst
@@ -18,7 +18,7 @@ gap> List(HallSubgroup(G, [2,3]), IdGroup);
 [ [ 24, 12 ], [ 24, 12 ] ]
 
 #
-gap> G:=PerfectGroup(60,1);
+gap> G:=PerfectGroup(IsFpGroup,60,1);
 A5
 gap> IsFpGroup(G);
 true


### PR DESCRIPTION
The default choice of representation used by the perfect groups library is
as finitely presented group. (This was decided by V. Felsch, when he
implemented this library in the 1990s.)

However, short of constructing or storing, this representation is almost
universally inferior to a permutation representation. This commit thus
switches this default.

