### PR TITLE
Website: link to MathJax version of docs if available

### DIFF
--- a/dev/releases/HelpLinks-to-JSON.g
+++ b/dev/releases/HelpLinks-to-JSON.g
@@ -74,7 +74,6 @@ for x in NamesOfComponents(HELP_BOOKS_INFO) do
       path := "FAIL";
     else
       path := ReplacedString(path, fulldir, "");
-      path := ReplacedString(path, "_mj.html", ".html");
     fi;
 
     r.(bname).reference.(name) := path;


### PR DESCRIPTION
... at least when wrapping the next release. I see no downside to this?