### PR TITLE
kernel: change `SyExecuteProcess` to use `posix_spawn`

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1624,8 +1624,8 @@ static UInt syCTRO; // number of '<ctr>-O' pending
 static UInt syESCN; // number of '<Esc>-N' pending
 
 UInt FreezeStdin;    // When true, ignore if any new input from stdin
-                            // This is used to stop HPC-GAP from reading stdin
-                            // while forked subprocesses are running.
+                     // This is used to stop HPC-GAP from reading stdin
+                     // while forked subprocesses are running.
 
 
 #ifdef HAVE_SELECT


### PR DESCRIPTION
@ChrisJefferson does this work under cygwin? If so, does it fix the bug where `Process` is changing the working dir for the parent process?

The patch is not ready for merging in any case:
- handling of SIGCHLD not integreated
- moving `SyExecuteProcess` to `iostream.c` is kind of a hack, but for the sake of quickly experimenting I didn't want to bother with trying to come up with a "clean" solution.