### PR TITLE
Release scripts: create and upload a file `help-links.json.gz` for use on the website

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,36 @@ jobs:
         run: dev/ci-download-pkgs.sh
       - name: "Make archives"
         run: python -u ./dev/releases/make_archives.py
+      - name: "Record the GAP build version"
+        id: get-build
+        run: |
+          # Remove the leading "tmp/" and the trailing "-core.tar.gz"
+          BUILD=`ls tmp/gap-*-core.tar.gz | cut -c 5-`
+          echo "::set-output name=name::${BUILD%-core.tar.gz}"
 
-      - name: "Upload artifacts"
+      # Upload the main GAP .tar.gz file (which includes packages).
+      # We only upload this tarball in order to minimise our demand on GitHub's
+      # resources, and that is why we also only upload these for the daily cron
+      # jobs, and in the case of an error on making a release.
+      #
+      # The artifact lives for 1 day; i.e. typically until the next cron job runs.
+      #
+      # Warning: the result is a single .zip file (so things are compressed twice).
+      - name: "Upload GAP tarball"
         if: ${{ (!startsWith(github.ref, 'refs/tags/v') && failure()) || github.event_name == 'schedule' }}
-        # Warning: the result is a single .zip file (so things are compressed twice)
-        # To keep things from exploding, we only upload a subset of all generated files
         uses: actions/upload-artifact@v2
         with:
