### PR TITLE
buildsys: switch to new package distribution

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1233,9 +1233,9 @@ testkernel: ${KERNELTESTS}
 
 # change PKG_BRANCH to stable-X.Y in the stable branch
 PKG_BRANCH = master
-PKG_BOOTSTRAP_URL = https://github.com/gap-system/gap-distribution/releases/download/package-archives/
-PKG_MINIMAL = packages-required-$(PKG_BRANCH).tar.gz
-PKG_FULL = packages-$(PKG_BRANCH).tar.gz
+PKG_BOOTSTRAP_URL = https://github.com/gap-system/PackageDistro/releases/download/latest/
+PKG_MINIMAL = packages-required.tar.gz
+PKG_FULL = packages.tar.gz
 DOWNLOAD = $(abs_srcdir)/cnf/download.sh
 
 bootstrap-pkg-minimal:


### PR DESCRIPTION
The new package distribution we started during the recent GAP Days is basically ready for use. I am not saying everything is done in terms of the automation. But I think it is sufficiently good for us to use. And it already contains dozens of package updates not in the current / "old" distribution.

Also please feel free to have a look at https://github.com/gap-system/PackageDistro for information on how things work. Feedback, suggestions and help are welcome.