### PR TITLE
Fix docs for Omega subgroup

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -2027,7 +2027,7 @@ DeclareAttribute( "NrConjugacyClasses", IsGroup );
 ##  <Description>
 ##  For a <A>p</A>-group <A>G</A>, one defines
 ##  <M>\Omega_{<A>n</A>}(<A>G</A>) =
-##  \{ g \in <A>G</A> \mid g^{{<A>p</A>^{<A>n</A>}}} = 1 \}</M>.
+##  \langle g \in <A>G</A> \mid g^{{<A>p</A>^{<A>n</A>}}} = 1 \rangle</M>.
 ##  The default value for <A>n</A> is <C>1</C>.
 ##  <P/>
 ##  <Example><![CDATA[


### PR DESCRIPTION
Fixes issue #5348 -- previously the documentation used set braces, but now it uses subgroup generated langle and rangle braces.

## Text for release notes

none