### PR TITLE
Remove tabs in files starting with "a"

### DIFF
--- a/lib/addgphom.gi
+++ b/lib/addgphom.gi
@@ -31,7 +31,7 @@ local map;
                                IsSPMappingByFunctionRep
                            and IsSingleValued
                            and IsTotal
-			   and IsGroupToAdditiveGroupHomomorphism ),
+                           and IsGroupToAdditiveGroupHomomorphism ),
                        rec( fun:= arg[3] ) );
 
     # inverse function given
@@ -43,7 +43,7 @@ local map;
         ElementsFamily(FamilyObj(arg[2]))),
                                IsSPMappingByFunctionWithInverseRep
                            and IsBijective
-			   and IsGroupToAdditiveGroupHomomorphism ),
+                           and IsGroupToAdditiveGroupHomomorphism ),
                        rec( fun    := arg[3],
                             invFun := arg[4] ) );
 

--- a/lib/adjoin.gi
+++ b/lib/adjoin.gi
@@ -142,10 +142,10 @@ end);
 
 InstallMethod(MonoidByAdjoiningIdentity, [IsSemigroup and HasGeneratorsOfSemigroup],
         function( s )
-	local m;
+        local m;
         m:=Monoid(List(GeneratorsOfSemigroup(s), MonoidByAdjoiningIdentityElt));
-	SetUnderlyingSemigroupOfMonoidByAdjoiningIdentity(m, s);
-      	return m;
+        SetUnderlyingSemigroupOfMonoidByAdjoiningIdentity(m, s);
+        return m;
 end);
 
 ###########################################################################

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -1836,7 +1836,7 @@ InstallMethod( IsSubset,
     # catch trivial case
     if IsSubset(GeneratorsOfLeftOperatorRing(D1),
                   GeneratorsOfLeftOperatorRing(D2)) then
-	return true;
+        return true;
     fi;
     return IsSubset( D1, GeneratorsOverIntersection( D2,
                              GeneratorsOfLeftOperatorRing( D2 ),

--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -78,8 +78,8 @@ function(f,p,check)
 
   impattr:=IsAlgebraicElement and CanEasilySortElements and IsZDFRE;
   fam:=NewFamily("AlgebraicElementsFamily(...)",IsAlgebraicElement,
-	 impattr,
-	 IsAlgebraicElementFamily and CanEasilySortElements);
+         impattr,
+         IsAlgebraicElementFamily and CanEasilySortElements);
 
   # The two types
   fam!.baseType := NewType(fam,IsAlgBFRep);
@@ -194,7 +194,7 @@ if Length(extra)>0 and IsString(extra[1]) then
     if IsFinite(f) then
       SetIsFinite(e,true);
       if HasSize(f) then
-	SetSize(e,Size(f)^fam!.deg);
+        SetSize(e,Size(f)^fam!.deg);
       fi;
     else
       SetIsNumberField(e,true);
@@ -501,10 +501,10 @@ local fam,b,d,i;
       # and whether the vector is too short.
       i:=Length(b)+1;
       while i<=fam!.deg do
-	if not IsBound(b[i]) then
-	  b[i]:=fam!.zeroCoefficient;
-	fi;
-	i:=i+1;
+        if not IsBound(b[i]) then
+          b[i]:=fam!.zeroCoefficient;
+        fi;
+        i:=i+1;
       od;
       return Objectify(fam!.extType,[b]);
     fi;
@@ -1036,7 +1036,7 @@ local fam;
     fam:=FamilyObj(elms[1]);
     if ForAll(elms,i->FamilyObj(i)=fam) then
       if IsBound(fam!.wholeExtension) then
-	return fam!.wholeExtension;
+        return fam!.wholeExtension;
       fi;
     fi;
   fi;
@@ -1062,9 +1062,9 @@ local l,f,i,j,k,gens;
     for j in i do
       for k in j do
         if not k in f then
-	  gens:=Concatenation(gens,[k]);
-	  f:=DefaultFieldByGenerators(gens);
-	fi;
+          gens:=Concatenation(gens,[k]);
+          f:=DefaultFieldByGenerators(gens);
+        fi;
       od;
     od;
   od;
@@ -1118,14 +1118,14 @@ local coeffring, basring, theta, xind, yind, x, y, coeffs, G, c, val, k, T,
     G:= Zero( basring );
     for i in [ 1 .. Length( coeffs ) ] do
       if IsAlgBFRep( coeffs[i] ) then
-	G:= G + coeffs[i]![1] * x^i;
+        G:= G + coeffs[i]![1] * x^i;
       else
-	c:= coeffs[i]![1];
-	val:= c[1];
-	for j in [ 2 .. Length( c ) ] do
-	  val:= val + c[j] * y^(j-1);
-	od;
-	G:= G + val * x^i;
+        c:= coeffs[i]![1];
+        val:= c[1];
+        for j in [ 2 .. Length( c ) ] do
+          val:= val + c[j] * y^(j-1);
+        od;
+        G:= G + val * x^i;
       fi;
     od;
 
@@ -1234,7 +1234,7 @@ local opt,irrfacs, coeffring, i, factors, ind, coeffs, val,
   val:= coeffs[2];
   coeffs:= coeffs[1];
   factors:= ListWithIdenticalEntries( val,
-		IndeterminateOfUnivariateRationalFunction( pol ) );
+                IndeterminateOfUnivariateRationalFunction( pol ) );
 
   if Length( coeffs ) = 1 then
 
@@ -1249,7 +1249,7 @@ local opt,irrfacs, coeffring, i, factors, ind, coeffs, val,
     # The polynomial is a linear polynomial times a power of the indet.
     factors[1]:= coeffs[2] * factors[1];
     factors[ val+1 ]:= LaurentPolynomialByExtRepNC( FamilyObj( pol ),
-			    [coeffs[1] / coeffs[2], One(coeffring)],0,ind );
+                            [coeffs[1] / coeffs[2], One(coeffring)],0,ind );
     StoreFactorsPol( coeffring, pol, factors );
     PopOptions();
     return factors;
