### PR TITLE
Speed up some stabilizer computations in matrix groups

### DIFF
--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -1146,6 +1146,11 @@ local   orb,  stb,  rep,  p,  q,  img,  sch,  i,d,act,r,
   fi;
   dict:=NewDictionary(d,true,D);
 
+  if HasIsHandledByNiceMonomorphism(G) and IsHandledByNiceMonomorphism(G) then
+    # ensure a nice monomorphism for the parent has been computed
+    NiceMonomorphism(G);
+  fi;
+
   if IsBound(dopr.stabsub) then
     stabsub:=AsSubgroup(Parent(G),dopr.stabsub);
   else


### PR DESCRIPTION
Ensure there is a nice monomorphism on the group in which we compute the stabilizers. This speeds up the following example command from the Sophus package:

    AreIsomorphicNilpotentLieAlgebras( L7[100], L7[101] );

Before this patch this takes 13 to 18 seconds on my laptop (timings vary substantially, presumably due to randomization). After this patch, this is down to 0.8 to 0.9 seconds.