### PR TITLE
Further improvements to pc group character table computation

### DIFF
--- a/lib/clas.gd
+++ b/lib/clas.gd
@@ -286,6 +286,7 @@ DeclareGlobalFunction( "CentralStepRatClPGroup" );
 DeclareGlobalFunction( "CentralStepClEANS" );
 DeclareGlobalFunction( "CorrectConjugacyClass" );
 DeclareGlobalFunction( "GeneralStepClEANS" );
+DeclareGlobalFunction("PcClassFactorCentralityTest");
 
 #############################################################################
 ##

--- a/lib/clas.gd
+++ b/lib/clas.gd
@@ -356,6 +356,9 @@ DeclareGlobalFunction( "GeneralStepClEANS" );
 ##
 DeclareGlobalFunction( "ClassesSolvableGroup" );
 
+# faster version for character table code
+DeclareGlobalFunction("MultiClassIdsPc");
+
 #############################################################################
 ##
 #F  RationalClassesSolvableGroup(<G>, <mode> [,<opt>])  . . . . .

--- a/lib/claspcgs.gi
+++ b/lib/claspcgs.gi
@@ -509,6 +509,22 @@ local  classes,    # classes to be constructed, the result
     return classes;
 end );
 
+# Test whether <Npcgs> is central in <grpg> modulo depth in <pcgs>.
+# This test is faster than membership with `in'. It is used in pc
+# class/centralizer computation
+InstallGlobalFunction(PcClassFactorCentralityTest,
+    function(pcgs,grpg,Npcgs,dep)
+	  local i,j;
+	    for i in grpg do
+	      for j in Npcgs do
+	        if DepthOfPcElement(pcgs,Comm(j,i))<dep then
+		  return false;
+		fi;
+	      od;
+	    od;
+	    return true;
+          end);
+
 #############################################################################
 ##
 #F  ClassesSolvableGroup(<G>, <mode> [,<opt>])  . . . . .
@@ -617,7 +633,7 @@ local  G,  home,  # the group and the home pcgs
 
     cent:=false;
 
-  elif IsPrimePowerInt(Size(G)) then
+  elif IsPGroup(G) then
     p:=PrimePGroup(G);
     home:=PcgsPCentralSeriesPGroup(G);
     eas:=PCentralNormalSeriesByPcgsPGroup(home);
@@ -643,18 +659,7 @@ local  G,  home,  # the group and the home pcgs
   fi;
 
   if cent=false then
-    # AH, 26-4-99: Test centrality not via `in' but via exponents
-    cent:=function(pcgs,grpg,Npcgs,dep)
-	  local i,j;
-	    for i in grpg do
-	      for j in Npcgs do
-	        if DepthOfPcElement(pcgs,Comm(j,i))<dep then
-		  return false;
-		fi;
-	      od;
-	    od;
-	    return true;
-          end;
+    cent:=PcClassFactorCentralityTest;
   fi;
   indstep:=IndicesEANormalSteps(home);
 
@@ -1031,7 +1036,7 @@ local  G,home,  # the group and the home pcgs
     # Calculate a (central)  elementary abelian series  with all pcgs induced
     # w.r.t. <homepcgs>.
 
-    if IsPrimePowerInt(Size(G)) then
+    if IsPGroup(G) then
       p:=PrimePGroup(G);
       home:=PcgsPCentralSeriesPGroup(G);
       eas:=PCentralNormalSeriesByPcgsPGroup(home);
@@ -1041,18 +1046,7 @@ local  G,home,  # the group and the home pcgs
       home:=PcgsElementaryAbelianSeries(G);
       eas:=EANormalSeriesByPcgs(home);
 
-      # AH, 26-4-99: Test centrality not via `in' but via exponents
-      cent:=function(pcgs,grpg,Npcgs,dep)
-            local i,j;
-              for i in grpg do
-                for j in Npcgs do
-                  if DepthOfPcElement(pcgs,Comm(j,i))<dep then
-                    return false;
-                  fi;
-                od;
-              od;
-              return true;
-            end;
+      cent:=PcClassFactorCentralityTest;
     fi;
 
     indstep:=IndicesEANormalSteps(home);
@@ -1428,7 +1422,7 @@ local  G,  home,  # the group and the home pcgs
       return ForAll(N, k -> ForAll
         (InducedPcgs(home,cl.centralizer), c -> Comm(k, c) in L));
     end;
