### PR TITLE
Align PrintString for empty lists with PrintObj, ViewString and ViewObj

### DIFF
--- a/lib/string.g
+++ b/lib/string.g
@@ -306,7 +306,7 @@ InstallMethod( String,
     [ IsString ],
     function(s)
       if Length(s) = 0 and not IsStringRep(s) then
-        return "[ ]";
+        return "[  ]";
       else
         return s;
       fi;

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -130,9 +130,9 @@ gap> DisplayString(x);
 gap> ViewString(x);
 "[  ]"
 gap> PrintString(x);
-"[ ]"
+"[  ]"
 gap> String(x);
-"[ ]"
+"[  ]"
 
 # Dense list
 gap> x:=[1,2,3];


### PR DESCRIPTION
PrintObj, ViewString and ViewObj all return/print two spaces.

I fear that this change might break too many packages but I wanted to bring it up for a quick discussion.

## Text for release notes

`String` and `PrintString` of empty lists now contain two empty spaces