### PR TITLE
MatrixObj: matrix manipulation ops for `IsMatrix`

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1490,59 +1490,77 @@ InstallMethod( \[\,\]\:\=, "for a matrix object, two positions, and an object",
 ############################################################################
 
 InstallMethod( MultMatrixRowLeft, "for a mutable matrix object, a row number, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsObject ],
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ],
   function( mat, row, scalar )
     local i;
-  
+
     for i in [1..NrCols(mat)] do
         mat[row,i] := scalar * mat[row,i];
     od;
-    
+
+  end );
+
+InstallEarlyMethod( MultMatrixRowLeft,
+  function( mat, i, scalar )
+    if IsPlistRep(mat) then
+      mat[i] := scalar * mat[i];
+    else
+      TryNextMethod();
+    fi;
   end );
 
 ############################################################################
 
 InstallMethod( MultMatrixColumnRight, "for a mutable matrix object, a column number, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsObject ],
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ],
   function( mat, column, scalar )
     local i;
-  
+
     for i in [1..NrRows(mat)] do
         mat[i,column] := mat[i,column] * scalar;
     od;
-    
+
   end );
 
 ############################################################################
 
 InstallMethod( MultMatrixRowRight, "for a mutable matrix object, a row number, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsObject ],
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ],
   function( mat, row, scalar )
       local i;
-  
+
     for i in [1..NrCols(mat)] do
         mat[row,i] := mat[row,i] * scalar;
     od;
-    
+
+  end );
+
+InstallEarlyMethod( MultMatrixRowRight,
+  function( mat, i, scalar )
+    if IsPlistRep(mat) then
+      mat[i] := mat[i] * scalar;
+    else
+      TryNextMethod();
+    fi;
   end );
 
 ############################################################################
 
 InstallMethod( MultMatrixColumnLeft, "for a mutable matrix object, a column number, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsObject ],
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ],
   function( mat, column, scalar )
     local i;
-  
+
     for i in [1..NrRows(mat)] do
         mat[i,column] := scalar * mat[i,column];
     od;
