### PR TITLE
Add `Exec2`, the "better version of Exec"

### DIFF
--- a/lib/process.gd
+++ b/lib/process.gd
@@ -186,3 +186,5 @@ DeclareOperation( "Process",
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "Exec" );
+
+DeclareGlobalName( "Exec2" );

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1311,19 +1311,20 @@ InstallGlobalFunction( InputFromUser,
 InstallGlobalFunction( OpenExternal, function(filename)
     local file;
     if ARCH_IS_MAC_OS_X() then
-      Exec(Concatenation("open \"",filename,"\""));
+      Exec2("open", filename);
     elif ARCH_IS_WINDOWS() then
-      Exec(Concatenation("cmd /c start \"",filename,"\""));
+      Exec2("cmd", "/c", "start", filename);
     elif ARCH_IS_WSL() then
       # If users pass a URL, make sure if does not get mangled.
       if ForAny(["https://", "http://"], {pre} -> StartsWith(filename, pre)) then
         file := filename;
       else
-        file := Concatenation("$(wslpath -a -w \"",filename,"\")");
+        file := "";
+        Exec2("wslpath", "-a", "-w", filename, OutputTextString(file, false));
       fi;
-      Exec(Concatenation("explorer.exe \"", file, "\""));
+      Exec2("explorer.exe", file);
     else
-      Exec(Concatenation("xdg-open \"",filename,"\""));
+      Exec2("xdg-open", filename);
     fi;
 end );
 


### PR DESCRIPTION
(This is code I wrote some time ago, but I never found time to clean it up enough for inclusion. Due to a recent question in the GAP forum, I thought it might be a good idea to at least upload it here as a draft; perhaps someone else is interested in helping to finish it up? E.g. by coming up with a better name for the new function ;-)

Add a new function `Exec2` which is as easy to use as `Exec` but
much more powerful and less easy to misuse:

- don't pass everything to a shell, thus avoiding compatibility issues due to different shells on different systems (this also has one downside: you can't use redirects like ">/dev/null")
- pass arguments as separate strings, thus avoiding any issues with quoting quotes, quoting spaces, etc.
- return the exit code of the executed command so that one can determine its success or failure; the return value is actually a record to allow returning other data, such as the programs output
- make it very easy to override the input and output streams
- by default, pass no input to the program (instead of passing anything the user might type, as `Exec` does); this can be changed by adding an input stream to the argument list
- by default, capture any output of the program into a string and return it, instead of just printing the output to the console; this can be changed by adding an output stream to the argument list
