### PR TITLE
buildsys: remove a bunch of symlinks from compat mode

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -303,7 +303,7 @@ modes using "out of tree builds". For details, please refer to the file
 You are now at a point where you can start GAP for the first time. Unix
 users (including those on macOS) should type
 
-    ./bin/gap.sh
+    ./gap
 
 Windows users should start GAP with the batch file
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -456,12 +456,13 @@ GAP_LDFLAGS += -Wl,--allow-multiple-definition
 # loads that DLL and calls the renamed main function.
 all: bin/$(GAPARCH)/gap.dll
 
-bin/$(GAPARCH)/gap.dll: symlinks libgap.la
+bin/$(GAPARCH)/gap.dll: libgap.la
 	# FIXME: HACK to support kernel extensions; this is necessary
 	# because we don't use `libtool --mode=install` and so we have to
 	# work with the libtool wrappers for shared libraries meant for
 	# using during development, not for what we actually use them for.
 	# See also `LTINSTALL` and `install-libgap`.
+	@$(MKDIR_P) bin/$(GAPARCH)
 	cp .libs/cyggap-*.dll $@
 
 gap$(EXEEXT): libgap.la cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
@@ -929,19 +930,6 @@ ifeq ($(COMPAT_MODE),yes)
 all: bin/gap.sh
 bin/gap.sh: $(srcdir)/cnf/compat/gap.sh.in config.status
 	$(SHELL) ./config.status $@
-
-# regenerate symlinks if necessary
-all: symlinks
-symlinks: FORCE
-	@$(MKDIR_P) bin/$(GAPARCH)
-	@if test -L sysinfo.gap ; then rm -f sysinfo.gap && $(MAKE) sysinfo.gap ; fi
-	@$(srcdir)/cnf/regen-symlink.sh sysinfo.gap sysinfo.gap-default$(ABI)
-	@$(srcdir)/cnf/regen-symlink.sh $(abs_srcdir)/src bin/$(GAPARCH)/src
-	@$(srcdir)/cnf/regen-symlink.sh ../../gac bin/$(GAPARCH)/gac
-	@$(srcdir)/cnf/regen-symlink.sh ../../gap bin/$(GAPARCH)/gap
-	@$(srcdir)/cnf/regen-symlink.sh ../../build/config.h bin/$(GAPARCH)/config.h
-
-.PHONY: symlinks
 
 endif
 

--- a/README.buildsys.md
+++ b/README.buildsys.md
@@ -124,10 +124,7 @@ far off.
 
 Compatibility mode does the following things:
 
-* create a symlink `sysinfo.gap-default$ABI` pointing at `sysinfo.gap`
-* create a `bin/$GAPARCH/config.h` symlink pointing at `build/config.h`
-* create a `bin/$GAPARCH/gac` symlink pointing at `gac`
-* create a `bin/$GAPARCH/src` symlink pointing at `$srcdir/src`
+* create a `bin/gap.sh` shell script invoking `gap`
 * for out-of-tree builds, it creates a `${builddir}/src/compiled.h` file
 * ...
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ packages as possible.
 
 If everything goes well, you should be able to start GAP by executing
 
-    sh bin/gap.sh
+    ./gap
 
 You can also find development versions of some of the GAP packages on
 <https://github.com/gap-packages> resp. on <https://gap-packages.github.io>.

--- a/tst/test-compile/regenerate_tests.sh
+++ b/tst/test-compile/regenerate_tests.sh
@@ -6,7 +6,7 @@ set -e
 # (so for out-of-tree builds, builddir and not srcdir)
 GAPDIR=${GAPDIR:-../..}
 
-gap="$GAPDIR/bin/gap.sh"
+gap="$GAPDIR/gap"
 gac="$GAPDIR/gac"
 for gfile in *.g; do
     echo "Regenerating ${gfile}.out ..."

--- a/tst/test-compile/run_all.sh
+++ b/tst/test-compile/run_all.sh
@@ -10,7 +10,7 @@ GAPDIR=${GAPDIR:-../..}
 rm -rf .libs
 
 retvalue=0
-gap="$GAPDIR/bin/gap.sh"
+gap="$GAPDIR/gap"
 gac="$GAPDIR/gac"
 for gfile in *.g; do
     echo "Now testing ${gfile}"

--- a/tst/testspecial/regenerate_tests.sh
+++ b/tst/testspecial/regenerate_tests.sh
@@ -6,7 +6,7 @@ set -ex
 # (so for out-of-tree builds, builddir and not srcdir)
 GAPDIR=${GAPDIR:-../..}
 
-gap="$GAPDIR/bin/gap.sh"
+gap="$GAPDIR/gap"
 
 echo This script should only be run with a 64-bit GAP
 if command -v parallel >/dev/null 2>&1 ; then

--- a/tst/testspecial/run_all.sh
+++ b/tst/testspecial/run_all.sh
@@ -7,7 +7,7 @@ set -ex
 GAPDIR=${GAPDIR:-../..}
 
 retvalue=0
-gap="$GAPDIR/bin/gap.sh"
+gap="$GAPDIR/gap"
 if "${gap}" -A -b -c 'QuitGap(GAPInfo.BytesPerVariable - 8);'; then
     echo "Running 64-bit special tests"
     tocheck="*.g 64bit/*.g"


### PR DESCRIPTION
These should not be needed anymore with current GAP packages.