### PR TITLE
fix the help system

### DIFF
--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -1013,6 +1013,27 @@ InstallGlobalFunction(HELP_GET_MATCHES, function( books, topic, frombegin )
   return [exact, match];
 end);
 
+
+#############################################################################
+##
+#F  InitialSubstringUTF8Text( <str>, <cols> )
+##
+##  This is a utility that extends the GAPDoc function
+##  <C>InitialSubstringUTF8String</C>, which deals with strings containing
+##  unicode characters but does not deal with escape sequences, i.e.,
+##  sequences starting with ESC and stopping with the first letter
+##  afterwards).
+##  Note that the text version of GAPDoc manuals contains both
+##  unicde characters and escape sequences.
+##
+##  <Ref Func="InitialSubstringUTF8Text"/> returns a string that is the
+##  longest prefix of the string <A>str</A> that has visible/printed length
+##  at most <A>cols</A> and contains all escape sequences from <C>str</C>.
+##
+
+# The following global variables will be defined via the GAPDoc package.
+# We assign them here (and unbind them later on) in order to avoid syntax
+# warnings.
 if not IsBound( InitialSubstringUTF8String ) then
   InitialSubstringUTF8String:= "dummy";
 fi;
@@ -1026,10 +1047,6 @@ fi;
 BindGlobal( "InitialSubstringUTF8Text", function( str, cols )
     local esc, parts, len, res, j, pos, word, w;
 
-    # Collect printable parts up to visible length 'cols',
-    # and all "escape sequences" in 'str'
-    # (sequences starting with ESC and stopping with the first letter
-    # afterwards).
     esc:= CHAR_INT(27);
     parts:= [];
     len:= Length( str );
@@ -1052,11 +1069,10 @@ BindGlobal( "InitialSubstringUTF8Text", function( str, cols )
       if len < pos then
         break;
       fi;
-      j:= pos + 1;
-      while j <= len and not str[j] in LETTERS do
-        j:= j+1;
-      od;
-      if j > len then
+      # Now pos points at an ESC character; all escape sequences we
+      # support are terminated by a letter, so search for one.
+      j:= PositionProperty( str, c -> c in LETTERS, pos );
+      if j = fail then
         Error( "string end inside escape sequence" );
       fi;
       Append( res, str{ [ pos .. j ] } );

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -1024,7 +1024,7 @@ end);
 ##  sequences starting with ESC and stopping with the first letter
 ##  afterwards).
 ##  Note that the text version of GAPDoc manuals contains both
-##  unicde characters and escape sequences.
+##  unicode characters and escape sequences.
 ##
 ##  <Ref Func="InitialSubstringUTF8Text"/> returns a string that is the
 ##  longest prefix of the string <A>str</A> that has visible/printed length

--- a/tst/testinstall/stringobj.tst
+++ b/tst/testinstall/stringobj.tst
@@ -5229,5 +5229,16 @@ gap> Append(s, "xyz");
 gap> [s, IsString(s), IsStringRep(s)];
 [ "strxyz", true, false ]
 
+# 'InitialSubstringUTF8String' vs. 'InitialSubstringUTF8Text'
+gap> s:= Concatenation( "abc", TextAttr.bold, "def", TextAttr.1, "ghi",
+>                       TextAttr.reset );
+"abc\033[1mdef\033[31mghi\033[0m"
+gap> List( [ 4 .. 8 ], i -> InitialSubstringUTF8String( s, i ) );
+[ "abc\033[", "abc\033[1", "abc\033[1m", "abc\033[1md", "abc\033[1mde" ]
+gap> List( [ 4 .. 8 ], i -> InitialSubstringUTF8Text( s, i ) );
+[ "abc\033[1md\033[31m\033[0m", "abc\033[1mde\033[31m\033[0m", 
+  "abc\033[1mdef\033[31m\033[0m", "abc\033[1mdef\033[31mg\033[0m", 
+  "abc\033[1mdef\033[31mgh\033[0m" ]
+
 #
 gap> STOP_TEST( "stringobj.tst", 1);


### PR DESCRIPTION
If the Browse package is not loaded and if the user preference `"Pager"` of GAP has the value `"builtin"` and if a help request yields more than one match then the entries of the list shown by the help request are not cut at `SizeScreen()[1]` columns up to now.

For example, `?Random` yields several entries that need more than 80 columns to be shown.
Since the pager prints `SizeScreen()[2]` lines, the first entries are not visible.

The current proposal fixes this.
Note that the GAPDoc function `InitialSubstringUTF8String` does not take care about escape sequences.

Perhaps it would be more appropriate to add the new auxiliary function `InitialSubstringUTF8Text` to the GAPDoc package.

(Besides this fix, the `\n` character at the end of the first line in the pager has been removed, such that this line becomes visible.)
