### PR TITLE
CI: wrap releases workflow: install Latex more robustly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,17 @@ jobs:
       - name: "Install Python modules"
         run: pip3 install PyGithub python-dateutil
       - name: "Install latex"
-        run: sudo apt-get install texlive texlive-latex-extra texlive-extra-utils texlive-fonts-extra
+        run: |
+          packages=(
+            texlive-latex-base
+            texlive-latex-recommended
+            texlive-latex-extra
+            texlive-extra-utils
+            texlive-fonts-recommended
+            texlive-fonts-extra
+          )
+          sudo apt-get update
+          sudo apt-get install "${packages[@]}"
       - name: "Configure GAP"
         run: dev/ci-configure-gap.sh
       - name: "Build GAP"


### PR DESCRIPTION
Adding a `sudo apt-get update` fixed the problems that we've been having with the “Wrap releases” workflow, in which the “Install latex” step was failing.

I've also changed the packages that are installed, and how they are presented in this file, to agree with https://github.com/gap-actions/build-pkg-docs