### PR TITLE
Remove incorrect line breaks in the output of `StringFormatted`

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -1387,12 +1387,15 @@ InstallGlobalFunction(PrintToFormatted, function(stream, s, data...)
 end);
 
 InstallGlobalFunction(StringFormatted, function(s, data...)
-    local str;
+    local str, stream;
     if not IsString(s) then
         ErrorNoReturn("Usage: StringFormatted(<string>, <data>...)");
     fi;
     str := "";
-    CallFuncList(PrintToFormatted, Concatenation([OutputTextString(str, false), s], data));
+    stream := OutputTextString(str, false);
+    SetPrintFormattingStatus(stream, false);
+
+    CallFuncList(PrintToFormatted, Concatenation([stream, s], data));
     return str;
 end);
 

--- a/tst/testinstall/format.tst
+++ b/tst/testinstall/format.tst
@@ -61,6 +61,20 @@ gap> StringFormatted("{a!}", rec(a := r1));
 gap> StringFormatted("abc{}def",[1,2]) = "abc[ 1, 2 ]def";
 true
 
+# Test long output
+gap> ListWithIdenticalEntries(1000, 'a') =
+> StringFormatted("{}", ListWithIdenticalEntries(1000, 'a'));
+true
+gap> ListWithIdenticalEntries(1000, 'a') =
+> StringFormatted("{}{}", ListWithIdenticalEntries(500, 'a'), ListWithIdenticalEntries(500, 'a'));
+true
+
+# Test line breaks
+gap>  StringFormatted("{}", "\>1\<") = "\>1\<";
+true
+gap>  StringFormatted("\>1\<") = "\>1\<";
+true
+
 # Test alternative functions
 gap> PrintFormatted();
 Error, Usage: PrintFormatted(<string>, <data>...)


### PR DESCRIPTION
`StringFormatted` delegates to `PrintToFormatted`, but this means long lines get GAP's automatic line wrapping, so disable that.