### PR TITLE
Remove compatibility mode from the GAP build system for old GAP packages (all currently distributed packages do not need it anymore)

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -22,8 +22,7 @@ HPCGAP = @HPCGAP@
 # garbage collector source files
 GC_SOURCES = @GC_SOURCES@
 
-# compatibility mode
-COMPAT_MODE = @COMPAT_MODE@
+# GAP architecture string
 GAPARCH = @GAPARCH@
 
 # maintainer mode

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -906,22 +906,6 @@ sysinfo.gap: config.status $(srcdir)/Makefile.rules cnf/GAP-CFLAGS cnf/GAP-CPPFL
 
 
 ########################################################################
-# Compatibility mode
-#
-# If enabled, we prepare the environment to look like it did with
-# the old build system, thus enabling existing packages with kernel
-# extensions to be compiled against this version of GAP/
-########################################################################
-ifeq ($(COMPAT_MODE),yes)
-
-# regenerate bin/gap.sh if necessary
-all: bin/gap.sh
-bin/gap.sh: $(srcdir)/cnf/compat/gap.sh.in config.status
-	$(SHELL) ./config.status $@
-
-endif
-
-########################################################################
 # Specifying GAP calls to use for the test suite and building manuals
 ########################################################################
 

--- a/README.buildsys.md
+++ b/README.buildsys.md
@@ -55,8 +55,6 @@ can follow the standard procedure:
   to add or remove a kernel C source file, you need to add or remove
   its name here and only here.
 
-* `bin/`: This directory is created for compatibility mode (see below).
-
 * `cnf/`: All files in this directory are part of the build system.
 
 * `extern/`: External libraries we bundle with GAP (such as GMP) are
@@ -111,26 +109,6 @@ or `--enable-hpcgap`.
 Once the configure script has completed, you can run `make` as usual,
 and all the object files and the gap executable will be placed inside
 builddir. Your srcdir will remain untouched.
-
-
-## Compatibility mode
-
-Compatibility mode emulates the build environment of the old GAP build system
-in order to allow packages with kernel extensions to be used with the new
-build system unmodified. As such, it mainly exists to ease the transition
-between new and old build system, and the plan is to remove it once all
-packages have been adapted to the new build system. However, that is still
-far off.
-
-Compatibility mode does the following things:
-
-* create a `bin/gap.sh` shell script invoking `gap`
-* ...
-
-For now, using compatibility mode is required if one wants to build the
-kernel extension for most packages which have one. In the future, we will
-provide an alternative way to do this, and also will extend `gac` to
-cleanly supported building kernel extensions.
 
 
 ## Dependency tracking

--- a/cnf/compat/gap.sh.in
+++ b/cnf/compat/gap.sh.in
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-GAP_EXE=$GAP_DIR
-if [ "x$GAP_DIR" = "x" ]; then
-  GAP_DIR=$(cd "@abs_top_srcdir@" && pwd)
-  GAP_EXE="@abs_top_builddir@"
-fi
-
-exec "$GAP_EXE/gap" -l "$GAP_DIR" "$@"

--- a/cnf/compat/gmp.h.in
+++ b/cnf/compat/gmp.h.in
@@ -1,1 +1,0 @@
-#include "@abs_top_builddir@/extern/install/gmp/include/gmp.h"

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,10 @@ AC_CONFIG_AUX_DIR([cnf])
 AC_CONFIG_HEADERS([build/config.h:src/config.h.in])
 AC_CONFIG_COMMANDS([build/stamp-h], [echo timestamp > build/stamp-h])
 
+AS_IF([test "x$srcdir" = x.],
+    [AC_MSG_NOTICE([in-tree build])],
+    [AC_MSG_NOTICE([out-of-tree build])])
+
 dnl note that the final version used by the GAP kernel is GAP_BUILD_VERSION
 dnl and is computed by cnf/gap-version-gen.sh, which takes git commit hashes into
 dnl account to produce a more fine-grained version string for GAP development
@@ -931,33 +935,6 @@ AS_IF([test "x$ARCH" != "x"], [GAPARCH="$ARCH"])
 AC_MSG_RESULT([${GAPARCH}])
 AC_DEFINE_UNQUOTED([GAPARCH], ["$GAPARCH"], [the GAP architecture, for kernel extensions])
 AC_SUBST([GAPARCH])
-
-dnl
-dnl User setting: Compatibility mode (on by default)
-dnl
-AC_ARG_ENABLE([compat-mode],
-    [AS_HELP_STRING([--disable-compat-mode], [enable compatibility mode])],
-    [],
-    [enable_compat_mode=yes]
-    )
-AC_MSG_CHECKING([whether to enable compatibility mode for packages])
-AC_MSG_RESULT([$enable_compat_mode])
-
-AC_SUBST([COMPAT_MODE], [$enable_compat_mode])
-AS_IF([test "x$enable_compat_mode" = xyes],
-    [
-    AC_CONFIG_FILES([bin/gap.sh:cnf/compat/gap.sh.in], [chmod +x bin/gap.sh])
-    AS_IF([test x$BUILD_GMP = xyes],[
-      AC_CONFIG_FILES([bin/$GAPARCH/extern/gmp/include/gmp.h:cnf/compat/gmp.h.in])
-    ])
-    AS_IF([test "x$srcdir" = x.],
-        [
-            AC_MSG_NOTICE([in-tree build])
-        ],
-        [
-            AC_MSG_NOTICE([out-of-tree build])
-        ])
-    ])
 
 
 dnl


### PR DESCRIPTION
I grepped through all distributed packages for uses of `bin/gap.sh`; most packages use it only as a fallback for old GAP versions (which of course is fine). Other packages using it:
- `anupq` uses it in its `tst/make_anupqeg` perl script. This is for internal use and if we (= the anupq maintainers, which is essentially me these days, I think) ever want to run it again, we'll adjust it (and we'll have to make more adjustments anyway)
- `float`, see https://github.com/gap-packages/float/pull/89
- `francy` uses it in a `Dockerfile`, but that doesn't seem relevant (but of course I still submitted https://github.com/gap-packages/francy/pull/108)
- `jupyterkernel` mentions in its README... https://github.com/gap-packages/JupyterKernel/pull/130
- `SCSCP`, see https://github.com/gap-packages/scscp/pull/45
- `ZeroMQInterface` uses it in its `zgap` script, but that is [broken anyway](https://github.com/gap-packages/ZeroMQInterface/issues/6)

IMHO we could just merge then and then inspect if how it affects the package distro, and if necessary, update any affected packages...

Resolves #4996