### PR TITLE
sysinfo.gap: set GAP to PREFIX/bin/gap

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -640,7 +640,7 @@ install-gaproot: CITATION
 install-sysinfo: SYSINFO_CPPFLAGS = -I${includedir}/gap $(GAP_DEFINES)
 install-sysinfo: SYSINFO_LDFLAGS = $(ABI_CFLAGS)
 install-sysinfo: SYSINFO_LIBS =
-install-sysinfo: SYSINFO_GAP = $(libdir)/gap/gap
+install-sysinfo: SYSINFO_GAP = $(bindir)/gap
 install-sysinfo: SYSINFO_GAC = $(bindir)/gac
 install-sysinfo: GMP_PREFIX =
 install-sysinfo:


### PR DESCRIPTION
Suggested by Bill Allombert on the GAP support list: instead of pointing package or anything which parses `sysinfo.gap` to the "real but hidden away" GAP executable, point to `PREFIX/bin/gap` -- which for now by default is a shell script starting the "real" GAP, which can be tweaked further, and arguably is what should be used anyway