### PR TITLE
Solvable radical instead of backtrack for centralizer/transporter

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -2510,7 +2510,7 @@ local r,	#radical
     else
       d:=SubgroupByFittingFreeData(G,i[3],i[4],i[2]);
       Assert(2,Size(d)=i[5]);
-      Assert(2,Centralizer(G,i[1])=d);
+      Assert(2,Centralizer(G,i[1]:usebacktrack)=d);
       SetSize(d,i[5]);
       r:=ConjugacyClass(G,i[1],d);
       SetSize(r,Size(G)/i[5]);
@@ -2999,10 +2999,10 @@ InstallMethod( CentralizerOp, "TF method:elm",IsCollsElms,
   IsMultiplicativeElementWithInverse ], OVERRIDENICE,
 function( G, e )
 local ffs;
-  if IsPermGroup(G) or IsPcGroup(G) then TryNextMethod();fi;
-  if not e in G then 
-    # TODO: form larger group containing e.
-    TryNextMethod();
+  if IsPcGroup(G) 
+    or (IsPermGroup(G) and AttemptPermRadicalMethod(G,"CENT")<>true)
+    or not e in G then 
+      TryNextMethod();
   fi;
   e:=TFCanonicalClassRepresentative(G,[e])[1];
   if e=fail then TryNextMethod();fi;
@@ -3041,10 +3041,14 @@ InstallOtherMethod( RepresentativeActionOp, "TF Method on elements",
   OVERRIDENICE,
 function ( G, d, e, act )
 local c;
-  if IsPermGroup(G) or IsPcGroup(G) then TryNextMethod();fi;
-  if not (d in G and e in G) then 
-    # TODO: form larger group containing e.
-    TryNextMethod();
+  if IsPcGroup(G) 
+    or (IsPermGroup(G) and AttemptPermRadicalMethod(G,"CENT")<>true)
+    or not (d in G and e in G) then 
+      TryNextMethod();
+  fi;
+
+  if IsPermGroup(G) and CycleStructurePerm(d)<>CycleStructurePerm(e) then
+    return fail;
   fi;
 
   if act=OnPoints then #and d in G and e in G then

--- a/lib/clasperm.gi
+++ b/lib/clasperm.gi
@@ -69,16 +69,26 @@ end );
 InstallMethod( \in,"perm class rep", IsElmsColls,
   [ IsPerm, IsConjugacyClassPermGroupRep ],
 function( g, cl )
-local   G;
+local   G,c;
 
+    if CycleStructurePerm(g)<>CycleStructurePerm(Representative(cl)) then
+      return false;
+    fi;
     if HasAsList(cl) or HasAsSSortedList(cl) then
       TryNextMethod();
     fi;
+
     G := ActingDomain( cl );
-    return RepOpElmTuplesPermGroup( true, ActingDomain( cl ),
-                   [ g ], [ Representative( cl ) ],
-                   TrivialSubgroup( G ),
-                   StabilizerOfExternalSet( cl ) ) <> fail;
+    if AttemptPermRadicalMethod(G,"CENT") and g in G  then
+      # use TF method
+      c:=TFCanonicalClassRepresentative(G,[g,Representative(cl)]:conjugacytest);
+      return c<>fail and c[1][2]=c[2][2];
+    else
+      return RepOpElmTuplesPermGroup( true, ActingDomain( cl ),
+                    [ g ], [ Representative( cl ) ],
+                    TrivialSubgroup( G ),
+                    StabilizerOfExternalSet( cl ) ) <> fail;
+    fi;
 end );
 
 

--- a/lib/fitfree.gd
+++ b/lib/fitfree.gd
@@ -31,7 +31,8 @@ DeclareInfoClass("InfoFitFree");
 ##
 ##  <Description>
 ##  This filter indicates whether algorithms using the TF-paradigm (Trivial
-##  Fitting) can be used for a group, that is whether a method for
+##  Fitting/Solvable Radical)
+##  can be used for a group, that is whether a method for
 ##  <Ref Func="FittingFreeLiftSetup"/> is available for <A>grp</A>.
 ##  Note that this filter may change its value from <K>false</K> to
 ##  <K>true</K>. 
