### PR TITLE
reordering parameters in calls of NewMatrix

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -269,7 +269,7 @@ InstallMethod( ZeroVector,
 ##
 InstallMethod( Matrix,
   [ IsOperation, IsSemiring, IsList, IsInt ],
-  { filt, R, list, nrCols } -> NewMatrix( filt, R, nrCols, list ) );
+  { filt, R, list, nrCols } -> NewMatrix( filt, R, list, nrCols ) );
 
 InstallMethod( Matrix,
     [ IsOperation, IsSemiring, IsList ],
@@ -278,18 +278,18 @@ InstallMethod( Matrix,
       Error( "<list> must be not empty; ",
              "to create empty matrices, please specify nrCols");
     fi;
-    return NewMatrix( filt, R, Length( list[1] ), list );
+    return NewMatrix( filt, R, list, Length( list[1] ) );
   end );
 
 InstallMethod( Matrix,
     [ IsOperation, IsSemiring, IsMatrixObj ],
-    { filt, R, mat } -> NewMatrix( filt, R, NrCols( mat ), Unpack( mat ) ) );
+    { filt, R, mat } -> NewMatrix( filt, R, Unpack( mat ), NrCols( mat ) ) );
 # TODO: can we do better? encourage MatrixObj implementors to overload this?
 
 InstallMethod( Matrix,
     [ IsSemiring, IsList, IsInt ],
     { R, list, nrCols } -> NewMatrix( DefaultMatrixRepForBaseDomain( R ),
-                                      R, nrCols, list ) );
+                                      R, list, nrCols ) );
 
 InstallMethod( Matrix,
     [ IsSemiring, IsList ],
@@ -298,13 +298,13 @@ InstallMethod( Matrix,
       Error( "list must be not empty" );
     fi;
     return NewMatrix( DefaultMatrixRepForBaseDomain( R ),
-                      R, Length( list[1] ), list );
+                      R, list, Length( list[1] ) );
     end );
 
 InstallMethod( Matrix,
     [ IsSemiring, IsMatrixObj ],
     { R, M } -> NewMatrix( DefaultMatrixRepForBaseDomain( R ),
-                           R, NrCols( M ), Unpack( M ) ) );
+                           R, Unpack( M ), NrCols( M ) ) );
 # TODO: can we do better? encourage MatrixObj implementors to overload this?
 
 #
@@ -318,7 +318,7 @@ InstallMethod( Matrix,
     if Length(list[1]) = 0 then Error("list[1] must be not empty, please specify base domain explicitly"); fi;
     basedomain := DefaultScalarDomainOfMatrixList([list]);
     rep := DefaultMatrixRepForBaseDomain(basedomain);
-    return NewMatrix( rep, basedomain, nrCols, list );
+    return NewMatrix( rep, basedomain, list, nrCols );
   end );
 
 InstallMethod( Matrix,
@@ -333,7 +333,7 @@ InstallMethod( Matrix,
     fi;
     R:= DefaultScalarDomainOfMatrixList( [ list ] );
     rep := DefaultMatrixRepForBaseDomain( R );
-    return NewMatrix( rep, R , Length( list[1] ), list );
+    return NewMatrix( rep, R , list, Length( list[1] ) );
   end );
 
 #
@@ -342,7 +342,7 @@ InstallMethod( Matrix,
 InstallMethod( Matrix,
   [IsList, IsInt, IsMatrixOrMatrixObj],
   function( list, nrCols, example )
-    return NewMatrix( ConstructingFilter(example), BaseDomain(example), nrCols, list );
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), list, nrCols );
   end );
 
 InstallMethod( Matrix, "generic convenience method with 2 args",
@@ -354,7 +354,7 @@ InstallMethod( Matrix, "generic convenience method with 2 args",
     if not (IsList(list[1]) or IsVectorObj(list[1])) then
         ErrorNoReturn("Matrix: flat data not supported in two-argument version");
     fi;
-    return NewMatrix( ConstructingFilter(example), BaseDomain(example), Length(list[1]), list );
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), list, Length(list[1]) );
   end );
 
 InstallMethod( Matrix,
@@ -362,7 +362,7 @@ InstallMethod( Matrix,
     function( mat, example )
     # TODO: can we avoid using Unpack? resp. make this more efficient
     # perhaps adjust NewMatrix to take an IsMatrixOrMatrixObj?
-    return NewMatrix( ConstructingFilter(example), BaseDomain(example), NrCols(mat), Unpack(mat) );
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), Unpack(mat), NrCols(mat) );
   end );
 
 #
@@ -1402,8 +1402,8 @@ InstallMethod( String,
     M -> Concatenation( "NewMatrix( ",
                NameFunction( ConstructingFilter( M ) ), ", ",
                String( BaseDomain( M ) ), ", ",
-               String( NumberColumns( M ) ), ", ",
-               String( Unpack( M ) ), " )" ) );
+               String( Unpack( M ) ), ", ",
+               String( NumberColumns( M ) ), ", " ) );
 
 
 ############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -799,14 +799,14 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 
 #############################################################################
 ##
-#O  NewMatrix( <filt>, <R>, <ncols>, <list> )
+#O  NewMatrix( <filt>, <R>, <list>, <ncols> )
 #O  NewZeroMatrix( <filt>, <R>, <m>, <n> )
 #O  NewIdentityMatrix( <filt>, <R>, <n> )
 ##
 ##  <#GAPDoc Label="NewMatrix">
 ##  <ManSection>
 ##  <Heading>NewMatrix, NewZeroMatrix, NewIdentityMatrix</Heading>
