### PR TITLE
Simplify `dev/releases/update-website.py` for the new GapWWW structure

### DIFF
--- a/dev/releases/README.md
+++ b/dev/releases/README.md
@@ -1,102 +1,102 @@
-# How To Make a GAP Release for version Z.X.Y
+# How to release GAP version X.Y.Z
  
-**This release process assumes the following**
-- A stable branch of GAP has been identified or agreed upon. This branch will be identified here as `stable-Z.X.Y` and the release notes in `CHANGES.md` have been created.
-- You run these scripts in the root directory of a clone of the [GAP repository](https://github.com/gap-system/gap)
-- You have compiled this clone of GAP
-- You have a clone of the [GapWWW repository](https://github.com/gap-system/GapWWW)
+**These instructions assume the following**
+- It has been agreed to make a release called `X.Y.Z` from the `stable-X.Y` branch.
+	- Note that most likely `X=4` for the foreseeable future.
+- All changes to be included in the release are now present in the `stable-X.Y` branch.
+	- This includes the release notes for version `X.Y.Z` being included in `CHANGES.md`.
 
-## Dependencies
-Before starting the release process, the scripts have the following dependencies. Make sure you have the following installed and up to date
+
+## The release process for GAP -- the quick guide
+
+This is the way the process should happen in practice, with the help of GitHub Actions. Instructions for achieving the same without GitHub Actions are given later (in case GitHub Actions breaks or disappears).
+
+1. Access your local clone of the GAP repository.
+2. Make sure that your clone is up to date with `gap-system/gap`.
+3. Create an annotated tag `vX.Y.Z` in your clone at the appropriate commit in the `stable-X.Y` branch, and push the tag to `gap-system/gap`. For example:
+    ```
+    git tag -m "Version X.Y.Z" vX.Y.Z stable-X.Y
+    git push origin vX.Y.Z
+    ```  
+4. Wait. Pushing the tag will trigger the “[Wrap releases](https://github.com/gap-system/gap/actions/workflows/release.yml)” GitHub Actions workflow on `gap-system/gap`, which wraps the release archives and Windows installers, and creates a release on GitHub with the archives and installers attached. This takes around 90 minutes.
+5. Once the “Wrap releases” workflow is finished, either manually dispatch the “[Sync](https://github.com/gap-system/GapWWW/actions/workflows/sync.yml)” GitHub Actions workflow on `gap-system/GapWWW`, or wait overnight for it to happen on schedule.
+	- This Workflow creates a pull request to `gap-system/GapWWW`, which updates the GAP website according to the release data hosted on `gap-system/gap`.  Check that the result is sensible.
+6. When it is time to publicise the new GAP release, merge the pull request to GapWWW.
+7. There are currently additional steps required for the changes to appear on <https://www.gap-system.org>, which could be automated but are currently not; these are described in steps 10–13 below.
+
+
+## The release process for GAP -- the more detailed guide
+
+In practice, you should use the process described above. The following information is mostly relevant for people who may wish to maintain/update/upgrade the release system for GAP.
+
+A GitHub access token is required for the scripts to interact with GitHub; see the [GitHub access token](#github-access-token) section below. 
+
+### Dependencies
+Before starting the release process, the scripts have the following dependencies. Make sure you have the following available:
 - All tools required to build GAP (as outlined in the GAP root `README.md`)
-- `git` command line tool
-- `curl` command line tool
+- The `git` command line tool
+- The `curl` command line tool
 - Python (version >= 3.6)
-- Several python modules (e.g. installed using `pip3` (`pip3 install <MODULENAME>`)
+- Several python modules, including (e.g. installed using `pip3` (`pip3 install <MODULENAME>`):
   - `PyGithub`
   - `requests`
   - `python-dateutil`
 
-## Release Process -- The quick guide
 
-You need a GitHub access token, which the script uses to authenticate with GitHub, so that it gets permission to upload files for you; see section [GitHub access token](#github-access-token) below. 
+### Steps
 
-If the GitHub token is in an environment variable called `GITHUB_TOKEN` then nothing needs to be done. 
-Otherwise a flag containing the token is needed when running `update_website.py`.
-
-
-1. In the terminal, change to the root directory of your clone of the GAP repository.
-2. Create an annotated tag for the release in git (using command line).
+1. Access your local clone of the GAP repository.
+2. Make sure that your clone is up to date with `gap-system/gap`.
+3. Create an annotated tag `vX.Y.Z` in your clone at the appropriate commit in the `stable-X.Y` branch, and push the tag to `gap-system/gap`. For example:
     ```
-    git tag -m "Version Z.X.Y" vZ.X.Y
-    git push --tags
+    git tag -m "Version X.Y.Z" vX.Y.Z stable-X.Y
+    git push origin vX.Y.Z
     ```  
-    Note that `Z` will most likely be 4.
-3. By default pushing the tag will trigger the GitHub action
-   [release](https://github.com/gap-system/gap/actions/workflows/release.yml),
-   which creates the release archives, creates a release on GitHub and uploads
-   the archives as assets.
-4. Change to the root directory of your clone of the `gap-system/GapWWW` repository.
-5. Run `update_website.py` in there.
-6. [optional] Remove the `tmp` directories (in GapWWW and gap directories).
-
-## Release Process -- The more detailed guide
-
-If the GitHub token is in an ENVIRONMENT variable called `GITHUB_TOKEN` then nothing needs to be done. 
-Otherwise a flag containing the token is needed when running `make_github_release.py`.
-
-
-1. In the terminal, change to the root directory of your clone of the GAP repository.
-    This should be obvious why
-2. Create an annotated tag for the release in git (using command line)
-    ```
-    git tag -m "Version Z.X.Y" vZ.X.Y
-    git push --tags
-    ```  
-    Note that `Z` will most likely be 4.
-3. By default pushing the tag will trigger the GitHub action
-   [release](https://github.com/gap-system/gap/actions/workflows/release.yml),
-   which runs the following steps:
-   1. Run `make_archives.py`.
-      - Exports repository content into new tmp directory `tmp/` via `git archive`.
-      - Makes and configures GAP to check that it is available (and this is needed for the manuals).
-      - Fetches the pkg tar ball.
-      - Builds the manuals.
+4. Pushing the tag will trigger the “[Wrap releases](https://github.com/gap-system/gap/actions/workflows/release.yml)” GitHub Actions workflow on `gap-system/gap`. This does the following steps:
+   1. Check out GAP at the appropriate commit.
+   2. Run `make_archives.py` from the GAP root directory, which:
+      - Exports the repository content into a new temporary directory `tmp/` via `git archive`.
+	  - Patches the release version and dates in `configure.ac`.
+      - Builds GAP and HPC-GAP.
+      - Fetches the appropriate GAP package tarballs.
+      - Builds GAP's manuals.
+	  - Builds the json package.
+      - Creates `package-infos.json.gz`, which contains JSON metadata of all distributed packages.
+      - Creates `help-links.json.gz`, which contains JSON data for cross-referencing between manuals, and is used by the GAP website.
       - Cleans everything up.
-      - Builds the tar ball(s) and checksum files.
-      - Creates a `package-infos.json.gz` which contains the metadata of all
-        distributed packages.
-      - Writes a file `MANIFEST` which contains a list of all created archives.
-   2. Run `make_github_release.py vZ.X.Y tmp/`, where `tmp/` is the path to the
-      temporary directory created by `make_archives.py`.
+      - Builds the tarballs and zips of GAP and its packages.
+      - Writes a file `MANIFEST` which contains a list of all files to be uploaded.
+   3. Run `make_github_release.py vX.Y.Z tmp/` from the GAP root directory; `tmp/` is the path to the temporary directory created by `make_archives.py`.
       - Creates the release on GitHub which matches the tag.
-      - Uploads the archives listed in the `MANIFEST` file as assets.
-4. Change to the root directory of your clone of the `gap-system/GapWWW` repository. 
-   This should be obvious why.
-5. Run `update_website.py` in there.
-   - Fetches the release assets, extracts and configures/builds GAP in a tmp directory.
-   - Extracts info from the built and rewrites various YAML files.
-   - Extracts info about packages and updates YAML files.
-   - Commits, pushes and creates pull request to GapWWW.
-6. [optional] Remove the `tmp` directories (in GapWWW and gap directories).
+      - Uploads the archives listed in the `MANIFEST` file as assets, along with a corresponding `.sha256` file.
+   4. Create some Windows installers and uploads them to the GitHub release, too. A Windows computer is required for this step.
+5. Access your local clone of the `GapWWW` repository.
+6. Make sure that your clone is up to date with `gap-system/GapWWW`.
+7. Check out the master branch.
+8. Run `update_website.py` in root directory of `GapWWW` (see `update_website.py --help`). This:
+   - Fetches the GitHub releases data from `gap-system/gap`.
+   - Deletes, modifies, and adds various JSON and HTML files according to this data.
+9. Inspect the changes, and commit and push them to the master branch to `gap-system/GapWWW`.
+10. Run `GapWWW`'s `etc/extract-manuals.py` script as internally documented, and move its resulting `Manuals` directory to the `~/test.gap-system.org` directory of the GAP web server, overwriting the existing one.
+11. Deploy <https://test.gap-system.org>, as described in the `README` of `GapWWW`.
+12. Check that <https://test.gap-system.org> is functioning as expected.
+13. Repeat the final three steps, but with `www` instead of `test`.
 
 
 ## GitHub access token
+<a name="github-access-token"></a>
 
-The `make_github_release.py` script needs limited write access to the GAP repository
-in order to upload the release archives for you. In order to do this, the
-scripts needs to authenticate itself with GitHub, for which it needs a
-so-called "personal access token". You can generate such a token as follows
-(see also <https://help.github.com/articles/creating-an-access-token-for-command-line-use>).
+Various scripts in the same folder as this README need limited read/write access to the GAP repository in order to interact with the GitHub API, including to create a release and upload release archives. In order to do this, the scripts need to authenticate with GitHub, for which is reuired a so-called "personal access token".
+You can generate such a token as follows (see also [the GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)):
 
 1. Go to <https://github.com/settings/tokens>.
-
 2. Click **Generate new token**.
-
 3. Select the scope "public_repo", and give your token a descriptive name.
-
 4. Click **Generate token** at the bottom of the page.
+5. Copy the token to your clipboard. For security reasons, after you navigate off the page, you will not be able to see the token again. You therefore should store the token somewhere, such as in the file mentioned in option 4 of the forthcoming list.
 
-5. Copy the token to your clipboard. For security reasons, after you navigate
-   off the page, you will not be able to see the token again. You therefore
-   should store it somewhere, e.g. with option 3 in the following list.
+The scripts that require an access token look for one in the following places, with the following precedence:
+1. The argument `--token`, if supported and given.
+2. The environment variable `GITHUB_TOKEN`, if set.
+3. The current git configuration, via `git config --get github.token`.
+4. The contents of the file `~/.github_shell_token`, if existent and non-empty.


### PR DESCRIPTION
In recent weeks, I have updated the GAP website to use the fairly new `package-infos.json.gz` and `help-links.json.gz` files, and I have made the GAP website use JSON in other places too. This had the promise of making the website much simpler to update (indeed it is now automated to use the new `update-website.py` script of this PR; see https://github.com/gap-system/GapWWW/pull/241).

This PR is the result of that promise.

This PR also refactors `dev/releases/README.md`, so this closes #4316.

_(To be honest I think the 'simple' version of the README is sufficient; that is the release process that we want to happen in practice. If someone wants to know more (in order to further the develop the release process, say), they can find out how it works by looking at the GitHub Actions workflows, and at the various scripts that they call. So I suggest we don't spend too much further effort keeping the 'detailed' version up to date, and perhaps remove it when it next becomes out of date.)_

You can try out this script by checking out this branch, and then running it from the root directory of an up-to-date master branch of GapWWW. The result should be... no changes, because all GitHub release data for GAP is already known by GapWWW.

But here's an example of what you get if a new (but fake) GAP v4.12.0 exists: https://github.com/wilfwilson/GapWWW/pull/9/files (ignore the changes from `gap-system` to `wilfwilson`; that's because I'm fetching release data there from my own GAP fork).