### PR TITLE
Cleanup release scripts, add more CI tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,32 @@ env:
   NO_COVERAGE: 1
 
 jobs:
+  tools:
+    name: "Validate release scripts"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r dev/releases/requirements.txt
+          python -m pip install pytest mock black isort
+
+      - name: Check code formatting
+        run: python -m black --check --diff dev/releases
+
+      - name: Check imports
+        run: python -m isort --check --profile black dev/releases
+
+      #- name: Validate types
+      #  run: python -m mypy --disallow-untyped-calls --disallow-untyped-defs dev/releases/*.py
+
+      #- name: Run tests
+      #  run: python -m pytest tools/tests/dev/releases*.py -vv
+
   unix:
     name: "Create Unix archives and data"
+    needs: tools
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest

--- a/dev/releases/create_stable_branch.py
+++ b/dev/releases/create_stable_branch.py
@@ -14,11 +14,11 @@
 # TODO: implement parts of the steps described in
 # <https://github.com/gap-system/gap-distribution/blob/master/DistributionUpdate/STABLE_BRANCH_CHECKLIST.md>
 
-from utils import error, notice, patchfile
-import utils
-
 import subprocess
 import sys
+
+import utils
+from utils import error, notice, patchfile
 
 # Insist on Python >= 3.6 for f-strings and other goodies
 if sys.version_info < (3, 6):

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -70,8 +70,7 @@ else:
 # release tag (but then we need to find and process that tag)
 commit_date = subprocess.run(
     ["git", "show", "-s", "--format=%as"], check=True, capture_output=True, text=True
-)
-commit_date = commit_date.stdout.strip()
+).stdout.strip()
 commit_year = commit_date[0:4]
 
 # derive tarball names
@@ -247,7 +246,9 @@ with working_directory(tmpdir + "/" + basename):
 # Create an archive in the current directory with shutil.make_archive, and
 # record the filename of the new archive in <manifest_list>.
 # The arguments of this function match those to shutil.make_archive.
-def make_and_record_archive(name, compression, root_dir, base_dir):
+def make_and_record_archive(
+    name: str, compression: str, root_dir: str, base_dir: str
+) -> None:
     # Deduce file extension from compression
     if compression == "gztar":
         ext = ".tar.gz"

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -9,10 +9,10 @@
 ##  SPDX-License-Identifier: GPL-2.0-or-later
 ##
 ##  This script create the archives that form a GA{} release.
-##  
+##
 ##  The version of the gap release is taken from the Makefile variable
 ##  GAP_BUILD_VERSION.
-##  
+##
 from utils import *
 
 import glob
@@ -27,7 +27,7 @@ import sys
 import tarfile
 
 # Insist on Python >= 3.6 for f-strings and other goodies
-if sys.version_info < (3,6):
+if sys.version_info < (3, 6):
     error("Python 3.6 or newer is required")
 
 notice("Checking prerequisites")
@@ -56,7 +56,7 @@ except:
     error("make sure GAP has been compiled via './configure && make'")
 notice(f"Detected GAP version {gapversion}")
 
-if re.fullmatch( r"[1-9]+\.[0-9]+\.[0-9]+", gapversion) != None:
+if re.fullmatch(r"[1-9]+\.[0-9]+\.[0-9]+", gapversion) != None:
     notice(f"--- THIS LOOKS LIKE A RELEASE ---")
     pkg_tag = f"v{gapversion}"
 else:
@@ -68,19 +68,22 @@ else:
 # TODO: is that really what we want? Or should it be the date this
 # script was run? Or for releases, perhaps use the TaggerDate of the
 # release tag (but then we need to find and process that tag)
-commit_date = subprocess.run(["git", "show", "-s", "--format=%as"],
-                             check=True, capture_output=True, text=True)
+commit_date = subprocess.run(
+    ["git", "show", "-s", "--format=%as"], check=True, capture_output=True, text=True
+)
 commit_date = commit_date.stdout.strip()
 commit_year = commit_date[0:4]
 
 # derive tarball names
 basename = f"gap-{gapversion}"
-all_packages = f"packages-v{gapversion}" # only the pkg dir
+all_packages = f"packages-v{gapversion}"  # only the pkg dir
 all_packages_tarball = f"{all_packages}.tar.gz"
-req_packages = f"packages-required-v{gapversion}" # a subset of the above
+req_packages = f"packages-required-v{gapversion}"  # a subset of the above
 req_packages_tarball = f"{req_packages}.tar.gz"
 
-PKG_BOOTSTRAP_URL = f"https://github.com/gap-system/PackageDistro/releases/download/{pkg_tag}/"
+PKG_BOOTSTRAP_URL = (
+    f"https://github.com/gap-system/PackageDistro/releases/download/{pkg_tag}/"
+)
 PKG_MINIMAL = "packages-required.tar.gz"
 PKG_FULL = "packages.tar.gz"
 
@@ -88,36 +91,54 @@ PKG_FULL = "packages.tar.gz"
 notice("Exporting repository content via `git archive`")
 rawbasename = "gap-raw"
 rawgap_tarfile = f"{tmpdir}/{rawbasename}.tar"
-subprocess.run(["git", "archive",
-                f"--prefix={basename}/",
-                f"--output={rawgap_tarfile}",
-                "HEAD"], check=True)
+subprocess.run(
+    ["git", "archive", f"--prefix={basename}/", f"--output={rawgap_tarfile}", "HEAD"],
+    check=True,
+)
 
 notice("Extracting exported content")
-shutil.rmtree(basename, ignore_errors=True) # remove any leftovers
+shutil.rmtree(basename, ignore_errors=True)  # remove any leftovers
 with tarfile.open(rawgap_tarfile) as tar:
     tar.extractall(path=tmpdir)
 os.remove(rawgap_tarfile)
 
 notice("Processing exported content")
