### PR TITLE
Correct libgap-api.h for C++ usage

### DIFF
--- a/src/libgap-api.h
+++ b/src/libgap-api.h
@@ -13,6 +13,10 @@
 #ifndef LIBGAP_API_H
 #define LIBGAP_API_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "system.h"
 
 #include <setjmp.h>
@@ -501,5 +505,9 @@ Int GAP_ValueOfChar(Obj obj);
 
 // Returns the GAP character object with value <obj>.
 Obj GAP_CharWithValue(UChar obj);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
In order to link C libraries to C++ programs, one needs to avoid the mangling.
This is done by adding the *extern "C" {" statements as done in this PR.
This allows to use the libgap in C++ programs with success.