### PR TITLE
document more standard math functions as discussed in #1778

### DIFF
--- a/lib/float.gd
+++ b/lib/float.gd
@@ -91,7 +91,7 @@ end);
 ##   <Attr Name="Zeta" Arg="f"/>
 ##   <Attr Name="Gamma" Arg="f"/>
 ##   <Description>
-##     Standard math functions. 
+##     Standard math functions.
 ##     Functions ending in an integer like <C>Log2</C>, <C>Log10</C>, <C>Exp2</C> and <C>Exp10</C> indicate the base used, in <C>log</C> and <C>exp</C> the natural base is used, i.e. <M>e</M>.
 ##   </Description>
 ## </ManSection>
@@ -173,7 +173,7 @@ DeclareAttribute("Gamma", IsFloat);
 ##       if <A>x&gt;0</A>.
 ##   </Description>
 ## </ManSection>
-##  
+##
 ## <ManSection>
 ##   <Attr Name="SinCos" Arg="x"/>
 ##   <Returns>The list <C>[sin(x), cos(x)]</C>.</Returns>
@@ -181,12 +181,12 @@ DeclareAttribute("Gamma", IsFloat);
 ##       The function returns a list with <C>sin</C> and <C>cos</C> of of <A>x</A>.
 ##   </Description>
 ## </ManSection>
-##  
+##
 ## <ManSection>
 ##   <Oper Name="Atan2" Arg="y x"/>
 ##   <Returns>The polar angle of <A>(x, y)</A> in the plane as float.</Returns>
 ##   <Description>
-##        Returns the principal value of the argument (polar angle) of (x, y) in the plane. 
+##        Returns the principal value of the argument (polar angle) of (x, y) in the plane.
 ##        The returned value will always be in <M>(-\pi , \pi]</M> and is not defined on <A>(0,0)</A>.
 ##        This function is defined in accordance with IEEE 1788-2015 and imported from IEEE 754.
 ##   </Description>

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -184,8 +184,8 @@ DeclareAttribute("Gamma", IsFloat);
 ##   <Oper Name="Atan2" Arg="y x"/>
 ##   <Returns>The polar angle of <A>(x, y)</A> in the plane as float.</Returns>
 ##   <Description>
-##        Returns the principal value of the argument (polar angle) of (x, y) in the plane.
-##        The returned value will always be in <M>(-\pi , \pi]</M> and is not defined on <A>(0,0)</A>.
+##        Returns the principal value of the argument (polar angle) of <M>(<A>x</A>, <A>y</A>)</M> in the plane.
+##        The returned value will always be in <M>(-\pi , \pi]</M> and is not defined on <M>(0,0)</M>.
 ##        This function is defined in accordance with IEEE 1788-2015 and imported from IEEE 754.
 ##   </Description>
 ## </ManSection>
@@ -193,11 +193,11 @@ DeclareAttribute("Gamma", IsFloat);
 ## <ManSection>
 ##   <Attr Name="Log1p" Arg="x"/>
 ##   <Attr Name="Expm1" Arg="x"/>
-##   <Returns>The natural logarithm of <A>x+1</A> or exponential <M>-1</M> of <A>x</A> respectively.</Returns>
+##   <Returns>The natural logarithm of <M><A>x</A>+1</M> or exponential <M>-1</M> of <A>x</A> respectively.</Returns>
 ##   <Description>
-##       The first function <C>Log1p</C> returns the natural logarithm <M>log(x+1)</M>.
+##       The first function <C>Log1p</C> returns the natural logarithm <M>log(<A>x</A>+1)</M>.
 ##
-##       <P/> The second function <C>Expm1</C> returns the exponential function <M>exp(x)-1</M>
+##       <P/> The second function <C>Expm1</C> returns the exponential function <M>exp(<A>x</A>)-1</M>
 ##
 ##       <P/> These two functions are inverse to each other.
 ##   </Description>
@@ -207,8 +207,8 @@ DeclareAttribute("Gamma", IsFloat);
 ##   <Oper Name="Erf" Arg="x"/>
 ##   <Returns>The error function given by the Gaussian integral</Returns>
 ##   <Description>
