### PR TITLE
Fixed the method selection for constructors

### DIFF
--- a/lib/oper.g
+++ b/lib/oper.g
@@ -2122,6 +2122,9 @@ end );
 ## This function recalculates all such ranks and adjusts the method ordering
 ## where needed. If the ordering changes, the relevant caches are flushed.
 ##
+## Besides this, also the flags list stored for the first argument of
+## each constructor method gets updated.
+##
 ## If PRINT_REORDERED_METHODS is true, it prints some diagnostics (this is a
 ## bit too low-level for Info).
 ##
@@ -2136,7 +2139,7 @@ Unbind(RECALCULATE_ALL_METHOD_RANKS);
 PRINT_REORDERED_METHODS := false;
 
 BIND_GLOBAL( "RECALCULATE_ALL_METHOD_RANKS", function()
-    local  oper, n, changed, meths, nmethods, i, base, rank, j, req,
+    local  oper, n, changed, meths, nmethods, i, base, rank, flags, j, req,
            req2, k, l, entrysize;
 
     for oper in OPERATIONS do
@@ -2156,6 +2159,15 @@ BIND_GLOBAL( "RECALCULATE_ALL_METHOD_RANKS", function()
                 # adjust the base rank by the rank of the argument filters
                 if IS_CONSTRUCTOR(oper) then
                     Assert(2, n > 0);
+                    # Take implications into account for the first argument.
+                    flags:= WITH_IMPS_FLAGS(meths[base+1+1]);
+                    if flags <> meths[base+1+1] then
+                      if IsHPCGAP and not changed then
+                        meths:= SHALLOW_COPY_OBJ(meths);
+                      fi;
+                      changed:= true;
+                      meths[base+1+1]:= flags;
+                    fi;
                     rank := rank - RankFilter(meths[base+1+1]);
                 else
                     for j in [1..n] do

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -166,6 +166,7 @@ BIND_GLOBAL( "INSTALL_METHOD_FLAGS",
         if 0 = LEN_LIST(flags)  then
             Error(NAME_FUNC(opr),": constructors must have at least one argument");
         fi;
+        flags[1]:= WITH_IMPS_FLAGS( flags[1] );
         rank := rank - RankFilter( flags[ 1 ] );
     else
         for i  in flags  do

--- a/tst/testinstall/constructor.tst
+++ b/tst/testinstall/constructor.tst
@@ -27,3 +27,9 @@ gap> InstallOtherMethod(c,[],{}->[]);
 Error, foobar: constructors must have at least one argument
 gap> c();
 Error, constructors must have at least one argument
+
+#
+gap> DeclareConstructor( "TestConstructor", [ IsMagma ] );
+gap> InstallMethod( TestConstructor, [ IsGroup ], ReturnTrue );
+gap> TestConstructor( IsMagma );
+true

--- a/tst/testinstall/constructor.tst
+++ b/tst/testinstall/constructor.tst
@@ -37,3 +37,10 @@ gap> meth:= ApplicableMethod( TestConstructor, [ IsMagma ] );;
 #I  Family predicate cannot be tested
 gap> meth <> fail;
 true
+
+#
+gap> meth:= ApplicableMethod( GeneralLinearGroupCons,
+>               [ IsPermGroup, 2, GF(3) ] );;
+#I  Family predicate cannot be tested
+gap> meth <> fail;
+true

--- a/tst/testinstall/constructor.tst
+++ b/tst/testinstall/constructor.tst
@@ -33,3 +33,7 @@ gap> DeclareConstructor( "TestConstructor", [ IsMagma ] );
 gap> InstallMethod( TestConstructor, [ IsGroup ], ReturnTrue );
 gap> TestConstructor( IsMagma );
 true
+gap> meth:= ApplicableMethod( TestConstructor, [ IsMagma ] );;
+#I  Family predicate cannot be tested
+gap> meth <> fail;
+true


### PR DESCRIPTION
Up to now, the installation of methods for constructors does not take implied filters of the first argument into account. This means that one can call the constructor with first argument a filter that does not contain the filter from the method installation but does contain the closure of that filter under implications.

(Think of a call of the constructor with first argument `IsMagma`. A constructor method that "promises" an object in `IsGroup` shall be applicable. Note that `TRUES_FLAGS( FLAGS_FILTER( IsGroup ) )` does not contain `TRUES_FLAGS( FLAGS_FILTER( IsMagma ) )`, but `TRUES_FLAGS( WITH_IMPS_FLAGS( FLAGS_FILTER( IsGroup ) ) )` does.)

The stored flags of the first argument of constructors must be updated when new implications become available,
in order to make the following example work.
```
gap> DeclareConstructor( "TestConstructor", [ IsMagma ] );
gap> InstallMethod( TestConstructor, [ IsGroup ], ReturnTrue );
gap> TestConstructor( IsGroup );
true
gap> F:= NewFilter( "FancyNewFilter" );
<Filter "FancyNewFilter">
gap> InstallTrueMethod( F, IsGroup );
gap> TestConstructor( IsGroup );
true
gap> TestConstructor( IsGroup and F );  # The method would not be available without updating the stored flags list.
true
```
Note that after the `InstallTrueMethod` call, `IsGroup and F` should be the same as `IsGroup`.
However, if the flags list stored in the method for `TestConstructor` does not get updated after the method installation, it does not know about the new filter `F`, hence the method claims to be not applicable in the call `TestConstructor( IsGroup and F )`.