### PR TITLE
Ensure `IsomorphismPermGroup(G)` always returns an isomorphism for `G` (before if `G` was a finite matrix group it sometimes returned an isomorphism for a general linear group containing `G`)

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -556,10 +556,6 @@ function(G)
 local map;
   if HasNiceMonomorphism(G) and IsPermGroup(Range(NiceMonomorphism(G))) then
     map:=NiceMonomorphism(G);
-    if IsIdenticalObj(Source(map),G) then
-      return map;
-    fi;
-    return GeneralRestrictedMapping(map,G,NiceObject(G));
   else
     if not HasIsFinite(G) then
       Info(InfoWarning,1,
@@ -567,8 +563,11 @@ local map;
     fi;
     map:=NicomorphismOfGeneralMatrixGroup(G,false,false);
     SetNiceMonomorphism(G,map);
+  fi;
+  if IsIdenticalObj(Source(map),G) then
     return map;
   fi;
+  return GeneralRestrictedMapping(map,G,NiceObject(G));
 end);
 
 InstallMethod( IsomorphismPermGroup,

--- a/lib/semitran.gi
+++ b/lib/semitran.gi
@@ -119,12 +119,12 @@ InstallMethod(IsomorphismPermGroup,
 function( h )
   local enum, permgroup, i, perm, j, elts;
 
-  if not(IsFinite(h)) then
+  if not IsFinite(h) then
     # What is an example where this can happen?
     TryNextMethod();
   fi;
 
-  if not( IsGroupHClass(h) ) then
+  if not IsGroupHClass(h) then
     # What is an example where this can happen?
     ErrorNoReturn("can only create isomorphisms of group H-classes");
   fi;
@@ -145,7 +145,8 @@ function( h )
     i := i+1;
   od;
 
-  return MappingByFunction( h, permgroup, a -> elts[Position( enum, a )]);
+  return MappingByFunction( h, permgroup, a -> elts[Position( enum, a )],
+                a -> enum[Position( elts, a )]);
 end);
 
 # TODO can this be removed? It doesn't seem to work

--- a/tst/testbugfix/2023-01-24-IsomorphismPermGroup.tst
+++ b/tst/testbugfix/2023-01-24-IsomorphismPermGroup.tst
@@ -1,0 +1,5 @@
+# see <https://github.com/gap-system/gap/issues/3601>
+gap> G:=SL(2,3);;Order(G);
+24
+gap> P:=Image(IsomorphismPermGroup(G));;Order(P);
+24

--- a/tst/testinstall/semitran.tst
+++ b/tst/testinstall/semitran.tst
@@ -1,5 +1,5 @@
 #@local BruteForceAntiIsoCheck,BruteForceInverseCheck,BruteForceIsoCheck
-#@local G,H,I,S,T,enum,inv,map
+#@local G,H,I,S,T,enum,inv,map,x,y
 gap> START_TEST("semitran.tst");
 
 # Test that the inverse of an isomorphism from a partial perm monoid to a
@@ -145,10 +145,11 @@ gap> S := Semigroup(IdentityTransformation);
 # Test IsomorphismPermGroup for an H-class
 gap> S := FullTransformationMonoid(4);;
 gap> H := GreensHClassOfElement(S, One(S));;
-gap> IsomorphismPermGroup(H);;
-gap> H := GreensHClassOfElement(S, Transformation([1, 1, 2, 3]));;
+gap> map := IsomorphismPermGroup(H);;
+gap> for x in H do y:=Image(map, x); Assert(0, PreImagesRepresentative(map, y) = x); od;
 
 # The Semigroups package produces different output so this test is suppressed
+#gap> H := GreensHClassOfElement(S, Transformation([1, 1, 2, 3]));;
 #gap> IsomorphismPermGroup(H);
 #Error, can only create isomorphisms of group H-classes
 


### PR DESCRIPTION
Fixes #3601