### PR TITLE
Fix regression in `IsomorphismPermGroupOrFailFpGroup` that caused it to fail in situations that worked in GAP 4.12.2

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -4051,6 +4051,7 @@ local mappow, G, max, p, gens, rels, comb, i, l, m, H, t, gen, sz,
             RelatorsOfFpGroup(G),[gen],true,false:
               cyclic:=true,limit:=1+max,quiet:=true );
     fi;
+
     if t=fail then
       # we cannot get the size within the permitted limits -- give up
       return fail;
@@ -4097,6 +4098,8 @@ local mappow, G, max, p, gens, rels, comb, i, l, m, H, t, gen, sz,
   if max>10^4*sz then
     max:=10^3*sz;
   fi;
+
+  amax:=Maximum(amax,max+1);
 
   useind:=false;
   t1:=timerFunc();

--- a/tst/testbugfix/2024-05-06-IsomorphismPermGroupOrFailFpGroup.tst
+++ b/tst/testbugfix/2024-05-06-IsomorphismPermGroupOrFailFpGroup.tst
@@ -1,0 +1,12 @@
+# Verify regression in IsomorphismPermGroupOrFailFpGroup is
+# resolved, see <https://github.com/gap-system/gap/issues/5697>
+gap> F:= FreeGroup(2);
+<free group on the generators [ f1, f2 ]>
+gap> gens:= GeneratorsOfGroup( F );
+[ f1, f2 ]
+gap> x:= gens[1];; y:= gens[2];;
+gap> rels:= [ y*x^-1*y^-1*x*y^-1*x^-1, x^-1*y*x*y*x^-1*y^-2 ];;
+gap> G:= F / rels;
+<fp group on the generators [ f1, f2 ]>
+gap> IsomorphismPermGroupOrFailFpGroup(G, 100000) <> fail;
+true


### PR DESCRIPTION
Resolves #5697

This has been extracted from PR #5698 by @hulpke mainly because it makes some maintenance tasks easier for me (managing the release notes, bisecting through commits to find sources of regressions etc.), and at the same time is supposed to not cause @hulpke any extra work (as we should be able to merge PR #5698 as-is after this one here).

I've also add a small test case.

Note that I've put this PR into the "bug" category, even though one can certainly argue that this is not fixing a bug, as the function `IsomorphismPermGroupOrFailFpGroup` is allowed to return `fail`. But it *is* fixing a regression compared to past GAP versions, and so to a user appears as "it used to work, then it didn't, now it does again", so category "bug" seems a bit more appropriate than "enhancement", and for the release notes we need to pick one of those.