### PR TITLE
Replace uses of `x->IsBound(x)`

### DIFF
--- a/benchmark/transgrp/examine4
+++ b/benchmark/transgrp/examine4
@@ -60,7 +60,7 @@ local i,p;
       Unbind(a[p]);
     fi;
   od;
-  return Filtered(a,i->IsBound(i));
+  return Compacted(a);
 end;
 
 GroupOrbitsMinimumEach := function(G,l)

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -4391,7 +4391,7 @@ local ReductionModuloTable,   #
 
           Unbind(r[n]);
        fi;
-       r:= Filtered( r, x -> IsBound(x) );
+       r:= Compacted( r );
 
      fi;
 
@@ -4440,7 +4440,7 @@ local ReductionModuloTable,   #
          fi;
        fi;
      od;
-     a:=Filtered(a,x -> IsBound(x));
+     a:=Compacted(a);
      a:= CollectPolynomial( a );
 
      if a = [ ] or a[1][2] = one then
@@ -4546,7 +4546,7 @@ local ReductionModuloTable,   #
            s:= List( s, x -> [ x[1], -rel[i][2]*x[2] ] );
            Append( rel, s );
            Unbind( rel[i] );
-           rel:= Filtered( rel, x -> IsBound( x ) );
+           rel:= Compacted( rel );
 
          else
            i:= i+1;
@@ -4635,12 +4635,10 @@ local ReductionModuloTable,   #
        Tij:= _T[s][t];
        pos:= Position( Tij[1], var );
        if pos <> fail then
-         Unbind( Tij[1][pos] );
+         Remove( Tij[1], pos );
          cf:= Tij[2][pos];
          if s <> c[1] then cf:= -cf; fi;
-         Unbind( Tij[2][pos] );
-         Tij[1]:= Filtered( Tij[1], x -> IsBound(x) );
-         Tij[2]:= Filtered( Tij[2], x -> IsBound(x) );
+         Remove( Tij[2], pos );
          Append( Tij[1], inds );
          Append( Tij[2],  cf*cfs );
          ii:= [ ]; cc:= [ ];
@@ -4714,7 +4712,7 @@ local ReductionModuloTable,   #
          max:= Maximum( max, Length( Flat(r[j][1]) ) );
        fi;
      od;
-     r:= Filtered( r, x -> IsBound(x) );
+     r:= Compacted( r );
      r:= LeftNormalization( r );
      r:= CollectPolynomial( r );
      if not max = 0 then
@@ -5161,7 +5159,7 @@ local ReductionModuloTable,   #
 
                od;
                if relation_found then break; fi;
-               rr:=Filtered(rr,x -> IsBound(x));
+               rr:=Compacted(rr);
              fi;
 
            fi;
@@ -5398,7 +5396,7 @@ local ReductionModuloTable,   #
              Unbind( defs[j][k] );
            fi;
          od;
-         defs[j]:= Filtered( defs[j], x -> IsBound( x ) );
+         defs[j]:= Compacted( defs[j] );
        od;
        i:= i-1;
      od;

