### PR TITLE
Support building packages which just have a Makefile

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -207,9 +207,11 @@ GAPInput
       echo_run "$MAKE" clean
       echo_run ./configure "$GAPROOT"
     fi
+  fi
+
+  if [[ -f makefile || -f Makefile || -f GNUmakefile ]]
+  then
     echo_run "$MAKE"
-  else
-    notice "No building required for $PKG"
   fi
 }
 


### PR DESCRIPTION
I had not noticed that `BuildPackages.sh` doesn't support packages which do not have a `./configure` file, only a `Makefile`. `Vole` is such a package.

This does remove the message `No building required for $PKG`, as it's less obvious where to put it now (I can't just put an `else` after the `Makefile` check, because then the message would be printed whenever the configure script failed to generate a Makefile).

If anyone really wants that message I'm happy to work on reintroducing it, but I thought it might be more useful to be a little quieter.
