### PR TITLE
Catch overflow in header size

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -259,6 +259,10 @@ Stat NewStatOrExpr(CodeState * cs, UInt type, UInt size, UInt line)
     StatHeader * header = STAT_HEADER(cs, stat);
     header->line = line;
     header->size = size;
+    // check size fits inside header
+    if (header->size != size) {
+        ErrorQuit("function too large for parser", 0, 0);
+    }
     header->type = type;
     RegisterStatWithHook(GET_GAPNAMEID_BODY(cs->currBody), line, type);
     // return the new statement

--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -339,5 +339,30 @@ function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]})[1, 1]; end
 gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}); # EXPR_ELMS_LIST
 function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}; end
 
+# Test functions with very large lists
+gap> r := List([1..(16777216/GAPInfo.BytesPerVariable)-1]);;
+gap> funcstr := String(r);;
+gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
+gap> Read(InputTextString(funcstr));;
+gap> func() = r;
+true
+gap> funcstr := String(List([1..(16777216/GAPInfo.BytesPerVariable)], x -> x));;
+gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
+gap> Read(InputTextString(funcstr));;
+Error, function too large for parser
+
+# Test functions with very large records
+gap> r := rec();; for x in [1..(16777216/GAPInfo.BytesPerVariable-2)/2] do r.(x) := x; od;;
+gap> funcstr := String(r);;
+gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
+gap> Read(InputTextString(funcstr));;
+gap> func() = r;
+true
+gap> r := rec();; for x in [1..(16777216/GAPInfo.BytesPerVariable)/2] do r.(x) := x; od;;
+gap> funcstr := String(r);;
+gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
+gap> Read(InputTextString(funcstr));;
+Error, function too large for parser
+
 #
 gap> STOP_TEST("function.tst", 1);

--- a/tst/testinstall/recordname.tst
+++ b/tst/testinstall/recordname.tst
@@ -92,8 +92,8 @@ sitive integer)
 gap> \.(r, "a");
 Error, Record Element: <rnam> must be a positive small integer (not a list (st\
 ring))
-gap> \.(r, 1000000);
-Error, Record Element: <rnam> must be a valid rnam (not the integer 1000000)
+gap> \.(r, 100000000);
+Error, Record Element: <rnam> must be a valid rnam (not the integer 100000000)
 
 ##
 gap> IsBound\.(r, RNamObj("y"));
@@ -112,8 +112,8 @@ sitive integer)
 gap> IsBound\.(r, "a");
 Error, Record IsBound: <rnam> must be a positive small integer (not a list (st\
 ring))
-gap> IsBound\.(r, 1000000);
-Error, Record IsBound: <rnam> must be a valid rnam (not the integer 1000000)
+gap> IsBound\.(r, 100000000);
+Error, Record IsBound: <rnam> must be a valid rnam (not the integer 100000000)
 
 ##
 gap> r;
@@ -137,8 +137,8 @@ itive integer)
 gap> Unbind\.(r, "a");
 Error, Record Unbind: <rnam> must be a positive small integer (not a list (str\
 ing))
-gap> Unbind\.(r, 1000000);
-Error, Record Unbind: <rnam> must be a valid rnam (not the integer 1000000)
+gap> Unbind\.(r, 100000000);
+Error, Record Unbind: <rnam> must be a valid rnam (not the integer 100000000)
 
 ##
 gap> r;
@@ -164,7 +164,7 @@ Error, Record Assignment: <rnam> must be a positive small integer (not a large\
 gap> \.\:\=(r, "a", 1);
 Error, Record Assignment: <rnam> must be a positive small integer (not a list \
 (string))
-gap> \.\:\=(r, 1000000, 1);
+gap> \.\:\=(r, 100000000, 1);
 Error, Record Assignment: <rnam> must be a valid rnam (not the integer 1000000\
-)
+00)
 gap> STOP_TEST( "recordname.tst", 1);


### PR DESCRIPTION
Fixes #5508 (GAP produces incorrect code when there are very large arrays inside functions). GAP will silently fail whenever there is a function with 2097152 or more elements given explicitly, inside a function (note a list must be this long, a list of lists whose sublists contain this many elements would be fine).

We could also look at increasing how much allowance we give, but I'm tempted to put this commit in as is (unless there are any small fixes / suggestions), because then if anyone has code that has hit this bug in the past, they will get a clear error message that an error has occurred (in fact, perhaps I should even extend the error to say "this code may have given incorrect answers in previous versions of GAP"?)
