### PR TITLE
kernel: make Bag pointer to an opaque struct

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -144,7 +144,7 @@ enum { FALSE = 0, TRUE = 1 };
 **
 **  (The documentation of 'Bag' is contained in 'gasman.h'.)
 */
-typedef UInt * *        Bag;
+typedef struct OpaqueBag * Bag;
 
 
 /****************************************************************************

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1580,7 +1580,7 @@ static Obj BindOncePosObj(Obj obj, Obj index, Obj *new, int eval, const char *cu
       UInt *mptr[2];
       mptr[0] = (UInt *)contents;
       mptr[1] = 0;
-      ResizeBag(mptr, sizeof(Bag) * (n+1));
+      ResizeBag((Bag)mptr, sizeof(Bag) * (n+1));
       MEMBAR_WRITE();
       SET_PTR_BAG(obj, (void *)(mptr[0]));
     }

--- a/src/read.c
+++ b/src/read.c
@@ -2822,7 +2822,7 @@ static Int InitKernel (
 
 static Int InitModuleState(void)
 {
-    STATE(ErrorLVars) = (UInt **)0;
+    STATE(ErrorLVars) = 0;
 
     return 0;
 }

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -659,11 +659,11 @@ static UInt *** SyFreeBags_(UInt size)
 #endif
 
 
-UInt *** SyAllocBags(Int size, UInt need)
+void * SyAllocBags(Int size, UInt need)
 {
     GAP_ASSERT(size > 0);
 
-    UInt *** ret = INVALID_PTR;
+    void * ret = INVALID_PTR;
 
     /* first check if we would get above SyStorKill, if yes exit! */
     if (SyStorKill != 0 && SyStorKill < syWorksize + size) {
@@ -691,7 +691,7 @@ UInt *** SyAllocBags(Int size, UInt need)
         if (need) {
             Panic("cannot extend the workspace any more!");
         }
-        return (UInt***)0;
+        return 0;
     }
 
     // set the overrun flag if we became larger than SyStorMax

--- a/src/sysmem.h
+++ b/src/sysmem.h
@@ -220,7 +220,7 @@ void SyMAdviseFree(void);
 **  If the operating system does not support dynamic memory management, simply
 **  give 'SyAllocBags' a static buffer, from where it returns the blocks.
 */
-UInt *** SyAllocBags(Int size, UInt need);
+void * SyAllocBags(Int size, UInt need);
 
 
 /****************************************************************************


### PR DESCRIPTION
This helps to further enforce that kernel code only accesses bags
through the APIs provided for that (PTR_BAG/ADDR_OBJ, BAG_HEADER etc.),
though of course, this being C, we cannot completely prevent abuse.

This is motivated by a desire to make further changes to GC internals (in another upcoming PR). The change was meant to expose potentially problematic code in the kernel (I found none!). There is a still chance that CI will reveal issues in a package kernel extension...