### PR TITLE
Fix ShowDeclarationsOfOperation for "trivial" argument filters

### DIFF
--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -412,7 +412,7 @@ end);
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL("ShowDeclarationsOfOperation",function(oper)
-    local locs, reqs, i, r;
+    local locs, reqs, i, r, f;
     if not IsOperation(oper) then
         Error("<oper> must be an operation");
     fi;
@@ -422,8 +422,13 @@ BIND_GLOBAL("ShowDeclarationsOfOperation",function(oper)
         return;
     fi;
     reqs := GET_OPER_FLAGS(oper);
+    f := function(filt)
+             filt:=NamesFilter(filt);
+             if Length(filt) = 0 then filt := ["IsObject"]; fi;
+             return filt;
+         end;
     for i in [1.. Length(locs)] do
-        r := List(reqs[i], r -> JoinStringsWithSeparator(NamesFilter(r), " and \c"));
+        r := List(reqs[i], r -> JoinStringsWithSeparator(f(r), " and \c"));
         Print(String(i, 3), ": ", locs[i][1], "\c:", locs[i][2], "\c",
               " with ", Length(reqs[i]), "\c",
               " arguments, and filters [ ", "\c",

--- a/lib/type.gi
+++ b/lib/type.gi
@@ -40,12 +40,11 @@ function(flags, max)
     local names;
 
     names := NamesFilter(flags);
-    names := names{[1..Minimum(Length(names), max)]};
-    names := JoinStringsWithSeparator(names, ", ");
-
-    if Length(NamesFilter(flags)) > max then
-        Append(names, ", ...");
+    if Length(names) > max then
+        names := names{[1..max]};
+        Add(names, "...");
     fi;
+    names := JoinStringsWithSeparator(names, ", ");
 
     return Concatenation("[ ", names, " ]");
 end);
@@ -113,7 +112,7 @@ function ( type )
 
     data := type![POS_DATA_TYPE];
     if data <> false  then
-        Append(res, STRINGIFY(", data: ", data, "," ) );
+        Append(res, STRINGIFY(", data: ", data ) );
     fi;
     Append(res, ">");
     return res;

--- a/tst/testinstall/kernel/bool.tst
+++ b/tst/testinstall/kernel/bool.tst
@@ -5,7 +5,7 @@ gap> START_TEST("kernel/bool.tst");
 
 # TypeBool
 gap> t:=TypeObj(true);
-<Type: (BooleanFamily, [ IsBool, IsInternalRep ]), data: fail,>
+<Type: (BooleanFamily, [ IsBool, IsInternalRep ]), data: fail>
 gap> IsIdenticalObj(t, TypeObj(false));
 true
 gap> IsIdenticalObj(t, TypeObj(fail));

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -519,11 +519,11 @@ gap> UnderlyingSemigroup(T);
 gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
 gap> TypeReesMatrixSemigroupElements(Semigroup(Representative(R)));
 <Type: (ReesZeroMatrixSemigroupElementsFamily, [ IsExtLElement, IsExtRElement,\
- IsMultiplicativeElement, ... ]), data: fail,>
+ IsMultiplicativeElement, ... ]), data: fail>
 gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
 gap> TypeReesMatrixSemigroupElements(Semigroup(Representative(R)));
 <Type: (ReesMatrixSemigroupElementsFamily, [ IsExtLElement, IsExtRElement, IsM\
-ultiplicativeElement, ... ]), data: fail,>
+ultiplicativeElement, ... ]), data: fail>
 
 # RMSElement global function
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(1,2), 0], [0, ()]]);;

--- a/tst/testspecial/ShowDeclarationsOfOperation.g
+++ b/tst/testspecial/ShowDeclarationsOfOperation.g
@@ -1,0 +1,1 @@
+ShowDeclarationsOfOperation(Position);

--- a/tst/testspecial/ShowDeclarationsOfOperation.g.out
+++ b/tst/testspecial/ShowDeclarationsOfOperation.g.out
@@ -1,0 +1,5 @@
+gap> ShowDeclarationsOfOperation(Position);
+Available declarations for operation <Operation "Position">:
+  1: GAPROOT/lib/list.gd:LINE with 2 arguments, and filters [ IsList, IsObject ]
+  2: GAPROOT/lib/list.gd:LINE with 3 arguments, and filters [ IsList, IsObject, IsInt ]
+gap> QUIT;


### PR DESCRIPTION
Before:

    gap> ShowDeclarationsOfOperation(Position);
    Available declarations for operation <Operation "Position">:
      1: GAPROOT/lib/list.gd:679 with 2 arguments, and filters [ IsList,  ]
      2: GAPROOT/lib/list.gd:680 with 3 arguments, and filters [ IsList, , IsInt ]

After:

    gap> ShowDeclarationsOfOperation(Position);
    Available declarations for operation <Operation "Position">:
      1: GAPROOT/lib/list.gd:679 with 2 arguments, and filters [ IsList, IsObject ]
      2: GAPROOT/lib/list.gd:680 with 3 arguments, and filters [ IsList, IsObject, IsInt ]


<s>This is still missing a test case, but I didn't want to forget about it, so I decided to just submit it as-is; I'll add a test case to this PR once I have time (if anybody wants to beat me to it, feel free and push into this PR :-)</s>

UPDATE: now has tests and also another minor fix:

Before:

    gap> TypeObj(IsObject);
    <Type: (FunctionsFamily, [ IsFunction, HasNAME_FUNC, IsOperation, ... ]), data: fail,>

After:

    gap> TypeObj(IsObject);
    <Type: (FunctionsFamily, [ IsFunction, HasNAME_FUNC, IsOperation, ... ]), data: fail>