### PR TITLE
Fix `LatticeSubgroup` sometimes returning wrong results for matrix groups

### DIFF
--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -520,7 +520,7 @@ InstallMethod(FactorCosetAction,"by right transversal operation, Niceo",
 function(G,U)
 local hom;
   hom:=RestrictedNiceMonomorphism(NiceMonomorphism(G),G);
-  return hom*DoFactorCosetAction(Image(hom,G),Image(hom,U));
+  return hom*DoFactorCosetAction(NiceObject(G),Image(hom,U));
 end);
 
 InstallOtherMethod(FactorCosetAction,
@@ -529,7 +529,7 @@ InstallOtherMethod(FactorCosetAction,
 function(G,U,N)
 local hom;
   hom:=RestrictedNiceMonomorphism(NiceMonomorphism(G),G);
-  return hom*DoFactorCosetAction(Image(hom,G),Image(hom,U),Image(hom,N));
+  return hom*DoFactorCosetAction(NiceObject(G),Image(hom,U),Image(hom,N));
 end);
 
 # action on lists of subgroups
@@ -1630,7 +1630,7 @@ InstallMethod(FindActionKernel,"Niceo",IsIdenticalObj,
 function(G,N)
 local hom,hom2;
   hom:=NiceMonomorphism(G);
-  hom2:=GenericFindActionKernel(Image(hom,G),Image(hom,N));
+  hom2:=GenericFindActionKernel(NiceObject(G),Image(hom,N));
   if hom2<>fail then
     return hom*hom2;
   else

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1257,7 +1257,7 @@ InstallMethod( LatticeSubgroups,
     local hom, lattice, classes;
 
     hom:= NiceMonomorphism( G );
-    lattice:= LatticeSubgroups( Image( hom ) );
+    lattice:= LatticeSubgroups( NiceObject( G ) );
     classes:= List( ConjugacyClassesSubgroups( lattice ),
                     C -> ConjugacyClassSubgroups( G,
                              PreImage( hom, Representative( C ) ) ) );

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -551,7 +551,7 @@ local map;
     if IsIdenticalObj(Source(map),G) then
       return map;
     fi;
-    return GeneralRestrictedMapping(map,G,Image(map,G));
+    return GeneralRestrictedMapping(map,G,NiceObject(G));
   else
     if not HasIsFinite(G) then
       Info(InfoWarning,1,

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -452,7 +452,7 @@ InstallMethod(HallSubgroupOp,"via niceomorphism",true,
 function(g,l)
 local mon,h;
    mon:=NiceMonomorphism(g);
-   h:=HallSubgroup(ImagesSet(mon,g),l);
+   h:=HallSubgroup(NiceObject(g),l);
    if h = fail then
        return fail;
    elif IsList(h) then
@@ -580,10 +580,8 @@ local mon,iso;
   mon:=NiceMonomorphism(g);
   if not IsIdenticalObj(Source(mon),g) then
     mon:=RestrictedNiceMonomorphism(mon,g);
-    iso:=IsomorphismPermGroup(Image(mon,g));
-  else
-    iso:=IsomorphismPermGroup(NiceObject(g));
   fi;
+  iso:=IsomorphismPermGroup(NiceObject(g));
   if iso=fail then
     return fail;
   else

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -251,7 +251,9 @@ function( G )
 
     # if not rational, use the nice monomorphism into a rational matrix group
     if not IsRationalMatrixGroup( G ) then
-        return IsFinite( Image( NiceMonomorphism( G ) ) );
+        # the following does not use NiceObject(G) as the only method for
+        # that currently requires IsHandledByNiceMonomorphism
+        return IsFinite( Image( NiceMonomorphism( G ), G ) );
     fi;
 
     # if not integer, choose basis in which it is integer

--- a/tst/testbugfix/2021-12-11-LatticeSubgroups.tst
+++ b/tst/testbugfix/2021-12-11-LatticeSubgroups.tst
@@ -1,0 +1,4 @@
+# see https://github.com/gap-system/gap/issues/4717
+gap> g := SL(2,3);;
+gap> ForAll(ConjugacyClassesSubgroups(g),x->IsSubgroup(g,Representative(x)));
+true


### PR DESCRIPTION
... if used on a group which is handled by a `NiceMonomorphism`, which normally includes all matrix groups. Also fix an `IsFinite` method for non-rational cyclotomic matrix groups.

In both cases, the code wrongly assumed that the `Image(NiceMonomorphism(g))` equals `Image(NiceMonomorphism(g),g)`. The solution is to use `NiceObject(g)` which is also cached, as it is an attribute.

Also change a few more places to use `NiceObject(g)`; while they were correct, using `NiceObject` is potentially more efficient.

Fixes #4717