### PR TITLE
Fix an unexpected error during tab completion for input like `a.b.` when `a` is not a record

### DIFF
--- a/dev/gaptest.expect
+++ b/dev/gaptest.expect
@@ -50,6 +50,23 @@ expect "gap> "
 send -- "g!.S\t"
 expect "ize"
 send -- ";;\r"
+
+# issue 5241
+expect "gap> "
+# this used to trigger an error
+send -- "g.x.\t"
+# ctrl-u to clear the input given so far
+send -- "\025"
+# just start a new line to verify we are not in a break loop
+send -- "\r"
+expect "gap> "
+# this also used to trigger an error
+send -- "g!.x.\t"
+# ctrl-u to clear the input given so far
+send -- "\025"
+# just start a new line to verify we are not in a break loop
+send -- "\r"
 expect "gap> "
 
 exit
+

--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -969,9 +969,9 @@ GAPInfo.CommandLineEditFunctions.Functions.Completion := function(l)
       if Length(cmps) > 0 and cmps[1] in idbnd then
         r := ValueGlobal(cmps[1]);
         for j in [2..Length(cmps)] do
-          if not hasbang[j-1] and IsBound(r.(cmps[j])) then
+          if not hasbang[j-1] and IsRecord(r) and IsBound(r.(cmps[j])) then
             r := r.(cmps[j]);
-          elif hasbang[j-1] and IsBound(r!.(cmps[j])) then
+          elif hasbang[j-1] and (IsRecord(r) or IsComponentObjectRep(r)) and IsBound(r!.(cmps[j])) then
             r := r!.(cmps[j]);
           else
             r := fail;


### PR DESCRIPTION
Resolves #5241 (cc @zickgraf)