### PR TITLE
Make third argument of `DeclareRepresentation` and `NewRepresentation` optional, and document that it and the fourth argument are (and always were) unused

### DIFF
--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -118,7 +118,7 @@ that is, <M>a_n = n/2</M> if <M>n</M> is even,
 and <M>a_n = (1-n)/2</M> otherwise.
 <P/>
 <Log><![CDATA[
-IsIntegersIteratorCompRep := NewRepresentation( "IsIntegersIteratorRep",
+DeclareRepresentation( "IsIntegersIteratorCompRep",
     IsComponentObjectRep, [ "counter" ] );
 ]]></Log>
 <P/>
@@ -220,7 +220,7 @@ See&nbsp;<Ref Sect="Component Objects"/> for an implementation using component o
 and more details.
 <P/>
 <Log><![CDATA[
-IsIntegersIteratorPosRep := NewRepresentation( "IsIntegersIteratorRep",
+DeclareRepresentation( "IsIntegersIteratorPosRep",
     IsPositionalObjectRep, [ 1 ] );
 ]]></Log>
 <P/>
@@ -236,7 +236,7 @@ InstallMethod( Iterator,
     function( Integers )
     return Objectify( NewType( IteratorsFamily,
                                    IsIterator
-                               and IsIntegersIteratorRep ),
+                               and IsIntegersIteratorPosRep ),
                       [ 0 ] );
     end );
 ]]></Log>

