### PR TITLE
Fix `One` issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ doc/gapmacrodoc.idx
 *~
 \#*\#
 .\#*
+gen

--- a/doc/ref/pperm.xml
+++ b/doc/ref/pperm.xml
@@ -1551,11 +1551,11 @@ multiplicative neutral element (i.e. an identity element) but not to satisfy
 <Example><![CDATA[
 gap> f := PartialPerm( [ 1, 2, 3, 6, 8, 10 ], [ 2, 6, 7, 9, 1, 5 ] );;
 gap> S := Semigroup(f, One(f));
-<commutative partial perm monoid of rank 9 with 1 generator>
+<partial perm semigroup of rank 9 with 2 generators>
 gap> IsMonoid(S);
-true
+false
 gap> IsPartialPermMonoid(S);
-true]]></Example>
+false]]></Example>
 
 Note that unlike transformation semigroups, the <Ref Attr="One"/> of a partial permutation semigroup must coincide with the multiplicative neutral element, if either exists.<P/>
 

--- a/doc/ref/reesmat.xml
+++ b/doc/ref/reesmat.xml
@@ -337,7 +337,7 @@ gap> V:=Semigroup(GeneratorsOfSemigroup(U));
 gap> IsReesZeroMatrixSemigroup(V);
 true
 gap> S:=Semigroup(Transformation([1,1]), Transformation([1,2]));
