### PR TITLE
Add tests for matrices in `Is8BitMatrixRep` and fix some inconsistent behaviour

### DIFF
--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -706,7 +706,7 @@ InstallMethod( InverseSameMutability, "8 bit matrix", true,
 
 #############################################################################
 ##
-#M <mat>^0
+#M One
 ##
 
 InstallMethod( OneSameMutability, "8 bit matrix", true,
@@ -761,15 +761,7 @@ InstallMethod( OneMutable, "8 bit matrix", true,
     return o;
 end);
 
-
-
-
-#############################################################################
-##
-#M One(<mat>) -- always immutable
-##
-
-InstallMethod( One, "8 bit matrix", true,
+InstallMethod(OneImmutable, "8 bit matrix", true,
         [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
         # the following are banalities, but they are required to get the
         # ranking right
@@ -778,11 +770,7 @@ InstallMethod( One, "8 bit matrix", true,
         ],
         0,
         function(m)
-    local   o;
-    o := OneOp(m);
-    MakeImmutable(o);
-    ConvertToMatrixRepNC(o, Q_VEC8BIT(m![2]));
-    return o;
+    return MakeImmutable(OneMutable(m));
     end );
 
 #############################################################################

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -587,27 +587,29 @@ InstallMethod(AdditiveInverseImmutable, "8 bit matrix", true,
     return neg;
 end);
 
-InstallMethod(AdditiveInverseSameMutability, "8 bit matrix", true,
+InstallMethod(AdditiveInverseSameMutability, "an 8-bit matrix",
         [Is8BitMatrixRep and IsMatrix and IsAdditiveElementWithZero
-         and IsSmallList ],
-        0,
-        function(mat)
-    local neg,i,negv;
-    neg := [mat![1]];
-    for i in [2..mat![1]+1] do
-        negv := AdditiveInverseSameMutability(mat![i]);
-        SetFilterObj(negv, IsLockedRepresentationVector);
-        neg[i] := negv;
-    od;
-    if IsMutable(mat) then
-        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), neg);
-    else
-        Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), neg);
-    fi;
-    return neg;
+         and IsSmallList],
+function(mat)
+  local inv_func, neg, i;
+
+  if IsMutable(mat[1]) then
+    inv_func := AdditiveInverseMutable;
+  else
+    inv_func := AdditiveInverseImmutable;
+  fi;
+  neg := [mat![1]];
+  for i in [2..mat![1]+1] do
+    neg[i] := inv_func(mat![i]);
+    SetFilterObj(neg[i], IsLockedRepresentationVector);
+  od;
+  if IsMutable(mat) then
+    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),true), neg);
+  else
+    Objectify(TYPE_MAT8BIT(Q_VEC8BIT(mat![2]),false), neg);
+  fi;
+  return neg;
 end);
-
-
 
 #############################################################################
 ##

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -675,12 +675,13 @@ InstallMethod( ZeroSameMutability, "8 bit matrix", true,
     return z;
 end);
 
+
 #############################################################################
 ##
-#M InverseOp(<mat>)
+#M Inverse
 ##
 
