### PR TITLE
fixed image of trivial space under matrix action

### DIFF
--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -524,16 +524,20 @@ InstallMethod( IsSemiEchelonized,
 ##
 InstallOtherMethod( \*, IsIdenticalObj, [ IsRowSpace, IsMatrix ],
     function( V, mat )
+    if IsTrivial( V ) then
+      return V;
+    fi;
     return LeftModuleByGenerators( LeftActingDomain( V ),
-                            List( GeneratorsOfLeftModule( V ),
-                                  v -> v * mat ) );
+               List( GeneratorsOfLeftModule( V ), v -> v * mat ) );
     end );
 
 InstallOtherMethod( \^, IsIdenticalObj, [ IsRowSpace, IsMatrix ],
     function( V, mat )
+    if IsTrivial( V ) then
+      return V;
+    fi;
     return LeftModuleByGenerators( LeftActingDomain( V ),
-                            List( GeneratorsOfLeftModule( V ),
-                                  v -> v * mat ) );
+               List( GeneratorsOfLeftModule( V ), v -> v * mat ) );
     end );
 
 

--- a/tst/testinstall/vspcrow.tst
+++ b/tst/testinstall/vspcrow.tst
@@ -375,7 +375,7 @@ x_1^6+Z(2^2)*x_1^5+x_1^4+Z(2^2)^2*x_1^3+x_1^2+Z(2^2)*x_1+Z(2)^0
 ##  11. Action of matrices on subspaces
 ##
 gap> v:= TrivialSubspace( GF(3)^2 );;
-gap> g:=GL(2,3).1;
+gap> g:=GL(2,3).1;;
 gap> v^g = v;
 true
 gap> v*g = v;

--- a/tst/testinstall/vspcrow.tst
+++ b/tst/testinstall/vspcrow.tst
@@ -369,4 +369,14 @@ gap> MinimalPolynomial(F, A);
 x_1^6+Z(2^2)*x_1^5+x_1^4+Z(2^2)^2*x_1^3+x_1^2+Z(2^2)*x_1+Z(2)^0
 gap> MinimalPolynomial(F, A);
 x_1^6+Z(2^2)*x_1^5+x_1^4+Z(2^2)^2*x_1^3+x_1^2+Z(2^2)*x_1+Z(2)^0
-gap> STOP_TEST( "vspcrow.tst", 1);
+
+#############################################################################
+##
+##  11. Action of matrices on subspaces
+##
+gap> v:= TrivialSubspace( GF(3)^2 );;
+gap> v^GeneratorsOfGroup( GL(2,3) )[1] = v;
+true
+
+##
+gap> STOP_TEST( "vspcrow.tst" );

--- a/tst/testinstall/vspcrow.tst
+++ b/tst/testinstall/vspcrow.tst
@@ -375,7 +375,10 @@ x_1^6+Z(2^2)*x_1^5+x_1^4+Z(2^2)^2*x_1^3+x_1^2+Z(2^2)*x_1+Z(2)^0
 ##  11. Action of matrices on subspaces
 ##
 gap> v:= TrivialSubspace( GF(3)^2 );;
-gap> v^GeneratorsOfGroup( GL(2,3) )[1] = v;
+gap> g:=GL(2,3).1;
+gap> v^g = v;
+true
+gap> v*g = v;
 true
 
 ##


### PR DESCRIPTION
Up to now, acting via `^` or `*` with a matrix on a vector space with empty generating set caused an eror message.