### PR TITLE
Initializing `SyNumProcessors` in runtime with the number of available CPUs for Linux, Windows and macOS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -109,6 +109,7 @@ SOURCES += $(GC_SOURCES)
 
 ifeq ($(HPCGAP),yes)
   SOURCES += src/hpc/aobjects.c
+  SOURCES += src/hpc/cpu.c
   SOURCES += src/hpc/misc.c
   SOURCES += src/hpc/region.c
   SOURCES += src/hpc/serialize.c

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -28,6 +28,7 @@
 #endif
 
 #ifdef HPCGAP
+#include "hpc/cpu.h"
 #include "hpc/guards.h"
 #include "hpc/misc.h"
 #include "hpc/thread.h"

--- a/src/gap.c
+++ b/src/gap.c
@@ -45,6 +45,7 @@
 #include "version.h"
 
 #ifdef HPCGAP
+#include "hpc/cpu.h"
 #include "hpc/misc.h"
 #include "hpc/thread.h"
 #include "hpc/threadapi.h"

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -15,8 +15,6 @@
 #include <sys/unistd.h>
 #elif _WIN32_WINNT >= _WIN32_WINNT_WIN7
 #include <windows.h>
-#elif _WIN32
-#include <sysinfoapi.h>
 #endif
 #endif
 
@@ -51,13 +49,6 @@ UInt SyCountProcessors(void)
     return result;
 #elif _WIN32_WINNT >= _WIN32_WINNT_WIN7
     return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
-#elif _WIN32
-    SYSTEM_INFO info;
-    GetSystemInfo(&info);
-    if (info.dwNumberOfProcessors < 1) {
-        return fallback_cpus_number;
-    }
-    return info.dwNumberOfProcessors;
 #else
     return fallback_cpus_number;
 #endif

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -26,14 +26,6 @@ UInt SyNumProcessors = 4;
 *F  SyCountProcessors() . . . . . . . . . . . . compute the number of CPUs.
 **
 **  SyCountProcessors() retrieves the number of active logical processors.
