### PR TITLE
Add `HexSHA256` function for computing SHA256 checksums

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -83,6 +83,7 @@ SOURCES += src/records.c
 SOURCES += src/saveload.c
 SOURCES += src/scanner.c
 SOURCES += src/sctable.c
+SOURCES += src/sha256.c
 SOURCES += src/set.c
 SOURCES += src/stats.c
 SOURCES += src/streams.c

--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -690,6 +690,7 @@ gap> HexStringInt(last);
 <#Include Label="Ordinal">
 <#Include Label="EvalString">
 <#Include Label="CrcString">
+<#Include Label="HexSHA256">
 <#Include Label="Pluralize">
 
 </Section>

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -535,16 +535,18 @@ end );
 ##  <Func Name="CrcFile" Arg='filename'/>
 ##
 ##  <Description>
-##  CRC (cyclic redundancy check) numbers provide a certain method of doing
-##  checksums. They are used by &GAP; to check whether
-##  files have changed.
+##  <Index>hash function</Index>
+##  <Index>checksum</Index>
+##  This function computes a CRC (cyclic redundancy check) number for the
+##  content of the file <A>filename</A>.
 ##  <P/>
-##  <Ref Func="CrcFile"/> computes a checksum value for the file with
-##  filename <A>filename</A> and returns this value as an integer.
-##  The function returns <K>fail</K> if a system error occurred,
+##  <Ref Func="CrcFile"/> computes a CRC (cyclic redundancy check) checksum
+##  value for the file with filename <A>filename</A> and returns this value
+##  as an integer. The function returns <K>fail</K> if an error occurred,
 ##  for example, if <A>filename</A> does not exist.
 ##  In this case the function <Ref Func="LastSystemError"/>
 ##  can be used to get information about the error.
+##  See also <Ref Func="CrcFile"/> and <Ref Func="HexSHA256"/>.
 ##  <P/>
 ##  <Log><![CDATA[
 ##  gap> CrcFile( "lib/morpheus.gi" );
@@ -774,3 +776,33 @@ BIND_GLOBAL("CHARS_LALPHA",
   Immutable(SSortedList("abcdefghijklmnopqrstuvwxyz")));
 BIND_GLOBAL("CHARS_SYMBOLS",Immutable(SSortedList(
   " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")));
+
+
+##  <#GAPDoc Label="HexSHA256">
+##  <ManSection>
+##  <Func Name="HexSHA256" Arg='string'/>
+##  <Func Name="HexSHA256" Arg='stream'/>
+##
+##  <Description>
+##  <Index>hash function</Index>
+##  <Index>checksum</Index>
+##  Return the SHA-256 cryptographic checksum of the bytes in <A>string</A>,
+##  resp. of the data in the input stream object <A>stream</A>
+##  (see Chapter&nbsp;<Ref Chap="Streams"/> to learn about streams)
+##  when read from the current position until EOF (end-of-file).
+##  <P/>
+##  The checksum is returned as string with 64 lowercase hexadecimal digits.
+##  <Example><![CDATA[
+##  gap> HexSHA256("abcd");
+##  "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+##  gap> HexSHA256(InputTextString("abcd"));
+##  "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("HexSHA256");
+
+BIND_GLOBAL("GAP_SHA256_State_Type",
+           NewType(NewFamily("GAP_SHA256_State_Family"), IsObject) );

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -402,3 +402,25 @@ InstallGlobalFunction(RemoveDirectoryRecursively,
     end;
     return Dowork(dirname);
   end );
