### PR TITLE
test-compile/regenerate_tests.sh: stop generating .static files

### DIFF
--- a/tst/test-compile/regenerate_tests.sh
+++ b/tst/test-compile/regenerate_tests.sh
@@ -12,5 +12,4 @@ for gfile in *.g; do
     echo "Regenerating ${gfile}.out ..."
     ./run_interpreted.sh "${gap}" "${gfile}" "${gfile}.out"
     "${gac}" -d -C -o "${gfile}.dynamic.c" "${gfile}"
-    "${gac}" -C -o "${gfile}.static.c" "${gfile}"
 done


### PR DESCRIPTION
We removed static mode from gac some time ago