### PR TITLE
Fix return marker

### DIFF
--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -126,7 +126,7 @@ static Obj VoidReturnMarker;
 
 static void PushFunctionVoidReturn(IntrState * intr)
 {
-    PushPlist(intr->StackObj, (Obj)&VoidReturnMarker);
+    PushPlist(intr->StackObj, VoidReturnMarker);
 }
 
 static void PushVoidObj(IntrState * intr)
@@ -138,7 +138,7 @@ static Obj PopObj(IntrState * intr)
 {
     Obj val = PopPlist(intr->StackObj);
 
-    if (val == (Obj)&VoidReturnMarker) {
+    if (val == VoidReturnMarker) {
         ErrorQuit("Function call: <func> must return a value", 0, 0);
     }
 
@@ -152,7 +152,7 @@ static Obj PopVoidObj(IntrState * intr)
     Obj val = PopPlist(intr->StackObj);
 
     // Treat a function which returned no value the same as 'void'
-    if (val == (Obj)&VoidReturnMarker) {
+    if (val == VoidReturnMarker) {
         val = 0;
     }
 
@@ -4163,7 +4163,13 @@ static Int InitKernel (
     /* Ensure that the value in '~' does not get garbage collected         */
     InitGlobalBag( &STATE(Tilde), "STATE(Tilde)" );
 
+    InitGlobalBag( &VoidReturnMarker, "VoidReturnMarker");
+
+    // Create a bag which is not used anywhere else
+    VoidReturnMarker = NEW_STRING(0);
+
     InitFopyGVar( "CONVERT_FLOAT_LITERAL_EAGER", &CONVERT_FLOAT_LITERAL_EAGER);
+
 
     /* The work of handling Options is also delegated*/
     ImportFuncFromLibrary( "PushOptions", &PushOptions );

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -298,6 +298,7 @@ void SaveSubObj( Obj subobj )
            (Bag *)PTR_BAG(subobj) < MptrEndBags)
     {
       Pr("#W bad bag id %d found, 0 saved\n", (Int)subobj, 0);
+      GAP_ASSERT(0);
       SaveUInt(0);
     }
   else


### PR DESCRIPTION
This is a subtle issue -- we were putting pointers to a C object into plists, which is fine until we do SaveWorkspace. This was (I think) breaking 32-bit tests (the bug was shown when float was loaded, but I think it's not float's fault).

The reason this was so hard to track down is (also, I think) usually bags with this object in them are GCed before we SaveWorkspace, but if things are lined up just right the bag can end up staying alive due to "false sharing".

I also add a GAP_ASSERT, as I hadn't noticed this failure was occurring. I am tempted to suggest we make SaveWorkspace always fail if the test for "bad bags" fails, but I thought to start I'd put in a GAP_ASSERT and see if we notice it triggering.