### PR TITLE
Add argument validation to `ListPerm`, and turn it into a kernel function to make it faster

### DIFF
--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -444,37 +444,42 @@ SetOne( PermutationsFamily, () );
 
 #############################################################################
 ##
-#F  ListPerm( <perm>[, <length>] )  . . . . . . . . . . . . .  list of images
+#F  ListPerm( <perm>[, <n>] )  . . . . . . . . . . . . .  list of images
 ##
 ##  <#GAPDoc Label="ListPerm">
 ##  <ManSection>
-##  <Func Name="ListPerm" Arg='perm[, length]'/>
+##  <Func Name="ListPerm" Arg='perm[, n]'/>
 ##
 ##  <Description>
 ##  is a list <M>l</M> that contains the images of the positive integers
-##  under the permutation <A>perm</A>.
+##  from 1 to <A>n</A> under the permutation <A>perm</A>.
 ##  That means that
 ##  <M>l</M><C>[</C><M>i</M><C>]</C> <M>= i</M><C>^</C><A>perm</A>,
-##  where <M>i</M> lies between 1
-##  and the largest point moved by <A>perm</A>
-##  (see&nbsp;<Ref Attr="LargestMovedPoint" Label="for a permutation"/>).
+##  where <M>i</M> lies between 1 and <A>n</A>.
 ##  <P/>
