### PR TITLE
Do not define unused functions with SYS_DEFAULT_PATHS

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -280,6 +280,7 @@ void Panic_(const char * file, int line, const char * fmt, ...)
 *F * * * * * * * * * * finding location of executable * * * * * * * * * * * *
 */
 
+#ifndef SYS_DEFAULT_PATHS
 /****************************************************************************
 ** The function 'find_yourself' is based on code (C) 2015 Mark Whitis, under
 ** the MIT License : https://stackoverflow.com/a/34271901/928031
@@ -384,16 +385,6 @@ static void SetupGAPLocation(const char * argv0)
 
 /****************************************************************************
 **
-*F  SyDotGapPath()
-*/
-const Char * SyDotGapPath(void)
-{
-    return DotGapPath;
-}
-
-
-/****************************************************************************
-**
 *F  SySetInitialGapRootPaths( <string> )  . . . . .  set the root directories
 **
 **  Set up GAP's initial root paths, based on the location of the
@@ -426,6 +417,17 @@ static void SySetInitialGapRootPaths(void)
     // idea, and for backwards compatibility.
     // Note that GAPExecLocation must always end with a slash.
     SySetGapRootPath("./");
+}
+#endif
+
+
+/****************************************************************************
+**
+*F  SyDotGapPath()
+*/
+const Char * SyDotGapPath(void)
+{
+    return DotGapPath;
 }
 
 


### PR DESCRIPTION
GCC complains about functions that are defined but not used if SYS_DEFAULT_PATHS is defined.  Wrap them with `#ifndef SYS_DEFAULT_PATHS` ... `#endif`, and move `SyDotGapPath` down so there is a single block of such definitions.

## Text for release notes

None

## Further details

None