### PR TITLE
fixed the documentation of `ComplementClassesRepresentatives`

### DIFF
--- a/lib/grppccom.gd
+++ b/lib/grppccom.gd
@@ -174,7 +174,8 @@ DeclareGlobalFunction("COSolvableFactor");
 ##  Complements are subgroups of <A>G</A> which intersect trivially with
 ##  <A>N</A> and together with <A>N</A> generate <A>G</A>.
 ##  <P/>
-##  At the moment only methods for a solvable <A>N</A> are available.
+##  At the moment methods are available only for the case that <A>N</A> or
+##  <A>G</A><C>/</C><A>N</A> is solvable.
 ##  <Example><![CDATA[
 ##  gap> ComplementClassesRepresentatives(g,Group((1,2)(3,4),(1,3)(2,4)));
 ##  [ Group([ (3,4), (2,4,3) ]) ]

--- a/tst/testbugfix/2018-05-24-IntermediateSubgroups.tst
+++ b/tst/testbugfix/2018-05-24-IntermediateSubgroups.tst
@@ -18,7 +18,7 @@ gap> NrMovedPoints(g);Size(g);
 325
 1018368000
 gap> s:=Stabilizer(g,1);;
-gap> s1:=Complementclasses(s,SolvableRadical(s));;
+gap> s1:=ComplementClassesRepresentatives(s,SolvableRadical(s));;
 gap> s1:=s1[1];;Size(s1);
 4080
 gap> n1:= Normalizer( g, s1 );;  Size( n1 );


### PR DESCRIPTION
(and replaced an obsolete function name in a testfile)

In fact, the statement is not entirely correct also after the change, since there is a `ComplementClassesRepresentatives` method for groups that know their conjugacy classes of subgroups.
(One can argue that this is not likely for groups `G` having a normal subgroup `N` such that both `N` and `G/N` are nonsolvable.)