### PR TITLE
explicitly document that `IsRowListMatrix` objects are "dense"

### DIFF
--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -231,8 +231,10 @@ DeclareCategory( "IsMatrixObj", IsMatrixOrMatrixObj );
 ##
 ##  <Description>
 ##  A <E>row list matrix object</E> is a matrix object
-##  (see <Ref Filt="IsMatrixObj"/>) which admits access to their rows,
-##  via list access <Ref Oper="\[\]"/>.
+##  (see <Ref Filt="IsMatrixObj"/>) <M>M</M> which admits access to its rows,
+##  that is, list access <M>M[i]</M> (see <Ref Oper="\[\]"/>) yields
+##  the <M>i</M>-th row of <M>M</M>,
+##  for <M>1 \leq i \leq</M> <C>NumberRows( </C><M>M</M><C> )</C>.
 ##  <P/>
 ##  All rows are <Ref Filt="IsVectorObj"/> objects in the same
 ##  representation.


### PR DESCRIPTION
The documentation of the relevant operations for objects in `IsRowListMatrix` (list access, list assignment, `IsBound[]`, ...) implies that such objects are "dense" (although they need not be lists), and this follows also from the fact that such an object `M` is in `IsMatrixObj` and hence admits entry access `M[i,j]`, for `i`and `j` up to `NumberRows( M )` and `NumberColumns( M )`, respectively.
However, it is better to say this explicitly (see also #4533).