### PR TITLE
Don't use InstallFlushableValue, and more "caching changes"

### DIFF
--- a/doc/hpc/regions.xml
+++ b/doc/hpc/regions.xml
@@ -310,7 +310,7 @@ region may lock another region while accessing it.
       Arg='obj[, name]'/>
 
 <Description>
-<Ref Func="ShareLibraryObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is negative.
+<Ref Func="ShareSpecialObj"/> functions like <Ref Func="ShareObj"/>, except that the precedence of the region it creates is negative.
 It is thus exempt from normal ordering and deadlock checks.
 </Description>
 </ManSection>

--- a/hpcgap/lib/variable.g
+++ b/hpcgap/lib/variable.g
@@ -63,37 +63,6 @@ end );
 
 #############################################################################
 ##
-#O  FlushCaches( ) . . . . . . . . . . . . . . . . . . . . . Clear all caches
-##
-##  <#GAPDoc Label="FlushCaches">
-##  <ManSection>
-##  <Oper Name="FlushCaches" Arg=""/>
-##
-##  <Description>
-##  <Ref Oper="FlushCaches"/> resets the value of each global variable that
-##  has been declared with <Ref Func="DeclareGlobalVariable"/> and for which
-##  the initial value has been set with <Ref Func="InstallFlushableValue"/>
-##  or <Ref Func="InstallFlushableValueFromFunction"/>
-##  to this initial value.
-##  <P/>
-##  <Ref Oper="FlushCaches"/> should be used only for debugging purposes,
-##  since the involved global variables include for example lists that store
-##  finite fields and cyclotomic fields used in the current &GAP; session,
-##  in order to avoid that these fields are constructed anew in each call
-##  to <Ref Func="GF" Label="for field size"/> and
-##  <Ref Func="CF" Label="for (subfield and) conductor"/>.
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-##
-DeclareOperation( "FlushCaches", [] );
-# This method is just that one method is callable. It is installed first, so
-# it will be last in line.
-InstallMethod( FlushCaches, "return method", [], function() end );
-
-
-#############################################################################
-##
 #F  DeclareGlobalVariable( <name>[, <description>] )
 ##
 ##  <#GAPDoc Label="DeclareGlobalVariable">

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -1831,7 +1831,7 @@ DeclareGlobalFunction( "QuaternionAlgebra" );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalVariable( "QuaternionAlgebraData" );
+BindGlobal( "QuaternionAlgebraData", NEW_SORTED_CACHE(true) );
 
 
 #############################################################################

