### PR TITLE
kernel: move `#include "config.h"` from headers into source files

### DIFF
--- a/README.buildsys.md
+++ b/README.buildsys.md
@@ -130,7 +130,6 @@ far off.
 
 Compatibility mode does the following things:
 
-* create `sysinfo.gap` file in the build dir
 * create a symlink `sysinfo.gap-default$ABI` pointing at `sysinfo.gap`
 * create a `bin/$GAPARCH/config.h` symlink pointing at `build/config.h`
 * create a `bin/$GAPARCH/gac` symlink pointing at `gac`
@@ -249,13 +248,6 @@ support for free. While it does indeed provide various parts of the puzzle,
 from our perspective those are mostly the easy ones (they may be tedious, but
 are not conceptually difficult). The real obstacles for `make install` support
 are unfortunately not resolved by using `automake`. Among these are:
-- dealing with installing the generated `config.h`. This file should ideally
-  not be installed at all and to this end not be included from any other
-  headers. But note that in GAP, currently *all* headers need to include
-  config.h directly or indirectly... Alternatively one can attempt to use
-  something like `AX_PREFIX_CONFIG_H`, but this, too, has its pitfalls
-- removing dependencies on compiler specific features in the headers and API,
-  mainly as introduced by `config.h`
 - making `gac` installable; in particular installing a version of GNU
   libtool needed by `gac`
 - The probably hardest problem of them all is coming up with a sane way for

--- a/dev/audit-config-h.sh
+++ b/dev/audit-config-h.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# This script scans all kernel sources which do not #include config.h for uses
+# of symbols potentially #defined in `config.h`, with a couple of exceptions
+# described below. It then reports all matches. The exit code is non-zero
+# (indicating an error) if there are any such matches.
+#
+# This is used in `dev/ci.sh` to verify that we don't use any of those symbols
+# in any of our headers. It can also be used to check which C/C++ source files
+# use any of these headers, and thus ought to
+# #include config.h.
+set -e
+
+# ensure that no .h file #includes config.h
+if git grep -n -w config.h :src/*.h > /dev/null ; then
+  echo "Error, a kernel header file includes config.h"
+  exit 1
+fi
+
+# First scan config.h to obtain a list of all symbols it might define. From
+# this is subtracts a list of "known OK" symbols. The symbols and there reason
+# for being on this list are:
+# - `HAVE_FUNC_ATTRIBUTE_`*: these are only used for optimizations; also, our
+#    headers try hard to define them on the fly (at least in GCC and clang)
+# - `HAVE___BUILTIN_MUL_OVERFLOW`: same as above
+# - `SIZEOF_VOID_P`: provided for backwards compatibility in a few packages,
+#    and actually (re-)defined in `common.h`
+# - `SPARC`: only appears in a comment
+PATTERN=$(egrep '(#define|#undef)' build/config.h | sed -E -e 's;(#define|/\* #undef) ([^ ]+) .*$;\2;' | egrep -v 'HAVE_FUNC_ATTRIBUTE_|HAVE___BUILTIN_MUL_OVERFLOW|SIZEOF_VOID_P|SPARC' | tr '\n' '|')
+PATTERN=${PATTERN%?} # remove trailing "|"
+
+# only consider files that do not #include config.h
+FILES=$(git grep --files-without-match -P '^#include "config\.h"$' src)
+
+# Next use `git grep` to search all kernel header files for occurrences of any
+# of the symbols in the pattern we just created. We negate the exit code: grep
+# exits with exit code 0 if there were hits, and with exit code 1 if there
+# were no hits. For our purposes, we want the reverse: no hits is "good".
+if git grep -n -P ${PATTERN} $FILES ; then
+  echo "Error, a kernel source file not including config.h uses symbols from config.h"
+  exit 1
+fi

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -160,6 +160,11 @@ GAPInput
     # test: running `make` a second time should produce no output
     test -z "$(make)"
 
+    # audit config.h
+    pushd $SRCDIR
+    dev/audit-config-h.sh
+    popd
+
     # test: touching all source files does *not* trigger a rebuild if we make
     # a target that doesn't depend on sources. We verify this by replacing the source
     # code with garbage

--- a/src/blister.c
+++ b/src/blister.c
@@ -84,6 +84,8 @@
 #include "saveload.h"
 #include "set.h"
 
+#include "config.h"
+
 
 #define RequireBlist(funcname, op)                                           \
     RequireArgumentCondition(funcname, op, IsBlistConv(op),                  \

--- a/src/common.h
+++ b/src/common.h
@@ -11,8 +11,6 @@
 #ifndef GAP_COMMON_H
 #define GAP_COMMON_H
 
-#include "config.h"
-
 #include <assert.h>
 #include <stdint.h>
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -28,6 +28,8 @@
 #include "hpc/region.h"
 #endif
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -58,6 +58,8 @@
 #include "boehm_gc.h"
 #endif
 
+#include "config.h"
+
 #include <gmp.h>
 
 static Obj Error;

--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -24,6 +24,8 @@
 #include "sysfiles.h"
 #include "system.h"
 
+#include "config.h"
+
 #include <errno.h>
 #include <stddef.h>
 #include <sys/time.h>

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -124,6 +124,8 @@
 
 #include "bags.inc"
 
+#include "config.h"
+
 #include <setjmp.h>
 #include <string.h>
 

--- a/src/integer.c
+++ b/src/integer.c
@@ -79,6 +79,8 @@
 #include "stats.h"
 #include "stringobj.h"
 
+#include "config.h"
+
 
 /* TODO: Remove after Ward2 */
 #ifndef WARD_ENABLED

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -35,6 +35,8 @@
 
 #include "hpc/thread.h"
 
