### PR TITLE
Fix performance regression in `AllHomomorphismClasses` and possibly other code searching isomorphisms

### DIFF
--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -1746,8 +1746,11 @@ InstallGlobalFunction(Morphium,function(G,H,DoAuto)
 local len,combi,Gr,Gcl,Ggc,Hr,Hcl,bg,bpri,x,dat,
       gens,i,c,hom,free,elms,price,result,rels,inns,bcl,vsu;
 
-  IsSolvableGroup(G); # force knowledge
-  gens:=SmallGeneratingSet(G);
+  if IsSolvableGroup(G) then
+    gens:=MinimalGeneratingSet(G);
+  else
+    gens:=SmallGeneratingSet(G);
+  fi;
   len:=Length(gens);
   Gr:=MorRatClasses(G);
   Gcl:=MorMaxFusClasses(Gr);

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -197,9 +197,9 @@ DeclareGlobalFunction("CosetDecomposition");
 ##  <A>H</A>-conjugacy.
 ##  <Example><![CDATA[
 ##  gap> AllHomomorphismClasses(SymmetricGroup(4),SymmetricGroup(3)); 
-##  [ [ (1,3,4,2), (1,3,4) ] -> [ (), () ],
-##    [ (1,3,4,2), (1,3,4) ] -> [ (1,2), () ],
-##    [ (1,3,4,2), (1,3,4) ] -> [ (2,3), (1,2,3) ] ]
+##  [ [ (2,4,3), (1,4,2,3) ] -> [ (), () ],
+##    [ (2,4,3), (1,4,2,3) ] -> [ (), (1,2) ],
+##    [ (2,4,3), (1,4,2,3) ] -> [ (1,2,3), (1,2) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -227,16 +227,16 @@ DeclareGlobalFunction("AllHomomorphismClasses");
 ##  <Ref Func="AllAutomorphisms"/> returns all bijective endomorphisms.
 ##  <Example><![CDATA[
 ##  gap> AllHomomorphisms(SymmetricGroup(3),SymmetricGroup(3));
-##  [ [ (1,2,3), (1,2) ] -> [ (), () ], 
-##    [ (1,2,3), (1,2) ] -> [ (), (1,2) ], 
-##    [ (1,2,3), (1,2) ] -> [ (), (2,3) ], 
-##    [ (1,2,3), (1,2) ] -> [ (), (1,3) ], 
-##    [ (1,2,3), (1,2) ] -> [ (1,2,3), (1,2) ], 
-##    [ (1,2,3), (1,2) ] -> [ (1,2,3), (2,3) ], 
-##    [ (1,2,3), (1,2) ] -> [ (1,3,2), (1,2) ], 
-##    [ (1,2,3), (1,2) ] -> [ (1,2,3), (1,3) ], 
-##    [ (1,2,3), (1,2) ] -> [ (1,3,2), (1,3) ], 
-##    [ (1,2,3), (1,2) ] -> [ (1,3,2), (2,3) ] ]
+##  [ [ (2,3), (1,2,3) ] -> [ (), () ],
+##    [ (2,3), (1,2,3) ] -> [ (1,2), () ],
+##    [ (2,3), (1,2,3) ] -> [ (2,3), () ],
+##    [ (2,3), (1,2,3) ] -> [ (1,3), () ],
+##    [ (2,3), (1,2,3) ] -> [ (2,3), (1,2,3) ],
+##    [ (2,3), (1,2,3) ] -> [ (1,3), (1,2,3) ],
+##    [ (2,3), (1,2,3) ] -> [ (1,3), (1,3,2) ],
+##    [ (2,3), (1,2,3) ] -> [ (1,2), (1,2,3) ],
+##    [ (2,3), (1,2,3) ] -> [ (2,3), (1,3,2) ],
+##    [ (2,3), (1,2,3) ] -> [ (1,2), (1,3,2) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -954,7 +954,11 @@ local cl,cnt,bg,bw,bo,bi,k,gens,go,imgs,params,emb,clg,sg,vsu,c,i;
     repeat
       if cnt=0 then
 	# first the small gen syst.
-	gens:=SmallGeneratingSet(H);
+        if IsSolvableGroup(H) then
+          gens:=MinimalGeneratingSet(H);
+        else
+          gens:=SmallGeneratingSet(H);
+        fi;
 	sg:=Length(gens);
       else
 	# then something random


### PR DESCRIPTION
Since this is costly, it is worth to force a minimal generating set for
solvable groups. This resolves problems the yangbaxter package has had.

Close #5024

This patch is taken from @hulpke's PR #5031, but having different, unrelated improvements and bug fixes on separate PRs reduces the work needed to make GAP releases quite a bit (as it allows us to deal with those PRs in automation, instead of adding them to the list of PRs that need manual work), and is also more convenient for reviewers, so I am splitting it off here.


For reference, here is the motivation for this patch from the description of PR #5024:

> The early abort condition `Length(gens)<=Length(AbelianInvariants(G))+2`
was inserted in 9d380c4091451fe8f6b8f5335c8bfc8b76a51556 to speed up
calculations in certain large cases. However this caused regressions
in various package test suites, so bdf94cb1f963f83e6931243e00096fb0b0a1d1bd
attempted to address this by reordering some computations. Alas, that
was not enough: the YangBaxter test suite got slowed down by an order of
magnitude (it went from about 30 seconds to several minutes on my laptop).

This PR addresses this.