### PR TITLE
ci: update lint.yml to use gaplint 1.1.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           python-version: '3.10'
       - name: "Install gaplint with pip"
-        run: pip install gaplint==1.1.4
+        run: pip install gaplint==1.1.5
       - name: "Run gaplint lib/*.g* hpcgap/lib/*.g* grp/*.g lib/hpc/*.g hpcgap/lib/hpc/*.g . . ."
         run: gaplint lib/*.g* hpcgap/lib/*.g* grp/*.g lib/hpc/*.g hpcgap/lib/hpc/*.g


### PR DESCRIPTION
Bump the version of gaplint in the ci to 1.1.5 to resolve:

https://github.com/gap-system/gap/issues/5321
https://github.com/gap-system/gap/issues/5316