### PR TITLE
WIP: positional matrix obj rep

### DIFF
--- a/lib/matobj/positional.gd
+++ b/lib/matobj/positional.gd
@@ -1,0 +1,49 @@
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+
+# TODO: document this
+DeclareRepresentation( "IsPositionalVectorRep",
+        IsVectorObj and IsPositionalObjectRep
+    and IsNoImmediateMethodsObject
+    and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
+    [] );
+
+# TODO: document this
+DeclareRepresentation( "IsPositionalMatrixRep",
+        IsMatrixObj and IsPositionalObjectRep
+    and IsNoImmediateMethodsObject
+    and HasNumberRows and HasNumberColumns
+    and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
+    [] );
+
+
+#
+# Some constants for matrix resp. vector access
+#
+# TODO: For now the order follows the order of the predecessors:
+# BDPOS = 1, RLPOS = 3, ROWSPOS = 4; the goal is to
+# eventually change this. But this needs us to carefully revisit
+# all Objectify calls
+
+# Position of the base domain
+BindConstant( "MAT_BD_POS", 1 );
+# Position of the number of rows
+BindConstant( "MAT_NROWS_POS", 5 );  # FIXME: in many cases superfluous (can be computed from NCOLS and DATA)
+# Position of the number of columns
+BindConstant( "MAT_NCOLS_POS", 3 );
+# Position of the data
+BindConstant( "MAT_DATA_POS", 4 );
+
+# Position of the base domain
+BindConstant( "VEC_BD_POS", 1 );
+# Position of the data
+BindConstant( "VEC_DATA_POS", 2 );
+# Position of the length
+#BindConstant( "VEC_LENPOS", 3 ); # FIXME: not actually needed in general????

--- a/lib/matobj/positional.gi
+++ b/lib/matobj/positional.gi
@@ -1,0 +1,97 @@
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+
+############################################################################
+#
+# Operations for positional matrix objects
+#
+############################################################################
+
+InstallMethod( BaseDomain, [ IsPositionalVectorRep ],
+  function( v )
+    return v![VEC_BD_POS];
+  end );
+
+InstallMethod( Length, [ IsPositionalVectorRep ],
+  function( v )
+    return Length(v![VEC_DATA_POS]); # FIXME: assumptions
+  end );
+
+
+InstallMethod( ShallowCopy, [ IsPositionalVectorRep ],
+  function( v )
+    local i, res;
+    res := List([1..LEN_POSOBJ(v)], i -> v![i]);
+    res![VEC_DATA_POS] := ShallowCopy(v![VEC_DATA_POS]);
+    res := Objectify(TypeObj(v), res);
+# FIXME: actually the "generic" ShallowCopy method is wrong, as it
+# e.g. doesn't reset IsZero etc -- if we want to keep this, we need
+# something like a helper to produce a "basic" typeobj for the
+# given basedomain.
+
+
+    # 'ShallowCopy' MUST return a mutable object if such an object exists at all!
+    if not IsMutable(v) then
+      SetFilterObj(res, IsMutable);
+    fi;
+    return res;
+  end );
+
+# StructuralCopy works automatically
+
+InstallMethod( PostMakeImmutable, [ IsPositionalVectorRep ],
+  function( v )
+    MakeImmutable( v![VEC_DATA_POS] );
+  end );
+
+
+############################################################################
+#
+# Operations for positional matrix objects
+#
+############################################################################
+
+InstallMethod( BaseDomain, [ IsPositionalMatrixRep ],
+  function( m )
+    return m![MAT_BD_POS];
+  end );
+
+InstallMethod( NumberRows, [ IsPositionalMatrixRep ],
+  function( m )
+    return Length(m![MAT_DATA_POS]); # FIXME: this makes assumptions...
+  end );
+
+InstallMethod( NumberColumns, [ IsPositionalMatrixRep ],
+  function( m )
+    return m![MAT_NCOLS_POS];
+  end );
+
+InstallMethod( ShallowCopy, [ IsPositionalMatrixRep ],
+  function( m )
+    local res;
+    res := List([1..LEN_POSOBJ(m)], i -> m![i]);
+    res![MAT_DATA_POS] := ShallowCopy(m![MAT_DATA_POS]);
+    res := Objectify(TypeObj(m), res);
+# FIXME: actually the "generic" ShallowCopy method is wrong, as it
+# e.g. doesn't reset IsZero etc -- if we want to keep this, we need
+# something like a helper to produce a "basic" typeobj for the
+# given basedomain.
+
+    # 'ShallowCopy' MUST return a mutable object if such an object exists at all!
+    if not IsMutable(m) then
+      SetFilterObj(res, IsMutable);
+    fi;
+    return res;
+  end );
+
+InstallMethod( PostMakeImmutable, [ IsPositionalMatrixRep ],
+  function( m )
+    MakeImmutable( m![MAT_DATA_POS] );
+  end );

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -49,10 +49,7 @@
 ##  </Enum>
 ##
 DeclareRepresentation( "IsPlistVectorRep",
-        IsVectorObj and IsPositionalObjectRep
-    and IsCopyable
-    and IsNoImmediateMethodsObject
-    and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
+        IsPositionalVectorRep and IsCopyable,
     [] );
 
 
