### PR TITLE
Remove some unused function arguments

### DIFF
--- a/lib/algrep.gi
+++ b/lib/algrep.gi
@@ -274,11 +274,11 @@ true,
       local F,V;
 
       if str<>"basis" then
-         Error( "Usage: RightAlgebraModule( <A>, <op>, <gens>, <str>) where the last argument is the string \"basis\"" );
+         Error( "Usage: BiAlgebraModuleByGenerators( <A>, <B>, <opl>, <opr>, <gens>, <str>) where the last argument is the string \"basis\"" );
       fi;
 
       F:= LeftActingDomain( A );
-      V:= VectorSpace( F, str );
+      V:= VectorSpace( F, gens, str );
       return BiAlgebraModule( A, B, opl, opr, V );
 
 end );

--- a/lib/arith.gi
+++ b/lib/arith.gi
@@ -672,10 +672,7 @@ InstallMethod( Characteristic,
 InstallMethod( Characteristic,
     "return fail",
     [ IsObject ], -SUM_FLAGS,
-    function( el )
-      return fail;
-    end );
-
+    ReturnFail);
 
 #############################################################################
 ##

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -1559,7 +1559,7 @@ end);
 # find corresponding characteristic subgroups
 BindGlobal("AGSRMatchedCharacteristics",function(g,h)
 local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
-  props:=function(a,chars)
+  props:=function(a)
   local p,b;
 
     if ID_AVAILABLE(Size(a))<>fail then
@@ -1617,8 +1617,8 @@ local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
   SortBy(cg,x->-Size(x));
   SortBy(ch,x->-Size(x));
 
-  pg:=List(cg,x->props(x,ng));
-  ph:=List(ch,x->props(x,nh));
+  pg:=List(cg,props);
+  ph:=List(ch,props);
   if Collected(pg)<>Collected(ph) then return fail;fi;
 
   stop:=false;

--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -226,7 +226,7 @@ function(xset)
 end);
 
 InstallGlobalFunction( ConjugacyClassesTry,
-function ( G, classes, elm, length, fixes )
+function ( G, classes, elm, length )
 local i,D,o,divs,pows,norms,next,nnorms,oq,lelm,from,n,k,m,nu,zen,pr,orb,lo,
       prg,C,u;
 
@@ -342,11 +342,11 @@ local   classes,    # conjugacy classes of <G>, result
 
             if Length(seed)>0 then
               # try random elements
-              cent:=ConjugacyClassesTry( G, classes, seed[1], 0, 1 );
+              cent:=ConjugacyClassesTry( G, classes, seed[1], 0 );
               seed:=seed{[2..Length(seed)]};
             else
               # try random elements
-              cent:=ConjugacyClassesTry( G, classes, Random(cent), 0, 1 );
+              cent:=ConjugacyClassesTry( G, classes, Random(cent), 0 );
             fi;
 
         od;

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -1633,7 +1633,7 @@ end);
 #F  LiftClassesEANonsolvGeneral( <H>,<N>,<NT>,<cl> )
 ##
 BindGlobal("LiftClassesEANonsolvGeneral",
-  function( H, Npcgs, cl, hom, pcisom,solvtriv,fran)
+  function(Npcgs, cl, hom, pcisom,solvtriv)
     local  classes,    # classes to be constructed, the result
            correctingelement,
            field,      # field over which <N> is a vector space
@@ -1782,7 +1782,7 @@ end);
 # algorithm. We can't  do this but have to use a more simple-minded
 # orbit/stabilizer approach.
 BindGlobal("LiftClassesEANonsolvCentral",
-  function( H, Npcgs, cl,hom,pcisom,solvtriv,fran )
+  function( Npcgs, cl,hom,pcisom,solvtriv )
 local  classes,            # classes to be constructed, the result
         field,             # field over which <Npcgs> is a vector space
         o,
@@ -1980,7 +1980,7 @@ end);
 #F  LiftClassesEATrivRep
 ##
 BindGlobal("LiftClassesEATrivRep",
-  function( H, Npcgs, cl, fants,hom, pcisom,solvtriv)
+  function( Npcgs, cl, fants,hom, pcisom,solvtriv)
     local  h,field,one,gens,imgs,M,bas,
            c,i,npcgsact,usent,dim,found,nsgens,nsimgs,mo,
            pcgsimgs,
@@ -2450,15 +2450,15 @@ local r,        #radical
                 i->ForAll(mpcgs,
                   j->DepthOfPcElement(pcgs,Comm(i,j))>=ser.depths[d])) ) then
         Info(InfoHomClass,3,"central step");
-        new:=LiftClassesEANonsolvCentral(G,mpcgs,i,hom,pcisom,solvtriv,fran);
+        new:=LiftClassesEANonsolvCentral(mpcgs,i,hom,pcisom,solvtriv);
       elif Length(fants)>0 and Order(i[1])=1 then
         # special case for trivial representative
-        new:=LiftClassesEATrivRep(G,mpcgs,i,fants,hom,pcisom,solvtriv);
+        new:=LiftClassesEATrivRep(mpcgs,i,fants,hom,pcisom,solvtriv);
         if new=fail then
