### PR TITLE
improve `GroupHomomorphismByFunction`

### DIFF
--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -1552,6 +1552,17 @@ RedispatchOnCondition(IsomorphismPcGroup,true,[IsGroup],[IsFinite],0);
 ##
 #F  GroupHomomorphismByFunction( <D>, <E>, <fun> )
 #F  GroupHomomorphismByFunction( <D>, <E>, <fun>, <invfun> )
+#F  GroupHomomorphismByFunction( <D>, <E>, <fun>, false, <prefun> )
+##
+##  The five argument version (independent of the actual value of the fourth
+##  argument) creates a mapping that is not necessarily bijective
+##  but for which <prefun> can be used to compute preimages.
+##
+##  For the three argument version,
+##  the filter 'IsPreimagesByAsGroupGeneralMappingByImages' is set in the
+##  mapping, which means that preimages will be computed by a group
+##  homomorphism constructed by mapping generators of <D> to their images
+##  under <fun>.
 ##
 InstallGlobalFunction( GroupHomomorphismByFunction, function ( arg )
 local map,type,prefun;
@@ -1565,9 +1576,7 @@ local map,type,prefun;
         prefun:=arg[5];
       else
         prefun:=fail;
-        if IsPermGroup(arg[2]) or IsPcGroup(arg[2]) then
-          type:=type and IsPreimagesByAsGroupGeneralMappingByImages;
-        fi;
+        type:= type and IsPreimagesByAsGroupGeneralMappingByImages;
       fi;
 
       # make the general mapping

--- a/tst/testinstall/mapphomo.tst
+++ b/tst/testinstall/mapphomo.tst
@@ -70,4 +70,12 @@ gap> GroupHomomorphismByImages(G, H, [(1,2)], [(1,2,3)]);
 fail
 gap> GroupHomomorphismByImages(G, H, [], []);
 fail
-gap> STOP_TEST( "mapphomo.tst", 1);
+
+# Check that group homomorphisms created by a function can compute preimages.
+gap> for G in [ SymmetricGroup(5), SmallGroup( 24, 12 ), GL(2,3) ] do
+>      hom:= GroupHomomorphismByFunction( G, G, x -> x );
+>      PreImagesRepresentative( hom, G.1 );
+>    od;
+
+#
+gap> STOP_TEST( "mapphomo.tst" );


### PR DESCRIPTION
resolves #4806

Set `IsPreimagesByAsGroupGeneralMappingByImages` for any
homomorphism constructed with `GroupHomomorphismByFunction`
that does not know a function or computing preimages.