### PR TITLE
Clean up 8 bit matrix

### DIFF
--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -14,10 +14,6 @@
 ##  all rows must be the same length and written over the same field
 ##
 
-#############################################################################
-##
-#V  TYPES_MAT8BIT . . . . . . . . prepared types for compressed GF(q) vectors
-##
 ##  A length 2 list of length 257 lists. TYPES_MAT8BIT[1][q] will be the type
 ##  of mutable vectors over GF(q), TYPES_MAT8BIT[2][q] is the type of
 ##  immutable vectors. The 257th position is bound to 1 to stop the lists
@@ -25,7 +21,6 @@
 ##
 ##  It is accessed directly by the kernel, so the format cannot be changed
 ##  without changing the kernel.
-##
 
 if IsHPCGAP then
     BindGlobal("TYPES_MAT8BIT", [ FixedAtomicList(256), FixedAtomicList(256) ]);
@@ -36,13 +31,8 @@ else
     TYPES_MAT8BIT[2][257] := 1;
 fi;
 
-#############################################################################
-##
-#F  TYPE_MAT8BIT( <q>, <mut> ) . .  computes type of compressed GF(q) matrices
-##
 ##  Normally called by the kernel, caches results in TYPES_MAT8BIT,
 ##  which is directly accessed by the kernel