-          new:=LiftClassesEANonsolvGeneral(G,mpcgs,i,hom,pcisom,solvtriv,fran);
+          new:=LiftClassesEANonsolvGeneral(mpcgs,i,hom,pcisom,solvtriv);
         fi;
       else
-        new:=LiftClassesEANonsolvGeneral(G,mpcgs,i,hom,pcisom,solvtriv,fran);
+        new:=LiftClassesEANonsolvGeneral(mpcgs,i,hom,pcisom,solvtriv);
       fi;
       #Assert(3,ForAll(new,x->x[6]
       #  =Size(Group(Concatenation(x[2],DenominatorOfModuloPcgs(mpcgs))))));
@@ -2512,7 +2512,7 @@ end);
 #F  LiftConCandCenNonsolvGeneral( <H>,<N>,<NT>,<cl> )
 ##
 BindGlobal("LiftConCandCenNonsolvGeneral",
-  function( H, Npcgs, reps, hom, pcisom,solvtriv,fran)
+  function(Npcgs, reps, hom, pcisom,solvtriv)
     local  nreps,      # new reps to be constructed, the result
            correctingelement,
            minvec,
@@ -2942,8 +2942,8 @@ local r,        #radical
       fi;
       Info(InfoHomClass,2,Length(sel)," in candidate group");
       select:=Difference(select,sel);
-      new:=LiftConCandCenNonsolvGeneral(G,mpcgs,reps{sel},hom,pcisom,
-             solvtriv,fran);
+      new:=LiftConCandCenNonsolvGeneral(mpcgs,reps{sel},hom,pcisom,
+             solvtriv);
       # conj test
       if new=fail then
         return new;
@@ -3191,5 +3191,3 @@ BindGlobal("TFClassMatrixColumn",function(D,M,r,t)
     fi;
   fi;
 end);
-
-

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -2316,7 +2316,7 @@ local r,        #radical
       gens,
       ser,      # series
       radsize,len,ntrihom,
-      mran,nran,fran,
+      mran,nran,
       central,
       fants,
       d,
@@ -2427,7 +2427,6 @@ local r,        #radical
     #N:=ser[i];
     mran:=[ser.depths[d-1]..len];
     nran:=[ser.depths[d]..len];
-    fran:=[mran,nran];
 
     mpcgs:=InducedPcgsByPcSequenceNC(pcgs,pcgs{mran}) mod
            InducedPcgsByPcSequenceNC(pcgs,pcgs{nran});
@@ -2764,7 +2763,7 @@ local r,        #radical
       pcisom,
       ser,      # series
       radsize,len,
-      mran,nran,fran,
+      mran,nran,
       central,
       #fants,
       reps,
@@ -2913,7 +2912,6 @@ local r,        #radical
     #N:=ser[i];
     mran:=[ser.depths[d-1]..len];
     nran:=[ser.depths[d]..len];
-    fran:=[mran,nran];
 
     mpcgs:=InducedPcgsByPcSequenceNC(pcgs,pcgs{mran}) mod
            InducedPcgsByPcSequenceNC(pcgs,pcgs{nran});

--- a/lib/claspcgs.gi
+++ b/lib/claspcgs.gi
@@ -599,7 +599,7 @@ local  G,  home,  # the group and the home pcgs
   if IsBound(opt.consider) then
     consider:=opt.consider;
   else
-    consider:=true;
+    consider:=ReturnTrue;
   fi;
 
   # Treat the case of a trivial group.
@@ -919,8 +919,7 @@ Error("This case disabled -- code not yet corrected");
       for cli in [1..Length(cls)]  do
 
         cl:=cls[cli];
-        if consider=true
-         or consider(fhome,cl.representative,cl.centralizerpcgs,K,L)
+        if consider(fhome,cl.representative,cl.centralizerpcgs,K,L)
           then
           if allcent or cent(fhome,cl.centralizerpcgs, N, Ldep) then
             news:=CentralStepClEANS(fhome,QG, QG, N, cl,false);

--- a/tst/testinstall/algrep.tst
+++ b/tst/testinstall/algrep.tst
@@ -131,4 +131,10 @@ gap> tmp:=Coboundaries(S,1);; Dimension(tmp);; tmp;
 <vector space of dimension 29 over GF(3)>
 
 #
+gap> A:= FullMatrixAlgebra( Rationals, 3 );;
+gap> V:= BiAlgebraModuleByGenerators( A, A, \*, \*, [ [1,0,0] ], "basis" );
+<bi-module over ( Rationals^[ 3, 3 ] ) (left) and ( Rationals^
+[ 3, 3 ] ) (right)>
+
+#
 gap> STOP_TEST( "algrep.tst", 1);


### PR DESCRIPTION
This PR contains several commits that remove unused function arguments from some functions that appear not to be user facing (they are `BindGlobal`ed in `gi` files for the most part). 

This PR is probably best viewed commit by commit. Perhaps these types of changes are not wanted, if so, then I will stop, if they are welcome, then I will continue to review the library for more instances.