### PR TITLE
Don't require tput for gac or dev/ci.sh

### DIFF
--- a/cnf/gac.in
+++ b/cnf/gac.in
@@ -65,7 +65,7 @@ GAP_LDFLAGS="${GAP_LDFLAGS} ${GAC_LDFLAGS}"
 
 
 # is output going to a terminal?
-if test -t 1; then
+if test -t 1 && command -v tput >/dev/null 2>&1 ; then
 
     # does the terminal support color?
     ncolors=$(tput colors)

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -36,7 +36,7 @@ COVDIR=${COVDIR:-coverage}
 # Various little helper functions
 
 # is output going to a terminal?
-if test -t 1; then
+if test -t 1 && command -v tput >/dev/null 2>&1 ; then
 
     # does the terminal support color?
     ncolors=$(tput colors)


### PR DESCRIPTION
Not every system may have it, and it's just for making things print a bit nicer; so just disable the code using `tput` if iitkmissing.

Specifically in a cross-compilation tests I did on ObenBSD it failed due to this