### PR TITLE
fixed `ListOp` for length zero `IsVectorObj`

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -567,10 +567,12 @@ InstallMethod( ListOp,
   local result, i, len;
   len := Length(vec);
   result := [];
-  result[len] := vec[len];
-  for i in [ 1 .. len - 1 ] do
-    result[i] := vec[i];
-  od;
+  if 0 < len then
+    result[len] := vec[len];
+    for i in [ 1 .. len - 1 ] do
+      result[i] := vec[i];
+    od;
+  fi;
   return result;
 end );
 #T delegation question -- use {}? or Unpack?
@@ -582,10 +584,12 @@ InstallMethod( ListOp,
   local result, i, len;
   len := Length(vec);
   result := [];
-  result[len] := func(vec[len]);
-  for i in [ 1 .. len - 1 ] do
-    result[i] := func(vec[i]);
-  od;
+  if 0 < len then
+    result[len] := func(vec[len]);
+    for i in [ 1 .. len - 1 ] do
+      result[i] := func(vec[i]);
+    od;
+  fi;
   return result;
 end );
 

--- a/tst/testinstall/MatrixObj/ListOp.tst
+++ b/tst/testinstall/MatrixObj/ListOp.tst
@@ -11,4 +11,16 @@ gap> v5 := Vector(GF(5), ll*One(GF(5)));
 [ Z(5)^0, Z(5), Z(5)^3, Z(5)^2, 0*Z(5), Z(5)^0 ]
 gap> List( v5, x->x^2 );
 [ Z(5)^0, Z(5)^2, Z(5)^2, Z(5)^0, 0*Z(5), Z(5)^0 ]
+gap> v:= [ Z(2) ];;  ConvertToVectorRep( v, 4 );;  Unbind( v[1] );  v;
+< mutable compressed vector length 0 over GF(4) >
+gap> List( v );
+[  ]
+gap> List( v, DegreeFFE );
+[  ]
+gap> ConvertToVectorRep( v, 2 );;  v;
+<a GF2 vector of length 0>
+gap> List( v );
+[  ]
+gap> List( v, DegreeFFE );
+[  ]
 gap> STOP_TEST( "ListOp.tst", 1);


### PR DESCRIPTION
Such vectors can arise for example as coefficient lists of polynomials,
for example of `2 * One( Indeterminate( GF(2) ) )`.

There are still issues with length zero vectors.
If one wants to convert  a length zero vector in `IsGF2VectorRep` to `Is8BitVectorRep` then one runs into an error.
```
gap> v:= [ Z(2) ];;  ConvertToVectorRep( v, 2 );;  Unbind( v[1] );  v;
<a GF2 vector of length 0>
gap> ConvertToVectorRep( v, 4 );
Error, List Element: <list>[1] must have an assigned value in
[...]
```
(The conversion in the other direction works.)

I am not sure whether we should fix this, and how.