### PR TITLE
CI: install fewer texlive packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,9 +199,7 @@ jobs:
                          texlive-latex-base
                          texlive-latex-recommended
                          texlive-latex-extra
-                         texlive-extra-utils
                          texlive-fonts-recommended
-                         texlive-fonts-extra
                        )
                    fi
                    if [[ $ABI == 32 ]] ; then
@@ -212,7 +210,7 @@ jobs:
                        packages+=(gcc-multilib g++-multilib)
                    fi
                    sudo apt-get update
-                   sudo apt-get install "${packages[@]}"
+                   sudo apt-get install --no-install-recommends "${packages[@]}"
                elif [ "$RUNNER_OS" == "macOS" ]; then
                    brew install gmp zlib
                fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,10 @@ jobs:
             texlive-latex-base
             texlive-latex-recommended
             texlive-latex-extra
-            texlive-extra-utils
             texlive-fonts-recommended
-            texlive-fonts-extra
           )
           sudo apt-get update
-          sudo apt-get install "${packages[@]}"
+          sudo apt-get install --no-install-recommends "${packages[@]}"
       - name: "Configure GAP"
         run: dev/ci-configure-gap.sh
       - name: "Build GAP"


### PR DESCRIPTION
Before: installs 79 packages, downloads 542 MB, uses 1482 MB disk space

After: installs 26 packages, downloads 77.8 MB, uses 274 MB disk space

By far the biggest chunk was `texlive-fonts-extra` which needed to
download ~350 MB and used ~900 MB disk space.

---

Let's see how it works in practice. I may have to add back some packages.

See also https://github.com/gap-actions/build-pkg-docs/pull/12