### PR TITLE
kernel: simplify FuncREAD_COMMAND_REAL implementation

### DIFF
--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -78,6 +78,17 @@ true
 gap> READ_COMMAND_REAL(true, fail);
 Error, READ_COMMAND_REAL: <stream> must be an input stream (not the value 'tru\
 e')
+gap> READ_COMMAND_REAL(InputTextString("1+1;"), false);
+[ true, 2 ]
+gap> READ_COMMAND_REAL(InputTextString("/1;"), false); # intentional syntax error
+Syntax error: expression expected in stream:1
+/1;
+^
+[ true ]
+gap> READ_COMMAND_REAL(InputTextString("quit;"), false);
+[ true ]
+gap> READ_COMMAND_REAL(InputTextString("QUIT;"), false);
+[ false ]
 
 #
 gap> READ(fail);

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -86,7 +86,7 @@ Syntax error: expression expected in stream:1
 ^
 [ true ]
 gap> READ_COMMAND_REAL(InputTextString("quit;"), false);
-[ true ]
+[ false ]
 gap> READ_COMMAND_REAL(InputTextString("QUIT;"), false);
 [ false ]
 


### PR DESCRIPTION
... by merging the READ_COMMAND helper into it. This enables some code simplifications (which to me were surprising, i.e., I clearly did not fully understand the code before).

I believe verifying this change is not that easy, I arrived at it in incremental steps. I recommend viewing the diff in "split view mode" (not as a "unified diff") so that one can more easily compared the complete old to the complete new code.

One of the things that surprised me was the helper function would set `STATE(UserHasQuit)` resp. `STATE(UserHasQUIT)` to 1 and the main function would promptly reset them to 0. Oh, and if they were set to 1 before (e.g. before entering `FuncREAD_COMMAND_REAL`, or as a side effect of `ReadEvalCommand`), then the helper returns immediately, and then `FuncREAD_COMMAND_REAL` returns immediately; this is unchanged.

The one drawback of this change is that the similarity of the code to `READ_INNER` is reduced. But I think that's fair, esp. since that "similarity" IMHO was misleading, as discussed in the preceding paragraph.

Oh, and note the FIXME comment I added... I am not sure about that one. Frank added it 2009-09-25 in "old history commit" f9ad911331c99b6407afcbfa6ae9bd83aa120b48 with this commit message:

>  Make sure that the recursion depth counter is reset to zero when quitting a
>  break loop. Problem reported by Simon King, caused by (non-elegant) Sage code
>  that entered and left many break loops.

But back then, we did not save & restore the recursion depth counter in `GAP_TRY`/`GAP_CATCH`/`TRY_IF_NO_ERROR` (resp. their predecessor code -- those macros did not exist back then). So I kinda expect we don't need that `SetRecursionDepth(0)` call anymore (nor its sibling in `READ_COMMAND`). We should test that theory, though.