### PR TITLE
dev/releases: add missing imports

### DIFF
--- a/dev/releases/utils_github.py
+++ b/dev/releases/utils_github.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 import github
 
+from utils import error, notice, verify_via_checksumfile
+
 CURRENT_REPO_NAME = os.environ.get("GITHUB_REPOSITORY", "gap-system/gap")
 
 # Initialized by initialize_github


### PR DESCRIPTION
This should unbreak the release test

For the PackageDistro tools I think the use `mypy` in a CI test helps catch such issues earlier. I hope we can eventually do this and else here, too.

Over there, we do this:
```yaml
#
# This workflow is run for pull requests the modify the `tools` directory
# and runs tests for the Python scripts in that directory
#
name: "Test Python tools"

on:
  workflow_dispatch:  # manual trigger for debugging
  push:
    paths:
      - 'tools/*'
    branches:
      - main
  pull_request:
    paths:
      - 'tools/*'

jobs:
  py39:
    name: "Run tests"
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v3

      - name: Install dependencies
        run: |
          python -m pip install -r tools/requirements.txt
          python -m pip install pytest mock black isort

      - name: Check code formatting
        run: python -m black --check --diff tools

      - name: Check imports
        run: python -m isort --check --profile black tools

      - name: Validate types
        run: python -m mypy --disallow-untyped-calls --disallow-untyped-defs tools/*.py

      - name: Run tests
        run: python -m pytest tools/tests/test*.py -vv
```