### PR TITLE
Disabled `NaturalHomomorphism` for `FactorGroup`, as it has side effects.

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -2848,8 +2848,10 @@ DeclareOperation( "CosetTableNormalClosure", [ IsGroup, IsGroup ] );
 ##
 ##  <Description>
 ##  returns the image of the <C>NaturalHomomorphismByNormalSubgroup(<A>G</A>,<A>N</A>)</C>.
-##  The homomorphism will be returned by calling the function
-##  <C>NaturalHomomorphism</C> on the result.
+##  This function is provided for compatibility with older code, but if a
+##  connection between group and factor is desired, users need to start by
+##  obtaining the <C>NaturalHomomorphismByNormalSubgroup</C> in the first
+##   place.
 ##  The <C>NC</C> version does not test whether <A>N</A> is normal in <A>G</A>.
 ##  <Example><![CDATA[
 ##  gap> g:=Group((1,2,3,4),(1,2));;n:=Subgroup(g,[(1,2)(3,4),(1,3)(2,4)]);;
@@ -2857,8 +2859,7 @@ DeclareOperation( "CosetTableNormalClosure", [ IsGroup, IsGroup ] );
 ##  [ (1,2,3,4), (1,2) ] -> [ f1*f2, f1 ]
 ##  gap> Size(ImagesSource(hom));
 ##  6
-##  gap> FactorGroup(g,n);;
-##  gap> StructureDescription(last);
+##  gap> StructureDescription(Image(hom,g));
 ##  "S3"
 ##  ]]></Example>
 ##  </Description>
@@ -2877,8 +2878,9 @@ DeclareOperation( "FactorGroupNC", [ IsGroup, IsGroup ] );
 ##  <Oper Name="NaturalHomomorphism" Arg='F'/>
 ##
 ##  <Description>
-##  For a group <A>F</A> obtained via <C>FactorGroup</C>, this operation
-##  returns the natural homomorphism onto <A>F</A>
+##  This function is obsolete now and will give an error message. Users
+##  should use <C>NaturalHomomorphismByNormalSubgroup</C> in the first place to
+##  get the homomorphism and then get the factor group as the image.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2669,6 +2669,7 @@ function( G, N )
 local hom,F,new;
   hom:=NaturalHomomorphismByNormalSubgroupNC( G, N );
   F:=ImagesSource(hom);
+  #TODO: Remove the !.nathom component
   if not IsBound(F!.nathom) then
     F!.nathom:=hom;
   else
@@ -2681,16 +2682,6 @@ local hom,F,new;
   fi;
   return F;
 end );
-
-InstallMethod( NaturalHomomorphism, "for a group with natural homomorphism stored",
-    [ IsGroup ],
-function(G)
-  if IsBound(G!.nathom) then
-    return G!.nathom;
-  else
-    Error("no natural homomorphism stored");
-  fi;
-end);
 
 InstallOtherMethod( \/,
     "generic method for two groups",

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -152,6 +152,7 @@ InstallMethod( NormalComplementNC,
           Gf,   # = G/T = N x B/B'
           Nf,   # = NT/T
           Bf,   # abelian complement to Nf in Gf ( = B/B')
+          nat,
           BfF;  # Direct factors of Bf
 
     # if <N> is trivial then the only complement is <G>
@@ -164,13 +165,15 @@ InstallMethod( NormalComplementNC,
 
     # if G/N is abelian
     elif HasAbelianFactorGroup(G, N) then
-      F := FactorGroupNC(G, N);
+      nat:=NaturalHomomorphismByNormalSubgroupNC(G,N);
+      #F := FactorGroupNC(G, N);
+      F:=Image(nat,G);
       b := [];
       l := [];
       i:=0;
       for gF in IndependentGeneratorsOfAbelianGroup(F) do
         i := i+1;
-        g := PreImagesRepresentative(NaturalHomomorphism(F), gF);
+        g := PreImagesRepresentative(nat, gF);
         R := RightCoset(N, g);
         # DirectFactorsOfGroup already computed Center and RationalClasses
         # when calling NormalComplement
@@ -224,15 +227,18 @@ InstallMethod( NormalComplementNC,
     else
       T := CommutatorSubgroup(Centralizer(G, N), G);
       if not IsTrivial(T) and IsTrivialNormalIntersection(G, T, N) then
-        Gf := FactorGroupNC(G, T);
-        Nf := Image(NaturalHomomorphism(Gf), N);
+        #Gf := FactorGroupNC(G, T);
+        #Nf := Image(NaturalHomomorphism(Gf), N);
+        nat:=NaturalHomomorphismByNormalSubgroupNC(G, T);
+        Gf:=Image(nat,G);
+        Nf:=Image(nat,N);
         # not quite sure if this check is needed
         if HasAbelianFactorGroup(Gf, Nf) then
           Bf := NormalComplementNC(Gf, Nf);
           if Bf = fail then
             return fail;
           else
-            B := PreImage(NaturalHomomorphism(Gf), Bf);
+            B := PreImage(nat, Bf);
             return B;
           fi;
         else

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -2023,7 +2023,8 @@ local  i, j, U, gens,o,v,a,sel,mintry,orb,orp,isok;
 
   # store orbit data
   orb:=Set(Orbits(G,MovedPoints(G)),Set);
-  orp:=Filtered([1..Length(orb)],x->IsPrimitive(Action(G,orb[x])));
+  # longer primitive orbits
+  orp:=Filtered([1..Length(orb)],x->Length(orb[x])>100 and IsPrimitive(Action(G,orb[x])));
 
   isok:=function(U)
     if Length(MovedPoints(G))>Length(MovedPoints(U)) or

--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2861,7 +2861,7 @@ local m;
   fi;
     
   if Size(RadicalGroup(G))>1 and CanComputeFittingFree(G) 
-    and (not IsSolvableGroup(G))
+    and not (IsSolvableGroup(G) and Size(G)<=2000)
     and (AbelianRank(G)>2 or Length(SmallGeneratingSet(G))>2 
       # the solvable radical method got better, so force if the radical of
       # the group is a good part

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -1029,6 +1029,21 @@ end );
 BindGlobal("R_N", fail);
 BindGlobal("R_X", fail);
 
+# Moved to obsolete in Nov. 2021 for 4.12
+InstallMethod( NaturalHomomorphism, "for a group with natural homomorphism stored",
+    [ IsGroup ],
+function(G)
+  Info(InfoWarning,0,"The use of `NaturalHomomorphism` for a `FactorGroup`\n",
+    "has been deprecated, as it caused side-effects.\n",
+    "Proceed at risk!");
+
+  if IsBound(G!.nathom) then
+    return G!.nathom;
+  else
+    Error("no natural homomorphism stored");
+  fi;
+end);
+
 
 
 #############################################################################


### PR DESCRIPTION
(Moved into obsoletes).
This resolves #4656

Also included the (trivial) fix for #4698

## Text for release notes

The use of `FactorGroup` succeeded by `NaturalHomomorphism` has been made obsolete, as the implementation relied on side-effects.