### PR TITLE
Allow manually running workflows with tmate enabled

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,11 @@ name: CI
 # Trigger the workflow on push or pull request
 on:
   workflow_dispatch:
+    inputs:
+      # see https://github.com/marketplace/actions/debugging-with-tmate
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'
+        type: boolean
   pull_request:
   push:
   schedule:
@@ -217,6 +222,9 @@ jobs:
         run: ${{ matrix.extra }} dev/ci-build-gap.sh
       - name: "Download packages"
         run: ${{ matrix.extra }} dev/ci-download-pkgs.sh
+      - name: "Setup tmate session"
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
       - name: "Run tests"
         run: ${{ matrix.extra }} dev/ci.sh
       - name: "Upload pdf manuals"


### PR DESCRIPTION
This allows to SSH into such workflow session using tmate (see <https://tmate.io>) which can be very handy for debugging.

I've placed it after GAP is built but just before tests are invoked. This is in my experience usually the most useful spot. From that point, one can perform individual tests or just call `dev/ci.sh` to run the usual test suite.

Motivation right now is to debug those pesky problems with 32bit float which I cannot quite reproduce locally (well I can repro the build failure and have fixes for that; but with the fixes we still see a segfault, and that's what I can't reproduce).

One concern with this PR is security: I think right now anyone could access such a tmate session (they just need to go to the build log and extract the session URL from there). I don't see what bad things one can do with this (esp. since not just anyone can *trigger* such a workflow manually). But if we are truly concerned about this, we could change it to "Use registered public SSH key(s)" as described on <https://mxschmitt.github.io/action-tmate/>. However, I am not completely sure whose public key is used... presumably that of the person who triggered the workflow? That should be fine (only drawback is that this way we can't have multiple people debug with the same workflow... but in practice I think this will be rare?).

Another concern is that this will right now trigger a tmate session on *each* of the currently 15 jobs in the matrix; each of those would then hog a CI builder until the timeout or the job is cancelled. Perhaps we can add another argument to the manual trigger which can be used to narrow down which jobs actually are run; e.g. perhaps this could be a freeform field taking the "name" of the job (such as `testpackages testinstall-loadall - ABI=32 NO_COVERAGE=1 - ubuntu-18.04`) resp. a pattern that is matched against the job; and then we only start tmate on matching jobs (or in fact, only run matching jobs -- that might actually be handy separately from tmate...)