-          name: "GAP release tarballs"
-          path: |
-            tmp/gap-*.tar.gz*
-            tmp/*json*
-            !tmp/gap-*-core.tar.gz*
+          name: ${{ steps.get-build.outputs.name }}.tar.gz
+          path: tmp/${{ steps.get-build.outputs.name }}.tar.gz
           retention-days: 1
+
+      # Always upload metadata, and keep longer, since it is much smaller.
+      - name: "Upload JSON metadata"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "JSON metadata"
+          path: tmp/*json.gz
+          retention-days: 7
 
       - name: "Make GitHub release"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/dev/releases/HelpLinks-to-JSON.g
+++ b/dev/releases/HelpLinks-to-JSON.g
@@ -1,0 +1,85 @@
+##  A utility for dumping links to all available manual sections
+##  (for use with named manual references on web pages or in search utilities).
+##
+##  The main purpose for this script is to create the help-links.json file that
+##  is used by the GAP website. This happens as part of the release process.
+##
+##  In order to be used on the GAP website, relative to a particular GAP
+##  version, this script should be run from within the corresponding released
+##  version of GAP, with exactly its bundled packages (installed in the pkg/
+##  subdirectory), and with no special user config. The GAP and package manuals
+##  are precompiled in the released version.
+
+# Temporary hack to make sure that the record components in the JSON file are
+# sorted, to increase stability in the output between GAP versions.
+# Remove once https://github.com/gap-packages/json/pull/24 is merged+released.
+InstallMethod(RecNames, [IsRecord and IsInternalRep], x -> AsSSortedList(REC_NAMES(x)));
+
+LoadPackage("json");
+out := OutputTextUser();
+r := rec();
+# load all books (without prompting the user for input)
+Perform(HELP_KNOWN_BOOKS[1], HELP_BOOK_INFO);;
+for x in NamesOfComponents(HELP_BOOKS_INFO) do
+  book := HELP_BOOKS_INFO.(x);
+
+  # We need two capitalised versions of the book name:
+  # - One with " (not loaded)" removed (we don't want this suffix, ultimately)
+  # - One with ": " added (for matching and removing this as a substring)
+  bname := ReplacedString(book.bookname, " (not loaded)", "");
+  match := Concatenation(book.bookname, ": ");
+
+  # Paths in the record <book> are full paths, which are machine-specific.
+  #
+  # For the GAP website use-case described above, for the individual items, we
+  # require paths relative to an imaginary common GAP root:
+  #   doc/{ref/tut/dev}/...    for the GAP manuals,
+  #   pkg/<pkgdir>/...         for the package manuals,
+  # where <pkgdir> agrees with the naming of the relevant bundled GAP package.
+  #
+  # If GAP is installed with packages from a release, then this can be achieved
+  # by simply removing the relevant GAP root path.
+  # We store the specific paths relative to the book directory, and we store
+  # the book directory relative to the imaginary GAP root.
+  #
+  # There seem to be two different ways to access the book directory.
+  if IsBound(book.directory) then
+    # Convert directory object to string.
+    fulldir := Filename(book.directory, "");
+  elif IsBound(book.directories) then
+    Assert(0, IsList(book.directories) and IsTrivial(book.directories));
+    # gapmacro manual: convert, and replace any trailing "/doc/" with "/htm/".
+    fulldir := Filename(book.directories[1], "");
+    if EndsWith(fulldir, "/doc/") then
+      fulldir := Concatenation(fulldir{[1 .. Length(fulldir) - 5]}, "/htm/");
+    fi;
+  else
+    Error("cannot determine the installation directory of the book: ", book);
+  fi;
+  reldir := ShallowCopy(fulldir);
+  for root in GAPInfo.RootPaths do
+    reldir := ReplacedString(reldir, root, "");
+  od;
+
+  r.(bname) := rec(directory := reldir, reference := rec());
+
+  for i in [1 .. Length(book.entries)] do
+    entry := HELP_BOOK_HANDLER.HelpDataRef(book, i);
+    name := StripEscapeSequences(entry[1]);
+    name := ReplacedString(name, match, "");
+    NormalizeWhitespace(name);
+
+    path := entry[6];
+    if path = fail then
+      path := "FAIL";
+    else
+      path := ReplacedString(path, fulldir, "");
+      path := ReplacedString(path, "_mj.html", ".html");
+    fi;
+
+    r.(bname).reference.(name) := path;
+  od;
+od;
+
+GapToJsonStream(out, r);;
+QUIT;

--- a/dev/releases/PackageInfos-to-JSON.g
+++ b/dev/releases/PackageInfos-to-JSON.g
@@ -1,3 +1,8 @@
+# Temporary hack to make sure that the record components in the JSON file are
+# sorted, to increase stability in the output between GAP versions.
+# Remove once https://github.com/gap-packages/json/pull/24 is merged+released.
+InstallMethod(RecNames, [IsRecord and IsInternalRep], x -> AsSSortedList(REC_NAMES(x)));
+
 LoadPackage("json");
 
 InstallMethod(_GapToJsonStreamInternal,

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import json
 
 # Insist on Python >= 3.6 for f-strings and other goodies
 if sys.version_info < (3,6):
@@ -170,9 +171,10 @@ with working_directory(tmpdir + "/" + basename):
         json_output = subprocess.run(
                 ["./bin/gap.sh", "-r", "--quiet", "--quitonbreak", f"dev/releases/{x[1]}.g"],
                 check=True, capture_output=True, text=True)
+        formatted_json = json.dumps(json.loads(json_output.stdout), indent=2)
         with working_directory(tmpdir):
             with gzip.open(f"{x[0]}.json.gz", 'wb') as file:
-                file.write(json_output.stdout.encode('utf-8'))
+                file.write(formatted_json.encode('utf-8'))
             manifest_list.append(f"{x[0]}.json.gz")
 
     notice("Cleaning up the json package")


### PR DESCRIPTION
This is an adaptation of the script https://github.com/gap-system/GapWWW/blob/master/etc/LinksOfAllHelpSections.g from the [GapWWW repository](https://github.com/gap-system/GapWWW).

I think that the updated script is a bit more robust/clear. The output is now JSON rather than YAML. I think it makes sense to build this information once, here, while making all of the other archives, and then upload it to the GitHub release.

In my PR https://github.com/gap-system/GapWWW/pull/247; I have deleted `LinksOfAllHelpSections.g` and updated the website to use this new `help-links.json` file to get its information about links in the manuals.

The reason that I now additionally **format** the outputted JSON files (with Python) is that it makes it much easier to see changes (i.e. to do a diff between GAP versions), and the extra characters come at a minimal space cost.

I am working on another PR to _this_ repository which updates (and massively simplifies) `dev/releases/update_website.py` to play nicely with the new system introduced by this PR and by https://github.com/gap-system/GapWWW/pull/247.

If you're happy, I think this is ready to merge.