### PR TITLE
get rid of `ImmutableVector` calls (WIP)

### DIFF
--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -101,7 +101,11 @@ function(f,p,check)
   fam!.deg:=deg;
   i:=List([1..DegreeOfLaurentPolynomial(p)],i->fam!.zeroCoefficient);
   i[2]:=fam!.oneCoefficient;
+
+  # Create a vector in the prefered internal representation.
   i:=ImmutableVector(f,i,true);
+  fam!.exampleCoefficientVector:= i;
+
   fam!.primitiveElm:=MakeImmutable(ObjByExtRep(fam,i));
   fam!.indeterminateName:=MakeImmutable("a");
 
@@ -605,7 +609,7 @@ local i,fam,f,g,t,h,rf,rg,rh,z;
     #od;
   od;
   rf:=1/f[Length(f)]*rf;
-  rf:=ImmutableVector(fam!.baseField, rf, true);
+  rf:= MakeImmutable( Vector( rf, fam!.exampleCoefficientVector ) );
   return AlgExtElm(fam,rf);
 end);
 
@@ -904,7 +908,7 @@ function(rs,e)
 local fam,l;
   fam:=e!.extFam;
   l:=List([1..fam!.deg],i->Random(rs,fam!.baseField));
-  l:=ImmutableVector(fam!.baseField,l,true);
+  l:= MakeImmutable( Vector( l, fam!.exampleCoefficientVector ) );
   return AlgExtElm(fam,l);
 end);
 

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -241,12 +241,17 @@ function(l)
   return NewVector(DefaultVectorRepForBaseDomain(dom), dom, l);
 end);
 
-# The following method is used for example
-# in code dealing with elements of 'AlgebraicExtension's.
+# The following methods are used for example
+# in code dealing with elements of 'AlgebraicExtension's,
+# and in 'ExtendedVectors'..
 # (Note that we want to return a vector with the same mutability status
 # as the given vector, and we need not copy it if it is mutable.)
 InstallOtherMethod( Vector,
     [ IsList and IsCyclotomicCollection, IsList and IsCyclotomicCollection ],
+    { v, example } -> v );
+
+InstallOtherMethod( Vector,
+    [ IsRowVector and IsPlistRep, IsRowVector and IsPlistRep ],
     { v, example } -> v );
 
 

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -741,7 +741,10 @@ InstallOtherMethod( SemiEchelonBasis,
       # but perhaps the base domain must be adjusted.
       gensi:= Immutable( List( gens, v -> ChangedBaseDomain( v, F ) ) );
     else
-      # We expect 'gens' to be a list of lists.
+      # We expect 'gens' to be a list of lists,
+      # perhaps a list of vectors over a small finite field.
+      # However, we cannot assume that the internal representation of
+      # 'gens' is nice.
       gensi:= ImmutableMatrix( F, gens );
     fi;
     SetBasisVectors( B, gensi );
@@ -871,7 +874,7 @@ local d,z;
   d:=LeftActingDomain(V);
   z:=Zero( d ) * [ 1 .. DimensionOfVectors( V ) ];
   if IsField(d) and IsFinite(d) and Size(d)<=256 then
-    z := ImmutableVector( d, z );
+    z:= MakeImmutable( Vector( d, z ) );
   fi;
   return z;
 end);
