### PR TITLE
BuildPackages.sh: don't use GAP_ABI anymore

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -124,26 +124,6 @@ else
 fi
 
 
-
-# detect whether GAP was built in 32bit mode
-# TODO: once all packages have adapted to the new build system,
-# this should no longer be necessary, as package build systems should
-# automatically adjust to 32bit mode.
-case "$GAP_ABI" in
-  32)
-    notice "Building with 32-bit ABI"
-    CONFIGFLAGS="CFLAGS=-m32 LDFLAGS=-m32 LOPTS=-m32 CXXFLAGS=-m32"
-    ;;
-  64)
-    notice "Building with 64-bit ABI"
-    CONFIGFLAGS=""
-    ;;
-  *)
-    error "Unsupported GAP ABI '$GAParch_abi'."
-    ;;
-esac
-
-
 LOGDIR=log
 mkdir -p "$LOGDIR"
 
@@ -200,7 +180,7 @@ Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput
 )
       local CONFIG_ARGS_FLAG_NAME="PACKAGE_CONFIG_ARGS_${PKG_NAME}"
-      echo_run ./configure --with-gaproot="$GAPROOT" $CONFIGFLAGS ${!CONFIG_ARGS_FLAG_NAME}
+      echo_run ./configure --with-gaproot="$GAPROOT" ${!CONFIG_ARGS_FLAG_NAME}
       echo_run "$MAKE" clean
     else
       echo_run ./configure "$GAPROOT"


### PR DESCRIPTION
Don't try to inject 32bit build flags into package build systems. Any necessary flags should already be contained in GAP_{C,CXX,LD}FLAGS, which package build systems should honor. If they don't, they should be adjusted.


This change might break tests in 32bit mode, requiring fixes to individual packages. But overall it should be fine. And 32bit mode realistically only is a "2nd class citizen" these days, and we may eventually want to make this official, too...