### PR TITLE
`IsVecOrMatObj` does no longer imply `IsCopyable`

### DIFF
--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -26,7 +26,7 @@
 # IsMatrixObj, then the first definition incurs a "hidden implication"
 # which then later leads to "method matches more than one declaration" messages.
 # The proper fix is to remove hidden implication
-DeclareCategory( "IsVecOrMatObj", IsCopyable );
+DeclareCategory( "IsVecOrMatObj", IsObject );
 
 
 #############################################################################


### PR DESCRIPTION
The filter `IsVecOrMatObj` is not documented.
The change means that `IsVectorObj` and `IsMatrixObj` objects are not automatically in `IsCopyable`.

The idea is that each representation of such objects (such as `IsPlistVectorRep`) decides whether its objects admit mutable variants or not,
by installing an implication to `IsCopyable` in the former case.

The currently available "constructing filters" of vector and matrix objects in the GAP library behave like this, and their documentation states that the objects are in fact copyable.