### PR TITLE
fixed `DefaultMatrixRepForBaseDomain`

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -159,7 +159,7 @@ BindGlobal( "DefaultMatrixRepForBaseDomain",
 function( basedomain )
     if IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) = 2 then
         return IsGF2MatrixRep;
-    elif IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) <= 256 then
+    elif IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) <= 256 and IsFFECollection(basedomain) then
         return Is8BitMatrixRep;
 ##  This should be enabled when the code for 
 ##       IsZmodnZVectorRep/IsZmodnZMatrixRep

--- a/tst/testbugfix/2022-10-07-DefaultMatrixRepForBaseDomain.tst
+++ b/tst/testbugfix/2022-10-07-DefaultMatrixRepForBaseDomain.tst
@@ -1,0 +1,8 @@
+# Make sure that 'DefaultMatrixRepForBaseDomain' works for
+# the fields provided by the StandardFF package.
+gap> if TestPackageAvailability( "StandardFF" ) <> fail and
+>       LoadPackage( "StandardFF", false ) <> fail then
+>      if DefaultMatrixRepForBaseDomain( FF( 3, 2 ) ) = Is8BitMatrixRep then
+>        Error( "wrong DefaultMatrixRepForBaseDomain( FF( 3, 2 ) )" );
+>      fi;
+>    fi;


### PR DESCRIPTION
Finite fields that do not consist of `FFE`s (for example fields created by `FF`) caused problems up to now.
Resolves #5055.