### PR TITLE
Fix `AllHomomorphisms` regression

### DIFF
--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -1746,7 +1746,7 @@ InstallGlobalFunction(Morphium,function(G,H,DoAuto)
 local len,combi,Gr,Gcl,Ggc,Hr,Hcl,bg,bpri,x,dat,
       gens,i,c,hom,free,elms,price,result,rels,inns,bcl,vsu;
 
-  if IsSolvableGroup(G) then
+  if IsSolvableGroup(G) and CanEasilyComputePcgs(G) then
     gens:=MinimalGeneratingSet(G);
   else
     gens:=SmallGeneratingSet(G);

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -954,7 +954,7 @@ local cl,cnt,bg,bw,bo,bi,k,gens,go,imgs,params,emb,clg,sg,vsu,c,i;
     repeat
       if cnt=0 then
 	# first the small gen syst.
-        if IsSolvableGroup(H) then
+        if IsSolvableGroup(H) and CanEasilyComputePcgs(H) then
           gens:=MinimalGeneratingSet(H);
         else
           gens:=SmallGeneratingSet(H);

--- a/tst/testbugfix/2022-09-17-AllHomomorphisms.tst
+++ b/tst/testbugfix/2022-09-17-AllHomomorphisms.tst
@@ -1,0 +1,9 @@
+# Verify AllHomomorphisms works for finite solvable groups
+# which are not in the filter CanEasilyComputePcgs: for such groups,
+# we used to invoke MinimalGeneratingSet, but it is not actually
+# implemented for them...
+gap> F:=FreeGroup(3);; G:=F/[F.1^2, F.2^2, Comm(F.1,F.2), F.3];;
+gap> IsSolvableGroup(G);
+true
+gap> Length(AllHomomorphisms(G, SmallGroup(8,1)));
+4


### PR DESCRIPTION
The problem is that we only checked `IsSolvableGroup` to decide whether to call `MinimalGeneratingSet` on a group. However, in reality this is only implemented for groups in the filter `CanEasilyComputePcgs` -- thus for perm and pc groups but not for fp groups.

This broke the HAP test suite.

This regression was introduced in PR #5032 and is not in GAP 4.12.0, so it also does not need a release notes entry.