### PR TITLE
Force `START_TEST` and `STOP_TEST` to be always used in tandem

### DIFF
--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1086,7 +1086,7 @@ START_TEST := function( name )
     fi;
 end;
 
-STOP_TEST := function( name, args... )
+STOP_TEST_QUIET := function( name, args... )
     local time;
 
     if not IsBound( GAPInfo.TestData.START_NAME ) then
@@ -1101,12 +1101,22 @@ STOP_TEST := function( name, args... )
     fi;
     
     time:= Runtime() - GAPInfo.TestData.START_TIME;
-    Print( GAPInfo.TestData.START_NAME, "\n" );
-    Print( "msecs: ", time, "\n" );
     SetAssertionLevel( GAPInfo.TestData.AssertionLevel );
     SetInfoLevel( InfoPerformance, GAPInfo.TestData.InfoPerformanceLevel );
     Unbind( GAPInfo.TestData.AssertionLevel );
     Unbind( GAPInfo.TestData.START_TIME );
     Unbind( GAPInfo.TestData.START_NAME );
     Unbind( GAPInfo.TestData.InfoPerformanceLevel );
+    
+    return time;
+end;
+
+STOP_TEST := function( name, args... )
+    local time;
+    
+    time := STOP_TEST_QUIET( name );
+    
+    Print( name, "\n" );
+    Print( "msecs: ", time, "\n" );
+    
 end;

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1026,14 +1026,14 @@ end);
 
 #############################################################################
 ##
-#F  START_TEST( <id> )  . . . . . . . . . . . . . . . . . . . start test file
-#F  STOP_TEST( <file> )  . . . . . . . . . . . . . . . . . . . stop test file
+#F  START_TEST( <name> )  . . . . . . . . . . . . . . . . . . start test file
+#F  STOP_TEST( <name> )  . . . . . . . . . . . . . . . . . . . stop test file
 ##
 ##  <#GAPDoc Label="StartStopTest">
 ##  <ManSection>
 ##  <Heading>Starting and stopping test</Heading>
-##  <Func Name="START_TEST" Arg='id'/>
-##  <Func Name="STOP_TEST" Arg='file'/>
+##  <Func Name="START_TEST" Arg='name'/>
+##  <Func Name="STOP_TEST" Arg='name'/>
 ##
 ##  <Description>
 ##  <Ref Func="START_TEST"/> and <Ref Func="STOP_TEST"/> may be optionally
@@ -1056,10 +1056,8 @@ end);
 ##  and should be finished with a line
 ##  <P/>
 ##  <Log><![CDATA[
-##  gap> STOP_TEST( "filename" );
+##  gap> STOP_TEST( "same identifier string as for START_TEST" );
 ##  ]]></Log>
-##  <P/>
-##  Here the string <C>"filename"</C> should give the name of the test file.
 ##  <P/>
 ##  Note that the functions in <F>tst/testutil.g</F> temporarily replace
 ##  <Ref Func="STOP_TEST"/> before they call <Ref Func="Test"/>.
@@ -1088,13 +1086,20 @@ START_TEST := function( name )
     fi;
 end;
 
-STOP_TEST := function( file, args... )
+STOP_TEST := function( name, args... )
     local time;
 
-    if not IsBound( GAPInfo.TestData.START_TIME ) then
+    if not IsBound( GAPInfo.TestData.START_NAME ) then
       Error( "`STOP_TEST' command without `START_TEST' command for `",
-             file, "'" );
+             name, "'" );
     fi;
+    
+    if GAPInfo.TestData.START_NAME <> name then
+      Info( InfoWarning, 2, "`STOP_TEST' command with name `", name,
+            "' after `START_TEST' ", "command with name `",
+            GAPInfo.TestData.START_NAME, "'" );
+    fi;
+    
     time:= Runtime() - GAPInfo.TestData.START_TIME;
     Print( GAPInfo.TestData.START_NAME, "\n" );
     Print( "msecs: ", time, "\n" );

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1099,4 +1099,5 @@ STOP_TEST := function( file, args... )
     Unbind( GAPInfo.TestData.AssertionLevel );
     Unbind( GAPInfo.TestData.START_TIME );
     Unbind( GAPInfo.TestData.START_NAME );
+    Unbind( GAPInfo.TestData.InfoPerformanceLevel );
 end;

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -1068,6 +1068,10 @@ end);
 ##  <#/GAPDoc>
 ##
 START_TEST := function( name )
