### PR TITLE
next step for `matobjplist`

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1177,7 +1177,7 @@ InstallMethod( CopySubMatrix,
 ##
 InstallMethod( TransposedMatImmutable,
     [ IsMatrixOrMatrixObj ],
-    TransposedMatMutable );
+    M -> MakeImmutable( TransposedMatMutable( M ) ) );
 
 
 #############################################################################

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -287,6 +287,15 @@ InstallMethod( ZeroVector,
     { len, M } -> NewZeroVector( CompatibleVectorFilter( M ),
                                  BaseDomain( M ), len ) );
 
+# compatibility method for representations as list of elements
+# (covers the cases of the second argument in `IsRowVector` or `IsMatrix`)
+InstallOtherMethod( ZeroVector, "for an integer and a plain list",
+  [ IsInt, IsPlistRep ],
+  -1, # rank lower than default as only fallback
+  function( l, t )
+    return ListWithIdenticalEntries( l, ZeroOfBaseDomain( t ) );
+  end);
+
 
 #############################################################################
 ##
@@ -1160,6 +1169,15 @@ InstallMethod( CopySubMatrix,
       od;
     od;
     end );
+
+
+#############################################################################
+##
+#M  TransposedMatImmutable( <M> )
+##
+InstallMethod( TransposedMatImmutable,
+    [ IsMatrixOrMatrixObj ],
+    TransposedMatMutable );
 
 
 #############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -265,8 +265,8 @@ DeclareAttribute( "CompatibleVectorFilter", IsMatrixOrMatrixObj );
 ##  <P/>
 ##  If <A>list</A> is a list of positive integers that are not larger than
 ##  the length of <A>v</A> then
-##  <A>v</A><C>{</C><A>list</A><C>}</C> returns a vector object in the same
-##  representation as <A>v</A>
+##  <A>v</A><C>{</C><A>list</A><C>}</C> returns a new mutable vector object
+##  in the same representation as <A>v</A>
 ##  (see <Ref Attr="ConstructingFilter" Label="for a vector object"/>)
 ##  that contains the <A>list</A><M>[ k ]</M>-th entry of <A>v</A> at
 ##  position <M>k</M>.
@@ -715,7 +715,7 @@ DeclareOperation( "Vector", [ IsList ] );
 ##  The list <A>list</A> is guaranteed not to be changed by this operation.
 ##  <P/>
 ##  If the global option <C>check</C> is set to <K>false</K> then
-##  <Ref Oper="NewVector"/> need not perform consistency checks.
+##  <Ref Constr="NewVector"/> need not perform consistency checks.
 ##  <P/>
 ##  Similarly, <Ref Constr="NewZeroVector"/> returns a vector object
 ##  of length <A>n</A> which has <A>filt</A> and <A>R</A> as
@@ -952,10 +952,14 @@ DeclareOperation( "DistanceOfVectors", [ IsVectorObj, IsVectorObj ] );
 ##  <Oper Name="ExtractSubMatrix" Arg='M, rows, cols'/>
 ##
 ##  <Description>
-##  Creates a fully mutable copy of the submatrix described by the two
+##  Creates a copy of the submatrix described by the two
 ##  lists, which mean subsets of row and column positions, respectively.
 ##  This does <A>M</A>{<A>rows</A>}{<A>cols</A>} and returns the result.
 ##  It preserves the representation of the matrix.
+##  <P/>
+##  If the <Ref Attr="ConstructingFilter" Label="for a matrix object"/>
+##  value of the result implies <Ref Filt="IsCopyable"/> then the result is
+##  fully mutable.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1343,8 +1347,8 @@ DeclareOperation( "Matrix", [ IsList ]);
 ##
 ##  <Description>
 ##  Called with a matrix object <A>M</A> with <M>m</M> rows,
-##  this operation returns a zero vector object <M>v</M> of length <M>m</M>
-##  and in the representation given by the
+##  this operation returns a mutable zero vector object <M>v</M> of length
+##  <M>m</M> and in the representation given by the
 ##  <Ref Attr="CompatibleVectorFilter" Label="for a matrix object"/> value
 ##  of <A>M</A> (provided that such a representation exists).
 ##  <P/>

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -44,9 +44,13 @@
 ##    and
 ##  </Item>
 ##  <Item>
-##    a plain list (see <Ref Filt="IsPlistRep"/> of its entries.
+##    a dense plain list (see <Ref Filt="IsPlistRep"/> of its entries.
 ##  </Item>
 ##  </Enum>
