### PR TITLE
Add user preference "ShortBanners"

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -1113,7 +1113,7 @@ it may produce the output looking like this:
 <Log><![CDATA[
 gap> ShowPackageVariables("example");
 ----------------------------------------------------------------
-Loading  Example 3.3 (Example/Template of a GAP Package)
+Loading Example 3.3 (Example/Template of a GAP Package)
 by Werner Nickel (http://www.mathematik.tu-darmstadt.de/~nickel),
    Greg Gamble (http://www.math.rwth-aachen.de/~Greg.Gamble), and
    Alexander Konovalov (http://www.cs.st-andrews.ac.uk/~alexk/).

--- a/doc/ref/user_pref_list.xml
+++ b/doc/ref/user_pref_list.xml
@@ -246,6 +246,24 @@ Admissible values:
 Default: <K>false</K>.
 </Item>
 <Mark>
+<Index Key='ShortBanners'><C>ShortBanners</C></Index>
+<C>ShortBanners</C>
+</Mark>
+<Item>
+If this option is set to <K>true</K>, package banners printed during loading
+will only show the name, version and description of a package.
+
+<P/>
+
+Admissible values:
+<K>true</K>,
+<K>false</K>.
+
+<P/>
+
+Default: <K>false</K>.
+</Item>
+<Mark>
 <Index Key='UseColorPrompt'><C>UseColorPrompt</C></Index>
 <C>UseColorPrompt</C>
 </Mark>

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -532,12 +532,15 @@ DeclareGlobalFunction( "IsPackageMarkedForLoading" );
 #F  DefaultPackageBannerString( <inforec> )
 ##
 ##  <ManSection>
-##  <Func Name="DefaultPackageBannerString" Arg='inforec'/>
+##  <Func Name="DefaultPackageBannerString" Arg='inforec[, useShortBanner]'/>
 ##
 ##  <Description>
 ##  For a record <A>inforec</A> as stored in the <F>PackageInfo.g</F> file
 ##  of a &GAP; package,
 ##  this function returns a string denoting a banner for the package.
+##  If the optional argument <A>useShortBanner</A> is set to <K>true</K>,
+##  only the first line of the default banner (including the name, version and
+##  description of the package) is returned.
 ##  </Description>
 ##  </ManSection>
 ##

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1124,7 +1124,7 @@ InstallGlobalFunction( DefaultPackageBannerString, function( inforec )
     # Add package name and version number.
     if IsBound( inforec.PackageName ) and IsBound( inforec.Version ) then
       Append( str, Concatenation(
-              "Loading  ", inforec.PackageName, " ", inforec.Version ) );
+              "Loading ", inforec.PackageName, " ", inforec.Version ) );
     fi;
 
     # Add the long title.

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -68,7 +68,7 @@ gap> pkginfo := rec(
 # just one author & maintainer
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth).
 Homepage: https://www.gap-system.org
 -----------------------------------------------------------------------------
@@ -80,7 +80,7 @@ gap> Add(pkginfo.Persons, rec( IsAuthor := false, IsMaintainer := true,
 >                           Email := "luke.skywalker@gap-system.org" ));
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth).
 maintained by:
    Lord Vader (https://www.gap-system.org/~darth) and
@@ -94,7 +94,7 @@ gap> Add(pkginfo.Persons, rec( IsAuthor := true, IsMaintainer := false,
 >                           FirstNames := "Leia", LastName := "Organa" ));
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth) and
    Leia Organa.
 maintained by:
@@ -110,7 +110,7 @@ gap> Add(pkginfo.Persons, rec( IsAuthor := false, IsMaintainer := false,
 >                           WWWHome := "https://www.gap-system.org/~yoda"));
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth) and
    Leia Organa.
 with contributions by:
@@ -126,7 +126,7 @@ Homepage: https://www.gap-system.org
 gap> for p in pkginfo.Persons do p.IsAuthor:=true; p.IsMaintainer:=true; od;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth),
    Luke Skywalker (luke.skywalker@gap-system.org),
    Leia Organa, and
@@ -139,7 +139,7 @@ Homepage: https://www.gap-system.org
 gap> for p in pkginfo.Persons do p.IsAuthor:=true; p.IsMaintainer:=false; od;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 by Lord Vader (https://www.gap-system.org/~darth),
    Luke Skywalker (luke.skywalker@gap-system.org),
    Leia Organa, and
@@ -152,7 +152,7 @@ Homepage: https://www.gap-system.org
 gap> for p in pkginfo.Persons do p.IsAuthor:=false; p.IsMaintainer:=true; od;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 maintained by:
    Lord Vader (https://www.gap-system.org/~darth),
    Luke Skywalker (luke.skywalker@gap-system.org),
@@ -166,7 +166,7 @@ Homepage: https://www.gap-system.org
 gap> for p in pkginfo.Persons do p.IsAuthor:=false; p.IsMaintainer:=false; od;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 with contributions by:
    Lord Vader (https://www.gap-system.org/~darth),
    Luke Skywalker (luke.skywalker@gap-system.org),
@@ -180,7 +180,7 @@ Homepage: https://www.gap-system.org
 gap> pkginfo.IssueTrackerURL := "https://issues.gap-system.org/";;
 gap> Display(DefaultPackageBannerString(pkginfo));
 -----------------------------------------------------------------------------
-Loading  TestPkg 1.0 (A test package)
+Loading TestPkg 1.0 (A test package)
 with contributions by:
    Lord Vader (https://www.gap-system.org/~darth),
    Luke Skywalker (luke.skywalker@gap-system.org),


### PR DESCRIPTION
If this option is set to <K>true</K>, package banners printed during
loading will only show the name, version and description of a package.

Rationale: The package banners contain lots of information which one usually does not need during development (authors, homepage, link to the issue tracker) and which clutters the terminal, sometimes hiding information which one would actually need (like syntax warnings/errors).

The first commit simply removes a duplicate whitespace. If this whitespace is deliberate, I can of course add it back, although I would suggest to remove it at least for the short banners because I think it looks a bit out of place there.

## Text for release notes

Add user preference "ShortBanners"

If this option is set to `true`, package banners printed during
loading will only show the name, version and description of a package.