### PR TITLE
Use ReturnTrue/False/Fail/First and IdFunc

### DIFF
--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -1567,10 +1567,7 @@ InstallMethod( ClosureLeftOperatorRing,
     IsCollsElms,
     [ IsFLMLOR and IsWholeFamily, IsRingElement ],
     SUM_FLAGS, # this is better than everything else
-    function( A, a )
-    return A;
-    end );
-
+    ReturnFirst);
 
 #############################################################################
 ##
@@ -1607,10 +1604,7 @@ InstallMethod( ClosureLeftOperatorRing,
     IsIdenticalObj,
     [ IsLeftOperatorRing and IsWholeFamily, IsCollection ],
     SUM_FLAGS, # this is better than everything else
-    function( A, S )
-    return A;
-    end );
-
+    ReturnFirst);
 
 #############################################################################
 ##

--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -634,10 +634,7 @@ InstallOtherMethod( \^,
 InstallOtherMethod( \^,
     "for two class functions (conjugation, trivial action)",
     [ IsClassFunction, IsClassFunction ],
-    function( chi, psi )
-    return chi;
-    end );
-
+    ReturnFirst);
 
 #############################################################################
 ##

--- a/lib/domain.gi
+++ b/lib/domain.gi
@@ -357,10 +357,7 @@ InstallMethod( Intersection2,
     IsIdenticalObj,
     [ IsDomain, IsCollection and IsWholeFamily ],
     SUM_FLAGS, # this is better than everything else
-    function( D1, D2 )
-    return D1;
-    end );
-
+    ReturnFirst);
 
 #############################################################################
 ##

--- a/lib/field.gi
+++ b/lib/field.gi
@@ -193,10 +193,7 @@ InstallMethod( ClosureDivisionRing,
     IsCollsElms,
     [ IsDivisionRing and IsWholeFamily, IsScalar ],
     SUM_FLAGS, # we can't be better than this
-    function( D, d )
-    return D;
-    end );
-
+    ReturnFirst);
 
 #############################################################################
 ##
@@ -229,9 +226,7 @@ InstallMethod( ClosureDivisionRing,
 InstallMethod( ClosureDivisionRing,
     "for division ring and empty list",
     [ IsDivisionRing, IsList and IsEmpty ],
-    function( D, empty )
-    return D;
-    end );
+    ReturnFirst);
 
 
 #############################################################################

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1503,10 +1503,7 @@ RedispatchOnCondition( FittingSubgroup, true, [IsGroup], [IsFinite], 0);
 #M  FrattiniSubgroup( <G> ) . . . . . . . . . .  Frattini subgroup of a group
 ##
 InstallMethod( FrattiniSubgroup, "method for trivial groups",
-            [ IsGroup and IsTrivial ],
-function(G)
-    return G;
-end);
+            [ IsGroup and IsTrivial ], IdFunc );
 
 InstallMethod( FrattiniSubgroup, "for abelian groups",
             [ IsGroup and IsAbelian ],
@@ -2582,10 +2579,7 @@ InstallMethod( ClosureGroup,
     IsCollsElms,
     [ IsGroup and IsWholeFamily, IsMultiplicativeElementWithInverse ],
     SUM_FLAGS, # this is better than everything else
-    function( G, g )
-    return G;
-    end );
-
+    ReturnFirst);
 
 #############################################################################
 ##
@@ -2611,9 +2605,7 @@ InstallMethod( ClosureGroup,
     IsIdenticalObj,
     [ IsGroup and IsWholeFamily, IsGroup ],
     SUM_FLAGS, # this is better than everything else
-    function( G, H )
-    return G;
-    end );
+    ReturnFirst);
 
 InstallMethod( ClosureGroup,
     "for group and element list",
@@ -2629,11 +2621,7 @@ InstallMethod( ClosureGroup,
 end );
 
 InstallMethod( ClosureGroup, "for group and empty element list",
-    [ IsGroup, IsList and IsEmpty ],
-function( G, nogens )
-  return G;
-end );
-
+    [ IsGroup, IsList and IsEmpty ], ReturnFirst);
 
 #############################################################################
 ##

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -626,9 +626,7 @@ end);
 
 InstallMethod( CanComputeIsSubset, "whole fp family group", IsIdenticalObj,
     [ IsSubgroupFpGroup and IsWholeFamily, IsSubgroupFpGroup ], 0,
-function(left,right)
-  return true;
-end);
+    ReturnTrue);
 
 InstallMethod(IsNormalOp,"subgroups of fp group by quot. rep in full fp grp.",
   IsIdenticalObj, [ IsSubgroupFpGroup and IsWholeFamily,

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1331,16 +1331,10 @@ function(G)
 end);
 
 InstallMethod(PerfectResiduum,"for perfect groups",true,
-  [IsPerfectGroup],0,
-function(G)
-  return G;
-end);
+  [IsPerfectGroup],0, IdFunc);
 
 InstallMethod(PerfectResiduum,"for solvable groups",true,
-  [IsSolvableGroup],0,
-function(G)
-  return TrivialSubgroup(G);
-end);
+  [IsSolvableGroup],0, TrivialSubgroup);
 
 #############################################################################
 ##

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -814,9 +814,7 @@ InstallOtherMethod( ClosureGroup,"permgroup, elements, options",
 
 InstallOtherMethod( ClosureGroup, "empty list",true,
         [ IsPermGroup, IsList and IsEmpty ], 0,
-function( G, nogens )
-    return G;
-end );
+ReturnFirst);
 
 InstallMethod( ClosureGroup, "permgroup, element",true,
   [ IsPermGroup, IsPerm ], 0,
@@ -844,9 +842,7 @@ end );
 
 InstallOtherMethod( ClosureGroup, "empty list and options",true,
         [ IsPermGroup, IsList and IsEmpty, IsRecord ], 0,
-    function( G, nogens, options )
-    return G;
-end );
+ReturnFirst);
 
 #############################################################################
 ##

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -3956,11 +3956,7 @@ function(l)
   return Length(l)=0 or CanEasilyCompareElements(l[1]);
 end);
 