-manifest_list = [] # collect names of assets to be uploaded to GitHub release
+manifest_list = []  # collect names of assets to be uploaded to GitHub release
 
 # download package distribution
-notice("Downloading package distribution")   # ... outside of the directory we just created
-download_with_sha256(PKG_BOOTSTRAP_URL+"package-infos.json.gz", tmpdir+"/"+"package-infos.json.gz")
+notice(
+    "Downloading package distribution"
+)  # ... outside of the directory we just created
+download_with_sha256(
+    PKG_BOOTSTRAP_URL + "package-infos.json.gz", tmpdir + "/" + "package-infos.json.gz"
+)
 manifest_list.append("package-infos.json.gz")
-download_with_sha256(PKG_BOOTSTRAP_URL+PKG_MINIMAL, tmpdir+"/"+req_packages_tarball)
+download_with_sha256(
+    PKG_BOOTSTRAP_URL + PKG_MINIMAL, tmpdir + "/" + req_packages_tarball
+)
 manifest_list.append(req_packages_tarball)
-download_with_sha256(PKG_BOOTSTRAP_URL+PKG_FULL, tmpdir+"/"+all_packages_tarball)
+download_with_sha256(PKG_BOOTSTRAP_URL + PKG_FULL, tmpdir + "/" + all_packages_tarball)
 manifest_list.append(all_packages_tarball)
 
 with working_directory(tmpdir + "/" + basename):
     # This sets the version, release day and year of the release we are
     # creating.
     notice("Patching configure.ac")
-    patchfile("configure.ac", r"m4_define\(\[gap_version\],[^\n]+", r"m4_define([gap_version], ["+gapversion+"])")
-    patchfile("configure.ac", r"m4_define\(\[gap_releaseday\],[^\n]+", r"m4_define([gap_releaseday], ["+commit_date+"])")
-    patchfile("configure.ac", r"m4_define\(\[gap_releaseyear\],[^\n]+", r"m4_define([gap_releaseyear], ["+commit_year+"])")
+    patchfile(
+        "configure.ac",
+        r"m4_define\(\[gap_version\],[^\n]+",
+        r"m4_define([gap_version], [" + gapversion + "])",
+    )
+    patchfile(
+        "configure.ac",
+        r"m4_define\(\[gap_releaseday\],[^\n]+",
+        r"m4_define([gap_releaseday], [" + commit_date + "])",
+    )
+    patchfile(
+        "configure.ac",
+        r"m4_define\(\[gap_releaseyear\],[^\n]+",
+        r"m4_define([gap_releaseyear], [" + commit_year + "])",
+    )
 
     # Building GAP
     notice("Running autogen.sh")
@@ -153,7 +174,7 @@ with working_directory(tmpdir + "/" + basename):
     shutil.rmtree("hpcgap-build")
 
     notice("Extracting package tarballs")
-    with tarfile.open(tmpdir+"/"+all_packages_tarball) as tar:
+    with tarfile.open(tmpdir + "/" + all_packages_tarball) as tar:
         tar.extractall(path="pkg")
     # for some reason pkg sometimes ends up with permission 0700 so
     # we make sure to fix that here
@@ -161,8 +182,8 @@ with working_directory(tmpdir + "/" + basename):
     # ensure all files are at readable by everyone
     subprocess.run(["chmod", "-R", "a+r", "."], check=True)
 
-    with tarfile.open(tmpdir+"/"+req_packages_tarball) as tar:
-        tar.extractall(path=tmpdir+"/"+req_packages)
+    with tarfile.open(tmpdir + "/" + req_packages_tarball) as tar:
+        tar.extractall(path=tmpdir + "/" + req_packages)
 
     notice("Building GAP's manuals")
     run_with_log(["make", "doc"], "gapdoc", "building the manuals")
@@ -170,19 +191,28 @@ with working_directory(tmpdir + "/" + basename):
     # Now we create the help-links.json file. We build
     # the json package, create the files, then clean up the package again.
     notice("Compiling json package")
