### PR TITLE
improved `SizeOfFieldOfDefinition`

### DIFF
--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -2737,18 +2737,26 @@ DeclareGlobalFunction( "ZevDataValue" );
 ##  and a prime integer <A>p</A>, <Ref Func="SizeOfFieldOfDefinition"/>
 ##  returns the size of the smallest finite field
 ##  in characteristic <A>p</A> that contains the <A>p</A>-modular reduction
-##  of <A>val</A>.
+##  of <A>val</A> if this can be determined, and <K>fail</K> otherwise.
 ##  <P/>
-##  The reduction map is defined as in&nbsp;<Cite Key="JLPW95"/>,
+##  The latter happens if <A>val</A> is not closed under Galois conjugacy
+##  and if the <A>p</A>-modular reduction of some value cannot be determined
+##  via the function <Ref Func="FrobeniusCharacterValue"/>.
+##  Note that the reduction map is defined as in&nbsp;<Cite Key="JLPW95"/>,
 ##  that is, the complex <M>(<A>p</A>^d-1)</M>-th root of unity
 ##  <M>\exp(<A>p</A>^d-1)</M> is mapped to the residue class of the
 ##  indeterminate, modulo the ideal spanned by the Conway polynomial
 ##  (see&nbsp;<Ref Func="ConwayPolynomial"/>) of degree <M>d</M> over the
 ##  field with <M>p</M> elements.
 ##  <P/>
-##  If <A>val</A> is a Brauer character then the value returned is the size
-##  of the smallest finite field in characteristic <A>p</A> over which the
-##  corresponding representation lives.
+##  If <A>val</A> is closed under Galois conjugacy then the result can be
+##  determined without explicitly computing the <A>p</A>-modular reduction
+##  of <A>val</A>.
+##  This happens for example if <A>val</A> is a Brauer character.
+##  <P/>
+##  If <A>val</A> is an irreducible Brauer character then the value returned
+##  is the size of the smallest finite field in characteristic <A>p</A>
+##  over which the corresponding representation lives.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/tst/testinstall/ctblfuns.tst
+++ b/tst/testinstall/ctblfuns.tst
@@ -1,4 +1,4 @@
-#@local S4,V4,irr,l
+#@local S4,V4,irr,l, tbl, v
 gap> START_TEST("ctblfuns.tst");
 gap> S4:= SymmetricGroup( 4 );
 Sym( [ 1 .. 4 ] )
@@ -27,4 +27,42 @@ gap> ForAll(AllSmallGroups(12),g -> IsInternallyConsistent(CharacterTable(g) mod
 true
 gap> ForAll(AllSmallGroups(12),g -> IsInternallyConsistent(TableOfMarks(g)));
 true
+
+# Up to GAP 4.11.1, the following returned 'fail' results.
+gap> tbl:= CharacterTable( "J1" );;
+gap> List( Filtered( Irr( tbl ), x -> x[1] = 120 ),
+>          x -> SizeOfFieldOfDefinition( x, 71 ) );
+[ 357911, 357911, 357911 ]
+
+# other situations for 'SizeOfFieldOfDefinition'
+gap> SizeOfFieldOfDefinition( 17, 2 );
+2
+gap> SizeOfFieldOfDefinition( E(7), 2 );
+8
+gap> SizeOfFieldOfDefinition( [ E(7) ], 2 );
+8
+gap> SizeOfFieldOfDefinition( E(7) / 2, 2 );
+fail
+gap> SizeOfFieldOfDefinition( E(8), 2 );
+fail
+gap> SizeOfFieldOfDefinition( E(4), 5 );
+5
+gap> SizeOfFieldOfDefinition( EX(63), 2 );
+2
+gap> SizeOfFieldOfDefinition( GaloisCyc( EX(63), -1 ), 2 );
+4
+gap> v:= Conjugates( CF(8), E(8) + 4*E(8)^3 );;
+gap> SizeOfFieldOfDefinition( v, 3 );
+3
+gap> v = List( v, x -> GaloisCyc( x, 3 ) );
+false
+gap> ForAll( ( v - List( v, x -> GaloisCyc( x, 3 ) ) ) / 3, IsCycInt );
+true
+gap> SizeOfFieldOfDefinition( EC(19), 71 );
+#I  the Conway polynomial of degree 18 for p = 71 is not known
+fail
+gap> SizeOfFieldOfDefinition( Z(25), 5 );
+Error, <val> must be a cyclotomic or a list of cyclotomics
+
+#
 gap> STOP_TEST( "ctblfuns.tst", 1);

--- a/tst/testinstall/ctblfuns.tst
+++ b/tst/testinstall/ctblfuns.tst
@@ -29,10 +29,13 @@ gap> ForAll(AllSmallGroups(12),g -> IsInternallyConsistent(TableOfMarks(g)));
 true
 
 # Up to GAP 4.11.1, the following returned 'fail' results.
-gap> tbl:= CharacterTable( "J1" );;
-gap> List( Filtered( Irr( tbl ), x -> x[1] = 120 ),
->          x -> SizeOfFieldOfDefinition( x, 71 ) );
-[ 357911, 357911, 357911 ]
+gap> if IsPackageMarkedForLoading( "ctbllib", "" ) then
+>   tbl:= CharacterTable( "J1" );;
+>   if fail in List( Filtered( Irr( tbl ), x -> x[1] = 120 ),
+>                    x -> SizeOfFieldOfDefinition( x, 71 ) ) then
+>     Error( "SizeOfFieldOfDefinition test failed" );
+>   fi;
+> fi;
 
 # other situations for 'SizeOfFieldOfDefinition'
 gap> SizeOfFieldOfDefinition( 17, 2 );


### PR DESCRIPTION
such that `fail` is no longer returned when a (Brauer) character is entered.

## Text for release notes 
`SizeOfFieldOfDefinition` does no longer return `fail` when the first argument is a (Brauer) character.
Note that the result in this situation does not depend on the choice of the reduction homomorphism to finite fields,
and it can be determined without explicitly computing the reduction of individual values.
## (End of text for release notes)