-##  <Constr Name="NewMatrix" Arg='filt,R,ncols,list'/>
+##  <Constr Name="NewMatrix" Arg='filt,R,list,ncols'/>
 ##  <Constr Name="NewZeroMatrix" Arg='filt,R,m,n'/>
 ##  <Constr Name="NewIdentityMatrix" Arg='filt,R,n'/>
 ##
@@ -846,7 +846,7 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareConstructor( "NewMatrix", [ IsMatrixOrMatrixObj, IsSemiring, IsInt, IsList] );
+DeclareConstructor( "NewMatrix", [ IsMatrixOrMatrixObj, IsSemiring, IsList, IsInt] );
 
 DeclareConstructor( "NewZeroMatrix",
     [ IsMatrixOrMatrixObj, IsSemiring, IsInt, IsInt ] );

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -60,9 +60,9 @@ InstallMethod( NewZeroVector, "for IsPlistVectorRep, a ring, and an int",
   end );
 
 InstallMethod( NewMatrix,
-  "for IsPlistMatrixRep, a ring, an int, and a list",
-  [ IsPlistMatrixRep, IsRing, IsInt, IsList ],
-  function( filter, basedomain, rl, l )
+  "for IsPlistMatrixRep, a ring, a list, and an int",
+  [ IsPlistMatrixRep, IsRing, IsList, IsInt ],
+  function( filter, basedomain, l, rl )
     local nd, filterVectors, m, e, filter2, i;
 
     # If applicable then replace a flat list 'l' by a nested list
@@ -875,9 +875,9 @@ InstallMethod( String, "for plist matrix", [ IsPlistMatrixRep ],
         Append(st,String(m![BDPOS]));
         Append(st,",");
     fi;
-    Append(st,String(NumberColumns(m)));
-    Add(st,',');
     Append(st,String(Unpack(m)));
+    Add(st,',');
+    Append(st,String(NumberColumns(m)));
     Add(st,')');
     return st;
   end );
@@ -1254,8 +1254,8 @@ InstallMethod( ChangedBaseDomain, "for a plist vector, and a domain",
 InstallMethod( ChangedBaseDomain, "for a plist matrix, and a domain",
   [ IsPlistMatrixRep, IsRing ],
   function( m, r )
-    return NewMatrix(IsPlistMatrixRep, r, NumberColumns(m),
-                     List(m![ROWSPOS], x-> x![ELSPOS]));
+    return NewMatrix(IsPlistMatrixRep, r, 
+                     List(m![ROWSPOS], x-> x![ELSPOS]), NumberColumns(m) );
   end );
 
 InstallMethod( CompatibleVector, "for a plist matrix",
@@ -1276,7 +1276,7 @@ InstallMethod( NewCompanionMatrix,
         Error("CompanionMatrix: polynomial is not monic");
         return fail;
     fi;
-    ll := NewMatrix(IsPlistMatrixRep,bd,n,[]);
+    ll := NewMatrix(IsPlistMatrixRep,bd,[],n);
     l := Vector(-l{[1..n]},CompatibleVector(ll));
     for i in [1..n-1] do
         Add(ll,ZeroMutable(l));

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1112,9 +1112,9 @@ InstallMethod( NewZeroVector, "for Is8BitVectorRep, GF(q), and an int",
     return v;
   end );
 
-InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsList ],
-  function( filter, f, rl, l )
+InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an list, and an int",
+  [ Is8BitMatrixRep, IsField and IsFinite, IsList, IsInt ],
+  function( filter, f, l, rl )
     local m;
     if not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");
@@ -1214,7 +1214,7 @@ InstallMethod( NewCompanionMatrix,
     fi;
     l := -l{[1..n]};
     ConvertToVectorRep(l,Size(bd));
-    ll := NewMatrix(ty,bd,n,[l]);
+    ll := NewMatrix(ty,bd,[l],n);
     for i in [1..n-1] do
         Add(ll,ZeroMutable(l),i);
         ll[i][i+1] := one;

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2455,9 +2455,9 @@ InstallMethod( NewZeroVector, "for IsGF2VectorRep, GF(2), and an int",
     return ZERO_GF2VEC_2(i);
   end );
 
-InstallMethod( NewMatrix, "for IsGF2MatrixRep, GF(2), an int, and a list",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt, IsList ],
-  function( filter, f, rl, l )
+InstallMethod( NewMatrix, "for IsGF2MatrixRep, GF(2), a list, and an int",
+  [ IsGF2MatrixRep, IsField and IsFinite, IsList, IsInt ],
+  function( filter, f, l, rl )
     local m;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
     m := List(l,ShallowCopy);
@@ -2552,7 +2552,7 @@ InstallMethod( NewCompanionMatrix,
     fi;
     l := -l{[1..n]};
     ConvertToVectorRep(l,2);
-    ll := NewMatrix(ty,bd,n,[l]);
+    ll := NewMatrix(ty,bd,[l],n);
     for i in [1..n-1] do
         Add(ll,ZeroMutable(l),i);
         ll[i,i+1] := one;


### PR DESCRIPTION
This PR addresses issue #4549 : "The two methods in matobj.gi have the following form: NewMatrix( filt, R, ncols, list ) and Matrix( filt, R, list, ncols ).  This inconsistency is unacceptable in the long run." 

## Text for release notes

The ordering of arguments in the NewMatrix operation have been changed to agree with those used in Matrix.  So 
NewMatrix( filt, R, ncols, list ) has been replaced by NewMatrix( filt, R, list, ncols ). 