+
+InstallGlobalFunction( HexSHA256,
+function(str)
+    local s, res;
+
+    if IsString(str) then
+        str := CopyToStringRep(str);
+    elif IsInputStream(str) then
+        str := ReadAll(str);
+        # TODO: instead o reading the complete stream at once (which might be
+        # huge), it would be better to read it in chunks, say 16kb at a time.
+        # Alas, our streams API currently offers no way to do that.
+    else
+        ErrorNoReturn("<str> has to be a string or an input stream");
+    fi;
+
+    s := GAP_SHA256_INIT();
+    GAP_SHA256_UPDATE(s, str);
+    res := GAP_SHA256_FINAL(s);
+    res := Sum([0..7], i -> res[8-i]*2^(32*i));;
+    return LowercaseString(HexStringInt(res));
+end);

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -916,7 +916,6 @@ static Int InitKernel(StructInitInfo * module)
 **
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-
 static Int InitLibrary(StructInitInfo * module)
 {
     /* init filters and functions                                          */

--- a/src/modules_builtin.c
+++ b/src/modules_builtin.c
@@ -21,6 +21,7 @@
 #include "objccoll.h"
 #include "objset.h"
 #include "profile.h"
+#include "sha256.h"
 #include "syntaxtree.h"
 #include "tracing.h"
 #include "vec8bit.h"
@@ -142,6 +143,9 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
     // libgap API
     InitInfoLibGapApi,
 #endif
+
+    // SHA256
+    InitSHA256,
 
     0
 };

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -1,0 +1,406 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "sha256.h"
+
+#include "bool.h"
+#include "error.h"
+#include "integer.h"
+#include "modules.h"
+#include "objects.h"
+#include "plist.h"
+#include "stringobj.h"
+
+#include "config.h"
+
+#include <string.h>
+
+static Obj GAP_SHA256_State_Type;
+
+// Implements the SHA256 hash function as per the description in
+// https://web.archive.org/web/20130526224224/http://csrc.nist.gov/groups/STM/cavp/documents/shs/sha256-384-512.pdf
+//
+
+
+// For the moment we assume the input is a string, we should probably have a
+// list of bytes, or words or something
+
+static inline UInt4 RotateRight(UInt4 x, const UInt4 n)
+{
+    return (x >> n) | (x << (32 - n));
+}
+
+static inline UInt4 Ch(UInt4 x, UInt4 y, UInt4 z)
+{
+    return (x & y) ^ (~x & z);
+}
+
+static inline UInt4 Maj(UInt4 x, UInt4 y, UInt4 z)
+{
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+static inline UInt4 Sigma0(UInt4 x)
+{
+    return RotateRight(x, 2) ^ RotateRight(x, 13) ^ RotateRight(x, 22);
+}
+
+static inline UInt4 Sigma1(UInt4 x)
+{
+    return RotateRight(x, 6) ^ RotateRight(x, 11) ^ RotateRight(x, 25);
+}
+
+static inline UInt4 sigma0(UInt4 x)
+{
+    return RotateRight(x, 7) ^ RotateRight(x, 18) ^ (x >> 3);
+}
+
+static inline UInt4 sigma1(UInt4 x)
+{
+    return RotateRight(x, 17) ^ RotateRight(x, 19) ^ (x >> 10);
+}
+
+static const UInt4 k[] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+static const UInt4 rinit[] = {
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+};
+
+#ifdef WORDS_BIGENDIAN
+#define be32decode(dst, src, len) memcpy(dst, src, len)
+#define be32encode(dst, src, len) memcpy(dst, src, len)
+#define store64be(dst, x) *dst = x
+#else
+static void be32decode(UInt4 * dst, const UInt1 * src, UInt len)
+{
+    UInt i;
+    for (i = 0; i < (len >> 2); i++) {
+        dst[i] = (src[i * 4] << 24) | (src[i * 4 + 1] << 16) |
+                 (src[i * 4 + 2] << 8) | (src[i * 4 + 3]);
+    }
+}
+
+static void be32encode(UInt1 * dst, const UInt4 * src, UInt len)
+{
+    UInt i;
+    for (i = 0; i < (len >> 2); i++) {
+        dst[4 * i + 0] = (src[i] & 0xff000000) >> 24;
+        dst[4 * i + 1] = (src[i] & 0xff0000) >> 16;
+        dst[4 * i + 2] = (src[i] & 0xff00) >> 8;
+        dst[4 * i + 3] = (src[i] & 0xff);
+    }
+}
+
+static void store64be(UInt8 * dst, UInt8 x)
+{
+    *dst = (((x >> 56) | ((x >> 40) & 0xff00) | ((x >> 24) & 0xff0000) |
+             ((x >> 8) & 0xff000000) | ((x << 8) & ((UInt8)0xff << 32)) |
+             ((x << 24) & ((UInt8)0xff << 40)) |
+             ((x << 40) & ((UInt8)0xff << 48)) | ((x << 56))));
+}
+#endif
+
+typedef struct sha256_state_t {
+    UInt4 r[8];       // Current hash value register
+    UInt  count;      // Nr of bits already hashed
+    UInt1 buf[64];    // One chunk, 512 bits
+} sha256_state_t;
+
+static int sha256_init(sha256_state_t * state)
+{
+    memcpy(state->r, rinit, sizeof(rinit));
+    state->count = 0UL;
+    memset(state->buf, 0, 64);
+
+    return 0;
+}
+
+static void sha256_transform(UInt4       state[8],
+                             const UInt1 block[64],
+                             UInt4       w[64],
+                             UInt4       r[8])
+{
+    UInt  i;
+    UInt4 temp1, temp2;
+
+    memcpy(r, state, 32);
+    be32decode(w, block, 64);
+    for (i = 16; i < 64; i++) {
+        w[i] = sigma1(w[i - 2]) + w[i - 7] + sigma0(w[i - 15]) + w[i - 16];
+    }
+
+    // A block is 512bit = 64bytes
+    for (i = 0; i < 64; i++) {
+        temp1 = r[7] + Sigma1(r[4]) + Ch(r[4], r[5], r[6]) + k[i] + w[i];
+        temp2 = Sigma0(r[0]) + Maj(r[0], r[1], r[2]);
+        r[7] = r[6];
+        r[6] = r[5];
+        r[5] = r[4];
+        r[4] = r[3] + temp1;
+        r[3] = r[2];
+        r[2] = r[1];
+        r[1] = r[0];
+        r[0] = temp1 + temp2;
+    }
+    for (i = 0; i < 8; i++) {
+        state[i] += r[i];
+    }
+}
+
+static int sha256_update(sha256_state_t * state, const UChar * buf, UInt8 len)
+{
+    UInt4 i, rem;
+    UInt4 w[64];
+    UInt4 r[8];
+
+    // If there is buffered stuff in state, fill block
+    rem = (state->count >> 3) & 0x3f;
+    // Number of bits already hashed. Needed for continuation, and for
+    // padding
+    state->count += len << 3;
+
+    // Not enough to hash full block, just buffer
+    if (len < 64 - rem) {
+        for (i = 0; i < len; i++) {
+            state->buf[rem + i] = buf[i];
+        }
+        return 0;
+    }
+    for (i = 0; i < 64 - rem; i++) {
+        state->buf[rem + i] = buf[i];
+    }
+    // Filled a block, do the SHA256 transform
+    sha256_transform(state->r, state->buf, w, r);
+    buf += (UInt4)64 - rem;
+    len -= (UInt4)64 - rem;
+
+    // Hash full blocks
+    while (len >= 64) {
+        sha256_transform(state->r, (const UInt1 *)buf, w, r);
+        buf += 64;
+        len -= 64;
+    }
+
+    // Store remainder in buffer
+    for (i = 0; i < len; i++) {
+        state->buf[i] = buf[i];
+    }
+    memset(w, 0x0, sizeof(w));
+    memset(r, 0x0, sizeof(r));
+
+    return 0;
+}
+
+static int sha256_final(sha256_state_t * state)
+{
+    UInt8 rem;
+    UInt8 i;
+    UInt4 w[64];
+    UInt4 r[8];
+
+    rem = (state->count >> 3) & 0x3f;
+    state->buf[rem] = 0x80;
+    if (rem < 56) {
+        for (i = 1; i < 56 - rem; i++) {
+            state->buf[rem + i] = 0x00;
+        }
+    }
+    else {
+        for (i = 1; i < (UInt4)64 - rem; i++) {
+            state->buf[rem + i] = 0x00;
+        }
+        sha256_transform(state->r, state->buf, w, r);
+        memset(state->buf, 0, 56);
+    }
+    store64be((UInt8 *)(&state->buf[56]), state->count);
+
+    sha256_transform(state->r, state->buf, w, r);
+
+    return 0;
+}
+
+Obj FuncGAP_SHA256_INIT(Obj self)
+{
+    Obj              result;
+    sha256_state_t * sptr;
+
+    result = NewBag(T_DATOBJ, sizeof(UInt4) + sizeof(sha256_state_t));
+    SET_TYPE_OBJ(result, GAP_SHA256_State_Type);
+
+    sptr = (sha256_state_t *)(&ADDR_OBJ(result)[1]);
+    sha256_init(sptr);
+
+    return result;
+}
+
+Obj FuncGAP_SHA256_UPDATE(Obj self, Obj state, Obj bytes)
+{
+    sha256_state_t * sptr;
+
+    RequireArgumentCondition(SELF_NAME, state,
+                             IS_DATOBJ(state) &&
+                                 TYPE_OBJ(state) == GAP_SHA256_State_Type,
+                             "must be a SHA256 state");
+    RequireStringRep(SELF_NAME, bytes);
+
+    sptr = (sha256_state_t *)(&ADDR_OBJ(state)[1]);
+    sha256_update(sptr, CHARS_STRING(bytes), GET_LEN_STRING(bytes));
+    CHANGED_BAG(state);
+
+    return 0;
+}
+
+Obj FuncGAP_SHA256_FINAL(Obj self, Obj state)
+{
+    Obj              result;
+    sha256_state_t * sptr;
+    int              i;
+
+    RequireArgumentCondition(SELF_NAME, state,
+                             IS_DATOBJ(state) &&
+                                 TYPE_OBJ(state) == GAP_SHA256_State_Type,
+                             "must be a SHA256 state");
+
+    result = NEW_PLIST(T_PLIST, 8);
+    SET_LEN_PLIST(result, 8);
+
+    sptr = (sha256_state_t *)(&ADDR_OBJ(state)[1]);
+    sha256_final(sptr);
+    CHANGED_BAG(state);
+
+    for (i = 0; i < 8; i++) {
+        SET_ELM_PLIST(result, i + 1, ObjInt_UInt(sptr->r[i]));
+        CHANGED_BAG(result);
+    }
+    return result;
+}
+
+Obj FuncGAP_SHA256_HMAC(Obj self, Obj key, Obj text)
+{
+    UInt           i, klen;
+    UInt1          k_ipad[64], k_opad[64];
+    UInt1          digest[32];
+    sha256_state_t st;
+    Obj            result;
+
+    RequireStringRep(SELF_NAME, key);
+    RequireStringRep(SELF_NAME, text);
+
+    memset(k_ipad, 0x36, sizeof(k_ipad));
+    memset(k_opad, 0x5c, sizeof(k_opad));
+
+    klen = GET_LEN_STRING(key);
+    if (GET_LEN_STRING(key) > 64) {
+        sha256_init(&st);
+        sha256_update(&st, CHARS_STRING(key), klen);
+        sha256_final(&st);
+
+        be32encode(digest, st.r, sizeof(digest));
+        klen = 32;
+
+        for (i = 0; i < klen; i++) {
+            k_ipad[i] ^= digest[i];
+            k_opad[i] ^= digest[i];
+        }
+    }
+    else {
+        for (i = 0; i < klen; i++) {
+            k_ipad[i] ^= CHARS_STRING(key)[i];
+            k_opad[i] ^= CHARS_STRING(key)[i];
+        }
+    }
+
+    sha256_init(&st);
+    sha256_update(&st, k_ipad, 64);
+    sha256_update(&st, CHARS_STRING(text), GET_LEN_STRING(text));
+    sha256_final(&st);
+
+    be32encode(digest, st.r, sizeof(digest));
+    sha256_init(&st);
+    sha256_update(&st, k_opad, 64);
+    sha256_update(&st, digest, 32);
+    sha256_final(&st);
+
+    result = NEW_PLIST(T_PLIST, 8);
+    SET_LEN_PLIST(result, 8);
+    for (i = 0; i < 8; i++) {
+        SET_ELM_PLIST(result, i + 1, ObjInt_UInt(st.r[i]));
+        CHANGED_BAG(result);
+    }
+    return result;
+}
+
+// Table of functions to export
+static StructGVarFunc GVarFuncs[] = {
+    GVAR_FUNC(GAP_SHA256_INIT, 0, ""),
+    GVAR_FUNC(GAP_SHA256_UPDATE, 2, "state, bytes"),
+    GVAR_FUNC(GAP_SHA256_FINAL, 1, "state"),
+    GVAR_FUNC(GAP_SHA256_HMAC, 2, "key, text"),
+
+    { 0 }    // Finish with an empty entry
+};
+
+/****************************************************************************
+**
+*F  InitKernel( <module> ) . . . . . . .  initialise kernel data structures
+*/
+static Int InitKernel(StructInitInfo * module)
+{
+    ImportGVarFromLibrary("GAP_SHA256_State_Type", &GAP_SHA256_State_Type);
+
+    // init filters and functions
+    InitHdlrFuncsFromTable(GVarFuncs);
+
+    // return success
+    return 0;
+}
+
+/****************************************************************************
+**
+*F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
+*/
+static Int InitLibrary(StructInitInfo * module)
+{
+    // init filters and functions
+    InitGVarFuncsFromTable(GVarFuncs);
+
+    return 0;
+}
+
+/****************************************************************************
+**
+*F  InitSHA256() . . . . . . . . . . . . . . . . . .  table of init functions
+*/
+static StructInitInfo module = {
+    // init struct using C99 designated initializers; for a full list of
+    // fields, please refer to the definition of StructInitInfo
+    .type = MODULE_BUILTIN,
+    .name = "crypting",
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+};
+
+StructInitInfo * InitSHA256(void)
+{
+    return &module;
+}

--- a/src/sha256.h
+++ b/src/sha256.h
@@ -1,0 +1,22 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef GAP_SHA256_H
+#define GAP_SHA256_H
+
+#include "common.h"
+
+/****************************************************************************
+**
+*F  InitSHA256() . . . . . . . . . . . . . . . . . .  table of init functions
+*/
+StructInitInfo * InitSHA256(void);
+
+#endif    // GAP_SHA256_H

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -299,8 +299,10 @@ Int4 SyGAPCRC( const Char * name )
 <Returns>an integer</Returns>
 
 <Description>
-This function computes a cyclic redundancy check number from a string
-<A>str</A>. See also <Ref Func="CrcFile"/>.
+<Index>hash function</Index>
+<Index>checksum</Index>
+This function computes a CRC (cyclic redundancy check) number from a string
+<A>str</A>. See also <Ref Func="CrcFile"/> and <Ref Func="HexSHA256"/>.
 <Example>
 gap> CrcString("GAP example string");
 -50451670

--- a/tst/testinstall/sha256.tst
+++ b/tst/testinstall/sha256.tst
@@ -1,0 +1,50 @@
+#
+gap> START_TEST("sha256.tst");
+
+#
+# test input validation for the kernel functions
+#
+gap> state := GAP_SHA256_INIT();
+<object>
+
+#
+gap> GAP_SHA256_UPDATE(fail, fail);
+Error, GAP_SHA256_UPDATE: <state> must be a SHA256 state (not the value 'fail'\
+)
+gap> GAP_SHA256_UPDATE(state, fail);
+Error, GAP_SHA256_UPDATE: <bytes> must be a string (not the value 'fail')
+gap> GAP_SHA256_HMAC(fail, fail);
+Error, GAP_SHA256_HMAC: <key> must be a string (not the value 'fail')
+gap> GAP_SHA256_HMAC("", fail);
+Error, GAP_SHA256_HMAC: <text> must be a string (not the value 'fail')
+
+#
+gap> HexSHA256("abcd");
+"88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+gap> HexSHA256(['a', 'b', 'c', 'd']);
+"88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+gap> HexSHA256("abcd\n");
+"fc4b5fd6816f75a7c81fc8eaa9499d6a299bd803397166e8c4cf9280b801d62c"
+gap> HexSHA256("abcd\r");
+"aea243b0f1748f70fe977b811723cd1e5bf37a9a3aafcb95957c4dbdea78b1d9"
+gap> HexSHA256("abcd\r\n");
+"9c9a433b67154b248b93bf805dd19241ed07c86ddf15c640f2dcdd927824bb23"
+gap> HexSHA256("");
+"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+#
+gap> HexSHA256(InputTextString("abcd"));
+"88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+gap> HexSHA256(InputTextString(['a', 'b', 'c', 'd']));
+"88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"
+gap> HexSHA256(InputTextString("abcd\n"));
+"fc4b5fd6816f75a7c81fc8eaa9499d6a299bd803397166e8c4cf9280b801d62c"
+gap> HexSHA256(InputTextString("abcd\r"));
+"aea243b0f1748f70fe977b811723cd1e5bf37a9a3aafcb95957c4dbdea78b1d9"
+gap> HexSHA256(InputTextString("abcd\r\n"));
+"9c9a433b67154b248b93bf805dd19241ed07c86ddf15c640f2dcdd927824bb23"
+gap> HexSHA256(InputTextString(""));
+"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+#
+gap> STOP_TEST("sha256.tst");


### PR DESCRIPTION
This uses C kernel code directly taken from the crypting packages, with the kernel functions renamed to avoid conflicting with crypting.

Resolves #4844.

Some concerns and ideas:
1. I picked `HexSHA256String` based on the name of the `SHA256String` in crypting, which does the same except the return value is not a hex string but rather a list of integers. So "String" seems to encode the argument type. But is this useful here? Can't we just call it `HexSHA256`? Well, I guess we might want a variant which takes a filename as argument, and then calling that e.g. `HexSHA256File` would be natural -- but this could be implemented as `HexSHA256String(StringFile(filename))`, so do we really need this? Hmm, thinking about it, perhaps yes: to deal with checksumming huge files, which we don't want to read into memory all at once?
2. It would probably be a useful to add a variant `HexSHA256Stream` which takes an input stream as argument.  And again: this could alternatively be also called `HexSHA256`, and then we can decide what to do based on the type of the argument. (If we handle streams, that also alleviates the issue of checksumming huge files without reading them into memory all at once).
3. How to ensure a smooth transition for crypting? Well, for now this PR tries hard to be compatible with `crypting`, and I just checked, it is. So we could leave things at that. But we could also tweak `crypting` to not load its kernel extension when it detects that the GAP kernel provides the required functionality. But there is no pressing need for that right now, I think? As far as I know, only `JupyterKernel` needs crypting, anyway.
4. Maybe we want other APIs beyond `HexSHA256String` (or whatever else to call it)? Suggestions, wishes?