### PR TITLE
Fix readline related workspace issue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
             "testmanuals",
 
             # test error reporting and compiling as well as libgap
-            "testexpect testmockpkg testspecial test-compile testlibgap testkernel",
+            "testexpect testmockpkg testspecial test-compile testlibgap testkernel testworkspace",
 
             # compile packages and run GAP tests
             # don't use --enable-debug to prevent the tests from taking too long

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -952,7 +952,7 @@ check: all
 # citests runs a subset of the tests run by CI -- this is SLOW and still doesn't
 # quite cover everything (e.g. we don't test out-of-tree builds and `make install`)
 citests: all
-	SRCDIR=$(abs_srcdir) dev/ci.sh testexpect testmockpkg testspecial test-compile testlibgap testkernel testinstall
+	SRCDIR=$(abs_srcdir) dev/ci.sh testexpect testmockpkg testspecial test-compile testlibgap testkernel testworkspace testinstall
 
 LIBGAPTESTS := $(addprefix tst/testlibgap/,basic api wscreate wsload trycatch)
 

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -353,8 +353,14 @@ GAPInput
 
     # if there were any failures, abort now.
     [[ $TESTMANUALSPASS = yes ]] || error "reference manual tests failed"
+    ;;
 
-    # while we are at it, also test the workspace code
+  testworkspace)
+
+    # test saving a workspace, with stdin redirected (this tests for an issue
+    # where we used to disable readline in this case, which lead to issues later
+    # on when loading the workspace without redirected stdin; for details,
+    # see https://github.com/gap-system/gap/issues/5014)
     $GAP -A $(gap_cover_arg workspace) <<GAPInput
         SetUserPreference("ReproducibleBehaviour", true);
         # Also test a package banner
@@ -362,6 +368,10 @@ GAPInput
         SaveWorkspace("test.wsp");
         QuitGap(0);
 GAPInput
+
+    # ... and test loading a workspace, then run testinstall in there
+    # (make sure to not redirect stdin here, see comment above)
+    $GAP -A -L test.wsp $(gap_cover_arg workspace) $SRCDIR/tst/testinstall.g
 
     ;;
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -1209,7 +1209,7 @@ void UpdateTime(UInt startTime)
 
 // UPDATE_STAT lets code assign the special variables which GAP
 // automatically sets in interactive sessions. This is for demonstration
-// code which wants to look like iteractive usage of GAP. Using this
+// code which wants to look like interactive usage of GAP. Using this
 // function will not stop GAP automatically changing these variables as
 // usual.
 static Obj FuncUPDATE_STAT(Obj self, Obj name, Obj newStat)

--- a/src/modules_builtin.c
+++ b/src/modules_builtin.c
@@ -53,6 +53,9 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
     InitInfoHookIntrprtr,
     InitInfoTracing,
 
+    // arithmetic operations
+    InitInfoAriths,
+
     // reader, interpreter, coder, caller, compiler, ...
     InitInfoIO,
     InitInfoRead,
@@ -66,9 +69,6 @@ const InitInfoFunc InitFuncsBuiltinModules[] = {
     InitInfoInfo,
     InitInfoIntrprtr,
     InitInfoCompiler,
-
-    // arithmetic operations
-    InitInfoAriths,
 
     // record packages
     InitInfoRecords,

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -3798,6 +3798,9 @@ static Int InitKernel (
     // install the printing function
     PrintObjFuncs[ T_FLAGS ] = PrintFlags;
 
+    // install the comparison methods
+    EqFuncs[T_FLAGS][T_FLAGS] = EqFlags;
+
 #ifdef GAP_ENABLE_SAVELOAD
     // and the saving function
     SaveObjFuncs[ T_FLAGS ] = SaveFlags;
@@ -3837,12 +3840,8 @@ static Int PostRestore(StructInitInfo * module)
 **
 *F  InitLibrary( <module> ) . . . . . . .  initialise library data structures
 */
-static Int InitLibrary (
-    StructInitInfo *    module )
+static Int InitLibrary(StructInitInfo * module)
 {
-    // HACK: move this here, instead of InitKernel, to avoid ariths.c overwriting it
-    EqFuncs[T_FLAGS][T_FLAGS] = EqFlags;
-
     ExportAsConstantGVar(BASE_SIZE_METHODS_OPER_ENTRY);
 
     HIDDEN_IMPS = NEW_PLIST(T_PLIST, 0);

--- a/src/system.c
+++ b/src/system.c
@@ -671,8 +671,10 @@ void InitSystem (
     if (SyWindow)
         SyUseReadline = 0;
     // don't use readline if stdin is not attached to a terminal
-    else if (!isatty(fileno(stdin)))
-        SyUseReadline = 0;
+    // FIXME: disabled this, as it breaks certain workspaces (see also
+    // issue https://github.com/gap-system/gap/issues/5014)
+    //else if (!isatty(fileno(stdin)))
+    //    SyUseReadline = 0;
 #endif
 
     InitSysFiles();


### PR DESCRIPTION
... by reverting a previous change that made us disable readline when stdin is not connected to a terminal (see https://github.com/gap-system/gap/pull/4495). While that still seems useful, and avoids certain issues when piping GAP output into files, it needs a better implication that avoids the issues described in https://github.com/gap-system/gap/issues/5014

Also add a separate CI test suite target "testworkspace" for testing for this issue, and potentially other workspace related issues.

Resolves #5405
Resolves #5014

CC @zickgraf 