### PR TITLE
buildsys: install-doc installs some more files

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -616,6 +616,8 @@ install-doc:
 	# TODO: should this depend on the 'doc' target? but that target is phony
 	# and will re-run each time it is invoked, which is not really what we want.
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(datarootdir)/gap/doc
+	$(INSTALL) -m 0644 $(srcdir)/doc/gapmacro.tex $(DESTDIR)$(datarootdir)/gap/doc/
+	$(INSTALL) -m 0644 $(srcdir)/doc/manualindex $(DESTDIR)$(datarootdir)/gap/doc/
 	for book in ref tut hpc ; do \
 		$(INSTALL) -d -m 0755 $(DESTDIR)$(datarootdir)/gap/doc/$$book ; \
 		for ext in css html js txt pdf six lab; do \


### PR DESCRIPTION
These are needed for building the manuals of some packages

Resolves #5630