### PR TITLE
Improvements around the MTC (and two ad-hoc fixes)

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -3518,7 +3518,7 @@ end );
 ##  is automatically cyclically reduced).
 ##
 InstallGlobalFunction( RelatorRepresentatives, function ( rels )
-local reps, word, length, fam, reversed, cyc, min, g, rel, i;
+local reps, word, length, fam, reversed, cyc, min, g, rel, i,j;
 
     reps := [ ];
 
@@ -3566,18 +3566,26 @@ local reps, word, length, fam, reversed, cyc, min, g, rel, i;
       if length>0 then
 	# invert the exponents to their negative values in order to get
 	# an appropriate lexicographical ordering of the relators.
+        word:=-word;
 	fam:=FamilyObj( rel );
-	reversed:=AssocWordByLetterRep(fam,-word);
+	reversed:=AssocWordByLetterRep(fam,word);
 
 	# find the minimal cyclic permutation
 	cyc:=reversed;
 	min:=cyc;
 	if cyc^-1<min then min:=cyc^-1;fi;
-	for i in [1..length] do
-	  g:=AssocWordByLetterRep(fam,word{[i]});
-	  cyc:=cyc^g;
+        i:=1;
+        while i<=length do
+          j:=1;
+          while j<Length(word) and word[j]=word[j+1] do j:=j+1;od;
+          word:=Concatenation(word{[j+1..Length(word)]},word{[1..j]});
+	  cyc:=AssocWordByLetterRep(fam,word);
 	  if cyc<min then min:=cyc;fi;
 	  if cyc^-1<min then min:=cyc^-1;fi;
+          i:=i+j;
+	  #g:=AssocWordByLetterRep(fam,word{[i]});
+	  #g:=Subword(cyc,1,1);
+	  #cyc:=cyc^g;
 	od;
 
 	# if the relator is new, add it to the representatives

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -423,11 +423,11 @@ DeclareGlobalFunction("TomDataSubgroupsAlmostSimple");
 
 #############################################################################
 ##
-#F  LowLayerSubgroups( [<act>,],<G>, <lim> [,<cond> [,<dosub>]] )
+#F  LowLayerSubgroups( [<act>,]<G>, <lim> [,<cond> [,<dosub>]] )
 ##
 ##  <#GAPDoc Label="LowLayerSubgroups">
 ##  <ManSection>
-##  <Func Name="LowLayerSubgroups" Arg='act, G, lim, cond, dosub'/>
+##  <Func Name="LowLayerSubgroups" Arg='[act,]G,lim [,cond,dosub]'/>
 ##
 ##  <Description>
 ##  This function computes representatives of the conjugacy classes of
@@ -441,6 +441,16 @@ DeclareGlobalFunction("TomDataSubgroupsAlmostSimple");
 ##  performance reasons).
 ##  In the example below, the result would be the same with leaving out the
 ##  fourth function, but calculation this way is slightly faster.
+##  <Example><![CDATA[
+##  gap> g:=SymmetricGroup(12);;
+##  gap> l:=LowLayerSubgroups(g,2,x->Size(x)>100000,x->Size(x)>200000);;
+##  gap> Collected(List(l,Size));
+##  [ [ 100800, 1 ], [ 120960, 1 ], [ 161280, 1 ], [ 241920, 1 ], [ 302400, 3 ],
+##    [ 322560, 1 ], [ 483840, 3 ], [ 518400, 3 ], [ 604800, 1 ], [ 725760, 1 ],
+##    [ 967680, 1 ], [ 1036800, 1 ], [ 1088640, 3 ], [ 2177280, 1 ],
+##    [ 3628800, 3 ], [ 7257600, 1 ], [ 19958400, 1 ], [ 39916800, 1 ],
+##    [ 239500800, 1 ], [ 479001600, 1 ] ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/tietze.gd
+++ b/lib/tietze.gd
@@ -525,8 +525,8 @@ DeclareGlobalFunction("PresentationRegularPermutationGroupNC");
 ##  gap> TzPrintRelators( P );
 ##  #I  1. f2^3
 ##  #I  2. f1^6
-##  #I  3. (f1^-1*f2^-1)^6
-##  #I  4. f1*f2*f1^-1*f2^-1*f1*f2^-1*f1^-1*f2*f1*f2^-1*f1^-1*f2^-1
+##  #I  3. (f1*f2)^6
+##  #I  4. f1*f2*f1^-1*f2*f1*f2^-1*f1^-1*f2*f1*f2*f1^-1*f2^-1
 ##  #I  5. f1^-3*f2*f1*f2*(f1^-1*f2^-1)^2*f1^-2*f2
 ##  ]]></Example>
 ##  <P/>
@@ -549,10 +549,10 @@ DeclareGlobalFunction("PresentationRegularPermutationGroupNC");
 ##  gap> G := FpGroupPresentation( P );
 ##  <fp group on the generators [ a, b, c ]>
 ##  gap> RelatorsOfFpGroup( G );
-##  [ c^2, b^4, (a*c)^3, (a*b^-2)^3, a^11, 
-##    a^2*b*a^-2*b^-1*(b^-1*a)^2*a*b^-1, (a*(b*a^-1)^2*b^-1)^2, 
-##    a^2*b*a^2*b^-2*a^-1*b*(a^-1*b^-1)^2, 
-##    (a*b)^2*a^2*b^-1*a^-1*b^-1*a*c*b*c, a^2*(a^2*b)^2*a^-2*c*a*b*a^-1*c 
+##  [ c^2, b^4, (a*c)^3, (a*b^-2)^3, a^11,
+##    a^2*b*a^-2*b^-1*(b^-1*a)^2*a*b^-1, (a*(b*a^-1)^2*b^-1)^2,
+##    a^2*b*a^2*b^-2*a^-1*b*(a^-1*b^-1)^2,
+##    a^2*b^-1*a^-1*b^-1*a*c*b*c*(a*b)^2, a^2*(a^2*b)^2*a^-2*c*a*b*a^-1*c
 ##   ]
 ##  ]]></Example>
 ##  <P/>
@@ -1088,6 +1088,23 @@ SimplifyPresentation := TzGo;
 ##
 DeclareGlobalFunction("TzGoGo");
 
+############################################################################
+##
+#F  TzGoElim(<P>,<len>)
+##
+##  <#GAPDoc Label="TzGoElim">
+##  <ManSection>
+##  <Func Name="TzGoElim" Arg='P,len'/>
+##
+##  <Description>
+##  A variant for the TzGoXXX functions for the MTC. Tries to reduce down to
+##  <C>len</C> generators and does not try so hard to reduce.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("TzGoElim");
+
 
 #############################################################################
 ##
@@ -1295,10 +1312,10 @@ DeclareGlobalFunction("TzNewGenerator");
 ##  #I  relators:
 ##  #I  1.  2  [ 3, 3 ]
 ##  #I  2.  4  [ 2, 2, 2, 2 ]
-##  #I  3.  4  [ -2, 3, -2, 3 ]
+##  #I  3.  4  [ 2, 3, 2, 3 ]
 ##  #I  4.  5  [ 1, 1, 1, 1, 1 ]
 ##  #I  5.  5  [ 1, 1, 2, 1, -2 ]
-##  #I  6.  8  [ -1, 3, 1, 3, -1, 2, 2, 3 ]
+##  #I  6.  8  [ 1, -2, -2, 3, 1, 3, -1, 3 ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -1598,9 +1615,9 @@ DeclareGlobalFunction("TzPrintOptions");
 ##  a word of length 2 to be substituted.
 ##  <Example><![CDATA[
 ##  gap> TzPrintPairs( P, 3 );
-##  #I  1.  3  occurrences of  f2 * f3
-##  #I  2.  2  occurrences of  f2^-1 * f3
-##  #I  3.  2  occurrences of  f1 * f3
+##  #I  1.  3  occurrences of  f2^-1 * f3
+##  #I  2.  2  occurrences of  f2 * f3
+##  #I  3.  2  occurrences of  f1^-1 * f3
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -1647,10 +1664,10 @@ DeclareGlobalFunction("TzPrintPresentation");
 ##  gap> TzPrintRelators( P );
 ##  #I  1. f3^2
 ##  #I  2. f2^4
-##  #I  3. (f2^-1*f3)^2
+##  #I  3. (f2*f3)^2
 ##  #I  4. f1^5
 ##  #I  5. f1^2*f2*f1*f2^-1
-##  #I  6. f1^-1*f3*f1*f3*f1^-1*f2^2*f3
+##  #I  6. f1*f2^-2*f3*f1*f3*f1^-1*f3
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/tietze.gi
+++ b/lib/tietze.gi
@@ -2320,6 +2320,28 @@ InstallGlobalFunction( TzGo, function ( arg )
 
 end );
 
+# reduce presentation in generators (for MTC)
+InstallGlobalFunction(TzGoElim,function(T,downto)
+local tietze,len,olen;
+  TzTestInitialSetup(T); # run `1Or2Relators' if not yet done
+  tietze := T!.tietze;
+
+  len:=tietze[TZ_TOTAL];
+  olen:=len+1;
+  while tietze[TZ_NUMGENS]-tietze[TZ_NUMREDUNDS]>downto and olen<>len do
+    TzSearch(T);
+    TzEliminateGens(T);
+    if not tietze[TZ_MODIFIED] then TzSearchEqual(T);fi;
+    olen:=len;
+    len:=tietze[TZ_TOTAL];
+    if TzOptions(T).printLevel>0 then  TzPrintStatus(T,true); fi;
+  od;
+  olen:=TzOptions(T).loopLimit;
+  TzOptions(T).loopLimit:=5;
+  TzGo(T); # cleanup
+  TzOptions(T).loopLimit:=olen;
+end);
+
 
 #############################################################################
 ##

--- a/lib/tietze.gi
+++ b/lib/tietze.gi
@@ -1546,12 +1546,14 @@ InstallGlobalFunction( TzEliminateFromTree, function ( T )
 
         # replace all occurrences of gen by word^-1.
         if TzOptions(T).printLevel >= 2 then
-            Print( "#I  eliminating ", gens[num], " = " );
-            if gen > 0 then
-                Print( AbstractWordTietzeWord( word, gens )^-1, "\n");
-            else
-                Print( AbstractWordTietzeWord( word, gens ), "\n" );
-           fi;
+          Print( "#I  eliminating ", gens[num], " = " );
+          if Length(word)>500 then
+            Print("<word of length ",Length(word)," >\n");
+          elif gen > 0 then
+              Print( AbstractWordTietzeWord( word, gens )^-1, "\n");
+          else
+              Print( AbstractWordTietzeWord( word, gens ), "\n" );
+          fi;
         fi;
         TzSubstituteGen( tietze, -gen, word );
 
@@ -1641,7 +1643,9 @@ InstallGlobalFunction( TzEliminateGen, function ( T, num )
             # replace all occurrences of gen by word^-1.
             if TzOptions(T).printLevel >= 2 then
                 Print( "#I  eliminating ", gens[num], " = " );
-                if gen > 0 then
+                if Length(word)>500 then
+                  Print("<word of length ",Length(word)," >\n");
+                elif gen > 0 then
                     Print( AbstractWordTietzeWord( word, gens )^-1, "\n" );
                 else
                     Print( AbstractWordTietzeWord( word, gens ), "\n" );
@@ -1764,7 +1768,9 @@ InstallGlobalFunction( TzEliminateGen1, function ( T )
         # replace all occurrences of gen by word^-1.
         if TzOptions(T).printLevel >= 2 then
             Print( "#I  eliminating ", gens[num], " = " );
-            if gen > 0 then
+            if Length(word)>500 then
+              Print("<word of length ",Length(word)," >\n");
+            elif gen > 0 then
                 Print( AbstractWordTietzeWord( word, gens )^-1, "\n" );
             else
                 Print( AbstractWordTietzeWord( word, gens ), "\n" );

--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -304,8 +304,8 @@ DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
 ##  [ [ 3888, 1 ], [ 6480, 1 ], [ 7776, 1 ], [ 19440, 1 ] ]
 ##  gap> p:=FpGroupCocycle(coh,coh.cohomology[1],true:normalform);;
 ##  gap> p.7*p.1; # i.e. m1*F1, but in normal form
-##  F1*m4
-##  ]]></Example>
+##  F1*m1*m2*m3^-1
+#  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1027,7 +1027,6 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     od;
   od;
 
-  
   eqs:=Filtered(TriangulizedMat(eqs),x->not IsZero(x));
   if Length(eqs)=0 then
     eqs:=IdentityMat(Length(rules),field);
@@ -1068,7 +1067,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
           Append(new,v1-v2);
         od;
         new:=ImmutableVector(field,new);
-        Assert(0,SolutionMat(eqs,new)<>fail);
+        Assert(0,(Length(eqs)>0 and SolutionMat(eqs,new)<>fail) or IsZero(new));
         Add(bds,new);
       od;
     fi;

--- a/tst/teststandard/twocohom.tst
+++ b/tst/teststandard/twocohom.tst
@@ -65,6 +65,10 @@ gap> mo:=TrivialModule(2,GF(2));;
 gap> coh:=TwoCohomologyGeneric(g,mo);;
 gap> List(Elements(VectorSpace(GF(2),coh.cohomology)),
 > x->FpGroupCocycle(coh,x,true:normalform));;
+gap> g:=CyclicGroup(3);;
+gap> mo:=GModuleByMats([[[0,1],[1,1]]]*Z(2),GF(2));;
+gap> TwoCohomologyGeneric(g,mo).cohomology;
+[  ]
 
 # routines used for rewriting
 gap> WeylGroupFp("A",3);


### PR DESCRIPTION
Slight changes in how the MTC is run and how the presentation is cleaned up by Tietze transformations.
Fixed the long-time-broken (wrong result) RelatorRepresentatives.

Fixed an overeager assertion (that could blame correct cases) and included a requested example for LowLayerSubgroups

## Text for release notes

None -- the errors would not have been notable to the user and the performance improvement is small.

## Further details

If necessary, provide further details down here.