-InstallMethod( InverseOp, "8 bit matrix", true,
+InstallMethod(InverseMutable, "8 bit matrix", true,
         [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse
         # the following are banalities, but they are required to get the
         # ranking right
@@ -690,12 +691,8 @@ InstallMethod( InverseOp, "8 bit matrix", true,
         0,
         INV_MAT8BIT_MUTABLE);
 
-
-
-#############################################################################
-##
-#M <mat>^-1
-##
+InstallMethod(InverseImmutable, "for 8-bit matrix rep", [Is8BitMatrixRep],
+INV_MAT8BIT_IMMUTABLE);
 
 InstallMethod( InverseSameMutability, "8 bit matrix", true,
         [Is8BitMatrixRep and IsMatrix and IsMultiplicativeElementWithInverse

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -254,9 +254,8 @@ InstallGlobalFunction(ConvertToMatrixRep,
 
     LeastCommonPower := function(qs)
         local p, d, x, i;
-        if Length(qs) = 0 then
-            return fail;
-        fi;
+        Assert(1, Length(qs) > 0);
+
         x := Z(qs[1]);
         p := Characteristic(x);
         d := DegreeFFE(x);
@@ -269,7 +268,6 @@ InstallGlobalFunction(ConvertToMatrixRep,
         od;
         return p^d;
     end;
-
 
     qs := [];
 

--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -996,30 +996,26 @@ InstallMethod(TriangulizeMat,
         TRIANGULIZE_LIST_VEC8BITS);
 
 InstallMethod(TriangulizeMat,
-        "method for compressed matrices",
-        true,
-        [IsMutable and IsMatrix and Is8BitMatrixRep and IsFFECollColl],
-        0,
-        function(m)
-    local q,i,imms;
-    imms := [];
-    q := Q_VEC8BIT(m![2]);
-    PLAIN_MAT8BIT(m);
-    for i in [1..Length(m)] do
-        if not IsMutable(m[i]) then
-            m[i] := ShallowCopy(m[i]);
-            imms[i] := true;
-        else
-            imms[i] := false;
-        fi;
-    od;
-    TRIANGULIZE_LIST_VEC8BITS(m);
-    for i in [1..Length(m)] do
-        if imms[i] then
-            MakeImmutable(m[i]);
-        fi;
-    od;
-    CONV_MAT8BIT(m,q);
+"for a mutable 8-bit matrix",
+[IsMutable and IsMatrix and Is8BitMatrixRep and IsFFECollColl],
+function(m)
+  local q, mut, i;
+
+  q := Q_VEC8BIT(m![2]);
+  mut := IsMutable(m[1]);
+
+  PLAIN_MAT8BIT(m);
+  for i in [1 .. NrRows(m)] do
+    if not IsMutable(m[i]) then
+      m[i] := ShallowCopy(m[i]);
+    fi;
+  od;
+  TRIANGULIZE_LIST_VEC8BITS(m);
+
+  CONV_MAT8BIT(m,q);
+  if not mut then
+    PostMakeImmutable(m);
+  fi;
 end);
 
 #############################################################################

--- a/tst/testinstall/mat8bit.tst
+++ b/tst/testinstall/mat8bit.tst
@@ -1,4 +1,4 @@
-#@local m, z, zm, mz;
+#@local m, z, zm, mz, mm;
 gap> START_TEST("mat8bit.tst");
 
 ##
@@ -221,6 +221,423 @@ gap> IsMutable(m[1]);
 false
 gap> IsMutable(m[2]); # previously returned true!
 false
+
+# Unbind for IsMutable and Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m, 4);;
+gap> Is8BitMatrixRep(m);
+true
+gap> m;
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> Unbind(m[1]);
+gap> m;
+[ , [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> Is8BitMatrixRep(m);
+false
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m, 4);;
+gap> Unbind(m[2]);
+gap> m;
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ] ]
+gap> Is8BitMatrixRep(m);
+true
+
+# ViewObj for Is8BitMatrixRep where r * c > 25 or r = 0 or c = 0
+gap> m := List([1 .. 7], x -> [0, 1, 1, 1] * Z(4));;
+gap> ConvertToMatrixRep(m);;
+gap> m;
+< mutable compressed matrix 7x4 over GF(4) >
+gap> MakeImmutable(m);
+< immutable compressed matrix 7x4 over GF(4) >
+
+# ShallowCopy for Is8BitMatrixRep
+gap> m := List([1 .. 7], x -> [0, 1, 1, 1] * Z(4));;
+gap> ConvertToMatrixRep(m);;
+gap> mm := ShallowCopy(m);;
+gap> IsIdenticalObj(m, mm);
+false
+gap> m = mm;
+true
+gap> IsMutable(mm);
+true
+gap> MakeImmutable(m);
+< immutable compressed matrix 7x4 over GF(4) >
+gap> mm := ShallowCopy(m);
+< mutable compressed matrix 7x4 over GF(4) >
+gap> IsIdenticalObj(m, mm);
+false
+gap> m = mm;
+true
+gap> IsMutable(mm);
+true
+
+# PositionCanonical for Is8BitMatrixRep and IsObject
+gap> m := List([1 .. 7], x -> [0, 1, 1, 1] * Z(4));;
+gap> ConvertToMatrixRep(m);;
+gap> PositionCanonical(m, fail);
+fail
+gap> PositionCanonical(m, m[1]);
+1
+gap> PositionCanonical(m, m[2]);
+1
+
+# AdditiveInverseMutable for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> mm := AdditiveInverseMutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> m + mm = ZeroMutable(m);
+true
+gap> ForAll(mm, IsMutable);
+true
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> IsMutable(m);
+true
+gap> IsMutable(m[1]);
+false
+gap> mm := AdditiveInverseMutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ForAll(mm, IsMutable);
+true
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);;
+gap> Is8BitMatrixRep(m) and not IsMutable(m);
+true
+gap> ForAny(m, IsMutable);
+false
+gap> mm := AdditiveInverseMutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> m + mm = ZeroMutable(m);
+true
+gap> ForAll(mm, IsMutable);
+true
+gap> mm := AdditiveInverseMutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ForAll(mm, IsMutable);
+true
+
+# AdditiveInverseImmutable for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := AdditiveInverseImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> m + mm = ZeroMutable(m);
+true
+gap> ForAny(mm, IsMutable);
+false
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> IsMutable(m);
+true
+gap> IsMutable(m[1]);
+false
+gap> mm := AdditiveInverseImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ForAny(mm, IsMutable);
+false
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);;
+gap> Is8BitMatrixRep(m) and not IsMutable(m);
+true
+gap> ForAny(m, IsMutable);
+false
+gap> mm := AdditiveInverseImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> m + mm = ZeroMutable(m);
+true
+gap> ForAny(mm, IsMutable);
+false
+gap> mm := AdditiveInverseImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ForAny(mm, IsMutable);
+false
+
+# AdditiveInverseSameMutability for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := AdditiveInverseSameMutability(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ForAll(mm, IsMutable);
+true
+gap> MakeImmutable(m[2]);
+[ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ]
+gap> mm := AdditiveInverseSameMutability(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> List(mm, IsMutable);
+[ true, true ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := AdditiveInverseSameMutability(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ForAny(mm, IsMutable);
+false
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> mm := AdditiveInverseSameMutability(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> List(mm, IsMutable);
+[ false, false ]
+
+# ZeroSameMutability for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> ForAll(mm, IsMutable);
+true
+gap> MakeImmutable(m[2]);
+[ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ]
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> List(mm, IsMutable);
+[ true, true ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> List(mm, IsMutable);
+[ false, false ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := ZeroSameMutability(m);
+[ [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+false
+gap> ForAny(mm, IsMutable);
+false
+
+# OneSameMutability for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := OneSameMutability(m);
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> ForAll(mm, IsMutable);
+true
+gap> MakeImmutable(m[2]);
+[ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ]
+gap> mm := OneSameMutability(m);
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> List(mm, IsMutable);
+[ true, true ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := OneSameMutability(m);
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> List(mm, IsMutable);
+[ false, false ]
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := OneSameMutability(m);
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+false
+gap> ForAny(mm, IsMutable);
+false
+
+# OneMutable/OneImmutable for Is8BitMatrixRep
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m);
+true
+gap> mm := OneMutable(m);
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+true
+gap> ForAll(mm, IsMutable);
+true
+gap> mm := OneImmutable(m);
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ] ]
+gap> IsMutable(mm);
+false
+gap> ForAny(mm, IsMutable);
+false
+
+# ConvertToMatrixRep
+gap> ConvertToMatrixRep(fail, CyclotomicField(10));
+fail
+gap> ConvertToMatrixRep(fail, fail);
+fail
+gap> ConvertToMatrixRep([], fail);
+fail
+gap> ConvertToMatrixRep([]);
+fail
+gap> ConvertToMatrixRep([], 16);
+16
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> ConvertToMatrixRep(m, 16);
+fail
+gap> ConvertToMatrixRep(m);
+4
+gap> ConvertToMatrixRep(m, 4);
+4
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(2);;
+gap> ConvertToMatrixRepNC(m);;
+gap> IsGF2MatrixRep(m);
+true
+gap> ConvertToMatrixRep(m, 2);
+2
+gap> ConvertToMatrixRep(m);
+2
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> ConvertToMatrixRepNC(m);;
+gap> mm := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(2);;
+gap> ConvertToMatrixRepNC(mm);;
+gap> m := [m[1], mm[1], m[2], mm[2]];
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], <a GF2 vector of length 4>, 
+  [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ], <a GF2 vector of length 4> ]
+gap> ConvertToMatrixRep(m, 5);
+fail
+gap> ConvertToMatrixRep(m, 8);
+Error, ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over\
+ <q>
+gap> ConvertToMatrixRep(m);
+#I  ConvertToVectorRep: locked vector not converted to different field
+fail
+gap> m := [m[1], mm[1], m[2], mm[2],[]];
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], <a GF2 vector of length 4>, 
+  <a GF2 vector of length 4>, <a GF2 vector of length 4>, [  ] ]
+gap> ConvertToMatrixRep(m);
+fail
+
+# ConvertToMatrixRepNC
+gap> ConvertToMatrixRepNC([], 3);
+3
+
+# DefaultFieldOfMatrix
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m);;
+gap> DefaultFieldOfMatrix(m);
+GF(2^2)
+
+# SemiEchelonMat
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1], [0, 1, 0, 0], [1, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m);;
+gap> mm := SemiEchelonMat(m);
+rec( heads := [ 1, 2, 3, 0 ], 
+  vectors := [ [ Z(2)^0, 0*Z(2), Z(2)^0, Z(2)^0 ], 
+      [ 0*Z(2), Z(2)^0, Z(2)^0, Z(2)^0 ], [ 0*Z(2), 0*Z(2), Z(2)^0, Z(2)^0 ] 
+     ] )
+gap> Is8BitMatrixRep(mm.vectors);
+true
+gap> m;
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ], 
+  [ 0*Z(2), Z(2^2), 0*Z(2), 0*Z(2) ], [ Z(2^2), Z(2^2), Z(2^2), Z(2^2) ] ]
+
+# TriangulizeMat
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1], [0, 1, 0, 0], [1, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m);;
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> TriangulizeMat(m);
+gap> m;
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ], 
+  [ 0*Z(2), 0*Z(2), Z(2)^0, Z(2)^0 ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> ForAll(m, IsMutable);
+true
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1], [0, 1, 0, 0], [1, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m[1]);
+[ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ]
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> TriangulizeMat(m);
+gap> m;
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ], 
+  [ 0*Z(2), 0*Z(2), Z(2)^0, Z(2)^0 ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> ForAny(m, IsMutable);
+false
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1], [0, 1, 0, 0], [1, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m[2]);
+[ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ]
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> TriangulizeMat(m);
+gap> m;
+[ [ Z(2)^0, 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2)^0, 0*Z(2), 0*Z(2) ], 
+  [ 0*Z(2), 0*Z(2), Z(2)^0, Z(2)^0 ], [ 0*Z(2), 0*Z(2), 0*Z(2), 0*Z(2) ] ]
+gap> Is8BitMatrixRep(m) and IsMutable(m);
+true
+gap> ForAll(m, IsMutable);
+true
+gap> m := [[1, 0, 1, 1], [0, 1, 1, 1], [0, 1, 0, 0], [1, 1, 1, 1]] * Z(4);;
+gap> ConvertToMatrixRepNC(m);;
+gap> MakeImmutable(m);
+[ [ Z(2^2), 0*Z(2), Z(2^2), Z(2^2) ], [ 0*Z(2), Z(2^2), Z(2^2), Z(2^2) ], 
+  [ 0*Z(2), Z(2^2), 0*Z(2), 0*Z(2) ], [ Z(2^2), Z(2^2), Z(2^2), Z(2^2) ] ]
+gap> TriangulizeMat(m);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `TriangulizeMat' on 1 arguments
 
 #
 gap> STOP_TEST("mat8bit.tst");


### PR DESCRIPTION
This PR adds a bunch of tests to `test/testinstall/mat8bit.tst` so that most of `lib/mat8bit.gi` is tested, and fixes some anomalies along the way. See #5345  for a discussion. 

## Text for release notes

?


