### PR TITLE
Add `InstallEarlyMethod` which allows installing special methods that bypass method selection (and thus its overhead)

### DIFF
--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -165,6 +165,7 @@ For declaring that a filter is implied by other filters there is
 
 <#Include Label="InstallMethod">
 <#Include Label="InstallOtherMethod">
+<#Include Label="InstallEarlyMethod">
 <#Include Label="InstallMethodWithRandomSource">
 
 </Section>

--- a/doc/tut/group.xml
+++ b/doc/tut/group.xml
@@ -303,7 +303,7 @@ method for conjugacy classes is slower than just explicit calculation of
 the elements. However, &GAP; is reluctant to construct explicit element
 lists, because for really large groups this direct method is infeasible.
 <P/>
-Note also the function <Ref Func="First" BookName="ref"/>,
+Note also the function <Ref Oper="First" BookName="ref"/>,
 used to find the first element in a list which passes some test.
 <P/>
 In this example,

--- a/etc/ctags_for_gap
+++ b/etc/ctags_for_gap
@@ -5,6 +5,7 @@
 --regex-GAP=/BIND_GLOBAL *\( *"([a-zA-Z0-9_]+)"/\1/v,value/
 --regex-GAP=/InstallMethod *\( *"?([a-zA-Z0-9_]+)"? *,/\1/m,method/
 --regex-GAP=/InstallOtherMethod *\( *"?([a-zA-Z0-9_]+)"? *,/\1/m,method/
+--regex-GAP=/InstallEarlyMethod *\( *"?([a-zA-Z0-9_]+)"? *,/\1/m,method/
 --regex-GAP=/InstallMethodWithRandomSource *\( *"?([a-zA-Z0-9_]+)"? *,/\1/m,method/
 --regex-GAP=/InstallGlobalFunction *\( *"?([a-zA-Z0-9_]+)"? *,/\1/g,gfunction/
 --regex-GAP=/InstallValue *\( *([a-zA-Z0-9_]+) *,/\1/v,value/

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -961,7 +961,7 @@ DeclareGlobalFunction( "PositionSet" );
 ##  490
 ##  ]]></Example>
 ##  <P/>
-##  <Ref Func="First"/> allows you to extract the first element of a list
+##  <Ref Oper="First"/> allows you to extract the first element of a list
 ##  that satisfies a certain property.
 ##  </Description>
 ##  </ManSection>
@@ -2061,25 +2061,26 @@ DeclareGlobalFunction( "IteratorList" );
 ##
 ##  <#GAPDoc Label="First">
 ##  <ManSection>
-##  <Func Name="First" Arg='list[, func]'/>
+##  <Oper Name="First" Arg='list[, func]'/>
 ##
 ##  <Description>
-##  <Ref Func="First"/> returns the first element of the list <A>list</A>
+##  <Ref Oper="First"/> returns the first element of the list <A>list</A>
 ##  for which the unary function <A>func</A> returns <K>true</K>;
 ##  if <A>func</A> is not given, the first element is returned.
 ##  <A>list</A> may contain holes.
 ##  <A>func</A> must return either <K>true</K> or <K>false</K> for each
 ##  element of <A>list</A>, otherwise an error is signalled.
 ##  If <A>func</A> returns <K>false</K> for all elements of <A>list</A>
-##  then <Ref Func="First"/> returns <K>fail</K>.
+##  then <Ref Oper="First"/> returns <K>fail</K>.
 ##  <P/>
 ##  <Ref Oper="PositionProperty"/> allows you to find the
 ##  position of the first element in a list that satisfies a certain
 ##  property.
 ##  <P/>
-##  Developers who wish to adapt this for custom list types need to
-##  install suitable methods for the operation <C>FirstOp</C>.
-##  <Index Key="FirstOp"><C>FirstOp</C></Index>
+##  Before &GAP; 4.12, developers who wished to adapt this for custom
+##  list types needed to install suitable methods for the operation
+##  <C>FirstOp</C>. This is still possible for backwards compatibility,
+##  but <C>FirstOp</C> now is just a synonym for <Ref Oper="First"/>.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> First( [10^7..10^8], IsPrime );
@@ -2095,11 +2096,8 @@ DeclareGlobalFunction( "IteratorList" );
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
-##
-##  We catch internal lists by a function to avoid method selection:
-DeclareGlobalFunction( "First" );
-DeclareOperation( "FirstOp", [ IsListOrCollection ] );
-DeclareOperation( "FirstOp", [ IsListOrCollection, IsFunction ] );
+DeclareOperation( "First", [ IsListOrCollection ] );
+DeclareOperation( "First", [ IsListOrCollection, IsFunction ] );
 
 
 #############################################################################

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2811,38 +2811,40 @@ InstallMethod( Permuted,
 ##
 #F  First( <C>, <func> )  . . .  find first element in a list with a property
 ##
-InstallGlobalFunction( First,
-    function ( C, func... )
+InstallEarlyMethod( First, 
+    function ( C )
     local tnum, elm;
-    if Length( func ) > 1 then
-      Error( "too many arguments" );
-    fi;
     tnum:= TNUM_OBJ( C );
     if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
-      if Length( func ) = 0 then
-        func := ReturnTrue;
-      else
-        func := func[1];
-      fi;
       for elm in C do
-          if func( elm ) then
-              return elm;
-          fi;
+        return elm;
       od;
       return fail;
-    elif Length( func ) = 0 then
-      return FirstOp( C );
-    else
-      return FirstOp( C, func[1] );
     fi;
-end );
+    TryNextMethod();
+    end );
+
+InstallEarlyMethod( First,
+    function ( C, func )
+    local tnum, elm;
+    tnum:= TNUM_OBJ( C );
+    if FIRST_LIST_TNUM <= tnum and tnum <= LAST_LIST_TNUM then
+      for elm in C do
+        if func( elm ) then
+          return elm;
+        fi;
+      od;
+      return fail;
+    fi;
+    TryNextMethod();
+    end );
 
 
 #############################################################################
 ##
-#M  FirstOp( <C>, <func> )  . .  find first element in a list with a property
+#M  First( <C>, <func> ) . . . . find first element in a list with a property
 ##
-InstallMethod( FirstOp,
+InstallMethod( First,
     "for a list or collection and a function",
     [ IsListOrCollection, IsFunction ],
     function ( C, func )
@@ -2855,7 +2857,7 @@ InstallMethod( FirstOp,
     return fail;
     end );
 
-InstallMethod( FirstOp,
+InstallMethod( First,
     "for a list or collection",
     [ IsListOrCollection ],
     function ( C )

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -24,7 +24,7 @@
 ##  </ManSection>
 ##
 BindGlobal("Print_Value_SFF",function(val)
-  if val>SUM_FLAGS then
+  if val>SUM_FLAGS and val < infinity then
     Print(QuoInt(val,SUM_FLAGS),"*SUM_FLAGS");
     val:=val mod SUM_FLAGS;
     if val>0 then
@@ -191,7 +191,7 @@ local oper,narg,args,skip,verbos,fams,flags,i,j,methods,flag,flag2,
     fi;
     flag:=true;
     j:=1;
-    while j<=narg and (flag or verbos>3) do
+    while j<=narg and (flag or verbos>3) and not m.early do
       if j=1 and isconstructor then
 	flag2:=IS_SUBSET_FLAGS(m.argFilt[j],flags[j]);
       else
@@ -212,7 +212,7 @@ local oper,narg,args,skip,verbos,fams,flags,i,j,methods,flag,flag2,
       j:=j+1;
     od;
     if flag then
-      if fams=fail or CallFuncList(m.famPred,fams) then
+      if m.early or fams=fail or CallFuncList(m.famPred,fams) then
 	if verbos=1 then
 	  Print("#I  Method ",i,": ``",nam,"''");
           if IsBound(m.location) then

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -747,3 +747,12 @@ DeclareObsoleteSynonym("FORCE_QUIT_GAP", "ForceQuitGap", 2);
 ##
 ##  Not used in any redistributed package (05/2021)
 DeclareObsoleteSynonym( "IsLexicographicallyLess", "<" );
+
+
+#############################################################################
+##
+##  We can't use DeclareObsoleteSynonym for FirstOp, because this would break
+##  code installing methods for it, and the `fr` package does just that.
+##
+##  Still used in fr (06/2021)
+DeclareSynonym( "FirstOp", First );

--- a/lib/oper.g
+++ b/lib/oper.g
@@ -2044,16 +2044,34 @@ fi;
 
 # TODO: document this?!
 BIND_GLOBAL("MethodsOperation", function(oper, nargs)
-    local meths, len, result, i, m;
+    local early, meths, len, result, i, m;
 
+    early := EARLY_METHOD(oper, nargs);
     meths := METHODS_OPERATION(oper, nargs);
-    if meths = fail then
+    if early = fail and meths = fail then
         return fail;
     fi;
-    len := BASE_SIZE_METHODS_OPER_ENTRY + nargs;
     result := [];
+    if early <> fail then
+        m := rec(
+            early   := true,
+            #famPred := meths[i + 1],
+            #argFilt := meths{[i + 2 .. i + nargs + 1]},
+            func    := early,
+            rank    := infinity,
+            info    := "early method",
+            #location := ["TODO",0],
+            rankbase := infinity,
+            );
+        ADD_LIST(result, m);
+        if meths = fail then
+            return result;
+        fi;
+    fi;
+    len := BASE_SIZE_METHODS_OPER_ENTRY + nargs;
     for i in [0, len .. LENGTH(meths) - len] do
         m := rec(
+            early   := false,
             famPred := meths[i + 1],
             argFilt := meths{[i + 2 .. i + nargs + 1]},
             func    := meths[i + nargs + 2],

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -362,6 +362,48 @@ BIND_GLOBAL( "InstallOtherMethod",
 
 #############################################################################
 ##
+#F  InstallEarlyMethod( <opr>,<method> )
+##
+##  <#GAPDoc Label="InstallEarlyMethod">
+##  <ManSection>
+##  <Func Name="InstallEarlyMethod" Arg="opr,method"/>
+##
+##  <Description>
+##  installs a special "early" function method <A>method</A> for the
+##  operation <A>opr</A>. An early method is special in that it bypasses
+##  method dispatch, and is always the first method to be called when
+##  invoking the operation.
+##  <P/>
+##  This can be used to avoid method selection overhead for certain special
+##  cases, i.e., as an optimization. Overall, we recommend to use this
+##  feature very sparingly, as it is tool with sharp edges: for example, any
+##  inputs that are handled by an early method can not be intercepted by a
+##  regular method, no matter how high its rank is; this can preclude other
+##  kinds of optimizations.
+##  <P/>
+##  Also, unlike regular methods, no checks are performed on the arguments.
+##  Not even the required filters for the operation are tested, so early
+##  methods must be careful in validating their inputs.
+##  This also means that any operation can have at most one such early
+##  method for each arity (i.e., one early method taking 1 argument, one
+##  early method taking 2 arguments, etc.).
+##  <P/>
+##  If an early method determines that it is not applicable, it can resume
+##  regular method dispatch by invoking <Ref Func="TryNextMethod"/>.
+##  <P/>
+##  For an example application of early methods, they are used by
+##  <Ref Oper="First"/> to deal with internal lists, for which computing
+##  the exact type (needed for method selection) can be very expensive.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+BIND_GLOBAL( "InstallEarlyMethod", INSTALL_EARLY_METHOD );
+#TODO; store location info somehow
+#MakeImmutable([INPUT_FILENAME(), READEVALCOMMAND_LINENUMBER, INPUT_LINENUMBER()])
+
+#############################################################################
+##
 #F  INSTALL_METHOD( <arglist>, <check> )  . . . . . . . . .  install a method
 ##
 DeclareGlobalFunction( "EvalString" );

--- a/src/opers.h
+++ b/src/opers.h
@@ -52,6 +52,9 @@ typedef struct {
     // cache of an operation
     Obj cache[MAX_OPER_ARGS+1];
 
+    //
+    Obj earlyMethod[MAX_OPER_ARGS+1];
+
     // small integer encoding a set of bit flags with information about the
     // operation, see OperExtras below
     //

--- a/tst/testinstall/boolean.tst
+++ b/tst/testinstall/boolean.tst
@@ -79,13 +79,13 @@ gap> IsAssociative and true;
 Error, <oper2> must be a filter (not the value 'true')
 gap> IsAssociative and Center;
 Error, <oper2> must be a filter (not a function)
-gap> IsAssociative and FirstOp;
+gap> IsAssociative and First;
 Error, <oper2> must be a filter (not a function)
 gap> true and IsAssociative;
 Error, <expr> must be 'true' or 'false' (not a function)
 gap> Center and IsAssociative;
 Error, <expr> must be 'true' or 'false' or a filter (not a function)
-gap> FirstOp and IsAssociative;
+gap> First and IsAssociative;
 Error, <expr> must be 'true' or 'false' or a filter (not a function)
 gap> IsAssociative and IsAssociative;
 <Property "IsAssociative">
@@ -111,13 +111,13 @@ gap> function() return IsAssociative and true; end();
 Error, <oper2> must be a filter (not the value 'true')
 gap> function() return IsAssociative and Center; end();
 Error, <oper2> must be a filter (not a function)
-gap> function() return IsAssociative and FirstOp; end();
+gap> function() return IsAssociative and First; end();
 Error, <oper2> must be a filter (not a function)
 gap> function() return true and IsAssociative; end();
 Error, <expr> must be 'true' or 'false' (not a function)
 gap> function() return Center and IsAssociative; end();
 Error, <expr> must be 'true' or 'false' or a filter (not a function)
-gap> function() return FirstOp and IsAssociative; end();
+gap> function() return First and IsAssociative; end();
 Error, <expr> must be 'true' or 'false' or a filter (not a function)
 gap> function() return IsAssociative and IsAssociative; end();
 <Property "IsAssociative">

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -242,6 +242,42 @@ Error, SET_METHODS_OPERATION: <narg> must be an integer between 0 and 6 (not t\
 he integer 7)
 
 #
+gap> oper := NewOperation("foobar", [IsList]);
+<Operation "foobar">
+gap> INSTALL_EARLY_METHOD(fail, fail);
+Error, INSTALL_EARLY_METHOD: <oper> must be an operation (not the value 'fail'\
+)
+gap> INSTALL_EARLY_METHOD(oper, fail);
+Error, INSTALL_EARLY_METHOD: <func> must be a function (not the value 'fail')
+gap> INSTALL_EARLY_METHOD(oper, oper);
+Error, <func> must not be an operation
+gap> InstallMethod(oper, [IsPlistRep], function(l) Print("IsPlistRep method\n"); end);
+gap> oper([1,2,3]);
+IsPlistRep method
+gap> INSTALL_EARLY_METHOD(oper, function(l) Print("early method\n"); TryNextMethod(); end);
+gap> oper([1,2,3]);
+early method
+IsPlistRep method
+gap> INSTALL_EARLY_METHOD(oper, ReturnTrue);
+Error, <func> must not be variadic
+gap> INSTALL_EARLY_METHOD(oper, {a,b,c,d,e,f,g} -> fail);
+Error, <func> must take at most 6 arguments
+gap> INSTALL_EARLY_METHOD(oper, x -> fail);
+Error, early method already installed
+
+#
+gap> EARLY_METHOD(fail, fail);
+Error, EARLY_METHOD: <oper> must be an operation (not the value 'fail')
+gap> EARLY_METHOD(oper, -1);
+Error, EARLY_METHOD: <narg> must be an integer between 0 and 6 (not the intege\
+r -1)
+gap> EARLY_METHOD(oper, 7);
+Error, EARLY_METHOD: <narg> must be an integer between 0 and 6 (not the intege\
+r 7)
+gap> List([0..6], n -> EARLY_METHOD(oper, n));
+[ fail, function( l ) ... end, fail, fail, fail, fail, fail ]
+
+#
 gap> f:=SETTER_FUNCTION("foobar", IsPGroup);;
 gap> f(fail, false);
 Error, <obj> must be a component object


### PR DESCRIPTION
Resolves #955

I only converted `First` / `FirstOp` to use it as a proof of concept. Before more is done, I thought it would be good to solicit feedback. Also, since I am a bit short on time, perhaps others would like to help and contribute by converting more `Foo` / `FooOp` pairs to use this?