### PR TITLE
Emscripten

### DIFF
--- a/etc/emscripten/build.sh
+++ b/etc/emscripten/build.sh
@@ -90,4 +90,4 @@ cp native-build/build/c_*.c native-build/build/ffdata.* src/
 
 # The EXEEXT is usually for windows, but here it lets us set GAP's extension,
 # which lets us produce a html page to run GAP in
-emmake make -j8 LDFLAGS="--preload-file pkg --preload-file lib --preload-file grp -s ASYNCIFY=1 -sTOTAL_STACK=32mb -sASYNCIFY_STACK_SIZE=32000000 -sINITIAL_MEMORY=2048mb -O2" EXEEXT=".html"
+emmake make -j8 LDFLAGS="--preload-file pkg --preload-file lib --preload-file grp --preload-file tst -s ASYNCIFY=1 -sTOTAL_STACK=32mb -sASYNCIFY_STACK_SIZE=32000000 -sINITIAL_MEMORY=2048mb -O2" EXEEXT=".html"

--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -54,6 +54,15 @@
 */
 UInt SyTime(void)
 {
+#ifdef EMSCRIPTEN
+    // Emscripten's standard library always returns the same values
+    // for getrusage, which makes some GAP functions enter an
+    // infinite loop, as they use this function to try running
+    // for some period of time. Use NanosecondsSinceEpoch() as
+    // a substitute (it is not perfect, as NanosecondsSinceEpoch()
+    // is walltime, while RUSAGE_SELF is CPU time).
+    return SyNanosecondsSinceEpoch()/1000000000;
+#else
     struct rusage buf;
 
     if (getrusage(RUSAGE_SELF, &buf)) {
@@ -62,6 +71,7 @@ UInt SyTime(void)
                      (Int)strerror(errno), (Int)errno);
     }
     return buf.ru_utime.tv_sec * 1000 + buf.ru_utime.tv_usec / 1000;
+#endif
 }
 
 


### PR DESCRIPTION
This PR switches `SyTime()` to use `NanosecondsSinceEpoch` in EMSCRIPTEN.

`SyTime` was previously broken, for two reasons:

1) Emscripten has a stack corruption bug when you call `getrusage` (but I don't plan on working around this, as it will get fixed soon).

2) Even after that is fixed, it just returns a fixed value at the moment.

Various bits of GAP expect `SyTime` to progress -- some standard library functions enter an infinite loop for example. We do have an option to avoid this problem (`ReproducableBehaviour`), but I thought making `SyTime` return something useful (even if it is wall time rather than CPU time) was the simplest and most useful fix.

This PR also adds the `tst` directory to the standard distributed files -- this makes it much bigger but also makes it easy to run the tests.

After this PR, GAP under emscripten passes all tests in testinstall except for those which involve temporary directory, or spawning processes.