-    
+
   end );
 
 ############################################################################
 
 InstallMethod( AddMatrixRowsLeft, "for a mutable matrix object, two row numbers, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
   function( mat, row1, row2, scalar )
     local i;
 
@@ -1551,24 +1569,42 @@ InstallMethod( AddMatrixRowsLeft, "for a mutable matrix object, two row numbers,
     od;
 
   end );
- 
+
+InstallEarlyMethod( AddMatrixRowsLeft,
+  function( mat, i, j, scalar )
+    if IsPlistRep(mat) then
+      mat[i] := mat[i] + scalar * mat[j];
+    else
+      TryNextMethod();
+    fi;
+  end );
+
  ############################################################################
 
 InstallMethod( AddMatrixRowsRight, "for a mutable matrix object, two row numbers, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
   function( mat, row1, row2, scalar )
     local i;
- 
+
     for i in [1..NrCols(mat)] do
         mat[row1,i] := mat[row1,i] + mat[row2,i] * scalar;
     od;
 
   end );
 
+InstallEarlyMethod( AddMatrixRowsRight,
+  function( mat, i, j, scalar )
+    if IsPlistRep(mat) then
+      mat[i] := mat[i] + mat[j] * scalar;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
 ############################################################################
 
 InstallMethod( AddMatrixColumnsRight, "for a mutable matrix object, two column numbers, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
   function( mat, column1, column2, scalar )
     local i;
 
@@ -1578,49 +1614,99 @@ InstallMethod( AddMatrixColumnsRight, "for a mutable matrix object, two column n
 
   end );
 
+InstallEarlyMethod( AddMatrixColumnsRight,
+  function( mat, i, j, scalar )
+    local row;
+    if IsPlistRep(mat) then
+      for row in mat do
+          row[i] := row[i] + row[j] * scalar;
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
 ############################################################################
 
 InstallMethod( AddMatrixColumnsLeft, "for a mutable matrix object, two column numbers, and a scalar",
-  [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] ,
   function( mat, column1, column2, scalar )
     local i;
 
     for i in [1..NrRows(mat)] do
-        mat[i,column1] := mat[i,column1] + scalar * mat[i,column2] ;
+        mat[i,column1] := mat[i,column1] + scalar * mat[i,column2];
     od;
 
   end );
 
-############################################################################  
+InstallEarlyMethod( AddMatrixColumnsLeft,
+  function( mat, i, j, scalar )
+    local row;
+    if IsPlistRep(mat) then
+      for row in mat do
+          row[i] := row[i] + scalar * row[j];
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
+############################################################################
 
 InstallMethod( SwapMatrixRows, "for a mutable matrix object, and two row numbers",
-  [ IsMatrixObj and IsMutable, IsInt, IsInt ],
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ],
   function( mat, row1, row2 )
     local temp, i;
-    
+
     if row1 <> row2 then
         for i in [1..NrCols(mat)] do
             temp := mat[row1,i];
             mat[row1,i] := mat[row2,i];
             mat[row2,i] := temp;
-        od; 
+        od;
     fi;
 
+  end );
+
+InstallEarlyMethod( SwapMatrixRows,
+  function( mat, i, j )
+    local tmp;
+    if IsPlistRep(mat) then
+      tmp := mat[i];
+      mat[i] := mat[j];
+      mat[j] := tmp;
+    else
+      TryNextMethod();
+    fi;
   end );
 
 ############################################################################
 
 InstallMethod( SwapMatrixColumns, "for a mutable matrix object, and two column numbers",
-  [ IsMatrixObj and IsMutable, IsInt, IsInt ],
+  [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ],
   function( mat, column1, column2 )
     local temp, i;
-    
+
     if column1 <> column2 then
         for i in [1..NrRows(mat)] do
             temp := mat[i,column1];
             mat[i,column1] := mat[i,column2];
             mat[i,column2] := temp;
-        od; 
+        od;
     fi;
-    
+
+  end );
+
+InstallEarlyMethod( SwapMatrixColumns,
+  function( mat, i, j )
+    local row, tmp;
+    if IsPlistRep(mat) then
+      for row in mat do
+        tmp := row[i];
+        row[i] := row[j];
+        row[j] := tmp;
+      od;
+    else
+      TryNextMethod();
+    fi;
   end );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1847,7 +1847,7 @@ DeclareOperation( "[]:=", [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt, IsObject ] 
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "MultMatrixRowLeft", [ IsMatrixObj and IsMutable, IsInt, IsObject ] );
+DeclareOperation( "MultMatrixRowLeft", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ] );
 DeclareSynonym( "MultMatrixRow", MultMatrixRowLeft);
 
 ############################################################################
@@ -1866,7 +1866,7 @@ DeclareSynonym( "MultMatrixRow", MultMatrixRowLeft);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "MultMatrixRowRight", [ IsMatrixObj and IsMutable, IsInt, IsObject ]);
+DeclareOperation( "MultMatrixRowRight", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ]);
 
 ############################################################################
 ##
@@ -1889,7 +1889,7 @@ DeclareOperation( "MultMatrixRowRight", [ IsMatrixObj and IsMutable, IsInt, IsOb
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "MultMatrixColumnRight", [ IsMatrixObj and IsMutable, IsInt, IsObject ] );
+DeclareOperation( "MultMatrixColumnRight", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ] );
 DeclareSynonym( "MultMatrixColumn",  MultMatrixColumnRight);
 
 ############################################################################
@@ -1908,7 +1908,7 @@ DeclareSynonym( "MultMatrixColumn",  MultMatrixColumnRight);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "MultMatrixColumnLeft", [ IsMatrixObj and IsMutable, IsInt, IsObject ] );
+DeclareOperation( "MultMatrixColumnLeft", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsObject ] );
 
 ############################################################################
 ##
