### PR TITLE
Fix `SetPrintFormattingStatus` and `PrintFormattingStatus` for `*stdout*`, and add a variant for the "current output"

### DIFF
--- a/lib/info.gi
+++ b/lib/info.gi
@@ -63,29 +63,25 @@ InstallGlobalFunction( "SetDefaultInfoOutput", function( out )
   MakeReadOnlyGlobal("DefaultInfoOutput");
 end);
 
+
+BIND_GLOBAL( "PrintWithoutFormatting", function ( arg )
+    local old;
+    old := PrintFormattingStatus("*current*");
+    SetPrintFormattingStatus("*current*", false);
+    CallFuncList(Print, arg);
+    SetPrintFormattingStatus("*current*", old);
+end );
+
+
 InstallGlobalFunction( "DefaultInfoHandler", function( infoclass, level, list )
-  local out, fun, s;
+  local out, s;
   out := InfoOutput(infoclass);
   if out = "*Print*" then
-    if IsBoundGlobal( "PrintFormattedString" ) then
-      fun := function(s)
-        if (IsString(s) and Length(s) > 0 or IsStringRep(s)) and
-          #XXX this is a temporary hack, we would need a
-          # IsInstalledGlobal instead of IsBoundGlobal here
-                 NARG_FUNC(ValueGlobal("PrintFormattedString")) <> -1 then
-          ValueGlobal( "PrintFormattedString" )(s);
-        else
-          Print(s);
-        fi;
-      end;
-    else
-      fun := Print;
-    fi;
-    fun("#I  ");
+    PrintWithoutFormatting("#I  ");
     for s in list do
-      fun(s);
+      PrintWithoutFormatting(s);
     od;
-    fun("\n");
+    PrintWithoutFormatting("\n");
   else
     AppendTo(out, "#I  ");
     for s in list do

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1395,7 +1395,7 @@ InstallGlobalFunction( LoadPackageDocumentation, function( arg )
 ##
 BindGlobal( "LoadPackage_ReadImplementationParts",
     function( secondrun, banner )
-    local pair, info, bannerstring, fun, u, pkgname, namespace;
+    local pair, info, bannerstring, u, pkgname, namespace;
 
     for pair in secondrun do
       namespace := pair[1].PackageName;
@@ -1433,15 +1433,9 @@ BindGlobal( "LoadPackage_ReadImplementationParts",
           bannerstring:= DefaultPackageBannerString( info );
         fi;
 
-        # Be aware of umlauts, accents etc. in the banner.
-        if IsBoundGlobal( "Unicode" ) and IsBoundGlobal( "Encode" ) then
-          # The GAPDoc package is completely loaded.
-          fun:= ValueGlobal( "PrintFormattedString" );
-          fun( bannerstring );
-        else
-          # GAPDoc is not available, simply print the banner string as is.
-          Print( bannerstring );
-        fi;
+        # Suppress output formatting to avoid troubles with umlauts,
+        # accents etc. in the banner.
+        PrintWithoutFormatting( bannerstring );
       od;
     fi;
     end );

--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -974,6 +974,8 @@ DeclareGlobalFunction( "InputOutputLocalProcess" );
 ##  If as argument <A>stream</A> the string <C>"*stdout*"</C> is given, these
 ##  functions refer to the formatting status of the standard output (so usually
 ##  the users terminal screen).<P/>
+##  If as argument <A>stream</A> the string <C>"*current*"</C> is given, these
+##  functions refer to the formatting status of the currently active output.<P/>
 ##  These functions do not influence the behaviour of the low level functions 
 ##  <Ref Oper="WriteByte"/>, 
 ##  <Ref Oper="WriteLine"/> or  <Ref Oper="WriteAll"/> which always write

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1222,13 +1222,12 @@ InstallMethod( SetPrintFormattingStatus, "output text file",
 end);
 
 ##  formatting status for stdout
-GAPInfo.FormattingStatusStdout := true;
 InstallOtherMethod( PrintFormattingStatus, "for stdout", [IsString],
 function(str)
   if str <> "*stdout*" then
     Error("Only the string \"*stdout*\" is recognized by this method.");
   fi;
-  return GAPInfo.FormattingStatusStdout;
+  return PRINT_FORMATTING_STDOUT();
 end);
 
 InstallOtherMethod( SetPrintFormattingStatus, "for stdout", [IsString, IsBool],
@@ -1238,10 +1237,8 @@ function(str, status)
   fi;
   if status = false then
     SET_PRINT_FORMATTING_STDOUT(false);
-    GAPInfo.FormattingStatusStdout := false;
   else
     SET_PRINT_FORMATTING_STDOUT(true);
-    GAPInfo.FormattingStatusStdout := true;
   fi;
 end);
 

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1221,24 +1221,26 @@ InstallMethod( SetPrintFormattingStatus, "output text file",
     fi;
 end);
 
-##  formatting status for stdout
+##  formatting status for stdout or current output
 InstallOtherMethod( PrintFormattingStatus, "for stdout", [IsString],
 function(str)
-  if str <> "*stdout*" then
-    Error("Only the string \"*stdout*\" is recognized by this method.");
+  if str = "*stdout*" then
+    return PRINT_FORMATTING_STDOUT();
+  elif str = "*current*" then
+    return PRINT_FORMATTING_CURRENT();
+  else
+    Error("Only the strings \"*stdout*\" and  \"*current*\" are recognized by this method.");
   fi;
-  return PRINT_FORMATTING_STDOUT();
 end);
 
 InstallOtherMethod( SetPrintFormattingStatus, "for stdout", [IsString, IsBool],
 function(str, status)
-  if str <> "*stdout*" then
-    Error("Only the string \"*stdout*\" is recognized by this method.");
-  fi;
-  if status = false then
-    SET_PRINT_FORMATTING_STDOUT(false);
+  if str = "*stdout*" then
+    SET_PRINT_FORMATTING_STDOUT(status);
+  elif str = "*current*" then
+    SET_PRINT_FORMATTING_CURRENT(status);
   else
-    SET_PRINT_FORMATTING_STDOUT(true);
+    Error("Only the strings \"*stdout*\" and  \"*current*\" are recognized by this method.");
   fi;
 end);
 

--- a/src/io.c
+++ b/src/io.c
@@ -55,6 +55,7 @@ static Obj IsOutputStringStream;
 static Obj PrintPromptHook = 0;
 Obj EndLineHook = 0;
 static Obj PrintFormattingStatus;
+static Obj SetPrintFormattingStatus;
 
 /****************************************************************************
 **
@@ -1888,6 +1889,25 @@ static Obj FuncPRINT_FORMATTING_STDOUT(Obj self)
     return 0;
 }
 
+static Obj FuncSET_PRINT_FORMATTING_CURRENT(Obj self, Obj val)
+{
+    TypOutputFile * output = IO()->Output;
+    if (!output)
+        ErrorMayQuit("SET_PRINT_FORMATTING_CURRENT called while no output is open", 0, 0);
+    output->format = (val != False);
+    if (output->stream)
+        CALL_2ARGS(SetPrintFormattingStatus, output->stream, val);
+    return 0;
+}
+
+static Obj FuncPRINT_FORMATTING_CURRENT(Obj self)
+{
+    TypOutputFile * output = IO()->Output;
+    if (!output)
+        ErrorMayQuit("PRINT_FORMATTING_CURRENT called while no output is open", 0, 0);
+    return output->format ? True : False;
+}
+
 static Obj FuncIS_INPUT_TTY(Obj self)
 {
     GAP_ASSERT(IO()->Input);
@@ -1919,6 +1939,8 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC_0ARGS(INPUT_LINENUMBER),
     GVAR_FUNC_1ARGS(SET_PRINT_FORMATTING_STDOUT, format),
     GVAR_FUNC_0ARGS(PRINT_FORMATTING_STDOUT),
+    GVAR_FUNC_1ARGS(SET_PRINT_FORMATTING_CURRENT, format),
+    GVAR_FUNC_0ARGS(PRINT_FORMATTING_CURRENT),
     GVAR_FUNC_0ARGS(IS_INPUT_TTY),
     GVAR_FUNC_0ARGS(IS_OUTPUT_TTY),
     GVAR_FUNC_0ARGS(GET_FILENAME_CACHE),
@@ -1978,6 +2000,7 @@ static Int InitKernel (
     InitCopyGVar( "PrintPromptHook", &PrintPromptHook );
     InitCopyGVar( "EndLineHook", &EndLineHook );
     InitFopyGVar( "PrintFormattingStatus", &PrintFormattingStatus);
+    InitFopyGVar( "SetPrintFormattingStatus", &SetPrintFormattingStatus);
 
     InitHdlrFuncsFromTable( GVarFuncs );
     return 0;

--- a/src/io.c
+++ b/src/io.c
@@ -1868,12 +1868,24 @@ static Obj FuncINPUT_LINENUMBER(Obj self)
 static Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val)
 {
     TypOutputFile * output = IO()->Output;
-    if (!output)
-        ErrorMayQuit("SET_PRINT_FORMATTING_STDOUT called while no output is opened\n", 0, 0);
-    while (output->prev)
+    while (output) {
+        if (!output->stream && output->file == 1)
+            output->format = (val != False);
         output = output->prev;
-    output->format = (val != False);
-    return val;
+    }
+    return 0;
+}
+
+static Obj FuncPRINT_FORMATTING_STDOUT(Obj self)
+{
+    TypOutputFile * output = IO()->Output;
+    while (output) {
+        if (!output->stream && output->file == 1)
+            return output->format ? True : False;
+        output = output->prev;
+    }
+    ErrorMayQuit("PRINT_FORMATTING_STDOUT called while stdout is not open", 0, 0);
+    return 0;
 }
 
 static Obj FuncIS_INPUT_TTY(Obj self)
@@ -1906,6 +1918,7 @@ static StructGVarFunc GVarFuncs [] = {
     GVAR_FUNC_0ARGS(INPUT_FILENAME),
     GVAR_FUNC_0ARGS(INPUT_LINENUMBER),
     GVAR_FUNC_1ARGS(SET_PRINT_FORMATTING_STDOUT, format),
+    GVAR_FUNC_0ARGS(PRINT_FORMATTING_STDOUT),
     GVAR_FUNC_0ARGS(IS_INPUT_TTY),
     GVAR_FUNC_0ARGS(IS_OUTPUT_TTY),
     GVAR_FUNC_0ARGS(GET_FILENAME_CACHE),

--- a/tst/testinstall/info.tst
+++ b/tst/testinstall/info.tst
@@ -56,7 +56,6 @@ Error, usage : Info(<selectors>, <level>, ...)
 gap> ShowUsedInfoClasses(true);
 gap> Info(InfoTest2, 2, "apple");
 #I Would print info with SetInfoLevel(InfoTest2,2)
-#I Would print info with SetInfoLevel(InfoGlobal,3)
 #I  apple
 gap> Info(InfoTest1 + InfoTest2, 2, "apple");
 #I Would print info with SetInfoLevel(InfoTest1,2)

--- a/tst/testinstall/print-formatting.tst
+++ b/tst/testinstall/print-formatting.tst
@@ -1,0 +1,8 @@
+gap> SetPrintFormattingStatus("*current*",false); Display(x -> x);
+function ( x )
+return x;
+end
+gap> Display(x -> x);
+function ( x )
+    return x;
+end

--- a/tst/testspecial/print-formatting.g
+++ b/tst/testspecial/print-formatting.g
@@ -1,3 +1,4 @@
+# test formatting status for stdout
 old := PrintFormattingStatus("*stdout*");
 SetPrintFormattingStatus("*stdout*", false);
 PrintFormattingStatus("*stdout*");
@@ -7,3 +8,15 @@ PrintFormattingStatus("*stdout*");
 Display(x -> x);
 SetPrintFormattingStatus("*stdout*", old);;
 PrintFormattingStatus("*stdout*");
+
+# test formatting status for current output
+old := PrintFormattingStatus("*current*");
+SetPrintFormattingStatus("*current*", false);
+PrintFormattingStatus("*current*");
+Display(x -> x);
+SetPrintFormattingStatus("*current*", true);
+PrintFormattingStatus("*current*");
+Display(x -> x);
+SetPrintFormattingStatus("*current*", old);;
+PrintFormattingStatus("*current*");
+

--- a/tst/testspecial/print-formatting.g
+++ b/tst/testspecial/print-formatting.g
@@ -1,0 +1,9 @@
+old := PrintFormattingStatus("*stdout*");
+SetPrintFormattingStatus("*stdout*", false);
+PrintFormattingStatus("*stdout*");
+Display(x -> x);
+SetPrintFormattingStatus("*stdout*", true);
+PrintFormattingStatus("*stdout*");
+Display(x -> x);
+SetPrintFormattingStatus("*stdout*", old);;
+PrintFormattingStatus("*stdout*");

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -1,0 +1,20 @@
+gap> old := PrintFormattingStatus("*stdout*");
+true
+gap> SetPrintFormattingStatus("*stdout*", false);
+gap> PrintFormattingStatus("*stdout*");
+false
+gap> Display(x -> x);
+function ( x )
+return x;
+end
+gap> SetPrintFormattingStatus("*stdout*", true);
+gap> PrintFormattingStatus("*stdout*");
+true
+gap> Display(x -> x);
+function ( x )
+    return x;
+end
+gap> SetPrintFormattingStatus("*stdout*", old);;
+gap> PrintFormattingStatus("*stdout*");
+true
+gap> QUIT;

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -1,3 +1,4 @@
+gap> # test formatting status for stdout
 gap> old := PrintFormattingStatus("*stdout*");
 true
 gap> SetPrintFormattingStatus("*stdout*", false);
@@ -17,4 +18,26 @@ end
 gap> SetPrintFormattingStatus("*stdout*", old);;
 gap> PrintFormattingStatus("*stdout*");
 true
+gap> 
+gap> # test formatting status for current output
+gap> old := PrintFormattingStatus("*current*");
+true
+gap> SetPrintFormattingStatus("*current*", false);
+gap> PrintFormattingStatus("*current*");
+false
+gap> Display(x -> x);
+function ( x )
+return x;
+end
+gap> SetPrintFormattingStatus("*current*", true);
+gap> PrintFormattingStatus("*current*");
+true
+gap> Display(x -> x);
+function ( x )
+    return x;
+end
+gap> SetPrintFormattingStatus("*current*", old);;
+gap> PrintFormattingStatus("*current*");
+true
+gap> 
 gap> QUIT;


### PR DESCRIPTION
Extracted from PR #4540 -- these are the hopefully unproblematic bits. <s>Fixes issue #4486</s> (UPDATE: no it doesn't) (CC @zickgraf)

# Description

## Text for release notes 

Fixed `PrintFormattingStatus` and `SetPrintFormattingStatus` for the standard output (i.e., when the first argument is `"*stdout*"` and add a variant that deals with the current output (whatever that may be), reachable by using `"*current*"` as first argument.

## (End of text for release notes)