@@ -94,23 +91,19 @@ DeclareRepresentation( "IsPlistVectorRep",
 ##  </Enum>
 ##
 DeclareRepresentation( "IsPlistMatrixRep",
-        IsRowListMatrix and IsPositionalObjectRep
-    and IsCopyable
-    and IsNoImmediateMethodsObject
-    and HasNumberRows and HasNumberColumns
-    and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
+        IsRowListMatrix and IsPositionalMatrixRep and IsCopyable,
     [] );
 
 
 # Some constants for matrix access:
-BindGlobal( "BDPOS", 1 );
-BindGlobal( "EMPOS", 2 );
-BindGlobal( "RLPOS", 3 );
-BindGlobal( "ROWSPOS", 4 );
+BindGlobal( "BDPOS", 1 );    # base domain
+BindGlobal( "EMPOS", 2 );    # empty vector as template for new vectors
+BindGlobal( "RLPOS", 3 );    # row length = number of columns
+BindGlobal( "ROWSPOS", 4 );  # list of row vectors
 
 # For vector access:
 #BindGlobal( "BDPOS", 1 );   # see above
-BindGlobal( "ELSPOS", 2 );
+BindGlobal( "ELSPOS", 2 );   # list of elements
 
 # Two filters to speed up some methods:
 DeclareFilter( "IsIntVector" );

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -222,21 +222,6 @@ InstallMethod( CompatibleVectorFilter, ["IsPlistMatrixRep"],
 
 
 ############################################################################
-# The basic attributes:
-############################################################################
-
-InstallMethod( BaseDomain, "for a plist vector", [ IsPlistVectorRep ],
-  function( v )
-    return v![BDPOS];
-  end );
-
-InstallMethod( Length, "for a plist vector", [ IsPlistVectorRep ],
-  function( v )
-    return Length(v![ELSPOS]);
-  end );
-
-
-############################################################################
 # Representation preserving constructors:
 ############################################################################
 
@@ -337,23 +322,6 @@ InstallMethod( Unpack, "for a plist vector",
   [ IsPlistVectorRep ],
   function( v )
     return ShallowCopy(v![ELSPOS]);
-  end );
-
-
-############################################################################
-# Standard operations for all objects:
-############################################################################
-
-InstallMethod( ShallowCopy, "for a plist vector", [ IsPlistVectorRep ],
-  function( v )
-    return MakeIsPlistVectorRep(v![BDPOS], ShallowCopy(v![ELSPOS]));
-  end );
-
-# StructuralCopy works automatically
-
-InstallMethod( PostMakeImmutable, "for a plist vector", [ IsPlistVectorRep ],
-  function( v )
-    MakeImmutable( v![ELSPOS] );
   end );
 
 
@@ -545,36 +513,6 @@ InstallMethod( CopySubVector, "for two plist vectors and two lists",
 ############################################################################
 ############################################################################
 
-
-############################################################################
-# The basic attributes:
-############################################################################
-
-InstallMethod( BaseDomain, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    return m![BDPOS];
-  end );
-
-InstallMethod( NumberRows, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    return Length(m![ROWSPOS]);
-  end );
-
-InstallMethod( NumberColumns, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    return m![RLPOS];
-  end );
-
-InstallMethod( DimensionsMat, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    return [Length(m![ROWSPOS]),m![RLPOS]];
-  end );
-
-
 ############################################################################
 # Representation preserving constructors:
 ############################################################################
@@ -719,26 +657,6 @@ InstallMethod( Append, "for two plist matrices",
   [ IsPlistMatrixRep and IsMutable, IsPlistMatrixRep ],
   function( m, n )
     Append(m![ROWSPOS],n![ROWSPOS]);
-  end );
-
-InstallMethod( ShallowCopy, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    local res;
-    res := Objectify(TypeObj(m),[m![BDPOS],m![EMPOS],m![RLPOS],
-                                 ShallowCopy(m![ROWSPOS])]);
-    if not IsMutable(m) then
-        SetFilterObj(res,IsMutable);
-    fi;
-#T 'ShallowCopy' MUST return a mutable object
-#T if such an object exists at all!
-    return res;
-  end );
-
-InstallMethod( PostMakeImmutable, "for a plist matrix",
-  [ IsPlistMatrixRep ],
-  function( m )
-    MakeImmutable( m![ROWSPOS] );
   end );
 
 InstallMethod( ListOp, "for a plist matrix",

--- a/lib/read3.g
+++ b/lib/read3.g
@@ -105,6 +105,7 @@ ReadLib( "word.gd"     );
 ReadLib( "wordass.gd"  );
 
 ReadLib( "matobj2.gd"  );
+ReadLib( "matobj/positional.gd" );
 ReadLib( "matobjplist.gd" );
 ReadLib( "matobjnz.gd" );
 

--- a/lib/read5.g
+++ b/lib/read5.g
@@ -112,6 +112,7 @@ ReadLib( "matrobjrowlist.gi"   );
 ReadLib( "vecmat.gi"   );
 ReadLib( "vec8bit.gi"  );
 ReadLib( "mat8bit.gi"  );
+ReadLib( "matobj/positional.gi" );
 ReadLib( "matobjplist.gi" );
 ReadLib( "matobjnz.gi" );
 ReadLib( "meataxe.gi"  );


### PR DESCRIPTION
The plan for this PR is to provide two incomplete representations for vector obj and matrix obj, on which many other implementations (such as the existing plist matrix obj) can be based; this is meant to reduce work for new implementation, reduce code duplication, and provide some uniformity.

Part of the work is to take constants like `BDPOS` and give them a better name. While doing this, I tried to reorder them, but discovered this isn't easy because their values are *implicitly* used in a `Objectify` calls (at least 70 are relevant for this). Since they also represent further code duplication, I plan to put them into a few helper functions, to reduce the number to 4 or so (one each for matrix vs. vector, and for plist rep vs. zmodnz rep). But then @ThomasBreuer pointed out the extra overhead this indirection causes... While I am not overly worried about this (in the worst case I can rewrite these as kernel functions), that made us think about the general impact of objection creation overhead for matrix obj vs. old-style matrices... So my work plan for this PR right now is this:

1. benchmark matrix and vector creation times; add the code for this into the repo somewhere; then act on the result. The idea is to compare at least these:
   - old style
   - plistrep
   - compressed
   - other??

2. factor out `Objectify` calls

3. really switch to the new constants (possibly not reordered for now)
