### PR TITLE
CI: use `windows-2019` in Cygwin test job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,7 +141,7 @@ jobs:
             test-suites: "testinstall"
             extra: "JULIA=yes CONFIGFLAGS=\"--enable-debug --disable-Werror\""
 
-          - os: windows-latest
+          - os: windows-2019
             # The 'run' steps in this job use Cygwin's bash, once it is set up.
             #   --login: make a login shell (so PATH is set up)
             #   -o igncr: Accept windows line endings


### PR DESCRIPTION
In #4745, @ChrisJefferson updated the 'Wrap releases' workflow to use `windows-2019` rather than `windows-latest` (which is currently `windows-2019`, but will still be `windows-2022`).

I approved and merged, but forgot that there was another Windows job, which runs the tests.

@ChrisJefferson should we change this one be `windows-2019` too?