### PR TITLE
Fix `AsSet` and other methods for `GL(1,Integers)` and also SL

### DIFF
--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -64,6 +64,7 @@ local gens,mat,G;
   else
     SetIsFinite(G,true);
     SetSize(G,2);
+    SetNiceMonomorphism(G,DoSparseLinearActionOnFaithfulSubset(G, OnRight, false));
   fi;    
   return G;
 end);
@@ -97,6 +98,7 @@ local gens,mat,G;
   else
     SetIsFinite(G,true);
     SetSize(G,1);
+    SetNiceMonomorphism(G,DoSparseLinearActionOnFaithfulSubset(G, OnRight, false));
   fi;
   return G;
 end);

--- a/tst/testinstall/grp/classic-G.tst
+++ b/tst/testinstall/grp/classic-G.tst
@@ -52,6 +52,28 @@ gap> ForAll([2,3,5], p -> IsConjugate(G, SylowSubgroup(G,2), SylowSubgroup(H,2))
 true
 
 #
+gap> G:=GL(1,Integers);
+GL(1,Integers)
+gap> Size(G);
+2
+gap> Elements(G);
+[ [ [ -1 ] ], [ [ 1 ] ] ]
+gap> [[-1]] in G;
+true
+gap> [[2]] in G;
+false
+
+#
+gap> G:=GL(2,Integers);
+GL(2,Integers)
+gap> Size(G);
+infinity
+gap> [[2,3],[0,1]] in G;
+false
+gap> [[1,3],[0,1]] in G;
+true
+
+#
 gap> G := GO(3,5);
 GO(0,3,5)
 gap> G = GO(0,3,5);

--- a/tst/testinstall/grp/classic-S.tst
+++ b/tst/testinstall/grp/classic-S.tst
@@ -25,6 +25,28 @@ gap> SL(3,6);
 Error, usage: SpecialLinearGroup( [<filter>, ]<d>, <R> )
 
 #
+gap> G:=SL(1,Integers);
+SL(1,Integers)
+gap> Size(G);
+1
+gap> Elements(G);
+[ [ [ 1 ] ] ]
+gap> [[1]] in G;
+true
+gap> [[-1]] in G;
+false
+
+#
+gap> G:=SL(2,Integers);
+SL(2,Integers)
+gap> Size(G);
+infinity
+gap> [[2,3],[0,1]] in G;
+false
+gap> [[1,3],[0,1]] in G;
+true
+
+#
 gap> G := SO(3,5);
 SO(0,3,5)
 gap> G = SO(0,3,5);


### PR DESCRIPTION
Resolves #5239

Probably not the "right" fix (the default nice monomorphism shouldn't use `Enumerator(Rationals^1)` but I couldn't figure out why that happens, so this was the quickest way to fix those two cases.