### PR TITLE
fixed the documentation of `InstallTrueMethod`

### DIFF
--- a/lib/filter.g
+++ b/lib/filter.g
@@ -281,9 +281,9 @@ end);
 ##  <C>IsGroup and IsCyclic</C> whose type gets created after the
 ##  installation of the implication will also be in the filter
 ##  <Ref Prop="IsCommutative"/>.
-##  In particular, objects which existed already before the installation of
-##  the implication can lie in <C>IsGroup and IsCyclic</C> but not in
-##  <Ref Prop="IsCommutative"/>.
+##  In particular, it may happen that an object which existed already before
+##  the installation of the implication lies in <C>IsGroup and IsCyclic</C>
+##  but not in <Ref Prop="IsCommutative"/>.
 ##  Thus it is advisable to install all implications between filters
 ##  before one starts creating (types of) objects lying in these filters.
 ##  <P/>

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -285,7 +285,7 @@ end);
 ##  the implication can lie in <C>IsGroup and IsCyclic</C> but not in
 ##  <Ref Prop="IsCommutative"/>.
 ##  Thus it is advisable to install all implications between filters
-##  before one starts to create objects that lie in these filters.
+##  before one starts creating (types of) objects lying in these filters.
 ##  <P/>
 ##  Adding logical implications can change the rank of filters (see
 ##  <Ref Func="RankFilter"/>) and consequently the rank, and so choice of

--- a/lib/filter.g
+++ b/lib/filter.g
@@ -278,8 +278,14 @@ end);
 ##  switched off.
 ##  This means that after the above implication has been installed,
 ##  one can rely on the fact that every object in the filter
-##  <C>IsGroup and IsCyclic</C> will also be in the filter
+##  <C>IsGroup and IsCyclic</C> whose type gets created after the
+##  installation of the implication will also be in the filter
 ##  <Ref Prop="IsCommutative"/>.
+##  In particular, objects which existed already before the installation of
+##  the implication can lie in <C>IsGroup and IsCyclic</C> but not in
+##  <Ref Prop="IsCommutative"/>.
+##  Thus it is advisable to install all implications between filters
+##  before one starts to create objects that lie in these filters.
 ##  <P/>
 ##  Adding logical implications can change the rank of filters (see
 ##  <Ref Func="RankFilter"/>) and consequently the rank, and so choice of


### PR DESCRIPTION
See the discussion of issue #3642 for details.

The proposed change adjusts the documentation of `InstallTrueMethod` to the current behaviour of GAP.
If we decide to deal with issue #3642 such that the behaviour of GAP gets changed, we have to adjust the documentation again.