### PR TITLE
Make GroupWithGenerators compatible with MatrixObj

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -914,7 +914,13 @@ local G,typ,f;
           gens,false,true);
 
   f:=DefaultScalarDomainOfMatrixList(gens);
-  gens:=List(Immutable(gens),i->ImmutableMatrix(f,i));
+  if ForAll(gens, x -> IsMatrixObj(x) and not IsGF2MatrixRep(x) and not
+                           Is8BitMatrixRep(x)) then
+    gens := List(gens, x -> Matrix(f, StructuralCopy(x)));
+    Perform(gens, MakeImmutable);
+  else
+    gens:=List(Immutable(gens),i->ImmutableMatrix(f,i));
+  fi;
 
   G:=rec();
   ObjectifyWithAttributes(G,typ,GeneratorsOfMagmaWithInverses,AsList(gens));


### PR DESCRIPTION
If GroupWithGenerators is called with a list of MatrixObj matrices which are
not compressed matrices, then `ImmutableMatrix` can't be called.

TODO: Add tests.

@fingolfin Do you have an idea on how to avoid the `StructuralCopy` call?
