### PR TITLE
fixed `IsTransitive` ...

### DIFF
--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -1814,7 +1814,8 @@ OrbitsishOperation( "Earns", OrbitsishReq, false, NewAttribute );
 ##  <P/>
 ##  <Index>transitive</Index>
 ##  We say that a  group <A>G</A> acts <E>transitively</E> on a domain
-##  <M>D</M> if and only if for every pair of points <M>d, e \in D</M>
+##  <M>D</M> if and only if <A>G</A> acts on <M>D</M> and for every pair of
+##  points <M>d, e \in D</M>
 ##  there is an element <M>g</M> in <A>G</A> such that <M>d^g = e</M>.
 ##  <P/>
 ##  For a permutation group <A>G</A>, one may also invoke this as
@@ -1823,6 +1824,21 @@ OrbitsishOperation( "Earns", OrbitsishReq, false, NewAttribute );
 ##  moved by it.
 ##  For example the group <M>\langle (2,3,4),(2,3) \rangle</M>
 ##  is transitive on the set <M>\{2, 3, 4\}</M>.
+##  <Example><![CDATA[
+##  gap> G:= Group( (2,3,4), (2,3) );;
+##  gap> IsTransitive( G, [ 2 .. 4 ] );
+##  true
+##  gap> IsTransitive( G, [ 2, 3 ] );   # G does not act on [ 2, 3 ]
+##  false
+##  gap> IsTransitive( G, [ 1 .. 4 ] );  # G has two orbits on [ 1 .. 4 ]
+##  false
+##  gap> IsTransitive( G );  # G is transitive on [ 2 .. 4 ]
+##  true
+##  gap> IsTransitive( SL(2, 3), NormedRowVectors( GF(3)^2 ) );
+##  false
+##  gap> IsTransitive( SL(2, 3), NormedRowVectors( GF(3)^2 ), OnLines );
+##  true
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2663,12 +2663,16 @@ end);
 ##
 #F  IsTransitive( <G>, <D>, <gens>, <acts>, <act> ) . . . . transitivity test
 ##
+##  We cannot assume that <G> acts on <D>.
+##  Thus it is in general not sufficient to check whether <D> is a subset of
+##  the <G>-orbit of a point in <D>, or whether <D> and this orbit have the
+##  same size.
+##
 InstallMethod( IsTransitive,
     "compare with orbit of element",
-    true,
-    OrbitsishReq, 0,
+    OrbitsishReq,
 function( G, D, gens, acts, act )
-    return Length(D)=0 or IsSubset( OrbitOp( G, D[ 1 ], gens, acts, act ), D );
+    return Length(D)=0 or IsEqualSet( OrbitOp( G, D[1], gens, acts, act ), D );
 end );
 
 

--- a/tst/testinstall/oprt.tst
+++ b/tst/testinstall/oprt.tst
@@ -38,4 +38,9 @@ gap> IsTransitive(eo);
 true
 gap> Blocks(eo);
 [ [ 1, 5, 9 ], [ 2, 6, 10 ], [ 3, 7, 11 ], [ 4, 8, 12 ] ]
-gap> STOP_TEST( "oprt.tst", 1);
+gap> G:= Group( (2,3,4), (2,3) );;
+gap> IsTransitive( G, [ 2, 3 ] );
+false
+gap> Transitivity( G, [ 2, 3 ] );
+0
+gap> STOP_TEST( "oprt.tst" );


### PR DESCRIPTION
... in the case that the group does not act on the given domain

## Text for release notes

Up to now, `IsTransitive( G, D )` did not require that `G` acts on `D`.
Thus `true` was returned also when `D` was a proper subset of a `G`-orbit.
From now on, `IsTransitive` returns `true` only if the given domain is closed under the `G`-action.
The documentation has been changed accordingly.

## Further details

The old behaviour was consistent with the old documentation,
but other parts of GAP apparently assumed that a group that acts transitively on a domain really acts on this domain.
(For example `RankAction` shows an error message that the action must be transitive if the group does not act on the given domain.)

There are related situations where GAP does not check whether the group in question really acts on the domain in question, see issue #4904.
