### PR TITLE
Remove duplicate entry in `COPYRIGHT` file

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -46,7 +46,6 @@ Copyright (C) 1988-2020 by its authors, which include:
 * Derek F. Holt
 * Dmitrii Pasechnik
 * Dominik Bernhardt
-* E. M. Bray
 * Emma Ahrens
 * Erik M. Bray
 * Erzsébet Horváth


### PR DESCRIPTION
I noticed that `E. M. Bray` and `Erik M. Bray` both appear in the `COPYRIGHT` file; I gather that they are both @embray. Perhaps @embray has a preference one way or another about which one should remain; I'm happy to change this PR if I've guessed the wrong one.