### PR TITLE
kernel: turn ExecStatus into a proper enum

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -287,7 +287,7 @@ static Obj FuncSHELL(Obj self,
             break;
 
         // if the statement we just processed itself was `QUIT`, also bail out
-        if (status & STATUS_QQUIT) {
+        if (status == STATUS_QQUIT) {
             STATE(UserHasQUIT) = TRUE;
             break;
         }
@@ -315,7 +315,7 @@ static Obj FuncSHELL(Obj self,
                0);
         }
         /* handle quit command or <end-of-file>                            */
-        else if (status & (STATUS_EOF | STATUS_QUIT)) {
+        else if (status == STATUS_EOF || status == STATUS_QUIT) {
             break;
         }
 
@@ -374,7 +374,7 @@ static Obj FuncSHELL(Obj self,
     // handle the remaining status codes; note that `STATUS_QQUIT` is handled
     // above, as part of the `UserHasQUIT` handling
     //
-    if (status & (STATUS_EOF | STATUS_QUIT)) {
+    if (status == STATUS_EOF || status == STATUS_QUIT) {
         return Fail;
     }
     if (status == STATUS_RETURN) {

--- a/src/gap.h
+++ b/src/gap.h
@@ -48,23 +48,18 @@ void ViewObjHandler(Obj obj);
 *T  ExecStatus . . . .  type of status values returned by read, eval and exec
 **                      subroutines, explaining why evaluation, or execution
 **                      has terminated.
-**
-**  Values are powers of two; this is used to test a given status for
-**  multiple possible values simultaneously.
 */
 
-typedef UInt ExecStatus;
-
-enum {
-    STATUS_END      = 0,    // ran off the end of the code
-    STATUS_RETURN   = 1<<0, // 'return' statement
-    STATUS_BREAK    = 1<<1, // 'break' statement
-    STATUS_CONTINUE = 1<<2, // 'continue' statement
-    STATUS_QUIT     = 1<<3, // 'quit' statement
-    STATUS_QQUIT    = 1<<4, // 'QUIT' statement
-    STATUS_EOF      = 1<<5, // end of file while parsing
-    STATUS_ERROR    = 1<<6, // syntax error while parsing
-};
+typedef enum {
+    STATUS_END,       // ran off the end of the code
+    STATUS_RETURN,    // 'return' statement
+    STATUS_BREAK,     // 'break' statement
+    STATUS_CONTINUE,  // 'continue' statement
+    STATUS_QUIT,      // 'quit' statement
+    STATUS_QQUIT,     // 'QUIT' statement
+    STATUS_EOF,       // end of file while parsing
+    STATUS_ERROR,     // syntax error while parsing
+} ExecStatus;
 
 
 /****************************************************************************

--- a/src/read.c
+++ b/src/read.c
@@ -2506,10 +2506,10 @@ static void RecreateStackNams(ReaderState * rs, Obj context)
 **  will be set to 1 if the command was followed by a double semicolon, else
 **  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
 */
-ExecStatus ReadEvalCommand(Obj            context,
-                           TypInputFile * input,
-                           Obj *          evalResult,
-                           BOOL *         dualSemicolon)
+UInt ReadEvalCommand(Obj            context,
+                     TypInputFile * input,
+                     Obj *          evalResult,
+                     BOOL *         dualSemicolon)
 {
     volatile ExecStatus status;
     volatile Obj        tilde;

--- a/src/read.h
+++ b/src/read.h
@@ -13,7 +13,7 @@
 #ifndef GAP_READ_H
 #define GAP_READ_H
 
-#include "system.h"
+#include "common.h"
 
 /****************************************************************************
 **

--- a/src/streams.c
+++ b/src/streams.c
@@ -169,7 +169,8 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
             Obj  evalResult;
 
             ExecStatus status = ReadEvalCommand(0, &input, &evalResult, &dualSemicolon);
-            if (status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))
+            if (status == STATUS_EOF || status == STATUS_QUIT ||
+                status == STATUS_QQUIT)
                 break;
 
             Obj result = NEW_PLIST(T_PLIST, 5);
@@ -247,7 +248,8 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     ExecStatus status = ReadEvalCommand(0, &input, &evalResult, 0);
     CloseInput(&input);
 
-    if (status & (STATUS_QUIT | STATUS_QQUIT | STATUS_EOF))
+    if (status == STATUS_EOF || status == STATUS_QUIT ||
+        status == STATUS_QQUIT)
         return result;
     else if (STATE(UserHasQuit) || STATE(UserHasQUIT))
         return result;
@@ -297,7 +299,7 @@ static void READ_INNER(TypInputFile * input)
         }
 
         /* handle quit command or <end-of-file>                            */
-        else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
+        else if (status == STATUS_EOF || status == STATUS_ERROR)
           break;
         else if (status == STATUS_QUIT) {
           STATE(UserHasQuit) = TRUE;
@@ -411,7 +413,7 @@ Int READ_GAP_ROOT ( const Char * filename )
             if (status == STATUS_RETURN) {
                 Pr("'return' must not be used in file", 0, 0);
             }
-            else if (status & (STATUS_QUIT | STATUS_EOF)) {
+            else if (status == STATUS_EOF || status == STATUS_QUIT) {
                 break;
             }
         }
@@ -911,7 +913,8 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
         }
 
         // handle quit command or <end-of-file>
-        else if (status & (STATUS_QUIT | STATUS_QQUIT | STATUS_EOF)) {
+        else if (status == STATUS_EOF || status == STATUS_QUIT ||
+                 status == STATUS_QQUIT) {
             break;
         }
     }


### PR DESCRIPTION
... and don't use it as a bitmask. It was a bitmask before as a (minor)
performance optimization. Alas, in most call sites, this did not matter: the
read-eval-loops in gap.c and streams.c are not affected by a few extra
instructions, especially if one is careful to first check the common case
(STATUS_END) before the exceptional cases (STATUS_QUIT, STATUS_QQUIT,
STATUS_ERROR, STATUS_EOF)

The only potentially performance critical check was in `EXEC_STAT_IN_LOOP`,
which was already switched away from using the bitmasks in a previous commit.
But even there, really only the case of a `break` or `return` statement
inside of a loop is affected, which once again is an "exceptional" case.


(All that said, if we want better performance for executing GAP code, we'd have to
implement a bytecode VM. If anybody wants to tackle that or has a student they'd like to assign to tackling that, I'd be happy to (co-)mentor this, I've thought about it plenty and could give some pointers as to how and where to start.)