### PR TITLE
support consistency checks for `Vector`, `Matrix`

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -237,7 +237,9 @@ for the new type of vector or matrix objects.
   <Ref Oper="\[\]" Label="for a vector object and an integer"/>,
 </Item>
 <Item>
-  <Ref Oper="\[\]\:\=" Label="for a vector object and an integer"/>,
+  <Ref Oper="\[\]\:\=" Label="for a vector object and an integer"/>
+  (with consistency checks if the global option <C>check</C> is not set to
+  <K>false</K>),
 </Item>
 <Item>
   <Ref Oper="\&lt;"/> (see <Ref Oper="\&lt;" Label="for two vector objects"/>),
@@ -246,7 +248,9 @@ for the new type of vector or matrix objects.
   <Ref Attr="ConstructingFilter" Label="for a vector object"/>,
 </Item>
 <Item>
-  <Ref Constr="NewVector"/>.
+  <Ref Constr="NewVector"/>
+  (with consistency checks if the global option <C>check</C> is not set to
+  <K>false</K>).
 </Item>
 </List>
 
@@ -268,7 +272,9 @@ for the new type of vector or matrix objects.
   <Ref Oper="MatElm"/>,
 </Item>
 <Item>
-  <Ref Oper="SetMatElm"/>,
+  <Ref Oper="SetMatElm"/>
+  (with consistency checks if the global option <C>check</C> is not set to
+  <K>false</K>),
 </Item>
 <Item>
   <Ref Oper="\&lt;"/> (see <Ref Oper="\&lt;" Label="for two matrix objects"/>),
@@ -280,9 +286,32 @@ for the new type of vector or matrix objects.
   <Ref Attr="CompatibleVectorFilter" Label="for a matrix object"/>,
 </Item>
 <Item>
-  <Ref Constr="NewMatrix"/>.
+  <Ref Constr="NewMatrix"/>
+  (with consistency checks if the global option <C>check</C> is not set to
+  <K>false</K>).
 </Item>
 </List>
+
+<P/>
+
+Methods for the constructors <Ref Constr="NewVector"/> and
+<Ref Constr="NewMatrix"/> must check their arguments for consistency
+(do the given filter and base domain fit together,
+are the entries compatible with the given base domain,
+is the number of matrix entries a multiple of the given number of columns)
+except if the global option <C>check</C> is set to <K>false</K>.
+(See Chapter <Ref Chap="Options Stack"/> for information about global
+options.)
+The same holds for methods for operations that modify mutable vector
+or matrix objects,
+such as <Ref Oper="\[\]\:\=" Label="for a vector object and an integer"/>,
+<Ref Oper="SetMatElm"/>, <Ref Oper="CopySubVector"/>,
+<Ref Oper="CopySubMatrix"/>,
+and for those methods of
+<Ref Oper="Vector" Label="for filter, base domain, and list"/> and
+<Ref Oper="Matrix" Label="for filter, base domain, list, ncols"/>
+that do not delegate to <Ref Constr="NewVector"/> and
+<Ref Constr="NewMatrix"/>, respectively.
 
 </Section>
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -180,6 +180,17 @@ end);
 
 # methods to create vector objects
 
+#############################################################################
+##
+#O  Vector( <filt>, <R>, <list> )
+#O  Vector( <filt>, <R>, <vec> )
+#O  Vector( <R>, <list> )
+#O  Vector( <R>, <vec> )
+#O  Vector( <list>, <vec> )
+#O  Vector( <vec1>, <vec2> )
+##
+##  Compute the missing arguments for 'NewVector' and then call it.
+##
 InstallMethod( Vector,
     [ IsOperation, IsSemiring, IsList ],
     NewVector );
