### PR TITLE
TestPackage: packages without tests 'pass' their tests

### DIFF
--- a/lib/test.gi
+++ b/lib/test.gi
@@ -1050,7 +1050,8 @@ elif LoadPackage( pkgname ) = fail then
 elif not IsBound( GAPInfo.PackagesInfo.(pkgname)[1].TestFile ) then
     Print("#I No standard tests specified in ", pkgname, " package, version ",
           GAPInfo.PackagesInfo.(pkgname)[1].Version,  "\n");
-    return fail;
+    # Since a TestFile is not required, technically we passed "all" tests
+    return true;
 else
     testfile := Filename( DirectoriesPackageLibrary( pkgname, "" ), 
                           GAPInfo.PackagesInfo.(pkgname)[1].TestFile );


### PR DESCRIPTION
This is a bit unfortunate, but we shouldn't punish packages that don't have
tests as they are not required
