### PR TITLE
Make `Remove` with two arguments faster for internal lists

### DIFF
--- a/lib/list.gi
+++ b/lib/list.gi
@@ -1984,9 +1984,12 @@ InstallMethod(Remove, "one argument", [IsList and IsMutable],
     return x;
 end);
 
-InstallMethod(Remove, "two arguments, fast", [IsList and IsPlistRep and IsMutable, IsPosInt],
+InstallEarlyMethod(Remove,
         function(l,p)
     local ret,x,len;
+    if not (IsPlistRep(l) and IsMutable(l) and IsPosInt(p)) then
+        TryNextMethod();
+    fi;
     len := Length(l);
     ret := IsBound(l[p]);
     if ret then


### PR DESCRIPTION
Before:

    gap> l := List([1..100000], i->[i]);;
    gap> while Length(l)>0 do Remove(l,Length(l)); od; time;
    53937

After:

    gap> l := List([1..100000], i->[i]);;
    gap> while Length(l)>0 do Remove(l,Length(l)); od; time;
    17

Resolves #767