### PR TITLE
Improve the `dev/ci.sh` script, make it usable interactive, and some related CI tweaks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
           - os: ubuntu-latest
             shell: bash
             test-suites: "makemanuals testmakeinstall"
-            extra: "GAPPREFIX=/tmp/gapprefix CONFIGFLAGS=\"--prefix=/tmp/gapprefix\" NO_COVERAGE=1"
+            extra: "CONFIGFLAGS=\"--prefix=/tmp/gapprefix\" NO_COVERAGE=1"
 
           - os: ubuntu-20.04
             shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -254,7 +254,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
       - name: "Run tests"
-        run: ${{ matrix.extra }} dev/ci.sh
+        run: ${{ matrix.extra }} dev/ci.sh ${{ matrix.test-suites }}
       - name: "Upload pdf manuals"
         if: ${{ contains(matrix.test-suites, 'makemanuals') }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -256,7 +256,7 @@ jobs:
       - name: "Run tests"
         run: ${{ matrix.extra }} dev/ci.sh
       - name: "Upload pdf manuals"
-        if: ${{ matrix.test-suites == 'makemanuals' }}
+        if: ${{ contains(matrix.test-suites, 'makemanuals') }}
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
@@ -267,7 +267,7 @@ jobs:
             doc/ref/manual.pdf
             doc/tut/manual.pdf
       - name: "Upload html manuals"
-        if: ${{ matrix.test-suites == 'makemanuals' }}
+        if: ${{ contains(matrix.test-suites, 'makemanuals') }}
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: "Test 'make install' from the primary release archive"
         run: |
           pushd test-gap-tarball/gap*
-          GAPPREFIX=/tmp/gapprefix TEST_SUITES="testmakeinstall" ../../dev/ci.sh
+          GAPPREFIX=/tmp/gapprefix ../../dev/ci.sh testmakeinstall
           popd
 
       # Upload the main GAP .tar.gz file (which includes packages).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: "Test 'make install' from the primary release archive"
         run: |
           pushd test-gap-tarball/gap*
-          GAPPREFIX=/tmp/gapprefix ../../dev/ci.sh testmakeinstall
+          ../../dev/ci.sh testmakeinstall
           popd
 
       # Upload the main GAP .tar.gz file (which includes packages).

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ doc/gapmacrodoc.idx
 /src/TAGS
 
 /builds/
+/coverage/
 
 /libgap.la
 .libs/

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -170,6 +170,12 @@ vpath src/hpc/%.c $(srcdir)
 vpath src/hpc/%.cc $(srcdir)
 vpath src/hpc/%.s $(srcdir)
 
+vpath tst/testkernel/%.h $(srcdir)
+vpath tst/testkernel/%.c $(srcdir)
+
+vpath tst/testlibgap/%.h $(srcdir)
+vpath tst/testlibgap/%.c $(srcdir)
+
 
 #
 # Finally, include the actual make rules.

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -949,6 +949,11 @@ check-manuals: all
 check: all
 	$(TESTGAPcore) $(top_srcdir)/tst/testinstall.g
 
+# citests runs a subset of the tests run by CI -- this is SLOW and still doesn't
+# quite cover everything (e.g. we don't test out-of-tree builds and `make install`)
+citests: all
+	SRCDIR=$(abs_srcdir) dev/ci.sh testexpect testmockpkg testspecial test-compile testlibgap testkernel testinstall
+
 LIBGAPTESTS := $(addprefix tst/testlibgap/,basic api wscreate wsload trycatch)
 
 # run a test in tst/testlibgap
@@ -1009,7 +1014,7 @@ testkernel: ${KERNELTESTS}
 
 .PHONY: testpkgconfigbuild testpkgconfigversion
 
-.PHONY: check
+.PHONY: check citests
 
 ########################################################################
 # Bootstrap rules

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -92,8 +92,9 @@ testmockpkg () {
     # Try building and loading the mockpkg kernel extension
     gap="$1"
     gaproot="$2"
-    mockpkg_dir="$PWD"
+    mockpkg_dir="$3"
 
+    cd "$mockpkg_dir"
     echo_and_run ./configure "$gaproot"
     echo_and_run make V=1
     # trick to make it easy to load the package in GAP
@@ -315,8 +316,7 @@ GAPInput
     ln -s $SRCDIR/pkg $GAPPREFIX/share/gap/pkg
 
     # test building and loading package kernel extension
-    cd "$SRCDIR/tst/mockpkg"
-    testmockpkg "$GAPPREFIX/bin/gap" "$GAPPREFIX/lib/gap"
+    testmockpkg "$GAPPREFIX/bin/gap" "$GAPPREFIX/lib/gap" "$SRCDIR/tst/mockpkg"
 
     # run testinstall for the resulting GAP
     $GAPPREFIX/bin/gap --quitonbreak -l ";$SRCDIR" $SRCDIR/tst/testinstall.g
@@ -381,8 +381,7 @@ GAPInput
     echo "${blue}---- END sysinfo.gap ----${normal}"
 
     # test building and loading a package kernel extension
-    cd "$SRCDIR/tst/mockpkg"
-    testmockpkg "$GAP $(gap_cover_arg)" "$BUILDDIR"
+    testmockpkg "$GAP $(gap_cover_arg)" "$BUILDDIR" "$SRCDIR/tst/mockpkg"
     ;;
 
   testexpect)

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -65,7 +65,13 @@ do
   # restore current directory before each test suite
   cd "$BUILDDIR"
 
-  echo "Running test suite $TEST_SUITE"
+  echo
+  echo "+-------------------------------------------"
+  echo "|"
+  echo "| Running test suite $TEST_SUITE"
+  echo "|"
+  echo "+-------------------------------------------"
+  echo
   case $TEST_SUITE in
   testspecial | test-compile)
     cd $SRCDIR/tst/$TEST_SUITE

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -256,7 +256,8 @@ GAPInput
     # directories after stripping gap and libgap
     strip $GAPPREFIX/bin/gap > /dev/null
     strip $GAPPREFIX/lib/gap/gap > /dev/null
