### PR TITLE
Add special cases to `Transitivity` for a permgroup with known size: natural An and Sn

### DIFF
--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -1094,6 +1094,10 @@ InstallOtherMethod( Transitivity,
       # The trivial group is transitive on the empty set,
       # but has transitivity zero.
       return 0;
+    elif IsNaturalSymmetricGroup( G ) then
+      return n;
+    elif IsNaturalAlternatingGroup( G ) then
+      return n - 2;
     fi;
     t:= 0;
     size:= Size( G );

--- a/tst/testinstall/oprtperm.tst
+++ b/tst/testinstall/oprtperm.tst
@@ -1,0 +1,26 @@
+#@local
+gap> START_TEST("oprtperm.tst");
+
+# Transitivity of permgroups of known size that happen to be natural Sn/An
+# (Really we're testing performance)
+gap> Transitivity(SymmetricGroup(1000));
+1000
+gap> Transitivity(AlternatingGroup(1002));
+1000
+
+# Check small cases with moved points [1..n]
+gap> List([0 .. 10], n -> Transitivity(SymmetricGroup(n)));
+[ 0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+gap> List([0 .. 10], n -> Transitivity(AlternatingGroup(n)));
+[ 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8 ]
+
+# Check small cases with moved points different from [1..n]
+gap> List([0 .. 10], n ->
+>      Transitivity(SymmetricGroup(Shuffle(ShallowCopy(Primes)){[1 .. n]})));
+[ 0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+gap> List([0 .. 10], n ->
+>      Transitivity(AlternatingGroup(Shuffle(ShallowCopy(Primes)){[1 .. n]})));
+[ 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8 ]
+
+#
+gap> STOP_TEST("oprtperm.tst", 1);


### PR DESCRIPTION
Apart from trivial cases, `Transitivity(SymmetricGroup(n)) = n` and `Transitivity(AlternatingGroup(n)) = n - 2`. Easy! This currently takes longer than it should, in my opinion, because there is no special case for such groups. The existing method works quite well for natural symmetric groups (presumably because there are special methods for point stabilisers of natural symmetric groups), but it's still not amazing:
```
gap> Transitivity(SymmetricGroup(1000));; time;
214
```
But it's much worse for alternating groups (degree of just 100):
```
gap> Transitivity(AlternatingGroup(100));; time;
12084
```
So I've added a special case to this method, and now:
```
gap> Transitivity(AlternatingGroup(1000));; time;
2
```
(This breaks down once the degree gets big enough that the order of the alternating/symmetric group is not set at creation.)

I think there's possibly a case to be made for setting the value of this attribute at creation in the `SymmetricGroup`/`AlternatingGroup` methods, but this works well enough already and this should catch groups that happen to be naturally symmetric/alternating without being created by those functions.

Of course this PR isn't meant to be exhaustive. There are many places in the permgroups code where we could add special cases for natural symmetric and alternating groups: they are cheap to detect as such, but it is expensive to build stabiliser chains for such groups (which default methods often do), so we should avoid doing that when reasonably practical.