### PR TITLE
kernel: minor tweaks to read-eval code

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -301,14 +301,14 @@ static Obj FuncSHELL(Obj self,
         }
 
         /* handle return-value or return-void command                      */
-        else if (status & STATUS_RETURN_VAL) {
+        else if (status == STATUS_RETURN && evalResult != 0) {
             if (canReturnObj == True)
                 break;
             Pr("'return <object>' cannot be used in this read-eval-print "
                "loop\n",
                0, 0);
         }
-        else if (status & STATUS_RETURN_VOID) {
+        else if (status == STATUS_RETURN && evalResult == 0) {
             if (canReturnVoid == True)
                 break;
             Pr("'return' cannot be used in this read-eval-print loop\n", 0,
@@ -377,11 +377,8 @@ static Obj FuncSHELL(Obj self,
     if (status & (STATUS_EOF | STATUS_QUIT)) {
         return Fail;
     }
-    if (status & STATUS_RETURN_VOID) {
-        return NewEmptyPlist();
-    }
-    if (status & STATUS_RETURN_VAL) {
-        return NewPlistFromArgs(evalResult);
+    if (status == STATUS_RETURN) {
+        return evalResult ? NewPlistFromArgs(evalResult) : NewEmptyPlist();
     }
 
     Panic("SHELL: unhandled status %d, this code should never be reached",

--- a/src/gap.c
+++ b/src/gap.c
@@ -277,7 +277,7 @@ static Obj FuncSHELL(Obj self,
         STATE(ErrorLVars) = errorLVars;
 
         // read and evaluate one command (statement or expression)
-        UInt dualSemicolon;
+        BOOL dualSemicolon;
         status =
             ReadEvalCommand(errorLVars, &input, &evalResult, &dualSemicolon);
 

--- a/src/gap.h
+++ b/src/gap.h
@@ -56,15 +56,14 @@ void ViewObjHandler(Obj obj);
 typedef UInt ExecStatus;
 
 enum {
-    STATUS_END         =  0,    // ran off the end of the code
-    STATUS_RETURN_VAL  =  1,    // value returned
-    STATUS_RETURN_VOID =  2,    // void returned
-    STATUS_BREAK       =  4,    // 'break' statement
-    STATUS_QUIT        =  8,    // quit command
-    STATUS_CONTINUE    =  8,    // 'continue' statement
-    STATUS_EOF         = 16,    // End of file
-    STATUS_ERROR       = 32,    // error
-    STATUS_QQUIT       = 64,    // QUIT command
+    STATUS_END      = 0,    // ran off the end of the code
+    STATUS_RETURN   = 1<<0, // 'return' statement
+    STATUS_BREAK    = 1<<1, // 'break' statement
+    STATUS_CONTINUE = 1<<2, // 'continue' statement
+    STATUS_QUIT     = 1<<3, // 'quit' statement
+    STATUS_QQUIT    = 1<<4, // 'QUIT' statement
+    STATUS_EOF      = 1<<5, // end of file while parsing
+    STATUS_ERROR    = 1<<6, // syntax error while parsing
 };
 
 

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -56,7 +56,12 @@ typedef struct GAPState {
     char Prompt[80];
 
     /* From stats.c */
+
+    // `ReturnObjStat` is the result of the return-statement that was last
+    // executed. It is set in `ExecReturnObj` and used in the handlers that
+    // interpret functions.
     Obj  ReturnObjStat;
+
     UInt (**CurrExecStatFuncs)(Stat);
 
     /* From code.c */

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -217,23 +217,23 @@ static void FinishAndCallFakeFuncExpr(IntrState * intr, Obj stackNams)
 
 /****************************************************************************
 **
-*F  IntrBegin() . . . . . . . . . . . . . . . . . . . .  start an interpreter
-*F  IntrEnd(<error>,<result>)  . . . . . . . . . . . . .  stop an interpreter
+*F  IntrBegin(<intr>) . . . . . . . . . . . . . . . . .  start an interpreter
+*F  IntrEnd(<intr>,<error>,<result>)  . . . . . . . . . . stop an interpreter
 **
 **  'IntrBegin' starts a new interpreter.
 **
-**  'IntrEnd' stops the current interpreter.
+**  'IntrEnd' stops the given interpreter.
 **
 **  If <error>  is non-zero a  syntax error was found by  the reader, and the
 **  interpreter only clears up the mess.
 **
 **  If 'IntrEnd' returns 'STATUS_END', then no return-statement or
-**  quit-statement was interpreted. If 'IntrEnd' returns 'STATUS_RETURN_VAL',
-**  then a return-value-statement was interpreted and in this case the return
-**  value is assigned to the address <result> points at (but only if <result>
-**  is not 0). If 'IntrEnd' returns 'STATUS_RETURN_VOID', then a
-**  return-void-statement was interpreted. If 'IntrEnd' returns 'STATUS_QUIT',
-**  then a quit-statement was interpreted.
+**  quit-statement was interpreted. If 'IntrEnd' returns 'STATUS_RETURN',
+**  then a return-statement was interpreted. If a value was returned, and the
+**  <result> is non-zero, then the returned value is assigned to the address
+**  <result> points at. If 'IntrEnd' returns 'STATUS_QUIT', then a
+**  quit-statement was interpreted. If 'IntrEnd' returns 'STATUS_QQUIT', then
+**  a QUIT-statement was interpreted.
 */
 void IntrBegin(IntrState * intr)
 {
@@ -1076,8 +1076,8 @@ void IntrReturnObj(IntrState * intr)
     SET_LEN_PLIST(intr->StackObj, 0);
     PushObj(intr, val);
 
-    /* indicate that a return-value-statement was interpreted              */
-    intr->returning = STATUS_RETURN_VAL;
+    // indicate that a return-statement was interpreted
+    intr->returning = STATUS_RETURN;
 }
 
 
@@ -1103,8 +1103,8 @@ void IntrReturnVoid(IntrState * intr)
     SET_LEN_PLIST(intr->StackObj, 0);
     PushVoidObj(intr);
 
-    /* indicate that a return-void-statement was interpreted               */
-    intr->returning = STATUS_RETURN_VOID;
+    // indicate that a return-statement was interpreted
+    intr->returning = STATUS_RETURN;
 }
 
 

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -58,23 +58,23 @@ typedef struct IntrState IntrState;
 
 /****************************************************************************
 **
-*F  IntrBegin() . . . . . . . . . . . . . . . . . . . .  start an interpreter
-*F  IntrEnd(<error>,<result>)  . . . . . . . . . . . . .  stop an interpreter
+*F  IntrBegin(<intr>) . . . . . . . . . . . . . . . . .  start an interpreter
+*F  IntrEnd(<intr>,<error>,<result>)  . . . . . . . . . . stop an interpreter
 **
 **  'IntrBegin' starts a new interpreter.
 **
-**  'IntrEnd' stops the current interpreter.
+**  'IntrEnd' stops the given interpreter.
 **
 **  If <error>  is non-zero a  syntax error was found by  the reader, and the
 **  interpreter only clears up the mess.
 **
 **  If 'IntrEnd' returns 'STATUS_END', then no return-statement or
-**  quit-statement was interpreted. If 'IntrEnd' returns 'STATUS_RETURN_VAL',
-**  then a return-value-statement was interpreted and in this case the return
-**  value is assigned to the address <result> points at (but only if <result>
-**  is not 0). If 'IntrEnd' returns 'STATUS_RETURN_VOID', then a
-**  return-void-statement was interpreted. If 'IntrEnd' returns 'STATUS_QUIT',
-**  then a quit-statement was interpreted.
+**  quit-statement was interpreted. If 'IntrEnd' returns 'STATUS_RETURN',
+**  then a return-statement was interpreted. If a value was returned, and the
+**  <result> is non-zero, then the returned value is assigned to the address
+**  <result> points at. If 'IntrEnd' returns 'STATUS_QUIT', then a
+**  quit-statement was interpreted. If 'IntrEnd' returns 'STATUS_QQUIT', then
+**  a QUIT-statement was interpreted.
 */
 void IntrBegin(IntrState * intr);
 

--- a/src/read.c
+++ b/src/read.c
@@ -2511,9 +2511,9 @@ ExecStatus ReadEvalCommand(Obj            context,
                            Obj *          evalResult,
                            BOOL *         dualSemicolon)
 {
-    volatile ExecStatus          type;
-    volatile Obj                 tilde;
-    volatile Obj                 errorLVars;
+    volatile ExecStatus status;
+    volatile Obj        tilde;
+    volatile Obj        errorLVars;
     jmp_buf           readJmpError;
 #ifdef HPCGAP
     int                 lockSP;
@@ -2606,7 +2606,7 @@ ExecStatus ReadEvalCommand(Obj            context,
         *dualSemicolon = (rs->s.Symbol == S_DUALSEMICOLON);
 
     // end the interpreter
-    type = IntrEnd(&rs->intr, rs->s.NrError > 0, evalResult);
+    status = IntrEnd(&rs->intr, rs->s.NrError > 0, evalResult);
 
     // restore the execution environment
     SWITCH_TO_OLD_LVARS(oldLVars);
@@ -2629,7 +2629,7 @@ ExecStatus ReadEvalCommand(Obj            context,
     ClearError();
 
     /* return whether a return-statement or a quit-statement were executed */
-    return type;
+    return status;
 }
 
 /****************************************************************************
@@ -2644,7 +2644,7 @@ ExecStatus ReadEvalCommand(Obj            context,
 */
 UInt ReadEvalFile(TypInputFile * input, Obj * evalResult)
 {
-    volatile ExecStatus type;
+    volatile ExecStatus status;
     volatile Obj        tilde;
     jmp_buf           readJmpError;
     volatile UInt       nr;
@@ -2714,7 +2714,7 @@ UInt ReadEvalFile(TypInputFile * input, Obj * evalResult)
     }
 
     /* end the interpreter                                                 */
-    type = IntrEnd(&rs->intr, rs->s.NrError > 0, evalResult);
+    status = IntrEnd(&rs->intr, rs->s.NrError > 0, evalResult);
 
     // restore the execution environment
     SWITCH_TO_OLD_LVARS(oldLVars);
@@ -2731,7 +2731,7 @@ UInt ReadEvalFile(TypInputFile * input, Obj * evalResult)
     ClearError();
 
     /* return whether a return-statement or a quit-statement were executed */
-    return type;
+    return status;
 }
 
 

--- a/src/read.c
+++ b/src/read.c
@@ -2509,7 +2509,7 @@ static void RecreateStackNams(ReaderState * rs, Obj context)
 ExecStatus ReadEvalCommand(Obj            context,
                            TypInputFile * input,
                            Obj *          evalResult,
-                           UInt *         dualSemicolon)
+                           BOOL *         dualSemicolon)
 {
     volatile ExecStatus          type;
     volatile Obj                 tilde;

--- a/src/read.h
+++ b/src/read.h
@@ -37,7 +37,7 @@
 UInt ReadEvalCommand(Obj            context,
                      TypInputFile * input,
                      Obj *          evalResult,
-                     UInt *         dualSemicolon);
+                     BOOL *         dualSemicolon);
 
 
 /****************************************************************************

--- a/src/stats.c
+++ b/src/stats.c
@@ -88,17 +88,6 @@ UInt            (* ExecStatFuncs[256]) ( Stat stat );
 
 /****************************************************************************
 **
-*V  ReturnObjStat . . . . . . . . . . . . . . . .  result of return-statement
-**
-**  'ReturnObjStat'  is   the result of the   return-statement  that was last
-**  executed.  It is set  in  'ExecReturnObj' and  used in the  handlers that
-**  interpret functions.
-*/
-/* TL: Obj             ReturnObjStat; */
-
-
-/****************************************************************************
-**
 *F  ExecUnknownStat(<stat>) . . . . . executor for statements of unknown type
 **
 **  'ExecUnknownStat' is the executor that is called if an attempt is made to

--- a/src/stats.h
+++ b/src/stats.h
@@ -36,12 +36,13 @@ extern  UInt            (* ExecStatFuncs[256]) ( Stat stat );
 **  'EXEC_STAT' executes the statement <stat>.
 **
 **  If   this  causes   the  execution  of   a  return-value-statement,  then
-**  'EXEC_STAT' returns 'STATUS_RETURN_VAL', and the return value is stored
+**  'EXEC_STAT' returns 'STATUS_RETURN', and the return value is stored
 **  in 'STATE(ReturnObjStat)'. If a return-void-statement is executed, then
-**  'EXEC_STAT' returns 'STATUS_RETURN_VOID'. If a break-statement is
-**  executed (which cannot happen if <stat> is the body of a function), then
-**  'EXEC_STAT' returns 'STATUS_BREAK'. Otherwise 'EXEC_STAT' returns
-**  'STATUS_END'.
+**  'EXEC_STAT' returns 'STATUS_RETURN' and sets 'STATE(ReturnObjStat)' to
+**  zero. If a break-statement is executed (which cannot happen if <stat> is
+**  the body of a function), then 'EXEC_STAT' returns 'STATUS_BREAK', and
+**  similarly for a continue-statement 'STATUS_CONTINUE' is returned.
+**  Otherwise 'EXEC_STAT' returns 'STATUS_END'.
 **
 **  'EXEC_STAT'  causes  the  execution  of  <stat>  by dispatching   to  the
 **  executor, i.e., to the  function that executes statements  of the type of

--- a/src/streams.c
+++ b/src/streams.c
@@ -176,7 +176,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
             AssPlist(result, 1, False);
             PushPlist(resultList, result);
 
-            if (!(status & STATUS_ERROR)) {
+            if (status != STATUS_ERROR) {
 
                 AssPlist(result, 1, True);
                 AssPlist(result, 3, dualSemicolon ? True : False);
@@ -251,7 +251,7 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
         return result;
     else if (STATE(UserHasQuit) || STATE(UserHasQUIT))
         return result;
-    else if (status & (STATUS_RETURN_VAL | STATUS_RETURN_VOID))
+    else if (status == STATUS_RETURN)
         Pr("'return' must not be used in file read-eval loop\n", 0, 0);
 
     AssPlist(result, 1, True);
@@ -292,7 +292,7 @@ static void READ_INNER(TypInputFile * input)
             break;
 
         /* handle return-value or return-void command                      */
-        if ( status & (STATUS_RETURN_VAL | STATUS_RETURN_VOID) ) {
+        if (status == STATUS_RETURN) {
             Pr("'return' must not be used in file read-eval loop\n", 0, 0);
         }
 
@@ -408,7 +408,7 @@ Int READ_GAP_ROOT ( const Char * filename )
             UInt type = ReadEvalCommand(0, &input, 0, 0);
             if (STATE(UserHasQuit) || STATE(UserHasQUIT))
                 break;
-            if (type & (STATUS_RETURN_VAL | STATUS_RETURN_VOID)) {
+            if (type == STATUS_RETURN) {
                 Pr("'return' must not be used in file", 0, 0);
             }
             else if (type & (STATUS_QUIT | STATUS_EOF)) {
@@ -906,7 +906,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
         }
 
         // handle return-value or return-void command
-        else if (type & (STATUS_RETURN_VAL | STATUS_RETURN_VOID)) {
+        else if (type == STATUS_RETURN) {
             Pr("'return' must not be used in file read-eval loop\n", 0, 0);
         }
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -165,7 +165,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
                 SET_LEN_STRING(outstreamString, 0);
             }
 
-            UInt dualSemicolon;
+            BOOL dualSemicolon;
             Obj  evalResult;
 
             ExecStatus status = ReadEvalCommand(0, &input, &evalResult, &dualSemicolon);
@@ -887,7 +887,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
     while (1) {
         UInt type;
         Obj  evalResult;
-        UInt dualSemicolon;
+        BOOL dualSemicolon;
         UInt oldtime = SyTime();
 
         // read and evaluate the command


### PR DESCRIPTION
- kernel: turn dualSemicolon into a BOOL
- kernel: document ReturnObjStat in gapstate.h
- kernel: merge STATUS_RETURN_VAL and STATUS_RETURN_VOID
- kernel: ReadEvalCommand returns an ExecStatus
