### PR TITLE
Fix Gcd to return StandardAssociate

### DIFF
--- a/lib/groebner.gi
+++ b/lib/groebner.gi
@@ -1184,7 +1184,7 @@ local basis_elt,p,t,F,vars,vars2,GB,coeff_t;
   for basis_elt in GB do
     coeff_t:=PolynomialCoefficientsOfPolynomial(basis_elt,t);
     if Length(coeff_t)=1 then 
-      return f*g/coeff_t[1];
+      return StandardAssociate(f*g/coeff_t[1]);
     fi;
   od;
   return One(F);

--- a/tst/testinstall/ratfun.tst
+++ b/tst/testinstall/ratfun.tst
@@ -202,6 +202,8 @@ gap> Gcd(DefaultRing(f),f,g);
 t^8*u-u
 gap> Gcd(f,g);
 t^8*u-u
+gap> Gcd(t, u/3);
+1
 
 #
 gap> STOP_TEST( "ratfun.tst", 1);


### PR DESCRIPTION
Method for Gcd of multivariate polynomials did not always return the
standard associate of the result.

Added an example as test.

## Text for release notes

Fixed `Gcd` of multivariate polynomials to always return a standard associate element.

