### PR TITLE
Fix hang in objset/objmap when filled up with dirty objects

### DIFF
--- a/src/objset.c
+++ b/src/objset.c
@@ -206,8 +206,8 @@ static void CheckObjSetForCleanUp(Obj set, UInt expand)
   UInt dirty = CONST_ADDR_WORD(set)[OBJSET_DIRTY];
   if (used * 3 >= size * 2)
     ResizeObjSet(set, bits+1);
-  else if (dirty && dirty >= used)
-    ResizeObjSet(set, bits);
+  else if (dirty && (dirty >= used || (dirty + used) * 3 >= size * 2))
+      ResizeObjSet(set, bits);
 }
 
 /**
@@ -476,8 +476,8 @@ static void CheckObjMapForCleanUp(Obj map, UInt expand)
   UInt dirty = ADDR_WORD(map)[OBJSET_DIRTY];
   if (used * 3 >= size * 2)
     ResizeObjMap(map, bits+1);
-  else if (dirty && dirty >= used)
-    ResizeObjMap(map, bits);
+  else if (dirty && (dirty >= used || (dirty + used) * 3 >= size * 2))
+      ResizeObjMap(map, bits);
 }
 
 /**


### PR DESCRIPTION
In some rare cases it was possible for objsets and objmaps to fill up with dirty objects.

This seems to require just the right combination of dirty locations being reused, so it's hard to make a repeatable test, but the code below hangs for me on GAP master, and is fixed with this PR.

```
makeObjMap := function(f)
local map, size, i, l, t;
map := OBJ_MAP();
size := Random([1..1000]);
for i in [1..size] do
	l := [Random([1..1000]), "abc"];
	t := [Random([1..1000]), "abc"];
	ADD_OBJ_MAP(map, l, t);
	if Random([1..5]) < 2 then
		REMOVE_OBJ_MAP(map, l);
	fi;
od;
return map;
end;
List([1..1000], makeObjMap);
```