### PR TITLE
Stop calling CHANGED_BAG during workspace restore, as it can cause crashes

### DIFF
--- a/src/gasman.c
+++ b/src/gasman.c
@@ -958,6 +958,13 @@ Bag * GlobalByCookie(
 
 static Bag NextMptrRestoring;
 
+#ifdef GAP_KERNEL_DEBUG
+BOOL InWorkspaceRestore(void)
+{
+    return NextMptrRestoring != 0;
+}
+#endif
+
 void StartRestoringBags( UInt nBags, UInt maxSize)
 {
   UInt target;
@@ -1036,6 +1043,7 @@ void FinishedRestoringBags( void )
   SizeDeadBags = 0;
   NrHalfDeadBags = 0;
   ChangedBags = 0;
+  NextMptrRestoring = 0;
 }
 
 
@@ -1360,6 +1368,8 @@ Bag NewBag (
     CollectBags(0,0);
 #endif
 
+    GAP_ASSERT(!InWorkspaceRestore());
+
     CANARY_DISABLE_VALGRIND();
 
     // check that a masterpointer and enough storage are available
@@ -1537,6 +1547,8 @@ UInt ResizeBag (
 #ifdef TREMBLE_HEAP
     CollectBags(0,0);
 #endif
+
+    GAP_ASSERT(!InWorkspaceRestore());
 
     CANARY_DISABLE_VALGRIND();
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -388,8 +388,14 @@ void CHANGED_BAG(Bag b);
 
 extern Bag * YoungBags;
 extern Bag   ChangedBags;
+
+#ifdef GAP_KERNEL_DEBUG
+BOOL         InWorkspaceRestore(void);
+#endif
+
 EXPORT_INLINE void CHANGED_BAG(Bag bag)
 {
+    GAP_ASSERT(!InWorkspaceRestore());
     if (CONST_PTR_BAG(bag) <= YoungBags && LINK_BAG(bag) == bag) {
         LINK_BAG(bag) = ChangedBags;
         ChangedBags = bag;

--- a/src/objset.c
+++ b/src/objset.c
@@ -351,7 +351,6 @@ void ClearObjSet(Obj set) {
   GAP_ASSERT(TNUM_OBJ(set) == T_OBJSET);
   Obj new = NewObjSet();
   SwapMasterPoint(set, new);
-  CHANGED_BAG(set);
 }
 
 /**
@@ -408,7 +407,6 @@ static void ResizeObjSet(Obj set, UInt bits)
     }
   }
   SwapMasterPoint(set, new);
-  CHANGED_BAG(set);
 }
 
 #ifdef GAP_ENABLE_SAVELOAD
@@ -730,8 +728,6 @@ static void ResizeObjMap(Obj map, UInt bits)
     }
   }
   SwapMasterPoint(map, new);
-  CHANGED_BAG(map);
-  CHANGED_BAG(new);
 }
 
 #ifdef GAP_ENABLE_SAVELOAD


### PR DESCRIPTION
While we are loading a workspace, gasman is kept in a slightly-inconsistent state, with various pointers only set at the end. This means we mustn't call functions like NewBag, ResizeBag and (the problem we were hitting, subtly), CHANGED_BAG.

This stops objset/objmap from calling CHANGED_BAG, and adds asserts to make sure this doesn't happen again in future (and verifies nothing else is calling any of these methods).