### PR TITLE
minor improvement for `?Undocumented;`

### DIFF
--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -1187,6 +1187,9 @@ InstallGlobalFunction(HELP, function( str )
   local origstr, nwostr, p, book, books, move, add;
 
   origstr := ShallowCopy(str);
+  while Last( origstr ) = ';' do
+    Remove( origstr );
+  od;
   nwostr := NormalizedWhitespace(origstr);
   
   # extract the book


### PR DESCRIPTION
Up to now, GAP's reaction on `?Something` and `?Something;` are different when `Something` is an undocumented variable:

In the first situation, one gets a hint that the variable exists but is undocumented, whereas this hint is missing in the second situation.