### PR TITLE
BugFix: Fix crash when QuitGap is called while reading from an InputTextString

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -983,7 +983,14 @@ static Int GetLine2(TypInputFile * input)
         if (input->sline == 0 ||
             (IS_STRING_REP(input->sline) &&
              GET_LEN_STRING(input->sline) <= input->spos)) {
-            input->sline = CALL_1ARGS( ReadLineFunc, input->stream );
+            // If we are in the process of quitting, we cannot call
+            // GAP functions, so we just return EOF.
+            if (STATE(UserHasQuit) || STATE(UserHasQUIT)) {
+                input->sline = Fail;
+            }
+            else {
+                input->sline = CALL_1ARGS(ReadLineFunc, input->stream);
+            }
             input->spos  = 0;
         }
         if ( input->sline == Fail || ! IS_STRING(input->sline) ) {

--- a/tst/testspecial/error-in-InputTextString.g
+++ b/tst/testspecial/error-in-InputTextString.g
@@ -1,0 +1,2 @@
+READ_NORECOVERY(InputTextString("Print(1 + [()]);"));
+quit;

--- a/tst/testspecial/error-in-InputTextString.g.out
+++ b/tst/testspecial/error-in-InputTextString.g.out
@@ -1,0 +1,9 @@
+gap> READ_NORECOVERY(InputTextString("Print(1 + [()]);"));
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
+<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
+ called from read-eval loop at stream:1
+type 'quit;' to quit to outer loop
+brk> quit;
+fail
+gap> QUIT;

--- a/tst/testspecial/exit-in-InputTextString.g
+++ b/tst/testspecial/exit-in-InputTextString.g
@@ -1,0 +1,1 @@
+READ_NORECOVERY(InputTextString("Print(QuitGap(0));"));

--- a/tst/testspecial/exit-in-InputTextString.g.out
+++ b/tst/testspecial/exit-in-InputTextString.g.out
@@ -1,0 +1,1 @@
+gap> READ_NORECOVERY(InputTextString("Print(QuitGap(0));"));


### PR DESCRIPTION
Fixes #4820 

I don't really like this, but I also don't have a better option.