### PR TITLE
Improve `Intersection` for permutation groups

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -177,7 +177,6 @@ info classes and levels is reset whenever <K>true</K> is passed.
 <Example><![CDATA[
 gap> ShowUsedInfoClasses(true);
 gap> Intersection(Group((1,3,2,4,5,6)), Group((1,2,3,4,5,6)));
-#I Would print info with SetInfoLevel(InfoOptions,1)
 #I Would print info with SetInfoLevel(InfoBckt,1)
 #I Would print info with SetInfoLevel(InfoBckt,3)
 #I Would print info with SetInfoLevel(InfoBckt,5)

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2974,20 +2974,15 @@ local   Omega, P, rbase, L, mg, mh, IsFinished, mg_minus_mh, mh_minus_mg;
         return TrivialGroup(IsPermGroup);
       fi;
 
-      IsFinished:=true;
       mg_minus_mh:=Difference(mg,mh);
       if Length(mg_minus_mh) > 0 then
         G:=Stabilizer(G,mg_minus_mh,OnTuples);
-        IsFinished:=false;
+        continue;
       fi;
       mh_minus_mg:=Difference(mh,mg);
       if Length(mh_minus_mg) > 0 then
         H:=Stabilizer(H,mh_minus_mg,OnTuples);
-        IsFinished:=false;
-      fi;
-
-      if IsFinished then
-        break;
+        continue;
       fi;
     od;
 

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2955,7 +2955,7 @@ end );
 InstallMethod( Intersection2, "perm groups", IsIdenticalObj,
   [ IsPermGroup, IsPermGroup ], 0,
 function( G, H )
-local   Omega, P, rbase, L, mg, mh, IsFinished, mg_minus_mh, mh_minus_mg;
+local   Omega, P, rbase, L, mg, mh, mg_minus_mh, mh_minus_mg;
 
     if IsIdenticalObj( G, H )  then
       return G;

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2955,24 +2955,41 @@ end );
 InstallMethod( Intersection2, "perm groups", IsIdenticalObj,
   [ IsPermGroup, IsPermGroup ], 0,
 function( G, H )
-local   Omega,  P,  rbase,  L,mg,mh,i;
-    
+local   Omega, P, rbase, L, mg, mh, IsFinished, mg_minus_mh, mh_minus_mg;
+
     if IsIdenticalObj( G, H )  then
       return G;
     fi;
-    
-    # align the acting domains
-    mg:=MovedPoints(G);
-    mh:=MovedPoints(H);
-    Omega := Intersection(mg,mh);
 
-    # no two points moved in common?
-    if Length(Omega)<=1 then
-      return TrivialSubgroup(Parent(G));
-    fi;
+    # iterate taking stabilizer until G and H have the same set of moved points
+    while(true)
+    do
+      # align the acting domains
+      mg:=MovedPoints(G);
+      mh:=MovedPoints(H);
+      Omega := Intersection(mg,mh);
 
-    G:=Stabilizer(G,Difference(mg,mh),OnTuples);
-    H:=Stabilizer(H,Difference(mh,mg),OnTuples);
+      # no two points moved in common?
+      if Length(Omega)<=1 then
+        return TrivialSubgroup(Parent(G));
+      fi;
+
+      IsFinished:=true;
+      mg_minus_mh:=Difference(mg,mh);
+      if Length(mg_minus_mh) > 0 then
+        G:=Stabilizer(G,mg_minus_mh,OnTuples);
+        IsFinished:=false;
+      fi;
+      mh_minus_mg:=Difference(mh,mg);
+      if Length(mh_minus_mg) > 0 then
+        H:=Stabilizer(H,mh_minus_mg,OnTuples);
+        IsFinished:=false;
+      fi;
+
+      if IsFinished then
+        break;
+      fi;
+    od;
 
     if IsSubset(G,H) then
       return H;

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2971,7 +2971,7 @@ local   Omega, P, rbase, L, mg, mh, IsFinished, mg_minus_mh, mh_minus_mg;
 
       # no two points moved in common?
       if Length(Omega)<=1 then
-        return TrivialSubgroup(Parent(G));
+        return Group(());
       fi;
 
       IsFinished:=true;

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2962,8 +2962,7 @@ local   Omega, P, rbase, L, mg, mh, IsFinished, mg_minus_mh, mh_minus_mg;
     fi;
 
     # iterate taking stabilizer until G and H have the same set of moved points
-    while(true)
-    do
+    while true do
       # align the acting domains
       mg:=MovedPoints(G);
       mh:=MovedPoints(H);

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2971,7 +2971,7 @@ local   Omega, P, rbase, L, mg, mh, IsFinished, mg_minus_mh, mh_minus_mg;
 
       # no two points moved in common?
       if Length(Omega)<=1 then
-        return Group(());
+        return TrivialGroup(IsPermGroup);
       fi;
 
       IsFinished:=true;

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -2955,7 +2955,7 @@ end );
 InstallMethod( Intersection2, "perm groups", IsIdenticalObj,
   [ IsPermGroup, IsPermGroup ], 0,
 function( G, H )
-local   Omega, P, rbase, L, mg, mh, mg_minus_mh, mh_minus_mg;
+local   omega, P, rbase, L, mg, mh, mg_minus_mh, mh_minus_mg;
 
     if IsIdenticalObj( G, H )  then
       return G;
@@ -2966,10 +2966,10 @@ local   Omega, P, rbase, L, mg, mh, mg_minus_mh, mh_minus_mg;
       # align the acting domains
       mg:=MovedPoints(G);
       mh:=MovedPoints(H);
-      Omega := Intersection(mg,mh);
+      omega := Intersection(mg,mh);
 
       # no two points moved in common?
-      if Length(Omega)<=1 then
+      if Length(omega)<=1 then
         return TrivialGroup(IsPermGroup);
       fi;
 
@@ -2983,6 +2983,7 @@ local   Omega, P, rbase, L, mg, mh, mg_minus_mh, mh_minus_mg;
         H:=Stabilizer(H,mh_minus_mg,OnTuples);
         continue;
       fi;
+      break;
     od;
 
     if IsSubset(G,H) then
@@ -3011,8 +3012,8 @@ local   Omega, P, rbase, L, mg, mh, mg_minus_mh, mh_minus_mg;
 #      fi;
 #    od;
 
-    P := OrbitsPartition( H, Omega );
-    rbase := EmptyRBase( [ G, H ], Omega, P );
+    P := OrbitsPartition( H, omega );
+    rbase := EmptyRBase( [ G, H ], omega, P );
     rbase.nextLevel := NextRBasePoint;
     
     # L := SubgroupNC( G, Concatenation

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -105,8 +105,11 @@ gap> Intersection(SymmetricGroup([1..5]),AlternatingGroup([3..8]));
 Alt( [ 3 .. 5 ] )
 gap> Intersection(AlternatingGroup([1..5]),AlternatingGroup([3..8]));
 Alt( [ 3 .. 5 ] )
-gap> Intersection(AlternatingGroup([1..5]),SymmetricGroup([3..8]));  
+gap> Intersection(AlternatingGroup([1..5]),SymmetricGroup([3..8]));
 Alt( [ 3 .. 5 ] )
+gap> Intersection(Group( (1,2,3), (4,5,6), (11,12,13), (11,12,14) ),
+                  Group( (1,7,8), (4,9,11), (10,12), (13,14) ));
+Group(())
 gap> s := SymmetricGroup(100);
 Sym( [ 1 .. 100 ] )
 gap> Stabilizer(s,3,OnPoints);

--- a/tst/testextra/grpperm.tst
+++ b/tst/testextra/grpperm.tst
@@ -110,6 +110,8 @@ Alt( [ 3 .. 5 ] )
 gap> Intersection(Group( (1,2,3), (4,5,6), (11,12,13), (11,12,14) ),
                   Group( (1,7,8), (4,9,11), (10,12), (13,14) ));
 Group(())
+gap> Intersection(Group((1,2), (3,4)), Group((3,4),(5,6)));
+Group( (3,4) )
 gap> s := SymmetricGroup(100);
 Sym( [ 1 .. 100 ] )
 gap> Stabilizer(s,3,OnPoints);


### PR DESCRIPTION
The code does make a small improvement to the Intersection of permutation groups.
The code in the master right now is replacing G with its stabilizer for the difference
Moved(G) \ Moved(H) and the same for H. But the thing is once you do this, the sets
Moved(G) and Moved(H) change which gives new opportunities for reducing the
groups.