-##
 
 InstallGlobalFunction(TYPE_MAT8BIT,
   function( q, mut)
@@ -64,48 +54,22 @@ InstallGlobalFunction(TYPE_MAT8BIT,
     return TYPES_MAT8BIT[col][q];
 end);
 
-
-#############################################################################
-##
-#M  Length( <mat> )
-##
-
 InstallMethod(Length, "for an 8 - bit matrix rep", [Is8BitMatrixRep],
 m -> m![1]);
-
-#############################################################################
-##
-#M  <mat> [ <pos> ]
-##
 
 InstallOtherMethod(\[\], "for an 8 - bit matrix rep and pos. int.",
 [Is8BitMatrixRep, IsPosInt], ELM_MAT8BIT);
 
-#############################################################################
-##
-#M  <mat> [ <pos1>, <pos2> ]
-##
-
 InstallMethod(\[\,\],  "for an 8-bit matrix rep and 2 pos. int.",
 [Is8BitMatrixRep, IsPosInt, IsPosInt], MAT_ELM_MAT8BIT);
 
-#############################################################################
-##
-#M  <mat> [ <pos> ] := <val>
-##
-##  This may involve turning <mat> into a plain list, if <mat> does
-##  not lie in the appropriate field.
-##
+# This may involve turning <mat> into a plain list, if <mat> does not lie in
+# the appropriate field.
 
 InstallOtherMethod(\[\]\:\=,
 "for a mutable 8-bit matrix rep, a pos. int. and object",
 [IsMutable and Is8BitMatrixRep, IsPosInt, IsObject],
 ASS_MAT8BIT);
-
-#############################################################################
-##
-#M  <mat> [ <pos1>, <pos2> ] := <val>
-##
 
 InstallMethod( \[\,\]\:\=,
 "for a mutable 8-bit matrix rep, 2 pos. ints., and an object",
@@ -113,13 +77,8 @@ InstallMethod( \[\,\]\:\=,
         SET_MAT_ELM_MAT8BIT
         );
 
-#############################################################################
-##
-#M  Unbind( <mat> [ <pos> ] )
-##
-##  Unless the last position is being unbound, this will result in <mat>
-##  turning into a plain list
-##
+# Unless the last position is being unbound, this will result in <mat> turning
+# into a plain list
 
 InstallMethod( Unbind\[\],
 "for a mutable 8-bit matrix rep and pos. int.",
@@ -134,13 +93,8 @@ InstallMethod( Unbind\[\],
     fi;
 end);
 
-#############################################################################
-##
-#M  ViewObj( <mat> )
-##
-##  Up to 25 entries,  GF(q) matrices are viewed in full, over that a
-##  description is printed
-##
+# Up to 25 entries,  GF(q) matrices are viewed in full, over that a description
+# is printed
 
 InstallMethod( ViewObj, "for an 8-bit matrix rep",
          [Is8BitMatrixRep],
@@ -160,13 +114,6 @@ InstallMethod( ViewObj, "for an 8-bit matrix rep",
     fi;
 end);
 
-#############################################################################
-##
-#M  PrintObj( <mat> )
-##
-##  Same method as for lists in internal rep.
-##
-
 InstallMethod( PrintObj,
 "for an 8-bit matrix rep",
         [Is8BitMatrixRep],
@@ -184,12 +131,6 @@ InstallMethod( PrintObj,
     Print(" \<\<\<\<]");
 end);
 
-#############################################################################
-##
-#M  ShallowCopy(<mat>)
-##
-##
-
 InstallMethod(ShallowCopy, "for an 8-bit matrix rep",
         [Is8BitMatrixRep],
         function(m)
@@ -203,11 +144,6 @@ InstallMethod(ShallowCopy, "for an 8-bit matrix rep",
     return c;
 end );
 
-#############################################################################
-##
-#M PositionCanonical( <mat> , <vec> )
-##
-
 # TODO required?
 
 InstallMethod( PositionCanonical,
@@ -217,37 +153,17 @@ InstallMethod( PositionCanonical,
     return Position( list, obj, 0 );
 end );
 
-
-
-#############################################################################
-##
-#M  <mat1> + <mat2>
-##
-
 InstallMethod( \+, "for two 8-bit matrices",
         IsIdenticalObj, [Is8BitMatrixRep,
                 Is8BitMatrixRep], ,
         SUM_MAT8BIT_MAT8BIT
 );
 
-#############################################################################
-##
-#M  <mat1> - <mat2>
-##
-
 InstallMethod( \-, "for two 8 bit matrices in same characteristic",
         IsIdenticalObj, [Is8BitMatrixRep,
                 Is8BitMatrixRep], ,
         DIFF_MAT8BIT_MAT8BIT
 );
-
-
-#############################################################################
-##
-#M  ConvertToMatrixRepNC( <list>, <fieldsize )
-#M  ConvertToMatrixRep( <list>[, <fieldsize> | <field>])
-##
-
 
 InstallGlobalFunction(ConvertToMatrixRep,
         function( arg )
@@ -395,7 +311,6 @@ InstallGlobalFunction(ConvertToMatrixRep,
     return q;
 end);
 
-
 InstallGlobalFunction(ConvertToMatrixRepNC, function(arg)
     local   v, m,  q, result;
     if Length(arg) = 1 then
@@ -430,22 +345,11 @@ InstallGlobalFunction(ConvertToMatrixRepNC, function(arg)
     return q;
 end);
 
-#############################################################################
-##
-#M <vec> * <mat>
-##
-
 InstallMethod( \*, "for an 8-bit vector and 8-bit matrix", IsElmsColls,
         [ Is8BitVectorRep and IsRowVector and IsRingElementList,
           Is8BitMatrixRep
           ],
         PROD_VEC8BIT_MAT8BIT);
-
-
-#############################################################################
-##
-#M <mat> * <vec>
-##
 
 InstallMethod( \*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
         [           Is8BitMatrixRep,
@@ -453,24 +357,14 @@ InstallMethod( \*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
           ],
         PROD_MAT8BIT_VEC8BIT);
 
-#############################################################################
-##
-#M <mat> * <mat>
-##
-
 InstallMethod( \*, "for 8-bit matrices", IsIdenticalObj,
         [           Is8BitMatrixRep,
                 Is8BitMatrixRep and IsMatrix
           ],
         PROD_MAT8BIT_MAT8BIT);
 
-#############################################################################
-##
-#M  <ffe> * <mat>
-##
-##  If <ffe> lies in the field of <mat> then we return a matrix in
-##  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
-##
+# If <ffe> lies in the field of <mat> then we return a matrix in
+# `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 
 InstallMethod( \*, "for an internal FFE and an 8 bit matrix", IsElmsCollColls,
         [           IsFFE and IsInternalRep,
@@ -506,14 +400,8 @@ InstallMethod( \*, "for an FFE and an 8-bit matrix", IsElmsCollColls,
     return s * m;
 end);
 
-
-#############################################################################
-##
-#M  <mat> * <ffe>
-##
-##  If <ffe> lies in the field of <mat> then we return a matrix in
-##  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
-##
+#  If <ffe> lies in the field of <mat> then we return a matrix in
+#  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 
 InstallMethod( \*, "for an 8-bit matrix and an internal FFE", IsCollCollsElms,
         [
@@ -549,12 +437,6 @@ InstallMethod( \*, "for an 8-bit matrix and an FFE", IsCollCollsElms,
     fi;
     return m * s;
 end);
-
-
-#############################################################################
-##
-#M  Additive Inverse
-##
 
 InstallMethod(AdditiveInverseMutable, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
@@ -601,12 +483,6 @@ InstallMethod(AdditiveInverseSameMutability, "for an 8-bit matrix",
     fi;
     return neg;
 end);
-
-
-
-#############################################################################
-##
-#M  Zero
 
 InstallMethod( ZeroMutable, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
@@ -665,32 +541,15 @@ InstallMethod( ZeroSameMutability, "for an 8-bit matrix",
     return z;
 end);
 
-#############################################################################
-##
-#M InverseOp(<mat>)
-##
-
 InstallMethod( InverseOp, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         INV_MAT8BIT_MUTABLE);
 
-
-
-#############################################################################
-##
-#M <mat>^-1
-##
-
 InstallMethod( InverseSameMutability, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         INV_MAT8BIT_SAME_MUTABILITY);
-
-#############################################################################
-##
-#M <mat>^0
-##
 
 InstallMethod( OneSameMutability, "for an 8-bit matrix",
         [Is8BitMatrixRep],
@@ -894,30 +753,15 @@ InstallMethod( \=, "for two 8-bit matrices", IsIdenticalObj,
         [ Is8BitMatrixRep, Is8BitMatrixRep ],
         EQ_MAT8BIT_MAT8BIT);
 
-#############################################################################
-##
-#M  TransposedMat( <mat> )
-#M  MutableTransposedMat( <mat> )
-##
-
-InstallOtherMethod( TransposedMat, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        TRANSPOSED_MAT8BIT);
+InstallOtherMethod(TransposedMat, "for an 8 - bit matrix",
+[Is8BitMatrixRep], TRANSPOSED_MAT8BIT);
 
 InstallOtherMethod( MutableTransposedMat, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        TRANSPOSED_MAT8BIT);
+[Is8BitMatrixRep], TRANSPOSED_MAT8BIT);
 
-
-#############################################################################
-##
-#M  SemiEchelonMat
-##
-#
-# If mat is in the  special representation, then we do
-# have to copy it, but we know that the rows of the result will
-# already be in special representation, so don't convert
-#
+# If mat is in the  special representation, then we do have to copy it, but we
+# know that the rows of the result will already be in special representation,
+# so don't convert
 
 InstallMethod(SemiEchelonMat, "for an 8-bit matrix",
         [ IsMatrix and Is8BitMatrixRep ],

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -23,28 +23,34 @@
 ##  without changing the kernel.
 
 if IsHPCGAP then
-    BindGlobal("TYPES_MAT8BIT", [ FixedAtomicList(256), FixedAtomicList(256) ]);
-    MakeReadOnlyObj(TYPES_MAT8BIT);
+  BindGlobal("TYPES_MAT8BIT", [FixedAtomicList(256), FixedAtomicList(256)]);
+  MakeReadOnlyObj(TYPES_MAT8BIT);
 else
-    BindGlobal("TYPES_MAT8BIT", [[],[]]);
-    TYPES_MAT8BIT[1][257] := 1;
-    TYPES_MAT8BIT[2][257] := 1;
+  BindGlobal("TYPES_MAT8BIT", [[], []]);
+  TYPES_MAT8BIT[1][257] := 1;
+  TYPES_MAT8BIT[2][257] := 1;
 fi;
 
 ##  Normally called by the kernel, caches results in TYPES_MAT8BIT,
 ##  which is directly accessed by the kernel
 
 InstallGlobalFunction(TYPE_MAT8BIT,
-  function( q, mut)
+  function(q, mut)
     local col, filts, type;
-    if mut then col := 1; else col := 2; fi;
+    if mut then
+      col := 1;
+    else
+      col := 2;
+    fi;
     if not IsBound(TYPES_MAT8BIT[col][q]) then
         filts := IsHomogeneousList and IsListDefault and IsCopyable and
                  Is8BitMatrixRep and IsSmallList and IsOrdinaryMatrix and
                  IsRingElementTable and IsNoImmediateMethodsObject and
                  HasIsRectangularTable and IsRectangularTable;
-        if mut then filts := filts and IsMutable; fi;
-        type := NewType(CollectionsFamily(FamilyObj(GF(q))),filts);
+        if mut then
+          filts := filts and IsMutable;
+        fi;
+        type := NewType(CollectionsFamily(FamilyObj(GF(q))), filts);
         if IsHPCGAP then
             InstallTypeSerializationTag(type, SERIALIZATION_BASE_MAT8BIT +
                         SERIALIZATION_TAG_BASE * (q * 2 + col - 1));
@@ -60,7 +66,7 @@ m -> m![1]);
 InstallOtherMethod(\[\], "for an 8 - bit matrix rep and pos. int.",
 [Is8BitMatrixRep, IsPosInt], ELM_MAT8BIT);
 
-InstallMethod(\[\,\],  "for an 8-bit matrix rep and 2 pos. int.",
+InstallMethod(\[\,\], "for an 8-bit matrix rep and 2 pos. int.",
 [Is8BitMatrixRep, IsPosInt, IsPosInt], MAT_ELM_MAT8BIT);
 
 # This may involve turning <mat> into a plain list, if <mat> does not lie in
@@ -71,692 +77,592 @@ InstallOtherMethod(\[\]\:\=,
 [IsMutable and Is8BitMatrixRep, IsPosInt, IsObject],
 ASS_MAT8BIT);
 
-InstallMethod( \[\,\]\:\=,
+InstallMethod(\[\,\]\:\=,
 "for a mutable 8-bit matrix rep, 2 pos. ints., and an object",
-        [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
-        SET_MAT_ELM_MAT8BIT
-        );
+[IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
+SET_MAT_ELM_MAT8BIT);
 
 # Unless the last position is being unbound, this will result in <mat> turning
 # into a plain list
 
-InstallMethod( Unbind\[\],
+InstallMethod(Unbind\[\],
 "for a mutable 8-bit matrix rep and pos. int.",
-        [IsMutable and Is8BitMatrixRep, IsPosInt],
-        function(m,p)
-    if p = 1 or  p <> m![1] then
-        PLAIN_MAT8BIT(m);
-        Unbind(m[p]);
-    else
-        m![1] := p-1;
-        Unbind(m![p+1]);
-    fi;
+[IsMutable and Is8BitMatrixRep, IsPosInt],
+function(m, p)
+  if p = 1 or p <> m![1] then
+    PLAIN_MAT8BIT(m);
+    Unbind(m[p]);
+  else
+    m![1] := p - 1;
+    Unbind(m![p + 1]);
+  fi;
 end);
 
 # Up to 25 entries,  GF(q) matrices are viewed in full, over that a description
 # is printed
 
-InstallMethod( ViewObj, "for an 8-bit matrix rep",
-         [Is8BitMatrixRep],
-        function( m )
-    local r,c;
-    r := NumberRows(m);
-    c := NumberColumns(m);
-    if r*c > 25 or r = 0 or c = 0 then
-        Print("< ");
-        if not IsMutable(m) then
-            Print("im");
-        fi;
-        # TODO change this to 8-bit ?
-        Print("mutable compressed matrix ",r,"x",c," over ", BaseDomain(m), " >");
-    else
-        PrintObj(m);
+InstallMethod(ViewObj, "for an 8 - bit matrix rep", [Is8BitMatrixRep],
+function(m)
+  local r, c;
+  r := NumberRows(m);
+  c := NumberColumns(m);
+  if r * c > 25 or r = 0 or c = 0 then
+    Print("< ");
+    if not IsMutable(m) then
+      Print("im");
     fi;
+    # TODO change this to 8-bit ?
+    Print("mutable compressed matrix ",
+          r,
+          "x",
+          c,
+          " over ",
+          BaseDomain(m),
+          " >");
+  else
+    PrintObj(m);
+  fi;
 end);
 
-InstallMethod( PrintObj,
-"for an 8-bit matrix rep",
-        [Is8BitMatrixRep],
-        function( mat )
-    local i,l;
-    Print("\>\>[ \>\>");
-    l := NumberRows(mat);
-    if l <> 0 then
-        PrintObj(mat[1]);
-        for i in [2..l] do
-            Print("\<,\< \>\>");
-            PrintObj(mat[i]);
-        od;
-    fi;
-    Print(" \<\<\<\<]");
-end);
-
-InstallMethod(ShallowCopy, "for an 8-bit matrix rep",
-        [Is8BitMatrixRep],
-        function(m)
-    local c,i,l;
-    l := m![1];
-    c := [l];
-    for i in [2..l+1] do
-        c[i] := m![i];
+InstallMethod(PrintObj, "for an 8-bit matrix rep", [Is8BitMatrixRep],
+function(mat)
+  local i, l;
+  Print("\>\>[ \>\>");
+  l := NumberRows(mat);
+  if l <> 0 then
+    PrintObj(mat[1]);
+    for i in [2 .. l] do
+      Print("\<,\< \>\>");
+      PrintObj(mat[i]);
     od;
-    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(m![2]), true),c);
-    return c;
-end );
+  fi;
+  Print(" \<\<\<\<]");
+end);
+
+# TODO renovate
+
+InstallMethod(ShallowCopy, "for an 8-bit matrix rep", [Is8BitMatrixRep],
+function(m)
+  local c, i, l;
+  l := m![1];
+  c := [l];
+  for i in [2 .. l + 1] do
+    c[i] := m![i];
+  od;
+  Objectify(TYPE_MAT8BIT(Q_VEC8BIT(m![2]), true), c);
+  return c;
+end);
 
 # TODO required?
 
-InstallMethod( PositionCanonical,
-    "for 8-bit matrix rep and object",
-    [ IsList and Is8BitMatrixRep, IsObject ],
-    function( list, obj )
-    return Position( list, obj, 0 );
-end );
+InstallMethod(PositionCanonical, "for 8-bit matrix rep and object",
+[IsList and Is8BitMatrixRep, IsObject],
+function(list, obj)
+  return Position(list, obj, 0);
+end);
 
-InstallMethod( \+, "for two 8-bit matrices",
-        IsIdenticalObj, [Is8BitMatrixRep,
-                Is8BitMatrixRep], ,
-        SUM_MAT8BIT_MAT8BIT
-);
+InstallMethod(\+, "for two 8-bit matrices", IsIdenticalObj,
+[Is8BitMatrixRep, Is8BitMatrixRep], SUM_MAT8BIT_MAT8BIT);
 
-InstallMethod( \-, "for two 8 bit matrices in same characteristic",
-        IsIdenticalObj, [Is8BitMatrixRep,
-                Is8BitMatrixRep], ,
-        DIFF_MAT8BIT_MAT8BIT
-);
+InstallMethod(\-, "for two 8-bit matrices", IsIdenticalObj,
+[Is8BitMatrixRep, Is8BitMatrixRep], DIFF_MAT8BIT_MAT8BIT);
 
 InstallGlobalFunction(ConvertToMatrixRep,
-        function( arg )
-    local m,qs, v,  q, givenq, q1, LeastCommonPower, lens;
+function(arg)
+  local m, qs, v, q, givenq, q1, LeastCommonPower, lens;
 
-    LeastCommonPower := function(qs)
-        local p, d, x, i;
-        if Length(qs) = 0 then
-            return fail;
-        fi;
-        x := Z(qs[1]);
-        p := Characteristic(x);
-        d := DegreeFFE(x);
-        for i in [2..Length(qs)] do
-            x := Z(qs[i]);
-            if p <> Characteristic(x) then
-                return fail;
-            fi;
-            d := Lcm(d, DegreeFFE(x));
-        od;
-        return p^d;
-    end;
-
-
-    qs := [];
-
-    m := arg[1];
-    if Length(arg) > 1 then
-        q1 := arg[2];
-        if not IsInt(q1) then
-            if IsField(q1) then
-                if Characteristic(q1) = 0 then
-                    return fail;
-                fi;
-                q1 := Size(q1);
-            else
-                return fail; # not a field -- exit
-            fi;
-        fi;
-        if q1 > 256 then
-            return fail;
-        fi;
-        givenq := true;
-        Add(qs,q1);
-    else
-        givenq := false;
+  LeastCommonPower := function(qs)
+    local p, d, x, i;
+    if Length(qs) = 0 then
+      return fail;
     fi;
-
-    if Length(m) = 0 then
-        if givenq then
-            return q1;
-        else
-            return fail;
-        fi;
-    fi;
-
-    #
-    # If we are already compressed, then our rows are certainly
-    #  locked, so we will not be able to change representation
-    #
-    if Is8BitMatrixRep(m) then
-        q := Q_VEC8BIT(m![2]);
-        if not givenq or q = q1 then
-            return q;
-        else
-            return fail;
-        fi;
-    fi;
-
-    if IsGF2MatrixRep(m) then
-        if not givenq or q1 = 2 then
-            return 2;
-        else
-            return fail;
-        fi;
-    fi;
-
-    #
-    # Pass 1, get all rows compressed, and find out what fields we have
-    #
-
-    #    mut := false;
-    lens := [];
-    for v in m do
-        if IsGF2VectorRep(v) then
-            AddSet(qs,2);
-        elif Is8BitVectorRep(v) then
-            AddSet(qs,Q_VEC8BIT(v));
-        elif givenq then
-            AddSet(qs,ConvertToVectorRepNC(v,q1));
-        else
-            AddSet(qs,ConvertToVectorRepNC(v));
-        fi;
-        AddSet(lens, Length(v));
-#        mut := mut or IsMutable(v);
+    x := Z(qs[1]);
+    p := Characteristic(x);
+    d := DegreeFFE(x);
+    for i in [2 .. Length(qs)] do
+      x := Z(qs[i]);
+      if p <> Characteristic(x) then
+        return fail;
+      fi;
+      d := Lcm(d, DegreeFFE(x));
     od;
+    return p ^ d;
+  end;
 
-    #
-    # We may know that there is no common field
-    # or that we can't win for some other reason
-    #
-    if
-      #      mut or
-      Length(lens) > 1 or lens[1] = 0 or
-      fail in qs  or true in qs then
+  qs := [];
+
+  m := arg[1];
+  if Length(arg) > 1 then
+    q1 := arg[2];
+    if not IsInt(q1) then
+      if IsField(q1) then
+        if Characteristic(q1) = 0 then
+          return fail;
+        fi;
+        q1 := Size(q1);
+      else
+        return fail;  # not a field -- exit
+      fi;
+    fi;
+    if q1 > 256 then
+      return fail;
+    fi;
+    givenq := true;
+    Add(qs, q1);
+  else
+    givenq := false;
+  fi;
+
+  if Length(m) = 0 then
+    if givenq then
+      return q1;
+    else
+      return fail;
+    fi;
+  fi;
+
+  # If we are already compressed, then our rows are certainly
+  # locked, so we will not be able to change representation
+  if Is8BitMatrixRep(m) then
+    q := Q_VEC8BIT(m![2]);
+    if not givenq or q = q1 then
+      return q;
+    else
+      return fail;
+    fi;
+  fi;
+
+  if IsGF2MatrixRep(m) then
+    if not givenq or q1 = 2 then
+      return 2;
+    else
+      return fail;
+    fi;
+  fi;
+
+  # Pass 1, get all rows compressed, and find out what fields we have
+  lens := [];
+  for v in m do
+    if IsGF2VectorRep(v) then
+      AddSet(qs, 2);
+    elif Is8BitVectorRep(v) then
+      AddSet(qs, Q_VEC8BIT(v));
+    elif givenq then
+      AddSet(qs, ConvertToVectorRepNC(v, q1));
+    else
+      AddSet(qs, ConvertToVectorRepNC(v));
+    fi;
+    AddSet(lens, Length(v));
+  od;
+
+    # We may know that there is no common field or that we can't win for some
+    # other reason
+    if Length(lens) > 1 or lens[1] = 0 or fail in qs  or true in qs then
         return fail;
     fi;
 
-    #
     # or it may be easy
-    #
     if Length(qs) = 1 then
         q := qs[1];
     else
+      # Now work out the common field
+      q := LeastCommonPower(qs);
 
-        #
-        # Now work out the common field
-        #
-        q := LeastCommonPower(qs);
+      if q = fail then
+        return fail;
+      fi;
 
-        if q = fail then
-            return fail;
+      if givenq and q1 <> q then
+        # TODO better error message
+        Error("ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over <q>");
+      fi;
+
+      # Now try and rewrite all the rows over this field
+      # this may fail if some rows are locked over a smaller field
+      for v in m do
+        if q <> ConvertToVectorRepNC(v, q) then
+          return fail;
         fi;
-
-        if givenq and q1 <> q then
-            Error("ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over <q>");
-        fi;
-
-        #
-        # Now try and rewrite all the rows over this field
-        # this may fail if some rows are locked over a smaller field
-        #
-
-        for v in m do
-            if q <> ConvertToVectorRepNC(v,q) then
-                return fail;
-            fi;
-        od;
+      od;
     fi;
 
     if q <= 256 then
-        ConvertToMatrixRepNC(m,q);
-    fi;
-
-    return q;
-end);
-
-InstallGlobalFunction(ConvertToMatrixRepNC, function(arg)
-    local   v, m,  q, result;
-    if Length(arg) = 1 then
-        return ConvertToMatrixRep(arg[1]);
-    else
-        m := arg[1];
-        q := arg[2];
-    fi;
-    if Length(m)=0 then
-        return ConvertToMatrixRep(m,q);
-    fi;
-    if not IsInt(q) then
-        q := Size(q);
-    fi;
-    if Is8BitMatrixRep(m) then
-        return Q_VEC8BIT(m[1]);
-    fi;
-    if IsGF2MatrixRep(m) then
-        return 2;
-    fi;
-    for v in m do
-        result := ConvertToVectorRepNC(v,q);
-        if result <> q then
-            return fail;
-        fi;
-    od;
-    if q = 2 then
-        CONV_GF2MAT(m);
-    elif q <= 256 then
-        CONV_MAT8BIT(m, q);
+      ConvertToMatrixRepNC(m, q);
     fi;
     return q;
 end);
 
-InstallMethod( \*, "for an 8-bit vector and 8-bit matrix", IsElmsColls,
-        [ Is8BitVectorRep and IsRowVector and IsRingElementList,
-          Is8BitMatrixRep
-          ],
-        PROD_VEC8BIT_MAT8BIT);
+InstallGlobalFunction(ConvertToMatrixRepNC,
+function(arg)
+  local v, m, q, result;
+  if Length(arg) = 1 then
+    return ConvertToMatrixRep(arg[1]);
+  else
+    m := arg[1];
+    q := arg[2];
+  fi;
+  if Length(m) = 0 then
+    return ConvertToMatrixRep(m, q);
+  fi;
+  if not IsInt(q) then
+    q := Size(q);
+  fi;
+  if Is8BitMatrixRep(m) then
+    return Q_VEC8BIT(m[1]);
+  fi;
+  if IsGF2MatrixRep(m) then
+    return 2;
+  fi;
+  for v in m do
+    result := ConvertToVectorRepNC(v, q);
+    if result <> q then
+      return fail;
+    fi;
+  od;
+  if q = 2 then
+    CONV_GF2MAT(m);
+  elif q <= 256 then
+    CONV_MAT8BIT(m, q);
+  fi;
+  return q;
+end);
 
-InstallMethod( \*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
-        [           Is8BitMatrixRep,
-                Is8BitVectorRep and IsRowVector and IsRingElementList
-          ],
-        PROD_MAT8BIT_VEC8BIT);
+InstallMethod(\*, "for an 8 - bit vector and 8 - bit matrix", IsElmsColls,
+[Is8BitVectorRep and IsRowVector and IsRingElementList, Is8BitMatrixRep],
+PROD_VEC8BIT_MAT8BIT);
 
-InstallMethod( \*, "for 8-bit matrices", IsIdenticalObj,
-        [           Is8BitMatrixRep,
-                Is8BitMatrixRep and IsMatrix
-          ],
-        PROD_MAT8BIT_MAT8BIT);
+InstallMethod(\*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
+[Is8BitMatrixRep, Is8BitVectorRep and IsRowVector and IsRingElementList],
+PROD_MAT8BIT_VEC8BIT);
+
+InstallMethod(\*, "for 8-bit matrices", IsIdenticalObj,
+[Is8BitMatrixRep, Is8BitMatrixRep], PROD_MAT8BIT_MAT8BIT);
 
 # If <ffe> lies in the field of <mat> then we return a matrix in
 # `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 
-InstallMethod( \*, "for an internal FFE and an 8 bit matrix", IsElmsCollColls,
-        [           IsFFE and IsInternalRep,
-                Is8BitMatrixRep
-          ],
-        function(s,m)
-    local q,i,l,r,pv;
-    q := Q_VEC8BIT(m![2]);
-    if not s in GF(q) then
-        TryNextMethod();
-    fi;
-    l := m![1];
-    r := [l];
-    for i in [2..l+1] do
-        pv := s*m![i];
-        SetFilterObj(pv, IsLockedRepresentationVector);
-        r[i] := pv;
-    od;
-    Objectify(TYPE_MAT8BIT(q, IsMutable(m)),r);
-    return r;
+InstallMethod(\*, "for an internal FFE and an 8-bit matrix", IsElmsCollColls,
+[IsFFE and IsInternalRep, Is8BitMatrixRep],
+function(s, m)
+  local q, i, l, r, pv;
+  q := Q_VEC8BIT(m![2]);
+  if not s in GF(q) then
+    TryNextMethod();
+  fi;
+  l := m![1];
+  r := [l];
+  for i in [2 .. l + 1] do
+    pv := s * m![i];
+    SetFilterObj(pv, IsLockedRepresentationVector);
+    r[i] := pv;
+  od;
+  Objectify(TYPE_MAT8BIT(q, IsMutable(m)), r);
+  return r;
 end);
 
-InstallMethod( \*, "for an FFE and an 8-bit matrix", IsElmsCollColls,
-    [ IsFFE, Is8BitMatrixRep ],
-    function( s, m )
-    if IsInternalRep( s ) then
-      TryNextMethod();
-    fi;
-    s:= AsInternalFFE( s );
-    if s = fail then
-      TryNextMethod();
-    fi;
-    return s * m;
+InstallMethod(\*, "for an FFE and an 8-bit matrix", IsElmsCollColls,
+[IsFFE, Is8BitMatrixRep],
+function(s, m)
+  if IsInternalRep(s) then
+    TryNextMethod();
+  fi;
+  s := AsInternalFFE(s);
+  if s = fail then
+    TryNextMethod();
+  fi;
+  return s * m;
 end);
 
 #  If <ffe> lies in the field of <mat> then we return a matrix in
 #  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 
-InstallMethod( \*, "for an 8-bit matrix and an internal FFE", IsCollCollsElms,
-        [
-                Is8BitMatrixRep,
-                IsFFE and IsInternalRep
-          ],
-        function(m,s)
-    local q,i,l,r,pv;
-    q := Q_VEC8BIT(m![2]);
-    if not s in GF(q) then
-        TryNextMethod();
-    fi;
-    l := m![1];
-    r := [l];
-    for i in [2..l+1] do
-        pv := m![i]*s;
-        SetFilterObj(pv, IsLockedRepresentationVector);
-        r[i] := pv;
-    od;
-    Objectify(TYPE_MAT8BIT(q, IsMutable(m)),r);
-    return r;
+InstallMethod(\*, "for an 8-bit matrix and an internal FFE", IsCollCollsElms,
+[Is8BitMatrixRep, IsFFE and IsInternalRep],
+function(m, s)
+  local q, i, l, r, pv;
+  q := Q_VEC8BIT(m![2]);
+  if not s in GF(q) then
+    TryNextMethod();
+  fi;
+  l := m![1];
+  r := [l];
+  for i in [2 .. l + 1] do
+    pv := m![i] * s;
+    SetFilterObj(pv, IsLockedRepresentationVector);
+    r[i] := pv;
+  od;
+  Objectify(TYPE_MAT8BIT(q, IsMutable(m)), r);
+  return r;
 end);
 
-InstallMethod( \*, "for an 8-bit matrix and an FFE", IsCollCollsElms,
-    [ Is8BitMatrixRep, IsFFE ],
-    function( m, s )
-    if IsInternalRep( s ) then
-      TryNextMethod();
-    fi;
-    s:= AsInternalFFE( s );
-    if s = fail then
-      TryNextMethod();
-    fi;
-    return m * s;
+InstallMethod(\*, "for an 8-bit matrix and an FFE", IsCollCollsElms,
+[Is8BitMatrixRep, IsFFE],
+function(m, s)
+  if IsInternalRep(s) then
+    TryNextMethod();
+  fi;
+  s := AsInternalFFE(s);
+  if s = fail then
+    TryNextMethod();
+  fi;
+  return m * s;
 end);
 
 InstallMethod(AdditiveInverseMutable, "for an 8-bit matrix",
-        [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        function(mat)
-    local neg,i,negv;
-    neg := [mat![1]];
-    for i in [2..mat![1]+1] do
-        negv := AdditiveInverseMutable(mat![i]);
-        SetFilterObj(negv, IsLockedRepresentationVector);
-        neg[i] := negv;
-    od;
-    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), neg);
-    return neg;
+[Is8BitMatrixRep and IsAdditiveElementWithZero],
+function(mat)
+  local neg, i, negv;
+  neg := [mat![1]];
+  for i in [2 .. mat![1] + 1] do
+    negv := AdditiveInverseMutable(mat![i]);
+    SetFilterObj(negv, IsLockedRepresentationVector);
+    neg[i] := negv;
+  od;
+  Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), true), neg);
+  return neg;
 end);
 
 InstallMethod(AdditiveInverseImmutable, "for an 8-bit matrix",
-        [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        function(mat)
-    local neg,i,negv;
-    neg := [mat![1]];
-    for i in [2..mat![1]+1] do
-        negv := AdditiveInverseImmutable(mat![i]);
-        SetFilterObj(negv, IsLockedRepresentationVector);
-        neg[i] := negv;
-    od;
-    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), neg);
-    return neg;
+[Is8BitMatrixRep and IsAdditiveElementWithZero],
+function(mat)
+  local neg, i, negv;
+  neg := [mat![1]];
+  for i in [2 .. mat![1] + 1] do
+    negv := AdditiveInverseImmutable(mat![i]);
+    SetFilterObj(negv, IsLockedRepresentationVector);
+    neg[i] := negv;
+  od;
+  Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), false), neg);
+  return neg;
 end);
 
 InstallMethod(AdditiveInverseSameMutability, "for an 8-bit matrix",
-        [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        function(mat)
-    local neg,i,negv;
-    neg := [mat![1]];
-    for i in [2..mat![1]+1] do
-        negv := AdditiveInverseSameMutability(mat![i]);
-        SetFilterObj(negv, IsLockedRepresentationVector);
-        neg[i] := negv;
-    od;
-    if IsMutable(mat) then
-        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), neg);
-    else
-        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), neg);
-    fi;
-    return neg;
+[Is8BitMatrixRep and IsAdditiveElementWithZero],
+function(mat)
+  local neg, i, negv;
+  neg := [mat![1]];
+  for i in [2 .. mat![1] + 1] do
+    negv := AdditiveInverseSameMutability(mat![i]);
+    SetFilterObj(negv, IsLockedRepresentationVector);
+    neg[i] := negv;
+  od;
+  if IsMutable(mat) then
+    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), true), neg);
+  else
+    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), false), neg);
+  fi;
+  return neg;
 end);
 
-InstallMethod( ZeroMutable, "for an 8-bit matrix",
-        [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        function(mat)
-    local z, i,zv;
-    z := [mat![1]];
-    for i in [2..mat![1]+1] do
-        zv := ZERO_VEC8BIT(mat![i]);
-        SetFilterObj(zv, IsLockedRepresentationVector);
-        z[i] := zv;
-    od;
-    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), z);
-    return z;
+InstallMethod(ZeroMutable, "for an 8-bit matrix",
+[Is8BitMatrixRep and IsAdditiveElementWithZero],
+function(mat)
+  local z, i, zv;
+  z := [mat![1]];
+  for i in [2 .. mat![1] + 1] do
+    zv := ZERO_VEC8BIT(mat![i]);
+    SetFilterObj(zv, IsLockedRepresentationVector);
+    z[i] := zv;
+  od;
+  Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), true), z);
+  return z;
 end);
 
-InstallMethod( ZeroImmutable, "for an 8-bit matrix",
-        [Is8BitMatrixRep and IsAdditiveElementWithZero],
+InstallMethod(ZeroImmutable, "for an 8-bit matrix",
+[Is8BitMatrixRep and IsAdditiveElementWithZero],
+function(mat)
+  local z, i, zv;
+  z := [mat![1]];
+  zv := ZERO_VEC8BIT(mat![2]);
+  SetFilterObj(zv, IsLockedRepresentationVector);
+  MakeImmutable(zv);
+  for i in [2 .. mat![1] + 1] do
+    z[i] := zv;
+  od;
+  Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), false), z);
+  return z;
+end);
 
-        function(mat)
-    local z, i,zv;
-    z := [mat![1]];
+InstallMethod(ZeroSameMutability, "for an 8-bit matrix",
+[Is8BitMatrixRep and IsAdditiveElementWithZero],
+function(mat)
+  local z, i, zv;
+  z := [mat![1]];
+  if not IsMutable(mat![2]) then
     zv := ZERO_VEC8BIT(mat![2]);
     SetFilterObj(zv, IsLockedRepresentationVector);
     MakeImmutable(zv);
-    for i in [2..mat![1]+1] do
-        z[i] := zv;
+    for i in [2 .. mat![1] + 1] do
+      z[i] := zv;
     od;
-    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), z);
-    return z;
-end);
-
-InstallMethod( ZeroSameMutability, "for an 8-bit matrix",
-        [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        function(mat)
-    local z, i,zv;
-    z := [mat![1]];
-    if not IsMutable(mat![2]) then
-        zv := ZERO_VEC8BIT(mat![2]);
-        SetFilterObj(zv, IsLockedRepresentationVector);
-        MakeImmutable(zv);
-        for i in [2..mat![1]+1] do
-            z[i] := zv;
-        od;
-    else
-        for i in [2..mat![1]+1] do
-            zv := ZERO_VEC8BIT(mat![i]);
-            SetFilterObj(zv,IsLockedRepresentationVector);
-            z[i] := zv;
-        od;
-    fi;
+  else
+    for i in [2 .. mat![1] + 1] do
+      zv := ZERO_VEC8BIT(mat![i]);
+      SetFilterObj(zv, IsLockedRepresentationVector);
+      z[i] := zv;
+    od;
+  fi;
     if IsMutable(mat) then
-       Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), z);
+       Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), true), z);
     else
