### PR TITLE
Fix new IrrConlon

### DIFF
--- a/lib/ctblsolv.gi
+++ b/lib/ctblsolv.gi
@@ -772,12 +772,17 @@ function( G )
       if x in N then
         evals := [];
         for g in coreps do
-          xg := x^g;
+          xg := x^(g^-1);
           if normal or xg in C then
+            # if true then x^((cg)^-1) is in the same C-class for all c in C
             Add( evals, IndependentGeneratorExponents( Cab, xg^hom ));
           fi;
         od;
-        Add( ind, evals );
+        if Length(evals) > 0 then
+          Add( ind, evals );
+        else
+          Add( ind, 0 );
+        fi;
       else
         Add( ind, 0 );
       fi;

--- a/tst/testbugfix/2022-07-14-IrrConlon.tst
+++ b/tst/testbugfix/2022-07-14-IrrConlon.tst
@@ -1,0 +1,10 @@
+gap> G := Group([ (5,9)(10,14)(11,12)(15,16), (2,3)(4,7)(5,10)(9,14)(11,12)(15,16), (2,4)(3,5)(6,12)(7,9)(10,14)(11,13), (1,2)(3,6)(4,8)(5,11)(7,13)(9,12)(10,15)(14,16) ]);;
+gap> Order(G);
+1024
+gap> c := Set(IrrConlon(G));;
+gap> bc := Set(IrrBaumClausen(G));;
+gap> ds := Set(IrrDixonSchneider(G));;
+gap> bc =ds;
+true
+gap> c = bc;
+true


### PR DESCRIPTION
This fixes a bug in the new `IrrConlon` implementation, reported in issue "New IrrConlon method doesn't work for all groups" #4940. 

Fixes #4940 



## Text for release notes

none