@@ -1279,9 +1279,9 @@ local opt,irrfacs, coeffring, i, factors, ind, coeffs, val,
       Add( factors, factor );
       q:= Quotient( R, g, factor );
       while q <> fail do
-	Add( factors, factor );
-	g:= q;
-	q:= Quotient( R, g, factor );
+        Add( factors, factor );
+        g:= q;
+        q:= Quotient( R, g, factor );
       od;
     od;
   fi;

--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -63,8 +63,8 @@ InstallMethod( AlgebraGeneralMappingByImages,
     function( S, R, gens, imgs )
 
     local map,        # general mapping from <S> to <R>, result
-	  filter,
-	  i,basic;
+          filter,
+          i,basic;
 
     # Handle the case that `gens' is a basis or empty.
     # We can form a left module general mapping directly.
@@ -89,22 +89,22 @@ InstallMethod( AlgebraGeneralMappingByImages,
 
     # type setting
     filter:=IsSPGeneralMapping
-	    and IsAlgebraGeneralMapping
-	    and IsAlgebraGeneralMappingByImagesDefaultRep;
+            and IsAlgebraGeneralMapping
+            and IsAlgebraGeneralMappingByImagesDefaultRep;
 
     #special case: test whether polynomial ring is mapped via 1 and free
     #generators
     if IsPolynomialRing(S) then
       basic:=ForAll(imgs,x->ForAll(imgs,y->x*y=y*x));
       for i in [1..Length(gens)] do
-	if IsOne(gens[i]) then
-	  if not IsOne(imgs[i]) then basic:=false;fi;
-	elif not gens[i] in IndeterminatesOfPolynomialRing(S) then
-	  basic:=false;
-	fi;
+        if IsOne(gens[i]) then
+          if not IsOne(imgs[i]) then basic:=false;fi;
+        elif not gens[i] in IndeterminatesOfPolynomialRing(S) then
+          basic:=false;
+        fi;
       od;
       if basic=true then
-	filter:=filter and IsPolynomialRingDefaultGeneratorMapping;
+        filter:=filter and IsPolynomialRingDefaultGeneratorMapping;
       fi;
     fi;
 
@@ -215,7 +215,7 @@ InstallMethod( AlgebraHomomorphismByFunction,
     [ IsAlgebra, IsAlgebra, IsFunction ],
     function( A, B, f )
     return Objectify( TypeOfDefaultGeneralMapping( A, B,
-	IsSPMappingByFunctionRep and IsAlgebraHomomorphism ), rec(fun:=f) );
+        IsSPMappingByFunctionRep and IsAlgebraHomomorphism ), rec(fun:=f) );
     end);
 
 InstallMethod(AlgebraWithOneHomomorphismByFunction,
@@ -224,7 +224,7 @@ InstallMethod(AlgebraWithOneHomomorphismByFunction,
     [ IsAlgebraWithOne, IsAlgebraWithOne, IsFunction ],
     function( A, B, f )
     return Objectify( TypeOfDefaultGeneralMapping( A, B,
-	IsSPMappingByFunctionRep and IsAlgebraWithOneHomomorphism ),
+        IsSPMappingByFunctionRep and IsAlgebraWithOneHomomorphism ),
         rec(fun:=f) );
     end);
 
@@ -254,8 +254,8 @@ function( map )
 local mapi;
   mapi:=MappingGeneratorsImages(map);
   Print( "AlgebraWithOneHomomorphismByImages( ",
-	  Source( map ), ", ", Range( map ), ", ",
-	  mapi[1], ", ", mapi[2], " )" );
+          Source( map ), ", ", Range( map ), ", ",
+          mapi[1], ", ", mapi[2], " )" );
 end );
 
 InstallMethod( PrintObj, "for an algebra hom. b.i.", true,
@@ -265,8 +265,8 @@ function( map )
 local mapi;
   mapi:=MappingGeneratorsImages(map);
   Print( "AlgebraHomomorphismByImages( ",
-	  Source( map ), ", ", Range( map ), ", ",
-	  mapi[1], ", ", mapi[2], " )" );
+          Source( map ), ", ", Range( map ), ", ",
+          mapi[1], ", ", mapi[2], " )" );
 end );
 
 InstallMethod( PrintObj, "for an algebra-with-one g.m.b.i", true,
@@ -276,8 +276,8 @@ function( map )
 local mapi;
   mapi:=MappingGeneratorsImages(map);
   Print( "AlgebraWithOneGeneralMappingByImages( ",
-	  Source( map ), ", ", Range( map ), ", ",
-	  mapi[1], ", ", mapi[2], " )" );
+          Source( map ), ", ", Range( map ), ", ",
+          mapi[1], ", ", mapi[2], " )" );
 end );
 
 InstallMethod( PrintObj, "for an algebra g.m.b.i", true,
@@ -287,8 +287,8 @@ function( map )
 local mapi;
   mapi:=MappingGeneratorsImages(map);
   Print( "AlgebraGeneralMappingByImages( ",
-	  Source( map ), ", ", Range( map ), ", ",
-	  mapi[1], ", ", mapi[2], " )" );
+          Source( map ), ", ", Range( map ), ", ",
+          mapi[1], ", ", mapi[2], " )" );
 end );
 
 
