### PR TITLE
kernel: workaround GCC 12 warning

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -653,7 +653,7 @@ static Char GetEscapedChar(ScannerState * s)
 static Char GetStr(ScannerState * s, Char c)
 {
     Obj  string = 0;
-    Char buf[1024];
+    Char buf[1024] = "";
     UInt i = 0;
 
     while (c != '"' && c != '\n' && c != '\377') {


### PR DESCRIPTION
With GCC 12, we get a spurious warning indicating that `buf` in `GetStr` may be used uninitialized. Weirdly, it does not complain about the almost identical code in e.g. `GetPragma`.