### PR TITLE
Add Bray/Holt/Roney-Dougal 2013 to the GAP bibliography

### DIFF
--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -5538,4 +5538,24 @@
   <other type="doi">10.2307/2005583</other>
 </article></entry>
 
+<entry id="BHRD2013"><book>
+  <author>
+    <name><first>John N.</first><last>Bray</last></name>
+    <name><first>Derek F.</first><last>Holt</last></name>
+    <name><first>Colva M.</first><last>Roney-Dougal</last></name>
+  </author>  
+  <title>The maximal subgroups of the low-dimensional finite classical groups</title>
+  <publisher>Cambridge University Press</publisher>
+  <year>2013</year>
+  <volume>407</volume>
+  <series>London Mathematical Society Lecture Note Series</series>
+  <address>Cambridge</address>
+  <isbn>978-0-521-13860-4</isbn>
+  <mrnumber>3098485</mrnumber>
+  <mrclass>20G40 (20E28)</mrclass>
+  <mrreviewer>Nadia P. Mazza</mrreviewer>
+  <other type="pages">xiv+438</other>
+  <other type="doi">10.1017/CBO9781139192576</other>
+</book></entry>
+
 </file>

--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -887,7 +887,7 @@ local id;
   return DataAboutSimpleGroup(id);
 end);
 
-# Tables for outer automorphisms from Bray/Holt/Roney-Dougal, p. 36/37
+# Tables for outer automorphisms from Bray/Holt/Roney-Dougal p. 36/37 [BHRD2013]
 BindGlobal("OuterAutoSimplePres",function(class,n,q)
 local p,e,f,rels,gp;
   class:=UppercaseString(class);


### PR DESCRIPTION
This book is the source for the data used in the function `OuterAutoSimplePres` of `grp/simple.gi`.

I'm not sure if there's a good place to actually cite this book in the manual; I'm open to suggestions if anyone has any. Otherwise, it's surely a good starting point to at least put this book in our bib file.