### PR TITLE
FIX: wrong Generators of Matrix Wreath Product with Intransitive Top Group.

### DIFF
--- a/lib/gprdmat.gi
+++ b/lib/gprdmat.gi
@@ -253,7 +253,7 @@ end);
 DeclareGlobalFunction("MatWreathProduct");
 
 InstallGlobalFunction(MatWreathProduct,function(A,B)
-local f,n,m,Agens,Bgens,emb,i,j,a,g,dim,rans,range;
+local f,n,m,Agens,Bgens,emb,i,j,a,g,dim,rans,range,orbs;
   f:=DefaultFieldOfMatrixGroup(A);
   n:=DimensionOfMatrixGroup(A);
   m:=LargestMovedPoint(B);
@@ -271,7 +271,8 @@ local f,n,m,Agens,Bgens,emb,i,j,a,g,dim,rans,range;
     od;
     emb[j]:=Agens;
   od;
-  Agens:=emb[1];
+  orbs := OrbitsDomain(B);
+  Agens := Concatenation(List(orbs, orb -> emb[orb[1]]));
 
   Bgens:=List(GeneratorsOfGroup(B),
 	  x->KroneckerProduct(PermutationMat(x,m,f),One(A)));

--- a/tst/testbugfix/2021-09-22-MatWreathProduct.tst
+++ b/tst/testbugfix/2021-09-22-MatWreathProduct.tst
@@ -1,0 +1,6 @@
+# Generators of Matrix Wreath Product with Intransitive Top Group # 4663
+gap> K := GL(3,2);;
+gap> H := Group((1,2,3)(4,5));;
+gap> G := WreathProduct(K, H);;
+gap> Size(Group(GeneratorsOfGroup(G))) = 802966929408;
+true


### PR DESCRIPTION
It was implicitely assumed that the top group is transitive,
resulting in insufficient generators for the base group of the matrix wreath product
if the top group was given intransitive.

## Further details

Closes #4663 
