### PR TITLE
Turn InducedPcgs into a global function

### DIFF
--- a/lib/grppc.gd
+++ b/lib/grppc.gd
@@ -156,7 +156,7 @@ DeclareAttribute( "InducedPcgsWrtFamilyPcgs", IsGroup );
 ##
 ##  <#GAPDoc Label="InducedPcgs">
 ##  <ManSection>
-##  <Oper Name="InducedPcgs" Arg='pcgs, grp'/>
+##  <Func Name="InducedPcgs" Arg='pcgs, grp'/>
 ##
 ##  <Description>
 ##  computes a pcgs for <A>grp</A> which is induced by <A>pcgs</A>.
@@ -170,7 +170,7 @@ DeclareAttribute( "InducedPcgsWrtFamilyPcgs", IsGroup );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "InducedPcgs", [IsPcgs,IsGroup] );
+DeclareGlobalFunction( "InducedPcgs" );
 
 #############################################################################
 ##

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -103,10 +103,16 @@ InstallMethod( InducedPcgsWrtHomePcgs,"pc group: home=family", true,
 ##
 #M  InducedPcgs( <pcgs>,<G> )
 ##
-InstallMethod( InducedPcgs, "cache pcgs", true, [ IsPcgs,IsGroup ], 0,
-function(pcgs, G )
+InstallGlobalFunction( InducedPcgs, function(pcgs, G)
   local cache, i, igs;
   
+  if not IsPcgs(pcgs) then
+     Error("InducedPcgs: <pcgs> must be a pcgs");
+  fi;
+  if not IsGroup(G) then
+     Error("InducedPcgs: <G> must be a group");
+  fi;
+
   pcgs := ParentPcgs (pcgs);
   cache := ComputedInducedPcgses(G);
   i := 1;
@@ -135,10 +141,6 @@ function(pcgs, G )
   
   return igs;
 end );
-
-atomic readwrite OPERATIONS_REGION do
-ADD_LIST(WRAPPER_OPERATIONS, InducedPcgs);
-od;
 
 #############################################################################
 ##


### PR DESCRIPTION
This way we don't have to mess with `WRAPPER_OPERATIONS` to prevent
people from installing methods for it.
