### PR TITLE
Fix `SaveOnExitFile` in restored workspaces

### DIFF
--- a/lib/session.g
+++ b/lib/session.g
@@ -30,7 +30,7 @@ BIND_GLOBAL("PROGRAM_CLEAN_UP", function()
         if IsHPCGAP then
             funcs := FromAtomicList(GAPInfo.AtExitFuncs);
         else
-            funcs := GAPInfo.AtExitFuncs;
+            funcs := ShallowCopy(GAPInfo.AtExitFuncs);
         fi;
         while not IsEmpty(funcs) do
             f := Remove(funcs);


### PR DESCRIPTION
... and possibly more errors: we accidentally removed all exit handlers when quitting GAP, just before the workspace was saved, thus when restoring GAP from this session, those exist handlers were missing, including the one dealing with `SaveOnExitFile`.

This code looses the ability to install new exit handlers as part of an exit handler, but that seems like a rather bad (and pointless) idea to me anyway.

Fixes #5035 