### PR TITLE
Fix CI on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,6 +225,8 @@ jobs:
           update_packager_index: false
           override_cache_key: ${{ runner.os }}-${{ hashFiles('extra.flags') }}-${{ github.ref }}
           override_cache_key_fallback: ${{ runner.os }}-${{ hashFiles('extra.flags') }}
+      - name: "Workaround GitHub security concerns" # see https://github.com/gap-system/gap/issues/4861
+        run: git config --global --add safe.directory $PWD
       - name: "Configure GAP"
         run: ${{ matrix.extra }} dev/ci-configure-gap.sh
       - name: "Build GAP"


### PR DESCRIPTION
Recently we are getting this error in the CI

    + git show --pretty=fuller -s
    fatal: unsafe repository ('/cygdrive/d/a/gap/gap' is owned by someone else)
    To add an exception for this directory, call:

        git config --global --add safe.directory /cygdrive/d/a/gap/gap

This is due to a fix for a security vulnerability in git, see
<https://github.blog/2022-04-12-git-security-vulnerability-announced/>.

This patch does just what the error message suggests.

Resolves #4861