@@ -662,7 +662,7 @@ InstallMethod( CompositionMapping2,
     local comp,        # composition of <map2> and <map1>, result
           gens,
           genimages,
-	  mapi1,mapi2;
+          mapi1,mapi2;
 
     mapi1:=MappingGeneratorsImages(map1);
     mapi2:=MappingGeneratorsImages(map2);

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -1141,7 +1141,7 @@ InstallMethod( PthPowerImage,
 
 InstallMethod( PthPowerImage, "for an element of a restricted Lie algebra",
     [ IsJacobianElement ], # weaker filter, we maybe only discovered later
-      			   # that the algebra is restricted
+                           # that the algebra is restricted
     function(x)
     local fam;
     fam := FamilyObj(x);
@@ -1157,7 +1157,7 @@ InstallMethod( PthPowerImage, "for an element of a restricted Lie algebra and an
     if not IsBound(fam!.pMapping) then TryNextMethod(); fi;
     while n>0 do
         x := PTHPOWERIMAGE_PPI_VEC(fam!.fullSCAlgebra,fam!.zerocoeff,Characteristic(fam),fam!.basisVectors,fam!.pMapping,ExtRepOfObj(x),x);
-	n := n-1;
+        n := n-1;
     od;
     return x;
 end);
@@ -1168,10 +1168,10 @@ InstallMethod( PClosureSubalgebra, "for a subalgebra of restricted jacobian elem
     local i, p, oldA;
 
     repeat
-	oldA := A;
+        oldA := A;
         for i in Basis(oldA) do
-      	    A := ClosureLeftModule(A,PthPowerImage(i));
-    	od;
+            A := ClosureLeftModule(A,PthPowerImage(i));
+        od;
     until A=oldA;
     return A;
 end);
@@ -3748,13 +3748,14 @@ InstallGlobalFunction( FreeLieAlgebra, function( arg )
                     z := Concatenation(x[1],y[1]);
                     if z<y[1] and x[1]<y[1] and (x[2]=fail or x[2]>=y[1]) then
                         Add(B[d],[z,y[1],x[3]*y[3]]);
+
                     fi;
                 od; od;
             od;
         od;
         if degree<1 then B := []; else B := B[degree]; fi;
         return FreeLeftModule( R, List( B,
-		p->ElementOfMagmaRing( F, zero, [ one ], [ p[3] ] )), Zero(L));
+                p->ElementOfMagmaRing( F, zero, [ one ], [ p[3] ] )), Zero(L));
     end) );
     # Return the ring.
     return L;
@@ -3892,9 +3893,9 @@ InstallMethod( NormalizedElementOfMagmaRingModuloRelations,
                fi;
              od;
 
-       	     if u[1]=u[2] then
+             if u[1]=u[2] then
                # the whole expression `s' reduces to zero.
-	       ll:= Filtered([1..Length(todo)], x->x<>k);
+               ll:= Filtered([1..Length(todo)], x->x<>k);
                todo:= todo{ll};
              else
                if Flat([u[1]]) > Flat([u[2]]) then

--- a/lib/algliess.gi
+++ b/lib/algliess.gi
@@ -1269,7 +1269,7 @@ SimpleLieAlgebraTypeM := function (n, F)
             WBracket,    # The commutator of two elements of WBasis
                          #   w.r.t. WProduct.
             degrees,     # The list of degrees of different components.
-	    GradingFunction, # The function giving the grading components.
+            GradingFunction, # The function giving the grading components.
             tildify, clean, # Utility functions.
             table,  i,  w1,  j,  w2, result,  term,  prod,  x2,  x1, d;
                          # Temporary results and counters.
@@ -1588,8 +1588,8 @@ SimpleLieAlgebraTypeM := function (n, F)
 #    end;
 #    SetGrading (result,
 #            rec (min_degree := -3,
-#        	 max_degree := 3 * (5^n1 + 5^n2) - 7,
-#        	 source := Integers,
+#                max_degree := 3 * (5^n1 + 5^n2) - 7,
+#                source := Integers,
 #                 hom_components := GradingFunction));
 
     return result;

--- a/lib/algmat.gi
+++ b/lib/algmat.gi
@@ -1121,7 +1121,7 @@ InstallGlobalFunction( FullMatrixAlgebraCentralizer, function( F, lst )
     if len = 0 then
       Error( "cannot compute the centralizer of an empty set" );
     elif not (IsSubset( F, DefaultScalarDomainOfMatrixList( lst ) ) or
-	      IsSubset( F, FieldOfMatrixList( lst ) ) ) then
+              IsSubset( F, FieldOfMatrixList( lst ) ) ) then
       Error( "not all entries of the matrices in <lst> lie in <F>" );
     fi;
 

--- a/lib/algsc.gi
+++ b/lib/algsc.gi
@@ -243,9 +243,9 @@ InstallMethod( String,
       zero:= Zero( elm[1] );
 
       if elm[ depth ] <> one then
-	Add(s,'(');
-	Append(s,String(elm[ depth ]));
-	Append(s, ")*" );
+        Add(s,'(');
+        Append(s,String(elm[ depth ]));
+        Append(s, ")*" );
       fi;
       Append(s, names[ depth ] );
 
@@ -253,11 +253,11 @@ InstallMethod( String,
         if elm[i] <> zero then
           Add(s, '+' );
           if elm[i] <> one then
-	    Add(s,'(');
-	    Append(s,String(elm[ i ]));
-	    Append(s, ")*" );
+            Add(s,'(');
+            Append(s,String(elm[ i ]));
+            Append(s, ")*" );
           fi;
-	  Append(s, names[ i ] );
+          Append(s, names[ i ] );
         fi;
       od;
 

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -1533,7 +1533,7 @@ DeclareOperationKernel( "AdditiveInverseSameMutability",
 #O  `<elm1>-<elm2>' . . . . . . . . . . . . . . .  difference of two elements
 ##
 DeclareOperationKernel( "-",
-	[ IsExtAElement, IsNearAdditiveElementWithInverse ], DIFF );
+        [ IsExtAElement, IsNearAdditiveElementWithInverse ], DIFF );
 
 
 #############################################################################

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -141,7 +141,7 @@ local ocr,fphom,fpg,free,len,dim,tmp,L0,S,R,rels,mat,r,RS,i,g,v,cnt;
   fpg:=FreeGeneratorsOfFpGroup(Range(fphom));
   ocr.factorpres:=[fpg,RelatorsOfFpGroup(Range(fphom))];
   ocr.generators:=List(GeneratorsOfGroup(Range(fphom)),
-			i->PreImagesRepresentative(fphom,i));
+                        i->PreImagesRepresentative(fphom,i));
   OCAddMatrices(ocr,ocr.generators);
   OCAddRelations(ocr,ocr.generators);
   OCAddSumMatrices(ocr,ocr.generators);
@@ -171,7 +171,7 @@ local ocr,fphom,fpg,free,len,dim,tmp,L0,S,R,rels,mat,r,RS,i,g,v,cnt;
   free:=FreeGroup(Length(ocr.generators),"f");
   ocr.free:=free;
   ocr.decomp:=GroupGeneralMappingByImages(Image(nat,G),free,
-	ocr.factorgens,GeneratorsOfGroup(free));
+        ocr.factorgens,GeneratorsOfGroup(free));
 
   # Initialize system.
   len:=Length(ocr.generators);
@@ -194,8 +194,8 @@ local ocr,fphom,fpg,free,len,dim,tmp,L0,S,R,rels,mat,r,RS,i,g,v,cnt;
     for g  in [1..len]  do
       RS:=OCEquationMatrix(ocr,rels[i],g);
       for v in RS do
-	Append(mat[r],v);
-	r:=r+1;
+        Append(mat[r],v);
+        r:=r+1;
       od;
     od;
   od;
@@ -261,9 +261,9 @@ BindGlobal("AGSRAutomLift",function(ocr,nat,fhom,miso)
   v:=[];
   rels:=ocr.relators;
   genimages:=List(ocr.factorgens,i->MappedWord(
-	        ImagesRepresentative(ocr.decomp,Image(fhom,i)),
-		GeneratorsOfGroup(ocr.free),
-		ocr.generators));
+                ImagesRepresentative(ocr.decomp,Image(fhom,i)),
+                GeneratorsOfGroup(ocr.free),
+                ocr.generators));
   for i in [1..Length(rels)] do
     v1:=OCEquationVectorAutom(ocr,rels[i],genimages);
     Add(v,v1);
