### PR TITLE
Performance additions / new method for `MinimalGeneratingSet`

### DIFF
--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -51,7 +51,7 @@ BindGlobal("HashKeyWholeBag", {x,y} -> HASHKEY_BAG(x,y,0,-1));
 
 #############################################################################
 ##
-#M  DenseIntKey(<objcol>)
+#M  SparseIntKey(<objcol>)
 ##
 InstallMethod(SparseIntKey,"for finite Gaussian row spaces",true,
     [ IsFFECollColl and IsGaussianRowSpace,IsObject ], 0,
@@ -128,6 +128,25 @@ local f,n,bytelen,data,qq,i;
             return sy;
            end;
   fi;
+end);
+
+#############################################################################
+##
+#M  SparseIntKey(<objcol>)
+##
+InstallMethod(SparseIntKey,"for bounded tuples",true,
+    [ IsList,IsList and IsCyclotomicCollection ], 0,
+function(m,v)
+local c,t;
+  if Length(m)<>3 or m[1]<>"BoundedTuples" then
+    TryNextMethod();
+  fi;
+  t:=Maximum(m[2])+1;
+  c:=[1,Maximum(m[2])+1];
+  return function(a)
+    return a*c;
+  end;
+
 end);
 
 SparseIntKeyVecListAndMatrix:=function(d,m)

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -2181,12 +2181,10 @@ DeclareAttribute( "LargestElementGroup", IsGroup );
 ##  <Description>
 ##  returns a generating set of <A>G</A> of minimal possible length.
 ##  <P/>
-##  Note that &ndash;apart from special cases&ndash; currently there are only
-##  efficient methods known to compute minimal generating sets of finite
-##  solvable groups and of finitely generated nilpotent groups.
-##  Hence so far these are the only cases for which methods are available.
-##  The former case is covered by a method implemented in the &GAP; library,
-##  while the second case requires the package <Package>Polycyclic</Package>.
+##  Note that only methods for finite groups, solvable groups, or finitely
+##  generated nilpotent groups are available (the latter through the
+##  <Package>Polycyclic</Package> package) and that
+##  calculations for nonsolvable finite groups of higher rank can be expensive.
 ##  <P/>
 ##  If you do not really need a minimal generating set, but are satisfied
 ##  with getting a reasonably small set of generators, you better use

--- a/lib/grplatt.gd
+++ b/lib/grplatt.gd
@@ -577,3 +577,9 @@ DeclareOperation("MinimalFaithfulPermutationRepresentation",
 DeclareGlobalFunction("DescSubgroupIterator");
 
 DeclareGlobalFunction("SubgroupConditionAbove");
+
+# Utility function 
+# MinimalInclusionsGroups(l)
+# returns a list of all inclusion indices [a,b] where l[a] is maximal subgroup
+# of l[b].
+DeclareGlobalFunction("MinimalInclusionsGroups");

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3737,3 +3737,36 @@ local divs,limit,mode,l,process,done,bound,maxer,prime;
              end));
 end);
 
+# Utility function 
+# MinimalInclusionsGroups(l)
+# returns a list of all inclusion indices [a,b] where l[a] is maximal subgroup
+# of l[b].
+InstallGlobalFunction(MinimalInclusionsGroups,function(l)
+local s,p,incl,cont,i,j,done;
+  # sort increasing size
+  s:=List(l,Size);
+  p:=Sortex(s);
+  l:=Permuted(l,p);
+  s:=List(l,Size);
+  incl:=[];
+  cont:=[];
+  for i in [Length(l),Length(l)-1..1] do
+    # those we know it will be in
+    done:=[i];
+    for j in [i+1..Length(l)] do
+      if not j in done and s[j]>s[i] and s[j] mod s[i]=0 then
+        if IsSubset(l[j],l[i]) then
+          Add(incl,[i,j]);
+          done:=Union(done,cont[j]); 
+        fi;
+      fi;
+    od;
+    cont[i]:=done;
+  od;
+  p:=p^-1;
+  incl:=List(incl,x->OnTuples(x,p));
+  Sort(incl);
+  return incl;
+end);
+
+

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -3563,6 +3563,23 @@ end);
 ##
 #M  DomainForAction( <pnt>, <acts>,<act> )
 ##
+InstallMethod(DomainForAction,"permutations on lists of integers",true,
+  [IsList,IsListOrCollection and IsPermCollection,IsFunction],0,
+function(pnt,acts,act)
+  local m;
+  if not (Length(pnt)>0 and ForAll(pnt,IsPosInt) and
+    (act=OnSets or act=OnPoints or act=OnRight or act=\^)) then
+    TryNextMethod();
+  fi;
+  m:=Maximum(Maximum(pnt),LargestMovedPoint(acts));
+  # workaround to avoid creating formal objects of bounded tuples
+  return ["BoundedTuples",[1..m],Length(pnt)];
+end);
+
+#############################################################################
+##
+#M  DomainForAction( <pnt>, <acts>,<act> )
+##
 InstallMethod(DomainForAction,"default: fail",true,
   [IsObject,IsListOrCollection,IsFunction],0,
 function(pnt,acts,act)

--- a/tst/testbugfix/2022-09-09-MinimalGeneratingSet.tst
+++ b/tst/testbugfix/2022-09-09-MinimalGeneratingSet.tst
@@ -1,5 +1,4 @@
 gap> G:=Group((1,2),(2,3),(3,4));;
 gap> H:=Image(IsomorphismFpGroup(G));;
 gap> MinimalGeneratingSet(H);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 4th choice method found for `MinimalGeneratingSet' on 1 arguments
+[ F1^-1*F2*F1^-1*F3^-1, F1^-1*F2^-1*F3^-1 ]

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -140,5 +140,10 @@ true
 gap> Length(ConjugacyClasses(PSL(2,64)));
 65
 
+# MinimalGeneratingSet
+gap> AllTransitiveGroups(NrMovedPoints,12,
+> x->Length(MinimalGeneratingSet(x)),4);
+[ [3^4:2^3]E(4) ]
+
 #
 gap> STOP_TEST( "permgrp.tst", 1);

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -140,10 +140,14 @@ true
 gap> Length(ConjugacyClasses(PSL(2,64)));
 65
 
-# MinimalGeneratingSet
+# MinimalGeneratingSet -- factor 400 speedup
 gap> AllTransitiveGroups(NrMovedPoints,12,
 > x->Length(MinimalGeneratingSet(x)),4);
 [ [3^4:2^3]E(4) ]
+
+# MinimalFaithfulPermutationDegree
+gap>  MinimalFaithfulPermutationDegree(SmallGroup(5^6,33));
+55
 
 #
 gap> STOP_TEST( "permgrp.tst", 1);


### PR DESCRIPTION
This PR adds:

- General method for `MinimalGeneratingSet` for finite groups
- Better method for `MinimalFaithfulPermutationDegree`
- Action of permutations on integer lists use hashing (for speedup, helps with #5040 )
- KB rewriting performs more efficiently (resolves #5045 )
- Cleaner code/result for RWS for simple, based on BN pairs.