### PR TITLE
Adjust documentation of SocleTypePrimitiveGroup

### DIFF
--- a/lib/grpperm.gd
+++ b/lib/grpperm.gd
@@ -463,8 +463,7 @@ DeclareAttribute( "ONanScottType", IsPermGroup );
 ##  <Ref Attr="IsomorphismTypeInfoFiniteSimpleGroup" Label="for a group"/>),
 ##  and <C>width</C> for the number of direct factors.
 ##  <P/>
-##  If <A>G</A> does not have a faithful primitive action,
-##  the result is undefined.
+##  If <A>G</A> does not act primitively on its moved points, an error is returned. 
 ##  <Example><![CDATA[
 ##  gap> g:=AlternatingGroup(5);;
 ##  gap> h:=DirectProduct(g,g);;


### PR DESCRIPTION
The documentation of `SocleTypePrimitiveGroup` now states that an error is returned when `G` does not act primitively on `MovedPoints(G)`.

This reflects the documentation and comments from @ThomasBreuer  from Issue #4735 and the changes made in PR #4736.