### PR TITLE
Remove VISITED_STAT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ dnl    if any interfaces have been added since the last public release, then
 dnl    increment minor.
 dnl
 m4_define([kernel_major_version], [9])
-m4_define([kernel_minor_version], [0])
+m4_define([kernel_minor_version], [1])
 
 m4_define([GAP_DEFINE], [GAP_DEFINES="$GAP_DEFINES -D$1"])
 

--- a/src/code.c
+++ b/src/code.c
@@ -121,14 +121,6 @@ static StatHeader * STAT_HEADER(CodeState * cs, Stat stat)
     return (StatHeader *)ADDR_STAT(cs, stat) - 1;
 }
 
-void SET_VISITED_STAT(Stat stat)
-{
-    Stat * addr = (Stat *)STATE(PtrBody) + stat / sizeof(Stat);
-    StatHeader * header = (StatHeader *)addr - 1;
-    header->visited = 1;
-}
-
-
 static Int TNUM_STAT_OR_EXPR(CodeState * cs, Expr expr)
 {
     if (IS_REF_LVAR(expr))

--- a/src/code.h
+++ b/src/code.h
@@ -26,10 +26,6 @@
 **  Header for any statement or expression encoded in a function body.
 */
 typedef struct {
-    // `visited` starts out as 0 and is set to 1 if the statement or
-    // expression has ever been executed while profiling is turned on
-    unsigned int visited : 1;
-
     // `line` records the line number in the source file in which the
     // statement or expression started
     unsigned int line : 31;
@@ -374,30 +370,6 @@ EXPORT_INLINE Int LINE_STAT(Stat stat)
 {
     return CONST_STAT_HEADER(stat)->line;
 }
-
-
-/****************************************************************************
-**
-*F  VISITED_STAT(<stat>) . . . . . . . . . . . if statement has even been run
-**
-**  'VISITED_STAT' returns true if the statement has ever been executed
-**  while profiling is turned on.
-*/
-EXPORT_INLINE Int VISITED_STAT(Stat stat)
-{
-    return CONST_STAT_HEADER(stat)->visited;
-}
-
-
-/****************************************************************************
-**
-*F  SET_VISITED_STAT(<stat>) . . . . . . . . . . mark statement as having run
-**
-**  'SET_VISITED_STAT' marks the statement as having been executed while
-**  profiling was turned on.
-*/
-void SET_VISITED_STAT(Stat stat);
-
 
 /****************************************************************************
 **

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -50,12 +50,16 @@ extern EvalBoolFunc OriginalEvalBoolFuncsForHook[256];
 **
 ** * 'visitStat' is called for every visited Stat (and Expr) from the
 **    GAP bytecode.
+** * 'visitInterpretedStat' is called when code is executed directly,
+**    and will not be turned into bytecode. Only the file and line are given.
 ** * 'enterFunction' and 'leaveFunction' are called whenever a function
 **    is entered, or left. This is passed the function which is being
 **    entered (or left)
 ** * 'registerStat' is called whenever a statement is read from a text
 **    file. Note that you will only see files which are read while your
 **    hooks are running.
+** * 'registerInterpretedStat' is called when code is read which will
+**    not be turned into bytecode. Only the file and line are given.
 ** * 'hookName' is a string is used in debugging messages to describe
 **    the currently active hooks.
 **

--- a/src/profile.c
+++ b/src/profile.c
@@ -149,12 +149,6 @@ static struct ProfileState
   int profiledThread;
 #endif
 
-  // Have we previously profiled this execution of GAP? We need this because
-  // code coverage doesn't work more than once, as we use a bit in each Stat
-  // to mark if we previously executed this statement, which we can't
-  // clear
-  UInt profiledPreviously;
-
   Int LongJmpOccurred;
 
   // We store the value of RecursionDepth each time we enter a function.
@@ -723,7 +717,6 @@ enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
 
     profileState.status = Profile_Active;
     RegisterThrowObserver(ProfileRegisterLongJmpOccurred);
-    profileState.profiledPreviously = 1;
 #ifdef HPCGAP
     profileState.profiledThread = TLS(threadID);
 #endif
@@ -775,12 +768,6 @@ static Obj FuncACTIVATE_PROFILING(Obj self,
 {
     if (profileState.status != Profile_Disabled) {
       return Fail;
-    }
-
-    if(profileState.profiledPreviously &&
-       coverage == True) {
-        ErrorMayQuit("Code coverage can only be started once per"
-                     " GAP session. Please exit GAP and restart. Sorry.",0,0);
     }
 
     memset(&profileState, 0, sizeof(profileState));
@@ -851,7 +838,6 @@ static Obj FuncACTIVATE_PROFILING(Obj self,
 
     profileState.status = Profile_Active;
     RegisterThrowObserver(ProfileRegisterLongJmpOccurred);
-    profileState.profiledPreviously = 1;
 #ifdef HPCGAP
     profileState.profiledThread = TLS(threadID);
 #endif

--- a/src/profile.c
+++ b/src/profile.c
@@ -532,7 +532,7 @@ static inline void printOutput(int fileid, int line, BOOL exec, BOOL visited)
 
 // Mark line as visited, and return true if the line has been previously
 // visited (executed)
-BOOL markVisited(int fileid, UInt line)
+static BOOL markVisited(int fileid, UInt line)
 {
     // Some STATs end up without a file or line -- do not output these
     // as they would just confuse the profile generation later.
@@ -553,31 +553,6 @@ BOOL markVisited(int fileid, UInt line)
         return FALSE;
     }
     return TRUE;
-}
-
-// Return TRUE is Stat has been visited (executed) before
-BOOL visitedStat(Stat stat)
-{
-    int fileid = getFilenameIdOfCurrentFunction();
-    int line = LINE_STAT(stat);
-
-    if (fileid == 0 || line == 0) {
-        return TRUE;
-    }
-
-    if (LEN_PLIST(profileState.visitedStatements) < fileid ||
-        !ELM_PLIST(profileState.visitedStatements, fileid)) {
-        return FALSE;
-    }
-
-    Obj linelist = ELM_PLIST(profileState.visitedStatements, fileid);
-
-    if (LEN_PLIST(linelist) < line || !ELM_PLIST(linelist, line)) {
-        return 0;
-    }
-    else {
-        return 1;
-    }
 }
 
 // type : the type of the statement


### PR DESCRIPTION
This remove VISITED_STAT and SET_VISITED_STAT, and the 'visited' bit from Stat, and keeps track of these things in profiling.c, and keep track of covered lines in profiling.c

This remove `ActivateProfileColour`, which allowed colouring functions with covered lines, hitting the exact parts of lines executed, as that was easy to do when we tracked what was covered per Stat, but I don't do that now (only by line), as I believe no-one was ever using this functionality!

If this is fine, please don't merge it yet, as I'll have to release an updating to the profiling package, as to sync up with this change (in particular, remove tests which use `ActivateProfileColour`)