### PR TITLE
mat8bit: fix bug in PostMakeImmutable

### DIFF
--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -1068,7 +1068,7 @@ InstallMethod(NestingDepthA, [Is8BitVectorRep], m->1);
 InstallMethod(PostMakeImmutable, [Is8BitMatrixRep],
         function(m)
     local i;
-    for i in [2..m![1]] do
+    for i in [2..m![1]+1] do
         MakeImmutable(m![i]);
     od;
 end);

--- a/tst/testinstall/mat8bit.tst
+++ b/tst/testinstall/mat8bit.tst
@@ -205,5 +205,22 @@ false
 gap> Zero( mz ) = m * Zero( z );
 true
 
+# PostMakeImmutable bug
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> m;
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> IsMutable(m);
+true
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> IsMutable(m);
+false
+gap> IsMutable(m[1]);
+false
+gap> IsMutable(m[2]); # previously returned true!
+false
+
 #
 gap> STOP_TEST("mat8bit.tst");


### PR DESCRIPTION
This PR fixes an off-by-one error in `PostMakeImmutable` for `Is8BitMatrixRep` objects. As I understand from discussions with @ThomasBreuer, all of the rows of an immutable matrix must be immutable, but previously for `Is8BitMatrixRep` the last row did not have `MakeImmutable` called on it due to an off-by-one error. 

## Text for release notes

I'm not sure if this should go in the release notes or not. 
