### PR TITLE
Faster Wreath Product `Embedding`

### DIFF
--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -863,7 +863,7 @@ end);
 InstallMethod( ListWreathProductElementNC, "perm wreath product", true,
  [ IsPermGroup and HasWreathProductInfo, IsObject, IsBool ], 0,
 function(G, x, testDecomposition)
-  local info, list, h, f, degK, i, j, constPoints, imageComponents, comp, restPerm;
+  local info, list, h, hIm, f, degK, i, j, constPoints, imageComponents, comp, restPerm;
 
   info := WreathProductInfo(G);
   # The top group element
@@ -871,8 +871,12 @@ function(G, x, testDecomposition)
   if h = fail then
     return fail;
   fi;
+  hIm := ImageElm(Embedding(G, info.degI + 1), h);
+  if hIm = fail then
+    return fail;
+  fi;
   # The product of the base group elements
-  f := x * Image(Embedding(G, info.degI + 1), h) ^ (-1);
+  f := x * hIm ^ (-1);
   list := EmptyPlist(info!.degI + 1);
   list[info.degI + 1] := h;
   # Imprimitive Action, tuple (i, j) corresponds

--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -610,6 +610,7 @@ local	G,H,	    # factors
     if IsEmpty( domI )  then
         domI := [ 1 ];
     fi;
+    domI := MakeImmutable(Set(domI));
     degI := Length( domI );
 
     # make the generators of the direct product of <deg> copies of <G>
@@ -674,6 +675,7 @@ local	G,H,	    # factors
       basegens:=basegens,
       I      := I,
       degI   := degI,
+      domI   := domI,
       hgens  := hgens,
       components := components,
       embeddingType := NewType(
@@ -773,11 +775,7 @@ InstallMethod( ImagesRepresentative,
     fi;
     # Embedding into top group
     x := g ^ info.alpha;
-    domI := MovedPoints(Range(info.alpha));
-    # force trivial group to act on 1 point
-    if IsEmpty( domI )  then
-      domI := [ 1 ];
-    fi;
+    domI := info.domI;
     degG := NrMovedPoints(info.groups[1]);
     # force trivial group to act on 1 point
     if degG = 0 then

--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -746,8 +746,10 @@ InstallMethod( Source,"perm wreath product embedding",
     function(emb)
       local info;
       info := WreathProductInfo( Range( emb ) );
+      # Embedding into top group
       if emb!.component = info.degI + 1 then
         return info.groups[2];
+      # Embedding into a component of the base group
       else
         return info.groups[1];
       fi;
@@ -765,32 +767,33 @@ InstallMethod( ImagesRepresentative,
     local info, degI, x, shift, domI, degG, i, k, l;
     info := WreathProductInfo(Range(emb));
     degI := info.degI;
-    if emb!.component = degI + 1 then
-      x := g ^ info.alpha;
-      domI := MovedPoints(Range(info.alpha));
-      # force trivial group to act on 1 point
-      if IsEmpty( domI )  then
-        domI := [ 1 ];
-      fi;
-      degG := Length(MovedPoints(info.groups[1]));
-      # force trivial group to act on 1 point
-      if degG = 0 then
-        degG := 1;
-      fi;
-      shift := [];
-      for i  in [1 .. degI ]  do
-        k := Position(domI, domI[i] ^ x);
-        if k = fail then
-          return fail;
-        fi;
-        for l  in [1 .. degG]  do
-          shift[(i - 1) * degG + l] := (k - 1) * degG + l;
-        od;
-      od;
-      return PermList(shift);
-    else
+    # Embedding into a component of the base group
+    if emb!.component <> degI + 1 then
       return g ^ info.perms[emb!.component];
     fi;
+    # Embedding into top group
+    x := g ^ info.alpha;
+    domI := MovedPoints(Range(info.alpha));
+    # force trivial group to act on 1 point
+    if IsEmpty( domI )  then
+      domI := [ 1 ];
+    fi;
+    degG := NrMovedPoints(info.groups[1]);
+    # force trivial group to act on 1 point
+    if degG = 0 then
+      degG := 1;
+    fi;
+    shift := [];
+    for i  in [1 .. degI]  do
+      k := Position(domI, domI[i] ^ x);
+      if k = fail then
+        return fail;
+      fi;
+      for l  in [1 .. degG]  do
+        shift[(i - 1) * degG + l] := (k - 1) * degG + l;
+      od;
+    od;
+    return PermList(shift);
 end );
 
 #############################################################################
@@ -804,15 +807,16 @@ InstallMethod( PreImagesRepresentative,
     function( emb, g )
     local info;
     info := WreathProductInfo( Range( emb ) );
+    # Embedding into top group
     if emb!.component = info.degI + 1 then
       return g ^ Projection(Range(emb));
-    else
-      if not g in info.base then
-        return fail;
-      fi;
-      return RestrictedPermNC( g, info.components[ emb!.component ] )
-            ^ (info.perms[ emb!.component ] ^ -1);
     fi;
+    # Embedding into component of base group
+    if not g in info.base then
+      return fail;
+    fi;
+    return RestrictedPermNC( g, info.components[ emb!.component ] )
+          ^ (info.perms[ emb!.component ] ^ -1);
 end );
 
 


### PR DESCRIPTION
I want to try to add faster implementations for `Embedding` for wreath products and
also fix errors that might happen in `ListWreathProductElement` for top groups not being the symmetric group.
Those issues might be related to the current `Embedding` implementations.

The motivation for this pull request is to fix annoying errors for the `\in` implementation for wreath product provided in my package [WPE](https://github.com/FriedrichRober/WreathProductElements)