### PR TITLE
CI: allow tags named v1.2.3-beta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    tags: v[1-9]+.[0-9]+.[0-9]+
+    tags:
+      - v[1-9]+.[0-9]+.[0-9]    # allow v1.2.3
+      - v[1-9]+.[0-9]+.[0-9]-*  # allow v1.2.3-beta3 etc.
     branches:
       - master
       - stable-*

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -23,6 +23,7 @@ if len(sys.argv) != 3:
 
 TAG_NAME = sys.argv[1]
 PATH_TO_RELEASE = sys.argv[2]
+VERSION = TAG_NAME[1:]  # strip 'v' prefix
 
 utils.verify_git_clean()
 utils.verify_is_possible_gap_release_tag(TAG_NAME)
@@ -43,7 +44,7 @@ if any(r.tag_name == TAG_NAME for r in utils.CURRENT_REPO.get_releases()):
     utils.error(f"Github release with tag '{TAG_NAME}' already exists!")
 
 # Create release
-RELEASE_NOTE = f"For an overview of changes in GAP {TAG_NAME[1:]} see the " \
+RELEASE_NOTE = f"For an overview of changes in GAP {VERSION} see the " \
     + f"[CHANGES.md](https://github.com/gap-system/gap/blob/{TAG_NAME}/CHANGES.md) file."
 utils.notice(f"Creating release {TAG_NAME}")
 RELEASE = utils.CURRENT_REPO.create_git_release(TAG_NAME, TAG_NAME,
@@ -60,7 +61,7 @@ with utils.working_directory(PATH_TO_RELEASE):
         print(filename)
 
     # Now check that TAG_NAME and the created archives belong together
-    main_archive_name = "gap-" + TAG_NAME[1:] + ".tar.gz"
+    main_archive_name = "gap-" + VERSION + ".tar.gz"
     if not main_archive_name in manifest:
         utils.error(f"Expected to find {main_archive_name} in MANIFEST, but did not!")
 

--- a/dev/releases/utils.py
+++ b/dev/releases/utils.py
@@ -141,7 +141,7 @@ def run_with_log(args, name, msg = None):
             error(msg+" failed. See "+name+".log.")
 
 def is_possible_gap_release_tag(tag):
-    return re.fullmatch( r"v[1-9]+\.[0-9]+\.[0-9]+", tag) != None
+    return re.fullmatch( r"v[1-9]+\.[0-9]+\.[0-9]+(-.+)?", tag) != None
 
 def verify_is_possible_gap_release_tag(tag):
     if not is_possible_gap_release_tag(tag):


### PR DESCRIPTION
... so that we can make alpha/beta/... releases -- not for publishing them to users, but for downstream packagers (Debian, Fedora, Gentoo, etc.)