### PR TITLE
Try to keep in StringRep when appending strings

### DIFF
--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -225,7 +225,10 @@ static Obj FuncAPPEND_LIST_INTR(Obj self, Obj list1, Obj list2)
     RequireSmallList(SELF_NAME, list2);
 
     /* handle the case of strings now */
-    if (IS_STRING_REP(list1) && IS_STRING_REP(list2)) {
+    if (IS_STRING_REP(list1) && IS_STRING(list2)) {
+        if (!IS_STRING_REP(list2)) {
+            list2 = ImmutableString(list2);
+        }
         AppendString(list1, list2);
         return 0;
     }

--- a/tst/testinstall/stringobj.tst
+++ b/tst/testinstall/stringobj.tst
@@ -5209,5 +5209,25 @@ true
 gap> "IsHomogeneousList" in CategoriesOfObject("");
 true
 
+# Append
+gap> s := "str";
+"str"
+gap> Append(s, "abc");
+gap> [s, IsString(s), IsStringRep(s)];
+[ "strabc", true, true ]
+gap> Append(s, ['a', 'b', 'c']);
+gap> [s, IsString(s), IsStringRep(s)];
+[ "strabcabc", true, true ]
+gap> Append(s, [1,2,3]);
+gap> [s, IsString(s), IsStringRep(s)];
+[ [ 's', 't', 'r', 'a', 'b', 'c', 'a', 'b', 'c', 1, 2, 3 ], false, false ]
+gap> s := s{[1..3]};
+"str"
+gap> [s, IsString(s), IsStringRep(s)];
+[ "str", true, false ]
+gap> Append(s, "xyz");
+gap> [s, IsString(s), IsStringRep(s)];
+[ "strxyz", true, false ]
+
 #
 gap> STOP_TEST( "stringobj.tst", 1);


### PR DESCRIPTION
I was getting some strange behaviour in the 'JSON' package, and I realised it was caused by code like:

```
gap> s := "";;
gap> o := OutputTextString(s, false);;
gap> WriteAll(o, ['a', 'b', 'c']);
true
gap> s;
"abc"
gap> IsStringRep(s);
false
```

What is happening is that the `WriteAll` uses `Append`, and `Append(stringrep,plist)` results in a `plist`, even if the result is a string. This doesn't result in bugs (well, it did in my code, but I've fixed that separately), but does still slow things down and create memory bloat.

This PR tries harder to keep the string as a stringrep -- it could possibly be written more efficiently, but I couldn't find a better way reusing existing pieces of code.