### PR TITLE
Pc group improvements

### DIFF
--- a/doc/ref/ctbl.xml
+++ b/doc/ref/ctbl.xml
@@ -493,9 +493,6 @@ yielding smaller spaces and several irreducible characters.
 gap> DixonSplit( d );
 #I  Matrix 2,Representative of Order 3,Centralizer: 5832
 #I  Dimensions: [ [ 1, 6 ], [ 2, 3 ], [ 4, 1 ], [ 12, 1 ] ]
-#I  Two-dim space split
-#I  Two-dim space split
-#I  Two-dim space split
 2
 ]]></Example>
 <P/>

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -3004,9 +3004,9 @@ local ffs,c;
     or not e in G then 
       TryNextMethod();
   fi;
-  c:=TFCanonicalClassRepresentative(G,[e])[1];
-  if c=fail then TryNextMethod();fi;
   ffs:=FittingFreeLiftSetup(G);
+  c:=TFCanonicalClassRepresentative(G,[e]:useradical:=false)[1];
+  if c=fail then TryNextMethod();fi;
   c:=SubgroupByFittingFreeData(G,c[6],c[7],
     InducedPcgsByGenerators(ffs.pcgs,c[5]))^Inverse(c[4]);
   Assert(2,ForAll(GeneratorsOfGroup(c),x->IsOne(Comm(x,e))));
@@ -3054,7 +3054,7 @@ local c;
   fi;
 
   if act=OnPoints then #and d in G and e in G then
-    c:=TFCanonicalClassRepresentative(G,[d,e]:conjugacytest);
+    c:=TFCanonicalClassRepresentative(G,[d,e]:conjugacytest,useradical:=false);
     if c=fail then
       return fail;
     else

--- a/lib/claspcgs.gi
+++ b/lib/claspcgs.gi
@@ -739,7 +739,6 @@ local  G,  home,  # the group and the home pcgs
   if candidates<>false then
     cls:=List(candidates, c -> cl);
     opr:=List(candidates, c -> One(G));
-    exp:=ListWithIdenticalEntries(Length(candidates), 1);
   else
     cls:=[cl];
   fi;
@@ -948,7 +947,7 @@ Error("This case disabled -- code not yet corrected");
         divi:=DivisorsInt(Size(G));
       fi;
       c:=Concatenation(c,List(divi,i->[i,0])); # to cope with `First'
-      Info(InfoClasses,2,List(divi,i->First(c,j->j[1]=i)[2]));
+      Info(InfoClasses,6,List(divi,i->First(c,j->j[1]=i)[2]));
     fi;
 
   od;

--- a/lib/clasperm.gi
+++ b/lib/clasperm.gi
@@ -81,7 +81,7 @@ local   G,c;
     G := ActingDomain( cl );
     if AttemptPermRadicalMethod(G,"CENT") and g in G  then
       # use TF method
-      c:=TFCanonicalClassRepresentative(G,[g,Representative(cl)]:conjugacytest);
+      c:=TFCanonicalClassRepresentative(G,[g,Representative(cl)]:conjugacytest,useradical:=false);
       return c<>fail and c[1][2]=c[2][2];
     else
       return RepOpElmTuplesPermGroup( true, ActingDomain( cl ),
@@ -170,10 +170,5 @@ InstallMethod( \in, true, [ IsPerm, IsRationalClassPermGroupRep ], 0,
     # the Galois group of the identity is <0>, therefore we have to do this
     # extra test.
     return Order(Representative(cl))=Order(g) and
-     ForAny( RightTransversalInParent( GaloisGroup( cl ) ), e ->
-                   RepOpElmTuplesPermGroup( true, G,
-                           [ g ^ Int( e ) ],
-                           [ Representative( cl ) ],
-                           TrivialSubgroup( G ),
-                           StabilizerOfExternalSet( cl ) ) <> fail );
+     ForAny(DecomposedRationalClass(cl),x->g in x);
 end );

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -23,7 +23,8 @@ local R;
   fi;
 
   # used in assertions
-  if ValueOption("usebacktrack")=true then return false;fi;
+  if ValueOption("usebacktrack")=true then return false;
+  elif ValueOption("useradical")=true then return true;fi;
 
   R:=RadicalGroup(G);
 

--- a/lib/grppcaut.gi
+++ b/lib/grppcaut.gi
@@ -1249,6 +1249,7 @@ InstallGlobalFunction(AutomorphismGroupSolvableGroup,function( G )
 	  fi;
 	  if actbase<>fail then
 	    e:=List(actbase,x->quotimg(H,pcgsH,x));
+            IsGroupOfAutomorphismsFiniteGroup(A);
 	    NiceMonomorphism(A:autactbase:=e);
 	  fi;
 
@@ -1463,6 +1464,7 @@ InstallGlobalFunction(AutomorphismGroupSolvableGroup,function( G )
 	  tmp:=Size(A);
 	  if actbase<>fail then
 	    e:=List(actbase,x->quotimg(H,pcgsH,x));
+            IsGroupOfAutomorphismsFiniteGroup(A);
 	    NiceMonomorphism(A:autactbase:=e);
 	  fi;
 	  for e in B do

--- a/tst/testbugfix/2022-03-20-pcisom.tst
+++ b/tst/testbugfix/2022-03-20-pcisom.tst
@@ -1,0 +1,5 @@
+# Pc Isomorphism #4827
+gap> IsomorphismGroups(SmallGroup(2156,2),SmallGroup(2156,2))=fail;
+false
+gap> IsomorphismGroups(SmallGroup(2156,2),SmallGroup(2156,1))=fail;
+true

--- a/tst/teststandard/opers/Ctbl.tst
+++ b/tst/teststandard/opers/Ctbl.tst
@@ -1,0 +1,12 @@
+gap> START_TEST("Ctbl.tst");
+
+#
+gap> g:=Group((1,2,3),(1,2));;w:=WreathProductImprimitiveAction(g,g);;
+gap> w:=Image(IsomorphismSpecialPcGroup(w));;
+gap> Length(ConjugacyClasses(w));
+22
+gap> Length(Irr(w));
+22
+
+#
+gap> STOP_TEST("Ctbl.tst",1);


### PR DESCRIPTION
Speed up of character tables for pc groups by attempting parallelized identification. And a minor fix (still needed for using MatrixObj) therein.

Pc isomorphism test resolves #4827 

Allow option to not use solvable radical method for class id.

The fixes are for issues only in the devel version, so no need to mention.