### PR TITLE
GAPInfo: add NonBareDependencies for use of package manager

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -33,6 +33,10 @@ BIND_GLOBAL( "GAPInfo", rec(
 # There is no SuggestedOtherPackages here because the default value of
 # the user preference PackagesToLoad does the job      
 
+    # If run with --bare, this means that the normal dependencies
+    # can still be found by the package manager
+    NonBareDependencies := ~.Dependencies,
+
     HasReadGAPRC:= false,
 
     # list of all reserved keywords


### PR DESCRIPTION
If GAP is loaded with `--bare`, `GAPInfo.Dependencies` is overwritten with an empty list.  One obvious use-case of `--bare` is loading GAP without packages for just long enough to use PackageManager to install required packages.  PackageManager has the `InstallRequiredPackages` function for this purpose, but since it requires `GAPInfo.Dependencies`, it ironically becomes useless in the one circumstance where it's really needed!

This commit would allow the normal required packages to be found in `GAPInfo.NonBareDependencies` even if `--bare` is used, which will allow PackageManager to install required packages without the need to hard-code anything.

**Release notes**: use title.