### PR TITLE
use `MutableCopyMatrix` not `MutableCopyMat`

### DIFF
--- a/doc/ref/obsolete.xml
+++ b/doc/ref/obsolete.xml
@@ -158,8 +158,12 @@ Here are some further name changes.
   <Item><Ref Func="MonomialExtGrlexLess"/></Item>
 </Row>
 <Row>
-  <Item><C>NormedVectors</C><Index Key="NormedVectors"><C>NormedVectors</C></Index></Item>
-  <Item><Ref Attr="NormedRowVectors"/></Item>
+  <Item><C>MultRowVector</C><Index Key="MultRowVector"><C>MultRowVector</C></Index></Item>
+  <Item><Ref Oper="MultVectorLeft"/></Item>
+</Row>
+<Row>
+  <Item><C>MutableCopyMat</C><Index Key="MutableCopyMat"><C>MutableCopyMat</C></Index></Item>
+  <Item><Ref Oper="MutableCopyMatrix" Label="for a matrix object"/></Item>
 </Row>
 <Row>
   <Item><C>MutableIdentityMat</C><Index Key="MutableIdentityMat"><C>MutableIdentityMat</C></Index></Item>
@@ -170,8 +174,8 @@ Here are some further name changes.
   <Item><Ref Func="NullMat"/></Item>
 </Row>
 <Row>
-  <Item><C>MultRowVector</C><Index Key="MultRowVector"><C>MultRowVector</C></Index></Item>
-  <Item><Ref Oper="MultVectorLeft"/></Item>
+  <Item><C>NormedVectors</C><Index Key="NormedVectors"><C>NormedVectors</C></Index></Item>
+  <Item><Ref Attr="NormedRowVectors"/></Item>
 </Row>
 <Row>
   <Item><C>RadicalGroup</C><Index Key="RadicalGroup"><C>RadicalGroup</C></Index></Item>

--- a/grp/basicmat.gi
+++ b/grp/basicmat.gi
@@ -419,7 +419,7 @@ SylowSubgroupOfTorusOfNaturalGL := function( gl, pi, p )
   gens := List( orbs, function( orb )
     local k, mat;
     k := Size(orb);
-    mat := MutableCopyMat( one );
+    mat := MutableCopyMatrix( one );
     mat{orb}{orb} := CompanionMat( MinimalPolynomial( gfq, Z(q^k) ) )^( (q^k-1)/p^PadicValuation(q^k-1,p));
     return ImmutableMatrix( gfq, mat, true );
   end );
@@ -474,7 +474,7 @@ SylowSubgroupOfNaturalGL := function( gl, p )
       then return List( GeneratorsOfGroup( syl1 ),
         function( x )
           local mat;
-          mat := MutableCopyMat( one );
+          mat := MutableCopyMatrix( one );
           mat{part}{part} := x ;
           return mat;
         end );
@@ -483,13 +483,13 @@ SylowSubgroupOfNaturalGL := function( gl, p )
       return Concatenation(
         List( GeneratorsOfGroup( prm ), function( x )
           local mat;
-          mat := MutableCopyMat( one );
+          mat := MutableCopyMatrix( one );
           mat{part}{part} := KroneckerProduct( PermutationMat( x, Size( part )/2, GF( q ) ), One( syl2 ) );
           return mat;
         end ),
         List( GeneratorsOfGroup( syl2 ), function( x )
           local mat;
-          mat := MutableCopyMat( one );
+          mat := MutableCopyMatrix( one );
           mat{part{[1..2]}}{part{[1..2]}} := x;
           return mat;
         end ) );

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1030,7 +1030,7 @@ InstallMethodWithRandomSource( Randomize,
     for i in [1..Length(v)] do v[i] := Random(rs,l); od;
     return v;
   end );