-##  An optional second argument specifies the length of the desired list.
+##  If the optional second argument <A>n</A> is omitted then the largest
+##  point moved by <A>perm</A> is used
+##  (see&nbsp;<Ref Attr="LargestMovedPoint" Label="for a permutation"/>).
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BIND_GLOBAL( "ListPerm", function( arg )
-    local n;
-    if Length(arg)=2 then
-        n := arg[2];
-    else
-        n := LargestMovedPoint(arg[1]);
+BIND_GLOBAL( "ListPerm", function( perm, n... )
+    if not IsPerm(perm) then
+        Error("ListPerm: <perm> must be a permutation");
     fi;
-    if IsOne(arg[1]) then
+    if Length(n)=1 then
+        n := n[1];
+        if not IsInt(n) then
+            Error("ListPerm: <n> must be an integer");
+        fi;
+    else
+        n := LargestMovedPoint(perm);
+    fi;
+    if IsOne(perm) then
         return [1..n];
     else
-        return OnTuples( [1..n], arg[1] );
+        return OnTuples( [1..n], perm );
     fi;
 end );
 

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -464,24 +464,6 @@ SetOne( PermutationsFamily, () );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BIND_GLOBAL( "ListPerm", function( perm, n... )
-    if not IsPerm(perm) then
-        Error("ListPerm: <perm> must be a permutation");
-    fi;
-    if Length(n)=1 then
-        n := n[1];
-        if not IsInt(n) then
-            Error("ListPerm: <n> must be an integer");
-        fi;
-    else
-        n := LargestMovedPoint(perm);
-    fi;
-    if IsOne(perm) then
-        return [1..n];
-    else
-        return OnTuples( [1..n], perm );
-    fi;
-end );
 
 
 #############################################################################

--- a/src/listfunc.c
+++ b/src/listfunc.c
@@ -1528,15 +1528,13 @@ static Int InitKernel (
     StructInitInfo *    module )
 {
     // init filters and functions
-    /* ADD_LIST needs special consideration because we want distinct kernel
-       handlers for 2 and 3 arguments */
-    InitHandlerFunc( FuncADD_LIST, "src/listfunc.c:FuncADD_LIST" );
-    InitHandlerFunc( FuncADD_LIST3, "src/listfunc.c:FuncADD_LIST3" );
-
     InitHdlrOpersFromTable( GVarOpers );
     InitHdlrFuncsFromTable( GVarFuncs );
 
-
+    // ADD_LIST needs special consideration because we want distinct kernel
+    // handlers for 2 and 3 arguments
+    InitHandlerFunc( FuncADD_LIST, "src/listfunc.c:FuncADD_LIST" );
+    InitHandlerFunc( FuncADD_LIST3, "src/listfunc.c:FuncADD_LIST3" );
 
     return 0;
 }

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2008,9 +2008,9 @@ static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
 {
     UInt                res;            // handle of the image, result
     const Obj *         ptTup;          // pointer to the tuple
-    const T *           ptPrm;         // pointer to the permutation
+    const T *           ptPrm;          // pointer to the permutation
     UInt                tmp;            // temporary handle
-    UInt                lmp;            // largest moved point
+    UInt                deg;            // degree of the permutation
     UInt                i, k;           // loop variables
 
     res = MAX_DEG_PERM4; // ``infty''.
@@ -2018,12 +2018,12 @@ static inline Obj SMALLEST_IMG_TUP_PERM(Obj tup, Obj perm)
     // get the pointer
     ptTup = CONST_ADDR_OBJ(tup) + LEN_LIST(tup);
     ptPrm = CONST_ADDR_PERM<T>(perm);
-    lmp = DEG_PERM<T>(perm);
+    deg = DEG_PERM<T>(perm);
 
     // loop over the entries of the tuple
     for ( i = LEN_LIST(tup); 1 <= i; i--, ptTup-- ) {
       k = INT_INTOBJ( *ptTup );
-      if ( k <= lmp )
+      if ( k <= deg )
           tmp = ptPrm[k-1] + 1;
       else
           tmp = k;
@@ -2061,7 +2061,7 @@ static inline Obj OnTuplesPerm_(Obj tup, Obj perm)
     Obj *               ptRes;          // pointer to the result
     const T *           ptPrm;          // pointer to the permutation
     Obj                 tmp;            // temporary handle
-    UInt                lmp;            // largest moved point
+    UInt                deg;            // degree of the permutation
     UInt                i, k;           // loop variables
 
     // copy the list into a mutable plist, which we will then modify in place
@@ -2073,14 +2073,14 @@ static inline Obj OnTuplesPerm_(Obj tup, Obj perm)
     // get the pointer
     ptRes = ADDR_OBJ(res) + 1;
     ptPrm = CONST_ADDR_PERM<T>(perm);
-    lmp = DEG_PERM<T>(perm);
+    deg = DEG_PERM<T>(perm);
 
     // loop over the entries of the tuple
     for (i = 1; i <= len; i++, ptRes++) {
         tmp = *ptRes;
         if (IS_POS_INTOBJ(tmp)) {
             k = INT_INTOBJ(tmp);
-            if (k <= lmp) {
+            if (k <= deg) {
                 *ptRes = INTOBJ_INT(ptPrm[k - 1] + 1);
             }
         }
@@ -2130,7 +2130,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
     Obj *               ptRes;          // pointer to the result
     const T *           ptPrm;          // pointer to the permutation
     Obj                 tmp;            // temporary handle
-    UInt                lmp;            // largest moved point
+    UInt                deg;            // degree of the permutation
     UInt                i, k;           // loop variables
 
     // copy the list into a mutable plist, which we will then modify in place
@@ -2140,7 +2140,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
     // get the pointer
     ptRes = ADDR_OBJ(res) + 1;
     ptPrm = CONST_ADDR_PERM<T>(perm);
-    lmp = DEG_PERM<T>(perm);
+    deg = DEG_PERM<T>(perm);
 
     // loop over the entries of the tuple
     BOOL isSmallIntList = TRUE;
@@ -2148,7 +2148,7 @@ static inline Obj OnSetsPerm_(Obj set, Obj perm)
         tmp = *ptRes;
         if (IS_POS_INTOBJ(tmp)) {
             k = INT_INTOBJ(tmp);
-            if (k <= lmp) {
+            if (k <= deg) {
                 *ptRes = INTOBJ_INT(ptPrm[k - 1] + 1);
             }
         }

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -287,7 +287,7 @@ gap> p := ();
 gap> ListPerm( p );
 [  ]
 gap> List([-1,0,1,5], n -> ListPerm( p, n ));
-[ [  ], [  ], [ 1 ], [ 1 .. 5 ] ]
+[ [  ], [  ], [ 1 ], [ 1, 2, 3, 4, 5 ] ]
 
 #
 gap> p := (1,100) / (1,100);
@@ -295,7 +295,7 @@ gap> p := (1,100) / (1,100);
 gap> ListPerm( p );
 [  ]
 gap> List([-1,0,1,5], n -> ListPerm( p, n ));
-[ [  ], [  ], [ 1 ], [ 1 .. 5 ] ]
+[ [  ], [  ], [ 1 ], [ 1, 2, 3, 4, 5 ] ]
 
 #
 gap> p := (1,2^17) / (1,2^17);
@@ -303,7 +303,7 @@ gap> p := (1,2^17) / (1,2^17);
 gap> ListPerm( p );
 [  ]
 gap> List([-1,0,1,5], n -> ListPerm( p, n ));
-[ [  ], [  ], [ 1 ], [ 1 .. 5 ] ]
+[ [  ], [  ], [ 1 ], [ 1, 2, 3, 4, 5 ] ]
 
 #
 gap> p := (1,2,3);
@@ -323,9 +323,9 @@ gap> List([-1,0,1,5], n -> ListPerm( p, n ));
 
 #
 gap> ListPerm( 1 );
-Error, ListPerm: <perm> must be a permutation
+Error, ListPerm: <perm> must be a permutation (not the integer 1)
 gap> ListPerm( (1,2,3), "bla" );
-Error, ListPerm: <n> must be an integer
+Error, ListPerm: <n> must be a small integer (not a list (string))
 
 #
 # PermList

--- a/tst/testinstall/perm.tst
+++ b/tst/testinstall/perm.tst
@@ -280,6 +280,54 @@ gap> SetX(permAll, permAll, {a,b} -> Comm(a,b) = LeftQuotient((b*a), a*b));
 # [ true ]
 
 #
+# ListPerm
+#
+gap> p := ();
+()
+gap> ListPerm( p );
+[  ]
+gap> List([-1,0,1,5], n -> ListPerm( p, n ));
+[ [  ], [  ], [ 1 ], [ 1 .. 5 ] ]
+
+#
+gap> p := (1,100) / (1,100);
+()
+gap> ListPerm( p );
+[  ]
+gap> List([-1,0,1,5], n -> ListPerm( p, n ));
+[ [  ], [  ], [ 1 ], [ 1 .. 5 ] ]
+
+#
+gap> p := (1,2^17) / (1,2^17);
+()
+gap> ListPerm( p );
+[  ]
+gap> List([-1,0,1,5], n -> ListPerm( p, n ));
+[ [  ], [  ], [ 1 ], [ 1 .. 5 ] ]
+
+#
+gap> p := (1,2,3);
+(1,2,3)
+gap> ListPerm( p );
+[ 2, 3, 1 ]
+gap> List([-1,0,1,5], n -> ListPerm( p, n ));
+[ [  ], [  ], [ 2 ], [ 2, 3, 1, 4, 5 ] ]
+
+#
+gap> p := (1,2,3,10000)*(1,10000);
+(1,2,3)
+gap> ListPerm( p );
+[ 2, 3, 1 ]
+gap> List([-1,0,1,5], n -> ListPerm( p, n ));
+[ [  ], [  ], [ 2 ], [ 2, 3, 1, 4, 5 ] ]
+
+#
+gap> ListPerm( 1 );
+Error, ListPerm: <perm> must be a permutation
+gap> ListPerm( (1,2,3), "bla" );
+Error, ListPerm: <n> must be an integer
+
+#
 # PermList
 #
 gap> PermList([1,2,3]) = ();


### PR DESCRIPTION
Resolves #4205

In that issue, @frankluebeck was concerned about performance overhead for validating the arguments. I measure it at about 5% on my laptop (going from 167 nanoseconds to 176 ns), which I personally consider fine. But to avoid any argument about that, I just rewrote it as a kernel function, after which it takes 21 ns, i.e., 8 times faster, including full argument validation.