### PR TITLE
Fix unexpected error in `ConjugacyClassesSubgroups`

### DIFF
--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -845,11 +845,15 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
   makesubgroupclasses,cefastersize;
 
   #group order below which cyclic extension is usually faster
-  if IsPackageMarkedForLoading("tomlib","")=true then
+  # WORKAROUND: there is a disparity between the data format returned
+  # by CE and what this code expects. This could be resolved properly,
+  # but since most people will have tomlib loaded anyway, this doesn't
+  # seem worth the effort.
+  #if IsPackageMarkedForLoading("tomlib","")=true then
     cefastersize:=1; 
-  else
-    cefastersize:=40000; 
-  fi;
+  #else
+  #  cefastersize:=40000; 
+  #fi;
 
   makesubgroupclasses:=function(g,l)
   local i,m,c;

--- a/tst/testbugfix/2022-09-06-ConjugacyClassesSubgroups.tst
+++ b/tst/testbugfix/2022-09-06-ConjugacyClassesSubgroups.tst
@@ -1,0 +1,5 @@
+# The following used to work in GAP 4.10, but was broken in GAP
+# 4.11.x and also 4.12.0.
+# See https://github.com/gap-system/gap/issues/4854
+gap> Length(ConjugacyClassesSubgroups(SmallGroup(1344,11293)));
+83


### PR DESCRIPTION
This disables an attempt to use cyclic extension instead of lifting for
lattices of smallish groups. The issue is that CE returns data in a
slightly different format than required. This resulted in some commands,
e.g. `ConjugacyClassesSubgroups(SmallGroup(1344,11293))`, to enter a
break loop.

If tomlib is loded it's a mote issue, and thus does not merit further
investigation.

This resolves #4854

---

This patch is taken from @hulpke's PR #5031 (but with a test case added and a code comment explaining what's going on). Having different, unrelated improvements and bug fixes on separate PRs reduces the work needed to make GAP releases quite a bit (as it allows us to deal with those PRs in automation, instead of adding them to the list of PRs that need manual work), and is also more convenient for reviewers, so I am splitting it off here.