### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#5624)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -279,7 +279,7 @@ jobs:
       - name: "Gather coverage data"
         run: ${{ matrix.extra }} dev/ci-gather-coverage.sh
       - name: "Upload coverage data to Codecov"
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
This reverts commit a633ed7689ccd36e85aaed78aa7546a134f8c725.

It broke the `testmockpkg testinstall - - windows-2019` CI job,
which now always has a timeout during the Codecov upload.
