### PR TITLE
fixed `ConsiderStructureConstants`

### DIFF
--- a/lib/ctblmaps.gd
+++ b/lib/ctblmaps.gd
@@ -956,7 +956,12 @@ DeclareAttributeSuppCT( "NamesOfFusionSources",
 ##    for the argument <A>quick</A>;
 ##    especially, as soon as only one possibility remains
 ##    then this possibility is returned immediately;
-##    the default value is <K>false</K>,
+##    the default value is <K>false</K>
+##    (note that in situations where the group of <A>tbl</A> has no subgroups
+##    with character table <A>subtbl</A>, it may happen that setting
+##    <C>quick</C> to <K>true</K> causes <Ref Oper="PossibleClassFusions"/>
+##    to return solutions,
+##    whereas the value <K>false</K> yields an empty list),
 ##  </Item>
 ##  <Mark><C>verify</C></Mark>
 ##  <Item>

--- a/lib/ctblmaps.gd
+++ b/lib/ctblmaps.gd
@@ -2497,7 +2497,7 @@ DeclareGlobalFunction( "FusionsAllowedByRestrictions" );
 ##  constants.
 ##  <P/>
 ##  The argument <A>quick</A> must be a Boolean; if it is <K>true</K> then
-##  only those triples are checked for which for which at least two entries
+##  only those triples are checked for which at least two entries
 ##  in <A>fusions</A> have different images.
 ##  </Description>
 ##  </ManSection>

--- a/lib/ctblmaps.gi
+++ b/lib/ctblmaps.gi
@@ -4492,11 +4492,17 @@ InstallGlobalFunction( ConsiderStructureConstants,
               sc:= ClassMultiplicationCoefficient( tbl, trpl[1], trpl[2],
                        trpl[3] );
               if sc < subsc then
+                fusions:= Filtered( fusions,
+                                    x -> x{ [ i, j, kk ] } <> trpl );
+                if Length( fusions ) = 0 then
+                  Info( InfoCharacterTable, 2,
+                        "ConsiderStructureConstants: contradiction for ",
+                        [ i, j, kk ] );
+                  return fusions;
+                fi;
                 Info( InfoCharacterTable, 2,
                       "ConsiderStructureConstants: improvement for ",
                       [ i, j, kk ] );
-                fusions:= Filtered( fusions,
-                                    x -> x{ [ i, j, kk ] } <> trpl );
                 parm:= Parametrized( fusions );
               fi;
             od;

--- a/tst/testinstall/ctblmaps.tst
+++ b/tst/testinstall/ctblmaps.tst
@@ -3,12 +3,16 @@ gap> START_TEST( "ctblmaps.tst" );
 
 # `ConsiderStructureConstants` can unexpectedly exclude all candidates.
 # (Benjamin Sambale found examples for that.)
-gap> s:= CharacterTable( "2.A6" );;
-gap> t:= CharacterTable( "Co3" );;
-gap> maps:= [ [ 1, 2, 8, 4, 11, 4, 13, 18, 18, 9, 22, 9, 22 ],
->             [ 1, 2, 8, 4, 11, 4, 13, 17, 17, 9, 22, 9, 22 ] ];;
-gap> Length( ConsiderStructureConstants( s, t, maps, true ) );
-0
+gap> if TestPackageAvailability("ctbllib") <> fail and
+>       LoadPackage("ctbllib", false) <> fail then
+>      s:= CharacterTable( "2.A6" );;
+>      t:= CharacterTable( "Co3" );;
+>      maps:= [ [ 1, 2, 8, 4, 11, 4, 13, 18, 18, 9, 22, 9, 22 ],
+>               [ 1, 2, 8, 4, 11, 4, 13, 17, 17, 9, 22, 9, 22 ] ];;
+>      if Length( ConsiderStructureConstants( s, t, maps, true ) ) <> 0 then
+>        Error( "test of ConsiderStructureConstants failed" );
+>      fi;
+>    fi;
 
 #
 gap> STOP_TEST( "ctblmaps.tst" );

--- a/tst/testinstall/ctblmaps.tst
+++ b/tst/testinstall/ctblmaps.tst
@@ -1,0 +1,14 @@
+#@local s, t, maps
+gap> START_TEST( "ctblmaps.tst" );
+
+# `ConsiderStructureConstants` can unexpectedly exclude all candidates.
+# (Benjamin Sambale found examples for that.)
+gap> s:= CharacterTable( "2.A6" );;
+gap> t:= CharacterTable( "Co3" );;
+gap> maps:= [ [ 1, 2, 8, 4, 11, 4, 13, 18, 18, 9, 22, 9, 22 ],
+>             [ 1, 2, 8, 4, 11, 4, 13, 17, 17, 9, 22, 9, 22 ] ];;
+gap> Length( ConsiderStructureConstants( s, t, maps, true ) );
+0
+
+#
+gap> STOP_TEST( "ctblmaps.tst" );


### PR DESCRIPTION
It may happen that `ConsiderStructureConstants` excludes all candidates.
Up to now, it was possible that one runs into an error in such a case because the function wants to proceed and tries to access entries in an empty list.

Benjamin Sambale found an example in which the `quick` parameter is set to `true` and hence some candidates do not get excluded in an earlier step, but the error could in principle happen also with the default setting `quick:= false`.