### PR TITLE
tst: fix file descriptor leaks

### DIFF
--- a/tst/testbugfix/2006-10-23-t00163.tst
+++ b/tst/testbugfix/2006-10-23-t00163.tst
@@ -8,3 +8,4 @@ gap> List([0..255], i-> ReadByte(f)) = a;
 true
 gap> RemoveFile(fnam);
 true
+gap> CloseStream(f);

--- a/tst/testinstall/compressed.tst
+++ b/tst/testinstall/compressed.tst
@@ -7,15 +7,18 @@ gap> rawfname := Filename(dir, "rawtest.g.gz");;
 # Let us check when we have written a compressed file by checking the gzip header
 # We need raw file access to do this, so we use 'IO'. We stub out this part of the
 # test if IO is not loaded
+#@if IsPackageLoaded("IO")
 gap> checkGzippedFile := function(fname, expected)
 >    local ins, str;
->    if not IsPackageLoaded("IO") then return true; fi;
->    # Use 'ValueGlobal' to avoid warnings about undefined functions
->    ins := ValueGlobal("IO_File")(fname, "r");
->    str := ValueGlobal("IO_Read")(ins, 2);;
+>    ins := IO_File(fname, "r");
+>    str := IO_Read(ins, 2);
+>    IO_Close(ins);
 >    # All gzipped files should start with these two characters
 >    return (str = [CharInt(31),CharInt(139)]) = expected;
 >  end;;
+#@else
+gap> checkGzippedFile := ReturnTrue;;
+#@fi
 gap> str := "hello\ngoodbye\n";;
 
 # Write an uncompressed file

--- a/tst/testinstall/read.tst
+++ b/tst/testinstall/read.tst
@@ -34,6 +34,9 @@ gap> SeekPositionStream(x, 3);
 true
 gap> ReadAll(x);
 "lo\ngoodbye\ni like pies\n"
+gap> CloseStream(x);
+
+#
 gap> x := InputTextString("hello\ngoodbye\ni like pies\n");;
 gap> ReadLine(x);
 "hello\n"
@@ -65,6 +68,9 @@ gap> SeekPositionStream(x, 3);
 true
 gap> ReadAll(x);
 "lo\ngoodbye\ni like pies\n"
+gap> CloseStream(x);
+
+#
 gap> x := StringFile(Filename( DirectoriesLibrary("tst"), "example.txt" ));;
 gap> ReplacedString(x, "\r\n", "\n");
 "hello\ngoodbye\ni like pies\n"

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -178,6 +178,7 @@ gap> file := InputTextFile( fname );;
 gap> repeat
 >  line := ReadLine( file );
 > until line = fail;
+gap> CloseStream(file);
 
 # Invalid files
 gap> PrintTo("/", "out");


### PR DESCRIPTION
This is a step towards fixing the `testinstall` test suite on macOS, where the maximum number of file descriptors seems to exactly match our limit, so any leaked descriptor causes the 'too many open files' test in `tst/testinstall/streams.tst` to fail in an unexpected way (namely because instead of the expected error, OutputTextFile returns 'fail').

Note that just executing the tests in `tst/testinstall/streams.tst` was and is fine, but running the full `testinstall` test suite still is not; I suspect there are some remaining fd leaks in IO and/or curlInterface, triggered by atlasrep using `Download` from the utils package... *sigh*.
