### PR TITLE
Minor performance improvements and a fix of case of variable overwrititing

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -986,7 +986,7 @@ local c, flip, maxidx, cano, tryfct, p, r, t,
       unten, compst, s, nr, nstab, lst, sifa, pinv, blist, bsz, cnt,
       ps, e, mop, mo, lstgens, lstgensop, rep, st, o, oi, i, img, ep,
       siz, rt, j, canrep,step,nu,doneidx,orbcnt,posi,
-      sizes,cluster,sel,lr,lstabs,ssizes,num,actfun,mayflip,
+      sizes,cluster,sel,lr,lstabs,ssizes,num,actfun,mayflip,rs,
       actlimit, uplimit, badlimit,avoidlimit,start,includestab,quot;
 
   actlimit:=300000; # maximal degree on which we try blocks
@@ -1128,10 +1128,10 @@ local c, flip, maxidx, cano, tryfct, p, r, t,
         fi;
       end;
 
-      r:=Filtered(TryMaximalSubgroupClassReps(G:cheap),
+      rs:=Filtered(TryMaximalSubgroupClassReps(G:cheap),
         x->Index(G,x)<=5*avoidlimit);
-      SortBy(r,a->-Size(a));
-      for i in r do
+      SortBy(rs,a->-Size(a));
+      for i in rs do
         if Index(G,i)<maxidx(c) then
           p:=Intersection(a,i);
           AddSet(doneidx,Index(a,p));
@@ -1154,11 +1154,11 @@ local c, flip, maxidx, cano, tryfct, p, r, t,
 
     if maxidx(c)>badlimit then
 
-      r:=ShallowCopy(TryMaximalSubgroupClassReps(a:cheap));
-      r:=Filtered(r,x->Index(a,x)<uplimit and not Index(a,x) in doneidx);
+      rs:=ShallowCopy(TryMaximalSubgroupClassReps(a:cheap));
+      rs:=Filtered(rs,x->Index(a,x)<uplimit and not Index(a,x) in doneidx);
 
-      SortBy(r,a->-Size(a));
-      for j in r do
+      SortBy(rs,a->-Size(a));
+      for j in rs do
         #Print("j=",Size(j),"\n");
         t:=AscendingChain(G,j:refineIndex:=avoidlimit,
                               refineChainActionLimit:=actlimit,indoublecoset);

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -509,16 +509,19 @@ local   nice,img,module,b;
     else
       module:=GModuleByMats(GeneratorsOfGroup(grp),DefaultFieldOfMatrixGroup(grp));
     fi;
-    #improve,
-    # try hard, unless absirr and orbit lengths at least 1/q^2 of domain --
-    #then we expect improvements to be of little help
-    if module<>fail and not (NrMovedPoints(img)>=
-      Size( DefaultFieldOfMatrixGroup( grp ) )^( NumberRows( One( grp ) )-2 )
-      and MTX.IsAbsolutelyIrreducible(module)) then
+    #improve, unless not wanted
+    if ValueOption("cheap")<>true then
+      # try hard, unless absirr and orbit lengths at least 1/q^2 of domain --
+      #then we expect improvements to be of little help
+      if module<>fail and not (NrMovedPoints(img)>=
+        Size( DefaultFieldOfMatrixGroup( grp ) )^( NumberRows( One( grp ) )-2 )
+        and MTX.IsAbsolutelyIrreducible(module)) then
+          nice:=nice*SmallerDegreePermutationRepresentation(img:cheap);
+      else
         nice:=nice*SmallerDegreePermutationRepresentation(img:cheap);
-    else
-      nice:=nice*SmallerDegreePermutationRepresentation(img:cheap);
+      fi;
     fi;
+
   fi;
   SetIsInjective( nice, true );
 

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -233,6 +233,9 @@ InstallMethod( \in,
 function( elm, G )
     local   nice,  img;
 
+    if HasGeneratorsOfGroup(G) and elm in GeneratorsOfGroup(G) then
+      return true;
+    fi;
     nice := NiceMonomorphism( G );
     img  := ImagesRepresentative( nice, elm:actioncanfail:=true );
     return img<>fail and img in NiceObject( G )

--- a/lib/morpheus.gd
+++ b/lib/morpheus.gd
@@ -579,6 +579,11 @@ DeclareOperation("GQuotients",[IsGroup,IsGroup]);
 ##  gap> emb:=IsomorphicSubgroups(g,h);
 ##  [ [ (3,4), (1,2) ] -> [ (1,2), (3,4) ],
 ##    [ (3,4), (1,2) ] -> [ (1,3)(2,4), (1,2)(3,4) ] ]
+##  gap> g1:=PSO(-1,8,2);;
+##  gap> Length(IsomorphicSubgroups(g1,PSL(2,7)));
+##  3
+##  gap> Length(IsomorphicSubgroups(g1,PSL(2,7):findall:=false));
+##  1
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>


### PR DESCRIPTION
- IsomorphicSubgroups prefers smaller orders for subgroup generators, if subgroup is small
- Nice group element test recognized generators first
- Matrix group nice monomorphism degree improvement can be toned down with `cheap` option
- Fix overuse of variable in double coset computation, leads to error message
(Test example is too big to include in distribution, is attached:
[gcbug.txt](https://github.com/gap-system/gap/files/12328207/gcbug.txt)
)
