### PR TITLE
FIX: Work around 0x0 matrices now being impossible

### DIFF
--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -272,6 +272,7 @@ local mat, n, one, zerovec, i, k, nullspace, row;
 
   # insert zero rows to bring the leading term of each row on the diagonal
   if mat = [] then
+    if n=0 then return [];fi;
     mat := ZeroMatrix(e.field, n, n);
   else
     zerovec := MakeImmutable(ZeroVector(n, mat));


### PR DESCRIPTION
Needed, as a consequence of changes in the matrix code.

This resolves #4514
