### PR TITLE
Make `ZeroSameMutability` for 8-bit matrices consistent with `AdditiveInverseSameMutability`

### DIFF
--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -1068,7 +1068,7 @@ InstallMethod(NestingDepthA, [Is8BitVectorRep], m->1);
 InstallMethod(PostMakeImmutable, [Is8BitMatrixRep],
         function(m)
     local i;
-    for i in [2..m![1]] do
+    for i in [2..m![1]+1] do
         MakeImmutable(m![i]);
     od;
 end);

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -646,33 +646,25 @@ InstallMethod( ZeroImmutable, "8 bit matrix", true,
     return z;
 end);
 
-InstallMethod( ZeroSameMutability, "8 bit matrix", true,
-        [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
-        0,
-        function(mat)
-    local z, i,zv;
-    z := [mat![1]];
-    if not IsMutable(mat![2]) then
-        zv := ZERO_VEC8BIT(mat![2]);
-        SetFilterObj(zv, IsLockedRepresentationVector);
-        MakeImmutable(zv);
-        for i in [2..mat![1]+1] do
-            z[i] := zv;
-        od;
+InstallMethod(ZeroSameMutability, "8 bit matrix",
+[Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
+and IsSmallList],
+function(mat)
+  local z, i, zv;
+  z := [mat![1]];
+  zv := ZERO_VEC8BIT(mat![2]);
+  SetFilterObj(zv, IsLockedRepresentationVector);
+  MakeImmutable(zv);
+  for i in [2 .. mat![1] + 1] do
+    if IsMutable(mat![i]) then
+      z[i] := ZERO_VEC8BIT(mat![i]);
+      SetFilterObj(z[i], IsLockedRepresentationVector);
     else
-        for i in [2..mat![1]+1] do
-            zv := ZERO_VEC8BIT(mat![i]);
-            SetFilterObj(zv,IsLockedRepresentationVector);
-            z[i] := zv;
-        od;
+      z[i] := zv;
     fi;
-    if IsMutable(mat) then
-       Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), z);
-    else
-        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), z);
-    fi;
-    return z;
+  od;
+  Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]), IsMutable(mat)), z);
+  return z;
 end);
 
 #############################################################################

--- a/tst/testinstall/mat8bit.tst
+++ b/tst/testinstall/mat8bit.tst
@@ -205,5 +205,22 @@ false
 gap> Zero( mz ) = m * Zero( z );
 true
 
+# PostMakeImmutable bug
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> m;
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> IsMutable(m);
+true
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> IsMutable(m);
+false
+gap> IsMutable(m[1]);
+false
+gap> IsMutable(m[2]); # previously returned true!
+false
+
 #
 gap> STOP_TEST("mat8bit.tst");

--- a/tst/testinstall/mat8bit.tst
+++ b/tst/testinstall/mat8bit.tst
@@ -1,4 +1,4 @@
-#@local m, z, zm, mz;
+#@local m, z, zm, mz, mm;
 gap> START_TEST("mat8bit.tst");
 
 ##
@@ -220,6 +220,53 @@ false
 gap> IsMutable(m[1]);
 false
 gap> IsMutable(m[2]); # previously returned true!
+false
+
+# ZeroSameMutability for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> ForAll(mm, IsMutable);
+true
+gap> MakeImmutable(m[2]);
+[ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ]
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> List(mm, IsMutable);
+[ true, false ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> List(mm, IsMutable);
+[ false, true ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+false
+gap> ForAny(mm, IsMutable);
 false
 
 #


### PR DESCRIPTION
The previous behaviour of the methods installed for `ZeroSameMutability` was inconsistent with the behaviour of `AdditiveInverseSameMutability`, this commit makes them have the same behaviour, i.e. that if `ZeroSameMutability` is called for a mutable matrix `m`, then the `m` can have mutable or immutable rows (in any combination), but the mutability of the rows in the output was determined by the mutability of the first row only. This commit gives the result of `ZeroSameMutability` the same pattern of mutable/immutable rows as the input.

I believe that this was the desired behaviour after a discussion with @ThomasBreuer and @fingolfin  some weeks ago.

This PR builds on #5343, can separate this dependency if necessary.

## Text for release notes

None?


