### PR TITLE
Improve linker flags for kernel extensions under Cygwin

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -292,7 +292,7 @@ GAP_LIBS += $(LIBS)
 #
 ifneq (,$(findstring cygwin,$(host_os)))
   GAC_CFLAGS =
-  GAC_LDFLAGS = -shared -Wl,$(abs_builddir)/bin/$(GAPARCH)/gap.dll
+  GAC_LDFLAGS = -shared -Wl,$(abs_builddir)/bin/$(GAPARCH)/gap.dll -Wl,--enable-auto-image-base
   # Note: the above won't be correct after "make install"; but then I am not
   # sure we care about "make install" on Cygwin, so I am not going to work on
   # this until someone specifically asks for it (and even then I'll require


### PR DESCRIPTION
Adding `-Wl,--enable-auto-image-base` seems to help avoid problems when forking a GAP with loaded kernel extensions under Cygwin

See https://github.com/semigroups/Semigroups/pull/902

CC @ChrisJefferson 