### PR TITLE
fix `DirectSumMat`

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -4145,8 +4145,8 @@ InstallGlobalFunction( DirectSumMat, function (arg)
     fi;
 
     # Distinguish:
-    # - If we are given a list of 'IsMatrix' or empty plain lists,
-    #   we want to return an 'IsMatrix',
+    # - If we are given a list of 'IsMatrix' that are *not* 'IsMatrixObj'
+    #   or of empty plain lists, we want to return an 'IsMatrix',
     #   and we do not care about base domains.
     # - If we are given a list of 'IsMatrixObj',
     #   we want to return an 'IsMatrixObj',
@@ -4160,7 +4160,7 @@ InstallGlobalFunction( DirectSumMat, function (arg)
     arg:= Filtered( arg, x -> x <> [] );
     if Length( arg ) = 0 then
       return [];
-    elif ForAll( arg, IsMatrix ) then
+    elif ForAll( arg, m -> IsMatrix( m ) and not IsMatrixObj( m ) ) then
       m:= arg[1];
       F:= DefaultField( m[1,1] );
       res:= NullMat( Sum( arg, NrRows ), Sum( arg, NrCols ), F );

--- a/tst/testinstall/MatrixObj/DirectSumMat.tst
+++ b/tst/testinstall/MatrixObj/DirectSumMat.tst
@@ -1,0 +1,44 @@
+#@local F, l, N, M
+gap> START_TEST( "DirectSumMat.tst" );
+
+# exotic arguments
+gap> DirectSumMat();
+[  ]
+gap> DirectSumMat([]);
+[  ]
+gap> DirectSumMat([], []);
+[  ]
+gap> DirectSumMat([], [], [[1]]);
+[ [ 1 ] ]
+
+# plists (the situation from GAP 4.11.1)
+gap> DirectSumMat([[1]], [[2]]);
+[ [ 1, 0 ], [ 0, 2 ] ]
+gap> DirectSumMat([[Z(2)]], [[Z(4)]]);
+[ <a GF2 vector of length 2>, [ 0*Z(2), Z(2^2) ] ]
+gap> DirectSumMat([[Z(2)]], [[Z(3)]]);
+[ <a GF2 vector of length 2>, [ 0*Z(2), Z(3) ] ]
+gap> F:= FunctionField( Rationals, [ "x1", "x2", "x3", "x4" ] );;
+gap> l:= IndeterminatesOfPolynomialRing( F );
+[ x1, x2, x3, x4 ]
+gap> N:= [ [ l[1], l[2] ],[ l[3], l[4] ] ];
+[ [ x1, x2 ], [ x3, x4 ] ]
+gap> DirectSumMat( N, N );
+[ [ x1, x2, 0, 0 ], [ x3, x4, 0, 0 ], [ 0, 0, x1, x2 ], [ 0, 0, x3, x4 ] ]
+
+# matrix objects
+gap> M:= Matrix( IsPlistMatrixRep, Rationals, [ 1, 2, 3, 4 ], 2 );
+<2x2-matrix over Rationals>
+gap> DirectSumMat( M ) = M;
+true
+gap> DirectSumMat( M, M );
+<4x4-matrix over Rationals>
+gap> DirectSumMat( [ M ] ) = M;
+true
+gap> DirectSumMat( [ M, M ] ) = DirectSumMat( M, M );
+true
+gap> DirectSumMat( M, [[ 1 ]] );
+<3x3-matrix over Rationals>
+
+#
+gap> STOP_TEST( "DirectSumMat.tst" );

--- a/tst/testinstall/MatrixObj/DirectSumMat.tst
+++ b/tst/testinstall/MatrixObj/DirectSumMat.tst
@@ -18,13 +18,14 @@ gap> DirectSumMat([[Z(2)]], [[Z(4)]]);
 [ <a GF2 vector of length 2>, [ 0*Z(2), Z(2^2) ] ]
 gap> DirectSumMat([[Z(2)]], [[Z(3)]]);
 [ <a GF2 vector of length 2>, [ 0*Z(2), Z(3) ] ]
-gap> F:= FunctionField( Rationals, [ "x1", "x2", "x3", "x4" ] );;
+gap> F:= FunctionField( Rationals, 4 );;
 gap> l:= IndeterminatesOfPolynomialRing( F );
-[ x1, x2, x3, x4 ]
+[ x_1, x_2, x_3, x_4 ]
 gap> N:= [ [ l[1], l[2] ],[ l[3], l[4] ] ];
-[ [ x1, x2 ], [ x3, x4 ] ]
+[ [ x_1, x_2 ], [ x_3, x_4 ] ]
 gap> DirectSumMat( N, N );
-[ [ x1, x2, 0, 0 ], [ x3, x4, 0, 0 ], [ 0, 0, x1, x2 ], [ 0, 0, x3, x4 ] ]
+[ [ x_1, x_2, 0, 0 ], [ x_3, x_4, 0, 0 ], [ 0, 0, x_1, x_2 ], 
+  [ 0, 0, x_3, x_4 ] ]
 
 # matrix objects
 gap> M:= Matrix( IsPlistMatrixRep, Rationals, [ 1, 2, 3, 4 ], 2 );


### PR DESCRIPTION
resolves #5434

This is just a temporary solution in order to fix the regression.

Eventually we will perhaps introduce a documented function `DirectSumMatrix` which deals only with compatible `IsMatrixObj` arguments.

(Concerning the release notes, `DirectSumMat` is undocumented, thus I think the change need not be mentioned.)