+#include "config.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -31,6 +31,8 @@
 
 #include "bags.inc"
 
+#include "config.h"
+
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -33,6 +33,8 @@
 #include "stringobj.h"
 #include "sysstr.h"
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -38,6 +38,8 @@
 #include "sysstr.h"
 #include "vars.h"
 
+#include "config.h"
+
 #ifdef HAVE_DLOPEN
 #include <dlfcn.h>
 #endif

--- a/src/profile.c
+++ b/src/profile.c
@@ -32,6 +32,8 @@
 
 #include "hpc/thread.h"
 
+#include "config.h"
+
 #include <stdio.h>
 #include <sys/time.h>                   // for gettimeofday
 #include <sys/types.h>

--- a/src/stats.c
+++ b/src/stats.c
@@ -35,6 +35,8 @@
 #include "sysfiles.h"
 #include "vars.h"
 
+#include "config.h"
+
 #ifdef USE_GASMAN
 #include "sysmem.h"
 #endif

--- a/src/streams.c
+++ b/src/streams.c
@@ -38,6 +38,8 @@
 #include "trycatch.h"
 #include "vars.h"
 
+#include "config.h"
+
 #include <dirent.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -11,6 +11,9 @@
 **  file and stream operations.
 */
 
+// ensure we can access large files
+#define _FILE_OFFSET_BITS 64
+
 #include "sysfiles.h"
 
 #include "bool.h"
@@ -34,6 +37,8 @@
 #include "system.h"
 
 #include "hpc/thread.h"
+
+#include "config.h"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -19,6 +19,8 @@
 #include "sysfiles.h"
 #include "sysopt.h"
 
+#include "config.h"
+
 #ifdef GAP_MEM_CHECK
 #include <fcntl.h>
 #endif

--- a/src/system.c
+++ b/src/system.c
@@ -38,6 +38,8 @@
 #include "boehm_gc.h"
 #endif
 
+#include "config.h"
+
 #include <assert.h>
 #include <fcntl.h>
 #include <stdarg.h>


### PR DESCRIPTION
This was part of PR #4492 (which is about implementing `make install` support) but it is of independent use and ready for merging *now*, unlike that PR, hence I've moved it into its own PR.
