### PR TITLE
Better errors when loading packages fails

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -599,7 +599,7 @@ InstallGlobalFunction( LogPackageLoadingMessage, function( arg )
       currpkg:= arg[3];
     elif IsBound( GAPInfo.PackageCurrent ) then
       # This happens inside availability tests.
-      currpkg:= GAPInfo.PackageCurrent.PackageName;
+      currpkg:= Concatenation(GAPInfo.PackageCurrent.PackageName, " version ", GAPInfo.PackageCurrent.Version);
     else
       currpkg:= "(unknown package)";
     fi;
@@ -666,7 +666,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
     function( name, version, record, suggested, checkall )
     local InvalidStrongDependencies, Name, equal, comp, pair, currversion,
           inforec, skip, msg, dep, record_local, wght, pos, needed, test,
-          name2, testpair;
+          name2, testpair, fullname;
 
     InvalidStrongDependencies:= function( dependencies, weights,
                                           strong_dependencies )
@@ -761,6 +761,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
     for inforec in PackageInfo( name ) do
 
       Name:= inforec.PackageName;
+      fullname := StringFormatted("{} version {}", inforec.PackageName, inforec.Version);
       skip:= false;
       currversion[2]:= inforec.Version;
 
@@ -790,11 +791,11 @@ InstallGlobalFunction( PackageAvailabilityInfo,
         else
           Add( msg, Concatenation( "(required: ", version, ")" ) );
           LogPackageLoadingMessage( PACKAGE_INFO, msg,
-              inforec.PackageName );
+              fullname );
         fi;
       else
         LogPackageLoadingMessage( PACKAGE_INFO, msg,
-            inforec.PackageName );
+            fullname );
       fi;
 
       # Test whether the required GAP version fits.
@@ -802,8 +803,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
          and not CompareVersionNumbers( GAPInfo.Version, dep.GAP ) then
         LogPackageLoadingMessage( PACKAGE_INFO,
             Concatenation( "PackageAvailabilityInfo: required GAP version (",
-                dep.GAP, ") does not fit",
-            inforec.PackageName ) );
+                dep.GAP, ") does not fit", fullname));
         if not checkall then
           continue;
         fi;
@@ -817,13 +817,11 @@ InstallGlobalFunction( PackageAvailabilityInfo,
       if test = true then
         LogPackageLoadingMessage( PACKAGE_DEBUG,
             Concatenation( "PackageAvailabilityInfo: the AvailabilityTest",
-                " function returned 'true'" ),
-            inforec.PackageName );
+                " function returned 'true'" ), fullname );
       else
         LogPackageLoadingMessage( PACKAGE_INFO,
             Concatenation( "PackageAvailabilityInfo: the AvailabilityTest",
-                " function returned ", String( test ) ),
-            inforec.PackageName );
+                " function returned ", String( test ) ), fullname );
         if not checkall then
           continue;
         fi;
@@ -836,8 +834,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
         LogPackageLoadingMessage( PACKAGE_WARNING,
             Concatenation( "PackageAvailabilityInfo: cannot locate `",
               inforec.InstallationPath,
-              "/init.g', please check the installation" ),
-            inforec.PackageName );
+              "/init.g', please check the installation" ), fullname );
         if not checkall then
           continue;
         fi;
@@ -884,13 +881,13 @@ InstallGlobalFunction( PackageAvailabilityInfo,
       if IsEmpty( needed ) then
         LogPackageLoadingMessage( PACKAGE_DEBUG,
             "PackageAvailabilityInfo: no needed packages",
-            inforec.PackageName );
+            fullname );
       else
         LogPackageLoadingMessage( PACKAGE_DEBUG, Concatenation(
             [ "PackageAvailabilityInfo: check needed packages" ],
             List( needed,
                   pair -> Concatenation( pair[1], " (", pair[2], ")" ) ) ),
-            inforec.PackageName );
+            fullname );
         for pair in needed do
           name2:= LowercaseString( pair[1] );
           testpair:= PackageAvailabilityInfo( name2, pair[2], record_local,
@@ -900,7 +897,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
             test:= false;
             LogPackageLoadingMessage( PACKAGE_INFO,
                 Concatenation( "PackageAvailabilityInfo: dependency '",
-                    name2, "' is not satisfied" ), inforec.PackageName );
+                    name2, "' is not satisfied" ), fullname );
             if not checkall then
               # Skip the check of other dependencies.
               break;
@@ -912,7 +909,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
         od;
         LogPackageLoadingMessage( PACKAGE_DEBUG,
             "PackageAvailabilityInfo: check of needed packages done",
-            inforec.PackageName );
+            fullname );
       fi;
       if test = false then
         # At least one package needed by this version is not available,
@@ -956,7 +953,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
             [ "PackageAvailabilityInfo: check suggested packages" ],
             List( dep.SuggestedOtherPackages,
                   pair -> Concatenation( pair[1], " (", pair[2], ")" ) ) ),
-            inforec.PackageName );
+            fullname );
         for pair in dep.SuggestedOtherPackages do
           name2:= LowercaseString( pair[1] );
           # Do not change the information collected up to now
@@ -984,7 +981,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
         od;
         LogPackageLoadingMessage( PACKAGE_DEBUG,
             "PackageAvailabilityInfo: check of suggested packages done",
-            inforec.PackageName );
+            fullname );
       fi;
 
       # Print a warning if the package should better be upgraded.


### PR DESCRIPTION
This PR tries to improve the messages we show users when a package fails to load. It means when a package fails to load users are shown a (hopefully brief) explanation of what went wrong, without having to rerun, turning up the info level.

Some general comments:

* Messages are only shown if the package banner isn't hidden (under the assumption people who want the banner hiding don't want lots of output).
* Messages are only shown for failures of required dependencies (unlike if you turn up the info level when you see information about both required and optional dependencies).
* This PR also adds version numbers to errors, which is useful if users have multiple versions installed (this could be separated)

As an example, the package `Vole` has a number of requirements, one of which is `BacktrackKit`, which requires `Digraphs`. I have two digraphs installed, neither is compiled. The new output is:

```
#I  Digraphs version 1.5.0: PackageAvailabilityInfo: the AvailabilityTest function returned fail
#I  Digraphs version 1.3.1: PackageAvailabilityInfo: the AvailabilityTest function returned fail
#I  Digraphs: PackageAvailabilityInfo: no installed version fits
#I  BacktrackKit version 0.6.2: PackageAvailabilityInfo: dependency 'digraphs' is not satisfied
#I  BacktrackKit: PackageAvailabilityInfo: no installed version fits
#I  Vole version 0.5.3: PackageAvailabilityInfo: dependency 'backtrackkit' is not satisfied
#I  Vole: PackageAvailabilityInfo: no installed version fits
#I  Vole package is not available. To see further details, enter
#I  SetInfoLevel(InfoPackageLoading,4); and try to load the package again.
```

There is one possible annoyance -- errors are printed for packages if a newer version does not work, but an older one does, for example, if I compile digraphs 1.3.1 from above, now the only error I see is:

```
#I  Digraphs version 1.5.0: PackageAvailabilityInfo: the AvailabilityTest function returned fail
```

I personally feel this is useful -- it tells the user they have a more recent version that wasn't loaded. However, it's also hard to hide this message without significant overhaul.