### PR TITLE
CI: error if there aren't artifacts to upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,8 +230,9 @@ jobs:
         run: ${{ matrix.extra }} dev/ci.sh
       - name: "Upload pdf manuals"
         if: ${{ matrix.test-suites == 'makemanuals' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: manuals-pdf
           path: |
             doc/dev/manual.pdf
@@ -240,8 +241,9 @@ jobs:
             doc/tut/manual.pdf
       - name: "Upload html manuals"
         if: ${{ matrix.test-suites == 'makemanuals' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: manuals-html
           path: |
             doc/*/*.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,16 +97,18 @@ jobs:
       # Warning: the result is a single .zip file (so things are compressed twice).
       - name: "Upload GAP tarball"
         if: ${{ (!startsWith(github.ref, 'refs/tags/v') && failure()) || github.event_name == 'schedule' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: gap-${{ steps.get-build.outputs.name }}.tar.gz
           path: tmp/gap-${{ steps.get-build.outputs.name }}.tar.gz
           retention-days: 1
 
       # Always upload metadata, and keep longer, since it is much smaller.
       - name: "Upload JSON metadata"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: "JSON metadata"
           path: tmp/*json.gz
           retention-days: 7
@@ -269,8 +271,9 @@ jobs:
       # Artifacts live for 1 day, i.e. until the next cron job runs.
       - name: "Upload the installer as an artifact"
         if: ${{ github.event_name == 'schedule' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
+          if-no-files-found: error
           name: gap-${{ env.GAP_BUILD_VERSION }}-${{ matrix.arch }}.exe
           path: sage-windows/Output/gap-${{ env.GAP_BUILD_VERSION }}-${{ matrix.arch }}.exe
           retention-days: 1


### PR DESCRIPTION
And upgrade to `actions/upload-artifact@v3` (from `v2`, because why not). This is related to #4824.