### PR TITLE
Make `SwapMatrixColumns` and `SwapMatrixRows` faster for classic matrices (lists-of-lists)

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1852,18 +1852,6 @@ InstallMethod( SwapMatrixRows, "for a mutable matrix object, and two row numbers
 
   end );
 
-InstallEarlyMethod( SwapMatrixRows,
-  function( mat, i, j )
-    local tmp;
-    if IsPlistRep(mat) then
-      tmp := mat[i];
-      mat[i] := mat[j];
-      mat[j] := tmp;
-    else
-      TryNextMethod();
-    fi;
-  end );
-
 ############################################################################
 
 InstallMethod( SwapMatrixColumns, "for a mutable matrix object, and two column numbers",
@@ -1879,20 +1867,6 @@ InstallMethod( SwapMatrixColumns, "for a mutable matrix object, and two column n
         od;
     fi;
 
-  end );
-
-InstallEarlyMethod( SwapMatrixColumns,
-  function( mat, i, j )
-    local row, tmp;
-    if IsPlistRep(mat) then
-      for row in mat do
-        tmp := row[i];
-        row[i] := row[j];
-        row[j] := tmp;
-      od;
-    else
-      TryNextMethod();
-    fi;
   end );
 
 

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -2034,7 +2034,7 @@ DeclareOperation( "AddMatrixColumnsLeft", [ IsMatrixOrMatrixObj and IsMutable, I
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SwapMatrixRows", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ] );
+DeclareOperationKernel( "SwapMatrixRows", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ], SWAP_MAT_ROWS );
 
 ############################################################################
 ##
@@ -2051,4 +2051,4 @@ DeclareOperation( "SwapMatrixRows", [ IsMatrixOrMatrixObj and IsMutable, IsInt, 
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SwapMatrixColumns", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ] );
+DeclareOperationKernel( "SwapMatrixColumns", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ], SWAP_MAT_COLS );

--- a/src/lists.c
+++ b/src/lists.c
@@ -1799,6 +1799,61 @@ void AsssListLevelCheck (
 
 /****************************************************************************
 **
+*F  FuncSWAP_MAT_ROWS( <self>, <mat>, <row1>, <row2> )
+*/
+static Obj SwapMatRows;
+
+static Obj FuncSWAP_MAT_ROWS(Obj self, Obj mat, Obj row1, Obj row2)
+{
+    if (IS_POS_INTOBJ(row1) && IS_POS_INTOBJ(row2) && IS_PLIST(mat)) {
+        Int r1 = INT_INTOBJ(row1);
+        Int r2 = INT_INTOBJ(row2);
+        Obj row1list = r1 <= LEN_PLIST(mat) ? ELM_PLIST(mat, r1) : 0;
+        Obj row2list = r1 <= LEN_PLIST(mat) ? ELM_PLIST(mat, r2) : 0;
+        if (!row1list)
+            ErrorMayQuit("Matrix Element: <mat>[%d] must have an assigned value",
+                         (Int)r1, 0);
+        if (!row2list)
+            ErrorMayQuit("Matrix Element: <mat>[%d] must have an assigned value",
+                         (Int)r2, 0);
+
+        SET_ELM_PLIST(mat, r1, row2list);
+        SET_ELM_PLIST(mat, r2, row1list);
+        return 0;
+    }
+
+    return DoOperation3Args(SwapMatRows, mat, row1, row2);
+}
+
+
+/****************************************************************************
+**
+*F  FuncSWAP_MAT_COLS( <self>, <mat>, <col1>, <col2> )
+*/
+static Obj SwapMatCols;
+
+static Obj FuncSWAP_MAT_COLS(Obj self, Obj mat, Obj col1, Obj col2)
+{
+    if (IS_POS_INTOBJ(col1) && IS_POS_INTOBJ(col2) && IS_PLIST(mat)) {
+        Int c1 = INT_INTOBJ(col1);
+        Int c2 = INT_INTOBJ(col2);
+        Int nrows = LEN_PLIST(mat);
+        for (int r = 1; r <= nrows; r++) {
+            Obj row = ELM_LIST(mat, r);
+            Obj elm1 = ELM_LIST(row, c1);
+            Obj elm2 = ELM_LIST(row, c2);
+            ASS_LIST(row, c1, elm2);
+            ASS_LIST(row, c2, elm1);
+        }
+        return 0;
+    }
+
+    return DoOperation3Args(SwapMatCols, mat, col1, col2);
+}
+
+
+/****************************************************************************
+**
 *F * * * * * * * * * * * * * initialize module * * * * * * * * * * * * * * *
 */
 
@@ -1864,6 +1919,9 @@ static StructGVarOper GVarOpers[] = {
 
     GVAR_OPER_4ARGS(ASS_MAT, mat, row, col, obj, &AssMatOper),
     GVAR_OPER_3ARGS(ELM_MAT, mat, row, col, &ElmMatOper),
+
+    GVAR_OPER_3ARGS(SWAP_MAT_ROWS, mat, row1, row2, &SwapMatRows),
+    GVAR_OPER_3ARGS(SWAP_MAT_COLS, mat, col1, col2, &SwapMatCols),
 
     { 0, 0, 0, 0, 0, 0 }
 


### PR DESCRIPTION
Yet another commit from an unfinished branch/PR that might be considered useful on its own: faster "early methods" for SwapRows/SwapCols using kernel methods. It is not tested thoroughly and I am not even sure we want to go in this direction, but we could e.g. use this as basis for discussions during the GAP Days

---

This speeds up swap operations for plain list matrices a lot, and
even for "real" matrix objs, as the overhead of a GAP early method
is much higher than the overhead of one written in the kernel.

Now whether this gain is worth the extra complexity is another question;
though of course when doing heavy linear algebra, these row and column
can add up.

Before:

    gap> mat:=IdentityMat(10,Integers);;
    gap> for i in [1..1000000] do SwapMatrixColumns(mat,1,2); od; time;
    326
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    90
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    37

    gap> mat:=IdentityMat(10,GF(2));; ConvertToMatrixRep(mat);; mat;
    <a 10x10 matrix over GF2>
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    146
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    84

After:

    gap> mat:=IdentityMat(10,Integers);;
    gap> for i in [1..1000000] do SwapMatrixColumns(mat,1,2); od; time;
    153
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    19
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    45

    gap> mat:=IdentityMat(10,GF(2));; ConvertToMatrixRep(mat);; mat;
    <a 10x10 matrix over GF2>
    gap> for i in [1..1000000] do SwapMatrixRows(mat,1,2); od; time;
    116
    gap> for i in [1..1000000] do tmp:=mat[1];mat[1]:=mat[2];mat[2]:=tmp; od; time;
    83