### PR TITLE
fixed a bug in character table `Display`

### DIFF
--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -5189,6 +5189,8 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
                  Print( String( "+", iw[j] ) );
                elif indic[j][i] = -1 then
                  Print( String( "-", iw[j] ) );
+               else
+                 Print( String( "?", iw[j] ) );
                fi;
             else
                if indic[j][i] = 0 then

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -277,6 +277,18 @@ gap> IsMutable( ComputedIndicators( t ) );
 true
 gap> ForAny( ComputedIndicators( t ), IsMutable );
 false
+gap> t:= CharacterTable( CyclicGroup( 2 ) );;
+gap> SetIdentifier( t, "C2" );
+gap> ComputedIndicators( t )[2]:= [ Unknown(), Unknown() ];;
+gap> Display( t, rec( indicator:= true ) );
+C2
+
+        2  1  1
+
+          1a 2a
+       2
+X.1    ?   1  1
+X.2    ?   1 -1
 gap> PrimeBlocks( t, 2 );;
 gap> Length( ComputedPrimeBlockss( t ) );
 2


### PR DESCRIPTION
If one wants to show the 2nd `indicator` in `Display` and if some indicator is stored as unknown (which happens for a few 2-modular library tables) then up to now the column alignment was not correct.

Taking that this effect had not been observed up to now, I think that the fix need not be mentioned in the release notes.