### PR TITLE
improved (documentation of) two `MTX` functions

### DIFF
--- a/doc/ref/makedocreldata.g
+++ b/doc/ref/makedocreldata.g
@@ -116,6 +116,7 @@ GAPInfo.ManualDataRef:= rec(
     "../../lib/matobj2.gd",
     "../../lib/matobjplist.gd",
     "../../lib/matrix.gd",
+    "../../lib/meataxe.gi",
     "../../lib/memusage.gd",
     "../../lib/methsel2.g",
     "../../lib/methwhy.g",

--- a/doc/ref/meataxe.xml
+++ b/doc/ref/meataxe.xml
@@ -597,17 +597,7 @@ or <K>fail</K> if no such form exists.
 </ManSection>
 
 
-<ManSection>
-<Func Name="MTX.InvariantQuadraticForm" Arg='module'/>
-
-<Description>
-returns an invariant quadratic form of <A>module</A>,
-or <K>fail</K> if no such form exists. If the characteristic of the field over
-which <A>module</A> is defined is not 2, then the invariant bilinear form (if
-any) divided by two will be returned. In characteristic 2, the form
-returned will be lower triangular.
-</Description>
-</ManSection>
+<#Include Label="MTX.InvariantQuadraticForm">
 
 
 <ManSection>
@@ -621,17 +611,7 @@ This is used by <Ref Func="MTX.InvariantQuadraticForm"/> in characteristic 2.
 </ManSection>
 
 
-<ManSection>
-<Func Name="MTX.OrthogonalSign" Arg='module'/>
-
-<Description>
-for an even dimensional module, returns 1 or -1, according as
-<C>MTX.InvariantQuadraticForm(<A>module</A>)</C> is of + or - type. For an odd
-dimensional module, returns 0. For a module with no invariant
-quadratic form, returns <K>fail</K>. This calculation uses an algorithm due
-to Jon Thackray.
-</Description>
-</ManSection>
+<#Include Label="MTX.OrthogonalSign">
 
 </Section>
 

--- a/tst/testinstall/meataxe.tst
+++ b/tst/testinstall/meataxe.tst
@@ -1,4 +1,4 @@
-#@local G,M,M2,M3,M4,M5,V,bf,bo,cf,homs,m,mat,qf,randM,res,sf,subs
+#@local G,M,M2,M3,M4,M5,V,bf,bo,cf,homs,m,mat,qf,randM,res,sf,subs,mats,Q
 gap> START_TEST("meataxe.tst");
 
 #
@@ -183,6 +183,69 @@ gap> Display(res[5]);
  . . . 1 . .
  . . . . 1 .
  . . . . . 1
+
+#
+# Tests for MTX.InvariantQuadraticForm and MTX.OrthogonalSign
+# (the documentation is a bit unorthodox)
+#
+# the easy cases:
+gap> mats:= GeneratorsOfGroup( GO( 1, 4, 3 ) );;
+gap> m:= GModuleByMats( mats, GF(3) );;
+gap> Q:= MTX.InvariantQuadraticForm( m );;
+gap> Q = TransposedMat( Q );  # bilinear form divided by 2
+true
+gap> MTX.OrthogonalSign( m );
+1
+gap> mats:= GeneratorsOfGroup( GO( -1, 4, 3 ) );;
+gap> m:= GModuleByMats( mats, GF(3) );;
+gap> Q:= MTX.InvariantQuadraticForm( m );;
+gap> Q = TransposedMat( Q );  # bilinear form divided by 2
+true
+gap> MTX.OrthogonalSign( m );
+-1
+gap> mats:= GeneratorsOfGroup( GO( 5, 3 ) );;
+gap> m:= GModuleByMats( mats, GF(3) );;
+gap> Q:= MTX.InvariantQuadraticForm( m );;
+gap> Q = TransposedMat( Q );  # bilinear form divided by 2
+true
+gap> MTX.OrthogonalSign( m );
+0
+gap> mats:= GeneratorsOfGroup( GO( 1, 4, 2 ) );;
+gap> m:= GModuleByMats( mats, GF(2) );;
+gap> Q:= MTX.InvariantQuadraticForm( m );;
+gap> IsLowerTriangularMat( Q );  # characteristic 2
+true
+gap> MTX.OrthogonalSign( m );
+1
+gap> mats:= GeneratorsOfGroup( GO( 5, 2 ) );;
+gap> m:= GModuleByMats( mats, GF(2) );;
+gap> MTX.InvariantQuadraticForm( m );
+Error, Argument of InvariantQuadraticForm is not an absolutely irreducible mod\
+ule
+gap> MTX.OrthogonalSign( m );
+Error, Argument of InvariantBilinearForm is not an absolutely irreducible modu\
+le
+gap> mats:= GeneratorsOfGroup( SP( 4, 2 ) );;
+gap> m:= GModuleByMats( mats, GF(2) );;
+gap> Q:= MTX.InvariantQuadraticForm( m );
+fail
+gap> MTX.OrthogonalSign( m );
+fail
+gap> g:= SU(4, 3);;
+gap> m:= GModuleByMats( GeneratorsOfGroup( g ), GF(9) );;
+gap> MTX.InvariantBilinearForm( m );
+fail
+gap> MTX.InvariantQuadraticForm( m );
+fail
+
+# the subtle case: odd characteristic, antisymmetric bilinear form
+gap> mats:= GeneratorsOfGroup( SP( 4, 3 ) );;
+gap> m:= GModuleByMats( mats, GF(3) );;
+gap> Q:= MTX.InvariantQuadraticForm( m );;  # matrix for the zero form
+gap> Q = TransposedMat( Q );
+false
+gap> MTX.OrthogonalSign( m );
+fail
 
 #
 gap> STOP_TEST("meataxe.tst", 1);


### PR DESCRIPTION
- fixed `MTX.OrthogonalSign` in the case of antisymmetric bilinear forms in odd characteristic (now returns `fail`, I think this fixes a bug and thus had to be done, independent of whether the behaviour of `MTX.InvariantQuadraticForm` gets changed or not)
- improved the documentation of `MTX.InvariantQuadraticForm` and `MTX.OrthogonalSign`, as discussed in issue #4936
- added some tests