### PR TITLE
Use `ReturnTrue`, `ReturnFalse`, `ReturnFail` instead of lambdas

### DIFF
--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -517,10 +517,8 @@ end);
 ##
 #M  IsSingleValued( <map> ) . . . . . . . . . . . . . .  for algebra g.m.b.i.
 ##
-InstallMethod( IsSingleValued,
-    "for algebra g.m.b.i.",
-    [ IsGeneralMapping and IsPolynomialRingDefaultGeneratorMapping ],0,
-    map->true);
+InstallTrueMethod( IsSingleValued, IsGeneralMapping and
+  IsPolynomialRingDefaultGeneratorMapping );
 
 
 #############################################################################

--- a/lib/claspcgs.gi
+++ b/lib/claspcgs.gi
@@ -682,7 +682,7 @@ local  G,  home,  # the group and the home pcgs
 
   # check to which factors we want to lift
 
-  mustlift:=List(eas,i->false);
+  mustlift:=List(eas,ReturnFalse);
   liftkerns:=[];
 
   if candidates=false then

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -579,11 +579,10 @@ end );
 InstallGlobalFunction(Arrangements,function ( mset, arg... )
     local   combs, m;
     mset := ShallowCopy(mset);  Sort( mset );
+    m := List( mset, ReturnTrue );
     if Length(arg) = 0  then
-        m := List( mset, i->true );
         combs := ArrangementsA( mset, m, Length(mset), [], 1 );
     elif Length(arg) = 1  then
-        m := List( mset, i->true );
         combs := ArrangementsK( mset, m, Length(mset), arg[1], [], 1 );
     else
         Error("usage: Arrangements( <mset> [, <k>] )");
@@ -1162,7 +1161,7 @@ end );
 InstallGlobalFunction(PermutationsList,function ( mset )
     local   m;
     mset := ShallowCopy(mset);  Sort( mset );
-    m := List( mset, i->true );
+    m := List( mset, ReturnTrue );
     return PermutationsListK(mset,m,Length(mset),Length(mset),[],1);
 end);
 
@@ -1222,7 +1221,7 @@ end );
 InstallGlobalFunction(Derangements,function ( list )
     local   mset, m;
     mset := ShallowCopy(list);  Sort( mset );
-    m := List( mset, i->true );
+    m := List( mset, ReturnTrue );
     return DerangementsK(mset,m,Length(mset),list,Length(mset),[],1);
 end);
 
