### PR TITLE
Remove unused lvars a files

### DIFF
--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -2056,7 +2056,6 @@ InstallMethod( ViewObj,
     "for an algebra-with-one with known generators",
     [ IsAlgebraWithOne and HasGeneratorsOfAlgebraWithOne ],
     function( A )
-    local nrgens;
     Print( "<algebra-with-one over ", LeftActingDomain( A ), ", with ",
            Pluralize( Length( GeneratorsOfAlgebraWithOne( A ) ), "generator" ),
            ">" );
@@ -2113,7 +2112,6 @@ InstallMethod( ViewObj,
     "for a Lie algebra with known generators",
     [ IsLieAlgebra and HasGeneratorsOfAlgebra ],
     function( A )
-    local nrgens;
     Print( "<Lie algebra over ", LeftActingDomain( A ), ", with ",
            Pluralize( Length( GeneratorsOfAlgebra( A ) ), "generator" ), ">" );
 end );

--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -485,7 +485,7 @@ end);
 ##
 InstallMethod(\*,"AlgElm*AlgElm",IsIdenticalObj,[IsKroneckerConstRep,IsKroneckerConstRep],0,
 function(x,y)
-local fam,b,d,i;
+local fam,b,i;
   fam:=FamilyObj(x);
   b:=ProductCoeffs(x![1],y![1]);
   while Length(b)<fam!.deg do
@@ -1072,7 +1072,7 @@ local l,f,i,j,k,gens;
 end);
 
 InstallGlobalFunction(AlgExtEmbeddedPol,function(ext,pol)
-local f, cof;
+local cof;
    cof:=CoefficientsOfUnivariatePolynomial(pol);
    return UnivariatePolynomial(ext,cof*One(ext),
              IndeterminateNumberOfUnivariateRationalFunction(pol));
@@ -1353,7 +1353,7 @@ end);
 ##
 InstallGlobalFunction(IdealDecompositionsOfPolynomial,function(f)
 local n,e,ff,p,ffp,ffd,roots,allroots,nowroots,fm,fft,comb,combi,k,h,i,j,
-      gut,avoid,blocks,g,m,decom,z,R,scale,allowed,hp,hpc,a,kfam,only;
+      gut,avoid,blocks,g,m,decom,z,allowed,hp,hpc,a,kfam,only;
 
   only:=ValueOption("onlyone")=true;
   n:=DegreeOfUnivariateLaurentPolynomial(f);

--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -502,7 +502,7 @@ InstallMethod( IsSingleValued,
     "for algebra g.m.b.i.",
     [ IsGeneralMapping and IsAlgebraGeneralMappingByImagesDefaultRep ],
 function(map)
-local S,gi,i,basic;
+local S;
   S:=Source(map);
 
   # rewriting to left modules is not feasible for infinite dimensional

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -1165,7 +1165,7 @@ end);
 InstallMethod( PClosureSubalgebra, "for a subalgebra of restricted jacobian elements",
     [ IsLieAlgebra and IsJacobianElementCollection ],
     function(A)
-    local i, p, oldA;
+    local i, oldA;
 
     repeat
         oldA := A;

--- a/lib/algliess.gi
+++ b/lib/algliess.gi
@@ -1349,7 +1349,7 @@ SimpleLieAlgebraTypeM := function (n, F)
     # that
     #    p = coeff * OBasis [pos].
     WOProduct := function (w1, x2)
-        local pow, prod;
+        local pow;
         if x2 [w1 [2]] > 0 then
             pow := ShallowCopy (x2);
             pow [w1 [2]] := pow [w1 [2]] - 1;

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -1145,41 +1145,41 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       precond:=function(perm)
       local aut,newgens,mo2;
         if perm in Aperm then
-	  return true;
-	fi;
+          return true;
+        fi;
         aut:=PreImagesRepresentative(AQiso,perm);
-	newgens:=List(GeneratorsOfGroup(Q),
-	  x->PreImagesRepresentative(q,Image(aut,ImagesRepresentative(q,x))));
+        newgens:=List(GeneratorsOfGroup(Q),
+          x->PreImagesRepresentative(q,Image(aut,ImagesRepresentative(q,x))));
         mo2:=GModuleByMats(LinearActionLayer(newgens,MPcgs),mo.field);
-	return MTX.IsomorphismModules(mo,mo2)<>fail;
+        return MTX.IsomorphismModules(mo,mo2)<>fail;
       end;
 
       cond:=function(perm)
       local aut,newgens,mo2,iso,a;
         if perm in Aperm then
-	  return true;
-	fi;
+          return true;
+        fi;
         aut:=PreImagesRepresentative(AQiso,perm);
-	newgens:=List(GeneratorsOfGroup(Q),
-	  x->PreImagesRepresentative(q,Image(aut,ImagesRepresentative(q,x))));
+        newgens:=List(GeneratorsOfGroup(Q),
+          x->PreImagesRepresentative(q,Image(aut,ImagesRepresentative(q,x))));
         mo2:=GModuleByMats(LinearActionLayer(newgens,MPcgs),mo.field);
-	iso:=MTX.IsomorphismModules(mo,mo2);
-	if iso=fail then
-	  return false;
-	else
-	  # build associated auto
-	  a:=AGSRAutomLift(ocr,q,aut,iso);
-	  if a=fail then
-	    #Print("test failed\n");
-	    return false;
-	  else
-	    Add(A,a);
-	    Add(Apa,perm);
-	    Aperm:=ClosureGroup(Aperm,perm);
-	    #Print("test succeeded\n");
-	    return true;
-	  fi;
-	fi;
+        iso:=MTX.IsomorphismModules(mo,mo2);
+        if iso=fail then
+          return false;
+        else
+          # build associated auto
+          a:=AGSRAutomLift(ocr,q,aut,iso);
+          if a=fail then
+            #Print("test failed\n");
+            return false;
+          else
+            Add(A,a);
+            Add(Apa,perm);
+            Aperm:=ClosureGroup(Aperm,perm);
+            #Print("test succeeded\n");
+            return true;
+          fi;
+        fi;
       end;
 
     fi;
@@ -1189,15 +1189,15 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
     Apa:=[];
     # note: we do not include AQI here, so might need to add later
     Aperm:=SubgroupNC(AQP,List(GeneratorsOfGroup(AQI),
-	    x->ImagesRepresentative(AQiso,x)));
+            x->ImagesRepresentative(AQiso,x)));
 
     # try to find some further generators
     if Size(AQP)/Size(Aperm)>100 then
       for j in SpecialPcgs(SolvableRadical(AQP)) do