-InstallMethod(CanEasilyCompareElements,"empty homogeneous list",
-  [IsHomogeneousList and IsEmpty],
-function(l)
-  return true;
-end);
+InstallTrueMethod(CanEasilyCompareElements, IsHomogeneousList and IsEmpty);
 
 #############################################################################
 ##
@@ -3972,12 +3968,7 @@ function(l)
   return Length(l)=0 or CanEasilySortElements(l[1]);
 end);
 
-InstallMethod(CanEasilySortElements,"empty homogeneous list",
-  [IsHomogeneousList and IsEmpty],
-function(l)
-  return true;
-end);
-
+InstallTrueMethod(CanEasilySortElements, IsHomogeneousList and IsEmpty);
 
 #############################################################################
 ##

--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -762,9 +762,7 @@ InstallOtherMethod( \+,
     "for general mapping and zero mapping",
     IsIdenticalObj,
     [ IsGeneralMapping, IsGeneralMapping and IsZero ], 0,
-    function( map, zero )
-    return map;
-    end );
+    ReturnFirst );
 
 
 #############################################################################

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -1208,9 +1208,7 @@ InstallMethod( \^,
     true,
     [ IsGeneralMapping and IsOne, IsInt ],
     SUM_FLAGS, # can't do better
-  function ( id, n )
-    return id;
-  end );
+  ReturnFirst );
 
 
 #############################################################################

--- a/lib/matint.gi
+++ b/lib/matint.gi
@@ -857,9 +857,7 @@ local norm, rs, t, M, r;
 end);
 
 InstallOtherMethod(SolutionIntMat,"empty",true,[IsEmpty,IsObject],0,
-function(mat,v)
-  return fail;
-end);
+ReturnFail);
 
 #############################################################################
 ##

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -297,9 +297,7 @@ InstallMethod( ZeroSameMutability,
 InstallMethod( \+,
     "for two null map matrices",
     [ IsNullMapMatrix, IsNullMapMatrix ],
-    function(null,null2)
-    return null;
-end );
+    ReturnFirst );
 
 InstallMethod( AdditiveInverseSameMutability,
     "for a null map matrix",
@@ -314,9 +312,7 @@ InstallMethod( AdditiveInverseOp,
 InstallMethod( \*,
     "for two null map matrices",
     [ IsNullMapMatrix, IsNullMapMatrix ],
-    function(null,null2)
-    return null;
-end );
+    ReturnFirst );
 
 InstallMethod( \*,
     "for a scalar and a null map matrix",
@@ -328,9 +324,7 @@ end );
 InstallMethod( \*,
     "for a null map matrix and a scalar",
     [ IsNullMapMatrix, IsScalar ],
-    function(null,s)
-    return null;
-end );
+    ReturnFirst );
 
 InstallMethod( \*,
     "for vector and null map matrix",

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2769,9 +2769,7 @@ InstallMethod( IsSemiRegular,
       IsList,
       IsFunction ],
       20, # we claim this method is very good
-    function( G, D, gens, acts, act )
-    return true;
-end );
+      ReturnTrue);
 
 InstallMethod( IsSemiRegular,
     "G, D, gens, [  ], act",
@@ -3581,9 +3579,7 @@ end);
 ##
 InstallMethod(DomainForAction,"default: fail",true,
   [IsObject,IsListOrCollection,IsFunction],0,
-function(pnt,acts,act)
-  return fail;
-end);
+ReturnFail);
 
 #############################################################################
 ##

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -3109,9 +3109,7 @@ InstallGlobalFunction( PackageVariablesInfo, function( pkgname, version )
       fi;
       end;
 
-    key_dependent_operation:= function( entry )
-      return entry;
-      end;
+    key_dependent_operation:= IdFunc;
 
     # List the cases to be dealt with.
     rules:= [

--- a/lib/pcgs.gi
+++ b/lib/pcgs.gi
@@ -872,9 +872,7 @@ end );
 ##
 InstallMethod( ExtendedPcgs, "pcgs, empty list", true,
         [ IsPcgs, IsList and IsEmpty ], 0,
-    function( N, gens )
-    return N;
-end );
+    ReturnFirst );
 
 
 #############################################################################

