### PR TITLE
kernel: change RegisterStatWithHook arguments

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -254,7 +254,7 @@ Stat NewStatOrExpr(CodeState * cs, UInt type, UInt size, UInt line)
     header->line = line;
     header->size = size;
     header->type = type;
-    RegisterStatWithHook(stat);
+    RegisterStatWithHook(GET_GAPNAMEID_BODY(cs->currBody), line, type);
     // return the new statement
     return stat;
 }

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -73,7 +73,7 @@ struct InterpreterHooks {
     void (*visitInterpretedStat)(int fileid, int line);
     void (*enterFunction)(Obj func);
     void (*leaveFunction)(Obj func);
-    void (*registerStat)(Stat stat);
+    void (*registerStat)(int fileid, int line, int type);
     void (*registerInterpretedStat)(int fileid, int line);
     const char * hookName;
 };
@@ -129,9 +129,9 @@ EXPORT_INLINE void HookedLineOutFunction(Obj func)
     GAP_HOOK_LOOP(leaveFunction, func);
 }
 
-EXPORT_INLINE void RegisterStatWithHook(Stat func)
+EXPORT_INLINE void RegisterStatWithHook(int fileid, int line, int type)
 {
-    GAP_HOOK_LOOP(registerStat, func);
+    GAP_HOOK_LOOP(registerStat, fileid, line, type);
 }
 
 EXPORT_INLINE void InterpreterHook(int fileid, int line, Int skipped)

--- a/src/profile.c
+++ b/src/profile.c
@@ -623,12 +623,11 @@ static void visitInterpretedStat(int fileid, int line)
 ** check we executed something on those lines!
 **/
 
-static void registerStat(Stat stat)
+static void registerStat(int fileid, int line, int type)
 {
     HashLock(&profileState);
     if (profileState.status == Profile_Active) {
-        outputStat(getFilenameIdOfCurrentFunction(), LINE_STAT(stat),
-                   TNUM_STAT(stat), FALSE, FALSE);
+        outputStat(fileid, line, type, FALSE, FALSE);
     }
     HashUnlock(&profileState);
 }


### PR DESCRIPTION
Instead of taking a `Stat`, let it take a fileid, line and type of STAT/EXPR

This is part of PR #5292, but it makes sense on its own.