### PR TITLE
Move slow tests to teststandard

### DIFF
--- a/tst/testinstall/function.tst
+++ b/tst/testinstall/function.tst
@@ -339,30 +339,5 @@ function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]})[1, 1]; end
 gap> funcloop(x -> ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}); # EXPR_ELMS_LIST
 function ( x ) return ([ [ x ] ]{[ 1 ]}{[ 1 ]}){[ 1 ]}; end
 
-# Test functions with very large lists
-gap> r := List([1..(16777216/GAPInfo.BytesPerVariable)-1]);;
-gap> funcstr := String(r);;
-gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
-gap> Read(InputTextString(funcstr));;
-gap> func() = r;
-true
-gap> funcstr := String(List([1..(16777216/GAPInfo.BytesPerVariable)], x -> x));;
-gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
-gap> Read(InputTextString(funcstr));;
-Error, function too large for parser
-
-# Test functions with very large records
-gap> r := rec();; for x in [1..(16777216/GAPInfo.BytesPerVariable-2)/2] do r.(x) := x; od;;
-gap> funcstr := String(r);;
-gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
-gap> Read(InputTextString(funcstr));;
-gap> func() = r;
-true
-gap> r := rec();; for x in [1..(16777216/GAPInfo.BytesPerVariable)/2] do r.(x) := x; od;;
-gap> funcstr := String(r);;
-gap> funcstr := Concatenation("func := function() return ", funcstr, "; end;");;
-gap> Read(InputTextString(funcstr));;
-Error, function too large for parser
-
 #
 gap> STOP_TEST("function.tst", 1);

--- a/tst/teststandard/function.tst
+++ b/tst/teststandard/function.tst
@@ -1,0 +1,30 @@
+#@local r,x,funcstr,func
+gap> START_TEST("function.tst");
+
+# Test functions with very large lists
+gap> r := List([1..(16777216/GAPInfo.BytesPerVariable)-1]);;
+gap> funcstr := String(r);;
+gap> funcstr := Concatenation("return ", funcstr, ";");;
+gap> func := ReadAsFunction(InputTextString(funcstr));;
+gap> func() = r;
+true
+gap> funcstr := String(List([1..(16777216/GAPInfo.BytesPerVariable)], x -> x));;
+gap> funcstr := Concatenation("return ", funcstr, ";");;
+gap> ReadAsFunction(InputTextString(funcstr));;
+Error, function too large for parser
+
+# Test functions with very large records
+gap> r := rec();; for x in [1..(16777216/GAPInfo.BytesPerVariable-2)/2] do r.(x) := x; od;;
+gap> funcstr := String(r);;
+gap> funcstr := Concatenation("return ", funcstr, ";");;
+gap> func := ReadAsFunction(InputTextString(funcstr));;
+gap> func() = r;
+true
+gap> r := rec();; for x in [1..(16777216/GAPInfo.BytesPerVariable)/2] do r.(x) := x; od;;
+gap> funcstr := String(r);;
+gap> funcstr := Concatenation("return ", funcstr, ";");;
+gap> ReadAsFunction(InputTextString(funcstr));;
+Error, function too large for parser
+
+#
+gap> STOP_TEST("function.tst", 1);


### PR DESCRIPTION
Also change them to use ReadAsFunction, thus avoiding a global variable 'func'

This test takes ~10 seconds on my M1 MacBook, out of ~60 seconds which `testinstall`  takes overall.


@ChrisJefferson you added these tests (and I approved), but I think it's fair to just run them in `teststandard` (which we always run as part of our CI anyway), given that it seems unlikely someone will break this again...