### PR TITLE
Makefile: signal error via exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,5 @@
 		fi; \
 		printf "./configure before make (please refer to INSTALL for details)\n" ; \
 	  fi
+	@exit 1
 all: .DEFAULT


### PR DESCRIPTION
... not just via a message printed to the user.

I noticed this because an automated build silently *passed* when I forgot to run `./configure`. Ouch.

While this hurt me quite a bit, overall I think this is rather obscure and does not warrant an entry in the release notes.