### PR TITLE
Fix check in testbugfix/2023-10-18-SetDimension.tst

### DIFF
--- a/tst/testbugfix/2023-10-18-SetDimension.tst
+++ b/tst/testbugfix/2023-10-18-SetDimension.tst
@@ -1,5 +1,5 @@
 # issue reported by Michel Lavrauw on 18 October 2023
-#@if LoadPackage("fining",false)
+#@if LoadPackage("fining",false) <> fail
 gap> G:=ProjectivityGroup(PG(8,2));
 The FinInG projectivity group PGL(9,2)
 gap> H:=Group(Identity(G));


### PR DESCRIPTION
If fining is not available, the previous check returns `fail`, which causes an error in `ParseTestInput`.

This causes the CI for Semigroups to fail at:

https://github.com/semigroups/Semigroups/actions/runs/7639126889/job/20811465267?pr=982