### PR TITLE
ImmutableMatrix should not convert between list of lists matrices and matrix objects

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -147,8 +147,11 @@ function( basedomain )
         return IsGF2VectorRep;
     elif IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) <= 256 then
         return Is8BitVectorRep;
-    elif IsFinite(basedomain) and IsZmodnZObj(Zero(basedomain)) then
-      return IsZmodnZVectorRep;
+##  This should be enabled when the code for 
+##       IsZmodnZVectorRep/IsZmodnZMatrixRep
+##  is finished and tested:
+##      elif IsFinite(basedomain) and IsZmodnZObj(Zero(basedomain)) then
+##        return IsZmodnZVectorRep;
     fi;
     return IsPlistVectorRep;
 end);
@@ -158,8 +161,11 @@ function( basedomain )
         return IsGF2MatrixRep;
     elif IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) <= 256 then
         return Is8BitMatrixRep;
-    elif IsFinite(basedomain) and IsZmodnZObj(Zero(basedomain)) then
-      return IsZmodnZMatrixRep;
+##  This should be enabled when the code for 
+##       IsZmodnZVectorRep/IsZmodnZMatrixRep
+##  is finished and tested:
+##      elif IsFinite(basedomain) and IsZmodnZObj(Zero(basedomain)) then
+##        return IsZmodnZMatrixRep;
     fi;
     return IsPlistMatrixRep;
 end);

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1745,3 +1745,14 @@ InstallEarlyMethod( SwapMatrixColumns,
       TryNextMethod();
     fi;
   end );
