### PR TITLE
InstallMethod warnings: show location of offending code

### DIFF
--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -495,8 +495,10 @@ BIND_GLOBAL( "INSTALL_METHOD",
       if opr in WRAPPER_OPERATIONS then
         INFO_DEBUG( 1,
               "a method is installed for the wrapper operation ",
-              NAME_FUNC( opr ), "\n",
-              "#I  probably it should be installed for (one of) its\n",
+              NAME_FUNC( opr ), " in ",
+              INPUT_FILENAME(), ":", STRING_INT(INPUT_LINENUMBER()),
+              "\n",
+              "#I  it should probably be installed for (one of) its\n",
               "#I  underlying operation(s)" );
       fi;
 
@@ -584,7 +586,8 @@ BIND_GLOBAL( "INSTALL_METHOD",
             if match and reqs<>oreqs then
               INFO_DEBUG( 1,
                     "method installed for ", NAME_FUNC(opr), 
-                    " matches more than one declaration" );
+                    " matches more than one declaration in ",
+                    INPUT_FILENAME(), ":", STRING_INT(INPUT_LINENUMBER()));
             fi;
           fi;
         od;


### PR DESCRIPTION
Before this, one might get warnings like this:

    #I  method installed for MutableCopyMatrix matches more than one declaration
    #I  method installed for MutableCopyMatrix matches more than one declaration

Now one gets this:

    #I  method installed for MutableCopyMatrix matches more than one declaration in GAPROOT/lib/vecmat.gi:2329
    #I  method installed for MutableCopyMatrix matches more than one declaration in GAPROOT/lib/vec8bit.gi:995

Similar for the warning about installing methods for wrapper operations.
