### PR TITLE
Remove last regular uses of InstallValue

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -1647,6 +1647,8 @@ DeclareAttributeSuppCT( "Identifier", IsNearlyCharacterTable, [] );
 ##  <Var Name="LARGEST_IDENTIFIER_NUMBER"/>
 ##
 ##  <Description>
+##  list containing the largest identifier of an ordinary character table in
+##  the current session.
 ##  <!--  We have to use a list in order to admit
 ##    <C>DeclareGlobalVariable</C> and
 ##    <C>InstallFlushableValue</C>.
@@ -1656,12 +1658,10 @@ DeclareAttributeSuppCT( "Identifier", IsNearlyCharacterTable, [] );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalVariable( "LARGEST_IDENTIFIER_NUMBER",
-    "list containing the largest identifier of an ordinary character table\
- in the current session" );
 if IsHPCGAP then
-    InstallValue( LARGEST_IDENTIFIER_NUMBER, FixedAtomicList([ 0 ]) );
+    BindGlobal( "LARGEST_IDENTIFIER_NUMBER", FixedAtomicList([ 0 ]) );
 else
+    DeclareGlobalVariable( "LARGEST_IDENTIFIER_NUMBER" );
     InstallFlushableValue( LARGEST_IDENTIFIER_NUMBER, [ 0 ] );
 fi;
 

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -1658,12 +1658,7 @@ DeclareAttributeSuppCT( "Identifier", IsNearlyCharacterTable, [] );
 ##  </Description>
 ##  </ManSection>
 ##
-if IsHPCGAP then
-    BindGlobal( "LARGEST_IDENTIFIER_NUMBER", FixedAtomicList([ 0 ]) );
-else
-    DeclareGlobalVariable( "LARGEST_IDENTIFIER_NUMBER" );
-    InstallFlushableValue( LARGEST_IDENTIFIER_NUMBER, [ 0 ] );
-fi;
+BindGlobal( "LARGEST_IDENTIFIER_NUMBER", FixedAtomicList([ 0 ]) );
 
 #############################################################################
 ##

--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -2719,7 +2719,7 @@ DeclareAttribute( "BrauerCharacterValue", IsMatrix );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalVariable( "ZEV_DATA", "nested list of length 2" );
+BindGlobal( "ZEV_DATA", [ [], [] ] );
 DeclareGlobalFunction( "ZevData" );
 DeclareGlobalFunction( "ZevDataValue" );
 

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -4622,7 +4622,13 @@ InstallMethod( BrauerCharacterValue,
 ##
 #V  ZEV_DATA
 ##
-InstallFlushableValue( ZEV_DATA, [ [], [] ] );
+InstallMethod( FlushCaches,
+  [],
+  function()
+      ZEV_DATA[1] := [];
+      ZEV_DATA[2] := [];
+      TryNextMethod();
+  end );
 
 
 #############################################################################

--- a/lib/grpramat.gd
+++ b/lib/grpramat.gd
@@ -216,7 +216,7 @@ DeclareAttribute( "CentralizerInGLnZ", IsCyclotomicMatrixGroup );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareGlobalVariable( "CrystGroupDefaultAction" );
+DeclareGlobalName( "CrystGroupDefaultAction" );
 
 BindGlobal( "LeftAction",  Immutable( "LeftAction"  ) );
 BindGlobal( "RightAction", Immutable( "RightAction" ) );

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -151,7 +151,7 @@ end );
 ##
 #M  CrystGroupDefaultAction . . . . . . . . . . . . . . RightAction initially
 ##
-InstallValue( CrystGroupDefaultAction, RightAction );
+BindGlobal( "CrystGroupDefaultAction", RightAction );
 
 #############################################################################
 ##


### PR DESCRIPTION
... from the GAP library -- package still use it. Also, it is still used in
InstallFlushableValue and InstallFlushableValueFromFunction


@ThomasBreuer I am curious about the use of `InstallFlushableValue ` for `LARGEST_IDENTIFIER_NUMBER` in regular GAP -- the documentation for `Identifier` to me strongly suggests that the values should be unique "in the current GAP session", but they are not if `FlushCaches()` is ever called. Is that really desirable?