### PR TITLE
Performance improvements for words and a small bugfix

### DIFF
--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -1018,6 +1018,14 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 	    ser[i+1]:=PreImage(hom,N);
 	    Info(InfoMorph,2,"insert2");
 	  fi;
+          N:=ser[i+1]; # the added normal
+          if rada<>fail 
+             and ForAny(GeneratorsOfGroup(rada),x->N<>Image(x,N)) then
+            Info(InfoMorph,3,"radical automorphism stabilizer");
+            SetIsGroupOfAutomorphismsFiniteGroup(rada,true);
+            NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
+            rada:=Stabilizer(rada,N,asAutom);
+          fi;
 	fi;
       fi;
     until split or fratsim;
@@ -1302,6 +1310,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 	    if ForAny(GeneratorsOfGroup(rada),x->Image(x,k)<>k) then
 	      Info(InfoMorph,3,"radical automorphism stabilizer");
 	      NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
+              SetIsGroupOfAutomorphismsFiniteGroup(rada,true);
 	      rada:=Stabilizer(rada,k,asAutom);
 	    fi;
 	  od;

--- a/lib/wordrep.gi
+++ b/lib/wordrep.gi
@@ -1610,8 +1610,9 @@ local i;
 end);
 
 InstallGlobalFunction(WordProductLetterRep,function(arg)
-local l,r,i,j,b,p;
+local l,r,i,j,b,p,lc;
   l:=arg[1];
+  lc:=false;
   for p in [2..Length(arg)] do
     r:=arg[p];
     b:=Length(r);
@@ -1625,10 +1626,18 @@ local l,r,i,j,b,p;
       od;
       if j>b then
 	l:=l{[1..i]};
+        lc:=true;
       elif i=0 then
 	l:=r{[j..b]};
+        lc:=true;
       else
-	l:=Concatenation(l{[1..i]},r{[j..b]});
+        if j=1 and lc then
+          # No cancellation, and l was changed already: Append
+          Append(l,r);
+        else
+          l:=Concatenation(l{[1..i]},r{[j..b]});
+          lc:=true;
+        fi;
       fi;
     fi;
   od;

--- a/tst/testbugfix/2021-08-05-Automorphisms.tst
+++ b/tst/testbugfix/2021-08-05-Automorphisms.tst
@@ -1,0 +1,7 @@
+# Fix GitHub issue #4624   (second issue), reported by Graham Erskine
+# When extending the series, must reduce radical automorphisms to valid ones
+gap> G:=Group([(1,2,3)(4,5,6),(1,7,5)(2,9,4)(3,8,6),
+> (10,14,26)(11,24,13)(12,21,15)(16,20,22)(17,27,19)(18,25,23),
+> (10,11,16)(12,25,23)(13,20,26)(14,24,22)(15,18,27)]);;
+gap> Size(AutomorphismGroup(G));
+8571080448


### PR DESCRIPTION
Improves performance of word products if there is no cancellation and cyclic replacement.

Also fixes a bug that is only in 4.12 (and thus does not need to be announced or backported).