### PR TITLE
Remove ClosedStreamType, simplify IsClosedStream setting

### DIFF
--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -20,29 +20,13 @@
 
 #############################################################################
 ##
-#V  ClosedStreamType  . . . . . . . . . . . . . . . . type of a closed stream
-##
-ClosedStreamType := NewType(
-    StreamsFamily,
-    IsClosedStream );
-
-
-#############################################################################
-##
-#M  CloseStream( <stream> ) . . . . . . . . .  set type to <ClosedStreamType>
+#M  CloseStream( <stream> ) . . . . . . . . . . . . . . mark stream as closed
 ##
 InstallMethod( CloseStream,
     "non-process streams",
-    [ IsStream and IsComponentObjectRep],
+    [ IsStream ],
 function( stream )
-    SET_TYPE_COMOBJ( stream, ClosedStreamType );
-end );
-
-InstallMethod( CloseStream,
-    "non-process streams",
-    [ IsStream and IsPositionalObjectRep],
-function( stream )
-    SET_TYPE_POSOBJ( stream, ClosedStreamType );
+    SetFilterObj( stream, IsClosedStream );
 end );
 
 
@@ -52,7 +36,7 @@ end );
 ##
 InstallMethod( PrintObj,
     "closed stream",
-    [ IsClosedStream ],
+    [ IsClosedStream ], SUM_FLAGS,
 function( obj )
     Print( "closed-stream" );
 end );
@@ -586,7 +570,7 @@ function( stream )
     atomic InputTextFileStillOpen do
         RemoveSet( InputTextFileStillOpen, stream![1] );
     od;
-    SET_TYPE_POSOBJ( stream, ClosedStreamType );
+    SetFilterObj( stream, IsClosedStream );
 end );
 
 
@@ -1065,7 +1049,7 @@ function( stream )
     atomic OutputTextFileStillOpen do
         RemoveSet( OutputTextFileStillOpen, stream![1] );
     od;
-    SET_TYPE_POSOBJ( stream, ClosedStreamType );
+    SetFilterObj( stream, IsClosedStream );
 end );
 
 InstallAtExit( function()

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -294,7 +294,7 @@ gap> CLEAR_CACHE_INFO();
 gap> opcheck := OPERS_CACHE_INFO();;
 #@if GAPInfo.KernelInfo.KernelDebug and IsHPCGAP
 gap> opcheck{[1..11]};
-[ 0, 0, 0, 6, 0, 0, 4, 0, 0, 0, 0 ]
+[ 2, 0, 0, 6, 0, 0, 6, 0, 0, 2, 0 ]
 #@fi
 
 # FIXME: the following code skips entry 4 (OperationHit, which is normally
@@ -338,7 +338,7 @@ gap> opcheck{[1..11]};
 #
 #@if GAPInfo.KernelInfo.KernelDebug and not IsHPCGAP
 gap> opcheck{Difference([1..11], [4])};
-[ 0, 0, 0, 0, 0, 2, 0, 0, 0, 0 ]
+[ 2, 0, 0, 0, 0, 4, 0, 0, 2, 0 ]
 #@fi
 #@if not GAPInfo.KernelInfo.KernelDebug
 gap> opcheck{[1..11]};


### PR DESCRIPTION
Set IsClosedStream using SetFilterObj, instead of directly calling the low-level functions `SET_TYPE_COMOBJ` and `SET_TYPE_POSOBJ`.

I wrote this in October 2019 as part of push to force all objects to specify either component or positional representation (see issue #1043). Never finished that PR, but this commit from it seems sensible on its own.

Perhaps @frankluebeck (who I believe wrote this code originally) spots an issue with it?