@@ -1271,7 +1270,7 @@ InstallGlobalFunction(NrDerangements,function ( list )
             od;
         fi;
     else
-        m := List( mset, i->true );
+        m := List( mset, ReturnTrue );
         nr := NrDerangementsK(mset,m,Length(mset),list,Length(mset),1);
     fi;
     return nr;
@@ -1416,7 +1415,7 @@ InstallGlobalFunction(PartitionsSet,function ( set, arg... )
         if set = []  then
             parts := [ [  ] ];
         else
-            m := List( set, i->true );
+            m := List( set, ReturnTrue );
             m[1] := false;
             parts := PartitionsSetA(set,Length(set),m,2,[[set[1]]],1,1);
         fi;
@@ -1429,7 +1428,7 @@ InstallGlobalFunction(PartitionsSet,function ( set, arg... )
                 parts := [ ];
             fi;
         else
-            m := List( set, i->true );
+            m := List( set, ReturnTrue );
             m[1] := false;
             parts := PartitionsSetK(
                         set, Length(set), m, 2, k, [[set[1]]], 1, 1 );

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -3132,7 +3132,7 @@ InstallMethod( InducedCyclic,
 
     centralizers:= SizesCentralizers( tbl );
     orders:= OrdersClassRepresentatives( tbl );
-    independent:= List( orders, x -> true );
+    independent:= List( orders, ReturnTrue );
     inducedcyclic:= [];
     for i in classes do                         # induce from i-th class
       if independent[i] then
@@ -3179,7 +3179,7 @@ InstallMethod( InducedCyclic,
 
     centralizers:= SizesCentralizers( tbl );
     orders:= OrdersClassRepresentatives( tbl );
-    independent:= List( orders, x -> true );
+    independent:= List( orders, ReturnTrue );
     inducedcyclic:= [];
     for i in classes do                         # induce from i-th class
       if independent[i] then

--- a/lib/ctblmaps.gi
+++ b/lib/ctblmaps.gi
@@ -2618,7 +2618,7 @@ BindGlobal( "ModGauss", function( matrix, moduls )
     local i, modgauss, nonzerocol, row;
 
     modgauss:= [];
-    nonzerocol:= List( moduls, i -> true );
+    nonzerocol:= List( moduls, ReturnTrue );
     for i in [ 1 .. Length( matrix[1] ) ] do
       row:= StepModGauss( matrix, moduls, nonzerocol, i );
       if row <> fail then

--- a/lib/ctblpope.gi
+++ b/lib/ctblpope.gi
@@ -808,7 +808,7 @@ InstallGlobalFunction( Permut, function( tbl, arec )
        minR:= Minimum(arec.degree); maxR:= Maximum(arec.degree);
        amax:= [1]; amin:= [1];
        Conditor:= permel.Conditor;
-       free:= List(Conditor, x->true);
+       free:= List(Conditor, ReturnTrue);
        free[1]:= false;
        const:= List(Conditor, x-> List(x, y->y[1]));
        solveKnot(const, free);

--- a/lib/galois.gi
+++ b/lib/galois.gi
@@ -582,7 +582,7 @@ local f,n,i,sh,fu,ps,pps,ind,keineu,ba,bk,j,a,anz,pm,
   n:=DegreeOfUnivariateLaurentPolynomial(f);
 
   sh:=Partitions(n);
-  fu:=List([1..Length(sh)-1],i->false);
+  fu:=List([1..Length(sh)-1],ReturnFalse);
   anz:=List(fu,i->0);
   cnt:=0;
   keineu:=0;
@@ -661,7 +661,7 @@ local n,i,sh,fu,ps,pps,ind,keineu,avoid,cf;
   n:=DegreeOfUnivariateLaurentPolynomial(f);
 
   sh:=Partitions(n);
-  fu:=List([1..Length(sh)-1],i->false);
+  fu:=List([1..Length(sh)-1],ReturnFalse);
   keineu:=0;
   repeat
     repeat
@@ -1256,4 +1256,3 @@ InstallMethod(GaloisType,"for polynomials",true,
 InstallOtherMethod(GaloisType,"for polynomials and list",true,
   [IsUnivariateRationalFunction and IsPolynomial,IsList],0,
   DoGaloisType);
-

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -1966,7 +1966,7 @@ local isob,isos,iso,gens,a,rels,l,i,j,bgens,cb,cs,b,f,k,w,monoid,
   # ensure that "weyl group" represents double cosets (but allow double
   # coverage)
 
-  rti:=List(dcnums,x->false); # which double are hit already
+  rti:=List(dcnums,ReturnFalse); # which double are hit already
   for i in weyl do
     a:=PositionCanonical(rt,i);
     j:=PositionProperty(dcnums,x->a in x);

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2161,7 +2161,7 @@ function( G )
     spec := SpecialPcgs( G );
     weights := LGWeights( spec );
     primes := Set( weights, x -> x[3] );
-    comp := List( primes, x -> false );
+    comp := List( primes, ReturnFalse );
     for i in [1..Length( primes )] do
         gens := spec{Filtered( [1..Length(spec)],
                      x -> weights[x][3] <> primes[i] )};
@@ -2188,7 +2188,7 @@ function( G )
     spec := SpecialPcgs( G );
     weights := LGWeights( spec );
     primes := Set( weights, x -> x[3] );
-    comp := List( primes, x -> false );
+    comp := List( primes, ReturnFalse );
     for i in [1..Length( primes )] do
         gens := spec{Filtered( [1..Length(spec)],
                            x -> weights[x][3] = primes[i] )};
@@ -2219,7 +2219,7 @@ function( G )
     weights := LGWeights( spec );
     primes := Set( weights, x -> x[3] );
     pis    := Combinations( primes );
-    comp   := List( pis, x -> false );
+    comp   := List( pis, ReturnFalse );
     for i in [1..Length( pis )] do
         gens := spec{Filtered( [1..Length(spec)],
                            x -> weights[x][3] in pis[i] )};

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -191,7 +191,7 @@ InstallMethod( NormalComplementNC,
             fi;
           od;
           # Intersection(l, R) can take a long time
-          l := First(l, x -> true);
+          l := First(l, ReturnTrue);
         # if N is big, then Center is hopefully small and fast to compute
         elif HasCenter(G) or Size(N) > Index(G, N) then
           C := Center(G);

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -1048,7 +1048,7 @@ end);
 InstallMethod(SeedFaithfulAction,
     "default: fail",
     true,[ IsGroup ],0,
-    G->fail);
+    ReturnFail);
 
 #############################################################################
 ##

--- a/lib/grppc.gi
+++ b/lib/grppc.gi
@@ -961,7 +961,7 @@ function( G, U )
 
     # compute the orbit of <G> on <pcgs>
     orb := Orbit( G, pcgs, f );
-    res := List( orb, x -> false );
+    res := List( orb, ReturnFalse );
     for i in [1..Length(orb)] do
         L := Subgroup( H, orb[i] );
         SetHomePcgs( L, home );

--- a/lib/grppcaut.gi
+++ b/lib/grppcaut.gi
@@ -682,7 +682,7 @@ BindGlobal( "LiftInduciblePair", function( epi, ind, M, weight )
     relsP := RelatorsOfFpGroup( P );
     l := Length( relsP );
 
-    E := List( [1..n*d], x -> List( [1..l*d], y -> true ) );
+    E := List( [1..n*d], x -> List( [1..l*d], ReturnTrue ) );
     v := [];
     for k in [1..l] do
         rel := relsP[k];

--- a/lib/grppcext.gi
+++ b/lib/grppcext.gi
@@ -20,7 +20,7 @@ InstallGlobalFunction( FpGroupPcGroupSQ, function( G )
     f := GeneratorsOfGroup( F );
     g := Pcgs( G );
     n := Length( g );
-    rels := List( [1..n], x -> List( [1..x], y -> false ) );
+    rels := List( [1..n], x -> List( [1..x], ReturnFalse ) );
     for i in [1..n] do
         for j in [1..i-1] do
             w := f[j]^-1 * f[i] * f[j];

--- a/lib/grppcrep.gi
+++ b/lib/grppcrep.gi
@@ -93,7 +93,7 @@ end );
 InstallGlobalFunction( ConjugatedModule, function( pcgsN, g, modu )
 local mats, i, exp;
 
-  mats := List(modu.generators, x -> false );
+  mats := List(modu.generators, ReturnFalse );
   for i in [1..Length(mats)] do
     exp := ExponentsOfPcElement( pcgsN, pcgsN[i]^g );
     mats[i] := ImmutableMatrix(modu.field,MappedVector(exp,modu.generators));
@@ -180,7 +180,7 @@ InstallGlobalFunction( GaloisConjugates, function( modu, F )
 
     # conjugate
     for k in [1..d-1] do
-      mats := List( modu.generators, x -> false );
+      mats := List( modu.generators, ReturnFalse );
       r    := RemInt( p^k, p^d-1 );
       for i in [1..Length(mats)] do
         mats[i]:=ImmutableMatrix(F,List(modu.generators[i],x->List(x,y->y^r)));
@@ -630,5 +630,3 @@ function( G, F, dim )
     od;
     return [gens,modus];
 end );
-
-

--- a/lib/grpreps.gi
+++ b/lib/grpreps.gi
@@ -15,7 +15,7 @@
 ##
 InstallGlobalFunction( RegularModuleByGens, function( G, gens, F )
     local mats, elms, d, zero, i, mat, j, o;
-    mats := List( gens, x -> false );
+    mats := [];
     elms := AsList( G );
     d    := Length(elms);
     zero := NullMat( d, d, F );
@@ -318,5 +318,3 @@ function( G, F, dim )
     fi;
     return [gens,modus];
 end);
-
-


### PR DESCRIPTION
In a similar vein to #5575, this PR removes all instances in `lib/*` of `x -> true|false|fail` replaces them with `ReturnTrue`, `ReturnFalse`, and `ReturnFail`. There are a couple of simplifications in there too, which were highlighted by the replacement of `x -> ...`