### PR TITLE
Revise our pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,58 +1,13 @@
-Please use the following template to submit a pull request, filling
-in at least the "Text for release notes" and/or "Further details".
-Thank you!
+Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.
 
-# Description
+## Text for release notes
 
-## Text for release notes 
+We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:
 
-If this pull request shall **not** be mentioned in the release notes
-(to be distributed in the file `CHANGES.md`),
-please add the label `release notes: not needed`.
-
-Otherwise, please proceed in one of the following ways:
-
-- Choose a title that can serve as text for the release notes,
-  and add the label `release notes: use title`.
-
-- Put the text for the release notes **here**,
-  that is, between the markers `Text for release notes`
-  and `(End of text for release notes)`.
-
-The first variant is recommended whenever the text for release notes
-is suitable as title.
-
-In both cases, please follow the style of the GAP `CHANGES.md` file
-in the root directory.
-In particular, please surround the names of GAP functions with backquotes.
-
-## (End of text for release notes)
+1. If this PR shall **not** be mentioned in the release notes, write "none" here.
+2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
+3. If a longer note is needed, just write it here, ideally following the general style used in that file
 
 ## Further details
 
-If necessary, please provide further details here.
-
-# Checklist for pull request reviewers
-
-- [ ] proper formatting
-
-If your code contains kernel C code, run `clang-format` on it; the 
-simplest way is to use `git clang-format`, e.g. like this (don't
-forget to commit the resulting changes):
-
-    git clang-format $(git merge-base HEAD master)
-
-- [ ] usage of relevant labels
-
-   1. either `release notes: not needed` or `release notes: to be added`
-   2. at least one of the labels `bug` or `enhancement` or `new feature`
-   3. for changes meant to be backported to `stable-4.X` add the `backport-to-4.X` label
-   4. consider adding any of the labels `build system`, `documentation`, `kernel`, `library`, `tests`
-
-- [ ] runnable tests
-- [ ] lines changed in commits are sufficiently covered by the tests
-- [ ] adequate pull request title
-- [ ] well formulated text for release notes
-- [ ] relevant documentation updates
-- [ ] sensible comments in the code
-
+If necessary, provide further details down here.


### PR DESCRIPTION
The old one was far too long, meaning that most people would skip
over most of it. So let's focus on the important bits, which are
a useful description and release notes.

The stuff at the end for reviewers was not used by us in practice;
instead, there should be a separate document somewhere with guidelines
for reviewers.
