### PR TITLE
hack for small matrix groups over large finite fields

### DIFF
--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -56,7 +56,7 @@ BindGlobal("HashKeyWholeBag", {x,y} -> HASHKEY_BAG(x,y,0,-1));
 InstallMethod(SparseIntKey,"for finite Gaussian row spaces",true,
     [ IsFFECollColl and IsGaussianRowSpace,IsObject ], 0,
 function(m,v)
-local f,n,bytelen,data,qq,i;
+local f,n,bytelen,data,qq,i,b,s,sl,nn;
   f:=LeftActingDomain(m);
   n:=Size(f);
   if n=2 then
@@ -104,6 +104,26 @@ local f,n,bytelen,data,qq,i;
              end;
 
     fi;
+  elif n > 100000 and Characteristic( f ) < n then
+    # large field, view it as an extension of its prime field
+    # in order to avoid writing down all of its elements
+    if Size( LeftActingDomain( f ) ) <> Characteristic( f ) then
+      f:= AsField( PrimeField( f ), f );
+    fi;
+    b:= Basis( f );
+    s:= LeftActingDomain( f );
+    sl:= AsSSortedList( s );
+    nn:= Size( s );
+    return function( v )
+      local sy, x, c;
+      sy:= 0;
+      for x in v do
+        for c in Coefficients( b, x ) do
+          sy:= nn*sy + ( Position( sl, c ) - 1 );
+        od;
+      od;
+      return sy;
+    end;
   else
     # large field -- vector represented as plist.
     f:=AsSSortedList(f);

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -49,6 +49,17 @@ false
 gap> IsTransitive( Image( IsomorphismPermGroup( SO( 1, 8, 2 ) ) ) );
 true
 
+# a small matrix group over a large field
+gap> F:= GF(3, 16);;  Size( F );
+43046721
+gap> o:= PrimitiveElement(F);;
+gap> a:= o^15 + 2*o^13 + o^12 + o^11 + o^10 + o^8 + o^7 + 2*o^2 + o + 2;;
+gap> Order( a );
+17
+gap> G:= Group( [ [ a ] ] );;
+gap> Size( G );
+17
+
 # 'NiceMonomorphism' shall work for finite rational matrix groups,
 # also if they do not know yet that they are finite.
 gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;


### PR DESCRIPTION
This addresses #5663, see this issue (or the proposed test) for an example where the change helps.

I know that this change is not a good solution,
it just points to one weakness of the code --writing down all elements of a finite field in order to create hash values for vectors over this field.
Better proposals are welcome.