### PR TITLE
kernel: add missing `#include`

### DIFF
--- a/src/iostream.c
+++ b/src/iostream.c
@@ -70,6 +70,9 @@
 #include <process.h>
 #endif
 
+#ifdef HAVE_SELECT
+#include <sys/time.h>
+#endif
 
 // LOCKING
 // In HPC-GAP, be sure to HashLock PtyIOStreams before accessing any of


### PR DESCRIPTION
This is just a missing header, we use the same #ifdef in other files so this shouldn't break anything

This is needed to build on cosmopolitan libc,.