### PR TITLE
CI: test cross compilation, big endian, OpenBSD; some related tooling changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -283,12 +283,127 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+
+  cross_compile:
+    # The host should always be linux
+    runs-on: ubuntu-22.04
+    name: Cross compiler for s390x
+
+    steps:
+      - name: Install Cross-Compile Support
+        uses: fingolfin/gha-ubuntu-cross@patch-1  # FIXME: see https://github.com/cyberjunk/gha-ubuntu-cross/pull/8
+        with:
+          arch: s390x
+
+      - name: Install general build dependencies
+        run: sudo apt-get install -q -y git autoconf
+
+      - name: Install cross compile dependencies
+        run: sudo apt-get install -q -y git libgmp-dev:s390x libreadline-dev:s390x zlib1g-dev:s390x
+
+      - uses: actions/checkout@v4
+
+      - run: ./autogen.sh
+
+      - name: Native compile
+        run: |
+          # When building a git snapshot, configure & compile a native version of GAP to
+          # generate ffdata.{c,h}, c_oper1.c and c_type1.c -- in a GAP release tarball
+          # this is not necessary.
+          mkdir native-build
+          cd native-build
+          ../configure --without-readline
+          make -j2
+          cp build/c_*.c build/ffdata.* ../src/
+          cd ..
+
+      - name: Configure
+        run: ./configure --host="s390x-linux-gnu"
+
+      - name: Cross compile
+        run: make -j2 V=1 all build-testlibgap build-testkernel
+
+      - name: Fixup sysinfo.gap
+        run: rm sysinfo.gap && make SYSINFO_CC=gcc SYSINFO_CXX=g++ sysinfo.gap
+
+      - name: Download required GAP packages
+        run: make bootstrap-pkg-minimal
+
+      - name: Run tests in VM
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: s390x
+          distro: ubuntu22.04
+
+          # Not required, but speeds up builds
+          githubToken: ${{ github.token }}
+
+          # The shell to run commands with in the container
+          shell: /bin/sh
+
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+              apt-get update -q -y
+              # we need build-essential for make and gcc (the latter is used by gac and
+              # hence by the tests involving mockpkg)
+              apt-get install -q -y build-essential git libgmp10 libreadline8 zlib1g
+
+          # Do the thing
+          run: |
+            set -x
+            git config --global --add safe.directory $PWD  # see https://github.com/gap-system/gap/issues/4861
+            make citests
+
+
+  openbsd:
+    runs-on: ubuntu-latest
+    name: Test in OpenBSD
+    env:
+      AUTOCONF_VERSION: 2.71
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download required GAP packages
+        run: |
+          wget https://github.com/gap-system/PackageDistro/releases/download/latest/packages-required.tar.gz
+          mkdir pkg
+          cd pkg
+          tar xvf ../packages-required.tar.gz
+
+      - name: Test in OpenBSD
+        id: test
+        uses: vmactions/openbsd-vm@v1
+        with:
+          envs: 'AUTOCONF_VERSION'
+          usesh: true
+          prepare: |
+            pkg_add bash git gmake autoconf-2.71 gmp
+
+          # Do the thing
+          run: |
+            set -x
+            git config --global --add safe.directory $PWD  # see https://github.com/gap-system/gap/issues/4861
+            rm -rf extern  # ensure we don't build and link against bundled libraries
+            ./autogen.sh
+            ./configure --with-gmp=/usr/local --without-readline
+            export MAKE=gmake
+            gmake -j2 V=1
+            gmake citests
+
+
   # The following job is duplicated in release.yml - keep the two in sync.
   # (except for their different 'needs' components).
   slack-notification:
     name: Send Slack notification on status change
     needs:
       - test
+      - cross_compile
+      - openbsd
     if: ${{ always() && github.event_name != 'pull_request' && github.repository == 'gap-system/gap' }}
     runs-on: ubuntu-latest
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,6 +145,14 @@ On Ubuntu or Debian, you can install these with the following command:
 
     sudo apt-get install build-essential autoconf libgmp-dev libreadline-dev zlib1g-dev
 
