### PR TITLE
kernel: add 'void * ref' to all GC mark functions

### DIFF
--- a/src/bags.inc
+++ b/src/bags.inc
@@ -15,43 +15,43 @@
 #include "error.h"
 #include "gasman.h"
 
-void MarkArrayOfBags(const Bag array[], UInt count)
+void MarkArrayOfBags(const Bag array[], UInt count, void * ref)
 {
     for (UInt i = 0; i < count; i++) {
-        MarkBag(array[i]);
+        MarkBag(array[i], ref);
     }
 }
 
-void MarkNoSubBags(Bag bag)
+void MarkNoSubBags(Bag bag, void * ref)
 {
 }
 
-void MarkOneSubBags(Bag bag)
+void MarkOneSubBags(Bag bag, void * ref)
 {
-    MarkArrayOfBags(CONST_PTR_BAG(bag), 1);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 1, ref);
 }
 
-void MarkTwoSubBags(Bag bag)
+void MarkTwoSubBags(Bag bag, void * ref)
 {
-    MarkArrayOfBags(CONST_PTR_BAG(bag), 2);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 2, ref);
 }
 
-void MarkThreeSubBags(Bag bag)
+void MarkThreeSubBags(Bag bag, void * ref)
 {
-    MarkArrayOfBags(CONST_PTR_BAG(bag), 3);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 3, ref);
 }
 
-void MarkFourSubBags(Bag bag)
+void MarkFourSubBags(Bag bag, void * ref)
 {
-    MarkArrayOfBags(CONST_PTR_BAG(bag), 4);
+    MarkArrayOfBags(CONST_PTR_BAG(bag), 4, ref);
 }
 
-void MarkAllSubBags(Bag bag)
+void MarkAllSubBags(Bag bag, void * ref)
 {
-    MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag));
+    MarkArrayOfBags(CONST_PTR_BAG(bag), SIZE_BAG(bag) / sizeof(Bag), ref);
 }
 
-void MarkAllButFirstSubBags(Bag bag)
+void MarkAllButFirstSubBags(Bag bag, void * ref)
 {
-    MarkArrayOfBags(CONST_PTR_BAG(bag) + 1, SIZE_BAG(bag) / sizeof(Bag) - 1);
+    MarkArrayOfBags(CONST_PTR_BAG(bag) + 1, SIZE_BAG(bag) / sizeof(Bag) - 1, ref);
 }

--- a/src/calls.c
+++ b/src/calls.c
@@ -1611,13 +1611,13 @@ static void LoadFunction(Obj func)
 **
 **  'MarkFunctionSubBags' is the marking function for bags of type 'T_FUNCTION'.
 */
-static void MarkFunctionSubBags(Obj func)
+static void MarkFunctionSubBags(Obj func, void * ref)
 {
     // the first eight slots are pointers to C functions, so we need
     // to skip those for marking
     UInt size = SIZE_BAG(func) / sizeof(Obj) - 8;
     const Bag * data = CONST_PTR_BAG(func) + 8;
-    MarkArrayOfBags(data, size);
+    MarkArrayOfBags(data, size, ref);
 }
 
 

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -1942,9 +1942,9 @@ static Obj FuncCycList(Obj self, Obj list)
 **
 **  'MarkCycSubBags' is the marking function for bags of type 'T_CYC'.
 */
-static void MarkCycSubBags(Obj cyc)
+static void MarkCycSubBags(Obj cyc, void * ref)
 {
-    MarkArrayOfBags( COEFS_CYC( cyc ), SIZE_CYC(cyc) );
+    MarkArrayOfBags( COEFS_CYC( cyc ), SIZE_CYC(cyc), ref );
 }
 
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -661,10 +661,11 @@ Bag  MakeBagReadOnly(Bag bag);
 **  function for a  type before it allocates  any  bag  of  that type.  It is
 **  probably best to install all marking functions before allocating any bag.
 **
