### PR TITLE
Add CALL_WITH_FORMATTING_STATUS helper

### DIFF
--- a/lib/info.gi
+++ b/lib/info.gi
@@ -65,11 +65,7 @@ end);
 
 
 BIND_GLOBAL( "PrintWithoutFormatting", function ( arg )
-    local old;
-    old := PrintFormattingStatus("*current*");
-    SetPrintFormattingStatus("*current*", false);
-    CallFuncList(Print, arg);
-    SetPrintFormattingStatus("*current*", old);
+    CALL_WITH_FORMATTING_STATUS(false, Print, arg);
 end );
 
 

--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -974,8 +974,9 @@ DeclareGlobalFunction( "InputOutputLocalProcess" );
 ##  If as argument <A>stream</A> the string <C>"*stdout*"</C> is given, these
 ##  functions refer to the formatting status of the standard output (so usually
 ##  the users terminal screen).<P/>
-##  If as argument <A>stream</A> the string <C>"*current*"</C> is given, these
-##  functions refer to the formatting status of the currently active output.<P/>
+##  Similarly, the string <C>"*errout*"</C> refers to the formatting status
+##  of the standard error output, which influences how error messages are
+##  printed.<P/>
 ##  These functions do not influence the behaviour of the low level functions 
 ##  <Ref Oper="WriteByte"/>, 
 ##  <Ref Oper="WriteLine"/> or  <Ref Oper="WriteAll"/> which always write

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1228,10 +1228,8 @@ function(str)
     return PRINT_FORMATTING_STDOUT();
   elif str = "*errout*" then
     return PRINT_FORMATTING_ERROUT();
-  elif str = "*current*" then
-    return PRINT_FORMATTING_CURRENT();
   else
-    Error("Only the strings \"*stdout*\", \"*errout*\" and  \"*current*\" are recognized by this method.");
+    Error("Only the strings \"*stdout*\" and \"*errout*\" are recognized by this method.");
   fi;
 end);
 
@@ -1241,10 +1239,8 @@ function(str, status)
     SET_PRINT_FORMATTING_STDOUT(status);
   elif str = "*errout*" then
     SET_PRINT_FORMATTING_ERROUT(status);
-  elif str = "*current*" then
-    SET_PRINT_FORMATTING_CURRENT(status);
   else
-    Error("Only the strings \"*stdout*\", \"*errout*\" and  \"*current*\" are recognized by this method.");
+    Error("Only the strings \"*stdout*\" and \"*errout*\" are recognized by this method.");
   fi;
 end);
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -522,7 +522,16 @@ static Obj FuncCALL_WITH_STREAM(Obj self, Obj stream, Obj func, Obj args)
         ErrorQuit("CALL_WITH_STREAM: cannot open stream for output", 0, 0);
     }
 
-    Obj result = CallFuncList(func, args);
+    Obj result;
+    GAP_TRY
+    {
+        result = CallFuncList(func, args);
+    }
+    GAP_CATCH
+    {
+        CloseOutput(&output);
+        GAP_THROW();
+    }
 
     if (!CloseOutput(&output)) {
         ErrorQuit("CALL_WITH_STREAM: cannot close output", 0, 0);

--- a/tst/testinstall/print-formatting.tst
+++ b/tst/testinstall/print-formatting.tst
@@ -1,8 +1,29 @@
-gap> SetPrintFormattingStatus("*current*",false); Display(x -> x);
+#
+gap> CALL_WITH_FORMATTING_STATUS(fail, fail, fail);
+Error, CALL_WITH_FORMATTING_STATUS: <status> must be 'true' or 'false' (not th\
+e value 'fail')
+gap> CALL_WITH_FORMATTING_STATUS(false, fail, fail);
+Error, CALL_WITH_FORMATTING_STATUS: <args> must be a small list (not the value\
+ 'fail')
+gap> CALL_WITH_FORMATTING_STATUS(false, Display, [x -> x]);
 function ( x )
 return x;
 end
+
+# for comparison
 gap> Display(x -> x);
 function ( x )
     return x;
 end
+
+#
+gap> str := JoinStringsWithSeparator(ListWithIdenticalEntries(20, "abcd 1234"), " ");
+"abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 12\
+34 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd \
+1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234"
+gap> PrintWithoutFormatting(str, "\n");
+abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234
+gap> Print(str, "\n");
+abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 123\
+4 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1234 abcd 1\
+234 abcd 1234 abcd 1234 abcd 1234 abcd 1234

--- a/tst/testspecial/print-formatting.g
+++ b/tst/testspecial/print-formatting.g
@@ -9,17 +9,6 @@ Display(x -> x);
 SetPrintFormattingStatus("*stdout*", old);;
 PrintFormattingStatus("*stdout*");
 
-# test formatting status for current output
-old := PrintFormattingStatus("*current*");
-SetPrintFormattingStatus("*current*", false);
-PrintFormattingStatus("*current*");
-Display(x -> x);
-SetPrintFormattingStatus("*current*", true);
-PrintFormattingStatus("*current*");
-Display(x -> x);
-SetPrintFormattingStatus("*current*", old);;
-PrintFormattingStatus("*current*");
-
 # test formatting status for errout
 1/0; # trigger a break loop
 old := PrintFormattingStatus("*errout*");

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -19,31 +19,10 @@ gap> SetPrintFormattingStatus("*stdout*", old);;
 gap> PrintFormattingStatus("*stdout*");
 true
 gap> 
-gap> # test formatting status for current output
-gap> old := PrintFormattingStatus("*current*");
-true
-gap> SetPrintFormattingStatus("*current*", false);
-gap> PrintFormattingStatus("*current*");
-false
-gap> Display(x -> x);
-function ( x )
-return x;
-end
-gap> SetPrintFormattingStatus("*current*", true);
-gap> PrintFormattingStatus("*current*");
-true
-gap> Display(x -> x);
-function ( x )
-    return x;
-end
-gap> SetPrintFormattingStatus("*current*", old);;
-gap> PrintFormattingStatus("*current*");
-true
-gap> 
 gap> # test formatting status for errout
 gap> 1/0; # trigger a break loop
 Error, Rational operations: <divisor> must not be zero
-not in any function at *stdin*:25
+not in any function at *stdin*:14
 type 'quit;' to quit to outer loop
 brk> old := PrintFormattingStatus("*errout*");
 true


### PR DESCRIPTION
... and remove again (SET_)PRINT_FORMATTING_CURRENT resp.
`SetPrintFormattingStatus("*current*",false);`. Those APIs always seemed a bit
awkward to me (albeit pragmatic), e.g. there were doubts in my mind whether or
not these should just temporarily modify the formatting status (which is what
they were added for), or modify it more permanently by also calling
`SetPrintFormattingStatus` on the underlying stream object (which would be
consistent with how `SetPrintFormattingStatus` behaves otherwise)

Another advantage of this approach is that it nicely composes with the
`CALL_WITH_STREAM` added in PR #4587; I.e., if one wants to print to
a specific output and at the same time temporarily modify the formatting status
of that output, one could do it this way:

```gap
CALL_WITH_FORMATTING_STATUS(false, CALL_WITH_STREAM, [stream, func, args]);
```
