### PR TITLE
Allow to override GAP_BUILD_DATETIME with `SOURCE_DATE_EPOCH`

### DIFF
--- a/cnf/gap-version-gen.sh
+++ b/cnf/gap-version-gen.sh
@@ -43,5 +43,5 @@ fi
 test "$VN" = "$VC" || {
 	echo >&2 "GAP_BUILD_VERSION = $VN"
 	echo "GAP_BUILD_VERSION = $VN" >$GVF
-	echo "GAP_BUILD_DATETIME = $(date '+%Y-%m-%d %H:%M:%S%z')" >>$GVF
+	echo "GAP_BUILD_DATETIME = $(date -u -d@${SOURCE_DATE_EPOCH:-$(date +%s)} '+%Y-%m-%d %H:%M:%S%z')" >>$GVF
 }


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.

## Text for release notes

see title

## Further details

See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This `date` call only works with GNU date.

Alternative approaches to reproducible results:
* use `date -r path/to/CHANGES.md`
* use a more complex patch that also supports FreeBSD/MacOS
* drop `GAP_BUILD_DATETIME`

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).