@@ -308,18 +308,18 @@ BindGlobal("AGSRAutomLift",function(ocr,nat,fhom,miso)
       l:=Length(ocr.modulePcgs);
       for i in [1..Length(genimages)] do
         v1:=s{[(i-1)*l+1..(i*l)]}*psim;
-	for j in [1..Length(v1)] do
-	  t[(i-1)*l+j]:=v1[j];
-	od;
+          for j in [1..Length(v1)] do
+            t[(i-1)*l+j]:=v1[j];
+          od;
       od;
       s:=ocr.cocycleToList(t);
       for i in [1..Length(genimages)] do
-	genimages[i]:=genimages[i]*s[i];
+        genimages[i]:=genimages[i]*s[i];
       od;
 
       # later use NC version
       hom:=GroupHomomorphismByImagesNC(ocr.group,ocr.group,
-	      ocr.generators,genimages);
+              ocr.generators,genimages);
       Assert(2,IsBijective(hom));
       return hom;
     fi;
@@ -762,15 +762,15 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
     if isBadPermrep(AQP) then
       a:=SmallerDegreePermutationRepresentation(AQP:cheap);
       if NrMovedPoints(Image(a))<NrMovedPoints(AQP) then
-	Info(InfoMorph,3,"Permdegree reduced ",
-	      NrMovedPoints(AQP),"->",NrMovedPoints(Image(a)));
-	AQiso:=AQiso*a;
-	b:=Image(a,AQP);
-	if Length(GeneratorsOfGroup(b))>Length(GeneratorsOfGroup(AQP)) then
-	  b:=Group(List(GeneratorsOfGroup(AQP),x->ImagesRepresentative(a,x)));
-	  SetSize(b,Size(AQP));
-	fi;
-	AQP:=b;
+        Info(InfoMorph,3,"Permdegree reduced ",
+              NrMovedPoints(AQP),"->",NrMovedPoints(Image(a)));
+        AQiso:=AQiso*a;
+        b:=Image(a,AQP);
+        if Length(GeneratorsOfGroup(b))>Length(GeneratorsOfGroup(AQP)) then
+          b:=Group(List(GeneratorsOfGroup(AQP),x->ImagesRepresentative(a,x)));
+          SetSize(b,Size(AQP));
+        fi;
+        AQP:=b;
       fi;
     fi;
 
@@ -783,31 +783,31 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       sz:=Size(Aperm);
       if Size(gp)/Size(Aperm)>lim then
         no:=Normalizer(gp,Aperm);
-	if Size(no)>Size(Aperm) and Size(no)<Size(gp) then
-	  stablim(no,cond,lim);
-	fi;
+        if Size(no)>Size(Aperm) and Size(no)<Size(gp) then
+          stablim(no,cond,lim);
+        fi;
       else
-	no:=Aperm;
+        no:=Aperm;
       fi;
       if Size(gp)/Size(Aperm)>lim then
-	ac:=AscendingChain(gp,Aperm);
-	List(Union(List(ac,GeneratorsOfGroup)),cond); # try generators...
-	if Size(Aperm)>sz then
-	  ac:=Unique(List(ac,x->ClosureGroup(Aperm,x)));
-	fi;
+        ac:=AscendingChain(gp,Aperm);
+        List(Union(List(ac,GeneratorsOfGroup)),cond); # try generators...
+        if Size(Aperm)>sz then
+          ac:=Unique(List(ac,x->ClosureGroup(Aperm,x)));
+        fi;
 
-	i:=First([Length(ac),Length(ac)-1..1],x->Size(ac[x])/sz<=lim);
-	sub:=ac[i];
+        i:=First([Length(ac),Length(ac)-1..1],x->Size(ac[x])/sz<=lim);
+        sub:=ac[i];
       else