-    path_to_json_package = glob.glob(f'{tmpdir}/{basename}/pkg/json*')[0]
+    path_to_json_package = glob.glob(f"{tmpdir}/{basename}/pkg/json*")[0]
     with working_directory(path_to_json_package):
         subprocess.run(["./configure"], check=True)
         subprocess.run(["make"], check=True)
 
     notice(f"Constructing help-links JSON file")
     json_output = subprocess.run(
-            ["./gap", "-r", "--quiet", "--quitonbreak", f"dev/releases/HelpLinks-to-JSON.g"],
-            check=True, capture_output=True, text=True)
+        [
+            "./gap",
+            "-r",
+            "--quiet",
+            "--quitonbreak",
+            f"dev/releases/HelpLinks-to-JSON.g",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     formatted_json = json.dumps(json.loads(json_output.stdout), indent=2)
     with working_directory(tmpdir):
-        with gzip.open("help-links.json.gz", 'wb') as file:
-            file.write(formatted_json.encode('utf-8'))
+        with gzip.open("help-links.json.gz", "wb") as file:
+            file.write(formatted_json.encode("utf-8"))
         manifest_list.append("help-links.json.gz")
 
     notice("Cleaning up the json package")
@@ -193,11 +223,11 @@ with working_directory(tmpdir + "/" + basename):
 
     notice("Removing unwanted version-controlled files")
     badfiles = [
-    ".codecov.yml",
-    ".ctags",
-    ".gitattributes",
-    ".gitignore",
-    ".mailmap",
+        ".codecov.yml",
+        ".ctags",
+        ".gitattributes",
+        ".gitignore",
+        ".mailmap",
     ]
 
     shutil.rmtree("benchmark")
@@ -230,25 +260,26 @@ def make_and_record_archive(name, compression, root_dir, base_dir):
     notice(f"Creating {filename}")
     owner = pwd.getpwuid(0).pw_name
     group = grp.getgrgid(0).gr_name
-    shutil.make_archive(name, compression, root_dir, base_dir, owner = owner, group = group)
+    shutil.make_archive(name, compression, root_dir, base_dir, owner=owner, group=group)
     manifest_list.append(filename)
+
 
 # Create the remaining archives
 notice("Creating remaining GAP and package archives")
 with working_directory(tmpdir):
     make_and_record_archive(basename, "gztar", ".", basename)
-    make_and_record_archive(basename, "zip",   ".", basename)
+    make_and_record_archive(basename, "zip", ".", basename)
     make_and_record_archive(all_packages, "zip", basename, "pkg")
     make_and_record_archive(req_packages, "zip", ".", req_packages)
     notice("Removing packages to facilitate creating the GAP core archives")
     shutil.rmtree(basename + "/pkg")
     make_and_record_archive(basename + "-core", "gztar", ".", basename)
-    make_and_record_archive(basename + "-core", "zip",   ".", basename)
+    make_and_record_archive(basename + "-core", "zip", ".", basename)
 
     # If you create additional archives, make sure to add them to manifest_list!
     manifest_filename = "MANIFEST"
     notice(f"Creating the manifest, with name {manifest_filename}")
-    with open(manifest_filename, 'w') as manifest:
+    with open(manifest_filename, "w") as manifest:
         for filename in manifest_list:
             manifest.write(f"{filename}\n")
 

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -13,8 +13,6 @@
 ##  The version of the gap release is taken from the Makefile variable
 ##  GAP_BUILD_VERSION.
 ##
-from utils import *
-
 import glob
 import grp
 import gzip
@@ -25,6 +23,8 @@ import shutil
 import subprocess
 import sys
 import tarfile
+
+from utils import *
 
 # Insist on Python >= 3.6 for f-strings and other goodies
 if sys.version_info < (3, 6):

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -15,10 +15,10 @@
 ##  If we do import * from utils, then initialize_github can't overwrite the
 ##  global CURRENT_REPO variables.
 ##
-import utils
-import utils_github
 import sys
 
+import utils
+import utils_github
 from utils import error, notice
 
 if len(sys.argv) != 3:

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -22,7 +22,7 @@ import sys
 from utils import error, notice
 
 if len(sys.argv) != 3:
-    error("usage: "+sys.argv[0]+" <tag_name> <path_to_release>")
+    error("usage: " + sys.argv[0] + " <tag_name> <path_to_release>")
 
 TAG_NAME = sys.argv[1]
 PATH_TO_RELEASE = sys.argv[2]
@@ -47,16 +47,18 @@ if any(r.tag_name == TAG_NAME for r in utils_github.CURRENT_REPO.get_releases())
     error(f"Github release with tag '{TAG_NAME}' already exists!")
 
 # Create release
-RELEASE_NOTE = f"For an overview of changes in GAP {VERSION} see the " \
+RELEASE_NOTE = (
+    f"For an overview of changes in GAP {VERSION} see the "
     + f"[CHANGES.md](https://github.com/gap-system/gap/blob/{TAG_NAME}/CHANGES.md) file."
+)
 notice(f"Creating release {TAG_NAME}")
-RELEASE = utils_github.CURRENT_REPO.create_git_release(TAG_NAME, TAG_NAME,
-                                                RELEASE_NOTE,
-                                                prerelease=True)
+RELEASE = utils_github.CURRENT_REPO.create_git_release(
+    TAG_NAME, TAG_NAME, RELEASE_NOTE, prerelease=True
+)
 
 with utils.working_directory(PATH_TO_RELEASE):
     manifest_filename = "MANIFEST"
-    with open(manifest_filename, 'r') as manifest_file:
+    with open(manifest_filename, "r") as manifest_file:
         manifest = manifest_file.read().splitlines()
 
     notice(f"Contents of {manifest_filename}:")

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -20,14 +20,14 @@
 # A version ending in .0 is consider MAJOR, any other MINOR
 # Don't use this with versions like 4.13.0-beta1
 
-import json
 import gzip
+import json
 import os
-import requests
 import subprocess
 import sys
 
-from utils import error, notice, warning, is_existing_tag, download_with_sha256
+import requests
+from utils import download_with_sha256, error, is_existing_tag, notice, warning
 
 
 def usage(name: str) -> None:

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -242,7 +242,7 @@ def changes_overview(prs, startdate, new_version):
 
     # Could also introduce some consistency checks here for wrong combinations of labels
     filename = "releasenotes_" + new_version + ".md"
-    notice("Writing release notes into file "+filename)
+    notice("Writing release notes into file " + filename)
     relnotes_file = open(filename, "w")
     prs_with_use_title = [pr for pr in prs if has_label(pr, "release notes: use title")]
 
@@ -283,7 +283,7 @@ affect some users directly.
 
     relnotes_file.close()
 
-    notice("Release notes were written into file "+filename)
+    notice("Release notes were written into file " + filename)
 
     unsorted_file = open("unsorted_PRs_" + new_version + ".md", "w")
 

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -25,6 +25,7 @@ import json
 import os
 import subprocess
 import sys
+from typing import Any, Dict, List, TextIO
 
 import requests
 from utils import download_with_sha256, error, is_existing_tag, notice, warning
@@ -36,13 +37,13 @@ def usage(name: str) -> None:
 
 
 def find_previous_version(version: str) -> str:
-    major, minor, patchlevel = version.split(".")
-    if major != "4":
+    major, minor, patchlevel = map(int, version.split("."))
+    if major != 4:
         error("unexpected GAP version, not starting with '4.'")
-    if patchlevel != "0":
-        patchlevel = int(patchlevel) - 1
+    if patchlevel != 0:
+        patchlevel -= 1
         return f"{major}.{minor}.{patchlevel}"
-    minor = int(minor) - 1
+    minor -= 1
     patchlevel = 0
     while True:
         v = f"{major}.{minor}.{patchlevel}"
@@ -55,16 +56,16 @@ def find_previous_version(version: str) -> str:
     return f"{major}.{minor}.{patchlevel}"
 
 
-def package_infos_url(tag):
+def package_infos_url(tag: str) -> str:
     return f"https://github.com/gap-system/PackageDistro/releases/download/{tag}/package-infos.json.gz"
 
 
-def url_exists(url):
+def url_exists(url: str) -> bool:
     response = requests.get(url)
     return response.status_code == 200
 
 
-def package_updates(relnotes_file, new_gap_version):
+def package_updates(relnotes_file: TextIO, new_gap_version: str) -> None:
     # create tmp directory
     tmpdir = os.getcwd() + "/tmp"
     notice(f"Files will be put in {tmpdir}")
@@ -112,12 +113,13 @@ def package_updates(relnotes_file, new_gap_version):
             home = pkg["PackageWWWHome"]
             desc = pkg["Subtitle"]
             vers = pkg["Version"]
-            authors = [
-                x["FirstNames"] + " " + x["LastName"]
-                for x in pkg["Persons"]
-                if x["IsAuthor"]
-            ]
-            authors = ", ".join(authors)
+            authors = ", ".join(
+                [
+                    x["FirstNames"] + " " + x["LastName"]
+                    for x in pkg["Persons"]
+                    if x["IsAuthor"]
+                ]
+            )
             relnotes_file.write(
                 f"- [**{name}**]({home}) {vers}: {desc}, by {authors}\n"
             )
@@ -202,7 +204,7 @@ def get_tag_date(tag: str) -> str:
     return res.stdout.strip()
 
 
-def get_pr_list(date: str, extra: str) -> str:
+def get_pr_list(date: str, extra: str) -> List[Dict[str, Any]]:
     query = f'merged:>={date} -label:"release notes: not needed" -label:"release notes: added" base:master {extra}'
     print("query: ", query)
     res = subprocess.run(
@@ -226,18 +228,20 @@ def get_pr_list(date: str, extra: str) -> str:
     return json.loads(res.stdout.strip())
 
 
-def pr_to_md(pr):
+def pr_to_md(pr: Dict[str, Any]) -> str:
     """Returns markdown string for the PR entry"""
     k = pr["number"]
     title = pr["title"]
     return f"- [#{k}](https://github.com/gap-system/gap/pull/{k}) {title}\n"
 
 
-def has_label(pr, label):
+def has_label(pr: Dict[str, Any], label: str) -> bool:
     return any(x["name"] == label for x in pr["labels"])
 
 
-def changes_overview(prs, startdate, new_version):
+def changes_overview(
+    prs: List[Dict[str, Any]], startdate: str, new_version: str
+) -> None:
     """Writes files with information for release notes."""
 
     # Could also introduce some consistency checks here for wrong combinations of labels
@@ -295,7 +299,7 @@ affect some users directly.
     unsorted_file.write(
         'When done, change their label to "release notes: use title".\n\n'
     )
-    removelist = []
+
     for pr in prs:
         if has_label(pr, "release notes: to be added"):
             unsorted_file.write(pr_to_md(pr))
@@ -312,7 +316,7 @@ affect some users directly.
     unsorted_file.write(
         'as above, or change their label to "release notes: not needed".\n\n'
     )
-    removelist = []
+
     for pr in prs:
         # we need to use both old "release notes: added" label and
         # the newly introduced in "release notes: use title" label
@@ -326,18 +330,18 @@ affect some users directly.
 
 
 def main(new_version: str) -> None:
-    major, minor, patchlevel = new_version.split(".")
-    if major != "4":
+    major, minor, patchlevel = map(int, new_version.split("."))
+    if major != 4:
         error("unexpected GAP version, not starting with '4.'")
-    if patchlevel == "0":
+    if patchlevel == 0:
         # "major" GAP release which changes just the minor version
-        previous_minor = int(minor) - 1
+        previous_minor = minor - 1
         basetag = f"v{major}.{minor}dev"
         # *exclude* PRs backported to previous stable-4.X branch
         extra = f'-label:"backport-to-{major}.{previous_minor}-DONE"'
     else:
         # "minor" GAP release which changes just the patchlevel
-        previous_patchlevel = int(patchlevel) - 1
+        previous_patchlevel = patchlevel - 1
         basetag = f"v{major}.{minor}.{previous_patchlevel}"
         # *include* PRs backported to current stable-4.X branch
         extra = f'label:"backport-to-{major}.{minor}-DONE"'

--- a/dev/releases/requirements.txt
+++ b/dev/releases/requirements.txt
@@ -1,0 +1,4 @@
+github
+mypy
+requests
+types-requests

--- a/dev/releases/update_website.py
+++ b/dev/releases/update_website.py
@@ -67,7 +67,7 @@ tmpdir = tempfile.gettempdir()
 
 # Downloads the asset with name <asset_name> from the current GitHub release
 # (global variable <release>, with assets <assets>) to <writedir>.
-def download_asset_by_name(asset_name, writedir):
+def download_asset_by_name(asset_name: str, writedir: str) -> None:
     try:
         url = [x for x in assets if x.name == asset_name][0].browser_download_url
     except:
@@ -80,7 +80,7 @@ def download_asset_by_name(asset_name, writedir):
         utils.download_with_sha256(url, asset_name)
 
 
-def extract_tarball(tarball):
+def extract_tarball(tarball: str) -> None:
     notice(f"Extracting {tarball} . . .")
     with tarfile.open(tarball) as tar:
         try:
@@ -89,7 +89,7 @@ def extract_tarball(tarball):
             error(f"Failed to extract {tarball}!")
 
 
-def get_date_from_configure_ac(gaproot):
+def get_date_from_configure_ac(gaproot: str) -> str:
     with open(f"{gaproot}/configure.ac", "r") as configure_ac:
         filedata = configure_ac.read()
         try:  # Expect date in YYYY-MM-DD format
@@ -97,15 +97,15 @@ def get_date_from_configure_ac(gaproot):
                 "\[gap_releaseday\], \[(\d{4}-\d{2}-\d{2})\]", filedata
             ).group(1)
             release_date = datetime.datetime.strptime(release_date, "%Y-%m-%d")
+            return release_date.strftime("%d %B %Y")
         except:
             error("Cannot find the release date in configure.ac!")
-    return release_date.strftime("%d %B %Y")
 
 
 # This function deals with package-infos.json.gz and help-links.json.gz.
 # The function downloads the release asset called <asset_name> to the tmpdir.
 # The asset is assumed to be gzipped. It is extracted to the filepath <dest>.
-def download_and_extract_json_gz_asset(asset_name, dest):
+def download_and_extract_json_gz_asset(asset_name: str, dest: str) -> None:
     download_asset_by_name(asset_name, tmpdir)
     with utils.working_directory(tmpdir):
         with gzip.open(asset_name, "rt", encoding="utf-8") as file_in:
@@ -184,8 +184,8 @@ for release in releases:
         }
         asset_data.append(filtered_asset)
     asset_data.sort(key=lambda s: list(map(str, s["name"])))
