### PR TITLE
Make `MappedWord` handle inverses better

### DIFF
--- a/lib/word.gd
+++ b/lib/word.gd
@@ -343,8 +343,8 @@ DeclareCategoryFamily( "IsNonassocWordWithOne" );
 ##  The lists <A>gens</A> and <A>imgs</A> must of course have the same length.
 ##  <P/>
 ##  <Ref Oper="MappedWord"/> needs to do some preprocessing to get internal
-##  generator numbers etc. When mapping many (several thousand) words, an
-##  explicit loop over the words syllables might be faster.
+##  generator numbers etc. When mapping many (several thousand) words, a
+##  dedicated loop might be faster.
 ##  <P/>
 ##  For example, if the elements in <A>imgs</A> are all
 ##  <E>associative words</E>
@@ -355,6 +355,10 @@ DeclareCategoryFamily( "IsNonassocWordWithOne" );
 ##  In this situation, the special case that the lists <A>gens</A>
 ##  and <A>imgs</A> have only length <M>1</M> is handled more efficiently by
 ##  <Ref Oper="EliminatedWord"/>.
+##  <P/>
+##  If the word is from a free group, it is permitted to give inverses of
+##  (some) of the generators as extra generators. This can speed up the
+##  execution by removing the need to calculate inverses anew.
 ##  <Example><![CDATA[
 ##  gap> m:= FreeMagma( "a", "b" );;  gens:= GeneratorsOfMagma( m );;
 ##  gap> a:= gens[1];  b:= gens[2];
@@ -371,6 +375,8 @@ DeclareCategoryFamily( "IsNonassocWordWithOne" );
 ##  gap> w:= a^5*b*a^2/b^4*a;
 ##  a^5*b*a^2*b^-4*a
 ##  gap> MappedWord( w, [ a, b ], [ (1,2), (1,2,3,4) ] );
+##  (1,3,4,2)
+##  gap> MappedWord( w, [ a, b, b^-1 ], [ (1,2), (1,2,3,4), (1,4,3,2) ] );
 ##  (1,3,4,2)
 ##  gap> (1,2)^5*(1,2,3,4)*(1,2)^2/(1,2,3,4)^4*(1,2);
 ##  (1,3,4,2)

--- a/tst/testinstall/wordrep.tst
+++ b/tst/testinstall/wordrep.tst
@@ -279,5 +279,29 @@ gap> SetX(words16, words16, {a,b} -> (a/b) * b = a);
 gap> SetX(words32, words32, {a,b} -> (a/b) * b = a);
 [ true ]
 
+# MappedWord with inverses
+gap> f:=FreeGroup(2);;
+gap> gens:=ShallowCopy(GeneratorsOfGroup(f));;
+gap> g:=GL(10,17);;
+gap> m:=List([1,2],x->PseudoRandom(g));;
+gap> w:=PseudoRandom(f:radius:=10000);;
+gap> gens:=ShallowCopy(GeneratorsOfGroup(f));;
+gap> e1:=MappedWord(w,gens,m);;
+gap> Append(gens,List(gens,x->x^-1));
+gap> Append(m,List(m,x->x^-1));
+gap> e2:=MappedWord(w,gens,m);;
+gap> e1=e2;
+true
+gap> g:=FreeGroup(IsSyllableWordsFamily,2);;
+gap> w:=MappedWord(w,gens{[1,2]},GeneratorsOfGroup(g));;
+gap> gens:=ShallowCopy(GeneratorsOfGroup(g));;
+gap> e2:=MappedWord(w,gens,m{[1,2]});;
+gap> e1=e2;
+true
+gap> Append(gens,List(gens,x->x^-1));
+gap> e2:=MappedWord(w,gens,m);;
+gap> e1=e2;
+true
+
 #
 gap> STOP_TEST("wordrep.tst", 1);


### PR DESCRIPTION
This is in response to #4606. So far only implemented for the letter representation of associative words. One would have to add similar changes for the syllable represenation and the generic method.

The code:
a) Precomputes inverses once (if they are to be used more than once)
b) Uses inverses that are given as extra generators

For example, just taking larger matrices so we see multiplication cost
```
gap> g:=AtlasGroup("M24",IsMatrixGroup,true,Dimension,483);;
gap> epi:=EpimorphismFromFreeGroup(g);;
gap> mgi:=MappingGeneratorsImages(epi);;
gap> w:=PseudoRandom(Source(epi):radius:=100);;  # random word
gap> v0:=MappedWord(w,mgi[1],mgi[2]);;time;  # old code
4147
``` 

This is the base-line for the existing code, which uses w/gen all the time to handle inverses

Here is the new code that caches inverses:
```
gap> v1:=MappedWord(w,mgi[1],mgi[2]);;time;  # new code
2412
```

Clearly a speedup. And if we give the inverses as extra generators, a little bit extra bump

```
gap> mgj:=List(mgi,x->Concatenation(x,List(x,Inverse)));; # also give inverses as extra generators
gap> v3:=MappedWord(w,mgj[1],mgj[2]);;time; # slight speedup
2323
```

This closes #4606