### PR TITLE
Refactor some kernel code related to `UserHasQuit`, `UserHasQUIT` and run-eval loops

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -222,11 +222,7 @@ InstallGlobalFunction(RunTests, function(arg)
     res := "";
     fres := OutputTextString(res, false);
     t := Runtime();
-    if localbag <> false then
-        READ_STREAM_LOOP_WITH_CONTEXT(s, fres, localbag);
-    else
-        READ_STREAM_LOOP(s, fres);
-    fi;
+    READ_STREAM_LOOP(s, fres, localbag);
     t := Runtime() - t;
     CloseStream(fres);
     CloseStream(s);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -166,8 +166,10 @@ static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call, St
         }
     }
     if (STATE(UserHasQuit) || STATE(UserHasQUIT)) {
-        // the function must have called READ() and the user quit from
-        // a break loop inside it
+        // the function must have called READ() and the user quit from a break loop
+        // inside it; or a file containing a `QUIT` statement was read at the top
+        // execution level (e.g. in init.g, before the primary REPL starts) after
+        // which the function was called, and now we are returning from that
         GAP_THROW();
     }
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -316,7 +316,6 @@ static Obj FuncSHELL(Obj self,
         }
         /* handle quit command or <end-of-file>                            */
         else if (status & (STATUS_EOF | STATUS_QUIT)) {
-            STATE(UserHasQuit) = TRUE;
             break;
         }
 
@@ -371,7 +370,6 @@ static Obj FuncSHELL(Obj self,
         return Fail;
     }
 
-    STATE(UserHasQuit) = FALSE;
     //
     // handle the remaining status codes; note that `STATUS_QQUIT` is handled
     // above, as part of the `UserHasQUIT` handling

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -72,15 +72,30 @@ typedef struct GAPState {
     // for use by GAP_TRY / GAP_CATCH and related code
     int TryCatchDepth;
 
-    /* From gap.c */
-    Obj  ThrownObject;
-    UInt UserHasQuit;
-    UInt UserHasQUIT;
-    Obj  ErrorLVars;        // ErrorLVars as modified by DownEnv / UpEnv
-    Int  ErrorLLevel;       // record where on the stack ErrorLVars is relative to the top
-    void (*JumpToCatchCallback)(void); // This callback is called in FuncJUMP_TO_CATCH,
-                                   // this is not used by GAP itself but by programs
-                                   // that use GAP as a library to handle errors
+    // Set by `FuncJUMP_TO_CATCH` to the value of its second argument, and
+    // and then later extracted by `CALL_WITH_CATCH`. Not currently used by
+    // the GAP kernel itself, as far as I can tell.
+    Obj ThrownObject;
+
+    // Set to TRUE when a read-eval-loop encounters a `quit` statement.
+    BOOL UserHasQuit;
+
+    // Set to TRUE when a read-eval-loop encounters a `QUIT` statement.
+    BOOL UserHasQUIT;
+
+    // Set by the primary read-eval loop in `FuncSHELL`, based on the value of
+    // `ErrorLLevel`. Also, `ReadEvalCommand` saves and restores this value
+    // before executing code.
+    Obj ErrorLVars;
+
+    // Records where on the stack `ErrorLVars` is relative to the top; this is
+    // modified by `FuncDownEnv` / `FuncUpEnv`, and ultimately used and
+    // controlled by the primary read-eval loop in `FuncSHELL`.
+    Int ErrorLLevel;
+
+    // This callback is called in FuncJUMP_TO_CATCH, this is not used by GAP
+    // itself but by programs that use GAP as a library to handle errors
+    void (*JumpToCatchCallback)(void);
 
     /* From info.c */
     Int ShowUsedInfoClassesActive;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -403,8 +403,10 @@ void IntrFuncCallEnd(IntrState * intr, UInt funccall, UInt options, UInt nr)
       else                { val = CALL_XARGS( func, args ); }
 
       if (STATE(UserHasQuit) || STATE(UserHasQUIT)) {
-        /* the procedure must have called READ() and the user quit
-           from a break loop inside it */
+        // the procedure must have called READ() and the user quit from a break loop
+        // inside it; or a file containing a `QUIT` statement was read at the top
+        // execution level (e.g. in init.g, before the primary REPL starts) after
+        // which the procedure was called, and now we are returning from that
         GAP_THROW();
       }
     }

