### PR TITLE
`Display` for a character table optionally shows the degrees of the character fields

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -3421,6 +3421,11 @@ DeclareGlobalFunction( "ConvertToLibraryCharacterTableNC" );
 ##    centralizer orders in a style similar to that used in the
 ##    &ATLAS; of Finite Groups&nbsp;<Cite Key="CCN85"/>,
 ##  </Item>
+##  <Mark><C>characterField</C></Mark>
+##  <Item>
+##    <K>true</K> to show the degrees of the character fields over the prime
+##    field, in a column with header <C>d</C>,
+##  </Item>
 ##  <Mark><C>chars</C></Mark>
 ##  <Item>
 ##    an integer or a list of integers to select a sublist of the

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -4803,11 +4803,13 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
           ncols,             # total number of columns
           linelen,           # line length
           q,                 # quadratic cyc / powermap entry
+          field_degrees,     # list of degrees of character fields
           indicator,         # list of primes
           OD,                # show a column with orthog. discriminants
           iw,                # width of indicator columns
           indic,             # indicator values
           oddata,            # orthog. discriminants
+          p,                 # characteristic
           ind2,              # 2nd indicator
           iwsum,             # total width of (OD and) indicator columns
           entry,             # run over 'oddata'
@@ -5005,6 +5007,17 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
       fi;
     od;
 
+    # print degrees of character fields?
+    field_degrees:= false;
+    for record in options do
+      if IsBound( record.characterField ) then
+        if record.characterField = true then
+          field_degrees:= true;
+        fi;
+        break;
+      fi;
+    od;
+
     # print Frobenius-Schur indicators?
     indicator:= [];
     for record in options do
@@ -5071,15 +5084,29 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
       fi;
       indicator:= Concatenation( [ "OD" ], indicator );
     fi;
+    if field_degrees then
+      indicator:= Concatenation( [ "d" ], indicator );
+    fi;
     if indicator <> [] then
       for i in [ 1 .. Length( indicator ) ] do
-        if indicator[i] = "OD" then
-          indic[1]:= ListWithIdenticalEntries( Length( cnr ), "" );
+        if indicator[i] = "d" then
+          p:= UnderlyingCharacteristic( tbl );
+          if p = 0 then
+            indic[i]:= List( chars,
+                         x -> String( Dimension( Field( Rationals, x ) ) ) );
+          else
+            indic[i]:= List( chars,
+                         x -> String( Length( Factors( SizeOfFieldOfDefinition(
+                                ClassFunction( tbl, x ), p ) ) ) ) );
+          fi;
+          iw[i]:= Maximum( 2, Maximum( List( indic[i], Length ) ) ) + 1;
+        elif indicator[i] = "OD" then
+          indic[i]:= ListWithIdenticalEntries( Length( cnr ), "" );
           if IsBoundGlobal( "OrthogonalDiscriminants" ) then
             oddata:= ValueGlobal( "OrthogonalDiscriminants" )( tbl );
             for j in [ 1 .. Length( cnr ) ] do
               if IsBound( oddata[ cnr[j] ] ) then
-                indic[1][j]:= oddata[ cnr[j] ];
+                indic[i][j]:= oddata[ cnr[j] ];
               fi;
             od;
           else
@@ -5088,11 +5115,11 @@ BindGlobal( "CharacterTableDisplayDefault", function( tbl, options )
             for j in [ 1 .. Length( cnr ) ] do
               if ( not ind2[ cnr[j] ] in [ -1, 0 ] ) and
                  Irr( tbl )[ cnr[j] ][1] mod 2 = 0 then
-                indic[1][j]:= "?";
+                indic[i][j]:= "?";
               fi;
             od;
           fi;
-          iw[i]:= Maximum( 2, Maximum( List( indic[1], Length ) ) ) + 1;
+          iw[i]:= Maximum( 2, Maximum( List( indic[i], Length ) ) ) + 1;
         else
           if chars_from_irr and
              IsBound( ComputedIndicators( tbl )[ indicator[i] ] ) then

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -252,6 +252,20 @@ CT2
 X.1                     1                 -1                  1
 X.2                     2                  .                 -1
 X.3                     1                  1                  1
+gap> Display( t,
+>        rec( characterField:= true ) );
+CT2
+
+         2  1  1  .
+         3  1  .  1
+
+           1a 2a 3a
+        2P 1a 1a 3a
+        3P 1a 2a 1a
+        d
+X.1     1   1 -1  1
+X.2     1   2  . -1
+X.3     1   1  1  1
 
 # viewing and printing of character tables with stored groups
 gap> t:= CharacterTable( DihedralGroup( 8 ) );;


### PR DESCRIPTION
Show the degrees of the field extensions of the shown characters if the `characterField` component of the options record given to `Display` is set to `true`; the default is `false`.