### PR TITLE
Fix GasmanLimits / GASMAN_LIMITS regression

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -860,11 +860,11 @@ static Obj FuncGASMAN_LIMITS(Obj self)
   Obj list;
   list = NEW_PLIST_IMM(T_PLIST_CYC, 3);
 #ifdef USE_GASMAN
-  ASS_LIST(list, 1, ObjInt_Int(SyStorMin));
-  ASS_LIST(list, 2, ObjInt_Int(SyStorMax));
+  AssPlist(list, 1, ObjInt_Int(SyStorMin));
+  AssPlist(list, 2, ObjInt_Int(SyStorMax));
 #endif
 #if defined(USE_GASMAN) || defined(USE_BOEHM_GC)
-  ASS_LIST(list, 3, ObjInt_Int(SyStorKill));
+  AssPlist(list, 3, ObjInt_Int(SyStorKill));
 #endif
   return list;
 }

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -138,10 +138,54 @@ gap> GASMAN(fail);
 Error, GASMAN: <cmd> must be a string (not the value 'fail')
 
 #
+gap> IsList(GASMAN_LIMITS());
+true
+
+#
+gap> IsInt(TOTAL_GC_TIME());
+true
+
+#
+gap> IsInt(TotalMemoryAllocated());
+true
+
+#
 gap> SIZE_OBJ(0);
 0
 gap> SIZE_OBJ(Z(2));
 0
+
+#
+gap> TNUM_OBJ(0);
+0
+gap> TNUM_OBJ(2^100);
+1
+gap> TNUM_OBJ(-2^100);
+2
+gap> TNUM_OBJ(1/2);
+3
+gap> TNUM_OBJ(Z(2));
+5
+gap> TNUM_OBJ(rec());
+20
+gap> TNUM_OBJ([]);
+34
+
+#
+gap> TNAM_OBJ(0);
+"integer"
+gap> TNAM_OBJ(2^100);
+"large positive integer"
+gap> TNAM_OBJ(-2^100);
+"large negative integer"
+gap> TNAM_OBJ(1/2);
+"rational"
+gap> TNAM_OBJ(Z(2));
+"ffe"
+gap> TNAM_OBJ(rec());
+"record (plain)"
+gap> TNAM_OBJ([]);
+"empty plain list"
 
 #
 gap> OBJ_HANDLE(-1);


### PR DESCRIPTION
They produced "Error, List Assignment: <list> must be a mutable list", which we now avoid.

Also add some rudimentary tests for these and a few other functions to verify they produce a result.

Fixes #4979. Since that was a regression, no entry in the release notes is needed.