### PR TITLE
Make KernelObjects mutable by default

### DIFF
--- a/lib/object.gi
+++ b/lib/object.gi
@@ -701,7 +701,7 @@ end );
 DeclareRepresentation( "IsKernelDataObjectRep", IsDataObjectRep );
 
 BIND_GLOBAL( "TYPE_KERNEL_OBJECT",
-          NewType(NewFamily("KernelObjectFamily", IsObject),
+          NewType(NewFamily("KernelObjectFamily", IsObject and IsMutable),
           IsObject and IsKernelDataObjectRep));
 
 InstallMethod( String, [IsKernelDataObjectRep], o->MakeImmutable("<kernel object>"));


### PR DESCRIPTION
This makes the "KernelObject" mutable. This is an internal type. This is required as part of fixing EDIM, but in general seems sensible -- these objects are typically mutated (and immutable shouldn't matter, hopefully, as they are only used internally). It's possible this will upset HPCGAP somewhere, as now more objects will be mutable, but not sure.