-    with open(f"{pwd}/_data/assets/{version_safe}.json", "wb") as file:
-        file.write(json.dumps(asset_data, indent=2).encode("utf-8"))
+    with open(f"{pwd}/_data/assets/{version_safe}.json", "wb") as outfile:
+        outfile.write(json.dumps(asset_data, indent=2).encode("utf-8"))
 
     # For new-to-me releases create a file in _Releases/ and _data/package-infos/
     if not known_release:
@@ -201,8 +201,10 @@ for release in releases:
         notice(f"Using release date {date} for GAP {version}")
 
         notice(f"Writing the file _Releases/{version}.html")
-        with open(f"{pwd}/_Releases/{version}.html", "w") as file:
-            file.write(f"---\nversion: {version}\ndate: '{date}'\n---\n")
+        with open(f"{pwd}/_Releases/{version}.html", "wb") as outfile:
+            outfile.write(
+                f"---\nversion: {version}\ndate: '{date}'\n---\n".encode("utf-8")
+            )
 
         notice(f"Writing the file _data/package-infos/{version_safe}.json")
         download_and_extract_json_gz_asset(
@@ -219,8 +221,8 @@ for release in releases:
             "version-safe": version_safe,
             "date": date,
         }
-        with open(f"{pwd}/_data/release.json", "wb") as file:
-            file.write(json.dumps(release_data, indent=2).encode("utf-8"))
+        with open(f"{pwd}/_data/release.json", "wb") as outfile:
+            outfile.write(json.dumps(release_data, indent=2).encode("utf-8"))
 
         notice("Overwriting _data/help.json with the contents of help-links.json.gz")
         download_and_extract_json_gz_asset(
@@ -232,8 +234,8 @@ for release in releases:
         )
         shutil.rmtree("_Packages")
         os.mkdir("_Packages")
