### PR TITLE
Ranges: improve printing and conversion to strings

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -382,6 +382,34 @@ local   str,ls, i;
   return str;
 end );
 
+InstallMethod( DisplayString,
+    "for a range",
+    [ IsRange ],
+    range -> Concatenation( String( range ), "\n" ) );
+
+InstallMethod( ViewString,
+    "for a range",
+    [ IsRange ],
+    function( list )
+    local   str;
+    str := "[ ";
+    Append( str, String( list[1] ) );
+    if Length( list ) > 1 then
+      if Length(list) = 2 or list[2] - list[1] <> 1 then
+        Append( str, ", " );
+        Append( str, String( list[2] ) );
+      fi;
+      if Length(list) > 2 then
+        Append( str, " .. " );
+        Append( str, String( list[ Length( list ) ] ) );
+      fi;
+    fi;
+    Append( str, " ]" );
+    Assert(0, IsStringRep(str));
+    ConvertToStringRep( str );
+    return str;
+    end );
+
 InstallMethod( String,
     "for a range",
     [ IsRange ],
@@ -3829,7 +3857,7 @@ LIST_WITH_IDENTICAL_ENTRIES );
 ##  and in the 'ViewString' method for finite lists.
 ##
 InstallMethod( ViewObj,
-    "for finite lists",
+    "for a finite list",
     [ IsList and IsFinite ],
     {} -> RankFilter(IsList) + 1 - RankFilter(IsList and IsFinite),
 function( list )
@@ -3857,7 +3885,7 @@ function( list )
 end );
 
 InstallMethod( ViewObj,
-    "for ranges",
+    "for a range",
     [ IsList and IsFinite and IsRange ],
     function( list )
     Print( "[ " );

--- a/tst/testinstall/range.tst
+++ b/tst/testinstall/range.tst
@@ -40,7 +40,7 @@ gap> TestPrintRangeRep:=function(r)
 #
 gap> TestPrintRangeRep([0..1]);
 Display: [ 0 .. 1 ]
-DisplayString: <object>
+DisplayString: [ 0 .. 1 ]
 ViewObj: [ 0, 1 ]
 ViewString: [ 0, 1 ]
 PrintObj: [ 0 .. 1 ]
@@ -48,31 +48,31 @@ PrintString: [ 0 .. 1 ]
 String: [ 0 .. 1 ]
 gap> TestPrintRangeRep([0..2]);
 Display: [ 0 .. 2 ]
-DisplayString: <object>
+DisplayString: [ 0 .. 2 ]
 ViewObj: [ 0 .. 2 ]
-ViewString: [ 0, 1, 2 ]
+ViewString: [ 0 .. 2 ]
 PrintObj: [ 0 .. 2 ]
 PrintString: [ 0 .. 2 ]
 String: [ 0 .. 2 ]
 gap> TestPrintRangeRep([0,2..4]);
 Display: [ 0, 2 .. 4 ]
-DisplayString: <object>
+DisplayString: [ 0, 2 .. 4 ]
 ViewObj: [ 0, 2 .. 4 ]
-ViewString: [ 0, 2, 4 ]
+ViewString: [ 0, 2 .. 4 ]
 PrintObj: [ 0, 2 .. 4 ]
 PrintString: [ 0, 2 .. 4 ]
 String: [ 0, 2 .. 4 ]
 gap> TestPrintRangeRep([0,-1..-2]);
 Display: [ 0, -1 .. -2 ]
-DisplayString: <object>
+DisplayString: [ 0, -1 .. -2 ]
 ViewObj: [ 0, -1 .. -2 ]
-ViewString: [ 0, -1, -2 ]
+ViewString: [ 0, -1 .. -2 ]
 PrintObj: [ 0, -1 .. -2 ]
 PrintString: [ 0, -1 .. -2 ]
 String: [ 0, -1 .. -2 ]
 gap> TestPrintRangeRep([0,-1..-1]);
 Display: [ 0, -1 .. -1 ]
-DisplayString: <object>
+DisplayString: [ 0, -1 .. -1 ]
 ViewObj: [ 0, -1 ]
 ViewString: [ 0, -1 ]
 PrintObj: [ 0, -1 .. -1 ]

--- a/tst/testinstall/range.tst
+++ b/tst/testinstall/range.tst
@@ -1,15 +1,83 @@
-#@local g,ranges,x,y,z,a,f
+#@local TestPrintRangeRep,g,ranges,x,y,z,a,f
 gap> START_TEST("range.tst");
 
 #
 gap> [0..0];
 [ 0 ]
+gap> [0..1];
+[ 0, 1 ]
+gap> [0..2];
+[ 0 .. 2 ]
+gap> [0,2..2];
+[ 0, 2 ]
+gap> [0,2..4];
+[ 0, 2 .. 4 ]
 gap> [0..-1];
 [  ]
+gap> [0..-2];
+[  ]
+gap> [0,-1..-1];
+[ 0, -1 ]
+gap> [0,-1..-2];
+[ 0, -1 .. -2 ]
 gap> [-5..5];
 [ -5 .. 5 ]
 gap> [-5,-3..5];
 [ -5, -3 .. 5 ]
+
+#
+gap> TestPrintRangeRep:=function(r)
+>    Assert(0, IsRangeRep(r));
+>    Print("Display: "); Display(r);
+>    Print("DisplayString: ", DisplayString(r));
+>    Print("ViewObj: "); ViewObj(r); Print("\n");
+>    Print("ViewString: ", ViewString(r), "\n");
+>    Print("PrintObj: ", r, "\n");
+>    Print("PrintString: ", PrintString(r), "\n");
+>    Print("String: ", String(r), "\n");
+>  end;;
+
+#
+gap> TestPrintRangeRep([0..1]);
+Display: [ 0 .. 1 ]
+DisplayString: <object>
+ViewObj: [ 0, 1 ]
+ViewString: [ 0, 1 ]
+PrintObj: [ 0 .. 1 ]
+PrintString: [ 0 .. 1 ]
+String: [ 0 .. 1 ]
+gap> TestPrintRangeRep([0..2]);
+Display: [ 0 .. 2 ]
+DisplayString: <object>
+ViewObj: [ 0 .. 2 ]
+ViewString: [ 0, 1, 2 ]
+PrintObj: [ 0 .. 2 ]
+PrintString: [ 0 .. 2 ]
+String: [ 0 .. 2 ]
+gap> TestPrintRangeRep([0,2..4]);
+Display: [ 0, 2 .. 4 ]
+DisplayString: <object>
+ViewObj: [ 0, 2 .. 4 ]
+ViewString: [ 0, 2, 4 ]
+PrintObj: [ 0, 2 .. 4 ]
+PrintString: [ 0, 2 .. 4 ]
+String: [ 0, 2 .. 4 ]
+gap> TestPrintRangeRep([0,-1..-2]);
+Display: [ 0, -1 .. -2 ]
+DisplayString: <object>
+ViewObj: [ 0, -1 .. -2 ]
+ViewString: [ 0, -1, -2 ]
+PrintObj: [ 0, -1 .. -2 ]
+PrintString: [ 0, -1 .. -2 ]
+String: [ 0, -1 .. -2 ]
+gap> TestPrintRangeRep([0,-1..-1]);
+Display: [ 0, -1 .. -1 ]
+DisplayString: <object>
+ViewObj: [ 0, -1 ]
+ViewString: [ 0, -1 ]
+PrintObj: [ 0, -1 .. -1 ]
+PrintString: [ 0, -1 .. -1 ]
+String: [ 0, -1 .. -1 ]
 
 #
 gap> 0 in [0..0];


### PR DESCRIPTION
- Add tests for printing ranges & converting them to strings
- Improve String/ViewString/PrintString for ranges

The diff between the first and second commit shows what changed.

Perhaps we should have similar tests for other library objects?

This patch has been motivated by the CI failure I observed here: https://github.com/gap-packages/fr/pull/38/checks?check_run_id=3160342361