-	sub:=gp;
+        sub:=gp;
       fi;
       if Size(sub)>Size(Aperm) and not IsSubset(no,sub) then
-	SubgroupProperty(sub,cond,Aperm);
+        SubgroupProperty(sub,cond,Aperm);
       fi;
       same:=Size(Aperm)=sz;
       if not same then
-	Info(InfoMorph,3,"stablim improves by ",Size(Aperm)/sz,
-	" remaining ",Size(gp)/Size(Aperm));
+        Info(InfoMorph,3,"stablim improves by ",Size(Aperm)/sz,
+        " remaining ",Size(gp)/Size(Aperm));
       fi;
     until same;
     return sub=gp;
@@ -829,29 +829,29 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
     somechar:=ValueOption("someCharacteristics");
     if somechar<>fail then
       if IsRecord(somechar) then
-	if IsBound(somechar.orbits) then
-	  scharorb:=somechar.orbits;
-	fi;
-	somechar:=somechar.subgroups;
+        if IsBound(somechar.orbits) then
+          scharorb:=somechar.orbits;
+        fi;
+        somechar:=somechar.subgroups;
       fi;
       for i in somechar do
-	d:=RefinedSubnormalSeries(d,i);
+        d:=RefinedSubnormalSeries(d,i);
       od;
     fi;
     for i in PrimeDivisors(Size(r)) do
       u:=PCore(r,i);
       if Size(u)>1 then
-	d:=RefinedSubnormalSeries(d,u);
-	j:=1;
-	repeat
-	  v:=Agemo(u,i,j);
-	  if Size(v)>1 then
-	    d:=RefinedSubnormalSeries(d,v);
-	  fi;
-	  j:=j+1;
-	until Size(v)=1;
-	j:=1;
-	repeat
+        d:=RefinedSubnormalSeries(d,u);
+        j:=1;
+        repeat
+          v:=Agemo(u,i,j);
+          if Size(v)>1 then
+            d:=RefinedSubnormalSeries(d,v);
+          fi;
+          j:=j+1;
+        until Size(v)=1;
+        j:=1;
+        repeat
           if Size(u)>=2^24 then
             v:=u; # bail out as method for `Omega` will do so.
           else
@@ -862,7 +862,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
             j:=j+1;
           fi;
 
-	until Size(v)=Size(u);
+        until Size(v)=Size(u);
       fi;
 
     od;
@@ -910,13 +910,13 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       u:=ClosureSubgroup(u,SylowSubgroup(i,p));
       v:=ser[Length(ser)];
       while not HasElementaryAbelianFactorGroup(u,v) do
-	gens:=Filtered(GeneratorsOfGroup(u),x->not x in v);
+        gens:=Filtered(GeneratorsOfGroup(u),x->not x in v);
         e:=List(gens,x->First([1..bd],a->x^(p^a) in v));
-	e:=p^(Maximum(e)-1);
-	for j in gens do
-	  v:=ClosureSubgroup(v,j^e);
-	od;
-	Add(ser,v);
+        e:=p^(Maximum(e)-1);
+        for j in gens do
+          v:=ClosureSubgroup(v,j^e);
+        od;
+        Add(ser,v);
       od;
       Add(ser,u);
     od;
@@ -928,11 +928,11 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
   hom:=ff.factorhom;
   Q:=Image(hom,G);
   if IsPermGroup(Q) and NrMovedPoints(Q)/Size(Q)*Size(Socle(Q))
-	>SufficientlySmallDegreeSimpleGroupOrder(Size(Q)) then
+        >SufficientlySmallDegreeSimpleGroupOrder(Size(Q)) then
     # just in case the radical factor hom is inherited.
     Q:=SmallerDegreePermutationRepresentation(Q:cheap);
     Info(InfoMorph,3,"Radical factor degree reduced ",NrMovedPoints(Range(hom)),
-	      " -> ",NrMovedPoints(Range(Q)));
+              " -> ",NrMovedPoints(Range(Q)));
     hom:=hom*Q;
     Q:=Image(hom,G);
   fi;
@@ -979,8 +979,8 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 
       # inherit radical factor map
       q:=GroupHomomorphismByImagesNC(Q,Range(ff.factorhom),
-	List(GeneratorsOfGroup(G),x->ImagesRepresentative(hom,x)),
-	List(GeneratorsOfGroup(G),x->ImagesRepresentative(ff.factorhom,x)));
+        List(GeneratorsOfGroup(G),x->ImagesRepresentative(hom,x)),
+        List(GeneratorsOfGroup(G),x->ImagesRepresentative(ff.factorhom,x)));
       b:=Image(hom,ff.radical);
       SetSolvableRadical(Q,b);
       AddNaturalHomomorphismsPool(Q,b,q);
@@ -988,9 +988,9 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       # Use known maximals for Frattini
       for j in ma do
         D:=Image(hom,j);
-	if not IsSubset(D,b) then
-	  b:=Core(Q,NormalIntersection(b,D));
-	fi;
+        if not IsSubset(D,b) then
+          b:=Core(Q,NormalIntersection(b,D));
+        fi;
       od;
       SetIsNilpotentGroup(b,true);
       SetFrattiniSubgroup(Q,b);
@@ -999,8 +999,8 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       Mim:=Image(hom,M);
       MPcgs:=Pcgs(Mim);
       q:=GroupHomomorphismByImagesNC(Q,OQ,
-	List(GeneratorsOfGroup(G),x->ImagesRepresentative(hom,x)),
-	List(GeneratorsOfGroup(G),x->ImagesRepresentative(lhom,x)));
+        List(GeneratorsOfGroup(G),x->ImagesRepresentative(hom,x)),
+        List(GeneratorsOfGroup(G),x->ImagesRepresentative(lhom,x)));
       AddNaturalHomomorphismsPool(Q,Mim,q);
 
       mo:=GModuleByMats(LinearActionLayer(GeneratorsOfGroup(Q),MPcgs),GF(RelativeOrders(MPcgs)[1]));