-        with open(f"{pwd}/_data/package-infos/{version_safe}.json", "rb") as file:
-            data = json.loads(file.read())
+        with open(f"{pwd}/_data/package-infos/{version_safe}.json", "rb") as infile:
+            data = json.loads(infile.read())
             for pkg in data:
                 with open(f"{pwd}/_Packages/{pkg}.html", "w+") as pkg_file:
                     pkg_file.write(f"---\ntitle: {data[pkg]['PackageName']}\n---\n")

--- a/dev/releases/update_website.py
+++ b/dev/releases/update_website.py
@@ -20,14 +20,14 @@ import gzip
 import json
 import os
 import re
-import requests
 import shutil
 import sys
 import tarfile
 import tempfile
+
+import requests
 import utils
 import utils_github
-
 from utils import error, notice
 
 if sys.version_info < (3, 6):

--- a/dev/releases/update_website.py
+++ b/dev/releases/update_website.py
@@ -30,27 +30,31 @@ import utils_github
 
 from utils import error, notice
 
-if sys.version_info < (3,6):
+if sys.version_info < (3, 6):
     error("Python 3.6 or newer is required")
 
-parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
-description=
-"""Update the GAP website from the GAP releases data on GitHub.
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description="""Update the GAP website from the GAP releases data on GitHub.
 
 Run this script in the root of a clone of the GapWWW repository, \
 checked out at the version from which you want to update \
 (most likely the master branch of github.com/gap-system/GapWWW). \
 The script modifies the working directory according to the information \
 on GitHub.""",
-epilog=
-"""Notes:
+    epilog="""Notes:
 * To learn how to create a GitHub access token, please consult \
   https://help.github.com/articles/creating-an-access-token-for-command-line-use
-""")
+""",
+)
 group = parser.add_argument_group("Repository details and access")
 group.add_argument("--token", type=str, help="GitHub access token")
-group.add_argument("--gap-fork", type=str, default="gap-system",
-        help="GitHub GAP fork to search for releases (for testing; default: gap-system)")
+group.add_argument(
+    "--gap-fork",
+    type=str,
+    default="gap-system",
+    help="GitHub GAP fork to search for releases (for testing; default: gap-system)",
+)
 args = parser.parse_args()
 
 utils.verify_command_available("git")
@@ -65,13 +69,16 @@ tmpdir = tempfile.gettempdir()
 # (global variable <release>, with assets <assets>) to <writedir>.
 def download_asset_by_name(asset_name, writedir):
     try:
-        url = [ x for x in assets if x.name == asset_name ][0].browser_download_url
+        url = [x for x in assets if x.name == asset_name][0].browser_download_url
     except:
-        error(f"Cannot find {asset_name} in the GitHub release with tag {release.tag_name}")
+        error(
+            f"Cannot find {asset_name} in the GitHub release with tag {release.tag_name}"
+        )
 
     with utils.working_directory(writedir):
         notice(f"Downloading {url} to {writedir} . . .")
         utils.download_with_sha256(url, asset_name)
+
 
 def extract_tarball(tarball):
     notice(f"Extracting {tarball} . . .")
@@ -81,15 +88,19 @@ def extract_tarball(tarball):
         except:
             error(f"Failed to extract {tarball}!")
 
+
 def get_date_from_configure_ac(gaproot):
     with open(f"{gaproot}/configure.ac", "r") as configure_ac:
         filedata = configure_ac.read()
-        try: # Expect date in YYYY-MM-DD format
-            release_date = re.search("\[gap_releaseday\], \[(\d{4}-\d{2}-\d{2})\]", filedata).group(1)
+        try:  # Expect date in YYYY-MM-DD format
+            release_date = re.search(
+                "\[gap_releaseday\], \[(\d{4}-\d{2}-\d{2})\]", filedata
+            ).group(1)
             release_date = datetime.datetime.strptime(release_date, "%Y-%m-%d")
         except:
             error("Cannot find the release date in configure.ac!")
     return release_date.strftime("%d %B %Y")
+
 
 # This function deals with package-infos.json.gz and help-links.json.gz.
 # The function downloads the release asset called <asset_name> to the tmpdir.
@@ -108,13 +119,20 @@ utils_github.CURRENT_REPO_NAME = f"{args.gap_fork}/gap"
 utils_github.initialize_github(args.token)
 notice(f"Will use temporary directory: {tmpdir}")
 
-releases = [ x for x in utils_github.CURRENT_REPO.get_releases() if
-                not x.draft and
-                not x.prerelease and
-                utils.is_possible_gap_release_tag(x.tag_name) and
-                (int(x.tag_name[1:].split('.')[0]) > 4 or
-                    (int(x.tag_name[1:].split('.')[0]) == 4 and
-                     int(x.tag_name[1:].split('.')[1]) >= 11)) ]
+releases = [
+    x
+    for x in utils_github.CURRENT_REPO.get_releases()
+    if not x.draft
+    and not x.prerelease
+    and utils.is_possible_gap_release_tag(x.tag_name)
+    and (
+        int(x.tag_name[1:].split(".")[0]) > 4
+        or (
+            int(x.tag_name[1:].split(".")[0]) == 4
+            and int(x.tag_name[1:].split(".")[1]) >= 11
+        )
+    )
+]
 if releases:
     notice(f"Found {len(releases)} published GAP releases >= v4.11.0")
 else:
@@ -122,7 +140,7 @@ else:
     sys.exit(0)
 
 # Sort by version number, biggest to smallest
-releases.sort(key=lambda s: list(map(int, s.tag_name[1:].split('.'))))
+releases.sort(key=lambda s: list(map(int, s.tag_name[1:].split("."))))
 releases.reverse()
 
 
@@ -141,7 +159,9 @@ for release in releases:
     elif newest_release:
         notice(f"This is a new release to me, and it has the biggest version number")
     else:
-        notice(f"This is a new release to me, but I know about releases with bigger version numbers")
+        notice(
+            f"This is a new release to me, but I know about releases with bigger version numbers"
+        )
 
     # For all releases, record the assets (in case they were deleted/updated/added)
     notice(f"Collecting GitHub release asset data in _data/assets/{version_safe}.json")
@@ -163,7 +183,7 @@ for release in releases:
             "url": asset.browser_download_url,
         }
         asset_data.append(filtered_asset)
-    asset_data.sort(key=lambda s: list(map(str, s['name'])))
+    asset_data.sort(key=lambda s: list(map(str, s["name"])))
     with open(f"{pwd}/_data/assets/{version_safe}.json", "wb") as file:
         file.write(json.dumps(asset_data, indent=2).encode("utf-8"))
 
@@ -185,7 +205,9 @@ for release in releases:
             file.write(f"---\nversion: {version}\ndate: '{date}'\n---\n")
 
         notice(f"Writing the file _data/package-infos/{version_safe}.json")
-        download_and_extract_json_gz_asset("package-infos.json.gz", f"{pwd}/_data/package-infos/{version_safe}.json")
+        download_and_extract_json_gz_asset(
+            "package-infos.json.gz", f"{pwd}/_data/package-infos/{version_safe}.json"
+        )
 
     # For a new-to-me release with biggest version number, also set this is the
     # 'default'/'main' version on the website (i.e. the most prominent release).
@@ -201,9 +223,13 @@ for release in releases:
             file.write(json.dumps(release_data, indent=2).encode("utf-8"))
 
         notice("Overwriting _data/help.json with the contents of help-links.json.gz")
-        download_and_extract_json_gz_asset("help-links.json.gz", f"{pwd}/_data/help.json")
+        download_and_extract_json_gz_asset(
+            "help-links.json.gz", f"{pwd}/_data/help.json"
+        )
 
-        notice("Repopulating _Packages/ with one HTML file for each package in packages-info.json")
+        notice(
+            "Repopulating _Packages/ with one HTML file for each package in packages-info.json"
+        )
         shutil.rmtree("_Packages")
         os.mkdir("_Packages")
         with open(f"{pwd}/_data/package-infos/{version_safe}.json", "rb") as file:

--- a/dev/releases/utils.py
+++ b/dev/releases/utils.py
@@ -14,25 +14,26 @@ import re
 import shutil
 import subprocess
 import sys
+from typing import Iterator, List, NoReturn, Optional
 
 
 # print notices in green
-def notice(msg):
+def notice(msg: str) -> None:
     print("\033[32m" + msg + "\033[0m")
 
 
 # print warnings in yellow
-def warning(msg):
-    print("\033[33m" + msg + "\033[0m")
+def warning(msg: str) -> None:
+    print("\033[33m" + msg + "\033[0m", file=sys.stderr)
 
 
 # print error in red and exit
-def error(msg):
-    print("\033[31m" + msg + "\033[0m")
+def error(msg: str) -> NoReturn:
+    print("\033[31m" + msg + "\033[0m", file=sys.stderr)
     sys.exit(1)
 
 
-def verify_command_available(cmd):
+def verify_command_available(cmd: str) -> None:
     if shutil.which(cmd) == None:
         error(f"the '{cmd}' command was not found, please install it")
     # TODO: do the analog of this in ReleaseTools bash script:
@@ -40,7 +41,7 @@ def verify_command_available(cmd):
     #     error "the 'curl' command was not found, please install it"
 
 
-def verify_git_repo():
+def verify_git_repo() -> None:
     res = subprocess.run(
         ["git", "--git-dir=.git", "rev-parse"], stderr=subprocess.DEVNULL
     )
@@ -49,21 +50,21 @@ def verify_git_repo():
 
 
 # check for uncommitted changes
-def is_git_clean():
+def is_git_clean() -> bool:
     res = subprocess.run(["git", "update-index", "--refresh"])
     if res.returncode == 0:
         res = subprocess.run(["git", "diff-index", "--quiet", "HEAD", "--"])
     return res.returncode == 0
 
 
-def verify_git_clean():
+def verify_git_clean() -> None:
     if not is_git_clean():
         error("uncommitted changes detected")
 
 
 # from https://code.activestate.com/recipes/576620-changedirectory-context-manager/
 @contextlib.contextmanager
-def working_directory(path):
+def working_directory(path: str) -> Iterator[None]:
     """A context manager which changes the working directory to the given
     path, and then changes it back to its previous value on exit.
 
