### PR TITLE
Set non-zero exit code if init.g not found

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -322,7 +322,8 @@ GAPInput
     ;;
 
   testexpect)
-    INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b  --cover $COVDIR/${TEST_SUITE}.coverage" $SRCDIR/dev/gaptest.expect
+    INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b --cover $COVDIR/${TEST_SUITE}.coverage" $SRCDIR/dev/gaptest.expect
+    INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b --cover $COVDIR/${TEST_SUITE}.coverage -l missing-dir" $SRCDIR/dev/gaptest2.expect
     ;;
 
   *)

--- a/dev/gaptest2.expect
+++ b/dev/gaptest2.expect
@@ -1,0 +1,10 @@
+set timeout 10
+
+# from https://serverfault.com/a/981762
+expect_before {
+    timeout { puts " TIMEOUT "; exit 2 }
+    eof     { puts " EOF ";     exit 1 }
+}
+
+expect "gap: hmm, I cannot find 'lib/init.g' maybe use option '-l <gaproot>'?"
+exit

--- a/src/gap.c
+++ b/src/gap.c
@@ -1524,9 +1524,9 @@ void InitializeGap (
     if ( SyLoadSystemInitFile ) {
       GAP_TRY {
         if ( READ_GAP_ROOT("lib/init.g") == 0 ) {
-                Pr( "gap: hmm, I cannot find 'lib/init.g' maybe",
-                    0, 0);
-                Pr( " use option '-l <gaproot>'?", 0, 0);
+                Pr( "gap: hmm, I cannot find 'lib/init.g' maybe"
+                    " use option '-l <gaproot>'?\n", 0, 0);
+                SystemErrorCode = 1;
             }
       }
       GAP_CATCH {


### PR DESCRIPTION
Also make the error message in this case visible again.

Resolves #5541