### PR TITLE
added a redispatch for `IsomorphismFpGroup`

### DIFF
--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -493,6 +493,12 @@ RedispatchOnCondition( IsomorphismPcGroup, true,
     [ IsCyclotomicMatrixGroup ],
     [ IsFinite ], 0 );
 
+# Note that there is a unary method with requirement 'IsGroup'
+# that calls the two-argument variant.
+RedispatchOnCondition( IsomorphismFpGroup, true,
+    [ IsCyclotomicMatrixGroup, IsString ],
+    [ IsFinite, IsObject ], 0 );
+
 RedispatchOnCondition( CompositionSeries, true,
     [ IsCyclotomicMatrixGroup ],
     [ IsFinite ], 0 );

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -53,6 +53,8 @@ true
 # also if they do not know yet that they are finite.
 gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;
 gap> NiceMonomorphism( G );;
+gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;
+gap> IsomorphismFpGroup( G );;
 
 #
 gap> STOP_TEST( "grpmat.tst" );


### PR DESCRIPTION
Recently @hongyi-zhao had noticed that `IsomorphismFpGroup` does not work for matrix groups that do not (yet) know that they are handled via nice monomorphisms.