### PR TITLE
Fix performance regression (caused by changes in `SmallGeneratingSet`)

### DIFF
--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1987,6 +1987,11 @@ local  i, j, U, gens,a,mintry,orb,orp,isok;
 
   gens := ShallowCopy(Set(GeneratorsOfGroup(G)));
 
+  # we can't do better than rank(G/G') generators...
+  if Length(gens)<=Length(AbelianInvariants(G)) then
+    return gens;
+  fi;
+
   # remove obvious redundancies...
   # sort elements by descending order; trivial permutations
   # at the end
@@ -2006,7 +2011,8 @@ local  i, j, U, gens,a,mintry,orb,orp,isok;
     i := i + 1;
   od;
 
-  if Length(gens)<=Length(AbelianInvariants(G))+2 then
+  # we can't do better than rank(G/G') generators...
+  if Length(gens)<=Length(AbelianInvariants(G)) then
     return gens;
   fi;
 
@@ -2017,6 +2023,11 @@ local  i, j, U, gens,a,mintry,orb,orp,isok;
       IsSolvableGroup(G)
       and Length(gens)>3 then
     return MinimalGeneratingSet(G);
+  fi;
+
+  # stop here if close to rank(G/G')
+  if Length(gens)<=Length(AbelianInvariants(G))+2 then
+    return gens;
   fi;
 
   # store orbit data


### PR DESCRIPTION
The early abort condition `Length(gens)<=Length(AbelianInvariants(G))+2`
was inserted in 9d380c4091451fe8f6b8f5335c8bfc8b76a51556 to speed up
calculations in certain large cases. However this caused regressions
in various package test suites, so bdf94cb1f963f83e6931243e00096fb0b0a1d1bd
attempted to address this by reordering some computations. Alas, that
was not enough: the YangBaxter test suite got slowed down by an order of
magnitude (it went from about 30 seconds to several minutes on my laptop).

This commit attempts a middle ground: we still abort immediately if we
provably reached an optimum. But the problematic abort condition is now
used a bit later, and only for non-solvable groups or solvable groups
with up to 3 generators.