### PR TITLE
kernel: move Default{In,Out}put from tls.h to io.c

### DIFF
--- a/src/hpc/tls.h
+++ b/src/hpc/tls.h
@@ -90,10 +90,6 @@ typedef struct ThreadLocalStorage
   /* From read.c */
   jmp_buf threadExit;
 
-  /* From scanner.c */
-  Obj DefaultOutput;
-  Obj DefaultInput;
-
   /* Profiling */
   UInt CountActive;
   UInt LocksAcquired;


### PR DESCRIPTION
... and rename them to `DefaultOutputStream` resp. `DefaultInputStream`,
to avoid confusion with `IO()->DefaultOutput`.