@@ -1008,32 +1008,32 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       ocr:=OneCocycles(Q,Mim);
       split:=ocr.isSplitExtension;
       if not split then
-	# test: Semisimple and Frattini
-	b:=MTX.BasisRadical(mo);
-	fratsim:=Length(b)=0;
-	if not fratsim then
-	  b:=List(b,x->PreImagesRepresentative(hom,PcElementByExponents(MPcgs,x)));
-	  for j in b do
-	    N:=ClosureSubgroup(N,b);
-	  od;
-	  # insert
-	  for j in [Length(ser),Length(ser)-1..i+1] do
-	    ser[j+1]:=ser[j];
-	  od;
-	  ser[i+1]:=N;
-	  Info(InfoMorph,2,"insert1");
-	else
-	  # Frattini?
-	  fratsim:=IsSubset(FrattiniSubgroup(Q),Mim);
-	  if not fratsim then
-	    N:=Intersection(FrattiniSubgroup(Q),Mim);
-	    # insert
-	    for j in [Length(ser),Length(ser)-1..i+1] do
-	      ser[j+1]:=ser[j];
-	    od;
-	    ser[i+1]:=PreImage(hom,N);
-	    Info(InfoMorph,2,"insert2");
-	  fi;
+        # test: Semisimple and Frattini
+        b:=MTX.BasisRadical(mo);
+        fratsim:=Length(b)=0;
+        if not fratsim then
+          b:=List(b,x->PreImagesRepresentative(hom,PcElementByExponents(MPcgs,x)));
+          for j in b do
+            N:=ClosureSubgroup(N,b);
+          od;
+          # insert
+          for j in [Length(ser),Length(ser)-1..i+1] do
+            ser[j+1]:=ser[j];
+          od;
+          ser[i+1]:=N;
+          Info(InfoMorph,2,"insert1");
+        else
+          # Frattini?
+          fratsim:=IsSubset(FrattiniSubgroup(Q),Mim);
+          if not fratsim then
+            N:=Intersection(FrattiniSubgroup(Q),Mim);
+            # insert
+            for j in [Length(ser),Length(ser)-1..i+1] do
+              ser[j+1]:=ser[j];
+            od;
+            ser[i+1]:=PreImage(hom,N);
+            Info(InfoMorph,2,"insert2");
+          fi;
           N:=ser[i+1]; # the added normal
           if rada<>fail
              and ForAny(GeneratorsOfGroup(rada),x->N<>Image(x,N)) then
@@ -1042,7 +1042,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
             NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
             rada:=Stabilizer(rada,N,asAutom);
           fi;
-	fi;
+        fi;
       fi;
     until split or fratsim;
 
@@ -1091,15 +1091,15 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       # find noninner of B
       innB:=List(SmallGeneratingSet(Zm),z->InnerAutomorphism(Q,z));
       innB:=Group(One(DefaultFieldOfMatrixGroup(maut))*
-		      List(innB,inn->List(MPcgs,m->ExponentsOfPcElement(MPcgs,Image(inn,m)))));
+                      List(innB,inn->List(MPcgs,m->ExponentsOfPcElement(MPcgs,Image(inn,m)))));
 
       tmpAut:=SubgroupNC(maut,Filtered(GeneratorsOfGroup(maut),aut->not aut in innB));
 
       gens:=GeneratorsOfGroup(ocr.complement);
       for a  in GeneratorsOfGroup(tmpAut)  do
-	imM:=List(a,i->PcElementByExponents(MPcgs,i));
-	imM:=GroupHomomorphismByImagesNC(Q,Q,Concatenation(MPcgs,gens),Concatenation(imM,gens));
-	Assert(2,IsBijective(imM));
+        imM:=List(a,i->PcElementByExponents(MPcgs,i));
+        imM:=GroupHomomorphismByImagesNC(Q,Q,Concatenation(MPcgs,gens),Concatenation(imM,gens));
+        Assert(2,IsBijective(imM));
         Add(B,imM);
       od;
 
@@ -1111,29 +1111,29 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       cond:=function(perm)
       local aut,newgens,mo2,iso,a;
         if perm in Aperm then
-	  return true;
-	fi;
+          return true;
+        fi;
         aut:=PreImagesRepresentative(AQiso,perm);
-	newgens:=List(gens,x->PreImagesRepresentative(comiso,
-	  ImagesRepresentative(aut,ImagesRepresentative(comiso,x))));
+        newgens:=List(gens,x->PreImagesRepresentative(comiso,
+          ImagesRepresentative(aut,ImagesRepresentative(comiso,x))));
 
         mo2:=GModuleByMats(LinearActionLayer(newgens,MPcgs),mo.field);
-	iso:=MTX.IsomorphismModules(mo,mo2);
-	if iso=fail then
-	  return false;
-	else
-	  # build associated auto
+        iso:=MTX.IsomorphismModules(mo,mo2);
+        if iso=fail then
+          return false;
+        else
+          # build associated auto
 
-	  a:=GroupHomomorphismByImagesNC(Q,Q,Concatenation(gens,MPcgs),
-	          Concatenation(newgens,
+          a:=GroupHomomorphismByImagesNC(Q,Q,Concatenation(gens,MPcgs),
+                  Concatenation(newgens,
                    List(MPcgs,x->PcElementByExponents(MPcgs,
-		     (ExponentsOfPcElement(MPcgs,x)*One(mo.field))*iso  ))));
-	 Assert(2,IsBijective(a));
+                     (ExponentsOfPcElement(MPcgs,x)*One(mo.field))*iso  ))));
+         Assert(2,IsBijective(a));
          Add(A,a);
-	 Add(Apa,perm);
-	 Aperm:=ClosureGroup(Aperm,perm);
+         Add(Apa,perm);
+         Aperm:=ClosureGroup(Aperm,perm);
          return true;
-	fi;
+        fi;
       end;
 
     else
