### PR TITLE
tests that libgap works correctly with kernel modules - draft

### DIFF
--- a/tst/testlibgap/basic.c
+++ b/tst/testlibgap/basic.c
@@ -6,6 +6,7 @@ int main(int argc, char ** argv)
 {
     printf("# Initializing GAP...\n");
     GAP_Initialize(argc, argv, 0, 0, 1);
+    test_eval("LoadPackage(\"io\");");
     test_eval("1+2+3;");
     test_eval("g:=FreeGroup(2);");
     test_eval("a:=g.1;");

--- a/tst/testlibgap/basic.expect
+++ b/tst/testlibgap/basic.expect
@@ -1,4 +1,6 @@
 # Initializing GAP...
+gap> LoadPackage("io");
+true
 gap> 1+2+3;
 6
 gap> g:=FreeGroup(2);


### PR DESCRIPTION
as a test, we load IO package - assuming it was built so that its kernel module is created.

That was missing, and caused a regression reported in https://github.com/gap-system/gap/issues/5232

When done, this PR will allow testing for the latter issue - which needs to be fixed elsewhere.
