### PR TITLE
Remove upranking of method that collides with semigroups package.

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -296,11 +296,7 @@ InstallMethod( Matrix,
                                       R, nrCols, list ) );
 
 InstallMethod( Matrix,
-    [ IsSemiring, IsList ],
-# rank higher than a method in the semigroups package, which otherwise jumps
-# in and causes an error when testing
-# line 318 of semigroups-3.4.0/gap/elements/semiringmat.gi
-20,
+    [ IsSemiring, IsList ], 0,
     function( R, list )
     if Length(list) = 0 then
       Error( "list must be not empty" );


### PR DESCRIPTION
This ought to fix #4814, but will only pass tests is the semigroups package
changes its method
line 318 of semigroups-3.4.0/gap/elements/semiringmat.gi
to fall back on `TryNextMethod` instead of issuing a hard error.

As of 3/20/22 the tests with all packages loaded fail in semigroups