-        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), z);
+        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), false), z);
     fi;
     return z;
 end);
 
-InstallMethod( InverseOp, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        SUM_FLAGS,
-        INV_MAT8BIT_MUTABLE);
+InstallMethod(InverseOp, "for an 8-bit matrix", [Is8BitMatrixRep], SUM_FLAGS,
+INV_MAT8BIT_MUTABLE);
 
-InstallMethod( InverseSameMutability, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        SUM_FLAGS,
-        INV_MAT8BIT_SAME_MUTABILITY);
+InstallMethod(InverseSameMutability, "for an 8-bit matrix", [Is8BitMatrixRep],
+SUM_FLAGS, INV_MAT8BIT_SAME_MUTABILITY);
 
-InstallMethod( OneSameMutability, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        SUM_FLAGS,
-        function(m)
-    local   v,  o,  one,  i,  w;
-    v := ZeroOp(m![2]);
-    o := [];
-    one := Z(Q_VEC8BIT(v))^0;
-    for i in [1..m![1]] do
-        w := ShallowCopy(v);
-        w[i] := one;
-        Add(o,w);
+InstallMethod(OneSameMutability, "for an 8-bit matrix", [Is8BitMatrixRep],
+SUM_FLAGS,
+function(m)
+  local v, o, one, w, i;
+  v := ZeroOp(m![2]);
+  o := [];
+  one := Z(Q_VEC8BIT(v)) ^ 0;
+  for i in [1 .. m![1]] do
+    w := ShallowCopy(v);
+    w[i] := one;
+    Add(o, w);
+  od;
+  if not IsMutable(m![2]) then
+    for i in [1 .. m![1]] do
+      MakeImmutable(o[i]);
     od;
-    if not IsMutable(m![2]) then
-        for i in [1..m![1]] do
-            MakeImmutable(o[i]);
-        od;
-    fi;
-    if not IsMutable(m) then
-        MakeImmutable(o);
-    fi;
-    ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
-    return o;
-end);
-
-InstallMethod( OneMutable, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        SUM_FLAGS,
-        function(m)
-    local   v,  o,  one,  i,  w;
-    v := ZeroOp(m![2]);
-    o := [];
-    one := Z(Q_VEC8BIT(v))^0;
-    for i in [1..m![1]] do
-        w := ShallowCopy(v);
-        w[i] := one;
-        Add(o,w);
-    od;
-    ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
-    return o;
-end);
-
-
-
-
-#############################################################################
-##
-#M One(<mat>) -- always immutable
-##
-
-InstallMethod( One, "for an 8-bit matrix",
-        [Is8BitMatrixRep],
-        SUM_FLAGS,
-        function(m)
-    local   o;
-    o := OneOp(m);
+  fi;
+  if not IsMutable(m) then
     MakeImmutable(o);
-    ConvertToMatrixRepNC(o, Q_VEC8BIT(m![2]));
-    return o;
-    end );
+  fi;
+  ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
+  return o;
+end);
 
-#############################################################################
-##
-#F  RepresentationsOfMatrix( <mat/vec> )
-##
-##
+InstallMethod(OneMutable, "for an 8-bit matrix", [Is8BitMatrixRep], SUM_FLAGS,
+function(m)
+  local v, o, one, w, i;
+  v := ZeroOp(m![2]);
+  o := [];
+  one := Z(Q_VEC8BIT(v)) ^ 0;
+  for i in [1 .. m![1]] do
+    w := ShallowCopy(v);
+    w[i] := one;
+    Add(o, w);
+  od;
+  ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
+  return o;
+end);
+
+# always immutable
+
+InstallMethod(One, "for an 8-bit matrix", [Is8BitMatrixRep], SUM_FLAGS,
+function(m)
+  local o;
+  o := OneOp(m);
+  MakeImmutable(o);
+  ConvertToMatrixRepNC(o, Q_VEC8BIT(m![2]));
+  return o;
+end);
 
 # TODO this function is probably not in the correct file.
 
-InstallGlobalFunction( RepresentationsOfMatrix,
-        function( m )
-    if not IsRowVector(m) and not IsMatrix(m) then
-        Print("Argument is not a matrix or vector\n");
-    fi;
+InstallGlobalFunction(RepresentationsOfMatrix,
+function(m)
+  if not IsRowVector(m) and not IsMatrix(m) then
+    Print("Argument is not a matrix or vector\n");
+  fi;
+  if IsMutable(m) then
+    Print("Mutable ");
+  else
+    Print("Immutable ");
+  fi;
+  if not IsMatrix(m) then
     if IsMutable(m) then
-        Print("Mutable ");
+      Print("Mutable ");
     else
-        Print("Immutable ");
+      Print("Immutable ");
     fi;
-    if not IsMatrix(m) then
-        if IsMutable(m) then
-            Print("Mutable ");
-        else
-            Print("Immutable ");
-        fi;
-        Print("Vector: ");
-        if IsGF2VectorRep(m) then
-            Print(" compressed over GF(2) ");
-        elif Is8BitVectorRep(m) then
-            Print(" compressed over GF(",Q_VEC8BIT(m),") ");
-        elif IsPlistRep(m) then
-            Print(" plain list, tnum: ",TNUM_OBJ(m)," ");
-            if TNUM_OBJ(m) in [T_PLIST_FFE,T_PLIST_FFE+1] then
-                Print("known to be vecffe over GF(",CHAR_FFE_DEFAULT(m[1]),"^",
-                      DEGREE_FFE_DEFAULT(m[1]),") ");
-            elif TNUM_OBJ(m) in [T_PLIST_CYC..T_PLIST_CYC_SSORT+1] then
-                Print("known to be vector of cyclotomics ");
-            fi;
-        else
-            Print(" not a compressed or plain list, representations: ",
-                  RepresentationsOfObject(m)," ");
-        fi;
-        if IsLockedRepresentationVector(m) then
-            Print("locked\n");
-        else
-            Print("unlocked\n");
-        fi;
-        return;
-    fi;
-    if IsMutable(m) then
-        if ForAll(m, IsMutable) then
-            Print(" with mutable rows ");
-        elif not ForAny(m, IsMutable) then
-            Print(" with immutable rows ");
-        else
-            Print(" with mixed mutability rows!! ");
-        fi;
-    fi;
-    if IsGF2MatrixRep(m) then
-        Print(" Compressed GF2 representation ");
-    elif Is8BitMatrixRep(m) then
-        Print(" Compressed 8 bit rep over GF(",Q_VEC8BIT(m[1]),
-              "), ");
+    Print("Vector: ");
+    if IsGF2VectorRep(m) then
+      Print(" compressed over GF(2) ");
+    elif Is8BitVectorRep(m) then
+      Print(" compressed over GF(", Q_VEC8BIT(m), ") ");
     elif IsPlistRep(m) then
-        Print(" plain list of vectors, tnum: ",TNUM_OBJ(m)," ");
-        if ForAll(m, IsGF2VectorRep) then
-            Print(" all rows GF2 compressed ");
-        elif ForAll(m, Is8BitVectorRep) then
-            Print(" all rows 8 bit compressed, fields ",
-                  Set(m,Q_VEC8BIT), " ");
-        elif ForAll(m, IsPlistRep) then
-            Print(" all rows plain lists, tnums: ", Set(m,
-                    TNUM_OBJ)," ");
-        else
-            Print(" mixed row representations or unusual row types ");
-        fi;
+      Print(" plain list, tnum: ", TNUM_OBJ(m), " ");
+      if TNUM_OBJ(m) in [T_PLIST_FFE, T_PLIST_FFE + 1] then
+        Print("known to be vecffe over GF(", CHAR_FFE_DEFAULT(m[1]), "^",
+        DEGREE_FFE_DEFAULT(m[1]), ") ");
+      elif TNUM_OBJ(m) in [T_PLIST_CYC .. T_PLIST_CYC_SSORT + 1] then
+        Print("known to be vector of cyclotomics ");
+      fi;
     else
-        Print(" unusual matrix representation: ",
-              RepresentationsOfObject(m)," ");
+      Print(" not a compressed or plain list, representations: ",
+      RepresentationsOfObject(m), " ");
     fi;
-    if ForAll(m, IsLockedRepresentationVector) then
-        Print(" all rows locked\n");
-    elif not ForAny(m, IsLockedRepresentationVector) then
-        Print(" no rows locked\n");
+    if IsLockedRepresentationVector(m) then
+      Print("locked\n");
     else
-        Print(" mixed lock status\n");
+      Print("unlocked\n");
     fi;
     return;
-    end
-    );
+  fi;
+  if IsMutable(m) then
+    if ForAll(m, IsMutable) then
+      Print(" with mutable rows ");
+    elif not ForAny(m, IsMutable) then
+      Print(" with immutable rows ");
+    else
+      Print(" with mixed mutability rows!! ");
+    fi;
+  fi;
+  if IsGF2MatrixRep(m) then
+    Print(" Compressed GF2 representation ");
+  elif Is8BitMatrixRep(m) then
+    Print(" Compressed 8 bit rep over GF(", Q_VEC8BIT(m[1]), "), ");
+  elif IsPlistRep(m) then
+    Print(" plain list of vectors, tnum: ", TNUM_OBJ(m), " ");
+    if ForAll(m, IsGF2VectorRep) then
+      Print(" all rows GF2 compressed ");
+    elif ForAll(m, Is8BitVectorRep) then
+      Print(" all rows 8 bit compressed, fields ", Set(m, Q_VEC8BIT), " ");
+    elif ForAll(m, IsPlistRep) then
+      Print(" all rows plain lists, tnums: ", Set(m, TNUM_OBJ), " ");
+    else
+      Print(" mixed row representations or unusual row types ");
+    fi;
+  else
+    Print(" unusual matrix representation: ",
+          RepresentationsOfObject(m),
+          " ");
+  fi;
+  if ForAll(m, IsLockedRepresentationVector) then
+    Print(" all rows locked\n");
+  elif not ForAny(m, IsLockedRepresentationVector) then
+    Print(" no rows locked\n");
+  else
+    Print(" mixed lock status\n");
+  fi;
+  return;
+end);
 
