### PR TITLE
Avoid using InstallValue on non-plain objects

### DIFF
--- a/lib/cyclotom.gi
+++ b/lib/cyclotom.gi
@@ -19,6 +19,24 @@
 
 #############################################################################
 ##
+#V  Cyclotomics . . . . . . . . . . . . . . . . . .  field of all cyclotomics
+##
+BindGlobal( "Cyclotomics", Objectify( NewType(
+    CollectionsFamily( CyclotomicsFamily ),
+    IsField and IsAttributeStoringRep ),
+    rec() ) );
+SetName( Cyclotomics, "Cyclotomics" );
+SetLeftActingDomain( Cyclotomics, Rationals );
+SetIsFiniteDimensional( Cyclotomics, false );
+SetIsFinite( Cyclotomics, false );
+SetIsWholeFamily( Cyclotomics, true );
+SetDegreeOverPrimeField( Cyclotomics, infinity );
+SetDimension( Cyclotomics, infinity );
+SetRepresentative(Cyclotomics, 0);
+
+
+#############################################################################
+##
 #M  Conductor( <list> ) . . . . . . . . . . . . . . . . . . . . .  for a list
 ##
 ##  (This works not only for lists of cyclotomics but also for lists of

--- a/lib/fldabnum.gd
+++ b/lib/fldabnum.gd
@@ -243,7 +243,7 @@ InstallIsomorphismMaintenance( GaloisStabilizer,
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalVariable( "Rationals", "field of rationals" );
+DeclareGlobalName( "Rationals" );
 
 DeclareSynonym( "IsRationals",
     IsCyclotomicCollection and IsField and IsPrimeField );
@@ -705,7 +705,7 @@ DeclareGlobalFunction( "LenstraBase" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalVariable( "Cyclotomics", "domain of all cyclotomics" );
+DeclareGlobalName( "Cyclotomics" );
 
 
 #############################################################################

--- a/lib/fldabnum.gi
+++ b/lib/fldabnum.gi
@@ -1651,24 +1651,6 @@ InstallMethod( Coefficients,
 
 #############################################################################
 ##
-#V  Cyclotomics . . . . . . . . . . . . . . . . . .  field of all cyclotomics
-##
-InstallValue( Cyclotomics, Objectify( NewType(
-    CollectionsFamily( CyclotomicsFamily ),
-    IsField and IsAttributeStoringRep ),
-    rec() ) );
-SetName( Cyclotomics, "Cyclotomics" );
-SetLeftActingDomain( Cyclotomics, Rationals );
-SetIsFiniteDimensional( Cyclotomics, false );
-SetIsFinite( Cyclotomics, false );
-SetIsWholeFamily( Cyclotomics, true );
-SetDegreeOverPrimeField( Cyclotomics, infinity );
-SetDimension( Cyclotomics, infinity );
-SetRepresentative(Cyclotomics, 0);
-
-
-#############################################################################
-##
 ##  Automorphisms of abelian number fields
 ##
 

--- a/lib/random.gd
+++ b/lib/random.gd
@@ -213,8 +213,8 @@ if IsHPCGAP then
     MakeThreadLocal( "GlobalRandomSource" );
     MakeThreadLocal( "GlobalMersenneTwister" );
 else
-    DeclareGlobalVariable( "GlobalRandomSource" );
-    DeclareGlobalVariable( "GlobalMersenneTwister" );
+    DeclareGlobalName( "GlobalRandomSource" );
+    DeclareGlobalName( "GlobalMersenneTwister" );
 fi;
 
 #############################################################################

--- a/lib/random.gi
+++ b/lib/random.gi
@@ -156,7 +156,7 @@ if IsHPCGAP then
     BindThreadLocalConstructor("GlobalRandomSource", {} ->
        RandomSource(IsGAPRandomSource, GET_RANDOM_SEED_COUNTER()));
 else
-    InstallValue(GlobalRandomSource, RandomSource(IsGAPRandomSource, 1));
+    BindGlobal("GlobalRandomSource", RandomSource(IsGAPRandomSource, 1));
 fi;
 
 
@@ -228,7 +228,7 @@ if IsHPCGAP then
 BindThreadLocalConstructor("GlobalMersenneTwister", {} ->
     RandomSource(IsMersenneTwister, String(GET_RANDOM_SEED_COUNTER())));
 else
-InstallValue(GlobalMersenneTwister, RandomSource(IsMersenneTwister, "1"));
+BindGlobal("GlobalMersenneTwister", RandomSource(IsMersenneTwister, "1"));
 fi;
 
 # default random method for lists and pairs of integers using the Mersenne

--- a/lib/rational.gi
+++ b/lib/rational.gi
@@ -16,7 +16,7 @@
 ##
 #V  Rationals . . . . . . . . . . . . . . . . . . . . . .  field of rationals
 ##
-InstallValue( Rationals, Objectify( NewType(
+BindGlobal( "Rationals", Objectify( NewType(
     CollectionsFamily( CyclotomicsFamily ),
     IsRationals and IsAttributeStoringRep ), rec() ) );
 SetName( Rationals, "Rationals" );


### PR DESCRIPTION
InstallValue and friends are the only reason we need the somewhat dangerous kernel function `CLONE_OBJ`. It has known issues when used on e.g. families (which we already try to reject) and types (see #1637).

If we can eliminate all uses of it on component and positional objects, then we could potentially replace it by a simpler implementation (which would reject attempts to use it on such non-plain objects), which would also help avoid pitfalls in HPC-GAP.