@@ -1344,16 +1344,16 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       B:=MappingGeneratorsImages(AQiso);
       res:=List(B[1],x->
         GroupHomomorphismByImagesNC(rf,rf,GeneratorsOfGroup(rf),
-	  List(GeneratorsOfGroup(rf),y->ImagesRepresentative(x,y))));
+          List(GeneratorsOfGroup(rf),y->ImagesRepresentative(x,y))));
 
       ind:=[];
       for j in GeneratorsOfGroup(rada) do
-	k:=GroupHomomorphismByImagesNC(rf,rf,
+        k:=GroupHomomorphismByImagesNC(rf,rf,
           GeneratorsOfGroup(rf),
-	  List(GeneratorsOfGroup(rf),
-	    y->ImagesRepresentative(hom,ImagesRepresentative(j,
-	         PreImagesRepresentative(hom,y)))));
-	Assert(2,IsBijective(k));
+          List(GeneratorsOfGroup(rf),
+            y->ImagesRepresentative(hom,ImagesRepresentative(j,
+                 PreImagesRepresentative(hom,y)))));
+        Assert(2,IsBijective(k));
         Add(ind,k);
       od;
 
@@ -1370,83 +1370,83 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
 
       if Size(ind)<Size(res) then
         # reduce to subgroup that induces valid automorphisms
-	Info(InfoMorph,1,"Radical autos reduce by factor ",Size(res)/Size(ind));
+        Info(InfoMorph,1,"Radical autos reduce by factor ",Size(res)/Size(ind));
         resperm:=IsomorphismPermGroup(C);
-	proj:=GroupHomomorphismByImagesNC(AQP,Image(resperm),
-	  B[2],List(GeneratorsOfGroup(res),x->ImagesRepresentative(resperm,x)));
-	C:=PreImage(proj,Image(resperm,ind));
-	C:=List(SmallGeneratingSet(C),x->PreImagesRepresentative(AQiso,x));
-	AQ:=Group(C);
-	SetIsFinite(AQ,true);
-	SetIsGroupOfAutomorphismsFiniteGroup(AQ,true);
+        proj:=GroupHomomorphismByImagesNC(AQP,Image(resperm),
+          B[2],List(GeneratorsOfGroup(res),x->ImagesRepresentative(resperm,x)));
+        C:=PreImage(proj,Image(resperm,ind));
+        C:=List(SmallGeneratingSet(C),x->PreImagesRepresentative(AQiso,x));
+        AQ:=Group(C);
+        SetIsFinite(AQ,true);
+        SetIsGroupOfAutomorphismsFiniteGroup(AQ,true);
         makeaqiso();
       fi;
 
       # # hook for using existing characteristics to reduce for next step
       if somechar<>fail then
         u:=Filtered(Unique(List(somechar,x->Image(hom,x))),x->Size(x)>1);
-	u:=Filtered(u,s->ForAny(GeneratorsOfGroup(AQ),h->Image(h,s)<>s));
-	SortBy(u,Size);
-	Info(InfoMorph,1,"Forced characteristics ",List(u,Size));
+        u:=Filtered(u,s->ForAny(GeneratorsOfGroup(AQ),h->Image(h,s)<>s));
+        SortBy(u,Size);
+        Info(InfoMorph,1,"Forced characteristics ",List(u,Size));
 
-	if scharorb<>fail then
-	  # these are subgroups for which certain orbits must be stabilized.
-	  C:=List(Reversed(scharorb),x->List(x,y->Image(hom,y)));
-	  C:=Filtered(C,x->Size(x[1])>1 and Size(x[1])<Size(Q));
-	  Info(InfoMorph,1,"Forced orbits ",List(C,x->Size(x[1])));
-	  Append(u,C);
-	fi;
+        if scharorb<>fail then
+          # these are subgroups for which certain orbits must be stabilized.
+          C:=List(Reversed(scharorb),x->List(x,y->Image(hom,y)));
+          C:=Filtered(C,x->Size(x[1])>1 and Size(x[1])<Size(Q));
+          Info(InfoMorph,1,"Forced orbits ",List(C,x->Size(x[1])));
+          Append(u,C);
+        fi;
 
