### PR TITLE
Remove `ActivateProfileColour` (it was rarely used or even known, and blocked work on the profiling engine)

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -839,7 +839,6 @@ Profiles are transformed into a human-readable form with
 <#Include Label="CoverageLineByLine">
 <#Include Label="UnprofileLineByLine">
 <#Include Label="UncoverageLineByLine">
-<#Include Label="ActivateProfileColour">
 <#Include Label="IsLineByLineProfileActive">
 
 

--- a/lib/newprofile.g
+++ b/lib/newprofile.g
@@ -153,25 +153,3 @@ end);
 BIND_GLOBAL("UncoverageLineByLine", function()
   return DEACTIVATE_PROFILING();
 end);
-
-
-#############################################################################
-##
-##
-##  <#GAPDoc Label="ActivateProfileColour">
-##  <ManSection>
-##  <Func Name="ActivateProfileColour" Arg=""/>
-##
-##  <Description>
-##  Called with argument <K>true</K>,
-##  <Ref Func="ActivateProfileColour"/>
-##  makes GAP colour functions when printing them to show which lines
-##  have been executed while profiling was active via
-##  <Ref Func="ProfileLineByLine" /> at any time during this GAP session.
-##  Passing <K>false</K> disables this behaviour.
-##  </Description>
-##  </ManSection>
-##  <#/GAPDoc>
-BIND_GLOBAL("ActivateProfileColour",function(b)
-    return ACTIVATE_COLOR_PROFILING(b);
-end);

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -1194,6 +1194,28 @@ static void RecExpr2(Obj rec, Expr expr)
 
 /****************************************************************************
 **
+*V  PrintExprFuncs[<type>]  . .  printing function for objects of type <type>
+**
+**  'PrintExprFuncs' is the dispatching table that contains for every type of
+**  expressions a pointer to the printer for expressions  of this type, i.e.,
+**  the function that should be called to print expressions of this type.
+*/
+static PrintExprFunc PrintExprFuncs[256];
+
+
+/****************************************************************************
+**
+*F  InstallPrintExprFunc(<pos>,<f>)
+*/
+void InstallPrintExprFunc(unsigned int pos, PrintExprFunc f)
+{
+    GAP_ASSERT(pos < ARRAY_SIZE(PrintExprFuncs));
+    PrintExprFuncs[pos] = f;
+}
+
+
+/****************************************************************************
+**
 *F  PrintExpr(<expr>) . . . . . . . . . . . . . . . . . . print an expression
 **
 **  'PrintExpr' prints the expression <expr>.
@@ -1201,22 +1223,10 @@ static void RecExpr2(Obj rec, Expr expr)
 **  'PrintExpr' simply dispatches  through  the table 'PrintExprFuncs' to the
 **  appropriate printer.
 */
-void            PrintExpr (
-    Expr                expr )
+void PrintExpr(Expr expr)
 {
-    (*PrintExprFuncs[ TNUM_EXPR(expr) ])( expr );
+    (*PrintExprFuncs[TNUM_EXPR(expr)])(expr);
 }
-
-
-/****************************************************************************
-**
-*V  PrintExprFuncs[<type>]  . .  printing function for objects of type <type>
-**
-**  'PrintExprFuncs' is the dispatching table that contains for every type of
-**  expressions a pointer to the printer for expressions  of this type, i.e.,
-**  the function that should be called to print expressions of this type.
-*/
-PrintExprFunc PrintExprFuncs[256];
 
 
 /****************************************************************************

--- a/src/exprs.h
+++ b/src/exprs.h
@@ -141,15 +141,7 @@ void PrintExpr(Expr expr);
 void PrintRecExpr1(Expr expr); /* needed for printing
                                        function calls with options */
 
