### PR TITLE
Fix a case where `Coefficients(B,v)` returned a list instead of `fail` although the vector `v` did not lie in the underlying vector space `V` of `B`

### DIFF
--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -336,6 +336,7 @@ COEFFS_SEMI_ECH_BASIS:=function( B, v )
     local vectors,   # basis vectors of `B'
           heads,     # heads info of `B'
           len,       # length of `v'
+          F,         # allowed coefficients
           coeff,     # coefficients list, result
           i,         # loop over `v'
           pos;       # heads position
@@ -351,6 +352,7 @@ COEFFS_SEMI_ECH_BASIS:=function( B, v )
     if len <> Length( heads ) then
       return fail;
     fi;
+    F:= LeftActingDomain( UnderlyingLeftModule( B ) );
 
     # Preset the coefficients list with zeroes.
     coeff:= ListWithIdenticalEntries( Length( vectors ), Zero( v[1] ) );
@@ -360,11 +362,11 @@ COEFFS_SEMI_ECH_BASIS:=function( B, v )
     i:= PositionNonZero( v );
     while i <= len do
       pos:= heads[i];
-      if pos <> 0 then
+      if pos = 0 or not v[i] in F then
+        return fail;
+      else
         coeff[ pos ]:= v[i];
         AddRowVector( v, vectors[ pos ], - v[i] );
-      else
-        return fail;
       fi;
       i:= PositionNonZero( v );
     od;

--- a/tst/testinstall/vspcrow.tst
+++ b/tst/testinstall/vspcrow.tst
@@ -91,6 +91,12 @@ gap> BaseDomain( b[1] );
 GF(2^2)
 gap> b[1] = vecs[1];
 true
+gap> v:= GF(2)^1;;
+gap> b:= Basis( v, [ [ Z(2) ] ] );;
+gap> Coefficients( b, [ Z(4) ] );
+fail
+gap> SiftedVector( b, [ Z(4) ] );
+fail
 
 #############################################################################
 ##


### PR DESCRIPTION
resolves #5334

## Text for release notes

Up to now it could happen that `Coefficients( B, v )` returned a list instead of `fail` although the vector `v` did not lie in the underlying vector space `V` of `B`.
In these cases, `V` was a Gaussian row space and the returned list described the coefficients w.r.t. an extension field. In particular, the entries of this list were not contained in `LeftActingDomain( V )`. 

