### PR TITLE
More formatting status related changes

### DIFF
--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1226,10 +1226,12 @@ InstallOtherMethod( PrintFormattingStatus, "for stdout", [IsString],
 function(str)
   if str = "*stdout*" then
     return PRINT_FORMATTING_STDOUT();
+  elif str = "*errout*" then
+    return PRINT_FORMATTING_ERROUT();
   elif str = "*current*" then
     return PRINT_FORMATTING_CURRENT();
   else
-    Error("Only the strings \"*stdout*\" and  \"*current*\" are recognized by this method.");
+    Error("Only the strings \"*stdout*\", \"*errout*\" and  \"*current*\" are recognized by this method.");
   fi;
 end);
 
@@ -1237,10 +1239,12 @@ InstallOtherMethod( SetPrintFormattingStatus, "for stdout", [IsString, IsBool],
 function(str, status)
   if str = "*stdout*" then
     SET_PRINT_FORMATTING_STDOUT(status);
+  elif str = "*errout*" then
+    SET_PRINT_FORMATTING_ERROUT(status);
   elif str = "*current*" then
     SET_PRINT_FORMATTING_CURRENT(status);
   else
-    Error("Only the strings \"*stdout*\" and  \"*current*\" are recognized by this method.");
+    Error("Only the strings \"*stdout*\", \"*errout*\" and  \"*current*\" are recognized by this method.");
   fi;
 end);
 

--- a/tst/testspecial/print-formatting.g
+++ b/tst/testspecial/print-formatting.g
@@ -20,3 +20,14 @@ Display(x -> x);
 SetPrintFormattingStatus("*current*", old);;
 PrintFormattingStatus("*current*");
 
+# test formatting status for errout
+1/0; # trigger a break loop
+old := PrintFormattingStatus("*errout*");
+SetPrintFormattingStatus("*errout*", false);
+PrintFormattingStatus("*errout*");
+Display(x -> x);
+SetPrintFormattingStatus("*errout*", true);
+PrintFormattingStatus("*errout*");
+Display(x -> x);
+SetPrintFormattingStatus("*errout*", old);;
+PrintFormattingStatus("*errout*");

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -40,4 +40,28 @@ gap> SetPrintFormattingStatus("*current*", old);;
 gap> PrintFormattingStatus("*current*");
 true
 gap> 
-gap> QUIT;
+gap> # test formatting status for errout
+gap> 1/0; # trigger a break loop
+Error, Rational operations: <divisor> must not be zero
+not in any function at *stdin*:25
+type 'quit;' to quit to outer loop
+brk> old := PrintFormattingStatus("*errout*");
+true
+brk> SetPrintFormattingStatus("*errout*", false);
+brk> PrintFormattingStatus("*errout*");
+false
+brk> Display(x -> x);
+function ( x )
+return x;
+end
+brk> SetPrintFormattingStatus("*errout*", true);
+brk> PrintFormattingStatus("*errout*");
+true
+brk> Display(x -> x);
+function ( x )
+    return x;
+end
+brk> SetPrintFormattingStatus("*errout*", old);;
+brk> PrintFormattingStatus("*errout*");
+true
+brk> QUIT;


### PR DESCRIPTION
- "Remember" the formatting status for `*stdout*`  when we close and reopen it
- Implement `(Set)PrintFormattingStatus` for `*errout*`