### PR TITLE
extend the documentation of `AllBlocks`

### DIFF
--- a/lib/grpperm.gd
+++ b/lib/grpperm.gd
@@ -249,6 +249,10 @@ DeclareGlobalFunction("ApproximateSuborbitsStabilizerPermGroup");
 ##  computes a list of representatives of all block systems for a
 ##  permutation group <A>G</A> acting transitively on the points moved by the
 ##  group.
+##  <P/>
+##  Each representative in the returned list is sorted and contains the
+##  smallest point moved by <A>G</A>.
+##  <P/>
 ##  <Example><![CDATA[
 ##  gap> AllBlocks(g);
 ##  [ [ 1, 8 ], [ 1, 2, 3, 8 ], [ 1, 4, 5, 8 ], [ 1, 6, 7, 8 ], [ 1, 3 ], 


### PR DESCRIPTION
State explicitly that smallest representatives are chosen.
(The current implementation has this property.)

If one wants to compare block systems of a group and a subgroup (acting transitively on the same set of points), it is useful to know that compatible representatives are chosen when this is possible --there is no need to compute the full block systems and then to compare them.