+##  <P/>
+##  Any <A>obj</A> in <Ref Filt="IsPlistVectorRep"/> satisfies that
+##  the entries in the stored plain list are elements of the stored base
+##  domain, in the sense of <C>\in</C>.
 ##
 DeclareRepresentation( "IsPlistVectorRep",
         IsVectorObj and IsPositionalObjectRep
@@ -88,10 +92,16 @@ DeclareRepresentation( "IsPlistVectorRep",
 ##    (see <Ref Attr="NumberColumns" Label="for a matrix object"/>), and
 ##  </Item>
 ##  <Item>
-##    a plain list (see <Ref Filt="IsPlistRep"/> of its rows,
+##    a dense plain list (see <Ref Filt="IsPlistRep"/> of its rows,
 ##    each of them being an object in <Ref Filt="IsPlistVectorRep"/>.
 ##  </Item>
 ##  </Enum>
+##  <P/>
+##  Any <A>obj</A> in <Ref Filt="IsPlistMatrixRep"/> satisfies that
+##  each entry in the stored plain list is a vector in
+##  <Ref Filt="IsPlistVectorRep"/>, whose base domain is identical with the
+##  stored base domain of <A>obj</A> and whose length is the stored number
+##  of columns.
 ##
 DeclareRepresentation( "IsPlistMatrixRep",
         IsRowListMatrix and IsPositionalObjectRep

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -1127,20 +1127,19 @@ InstallMethod( IsZero,
 InstallMethod( IsOne,
   [ "IsPlistMatrixRep" ],
   function( m )
-    local i,j,n;
+    local n, i, row;
     if Length(m![ROWSPOS]) <> m![RLPOS] then
         #Error("IsOne: Matrix must be square");
         return false;
     fi;
     n := m![RLPOS];
     for i in [1..n] do
-        if not IsOne(m![ROWSPOS][i]![ELSPOS][i]) then return false; fi;
-        for j in [1..i-1] do
-            if not IsZero(m![ROWSPOS][i]![ELSPOS][j]) then return false; fi;
-        od;
-        for j in [i+1..n] do
-            if not IsZero(m![ROWSPOS][i]![ELSPOS][j]) then return false; fi;
-        od;
+      row:= m![ROWSPOS][i];
+      if PositionNonZero( row ) <> i or
+         not IsOne( row![ELSPOS][i] ) or
+         PositionNonZero( row, i ) <= n then
+        return false;
+      fi;
     od;
     return true;
   end );

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -183,7 +183,9 @@ InstallOtherMethod( LeftModuleByGenerators,
 #FIXME: Setting the filter 'IsNonGaussianRowSpace' enables the handling
 #       via nice bases, but there is currently no support for that
 #       in the case of vector spaces of 'IsVectorObj' objects.
-#       See issue #5347 and discussion #5346 for more information.
+#       See https://github.com/gap-system/gap/issues/5347
+#       and https://github.com/gap-system/gap/discussions/5346
+#       for more information.
     fi;
 
     if Length(mat)>0 and ForAny(mat,x->not IsZero(x)) then

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -180,6 +180,10 @@ InstallOtherMethod( LeftModuleByGenerators,
       od;
       mat:= List( mat, v -> ChangedBaseDomain( v, K ) );
       typ:=typ and IsVectorSpace and IsRowModule and IsNonGaussianRowSpace;
+#FIXME: Setting the filter 'IsNonGaussianRowSpace' enables the handling
+#       via nice bases, but there is currently no support for that
+#       in the case of vector spaces of 'IsVectorObj' objects.
+#       See issue #5347 and discussion #5346 for more information.
     fi;
 
     if Length(mat)>0 and ForAny(mat,x->not IsZero(x)) then

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -161,7 +161,7 @@ InstallOtherMethod( LeftModuleByGenerators,
     [ IsDivisionRing, IsList ],
     # ensure it ranks above the generic method
     function( F, mat )
-    local V,typ;
+    local V, typ, K, row;
 
     # filter for vector objects, not compressed FF vectors
     if not ForAll(mat,x->IsVectorObj(x) and not IsDataObjectRep(x)) then
@@ -169,8 +169,16 @@ InstallOtherMethod( LeftModuleByGenerators,
     fi;
     typ:=IsAttributeStoringRep and HasIsEmpty and IsFiniteDimensional;
     if ForAll( mat, row -> IsSubset( F, BaseDomain(row) ) ) then
+      # Replace 'mat' by vector objects with base domain 'F'.
+      mat:= List( mat, v -> ChangedBaseDomain( v, F ) );
       typ:=typ and IsGaussianRowSpace;
     else
+      # Replace 'mat' by vector objects with base domain containing 'F'.
+      K:= F;
+      for row in mat do
+        K:= ClosureDivisionRing( K, BaseDomain( row ) );
+      od;
+      mat:= List( mat, v -> ChangedBaseDomain( v, K ) );
       typ:=typ and IsVectorSpace and IsRowModule and IsNonGaussianRowSpace;
     fi;
 

--- a/lib/vspcrow.gi
+++ b/lib/vspcrow.gi
@@ -183,6 +183,7 @@ InstallOtherMethod( LeftModuleByGenerators,
 #FIXME: Setting the filter 'IsNonGaussianRowSpace' enables the handling
 #       via nice bases, but there is currently no support for that
 #       in the case of vector spaces of 'IsVectorObj' objects.
+#       In particular, the 'else' branch does not work.
 #       See https://github.com/gap-system/gap/issues/5347
 #       and https://github.com/gap-system/gap/discussions/5346
 #       for more information.

--- a/tst/testinstall/MatrixObj/BaseDomain.tst
+++ b/tst/testinstall/MatrixObj/BaseDomain.tst
@@ -11,7 +11,7 @@ Rationals
 gap> BaseDomain(Matrix(Integers, m));
 Integers
 
-# FIXME: BUG:
+# FIXME: BUG:  -> vecmat.gi, code does not check!
 #gap> BaseDomain(Matrix(GF(2), m));
 #Rationals
 
@@ -23,10 +23,10 @@ gap> BaseDomain(Matrix(m));
 Rationals
 gap> BaseDomain(Matrix(Rationals, m));
 Rationals
+gap> BaseDomain(Matrix(Integers, m));
+Error, the elements in <list> must lie in <basedomain>
 
-# FIXME: BUG:
-# gap> BaseDomain(Matrix(Integers, m));
-#Integers
+# FIXME: BUG:  -> vecmat.gi, code does not check!
 #gap> BaseDomain(Matrix(GF(2), m));
 #Rationals
 
@@ -38,10 +38,8 @@ gap> BaseDomain(Matrix(m));
 GF(2)
 gap> BaseDomain(Matrix(GF(2), m));
 GF(2)
-
-# FIXME: BUG:
-#gap> BaseDomain(Matrix(Rationals, m));
-#Rationals
+gap> BaseDomain(Matrix(Rationals, m));
+Error, the elements in <list> must lie in <basedomain>
 
 #
 gap> m := [[1,2],[3,Z(4)]] * Z(2);;
@@ -53,10 +51,8 @@ gap> BaseDomain(Matrix(GF(4), m));
 GF(2^2)
 gap> BaseDomain(Matrix(GF(2), m));
 Error, ConvertToVectorRepNC: Vector cannot be written over GF(2)
-
-# FIXME: BUG:
-#gap> BaseDomain(Matrix(Rationals, m));
-#Rationals
+gap> BaseDomain(Matrix(Rationals, m));
+Error, the elements in <list> must lie in <basedomain>
 
 #
 gap> STOP_TEST("BaseDomain.tst");

--- a/tst/testinstall/MatrixObj/matobjplist.tst
+++ b/tst/testinstall/MatrixObj/matobjplist.tst
@@ -1,0 +1,73 @@
+#@local e, v, w, M, v2, z
+gap> START_TEST( "matobjplist.tst" );
+
+#
+gap> e:= MakeIsPlistVectorRep( Integers, [], true );;
+gap> v:= MakeIsPlistVectorRep( Integers, [ 1 ], true );;
+gap> MakeIsPlistVectorRep( Integers, [ 1/2 ], true );;
+Error, the elements in <list> must lie in <basedomain>
+gap> w:= MakeIsPlistVectorRep( Rationals, [ 1 ], true );;
+gap> MakeIsPlistVectorRep( Rationals, [ Z(2) ], true );;
+Error, the elements in <list> must lie in <basedomain>
+gap> MakeIsPlistVectorRep( GF(2), [ Z(2) ], true );;
+gap> MakeIsPlistVectorRep( GF(2), [ Z(4) ], true );;
+Error, the elements in <list> must lie in <basedomain>
+gap> MakeIsPlistVectorRep( GF(4), [ Z(2) ], true );;
+
+#
+gap> MakeIsPlistMatrixRep( Integers, [], 2, [], true );;
+Error, <emptyvector> must be in 'IsPlistVectorRep'
+gap> M:= MakeIsPlistMatrixRep( Integers, e, 2, [], true );;
+gap> MakeIsPlistMatrixRep( Rationals, e, 2, [], true );;
+Error, <emptyvector> must have the given base domain
+gap> MakeIsPlistMatrixRep( Integers, e, 1, [ v ], true );;
+gap> MakeIsPlistMatrixRep( Integers, e, 2, [ v ], true );;
+Error, the entries of <list> must have length <ncols>
+gap> MakeIsPlistMatrixRep( Integers, e, 2, [ [ 1, 2 ] ], true );;
+Error, the entries of <list> must be in 'IsPlistVectorRep'
+gap> MakeIsPlistMatrixRep( Integers, e, 1, [ w ], true );;
+Error, the entries of <list> must have the given base domain
+
+#
+gap> NewVector( IsPlistVectorRep, Integers, [] );;
+gap> v2:= NewVector( IsPlistVectorRep, Integers, [ 1, 0 ] );;
+gap> IsMutable( v2 );
+true
+gap> NewVector( IsPlistVectorRep, Integers, [ 1/2 ] );;
+Error, the elements in <list> must lie in <basedomain>
+
+#
+gap> NewZeroVector( IsPlistVectorRep, Integers, 0 );;
+gap> z:= NewZeroVector( IsPlistVectorRep, Integers, 1 );;
+gap> IsMutable( z );
+true
+
+#
+gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [] );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ 1 ] );;
+Error, NewMatrix: Length of <list> is not a multiple of <ncols>
+gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ [ 1 ] ] );;
+Error, the entries of <list> must have length <ncols>
+gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ [ 1, 2 ] ] );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ v ] );;
+Error, the entries of <list> must have length <ncols>
+gap> M:= NewMatrix( IsPlistMatrixRep, Integers, 2, [ v2, v2 ] );;
+gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
+true
+
+#
+gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 0 );;
+gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 0 );;
+gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 3 );;
+gap> M:= NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 3 );;
+gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
+true
+
+#
+gap> NewIdentityMatrix( IsPlistMatrixRep, Integers, 0 );;
+gap> M:= NewIdentityMatrix( IsPlistMatrixRep, Integers, 2 );;
+gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
+true
+
+#
+gap> STOP_TEST( "matobjplist.tst" );


