### PR TITLE
Stop requiring `Status` in package metadata

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -212,14 +212,6 @@ The following components of this record are <E>mandatory</E>.
   a string that lists the supported formats (among <C>.tar.gz</C>,
   <C>.tar.bz2</C>, <C>-win.zip</C>), separated by whitespace or commas,
 </Item>
-<Mark><C>Status</C></Mark>
-<Item>
-  one of <C>"accepted"</C>, <C>"submitted"</C>, <C>"deposited"</C>,
-  <C>"dev"</C>, <C>"other"</C>;
-  if the value is <C>"accepted"</C> then also
-  <C>CommunicatedBy</C> (a string of the form <C>name (place)</C>) and
-  <C>AcceptDate</C> (a string of the form <C>mm/yyyy</C>) are mandatory,
-</Item>
 <Mark><C>README_URL</C></Mark>
 <Item>
   a string started with <C>http://</C>, <C>https://</C>, or <C>ftp://</C>,
@@ -932,7 +924,6 @@ gap> ValidatePackageInfo("PackageInfo.g");
 #E  component `Date' must be bound to a string of the form `dd/mm/yyyy'
 #E  component `ArchiveURL' must be bound to a string started with http://, https:// or ftp://
 #E  component `ArchiveFormats' must be bound to a string
-#E  component `Status' must be bound to one of "accepted", "deposited", "dev", "other"
 #E  component `README_URL' must be bound to a string started with http://, https:// or ftp://
 #E  component `PackageInfoURL' must be bound to a string started with http://, https:// or ftp://
 #E  component `AbstractHTML' must be bound to a string

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2318,19 +2318,6 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
       od;
     fi;
 
-    if TestMandat( record, "Status",
-           x -> x in [ "accepted", "submitted", "deposited", "dev", "other" ],
-           "one of \"accepted\", \"deposited\", \"dev\", \"other\"" )
-       and record.Status = "accepted" then
-      TestMandat( record, "CommunicatedBy",
-          x -> IsString(x) and PositionSublist( x, " (" ) <> fail
-                   and x[ Length(x) ] = ')',
-          "a string of the form `<name> (<place>)'" );
-      TestMandat( record, "AcceptDate",
-          x -> IsString( x ) and Length( x ) = 7 and x[3] = '/'
-                   and ForAll( x{ [1,2,4,5,6,7] }, IsDigitChar ),
-          "a string of the form `mm/yyyy'" );
-    fi;
     TestMandat( record, "README_URL", IsURL, "a string started with http://, https:// or ftp://" );
     TestMandat( record, "PackageInfoURL", IsURL, "a string started with http://, https:// or ftp://" );
 
@@ -2835,11 +2822,7 @@ InstallGlobalFunction( BibEntry, function( arg )
             "  <year>", pkginfo.Date{ [ 7 .. 10 ] }, "</year>\n" ) );
         fi;
       fi;
-      if IsBound( pkginfo.Status ) and pkginfo.Status = "accepted" then
-        Append( entry, "  <note>Refereed " );
-      else
-        Append( entry, "  <note>" );
-      fi;
+      Append( entry, "  <note>" );
 #     Append( entry, "<Package>GAP</Package> package</note>\n" );
       Append( entry, "GAP package</note>\n" );
       if IsBound( pkginfo.Keywords ) then

--- a/tst/mockpkg/PackageInfo.g
+++ b/tst/mockpkg/PackageInfo.g
@@ -58,16 +58,6 @@ ArchiveURL     := Concatenation( ~.PackageWWWHome,
 
 ArchiveFormats := ".tar.gz",
 
-##  Status information. Currently the following cases are recognized:
-##    "accepted"      for successfully refereed packages
-##    "submitted"     for packages submitted for the refereeing
-##    "deposited"     for packages for which the GAP developers agreed
-##                    to distribute them with the core GAP system
-##    "dev"           for development versions of packages
-##    "other"         for all other packages
-##
-Status := "dev",
-
 AbstractHTML   :=  "",
 
 PackageDoc := rec(

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -207,8 +207,6 @@ gap> ValidatePackageInfo(rec());
 #E  component `ArchiveURL' must be bound to a string started with http://, htt\
 ps:// or ftp://
 #E  component `ArchiveFormats' must be bound to a string
-#E  component `Status' must be bound to one of "accepted", "deposited", "dev",\
- "other"
 #E  component `README_URL' must be bound to a string started with http://, htt\
 ps:// or ftp://
 #E  component `PackageInfoURL' must be bound to a string started with http://,\
@@ -226,7 +224,6 @@ gap> info := rec(
 >     Date := "01/20/2015",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
->     Status := "other",
 >     README_URL := "https://",
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
@@ -255,7 +252,6 @@ gap> info := rec(
 >     Date := "2013-05-22",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
->     Status := "other",
 >     README_URL := "https://",
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
@@ -282,7 +278,6 @@ gap> info := rec(
 >     Date := "2013-22-05",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
->     Status := "other",
 >     README_URL := "https://",
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
@@ -311,7 +306,6 @@ gap> info := rec(
 >     Date := "2013-05-22-",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
->     Status := "other",
 >     README_URL := "https://",
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
@@ -340,7 +334,6 @@ gap> info := rec(
 >     Date := "01/02/3000",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
->     Status := "other",
 >     README_URL := "https://",
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",


### PR DESCRIPTION
Likewise for `CommunicatedBy` and `AcceptDate`.

Motivation: this data logically does not belong with the package metadata controlled by package authors. Instead it should be stored in a central location managed by the GAP team.

For example, in order to be accepted for distribution, currently GAP package authors must provide a proper release of their package, which then is reviewed. But that release should not yet have status `accepted` resp. `deposited`... so strictly speaking, right after the package is officially accepted, a second release with the updated status should be made right away.

Indeed, for now the plan is to have this central location be in the GapWWW repository, see https://github.com/gap-system/GapWWW/pull/330, simply because the website is the only place we need this data right now. We can of course change this in the future, but for now this way requires the least amount of work.