### PR TITLE
Two small fixes from working with U4(3)

### DIFF
--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -290,6 +290,7 @@ function(g,str,N)
       od;
       if Size(ser[1])<Size(f) then
         ser:=ChiefSeriesThrough(f,ser);
+        gens:=Union(gens,Union(List(ser,SmallGeneratingSet)));
       fi;
       if f<>g then
         gens:=List(gens,x->PreImagesRepresentative(hom,x));
@@ -300,6 +301,7 @@ function(g,str,N)
     else
       rad:=g;
     fi;
+
     if Length(ser)=0 or Size(ser[Length(ser)])>Size(rad) then Add(ser,rad);fi;
 
     if Size(rad)>1 then
@@ -479,6 +481,7 @@ function(g,str,N)
   vals:=[];
 
   dec:=[];
+
   for i in [2..Length(ser)] do
     still:=i<Length(ser);
     lgens:=gens{idx[i-1]};

--- a/lib/oprtglat.gi
+++ b/lib/oprtglat.gi
@@ -468,11 +468,11 @@ local n,l, o, b, t, r;
     #and NrMovedPoints(G)*1000>Size(G) then
 
     b:=SmallerDegreePermutationRepresentation(G:cheap);
-    if NrMovedPoints(Range(b))<NrMovedPoints(G) then
-      dom:=SubgroupsOrbitsAndNormalizers(Image(b,G),
+    if NrMovedPoints(Range(b))*13/10<NrMovedPoints(G) then
+      l:=SubgroupsOrbitsAndNormalizers(Image(b,G),
         List(dom,x->Image(b,x)),all);
-      dom:=List(dom,x->rec(pos:=x.pos,normalizer:=PreImage(b,x.normalizer),
-        representative:=dom[x]));
+      dom:=List(l,x->rec(pos:=x.pos,normalizer:=PreImage(b,x.normalizer),
+        representative:=dom[x.pos]));
       return dom;
     fi;
   fi;


### PR DESCRIPTION
Fix for action on subgroups through smaller degree, as well as generator selection for building a rewriting system of a group.

Both errors lead to error messages. 

The example in which I found them is to take G=Aut(U4(3)) and to calculate the subgroup lattice and `IsomorphismFpGroupForRewriting` for it. Both seem too large/costly to add to the standard test suite.