### PR TITLE
Update trivial case for SubgroupsSolvableGroup with retnorm

### DIFF
--- a/lib/grppclat.gi
+++ b/lib/grppclat.gi
@@ -570,9 +570,6 @@ local g,	# group
       xo;	# xternal orbits
 
   g:=arg[1];
-  if Size(g)=1 then
-    return [g];
-  fi;
   if Length(arg)>1 and IsRecord(arg[Length(arg)]) then
     opt:=arg[Length(arg)];
   else
@@ -580,14 +577,23 @@ local g,	# group
   fi;
 
   # parse options
+  retnorm:=IsBound(opt.retnorm) and opt.retnorm;
+
+  # handle trivial case
+  if IsTrivial(g) then
+    if retnorm then
+       return [[g],[g]];
+    else
+       return [g];
+    fi;
+  fi;
+
   normal:=IsBound(opt.normal) and opt.normal=true;
   if IsBound(opt.consider) then 
     consider:=opt.consider;
   else
     consider:=false;
   fi;
-
-  retnorm:=IsBound(opt.retnorm) and opt.retnorm;
 
   isom:=fail;
 

--- a/tst/testbugfix/2022-05-10-SubgroupsSolvableGroup.tst
+++ b/tst/testbugfix/2022-05-10-SubgroupsSolvableGroup.tst
@@ -1,0 +1,9 @@
+# Verify SubgroupsSolvableGroup honor retnorm=true if the
+# input is a trivial group.
+# See https://github.com/gap-system/gap/pull/4855
+gap> G:=TrivialGroup(IsPermGroup);
+Group(())
+gap> SubgroupsSolvableGroup(G);
+[ Group(()) ]
+gap> SubgroupsSolvableGroup(G, rec(retnorm:=true));
+[ [ Group(()) ], [ Group(()) ] ]


### PR DESCRIPTION
The function `SubgroupsSolvableGroup` with a trivial group with an argument does not return the list of normalizers when called with the option `retnorm`. I suggest considering this flag for trivial groups. I propose moving first the parsing of the `retnorm` flag and immediately checking the trivial case. Please check I have not destroyed the rest of the function!


## Text for release notes

See title (or leave it up to you)

