### PR TITLE
matrix/vector objects: use tag based operations not constructors

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -250,6 +250,9 @@ The installations of default methods can be found in the file
 <F>lib/matobj.gi</F> of the &GAP; distribution.
 There one can check for which operations it makes sense to overload them
 for the new type of vector or matrix objects.
+Note that the specific methods must be installed with
+<Ref Func="InstallTagBasedMethod"/> whenever the default method is installed
+with this function.
 
 <P/>
 
@@ -277,9 +280,9 @@ for the new type of vector or matrix objects.
   <Ref Attr="ConstructingFilter" Label="for a vector object"/>,
 </Item>
 <Item>
-  <Ref Oper="NewVector"/> and <Ref Oper="NewZeroVector"/>
+  <Ref Oper="NewVector"/>
   (with consistency checks if the global option <C>check</C> is not set to
-  <K>false</K>).
+  <K>false</K>, install the method with <Ref Func="InstallTagBasedMethod"/>).
 </Item>
 </List>
 
@@ -315,10 +318,9 @@ for the new type of vector or matrix objects.
   <Ref Attr="CompatibleVectorFilter" Label="for a matrix object"/>,
 </Item>
 <Item>
-  <Ref Oper="NewMatrix"/>, <Ref Oper="NewIdentityMatrix"/>,
-  and <Ref Oper="NewZeroMatrix"/>,
+  <Ref Oper="NewMatrix"/>
   (with consistency checks if the global option <C>check</C> is not set to
-  <K>false</K>).
+  <K>false</K>, install the method with <Ref Func="InstallTagBasedMethod"/>).
 </Item>
 </List>
 

--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -277,7 +277,7 @@ for the new type of vector or matrix objects.
   <Ref Attr="ConstructingFilter" Label="for a vector object"/>,
 </Item>
 <Item>
-  <Ref Constr="NewVector"/> and <Ref Constr="NewZeroVector"/>
+  <Ref Oper="NewVector"/> and <Ref Oper="NewZeroVector"/>
   (with consistency checks if the global option <C>check</C> is not set to
   <K>false</K>).
 </Item>
@@ -315,8 +315,8 @@ for the new type of vector or matrix objects.
   <Ref Attr="CompatibleVectorFilter" Label="for a matrix object"/>,
 </Item>
 <Item>
-  <Ref Constr="NewMatrix"/>, <Ref Constr="NewIdentityMatrix"/>,
-  and <Ref Constr="NewZeroMatrix"/>,
+  <Ref Oper="NewMatrix"/>, <Ref Oper="NewIdentityMatrix"/>,
+  and <Ref Oper="NewZeroMatrix"/>,
   (with consistency checks if the global option <C>check</C> is not set to
   <K>false</K>).
 </Item>
@@ -324,8 +324,8 @@ for the new type of vector or matrix objects.
 
 <P/>
 
-Methods for the constructors <Ref Constr="NewVector"/> and
-<Ref Constr="NewMatrix"/> must check their arguments for consistency
+Methods for <Ref Oper="NewVector"/> and
+<Ref Oper="NewMatrix"/> must check their arguments for consistency
 (do the given filter and base domain fit together,
 are the entries compatible with the given base domain,
 is the number of matrix entries a multiple of the given number of columns)
@@ -340,8 +340,8 @@ such as <Ref Oper="\[\]\:\=" Label="for a vector object and an integer"/>,
 and for those methods of
 <Ref Oper="Vector" Label="for filter, base domain, and list"/> and
 <Ref Oper="Matrix" Label="for filter, base domain, list, ncols"/>
