### PR TITLE
fix `PreImagesRepresentative` for `IsToPcGroupHomomorphismByImages`

### DIFF
--- a/lib/ghompcgs.gi
+++ b/lib/ghompcgs.gi
@@ -511,7 +511,11 @@ InstallMethod( PreImagesRepresentative, "method for pcgs hom",
 function( hom, elm )
     local  pcgsR, exp, imgs, pre, i;
 
-    # precompute pcgs
+    if not elm in ImagesSource( hom ) then
+      return fail;
+    fi;
+
+    # Precompute a pcgs for the *image* of 'hom'.
     InversePcgs( hom );
 
     pcgsR := hom!.rangePcgs;

--- a/tst/testinstall/grppc.tst
+++ b/tst/testinstall/grppc.tst
@@ -183,5 +183,26 @@ true
 gap> IsIdenticalObj( Range( iso ), ImagesSource( iso ) );
 true
 
+#
+gap> G:= AbelianGroup( IsPcGroup, [ 3, 3, 3 ] );;
+gap> S:= AbelianGroup( IsPcGroup, [ 3, 3 ] );;
+gap> f:= GroupHomomorphismByImages( G, S, GeneratorsOfGroup( G ),
+>         [ GeneratorsOfGroup( S )[1], One( S ), One( S ) ] );;
+gap> x:= GeneratorsOfGroup( S )[2];;
+gap> x in Range( f ) and not x in Image( f );
+true
+gap> PreImagesRepresentative( f, x );
+fail
+gap> G:= AbelianGroup( IsPcGroup, [ 3, 3 ] );;
+gap> S:= AbelianGroup( IsPcGroup, [ 3 ] );;
+gap> f:= GroupHomomorphismByImages( G, S, GeneratorsOfGroup( G ),
+>         [ One( S ), One( S ) ] );;
+gap> x:= GeneratorsOfGroup( S )[1];
+f1
+gap> x in Range( f ) and not x in Image( f );
+true
+gap> PreImagesRepresentative( f, x );
+fail
+
 # that's all, folks
 gap> STOP_TEST( "grppc.tst" );


### PR DESCRIPTION
Added a check whether the given element is in the image of the map. Now the method returns `fail` if not, as is specified in the documentation of `PreImagesRepresentative`.

Note that `InversePcgs` is called (only) in the
`PreImagesRepresentative` method for a group homomorphism in `IsToPcGroupHomomorphismByImages`.
It sets the component `rangePcgs`; the value is a pcgs for the *image* of the homomorphism (in general *not* for the range).

Resolves #5704, but there are likely other bugs of this kind.

I expect that #5073 or some follow-up of it will discuss the problem in the text for the release notes, thus there is no need to mention the current pull request in the release notes.