@@ -282,6 +293,8 @@ InstallMethod( ZeroVector,
 #M  Matrix( <M1>, <M2> )
 #M  Matrix( <list>, <ncols> )
 #M  Matrix( <list> )
+##
+##  Compute the missing arguments for 'NewMatrix' and then call it.
 ##
 InstallMethod( Matrix,
   [ IsOperation, IsSemiring, IsList, IsInt ],
@@ -389,6 +402,7 @@ InstallMethod( Matrix,
     # perhaps adjust NewMatrix to take an IsMatrixOrMatrixObj?
     return NewMatrix( ConstructingFilter(example), BaseDomain(example), NrCols(mat), Unpack(mat) );
   end );
+
 
 #
 #

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -646,6 +646,9 @@ DeclareOperation( "ZeroVector", [ IsInt, IsVecOrMatObj ] );
 ##  this list.
 ##  <P/>
 ##  It is <E>not</E> guaranteed that the given list of entries is copied.
+##  <P/>
+##  If the global option <C>Check</C> is set to <K>false</K> then
+##  <Ref Oper="Vector"/> need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -679,6 +682,9 @@ DeclareOperation( "Vector", [ IsList ] );
 ##  the <Ref Attr="BaseDomain" Label="for a vector object"/> <A>R</A>,
 ##  and the entries in <A>list</A>.
 ##  The list <A>list</A> is guaranteed not to be changed by this operation.
+##  <P/>
+##  If the global option <C>Check</C> is set to <K>false</K> then
+##  <Ref Oper="NewVector"/> need not perform consistency checks.
 ##  <P/>
 ##  Similarly, <Ref Constr="NewZeroVector"/> returns a mutable vector object
 ##  of length <A>n</A> which has <A>filt</A> and <A>R</A> as
@@ -725,6 +731,9 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  <P/>
 ##  The corresponding entries must be in or compatible with <A>R</A>.
 ##  If <A>list</A> already contains vector objects, they are copied.
+##  <P/>
+##  If the global option <C>Check</C> is set to <K>false</K> then
+##  <Ref Oper="NewMatrix"/> need not perform consistency checks.
 ##  <P/>
 ##  Similarly, <Ref Constr="NewZeroMatrix"/> returns a mutable zero matrix
 ##  object with <A>m</A> rows and <A>n</A> columns
@@ -1194,7 +1203,7 @@ DeclareOperation( "CompanionMatrix",
 ##  value <A>filt</A>, is defined over the base domain <A>R</A>,
 ##  and has the entries given by the list <A>list</A> or the matrix object
 ##  <A>M</A>, respectively.
-##  Here <A>list</A> can be either a list of plain list that describe the
+##  Here <A>list</A> can be either a list of plain lists that describe the
 ##  entries of the rows, or a flat list of the entries in row major order,
 ##  where <A>ncols</A> defines the number of columns.
 ##  <P/>
@@ -1222,6 +1231,9 @@ DeclareOperation( "CompanionMatrix",
 ##  of <Ref Oper="ShallowCopy"/>.
 ##  If <A>list</A> is a nested list then it is <E>not</E> guaranteed
 ##  that also the entries of <A>list</A> are copied.
+##  <P/>
+##  If the global option <C>Check</C> is set to <K>false</K> then
+##  <Ref Oper="Matrix"/> need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -266,10 +266,9 @@ DeclareAttribute( "CompatibleVectorFilter", IsMatrixOrMatrixObj );
 ##  that contains the <A>list</A><M>[ k ]</M>-th entry of <A>v</A> at
 ##  position <M>k</M>.
 ##  <P/>
-##  It is not specified what happens if <A>i</A> is larger than the length
-##  of <A>v</A>,
-##  or if <A>obj</A> is not in the base domain of <A>v</A>,
-##  or if <A>list</A> contains entries not in the allowed range.
+##  If the global option <C>check</C> is set to <K>false</K> then
+##  <Ref Oper="\[\]\:\=" Label="for a vector object and an integer"/>
+##  need not perform consistency checks.
 ##  <P/>
 ##  Note that the sublist assignment operation <Ref Oper="\{\}\:\="/>
 ##  is left out here since it tempts the programmer to use constructions like
@@ -647,8 +646,9 @@ DeclareOperation( "ZeroVector", [ IsInt, IsVecOrMatObj ] );
 ##  <P/>
 ##  It is <E>not</E> guaranteed that the given list of entries is copied.
 ##  <P/>
-##  If the global option <C>Check</C> is set to <K>false</K> then
-##  <Ref Oper="Vector"/> need not perform consistency checks.
+##  If the global option <C>check</C> is set to <K>false</K> then
+##  <Ref Oper="Vector" Label="for filter, base domain, and list"/>
+##  need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -683,7 +683,7 @@ DeclareOperation( "Vector", [ IsList ] );
 ##  and the entries in <A>list</A>.
 ##  The list <A>list</A> is guaranteed not to be changed by this operation.
 ##  <P/>
-##  If the global option <C>Check</C> is set to <K>false</K> then
+##  If the global option <C>check</C> is set to <K>false</K> then
 ##  <Ref Oper="NewVector"/> need not perform consistency checks.
 ##  <P/>
 ##  Similarly, <Ref Constr="NewZeroVector"/> returns a mutable vector object
@@ -732,7 +732,7 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  The corresponding entries must be in or compatible with <A>R</A>.
 ##  If <A>list</A> already contains vector objects, they are copied.
 ##  <P/>
-##  If the global option <C>Check</C> is set to <K>false</K> then
+##  If the global option <C>check</C> is set to <K>false</K> then
 ##  <Ref Oper="NewMatrix"/> need not perform consistency checks.
 ##  <P/>
 ##  Similarly, <Ref Constr="NewZeroMatrix"/> returns a mutable zero matrix
@@ -852,6 +852,9 @@ DeclareOperation( "Randomize", [ IsRandomSource, IsMatrixOrMatrixObj and IsMutab
 ##  For certain objects like compressed vectors this might be significantly
 ##  more efficient if <A>scols</A> and <A>dcols</A> are ranges
 ##  with increment 1.
+##  <P/>
+##  If the global option <C>check</C> is set to <K>false</K> then
+##  <Ref Oper="CopySubVector"/> need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -954,6 +957,9 @@ DeclareOperation( "MutableCopyMatrix", [ IsMatrixOrMatrixObj ] );
 ##  For certain objects like compressed vectors this might be
 ##  significantly more efficient if <A>scols</A> and <A>dcols</A> are
 ##  ranges with increment 1.
+##  <P/>
+##  If the global option <C>check</C> is set to <K>false</K> then
+##  <Ref Oper="CopySubMatrix"/> need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1017,6 +1023,9 @@ DeclareSynonym( "MatElm", ELM_MAT );
 ##  <A>M</A><C>[ </C><A>row</A><C> ][ </C><A>col</A><C> ]:= </C><A>obj</A>,
 ##  which would first try to access <A>M</A><C>[ </C><A>row</A><C> ]</C>,
 ##  and this is in general not possible.
+##  <P/>
+##  If the global option <C>check</C> is set to <K>false</K> then
+##  <Ref Oper="SetMatElm"/> need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1232,8 +1241,9 @@ DeclareOperation( "CompanionMatrix",
 ##  If <A>list</A> is a nested list then it is <E>not</E> guaranteed
 ##  that also the entries of <A>list</A> are copied.
 ##  <P/>
-##  If the global option <C>Check</C> is set to <K>false</K> then
-##  <Ref Oper="Matrix"/> need not perform consistency checks.
+##  If the global option <C>check</C> is set to <K>false</K> then
+##  <Ref Oper="Matrix" Label="for filter, base domain, list, ncols"/>
+##  need not perform consistency checks.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -50,6 +50,9 @@ InstallMethod( NewVector, "for IsZmodnZVectorRep, a ring, and a list",
       l:=List(l,Int);
     else
       l:=ShallowCopy(l);
+      if ValueOption( "Check" ) <> false and not ForAll( l, IsInt ) then
+        Error( "<l> must be a list of integers or of elements in <basedomain>" );
+      fi;
     fi;
     v := [basedomain,l];
     Objectify(typ,v);

--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -42,17 +42,21 @@ InstallMethod( CompatibleVectorFilter, "zmodnz",
 InstallMethod( NewVector, "for IsZmodnZVectorRep, a ring, and a list",
   [ IsZmodnZVectorRep, IsRing, IsList ],
   function( filter, basedomain, l )
-    local typ, v;
+    local check, typ, v;
+    check:= ValueOption( "check" ) <> false;
+    if check and not ( IsZmodnZObjNonprimeCollection( basedomain ) or
+        ( IsFinite( basedomain ) and IsPrimeField( basedomain ) ) ) then
+      Error( "<basedomain> must be Integers mod <n> for some <n>" );
+    fi;
     typ:=NewType(FamilyObj(basedomain),IsZmodnZVectorRep and IsMutable and
       CanEasilyCompareElements);
     # force list of integers
     if FamilyObj(basedomain)=FamilyObj(l) then
       l:=List(l,Int);
+    elif check and not ForAll( l, IsInt ) then
+      Error( "<l> must be a list of integers or of elements in <basedomain>" );
     else
       l:=ShallowCopy(l);
-      if ValueOption( "Check" ) <> false and not ForAll( l, IsInt ) then
-        Error( "<l> must be a list of integers or of elements in <basedomain>" );
-      fi;
     fi;
     v := [basedomain,l];
     Objectify(typ,v);
@@ -62,7 +66,12 @@ InstallMethod( NewVector, "for IsZmodnZVectorRep, a ring, and a list",
 InstallMethod( NewZeroVector, "for IsZmodnZVectorRep, a ring, and an int",
   [ IsZmodnZVectorRep, IsRing, IsInt ],
   function( filter, basedomain, l )
-    local typ, v;
+    local check, typ, v;
+    check:= ValueOption( "check" ) <> false;
+    if check and not ( IsZmodnZObjNonprimeCollection( basedomain ) or
+        ( IsFinite( basedomain ) and IsPrimeField( basedomain ) ) ) then
+      Error( "<basedomain> must be Integers mod <n> for some <n>" );
+    fi;
     typ:=NewType(FamilyObj(basedomain),IsZmodnZVectorRep and IsMutable and
       CanEasilyCompareElements);
     # represent list as integers
@@ -585,6 +594,9 @@ InstallMethod( CopySubVector, "for two zmodnz vectors and two lists",
   [ IsZmodnZVectorRep, IsZmodnZVectorRep and IsMutable, IsList, IsList ],
   function( a,b,pa,pb )
     # The following should eventually go into the kernel:
+    if ValueOption( "check" ) <> false and a![BDPOS] <> b![BDPOS] then
+      Error( "<a> and <b> have different base domains" );
+    fi;
     b![ELSPOS]{pb} := a![ELSPOS]{pa};
   end );
 
@@ -603,7 +615,13 @@ InstallMethod( NewMatrix,
   "for IsZmodnZMatrixRep, a ring, an int, and a list",
   [ IsZmodnZMatrixRep, IsRing, IsInt, IsList ],
   function( filter, basedomain, rl, l )
-    local nd, filterVectors, m, e, filter2, i;
+    local check, nd, filterVectors, m, e, filter2, i;
+
+    check:= ValueOption( "check" ) <> false;
+    if check and not ( IsZmodnZObjNonprimeCollection( basedomain ) or
+        ( IsFinite( basedomain ) and IsPrimeField( basedomain ) ) ) then
+      Error( "<basedomain> must be Integers mod <n> for some <n>" );
+    fi;
 
     # If applicable then replace a flat list 'l' by a nested list
     # of lists of length 'rl'.
@@ -642,7 +660,14 @@ InstallMethod( NewZeroMatrix,
   "for IsZmodnZMatrixRep, a ring, and two ints",
   [ IsZmodnZMatrixRep, IsRing, IsInt, IsInt ],
   function( filter, basedomain, rows, cols )
-    local m,i,e,filter2;
+    local check, m,i,e,filter2;
+
+    check:= ValueOption( "check" ) <> false;
+    if check and not ( IsZmodnZObjNonprimeCollection( basedomain ) or
+        ( IsFinite( basedomain ) and IsPrimeField( basedomain ) ) ) then
+      Error( "<basedomain> must be Integers mod <n> for some <n>" );
+    fi;
+
     filter2 := IsZmodnZVectorRep;
     m := 0*[1..rows];
     e := NewVector(filter2, basedomain, []);
@@ -977,6 +1002,9 @@ InstallMethod( CopySubMatrix, "for two zmodnz matrices and four lists",
     IsList, IsList, IsList, IsList ],
   function( m, n, srcrows, dstrows, srccols, dstcols )
     local i;
+    if ValueOption( "check" ) <> false and m![BDPOS] <> n![BDPOS] then
+      Error( "<m> and <n> have different base domains" );
+    fi;
     # This eventually should go into the kernel without creating
     # a intermediate objects:
     for i in [1..Length(srcrows)] do
@@ -1009,6 +1037,10 @@ InstallMethod( MatElm, "for a zmodnz matrix and two positions",
 InstallMethod( SetMatElm, "for a zmodnz matrix, two positions, and an object",
   [ IsZmodnZMatrixRep and IsMutable, IsPosInt, IsPosInt, IsObject ],
   function( m, row, col, ob )
+    if ValueOption( "check" ) <> false and
+       not ( IsInt( ob ) or ob in BaseDomain( m ) ) then
+      Error( "<ob> must be an integer or in the base domain of <m>" );
+    fi;
     m![ROWSPOS][row]![ELSPOS][col] := Int(ob);
   end );
 

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -43,6 +43,9 @@ InstallMethod( NewVector, "for IsPlistVectorRep, a ring, and a list",
   [ IsPlistVectorRep, IsRing, IsList ],
   function( filter, basedomain, l )
     local typ, v;
+    if ValueOption( "Check" ) <> false and not IsSubset( basedomain, l ) then
+      Error( "the elements in <l> must lie in <basedomain>" );
+    fi;
     typ := MakePlistVectorType(basedomain,IsPlistVectorRep);
     v := [basedomain,ShallowCopy(l)];
     Objectify(typ,v);
@@ -63,7 +66,9 @@ InstallMethod( NewMatrix,
   "for IsPlistMatrixRep, a ring, an int, and a list",
   [ IsPlistMatrixRep, IsRing, IsInt, IsList ],
   function( filter, basedomain, rl, l )
-    local nd, filterVectors, m, e, filter2, i;
+    local check, nd, filterVectors, m, e, filter2, i;
+
+    check:= ValueOption( "Check" ) <> false;
 
     # If applicable then replace a flat list 'l' by a nested list
     # of lists of length 'rl'.
@@ -84,6 +89,9 @@ InstallMethod( NewMatrix,
             m[i] := ShallowCopy(l[i]);
         else
             m[i] := NewVector( filterVectors, basedomain, l[i] );
+        fi;
+        if check and Length( m[i] ) <> rl then
+          Error( "the rows of <m> must have length <rl>" );
         fi;
     od;
     e := NewVector(filterVectors, basedomain, []);

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -43,7 +43,7 @@ InstallMethod( NewVector, "for IsPlistVectorRep, a ring, and a list",
   [ IsPlistVectorRep, IsRing, IsList ],
   function( filter, basedomain, l )
     local typ, v;
-    if ValueOption( "Check" ) <> false and not IsSubset( basedomain, l ) then
+    if ValueOption( "check" ) <> false and not IsSubset( basedomain, l ) then
       Error( "the elements in <l> must lie in <basedomain>" );
     fi;
     typ := MakePlistVectorType(basedomain,IsPlistVectorRep);
@@ -68,7 +68,7 @@ InstallMethod( NewMatrix,
   function( filter, basedomain, rl, l )
     local check, nd, filterVectors, m, e, filter2, i;
 
-    check:= ValueOption( "Check" ) <> false;
+    check:= ValueOption( "check" ) <> false;
 
     # If applicable then replace a flat list 'l' by a nested list
     # of lists of length 'rl'.
@@ -835,6 +835,13 @@ InstallMethod( MatElm, "for a plist matrix and two positions",
 InstallMethod( SetMatElm, "for a plist matrix, two positions, and an object",
   [ IsPlistMatrixRep and IsMutable, IsPosInt, IsPosInt, IsObject ],
   function( m, row, col, ob )
+    if ValueOption( "check" ) <> false then
+      if not ob in BaseDomain( m ) then
+        Error( "<ob> must lie in the base domain of <m>" );
+      elif col > m![RLPOS] then
+        Error( "<col> must be at most <m>![RLPOS]" );
+      fi;
+    fi;
     m![ROWSPOS][row]![ELSPOS][col] := ob;
   end );
 

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1094,7 +1094,7 @@ InstallMethod( BaseField, "for a compressed 8bit vector",
 InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
   [ Is8BitVectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
-    if not Size(f) in [3..256] then
+    if ValueOption( "Check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitVectorRep only supports base fields with 3 to 256 elements");
     fi;
     return CopyToVectorRep(l,Size(f));
@@ -1116,7 +1116,7 @@ InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
   [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsList ],
   function( filter, f, rl, l )
     local m;
-    if not Size(f) in [3..256] then
+    if ValueOption( "Check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");
     fi;
     m := List(l,ShallowCopy);

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1094,7 +1094,7 @@ InstallMethod( BaseField, "for a compressed 8bit vector",
 InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
   [ Is8BitVectorRep, IsField and IsFinite, IsList ],
   function( filter, f, l )
-    if ValueOption( "Check" ) <> false and not Size(f) in [3..256] then
+    if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitVectorRep only supports base fields with 3 to 256 elements");
     fi;
     return CopyToVectorRep(l,Size(f));
@@ -1116,7 +1116,7 @@ InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
   [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsList ],
   function( filter, f, rl, l )
     local m;
-    if ValueOption( "Check" ) <> false and not Size(f) in [3..256] then
+    if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");
     fi;
     m := List(l,ShallowCopy);

--- a/tst/testinstall/MatrixObj/Eigenvalues.tst
+++ b/tst/testinstall/MatrixObj/Eigenvalues.tst
@@ -2,7 +2,7 @@ gap> mat := [[1,2,1],[1,0,1],[0,0,1]];
 [ [ 1, 2, 1 ], [ 1, 0, 1 ], [ 0, 0, 1 ] ]
 gap> Eigenvalues(Rationals,mat);
 [ 2, 1, -1 ]
-gap> matObj1 := NewMatrix(IsPlistMatrixRep,GF(5),3,mat);
+gap> matObj1 := NewMatrix(IsPlistMatrixRep,GF(5),3,mat*Z(5)^0);
 <3x3-matrix over GF(5)>
 gap> Eigenvalues(GF(5),matObj1);
 [ Z(5)^2, Z(5)^0, Z(5) ]


### PR DESCRIPTION
The idea is to admit/force consistency checks in the constructions of vector and matrix objects, via `Vector`, `NewVector`, `Matrix`, `NewMatrix`:
One either may want to make sure that the given arguments are consistent (e.g., the entries are really in the given ring, the intended shape of a matrix fits to the given number of columns, and the entries also fit to the intended representation) or one wants to omit such checks if possible.

Some problems have been described in #4884, #5133, #5135.
(Consistency checks will also be needed in operations that change existing vector and matrix objects, such as assignments via `:=`.)

I propose to use a global option `Check` that is supported by `Vector`, `NewVector`, `Matrix`, and `NewMatrix`, as follows:
If `Check` is `false` then the code for methods of these operations is allowed to omit consistency checks, otherwise consistency checks are recommended for methods of `NewVector` and `NewMatrix`.

(Before that, I had tried the idea to introduce new operations `VectorNC` and `NewVectorNC` (likewise for matrices) such that
- `Vector` computes the necessary data for calling `NewVector`,
- `VectorNC` computes the necessary data for calling `NewVectorNC`,
- `NewVector` first checks for consistency and then calls `NewVectorNC`.
Up to now, each implementation of a new type of vector objects must provide a `NewVector` method. After the change, a `NewVectorNC` method would be needed for each type of vector objects.
Due to the fact that `NewVector` and `NewVectorNC` must be constructors (in the sense of GAP, i. e., they get created with `DeclareConstructor`), we cannot have one default method for `NewVector` with the above behaviour.
Thus each implementation of a new type of vector objects would have to provide also a `NewVector` method.
This idea does not look sensible.)