### PR TITLE
Fix for #5539 m& for NewmanInfinityTest

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -1422,7 +1422,9 @@ local c, flip, maxidx, cano, tryfct, p, r, t,
         # in the normal case, we can obtain the other orbits easily via
         # the orbit theorem (same stabilizer)
         if Size(lst)/Size(st)<10 then
-          rt:=Orbit(lst,One(st),
+          # if the group `st` is handled by a nice monomorphism, the
+          # identity might not be the canonical element for the subgroup.
+          rt:=Orbit(lst,CanonicalRightCosetElement(st,One(st)),
             function(rep,g) return CanonicalRightCosetElement(st,rep*g);end);
         else
           rt:=RightTransversal(lst,st:noascendingchain);

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5525,9 +5525,10 @@ local GO,q,d,e,b,r,val,agemo,ngens;
   ngens:=32;
   repeat
     ngens:=ngens*8;
-    q:=PQuotient(G,p,2,ngens);
+    q:=PQuotient(G,p,2,ngens:noninteractive);
   until q<>fail;
   q:=Image(EpimorphismQuotientSystem(q));
+  # factor out G^p
   q:=ShallowCopy(PCentralSeries(q,p));
   if Length(q)=1 then
     Error("Trivial <p> quotient");
@@ -5535,9 +5536,12 @@ local GO,q,d,e,b,r,val,agemo,ngens;
   if Length(q)=2 then
     Add(q,q[2]); # maximal quotient is abelian, second term is trivial
   fi;
+
   d:=LogInt(Index(q[1],q[2]),p);
 
   if p=2 then
+    # This case is taken from the book by Johnson, as Newman's paper only
+    # treats odd n.
     e:=LogInt(Index(q[2],q[3]),p);
     Info(InfoFpGroup,1,b," generators, ",r," relators, p=",p,", d=",d," e=",e);
     q:=r-b+d;

--- a/tst/testbugfix/2023-12-07-DCoset.tst
+++ b/tst/testbugfix/2023-12-07-DCoset.tst
@@ -1,0 +1,5 @@
+# Issue #5539
+gap> T := SmallGroup( 4, 2 );;
+gap> G := SmallGroup( 9, 2 );;
+gap> A := AutomorphismGroup(T);;
+gap> homs := AllHomomorphisms(G,A);;


### PR DESCRIPTION
Two fixes for error messages. One from #5539 and one in `NewmanInfinityTest` to quietly increase generator number as needed without error message.