### PR TITLE
Make sure to reset C pointers after possible garbage collection

### DIFF
--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -201,7 +201,9 @@ static void PrintPerm(Obj perm)
             ptSeen[p] = 1;
             isId = FALSE;
             Pr(fmt1,(Int)(p+1), 0);
+            /* restore pointer, in case Pr caused a garbage collection */
             ptPerm = CONST_ADDR_PERM<T>(perm);
+            ptSeen = ADDR_TMP_PERM<T>();
             for ( q = ptPerm[p]; q != p; q = ptPerm[q] ) {
                 ptSeen[q] = 1;
                 Pr(fmt2,(Int)(q+1), 0);


### PR DESCRIPTION
This was introduced, by me, in 2019, when I added ptSeen to make permutation printing faster.

It is very hard to hit a bug here -- you need to be writing to a OutputTextString, which needs to resize at just the wrong point. I'm not sure if this is the source of recent crashes.