### PR TITLE
Update PerfectIdentification for larger lib

### DIFF
--- a/grp/perf.grp
+++ b/grp/perf.grp
@@ -691,7 +691,7 @@ local s,l;
   fi;
   s:=Size(G);
   PerfGrpLoad(0);
-  if s>=10^6 or s in PERFRec.notKnown then
+  if NumberPerfectLibraryGroups(s) = 0 then
     Print("#W  No information about size ",s," available\n");
     return fail;
   fi;

--- a/tst/testinstall/grp/perf.tst
+++ b/tst/testinstall/grp/perf.tst
@@ -98,6 +98,9 @@ gap> PerfectIdentification(AlternatingGroup(4));
 fail
 gap> PerfectIdentification(AlternatingGroup(8));
 [ 20160, 4 ]
+gap> PerfectIdentification(PSL(5,2));
+#W  No information about size 9999360 available
+fail
 
 #
 # construct some perfect groups which exercise the different construction methods


### PR DESCRIPTION
This commit fixes the check for "can we construct all perfect groups of order n" to use the library functions rather than hard coded constants. I added a test to check the "order too large" case.

# Description

## Text for release notes 

`release notes: not needed`.

## (End of text for release notes)

## Further details

This commit fixes the check for "can we construct all perfect groups of order n" to use the library functions rather than hard coded constants.

# Checklist for pull request reviewers

- [ ] proper formatting

If your code contains kernel C code, run `clang-format` on it; the 
simplest way is to use `git clang-format`, e.g. like this (don't
forget to commit the resulting changes):

    git clang-format $(git merge-base HEAD master)

- [ ] usage of relevant labels

   1. either `release notes: not needed` or `release notes: to be added`
   2. at least one of the labels `bug` or `enhancement` or `new feature`
   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`

- [ ] runnable tests
- [ ] lines changed in commits are sufficiently covered by the tests
- [ ] adequate pull request title
- [ ] well formulated text for release notes
- [ ] relevant documentation updates
- [ ] sensible comments in the code

