### PR TITLE
fp groups with more gens than rels are infinite

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -3906,7 +3906,7 @@ local   fgens,      # generators of the free group
   # handle free and trivial group
   if 0 = Length( fgens ) then
       return 1;
-  elif 0 = Length(rels) then
+  elif Length( fgens ) > Length(rels) then
       return infinity;
 
   # handle nontrivial fp group by computing the index of its trivial


### PR DESCRIPTION
This is actually normally already set when the fp groups is created. But with that argument, the code being modified here could be removed outright? In any case, if someone manages to produce such a group with some alternate means, this could be useful after all?