### PR TITLE
Makefile.gappkg: ensure `make doc` terminates

### DIFF
--- a/etc/Makefile.gappkg
+++ b/etc/Makefile.gappkg
@@ -156,7 +156,7 @@ distclean-kext:
 # hook into `make doc`
 doc: doc-kext
 doc-kext:
-	$(GAP) makedoc.g
+	$(GAP) --quitonbreak -b -q < makedoc.g
 
 # hook into `make check`
 check: check-kext


### PR DESCRIPTION
Before this, `make doc` would end up in a GAP prompt, which is against any convention and makes it unusable in automation.

Likewise, errors would just result in a break loop, instead of terminating with a non-zero exit code.

This patch fixes this. It also suppresses the GAP banner for `make doc`.

To take effect, packages need to update to this new version.

See also https://github.com/gap-packages/io/pull/115 and https://github.com/gap-packages/io/issues/100

This doesn't really warrant a release notes entry for GAP; if at all, then affected packages should report the change in their respective release notes.