### PR TITLE
Set various filters for MatrixObj implementations

### DIFF
--- a/lib/mat8bit.gd
+++ b/lib/mat8bit.gd
@@ -17,7 +17,10 @@
 #R  Is8BitMatrixRep( <obj> ) . . . compressed vector over GFQ (3 <= q <= 256)
 ##
 DeclareRepresentation( "Is8BitMatrixRep", 
-        IsPositionalObjectRep and IsRowListMatrix );
+        IsPositionalObjectRep and IsRowListMatrix
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns);
 
 
 #############################################################################

--- a/lib/matobjnz.gd
+++ b/lib/matobjnz.gd
@@ -13,7 +13,15 @@
 # arithmetic. This way avoid always wrapping all entries separately
 
 DeclareRepresentation( "IsZmodnZVectorRep",
-   IsVectorObj and IsPositionalObjectRep and HasBaseDomain, [] );
+        IsVectorObj and IsPositionalObjectRep
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns,
+    [] );
 
 DeclareRepresentation( "IsZmodnZMatrixRep",
-   IsRowListMatrix and IsPositionalObjectRep and HasBaseDomain, [] );
+        IsRowListMatrix and IsPositionalObjectRep
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns,
+    [] );

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -45,7 +45,11 @@
 ##  <#/GAPDoc>
 ##
 DeclareRepresentation( "IsPlistVectorRep",
-   IsVectorObj and IsPositionalObjectRep, [] );
+        IsVectorObj and IsPositionalObjectRep
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns,
+    [] );
 
 
 #############################################################################
@@ -83,7 +87,11 @@ DeclareRepresentation( "IsPlistVectorRep",
 ##  <#/GAPDoc>
 ##
 DeclareRepresentation( "IsPlistMatrixRep",
-   IsRowListMatrix and IsPositionalObjectRep, [] );
+        IsRowListMatrix and IsPositionalObjectRep
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns,
+    [] );
 
 
 # Some constants for matrix access:

--- a/lib/vec8bit.gd
+++ b/lib/vec8bit.gd
@@ -27,7 +27,10 @@ MakeImmutable(PRIMES_COMPACT_FIELDS);
 #R  Is8BitVectorRep( <obj> ) . . . compressed vector over GFQ (3 <= q <= 256)
 ##
 DeclareRepresentation( "Is8BitVectorRep", 
-        IsDataObjectRep and IsVectorObj );
+        IsDataObjectRep and IsVectorObj
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns);
 
 
 #############################################################################

--- a/lib/vecmat.gd
+++ b/lib/vecmat.gd
@@ -39,7 +39,10 @@ BIND_GLOBAL( "GF2Zero", 0*Z(2) );
 ##  </ManSection>
 ##
 DeclareRepresentation( "IsGF2VectorRep",
-    IsDataObjectRep and IsVectorObj );
+        IsDataObjectRep and IsVectorObj
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns);
 
 
 #############################################################################
@@ -216,7 +219,10 @@ DeclareGlobalFunction( "ConvertToMatrixRep" );
 #R  IsGF2MatrixRep( <obj> ) . . . . . . . . . . . . . . . . . matrix over GF2
 ##
 DeclareRepresentation( "IsGF2MatrixRep",
-    IsPositionalObjectRep and IsRowListMatrix );
+        IsPositionalObjectRep and IsRowListMatrix
+    and IsNoImmediateMethodsObject and HasBaseDomain
+    and HasOneOfBaseDomain and HasZeroOfBaseDomain
+    and HasNumberRows and HasNumberColumns);
 
 
 #############################################################################


### PR DESCRIPTION
Set IsNoImmediateMethodsObject to make Objectify faster.
Set HasBaseDomain, HasNumberRows etc. to indicate these are
always available.

This also increases the ranks of these representations...
