### PR TITLE
CI: update some actions to latest version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,10 +152,10 @@ jobs:
       TEST_SUITES: ${{ matrix.test-suites }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: "Set up Python 3.7"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -279,7 +279,7 @@ jobs:
       - name: "Gather coverage data"
         run: ${{ matrix.extra }} dev/ci-gather-coverage.sh
       - name: "Upload coverage data to Codecov"
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       gap-build-version: ${{ steps.get-build.outputs.name }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
           git fetch --tags --force
 
       - name: "Set up Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: "Install Python modules"
         run: pip3 install PyGithub python-dateutil
       - name: "Install latex"
@@ -207,14 +207,14 @@ jobs:
       #   artifact would/could already contain the appropriate packages.
 
       - name: "Clone GAP"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.GAPDEV_DIR }}
 
       - name: "Copy GAP's release scripts to a safe place"
         run: cp -rp ${GAPDEV_DIR}/dev/releases .
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: "Install required Python modules"
@@ -239,7 +239,7 @@ jobs:
       # organisation, and perhaps ultimately it could/should be re-integrated
       # with the original sagemath/sage-windows repository.
       - name: "Clone the Windows installer maker scripts"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ChrisJefferson/sage-windows
           ref: master

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -53,7 +53,7 @@ jobs:
           make bootstrap-pkg-minimal
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v1
+        uses: actions/configure-pages@v2
       - name: Build GAP manuals
         run: |
           make html # we are only intersted in the HTML version


### PR DESCRIPTION
This silences some warnings shown in the GH Actions webinterface.

See also https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
