### PR TITLE
Fixed printing of GAP strings containing null characters (skip them instead of truncating the string)

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1594,6 +1594,7 @@ static inline void FormatOutput(
 
     // '%s' or '%g' print a string
     else if ( *p == 's' || *p == 'g') {
+      UInt len;
 
       // If arg is a GAP obj, get out the contained string, and
       // set arg1obj so we can re-evaluate after any possible GC
@@ -1601,15 +1602,18 @@ static inline void FormatOutput(
       if (*p == 'g') {
         arg1obj = (Obj)arg1;
         arg1 = (Int)CONST_CSTR_STRING(arg1obj);
+        len = GET_LEN_STRING(arg1obj);
       }
       else {
         arg1obj = 0;
+        len = strlen((const Char *)arg1);
       }
 
       // compute how many characters this identifier requires
-      for ( const Char * q = (const Char *)arg1; *q != '\0' && prec > 0; q++ ) {
-        prec--;
-      }
+      if(len >= prec)
+        prec = 0;
+      else
+        prec -= len;
 
       // if wanted push an appropriate number of <space>-s
       while ( prec-- > 0 )  put_a_char(state, ' ');
@@ -1621,8 +1625,9 @@ static inline void FormatOutput(
       // print the string
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
-      for ( Int i = 0; ((const Char *)arg1)[i] != '\0'; i++ ) {
+      for ( Int i = 0; i < len; i++ ) {
           const Char* q = ((const Char *)arg1) + i;
+          if (*q == '\0') continue;
           if (*q == '\\' && IO()->NoSplitLine == 0) {
               if (*(q + 1) < '8' && *(q + 1) >= '0')
                   IO()->NoSplitLine = 3;

--- a/src/io.c
+++ b/src/io.c
@@ -1610,7 +1610,7 @@ static inline void FormatOutput(
       }
 
       // compute how many characters this identifier requires
-      if(len >= prec)
+      if (len >= prec)
         prec = 0;
       else
         prec -= len;
@@ -1625,9 +1625,13 @@ static inline void FormatOutput(
       // print the string
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
-      for ( Int i = 0; i < len; i++ ) {
+      while (len--) {
         const Char* q = ((const Char *)arg1) + i;
-        if (*q == '\0') continue;
+        // skip null bytes; this means 'prec' is off in this case. Fixing this
+        // is not worth the effort. So instead, new rule: if you print strings
+        // with null bytes, behavior of 'prec' is undefined.
+        if (*q == '\0')
+          continue;
         if (*q == '\\' && IO()->NoSplitLine == 0) {
           if (*(q + 1) < '8' && *(q + 1) >= '0')
             IO()->NoSplitLine = 3;

--- a/src/io.c
+++ b/src/io.c
@@ -1619,23 +1619,23 @@ static inline void FormatOutput(
       while ( prec-- > 0 )  put_a_char(state, ' ');
 
       if (arg1obj) {
-          arg1 = (Int)CONST_CSTR_STRING(arg1obj);
+        arg1 = (Int)CONST_CSTR_STRING(arg1obj);
       }
 
       // print the string
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
       for ( Int i = 0; i < len; i++ ) {
-          const Char* q = ((const Char *)arg1) + i;
-          if (*q == '\0') continue;
-          if (*q == '\\' && IO()->NoSplitLine == 0) {
-              if (*(q + 1) < '8' && *(q + 1) >= '0')
-                  IO()->NoSplitLine = 3;
-              else
-                  IO()->NoSplitLine = 1;
+        const Char* q = ((const Char *)arg1) + i;
+        if (*q == '\0') continue;
+        if (*q == '\\' && IO()->NoSplitLine == 0) {
+          if (*(q + 1) < '8' && *(q + 1) >= '0')
+            IO()->NoSplitLine = 3;
+          else
+            IO()->NoSplitLine = 1;
         }
         else if (IO()->NoSplitLine > 0)
-            IO()->NoSplitLine--;
+          IO()->NoSplitLine--;
         put_a_char(state, *q);
 
         if (arg1obj) {

--- a/src/io.c
+++ b/src/io.c
@@ -1625,7 +1625,7 @@ static inline void FormatOutput(
       // print the string
       /* must be careful that line breaks don't go inside
          escaped sequences \n or \123 or similar */
-      while (len--) {
+      for (UInt i = 0; i < len; i++) {
         const Char* q = ((const Char *)arg1) + i;
         // skip null bytes; this means 'prec' is off in this case. Fixing this
         // is not worth the effort. So instead, new rule: if you print strings

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -218,4 +218,12 @@ gap> ReplacedString("Hello world", "", "*");
 Error, <old> must not be empty
 
 #
+gap> x := "abc\000def";
+"abc\000def"
+gap> Length(x);
+7
+gap> Print(x, "\n");
+abcdef
+
+#
 gap> STOP_TEST( "strings.tst", 1);


### PR DESCRIPTION
Fixes #4120.

Print function used to have a problem: if a GAP string contained a null character, then the string was printed only up to the null character (which is an expected behavior for traditional C strings). Now a GAP string conaining a null character would be printed from start to end and the null character would be skipped.


## Text for release notes

See title.