### PR TITLE
kernel: improve position tracking after ReadEvalCommand

### DIFF
--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -75,11 +75,36 @@ gap> CLOSE_OUTPUT_LOG_TO();
 true
 
 #
+# READ_COMMAND_REAL
+#
 gap> READ_COMMAND_REAL(true, fail);
 Error, READ_COMMAND_REAL: <stream> must be an input stream (not the value 'tru\
 e')
-gap> READ_COMMAND_REAL(InputTextString("1+1;"), false);
+
+#
+gap> stream:=InputTextString("1+1;");
+InputTextString(0,4)
+gap> READ_COMMAND_REAL(stream, false); stream;
 [ true, 2 ]
+InputTextString(4,4)
+gap> READ_COMMAND_REAL(stream, false); stream;
+[ false ]
+InputTextString(4,4)
+
+#
+gap> stream := InputTextString("1+1;2+2;");
+InputTextString(0,8)
+gap> READ_COMMAND_REAL(stream, false); stream;
+[ true, 2 ]
+InputTextString(4,8)
+gap> READ_COMMAND_REAL(stream, false); stream;
+[ true, 4 ]
+InputTextString(8,8)
+gap> READ_COMMAND_REAL(stream, false); stream;
+[ false ]
+InputTextString(8,8)
+
+#
 gap> READ_COMMAND_REAL(InputTextString("/1;"), false); # intentional syntax error
 Syntax error: expression expected in stream:1
 /1;


### PR DESCRIPTION
When evaluating inputs, ReadEvalCommand and the GAP scanner greedily read full
lines of input, even if only a part of the line ends up being evaluated; e.g.
because there are multiple commands on a line.

Unfortunately, this rendered the (undocumented) command `READ_COMMAND_REAL`
far less useful: when invoked on a generic input stream, it evaluates exactly
one command; but afterwards the end of that command can not be inferred from
the position of the input stream, as it always reads full lines.

This patch changes things so that when closing an input *stream*, backed by a
GAP stream object, we try adjust its seek position to where the actual command
ended.

This means that now one can repeatedly call `READ_COMMAND_REAL` on a string
stream to iteratively evaluated the statements in the underlying string.
Combined with `CALL_WITH_STREAM` this mostly allows to reimplement
`READ_ALL_COMMANDS` in GAP code, but with far more flexibility. This is
potentially useful for e.g. the Jupyter interface.

(The one thing that is not yet available is detection of dual semicolons,
which `READ_ALL_COMMANDS` supports but `READ_COMMAND_REAL` does not. But this
could be tacked on to `READ_ALL_COMMANDS`, or we could implement a new
variant of this command providing that information.)
