### PR TITLE
changed `ExtendRootDirectories` such that each added path ends with a slash `/`

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1793,8 +1793,16 @@ InstallGlobalFunction( SetPackagePath, function( pkgname, pkgpath )
 #F  ExtendRootDirectories( <paths> )
 ##
 InstallGlobalFunction( ExtendRootDirectories, function( rootpaths )
+    local i;
+
     rootpaths:= Filtered( rootpaths, path -> not path in GAPInfo.RootPaths );
     if not IsEmpty( rootpaths ) then
+      # 'DirectoriesLibrary' concatenates root paths with directory names.
+      for i in [ 1 .. Length( rootpaths ) ] do
+        if not EndsWith( rootpaths[i], "/" ) then
+          rootpaths[i]:= Concatenation( rootpaths[i], "/" );
+        fi;
+      od;
       # Append the new root paths.
       GAPInfo.RootPaths:= Immutable( Concatenation( GAPInfo.RootPaths,
           rootpaths ) );

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -655,7 +655,11 @@ gap> IsPackageLoaded("mockpkg", ">=2.0");
 false
 
 # now add the temporary directory created above as a new root directory
-gap> ExtendRootDirectories( [ Filename( tmp_dir, "" ) ] );
+gap> filename:= ShallowCopy( Filename( tmp_dir, "" ) );;
+gap> while EndsWith( filename, "/" ) do Remove( filename ); od;
+gap> ExtendRootDirectories( [ filename ] );
+gap> ForAll( GAPInfo.RootPaths, x -> EndsWith( x, "/" ) );
+true
 
 # make sure that the newly discovered installation path matches
 # the path from which mockpkg was loaded above


### PR DESCRIPTION
The function `ExtendRootDirectories` takes a list of strings as its argument, and stores them in `GAPInfo.RootPaths`.
Up to now, these paths had to end with a slash `/`; if not then `DirectoriesLibrary` misunderstood them, in the sense that `DirectoriesLibrary` just concatenates the root path with the given directory name, and if the result is not a valid path then this root path gets ignored.

Now `ExtendRootDirectories` adds a slash to the end of the paths if it is missing.

(Once we are thinking about it: `ExtendRootDirectories` could require that the given paths exist, and it could apply `UserHomeExpand` to them. However, one can think of situations where such features are unwanted.)