### PR TITLE
Let `RootSystem` use the correct field for determining eigenvectors

### DIFF
--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -2917,7 +2917,7 @@ InstallMethod( RootSystem,
 
         V:= Basis( VectorSpace( F, j, "basis" ), j );
         M:= List( j, x -> Coefficients( V, i*x ) );
-        facs:= Factors( MinimalPolynomial( F, M ) );
+        facs:= Factors( PolynomialRing( F ), MinimalPolynomial( F, M ) );
 
         for l in facs do
           V:= NullspaceMat( Value( l, M ) );

--- a/tst/testbugfix/2021-09-25-RootSystem.tst
+++ b/tst/testbugfix/2021-09-25-RootSystem.tst
@@ -1,0 +1,8 @@
+# Fix GitHub issue #4661, reported by Lars Göttgens
+gap> mats:=[ [[0,1,0],[-1,0,0],[0,0,0]], [[0,0,1],[0,0,0],[-1,0,0]], [[0,0,0],[0,0,1],[0,-1,0]] ];;
+gap> F:=Field( E( 4 ) );;
+gap> L:=LieAlgebra( F, mats );;
+gap> R:=RootSystem( L );
+<root system of rank 1>
+gap> CartanMatrix( R );
+[ [ 2 ] ]


### PR DESCRIPTION
It was assumed that the DefaultField of the minimal polynomial is the field to factor it over. In some cases, i.e. x^2+1 for some Lie Algebra over CC (=Field(E(4))) this differs and thus makes RootSystem fail.
Now, it uses the field of the lie algebra.

Closes #4661 

## Text for release notes

see title