### PR TITLE
doc: add heading to `Centralizer` entry

### DIFF
--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -703,6 +703,7 @@ DeclareOperation( "IsCentral", [ IsMagma, IsObject ] );
 ##
 ##  <#GAPDoc Label="Centralizer">
 ##  <ManSection>
+##  <Heading>Centralizer</Heading>
 ##  <Oper Name="Centralizer" Arg='M, elm'
 ##   Label="for a magma and an element"/>
 ##  <Oper Name="Centralizer" Arg='M, S'


### PR DESCRIPTION
This fixes a reference to `Centralizer` in the xgap manual, and also matches what we do for `Normalizer`
