### PR TITLE
julia_gc: don't call jl_get_ptls_states from code running during GC

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -509,7 +509,7 @@ ScanTaskStack(int rescan, jl_task_t * task, void * start, void * end)
             PtrArraySetLen(stack, p + 1);
         }
     }
-    MarkFromList(jl_get_ptls_states(), stack);
+    MarkFromList(task->ptls, stack);
 }
 
 static NOINLINE void TryMarkRange(jl_ptls_t ptls, void * start, void * end)


### PR DESCRIPTION
It is not quite safe there when multithreading, it seems. Instead get it from the task struct.

This is a tiny but necessary step towards resolving the multi threading issues we've been seeing in GAP.jl