### PR TITLE
Small change and tests for numbers of conjugacy classes in classical groups

### DIFF
--- a/lib/grpffmat.gd
+++ b/lib/grpffmat.gd
@@ -99,15 +99,16 @@ DeclareGlobalFunction( "ConjugacyClassesOfNaturalGroup" );
 #F  Phi2( <n> ) . . . . . . . . . . . .  Modification of Euler's Phi function
 ##
 ##  <ManSection>
-##  <Func Name="Phi2" Arg='n'/>
+##  <Func Name="Phi2_Md" Arg='n'/>
 ##
 ##  <Description>
-##  This is needed for the computation of the class numbers of SL(n,q),
-##  PSL(n,q), SU(n,q) and PSU(n,q)
+##  This is a utility function for the computation of the class numbers of 
+##  SL(n,q), PSL(n,q), SU(n,q) and PSU(n,q). It is a variant of the Euler
+##  Phi function defined by Macdonald in <Cite Key="Mac81"/>.
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareGlobalFunction("Phi2");
+DeclareGlobalFunction("Phi2_Md");
 
 #############################################################################
 ##

--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -538,12 +538,12 @@ end);
 
 #############################################################################
 ##
-#F  Phi2( <n> ) . . . . . . . . . . . .  Modification of Euler's Phi function
+#F  Phi2_Md( <n> )  . . . . . . . . . .  Modification of Euler's Phi function
 ##
 ##  This is needed for the computation of the class numbers of SL(n,q),
-##  PSL(n,q), SU(n,q) and PSU(n,q)
+##  PSL(n,q), SU(n,q) and PSU(n,q). Defined by Macdonald in [Mac81].
 ##
-InstallGlobalFunction(Phi2,
+InstallGlobalFunction(Phi2_Md,
 n -> n^2 * Product(Set(Filtered(Factors(Integers,n), m -> m <> 1)),
                    p -> (1 - 1/p^2)));
 
@@ -571,7 +571,7 @@ InstallGlobalFunction(NrConjugacyClassesSLIsogeneous,
 function(n,q,f)
   return Sum(Cartesian(DivisorsInt(Gcd(  f,q - 1)),
                        DivisorsInt(Gcd(n/f,q - 1))),
-             d ->   Phi(d[1]) * Phi2(d[2]) 
+             d ->   Phi(d[1]) * Phi2_Md(d[2]) 
                   * NrConjugacyClassesGL(n/Product(d),q))/(q - 1);
 end);
 
@@ -601,7 +601,7 @@ InstallGlobalFunction(NrConjugacyClassesPSL,
 function(n,q)
   return Sum(Filtered(Cartesian(DivisorsInt(q - 1),DivisorsInt(q - 1)),
                       d -> n mod Product(d) = 0),
-             d -> Phi(d[1]) * Phi2(d[2])
+             d -> Phi(d[1]) * Phi2_Md(d[2])
                 * NrConjugacyClassesGL(n/Product(d),q)/(q - 1))/Gcd(n,q - 1);
 end);
 
@@ -629,7 +629,7 @@ InstallGlobalFunction(NrConjugacyClassesSUIsogeneous,
 function(n,q,f)
   return Sum(Cartesian(DivisorsInt(Gcd(  f,q + 1)),
                        DivisorsInt(Gcd(n/f,q + 1))),
-             d ->   Phi(d[1]) * Phi2(d[2]) 
+             d ->   Phi(d[1]) * Phi2_Md(d[2]) 
                   * NrConjugacyClassesGU(n/Product(d),q))/(q + 1);
 end);
 
@@ -659,7 +659,7 @@ InstallGlobalFunction(NrConjugacyClassesPSU,
 function(n,q)
   return Sum(Filtered(Cartesian(DivisorsInt(q + 1),DivisorsInt(q + 1)),
                       d -> n mod Product(d) = 0),
-             d -> Phi(d[1]) * Phi2(d[2])
+             d -> Phi(d[1]) * Phi2_Md(d[2])
                 * NrConjugacyClassesGU(n/Product(d),q)/(q + 1))/Gcd(n,q + 1);
 end);
 

--- a/tst/teststandard/nrclclass.tst
+++ b/tst/teststandard/nrclclass.tst
@@ -1,0 +1,32 @@
+gap> START_TEST("nrclclass.tst");
+gap> NrConjugacyClassesGL(24,27);
+22528399544939174406067288580609952
+gap> NrConjugacyClassesGL(14,27);
+109418989131110078784
+gap> NrConjugacyClassesGU(16,8);
+375055786601640
+gap> NrConjugacyClassesSL(12,25);
+2483526895874346
+gap> NrConjugacyClassesSU(12,25);
+2491819137278352
+gap> NrConjugacyClassesPGL(10,107);
+1855803167385374844
+gap> NrConjugacyClassesPGU(10,107);
+1856130440668628222
+gap> NrConjugacyClassesPSL(22,89);
+3978091730042006823322155084728995353940
+gap> NrConjugacyClassesPSU(15,89);
+131943217708320656361053136
+gap> NrConjugacyClassesSU(15,89);
+1979148265624809845288822240
+gap> NrConjugacyClassesSLIsogeneous(22,67,1);
+225996505505835630054268815111866308348
+gap> NrConjugacyClassesSLIsogeneous(22,67,11);
+225996505505835630054268815111866300538
+gap> NrConjugacyClassesSUIsogeneous(6,101,1);
+10617335172
+gap> NrConjugacyClassesSUIsogeneous(6,101,3);
+10617334542
+gap> NrConjugacyClassesSUIsogeneous(6,101,2);
+10617314548
+gap> STOP_TEST("nrclclass.tst");


### PR DESCRIPTION
Avoid binding `Phi2` for local utiltiy in library. See commit message.

New tests.

## Text for release notes
not needed