--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -1392,9 +1392,8 @@ InstallMethod(\+,
     sum:=  ZippedSum( lu, lv, zero, [\<,\+] );
     if Length( sum ) >= 2 then
         if sum[1] = [] and sum[2] = zero then
-            Unbind( sum[1] );
-            Unbind( sum[2] );
-            sum:= Filtered( sum , x -> IsBound(x) );
+            Remove( sum, 1 );
+            Remove( sum, 1 );
         fi;
     fi;
     if sum = [ ] then sum:= [ [], zero ]; fi;
@@ -1536,10 +1535,8 @@ BindGlobal( "TriangulizeMonomialElementList", function( tt, zero, LM, LC )
         if IsZero( tt[k] ) then
 
             # Get rid of it.
-            Unbind( tt[k] );
-            Unbind( basechange[k] );
-            tt:= Filtered( tt, x -> IsBound( x ) );
-            basechange:= Filtered( basechange, x -> IsBound( x ) );
+            Remove( tt, k );
+            Remove( basechange, k );
         else
 
             # Eliminate all instances of `LM( tt[k] )' that occur `below'
@@ -1560,11 +1557,8 @@ BindGlobal( "TriangulizeMonomialElementList", function( tt, zero, LM, LC )
                     if IsZero( tt[i] ) then
 
                         # Get rid of it.
-                        Unbind( tt[i] );
-                        Unbind( basechange[i] );
-                        tt:= Filtered( tt, x -> IsBound( x ) );
-                        basechange:= Filtered( basechange,
-                                             x -> IsBound( x ) );
+                        Remove( tt, i );
+                        Remove( basechange, i );
                     else
 
                         # Adjust the i-th entry in basechange, we basically
@@ -1882,8 +1876,8 @@ InstallMethod( ConvertToNormalFormMonomialElement,
             fi;
 
         od;
-        tensors:= Filtered( tensors, x -> IsBound( x ) );
-        cfts:= Filtered( cfts, x -> IsBound( x ) );
+        tensors:= Compacted( tensors );
+        cfts:= Compacted( cfts );
     od;
 
     # Merge tensors and coefficients, take equal tensors together.
@@ -2268,9 +2262,9 @@ InstallMethod( ConvertToNormalFormMonomialElement,
             fi;
 
         od;
-        tensors:= Filtered( tensors, x -> IsBound( x ) );
-        cfts:= Filtered( cfts, x -> IsBound( x ) );
-        wedge_inds:= Filtered( wedge_inds, x -> IsBound( x ) );
+        tensors:= Compacted( tensors );
+        cfts:= Compacted( cfts );
+        wedge_inds:= Compacted( wedge_inds );
     od;
 
     # Merge wedges and coefficients, apply permutations to make the wedges
@@ -2292,9 +2286,9 @@ InstallMethod( ConvertToNormalFormMonomialElement,
 
     od;
 
-    tensors:= Filtered( tensors, x -> IsBound(x) );
-    wedge_inds:= Filtered( wedge_inds, x -> IsBound(x) );
-    cfts:= Filtered( cfts, x -> IsBound(x) );
+    tensors:= Compacted( tensors );
+    wedge_inds:= Compacted( wedge_inds );
+    cfts:= Compacted( cfts );
 
     perm:= Sortex( tensors );
     cfts:= Permuted( cfts, perm );
@@ -2602,9 +2596,9 @@ InstallMethod( ConvertToNormalFormMonomialElement,
             fi;
 
         od;
-        tensors:= Filtered( tensors, x -> IsBound( x ) );
-        cfts:= Filtered( cfts, x -> IsBound( x ) );
-        symmetric_inds:= Filtered( symmetric_inds, x -> IsBound( x ) );
+        tensors:= Compacted( tensors );
+        cfts:= Compacted( cfts );
+        symmetric_inds:= Compacted( symmetric_inds );
     od;
 
     # Merge symmetric elements and coefficients, apply permutations to make
@@ -3011,10 +3005,8 @@ BindGlobal( "BasisOfSparseRowSpace",
         if IsZero( tt[k] ) then
 
             # Get rid of it.
-            Unbind( tt[k] );
-            Unbind( basechange[k] );
-            tt:= Filtered( tt, x -> IsBound( x ) );
-            basechange:= Filtered( basechange, x -> IsBound( x ) );
+            Remove( tt, k );
+            Remove( basechange, k );
         else
 
             # If there is a vector starting with the same index as `tt[k]'
@@ -3038,11 +3030,8 @@ BindGlobal( "BasisOfSparseRowSpace",
                     if IsZero( tt[i] ) then
 
                         # Get rid of it.
-                        Unbind( tt[i] );
-                        Unbind( basechange[i] );
-                        tt:= Filtered( tt, x -> IsBound( x ) );
-                        basechange:= Filtered( basechange,
-                                             x -> IsBound( x ) );
+                        Remove( tt, i );
+                        Remove( basechange, i );
                     else
 
                         # Adjust the i-th entry in basechange, we basically

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -341,7 +341,7 @@ local clT,        # classes T
           cen:=centralizers[t];
 
           if not IsBound(etas[t]) then
-            if Number(etas,i->IsBound(i))>500 then
+            if Number(etas)>500 then
               for d in
                 Filtered([1..Length(etas)],i->IsBound(etas[i])){[1..500]} do
                 Unbind(etas[d]);
@@ -2288,7 +2288,7 @@ if miss<>1 then
   # something is dodgy -- fallback to the default algorithm
   return fail;Error("HEH?");fi;
     Info(InfoHomClass,3,"Fused ",Length(norb),"*",norb[1].len," ",
-      Number(orb,x->IsBound(x))," left");
+      Number(orb)," left");
     Assert(1,ForAll(rsgens,x->norb[1].rep*bas*npcgsact(x)*basinv=norb[1].rep));
     Assert(1,ForAll(sgens,x->norb[1].rep*bas*npcgsact(x)*basinv=norb[1].rep));
 #if ForAny(rsgens,x->Order(x)=1) then Error("HUH5"); fi;

--- a/lib/galois.gi
+++ b/lib/galois.gi
@@ -939,7 +939,7 @@ local f,n,p,cand,noca,alt,d,co,dco,res,resf,pat,i,j,k,
           co[i]:=co[i][1]; # throw away unneeded list
           dco[i]:=UnParOrbits(co[i]);
         od;
-        degs:=List(Filtered(co,i->IsBound(i)),GrabCodedLengths);
+        degs:=List(Compacted(co),GrabCodedLengths);
 
         res:=GetResolvent(f,act);
         resf:=Factors(polring,res:factoroptions:=rec(onlydegs:=Union(degs)));

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -3863,7 +3863,7 @@ local divs,limit,mode,l,process,done,bound,maxer,prime;
               fi;
             od;
           od;
-          a:=Filtered(a,x->IsBound(x));
+          a:=Compacted(a);
           if tb>bound and Length(a)>5*10^(1+LogInt((1+QuoInt(tb,bound)),prime)) then
             bound:=bound*prime;
             tb:=infinity;

--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -595,7 +595,7 @@ InstallGlobalFunction( LieCoboundaryOperator,
              elts:= bL{t};
              z:= elts[q]*elts[r];
              Unbind( elts[q] ); Unbind( elts[r] );
-             elts:= Filtered( elts, x -> IsBound( x ) );
+             elts:= Compacted( elts );
              inp:= [ c ]; Append( inp, elts ); Add( inp, z );
              val:= val+(-1)^(q+r)*ValueCochain( inp );
            od;
@@ -1614,7 +1614,7 @@ InstallGlobalFunction( CollectUEALatticeElement,
                  Add( fac, e[k+1] ); Unbind( e[k+1] );
              fi;
          od;
-         e:= Filtered( e, x-> IsBound(x) );
+         e:= Compacted( e );
          # `e' now contains the rest of the polynomial.
 
          p:= PolynomialByExtRepNC( fam, fac )/(vars[1]^d);
@@ -1648,7 +1648,7 @@ InstallGlobalFunction( CollectUEALatticeElement,
              fi;
          od;
 
-         return Filtered( res, x -> IsBound(x) );
+         return Compacted( res );
      end;
 
 
@@ -1735,9 +1735,8 @@ InstallGlobalFunction( CollectUEALatticeElement,
                 mon[i+1]:= mon[i+1]+mon[i+3];
                 todo[2]:= todo[2]*Binomial(mon[i+1],mon[i+3]);
 
-                Unbind( mon[i+2] );
-                Unbind( mon[i+3] );
-                mon:= Filtered( mon, x -> IsBound(x) );
+                Remove( mon, i+2 );
+                Remove( mon, i+2 );
                 todo[1]:= mon;
             elif mon[i] < mon[i+2] then
 
@@ -2036,7 +2035,7 @@ InstallGlobalFunction( CollectUEALatticeElement,
                         fi;
                     fi;
                 od;
-                todo:= Filtered( todo, x-> IsBound( x ) );
+                todo:= Compacted( todo );
                 collocc:= true;
 
                # We performed one collection step, and we break from
@@ -2124,14 +2123,14 @@ InstallGlobalFunction( CollectUEALatticeElement,
                 else
                     dones[p+1]:= dones[p+1]+mons[i+1];
                     if dones[p+1] = 0 then
-                        Unbind( dones[p] ); Unbind( dones[p+1] );
-                        dones:= Filtered( dones, x -> IsBound(x) );
+                        Remove( dones, p );
+                        Remove( dones, p );
                     fi;
                 fi;
             od;
 
-            Unbind( todo[1] ); Unbind( todo[2] );
-            todo:= Filtered( todo, x -> IsBound(x) );
+            Remove( todo, 1 );
+            Remove( todo, 1 );
 
         fi;
     od;
@@ -2197,8 +2196,8 @@ InstallMethod( \*,
         if len > 0 and lst[len-1] = mons[i] then
             lst[len]:= lst[len]+cfs[i];
             if lst[len] = 0*lst[len] then
-                Unbind( lst[len-1] ); Unbind( lst[len] );
-                lst:= Filtered( lst, x -> IsBound(x) );
+                Remove( lst, len-1 );
+                Remove( lst, len-1 );
                 len:= len-2;
             fi;
 
@@ -2987,8 +2986,8 @@ InstallOtherMethod(\^,
                     else
                         er[pos+1]:= er[pos+1]+cf;
                         if er[pos+1] = 0*er[pos+1] then
-                            Unbind( er[pos] ); Unbind( er[pos+1] );
-                            er:= Filtered( er, x -> IsBound( x ) );
+                            Remove( er, pos );
+                            Remove( er, pos );
                         fi;
                     fi;
                 fi;
@@ -3002,8 +3001,8 @@ InstallOtherMethod(\^,
             else
                 er[pos+1]:= er[pos+1]+cf;
                 if er[pos+1] = 0*er[pos+1] then
-                    Unbind( er[pos] ); Unbind( er[pos+1] );
-                    er:= Filtered( er, x -> IsBound( x ) );
+                    Remove( er, pos );
+                    Remove( er, pos );
                 fi;
             fi;
         fi;
@@ -3074,10 +3073,8 @@ BindGlobal( "TriangulizeWeightRepElementList", function( ww )
     k:= 1;
     while k <= Length( ww ) do
         if IsZero( ww[k] ) then
-            Unbind( ww[k] );
-            Unbind( basechange[k] );
-            ww:= Filtered( ww, x -> IsBound( x ) );
-            basechange:= Filtered( basechange, x -> IsBound( x ) );
+            Remove( ww, k );
+            Remove( basechange, k );
         else
             cf:= ww[k]![1][2];
             ww[k]:= ww[k]/cf;
@@ -3115,8 +3112,8 @@ BindGlobal( "TriangulizeWeightRepElementList", function( ww )
                 Unbind( basechange[i] );
             fi;
         od;
-        ww:= Filtered( ww, x -> IsBound( x ) );
-        basechange:= Filtered( basechange, x -> IsBound( x ) );
+        ww:= Compacted( ww );
+        basechange:= Compacted( basechange );
 
         SortParallel( ww, basechange,
                 function( u, v )
@@ -3512,7 +3509,7 @@ InstallMethod( HighestWeightModule,
                     Unbind( mons[j][i] );
                 fi;
             od;
-            mons[j]:= Filtered( mons[j], x -> IsBound(x) );
+            mons[j]:= Compacted( mons[j] );
 
             Glmsk[j]:= [ ];
             Gk[ j ]:= [ ];
@@ -3732,7 +3729,7 @@ InstallMethod( HighestWeightModule,
                         Unbind( mmm[j][i] );
                     fi;
                 od;
-                mmm[j]:= Filtered( mmm[j], x -> IsBound(x) );
+                mmm[j]:= Compacted( mmm[j] );
                 paths[Position(weights,w[j])]:= mmm[j];
             else
 

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2196,7 +2196,7 @@ InstallMethod( MutableTransposedMatDestructive,
             Add( mat, store );
         od;
         for i in [1..m] do
-            mat[i]:= Filtered( mat[i], x -> IsBound(x) );
+            mat[i]:= Compacted( mat[i] );
         od;
     fi;
 
@@ -2207,7 +2207,7 @@ InstallMethod( MutableTransposedMatDestructive,
             od;
             Unbind( mat[i] );
         od;
-        mat:= Filtered( mat, x -> IsBound( x ) );
+        mat:= Compacted( mat );
     fi;
 
     # return the transposed

--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -2971,7 +2971,7 @@ local m,offset,rels,ri,ccr,i,r,ct,A,a,w,n,DATA,p,dr,
       fi;
     fi;
   od;
-  ri:=Filtered(ri,x->IsBound(x));
+  ri:=Compacted(ri);
 
 
   # cyclic conjugates, sort by first letter


### PR DESCRIPTION
This is a complicated way of saying `x->true` or `ReturnTrue`. It did seem to do something sensible when used as argument for `Filtered`, but really, it could have been replaced by the named alternatives.

So instead of `Filtered(a,x->IsBound(x))`, either use `Compacted(a)` or avoid the need for this operation altogether.