### PR TITLE
CI: install autoconf for macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -229,7 +229,7 @@ jobs:
                    sudo apt-get install --no-install-recommends "${packages[@]}"
                    sudo apt-get install pkg-config
                elif [ "$RUNNER_OS" == "macOS" ]; then
-                   brew install gmp zlib pkg-config
+                   brew install autoconf gmp zlib pkg-config
                fi
                python -m pip install gcovr
 


### PR DESCRIPTION
Hopefully fixes the bogus failures (see e.g. [here](https://github.com/gap-system/gap/actions/runs/8970249740/job/24633365343?pr=5709)) in `testmockpkg` on macOS caused by `autoconf` not being available.