### PR TITLE
kernel: rename several arithmetic functions for clarity

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -441,7 +441,7 @@ InstallMethod( ZeroOp, "for an 8 bit vector",
 
 #############################################################################
 ##
-#M  ZEROOp( <vec> )
+#M  ZeroSameMutability( <vec> )
 ##
 ##  A  zero vector of the same field and length and mutability
 ##

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -1005,12 +1005,12 @@ function( mat )
     if 0 < new[1]   then
         if  IsMutable(mat![2]) then
             for i in [ 1 .. new[1] ]  do
-                zero := ZERO(mat![2]);
+                zero := ZeroSameMutability(mat![2]);
                 SetFilterObj(zero, IsLockedRepresentationVector);
                 Add( new, zero );
             od;
         else
-            zero := ZERO(mat![2]);
+            zero := ZeroSameMutability(mat![2]);
             SetFilterObj(zero, IsLockedRepresentationVector);
             for i in [ 1 .. new[1] ]  do
                 Add( new, zero );

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -308,7 +308,7 @@ InstallMethod( ZeroOp,
 
 #############################################################################
 ##
-#M  ZEROOp( <gf2vec> )  . . . . . . . . . . . same mutability zero GF2 vector
+#M  ZeroSameMutability( <gf2vec> ) . . . . .  same mutability zero GF2 vector
 ##
 InstallMethod( ZeroSameMutability,
     "for GF2 vector, mutable",
@@ -988,10 +988,8 @@ end );
 
 #############################################################################
 ##
-#M  ZEROOp( <gf2mat> )  . . . . . . . . . . . . . . . matching mutability
+#M  ZeroSameMutability( <gf2mat> ) . . . . . . . . . . .  matching mutability
 ##
-##
-
 InstallMethod( ZeroSameMutability,
     "for GF2 Matrix",
     true,

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1540,7 +1540,7 @@ DeclareOperationKernel( "AdditiveInverseMutable",
 DeclareSynonym( "AdditiveInverseOp", AdditiveInverseMutable);
 
 DeclareOperationKernel( "AdditiveInverseSameMutability", 
-    [ IsAdditiveElementWithInverse ], AINV );
+    [ IsAdditiveElementWithInverse ], AINV_SAMEMUT );
 DeclareSynonym( "AdditiveInverseSM", AdditiveInverseSameMutability);
 
 

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1460,7 +1460,7 @@ DeclareOperationKernel( "ZeroMutable", [ IsAdditiveElementWithZero ],
 DeclareSynonym( "ZeroOp", ZeroMutable );
 
 DeclareOperationKernel( "ZeroSameMutability", [ IsAdditiveElementWithZero ],
-    ZERO );
+    ZERO_SAMEMUT );
 DeclareSynonym( "ZeroSM", ZeroSameMutability );
 
 

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1653,7 +1653,7 @@ DeclareOperationKernel( "OneMutable", [ IsMultiplicativeElementWithOne ],
 DeclareSynonym( "OneOp", OneMutable);
 
 DeclareOperationKernel( "OneSameMutability",
-    [ IsMultiplicativeElementWithOne ], ONE_MUT );
+    [ IsMultiplicativeElementWithOne ], ONE_SAMEMUT );
 DeclareSynonym( "OneSM", OneSameMutability);
 
 
@@ -1739,7 +1739,7 @@ DeclareOperationKernel( "InverseMutable",
 DeclareSynonym( "InverseOp", InverseMutable );
 
 DeclareOperationKernel( "InverseSameMutability",
-    [ IsMultiplicativeElementWithInverse ], INV_MUT );
+    [ IsMultiplicativeElementWithInverse ], INV_SAMEMUT );
 DeclareSynonym( "InverseSM", InverseSameMutability );
 
 

--- a/lib/arith.gi
+++ b/lib/arith.gi
@@ -68,16 +68,16 @@ InstallMethod( NestingDepthM,
 ##
 #M  Zero( <elm> ) . . . . . . . . . . . . . . . .  for an add.-elm.-with-zero
 ##
-##  `ZeroOp' guarantees that its results are *new* objects,
+##  `ZeroMutable' guarantees that its results are *new* objects,
 ##  so we may call `MakeImmutable'.
 #T This should be installed for `IsAdditiveElementWithZero',
 #T but at least in the compatibility mode we need it also for records ...
 ##
 InstallOtherMethod( Zero,
-    "for any object (call `ZERO')",
+    "for any object (call `ZeroMutable')",
     [ IsObject ],
     function( elm )
-    elm:= ZERO_MUT( elm );
+    elm:= ZeroMutable( elm );
     MakeImmutable( elm );
     return elm;
     end );
@@ -189,16 +189,16 @@ InstallMethod( IsZero,
 ##
 #M  AdditiveInverse( <elm> )
 ##
-##  `AdditiveInverseOp' guarantees that its results are *new* objects,
+##  `AdditiveInverseMutable' guarantees that its results are *new* objects,
 ##  so we may call `MakeImmutable'.
 #T This should be installed for `IsAdditiveElementWithInverse',
 #T but at least in the compatibility mode we need it also for records ...
 ##
 InstallOtherMethod( AdditiveInverse,
-    "for any object (call `AINV')",
+    "for any object (call `AdditiveInverseMutable')",
     [ IsObject ],
     function( elm )
-    elm:= AINV_MUT( elm );
+    elm:= AdditiveInverseMutable( elm );
     MakeImmutable( elm );
     return elm;
     end );
@@ -513,9 +513,9 @@ InstallMethod( LieBracket,
 ##
 ##  `PROD_INT_OBJ' is a kernel function that first checks whether <int> is
 ##  equal to one of
-##  `0' (then `ZERO' is called),
+##  `0' (then `ZeroSameMutability' is called),
 ##  `1' (then a copy of <elm> is returned), or
-##  `-1' (then `AINV' is called).
+##  `-1' (then `AdditiveInverseSameMutability' is called).
 ##  Otherwise if <int> is negative then the product of the additive inverses
 ##  of <int> and <elm> is computed,
 ##  where the product with positive <int> is formed by repeated doubling.

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -289,7 +289,7 @@ InstallMethod( IsZero,
     [ IsNullMapMatrix ],
     x -> true);
 
-InstallMethod( ZERO,
+InstallMethod( ZeroSameMutability,
     "for null map matrix",
     [ IsNullMapMatrix ],
     null -> null );
@@ -301,7 +301,7 @@ InstallMethod( \+,
     return null;
 end );
 
-InstallMethod( AINV,
+InstallMethod( AdditiveInverseSameMutability,
     "for a null map matrix",
     [ IsNullMapMatrix ],
     null -> null );

--- a/lib/obsolete.gi
+++ b/lib/obsolete.gi
@@ -1045,10 +1045,37 @@ function(G)
 end);
 
 
-
 #############################################################################
 ##
 #F  TmpNameAllArchs( )
 ##
 ##  Still used in guava (10/2019)
 DeclareObsoleteSynonym( "TmpNameAllArchs", "TmpName" );
+
+#############################################################################
+##
+#F  ZERO
+##
+##  Still used in Modules (02/2022)
+BindGlobal( "ZERO", ZeroSameMutability );
+
+#############################################################################
+##
+#F  AINV
+##
+##  Still used in corelg, float, fr, liering, qpa, quagroup (02/2022)
+BindGlobal( "AINV", AdditiveInverseSameMutability );
+
+#############################################################################
+##
+#F  ONE_MUT
+##
+##  Not used in any redistributed package (02/2022)
+BindGlobal( "ONE_MUT", OneSameMutability );
+
+#############################################################################
+##
+#F  INV_MUT
+##
+##  Still used in float (02/2022)
+BindGlobal( "INV_MUT", InverseSameMutability );

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -233,7 +233,7 @@ BIND_GLOBAL( "INSTALL_METHOD_FLAGS",
     elif IS_FUNCTION(rel)  then
         if CHECK_INSTALL_METHOD  then
             tmp := NARG_FUNC(rel);
-            if tmp < AINV(narg)-1 or (tmp >= 0 and tmp <> narg)   then
+            if tmp < -narg-1 or (tmp >= 0 and tmp <> narg)   then
                 Error(NAME_FUNC(opr),": <famrel> must accept ",
                       narg, " arguments");
             fi;
@@ -251,7 +251,7 @@ BIND_GLOBAL( "INSTALL_METHOD_FLAGS",
     elif IS_FUNCTION(method)  then
         if CHECK_INSTALL_METHOD and not IS_OPERATION( method ) then
             tmp := NARG_FUNC(method);
-            if tmp < AINV(narg)-1 or (tmp >= 0 and tmp <> narg)  then
+            if tmp < -narg-1 or (tmp >= 0 and tmp <> narg)  then
                Error(NAME_FUNC(opr),": <method> must accept ",
                      narg, " arguments");
             fi;

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -430,7 +430,7 @@ InstallMethod( ZeroOp, "for an 8 bit vector",
 
 #############################################################################
 ##
-#M  ZEROOp( <vec> )
+#M  ZeroSameMutability( <vec> )
 ##
 ##  A  zero vector of the same field and length and mutability
 ##

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1005,12 +1005,12 @@ function( mat )
     if 0 < new[1]   then
         if  IsMutable(mat![2]) then
             for i in [ 1 .. new[1] ]  do
-                zero := ZERO(mat![2]);
+                zero := ZeroSameMutability(mat![2]);
                 SetFilterObj(zero, IsLockedRepresentationVector);
                 Add( new, zero );
             od;
         else
-            zero := ZERO(mat![2]);
+            zero := ZeroSameMutability(mat![2]);
             SetFilterObj(zero, IsLockedRepresentationVector);
             for i in [ 1 .. new[1] ]  do
                 Add( new, zero );

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -308,7 +308,7 @@ InstallMethod( ZeroOp,
 
 #############################################################################
 ##
-#M  ZEROOp( <gf2vec> )  . . . . . . . . . . . same mutability zero GF2 vector
+#M  ZeroSameMutability( <gf2vec> ) . . . . .  same mutability zero GF2 vector
 ##
 InstallMethod( ZeroSameMutability,
     "for GF2 vector, mutable",
@@ -988,10 +988,8 @@ end );
 
 #############################################################################
 ##
-#M  ZEROOp( <gf2mat> )  . . . . . . . . . . . . . . . matching mutability
+#M  ZeroSameMutability( <gf2mat> ) . . . . . . . . . . .  matching mutability
 ##
-##
-
 InstallMethod( ZeroSameMutability,
     "for GF2 Matrix",
     true,

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -335,62 +335,62 @@ static Obj FuncONE(Obj self, Obj obj)
 
 /****************************************************************************
 **
-*V  OneMutFuncs[ <type> ]  . . . . .table of mutability retaining one methods
+*V  OneSameMut[ <type> ]  . . . . .table of mutability retaining one methods
 */
-ArithMethod1 OneMutFuncs [LAST_REAL_TNUM+1];
+ArithMethod1 OneSameMut[LAST_REAL_TNUM + 1];
 
 
 /****************************************************************************
 **
-*F  OneMutObject( <obj> )  . . . . . . . . . . . . . . . . . . . .  call methsel
+*F  OneSameMutObject( <obj> ) . . . . . . . . . . . . . . . . .  call methsel
 */
-static Obj OneMutOp;
+static Obj OneSameMutabilityOp;
 
-static Obj OneMutObject(Obj obj)
+static Obj OneSameMutObject(Obj obj)
 {
   Obj val;
-  val = DoOperation1Args( OneMutOp, obj );
-  RequireValue("ONEOp", val);
+  val = DoOperation1Args(OneSameMutabilityOp, obj);
+  RequireValue("OneSameMutability", val);
   return val;
 }
 
 
 /****************************************************************************
 **
-*F  VerboseOneMutObject( <obj> ) . . .  . . . . . . . . . . . .  call methsel
+*F  VerboseOneSameMutObject( <obj> ) . . . . . . . . . . . . . . call methsel
 */
-static Obj VerboseOneMutObject(Obj obj)
+static Obj VerboseOneSameMutObject(Obj obj)
 {
   Obj val;
-  val = DoVerboseOperation1Args( OneMutOp, obj );
-  RequireValue("ONEOp", val);
+  val = DoVerboseOperation1Args(OneSameMutabilityOp, obj);
+  RequireValue("OneSameMutability", val);
   return val;
 }
 
 
 /****************************************************************************
 **
-*F  InstallOneMutObject( <verb> )  . . . . . . . . . . . . . install one methods
+*F  InstallOneSameMutObject( <verb> ) . . . . . . . . . . install one methods
 */
-static void InstallOneMutObject ( Int verb )
+static void InstallOneSameMutObject(Int verb)
 {
     UInt                t1;             /* type of left  operand           */
     ArithMethod1        func;           /* one function                    */
 
-    func = ( verb ? VerboseOneMutObject : OneMutObject );
+    func = (verb ? VerboseOneSameMutObject : OneSameMutObject);
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
-        OneMutFuncs[t1] = func;
+        OneSameMut[t1] = func;
     }
 }
 
 
 /****************************************************************************
 **
-*F  FuncONE_MUT( <self>, <obj> ) . . . . . . . . . . . . . . . .call 'ONE_MUT'
+*F  FuncONE_SAMEMUT( <self>, <obj> ) . . . . . . . . . . . call 'ONE_SAMEMUT'
 */
-static Obj FuncONE_MUT(Obj self, Obj obj)
+static Obj FuncONE_SAMEMUT(Obj self, Obj obj)
 {
-    return ONE_MUT(obj);
+    return ONE_SAMEMUT(obj);
 }
 
 
@@ -457,62 +457,62 @@ static Obj FuncINV(Obj self, Obj obj)
 
 /****************************************************************************
 **
-*V  InvMutFuncs[ <type> ]  . table of mutability-preserving inverse functions
+*V  InvSameMutFuncs[ <type> ] . table of mutability-preserving inverse functions
 */
-ArithMethod1 InvMutFuncs [LAST_REAL_TNUM+1];
+ArithMethod1 InvSameMutFuncs[LAST_REAL_TNUM + 1];
 
-    
+
 /****************************************************************************
 **
-*F  InvMutObject( <obj> )  . . . . . . . . . . . . . . .. . . . .  call methsel
+*F  InvSameMutObject( <obj> ) . . . . . . . . . . . . . . . . .  call methsel
 */
-static Obj InvMutOp;
+static Obj InverseSameMutabilityOp;
 
-static Obj InvMutObject(Obj obj)
+static Obj InvSameMutObject(Obj obj)
 {
   Obj val;
-  val = DoOperation1Args( InvMutOp, obj );
-  RequireValue("INVOp", val);
+  val = DoOperation1Args(InverseSameMutabilityOp, obj);
+  RequireValue("InverseSameMutability", val);
   return val;
 }
 
 
 /****************************************************************************
 **
-*F  VerboseInvMutObject( <obj> ) . . .  . . . . . . . . . . . .  call methsel
+*F  VerboseInvSameMutObject( <obj> ) . . . . . . . . . . . . . . call methsel
 */
-static Obj VerboseInvMutObject(Obj obj)
+static Obj VerboseInvSameMutObject(Obj obj)
 {
   Obj val;
-  val = DoVerboseOperation1Args( InvMutOp, obj );
-  RequireValue("INVOp", val);
+  val = DoVerboseOperation1Args(InverseSameMutabilityOp, obj);
+  RequireValue("InverseSameMutability", val);
   return val;
 }
 
 
 /****************************************************************************
 **
-*F  InstallInvMutObject( <verb> ) install mutability preserving inverse methods
+*F  InstallInvSameMutObject( <verb> ) . install mutability preserving inverse methods
 */
-static void InstallInvMutObject ( Int verb )
+static void InstallInvSameMutObject(Int verb)
 {
     UInt                t1;             /* type of left  operand           */
     ArithMethod1        func;           /* inv function                    */
 
-    func = ( verb ? VerboseInvMutObject : InvMutObject );
+    func = (verb ? VerboseInvSameMutObject : InvSameMutObject);
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
-        InvMutFuncs[t1] = func;
+        InvSameMutFuncs[t1] = func;
     }
 }
 
 
 /****************************************************************************
 **
-*F  FuncINV_MUT( <self>, <obj> )  . . .  . . . . . . . . . .  call 'INV_MUT'
+*F  FuncINV_SAMEMUT( <self>, <obj> ) . . . . . . . . . . . call 'INV_SAMEMUT'
 */
-static Obj FuncINV_MUT(Obj self, Obj obj)
+static Obj FuncINV_SAMEMUT(Obj self, Obj obj)
 {
-    return INV_MUT( obj );
+    return INV_SAMEMUT(obj);
 }
 
 
@@ -965,7 +965,7 @@ ArithMethod2 QuoFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 static Obj QuoDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
-    tmp = INV_MUT( opR );
+    tmp = INV_SAMEMUT(opR);
     return PROD( opL, tmp );
 }
 
@@ -1052,7 +1052,7 @@ ArithMethod2 LQuoFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 static Obj LQuoDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
-    tmp = INV_MUT( opL );
+    tmp = INV_SAMEMUT(opL);
     return PROD( tmp, opR );
 }
 
@@ -1362,9 +1362,9 @@ DEFINE_OP_WRAPPER1(ZeroMutFuncs);
 DEFINE_OP_WRAPPER1(AInvFuncs);
 DEFINE_OP_WRAPPER1(AInvMutFuncs);
 DEFINE_OP_WRAPPER1(OneFuncs);
-DEFINE_OP_WRAPPER1(OneMutFuncs);
+DEFINE_OP_WRAPPER1(OneSameMut);
 DEFINE_OP_WRAPPER1(InvFuncs);
-DEFINE_OP_WRAPPER1(InvMutFuncs);
+DEFINE_OP_WRAPPER1(InvSameMutFuncs);
 
 DEFINE_OP_WRAPPER2(SumFuncs);
 DEFINE_OP_WRAPPER2(DiffFuncs);
@@ -1383,8 +1383,8 @@ static void InstallArithWrappers(void)
     INSTALL_OP_WRAPPER(AInvMutFuncs);
     INSTALL_OP_WRAPPER(OneFuncs);
     INSTALL_OP_WRAPPER(InvFuncs);
-    INSTALL_OP_WRAPPER(OneMutFuncs);
-    INSTALL_OP_WRAPPER(InvMutFuncs);
+    INSTALL_OP_WRAPPER(OneSameMut);
+    INSTALL_OP_WRAPPER(InvSameMutFuncs);
 
     INSTALL_OP_WRAPPER(SumFuncs);
     INSTALL_OP_WRAPPER(DiffFuncs);
@@ -1430,8 +1430,12 @@ void ChangeArithDoOperations(Obj oper, Int verb)
     if ( oper == AInvOp )  { InstallAInvObject(verb); }
     if ( oper == ZEROOp )  { InstallZeroObject(verb); }
 
-    if ( oper == InvMutOp  )  { InstallInvMutObject(verb);  }
-    if ( oper == OneMutOp  )  { InstallOneMutObject(verb);  }
+    if (oper == InverseSameMutabilityOp) {
+        InstallInvSameMutObject(verb);
+    }
+    if (oper == OneSameMutabilityOp) {
+        InstallOneSameMutObject(verb);
+    }
     if ( oper == AdditiveInverseOp )  { InstallAInvMutObject(verb); }
     if ( oper == ZeroOp )  { InstallZeroMutObject(verb); }
 }
@@ -1446,7 +1450,7 @@ void ChangeArithDoOperations(Obj oper, Int verb)
 **
 *V  GVarOpers . . . . . . . . . . . . . . . . .  list of operations to export
 */
-static StructGVarOper GVarOpers [] = {
+static StructGVarOper GVarOpers[] = {
 
     GVAR_OPER_2ARGS(EQ, opL, opR, &EqOper),
     GVAR_OPER_2ARGS(LT, opL, opR, &LtOper),
@@ -1464,9 +1468,9 @@ static StructGVarOper GVarOpers [] = {
     GVAR_OPER_1ARGS(AINV, op, &AInvOp),
     GVAR_OPER_1ARGS(AINV_MUT, op, &AdditiveInverseOp),
     GVAR_OPER_1ARGS(ONE, op, &OneOp),
-    GVAR_OPER_1ARGS(ONE_MUT, op, &OneMutOp),
+    GVAR_OPER_1ARGS(ONE_SAMEMUT, op, &OneSameMutabilityOp),
     GVAR_OPER_1ARGS(INV, op, &InvOp),
-    GVAR_OPER_1ARGS(INV_MUT, op, &InvMutOp),
+    GVAR_OPER_1ARGS(INV_SAMEMUT, op, &InverseSameMutabilityOp),
     { 0, 0, 0, 0, 0, 0 }
 
 };
@@ -1541,10 +1545,10 @@ static Int InitKernel (
 
     /* make and install the 'ONE' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(OneMutFuncs[t1] == 0);
-        OneMutFuncs[t1] = OneMutObject;
+        assert(OneSameMut[t1] == 0);
+        OneSameMut[t1] = OneSameMutObject;
     }
-    InstallOneMutObject(0);
+    InstallOneSameMutObject(0);
 
     /* make and install the 'INV' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
@@ -1555,10 +1559,10 @@ static Int InitKernel (
 
     /* make and install the 'INV' arithmetic operation                     */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(InvMutFuncs[t1] == 0);
-        InvMutFuncs[t1] = InvMutObject;
+        assert(InvSameMutFuncs[t1] == 0);
+        InvSameMutFuncs[t1] = InvSameMutObject;
     }
-    InstallInvMutObject(0);
+    InstallInvSameMutObject(0);
 
     /* make and install the 'EQ' comparison operation                      */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -33,64 +33,62 @@
 
 /****************************************************************************
 **
-*V  ZeroFuncs[ <type> ] . . . . . . . . . . . . . . . . table of zero methods
+*V  ZeroSameMutFuncs[ <type> ] . . . . . . . . . . . .  table of zero methods
 */
-ArithMethod1 ZeroFuncs [LAST_REAL_TNUM+1];
+ArithMethod1 ZeroSameMutFuncs[LAST_REAL_TNUM + 1];
 
 
 /****************************************************************************
 **
-*F  ZeroObject( <obj> ) . . . . . . . . . . . . . . . . . . . .  call methsel
+*F  ZeroSameMutObject( <obj> ) . . . . . . . . . . . . . . . . . call methsel
 */
-static Obj ZEROOp;
+static Obj ZeroSameMutabilityOp;
 
-static Obj ZeroObject(Obj obj)
-
+static Obj ZeroSameMutObject(Obj obj)
 {
-  Obj val;
-  val = DoOperation1Args( ZEROOp, obj );
-  RequireValue("ZEROOp", val);
-  return val;
+    Obj val;
+    val = DoOperation1Args(ZeroSameMutabilityOp, obj);
+    RequireValue("ZeroSameMutability", val);
+    return val;
 }
 
 
 /****************************************************************************
 **
-*F  VerboseZeroObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
+*F  VerboseZeroSameMutObject( <obj> ) . . . . . . . . .  call verbose methsel
 */
-static Obj VerboseZeroObject(Obj obj)
-
+static Obj VerboseZeroSameMutObject(Obj obj)
 {
-  Obj val;
-  val = DoVerboseOperation1Args( ZEROOp, obj );
-  RequireValue("ZEROOp", val);
-  return val;
+    Obj val;
+    val = DoVerboseOperation1Args(ZeroSameMutabilityOp, obj);
+    RequireValue("ZeroSameMutability", val);
+    return val;
 }
 
 
 /****************************************************************************
 **
-*F  InstallZeroObject( <verb> ) . . . . . . . . . . . .  install zero methods
+*F  InstallZeroSameMutObject( <verb> ) . . . . . . . . . install zero methods
 */
-static void InstallZeroObject ( Int verb )
+static void InstallZeroSameMutObject(Int verb)
 {
     UInt                t1;             /* type of left  operand           */
     ArithMethod1        func;           /* zero function                   */
 
-    func = ( verb ? VerboseZeroObject : ZeroObject );
+    func = (verb ? VerboseZeroSameMutObject : ZeroSameMutObject);
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
-        ZeroFuncs[t1] = func;
+        ZeroSameMutFuncs[t1] = func;
     }
 }
 
 
 /****************************************************************************
 **
-*F  FuncZERO( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'ZERO'
+*F  FuncZERO_SAMEMUT( <self>, <obj> ) . . . . . . . . . . call 'ZERO_SAMEMUT'
 */
-static Obj FuncZERO(Obj self, Obj obj)
+static Obj FuncZERO_SAMEMUT(Obj self, Obj obj)
 {
-    return ZERO(obj);
+    return ZERO_SAMEMUT(obj);
 }
 
 /****************************************************************************
@@ -102,7 +100,7 @@ ArithMethod1 ZeroMutFuncs [LAST_REAL_TNUM+1];
 
 /****************************************************************************
 **
-*F  ZeroMutObject( <obj> ) . . . . . . . . . . . . . . . . . . . .  call methsel
+*F  ZeroMutObject( <obj> ) . . . . . . . . . . . . . . . . . . . call methsel
 */
 static Obj ZeroOp;
 
@@ -118,7 +116,7 @@ static Obj ZeroMutObject(Obj obj)
 
 /****************************************************************************
 **
-*F  VerboseZeroMutObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
+*F  VerboseZeroMutObject( <obj> ) . . . . . . . . . . .  call verbose methsel
 */
 static Obj VerboseZeroMutObject(Obj obj)
 
@@ -1357,7 +1355,7 @@ static void InstallModObject ( Int verb )
     }
 }
 
-DEFINE_OP_WRAPPER1(ZeroFuncs);
+DEFINE_OP_WRAPPER1(ZeroSameMutFuncs);
 DEFINE_OP_WRAPPER1(ZeroMutFuncs);
 DEFINE_OP_WRAPPER1(AInvFuncs);
 DEFINE_OP_WRAPPER1(AInvMutFuncs);
@@ -1377,7 +1375,7 @@ DEFINE_OP_WRAPPER2(ModFuncs);
 
 static void InstallArithWrappers(void)
 {
-    INSTALL_OP_WRAPPER(ZeroFuncs);
+    INSTALL_OP_WRAPPER(ZeroSameMutFuncs);
     INSTALL_OP_WRAPPER(ZeroMutFuncs);
     INSTALL_OP_WRAPPER(AInvFuncs);
     INSTALL_OP_WRAPPER(AInvMutFuncs);
@@ -1428,8 +1426,9 @@ void ChangeArithDoOperations(Obj oper, Int verb)
     if ( oper == InvOp  )  { InstallInvObject(verb);  }
     if ( oper == OneOp  )  { InstallOneObject(verb);  }
     if ( oper == AInvOp )  { InstallAInvObject(verb); }
-    if ( oper == ZEROOp )  { InstallZeroObject(verb); }
-
+    if (oper == ZeroSameMutabilityOp) {
+        InstallZeroSameMutObject(verb);
+    }
     if (oper == InverseSameMutabilityOp) {
         InstallInvSameMutObject(verb);
     }
@@ -1463,7 +1462,7 @@ static StructGVarOper GVarOpers[] = {
     GVAR_OPER_2ARGS(POW, opL, opR, &PowOper),
     GVAR_OPER_2ARGS(COMM, opL, opR, &CommOper),
     GVAR_OPER_2ARGS(MOD, opL, opR, &ModOper),
-    GVAR_OPER_1ARGS(ZERO, op, &ZEROOp),
+    GVAR_OPER_1ARGS(ZERO_SAMEMUT, op, &ZeroSameMutabilityOp),
     GVAR_OPER_1ARGS(ZERO_MUT, op, &ZeroOp),
     GVAR_OPER_1ARGS(AINV, op, &AInvOp),
     GVAR_OPER_1ARGS(AINV_MUT, op, &AdditiveInverseOp),
@@ -1508,12 +1507,12 @@ static Int InitKernel (
 
     InstallArithWrappers();
 
-    /* make and install the 'ZERO' arithmetic operation                    */
+    /* make and install the 'ZERO_SAMEMUT' arithmetic operation            */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(ZeroFuncs[t1] == 0);
-        ZeroFuncs[t1] = ZeroObject;
+        assert(ZeroSameMutFuncs[t1] == 0);
+        ZeroSameMutFuncs[t1] = ZeroSameMutObject;
     }
-    InstallZeroObject(0);
+    InstallZeroSameMutObject(0);
 
     /* make and install the 'ZERO_MUT' arithmetic operation                */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {

--- a/src/ariths.c
+++ b/src/ariths.c
@@ -156,11 +156,12 @@ static Obj FuncZERO_MUT(Obj self, Obj obj)
 
 /****************************************************************************
 **
-*V  AInvFuncs[ <type> ] . . . . . . . . . . table of additive inverse methods
-*V  AInvMutFuncs[ <type> ] . .  . . . . . . table of additive inverse methods
+*V  AInvSameMutFuncs[ <type> ] . . . . . .  table of additive inverse methods
+**                                          which preserve mutability
+*V  AInvMutFuncs[ <type> ] . . . . . . . .  table of additive inverse methods
 **                                          which return mutable results
 */
-ArithMethod1 AInvFuncs [LAST_REAL_TNUM+1];
+ArithMethod1 AInvSameMutFuncs[LAST_REAL_TNUM + 1];
 ArithMethod1 AInvMutFuncs[ LAST_REAL_TNUM + 1];
 
 
@@ -168,58 +169,58 @@ ArithMethod1 AInvMutFuncs[ LAST_REAL_TNUM + 1];
 **
 *F  AInvObj( <obj> )  . . . . . . . . . . . . . . . . . . . . .  call methsel
 */
-static Obj AInvOp;
+static Obj AdditiveInverseSameMutabilityOp;
 
-static Obj AInvObject(Obj obj)
+static Obj AInvSameMutObject(Obj obj)
 {
-  Obj val;
-  val = DoOperation1Args( AInvOp, obj );
-  RequireValue("AInvOp", val);
-  return val;
+    Obj val;
+    val = DoOperation1Args(AdditiveInverseSameMutabilityOp, obj);
+    RequireValue("AdditiveInverseSameMutability", val);
+    return val;
 }
 
 
 /****************************************************************************
 **
-*F  VerboseAInvObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
+*F  VerboseAInvSameMutObject( <obj> ) . . . . . . . . .  call verbose methsel
 */
-static Obj VerboseAInvObject(Obj obj)
+static Obj VerboseAInvSameMutObject(Obj obj)
 {
-  Obj val;
-  val = DoVerboseOperation1Args( AInvOp, obj );
-  RequireValue("AInvOp", val);
-  return val;
+    Obj val;
+    val = DoVerboseOperation1Args(AdditiveInverseSameMutabilityOp, obj);
+    RequireValue("AdditiveInverseSameMutability", val);
+    return val;
 }
 
 
 /****************************************************************************
 **
-*F  InstallAInvObject( <verb> ) . . . . . .  install additive inverse methods
+*F  InstallAInvSameMutObject( <verb> ) . . . install additive inverse methods
 */
-static void InstallAInvObject(Int verb)
+static void InstallAInvSameMutObject(Int verb)
 {
     UInt                t1;             /* type of left  operand           */
     ArithMethod1        func;           /* ainv function                   */
 
-    func = ( verb ? VerboseAInvObject : AInvObject );
+    func = (verb ? VerboseAInvSameMutObject : AInvSameMutObject);
     for ( t1 = FIRST_EXTERNAL_TNUM; t1 <= LAST_EXTERNAL_TNUM; t1++ ) {
-        AInvFuncs[t1] = func;
+        AInvSameMutFuncs[t1] = func;
     }
 }
 
 
 /****************************************************************************
 **
-*F  FuncAINV( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'AINV'
+*F  FuncAINV_SAMEMUT( <self>, <obj> ) . . . . . . . . . .  call 'AINV_SAMEMUT'
 */
-static Obj FuncAINV(Obj self, Obj obj)
+static Obj FuncAINV_SAMEMUT(Obj self, Obj obj)
 {
-    return AINV(obj);
+    return AINV_SAMEMUT(obj);
 }
 
 /****************************************************************************
 **
-*F  AInvMutObject( <obj> )  . .. . . . . . . . . . . . . . . . .  call methsel
+*F  AInvMutObject( <obj> ) . . . . . . . . . . . . . . . . . . . call methsel
 */
 static Obj AdditiveInverseOp;
 
@@ -234,7 +235,7 @@ static Obj AInvMutObject(Obj obj)
 
 /****************************************************************************
 **
-*F  VerboseAInvMutObject( <obj> )  . . . . . . . . . . . .  call verbose methsel
+*F  VerboseAInvMutObject( <obj> )  . . . . . . . . . . . call verbose methsel
 */
 static Obj VerboseAInvMutObject(Obj obj)
 {
@@ -263,7 +264,7 @@ static void InstallAInvMutObject(Int verb)
 
 /****************************************************************************
 **
-*F  FuncAINV_MUT( <self>, <obj> ) . . . . . . . . . . . . . . . . . . call 'AINV'
+*F  FuncAINV_MUT( <self>, <obj> ) . . . . . . . . . . . . . . call 'AINV_MUT'
 */
 static Obj FuncAINV_MUT(Obj self, Obj obj)
 {
@@ -805,13 +806,13 @@ ArithMethod2 DiffFuncs [LAST_REAL_TNUM+1][LAST_REAL_TNUM+1];
 
 /****************************************************************************
 **
-*F  DiffDefault( <opL>, <opR> ) . . . . . . . . . . . . call 'SUM' and 'AINV'
+*F  DiffDefault( <opL>, <opR> ) . . . . . . . . call 'SUM' and 'AINV_SAMEMUT'
 */
 static Obj DiffDefault(Obj opL, Obj opR)
 {
     Obj                 tmp;
 
-    tmp = AINV( opR );
+    tmp = AINV_SAMEMUT(opR);
     return SUM( opL, tmp );
 }
 
@@ -1357,7 +1358,7 @@ static void InstallModObject ( Int verb )
 
 DEFINE_OP_WRAPPER1(ZeroSameMutFuncs);
 DEFINE_OP_WRAPPER1(ZeroMutFuncs);
-DEFINE_OP_WRAPPER1(AInvFuncs);
+DEFINE_OP_WRAPPER1(AInvSameMutFuncs);
 DEFINE_OP_WRAPPER1(AInvMutFuncs);
 DEFINE_OP_WRAPPER1(OneFuncs);
 DEFINE_OP_WRAPPER1(OneSameMut);
@@ -1377,7 +1378,7 @@ static void InstallArithWrappers(void)
 {
     INSTALL_OP_WRAPPER(ZeroSameMutFuncs);
     INSTALL_OP_WRAPPER(ZeroMutFuncs);
-    INSTALL_OP_WRAPPER(AInvFuncs);
+    INSTALL_OP_WRAPPER(AInvSameMutFuncs);
     INSTALL_OP_WRAPPER(AInvMutFuncs);
     INSTALL_OP_WRAPPER(OneFuncs);
     INSTALL_OP_WRAPPER(InvFuncs);
@@ -1425,7 +1426,9 @@ void ChangeArithDoOperations(Obj oper, Int verb)
 
     if ( oper == InvOp  )  { InstallInvObject(verb);  }
     if ( oper == OneOp  )  { InstallOneObject(verb);  }
-    if ( oper == AInvOp )  { InstallAInvObject(verb); }
+    if (oper == AdditiveInverseSameMutabilityOp) {
+        InstallAInvSameMutObject(verb);
+    }
     if (oper == ZeroSameMutabilityOp) {
         InstallZeroSameMutObject(verb);
     }
@@ -1464,7 +1467,7 @@ static StructGVarOper GVarOpers[] = {
     GVAR_OPER_2ARGS(MOD, opL, opR, &ModOper),
     GVAR_OPER_1ARGS(ZERO_SAMEMUT, op, &ZeroSameMutabilityOp),
     GVAR_OPER_1ARGS(ZERO_MUT, op, &ZeroOp),
-    GVAR_OPER_1ARGS(AINV, op, &AInvOp),
+    GVAR_OPER_1ARGS(AINV_SAMEMUT, op, &AdditiveInverseSameMutabilityOp),
     GVAR_OPER_1ARGS(AINV_MUT, op, &AdditiveInverseOp),
     GVAR_OPER_1ARGS(ONE, op, &OneOp),
     GVAR_OPER_1ARGS(ONE_SAMEMUT, op, &OneSameMutabilityOp),
@@ -1521,12 +1524,12 @@ static Int InitKernel (
     }
     InstallZeroMutObject(0);
 
-    /* make and install the 'AINV' arithmetic operation                    */
+    /* make and install the 'AINV_SAMEMUT' arithmetic operation            */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {
-        assert(AInvFuncs[t1] == 0);
-        AInvFuncs[t1] = AInvObject;
+        assert(AInvSameMutFuncs[t1] == 0);
+        AInvSameMutFuncs[t1] = AInvSameMutObject;
     }
-    InstallAInvObject(0);
+    InstallAInvSameMutObject(0);
 
     /* make and install the 'AINV_MUT' arithmetic operation                */
     for ( t1 = FIRST_REAL_TNUM;  t1 <= LAST_REAL_TNUM;  t1++ ) {

--- a/src/ariths.h
+++ b/src/ariths.h
@@ -55,21 +55,22 @@ typedef Obj (* ArithMethod2) ( Obj opL, Obj opR );
 
 /****************************************************************************
 **
-*V  ZeroFuncs[<type>] . . . . . . . . . . . . . . . . . table of zero methods
+*V  ZeroSameMutFuncs[<type>] . . . . . . . . . . . . . .table of zero methods
 */
-extern ArithMethod1 ZeroFuncs[LAST_REAL_TNUM + 1];
+extern ArithMethod1 ZeroSameMutFuncs[LAST_REAL_TNUM + 1];
 
 
 /****************************************************************************
 **
-*F  ZERO( <op> )  . . . . . . . . . . . . . . . . . . . . . zero of an object
+*F  ZERO_SAMEMUT( <op> ) . . . . . . . zero of an object retaining mutability
 **
-**  'ZERO' returns the zero of the object <op>.
+**  'ZERO_SAMEMUT' returns the zero of the object <op> with the same
+**  mutability level as <op>
 */
-EXPORT_INLINE Obj ZERO(Obj op)
+EXPORT_INLINE Obj ZERO_SAMEMUT(Obj op)
 {
     UInt tnum = TNUM_OBJ(op);
-    return (*ZeroFuncs[tnum])(op);
+    return (*ZeroSameMutFuncs[tnum])(op);
 }
 
 

--- a/src/ariths.h
+++ b/src/ariths.h
@@ -180,22 +180,22 @@ EXPORT_INLINE Obj ONE(Obj op)
 
 /****************************************************************************
 **
-*V  OneMutFuncs[<type>]  . . . . . .table of mutability preservingone methods
+*V  OneSameMut[<type>] . . . . . . table of mutability preserving one methods
 */
-extern ArithMethod1 OneMutFuncs[LAST_REAL_TNUM + 1];
+extern ArithMethod1 OneSameMut[LAST_REAL_TNUM + 1];
 
 
 /****************************************************************************
 **
-*F  ONE_MUT( <op> )    . . . . . . . .  one of an object retaining mutability
+*F  ONE_SAMEMUT( <op> ) . . . . . . . . one of an object retaining mutability
 **
-**  'ONE_MUT' returns the one of the object <op> with the same
+**  'ONE_SAMEMUT' returns the one of the object <op> with the same
 **  mutability level as <op>.
 */
-EXPORT_INLINE Obj ONE_MUT(Obj op)
+EXPORT_INLINE Obj ONE_SAMEMUT(Obj op)
 {
     UInt tnum = TNUM_OBJ(op);
-    return (*OneMutFuncs[tnum])(op);
+    return (*OneSameMut[tnum])(op);
 }
 
 
@@ -221,21 +221,22 @@ EXPORT_INLINE Obj INV(Obj op)
 
 /****************************************************************************
 **
-*V  InvMutFuncs[<type>]  .. .table of mutability preserving inverse functions
+*V  InvSameMutFuncs[<type>]  table of mutability preserving inverse functions
 */
-extern ArithMethod1 InvMutFuncs[LAST_REAL_TNUM + 1];
+extern ArithMethod1 InvSameMutFuncs[LAST_REAL_TNUM + 1];
 
 
 /****************************************************************************
 **
-*F  INV_MUT( <op> ) . . . . . . . . inverse of an object retaining mutability
+*F  INV_SAMEMUT( <op> ) . . . . . . inverse of an object retaining mutability
 **
-**  'INV_MUT' returns the multiplicative inverse of the object <op>.
+**  'INV_SAMEMUT' returns the multiplicative inverse of the object <op> with
+**  the same mutability level as <op>.
 */
-EXPORT_INLINE Obj INV_MUT(Obj op)
+EXPORT_INLINE Obj INV_SAMEMUT(Obj op)
 {
     UInt tnum = TNUM_OBJ(op);
-    return (*InvMutFuncs[tnum])(op);
+    return (*InvSameMutFuncs[tnum])(op);
 }
 
 

--- a/src/ariths.h
+++ b/src/ariths.h
@@ -96,21 +96,22 @@ EXPORT_INLINE Obj ZERO_MUT(Obj op)
 
 /****************************************************************************
 **
-*V  AInvFuncs[<type>] . . . . . . . . . . . table of additive inverse methods
+*V  AInvSameMutFuncs[<type>] . . . . . . .  table of additive inverse methods
 */
-extern ArithMethod1 AInvFuncs[LAST_REAL_TNUM + 1];
+extern ArithMethod1 AInvSameMutFuncs[LAST_REAL_TNUM + 1];
 
 
 /****************************************************************************
 **
-*F  AINV( <op> )  . . . . . . . . . . . . . . . additive inverse of an object
+*F  AINV_SAMEMUT( <op> ) . . . . . . . . . . . . additive inverse of an object
 **
-**  'AINV' returns the additive inverse of the object <op>.
+**  'AINV_SAMEMUT' returns the additive inverse of the object <op> with the
+**  same mutability level as <op>
 */
-EXPORT_INLINE Obj AINV(Obj op)
+EXPORT_INLINE Obj AINV_SAMEMUT(Obj op)
 {
     UInt tnum = TNUM_OBJ(op);
-    return (*AInvFuncs[tnum])(op);
+    return (*AInvSameMutFuncs[tnum])(op);
 }
 
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -997,7 +997,7 @@ static Obj AInvCyc(Obj op)
     for ( i = 1; i < len; i++ ) {
         if ( ! IS_INTOBJ( cfs[i] ) || cfs[i] == INTOBJ_MIN ) {
             CHANGED_BAG( res );
-            prd = AINV( cfs[i] );
+            prd = AINV_SAMEMUT(cfs[i]);
             cfs = CONST_COEFS_CYC(op);
             exs = CONST_EXPOS_CYC(op,len);
             cfp = COEFS_CYC(res);
@@ -2117,7 +2117,7 @@ static Int InitKernel (
     /* install the unary arithmetic methods                                */
     ZeroSameMutFuncs[T_CYC] = ZeroCyc;
     ZeroMutFuncs[ T_CYC ] = ZeroCyc;
-    AInvFuncs[ T_CYC ] = AInvCyc;
+    AInvSameMutFuncs[T_CYC] = AInvCyc;
     AInvMutFuncs[ T_CYC ] = AInvCyc;
     OneFuncs [ T_CYC ] = OneCyc;
     OneSameMut[T_CYC] = OneCyc;

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2120,9 +2120,9 @@ static Int InitKernel (
     AInvFuncs[ T_CYC ] = AInvCyc;
     AInvMutFuncs[ T_CYC ] = AInvCyc;
     OneFuncs [ T_CYC ] = OneCyc;
-    OneMutFuncs [ T_CYC ] = OneCyc;
+    OneSameMut[T_CYC] = OneCyc;
     InvFuncs [ T_CYC ] = InvCyc;
-    InvMutFuncs [ T_CYC ] = InvCyc;
+    InvSameMutFuncs[T_CYC] = InvCyc;
 
     /* install the arithmetic methods                                      */
     SumFuncs[  T_CYC    ][ T_CYC    ] = SumCyc;

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2115,7 +2115,7 @@ static Int InitKernel (
     LtFuncs[   T_CYC    ][ T_RAT    ] = LtCycNot;
 
     /* install the unary arithmetic methods                                */
-    ZeroFuncs[ T_CYC ] = ZeroCyc;
+    ZeroSameMutFuncs[T_CYC] = ZeroCyc;
     ZeroMutFuncs[ T_CYC ] = ZeroCyc;
     AInvFuncs[ T_CYC ] = AInvCyc;
     AInvMutFuncs[ T_CYC ] = AInvCyc;

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -496,7 +496,7 @@ static Obj EvalSum(Expr expr)
 **  value, i.e., the  additive inverse of  the operand.  'EvalAInv' is called
 **  from 'EVAL_EXPR' to evaluate expressions of type 'EXPR_AINV'.
 **
-**  'EvalAInv' evaluates the operand and then calls the 'AINV' macro.
+**  'EvalAInv' evaluates the operand and then calls the 'AINV_SAMEMUT' macro.
 */
 static Obj EvalAInv(Expr expr)
 {
@@ -510,7 +510,7 @@ static Obj EvalAInv(Expr expr)
 
     /* compute the additive inverse                                        */
     SET_BRK_CALL_TO(expr);     /* Note possible call for FuncWhere */
-    val = AINV( opL );
+    val = AINV_SAMEMUT(opL);
 
     /* return the value                                                    */
     return val;

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1554,7 +1554,7 @@ static Int InitKernel (
     LtFuncs[   T_FFE ][ T_FFE ] = LtFFE;
 
     /* install the arithmetic methods                                      */
-    ZeroFuncs[ T_FFE ] = ZeroFFE;
+    ZeroSameMutFuncs[T_FFE] = ZeroFFE;
     ZeroMutFuncs[ T_FFE ] = ZeroFFE;
     AInvFuncs[ T_FFE ] = AInvFFE;
     AInvMutFuncs[ T_FFE ] = AInvFFE;

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1559,9 +1559,9 @@ static Int InitKernel (
     AInvFuncs[ T_FFE ] = AInvFFE;
     AInvMutFuncs[ T_FFE ] = AInvFFE;
     OneFuncs [ T_FFE ] = OneFFE;
-    OneMutFuncs [ T_FFE ] = OneFFE;
+    OneSameMut[T_FFE] = OneFFE;
     InvFuncs [ T_FFE ] = InvFFE;
-    InvMutFuncs [ T_FFE ] = InvFFE;
+    InvSameMutFuncs[T_FFE] = InvFFE;
     SumFuncs[  T_FFE ][ T_FFE ] = SumFFEFFE;
     SumFuncs[  T_FFE ][ T_INT ] = SumFFEInt;
     SumFuncs[  T_INT ][ T_FFE ] = SumIntFFE;

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1556,7 +1556,7 @@ static Int InitKernel (
     /* install the arithmetic methods                                      */
     ZeroSameMutFuncs[T_FFE] = ZeroFFE;
     ZeroMutFuncs[ T_FFE ] = ZeroFFE;
-    AInvFuncs[ T_FFE ] = AInvFFE;
+    AInvSameMutFuncs[T_FFE] = AInvFFE;
     AInvMutFuncs[ T_FFE ] = AInvFFE;
     OneFuncs [ T_FFE ] = OneFFE;
     OneSameMut[T_FFE] = OneFFE;

--- a/src/integer.c
+++ b/src/integer.c
@@ -1648,7 +1648,7 @@ static Obj PowObjInt(Obj op, Obj n)
 
   /* if the integer is zero, return the neutral element of the operand   */
   if ( n == INTOBJ_INT(0) ) {
-    return ONE_MUT( op );
+    return ONE_SAMEMUT( op );
   }
   
   /* if the integer is one, return a copy of the operand                 */
@@ -1658,12 +1658,12 @@ static Obj PowObjInt(Obj op, Obj n)
   
   /* if the integer is minus one, return the inverse of the operand      */
   else if ( n == INTOBJ_INT(-1) ) {
-    res = INV_MUT( op );
+    res = INV_SAMEMUT( op );
   }
   
   /* if the integer is negative, invert the operand and the integer      */
   else if ( IS_NEG_INT(n) ) {
-    res = INV_MUT( op );
+    res = INV_SAMEMUT( op );
     if ( res == Fail ) {
       ErrorMayQuit("Operations: <obj> must have an inverse", 0, 0);
     }
@@ -2865,7 +2865,7 @@ static Int InitKernel ( StructInitInfo * module )
     AInvFuncs[ t1 ] = AInvInt;
     AInvMutFuncs[ t1 ] = AInvInt;
     OneFuncs [ t1 ] = OneInt;
-    OneMutFuncs [ t1 ] = OneInt;
+    OneSameMut[t1] = OneInt;
   }
 
     /* install the default power methods                                   */

--- a/src/integer.c
+++ b/src/integer.c
@@ -1509,16 +1509,16 @@ static Obj ProdIntObj ( Obj n, Obj op )
   
   /* if the integer is minus one, return the inverse of the operand        */
   else if ( n == INTOBJ_INT(-1) ) {
-    res = AINV( op );
+    res = AINV_SAMEMUT( op );
   }
   
   /* if the integer is negative, invert the operand and the integer        */
   else if ( IS_NEG_INT(n) ) {
-    res = AINV( op );
+    res = AINV_SAMEMUT( op );
     if ( res == Fail ) {
       ErrorMayQuit("Operations: <obj> must have an additive inverse", 0, 0);
     }
-    res = PROD( AINV( n ), res );
+    res = PROD(AINV_SAMEMUT(n), res);
   }
 
   /* if the integer is small, compute the product by repeated doubling     */
@@ -1667,7 +1667,7 @@ static Obj PowObjInt(Obj op, Obj n)
     if ( res == Fail ) {
       ErrorMayQuit("Operations: <obj> must have an inverse", 0, 0);
     }
-    res = POW( res, AINV( n ) );
+    res = POW(res, AINV_SAMEMUT(n));
   }
   
   /* if the integer is small, compute the power by repeated squaring     */
@@ -2862,7 +2862,7 @@ static Int InitKernel ( StructInitInfo * module )
   for ( t1 = T_INT; t1 <= T_INTNEG; t1++ ) {
     ZeroSameMutFuncs[ t1 ] = ZeroInt;
     ZeroMutFuncs[ t1 ] = ZeroInt;
-    AInvFuncs[ t1 ] = AInvInt;
+    AInvSameMutFuncs[t1] = AInvInt;
     AInvMutFuncs[ t1 ] = AInvInt;
     OneFuncs [ t1 ] = OneInt;
     OneSameMut[t1] = OneInt;

--- a/src/integer.c
+++ b/src/integer.c
@@ -1494,7 +1494,7 @@ static Obj ProdIntObj ( Obj n, Obj op )
 
   /* if the integer is zero, return the neutral element of the operand     */
   if ( n == INTOBJ_INT(0) ) {
-    res = ZERO( op );
+    res = ZERO_SAMEMUT( op );
   }
   
   /* if the integer is one, return the object if immutable -
@@ -1502,7 +1502,7 @@ static Obj ProdIntObj ( Obj n, Obj op )
      ensure correct mutability propagation                                 */
   else if ( n == INTOBJ_INT(1) ) {
     if (IS_MUTABLE_OBJ(op))
-      res = SUM(ZERO(op),op);
+      res = SUM(ZERO_SAMEMUT(op),op);
     else
       res = op;
   }
@@ -2860,7 +2860,7 @@ static Int InitKernel ( StructInitInfo * module )
   
   /* install the unary arithmetic methods                                  */
   for ( t1 = T_INT; t1 <= T_INTNEG; t1++ ) {
-    ZeroFuncs[ t1 ] = ZeroInt;
+    ZeroSameMutFuncs[ t1 ] = ZeroInt;
     ZeroMutFuncs[ t1 ] = ZeroInt;
     AInvFuncs[ t1 ] = AInvInt;
     AInvMutFuncs[ t1 ] = AInvInt;

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -1643,7 +1643,7 @@ void IntrAInv(IntrState * intr)
     opL = PopObj(intr);
 
     /* compute the additive inverse                                        */
-    val = AINV( opL );
+    val = AINV_SAMEMUT(opL);
 
     /* push the result                                                     */
     PushObj(intr, val);

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -458,9 +458,9 @@ static Obj FuncZERO_ATTR_MAT(Obj self, Obj mat)
 **
 **  'AInvList' is the extended dispatcher for  the additive inverse involving
 **  lists.  That is, whenever  the additive inverse for  lists is called  and
-**  'AInvFuncs' does not   point to a   special function, then  'AInvList' is
-**  called.  'AInvList' determines the extended  type of the operand and then
-**  dispatches through 'AInvFuncs' again.
+**  'AInvSameMutFuncs' does not point to a special function, then 'AInvList'
+**  is called.'AInvList' determines the extended type of the operand and then
+**  dispatches through 'AInvSameMutFuncs' again.
 **
 **  'AInvListDefault' is a generic function for the additive inverse.
 */
@@ -540,7 +540,7 @@ static Obj AInvListDefault(Obj list)
     for ( i = 1; i <= len; i++ ) {
         elm = ELM0_LIST( list, i );
         if (elm) {
-          elm = AINV( elm );
+          elm = AINV_SAMEMUT( elm );
           SET_ELM_PLIST( res, i, elm );
           CHANGED_BAG( res );
         }
@@ -745,7 +745,7 @@ Obj             DiffListList (
             if (mutD)
               elmD = AINV_MUT(elmR);
             else
-              elmD = AINV(elmR);
+              elmD = AINV_SAMEMUT(elmR);
           }
         else
           elmD = 0;
@@ -1189,7 +1189,7 @@ static Obj InvMatrix(Obj mat, UInt mut)
             if (mut < 2)
               elm = AINV_MUT( ELM_PLIST( row2, k ) );
             else
-              elm = AINV( ELM_PLIST( row2, k ) );
+              elm = AINV_SAMEMUT( ELM_PLIST( row2, k ) );
             if ( i != k-len && ! EQ(elm,zero) ) {
                 for ( l = 1; l <= 2*len; l++ ) {
                     elm2 = PROD( elm, ELM_PLIST( row, l ) );
@@ -1635,7 +1635,7 @@ static Obj InvMatWithRowVecs(Obj mat, UInt mut)
           y = ELMW_LIST(row3,i);
           if (!EQ(y,zero))
             {
-              yi = AINV(y);
+              yi = AINV_SAMEMUT(y);
               CALL_3ARGS(AddRowVectorOp, row3, row, yi);
               CALL_3ARGS(AddRowVectorOp, ELM_PLIST(res,k), row2, yi);
             }
@@ -1646,7 +1646,7 @@ static Obj InvMatWithRowVecs(Obj mat, UInt mut)
           y = ELMW_LIST(row3,i);
           if (!EQ(y,zero))
             {
-              yi = AINV(y);
+              yi = AINV_SAMEMUT(y);
               CALL_3ARGS(AddRowVectorOp, row3, row, yi);
               CALL_3ARGS(AddRowVectorOp, ELM_PLIST(res,k), row2, yi);
             }
@@ -2126,8 +2126,8 @@ static Int InitKernel (
     }
 
     for (t1 = FIRST_LIST_TNUM; t1 <= LAST_LIST_TNUM; t1 ++ ) {
-            AInvFuncs[t1] = AInvListDefault;
-            AInvMutFuncs[t1] = AInvMutListDefault;
+        AInvSameMutFuncs[t1] = AInvListDefault;
+        AInvMutFuncs[t1] = AInvMutListDefault;
     }
 
     /* No kernel installations for One or Inverse any more */

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -1004,7 +1004,7 @@ static Obj OneMatrix(Obj mat, UInt mut)
     switch (mut) {
     case 0:
       zero = ZERO_MUT( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
-      one  = ONE_MUT( zero );
+      one = ONE_SAMEMUT(zero);
       CheckedMakeImmutable(zero);
       CheckedMakeImmutable(one);
       ctype = rtype = T_PLIST+IMMUTABLE;
@@ -1012,7 +1012,7 @@ static Obj OneMatrix(Obj mat, UInt mut)
       
     case 1:
       zero = ZERO_MUT( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
-      one  = ONE_MUT( zero );
+      one = ONE_SAMEMUT(zero);
       if (IS_MUTABLE_OBJ(mat))
         {
           ctype = T_PLIST;
@@ -1107,7 +1107,7 @@ static Obj InvMatrix(Obj mat, UInt mut)
       {
       case 0:
         zero = ZERO_MUT( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
-        one  = ONE_MUT( zero );
+        one = ONE_SAMEMUT(zero);
         ctype = rtype = T_PLIST+IMMUTABLE;
         CheckedMakeImmutable(zero);
         CheckedMakeImmutable(one);
@@ -1115,7 +1115,7 @@ static Obj InvMatrix(Obj mat, UInt mut)
         
       case 1:
         zero = ZERO_MUT( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
-        one  = ONE_MUT( zero );
+        one = ONE_SAMEMUT(zero);
         if (IS_MUTABLE_OBJ(mat))
           {
             ctype = T_PLIST;
@@ -1174,7 +1174,7 @@ static Obj InvMatrix(Obj mat, UInt mut)
         SET_ELM_PLIST( res, i, ELM_PLIST( res, k-len ) );
         SET_ELM_PLIST( res, k-len, row );
         if (mut < 2)
-          elm2 = INV_MUT( ELM_PLIST( row, k ) );
+          elm2 = INV_SAMEMUT( ELM_PLIST( row, k ) );
         else
           elm2 = INV( ELM_PLIST( row, k ) );
         for ( l = 1; l <= 2*len; l++ ) {

--- a/src/listoper.c
+++ b/src/listoper.c
@@ -298,10 +298,10 @@ static Obj FuncSUM_LIST_LIST_DEFAULT(Obj self, Obj listL, Obj listR)
 *F  ZeroListDefault(<list>) . . . . . . . . . . . . . . . . .  zero of a list
 **
 **  'ZeroList' is the extended dispatcher for the zero involving lists.  That
-**  is, whenever zero for a list is called and  'ZeroFuncs' does not point to
-**  a special function, then 'ZeroList' is called.  'ZeroList' determines the
-**  extended   type of the  operand  and then  dispatches through 'ZeroFuncs'
-**  again.
+**  is, whenever zero for a list is called and 'ZeroSameMutFuncs' does not
+**  point to a special function, then 'ZeroList' is called. 'ZeroList'
+**  determines the extended type of the operand and then dispatches through
+**  'ZeroSameMutFuncs' again.
 **
 **  'ZeroListDefault' is a generic function for the zero.
 */
@@ -326,7 +326,7 @@ static Obj ZeroListDefault(Obj list)
       {
         Obj tmp = ELM0_LIST( list, i);
         if (tmp) {
-          tmp = ZERO(tmp);
+          tmp = ZERO_SAMEMUT(tmp);
           SET_ELM_PLIST( res, i,tmp );
           CHANGED_BAG( res);
         }
@@ -442,7 +442,7 @@ static Obj FuncZERO_ATTR_MAT(Obj self, Obj mat)
   len = LEN_LIST(mat);
   if (len == 0)
     return NewImmutableEmptyPlist();
-  zrow = ZERO(ELM_LIST(mat,1));
+  zrow = ZERO_SAMEMUT(ELM_LIST(mat,1));
   CheckedMakeImmutable(zrow);
   res = NEW_PLIST_IMM(T_PLIST_TAB_RECT, len);
   SET_LEN_PLIST(res,len);
@@ -1023,7 +1023,7 @@ static Obj OneMatrix(Obj mat, UInt mut)
       break;
 
     case 2:
-      zero = ZERO( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
+      zero = ZERO_SAMEMUT( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
       one  = ONE( zero );
       ctype = rtype = T_PLIST;
       break;
@@ -1126,7 +1126,7 @@ static Obj InvMatrix(Obj mat, UInt mut)
         break;
 
       case 2:
-        zero = ZERO( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
+        zero = ZERO_SAMEMUT( ELM_LIST( ELM_LIST( mat, 1 ), 1 ) );
         one  = ONE( zero );
         ctype = rtype = T_PLIST;
         break;
@@ -1510,7 +1510,7 @@ static Obj FuncPROD_VEC_MAT_DEFAULT(Obj self, Obj vec, Obj mat)
   len = LEN_LIST(vec);
   RequireSameLength("<vec> * <mat>", vec, mat);
   elt = ELMW_LIST(vec,1);
-  z = ZERO(elt);
+  z = ZERO_SAMEMUT(elt);
   for (i = 1; i <= len; i++)
     {
       elt = ELMW_LIST(vec,i);
@@ -1527,7 +1527,7 @@ static Obj FuncPROD_VEC_MAT_DEFAULT(Obj self, Obj vec, Obj mat)
         }
     }
   if (res == (Obj)0)
-    res = ZERO(ELMW_LIST(mat,1));
+    res = ZERO_SAMEMUT(ELMW_LIST(mat,1));
   if (!IS_MUTABLE_OBJ(vec) && !IS_MUTABLE_OBJ(mat))
     CheckedMakeImmutable(res);
   return res;
@@ -1569,8 +1569,8 @@ static Obj InvMatWithRowVecs(Obj mat, UInt mut)
   }
 
   /* get the zero and the one                                            */
-  zerov = ZERO( ELMW_LIST(mat, 1));
-  zero = ZERO( ELMW_LIST( ELMW_LIST( mat, 1 ), 1 ) );
+  zerov = ZERO_SAMEMUT(ELMW_LIST(mat, 1));
+  zero = ZERO_SAMEMUT(ELMW_LIST(ELMW_LIST(mat, 1), 1));
   one  = ONE( zero );
     
   /* set up res (initially the identity) and matcopy */
@@ -2121,8 +2121,8 @@ static Int InitKernel (
     }
 
     for (t1 = FIRST_LIST_TNUM; t1 <= LAST_LIST_TNUM; t1 ++ ) {
-            ZeroFuncs[t1] = ZeroListDefault;
-            ZeroMutFuncs[t1] = ZeroListMutDefault;
+        ZeroSameMutFuncs[t1] = ZeroListDefault;
+        ZeroMutFuncs[t1] = ZeroListMutDefault;
     }
 
     for (t1 = FIRST_LIST_TNUM; t1 <= LAST_LIST_TNUM; t1 ++ ) {

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -631,7 +631,7 @@ static Int InitKernel (
         EqFuncs[T_MACFLOAT][t] = EqFuncs[t][T_MACFLOAT] = EqObject;
 
     /* install the unary arithmetic methods                                */
-    ZeroFuncs[ T_MACFLOAT ] = ZeroMacfloat;
+    ZeroSameMutFuncs[T_MACFLOAT] = ZeroMacfloat;
     ZeroMutFuncs[ T_MACFLOAT ] = ZeroMacfloat;
     AInvMutFuncs[ T_MACFLOAT ] = AInvMacfloat;
     OneFuncs [ T_MACFLOAT ] = OneMacfloat;

--- a/src/macfloat.c
+++ b/src/macfloat.c
@@ -635,7 +635,7 @@ static Int InitKernel (
     ZeroMutFuncs[ T_MACFLOAT ] = ZeroMacfloat;
     AInvMutFuncs[ T_MACFLOAT ] = AInvMacfloat;
     OneFuncs [ T_MACFLOAT ] = OneMacfloat;
-    OneMutFuncs [ T_MACFLOAT ] = OneMacfloat;
+    OneSameMut[T_MACFLOAT] = OneMacfloat;
     InvFuncs [ T_MACFLOAT ] = InvMacfloat;
 
     /* install binary arithmetic methods */

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2886,14 +2886,14 @@ static Int InitKernel (
     /* install the 'ONE' function for permutations                         */
     OneFuncs[ T_PERM2 ] = OnePerm;
     OneFuncs[ T_PERM4 ] = OnePerm;
-    OneMutFuncs[ T_PERM2 ] = OnePerm;
-    OneMutFuncs[ T_PERM4 ] = OnePerm;
+    OneSameMut[T_PERM2] = OnePerm;
+    OneSameMut[T_PERM4] = OnePerm;
 
     /* install the 'INV' function for permutations                         */
     InvFuncs[ T_PERM2 ] = InvPerm<UInt2>;
     InvFuncs[ T_PERM4 ] = InvPerm<UInt4>;
-    InvMutFuncs[ T_PERM2 ] = InvPerm<UInt2>;
-    InvMutFuncs[ T_PERM4 ] = InvPerm<UInt4>;
+    InvSameMutFuncs[T_PERM2] = InvPerm<UInt2>;
+    InvSameMutFuncs[T_PERM4] = InvPerm<UInt4>;
 
     return 0;
 }

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -3930,14 +3930,14 @@ static Int InitKernel(StructInitInfo * module)
     /* install the one function for partial perms */
     OneFuncs[T_PPERM2] = OnePPerm;
     OneFuncs[T_PPERM4] = OnePPerm;
-    OneMutFuncs[T_PPERM2] = OnePPerm;
-    OneMutFuncs[T_PPERM4] = OnePPerm;
+    OneSameMut[T_PPERM2] = OnePPerm;
+    OneSameMut[T_PPERM4] = OnePPerm;
 
     /* install the inverse functions for partial perms */
     InvFuncs[T_PPERM2] = InvPPerm2;
     InvFuncs[T_PPERM4] = InvPPerm4;
-    InvMutFuncs[T_PPERM2] = InvPPerm2;
-    InvMutFuncs[T_PPERM4] = InvPPerm4;
+    InvSameMutFuncs[T_PPERM2] = InvPPerm2;
+    InvSameMutFuncs[T_PPERM4] = InvPPerm4;
 
     return 0;
 }

--- a/src/rational.c
+++ b/src/rational.c
@@ -857,16 +857,16 @@ static Int InitKernel (
     AInvFuncs[ T_RAT    ] = AInvRat;
     AInvMutFuncs[ T_RAT    ] = AInvRat;
     OneFuncs [ T_RAT    ] = OneRat;
-    OneMutFuncs [ T_RAT    ] = OneRat;
+    OneSameMut[T_RAT] = OneRat;
     InvFuncs [ T_INT    ] = InvRat;
     InvFuncs [ T_INTPOS ] = InvRat;
     InvFuncs [ T_INTNEG ] = InvRat;
     InvFuncs [ T_RAT    ] = InvRat;
-    InvMutFuncs [ T_INT    ] = InvRat;
-    InvMutFuncs [ T_INTPOS ] = InvRat;
-    InvMutFuncs [ T_INTNEG ] = InvRat;
-    InvMutFuncs [ T_RAT    ] = InvRat;
-    
+    InvSameMutFuncs[T_INT] = InvRat;
+    InvSameMutFuncs[T_INTPOS] = InvRat;
+    InvSameMutFuncs[T_INTNEG] = InvRat;
+    InvSameMutFuncs[T_RAT] = InvRat;
+
     SumFuncs [ T_RAT    ][ T_RAT    ] = SumRat;
     SumFuncs [ T_INT    ][ T_RAT    ] = SumRat;
     SumFuncs [ T_INTPOS ][ T_RAT    ] = SumRat;

--- a/src/rational.c
+++ b/src/rational.c
@@ -853,7 +853,7 @@ static Int InitKernel (
     LtFuncs  [ T_RAT    ][ T_INTNEG ] = LtRat;
 
     /* install the arithmetic operations                                   */
-    ZeroFuncs[ T_RAT    ] = ZeroRat;
+    ZeroSameMutFuncs[T_RAT] = ZeroRat;
     AInvFuncs[ T_RAT    ] = AInvRat;
     AInvMutFuncs[ T_RAT    ] = AInvRat;
     OneFuncs [ T_RAT    ] = OneRat;

--- a/src/rational.c
+++ b/src/rational.c
@@ -854,7 +854,7 @@ static Int InitKernel (
 
     /* install the arithmetic operations                                   */
     ZeroSameMutFuncs[T_RAT] = ZeroRat;
-    AInvFuncs[ T_RAT    ] = AInvRat;
+    AInvSameMutFuncs[T_RAT] = AInvRat;
     AInvMutFuncs[ T_RAT    ] = AInvRat;
     OneFuncs [ T_RAT    ] = OneRat;
     OneSameMut[T_RAT] = OneRat;

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -4268,9 +4268,9 @@ static Int InitKernel(StructInitInfo * module)
 
     /* install the 'ONE' function for transformations */
     OneFuncs[T_TRANS2] = OneTrans;
-    OneMutFuncs[T_TRANS2] = OneTrans;
+    OneSameMut[T_TRANS2] = OneTrans;
     OneFuncs[T_TRANS4] = OneTrans;
-    OneMutFuncs[T_TRANS4] = OneTrans;
+    OneSameMut[T_TRANS4] = OneTrans;
 
     return 0;
 }

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -3742,8 +3742,9 @@ static Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
 static Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
 {
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
-        ErrorMayQuit("INVOp: matrix must be square, not %d by %d",
-                     LEN_MAT8BIT(mat), LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)));
+        ErrorMayQuit(
+            "InverseSameMutability: matrix must be square, not %d by %d",
+            LEN_MAT8BIT(mat), LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)));
     }
 
     return InverseMat8Bit(mat, 1);

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -5191,7 +5191,7 @@ static UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
     }
     if (deterp) {
         if (rank < nrows)
-            deter = ZERO(deter);
+            deter = ZERO_SAMEMUT(deter);
         else if (sign == -1)
             deter = AINV(deter);
         *deterp = deter;

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -3689,7 +3689,7 @@ static Obj InverseMat8Bit(Obj mat, UInt mut)
                 row2 = ELM_PLIST(cmat, k);
                 byte = CONST_BYTES_VEC8BIT(row2)[off];
                 if (byte != 0 && (x = gettab[byte + 256 * pos]) != 0) {
-                    xn = AINV(ffefelt[x]);
+                    xn = AINV_SAMEMUT(ffefelt[x]);
                     AddVec8BitVec8BitMultInner(row2, row2, row, xn, i, len);
                     row2 = ELM_PLIST(inv, k + 1);
                     AddVec8BitVec8BitMultInner(row2, row2, row1, xn, 1, len);
@@ -4845,7 +4845,7 @@ static void ReduceCoeffsVec8Bit(Obj vl, Obj vrshifted, Obj quot)
             if (p == 2)
                 xn = x;
             else
-                xn = feltffe[VAL_FFE(AINV(ffefelt[x]))];
+                xn = feltffe[VAL_FFE(AINV_SAMEMUT(ffefelt[x]))];
             multab = SCALAR_FIELDINFO_8BIT(info) + 256 * xn;
             vrs = ELM_PLIST(vrshifted, 1 + i % elts);
             lrs = LEN_VEC8BIT(vrs);
@@ -5034,7 +5034,7 @@ static Obj SemiEchelonListVec8Bits(Obj mat, UInt TransformationsNeeded)
                 byte = CONST_BYTES_VEC8BIT(row)[(j - 1) / elts];
                 if (byte &&
                     zero != (x = gettab[byte + 256 * ((j - 1) % elts)])) {
-                    y = AINV(convtab1[x]);
+                    y = AINV_SAMEMUT(convtab1[x]);
                     AddVec8BitVec8BitMultInner(
                         row, row, ELM_PLIST(vectors, h), y, 1, ncols);
                     if (TransformationsNeeded)
@@ -5174,14 +5174,15 @@ static UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
                     row2 = ELM_PLIST(mat, j);
                     if ((x2 = getcol[CONST_BYTES_VEC8BIT(row2)[byte]]))
                         AddVec8BitVec8BitMultInner(row2, row2, row,
-                                                   AINV(convtab[x2]), workcol,
-                                                   ncols);
+                                                   AINV_SAMEMUT(convtab[x2]),
+                                                   workcol, ncols);
                 }
             for (j = workrow + 1; j <= nrows; j++) {
                 row2 = ELM_PLIST(mat, j);
                 if ((x2 = getcol[CONST_BYTES_VEC8BIT(row2)[byte]]))
-                    AddVec8BitVec8BitMultInner(
-                        row2, row2, row, AINV(convtab[x2]), workcol, ncols);
+                    AddVec8BitVec8BitMultInner(row2, row2, row,
+                                               AINV_SAMEMUT(convtab[x2]),
+                                               workcol, ncols);
             }
         }
         if (TakeInterrupt()) {
@@ -5193,7 +5194,7 @@ static UInt TriangulizeListVec8Bits(Obj mat, UInt clearup, Obj * deterp)
         if (rank < nrows)
             deter = ZERO_SAMEMUT(deter);
         else if (sign == -1)
-            deter = AINV(deter);
+            deter = AINV_SAMEMUT(deter);
         *deterp = deter;
     }
     return rank;

--- a/src/vecffe.c
+++ b/src/vecffe.c
@@ -844,7 +844,7 @@ static Obj ZeroMutVecFFE(Obj vec)
     assert(len);
     res  = NEW_PLIST(T_PLIST_FFE, len);
     SET_LEN_PLIST(res, len);
-    z = ZERO(ELM_PLIST(vec, 1));
+    z = ZERO_SAMEMUT(ELM_PLIST(vec, 1));
     for (i = 1; i <= len; i++)
         SET_ELM_PLIST(res, i, z);
     return res;
@@ -861,7 +861,7 @@ static Obj ZeroVecFFE(Obj vec)
     assert(len);
     res  = NEW_PLIST(TNUM_OBJ(vec), len);
     SET_LEN_PLIST(res, len);
-    z = ZERO(ELM_PLIST(vec, 1));
+    z = ZERO_SAMEMUT(ELM_PLIST(vec, 1));
     for (i = 1; i <= len; i++)
         SET_ELM_PLIST(res, i, z);
     return res;
@@ -953,7 +953,7 @@ static Int InitKernel (
         DiffFuncs[  t1   ][ T_FFE ] = DiffVecFFEFFE;
         ProdFuncs[ T_FFE ][  t1   ] = ProdFFEVecFFE;
         ProdFuncs[  t1   ][ T_FFE ] = ProdVecFFEFFE;
-        ZeroFuncs[  t1   ] = ZeroVecFFE;
+        ZeroSameMutFuncs[t1] = ZeroVecFFE;
         ZeroMutFuncs[  t1   ] = ZeroMutVecFFE;
     }
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -696,7 +696,7 @@ static Int InitKernel (
 
     /* install the arithmetic operation methods                            */
     for (t1 = T_PLIST_CYC; t1 <= T_PLIST_CYC_SSORT + IMMUTABLE; t1++) {
-        ZeroFuncs[ t1 ] = ZeroVector;
+        ZeroSameMutFuncs[t1] = ZeroVector;
         ZeroMutFuncs[ t1 ] = ZeroMutVector;
 
         for (t2 = T_PLIST_CYC; t2 <= T_PLIST_CYC_SSORT + IMMUTABLE; t2++) {

--- a/src/vector.c
+++ b/src/vector.c
@@ -335,7 +335,7 @@ static Obj DiffVectorVector(Obj vecL, Obj vecR)
         for (; i <= lenR; i++) {
             elmR = ptrR[i];
             if (! IS_INTOBJ(elmR) || ! DIFF_INTOBJS(elmD, INTOBJ_INT(0), elmR)) {
-                elmD = AINV(elmR);
+                elmD = AINV_SAMEMUT(elmR);
                 ptrR = CONST_ADDR_OBJ(vecR);
                 ptrD = ADDR_OBJ(vecD);
                 ptrD[i] = elmD;

--- a/tst/testbugfix/2012-11-10-t00273.tst
+++ b/tst/testbugfix/2012-11-10-t00273.tst
@@ -1,5 +1,5 @@
 # 2012/11/10 (SL)
 gap> l :=  [ 2, 3, 4, 1, 5, 10, 9, 7, 8, 6, 11 ];;
-gap> SortBy(l,AINV);
+gap> SortBy(l,AdditiveInverseSameMutability);
 gap> l;
 [ 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 ]

--- a/tst/testinstall/kernel/ariths.tst
+++ b/tst/testinstall/kernel/ariths.tst
@@ -294,13 +294,13 @@ Error, ZeroOp: method should have returned a value
 gap> ZeroSameMutability(a);
 Error, ZeroSameMutability: method should have returned a value
 gap> -a;
-Error, AInvOp: method should have returned a value
+Error, AdditiveInverseSameMutability: method should have returned a value
 gap> AdditiveInverse(a);
 Error, Method for an attribute must return a value
 gap> AdditiveInverseMutable(a);
 Error, AdditiveInverseOp: method should have returned a value
 gap> AdditiveInverseSameMutability(a);
-Error, AInvOp: method should have returned a value
+Error, AdditiveInverseSameMutability: method should have returned a value
 gap> a^0;
 Error, OneSameMutability: method should have returned a value
 gap> One(a);
@@ -360,7 +360,7 @@ gap> ZeroSameMutability(a);
 Error, ZeroSameMutability: method should have returned a value
 gap> -a;
 #I  AdditiveInverseSameMutability
-Error, AInvOp: method should have returned a value
+Error, AdditiveInverseSameMutability: method should have returned a value
 gap> AdditiveInverse(a);
 #I  AdditiveInverseImmutable
 Error, Method for an attribute must return a value
@@ -369,7 +369,7 @@ gap> AdditiveInverseMutable(a);
 Error, AdditiveInverseOp: method should have returned a value
 gap> AdditiveInverseSameMutability(a);
 #I  AdditiveInverseSameMutability
-Error, AInvOp: method should have returned a value
+Error, AdditiveInverseSameMutability: method should have returned a value
 gap> a^0;
 #I  ^: for mult. element-with-one, and zero
 #I  OneSameMutability

--- a/tst/testinstall/kernel/ariths.tst
+++ b/tst/testinstall/kernel/ariths.tst
@@ -302,21 +302,21 @@ Error, AdditiveInverseOp: method should have returned a value
 gap> AdditiveInverseSameMutability(a);
 Error, AInvOp: method should have returned a value
 gap> a^0;
-Error, ONEOp: method should have returned a value
+Error, OneSameMutability: method should have returned a value
 gap> One(a);
 Error, Method for an attribute must return a value
 gap> OneMutable(a);
 Error, OneOp: method should have returned a value
 gap> OneSameMutability(a);
-Error, ONEOp: method should have returned a value
+Error, OneSameMutability: method should have returned a value
 gap> a^-1;
-Error, INVOp: method should have returned a value
+Error, InverseSameMutability: method should have returned a value
 gap> Inverse(a);
 Error, Method for an attribute must return a value
 gap> InverseMutable(a);
 Error, InvOp: method should have returned a value
 gap> InverseSameMutability(a);
-Error, INVOp: method should have returned a value
+Error, InverseSameMutability: method should have returned a value
 gap> a = b;
 false
 gap> a < b;
@@ -373,7 +373,7 @@ Error, AInvOp: method should have returned a value
 gap> a^0;
 #I  ^: for mult. element-with-one, and zero
 #I  OneSameMutability
-Error, ONEOp: method should have returned a value
+Error, OneSameMutability: method should have returned a value
 gap> One(a);
 #I  OneImmutable
 Error, Method for an attribute must return a value
@@ -382,11 +382,11 @@ gap> OneMutable(a);
 Error, OneOp: method should have returned a value
 gap> OneSameMutability(a);
 #I  OneSameMutability
-Error, ONEOp: method should have returned a value
+Error, OneSameMutability: method should have returned a value
 gap> a^-1;
 #I  ^: for mult. element-with-inverse, and negative integer
 #I  InverseSameMutability
-Error, INVOp: method should have returned a value
+Error, InverseSameMutability: method should have returned a value
 gap> Inverse(a);
 #I  InverseImmutable
 Error, Method for an attribute must return a value
@@ -395,7 +395,7 @@ gap> InverseMutable(a);
 Error, InvOp: method should have returned a value
 gap> InverseSameMutability(a);
 #I  InverseSameMutability
-Error, INVOp: method should have returned a value
+Error, InverseSameMutability: method should have returned a value
 gap> a = b;
 #I  =
 false

--- a/tst/testinstall/kernel/ariths.tst
+++ b/tst/testinstall/kernel/ariths.tst
@@ -286,13 +286,13 @@ gap> for m in binary do InstallMethod(m, [cat, cat], 2, ReturnNothing); od;
 
 #
 gap> 0*a;
-Error, ZEROOp: method should have returned a value
+Error, ZeroSameMutability: method should have returned a value
 gap> Zero(a);
 Error, Method for an attribute must return a value
 gap> ZeroMutable(a);
 Error, ZeroOp: method should have returned a value
 gap> ZeroSameMutability(a);
-Error, ZEROOp: method should have returned a value
+Error, ZeroSameMutability: method should have returned a value
 gap> -a;
 Error, AInvOp: method should have returned a value
 gap> AdditiveInverse(a);
@@ -348,7 +348,7 @@ gap> TraceMethods(meths);
 gap> 0*a;
 #I  *: zero integer * additive element with zero
 #I  ZeroSameMutability
-Error, ZEROOp: method should have returned a value
+Error, ZeroSameMutability: method should have returned a value
 gap> Zero(a);
 #I  ZeroImmutable
 Error, Method for an attribute must return a value
@@ -357,7 +357,7 @@ gap> ZeroMutable(a);
 Error, ZeroOp: method should have returned a value
 gap> ZeroSameMutability(a);
 #I  ZeroSameMutability
-Error, ZEROOp: method should have returned a value
+Error, ZeroSameMutability: method should have returned a value
 gap> -a;
 #I  AdditiveInverseSameMutability
 Error, AInvOp: method should have returned a value

--- a/tst/testinstall/listgen.tst
+++ b/tst/testinstall/listgen.tst
@@ -71,7 +71,7 @@ gap> SortParallel( [ 2, 3, 4, 1, 5, 10, 9, 7, 8, 6 ], l,
 gap> l;
 [ 10, 8, 7, 9, 6, 5, 2, 1, 4, 3 ]
 gap> l :=  [ 2, 3, 4, 1, 5, 10, 9, 7, 8, 6 ];;
-gap> SortBy(l,AINV);
+gap> SortBy(l,AdditiveInverseSameMutability);
 gap> l;
 [ 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 ]
 gap> l2 := [ 2, 3, 4, 1, 5, 10, 9, 7, 8, 6 ];;

--- a/tst/testinstall/trace.tst
+++ b/tst/testinstall/trace.tst
@@ -75,7 +75,8 @@ gap> testTrace({} -> Inverse([[1,0],[0,1]]));
 rec( AInv := rec( integer := 4 ), 
   Inv := rec( ("dense plain list") := 1, integer := 2 ), 
   Mod := rec( integer := rec( integer := 1 ) ), One := rec( integer := 1 ), 
-  Prod := rec( integer := rec( integer := 8 ) ), Zero := rec( integer := 1 ) )
+  Prod := rec( integer := rec( integer := 8 ) ), 
+  ZeroSameMut := rec( integer := 1 ) )
 gap> testTrace({} -> 55/2 mod 7);
 rec( Mod := rec( rational := rec( integer := 1 ) ), 
   Quo := rec( integer := rec( integer := 1 ) ) )
@@ -97,7 +98,7 @@ rec( One := rec( rational := 1 ),
 gap> testTrace({} -> OneMutable([[1,2],[3,4]]));
 rec( Mod := rec( integer := rec( integer := 1 ) ), 
   One := rec( ("dense plain list") := 1, integer := 1 ), 
-  Zero := rec( integer := 1 ) )
+  ZeroSameMut := rec( integer := 1 ) )
 gap> testTrace({} -> ZeroMutable(1/2));
 rec( Quo := rec( integer := rec( integer := 1 ) ), 
   ZeroMut := rec( rational := 1 ) )

--- a/tst/testinstall/trace.tst
+++ b/tst/testinstall/trace.tst
@@ -58,7 +58,7 @@ rec( Sum := rec( ("dense plain list") := rec( ("dense plain list") := 1 ),
 gap> testTrace({} -> 2^(3,4,5));
 rec( Pow := rec( integer := rec( ("permutation (small)") := 1 ) ) )
 gap> testTrace({} -> [4,3] - [2,3]);
-rec( AInv := rec( ("dense plain list") := 1, integer := 2 ), 
+rec( AInvSameMut := rec( ("dense plain list") := 1, integer := 2 ), 
   Diff := rec( ("dense plain list") := rec( ("dense plain list") := 1 ) ), 
   Sum := rec( ("dense plain list") := rec( ("dense plain list") := 1 ), 
       integer := rec( integer := 2 ) ) )
@@ -72,7 +72,7 @@ rec( AInvMut := rec( rational := 1 ),
 gap> testTrace({} -> AdditiveInverse([2,3,4]));
 rec( AInvMut := rec( integer := 3, ("plain list of cyclotomics") := 1 ) )
 gap> testTrace({} -> Inverse([[1,0],[0,1]]));
-rec( AInv := rec( integer := 4 ), 
+rec( AInvSameMut := rec( integer := 4 ), 
   Inv := rec( ("dense plain list") := 1, integer := 2 ), 
   Mod := rec( integer := rec( integer := 1 ) ), One := rec( integer := 1 ), 
   Prod := rec( integer := rec( integer := 8 ) ), 

--- a/tst/testinstall/trace.tst
+++ b/tst/testinstall/trace.tst
@@ -84,7 +84,7 @@ rec(
   Comm := 
     rec( ("transformation (small)") := rec( ("transformation (small)") := 1 ) 
      ), Inv := rec( ("transformation (small)") := 1 ), 
-  InvMut := rec( ("transformation (small)") := 1 ), 
+  InvSameMut := rec( ("transformation (small)") := 1 ), 
   LQuo := 
     rec( ("transformation (small)") := rec( ("transformation (small)") := 1 ) 
      ), 
@@ -104,7 +104,7 @@ rec( Quo := rec( integer := rec( integer := 1 ) ),
 gap> testTrace({} -> ZeroMutable([[1,2],[3,4]]));
 rec( ZeroMut := rec( ("dense plain list") := 3, integer := 4 ) )
 gap> testTrace({} -> LeftQuotient(4,2));
-rec( InvMut := rec( integer := 1 ), 
+rec( InvSameMut := rec( integer := 1 ), 
   LQuo := rec( integer := rec( integer := 1 ) ), 
   Prod := rec( rational := rec( integer := 1 ) ) )
 gap> STOP_TEST("trace.tst", 1);

--- a/tst/testspecial/bad-minus.g.out
+++ b/tst/testspecial/bad-minus.g.out
@@ -5,7 +5,7 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-AINV_MUT( elm ) at GAPROOT/lib/arith.gi:LINE called from
+AdditiveInverseMutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
 AdditiveInverseAttr( elm ) at GAPROOT/lib/arith.gi:LINE called from
 1 - "abc" at *stdin*:3 called from
 <function "f">( <arguments> )


### PR DESCRIPTION
This rectifies a problem I've first run into several years ago: the kernel functions for basic arithmetic function (one, zero, additive & multiplicative inverse) had inconsistent names. This PR works towards rectifying this: it renames all functions which preserve mutability to follow a consistent naming scheme. Specifically:

- lib: avoid AINV(_MUT), ZERO(_MUT), instead use high-level names
- kernel: {INV,ONE}_MUT -> {INV,ONE}_SAMEMUT
- kernel: ZERO -> ZERO_SAMEMUT
- kernel: AINV -> AINV_SAMEMUT

I've grepped through all packages (both in the latest distribution, and also many git clones I have around) to see if this breaks any packages, but to the best of my ability, this is not the case, with one exception: the `Modules` package from homalg installs a method for `ZERO`, see https://github.com/homalg-project/homalg_project/pull/462.

Thus we may want to retain `ZERO` as synonym for `ZERO_SAMEMUT`, at least for a while ?

Ultimately, I'd also like to rename `ONE -> ONE_MUT` and `INV -> INV_MUT`. But note that `ONE_MUT` and `INV_MUT` were already in use before this PR. Moreover, several packages use `INV` or `ONE`... So I'd rather do this in a separate PR, after the dust on this one has settled...