--- a/src/read.c
+++ b/src/read.c
@@ -2749,7 +2749,7 @@ Obj Call0ArgsInNewReader(Obj f)
     volatile Obj  result = 0;
 
     // initialize everything
-    STATE(UserHasQuit) = 0;
+    STATE(UserHasQuit) = FALSE;
     oldLvars = SWITCH_TO_BOTTOM_LVARS();
 
     GAP_TRY
@@ -2782,7 +2782,7 @@ Obj Call1ArgsInNewReader(Obj f, Obj a)
     volatile Obj  result = 0;
 
     // initialize everything
-    STATE(UserHasQuit) = 0;
+    STATE(UserHasQuit) = FALSE;
     oldLvars = SWITCH_TO_BOTTOM_LVARS();
 
     GAP_TRY

--- a/src/streams.c
+++ b/src/streams.c
@@ -275,12 +275,12 @@ static void READ_INNER(TypInputFile * input)
     if (STATE(UserHasQuit))
       {
         Pr("Warning: Entering READ with UserHasQuit set, this should never happen, resetting",0,0);
-        STATE(UserHasQuit) = 0;
+        STATE(UserHasQuit) = FALSE;
       }
     if (STATE(UserHasQUIT))
       {
         Pr("Warning: Entering READ with UserHasQUIT set, this should never happen, resetting",0,0);
-        STATE(UserHasQUIT) = 0;
+        STATE(UserHasQUIT) = FALSE;
       }
     AssGVarWithoutReadOnlyCheck( LastReadValueGVar, 0);
 
@@ -300,11 +300,11 @@ static void READ_INNER(TypInputFile * input)
         else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
           break;
         else if (status == STATUS_QUIT) {
-          STATE(UserHasQuit) = 1;
+          STATE(UserHasQuit) = TRUE;
           break;
         }
         else if (status == STATUS_QQUIT) {
-          STATE(UserHasQUIT) = 1;
+          STATE(UserHasQUIT) = TRUE;
           break;
         }
         if (evalResult)
@@ -886,7 +886,7 @@ static Obj FuncREAD_NORECOVERY(Obj self, Obj inputObj)
         ErrorQuit("Panic: READ_NORECOVERY cannot close input", 0, 0);
     }
     if (STATE(UserHasQuit)) {
-        STATE(UserHasQuit) = 0;    // stop recovery here
+        STATE(UserHasQuit) = FALSE;    // stop recovery here
         return Fail;
     }
     return True;

--- a/src/streams.c
+++ b/src/streams.c
@@ -900,15 +900,20 @@ static Obj FuncREAD_NORECOVERY(Obj self, Obj inputObj)
 **  Read data from <instream> in a read-eval-view loop and write all output
 **  to <outstream>.
 */