--- a/lib/algsc.gi
+++ b/lib/algsc.gi
@@ -687,16 +687,6 @@ InstallAccessToGenerators( IsSCAlgebraObjCollection and IsFullSCAlgebra,
 
 #############################################################################
 ##
-#V  QuaternionAlgebraData
-##
-InstallFlushableValue( QuaternionAlgebraData, [ [], [] ] );
-if IsHPCGAP then
-    ShareSpecialObj( QuaternionAlgebraData );
-fi;
-
-
-#############################################################################
-##
 #F  QuaternionAlgebra( <F>[, <a>, <b>] )
 ##
 InstallGlobalFunction( QuaternionAlgebra, function( arg )

--- a/lib/cache.gd
+++ b/lib/cache.gd
@@ -13,6 +13,37 @@
 
 #############################################################################
 ##
+#O  FlushCaches( ) . . . . . . . . . . . . . . . . . . . . . Clear all caches
+##
+##  <#GAPDoc Label="FlushCaches">
+##  <ManSection>
+##  <Oper Name="FlushCaches" Arg=""/>
+##
+##  <Description>
+##  <Ref Oper="FlushCaches"/> resets the value of each global variable that
+##  has been declared with <Ref Func="DeclareGlobalVariable"/> and for which
+##  the initial value has been set with <Ref Func="InstallFlushableValue"/>
+##  or <Ref Func="InstallFlushableValueFromFunction"/>
+##  to this initial value.
+##  <P/>
+##  <Ref Oper="FlushCaches"/> should be used only for debugging purposes,
+##  since the involved global variables include for example lists that store
+##  finite fields and cyclotomic fields used in the current &GAP; session,
+##  in order to avoid that these fields are constructed anew in each call
+##  to <Ref Func="GF" Label="for field size"/> and
+##  <Ref Func="CF" Label="for (subfield and) conductor"/>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "FlushCaches", [] );
+# This method is just that one method is callable. It is installed first, so
+# it will be last in line.
+InstallMethod( FlushCaches, "return method", [], function() end );
+
+
+#############################################################################
+##
 #F  MemoizePosIntFunction(<function> [,<options> ] )
 ##
 ##  <#GAPDoc Label="MemoizePosIntFunction">

--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -2719,7 +2719,7 @@ DeclareAttribute( "BrauerCharacterValue", IsMatrix );
 ##  </Description>
 ##  </ManSection>
 ##
-BindGlobal( "ZEV_DATA", [ [], [] ] );
+BindGlobal( "ZEV_DATA", NEW_SORTED_CACHE(true) );
 DeclareGlobalFunction( "ZevData" );
 DeclareGlobalFunction( "ZevDataValue" );
 

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -4620,19 +4620,6 @@ InstallMethod( BrauerCharacterValue,
 
 #############################################################################
 ##
-#V  ZEV_DATA
-##
-InstallMethod( FlushCaches,
-  [],
-  function()
-      ZEV_DATA[1] := [];
-      ZEV_DATA[2] := [];
-      TryNextMethod();
-  end );
-
-
-#############################################################################
-##
 #F  ZevDataValue( <q>, <n> )
 ##
 InstallGlobalFunction( ZevDataValue, function( q, n )
@@ -4755,50 +4742,21 @@ InstallGlobalFunction( ZevDataValue, function( q, n )
 #F  ZevData( <q>, <n> )
 #F  ZevData( <q>, <n>, <listofpairs> )
 ##
-InstallGlobalFunction( ZevData, function( arg )
-    local q,
-          n,
-          pos,
-          pos2;
+InstallGlobalFunction( ZevData, function( q, n, listofpairs... )
+    local aux, result;
 
-    q:= arg[1];
-    n:= arg[2];
+    aux := GET_FROM_SORTED_CACHE(ZEV_DATA, q, {} -> NEW_SORTED_CACHE(false));
 
-    pos:= Position( ZEV_DATA[1], q );
-    if pos = fail then
-      Add( ZEV_DATA[1], q );
-      Add( ZEV_DATA[2], [ [], [] ] );
-      pos:= Length( ZEV_DATA[1] );
-    fi;
-
-    pos2:= Position( ZEV_DATA[2][ pos ][1], n );
-    if pos2 = fail then
-      Add( ZEV_DATA[2][ pos ][1], n );
-      pos2:= Length( ZEV_DATA[2][ pos ][1] );
-    fi;
-
-    if Length( arg ) = 3 then
-
-      # Store the third argument at this position.
-      if IsBound( ZEV_DATA[2][ pos ][2][ pos2 ] ) then
-        if ZEV_DATA[2][ pos ][2][ pos2 ] = arg[3] then
-          Info( InfoWarning, 1,
-                "ZevData( ", q, ", ", n, " ) was already stored" );
-        else
-          Error( "incompatible ZevData( ", q, ", ", n, " )" );
-        fi;
+    if Length( listofpairs ) = 1 then
+      listofpairs := listofpairs[1];
+      result := GET_FROM_SORTED_CACHE(aux, n, {} -> Immutable(listofpairs));
+      if result <> listofpairs then
+        Error( "incompatible ZevData( ", q, ", ", n, " )" );
       fi;
-      ZEV_DATA[2][ pos ][2][ pos2 ]:= Immutable( arg[3] );
-      return arg[3];
+      return result;
 
     else
-
-      # Get the entry.
-      if not IsBound( ZEV_DATA[2][ pos ][2][ pos2 ] ) then
-        ZEV_DATA[2][ pos ][2][ pos2 ]:= ZevDataValue( q, n );
-      fi;
-      return ZEV_DATA[2][ pos ][2][ pos2 ];
-
+      return GET_FROM_SORTED_CACHE(aux, n, {} -> ZevDataValue( q, n ));
     fi;
 end );
 

--- a/lib/ffe.gd
+++ b/lib/ffe.gd
@@ -322,10 +322,8 @@ DeclareGlobalFunction( "FFEFamily" );
 ##  </Description>
 ##  </ManSection>
 ##
-BIND_GLOBAL( "FAMS_FFE_LARGE", [ [], [] ] );
-if IsHPCGAP then
-    ShareSpecialObj( FAMS_FFE_LARGE );
-fi;
+BIND_GLOBAL( "FAMS_FFE_LARGE", NEW_SORTED_CACHE(false) );
+
 
 #############################################################################
 ##
@@ -346,7 +344,7 @@ fi;
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalVariable( "GALOIS_FIELDS" );
+BIND_GLOBAL( "GALOIS_FIELDS", NEW_SORTED_CACHE(true) );
 
 
 #############################################################################

--- a/lib/ffe.gi
+++ b/lib/ffe.gi
@@ -25,21 +25,6 @@
 
 #############################################################################
 ##
-#V  GALOIS_FIELDS
-##
-##  global cache of finite fields `GF( <p>^<d> )', consisting of a pair of
-##  lists of equal size, the first list being a set of field sizes;
-##  the field of size $p^d$ is stored in `GALOIS_FIELDS[2][<pos>]' if and
-##  and only if `GALOIS_FIELDS[1][<pos>]' is equal to $p^d$
-##
-InstallFlushableValue( GALOIS_FIELDS, [ [], [] ] );
-if IsHPCGAP then
-  ShareSpecialObj( GALOIS_FIELDS );
-fi;
-
-
-#############################################################################
-##
 #M  \+( <ffe>, <rat> )
 #M  \+( <rat>, <ffe> )
 #M  \*( <ffe>, <rat> )

--- a/lib/fldabnum.gd
+++ b/lib/fldabnum.gd
@@ -361,12 +361,7 @@ DeclareSynonym( "CF", CyclotomicField );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalVariable( "ABELIAN_NUMBER_FIELDS" );
-InstallFlushableValue( ABELIAN_NUMBER_FIELDS, [ [], [] ] );
-if IsHPCGAP then
-    ShareSpecialObj(ABELIAN_NUMBER_FIELDS);
-fi;
-
+BindGlobal( "ABELIAN_NUMBER_FIELDS", NEW_SORTED_CACHE(true) );
 
 #############################################################################
 ##

--- a/lib/pcgsperm.gi
+++ b/lib/pcgsperm.gi
@@ -1301,10 +1301,7 @@ function( G, d, e, opr )
     fi;
 end );
 
-BIND_GLOBAL( "CYCLICACHE", [ [], [] ]);
-if IsHPCGAP then
-  ShareSpecialObj(CYCLICACHE);
-fi;
+BIND_GLOBAL( "CYCLICACHE", NEW_SORTED_CACHE(false) );
 
 InstallGlobalFunction(CreateIsomorphicPcGroup,function(pcgs,needindices,flag)
 local r,i,p,A,f,a;

--- a/lib/polyrat.gi
+++ b/lib/polyrat.gi
@@ -128,10 +128,7 @@ end);
 #F  ApproximateRoot(<num>,<n>[,<digits>]) . . approximate th n-th root of num
 ##   numerically with a denominator of 'digits' digits.
 ##
-APPROXROOTS:=[ [], [] ];
-if IsHPCGAP then
-  ShareSpecialObj(APPROXROOTS);
-fi;
+BIND_GLOBAL( "APPROXROOTS", NEW_SORTED_CACHE(false) );
 
 BindGlobal("ApproximateRoot",function(arg)
 local r,e,f,store,maker;

--- a/lib/upolyirr.gi
+++ b/lib/upolyirr.gi
@@ -37,10 +37,7 @@ end );
 ##  
 #V  IRR_POLS_OVER_GF_CACHE:  a cache for the following function
 ##  
-IRR_POLS_OVER_GF_CACHE := [ [], [] ];
-if IsHPCGAP then
-    ShareSpecialObj( IRR_POLS_OVER_GF_CACHE );
-fi;
+BindGlobal( "IRR_POLS_OVER_GF_CACHE", NEW_SORTED_CACHE(false) );
 
 DeclareGlobalName("AllIrreducibleMonicPolynomialCoeffsOfDegree");
 BindGlobal("AllIrreducibleMonicPolynomialCoeffsOfDegree", function(n, q)

--- a/lib/variable.g
+++ b/lib/variable.g
@@ -63,37 +63,6 @@ end );
 
 #############################################################################
 ##
-#O  FlushCaches( ) . . . . . . . . . . . . . . . . . . . . . Clear all caches
-##
-##  <#GAPDoc Label="FlushCaches">
-##  <ManSection>
-##  <Oper Name="FlushCaches" Arg=""/>
-##
-##  <Description>
-##  <Ref Oper="FlushCaches"/> resets the value of each global variable that
-##  has been declared with <Ref Func="DeclareGlobalVariable"/> and for which
-##  the initial value has been set with <Ref Func="InstallFlushableValue"/>
-##  or <Ref Func="InstallFlushableValueFromFunction"/>
-##  to this initial value.
-##  <P/>
-##  <Ref Oper="FlushCaches"/> should be used only for debugging purposes,
-##  since the involved global variables include for example lists that store
-##  finite fields and cyclotomic fields used in the current &GAP; session,
-##  in order to avoid that these fields are constructed anew in each call
-##  to <Ref Func="GF" Label="for field size"/> and
-##  <Ref Func="CF" Label="for (subfield and) conductor"/>.
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-##
-DeclareOperation( "FlushCaches", [] );
-# This method is just that one method is callable. It is installed first, so
-# it will be last in line.
-InstallMethod( FlushCaches, "return method", [], function() end );
-
-
-#############################################################################
-##
 #F  DeclareGlobalVariable( <name>[, <description>] )
 ##
 ##  <#GAPDoc Label="DeclareGlobalVariable">

--- a/lib/zmodnz.gd
+++ b/lib/zmodnz.gd
@@ -148,12 +148,7 @@ InstallTrueMethod(IsEuclideanRing, IsZmodnZObjNonprimeCollection and
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalVariable( "Z_MOD_NZ",
-    "list of lists, at position [1][i] is n s.t. [2][i] is ZmodnZ(n)" );
-InstallFlushableValue( Z_MOD_NZ, [ [], [] ] );
-if IsHPCGAP then
-    ShareSpecialObj( Z_MOD_NZ );
-fi;
+BindGlobal( "Z_MOD_NZ", NEW_SORTED_CACHE(true) );
 
 
 #############################################################################


### PR DESCRIPTION
This builds upon PR #4926 which perhaps should be merged first, then I can rebase this PR and reviewing gets easier...

- add a helper `NEW_SORTED_CACHE` for use in tandem with the existing `GET_FROM_SORTED_CACHE`
- change a bunch of code to use that new helper
- add a comment explaining how to use `GET_FROM_SORTED_CACHE`
- merge the HPC-GAP and plain GAP implementations of `GET_FROM_SORTED_CACHE` (they now were identical other than for some `atomic` guards anyway)
- changed `ZEV_DATA` to use nested "SORTED_CACHE" instances as well

I agree with @ThomasBreuer that in principle, `Z_MOD_NZ` should be changed to not flush anymore. But then it essentially becomes a leak, because the user can fill it up but not clear anything from it (at least officially)... The proper fix would be to use a weak pointer object for the families here, and then letting `FlushCaches` just compact the thing to clean out unused entries...