### PR TITLE
changed `ViewObj` for trivial matrix groups

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -723,8 +723,9 @@ function(G)
 local gens, nrgens;
   gens:=GeneratorsOfGroup(G);
   nrgens:=Length(gens);
-  if nrgens>0 and
-     nrgens * DimensionOfMatrixGroup(G)^2 / GAPInfo.ViewLength > 8 then
+  if nrgens = 0 then
+    Print( "<matrix group of size 1>" );
+  elif nrgens * DimensionOfMatrixGroup(G)^2 / GAPInfo.ViewLength > 8 then
     Print("<matrix group");
     if HasSize(G) then
       Print(" of size ",Size(G));

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -57,4 +57,8 @@ gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;
 gap> IsomorphismFpGroup( G );;
 
 #
+gap> TrivialSubgroup( GL(2, 2) );
+<matrix group of size 1>
+
+#
 gap> STOP_TEST( "grpmat.tst" );


### PR DESCRIPTION
I think that `<matrix group of size 1>` is better than `Group([  ])`.