### PR TITLE
CI: test whether `make install` works with release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,23 @@ jobs:
       - name: "Make archives"
         run: python -u ./dev/releases/make_archives.py
 
+      - name: "Test building GAP from the primary release archive"
+        run: |
+          mkdir -p test-gap-tarball
+          pushd test-gap-tarball
+          tar xvf ../tmp/gap-${{ steps.get-build.outputs.name }}.tar.gz
+          cd gap*
+          # test building GAP
+          ./configure --prefix=/tmp/gapprefix
+          make -j8
+          popd
+
+      - name: "Test 'make install' from the primary release archive"
+        run: |
+          pushd test-gap-tarball/gap*
+          GAPPREFIX=/tmp/gapprefix TEST_SUITES="testmakeinstall" ../../dev/ci.sh
+          popd
+
       # Upload the main GAP .tar.gz file (which includes packages).
       # We only upload this tarball in order to minimise our demand on GitHub's
       # resources, and that is why we also only upload these for the daily cron

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -302,7 +302,10 @@ ifneq (,$(findstring cygwin,$(host_os)))
 else
   ifneq (,$(findstring darwin,$(host_os)))
     GAC_CFLAGS = -fno-common
-    GAC_LDFLAGS = -bundle -bundle_loader $(SYSINFO_GAP)
+    # HACK: we need to point to the real GAP binary, not a shell script
+    # wrapper. We can remove this hack (and once again use SYSINFO_GAP)
+    # once we get rid of the shell script wrapper
+    GAC_LDFLAGS = -bundle -bundle_loader $(SYSINFO_GAP2)
   else
     GAC_CFLAGS = -fPIC
     GAC_LDFLAGS = -shared
@@ -316,6 +319,7 @@ endif
 
 # paths to gap and gac executable
 SYSINFO_GAP = $(abs_builddir)/gap
+SYSINFO_GAP2 = $(abs_builddir)/gap # HACK for bundle_loader support
 SYSINFO_GAC = $(abs_builddir)/gac
 
 
@@ -639,6 +643,7 @@ install-sysinfo: SYSINFO_CPPFLAGS = -I${includedir}/gap $(GAP_DEFINES)
 install-sysinfo: SYSINFO_LDFLAGS = $(ABI_CFLAGS)
 install-sysinfo: SYSINFO_LIBS =
 install-sysinfo: SYSINFO_GAP = $(bindir)/gap
+install-sysinfo: SYSINFO_GAP2 = $(libdir)/gap/gap
 install-sysinfo: SYSINFO_GAC = $(bindir)/gac
 install-sysinfo: GMP_PREFIX =
 install-sysinfo:

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -254,10 +254,8 @@ GAPInput
     cd "$SRCDIR/tst/mockpkg"
     testmockpkg "$GAPPREFIX/bin/gap" "$GAPPREFIX/lib/gap"
 
-    # run testsuite for the resulting GAP, via a little HACK
-    # TODO: should we install the GAP test suite???
-    cp -R $SRCDIR/tst $GAPPREFIX/share/gap/
-    $GAPPREFIX/bin/gap $GAPPREFIX/share/gap/tst/testinstall.g
+    # run testsuite for the resulting GAP
+    $GAPPREFIX/bin/gap --quitonbreak -l ";$SRCDIR" $SRCDIR/tst/testinstall.g
 
     # test integration with pkg-config
     cd "$SRCDIR"


### PR DESCRIPTION
Resolves #5094

Working on it revealed an actual bug in `make install` for macOS (a regression compared to GAP 4.12.0). yay!