### PR TITLE
CI: add a test kernel extension to mockpkg

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
             "testmanuals",
 
             # test error reporting and compiling as well as libgap
-            "testexpect testspecial test-compile testlibgap testkernel",
+            "testexpect testmockpkg testspecial test-compile testlibgap testkernel",
 
             # compile packages and run GAP tests
             # don't use --enable-debug to prevent the tests from taking too long
@@ -98,7 +98,7 @@ jobs:
           # this job also tests GAP without readline
           - os: macos-latest
             shell: bash
-            test-suites: "testinstall"
+            test-suites: "testmockpkg testinstall"
             extra: "BOOTSTRAP_MINIMAL=yes"
 
           # run bugfix regression tests
@@ -123,7 +123,7 @@ jobs:
           # tests using valgrind, as it is too slow.
           - os: ubuntu-18.04
             shell: bash
-            test-suites: "testbuildsys testinstall"
+            test-suites: "testbuildsys testmockpkg testinstall"
             extra: "NO_COVERAGE=1 ABI=64 BUILDDIR=out-of-tree
                     CONFIGFLAGS=\"--enable-valgrind\""
             packages: "valgrind"
@@ -132,7 +132,7 @@ jobs:
           # elsewhere in this file for an explanation).
           - os: ubuntu-18.04
             shell: bash
-            test-suites: "testbuildsys testinstall"
+            test-suites: "testbuildsys testmockpkg testinstall"
             extra: "NO_COVERAGE=1 ABI=32 BUILDDIR=out-of-tree CONFIGFLAGS=\"\""
 
           # test Julia integration
@@ -147,7 +147,7 @@ jobs:
             #   -o igncr: Accept windows line endings
             #   {0} : Pass any extra arguments from CI
             shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
-            test-suites: "testinstall"
+            test-suites: "testmockpkg testinstall"
 
           # TODO: add back big endian test (we had s390x on Travis)
           # TODO: add back test with an older GCC, e.g. 4.7

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ doc/gapmacrodoc.idx
 /tst/testkernel/dstruct
 /tst/testkernel/*.out
 
+/tst/mockpkg/pkg
+
 # emacs backup and lock files
 *~
 \#*\#

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -225,6 +225,18 @@ GAPInput
     make testkernel
     ;;
 
+  testmockpkg)
+    # test building a package kernel extension
+    cd "$SRCDIR/tst/mockpkg"
+    ./configure "$BUILDDIR"
+    make
+    # trick to make it easy to load the package in GAP
+    ln -s . pkg
+    # try to load the kernel extension
+    cd "$BUILDDIR"
+    $GAP -A --cover $COVDIR/testmockpkg.coverage -l "$SRCDIR/tst/mockpkg;" "$SRCDIR/tst/mockpkg/tst/testall.g"
+    ;;
+
   testexpect)
     INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b  --cover $COVDIR/${TEST_SUITE}.coverage" $SRCDIR/dev/gaptest.expect
     ;;

--- a/tst/mockpkg/.gitignore
+++ b/tst/mockpkg/.gitignore
@@ -1,0 +1,3 @@
+/Makefile
+/bin
+/gen

--- a/tst/mockpkg/Makefile.gappkg
+++ b/tst/mockpkg/Makefile.gappkg
@@ -1,0 +1,1 @@
+../../etc/Makefile.gappkg

--- a/tst/mockpkg/Makefile.in
+++ b/tst/mockpkg/Makefile.in
@@ -1,0 +1,9 @@
+#
+# Makefile rules for the mockpkg package
+#
+KEXT_NAME = mockpkg
+KEXT_SOURCES = src/mockpkg.c
+
+# include shared GAP package build system
+GAPPATH = @GAPPATH@
+include Makefile.gappkg

--- a/tst/mockpkg/PackageInfo.g
+++ b/tst/mockpkg/PackageInfo.g
@@ -88,6 +88,7 @@ Dependencies := rec(
 
 AvailabilityTest := function()
   Print("oops, should not print here\n");
+  #return IsKernelExtensionAvailable("mockpkg");
   return true;
 end,
 

--- a/tst/mockpkg/configure
+++ b/tst/mockpkg/configure
@@ -1,0 +1,34 @@
+#!/bin/sh
+# usage: configure gappath
+# this script creates a `Makefile' from `Makefile.in'
+
+set -e
+
+GAPPATH=../..
+while test "$#" -ge 1 ; do
+  option="$1" ; shift
+  case "$option" in
+    --with-gaproot=*) GAPPATH=${option#--with-gaproot=}; ;;
+    -*)               echo "ERROR: unsupported argument $option" ; exit 1;;
+    *)                GAPPATH="$option" ;;
+  esac
+done
+
+if test ! -r "$GAPPATH/sysinfo.gap" ; then
+    echo
+    echo "No file $GAPPATH/sysinfo.gap found."
+    echo
+    echo "Usage: ./configure [GAPPATH]"
+    echo "       where GAPPATH is a path to your GAP installation"
+    echo "       (The default for GAPPATH is \"../..\")"
+    echo
+    echo "Either your GAPPATH is incorrect or the GAP it is pointing to"
+    echo "is not properly compiled (do \"./configure && make\" there first)."
+    echo
+    echo "Aborting... No Makefile is generated."
+    echo
+    exit 1
+fi
+
+echo "Using settings from $GAPPATH/sysinfo.gap"
+sed -e "s;@GAPPATH@;$GAPPATH;g" Makefile.in > Makefile

--- a/tst/mockpkg/init.g
+++ b/tst/mockpkg/init.g
@@ -4,4 +4,8 @@
 # Reading the declaration part of the package.
 #
 
+#if not LoadKernelExtension("mockpkg") then
+#  Error("could not load 'mockpkg' kernel extension")
+#fi;
+
 ReadPackage( "mockpkg", "gap/mockpkg.gd");

--- a/tst/mockpkg/src/mockpkg.c
+++ b/tst/mockpkg/src/mockpkg.c
@@ -1,0 +1,48 @@
+#include <gap_all.h>    // GAP headers
+
+Obj FuncTestCommand(Obj self)
+{
+    return True;
+}
+
+// Table of functions to export
+static StructGVarFunc GVarFuncs[] = {
+    GVAR_FUNC(TestCommand, 0, ""),
+    { 0 }
+};
+
+/****************************************************************************
+**
+*F  InitKernel( <module> ) . . . . . . . .  initialise kernel data structures
+*/
+static Int InitKernel(StructInitInfo * module)
+{
+    InitHdlrFuncsFromTable(GVarFuncs);
+    return 0;
+}
+
+/****************************************************************************
+**
+*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+*/
+static Int InitLibrary(StructInitInfo * module)
+{
+    InitGVarFuncsFromTable(GVarFuncs);
+    return 0;
+}
+
+/****************************************************************************
+**
+*F  Init__Dynamic() . . . . . . . . . . . . . . . . . table of init functions
+*/
+static StructInitInfo module = {
+    .type = MODULE_DYNAMIC,
+    .name = "mockpkg",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+};
+
+StructInitInfo * Init__Dynamic(void)
+{
+    return &module;
+}

--- a/tst/mockpkg/tst/kext.tst
+++ b/tst/mockpkg/tst/kext.tst
@@ -1,0 +1,11 @@
+#
+# Try to load its kernel extension
+#
+gap> LoadPackage("mockpkg");
+true
+gap> IsKernelExtensionAvailable("mockpkg");
+true
+gap> LoadKernelExtension("mockpkg");
+true
+gap> TestCommand();
+true


### PR DESCRIPTION
This is preparation for PR #4746 but also useful on its own.