### PR TITLE
Fix spelling: homogenous -> homogeneous

### DIFF
--- a/dev/listarith.tex
+++ b/dev/listarith.tex
@@ -179,11 +179,11 @@ these. Rather than rewrite it, I copy here the  explanation from
 **   T_PLIST                    nothing is known
 **   T_PLIST_NDENSE             known to have a hole
 **   T_PLIST_DENSE              known only not to have a hole
-**   T_PLIST_DENSE_NHOM         known to be dense but not homogenous *  **
+**   T_PLIST_DENSE_NHOM         known to be dense but not homogeneous *  **
 **   T_PLIST_DENSE_NHOM_SSORT   dense, non-hom but strictly sorted
 **   T_PLIST_DENSE_NHOM_NSORT   dense, non-hom, known not be be sorted
 **   T_PLIST_EMPTY              the empty list
-**   T_PLIST_HOM                known to be homogenous *
+**   T_PLIST_HOM                known to be homogeneous *
 **   T_PLIST_HOM_NSORT           etc
 **   T_PLIST_HOM_SSORT           etc
 **   T_PLIST_TAB                known to be a table  *
@@ -232,7 +232,7 @@ these. Rather than rewrite it, I copy here the  explanation from
 **     8 is the simpler. It calls KTnumHomPlist, which checks whether we
 **     should really be in T_PLIST_CYC, T_PLIST_FFE or T_PLIST_TAB and if so,
 **     changes the TNUM appropriately and returns the new tnum.  The only
-**     time this is slow is a homogenous list of lists which looks like a
+**     time this is slow is a homogeneous list of lists which looks like a
 **     table until the very last entry which has the wrong length. This
 **     should be rare.
 **     
@@ -244,7 +244,7 @@ these. Rather than rewrite it, I copy here the  explanation from
 **     the type and the ktnum of the list. This must be done in one function
 **     to avoid an exponential slowdown for deeply nested lists. This
 **     function is mutually recursive with KTnumPlist, which also returns two