### PR DESCRIPTION
- added consistency checks to `MakeIsPlistVectorRep` (which can be switched off via the third argument)
- added `MakeIsPlistMatrixRep` analogous to `MakeIsPlistVectorRep`
- changed the installed methods such that they call `MakeIsPlistMatrixRep` instead of `Objectify`, and such that hey perform the necessary consistency checks if needed (this fixes a problem from issue #4884)
- state explicitly which consistency checks are needed when creating objects in the filters `IsPlistVectorRep`, `IsPlistMatrixRep` (not in the visible documentation but near to the declarations of the filters)
- moved some code from `matobjplist.gi` to `matobj.gi`
- changed the `InstallMethod` syntax: use strings describing the filters in the requirements instead of an additional info string where possible
- document the mutability status of the resullts of `ChangedBaseDomain` and `CompatibleVector`

The situation with consistency checks (when creating vector and matrix objects) looks as follows:

- The constructors (`Vector`, `NewVector`, `Matrix` ...) can take user input, therefore checks are necessary in their methods; do the entries fit to the base domain, are the base domains of the matrix and its rows equal (currently: identical), are the lengths of the matrix rows correct.
- Operations that take some vector/matrix objects and create a new one have to check whether the arguments are compatible, but then often it is clear that the result will be consistent; for example, the sum of two vector objects with the same base domain is safe.
- There are cases where this is not clear, `Inverse` for a matrix object must check that the result fits to the base domain.
- For in-place operations such as `AddRowVector` and `MultVectorLeft`, we have the problem that the consistency can be checked only after the operation, and if not then we have already created a corrupted object. (Note that the aim of the in-place operation is to avoid making a copy.) We could avoid this problem by requesting that scalar multiplications are allowed only with elements of the base domain (or also with integers?).