### PR TITLE
Fix regression in the tab completion code

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -942,7 +942,11 @@ GAPInfo.CommandLineEditFunctions.Functions.Completion := function(l)
     cf.tabcompnam := true;
     if cf.tabcount = 1 then
       # try to find name of component object
-      cmps := SplitString(l[3], ".");
+      i := pos;
+      while i > 0 and (l[3][i] in IdentifierLetters or l[3][i] in ".!") do
+        i := i-1;
+      od;
+      cmps := SplitString(l[3]{[i+1..pos]}, ".");
       hasbang := [];
       i := Length(cmps);
       while i > 0 do


### PR DESCRIPTION
This restores tab completion of record components to its
previous glory:

    gap> var := rec(member := true, data1 := 1, data2 := 2);;
    gap> var.d              # <TAB> completes to the next line:
    gap> var.data           # <TAB> again offers these completions:
    data1  data2
    gap> var.data

Also fixes this:

    gap> func(var.d         # <TAB>
    gap> func(var.data      # <TAB>
    data1  data2
    gap> func(var.data

Resolves #4751

Alternative to PR #4754 and hence closes #4754