### PR TITLE
CI: Upload code coverage for Windows build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -251,7 +251,6 @@ jobs:
         run: ${{ matrix.extra }} dev/ci-gather-coverage.sh
       - name: "Upload coverage data to Codecov"
         uses: codecov/codecov-action@v2
-        if: ${{ runner.os != 'Windows' }} # FIXME/HACK: skip this on Windows, it runs forever
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
I noticed the presence of a line stopping code coverage from being reported on the Windows build.

Let's remove this line to see if it works again.

This may let us close issue #4640, if it no longer persists.