### PR TITLE
Support method dispatch based on tags (see the manual section "Tag Based Operations")

### DIFF
--- a/doc/ref/makedocreldata.g
+++ b/doc/ref/makedocreldata.g
@@ -120,6 +120,7 @@ GAPInfo.ManualDataRef:= rec(
     "../../lib/matrix.gd",
     "../../lib/meataxe.gi",
     "../../lib/memusage.gd",
+    "../../lib/methsel.g",
     "../../lib/methsel2.g",
     "../../lib/methwhy.g",
     "../../lib/mgmadj.gd",

--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -322,6 +322,7 @@ see&nbsp;<Ref Sect="Mutability and Copyability"/>.
 <#Include Label="NullMat">
 <#Include Label="EmptyMatrix">
 <#Include Label="DiagonalMat">
+<#Include Label="DiagonalMatrix">
 <#Include Label="PermutationMat">
 <#Include Label="TransposedMatImmutable">
 <#Include Label="TransposedMatDestructive">

--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -72,6 +72,7 @@ and then set the attribute tester for the object to <K>true</K>.
 <#Include Label="ShowDeclarationsOfOperation">
 <#Include Label="NewOperation">
 <#Include Label="DeclareOperation">
+<#Include Label="DeclareKeyBasedOperation">
 
 </Section>
 

--- a/doc/ref/methsel.xml
+++ b/doc/ref/methsel.xml
@@ -72,7 +72,7 @@ and then set the attribute tester for the object to <K>true</K>.
 <#Include Label="ShowDeclarationsOfOperation">
 <#Include Label="NewOperation">
 <#Include Label="DeclareOperation">
-<#Include Label="DeclareKeyBasedOperation">
+<#Include Label="DeclareTagBasedOperation">
 
 </Section>
 

--- a/lib/list.g
+++ b/lib/list.g
@@ -62,6 +62,16 @@ DeclareCategory( "IsListDefault", IsMultiplicativeGeneralizedRowVector );
 InstallTrueMethod( IsListDefault, IsInternalRep and IsList );
 
 
+# This is an auxiliary filter intended to simplify method installations.
+# We must declare it here because the implication from 'IsList and IsEmpty'
+# must be installed before the types 'TYPE_LIST_EMPTY_MUTABLE' and
+# 'TYPE_LIST_EMPTY_IMMUTABLE' are created.
+DeclareCategory( "IsRowVectorOrVectorObj", IsObject );
+
+InstallTrueMethod( IsRowVectorOrVectorObj, IsRowVector );
+InstallTrueMethod( IsRowVectorOrVectorObj, IsEmpty );
+
+
 #############################################################################
 ##
 #P  IsRectangularTable( <list> )  . . . . table with all rows the same length

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -147,7 +147,7 @@ InstallMethod( DistanceOfVectors,
 #
 # TODO: possibly rename the following
 #
-BindGlobal( "DefaultVectorRepForBaseDomain",
+InstallGlobalFunction( DefaultVectorRepForBaseDomain,
 function( basedomain )
     if IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) = 2 then
         return IsGF2VectorRep;
@@ -161,7 +161,7 @@ function( basedomain )
     fi;
     return IsPlistVectorRep;
 end);
-BindGlobal( "DefaultMatrixRepForBaseDomain",
+InstallGlobalFunction( DefaultMatrixRepForBaseDomain,
 function( basedomain )
     if IsFinite(basedomain) and IsField(basedomain) and Size(basedomain) = 2 then
         return IsGF2MatrixRep;
@@ -286,6 +286,11 @@ InstallMethod( ZeroVector,
     [ IsInt, IsMatrixOrMatrixObj ],
     { len, M } -> NewZeroVector( CompatibleVectorFilter( M ),
                                  BaseDomain( M ), len ) );
+
+InstallMethod( CompatibleVectorFilter,
+    "for IsMatrix",
+    [ IsMatrix ],
+    M -> IsPlistRep );
 
 # compatibility method for representations as list of elements
 # (covers the cases of the second argument in `IsRowVector` or `IsMatrix`)

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -290,6 +290,7 @@ InstallMethod( ZeroVector,
 InstallMethod( CompatibleVectorFilter,
     "for IsMatrix",
     [ IsMatrix ],
+    {} -> -RankFilter(IsMatrix),
     M -> IsPlistRep );
 
 # compatibility method for representations as list of elements

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -91,7 +91,7 @@ DeclareCategory( "IsVecOrMatObj", IsObject );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareCategory( "IsVectorObj", IsVector and IsVecOrMatObj );
+DeclareCategory( "IsVectorObj", IsVector and IsVecOrMatObj and IsRowVectorOrVectorObj );
 
 
 #############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1395,6 +1395,17 @@ DeclareAttribute( "RowsOfMatrix", IsMatrixOrMatrixObj );
 
 #############################################################################
 ##
+#F  DefaultVectorRepForBaseDomain( <D> )
+#F  DefaultMatrixRepForBaseDomain( <D> )
+##
+##  currently undocumented
+##
+DeclareGlobalFunction( "DefaultVectorRepForBaseDomain" );
+DeclareGlobalFunction( "DefaultMatrixRepForBaseDomain" );
+
+
+#############################################################################
+##
 ##  Operations for Row List Matrix Objects
 ##
 

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1643,6 +1643,70 @@ DeclareGlobalFunction( "PermutationMat" );
 
 #############################################################################
 ##
+#O  DiagonalMatrix( [<filt>, ]<R>, <vector> )
+#O  DiagonalMatrix( <vector>[, <M>] )
+##
+##  <#GAPDoc Label="DiagonalMatrix">
+##  <ManSection>
+##  <Oper Name="DiagonalMatrix" Arg='[filt, ]R, vector'
+##   Label="with base domain"/>
+##  <Oper Name="DiagonalMatrix" Arg='vector[, M]'
+##   Label="with example matrix"/>
+##
+##  <Returns>
+##  a square matrix or matrix object with column number equal to the length
+##  of the dense list <A>vector</A>,
+##  whose diagonal entries are given by the entries of <A>vector</A>,
+##  and whose off-diagonal entries are zero.
+##  </Returns>
+##  <Description>
+##  If a semiring <A>R</A> is given then it will be the base domain
+##  (see <Ref Attr="BaseDomain" Label="for a matrix object"/>)
+##  of the returned matrix.
+##  In this case, a filter <A>filt</A> can be specified that defines the
+##  internal representation of the result
+##  (see <Ref Attr="ConstructingFilter" Label="for a matrix object"/>).
+##  The default value for <A>filt</A> is determined from <A>R</A>.
+##  <P/>
+##  If a matrix object <A>M</A> is given then the returned matrix will have
+##  the same internal representation and the same base domain as <A>M</A>.
+##  <P/>
+##  If only <A>vector</A> is given then it is used to compute a default for
+##  <A>R</A>.
+##  <P/>
+##  If the <Ref Filt="ConstructingFilter"/> value of the result implies
+##  <Ref Filt="IsCopyable"/> then the result is fully mutable.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> d1:= DiagonalMatrix( GF(9), [ 1, 2 ] * Z(3)^0 );
+##  [ [ Z(3)^0, 0*Z(3) ], [ 0*Z(3), Z(3) ] ]
+##  gap> Is8BitMatrixRep( d1 );
+##  true
+##  gap> d2:= DiagonalMatrix( IsPlistMatrixRep, GF(9), [ 1, 2 ] * Z(3)^0 );
+##  <2x2-matrix over GF(3^2)>
+##  gap> IsPlistMatrixRep( d2 );
+##  true
+##  gap> DiagonalMatrix( [ 1, 2 ] );
+##  <2x2-matrix over Rationals>
+##  gap> DiagonalMatrix( [ 1, 2 ], Matrix( Integers, [ [ 1 ] ], 1 ) );
+##  <2x2-matrix over Integers>
+##  gap> DiagonalMatrix( [ 1, 2 ], [ [ 1 ] ] );
+##  [ [ 1, 0 ], [ 0, 2 ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "DiagonalMatrix",
+    [ IsOperation, IsSemiring, IsRowVectorOrVectorObj ] );
+DeclareOperation( "DiagonalMatrix", [ IsSemiring, IsRowVectorOrVectorObj ] );
+DeclareOperation( "DiagonalMatrix",
+    [ IsRowVectorOrVectorObj, IsMatrixOrMatrixObj ] );
+DeclareOperation( "DiagonalMatrix", [ IsRowVectorOrVectorObj ] );
+
+
+#############################################################################
+##
 #F  DiagonalMat( <vector> ) . . . . . . . . . . . . . . . . . diagonal matrix
 ##
 ##  <#GAPDoc Label="DiagonalMat">
@@ -2125,58 +2189,6 @@ DeclareOperation("DefaultScalarDomainOfMatrixList",[IsListOrCollection]);
 ##
 DeclareOperation("BaseField",[IsObject]);
 
-
-#############################################################################
-##
-#O  ZeroVector( <len>, <vector> )
-##
-##  <ManSection>
-##  <Oper Name="ZeroVector" Arg='len, vector'/>
-##
-##  <Description>
-##  returns a new mutable zero vector in the same representation as
-##  <A>vector</A> of a possibly different length <A>len</A>. The idea behind this
-##  is to be able to write code that preserves for example compression
-##  over a finite field but returning a vector of different length.
-##  </Description>
-##  </ManSection>
-##
-#DeclareOperation("ZeroVector",[IsInt,IsObject]);
-
-
-#############################################################################
-##
-#O  ZeroMatrix( <rows>, <cols>, <matrix>  )
-##
-##  <ManSection>
-##  <Oper Name="ZeroMatrix" Arg='rows, cols, matrix'/>
-##
-##  <Description>
-##  returns a new mutable zero matrix in the same representation as
-##  <A>matrix</A> of possibly different dimensions. The number of rows of
-##  the new matrix is <A>rows</A> and the number of columns is <A>cols</A>.
-##  The idea behind this is to be able to write code that preserves
-##  for example compression over a finite field.
-##  </Description>
-##  </ManSection>
-##
-#DeclareOperation("ZeroMatrix",[IsInt,IsInt,IsObject]);
-
-
-#############################################################################
-##
-#O  IdentityMatrix( <rows>, <matrix> )
-##
-##  <ManSection>
-##  <Oper Name="IdentityMatrix" Arg='rows, matrix'/>
-##
-##  <Description>
-##  returns a new mutable identity matrix in the same representation as
-##  <A>matrix</A> with <A>rows</A> rows.
-##  </Description>
-##  </ManSection>
-##
-#DeclareOperation("IdentityMatrix",[IsInt,IsObject]);
 
 #############################################################################
 ##

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1698,7 +1698,7 @@ DeclareGlobalFunction( "PermutationMat" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareKeyBasedOperation( "DiagonalMatrix",
+DeclareTagBasedOperation( "DiagonalMatrix",
     [ IsOperation, IsSemiring, IsRowVectorOrVectorObj ] );
 DeclareOperation( "DiagonalMatrix", [ IsSemiring, IsRowVectorOrVectorObj ] );
 DeclareOperation( "DiagonalMatrix",

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1697,7 +1697,7 @@ DeclareGlobalFunction( "PermutationMat" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "DiagonalMatrix",
+DeclareKeyBasedOperation( "DiagonalMatrix",
     [ IsOperation, IsSemiring, IsRowVectorOrVectorObj ] );
 DeclareOperation( "DiagonalMatrix", [ IsSemiring, IsRowVectorOrVectorObj ] );
 DeclareOperation( "DiagonalMatrix",

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1674,8 +1674,9 @@ DeclareGlobalFunction( "PermutationMat" );
 ##  If only <A>vector</A> is given then it is used to compute a default for
 ##  <A>R</A>.
 ##  <P/>
-##  If the <Ref Filt="ConstructingFilter"/> value of the result implies
-##  <Ref Filt="IsCopyable"/> then the result is fully mutable.
+##  If the <Ref Filt="ConstructingFilter" Label="for a matrix object"/> value
+##  of the result implies <Ref Filt="IsCopyable"/> then the result is
+##  fully mutable.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> d1:= DiagonalMatrix( GF(9), [ 1, 2 ] * Z(3)^0 );

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1358,6 +1358,26 @@ InstallOtherMethod( ConstructingFilter,
 
 #############################################################################
 ##
+##  The following "auxiliary methods" are needed when 'DiagonalMatrix' etc.
+##  is called with filter 'IsPlistRep'.
+##  (Strictly speaking, 'NewZeroMatrix' and 'NewIdentityMatrix' are not
+##  defined for this situation, since they promise to return matrix objects.)
+##
+InstallOtherMethod( NewZeroMatrix,
+  [ "IsPlistRep", "IsSemiring", "IsInt", "IsInt" ],
+  function( filter, basedomain, nrows, ncols )
+    return NullMat( nrows, ncols, basedomain );
+  end );
+
+InstallOtherMethod( NewIdentityMatrix,
+  [ "IsPlistRep", "IsSemiring", "IsInt" ],
+  function( filter, basedomain, dim )
+    return IdentityMat( dim, basedomain );
+  end );
+
+
+#############################################################################
+##
 #M  DepthOfUpperTriangularMatrix( <mat> )
 ##
 InstallMethod( DepthOfUpperTriangularMatrix,
@@ -3639,6 +3659,56 @@ InstallGlobalFunction( PermutationMat, function( arg )
 
     return mat;
 end );
+
+
+#############################################################################
+##
+#M  DiagonalMatrix( [<filt>, ]<R>, <vector> )
+#M  DiagonalMatrix( <vector>[, <M>] )
+##
+InstallMethod( DiagonalMatrix,
+    [ "IsOperation", "IsSemiring", "IsRowVectorOrVectorObj" ],
+    function( filt, R, vector )
+    local n, mat, i;
+
+    n:= Length( vector );
+    mat:= NewZeroMatrix( filt, R, n, n );
+    for i in [ 1 .. n ] do
+      mat[i, i]:= vector[i];
+    od;
+
+    return mat;
+    end );
+
+InstallMethod( DiagonalMatrix,
+    [ "IsSemiring", "IsRowVectorOrVectorObj" ],
+    function( R, vector )
+    return DiagonalMatrix( DefaultMatrixRepForBaseDomain( R ), R, vector );
+    end );
+
+InstallMethod( DiagonalMatrix,
+    [ "IsRowVectorOrVectorObj", "IsMatrixOrMatrixObj" ],
+    function( vector, M )
+    return DiagonalMatrix( ConstructingFilter( M ), BaseDomain( M ), vector );
+    end );
+
+InstallMethod( DiagonalMatrix,
+    [ "IsRowVectorOrVectorObj" ],
+    function( vector )
+    local R;
+
+    if Length( vector ) = 0 then
+      Error( "do not know over which ring the matrix shall be defined" );
+    fi;
+    R:= DefaultScalarDomainOfMatrixList( [ [ vector ] ] );
+    return DiagonalMatrix( DefaultMatrixRepForBaseDomain( R ), R, vector );
+    end );
+#T Alternatively, we could use the code of 'DiagonalMat' in this method,
+#T turn 'DiagonalMat' into an obsolescent synonym of 'DiagonalMatrix',
+#T and turn the documentation of 'DiagonalMat' into a link to the
+#T documentation of 'DiagonalMatrix'.
+#T The behaviour is slightly different for example if the argument is a list
+#T of integers or rationals.
 
 
 #############################################################################

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -3666,7 +3666,7 @@ end );
 #M  DiagonalMatrix( [<filt>, ]<R>, <vector> )
 #M  DiagonalMatrix( <vector>[, <M>] )
 ##
-InstallKeyBasedMethod( DiagonalMatrix,
+InstallTagBasedMethod( DiagonalMatrix,
     function( filt, R, vector )
     local n, mat, i;
 

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -3666,8 +3666,7 @@ end );
 #M  DiagonalMatrix( [<filt>, ]<R>, <vector> )
 #M  DiagonalMatrix( <vector>[, <M>] )
 ##
-InstallMethod( DiagonalMatrix,
-    [ "IsOperation", "IsSemiring", "IsRowVectorOrVectorObj" ],
+InstallKeyBasedMethod( DiagonalMatrix,
     function( filt, R, vector )
     local n, mat, i;
 

--- a/lib/methsel.g
+++ b/lib/methsel.g
@@ -75,6 +75,72 @@ end );
 ##
 #F  NewKeyBasedOperation( <name>, <requirements> )
 #F  DeclareKeyBasedOperation( <name>, <requirements> )
+#F  InstallKeyBasedMethod( <oper>[, <key>], <meth> )
+##
+##  <#GAPDoc Label="DeclareKeyBasedOperation">
+##  <ManSection>
+##  <Heading>Key Based Operations</Heading>
+##  <Func Name="NewKeyBasedOperation" Arg='name, requirements'/>
+##  <Func Name="DeclareKeyBasedOperation" Arg='name, requirements'/>
+##  <Func Name="InstallKeyBasedMethod" Arg='oper[, key], meth'/>
+##
+##  <Description>
+##  <Ref Func="NewKeyBasedOperation"/> returns an operation with name
+##  <A>name</A> that is declared as <E>key based</E>
+##  w.r.t. the list <A>requirements</A> of filters for its arguments.
+##  If an operation with name <A>name</A> exists already before the call
+##  then this operation is returned, otherwise a new operation gets created.
+##  <P/>
+##  <Ref Func="DeclareKeyBasedOperation"/> does the same and additionally
+##  binds the returned operation to the global variable <A>name</A> if the
+##  operation is new.
+##  <P/>
+##  Declaring the operation <A>oper</A> as key based w.r.t.
+##  <A>requirements</A> means that <Ref Func="InstallKeyBasedMethod"/>
+##  can be used to install the method <A>meth</A> for <A>oper</A>,
+##  a function whose arguments satisfy <A>requirements</A>,
+##  with the following meaning.
+##  <P/>
+##  <List>
+##  <Item>
+##    The method <A>meth</A> is applicable if the first argument
+##    of the call to <A>oper</A> is identical (in the sense of
+##    <Ref Func="IsIdenticalObj"/>) with the key <A>key</A> that has been
+##    specified in the <Ref Func="InstallKeyBasedMethod"/> call.
+##  </Item>
+##  <Item>
+##    If none of the key based methods for <A>oper</A> has a <A>key</A>
+##    that is identical with the first argument of the call to <A>oper</A>
+##    and if there is a key based method for <A>oper</A> for which no
+##    <A>key</A> was specified then this method is applicable.
+##  </Item>
+##  </List>
+##  <P/>
+##  Thus at most <E>one</E> key based method for <A>oper</A> is applicable,
+##  and if a method without <A>key</A> has been installed then it serves as
+##  the default method.
+##  This is in contrast to the situation with constructors
+##  (see <Ref Sect="Constructors"/>) where the first argument is a filter
+##  that is used as a key, but several methods can be applicable in a call
+##  to a constructor and one cannot define a default method for it.
+##  <P/>
+##  Typical use cases for key based operations are operations that shall
+##  create objects in particular internal representations; the filters that
+##  define these representations are then used as the first argument,
+##  and one wants that either the unique method that belongs to this filter
+##  or a default method is called.
+##  <P/>
+##  Currently it is possible to declare an operation as key based
+##  only for <E>one</E> list of requirements.
+##  <P/>
+##  Installing methods with <Ref Func="InstallMethod"/> for a key based
+##  operation is possible.
+##  (Installing such methods with the same requirements as the ones for the
+##  key based methods is not recommended, because this may lead to unwanted
+##  effects.)
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "_METHODS_KEY_BASED", OBJ_MAP() );
 BIND_GLOBAL( "_METHODS_KEY_BASED_DEFAULTS", OBJ_MAP() );
@@ -132,10 +198,6 @@ BIND_GLOBAL( "DeclareKeyBasedOperation",
     fi;
 end );
 
-#############################################################################
-##
-#F  InstallKeyBasedMethod( <oper>[, <key>], <meth> )
-##
 BIND_GLOBAL( "InstallKeyBasedMethod", function( oper, meth... )
     local dict, defaultdata, key, n;
 

--- a/lib/methsel.g
+++ b/lib/methsel.g
@@ -73,30 +73,30 @@ end );
 
 #############################################################################
 ##
-#F  NewKeyBasedOperation( <name>, <requirements> )
-#F  DeclareKeyBasedOperation( <name>, <requirements> )
-#F  InstallKeyBasedMethod( <oper>[, <key>], <meth> )
+#F  NewTagBasedOperation( <name>, <requirements> )
+#F  DeclareTagBasedOperation( <name>, <requirements> )
+#F  InstallTagBasedMethod( <oper>[, <tag>], <meth> )
 ##
-##  <#GAPDoc Label="DeclareKeyBasedOperation">
+##  <#GAPDoc Label="DeclareTagBasedOperation">
 ##  <ManSection>
-##  <Heading>Key Based Operations</Heading>
-##  <Func Name="NewKeyBasedOperation" Arg='name, requirements'/>
-##  <Func Name="DeclareKeyBasedOperation" Arg='name, requirements'/>
-##  <Func Name="InstallKeyBasedMethod" Arg='oper[, key], meth'/>
+##  <Heading>Tag Based Operations</Heading>
+##  <Func Name="NewTagBasedOperation" Arg='name, requirements'/>
+##  <Func Name="DeclareTagBasedOperation" Arg='name, requirements'/>
+##  <Func Name="InstallTagBasedMethod" Arg='oper[, tag], meth'/>
 ##
 ##  <Description>
-##  <Ref Func="NewKeyBasedOperation"/> returns an operation with name
-##  <A>name</A> that is declared as <E>key based</E>
+##  <Ref Func="NewTagBasedOperation"/> returns an operation with name
+##  <A>name</A> that is declared as <E>tag based</E>
 ##  w.r.t. the list <A>requirements</A> of filters for its arguments.
 ##  If an operation with name <A>name</A> exists already before the call
 ##  then this operation is returned, otherwise a new operation gets created.
 ##  <P/>
-##  <Ref Func="DeclareKeyBasedOperation"/> does the same and additionally
+##  <Ref Func="DeclareTagBasedOperation"/> does the same and additionally
 ##  binds the returned operation to the global variable <A>name</A> if the
 ##  operation is new.
 ##  <P/>
-##  Declaring the operation <A>oper</A> as key based w.r.t.
-##  <A>requirements</A> means that <Ref Func="InstallKeyBasedMethod"/>
+##  Declaring the operation <A>oper</A> as tag based w.r.t.
+##  <A>requirements</A> means that <Ref Func="InstallTagBasedMethod"/>
 ##  can be used to install the method <A>meth</A> for <A>oper</A>,
 ##  a function whose arguments satisfy <A>requirements</A>,
 ##  with the following meaning.
@@ -105,47 +105,47 @@ end );
 ##  <Item>
 ##    The method <A>meth</A> is applicable if the first argument
 ##    of the call to <A>oper</A> is identical (in the sense of
-##    <Ref Func="IsIdenticalObj"/>) with the key <A>key</A> that has been
-##    specified in the <Ref Func="InstallKeyBasedMethod"/> call.
+##    <Ref Func="IsIdenticalObj"/>) with the tag <A>tag</A> that has been
+##    specified in the <Ref Func="InstallTagBasedMethod"/> call.
 ##  </Item>
 ##  <Item>
-##    If none of the key based methods for <A>oper</A> has a <A>key</A>
+##    If none of the tag based methods for <A>oper</A> has a <A>tag</A>
 ##    that is identical with the first argument of the call to <A>oper</A>
-##    and if there is a key based method for <A>oper</A> for which no
-##    <A>key</A> was specified then this method is applicable.
+##    and if there is a tag based method for <A>oper</A> for which no
+##    <A>tag</A> was specified then this method is applicable.
 ##  </Item>
 ##  </List>
 ##  <P/>
-##  Thus at most <E>one</E> key based method for <A>oper</A> is applicable,
-##  and if a method without <A>key</A> has been installed then it serves as
+##  Thus at most <E>one</E> tag based method for <A>oper</A> is applicable,
+##  and if a method without <A>tag</A> has been installed then it serves as
 ##  the default method.
 ##  This is in contrast to the situation with constructors
 ##  (see <Ref Sect="Constructors"/>) where the first argument is a filter
-##  that is used as a key, but several methods can be applicable in a call
+##  that is used as a tag, but several methods can be applicable in a call
 ##  to a constructor and one cannot define a default method for it.
 ##  <P/>
-##  Typical use cases for key based operations are operations that shall
+##  Typical use cases for tag based operations are operations that shall
 ##  create objects in particular internal representations; the filters that
 ##  define these representations are then used as the first argument,
 ##  and one wants that either the unique method that belongs to this filter
 ##  or a default method is called.
 ##  <P/>
-##  Currently it is possible to declare an operation as key based
+##  Currently it is possible to declare an operation as tag based
 ##  only for <E>one</E> list of requirements.
 ##  <P/>
-##  Installing methods with <Ref Func="InstallMethod"/> for a key based
+##  Installing methods with <Ref Func="InstallMethod"/> for a tag based
 ##  operation is possible.
 ##  (Installing such methods with the same requirements as the ones for the
-##  key based methods is not recommended, because this may lead to unwanted
+##  tag based methods is not recommended, because this may lead to unwanted
 ##  effects.)
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BIND_GLOBAL( "_METHODS_KEY_BASED", OBJ_MAP() );
-BIND_GLOBAL( "_METHODS_KEY_BASED_DEFAULTS", OBJ_MAP() );
+BIND_GLOBAL( "_METHODS_TAG_BASED", OBJ_MAP() );
+BIND_GLOBAL( "_METHODS_TAG_BASED_DEFAULTS", OBJ_MAP() );
 
-BIND_GLOBAL( "NewKeyBasedOperation",
+BIND_GLOBAL( "NewTagBasedOperation",
     function( name, requirements )
     local oper, methods;
 
@@ -157,17 +157,17 @@ BIND_GLOBAL( "NewKeyBasedOperation",
       oper:= NewOperation( name, requirements );
     fi;
 
-    # initialize the key handling for 'oper'
-    if FIND_OBJ_MAP( _METHODS_KEY_BASED, oper, fail ) <> fail then
-      Error( "operation <oper> has already been declared as key based" );
+    # initialize the tag handling for 'oper'
+    if FIND_OBJ_MAP( _METHODS_TAG_BASED, oper, fail ) <> fail then
+      Error( "operation <oper> has already been declared as tag based" );
     fi;
     methods:= OBJ_MAP();
-    ADD_OBJ_MAP( _METHODS_KEY_BASED, oper, methods );
-    ADD_OBJ_MAP( _METHODS_KEY_BASED_DEFAULTS, oper, requirements );
+    ADD_OBJ_MAP( _METHODS_TAG_BASED, oper, methods );
+    ADD_OBJ_MAP( _METHODS_TAG_BASED_DEFAULTS, oper, requirements );
 
-    # install the method for 'oper' that uses the key handling
+    # install the method for 'oper' that uses the tag handling
     InstallMethod( oper,
-      "key based method",
+      "tag based method",
       requirements,
       function( requ... )
       local method;
@@ -180,7 +180,7 @@ BIND_GLOBAL( "NewKeyBasedOperation",
       if method = fail then
         # Calling 'TryNextMethod' would lead to a less useful error message,
         # and perhaps cause real trouble.
-        Error( "no default installed for key based operation <oper>" );
+        Error( "no default installed for tag based operation <oper>" );
       fi;
 
       return CallFuncList( method, requ );
@@ -189,40 +189,40 @@ BIND_GLOBAL( "NewKeyBasedOperation",
     return oper;
 end );
 
-BIND_GLOBAL( "DeclareKeyBasedOperation",
+BIND_GLOBAL( "DeclareTagBasedOperation",
     function( name, requirements )
     local oper;
 
-    oper:= NewKeyBasedOperation( name, requirements );
+    oper:= NewTagBasedOperation( name, requirements );
     if not ISBOUND_GLOBAL( name ) then
       BIND_GLOBAL( name, oper );
     fi;
 end );
 
-BIND_GLOBAL( "InstallKeyBasedMethod", function( oper, meth... )
-    local dict, defaultdata, key, n;
+BIND_GLOBAL( "InstallTagBasedMethod", function( oper, meth... )
+    local dict, defaultdata, tag, n;
 
-    dict:= FIND_OBJ_MAP( _METHODS_KEY_BASED, oper, fail );
+    dict:= FIND_OBJ_MAP( _METHODS_TAG_BASED, oper, fail );
     if dict = fail then
-      Error( "<oper> is not declared as key based operation" );
+      Error( "<oper> is not declared as tag based operation" );
     fi;
-    defaultdata:= FIND_OBJ_MAP( _METHODS_KEY_BASED_DEFAULTS, oper, fail );
+    defaultdata:= FIND_OBJ_MAP( _METHODS_TAG_BASED_DEFAULTS, oper, fail );
     if defaultdata = fail then
       Error( "this should not happen" );
     fi;
 
     if LENGTH( meth ) = 1 then
-      key:= IS_OBJECT;
+      tag:= IS_OBJECT;
       meth:= meth[1];
     elif LENGTH( meth ) = 2 then
-      key:= meth[1];
+      tag:= meth[1];
       meth:= meth[2];
     else
-      Error( "usage: InstallKeyBasedMethod( oper[, key], meth )" );
+      Error( "usage: InstallTagBasedMethod( oper[, tag], meth )" );
     fi;
 
-    if FIND_OBJ_MAP( dict, key, fail ) <> fail then
-      Error( "<key> has already been set in <dict>" );
+    if FIND_OBJ_MAP( dict, tag, fail ) <> fail then
+      Error( "<tag> has already been set in <dict>" );
     elif not IS_FUNCTION( meth ) then
       Error( "<meth> must be a function" );
     fi;
@@ -231,5 +231,5 @@ BIND_GLOBAL( "InstallKeyBasedMethod", function( oper, meth... )
       Error( "<meth> must take ", LENGTH( defaultdata ), " arguments" );
     fi;
 
-    ADD_OBJ_MAP( dict, key, meth );
+    ADD_OBJ_MAP( dict, tag, meth );
 end );

--- a/lib/methsel.g
+++ b/lib/methsel.g
@@ -167,7 +167,7 @@ BIND_GLOBAL( "NewKeyBasedOperation",
 
     # install the method for 'oper' that uses the key handling
     InstallMethod( oper,
-      "key dependent method",
+      "key based method",
       requirements,
       function( requ... )
       local method;
@@ -178,8 +178,9 @@ BIND_GLOBAL( "NewKeyBasedOperation",
         method:= FIND_OBJ_MAP( methods, IS_OBJECT, fail );
       fi;
       if method = fail then
+        # Calling 'TryNextMethod' would lead to a less useful error message,
+        # and perhaps cause real trouble.
         Error( "no default installed for key based operation <oper>" );
-#T or would it make sense to call 'TryNextMethod'?
       fi;
 
       return CallFuncList( method, requ );

--- a/tst/testinstall/MatrixObj/DiagonalMatrix.tst
+++ b/tst/testinstall/MatrixObj/DiagonalMatrix.tst
@@ -34,7 +34,7 @@ gap> M:= Matrix( IsPlistMatrixRep, GF(3), [ Z(3) ], 1 );;
 gap> DiagonalMatrix( [ 1, 2 ] * Z(3), M );
 <2x2-matrix over GF(3)>
 gap> DiagonalMatrix( [ 1, 2 ], M );
-Error, <ob> must lie in the base domain of <m>
+Error, <ob> must lie in the base domain of <M>
 
 # with vector of diagonal entries only (choose a default representation)
 gap> Is8BitMatrixRep( DiagonalMatrix( [ 1, 2 ] * Z(3) ) );

--- a/tst/testinstall/MatrixObj/DiagonalMatrix.tst
+++ b/tst/testinstall/MatrixObj/DiagonalMatrix.tst
@@ -1,0 +1,48 @@
+#@local M
+gap> START_TEST( "DiagonalMatrix.tst" );
+
+# with base domain and vector of diagonal entries
+gap> Is8BitMatrixRep( DiagonalMatrix( GF(9), [ 1, 2 ] * Z(3)^0 ) );
+true
+gap> DiagonalMatrix( GF(9), [] );
+Error, Is8BitMatrixRep with zero rows not yet supported
+gap> IsPlistMatrixRep( DiagonalMatrix( Integers, [ 1, 2 ] ) );
+true
+gap> IsPlistMatrixRep( DiagonalMatrix( Integers, [] ) );
+true
+
+# with constructing filter, base domain, and vector of diagonal entries
+gap> Is8BitMatrixRep( DiagonalMatrix( Is8BitMatrixRep, GF(9), [ 1, 2 ] * Z(3)^0 ) );
+true
+gap> IsPlistMatrixRep( DiagonalMatrix( IsPlistMatrixRep, GF(9), [] ) );
+true
+gap> IsPlistRep( DiagonalMatrix( IsPlistRep, Integers, [ 1, 2 ] ) );
+true
+
+# with vector of diagonal entries and example matrix
+gap> M:= Matrix( IsPlistMatrixRep, Integers, [ 1 ], 1 );;
+gap> DiagonalMatrix( [ 1, 2 ], M );
+<2x2-matrix over Integers>
+gap> DiagonalMatrix( [], M );
+<0x0-matrix over Integers>
+gap> M:= [ [ 1 ] ];;
+gap> DiagonalMatrix( [ 1, 2 ], M );
+[ [ 1, 0 ], [ 0, 2 ] ]
+gap> DiagonalMatrix( [], M );
+[  ]
+gap> M:= Matrix( IsPlistMatrixRep, GF(3), [ Z(3) ], 1 );;
+gap> DiagonalMatrix( [ 1, 2 ] * Z(3), M );
+<2x2-matrix over GF(3)>
+gap> DiagonalMatrix( [ 1, 2 ], M );
+Error, <ob> must lie in the base domain of <m>
+
+# with vector of diagonal entries only (choose a default representation)
+gap> Is8BitMatrixRep( DiagonalMatrix( [ 1, 2 ] * Z(3) ) );
+true
+gap> IsPlistMatrixRep( DiagonalMatrix( [ 1, 2 ] ) );
+true
+gap> DiagonalMatrix( [] );
+Error, do not know over which ring the matrix shall be defined
+
+#
+gap> STOP_TEST( "DiagonalMatrix.tst" );

--- a/tst/testinstall/oper.tst
+++ b/tst/testinstall/oper.tst
@@ -1,0 +1,38 @@
+#@local newop
+gap> START_TEST( "oper.tst" );
+
+#
+gap> newop:= NewKeyBasedOperation( "newop", [ IsOperation, IsInt ] );;
+gap> newop( IsList, 1 );
+Error, no default installed for key based operation <oper>
+gap> InstallKeyBasedMethod( newop,
+>        { oper, n } -> n );
+gap> InstallKeyBasedMethod( newop,
+>        { oper, n } -> n );
+Error, <key> has already been set in <dict>
+gap> InstallKeyBasedMethod( newop, IsGroup,
+>        { oper, n } -> 2*n );
+gap> InstallKeyBasedMethod( newop, IsGroup,
+>        { oper, n } -> 2*n );
+Error, <key> has already been set in <dict>
+gap> InstallKeyBasedMethod( newop, IsMagma,
+>        { oper, n } -> 3*n );
+gap> InstallKeyBasedMethod( newop, IsInt,
+>        { oper, n } -> 4*n );
+gap> newop( IsList );
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `newop' on 1 arguments
+gap> newop( IsList, 1, 2 );
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `newop' on 3 arguments
+gap> newop( IsList, 1 );
+1
+gap> newop( IsGroup, 1 );
+2
+gap> newop( IsMagma, 1 );
+3
+gap> newop( IsInt, 1 );
+4
+
+#
+gap> STOP_TEST( "oper.tst" );

--- a/tst/testinstall/oper.tst
+++ b/tst/testinstall/oper.tst
@@ -2,22 +2,22 @@
 gap> START_TEST( "oper.tst" );
 
 #
-gap> newop:= NewKeyBasedOperation( "newop", [ IsOperation, IsInt ] );;
+gap> newop:= NewTagBasedOperation( "newop", [ IsOperation, IsInt ] );;
 gap> newop( IsList, 1 );
-Error, no default installed for key based operation <oper>
-gap> InstallKeyBasedMethod( newop,
+Error, no default installed for tag based operation <oper>
+gap> InstallTagBasedMethod( newop,
 >        { oper, n } -> n );
-gap> InstallKeyBasedMethod( newop,
+gap> InstallTagBasedMethod( newop,
 >        { oper, n } -> n );
-Error, <key> has already been set in <dict>
-gap> InstallKeyBasedMethod( newop, IsGroup,
+Error, <tag> has already been set in <dict>
+gap> InstallTagBasedMethod( newop, IsGroup,
 >        { oper, n } -> 2*n );
-gap> InstallKeyBasedMethod( newop, IsGroup,
+gap> InstallTagBasedMethod( newop, IsGroup,
 >        { oper, n } -> 2*n );
-Error, <key> has already been set in <dict>
-gap> InstallKeyBasedMethod( newop, IsMagma,
+Error, <tag> has already been set in <dict>
+gap> InstallTagBasedMethod( newop, IsMagma,
 >        { oper, n } -> 3*n );
-gap> InstallKeyBasedMethod( newop, IsInt,
+gap> InstallTagBasedMethod( newop, IsInt,
 >        { oper, n } -> 4*n );
 gap> newop( IsList );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound


### PR DESCRIPTION
In calls to operations such as `DiagonalMatrix`, `CompanionMatrix`, etc., one wants to specify the internal representation of the result via a filter (such as `IsPlistMatrixRep`) as the first argument. In order to be able to install individual methods depending on this filter, one does not really want to declare the operations as [constructors](https://docs.gap-system.org/doc/ref/chap78_mj.html#X86EC0F0A78ECBC10) because the result shall have *exactly* the given filter (and not perhaps something better), and also because one wants to be able to install a default method. (See the discussion of #4398 for details.)

The changes proposed here provide an implementation (see commit 949cbc4) and documentation (see commit 9aaf40f) for this feature. Note that the operations in question are still GAP operations, the tag based mechanism is called only in the situation that the first argument is a filter.

The rest of the pull request applies the new mechanism to the operation `DiagonalMatrix`:

- added a new operation `DiagonalMatrix`, and added its documentation to the Reference Manual
- added a new filter `IsRowVectorOrVectorObj`, analogous to `IsMatrixOrMatrixObj`, in order to simplify some method installations
- moved the declarations of `DefaultVectorRepForBaseDomain` and `DefaultMatrixRepForBaseDomain` from `lib/matobj.gi` to `lib/matobj2.gd`
- added a `CompatibleVectorFilter` method for `IsMatrix` objects
- added `NewZeroMatrix` and `NewIdentityMatrix` methods for `IsPlistRep`
- added preliminary tests for `DiagonalMatrix`
- removed some comment lines

As soon as we agree on the details, the same changes can be applied to `PermutationMatrix`, `ReflectionMatrix`, `RandomMatrix`, see issue #4367.

Here are the perhaps controversial pieces of the changes:

- We could decide that `DiagonalMatrix( list )` behaves like the global function `DiagonalMat( list )`, and then `DiagonalMat` could become deprecated.
- It is not clear to me to which extent we want `IsPlistRep` matrices to be supported w.r.t. functionality for matrix objects. Thus perhaps the "auxiliary" `NewZeroMatrix` and `NewIdentityMatrix` methods for `IsPlistRep` and the `CompatibleVectorFilter` method for `IsMatrix` objects are not what we want.