-**  A marking function  is a function  that takes a  single  argument of type
-**  'Bag' and returns nothing, i.e., has return type 'void'.  Such a function
-**  must apply the function 'MarkBag' to each bag  identifier that  appears in
-**  the bag (see below).
+**  A marking function is a function that takes a two arguments, one of type
+**  'Bag' and one of type 'void *' and returns nothing, i.e., has return type
+**  'void'.  Such a function must apply the function 'MarkBag' to each bag
+**  identifier that appears in the bag (see below), passing on its 'void *'
+**  argument unchanged to 'MarkBag' as second argument.
 **
 **  Those functions are applied during the garbage  collection to each marked
 **  bag, i.e., bags  that are assumed to be  still live,  to also mark  their
@@ -673,7 +674,8 @@ Bag  MakeBagReadOnly(Bag bag);
 **
 **  {\Gasman} already provides several marking functions, see below.
 */
-typedef void (* TNumMarkFuncBags )( Bag bag );
+#define GAP_MARK_FUNC_WITH_REF 1
+typedef void (* TNumMarkFuncBags )( Bag bag, void * ref );
 void InitMarkFuncBags(UInt type, TNumMarkFuncBags mark_func);
 
 #if !defined(USE_THREADSAFE_COPYING) && !defined(USE_BOEHM_GC)
@@ -689,7 +691,7 @@ extern TNumMarkFuncBags TabMarkFuncBags[NUM_TYPES];
 **  simply returns.  For example   in  {\GAP} the  bags for   large  integers
 **  contain only the digits and no identifiers of bags.
 */
-void MarkNoSubBags(Bag bag);
+void MarkNoSubBags(Bag bag, void * ref);
 
 
 /****************************************************************************
@@ -703,10 +705,10 @@ void MarkNoSubBags(Bag bag);
 **  the indicated number as bag identifiers as their initial entries.
 **  These functions mark those subbags and return.
 */
-void MarkOneSubBags(Bag bag);
-void MarkTwoSubBags(Bag bag);
-void MarkThreeSubBags(Bag bag);
-void MarkFourSubBags(Bag bag);
+void MarkOneSubBags(Bag bag, void * ref);
+void MarkTwoSubBags(Bag bag, void * ref);
+void MarkThreeSubBags(Bag bag, void * ref);
+void MarkFourSubBags(Bag bag, void * ref);
 
 
 /****************************************************************************
@@ -725,14 +727,14 @@ void MarkFourSubBags(Bag bag);
 **  bag identifiers for the elements  of the  list or 0   if an entry has  no
 **  assigned value.
 */
-void MarkAllSubBags(Bag bag);
+void MarkAllSubBags(Bag bag, void * ref);
 
 
 /****************************************************************************
 **
 *F  MarkAllButFirstSubBags(<bag>) . . . .  marks all subbags except the first
 */
-void MarkAllButFirstSubBags(Bag bag);
+void MarkAllButFirstSubBags(Bag bag, void * ref);
 
 
 /****************************************************************************
@@ -749,11 +751,11 @@ void MarkAllButFirstSubBags(Bag bag);
 **  identifier.
 */
 #ifdef USE_BOEHM_GC
-EXPORT_INLINE void MarkBag( Bag bag )
+EXPORT_INLINE void MarkBag( Bag bag, void * ref )
 {
 }
 #else
-void MarkBag(Bag bag);
+void MarkBag(Bag bag, void * ref);
 #endif
 
 
@@ -764,7 +766,7 @@ void MarkBag(Bag bag);
 **  'MarkArrayOfBags' iterates over <count> all bags in the given array,
 **  and marks each bag using MarkBag.
 */
