### PR TITLE
kernel: correct outdated comments

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -2746,12 +2746,12 @@ void CodeIsbRecExpr ( void )
 
 /****************************************************************************
 **
-*F  CodeAssPosObj() . . . . . . . . . . . . . . . . code assignment to a list
+*F  CodeAssPosObj() . . . . . . . . . . . . . . . code assignment to a posobj
 */
 void CodeAssPosObj ( void )
 {
     Stat                ass;            /* assignment, result              */
-    Expr                list;           /* list expression                 */
+    Expr                posobj;         // posobj expression
     Expr                pos;            /* position expression             */
     Expr                rhsx;           /* right hand side expression      */
 
@@ -2766,9 +2766,9 @@ void CodeAssPosObj ( void )
     pos = PopExpr();
     WRITE_STAT(ass, 1, pos);
 
-    /* enter the list expression                                           */
-    list = PopExpr();
-    WRITE_STAT(ass, 0, list);
+    // enter the posobj expression
+    posobj = PopExpr();
+    WRITE_STAT(ass, 0, posobj);
 
     /* push the assignment                                                 */
     PushStat( ass );
@@ -2781,7 +2781,7 @@ void CodeAssPosObj ( void )
 */
 void CodeUnbPosObj ( void )
 {
-    Expr                list;           /* list expression                 */
+    Expr                posobj;         // posobj expression
     Expr                pos;            /* position expression             */
     Stat                ass;            /* unbind, result                  */
 
@@ -2792,9 +2792,9 @@ void CodeUnbPosObj ( void )
     pos = PopExpr();
     WRITE_STAT(ass, 1, pos);
 
-    /* enter the list expression                                           */
-    list = PopExpr();
-    WRITE_STAT(ass, 0, list);
+    // enter the posobj expression
+    posobj = PopExpr();
+    WRITE_STAT(ass, 0, posobj);
 
     /* push the unbind                                                     */
     PushStat( ass );
@@ -2803,12 +2803,12 @@ void CodeUnbPosObj ( void )
 
 /****************************************************************************
 **
-*F  CodeElmPosObj() . . . . . . . . . . . . . . . .  code selection of a list
+*F  CodeElmPosObj() . . . . . . . . . . . . . . .  code selection of a posobj
 */
 void CodeElmPosObj ( void )
 {
     Expr                ref;            /* reference, result               */
-    Expr                list;           /* list expression                 */
+    Expr                posobj;         // posobj expression
     Expr                pos;            /* position expression             */
 
     /* allocate the reference                                              */
@@ -2818,9 +2818,9 @@ void CodeElmPosObj ( void )
     pos = PopExpr();
     WRITE_EXPR(ref, 1, pos);
 
-    /* enter the list expression                                           */
-    list = PopExpr();
-    WRITE_EXPR(ref, 0, list);
+    // enter the posobj expression
+    posobj = PopExpr();
+    WRITE_EXPR(ref, 0, posobj);
 
     /* push the reference                                                  */
     PushExpr( ref );
@@ -2834,7 +2834,7 @@ void CodeElmPosObj ( void )
 void CodeIsbPosObj ( void )
 {
     Expr                ref;            /* isbound, result                 */
-    Expr                list;           /* list expression                 */
+    Expr                posobj;         // posobj expression
     Expr                pos;            /* position expression             */
 
     /* allocate the isbound                                                */
@@ -2844,9 +2844,9 @@ void CodeIsbPosObj ( void )
     pos = PopExpr();
     WRITE_EXPR(ref, 1, pos);
 
-    /* enter the list expression                                           */
-    list = PopExpr();
-    WRITE_EXPR(ref, 0, list);
+    // enter the posobj expression
+    posobj = PopExpr();
+    WRITE_EXPR(ref, 0, posobj);
 
     /* push the isbound                                                    */
     PushExpr( ref );
@@ -2855,14 +2855,13 @@ void CodeIsbPosObj ( void )
 
 /****************************************************************************
 **
-*F  CodeAssComObjName( <rnam> ) . . . . . . . . . code assignment to a record
-*F  CodeAssComObjExpr() . . . . . . . . . . . . . code assignment to a record
+*F  CodeAssComObjName( <rnam> ) . . . . . . . . . code assignment to a comobj
+*F  CodeAssComObjExpr() . . . . . . . . . . . . . code assignment to a comobj
 */
-void            CodeAssComObjName (
-    UInt                rnam )
+void CodeAssComObjName(UInt rnam)
 {
     Stat                stat;           /* assignment, result              */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
     Expr                rhsx;           /* right hand side expression      */
 
     /* allocate the assignment                                             */
@@ -2875,18 +2874,18 @@ void            CodeAssComObjName (
     /* enter the name                                                      */
     WRITE_STAT(stat, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_STAT(stat, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_STAT(stat, 0, comobj);
 
     /* push the assignment                                                 */
     PushStat( stat );
 }
 
-void            CodeAssComObjExpr ( void )
+void CodeAssComObjExpr(void)
 {
     Stat                stat;           /* assignment, result              */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
     Expr                rnam;           /* name expression                 */
     Expr                rhsx;           /* right hand side expression      */
 
@@ -2901,19 +2900,18 @@ void            CodeAssComObjExpr ( void )
     rnam = PopExpr();
     WRITE_STAT(stat, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_STAT(stat, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_STAT(stat, 0, comobj);
 
     /* push the assignment                                                 */
     PushStat( stat );
 }
 
-void            CodeUnbComObjName (
-    UInt                rnam )
+void CodeUnbComObjName(UInt rnam)
 {
     Stat                stat;           /* unbind, result                  */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
 
     /* allocate the unbind                                                 */
     stat = NewStat( STAT_UNB_COMOBJ_NAME, 2 * sizeof(Stat) );
@@ -2921,18 +2919,18 @@ void            CodeUnbComObjName (
     /* enter the name                                                      */
     WRITE_STAT(stat, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_STAT(stat, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_STAT(stat, 0, comobj);
 
     /* push the unbind                                                     */
     PushStat( stat );
 }
 
-void            CodeUnbComObjExpr ( void )
+void CodeUnbComObjExpr(void)
 {
     Stat                stat;           /* unbind, result                  */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
     Expr                rnam;           /* name expression                 */
 
     /* allocate the unbind                                                 */
@@ -2942,9 +2940,9 @@ void            CodeUnbComObjExpr ( void )
     rnam = PopExpr();
     WRITE_STAT(stat, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_STAT(stat, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_STAT(stat, 0, comobj);
 
     /* push the unbind                                                     */
     PushStat( stat );
@@ -2953,14 +2951,13 @@ void            CodeUnbComObjExpr ( void )
 
 /****************************************************************************
 **
-*F  CodeElmComObjName( <rnam> ) . . . . . . . . .  code selection of a record
-*F  CodeElmComObjExpr() . . . . . . . . . . . . .  code selection of a record
+*F  CodeElmComObjName( <rnam> ) . . . . . . . . .  code selection of a comobj
+*F  CodeElmComObjExpr() . . . . . . . . . . . . .  code selection of a comobj
 */
-void CodeElmComObjName (
-    UInt                rnam )
+void CodeElmComObjName(UInt rnam)
 {
     Expr                expr;           /* reference, result               */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
 
     /* allocate the reference                                              */
     expr = NewExpr( EXPR_ELM_COMOBJ_NAME, 2 * sizeof(Expr) );
@@ -2968,19 +2965,19 @@ void CodeElmComObjName (
     /* enter the name                                                      */
     WRITE_EXPR(expr, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_EXPR(expr, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_EXPR(expr, 0, comobj);
 
     /* push the reference                                                  */
     PushExpr( expr );
 }
 
-void CodeElmComObjExpr ( void )
+void CodeElmComObjExpr(void)
 {
     Expr                expr;           /* reference, result               */
     Expr                rnam;           /* name expression                 */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
 
     /* allocate the reference                                              */
     expr = NewExpr( EXPR_ELM_COMOBJ_EXPR, 2 * sizeof(Expr) );
@@ -2989,9 +2986,9 @@ void CodeElmComObjExpr ( void )
     rnam = PopExpr();
     WRITE_EXPR(expr, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_EXPR(expr, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_EXPR(expr, 0, comobj);
 
     /* push the reference                                                  */
     PushExpr( expr );
@@ -3002,11 +2999,10 @@ void CodeElmComObjExpr ( void )
 **
 *F  CodeIsbComObjName( <rname> )  . . . . .  code bound com object name check
 */
-void CodeIsbComObjName (
-    UInt                rnam )
+void CodeIsbComObjName(UInt rnam)
 {
     Expr                expr;           /* isbound, result                 */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
 
     /* allocate the isbound                                                */
     expr = NewExpr( EXPR_ISB_COMOBJ_NAME, 2 * sizeof(Expr) );
@@ -3014,9 +3010,9 @@ void CodeIsbComObjName (
     /* enter the name                                                      */
     WRITE_EXPR(expr, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_EXPR(expr, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_EXPR(expr, 0, comobj);
 
     /* push the isbound                                                    */
     PushExpr( expr );
@@ -3026,11 +3022,11 @@ void CodeIsbComObjName (
 **
 *F  CodeIsbComObjExpr() . . . . . . . . . .  code bound com object expr check
 */
-void CodeIsbComObjExpr ( void )
+void CodeIsbComObjExpr(void)
 {
     Expr                expr;           /* reference, result               */
     Expr                rnam;           /* name expression                 */
-    Expr                rec;            /* record expression               */
+    Expr                comobj;         // comobj expression
 
     /* allocate the isbound                                                */
     expr = NewExpr( EXPR_ISB_COMOBJ_EXPR, 2 * sizeof(Expr) );
@@ -3039,9 +3035,9 @@ void CodeIsbComObjExpr ( void )
     rnam = PopExpr();
     WRITE_EXPR(expr, 1, rnam);
 
-    /* enter the record expression                                         */
-    rec = PopExpr();
-    WRITE_EXPR(expr, 0, rec);
+    // enter the comobj expression
+    comobj = PopExpr();
+    WRITE_EXPR(expr, 0, comobj);
 
     /* push the isbound                                                    */
     PushExpr( expr );

--- a/src/code.h
+++ b/src/code.h
@@ -1316,7 +1316,7 @@ void CodeIsbRecExpr(void);
 
 /****************************************************************************
 **
-*F  CodeAssPosObj() . . . . . . . . . . . . . . . . code assignment to a list
+*F  CodeAssPosObj() . . . . . . . . . . . . . . . code assignment to a posobj
 */
 void CodeAssPosObj(void);
 
@@ -1325,7 +1325,7 @@ void CodeUnbPosObj(void);
 
 /****************************************************************************
 **
-*F  CodeElmPosObj() . . . . . . . . . . . . . . . .  code selection of a list
+*F  CodeElmPosObj() . . . . . . . . . . . . . . .  code selection of a posobj
 */
 void CodeElmPosObj(void);
 
@@ -1334,8 +1334,8 @@ void CodeIsbPosObj(void);
 
 /****************************************************************************
 **
-*F  CodeAssComObjName(<rnam>) . . . . . . . . . . code assignment to a record
-*F  CodeAssComObjExpr() . . . . . . . . . . . . . code assignment to a record
+*F  CodeAssComObjName(<rnam>) . . . . . . . . . . code assignment to a comobj
+*F  CodeAssComObjExpr() . . . . . . . . . . . . . code assignment to a comobj
 */
 void CodeAssComObjName(UInt rnam);
 
@@ -1348,8 +1348,8 @@ void CodeUnbComObjExpr(void);
 
 /****************************************************************************
 **
-*F  CodeElmComObjName(<rnam>) . . . . . . . . . .  code selection of a record
-*F  CodeElmComObjExpr() . . . . . . . . . . . . .  code selection of a record
+*F  CodeElmComObjName(<rnam>) . . . . . . . . . .  code selection of a comobj
+*F  CodeElmComObjExpr() . . . . . . . . . . . . .  code selection of a comobj
 */
 void CodeElmComObjName(UInt rnam);
 

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -3531,11 +3531,11 @@ void IntrIsbRecExpr(IntrState * intr)
 
 /****************************************************************************
 **
-*F  IntrAssPosObj() . . . . . . . . . . . . .  interpret assignment to a list
+*F  IntrAssPosObj() . . . . . . . . . . . .  interpret assignment to a posobj
 */
 void IntrAssPosObj(IntrState * intr)
 {
-    Obj                 list;           /* list                            */
+    Obj                 posobj;         // posobj
     Obj                 pos;            /* position                        */
     Int                 p;              /* position, as a C integer        */
     Obj                 rhs;            /* right hand side                 */
@@ -3556,11 +3556,11 @@ void IntrAssPosObj(IntrState * intr)
     pos = PopObj(intr);
     p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
-    /* get the list (checking is done by 'ASS_LIST')                       */
-    list = PopObj(intr);
+    // get the posobj (checking is done by 'AssPosObj')
+    posobj = PopObj(intr);
 
-    /* assign to the element of the list                                   */
-    AssPosObj( list, p, rhs );
+    // assign to the element of the posobj
+    AssPosObj(posobj, p, rhs);
 
     /* push the right hand side again                                      */
     PushObj(intr, rhs);
@@ -3568,7 +3568,7 @@ void IntrAssPosObj(IntrState * intr)
 
 void IntrUnbPosObj(IntrState * intr)
 {
-    Obj                 list;           /* list                            */
+    Obj                 posobj;         // posobj
     Obj                 pos;            /* position                        */
     Int                 p;              /* position, as a C integer        */
 
@@ -3585,11 +3585,11 @@ void IntrUnbPosObj(IntrState * intr)
     pos = PopObj(intr);
     p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
-    /* get the list (checking is done by 'UNB_LIST')                       */
-    list = PopObj(intr);
+    // get the posobj (checking is done by 'UnbPosObj')
+    posobj = PopObj(intr);
 
     /* unbind the element                                                  */
-    UnbPosObj( list, p );
+    UnbPosObj(posobj, p);
 
     /* push void                                                           */
     PushVoidObj(intr);
@@ -3598,12 +3598,12 @@ void IntrUnbPosObj(IntrState * intr)
 
 /****************************************************************************
 **
-*F  IntrElmPosObj() . . . . . . . . . . . . . . interpret selection of a list
+*F  IntrElmPosObj() . . . . . . . . . . . . . interpret selection of a posobj
 */
 void IntrElmPosObj(IntrState * intr)
 {
     Obj                 elm;            /* element, result                 */
-    Obj                 list;           /* list, left operand              */
+    Obj                 posobj;         // posobj, left operand
     Obj                 pos;            /* position, right operand         */
     Int                 p;              /* position, as C integer          */
 
@@ -3620,11 +3620,11 @@ void IntrElmPosObj(IntrState * intr)
     pos = PopObj(intr);
     p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
-    /* get the list (checking is done by 'ELM_LIST')                       */
-    list = PopObj(intr);
+    // get the posobj (checking is done by 'ElmPosObj')
+    posobj = PopObj(intr);
 
-    /* get the element of the list                                         */
-    elm = ElmPosObj( list, p );
+    // get the element of the posobj
+    elm = ElmPosObj(posobj, p);
 
     /* push the element                                                    */
     PushObj(intr, elm);
@@ -3633,7 +3633,7 @@ void IntrElmPosObj(IntrState * intr)
 void IntrIsbPosObj(IntrState * intr)
 {
     Obj                 isb;            /* isbound, result                 */
-    Obj                 list;           /* list, left operand              */
+    Obj                 posobj;         // posobj, left operand
     Obj                 pos;            /* position, right operand         */
     Int                 p;              /* position, as C integer          */
 
@@ -3650,11 +3650,11 @@ void IntrIsbPosObj(IntrState * intr)
     pos = PopObj(intr);
     p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
-    /* get the list (checking is done by 'ISB_LIST')                       */
-    list = PopObj(intr);
+    // get the posobj (checking is done by 'IsbPosObj')
+    posobj = PopObj(intr);
 
     /* get the result                                                      */
-    isb = IsbPosObj( list, p ) ? True : False;
+    isb = IsbPosObj(posobj, p) ? True : False;
 
     /* push the result                                                     */
     PushObj(intr, isb);
@@ -3663,12 +3663,12 @@ void IntrIsbPosObj(IntrState * intr)
 
 /****************************************************************************
 **
-*F  IntrAssComObjName(<rnam>) . . . . . . .  interpret assignment to a record
-*F  IntrAssComObjExpr() . . . . . . . . . .  interpret assignment to a record
+*F  IntrAssComObjName(<rnam>) . . . . . . .  interpret assignment to a comobj
+*F  IntrAssComObjExpr() . . . . . . . . . .  interpret assignment to a comobj
 */
 void IntrAssComObjName(IntrState * intr, UInt rnam)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     Obj                 rhs;            /* rhs, right operand              */
 
     /* ignore or code                                                      */
@@ -3683,11 +3683,11 @@ void IntrAssComObjName(IntrState * intr, UInt rnam)
     /* get the right hand side                                             */
     rhs = PopObj(intr);
 
-    /* get the record (checking is done by 'ASS_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'AssComObj')
+    comobj = PopObj(intr);
 
-    /* assign the right hand side to the element of the record             */
-    AssComObj( record, rnam, rhs );
+    // assign the right hand side to the element of the comobj
+    AssComObj(comobj, rnam, rhs);
 
     /* push the assigned value                                             */
     PushObj(intr, rhs);
@@ -3695,7 +3695,7 @@ void IntrAssComObjName(IntrState * intr, UInt rnam)
 
 void IntrAssComObjExpr(IntrState * intr)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     UInt                rnam;           /* name, left operand              */
     Obj                 rhs;            /* rhs, right operand              */
 
@@ -3711,14 +3711,14 @@ void IntrAssComObjExpr(IntrState * intr)
     /* get the right hand side                                             */
     rhs = PopObj(intr);
 
-    /* get the name and convert it to a record name                        */
+    // get the name and convert it to a comobj name
     rnam = RNamObj(PopObj(intr));
 
-    /* get the record (checking is done by 'ASS_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'AssComObj')
+    comobj = PopObj(intr);
 
-    /* assign the right hand side to the element of the record             */
-    AssComObj( record, rnam, rhs );
+    // assign the right hand side to the element of the comobj
+    AssComObj(comobj, rnam, rhs);
 
     /* push the assigned value                                             */
     PushObj(intr, rhs);
@@ -3726,7 +3726,7 @@ void IntrAssComObjExpr(IntrState * intr)
 
 void IntrUnbComObjName(IntrState * intr, UInt rnam)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
 
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
@@ -3737,11 +3737,11 @@ void IntrUnbComObjName(IntrState * intr, UInt rnam)
     }
 
 
-    /* get the record (checking is done by 'UNB_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'UnbComObj')
+    comobj = PopObj(intr);
 
-    /* unbind the element of the record                                    */
-    UnbComObj( record, rnam );
+    // unbind the element of the comobj
+    UnbComObj(comobj, rnam);
 
     /* push void                                                           */
     PushVoidObj(intr);
@@ -3749,7 +3749,7 @@ void IntrUnbComObjName(IntrState * intr, UInt rnam)
 
 void IntrUnbComObjExpr(IntrState * intr)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     UInt                rnam;           /* name, left operand              */
 
     /* ignore or code                                                      */
@@ -3761,14 +3761,14 @@ void IntrUnbComObjExpr(IntrState * intr)
     }
 
 
-    /* get the name and convert it to a record name                        */
+    // get the name and convert it to a comobj name
     rnam = RNamObj(PopObj(intr));
 
-    /* get the record (checking is done by 'UNB_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'UnbComObj')
+    comobj = PopObj(intr);
 
-    /* unbind the element of the record                                    */
-    UnbComObj( record, rnam );
+    // unbind the element of the comobj
+    UnbComObj(comobj, rnam);
 
     /* push void                                                           */
     PushVoidObj(intr);
@@ -3777,13 +3777,13 @@ void IntrUnbComObjExpr(IntrState * intr)
 
 /****************************************************************************
 **
-*F  IntrElmComObjName(<rnam>) . . . . . . . . interpret selection of a record
-*F  IntrElmComObjExpr() . . . . . . . . . . . interpret selection of a record
+*F  IntrElmComObjName(<rnam>) . . . . . . . . interpret selection of a comobj
+*F  IntrElmComObjExpr() . . . . . . . . . . . interpret selection of a comobj
 */
 void IntrElmComObjName(IntrState * intr, UInt rnam)
 {
     Obj                 elm;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
 
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
@@ -3793,12 +3793,11 @@ void IntrElmComObjName(IntrState * intr, UInt rnam)
         return;
     }
 
+    // get the comobj (checking is done by 'ElmComObj')
+    comobj = PopObj(intr);
 
-    /* get the record (checking is done by 'ELM_REC')                      */
-    record = PopObj(intr);
-
-    /* select the element of the record                                    */
-    elm = ElmComObj( record, rnam );
+    // select the element of the comobj
+    elm = ElmComObj(comobj, rnam);
 
     /* push the element                                                    */
     PushObj(intr, elm);
@@ -3807,7 +3806,7 @@ void IntrElmComObjName(IntrState * intr, UInt rnam)
 void IntrElmComObjExpr(IntrState * intr)
 {
     Obj                 elm;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
@@ -3818,15 +3817,14 @@ void IntrElmComObjExpr(IntrState * intr)
         return;
     }
 
-
-    /* get the name and convert it to a record name                        */
+    // get the name and convert it to a comobj name
     rnam = RNamObj(PopObj(intr));
 
-    /* get the record (checking is done by 'ELM_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'ElmComObj')
+    comobj = PopObj(intr);
 
-    /* select the element of the record                                    */
-    elm = ElmComObj( record, rnam );
+    // select the element of the comobj
+    elm = ElmComObj(comobj, rnam);
 
     /* push the element                                                    */
     PushObj(intr, elm);
@@ -3835,7 +3833,7 @@ void IntrElmComObjExpr(IntrState * intr)
 void IntrIsbComObjName(IntrState * intr, UInt rnam)
 {
     Obj                 isb;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
 
     /* ignore or code                                                      */
     SKIP_IF_RETURNING();
@@ -3845,12 +3843,11 @@ void IntrIsbComObjName(IntrState * intr, UInt rnam)
         return;
     }
 
-
-    /* get the record (checking is done by 'ISB_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'IsbComObj')
+    comobj = PopObj(intr);
 
     /* get the result                                                      */
-    isb = IsbComObj( record, rnam ) ? True : False;
+    isb = IsbComObj(comobj, rnam) ? True : False;
 
     /* push the result                                                     */
     PushObj(intr, isb);
@@ -3859,7 +3856,7 @@ void IntrIsbComObjName(IntrState * intr, UInt rnam)
 void IntrIsbComObjExpr(IntrState * intr)
 {
     Obj                 isb;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
     UInt                rnam;           /* the name, right operand         */
 
     /* ignore or code                                                      */
@@ -3870,15 +3867,14 @@ void IntrIsbComObjExpr(IntrState * intr)
         return;
     }
 
-
-    /* get the name and convert it to a record name                        */
+    // get the name and convert it to a comobj name
     rnam = RNamObj(PopObj(intr));
 
-    /* get the record (checking is done by 'ISB_REC')                      */
-    record = PopObj(intr);
+    // get the comobj (checking is done by 'IsbComObj')
+    comobj = PopObj(intr);
 
     /* get the result                                                      */
-    isb = IsbComObj( record, rnam ) ? True : False;
+    isb = IsbComObj(comobj, rnam) ? True : False;
 
     /* push the result                                                     */
     PushObj(intr, isb);

--- a/src/vars.c
+++ b/src/vars.c
@@ -713,7 +713,7 @@ static ExecStatus ExecUnbList(Expr stat)
     Int narg;
     Int i;
 
-    /* evaluate the list (checking is done by 'LEN_LIST')                  */
+    /* evaluate the list (checking is done by 'UNB_LIST')                  */
     list = EVAL_EXPR(READ_STAT(stat, 0));
     narg = SIZE_STAT(stat)/sizeof(Stat) - 1;
     if (narg == 1) {
@@ -1439,20 +1439,20 @@ static void PrintIsbRecExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  ExecAssPosObj(<ass>)  . . . . . . . . . . .  assign to an element of a list
+*F  ExecAssPosObj(<ass>)  . . . . . . . . .  assign to an element of a posobj
 **
-**  'ExecAssPosObj'  executes the list  assignment statement <stat> of the form
-**  '<list>[<position>] := <rhs>;'.
+**  'ExecAssPosObj' executes the posobj assignment statement <stat> of the
+**  form '<posobj>[<position>] := <rhs>;'.
 */
 static ExecStatus ExecAssPosObj(Expr stat)
 {
-    Obj                 list;           /* list, left operand              */
+    Obj                 posobj;         // posobj, left operand
     Obj                 pos;            /* position, left operand          */
     Int                 p;              /* position, as a C integer        */
     Obj                 rhs;            /* right hand side, right operand  */
 
-    /* evaluate the list (checking is done by 'ASS_LIST')                  */
-    list = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate the posobj (checking is done by 'AssPosObj')
+    posobj = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
@@ -1461,8 +1461,8 @@ static ExecStatus ExecAssPosObj(Expr stat)
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
-    /* special case for plain list                                         */
-    AssPosObj(list, p, rhs);
+    // special case for plain posobj
+    AssPosObj(posobj, p, rhs);
 
     return STATUS_END;
 }
@@ -1470,26 +1470,26 @@ static ExecStatus ExecAssPosObj(Expr stat)
 
 /****************************************************************************
 **
-*F  ExecUnbPosObj(<ass>)  . . . . . . . . . . . . . unbind an element of a list
+*F  ExecUnbPosObj(<ass>)  . . . . . . . . . . . unbind an element of a posobj
 **
-**  'ExecUnbPosObj'  executes the list   unbind  statement <stat> of the   form
-**  'Unbind( <list>[<position>] );'.
+**  'ExecUnbPosObj' executes the posobj unbind statement <stat> of the form
+**  'Unbind( <posobj>[<position>] );'.
 */
 static ExecStatus ExecUnbPosObj(Expr stat)
 {
-    Obj                 list;           /* list, left operand              */
+    Obj                 posobj;         // posobj, left operand
     Obj                 pos;            /* position, left operand          */
     Int                 p;              /* position, as a C integer        */
 
-    /* evaluate the list (checking is done by 'LEN_LIST')                  */
-    list = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate the posobj (checking is done by 'UnbPosObj')
+    posobj = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_STAT(stat, 1));
     p = GetPositiveSmallIntEx("PosObj Assignment", pos, "<position>");
 
     /* unbind the element                                                  */
-    UnbPosObj(list, p);
+    UnbPosObj(posobj, p);
 
     return STATUS_END;
 }
@@ -1497,27 +1497,27 @@ static ExecStatus ExecUnbPosObj(Expr stat)
 
 /****************************************************************************
 **
-*F  EvalElmPosObj(<expr>) . . . . . . . . . . . . . select an element of a list
+*F  EvalElmPosObj(<expr>) . . . . . . . . . . . select an element of a posobj
 **
-**  'EvalElmPosObj' evaluates the list  element expression  <expr> of the  form
-**  '<list>[<position>]'.
+**  'EvalElmPosObj' evaluates the posobj element expression <expr> of the
+**  form '<posobj>[<position>]'.
 */
 static Obj EvalElmPosObj(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
-    Obj                 list;           /* list, left operand              */
+    Obj                 posobj;         // posobj, left operand
     Obj                 pos;            /* position, right operand         */
     Int                 p;              /* position, as C integer          */
 
-    /* evaluate the list (checking is done by 'ELM_LIST')                  */
-    list = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate the posobj (checking is done by 'ElmPosObj')
+    posobj = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
     p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
-    /* special case for plain lists (use generic code to signal errors)    */
-    elm = ElmPosObj(list, p);
+    // special case for plain posobjs (use generic code to signal errors)
+    elm = ElmPosObj(posobj, p);
 
     /* return the element                                                  */
     return elm;
@@ -1526,27 +1526,27 @@ static Obj EvalElmPosObj(Expr expr)
 
 /****************************************************************************
 **
-*F  EvalIsbPosObj(<expr>) . . . . . . . . test if an element of a list is bound
+*F  EvalIsbPosObj(<expr>) . . . . . . test if an element of a posobj is bound
 **
-**  'EvalElmPosObj'  evaluates the list  isbound expression  <expr> of the form
-**  'IsBound( <list>[<position>] )'.
+**  'EvalElmPosObj' evaluates the posobj isbound expression <expr> of the
+**  form 'IsBound( <posobj>[<position>] )'.
 */
 static Obj EvalIsbPosObj(Expr expr)
 {
     Obj                 isb;            /* isbound, result                 */
-    Obj                 list;           /* list, left operand              */
+    Obj                 posobj;         // posobj, left operand
     Obj                 pos;            /* position, right operand         */
     Int                 p;              /* position, as C integer          */
 
-    /* evaluate the list (checking is done by 'ISB_LIST')                  */
-    list = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate the posobj (checking is done by 'IsbPosObj')
+    posobj = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* evaluate and check the position                                     */
     pos = EVAL_EXPR(READ_EXPR(expr, 1));
     p = GetPositiveSmallIntEx("PosObj Element", pos, "<position>");
 
     /* get the result                                                      */
-    isb = IsbPosObj(list, p) ? True : False;
+    isb = IsbPosObj(posobj, p) ? True : False;
 
     return isb;
 }
@@ -1554,10 +1554,10 @@ static Obj EvalIsbPosObj(Expr expr)
 
 /****************************************************************************
 **
-*F  PrintAssPosObj(<stat>)  . . . . print an assignment to an element of a list
+*F  PrintAssPosObj(<stat>) . .  print an assignment to an element of a posobj
 **
-**  'PrintAssPosObj' prints the list  assignment statement  <stat> of the  form
-**  '<list>[<position>] := <rhs>;'.
+**  'PrintAssPosObj' prints the posobj assignment statement <stat> of the
+**  form '<posobj>[<position>] := <rhs>;'.
 **
 **  Linebreaks are preferred before the ':='.
 */
@@ -1587,10 +1587,10 @@ static void PrintUnbPosObj(Stat stat)
 
 /****************************************************************************
 **
-*F  PrintElmPosObj(<expr>)  . . . . . print a selection of an element of a list
+*F  PrintElmPosObj(<expr>) . . .  print a selection of an element of a posobj
 **
-**  'PrintElmPosObj'   prints the list element   expression  <expr> of the form
-**  '<list>[<position>]'.
+**  'PrintElmPosObj' prints the posobj element expression <expr> of the form
+**  '<posobj>[<position>]'.
 **
 **  Linebreaks are preferred after the '['.
 */
@@ -1617,19 +1617,19 @@ static void PrintIsbPosObj(Expr expr)
 
 /****************************************************************************
 **
-*F  ExecAssComObjName(<stat>) . . . . . . . .  assign to an element of a record
+*F  ExecAssComObjName(<stat>) . . . . . . .  assign to an element of a comobj
 **
-**  'ExecAssComObjName' executes the  record assignment statement <stat> of the
-**  form '<record>.<name> := <rhs>;'.
+**  'ExecAssComObjName' executes the comobj assignment statement <stat> of
+**  the form '<comobj>!.<name> := <rhs>;'.
 */
 static ExecStatus ExecAssComObjName(Stat stat)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     UInt                rnam;           /* name, left operand              */
     Obj                 rhs;            /* rhs, right operand              */
 
-    /* evaluate the record (checking is done by 'ASS_REC')                 */
-    record = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate the comobj (checking is done by 'AssComObj')
+    comobj = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
     rnam = READ_STAT(stat, 1);
@@ -1637,8 +1637,8 @@ static ExecStatus ExecAssComObjName(Stat stat)
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
-    /* assign the right hand side to the element of the record             */
-    AssComObj( record, rnam, rhs );
+    // assign the right hand side to the element of the comobj
+    AssComObj(comobj, rnam, rhs);
 
     return STATUS_END;
 }
@@ -1646,28 +1646,28 @@ static ExecStatus ExecAssComObjName(Stat stat)
 
 /****************************************************************************
 **
-*F  ExecAssComObjExpr(<stat>) . . . . . . . .  assign to an element of a record
+*F  ExecAssComObjExpr(<stat>) . . . . . . .  assign to an element of a comobj
 **
-**  'ExecAssComObjExpr' executes the record assignment  statement <stat> of the
-**  form '<record>.(<name>) := <rhs>;'.
+**  'ExecAssComObjExpr' executes the comobj assignment statement <stat> of
+**  the form '<comobj>.(<name>) := <rhs>;'.
 */
 static ExecStatus ExecAssComObjExpr(Stat stat)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     UInt                rnam;           /* name, left operand              */
     Obj                 rhs;            /* rhs, right operand              */
 
-    /* evaluate the record (checking is done by 'ASS_REC')                 */
-    record = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate the comobj (checking is done by 'AssComObj')
+    comobj = EVAL_EXPR(READ_STAT(stat, 0));
 
-    /* evaluate the name and convert it to a record name                   */
+    // evaluate the name and convert it to a comobj name
     rnam = RNamObj(EVAL_EXPR(READ_STAT(stat, 1)));
 
     /* evaluate the right hand side                                        */
     rhs = EVAL_EXPR(READ_STAT(stat, 2));
 
-    /* assign the right hand side to the element of the record             */
-    AssComObj( record, rnam, rhs );
+    // assign the right hand side to the element of the comobj
+    AssComObj(comobj, rnam, rhs);
 
     return STATUS_END;
 }
@@ -1675,24 +1675,24 @@ static ExecStatus ExecAssComObjExpr(Stat stat)
 
 /****************************************************************************
 **
-*F  ExecUnbComObjName(<stat>) . . . . . . . . . . unbind an element of a record
+*F  ExecUnbComObjName(<stat>) . . . . . . . . . unbind an element of a comobj
 **
-**  'ExecUnbComObjName' executes the record unbind statement <stat> of the form
-**  'Unbind( <record>.<name> );'.
+**  'ExecUnbComObjName' executes the comobj unbind statement <stat> of the
+**  form 'Unbind( <comobj>.<name> );'.
 */
 static ExecStatus ExecUnbComObjName(Stat stat)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     UInt                rnam;           /* name, left operand              */
 
-    /* evaluate the record (checking is done by 'UNB_REC')                 */
-    record = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate the comobj (checking is done by 'UnbComObj')
+    comobj = EVAL_EXPR(READ_STAT(stat, 0));
 
     /* get the name (stored immediately in the statement)                  */
     rnam = READ_STAT(stat, 1);
 
-    /* unbind the element of the record                                    */
-    UnbComObj( record, rnam );
+    // unbind the element of the comobj
+    UnbComObj(comobj, rnam);
 
     return STATUS_END;
 }
@@ -1700,24 +1700,24 @@ static ExecStatus ExecUnbComObjName(Stat stat)
 
 /****************************************************************************
 **
-*F  ExecUnbComObjExpr(<stat>) . . . . . . . . . . unbind an element of a record
+*F  ExecUnbComObjExpr(<stat>) . . . . . . . . . unbind an element of a comobj
 **
-**  'ExecUnbComObjExpr' executes the record unbind statement <stat> of the form
-**  'Unbind( <record>.(<name>) );'.
+**  'ExecUnbComObjExpr' executes the comobj unbind statement <stat> of the
+**  form 'Unbind( <comobj>.(<name>) );'.
 */
 static ExecStatus ExecUnbComObjExpr(Stat stat)
 {
-    Obj                 record;         /* record, left operand            */
+    Obj                 comobj;         // comobj, left operand
     UInt                rnam;           /* name, left operand              */
 
-    /* evaluate the record (checking is done by 'UNB_REC')                 */
-    record = EVAL_EXPR(READ_STAT(stat, 0));
+    // evaluate the comobj (checking is done by 'UnbComObj')
+    comobj = EVAL_EXPR(READ_STAT(stat, 0));
 
-    /* evaluate the name and convert it to a record name                   */
+    // evaluate the name and convert it to a comobj name
     rnam = RNamObj(EVAL_EXPR(READ_STAT(stat, 1)));
 
-    /* unbind the element of the record                                    */
-    UnbComObj( record, rnam );
+    // unbind the element of the comobj
+    UnbComObj(comobj, rnam);
 
     return STATUS_END;
 }
@@ -1725,25 +1725,25 @@ static ExecStatus ExecUnbComObjExpr(Stat stat)
 
 /****************************************************************************
 **
-*F  EvalElmComObjName(<expr>) . . . . . . . . . . . . . select a record element
+*F  EvalElmComObjName(<expr>) . . . . . . . . . . . . select a comobj element
 **
-**  'EvalElmComObjName' evaluates the  record element expression  <expr> of the
-**  form '<record>.<name>'.
+**  'EvalElmComObjName' evaluates the comobj element expression <expr> of the
+**  form '<comobj>.<name>'.
 */
 static Obj EvalElmComObjName(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
     UInt                rnam;           /* the name, right operand         */
 
-    /* evaluate the record (checking is done by 'ELM_REC')                 */
-    record = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate the comobj (checking is done by 'ElmComObj')
+    comobj = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
     rnam = READ_EXPR(expr, 1);
 
-    /* select the element of the record                                    */
-    elm = ElmComObj( record, rnam );
+    // select the element of the comobj
+    elm = ElmComObj(comobj, rnam);
 
     /* return the element                                                  */
     return elm;
@@ -1752,25 +1752,25 @@ static Obj EvalElmComObjName(Expr expr)
 
 /****************************************************************************
 **
-*F  EvalElmComObjExpr(<expr>) . . . . . . . . . . . . . select a record element
+*F  EvalElmComObjExpr(<expr>) . . . . . . . . . . . . select a comobj element
 **
-**  'EvalElmComObjExpr' evaluates the  record element expression  <expr> of the
-**  form '<record>.(<name>)'.
+**  'EvalElmComObjExpr' evaluates the comobj element expression <expr> of the
+**  form '<comobj>.(<name>)'.
 */
 static Obj EvalElmComObjExpr(Expr expr)
 {
     Obj                 elm;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
     UInt                rnam;           /* the name, right operand         */
 
-    /* evaluate the record (checking is done by 'ELM_REC')                 */
-    record = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate the comobj (checking is done by 'ElmComObj')
+    comobj = EVAL_EXPR(READ_EXPR(expr, 0));
 
-    /* evaluate the name and convert it to a record name                   */
+    // evaluate the name and convert it to a comobj name
     rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
-    /* select the element of the record                                    */
-    elm = ElmComObj( record, rnam );
+    // select the element of the comobj
+    elm = ElmComObj(comobj, rnam);
 
     /* return the element                                                  */
     return elm;
@@ -1779,25 +1779,25 @@ static Obj EvalElmComObjExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  EvalIsbComObjName(<expr>) . . . . . . . . test if a record element is bound
+*F  EvalIsbComObjName(<expr>) . . . . . . . test if a comobj element is bound
 **
-**  'EvalIsbComObjName' evaluates  the record isbound  expression <expr> of the
-**  form 'IsBound( <record>.<name> )'.
+**  'EvalIsbComObjName' evaluates the comobj isbound expression <expr> of the
+**  form 'IsBound( <comobj>.<name> )'.
 */
 static Obj EvalIsbComObjName(Expr expr)
 {
     Obj                 isb;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
     UInt                rnam;           /* the name, right operand         */
 
-    /* evaluate the record (checking is done by 'ISB_REC')                 */
-    record = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate the comobj (checking is done by 'IsbComObj')
+    comobj = EVAL_EXPR(READ_EXPR(expr, 0));
 
     /* get the name (stored immediately in the expression)                 */
     rnam = READ_EXPR(expr, 1);
 
-    /* select the element of the record                                    */
-    isb = IsbComObj( record, rnam ) ? True : False;
+    // select the element of the comobj
+    isb = IsbComObj(comobj, rnam) ? True : False;
 
     return isb;
 }
@@ -1805,25 +1805,25 @@ static Obj EvalIsbComObjName(Expr expr)
 
 /****************************************************************************
 **
-*F  EvalIsbComObjExpr(<expr>) . . . . . . . . test if a record element is bound
+*F  EvalIsbComObjExpr(<expr>) . . . . . . . test if a comobj element is bound
 **
-**  'EvalIsbComObjExpr'  evaluates the record isbound  expression <expr> of the
-**  form 'IsBound( <record>.(<name>) )'.
+**  'EvalIsbComObjExpr' evaluates the comobj isbound expression <expr> of the
+**  form 'IsBound( <comobj>.(<name>) )'.
 */
 static Obj EvalIsbComObjExpr(Expr expr)
 {
     Obj                 isb;            /* element, result                 */
-    Obj                 record;         /* the record, left operand        */
+    Obj                 comobj;         // the comobj, left operand
     UInt                rnam;           /* the name, right operand         */
 
-    /* evaluate the record (checking is done by 'ISB_REC')                 */
-    record = EVAL_EXPR(READ_EXPR(expr, 0));
+    // evaluate the comobj (checking is done by 'IsbComObj')
+    comobj = EVAL_EXPR(READ_EXPR(expr, 0));
 
-    /* evaluate the name and convert it to a record name                   */
+    // evaluate the name and convert it to a comobj name
     rnam = RNamObj(EVAL_EXPR(READ_EXPR(expr, 1)));
 
-    /* select the element of the record                                    */
-    isb = IsbComObj( record, rnam ) ? True : False;
+    // select the element of the comobj
+    isb = IsbComObj(comobj, rnam) ? True : False;
 
     return isb;
 }
@@ -1831,10 +1831,10 @@ static Obj EvalIsbComObjExpr(Expr expr)
 
 /****************************************************************************
 **
-*F  PrintAssComObjName(<stat>)  . print an assignment to an element of a record
+*F  PrintAssComObjName(<stat>) . print an assignment to an element of a comobj
 **
-**  'PrintAssComObjName' prints the  record assignment statement <stat>  of the
-**  form '<record>.<name> := <rhs>;'.
+**  'PrintAssComObjName' prints the comobj assignment statement <stat> of the
+**  form '<comobj>.<name> := <rhs>;'.
 */
 static void PrintAssComObjName(Stat stat)
 {
@@ -1862,10 +1862,10 @@ static void PrintUnbComObjName(Stat stat)
 
 /****************************************************************************
 **
-*F  PrintAssComObjExpr(<stat>)  . print an assignment to an element of a record
+*F  PrintAssComObjExpr(<stat>) . print an assignment to an element of a comobj
 **
-**  'PrintAssComObjExpr' prints the  record assignment statement <stat>  of the
-**  form '<record>.(<name>) := <rhs>;'.
+**  'PrintAssComObjExpr' prints the comobj assignment statement <stat> of the
+**  form '<comobj>.(<name>) := <rhs>;'.
 */
 static void PrintAssComObjExpr(Stat stat)
 {
@@ -1893,10 +1893,10 @@ static void PrintUnbComObjExpr(Stat stat)
 
 /****************************************************************************
 **
-*F  PrintElmComObjName(<expr>)  . . print a selection of an element of a record
+*F  PrintElmComObjName(<expr>) .  print a selection of an element of a comobj
 **
-**  'PrintElmComObjName' prints the  record  element expression <expr> of   the
-**  form '<record>.<name>'.
+**  'PrintElmComObjName' prints the comobj element expression <expr> of the
+**  form '<comobj>.<name>'.
 */
 static void PrintElmComObjName(Expr expr)
 {
@@ -1921,10 +1921,10 @@ static void PrintIsbComObjName(Expr expr)
 
 /****************************************************************************
 **
-*F  PrintElmComObjExpr(<expr>)  . . print a selection of an element of a record
+*F  PrintElmComObjExpr(<expr>) .  print a selection of an element of a comobj
 **
-**  'PrintElmComObjExpr' prints the record   element expression <expr>  of  the
-**  form '<record>.(<name>)'.
+**  'PrintElmComObjExpr' prints the comobj element expression <expr> of the
+**  form '<comobj>.(<name>)'.
 */
 static void PrintElmComObjExpr(Expr expr)
 {


### PR DESCRIPTION
The interpreter functions for positional and component objects clearly
were copied from those for lists and records and only slightly tweaked.
The comments and some variable names were not adjusted. This is somewhat
confusing when reading that code, which this patch addresses.

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
