### PR TITLE
Fix an unexpected error in `GQuotients` (by fixing a bug in the cyclic modified Todd-Coxeter)

### DIFF
--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -2847,7 +2847,12 @@ local c,offset,f,b,r,i,j,fp,bp;
     od;
     if i>r then
       if f<>alpha then
-        NEWTC_ModifiedCoincidence(DATA,f,alpha,WordProductLetterRep(-Reversed(fp),y));
+        if DATA.useAddition then
+          NEWTC_ModifiedCoincidence(DATA,f,alpha,-fp+y);
+        else
+          NEWTC_ModifiedCoincidence(DATA,f,alpha,
+            WordProductLetterRep(-Reversed(fp),y));
+        fi;
       fi;
       return;
     fi;

--- a/tst/testbugfix/2023-10-28-GQuotients.tst
+++ b/tst/testbugfix/2023-10-28-GQuotients.tst
@@ -1,0 +1,7 @@
+# Fix unexpected error in GQuotients.
+# See https://github.com/gap-system/gap/issues/5525
+#
+gap> G := FreeGroup(2);;
+gap> Q := G / [G.1*G.2^-2*G.1, G.1^-1*G.2^-3];;
+gap> GQuotients(Q, SmallGroup(12, 1));
+[  ]


### PR DESCRIPTION
When rewriting to cyclic subgroup words are just numbers, not lists. Thus concatenation needs to be replaced by addition. This was overlooked in one case.

This will fix #5525

Extracted from PR #5521 which mixes multiple changes.