### PR TITLE
Fix printing of expressions including non-zero list levels

### DIFF
--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -314,4 +314,30 @@ function ( x ) return ([ [ x ] ]{[ 1 ]}){[ 1 ]}{[ 1 ]}; end
 # four extractions
 gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}{[ 1 ]});
 function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}{[ 1 ]}; end
+
+# list access at level 0 after EXPR_ELMS_LIST
+gap> funcloop(x -> ([ x ]{[ 1 ]})[1]); # EXPR_ELM_LIST
+function ( x ) return ([ x ]{[ 1 ]})[1]; end
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]})[1, 1]); # EXPR_ELM_MAT
+function ( x ) return ([ [ x ] ]{[ 1 ]})[1, 1]; end
+gap> funcloop(x -> ([ x ]{[ 1 ]}){[ 1 ]}); # EXPR_ELMS_LIST
+function ( x ) return ([ x ]{[ 1 ]}){[ 1 ]}; end
+
+# list access at level 0 after EXPR_ELM_LEV
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}[1])[1]); # EXPR_ELM_LIST
+function ( x ) return ([ [ x ] ]{[ 1 ]}[1])[1]; end
+gap> funcloop(x -> ([ [ [ x ] ] ]{[ 1 ]}[1])[1, 1]); # EXPR_ELM_MAT
+function ( x ) return ([ [ [ x ] ] ]{[ 1 ]}[1])[1, 1]; end
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}[1]){[ 1 ]}); # EXPR_ELMS_LIST
+function ( x ) return ([ [ x ] ]{[ 1 ]}[1]){[ 1 ]}; end
+
+# list access at level 0 after EXPR_ELMS_LEV
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]})[1]); # EXPR_ELM_LIST
+function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]})[1]; end
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]})[1, 1]); # EXPR_ELM_MAT
+function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]})[1, 1]; end
+gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}); # EXPR_ELMS_LIST
+function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}; end
+
+#
 gap> STOP_TEST("function.tst", 1);


### PR DESCRIPTION
For example, `([ x ]{[ 1 ]})[1]` was previously printed as `[ x ]{[ 1 ]}[1]`, that is, the parentheses were missing.

This is a follow-up to #5116 which fixed this for nested sublist extractions only. This PR should now cover all possible cases.

See the description of the new helper function `ExprHasNonZeroListLevel` for details.

## Text for release notes

see title