### PR TITLE
Prevent more ways to make groups of cyclotomics

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -4819,6 +4819,27 @@ local fam;
 end );
 
 
+InstallMethod( GroupWithGenerators,
+    "generic method for cyclotomic collection",
+    [ IsCyclotomicCollection ],
+function( gens )
+  Error("no groups of cyclotomics allowed because of incompatible ^");
+end );
+
+InstallMethod( GroupWithGenerators,
+    "generic method for cyclotomic collection and identity element",
+    IsCollsElms, [ IsCollection, IsCyclotomic ],
+function( gens, id )
+  Error("no groups of cyclotomics allowed because of incompatible ^");
+end );
+
+InstallMethod( GroupWithGenerators,"method for empty list and cyclotomic element",
+  [ IsList and IsEmpty, IsCyclotomic ],
+function( empty, id )
+  Error("no groups of cyclotomics allowed because of incompatible ^");
+end );
+
+
 #############################################################################
 ##
 #M  GroupByGenerators( <gens> ) . . . . . . . . . . . . . group by generators

--- a/tst/testbugfix/2023-06-05-CycloGroup.tst
+++ b/tst/testbugfix/2023-06-05-CycloGroup.tst
@@ -1,0 +1,26 @@
+# Verify that creating a group of cyclotomics is not possible
+#
+gap> Group([1]);
+#I  no groups of cyclotomics allowed because of incompatible ^
+Error, usage: Group(<gen>,...), Group(<gens>), Group(<gens>,<id>)
+gap> Group([1],1);
+#I  no groups of cyclotomics allowed because of incompatible ^
+Error, usage: Group(<gen>,...), Group(<gens>), Group(<gens>,<id>)
+gap> Group([],1);
+Error, no groups of cyclotomics allowed because of incompatible ^
+
+#
+gap> GroupByGenerators([1]);
+Error, no groups of cyclotomics allowed because of incompatible ^
+gap> GroupByGenerators([1],1);
+Error, no groups of cyclotomics allowed because of incompatible ^
+gap> GroupByGenerators([],1);
+Error, no groups of cyclotomics allowed because of incompatible ^
+
+#
+gap> GroupWithGenerators([1]);
+Error, no groups of cyclotomics allowed because of incompatible ^
+gap> GroupWithGenerators([1],1);
+Error, no groups of cyclotomics allowed because of incompatible ^
+gap> GroupWithGenerators([],1);
+Error, no groups of cyclotomics allowed because of incompatible ^


### PR DESCRIPTION
We generally disallow constructing groups of cyclotomics, because these
groups would render the expression `x^y` ambiguous.
