### PR TITLE
Add SpinorNorm.

### DIFF
--- a/grp/classic.gi
+++ b/grp/classic.gi
@@ -1915,6 +1915,102 @@ InstallMethod( Omega,
 InstallMethod( Omega,
     [ IsFunction, IsInt, IsPosInt, IsField and IsFinite ],
     { filt, e, d, R } -> OmegaCons( filt, e, d, Size( R ) ) );
+    
+    
+#############################################################################
+##
+#F  WallForm( <form>, <m> ) . . . . . . . . . . . . . compute the wall of <m>
+##
+# Computes the Wall Form of a matrix. The defintition can be found in
+# [Taylor, page 163].
+BindGlobal( "WallForm", function( form, m )
+    local id,  w,  b,  p,  i,  x,  j;
+
+    # first argument should really be something useful
+    id := One( m );
+
+    # compute a base for Image(id-m), use the most stupid algorithm
+    w := id - m;
+    b := [];
+    p := [];
+    for i  in [ 1 .. Length(w) ]  do
+        if Length(b) = 0  then
+            if w[i] <> 0*w[i]  then
+                Add( b, w[i] );
+                Add( p, i );
+            fi;
+        elif RankMat(b) <> RankMat(Concatenation(b,[w[i]]))  then
+            Add( b, w[i] );
+            Add( p, i );
+        fi;
+    od;
+
+    # compute the form
+    x := List( b, x -> [] );
+    for i  in [ 1 .. Length(b) ]  do
+        for j  in [ 1 .. Length(b) ]  do
+            x[i][j] := id[p[i]] * form * b[j];
+        od;
+    od;
+
+    # and return
+    return rec( base := b, pos := p, form := x );
+
+end );
+
+
+#############################################################################
+##
+#F  IsSquare( fld, e) . . . . . . . . . . . Tests whether <e> is a square element
+##   in <fld>
+##
+# Input: Field fld, e element of fld
+# Output: true if e is a square element in fld. Otherwise false.
+BindGlobal( "IsSquare", function( fld, e )
+    local char, q;
+    
+    char := Characteristic(fld);
+    # If the characteristic of fld is equal to 2, we know that every element is a
+    # sqare. Hence, we can return true.
+    if char = 2 then
+        return true;
+    fi;
+    q := Size(fld);
+    
+    # If the characteristic of fld is not 2, we know that there are exactly
+    # (q+1)/2 elements which are a square (Huppert LA, Theorem 2.5.4). Now observe
+    # that for a square element e we have that e^((q-1)/2) = 1. And, thus, the
+    # polynomial X^((q-1)/2) - 1 has already (q-1)/2 different roots (every square
+    # except 0). Hence, for a non-square element e' we have that (e')^((q-1)/2) <> 1
+    # which proves the lines below.
+    if e^((q-1)/2) = One(fld) then
+        return true;
+    else
+        return false;
+    fi;
+    
+end );
+
+
+#############################################################################
+##
+#F  SpinorNorm( <form>, <m> ) . . . . . . . .  compute the spinor norm of <m>
+##
+# Output: 1 if the discriminant of the Wall form of <m> is (F^*)^2.
+#          Otherwise -1.
+# The defintition can be found in [Taylor, page 163].
+BindGlobal( "SpinorNorm", function( form, m )
+    local one;
+    one := One(m[1][1]);
+    if IsOne(m) then return one; fi;
+    
+    if IsSquare(FieldOfMatrixList([m]), DeterminantMat( WallForm(form,m).form )) then
+        return one;
+    else
+        return -1 * one;
+    fi;
+end );
+
 
 
 #############################################################################

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -1,7 +1,7 @@
 #
 # Tests for the "general" group constructors: GL, GO, GU, GammaL
 #
-#@local G, H, d, q, S, grps
+#@local G, H, d, q, S, grps, gens, w, form, g
 
 gap> START_TEST("classic-G.tst");
 
@@ -195,6 +195,21 @@ Error, no 1st choice method found for `Omega' on 3 arguments
 #
 gap> Omega(2,2);
 Error, sign <e> = 0 but dimension <d> is even
+
+#
+gap> G := Omega(1,4,3);;
+gap> gens := GeneratorsOfGroup(G);;
+gap> form := G!.InvariantBilinearForm.matrix;;
+gap> SpinorNorm(form,gens[1]) = One(GF(3));
+true
+gap> SpinorNorm(form,gens[2]) = One(GF(3));
+true
+gap> w := PrimitiveElement(GF(3));;
+gap> g := IdentityMat(4,GF(3));;
+gap> g[1,1] := w^3;;
+gap> g[4,4] := w^(-3);;
+gap> SpinorNorm(form,g) = One(GF(3));
+false
 
 # Membership tests in GL, SL, GO, SO, GU, SU, Sp can be delegated
 # to the tests of the stored respected forms and therefore are cheap.


### PR DESCRIPTION
For the maximal subgroup project we need the SpinorNorm. In the package "matrix" of GAP3 I found the WallForm and SpinorNorm functions of this PR. I modified the SpinorNorm output slightly in order to have a more intuitive feedback. For this, the function "IsSquare" has been added.

## Text for release notes

see title
