### PR TITLE
kernel: replace `SyWriteandcheck` by `echoandcheck`

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -83,8 +83,6 @@ typedef void sig_handler_t ( int );
 
 #include <sys/utsname.h>
 
-static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count);
-
 
 /****************************************************************************
 **
@@ -1220,7 +1218,7 @@ void SyFputs (
 
     /* otherwise, write it to the output file                              */
     else
-        SyWriteandcheck(fid, line, i);
+        echoandcheck(fid, line, i);
 }
 
 
@@ -1383,33 +1381,6 @@ Int SyWrite(Int fid, const void * ptr, size_t len)
     else {
         return write(syBuf[fid].echo, ptr, len);
     }
-}
-
-static ssize_t SyWriteandcheck(Int fid, const void * buf, size_t count)
-{
-    int ret;
-    if (syBuf[fid].type == gzip_socket) {
-        ret = gzwrite(syBuf[fid].gzfp, buf, count);
-        if (ret < 0) {
-            ErrorQuit(
-                "Cannot write to compressed file, see 'LastSystemError();'\n",
-                0, 0);
-        }
-    }
-    else {
-        ret = write(syBuf[fid].fp, buf, count);
-        if (ret < 0) {
-            if (syBuf[fid].fp == fileno(stdout) || syBuf[fid].fp == fileno(stderr)) {
-                Panic("Could not write to stdout/stderr.");
-            } else {
-                ErrorQuit("Cannot write to file descriptor %d, see "
-                          "'LastSystemError();'\n",
-                          syBuf[fid].fp, 0);
-            }
-        }
-    }
-
-    return ret;
 }
 
 static Int syGetchTerm(Int fid)


### PR DESCRIPTION
There is just one difference between the two: whether to print to
`syBuf[fid].fp` or to `syBuf[fid].echo`. This only makes a difference
for stdin and errin, where the former is wrong and only the latter
is correct. So goodbye to `SyWriteandcheck`

I have some hope that this might fix an actual bug I am seeing in the GAP-Julia interface; I'll test that later.