### PR TITLE
Improvement to permrep of fp group

### DIFF
--- a/doc/ref/grpfp.xml
+++ b/doc/ref/grpfp.xml
@@ -282,7 +282,7 @@ gap> f := FreeGroup( "a", "b" );
 gap> g := f / [ f.1^2, f.2^3, (f.1*f.2)^5 ];
 <fp group on the generators [ a, b ]>
 gap> h := IsomorphismPermGroup( g );
-[ a, b ] -> [ (1,2)(3,5), (2,3,4) ]
+[ a, b ] -> [ (1,2)(4,5), (2,3,4) ]
 gap> u:=Subgroup(g,[g.1*g.2]);;rt:=RightTransversal(g,u);
 RightTransversal(<fp group of size 60 on the generators 
 [ a, b ]>,Group([ a*b ]))

--- a/lib/ghomfp.gd
+++ b/lib/ghomfp.gd
@@ -357,3 +357,10 @@ DeclareGlobalFunction("LargerQuotientBySubgroupAbelianization");
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction("ProcessEpimorphismToNewFpGroup");
+
+#############################################################################
+##
+#M  InducedRepFpGroup(<hom>,<u> )
+##
+##  induce <hom> def. on <u> up to the full group
+DeclareGlobalFunction("InducedRepFpGroup");

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -504,7 +504,7 @@ end);
 #M  InducedRepFpGroup(<hom>,<u> )
 ##
 ##  induce <hom> def. on <u> up to the full group
