### PR TITLE
kernel: minimize uses of `GetCurrentInput`

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -795,6 +795,7 @@ void CodeFuncExprBegin (
     Int                 narg,
     Int                 nloc,
     Obj                 nams,
+    UInt                gapnameid,
     Int                 startLine)
 {
     Obj                 fexp;           /* function expression bag         */
@@ -820,7 +821,6 @@ void CodeFuncExprBegin (
     CHANGED_BAG( fexp );
 
     /* record where we are reading from */
-    UInt gapnameid = GetInputFilenameID(GetCurrentInput());
     if (gapnameid)
         SET_GAPNAMEID_BODY(body, gapnameid);
     SET_STARTLINE_BODY(body, startLine);
@@ -839,7 +839,7 @@ void CodeFuncExprBegin (
     assert( stat1 == OFFSET_FIRST_STAT );
 }
 
-Expr CodeFuncExprEnd(UInt nr, UInt pushExpr)
+Expr CodeFuncExprEnd(UInt nr, BOOL pushExpr, Int endLine)
 {
     Expr                expr;           /* function expression, result     */
     Stat                stat1;          /* single statement of body        */
@@ -900,7 +900,7 @@ Expr CodeFuncExprEnd(UInt nr, UInt pushExpr)
 
     /* make the body smaller                                               */
     ResizeBag(BODY_FUNC(fexp), CS(OffsBody));
-    SET_ENDLINE_BODY(BODY_FUNC(fexp), GetInputLineNumber(GetCurrentInput()));
+    SET_ENDLINE_BODY(BODY_FUNC(fexp), endLine);
 
     /* switch back to the previous function                                */
     SWITCH_TO_OLD_LVARS( ENVI_FUNC(fexp) );

--- a/src/code.h
+++ b/src/code.h
@@ -671,8 +671,10 @@ void CodeFuncCallEnd(UInt funccall, UInt options, UInt nr);
 
 /****************************************************************************
 **
-*F  CodeFuncExprBegin(<narg>,<nloc>,<nams>,<startline>) . code function expression, begin
-*F  CodeFuncExprEnd(<nr>,<pushExpr>) . . . . .  code function expression, end
+*F  CodeFuncExprBegin(<narg>,<nloc>,<nams>,<gapnameid>,<startLine>)
+**                                        . . code function expression, begin
+*F  CodeFuncExprEnd(<nr>,<pushExpr>,<endLine>)
+**                                        . . . code function expression, end
 **
 **  'CodeFuncExprBegin'  is an action to code  a  function expression.  It is
 **  called when the reader encounters the beginning of a function expression.
@@ -685,9 +687,9 @@ void CodeFuncCallEnd(UInt funccall, UInt options, UInt nr);
 **  is the number of statements in the body of the function. If <pushExpr> is
 **  set, the current function expression is pushed on the expression stack.
 */
-void CodeFuncExprBegin(Int narg, Int nloc, Obj nams, Int startLine);
+void CodeFuncExprBegin(Int narg, Int nloc, Obj nams, UInt gapnameid, Int startLine);
 
-Expr CodeFuncExprEnd(UInt nr, UInt pushExpr);
+Expr CodeFuncExprEnd(UInt nr, BOOL pushExpr, Int endLine);
 
 /****************************************************************************
 **

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -49,6 +49,10 @@ struct IntrState {
     // profiling
     UInt startLine;
 
+    // The id of the file or stream from which the code being read originates
+    // from. Can be turned into a string object via `GetCachedFilename`.
+    UInt gapnameid;
+
     // 'StackObj' is the stack of values.
     Obj StackObj;
 };
@@ -152,7 +156,7 @@ void IntrFuncCallOptionsEnd(IntrState * intr, UInt nr);
 void IntrFuncExprBegin(
     IntrState * intr, Int narg, Int nloc, Obj nams, Int startLine);
 
-void IntrFuncExprEnd(IntrState * intr, UInt nr);
+void IntrFuncExprEnd(IntrState * intr, UInt nr, Int endLine);
 
 
 /****************************************************************************

--- a/src/io.c
+++ b/src/io.c
@@ -1886,7 +1886,7 @@ static Obj FuncINPUT_FILENAME(Obj self)
     if (IO()->Input == 0)
         return MakeImmString("*defin*");
 
-    UInt gapnameid = GetInputFilenameID(GetCurrentInput());
+    UInt gapnameid = GetInputFilenameID(IO()->Input);
     return GetCachedFilename(gapnameid);
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -1324,7 +1324,7 @@ static void ReadFuncExprBody(ReaderState * rs,
 
     // end interpreting the function expression
     TRY_IF_NO_ERROR {
-        IntrFuncExprEnd(&rs->intr, nr);
+        IntrFuncExprEnd(&rs->intr, nr, GetInputLineNumber(rs->s.input));
     }
 
     // pop the new local variables list
@@ -2558,7 +2558,7 @@ ExecStatus ReadEvalCommand(Obj            context,
 #endif
 
     AssGVar(GVarName("READEVALCOMMAND_LINENUMBER"),
-            INTOBJ_INT(GetInputLineNumber(rs->s.input)));
+            INTOBJ_INT(GetInputLineNumber(input)));
 
     // remember the old execution state and start an execution environment
     Bag oldLVars =
@@ -2570,6 +2570,7 @@ ExecStatus ReadEvalCommand(Obj            context,
     STATE(ErrorLVars) = STATE(CurrLVars);
 
     IntrBegin(&rs->intr);
+    rs->intr.gapnameid = GetInputFilenameID(input);
 
     switch (rs->s.Symbol) {
     /* read an expression or an assignment or a procedure call             */
@@ -2684,6 +2685,7 @@ ExecStatus ReadEvalFile(TypInputFile * input, Obj * evalResult)
     Bag oldLVars = SWITCH_TO_BOTTOM_LVARS();
 
     IntrBegin(&rs->intr);
+    rs->intr.gapnameid = GetInputFilenameID(input);
 
     /* check for local variables                                           */
     nams = NEW_PLIST(T_PLIST, 0);
@@ -2695,7 +2697,7 @@ ExecStatus ReadEvalFile(TypInputFile * input, Obj * evalResult)
 
     /* fake the 'function ()'                                              */
     IntrFuncExprBegin(&rs->intr, 0, nloc, nams,
-                      GetInputLineNumber(rs->s.input));
+                      GetInputLineNumber(input));
 
     /* read the statements                                                 */
     GAP_ASSERT(rs->LoopNesting == 0);
@@ -2710,7 +2712,7 @@ ExecStatus ReadEvalFile(TypInputFile * input, Obj * evalResult)
 
     /* fake the 'end;'                                                     */
     TRY_IF_NO_ERROR {
-        IntrFuncExprEnd(&rs->intr, nr);
+        IntrFuncExprEnd(&rs->intr, nr, GetInputLineNumber(input));
     }
 
     /* end the interpreter                                                 */

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -884,8 +884,6 @@ static void StoreSymbolPosition(ScannerState * s)
 */
 static UInt NextSymbol(ScannerState * s)
 {
-    GAP_ASSERT(s->input == GetCurrentInput());
-
     // Record end of previous symbol's position
     StoreSymbolPosition(s);
 

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -606,9 +606,9 @@ static Obj SyntaxTreeFunc(Obj result, Obj func)
     return result;
 }
 
-static UInt SyntaxTreeCodeFunc_Internal(Obj node)
+static Expr SyntaxTreeCodeFunc(Obj node)
 {
-    RequirePlainRec("SyntaxTreeCodeFunc_Internal", node);
+    RequirePlainRec("SyntaxTreeCodeFunc", node);
     Int narg = INT_INTOBJ(ElmRecST(EXPR_FUNC, node, "narg"));
     Int nloc = INT_INTOBJ(ElmRecST(EXPR_FUNC, node, "nloc"));
     Obj nams = ElmRecST(EXPR_FUNC, node, "nams");
@@ -624,23 +624,14 @@ static UInt SyntaxTreeCodeFunc_Internal(Obj node)
         Expr current = SyntaxTreeDefaultStatCoder(ELM_LIST(body_stats, i));
         PushStat(current);
     }
-    return nr_stats;
-}
-
-static Expr SyntaxTreeCodeFunc(Obj node)
-{
-    RequirePlainRec("SyntaxTreeCodeFunc", node);
-    UInt nr_stats = SyntaxTreeCodeFunc_Internal(node);
-    Expr funcexpr = CodeFuncExprEnd(nr_stats, FALSE, 0);
-    return funcexpr;
+    return CodeFuncExprEnd(nr_stats, FALSE, 0);
 }
 
 static Obj FuncSYNTAX_TREE_CODE(Obj self, Obj tree)
 {
     RequirePlainRec(SELF_NAME, tree);
     CodeBegin();
-    UInt nr_stats = SyntaxTreeCodeFunc_Internal(tree);
-    CodeFuncExprEnd(nr_stats, FALSE, 0);
+    SyntaxTreeCodeFunc(tree);
     Obj func = CodeEnd(0);
     if (IsbPRec(tree, RNamName("name"))) {
         Obj name = ELM_REC(tree, RNamName("name"));

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -616,7 +616,7 @@ static UInt SyntaxTreeCodeFunc_Internal(Obj node)
     if (variadic == True) {
         narg = -narg;
     }
-    CodeFuncExprBegin(narg, nloc, nams, 0);
+    CodeFuncExprBegin(narg, nloc, nams, 0, 0);
     Obj  stat_rec = ElmRecST(EXPR_FUNC, node, "stats");
     Obj  body_stats = ElmRecST(EXPR_FUNC, stat_rec, "statements");
     UInt nr_stats = LEN_LIST(body_stats);
@@ -631,7 +631,7 @@ static Expr SyntaxTreeCodeFunc(Obj node)
 {
     RequirePlainRec("SyntaxTreeCodeFunc", node);
     UInt nr_stats = SyntaxTreeCodeFunc_Internal(node);
-    Expr funcexpr = CodeFuncExprEnd(nr_stats, 0);
+    Expr funcexpr = CodeFuncExprEnd(nr_stats, FALSE, 0);
     return funcexpr;
 }
 
@@ -640,7 +640,7 @@ static Obj FuncSYNTAX_TREE_CODE(Obj self, Obj tree)
     RequirePlainRec(SELF_NAME, tree);
     CodeBegin();
     UInt nr_stats = SyntaxTreeCodeFunc_Internal(tree);
-    CodeFuncExprEnd(nr_stats, 0);
+    CodeFuncExprEnd(nr_stats, FALSE, 0);
     Obj func = CodeEnd(0);
     if (IsbPRec(tree, RNamName("name"))) {
         Obj name = ELM_REC(tree, RNamName("name"));


### PR DESCRIPTION
For the "fake function expressions" used to handle loops and atomic statements
in the interpreter, we simply do not bother anymore to record precise start and end
line numbers. In practice these should not matter anyway.

Only one call to `GetCurrentInput` is left, in `NewStat`; getting rid of that will require more substantial refactoring.

The motivation for this is that this function represents a hidden tight coupling between "global state" of the code in `io.c` on the one hand, and the code in `scanner.c`/`read.c`/`intrprtr.c`/`code.c` on the other hand, which ultimately lead to the crash addressed in PR #4894. That PR in some sense only addresses a symptom of the problem, not the root cause, which is that the syntax tree tries to access the coder, but without fully initializing all global state needed by the coder. It actually calls `CodeBegin` in an attempt to setup that global state, but it turns out this is not enough.

Fully addressing this could consist of adding a member `UInt currentLine` to `struct CodeStat`, and then updating that variable from the reader (e.g. we could modify `Match_` in `read.c` to update this, say by calling a suitable helper `SetCurrentLineNumberInCodeState`. Even better would be if in addition `CodeState` was not a "hidden" global variable implemented as module state; but rather a pointer to it should be passed to all `Code*` functions. That would immediately turn it into "local state", enabling further future cleanup.