-**  In case of Linux, calls get_nprocs().
-**  In case of Windows 7 and higher, calls
-**  GetActiveProcessorCount(ALL_PROCESSOR_GROUPS).
-**  In case of older versions of Windows, tries to load the number of
-**  processors in current processor group via GetSystemInfo with proper
-**  arguments and falls back to the value of 4 in case of an error.
-**  In case of macOS, sysctl is called with HW_AVAILCPU flag.
-**  In case of other operating systems the value of 4 is returned.
 */
 
 UInt SyCountProcessors(void) {

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -10,12 +10,10 @@
 
 #include "hpc/cpu.h"
 
-#ifndef NUM_CPUS
 #ifdef _POSIX_C_SOURCE
 #include <sys/unistd.h>
 #elif _WIN32_WINNT >= _WIN32_WINNT_WIN7
 #include <windows.h>
-#endif
 #endif
 
 /****************************************************************************
@@ -23,11 +21,7 @@
 *V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs
 **
 */
-#ifdef NUM_CPUS
-UInt SyNumProcessors = NUM_CPUS;
-#else
 UInt SyNumProcessors = 4;
-#endif
 
 /****************************************************************************
 **
@@ -37,12 +31,9 @@ UInt SyNumProcessors = 4;
 */
 UInt SyCountProcessors(void)
 {
-#ifdef NUM_CPUS
-    return NUM_CPUS;
-#else
     const UInt fallback_cpus_number = 4;
 #if _POSIX_C_SOURCE
-    const int  result = sysconf(_SC_NPROCESSORS_ONLN);
+    const int result = sysconf(_SC_NPROCESSORS_ONLN);
     if (result < 1) {
         return fallback_cpus_number;
     }
@@ -51,6 +42,5 @@ UInt SyCountProcessors(void)
     return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 #else
     return fallback_cpus_number;
-#endif
 #endif
 }

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -16,7 +16,7 @@
 #include <windows.h>
 #endif
 
-static const UInt FALLBACK_CPUS_NUMBER = 4;
+#define FALLBACK_CPUS_NUMBER 4
 
 /****************************************************************************
 **

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -10,6 +10,20 @@
 
 #include "hpc/cpu.h"
 
+#ifndef NUM_CPUS
+#ifdef __linux__
+#include <sys/sysinfo.h>
+#elif _WIN32
+#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+#include <windows.h>
+#else
+#include <sysinfoapi.h>
+#endif
+#elif __APPLE__
+#include <sys/sysctl.h>
+#endif
+#endif
+
 /****************************************************************************
 **
 *V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -23,7 +23,7 @@ UInt SyNumProcessors = 4;
 
 /****************************************************************************
 **
-*F  SyCountProcessors() . . . . . . . . . . . . compute the number of CPUs.
+*F  SyCountProcessors() . . . . . . . . . . . . . . compute the number of CPUs
 **
 **  SyCountProcessors() retrieves the number of active logical processors.
 */

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -28,39 +28,40 @@ UInt SyNumProcessors = 4;
 **  SyCountProcessors() retrieves the number of active logical processors.
 */
 
-UInt SyCountProcessors(void) {
+UInt SyCountProcessors(void)
+{
 #ifdef NUM_CPUS
     return NUM_CPUS;
 #else
-    #if __linux__
-        return get_nprocs();
-    #else
-        const UInt fallback_cpus_number = 4;
-        #if _WIN32
-            #if _WIN32_WINNT >= _WIN32_WINNT_WIN7
-                return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
-            #else
-                SYSTEM_INFO info;
-                GetSystemInfo(&info);
-                if(info.dwNumberOfProcessors < 1) {
-                    return fallback_cpus_number;
-                }
-                return info.dwNumberOfProcessors;
-            #endif
-        #elif __APPLE__
-            int nm[2] = {CTL_HW, HW_AVAILCPU};
-            size_t len = 4;
-            uint32_t count;
+#if __linux__
+    return get_nprocs();
+#else
+    const UInt fallback_cpus_number = 4;
+#if _WIN32
+#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+    return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+#else
+    SYSTEM_INFO info;
+    GetSystemInfo(&info);
+    if (info.dwNumberOfProcessors < 1) {
+        return fallback_cpus_number;
+    }
+    return info.dwNumberOfProcessors;
+#endif
+#elif __APPLE__
+    int      nm[2] = { CTL_HW, HW_AVAILCPU };
+    size_t   len = 4;
+    uint32_t count;
 
-            sysctl(nm, 2, &count, &len, NULL, 0);
+    sysctl(nm, 2, &count, &len, NULL, 0);
 
-            if (count < 1) {
-                return fallback_cpus_number;
-            }
-            return count;
-        #else
-            return fallback_cpus_number;
-        #endif
-    #endif
+    if (count < 1) {
+        return fallback_cpus_number;
+    }
+    return count;
+#else
+    return fallback_cpus_number;
+#endif
+#endif
 #endif
 }

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -16,12 +16,14 @@
 #include <windows.h>
 #endif
 
+static const UInt FALLBACK_CPUS_NUMBER = 4;
+
 /****************************************************************************
 **
 *V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs
 **
 */
-UInt SyNumProcessors = 4;
+UInt SyNumProcessors = FALLBACK_CPUS_NUMBER;
 
 /****************************************************************************
 **
@@ -31,16 +33,15 @@ UInt SyNumProcessors = 4;
 */
 UInt SyCountProcessors(void)
 {
-    const UInt fallback_cpus_number = 4;
 #if _POSIX_C_SOURCE
     const int result = sysconf(_SC_NPROCESSORS_ONLN);
     if (result < 1) {
-        return fallback_cpus_number;
+        return FALLBACK_CPUS_NUMBER;
     }
     return result;
 #elif _WIN32_WINNT >= _WIN32_WINNT_WIN7
     return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 #else
-    return fallback_cpus_number;
+    return FALLBACK_CPUS_NUMBER;
 #endif
 }

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -41,7 +41,6 @@ UInt SyNumProcessors = 4;
 **
 **  SyCountProcessors() retrieves the number of active logical processors.
 */
-
 UInt SyCountProcessors(void)
 {
 #ifdef NUM_CPUS

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -13,12 +13,10 @@
 #ifndef NUM_CPUS
 #ifdef _POSIX_C_SOURCE
 #include <sys/unistd.h>
-#elif _WIN32
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+#elif _WIN32_WINNT >= _WIN32_WINNT_WIN7
 #include <windows.h>
-#else
+#elif _WIN32
 #include <sysinfoapi.h>
-#endif
 #endif
 #endif
 
@@ -51,21 +49,17 @@ UInt SyCountProcessors(void)
         return fallback_cpus_number;
     }
     return result;
-#else
-#if _WIN32
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+#elif _WIN32_WINNT >= _WIN32_WINNT_WIN7
     return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
-#else
+#elif _WIN32
     SYSTEM_INFO info;
     GetSystemInfo(&info);
     if (info.dwNumberOfProcessors < 1) {
         return fallback_cpus_number;
     }
     return info.dwNumberOfProcessors;
-#endif
 #else
     return fallback_cpus_number;
-#endif
 #endif
 #endif
 }

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "hpc/cpu.h"
+
+/****************************************************************************
+**
+*V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs
+**
+*/
+#ifdef NUM_CPUS
+UInt SyNumProcessors = NUM_CPUS;
+#else
+UInt SyNumProcessors = 4;
+#endif
+
+/****************************************************************************
+**
+*F  SyCountProcessors() . . . . . . . . . . . . compute the number of CPUs.
+**
+**  SyCountProcessors() retrieves the number of active logical processors.
+**  In case of Linux, calls get_nprocs().
+**  In case of Windows 7 and higher, calls
+**  GetActiveProcessorCount(ALL_PROCESSOR_GROUPS).
+**  In case of older versions of Windows, tries to load the number of
+**  processors in current processor group via GetSystemInfo with proper
+**  arguments and falls back to the value of 4 in case of an error.
+**  In case of macOS, sysctl is called with HW_AVAILCPU flag.
+**  In case of other operating systems the value of 4 is returned.
+*/
+
+UInt SyCountProcessors(void) {
+#ifdef NUM_CPUS
+    return NUM_CPUS;
+#else
+    #if __linux__
+        return get_nprocs();
+    #else
+        const UInt fallback_cpus_number = 4;
+        #if _WIN32
+            #if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+                return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+            #else
+                SYSTEM_INFO info;
+                GetSystemInfo(&info);
+                if(info.dwNumberOfProcessors < 1) {
+                    return fallback_cpus_number;
+                }
+                return info.dwNumberOfProcessors;
+            #endif
+        #elif __APPLE__
+            int nm[2] = {CTL_HW, HW_AVAILCPU};
+            size_t len = 4;
+            uint32_t count;
+
+            sysctl(nm, 2, &count, &len, NULL, 0);
+
+            if (count < 1) {
+                return fallback_cpus_number;
+            }
+            return count;
+        #else
+            return fallback_cpus_number;
+        #endif
+    #endif
+#endif
+}

--- a/src/hpc/cpu.h
+++ b/src/hpc/cpu.h
@@ -26,19 +26,10 @@ extern UInt SyNumProcessors;
 
 /****************************************************************************
 **
-*F  SyCountProcessors() . . . . . . . . . . . . compute the number of CPUs.
+*F  SyCountProcessors() . . . . . . . . . . . . . . compute the number of CPUs
 **
 **  SyCountProcessors() retrieves the number of active logical processors.
-**  In case of Linux, calls get_nprocs().
-**  In case of Windows 7 and higher, calls
-**  GetActiveProcessorCount(ALL_PROCESSOR_GROUPS).
-**  In case of older versions of Windows, tries to load the number of
-**  processors in current processor group via GetSystemInfo with proper
-**  arguments and falls back to the value of 4 in case of an error.
-**  In case of macOS sysctl is called with HW_AVAILCPU flag.
-**  In case of other operating systems the value of 4 is returned.
 */
-
 UInt SyCountProcessors(void);
 
 #endif    // GAP_HPC_CPU_H

--- a/src/hpc/cpu.h
+++ b/src/hpc/cpu.h
@@ -18,17 +18,17 @@
 #endif
 
 #ifndef NUM_CPUS
-    #ifdef __linux__
-        #include <sys/sysinfo.h>
-    #elif _WIN32
-        #if _WIN32_WINNT >= _WIN32_WINNT_WIN7
-            #include <windows.h>
-        #else
-            #include <sysinfoapi.h>
-        #endif
-    #elif __APPLE__
-        #include <sys/sysctl.h>
-    #endif
+#ifdef __linux__
+#include <sys/sysinfo.h>
+#elif _WIN32
+#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+#include <windows.h>
+#else
+#include <sysinfoapi.h>
+#endif
+#elif __APPLE__
+#include <sys/sysctl.h>
+#endif
 #endif
 
 /****************************************************************************
@@ -55,4 +55,4 @@ extern UInt SyNumProcessors;
 
 UInt SyCountProcessors(void);
 
-#endif  // GAP_HPC_CPU_H
+#endif    // GAP_HPC_CPU_H

--- a/src/hpc/cpu.h
+++ b/src/hpc/cpu.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+**
+**  This file is part of GAP, a system for computational discrete algebra.
+**
+**  Copyright of GAP belongs to its developers, whose names are too numerous
+**  to list here. Please refer to the COPYRIGHT file for details.
+**
+**  SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef GAP_HPC_CPU_H
+#define GAP_HPC_CPU_H
+
+#include "common.h"
+
+#ifndef HPCGAP
+#error This header is only meant to be used with HPC-GAP
+#endif
+
+#ifndef NUM_CPUS
+    #ifdef __linux__
+        #include <sys/sysinfo.h>
+    #elif _WIN32
+        #if _WIN32_WINNT >= _WIN32_WINNT_WIN7
+            #include <windows.h>
+        #else
+            #include <sysinfoapi.h>
+        #endif
+    #elif __APPLE__
+        #include <sys/sysctl.h>
+    #endif
+#endif
+
+/****************************************************************************
+**
+*V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs
+**
+*/
+extern UInt SyNumProcessors;
+
+/****************************************************************************
+**
+*F  SyCountProcessors() . . . . . . . . . . . . compute the number of CPUs.
+**
+**  SyCountProcessors() retrieves the number of active logical processors.
+**  In case of Linux, calls get_nprocs().
+**  In case of Windows 7 and higher, calls
+**  GetActiveProcessorCount(ALL_PROCESSOR_GROUPS).
+**  In case of older versions of Windows, tries to load the number of
+**  processors in current processor group via GetSystemInfo with proper
+**  arguments and falls back to the value of 4 in case of an error.
+**  In case of macOS sysctl is called with HW_AVAILCPU flag.
+**  In case of other operating systems the value of 4 is returned.
+*/
+
+UInt SyCountProcessors(void);
+
+#endif  // GAP_HPC_CPU_H

--- a/src/hpc/cpu.h
+++ b/src/hpc/cpu.h
@@ -17,20 +17,6 @@
 #error This header is only meant to be used with HPC-GAP
 #endif
 
-#ifndef NUM_CPUS
-#ifdef __linux__
-#include <sys/sysinfo.h>
-#elif _WIN32
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
-#include <windows.h>
-#else
-#include <sysinfoapi.h>
-#endif
-#elif __APPLE__
-#include <sys/sysctl.h>
-#endif
-#endif
-
 /****************************************************************************
 **
 *V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs

--- a/src/hpc/misc.c
+++ b/src/hpc/misc.c
@@ -29,17 +29,6 @@ UInt DeadlockCheck = 1;
 
 /****************************************************************************
 **
-*V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs
-**
-*/
-#ifdef NUM_CPUS
-UInt SyNumProcessors = NUM_CPUS;
-#else
-UInt SyNumProcessors = 4;
-#endif
-
-/****************************************************************************
-**
 *V  SyNumGCThreads  . . . . . . . . . . . . . . . number of GC worker threads
 **
 */

--- a/src/hpc/misc.h
+++ b/src/hpc/misc.h
@@ -17,6 +17,7 @@
 #error This header is only meant to be used with HPC-GAP
 #endif
 
+
 /****************************************************************************
 **
 *V  ThreadUI  . . . . . . . . . . . . . . . . . . . .  support UI for threads
@@ -30,13 +31,6 @@ extern UInt ThreadUI;
 **
 */
 extern UInt DeadlockCheck;
-
-/****************************************************************************
-**
-*V  SyNumProcessors  . . . . . . . . . . . . . . . . . number of logical CPUs
-**
-*/
-extern UInt SyNumProcessors;
 
 /****************************************************************************
 **

--- a/src/system.c
+++ b/src/system.c
@@ -27,6 +27,7 @@
 #include "version.h"
 
 #ifdef HPCGAP
+#include "hpc/cpu.h"
 #include "hpc/misc.h"
 #endif
 
@@ -695,6 +696,7 @@ void InitSystem (
     SyLineEdit = 1;
 #ifdef HPCGAP
     SyUseReadline = 0;
+    SyNumProcessors = SyCountProcessors();
 #else
     SyUseReadline = 1;
 #endif


### PR DESCRIPTION
`SyCountProcessors()` retrieves the number of active logical processors. In case of Linux, calls `get_nprocs()`. In case of Windows 7 and higher, calls `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`. In case of older versions of Windows calls `GetSystemInfo` with proper arguments. In case of macOS `sysctl` is called with `HW_AVAILCPU` flag. In case of other operating systems the value of `4` is returned.

Resolves #1219.

## Text for release notes

see title