### PR TITLE
Fix compiler warning on macOS with GCC

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,12 @@
 #include <string.h>
 #include <unistd.h>
 
+#if defined(__APPLE__) && defined(__MACH__)
+// Workaround: TRUE / FALSE are also defined by the macOS Mach-O headers
+#define ENUM_DYLD_BOOL
+#include <mach-o/dyld.h>
+#endif
+
 extern int realmain(int argc, char * argv[]);
 
 /****************************************************************************


### PR DESCRIPTION
With GCC 13 on macOS I was getting this warning:

    warning: implicit declaration of function '_NSGetExecutablePath'
