### PR TITLE
ENHANCE: FittingFreeLiftSetup

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1255,8 +1255,7 @@ DeclareAttribute( "ConjugacyClasses", IsGroup );
 ##  <Example><![CDATA[
 ##  gap> ConjugacyClassesMaximalSubgroups(g);
 ##  [ Group( [ (2,4,3), (1,4)(2,3), (1,3)(2,4) ] )^G,
-##    Group( [ (3,4), (1,4)(2,3), (1,3)(2,4) ] )^G,
-##    Group( [ (3,4), (2,4,3) ] )^G ]
+##    Group( [ (3,4), (1,3)(2,4) ] )^G, Group( [ (3,4), (2,4,3) ] )^G ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
@@ -1302,8 +1301,8 @@ DeclareAttribute( "MaximalSubgroups", IsGroup );
 ##  of <A>G</A>.
 ##  <Example><![CDATA[
 ##  gap> MaximalSubgroupClassReps(g);
-##  [ Group([ (2,4,3), (1,4)(2,3), (1,3)(2,4) ]), Group([ (3,4), (1,4)
-##    (2,3), (1,3)(2,4) ]), Group([ (3,4), (2,4,3) ]) ]
+##  [ Group([ (2,4,3), (1,4)(2,3), (1,3)(2,4) ]),
+##    Group([ (3,4), (1,3)(2,4) ]), Group([ (3,4), (2,4,3) ]) ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -69,15 +69,6 @@ function( G, fampcgs,pcgs,fphom,words,wordgens,wordimgs)
                 group := G,
                 factorfphom:=fphom
                          );
-                # giving generators enforces a bad presentation
-                #generators := GeneratorsOfGroup( G ) );
-
-#for gen in
-#  List(GeneratorsOfGroup(Range(fphom)),x->PreImagesRepresentative(fphom,x)) do
-#  gen:=(List(pcgs,y->ExponentsOfPcElement(pcgs,y^gen)));
-#  Print(gen,"\n");
-#od;
-#Error("EH");
 
     OCOneCocycles( ocr, false );
     if not IsBound( ocr.complement ) then return []; fi;
@@ -189,6 +180,11 @@ BindGlobal("MaximalSubgroupClassesSol",function(G)
     f:=ff.factorhom;
     mgi:=MappingGeneratorsImages(ff.factorhom);
     sel:=Filtered([1..Length(mgi[2])],x->not IsOne(mgi[2][x]));
+    if 4^Length(sel)>Size(Range(ff.factorhom)) then
+      f:=SmallGeneratingSet(Image(ff.factorhom));
+      mgi:=[List(f,x->PreImagesRepresentative(ff.factorhom,x)),f];
+      sel:=[1..Length(mgi[1])];
+    fi;
     gensG:=mgi[1]{sel};
 
     # fp group and word representation for gensG
@@ -903,7 +899,7 @@ local G,types,ff,maxes,lmax,q,d,dorb,dorbt,i,dorbc,dorba,dn,act,comb,smax,soc,
         # eliminate those containing the socle
         lmax:=Filtered(lmax,x->not IsSubset(x,soc));
         Info(InfoLattice,1,Length(lmax)," type 2 maxes");
-for mm in lmax do mm!.type:="2";od;
+        for mm in lmax do mm!.type:="2";od;
         Append(maxes,lmax);
       fi;
 
@@ -913,7 +909,7 @@ for mm in lmax do mm!.type:="2";od;
           lmax:=MaxesType3(act[1],Image(act[2],q),act[3],act[4],act[5],true);
           Info(InfoLattice,1,Length(lmax)," type 3b maxes");
           lmax:=List(lmax,x->PreImage(act[2],x));
-for mm in lmax do mm!.type:="3b";od;
+          for mm in lmax do mm!.type:="3b";od;
           Append(maxes,lmax);
         fi;
 

--- a/lib/permdeco.gi
+++ b/lib/permdeco.gi
@@ -22,7 +22,34 @@ local   pcgs,r,hom,A,iso,p,i,depths,ords,b,mo,pc,limit,good,new,start,np;
   if Size(r)=1 then
     hom:=IdentityMapping(G);
   else
-    hom:=NaturalHomomorphismByNormalSubgroup(G,r);
+    hom:=fail;
+    if IsBound(G!.cachedFFS) then
+      A:=First(G!.cachedFFS,x->IsSubset(x[1]!.radical,r));
+      if A<>fail then
+        hom:=A[2].rest;
+        pcgs:=A[2].pcgs;
+        pc:=CreateIsomorphicPcGroup(pcgs,true,false);
+        iso := GroupHomomorphismByImagesNC( r, pc, pcgs, GeneratorsOfGroup( pc ));
+        r:=rec(inducedfrom:=A[1],
+               radical:=r,
+               factorhom:=hom,
+               depths:=Set(A[2].serdepths), #Set as factors might vanish
+               pcisom:=iso,
+               pcgs:=pcgs);
+        return r;
+      fi;
+      A:=First(G!.cachedFFS,x->IsSubset(r,x[1]!.radical));
+      if A<>fail then
+        b:=Image(A[2].rest);
+        b:=NaturalHomomorphismByNormalSubgroupNC(b,RadicalGroup(b));
+        hom:=A[2]!.rest*b;
+        SetKernelOfMultiplicativeGeneralMapping(hom,r);
+        AddNaturalHomomorphismsPool(G,r,hom);
+      fi;
+    fi;
+    if hom=fail then
+      hom:=NaturalHomomorphismByNormalSubgroup(G,r);
+    fi;
   fi;
 
   A:=Image(hom);


### PR DESCRIPTION
Improve implementartion of `FittingFreeLiftSetup`. In particular enable inheritance of information when group is created.
Better interaction with permutation groups and their homomorphisms.