### PR TITLE
buildsys: better solution for src/compiled.h

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -656,8 +656,11 @@ install-headers: $(FFDATA_H) build/version.h
 	$(INSTALL) -m 0644 $(builddir)/build/version.h $(DESTDIR)$(includedir)/gap
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(includedir)/gap/hpc
 	$(INSTALL) -m 0644 $(srcdir)/src/hpc/*.h $(DESTDIR)$(includedir)/gap/hpc
-	# Create a symlink to support packages using `#include "src/compiled.h"`
-	ln -sfn . $(DESTDIR)$(includedir)/gap/src
+	# Create fake "src/compiled.h" header which includes the real one; for
+	# compatibility with GAP packages still using `#include "src/compiled.h"`
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(includedir)/gap/src
+	@echo "#include \"$(includedir)/gap/compiled.h\"" > $(DESTDIR)$(includedir)/gap/src/compiled.h
+	chmod 0644 $(DESTDIR)$(includedir)/gap/src/compiled.h
 
 install-libgap: libgap.la libgap.pc
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)


### PR DESCRIPTION
So far `make install` created a symlink from `$(includedir)/gap/src` to `$(includedir)/gap` to ensure compatibility with GAP packages that still `#include "src/compiled.h"`.

This is something various downstream packagers for Linux distros don't like, as it results in `$(includedir)/gap/src`, `$(includedir)/gap/src/src`, `$(includedir)/gap/src/src/src`, ... all being valid paths.

This patch implements a different solution, which we actually already use for our "compatibility mode" when doing out of tree builds: in `configure.ac` we have this code:
```
            AC_CONFIG_COMMANDS([src/compiled.h],
                [
                echo "#include \"$ac_abs_top_srcdir/src/compiled.h\"" > src/compiled.h
                ])
```
