### PR TITLE
kernel: add #define to disable subprocess code

### DIFF
--- a/src/iostream.c
+++ b/src/iostream.c
@@ -37,6 +37,8 @@
 
 #include "config.h"
 
+#ifndef GAP_DISABLE_SUBPROCESS_CODE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -804,6 +806,60 @@ static Obj FuncFD_OF_IOSTREAM(Obj self, Obj stream)
     return result;
 }
 
+#else // !defined(GAP_DISABLE_SUBPROCESS_CODE)
+
+int CheckChildStatusChanged(int childPID, int status)
+{
+    return 0;
+}
+
+static Obj FuncCREATE_PTY_IOSTREAM(Obj self, Obj dir, Obj prog, Obj args)
+{
+    return Fail;
+}
+
+static Obj FuncWRITE_IOSTREAM(Obj self, Obj stream, Obj string, Obj len)
+{
+    return Fail;
+}
+
+static Obj FuncREAD_IOSTREAM(Obj self, Obj stream, Obj len)
+{
+    return Fail;
+}
+
+static Obj FuncREAD_IOSTREAM_NOWAIT(Obj self, Obj stream, Obj len)
+{
+    return Fail;
+}
+
+static Obj FuncKILL_CHILD_IOSTREAM(Obj self, Obj stream)
+{
+    return 0;
+}
+
+static Obj FuncSIGNAL_CHILD_IOSTREAM(Obj self, Obj stream, Obj sig)
+{
+    return 0;
+}
+
+static Obj FuncCLOSE_PTY_IOSTREAM(Obj self, Obj stream)
+{
+    return 0;
+}
+
+static Obj FuncIS_BLOCKED_IOSTREAM(Obj self, Obj stream)
+{
+    return Fail;
+}
+
+static Obj FuncFD_OF_IOSTREAM(Obj self, Obj stream)
+{
+    return Fail;
+}
+
+#endif
+
 
 /****************************************************************************
 **
@@ -841,6 +897,7 @@ static StructGVarFunc GVarFuncs[] = {
 */
 static Int InitKernel(StructInitInfo * module)
 {
+#ifndef GAP_DISABLE_SUBPROCESS_CODE
     UInt i;
     PtyIOStreams[0].childPID = -1;
     for (i = 1; i < MAX_PTYS; i++) {
@@ -849,13 +906,15 @@ static Int InitKernel(StructInitInfo * module)
     }
     FreePtyIOStreams = MAX_PTYS - 1;
 
-    /* init filters and functions                                          */
-    InitHdlrFuncsFromTable(GVarFuncs);
-
 #if !defined(HPCGAP)
     /* Set up the trap to detect future dying children */
     signal(SIGCHLD, ChildStatusChanged);
 #endif
+
+#endif
+
+    /* init filters and functions                                          */
+    InitHdlrFuncsFromTable(GVarFuncs);
 
     return 0;
 }

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -2791,6 +2791,20 @@ void SySetErrorNo ( void )
 *F * * * * * * * * * * * * * file and execution * * * * * * * * * * * * * * *
 */
 
+#ifdef GAP_DISABLE_SUBPROCESS_CODE
+
+UInt SyExecuteProcess (
+    Char *                  dir,
+    Char *                  prg,
+    Int                     in,
+    Int                     out,
+    Char *                  args[] )
+{
+    return 255;
+}
+
+#else
+
 /****************************************************************************
 **
 *F  SyExecuteProcess( <dir>, <prg>, <in>, <out>, <args> ) . . . . new process
@@ -3027,6 +3041,7 @@ UInt SyExecuteProcess (
 
 #endif
 
+#endif // !GAP_DISABLE_SUBPROCESS_CODE
 
 /****************************************************************************
 **


### PR DESCRIPTION
This helps debug whether the Julia replacements for GAP's subprocess
code are fully in place, and ensure we don't forget anything. More
importantly, it disables the SIGCHLD handler in the GAP kernel.

In the future we could also add configure flag to set it.

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
