### PR TITLE
Add user preference `HistoryBackwardSearchSkipIdenticalEntries`

### DIFF
--- a/doc/ref/user_pref_list.xml
+++ b/doc/ref/user_pref_list.xml
@@ -73,6 +73,25 @@ Try <C>HelpViewers:= [ "screen", "firefox", "xpdf" ];</C>.
 Defaults: <C>[ [ "screen" ], "", "" ]</C>.
 </Item>
 <Mark>
+<Index Key='HistoryBackwardSearchSkipIdenticalEntries'><C>HistoryBackwardSearchSkipIdenticalEntries</C></Index>
+<C>HistoryBackwardSearchSkipIdenticalEntries</C>
+</Mark>
+<Item>
+When a command is executed multiple times, it is also stored in history
+multiple times. Setting this option to <K>true</K> skips identical entries
+when searching backwards in history.
+
+<P/>
+
+Admissible values:
+<K>true</K>,
+<K>false</K>.
+
+<P/>
+
+Default: <K>false</K>.
+</Item>
+<Mark>
 <Index Key='HistoryMaxLines'><C>HistoryMaxLines</C></Index>
 <Index Key='SaveAndRestoreHistory'><C>SaveAndRestoreHistory</C></Index>
 <C>HistoryMaxLines</C>,

--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -64,6 +64,18 @@ readline support.",
   default := "default",
   ) );
 
+DeclareUserPreference( rec(
+  name:= "HistoryBackwardSearchSkipIdenticalEntries",
+  description:= [
+    "When a command is executed multiple times, it is also stored in history \
+multiple times. Setting this option to <K>true</K> skips identical entries \
+when searching backwards in history."
+    ],
+  default:= false,
+  values:= [ true, false ],
+  multi:= false,
+  ) );
+
 
 if GAPInfo.CommandLineOptions.E then
 ############################################################################
@@ -543,6 +555,9 @@ GAPInfo.CommandLineEditFunctions.Functions.BackwardHistory := function(l)
   while n > 1 do
     n := n - 1;
     if PositionSublist(hist[n], start) = 1 then
+      if UserPreference("HistoryBackwardSearchSkipIdenticalEntries") and hist[n] = l[3] then
+        continue;
+      fi;
       GAPInfo.History.Pos := n;
       GAPInfo.History.Last := n;
       return [1, Length(l[3])+1, hist[n], l[4]];


### PR DESCRIPTION
When debugging loops/recursion using break loops I often find myself in the following situation:
I type some initial command which triggers a loop or recursion with an `Error` inside. Now I type `return;` until the loop/recursion is a the point I want to debug. I fix something in the code and repeat.

Now if I open a new GAP session, the history is full of repeated `return;` entries, so I have to press "arrow up" many times before I reach my original command.

This PR adds a user preference "HistoryBackwardSearchSkipIdenticalEntries":
Setting this option to <K>true</K> ensures that during a
backward search a history item is selected which actually changes the
currently displayed line. Note: This does not affect forward searches.

## Text for release notes

Add user preference `HistoryBackwardSearchSkipIdenticalEntries`

When a command is executed multiple times, it is also stored in history
multiple times. Setting this option to <K>true</K> skips identical entries
when searching backwards in history.