### PR TITLE
Performance improvements and cleanup related to permutation representations

### DIFF
--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -692,7 +692,7 @@ end);
 BADINDEX:=1000; # the index that is too big
 GenericFindActionKernel:=function(arg)
 local G, N, knowi, goodi, simple, uc, zen, cnt, pool, ise, v, bv, badi,
-totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i;
+totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i,hard;
 
   G:=arg[1];
   N:=arg[2];
@@ -774,6 +774,12 @@ totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i;
 
   badcores:=[];
   badi:=BADINDEX;
+  hard:=ValueOption("hard");
+  if hard=fail then
+    hard:=100000;
+  elif hard=true then
+    hard:=10000;
+  fi;
   totalcnt:=0;
   interupt:=false;
   cnt:=20;
@@ -804,7 +810,7 @@ totalcnt, interupt, u, nu, cor, zzz,bigperm,perm,badcores,max,i;
 	fi;
 	totalcnt:=totalcnt+1;
 	if KnownNaturalHomomorphismsPool(G,N) and
-	  Minimum(IndexNC(G,v),knowi)<100000 
+	  Minimum(IndexNC(G,v),knowi)<hard 
 	     and 5*totalcnt>Minimum(IndexNC(G,v),knowi,1000) then
 	  # interupt if we're already quite good
 	  interupt:=true;

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -512,13 +512,18 @@ DeclareSynonym("EmbeddingConjugates",ContainingConjugates);
 ##  <#GAPDoc Label="MinimalFaithfulPermutationDegree">
 ##  <ManSection>
 ##  <Oper Name="MinimalFaithfulPermutationDegree" Arg='G'/>
+##  <Oper Name="MinimalFaithfulPermutationRepresentation" Arg='G'/>
 ##
 ##  <Description>
-##  For  a finite group <A>G</A> this operation calculates the least
+##  For  a finite group <A>G</A>,
+##  <Ref Oper="MinimalFaithfulPermutationDegree"/>
+##  calculates the least
 ##  positive integer <M>n=\mu(G)</M> such that <A>G</A> is isomorphic to a
 ##  subgroup of the symmetric group of degree <M>n</M>.
 ##  This can require calculating the whole subgroup lattice.
-##  If the option `representation` is given, the operation returns the
+##  The operation
+##  <Ref Oper="MinimalFaithfulPermutationRepresentation"/>
+##  returns a
 ##  corresponding isomorphism.
 ##  <Example><![CDATA[
 ##  gap> MinimalFaithfulPermutationDegree(SmallGroup(96,3));
@@ -526,7 +531,7 @@ DeclareSynonym("EmbeddingConjugates",ContainingConjugates);
 ##  gap> g:=TransitiveGroup(10,32);;
 ##  gap> MinimalFaithfulPermutationDegree(g);
 ##  6
-##  gap> map:=MinimalFaithfulPermutationDegree(g:representation);;
+##  gap> map:=MinimalFaithfulPermutationRepresentation(g);;
 ##  gap> Size(Image(map));
 ##  720
 ##  ]]></Example>
@@ -535,6 +540,8 @@ DeclareSynonym("EmbeddingConjugates",ContainingConjugates);
 ##  <#/GAPDoc>
 ##
 DeclareOperation("MinimalFaithfulPermutationDegree",[IsGroup and IsFinite]);
+DeclareOperation("MinimalFaithfulPermutationRepresentation",
+  [IsGroup and IsFinite]);
 
 #############################################################################
 ##

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3295,14 +3295,13 @@ local l,N,t,gens,i,c,o,rep,r,sub,gen;
   fi;
 end);
 
-InstallMethod(MinimalFaithfulPermutationDegree,"use lattice",true,
-  [IsGroup and IsFinite],0,
-function(G)
+BindGlobal("DoMinimalFaithfulPermutationDegree",
+function(G,dorep)
 local c,n,deg,ind,core,i,j,sum;
   if Size(G)=1 then
     # option allows to calculate actual representation -- maybe access under
     # different name
-    if ValueOption("representation")<>true then
+    if dorep=false then
       return 1;
     else
       return GroupHomomorphismByImages(G,Group(()),[One(G)],[()]);
@@ -3344,7 +3343,7 @@ local c,n,deg,ind,core,i,j,sum;
 
   od;
 
-  if ValueOption("representation")<>true then
+  if dorep=false then
     return deg[Length(n)][1]; # smallest degree
   fi;
   # calculate the representation
@@ -3361,6 +3360,23 @@ local c,n,deg,ind,core,i,j,sum;
 
   return GroupHomomorphismByImages(G,ind,GeneratorsOfGroup(G),sum);
 
+end);
+
+InstallMethod(MinimalFaithfulPermutationDegree,"use lattice",true,
+  [IsGroup and IsFinite],0,
+function(G)
+  if ValueOption("representation")=true then
+    Error("Use of the `representation` option discontinued,\n",
+    "Use `MinimalFaithfulPermutationRepresentation` instead");
+    return MinimalFaithfulPermutationRepresentation(G);
+  fi;
+  return DoMinimalFaithfulPermutationDegree(G,false);
+end);
+
+InstallMethod(MinimalFaithfulPermutationRepresentation,"use lattice",true,
+  [IsGroup and IsFinite],0,
+function(G)
+  return DoMinimalFaithfulPermutationDegree(G,true);
 end);
 
 

--- a/lib/oprtglat.gi
+++ b/lib/oprtglat.gi
@@ -134,6 +134,21 @@ function(G,dom,all)
   fi;
   savemem:=ValueOption("savemem");
   n:=Length(dom);
+  if n>20 and ForAll(dom,x->IsSubset(G,x)) 
+    and NrMovedPoints(G)>1000 
+    and NrMovedPoints(G)*1000>Size(G) then
+
+    b:=SmallerDegreePermutationRepresentation(G:cheap);
+    if NrMovedPoints(Range(b))<NrMovedPoints(G) then
+#Print("Degreduce ",NrMovedPoints(G)," => ",NrMovedPoints(Range(b)),"\n");
+      dom:=SubgroupsOrbitsAndNormalizers(Image(b,G),
+        List(dom,x->Image(b,x)),all);
+      dom:=List(dom,x->rec(pos:=x.pos,normalizer:=PreImage(b,x.normalizer),
+        representative:=PreImage(b,x.representative)));
+      return dom;
+    fi;
+  fi;
+
   l:=n;
   o:=[];
   # determine some points that distinguish groups


### PR DESCRIPTION
- When calculating transversals in large degree permutation groups, do not maintain large image lists
- Option to work harder on finding a smaller degree permutation representation
- Action on subgroups may use reduced degree if appropriate  (can speed up subgroup lattice)
- Clean up interface of `MinimalFaithfulPermutationDegree` (avoid use of option for getting representation)
- 
## Text for release notes

None

## Further details

