### PR TITLE
Undo temporary CI hack (deleting `float-1.0.1`)

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -47,9 +47,6 @@ do
     # skip itc because it requires xgap
     rm -rf itc*
 
-    # HACK: skip float until 1.0.2 is released, as it crashes in the 32bit builds
-    rm -rf float-1.0.1
-
     # HACK to work out timestamp issues with anupq
     touch anupq*/configure* anupq*/Makefile* anupq*/aclocal.m4
 


### PR DESCRIPTION
float 1.0.2 has been and 'picked' up, and is therefore now used in the CI tests.

Therefore we can remove this line (which currently does nothing).