### PR TITLE
Signal an error when internal file descriptor limit is reached (at most 256 files can be open at the same time)

### DIFF
--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -649,6 +649,10 @@ DeclareOperation( "InputTextString", [ IsString ] );
 ##  handles windows-style line endings. This means it should <E>not</E> be used for
 ##  binary data. The <Ref BookName="IO" Oper="IO_File" /> function from the <Package>IO</Package>
 ##  package should be used to access binary data.
+##  <P/>
+##  Note: At most 256 files may be open for reading or writing at the same time.
+##  Use <Ref Oper="CloseStream"/> to close the input stream once you have finished
+##  reading from it.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -750,6 +754,10 @@ DeclareOperation( "OutputTextString", [ IsList, IsBool ] );
 ##  otherwise received characters are added at the end of the file.
 ##  <C>OutputGzipFile</C> acts identically to <C>OutputTextFile</C>, except it compresses
 ##  the output with gzip.
+##  <P/>
+##  Note: At most 256 files may be open for reading or writing at the same time.
+##  Use <Ref Oper="CloseStream"/> to close the output stream once you have finished
+##  writing to it.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> # use a temporary directory

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -678,6 +678,7 @@ Int SyFopen(const Char * name, const Char * mode, BOOL transparent_compress)
 
     if ( fid == ARRAY_SIZE(syBuf) ) {
         HashUnlock(&syBuf);
+        ErrorReturnVoid("Too many open files (internal file descriptor limit reached)", 0, 0, "you can 'return;'");
         return (Int)-1;
     }
 

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -1,4 +1,4 @@
-#@local dir,fname,file,line,stream,tmpdir,res
+#@local dir,fname,file,line,stream,tmpdir,res,streams,i
 gap> START_TEST("streams.tst");
 
 #
@@ -208,6 +208,14 @@ gap> WriteByte(stream, 300);
 Error, <byte> must an integer between 0 and 255
 gap> SetPrintFormattingStatus(stream, fail);
 Error, Print formatting status must be true or false
+
+# too many open files
+gap> streams := [ ];;
+gap> for i in [ 1 .. 300 ] do
+>    Add( streams, OutputTextFile( fname, false ) );
+> od;;
+Error, Too many open files (internal file descriptor limit reached)
+gap> Perform( streams, CloseStream );
 
 #
 gap> STOP_TEST( "streams.tst", 1);


### PR DESCRIPTION
and add corresponding notes to the documentation

Rationale: I guess most code does not handle the case that `InputTextFile` or `OutputTextFile` returns `fail` properly, or just prints a generic error message like "Could not open file", which is not very helpful. Thus, making this error explicit significantly simplifies debugging. If one really wants to handle this gracefully, one can look at `InputTextFileStillOpen` and `OutputTextFileStillOpen` to detect if opening a new file would reach the descriptor limit.

## Text for release notes

none