### PR TITLE
Fix GASMAN register marking

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1921,11 +1921,12 @@ static NOINLINE void GenStackFuncBags(void)
         }
     }
 
-    // mark from registers, dirty dirty hack: we treat the jmp_buf as a
-    // sequence of Bag values. Note that sizeof(jmp_buf) need not be a
-    // multiple of sizeof(Bag), hence the end condition looks slightly.
-    // unusual.
-    for (p = (Bag *)RegsBags; p + 1 <= (Bag *)(RegsBags + 1); p++)
+    // mark content of registers, dirty dirty hack: we treat the jmp_buf
+    // as a sequence of Bag values. Note that sizeof(jmp_buf) need not
+    // be a multiple of sizeof(Bag), hence the end condition looks
+    // slightly. unusual.
+    for (p = (Bag *)RegsBags;
+         p < (Bag *)((char *)RegsBags + sizeof(RegsBags)); p++)
         MarkBag( *p );
 
 #ifdef DEBUG_GASMAN_MARKING


### PR DESCRIPTION
Marking of bag pointers stored in registers was broken by me in commit fab1afb8488eae8bc812a858926bd98d8b794010 -- the register marking loop ended up iterating zero times. This is now fixed (and verified to be fixed by the good old "insert printf to see what it marks" technique...

So this was broken since 2020-04-13 and somehow we didn't notice until now. Wow