-static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT(Obj self,
-                                             Obj instream,
-                                             Obj outstream,
-                                             Obj context)
+static Obj FuncREAD_STREAM_LOOP(Obj self,
+                                Obj instream,
+                                Obj outstream,
+                                Obj context)
 {
     Int res;
 
     RequireInputStream(SELF_NAME, instream);
     RequireOutputStream(SELF_NAME, outstream);
+    if (context == False)
+        context = 0;
+    else if (!IS_LVARS_OR_HVARS(context))
+        RequireArgument(SELF_NAME, context, "must be a local variables bag "
+                                            "or the value 'false'");
 
     TypInputFile input = { 0 };
     if (!OpenInputStream(&input, instream, FALSE)) {
@@ -933,11 +938,6 @@ static Obj FuncREAD_STREAM_LOOP_WITH_CONTEXT(Obj self,
     GAP_ASSERT(res);
 
     return res ? True : False;
-}
-
-static Obj FuncREAD_STREAM_LOOP(Obj self, Obj stream, Obj catcherrstdout)
-{
-    return FuncREAD_STREAM_LOOP_WITH_CONTEXT(self, stream, catcherrstdout, 0);
 }
 
 
@@ -1749,9 +1749,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_4ARGS(
         READ_ALL_COMMANDS, instream, echo, capture, resultCallback),
     GVAR_FUNC_2ARGS(READ_COMMAND_REAL, stream, echo),
-    GVAR_FUNC_2ARGS(READ_STREAM_LOOP, stream, catchstderrout),
-    GVAR_FUNC_3ARGS(
-        READ_STREAM_LOOP_WITH_CONTEXT, stream, catchstderrout, context),
+    GVAR_FUNC_3ARGS(READ_STREAM_LOOP, stream, catchstderrout, context),
     GVAR_FUNC_1ARGS(READ_AS_FUNC, input),
     GVAR_FUNC_1ARGS(READ_GAP_ROOT, filename),
     GVAR_FUNC_3ARGS(CALL_WITH_STREAM, stream, func, args),

--- a/src/streams.c
+++ b/src/streams.c
@@ -847,7 +847,8 @@ static Obj FuncREAD_NORECOVERY(Obj self, Obj inputObj)
 *F  FuncREAD_STREAM_LOOP( <self>, <instream>, <outstream> ) . . read a stream
 **
 **  Read data from <instream> in a read-eval-view loop and write all output
-**  to <outstream>.
+**  to <outstream>. This is used by the GAP function `RunTests` and hence
+**  indirectly for implementing `Test` and `TestDirectory`,
 */
 static Obj FuncREAD_STREAM_LOOP(Obj self,
                                 Obj instream,
@@ -880,7 +881,6 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
     LockCurrentOutput(TRUE);
 
     // get the starting time
-    UInt oldtime = SyTime();
     UInt oldPrintObjState = SetPrintObjState(0);
 
     // now do the reading
@@ -888,6 +888,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
         UInt type;
         Obj  evalResult;
         UInt dualSemicolon;
+        UInt oldtime = SyTime();
 
         // read and evaluate the command
         SetPrintObjState(0);
@@ -897,12 +898,8 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
         UpdateTime(oldtime);
 
         // handle ordinary command
-        if (type == 0 && evalResult != 0) {
-
-            // remember the value in 'last' and the time in 'time'
+        if (type == STATUS_END && evalResult != 0) {
             UpdateLast(evalResult);
-
-            // print the result
             if (!dualSemicolon) {
                 ViewObjHandler(evalResult);
             }
@@ -917,7 +914,6 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
         else if (type & (STATUS_QUIT | STATUS_QQUIT | STATUS_EOF)) {
             break;
         }
-        // FIXME: what about STATUS_ERROR
     }
 
     SetPrintObjState(oldPrintObjState);

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -124,12 +124,12 @@ gap> READ_NORECOVERY(InputTextString(""));
 true
 
 #
-gap> READ_STREAM_LOOP_WITH_CONTEXT(fail, fail, fail);
-Error, READ_STREAM_LOOP_WITH_CONTEXT: <instream> must be an input stream (not \
-the value 'fail')
-gap> READ_STREAM_LOOP_WITH_CONTEXT(InputTextString(""), fail, fail);
-Error, READ_STREAM_LOOP_WITH_CONTEXT: <outstream> must be an output stream (no\
-t the value 'fail')
+gap> READ_STREAM_LOOP(fail, fail, fail);
+Error, READ_STREAM_LOOP: <instream> must be an input stream (not the value 'fa\
+il')
+gap> READ_STREAM_LOOP(InputTextString(""), fail, fail);
+Error, READ_STREAM_LOOP: <outstream> must be an output stream (not the value '\
+fail')
 
 #
 gap> READ_AS_FUNC(fail);


### PR DESCRIPTION
I'd like to eventually tackle #4695 but first wanted to understand the code better, and cleaning it up for that seemed useful.