### PR TITLE
Warn users on 32-bit CPUs and big-endian CPUs

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -421,7 +421,7 @@ end );
 
 BindGlobal( "ShowKernelInformation", function()
   local sysdate, linelen, indent, btop, vert, bbot, print_info,
-        config, str, gap;
+        config, str, gap, warnings;
 
   linelen:= SizeScreen()[1] - 2;
   print_info:= function( prefix, values, suffix )
@@ -474,6 +474,22 @@ BindGlobal( "ShowKernelInformation", function()
     Print( "             Maximum concurrent threads: ",
        GAPInfo.KernelInfo.NUM_CPUS, "\n");
   fi;
+
+  # Warn about poorly tested, or unsupported, variants of GAP
+  warnings := [];
+  
+  if GAPInfo.BytesPerVariable = 4 then
+    Add( warnings, "32-bit CPUs");
+  fi;
+  if GAPInfo.KernelInfo.BIGENDIAN_CPU then
+    Add( warnings, "Big-endian CPUs");
+  fi;
+
+  if warnings <> [] then
+    print_info("\n **** Warning, this copy of GAP was built for: ", warnings,
+               "\n **** This configuration is not officially supported or tested \n\n");
+  fi;
+
   # For each library or configuration setting, print some info.
   config:= [];
   # always mention GMP

--- a/src/gap.c
+++ b/src/gap.c
@@ -1150,6 +1150,12 @@ static Obj FuncKERNEL_INFO(Obj self)
     AssPRec(res, r, False);
 #endif
 
+#ifdef WORDS_BIGENDIAN
+    AssPRec(res, RNamName("BIGENDIAN_CPU"), True);
+#else
+    AssPRec(res, RNamName("BIGENDIAN_CPU"), False);
+#endif
+
     MakeImmutable(res);
 
     return res;


### PR DESCRIPTION
This PR adds a message which is displayed whenever GAP is started on a 32-bit CPU, or a big-endian CPU, pointing out that GAP don't support this CPU, and we aren't doing full testing.

There are I feel two questions here:

1) Is adding such a message reasonable? I think it is, because in general people want to trust the answers they get from GAP.

2) Is this message right? Here's what the output looks like:

```
 ┌───────┐   GAP 4.13dev-42-g7cf6fb7 built on 2022-09-29 20:35:04+0100
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-pc-linux-gnu-default64-kv8

 **** Warning, this copy of GAP was built for: 32-bit CPUs
 **** This configuration is not officially supported or tested

 Configuration:  gmp 6.2.1, GASMAN, readline
 Loading the library and packages ...
```