### PR TITLE
Make sure owner and group in tarballs are set uniformly to 0

### DIFF
--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -16,13 +16,15 @@
 from utils import *
 
 import glob
+import grp
 import gzip
+import json
+import pwd
 import re
 import shutil
 import subprocess
 import sys
 import tarfile
-import json
 
 # Insist on Python >= 3.6 for f-strings and other goodies
 if sys.version_info < (3,6):
@@ -223,7 +225,9 @@ def make_and_record_archive(name, compression, root_dir, base_dir):
 
     filename = f"{name}{ext}"
     notice(f"Creating {filename}")
-    shutil.make_archive(name, compression, root_dir, base_dir)
+    owner = pwd.getpwuid(0).pw_name
+    group = grp.getgrgid(0).gr_name
+    shutil.make_archive(name, compression, root_dir, base_dir, owner = owner, group = group)
     manifest_list.append(filename)
 
 # Create the remaining archives

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -156,6 +156,12 @@ with working_directory(tmpdir + "/" + basename):
     notice("Extracting package tarballs")
     with tarfile.open(tmpdir+"/"+all_packages_tarball) as tar:
         tar.extractall(path="pkg")
+    # for some reason pkg sometimes ends up with permission 0700 so
+    # we make sure to fix that here
+    subprocess.run(["chmod", "0755", "pkg"], check=True)
+    # ensure all files are at readable by everyone
+    subprocess.run(["chmod", "-R", "a+r", "."], check=True)
+
     with tarfile.open(tmpdir+"/"+req_packages_tarball) as tar:
         tar.extractall(path=tmpdir+"/"+req_packages)
 


### PR DESCRIPTION
Fixes #5016

This is not yet complete: it only ensures the owner and group are set to a sane default. But it does nothing to prevent files with 0700 or 0600 access flags. Gotta think whether and how to ensure this. Perhaps a matter of calling `umask`? or iterating over all files recurively and fixing up their flags, somehow?

CC @zickgraf