### PR TITLE
kernel: get rid of `name` field in `struct TypInputFile`

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -231,12 +231,6 @@ void SKIP_TO_END_OF_LINE(TypInputFile * input)
 }
 
 
-const Char * GetInputFilename(TypInputFile * input)
-{
-    GAP_ASSERT(input);
-    return input->name;
-}
-
 Int GetInputLineNumber(TypInputFile * input)
 {
     GAP_ASSERT(input);
@@ -259,11 +253,7 @@ Int GetInputLinePosition(TypInputFile * input)
 UInt GetInputFilenameID(TypInputFile * input)
 {
     GAP_ASSERT(input);
-    UInt gapnameid = input->gapnameid;
-    if (gapnameid == 0) {
-        input->gapnameid = LookupSymbol(&FilenameSymbolTable, input->name);
-    }
-    return gapnameid;
+    return input->gapnameid;
 }
 
 static void AddCachedFilename(SymbolTable * symtab, UInt id, Obj name)
@@ -384,8 +374,7 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
     else
         input->echo = FALSE;
 
-    gap_strlcpy(input->name, filename, sizeof(input->name));
-    input->gapnameid = 0;
+    input->gapnameid = LookupSymbol(&FilenameSymbolTable, filename);
 
     // start with an empty line
     input->line[0] = '\0';    // init the pushback buffer
@@ -424,8 +413,7 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
         input->sline = 0;
     }
     input->echo = echo;
-    gap_strlcpy(input->name, "stream", sizeof(input->name));
-    input->gapnameid = 0;
+    input->gapnameid = LookupSymbol(&FilenameSymbolTable, "stream");
 
     // start with an empty line
     input->line[0] = '\0';    // init the pushback buffer

--- a/src/io.h
+++ b/src/io.h
@@ -45,9 +45,6 @@ struct TypInputFile {
     // to 'SyFgets' and 'SyFclose' to identify this file
     Int file;
 
-    // the name of the file; this is only used in error messages
-    char name[256];
-
     //
     UInt gapnameid;
 
@@ -422,9 +419,6 @@ Char PEEK_CURR_CHAR(TypInputFile * input);
 // skip the rest of the current line, ignoring line continuations
 // (used to handle comments)
 void SKIP_TO_END_OF_LINE(TypInputFile * input);
-
-// get the filename of the current input
-const Char * GetInputFilename(TypInputFile * input);
 
 // get the number of the current line in the current thread's input
 Int GetInputLineNumber(TypInputFile * input);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -57,9 +57,9 @@ static void SyntaxErrorOrWarning(ScannerState * s,
             Pr("Syntax warning: %s", (Int)msg, 0);
 
         // ... and the filename + line, unless it is '*stdin*'
-        if (!streq("*stdin*", GetInputFilename(s->input)))
-            Pr(" in %s:%d", (Int)GetInputFilename(s->input),
-               GetInputLineNumber(s->input));
+        Obj name = GetCachedFilename(GetInputFilenameID(s->input));
+        if (!streq("*stdin*", CONST_CSTR_STRING(name)))
+            Pr(" in %g:%d", (Int)name, GetInputLineNumber(s->input));
         Pr("\n", 0, 0);
 
         // print the current line


### PR DESCRIPTION
This results in a super tiny amount of extra work for reading empty files /
files with only comments but no code. On the up side it opens the way for
cleanly supporting paths longer than 256 chars. We still have limits in other
places, but I think they are mostly 1204 or 4096 chars.

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
