### PR TITLE
avoid an error message in `FrobeniusCharacterValue`

### DIFF
--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -4209,7 +4209,7 @@ InstallGlobalFunction( FrobeniusCharacterValue, function( value, p )
       for i in [ 2 .. m ] do
         lastvalue:= ProductCoeffs( y, lastvalue );
         ReduceCoeffs( lastvalue, conwaypol );
-#T bad that ReduceCoeffs does not predict how it deals with trailing zeros
+        ShrinkRowVector( lastvalue );
         PadCoeffs( lastvalue, k, zero );
         fieldbase[i]:= lastvalue;
         ConvertToVectorRepNC( fieldbase[i], p );
@@ -4217,7 +4217,6 @@ InstallGlobalFunction( FrobeniusCharacterValue, function( value, p )
 
       value:= ValuePol( SolutionMatDestructive( fieldbase, value ),
                         Z( p, m ) );
-
     fi;
 
     # Return the Frobenius character value.

--- a/tst/teststandard/ctblfuns.tst
+++ b/tst/teststandard/ctblfuns.tst
@@ -34,4 +34,23 @@ gap> List( const, ValuesOfClassFunction );
 [ [ 1, 1 ], [ 2, -1 ] ]
 
 #
+gap> FrobeniusCharacterValue( E(7), 7 );
+fail
+gap> FrobeniusCharacterValue( 1/7, 7 );
+fail
+gap> FrobeniusCharacterValue( 1, 7 );
+Z(7)^0
+gap> FrobeniusCharacterValue( 7*E(5), 7 );
+0*Z(7)
+gap> FrobeniusCharacterValue( E(23), 2 );
+Z(2^11)^89
+gap> FrobeniusCharacterValue( E(19), 97 );
+#I  the Conway polynomial of degree 18 for p = 97 is not known
+fail
+gap> FrobeniusCharacterValue( 82*E(16)+E(16)^5, 269 );
+0*Z(269)
+gap> FrobeniusCharacterValue( E(16), 269 );
+162+256z+143z2+219z3
+
+#
 gap> STOP_TEST( "ctblfuns.tst" );


### PR DESCRIPTION
An error was thrown when the rows of the equation system had different lengths.

(Resolves #4564.)