### PR TITLE
Makefile.gappkg: move pkgconfig.h.in from gen to src

### DIFF
--- a/etc/Makefile.gappkg
+++ b/etc/Makefile.gappkg
@@ -193,14 +193,14 @@ gen/pkgconfig.h: gen/pkgconfig.h.stamp
 	@if test ! -f $@; then rm -f $<; else :; fi
 	@if test ! -f $@; then $(MAKE) $<; else :; fi
 
-gen/pkgconfig.h.stamp: gen/pkgconfig.h.in config.status
+gen/pkgconfig.h.stamp: src/pkgconfig.h.in config.status
 	@rm -f $@
 	@mkdir -p $(@D)
 	./config.status gen/pkgconfig.h
 	echo > $@
 
 ifneq ($(MAINTAINER_MODE),no)
-gen/pkgconfig.h.in: $(configure_deps)
+src/pkgconfig.h.in: $(configure_deps)
 	@if command -v autoheader >/dev/null 2>&1 ; then \
 	   mkdir -p $(@D) ; \
 	   echo "running autoheader" ; \


### PR DESCRIPTION
The `gen` directory is for things that are created by `make` and it is deleted by `make clean`. But `pkgconfig.h.in` is *not* generated by `make`. So it does not belong into `src` but rather into `gen`.

Unfortunately GAP's `BuildPackages.sh` script runs `make clean` before `make`, which triggered this problematic behavior, causing build failures in `io` and `curlInterface`.
