### PR TITLE
Avoid trivial function wrappers

### DIFF
--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -4817,8 +4817,7 @@ local ReductionModuloTable,   #
          # i.e., the previous loop has been executed without breaking
          # caused by finding a relation among the generators.
 
-         vg:=Difference( List( Combinations(e[1],2), x -> Reversed(x) ),
-                                                                     R[2] );
+         vg:=Difference( List( Combinations(e[1],2), Reversed ), R[2] );
          Append( R[2], vg  );
          for i in [1..Length(vg)] do
            d:=d+1;

--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -3295,7 +3295,7 @@ InstallMethod( ZeroOp,
         function( u )
 
     return ObjByExtRep( FamilyObj( u ), List(
-                   FamilyObj( u )!.constituentModules, V -> Zero(V) ) );
+                   FamilyObj( u )!.constituentModules, Zero ) );
 end );
 
 

--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -357,7 +357,7 @@ InstallGlobalFunction (PcgsDirectProduct,
         rels := [];
         pcgs := [];
         indices := [];
-        one := List( info.groups, x -> One(x) );
+        one := List( info.groups, One );
         offset := 0;
         for i in [1..Length(info.groups)] do
             pcgs[i] := pcgsop ( info.groups[i] );

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -932,7 +932,7 @@ function( G )
     exp    := 1;
     while Size( U ) < Size( G ) do
         sub := Filtered( cl, x -> Order( Representative( x ) ) = p ^ exp );
-        sub := Concatenation( List( sub, x -> AsList(x) ) );
+        sub := Concatenation( List( sub, AsList ) );
         sub := InducedPcgsByPcSequenceAndGenerators( pcgs, Pcgs(U), sub );
         M   := SubgroupByPcgs( G, sub );
         if Size( M ) > Size( U ) then

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -1372,13 +1372,13 @@ InstallGlobalFunction(HELP, function( str )
 
   # if the topic is 'chapters' display the table of chapters
   elif str = "chapters"  or str = "contents" or book <> "" and str = "" then
-      if ForAll(books, b->  HELP_SHOW_CHAPTERS(b)) then
+      if ForAll(books, HELP_SHOW_CHAPTERS) then
         add( books, "chapters", "chapters" );
       fi;
 
   # if the topic is 'sections' display the table of sections
   elif str = "sections"  then
-      if ForAll(books, b-> HELP_SHOW_SECTIONS(b)) then
+      if ForAll(books, HELP_SHOW_SECTIONS) then
         add(books, "sections", "sections");
       fi;
 
@@ -1409,4 +1409,3 @@ InstallGlobalFunction(HELP, function( str )
      # Print( "Help: Sorry, could not find a match for '", origstr, "'.\n");
   fi;
 end);
-

--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -4079,7 +4079,7 @@ InstallGlobalFunction( ExtendRepresentation,
         n:= Length( mats[1] );
 
         for i in [1..Length(mats)] do
-          Q:= List( mats[i], x -> ShallowCopy(x) );
+          Q:= List( mats[i], ShallowCopy );
           for j in [1..n] do
             Add( Q[j], Zero( F ) );
           od;


### PR DESCRIPTION
That is, use 'f' instead of 'x -> f(x)' and so on.

This is just a continuation of @fingolfin's #5560 removing the last remaining trivial function wrappers.