### PR TITLE
kernel: refactor code.c and related code

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -805,6 +805,13 @@ void CodeFuncExprBegin(CodeState * cs,
     assert( stat1 == OFFSET_FIRST_STAT );
 }
 
+#ifdef HPCGAP
+void CodeFuncExprSetLocks(CodeState * cs, Obj locks)
+{
+    SET_LCKS_FUNC(cs->currFunc, locks);
+}
+#endif
+
 Expr CodeFuncExprEnd(CodeState * cs, UInt nr, BOOL pushExpr, Int endLine)
 {
     Expr                expr;           /* function expression, result     */

--- a/src/code.h
+++ b/src/code.h
@@ -731,6 +731,10 @@ void CodeFuncExprBegin(CodeState * cs,
                        UInt        gapnameid,
                        Int         startLine);
 
+#ifdef HPCGAP
+void CodeFuncExprSetLocks(CodeState * cs, Obj locks);
+#endif
+
 Expr CodeFuncExprEnd(CodeState * cs, UInt nr, BOOL pushExpr, Int endLine);
 
 /****************************************************************************

--- a/src/code.h
+++ b/src/code.h
@@ -183,7 +183,7 @@ enum {
 Obj NewFunctionBody(void);
 
 
-void WRITE_EXPR(Expr expr, UInt idx, UInt val);
+void WRITE_EXPR(CodeState * cs, Expr expr, UInt idx, UInt val);
 
 
 /****************************************************************************

--- a/src/code.h
+++ b/src/code.h
@@ -59,6 +59,10 @@ struct CodeState {
     // the offset in the current body. It is only valid while coding
     Stat OffsBody;
 
+    // a linked list of further OffsBody values, used when coding
+    // nested function expressions
+    Obj OffsBodyList;
+
     // the result of the coding, i.e., the function that was coded
     Obj CodeResult;
 

--- a/src/code.h
+++ b/src/code.h
@@ -68,6 +68,12 @@ struct CodeState {
 
     // place to store the previous value of STATE(CurrLVars)
     Bag CodeLVars;
+
+    //
+    Obj currFunc;
+
+    //
+    Obj currBody;
 };
 
 typedef struct CodeState CodeState;
@@ -745,7 +751,7 @@ Expr CodeFuncExprEnd(CodeState * cs, UInt nr, BOOL pushExpr, Int endLine);
 **  function currently being coded, and returns the index at which the value
 **  was inserted. This function must only be called while coding a function.
 */
-Int AddValueToBody(Obj val);
+Int AddValueToBody(CodeState * cs, Obj val);
 
 /****************************************************************************
 **

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -453,6 +453,20 @@ void IntrFuncExprBegin(
     CodeFuncExprBegin(intr->cs, narg, nloc, nams, intr->gapnameid, startLine);
 }
 
+#ifdef HPCGAP
+void IntrFuncExprSetLocks(IntrState * intr, Obj locks)
+{
+    /* ignore or code                                                      */
+    SKIP_IF_RETURNING();
+    SKIP_IF_IGNORING();
+
+    /* otherwise must be coding                                            */
+    GAP_ASSERT(intr->coding > 0);
+
+    CodeFuncExprSetLocks(intr->cs, locks);
+}
+#endif
+
 void IntrFuncExprEnd(IntrState * intr, UInt nr, Int endLine)
 {
     /* ignore or code                                                      */

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -19,11 +19,14 @@
 #ifndef GAP_INTRPRTR_H
 #define GAP_INTRPRTR_H
 
+#include "code.h"
 #include "common.h"
 #include "gap.h"
 
 
 struct IntrState {
+    //
+    CodeState cs[1];
 
     // If 'IntrIgnoring' is non-zero, the interpreter is currently ignoring
     // actions. The interpreter switches to this mode for the right operand of

--- a/src/intrprtr.h
+++ b/src/intrprtr.h
@@ -159,8 +159,11 @@ void IntrFuncCallOptionsEnd(IntrState * intr, UInt nr);
 void IntrFuncExprBegin(
     IntrState * intr, Int narg, Int nloc, Obj nams, Int startLine);
 
-void IntrFuncExprEnd(IntrState * intr, UInt nr, Int endLine);
+#ifdef HPCGAP
+void IntrFuncExprSetLocks(IntrState * intr, Obj locks);
+#endif
 
+void IntrFuncExprEnd(IntrState * intr, UInt nr, Int endLine);
 
 /****************************************************************************
 **

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -284,14 +284,14 @@ static Expr SyntaxTreeDefaultCoder(CodeState * cs, Obj node)
                 Obj elem = ELM0_LIST(vararglist, offset + 1);
                 // Deal with empty entries in list expressions
                 if (elem == 0) {
-                    WRITE_EXPR(expr, i + offset, 0);
+                    WRITE_EXPR(cs, expr, i + offset, 0);
                 }
                 else if (comp.args[i].isStat) {
-                    WRITE_EXPR(expr, i + offset,
+                    WRITE_EXPR(cs, expr, i + offset,
                                SyntaxTreeDefaultStatCoder(cs, elem));
                 }
                 else {
-                    WRITE_EXPR(expr, i + offset,
+                    WRITE_EXPR(cs, expr, i + offset,
                                SyntaxTreeDefaultExprCoder(cs, elem));
                 }
             }
@@ -300,7 +300,8 @@ static Expr SyntaxTreeDefaultCoder(CodeState * cs, Obj node)
         }
         else {
             Obj subast = ElmRecST(tnum, node, comp.args[i].argname);
-            WRITE_EXPR(expr, i + offset, comp.args[i].argcode(cs, subast));
+            WRITE_EXPR(cs, expr, i + offset,
+                       comp.args[i].argcode(cs, subast));
         }
     }
 
@@ -406,13 +407,13 @@ static Expr SyntaxTreeCodeRangeExpr(CodeState * cs, Obj node)
     UInt size = hassecond ? 3 : 2;
     Expr result = NewStatOrExpr(cs, EXPR_RANGE, size * sizeof(Expr), 0);
     WRITE_EXPR(
-        result, 0,
+        cs, result, 0,
         SyntaxTreeDefaultExprCoder(cs, ElmRecST(EXPR_RANGE, node, "first")));
     WRITE_EXPR(
-        result, size - 1,
+        cs, result, size - 1,
         SyntaxTreeDefaultExprCoder(cs, ElmRecST(EXPR_RANGE, node, "last")));
     if (hassecond) {
-        WRITE_EXPR(result, 1,
+        WRITE_EXPR(cs, result, 1,
                    SyntaxTreeDefaultExprCoder(
                        cs, ElmRecST(EXPR_RANGE, node, "second")));
     }
@@ -474,8 +475,8 @@ static Expr SyntaxTreeCodeRecExpr(CodeState * cs, Obj node)
             key = SyntaxTreeDefaultExprCoder(cs, keynode);
         }
         Expr value = SyntaxTreeDefaultExprCoder(cs, valuenode);
-        WRITE_EXPR(record, 2 * i, key);
-        WRITE_EXPR(record, 2 * i + 1, value);
+        WRITE_EXPR(cs, record, 2 * i, key);
+        WRITE_EXPR(cs, record, 2 * i + 1, value);
     }
     return record;
 }
@@ -512,9 +513,9 @@ static Expr SyntaxTreeCodeFloatEager(CodeState * cs, Obj node)
     Obj  string = ElmRecST(EXPR_FLOAT_EAGER, node, "string");
     Obj  mark = ElmRecST(EXPR_FLOAT_EAGER, node, "mark");
     Expr fl = NewStatOrExpr(cs, EXPR_FLOAT_EAGER, 3 * sizeof(UInt), 0);
-    WRITE_EXPR(fl, 0, AddValueToBody(cs, value));
-    WRITE_EXPR(fl, 1, AddValueToBody(cs, string));
-    WRITE_EXPR(fl, 2, (UInt)CHAR_VALUE(mark));
+    WRITE_EXPR(cs, fl, 0, AddValueToBody(cs, value));
+    WRITE_EXPR(cs, fl, 1, AddValueToBody(cs, string));
+    WRITE_EXPR(cs, fl, 2, (UInt)CHAR_VALUE(mark));
     return fl;
 }
 
@@ -565,8 +566,8 @@ static Expr SyntaxTreeCodeIf(CodeState * cs, Obj node)
         Obj  bodynode = ElmRecST(tnum, condbodypair, "body");
         Expr condition = SyntaxTreeDefaultExprCoder(cs, conditionnode);
         Stat body = SyntaxTreeDefaultStatCoder(cs, bodynode);
-        WRITE_EXPR(ifexpr, 2 * i, condition);
-        WRITE_EXPR(ifexpr, 2 * i + 1, body);
+        WRITE_EXPR(cs, ifexpr, 2 * i, condition);
+        WRITE_EXPR(cs, ifexpr, 2 * i + 1, body);
     }
     return ifexpr;
 }
@@ -587,7 +588,7 @@ static Expr SyntaxTreeCodeValue(CodeState * cs, Obj node)
     Obj   value = ElmRecST(tnum, node, "value");
     Expr  expr = NewStatOrExpr(cs, tnum, sizeof(UInt), 0);
     Int   ix = AddValueToBody(cs, value);
-    WRITE_EXPR(expr, 0, ix);
+    WRITE_EXPR(cs, expr, 0, ix);
     return expr;
 }
 
@@ -597,7 +598,7 @@ static Expr SyntaxTreeCodeChar(CodeState * cs, Obj node)
     Obj  chr = ElmRecST(EXPR_CHAR, node, "value");
     Char currchar = CHAR_VALUE(chr);
     Expr lit = NewStatOrExpr(cs, EXPR_CHAR, sizeof(UInt), 0);
-    WRITE_EXPR(lit, 0, currchar);
+    WRITE_EXPR(cs, lit, 0, currchar);
     return lit;
 }
 

--- a/src/syntaxtree.c
+++ b/src/syntaxtree.c
@@ -512,8 +512,8 @@ static Expr SyntaxTreeCodeFloatEager(CodeState * cs, Obj node)
     Obj  string = ElmRecST(EXPR_FLOAT_EAGER, node, "string");
     Obj  mark = ElmRecST(EXPR_FLOAT_EAGER, node, "mark");
     Expr fl = NewStatOrExpr(cs, EXPR_FLOAT_EAGER, 3 * sizeof(UInt), 0);
-    WRITE_EXPR(fl, 0, AddValueToBody(value));
-    WRITE_EXPR(fl, 1, AddValueToBody(string));
+    WRITE_EXPR(fl, 0, AddValueToBody(cs, value));
+    WRITE_EXPR(fl, 1, AddValueToBody(cs, string));
     WRITE_EXPR(fl, 2, (UInt)CHAR_VALUE(mark));
     return fl;
 }
@@ -586,7 +586,7 @@ static Expr SyntaxTreeCodeValue(CodeState * cs, Obj node)
     UInt1 tnum = GetTypeTNum(node);
     Obj   value = ElmRecST(tnum, node, "value");
     Expr  expr = NewStatOrExpr(cs, tnum, sizeof(UInt), 0);
-    Int   ix = AddValueToBody(value);
+    Int   ix = AddValueToBody(cs, value);
     WRITE_EXPR(expr, 0, ix);
     return expr;
 }


### PR DESCRIPTION
I've been working on refactoring the coder and related code. Right now the same infrastructure is used to read function bodies for executions, and to write them. That prevents us from declaring more pointers `const`, (and thus might miss some optimizations -- but I don't expect much in this regard, so that's not really a factor for me). More importantly, it untangles the coder mostly from `STATE(PtrBody)` and related machinery, which is somewhat "magical" and difficult to understand. Indeed, I discovered and removed one place where we violated the layering between reader -> interpreter -> coder (see commit `kernel: replace hack in the reader for setting function locks`).

Future planned steps: removing the `visited` flag and the line numbers from stats, moving them to separate data structures. And getting rid of the final uses of `PtrBody` in there, to wit, by replacing uses of `SWITCH_TO_NEW_LVARS` and `SWITCH_TO_OLD_LVARS` with new alternatives specific to the coder.