### PR TITLE
Make sure that syntax error messages during `EvalString` are displayed correctly

### DIFF
--- a/lib/string.gi
+++ b/lib/string.gi
@@ -649,7 +649,10 @@ InstallGlobalFunction("EvalString", function( s )
   local a, f, res;
   a := "_EVALSTRINGTMP:=";
   Append(a, s);
-  Add(a, ';');
+  # The code handling syntax error messages breaks if the semicolon is the
+  # last character in the input stream. We thus add a line break just as one
+  # would by pressing the <RETURN> key while in the REPL.
+  Append(a, ";\n");
   Unbind(_EVALSTRINGTMP);
   f := InputTextString(a);
   Read(f);

--- a/tst/testbugfix/2022-12-06-EvalString-syntax-error.tst
+++ b/tst/testbugfix/2022-12-06-EvalString-syntax-error.tst
@@ -1,0 +1,8 @@
+# make sure that syntax error messages during EvalString are displayed correctly
+# See https://github.com/gap-system/gap/issues/5242
+gap> EvalString( "(1" );
+Syntax error: ) expected in stream:1
+_EVALSTRINGTMP:=(1;
+                  ^
+Error, Could not evaluate string.
+


### PR DESCRIPTION
Fixes https://github.com/gap-system/gap/issues/5242