-BindGlobal("InducedRepFpGroup",function(thom,s)
+InstallGlobalFunction(InducedRepFpGroup,function(thom,s)
 local t,w,c,q,chom,tg,hi,u;
   w:=FamilyObj(s)!.wholeGroup;
 

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4347,13 +4347,14 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##  <Example><![CDATA[
 ##  gap> SetInfoLevel( InfoFpGroup, 1 );
 ##  gap> iso := IsomorphismFpGroupByGenerators( g, [ (1,2), (1,2,3,4,5) ] );
-##  #I  the image group has 2 gens and 5 rels of total length 39
+##  #I  the image group has 2 gens and 5 rels of total length 52
 ##  [ (1,2), (1,2,3,4,5) ] -> [ F1, F2 ]
 ##  gap> fp := Image( iso );
 ##  <fp group of size 120 on the generators [ F1, F2 ]>
 ##  gap> RelatorsOfFpGroup( fp );
-##  [ F1^2, F2^5, (F2^-1*F1)^4, (F1*F2*F1*F2^-1)^3, (F2*F1*F2^-2*F1*F2)^2
-##   ]
+##  [ F1^2, (F1*F2^-1)^4, (F2^-2*F1*F2^-3)^2,
+##    F2^-1*(F2^-1*F1)^2*F2^2*(F1*F2^-1)^2*F2^-1*F1*F2*F1,
+##    (F1*F2^-2)^2*F2^-1*F1*F2^3*F1*F2^-3 ]
 ##  ]]></Example>
 ##  <P/>
 ##  The main task of the function
@@ -4380,9 +4381,9 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##    (1,12)(2,11)(3,6)(4,8)(5,9)(7,10) ])
 ##  gap> gens := GeneratorsOfGroup( M12 );;
 ##  gap> iso := IsomorphismFpGroupByGenerators( M12, gens );;
-##  #I  the image group has 3 gens and 20 rels of total length 418
+##  #I  the image group has 3 gens and 21 rels of total length 559
 ##  gap> iso := IsomorphismFpGroupByGenerators( M12, gens );;
-##  #I  the image group has 3 gens and 20 rels of total length 526
+##  #I  the image group has 3 gens and 21 rels of total length 548
 ##  ]]></Example>
 ##  <P/>
 ##  Also in the case of a permutation group <A>G</A>, the function
@@ -4431,7 +4432,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##  #I  the image group has 3 gens and 11 rels of total length 92
 ##  gap> iso := IsomorphismFpGroupByGenerators( M12, gens : 
 ##  >                                           method := "fast" );;
-##  #I  the image group has 3 gens and 135 rels of total length 2938
+##  #I  the image group has 3 gens and 176 rels of total length 3821
 ##  ]]></Example>
 ##  <P/>
 ##  Though the option <C>method := "regular"</C> is only checked in the case
@@ -4453,7 +4454,7 @@ DeclareAttribute( "IsomorphismFpGroup", IsGroup );
 ##    [ [ 0, 1, 0, 0, 0 ], [ 0, 0, 1, 0, 0 ], [ 0, 0, 0, 1, 0 ], 
 ##        [ 1, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 1 ] ] ]
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens );;
-##  #I  the image group has 2 gens and 10 rels of total length 132
+##  #I  the image group has 2 gens and 8 rels of total length 88
 ##  gap> iso := IsomorphismFpGroupByGenerators( G, gens : 
 ##  >                                           method := "regular");;
 ##  #I  the image group has 2 gens and 6 rels of total length 56

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -168,11 +168,16 @@ local r,i,j,u,f,q,n,lim,sel,nat,ok,mi;
     od;
     f:=FreeGroup(r);
     ok:=false;
-    if IsPerfectGroup(g) then
+    if not IsSolvableGroup(g) then
       if n=false then
         n:=ShallowCopy(NormalSubgroups(g));
-        # all perfect groups of order <15360 *are* 2-generated
-        lim:=15360;
+        if IsPerfectGroup(g) then
+          # all perfect groups of order <15360 *are* 2-generated
+          lim:=15360;
+        else
+          # all groups of order <8 *are* 2-generated
+          lim:=8;
+        fi;
         n:=Filtered(n,x->IndexNC(g,x)>=lim and Size(x)>1);
         SortBy(n,x->-Size(x));
         mi:=MinimalInclusionsGroups(n);

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1354,7 +1354,7 @@ end);
 
 BindGlobal("RepsPerfSimpSub",function(G,simple)
 local badsizes,n,un,cl,r,i,l,u,bw,cnt,gens,go,imgs,bg,bi,emb,nu,k,j,
-      D,params,might,bo;
+      D,params,might,bo,pls;
   if IsSolvableGroup(G) then
     return [TrivialSubgroup(G)];
   elif Size(SolvableRadical(G))>1 and (IsPermGroup(G) or IsMatrixGroup(G)) then
@@ -1394,7 +1394,8 @@ local badsizes,n,un,cl,r,i,l,u,bw,cnt,gens,go,imgs,bg,bi,emb,nu,k,j,
     fi;
     Info(InfoLattice,1,"Searching perfect groups up to size ",Maximum(un));
 
-    if ForAny(un,i->i>10^6) then
+    pls:=Maximum(SizesPerfectGroups());
+    if ForAny(un,i->i>pls) then
       Error("the perfect residuum is too large");
     fi;
 

--- a/lib/oprtglat.gi
+++ b/lib/oprtglat.gi
@@ -135,8 +135,8 @@ function(G,dom,all)
   savemem:=ValueOption("savemem");
   n:=Length(dom);
   if n>20 and ForAll(dom,x->IsSubset(G,x)) 
-    and NrMovedPoints(G)>1000 
-    and NrMovedPoints(G)*1000>Size(G) then
+    and NrMovedPoints(G)>1000 then
+    #and NrMovedPoints(G)*1000>Size(G) then
 
     b:=SmallerDegreePermutationRepresentation(G:cheap);
     if NrMovedPoints(Range(b))<NrMovedPoints(G) then


### PR DESCRIPTION
Use induced representation to get better degree if there is an awkward small normal subgroup. This resolves #5222 

Also include minor changes to improve `MinimalGeneratingSet`, using perfect groups up to order 2 million for perfect subgroups, and degree reduction when acting on subgroups.