### PR TITLE
Add CALL_WITH_STREAM helper

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -506,6 +506,34 @@ Int READ_GAP_ROOT ( const Char * filename )
 
 /****************************************************************************
 **
+*F  FuncCALL_WITH_STREAM( <stream>, <func>, <args> )
+**
+**  Temporarily set the active output stream to <stream>, then call the
+**  function <func> with the arguments in the list <args>. This can for
+**  example be used to capture the output of a function into a string.
+*/
+static Obj FuncCALL_WITH_STREAM(Obj self, Obj stream, Obj func, Obj args)
+{
+    RequireOutputStream(SELF_NAME, stream);
+    RequireSmallList(SELF_NAME, args);
+
+    TypOutputFile output = { 0 };
+    if (!OpenOutputStream(&output, stream)) {
+        ErrorQuit("CALL_WITH_STREAM: cannot open stream for output", 0, 0);
+    }
+
+    Obj result = CallFuncList(func, args);
+
+    if (!CloseOutput(&output)) {
+        ErrorQuit("CALL_WITH_STREAM: cannot close output", 0, 0);
+    }
+
+    return result;
+}
+
+
+/****************************************************************************
+**
 *F  FuncCLOSE_LOG_TO()  . . . . . . . . . . . . . . . . . . . .  stop logging
 **
 **  'FuncCLOSE_LOG_TO' implements a method for 'LogTo'.
@@ -1739,13 +1767,15 @@ static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC_1ARGS(READ, input),
     GVAR_FUNC_1ARGS(READ_NORECOVERY, input),
-    GVAR_FUNC_4ARGS(READ_ALL_COMMANDS, instream, echo, capture, resultCallback),
+    GVAR_FUNC_4ARGS(
+        READ_ALL_COMMANDS, instream, echo, capture, resultCallback),
     GVAR_FUNC_2ARGS(READ_COMMAND_REAL, stream, echo),
     GVAR_FUNC_2ARGS(READ_STREAM_LOOP, stream, catchstderrout),
     GVAR_FUNC_3ARGS(
         READ_STREAM_LOOP_WITH_CONTEXT, stream, catchstderrout, context),
     GVAR_FUNC_1ARGS(READ_AS_FUNC, input),
     GVAR_FUNC_1ARGS(READ_GAP_ROOT, filename),
+    GVAR_FUNC_3ARGS(CALL_WITH_STREAM, stream, func, args),
     GVAR_FUNC_1ARGS(LOG_TO, filename),
     GVAR_FUNC_1ARGS(LOG_TO_STREAM, filename),
     GVAR_FUNC_0ARGS(CLOSE_LOG_TO),

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -8,6 +8,20 @@ gap> LastSystemError();
 rec( message := "no error", number := 0 )
 
 #
+gap> str := "";;
+gap> out := OutputTextString(str, false);;
+gap> SetPrintFormattingStatus(out, false);
+gap> CALL_WITH_STREAM(fail, fail, fail);
+Error, CALL_WITH_STREAM: <stream> must be an output stream (not the value 'fai\
+l')
+gap> CALL_WITH_STREAM(out, fail, fail);
+Error, CALL_WITH_STREAM: <args> must be a small list (not the value 'fail')
+gap> CALL_WITH_STREAM(out, Display, [ [[1,2],[3,4]] ]);
+gap> CloseStream(out);
+gap> str;
+"[ [  1,  2 ],\n  [  3,  4 ] ]\n"
+
+#
 gap> CLOSE_LOG_TO();
 Error, LogTo: cannot close the logfile
 gap> LOG_TO(fail);


### PR DESCRIPTION
This allows calling a function while redirect the GAP output to a given stream. This is e.g. useful for the Julia-GAP interface, but can also be used for other GAP interfaces, and probably also has all kinds of other applications.

I am not saying this is the greatest interface, we could argue a lot about that: e.g. perhaps it should instead (or in addition?) be a function available on the kernel level via `libgap-api.h`. But note that I think it's useful to be able to call this from GAP; and from there it is reachable for libgap users, albeit with some overhead for going though the GAP function call machinery. 

Since I am not yet sure this is the best way to go, I delieberately left this as an undocumented kernel function for now -- if we decide it is good, we can come up with a high level name (`CallWithStream`), and possible add some nicer variants (say `CallFuncWithListAndOuputStream`).

But this particular function has already been used as-is for some time in the GAP-Julia interface, so it seems useful to me to have to it. I'd like to have it in the kernel to decouple it from implementation details of the kernel.

CC @embray 