### PR TITLE
Make GroupWithMemory behave more like Group

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -123,13 +123,14 @@ InstallGlobalFunction( CopyMemory,
 
 InstallGlobalFunction( GroupWithMemory,
   function(gens)
-    # gens a list of generators
+    # gens a list of generators or a group
     local g,memgens;
-    if IsGroup(gens) then
-        memgens := GeneratorsWithMemory(GeneratorsOfGroup(gens));
-    else
-        memgens := GeneratorsWithMemory(gens);
+    if not IsGroup(gens) then
+        # trick: ensure all transformations that GroupWithGenerators applies
+        # to the generators are applied here, too
+        gens := GroupWithGenerators(gens);
     fi;
+    memgens := GeneratorsWithMemory(GeneratorsOfGroup(gens));
     g := GroupWithGenerators(memgens);
     return g;
   end);

--- a/tst/testinstall/memory.tst
+++ b/tst/testinstall/memory.tst
@@ -1,5 +1,5 @@
 #@local G, H, g, h, tmp, stabChain, s1, s2
-gap> G := GroupWithMemory(GroupByGenerators([ (1,2,3,4,5), (1,2) ]));;
+gap> G := GroupWithMemory([ (1,2,3,4,5), (1,2) ]);;
 gap> H := GroupWithMemory(GL(IsMatrixGroup, 3, 3));;
 gap> g := H.1 ^ 2;; h := H.2 ^ 2;;
 gap> StripMemory(g);


### PR DESCRIPTION
In particular, ensure that the wrapped generators are made
immutable, and in the case of matrices, possibly converted
to a better representation. This is achieved by calling
`GroupWithGenerators` on the given generators, and then
wrapping the generators of the resulting group.

This avoids a surprising mismatch in behavior between
ordinary groups and groups with memory in some situations.
And of course making the generators immutable prevents
further pitfalls.
