### PR TITLE
Fix HPC-GAP crash when calling `IntFFE` repeatedly

### DIFF
--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1349,7 +1349,7 @@ static Obj INT_FF(FF ff)
             z = succ[ z ];
         }
 #ifdef HPCGAP
-        GrowPlist(IntFF, ff);
+        GROW_PLIST(IntFF, ff);
         ATOMIC_SET_ELM_PLIST( IntFF, ff, conv );
         MEMBAR_WRITE();
         NumFF = LEN_PLIST(IntFF);


### PR DESCRIPTION
The kernel function `INT_FF` had a bug under HPC-GAP that could lead to it allocating more and more memory (that it did not actually need), eventually causing GAP to come to a halt or the system running out of memory.

This kernel function is called by e.g. `IntFFE` and other user facing code. As a result, this code did not terminate (with the fix it runs in a few milliseconds):

    for p in Primes do IntFFE(Z(p)); od;

For the experts: the code was directly calling `GrowPlist`, which does not perform a check to see if the list is actually already big enough. So each time `INT_FF` was called ended up increasing an internal list by a certain small percentage. But doing this often enough still leads to exponential growth of the size of that list...

I did not include a test case (other than the one in the commit message) because the test really only can test whether GAP hangs and/or gets slow or not, which is not terribly useful by itself. Besides, PR #5495 adds a test which also triggers this problem.