### PR TITLE
Fix BuildPackages.sh

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -267,7 +267,13 @@ build_one_package() {
       run_configure_and_make
     ;;
   esac
-  ) && ([[ $GITHUB_ACTIONS = true ]] && echo "::endgroup::") || build_fail
+  ) &&
+  (  # start subshell
+  if [[ $GITHUB_ACTIONS = true ]]
+  then
+    echo "::endgroup::"
+  fi
+  ) || build_fail
 }
 
 date >> "$LOGDIR/fail.log"


### PR DESCRIPTION
When I added support for grouping the output of BuildPackages.sh in
our CI scripts, I accidentally broke running the script normally;
it now printed `Failed to build $PKG` for every package, even if it
built just fine.
