### PR TITLE
Permutation representation of extensions with reducible modules

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2469,7 +2469,7 @@ InstallGlobalFunction( ClosureSubgroupNC, function(arg)
 local G,obj,close;
     G:=arg[1];
     obj:=arg[2];
-    if IsTrivial(G) and IsGroup(obj) then
+    if HasIsTrivial(G) and IsTrivial(G) and IsGroup(obj) then
       obj:=AsSubgroup(Parent(G),obj);
     fi;
     if not HasParent( G ) then

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2421,7 +2421,7 @@ local uind,subs,incl,i,j,k,m,gens,t,c,p,conj,bas,basl,r;
     fi;
 
     Info(InfoLattice,1,"Subgroup ",i,", Order ",Size(subs[i]),": ",Length(m),
-      " maxes");
+      " maxes. So far found ",Length(subs)," ratio ",EvalF(i/Length(subs)));
     for j in m do
       Info(InfoLattice,2,"Max index ",Index(subs[i],j));
       # maximals must be self-normalizing or normal

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1723,16 +1723,20 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,old,sim,
       if IsPermGroup(p) then
         mindeg:=Minimum(List(Orbits(p,MovedPoints(p)),Length));
       fi;
+      it:=fail;
       while Size(p)<Size(fp) do
         # we allow do go immediately to normal subgroup of index up to 4.
         # This reduces search space
-        if p=r.group then
-          # re-use the first quotient, helps with repeated subgroups iterator
-          it:=DescSubgroupIterator(p:skip:=LogInt(Size(p),2));
-        else
-          it:=DescSubgroupIterator(r.group:skip:=LogInt(Size(p),2));
-        fi;
         repeat
+          if it=fail then
+            # re-use the first quotient, helps with repeated subgroups iterator
+            if p=r.group then
+              it:=DescSubgroupIterator(r.group:skip:=LogInt(Size(p),2));
+            else
+              it:=DescSubgroupIterator(p:skip:=LogInt(Size(p),2));
+            fi;
+          fi;
+
           wasbold:=false;
           m:=NextIterator(it);
           # catch case of large permdegree, try naive first
@@ -1982,6 +1986,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,old,sim,
              Size(p)/Size(i)," at degree ",NrMovedPoints(p));
         hom:=false; # we don't have hom cheaply any longer as group changed.
         # this is not an issue if module is irreducible
+        it:=fail; simi:=fail; # cleanout info for first factor
       od;
       quot:=sim*quot;
       new:=GroupHomomorphismByImages(fp,p,GeneratorsOfGroup(fp),

--- a/tst/testextra/perfect.tst
+++ b/tst/testextra/perfect.tst
@@ -10,4 +10,16 @@ gap> Length(l);
 gap> l:=Practice(10752);;
 gap> Length(l);
 9
+gap> LoadPackage("atlasrep");;
+gap> perms:=AtlasGenerators("2.A5",1).generators;;
+gap> mats:=AtlasGenerators("2.A5",4).generators;;
+gap> gp:=Group(perms);;
+gap> mo:=GModuleByMats(mats,GF(2));;
+gap> coh:=TwoCohomologyGeneric(gp,mo);;
+gap> Length(coh.cohomology);
+1
+gap> gp:=FpGroupCocycle(coh,coh.cohomology[1],true);;
+gap> gp:=Image(IsomorphismPermGroup(gp));;
+gap> Size(Group(GeneratorsOfGroup(gp)));
+61440
 gap> STOP_TEST( "perfect.tst", 1);

--- a/tst/testinstall/grpfp.tst
+++ b/tst/testinstall/grpfp.tst
@@ -1,4 +1,4 @@
-#@local a,b,c2,e,f,g,iter,l,s,F,rels
+#@local a,b,c2,e,f,g,iter,l,s,F,rels,sub
 gap> START_TEST("grpfp.tst");
 gap> f:= FreeGroup( "a", "b" );;  a := f.1;;  b := f.2;;
 gap> c2:= f / [ a*b*a^-2*b*a/b, (b^-1*a^3*b^-1*a^-3)^2*a ];;
@@ -107,6 +107,13 @@ gap> rels:=ParseRelators(F,"a2,b3,c4,abC");
 [ a^2, b^3, c^4, a*b*c^-1 ]
 gap> IsomorphismSimplifiedFpGroup(F/rels);
 [ a, b, c ] -> [ c*b^-1, b, c ]
+
+# ClosureSubgroupNC will not force a triviality or membership test
+# if we do not know anything.
+gap> f:=FreeGroup(3);;
+gap> g:=f/[f.1*f.2,f.2^2,(f.2*f.3)^7];;
+gap> sub:=SubgroupNC(g,[g.1*g.2^3]);;
+gap> ClosureSubgroupNC(sub,g.3);;
 
 #
 gap> STOP_TEST( "grpfp.tst", 1);


### PR DESCRIPTION
Fixed a bug (in updating data structure) if a permutation representation of an extension needs several steps (can only happen for reducible modules).
Also made `ClosureSubgroup` not force a triviality test if not known, and expanded an info message