-  elif IsPrimePowerInt(Size(G)) then
+  elif IsPGroup(G) then
     p:=PrimePGroup(G);
     home:=PcgsPCentralSeriesPGroup(G);
     eas:=PCentralNormalSeriesByPcgsPGroup(home);

--- a/lib/ctblgrp.gi
+++ b/lib/ctblgrp.gi
@@ -692,7 +692,7 @@ InstallGlobalFunction(SplitStep,function(D,bestMat)
       D.ClassMatrixColumn(D,M,bestMat,col);
     od;
 
-    M:=M*o;
+    M:=Matrix(D.field,Unpack(M)*o);
 
     # note,that we will have calculated yet one!
     D.maycent:=true;
@@ -1314,7 +1314,7 @@ end;
 ##
 InstallGlobalFunction( BestSplittingMatrix, function(D)
 local n,i,val,b,requiredCols,splitBases,wert,nu,r,rs,rc,bn,bw,split,
-      orb,os,lim,ksl,dmats;
+      orb,os,lim,ksl,dmats,imp;
 
   nu:=Zero(D.field);
   requiredCols:=List([1..D.klanz],x->[]);
@@ -1342,6 +1342,7 @@ local n,i,val,b,requiredCols,splitBases,wert,nu,r,rs,rc,bn,bw,split,
       requiredCols[n]:=[];
       splitBases[n]:=[];
       wert[n]:=0;
+      imp:=false;
 
       # only take classes small enough
       if D.classiz[n]<=lim and
@@ -1364,6 +1365,7 @@ local n,i,val,b,requiredCols,splitBases,wert,nu,r,rs,rc,bn,bw,split,
 	    else
 	      b:=DxNiceBasis(D,r);
 	      split:=ForAny(b{[2..r.dim]},i->i[n]<>nu);
+              imp:=imp or split;
 	      if split then
 		if r.dim<4 then
 		  # very small spaces will split nearly perfect
@@ -1414,7 +1416,9 @@ local n,i,val,b,requiredCols,splitBases,wert,nu,r,rs,rc,bn,bw,split,
       fi;
       # is there one that does all already? If so don't bother testing the
       # rest, as we go by cost
-      if ForAll(D.raeume,x->IsBound(x.splits)) then
+      if imp and Length(D.raeume)<=20
+        and ForAll(D.raeume,x->IsBound(x.splits)) then
+
         rc:=Intersection(List(D.raeume,x->Filtered([1..Length(x.splits)],
           y->IsBound(x.splits[y]) and x.splits[y].split=true)));
         if Length(rc)>0 then
@@ -1728,7 +1732,7 @@ DoubleCentralizerOrbit := function(D,c1,c2)
     often:=List(trans,i->Length(i));
     return [List(trans,i->i[1]),often];
   else
-    Info(InfoCharacterTable,2,"using DoubleCosets;");
+    Info(InfoCharacterTable,3,"using DoubleCosets;");
     cent:=Centralizer(D.classes[inv]);
     l:=DoubleCosetRepsAndSizes(D.group,cent,Centralizer(D.classes[c2]));
     s1:=Size(cent);
@@ -1801,7 +1805,7 @@ StandardClassMatrixColumn := function(D,M,r,t)
             # were these classes detected weakly ?
             e:=M[i[1],t];
             if e>0 then
-              Info(InfoCharacterTable,2,"GaloisIdentification ",i,": ",e);
+              Info(InfoCharacterTable,3,"GaloisIdentification ",i,": ",e);
             fi;
             for j in i do
               M[j,t]:=e/Length(i);

--- a/lib/ctblpc.gi
+++ b/lib/ctblpc.gi
@@ -43,31 +43,28 @@ PcGroupClassMatrixColumn := function(D,M,r,t)
     for i in [1..Length(T[1])] do
       T[1][i]:=T[1][i]*z;
     od;
-    T[3]:=List(T[1],x->Position(D.ids,D.identification(D,x)));
+    #T[3]:=List(T[1],x->Position(D.ids,D.identification(D,x)));
+    T[3]:=[];
 
     # identify in blocks of at most 5000
     chunk:=5000;
 
     for i in [0..QuoInt(Length(T[1]),chunk)] do
-      orb:=[chunk*i+1..Minimum(chunk*(i+1)-1,Length(T[1]))];
+      orb:=[chunk*i+1..Minimum(chunk*(i+1),Length(T[1]))];
 
-      z:=ClassesSolvableGroup(D.group,0, rec(candidates:=T[1]{orb}));
-      # The class identification in chunks can produce wrong results if
-      # elements do not end up in the same class (since
-      # it assumes the vector space decomposition to be always the same).
-      # Thus do not test the resulting canonical representatives, but
-      # conjugate the representatives as indicated and allow for
-      # failure.
-      z:=List([1..Length(orb)],x->Position(D.ids,T[1][orb[x]]^z[x].operator));
+      #z:=ClassesSolvableGroup(D.group,0, rec(candidates:=T[1]{orb}));
+      z:=MultiClassIdsPc(D.classiddat,T[1]{orb});
+      z:=List(z,x->Position(D.ids,x));
       T[3]{orb}:=z;
 
     od;
 
     for i in [1..Length(T[1])] do
       s:=T[3][i];
-      if s=fail then
-        s:=Position(D.ids,D.identification(D,T[1][i]));
-      fi;
+#      if s=fail then
+#        Error("failer");
+#        s:=Position(D.ids,D.identification(D,T[1][i]));
+#      fi;
 
       M[s][t]:=M[s][t]+T[2][i];
     od;
@@ -81,7 +78,8 @@ end;
 #F  IdentificationSolvableGroup(<D>,<el>) . .  class invariants for el in G
 ##
 IdentificationSolvableGroup := function(D,el)
-  return ClassesSolvableGroup(D.group,0,rec(candidates:=[el]))[1].representative;
+  return MultiClassIdsPc(D.classiddat,[el])[1];
+  #return ClassesSolvableGroup(D.group,0,rec(candidates:=[el]))[1].representative;
 end;
 
 
@@ -91,7 +89,7 @@ end;
 ##
 InstallMethod(DxPreparation,"pc group",true,[IsPcGroup,IsRecord],0,
 function(G,D)
-local i,cl;
+local i,cl,dat;
 
   if not IsDxLargeGroup(G) then
     TryNextMethod();
@@ -103,12 +101,12 @@ local i,cl;
   D.ClassMatrixColumn:=PcGroupClassMatrixColumn;
 
   cl:=D.classes;
-  D.ids:=[];
-  #D.ids:=List(ClassesSolvableGroup(D.group,0,rec(candidates:=D.classreps)),
-  #  x->x.representative);
+
+  dat:=rec(group:=G);
+  D.classiddat:=dat;
+  D.ids:=MultiClassIdsPc(dat,D.classreps);
   D.rids:=[];
   for i in D.classrange do
-    D.ids[i]:=D.identification(D,D.classreps[i]);
     D.rids[i]:=D.rationalidentification(D,D.classreps[i]);
   od;
 

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -938,7 +938,7 @@ local s,o,a,n,d,f,fn,j,b,i;
       n:=Filtered(NormalSubgroups(i),x->Size(x)>1);
       # if G is not fitting-free it has a proper normal subgroup of
       #  prime-power order
-      if ForAny(n,x->IsPrimePowerInt(Size(x))) then
+      if ForAny(n,x->IsPGroup(x)) then
 	return fail;
       fi;
       n:=Filtered(n,IsNonabelianSimpleGroup);

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -117,7 +117,7 @@ InstallGlobalFunction( InducedPcgs, function(pcgs, G)
   cache := ComputedInducedPcgses(G);
   i := 1;
   while i <= Length (cache) do
-     if IsIdenticalObj (cache[i], pcgs) then
+     if cache[i]= pcgs then
         return cache[i+1];
      fi;
      i := i + 2;

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -1328,18 +1328,7 @@ local  G,  home,  # the supergroup (of <H> and <U>), the home pcgs
   else
     home:=PcgsElementaryAbelianSeries(G);
     eas:=EANormalSeriesByPcgs(home);
-    # AH, 26-4-99: Test centrality not via `in' but via exponents
-    cent:=function(pcgs,grpg,Npcgs,dep)
-	  local i,j;
-	    for i in grpg do
-	      for j in Npcgs do
-		if DepthOfPcElement(pcgs,Comm(j,i))<dep then
-		  return false;
-		fi;
-	      od;
-	    od;
-	    return true;
-	  end;
+    cent:=PcClassFactorCentralityTest;
 
   fi;
   indstep:=IndicesEANormalSteps(home);


### PR DESCRIPTION
Faster class ID, avoiding redundancy in computing induced Pcgs (should also help in other situations), and some further MatrixObj cleanup in Dixon/Schneider.

Overall (e.g. measured for Weyl(B4)\wr S4) this gives a speedup of close to 2 compared with 4.11.1

Release Notes:

The calculation of character tables, in particular for solvable groups, now is often significantly faster.