### PR TITLE
Fix a crash in the syntax tree code

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -820,7 +820,9 @@ void CodeFuncExprBegin (
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
-    SET_GAPNAMEID_BODY(body, GetInputFilenameID(GetCurrentInput()));
+    UInt gapnameid = GetInputFilenameID(GetCurrentInput());
+    if (gapnameid)
+        SET_GAPNAMEID_BODY(body, gapnameid);
     SET_STARTLINE_BODY(body, startLine);
     CS(OffsBody) = sizeof(BodyHeader);
 

--- a/src/io.c
+++ b/src/io.c
@@ -233,8 +233,7 @@ void SKIP_TO_END_OF_LINE(TypInputFile * input)
 
 Int GetInputLineNumber(TypInputFile * input)
 {
-    GAP_ASSERT(input);
-    return input->number;
+    return input ? input->number : 0;
 }
 
 const Char * GetInputLineBuffer(TypInputFile * input)
@@ -252,8 +251,7 @@ Int GetInputLinePosition(TypInputFile * input)
 
 UInt GetInputFilenameID(TypInputFile * input)
 {
-    GAP_ASSERT(input);
-    return input->gapnameid;
+    return input ? input->gapnameid : 0;
 }
 
 static void AddCachedFilename(SymbolTable * symtab, UInt id, Obj name)


### PR DESCRIPTION
... when no input stream is open. E.g. this would crash:

    gap> tree := SYNTAX_TREE(EvalString("x -> x"));;
    gap> SYNTAX_TREE_CODE(tree);

This is a bit difficult to reproduce in plain GAP, but it can
happen in HPC-GAP or GAP.jl (the Julia interface to GAP).

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

Resolves https://github.com/oscar-system/GAP.jl/issues/814

CC @zickgraf 