### PR TITLE
Make documentation of nested sublist extractions more visible

### DIFF
--- a/doc/ref/lists.xml
+++ b/doc/ref/lists.xml
@@ -259,7 +259,8 @@ end;
 This operation implements <E>sublist access</E>.
 For any list, the default method is to loop over the entries in the list
 <A>poss</A>, and to delegate to the element access operation.
-(For the somewhat strange variable name,
+(For nested sublist extractions, cf.&nbsp;<Ref Sect="List Elements"/>.
+For the somewhat strange variable name,
 cf.&nbsp;<Ref Sect="Basic Operations for Lists"/>.)
 </Description>
 </ManSection>


### PR DESCRIPTION
Previously, it was hard to find when only using `?\{\};`.

## Text for release notes

none