-<commutative transformation monoid of degree 2 with 1 generator>
+<transformation semigroup of degree 2 with 2 generators>
 gap> IsSimpleSemigroup(S);
 false
 gap> mat:=[[0, One(S), 0, One(S)], [One(S), 0, One(S), 0], 

--- a/doc/ref/trans.xml
+++ b/doc/ref/trans.xml
@@ -970,7 +970,7 @@ gap> S := FullTransformationSemigroup( 5 );
 gap> SmallestMovedPoint( S );              
 1
 gap> S := Semigroup( IdentityTransformation );
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 gap> SmallestMovedPoint( S );
 infinity
 gap> f := Transformation( [ 1, 2, 3, 6, 6, 6 ] );;
@@ -1006,7 +1006,7 @@ gap> S := FullTransformationSemigroup( 5 );
 gap> LargestMovedPoint( S );
 5
 gap> S := Semigroup( IdentityTransformation );
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 gap> LargestMovedPoint( S );
 0
 gap> f := Transformation( [ 1, 2, 3, 6, 6, 6 ] );;
@@ -1042,7 +1042,7 @@ gap> S := FullTransformationSemigroup( 5 );
 gap> SmallestImageOfMovedPoint( S );              
 1
 gap> S := Semigroup( IdentityTransformation );
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 gap> SmallestImageOfMovedPoint( S );
 infinity
 gap> f := Transformation( [ 1, 2, 3, 6, 6, 6 ] );;
@@ -1572,11 +1572,11 @@ satisfy <C>IsTransformationMonoid</C>. For example,
     <Example><![CDATA[
 gap> f := Transformation( [ 2, 6, 7, 2, 6, 9, 9, 1, 1, 5 ] );;
 gap> S := Semigroup( f, One( f ) );
-<commutative transformation monoid of degree 10 with 1 generator>
+<transformation semigroup of degree 10 with 2 generators>
 gap> IsMonoid( S );
-true
+false
 gap> IsTransformationMonoid( S );
-true
+false
 gap> S := Semigroup( 
 > Transformation( [ 3, 8, 1, 4, 5, 6, 7, 1, 10, 10 ] ), 
 > Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 10, 10 ] ) );

--- a/lib/arith.gi
+++ b/lib/arith.gi
@@ -12,13 +12,6 @@
 ##  allow certain arithmetical operations.
 ##
 
-
-InstallOtherMethod(One, "for a multiplicative element with one collection", 
-[IsMultiplicativeElementWithOneCollection], 
-function(coll)
-  return One(Representative(coll));
-end);
-
 #############################################################################
 ##
 #M  IsImpossible( <matrix> )

--- a/lib/monoid.gi
+++ b/lib/monoid.gi
@@ -69,7 +69,7 @@ InstallMethod( ViewString,
 InstallOtherMethod(MonoidByGenerators, "for a collection",
 [IsCollection],
 function(gens)
-  local M, pos;
+  local M, pos, one;
 
   M := Objectify(NewType(FamilyObj(gens), IsMonoid
                                           and IsAttributeStoringRep), rec());
@@ -77,13 +77,14 @@ function(gens)
 
   if CanEasilyCompareElements(gens) and IsFinite(gens)
       and IsMultiplicativeElementWithOneCollection(gens) then
-    SetOne(M, One(gens));
-    pos := Position(gens, One(gens));
+    one := One(Representative(gens));
+    SetOne(M, one);
+    pos := Position(gens, one);
     if pos <> fail then
       SetGeneratorsOfMagma(M, gens);
-      if Length(gens) = 1 then # Length(gens) <> 0 since One(gens) in gens
+      if Length(gens) = 1 then # Length(gens) <> 0 since one in gens
         SetIsTrivial(M, true);
-      elif not IsPartialPermCollection(gens) or One(gens) =
+      elif not IsPartialPermCollection(gens) or one =
           One(gens{Concatenation([1 .. pos - 1], [pos + 1 .. Length(gens)])}) then
         # if gens = [PartialPerm([1,2]), PartialPerm([1])], then removing the One
         # = gens[1] from this, it is not possible to recreate the semigroup using
@@ -93,7 +94,7 @@ function(gens)
         Remove(gens, pos);
       fi;
     else
-      SetGeneratorsOfMagma(M, Concatenation([One(gens)], gens));
+      SetGeneratorsOfMagma(M, Concatenation([one], gens));
     fi;
   fi;
 

--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -498,7 +498,7 @@ InstallMethod(SemigroupByGenerators,
 "for a collection",
 [IsCollection],
 function(gens)
-  local S, pos;
+  local S, pos, one;
 
   S := Objectify(NewType(FamilyObj(gens), IsSemigroup
                                              and IsAttributeStoringRep), rec());
@@ -508,12 +508,13 @@ function(gens)
   if IsMultiplicativeElementWithOneCollection(gens)
       and CanEasilyCompareElements(gens)
       and IsFinite(gens) then
-    pos := Position(gens, One(gens));
+    one := One(Representative(gens));
+    pos := Position(gens, one);
     if pos <> fail then
       SetFilterObj(S, IsMonoid);
-      if Length(gens) = 1 then # Length(gens) <> 0 since One(gens) in gens
+      if Length(gens) = 1 then # Length(gens) <> 0 since one in gens
         SetIsTrivial(S, true);
-      elif not IsPartialPermCollection(gens) or One(gens) =
+      elif not IsPartialPermCollection(gens) or one =
         One(gens{Concatenation([1 .. pos - 1], [pos + 1 .. Length(gens)])}) then
         # if gens = [PartialPerm([1, 2]), PartialPerm([1])], then removing the One
         # = gens[1] from this, it is not possible to recreate the semigroup using

--- a/lib/semigrp.gi
+++ b/lib/semigrp.gi
@@ -498,35 +498,11 @@ InstallMethod(SemigroupByGenerators,
 "for a collection",
 [IsCollection],
 function(gens)
-  local S, pos, one;
-
-  S := Objectify(NewType(FamilyObj(gens), IsSemigroup
-                                             and IsAttributeStoringRep), rec());
-  gens := AsList(gens);
-  SetGeneratorsOfMagma(S, gens);
-
-  if IsMultiplicativeElementWithOneCollection(gens)
-      and CanEasilyCompareElements(gens)
-      and IsFinite(gens) then
-    one := One(Representative(gens));
-    pos := Position(gens, one);
-    if pos <> fail then
-      SetFilterObj(S, IsMonoid);
-      if Length(gens) = 1 then # Length(gens) <> 0 since one in gens
-        SetIsTrivial(S, true);
-      elif not IsPartialPermCollection(gens) or one =
-        One(gens{Concatenation([1 .. pos - 1], [pos + 1 .. Length(gens)])}) then
-        # if gens = [PartialPerm([1, 2]), PartialPerm([1])], then removing the One
-        # = gens[1] from this, it is not possible to recreate the semigroup using
-        # Monoid(PartialPerm([1])) (since the One in this case is
-        # PartialPerm([1]) not PartialPerm([1, 2]) as it should be.
-        gens := ShallowCopy(gens);
-        Remove(gens, pos);
-      fi;
-      SetGeneratorsOfMonoid(S, gens);
-    fi;
-  fi;
-
+  local S;
+  S := Objectify(NewType(FamilyObj(gens), 
+                         IsSemigroup and IsAttributeStoringRep), 
+                 rec());
+  SetGeneratorsOfMagma(S, AsList(gens));
   return S;
 end);
 

--- a/lib/semitran.gi
+++ b/lib/semitran.gi
@@ -216,14 +216,14 @@ function(s)
   
   n := DegreeOfTransformationSemigroup(s);
 
-  if n = 0 and HasIsTrivial(s) and IsTrivial(s) then 
+  if n = 0 then 
     return true;
   elif HasSize(s) then
-    return Size(s)=n^n;
+    return Size(s) = n ^ n;
   fi;
 
-  t:=FullTransformationSemigroup(DegreeOfTransformationSemigroup(s));
-  return ForAll(GeneratorsOfSemigroup(t), x-> x in s);
+  t := FullTransformationSemigroup(n);
+  return ForAll(GeneratorsOfSemigroup(t), x -> x in s);
 end);
 
 #

--- a/tst/testbugfix/2017-09-07-FroidurePinExtendedAlg.tst
+++ b/tst/testbugfix/2017-09-07-FroidurePinExtendedAlg.tst
@@ -12,7 +12,7 @@ gap> x := PartialPerm([1]);
 gap> y := PartialPerm([0]);
 <empty partial perm>
 gap> S := Semigroup(x, y);
-<partial perm monoid of rank 1 with 2 generators>
+<partial perm semigroup of rank 1 with 2 generators>
 gap> D := ShallowCopy(GreensDClasses(S));;
 gap> Sort(D, sort);
 gap> D;
@@ -21,7 +21,7 @@ gap> D;
 gap> Elements(S);
 [ <empty partial perm>, <identity partial perm on [ 1 ]> ]
 gap> S := Semigroup(x, y);
-<partial perm monoid of rank 1 with 2 generators>
+<partial perm semigroup of rank 1 with 2 generators>
 gap> Elements(S);
 [ <empty partial perm>, <identity partial perm on [ 1 ]> ]
 gap> D := ShallowCopy(GreensDClasses(S));;
@@ -42,7 +42,7 @@ gap> D;
 
 #
 gap> S := Semigroup(x, y);
-<partial perm monoid of rank 1 with 2 generators>
+<partial perm semigroup of rank 1 with 2 generators>
 gap> FroidurePinExtendedAlg(S);
 gap> LeftCayleyGraphSemigroup(S);
-[ [ 1 ], [ 1 ] ]
+[ [ 1, 1 ], [ 1, 2 ] ]

--- a/tst/testinstall/semigrp.tst
+++ b/tst/testinstall/semigrp.tst
@@ -282,21 +282,27 @@ gap>
 #T# Checking for correct non-removal of one from generating sets in
 # SemigroupByGenerators JDM
 gap> S := Semigroup(PartialPerm([1]));
-<trivial partial perm group of rank 1 with 1 generator>
+<commutative partial perm semigroup of rank 1 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> GeneratorsOfMonoid(S);
-[ <identity partial perm on [ 1 ]> ]
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `GeneratorsOfMagmaWithOne' on 1 argument\
+s
 gap> GeneratorsOfInverseSemigroup(S);
 [ <identity partial perm on [ 1 ]> ]
 gap> GeneratorsOfInverseMonoid(S);
-[ <identity partial perm on [ 1 ]> ]
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 2nd choice method found for `GeneratorsOfInverseMonoid' on 1 argumen\
+ts
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 gap> GeneratorsOfSemigroup(S);
 [ IdentityTransformation ]
 gap> GeneratorsOfMonoid(S);
-[ IdentityTransformation ]
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `GeneratorsOfMagmaWithOne' on 1 argument\
+s
 
 #T# Checking for correct non-removal of one from generating sets in
 # MonoidByGenerators JDM

--- a/tst/testinstall/semitran.tst
+++ b/tst/testinstall/semitran.tst
@@ -46,7 +46,7 @@ true
 # gap> Print(Semigroup(IdentityTransformation));
 # Test SemigroupViewStringPrefix
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 
 # Test < 
 gap> T := Semigroup(Transformation([2, 3, 1]));
@@ -140,7 +140,7 @@ gap> S := Group(IdentityTransformation);
 gap> GeneratorsOfGroup(S);
 [ IdentityTransformation ]
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 
 # Test IsomorphismPermGroup for an H-class
 gap> S := FullTransformationMonoid(4);;
@@ -160,15 +160,15 @@ Error, the argument must be a positive integer
 
 # Test IsFullTransformationMonoid 
 gap> S := Semigroup(GeneratorsOfSemigroup(FullTransformationMonoid(3)));
-<transformation monoid of degree 3 with 3 generators>
+<transformation semigroup of degree 3 with 4 generators>
 gap> IsFullTransformationSemigroup(S);
 true
 gap> S := Semigroup(IdentityTransformation);
-<trivial transformation group of degree 0 with 1 generator>
+<commutative transformation semigroup of degree 0 with 1 generator>
 gap> IsFullTransformationSemigroup(S);
 true
 gap> S := Semigroup(GeneratorsOfSemigroup(FullTransformationMonoid(3)));
-<transformation monoid of degree 3 with 3 generators>
+<transformation semigroup of degree 3 with 4 generators>
 gap> Size(S);
 27
 gap> IsFullTransformationSemigroup(S);
@@ -245,7 +245,7 @@ gap> MultiplicativeNeutralElement(S);
 m1
 gap> IsomorphismTransformationSemigroup(S);
 MappingByFunction( <semigroup of size 3, with 3 generators>, <transformation 
- monoid of size 3, degree 3 with 2 generators>
+ semigroup of size 3, degree 3 with 3 generators>
  , function( x ) ... end, function( x ) ... end )
 gap> BruteForceIsoCheck(last);
 true
@@ -362,7 +362,7 @@ gap> MultiplicativeNeutralElement(S);
 m1
 gap> AntiIsomorphismTransformationSemigroup(S);
 MappingByFunction( <semigroup of size 3, with 3 generators>, <transformation 
- monoid of degree 3 with 2 generators>
+ semigroup of degree 3 with 3 generators>
  , function( x ) ... end, function( x ) ... end )
 gap> BruteForceAntiIsoCheck(last);
 true


### PR DESCRIPTION
This PR resolves Issue #4763 and changes the behaviour of `SemigroupByGenerators` to stop it from returning a monoid if the `One` of the generators is one of the generators. This PR builds on #4766 and supersedes #4767.