-**     pieces of information: the ktnum of the list and, if it is homogenous,
+**     pieces of information: the ktnum of the list and, if it is homogeneous,
 **     the family of the elements.
 **
 **     recursive lists (ie lists which are there own subobjects are detected
@@ -262,7 +262,7 @@ of it, as far as necessary to determine its ``transient'' TNUM (ie
 the TNUM that it really deserves, but which might not be storable
 thanks to the presence of mutable subobjects) storing as much
 information along the way as it can. After that, the type is just
-looked up in global variables for non-homogenous lists. For
+looked up in global variables for non-homogeneous lists. For
 homogeneous lists, the lookup is done in data stored in the lists
 family. 
 

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1002,7 +1002,7 @@ DeclareCategoryCollections("IsZDFRECollection");
 ##  <Ref Filt="IsMatrix"/> returns <K>true</K> for tables such as 
 ##  <C>[[1,2],[3]]</C>.
 ##  If necessary, <Ref Prop="IsRectangularTable"/> can be used to test whether
-##  an object is a list of homogenous lists of equal lengths manually.
+##  an object is a list of homogeneous lists of equal lengths manually.
 ##  <P/>
 ##  Note that matrices may have different multiplications,
 ##  besides the usual matrix product there is for example the Lie product.

--- a/lib/list.g
+++ b/lib/list.g
@@ -289,8 +289,8 @@ BIND_GLOBAL( "TYPE_BLIST_EMPTY_IMM",
 ##  <Func Name="TYPE_LIST_HOM" Arg='family, isMutable, sort, table'/>
 ##
 ##  <Description>
-##  Return the type of a homogenous list whose elements are in <family>, with
-##  additional properties indicated by <isMutable>, <sort> and <table>.
+##  Return the type of a homogeneous list whose elements are in <family>,
+##  with additional properties indicated by <isMutable>, <sort> and <table>.
 ##  </Description>
 ##  </ManSection>
 ##

--- a/lib/pcgsspec.gi
+++ b/lib/pcgsspec.gi
@@ -355,7 +355,7 @@ PcgsSystemWithHallSystem := function( pcgssys )
             size  := next - start;
             base  := pcgssys.pcgs{[start..next-1]};
 
-            # InitializeSystem inhomogenous system  
+            # InitializeSystem inhomogeneous system  
             V := [];
             M := List([1..size], x -> []);
 
@@ -509,7 +509,7 @@ PcgsSystemWithComplementSystem := function( pcgssys )
             size  := next - start;
             base  := pcgssys.pcgs{[start..next-1]};
 
-            # InitializeSystem inhomogenous system  
+            # InitializeSystem inhomogeneous system  
             V := [];
             M := List([1..size], x -> []);
 

--- a/lib/sparselist.gd
+++ b/lib/sparselist.gd
@@ -45,7 +45,7 @@ DeclareOperation( "SparseStructureOfList", [IsList]);
 ##  sparse methods should be used.
 ##
 ##  The filter is ranked up so that sparse list methods will beat
-##  competing methods for finite, homogenous, etc. lists, which is
+##  competing methods for finite, homogeneous, etc. lists, which is
 ##  usually right
 ##
 

--- a/lib/sparselistsorted.gi
+++ b/lib/sparselistsorted.gi
@@ -21,7 +21,7 @@
 ##  the default value a sorted list of positions with non-default values
 ##  and the values for those positions, in the corresponding order
 ##
-##  The lists must be homogenous, and will only tolerate assignment of
+##  The lists must be homogeneous, and will only tolerate assignment of
 ##  elements in the proper family. The user must ensure that mutable elements
 ##  do not change family
 ##

--- a/src/blister.c
+++ b/src/blister.c
@@ -766,7 +766,7 @@ static BOOL IsPossBlist(Obj list)
 
 /****************************************************************************
 **
-*F  IsHomogBlist( <list> )  . . . . . . . . . . check if <list> is homogenous
+*F  IsHomogBlist( <list> ) . . . . . . . . . . check if <list> is homogeneous
 */
 static BOOL IsHomogBlist(Obj list)
 {

--- a/src/lists.h
+++ b/src/lists.h
@@ -576,7 +576,7 @@ void AssListObject(Obj list, Int pos, Obj obj);
 **  A  package implementing a list  type <type> must  provide such a function
 **  and install it in  'IsTableListFuncs[<type>]'.   This function must  loop
 **  over the list and test whether  all elements lie  in the same family, are
-**  homogenous lists, and have  the same length, unless the  type of the list
+**  homogeneous lists, and have  the same length, unless the type of the list
 **  guarantees already that the list has this property.
 */
 

--- a/src/plist.c
+++ b/src/plist.c
@@ -116,11 +116,11 @@ void             GrowPlist (
 **   T_PLIST                    nothing is known
 **   T_PLIST_NDENSE             known to have a hole
 **   T_PLIST_DENSE              known only not to have a hole
-**   T_PLIST_DENSE_NHOM         known to be dense but not homogenous *  **
+**   T_PLIST_DENSE_NHOM         known to be dense but not homogeneous *  **
 **   T_PLIST_DENSE_NHOM_SSORT   dense, non-hom but strictly sorted
 **   T_PLIST_DENSE_NHOM_NSORT   dense, non-hom, known not to be sorted
 **   T_PLIST_EMPTY              the empty list
-**   T_PLIST_HOM                known to be homogenous *
+**   T_PLIST_HOM                known to be homogeneous *
 **   T_PLIST_HOM_NSORT           etc
 **   T_PLIST_HOM_SSORT           etc
 **   T_PLIST_TAB                known to be a table  *
@@ -169,7 +169,7 @@ void             GrowPlist (
 **     8 is the simpler. It calls KTNumHomPlist, which checks whether we
 **     should really be in T_PLIST_CYC, T_PLIST_FFE or T_PLIST_TAB and if so,
 **     changes the TNUM appropriately and returns the new tnum.  The only
-**     time this is slow is a homogenous list of lists which looks like a
+**     time this is slow is a homogeneous list of lists which looks like a
 **     table until the very last entry which has the wrong length. This
 **     should be rare.
 **
@@ -181,7 +181,7 @@ void             GrowPlist (
 **     the type and the ktnum of the list. This must be done in one function
 **     to avoid an exponential slowdown for deeply nested lists. This
 **     function is mutually recursive with KTNumPlist, which also returns two
-**     pieces of information: the ktnum of the list and, if it is homogenous,
+**     pieces of information: the ktnum of the list and, if it is homogeneous,
 **     the family of the elements.
 **
 **     recursive lists (ie lists which are there own subobjects are detected
@@ -290,7 +290,7 @@ static Int KTNumPlist(Obj list, Obj * famfirst)
         if ( ktnumFirst >= T_PLIST_HOM ||
              ( ktnumFirst == 0 && IS_HOMOG_LIST( elm) )) {
 
-          /* entry is a homogenous list, so this might be a table */
+          /* entry is a homogeneous list, so this might be a table */
           isTable = 1;
 
           /* also check for rectangularity, unless this would be expensive */
@@ -2410,7 +2410,7 @@ static Obj FuncASS_PLIST_DEFAULT(Obj self, Obj plist, Obj pos, Obj val)
 *F  MakeImmutablePlistInHom( <plist> )
 **
 **  This is the function for Plists that might have mutable subobjects
-**  which is currently exactly those that are not known to be homogenous
+**  which is currently exactly those that are not known to be homogeneous
 **  (or immutable, but MakeImmutable will have caught that case before we get
 **  here)
 */
@@ -2439,8 +2439,8 @@ static void MakeImmutablePlistInHom(Obj list)
 *F  MakeImmutablePlistNoMutElms( <plist> )
 **
 **  This is the function for Plists that cannot have mutable subobjects
-**  which is currently  those that are  known to be homogenous or known to
-**  be non-homogenous
+**  which is currently  those that are  known to be homogeneous or known to
+**  be non-homogeneous
 **  (or immutable, but MakeImmutable will have caught that case before we get
 **  here)
 */

--- a/src/set.c
+++ b/src/set.c
@@ -361,7 +361,7 @@ static Obj FuncADD_SET(Obj self, Obj set, Obj obj)
                                    conclude more */
       if ( ! IS_MUTABLE_OBJ(obj) ) {
                                 /* a one element list is automatically
-                                   homogenous  and ssorted */
+                                   homogeneous  and ssorted */
         if (len == 0 )
           {
             if (IS_CYC(obj))


### PR DESCRIPTION
Both are valid words, but with different meaning.
