### PR TITLE
Quit GAP with non-zero exit code if processing init files fails

### DIFF
--- a/doc/ref/run.xml
+++ b/doc/ref/run.xml
@@ -403,7 +403,10 @@ before the first prompt is  printed. Filenames ending with <C>.tst</C>
 are processed by <Ref Func="Test" />, all other files by <Ref Oper="Read" />.
 These files and also commands specified via the <C>-c</C> option are processed
 in the order in which they appear on the command line.
-If a file cannot be opened &GAP; will print an error message and will abort.
+If a file cannot be opened or if executing the code in it raises an error,
+then the usual error handling for <Ref Oper="Read" /> respectively
+<Ref Func="Test" /> kicks in. If this enters a break loop, then exiting that
+break loop also exits &GAP;.
 </Item>
 </List>
 <P/>

--- a/lib/init.g
+++ b/lib/init.g
@@ -946,36 +946,15 @@ fi;
 ResumeMethodReordering();
 
 BindGlobal( "ProcessInitFiles", function(initFiles)
-    local i, f, status;
+    local i, f;
     for i in [1..Length(initFiles)] do
         f := initFiles[i];
         if IsRecord(f) then
-            status := READ_NORECOVERY(InputTextString(f.command));
+            Read(InputTextString(f.command));
         elif EndsWith(f, ".tst") then
             Test(f);
-            status := true;
         else
-            status := READ_NORECOVERY(f);
-        fi;
-        if status = fail then
-            if IsRecord(f) then
-                PRINT_TO( "*errout*", "Executing command \"", f.command,
-                    "\" has been aborted.\n");
-            else
-                PRINT_TO( "*errout*", "Reading file \"", f,
-                    "\" has been aborted.\n");
-            fi;
-            if i < Length (initFiles) then
-                PRINT_TO( "*errout*",
-                    "The remaining files or commands on the command line will not be read.\n" );
-            fi;
-            break;
-        elif status = false then
-            if IsRecord(f) then
-                PRINT_TO( "*errout*", "Could not execute command \"", f.command, "\".\n" );
-            else
-                PRINT_TO( "*errout*", "Could not read file \"", f, "\".\n" );
-            fi;
+            Read(f);
         fi;
     od;
 end );

--- a/src/streams.c
+++ b/src/streams.c
@@ -817,34 +817,6 @@ static Obj FuncREAD(Obj self, Obj inputObj)
 
 /****************************************************************************
 **
-*F  FuncREAD_NORECOVERY( <self>, <input> ) . . .  . . . read a file or stream
-**
-**  Read the current input and close the input stream. Disable the normal
-**  mechanism which ensures that quitting from a break loop gets you back to
-**  a live prompt. This is initially designed for the files read from the
-**  command line.
-*/
-static Obj FuncREAD_NORECOVERY(Obj self, Obj inputObj)
-{
-    TypInputFile input;
-    if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
-        return False;
-
-    // read the file
-    READ_INNER(&input);
-    if (!CloseInput(&input)) {
-        ErrorQuit("Panic: READ_NORECOVERY cannot close input", 0, 0);
-    }
-    if (STATE(UserHasQuit)) {
-        STATE(UserHasQuit) = FALSE;    // stop recovery here
-        return Fail;
-    }
-    return True;
-}
-
-
-/****************************************************************************
-**
 *F  FuncREAD_STREAM_LOOP( <self>, <instream>, <outstream> ) . . read a stream
 **
 **  Read data from <instream> in a read-eval-view loop and write all output
@@ -1738,7 +1710,6 @@ FuncExecuteProcess(Obj self, Obj dir, Obj prg, Obj in, Obj out, Obj args)
 static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC_1ARGS(READ, input),
-    GVAR_FUNC_1ARGS(READ_NORECOVERY, input),
     GVAR_FUNC_4ARGS(
         READ_ALL_COMMANDS, instream, echo, capture, resultCallback),
     GVAR_FUNC_2ARGS(READ_COMMAND_REAL, stream, echo),

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -140,15 +140,6 @@ gap> NameFunction(func);
 "func"
 
 #
-gap> READ_NORECOVERY(fail);
-Error, READ_NORECOVERY: <input> must be a string or an input stream (not the v\
-alue 'fail')
-gap> READ_NORECOVERY("/this/path/does/not/exist!");
-false
-gap> READ_NORECOVERY(InputTextString(""));
-true
-
-#
 gap> READ_STREAM_LOOP(fail, fail, fail);
 Error, READ_STREAM_LOOP: <instream> must be an input stream (not the value 'fa\
 il')

--- a/tst/testspecial/error-in-InputTextString.g
+++ b/tst/testspecial/error-in-InputTextString.g
@@ -1,2 +1,2 @@
-READ_NORECOVERY(InputTextString("Print(1 + [()]);"));
+Read(InputTextString("Print(1 + [()]);"));
 quit;

--- a/tst/testspecial/error-in-InputTextString.g.out
+++ b/tst/testspecial/error-in-InputTextString.g.out
@@ -1,9 +1,8 @@
-gap> READ_NORECOVERY(InputTextString("Print(1 + [()]);"));
+gap> Read(InputTextString("Print(1 + [()]);"));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
 <function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
  called from read-eval loop at stream:1
 type 'quit;' to quit to outer loop
 brk> quit;
-fail
 gap> QUIT;

--- a/tst/testspecial/exit-in-InputTextString.g
+++ b/tst/testspecial/exit-in-InputTextString.g
@@ -1,1 +1,1 @@
-READ_NORECOVERY(InputTextString("Print(QuitGap(0));"));
+Read(InputTextString("Print(QuitGap(0));"));

--- a/tst/testspecial/exit-in-InputTextString.g.out
+++ b/tst/testspecial/exit-in-InputTextString.g.out
@@ -1,1 +1,1 @@
-gap> READ_NORECOVERY(InputTextString("Print(QuitGap(0));"));
+gap> Read(InputTextString("Print(QuitGap(0));"));


### PR DESCRIPTION
Currently, GAP prints a warning when a nonexistent file is specified on the command line but otherwise continues unharmed:
```
$ gap nonexistent_file_1.g nonexistent_file_2.g
 ┌───────┐   GAP 4.13dev-120-g7da3f5a built on 2022-10-27 15:48:01+0200
 │  GAP  │   https://www.gap-system.org
 └───────┘   Architecture: x86_64-pc-linux-gnu-default64-kv8
 Configuration:  gmp 6.2.1, GASMAN, readline
 Loading the library and packages ...
 Packages:   GAPDoc 1.dev, IO 4.7.0dev, PrimGrp 3.4.0, SmallGrp 1.4.1, TransGrp 2.0.5
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
Could not read file "nonexistent_file_1.g".
Could not read file "nonexistent_file_2.g".
gap>
```
In particular, it exits with exit code 0 if no other error occurs. In CI tests I would like exit GAP with a non-zero exit code in this case to catch typos, problems in the setup, etc.

I expect that this PR will not be accepted as-is. If this expectation is correct, I would like to use it as a starting point for a discussion how this could be achieved. For example, I could imagine tying this to the options `--quitonbreak` or `--norepl` because those are often used in automation where the warning "Could not read file" would possibly go unnoticed.

## Text for release notes

TBD



---

Resolves #4994 