### PR TITLE
Change handling of long command line options like `--norepl` so that repeating them will not toggle behaviour anymore

### DIFF
--- a/lib/system.g
+++ b/lib/system.g
@@ -373,7 +373,9 @@ CallAndInstallPostRestore( function()
         else
           opt := GAPInfo.CommandLineOptionCanonicalName.( opt );
           value:= CommandLineOptions.( opt );
-          if IS_BOOL( value ) then
+          if IS_BOOL( value ) and word[2] = '-' then
+            CommandLineOptions.( opt ):= true;
+          elif IS_BOOL( value ) then
             CommandLineOptions.( opt ):= not CommandLineOptions.( opt );
           elif IS_INT( value ) then
             CommandLineOptions.( opt ):= CommandLineOptions.( opt ) + 1;
@@ -496,7 +498,7 @@ CallAndInstallPostRestore( function()
 
       PRINT_TO("*stdout*",
        "\n",
-       "  Boolean options toggle the current value each time they are called.\n",
+       "  Short boolean options toggle the current value each time they are called.\n",
        "  Default actions are indicated first.\n",
        "\n" );
       QuitGap();


### PR DESCRIPTION
Fixes #4187 by only toggling short boolean options like `-T` when repeated.  Long options like `--norepl` are now idempotent. I have also edited the output of `gap -h` to match this change, but I don't currently like the way it is worded (any suggestions?). I've glanced through the manual documentation to see if anything needs to be changed there, but the long command line options aren't yet documented (see #4197). 