### PR TITLE
changed a generic `OneSameMutability` method

### DIFF
--- a/lib/arith.gi
+++ b/lib/arith.gi
@@ -88,17 +88,21 @@ InstallOtherMethod( Zero,
 #T which takes less than 1 microsecond on my system.
 #T         Steve
 
+
+#############################################################################
+##
+#M  ZeroSameMutability( <obj> ) . . . . . . . . . . for an (immutable) object
+##
+##  This method is applicable for example to domains.
+##
 InstallOtherMethod( ZeroSameMutability,
     "for an (immutable) object",
     [ IsObject ],
-    function(elm)
-    local z;
-    if IsMutable( elm ) then
+    function( obj )
+    if IsMutable( obj ) then
       TryNextMethod();
     fi;
-    z:= ZeroAttr( elm );
-    MakeImmutable( z );
-    return z;
+    return ZeroAttr( obj );
     end );
 
 
@@ -295,17 +299,21 @@ InstallMethod( OneOp,
     return one;
     end );
 
+
+#############################################################################
+##
+#M  OneSameMutability( <obj> )  . . . . . . . . . . for an (immutable) object
+##
+##  This method is applicable for example to domains.
+##
 InstallOtherMethod( OneSameMutability,
     "for an (immutable) object",
     [ IsObject ],
-    function( elm )
-    local o;
-    if IsMutable( elm ) then
+    function( obj )
+    if IsMutable( obj ) then
       TryNextMethod();
     fi;
-    o:= OneMutable( elm );
-    MakeImmutable( o );
-    return o;
+    return OneImmutable( obj );
     end );
 
 

--- a/tst/teststandard/arith.tst
+++ b/tst/teststandard/arith.tst
@@ -1,0 +1,33 @@
+#@local x, D
+gap> START_TEST( "arith.tst" );
+
+# 'OneSameMutability' for mult. elements
+gap> for x in [ Z(2), [ [ 1 ] ], Immutable( [ [ 1 ] ] ) ] do
+>      if IsMutable( OneSameMutability( x ) ) <> IsMutable( x ) then
+>        Error( "result must have same mutability value" );
+>      fi;
+>    od;
+
+# 'OneSameMutability' for domains with one (result shall be immutable)
+gap> for D in [ SymmetricGroup(4), GL(2, 3), GF(2) ] do
+>      if IsMutable( OneSameMutability( D ) ) then
+>        Error( "result must be immutable" );
+>      fi;
+>    od;
+
+# 'ZeroSameMutability' for add. elements
+gap> for x in [ Z(2), [ [ 1 ] ], Immutable( [ [ 1 ] ] ) ] do
+>      if IsMutable( ZeroSameMutability( x ) ) <> IsMutable( x ) then
+>        Error( "result must have same mutability value" );
+>      fi;
+>    od;
+
+# 'ZeroSameMutability' for domains with zero (result shall be immutable)
+gap> for D in [ GF(2), GF(2)^2, GF(2)^[2, 2] ] do
+>      if IsMutable( ZeroSameMutability( D ) ) then
+>        Error( "result must be immutable" );
+>      fi;
+>    od;
+
+#
+gap> STOP_TEST( "arith.tst" );


### PR DESCRIPTION
Up to now, the lowest rank method for `OneSameMutability` called `OneMutable` and then `MakeImmutable` for an immutable argument.
This approach runs into a "no method found" error if the argument is a domain.
```
gap> OneSameMutability( GF(2) );
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `OneMutable' on 1 arguments
[...]
```
Note that the analogous situation for `ZeroImmutable` was different:
Here the lowest rank method calls `ZeroAttr` for an immutable argument.
(Calling `MakeImmutable` on the result seems to be superfluous.)
```
gap> ZeroSameMutability( GF(2) );
0*Z(2)
```
This asymmetry was observed in the context of the GAP-Oscar integration:
We had installed a method for the Oscar function `one` that delegates to GAP's `OneSameMutability` in the case that the argument is a GAP object, and analogously a `zero` method that delegates to `ZeroSameMutability`.
The latter works also for GAP domains, the former does not.

