### PR TITLE
Fix windows version used on github actions to windows-2019

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
   cygwin:
     name: "Create Windows ${{ matrix.arch }} installer"
     needs: unix
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       CHERE_INVOKING: 1
       GAP_BUILD_VERSION: ${{ needs.unix.outputs.gap-build-version }}


### PR DESCRIPTION
There are significant differences between windows-2019 and
windows-2022 (like InnoSetup not being installed by default),
and it is hard to work with both at the same time.


This should (hopefully!) make no difference, as we were already using windows-2019, but will stop the build breaking when windows-latest switches to windows-2022 by default (which currently doesn't work)