### PR TITLE
kernel: add SymbolTable type, change GetInputFilenameID to use it

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -88,6 +88,7 @@ SOURCES += src/set.c
 SOURCES += src/stats.c
 SOURCES += src/streams.c
 SOURCES += src/stringobj.c
+SOURCES += src/symbols.c
 SOURCES += src/syntaxtree.c
 SOURCES += src/sysfiles.c
 SOURCES += src/sysroots.c

--- a/src/gap.c
+++ b/src/gap.c
@@ -1105,7 +1105,8 @@ static Obj FuncKERNEL_INFO(Obj self)
             // FIXME: should we print a warning here?
             continue;
         }
-        r = RNamNameWithLen(environ[i], p - environ[i]);
+        Obj name = MakeStringWithLen(environ[i], p - environ[i]);
+        r = RNamName(CONST_CSTR_STRING(name));
         p++; /* Move pointer behind = character */
         AssPRec(tmp, r, MakeImmString(p));
     }

--- a/src/gvars.c
+++ b/src/gvars.c
@@ -1567,7 +1567,7 @@ static Int PostSave (
 static Int InitLibrary (
     StructInitInfo *    module )
 {
-    InitSymbolTableLibrary(&GVarSymbolTable);
+    InitSymbolTableLibrary(&GVarSymbolTable, 28069);
 
     /* make the error functions for 'AssGVar'                              */
     ErrorMustEvalToFuncFunc = NewFunctionC(

--- a/src/io.c
+++ b/src/io.c
@@ -2003,7 +2003,7 @@ static StructGVarFunc GVarFuncs [] = {
 static Int InitLibrary (
     StructInitInfo *    module )
 {
-    InitSymbolTableLibrary(&FilenameSymbolTable);
+    InitSymbolTableLibrary(&FilenameSymbolTable, 7079);
     FilenameCache = NEW_PLIST(T_PLIST, 0);
 
     /* init filters and functions                                          */

--- a/src/records.c
+++ b/src/records.c
@@ -79,10 +79,10 @@ static void HPC_UnlockNames(void)
 #endif
 
 
-static inline UInt HashString( const Char * name, UInt len )
+static inline UInt HashString( const Char * name )
 {
     UInt hash = 0;
-    while ( len-- > 0 ) {
+    while ( *name ) {
         hash = 65599 * hash + *name++;
     }
     return hash;
@@ -102,13 +102,7 @@ static inline int EqString(Obj str, const Char * name, UInt len)
 **  'RNamName' returns  the record name with the  name  <name> (which is  a C
 **  string).
 */
-UInt            RNamName (
-    const Char *        name )
-{
-    return RNamNameWithLen(name, strlen(name));
-}
-
-UInt RNamNameWithLen(const Char * name, UInt len)
+UInt RNamName(const Char * name)
 {
     Obj                 rnam;           /* record name (as imm intobj)     */
     UInt                pos;            /* hash position                   */
@@ -119,13 +113,14 @@ UInt RNamNameWithLen(const Char * name, UInt len)
     UInt                i;              /* loop variable                   */
     UInt                sizeRNam;
 
+    UInt len = strlen(name)
     if (len > 1023) {
         // Note: We can't pass 'name' here, as it might get moved by garbage collection
         ErrorQuit("Record names must consist of at most 1023 characters", 0, 0);
     }
 
     /* start looking in the table at the following hash position           */
-    const UInt hash = HashString( name, len );
+    const UInt hash = HashString( name );
 
 #ifdef HPCGAP
     HPC_LockNames(0); /* try a read lock first */
@@ -188,7 +183,7 @@ UInt RNamNameWithLen(const Char * name, UInt len)
             rnam2 = ELM_PLIST( table, i );
             if ( rnam2 == 0 )  continue;
             string = NAME_RNAM( INT_INTOBJ(rnam2) );
-            pos = HashString( CONST_CSTR_STRING( string ), GET_LEN_STRING( string) );
+            pos = HashString( CONST_CSTR_STRING( string ) );
             pos = (pos % sizeRNam) + 1;
             while ( ELM_PLIST( HashRNam, pos ) != 0 ) {
                 pos = (pos % sizeRNam) + 1;

--- a/src/records.c
+++ b/src/records.c
@@ -529,7 +529,7 @@ static Int InitKernel (
 static Int InitLibrary (
     StructInitInfo *    module )
 {
-    InitSymbolTableLibrary(&RNamSymbolTable);
+    InitSymbolTableLibrary(&RNamSymbolTable, 28069);
 
     /* make the list of names of record names                              */
     NamesRNam = NEW_PLIST( T_PLIST, 0 );

--- a/src/records.h
+++ b/src/records.h
@@ -36,8 +36,6 @@ Obj NAME_RNAM(UInt rnam);
 */
 UInt RNamName(const Char * name);
 
-UInt RNamNameWithLen(const Char * name, UInt len);
-
 
 /****************************************************************************
 **

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1,0 +1,233 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "symbols.h"
+
+#include "error.h"
+#include "plist.h"
+#include "stringobj.h"
+#include "sysstr.h"
+
+#ifdef HPCGAP
+#include "hpc/tls.h"
+#include "hpc/thread.h"
+#endif
+
+#include <stdlib.h>
+
+
+void InitSymbolTableKernel(SymbolTable *      symtab,
+                           const char *       cookieCount,
+                           const char *       cookieTable,
+                           SymbolIdToNameFunc nameFunc,
+                           NewSymbolFunc      newSymbolFunc)
+{
+    GAP_ASSERT(symtab);
+    GAP_ASSERT(cookieCount);
+    GAP_ASSERT(cookieTable);
+    GAP_ASSERT(nameFunc);
+    GAP_ASSERT(newSymbolFunc);
+
+    symtab->count = INTOBJ_INT(0);
+    symtab->table = 0;
+    symtab->nameFunc = nameFunc;
+    symtab->newSymbolFunc = newSymbolFunc;
+
+#ifdef HPCGAP
+    pthread_rwlock_init(&symtab->lock, NULL);
+    symtab->lockOwner = 0;
+    symtab->lockDepth = 0;
+#endif
+
+    InitGlobalBag(&symtab->count, cookieCount);
+    InitGlobalBag(&symtab->table, cookieTable);
+}
+
+void InitSymbolTableLibrary(SymbolTable * symtab)
+{
+    GAP_ASSERT(symtab);
+
+    symtab->table = NEW_PLIST(T_PLIST, 14033);
+    SET_LEN_PLIST(symtab->table, 14033);
+#ifdef HPCGAP
+    MakeBagPublic(symtab->table);
+#endif
+}
+
+#ifdef HPCGAP
+void LockSymbolTableForReading(SymbolTable * symtab)
+{
+    if (PreThreadCreation)
+        return;
+
+    if (symtab->lockOwner == GetTLS()) {
+        symtab->lockDepth++;
+        return;
+    }
+
+    pthread_rwlock_rdlock(&symtab->lock);
+}
+
+void LockSymbolTableForWriting(SymbolTable * symtab)
+{
+    if (PreThreadCreation)
+        return;
+
+    if (symtab->lockOwner == GetTLS()) {
+        symtab->lockDepth++;
+        return;
+    }
+
+    pthread_rwlock_wrlock(&symtab->lock);
+
+    symtab->lockOwner = GetTLS();
+    symtab->lockDepth = 1;
+}
+
+void UnlockSymbolTable(SymbolTable * symtab)
+{
+    if (PreThreadCreation)
+        return;
+
+    if (symtab->lockOwner == GetTLS()) {
+        symtab->lockDepth--;
+        if (symtab->lockDepth != 0)
+            return;
+        symtab->lockOwner = NULL;
+    }
+
+    pthread_rwlock_unlock(&symtab->lock);
+}
+#endif
+
+int LengthSymbolTable(SymbolTable * symtab)
+{
+#ifdef HPCGAP
+    LockSymbolTableForReading(symtab);
+#endif
+    int count = INT_INTOBJ(symtab->count);
+#ifdef HPCGAP
+    UnlockSymbolTable(symtab);
+#endif
+    return count;
+}
+
+static inline UInt HashString(const Char * name)
+{
+    UInt hash = 0;
+    while (*name) {
+        hash = 65599 * hash + *name++;
+    }
+    return hash;
+}
+
+UInt LookupSymbol(SymbolTable * symtab, const char * name)
+{
+    Obj  id;            // symbol id (as imm intobj)
+    UInt pos;           // hash position
+    Char namx[1024];    // temporary copy of <name>
+    Obj  string;        // temporary string object <name>
+    Obj  table;         // temporary copy of <symtab->table>
+    UInt i;             // loop variable
+    UInt sizeTable;
+
+    if (strlen(name) > 1023) {
+        // Note: We can't pass 'name' here, as it might get moved by garbage
+        // collection
+        ErrorQuit("Symbol names must consist of at most 1023 characters", 0,
+                  0);
+    }
+
+    // start looking in the table at the following hash position
+    const UInt hash = HashString(name);
+
+#ifdef HPCGAP
+    LockSymbolTableForReading(symtab);    // try a read lock first
+#endif
+
+    // look through the table until we find a free slot or the global
+    sizeTable = LEN_PLIST(symtab->table);
+    pos = (hash % sizeTable) + 1;
+    while (
+        (id = ELM_PLIST(symtab->table, pos)) != 0 &&
+        strcmp(CONST_CSTR_STRING(symtab->nameFunc(INT_INTOBJ(id))), name)) {
+        pos = (pos % sizeTable) + 1;
+    }
+    if (id != 0) {
+#ifdef HPCGAP
+        UnlockSymbolTable(symtab);
+#endif
+        return INT_INTOBJ(id);
+    }
+#ifdef HPCGAP
+    if (!PreThreadCreation) {
+        // switch to a write lock
+        UnlockSymbolTable(symtab);
+        LockSymbolTableForWriting(symtab);
+        // when we switched to a write lock, another thread might have
+        // modified the symbol table; so repeat the lookup
+        sizeTable = LEN_PLIST(symtab->table);
+        pos = (hash % sizeTable) + 1;
+        while ((id = ELM_PLIST(symtab->table, pos)) != 0 &&
+               strcmp(CONST_CSTR_STRING(symtab->nameFunc(INT_INTOBJ(id))),
+                      name)) {
+            pos = (pos % sizeTable) + 1;
+        }
+        if (id != 0) {
+            UnlockSymbolTable(symtab);
+            return INT_INTOBJ(id);
+        }
+    }
+#endif
+
+    // if we did not find the global variable, make a new one and enter it
+    // (copy the name first, to avoid a stale pointer in case of a GC)
+    strxcpy(namx, name, sizeof(namx));
+    string = MakeImmString(namx);
+
+    // store the id
+    GAP_ASSERT(id == 0);
+    symtab->count = id = INTOBJ_INT(INT_INTOBJ(symtab->count) + 1);
+    SET_ELM_PLIST(symtab->table, pos, id);
+
+    // notify about the new entry
+    symtab->newSymbolFunc(symtab, INT_INTOBJ(id), string);
+
+    // if the table is too crowded, make a larger one, rehash the names
+    if (sizeTable < 3 * INT_INTOBJ(id) / 2) {
+        table = symtab->table;
+        sizeTable = 2 * sizeTable + 1;
+        symtab->table = NEW_PLIST(T_PLIST, sizeTable);
+        SET_LEN_PLIST(symtab->table, sizeTable);
+#ifdef HPCGAP
+        // The list is briefly non-public, but this is safe, because
+        // the mutex protects it from being accessed by other threads.
+        MakeBagPublic(symtab->table);
+#endif
+        for (i = 1; i <= (sizeTable - 1) / 2; i++) {
+            Obj id2 = ELM_PLIST(table, i);
+            if (id2 == 0)
+                continue;
+            string = symtab->nameFunc(INT_INTOBJ(id2));
+            pos = HashString(CONST_CSTR_STRING(string));
+            pos = (pos % sizeTable) + 1;
+            while (ELM_PLIST(symtab->table, pos) != 0) {
+                pos = (pos % sizeTable) + 1;
+            }
+            SET_ELM_PLIST(symtab->table, pos, id2);
+        }
+    }
+#ifdef HPCGAP
+    UnlockSymbolTable(symtab);
+#endif
+
+    // return the symbol id
+    return INT_INTOBJ(id);
+}

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -50,12 +50,12 @@ void InitSymbolTableKernel(SymbolTable *      symtab,
     InitGlobalBag(&symtab->table, cookieTable);
 }
 
-void InitSymbolTableLibrary(SymbolTable * symtab)
+void InitSymbolTableLibrary(SymbolTable * symtab, UInt initialSize)
 {
     GAP_ASSERT(symtab);
 
-    symtab->table = NEW_PLIST(T_PLIST, 14033);
-    SET_LEN_PLIST(symtab->table, 14033);
+    symtab->table = NEW_PLIST(T_PLIST, initialSize);
+    SET_LEN_PLIST(symtab->table, initialSize);
 #ifdef HPCGAP
     MakeBagPublic(symtab->table);
 #endif

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -1,0 +1,75 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef GAP_SYMBOLS_H
+#define GAP_SYMBOLS_H
+
+#include "common.h"
+
+#ifdef HPCGAP
+#include <pthread.h>
+#endif
+
+// some auxiliary typedefs for SymbolTable
+typedef struct SymbolTable SymbolTable;
+typedef Obj (*SymbolIdToNameFunc)(UInt id);
+typedef void (*NewSymbolFunc)(SymbolTable * symtab, UInt id, Obj name);
+
+// A SymbolTable maps strings to unique monotonously increasing
+// integer ids.
+struct SymbolTable {
+    // number of symbols, stored as an object so it can be saved
+    // in workspaces
+    Obj count;
+
+    // hashtable: a plist containing integers
+    Obj table;
+
+    // a function which maps symbol ids back to names
+    SymbolIdToNameFunc nameFunc;
+
+    // a function which is called whenever a new symbol is
+    // added to the table
+    NewSymbolFunc newSymbolFunc;
+
+#ifdef HPCGAP
+    pthread_rwlock_t lock;
+    void *           lockOwner;
+    UInt             lockDepth;
+#endif
+};
+
+// Initialize kernel part of a SymbolTable (to be called from InitKernel)
+void InitSymbolTableKernel(SymbolTable *      symtab,
+                           const char *       cookieCount,
+                           const char *       cookieTable,
+                           SymbolIdToNameFunc nameFunc,
+                           NewSymbolFunc      newSymbolFunc);
+
+// Initialize library part of a SymbolTable (to be called from InitLibrary)
+void InitSymbolTableLibrary(SymbolTable * symtab);
+
+// Return the number of symbols contained in a SymbolTable (thread safe)
+int LengthSymbolTable(SymbolTable * symtab);
+
+// Return a unique id for the symbol <name> in <symtab>. If the entry
+// is not yet in the table, it is added, and <symtab->newSymbolFunc> is
+// invoked.
+UInt LookupSymbol(SymbolTable * symtab, const char * name);
+
+
+#ifdef HPCGAP
+void LockSymbolTableForReading(SymbolTable * symtab);
+void LockSymbolTableForWriting(SymbolTable * symtab);
+void UnlockSymbolTable(SymbolTable * symtab);
+#endif
+
+
+#endif    // GAP_SYMBOLS_H

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -54,7 +54,7 @@ void InitSymbolTableKernel(SymbolTable *      symtab,
                            NewSymbolFunc      newSymbolFunc);
 
 // Initialize library part of a SymbolTable (to be called from InitLibrary)
-void InitSymbolTableLibrary(SymbolTable * symtab);
+void InitSymbolTableLibrary(SymbolTable * symtab, UInt initialSize);
 
 // Return the number of symbols contained in a SymbolTable (thread safe)
 int LengthSymbolTable(SymbolTable * symtab);


### PR DESCRIPTION
- kernel: get rid of RNamNameWithLen
- kernel: add a dedicated SymbolTable type
- kernel: switch GetInputFilenameID to use a SymbolTable

Resolves #4771 (mostly, at least...?)

Needs some cleanup, but overall seems to work. Using the test function from #4771, and together with PR #4772, I now get the following:
```
gap> for i in [1..100000] do EvalString("12+13"); od; time;
125
gap> for i in [1..100000] do myeval("12+13"); od; time;
119
```

Granted, this is still slower than GAP 4.8, but only by a factor of about 1.5, not 5.5.