### PR TITLE
Document and unify the order in which GAP evaluates function arguments and options

### DIFF
--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -1130,15 +1130,13 @@ Remember that a variable is a location in a &GAP; program
 that points to a value. Thus for  each formal argument and for each
 formal local such a location is allocated.
 <P/>
-Next the arguments <A>arg-expr</A>s are evaluated, and the values are assigned
+Next the arguments <A>arg-expr</A>s are evaluated from left to right,
+and the values are assigned
 to the newly created variables corresponding to the formal arguments. Of
 course the first value is assigned to the new variable corresponding to
 the first formal argument, the second  value  is assigned to the new
 variable corresponding  to  the second  formal argument, and  so on.
-However, &GAP; does not make any guarantee about the order in which the
-arguments are evaluated. They might be evaluated left to right, right to
-left, or in any other order, but each argument is evaluated once. An
-exception again occurs if the last formal argument has
+An exception again occurs if the last formal argument has
 the name <C>arg</C>. In this case the values of all the actual
 arguments not assigned to the other formal parameters are
 stored in  a list and this  list is assigned to the  new variable
@@ -1200,6 +1198,8 @@ are separated from the actual arguments by a colon <C>:</C> and have much
 the same syntax as the components of a record expression. The one
 exception to this is that a component name may appear without a value,
 in which case the value <K>true</K> is silently inserted.
+<P/>
+Options are evaluated from left to right, but only after all arguments have been evaluated.
 <P/>
 The following example shows a call to <Ref Attr="Size"/> passing the options
 <C>hard</C> (with the value <K>true</K>)

--- a/tst/testbugfix/2021-08-19-FuncCallOptionEvalOrder.tst
+++ b/tst/testbugfix/2021-08-19-FuncCallOptionEvalOrder.tst
@@ -1,0 +1,32 @@
+#@local myfunc, func_call, proc_call
+# Fix GitHub issue #4631: The evaluation order of arguments versus
+# options in function and procedure calls differed between the immediate
+# interpreter, and the executor for coded statements.
+gap> myfunc := function( )
+>       Display( ValueOption( "myopt" ) );
+>       return 1;
+>    end;;
+gap> func_call := function( )
+>       # a function call follows; one of the arguments uses myopt as a side effect
+>       return IdFunc( myfunc( ) : myopt := "myopt_value" );
+>    end;;
+gap> proc_call := function( )
+>     # a procedure call follows; one of the arguments uses myopt as a side effect
+>     Ignore( myfunc( ) : myopt := "myopt_value" );
+>    end;;
+
+# call as function, delayed
+gap> func_call( );;
+fail
+
+# call as function, immediately
+gap> IdFunc( myfunc( ) : myopt := "myopt_value" );;
+fail
+
+# call as procedure, delayed
+gap> proc_call( );
+fail
+
+# call as procedure, immediately
+gap> Ignore( myfunc( ) : myopt := "myopt_value" );
+fail

--- a/tst/testinstall/kernel/funcs.tst
+++ b/tst/testinstall/kernel/funcs.tst
@@ -1,3 +1,12 @@
+#
+# Tests for functions defined in src/funcs.c
+#
+gap> START_TEST("kernel/funcs.tst");
+
+#
 gap> SetRecursionTrapInterval(fail);
 Error, SetRecursionTrapInterval: <interval> must be a small integer greater th\
 an 5 (not the value 'fail')
+
+#
+gap> STOP_TEST("kernel/funcs.tst", 1);


### PR DESCRIPTION
Previously, this was what the immediate interpreter did, but *not*
what the executor did; the latter always evaluated options first.

Fixes #4631