### PR TITLE
`IsNoImmediateMethodsObject` is now a documented filter; it is intended for performance improvements.

### DIFF
--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -323,6 +323,7 @@ For attributes and properties,
 one can install also <E>immediate methods</E>.
 
 <#Include Label="InstallImmediateMethod">
+<#Include Label="IsNoImmediateMethodsObject">
 
 </Section>
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -141,6 +141,12 @@
 ##  However, row list matrices behave nearly like lists of row vectors
 ##  that insist on being dense and containing only vectors of the same
 ##  length and with the same base domain.
+##  <P/>
+##  Vector and matrix objects are not likely to benefit from &GAP;'s
+##  immediate methods (see section <Ref Sect="Immediate Methods"/>).
+##  Therefore it may be useful to set the filter
+##  <Ref Filt="IsNoImmediateMethodsObject"/> in the definition of new kinds
+##  of vector and matrix objects.
 ##  <#/GAPDoc>
 ##
 

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -210,16 +210,23 @@ fi;
 ##
 #F  IsNoImmediateMethodsObject(<obj>)
 ##
+##  <#GAPDoc Label="IsNoImmediateMethodsObject">
 ##  <ManSection>
-##  <Func Name="IsNoImmediateMethodsObject" Arg='obj'/>
+##  <Filt Name="IsNoImmediateMethodsObject" Arg='obj'/>
 ##
 ##  <Description>
-##  If this filter is set immediate methods will be ignored for <A>obj</A>. This
-##  can be crucial for performance for objects like PCGS, of which many are
-##  created, which are collections, but for which all those immediate
-##  methods for <C>IsTrivial</C> et cetera do not really make sense.
+##  If this filter is set immediate methods will be ignored for <A>obj</A>.
+##  This can be crucial for performance for objects like pcgs
+##  (see Section <Ref Sect="Polycyclic Generating Systems"/>), of which many
+##  are created, which are collections, but for which all those immediate
+##  methods for <Ref Prop="IsTrivial"/> et cetera do not really make sense.
+##  Other examples of objects in <Ref Filt="IsNoImmediateMethodsObject"/> are
+##  compressed vectors and matrices over small finite fields,
+##  see the sections <Ref Subsect="Row Vectors over Finite Fields"/> and
+##  <Ref Subsect="Matrices over Finite Fields"/>.
 ##  </Description>
 ##  </ManSection>
+##  <#/GAPDoc>
 ##
 BIND_GLOBAL("IsNoImmediateMethodsObject",
   NewFilter("IsNoImmediateMethodsObject"));


### PR DESCRIPTION
and add a hint to the documentation of vector and matrix objects that setting this filter is recommended for them.
(There is no dedicated "performance hints" section for vector and matrix objects yet.)