### PR TITLE
Introduce scanning of 'getcontext' for registers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -946,6 +946,9 @@ dnl including pseudo TTY support, signals, etc.
 AC_CHECK_HEADERS([termios.h])
 AC_CHECK_HEADERS([sys/ioctl.h sys/resource.h])
 
+dnl check for ucontext for gasman
+AC_CHECK_HEADERS([ucontext.h])
+
 
 # openpty() is available on various BSD variants, but also in glibc.
 # On BSD systems, one usually needs to add -lutil to LIBS in order

--- a/src/gap.c
+++ b/src/gap.c
@@ -1536,3 +1536,22 @@ void InitializeGap (
     }
 
 }
+
+int gasman_check_do_call(int a, int b, int c, int d, int e, int f, int g);
+void gasman_check_gc(void);
+
+// The following function is used as part of GASMAN's sanity check.
+// It is placed here, rather than in gasman.c, to avoid it being considered
+// for inlining
+NOINLINE void gasman_check_fill_registers(int a, int b, int c, int d, int e, int f, int g) {
+    int a1 = a*b+1;
+    int b1 = b*c+2;
+    int c1 = a*d+3;
+    int d1 = b*d+4;
+    int e1 = e*g+5;
+    int f1 = f*g+6;
+    int g1 = a*g+7;
+    gasman_check_do_call(a1,b1,c1,d1,e1,f1,g1);
+    gasman_check_gc();
+    gasman_check_do_call(a1,b1,c1,d1,e1,f1,g1);
+}


### PR DESCRIPTION
On Mac OS X, the registers are 'munged' when stored in setjmp, so we use getcontext as well, which stores registers in a raw format.

Also, change to scanning every byte, instead of in sizeof(Bag) blocks, just in case setjmp or context aren't aligned.

This is mostly a defensive fix -- there has been issues on Mac, and I can see setjmp 'munging' registers ( _OS_PTR_MUNGE in https://github.com/apple-oss-distributions/libplatform/blob/a00a4cc36da2110578bcf3b8eeeeb93dcc7f4e11/src/setjmp/arm/_setjmp.s ), while getcontext doesn't seem to ( https://github.com/apple-oss-distributions/libplatform/blob/a00a4cc36da2110578bcf3b8eeeeb93dcc7f4e11/src/ucontext/arm64/getcontext.s#L29 ).

Hopefully there is no reason for this to be worse than code we had before (assuming I haven't messed anything up, I did throw some printfs around to make sure I was scaning enough.

I was confused as to why `(Bag*)setjmp_buf` ever worked -- turns out it's usually stored as an array, but I turned it into `(Bag*)&setjmp_buf` for consistency.