@@ -1024,6 +1027,7 @@ InstallMethod( NormedRowVectors,
     [ IsGaussianRowSpace ],
     function( V )
     local base,       # basis vectors
+          example,    # one vector which is used as an example
           elms,       # element list, result
           elms2,      # intermediate element list
           F,          # `LeftActingDomain( V )'
@@ -1047,8 +1051,9 @@ InstallMethod( NormedRowVectors,
       return [];
     fi;
 
-    elms      := [ base[1] ];
-    elms2     := [ base[1] ];
+    example   := base[1];
+    elms      := [ example ];
+    elms2     := [ example ];
     F         := LeftActingDomain( V );
     q         := Size( F );
     fieldelms := List( AsSSortedList( F ), x -> x - 1 );
@@ -1065,7 +1070,7 @@ InstallMethod( NormedRowVectors,
         toadd:= base[j+1] + i * base[j];
         for k in [ 1 .. len ] do
           v:= elms2[k] + toadd;
-          v:= ImmutableVector( q, v );
+          v:= MakeImmutable( Vector( v, example ) );
           new[ pos + k ]:= v;
         od;
         pos:= pos + len;
@@ -1863,7 +1868,7 @@ BindGlobal( "ElementNumber_ExtendedVectors", function( enum, n )
       Error( "<enum>[", n, "] must have an assigned value" );
     fi;
     n:= Concatenation( enum!.spaceEnumerator[n], [ enum!.one ] );
-    return ImmutableVector( enum!.q, n );
+    return MakeImmutable( Vector( n, enum!.exampleVector ) );
 end );
 
 BindGlobal( "NumberElement_ExtendedVectors", function( enum, elm )
@@ -1923,6 +1928,8 @@ BindGlobal( "ExtendedVectors", function( V )
                len             := Length( Zero( V ) ) + 1 ) );
 
     enum!.q:= Size( LeftActingDomain( V ) );
+    enum!.exampleVector:= ImmutableVector( enum!.q,
+                              Concatenation( Zero( V ), [ enum!.one ] ) );
     if     IsFinite( LeftActingDomain( V ) )
        and IsPrimeInt( Size( LeftActingDomain( V ) ) )
        and Size( LeftActingDomain( V ) ) < 256
@@ -1972,7 +1979,7 @@ BindGlobal( "ElementNumber_NormedRowVectors", function( T, num )
         v[ i ] := f[ num mod q + 1 ];
         num := QuoInt( num, q );
     od;
-    return ImmutableVector( q, v );
+    return MakeImmutable( Vector( v, T!.exampleVector ) );
 end );
 
 BindGlobal( "NumberElement_NormedRowVectors", function( T, elm )
@@ -2021,20 +2028,24 @@ BindGlobal( "PrintObj_NormedRowVectors", function( T )
 end );
 
 BindGlobal( "EnumeratorOfNormedRowVectors", function( V )
+    local F;
+
     if not ( IsFullRowModule( V ) and IsFinite( V ) ) then
       Error( "<V> must be a finite full row space" );
     fi;
 
+    F:= LeftActingDomain( V );
     return EnumeratorByFunctions( FamilyObj( V ), rec(
                ElementNumber   := ElementNumber_NormedRowVectors,
                NumberElement   := NumberElement_NormedRowVectors,
                Length          := Length_NormedRowVectors,
                PrintObj        := PrintObj_NormedRowVectors,
 
-               enumeratorField := Enumerator( LeftActingDomain( V ) ),
+               enumeratorField := Enumerator( F ),
                domain          := V,
                dimension       := Dimension( V ),
-               one             := One( LeftActingDomain( V ) ) ) );
+               exampleVector   := ImmutableVector( F, Zero( V ) ),
+               one             := One( F ) ) );
 end );
 
 

--- a/tst/testinstall/vspcrow.tst
+++ b/tst/testinstall/vspcrow.tst
@@ -390,5 +390,36 @@ true
 gap> v*g = v;
 true
 
+#############################################################################
+##
+##  12. ExtendedVectors, EnumeratorOfNormedRowVectors
+##
+##  The functions 'ExtendedVectors', 'EnumeratorOfNormedRowVectors' are
+##  undocumented but there should be some tests
+##  since they are used in library functions.
+##
+gap> for F in [ GF(2), GF(3), GF(4), GF(257) ] do
+>      for n in [ 0, 1, 2 ] do
+>        A:= ExtendedVectors( F^n );
+>        for i in [ 1 .. Size( A ) ] do
+>          v:= A[i];
+>          if Position( A, v ) <> i then
+>            Error( "problem with 'ExtendedVectors( ", F, "^", n, " )" );
+>          fi;
+>        od;
+>      od;
+>    od;
+gap> for F in [ GF(2), GF(3), GF(4), GF(257) ] do
+>      for n in [ 0, 1, 2 ] do
+>        A:= EnumeratorOfNormedRowVectors( F^n );
+>        for i in [ 1 .. Size( A ) ] do
+>          v:= A[i];
+>          if Position( A, v ) <> i then
+>            Error( "problem with 'ExtendedVectors( ", F, "^", n, " )" );
+>          fi;
+>        od;
+>      od;
+>    od;
+
 ##
 gap> STOP_TEST( "vspcrow.tst" );


### PR DESCRIPTION
The idea is to use "example vectors" with the desired internal representation whenever this is possible.
Thus eventually only those (few) `ImmutableVector` calls will remain where GAP is expected to choose an appropriate internal representation. (And we will then see how this situation can be improved further.)