### PR TITLE
Fixed the error handling of `AllHomomorphisms` and `AllHomomorphismClasses`

### DIFF
--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -921,9 +921,9 @@ local cl,cnt,bg,bw,bo,bi,k,gens,go,imgs,params,emb,clg,sg,vsu,c,i;
 
   if not HasIsFinite(H) then
     Info(InfoPerformance,1,"Forcing finiteness test -- might not terminate");
-    if not IsFinite(H) then
-      Error("First argument must be finite group");
-    fi;
+  fi;
+  if not IsFinite(H) then
+    Error("the first argument must be a finite group");
   fi;
 
   if IsAbelian(G) and not IsAbelian(H) then

--- a/tst/testinstall/teaching.tst
+++ b/tst/testinstall/teaching.tst
@@ -1,0 +1,18 @@
+#@local H, G
+
+gap> START_TEST( "teaching.tst" );
+
+#
+gap> H:= CyclicGroup( infinity );;  G:= CyclicGroup( 2 );;
+gap> AllHomomorphisms( H, G );  # test for 'H' that does not know to be infinite
+Error, the first argument must be a finite group
+
+#
+gap> H:= CyclicGroup( infinity );;  G:= CyclicGroup( 2 );;
+gap> IsFinite( H );
+false
+gap> AllHomomorphisms( H, G );  # test for 'H' that knows to be infinite
+Error, the first argument must be a finite group
+
+#
+gap> STOP_TEST( "teaching.tst" );


### PR DESCRIPTION
The relevant change in pull request #4054 did not catch the situation that the first group knows to be infinite.

This change is not a bugfix in the sense that the documentation has been changed since GAP 4.11 such that the arguments of `AllHomomorphisms` and `AllHomomorphismsClasses` must be finite, and thus we do not have to raise an error if the first argument is infinite. However, since there was already an error handler, I think it should catch also the case that was missing up to now.

Since pull request #4054 does not generate an entry for the release notes, the title of the current pull request is perhaps suitable for explaining that there was some interesting change.