### PR TITLE
fix a `<Log>` example in the Reference Manual

### DIFF
--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -924,7 +924,7 @@ DeclareCategory( "IsInputOutputStream", IsInputStream and
 ##  true
 ##  gap> y := ReadAll(s);;
 ##  gap> Length(y);
-##  4095
+##  10002
 ##  gap> CloseStream(s);
 ##  gap> s;
 ##  < closed input/output stream to rev >


### PR DESCRIPTION
Up to now, the example for `InputOutputLocalProcess` promised a string of length 4095, but 10002 is more reasonable.

Can't we turn this example from `<Log>` (which is not tested automatically) to `<Example>`?
For that: Can we assume that the system program `rev` is always available?
If yes then all we have to change is to hide the local paths that occur in the example, if not then we should invent a different example.