### PR TITLE
kernel: deal with T_DATOBJ instances without type

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -74,6 +74,9 @@ typedef struct {
 static Int lastFreePackageTNUM = FIRST_PACKAGE_TNUM;
 
 
+static Obj TYPE_KERNEL_OBJECT;
+
+
 /****************************************************************************
 **
 *V  NameOfType[<type>] . . . . . . . . . . . . . . . . . . . . names of types
@@ -1498,7 +1501,8 @@ BOOL IsbPosObj(Obj obj, Int idx)
 */
 static Obj TypeDatObj(Obj obj)
 {
-    return TYPE_DATOBJ( obj );
+    Obj type = TYPE_DATOBJ( obj );
+    return type ? type : TYPE_KERNEL_OBJECT;
 }
 
 void SetTypeDatObj( Obj obj, Obj type)
@@ -1549,8 +1553,6 @@ static Obj FuncSET_TYPE_DATOBJ(Obj self, Obj obj, Obj type)
 **
 *F  NewKernelBuffer( <size> )  . . . . . . . . . . return a new kernel buffer
 */
-static Obj TYPE_KERNEL_OBJECT;
-
 Obj NewKernelBuffer(UInt size)
 {
     Obj obj = NewBag(T_DATOBJ, size);


### PR DESCRIPTION
Some kernel extension (EDIM, float) create T_DATOBJ instances for
use as internal buffers without ever setting a typeobj. This
mostly works as long as the buffer stays 100% local. But at least
in EDIM, one of the buffers gets retyped into a plist, which used
to be fine, except now we perform some sanity checks in
`PrecheckRetypeBag`.

Arguably the "correct" way to deal with this is to change affected
packages to use `NewKernelBuffer`. But it seems prudent to also
deal with this case directly in GAP itself. Especially since we
also still created a ton of T_DATOBJ directly in GAP and I think
we don't set a type for all of them either.