@@ -75,7 +76,7 @@ def working_directory(path):
 
 
 # helper for extracting values of variables set in the GAP Makefiles.rules
-def get_makefile_var(var):
+def get_makefile_var(var: str) -> str:
     res = subprocess.run(["make", f"print-{var}"], check=True, capture_output=True)
     kv = res.stdout.decode("ascii").strip().split("=")
     assert len(kv) == 2
@@ -84,7 +85,7 @@ def get_makefile_var(var):
 
 
 # compute the sha256 checksum of a file
-def sha256file(path):
+def sha256file(path: str) -> str:
     h = hashlib.sha256()
     with open(path, "rb") as f:
         # Read and update hash string value in blocks of 4K
@@ -94,7 +95,7 @@ def sha256file(path):
 
 
 # read a file into memory, apply some transformations, and write it back
-def patchfile(path, pattern, repl):
+def patchfile(path: str, pattern: str, repl: str) -> None:
     # Read in the file
     with open(path, "r") as file:
         filedata = file.read()
@@ -108,20 +109,20 @@ def patchfile(path, pattern, repl):
 
 
 # download file at the given URL to path `dst`
-def download(url, dst):
+def download(url: str, dst: str) -> None:
     notice(f"Downlading {url} to {dst}")
     res = subprocess.run(["curl", "-L", "-C", "-", "-o", dst, url])
     if res.returncode != 0:
         error("failed downloading " + url)
 
 
