### PR TITLE
kernel: reduce calls to `SetRecursionDepth(0)`

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -306,8 +306,6 @@ static Obj FuncJUMP_TO_CATCH(Obj self, Obj payload)
 static Obj FuncSetUserHasQuit(Obj Self, Obj value)
 {
     STATE(UserHasQuit) = INT_INTOBJ(value);
-    if (STATE(UserHasQuit))
-        SetRecursionDepth(0);
     return 0;
 }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -290,7 +290,6 @@ static Obj Shell(Obj    context,
     
     /* handle quit command or <end-of-file>                            */
     else if ( status & (STATUS_EOF | STATUS_QUIT ) ) {
-      SetRecursionDepth(0);
       STATE(UserHasQuit) = 1;
       break;
     }

--- a/src/streams.c
+++ b/src/streams.c
@@ -102,7 +102,6 @@ static Int READ_COMMAND(TypInputFile * input, Obj *evalResult)
 
     /* handle quit command                                 */
     else if (status == STATUS_QUIT) {
-        SetRecursionDepth(0);
         STATE(UserHasQuit) = 1;
     }
     else if (status == STATUS_QQUIT) {
@@ -329,7 +328,6 @@ static void READ_INNER(TypInputFile * input)
         else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
           break;
         else if (status == STATUS_QUIT) {
-          SetRecursionDepth(0);
           STATE(UserHasQuit) = 1;
           break;
         }


### PR DESCRIPTION
These were added 2009-09-25 to resolve issues where the recursion
depth counter would "overflow" after entering and leaving the break
loop repeatedly during recursive execution.

But these days, we save and restore the execution depth in `GAP_TRY` and
`GAP_CATCH` as well as in `TRY_IF_NO_ERROR` and `Shell`; and at the start
of each REPL iteration in `Shell`, it is set to 0 freshly.

I've verified this experimentally by printing the recursion depth in
the spots were we formerly reset it, and this seems to confirm that the
explicit reset is no longer necessary.