+
+
+############################################################################
+##  Fallback method for DeterminantMatrix
+InstallMethod(DeterminantMatrix, ["IsMatrixObj"],
+function( mat )
+  local unpack;
+  unpack := List(mat, List);
+  return DeterminantMat( unpack );
+end);
+

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1751,8 +1751,6 @@ InstallEarlyMethod( SwapMatrixColumns,
 ##  Fallback method for DeterminantMatrix
 InstallMethod(DeterminantMatrix, ["IsMatrixObj"],
 function( mat )
-  local unpack;
-  unpack := List(mat, List);
-  return DeterminantMat( unpack );
+  return DeterminantMat( Unpack( mat ) );
 end);
 

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -174,6 +174,8 @@ InstallMethod( Display, "for a plist vector", [ IsPlistVectorRep ],
     Print(v![ELSPOS],"\n>\n");
   end );
 
+InstallMethod( CompatibleVectorFilter, ["IsPlistMatrixRep"],
+  M -> IsPlistVectorRep );
 
 ############################################################################
 ############################################################################
@@ -1291,4 +1293,10 @@ InstallMethod( NewCompanionMatrix,
     Add(ll,l);
     return ll;
   end );
+
+# tell method selection that objects know their BaseDomain
+# (this should be in the first section above, but that causes
+# various "method matches more than one declaration" messages)
+InstallTrueMethod(HasBaseDomain, IsPlistVectorRep);
+InstallTrueMethod(HasBaseDomain, IsPlistMatrixRep);
 

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -1294,9 +1294,3 @@ InstallMethod( NewCompanionMatrix,
     return ll;
   end );
 
-# tell method selection that objects know their BaseDomain
-# (this should be in the first section above, but that causes
-# various "method matches more than one declaration" messages)
-InstallTrueMethod(HasBaseDomain, IsPlistVectorRep);
-InstallTrueMethod(HasBaseDomain, IsPlistMatrixRep);
-

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1642,7 +1642,12 @@ local sf, rep, ind, ind2, row, i,big,l,nr;
     if sf<>infinity and IsPrimeInt(sf) and sf>MAXSIZE_GF_INTERNAL then
       if not (IsMatrixObj(matrix) and not IsMutable(matrix)) then
         if field=sf then field:=Integers mod sf;fi;
-        matrix:=Matrix(field,matrix);
+##  Enable this later when the code for matrix objects over large prime fields
+##  is complete and tested.
+##          matrix:=Matrix(field,matrix);
+        for i in ind2 do
+          matrix[i]:=List(matrix[i],j->j); # plist conversion
+        od;
       fi;
     else
       for i in ind2 do

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -1562,6 +1562,7 @@ end);
 BindGlobal("DoImmutableMatrix", function(field,matrix,change)
 local sf, rep, ind, ind2, row, i,big,l,nr;
   if IsMatrixObj(matrix) then
+    # result is a matrix object iff 'matrix' is
     if field=BaseDomain(matrix) then
       return Immutable(matrix);
     else
@@ -1636,15 +1637,11 @@ local sf, rep, ind, ind2, row, i,big,l,nr;
 
   # rebuild some rows
   if IsZmodnZObjNonprimeCollection(field) then
-    matrix:=Matrix(field,matrix);
     big:=true;
   elif big then
     if sf<>infinity and IsPrimeInt(sf) and sf>MAXSIZE_GF_INTERNAL then
       if not (IsMatrixObj(matrix) and not IsMutable(matrix)) then
         if field=sf then field:=Integers mod sf;fi;
-##  Enable this later when the code for matrix objects over large prime fields
-##  is complete and tested.
-##          matrix:=Matrix(field,matrix);
         for i in ind2 do
           matrix[i]:=List(matrix[i],j->j); # plist conversion
         od;
@@ -1742,17 +1739,19 @@ end);
 ##
 InstallMethod( ImmutableVector,"general,2",[IsObject,IsRowVector],0,
 function(f,v)
-local sf;
-  if (IsInt(f) and f>MAXSIZE_GF_INTERNAL) or 
-     (IsField(f) and Size(f)>MAXSIZE_GF_INTERNAL) then
-    if IsInt(f) then
-      sf:=f;
+  if IsInt(f) then
+    if IsPrimePowerInt(f) then
+      f := GF(f);
     else
-      sf:=Size(f);
+      f := ZmodnZ(f);
     fi;
-    if sf<>infinity and IsPrimeInt(sf) then
-      if f=sf then f:=Integers mod sf;fi;
-      return Immutable(Vector(f,v));
+  fi;
+  if IsVectorObj(v) then
+    # result is a vector object iff 'v' is
+    if f=BaseDomain(v) then
+      return Immutable(v);
+    else
+      return Immutable(Vector(f,Unpack(v)));
     fi;
   fi;
   ConvertToVectorRepNC(v,f);

--- a/tst/testinstall/MatrixObj/IdentityMatrix.tst
+++ b/tst/testinstall/MatrixObj/IdentityMatrix.tst
@@ -88,9 +88,9 @@ Error, IdentityMatrix: the dimension must be non-negative
 
 #
 gap> IdentityMatrix(Integers mod 4, 2);
-<matrix mod 4: [ [ 1, 0 ], [ 0, 1 ] ]>
+<2x2-matrix over (Integers mod 4)>
 gap> IdentityMatrix(Integers mod 4, 0);
-<0x0-matrix mod 4>
+<0x0-matrix over (Integers mod 4)>
 gap> IdentityMatrix(Integers mod 4, -1);
 Error, IdentityMatrix: the dimension must be non-negative
 

--- a/tst/testinstall/MatrixObj/ZeroMatrix.tst
+++ b/tst/testinstall/MatrixObj/ZeroMatrix.tst
@@ -94,11 +94,11 @@ gap> ZeroMatrix(Integers, 2, 0);
 
 #
 gap> ZeroMatrix(Integers mod 4, 2, 3);
-<matrix mod 4: [ [ 0, 0, 0 ], [ 0, 0, 0 ] ]>
+<2x3-matrix over (Integers mod 4)>
 gap> ZeroMatrix(Integers mod 4, 0, 3);
-<0x3-matrix mod 4>
+<0x3-matrix over (Integers mod 4)>
 gap> ZeroMatrix(Integers mod 4, 2, 0);
-<2x0-matrix mod 4>
+<2x0-matrix over (Integers mod 4)>
 
 #
 gap> ZeroMatrix(GF(2), 2, 3);

--- a/tst/testinstall/MatrixObj/ZeroVector.tst
+++ b/tst/testinstall/MatrixObj/ZeroVector.tst
@@ -82,9 +82,9 @@ Error, ZeroVector: length must be non-negative
 
 #
 gap> ZeroVector(Integers mod 4, 2);
-<vector mod 4: [ 0, 0 ]>
+<plist vector over (Integers mod 4) of length 2>
 gap> ZeroVector(Integers mod 4, 0);
-<vector mod 4 of length 0>
+<plist vector over (Integers mod 4) of length 0>
 gap> ZeroVector(Integers mod 4, -1);
 Error, ZeroVector: length must be non-negative
 

--- a/tst/testinstall/vecmat.tst
+++ b/tst/testinstall/vecmat.tst
@@ -227,13 +227,17 @@ gap> F := Integers mod 6;; m := IdentityMat( 3, F );
   [ ZmodnZObj( 0, 6 ), ZmodnZObj( 1, 6 ), ZmodnZObj( 0, 6 ) ], 
   [ ZmodnZObj( 0, 6 ), ZmodnZObj( 0, 6 ), ZmodnZObj( 1, 6 ) ] ]
 gap> w := ImmutableMatrix( F, m );;
