### PR TITLE
add a fallback method for `NiceMonomorphism`

### DIFF
--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -496,3 +496,7 @@ RedispatchOnCondition( IsomorphismPcGroup, true,
 RedispatchOnCondition( CompositionSeries, true,
     [ IsCyclotomicMatrixGroup ],
     [ IsFinite ], 0 );
+
+RedispatchOnCondition( NiceMonomorphism, true,
+    [ IsCyclotomicMatrixGroup ],
+    [ IsFinite ], 0 );

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -49,5 +49,10 @@ false
 gap> IsTransitive( Image( IsomorphismPermGroup( SO( 1, 8, 2 ) ) ) );
 true
 
+# 'NiceMonomorphism' shall work for finite rational matrix groups,
+# also if they do not know yet that they are finite.
+gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;
+gap> NiceMonomorphism( G );;
+
 #
-gap> STOP_TEST( "grpmat.tst", 1);
+gap> STOP_TEST( "grpmat.tst" );


### PR DESCRIPTION
`NiceMonomorphism` shall work for finite rational matrix groups, also if they do not know yet that they are finite.

(The problem had be mentioned in a message by Hongyi Zhao in a message to the GAP Forum.)