### PR TITLE
Import MappedVector changes from polycyclic

### DIFF
--- a/lib/grppcrep.gi
+++ b/lib/grppcrep.gi
@@ -18,8 +18,9 @@ MappedVector := function( exp, list )
     local elm, i;
 
     if Length( list ) = 0 then
-        Error("cannot compute this\n");
+        Error("cannot compute this");
     fi;
+    if IsFFE( exp[1] ) then exp := IntVecFFE(exp); fi;
     elm := list[1]^exp[1];
     for i in [2..Length(list)] do
         elm := elm * list[i]^exp[i];


### PR DESCRIPTION
For many years, the polycyclic package silently redefined MappedVector
to accept finite field exponents. This means that potentially people saw
different behavior depending on whether polycyclic was loaded (which
it is by default) or not.

So it seems safer to align the two.
