### PR TITLE
CI: use ccache to speed up compilation, esp. of packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -217,6 +217,13 @@ jobs:
                fi
                python -m pip install gcovr
 
+      # Setup ccache, to speed up repeated compilation of the same binaries
+      # (i.e., GAP and the packages)
+      - name: "Setup ccache"
+        if: ${{ runner.os != 'Windows' }}
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          update_packager_index: false
       - name: "Configure GAP"
         run: ${{ matrix.extra }} dev/ci-configure-gap.sh
       - name: "Build GAP"


### PR DESCRIPTION
For the PackageDistro, this reduced the time to compile GAP package binaries by several minutes in case of a cache hit (i.e. all the time unless the package is updated in the package distribution).