-    strip $GAPPREFIX/lib/libgap.so > /dev/null
+    strip $GAPPREFIX/lib/libgap.so > /dev/null 2>&1 || :      # for Linux
+    strip -S $GAPPREFIX/lib/libgap.dylib > /dev/null 2>&1 || :   # for macOS
     fgrep -r $BUILDDIR $GAPPREFIX && exit 1
     fgrep -r $SRCDIR $GAPPREFIX && exit 1
     fgrep -r $HOME $GAPPREFIX && exit 1

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -320,11 +320,11 @@ GAPInput
     ;;
 
   testlibgap)
-    make testlibgap
+    make V=1 testlibgap
     ;;
 
   testkernel)
-    make testkernel
+    make V=1 testkernel
     ;;
 
   testmockpkg)

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -5,7 +5,10 @@
 # It can also be run manually, to simulate locally what happens in the
 # CI environment (say, for debugging purposes).
 
-set -ex
+set -E # inherit -e
+set -e # exit immediately on errors
+set -o pipefail # exit on pipe failure
+set -x
 
 SRCDIR=${SRCDIR:-$PWD}
 

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -41,7 +41,7 @@ testmockpkg () {
 }
 
 
-for TEST_SUITE in $TEST_SUITES
+for TEST_SUITE in "$@"
 do
   # restore current directory before each test suite
   cd "$BUILDDIR"

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -3,7 +3,11 @@
 # Continuous integration testing script
 
 # It can also be run manually, to simulate locally what happens in the
-# CI environment (say, for debugging purposes).
+# CI environment (say, for debugging purposes). For example:
+#
+#    dev/ci.sh testinstall
+#
+# run just the 'testinstall' testsuite
 
 set -E # inherit -e
 set -e # exit immediately on errors
@@ -272,7 +276,7 @@ GAPInput
     cd "$SRCDIR/tst/mockpkg"
     testmockpkg "$GAPPREFIX/bin/gap" "$GAPPREFIX/lib/gap"
 
-    # run testsuite for the resulting GAP
+    # run testinstall for the resulting GAP
     $GAPPREFIX/bin/gap --quitonbreak -l ";$SRCDIR" $SRCDIR/tst/testinstall.g
 
     # test integration with pkg-config

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -217,8 +217,9 @@ GAPInput
     ;;
 
   testmakeinstall)
-    # at this point GAPPREFIX should be set
-    test -n $GAPPREFIX  || (echo "GAPPREFIX must be set" ; exit 1)
+    # get the install prefix from the GAP build system
+    eval $(make print-prefix)
+    GAPPREFIX=$prefix
 
     # verify $GAPPREFIX does not yet exist
     test ! -d $GAPPREFIX

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -9,9 +9,6 @@ set -ex
 
 SRCDIR=${SRCDIR:-$PWD}
 
-# Make sure any Error() immediately exits GAP with exit code 1.
-GAP="./gap --quitonbreak"
-
 # change into BUILDDIR (creating it if necessary), and turn it into an absolute path
 if [[ -n "$BUILDDIR" ]]
 then
@@ -19,6 +16,11 @@ then
   cd "$BUILDDIR"
 fi
 BUILDDIR=$PWD
+
+GAP=${GAP:-$BUILDDIR/gap}
+
+# Make sure any Error() immediately exits GAP with exit code 1.
+GAP="$GAP --quitonbreak"
 
 # create dir for coverage results unless coverage is disabled
 COVDIR=${COVDIR:-coverage}

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -75,24 +75,12 @@ do
   testpackages)
     cd $SRCDIR/pkg
 
-    # skip PolymakeInterface: no polynmake installed (TODO: is there a polymake package we can use)
+    # skip PolymakeInterface: no polymake installed (TODO: is there a polymake package we can use?)
     rm -rf PolymakeInterface*
     # skip xgap: no X11 headers, and no means to test it
     rm -rf xgap*
     # skip itc because it requires xgap
     rm -rf itc*
-
-    # HACK to work out timestamp issues with anupq
-    touch anupq*/configure* anupq*/Makefile* anupq*/aclocal.m4
-
-    # HACK/WORKAROUND: excise `-march=native` from some configure
-    # scripts by replacing it with `-g0` ; we do it this way to simplify
-    # the patching process (we don't want to use an actual patchh file
-    # that may need to be updated for every new release of the affected
-    # packages'), while ensuring the patched shell scripts keep working;
-    # as an added bonus, the `-g0` helps ensure that any existing ccache
-    # entries for those files are invalidated.
-    perl -pi -e 's;-march=native;-g0;' [Dd]igraphs*/configure [Ss]emigroups*/configure [Ss]emigroups*/libsemigroups/configure
 
     # reset CFLAGS, CXXFLAGS, LDFLAGS before compiling packages, to prevent
     # them from being compiled with coverage gathering, because


### PR DESCRIPTION
In particular `dev/ci.sh` is now very convenient to use interactively so one can easily replicate what certain CI tests do.

Also fix a bunch of minor issues with CI and the tests here and there.

It may be best to review this commit-by-commit.

Resolves #1740
Resolves #4167