### PR TITLE
Fix an error in evaluating the MaximalAbelianQuotient of a subgroup of an FPGroup which could result in wrong results

### DIFF
--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -712,34 +712,36 @@ local somechar,d,i,j,u,v;
     od;
   fi;
 
-  for i in PrimeDivisors(Size(r)) do
-    u:=PCore(r,i);
-    if Size(u)>1 then
-      d:=RefinedSubnormalSeries(d,u);
-      j:=1;
-      repeat
-        v:=Agemo(u,i,j);
-        if Size(v)>1 then
-          d:=RefinedSubnormalSeries(d,v);
-        fi;
-        j:=j+1;
-      until Size(v)=1;
-      j:=1;
-      repeat
-        if Size(u)>=2^24 then
-          v:=u; # bail out as method for `Omega` will do so.
-        else
-          v:=Omega(u,i,j);
-          if Size(v)<Size(u) then
+  if not ForAll([1..Length(d)-1],
+    x->HasElementaryAbelianFactorGroup(d[x],d[x+1])) then
+    for i in PrimeDivisors(Size(r)) do
+      u:=PCore(r,i);
+      if Size(u)>1 then
+        d:=RefinedSubnormalSeries(d,u);
+        j:=1;
+        repeat
+          v:=Agemo(u,i,j);
+          if Size(v)>1 then
             d:=RefinedSubnormalSeries(d,v);
           fi;
           j:=j+1;
-        fi;
+        until Size(v)=1;
+        j:=1;
+        repeat
+          if Size(u)>=2^24 then
+            v:=u; # bail out as method for `Omega` will do so.
+          else
+            v:=Omega(u,i,j);
+            if Size(v)<Size(u) then
+              d:=RefinedSubnormalSeries(d,v);
+            fi;
+            j:=j+1;
+          fi;
 
       until Size(v)=Size(u);
     fi;
-
-  od;
+    od;
+  fi;
   Assert(1,ForAll([1..Length(d)-1],x->Size(d[x])<>Size(d[x+1])));
   return d;
 end);

--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -1374,7 +1374,16 @@ InstallOtherMethod( RepresentativeActionOp, "permgrp",true, [ IsPermGroup,
     # action on permgroups, use backtrack
     elif act = OnPoints and IsPermGroup( d ) and IsPermGroup( e )  then
 
-      if Size(G)<10^5 or NrMovedPoints(G)<500 then
+      if Size(G)<10^5 or NrMovedPoints(G)<500
+        # cyclic is handled special by backtrack
+        or IsCyclic(d) or IsCyclic(e) or
+        # does the group have many short orbits? If so the cluster test
+        # would do a lot of checking
+        Length(Orbits(d,MovedPoints(G)))^2>NrMovedPoints(G)
+        # Do not test for same orbit lengths -- this will be done by next
+        # level routine
+        then
+
         rep:=ConjugatorPermGroup(G,d,e);
       else
         S:=ClusterConjugacyPermgroups(G,[e,d]);

--- a/tst/testbugfix/2024-01-25-MaxAbQuot.tst
+++ b/tst/testbugfix/2024-01-25-MaxAbQuot.tst
@@ -1,0 +1,32 @@
+# Reported by don't know, # 5609
+gap> f := FreeGroup("a", "b", "c", "d", "e");;
+gap> a := f.1;;b := f.2;;c := f.3;;d := f.4;;e := f.5;;
+gap> g := f / [a^2, b^2, c^2, d^2, e^2, (a*b)^5, (a*c)^2, (a*d)^2, (a*e)^2,
+> (b*c)^3, (b*d)^2, (b*e)^2, (c*d)^3, (c*e)^2, (d*e)^3];;
+gap> w1 := ElementOfFpGroup(FamilyObj(g.1), a*b*c*d*e);;
+gap> w2 := ElementOfFpGroup(FamilyObj(g.1),
+> b*a*b*c*b*a*b*a*c*b*a*d*c*e*d*c*b*a*b*a*c*d*e*b*c*a*b*a*b*c*d*c*b*a
+> *b*c*a*b*a*b*c);;
+gap> w3 := ElementOfFpGroup(FamilyObj(g.1),
+> b*a*b*c*b*a*d*c*b*a*b*a*c*b*a*d*e*d*c*b*a*b*c*d*e*a*b*a*b*c*d*b*a*b
+> *c*a*b*a*b*c*d*c*b);;
+gap> w4 := ElementOfFpGroup(FamilyObj(g.1),
+> b*c*b*a*b*a*d*c*b*a*b*a*c*b*a*b*c*d*c*b*a*b*a*c*d*b*c*a*b*a*b*c*d*e
+> *b*c*a*b*a*b*c*d*b*a*b*c*a*b);;
+gap> w5 := ElementOfFpGroup(FamilyObj(g.1),
+> b*a*b*a*c*d*c*b*a*b*a*c*b*a*d*c*b*a*b*c*d*e*d*c*b*a*b*c*d*a*b*c*a*b
+> *a*b*c*d*e*b*a*b*c*d*b*c*a*b*a*b*c);;
+gap> s := Subgroup(g, [w1, w2, w3, w4, w5]);;
+gap> s1 := Subgroup(g, [w1, w2^-2, w3*w2^-1, w3^-1*w2^-1, w4*w2^-1,
+> w4^-1*w2^-1, w5*w2^-1, w5^-1*w2^-1]);;
+gap> s2:=Subgroup(g,[w1^-2, w2, w3, w4*w1^-1, w1*w2*w1^-1, w1*w3*w1^-1, w5]);;
+gap> ab := MaximalAbelianQuotient(s);;
+gap> q1 := GQuotients(s1, SymmetricGroup(2));;
+gap> q2 := GQuotients(s2, SymmetricGroup(2));;
+gap> k1 := Kernel(q1[7]);;
+gap> nr:=First(Concatenation([7],[1..Length(q2)]),x->Kernel(q2[x])=k1);;
+gap> k2 := Kernel(q2[nr]);;
+gap> k1=k2;
+true
+gap> Image(ab,k1)=Image(ab,k2);
+true


### PR DESCRIPTION
- fixes #5609 (issue from the title)
- fixes #5564 (issue that did not exist in 4.12.2, so no need to mention it in release notes)
- speed improvement in `AGSRCharacteristicSeries`

## Text for release notes

An error in evaluating the MaximalAbelianQuotient of a subgroup of an FPGroup was fixed. This error could have produced wrong results.
