### PR TITLE
CI: build manual & deploy to gh-pages

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -1,0 +1,84 @@
+# For information about the parts of this workflow,
+# see <https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/>
+# and <https://github.com/actions/starter-workflows/tree/main/pages>
+name: Deploy GAP manual to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          packages=(
+              libgmp-dev
+              libreadline-dev
+              zlib1g-dev
+              texlive-latex-base
+              texlive-latex-recommended
+              texlive-latex-extra
+              texlive-fonts-recommended
+          )
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends "${packages[@]}"
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Configure GAP
+        run: |
+          ./autogen.sh && ./configure
+      - name: Build GAP
+        run: |
+          make -j4
+      - name: Download minimal packages
+        run: |
+          make bootstrap-pkg-minimal
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v1
+      - name: Build GAP manuals
+        run: |
+          make html # we are only intersted in the HTML version
+      - name: Bundling GAP manuals for deployment
+        run: |
+          set -e
+          for book in dev hpc ref tut ; do
+            mkdir -p public/doc/$book/
+            mv doc/$book/*.{html,css,js} public/doc/$book/
+          done
+          mv doc/dev/bigpic.* public/doc/dev/
+          cp dev/index.html public/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,15 @@
+<!-- This file is used by .github/workflows/update-gh-pages.yml -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>GAP manuals</title>
+</head>
+<body>
+Development snapshots of the GAP manuals:
+<a href="doc/ref/chap0_mj.html">[ref]</a>
+<a href="doc/dev/chap0_mj.html">[dev]</a>
+<a href="doc/hpc/chap0_mj.html">[hpc]</a>
+<a href="doc/tut/chap0_mj.html">[tut]</a>
+</body>
+</html>


### PR DESCRIPTION
Resolves #4362 

Tested on my GAP fork, see
- https://github.com/fingolfin/gap/actions/workflows/update-gh-pages.yml
- https://github.com/fingolfin/gap/actions/runs/2773544122
- https://fingolfin.github.io/gap/

To make this work, I've now changed https://github.com/gap-system/gap/settings/pages to deploy from a GH action (see <https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta>). Of course this is a beta feature, so it might break or go away at some point, but then we are not worse off than we are right now.

The built files will appear on http://gap-system.github.io/gap/ but only after this PR has been merged, as it is configured to only work from the `master` branch.

A future improvement would be to tweak the generated file `doc/versiondata` to replace `today` by the actual current date and similar for `this year`