+On Fedora:
+
+    sudo dnf install gcc gcc-c++ make autoconf gmp gmp-devel readline readline-devel zlib zlib-devel
+
+On Alpine:
+
+    sudo apk add build-base autoconf gmp-dev readline-dev zlib-dev
+
 On macOS, please follow the instructions in section "GAP for macOS" below.
 
 On other operating systems, you will need to figure out equivalent commands

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -976,7 +976,7 @@ check: all
 # citests runs a subset of the tests run by CI -- this is SLOW and still doesn't
 # quite cover everything (e.g. we don't test out-of-tree builds and `make install`)
 citests: all
-	SRCDIR=$(abs_srcdir) dev/ci.sh testexpect testmockpkg testspecial test-compile testlibgap testkernel testworkspace testinstall
+	SRCDIR=$(abs_srcdir) dev/ci.sh testmockpkg testspecial test-compile testlibgap testkernel testworkspace testinstall
 
 LIBGAPTESTS := $(addprefix tst/testlibgap/,basic api wscreate wsload trycatch)
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -166,6 +166,14 @@ SOURCES_ALL := $(SOURCES)
 SOURCES_ALL += src/compstat_empty.c
 SOURCES_ALL += src/main.c
 
+
+########################################################################
+#
+########################################################################
+
+SYSINFO_CC := $(CC)
+SYSINFO_CXX := $(CXX)
+
 ########################################################################
 # Preprocessor flags
 #
@@ -907,8 +915,8 @@ GAP_OBJEXT=o
 
 # Build flags for use by `gac` resp. package build systems: these correspond to
 # the usual variables as used by e.g. autotools, with the added prefix `GAP_`.
-GAP_CC="$(CC)"
-GAP_CXX="$(CXX)"
+GAP_CC="$(SYSINFO_CC)"
+GAP_CXX="$(SYSINFO_CXX)"
 GAP_CFLAGS="$(SYSINFO_CFLAGS)"
 GAP_CXXFLAGS="$(SYSINFO_CXXFLAGS)"
 GAP_CPPFLAGS="$(SYSINFO_CPPFLAGS)"

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -980,6 +980,8 @@ citests: all
 
 LIBGAPTESTS := $(addprefix tst/testlibgap/,basic api wscreate wsload trycatch)
 
+build-testlibgap: ${LIBGAPTESTS}
+
 # run a test in tst/testlibgap
 tst/testlibgap/%: build/obj/tst/testlibgap/%.c.o build/obj/tst/testlibgap/common.c.o libgap$(SHLIB_EXT)
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -Wl,-rpath,$(abs_builddir) $^ $(GAP_LIBS) -o $@
@@ -1019,6 +1021,8 @@ testpkgconfigbuild: install-libgap install-headers
 
 KERNELTESTS := $(addprefix tst/testkernel/,dstruct)
 
+build-testkernel: ${KERNELTESTS}
+
 # run a test in tst/testkernel
 tst/testkernel/%: build/obj/tst/testkernel/%.c.o libgap$(SHLIB_EXT)
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -Wl,-rpath,$(abs_builddir) $^ $(GAP_LIBS) -o $@
@@ -1034,7 +1038,7 @@ testkernel: ${KERNELTESTS}
 		$(v) -A -l $(top_srcdir) -q -T --nointeract >$(v).out && \
 		diff $(top_srcdir)/$(v).expect $(v).out && ) :
 
-.PHONY: testlibgap testkernel
+.PHONY: testlibgap testkernel build-testlibgap build-testkernel
 
 .PHONY: testpkgconfigbuild testpkgconfigversion
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ On Ubuntu or Debian, you can install these with the following command:
 
     sudo apt-get install build-essential autoconf libgmp-dev libreadline-dev zlib1g-dev
 
+On Fedora:
+
+    sudo dnf install gcc gcc-c++ make autoconf gmp gmp-devel readline readline-devel zlib zlib-devel
+
+On Alpine:
+
+    sudo apk add build-base autoconf gmp-dev readline-dev zlib-dev
+
 On macOS, you can install the dependencies in several ways:
 
  * using Homebrew: `brew install autoconf gmp readline`

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -23,6 +23,8 @@ then
 fi
 BUILDDIR=$PWD
 
+MAKE=${MAKE:-make}
+
 GAP=${GAP:-$BUILDDIR/gap}
 
 # Make sure any Error() immediately exits GAP with exit code 1.