-InstallMethod( MutableCopyMat, "for an 8bit matrix",
+InstallMethod( MutableCopyMatrix, "for an 8bit matrix",
   [ Is8BitMatrixRep ],
   function( m )
     local mm;

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2377,7 +2377,7 @@ InstallMethodWithRandomSource( Randomize,
     return v;
   end );
 
-InstallMethod( MutableCopyMat, "for a gf2 matrix",
+InstallMethod( MutableCopyMatrix, "for a gf2 matrix",
   [ IsGF2MatrixRep ],
   function( m )
     local mm;

--- a/lib/algmat.gi
+++ b/lib/algmat.gi
@@ -1241,7 +1241,7 @@ InstallGlobalFunction( FullMatrixFLMLOR, function( R, n )
           A;      # algebra, result
 
     gens:= NullMat( n, n, R );
-    gens:= [ gens, MutableCopyMat( gens ) ];
+    gens:= [ gens, MutableCopyMatrix( gens ) ];
     one:= One( R );
 
     # Construct the generators.
@@ -1284,17 +1284,17 @@ InstallGlobalFunction( FullMatrixLieFLMLOR, function( F, n )
     one:= One( F );
 
 
-    gen:= MutableCopyMat( null );
+    gen:= MutableCopyMatrix( null );
     gen[1,1]:= one;
     gens:= [ LieObject( gen ) ];
 
     for i in [ 2 .. n ] do
 
-      gen:= MutableCopyMat( null );
+      gen:= MutableCopyMatrix( null );
       gen[1,i]:= one;
       Add( gens, LieObject( gen ) );
 
-      gen:= MutableCopyMat( null );
+      gen:= MutableCopyMatrix( null );
       gen[i,1]:= one;
       Add( gens, LieObject( gen ) );
 

--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -973,7 +973,7 @@ local fam;
   end );
 
 
-InstallMethod( MutableCopyMat, "for a zmodnz matrix",
+InstallMethod( MutableCopyMatrix, "for a zmodnz matrix",
   [ IsZmodnZMatrixRep ],
   function( m )
     local l,res;
@@ -1357,7 +1357,7 @@ InstallMethod( InverseSameMutability, "for a zmodnz matrix",
 
 InstallMethod( RankMat, "for a zmodnz matrix", [ IsZmodnZMatrixRep ],
 function( m )
-  m:=MutableCopyMat(m);
+  m:=MutableCopyMatrix(m);
   m:=SemiEchelonMatDestructive(m);
   if m<>fail then m:=Length(m.vectors);fi;
   return m;

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1529,10 +1529,6 @@ DeclareGlobalFunction( "IdentityMat" );
 ##
 DeclareOperation( "MutableCopyMatrix", [ IsList ] );
 
-#T for backwards compatibility,
-#T but note that 'MutableCopyMat' was not documented
-DeclareSynonym( "MutableCopyMat", MutableCopyMatrix );
-
 
 #############################################################################
 ##

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -769,6 +769,23 @@ DeclareObsoleteSynonym( "RadicalGroup", "SolvableRadical" );
 
 #############################################################################
 ##
+#O  MutableCopyMat( <mat> )
+##
+##  Moved to obsoletes in February 2023.
+##
+##  Still used in corelg, crisp, cryst, cubefree, cvec, fining, forms, genss,
+##  guava, hap, hapcryst, lpres, matricesforhomalg, modisom, polycyclic,
+##  recog, semigroups, smallsemi, sophus (02/2023)
+##
+##  (We cannot use 'DeclareObsoleteSynonym' because the cvec package wants to
+##  install a method for 'MutableCopyMat', thus 'MutableCopyMat' must be an
+##  operation.)
+##
+DeclareSynonym( "MutableCopyMat", MutableCopyMatrix );
+
+
+#############################################################################
+##
 ##  Not used in any redistributed package
 DeclareObsoleteSynonym( "ZeroSM", "ZeroSameMutability" );
 DeclareObsoleteSynonym( "AdditiveInverseSM", "AdditiveInverseSameMutability" );

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -985,7 +985,7 @@ InstallMethodWithRandomSource( Randomize,
     for i in [1..Length(v)] do v[i] := Random(rs,l); od;
     return v;
   end );
-InstallMethod( MutableCopyMat, "for an 8bit matrix",
+InstallMethod( MutableCopyMatrix, "for an 8bit matrix",
   [ Is8BitMatrixRep ],
   function( m )
     local mm;

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2380,7 +2380,7 @@ InstallMethodWithRandomSource( Randomize,
     return v;
   end );
 
-InstallMethod( MutableCopyMat, "for a gf2 matrix",
+InstallMethod( MutableCopyMatrix, "for a gf2 matrix",
   [ IsGF2MatrixRep ],
   function( m )
     local mm;

--- a/tst/testbugfix/2005-08-26-t00100.tst
+++ b/tst/testbugfix/2005-08-26-t00100.tst
@@ -1,3 +1,3 @@
 # 2005/08/26 (Max)
-gap> IsOperation(MutableCopyMat);
+gap> IsOperation(MutableCopyMatrix);
 true


### PR DESCRIPTION
As suggested in the discussion of #5352,
`MutableCopyMat` is just an (obsolete) synonym of `MutableCopyMatrix` and therefore `MutableCopyMat` should not be used in GAP library code.