### PR TITLE
specified/unified the definition of `CompanionMatrix`, adjusted the method for it

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -553,10 +553,10 @@ InstallTagBasedMethod( NewCompanionMatrix,
     fi;
     mat:= NewZeroMatrix( filter, basedomain, n, n );
     for i in [ 1 .. n-1 ] do
-      mat[i,i+1]:= one;
+      mat[i+1,i]:= one;
     od;
     for i in [ 1 .. n ] do
-      mat[n,i]:= - l[i];
+      mat[i,n]:= - l[i];
     od;
 
     return mat;

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1226,6 +1226,7 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  [[ 0*Z(5), 0*Z(5), Z(5) ]
 ##   [ Z(5)^0, 0*Z(5), Z(5)^3 ]
 ##   [ 0*Z(5), Z(5)^0, Z(5)^2 ]
+##  ]>
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1202,8 +1202,8 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  <Ref Attr="ConstructingFilter" Label="for a matrix object"/> and
 ##  <Ref Attr="BaseDomain" Label="for a matrix object"/> values as <A>M</A>.
 ##  <P/>
-##  We use row convention, that is, the negatives of the coefficients of
-##  <A>pol</A> appear in the last row of the result.
+##  We use column convention, that is, the negatives of the coefficients of
+##  <A>pol</A> appear in the last column of the result.
 ##  <P/>
 ##  If a filter <A>filt</A> and a semiring <A>R</A> are given then the
 ##  companion matrix is returned as a matrix object with
@@ -1217,6 +1217,16 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  If the <Ref Attr="ConstructingFilter" Label="for a matrix object"/>
 ##  value of the result implies <Ref Filt="IsCopyable"/> then the result is
 ##  fully mutable.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> x:= X( GF(5) );;  pol:= x^3 + x^2 + 2*x + 3;;
+##  gap> M:= CompanionMatrix( IsPlistMatrixRep, pol, GF(25) );;
+##  gap> Display( M );
+##  <3x3-matrix over GF(5^2):
+##  [[ 0*Z(5), 0*Z(5), Z(5) ]
+##   [ Z(5)^0, 0*Z(5), Z(5)^3 ]
+##   [ 0*Z(5), Z(5)^0, Z(5)^2 ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -1789,13 +1799,22 @@ DeclareSynonymAttr( "RowLength", NumberColumns );
 
 #############################################################################
 ##
-#O  NewCompanionMatrix( ... )
+#O  NewCompanionMatrix( <filt>, <pol>, <R> )
 ##
-##  Once there was the idea to introduce a constructor 'NewCompanionMatrix',
-##  and it is used in several library files, perhaps also in packages.
-##  As a simpler replacement, there is now a method for the operation
-##  'CompanionMatrix' which admits a filter as its first argument.
-##  We should use 'CompanionMatrix' instead of 'NewCompanionMatrix'.
+##  This operation is intended for the installation of tag based methods for
+##  'CompanionMatrix', such that 'CompanionMatrix' admits method dispatch
+##  based on <filt>.
+##
+##  (Currently 'NewCompanionMatrix' is undocumented.
+##  Perhaps we can simply declare 'CompanionMatrix' itself as a tag based
+##  operation for the given requirement.
+##  This would work also for `DiagonalMatrix`, `RandomMatrix`,
+##  `ReflectionMatrix`, etc.
+##  We could even get rid of `NewMatrix`, `NewZeroMatrix`,
+##  `NewIdentityMatrix`, by declaring `Matrix`, `ZeroMatrix`,
+##  `IdentityMatrix` as tag based operations for the requirements in
+##  question, except that the ordering of the arguments for the four
+##  argument versions of `NewMatrix` and `Matrix` does not fit.)
 ##
 DeclareTagBasedOperation( "NewCompanionMatrix",
     [ IsOperation, IsUnivariatePolynomial, IsSemiring ] );

--- a/lib/upoly.gd
+++ b/lib/upoly.gd
@@ -196,8 +196,25 @@ DeclareOperation( "IsPrimitivePolynomial", [ IsField, IsRationalFunction ] );
 ##  <Oper Name="CompanionMat" Arg='poly'/>
 ##
 ##  <Description>
-##  compute a companion matrix of the polynomial <A>poly</A>. This matrix has
-##  <A>poly</A> as its minimal polynomial.
+##  Return a fully mutable matrix that is the companion matrix of the
+##  polynomial <A>poly</A>.
+##  The negatives of the coefficients of <A>poly</A> appear
+##  in the last column of the result.
+##  <P/>
+##  The companion matrix of <A>poly</A> has <A>poly</A> as its
+##  minimal polynomial (see <Ref Oper="MinimalPolynomial"/>) and as its
+##  characteristic polynomial (see <Ref Attr="CharacteristicPolynomial"/>).
+##  <P/>
+##  <Example><![CDATA[
+##  gap> x:= X( Rationals );;  pol:= x^3 + x^2 + 2*x + 3;;
+##  gap> M:= CompanionMatrix( pol );;
+##  gap> Display( M );
+##  [ [   0,   0,  -3 ],
+##    [   1,   0,  -2 ],
+##    [   0,   1,  -1 ] ]
+##  gap> MinimalPolynomial( M ) = pol;
+##  true
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/tst/testinstall/MatrixObj/CompanionMatrix.tst
+++ b/tst/testinstall/MatrixObj/CompanionMatrix.tst
@@ -23,7 +23,7 @@ gap> F:= GF(3);;  x:= X(F);;
 gap> TestCompanionMatrix(Is8BitMatrixRep, x+1, F);
 [ [ Z(3) ] ]
 gap> TestCompanionMatrix(Is8BitMatrixRep, x^2+x+1, F);
-[ [ 0*Z(3), Z(3)^0 ], [ Z(3), Z(3) ] ]
+[ [ 0*Z(3), Z(3) ], [ Z(3)^0, Z(3) ] ]
 
 # test error handling
 gap> TestCompanionMatrix(Is8BitMatrixRep, Zero(x), F);
@@ -36,7 +36,7 @@ gap> F:= GF(251);;  x:= X(F);;
 gap> TestCompanionMatrix(Is8BitMatrixRep, x+1, F);
 [ [ Z(251)^125 ] ]
 gap> TestCompanionMatrix(Is8BitMatrixRep, x^2+x+1, F);
-[ [ 0*Z(251), Z(251)^0 ], [ Z(251)^125, Z(251)^125 ] ]
+[ [ 0*Z(251), Z(251)^125 ], [ Z(251)^0, Z(251)^125 ] ]
 
 # test error handling
 gap> TestCompanionMatrix(Is8BitMatrixRep, Zero(x), F);
@@ -74,7 +74,7 @@ gap> F:= GF(251);;  x:= X(F);;
 gap> TestCompanionMatrix(IsPlistRep, x+1, F);
 [ [ Z(251)^125 ] ]
 gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
-[ [ 0*Z(251), Z(251)^0 ], [ Z(251)^125, Z(251)^125 ] ]
+[ [ 0*Z(251), Z(251)^125 ], [ Z(251)^0, Z(251)^125 ] ]
 
 #
 gap> F:= Integers;;  x:= X(F);;
@@ -88,15 +88,15 @@ gap> F:= Rationals;;  x:= X(F);;
 gap> TestCompanionMatrix(IsPlistRep, x+1, F);
 [ [ -1 ] ]
 gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
-[ [ 0, 1 ], [ -1, -1 ] ]
+[ [ 0, -1 ], [ 1, -1 ] ]
 
 #
 gap> F:= Integers mod 4;;  x:= X(F);;
 gap> TestCompanionMatrix(IsPlistRep, x+1, F);
 [ [ ZmodnZObj( 3, 4 ) ] ]
 gap> TestCompanionMatrix(IsPlistRep, x^2+x+1, F);
-[ [ ZmodnZObj( 0, 4 ), ZmodnZObj( 1, 4 ) ], 
-  [ ZmodnZObj( 3, 4 ), ZmodnZObj( 3, 4 ) ] ]
+[ [ ZmodnZObj( 0, 4 ), ZmodnZObj( 3, 4 ) ], 
+  [ ZmodnZObj( 1, 4 ), ZmodnZObj( 3, 4 ) ] ]
 
 #
 # Test CompanionMatrix variant which "guesses" a suitable representation, i.e.:
@@ -115,7 +115,7 @@ gap> F:= GF(3);;  x:= X(F);;
 gap> CompanionMatrix(x+1, F);
 [ [ Z(3) ] ]
 gap> CompanionMatrix(x^2+x+1, F);
-[ [ 0*Z(3), Z(3)^0 ], [ Z(3), Z(3) ] ]
+[ [ 0*Z(3), Z(3) ], [ Z(3)^0, Z(3) ] ]
 
 #
 gap> F:= GF(4);;  x:= X(F);;

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -65,11 +65,11 @@ TestCompanionMatrix := function(filt, pol, ring)
   Assert(0, BaseDomain(mat) = ring);
   Assert(0, NrRows(mat) = degree);
   Assert(0, NrCols(mat) = degree);
-  for i in [1..degree-1] do
-    for j in [1..degree] do
-      if i+1<>j and not IsZero(mat[i,j]) then
+  for i in [1..degree] do
+    for j in [1..degree-1] do
+      if i <> j+1 and not IsZero(mat[i,j]) then
         Error("entry ", i,",",j," is not zero");
-      elif i+1=j and not IsOne(mat[i,j]) then
+      elif i = j+1 and not IsOne(mat[i,j]) then
         Error("entry ", i,",",j," is not one");
       fi;
     od;


### PR DESCRIPTION
fixes #5423

- added an example to the documentation of `CompanionMatrix` for a polynomial (in `lib/upoly.gd`)

- changed the definition of `CompanionMatrix` in `lib/matobj2.gd` from *row* convention to *column* convention, such that it fits to `CompanionMatrix` in `lib/upoly.gd`; changed the corresponding method (for `NewCompanionMatrix`) accordingly.

- adjusted the tests

(Now the method in the cvec package has to be adjusted as well.)