### PR TITLE
Fix a problem with kernel extensions on macOS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -300,7 +300,7 @@ ifneq (,$(findstring cygwin,$(host_os)))
 else
   ifneq (,$(findstring darwin,$(host_os)))
     GAC_CFLAGS = -fno-common
-    GAC_LDFLAGS = -bundle -bundle_loader $(SYSINFO_GAP)
+    GAC_LDFLAGS = -bundle -flat_namespace -bundle_loader $(SYSINFO_GAP)
     GAC_LDFLAGS_FOR_INSTALL = -bundle -L$(libdir) -lgap
   else
     GAC_CFLAGS = -fPIC


### PR DESCRIPTION
On macOS, kernel extensions built against non-installed GAP could not be loaded into an executable built using libgap, such as `tst/testlibgap/basic`. Resolve this by building kernel extensions again with flat namespace (thus matching the behavior of the Linux dynamic linker more closely), as we used to when we were still using libtool for kernel extensions

This problem was only relevant for non-installed GAP builds. For GAP installed via `make install` and kernel extensions built against that, all was and is fine.

Resolves #5232