+InstallMethod(DefaultFieldOfMatrix, "for an 8-bit matrix",
+[IsMatrix and Is8BitMatrixRep],
+function(mat)
+  return GF(Q_VEC8BIT(mat![2]));
+end);
 
-#############################################################################
-##
-#M  ASS_LIST( <empty list>, <vec>)
-##
+InstallMethod(\<, "for two 8-bit matrices", IsIdenticalObj,
+[Is8BitMatrixRep, Is8BitMatrixRep], LT_MAT8BIT_MAT8BIT);
 
-#InstallMethod(ASS_LIST, "empty list and 8 bit vector", true,
-#        [IsEmpty and IsMutable and IsList and IsPlistRep, IsPosInt, Is8BitVectorRep],
-#        0,
-#        function(l,p,  v)
-#    if p <> 1 then
-#        PLAIN_MAT8BIT(l);
-#        l[p] := v;
-#    else
-#        l[1] := 1;
-#        l[2] := v;
-#        SetFilterObj(v,IsLockedRepresentationVector);
-#        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(v), true), l);
-#   fi;
-#end);
-
-
-#############################################################################
-##
-#M  DefaultFieldOfMatrix( <ffe-mat> )
-##
-InstallMethod( DefaultFieldOfMatrix,
-    "for an 8-bit matrix",
-    [ IsMatrix and Is8BitMatrixRep ],
-function( mat )
-    return GF(Q_VEC8BIT(mat![2]));
-end );
-
-#############################################################################
-##
-#M  <mat> < <mat>
-##
-
-InstallMethod( \<, "for two 8-bit matrices", IsIdenticalObj,
-        [ Is8BitMatrixRep, Is8BitMatrixRep ],
-        LT_MAT8BIT_MAT8BIT);
-
-#############################################################################
-##
-#M  <mat> = <mat>
-##
-
-InstallMethod( \=, "for two 8-bit matrices", IsIdenticalObj,
-        [ Is8BitMatrixRep, Is8BitMatrixRep ],
-        EQ_MAT8BIT_MAT8BIT);
+InstallMethod(\=, "for two 8-bit matrices", IsIdenticalObj,
+[Is8BitMatrixRep, Is8BitMatrixRep], EQ_MAT8BIT_MAT8BIT);
 
 InstallOtherMethod(TransposedMat, "for an 8 - bit matrix",
 [Is8BitMatrixRep], TRANSPOSED_MAT8BIT);
 
