### PR TITLE
BuildPackages.sh: allow user GAP root dir

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -194,7 +194,7 @@ run_configure_and_make() {
   then
     if grep Autoconf ./configure > /dev/null
     then
-      local PKG_NAME=$($GAP -q -T -A -r -M <<GAPInput
+      local PKG_NAME=$($GAP -q -T -A -M <<GAPInput
 Read("PackageInfo.g");
 Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput


### PR DESCRIPTION
This one instance of `-r` means that `primgrp`, `smallgrp`, `transgrp` and `GAPDoc` need to be installed *in the GAP installation directory* in order for any packages to be compiled by `BuildPackages.sh`.  PackageManager of course does everything using the user's `.gap` directory, so any package updates from the package manager would not be reflected when calling `BuildPackages.sh`.

If the `-r` is removed, it should be possible for a user to install the package manager and then use it to handle *all* required packages with `InstallRequiredPackages`, without any packages ever being installed in the GAP installation directory.  This would allow a fully working GAP installation starting with only the `gap-core` archive and the PackageManager package, which would be cool!

I have a feeling we've talked about this sometime before, but I can't remember the details.  Please tell me if we've already discussed this and it's impossible for some reason!

Text for release notes: none.