-	cond(j);
+        cond(j);
       od;
       for j in GeneratorsOfGroup(AQP) do
-	cond(j);
+        cond(j);
       od;
     fi;
 
@@ -1246,8 +1246,8 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       k:=ImagesRepresentative(AQiso,ac);
       if not k in Aperm then
         Add(Apa,k);
-	Aperm:=ClosureGroup(Aperm,k);
-	Add(A,InnerAutomorphism(Q,GeneratorsOfGroup(Q)[j]));
+        Aperm:=ClosureGroup(Aperm,k);
+        Add(A,InnerAutomorphism(Q,GeneratorsOfGroup(Q)[j]));
       fi;
       j:=j+1;
     od;
@@ -1306,35 +1306,35 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
      and ValueOption("noradicalaut")<>true then
 
       if rada=fail then
-	if IsElementaryAbelian(r) and Size(r)>1 then
-	  B:=Pcgs(r);
-	  rf:=GF(RelativeOrders(B)[1]);
-	  ind:=Filtered(ser,x->IsSubset(r,x) and Size(x)>1 and Size(x)<Size(r));
-	  ind:=List(ind,x->List(GeneratorsOfGroup(x),y->ExponentsOfPcElement(B,y)));
-	  ind:=List(ind,x->x*One(rf));
-	  ind:=SpaceAndOrbitStabilizer(Length(B),rf,ind,[]);
-	  rada:=List(GeneratorsOfGroup(ind),x->
-	    GroupHomomorphismByImagesNC(r,r,B,List(x,y->PcElementByExponents(B,List(y,Int)))));
-	  rada:=Group(rada);
-	  SetIsGroupOfAutomorphismsFiniteGroup(rada,true);
-	  NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
-	else
-	  ind:=IsomorphismPcGroup(r);
-	  rada:=AutomorphismGroup(Image(ind,r):someCharacteristics:=fail,autactbase:=fail);
-	  # we only consider those homomorphism that stabilize the series we use
-	  for k in List(ser,x->Image(ind,x)) do
-	    if ForAny(GeneratorsOfGroup(rada),x->Image(x,k)<>k) then
-	      Info(InfoMorph,3,"radical automorphism stabilizer");
-	      NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
+        if IsElementaryAbelian(r) and Size(r)>1 then
+          B:=Pcgs(r);
+          rf:=GF(RelativeOrders(B)[1]);
+          ind:=Filtered(ser,x->IsSubset(r,x) and Size(x)>1 and Size(x)<Size(r));
+          ind:=List(ind,x->List(GeneratorsOfGroup(x),y->ExponentsOfPcElement(B,y)));
+          ind:=List(ind,x->x*One(rf));
+          ind:=SpaceAndOrbitStabilizer(Length(B),rf,ind,[]);
+          rada:=List(GeneratorsOfGroup(ind),x->
+            GroupHomomorphismByImagesNC(r,r,B,List(x,y->PcElementByExponents(B,List(y,Int)))));
+          rada:=Group(rada);
+          SetIsGroupOfAutomorphismsFiniteGroup(rada,true);
+          NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
+        else
+          ind:=IsomorphismPcGroup(r);
+          rada:=AutomorphismGroup(Image(ind,r):someCharacteristics:=fail,autactbase:=fail);
+          # we only consider those homomorphism that stabilize the series we use
+          for k in List(ser,x->Image(ind,x)) do
+            if ForAny(GeneratorsOfGroup(rada),x->Image(x,k)<>k) then
+              Info(InfoMorph,3,"radical automorphism stabilizer");
+              NiceMonomorphism(rada:autactbase:=fail,someCharacteristics:=fail);
               SetIsGroupOfAutomorphismsFiniteGroup(rada,true);
