### PR TITLE
Objectify: warn if Is{Component,Positional}ObjectRep absent

### DIFF
--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -3975,7 +3975,8 @@ InstallMethod( NormalizedElementOfMagmaRingModuloRelations,
            Append( tlist, todo[i] );
          od;
 
-         return ObjByExtRep( Fam, [ zero, tlist ] );
+         tlist := ObjByExtRep( Fam, [ zero, tlist ] );
+         return [ zero, tlist![2] ];
 
      end );
 

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -7,7 +7,7 @@ gap> START_TEST("kernel/gap.tst");
 # in ViewObj; afterwards everything should still work as before
 gap> l := [ ~ ];; r := rec(a:=~);;
 gap> cat := NewCategory("IsMockObject", IsObject);;
-gap> type := NewType(NewFamily("MockFamily"), cat);;
+gap> type := NewType(NewFamily("MockFamily"), cat and IsPositionalObjectRep);;
 gap> InstallMethod(ViewObj, [cat], function(s) Error("oops"); end);
 gap> InstallMethod(PrintObj, [cat], function(s) Error("uups"); end);
 gap> x:=Objectify(type,[]); r; Print(l, "\n");

--- a/tst/testinstall/kernel/opers.tst
+++ b/tst/testinstall/kernel/opers.tst
@@ -294,7 +294,7 @@ gap> CLEAR_CACHE_INFO();
 gap> opcheck := OPERS_CACHE_INFO();;
 #@if GAPInfo.KernelInfo.KernelDebug and IsHPCGAP
 gap> opcheck{[1..11]};
-[ 2, 0, 0, 6, 0, 0, 6, 0, 0, 2, 0 ]
+[ 2, 0, 0, 6, 0, 0, 10, 0, 0, 2, 0 ]
 #@fi
 
 # FIXME: the following code skips entry 4 (OperationHit, which is normally
@@ -338,7 +338,7 @@ gap> opcheck{[1..11]};
 #
 #@if GAPInfo.KernelInfo.KernelDebug and not IsHPCGAP
 gap> opcheck{Difference([1..11], [4])};
-[ 2, 0, 0, 0, 0, 4, 0, 0, 2, 0 ]
+[ 2, 0, 0, 0, 0, 8, 0, 0, 2, 0 ]
 #@fi
 #@if not GAPInfo.KernelInfo.KernelDebug
 gap> opcheck{[1..11]};

--- a/tst/testinstall/object.tst
+++ b/tst/testinstall/object.tst
@@ -4,7 +4,7 @@
 gap> START_TEST("object.tst");
 
 # test some standard object types
-gap> r := Objectify(TYPE_KERNEL_OBJECT, rec());
+gap> r := [];; SET_TYPE_DATOBJ(r,TYPE_KERNEL_OBJECT);
 <kernel object>
 gap> KnownAttributesOfObject(r);
 [  ]


### PR DESCRIPTION
This works towards resolving #1043: now `Objectify` warns if `IsPositionalObjectRep` resp. `IsComponentObjectRep` is not set for an object that should have one of them; and it also gives an error if both are set / "the wrong one" is set (i.e. `IsPositionalObjectRep` for a `T_COMOBJ` or `IsComponentObjectRep` for a `T_POSOBJ`). 

I've eliminated all the warnings triggered by loading GAP and running `tst/testinstall.g`, and submitted https://github.com/gap-packages/fr/pull/50 to fix one violation in a package (I've already fixed a bunch of others in packages in the past couple years). I am guessing there may still be a couple more, so I am reluctant to turn the warnings into an error just now... at the very least, before we attempt such a thing, the test suites of all packages should be run against a GAP with that error activated.

Also, before merging this PR we should check how this extra test affects performance: `Objectify` is a bit of a bottleneck, and we don't want to make it worse than it already is...