### PR TITLE
Fix missing filenames of statements

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -152,6 +152,11 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
         return Fail;
     }
 
+    Obj filename = GET_FILENAME_BODY(body);
+    if (!filename) {
+        return Fail;
+    }
+
     Obj currLVars = SWITCH_TO_OLD_LVARS(context);
 
     Obj retlist = Fail;
@@ -159,7 +164,6 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
     if ((FIRST_STAT_TNUM <= type && type <= LAST_STAT_TNUM) ||
         (FIRST_EXPR_TNUM <= type && type <= LAST_EXPR_TNUM)) {
         Int line = LINE_STAT(call);
-        Obj filename = GET_FILENAME_BODY(body);
         retlist = NewPlistFromArgs(filename, INTOBJ_INT(line));
     }
     SWITCH_TO_OLD_LVARS(currLVars);
@@ -192,6 +196,7 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
         GAP_ASSERT(func);
         Stat call = STAT_LVARS(context);
         Obj  body = BODY_FUNC(func);
+        Obj  filename = GET_FILENAME_BODY(body);
         if (IsKernelFunction(func)) {
             PrintKernelFunction(func);
             Obj funcname = NAME_FUNC(func);
@@ -203,11 +208,10 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
                  call > SIZE_BAG(body) - sizeof(StatHeader)) {
             Pr("<corrupted statement> ", 0, 0);
         }
-        else {
+        else if (filename) {
             Obj currLVars = SWITCH_TO_OLD_LVARS(context);
 
             Int type = TNUM_STAT(call);
-            Obj filename = GET_FILENAME_BODY(body);
             if (FIRST_STAT_TNUM <= type && type <= LAST_STAT_TNUM) {
                 PrintStat(call);
                 Pr(" at %g:%d", (Int)filename, LINE_STAT(call));

--- a/tst/testspecial/syntax-tree-current-statement.g
+++ b/tst/testspecial/syntax-tree-current-statement.g
@@ -1,0 +1,9 @@
+func := function ( )
+    return CURRENT_STATEMENT_LOCATION(GetCurrentLVars());
+end;
+
+func( );
+
+func := SYNTAX_TREE_CODE( SYNTAX_TREE( func ) );
+
+func( );

--- a/tst/testspecial/syntax-tree-current-statement.g.out
+++ b/tst/testspecial/syntax-tree-current-statement.g.out
@@ -1,0 +1,14 @@
+gap> func := function ( )
+>     return CURRENT_STATEMENT_LOCATION(GetCurrentLVars());
+> end;
+function(  ) ... end
+gap> 
+gap> func( );
+[ "*stdin*", 3 ]
+gap> 
+gap> func := SYNTAX_TREE_CODE( SYNTAX_TREE( func ) );
+function(  ) ... end
+gap> 
+gap> func( );
+fail
+gap> QUIT;

--- a/tst/testspecial/syntax-tree-error.g
+++ b/tst/testspecial/syntax-tree-error.g
@@ -1,0 +1,7 @@
+func := function ( )
+    Error( );
+end;
+
+func := SYNTAX_TREE_CODE( SYNTAX_TREE( func ) );
+
+func( );

--- a/tst/testspecial/syntax-tree-error.g.out
+++ b/tst/testspecial/syntax-tree-error.g.out
@@ -1,0 +1,15 @@
+gap> func := function ( )
+>     Error( );
+> end;
+function(  ) ... end
+gap> 
+gap> func := SYNTAX_TREE_CODE( SYNTAX_TREE( func ) );
+function(  ) ... end
+gap> 
+gap> func( );
+Error,  called from
+<function "func">( <arguments> )
+ called from read-eval loop at *stdin*:8
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> QUIT;


### PR DESCRIPTION
Fixes #5454 (and I looked for similar bugs).

I did wonder if it was better adding the check inside GET_FILENAME_BODY or check the return value for NULL -- for a function used in so few places, I don't think it deeply matters.