### PR TITLE
buildsys: let 'make clean' remove `libgap.9.{dylib,so}`

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -569,7 +569,7 @@ clean:
 	rm -rf extern/build extern/install
 	rm -f bin/gap.sh sysinfo.gap*
 	rm -f gap$(EXEEXT) gac ffgen
-	rm -f libgap$(SHLIB_EXT)
+	rm -f libgap$(SHLIB_EXT) $(LIBGAP_FULL)
 	rm -f libgap.pc
 	rm -rf .libs
 	rm -f doc/wsp.g


### PR DESCRIPTION
Reported by Bill Allombert. Regression due to the recent removal of `libtool`.