### PR TITLE
buildsys: rename SPARC -> SYS_IS_SPARC, drop SYS_IS_CYGWIN32

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -12,7 +12,6 @@
 #
 
 # GAP specific
-SYS_IS_CYGWIN32 = @SYS_IS_CYGWIN32@
 ABI = @ABI@
 ABI_CFLAGS = @ABI_CFLAGS@
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -425,7 +425,7 @@ build/obj/%.c.o: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS $(obj_deps)
 LINK=$(CC)
 
 SHLIB_MAJOR = $(GAP_KERNEL_MAJOR_VERSION)
-ifeq ($(SYS_IS_CYGWIN32),yes)
+ifneq (,$(findstring cygwin,$(host_os)))
   SHLIB_EXT=.dll
   LIBGAP_FULL = libgap$(SHLIB_EXT)
 
@@ -466,7 +466,7 @@ libgap: libgap$(SHLIB_EXT) $(LIBGAP_FULL)
 $(LIBGAP_FULL): $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 	$(QUIET_LINK)$(LINK) -o $@ $(LINK_SHLIB_FLAGS) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS)
 
-ifeq ($(SYS_IS_CYGWIN32),yes)
+ifneq (,$(findstring cygwin,$(host_os)))
 
 # increase stack size, the default is too small (see issue #1522)
 GAP_LDFLAGS += -Wl,--stack,16777216
@@ -758,7 +758,8 @@ ZLIB_FILES := $(ZLIB_PREFIX)/include/zlib.h
 EXTERN_FILES += $(ZLIB_FILES)
 
 zlib: $(ZLIB_FILES)
-ifeq ($(SYS_IS_CYGWIN32),yes)
+
+ifneq (,$(findstring cygwin,$(host_os)))
 $(ZLIB_FILES):
 	MAKE=$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" $(srcdir)/cnf/build-cygwin-zlib.sh
 
@@ -767,7 +768,7 @@ else
 $(ZLIB_FILES):
 	MAKE=$(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" $(srcdir)/cnf/build-extern.sh zlib "$(abs_srcdir)/extern/zlib"
 
-endif # SYS_IS_CYGWIN32
+endif
 
 .PHONY: zlib
 

--- a/configure.ac
+++ b/configure.ac
@@ -928,18 +928,9 @@ GP_C_LONG_ALIGN
 
 case "$host_cpu" in
   sparc* )
-    AC_DEFINE([SPARC], [1], [define as 1 on SPARC architecture to flush register windows])
-    SPARC=yes
+    AC_DEFINE([SYS_IS_SPARC], [1], [define as 1 on SPARC architecture to flush register windows])
     ;;
 esac
-
-case "$host_os" in
-  *cygwin*)
-    CYGWIN=yes
-    ;;
-esac
-
-AC_SUBST([SYS_IS_CYGWIN32], [$CYGWIN])
 
 
 dnl

--- a/dev/audit-config-h.sh
+++ b/dev/audit-config-h.sh
@@ -21,15 +21,14 @@ if git grep -n -w config.h -- :/src/*.h > /dev/null ; then
 fi
 
 # First scan config.h to obtain a list of all symbols it might define. From
-# this is subtracts a list of "known OK" symbols. The symbols and there reason
+# this is subtracts a list of "known OK" symbols. The symbols and their reason
 # for being on this list are:
 # - `HAVE_FUNC_ATTRIBUTE_`*: these are only used for optimizations; also, our
 #    headers try hard to define them on the fly (at least in GCC and clang)
 # - `HAVE___BUILTIN_MUL_OVERFLOW`: same as above
 # - `SIZEOF_VOID_P`: provided for backwards compatibility in a few packages,
 #    and actually (re-)defined in `common.h`
-# - `SPARC`: only appears in a comment
-PATTERN=$(egrep '(#define|#undef)' build/config.h | sed -E -e 's;(#define|/\* #undef) ([^ ]+) .*$;\2;' | egrep -v 'HAVE_FUNC_ATTRIBUTE_|HAVE___BUILTIN_MUL_OVERFLOW|SIZEOF_VOID_P|SPARC' | tr '\n' '|')
+PATTERN=$(egrep '(#define|#undef)' build/config.h | sed -E -e 's;(#define|/\* #undef) ([^ ]+) .*$;\2;' | egrep -v 'HAVE_FUNC_ATTRIBUTE_|HAVE___BUILTIN_MUL_OVERFLOW|SIZEOF_VOID_P' | tr '\n' '|')
 PATTERN=${PATTERN%?} # remove trailing "|"
 
 # only consider files that do not #include config.h

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1893,7 +1893,7 @@ UInt ResizeBag (
 
 static jmp_buf RegsBags;
 
-#if defined(SPARC)
+#if defined(SYS_IS_SPARC)
 static void SparcStackFuncBags(void)
 {
   asm (" ta 0x3 ");
@@ -1998,7 +1998,7 @@ static UInt CollectBags_Mark(UInt FullBags)
 
     // mark from the stack
     _setjmp(RegsBags);
-#if defined(SPARC)
+#if defined(SYS_IS_SPARC)
     SparcStackFuncBags();
 #endif
     GenStackFuncBags();


### PR DESCRIPTION
This only affects configure and Makefile.rules; the headers still define a macro SYS_IS_CYGWIN32.
