### PR TITLE
Introduce SetGlobalLineWrappingStatus

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -560,6 +560,23 @@ static Obj FuncSizeScreen(Obj self, Obj args)
 
 /****************************************************************************
 **
+*F  FuncSetGlobalLineWrappingStatus( <self>, <args> )  . . . .  internal function 'SetGlobalLineWrappingStatus'
+**
+*/
+static Obj FuncSetGlobalLineWrappingStatus(Obj self, Obj val)
+{
+
+  RequireTrueOrFalse(SELF_NAME, val);
+
+  SyLineWrappingDisabled = (val == False);
+
+  return 0;
+
+}
+
+
+/****************************************************************************
+**
 *F  FuncWindowCmd( <self>, <args> ) . . . . . . . .  execute a window command
 */
 static Obj WindowCmdString;
@@ -1280,6 +1297,7 @@ static Obj FuncAssertionLevel(Obj self)
 static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC(SizeScreen, -1, "args"),
+    GVAR_FUNC_1ARGS(SetGlobalLineWrappingStatus, val),
     GVAR_FUNC_1ARGS(ID_FUNC, object),
     GVAR_FUNC(RETURN_FIRST, -2, "first, rest"),
     GVAR_FUNC(RETURN_NOTHING, -1, "object"),

--- a/src/io.c
+++ b/src/io.c
@@ -1285,12 +1285,12 @@ static void PutChrTo(TypOutputFile * stream, Char ch)
 
       /* if we are going to split at the end of the line, and we are
          formatting discard blanks */
-      if ( stream->format && spos == stream->pos && ch == ' ' ) {
+      if ( !SyLineWrappingDisabled && stream->format && spos == stream->pos && ch == ' ' ) {
         ;
       }
 
       /* full line, acceptable split position                              */
-      else if ( stream->format && spos != 0 ) {
+      else if ( !SyLineWrappingDisabled && stream->format && spos != 0 ) {
 
         /* add character to the line, terminate it                         */
         stream->line[ stream->pos++ ] = ch;
@@ -1329,7 +1329,7 @@ static void PutChrTo(TypOutputFile * stream, Char ch)
       /* full line, no split position                                       */
       else {
 
-        if (stream->format)
+        if ( !SyLineWrappingDisabled && stream->format )
           {
             /* append a '\',*/
             stream->line[ stream->pos++ ] = '\\';
@@ -1343,7 +1343,7 @@ static void PutChrTo(TypOutputFile * stream, Char ch)
         stream->pos = 0;
         stream->line[ stream->pos++ ] = ch;
 
-        if (stream->format)
+        if ( !SyLineWrappingDisabled && stream->format )
           stream->hints[0] = -1;
       }
 

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -107,6 +107,13 @@ extern UInt SyNrRowsLocked;
 
 /****************************************************************************
 **
+*V  SyLineWrappingDisabled . . . . . . . . .  do not wrap lines when printing
+**
+*/
+extern UInt SyLineWrappingDisabled;
+
+/****************************************************************************
+**
 *V  SyQuiet . . . . . . . . . . . . . . . . . . . . . . . . . surpress prompt
 **
 **  'SyQuit' determines whether GAP should print the prompt and  the  banner.

--- a/src/system.c
+++ b/src/system.c
@@ -159,6 +159,12 @@ UInt SyNrRowsLocked;
 
 /****************************************************************************
 **
+*V  SyLineWrappingDisabled . . . . . . . . .  do not wrap lines when printing
+*/
+UInt SyLineWrappingDisabled;
+
+/****************************************************************************
+**
 *V  SyQuiet . . . . . . . . . . . . . . . . . . . . . . . . . suppress prompt
 **
 **  'SyQuiet' determines whether GAP should print the prompt and the  banner.
@@ -705,6 +711,7 @@ void InitSystem (
     SyNrColsLocked = 0;
     SyNrRows = 0;
     SyNrRowsLocked = 0;
+    SyLineWrappingDisabled = 0;
     SyQuiet = 0;
     SyInitializing = 0;
 


### PR DESCRIPTION
# Description

This is a prototype of my suggestion in #4496.

My setting is: I never want line wrapping (because I prefer to let my terminal wrap lines and do not want "random" backslashes when printing to strings/files) and I always want indentation, regardless of the print target (stdout, file, string). This PR introduces a function `SetGlobalLineWrappingStatus` which disables (or re-enables) line wrapping completely (I hope).

If you like the idea, I would add some documentation and tests and fill in the text for release notes below.

## Text for release notes 

TODO

If this pull request shall **not** be mentioned in the release notes
(to be distributed in the file `CHANGES.md`),
please add the label `release notes: not needed`.

Otherwise, please proceed in one of the following ways:

- Choose a title that can serve as text for the release notes,
  and add the label `release notes: use title`.

- Put the text for the release notes **here**,
  that is, between the markers `Text for release notes`
  and `(End of text for release notes)`.

The first variant is recommended whenever the text for release notes
is suitable as title.

In both cases, please follow the style of the GAP `CHANGES.md` file
in the root directory.
In particular, please surround the names of GAP functions with backquotes.

## (End of text for release notes)

## Further details

If necessary, please provide further details here.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

