### PR TITLE
"Wrap releases" workflow: also fetch tags from gap-system/gap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
       # in this action; instead an unannotated tag with the same is present;
       # resolve this by force-fetching tags
       - name: "Force fetch tags"
-        run: git fetch --tags --force
+        run: |
+          git fetch --tags --force
+          git fetch https://github.com/gap-system/gap --tags --force
 
       - name: "Set up Python"
         uses: actions/setup-python@v2


### PR DESCRIPTION
This change is relevant for running this workflow on a fork of GAP that does not keep its tags up to date with gap-system/gap. Of course, for people who are not interested in git tags, there should be no need to keep them up to date; but that should not break this workflow.

This is particularly relevant for @hulpke, for whom the "Wrap releases" workflow has _never_ successfully passed, see https://github.com/hulpke/gap/actions/workflows/release.yml – sorry about this. I reproduced this failure by deleting all tags newer that `v4.8.1` on my own fork, and I got the same error.  This change made things work again.

Once this PR is merged, hopefully you should be able to drop your personal commits that remove this workflow, i.e. https://github.com/hulpke/gap/commit/10d9bd65f273626c9eb09d1b60f7943849e445a8 - if it's still broken please do let me know!