### PR TITLE
fixed `AbsolutelyIrreducibleModules` for a pc group and a finite prime field

### DIFF
--- a/lib/grppcrep.gi
+++ b/lib/grppcrep.gi
@@ -587,10 +587,8 @@ end );
 ##
 #M AbsolutIrreducibleModules( <G>, <F>, <dim> ). . . . . . .up to equivalence
 ##
-## <dim> is the limit of Dim( F ) * Dim( M ) for the modules M
-##
 InstallMethod( AbsolutIrreducibleModules,
-    "generic method for groups with pcgs",
+    "method for group with pcgs and finite prime field",
     true, 
     [ IsGroup and CanEasilyComputePcgs, IsField and IsFinite and IsPrimeField, IsInt ],
     0,
@@ -598,7 +596,9 @@ InstallMethod( AbsolutIrreducibleModules,
 function( G, F, dim )
     local modus;
     modus := AbsAndIrredModules( G, F, dim );
-    return [modus[1],List( modus[2], x -> x.absirr )];
+    return [ modus[1],
+             Filtered( List( modus[2], x -> x.absirr ),
+                       x -> IsPrimeField( x.field ) ) ];
 end );
 
 #############################################################################

--- a/lib/grpreps.gd
+++ b/lib/grpreps.gd
@@ -22,10 +22,13 @@
 ##  <Oper Name="AbsolutIrreducibleModules" Arg='G, F, dim'/>
 ##
 ##  <Description>
-##  returns a list of length 2. The first entry is a generating system of
-##  <A>G</A>. The second entry is a list of all absolute irreducible modules of
-##  <A>G</A> over the field <A>F</A> in dimension <A>dim</A>, given as MeatAxe modules
+##  <Ref Oper="AbsolutelyIrreducibleModules"/> returns a list of length 2.
+##  The first entry is a generating system of the group <A>G</A>.
+##  The second entry is a list of all those absolutely irreducible modules of
+##  <A>G</A> that can be realized over the finite field <A>F</A>
+##  and have dimension at most <A>dim</A>, given as MeatAxe modules
 ##  (see&nbsp;<Ref Func="GModuleByMats" Label="for generators and a field"/>).
+##  <P/>
 ##  The other two names are just synonyms.
 ##  </Description>
 ##  </ManSection>

--- a/tst/testinstall/grpreps.tst
+++ b/tst/testinstall/grpreps.tst
@@ -1,0 +1,21 @@
+#@local G1, G2, F, res1, res2;
+gap> START_TEST( "grpreps.tst" );
+
+# Compare the two methods for 'AbsolutelyIrreducibleModules'.
+gap> G1:= DihedralGroup( 10 );;
+gap> G2:= DihedralGroup( IsPermGroup, 10 );;
+gap> F:= GF(2);;
+gap> # Make sure that different methods will be called.
+gap> ApplicableMethod( AbsolutelyIrreducibleModules, [ G1, F, 10 ] )
+> <> ApplicableMethod( AbsolutelyIrreducibleModules, [ G2, F, 10 ] );
+true
+gap> res1:= AbsolutelyIrreducibleModules( G1, F, 10 );;
+gap> List( res1[2], r -> [ r.field, r.dimension ] );
+[ [ GF(2), 1 ] ]
+gap> res2:= AbsolutelyIrreducibleModules( G2, F, 10 );;
+gap> List( res2[2], r -> [ r.field, r.dimension ] );
+[ [ GF(2), 1 ] ]
+
+#
+gap> STOP_TEST( "grpreps.tst" );
+


### PR DESCRIPTION
The two methods now give equivalent results when both are applicable (for a pc group and a finite prime field).

This resolves #5061.