### PR TITLE
kernel: signal file open errors in a consistent way

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -678,7 +678,6 @@ Int SyFopen(const Char * name, const Char * mode, BOOL transparent_compress)
 
     if ( fid == ARRAY_SIZE(syBuf) ) {
         HashUnlock(&syBuf);
-        ErrorReturnVoid("Too many open files (internal file descriptor limit reached)", 0, 0, "you can 'return;'");
         return (Int)-1;
     }
 

--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -213,9 +213,11 @@ Error, Print formatting status must be true or false
 # too many open files
 gap> streams := [ ];;
 gap> for i in [ 1 .. 300 ] do
->    Add( streams, OutputTextFile( fname, false ) );
+>    stream := OutputTextFile( fname, false );
+>    Assert(0, stream <> fail);
+>    Add( streams, stream );
 > od;;
-Error, Too many open files (internal file descriptor limit reached)
+Error, Assertion failure
 gap> Perform( streams, CloseStream );
 gap> RemoveFile(fname);
 true


### PR DESCRIPTION
... by returning -1 in SyFopen, even for the case were we run out of internal file buffers.

Then adjust the test suite check for this situation accordingly.

This fixes intermittent failures in this test on macOS and OpenBSD: for both of these we run out of OS file descriptors before we run out of GAP file buffers. But that situation was previously handled differently: `OutputTextFile` just returns `fail` for most errors opening a file, just in the one case were we run out of internal buffers is an actual error raised.

Besides fixing a portability problem with the test suite, I also think this is the "right" thing overall, in terms of overall consistency.