### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -35,7 +35,7 @@
 #include <sys/resource.h>
 #endif
 
-#if defined(__MACH__) // macOS
+#if defined(__APPLE__) && defined(__MACH__) // macOS
 #include <mach/mach_time.h>
 #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
 #include <time.h>
@@ -101,7 +101,7 @@ Int8 SyNanosecondsSinceEpoch(void)
 {
     Int8 res;
 
-#if defined(__MACH__) // macOS
+#if defined(__APPLE__) && defined(__MACH__) // macOS
     static mach_timebase_info_data_t timeinfo;
     if (timeinfo.denom == 0) {
         (void)mach_timebase_info(&timeinfo);
@@ -161,7 +161,7 @@ static Int8 SyNanosecondsSinceEpochResolution(void)
 {
     Int8 res;
 
-#if defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__)
     static mach_timebase_info_data_t timeinfo;
     if (timeinfo.denom == 0) {
         (void)mach_timebase_info(&timeinfo);
@@ -269,7 +269,7 @@ static Obj FuncNanosecondsSinceEpochInfo(Obj self)
     const char * method = "unsupported";
     Int          monotonic = 0;
 
-#if defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__)
     method = "mach_absolute_time";
     monotonic = 1;
 #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)

--- a/src/system.c
+++ b/src/system.c
@@ -51,7 +51,7 @@
 
 #include <sys/stat.h>
 
-#ifdef __MACH__
+#if defined(__APPLE__) && defined(__MACH__)
 // Workaround: TRUE / FALSE are also defined by the macOS Mach-O headers
 #define ENUM_DYLD_BOOL
 #include <mach-o/dyld.h>


### PR DESCRIPTION
Hurd uses a different version of Mach that does not have `mach/clock.h`.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```