-extern void MarkArrayOfBags(const Bag array[], UInt count);
+extern void MarkArrayOfBags(const Bag array[], UInt count, void * ref);
 
 
 /****************************************************************************

--- a/src/hpc/aobjects.c
+++ b/src/hpc/aobjects.c
@@ -403,7 +403,7 @@ static Obj FuncFromAtomicList(Obj self, Obj list)
     return FromAtomicList(list);
 }
 
-static void MarkAtomicList(Bag bag)
+static void MarkAtomicList(Bag bag, void * ref)
 {
   UInt len;
   const AtomicObj *ptr, *ptrend;
@@ -411,7 +411,7 @@ static void MarkAtomicList(Bag bag)
   len = ALIST_LEN((UInt)(ptr++->atom));
   ptrend = ptr + len + 1;
   while (ptr < ptrend)
-    MarkBag(ptr++->obj);
+    MarkBag(ptr++->obj, ref);
 }
 
 /* T_AREC_INNER substructure:
@@ -449,24 +449,24 @@ static Obj GetTLInner(Obj obj)
   return contents;
 }
 
-static void MarkTLRecord(Bag bag)
+static void MarkTLRecord(Bag bag, void * ref)
 {
-  MarkBag(GetTLInner(bag));
+  MarkBag(GetTLInner(bag), ref);
 }
 
 
-static void MarkAtomicRecord(Bag bag)
+static void MarkAtomicRecord(Bag bag, void * ref)
 {
-  MarkBag(GetTLInner(bag));
+  MarkBag(GetTLInner(bag), ref);
 }
 
-static void MarkAtomicRecord2(Bag bag)
+static void MarkAtomicRecord2(Bag bag, void * ref)
 {
   const AtomicObj *p = CONST_ADDR_ATOM(bag);
   UInt cap = p->atom;
   p += 5;
   while (cap) {
-    MarkBag(p->obj);
+    MarkBag(p->obj, ref);
     p += 2;
     cap--;
   }

--- a/src/julia_gc.h
+++ b/src/julia_gc.h
@@ -22,7 +22,7 @@
 **  may result.
 */
 
-void MarkJuliaObj(void * obj);
+void MarkJuliaObj(void * obj, void * ref);
 
 /****************************************************************************
 **
@@ -33,7 +33,7 @@ void MarkJuliaObj(void * obj);
 **  a valid Julia object. If not, it is silently ignored.
 */
 
-void MarkJuliaObjSafe(void * obj);
+void MarkJuliaObjSafe(void * obj, void * ref);
 
 /****************************************************************************
 **
@@ -43,6 +43,6 @@ void MarkJuliaObjSafe(void * obj);
 **  reference and cannot be NULL.
 */
 
