### PR TITLE
change the generic `PermutationOp` method

### DIFF
--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2100,6 +2100,12 @@ InstallMethod( PermutationOp, "object on list", true,
             fi;
             blist[ new ] := true;
             list[ old ] := new;
+            # Map the "original" points not the images under `act'.
+            # We assume that they are at least as nice as the images.
+            # In the case of automorphisms acting on elements of a f. p. group,
+            # the images are represented by words which are usually longer
+            # than the words in `D'.
+            pnt := D[ new ];
         until new = fst;
         fst := Position( blist, false, fst );
     od;


### PR DESCRIPTION
Apply the action function to the points in the action domain, not to images computed by the action function.
This is expected to yield a small improvement in the case of actions on elements of a f.p. group, where the lengths of the words tend to grow when one computes images.
(The tests from `tst/testextra/grpperm.tst` are indeed sped up by the proposed change.)

The change was motivated by #5590.