### PR TITLE
Fix RemoveDirectoryRecursively for immutable argument

### DIFF
--- a/lib/files.gi
+++ b/lib/files.gi
@@ -373,7 +373,8 @@ InstallGlobalFunction(RemoveDirectoryRecursively,
         Error("dirname must be a directory");
         return fail;
     fi;
-    while Length(dirname) > 0 and dirname[Length(dirname)] = '/' do
+    dirname := ShallowCopy(dirname);
+    while Length(dirname) > 0 and Last(dirname) = '/' do
         Remove(dirname);
     od;
     if Length(dirname) = 0 then

--- a/tst/testinstall/kernel/streams.tst
+++ b/tst/testinstall/kernel/streams.tst
@@ -173,6 +173,30 @@ gap> IsDir(fail);
 Error, IsDir: <filename> must be a string (not the value 'fail')
 
 #
+gap> tmpdir := MakeImmutable(TmpDirectory());;
+gap> subdir := MakeImmutable(Concatenation(tmpdir, "/subdir"));;
+gap> CreateDir(subdir);
+true
+gap> IsDir(subdir);
+'D'
+gap> RemoveDir(subdir);
+true
+gap> IsDir(subdir);
+fail
+gap> CreateDir(subdir);
+true
+gap> FileString(Concatenation(subdir, "/file"), "data");
+4
+gap> IsDir(subdir);
+'D'
+gap> RemoveDirectoryRecursively(tmpdir);
+true
+gap> IsDir(subdir);
+fail
+gap> IsDir(tmpdir);
+fail
+
+#
 gap> IsExistingFile(fail);
 Error, IsExistingFile: <filename> must be a string (not the value 'fail')
 gap> IsReadableFile(fail);


### PR DESCRIPTION
It's a bad idea to modify an argument inplace anyway, unless this behavior is explicitly documented and 'necessary'.

Also add a bunch of tests to verify the text and more.