### PR TITLE
Don't strip binaries when installing them

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -582,10 +582,10 @@ install: install-bin install-doc install-gaproot install-sysinfo install-headers
 install-bin: build/gap-install install-libgap
 	# install a special build of gap with SYS_DEFAULT_PATHS set suitably
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(bindir)
-	$(LTINSTALL) -s build/gap-install $(DESTDIR)$(bindir)/gap
+	$(LTINSTALL) build/gap-install $(DESTDIR)$(bindir)/gap
 	# for backwards compatibility, also install it into $(libdir)/gap
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)/gap
-	$(LTINSTALL) -s build/gap-install $(DESTDIR)$(libdir)/gap/gap
+	$(LTINSTALL) build/gap-install $(DESTDIR)$(libdir)/gap/gap
 	# install gac
 	sed -e "s;@SYSINFO_GAPROOT@;$(libdir)/gap;" < $(srcdir)/cnf/gac.in > $(DESTDIR)$(bindir)/gac
 	chmod 0755 $(DESTDIR)$(bindir)/gac
@@ -663,7 +663,7 @@ install-headers: $(FFDATA_H) build/version.h
 
 install-libgap: libgap.la libgap.pc
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)
-	$(LTINSTALL) -s libgap.la $(DESTDIR)$(libdir)
+	$(LTINSTALL) libgap.la $(DESTDIR)$(libdir)
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL) -m 0644 libgap.pc $(DESTDIR)$(libdir)/pkgconfig
 

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -242,7 +242,11 @@ GAPInput
     test -f $GAPPREFIX/share/gap/hpcgap/lib/hpc/tasks.g
     test -f $GAPPREFIX/share/gap/lib/init.g
 
-    # check for references to the build, source or home directories
+    # verify that there are no references to the build, source or home
+    # directories after stripping gap and libgap
+    strip $GAPPREFIX/bin/gap > /dev/null
+    strip $GAPPREFIX/lib/gap/gap > /dev/null
+    strip $GAPPREFIX/lib/libgap.so > /dev/null
     fgrep -r $BUILDDIR $GAPPREFIX && exit 1
     fgrep -r $SRCDIR $GAPPREFIX && exit 1
     fgrep -r $HOME $GAPPREFIX && exit 1

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -222,7 +222,7 @@ GAPInput
     # verify `make install DESTDIR=...` produces identical content, just
     # in a different directory
     make install DESTDIR=/tmp/DESTDIR
-    diff -ru $DESTDIR/$GAPPREFIX $GAPPREFIX
+    diff -ru /tmp/DESTDIR/$GAPPREFIX $GAPPREFIX
 
     # change directory to prevent the installed GAP from accidentally picking
     # up files from the GAP source resp. build directory (wherever we are


### PR DESCRIPTION
The stripping causes issues in various situations. Some distros
also disable it for that reason. It is also easy to strip the
libraries manually later on if so desired.
