### PR TITLE
Stop installing headers into `${includedir}/gap/src`

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -648,15 +648,6 @@ install-headers: $(FFDATA_H) build/version.h
 	$(INSTALL) -m 0644 $(builddir)/build/version.h $(DESTDIR)$(includedir)/gap
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(includedir)/gap/hpc
 	$(INSTALL) -m 0644 $(srcdir)/src/hpc/*.h $(DESTDIR)$(includedir)/gap/hpc
-	# For compatibility with GAP packages still using `#include "src/compiled.h"`
-	# and similar, also install copies of all headers into a `src` directory
-	# TODO: remove this once no distributed packages needs it anymore
-	$(INSTALL) -d -m 0755 $(DESTDIR)$(includedir)/gap/src
-	$(INSTALL) -m 0644 $(srcdir)/src/*.h $(DESTDIR)$(includedir)/gap/src
-	$(INSTALL) -m 0644 $(FFDATA_H) $(DESTDIR)$(includedir)/gap/src
-	$(INSTALL) -m 0644 $(builddir)/build/version.h $(DESTDIR)$(includedir)/gap/src
-	$(INSTALL) -d -m 0755 $(DESTDIR)$(includedir)/gap/src/hpc
-	$(INSTALL) -m 0644 $(srcdir)/src/hpc/*.h $(DESTDIR)$(includedir)/gap/src/hpc
 
 install-libgap: libgap.la libgap.pc
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)

--- a/README.buildsys.md
+++ b/README.buildsys.md
@@ -125,7 +125,6 @@ far off.
 Compatibility mode does the following things:
 
 * create a `bin/gap.sh` shell script invoking `gap`
-* for out-of-tree builds, it creates a `${builddir}/src/compiled.h` file
 * ...
 
 For now, using compatibility mode is required if one wants to build the
@@ -224,7 +223,6 @@ readline, or to specify an installation prefix, and so on.
 One final remark: some of the generated files differ for HPC-GAP. If you want
 to cross compile HPC-GAP, you need to generate them with HPC-GAP, and place
 them into `src/hpc` instead of `src`, like in this example:
-
 
     ./configure --enable-hpcgap
     make

--- a/configure.ac
+++ b/configure.ac
@@ -956,13 +956,6 @@ AS_IF([test "x$enable_compat_mode" = xyes],
         ],
         [
             AC_MSG_NOTICE([out-of-tree build])
-            # FIXME: the following config command works if invoked
-            # explicitly, but for some reason is not added to the list
-            # of automatic command
-            AC_CONFIG_COMMANDS([src/compiled.h],
-                [
-                echo "#include \"$ac_abs_top_srcdir/src/compiled.h\"" > src/compiled.h
-                ])
         ])
     ])
 

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -234,7 +234,6 @@ GAPInput
     test -f $GAPPREFIX/bin/gac
     test -f $GAPPREFIX/include/gap/gap_all.h
     test -f $GAPPREFIX/include/gap/version.h
-    test -f $GAPPREFIX/include/gap/src/compiled.h # for backwards compatibility
     test -f $GAPPREFIX/lib/gap/sysinfo.gap
     test -f $GAPPREFIX/lib/pkgconfig/libgap.pc
     test -f $GAPPREFIX/share/gap/doc/ref/chap0_mj.html


### PR DESCRIPTION
No currently distributed package needs this anymore.
Not installing these headers simplifies things slightly for downstream packagers.

Resolves #5361