### PR TITLE
.editorconfig: don't strip trailing spaces in .tst files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,10 @@ indent_style = space
 indent_size = 4
 charset = utf-8
 
+#
+[*.tst]
+trim_trailing_whitespace = false
+
 # In Makefile one must use tab indentation
 [Makefile*]
 indent_style = tab


### PR DESCRIPTION
... as there these may be necessary parts of various outputs.
