### PR TITLE
Check when we build a library, it functions correctly (in particular …

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,7 +94,7 @@ jobs:
             test-suites: "testpackages testinstall-loadall"
             extra: "ABI=32 NO_COVERAGE=1"
 
-          # this job also tests GAP without readline
+          # this job also tests GAP without readline and gmp
           - os: macos-latest
             shell: bash
             test-suites: "testmockpkg testinstall"
@@ -228,8 +228,9 @@ jobs:
                    fi
                    sudo apt-get update
                    sudo apt-get install --no-install-recommends "${packages[@]}"
+                   sudo apt-get install pkg-config
                elif [ "$RUNNER_OS" == "macOS" ]; then
-                   brew install gmp zlib
+                   brew install autoconf zlib pkg-config
                fi
                python -m pip install gcovr
 

--- a/cnf/build-extern.sh
+++ b/cnf/build-extern.sh
@@ -26,6 +26,14 @@ if [[ ( ! "$builddir/config.status" -nt "$src/configure" )
 fi
 
 $MAKE -C "$builddir"
+if ! $MAKE -C "$builddir" check; then
+  echo "=== FAILED checking $pkg ==="
+  echo "The copy of $pkg distributed with GAP has failed to pass its internal checks"
+  echo "You can either install the library from a different source, or use"
+  echo "a newer release of GAP"
+  exit 1
+fi
+
 $MAKE -C "$builddir" install
 
 # TODO: insert command to check whether make needs to be called at all?


### PR DESCRIPTION
This is a cherry-pick of #5720 to stable-4.12, mainly to show that it works correctly when it detects a bad version of GMP, and the version of GMP in 4.12 fails to work in macs.

I'm not sure we should bother merging and releasing a new 4.12, just wanted to confirm everything.