### PR TITLE
deal with unwanted side-effects of #3006

### DIFF
--- a/lib/basis.gd
+++ b/lib/basis.gd
@@ -786,9 +786,10 @@ DeclareOperation( "RelativeBasisNC", [ IsBasis, IsHomogeneousList ] );
 ##  (see&nbsp;<Ref Sect="Vector Spaces Handled By Nice Bases"/>).
 ##  <P/>
 ##  <A>name</A> must be a string,
-##  a filter <M>f</M> with this name is created, and
+##  a filter <M>f</M> with this name is created which implies
+##  <Ref Filt="IsFreeLeftModule"/>, and
 ##  a logical implication from the join of <M>f</M> with
-##  <Ref Filt="IsFreeLeftModule"/> and <Ref Filt="IsAttributeStoringRep"/> to
+##  <Ref Filt="IsAttributeStoringRep"/> to
 ##  <Ref Filt="IsHandledByNiceBasis"/> is installed.
 ##  <P/>
 ##  <A>record</A> must be a record with the following components.
@@ -895,6 +896,7 @@ DeclareGlobalFunction( "CheckForHandlingByNiceBasis" );
 InstallGlobalFunction( "DeclareHandlingByNiceBasis", function( name, info )
     local entry;
     DeclareFilter( name );
+    InstallTrueMethod( IsFreeLeftModule, ValueGlobal( name ) );
     entry := [ ValueGlobal( name ), info ];
     Add( NiceBasisFiltersInfo, entry, 1 );
 end );

--- a/lib/basis.gi
+++ b/lib/basis.gi
@@ -693,7 +693,7 @@ InstallGlobalFunction( "InstallHandlingByNiceBasis",
     entry:= First( NiceBasisFiltersInfo,
                    x -> IsIdenticalObj( filter, x[1] ) );
     entry[3] := record.detect;
-    filter:= filter and IsFreeLeftModule and IsAttributeStoringRep;
+    filter:= filter and IsAttributeStoringRep;
     InstallTrueMethod( IsHandledByNiceBasis, filter );
 
     # Install the methods.

--- a/lib/module.gd
+++ b/lib/module.gd
@@ -247,8 +247,10 @@ DeclareProperty( "IsFullMatrixModule", IsFreeLeftModule, 20 );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareCategory( "IsHandledByNiceBasis", IsFreeLeftModule );
-#T why not `DeclareFilter' ?
+DeclareCategory( "IsHandledByNiceBasis", IsFreeLeftModule, 3 );
+# We want that 'IsFreeLeftModule and IsHandledByNiceBasis' has a higher rank
+# than 'IsFreeLeftModule and IsFiniteDimensional'.
+# (There are concurrent '\in' methods for the two situations.)
 
 
 #############################################################################


### PR DESCRIPTION
- Let the filters created by `DeclareHandlingByNiceBasis` imply `IsFreeLeftModule`. This was the case before the changes from #3006, and this change fixes the problem described in #5322, as I had sketched in the discussion of #5325.
- Document this change (following #5325).
- Increase the rank of `IsHandledByNiceBasis` by 2. Then we get back to the rank before the changes from #3006. This way, the `\in` method with second argument in `IsFreeLeftModule and IsHandledByNiceBasis` is again ranked higher than the one with second argument `IsFreeLeftModule and IsFiniteDimensional`. The bug described in issue #5334 which has been found because of the reordering of these two methods (due to #3006) gets fixed via pull request #5335, now we can return to the better method ordering. (I do not like uprankings, but I have no better idea to solve this problem.)