### PR TITLE
Forbid installing an operation as method for itself

### DIFF
--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -147,6 +147,10 @@ BIND_GLOBAL( "INSTALL_METHOD_FLAGS",
     function( opr, info, rel, flags, baserank, method )
     local   methods,  narg,  i,  k,  tmp, replace, match, j, lk, rank;
 
+    if IS_IDENTICAL_OBJ(opr, method) then
+        Error("Cannot install an operation as a method for itself");
+    fi;
+
     if IsHPCGAP then
         # TODO: once the GAP compiler supports 'atomic', use that
         # to replace the explicit locking and unlocking here.

--- a/tst/testbugfix/2021-03-25-InstallMethod.tst
+++ b/tst/testbugfix/2021-03-25-InstallMethod.tst
@@ -1,0 +1,6 @@
+# Installing an operation as a method for itself is forbidden (now, at least;
+# it used to lead to a segfault if you ever managed to trigger that "method")
+# Fixes GitHub issues #1286 and #4340.
+gap> foo := NewOperation("foo", [IsObject]);;
+gap> InstallMethod(foo, [IsInt], foo);
+Error, Cannot install an operation as a method for itself


### PR DESCRIPTION
Triggering such a "method" would lead to a segfault due to a stack overflow.

Of course one can still trigger this by e.g. having two operations `foo` and
`bar`, and installing `foo` as method for `bar` and vice-versa. But that is far
less likely to happen by accident. Also, it seems better to fix at least some
instances of this issue than to give up because we can't fix it completely.

(This used to be PR #4349 but I accidentally deleted the underlying branch, it seems, so I had to reopen it in a fresh PR)