-##        Returns the error function imported from IEEE 754 given by the formula:<Br/>
-##        <M> Erf(x) := \frac{2}{\sqrt{\pi}} \int_{0}^{x} exp(- t^2 ) dt </M>
+##        Returns the error function imported from IEEE 754 given by the formula:
+##        <Display> Erf(x) := \frac{2}{\sqrt{\pi}} \int_{0}^{x} exp(- t^2 ) dt </Display>
 ##   </Description>
 ## </ManSection>
 ## <#/GAPDoc>

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -72,14 +72,11 @@ end);
 ##   <Oper Name="Log" Arg="f"/>
 ##   <Attr Name="Log2" Arg="f"/>
 ##   <Attr Name="Log10" Arg="f"/>
-##   <Attr Name="Log1p" Arg="f"/>
 ##   <Attr Name="Exp" Arg="f"/>
 ##   <Attr Name="Exp2" Arg="f"/>
 ##   <Attr Name="Exp10" Arg="f"/>
-##   <Attr Name="Expm1" Arg="f"/>
 ##   <Attr Name="CubeRoot" Arg="f"/>
 ##   <Attr Name="Square" Arg="f"/>
-##   <Oper Name="Atan2" Arg="y x"/>
 ##   <Oper Name="Hypothenuse" Arg="x y"/>
 ##   <Attr Name="Ceil" Arg="f"/>
 ##   <Attr Name="Floor" Arg="f"/>
@@ -90,12 +87,12 @@ end);
 ##   <Attr Name="AbsoluteValue" Arg="f" Label="for floats"/>
 ##   <Attr Name="Norm" Arg="f" Label="for floats"/>
 ##   <Attr Name="Frac" Arg="f"/>
-##   <Attr Name="SinCos" Arg="f"/>
 ##   <Attr Name="Erf" Arg="f"/>
 ##   <Attr Name="Zeta" Arg="f"/>
 ##   <Attr Name="Gamma" Arg="f"/>
 ##   <Description>
-##     Standard math functions.
+##     Standard math functions. 
+##     Functions ending in an integer like <C>Log2</C>, <C>Log10</C>, <C>Exp2</C> and <C>Exp10</C> indicate the base used, in <C>log</C> and <C>exp</C> the natural base is used, i.e. <M>e</M>.
 ##   </Description>
 ## </ManSection>
 ## <#/GAPDoc>
@@ -121,25 +118,21 @@ DeclareAttribute("Atanh", IsFloat);
 DeclareOperation("Log", [IsFloat]);
 DeclareAttribute("Log2", IsFloat);
 DeclareAttribute("Log10", IsFloat);
-DeclareAttribute("Log1p", IsFloat);
 DeclareAttribute("Exp", IsFloat);
 DeclareAttribute("Exp2", IsFloat);
 DeclareAttribute("Exp10", IsFloat);
-DeclareAttribute("Expm1", IsFloat);
 DeclareAttribute("CubeRoot", IsFloat);
 DeclareAttribute("Square", IsFloat);
 DeclareAttribute("Ceil", IsFloat);
 DeclareAttribute("Floor", IsFloat);
 DeclareAttribute("Round", IsFloat);
 DeclareAttribute("Trunc", IsFloat);
-DeclareOperation("Atan2", [IsFloat, IsFloat]);
 DeclareAttribute("FrExp", IsFloat);
 DeclareOperation("LdExp", [IsFloat, IsInt]);
 DeclareAttribute("AbsoluteValue", IsFloat);
 #DeclareAttribute("Norm", IsFloat); # already defined
 DeclareOperation("Hypothenuse", [IsFloat, IsFloat]);
 DeclareAttribute("Frac", IsFloat);
-DeclareAttribute("SinCos", IsFloat);
 DeclareAttribute("Erf", IsFloat);
 DeclareAttribute("Zeta", IsFloat);
 DeclareAttribute("Gamma", IsFloat);
@@ -180,12 +173,46 @@ DeclareAttribute("Gamma", IsFloat);
 ##       if <A>x&gt;0</A>.
 ##   </Description>
 ## </ManSection>
-## <#/GAPDoc>
+##  
+## <ManSection>
+##   <Attr Name="SinCos" Arg="x"/>
+##   <Returns>The list <C>[sin(x), cos(x)]</C>.</Returns>
+##   <Description>
+##       The function returns a list with <C>sin</C> and <C>cos</C> of of <A>x</A>.
+##   </Description>
+## </ManSection>
+##  
+## <ManSection>
+##   <Oper Name="Atan2" Arg="y x"/>
+##   <Returns>The polar angle of <A>(x, y)</A> in the plane as float.</Returns>
+##   <Description>
+##        Returns the principal value of the argument (polar angle) of (x, y) in the plane. 
+##        The returned value will always be in <M>(-\pi , \pi]</M> and is not defined on <A>(0,0)</A>.
+##        This function is defined in accordance with IEEE 1788-2015 and imported from IEEE 754.
+##   </Description>
+## </ManSection>
 ##
