### PR TITLE
Fix unexpected error in `MinimalGeneratingSet` for solvable non-pc groups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -112,7 +112,7 @@ InstallMethod(MinimalGeneratingSet,"test solvable and 2-generator noncyclic",
 function(G)
 local i;
   if not HasIsSolvableGroup(G) and IsSolvableGroup(G) and
-  CanEasilyComputePcgs(G)  then
+     CanEasilyComputePcgs(G) then
     # discovered solvable -- redo
     return MinimalGeneratingSet(G);
   elif not IsSolvableGroup(G) then
@@ -120,8 +120,8 @@ local i;
         and Length(GeneratorsOfGroup(G)) = 2 then
       return GeneratorsOfGroup(G);
     fi;
-    TryNextMethod();
   fi;
+  TryNextMethod();
 end);
 
 #############################################################################

--- a/tst/testbugfix/2022-09-09-MinimalGeneratingSet.tst
+++ b/tst/testbugfix/2022-09-09-MinimalGeneratingSet.tst
@@ -1,0 +1,5 @@
+gap> G:=Group((1,2),(2,3),(3,4));;
+gap> H:=Image(IsomorphismFpGroup(G));;
+gap> MinimalGeneratingSet(H);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 4th choice method found for `MinimalGeneratingSet' on 1 arguments


### PR DESCRIPTION
It could end up returning nothing and not invoking TryNextMethod().
This caused a failure in the hap test suite.

This is a recent regression in 4.12.0, introduced in commit 97feedb5c078eef4a24ecf4e535295e31e3e0218
