### PR TITLE
in general, do not use a known `Name` value in `PrintObj`

### DIFF
--- a/lib/object.gi
+++ b/lib/object.gi
@@ -377,24 +377,6 @@ end );
 
 #############################################################################
 ##
-#M  PrintObj( <obj> )
-##
-InstallMethod( PrintObj,
-    "for an object with name",
-    true,
-    [ HasName ],
-    SUM_FLAGS, # override anything specific
-    function( obj )
-    if ISBOUND_GLOBAL( Name( obj ) ) then
-      Print( Name( obj ) );
-    else
-      TryNextMethod();
-    fi;
-    end );
-
-
-#############################################################################
-##
 #M  ViewObj( <obj> )  . . . . . . . . . . . . . . . . for an object with name
 ##
 InstallMethod( ViewObj,

--- a/lib/object.gi
+++ b/lib/object.gi
@@ -384,7 +384,13 @@ InstallMethod( PrintObj,
     true,
     [ HasName ],
     SUM_FLAGS, # override anything specific
-    function ( obj )  Print( Name( obj ) ); end );
+    function( obj )
+    if ISBOUND_GLOBAL( Name( obj ) ) then
+      Print( Name( obj ) );
+    else
+      TryNextMethod();
+    fi;
+    end );
 
 
 #############################################################################

--- a/lib/overload.g
+++ b/lib/overload.g
@@ -389,6 +389,31 @@ InstallMethod( UpperCentralSeries, [ IsAlgebra ],
 InstallMethod( UpperCentralSeries, [ IsGroup ], UpperCentralSeriesOfGroup );
 
 
+#############################################################################
+##
+#M  PrintObj( <obj> )
+##
+##  For a few global variables, we want that their 'Name' value is used by
+##  'PrintObj'.
+##  Note that in general we do not want that setting a 'Name' value changes
+##  the behaviour of 'PrintObj'.
+##
+Perform( [ "IsGaussianIntegers", "IsGaussianRationals", "IsIntegers",
+           "IsRationals" ],
+  function( filtname )
+    InstallMethod( PrintObj,
+      [ filtname ],
+      SUM_FLAGS, # override anything specific
+      function( obj )
+        if ISBOUND_GLOBAL( Name( obj ) ) then
+          Print( Name( obj ) );
+        else
+          TryNextMethod();
+        fi;
+      end );
+  end );
+
+
 DeclareGlobalFunction( "InsertElmList" );
 
 InstallGlobalFunction(InsertElmList, function (list, pos, elm)

--- a/lib/overload.g
+++ b/lib/overload.g
@@ -398,7 +398,8 @@ InstallMethod( UpperCentralSeries, [ IsGroup ], UpperCentralSeriesOfGroup );
 ##  Note that in general we do not want that setting a 'Name' value changes
 ##  the behaviour of 'PrintObj'.
 ##
-Perform( [ "IsGaussianIntegers", "IsGaussianRationals", "IsIntegers",
+Perform( [ "IsCyclotomicCollection and IsWholeFamily",
+           "IsGaussianIntegers", "IsGaussianRationals", "IsIntegers",
            "IsRationals" ],
   function( filtname )
     InstallMethod( PrintObj,

--- a/tst/teststandard/simplegrpit.tst
+++ b/tst/teststandard/simplegrpit.tst
@@ -41,7 +41,7 @@ PSL(2,59)
 
 #
 gap> it := SimpleGroupsIterator(20000,80000:NOPSL2);;
-gap> for g in it do Print(g,"\n"); od;
+gap> for g in it do View( g ); Print( "\n" ); od;
 A8
 PSL(3,4)
 PSp(4,3)
@@ -50,7 +50,7 @@ PSU(3,4)
 gap> IsDoneIterator(it);
 true
 gap> it:=SimpleGroupsIterator(1053927211015007279,1053927211015007281);;
-gap> for g in it do Print(g,"\n"); od;
+gap> for g in it do View( g ); Print( "\n" ); od;
 PSL(3,179)
 
 #


### PR DESCRIPTION
This addresses #5699.

For more than 25 years, there is a `PrintObj` method with high rank that just prints a known `Name` value of the object in question.
According to the documentation of `Name`, a known `Name` value should be used only by `View` and `ViewObj`; the function `Print` is recommended to show GAP input to reconstruct the object in question if this makes sense.

When we remove the `PrintObj` method in question, the tests from `testinstall` and `teststandard` show differences essentially in two situations:
- Certain global variables such as `Rationals` are currently expected to be printed via this name. The solution proposed here is to provide ~a `PrintObj` method with high rank that uses a known name under the condition that a global variable with this name exists~ individual `PrintObj` methods for the objects in question. This works because there are already filters that describe these objects.
- Some tests for groups returned by `SimpleGroupsIterator` call `Print` in order to show the names of these groups. Here we can call `View` instead of `Print`.

(Let us see the results of the other tests, perhaps there are more differences.)