### PR TITLE
Always use non-threadsafe coverage generation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -170,8 +170,15 @@ jobs:
                ${{ matrix.extra }}
                if [[ -n ${NO_COVERAGE} ]] ; then
                   echo "No coverage reporting"
+               elif [ "$RUNNER_OS" == "Linux" ] ; then
+                  # Passing -pthread makes linux gcc generate profiles in a thread-safe way,
+                  # but that is very slow, so we force non-threadsafe generation.
+                  echo "Use non-threadsafe coverage options, updating compiler and linker flags"
+                  echo "CFLAGS=--coverage -O2 -g -fprofile-update=single" >> $GITHUB_ENV
+                  echo "CXXFLAGS=--coverage -O2 -g -fprofile-update=single" >> $GITHUB_ENV
+                  echo "LDFLAGS=--coverage -fprofile-update=single" >> $GITHUB_ENV
                else
-                  echo "Coverage reporting, updating compiler and linker flags"
+                  echo "Using standard coverage options, updating compiler and linker flags"
                   echo "CFLAGS=--coverage -O2 -g" >> $GITHUB_ENV
                   echo "CXXFLAGS=--coverage -O2 -g" >> $GITHUB_ENV
                   echo "LDFLAGS=--coverage" >> $GITHUB_ENV

--- a/configure.ac
+++ b/configure.ac
@@ -1069,9 +1069,16 @@ dnl check for non-standard math functions
 AC_CHECK_FUNCS([exp10])
 
 dnl pthreads
-AS_IF([test "x$enable_hpcgap" = xyes -o "x$with_julia" != xno ],[
+dnl unconditionally check for pthread flags (and use them), even though we
+dnl only use pthreads if HPC-GAP is enabled. The reason is that if a kernel
+dnl extension uses pthreads (e.g. that of the Semigroups package does it),
+dnl then it may be necessary under certain Linux variants that the
+dnl gap executable is linked with flags like `-pthread`. If it is not, then
+dnl using the kernel extension leads to a runtime exception.
+dnl See also <https://github.com/gap-system/gap/issues/5192>
+#AS_IF([test "x$enable_hpcgap" = xyes -o "x$with_julia" != xno ],[
   AX_PTHREAD
-  ])
+#  ])
 
 dnl backtraces via execinfo
 AX_EXECINFO


### PR DESCRIPTION
The --coverage option generates coverage of both which lines are executed, and also which branches (or arcs) are taken everywhere. Generating 'arc' coverage seems to take a long time (slows GAP starting on my machine from 1.5seconds to 6seconds), so this will hopefully significantly speed up testing, while having only a small effect on coverage quality.

EDIT: This PR now does a different thing. I am going to investigate further tunings of the coverage settings later, assuming this one improves things so we can use -pthreads.


Closes #5196