### PR TITLE
Fix tab completion of partial names of record members

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -964,7 +964,7 @@ GAPInfo.CommandLineEditFunctions.Functions.Completion := function(l)
       r := fail;
       if Length(cmps) > 0 and cmps[1] in idbnd then
         r := ValueGlobal(cmps[1]);
-        for j in [2..Length(cmps)] do
+        for j in [2..Length(cmps)-1] do
           if not hasbang[j-1] and IsBound(r.(cmps[j])) then
             r := r.(cmps[j]);
           elif hasbang[j-1] and IsBound(r!.(cmps[j])) then


### PR DESCRIPTION
(the following is all in the commit message, as I wanted to describe what happened here)

Given a variable like "abc := rec(grape := 2);", we expect if we
type "abc.gr<tab>", then the single completion "grape" will be
suggested. Instead, before this commit we are suggested all global
variables which begin 'gr'.

Note that "abc.<tab>" did correctly suggest "grape", so only partial
completing was broken.

This was caused by an off-by-one error, where when steping through
the record members, we try finding the last member (which doesn't
exist).

This can't (currently) be sensibly tested.

Fixes github issue #4751
(more text follows)

This can't be tested (as far as I know) -- we do have some tests that test input/output, but I tried putting tabs into them and found that eeadline is too clever, and realises we are redirecting a file in so doesn't do tab completion.

I have tested, as much as I can, I haven't broken anything involving tab-completing records, but I'd be happy if at least one other people tried this PR and made sure everything seemed good (@wilfwilson ?)

