### PR TITLE
Improvement in `MinimalGeneratingSet`

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -218,13 +218,7 @@ function(G)
       fi;
     od;
     if G = GroupByGenerators(mingenset_k_reps) then return mingenset_k_reps; fi;
-    Print("Calculated mingen doesn't generate the group.");
     return mingenset_k_reps;
-    Error(
-  "`MinimalGeneratingSet' currently assumes that the group is solvable, or\n",
-  "already possesses a generating set of size 2.\n",
-  "In general, try `SmallGeneratingSet' instead, which returns a generating\n",
-  "set that is small but not of guaranteed smallest cardinality");
   fi;
 end);
 


### PR DESCRIPTION
### Changes

The function `MinimalGeneratingSet` is supposed to efficiently compute the generating set of minimum size for a group. This was previously failing for non-solvable groups. I have fixed that using the algorithm derived from [the research paper](https://arxiv.org/abs/2306.07633) by Dhara Thakkar and Andrea Lucchini. 

The algorithm works as shown in this flowchart :

![MinGenSet](https://github.com/gap-system/gap/assets/108942295/3eaeaed6-ee82-4f4d-96b3-555784ab6329)

### Example Usage

```GAP
gap> A5ton := function(n)
>     local A5,G,k;
>     A5 := AlternatingGroup(5);
>     G := A5;
>     for k in [2..n] do 
>         G := DirectProduct(G,A5);
>     od;
>     return G;
> end;
function( n ) ... end
gap> G := A5ton(5);
<permutation group of size 777600000 with 10 generators>
gap> MinimalGeneratingSet(G);
[ (1,5,4,3,2)(6,7,10,9,8)(11,12,14,15,13)(16,17,18,20,19)(21,22,23,25,24), 
  (1,4,2)(6,7)(9,10)(11,15)(12,13)(16,17,20,19,18)(21,24,22) ]
gap> G := A5ton(7);
<permutation group of size 2799360000000 with 14 generators>
gap> MinimalGeneratingSet(G);
[ (1,2,3,5,4)(6,9,10)(11,13,12,15,14)(16,19,17,20,18)(21,25,22,24,23)(26,
    27)(28,30)(31,32,35), (1,3)(2,5)(7,8,10)(13,15,14)(16,20,17,19,18)(21,22,
    25,23,24)(26,27,29,28,30)(31,35,32,33,34) ]
gap> 

```
