### PR TITLE
kernel: change how ours GCs represent master pointers

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -115,13 +115,13 @@ enum {
 EXPORT_INLINE BagHeader * BAG_HEADER(Bag bag)
 {
     GAP_ASSERT(bag);
-    return ((*(BagHeader **)bag) - 1);
+    return *(BagHeader **)bag;
 }
 
 EXPORT_INLINE const BagHeader * CONST_BAG_HEADER(Bag bag)
 {
     GAP_ASSERT(bag);
-    return ((*(const BagHeader **)bag) - 1);
+    return *(const BagHeader **)bag;
 }
 
 
@@ -308,13 +308,13 @@ EXPORT_INLINE UInt SIZE_BAG_CONTENTS(const void *ptr)
 EXPORT_INLINE Bag *PTR_BAG(Bag bag)
 {
     GAP_ASSERT(bag != 0);
-    return *(Bag**)bag;
+    return  (Bag *)((*(BagHeader **)bag) + 1);
 }
 
 EXPORT_INLINE const Bag *CONST_PTR_BAG(Bag bag)
 {
     GAP_ASSERT(bag != 0);
-    return *(const Bag * const *)bag;
+    return  (const Bag *)((*(const BagHeader **)bag) + 1);
 }
 
 #if defined(USE_BOEHM_GC)

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -1578,11 +1578,11 @@ static Obj BindOncePosObj(Obj obj, Obj index, Obj *new, int eval, const char *cu
       // can't use ResizeBag() directly because of guards.
       // therefore we create a faux master pointer in the public region.
       UInt *mptr[2];
-      mptr[0] = (UInt *)contents;
-      mptr[1] = 0;
+      SET_PTR_BAG((Bag)mptr, contents);
+      SET_REGION((Bag)mptr, NULL);
       ResizeBag((Bag)mptr, sizeof(Bag) * (n+1));
       MEMBAR_WRITE();
-      SET_PTR_BAG(obj, (void *)(mptr[0]));
+      SET_PTR_BAG(obj, PTR_BAG((Bag)mptr));
     }
     // reread contents pointer
     HashUnlock(obj);


### PR DESCRIPTION
So far, our master pointers are pointers to a pointer to the data portion of a bag. This patch changes them to instead point at the start of the bag.

Pointing inside the bag, as was done before, was an optimization for the common case where one wants to access the content of a bag. However, at least on x86 and ARM architectures, there is no difference in practice, because adding an offset of 16 (GASMAN) resp. 8 (Boehm, Julia) is essentially free for most machine code opcodes used to access the data.

So this should not introduce a drawback, but at the same time there is no real advantage to doing this.

BUT of course there is still a reason why I want to do this: I need this for experimental work on the Julia GC integration (in an attempt to resolve https://github.com/oscar-system/GAP.jl/issues/817). But right now the result is crashing, in the Julia GC -- hence I adapted the other GCs to also use this mode, so I can test that everything is fine in GASMAN with this change. It is locally for me, but having it here as a PR gives a chance for more extensive CI tests to check it; also, the change is ABI breaking, so testing it on a "clean slate" is better than on my system.

tl;dr: this PR is not for merging but to allow me to experiment