### PR TITLE
CI: install autoconf 2.72 before generating release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,15 @@ jobs:
           git fetch https://github.com/gap-system/gap --tags --force
           git fetch --tags --force
 
+      - name: "Install autoconf 2.72"   # for compatibility with GCC 14 & clang versions
+        run: |
+          wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz
+          tar xvf autoconf-2.72.tar.xz
+          cd autoconf-2.72
+          ./configure
+          make
+          sudo make install
+
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This is required for compatibility with GCC 14 and future clang versions. See e.g. <https://gcc.gnu.org/gcc-14/porting_to.html> for some background.

Resolves #5643

CC @orlitzky 