### PR TITLE
Temporary workaround for Cygwin CI failure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,6 +164,12 @@ jobs:
 
       - uses: gap-actions/setup-cygwin@v1
         if: ${{ runner.os == 'Windows' }}
+        with:
+          # HACK/FIXME/TODO: workaround for https://github.com/gap-system/gap/issues/4955
+          # which essentially removes xdg-utils ; its presence leads GAP to think the
+          # Cygwin environment is Unix, not Windows, which enables some tests which then
+          # hang.
+          PKGS_TO_INSTALL: 'wget,git,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel'
 
       - name: "Set up compiler and linker flags"
         run: |


### PR DESCRIPTION
Based on discussion with @wilfwilson and @ChrisJefferson on Slack, this might resolves #4955.

If it does, then we can either revert https://github.com/gap-actions/setup-cygwin/commit/7f953df8576fbc43264718b21a602e72605f0859 there, or else debug further why it hangs now 