### PR TITLE
let `EpimorphismSolvableQuotient` set `IsSurjective`

### DIFF
--- a/lib/grppcfp.gi
+++ b/lib/grppcfp.gi
@@ -877,6 +877,7 @@ local g, sq, hom;
   g:=arg[1];
   sq:=CallFuncList(SQ,arg);
   hom:=GroupHomomorphismByImages(g,sq.image,GeneratorsOfGroup(g),sq.imgs);
+  SetIsSurjective( hom, true );
   if HasSize(g) then
     SetIsInjective(hom, Size(g)=Size(sq.image));
   fi;

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -2199,7 +2199,7 @@ end);
 ##
 #M  AsList( <G> ) elements of perm group
 ##
-InstallMethod( AsList, "permgp: AsSSortedList", [ IsPermGroup ],
+InstallMethod( AsList, "permgp: ElementsStabChain", [ IsPermGroup ],
   G -> ElementsStabChain( StabChainMutable(G)) );
 
 #############################################################################

--- a/tst/testinstall/grppc.tst
+++ b/tst/testinstall/grppc.tst
@@ -1,4 +1,4 @@
-#@local F,G,S,c,cl,f,g,g1,g10,g3,gens,h,hh,i,m,n,pcgs,r,rws,sys,u,v,x,y
+#@local F,G,S,c,cl,f,g,g1,g10,g3,gens,h,hh,i,m,n,pcgs,r,rws,sys,u,v,x,y,iso
 gap> START_TEST("grppc.tst");
 gap> Display(TrivialGroup(IsPcGroup));
 trivial pc-group
@@ -172,5 +172,16 @@ true
 gap> AsSet(Omega(g,3,2)) = Set(Filtered(g, g -> IsOne(g^9)));
 true
 
+#
+gap> F:= FreeGroup(2);; x:= F.1;; y:= F.2;;
+gap> G:= F / [ x^2, y^2, (x*y)^2 ];;
+gap> iso:= IsomorphismPcGroup( G );;
+gap> HasIsSurjective( iso );
+true
+gap> HasImagesSource( iso );
+true
+gap> IsIdenticalObj( Range( iso ), ImagesSource( iso ) );
+true
+
 # that's all, folks
-gap> STOP_TEST( "grppc.tst", 1);
+gap> STOP_TEST( "grppc.tst" );


### PR DESCRIPTION
(and fix a comment in a method installation)

Before the change, we have the following.
```
gap> F:= FreeGroup(2);; x:= F.1;; y:= F.2;;
gap> G:= F / [ x^2, y^2, (x*y)^5 ];;
gap> iso:= IsomorphismPcGroup( G );;
gap> HasIsSurjective( iso );  # this has not been set
false
gap> HasImagesSource( iso );  # the image has been computed already
true
gap> IsIdenticalObj( Range( iso ), ImagesSource( iso ) );
false
```
After the change, the `IsSurjective` flag is set as soon as the map gets constructed, and then `ImagesSource` value can be computed with the method that simply fetches the `Range` value.

I noticed the strange situation just because the `ImagesSource` values of maps computed with `IsomorphismPcGroup` had very strange generators.