### PR TITLE
kernel: change BOOL from Int to int

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ dnl
 dnl For further details, refer to the Libtool manual chapter on "Library
 dnl interface versions", available at
 dnl <https://www.gnu.org/software/libtool/manual/html_node/Versioning.html>
-m4_define([libtool_current], [8])
+m4_define([libtool_current], [9])
 m4_define([libtool_age], [0])
 
 m4_define([GAP_DEFINE], [GAP_DEFINES="$GAP_DEFINES -D$1"])

--- a/src/common.h
+++ b/src/common.h
@@ -104,7 +104,7 @@ GAP_STATIC_ASSERT(sizeof(void *) == sizeof(UInt), "sizeof(UInt) is wrong");
 
 // FIXME: workaround a conflict with the Semigroups package
 #undef BOOL
-typedef Int BOOL; // TODO: should be changed to `char` once packages adapted
+typedef int BOOL;
 enum { FALSE = 0, TRUE = 1 };
 
 


### PR DESCRIPTION
I guess technically this is an ABI change so we should increment the
kernel version and possibly the libgap ABI version?