### PR TITLE
Fix dev/audit-config-h.sh and how we use it

### DIFF
--- a/dev/audit-config-h.sh
+++ b/dev/audit-config-h.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script scans all kernel sources which do not #include config.h for uses
 # of symbols potentially #defined in `config.h`, with a couple of exceptions
@@ -9,10 +9,13 @@
 # in any of our headers. It can also be used to check which C/C++ source files
 # use any of these headers, and thus ought to
 # #include config.h.
-set -e
+
+set -E # inherit -e
+set -e # exit immediately on errors
+set -o pipefail # exit on pipe failure
 
 # ensure that no .h file #includes config.h
-if git grep -n -w config.h :src/*.h > /dev/null ; then
+if git grep -n -w config.h -- :/src/*.h > /dev/null ; then
   echo "Error, a kernel header file includes config.h"
   exit 1
 fi
@@ -30,7 +33,7 @@ PATTERN=$(egrep '(#define|#undef)' build/config.h | sed -E -e 's;(#define|/\* #u
 PATTERN=${PATTERN%?} # remove trailing "|"
 
 # only consider files that do not #include config.h
-FILES=$(git grep --files-without-match -P '^#include "config\.h"$' src)
+FILES=$(git grep --files-without-match -P '^#include "config\.h"$' -- :/src)
 
 # Next use `git grep` to search all kernel header files for occurrences of any
 # of the symbols in the pattern we just created. We negate the exit code: grep

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -187,9 +187,7 @@ GAPInput
     test -z "$(make)"
 
     # audit config.h
-    pushd $SRCDIR
-    dev/audit-config-h.sh
-    popd
+    $SRCDIR/dev/audit-config-h.sh
 
     # test: touching all source files does *not* trigger a rebuild if we make
     # a target that doesn't depend on sources. We verify this by replacing the source

--- a/src/hpc/cpu.c
+++ b/src/hpc/cpu.c
@@ -16,6 +16,8 @@
 #include <windows.h>
 #endif
 
+#include "config.h"
+
 #define FALLBACK_CPUS_NUMBER 4
 
 /****************************************************************************


### PR DESCRIPTION
Looking at our CI logs, `dev/audit-config-h.sh` actually always failed since recently, but didn't signal this via its exit code. Specifically, the `egrep` call failed but it runs in a subshell which hides the error... so now we set shell options to detect errors in subshells.

Next, we need to fix the error. This was caused by dev/audit-config-h.sh not working correctly when used outside the git root directory -- but that's precisely what we want, as we use it in out-of-tree builds. So fix the script, and also its invocation in dev/ci.sh, to work in this case (e.g. by tweaking the `git grep` invocations to work in subdirs of the git root).

Finally, we actually missed a regression were a file did not include config.h that should. So we also fix that, as the now fixed tests of course complain about it otherwise.

Part of PR #5567 which is getting too big...