@@ -48,6 +49,23 @@ InstallTrueMethod(IsGroup,CanComputeFittingFree);
 InstallTrueMethod(CanComputeFittingFree, IsPermGroup);
 InstallTrueMethod(CanComputeFittingFree, IsPcGroup);
 
+#############################################################################
+##
+#F  AttemptPermRadicalMethod( <grp>,<task> )
+##
+##  <#GAPDoc Label="AttemptPermRadicalMethod">
+##  <ManSection>
+##  <Func Name="AttemptPermRadicalMethod" Arg='grp,task'/>
+##
+##  <Description>
+##  Function that encodes (hard-coded) heuristics on whether it is worth to use
+##  Trivial-Fitting/Solvable Radical methods for problems in permutation
+##  groups in favor over backtrack solutions. Returns <K>fail</K> if decision
+##  cannot be made.
+##  The kind of problem is described by a string. Currently supported are
+##  <K>"CENT"</K> for centralizer/element conjugacy.
+##  </Description>
+DeclareGlobalFunction("AttemptPermRadicalMethod");
 
 
 #############################################################################

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -13,6 +13,33 @@
 ##  matrix groups
 ##
 
+InstallGlobalFunction(AttemptPermRadicalMethod,function(G,T)
+local R;
+  if not IsPermGroup(G) then return fail;fi;
+
+  if not (HasFittingFreeLiftSetup(G) or HasSolvableRadical(G)) then 
+    # do not force radical method if it was not tried
+    return false;
+  fi;
+
+  # used in assertions
+  if ValueOption("usebacktrack")=true then return false;fi;
+
+  R:=RadicalGroup(G);
+
+  # any chance to apply it, and not too small?
+  if Size(R)=1 or Size(G)<10000 then return false; fi;
+
+  if T="CENT" then
+    # centralizer/element conjugacy -- degree compares well with radical
+    # factor, but 
+    return NrMovedPoints(G)^2>Size(G)/Size(R);
+  else
+    # Task not yet covered
+    return fail;
+  fi;
+end);
+
 InstallGlobalFunction(FittingFreeSubgroupSetup,function(G,U)
 local cache,ffs,pcisom,rest,it,kpc,k,x,ker,r,pool,i,xx,inv,pregens;
   ffs:=FittingFreeLiftSetup(G);
@@ -1464,4 +1491,5 @@ local ff,i,j,c,q,a,b,prev,sub,m,k;
   od;
   return c;
 end);
+
 

--- a/lib/read5.g
+++ b/lib/read5.g
@@ -185,7 +185,6 @@ ReadLib( "stbcbckt.gi" );
 ReadLib( "stbcrand.gi" );
 ReadLib( "clas.gi"     );
 ReadLib( "claspcgs.gi" );
-ReadLib( "clasperm.gi" );
 ReadLib( "csetgrp.gi"  );
 ReadLib( "csetperm.gi" );
 ReadLib( "csetpc.gi"   );
@@ -217,6 +216,7 @@ ReadLib( "grpnice.gi"  );
 ReadLib( "fitfree.gi"  );
 ReadLib( "permdeco.gi" );
 ReadLib( "clashom.gi"  );
+ReadLib( "clasperm.gi" );
 ReadLib( "maxsub.gi"   );
 ReadLib( "norad.gi"    );
 

--- a/tst/testinstall/ctblmoli.tst
+++ b/tst/testinstall/ctblmoli.tst
@@ -1,4 +1,4 @@
-#@local G,molser,psi,x,y,tbl,irr,lin,deg3,ser,ser2
+#@local G,molser,psi,x,y,tbl,irr,lin,deg3,ser,ser2,m2
 gap> START_TEST("ctblmoli.tst");
 
 #


### PR DESCRIPTION
Permutation groups now use a solvable-radical based method for element centralizer/transporter if the degree is large enough.
Introduce decide function to encapsulate heuristics for when to use solvable radical over backtrack for permgroup 

## Text for release notes

None

