### PR TITLE
Improve generate_package_release_notes.py

### DIFF
--- a/dev/releases/utils.py
+++ b/dev/releases/utils.py
@@ -140,6 +140,12 @@ def verify_is_possible_gap_release_tag(tag):
     if not is_possible_gap_release_tag(tag):
         error(f"{tag} does not look like the tag of a GAP release version")
 
+def is_existing_tag(tag):
+    res = subprocess.run(
+        ["git", "show-ref", "--quiet", "--verify", "refs/tags/" + tag],
+    )
+    return res.returncode == 0
+
 # Error checked git fetch of tags
 def safe_git_fetch_tags():
     try:


### PR DESCRIPTION
Now only the new version has to be passed in, the old version is compute. Also if the is no package infos JSON for the new version, it automatically falls back to using the "latest" set of package infos.

From this it is one step towards merging this into the `release_notes.py` script and hence resolves issue #5004.

However I don't want to interfere with the cleanup work by @james-d-mitchell . So I am happy to discuss how to proceed -- I can wait for his PR to be merged and then update this; or the other way around. Or whatever. :-)