### PR TITLE
kernel: avoid compiler warnings in some kernel extensions

### DIFF
--- a/src/calls.h
+++ b/src/calls.h
@@ -228,42 +228,42 @@ BOOL IsKernelFunction(Obj func);
 
 EXPORT_INLINE ObjFunc_0ARGS HDLR_0ARGS(Obj func)
 {
-    return (ObjFunc_0ARGS)HDLR_FUNC(func, 0);
+    return (ObjFunc_0ARGS)(void *)HDLR_FUNC(func, 0);
 }
 
 EXPORT_INLINE ObjFunc_1ARGS HDLR_1ARGS(Obj func)
 {
-    return (ObjFunc_1ARGS)HDLR_FUNC(func, 1);
+    return (ObjFunc_1ARGS)(void *)HDLR_FUNC(func, 1);
 }
 
 EXPORT_INLINE ObjFunc_2ARGS HDLR_2ARGS(Obj func)
 {
-    return (ObjFunc_2ARGS)HDLR_FUNC(func, 2);
+    return (ObjFunc_2ARGS)(void *)HDLR_FUNC(func, 2);
 }
 
 EXPORT_INLINE ObjFunc_3ARGS HDLR_3ARGS(Obj func)
 {
-    return (ObjFunc_3ARGS)HDLR_FUNC(func, 3);
+    return (ObjFunc_3ARGS)(void *)HDLR_FUNC(func, 3);
 }
 
 EXPORT_INLINE ObjFunc_4ARGS HDLR_4ARGS(Obj func)
 {
-    return (ObjFunc_4ARGS)HDLR_FUNC(func, 4);
+    return (ObjFunc_4ARGS)(void *)HDLR_FUNC(func, 4);
 }
 
 EXPORT_INLINE ObjFunc_5ARGS HDLR_5ARGS(Obj func)
 {
-    return (ObjFunc_5ARGS)HDLR_FUNC(func, 5);
+    return (ObjFunc_5ARGS)(void *)HDLR_FUNC(func, 5);
 }
 
 EXPORT_INLINE ObjFunc_6ARGS HDLR_6ARGS(Obj func)
 {
-    return (ObjFunc_6ARGS)HDLR_FUNC(func, 6);
+    return (ObjFunc_6ARGS)(void *)HDLR_FUNC(func, 6);
 }
 
 EXPORT_INLINE ObjFunc_1ARGS HDLR_XARGS(Obj func)
 {
-    return (ObjFunc_1ARGS)HDLR_FUNC(func, 7);
+    return (ObjFunc_1ARGS)(void *)HDLR_FUNC(func, 7);
 }
 
 

--- a/src/common.h
+++ b/src/common.h
@@ -163,7 +163,9 @@ typedef Bag Obj;
 **  'ObjFunc' is the type of a function returning an object.
 */
 #pragma GCC diagnostic push
+#ifndef __cplusplus
 #pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
 typedef Obj (* ObjFunc) (/*arguments*/);
 #pragma GCC diagnostic pop
 

--- a/src/modules.h
+++ b/src/modules.h
@@ -154,19 +154,19 @@ static inline ObjFunc VALIDATE_FUNC_HELPER_6(ObjFunc_6ARGS f)
 }
 
 #define VALIDATE_FUNC_0ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_0(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_0(func) : (ObjFunc)(void *)func)
 #define VALIDATE_FUNC_1ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_1(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_1(func) : (ObjFunc)(void *)func)
 #define VALIDATE_FUNC_2ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_2(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_2(func) : (ObjFunc)(void *)func)
 #define VALIDATE_FUNC_3ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_3(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_3(func) : (ObjFunc)(void *)func)
 #define VALIDATE_FUNC_4ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_4(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_4(func) : (ObjFunc)(void *)func)
 #define VALIDATE_FUNC_5ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_5(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_5(func) : (ObjFunc)(void *)func)
 #define VALIDATE_FUNC_6ARGS(func)                                            \
-    (0 ? VALIDATE_FUNC_HELPER_6(func) : (ObjFunc)func)
+    (0 ? VALIDATE_FUNC_HELPER_6(func) : (ObjFunc)(void *)func)
 
 
 /****************************************************************************
@@ -322,7 +322,7 @@ typedef struct {
 // StructGVarFunc arrays
 #define GVAR_FUNC(name, nargs, args)                                         \
     {                                                                        \
-        #name, nargs, args, (ObjFunc)Func##name, __FILE__ ":" #name   \
+        #name, nargs, args, (ObjFunc)(void *)Func##name, __FILE__ ":" #name   \
     }
 
 // The following helper macros are similar to GVAR_FUNC, but perform stricter


### PR DESCRIPTION
Kernel extensions which don't use compiler options to turn off
certain warnings may see a bunch of them caused by conversion
between different kinds of function pointers, which in general
can indeed indicate a bug, but here is *really* correct. We
silence these for good by first casting to `void *` which is
always legal.

Also, when compiling with C++, disable a `#pragma` we use to
temporarily silence the warning issued by `-Wstrict-prototypes`,
as this warning is not supported in C++ and so trying to disable
it can cause a warning by itself.