### PR TITLE
kernel: use ExecStatus instead of UInt where possible

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -246,6 +246,25 @@ typedef struct TypOutputFile TypOutputFile;
 
 /****************************************************************************
 **
+*T  ExecStatus . . . .  type of status values returned by read, eval and exec
+**                      subroutines, explaining why evaluation, or execution
+**                      has terminated.
+*/
+
+typedef enum {
+    STATUS_END,         // ran off the end of the code
+    STATUS_RETURN,      // 'return' statement
+    STATUS_BREAK,       // 'break' statement
+    STATUS_CONTINUE,    // 'continue' statement
+    STATUS_QUIT,        // 'quit' statement
+    STATUS_QQUIT,       // 'QUIT' statement
+    STATUS_EOF,         // end of file while parsing
+    STATUS_ERROR,       // syntax error while parsing
+} ExecStatus;
+
+
+/****************************************************************************
+**
 *T  EvalBoolFunc
 *T  EvalExprFunc
 *T  ExecStatFunc
@@ -254,7 +273,7 @@ typedef struct TypOutputFile TypOutputFile;
 */
 typedef Obj (*EvalBoolFunc)(Expr);
 typedef Obj (*EvalExprFunc)(Expr);
-typedef UInt (*ExecStatFunc)(Stat);
+typedef ExecStatus (*ExecStatFunc)(Stat);
 typedef void (*PrintStatFunc)(Stat);
 typedef void (*PrintExprFunc)(Expr);
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -193,7 +193,7 @@ static ALWAYS_INLINE Obj EvalOrExecCall(Int ignoreResult, UInt nr, Stat call, St
 **  handled here
 */
 
-static UInt ExecProccallOpts(Stat call)
+static ExecStatus ExecProccallOpts(Stat call)
 {
     Expr opts = READ_STAT(call, 0);
     Expr real_call = READ_STAT(call, 1);
@@ -203,75 +203,59 @@ static UInt ExecProccallOpts(Stat call)
 
     EvalOrExecCall(1, narg, real_call, opts);
 
-    return 0;
+    return STATUS_END;
 }
 
 
-static UInt ExecProccall0args(Stat call)
+static ExecStatus ExecProccall0args(Stat call)
 {
     EvalOrExecCall(1, 0, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccall1args(Stat call)
+static ExecStatus ExecProccall1args(Stat call)
 {
     EvalOrExecCall(1, 1, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccall2args(Stat call)
+static ExecStatus ExecProccall2args(Stat call)
 {
     EvalOrExecCall(1, 2, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccall3args(Stat call)
+static ExecStatus ExecProccall3args(Stat call)
 {
     EvalOrExecCall(1, 3, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccall4args(Stat call)
+static ExecStatus ExecProccall4args(Stat call)
 {
     EvalOrExecCall(1, 4, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccall5args(Stat call)
+static ExecStatus ExecProccall5args(Stat call)
 {
     EvalOrExecCall(1, 5, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccall6args(Stat call)
+static ExecStatus ExecProccall6args(Stat call)
 {
     EvalOrExecCall(1, 6, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecProccallXargs(Stat call)
+static ExecStatus ExecProccallXargs(Stat call)
 {
     // pass in 7 (instead of NARG_SIZE_CALL(SIZE_STAT(call)))
     // to allow the compiler to perform better optimizations
     // (as we know that the number of arguments is >= 7 here)
     EvalOrExecCall(1, 7, call, 0);
-
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
 /****************************************************************************

--- a/src/gap.c
+++ b/src/gap.c
@@ -287,7 +287,7 @@ static Obj FuncSHELL(Obj self,
             break;
 
         // if the statement we just processed itself was `QUIT`, also bail out
-        if (status & STATUS_QQUIT) {
+        if (status == STATUS_QQUIT) {
             STATE(UserHasQUIT) = TRUE;
             break;
         }
@@ -315,7 +315,7 @@ static Obj FuncSHELL(Obj self,
                0);
         }
         /* handle quit command or <end-of-file>                            */
-        else if (status & (STATUS_EOF | STATUS_QUIT)) {
+        else if (status == STATUS_EOF || status == STATUS_QUIT) {
             break;
         }
 
@@ -374,7 +374,7 @@ static Obj FuncSHELL(Obj self,
     // handle the remaining status codes; note that `STATUS_QQUIT` is handled
     // above, as part of the `UserHasQUIT` handling
     //
-    if (status & (STATUS_EOF | STATUS_QUIT)) {
+    if (status == STATUS_EOF || status == STATUS_QUIT) {
         return Fail;
     }
     if (status == STATUS_RETURN) {

--- a/src/gap.c
+++ b/src/gap.c
@@ -229,7 +229,7 @@ static Obj FuncSHELL(Obj self,
     //
     // return values of ReadEvalCommand
     //
-    UInt status;
+    ExecStatus status;
     Obj  evalResult;
 
     //

--- a/src/gap.h
+++ b/src/gap.h
@@ -48,23 +48,18 @@ void ViewObjHandler(Obj obj);
 *T  ExecStatus . . . .  type of status values returned by read, eval and exec
 **                      subroutines, explaining why evaluation, or execution
 **                      has terminated.
-**
-**  Values are powers of two; this is used to test a given status for
-**  multiple possible values simultaneously.
 */
 
-typedef UInt ExecStatus;
-
-enum {
-    STATUS_END      = 0,    // ran off the end of the code
-    STATUS_RETURN   = 1<<0, // 'return' statement
-    STATUS_BREAK    = 1<<1, // 'break' statement
-    STATUS_CONTINUE = 1<<2, // 'continue' statement
-    STATUS_QUIT     = 1<<3, // 'quit' statement
-    STATUS_QQUIT    = 1<<4, // 'QUIT' statement
-    STATUS_EOF      = 1<<5, // end of file while parsing
-    STATUS_ERROR    = 1<<6, // syntax error while parsing
-};
+typedef enum {
+    STATUS_END,       // ran off the end of the code
+    STATUS_RETURN,    // 'return' statement
+    STATUS_BREAK,     // 'break' statement
+    STATUS_CONTINUE,  // 'continue' statement
+    STATUS_QUIT,      // 'quit' statement
+    STATUS_QQUIT,     // 'QUIT' statement
+    STATUS_EOF,       // end of file while parsing
+    STATUS_ERROR,     // syntax error while parsing
+} ExecStatus;
 
 
 /****************************************************************************

--- a/src/gap.h
+++ b/src/gap.h
@@ -45,25 +45,6 @@ void ViewObjHandler(Obj obj);
 
 /****************************************************************************
 **
-*T  ExecStatus . . . .  type of status values returned by read, eval and exec
-**                      subroutines, explaining why evaluation, or execution
-**                      has terminated.
-*/
-
-typedef enum {
-    STATUS_END,       // ran off the end of the code
-    STATUS_RETURN,    // 'return' statement
-    STATUS_BREAK,     // 'break' statement
-    STATUS_CONTINUE,  // 'continue' statement
-    STATUS_QUIT,      // 'quit' statement
-    STATUS_QQUIT,     // 'QUIT' statement
-    STATUS_EOF,       // end of file while parsing
-    STATUS_ERROR,     // syntax error while parsing
-} ExecStatus;
-
-
-/****************************************************************************
-**
 *S  MAX_FUNC_EXPR_NESTING_BITS
 *S  MAX_FUNC_EXPR_NESTING . . . . . . . . . . . . . . . maximal nesting level
 **

--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -103,7 +103,7 @@ void InstallPrintExprFunc(Int pos, PrintExprFunc f)
     HashUnlock(&activeHooks);
 }
 
-static UInt ProfileExecStatPassthrough(Stat stat)
+static ExecStatus ProfileExecStatPassthrough(Stat stat)
 {
     GAP_HOOK_LOOP(visitStat, stat);
     return OriginalExecStatFuncsForHook[TNUM_STAT(stat)](stat);

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -59,9 +59,9 @@
 static void INTERPRETER_PROFILE_HOOK(IntrState * intr, int ignoreLevel)
 {
     if (!intr->coding) {
-        InterpreterHook(GetInputFilenameID(GetCurrentInput()),
-                        intr->startLine,
-                        intr->returning || (intr->ignoring > ignoreLevel));
+        InterpreterHook(
+            GetInputFilenameID(GetCurrentInput()), intr->startLine,
+            intr->returning != STATUS_END || (intr->ignoring > ignoreLevel));
     }
     intr->startLine = 0;
 }
@@ -75,7 +75,7 @@ static void INTERPRETER_PROFILE_HOOK(IntrState * intr, int ignoreLevel)
 
 // Need to
 #define SKIP_IF_RETURNING_NO_PROFILE_HOOK()                                  \
-    if (intr->returning > 0) {                                               \
+    if (intr->returning != STATUS_END) {                                     \
         return;                                                              \
     }
 
@@ -245,7 +245,7 @@ void IntrBegin(IntrState * intr)
     GAP_ASSERT(intr->coding == 0);
 
     /* no return-statement was yet interpreted                             */
-    intr->returning = 0;
+    intr->returning = STATUS_END;
 }
 
 ExecStatus IntrEnd(IntrState * intr, BOOL error, Obj * result)
@@ -590,7 +590,7 @@ Int IntrIfEndBody(IntrState * intr, UInt nr)
     INTERPRETER_PROFILE_HOOK(intr, 0);
 
     /* ignore or code                                                      */
-    if (intr->returning > 0) {
+    if (intr->returning != STATUS_END) {
         return 0;
     }
     if (intr->ignoring > 0) {

--- a/src/read.c
+++ b/src/read.c
@@ -2506,10 +2506,10 @@ static void RecreateStackNams(ReaderState * rs, Obj context)
 **  will be set to 1 if the command was followed by a double semicolon, else
 **  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
 */
-ExecStatus ReadEvalCommand(Obj            context,
-                           TypInputFile * input,
-                           Obj *          evalResult,
-                           BOOL *         dualSemicolon)
+UInt ReadEvalCommand(Obj            context,
+                     TypInputFile * input,
+                     Obj *          evalResult,
+                     BOOL *         dualSemicolon)
 {
     volatile ExecStatus status;
     volatile Obj        tilde;

--- a/src/read.c
+++ b/src/read.c
@@ -2506,10 +2506,10 @@ static void RecreateStackNams(ReaderState * rs, Obj context)
 **  will be set to 1 if the command was followed by a double semicolon, else
 **  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
 */
-UInt ReadEvalCommand(Obj            context,
-                     TypInputFile * input,
-                     Obj *          evalResult,
-                     BOOL *         dualSemicolon)
+ExecStatus ReadEvalCommand(Obj            context,
+                           TypInputFile * input,
+                           Obj *          evalResult,
+                           BOOL *         dualSemicolon)
 {
     volatile ExecStatus status;
     volatile Obj        tilde;
@@ -2642,7 +2642,7 @@ UInt ReadEvalCommand(Obj            context,
 **  It does not expect the first symbol of its input already read and reads
 **  to the end of the input (unless an error happens).
 */
-UInt ReadEvalFile(TypInputFile * input, Obj * evalResult)
+ExecStatus ReadEvalFile(TypInputFile * input, Obj * evalResult)
 {
     volatile ExecStatus status;
     volatile Obj        tilde;

--- a/src/read.h
+++ b/src/read.h
@@ -13,7 +13,7 @@
 #ifndef GAP_READ_H
 #define GAP_READ_H
 
-#include "system.h"
+#include "common.h"
 
 /****************************************************************************
 **

--- a/src/read.h
+++ b/src/read.h
@@ -34,10 +34,10 @@
 **  will be set to 1 if the command was followed by a double semicolon, else
 **  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
 */
-UInt ReadEvalCommand(Obj            context,
-                     TypInputFile * input,
-                     Obj *          evalResult,
-                     BOOL *         dualSemicolon);
+ExecStatus ReadEvalCommand(Obj            context,
+                           TypInputFile * input,
+                           Obj *          evalResult,
+                           BOOL *         dualSemicolon);
 
 
 /****************************************************************************
@@ -50,7 +50,7 @@ UInt ReadEvalCommand(Obj            context,
 **  It does not expect the first symbol of its input already read and reads
 **  to the end of the input (unless an error happens).
 */
-UInt ReadEvalFile(TypInputFile * input, Obj * evalResult);
+ExecStatus ReadEvalFile(TypInputFile * input, Obj * evalResult);
 
 
 /****************************************************************************

--- a/src/stats.h
+++ b/src/stats.h
@@ -48,7 +48,7 @@ extern ExecStatFunc ExecStatFuncs[256];
 **  executor, i.e., to the  function that executes statements  of the type of
 **  <stat>.
 */
-UInt EXEC_STAT(Stat stat);
+ExecStatus EXEC_STAT(Stat stat);
 
 // Executes the current function and returns its return value
 // if the last statement was STAT_RETURN_OBJ, or null if the last

--- a/src/streams.c
+++ b/src/streams.c
@@ -169,7 +169,8 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
             Obj  evalResult;
 
             ExecStatus status = ReadEvalCommand(0, &input, &evalResult, &dualSemicolon);
-            if (status & (STATUS_EOF | STATUS_QUIT | STATUS_QQUIT))
+            if (status == STATUS_EOF || status == STATUS_QUIT ||
+                status == STATUS_QQUIT)
                 break;
 
             Obj result = NEW_PLIST(T_PLIST, 5);
@@ -247,7 +248,8 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     ExecStatus status = ReadEvalCommand(0, &input, &evalResult, 0);
     CloseInput(&input);
 
-    if (status & (STATUS_QUIT | STATUS_QQUIT | STATUS_EOF))
+    if (status == STATUS_EOF || status == STATUS_QUIT ||
+        status == STATUS_QQUIT)
         return result;
     else if (STATE(UserHasQuit) || STATE(UserHasQUIT))
         return result;
@@ -297,7 +299,7 @@ static void READ_INNER(TypInputFile * input)
         }
 
         /* handle quit command or <end-of-file>                            */
-        else if ( status  & (STATUS_ERROR | STATUS_EOF)) 
+        else if (status == STATUS_EOF || status == STATUS_ERROR)
           break;
         else if (status == STATUS_QUIT) {
           STATE(UserHasQuit) = TRUE;
@@ -411,7 +413,7 @@ Int READ_GAP_ROOT ( const Char * filename )
             if (status == STATUS_RETURN) {
                 Pr("'return' must not be used in file", 0, 0);
             }
-            else if (status & (STATUS_QUIT | STATUS_EOF)) {
+            else if (status == STATUS_EOF || status == STATUS_QUIT) {
                 break;
             }
         }
@@ -911,7 +913,8 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
         }
 
         // handle quit command or <end-of-file>
-        else if (status & (STATUS_QUIT | STATUS_QQUIT | STATUS_EOF)) {
+        else if (status == STATUS_EOF || status == STATUS_QUIT ||
+                 status == STATUS_QQUIT) {
             break;
         }
     }

--- a/src/vars.c
+++ b/src/vars.c
@@ -159,7 +159,7 @@ void FreeLVarsBag(Bag bag)
 **  'ExecAssLVar' executes the local  variable assignment statement <stat> to
 **  the local variable that is referenced in <stat>.
 */
-static UInt ExecAssLVar(Stat stat)
+static ExecStatus ExecAssLVar(Stat stat)
 {
     Obj                 rhs;            /* value of right hand side        */
 
@@ -167,17 +167,15 @@ static UInt ExecAssLVar(Stat stat)
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
     ASS_LVAR(READ_STAT(stat, 0), rhs);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecUnbLVar(Stat stat)
+static ExecStatus ExecUnbLVar(Stat stat)
 {
     /* unbind the local variable                                           */
     ASS_LVAR(READ_STAT(stat, 0), (Obj)0);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -307,7 +305,7 @@ Obj NAME_HVAR_WITH_CONTEXT(Obj context, UInt hvar)
 **  'ExecAssHVar' executes the higher variable assignment statement <stat> to
 **  the higher variable that is referenced in <stat>.
 */
-static UInt ExecAssHVar(Stat stat)
+static ExecStatus ExecAssHVar(Stat stat)
 {
     Obj                 rhs;            /* value of right hand side        */
 
@@ -315,17 +313,15 @@ static UInt ExecAssHVar(Stat stat)
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
     ASS_HVAR(READ_STAT(stat, 0), rhs);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecUnbHVar(Stat stat)
+static ExecStatus ExecUnbHVar(Stat stat)
 {
     /* unbind the higher variable                                          */
     ASS_HVAR(READ_STAT(stat, 0), 0);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -413,7 +409,7 @@ static void PrintIsbHVar(Expr expr)
 **  'ExecAssGVar' executes the global variable assignment statement <stat> to
 **  the global variable that is referenced in <stat>.
 */
-static UInt ExecAssGVar(Stat stat)
+static ExecStatus ExecAssGVar(Stat stat)
 {
     Obj                 rhs;            /* value of right hand side        */
 
@@ -421,17 +417,15 @@ static UInt ExecAssGVar(Stat stat)
     rhs = EVAL_EXPR(READ_STAT(stat, 1));
     AssGVar(READ_STAT(stat, 0), rhs);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
-static UInt ExecUnbGVar(Stat stat)
+static ExecStatus ExecUnbGVar(Stat stat)
 {
     /* unbind the global variable                                          */
     AssGVar(READ_STAT(stat, 0), (Obj)0);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -518,7 +512,7 @@ static void PrintIsbGVar(Expr expr)
 **  'ExecAssList'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>] := <rhs>;'.
 */
-static UInt ExecAssList(Expr stat)
+static ExecStatus ExecAssList(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -555,8 +549,7 @@ static UInt ExecAssList(Expr stat)
         ASSB_LIST(list, pos, rhs);
     }
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 /****************************************************************************
 **
@@ -565,7 +558,7 @@ static UInt ExecAssList(Expr stat)
 **  'ExecAssMat' executes the matrix assignment statement <stat> of the form
 **  '<mat>[<row>,<col>] := <rhs>;'.
 */
-static UInt ExecAssMat(Expr stat)
+static ExecStatus ExecAssMat(Expr stat)
 {
     // evaluate the matrix (checking is done by 'ASS_MAT')
     Obj mat = EVAL_EXPR(READ_STAT(stat, 0));
@@ -579,8 +572,7 @@ static UInt ExecAssMat(Expr stat)
 
     ASS_MAT(mat, row, col, rhs);
 
-    // return 0 (to indicate that no leave-statement was executed)
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -591,7 +583,7 @@ static UInt ExecAssMat(Expr stat)
 **  'ExecAsssList' executes the list assignment statement  <stat> of the form
 **  '<list>{<positions>} := <rhss>;'.
 */
-static UInt ExecAsssList(Expr stat)
+static ExecStatus ExecAsssList(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 poss;           /* positions, left operand         */
@@ -612,8 +604,7 @@ static UInt ExecAsssList(Expr stat)
     /* assign the right hand sides to several elements of the list         */
     ASSS_LIST( list, poss, rhss );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -631,7 +622,7 @@ static UInt ExecAsssList(Expr stat)
 **  a  list, and 'ExecAssListLevel' assigns the  element '<rhss>[<i>]' to the
 **  list '<list>[<i>]' at <position>.
 */
-static UInt ExecAssListLevel(Expr stat)
+static ExecStatus ExecAssListLevel(Expr stat)
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 pos;            /* position, left operand          */
@@ -661,8 +652,7 @@ static UInt ExecAssListLevel(Expr stat)
     /* assign the right hand sides to the elements of several lists        */
     AssListLevel( lists, ixs, rhss, level );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -680,7 +670,7 @@ static UInt ExecAssListLevel(Expr stat)
 **  a list, and 'ExecAsssListLevel' assigns the elements '<rhss>[<i>]' to the
 **  list '<list>[<i>]' at the positions <positions>.
 */
-static UInt ExecAsssListLevel(Expr stat)
+static ExecStatus ExecAsssListLevel(Expr stat)
 {
     Obj                 lists;          /* lists, left operand             */
     Obj                 poss;           /* position, left operand          */
@@ -704,8 +694,7 @@ static UInt ExecAsssListLevel(Expr stat)
     /* assign the right hand sides to several elements of several lists    */
     AsssListLevel( lists, poss, rhss, level );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -716,7 +705,7 @@ static UInt ExecAsssListLevel(Expr stat)
 **  'ExecUnbList'  executes the list   unbind  statement <stat> of the   form
 **  'Unbind( <list>[<position>] );'.
 */
-static UInt ExecUnbList(Expr stat)
+static ExecStatus ExecUnbList(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -746,10 +735,8 @@ static UInt ExecUnbList(Expr stat)
       SET_LEN_PLIST(ixs, narg);
       UNBB_LIST(list, ixs);
     }
-    
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1133,7 +1120,7 @@ static void PrintElmsList(Expr expr)
 **  'ExecAssRecName' executes the record  assignment statement <stat>  of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static UInt ExecAssRecName(Stat stat)
+static ExecStatus ExecAssRecName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1151,8 +1138,7 @@ static UInt ExecAssRecName(Stat stat)
     /* assign the right hand side to the element of the record             */
     ASS_REC( record, rnam, rhs );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1163,7 +1149,7 @@ static UInt ExecAssRecName(Stat stat)
 **  'ExecAssRecExpr'  executes the record assignment  statement <stat> of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static UInt ExecAssRecExpr(Stat stat)
+static ExecStatus ExecAssRecExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1181,8 +1167,7 @@ static UInt ExecAssRecExpr(Stat stat)
     /* assign the right hand side to the element of the record             */
     ASS_REC( record, rnam, rhs );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1193,7 +1178,7 @@ static UInt ExecAssRecExpr(Stat stat)
 **  'ExecUnbRecName' executes the record  unbind statement <stat> of the form
 **  'Unbind( <record>.<name> );'.
 */
-static UInt ExecUnbRecName(Stat stat)
+static ExecStatus ExecUnbRecName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1207,8 +1192,7 @@ static UInt ExecUnbRecName(Stat stat)
     /* unbind the element of the record                                    */
     UNB_REC( record, rnam );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1219,7 +1203,7 @@ static UInt ExecUnbRecName(Stat stat)
 **  'ExecUnbRecExpr' executes the record  unbind statement <stat> of the form
 **  'Unbind( <record>.(<name>) );'.
 */
-static UInt ExecUnbRecExpr(Stat stat)
+static ExecStatus ExecUnbRecExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1233,8 +1217,7 @@ static UInt ExecUnbRecExpr(Stat stat)
     /* unbind the element of the record                                    */
     UNB_REC( record, rnam );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1461,7 +1444,7 @@ static void PrintIsbRecExpr(Expr expr)
 **  'ExecAssPosObj'  executes the list  assignment statement <stat> of the form
 **  '<list>[<position>] := <rhs>;'.
 */
-static UInt ExecAssPosObj(Expr stat)
+static ExecStatus ExecAssPosObj(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -1481,8 +1464,7 @@ static UInt ExecAssPosObj(Expr stat)
     /* special case for plain list                                         */
     AssPosObj(list, p, rhs);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1493,7 +1475,7 @@ static UInt ExecAssPosObj(Expr stat)
 **  'ExecUnbPosObj'  executes the list   unbind  statement <stat> of the   form
 **  'Unbind( <list>[<position>] );'.
 */
-static UInt ExecUnbPosObj(Expr stat)
+static ExecStatus ExecUnbPosObj(Expr stat)
 {
     Obj                 list;           /* list, left operand              */
     Obj                 pos;            /* position, left operand          */
@@ -1509,8 +1491,7 @@ static UInt ExecUnbPosObj(Expr stat)
     /* unbind the element                                                  */
     UnbPosObj(list, p);
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1641,7 +1622,7 @@ static void PrintIsbPosObj(Expr expr)
 **  'ExecAssComObjName' executes the  record assignment statement <stat> of the
 **  form '<record>.<name> := <rhs>;'.
 */
-static UInt ExecAssComObjName(Stat stat)
+static ExecStatus ExecAssComObjName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1659,8 +1640,7 @@ static UInt ExecAssComObjName(Stat stat)
     /* assign the right hand side to the element of the record             */
     AssComObj( record, rnam, rhs );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1671,7 +1651,7 @@ static UInt ExecAssComObjName(Stat stat)
 **  'ExecAssComObjExpr' executes the record assignment  statement <stat> of the
 **  form '<record>.(<name>) := <rhs>;'.
 */
-static UInt ExecAssComObjExpr(Stat stat)
+static ExecStatus ExecAssComObjExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1689,8 +1669,7 @@ static UInt ExecAssComObjExpr(Stat stat)
     /* assign the right hand side to the element of the record             */
     AssComObj( record, rnam, rhs );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1701,7 +1680,7 @@ static UInt ExecAssComObjExpr(Stat stat)
 **  'ExecUnbComObjName' executes the record unbind statement <stat> of the form
 **  'Unbind( <record>.<name> );'.
 */
-static UInt ExecUnbComObjName(Stat stat)
+static ExecStatus ExecUnbComObjName(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1715,8 +1694,7 @@ static UInt ExecUnbComObjName(Stat stat)
     /* unbind the element of the record                                    */
     UnbComObj( record, rnam );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 
@@ -1727,7 +1705,7 @@ static UInt ExecUnbComObjName(Stat stat)
 **  'ExecUnbComObjExpr' executes the record unbind statement <stat> of the form
 **  'Unbind( <record>.(<name>) );'.
 */
-static UInt ExecUnbComObjExpr(Stat stat)
+static ExecStatus ExecUnbComObjExpr(Stat stat)
 {
     Obj                 record;         /* record, left operand            */
     UInt                rnam;           /* name, left operand              */
@@ -1741,8 +1719,7 @@ static UInt ExecUnbComObjExpr(Stat stat)
     /* unbind the element of the record                                    */
     UnbComObj( record, rnam );
 
-    /* return 0 (to indicate that no leave-statement was executed)         */
-    return 0;
+    return STATUS_END;
 }
 
 


### PR DESCRIPTION
- kernel: turn ExecStatus into a proper enum (PR #4729)
- kernel: use ExecStatus instead of UInt where possible

This contains #4729. So either merge this PR to get both; or if PR #4729 is merged first, I can rebase this one afterwards.