### PR TITLE
Improve property deduction for simple groups

### DIFF
--- a/grp/basicprm.gi
+++ b/grp/basicprm.gi
@@ -134,8 +134,7 @@ function( filter, dom )
         SetMovedPoints( alt, dom );
         SetNrMovedPoints( alt, Length(dom) );
         if 4 < Length(dom)  then
-            SetIsSimpleGroup(  alt, true );
-            SetIsPerfectGroup( alt, true );
+            SetIsNonabelianSimpleGroup( alt, true );
         elif 2 < Length(dom)  then
             SetIsPerfectGroup( alt, false );
         fi;
@@ -291,7 +290,7 @@ InstallMethod( MathieuGroupCons,
             (1,2,3,4,5,6,7,8,9,10,11),
             (3,7,11,8)(4,10,5,6) );
       SetSize( M, 7920 );
-      SetIsSimpleGroup( M, true );
+      SetIsNonabelianSimpleGroup( M, true );
 
     # degree 12, base 1 2 3 4 5, indices 12 11 10 9 8
     elif degree = 12  then
@@ -300,7 +299,7 @@ InstallMethod( MathieuGroupCons,
             (3,7,11,8)(4,10,5,6),
             (1,12)(2,11)(3,6)(4,8)(5,9)(7,10) );
       SetSize( M, 95040 );
-      SetIsSimpleGroup( M, true );
+      SetIsNonabelianSimpleGroup( M, true );
 
     # degree 21, base 1 2 3 4, indices 21 20 16 3
     elif degree = 21  then
@@ -308,7 +307,7 @@ InstallMethod( MathieuGroupCons,
              (1,4,5,9,3)(2,8,10,7,6)(12,15,16,20,14)(13,19,21,18,17),
              (1,21,5,12,20)(2,16,3,4,17)(6,18,7,19,15)(8,13,9,14,11) );
       SetSize( M, 20160 );
-      SetIsSimpleGroup( M, true );
+      SetIsNonabelianSimpleGroup( M, true );
 
     # degree 22, base 1 2 3 4 5, indices 22 21 20 16 3
     elif degree = 22  then
@@ -317,7 +316,7 @@ InstallMethod( MathieuGroupCons,
             (1,4,5,9,3)(2,8,10,7,6)(12,15,16,20,14)(13,19,21,18,17),
             (1,21)(2,10,8,6)(3,13,4,17)(5,19,9,18)(11,22)(12,14,16,20) );
       SetSize( M, 443520 );
-      SetIsSimpleGroup( M, true );
+      SetIsNonabelianSimpleGroup( M, true );
 
     # degree 23, base 1 2 3 4 5 6, indices 23 22 21 20 16 3
     elif degree = 23  then
@@ -325,7 +324,7 @@ InstallMethod( MathieuGroupCons,
             (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23),
             (3,17,10,7,9)(4,13,14,19,5)(8,18,11,12,23)(15,20,22,21,16) );
       SetSize( M, 10200960 );
-      SetIsSimpleGroup( M, true );
+      SetIsNonabelianSimpleGroup( M, true );
 
     # degree 24, base 1 2 3 4 5 6 7, indices 24 23 22 21 20 16 3
     elif degree = 24  then
@@ -335,7 +334,7 @@ InstallMethod( MathieuGroupCons,
             (1,24)(2,23)(3,12)(4,16)(5,18)(6,10)(7,20)(8,14)(9,21)(11,17)
             (13,22)(19,15) );
       SetSize( M, 244823040 );
-      SetIsSimpleGroup( M, true );
+      SetIsNonabelianSimpleGroup( M, true );
 
     # error
     else

--- a/grp/ree.gi
+++ b/grp/ree.gi
@@ -79,7 +79,8 @@ local theta, m, f, bas, one, zero, x, h, r, gens, G, i;
   SetFieldOfMatrixGroup(G,f);
   SetIsFinite(G,true);
   SetSize(G,q^3*(q-1)*(q^3+1));
-  if q > 3 then SetIsSimpleGroup(G,true); fi;
+  SetIsSimpleGroup(G, q > 3);
+  SetIsPerfectGroup(G, q > 3);
   return G;
 end );
 

--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -386,7 +386,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
       if Length(param)=1 and param[1]>4 then
         g:=AlternatingGroup(param[1]);
         SetName(g,Concatenation("A",String(param[1])));
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       else
         Error("illegal parameter for alternating groups");
@@ -415,7 +415,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
           g:=[,,"J3","J4"];
           g:=DoAtlasrepGroup([g[param[1]]]);
         fi;
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       else
         Error("illegal parameter for Janko groups");
@@ -430,7 +430,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
         else
           g:=DoAtlasrepGroup(["Co1"]);
         fi;
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       else
         Error("illegal parameter for Conway groups");
@@ -441,7 +441,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
         s:=Concatenation("Fi",String(param[1]));
         if param[1] = 24 then Append(s,"'"); fi;
         g:=DoAtlasrepGroup([s]);
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       else
         Error("illegal parameter for Fischer groups");
@@ -449,13 +449,13 @@ local brg,str,p,a,param,g,s,small,plus,sets;
     elif str="SUZ" or str="SZ" or str="SUZUKI" then
       if Length(param)=0 and str="SUZ" then
         g:=PrimitiveGroup(1782,1);
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       elif Length(param)=1 and param[1]>7 and
         PrimeDivisors(param[1])=[2] and IsOddInt(LogInt(param[1],2)) then
         g:=SuzukiGroup(IsPermGroup,param[1]);
         SetName(g,Concatenation("Sz(",String(param),")"));
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       else
         Error("illegal parameter for Suzuki groups");
