### PR TITLE
CI: consistently use Python 3.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,10 +154,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: "Set up Python 3.7"
+      - name: "Set up Python"
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - uses: gap-actions/setup-cygwin@v1
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: "Set up Python"
         uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
       - name: "Install Python modules"
         run: pip3 install PyGithub python-dateutil
       - name: "Install latex"
@@ -233,6 +235,8 @@ jobs:
 
       - uses: actions/setup-python@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          python-version: 3.9
 
       - name: "Install required Python modules"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Why 3.9? Arbitrary... not too old, not too new.

This fixes warnings issues by GitHub on our action runs.