-def file_matches_checksumfile(filename):
+def file_matches_checksumfile(filename: str) -> bool:
     with open(filename + ".sha256", "r") as f:
         expected_checksum = f.read().strip()
     return expected_checksum == sha256file(filename)
 
 
-def verify_via_checksumfile(filename):
+def verify_via_checksumfile(filename: str) -> None:
     actual_checksum = sha256file(filename)
     with open(filename + ".sha256", "r") as f:
         expected_checksum = f.read().strip()
@@ -133,7 +134,7 @@ def verify_via_checksumfile(filename):
 
 # Download file at the given URL to path `dst`, unless we detect that a file
 # already exists at `dst` with the expected checksum.
-def download_with_sha256(url, dst):
+def download_with_sha256(url: str, dst: str) -> None:
     download(url + ".sha256", dst + ".sha256")
     if os.path.isfile(dst):
         if file_matches_checksumfile(dst):
@@ -144,8 +145,8 @@ def download_with_sha256(url, dst):
 
 
 # Run what ever <args> command and create appropriate log file
-def run_with_log(args, name, msg=None):
-    if msg == None:
+def run_with_log(args: List[str], name: str, msg: Optional[str] = None) -> None:
+    if not msg:
         msg = name
     with open("../" + name + ".log", "w") as fp:
         try:
@@ -154,16 +155,16 @@ def run_with_log(args, name, msg=None):
             error(msg + " failed. See " + name + ".log.")
 
 
-def is_possible_gap_release_tag(tag):
+def is_possible_gap_release_tag(tag: str) -> bool:
     return re.fullmatch(r"v[1-9]+\.[0-9]+\.[0-9]+(-.+)?", tag) != None
 
 
-def verify_is_possible_gap_release_tag(tag):
+def verify_is_possible_gap_release_tag(tag: str) -> None:
     if not is_possible_gap_release_tag(tag):
         error(f"{tag} does not look like the tag of a GAP release version")
 
 