+    if IsBound( GAPInfo.TestData.START_NAME ) then
+      Info( InfoWarning, 2, "`START_TEST' was already called with name `",
+             GAPInfo.TestData.START_NAME, "'" );
+    fi;
     FlushCaches();
     Reset(GlobalRandomSource);
     Reset(GlobalMersenneTwister);

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -867,7 +867,8 @@ InstallGlobalFunction( "TestDirectory", function(arg)
   totalGcTime := 0;
   
   STOP_TEST_CPY := STOP_TEST;
-  STOP_TEST := function(arg) end;
+  # wrap STOP_TEST_QUIET to drop the return value so it does not get printed below
+  STOP_TEST := function(arg) CallFuncList( STOP_TEST_QUIET, arg ); end;
   
   if IsString(arg[1]) or IsDirectory(arg[1]) then
     basedirs := [arg[1]];

--- a/tst/testbugfix/2018-12-06-GroupWithGenerators.tst
+++ b/tst/testbugfix/2018-12-06-GroupWithGenerators.tst
@@ -1,5 +1,8 @@
+gap> START_TEST("2018-12-06-GroupWithGenerators.tst");
+
 # These are undocumented, but should still work
 gap> GroupByGenerators( Group( (1,2) ) );
 Group([ (), (1,2) ])
 gap> GroupWithGenerators( Group( (1,2) ) );
 Group([ (), (1,2) ])
+gap> STOP_TEST("2018-12-06-GroupWithGenerators.tst", 1);

--- a/tst/testbugfix/2022-09-09-MinimalGeneratingSet.tst
+++ b/tst/testbugfix/2022-09-09-MinimalGeneratingSet.tst
@@ -1,4 +1,6 @@
+gap> START_TEST("2022-09-09-MinimalGeneratingSet.tst");
 gap> G:=Group((1,2),(2,3),(3,4));;
 gap> H:=Image(IsomorphismFpGroup(G));;
 gap> MinimalGeneratingSet(H);
-[ F1^-1*F2*F1^-1*F3^-1, F1^-1*F2^-1*F3^-1 ]
+[ F1^-1*F2^-1*F3^-1, F1^-1*F2^-1*F3^-1*F2^-1*F1^-1 ]
+gap> STOP_TEST("2022-09-09-MinimalGeneratingSet.tst", 1);

--- a/tst/testinstall/grp/classic-PS.tst
+++ b/tst/testinstall/grp/classic-PS.tst
@@ -85,4 +85,4 @@ gap> PSigmaL( 3, 6 );
 Error, usage: SpecialLinearGroup( [<filter>, ]<d>, <R> )
 
 #
-gap> STOP_TEST("classic.tst-PS", 1);
+gap> STOP_TEST("classic-PS.tst", 1);

--- a/tst/testinstall/grp/classic-S.tst
+++ b/tst/testinstall/grp/classic-S.tst
@@ -119,4 +119,4 @@ gap> SigmaL(3,6);
 Error, <subfield> must be a prime or a finite field
 
 #
-gap> STOP_TEST("classic.tst-S", 1);
+gap> STOP_TEST("classic-S.tst", 1);

--- a/tst/testinstall/monofree.tst
+++ b/tst/testinstall/monofree.tst
@@ -161,4 +161,4 @@ Error, usage: FreeMonoid( [<wfilt>, ]<rank>[, <name>] )
               FreeMonoid( [<wfilt>, ]infinity[, <name>][, <init>] )
 
 #
-gap> STOP_TEST( "grpfree.tst", 1);
+gap> STOP_TEST( "monofree.tst", 1);

--- a/tst/testinstall/opers/ListWreathProductElement.tst
+++ b/tst/testinstall/opers/ListWreathProductElement.tst
@@ -240,3 +240,6 @@ gap> x := G.1 * G.5 * G.2 * G.5 ^ ((G.4 * G.5) ^ 2) * G.2;;
 gap> list := ListWreathProductElement(G, x);;
 gap> x = WreathProductElementList(G, list);
 true
+
+#
+gap> STOP_TEST("ListWreathProductElement.tst", 1);

--- a/tst/testinstall/pluralize.tst
+++ b/tst/testinstall/pluralize.tst
@@ -231,4 +231,4 @@ gap> Pluralize(5, "millennium");
 "\>5\< millennia"
 
 #
-gap> STOP_TEST("format.tst",1);
+gap> STOP_TEST("pluralize.tst",1);

--- a/tst/testinstall/unbound.tst
+++ b/tst/testinstall/unbound.tst
@@ -61,4 +61,4 @@ f := function() unknownname -> 3; end;;
 gap> f := function() return unknownname -> 3; end;;
 
 #
-gap> STOP_TEST( "unknown.tst", 1);
+gap> STOP_TEST( "unbound.tst", 1);

--- a/tst/teststandard/innerfunc.tst
+++ b/tst/teststandard/innerfunc.tst
@@ -65,4 +65,4 @@ gap> y = [len+1..len*2];
 true
 
 #
-gap> STOP_TEST("info.tst", 1);
+gap> STOP_TEST("innerfunc.tst", 1);


### PR DESCRIPTION
See commit messages for details. The third commit ("Force START_TEST and STOP_TEST to appear as a pair with the same name") changes the meaning of the first argument of `STOP_TEST`. If you do not like this (or it causes to many test failures), I will remove this commit.

## Text for release notes

TBD
