### PR TITLE
Avoid passing immutable objects to Objectify

### DIFF
--- a/lib/rvecempt.gi
+++ b/lib/rvecempt.gi
@@ -32,7 +32,7 @@ InstallMethod( EmptyRowVector,
                                    IsRowVector
                                and IsEmpty
                                and IsEmptyRowVectorRep ),
-                      MakeImmutable([]) );
+                      [] );
     end );
 
 

--- a/lib/rwsgrp.gi
+++ b/lib/rwsgrp.gi
@@ -23,8 +23,7 @@ InstallMethod( ElementByRws,
     0,
 
 function( fam, elm )
-    elm := Immutable([ elm ]);
-    return Objectify( fam!.defaultType, elm );
+    return Objectify( fam!.defaultType, [ elm ] );
 end );
 
 ##
@@ -43,8 +42,7 @@ function( fam, list )
 
     freefam := UnderlyingFamily( fam!.rewritingSystem );
     elm := ObjByExtRep( freefam, list );
-    elm := Immutable([ elm ]);
-    return Objectify( fam!.defaultType, elm );
+    return Objectify( fam!.defaultType, [ elm ] );
 end );
 
 

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1380,7 +1380,7 @@ InstallGlobalFunction( InputOutputLocalProcess,
     od;
     basename := exec{[i+1..Length(exec)]};
     return Objectify(InputOutputStreamByPtyDefaultType,
-                   Immutable([ptynum, basename, argts, false]) );
+                   [ptynum, Immutable(basename), Immutable(argts), false] );
 end);
 
 #############################################################################


### PR DESCRIPTION
Immutable objects should never be able to turn into mutable objects. Strictly speaking this is violated when passing an immutable list or record to Objectify. Unfortunately we can't currently reject such inputs because some GAP library code relies on this misfeature (and possibly also in some packages). But we can at least reduce the occurrences for now to prepare for a potential stricter future.

This is part of my long-term goal to minimize "magic" changes to GAP types, which is an incredibly dangerous feature. It also makes correct and sage bridging to other language more difficult: foreign language wrapper objects around GAP objects always have to worry about the GAP object magically changing. It also was always an issue for HPC-GAP. Thus I hope that one day we can restrict this to a minimal and fully enumerable set of possible conversions.