### PR TITLE
buildsys: detect 'check-manuals' exit code

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -560,7 +560,6 @@ distclean: clean
 	rm -f config.log config.status GNUmakefile
 	rm -f doc/make_doc
 	rm -f doc/*/*.aux doc/*/*.bbl doc/*/*.blg doc/*/*.brf doc/*/*.idx doc/*/*.ilg doc/*/*.ind doc/*/*.log doc/*/*.out doc/*/*.pnr doc/*/*.tex doc/*/*.toc
-	rm -rf dev/log
 	rm -rf tags
 	rm -rf TAGS
 
@@ -971,9 +970,7 @@ clean-doc:
 
 # Manual consistency check
 check-manuals: all
-	$(MKDIR_P) dev/log
-	( cd doc/ref ; echo 'Read("testconsistency.g");' | $(TESTGAP) | \
-	               tee `date -u +../../dev/log/check_manuals_%Y-%m-%d-%H-%M` )
+	cd doc/ref && $(TESTGAP) testconsistency.g
 
 .PHONY: doc clean-doc manuals check-manuals html
 

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -1664,7 +1664,7 @@ DeclareGlobalFunction( "AlgebraByStructureConstants" );
 ##  that describes the unique multiplicative identity element of the returned
 ##  algebra w. r. t. the defining basis of this algebra,
 ##  and that the returned algebra is an algebra-with-one
-##  (see <Ref Func="IsAlgebraWithOne"/>).
+##  (see <Ref Filt="IsAlgebraWithOne"/>).
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> A:= GF(2)^[2,2];;

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -2790,7 +2790,7 @@ DeclareGlobalFunction( "IsClassFusionOfNormalSubgroup" );
 ##  <P/>
 ##  For each <M>2</M>-modular Brauer characters where these conditions are
 ##  not sufficient to determine the indicator, an unknown value
-##  (see <Ref Func="Unknown"/>) is returned.
+##  (see <Ref Oper="Unknown"/>) is returned.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1670,7 +1670,7 @@ DeclareGlobalFunction( "PermutationMat" );
 ##  If only <A>vector</A> is given then it is used to compute a default for
 ##  <A>R</A>.
 ##  <P/>
-##  If the <Ref Filt="ConstructingFilter" Label="for a matrix object"/> value
+##  If the <Ref Attr="ConstructingFilter" Label="for a matrix object"/> value
 ##  of the result implies <Ref Filt="IsCopyable"/> then the result is
 ##  fully mutable.
 ##  <P/>


### PR DESCRIPTION
The 'tee' and subshell combo ate the exit code. Also get rid of the 'dev/log' subdirectory.

Resolves #1927

To test this, I am adding a commit causing issues, it should fail CI. If that works, I'll remove the commit and draft status of this PR.