### PR TITLE
Remove GAPInfo.FormattingStatusStdout

### DIFF
--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1222,13 +1222,12 @@ InstallMethod( SetPrintFormattingStatus, "output text file",
 end);
 
 ##  formatting status for stdout
-GAPInfo.FormattingStatusStdout := true;
 InstallOtherMethod( PrintFormattingStatus, "for stdout", [IsString],
 function(str)
   if str <> "*stdout*" then
     Error("Only the string \"*stdout*\" is recognized by this method.");
   fi;
-  return GAPInfo.FormattingStatusStdout;
+  return PRINT_FORMATTING_STDOUT();
 end);
 
 InstallOtherMethod( SetPrintFormattingStatus, "for stdout", [IsString, IsBool],
@@ -1238,10 +1237,8 @@ function(str, status)
   fi;
   if status = false then
     SET_PRINT_FORMATTING_STDOUT(false);
-    GAPInfo.FormattingStatusStdout := false;
   else
     SET_PRINT_FORMATTING_STDOUT(true);
-    GAPInfo.FormattingStatusStdout := true;
   fi;
 end);
 

--- a/src/io.c
+++ b/src/io.c
@@ -1872,6 +1872,16 @@ static Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val)
     return val;
 }
 
+static Obj FuncPRINT_FORMATTING_STDOUT(Obj self)
+{
+    TypOutputFile * output = IO()->Output;
+    if (!output)
+        ErrorMayQuit("PRINT_FORMATTING_STDOUT called while no output is opened\n", 0, 0);
+    while (output->prev)
+        output = output->prev;
+    return output->format ? True : False;
+}
+
 static Obj FuncIS_INPUT_TTY(Obj self)
 {
     GAP_ASSERT(IO()->Input);
@@ -1902,6 +1912,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC_0ARGS(INPUT_FILENAME),
     GVAR_FUNC_0ARGS(INPUT_LINENUMBER),
     GVAR_FUNC_1ARGS(SET_PRINT_FORMATTING_STDOUT, format),
+    GVAR_FUNC_0ARGS(PRINT_FORMATTING_STDOUT),
     GVAR_FUNC_0ARGS(IS_INPUT_TTY),
     GVAR_FUNC_0ARGS(IS_OUTPUT_TTY),
     GVAR_FUNC_0ARGS(GET_FILENAME_CACHE),


### PR DESCRIPTION
... and instead use a new kernel helper function PRINT_FORMATTING_STDOUT().
This way we only track this piece of state once, in the kernel; tracking
something twice always carries the risk of getting out of sync.
