### PR TITLE
call `FreeGeneratorsOfWholeGroup` not `FreeGeneratorsOfFpGroup`

### DIFF
--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -345,12 +345,12 @@ local   filter,  hom,pcgs,imgso,mapi,l,obj_args,p;
   if IsSubgroupFpGroup(G) then
     if HasIsWholeFamily(G) and IsWholeFamily(G) 
       # total on free generators
-      and Set(FreeGeneratorsOfFpGroup(G))=Set(gens,UnderlyingElement)
+      and Set(FreeGeneratorsOfWholeGroup(G))=Set(gens,UnderlyingElement)
       then
         l:=List(gens,UnderlyingElement);
-        p:=List(l,i->Position(FreeGeneratorsOfFpGroup(G),i));
+        p:=List(l,i->Position(FreeGeneratorsOfWholeGroup(G),i));
         # test for duplicate generators, same images
-        if Length(gens)=Length(FreeGeneratorsOfFpGroup(G)) or
+        if Length(gens)=Length(FreeGeneratorsOfWholeGroup(G)) or
           ForAll([1..Length(gens)],x->imgs[x]=imgs[Position(l,l[x])]) then
           filter := filter and IsFromFpGroupStdGensGeneralMappingByImages;
           hom.genpositions:=p;

--- a/tst/testinstall/grpfree.tst
+++ b/tst/testinstall/grpfree.tst
@@ -266,4 +266,15 @@ gap> Group(F.1 ^ 100);
 Group(<1 generator>)
 
 #
+gap> F:= FreeGroup( 2 );;
+gap> F:= Group( GeneratorsOfGroup( F ) );;
+gap> gens:= GeneratorsOfGroup( F );;
+gap> HasIsWholeFamily( F );
+false
+gap> H:= SymmetricGroup( 5 );;
+gap> GroupHomomorphismByImagesNC( F, H, gens, GeneratorsOfGroup( H ) );;
+gap> SetIsWholeFamily( F, true );
+gap> GroupHomomorphismByImagesNC( F, H, gens, GeneratorsOfGroup( H ) );;
+
+#
 gap> STOP_TEST( "grpfree.tst", 1);


### PR DESCRIPTION
This is intended to resolve #5145.
There are groups in `IsSubgroupFpGroup and IsWholeFamily` for which `FreeGeneratorsOfFpGroup` has no method.
(Should such a method perhaps be added?)
The test suite of the `classicpres` package contains examples which run into errors inside the GAP library function DoGGMBINC;
the problems disappear when one calls `FreeGeneratorsOfWholeGroup` instead of `FreeGeneratorsOfFpGroup`.