### PR TITLE
kernel: cleanup hookintrprtr and profile code

### DIFF
--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -25,7 +25,7 @@
 
 
 // List of active hooks
-struct InterpreterHooks * activeHooks[HookCount];
+struct InterpreterHooks * activeHooks[MAX_HOOK_COUNT];
 
 // Number of active hooks
 static Int HookActiveCount;
@@ -135,19 +135,19 @@ static Obj ProfileEvalBoolPassthrough(Expr stat)
 **
 */
 
-Int ActivateHooks(struct InterpreterHooks * hook)
+void ActivateHooks(struct InterpreterHooks * hook)
 {
     Int i;
 
-    if (HookActiveCount == HookCount) {
-        return 0;
+    if (HookActiveCount == MAX_HOOK_COUNT) {
+        return;
     }
 
     HashLock(&activeHooks);
-    for (i = 0; i < HookCount; ++i) {
+    for (i = 0; i < MAX_HOOK_COUNT; ++i) {
         if (activeHooks[i] == hook) {
             HashUnlock(&activeHooks);
-            return 0;
+            return;
         }
     }
 
@@ -157,24 +157,20 @@ Int ActivateHooks(struct InterpreterHooks * hook)
         EvalBoolFuncs[i] = ProfileEvalBoolPassthrough;
     }
 
-    for (i = 0; i < HookCount; ++i) {
+    for (i = 0; i < MAX_HOOK_COUNT; ++i) {
         if (!activeHooks[i]) {
             activeHooks[i] = hook;
             HookActiveCount++;
-            HashUnlock(&activeHooks);
-            return 1;
+            break;
         }
     }
     HashUnlock(&activeHooks);
-    return 0;
 }
 
-Int DeactivateHooks(struct InterpreterHooks * hook)
+void DeactivateHooks(struct InterpreterHooks * hook)
 {
-    Int i;
-
     HashLock(&activeHooks);
-    for (i = 0; i < HookCount; ++i) {
+    for (int i = 0; i < MAX_HOOK_COUNT; ++i) {
         if (activeHooks[i] == hook) {
             activeHooks[i] = 0;
             HookActiveCount--;
@@ -188,7 +184,6 @@ Int DeactivateHooks(struct InterpreterHooks * hook)
     }
 
     HashUnlock(&activeHooks);
-    return 1;
 }
 
 void ActivatePrintHooks(struct PrintHooks * hook)

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -75,21 +75,21 @@ extern PrintExprFunc OriginalPrintExprFuncsForHook[256];
 
 struct InterpreterHooks {
     void (*visitStat)(Stat stat);
-    void (*visitInterpretedStat)(Int line, Int pos);
+    void (*visitInterpretedStat)(int fileid, int line);
     void (*enterFunction)(Obj func);
     void (*leaveFunction)(Obj func);
     void (*registerStat)(Stat stat);
-    void (*registerInterpretedStat)(Int line, Int pos);
+    void (*registerInterpretedStat)(int fileid, int line);
     const char * hookName;
 };
 
 
-enum { HookCount = 6 };
+enum { MAX_HOOK_COUNT = 6 };
 
-extern struct InterpreterHooks * activeHooks[HookCount];
+extern struct InterpreterHooks * activeHooks[MAX_HOOK_COUNT];
 
-Int ActivateHooks(struct InterpreterHooks * hook);
-Int DeactivateHooks(struct InterpreterHooks * hook);
+void ActivateHooks(struct InterpreterHooks * hook);
+void DeactivateHooks(struct InterpreterHooks * hook);
 
 /****************************************************************************
 **
@@ -128,9 +128,8 @@ void DeactivatePrintHooks(struct PrintHooks * hook);
 
 #define GAP_HOOK_LOOP(member, ...)                                           \
     do {                                                                     \
-        Int                       i;                                         \
         struct InterpreterHooks * hook;                                      \
-        for (i = 0; i < HookCount; ++i) {                                    \
+        for (int i = 0; i < MAX_HOOK_COUNT; ++i) {                           \
             hook = activeHooks[i];                                           \
             if (hook && hook->member) {                                      \
                 (hook->member)(__VA_ARGS__);                                 \
@@ -159,11 +158,11 @@ EXPORT_INLINE void RegisterStatWithHook(Stat func)
     GAP_HOOK_LOOP(registerStat, func);
 }
 
-EXPORT_INLINE void InterpreterHook(Int file, Int line, Int skipped)
+EXPORT_INLINE void InterpreterHook(int fileid, int line, Int skipped)
 {
-    GAP_HOOK_LOOP(registerInterpretedStat, file, line);
+    GAP_HOOK_LOOP(registerInterpretedStat, fileid, line);
     if (!skipped) {
-        GAP_HOOK_LOOP(visitInterpretedStat, file, line);
+        GAP_HOOK_LOOP(visitInterpretedStat, fileid, line);
     }
 }
 


### PR DESCRIPTION
- unify nameid, file, fileID, fileid -> fileid
- unify argument order: first fileid, then line
- remove unused return value from `ActivateHooks` and `DeactivateHooks`
- rename `HookCount` to `MAX_HOOK_COUNT`
- convert some `UInt` / `Int` values to just `int`
- use `BOOL`, `TRUE`, `FALSE` in more places
- change `outputStat` to take `fileid`, `line` and `type` as argument instead of `stat` (to enable future refactoring)