--- a/doc/ref/intrfc.xml
+++ b/doc/ref/intrfc.xml
@@ -382,7 +382,7 @@ implementation one would have to design this as well, but it does not affect
 the declarations this chapter is about).
 <P/>
 <Log><![CDATA[
-IsPermutationGroupByRelations:=NewRepresentation(
+DeclareRepresentation(
   "IsPermutationGroupByRelations",
   IsComponentObjectRep and IsAttributeStoringRep and IsPermGroup,
   ["degree","relations"]);

--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -33,8 +33,7 @@
 ##
 ##  
 
-BindGlobal("IsCoeffsModConwayPolRep", 
-        NewRepresentation( "IsCoeffsModConwayPolRep", IsPositionalObjectRep,3));
+DeclareRepresentation("IsCoeffsModConwayPolRep", IsPositionalObjectRep, 3);
 
 #############################################################################
 ##

--- a/lib/dict.gd
+++ b/lib/dict.gd
@@ -277,7 +277,7 @@ DeclareOperation("LookupDictionary",[IsDictionary,IsObject]);
 
 DeclareSynonym("GetHashEntry",LookupDictionary);
 
-IsDictionaryDefaultRep:=NewRepresentation("IsDictionaryDefaultRep",
+DeclareRepresentation("IsDictionaryDefaultRep",
   IsDictionary and IsNonAtomicComponentObjectRep,[]);
 
 #############################################################################
@@ -294,9 +294,9 @@ IsDictionaryDefaultRep:=NewRepresentation("IsDictionaryDefaultRep",
 ##  </Description>
 ##  </ManSection>
 ##
-IsListDictionary:=NewRepresentation("IsListDictionary",IsDictionaryDefaultRep,
+DeclareRepresentation("IsListDictionary",IsDictionaryDefaultRep,
   ["entries"] );
-IsListLookupDictionary:=NewRepresentation("IsListLookupDictionary",
+DeclareRepresentation("IsListLookupDictionary",
   IsListDictionary and IsLookupDictionary,
   ["entries"] );
 
@@ -328,9 +328,9 @@ DeclareOperation( "ListKeyEnumerator", [ IsListDictionary ] );
 ##  </Description>
 ##  </ManSection>
 ##
-IsSortDictionary:=NewRepresentation("IsSortDictionary",IsListDictionary,
+DeclareRepresentation("IsSortDictionary",IsListDictionary,
   ["entries"] );
-IsSortLookupDictionary:=NewRepresentation("IsSortLookupDictionary",
+DeclareRepresentation("IsSortLookupDictionary",
   IsSortDictionary and IsListLookupDictionary and IsLookupDictionary,
   ["entries"] );
 
@@ -349,9 +349,9 @@ IsSortLookupDictionary:=NewRepresentation("IsSortLookupDictionary",
 ##  </Description>
 ##  </ManSection>
 ##
-IsPositionDictionary:=NewRepresentation("IsPositionDictionary",
+DeclareRepresentation("IsPositionDictionary",
   IsDictionaryDefaultRep,["domain","blist"] );
-IsPositionLookupDictionary:=NewRepresentation("IsPositionLookupDictionary",
+DeclareRepresentation("IsPositionLookupDictionary",
   IsPositionDictionary and IsLookupDictionary,
   ["domain","blist","vals"] );
 

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -33,8 +33,7 @@
 ##
 ##  
 
-BindGlobal("IsCoeffsModConwayPolRep", 
-        NewRepresentation( "IsCoeffsModConwayPolRep", IsPositionalObjectRep,3));
+DeclareRepresentation("IsCoeffsModConwayPolRep", IsPositionalObjectRep, 3);
 
 #############################################################################
 ##

--- a/lib/info.gi
+++ b/lib/info.gi
@@ -471,5 +471,22 @@ end);
 ##  Warnings can be disabled entirely by setting its level to 0, and further
 ##  warnings can be switched on by setting its level to 2.
 ##
-DeclareInfoClass( "InfoObsolete" );
-SetInfoLevel(InfoObsolete,1);
+##  Also deal with INFO_OBSOLETE, similar to INFO_DEBUG / InfoDebug earlier in
+##  this file.
+##
+if not IsBound( InfoObsolete ) then
+  DeclareInfoClass( "InfoObsolete" );
+  SetInfoLevel( InfoObsolete, 1 );
+
+  MAKE_READ_WRITE_GLOBAL( "INFO_OBSOLETE" );
+  INFO_OBSOLETE:= function( arg )
+    local string, i;
+
+    string:= [];
+    for i in [ 2 .. LEN_LIST( arg ) ] do
+      APPEND_LIST_INTR( string, arg[i] );
+    od;
+    Info( InfoObsolete, arg[1], string );
+  end;
+  MAKE_READ_ONLY_GLOBAL( "INFO_OBSOLETE" );
+fi;

--- a/lib/mat8bit.gd
+++ b/lib/mat8bit.gd
@@ -17,8 +17,7 @@
 #R  Is8BitMatrixRep( <obj> ) . . . compressed vector over GFQ (3 <= q <= 256)
 ##
 DeclareRepresentation( "Is8BitMatrixRep", 
-        IsPositionalObjectRep and IsRowListMatrix,[],
-        IsMatrix );
+        IsPositionalObjectRep and IsRowListMatrix );
 
 
 #############################################################################

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -38,6 +38,28 @@ end );
 
 #############################################################################
 ##
+#F  INFO_OBSOLETE( <level>, ... )
+##
+##  <ManSection>
+##  <Func Name="INFO_OBSOLETE" Arg='level, ...'/>
+##
+##  <Description>
+##  This will delegate to the proper info class <C>InfoObsolete</C>
+##  as soon as the info classes are available.
+##  </Description>
+##  </ManSection>
+##
+BIND_GLOBAL( "INFO_OBSOLETE", function( arg )
+    if GAPInfo.CommandLineOptions.O then
+        Print( "#I  " );
+        CALL_FUNC_LIST( Print, arg{ [ 2 .. LEN_LIST( arg ) ] } );
+        Print( "\n" );
+    fi;
+end );
+
+
+#############################################################################
+##
 #V  CATS_AND_REPS
 ##
 ##  <ManSection>

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -32,6 +32,7 @@ INSTALL_METHOD := false;
 BIND_GLOBAL( "INFO_DEBUG", function( arg )
     Print( "#I  " );
     CALL_FUNC_LIST( Print, arg{ [ 2 .. LEN_LIST( arg ) ] } );
+    Print( "\n" );
 end );
 
 

--- a/lib/rwsdt.gi
+++ b/lib/rwsdt.gi
@@ -16,11 +16,8 @@
 ##
 #R  IsDeepThoughtCollectorRep( <obj> )
 ##
-DeclareRepresentation(
-         "IsDeepThoughtCollectorRep",
-         IsPositionalObjectRep,   
-         [1..PC_DEFAULT_TYPE],
-         IsPowerConjugateCollector);
+DeclareRepresentation( "IsDeepThoughtCollectorRep",
+         IsPositionalObjectRep);
 
 
 

--- a/lib/rwspccoc.gi
+++ b/lib/rwspccoc.gi
@@ -17,10 +17,8 @@
 ##
 #R  IsCombinatorialCollectorRep( <obj> )  . . . . . . . . . . . . declaration
 ##
-DeclareRepresentation(
-    "IsCombinatorialCollectorRep",
-    IsSingleCollectorRep, [1..SCP_CLASS],
-    IsPowerConjugateCollector and IsFinite );
+DeclareRepresentation( "IsCombinatorialCollectorRep",
+    IsSingleCollectorRep );
 
 
 #############################################################################

--- a/lib/rwspcsng.gi
+++ b/lib/rwspcsng.gi
@@ -22,40 +22,32 @@
 ##
 #R  IsSingleCollectorRep( <obj> )
 ##
-DeclareRepresentation(
-    "IsSingleCollectorRep",
-    IsPositionalObjectRep, [1..SCP_AVECTOR],
-    IsPowerConjugateCollector and IsFinite );
+DeclareRepresentation( "IsSingleCollectorRep",
+    IsPositionalObjectRep );
 
 
 #############################################################################
 ##
 #R  Is8BitsSingleCollectorRep( <obj> )
 ##
-DeclareRepresentation(
-    "Is8BitsSingleCollectorRep",
-    IsSingleCollectorRep, [],
-    IsPowerConjugateCollector and IsFinite );
+DeclareRepresentation( "Is8BitsSingleCollectorRep",
+    IsSingleCollectorRep );
 
 
 #############################################################################
 ##
 #R  Is16BitsSingleCollectorRep( <obj> )
 ##
-DeclareRepresentation(
-    "Is16BitsSingleCollectorRep",
-    IsSingleCollectorRep, [],
-    IsPowerConjugateCollector and IsFinite );
+DeclareRepresentation( "Is16BitsSingleCollectorRep",
+    IsSingleCollectorRep );
 
 
 #############################################################################
 ##
 #R  Is32BitsSingleCollectorRep( <obj> )
 ##
-DeclareRepresentation(
-    "Is32BitsSingleCollectorRep",
-    IsSingleCollectorRep, [],
-    IsPowerConjugateCollector and IsFinite );
+DeclareRepresentation( "Is32BitsSingleCollectorRep",
+    IsSingleCollectorRep );
 
 
 #############################################################################

--- a/lib/type.g
+++ b/lib/type.g
@@ -166,11 +166,11 @@ end );
 
 #############################################################################
 ##
-#F  NewRepresentation( <name>, <super>, <slots>[, <req>] )  .  representation
+#F  NewRepresentation( <name>, <super>[, <slots>[, <req>]] )  .  representation
 ##
 ##  <#GAPDoc Label="NewRepresentation">
 ##  <ManSection>
-##  <Func Name="NewRepresentation" Arg='name, super, slots[, req]'/>
+##  <Func Name="NewRepresentation" Arg='name, super[, slots[, req]]'/>
 ##
 ##  <Description>
 ##  <Ref Func="NewRepresentation"/> returns a new representation <A>rep</A>
@@ -190,25 +190,13 @@ end );
 ##  see&nbsp;<Ref Sect="Component Objects"/>
 ##  and&nbsp;<Ref Sect="Positional Objects"/> for the details.
 ##  <P/>
-##  The third argument <A>slots</A> is a list either of integers or of
-##  strings.
-##  In the former case,
-##  <A>rep</A> must be <Ref Filt="IsPositionalObjectRep"/> or a
-##  subrepresentation of it, and <A>slots</A> tells what positions of the
-##  objects in the representation <A>rep</A> may be bound.
-##  In the latter case,
-##  <A>rep</A> must be <Ref Filt="IsComponentObjectRep"/> or a
-##  subrepresentation of, and <A>slots</A> lists the admissible names of
-##  components that objects in the representation <A>rep</A> may have.
-##  The admissible positions resp. component names of <A>super</A> need not
-##  be listed in <A>slots</A>.
+##  The optional third and fourth arguments <A>slots</A> and <A>req</A> are
+##  (and always were) unused and are only provided for backwards
+##  compatibility. Note that <A>slots</A> was required (but still unused)
+##  before GAP 4.12.
 ##  <P/>
 ##  The incremental rank (see&nbsp;<Ref Sect="Filters"/>)
 ##  of <A>rep</A> is 1.
-##  <P/>
-##  Note that for objects in the representation <A>rep</A>,
-##  of course some of the component names and positions reserved via
-##  <A>slots</A> may be unbound.
 ##  <P/>
 ##  Examples for the use of <Ref Func="NewRepresentation"/> can be found
 ##  in&nbsp;<Ref Sect="Component Objects"/>,
@@ -218,15 +206,15 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BIND_GLOBAL( "NewRepresentation", function ( arg )
+BIND_GLOBAL( "NewRepresentation", function ( name, super, arg... )
     local   rep, filt;
 
     # Do *not* create a new representation when the file is reread.
     if REREADING then
         atomic readonly CATS_AND_REPS, readwrite FILTER_REGION do
             for filt in CATS_AND_REPS do
-                if NAME_FUNC(FILTERS[filt]) = arg[1] then
-                    Print("#W NewRepresentation \"",arg[1],"\" in Reread. ");
+                if NAME_FUNC(FILTERS[filt]) = name then
+                    Print("#W NewRepresentation \"",name,"\" in Reread. ");
                     Print("Change of Super-rep not handled\n");
                     return FILTERS[filt];
                 fi;
@@ -235,13 +223,10 @@ BIND_GLOBAL( "NewRepresentation", function ( arg )
     fi;
 
     # Create the filter.
-    if LEN_LIST(arg) = 3  then
-        rep := NEW_FILTER( arg[1] );
-    elif LEN_LIST(arg) = 4  then
-        rep := NEW_FILTER( arg[1] );
-    else
-        Error("usage: NewRepresentation( <name>, <super>, <slots> [, <req> ] )");
+    if LEN_LIST(arg) > 2 then
+        Error("usage: NewRepresentation( <name>, <super>[, <slots> [, <req> ]] )");
     fi;
+    rep := NEW_FILTER( name );
 
     # Do some administrational work.
     atomic readwrite CATS_AND_REPS, FILTER_REGION do
@@ -250,7 +235,7 @@ BIND_GLOBAL( "NewRepresentation", function ( arg )
     od;
 
     # Do not call this before adding 'rep' to 'FILTERS'.
-    InstallTrueMethodNewFilter( arg[2], rep );
+    InstallTrueMethodNewFilter( super, rep );
 
     # Return the filter.
     return rep;
@@ -259,11 +244,11 @@ end );
 
 #############################################################################
 ##
-#F  DeclareRepresentation( <name>, <super>, <slots> [,<req>] )
+#F  DeclareRepresentation( <name>, <super>[, <slots>[, <req>]] )
 ##
 ##  <#GAPDoc Label="DeclareRepresentation">
 ##  <ManSection>
-##  <Func Name="DeclareRepresentation" Arg='name, super, slots [,req]'/>
+##  <Func Name="DeclareRepresentation" Arg='name, super[, slots[, req]]'/>
 ##
 ##  <Description>
 ##  does the same as <Ref Func="NewRepresentation"/> and then binds

--- a/lib/type.g
+++ b/lib/type.g
@@ -225,6 +225,13 @@ BIND_GLOBAL( "NewRepresentation", function ( name, super, arg... )
     # Create the filter.
     if LEN_LIST(arg) > 2 then
         Error("usage: NewRepresentation( <name>, <super>[, <slots> [, <req> ]] )");
+    elif LEN_LIST(arg) > 0 then
+        INFO_OBSOLETE(3, "starting with GAP 4.12, the third argument <slots> is unused",
+            " in ", INPUT_FILENAME(), ":", STRING_INT(INPUT_LINENUMBER()));
+        if LEN_LIST(arg) = 2 then
+            INFO_OBSOLETE(2, "the fourth argument <req> is unused",
+                " in ", INPUT_FILENAME(), ":", STRING_INT(INPUT_LINENUMBER()));
+        fi;
     fi;
     rep := NEW_FILTER( name );
 

--- a/lib/type.g
+++ b/lib/type.g
@@ -331,19 +331,19 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareRepresentation( "IsInternalRep", IS_OBJECT, [], IS_OBJECT );
-DeclareRepresentation( "IsPositionalObjectRep", IS_OBJECT, [], IS_OBJECT );
-DeclareRepresentation( "IsComponentObjectRep", IS_OBJECT, [], IS_OBJECT );
-DeclareRepresentation( "IsDataObjectRep", IS_OBJECT, [], IS_OBJECT );
+DeclareRepresentation( "IsInternalRep", IS_OBJECT );
+DeclareRepresentation( "IsPositionalObjectRep", IS_OBJECT );
+DeclareRepresentation( "IsComponentObjectRep", IS_OBJECT );
+DeclareRepresentation( "IsDataObjectRep", IS_OBJECT );
 
 # the following are for HPC-GAP, but we also provide them in plain GAP, to
 # make it easier to write code which works in both.
 DeclareRepresentation( "IsNonAtomicComponentObjectRep",
-        IsComponentObjectRep, [], IS_OBJECT); 
+        IsComponentObjectRep );
 DeclareRepresentation( "IsReadOnlyPositionalObjectRep",
-        IsPositionalObjectRep, [], IS_OBJECT); 
+        IsPositionalObjectRep );
 DeclareRepresentation( "IsAtomicPositionalObjectRep",
-        IsPositionalObjectRep, [], IS_OBJECT); 
+        IsPositionalObjectRep );
 
 #############################################################################
 ##
@@ -404,8 +404,7 @@ DeclareRepresentation( "IsAtomicPositionalObjectRep",
 ##  (In earlier versions of GAP, a rule had been stated in a code file,
 ##  but this rule was not part of the manuals.)
 ##
-DeclareRepresentation( "IsAttributeStoringRep",
-    IsComponentObjectRep, [], IS_OBJECT );
+DeclareRepresentation( "IsAttributeStoringRep", IsComponentObjectRep );
 
 
 #############################################################################
@@ -420,15 +419,11 @@ DeclareCategory( "IsFamilyOfFamilies", IsFamily );
 DeclareCategory( "IsFamilyOfTypes"   , IsFamily );
 
 DeclareRepresentation( "IsFamilyDefaultRep",
-                            IsComponentObjectRep,
+                            IsComponentObjectRep );
 #T why not `IsAttributeStoringRep' ?
-                            "NAME,REQ_FLAGS,IMP_FLAGS,TYPES,TYPES_LIST_FAM",
-#T add nTypes, HASH_SIZE
-                            IsFamily );
 
 DeclareRepresentation( "IsTypeDefaultRep",
-                            IsPositionalObjectRep,
-                            "", IsType );
+                            IsPositionalObjectRep );
 
 if IsHPCGAP then
     BIND_GLOBAL( "FamilyOfFamilies", AtomicRecord( rec() ) );

--- a/lib/vec8bit.gd
+++ b/lib/vec8bit.gd
@@ -27,8 +27,7 @@ MakeImmutable(PRIMES_COMPACT_FIELDS);
 #R  Is8BitVectorRep( <obj> ) . . . compressed vector over GFQ (3 <= q <= 256)
 ##
 DeclareRepresentation( "Is8BitVectorRep", 
-        IsDataObjectRep and IsVectorObj,[],
-        IsRowVector and IsSmallList );
+        IsDataObjectRep and IsVectorObj );
 
 
 #############################################################################

--- a/lib/vecmat.gd
+++ b/lib/vecmat.gd
@@ -38,10 +38,9 @@ BIND_GLOBAL( "GF2Zero", 0*Z(2) );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareRepresentation(
-    "IsGF2VectorRep",
-    IsDataObjectRep and IsVectorObj, [],
-    IsRowVector );
+DeclareRepresentation( "IsGF2VectorRep",
+    IsDataObjectRep and IsVectorObj );
+
 
 #############################################################################
 ##
@@ -216,10 +215,8 @@ DeclareGlobalFunction( "ConvertToMatrixRep" );
 ##
 #R  IsGF2MatrixRep( <obj> ) . . . . . . . . . . . . . . . . . matrix over GF2
 ##
-DeclareRepresentation(
-    "IsGF2MatrixRep",
-    IsPositionalObjectRep and IsRowListMatrix, [],
-    IsMatrix );
+DeclareRepresentation( "IsGF2MatrixRep",
+    IsPositionalObjectRep and IsRowListMatrix );
 
 
 #############################################################################


### PR DESCRIPTION
See the commit messages for details.

See also issues #4409 and #1042