### PR TITLE
support initial search in `PAGER_BUILTIN`

### DIFF
--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -522,7 +522,7 @@ BIND_GLOBAL("PageSource", function ( fun, nr... )
               s := First(ss, a-> ':' in a);
               if s <> fail then
                 ss := SplitString(s,":","");
-                l := Concatenation("/Obj *Func", ss[2]);
+                l := Concatenation("/Obj Func", ss[2]);
               fi;
           fi;
         fi;

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -522,7 +522,7 @@ BIND_GLOBAL("PageSource", function ( fun, nr... )
               s := First(ss, a-> ':' in a);
               if s <> fail then
                 ss := SplitString(s,":","");
-                l := Concatenation("/Obj Func", ss[2]);
+                l := Concatenation("Obj Func", ss[2]);
               fi;
           fi;
         fi;

--- a/lib/pager.gd
+++ b/lib/pager.gd
@@ -30,8 +30,10 @@
 ##  <P/>
 ##  At least on a UNIX system one should use an external pager program like
 ##  <C>less</C> or <C>more</C>.
-##  &GAP; assumes that this program has a command line option <C>+nr</C>
-##  which starts the display of the text with line number <C>nr</C>.
+##  &GAP; assumes that this program has command line options <C>+nr</C> and
+##  <C>+/str</C> which start the display of the text with line number
+##  <C>nr</C> or at the line with the first occurrence of the string
+##  <C>str</C>.
 ##  <P/>
 ##  Which pager is used can be controlled by setting the user preference
 ##  <C>"Pager"</C>.
@@ -77,9 +79,12 @@
 ##  </Item>
 ##  <Mark><C>start</C></Mark>
 ##  <Item>
-##    must be a positive integer.
-##    This is interpreted as the number of the first line shown by the pager
-##    (one may see the beginning of the text via back scrolling).
+##    must be a positive integer or a string.
+##    An integer is interpreted as the number of the first line shown by the
+##    pager, a string is interpreted as a search string such that the first
+##    line containing this string is the first line shown by the pager
+##    (in both cases, one may see the beginning of the text via back
+##    scrolling),
 ##  </Item>
 ##  <Mark><C>exitAtEnd</C></Mark>
 ##  <Item>

--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -160,6 +160,9 @@ BindGlobal("PAGER_BUILTIN", function( r )
   if IsRecord(r) then
     if IsBound(r.formatted) then
       formatted := r.formatted;
+      if formatted <> true and formatted <> false then
+        Error("unsupported r.formatted value: ", formatted);
+      fi;
     fi;
     if IsBound(r.start) then
       if IsPosInt(r.start) then
@@ -168,10 +171,15 @@ BindGlobal("PAGER_BUILTIN", function( r )
         search := r.start{[2..Length(r.start)]};
         linepos := PositionProperty(lines,
                      l -> PositionSublist(l, search) <> fail);
+      else
+        Error("unsupported r.start value: ", r.start);
       fi;
     fi;
     if IsBound( r.exitAtEnd ) then
       exitAtEnd:= r.exitAtEnd;
+      if exitAtEnd <> true and exitAtEnd <> false then
+        Error("unsupported r.exitAtEnd value: ", exitAtEnd);
+      fi;
     fi;
   fi;
 
@@ -289,6 +297,9 @@ BindGlobal("PAGER_EXTERNAL",  function( lines )
   if IsRecord(lines) then
     if IsBound(lines.start) then
       linepos := lines.start;
+      if not (IsPosInt(lines.start) or IsString(lines.start)) then
+        Error("unsupported lines.start value: ", linepos);
+      fi;
     fi;
     lines := lines.lines;
   fi;


### PR DESCRIPTION
When `PageSource` calls `Pager` with the data for a kernel function, it specifies the start line by a search string.
This works well for external pagers such as `less`, but up to now `PAGER_BUILTIN` did not honor this hint.

With the changes proposed here,
calls such as `PageSource( IS_SSORT_LIST_DEFAULT )` will work as expected also when `PAGER_BUILTIN` is used.

(The code is a hack, because GAP does not support regular expressions and because the search in C code files is based only on some heuristics.)