### PR TITLE
kernel: revert how READ_COMMAND_REAL treats "quit;"

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -248,8 +248,7 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     ExecStatus status = ReadEvalCommand(0, &input, &evalResult, 0);
     CloseInput(&input);
 
-    if (status == STATUS_EOF || status == STATUS_QUIT ||
-        status == STATUS_QQUIT)
+    if (status == STATUS_EOF || status == STATUS_QQUIT)
         return result;
     else if (STATE(UserHasQuit) || STATE(UserHasQUIT))
         return result;

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -111,7 +111,7 @@ Syntax error: expression expected in stream:1
 ^
 [ true ]
 gap> READ_COMMAND_REAL(InputTextString("quit;"), false);
-[ false ]
+[ true ]
 gap> READ_COMMAND_REAL(InputTextString("QUIT;"), false);
 [ false ]
 


### PR DESCRIPTION
This reverts the behaviour of `READ_COMMAND_REAL` back to how
it was in previous GAP versions. Specifically, the command

    READ_COMMAND_REAL(InputTextString("quit;"),false);

now once again returns `[ true ]` (and not `[ false ]`). The "new"
behavior, while perhaps more logical, broke the OpenMath package and
perhaps other code as well.

See also https://github.com/gap-packages/openmath/issues/26