### PR TITLE
Disable tests for DirectoryHome, DirectoryDesktop

### DIFF
--- a/lib/files.gi
+++ b/lib/files.gi
@@ -297,8 +297,10 @@ end);
 
 InstallGlobalFunction(DirectoryHome,function()
 local a,h,d;
-  if ARCH_IS_WINDOWS() then
-    h:=StringHOMEPath();
+  h:=StringHOMEPath();
+  if h = fail then
+    return fail;
+  elif ARCH_IS_WINDOWS() then
     d:=List(DirectoryContents(h),LowercaseString);
     a:=First(["My Documents", #en
           "Documents", #en-win8
@@ -322,18 +324,17 @@ local a,h,d;
         h := Concatenation(h,"/");
       fi;
       return Directory(Concatenation(h,a));
-    else
-      return Directory(StringHOMEPath());
     fi;
-  else
-    return Directory(StringHOMEPath());
   fi;
+  return Directory(h);
 end);
 
 InstallGlobalFunction(DirectoryDesktop,function()
 local a,h,d;
   h:=StringHOMEPath();
-  if ARCH_IS_WINDOWS() then
+  if h = fail then
+    return fail;
+  elif ARCH_IS_WINDOWS() then
     d:=List(DirectoryContents(h),LowercaseString);
     a:=First(["Desktop",
               "Bureau", #fr
@@ -346,8 +347,6 @@ local a,h,d;
         h := Concatenation(h,"/");
       fi;
       return Directory(Concatenation(h,a));
-    else
-      return Directory(StringHOMEPath());
     fi;
   else
     d:=List(DirectoryContents(h),LowercaseString);
@@ -361,10 +360,9 @@ local a,h,d;
         h := Concatenation(h,"/");
       fi;
       return Directory(Concatenation(h,a));
-    else
-      return Directory(h);
     fi;
   fi;
+  return Directory(h);
 end);
 
 InstallGlobalFunction(RemoveDirectoryRecursively,

--- a/tst/testinstall/dir.tst
+++ b/tst/testinstall/dir.tst
@@ -11,8 +11,9 @@ gap> List(dirs, IsDirectory);
 [ false, true, false, true ]
 gap> DirectoryHome() = Directory("~") or ARCH_IS_WINDOWS();
 true
-gap> ForAll([DirectoryHome, DirectoryDesktop,DirectoryCurrent],
->           x -> (IsDirectoryPath(x()) and IsDirectory(x())) );
+gap> IsDirectoryPath(DirectoryCurrent());
+true
+gap> IsDirectory(DirectoryCurrent());
 true
 gap> dirTest := Concatenation(base,"/dir-test");;
 gap> SortedList(DirectoryContents(dirTest));


### PR DESCRIPTION
These tests are not very important, but easily break -- e.g there might be no "desktop directory". Also, guix sets HOME to an invalid directory path *on purpose*, GAP works 100% in this setting, *except* for this test.

In the other direction, I don't really see anything we can from this test, so instead of trying to fiddle around with it, I decided to just scrap it.

At the same time, let's make the code a little bit more robust in case HOME is not even set.

Resolves #3292