### PR TITLE
kernel: merge GMP_REDUCE into GMP_NORMALIZE

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -62,7 +62,7 @@
 **  small integer). Internally, a large integer may temporarily not be
 **  normalized or not be reduced, but all kernel functions must make sure
 **  that they eventually return normalized and reduced values. The function
-**  GMP_NORMALIZE and GMP_REDUCE can be used to ensure this.
+**  GMP_NORMALIZE can be used to ensure this.
 */
 
 #include "integer.h"
@@ -359,7 +359,6 @@ static Obj GMPorINTOBJ_FAKEMPZ( fake_mpz_t fake )
       RetypeBag( obj, T_INTNEG );
     }
     obj = GMP_NORMALIZE( obj );
-    obj = GMP_REDUCE( obj );
   }
   else {
     if ( fake->v->_mp_size == 1 )
@@ -430,14 +429,7 @@ Obj GMP_NORMALIZE(Obj op)
     if (size < SIZE_INT(op)) {
         ResizeBag(op, size * sizeof(mp_limb_t));
     }
-    return op;
-}
 
-Obj GMP_REDUCE(Obj op)
-{
-    if (IS_INTOBJ(op)) {
-        return op;
-    }
     if (SIZE_INT(op) == 1) {
         if ((VAL_LIMB0(op) <= INT_INTOBJ_MAX) ||
             (IS_INTNEG(op) && VAL_LIMB0(op) == -INT_INTOBJ_MIN)) {
@@ -451,6 +443,7 @@ Obj GMP_REDUCE(Obj op)
     }
     return op;
 }
+
 
 /****************************************************************************
 **
@@ -720,7 +713,6 @@ Obj MakeObjInt(const UInt * limbs, int size)
         memcpy(ADDR_INT(obj), limbs, size * sizeof(mp_limb_t));
 
         obj = GMP_NORMALIZE(obj);
-        obj = GMP_REDUCE(obj);
     }
     return obj;
 }
@@ -943,7 +935,6 @@ Obj IntHexString(Obj str)
     }
 
     res = GMP_NORMALIZE(res);
-    res = GMP_REDUCE(res);
     return res;
   }
 }
@@ -1823,7 +1814,6 @@ Obj ModInt(Obj opL, Obj opR)
 
     // reduce to small integer if possible, otherwise shrink bag
     mod = GMP_NORMALIZE( mod );
-    mod = GMP_REDUCE( mod );
 
     // make the representative positive
     if ( IS_NEG_INT(mod) ) {
@@ -1947,7 +1937,6 @@ Obj QuoInt(Obj opL, Obj opR)
   }
 
   quo = GMP_NORMALIZE(quo);
-  quo = GMP_REDUCE( quo );
   return quo;
 }
 
@@ -2073,8 +2062,6 @@ Obj RemInt(Obj opL, Obj opR)
 
     // reduce to small integer if possible, otherwise shrink bag
     rem = GMP_NORMALIZE( rem );
-    rem = GMP_REDUCE( rem );
-
   }
 
   CHECK_INT(rem);
@@ -2691,10 +2678,7 @@ static Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)
        SWAP(UInt4, pt[0], pt[1]);
      }
 #endif
-     // shrink bag if necessary
      res = GMP_NORMALIZE(res);
-     // convert result if small int
-     res = GMP_REDUCE(res);
   }
 
   return res;

--- a/src/integer.h
+++ b/src/integer.h
@@ -162,7 +162,6 @@ Obj MakeObjInt(const UInt * limbs, int size);
 **  TODO: This is an internal implementation detail and ideally should not
 **  be exported; unfortunately, FuncNUMBER_GF2VEC currently needs this.
 */
-Obj GMP_REDUCE(Obj gmp);
 Obj GMP_NORMALIZE(Obj gmp);
 
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -2727,8 +2727,6 @@ static Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
         nd = ((len - 1) / GMP_LIMB_BITS) + 1;
 
         zahl = NewBag(T_INTPOS, nd * sizeof(UInt));
-        //    zahl = NewBag( T_INTPOS, (((nd+1)>>1)<<1)*sizeof(UInt) );
-        // +1)>>1)<<1: round up to next even number
 
         // garbage collection might lose pointer
         const UInt * num = CONST_BLOCKS_GF2VEC(vec) + (len - 1) / BIPEB;
@@ -2760,10 +2758,7 @@ static Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
             }
         }
 
-
         zahl = GMP_NORMALIZE(zahl);
-        zahl = GMP_REDUCE(zahl);
-
         return zahl;
     }
 }


### PR DESCRIPTION
Old patch I wrote a couple years ago as part of another bigger change (which is still incomplete, but I figured this bit could be merged now...).