### PR TITLE
Fix regression caused by GNUMakefile.in plus libgap.pc changes

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1263,12 +1263,12 @@ testlibgap: ${LIBGAPTESTS}
 
 # test libgap's pkg-config's libgap version reporting
 testpkgconfigversion: install-libgap
-ifeq ($(shell PKG_CONFIG_PATH=$(DESTDIR)$(libdir)/pkgconfig pkg-config --modversion libgap), $(PACKAGE_VERSION))
-	@echo "pkg-config reports correct version of libgap: "$(PACKAGE_VERSION)
-else
-	@echo "pkg-config does not report version of libgap, or is not installed"
-	exit 1
-endif
+	$(eval PKG_REPORTED_VERSION := $(shell PKG_CONFIG_PATH=$(DESTDIR)$(libdir)/pkgconfig pkg-config --modversion libgap))
+	@echo "pkg-config reports version $(PKG_REPORTED_VERSION)"
+	@if [ $(PKG_REPORTED_VERSION) != $(GAP_VERSION) ] ; then \
+	   echo "reported version does not match GAP_VERSION = $(GAP_VERSION)" ; \
+	   exit 1 ; \
+	fi
 
 # test libgap's pkg-config's libgap flags fetching
 testpkgconfigbuild: install-libgap install-headers

--- a/doc/versiondata.in
+++ b/doc/versiondata.in
@@ -4,7 +4,7 @@ Instead edit either the template file `doc/versiondata.in`, or edit
 `Makefile.rules` (which has code for generating this file), or edit
 `configure.ac` (where the value being substituted come from)
 -->
-<!ENTITY VERSIONNUMBER "@PACKAGE_VERSION@">
+<!ENTITY VERSIONNUMBER "@GAP_VERSION@">
 <!ENTITY RELEASEDAY "@GAP_RELEASEDAY@">
 <!ENTITY RELEASEYEAR "@GAP_RELEASEYEAR@">
-<!ENTITY GAPDIRNAME "@PACKAGE_TARNAME@">
+<!ENTITY GAPDIRNAME "gap-@GAP_VERSION@">


### PR DESCRIPTION
A few symbols were removed from GNUMakefile.in, and the testpkgconfigversion was a bit too eager in evaluating shell code

Hopefully resolves #5113