-/****************************************************************************
-**
-*V  PrintExprFuncs[<type>]  . .  printing function for objects of type <type>
-**
-**  'PrintExprFuncs' is the dispatching table that contains for every type of
-**  expressions a pointer to the printer for expressions  of this type, i.e.,
-**  the function that should be called to print expressions of this type.
-*/
-extern PrintExprFunc PrintExprFuncs[256];
+void InstallPrintExprFunc(unsigned int pos, PrintExprFunc f);
 
 
 /****************************************************************************

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -19,8 +19,6 @@
 void InstallEvalBoolFunc(Int, EvalBoolFunc);
 void InstallEvalExprFunc(Int, EvalExprFunc);
 void InstallExecStatFunc(Int, ExecStatFunc);
-void InstallPrintStatFunc(Int, PrintStatFunc);
-void InstallPrintExprFunc(Int, PrintExprFunc);
 
 
 /****************************************************************************
@@ -35,9 +33,6 @@ extern ExecStatFunc OriginalExecStatFuncsForHook[256];
 
 extern EvalExprFunc OriginalEvalExprFuncsForHook[256];
 extern EvalBoolFunc OriginalEvalBoolFuncsForHook[256];
-
-extern PrintStatFunc OriginalPrintStatFuncsForHook[256];
-extern PrintExprFunc OriginalPrintExprFuncsForHook[256];
 
 
 /****************************************************************************
@@ -90,25 +85,6 @@ extern struct InterpreterHooks * activeHooks[HookCount];
 
 Int ActivateHooks(struct InterpreterHooks * hook);
 Int DeactivateHooks(struct InterpreterHooks * hook);
-
-/****************************************************************************
-**
-** A struct to represent the hooks allowed into printing functions
-**
-**
-** This struct represents a list of functions which will be called whenever
-** a statement or expression is printed. They can be used to provide
-** simple customisation of printing. At the moment they are used by
-** profiling.c, to mark statements which have been executed.
-** Look at that code to get an idea how to use them.
-*/
-struct PrintHooks {
-    void (*printStatPassthrough)(Stat stat);
-    void (*printExprPassthrough)(Expr stat);
-};
-
-void ActivatePrintHooks(struct PrintHooks * hook);
-void DeactivatePrintHooks(struct PrintHooks * hook);
 
 /****************************************************************************
 **

--- a/src/stats.c
+++ b/src/stats.c
@@ -1137,21 +1137,6 @@ void ClearError ( void )
     }
 }
 
-/****************************************************************************
-**
-*F  PrintStat(<stat>) . . . . . . . . . . . . . . . . . . . print a statement
-**
-**  'PrintStat' prints the statements <stat>.
-**
-**  'PrintStat' simply dispatches  through the table  'PrintStatFuncs' to the
-**  appropriate printer.
-*/
-void            PrintStat (
-    Stat                stat )
-{
-    (*PrintStatFuncs[TNUM_STAT(stat)])( stat );
-}
-
 
 /****************************************************************************
 **
@@ -1161,7 +1146,33 @@ void            PrintStat (
 **  statements a pointer to the  printer for statements  of this type,  i.e.,
 **  the function that should be called to print statements of this type.
 */
-PrintStatFunc PrintStatFuncs[256];
+static PrintStatFunc PrintStatFuncs[256];
+
+
+/****************************************************************************
+**
+*F  InstallPrintStatFunc(<pos>,<f>)
+*/
+void InstallPrintStatFunc(unsigned int pos, PrintStatFunc f)
+{
+    GAP_ASSERT(pos < ARRAY_SIZE(PrintStatFuncs));
+    PrintStatFuncs[pos] = f;
+}
+
+
+/****************************************************************************
+**
+*F  PrintStat(<stat>) . . . . . . . . . . . . . . . . . . . print a statement
+**
+**  'PrintStat' prints the statements <stat>.
+**
+**  'PrintStat' simply dispatches  through the table  'PrintStatFuncs' to the
+**  appropriate printer.
+*/
+void PrintStat(Stat stat)
+{
+    (*PrintStatFuncs[TNUM_STAT(stat)])(stat);
+}
 
 
 /****************************************************************************

--- a/src/stats.h
+++ b/src/stats.h
@@ -109,15 +109,7 @@ void InterruptExecStat(void);
 void PrintStat(Stat stat);
 
 
-/****************************************************************************
-**
-*V  PrintStatFuncs[<type>]  . .  print function for statements of type <type>
-**
-**  'PrintStatFuncs' is the dispatching table that contains for every type of
-**  statements a pointer to the  printer for statements  of this type,  i.e.,
-**  the function that should be called to print statements of this type.
-*/
-extern PrintStatFunc PrintStatFuncs[256];
+void InstallPrintStatFunc(unsigned int pos, PrintStatFunc f);
 
 
 /****************************************************************************


### PR DESCRIPTION
Part of #5261 , which removes a function which was previously tested in the `profiling` package.