### PR TITLE
Add `AlgebraHomomorphismByFunction` and `AlgebraWithOneHomomorphismByFunction`, formerly provided by the packages FR and XModAlg

### DIFF
--- a/doc/ref/algebra.xml
+++ b/doc/ref/algebra.xml
@@ -210,6 +210,7 @@ true
 <#Include Label="AlgebraWithOneGeneralMappingByImages">
 <#Include Label="AlgebraWithOneHomomorphismByImages">
 <#Include Label="AlgebraWithOneHomomorphismByImagesNC">
+<#Include Label="AlgebraHomomorphismbyFunction">
 <#Include Label="NaturalHomomorphismByIdeal_algebras">
 <#Include Label="OperationAlgebraHomomorphism">
 <#Include Label="NiceAlgebraMonomorphism">

--- a/lib/alghom.gd
+++ b/lib/alghom.gd
@@ -258,6 +258,34 @@ DeclareOperation( "AlgebraWithOneHomomorphismByImagesNC",
 
 #############################################################################
 ##
+#O  AlgebraHomomorphismByFunction( <A>, <B>, <f> ), 
+##
+##  <#GAPDoc Label="AlgebraHomomorphismbyFunction">
+##  <ManSection>
+##  <Oper Name="AlgebraHomomorphismByFunction" Arg="A B f"/>
+##  <Oper Name="AlgebraWithOneHomomorphismByFunction" Arg="A B f"/>
+##  <Description>
+##  These functions construct an algebra homomorphism from the algebra 
+##  <A>A</A> to the algebra <A>B</A> using a one-argument function <A>f</A>. 
+##  They do not check that the function actually defines a homomorphism.
+##  <Example><![CDATA[
+##  gap> A := MatrixAlgebra( Rationals, 2 );;
+##  gap> f := AlgebraHomomorphismByFunction( Rationals, A, q->[[q,0],[0,0]] );
+##  MappingByFunction( Rationals, ( Rationals^[ 2, 2 ] ), function( q ) ... end )
+##  gap> 11^f;
+##  [ [ 11, 0 ], [ 0, 0 ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "AlgebraHomomorphismByFunction", 
+    [ IsAlgebra, IsAlgebra, IsFunction ] );
+DeclareOperation( "AlgebraWithOneHomomorphismByFunction", 
+    [ IsAlgebraWithOne, IsAlgebraWithOne, IsFunction ] );
+
+#############################################################################
+##
 #O  OperationAlgebraHomomorphism( <A>, <B>[, <opr>] )
 #O  OperationAlgebraHomomorphism( <A>, <V>[, <opr>] )
 ##

--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -206,6 +206,30 @@ end );
 
 #############################################################################
 ##
+#M  AlgebraHomomorphismByFunction( <A>, <B>, <f> )
+#M  AlgebraWithOneHomomorphismByFunction( <A>, <B>, <f> )
+##
+InstallMethod( AlgebraHomomorphismByFunction, 
+    "for two algebras and a function",
+    true, 
+    [ IsAlgebra, IsAlgebra, IsFunction ],
+    function( A, B, f )
+    return Objectify( TypeOfDefaultGeneralMapping( A, B, 
+	IsSPMappingByFunctionRep and IsAlgebraHomomorphism ), rec(fun:=f) );
+    end);
+
+InstallMethod(AlgebraWithOneHomomorphismByFunction, 
+    "for two algebras and a function",
+    true,
+    [ IsAlgebraWithOne, IsAlgebraWithOne, IsFunction ],
+    function( A, B, f )
+    return Objectify( TypeOfDefaultGeneralMapping( A, B, 
+	IsSPMappingByFunctionRep and IsAlgebraWithOneHomomorphism ), 
+        rec(fun:=f) );
+    end);
+
+#############################################################################
+##
 #M  ViewObj( <map> )  . . . . . . . . . . . . . . . . .  for algebra g.m.b.i.
 ##
 InstallMethod( ViewObj, "for an algebra g.m.b.i", true,

--- a/tst/testinstall/alghom.tst
+++ b/tst/testinstall/alghom.tst
@@ -73,6 +73,14 @@ gap> pr := NaturalHomomorphismByIdeal(P, I);;
 gap> IsZero(Image(pr,x));
 false
 
+# an example of an algebra homomorphism by function 
+gap> A := MatrixAlgebra( Rationals, 2 );;
+gap> f := AlgebraHomomorphismByFunction( Rationals, A, q->[[q,0],[0,0]] );
+MappingByFunction( Rationals, ( Rationals^[ 2, 2 ] ), function( q ) ... end )
+gap> 11^f;
+[ [ 11, 0 ], [ 0, 0 ] ]
+
+
 # example for structure constant rings, Martin Brandenburg on stackexchange
 gap> ExampleRing := function(n)
 > local T,O;

--- a/tst/testinstall/alghom.tst
+++ b/tst/testinstall/alghom.tst
@@ -80,7 +80,6 @@ MappingByFunction( Rationals, ( Rationals^[ 2, 2 ] ), function( q ) ... end )
 gap> 11^f;
 [ [ 11, 0 ], [ 0, 0 ] ]
 
-
 # example for structure constant rings, Martin Brandenburg on stackexchange
 gap> ExampleRing := function(n)
 > local T,O;


### PR DESCRIPTION
The operation AlgebraHomomorphismByFunction was originally in the FR package and was later, independently, added to XModAlg.  The declarations and implementations in these two packages have recently been synchronised, with the intention that the function would be moved to the main GAP library.  The same would be true of the FR operation AlgebraWithOneHomomorphismByFunction. 

## Text for release notes
Operation `AlgebraHomomorphismByFunction` transferred from packages FR and XModAlg. 

