### PR TITLE
Speed up IsValidIdentifier

### DIFF
--- a/lib/global.gi
+++ b/lib/global.gi
@@ -47,7 +47,7 @@ DeclareInfoClass("InfoGlobal");
 InstallGlobalFunction( IsValidIdentifier, function(str)
     return ForAll(str, c -> c in IdentifierLetters) and
            ForAny(str, c -> not (c in "0123456789")) and
-           not str in ALL_KEYWORDS();
+           not str in GAPInfo.Keywords;
 end);
 
 #############################################################################

--- a/src/io.c
+++ b/src/io.c
@@ -27,6 +27,7 @@
 #include "gapstate.h"
 #include "gaputils.h"
 #include "gvars.h"
+#include "listfunc.h"
 #include "lists.h"
 #include "modules.h"
 #include "plist.h"
@@ -1444,6 +1445,9 @@ static Obj FuncALL_KEYWORDS(Obj self)
         Obj s = MakeImmString(AllKeywords[i]);
         ASS_LIST(l, i+1, s);
     }
+    SortDensePlist(l);
+    SET_FILT_LIST(l, FN_IS_HOMOG);
+    SET_FILT_LIST(l, FN_IS_SSORT);
     MakeImmutable(l);
     return l;
 }


### PR DESCRIPTION
Each time `IsValidIdentifier` got called, it invoked `ALL_KEYWORDS()`, which
in turned created a fresh list of keywords. Instead, use `GAPInfo.Keywordds`.
Moreover, sort that list to speed up the `str in GAPInfo.Keywords` test.