-	if Length(u)>0 then
-	  C:=MappingGeneratorsImages(AQiso);
-	  if C[2]<>GeneratorsOfGroup(AQP) then
-	    C:=[List(GeneratorsOfGroup(AQP),
-	             x->PreImagesRepresentative(AQiso,x)),
-		     GeneratorsOfGroup(AQP)];
-	  fi;
-	  for j in u do
-	    if IsList(j) then
-	      # stabilizer set of subgroups
-	      jorb:=ShallowCopy(Orbit(AQP,j[1],C[2],C[1],asAutom));
-	      jorpo:=[Position(jorb,j[1]),Position(jorb,j[2])];
-	      if jorpo[2]=fail then
-	        Append(jorb,Orbit(AQP,j[1],C[2],C[1],asAutom));
-		jorpo[2]:=Position(jorb,j[2]);
-	      fi;
-	      if Length(jorb)>Length(j) then
-		B:=ActionHomomorphism(AQP,jorb,C[2],C[1],asAutom);
-		substb:=Group(List(C[2],x->ImagesRepresentative(B,x)),());
-		substb:=Stabilizer(substb,Set(jorpo),OnSets);
-		substb:=PreImage(B,substb);
-		Info(InfoMorph,2,"Stabilize characteristic orbit ",Size(j[1]),
-		  " :",Size(AQP)/Size(substb) );
-	      else
-	        substb:=AQP;
-	      fi;
+        if Length(u)>0 then
+          C:=MappingGeneratorsImages(AQiso);
+          if C[2]<>GeneratorsOfGroup(AQP) then
+            C:=[List(GeneratorsOfGroup(AQP),
+                     x->PreImagesRepresentative(AQiso,x)),
+                 GeneratorsOfGroup(AQP)];
+          fi;
+          for j in u do
+            if IsList(j) then
+              # stabilizer set of subgroups
+              jorb:=ShallowCopy(Orbit(AQP,j[1],C[2],C[1],asAutom));
+              jorpo:=[Position(jorb,j[1]),Position(jorb,j[2])];
+              if jorpo[2]=fail then
+                Append(jorb,Orbit(AQP,j[1],C[2],C[1],asAutom));
+            jorpo[2]:=Position(jorb,j[2]);
+              fi;
+              if Length(jorb)>Length(j) then
+            B:=ActionHomomorphism(AQP,jorb,C[2],C[1],asAutom);
+            substb:=Group(List(C[2],x->ImagesRepresentative(B,x)),());
+            substb:=Stabilizer(substb,Set(jorpo),OnSets);
+            substb:=PreImage(B,substb);
+            Info(InfoMorph,2,"Stabilize characteristic orbit ",Size(j[1]),
+              " :",Size(AQP)/Size(substb) );
+              else
+                substb:=AQP;
+              fi;
 
 
-	    else
-	      substb:=Stabilizer(AQP,j,C[2],C[1],asAutom);
-	      Info(InfoMorph,2,"Stabilize characteristic subgroup ",Size(j),
-		" :",Size(AQP)/Size(substb) );
-	    fi;
-	    if Size(substb)<Size(AQP) then
-	      B:=Size(substb);
-	      substb:=SmallGeneratingSet(substb);
-	      AQP:=Group(substb);
-	      SetSize(AQP,B);
-	      C:=[List(substb,x->PreImagesRepresentative(AQiso,x)),substb];
-	    fi;
+        else
+          substb:=Stabilizer(AQP,j,C[2],C[1],asAutom);
+          Info(InfoMorph,2,"Stabilize characteristic subgroup ",Size(j),
+        " :",Size(AQP)/Size(substb) );
+        fi;
+        if Size(substb)<Size(AQP) then
+          B:=Size(substb);
+          substb:=SmallGeneratingSet(substb);
+          AQP:=Group(substb);
+          SetSize(AQP,B);
+          C:=[List(substb,x->PreImagesRepresentative(AQiso,x)),substb];
+        fi;
 
-	  od;
-	  AQ:=Group(C[1]);
-	  SetIsFinite(AQ,true);
-	  SetIsGroupOfAutomorphismsFiniteGroup(AQ,true);
-	  SetSize(AQ,Size(AQP));
-	  #AQP:=Group(C[2]); # ensure small gen set
-	  #SetSize(AQP,Size(AQ));
-	  makeaqiso();
-	fi;
+      od;
+      AQ:=Group(C[1]);
+      SetIsFinite(AQ,true);
+      SetIsGroupOfAutomorphismsFiniteGroup(AQ,true);
+      SetSize(AQ,Size(AQP));
+      #AQP:=Group(C[2]); # ensure small gen set
+      #SetSize(AQP,Size(AQ));
+      makeaqiso();
+    fi;
       fi;
 
       lastperm:=AQiso;
@@ -1713,7 +1713,7 @@ local d,a,map,possibly,cG,cH,nG,nH,i,j,sel,u,v,asAutomorphism,K,L,conj,e1,e2,
      and ValueOption(NO_PRECOMPUTED_DATA_OPTION)<>true then
       Info(InfoPerformance,2,"Using Small Groups Library");
       if IdGroup(a)<>IdGroup(b) then
-	return false;
+        return false;
       fi;
     fi;
     return true;
@@ -1785,7 +1785,7 @@ local d,a,map,possibly,cG,cH,nG,nH,i,j,sel,u,v,asAutomorphism,K,L,conj,e1,e2,
 
   for i in [2..Length(nG)] do
     K:=Filtered([1..Length(nG)],x->Size(nG[x])*2=Size(nG[i])
-	  and IsSubset(nG[i],nG[x]));
+          and IsSubset(nG[i],nG[x]));
     if Length(K)>0 then
       K:=K[1];
       # We are seeking an isomorphism, not the full automorphism group of
@@ -1801,9 +1801,9 @@ local d,a,map,possibly,cG,cH,nG,nH,i,j,sel,u,v,asAutomorphism,K,L,conj,e1,e2,
       # ``characteristic'' to improve the series.
 
       Add(cG,ClosureGroup(
-	ClosureGroup(Image(e1,nG[K]),Image(e2,nH[K])),
-	  Image(e1,First(GeneratorsOfGroup(nG[i]),x->not x in nG[K]))
-	 *Image(e2,First(GeneratorsOfGroup(nH[i]),x->not x in nH[K]))));
+        ClosureGroup(Image(e1,nG[K]),Image(e2,nH[K])),
+          Image(e1,First(GeneratorsOfGroup(nG[i]),x->not x in nG[K]))
+         *Image(e2,First(GeneratorsOfGroup(nH[i]),x->not x in nH[K]))));
 
     fi;
   od;
@@ -1821,7 +1821,7 @@ local d,a,map,possibly,cG,cH,nG,nH,i,j,sel,u,v,asAutomorphism,K,L,conj,e1,e2,
   #if NrMovedPoints(api)>5000 then
   #  K:=SmallerDegreePermutationRepresentation(api);
   #  Info(InfoMorph,2,"Permdegree reduced ",
-#	  NrMovedPoints(api),"->",NrMovedPoints(Image(K)));
+#         NrMovedPoints(api),"->",NrMovedPoints(Image(K)));
 #    iso:=iso*K;
 #    api:=Image(iso);
 #  fi;


### PR DESCRIPTION
As discussed in #5268, this is the first (of 26?) pull requests removing tabs from files in `lib`, this one does so for the files starting with `a`.  I have replaced tabs by spaces so that the existing indentation, however, wonky, is preserved. I'm not sure that the diff on GitHub is 100% accurate, all files in this PR show identical indentation with the previous version when I view them in vim.

## Text for release notes

None

