### PR TITLE
Replace remaining instance of `SYS_IS_DARWIN` (Fix issue #4681)

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -865,8 +865,8 @@ void InitSystem (
     /* the users home directory                                            */
     if ( getenv("HOME") != 0 ) {
         strxcpy(DotGapPath, getenv("HOME"), sizeof(DotGapPath));
-# if defined(SYS_IS_DARWIN) && SYS_IS_DARWIN
-        /* On Darwin, add .gap to the sys roots, but leave */
+# if defined(__APPLE__)
+        /* On Mac OS, add .gap to the sys roots, but leave */
         /* DotGapPath at $HOME/Library/Preferences/GAP     */
         strxcat(DotGapPath, "/.gap;", sizeof(DotGapPath));
         if (!IgnoreGapRC) {


### PR DESCRIPTION
Commit 2dc214f2c7ce1624f35da1676e3ad986cc7719ff from #4678 was incomplete in replacing `SYS_IS_DARWIN`, this is my attempt at fixing it (`GAPInfo.UserGapRoot` and `GAPInfo.RootPaths` are fixed on my Mac again, anyway).

I wasn't sure whether `defined(__MACH__)` and/or `defined(__APPLE__)` was more appropriate.

Closes #4681.