### PR TITLE
CI: cancel redundant PR builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,12 @@ on:
     # Every day at 2:30 AM UTC
     - cron: '30 2 * * *'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 env:
   CFLAGS: "--coverage -O2 -g"
   CXXFLAGS: "--coverage -O2 -g"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ on:
     # Every day at 3:33 AM UTC
     - cron:  '33 3 * * *'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 env:
   NO_COVERAGE: 1
   BOOTSTRAP_MINIMAL: yes


### PR DESCRIPTION
When updating a PR, automatically cancel any previously running instances
of the build.

Borrowed from https://github.com/JuliaCI/rootfs-images/blob/192cf1edb49f128f3eb9d4ffda2f6675a8d0a05d/.github/workflows/linux.yml#L14-L18

See also https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

I think we'll need to merge it in order to test it...