### PR TITLE
make_doc: Remove -r flag to allow user packages

### DIFF
--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 GAP=@abs_top_builddir@/bin/gap.sh
-GAPARGS="-b -m 1g -x 80 -q -r --quitonbreak"
+GAPARGS="-b -m 1g -x 80 -q --quitonbreak"
 if [ "$1" == "nopdf" ]; then
   NOPDF=", \"nopdf\""
 else


### PR DESCRIPTION
This PR is very similar to #5182, which I'm delighted to see was merged recently!

This one instance of `-r` means that primgrp, smallgrp, transgrp and GAPDoc need to be installed in the GAP installation directory in order for manuals to be built by `make doc` and `make manuals`.

If the `-r` is removed, it should be possible for a user to install the package manager and then use it to handle all required packages with InstallRequiredPackages, without any packages ever being installed in the GAP installation directory. This would allow a fully working GAP installation starting with only the gap-core archive and the PackageManager package, which would be cool!

Text for release notes: none.