### PR TITLE
kernel: avoid memset'ing TypInputFile / TypOutputFile

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -209,11 +209,11 @@ static Obj FuncSHELL(Obj self,
         outFile = "*stdout*";
     }
 
-    TypOutputFile output = { 0 };
+    TypOutputFile output;
     if (!OpenOutput(&output, outFile, FALSE))
         ErrorQuit("SHELL: can't open outfile %s", (Int)outFile, 0);
 
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInput(&input, inFile)) {
         CloseOutput(&output);
         ErrorQuit("SHELL: can't open infile %s", (Int)inFile, 0);
@@ -398,7 +398,7 @@ int realmain( int argc, char * argv[] )
                                    read of init.g  somehow*/
     /* maybe compile in which case init.g got skipped */
     if ( SyCompilePlease ) {
-      TypInputFile input = { 0 };
+      TypInputFile input;
       if ( ! OpenInput(&input, SyCompileInput) ) {
         return 1;
       }

--- a/src/io.c
+++ b/src/io.c
@@ -373,6 +373,10 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
         return 0;
 
     /* enter the file identifier and the file name                         */
+#ifdef GAP_KERNEL_DEBUG
+    // paranoia: fill with garbage, to verify we initialize everything
+    memset(input, 0x47, sizeof(TypInputFile));
+#endif
     input->prev = IO()->Input;
     input->stream = 0;
     input->file = file;
@@ -411,6 +415,10 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
     GAP_ASSERT(input);
 
     /* enter the file identifier and the file name                         */
+#ifdef GAP_KERNEL_DEBUG
+    // paranoia: fill with garbage, to verify we initialize everything
+    memset(input, 0x47, sizeof(TypInputFile));
+#endif
     input->prev = IO()->Input;
     input->stream = stream;
     input->file = -1;
@@ -839,6 +847,10 @@ UInt OpenOutput(TypOutputFile * output, const Char * filename, BOOL append)
         return 0;
 
     /* put the file on the stack, start at position 0 on an empty line     */
+#ifdef GAP_KERNEL_DEBUG
+    // paranoia: fill with garbage, to verify we initialize everything
+    memset(output, 0x47, sizeof(TypOutputFile));
+#endif
     output->prev = IO()->Output;
     IO()->Output = output;
     output->isstringstream = FALSE;
@@ -875,6 +887,10 @@ UInt OpenOutputStream(TypOutputFile * output, Obj stream)
     GAP_ASSERT(output);
 
     /* put the file on the stack, start at position 0 on an empty line     */
+#ifdef GAP_KERNEL_DEBUG
+    // paranoia: fill with garbage, to verify we initialize everything
+    memset(output, 0x47, sizeof(TypOutputFile));
+#endif
     output->prev = IO()->Output;
     IO()->Output = output;
     output->isstringstream = (CALL_1ARGS(IsOutputStringStream, stream) == True);

--- a/src/io.c
+++ b/src/io.c
@@ -373,7 +373,6 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
         return 0;
 
     /* enter the file identifier and the file name                         */
-    memset(input, 0, sizeof(TypInputFile));
     input->prev = IO()->Input;
     input->stream = 0;
     input->file = file;
@@ -392,6 +391,7 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
     input->line[1] = '\0';    // empty line buffer
     input->ptr = input->line + 1;
     input->number = 1;
+    input->lastErrorLine = 0;
 
     IO()->Input = input;
 
@@ -411,7 +411,6 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
     GAP_ASSERT(input);
 
     /* enter the file identifier and the file name                         */
-    memset(input, 0, sizeof(TypInputFile));
     input->prev = IO()->Input;
     input->stream = stream;
     input->file = -1;
@@ -432,6 +431,7 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
     input->line[1] = '\0';    // empty line buffer
     input->ptr = input->line + 1;
     input->number = 1;
+    input->lastErrorLine = 0;
 
     IO()->Input = input;
 
@@ -841,6 +841,7 @@ UInt OpenOutput(TypOutputFile * output, const Char * filename, BOOL append)
     /* put the file on the stack, start at position 0 on an empty line     */
     output->prev = IO()->Output;
     IO()->Output = output;
+    output->isstringstream = FALSE;
     output->stream = 0;
     output->file = file;
     output->line[0] = '\0';

--- a/src/streams.c
+++ b/src/streams.c
@@ -138,7 +138,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
     RequireInputStream("READ_ALL_COMMANDS", instream);
 
     /* try to open the streams */
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInputStream(&input, instream, echo == True)) {
         return Fail;
     }
@@ -148,7 +148,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
         outstream = DoOperation2Args(ValGVar(GVarName("OutputTextString")),
                                      outstreamString, True);
     }
-    TypOutputFile output = { 0 };
+    TypOutputFile output;
     if (outstream && !OpenOutputStream(&output, outstream)) {
         CloseInput(&input);
         return Fail;
@@ -241,7 +241,7 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     AssPlist(result, 1, False);
 
     // open the stream, read a command, and close it again
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInputStream(&input, stream, echo == True)) {
         return result;
     }
@@ -404,7 +404,7 @@ Int READ_GAP_ROOT ( const Char * filename )
         Pr("#I  READ_GAP_ROOT: loading '%s' as GAP file\n", (Int)filename, 0);
     }
 
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (OpenInput(&input, path)) {
         while (1) {
             ExecStatus status = ReadEvalCommand(0, &input, 0, 0);
@@ -438,7 +438,7 @@ static Obj FuncCALL_WITH_STREAM(Obj self, Obj stream, Obj func, Obj args)
     RequireOutputStream(SELF_NAME, stream);
     RequireSmallList(SELF_NAME, args);
 
-    TypOutputFile output = { 0 };
+    TypOutputFile output;
     if (!OpenOutputStream(&output, stream)) {
         ErrorQuit("CALL_WITH_STREAM: cannot open stream for output", 0, 0);
     }
@@ -682,7 +682,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
     /* first entry is the file or stream                                   */
     destination = ELM_LIST(args, 1);
 
-    TypOutputFile output = { 0 };
+    TypOutputFile output;
 
     /* try to open the output and handle failures                          */
     if (file) {
@@ -803,7 +803,7 @@ static Obj FuncAPPEND_TO_STREAM(Obj self, Obj args)
 */
 static Obj FuncREAD(Obj self, Obj inputObj)
 {
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 
@@ -827,7 +827,7 @@ static Obj FuncREAD(Obj self, Obj inputObj)
 */
 static Obj FuncREAD_NORECOVERY(Obj self, Obj inputObj)
 {
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 
@@ -868,12 +868,12 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
                         "must be a local variables bag "
                         "or the value 'false'");
 
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInputStream(&input, instream, FALSE)) {
         return False;
     }
 
-    TypOutputFile output = { 0 };
+    TypOutputFile output;
     if (!OpenOutputStream(&output, outstream)) {
         res = CloseInput(&input);
         GAP_ASSERT(res);
@@ -939,7 +939,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
 */
 static Obj FuncREAD_AS_FUNC(Obj self, Obj inputObj)
 {
-    TypInputFile input = { 0 };
+    TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 


### PR DESCRIPTION
Before this patch:

    gap> for i in [1..100000] do EvalString("12+13"); od; time;
    380

After this patch:

    gap> for i in [1..100000] do EvalString("12+13"); od; time;
    314

See issue #4771