### PR TITLE
Fix `Centre` for pc groups giving wrong results, e.g. `Size(Center(SmallGroup(2^9,261648)))` gave 4 instead of 8

### DIFF
--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -717,37 +717,15 @@ end);
 #F  NextStepCentralizer( <gens>, <cent>, <pcgsF>, <field> )
 ##
 NextStepCentralizer := function( gens, cent, pcgsF, field )
-    local   g,  newgens,  matlist,  notcentral,  h,  comm,  null,  j,  elm;
-  
+    local g, matlist, null;
+
     for g in gens do
         if Length( cent ) = 0 then return []; fi;
-
-        newgens := [];
-        matlist := [];
-        notcentral := [];
-        for h in cent do
-            comm := ExponentsOfPcElement( pcgsF, Comm( h, g ) ) * One(field);
-            if comm = Zero( field ) * comm  then
-                Add( newgens, h );
-            else
-                Add( notcentral, h );
-                Add( matlist, comm );
-            fi;
-        od;
-       
-        if Length( matlist ) > 0  then
-    
-            # get nullspace
-            null := TriangulizedNullspaceMat( matlist );
-
-            # calculate elements corresponding to null
-            for j  in [1..Length(null)]  do
-                elm := PcElementByExponentsNC( pcgsF, notcentral, null[j] );
-                Add( newgens, elm );
-            od;
-        fi;
-        cent := newgens;
+        matlist := List( cent, x -> ExponentsOfPcElement(pcgsF, Comm(x,g)));
+        null := TriangulizedNullspaceMat(matlist*One(field));
+        cent := List( null, x -> PcElementByExponentsNC(pcgsF, cent, x));
     od;
+
     return cent;
 end;
 

--- a/tst/testbugfix/2022-09-07-Centre.tst
+++ b/tst/testbugfix/2022-09-07-Centre.tst
@@ -1,0 +1,6 @@
+# Centre for PcGroups sometimes returned wrong results.
+# See https://github.com/gap-system/gap/issues/3940
+#
+gap> G:=SmallGroup(2^9,261648);;
+gap> Size(Center(G)); # This used to return 4
+8


### PR DESCRIPTION
Fixes #3940 with a change provided by @beick.
