### PR TITLE
Remove 32-bit Cygwin support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,11 +139,7 @@ jobs:
       - name: "Decide which Cygwin installers to build next"
         id: set-cygwin-matrix
         run: |
-          if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
-            CYGWIN_MATRIX='{"arch":["x86_64"]}'
-          else
-            CYGWIN_MATRIX='{"arch":["x86_64","x86"]}'
-          fi
+          CYGWIN_MATRIX='{"arch":["x86_64"]}'
           echo "Setting Cygwin matrix: $CYGWIN_MATRIX"
           echo "matrix=$CYGWIN_MATRIX" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This PR could be significantly improved, by removing all mentions to "arch", but I thought I'd start with the simplest change and see what, if anything, breaks.

Part of #5226 