### PR TITLE
Knuth-Bendix, Earns and some code cleanup

### DIFF
--- a/doc/ref/ctbl.xml
+++ b/doc/ref/ctbl.xml
@@ -492,7 +492,7 @@ yielding smaller spaces and several irreducible characters.
 <Example><![CDATA[
 gap> DixonSplit( d );
 #I  Matrix 2,Representative of Order 3,Centralizer: 5832
-#I  Dimensions: [ 1, 2, 1, 4, 12, 1, 1, 2, 1, 2, 1 ]
+#I  Dimensions: [ [ 1, 6 ], [ 2, 3 ], [ 4, 1 ], [ 12, 1 ] ]
 #I  Two-dim space split
 #I  Two-dim space split
 #I  Two-dim space split

--- a/lib/ctblgrp.gi
+++ b/lib/ctblgrp.gi
@@ -807,7 +807,7 @@ InstallGlobalFunction(SplitStep,function(D,bestMat)
     fi;
   od;
 
-  Info(InfoCharacterTable,1,"Dimensions: ",List(raeume,i->i.dim));
+  Info(InfoCharacterTable,1,"Dimensions: ",Collected(List(raeume,i->i.dim)));
   D.raeume:=raeume;
   return true;
 end);

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1904,6 +1904,7 @@ local isob,isos,iso,gens,u,a,rels,l,i,j,bgens,cb,cs,b,f,k,w,monoid,
   rels:=[];
   mytzf:=maketzf(rels);
 
+  directerr:=false;
   if newstyle then directerr:=true;fi;
 
   addrule:=function(rule)

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1650,8 +1650,8 @@ InstallMethod( Socle,"test primitive", true, [ IsPermGroup ], 0,
     
     # Affine groups first.
     L := Earns( G, Omega );
-    if L <> fail  then
-        return L;
+    if L <> []  then
+        return L[1];
     fi;
     
     deg := Length( Omega );

--- a/lib/kbsemi.gd
+++ b/lib/kbsemi.gd
@@ -131,3 +131,37 @@ DeclareGlobalFunction("ReduceWordUsingRewritingSystem");
 ##  </ManSection>
 ##
 DeclareAttribute( "TzRules", IsKnuthBendixRewritingSystem );
+
+# utility functions for identifying applicable rules through a DAG
+############################################################################
+##
+#F  EmptyKBDAG(<genids>)
+##
+## takes a list of generator id's (signed integers, used to check how far
+## indices have to be shifted) and returns a record that represents such
+## a DAG. 
+DeclareGlobalFunction("EmptyKBDAG");
+
+############################################################################
+##
+#F  AddRuleKBDAG(<dag>,<left>,<index>)
+##
+##  Adds rule with given left side to the DAG at given index position 
+DeclareGlobalFunction("AddRuleKBDAG");
+
+############################################################################
+##
+#F  DeleteRuleKBDAG(<dag>,<left>,<index>)
+##
+## removes a rule with given left side (sgtored at position <index> from the
+## DAG. Index numbers of all rules with higher index number will be shifted
+##  one down.
+DeclareGlobalFunction("DeleteRuleKBDAG");
+
+############################################################################
+##
+#F  RuleAtPosKBDAG(<dag>,<w>,<p>)
+##
+## returns the index position of the rule that applies at position <p> in
+##  word <w> (or `fail` if no rule applies.
+DeclareGlobalFunction("RuleAtPosKBDAG");

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2716,10 +2716,15 @@ end );
 ##
 #M  SetEarns( <G>, fail ) . . . . . . . . . . . . . . . . .  never set `fail'
 ##
-InstallOtherMethod( SetEarns,"never set fail",
-    true, [ IsGroup, IsBool ], 0,
-function( G, failval )
+# the following is the system setter for `Earns'.
+SET_EARNS := SETTER_FUNCTION(
+    "Earns", HasEarns );
+
+InstallOtherMethod( SetEarns,"deduce not primitive affine",
+    true, [ IsGroup, IsList and IsEmpty ], 0,
+function( G, emptylist )
     Setter( IsPrimitiveAffine )( G, false );
+    SET_EARNS(G,emptylist);
 end );
 
 
@@ -2732,7 +2737,7 @@ InstallMethod( IsPrimitiveAffine,"primitive and earns",
     OrbitsishReq, 0,
     function( G, D, gens, acts, act )
     return     IsPrimitive( G, D, gens, acts, act )
-           and Earns( G, D, gens, acts, act ) <> fail;
+           and Earns( G, D, gens, acts, act ) <> [];
 end );
 
 

--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -916,7 +916,7 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
 
     n := Length( D );
     if not IsPrimePowerInt( n )  then
-        return fail;
+        return [];
     elif not IsPrimitive( G, D )  then
         TryNextMethod();
     fi;
@@ -942,7 +942,7 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
 
     # If <G> is regular, it must be cyclic of prime order.
     if IsTrivial( G1 )  then
-        return G;
+        return [G];
     fi;
 
     # If <G> is not a Frobenius group ...
@@ -954,13 +954,13 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
                 Gamma := Filtered( D, p -> ForAll( GeneratorsOfGroup( G2 ),
                                  g -> p ^ g = p ) );
                 if PrimeDivisors( Length( Gamma ) ) <> [ p ]  then
-                    return fail;
+                    return [];
                 fi;
                 C := Centralizer( G, G2 );
                 f := ActionHomomorphism( C, Gamma,"surjective" );
                 P := PCore( ImagesSource( f ), p );
                 if not IsTransitive( P, [ 1 .. Length( Gamma ) ] )  then
-                    return fail;
+                    return [];
                 fi;
                 gens := [  ];
                 for gen  in GeneratorsOfGroup( Centre( P ) )  do
@@ -976,9 +976,9 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
                         if z <> One( C )  then
                             M := SolvableNormalClosurePermGroup( G, [ z ] );
                             if M <> fail  and  Size( M ) = n  then
-                                return M;
+                                return [M];
                             else
-                                return fail;
+                                return [];
                             fi;
                         fi;
                     od;
@@ -989,7 +989,7 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
                 # This is unnecessary  if   you trust the   classification of
                 # finite simple groups.
                 if Size( Q ) > p ^ ( d - 1 )  then
-                    return fail;
+                    return [];
                 fi;
 
                 R := ClosureGroup( Q, gens );
@@ -1004,10 +1004,10 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
                 for z  in Q0  do
                     M := SolvableNormalClosurePermGroup( G, [ y * z ] );
                     if M <> fail  and  Size( M ) = n  then
-                        return M;
+                        return [M];
                     fi;
                 od;
-                return fail;
+                return [];
             fi;
         fi;
     od;
@@ -1017,7 +1017,7 @@ InstallMethod( Earns, "G, ints, gens, perms, act", true,
     x := First( GeneratorsOfGroup( G ), gen -> alpha ^ gen <> alpha );
     z := Comm( a, a ^ x );
     M := SolvableNormalClosurePermGroup( G, [ z ] );
-    return M;
+    return [M];
 
 end );
 

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -1958,6 +1958,13 @@ InstallGlobalFunction( NextLevelRegularGroups, function( P, rbase )
     
 end );
 
+BindGlobal("STBCTEARNS",function(G,Omega)
+  G:=Earns(G,Omega);
+  if Length(G)=0 then return fail;
+  elif Length(G)=1 then return G[1];
+  else Error("more than one Earns");fi;
+end);
+
 #############################################################################
 ##
 #F  RBaseGroupsBloxPermGroup( ... ) . . . . .  opr. on groups respecting blox
@@ -2021,10 +2028,10 @@ InstallGlobalFunction( RBaseGroupsBloxPermGroup, function( repr, G, Omega, E, di
         AddGeneratorsExtendSchreierTree( rbase.regorb,
                 GeneratorsOfGroup( E ) );
     elif IsPrimitive( E, Omega )  then
-        reg := Earns( E, Omega );
+        reg := STBCTEARNS( E, Omega );
         if reg <> fail  then
             Info( InfoBckt, 1, "Subgroup is affine" );
-            rbase.reggrp := Earns;
+            rbase.reggrp := STBCTEARNS;
             rbase.regorb := EmptyStabChain( [  ], One( reg ),
                                     Omega[ 1 ] );
             AddGeneratorsExtendSchreierTree( rbase.regorb,

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -706,9 +706,9 @@ InstallMethod( TwoCohomologyGeneric,"generic, using rewriting system",true,
 function(G,mo)
 local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       len1,l2,m,start,formalinverse,hastail,one,zero,new,v1,v2,collectail,
-      findtail,colltz,mapped,mapped2,onemat,zerovec,dict,max,mal,s,p,genkill,
+      findtail,colltz,mapped,mapped2,onemat,zerovec,max,mal,s,p,genkill,
       c,nvars,htpos,zeroq,r,ogens,bds,model,q,pre,pcgs,miso,ker,solvec,rulpos,
-      nonone,predict,lenpre,jv,olen;
+      nonone,lenpre,jv,olen,dag;
 
 
   # collect the word in factor group
@@ -720,19 +720,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     while i<=Length(a) do
 
       # does a rule apply at position i?
-      j:=0;
-      s:=0;
-      mm:=Minimum(mal,Length(a)-i+1);
-      while j<mm do
-        s:=s*max+a[i+j];
-        if s<=lenpre then
-          p:=predict[s];
-        else
-          p:=LookupDictionary(dict,s);
-        fi;
-        if IsInt(p) then break; fi;
-        j:=j+1;
-      od;
+      p:=RuleAtPosKBDAG(dag,a,i);
 
       if IsInt(p) then
         a:=Concatenation(a{[1..i-1]},tzrules[p][2],
@@ -767,20 +755,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     while i<=Length(wrd) do
 
       # does a rule apply at position i?
-      j:=0;
-      s:=0;
-      mm:=Minimum(mal,Length(wrd)-i+1);
-      p:=true;
-      while j<mm and p<>fail do
-        s:=s*max+wrd[i+j];
-        if s<=lenpre then
-          p:=predict[s];
-        else
-          p:=LookupDictionary(dict,s);
-        fi;
-        if IsInt(p) and rulpos[p]<>fail then break; fi;
-        j:=j+1;
-      od;
+      p:=RuleAtPosKBDAG(dag,wrd,i);
 
       if IsInt(p) and rulpos[p]<>fail then
         p:=rulpos[p];
@@ -831,36 +806,11 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     tzrules:=List(RelationsOfFpMonoid(mon),x->List(x,LetterRepAssocWord));
 #  fi;
 
-  # build data structure to find rule applicable at given position. Assumes
-  # that rule set is reduced.
-  max:=Maximum(Union(List(tzrules,x->x[1])))+1;
+  dag:=EmptyKBDAG(Union(List(GeneratorsOfMonoid(FreeMonoidOfFpMonoid(mon)),
+    LetterRepAssocWord)));
   mal:=Maximum(List(tzrules,x->Length(x[1])));
-
-  # leaving out integers makes it a sort dictionary, which behaves better 
-  # for the few entries we typically look up
-  #dict:=NewDictionary(max,Integers,true);
-  dict:=NewDictionary(max,true); 
-  lenpre:=20000;
-  predict:=ListWithIdenticalEntries(lenpre,fail);
-  AddDictionary(dict,0,true);
-  for i in [1..mal] do
-    p:=Filtered([1..Length(tzrules)],x->Length(tzrules[x][1])=i);
-    for j in p do
-      s:=0;
-      for k in [1..i] do
-        s:=s*max+tzrules[j][1][k];
-        if k<i then
-          jv:=true;
-        else
-          jv:=j;
-        fi;
-        if s<=lenpre then
-          predict[s]:=jv;
-        else
-          AddDictionary(dict,s,jv);
-        fi;
-      od;
-    od;
+  for i in [1..Length(tzrules)] do
+    AddRuleKBDAG(dag,tzrules[i][1],i);
   od;
 
   gens:=List(GeneratorsOfGroup(FamilyObj(fpg)!.wholeGroup),
@@ -1130,19 +1080,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
     while i<=Length(wrd) do
 
       # does a rule apply at position i?
-      j:=0;
-      s:=0;
-      mm:=Minimum(mal,Length(wrd)-i+1);
-      while j<mm do
-        s:=s*max+wrd[i+j];
-        if s<=lenpre then
-          p:=predict[s];
-        else
-          p:=LookupDictionary(dict,s);
-        fi;
-        if IsInt(p) and rulpos[p]<>fail then break; fi;
-        j:=j+1;
-      od;
+      p:=RuleAtPosKBDAG(dag,wrd,i);
 
       if IsInt(p) and rulpos[p]<>fail then
         p:=rulpos[p];
@@ -1209,19 +1147,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,kb,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
       while i<=Length(wrd) do
 
         # does a rule apply at position i?
-        j:=0;
-        s:=0;
-        mm:=Minimum(mal,Length(wrd)-i+1);
-        while j<mm do
-          s:=s*max+wrd[i+j];
-          if s<=lenpre then
-            p:=predict[s];
-          else
-            p:=LookupDictionary(dict,s);
-          fi;
-          if IsInt(p) and rulpos[p]<>fail then break; fi;
-          j:=j+1;
-        od;
+        p:=RuleAtPosKBDAG(dag,wrd,i);
 
         if IsInt(p) and rulpos[p]<>fail then
           p:=rulpos[p];


### PR DESCRIPTION
Recent improvements:

- The Knuth-Bendix uses a DAG for identifying which rule could apply at a given position. This cleans up other ad-hoc improvements, resulting in shorter and cleaner code
- The requested fix for `Earns` to agree with its definition.
- `SubgroupConditionAbove` works for arbitrary groups, not just permutation groups
- `LowLayerSubgroups` uses orbit in favor of pairwise conjugacy, if this is a plausible approach.
- Info statement in Dixon-Schneider prints more compact information.
-  Clean up code duplication in compuattion of rewriting system for simple groups

## Text for release notes

As promised in the manual, Earns now always returns a list.
