### PR TITLE
Add some implications for permutation groups

### DIFF
--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -1917,6 +1917,10 @@ OrbitsishOperation( "IsTransitive", OrbitsishReq, false, NewProperty );
 ##
 OrbitsishOperation( "IsPrimitive", OrbitsishReq, false, NewProperty );
 
+InstallTrueMethod( IsPrimitive, IsNaturalSymmetricGroup );
+InstallTrueMethod( IsPrimitive, IsNaturalAlternatingGroup );
+InstallTrueMethod( IsTransitive, IsPrimitive and IsPermGroup );
+
 
 #############################################################################
 ##
@@ -2018,6 +2022,8 @@ OrbitsishOperation( "IsSemiRegular", OrbitsishReq, false, NewProperty );
 ##  <#/GAPDoc>
 ##
 OrbitsishOperation( "IsRegular", OrbitsishReq, false, NewProperty );
+
+InstallTrueMethod( IsRegular, IsTransitive and IsSemiRegular );
 
 
 #############################################################################


### PR DESCRIPTION
- Natural alternating and symmetric groups are primitive on their moved points.
- Groups which are primitive on their moved points are also transitive on them.
- Groups which act transitively and semi-regular on their moved points also act regular on them.

Motivation: I had some code where I tested `IsPrimitive(G)` for some permutation group `G` of degree ~1000, and when `G` happened to be natural alternating or symmetric, it was sometimes quite slow (a couple hundred milliseconds). With this change (which is essentially free in terms of run time performance) the result is near instantaneous in these cases (as the groups have `IsNaturalSymmetricGroup` or `IsNaturalAlternatingGroup` set anyway)