### PR TITLE
MatrixObj: speed up MultMatrixColumnLeft/Right for plain matrices

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1527,6 +1527,18 @@ InstallMethod( MultMatrixColumnRight, "for a mutable matrix object, a column num
 
   end );
 
+InstallEarlyMethod( MultMatrixColumnRight,
+  function( mat, i, scalar )
+    local row;
+    if IsPlistRep(mat) then
+      for row in mat do
+          row[i] := row[i] * scalar;
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
 ############################################################################
 
 InstallMethod( MultMatrixRowRight, "for a mutable matrix object, a row number, and a scalar",
@@ -1560,6 +1572,18 @@ InstallMethod( MultMatrixColumnLeft, "for a mutable matrix object, a column numb
         mat[i,column] := scalar * mat[i,column];
     od;
 
+  end );
+
+InstallEarlyMethod( MultMatrixColumnLeft,
+  function( mat, i, scalar )
+    local row;
+    if IsPlistRep(mat) then
+      for row in mat do
+          row[i] := scalar * row[i];
+      od;
+    else
+      TryNextMethod();
+    fi;
   end );
 
 ############################################################################


### PR DESCRIPTION
[Another piece of an unfinished branch I had sitting around...]


The following micro benchmarks show that they are now close to optimal for both
plain lists and matrix objects.

Before:

    gap> mat:=IdentityMat(10,Integers);;
    gap> for i in [1..1000000] do MultMatrixColumnRight(mat,7,-1); od; time;
    707
    gap> for i in [1..1000000] do for row in mat do row[7] := row[7] * -1; od;  od; time;
    220
    gap> for i in [1..1000000] do for i in [1..10] do mat[i,7] := mat[i,7] *-1; od;  od; time;
    292

    gap> mat:=IdentityMat(10,GF(2));; ConvertToMatrixRep(mat);; mat;
    <a 10x10 matrix over GF2>
    gap> for i in [1..1000000] do MultMatrixColumnRight(mat,7,Z(2)); od; time;
    561
    gap> for i in [1..1000000] do for row in mat do row[7] := row[7] * Z(2); od;  od; time;
    2294
    gap> for i in [1..1000000] do for i in [1..10] do mat[i,7] := mat[i,7] * Z(2); od;  od; time;
    574

After:

    gap> mat:=IdentityMat(10,Integers);;
    gap> for i in [1..1000000] do MultMatrixColumnRight(mat,7,-1); od; time;
    243
    gap> for i in [1..1000000] do for row in mat do row[7] := row[7] * -1; od;  od; time;
    227
    gap> for i in [1..1000000] do for i in [1..10] do mat[i,7] := mat[i,7] *-1; od;  od; time;
    295

    gap> mat:=IdentityMat(10,GF(2));; ConvertToMatrixRep(mat);; mat;
    <a 10x10 matrix over GF2>
    gap> for i in [1..1000000] do MultMatrixColumnRight(mat,7,Z(2)); od; time;
    598
    gap> for i in [1..1000000] do for row in mat do row[7] := row[7] * Z(2); od;  od; time;
    2295
    gap> for i in [1..1000000] do for i in [1..10] do mat[i,7] := mat[i,7] * Z(2); od;  od; time;
    584
