### PR TITLE
Fix a bunch of representations

### DIFF
--- a/lib/groebner.gd
+++ b/lib/groebner.gd
@@ -74,7 +74,7 @@ DeclareCategory("IsMonomialOrdering",IsObject);
 ##  </ManSection>
 ##
 DeclareRepresentation("IsMonomialOrderingDefaultRep",
-  IsAttributeStoringRep and IsPositionalObjectRep and IsMonomialOrdering,[]);
+  IsAttributeStoringRep and IsMonomialOrdering,[]);
 
 BindGlobal("MonomialOrderingsFamily",
   NewFamily("MonomialOrderingsFamily",IsMonomialOrdering,IsMonomialOrdering));

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -274,7 +274,7 @@ end );
 ##
 #R  IsNullMapMatrix . . . . . . . . . . . . . . . . . . .  null map as matrix
 ##
-DeclareRepresentation( "IsNullMapMatrix", IsMatrix, [  ] );
+DeclareRepresentation( "IsNullMapMatrix", IsMatrix and IsPositionalObjectRep, [  ] );
 
 BindGlobal( "NullMapMatrix",
     Objectify( NewType( ListsFamily, IsNullMapMatrix ), [  ] ) );

--- a/lib/padics.gi
+++ b/lib/padics.gi
@@ -395,7 +395,7 @@ InstallGlobalFunction( PurePadicNumberFamily, function( p, precision )
         fam!.precision:= precision;
         fam!.modulus:= p^precision;
         fam!.printPadicSeries:= true;
-        fam!.defaultType := NewType( fam, IsPurePadicNumber );
+        fam!.defaultType := NewType( fam, IsPurePadicNumber and IsPositionalObjectRep );
         PADICS_FAMILIES[p][precision] := fam;
     fi;
     return PADICS_FAMILIES[p][precision];
@@ -760,7 +760,7 @@ InstallGlobalFunction( PadicExtensionNumberFamily,
     Append( str, String(precision) );
     Append( str, ",...)" );
     fam := NewFamily( str, IsPadicExtensionNumber );
-    fam!.defaultType := NewType( fam, IsPadicExtensionNumber );
+    fam!.defaultType := NewType( fam, IsPadicExtensionNumber and IsPositionalObjectRep );
     fam!.prime       := p;
     fam!.precision   := precision;
     fam!.modulus     := p^precision;

--- a/lib/pquot.gi
+++ b/lib/pquot.gi
@@ -1191,7 +1191,7 @@ function( G, p, n, collector )
     
     ##  Now turn this into a new object.
     fam  := NewFamily( "QuotientSystem", IsQuotientSystem );
-    type := NewType( fam, IsPQuotientSystem and IsMutable );
+    type := NewType( fam, IsPQuotientSystem and IsMutable and IsComponentObjectRep );
     Objectify( type, qs );
 
     return qs;

--- a/lib/reesmat.gi
+++ b/lib/reesmat.gi
@@ -251,7 +251,7 @@ function(S, mat)
    IsReesMatrixSubsemigroup and IsAttributeStoringRep ), rec() );
 
   # store the type of the elements in the semigroup
-  type:=NewType(fam, IsReesMatrixSemigroupElement);
+  type:=NewType(fam, IsReesMatrixSemigroupElement and IsPositionalObjectRep);
   
   fam!.type:=type;
   SetTypeReesMatrixSemigroupElements(R, type); 
@@ -308,7 +308,7 @@ function(S, mat)
                  and IsAttributeStoringRep), rec());
 
   # store the type of the elements in the semigroup
-  type := NewType(fam, IsReesZeroMatrixSemigroupElement);
+  type := NewType(fam, IsReesZeroMatrixSemigroupElement and IsPositionalObjectRep);
 
   fam!.type := type;
   SetTypeReesMatrixSemigroupElements(R, type);

--- a/lib/stbcbckt.gi
+++ b/lib/stbcbckt.gi
@@ -43,7 +43,7 @@ BindGlobal( "Refinements", AtomicRecord() );
 ##
 #F  IsSlicedPerm( <perm> )  . . . . . . . . . . . . . . . sliced permutations
 ##
-DeclareRepresentation( "IsSlicedPerm", IsPerm,
+DeclareRepresentation( "IsSlicedPerm", IsPerm and IsComponentObjectRep,
                         [ "length", "word", "lftObj","opr" ] );
 
 #############################################################################
@@ -96,7 +96,7 @@ InstallMethod( ViewObj,"sliced perm", true, [ IsSlicedPerm ], 0,
     Print( "<perm word of length ", perm!.length, ">" );
 end );
 
-DeclareRepresentation( "IsSlicedPermInv", IsPerm,
+DeclareRepresentation( "IsSlicedPermInv", IsPerm and IsComponentObjectRep,
                            [ "length", "word", "lftObj", "opr" ] );
 
 InstallOtherMethod( \^,"sliced perm", true, [ IsObject, IsSlicedPermInv ], 0,

--- a/tst/testinstall/reesmat.tst
+++ b/tst/testinstall/reesmat.tst
@@ -518,12 +518,12 @@ gap> UnderlyingSemigroup(T);
 # TypeReesMatrixSemigroupElements: for a Rees (0-)matrix semigroup
 gap> R := ReesZeroMatrixSemigroup(Group(()), [[()]]);;
 gap> TypeReesMatrixSemigroupElements(Semigroup(Representative(R)));
-<Type: (ReesZeroMatrixSemigroupElementsFamily, [ IsExtLElement, IsExtRElement,\
- IsMultiplicativeElement, ... ]), data: fail>
+<Type: (ReesZeroMatrixSemigroupElementsFamily, [ IsPositionalObjectRep, IsExtL\
+Element, IsExtRElement, ... ]), data: fail>
 gap> R := ReesMatrixSemigroup(Group(()), [[()]]);;
 gap> TypeReesMatrixSemigroupElements(Semigroup(Representative(R)));
-<Type: (ReesMatrixSemigroupElementsFamily, [ IsExtLElement, IsExtRElement, IsM\
-ultiplicativeElement, ... ]), data: fail>
+<Type: (ReesMatrixSemigroupElementsFamily, [ IsPositionalObjectRep, IsExtLElem\
+ent, IsExtRElement, ... ]), data: fail>
 
 # RMSElement global function
 gap> R := ReesZeroMatrixSemigroup(SymmetricGroup(2), [[(1,2), 0], [0, ()]]);;


### PR DESCRIPTION
... which were neither in `IsComponentObjectRep` nor in `IsPositionalObjectRep`; or which were in both.

I wrote this in October 2019 as part of push to force all objects to specify either component or positional representation (see issue #1043). Never finished that PR, but this commit from it seems sensible on its own.
