### PR TITLE
fix multiplication of `IsFFE` and `Is8BitMatrixRep`

### DIFF
--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -462,11 +462,14 @@ InstallMethod( \*, "8 bit matrix * 8 bit matrix", IsIdenticalObj,
 
 #############################################################################
 ##
-#M <scal> * <mat>
+#M  <ffe> * <mat>
+##
+##  If <ffe> lies in the field of <mat> then we return a matrix in
+##  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 ##
 
-InstallMethod( \*, "scalar * 8 bit matrix", IsElmsCollColls, 
-        [           IsFFE, 
+InstallMethod( \*, "internal FFE * 8 bit matrix", IsElmsCollColls,
+        [           IsFFE and IsInternalRep,
                 Is8BitMatrixRep and IsMatrix
           ], 0,
         function(s,m)
@@ -486,15 +489,32 @@ InstallMethod( \*, "scalar * 8 bit matrix", IsElmsCollColls,
     return r;
 end);
 
+InstallMethod( \*, "FFE * 8 bit matrix", IsElmsCollColls,
+    [ IsFFE, Is8BitMatrixRep and IsMatrix ],
+    function( s, m )
+    if IsInternalRep( s ) then
+      TryNextMethod();
+    fi;
+    s:= AsInternalFFE( s );
+    if s = fail then
+      TryNextMethod();
+    fi;
+    return s * m;
+end);
+
+
 #############################################################################
 ##
-#M  <mat> * <scal>
+#M  <mat> * <ffe>
+##
+##  If <ffe> lies in the field of <mat> then we return a matrix in
+##  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 ##
 
-InstallMethod( \*, "scalar * 8 bit matrix", IsCollCollsElms, 
+InstallMethod( \*, "8 bit matrix * internal FFE", IsCollCollsElms,
         [         
                 Is8BitMatrixRep and IsMatrix,
-                IsFFE
+                IsFFE and IsInternalRep
           ], 0,
         function(m,s)
     local q,i,l,r,pv;
@@ -513,6 +533,18 @@ InstallMethod( \*, "scalar * 8 bit matrix", IsCollCollsElms,
     return r;
 end);
 
+InstallMethod( \*, "8 bit matrix * FFE", IsCollCollsElms,
+    [ Is8BitMatrixRep and IsMatrix, IsFFE ],
+    function( m, s )
+    if IsInternalRep( s ) then
+      TryNextMethod();
+    fi;
+    s:= AsInternalFFE( s );
+    if s = fail then
+      TryNextMethod();
+    fi;
+    return m * s;
+end);
 
 
 #############################################################################

--- a/tst/testinstall/mat8bit.tst
+++ b/tst/testinstall/mat8bit.tst
@@ -1,0 +1,73 @@
+#@local m, z, zm, mz;
+gap> START_TEST("mat8bit.tst");
+
+# FFE * 8 bit matrix
+gap> m:= [ [ Z(3)^0 ] ];;
+gap> ConvertToMatrixRep( m, 3 );;
+gap> Is8BitMatrixRep( m );
+true
+gap> z:= Z(3);;  # internal FFE in the field of 'm'
+gap> zm:= z * m;;
+gap> Is8BitMatrixRep( zm );
+true
+gap> Zero( zm ) = Zero( z ) * m;
+true
+gap> z:= Z(9);;  # internal FFE not in the field of 'm'
+gap> zm:= z * m;;
+gap> Is8BitMatrixRep( zm );
+false
+gap> Zero( zm ) = Zero( z ) * m;
+true
+gap> z:= Zero( Z(3,11) );;  # non-internal FFE in the field of 'm'
+gap> IsInternalRep( z );
+false
+gap> zm:= z * m;;
+gap> Is8BitMatrixRep( zm );
+true
+gap> Zero( zm ) = Zero( z ) * m;
+true
+gap> z:= Z(3,11);;  # non-internal FFE not in the field of 'm'
+gap> IsInternalRep( z );
+false
+gap> zm:= z * m;;
+gap> Is8BitMatrixRep( zm );
+false
+gap> Zero( zm ) = Zero( z ) * m;
+true
+
+# 8 bit matrix * FFE
+gap> m:= [ [ Z(3)^0 ] ];;
+gap> ConvertToMatrixRep( m, 3 );;
+gap> Is8BitMatrixRep( m );
+true
+gap> z:= Z(3);;  # internal FFE in the field of 'm'
+gap> mz:= m * z;;
+gap> Is8BitMatrixRep( mz );
+true
+gap> Zero( mz ) = m * Zero( z );
+true
+gap> z:= Z(9);;  # internal FFE not in the field of 'm'
+gap> mz:= m * z;;
+gap> Is8BitMatrixRep( mz );
+false
+gap> Zero( mz ) = m * Zero( z );
+true
+gap> z:= Zero( Z(3,11) );;  # non-internal FFE in the field of 'm'
+gap> IsInternalRep( z );
+false
+gap> mz:= m * z;;
+gap> Is8BitMatrixRep( mz );
+true
+gap> Zero( mz ) = m * Zero( z );
+true
+gap> z:= Z(3,11);;  # non-internal FFE not in the field of 'm'
+gap> IsInternalRep( z );
+false
+gap> mz:= m * z;;
+gap> Is8BitMatrixRep( mz );
+false
+gap> Zero( mz ) = m * Zero( z );
+true
+
+#
+gap> STOP_TEST("mat8bit.tst");


### PR DESCRIPTION
(and the other way round)
by installing the current methods only for mutiplying with internal FFEs and adding new methods for multiplying with non-internal FFEs.

(This addresses issue #5062.)