### PR TITLE
Fix HASH_FLAGS on big endian

### DIFF
--- a/src/opers.cc
+++ b/src/opers.cc
@@ -48,6 +48,8 @@ extern "C" {
 
 #include <stdio.h>
 
+#include "config.h"
+
 } // extern "C"
 
 #ifdef GAP_KERNEL_DEBUG


### PR DESCRIPTION
The test suite reported a diff without this. Reported by Bill Allombert.