-def is_existing_tag(tag):
+def is_existing_tag(tag: str) -> bool:
     res = subprocess.run(
         ["git", "show-ref", "--quiet", "--verify", "refs/tags/" + tag],
     )
@@ -171,7 +172,7 @@ def is_existing_tag(tag):
 
 
 # Error checked git fetch of tags
-def safe_git_fetch_tags():
+def safe_git_fetch_tags() -> None:
     try:
         subprocess.run(["git", "fetch", "--tags"], check=True)
     except subprocess.CalledProcessError:
@@ -180,14 +181,14 @@ def safe_git_fetch_tags():
 
 # lightweight vs annotated
 # https://stackoverflow.com/questions/40479712/how-can-i-tell-if-a-given-git-tag-is-annotated-or-lightweight#40499437
-def is_annotated_git_tag(tag):
+def is_annotated_git_tag(tag: str) -> bool:
     res = subprocess.run(
         ["git", "for-each-ref", "refs/tags/" + tag], capture_output=True, text=True
     )
     return res.returncode == 0 and res.stdout.split()[1] == "tag"
 
 
-def check_git_tag_for_release(tag):
+def check_git_tag_for_release(tag: str) -> None:
     if not is_annotated_git_tag(tag):
         error(f"There is no annotated tag {tag}")
     # check that tag points to HEAD

--- a/dev/releases/utils_github.py
+++ b/dev/releases/utils_github.py
@@ -14,8 +14,8 @@ import re
 import shutil
 import subprocess
 import sys
-import github
 
+import github
 from utils import error, notice, sha256file, verify_via_checksumfile
 
 CURRENT_REPO_NAME = os.environ.get("GITHUB_REPOSITORY", "gap-system/gap")

--- a/dev/releases/utils_github.py
+++ b/dev/releases/utils_github.py
@@ -28,7 +28,7 @@ CURRENT_REPO = None
 # sets the global variables GITHUB_INSTANCE and CURRENT_REPO
 # If no token is provided, this uses the value of the environment variable
 # GITHUB_TOKEN.
-def initialize_github(token=None):
+def initialize_github(token=None) -> None:
     global GITHUB_INSTANCE, CURRENT_REPO
     if GITHUB_INSTANCE != None or CURRENT_REPO != None:
         error(
@@ -64,7 +64,7 @@ def initialize_github(token=None):
 # just to be safe, in the latter case). Then upload the files <filename> and
 # <filename>.sha256 as assets to the GitHub <release>.
 # Files already ending in ".sha256" are ignored.
-def upload_asset_with_checksum(release, filename):
+def upload_asset_with_checksum(release, filename: str) -> None:
     if not os.path.isfile(filename):
         error(f"{filename} not found")
 

--- a/dev/releases/utils_github.py
+++ b/dev/releases/utils_github.py
@@ -24,22 +24,29 @@ CURRENT_REPO_NAME = os.environ.get("GITHUB_REPOSITORY", "gap-system/gap")
 GITHUB_INSTANCE = None
 CURRENT_REPO = None
 
+
 # sets the global variables GITHUB_INSTANCE and CURRENT_REPO
 # If no token is provided, this uses the value of the environment variable
 # GITHUB_TOKEN.
 def initialize_github(token=None):
     global GITHUB_INSTANCE, CURRENT_REPO
     if GITHUB_INSTANCE != None or CURRENT_REPO != None:
-        error("Global variables GITHUB_INSTANCE and CURRENT_REPO"
-              + " are already initialized.")
+        error(
+            "Global variables GITHUB_INSTANCE and CURRENT_REPO"
+            + " are already initialized."
+        )
     if token == None and "GITHUB_TOKEN" in os.environ:
         token = os.environ["GITHUB_TOKEN"]
     if token == None:
-        temp = subprocess.run(["git", "config", "--get", "github.token"], text=True, capture_output=True)
+        temp = subprocess.run(
+            ["git", "config", "--get", "github.token"], text=True, capture_output=True
+        )
         if temp.returncode == 0:
             token = temp.stdout.strip()
-    if token == None and os.path.isfile(os.path.expanduser('~') + '/.github_shell_token'):
-        with open(os.path.expanduser('~') + '/.github_shell_token', 'r') as token_file:
+    if token == None and os.path.isfile(
+        os.path.expanduser("~") + "/.github_shell_token"
+    ):
+        with open(os.path.expanduser("~") + "/.github_shell_token", "r") as token_file:
             token = token_file.read().strip()
     if token == None:
         error("Error: no access token found or provided")
@@ -50,6 +57,7 @@ def initialize_github(token=None):
         CURRENT_REPO = GITHUB_INSTANCE.get_repo(CURRENT_REPO_NAME)
     except github.GithubException:
         error("Error: the access token may be incorrect")
+
 
 # Given the <filename> of a file that does not end with .sha256, create or get
 # the corresponding sha256 checksum file <filename>.sha256, (comparing checksums


### PR DESCRIPTION
- Add dev/releases/requirements.txt
- dev/releases: run black on python code
- dev/releases: run isort on python code
- CI: ensure code in dev/releases is formatted
- dev/releases: fix many mypy errors

The remaining mypy errors revolve around missing type annotations for the `github` Python package we use.

Instead of trying to add those annotations, I would rather get rid of this dependency: I can't install `github` on my machine because it has a [known issue with Python 3.11](https://github.com/VarMonke/GitHub-API-Wrapper/issues/20) that was reported last July; a fix actually was merged in October, but no release made.

Instead, I think we should do this:
- in `update_website.py` we can just use the `gh` command line tool to query a list of releases, just like we do in `release_notes.py` for PRs
- for `make_github_release.py` we probably could replace the whole script by either a GitHub action (such as https://github.com/softprops/action-gh-release which we use for the PackageDistro), or also wrap `gh` (see also [here](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows))