### PR TITLE
kernel: add missing GAP_CATCH handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ doc/gapmacrodoc.idx
 /tst/testlibgap/basic
 /tst/testlibgap/wscreate
 /tst/testlibgap/wsload
+/tst/testlibgap/trycatch
 /tst/testlibgap/*.out
 
 /tst/testkernel/dstruct

--- a/tst/testlibgap/trycatch.c
+++ b/tst/testlibgap/trycatch.c
@@ -11,17 +11,14 @@ static void handle_trycatch(TryCatchMode mode)
     switch (mode) {
     case TryEnter:
         level++;
-        if (level == 1)
-            printf("Entering GAP_TRY section\n");
+        printf("%d: Entering GAP_TRY section\n", level);
         break;
     case TryLeave:
-        if (level == 1)
-            printf("Leaving GAP_TRY section\n");
+        printf("%d: Leaving GAP_TRY section\n", level);
         level--;
         break;
     case TryCatch:
-        if (level == 1)
-            printf("Caught error in GAP_TRY section\n");
+        printf("%d: Caught error in GAP_TRY section\n", level);
         level--;
         break;
     }
@@ -31,11 +28,12 @@ int main(int argc, char ** argv)
 {
     printf("# Initializing GAP...\n");
     GAP_Initialize(argc, argv, 0, 0, 1);
-    RegisterTryCatchHandler(handle_trycatch);
     test_eval("OnBreak := false;;");
     // Necessary to redirect error printing to stdout.
     test_eval("MakeReadWriteGVar(\"ERROR_OUTPUT\");");
     test_eval("ERROR_OUTPUT := MakeImmutable(\"*stdout*\");;");
+
+    RegisterTryCatchHandler(handle_trycatch);
     test_eval("Display(CALL_WITH_CATCH(function() return 314; end, []));;");
     test_eval("Display(CALL_WITH_CATCH(function() return [][1]; end, []));;");
     return 0;

--- a/tst/testlibgap/trycatch.expect
+++ b/tst/testlibgap/trycatch.expect
@@ -6,13 +6,19 @@ gap> MakeReadWriteGVar("ERROR_OUTPUT");
 gap> ERROR_OUTPUT := MakeImmutable("*stdout*");;
 
 gap> Display(CALL_WITH_CATCH(function() return 314; end, []));;
-Entering GAP_TRY section
-Leaving GAP_TRY section
+1: Entering GAP_TRY section
+1: Leaving GAP_TRY section
 [ true, 314 ]
 
 gap> Display(CALL_WITH_CATCH(function() return [][1]; end, []));;
-Entering GAP_TRY section
-Error, List Element: <list>[1] must have an assigned value
-Caught error in GAP_TRY section
+1: Entering GAP_TRY section
+2: Entering GAP_TRY section
+2: Leaving GAP_TRY section
+Error, 2: Entering GAP_TRY section
+2: Leaving GAP_TRY section
+List Element: <list>[1] must have an assigned value2: Entering GAP_TRY section
+
+2: Leaving GAP_TRY section
+1: Caught error in GAP_TRY section
 [ false, 0 ]
 

--- a/tst/testlibgap/trycatch.expect
+++ b/tst/testlibgap/trycatch.expect
@@ -7,18 +7,22 @@ gap> ERROR_OUTPUT := MakeImmutable("*stdout*");;
 
 gap> Display(CALL_WITH_CATCH(function() return 314; end, []));;
 1: Entering GAP_TRY section
+2: Entering GAP_TRY section
+2: Leaving GAP_TRY section
 1: Leaving GAP_TRY section
 [ true, 314 ]
 
 gap> Display(CALL_WITH_CATCH(function() return [][1]; end, []));;
 1: Entering GAP_TRY section
 2: Entering GAP_TRY section
-2: Leaving GAP_TRY section
-Error, 2: Entering GAP_TRY section
-2: Leaving GAP_TRY section
-List Element: <list>[1] must have an assigned value2: Entering GAP_TRY section
+3: Entering GAP_TRY section
+3: Leaving GAP_TRY section
+Error, 3: Entering GAP_TRY section
+3: Leaving GAP_TRY section
+List Element: <list>[1] must have an assigned value3: Entering GAP_TRY section
 
-2: Leaving GAP_TRY section
-1: Caught error in GAP_TRY section
+3: Leaving GAP_TRY section
+2: Caught error in GAP_TRY section
+1: Leaving GAP_TRY section
 [ false, 0 ]
 


### PR DESCRIPTION
In the past, not closing an output was not too bad; now it can lead to crashes.
At least when using this code in an embedded GAP (i.e., libgap).


This patch looks big, but that's due to whitespace changes. If you instruct GitHub to hide whitespace ([click here to see the result](https://github.com/gap-system/gap/pull/4616/files?diff=unified&w=1) or better yet, look at each commit separately), you can see that this PR is actually quite small.