### PR TITLE
CI: tweak expect test to make it a bit more robust

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -226,7 +226,6 @@ GAPInput
     ;;
 
   testexpect)
-    actual=/tmp/gaptest.expect.actual
     INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b  --cover $COVDIR/${TEST_SUITE}.coverage" $SRCDIR/dev/gaptest.expect
     ;;
 

--- a/dev/gaptest.expect
+++ b/dev/gaptest.expect
@@ -1,4 +1,4 @@
-set timeout 3
+set timeout 10
 
 # from https://serverfault.com/a/981762
 expect_before {
@@ -8,6 +8,7 @@ expect_before {
 
 expect "gap> "
 send -- "var := rec(member := true, data1 := 1, data2 := 2);;\r"
+sleep 0.1
 
 # test tab completing "v" to "var"
 expect "gap> "
@@ -17,6 +18,7 @@ send -- "\t"
 expect "var"
 send -- ";\r"
 expect "rec"
+sleep 0.1
 
 # test tab completing "var.d" to "var.data" to "var.data1" or "var.data2"
 expect "gap> "
@@ -26,6 +28,7 @@ send -- "\t"
 expect "data1  data2"
 send -- "1;\r"
 expect "1"
+sleep 0.1
 
 # the same, but now with some code right before "var.d"
 expect "gap> "


### PR DESCRIPTION
I think it sometimes takes too long to start GAP on the CI, hence it dies. So let's increase the timeout