-void MarkJuliaWeakRef(void * obj);
+void MarkJuliaWeakRef(void * obj, void * ref);
 
 #endif

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -74,7 +74,10 @@ void GAP_Initialize(int              argc,
 ////
 void GAP_MarkBag(Obj obj)
 {
-    MarkBag(obj);
+    // For now pass a dummy 'ref' value to MarkBag. That's fine
+    // when using GASMAN or Boehm GC. It won't work with Julia GC
+    // but that's fine as GAP.jl doesn't need it.
+    MarkBag(obj, 0);
 }
 
 void GAP_CollectBags(BOOL full)

--- a/src/objects.c
+++ b/src/objects.c
@@ -579,16 +579,16 @@ void CLEAN_OBJ(Obj obj)
 
 #if !defined(USE_THREADSAFE_COPYING) && !defined(USE_BOEHM_GC)
 
-static void MarkCopyingSubBags(Obj obj)
+static void MarkCopyingSubBags(Obj obj, void * ref)
 {
     Obj fpl = CONST_ADDR_OBJ(obj)[0];
 
     // mark the forwarding pointer
-    MarkBag(fpl);
+    MarkBag(fpl, ref);
 
     // mark the rest as in the non-copied case
     UInt tnum = INT_INTOBJ(ELM_PLIST(fpl, 3));
-    TabMarkFuncBags[tnum](obj);
+    TabMarkFuncBags[tnum](obj, ref);
 }
 
 #endif

--- a/src/objset.c
+++ b/src/objset.c
@@ -171,16 +171,16 @@ static void PrintObjMap(Obj map)
  *  These functions are not yet implemented.
  */
 
-static void MarkObjSet(Obj obj)
+static void MarkObjSet(Obj obj, void * ref)
 {
   UInt size = CONST_ADDR_WORD(obj)[OBJSET_SIZE];
-  MarkArrayOfBags( CONST_ADDR_OBJ(obj) + OBJSET_HDRSIZE, size );
+  MarkArrayOfBags( CONST_ADDR_OBJ(obj) + OBJSET_HDRSIZE, size, ref );
 }
 
-static void MarkObjMap(Obj obj)
+static void MarkObjMap(Obj obj, void * ref)
 {
   UInt size = CONST_ADDR_WORD(obj)[OBJSET_SIZE];
-  MarkArrayOfBags( CONST_ADDR_OBJ(obj) + OBJSET_HDRSIZE, 2 * size );
+  MarkArrayOfBags( CONST_ADDR_OBJ(obj) + OBJSET_HDRSIZE, 2 * size, ref );
 }
 
 /**

--- a/src/precord.c
+++ b/src/precord.c
@@ -748,7 +748,7 @@ static void LoadPRec(Obj prec)
 **  'MarkPRecSubBags' is the marking function for bags of type 'T_PREC' or
 **  'T_COMOBJ'.
 */
-void MarkPRecSubBags(Obj bag)
+void MarkPRecSubBags(Obj bag, void * ref)
 {
     const Bag * data = CONST_PTR_BAG(bag);
     const UInt count = SIZE_BAG(bag) / sizeof(Bag);
@@ -756,10 +756,10 @@ void MarkPRecSubBags(Obj bag)
     // data[0] is unused for regular precords, but it is used during copying
     // to store a pointer to the copy; moreover, this mark function is also
     // used for component objects, which store their type in slot 0
-    MarkBag(data[0]);
+    MarkBag(data[0], ref);
 
     for (UInt i = 3; i < count; i += 2) {
-        MarkBag(data[i]);
+        MarkBag(data[i], ref);
     }
 }
 

--- a/src/precord.h
+++ b/src/precord.h
@@ -258,7 +258,7 @@ void CopyPRecord(TraversalState * traversal, Obj copy, Obj original);
 #endif
 
 
-void MarkPRecSubBags(Obj bag);
+void MarkPRecSubBags(Obj bag, void * ref);
 
 
 /****************************************************************************

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -534,7 +534,7 @@ static Obj FiltIsWPObj(Obj self, Obj wp)
 
 #if defined(USE_GASMAN)
 
-static void MarkWeakPointerObj(Obj wp)
+static void MarkWeakPointerObj(Obj wp, void * ref)
 {
     // can't use the stored length here, in case we are in the middle of
     // copying
@@ -558,7 +558,7 @@ static void SweepWeakPointerObj( Bag *src, Bag *dst, UInt len)
 
 #ifdef USE_JULIA_GC
 
-static void MarkWeakPointerObj(Obj wp)
+static void MarkWeakPointerObj(Obj wp, void * ref)
 {
     // can't use the stored length here, in case we are in the middle of
     // copying
@@ -566,7 +566,7 @@ static void MarkWeakPointerObj(Obj wp)
     for (UInt i = 1; i <= len; i++) {
         Bag elm = CONST_ADDR_OBJ(wp)[i];
         if (IS_BAG_REF(elm))
-            MarkJuliaWeakRef(elm);
+            MarkJuliaWeakRef(elm, ref);
     }
 }
 


### PR DESCRIPTION
This helps the Julia GC to pass along certain global state through marking functions to `MarkBag`, instead of needing to use global variables for that (which is not thread safe).

For GASMAN and Boehm, this does nothing.

The main downside is that it breaks kernel extensions defining custom marking functions. But as far as I can tell, that only affects `Semigroups`, for which I am confident we can get a patch in that will make it work with this while staying compatible with older kernel versions. Enabling this is why I've added

    #define GAP_MARK_FUNC_WITH_REF 1

to this PR: then one can add something like

    #ifdef GAP_MARK_FUNC_WITH_REF
    #define MarkBag(obj,ref) MarkBag(obj)
    #endif

to code that needs to stay compatible with GAP versions before and after this patch.


This is still a draft. In particular, the Julia versions crashes right now 😂 but I created this some time ago late at night, and didn't have time to debug this so far. But I don't want to forget it as it will help me resolve threading issues with the Julia GC. As this is breaking the kernel ABI, it would be kinda cool if this could still go into GAP 4.13.0 (otherwise it would have to wait for 4.14.x...). But of course that depends on how quick it can be made to work, and how quick I can then submit a patch to @james-d-mitchell for updating semigroups, and whether we can update that in time, and ...

Anyway, I now plan to have GAP 4.13.0 released at the latest during GAP Days, so if this is not ready then, it's out.