### PR TITLE
Ensure all lists of lists are marked as rectangular tables when approriate

### DIFF
--- a/tst/testinstall/table.tst
+++ b/tst/testinstall/table.tst
@@ -1,0 +1,31 @@
+#@local u,v, check
+gap> START_TEST("table.tst");
+gap> check := {m} -> [IsTable(m), IsRectangularTable(m), HasIsRectangularTable(m) ];
+function( m ) ... end
+gap> check( [ ]);
+[ false, false, false ]
+gap> check( [ [] ]);
+[ false, false, false ]
+gap> check( [ [], [] ]);
+[ false, false, false ]
+gap> check([ [1,2], [3,4] ]);
+[ true, true, true ]
+gap> check( [ [1,2], [3]]);
+[ true, false, false ]
+gap> check( [ "ab", "cd" ]);
+[ true, true, true ]
+gap> check( [ ['a', 'b'], "cd"]);
+[ true, true, true ]
+gap> check( [ "ab", ['a', 'b']]);
+[ true, true, true ]
+gap> check( [ [1,2], "cd"]);
+[ false, false, false ]
+gap> check( [ [1,2], 3]);
+[ false, false, false ]
+gap> check(InfiniteListOfNames("a"));
+[ false, false, true ]
+gap> check([InfiniteListOfNames("a")]);
+[ true, true, true ]
+gap> check([ ["a","b"], InfiniteListOfNames("a")]);
+[ false, false, false ]
+gap> STOP_TEST( "table.tst", 1);


### PR DESCRIPTION
Fixes #5449

Basically, we were inconsistent on if we treated lists of lists as if they were rectangular tables, depending on what type the inner lists were.

I have tried to very carefully write the code so in the standard cases where everything is a plist of plist, or a plist of not lists, the code is exactly as fast as it used to be -- I tried benchmarking this and I couldn't measure any differences.