-	      rada:=Stabilizer(rada,k,asAutom);
-	    fi;
-	  od;
-	  # move back to bad degree
-	  rada:=Group(List(GeneratorsOfGroup(rada),
-	    x-> InducedAutomorphism(InverseGeneralMapping(ind),x)));
+              rada:=Stabilizer(rada,k,asAutom);
+            fi;
+          od;
+          # move back to bad degree
+          rada:=Group(List(GeneratorsOfGroup(rada),
+            x-> InducedAutomorphism(InverseGeneralMapping(ind),x)));
 
-	fi;
+        fi;
       fi;
 
       rf:=Image(hom,r);

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -86,7 +86,7 @@ end;
 # of representatives and can be used to deduce the module automorphism
 # belonging to a factor group automorphism.
 BindGlobal("AGSRFindRels",function(nat,newgens)
-local C,M,p,all,gens,sub,q,hom,fp,rels,new,pre,sel,i,free,cnt;
+local C,M,p,all,gens,sub,q,hom,fp,rels,new,pre,i,free,cnt;
   M:=KernelOfMultiplicativeGeneralMapping(nat);
   C:=Centralizer(Source(nat),M);
   if not IsSubset(FrattiniSubgroup(C),M) then
@@ -334,7 +334,7 @@ end);
 # First try `SubgroupProperty`, but when it stalls attempt to find
 # minimal supergroups and prove that none of them satisfies.
 BindGlobal("SubgroupConditionAboveAux",function(G,cond,S1,avoid)
-local S,c,hom,q,a,b,i,t,int,bad,have,ups,up,new,u,good,abort,clim,worked,pp,
+local S,c,hom,q,a,b,i,t,have,ups,new,u,good,abort,clim,worked,pp,
   cnt,locond,tstcnt,setupc,havetest;
 
   setupc:=function()
@@ -704,7 +704,7 @@ end);
 # component subgroups, orbits
 BindGlobal("AutomGrpSR",function(G)
 local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
-      b,fratsim,AQ,OQ,Zm,D,innC,bas,oneC,imgs,C,maut,innB,tmpAut,imM,a,A,B,
+      b,fratsim,AQ,OQ,Zm,D,innC,oneC,imgs,C,maut,innB,tmpAut,imM,a,A,B,
       cond,sub,AQI,AQP,AQiso,rf,res,resperm,proj,Aperm,Apa,precond,ac,
       comiso,extra,mo,rada,makeaqiso,ind,lastperm,actbase,somechar,stablim,
       scharorb,asAutom,jorb,jorpo,substb,isBadPermrep,ma,nosucl,nosuf,rlgf;
@@ -1143,7 +1143,7 @@ local ff,r,d,ser,u,v,i,j,k,p,bd,e,gens,lhom,M,N,hom,Q,Mim,q,ocr,split,MPcgs,
       ocr:=AGSRPrepareAutomLift( Q, MPcgs, q );
 
       precond:=function(perm)
-      local aut,newgens,mo2,iso,a;
+      local aut,newgens,mo2;
         if perm in Aperm then
 	  return true;
 	fi;
@@ -1547,7 +1547,7 @@ end);
 BindGlobal("AGSRMatchedCharacteristics",function(g,h)
 local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
   props:=function(a,chars)
-  local p,b,i,r,der;
+  local p,b,der;
     der:=function(u)
       if u in chars then
         Add(p,-Position(chars,u));
@@ -1699,8 +1699,8 @@ end);
 # only of use as long as we don't yet have a Cannon/Holt version of
 # isomorphism available and there are many generators
 InstallGlobalFunction(PatheticIsomorphism,function(G,H)
-local d,a,map,possibly,cG,cH,nG,nH,i,j,sel,u,v,asAutomorphism,K,L,conj,e1,e2,
-      iso,api,good,gens,pre,aab,as;
+local d,a,map,possibly,cG,nG,nH,i,j,u,v,asAutomorphism,K,L,conj,e1,e2,
+      iso,api,gens,pre,aab,as;
 
   possibly:=function(a,b)
     if Size(a)<>Size(b) then


### PR DESCRIPTION
This PR removes all declared but unused local variables in the files in the library starting with the letter "a", and removes tabs from one of these files again. 

## Text for release notes

None