### PR TITLE
Add type checks to Concatenation

### DIFF
--- a/lib/coll.gd
+++ b/lib/coll.gd
@@ -2979,14 +2979,14 @@ DeclareOperation( "IsSubset", [ IsListOrCollection, IsListOrCollection ] );
 
 #############################################################################
 ##
-#F  Intersection( <C1>, <C2> ... )  . . . . . . . intersection of collections
+#F  Intersection( <C1>, <C2>, ... ) . . . . . . . intersection of collections
 #F  Intersection( <list> )  . . . . . . . . . . . intersection of collections
 #O  Intersection2( <C1>, <C2> ) . . . . . . . . . intersection of collections
 ##
 ##  <#GAPDoc Label="Intersection">
 ##  <ManSection>
 ##  <Heading>Intersection</Heading>
-##  <Func Name="Intersection" Arg='C1, C2 ...'
+##  <Func Name="Intersection" Arg='C1, C2, ...'
 ##   Label="for various collections"/>
 ##  <Func Name="Intersection" Arg='list' Label="for a list"/>
 ##  <Oper Name="Intersection2" Arg='C1, C2'/>
@@ -3055,14 +3055,14 @@ DeclareOperation( "Intersection2",
 
 #############################################################################
 ##
-#F  Union( <C1>, <C2> ... ) . . . . . . . . . . . . . .  union of collections
+#F  Union( <C1>, <C2>, ... )  . . . . . . . . . . . . .  union of collections
 #F  Union( <list> ) . . . . . . . . . . . . . . . . . .  union of collections
 #O  Union2( <C1>, <C2> )  . . . . . . . . . . . . . . .  union of collections
 ##
 ##  <#GAPDoc Label="Union">
 ##  <ManSection>
 ##  <Heading>Union</Heading>
-##  <Func Name="Union" Arg='C1, C2 ...' Label="for various collections"/>
+##  <Func Name="Union" Arg='C1, C2, ...' Label="for various collections"/>
 ##  <Func Name="Union" Arg='list' Label="for a list"/>
 ##  <Oper Name="Union2" Arg='C1, C2'/>
 ##

--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -552,7 +552,7 @@ DeclareGlobalFunction("NrUnorderedTuples");
 ##  <#GAPDoc Label="IteratorOfCartesianProduct">
 ##  <ManSection>
 ##  <Heading>IteratorOfCartesianProduct</Heading>
-##  <Func Name="IteratorOfCartesianProduct" Arg='list1, list2 ...'
+##  <Func Name="IteratorOfCartesianProduct" Arg='list1, list2, ...'
 ##   Label="for several lists"/>
 ##  <Func Name="IteratorOfCartesianProduct" Arg='list'
 ##   Label="for a list of lists"/>

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -1824,13 +1824,13 @@ DeclareOperation( "StableSortParallel",
 
 #############################################################################
 ##
-#F  Maximum( <obj1>, <obj2> ... ) . . . . . . . . . . . .  maximum of objects
+#F  Maximum( <obj1>, <obj2>, ... )  . . . . . . . . . . .  maximum of objects
 #F  Maximum( <list> )
 ##
 ##  <#GAPDoc Label="Maximum">
 ##  <ManSection>
 ##  <Heading>Maximum</Heading>
-##  <Func Name="Maximum" Arg='obj1, obj2 ...' Label="for various objects"/>
+##  <Func Name="Maximum" Arg='obj1, obj2, ...' Label="for various objects"/>
 ##  <Func Name="Maximum" Arg='list' Label="for a list"/>
 ##
 ##  <Description>
@@ -1862,13 +1862,13 @@ DeclareGlobalFunction( "Maximum" );
 
 #############################################################################
 ##
-#F  Minimum( <obj1>, <obj2> ... ) . . . . . . . . . . . .  minimum of objects
+#F  Minimum( <obj1>, <obj2>, ... )  . . . . . . . . . . .  minimum of objects
 #F  Minimum( <list> )
 ##
 ##  <#GAPDoc Label="Minimum">
 ##  <ManSection>
 ##  <Heading>Minimum</Heading>
-##  <Func Name="Minimum" Arg='obj1, obj2 ...' Label="for various objects"/>
+##  <Func Name="Minimum" Arg='obj1, obj2, ...' Label="for various objects"/>
 ##  <Func Name="Minimum" Arg='list' Label="for a list"/>
 ##
 ##  <Description>
@@ -1940,13 +1940,13 @@ DeclareOperation( "MinimumList", [ IsList, IsObject ] );
 
 #############################################################################
 ##
-#F  Cartesian( <list1>, <list2> ... ) . . . . . .  cartesian product of lists
+#F  Cartesian( <list1>, <list2>, ... )  . . . . .  cartesian product of lists
 #F  Cartesian( <list> )
 ##
 ##  <#GAPDoc Label="Cartesian">
 ##  <ManSection>
 ##  <Heading>Cartesian</Heading>
-##  <Func Name="Cartesian" Arg='list1, list2 ...'
+##  <Func Name="Cartesian" Arg='list1, list2, ...'
 ##   Label="for various objects"/>
 ##  <Func Name="Cartesian" Arg='list' Label="for a list"/>
 ##

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2797,7 +2797,7 @@ InstallMethod( MinimumList,
 
 #############################################################################
 ##
-#F  Cartesian( <list1>, <list2> ... )
+#F  Cartesian( <list1>, <list2>, ... )
 #F  Cartesian( <list> )
 ##
 DeclareGlobalName( "Cartesian2" );

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2084,8 +2084,14 @@ InstallGlobalFunction( Concatenation, function ( arg )
     if Length( arg ) = 0  then
         return [  ];
     fi;
+    if not IsList( arg[1] ) then
+        Error( "Concatenation: arguments must be lists" );
+    fi;
     res := ShallowCopy( arg[1] );
     for i  in [ 2 .. Length( arg ) ]  do
+        if not IsList( arg[i] ) then
+            Error( "Concatenation: arguments must be lists" );
+        fi;
         Append( res, arg[i] );
     od;
     return res;

--- a/tst/testinstall/opers/Concatenation.tst
+++ b/tst/testinstall/opers/Concatenation.tst
@@ -1,0 +1,18 @@
+gap> START_TEST("Concatenation.tst");
+
+#
+gap> Concatenation( );
+[  ]
+gap> Concatenation( [ ] );
+[  ]
+gap> Concatenation( [ 1 ] );
+Error, Concatenation: arguments must be lists
+gap> Concatenation( [ [ 1, 2 ] ] );
+[ 1, 2 ]
+gap> Concatenation( [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ] );
+[ 1, 2, 3, 4, 5, 6 ]
+gap> Concatenation( [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] );
+[ 1, 2, 3, 4, 5, 6 ]
+
+#
+gap> STOP_TEST("Concatenation.tst", 1);


### PR DESCRIPTION
In particular, this lets the undefined expression `Concatenation( [ 1 ] )` throw an error instead of returning `1`.

The first commit fixes some inconsistencies I discovered while grepping for functions similar to `Concatenation`.

## Text for release notes

none