### PR TITLE
Switch (Set)MatElm with `[,]` resp. `[,]:=`

### DIFF
--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -979,8 +979,8 @@ DeclareOperation( "CopySubMatrix",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperationKernel( "MatElm", [ IsMatrixOrMatrixObj, IS_INT, IS_INT ], ELM_MAT );
-DeclareSynonym( "[,]", ELM_MAT );
+DeclareOperationKernel( "[,]", [ IsMatrixOrMatrixObj, IS_INT, IS_INT ], ELM_MAT );
+DeclareSynonym( "MatElm", ELM_MAT );
 
 
 #############################################################################
@@ -1012,14 +1012,14 @@ DeclareSynonym( "[,]", ELM_MAT );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperationKernel( "SetMatElm", [ IsMatrixOrMatrixObj, IsInt, IsInt, IsObject ],
+DeclareOperationKernel( "[,]:=", [ IsMatrixOrMatrixObj, IsInt, IsInt, IsObject ],
     ASS_MAT );
 #T We want to require also 'IsMutable' for the first argument,
 #T but some package may have installed methods without this requirement.
 #T Note that if we declare the operation twice, once with requirement
 #T 'IsMutable' and once without, each method installation will show
 #T a complaint that it matches more than one declaration.
-DeclareSynonym( "[,]:=", ASS_MAT );
+DeclareSynonym( "SetMatElm", ASS_MAT );
 
 
 #############################################################################

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -337,17 +337,17 @@ gap> l := [,[,4]];
 [ , [ , 4 ] ]
 gap> l[0,1];  # row is out of bounds
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `MatElm' on 3 arguments
+Error, no 1st choice method found for `[,]' on 3 arguments
 gap> l[1,1];  # row is in bounds but missing
 Error, Matrix Element: <mat>[1] must have an assigned value
 gap> l[2,1];  # row is there but entry is missing
 Error, Matrix Element: <mat>[2,1] must have an assigned value
 gap> l[3,1];  # row is out of bounds
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `MatElm' on 3 arguments
+Error, no 1st choice method found for `[,]' on 3 arguments
 gap> l[2,0];  # column is out of bounds
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `MatElm' on 3 arguments
+Error, no 1st choice method found for `[,]' on 3 arguments
 gap> l[2,2];  # OK
 4
 gap> l[2,3];  # column is out of bounds
@@ -358,14 +358,14 @@ gap> l;
 [ , [ , 4 ] ]
 gap> l[0,1] := 3; # error, row out of bounds
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `SetMatElm' on 4 arguments
+Error, no 1st choice method found for `[,]:=' on 4 arguments
 gap> l[1,1] := 3; # error, row is missing
 Error, Matrix Assignment: <mat>[1] must have an assigned value
 gap> l[2,1] := 3; # OK
 3
 gap> l[3,1] := 3; # error, row out of bounds
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `SetMatElm' on 4 arguments
+Error, no 1st choice method found for `[,]:=' on 4 arguments
 gap> l;
 [ , [ 3, 4 ] ]
 gap> l[2,1];

--- a/tst/testspecial/bad-array-double-1.g.out
+++ b/tst/testspecial/bad-array-double-1.g.out
@@ -4,7 +4,7 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `MatElm' on 3 arguments at GAPROOT/lib/methsel2.g:LINE called from
+Error, no 1st choice method found for `[,]' on 3 arguments at GAPROOT/lib/methsel2.g:LINE called from
 return "abc"[1, 1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5


### PR DESCRIPTION
This should only affect printing, and is for consistency with `[]` and `[]:=`.

Not sure whether this is a good or a bad idea...