-gap> m = w;
-true
+
+#  these "=" tests contradict the definition of "=" in matobj.gi
+#  there is no method for IsPlist and IsMatrixObj in general
+#gap> m = w;
+#true
 gap> IsMutable(w);
 false
 gap> w := ImmutableMatrix( F, m, true );;
-gap> m = w;
-true
+
+#gap> m = w;
+#true
 gap> IsMutable(w);
 false
 

--- a/tst/testinstall/zmodnz.tst
+++ b/tst/testinstall/zmodnz.tst
@@ -421,9 +421,12 @@ gap> one:= One( A );
 gap> G:= GroupWithGenerators( [ one ] );;
 gap> One( G );;
 gap> m:=[[4,1],[1,5]] * ZmodnZObj(1,6);;
-gap> m in A; m in G;
+gap> m in A;
 true
-false
+
+# should there be a method? m and elements in G have different representations
+#gap> m in G;
+#false
 gap> m2 := Inverse(m);
 [ [ ZmodnZObj( 5, 6 ), ZmodnZObj( 5, 6 ) ], 
   [ ZmodnZObj( 5, 6 ), ZmodnZObj( 4, 6 ) ] ]


### PR DESCRIPTION
This is a new version of pull request "Some fixes concerning matrices and polynomials over large prime fields (related to issue #4901)" (#4935).

See also the discussion in  #4935. This fixes the bugs reported in #4901, but also others.

Problems occured because `ImmutableMatrix` converted some list of lists matrices into matrix objects, in particular when the base ring was of the form `Integers mod n`. This is not allowed according to the documentation of vector and matrix objects because  mixed arithmetic  of "classical" vectors and matrices and vector/matrix objects is not defined. 

`ImmutableMatrix` was originally introduced to ensure efficient representations, in particular of matrices over small fields. But note that the changed representations did not change the behaviour of the objects (e.g., a list of small finite field elements can be multiplied with a matrix in `Is8BitMatrixRep` over that field in both representations, as plain list or as compact vector in `Is8BitVectorRep`; the results are the same, the latter is only more efficient). Conversions from list of lists matrices into matrix objects are of a different kind; the resulting objects behave differently compared to the original object, e.g., allowed objects for arithmetic operations are different. This sort of conversion should not be done with `ImmutableMatrix`. 

Of course, it may be desirable to create, say, matrix groups or meataxe modules with matrix objects as elements. These should be created with explicit calls of `Matrix` or `Vector` with appropriate base rings and in that case all further data, like matrices of invariant forms, must also be stored as matrix objects over the same base ring.

## Text for release notes
not needed (this concerns changes which are not in GAP 4.11)
