### PR TITLE
BuildPackages.sh: tweak how GAP is invoked

### DIFF
--- a/bin/BuildPackages.sh
+++ b/bin/BuildPackages.sh
@@ -194,7 +194,7 @@ run_configure_and_make() {
   then
     if grep Autoconf ./configure > /dev/null
     then
-      local PKG_NAME=$($GAP -q -T -A -M <<GAPInput
+      local PKG_NAME=$($GAP -q -T -A -r -M --bare <<GAPInput
 Read("PackageInfo.g");
 Print(GAPInfo.PackageInfoCurrent.PackageName);
 GAPInput


### PR DESCRIPTION
... to determine package names. Namely, add back the -r command line option for GAP we recently removed, and instead add --bare to achieve a similar effect: namely to allow starting GAP with the required packages smallgrp etc. not present in the pkg directory of the primary GAP root

Should resolve #5286