### PR TITLE
Make `License` field for GAP packages mandatory

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -200,6 +200,11 @@ The following components of this record are <E>mandatory</E>.
   denoting the release date of the current version of the package
   (a date since 1999, when &GAP;&nbsp;4 appeared),
 </Item>
+<Mark><C>License</C></Mark>
+<Item>
+  a nonempty string containing an SPDX ID
+  (see Section <Ref Sect="Selecting a license for a GAP Package"/>),
+</Item>
 <Mark><C>ArchiveURL</C></Mark>
 <Item>
   a string started with <C>http://</C>, <C>https://</C>, or <C>ftp://</C>,
@@ -282,11 +287,6 @@ The following components of this record are <E>mandatory</E>.
 The following components of the record are <E>optional</E>.
 
 <List>
-<Mark><C>License</C></Mark>
-<Item>
-  a nonempty string containing an SPDX ID
-  (see Section <Ref Sect="Selecting a license for a GAP Package"/>),
-</Item>
 <Mark><C>TextFiles</C> or <C>BinaryFiles</C> or <C>TextBinaryFilesPatterns</C></Mark>
 <Item>
   a list of strings that specify which files in the archive are text files
@@ -1304,7 +1304,7 @@ each being a record with the following components.
 As an example suppose the following is part of the <F>PackageInfo.g</F>.
 Then &GAP; will load the file <F>fileForB.gd</F> as soon as package
 <C>B</C> is loaded in version 0.6 or newer, and <F>fileForCD.gi</F> once
-package <C>C</C> and <C>D</C> are loaded in version 1.2 and 0.1 or newer respectively. 
+package <C>C</C> and <C>D</C> are loaded in version 1.2 and 0.1 or newer respectively.
 
 <Log><![CDATA[
 Extensions := [

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2267,7 +2267,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
     #   Info( InfoPackageLoading, 2, Concatenation( record.PackageName, ": Please be advised to change the date format to `yyyy-mm-dd`") );
     #fi;
 
-    TestOption( record, "License",
+    TestMandat( record, "License",
         x -> IsString(x) and 0 < Length(x),
         "a nonempty string containing an SPDX ID" );
     TestMandat( record, "ArchiveURL", IsURL, "a string started with http://, https:// or ftp://" );

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -204,6 +204,8 @@ gap> ValidatePackageInfo(rec());
  with `='
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
+#E  component `License' must be bound to a nonempty string containing an SPDX \
+ID
 #E  component `ArchiveURL' must be bound to a string started with http://, htt\
 ps:// or ftp://
 #E  component `ArchiveFormats' must be bound to a string
@@ -234,6 +236,8 @@ gap> info := rec(
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
+#E  component `License' must be bound to a nonempty string containing an SPDX \
+ID
 #E  component `BookName' must be bound to a string
 #E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
 elative paths to readable files or directories
@@ -260,6 +264,8 @@ gap> info := rec(
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);
+#E  component `License' must be bound to a nonempty string containing an SPDX \
+ID
 #E  component `BookName' must be bound to a string
 #E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
 elative paths to readable files or directories
@@ -288,6 +294,8 @@ gap> info := rec(
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
+#E  component `License' must be bound to a nonempty string containing an SPDX \
+ID
 #E  component `BookName' must be bound to a string
 #E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
 elative paths to readable files or directories
@@ -316,6 +324,8 @@ gap> info := rec(
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
+#E  component `License' must be bound to a nonempty string containing an SPDX \
+ID
 #E  component `BookName' must be bound to a string
 #E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
 elative paths to readable files or directories
@@ -332,6 +342,7 @@ gap> info := rec(
 >     Subtitle := "desc",
 >     Version := "0",
 >     Date := "01/02/3000",
+>     License := "GPL-2.0-or-later",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
 >     README_URL := "https://",


### PR DESCRIPTION
Resolves #5281

All distributed packages have one, and we want all future distributed packages to have one. The package distribution already enforces this separately.

Of course non-distributed packages can skip it, just like they can skip most other mandatory fields.