### PR TITLE
fix `AbelianGroup` w.r.t. generators of order 1

### DIFF
--- a/grp/basicfp.gi
+++ b/grp/basicfp.gi
@@ -32,7 +32,7 @@ InstallMethod( AbelianGroupCons, "fp group", true,
 function( filter, ints )
 local   f,g,i,j,rels,gfam,fam;
 
-  if Length(ints)=0 or not ForAll( ints, x -> IsInfinity(x) or (IsInt(x) and x >= 0) )  then
+  if not ForAll( ints, x -> IsInfinity(x) or (IsInt(x) and x >= 0) )  then
       Error( "<ints> must be a list of integers" );
   fi;
 

--- a/grp/basicpcg.gi
+++ b/grp/basicpcg.gi
@@ -44,7 +44,12 @@ local   pis,  f,  g,  r,  k,  pi,  i,  geni,  j,  name,  ps;
     fi;
     if ForAll(ints,i->i=1) then
       # the stupid trivial group case
-      return CyclicGroup( IsPcGroup, 1 );
+      g:= CyclicGroup( IsPcGroup, 1 );
+      if Length( ints ) > 0 then
+        g:= GroupWithGenerators(
+                ListWithIdenticalEntries( Length( ints ), One( g ) ) );
+      fi;
+      return g;
     fi;
 
     pis := List( ints, Factors );

--- a/grp/basicprm.gi
+++ b/grp/basicprm.gi
@@ -39,6 +39,10 @@ InstallMethod( AbelianGroupCons,
 function( filter, ints )
     local   grp,  grps;
 
+    if IsEmpty( ints ) then
+      # Create a group with empty list of generators
+      return GroupWithGenerators( [], () );
+    fi;
     if not ForAll( ints, IsInt )  then
         Error( "<ints> must be a list of integers" );
     fi;
@@ -48,7 +52,7 @@ function( filter, ints )
 
     grps := List( ints, x -> CyclicGroupCons( IsPermGroup, x ) );
     # the way a direct product is constructed guarantees the right
-    # generators
+    # generators (also generators of order 1)
     grp  := CallFuncList( DirectProduct, grps );
     SetSize( grp, Product(ints) );
     SetIsAbelian( grp, true );

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -45,6 +45,17 @@ gap> A.2^-1;
 f2^2
 
 #
+gap> inputs:= [ [], [ 1 ], [ 2, 3, 4 ], [ 1, 2, 1, 3, 1 ] ];;
+gap> for ints in inputs do
+>      for filt in [ IsPcGroup, IsPermGroup, IsFpGroup ] do
+>        G:= AbelianGroup( ints );
+>        if List( GeneratorsOfGroup( G ), Order ) <> ints then
+>          Error( "orders of the generators do not fit" );
+>        fi;
+>      od;
+>    od;
+
+#
 gap> AbelianGroup([2,0]);
 <fp group of size infinity on the generators [ f1, f2 ]>
 gap> AbelianGroup([2,infinity]);


### PR DESCRIPTION
- support `AbelianGroup( IsPermGroup, [] )` and `AbelianGroup( IsFpGroup, [] )`
- changed the output of `AbelianGroup( IsPcGroup, ints )` such that also generators of order 1 appear

resolves #5430