### PR TITLE
Enhance `IsomorphismFpGroup(G)` to transfer in more cases information about `G` to its image

### DIFF
--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1393,7 +1393,20 @@ local s,r,fam,fas,fpf,mapi;
     #extra generators separately, but that is too much work for what is
     #intended as a minor hint.
   fi;
+
+  # Transfer some knowledge about the source group to its image.
+  if HasIsMapping(hom) and IsMapping(hom) then
+    if HasIsInjective(hom) and IsInjective(hom) then
+      UseIsomorphismRelation(s, r);
+    elif HasKernelOfMultiplicativeGeneralMapping(hom) then
+      UseFactorRelation(s, KernelOfMultiplicativeGeneralMapping(hom), r);
+    else
+      UseFactorRelation(s, fail, r);
+    fi;
+  fi;
+
   s:=SubgroupNC(s,mapi[1]);
+
   fam:=FamilyObj(One(r));
   fas:=FamilyObj(One(s));
   if IsPermCollection(s) or IsMatrixCollection(s)

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -1,4 +1,4 @@
-#@local F,G,N,cube,g,s,x,y,a,b,sym,h
+#@local F,G,N,cube,g,s,x,y,a,b,sym,h,iso
 gap> START_TEST("grpperm.tst");
 gap> G := Group((1,2),(1,2,3,4));;
 gap> HasAbelianFactorGroup(G,G);
@@ -80,12 +80,28 @@ gap> Length(MinimalGeneratingSet(G));
 2
 gap> IsomorphismPermGroup(G) = IdentityMapping(G);
 true
+
+#
 gap> g:=SymmetricGroup(6);;
 gap> h:=Action(g,Combinations([1..6],2),OnSets);;
 gap> IsSymmetricGroup(h);
 true
-gap> IsomorphismFpGroup(h);;
-gap> IsomorphismFpGroup(DerivedSubgroup(h));;
+gap> iso:=IsomorphismFpGroup(h);;
+gap> HasSize(ImagesSource(iso));
+true
+gap> iso:=IsomorphismFpGroup(DerivedSubgroup(h));;
+gap> HasSize(ImagesSource(iso));
+true
+
+#
+gap> G:=Group((2,5)(3,4), (1,3)(4,5));;
+gap> Size(G);
+10
+gap> iso:=IsomorphismFpGroup(G);;
+gap> HasSize(Range(iso));
+true
+
+#
 gap> sym:=SymmetricGroup(13);;
 gap> a:=Stabilizer(sym,[[1,2,3],[4,5,6,7]],OnTuplesSets);;Index(sym,a);
 60060


### PR DESCRIPTION
Achieved by making ProcessEpimorphismToNewFpGroup invoke UseIsomorphismRelation or UseFactorRelation as appropriate.