### PR TITLE
kernel: use errno.h as in other files

### DIFF
--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -24,8 +24,8 @@
 #include "sysfiles.h"
 #include "system.h"
 
+#include <errno.h>
 #include <stddef.h>
-#include <sys/errno.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
This fixes a cross compilation issue for me; it is also
consistent with other kernel source files.