### PR TITLE
Replace redundant ifs

### DIFF
--- a/lib/dict.gi
+++ b/lib/dict.gi
@@ -174,11 +174,7 @@ InstallMethod(KnowsDictionary,"for lookup sort dictionaries",true,
 function(d,x)
 local p;
   p := PositionSorted(d!.entries,[x]);
-  if p <= Length(d!.entries) and d!.entries[p][1] = x then
-    return true;
-  else
-    return false;
-  fi;
+  return p <= Length(d!.entries) and d!.entries[p][1] = x;
 end);
 
 InstallMethod(KnowsDictionary,"for list dictionaries",true,

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2955,7 +2955,7 @@ local n,a;
   fi;
 
   a:=AutomorphismGroup(G);
-  return not ForAny(GeneratorsOfGroup(a),i->Image(i,H)<>H);
+  return ForAll(GeneratorsOfGroup(a),i->Image(i,H)=H);
 end );
 
 

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -394,11 +394,7 @@ InstallMethod( IsPowerfulPGroup,
       # for p>3 by Jon Gonzalez-Sanchez, Amaia Zugadi-Reizabal
       # can be found in 'A characterization of powerful p-groups'
       if (p>3) then
-        if (RankPGroup(G)=Log(Order(Omega(G,p)),p)) then
-          return true;
-        else
-          return false;
-        fi;
+        return RankPGroup(G)=Log(Order(Omega(G,p)),p);
       else
         TryNextMethod();
       fi;
@@ -5735,14 +5731,7 @@ InstallMethod(CharacteristicSubgroups,"use automorphisms",true,[IsGroup],
 InstallTrueMethod( CanComputeSize, HasSize );
 
 InstallMethod( CanComputeIndex,"by default impossible unless identical",
-  IsIdenticalObj, [IsGroup,IsGroup],
-function(G,U)
-  if IsIdenticalObj(G,U) then
-    return true;
-  else
-    return false;
-  fi;
-end);
+  IsIdenticalObj, [IsGroup,IsGroup], IsIdenticalObj );
 
 InstallMethod( CanComputeIndex,"if sizes can be computed",IsIdenticalObj,
   [IsGroup and CanComputeSize,IsGroup and CanComputeSize],

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -2955,11 +2955,7 @@ local n,a;
   fi;
 
   a:=AutomorphismGroup(G);
-  if ForAny(GeneratorsOfGroup(a),i->Image(i,H)<>H) then
-    return false;
-  else
-    return true;
-  fi;
+  return not ForAny(GeneratorsOfGroup(a),i->Image(i,H)<>H);
 end );
 
 

--- a/lib/kernel.g
+++ b/lib/kernel.g
@@ -103,11 +103,7 @@ end;
 ##  </ManSection>
 ##
 IS_SUBSTRING := function( str, sub )
-  if LEN_LIST(sub) > 0 and POSITION_SUBSTRING(str, sub, 0) = fail then
-    return false;
-  else
-    return true;
-  fi;
+  return LEN_LIST(sub) = 0 or POSITION_SUBSTRING(str, sub, 0) <> fail;
 end;
 
 

--- a/lib/orders.gi
+++ b/lib/orders.gi
@@ -1018,11 +1018,7 @@ function(fam,alphabet)
       fi;
     od;
 
-    if mp<=0 and np<>0 then
-      return true;
-    else
-      return false;
-    fi;
+    return mp<=0 and np<>0;
   end;
 
   ########
@@ -1074,11 +1070,7 @@ function(fam,alphabet)
       fi;
     od;
 
-    if m =0 and n<>0 then
-      return true;
-    else
-        return false;
-      fi;
+    return m =0 and n<>0;
   end;
 
   ltfun:=function(u,v)
@@ -1572,5 +1564,3 @@ InstallOtherMethod(WreathProductOrdering,
   function(f,gensorder,levels)
     return WreathProductOrdering(ElementsFamily(FamilyObj(f)),gensorder,levels);
   end);
-
-

--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -635,11 +635,7 @@ local a,b,fam,i, j,ln,ld,rn,rd;
   od;
   # is there an a-remainder (then a is larger)
   # or are both polynomials equal?
-  if i>0 or i=j then
-    return false;
-  else
-    return true;
-  fi;
+  return not (i>0 or i=j);
 end );
 
 #############################################################################

--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -378,11 +378,7 @@ local x,y;
     x:=x-2;
     y:=y-2;
   od;
-  if x<=0 and y>0 then
-    return true;
-  else
-    return false;
-  fi;
+  return x<=0 and y>0;
 end );
 
 ##  Low level workhorse for operations with monomials in Zipped form
@@ -1398,4 +1394,3 @@ local c,i,j,m,ex;
   od;
   return c;
 end );
-

--- a/lib/straight.gi
+++ b/lib/straight.gi
@@ -526,7 +526,7 @@ InstallMethod( IsInternallyConsistent,
 
       # If the number of generators is stored then check
       # that only defined positions are accessed.
-      return not ( IsBound( nrgens ) and not IsSubset( defined, gens ) );
+      return not IsBound( nrgens ) or IsSubset( defined, gens );
     end;
 
     len:= Length( lines );

--- a/lib/straight.gi
+++ b/lib/straight.gi
@@ -526,11 +526,7 @@ InstallMethod( IsInternallyConsistent,
 
       # If the number of generators is stored then check
       # that only defined positions are accessed.
-      if IsBound( nrgens ) and not IsSubset( defined, gens ) then
-        return false;
-      else
-        return true;
-      fi;
+      return not ( IsBound( nrgens ) and not IsSubset( defined, gens ) );
     end;
 
     len:= Length( lines );


### PR DESCRIPTION
This PR contains some further refactoring of the library code, replacing all instances of 

~~~
if something then
   return true;
else
  return false;
fi;
~~~

by `return something;` and the analogous change with `true` and `false` exchanged.

