### PR TITLE
Fix printing of GAP functions containing sublist extractions

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -1105,6 +1105,32 @@ static void PrintIsbList(Expr expr)
 */
 static void PrintElmsList(Expr expr)
 {
+    Expr list = READ_EXPR(expr, 0);
+    Pr("%2>", 0, 0);
+    if (TNUM_EXPR(list) == EXPR_ELMS_LIST || TNUM_EXPR(list) == EXPR_ELMS_LIST_LEV) {
+        Pr("(", 0, 0);
+        PrintExpr(list);
+        Pr(")", 0, 0);
+    } else {
+        PrintExpr(list);
+    }
+    Pr("%<{", 0, 0);
+    PrintExpr(READ_EXPR(expr, 1));
+    Pr("%<}", 0, 0);
+}
+
+
+/****************************************************************************
+**
+*F  PrintElmsListLevel(<expr>) . . print a selection of several elements of a list
+**
+**  'PrintElmsListLevel'  prints the list  elements  expression  <expr> of the   form
+**  '<list>{<positions>}'.
+**
+**  Linebreaks are preferred after the '{'.
+*/
+static void PrintElmsListLevel(Expr expr)
+{
     Pr("%2>", 0, 0);
     PrintExpr(READ_EXPR(expr, 0));
     Pr("%<{", 0, 0);
@@ -2242,7 +2268,7 @@ static Int InitKernel (
     InstallPrintExprFunc( EXPR_ELM_LIST       , PrintElmList);
     InstallPrintExprFunc( EXPR_ELMS_LIST      , PrintElmsList);
     InstallPrintExprFunc( EXPR_ELM_LIST_LEV   , PrintElmListLevel);
-    InstallPrintExprFunc( EXPR_ELMS_LIST_LEV  , PrintElmsList);
+    InstallPrintExprFunc( EXPR_ELMS_LIST_LEV  , PrintElmsListLevel);
     InstallPrintExprFunc( EXPR_ISB_LIST       , PrintIsbList);
 
     // install executors, evaluators, and printers for matrix elements

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -291,4 +291,27 @@ gap> funcloop(x -> (x in x) and x);
 function ( x ) return x in x and x; end
 gap> funcloop(x -> x in (x and x));
 function ( x ) return x in (x and x); end
+
+# nested sublist extractions
+# a single extraction
+gap> funcloop(x -> [ x ]{[ 1 ]});
+function ( x ) return [ x ]{[ 1 ]}; end
+
+# two extractions
+gap> funcloop(x -> ([ x ]{[ 1 ]}){[ 1 ]});
+function ( x ) return ([ x ]{[ 1 ]}){[ 1 ]}; end
+gap> funcloop(x -> [ [ x ] ]{[ 1 ]}{[ 1 ]});
+function ( x ) return [ [ x ] ]{[ 1 ]}{[ 1 ]}; end
+
+# three extractions
+gap> funcloop(x -> (([ x ]{[ 1 ]}){[ 1 ]}){[ 1 ]});
+function ( x ) return (([ x ]{[ 1 ]}){[ 1 ]}){[ 1 ]}; end
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]});
+function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}; end
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}){[ 1 ]}{[ 1 ]});
+function ( x ) return ([ [ x ] ]{[ 1 ]}){[ 1 ]}{[ 1 ]}; end
+
+# four extractions
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}{[ 1 ]});
+function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}{[ 1 ]}; end
 gap> STOP_TEST("function.tst", 1);


### PR DESCRIPTION
* PrintElmsListLevel preserves the old behaviour of PrintElmsList for EXPR_ELMS_LIST_LEV.
* PrintElmsList applies to EXPR_ELMS_LIST and now checks if its first argument is of type EXPR_ELMS_LIST or EXPR_ELMS_LIST_LEV. If yes, the list is put in brackets.

## Text for release notes

see title

## Further details

I'm not sure this works for all cases, but I currently cannot inspect the internals of some cases due to getting a segfault (#5117). From my testing it seems that everything works fine, even for deeply nested cases.

Fixes #5109.
