### PR TITLE
Fix off-by-one error in CopyListEntries

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1388,7 +1388,7 @@ static Obj FuncCOPY_LIST_ENTRIES(Obj self, Obj args)
         }
     }
 
-  if (dstmax > LEN_PLIST(dstlist))
+  if (dstmax >= LEN_PLIST(dstlist))
     {
       sptr = CONST_ADDR_OBJ(dstlist)+dstmax;
       ct = dstmax;

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -265,6 +265,15 @@ gap> CopyListEntries(l,2,2,l,3,2,2); l;
 gap> l := [1,2,3,4,5];;
 gap> CopyListEntries(l,1,1,l,3,2,2); l;
 [ 1, 2, 1, 4, 2 ]
+gap> l := [1,2,3,4,5];;
+gap> CopyListEntries([],1,1,l,1,1,5); l;
+[  ]
+gap> l := [1,2,3,4,5];;
+gap> CopyListEntries([],1,1,l,1,1,6); l;
+[  ]
+gap> l := [1,2,3,4,5];;
+gap> CopyListEntries([1,,,,,,7],1,1,l,1,1,6); l;
+[ 1 ]
 
 #
 gap> CopyListEntries();


### PR DESCRIPTION
The length of the list may be changed if we add new members to the
list to the end of list, or unbind the final element.

Fixes #4927 