### PR TITLE
Relax correctness check of Test pragmas

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -128,7 +128,7 @@ InstallGlobalFunction(ParseTestInput, function(str, ignorecomments, fnam)
     elif StartsWith(lines[i], ">\t") then
         testError("Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space");
     elif Length(outp) > 0 then
-      if foundcmd then
+      if foundcmd and not ForAll(lines[i], c -> c = ' ' or c = '\t') then
         testError("Invalid test file: #@ command found in the middle of a single test");
       fi;
       Append(outp[Length(outp)], lines[i]);

--- a/tst/testspecial/broken-test-1.tst
+++ b/tst/testspecial/broken-test-1.tst
@@ -1,0 +1,9 @@
+#@if false
+gap> 1
+#@else
+gap> 2;
+2
+#@fi
+
+gap> 3;
+3


### PR DESCRIPTION
It turned simple whitespace issues (such as placing an empty line into
the wrong spot) into hard error saying:

> Invalid test file: #@ command found in the middle of a single test

Resolves #4635

To be clear, @ssiccha's example test files will still result in test failures, and those extra empty lines will be removed by `rewriteToFile:=true`. But that's as intended.