### PR TITLE
Improve documentation and argument checks for `StabChainBaseStrongGenerators`

### DIFF
--- a/lib/stbc.gd
+++ b/lib/stbc.gd
@@ -216,20 +216,33 @@ DeclareGlobalName( "DefaultStabChainOptions" );
 
 #############################################################################
 ##
-#F  StabChainBaseStrongGenerators( <base>, <sgs>, <one> )
+#F  StabChainBaseStrongGenerators( <base>, <sgs>[, <one>] )
 ##
 ##  <#GAPDoc Label="StabChainBaseStrongGenerators">
 ##  <ManSection>
-##  <Func Name="StabChainBaseStrongGenerators" Arg='base, sgs, one'/>
+##  <Func Name="StabChainBaseStrongGenerators" Arg='base, sgs[, one]'/>
 ##
 ##  <Description>
 ##  Let <A>base</A> be a base for a permutation group <M>G</M>, and let
 ##  <A>sgs</A> be a strong generating set for <M>G</M> with respect to
 ##  <A>base</A>; <A>one</A> must be the appropriate identity element of
 ##  <M>G</M> (see <Ref Attr="One"/>, in most cases this will be <C>()</C>).
-##  This function constructs a stabilizer chain without the need to find
+##  This function constructs a stabilizer chain corresponding to the given
+##  base and strong generating set without the need to find
 ##  Schreier generators;
 ##  so this is much faster than the other algorithms.
+##  <P/>
+##  If <A>sgs</A> is nonempty, then the argument <A>one</A> is optional;
+##  if not given, then the <Ref Attr="One" Style="Text"/> of
+##  <C><A>sgs</A>[1]</C> is taken as the identity element.
+##  <Example><![CDATA[
+##  gap> sc := StabChainBaseStrongGenerators([1,2], [(1,3,4), (2,3,4)], ());
+##  <stabilizer chain record, Base [ 1, 2 ], Orbit length 4, Size: 12>
+##  gap> GroupStabChain(sc) = AlternatingGroup(4);
+##  true
+##  gap> StabChainBaseStrongGenerators([1,3], [(1,2),(3,4)]);
+##  <stabilizer chain record, Base [ 1, 3 ], Orbit length 2, Size: 4>
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/stbc.gi
+++ b/lib/stbc.gi
@@ -398,12 +398,20 @@ end);
 InstallGlobalFunction(StabChainBaseStrongGenerators,function(arg)
 local   base,sgs,one,S,  T,  pnt, genlabels;
 
+    if not Length(arg) in [2, 3]
+        or not ForAll([1, 2], i -> IsHomogeneousList(arg[i])) then
+      ErrorNoReturn("usage: ",
+                    "StabChainBaseStrongGenerators(<base>, <sgs>[, <one>])");
+    fi;
     base:=PlainListCopy(arg[1]);
     sgs:=PlainListCopy(arg[2]);
     if Length(arg)=3 then
       one:=arg[3];
+    elif not IsEmpty(sgs) then
+      one:= One(sgs[1]);
     else
-      one:= One(arg[2][1]);
+      ErrorNoReturn("the identity element must be given as the third argument ",
+                    "when the second argument <sgs> is empty");
     fi;
     S := EmptyStabChain( sgs, one );
     # Skip the identity in genlabels

--- a/tst/testinstall/stbc.tst
+++ b/tst/testinstall/stbc.tst
@@ -1,0 +1,24 @@
+#@local sc
+gap> START_TEST("stbc.tst");
+
+#
+gap> StabChainBaseStrongGenerators([1]);
+Error, usage: StabChainBaseStrongGenerators(<base>, <sgs>[, <one>])
+gap> StabChainBaseStrongGenerators([1], [()], fail, fail);
+Error, usage: StabChainBaseStrongGenerators(<base>, <sgs>[, <one>])
+gap> StabChainBaseStrongGenerators([1], []);
+Error, the identity element must be given as the third argument when the secon\
+d argument <sgs> is empty
+gap> sc := StabChainBaseStrongGenerators([1], [], ());
+<stabilizer chain record, Base [ 1 ], Orbit length 1, Size: 1>
+gap> IsTrivial(GroupStabChain(sc));
+true
+gap> sc := StabChainBaseStrongGenerators([1 .. 4], [(1,2), (2,3), (3,4)]);
+<stabilizer chain record, Base [ 1, 2, 3, 4 ], Orbit length 4, Size: 24>
+gap> sc = StabChainBaseStrongGenerators([1 .. 4], [(1,2), (2,3), (3,4)], ());
+true
+gap> GroupStabChain(sc) = SymmetricGroup(4);
+true
+
+#
+gap> STOP_TEST("stbc.tst", 1);


### PR DESCRIPTION
I made a note to myself to document the 2-argument version of `StabChainBaseStrongGenerators` (which was already implemented and is probably what most people would want to use). I finally got around to it, and in the process I made a few other small improvements: added a manual example; added tests; added some argument checks.

(Can anyone think when you might want the `one` to _not_ be `()`?)