### PR TITLE
enhance `Indicator`

### DIFF
--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -341,5 +341,14 @@ true
 gap> IsPerfectCharacterTable( t );
 false
 
+# compute indicators
+gap> t:= CharacterTable( SymmetricGroup( 4 ) );;
+gap> Indicator( t, 2 );
+[ 1, 1, 1, 1, 1 ]
+gap> Indicator( t mod 3, 2 );
+[ 1, 1, 1, 1 ]
+gap> ForAny( Indicator( t mod 2, 2 ), IsUnknown );
+true
+
 ##
 gap> STOP_TEST( "ctbl.tst" );


### PR DESCRIPTION
Up to now, `IndicatorOp( tbl, 2 )` signaled an error if `tbl` was a Brauer table in characteristic 2.
Thus `Indicator( tbl, 2 )` worked in this situation if the list of indicators was already stored (perhaps containing some unknown values), whereas one got an error otherwise.

Now one always gets a list, with unknown values where the (weak) necessary conditions do not determine them.