### PR TITLE
`Exponent` for groups with known conjugacy classes

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1277,6 +1277,11 @@ function(G)
   return exp;
 end);
 
+# ranked below the method for abelian groups
+InstallMethod( Exponent,
+    [ "IsGroup and IsFinite and HasConjugacyClasses" ],
+    G-> Lcm(List(ConjugacyClasses(G), c-> Order(Representative(c)))) );
+
 InstallMethod( Exponent,
     "method for finite abelian groups with generators",
     [ IsGroup and IsAbelian and HasGeneratorsOfGroup and IsFinite ],


### PR DESCRIPTION
In this case there is no need to compute all Sylow subgroups.

I noticed that `Exponent` took noticable time on a larger group for which I had computed the conjugacy classes before.

## Text for release notes
none

