### PR TITLE
introduce `IsMatrixOrMatrixObj`

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -32,6 +32,7 @@ More can be added as soon as there is need for them.
 
 <#Include Label="IsVectorObj">
 <#Include Label="IsMatrixObj">
+<#Include Label="IsMatrixOrMatrixObj">
 <#Include Label="IsRowListMatrix">
 
 </Section>

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -881,7 +881,7 @@ InstallMethod( IsGeneratorsOfMagmaWithInverses,
     function( matlist )
     local nrows, ncols;
 
-    if IsList( matlist ) and ForAll( matlist, IsMatrixObj ) then
+    if IsList( matlist ) and ForAll( matlist, IsMatrixOrMatrixObj ) then
       nrows:= NumberRows( matlist[1] );
       ncols:= NumberColumns( matlist[1] );
       return nrows = ncols and

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -75,7 +75,7 @@ InstallMethod( \=,
 
 InstallMethod( \=,
     "for two matrix objects",
-    [ IsMatrixObj, IsMatrixObj ],
+    [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ],
     function( M1, M2 )
     if IsList( M1 ) and IsList( M2 ) then
       TryNextMethod();
@@ -101,13 +101,13 @@ InstallMethod( ZeroOfBaseDomain,
     v -> Zero( BaseDomain( v ) ) );
 
 InstallMethod( OneOfBaseDomain,
-    "generic method for IsMatrixObj",
-    [ IsMatrixObj ],
+    "generic method for IsMatrixOrMatrixObj",
+    [ IsMatrixOrMatrixObj ],
     M -> One( BaseDomain( M ) ) );
 
 InstallMethod( ZeroOfBaseDomain,
-    "generic method for IsMatrixObj",
-    [ IsMatrixObj ],
+    "generic method for IsMatrixOrMatrixObj",
+    [ IsMatrixOrMatrixObj ],
     M -> Zero( BaseDomain( M ) ) );
 
 
@@ -253,7 +253,7 @@ InstallMethod( ZeroVector,
 
 InstallMethod( ZeroVector,
     "for length and matrix object",
-    [ IsInt, IsMatrixObj ],
+    [ IsInt, IsMatrixOrMatrixObj ],
     { len, M } -> NewZeroVector( CompatibleVectorFilter( M ),
                                  BaseDomain( M ), len ) );
 
@@ -287,7 +287,7 @@ InstallMethod( Matrix,
   end );
 
 InstallMethod( Matrix,
-    [ IsOperation, IsSemiring, IsMatrixObj ],
+    [ IsOperation, IsSemiring, IsMatrixOrMatrixObj ],
     function( filt, R, mat )
     if IsPlistRep( mat ) then
       TryNextMethod();
@@ -312,7 +312,7 @@ InstallMethod( Matrix,
     end );
 
 InstallMethod( Matrix,
-    [ IsSemiring, IsMatrixObj ],
+    [ IsSemiring, IsMatrixOrMatrixObj ],
     function( R, M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -355,13 +355,13 @@ InstallMethod( Matrix,
 # matrix constructors using example objects (as last argument)
 #
 InstallMethod( Matrix,
-  [IsList, IsInt, IsMatrixObj],
+  [IsList, IsInt, IsMatrixOrMatrixObj],
   function( list, nrCols, example )
     return NewMatrix( ConstructingFilter(example), BaseDomain(example), nrCols, list );
   end );
 
 InstallMethod( Matrix, "generic convenience method with 2 args",
-  [IsList, IsMatrixObj],
+  [IsList, IsMatrixOrMatrixObj],
   function( list, example )
     if Length(list) = 0 then
         ErrorNoReturn("Matrix: two-argument version not allowed with empty first arg");
@@ -373,13 +373,13 @@ InstallMethod( Matrix, "generic convenience method with 2 args",
   end );
 
 InstallMethod( Matrix,
-  [IsMatrixObj, IsMatrixObj],
+  [IsMatrixOrMatrixObj, IsMatrixOrMatrixObj],
     function( mat, example )
     if IsPlistRep( mat ) then
       TryNextMethod();
     fi;
     # TODO: can we avoid using Unpack? resp. make this more efficient
-    # perhaps adjust NewMatrix to take an IsMatrixObj?
+    # perhaps adjust NewMatrix to take an IsMatrixOrMatrixObj?
     return NewMatrix( ConstructingFilter(example), BaseDomain(example), NrCols(mat), Unpack(mat) );
   end );
 
@@ -387,7 +387,7 @@ InstallMethod( Matrix,
 #
 #
 InstallMethod( ZeroMatrix,
-  [IsInt, IsInt, IsMatrixObj],
+  [IsInt, IsInt, IsMatrixOrMatrixObj],
   function( rows, cols, example )
     if rows < 0 or cols < 0 then Error("ZeroMatrix: the number of rows and cols must be non-negative"); fi;
     return NewZeroMatrix( ConstructingFilter(example), BaseDomain(example), rows, cols );
@@ -411,7 +411,7 @@ InstallMethod( ZeroMatrix,
 #
 #
 InstallMethod( IdentityMatrix,
-  [IsInt, IsMatrixObj],
+  [IsInt, IsMatrixOrMatrixObj],
   function( dim, example )
     if dim < 0 then Error("IdentityMatrix: the dimension must be non-negative"); fi;
     return NewIdentityMatrix( ConstructingFilter(example), BaseDomain(example), dim );
@@ -436,7 +436,7 @@ InstallMethod( IdentityMatrix,
 #
 InstallMethod( CompanionMatrix,
     "for a polynomial and a matrix",
-  [ IsUnivariatePolynomial, IsMatrixObj ],
+  [ IsUnivariatePolynomial, IsMatrixOrMatrixObj ],
   function( po, m )
     local l, n, q, ll, i, one;
     one := OneOfBaseDomain( m );
@@ -481,7 +481,7 @@ InstallMethod( CompanionMatrix,
 
 
 InstallMethod( KroneckerProduct, "for two matrices",
-  [ IsMatrixObj, IsMatrixObj ],
+  [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ],
   function( A, B )
     local rowsA, rowsB, colsA, colsB, newclass, AxB, i, j;
 
@@ -536,7 +536,7 @@ InstallGlobalFunction( ConcatenationOfVectors,
 
 InstallMethod( TraceMat,
     "for a matrix object",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     local s, i;
 
@@ -635,7 +635,7 @@ InstallMethod( ExtractSubVector,
 
 InstallMethod( ExtractSubMatrix,
     "generic method for a matrix object and two lists",
-    [ IsMatrixObj, IsList, IsList ],
+    [ IsMatrixOrMatrixObj, IsList, IsList ],
     function( M, rowpos, colpos )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -670,7 +670,7 @@ InstallMethod( ChangedBaseDomain,
 
 InstallMethod( ChangedBaseDomain,
     "for a matrix object and a semiring",
-    [ IsMatrixObj, IsSemiring ],
+    [ IsMatrixOrMatrixObj, IsSemiring ],
     { M, R } -> Matrix( R, M ) );
 
 
@@ -693,7 +693,7 @@ end );
 
 InstallMethodWithRandomSource( Randomize,
   "for a random source and a matrix object",
-  [ IsRandomSource, IsMatrixObj and IsMutable ],
+  [ IsRandomSource, IsMatrixOrMatrixObj and IsMutable ],
   function( rs, mat )
     local basedomain, i, j;
     basedomain := BaseDomain( mat );
@@ -1001,18 +1001,19 @@ InstallMethod( MultVectorRight,
 ##
 InstallMethod( \+,
     "for two matrix objects",
-    [ IsMatrixObj, IsMatrixObj ],
+    [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ],
     -SUM_FLAGS,
     function( M1, M2 )
     if IsPlistRep( M1 ) then
       TryNextMethod();
     fi;
     return Matrix( Unpack( M1 ) + Unpack( M2 ), M1 );
+#T infinite recursion for plist M2 and non-plist M1?
     end );
 
 InstallMethod( \-,
     "for two matrix objects",
-    [ IsMatrixObj, IsMatrixObj ],
+    [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ],
     -SUM_FLAGS,
     function( M1, M2 )
     if IsPlistRep( M1 ) then
@@ -1023,7 +1024,7 @@ InstallMethod( \-,
 
 InstallMethod( \*,
     "for two ordinary matrix objects (ordinary matrix product)",
-    [ IsMatrixObj and IsOrdinaryMatrix, IsMatrixObj and IsOrdinaryMatrix ],
+    [ IsMatrixOrMatrixObj and IsOrdinaryMatrix, IsMatrixOrMatrixObj and IsOrdinaryMatrix ],
     -SUM_FLAGS,
     function( M1, M2 )
     if IsList( M1 ) or IsList( M2 ) then
@@ -1034,7 +1035,7 @@ InstallMethod( \*,
 
 InstallMethod( \*,
     "for matrix object and scalar",
-    [ IsMatrixObj, IsScalar ],
+    [ IsMatrixOrMatrixObj, IsScalar ],
     -SUM_FLAGS,
     function( M, s )
     if IsList( M ) then
@@ -1045,7 +1046,7 @@ InstallMethod( \*,
 
 InstallMethod( \*,
     "for scalar and matrix object",
-    [ IsScalar, IsMatrixObj ],
+    [ IsScalar, IsMatrixOrMatrixObj ],
     -SUM_FLAGS,
     function( s, M )
     if IsList( M ) then
@@ -1056,7 +1057,7 @@ InstallMethod( \*,
 
 InstallMethod( \/,
     "for matrix object and scalar",
-    [ IsMatrixObj, IsScalar ],
+    [ IsMatrixOrMatrixObj, IsScalar ],
     -SUM_FLAGS,
     function( M, s )
     if IsList( M ) then
@@ -1081,7 +1082,7 @@ InstallMethod( \/,
 ##  The code in question uses <Ref Func="OnPoints"/> as the default action,
 ##  which means that the operation <Ref Oper="\^"/> gets called.
 ##  Therefore, we declare this operation for the case that the two arguments
-##  are in <Ref Cat="IsVectorObj"/> and <Ref Cat="IsMatrixObj"/>,
+##  are in <Ref Cat="IsVectorObj"/> and <Ref Cat="IsMatrixOrMatrixObj"/>,
 ##  and install the multiplication as a method for this situation;
 ##  thus one need not install individual <Ref Oper="\^"/> methods
 ##  in special cases.
@@ -1090,7 +1091,7 @@ InstallMethod( \/,
 ##  it is recommended to use the multiplication <Ref Oper="\*"/> directly.
 ##
 InstallMethod( \*,
-    [ IsVectorObj, IsMatrixObj ],
+    [ IsVectorObj, IsMatrixOrMatrixObj ],
     function( v, M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1099,7 +1100,7 @@ InstallMethod( \*,
     end );
 
 InstallMethod( \*,
-    [ IsMatrixObj, IsVectorObj ],
+    [ IsMatrixOrMatrixObj, IsVectorObj ],
     function( M, v )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1108,7 +1109,7 @@ InstallMethod( \*,
     end );
 
 InstallOtherMethod( \^,
-    [ IsVectorObj, IsMatrixObj ],
+    [ IsVectorObj, IsMatrixOrMatrixObj ],
     \* );
 
 
@@ -1117,7 +1118,7 @@ InstallOtherMethod( \^,
 #M  IsEmptyMatrix( <matobj> )
 ##
 InstallMethod( IsEmptyMatrix,
-  [ IsMatrixObj ],
+  [ IsMatrixOrMatrixObj ],
   mat -> NrRows(mat) = 0 or NrCols(mat) = 0
 );
 
@@ -1137,7 +1138,7 @@ InstallMethod( ShallowCopy,
 #M  MutableCopyMatrix( <M> )
 ##
 InstallMethod( MutableCopyMatrix,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     -SUM_FLAGS,
     function( M )
     if IsPlistRep( M ) then
@@ -1152,7 +1153,7 @@ InstallMethod( MutableCopyMatrix,
 #M  CopySubMatrix( <src>, <dst>, <srcrows>, <dstrows>, <srccols>, <dstcols> )
 ##
 InstallMethod( CopySubMatrix,
-    [ IsMatrixObj and IsMutable, IsMatrixObj, IsList, IsList, IsList, IsList ],
+    [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj, IsList, IsList, IsList, IsList ],
     function( src, dst, srcrows, dstrows, srccols, dstcols )
     local i, j;
 
@@ -1327,7 +1328,7 @@ InstallMethod( Characteristic,
 ##  are already installed more generally.
 ##
 InstallMethod( AdditiveInverseMutable,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1337,7 +1338,7 @@ InstallMethod( AdditiveInverseMutable,
     end );
 
 InstallMethod( AdditiveInverseSameMutability,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsMutable( M ) then
       return AdditiveInverseMutable( M );
@@ -1347,7 +1348,7 @@ InstallMethod( AdditiveInverseSameMutability,
     end );
 
 InstallMethod( ZeroMutable,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1357,7 +1358,7 @@ InstallMethod( ZeroMutable,
     end );
 
 InstallMethod( ZeroSameMutability,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsMutable( M ) then
       return ZeroMutable( M );
@@ -1367,7 +1368,7 @@ InstallMethod( ZeroSameMutability,
     end );
 
 InstallMethod( OneMutable,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1377,7 +1378,7 @@ InstallMethod( OneMutable,
     end );
 
 InstallMethod( OneSameMutability,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsMutable( M ) then
       return OneMutable( M );
@@ -1387,7 +1388,7 @@ InstallMethod( OneSameMutability,
     end );
 
 InstallMethod( InverseMutable,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1397,7 +1398,7 @@ InstallMethod( InverseMutable,
     end );
 
 InstallMethod( InverseSameMutability,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsMutable( M ) then
       return InverseMutable( M );
@@ -1407,7 +1408,7 @@ InstallMethod( InverseSameMutability,
     end );
 
 InstallMethod( IsZero,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1416,7 +1417,7 @@ InstallMethod( IsZero,
     end );
 
 InstallMethod( IsOne,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1425,7 +1426,7 @@ InstallMethod( IsOne,
     end );
 
 InstallMethod( Characteristic,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     M -> Characteristic( BaseDomain( M ) ) );
 
 
@@ -1477,15 +1478,15 @@ BindGlobal( "ViewStringForMatrixObj",
              " over ", String( BaseDomain( M ) ), ">" ) );
 
 InstallMethod( ViewString,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     ViewStringForMatrixObj );
 
 InstallMethod( DisplayString,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     ViewStringForMatrixObj );
 
 InstallMethod( String,
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     if IsPlistRep( M ) then
       TryNextMethod();
@@ -1504,7 +1505,7 @@ InstallMethod( String,
 ##
 InstallMethod( CompatibleVector,
     "for a matrix object",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     M -> NewZeroVector( CompatibleVectorFilter( M ), BaseDomain( M ),
                         NumberRows( M ) ) );
 
@@ -1515,7 +1516,7 @@ InstallMethod( CompatibleVector,
 ##
 InstallMethod( RowsOfMatrix,
     "for a matrix object",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( M )
     local R, f;
 
@@ -1534,7 +1535,7 @@ InstallMethod( RowsOfMatrix,
 
 InstallMethod( DimensionsMat,
     "for a matrix object",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     M -> [ NumberRows( M ), NumberColumns( M ) ] );
 
 InstallOtherMethod( Randomize,
@@ -1544,7 +1545,7 @@ InstallOtherMethod( Randomize,
 
 InstallMethod( Length,
     "for a matrix object",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     -SUM_FLAGS,
     NumberRows );
 
@@ -1554,15 +1555,15 @@ InstallMethod( Length,
 # should be fine without these). We lower the rank so that these are only
 # used as a last resort.
 InstallMethod( \[\,\], "for a matrix object and two positions",
-  [ IsMatrixObj, IsPosInt, IsPosInt ],
-  {} -> -RankFilter(IsMatrixObj),
+  [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt ],
+  {} -> -RankFilter(IsMatrixOrMatrixObj),
   function( m, row, col )
     return ELM_LIST( m, row, col );
   end );
 
 InstallMethod( \[\,\]\:\=, "for a matrix object, two positions, and an object",
-  [ IsMatrixObj and IsMutable, IsPosInt, IsPosInt, IsObject ],
-  {} -> -RankFilter(IsMatrixObj),
+  [ IsMatrixOrMatrixObj and IsMutable, IsPosInt, IsPosInt, IsObject ],
+  {} -> -RankFilter(IsMatrixOrMatrixObj),
   function( m, row, col, obj )
     ASS_LIST( m, row, col, obj );
   end );

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -91,12 +91,13 @@ DeclareCategory( "IsVectorObj", IsVector and IsCopyable );
 ##  <Filt Name="IsMatrixOrMatrixObj" Arg='obj' Type="category"/>
 ##
 ##  <Description>
-##  This filter is the <Q>common roof</Q> for <Ref Filt="IsMatrix"/> and
-##  <Ref Filt="IsMatrixObj"/>.
+##  Several functions are defined for objects in <Ref Filt="IsMatrix"/> and
+##  objects in <Ref Filt="IsMatrixObj"/>.
+##  All these objects lie in the filter <Ref Filt="IsMatrixOrMatrixObj"/>.
 ##  It should be used in situations where an object can be either a list of
 ##  lists in <Ref Filt="IsMatrix"/> or a <Q>proper</Q> matrix object in
 ##  <Ref Filt="IsMatrixObj"/>,
-##  for example as requirement in the installation of a method for such an
+##  for example as a requirement in the installation of a method for such an
 ##  argument.
 ##  <P/>
 ##  <Example><![CDATA[

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -26,7 +26,6 @@
 ##  <Filt Name="IsVectorObj" Arg='obj' Type="category"/>
 ##
 ##  <Description>
-##  <P/>
 ##  The idea behind <E>vector objects</E> is that one wants to deal with
 ##  objects like coefficient lists of fixed length over a given domain
 ##  <M>R</M>, say, which can be added and can be multiplied from the left
@@ -83,6 +82,58 @@
 ##  <#/GAPDoc>
 ##
 DeclareCategory( "IsVectorObj", IsVector and IsCopyable );
+
+
+#############################################################################
+##
+##  <#GAPDoc Label="IsMatrixOrMatrixObj">
+##  <ManSection>
+##  <Filt Name="IsMatrixOrMatrixObj" Arg='obj' Type="category"/>
+##
+##  <Description>
+##  This filter is the <Q>common roof</Q> for <Ref Filt="IsMatrix"/> and
+##  <Ref Filt="IsMatrixObj"/>.
+##  It should be used in situations where an object can be either a list of
+##  lists in <Ref Filt="IsMatrix"/> or a <Q>proper</Q> matrix object in
+##  <Ref Filt="IsMatrixObj"/>,
+##  for example as requirement in the installation of a method for such an
+##  argument.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> m:= IdentityMat( 2, GF(2) );;
+##  gap> IsMatrix( m );  IsMatrixObj( m ); IsMatrixOrMatrixObj( m );
+##  true
+##  false
+##  true
+##  gap> m:= NewIdentityMatrix( IsPlistMatrixRep, GF(2), 2 );;
+##  gap> IsMatrix( m );  IsMatrixObj( m ); IsMatrixOrMatrixObj( m );
+##  false
+##  true
+##  true
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareCategory( "IsMatrixOrMatrixObj", IsVector and IsScalar and IsCopyable );
+
+
+#############################################################################
+##
+##  Note that we cannot get this implication already in the declaration of
+##  'IsMatrix' because both 'IsVector' and 'IsMatrix' are declared in
+##  'lib/arith.gd',
+##  and 'IsMatrixOrMatrixObj' --which shall be in the middle--
+##  is declared in 'lib/matobj1.gd'.)
+##
+#T Do we want an analogous setup also for objects in 'IsRowVector' (which are
+#T plain lists) and objects in 'IsVectorObj'?
+#T (For some operations, such as 'WeightOfVector' or 'DistanceOfVectors',
+#T this implication would make sense, but in fact the default methods for
+#T 'WeightVecFFE' and 'DistanceVecFFE' are installed with requirement
+#T 'IsList'.)
+##
+InstallTrueMethod( IsMatrixOrMatrixObj, IsMatrix );
 
 
 #############################################################################
@@ -168,27 +219,7 @@ DeclareCategory( "IsVectorObj", IsVector and IsCopyable );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareCategory( "IsMatrixObj", IsVector and IsScalar and IsCopyable );
-
-
-#############################################################################
-##
-##  We want that objects in 'IsMatrix' (which are plain lists of lists)
-##  are also in 'IsMatrixObj', in order to be able to install generic methods
-##  that cover also the case of 'IsMatrix'.
-##  Note that we cannot get this implication already in the declaration of
-##  'IsMatrix' because both 'IsVector' and 'IsMatrix' are declared in
-##  'lib/arith.gd', and 'IsMatrixObj' --which shall be in the middle-- is
-##  declared in 'lib/matobj1.gd'.)
-##
-#T Do we want that objects in 'IsRowVector' (which are plain lists)
-#T are also in 'IsVectorObj'?
-#T (For some operations, such as 'WeightOfVector' or 'DistanceOfVectors',
-#T this implication would make sense, but in fact the default methods for
-#T 'WeightVecFFE' and 'DistanceVecFFE' are installed with requirement
-#T 'IsList'.)
-##
-InstallTrueMethod( IsMatrixObj, IsMatrix );
+DeclareCategory( "IsMatrixObj", IsMatrixOrMatrixObj );
 
 
 #############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -53,12 +53,23 @@
 ##  <Q>matrix objects</Q> respectively.
 ##  <P/>
 ##  (Of course the terminology is somewhat confusing:
-##  An abstract matrix should be thought of as represented by
-##  a matrix object; it can be detected from the filter
-##  <Ref Filt="IsMatrixObj"/>, whereas the filter <Ref Filt="IsMatrix"/>
-##  denotes matrices represented by lists of lists.
-##  We regard the objects in <Ref Filt="IsMatrix"/> as special cases of
-##  objects in <Ref Filt="IsMatrixObj"/>.)
+##  An <Q>abstract matrix</Q> in &GAP; can be represented either by a list of
+##  lists or by a matrix object.
+##  It can be detected from the filter <Ref Filt="IsMatrixOrMatrixObj"/>;
+##  this is the union of the filters <Ref Filt="IsMatrix"/>
+##  &ndash;which denotes those matrices that are represented by lists of
+##  lists&ndash;
+##  and the filter <Ref Filt="IsMatrixObj"/>
+##  &ndash;which defines <Q>proper</Q> matrix objects in the above sense.
+##  In particular, we do <E>not</E> regard the objects in
+##  <Ref Filt="IsMatrix"/> as special cases of objects in
+##  <Ref Filt="IsMatrixObj"/>, or vice versa.
+##  Thus one can install specific methods for all three situations:
+##  just for <Q>proper</Q> matrix objects, just for matrices represented
+##  by lists of lists, or for both kinds of matrices.
+##  For example, a &GAP; package may decide to accept only <Q>proper</Q>
+##  matrix objects as arguments of its functions, or it may try to support
+##  also objects in <Ref Filt="IsMatrix"/> as far as this is possible.)
 ##  <P/>
 ##  We want to be able to write (efficient) code that is independent of the
 ##  actual representation (in the sense of &GAP;'s representation filters,
@@ -159,7 +170,7 @@
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "BaseDomain", IsVectorObj );
-DeclareAttribute( "BaseDomain", IsMatrixObj );
+DeclareAttribute( "BaseDomain", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -191,10 +202,10 @@ DeclareAttribute( "BaseDomain", IsMatrixObj );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "NumberRows", IsMatrixObj );
+DeclareAttribute( "NumberRows", IsMatrixOrMatrixObj );
 DeclareSynonymAttr( "NrRows", NumberRows );
 
-DeclareAttribute( "NumberColumns", IsMatrixObj );
+DeclareAttribute( "NumberColumns", IsMatrixOrMatrixObj );
 DeclareSynonymAttr( "NrCols", NumberColumns );
 
 
@@ -234,10 +245,10 @@ DeclareSynonymAttr( "NrCols", NumberColumns );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "OneOfBaseDomain", IsVectorObj );
-DeclareAttribute( "OneOfBaseDomain", IsMatrixObj );
+DeclareAttribute( "OneOfBaseDomain", IsMatrixOrMatrixObj );
 
 DeclareAttribute( "ZeroOfBaseDomain", IsVectorObj );
-DeclareAttribute( "ZeroOfBaseDomain", IsMatrixObj );
+DeclareAttribute( "ZeroOfBaseDomain", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -283,7 +294,7 @@ DeclareAttribute( "Length", IsVectorObj );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "ConstructingFilter", IsVectorObj );
-DeclareAttribute( "ConstructingFilter", IsMatrixObj );
+DeclareAttribute( "ConstructingFilter", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -307,7 +318,7 @@ DeclareAttribute( "ConstructingFilter", IsMatrixObj );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "CompatibleVectorFilter", IsMatrixObj );
+DeclareAttribute( "CompatibleVectorFilter", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -464,7 +475,7 @@ DeclareOperation( "ListOp", [ IsVectorObj, IsFunction ] );
 ##  because its result would be immutable.
 ##
 DeclareOperation( "Unpack", [ IsVectorObj ] );
-DeclareOperation( "Unpack", [ IsMatrixObj ] );
+DeclareOperation( "Unpack", [ IsMatrixOrMatrixObj ] );
 
 
 #############################################################################
@@ -666,7 +677,7 @@ DeclareOperation( "ScalarProduct", [ IsVectorObj, IsVectorObj ] );
 DeclareOperation( "ZeroVector", [ IsOperation, IsSemiring, IsInt ] );
 DeclareOperation( "ZeroVector", [ IsSemiring, IsInt ] );
 DeclareOperation( "ZeroVector", [ IsInt, IsVectorObj ] );
-DeclareOperation( "ZeroVector", [ IsInt, IsMatrixObj ] );
+DeclareOperation( "ZeroVector", [ IsInt, IsMatrixOrMatrixObj ] );
 
 
 #############################################################################
@@ -822,13 +833,13 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareConstructor( "NewMatrix", [ IsMatrixObj, IsSemiring, IsInt, IsList] );
+DeclareConstructor( "NewMatrix", [ IsMatrixOrMatrixObj, IsSemiring, IsInt, IsList] );
 
 DeclareConstructor( "NewZeroMatrix",
-    [ IsMatrixObj, IsSemiring, IsInt, IsInt ] );
+    [ IsMatrixOrMatrixObj, IsSemiring, IsInt, IsInt ] );
 
 DeclareConstructor( "NewIdentityMatrix",
-    [ IsMatrixObj, IsSemiring, IsInt ] );
+    [ IsMatrixOrMatrixObj, IsSemiring, IsInt ] );
 
 
 #############################################################################
@@ -861,7 +872,7 @@ DeclareConstructor( "NewIdentityMatrix",
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "ChangedBaseDomain", [ IsVectorObj, IsSemiring ] );
-DeclareOperation( "ChangedBaseDomain", [ IsMatrixObj, IsSemiring ] );
+DeclareOperation( "ChangedBaseDomain", [ IsMatrixOrMatrixObj, IsSemiring ] );
 
 
 ############################################################################
@@ -892,8 +903,8 @@ DeclareOperation( "ChangedBaseDomain", [ IsMatrixObj, IsSemiring ] );
 ##
 DeclareOperation( "Randomize", [ IsVectorObj and IsMutable ] );
 DeclareOperation( "Randomize", [ IsRandomSource, IsVectorObj and IsMutable ] );
-DeclareOperation( "Randomize", [ IsMatrixObj and IsMutable ] );
-DeclareOperation( "Randomize", [ IsRandomSource, IsMatrixObj and IsMutable ] );
+DeclareOperation( "Randomize", [ IsMatrixOrMatrixObj and IsMutable ] );
+DeclareOperation( "Randomize", [ IsRandomSource, IsMatrixOrMatrixObj and IsMutable ] );
 
 
 #############################################################################
@@ -981,7 +992,7 @@ DeclareOperation( "DistanceOfVectors", [ IsVectorObj, IsVectorObj ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "ExtractSubMatrix", [ IsMatrixObj, IsList, IsList ] );
+DeclareOperation( "ExtractSubMatrix", [ IsMatrixOrMatrixObj, IsList, IsList ] );
 
 
 #############################################################################
@@ -1001,7 +1012,7 @@ DeclareOperation( "ExtractSubMatrix", [ IsMatrixObj, IsList, IsList ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "MutableCopyMatrix", [ IsMatrixObj ] );
+DeclareOperation( "MutableCopyMatrix", [ IsMatrixOrMatrixObj ] );
 
 
 #############################################################################
@@ -1028,7 +1039,7 @@ DeclareOperation( "MutableCopyMatrix", [ IsMatrixObj ] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "CopySubMatrix",
-    [ IsMatrixObj, IsMatrixObj, IsList, IsList, IsList, IsList ] );
+    [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj, IsList, IsList, IsList, IsList ] );
 
 
 #############################################################################
@@ -1057,7 +1068,7 @@ DeclareOperation( "CopySubMatrix",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperationKernel( "MatElm", [ IsMatrixObj, IS_INT, IS_INT ], ELM_MAT );
+DeclareOperationKernel( "MatElm", [ IsMatrixOrMatrixObj, IS_INT, IS_INT ], ELM_MAT );
 DeclareSynonym( "[,]", ELM_MAT );
 
 
@@ -1090,7 +1101,7 @@ DeclareSynonym( "[,]", ELM_MAT );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperationKernel( "SetMatElm", [ IsMatrixObj, IsInt, IsInt, IsObject ],
+DeclareOperationKernel( "SetMatElm", [ IsMatrixOrMatrixObj, IsInt, IsInt, IsObject ],
     ASS_MAT );
 #T We want to require also 'IsMutable' for the first argument,
 #T but some package may have installed methods without this requirement.
@@ -1136,7 +1147,7 @@ DeclareSynonym( "[,]:=", ASS_MAT );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "ZeroMatrix", [ IsInt, IsInt, IsMatrixObj ] );
+DeclareOperation( "ZeroMatrix", [ IsInt, IsInt, IsMatrixOrMatrixObj ] );
 DeclareOperation( "ZeroMatrix", [ IsSemiring, IsInt, IsInt ] );
 DeclareOperation( "ZeroMatrix", [ IsOperation, IsSemiring, IsInt, IsInt ] );
 
@@ -1175,7 +1186,7 @@ DeclareOperation( "ZeroMatrix", [ IsOperation, IsSemiring, IsInt, IsInt ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "IdentityMatrix", [ IsInt, IsMatrixObj ] );
+DeclareOperation( "IdentityMatrix", [ IsInt, IsMatrixOrMatrixObj ] );
 DeclareOperation( "IdentityMatrix", [ IsSemiring, IsInt ] );
 DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 
@@ -1219,7 +1230,7 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  to a possible constructor 'NewCompanionMatrix'.)
 ##
 DeclareOperation( "CompanionMatrix",
-    [ IsUnivariatePolynomial, IsMatrixObj ] );
+    [ IsUnivariatePolynomial, IsMatrixOrMatrixObj ] );
 DeclareOperation( "CompanionMatrix",
     [ IsOperation, IsUnivariatePolynomial, IsSemiring ] );
 
@@ -1306,13 +1317,13 @@ DeclareOperation( "CompanionMatrix",
 ##
 DeclareOperation( "Matrix", [ IsOperation, IsSemiring, IsList, IsInt ] );
 DeclareOperation( "Matrix", [ IsOperation, IsSemiring, IsList ] );
-DeclareOperation( "Matrix", [ IsOperation, IsSemiring, IsMatrixObj ] );
+DeclareOperation( "Matrix", [ IsOperation, IsSemiring, IsMatrixOrMatrixObj ] );
 DeclareOperation( "Matrix", [ IsSemiring, IsList, IsInt ] );
 DeclareOperation( "Matrix", [ IsSemiring, IsList ] );
-DeclareOperation( "Matrix", [ IsSemiring, IsMatrixObj ] );
-DeclareOperation( "Matrix", [ IsList, IsInt, IsMatrixObj ] );
-DeclareOperation( "Matrix", [ IsList, IsMatrixObj ] );
-DeclareOperation( "Matrix", [ IsMatrixObj, IsMatrixObj ] );
+DeclareOperation( "Matrix", [ IsSemiring, IsMatrixOrMatrixObj ] );
+DeclareOperation( "Matrix", [ IsList, IsInt, IsMatrixOrMatrixObj ] );
+DeclareOperation( "Matrix", [ IsList, IsMatrixOrMatrixObj ] );
+DeclareOperation( "Matrix", [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ] );
 DeclareOperation( "Matrix", [ IsList, IsInt ] );
 DeclareOperation( "Matrix", [ IsList ]);
 
@@ -1340,7 +1351,7 @@ DeclareOperation( "Matrix", [ IsList ]);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "CompatibleVector", [ IsMatrixObj ] );
+DeclareOperation( "CompatibleVector", [ IsMatrixOrMatrixObj ] );
 
 
 ############################################################################
@@ -1372,7 +1383,7 @@ DeclareOperation( "CompatibleVector", [ IsMatrixObj ] );
 ##  entering a template vector as the second argument is not an option
 ##  in this situation.
 ##
-DeclareAttribute( "RowsOfMatrix", IsMatrixObj );
+DeclareAttribute( "RowsOfMatrix", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -1671,7 +1682,7 @@ DeclareOperation( "ListOp", [ IsRowListMatrix, IsFunction ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsEmptyMatrix", IsMatrixObj );
+DeclareProperty( "IsEmptyMatrix", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -1696,7 +1707,7 @@ DeclareProperty( "IsEmptyMatrix", IsMatrixObj );
 # In the following sense matrices behave like lists:
 ############################################################################
 
-DeclareOperation( "[]", [IsMatrixObj,IsPosInt] );  # <mat>, <pos>
+DeclareOperation( "[]", [IsMatrixOrMatrixObj,IsPosInt] );  # <mat>, <pos>
 # This is guaranteed to return a vector object that has the property
 # that changing it changes <pos>th row (?) of the matrix <mat>!
 # A matrix which is not a row-lists internally has to create an intermediate object that refers to some
@@ -1744,7 +1755,7 @@ DeclareSynonym( "IsRowVectorObj", IsVectorObj );
 ##  only for backwards compatibility with existing code:
 ##  <matobj> -> [ NrRows( <matobj> ), NrCols( <matobj> ) ]
 ##
-DeclareAttribute( "DimensionsMat", IsMatrixObj );
+DeclareAttribute( "DimensionsMat", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -1754,7 +1765,7 @@ DeclareAttribute( "DimensionsMat", IsMatrixObj );
 ##
 ##  They had been used in older versions.
 ##
-DeclareAttribute( "Length", IsMatrixObj );
+DeclareAttribute( "Length", IsMatrixOrMatrixObj );
 DeclareSynonymAttr( "RowLength", NumberColumns );
 
 
@@ -1769,7 +1780,7 @@ DeclareSynonymAttr( "RowLength", NumberColumns );
 ##  We should use 'CompanionMatrix' instead of 'NewCompanionMatrix'.
 ##
 DeclareConstructor( "NewCompanionMatrix",
-    [ IsMatrixObj, IsUnivariatePolynomial, IsSemiring ] );
+    [ IsMatrixOrMatrixObj, IsUnivariatePolynomial, IsSemiring ] );
 
 
 #############################################################################
@@ -1786,7 +1797,7 @@ DeclareSynonym( "NewRowVector", NewVector );
 ##  for backwards compatibility with the cvec package
 ##
 DeclareOperation( "Randomize", [ IsVectorObj and IsMutable, IsRandomSource ] );
-DeclareOperation( "Randomize", [ IsMatrixObj and IsMutable, IsRandomSource ] );
+DeclareOperation( "Randomize", [ IsMatrixOrMatrixObj and IsMutable, IsRandomSource ] );
 
 
 #############################################################################
@@ -1794,8 +1805,8 @@ DeclareOperation( "Randomize", [ IsMatrixObj and IsMutable, IsRandomSource ] );
 #O  <matobj>[ <i>, <j> ]
 #O  <matobj>[ <i>, <j> ]:= <obj>
 ##
-DeclareOperation( "[]", [ IsMatrixObj, IsPosInt, IsPosInt ] );
-DeclareOperation( "[]:=", [ IsMatrixObj, IsPosInt, IsPosInt, IsObject ] );
+DeclareOperation( "[]", [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt ] );
+DeclareOperation( "[]:=", [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt, IsObject ] );
 
 
 #############################################################################

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -59,7 +59,7 @@ DeclareGlobalFunction("PrintArray");
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareProperty( "IsGeneralizedCartanMatrix", IsMatrixObj );
+DeclareProperty( "IsGeneralizedCartanMatrix", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -87,7 +87,7 @@ DeclareProperty( "IsGeneralizedCartanMatrix", IsMatrixObj );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsDiagonalMatrix", IsMatrixObj );
+DeclareProperty( "IsDiagonalMatrix", IsMatrixOrMatrixObj );
 
 DeclareSynonym( "IsDiagonalMat", IsDiagonalMatrix );
 
@@ -117,7 +117,7 @@ DeclareSynonym( "IsDiagonalMat", IsDiagonalMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsUpperTriangularMatrix", IsMatrixObj );
+DeclareProperty( "IsUpperTriangularMatrix", IsMatrixOrMatrixObj );
 
 DeclareSynonym( "IsUpperTriangularMat", IsUpperTriangularMatrix );
 
@@ -147,7 +147,7 @@ DeclareSynonym( "IsUpperTriangularMat", IsUpperTriangularMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsLowerTriangularMatrix", IsMatrixObj );
+DeclareProperty( "IsLowerTriangularMatrix", IsMatrixOrMatrixObj );
 
 DeclareSynonym( "IsLowerTriangularMat", IsLowerTriangularMatrix );
 
@@ -321,7 +321,7 @@ DeclareAttribute( "DepthOfUpperTriangularMatrix", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "DeterminantMatrix", IsMatrixObj );
+DeclareAttribute( "DeterminantMatrix", IsMatrixOrMatrixObj );
 DeclareSynonymAttr( "DeterminantMat", DeterminantMatrix );
 
 
@@ -353,7 +353,7 @@ DeclareSynonymAttr( "DeterminantMat", DeterminantMatrix );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "DeterminantMatrixDestructive",
-    [ IsMatrixObj and IsMutable] );
+    [ IsMatrixOrMatrixObj and IsMutable] );
 DeclareSynonym( "DeterminantMatDestructive", DeterminantMatrixDestructive );
 
 
@@ -375,7 +375,7 @@ DeclareSynonym( "DeterminantMatDestructive", DeterminantMatrixDestructive );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "DeterminantMatrixDivFree", [ IsMatrixObj ] );
+DeclareOperation( "DeterminantMatrixDivFree", [ IsMatrixOrMatrixObj ] );
 DeclareSynonym( "DeterminantMatDivFree", DeterminantMatrixDivFree );
 
 
@@ -767,7 +767,7 @@ DeclareGlobalFunction( "OrderMatTrial" );
 ##  <#/GAPDoc>
 #T suitable definition? example for a 'fail' result?
 ##
-DeclareAttribute( "RankMatrix", IsMatrixObj );
+DeclareAttribute( "RankMatrix", IsMatrixOrMatrixObj );
 DeclareSynonymAttr( "RankMat", RankMatrix );
 
 
@@ -788,7 +788,7 @@ DeclareSynonymAttr( "RankMat", RankMatrix );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareOperation( "RankMatrixDestructive", [ IsMatrixObj and IsMutable ]);
+DeclareOperation( "RankMatrixDestructive", [ IsMatrixOrMatrixObj and IsMutable ]);
 DeclareSynonymAttr( "RankMatDestructive", RankMatrixDestructive );
 
 
@@ -1013,12 +1013,12 @@ DeclareOperation( "SemiEchelonMatsDestructive", [ IsList ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "TransposedMatImmutable", IsMatrixObj );
+DeclareAttribute( "TransposedMatImmutable", IsMatrixOrMatrixObj );
 
 DeclareSynonymAttr( "TransposedMatAttr", TransposedMatImmutable );
 DeclareSynonymAttr( "TransposedMat", TransposedMatImmutable );
 
-DeclareOperation( "TransposedMatMutable", [ IsMatrixObj ] );
+DeclareOperation( "TransposedMatMutable", [ IsMatrixOrMatrixObj ] );
 DeclareSynonym( "TransposedMatOp", TransposedMatMutable );
 DeclareSynonym( "MutableTransposedMat", TransposedMatMutable ); # needed?
 
@@ -1137,7 +1137,7 @@ DeclareOperation( "InverseMatMod", [ IsMatrix, IsObject ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "KroneckerProduct", [ IsMatrixObj, IsMatrixObj ] );
+DeclareOperation( "KroneckerProduct", [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ] );
 #T state how mutable the result is!
 
 
@@ -1309,7 +1309,7 @@ DeclareOperation( "TriangulizeMat", [ IsMatrix and IsMutable ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "UpperSubdiagonal", [ IsMatrixObj, IsPosInt ] );
+DeclareOperation( "UpperSubdiagonal", [ IsMatrixOrMatrixObj, IsPosInt ] );
 
 
 #############################################################################
@@ -1846,7 +1846,7 @@ DeclareGlobalFunction( "SimultaneousEigenvalues" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "TraceMatrix", IsMatrixObj );
+DeclareAttribute( "TraceMatrix", IsMatrixOrMatrixObj );
 DeclareSynonymAttr( "TraceMat", TraceMatrix );
 
 

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -136,7 +136,7 @@ InstallMethod( Display,
 ##
 InstallMethod( IsGeneralizedCartanMatrix,
     "for a matrix",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( A )
 
     local n, i, j;
@@ -172,7 +172,7 @@ InstallMethod( IsGeneralizedCartanMatrix,
 ##
 InstallMethod( IsDiagonalMatrix,
     "for a matrix",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( mat )
     local  i, j, z;
     z:=ZeroOfBaseDomain(mat);
@@ -186,7 +186,7 @@ InstallMethod( IsDiagonalMatrix,
     return true;
     end);
 
-InstallTrueMethod( IsDiagonalMatrix, IsMatrixObj and IsEmptyMatrix );
+InstallTrueMethod( IsDiagonalMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
 
 
 #############################################################################
@@ -213,7 +213,7 @@ InstallOtherMethod( IsDiagonalMatrix, [ IsList and IsEmpty ], x -> true );
 ##
 InstallMethod( IsUpperTriangularMatrix,
     "for a matrix",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( mat )
     local  i, j, z;
     z:=ZeroOfBaseDomain(mat);
@@ -234,7 +234,7 @@ InstallMethod( IsUpperTriangularMatrix,
 ##
 InstallMethod( IsLowerTriangularMatrix,
     "for a matrix",
-    [ IsMatrixObj ],
+    [ IsMatrixOrMatrixObj ],
     function( mat )
     local  i, j, z;
     z:=ZeroOfBaseDomain(mat);
@@ -3087,7 +3087,7 @@ mat -> []);
 #M  UpperSubdiagonal( <mat>, <pos> )
 ##
 InstallMethod( UpperSubdiagonal,
-    [ IsMatrixObj, IsPosInt ],
+    [ IsMatrixOrMatrixObj, IsPosInt ],
 function( mat, l )
     return List( [ 1 .. Minimum( NrRows( mat ), NrCols( mat ) - l ) ],
                  i -> mat[ i, l+i ] );
@@ -4015,7 +4015,7 @@ InstallMethod( DefaultScalarDomainOfMatrixList,
     function(l)
     local B, i,j,k,fg,f;
     # try to find out the field
-    if Length( l ) = 0 or ForAny( l, i -> not IsMatrixObj( i ) ) then
+    if Length( l ) = 0 or ForAny( l, i -> not IsMatrixOrMatrixObj( i ) ) then
       Error( "<l> must be a nonempty list of matrices" );
     elif ForAll( l, HasBaseDomain ) then
       B:= BaseDomain( l[1] );
@@ -4399,7 +4399,7 @@ end);
 
 InstallMethod( \^,
     "for matrices, use char. poly. for large exponents",
-    [ IsMatrixObj, IsPosInt ], POW_MAT_INT );
+    [ IsMatrixOrMatrixObj, IsPosInt ], POW_MAT_INT );
 
 InstallGlobalFunction(RationalCanonicalFormTransform,function(mat)
 local cr,R,x,com,nf,matt,p,i,j,di,d,v;

--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -28,11 +28,14 @@ InstallGlobalFunction( GeneratorsWithMemory,
       o := l[i];
       r := rec(slp := slp, n := i, el := o);
       Objectify(TypeOfObjWithMemory(FamilyObj(o)),r);
-      if IsMatrix(o) then
+      if IsMatrixOrMatrixObj(o) then
+        SetFilterObj(r,IsMatrixOrMatrixObj);
+        if IsMatrix(o) then
           SetFilterObj(r,IsMatrix);
-      fi;
-      if IsMatrixObj(o) then
+        fi;
+        if IsMatrixObj(o) then
           SetFilterObj(r,IsMatrixObj);
+        fi;
       fi;
       Add(ll,r);
     od;
@@ -200,11 +203,14 @@ InstallMethod( \*, "objects with memory", true,
         Add(slp.prog,[a!.n,1,b!.n,1]);
     fi;
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
-    if IsMatrix(a) then
+    if IsMatrixOrMatrixObj(a) then
+      SetFilterObj(r,IsMatrixOrMatrixObj);
+      if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
-    fi;
-    if IsMatrixObj(a) then
+      fi;
+      if IsMatrixObj(a) then
         SetFilterObj(r,IsMatrixObj);
+      fi;
     fi;
     return r;
   end);
@@ -215,11 +221,14 @@ InstallMethod( One, "objects with memory", true,
     local r;
     r := rec(slp := a!.slp, n := 0, el := One(a!.el));
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
-    if IsMatrix(a) then
+    if IsMatrixOrMatrixObj(a) then
+      SetFilterObj(r,IsMatrixOrMatrixObj);
+      if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
-    fi;
-    if IsMatrixObj(a) then
+      fi;
+      if IsMatrixObj(a) then
         SetFilterObj(r,IsMatrixObj);
+      fi;
     fi;
     return r;
   end);
@@ -230,11 +239,14 @@ InstallMethod( OneOp, "objects with memory", true,
     local r;
     r := rec(slp := a!.slp, n := 0, el := One(a!.el));
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
-    if IsMatrix(a) then
+    if IsMatrixOrMatrixObj(a) then
+      SetFilterObj(r,IsMatrixOrMatrixObj);
+      if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
-    fi;
-    if IsMatrixObj(a) then
+      fi;
+      if IsMatrixObj(a) then
         SetFilterObj(r,IsMatrixObj);
+      fi;
     fi;
     return r;
   end);
@@ -252,11 +264,14 @@ InstallMethod( InverseOp, "objects with memory", true,
         r := rec(slp := slp, n := 0, el := a!.el);
     fi;
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
-    if IsMatrix(a) then
+    if IsMatrixOrMatrixObj(a) then
+      SetFilterObj(r,IsMatrixOrMatrixObj);
+      if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
-    fi;
-    if IsMatrixObj(a) then
+      fi;
+      if IsMatrixObj(a) then
         SetFilterObj(r,IsMatrixObj);
+      fi;
     fi;
     return r;
   end);
@@ -273,11 +288,14 @@ InstallMethod( \^, "objects with memory", true,
         Add(slp.prog,[a!.n,b]);
     fi;
     Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
-    if IsMatrix(a) then
+    if IsMatrixOrMatrixObj(a) then
+      SetFilterObj(r,IsMatrixOrMatrixObj);
+      if IsMatrix(a) then
         SetFilterObj(r,IsMatrix);
-    fi;
-    if IsMatrixObj(a) then
+      fi;
+      if IsMatrixObj(a) then
         SetFilterObj(r,IsMatrixObj);
+      fi;
     fi;
     return r;
   end);
@@ -398,19 +416,19 @@ InstallOtherMethod(CycleStructurePerm,
 # MatrixObj methods:
 
 InstallOtherMethod( BaseDomain, "for a matrix with memory",
-  [ IsMatrixObj and IsObjWithMemory ],
+  [ IsMatrixOrMatrixObj and IsObjWithMemory ],
   M -> BaseDomain(M!.el) );
 
 InstallOtherMethod( NumberRows, "for a matrix with memory",
-  [ IsMatrixObj and IsObjWithMemory ],
+  [ IsMatrixOrMatrixObj and IsObjWithMemory ],
   M -> NumberRows(M!.el) );
 
 InstallOtherMethod( NumberColumns, "for a matrix with memory",
-  [ IsMatrixObj and IsObjWithMemory ],
+  [ IsMatrixOrMatrixObj and IsObjWithMemory ],
   M -> NumberColumns(M!.el) );
 
 InstallOtherMethod( MatElm, "for a matrix with memory",
-  [ IsMatrixObj and IsObjWithMemory, IsPosInt, IsPosInt ],
+  [ IsMatrixOrMatrixObj and IsObjWithMemory, IsPosInt, IsPosInt ],
   { M, i, j } -> M!.el[i,j] );
 
 # legacy matrix methods
@@ -431,11 +449,11 @@ InstallOtherMethod( \*, "for a row vector and a matrix with memory",
   end);
 
 InstallOtherMethod( \*, "for a scalar and a matrix with memory",
-  [ IsScalar, IsMatrixObj and IsObjWithMemory ], 0,
+  [ IsScalar, IsMatrixOrMatrixObj and IsObjWithMemory ], 0,
   { s, M } ->  s * M!.el );
 
 InstallOtherMethod( \*, "for a matrix with memory and a scalar",
-  [ IsMatrixObj and IsObjWithMemory, IsScalar ], 0,
+  [ IsMatrixOrMatrixObj and IsObjWithMemory, IsScalar ], 0,
   { M , s} ->  M!.el * s );
 
 InstallOtherMethod(ProjectiveOrder,"object with memory", 

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -411,9 +411,16 @@ Obj GAP_NewPlist(Int capacity)
 //// matrix obj
 ////
 
+static Obj IsMatrixOrMatrixObjFilt;
 static Obj IsMatrixObjFilt;
 static Obj NrRowsAttr;
 static Obj NrColsAttr;
+
+// Returns 1 if <obj> is a GAP matrix or matrix obj, 0 if not.
+int GAP_IsMatrixOrMatrixObj(Obj obj)
+{
+    return obj && DoFilter(IsMatrixOrMatrixObjFilt, obj) == True;
+}
 
 // Returns 1 if <obj> is a GAP matrix obj, 0 if not.
 int GAP_IsMatrixObj(Obj obj)
@@ -608,6 +615,7 @@ void GAP_Error_Postjmp_Returning_(void)
 */
 static Int InitKernel(StructInitInfo * module)
 {
+    InitFopyGVar("IsMatrixOrMatrixObj", &IsMatrixOrMatrixObjFilt);
     InitFopyGVar("IsMatrixObj", &IsMatrixObjFilt);
     InitFopyGVar("NrRows", &NrRowsAttr);
     InitFopyGVar("NrCols", &NrColsAttr);

--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -374,6 +374,9 @@ Obj GAP_NewPlist(Int capacity);
 //// matrix obj
 ////
 
+// Returns 1 if <obj> is a GAP matrix or matrix obj, 0 if not.
+int GAP_IsMatrixOrMatrixObj(Obj obj);
+
 // Returns 1 if <obj> is a GAP matrix obj, 0 if not.
 int GAP_IsMatrixObj(Obj obj);
 

--- a/tst/testlibgap/api.c
+++ b/tst/testlibgap/api.c
@@ -66,16 +66,21 @@ void matrices(void)
     mat = GAP_NewPlist(1);
     val = INTOBJ_INT(42);
 
-    assert(!GAP_IsMatrixObj(mat));   // empty list, not yet a matrix
+    assert(!GAP_IsMatrixOrMatrixObj(mat));   // empty list, not yet a matrix
+    assert(!GAP_IsMatrixObj(mat));
+    assert(!GAP_IsMatrixOrMatrixObj(0));
     assert(!GAP_IsMatrixObj(0));
+    assert(!GAP_IsMatrixOrMatrixObj(val));
     assert(!GAP_IsMatrixObj(val));
 
     row = GAP_NewPlist(2);
     GAP_AssList(row, 1, INTOBJ_INT(1));
     GAP_AssList(row, 2, INTOBJ_INT(2));
     GAP_AssList(mat, 1, row);
+    assert(!GAP_IsMatrixOrMatrixObj(row));
     assert(!GAP_IsMatrixObj(row));
-    assert(GAP_IsMatrixObj(mat));
+    assert(GAP_IsMatrixOrMatrixObj(mat));
+    assert(!GAP_IsMatrixObj(mat));   // list of lists, not proper matrix object
 
     GAP_AssMat(mat, 1, 1, val);
     ret = GAP_ElmMat(mat, 1, 1);

--- a/tst/testspecial/backtrace.g
+++ b/tst/testspecial/backtrace.g
@@ -96,7 +96,7 @@ WhereWithVars();
 quit;
 
 # Verify issue #2656 is fixed
-InstallMethod( \[\,\], [ IsMatrixObj, IsPosInt, IsPosInt ],
+InstallMethod( \[\,\], [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt ],
     { m, row, col } -> ELM_LIST( m, row, col ) );
 l := [[1]];; f := {} -> l[2,1];;
 f();

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -313,7 +313,7 @@ brk> WhereWithVars();
 brk> quit;
 gap> 
 gap> # Verify issue #2656 is fixed
-gap> InstallMethod( \[\,\], [ IsMatrixObj, IsPosInt, IsPosInt ],
+gap> InstallMethod( \[\,\], [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt ],
 >     { m, row, col } -> ELM_LIST( m, row, col ) );
 gap> l := [[1]];; f := {} -> l[2,1];;
 gap> f();


### PR DESCRIPTION
as sketched in issue #4503.

In this first step, I have changed the documentation of the defining filters and replaced `IsMatrixObj` by `IsMatrixOrMatrixObj` in most places.

(In a next step, we can now change the method installations mentioned in issue #4503.)