@@ -1931,7 +1931,7 @@ DeclareOperation( "MultMatrixColumnLeft", [ IsMatrixObj and IsMutable, IsInt, Is
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "AddMatrixRowsLeft", [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
+DeclareOperation( "AddMatrixRowsLeft", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
 DeclareSynonym( "AddMatrixRows", AddMatrixRowsLeft);
 
 ############################################################################
@@ -1950,7 +1950,7 @@ DeclareSynonym( "AddMatrixRows", AddMatrixRowsLeft);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "AddMatrixRowsRight", [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
+DeclareOperation( "AddMatrixRowsRight", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
 
 ############################################################################
 ##
@@ -1973,7 +1973,7 @@ DeclareOperation( "AddMatrixRowsRight", [ IsMatrixObj and IsMutable, IsInt, IsIn
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "AddMatrixColumnsRight", [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
+DeclareOperation( "AddMatrixColumnsRight", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
 DeclareSynonym( "AddMatrixColumns", AddMatrixColumnsRight);
 
 ############################################################################
@@ -1992,7 +1992,7 @@ DeclareSynonym( "AddMatrixColumns", AddMatrixColumnsRight);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "AddMatrixColumnsLeft", [ IsMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
+DeclareOperation( "AddMatrixColumnsLeft", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt, IsObject ] );
 
 ############################################################################
 ##
@@ -2009,7 +2009,7 @@ DeclareOperation( "AddMatrixColumnsLeft", [ IsMatrixObj and IsMutable, IsInt, Is
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SwapMatrixRows", [ IsMatrixObj and IsMutable, IsInt, IsInt ] );
+DeclareOperation( "SwapMatrixRows", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ] );
 
 ############################################################################
 ##
@@ -2026,4 +2026,4 @@ DeclareOperation( "SwapMatrixRows", [ IsMatrixObj and IsMutable, IsInt, IsInt ] 
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SwapMatrixColumns", [ IsMatrixObj and IsMutable, IsInt, IsInt ] );
+DeclareOperation( "SwapMatrixColumns", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ] );

--- a/tst/testinstall/MatrixObj/ElementaryMatrices.tst
+++ b/tst/testinstall/MatrixObj/ElementaryMatrices.tst
@@ -1,6 +1,42 @@
 gap> START_TEST("ElementaryMatrices.tst");
 
 #
+gap> ReadGapRoot("tst/testinstall/MatrixObj/testmatobj.g");
+
+#
+gap> TestElementaryTransforms( [[2,4,5],[7,11,-4],[-3,20,0]], -1 );
+gap> TestElementaryTransforms( Matrix( [[2,4,5],[7,11,-4],[-3,20,0]]), -1 );
+
+#
+gap> F := GF(2);;
+gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> ConvertToMatrixRep(mat);;  # proper matrix obj
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+
+#
+gap> F := GF(3);;
+gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> ConvertToMatrixRep(mat);;  # proper matrix obj
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+
+#
+gap> F := GF(4);;
+gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> ConvertToMatrixRep(mat);;  # proper matrix obj
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+
+#
+gap> F := GF(5);;
+gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> ConvertToMatrixRep(mat);;  # proper matrix obj
+gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+
+##########
+#
 gap> mat := Matrix( [[2,4,5],[7,11,-4],[-3,20,0]]);;
 gap> SwapMatrixRows(mat,1,3);
 gap> mat= Matrix( [ [ -3, 20, 0 ], [ 7, 11, -4 ], [ 2, 4, 5 ] ]);

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -55,3 +55,113 @@ TestIdentityMatrix := function(filt, ring, degree)
   if mat <> mat2 then Error("NewIdentityMatrix(filt, ring, degree) differs"); fi;
   return mat;
 end;
+
+TestElementaryTransforms := function(mat, scalar)
+    local i, j, copy, eq;
+    Assert(0, NrRows(mat) >= 2);
+    Assert(0, NrCols(mat) >= 2);
+
+    # make an old-fashioned entry-wise copy of this matrix so we can compare
+    # all changes made there independent of any special properties of the
+    # matrix representation
+    copy := [];
+    for i in [1..NrRows(mat)] do
+        copy[i] := [];
+        for j in [1..NrCols(mat)] do
+            copy[i,j] := mat[i,j];
+        od;
+    od;
+
+    eq := function()
+        local i, j;
+        for i in [1..NrRows(mat)] do
+            for j in [1..NrCols(mat)] do
+                if copy[i,j] <> mat[i,j] then
+                    return false;
+                fi;
+            od;
+        od;
+        return true;
+    end;
+
+    #
+    #
+    #
+    for i in [1..NrRows(mat)] do
+        MultMatrixRowLeft(mat,i,scalar);
+        MultMatrixRowLeft(copy,i,scalar);
+        if not eq() then Error("MultMatrixRowLeft(",i,",",scalar,") failure"); fi;
+    od;
+
+    for i in [1..NrRows(mat)] do
+        MultMatrixRowRight(mat,i,scalar);
+        MultMatrixRowRight(copy,i,scalar);
+        if not eq() then Error("MultMatrixRowRight(",i,",",scalar,") failure"); fi;
+    od;
+
+    for i in [1..NrCols(mat)] do
+        MultMatrixColumnLeft(mat,i,scalar);
+        MultMatrixColumnLeft(copy,i,scalar);
+        if not eq() then Error("MultMatrixColumnLeft(",i,",",scalar,") failure"); fi;
+    od;
+
+    for i in [1..NrCols(mat)] do
+        MultMatrixColumnRight(mat,i,scalar);
+        MultMatrixColumnRight(copy,i,scalar);
+        if not eq() then Error("MultMatrixColumnRight(",i,",",scalar,") failure"); fi;
+    od;
+
+    #
+    #
+    #
+    for i in [1..NrRows(mat)] do
+        for j in [1..NrRows(mat)] do
+            AddMatrixRowsLeft(mat,i,j,scalar);
+            AddMatrixRowsLeft(copy,i,j,scalar);
+            if not eq() then Error("AddMatrixRowsLeft(",i,",",j,",",scalar,") failure"); fi;
+        od;
+    od;
+
+    for i in [1..NrRows(mat)] do
+        for j in [1..NrRows(mat)] do
+            AddMatrixRowsRight(mat,i,j,scalar);
+            AddMatrixRowsRight(copy,i,j,scalar);
+            if not eq() then Error("AddMatrixRowsRight(",i,",",j,",",scalar,") failure"); fi;
+        od;
+    od;
+
+    for i in [1..NrCols(mat)] do
+        for j in [1..NrCols(mat)] do
+            AddMatrixColumnsLeft(mat,i,j,scalar);
+            AddMatrixColumnsLeft(copy,i,j,scalar);
+            if not eq() then Error("AddMatrixColumnsLeft(",i,",",j,",",scalar,") failure"); fi;
+        od;
+    od;
+
+    for i in [1..NrCols(mat)] do
+        for j in [1..NrCols(mat)] do
+            AddMatrixColumnsRight(mat,i,j,scalar);
+            AddMatrixColumnsRight(copy,i,j,scalar);
+            if not eq() then Error("AddMatrixColumnsRight(",i,",",j,",",scalar,") failure"); fi;
+        od;
+    od;
+
+    #
+    #
+    #
+    for i in [1..NrRows(mat)] do
+        for j in [1..NrRows(mat)] do
+            SwapMatrixRows(mat,i,j);
+            SwapMatrixRows(copy,i,j);
+            if not eq() then Error("SwapMatrixRows(",i,",",j,") failure"); fi;
+        od;
+    od;
+
+    for i in [1..NrCols(mat)] do
+        for j in [1..NrCols(mat)] do
+            SwapMatrixColumns(mat,i,j);
+            SwapMatrixColumns(copy,i,j);
+            if not eq() then Error("SwapMatrixColumns(",i,",",j,") failure"); fi;
+        od;
+    od;
+end;


### PR DESCRIPTION
Before this, e.g. `SwapMatrixRows(IdentityMat(10,Integers), 1, 2)`
resulted in a "no method found" error.

In addition, use `InstallEarlyMethod` to provide fast methods for classical
lists-of-list matrices.

Before the new early methods (but after enabling everything for `IsMatrix`):

    gap> mat:=IdentityMat(10,Integers);;
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    874
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    38
    gap> mat:=IdentityMat(10,GF(2));; ConvertToMatrixRep(mat);; mat;
    <a 10x10 matrix over GF2>
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    137
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    107

After:

    gap> mat:=IdentityMat(10,Integers);;
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    132
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    37
    gap> mat:=IdentityMat(10,GF(2));; ConvertToMatrixRep(mat);; mat;
    <a 10x10 matrix over GF2>
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    163
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    102

Note that `SwapMatrixRows` got slightly slower for the compressed matrix over GF(2),
due to the extra overhead caused by the early method. I think for now this is
acceptable. If we are concerned about this, we could probably get rid of most or
all of it by using a "classic" early method, i.e., a kernel one.

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
