### PR TITLE
Skip checking DATOBJ when retyping bag

### DIFF
--- a/src/bags.c
+++ b/src/bags.c
@@ -46,6 +46,11 @@ void PrecheckRetypeBag(Bag bag, UInt new_type)
             return;
 #endif
 
+        // Some GAP code and packages (including EDIM) produce invalid
+        // T_DATOBJ objects without correct type info, so skip T_DATOBJ for now
+        if (IS_DATOBJ(bag))
+            return;
+
 #ifndef HPCGAP
         // HACK: when using `DeclareGlobalVariable`, the placeholder object of
         // type `IsToBeDefinedObj` is immutable, while `InstallValue` also


### PR DESCRIPTION
This is a (hopefully) temporary workaround, which disables a debug check when changing the type of T_DATOBJ objects, because it is currently triggered by the EDIM package.

What EDIM is doing won't actually cause GAP to crash -- but long term we would like to be more careful with how bags are typed. Once EDIM is fixed this can be removed, but this lets us run debug builds until a new EDIM release.