### PR TITLE
Avoid double-slash in `TestDirectory` output

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1281,7 +1281,7 @@ InstallGlobalFunction( DirectoriesPackageLibrary, function( arg )
       # This package is not known.
       return [];
     fi;
-    tmp:= Concatenation( installationpath, "/", path );
+    tmp:= Filename( Directory( installationpath ), path );
     if IsDirectoryPath( tmp ) = true then
       return [ Directory( tmp ) ];
     fi;


### PR DESCRIPTION
Fixes #5249.

## Text for release notes

none
