### PR TITLE
CI: fix testbuildsys

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -134,8 +134,8 @@ GAPInput
 
     # verify that deps file has a target for the .lo file but not for the .d file
     fgrep "bool.c.lo:" ${bool_d} > /dev/null
-    ! fgrep "bool.c.d:" ${bool_d} > /dev/null
-    ! fgrep "garbage content" ${bool_lo} > /dev/null
+    fgrep "bool.c.d:" ${bool_d} > /dev/null && exit 1
+    fgrep "garbage content" ${bool_lo} > /dev/null && exit 1
 
     # verify our "garbage" files are still there
     test -f $SRCDIR/${bool_d}
@@ -148,8 +148,8 @@ GAPInput
 
     # verify that deps file has a target for the .lo file but not for the .d file
     fgrep "bool.c.lo:" ${bool_d} > /dev/null
-    ! fgrep "bool.c.d:" ${bool_d} > /dev/null
-    ! fgrep "garbage content" ${bool_lo} > /dev/null
+    fgrep "bool.c.d:" ${bool_d} > /dev/null && exit 1
+    fgrep "garbage content" ${bool_lo} > /dev/null && exit 1
 
     # test: `make` should regenerate removed *.d files (and then also regenerate the
     # corresponding *.lo file, which we verify by overwriting it with garbage)
@@ -164,8 +164,8 @@ GAPInput
 
     # verify that deps file has a target for the .lo file but not for the .d file
     fgrep "bool.c.lo:" ${bool_d} > /dev/null
-    ! fgrep "bool.c.d:" ${bool_d} > /dev/null
-    ! fgrep "garbage content" ${bool_lo} > /dev/null
+    fgrep "bool.c.d:" ${bool_d} > /dev/null && exit 1
+    fgrep "garbage content" ${bool_lo} > /dev/null && exit 1
 
     # test: running `make` a second time should produce no output
     test -z "$(make)"


### PR DESCRIPTION
Putting `!` in front of a command changes its exit code, but it does
*not* cause a success-turned-failure to abort the shell script, even
if `set -e` is active. This is explicitly documented this way in the
bash reference manual.

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
