### PR TITLE
Update the "Wrap releases" workflow again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,19 +106,19 @@ jobs:
 
     steps:
       # If the event is a pushed release tag v1.2.3, then VERSION=1.2.3
-      # If the event is a PR #123, then VERSION=pr-123
+      # If the event is for the pull request #123, then VERSION=pr-123
       # Otherwise VERSION=branch, where <branch> is either the pushed branch, or
       # the branch selected for workflow_dispatch, or master (for a cron job).
       # In all cases, the GAP to be wrapped is put into gap-$VERSION/
       #
-      # The name of this directory is currently required for the sage-windows
-      # script, which is passed the value of $VERSION (via SAGE_VERSION)
+      # The sage-windows script requires the GAP directory to be named this way.
+      # The value $VERSION is passed to the sage-windows script as SAGE_VERSION.
       #
       # If the event is a pushed release tag, then we are wrapping a version of
       # GAP that already has its packages in place and all manuals compiled.
       # Therefore sage-windows only needs to compile GAP and the packages.
       #
-      # Otherwise, (currently) we are wrapping a cloned version of GAP.
+      # Otherwise, we wrap a cloned version of GAP.
       # In none of these cases do we build GAP's manuals, because it's too slow.
       # If the event is a PR, then we `make bootstrap-pkg-minimal` to save time
       # (none of the required packages requires compilation).
@@ -127,26 +127,36 @@ jobs:
       - name: "Set some environment variables according to the GitHub context"
         shell: bash
         run: |
+          COMPILEGAP="make -j2"
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-            COMPILEGAP="make -j2"
-            GAPDEV_DIR="gap-dev"
+            VERSION=${GITHUB_REF#refs/tags/v} # Remove prefix "v" from tag name
           else
             if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
-               VERSION=${GITHUB_REF#refs/pull/}
-               VERSION="pr-${VERSION%/merge}"
-               COMPILEGAP="make -j2 && make bootstrap-pkg-minimal"
+              COMPILEGAP="${COMPILEGAP} && make bootstrap-pkg-minimal"
+              # Extract the PR number from GITHUB_REF
+              VERSION=${GITHUB_REF#refs/pull/} # Remove prefix "refs/pull/"
+              VERSION="pr-${VERSION%/merge}"   # Remove suffix "/merge"
             elif [[ $GITHUB_REF == refs/heads/* ]]; then
-              VERSION=${GITHUB_REF#refs/heads/}
-              COMPILEGAP="make -j2 && make bootstrap-pkg-full"
+              COMPILEGAP="${COMPILEGAP} && make bootstrap-pkg-full"
+              VERSION=${GITHUB_REF#refs/heads/} # Remove prefix "refs/heads/"
             else
               echo "Unrecognised GitHub situation"
               exit 1
             fi
+          fi
+
+          # Replace any "/" characters by "-" in the version name.
+          # This variable eventually becomes part of a filename, and a "/" will
+          # eventually break something in the release_gap.sh script.
+          VERSION=${VERSION//\//-}
+
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            GAPDEV_DIR="gap-dev"
+          else
             GAPDEV_DIR="gap-$VERSION"
           fi
 
-          echo "Using data: VERSION=$VERSION / GAPDEV_DIR=$GAPDEV_DIR / COMPILEGAP=$COMPILEGAP"
+          echo "Using: VERSION=$VERSION / GAPDEV_DIR=$GAPDEV_DIR / COMPILEGAP=$COMPILEGAP"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "GAPDEV_DIR=$GAPDEV_DIR" >> $GITHUB_ENV
           echo "SAGE_RUN_CONFIGURE_CMD=\"cd \$(SAGE_ROOT) && ${COMPILEGAP}\"" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # when an annotated tag is pushed, then for some reason we don't see it
-      # in this action; instead an unannotated tag with the same is present;
-      # resolve this by force-fetching tags
+      # When an annotated tag is pushed, then for some reason we don't see it
+      # in this action; instead an unannotated tag with the same name is
+      # present, we resolve this by force-fetching tags.
+      # But we first fetch tags from gap-system/gap, so that our scripts should
+      # know about all of the 'usual' tags.
+      # Only then do we fetch tags from the current fork, which will overwrite
+      # any of those from gap-system/gap that conflict.
       - name: "Force fetch tags"
         run: |
-          git fetch --tags --force
           git fetch https://github.com/gap-system/gap --tags --force
+          git fetch --tags --force
 
       - name: "Set up Python"
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,19 +208,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO When the PR https://github.com/ChrisJefferson/sage-windows/pull/1
-      # is merged, then should be updated to ChrisJefferson/sage-windows.
-      # Ultimately, this repository should be owned by one of the GAP-related
-      # organisations, and perhaps ultimately it could/should be re-integrated
+      # The following repository should eventually be owned by a GAP-related
+      # organisation, and perhaps ultimately it could/should be re-integrated
       # with the original sagemath/sage-windows repository.
       - name: "Clone the Windows installer maker scripts"
         uses: actions/checkout@v2
         with:
-          repository: wilfwilson/sage-windows
+          repository: ChrisJefferson/sage-windows
           ref: master
           path: sage-windows
 
-      - uses: gap-actions/setup-cygwin-for-gap@v1
+      - uses: gap-actions/setup-cygwin@v1
 
       # Currently, the sage-windows/release_gap.sh script wraps the GAP
       # contained in gap-$VERSION, and outputs its installer to


### PR DESCRIPTION
There was a problem with my recent PR #4567 that I didn't catch until now. Sorry about this.

I think I have now discovered the precise cause of the problem that was (kind of) fixed in #4567
* In any fork/clone of the development version of GAP, GAP uses git's tags feature in the relevant fork/clone to determine the version of GAP.
* For users who don't fetch tags to their local clone, and/or for users you don't push their tags to their fork, this version can be quite out of date. In Alexander Hulpke's case (entirely reasonably) the latest tag was v4.8.1.
* This meant that the "Wrap releases" workflow believed that it was building and running a very old version of GAP (eg `GAP 4.8.1-8337-g2685882 of 2021-06-17`).
* This caused a problem, because the _packages_ that are included are the up-to-date ones. In particular, GAP wouldn't load because its PrimGrp requires GAP >= 4.9.0, and so `Constructing package_infos json file` would fail, and so the whole `make_archives.py` script would fail.

(Related: I'll also note that I'm pretty sure, although can't find the details now, that I have come across users of long-time installations of GAPdev who have been confused why GAP reports being an old version, despite their branches being up to date. I now presume that this is because they were not also keeping tags up to date. Is there any reasonable way to make this automatic?)

After #4567, the "Wrap releases" workflow worked around this by force-fetching tags from the fork on which it was running, and then force-fetching from gap-system/gap. But later on, the `make_archives.py` script itself would fetch tags (but not force-fetch) from the fork. Therefore there would be an error if there were conflicts between the tags on gap-system/gap and the fork.

Here is an example of it happening on my fork, where my tags for `v4.9.0`, `v4.9.1`, and `v4.10dev` differed from those on `gap-system/gap` (for some reason) https://github.com/wilfwilson/gap/runs/2845429618?check_suite_focus=true

This can be resolved by force-fetching from `gap-system/gap` _first_, and then force-fetching from the fork. I think this is the more desirable thing to do anyway.

(In this PR, I also took the opportunity to address a TODO, namely to use Chris Jefferson's fork of sage-windows, rather than my own fork of Chris's fork,  now that my changes have been merged.)