### PR TITLE
buildsys: generate cnf/GAP-VERSION-FILE in builddir, not srcdir

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1289,11 +1289,12 @@ cnf/GAP-OBJS: FORCE
 # should we need to.
 ########################################################################
 
-GVF = $(srcdir)/cnf/GAP-VERSION-FILE
+GVF = cnf/GAP-VERSION-FILE
 
 # the GAP-VERSION-FILE contains the raw version, nothing else
 $(GVF): FORCE
-	@cd $(srcdir) && $(SHELL) cnf/gap-version-gen.sh $(GAP_VERSION)
+	@$(MKDIR_P) $(@D)
+	@$(SHELL) $(srcdir)/cnf/gap-version-gen.sh $(GAP_VERSION)
 -include $(GVF)
 
 # generate build/gap_version.c


### PR DESCRIPTION
Previously I thought this file could be "safely" shared between multiple GAP
builds. While that's technically true, it can be irritating if one does a
fresh build on otherwise unchanged sources that were last compiled a couple
days/weeks/months ago: the resulting GAP executable will print the build
time from that last build, not the new build, which can be confusing.

Letting each build track this on its own avoids that confusion.

Reported by @ThomasBreuer 