### PR TITLE
Fix a regression in MaximalSubgroupClassReps

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1461,7 +1461,7 @@ InstallMethod(MaximalSubgroupClassReps,"default, catch dangerous options",
 function(G)
 local H,a,m,i,l;
   # use ``try'' and set flags so that a known partial result is not used
-  m:=TryMaximalSubgroupClassReps(H:
+  m:=TryMaximalSubgroupClassReps(G:
           cheap:=false,intersize:=false,inmax:=false,nolattice:=false);
   l:=[];
   for i in m do

--- a/tst/testinstall/maxsub.tst
+++ b/tst/testinstall/maxsub.tst
@@ -1,0 +1,32 @@
+gap> START_TEST("maxsub.tst");
+
+#
+gap> G := GL(2,3);;
+gap> msc := MaximalSubgroupClassReps(G);;
+gap> ForAll(msc, H -> Parent(H) = G);
+true
+gap> SortedList(List(msc, IndexInParent));
+[ 2, 3, 4 ]
+
+#
+gap> G := GL(2,4);;
+gap> #msc:=MaximalSubgroupClassReps(G); # FIXME: GAP cannot currently do this in reasonable time
+gap> #ForAll(msc, H -> Parent(H) = G);
+gap> #SortedList(List(msc, IndexInParent));
+
+#
+gap> G := GL(2,5);;
+gap> msc := MaximalSubgroupClassReps(G);;
+gap> ForAll(msc, H -> Parent(H) = G);
+true
+gap> SortedList(List(msc, IndexInParent));
+[ 2, 5, 6, 10 ]
+
+#
+gap> G := AlternatingGroup(5);;
+gap> msc := MaximalSubgroupClassReps(G);;
+gap> SortedList(List(msc, H -> Index(G, H)));
+[ 5, 6, 10 ]
+
+#
+gap> STOP_TEST("maxsub.tst", 1);


### PR DESCRIPTION
Also add some tests, and mark another (currently unresolved) regression: the command `MaximalSubgroupClassReps (GL(2,4));` should terminate quickly but in fact runs for a long time. I did not wait for it to complete, but it definitely is MUCH slower than in previous GAP versions.


Actually, I noticed that this got a lot faster from GAP 4.8 to 4.9: in 4.8 that test file completes for me in ~350 milliseconds, in all versions of GAP after that, including master, it is more like 1100 milliseconds. I wonder what's behind that, perhaps we can bisect the cause for this.