### PR TITLE
Add faster IsOne method for matrices

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1381,6 +1381,38 @@ InstallMethod( InverseSameMutability,
     end );
 
 InstallMethod( IsZero,
+    [ IsRowListMatrix and IsMatrixObj ],
+    function( mat )
+    local ncols, row;
+
+    ncols:= NrCols( mat );
+    for row in mat do
+      if PositionNonZero( row ) <= ncols then
+        return false;
+      fi;
+    od;
+    return true;
+    end );
+
+InstallMethod( IsOne,
+    [ IsRowListMatrix and IsMatrixObj ],
+    function( mat )
+    local ncols, i, row;
+
+    ncols:= NrCols( mat );
+    for i in [1 .. NrRows( mat )] do
+      row := mat[i];
+      if PositionNonZero( row ) <> i or not IsOne( row[i] ) then
+        return false;
+      fi;
+      if PositionNonZero( row, i ) <= ncols then
+        return false;
+      fi;
+    od;
+    return true;
+    end );
+
+InstallMethod( IsZero,
     [ IsMatrixObj ],
     M -> IsZero( Unpack( M ) ) );
 

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1174,6 +1174,32 @@ InstallMethod( IsZero,
     return true;
     end );
 
+
+#############################################################################
+##
+#M  IsOne( <mat> )
+##
+InstallMethod( IsOne,
+    "method for a matrix",
+    [ IsMatrix ],
+    function( mat )
+    local ncols,  # number of columns
+          i,
+          row;    # loop over rows in 'obj'
+
+    ncols:= NrCols( mat );
+    for i in [1 .. NrRows( mat )] do
+      row := mat[i];
+      if PositionNonZero( row ) <> i or not IsOne( row[i] ) then
+        return false;
+      fi;
+      if PositionNonZero( row, i ) <= ncols then
+        return false;
+      fi;
+    od;
+    return true;
+    end );
+
 #############################################################################
 ##
 #M  BaseMat( <mat> )  . . . . . . . . . .  base for the row space of a matrix


### PR DESCRIPTION
Also add similar IsOne and IsZero methods for rowlist matobj

Resolves #5341 by @hulpke 

Example (before these took veery long... I didn't time it, but let's say closer to minutes than to milliseconds):
```
gap> map:=RegularActionHomomorphism(MathieuGroup(12));;
gap> p:=Image(map);
<permutation group of size 95040 with 3 generators>
gap>
gap> m:=PermutationMat(p.1,95040,GF(2));;
gap> IsOne(m); time;
false
13
gap> ConvertToMatrixRep(m);
2
gap> IsOne(m); time;
false
0
gap>
gap> m2:=PermutationMat(One(p),95040,GF(2));;
gap> IsOne(m2); time;
true
81
gap> ConvertToMatrixRep(m2);
2
gap> IsOne(m2); time;
true
70
```