### PR TITLE
Fix indentation when printing EXPR_ELM_MAT or EXPR_ELM_LIST_LEVEL

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -1055,7 +1055,7 @@ static void PrintElmMat(Expr expr)
     PrintExpr(READ_EXPR(expr, 0));
     Pr("%<[", 0, 0);
     PrintExpr(READ_EXPR(expr, 1));
-    Pr("%<, %<", 0, 0);
+    Pr("%<, %>", 0, 0);
     PrintExpr(READ_EXPR(expr, 2));
     Pr("%<]", 0, 0);
 }
@@ -1069,7 +1069,7 @@ static void PrintElmListLevel(Expr expr)
     Pr("%<[", 0, 0);
     PrintExpr(READ_EXPR(expr, 1));
     for (i = 2; i <= narg; i++) {
-        Pr("%<, %<", 0, 0);
+        Pr("%<, %>", 0, 0);
         PrintExpr(READ_EXPR(expr, i));
     }
     Pr("%<]", 0, 0);

--- a/tst/testinstall/listindex.tst
+++ b/tst/testinstall/listindex.tst
@@ -139,8 +139,8 @@ function( a ) ... end
 gap> Print(foo,"\n");
 function ( a )
     return [ a[2, 3], o[4, 5], function (  )
-          return [ a[6, 7], o[8, 9] ];
-  end ];
+              return [ a[6, 7], o[8, 9] ];
+          end ];
 end
 gap> res := foo(o);
 ELM_MAT [2,3]
@@ -375,6 +375,38 @@ gap> l[2,1] := 2;;
 Error, List Assignment: <list> must be a mutable list
 gap> l;
 [ , [ 3, 4 ] ]
+
+# test indentation
+gap> foo := function( x )
+>    local a, b, c;
+>    a := x[1, 1];
+>    b := x[1, 1];
+>    c := x[1, 1];
+>    return 1;
+> end;;
+gap> Print(foo,"\n");
+function ( x )
+    local a, b, c;
+    a := x[1, 1];
+    b := x[1, 1];
+    c := x[1, 1];
+    return 1;
+end
+gap> foo := function( x )
+>    local a, b, c;
+>    a := x{[ 1 ]}[1, 1];
+>    b := x{[ 1 ]}[1, 1];
+>    c := x{[ 1 ]}[1, 1];
+>    return 1;
+> end;;
+gap> Print(foo,"\n");
+function ( x )
+    local a, b, c;
+    a := x{[ 1 ]}[1, 1];
+    b := x{[ 1 ]}[1, 1];
+    c := x{[ 1 ]}[1, 1];
+    return 1;
+end
 
 # that's all, folks
 gap> STOP_TEST( "listindex.tst", 1);


### PR DESCRIPTION
See testfile for examples.

## Text for release notes

none

## Further details

I have no deep understanding of the indentation modifiers (`%>`, `%<`), but I guess they should be balanced. Maybe someone with more knowledge about this could add an easy check that after each `Print...` the indentation level is the same as before?