@@ -96,7 +98,7 @@ testmockpkg () {
 
     cd "$mockpkg_dir"
     echo_and_run ./configure "$gaproot"
-    echo_and_run make V=1
+    echo_and_run $MAKE V=1
     # trick to make it easy to load the package in GAP
     rm -f pkg && ln -sf . pkg
     # try to load the kernel extension
@@ -207,8 +209,8 @@ GAPInput
 
     # test: `make clean` works and afterwards we can still `make`; in particular
     # build/config.h must be regenerated before any actual compilation
-    make clean
-    make > /dev/null 2>&1
+    $MAKE clean
+    $MAKE > /dev/null 2>&1
 
     # verify that deps file has a target for the .o file but not for the .d file
     fgrep "bool.c.o:" ${bool_d} > /dev/null
@@ -221,7 +223,7 @@ GAPInput
 
     # test: `make` should regenerate removed *.o files
     rm ${bool_o}
-    make > /dev/null 2>&1
+    $MAKE > /dev/null 2>&1
     test -f ${bool_o}
 
     # verify that deps file has a target for the .o file but not for the .d file
@@ -237,7 +239,7 @@ GAPInput
     # implementation for this, the test below can be re-enabled
     #rm ${bool_d}
     #echo "garbage content 3" > ${bool_o}
-    #make > /dev/null 2>&1
+    #$MAKE > /dev/null 2>&1
     #test -f ${bool_d}
 
     # verify that deps file has a target for the .o file but not for the .d file
@@ -246,7 +248,7 @@ GAPInput
     fgrep "garbage content" ${bool_o} > /dev/null && exit 1
 
     # test: running `make` a second time should produce no output
-    test -z "$(make)"
+    test -z "$($MAKE)"
 
     # audit config.h
     $SRCDIR/dev/audit-config-h.sh
@@ -256,7 +258,7 @@ GAPInput
     # code with garbage
     mv $SRCDIR/src/bool.h book.h.bak
     echo "garbage content 4" > $SRCDIR/src/bool.h
-    make print-OBJS  # should print something but not error out
+    $MAKE print-OBJS  # should print something but not error out
     mv book.h.bak $SRCDIR/src/bool.h
 
     set +x
@@ -264,27 +266,27 @@ GAPInput
     ;;
 
   makemanuals)
-    make doc
-    make check-manuals
+    $MAKE doc
+    $MAKE check-manuals
     ;;
 
   testmakeinstall)
     # get the install prefix from the GAP build system
-    eval $(make print-prefix)
+    eval $($MAKE print-prefix)
     GAPPREFIX=$prefix
 
     # verify $GAPPREFIX does not yet exist
     test ! -d $GAPPREFIX
 
     # perform he installation
-    make install
+    $MAKE install
 
     # verify $GAPPREFIX now exists
     test -d $GAPPREFIX
 
     # verify `make install DESTDIR=...` produces identical content, just
     # in a different directory
-    make install DESTDIR=/tmp/DESTDIR
+    $MAKE install DESTDIR=/tmp/DESTDIR
     diff -ru /tmp/DESTDIR/$GAPPREFIX $GAPPREFIX
 
     # change directory to prevent the installed GAP from accidentally picking
@@ -329,9 +331,9 @@ GAPInput
 
     # test integration with pkg-config
     cd "$SRCDIR"
-    # make install # might be actually needed for testpkgconfigbuild
-    make testpkgconfigversion
-    make testpkgconfigbuild
+    # $MAKE install # might be actually needed for testpkgconfigbuild
+    $MAKE testpkgconfigversion
+    $MAKE testpkgconfigbuild
     ;;
 
   testmanuals)
@@ -382,11 +384,11 @@ GAPInput
     ;;
 
   testlibgap)
-    make V=1 testlibgap
+    $MAKE V=1 testlibgap
     ;;
 
   testkernel)
-    make V=1 testkernel
+    $MAKE V=1 testkernel
     ;;
 
   testmockpkg)


### PR DESCRIPTION
Add two new CI jobs: The first one tests cross compilation to Linux running on s390x, then tests the resulting binaries in a VM. Since s390x is big endian this also gives us a test for that.

The second new job tests in an OpenBSD VM.

The other changes are mostly needed to make the above work. The changes to `README.md` / `INSTALL.md` are motivated by an earlier iteration of this PR which also added tests in VMs for various other Linux distros. I removed these in the final version because they were rather slow and the value for us is unclear.