### PR TITLE
buildsys: add ABI_CFLAGS back into {C,CXX,LD}FLAGS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -200,7 +200,7 @@ GAP_PKG_CPPFLAGS += $(CPPFLAGS)
 ########################################################################
 # C compiler flags
 ########################################################################
-GAP_CFLAGS =
+GAP_CFLAGS = $(ABI_CFLAGS)
 
 ifeq ($(HPCGAP),yes)
 GAP_CFLAGS += $(PTHREAD_CFLAGS)
@@ -213,7 +213,7 @@ GAP_CFLAGS += $(CFLAGS)
 ########################################################################
 # C++ compiler flags
 ########################################################################
-GAP_CXXFLAGS =
+GAP_CXXFLAGS = $(ABI_CFLAGS)
 
 ifeq ($(HPCGAP),yes)
 GAP_CXXFLAGS += $(PTHREAD_CFLAGS)
@@ -226,7 +226,7 @@ GAP_CXXFLAGS += $(CXXFLAGS)
 ########################################################################
 # Linker flags
 ########################################################################
-GAP_LDFLAGS =
+GAP_LDFLAGS = $(ABI_CFLAGS)
 
 # Add flags for dependencies
 GAP_LDFLAGS += $(GMP_LDFLAGS)


### PR DESCRIPTION
We retain them in CC and CXX, so now when building 32bit GAP on a 64 bit machine, we may  pass -m32 twice to the compiler; but that doesn't hurt.

But on the upside, this way packages which obtain compiler flags from flags.


This is meant to help packages like `float` (which currently fails to build in our 32bit CI tests), but also should simplify `bin/BuildPackages.sh`, which currently pushes the `-m32` bit flag via CFLAGS/CXXFLAGS/LDFLAGS -- with this PR, this shouldn't be necessary anymore for most (all?) packages

This PR is still work in progress, I did not yet have time to properly test and debug it, but I wanted to get it out there so I can reference it.