### PR TITLE
buildsys: fix broken `__builtin_mul_overflow` check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ AC_DEFUN([CHECK_COMPILER_BUILTIN],
     AC_LINK_IFELSE(
         [AC_LANG_PROGRAM(
             [[]],
-            [$1[($2)];
+            [int x; $1[($2)];
             ]
         )],
         [AS_VAR_SET([[have_]$1], [yes])],
@@ -185,7 +185,7 @@ AC_DEFUN([CHECK_COMPILER_BUILTIN],
             [Define to 1 if the system has the `]$1[' built-in function])], []
         )])
 
-CHECK_COMPILER_BUILTIN([__builtin_mul_overflow],[0,0,0]);
+CHECK_COMPILER_BUILTIN([__builtin_mul_overflow],[0,0,&x]);
 CHECK_COMPILER_BUILTIN([__builtin_clz],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzl],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzll],[0]);


### PR DESCRIPTION
Without this, the check failed with at least some compilers; here is an error from Apple Clang:

    conftest.c:34:28: error: result argument to overflow builtin must be
    a pointer to a non-const integer ('int' invalid)
    __builtin_mul_overflow(0,0,0);
                               ^

And here with GCC 9.4:

    conftest.c:34:28: error: argument 3 in call to function
    '__builtin_mul_overflow' does not have pointer to integral type
       34 | __builtin_mul_overflow(0,0,0);
          |                            ^

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.



Luckily the effects are not so bad because `intobj.h` has fallbacks, so for GCC >= 5 and clang >= 3.8 we are good anyway. Hence I don't think this needs release notes.