@@ -465,7 +465,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
         PrimeDivisors(param[1])=[3] and IsOddInt(LogInt(param[1],3)) then
         g:=ReeGroup(IsMatrixGroup,param[1]);
         SetName(g,Concatenation("Ree(",String(param[1]),")"));
-        SetIsSimpleGroup(g,true);
+        SetIsNonabelianSimpleGroup(g,true);
         return g;
       else
         Error("illegal parameter for Ree groups");
@@ -495,7 +495,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
       g:=Group(GeneratorsOfGroup(g));
       SetSize(g,s);
       SetName(g,"2F(4,2)'");
-      SetIsSimpleGroup(g,true);
+      SetIsNonabelianSimpleGroup(g,true);
       return g;
     fi;
   fi;
@@ -669,7 +669,7 @@ local brg,str,p,a,param,g,s,small,plus,sets;
   if s<>fail and not HasName(g) then
     SetName(g,s);
   fi;
-  SetIsSimpleGroup(g,true);
+  SetIsNonabelianSimpleGroup(g,true);
   return g;
 
 end);

--- a/grp/suzuki.gi
+++ b/grp/suzuki.gi
@@ -55,7 +55,8 @@ function ( filter, q )
   SetFieldOfMatrixGroup(G,f);
   SetIsFinite(G,true);
   SetSize(G,q^2*(q-1)*(q^2+1));
-  if q > 2 then SetIsSimpleGroup(G,true); fi;
+  SetIsSimpleGroup(G, q > 2);
+  SetIsPerfectGroup(G, q > 2);
   return G;
 end );
 
@@ -96,6 +97,7 @@ function ( filter, q )
   G := Action(SuzukiGroupCons(IsMatrixGroup,q),Ovoid,OnLines);
   SetName(G,Concatenation("Sz(",String(q),")"));
   SetSize(G,q^2*(q-1)*(q^2+1));
-  if q > 2 then SetIsSimpleGroup(G,true); fi;
+  SetIsSimpleGroup(G, q > 2);
+  SetIsPerfectGroup(G, q > 2);
   return G;
 end );

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -4605,8 +4605,9 @@ DeclareGlobalFunction( "NormalSubgroupClasses" );
 ##    Character( CharacterTable( S4 ), [ 2, 0, 2, -1, 0 ] ), 
 ##    Character( CharacterTable( S4 ), [ 3, 1, -1, 0, -1 ] ), 
 ##    Character( CharacterTable( S4 ), [ 1, 1, 1, 1, 1 ] ) ]
-##  gap> kernel:= KernelOfCharacter( irr[3] );
-##  Group([ (1,2)(3,4), (1,4)(2,3) ])
+##  gap> kernel:= KernelOfCharacter( irr[3] );;
+##  gap> AsSet(kernel);
+##  [ (), (1,2)(3,4), (1,3)(2,4), (1,4)(2,3) ]
 ##  gap> SetName(kernel,"V4");
 ##  gap> HasNormalSubgroupClassesInfo( tbl );
 ##  true

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -629,8 +629,13 @@ InstallTrueMethod( IsPerfectGroup, IsGroup and IsTrivial );
 ##
 DeclareProperty( "IsSimpleGroup", IsGroup );
 InstallTrueMethod( IsGroup and IsNonTrivial, IsSimpleGroup );
+
 DeclareSynonymAttr( "IsNonabelianSimpleGroup", IsSimpleGroup and IsPerfectGroup );
+# ... implies not abelian, not nilpotent (also not solvable, but
+# HasIsSolvableGroup only gets defined later)
 InstallTrueMethod( HasIsAbelian, IsNonabelianSimpleGroup );
+InstallTrueMethod( HasIsNilpotentGroup, IsNonabelianSimpleGroup );
+#InstallTrueMethod( HasIsSolvableGroup, IsNonabelianSimpleGroup );
 
 InstallIsomorphismMaintenance( IsSimpleGroup, IsGroup, IsGroup );
 
@@ -812,7 +817,11 @@ InstallFactorMaintenance( IsSolvableGroup,
 InstallTrueMethod( IsSolvableGroup, IsMonomialGroup );
 InstallTrueMethod( IsSolvableGroup, IsSupersolvableGroup );
 
+# nontrivial solvable groups are not perfect
 InstallTrueMethod( HasIsPerfectGroup, IsGroup and IsSolvableGroup and IsNonTrivial );
+
+# nonabelian simple groups are not solvable
+InstallTrueMethod( HasIsSolvableGroup, IsNonabelianSimpleGroup );
 
 
 #############################################################################

--- a/tst/teststandard/ctblmono.tst
+++ b/tst/teststandard/ctblmono.tst
@@ -26,7 +26,7 @@ gap> IsMinimalNonmonomial(PSL(3,3));
 false
 gap> IsMinimalNonmonomial(Sz(8));
 true
-gap> g := Sz(512);; SetIsSolvableGroup(g,false);; IsMinimalNonmonomial(g);
+gap> IsMinimalNonmonomial(Sz(2^9));
 false
 
 # To avoid more silly mistakes, the following tests were also run


### PR DESCRIPTION
- change various constructors for simple groups to also indicate the
  constructed groups are nonabelian
- add some more automatic implications: nonabelian simple groups are
  also non-nilpotent and non-solvable

Now `IsSolvableGroup(SuzukiGroup(2^9));` returns instantly, as GAP
already knows the answer.

CC @jackschmidt