### PR TITLE
Don't attempt to install the 'dev' manual...

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -597,7 +597,7 @@ install-doc:
 	# TODO: should this depend on the 'doc' target? but that target is phony
 	# and will re-run each time it is invoked, which is not really what we want.
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(datarootdir)/gap/doc
-	for book in ref tut hpc dev ; do \
+	for book in ref tut hpc ; do \
 		$(INSTALL) -d -m 0755 $(DESTDIR)$(datarootdir)/gap/doc/$$book ; \
 		for ext in css html js txt pdf six lab; do \
 			$(INSTALL) -m 0644  $(srcdir)/doc/$$book/*.$$ext $(DESTDIR)$(datarootdir)/gap/doc/$$book/ ; \


### PR DESCRIPTION
... as it is not contained in release tarballs!

An alternative would of course be to include the dev manual in release tarballs; but given its really bad state, I don't think that's a good idea (this may of course change in the future)

Inspired by https://github.com/NixOS/nixpkgs/pull/192548