### PR TITLE
CI: disable coverage gathering for windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -236,6 +236,7 @@ jobs:
         run: ${{ matrix.extra }} dev/ci-gather-coverage.sh
       - name: "Upload coverage data to Codecov"
         uses: codecov/codecov-action@v1
+        if: ${{ runner.os != 'Windows' }} # FIXME/HACK: skip this on Windows, it runs forever
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: "!./pkg/**,!./extern/**"


### PR DESCRIPTION
This is a hack to get our Windows CI tests unstuck: it currently tries for over 5 hours to "upload coverage data" and then times out. This in turn *could* be caused by a version of `gcov` not matching the version of `gcc` being installed -- see issue #4640.

So perhaps this is also related to the `setup-cygwin` github action?

But I don't have time to debug this further, so this PR just tries to fix the symptom, and perhaps others can find a cure for the cause?