--- a/lib/ratfun.gi
+++ b/lib/ratfun.gi
@@ -1098,9 +1098,7 @@ InstallMethod(HeuristicCancelPolynomialsExtRep,"ignore",true,
   [IsRationalFunctionsFamily,IsList,IsList],
   # fallback: lower than default for the weakest conditions
   -1,
-function(f,a,b)
-  return fail; # can't do anything
-end);
+ReturnFail);
 
 InstallGlobalFunction(TryGcdCancelExtRepPolynomials,TRY_GCD_CANCEL_EXTREP_POL);
 

--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -760,9 +760,7 @@ InstallMethod( ClosureRing,
     IsCollsElms,
     [ IsRing and IsWholeFamily, IsRingElement ],
     SUM_FLAGS, # can't do better
-    function( R, r )
-    return R;
-    end );
+    ReturnFirst );
 
 
 #############################################################################
@@ -800,9 +798,7 @@ InstallMethod( ClosureRing,
     IsIdenticalObj,
     [ IsRing and IsWholeFamily, IsCollection ],
     SUM_FLAGS, # can't do better
-    function( R, S )
-    return R;
-    end );
+    ReturnFirst );
 
 
 #############################################################################

--- a/lib/rvecempt.gi
+++ b/lib/rvecempt.gi
@@ -69,9 +69,7 @@ InstallMethod( IsBound\[\],
     true,
     [ IsRowVector and IsEmpty and IsEmptyRowVectorRep,
       IsPosInt ], 0,
-    function( emptyvec, pos )
-    return false;
-    end );
+    ReturnFalse);
 
 
 #############################################################################
@@ -130,9 +128,7 @@ InstallMethod( \+,
     IsIdenticalObj,
     [ IsRowVector and IsEmpty and IsEmptyRowVectorRep,
       IsRowVector and IsEmpty and IsEmptyRowVectorRep ], 0,
-    function( emptyvec1, emptyvec2 )
-    return emptyvec1;
-    end );
+    ReturnFirst );
 
 
 #############################################################################
@@ -180,9 +176,7 @@ InstallMethod( \*,
     IsCollsElms,
     [ IsRowVector and IsEmpty and IsEmptyRowVectorRep,
       IsMultiplicativeElement ], 0,
-    function( emptyvec, coeff )
-    return emptyvec;
-    end );
+    ReturnFirst );
 
 
 #############################################################################
@@ -206,9 +200,7 @@ InstallMethod( \*,
     "for empty row vector, and integer",
     true,
     [ IsRowVector and IsEmpty and IsEmptyRowVectorRep, IsInt ], 0,
-    function( emptyvec, int )
-    return emptyvec;
-    end );
+    ReturnFirst );
 
 
 #############################################################################

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1217,10 +1217,7 @@ end );
 InstallMethod( WriteAll,
     "output text none",
     [ IsOutputTextNone and IsOutputTextNoneRep,
-      IsString ],
-function( stream, string )
-    return true;
-end );
+      IsString ], ReturnTrue );
 
 
 #############################################################################

--- a/lib/word.gi
+++ b/lib/word.gi
@@ -149,9 +149,7 @@ InstallMethod( MappedWord,
 ##
 InstallOtherMethod( MappedWord, "empty generators list", true,
     [ IsObject, IsEmpty, IsList ], 0,
-function( x, gens1, gens2 )
-  return x;
-end);
+ReturnFirst );
 
 #############################################################################
 ##


### PR DESCRIPTION
This PR removes all further instances (that I could locate) in the library code of 1 line functions that just return `true`, `false`, `fail`, the first argument (if there is more than one), and functions with a single argument that return that argument (with `IdFunc`). Two of these replacements resulted in warnings at GAP start up that `InstallTrueMethod` should be used instead of `InstallMethod(..., ReturnTrue);` so I replaced these with `InstallTrueMethod` also. This is sometimes problematic, and so might require dropping the `InstallTrueMethod` changes.