-InstallOtherMethod( MutableTransposedMat, "for an 8-bit matrix",
+InstallOtherMethod(MutableTransposedMat, "for an 8-bit matrix",
 [Is8BitMatrixRep], TRANSPOSED_MAT8BIT);
 
 # If mat is in the  special representation, then we do have to copy it, but we
@@ -764,108 +670,89 @@ InstallOtherMethod( MutableTransposedMat, "for an 8-bit matrix",
 # so don't convert
 
 InstallMethod(SemiEchelonMat, "for an 8-bit matrix",
-        [ IsMatrix and Is8BitMatrixRep ],
-        function( mat )
-    local copymat, res;
+[IsMatrix and Is8BitMatrixRep],
+function(mat)
+  local copymat, res;
 
-    copymat := List(mat, ShallowCopy);
-    res := SemiEchelonMatDestructive( copymat );
-    ConvertToMatrixRepNC(res.vectors,Q_VEC8BIT(mat![2]));
-    return res;
+  copymat := List(mat, ShallowCopy);
+  res := SemiEchelonMatDestructive(copymat);
+  ConvertToMatrixRepNC(res.vectors, Q_VEC8BIT(mat![2]));
+  return res;
 end);
 
 InstallMethod(SemiEchelonMatTransformation, "for an 8-bit matrix",
-        [ IsMatrix and Is8BitMatrixRep ],
-        function( mat )
-    local copymat,res,q;
-    copymat := List(mat, ShallowCopy);
-    res := SemiEchelonMatTransformationDestructive( copymat );
-    q := Q_VEC8BIT(mat![2]);
-    ConvertToMatrixRepNC(res.vectors,q);
-    ConvertToMatrixRepNC(res.coeffs,q);
-    ConvertToMatrixRepNC(res.relations,q);
-    return res;
+[IsMatrix and Is8BitMatrixRep],
+function(mat)
+  local copymat, res, q;
+  copymat := List(mat, ShallowCopy);
+  res := SemiEchelonMatTransformationDestructive(copymat);
+  q := Q_VEC8BIT(mat![2]);
+  ConvertToMatrixRepNC(res.vectors, q);
+  ConvertToMatrixRepNC(res.coeffs, q);
+  ConvertToMatrixRepNC(res.relations, q);
+  return res;
 end);
 
 # TODO: There's a bunch of argument checking in SEMIECHELON_LIST_VEC8BITS that
 # could be done by method selection.
 InstallMethod(SemiEchelonMatDestructive,
 "for mutable plist-rep matrix of FFEs",
-        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        SEMIECHELON_LIST_VEC8BITS
-        );
+[IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
+SEMIECHELON_LIST_VEC8BITS);
 
 # TODO: There's a bunch of argument checking in SEMIECHELON_LIST_VEC8BITS that
 # could be done by method selection.
 InstallMethod(SemiEchelonMatTransformationDestructive,
 "for mutable plist-rep matrix of FFEs",
-        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS);
+[IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
+SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS);
 
-
-
-#############################################################################
-##
-#M  TriangulizeMat( <plain list of GF2 vectors> )
-##
 InstallMethod(TriangulizeMat,
 "for mutable plist-rep matrix of FFEs",
-        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        TRIANGULIZE_LIST_VEC8BITS);
+[IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
+TRIANGULIZE_LIST_VEC8BITS);
 
 InstallMethod(TriangulizeMat,
-        "for a mutable 8-bit matrix",
-        [IsMutable and IsMatrix and Is8BitMatrixRep],
-        function(m)
-    local q,i,imms;
-    imms := [];
-    q := Q_VEC8BIT(m![2]);
-    PLAIN_MAT8BIT(m);
-    for i in [1..Length(m)] do
-        if not IsMutable(m[i]) then
-            m[i] := ShallowCopy(m[i]);
-            imms[i] := true;
-        else
-            imms[i] := false;
-        fi;
-    od;
-    TRIANGULIZE_LIST_VEC8BITS(m);
-    for i in [1..Length(m)] do
-        if imms[i] then
-            MakeImmutable(m[i]);
-        fi;
-    od;
-    CONV_MAT8BIT(m,q);
+"for a mutable 8-bit matrix",
+[IsMutable and IsMatrix and Is8BitMatrixRep],
+function(m)
+  local q, i, imms;
+  imms := [];
+  q := Q_VEC8BIT(m![2]);
+  PLAIN_MAT8BIT(m);
+  for i in [1 .. Length(m)] do
+    if not IsMutable(m[i]) then
+      m[i] := ShallowCopy(m[i]);
+      imms[i] := true;
+    else
+      imms[i] := false;
+    fi;
+  od;
+  TRIANGULIZE_LIST_VEC8BITS(m);
+  for i in [1 .. Length(m)] do
+    if imms[i] then
+      MakeImmutable(m[i]);
+    fi;
+  od;
+  CONV_MAT8BIT(m, q);
 end);
-
-#############################################################################
-##
-#M  DeterminantMatDestructive ( <plain list of GF2 vectors> )
-##
 
 InstallMethod(DeterminantMatDestructive,
 "for mutable plist-rep matrix of FFEs",
-        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        DETERMINANT_LIST_VEC8BITS);
-
-#############################################################################
-##
-#M  RankMatDestructive ( <plain list of GF2 vectors> )
-##
-
+[IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
+DETERMINANT_LIST_VEC8BITS);
 
 InstallMethod(RankMatDestructive,
 "for mutable plist-rep matrix of FFEs",
-        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        RANK_LIST_VEC8BITS);
+[IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
+RANK_LIST_VEC8BITS);
 
-InstallMethod(NestingDepthM, [Is8BitMatrixRep], m->2);
-InstallMethod(NestingDepthA, [Is8BitMatrixRep], m->2);
-InstallMethod(NestingDepthM, [Is8BitVectorRep], m->1);
-InstallMethod(NestingDepthA, [Is8BitVectorRep], m->1);
+InstallMethod(NestingDepthM, [Is8BitMatrixRep], m -> 2);
+InstallMethod(NestingDepthA, [Is8BitMatrixRep], m -> 2);
+InstallMethod(NestingDepthM, [Is8BitVectorRep], m -> 1);
+InstallMethod(NestingDepthA, [Is8BitVectorRep], m -> 1);
 
-InstallMethod(PostMakeImmutable, "for an 8-bit matrix",
-[Is8BitMatrixRep],
+InstallMethod(PostMakeImmutable, "for an 8-bit matrix", [Is8BitMatrixRep],
 function(m)
   local i;
   for i in [1 .. NumberRows(m)] do

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -70,16 +70,16 @@ end);
 #M  Length( <mat> )
 ##
 
-InstallOtherMethod( Length, "for a compressed MatFFE",
-        true, [IsList and Is8BitMatrixRep], 0, m->m![1]);
+InstallMethod( Length, "for an 8-bit matrix rep",
+        true, [Is8BitMatrixRep], 0, m->m![1]);
 
 #############################################################################
 ##
 #M  <mat> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "for a compressed MatFFE",
-        [IsList and Is8BitMatrixRep, IsPosInt],
+InstallOtherMethod( \[\],  "for an 8-bit matrix rep and pos. int.",
+        [Is8BitMatrixRep, IsPosInt],
         ELM_MAT8BIT
         );
 
@@ -88,7 +88,7 @@ InstallOtherMethod( \[\],  "for a compressed MatFFE",
 #M  <mat> [ <pos1>, <pos2> ]
 ##
 
-InstallMethod( \[\,\],  "for a compressed MatFFE",
+InstallMethod( \[\,\],  "for an 8-bit matrix rep and 2 pos. int.",
         [Is8BitMatrixRep, IsPosInt, IsPosInt],
         MAT_ELM_MAT8BIT
         );
@@ -101,8 +101,9 @@ InstallMethod( \[\,\],  "for a compressed MatFFE",
 ##  not lie in the appropriate field.
 ##
 
-InstallOtherMethod( \[\]\:\=,  "for a compressed MatFFE",
-        [IsMutable and IsList and Is8BitMatrixRep, IsPosInt, IsObject],
+InstallOtherMethod( \[\]\:\=,
+"for a mutable 8-bit matrix rep, a pos. int. and object",
+        [IsMutable and Is8BitMatrixRep, IsPosInt, IsObject],
         ASS_MAT8BIT
         );
 
@@ -111,7 +112,8 @@ InstallOtherMethod( \[\]\:\=,  "for a compressed MatFFE",
 #M  <mat> [ <pos1>, <pos2> ] := <val>
 ##
 
-InstallMethod( \[\,\]\:\=,  "for a compressed MatFFE",
+InstallMethod( \[\,\]\:\=,
+"for a mutable 8-bit matrix rep, 2 pos. ints., and an object",
         [IsMutable and Is8BitMatrixRep, IsPosInt, IsPosInt, IsObject],
         SET_MAT_ELM_MAT8BIT
         );
@@ -124,8 +126,9 @@ InstallMethod( \[\,\]\:\=,  "for a compressed MatFFE",
 ##  turning into a plain list
 ##
 
-InstallOtherMethod( Unbind\[\], "for a compressed MatFFE",
-        true, [IsMutable and IsList and Is8BitMatrixRep, IsPosInt],
+InstallMethod( Unbind\[\],
+"for a mutable 8-bit matrix rep and pos. int.",
+        true, [IsMutable and Is8BitMatrixRep, IsPosInt],
         0, function(m,p)
     if p = 1 or  p <> m![1] then
         PLAIN_MAT8BIT(m);
@@ -144,18 +147,19 @@ end);
 ##  description is printed
 ##
 
-InstallMethod( ViewObj, "for a compressed MatFFE",
-        true, [Is8BitMatrixRep and IsSmallList], 0,
+InstallMethod( ViewObj, "for an 8-bit matrix rep",
+        true, [Is8BitMatrixRep], 0,
         function( m )
     local r,c;
-    r := m![1];
-    c := LEN_VEC8BIT(m![2]);
+    r := NumberRows(m);
+    c := NumberColumns(m);
     if r*c > 25 or r = 0 or c = 0 then
         Print("< ");
         if not IsMutable(m) then
             Print("im");
         fi;
-        Print("mutable compressed matrix ",r,"x",c," over GF(",Q_VEC8BIT(m![2]),") >");
+        # TODO change this to 8-bit ?
+        Print("mutable compressed matrix ",r,"x",c," over ", BaseDomain(m), " >");
     else
         PrintObj(m);
     fi;
@@ -168,17 +172,18 @@ end);
 ##  Same method as for lists in internal rep.
 ##
 
-InstallMethod( PrintObj, "for a compressed MatFFE",
-        true, [Is8BitMatrixRep and IsSmallList], 0,
+InstallMethod( PrintObj,
+"for an 8-bit matrix rep",
+        true, [Is8BitMatrixRep], 0,
         function( mat )
     local i,l;
     Print("\>\>[ \>\>");
-    l := mat![1];
+    l := NumberRows(mat);
     if l <> 0 then
-        PrintObj(mat![2]);
+        PrintObj(mat[1]);
         for i in [2..l] do
             Print("\<,\< \>\>");
-            PrintObj(mat![i+1]);
+            PrintObj(mat[i]);
         od;
     fi;
     Print(" \<\<\<\<]");
@@ -190,8 +195,8 @@ end);
 ##
 ##
 
-InstallMethod(ShallowCopy, "for a compressed MatFFE",
-        true, [Is8BitMatrixRep and IsSmallList], 0,
+InstallMethod(ShallowCopy, "for an 8-bit matrix rep",
+        true, [Is8BitMatrixRep], 0,
         function(m)
     local c,i,l;
     l := m![1];
@@ -208,9 +213,11 @@ end );
 #M PositionCanonical( <mat> , <vec> )
 ##
 
+# TODO required?
+
 InstallMethod( PositionCanonical,
-    "for 8bit matrices lists, fall back on `Position'",
-    true, # the list may be non-homogeneous.
+    "for 8-bit matrix rep and object",
+    true,
     [ IsList and Is8BitMatrixRep, IsObject ], 0,
     function( list, obj )
     return Position( list, obj, 0 );
@@ -223,9 +230,9 @@ end );
 #M  <mat1> + <mat2>
 ##
 
-InstallMethod( \+, "for two 8 bit matrices in same characteristic",
-        IsIdenticalObj, [IsMatrix and Is8BitMatrixRep,
-                IsMatrix and Is8BitMatrixRep], 0,
+InstallMethod( \+, "for two 8-bit matrices",
+        IsIdenticalObj, [Is8BitMatrixRep,
+                Is8BitMatrixRep], 0,
         SUM_MAT8BIT_MAT8BIT
 );
 
@@ -235,8 +242,8 @@ InstallMethod( \+, "for two 8 bit matrices in same characteristic",
 ##
 
 InstallMethod( \-, "for two 8 bit matrices in same characteristic",
-        IsIdenticalObj, [IsMatrix and Is8BitMatrixRep,
-                IsMatrix and Is8BitMatrixRep], 0,
+        IsIdenticalObj, [Is8BitMatrixRep,
+                Is8BitMatrixRep], 0,
         DIFF_MAT8BIT_MAT8BIT
 );
 
@@ -434,9 +441,9 @@ end);
 #M <vec> * <mat>
 ##
 
-InstallMethod( \*, "8 bit vector * 8 bit matrix", IsElmsColls,
+InstallMethod( \*, "for an 8-bit vector and 8-bit matrix", IsElmsColls,
         [ Is8BitVectorRep and IsRowVector and IsRingElementList,
-          Is8BitMatrixRep and IsMatrix
+          Is8BitMatrixRep
           ], 0,
         PROD_VEC8BIT_MAT8BIT);
 
@@ -446,8 +453,8 @@ InstallMethod( \*, "8 bit vector * 8 bit matrix", IsElmsColls,
 #M <mat> * <vec>
 ##
 
-InstallMethod( \*, "8 bit matrix * 8 bit vector", IsCollsElms,
-        [           Is8BitMatrixRep and IsMatrix,
+InstallMethod( \*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
+        [           Is8BitMatrixRep,
                 Is8BitVectorRep and IsRowVector and IsRingElementList
           ], 0,
         PROD_MAT8BIT_VEC8BIT);
@@ -457,8 +464,8 @@ InstallMethod( \*, "8 bit matrix * 8 bit vector", IsCollsElms,
 #M <mat> * <mat>
 ##
 
-InstallMethod( \*, "8 bit matrix * 8 bit matrix", IsIdenticalObj,
-        [           Is8BitMatrixRep and IsMatrix,
+InstallMethod( \*, "for 8-bit matrices", IsIdenticalObj,
+        [           Is8BitMatrixRep,
                 Is8BitMatrixRep and IsMatrix
           ], 0,
         PROD_MAT8BIT_MAT8BIT);
@@ -471,9 +478,9 @@ InstallMethod( \*, "8 bit matrix * 8 bit matrix", IsIdenticalObj,
 ##  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 ##
 
-InstallMethod( \*, "internal FFE * 8 bit matrix", IsElmsCollColls,
+InstallMethod( \*, "for an internal FFE and an 8 bit matrix", IsElmsCollColls,
         [           IsFFE and IsInternalRep,
-                Is8BitMatrixRep and IsMatrix
+                Is8BitMatrixRep
           ], 0,
         function(s,m)
     local q,i,l,r,pv;
@@ -492,8 +499,8 @@ InstallMethod( \*, "internal FFE * 8 bit matrix", IsElmsCollColls,
     return r;
 end);
 
-InstallMethod( \*, "FFE * 8 bit matrix", IsElmsCollColls,
-    [ IsFFE, Is8BitMatrixRep and IsMatrix ],
+InstallMethod( \*, "for an FFE and an 8-bit matrix", IsElmsCollColls,
+    [ IsFFE, Is8BitMatrixRep ],
     function( s, m )
     if IsInternalRep( s ) then
       TryNextMethod();
@@ -514,9 +521,9 @@ end);
 ##  `Is8BitMatrixRep`, otherwise we delegate to a generic method.
 ##
 
-InstallMethod( \*, "8 bit matrix * internal FFE", IsCollCollsElms,
+InstallMethod( \*, "for an 8-bit matrix and an internal FFE", IsCollCollsElms,
         [
-                Is8BitMatrixRep and IsMatrix,
+                Is8BitMatrixRep,
                 IsFFE and IsInternalRep
           ], 0,
         function(m,s)
@@ -536,8 +543,8 @@ InstallMethod( \*, "8 bit matrix * internal FFE", IsCollCollsElms,
     return r;
 end);
 
-InstallMethod( \*, "8 bit matrix * FFE", IsCollCollsElms,
-    [ Is8BitMatrixRep and IsMatrix, IsFFE ],
+InstallMethod( \*, "for an 8-bit matrix and an FFE", IsCollCollsElms,
+    [ Is8BitMatrixRep, IsFFE ],
     function( m, s )
     if IsInternalRep( s ) then
       TryNextMethod();
@@ -555,9 +562,8 @@ end);
 #M  Additive Inverse
 ##
 
-InstallMethod(AdditiveInverseMutable, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
+InstallMethod(AdditiveInverseMutable, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep and IsAdditiveElementWithZero],
         0,
         function(mat)
     local neg,i,negv;
@@ -571,9 +577,8 @@ InstallMethod(AdditiveInverseMutable, "8 bit matrix", true,
     return neg;
 end);
 
-InstallMethod(AdditiveInverseImmutable, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
+InstallMethod(AdditiveInverseImmutable, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep and IsAdditiveElementWithZero],
         0,
         function(mat)
     local neg,i,negv;
@@ -587,9 +592,8 @@ InstallMethod(AdditiveInverseImmutable, "8 bit matrix", true,
     return neg;
 end);
 
-InstallMethod(AdditiveInverseSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
+InstallMethod(AdditiveInverseSameMutability, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep and IsAdditiveElementWithZero],
         0,
         function(mat)
     local neg,i,negv;
@@ -613,9 +617,8 @@ end);
 ##
 #M  Zero
 
-InstallMethod( ZeroMutable, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
+InstallMethod( ZeroMutable, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep and IsAdditiveElementWithZero],
         0,
         function(mat)
     local z, i,zv;
@@ -629,9 +632,8 @@ InstallMethod( ZeroMutable, "8 bit matrix", true,
     return z;
 end);
 
-InstallMethod( ZeroImmutable, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
+InstallMethod( ZeroImmutable, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep and IsAdditiveElementWithZero],
         0,
         function(mat)
     local z, i,zv;
@@ -646,9 +648,8 @@ InstallMethod( ZeroImmutable, "8 bit matrix", true,
     return z;
 end);
 
-InstallMethod( ZeroSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
+InstallMethod( ZeroSameMutability, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep and IsAdditiveElementWithZero],
         0,
         function(mat)
     local z, i,zv;
@@ -680,14 +681,9 @@ end);
 #M InverseOp(<mat>)
 ##
 
-InstallMethod( InverseOp, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
-        # the following are banalities, but they are required to get the
-        # ranking right
-        and IsOrdinaryMatrix and IsSmallList and
-        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-        ],
-        0,
+InstallMethod( InverseOp, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep],
+        SUM_FLAGS,
         INV_MAT8BIT_MUTABLE);
 
 
@@ -697,14 +693,9 @@ InstallMethod( InverseOp, "8 bit matrix", true,
 #M <mat>^-1
 ##
 
-InstallMethod( InverseSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
-        # the following are banalities, but they are required to get the
-        # ranking right
-        and IsOrdinaryMatrix and IsSmallList and
-        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-        ],
-        0,
+InstallMethod( InverseSameMutability, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep],
+        SUM_FLAGS,
         INV_MAT8BIT_SAME_MUTABILITY);
 
 #############################################################################
@@ -712,14 +703,9 @@ InstallMethod( InverseSameMutability, "8 bit matrix", true,
 #M <mat>^0
 ##
 
-InstallMethod( OneSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
-        # the following are banalities, but they are required to get the
-        # ranking right
-        and IsOrdinaryMatrix and IsSmallList and
-        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-        ],
-        0,
+InstallMethod( OneSameMutability, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep],
+        SUM_FLAGS,
         function(m)
     local   v,  o,  one,  i,  w;
     v := ZeroOp(m![2]);
@@ -742,14 +728,9 @@ InstallMethod( OneSameMutability, "8 bit matrix", true,
     return o;
 end);
 
-InstallMethod( OneMutable, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
-        # the following are banalities, but they are required to get the
-        # ranking right
-        and IsOrdinaryMatrix and IsSmallList and
-        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-        ],
-        0,
+InstallMethod( OneMutable, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep],
+        SUM_FLAGS,
         function(m)
     local   v,  o,  one,  i,  w;
     v := ZeroOp(m![2]);
@@ -772,14 +753,9 @@ end);
 #M One(<mat>) -- always immutable
 ##
 
-InstallMethod( One, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
-        # the following are banalities, but they are required to get the
-        # ranking right
-        and IsOrdinaryMatrix and IsSmallList and
-        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-        ],
-        0,
+InstallMethod( One, "for an 8-bit matrix", true,
+        [Is8BitMatrixRep],
+        SUM_FLAGS,
         function(m)
     local   o;
     o := OneOp(m);
@@ -793,6 +769,8 @@ InstallMethod( One, "8 bit matrix", true,
 #F  RepresentationsOfMatrix( <mat/vec> )
 ##
 ##
+
+# TODO this function is probably not in the correct file.
 
 InstallGlobalFunction( RepresentationsOfMatrix,
         function( m )
@@ -903,8 +881,8 @@ InstallGlobalFunction( RepresentationsOfMatrix,
 #M  DefaultFieldOfMatrix( <ffe-mat> )
 ##
 InstallMethod( DefaultFieldOfMatrix,
-    "method for a compressed matrix over GF(q)", true,
-    [ IsMatrix and IsFFECollColl and Is8BitMatrixRep ], 0,
+    "for an 8-bit matrix", true,
+    [ IsMatrix and Is8BitMatrixRep ], 0,
 function( mat )
     return GF(Q_VEC8BIT(mat![2]));
 end );
@@ -914,8 +892,8 @@ end );
 #M  <mat> < <mat>
 ##
 
-InstallMethod( \<, "for two compressed 8 bit matrices", IsIdenticalObj,
-        [ IsMatrix and IsFFECollColl and Is8BitMatrixRep, IsMatrix and IsFFECollColl and Is8BitMatrixRep ], 0,
+InstallMethod( \<, "for two 8-bit matrices", IsIdenticalObj,
+        [ Is8BitMatrixRep, Is8BitMatrixRep ], 0,
         LT_MAT8BIT_MAT8BIT);
 
 #############################################################################
@@ -923,8 +901,8 @@ InstallMethod( \<, "for two compressed 8 bit matrices", IsIdenticalObj,
 #M  <mat> = <mat>
 ##
 
-InstallMethod( \=, "for two compressed 8 bit matrices", IsIdenticalObj,
-        [ IsMatrix and IsFFECollColl and Is8BitMatrixRep, IsMatrix and IsFFECollColl and Is8BitMatrixRep ], 0,
+InstallMethod( \=, "for two 8-bit matrices", IsIdenticalObj,
+        [ Is8BitMatrixRep, Is8BitMatrixRep ], 0,
         EQ_MAT8BIT_MAT8BIT);
 
 #############################################################################
@@ -933,14 +911,12 @@ InstallMethod( \=, "for two compressed 8 bit matrices", IsIdenticalObj,
 #M  MutableTransposedMat( <mat> )
 ##
 
-InstallOtherMethod( TransposedMat, "for a compressed 8 bit matrix",
-        true, [IsMatrix and IsFFECollColl and
-        Is8BitMatrixRep ], 0,
+InstallOtherMethod( TransposedMat, "for an 8-bit matrix",
+        true, [Is8BitMatrixRep], 0,
         TRANSPOSED_MAT8BIT);
 
-InstallOtherMethod( MutableTransposedMat, "for a compressed 8 bit matrix",
-        true, [IsMatrix and IsFFECollColl and
-        Is8BitMatrixRep ], 0,
+InstallOtherMethod( MutableTransposedMat, "for an 8-bit matrix",
+        true, [Is8BitMatrixRep], 0,
         TRANSPOSED_MAT8BIT);
 
 
@@ -954,9 +930,9 @@ InstallOtherMethod( MutableTransposedMat, "for a compressed 8 bit matrix",
 # already be in special representation, so don't convert
 #
 
-InstallMethod(SemiEchelonMat, "shortcut method for 8bit matrices",
+InstallMethod(SemiEchelonMat, "for an 8-bit matrix",
         true,
-        [ IsMatrix and Is8BitMatrixRep and IsFFECollColl ],
+        [ IsMatrix and Is8BitMatrixRep ],
         0,
         function( mat )
     local copymat, res;
@@ -967,9 +943,9 @@ InstallMethod(SemiEchelonMat, "shortcut method for 8bit matrices",
     return res;
 end);
 
-InstallMethod(SemiEchelonMatTransformation, "shortcut method for 8bit matrices",
+InstallMethod(SemiEchelonMatTransformation, "for an 8-bit matrix",
         true,
-        [ IsMatrix and Is8BitMatrixRep and IsFFECollColl ],
+        [ IsMatrix and Is8BitMatrixRep ],
         0,
         function( mat )
     local copymat,res,q;
@@ -982,17 +958,22 @@ InstallMethod(SemiEchelonMatTransformation, "shortcut method for 8bit matrices",
     return res;
 end);
 
-InstallMethod(SemiEchelonMatDestructive, "kernel method for plain lists of 8bit vectors",
+# TODO: There's a bunch of argument checking in SEMIECHELON_LIST_VEC8BITS that
+# could be done by method selection.
+InstallMethod(SemiEchelonMatDestructive,
+"for mutable plist-rep matrix of FFEs",
         true,
-        [ IsPlistRep and IsMatrix and IsMutable and IsFFECollColl ],
+        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
         0,
         SEMIECHELON_LIST_VEC8BITS
         );
 
+# TODO: There's a bunch of argument checking in SEMIECHELON_LIST_VEC8BITS that
+# could be done by method selection.
 InstallMethod(SemiEchelonMatTransformationDestructive,
-        " kernel method for plain lists of 8 bit vectors",
+"for mutable plist-rep matrix of FFEs",
         true,
-        [ IsMatrix and IsFFECollColl and IsPlistRep and IsMutable],
+        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
         0,
         SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS);
 
@@ -1002,18 +983,18 @@ InstallMethod(SemiEchelonMatTransformationDestructive,
 ##
 #M  TriangulizeMat( <plain list of GF2 vectors> )
 ##
-
+# HERE
 InstallMethod(TriangulizeMat,
-        "kernel method for plain list of GF2 vectors",
+"for mutable plist-rep matrix of FFEs",
         true,
-        [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
+        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
         0,
         TRIANGULIZE_LIST_VEC8BITS);
 
 InstallMethod(TriangulizeMat,
-        "method for compressed matrices",
+        "for a mutable 8-bit matrix",
         true,
-        [IsMutable and IsMatrix and Is8BitMatrixRep and IsFFECollColl],
+        [IsMutable and IsMatrix and Is8BitMatrixRep],
         0,
         function(m)
     local q,i,imms;
@@ -1043,9 +1024,9 @@ end);
 ##
 
 InstallMethod(DeterminantMatDestructive,
-        "kernel method for plain list of GF2 vectors",
+"for mutable plist-rep matrix of FFEs",
         true,
-        [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
+        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
         0,
         DETERMINANT_LIST_VEC8BITS);
 
@@ -1055,9 +1036,9 @@ InstallMethod(DeterminantMatDestructive,
 ##
 
 
-InstallOtherMethod(RankMatDestructive,
-        "kernel method for plain list of GF2 vectors",
-        [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
+InstallMethod(RankMatDestructive,
+"for mutable plist-rep matrix of FFEs",
+        [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
         RANK_LIST_VEC8BITS);
 
 InstallMethod(NestingDepthM, [Is8BitMatrixRep], m->2);
@@ -1065,10 +1046,11 @@ InstallMethod(NestingDepthA, [Is8BitMatrixRep], m->2);
 InstallMethod(NestingDepthM, [Is8BitVectorRep], m->1);
 InstallMethod(NestingDepthA, [Is8BitVectorRep], m->1);
 
-InstallMethod(PostMakeImmutable, [Is8BitMatrixRep],
-        function(m)
-    local i;
-    for i in [2..m![1]] do
-        MakeImmutable(m![i]);
-    od;
+InstallMethod(PostMakeImmutable, "for an 8-bit matrix",
+[Is8BitMatrixRep],
+function(m)
+  local i;
+  for i in [1 .. NumberRows(m)] do
+    MakeImmutable(m[i]);
+  od;
 end);

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -60,10 +60,10 @@ InstallGlobalFunction(TYPE_MAT8BIT,
     return TYPES_MAT8BIT[col][q];
 end);
 
-InstallMethod(Length, "for an 8 - bit matrix rep", [Is8BitMatrixRep],
+InstallMethod(Length, "for an 8-bit matrix rep", [Is8BitMatrixRep],
 m -> m![1]);
 
-InstallOtherMethod(\[\], "for an 8 - bit matrix rep and pos. int.",
+InstallOtherMethod(\[\], "for an 8-bit matrix rep and pos. int.",
 [Is8BitMatrixRep, IsPosInt], ELM_MAT8BIT);
 
 InstallMethod(\[\,\], "for an 8-bit matrix rep and 2 pos. int.",
@@ -327,7 +327,7 @@ function(arg)
   return q;
 end);
 
-InstallMethod(\*, "for an 8 - bit vector and 8 - bit matrix", IsElmsColls,
+InstallMethod(\*, "for an 8-bit vector and 8-bit matrix", IsElmsColls,
 [Is8BitVectorRep and IsRowVector and IsRingElementList, Is8BitMatrixRep],
 PROD_VEC8BIT_MAT8BIT);
 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -70,28 +70,24 @@ end);
 #M  Length( <mat> )
 ##
 
-InstallMethod( Length, "for an 8-bit matrix rep",
-        true, [Is8BitMatrixRep], 0, m->m![1]);
+InstallMethod(Length, "for an 8 - bit matrix rep", [Is8BitMatrixRep],
+m -> m![1]);
 
 #############################################################################
 ##
 #M  <mat> [ <pos> ]
 ##
 
-InstallOtherMethod( \[\],  "for an 8-bit matrix rep and pos. int.",
-        [Is8BitMatrixRep, IsPosInt],
-        ELM_MAT8BIT
-        );
+InstallOtherMethod(\[\], "for an 8 - bit matrix rep and pos. int.",
+[Is8BitMatrixRep, IsPosInt], ELM_MAT8BIT);
 
 #############################################################################
 ##
 #M  <mat> [ <pos1>, <pos2> ]
 ##
 
-InstallMethod( \[\,\],  "for an 8-bit matrix rep and 2 pos. int.",
-        [Is8BitMatrixRep, IsPosInt, IsPosInt],
-        MAT_ELM_MAT8BIT
-        );
+InstallMethod(\[\,\],  "for an 8-bit matrix rep and 2 pos. int.",
+[Is8BitMatrixRep, IsPosInt, IsPosInt], MAT_ELM_MAT8BIT);
 
 #############################################################################
 ##
@@ -101,11 +97,10 @@ InstallMethod( \[\,\],  "for an 8-bit matrix rep and 2 pos. int.",
 ##  not lie in the appropriate field.
 ##
 
-InstallOtherMethod( \[\]\:\=,
+InstallOtherMethod(\[\]\:\=,
 "for a mutable 8-bit matrix rep, a pos. int. and object",
-        [IsMutable and Is8BitMatrixRep, IsPosInt, IsObject],
-        ASS_MAT8BIT
-        );
+[IsMutable and Is8BitMatrixRep, IsPosInt, IsObject],
+ASS_MAT8BIT);
 
 #############################################################################
 ##
@@ -128,8 +123,8 @@ InstallMethod( \[\,\]\:\=,
 
 InstallMethod( Unbind\[\],
 "for a mutable 8-bit matrix rep and pos. int.",
-        true, [IsMutable and Is8BitMatrixRep, IsPosInt],
-        0, function(m,p)
+        [IsMutable and Is8BitMatrixRep, IsPosInt],
+        function(m,p)
     if p = 1 or  p <> m![1] then
         PLAIN_MAT8BIT(m);
         Unbind(m[p]);
@@ -148,7 +143,7 @@ end);
 ##
 
 InstallMethod( ViewObj, "for an 8-bit matrix rep",
-        true, [Is8BitMatrixRep], 0,
+         [Is8BitMatrixRep],
         function( m )
     local r,c;
     r := NumberRows(m);
@@ -174,7 +169,7 @@ end);
 
 InstallMethod( PrintObj,
 "for an 8-bit matrix rep",
-        true, [Is8BitMatrixRep], 0,
+        [Is8BitMatrixRep],
         function( mat )
     local i,l;
     Print("\>\>[ \>\>");
@@ -196,7 +191,7 @@ end);
 ##
 
 InstallMethod(ShallowCopy, "for an 8-bit matrix rep",
-        true, [Is8BitMatrixRep], 0,
+        [Is8BitMatrixRep],
         function(m)
     local c,i,l;
     l := m![1];
@@ -217,8 +212,7 @@ end );
 
 InstallMethod( PositionCanonical,
     "for 8-bit matrix rep and object",
-    true,
-    [ IsList and Is8BitMatrixRep, IsObject ], 0,
+    [ IsList and Is8BitMatrixRep, IsObject ],
     function( list, obj )
     return Position( list, obj, 0 );
 end );
@@ -232,7 +226,7 @@ end );
 
 InstallMethod( \+, "for two 8-bit matrices",
         IsIdenticalObj, [Is8BitMatrixRep,
-                Is8BitMatrixRep], 0,
+                Is8BitMatrixRep], ,
         SUM_MAT8BIT_MAT8BIT
 );
 
@@ -243,7 +237,7 @@ InstallMethod( \+, "for two 8-bit matrices",
 
 InstallMethod( \-, "for two 8 bit matrices in same characteristic",
         IsIdenticalObj, [Is8BitMatrixRep,
-                Is8BitMatrixRep], 0,
+                Is8BitMatrixRep], ,
         DIFF_MAT8BIT_MAT8BIT
 );
 
@@ -444,7 +438,7 @@ end);
 InstallMethod( \*, "for an 8-bit vector and 8-bit matrix", IsElmsColls,
         [ Is8BitVectorRep and IsRowVector and IsRingElementList,
           Is8BitMatrixRep
-          ], 0,
+          ],
         PROD_VEC8BIT_MAT8BIT);
 
 
@@ -456,7 +450,7 @@ InstallMethod( \*, "for an 8-bit vector and 8-bit matrix", IsElmsColls,
 InstallMethod( \*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
         [           Is8BitMatrixRep,
                 Is8BitVectorRep and IsRowVector and IsRingElementList
-          ], 0,
+          ],
         PROD_MAT8BIT_VEC8BIT);
 
 #############################################################################
@@ -467,7 +461,7 @@ InstallMethod( \*, "for 8-bit matrix and 8-bit vector", IsCollsElms,
 InstallMethod( \*, "for 8-bit matrices", IsIdenticalObj,
         [           Is8BitMatrixRep,
                 Is8BitMatrixRep and IsMatrix
-          ], 0,
+          ],
         PROD_MAT8BIT_MAT8BIT);
 
 #############################################################################
@@ -481,7 +475,7 @@ InstallMethod( \*, "for 8-bit matrices", IsIdenticalObj,
 InstallMethod( \*, "for an internal FFE and an 8 bit matrix", IsElmsCollColls,
         [           IsFFE and IsInternalRep,
                 Is8BitMatrixRep
-          ], 0,
+          ],
         function(s,m)
     local q,i,l,r,pv;
     q := Q_VEC8BIT(m![2]);
@@ -525,7 +519,7 @@ InstallMethod( \*, "for an 8-bit matrix and an internal FFE", IsCollCollsElms,
         [
                 Is8BitMatrixRep,
                 IsFFE and IsInternalRep
-          ], 0,
+          ],
         function(m,s)
     local q,i,l,r,pv;
     q := Q_VEC8BIT(m![2]);
@@ -562,9 +556,8 @@ end);
 #M  Additive Inverse
 ##
 
-InstallMethod(AdditiveInverseMutable, "for an 8-bit matrix", true,
+InstallMethod(AdditiveInverseMutable, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        0,
         function(mat)
     local neg,i,negv;
     neg := [mat![1]];
@@ -577,9 +570,8 @@ InstallMethod(AdditiveInverseMutable, "for an 8-bit matrix", true,
     return neg;
 end);
 
-InstallMethod(AdditiveInverseImmutable, "for an 8-bit matrix", true,
+InstallMethod(AdditiveInverseImmutable, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        0,
         function(mat)
     local neg,i,negv;
     neg := [mat![1]];
@@ -592,9 +584,8 @@ InstallMethod(AdditiveInverseImmutable, "for an 8-bit matrix", true,
     return neg;
 end);
 
-InstallMethod(AdditiveInverseSameMutability, "for an 8-bit matrix", true,
+InstallMethod(AdditiveInverseSameMutability, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        0,
         function(mat)
     local neg,i,negv;
     neg := [mat![1]];
@@ -617,9 +608,8 @@ end);
 ##
 #M  Zero
 
-InstallMethod( ZeroMutable, "for an 8-bit matrix", true,
+InstallMethod( ZeroMutable, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        0,
         function(mat)
     local z, i,zv;
     z := [mat![1]];
@@ -632,9 +622,9 @@ InstallMethod( ZeroMutable, "for an 8-bit matrix", true,
     return z;
 end);
 
-InstallMethod( ZeroImmutable, "for an 8-bit matrix", true,
+InstallMethod( ZeroImmutable, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        0,
+
         function(mat)
     local z, i,zv;
     z := [mat![1]];
@@ -648,9 +638,8 @@ InstallMethod( ZeroImmutable, "for an 8-bit matrix", true,
     return z;
 end);
 
-InstallMethod( ZeroSameMutability, "for an 8-bit matrix", true,
+InstallMethod( ZeroSameMutability, "for an 8-bit matrix",
         [Is8BitMatrixRep and IsAdditiveElementWithZero],
-        0,
         function(mat)
     local z, i,zv;
     z := [mat![1]];
@@ -681,7 +670,7 @@ end);
 #M InverseOp(<mat>)
 ##
 
-InstallMethod( InverseOp, "for an 8-bit matrix", true,
+InstallMethod( InverseOp, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         INV_MAT8BIT_MUTABLE);
@@ -693,7 +682,7 @@ InstallMethod( InverseOp, "for an 8-bit matrix", true,
 #M <mat>^-1
 ##
 
-InstallMethod( InverseSameMutability, "for an 8-bit matrix", true,
+InstallMethod( InverseSameMutability, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         INV_MAT8BIT_SAME_MUTABILITY);
@@ -703,7 +692,7 @@ InstallMethod( InverseSameMutability, "for an 8-bit matrix", true,
 #M <mat>^0
 ##
 
-InstallMethod( OneSameMutability, "for an 8-bit matrix", true,
+InstallMethod( OneSameMutability, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         function(m)
@@ -728,7 +717,7 @@ InstallMethod( OneSameMutability, "for an 8-bit matrix", true,
     return o;
 end);
 
-InstallMethod( OneMutable, "for an 8-bit matrix", true,
+InstallMethod( OneMutable, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         function(m)
@@ -753,7 +742,7 @@ end);
 #M One(<mat>) -- always immutable
 ##
 
-InstallMethod( One, "for an 8-bit matrix", true,
+InstallMethod( One, "for an 8-bit matrix",
         [Is8BitMatrixRep],
         SUM_FLAGS,
         function(m)
@@ -881,8 +870,8 @@ InstallGlobalFunction( RepresentationsOfMatrix,
 #M  DefaultFieldOfMatrix( <ffe-mat> )
 ##
 InstallMethod( DefaultFieldOfMatrix,
-    "for an 8-bit matrix", true,
-    [ IsMatrix and Is8BitMatrixRep ], 0,
+    "for an 8-bit matrix",
+    [ IsMatrix and Is8BitMatrixRep ],
 function( mat )
     return GF(Q_VEC8BIT(mat![2]));
 end );
@@ -893,7 +882,7 @@ end );
 ##
 
 InstallMethod( \<, "for two 8-bit matrices", IsIdenticalObj,
-        [ Is8BitMatrixRep, Is8BitMatrixRep ], 0,
+        [ Is8BitMatrixRep, Is8BitMatrixRep ],
         LT_MAT8BIT_MAT8BIT);
 
 #############################################################################
@@ -902,7 +891,7 @@ InstallMethod( \<, "for two 8-bit matrices", IsIdenticalObj,
 ##
 
 InstallMethod( \=, "for two 8-bit matrices", IsIdenticalObj,
-        [ Is8BitMatrixRep, Is8BitMatrixRep ], 0,
+        [ Is8BitMatrixRep, Is8BitMatrixRep ],
         EQ_MAT8BIT_MAT8BIT);
 
 #############################################################################
@@ -912,11 +901,11 @@ InstallMethod( \=, "for two 8-bit matrices", IsIdenticalObj,
 ##
 
 InstallOtherMethod( TransposedMat, "for an 8-bit matrix",
-        true, [Is8BitMatrixRep], 0,
+        [Is8BitMatrixRep],
         TRANSPOSED_MAT8BIT);
 
 InstallOtherMethod( MutableTransposedMat, "for an 8-bit matrix",
-        true, [Is8BitMatrixRep], 0,
+        [Is8BitMatrixRep],
         TRANSPOSED_MAT8BIT);
 
 
@@ -931,9 +920,7 @@ InstallOtherMethod( MutableTransposedMat, "for an 8-bit matrix",
 #
 
 InstallMethod(SemiEchelonMat, "for an 8-bit matrix",
-        true,
         [ IsMatrix and Is8BitMatrixRep ],
-        0,
         function( mat )
     local copymat, res;
 
@@ -944,9 +931,7 @@ InstallMethod(SemiEchelonMat, "for an 8-bit matrix",
 end);
 
 InstallMethod(SemiEchelonMatTransformation, "for an 8-bit matrix",
-        true,
         [ IsMatrix and Is8BitMatrixRep ],
-        0,
         function( mat )
     local copymat,res,q;
     copymat := List(mat, ShallowCopy);
@@ -962,9 +947,7 @@ end);
 # could be done by method selection.
 InstallMethod(SemiEchelonMatDestructive,
 "for mutable plist-rep matrix of FFEs",
-        true,
         [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        0,
         SEMIECHELON_LIST_VEC8BITS
         );
 
@@ -972,9 +955,7 @@ InstallMethod(SemiEchelonMatDestructive,
 # could be done by method selection.
 InstallMethod(SemiEchelonMatTransformationDestructive,
 "for mutable plist-rep matrix of FFEs",
-        true,
         [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        0,
         SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS);
 
 
@@ -983,19 +964,14 @@ InstallMethod(SemiEchelonMatTransformationDestructive,
 ##
 #M  TriangulizeMat( <plain list of GF2 vectors> )
 ##
-# HERE
 InstallMethod(TriangulizeMat,
 "for mutable plist-rep matrix of FFEs",
-        true,
         [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        0,
         TRIANGULIZE_LIST_VEC8BITS);
 
 InstallMethod(TriangulizeMat,
         "for a mutable 8-bit matrix",
-        true,
         [IsMutable and IsMatrix and Is8BitMatrixRep],
-        0,
         function(m)
     local q,i,imms;
     imms := [];
@@ -1025,9 +1001,7 @@ end);
 
 InstallMethod(DeterminantMatDestructive,
 "for mutable plist-rep matrix of FFEs",
-        true,
         [IsPlistRep and IsMatrix and IsMutable and IsFFECollColl],
-        0,
         DETERMINANT_LIST_VEC8BITS);
 
 #############################################################################

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -390,23 +390,6 @@ function(mat)
   return neg;
 end);
 
-# TODO is the next method required? Doesn't use the representation at all
-
-InstallMethod(AdditiveInverseImmutable, "for an 8-bit matrix",
-[Is8BitMatrixRep and IsAdditiveElementWithZero],
-mat -> MakeImmutable(AdditiveInverseMutable(mat)));
-
-# TODO is the next method required? Doesn't use the representation at all
-
-InstallMethod(AdditiveInverseSameMutability, "for an 8-bit matrix",
-[Is8BitMatrixRep and IsAdditiveElementWithZero],
-function(mat)
-  if IsMutable(mat) then
-    return AdditiveInverseMutable(mat);
-  fi;
-  return AdditiveInverseImmutable(mat);
-end);
-
 InstallMethod(ZeroMutable, "for an 8-bit matrix",
 [Is8BitMatrixRep and IsAdditiveElementWithZero],
 function(mat)
@@ -419,23 +402,6 @@ function(mat)
   od;
   Objectify(TYPE_MAT8BIT(Size(BaseDomain(mat)), true), z);
   return z;
-end);
-
-# TODO is the next method required? Doesn't use the representation at all
-
-InstallMethod(ZeroImmutable, "for an 8-bit matrix",
-[Is8BitMatrixRep and IsAdditiveElementWithZero],
-mat -> MakeImmutable(ZeroMutable(mat)));
-
-# TODO is the next method required? Doesn't use the representation at all
-
-InstallMethod(ZeroSameMutability, "for an 8-bit matrix",
-[Is8BitMatrixRep and IsAdditiveElementWithZero],
-function(mat)
-  if IsMutable(mat) then
-    return ZeroMutable(mat);
-  fi;
-  return ZeroImmutable(mat);
 end);
 
 InstallMethod(InverseMutable, "for an 8-bit matrix", [Is8BitMatrixRep],
@@ -457,20 +423,6 @@ function(m)
   od;
   ConvertToMatrixRepNC(o, Size(BaseDomain(m)));
   return o;
-end);
-
-# TODO is the next method required? Doesn't use the representation at all
-InstallMethod(OneImmutable, "for an 8-bit matrix", [Is8BitMatrixRep],
-SUM_FLAGS, m -> MakeImmutable(OneMutable(m)));
-
-# TODO is the next method required? Doesn't use the representation at all
-InstallMethod(OneSameMutability, "for an 8-bit matrix", [Is8BitMatrixRep],
-SUM_FLAGS,
-function(m)
-  if IsMutable(m) then
-    return OneMutable(m);
-  fi;
-  return OneImmutable(m);
 end);
 
 # TODO this function is probably not in the correct file.

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -14,13 +14,12 @@
 ##  all rows must be the same length and written over the same field
 ##
 
-##  A length 2 list of length 257 lists. TYPES_MAT8BIT[1][q] will be the type
-##  of mutable vectors over GF(q), TYPES_MAT8BIT[2][q] is the type of
-##  immutable vectors. The 257th position is bound to 1 to stop the lists
-##  shrinking.
-##
-##  It is accessed directly by the kernel, so the format cannot be changed
-##  without changing the kernel.
+# A length 2 list of length 257 lists. TYPES_MAT8BIT[1][q] will be the type of
+# mutable matrices over GF(q), TYPES_MAT8BIT[2][q] is the type of immutable
+# matrices. The 257th position is bound to 1 to stop the lists shrinking.
+#
+# It is accessed directly by the kernel, so the format cannot be changed
+# without changing the kernel.
 
 if IsHPCGAP then
   BindGlobal("TYPES_MAT8BIT", [FixedAtomicList(256), FixedAtomicList(256)]);
@@ -31,8 +30,8 @@ else
   TYPES_MAT8BIT[2][257] := 1;
 fi;
 
-##  Normally called by the kernel, caches results in TYPES_MAT8BIT,
-##  which is directly accessed by the kernel
+# Normally called by the kernel, caches results in TYPES_MAT8BIT, which is
+# directly accessed by the kernel
 
 InstallGlobalFunction(TYPE_MAT8BIT,
   function(q, mut)

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -8,7 +8,7 @@
 ##
 ##  SPDX-License-Identifier: GPL-2.0-or-later
 ##
-##  This file is a first stab at a special posobj-based representation 
+##  This file is a first stab at a special posobj-based representation
 ##  for 8 bit matrices, mimicking the one for GF(2)
 ##
 ##  all rows must be the same length and written over the same field
@@ -19,7 +19,7 @@
 #V  TYPES_MAT8BIT . . . . . . . . prepared types for compressed GF(q) vectors
 ##
 ##  A length 2 list of length 257 lists. TYPES_MAT8BIT[1][q] will be the type
-##  of mutable vectors over GF(q), TYPES_MAT8BIT[2][q] is the type of 
+##  of mutable vectors over GF(q), TYPES_MAT8BIT[2][q] is the type of
 ##  immutable vectors. The 257th position is bound to 1 to stop the lists
 ##  shrinking.
 ##
@@ -51,7 +51,7 @@ InstallGlobalFunction(TYPE_MAT8BIT,
     if not IsBound(TYPES_MAT8BIT[col][q]) then
         filts := IsHomogeneousList and IsListDefault and IsCopyable and
                  Is8BitMatrixRep and IsSmallList and IsOrdinaryMatrix and
-                 IsRingElementTable and IsNoImmediateMethodsObject and 
+                 IsRingElementTable and IsNoImmediateMethodsObject and
                  HasIsRectangularTable and IsRectangularTable;
         if mut then filts := filts and IsMutable; fi;
         type := NewType(CollectionsFamily(FamilyObj(GF(q))),filts);
@@ -140,7 +140,7 @@ end);
 ##
 #M  ViewObj( <mat> )
 ##
-##  Up to 25 entries,  GF(q) matrices are viewed in full, over that a 
+##  Up to 25 entries,  GF(q) matrices are viewed in full, over that a
 ##  description is printed
 ##
 
@@ -165,7 +165,7 @@ end);
 ##
 #M  PrintObj( <mat> )
 ##
-##  Same method as for lists in internal rep. 
+##  Same method as for lists in internal rep.
 ##
 
 InstallMethod( PrintObj, "for a compressed MatFFE",
@@ -190,10 +190,10 @@ end);
 ##
 ##
 
-InstallMethod(ShallowCopy, "for a compressed MatFFE", 
-        true, [Is8BitMatrixRep and IsSmallList], 0, 
-        function(m) 
-    local c,i,l; 
+InstallMethod(ShallowCopy, "for a compressed MatFFE",
+        true, [Is8BitMatrixRep and IsSmallList], 0,
+        function(m)
+    local c,i,l;
     l := m![1];
     c := [l];
     for i in [2..l+1] do
@@ -207,7 +207,7 @@ end );
 ##
 #M PositionCanonical( <mat> , <vec> )
 ##
-    
+
 InstallMethod( PositionCanonical,
     "for 8bit matrices lists, fall back on `Position'",
     true, # the list may be non-homogeneous.
@@ -215,8 +215,8 @@ InstallMethod( PositionCanonical,
     function( list, obj )
     return Position( list, obj, 0 );
 end );
-    
-    
+
+
 
 #############################################################################
 ##
@@ -251,7 +251,7 @@ InstallMethod( \-, "for two 8 bit matrices in same characteristic",
 InstallGlobalFunction(ConvertToMatrixRep,
         function( arg )
     local m,qs, v,  q, givenq, q1, LeastCommonPower, lens;
-    
+
     LeastCommonPower := function(qs)
         local p, d, x, i;
         if Length(qs) = 0 then
@@ -269,10 +269,10 @@ InstallGlobalFunction(ConvertToMatrixRep,
         od;
         return p^d;
     end;
-        
-             
+
+
     qs := [];
-    
+
     m := arg[1];
     if Length(arg) > 1 then
         q1 := arg[2];
@@ -294,7 +294,7 @@ InstallGlobalFunction(ConvertToMatrixRep,
     else
         givenq := false;
     fi;
-    
+
     if Length(m) = 0 then
         if givenq then
             return q1;
@@ -302,7 +302,7 @@ InstallGlobalFunction(ConvertToMatrixRep,
             return fail;
         fi;
     fi;
-    
+
     #
     # If we are already compressed, then our rows are certainly
     #  locked, so we will not be able to change representation
@@ -315,7 +315,7 @@ InstallGlobalFunction(ConvertToMatrixRep,
             return fail;
         fi;
     fi;
-    
+
     if IsGF2MatrixRep(m) then
         if not givenq or q1 = 2 then
             return 2;
@@ -323,11 +323,11 @@ InstallGlobalFunction(ConvertToMatrixRep,
             return fail;
         fi;
     fi;
-    
+
     #
     # Pass 1, get all rows compressed, and find out what fields we have
     #
-    
+
     #    mut := false;
     lens := [];
     for v in m do
@@ -343,70 +343,70 @@ InstallGlobalFunction(ConvertToMatrixRep,
         AddSet(lens, Length(v));
 #        mut := mut or IsMutable(v);
     od;
-    
+
     #
     # We may know that there is no common field
     # or that we can't win for some other reason
     #
-    if 
-      #      mut or 
+    if
+      #      mut or
       Length(lens) > 1 or lens[1] = 0 or
-      fail in qs  or true in qs then 
+      fail in qs  or true in qs then
         return fail;
     fi;
-    
+
     #
     # or it may be easy
     #
     if Length(qs) = 1 then
-        q := qs[1]; 
+        q := qs[1];
     else
-        
+
         #
         # Now work out the common field
         #
         q := LeastCommonPower(qs);
-        
+
         if q = fail then
             return fail;
         fi;
-        
+
         if givenq and q1 <> q then
             Error("ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over <q>");
         fi;
-        
+
         #
         # Now try and rewrite all the rows over this field
         # this may fail if some rows are locked over a smaller field
         #
-        
+
         for v in m do
             if q <> ConvertToVectorRepNC(v,q) then
                 return fail;
             fi;
         od;
     fi;
-    
+
     if q <= 256 then
         ConvertToMatrixRepNC(m,q);
     fi;
-    
+
     return q;
-end);    
+end);
 
 
-InstallGlobalFunction(ConvertToMatrixRepNC, function(arg)    
+InstallGlobalFunction(ConvertToMatrixRepNC, function(arg)
     local   v, m,  q, result;
     if Length(arg) = 1 then
         return ConvertToMatrixRep(arg[1]);
-    else 
+    else
         m := arg[1];
         q := arg[2];
     fi;
     if Length(m)=0 then
         return ConvertToMatrixRep(m,q);
     fi;
-    if not IsInt(q) then 
+    if not IsInt(q) then
         q := Size(q);
     fi;
     if Is8BitMatrixRep(m) then
@@ -434,8 +434,8 @@ end);
 #M <vec> * <mat>
 ##
 
-InstallMethod( \*, "8 bit vector * 8 bit matrix", IsElmsColls, 
-        [ Is8BitVectorRep and IsRowVector and IsRingElementList, 
+InstallMethod( \*, "8 bit vector * 8 bit matrix", IsElmsColls,
+        [ Is8BitVectorRep and IsRowVector and IsRingElementList,
           Is8BitMatrixRep and IsMatrix
           ], 0,
         PROD_VEC8BIT_MAT8BIT);
@@ -446,8 +446,8 @@ InstallMethod( \*, "8 bit vector * 8 bit matrix", IsElmsColls,
 #M <mat> * <vec>
 ##
 
-InstallMethod( \*, "8 bit matrix * 8 bit vector", IsCollsElms, 
-        [           Is8BitMatrixRep and IsMatrix, 
+InstallMethod( \*, "8 bit matrix * 8 bit vector", IsCollsElms,
+        [           Is8BitMatrixRep and IsMatrix,
                 Is8BitVectorRep and IsRowVector and IsRingElementList
           ], 0,
         PROD_MAT8BIT_VEC8BIT);
@@ -457,8 +457,8 @@ InstallMethod( \*, "8 bit matrix * 8 bit vector", IsCollsElms,
 #M <mat> * <mat>
 ##
 
-InstallMethod( \*, "8 bit matrix * 8 bit matrix", IsIdenticalObj, 
-        [           Is8BitMatrixRep and IsMatrix, 
+InstallMethod( \*, "8 bit matrix * 8 bit matrix", IsIdenticalObj,
+        [           Is8BitMatrixRep and IsMatrix,
                 Is8BitMatrixRep and IsMatrix
           ], 0,
         PROD_MAT8BIT_MAT8BIT);
@@ -515,7 +515,7 @@ end);
 ##
 
 InstallMethod( \*, "8 bit matrix * internal FFE", IsCollCollsElms,
-        [         
+        [
                 Is8BitMatrixRep and IsMatrix,
                 IsFFE and IsInternalRep
           ], 0,
@@ -606,7 +606,7 @@ InstallMethod(AdditiveInverseSameMutability, "8 bit matrix", true,
     fi;
     return neg;
 end);
-    
+
 
 
 #############################################################################
@@ -674,19 +674,19 @@ InstallMethod( ZeroSameMutability, "8 bit matrix", true,
     fi;
     return z;
 end);
-        
+
 #############################################################################
 ##
 #M InverseOp(<mat>)
 ##
 
 InstallMethod( InverseOp, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse 
-	# the following are banalities, but they are required to get the
-	# ranking right
+        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
+        # the following are banalities, but they are required to get the
+        # ranking right
         and IsOrdinaryMatrix and IsSmallList and
-	IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-	],
+        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
+        ],
         0,
         INV_MAT8BIT_MUTABLE);
 
@@ -698,12 +698,12 @@ InstallMethod( InverseOp, "8 bit matrix", true,
 ##
 
 InstallMethod( InverseSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse 
-	# the following are banalities, but they are required to get the
-	# ranking right
+        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
+        # the following are banalities, but they are required to get the
+        # ranking right
         and IsOrdinaryMatrix and IsSmallList and
-	IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-	],
+        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
+        ],
         0,
         INV_MAT8BIT_SAME_MUTABILITY);
 
@@ -713,12 +713,12 @@ InstallMethod( InverseSameMutability, "8 bit matrix", true,
 ##
 
 InstallMethod( OneSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse 
-	# the following are banalities, but they are required to get the
-	# ranking right
+        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
+        # the following are banalities, but they are required to get the
+        # ranking right
         and IsOrdinaryMatrix and IsSmallList and
-	IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-	],
+        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
+        ],
         0,
         function(m)
     local   v,  o,  one,  i,  w;
@@ -743,12 +743,12 @@ InstallMethod( OneSameMutability, "8 bit matrix", true,
 end);
 
 InstallMethod( OneMutable, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse 
-	# the following are banalities, but they are required to get the
-	# ranking right
+        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
+        # the following are banalities, but they are required to get the
+        # ranking right
         and IsOrdinaryMatrix and IsSmallList and
-	IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-	],
+        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
+        ],
         0,
         function(m)
     local   v,  o,  one,  i,  w;
@@ -763,7 +763,7 @@ InstallMethod( OneMutable, "8 bit matrix", true,
     ConvertToMatrixRepNC(o, Q_VEC8BIT(v));
     return o;
 end);
-    
+
 
 
 
@@ -773,12 +773,12 @@ end);
 ##
 
 InstallMethod( One, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse 
-	# the following are banalities, but they are required to get the
-	# ranking right
+        [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
+        # the following are banalities, but they are required to get the
+        # ranking right
         and IsOrdinaryMatrix and IsSmallList and
-	IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
-	],
+        IsCommutativeElementCollColl and IsRingElementTable and IsFFECollColl
+        ],
         0,
         function(m)
     local   o;
@@ -801,13 +801,13 @@ InstallGlobalFunction( RepresentationsOfMatrix,
     fi;
     if IsMutable(m) then
         Print("Mutable ");
-    else 
+    else
         Print("Immutable ");
     fi;
     if not IsMatrix(m) then
         if IsMutable(m) then
             Print("Mutable ");
-        else 
+        else
             Print("Immutable ");
         fi;
         Print("Vector: ");
@@ -824,7 +824,7 @@ InstallGlobalFunction( RepresentationsOfMatrix,
                 Print("known to be vector of cyclotomics ");
             fi;
         else
-            Print(" not a compressed or plain list, representations: ", 
+            Print(" not a compressed or plain list, representations: ",
                   RepresentationsOfObject(m)," ");
         fi;
         if IsLockedRepresentationVector(m) then
@@ -896,8 +896,8 @@ InstallGlobalFunction( RepresentationsOfMatrix,
 #        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(v), true), l);
 #   fi;
 #end);
-    
-            
+
+
 #############################################################################
 ##
 #M  DefaultFieldOfMatrix( <ffe-mat> )
@@ -942,14 +942,14 @@ InstallOtherMethod( MutableTransposedMat, "for a compressed 8 bit matrix",
         true, [IsMatrix and IsFFECollColl and
         Is8BitMatrixRep ], 0,
         TRANSPOSED_MAT8BIT);
-    
+
 
 #############################################################################
 ##
 #M  SemiEchelonMat
 ##
 #
-# If mat is in the  special representation, then we do 
+# If mat is in the  special representation, then we do
 # have to copy it, but we know that the rows of the result will
 # already be in special representation, so don't convert
 #
@@ -988,12 +988,12 @@ InstallMethod(SemiEchelonMatDestructive, "kernel method for plain lists of 8bit 
         0,
         SEMIECHELON_LIST_VEC8BITS
         );
-        
-InstallMethod(SemiEchelonMatTransformationDestructive, 
+
+InstallMethod(SemiEchelonMatTransformationDestructive,
         " kernel method for plain lists of 8 bit vectors",
         true,
         [ IsMatrix and IsFFECollColl and IsPlistRep and IsMutable],
-        0, 
+        0,
         SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS);
 
 
@@ -1007,7 +1007,7 @@ InstallMethod(TriangulizeMat,
         "kernel method for plain list of GF2 vectors",
         true,
         [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
-        0, 
+        0,
         TRIANGULIZE_LIST_VEC8BITS);
 
 InstallMethod(TriangulizeMat,
@@ -1046,7 +1046,7 @@ InstallMethod(DeterminantMatDestructive,
         "kernel method for plain list of GF2 vectors",
         true,
         [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
-        0, 
+        0,
         DETERMINANT_LIST_VEC8BITS);
 
 #############################################################################
@@ -1059,13 +1059,13 @@ InstallOtherMethod(RankMatDestructive,
         "kernel method for plain list of GF2 vectors",
         [IsMatrix and IsPlistRep and IsFFECollColl and IsMutable],
         RANK_LIST_VEC8BITS);
-  
+
 InstallMethod(NestingDepthM, [Is8BitMatrixRep], m->2);
 InstallMethod(NestingDepthA, [Is8BitMatrixRep], m->2);
 InstallMethod(NestingDepthM, [Is8BitVectorRep], m->1);
 InstallMethod(NestingDepthA, [Is8BitVectorRep], m->1);
 
-InstallMethod(PostMakeImmutable, [Is8BitMatrixRep], 
+InstallMethod(PostMakeImmutable, [Is8BitMatrixRep],
         function(m)
     local i;
     for i in [2..m![1]] do

--- a/lib/schursym.gd
+++ b/lib/schursym.gd
@@ -28,27 +28,27 @@
 ##
 ##  <Example><![CDATA[
 ##  gap> EpimorphismSchurCover(SymmetricGroup(15));
-##  [ < immutable compressed matrix 64x64 over GF(9) >, 
-##    < immutable compressed matrix 64x64 over GF(9) > ] -> 
+##  [ < immutable compressed matrix 64x64 over GF(3^2) >, 
+##    < immutable compressed matrix 64x64 over GF(3^2) > ] -> 
 ##  [ (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15), (1,2) ]
 ##  gap> EpimorphismSchurCover(AlternatingGroup(15));
-##  [ < immutable compressed matrix 64x64 over GF(9) >, 
-##    < immutable compressed matrix 64x64 over GF(9) > ] -> 
+##  [ < immutable compressed matrix 64x64 over GF(3^2) >, 
+##    < immutable compressed matrix 64x64 over GF(3^2) > ] -> 
 ##  [ (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15), (13,14,15) ]
 ##  gap> SchurCoverOfSymmetricGroup(12);
 ##  <matrix group of size 958003200 with 2 generators>
 ##  gap> DoubleCoverOfAlternatingGroup(12);
 ##  <matrix group of size 479001600 with 2 generators>
 ##  gap> BasicSpinRepresentationOfSymmetricGroup( 10, 3, -1 );
-##  [ < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) >, 
-##    < immutable compressed matrix 16x16 over GF(9) > ]
+##  [ < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) >, 
+##    < immutable compressed matrix 16x16 over GF(3^2) > ]
 ##  ]]></Example>
 ##
 ##  </Subsection>

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -1427,6 +1427,7 @@ static Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
 
 static Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec), 1);
 }
 
@@ -2668,6 +2669,7 @@ static Obj FuncLEN_VEC8BIT(Obj self, Obj list)
 */
 static Obj FuncQ_VEC8BIT(Obj self, Obj list)
 {
+    RequireVec8BitRep(SELF_NAME, list);
     return INTOBJ_INT(FIELD_VEC8BIT(list));
 }
 

--- a/tst/testinstall/MatrixObj/ZeroMatrix.tst
+++ b/tst/testinstall/MatrixObj/ZeroMatrix.tst
@@ -122,7 +122,7 @@ gap> ZeroMatrix(GF(4), 2, 3);
 gap> ZeroMatrix(GF(4), 0, 3);
 Error, Is8BitMatrixRep with zero rows not yet supported
 gap> ZeroMatrix(GF(4), 2, 0);
-< mutable compressed matrix 2x0 over GF(4) >
+< mutable compressed matrix 2x0 over GF(2^2) >
 
 #
 gap> STOP_TEST("ZeroMatrix.tst");

--- a/tst/testinstall/meataxe.tst
+++ b/tst/testinstall/meataxe.tst
@@ -106,8 +106,8 @@ true
 #
 gap> M4:=InducedGModule(SymmetricGroup(6),G,M);
 rec( IsOverFiniteField := true, dimension := 30, field := GF(7^2), 
-  generators := [ < immutable compressed matrix 30x30 over GF(49) >, 
-      < immutable compressed matrix 30x30 over GF(49) > ], 
+  generators := [ < immutable compressed matrix 30x30 over GF(7^2) >, 
+      < immutable compressed matrix 30x30 over GF(7^2) > ], 
   isMTXModule := true )
 gap> SortedList(List(MTX.CompositionFactors(M4), m -> m.dimension));
 [ 1, 5, 5, 9, 10 ]
@@ -115,8 +115,8 @@ gap> SortedList(List(MTX.CompositionFactors(M4), m -> m.dimension));
 #
 gap> M5:=WedgeGModule(M);
 rec( IsOverFiniteField := true, dimension := 10, field := GF(7^2), 
-  generators := [ < immutable compressed matrix 10x10 over GF(49) >, 
-      < immutable compressed matrix 10x10 over GF(49) > ], 
+  generators := [ < immutable compressed matrix 10x10 over GF(7^2) >, 
+      < immutable compressed matrix 10x10 over GF(7^2) > ], 
   isMTXModule := true )
 gap> SortedList(List(MTX.CompositionFactors(M5), m -> m.dimension));
 [ 4, 6 ]
@@ -124,29 +124,29 @@ gap> cf:=MTX.CollectedFactors(M5);;
 gap> MTX.Distinguish(cf,1);
 gap> MTX.Distinguish(cf,2);
 gap> MTX.BasesSubmodules(M5);
-[ [  ], < immutable compressed matrix 4x10 over GF(49) >, 
-  < immutable compressed matrix 6x10 over GF(49) >, 
-  < immutable compressed matrix 10x10 over GF(49) > ]
+[ [  ], < immutable compressed matrix 4x10 over GF(7^2) >, 
+  < immutable compressed matrix 6x10 over GF(7^2) >, 
+  < immutable compressed matrix 10x10 over GF(7^2) > ]
 gap> MTX.BasesMinimalSubmodules(M5);
-[ < immutable compressed matrix 4x10 over GF(49) >, 
-  < immutable compressed matrix 6x10 over GF(49) > ]
+[ < immutable compressed matrix 4x10 over GF(7^2) >, 
+  < immutable compressed matrix 6x10 over GF(7^2) > ]
 gap> MTX.BasesMaximalSubmodules(M5);
-[ < immutable compressed matrix 6x10 over GF(49) >, 
-  < immutable compressed matrix 4x10 over GF(49) > ]
+[ < immutable compressed matrix 6x10 over GF(7^2) >, 
+  < immutable compressed matrix 4x10 over GF(7^2) > ]
 gap> MTX.BasisRadical(M5);
 [  ]
 gap> MTX.BasisSocle(M5);
-< immutable compressed matrix 10x10 over GF(49) >
+< immutable compressed matrix 10x10 over GF(7^2) >
 gap> subs:=SMTX.MinimalSubGModules(M2,M5);
-[ < immutable compressed matrix 4x10 over GF(49) > ]
+[ < immutable compressed matrix 4x10 over GF(7^2) > ]
 gap> MTX.BasesMinimalSupermodules(M5,subs[1]) = [ IdentityMat(10,Z(7)) ];
 true
 gap> homs:=MTX.Homomorphisms(M2,M5);
-[ < immutable compressed matrix 4x10 over GF(49) > ]
+[ < immutable compressed matrix 4x10 over GF(7^2) > ]
 gap> MTX.Homomorphism(M2,M5,homs[1]);
 [ [ Z(7)^0, 0*Z(7), 0*Z(7), 0*Z(7) ], [ 0*Z(7), Z(7)^0, 0*Z(7), 0*Z(7) ], 
   [ 0*Z(7), 0*Z(7), Z(7)^0, 0*Z(7) ], [ 0*Z(7), 0*Z(7), 0*Z(7), Z(7)^0 ] 
- ] -> < immutable compressed matrix 4x10 over GF(49) >
+ ] -> < immutable compressed matrix 4x10 over GF(7^2) >
 
 #
 gap> randM := SMTX.RandomIrreducibleSubGModule(M)[2];;


### PR DESCRIPTION
This PR further cleans up the code in `lib/mat8bit.gi` by:

1. using uniform code formatting
2. fixing/making uniform the description strings of the methods in the file
3. making the filters for methods used more uniform
4. removing some duplicate/unnecessary code

Altogether this removes about 400 lines of code from this file. This is more preparation for tackling #4914, the changes in this PR should make it easier to make the changes necessary for #4914. Some things that weren't completely clear to me (but also didn't seem to cause the tests to fail) were:

* There were lots of methods with filters `IsList and Is8BitMatrixRep` or `IsSmallList and Is8BitMatrixRep` or `IsMatrix and Is8BitMatrixRep`. Looking at the code it seems like every object belonging to `Is8BitMatrixRep` must belong to `IsSmallList` and `IsMatrixObj`. So, I removed the unnecessary `IsList`, `IsSmallList`, or `IsMatrix`, wherever that worked. This might be a terrible idea, I'm happy to reverse these changes if so. 
* There was a fair amount of duplicated code in `lib/mat8bit.gi` for `XMutable`, `XImmutable`, and `XSameMutability` (where `X = One`, `X = Zero` etc), and products of ffe's and `Is8BitMatrixRep`, which I've removed/replaced. I suppose it's possible that this has some negative impact on performance (an additional function call + method selection), but I couldn't detect any. 
* I removed as many direct uses of the representation `Is8BitMatrixRep` as I could, which I suppose might also have some negative performance implications (but again I couldn't detect any). This will make resolving #4914 more straightforward. 

I'm not particularly attached to any of the changes, and I'm happy to modify this if anyone feels strongly about it. 

I'm opening this just now to check that the tests run, I want to add some more tests before taking it any further. 

## Text for release notes

None