### PR TITLE
Normalize package paths to always contain a trailing slash

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -236,6 +236,8 @@ BindGlobal( "AddPackageInfos", function( files, pkgdir, ignore )
               " (user preference PackagesToIgnore)" ), "GAP" );
         else
           record.InstallationPath:= Filename( [ pkgdir ], file[2] );
+          # normalize to include trailing "/"
+          record.InstallationPath:= Filename( [ Directory( record.InstallationPath ) ], "" );
           if not IsBound( record.PackageDoc ) then
             record.PackageDoc:= [];
           elif IsRecord( record.PackageDoc ) then
@@ -1746,7 +1748,8 @@ InstallGlobalFunction( SetPackagePath, function( pkgname, pkgpath )
     pkgname:= LowercaseString( pkgname );
     NormalizeWhitespace( pkgname );
     if IsBound( GAPInfo.PackagesLoaded.( pkgname ) ) then
-      if GAPInfo.PackagesLoaded.( pkgname )[1] = pkgpath then
+      # compare using `Directory` to expand "~" and add trailing "/"
+      if Directory( GAPInfo.PackagesLoaded.( pkgname )[1] ) = Directory( pkgpath ) then
         return;
       fi;
       Error( "another version of package ", pkgname, " is already loaded" );


### PR DESCRIPTION
`SetPackagePath` always appends a trailing "/" to the installation path of a package while `AddPackageInfos` did not before this PR. This could lead to the following error:

```gap
gap> SetPackagePath( "cap", GAPInfo.PackagesInfo.cap[1].InstallationPath );
gap> LoadPackage( "CAP", false );
true
gap> ExtendRootDirectories( [ "/tmp/some/dir" ] );
gap> SetPackagePath( "cap", GAPInfo.PackagesInfo.cap[1].InstallationPath );
Error, another version of package cap is already loaded at .../lib/package.gi:1752
brk> GAPInfo.PackagesLoaded.( pkgname )[1];
".../.gap/pkg/CAP_project/CAP/"
brk> pkgpath;
".../.gap/pkg/CAP_project/CAP"
```
i.e. an error is signaled because the installation path differs by a trailing slash.

This PR does two things to prevent this:
1. It normalizes the installation path in `AddPackageInfos` to also include a trailing slash.
2. It uses `Directory` in the comparison which triggers the error.

Both changes would fix the error on their own, but I think both are sensible in general:

1. Being consistent is always a good thing.
2. `pkgpath` is a user input, so normalizing it is a good idea anyway (as users might enter paths including "~" or with or without trailing slashes).

## Text for release notes

none
