### PR TITLE
make `?!.` and `?![]` work

### DIFF
--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -79,6 +79,7 @@ Chapter&nbsp;<Ref Chap="An Example -- Residue Class Rings"/>.
 <Section Label="Component Objects">
 <Heading>Component Objects</Heading>
 
+<Index Key='!.'><C>!.</C></Index>
 A <E>component object</E> is an object in the representation
 <Ref Filt="IsComponentObjectRep"/> or a subrepresentation of it.
 Such an object <A>cobj</A> is built from subobjects that can be accessed via
@@ -187,6 +188,7 @@ InstallMethod( NextIterator,
 <Section Label="Positional Objects">
 <Heading>Positional Objects</Heading>
 
+<Index Key='![]'><C>![]</C></Index>
 A <E>positional object</E> is an object in the representation
 <Ref Filt="IsPositionalObjectRep"/> or a subrepresentation of it.
 Such an object <A>pobj</A> is built from subobjects that can be accessed via

--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -173,8 +173,8 @@ Operator and delimiter symbols are
 <Listing><![CDATA[
 +    -    *    /    ^    ~   !.
 =    <>   <    <=   >    >=  ![
-:=   .    ..   ->   ,    ;   !{
-[    ]    {    }    (    )    :
+:=   .    ..   ->   ,    ;   [
+]    {    }    (    )    :
 ]]></Listing>
 <P/>
 Note also that during the process of scanning all whitespace is removed

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -445,7 +445,7 @@ InstallGlobalFunction(SIMPLE_STRING, function(str)
   # we simply list here in Position i how character i-1 should be translated
   trans :=Concatenation(
 "\000\>\<\c\004\005\006\007\b\t\n\013\014\r\016\017\020\021\022\023\024\025",
-"\026\027\030\031\032\033\034\035\036\037  \000   &\000  *+ -./",
+"\026\027\030\031\032\033\034\035\036\037 !\000   &\000  *+ -./",
 "0123456789: <=>? abcd",
 "efghijklmnopqrstuvwxyz[\000]^_\000abcdefghijklmnopqrstuvwxyz{ }~",
 "\177\200\201\202",


### PR DESCRIPTION
- let `SIMPLE_STRING` no longer strip `!` away
- added  index entries for `!.` and `![]`, pointing to the sections about component objects and positional objects
- removed `!{` from the [table of "Operator and delimiter symbols"](https://docs.gap-system.org/doc/ref/chap4_mj.html#X7E90E6607F4E4943) in the Reference Manual

Resolves #3583.

(In order to get rid of the superfluous matches which we get for `?.`, first we need frankluebeck/GAPDoc/pull/62 or something equivalent, and then the manuals must be processed again with an updated GAPDoc version.)