### PR TITLE
Check when we build a library, it functions correctly (in particular gmp)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,7 @@ jobs:
             test-suites: "testinstall"
             extra: "HPCGAP=yes ABI=64"
 
-          # this job also tests GAP without readline
+          # this job also tests GAP without readline and gmp
           - os: macos-latest
             shell: bash
             test-suites: "testmockpkg testinstall"
@@ -229,7 +229,7 @@ jobs:
                    sudo apt-get install --no-install-recommends "${packages[@]}"
                    sudo apt-get install pkg-config
                elif [ "$RUNNER_OS" == "macOS" ]; then
-                   brew install autoconf gmp zlib pkg-config
+                   brew install autoconf zlib pkg-config
                fi
                python -m pip install gcovr
 

--- a/cnf/build-extern.sh
+++ b/cnf/build-extern.sh
@@ -26,6 +26,14 @@ if [[ ( ! "$builddir/config.status" -nt "$src/configure" )
 fi
 
 $MAKE -C "$builddir"
+if ! $MAKE -C "$builddir" check; then
+  echo "=== FAILED checking $pkg ==="
+  echo "The copy of $pkg distributed with GAP has failed to pass its internal checks"
+  echo "You can either install the library from a different source, or use"
+  echo "a newer release of GAP"
+  exit 1
+fi
+
 $MAKE -C "$builddir" install
 
 # TODO: insert command to check whether make needs to be called at all?


### PR DESCRIPTION
Run `make check` whenever we build zlib or gmp as an external dependancy.

This will, hopefully, catch if we end up with an out-of-date gmp. This could probably be improved to explain to users why compiling is braking, and suggest they go and suggest they install the approriate library themselves?

Check it works by not installing gmp on mac.