### PR TITLE
Rank down MatrixObj emulation methods

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1338,11 +1338,13 @@ InstallMethod( RowsOfMatrix,
 InstallMethod( NumberRows,
     "generic method for a (perhaps empty) matrix",
     [ IsMatrix ],
+    -SUM_FLAGS,
     Length );
 
 InstallMethod( NumberColumns,
     "generic method for a (perhaps empty) matrix",
     [ IsMatrix ],
+    -SUM_FLAGS,
     function( mat )
     if Length( mat ) = 0 then
       return 0;


### PR DESCRIPTION
Reduce the rank of `NumberRows` and `NumberColumns` methods that are meant to
emulate the MatrixObj interface for classic plist-of-list matrices.

These methods were in some cases ranked higher than their counterparts for compressed matrices, leading to unnecessary overhead for e.g. `NrRows` when invoked on a compressed matrix.