### PR TITLE
configure.ac: fix a bashism in a comparison

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,7 +294,7 @@ dnl Right now, we only do the latter for 64-bit macOS. See src/hpc/tls.h
 dnl for details.
 dnl
 enable_macos_tls_asm=default
-AS_IF([[test "x$enable_native_tls" == "xyes"]], [
+AS_IF([[test "x$enable_native_tls" = "xyes"]], [
         case "$host" in
             x86_64-apple-darwin*)
                 GAP_DEFINE([USE_PTHREAD_TLS=1])


### PR DESCRIPTION
There's a `==` that accidentally crept in here. String comparison should be `=` instead in POSIX sh.
