### PR TITLE
Disable storing build date and time when SOURCE_DATE_EPOCH is defined

### DIFF
--- a/cnf/gap-version-gen.sh
+++ b/cnf/gap-version-gen.sh
@@ -43,5 +43,9 @@ fi
 test "$VN" = "$VC" || {
 	echo >&2 "GAP_BUILD_VERSION = $VN"
 	echo "GAP_BUILD_VERSION = $VN" >$GVF
-	echo "GAP_BUILD_DATETIME = $(date '+%Y-%m-%d %H:%M:%S%z')" >>$GVF
+	if [ -z "$SOURCE_DATE_EPOCH" ]; then
+		echo "GAP_BUILD_DATETIME = $(date '+%Y-%m-%d %H:%M:%S%z')" >>$GVF
+	else
+		echo "GAP_BUILD_DATETIME = reproducible" >>$GVF
+	fi
 }

--- a/lib/init.g
+++ b/lib/init.g
@@ -438,6 +438,8 @@ BindGlobal( "ShowKernelInformation", function()
   if GAPInfo.Date <> "today" then
     sysdate := " of ";
     Append(sysdate, GAPInfo.Date);
+  elif GAPInfo.BuildDateTime = "reproducible" then
+    sysdate := "";
   else
     sysdate := " built on ";
     Append(sysdate, GAPInfo.BuildDateTime);

--- a/src/version.c.in
+++ b/src/version.c.in
@@ -47,6 +47,7 @@ const char * SyBuildVersion = "@GAP_BUILD_VERSION@";
 *V  SyBuildDateTime . . . . . . . . . .  date and time the build was compiled
 **
 **  'SyBuildDateTime' is set to something like "2020-01-30 09:48:08", with
-**  the value given in local time.
+**  the value given in local time, or 'reproducible' if GAP was built without
+**  a build time, to create a reproducible executable.
 */
 const char * SyBuildDateTime = "@GAP_BUILD_DATETIME@";


### PR DESCRIPTION
Alternative to #5550 . While this doesn't do what we are 'supposed' to do (use SOURCE_DATE_EPOCH as the source of the date), it has the advantage it (should) work on mac os x and BSD. Rather than print a false build time, just don't store, or print, the build time when SOURCE_DATE_EPOCH is defined