+## <ManSection>
+##   <Attr Name="Log1p" Arg="x"/>
+##   <Attr Name="Expm1" Arg="x"/>
+##   <Returns>The natural logarithm of <A>x+1</A> or exponential <M>-1</M> of <A>x</A> respectively.</Returns>
+##   <Description>
+##       The first function <C>Log1p</C> returns the natural logarithm <M>log(x+1)</M>.
+##
+##       <P/> The second function <C>Expm1</C> returns the exponential function <M>exp(x)-1</M>
+##
+##       <P/> These two functions are inverse to each other.
+##   </Description>
+## </ManSection>
+## <#/GAPDoc>
 DeclareOperation("EqFloat", [IsFloat, IsFloat]);
 DeclareAttribute("PrecisionFloat", IsFloat);
 DeclareAttribute("SignBit", IsFloat);
 DeclareAttribute("SignFloat", IsFloat);
+DeclareAttribute("SinCos", IsFloat);
+DeclareOperation("Atan2", [IsFloat, IsFloat]);
+DeclareAttribute("Log1p", IsFloat);
+DeclareAttribute("Expm1", IsFloat);
 ################################################################
 
 ################################################################

--- a/lib/float.gd
+++ b/lib/float.gd
@@ -87,7 +87,6 @@ end);
 ##   <Attr Name="AbsoluteValue" Arg="f" Label="for floats"/>
 ##   <Attr Name="Norm" Arg="f" Label="for floats"/>
 ##   <Attr Name="Frac" Arg="f"/>
-##   <Attr Name="Erf" Arg="f"/>
 ##   <Attr Name="Zeta" Arg="f"/>
 ##   <Attr Name="Gamma" Arg="f"/>
 ##   <Description>
@@ -133,7 +132,6 @@ DeclareAttribute("AbsoluteValue", IsFloat);
 #DeclareAttribute("Norm", IsFloat); # already defined
 DeclareOperation("Hypothenuse", [IsFloat, IsFloat]);
 DeclareAttribute("Frac", IsFloat);
-DeclareAttribute("Erf", IsFloat);
 DeclareAttribute("Zeta", IsFloat);
 DeclareAttribute("Gamma", IsFloat);
 
@@ -204,6 +202,15 @@ DeclareAttribute("Gamma", IsFloat);
 ##       <P/> These two functions are inverse to each other.
 ##   </Description>
 ## </ManSection>
+##
+## <ManSection>
+##   <Oper Name="Erf" Arg="x"/>
+##   <Returns>The error function given by the Gaussian integral</Returns>
+##   <Description>
+##        Returns the error function imported from IEEE 754 given by the formula:<Br/>
+##        <M> Erf(x) := \frac{2}{\sqrt{\pi}} \int_{0}^{x} exp(- t^2 ) dt </M>
+##   </Description>
+## </ManSection>
 ## <#/GAPDoc>
 DeclareOperation("EqFloat", [IsFloat, IsFloat]);
 DeclareAttribute("PrecisionFloat", IsFloat);
@@ -213,6 +220,7 @@ DeclareAttribute("SinCos", IsFloat);
 DeclareOperation("Atan2", [IsFloat, IsFloat]);
 DeclareAttribute("Log1p", IsFloat);
 DeclareAttribute("Expm1", IsFloat);
+DeclareAttribute("Erf", IsFloat);
 ################################################################
 
 ################################################################


### PR DESCRIPTION
I documented more of the "standard" math functions which are mostly imported from IEEE 754, as discussed in #1778. Fortunately from the university library I have access to the IEEE documents, so I could verify that this is what the standard intended. 

However I was not able to find a definition for ```Erf(x)```. I assume it is the error function as described here:
https://mathworld.wolfram.com/Erf.html
https://en.wikipedia.org/wiki/Error_function
But as I am unsure if e.g. the scalar factor in front is used and the function is implemented from a C library I would like some clarification from someone more experienced than me. As soon as I have this, I will make this not a draft and we can merge.

## Text for release notes
none