-that do not delegate to <Ref Constr="NewVector"/> and
-<Ref Constr="NewMatrix"/>, respectively.
+that do not delegate to <Ref Oper="NewVector"/> and
+<Ref Oper="NewMatrix"/>, respectively.
 
 </Section>
 

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1145,6 +1145,7 @@ InstallTagBasedMethod( NewVector,
     return CopyToVectorRep(l,Size(f));
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroVector,
   Is8BitVectorRep,
   function( filter, f, i )
@@ -1169,6 +1170,7 @@ InstallTagBasedMethod( NewMatrix,
     return m;
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
   Is8BitMatrixRep,
   function( filter, f, rows, cols )
@@ -1186,18 +1188,6 @@ InstallTagBasedMethod( NewZeroMatrix,
     od;
     ConvertToMatrixRepNC(m,Size(f));
     return m;
-  end );
-
-InstallTagBasedMethod( NewIdentityMatrix,
-  Is8BitMatrixRep,
-  function( filter, basedomain, dim )
-    local mat, one, i;
-    mat := NewZeroMatrix(filter, basedomain, dim, dim);
-    one := One(basedomain);
-    for i in [1..dim] do
-        mat[i,i] := one;
-    od;
-    return mat;
   end );
 
 InstallMethod( ChangedBaseDomain, "for an 8bit vector and a finite field",
@@ -1243,25 +1233,4 @@ InstallMethod( DistanceOfVectors, "for two 8bit vectors",
   [ Is8BitVectorRep, Is8BitVectorRep ],
   function( v, w )
     return DistanceVecFFE(v,w);
-  end );
-
-InstallTagBasedMethod( NewCompanionMatrix,
-  Is8BitMatrixRep,
-  function( ty, po, bd )
-    local i,l,ll,n,one;
-    one := One(bd);
-    l := CoefficientsOfUnivariatePolynomial(po);
-    n := Length(l)-1;
-    if not IsOne(l[n+1]) then
-        Error("CompanionMatrix: polynomial is not monic");
-        return fail;
-    fi;
-    l := -l{[1..n]};
-    ConvertToVectorRep(l,Size(bd));
-    ll := NewMatrix(ty,bd,n,[l]);
-    for i in [1..n-1] do
-        Add(ll,ZeroMutable(l),i);
-        ll[i][i+1] := one;
-    od;
-    return ll;
   end );

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1136,17 +1136,17 @@ InstallMethod( BaseField, "for a compressed 8bit matrix",
 InstallMethod( BaseField, "for a compressed 8bit vector",
   [Is8BitVectorRep], function(v) return GF(Q_VEC8BIT(v)); end );
 
-InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
-  [ Is8BitVectorRep, IsField and IsFinite, IsList ],
+InstallTagBasedMethod( NewVector,
+  Is8BitVectorRep,
   function( filter, f, l )
-    if not Size(f) in [3..256] then
+    if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitVectorRep only supports base fields with 3 to 256 elements");
     fi;
     return CopyToVectorRep(l,Size(f));
   end );
 
-InstallMethod( NewZeroVector, "for Is8BitVectorRep, GF(q), and an int",
-  [ Is8BitVectorRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewZeroVector,
+  Is8BitVectorRep,
   function( filter, f, i )
     local v;
     if not Size(f) in [3..256] then
@@ -1157,11 +1157,11 @@ InstallMethod( NewZeroVector, "for Is8BitVectorRep, GF(q), and an int",
     return v;
   end );
 
-InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsList ],
+InstallTagBasedMethod( NewMatrix,
+  Is8BitMatrixRep,
   function( filter, f, rl, l )
     local m;
-    if not Size(f) in [3..256] then
+    if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");
     fi;
     m := List(l,ShallowCopy);
@@ -1169,8 +1169,8 @@ InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
     return m;
   end );
 
-InstallMethod( NewZeroMatrix, "for Is8BitMatrixRep, GF(q), and two ints",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsInt ],
+InstallTagBasedMethod( NewZeroMatrix,
+  Is8BitMatrixRep,
   function( filter, f, rows, cols )
     local m,i;
     if not Size(f) in [3..256] then
@@ -1188,8 +1188,8 @@ InstallMethod( NewZeroMatrix, "for Is8BitMatrixRep, GF(q), and two ints",
     return m;
   end );
 
-InstallMethod( NewIdentityMatrix, "for Is8BitMatrixRep, GF(q), and an int",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  Is8BitMatrixRep,
   function( filter, basedomain, dim )
     local mat, one, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);
@@ -1245,9 +1245,8 @@ InstallMethod( DistanceOfVectors, "for two 8bit vectors",
     return DistanceVecFFE(v,w);
   end );
 
-InstallMethod( NewCompanionMatrix,
-  "for Is8BitMatrixRep, a polynomial and a ring",
-  [ Is8BitMatrixRep, IsUnivariatePolynomial, IsRing ],
+InstallTagBasedMethod( NewCompanionMatrix,
+  Is8BitMatrixRep,
   function( ty, po, bd )
     local i,l,ll,n,one;
     one := One(bd);

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2523,6 +2523,7 @@ InstallTagBasedMethod( NewMatrix,
     return m;
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
   IsGF2MatrixRep,
   function( filter, f, rows, cols )
@@ -2537,18 +2538,6 @@ InstallTagBasedMethod( NewZeroMatrix,
     od;
     ConvertToMatrixRepNC(m,2);
     return m;
-  end );
-
-InstallTagBasedMethod( NewIdentityMatrix,
-  IsGF2MatrixRep,
-  function( filter, basedomain, dim )
-    local mat, one, i;
-    mat := NewZeroMatrix(filter, basedomain, dim, dim);
-    one := One(basedomain);
-    for i in [1..dim] do
-        mat[i,i] := one;
-    od;
-    return mat;
   end );
 
 InstallMethod( ChangedBaseDomain, "for a gf2 vector and a finite field",
@@ -2594,25 +2583,4 @@ InstallMethod( DistanceOfVectors, "for two gf2 vectors",
   [ IsGF2VectorRep, IsGF2VectorRep ],
   function( v, w )
     return DistanceVecFFE(v,w);
-  end );
-
-InstallTagBasedMethod( NewCompanionMatrix,
-  IsGF2MatrixRep,
-  function( ty, po, bd )
-    local i,l,ll,n,one;
-    one := One(bd);
-    l := CoefficientsOfUnivariatePolynomial(po);
-    n := Length(l)-1;
-    if not IsOne(l[n+1]) then
-        Error("CompanionMatrix: polynomial is not monic");
-        return fail;
-    fi;
-    l := -l{[1..n]};
-    ConvertToVectorRep(l,2);
-    ll := NewMatrix(ty,bd,n,[l]);
-    for i in [1..n-1] do
-        Add(ll,ZeroMutable(l),i);
-        ll[i,i+1] := one;
-    od;
-    return ll;
   end );

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2499,22 +2499,22 @@ InstallMethod( BaseField, "for a compressed gf2 matrix",
 InstallMethod( BaseField, "for a compressed gf2 vector",
   [IsGF2VectorRep], function(v) return GF(2); end );
 
-InstallMethod( NewVector, "for IsGF2VectorRep, GF(2), and a list",
-  [ IsGF2VectorRep, IsField and IsFinite, IsList ],
+InstallTagBasedMethod( NewVector,
+  IsGF2VectorRep,
   function( filter, f, l )
     if Size(f) <> 2 then Error("IsGF2VectorRep only supported over GF(2)"); fi;
     return CopyToVectorRep(l,2);
   end );
 
-InstallMethod( NewZeroVector, "for IsGF2VectorRep, GF(2), and an int",
-  [ IsGF2VectorRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewZeroVector,
+  IsGF2VectorRep,
   function( filter, f, i )
     if Size(f) <> 2 then Error("IsGF2VectorRep only supported over GF(2)"); fi;
     return ZERO_GF2VEC_2(i);
   end );
 
-InstallMethod( NewMatrix, "for IsGF2MatrixRep, GF(2), an int, and a list",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt, IsList ],
+InstallTagBasedMethod( NewMatrix,
+  IsGF2MatrixRep,
   function( filter, f, rl, l )
     local m;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
@@ -2523,8 +2523,8 @@ InstallMethod( NewMatrix, "for IsGF2MatrixRep, GF(2), an int, and a list",
     return m;
   end );
 
-InstallMethod( NewZeroMatrix, "for IsGF2MatrixRep, GF(2), and two ints",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt, IsInt ],
+InstallTagBasedMethod( NewZeroMatrix,
+  IsGF2MatrixRep,
   function( filter, f, rows, cols )
     local m,i;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
@@ -2539,8 +2539,8 @@ InstallMethod( NewZeroMatrix, "for IsGF2MatrixRep, GF(2), and two ints",
     return m;
   end );
 
-InstallMethod( NewIdentityMatrix, "for IsGF2MatrixRep, GF(2), and an int",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  IsGF2MatrixRep,
   function( filter, basedomain, dim )
     local mat, one, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);
@@ -2596,9 +2596,8 @@ InstallMethod( DistanceOfVectors, "for two gf2 vectors",
     return DistanceVecFFE(v,w);
   end );
 
-InstallMethod( NewCompanionMatrix,
-  "for IsGF2MatrixRep, a polynomial and a ring",
-  [ IsGF2MatrixRep, IsUnivariatePolynomial, IsRing ],
+InstallTagBasedMethod( NewCompanionMatrix,
+  IsGF2MatrixRep,
   function( ty, po, bd )
     local i,l,ll,n,one;
     one := One(bd);

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -57,8 +57,7 @@ DeclareCategory( "IsVecOrMatObj", IsObject );
 ##  Typically, <M>R</M> will be at least a semiring.
 ##  <P/>
 ##  For creating new vector objects compatible with <M>v</M>,
-##  the constructor <Ref Constr="NewVector"/>
-##  requires that also the value of
+##  <Ref Oper="NewVector"/> requires that also the value of
 ##  <Ref Attr="ConstructingFilter" Label="for a vector object"/>
 ##  is known for <M>v</M>.
 ##  <P/>
@@ -181,8 +180,7 @@ InstallTrueMethod( IsMatrixOrMatrixObj, IsMatrix );
 ##  Typically, <M>R</M> will be at least a semiring.
 ##  <P/>
 ##  For creating new matrix objects compatible with <M>M</M>,
-##  the constructor <Ref Constr="NewMatrix"/>
-##  requires that also the value of
+##  <Ref Oper="NewMatrix"/> requires that also the value of
 ##  <Ref Attr="ConstructingFilter" Label="for a matrix object"/>
 ##  is known for <M>M</M>.
 ##  <P/>

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1180,7 +1180,7 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 #############################################################################
 ##
 #O  CompanionMatrix( <pol>, <M> )
-#O  CompanionMatrix( <filt>, <pol>, <R> )
+#O  CompanionMatrix( [<filt>, ]<pol>, <R> )
 ##
 ##  <#GAPDoc Label="MatObj_CompanionMatrix">
 ##  <ManSection>
@@ -1189,6 +1189,8 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##   Label="for polynomial and matrix object"/>
 ##  <Oper Name="CompanionMatrix" Arg='filt, pol, R'
 ##   Label="for filter, polynomial, and semiring"/>
+##  <Oper Name="CompanionMatrix" Arg='pol, R'
+##   Label="for polynomial and semiring"/>
 ##
 ##  <Returns>a matrix object</Returns>
 ##  <Description>
@@ -1208,6 +1210,13 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  <Ref Attr="ConstructingFilter" Label="for a matrix object"/> value
 ##  <A>filt</A> and
 ##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value <A>R</A>.
+##  <P/>
+##  If only <A>pol</A> and a semiring <A>R</A> are given,
+##  the representation of the result is guessed from <A>R</A>.
+##  <P/>
+##  If the <Ref Attr="ConstructingFilter" Label="for a matrix object"/>
+##  value of the result implies <Ref Filt="IsCopyable"/> then the result is
+##  fully mutable.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1216,7 +1225,8 @@ DeclareOperation( "CompanionMatrix",
     [ IsUnivariatePolynomial, IsMatrixOrMatrixObj ] );
 DeclareOperation( "CompanionMatrix",
     [ IsOperation, IsUnivariatePolynomial, IsSemiring ] );
-#T tag based?
+DeclareOperation( "CompanionMatrix",
+    [ IsUnivariatePolynomial, IsSemiring ] );
 
 
 #############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -14,7 +14,7 @@
 ##  This file together with 'matobj1.gd' formally define the interface to
 ##  those vector and matrix objects in GAP that are not represented
 ##  by plain lists.
-##  In this file all the operations, attributes and constructors are defined.
+##  In this file all the operations and attributes are defined.
 ##  It is read later in the GAP library reading process.
 ##
 
@@ -190,7 +190,7 @@ DeclareAttribute( "Length", IsVectorObj );
 ##  respectively,
 ##  <Ref Attr="ConstructingFilter" Label="for a vector object"/> returns
 ##  a filter <C>f</C> such that when
-##  <Ref Constr="NewVector"/> or <Ref Constr="NewMatrix"/>, respectively,
+##  <Ref Oper="NewVector"/> or <Ref Oper="NewMatrix"/>, respectively,
 ##  is called with <C>f</C> then a vector object or a matrix object,
 ##  respectively, in the same representation as the argument is produced.
 ##  <P/>
@@ -203,8 +203,6 @@ DeclareAttribute( "Length", IsVectorObj );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "ConstructingFilter", IsVecOrMatObj );
-#DeclareAttribute( "ConstructingFilter", IsVectorObj );
-#DeclareAttribute( "ConstructingFilter", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -592,7 +590,7 @@ DeclareOperation( "ScalarProduct", [ IsVectorObj, IsVectorObj ] );
 ##  <P/>
 ##  Default methods for
 ##  <Ref Oper="ZeroVector" Label="for filter, base domain and length"/>
-##  delegate to <Ref Constr="NewZeroVector"/>.
+##  delegate to <Ref Oper="NewZeroVector"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -679,7 +677,7 @@ DeclareOperation( "ZeroVector", [ IsInt, IsVecOrMatObj ] );
 ##  <P/>
 ##  Default methods for
 ##  <Ref Oper="Vector" Label="for filter, base domain, and list"/>
-##  delegate to <Ref Constr="NewVector"/>.
+##  delegate to <Ref Oper="NewVector"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -701,13 +699,13 @@ DeclareOperation( "Vector", [ IsList ] );
 ##  <#GAPDoc Label="NewVector">
 ##  <ManSection>
 ##  <Heading>NewVector and NewZeroVector</Heading>
-##  <Constr Name="NewVector" Arg='filt,R,list'/>
-##  <Constr Name="NewZeroVector" Arg='filt,R,n'/>
+##  <Oper Name="NewVector" Arg='filt,R,list'/>
+##  <Oper Name="NewZeroVector" Arg='filt,R,n'/>
 ##
 ##  <Description>
 ##  For a filter <A>filt</A>, a semiring <A>R</A>, and a list <A>list</A>
 ##  of elements that belong to <A>R</A>,
-##  <Ref Constr="NewVector"/> returns a vector object which has
+##  <Ref Oper="NewVector"/> returns a vector object which has
 ##  the <Ref Attr="ConstructingFilter" Label="for a vector object"/>
 ##  <A>filt</A>,
 ##  the <Ref Attr="BaseDomain" Label="for a vector object"/> <A>R</A>,
@@ -715,9 +713,9 @@ DeclareOperation( "Vector", [ IsList ] );
 ##  The list <A>list</A> is guaranteed not to be changed by this operation.
 ##  <P/>
 ##  If the global option <C>check</C> is set to <K>false</K> then
-##  <Ref Constr="NewVector"/> need not perform consistency checks.
+##  <Ref Oper="NewVector"/> need not perform consistency checks.
 ##  <P/>
-##  Similarly, <Ref Constr="NewZeroVector"/> returns a vector object
+##  Similarly, <Ref Oper="NewZeroVector"/> returns a vector object
 ##  of length <A>n</A> which has <A>filt</A> and <A>R</A> as
 ##  <Ref Attr="ConstructingFilter" Label="for a vector object"/> and
 ##  <Ref Attr="BaseDomain" Label="for a vector object"/> values,
@@ -725,17 +723,14 @@ DeclareOperation( "Vector", [ IsList ] );
 ##  <P/>
 ##  The returned object is mutable if and only if <A>filt</A> implies
 ##  <Ref Filt="IsCopyable"/>.
-##  <P/>
-##  Since <Ref Constr="NewVector"/> and <Ref Constr="NewZeroVector"/>
-##  are constructors
-##  (see <Ref Sect="Constructors"/>), they cannot have default methods.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareConstructor( "NewVector", [ IsVectorObj, IsSemiring, IsList ] );
+DeclareTagBasedOperation( "NewVector", [ IsOperation, IsSemiring, IsList ] );
 
-DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
+DeclareTagBasedOperation( "NewZeroVector",
+    [ IsOperation, IsSemiring, IsInt ] );
 
 
 #############################################################################
@@ -747,14 +742,14 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  <#GAPDoc Label="NewMatrix">
 ##  <ManSection>
 ##  <Heading>NewMatrix, NewZeroMatrix, NewIdentityMatrix</Heading>
-##  <Constr Name="NewMatrix" Arg='filt,R,ncols,list'/>
-##  <Constr Name="NewZeroMatrix" Arg='filt,R,m,n'/>
-##  <Constr Name="NewIdentityMatrix" Arg='filt,R,n'/>
+##  <Oper Name="NewMatrix" Arg='filt,R,ncols,list'/>
+##  <Oper Name="NewZeroMatrix" Arg='filt,R,m,n'/>
+##  <Oper Name="NewIdentityMatrix" Arg='filt,R,n'/>
 ##
 ##  <Description>
 ##  For a filter <A>filt</A>, a semiring <A>R</A>,
 ##  a positive integer <A>ncols</A>, and a list <A>list</A>,
-##  <Ref Constr="NewMatrix"/> returns a matrix object which has
+##  <Ref Oper="NewMatrix"/> returns a matrix object which has
 ##  the <Ref Attr="ConstructingFilter" Label="for a vector object"/>
 ##  <A>filt</A>,
 ##  the <Ref Attr="BaseDomain" Label="for a matrix object"/> <A>R</A>,
@@ -771,15 +766,15 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  If <A>list</A> already contains vector objects, they are copied.
 ##  <P/>
 ##  If the global option <C>check</C> is set to <K>false</K> then
-##  <Ref Constr="NewMatrix"/> need not perform consistency checks.
+##  <Ref Oper="NewMatrix"/> need not perform consistency checks.
 ##  <P/>
-##  Similarly, <Ref Constr="NewZeroMatrix"/> returns a zero matrix
+##  Similarly, <Ref Oper="NewZeroMatrix"/> returns a zero matrix
 ##  object with <A>m</A> rows and <A>n</A> columns
 ##  which has <A>filt</A> and <A>R</A> as
 ##  <Ref Attr="ConstructingFilter" Label="for a vector object"/> and
 ##  <Ref Attr="BaseDomain" Label="for a vector object"/> values.
 ##  <P/>
-##  Similarly, <Ref Constr="NewIdentityMatrix"/> returns an identity
+##  Similarly, <Ref Oper="NewIdentityMatrix"/> returns an identity
 ##  matrix object with <A>n</A> rows and columns
 ##  which has <A>filt</A> and <A>R</A> as
 ##  <Ref Attr="ConstructingFilter" Label="for a vector object"/> and
@@ -789,21 +784,18 @@ DeclareConstructor( "NewZeroVector", [ IsVectorObj, IsSemiring, IsInt ] );
 ##  <P/>
 ##  The returned object is mutable if and only if <A>filt</A> implies
 ##  <Ref Filt="IsCopyable"/>.
-##  <P/>
-##  Since <Ref Constr="NewMatrix"/>, <Ref Constr="NewZeroMatrix"/>, and
-##  <Ref Constr="NewIdentityMatrix"/> are constructors
-##  (see <Ref Sect="Constructors"/>), they cannot have default methods.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareConstructor( "NewMatrix", [ IsMatrixOrMatrixObj, IsSemiring, IsInt, IsList] );
+DeclareTagBasedOperation( "NewMatrix",
+    [ IsOperation, IsSemiring, IsInt, IsList] );
 
-DeclareConstructor( "NewZeroMatrix",
-    [ IsMatrixOrMatrixObj, IsSemiring, IsInt, IsInt ] );
+DeclareTagBasedOperation( "NewZeroMatrix",
+    [ IsOperation, IsSemiring, IsInt, IsInt ] );
 
-DeclareConstructor( "NewIdentityMatrix",
-    [ IsMatrixOrMatrixObj, IsSemiring, IsInt ] );
+DeclareTagBasedOperation( "NewIdentityMatrix",
+    [ IsOperation, IsSemiring, IsInt ] );
 
 
 #############################################################################
@@ -1128,7 +1120,7 @@ DeclareSynonym( "SetMatElm", ASS_MAT );
 ##  <P/>
 ##  Default methods for
 ##  <Ref Oper="ZeroMatrix" Label="for dimensions and matrix object"/>
-##  delegate to <Ref Constr="NewZeroMatrix"/>.
+##  delegate to <Ref Oper="NewZeroMatrix"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1175,7 +1167,7 @@ DeclareOperation( "ZeroMatrix", [ IsOperation, IsSemiring, IsInt, IsInt ] );
 ##  <P/>
 ##  Default methods for
 ##  <Ref Oper="IdentityMatrix" Label="for dimension and matrix object"/>
-##  delegate to <Ref Constr="NewIdentityMatrix"/>.
+##  delegate to <Ref Oper="NewIdentityMatrix"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1220,13 +1212,11 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-##  (The variant with filter and semiring is used as a simpler alternative
-##  to a possible constructor 'NewCompanionMatrix'.)
-##
 DeclareOperation( "CompanionMatrix",
     [ IsUnivariatePolynomial, IsMatrixOrMatrixObj ] );
 DeclareOperation( "CompanionMatrix",
     [ IsOperation, IsUnivariatePolynomial, IsSemiring ] );
+#T tag based?
 
 
 #############################################################################
@@ -1317,7 +1307,7 @@ DeclareOperation( "CompanionMatrix",
 ##  <P/>
 ##  Default methods for
 ##  <Ref Oper="Matrix" Label="for filter, base domain, list, ncols"/>
-##  delegate to <Ref Constr="NewMatrix"/>.
+##  delegate to <Ref Oper="NewMatrix"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1797,8 +1787,8 @@ DeclareSynonymAttr( "RowLength", NumberColumns );
 ##  'CompanionMatrix' which admits a filter as its first argument.
 ##  We should use 'CompanionMatrix' instead of 'NewCompanionMatrix'.
 ##
-DeclareConstructor( "NewCompanionMatrix",
-    [ IsMatrixOrMatrixObj, IsUnivariatePolynomial, IsSemiring ] );
+DeclareTagBasedOperation( "NewCompanionMatrix",
+    [ IsOperation, IsUnivariatePolynomial, IsSemiring ] );
 
 
 #############################################################################

--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -39,8 +39,8 @@ InstallMethod( CompatibleVectorFilter, "zmodnz",
 # Vectors
 ############################################################################
 
-InstallMethod( NewVector, "for IsZmodnZVectorRep, a ring, and a list",
-  [ IsZmodnZVectorRep, IsRing, IsList ],
+InstallTagBasedMethod( NewVector,
+  IsZmodnZVectorRep,
   function( filter, basedomain, l )
     local check, typ, v;
     check:= ValueOption( "check" ) <> false;
@@ -63,8 +63,8 @@ InstallMethod( NewVector, "for IsZmodnZVectorRep, a ring, and a list",
     return v;
   end );
 
-InstallMethod( NewZeroVector, "for IsZmodnZVectorRep, a ring, and an int",
-  [ IsZmodnZVectorRep, IsRing, IsInt ],
+InstallTagBasedMethod( NewZeroVector,
+  IsZmodnZVectorRep,
   function( filter, basedomain, l )
     local check, typ, v;
     check:= ValueOption( "check" ) <> false;
@@ -611,9 +611,8 @@ end);
 # Matrices
 ############################################################################
 
-InstallMethod( NewMatrix,
-  "for IsZmodnZMatrixRep, a ring, an int, and a list",
-  [ IsZmodnZMatrixRep, IsRing, IsInt, IsList ],
+InstallTagBasedMethod( NewMatrix,
+  IsZmodnZMatrixRep,
   function( filter, basedomain, rl, l )
     local check, nd, filterVectors, m, e, filter2, i;
 
@@ -656,9 +655,8 @@ InstallMethod( NewMatrix,
     return m;
   end );
 
-InstallMethod( NewZeroMatrix,
-  "for IsZmodnZMatrixRep, a ring, and two ints",
-  [ IsZmodnZMatrixRep, IsRing, IsInt, IsInt ],
+InstallTagBasedMethod( NewZeroMatrix,
+  IsZmodnZMatrixRep,
   function( filter, basedomain, rows, cols )
     local check, m,i,e,filter2;
 
@@ -680,9 +678,8 @@ InstallMethod( NewZeroMatrix,
     return m;
   end );
 
-InstallMethod( NewIdentityMatrix,
-  "for IsZmodnZMatrixRep, a ring, and an int",
-  [ IsZmodnZMatrixRep, IsRing, IsInt ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  IsZmodnZMatrixRep,
   function( filter, basedomain, dim )
     local mat, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);

--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -655,6 +655,7 @@ InstallTagBasedMethod( NewMatrix,
     return m;
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
   IsZmodnZMatrixRep,
   function( filter, basedomain, rows, cols )
@@ -678,12 +679,12 @@ InstallTagBasedMethod( NewZeroMatrix,
     return m;
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewIdentityMatrix,
   IsZmodnZMatrixRep,
   function( filter, basedomain, dim )
     local mat, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);
-#    one := One(basedomain);
     for i in [1..dim] do
         mat[i,i] := 1;
     od;

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -174,22 +174,22 @@ BindGlobal( "MakeIsPlistMatrixRep",
 # Constructor methods:
 ############################################################################
 
-InstallMethod( NewVector,
-  [ "IsPlistVectorRep", "IsRing", "IsDenseList" ],
+InstallTagBasedMethod( NewVector,
+  IsPlistVectorRep,
   function( filter, basedomain, list )
     return MakeIsPlistVectorRep(basedomain, ShallowCopy(list), true);
   end );
 
-InstallMethod( NewZeroVector,
-  [ "IsPlistVectorRep", "IsRing", "IsInt" ],
+InstallTagBasedMethod( NewZeroVector,
+  IsPlistVectorRep,
   function( filter, basedomain, len )
     local list;
     list := ListWithIdenticalEntries(len, Zero(basedomain));
     return MakeIsPlistVectorRep(basedomain, list, false);
   end );
 
-InstallMethod( NewMatrix,
-  [ "IsPlistMatrixRep", "IsRing", "IsInt", "IsList" ],
+InstallTagBasedMethod( NewMatrix,
+  IsPlistMatrixRep,
   function( filter, basedomain, ncols, list )
     local nd, filterVectors, m, e, i;
 
@@ -219,8 +219,8 @@ InstallMethod( NewMatrix,
     return MakeIsPlistMatrixRep( basedomain, e, ncols, m, true );
   end );
 
-InstallMethod( NewZeroMatrix,
-  [ "IsPlistMatrixRep", "IsRing", "IsInt", "IsInt" ],
+InstallTagBasedMethod( NewZeroMatrix,
+  IsPlistMatrixRep,
   function( filter, basedomain, rows, cols )
     local m,i,e,filter2;
     filter2 := IsPlistVectorRep;
@@ -232,8 +232,8 @@ InstallMethod( NewZeroMatrix,
     return MakeIsPlistMatrixRep( basedomain, e, cols, m, false );
   end );
 
-InstallMethod( NewIdentityMatrix,
-  [ "IsPlistMatrixRep", "IsRing", "IsInt" ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  IsPlistMatrixRep,
   function( filter, basedomain, dim )
     local mat, one, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);
@@ -1331,8 +1331,8 @@ InstallMethod( CompatibleVector,
   [ "IsPlistMatrixRep" ],
   M -> NewZeroVector( IsPlistVectorRep, BaseDomain( M ), NumberRows( M ) ) );
 
-InstallMethod( NewCompanionMatrix,
-  [ "IsPlistMatrixRep", "IsUnivariatePolynomial", "IsRing" ],
+InstallTagBasedMethod( NewCompanionMatrix,
+  IsPlistMatrixRep,
   function( filter, po, bd )
     local i,l,ll,n,one;
     one := One(bd);

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -219,6 +219,7 @@ InstallTagBasedMethod( NewMatrix,
     return MakeIsPlistMatrixRep( basedomain, e, ncols, m, true );
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
   IsPlistMatrixRep,
   function( filter, basedomain, rows, cols )
@@ -230,18 +231,6 @@ InstallTagBasedMethod( NewZeroMatrix,
         m[i] := ZeroVector( cols, e );
     od;
     return MakeIsPlistMatrixRep( basedomain, e, cols, m, false );
-  end );
-
-InstallTagBasedMethod( NewIdentityMatrix,
-  IsPlistMatrixRep,
-  function( filter, basedomain, dim )
-    local mat, one, i;
-    mat := NewZeroMatrix(filter, basedomain, dim, dim);
-    one := One(basedomain);
-    for i in [1..dim] do
-        mat[i,i] := one;
-    od;
-    return mat;
   end );
 
 
@@ -1331,24 +1320,3 @@ InstallMethod( CompatibleVector,
   [ "IsPlistMatrixRep" ],
   M -> NewZeroVector( IsPlistVectorRep, BaseDomain( M ), NumberRows( M ) ) );
 
-InstallTagBasedMethod( NewCompanionMatrix,
-  IsPlistMatrixRep,
-  function( filter, po, bd )
-    local i,l,ll,n,one;
-    one := One(bd);
-    l := CoefficientsOfUnivariatePolynomial(po);
-    n := Length(l)-1;
-    if not IsOne(l[n+1]) then
-        Error("CompanionMatrix: polynomial is not monic");
-        return fail;
-    fi;
-    ll := NewMatrix(IsPlistMatrixRep,bd,n,[]);
-    l := Vector(-l{[1..n]},CompatibleVector(ll));
-    for i in [1..n-1] do
-        Add(ll,ZeroMutable(l));
-        ll[i][i+1] := one;
-    od;
-    Add(ll,l);
-    return ll;
-  end );
-#T deprecated, see matobj2.gd -> remove this and other existing methods?

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1363,14 +1363,14 @@ InstallOtherMethod( ConstructingFilter,
 ##  (Strictly speaking, 'NewZeroMatrix' and 'NewIdentityMatrix' are not
 ##  defined for this situation, since they promise to return matrix objects.)
 ##
-InstallOtherMethod( NewZeroMatrix,
-  [ "IsPlistRep", "IsSemiring", "IsInt", "IsInt" ],
+InstallTagBasedMethod( NewZeroMatrix,
+  IsPlistRep,
   function( filter, basedomain, nrows, ncols )
     return NullMat( nrows, ncols, basedomain );
   end );
 
-InstallOtherMethod( NewIdentityMatrix,
-  [ "IsPlistRep", "IsSemiring", "IsInt" ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  IsPlistRep,
   function( filter, basedomain, dim )
     return IdentityMat( dim, basedomain );
   end );

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1091,8 +1091,8 @@ InstallMethod( BaseField, "for a compressed 8bit matrix",
 InstallMethod( BaseField, "for a compressed 8bit vector",
   [Is8BitVectorRep], function(v) return GF(Q_VEC8BIT(v)); end );
 
-InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
-  [ Is8BitVectorRep, IsField and IsFinite, IsList ],
+InstallTagBasedMethod( NewVector,
+  Is8BitVectorRep,
   function( filter, f, l )
     if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitVectorRep only supports base fields with 3 to 256 elements");
@@ -1100,8 +1100,8 @@ InstallMethod( NewVector, "for Is8BitVectorRep, GF(q), and a list",
     return CopyToVectorRep(l,Size(f));
   end );
 
-InstallMethod( NewZeroVector, "for Is8BitVectorRep, GF(q), and an int",
-  [ Is8BitVectorRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewZeroVector,
+  Is8BitVectorRep,
   function( filter, f, i )
     local v;
     if not Size(f) in [3..256] then
@@ -1112,8 +1112,8 @@ InstallMethod( NewZeroVector, "for Is8BitVectorRep, GF(q), and an int",
     return v;
   end );
 
-InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsList ],
+InstallTagBasedMethod( NewMatrix,
+  Is8BitMatrixRep,
   function( filter, f, rl, l )
     local m;
     if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
@@ -1124,8 +1124,8 @@ InstallMethod( NewMatrix, "for Is8BitMatrixRep, GF(q), an int, and a list",
     return m;
   end );
 
-InstallMethod( NewZeroMatrix, "for Is8BitMatrixRep, GF(q), and two ints",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt, IsInt ],
+InstallTagBasedMethod( NewZeroMatrix,
+  Is8BitMatrixRep,
   function( filter, f, rows, cols )
     local m,i;
     if not Size(f) in [3..256] then
@@ -1143,8 +1143,8 @@ InstallMethod( NewZeroMatrix, "for Is8BitMatrixRep, GF(q), and two ints",
     return m;
   end );
 
-InstallMethod( NewIdentityMatrix, "for Is8BitMatrixRep, GF(q), and an int",
-  [ Is8BitMatrixRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  Is8BitMatrixRep,
   function( filter, basedomain, dim )
     local mat, one, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);
@@ -1200,9 +1200,8 @@ InstallMethod( DistanceOfVectors, "for two 8bit vectors",
     return DistanceVecFFE(v,w);
   end );
 
-InstallMethod( NewCompanionMatrix,
-  "for Is8BitMatrixRep, a polynomial and a ring",
-  [ Is8BitMatrixRep, IsUnivariatePolynomial, IsRing ],
+InstallTagBasedMethod( NewCompanionMatrix,
+  Is8BitMatrixRep,
   function( ty, po, bd )
     local i,l,ll,n,one;
     one := One(bd);

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1100,6 +1100,7 @@ InstallTagBasedMethod( NewVector,
     return CopyToVectorRep(l,Size(f));
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroVector,
   Is8BitVectorRep,
   function( filter, f, i )
@@ -1124,6 +1125,7 @@ InstallTagBasedMethod( NewMatrix,
     return m;
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
   Is8BitMatrixRep,
   function( filter, f, rows, cols )
@@ -1141,18 +1143,6 @@ InstallTagBasedMethod( NewZeroMatrix,
     od;
     ConvertToMatrixRepNC(m,Size(f));
     return m;
-  end );
-
-InstallTagBasedMethod( NewIdentityMatrix,
-  Is8BitMatrixRep,
-  function( filter, basedomain, dim )
-    local mat, one, i;
-    mat := NewZeroMatrix(filter, basedomain, dim, dim);
-    one := One(basedomain);
-    for i in [1..dim] do
-        mat[i,i] := one;
-    od;
-    return mat;
   end );
 
 InstallMethod( ChangedBaseDomain, "for an 8bit vector and a finite field",
@@ -1198,25 +1188,4 @@ InstallMethod( DistanceOfVectors, "for two 8bit vectors",
   [ Is8BitVectorRep, Is8BitVectorRep ],
   function( v, w )
     return DistanceVecFFE(v,w);
-  end );
-
-InstallTagBasedMethod( NewCompanionMatrix,
-  Is8BitMatrixRep,
-  function( ty, po, bd )
-    local i,l,ll,n,one;
-    one := One(bd);
-    l := CoefficientsOfUnivariatePolynomial(po);
-    n := Length(l)-1;
-    if not IsOne(l[n+1]) then
-        Error("CompanionMatrix: polynomial is not monic");
-        return fail;
-    fi;
-    l := -l{[1..n]};
-    ConvertToVectorRep(l,Size(bd));
-    ll := NewMatrix(ty,bd,n,[l]);
-    for i in [1..n-1] do
-        Add(ll,ZeroMutable(l),i);
-        ll[i][i+1] := one;
-    od;
-    return ll;
   end );

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2526,6 +2526,7 @@ InstallTagBasedMethod( NewMatrix,
     return m;
   end );
 
+# This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
   IsGF2MatrixRep,
   function( filter, f, rows, cols )
@@ -2540,18 +2541,6 @@ InstallTagBasedMethod( NewZeroMatrix,
     od;
     ConvertToMatrixRepNC(m,2);
     return m;
-  end );
-
-InstallTagBasedMethod( NewIdentityMatrix,
-  IsGF2MatrixRep,
-  function( filter, basedomain, dim )
-    local mat, one, i;
-    mat := NewZeroMatrix(filter, basedomain, dim, dim);
-    one := One(basedomain);
-    for i in [1..dim] do
-        mat[i,i] := one;
-    od;
-    return mat;
   end );
 
 InstallMethod( ChangedBaseDomain, "for a gf2 vector and a finite field",
@@ -2597,25 +2586,4 @@ InstallMethod( DistanceOfVectors, "for two gf2 vectors",
   [ IsGF2VectorRep, IsGF2VectorRep ],
   function( v, w )
     return DistanceVecFFE(v,w);
-  end );
-
-InstallTagBasedMethod( NewCompanionMatrix,
-  IsGF2MatrixRep,
-  function( ty, po, bd )
-    local i,l,ll,n,one;
-    one := One(bd);
-    l := CoefficientsOfUnivariatePolynomial(po);
-    n := Length(l)-1;
-    if not IsOne(l[n+1]) then
-        Error("CompanionMatrix: polynomial is not monic");
-        return fail;
-    fi;
-    l := -l{[1..n]};
-    ConvertToVectorRep(l,2);
-    ll := NewMatrix(ty,bd,n,[l]);
-    for i in [1..n-1] do
-        Add(ll,ZeroMutable(l),i);
-        ll[i,i+1] := one;
-    od;
-    return ll;
   end );

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2502,22 +2502,22 @@ InstallMethod( BaseField, "for a compressed gf2 matrix",
 InstallMethod( BaseField, "for a compressed gf2 vector",
   [IsGF2VectorRep], function(v) return GF(2); end );
 
-InstallMethod( NewVector, "for IsGF2VectorRep, GF(2), and a list",
-  [ IsGF2VectorRep, IsField and IsFinite, IsList ],
+InstallTagBasedMethod( NewVector,
+  IsGF2VectorRep,
   function( filter, f, l )
     if Size(f) <> 2 then Error("IsGF2VectorRep only supported over GF(2)"); fi;
     return CopyToVectorRep(l,2);
   end );
 
-InstallMethod( NewZeroVector, "for IsGF2VectorRep, GF(2), and an int",
-  [ IsGF2VectorRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewZeroVector,
+  IsGF2VectorRep,
   function( filter, f, i )
     if Size(f) <> 2 then Error("IsGF2VectorRep only supported over GF(2)"); fi;
     return ZERO_GF2VEC_2(i);
   end );
 
-InstallMethod( NewMatrix, "for IsGF2MatrixRep, GF(2), an int, and a list",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt, IsList ],
+InstallTagBasedMethod( NewMatrix,
+  IsGF2MatrixRep,
   function( filter, f, rl, l )
     local m;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
@@ -2526,8 +2526,8 @@ InstallMethod( NewMatrix, "for IsGF2MatrixRep, GF(2), an int, and a list",
     return m;
   end );
 
-InstallMethod( NewZeroMatrix, "for IsGF2MatrixRep, GF(2), and two ints",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt, IsInt ],
+InstallTagBasedMethod( NewZeroMatrix,
+  IsGF2MatrixRep,
   function( filter, f, rows, cols )
     local m,i;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
@@ -2542,8 +2542,8 @@ InstallMethod( NewZeroMatrix, "for IsGF2MatrixRep, GF(2), and two ints",
     return m;
   end );
 
-InstallMethod( NewIdentityMatrix, "for IsGF2MatrixRep, GF(2), and an int",
-  [ IsGF2MatrixRep, IsField and IsFinite, IsInt ],
+InstallTagBasedMethod( NewIdentityMatrix,
+  IsGF2MatrixRep,
   function( filter, basedomain, dim )
     local mat, one, i;
     mat := NewZeroMatrix(filter, basedomain, dim, dim);
@@ -2599,9 +2599,8 @@ InstallMethod( DistanceOfVectors, "for two gf2 vectors",
     return DistanceVecFFE(v,w);
   end );
 
-InstallMethod( NewCompanionMatrix,
-  "for IsGF2MatrixRep, a polynomial and a ring",
-  [ IsGF2MatrixRep, IsUnivariatePolynomial, IsRing ],
+InstallTagBasedMethod( NewCompanionMatrix,
+  IsGF2MatrixRep,
   function( ty, po, bd )
     local i,l,ll,n,one;
     one := One(bd);

--- a/tst/testinstall/MatrixObj/CompanionMatrix.tst
+++ b/tst/testinstall/MatrixObj/CompanionMatrix.tst
@@ -1,0 +1,149 @@
+gap> START_TEST("CompanionMatrix.tst");
+gap> ReadGapRoot("tst/testinstall/MatrixObj/testmatobj.g");
+
+#
+# IsGF2MatrixRep
+#
+gap> F:= GF(2);;  x:= X(F);;
+gap> TestCompanionMatrix(IsGF2MatrixRep, x+1, F);
+<a 1x1 matrix over GF2>
+gap> TestCompanionMatrix(IsGF2MatrixRep, x^2+x+1, F);
+<a 2x2 matrix over GF2>
+
+# test error handling
+gap> TestCompanionMatrix(IsGF2MatrixRep, Zero(x), F);
+Error, NewCompanionMatrix: degree of <pol> must be at least 1
+gap> TestCompanionMatrix(IsGF2MatrixRep, One(x), F);
+Error, NewCompanionMatrix: degree of <pol> must be at least 1
+
+#
+# Is8BitMatrixRep
+#
+gap> F:= GF(3);;  x:= X(F);;
+gap> TestCompanionMatrix(Is8BitMatrixRep, x+1, F);
+[ [ Z(3) ] ]
+gap> TestCompanionMatrix(Is8BitMatrixRep, x^2+x+1, F);
+[ [ 0*Z(3), Z(3)^0 ], [ Z(3), Z(3) ] ]
+
+# test error handling
+gap> TestCompanionMatrix(Is8BitMatrixRep, Zero(x), F);
+Error, NewCompanionMatrix: degree of <pol> must be at least 1
+gap> TestCompanionMatrix(Is8BitMatrixRep, One(x), F);
+Error, NewCompanionMatrix: degree of <pol> must be at least 1
+
+#
+gap> F:= GF(251);;  x:= X(F);;
+gap> TestCompanionMatrix(Is8BitMatrixRep, x+1, F);
+[ [ Z(251)^125 ] ]
+gap> TestCompanionMatrix(Is8BitMatrixRep, x^2+x+1, F);
+[ [ 0*Z(251), Z(251)^0 ], [ Z(251)^125, Z(251)^125 ] ]
+
+# test error handling
+gap> TestCompanionMatrix(Is8BitMatrixRep, Zero(x), F);
+Error, NewCompanionMatrix: degree of <pol> must be at least 1
+gap> TestCompanionMatrix(Is8BitMatrixRep, One(x), F);
+Error, NewCompanionMatrix: degree of <pol> must be at least 1
+
+#
+# IsPlistMatrixRep
+#
+gap> F:= GF(251);;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistMatrixRep, x+1, F);
+<1x1-matrix over GF(251)>
+gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
+<2x2-matrix over GF(251)>
+
+#
+gap> F:= Integers;;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistMatrixRep, x+1, F);
+<1x1-matrix over Integers>
+gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
+<2x2-matrix over Integers>
+
+#
+gap> F:= Rationals;;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistMatrixRep, x+1, F);
+<1x1-matrix over Rationals>
+gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
+<2x2-matrix over Rationals>
+
+#
+# IsPlistRep
+#
+gap> F:= GF(251);;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistRep, x+1, F);
+[ [ Z(251)^125 ] ]
+gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
+[ [ 0*Z(251), Z(251)^0 ], [ Z(251)^125, Z(251)^125 ] ]
+
+#
+gap> F:= Integers;;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistRep, x+1, F);
+Error, Assertion failure
+gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
+Error, Assertion failure
+
+#
+gap> F:= Rationals;;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistRep, x+1, F);
+[ [ -1 ] ]
+gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
+[ [ 0, 1 ], [ -1, -1 ] ]
+
+#
+gap> F:= Integers mod 4;;  x:= X(F);;
+gap> TestCompanionMatrix(IsPlistRep, x+1, F);
+[ [ ZmodnZObj( 3, 4 ) ] ]
+gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
+[ [ ZmodnZObj( 0, 4 ), ZmodnZObj( 1, 4 ) ], 
+  [ ZmodnZObj( 3, 4 ), ZmodnZObj( 3, 4 ) ] ]
+
+#
+# Test CompanionMatrix variant which "guesses" a suitable representation, i.e.:
+#    CompanionMatrix( <pol>, <R> )
+#
+
+#
+gap> F:= GF(2);;  x:= X(F);;
+gap> CompanionMatrix(x+1, F);
+<a 1x1 matrix over GF2>
+gap> CompanionMatrix(x^2+x+1, F);
+<a 2x2 matrix over GF2>
+
+#
+gap> F:= GF(3);;  x:= X(F);;
+gap> CompanionMatrix(x+1, F);
+[ [ Z(3) ] ]
+gap> CompanionMatrix(x^2+x+1, F);
+[ [ 0*Z(3), Z(3)^0 ], [ Z(3), Z(3) ] ]
+
+#
+gap> F:= GF(4);;  x:= X(F);;
+gap> CompanionMatrix(x+1, F);
+[ [ Z(2)^0 ] ]
+gap> CompanionMatrix(x^2+x+1, F);
+[ [ 0*Z(2), Z(2)^0 ], [ Z(2)^0, Z(2)^0 ] ]
+
+#
+gap> F:= Integers;;  x:= X(F);;
+gap> CompanionMatrix(x+1, F);
+<1x1-matrix over Integers>
+gap> CompanionMatrix(x^2+x+1, F);
+<2x2-matrix over Integers>
+
+#
+gap> F:= Rationals;;  x:= X(F);;
+gap> CompanionMatrix(x+1, F);
+<1x1-matrix over Rationals>
+gap> CompanionMatrix(x^2+x+1, F);
+<2x2-matrix over Rationals>
+
+#
+gap> F:= Integers mod 4;;  x:= X(F);;
+gap> CompanionMatrix(x+1, F);
+<1x1-matrix over (Integers mod 4)>
+gap> CompanionMatrix(x^2+x+1, F);
+<2x2-matrix over (Integers mod 4)>
+
+#
+gap> STOP_TEST("CompanionMatrix.tst");

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -56,6 +56,31 @@ TestIdentityMatrix := function(filt, ring, degree)
   return mat;
 end;
 
+TestCompanionMatrix := function(filt, pol, ring)
+  local degree, mat, i, j, mat2;
+
+  degree:= Degree(pol);
+  mat:= CompanionMatrix(filt, pol, ring);
+  Assert(0, filt(mat) = true);
+  Assert(0, BaseDomain(mat) = ring);
+  Assert(0, NrRows(mat) = degree);
+  Assert(0, NrCols(mat) = degree);
+  for i in [1..degree-1] do
+    for j in [1..degree] do
+      if i+1<>j and not IsZero(mat[i,j]) then
+        Error("entry ", i,",",j," is not zero");
+      elif i+1=j and not IsOne(mat[i,j]) then
+        Error("entry ", i,",",j," is not one");
+      fi;
+    od;
+  od;
+  mat2 := CompanionMatrix(pol, mat);
+  if mat <> mat2 then Error("CompanionMatrix(pol, mat) differs"); fi;
+  mat2 := NewCompanionMatrix(filt, pol, ring);
+  if mat <> mat2 then Error("NewCompanionMatrix(filt, pol, ring) differs"); fi;
+  return mat;
+end;
+
 TestElementaryTransforms := function(mat, scalar)
     local i, j, copy, eq;
     Assert(0, NrRows(mat) >= 2);


### PR DESCRIPTION
This is a follow-up of pull request #5344:

Turned `NewCompanionMatrix`, `NewIdentityMatrix`, `NewMatrix`, `NewVector`, `NewZeroMatrix`, `NewZeroVector` from constructors to tag based operations.

Default methods for these operations are now available; the available (and up to now necessary) specific methods have been kept, except for the `NewCompanionMatrix` and `NewIdentityMatrix` methods, for which the default methods do not create unnecessary copies.

The documentation can be changed accordingly.

~The current changes are breaking the current cvec package.
See gap-packages/cvec/pull/41 for a pull request for cvec that fixes the problem.~
Meanwhile the cvec package has been adjusted to the changes from this pull request.
(Let us see which tests are still failing.)