### PR TITLE
Fix an error message when computing subgroup lattices of certain insolvable groups

### DIFF
--- a/lib/oprtglat.gi
+++ b/lib/oprtglat.gi
@@ -450,7 +450,7 @@ end);
 InstallMethod(SubgroupsOrbitsAndNormalizers,"perm group on list",true,
   [IsPermGroup,IsList,IsBool],0,
 function(G,dom,all)
-local n,l, o, b, t, r;
+local n,l, o, b, t, r,sub;
 
   if Length(dom)=0 then
     return dom;
@@ -463,8 +463,8 @@ local n,l, o, b, t, r;
   # new code -- without `all` option
 
   n:=Length(dom);
-  if n>20 and ForAll(dom,x->IsSubset(G,x))
-    and NrMovedPoints(G)>1000 then
+  sub:=ForAll(dom,x->IsSubset(G,x));
+  if n>20 and sub and NrMovedPoints(G)>1000 then
     #and NrMovedPoints(G)*1000>Size(G) then
 
     b:=SmallerDegreePermutationRepresentation(G:cheap);
@@ -476,6 +476,8 @@ local n,l, o, b, t, r;
       return dom;
     fi;
   fi;
+
+  if not sub then TryNextMethod();fi;
 
   l:=ClusterConjugacyPermgroups(G,ShallowCopy(dom));
   l:=RefineClusterConjugacyPermgroups(l);

--- a/lib/pcgsind.gd
+++ b/lib/pcgsind.gd
@@ -136,6 +136,9 @@ DeclareOperation( "InducedPcgsByGeneratorsNC", [ IsPcgs, IsCollection ] );
 ##  <ManSection>
 ##  <Oper Name="InducedPcgsByGeneratorsWithImages" Arg='pcgs, gens, imgs'/>
 ##
+##  The option `abeliandomain` can be used to avoid a test for the group to
+##  be abelian (which can be costly if the group has hundreds of generators).
+##
 ##  <Description>
 ##  </Description>
 ##  </ManSection>

--- a/lib/pcgsind.gi
+++ b/lib/pcgsind.gi
@@ -458,7 +458,11 @@ function( pcgs, gens, imgs )
     if gens = AsList( pcgs ) then return [pcgs, imgs]; fi;
 
     #catch special case: abelian
-    nonab:=not IsAbelian(Group(pcgs,OneOfPcgs(pcgs)));
+    f:=ValueOption("abeliandomain");
+    if not (f in [true,false]) then
+      f:=IsAbelian(Group(pcgs,OneOfPcgs(pcgs)));
+    fi;
+    nonab:=not f;
 
     # get relative orders and composition length
     ro  := RelativeOrders(pcgs);

--- a/tst/testbugfix/2024-05-24-Cluster.tst
+++ b/tst/testbugfix/2024-05-24-Cluster.tst
@@ -1,0 +1,3 @@
+# Fix #5717
+gap> g := TransitiveGroup(12,288);;
+gap> ConjugacyClassesSubgroups(g);;


### PR DESCRIPTION
Special permgroup method for multiple conjugation tests in `SubgroupsOrbitsAndNormalizers` only applies if the groups are subgroups of the acting one. This fixes #5717
Included is a hook to shortcut a test for a subgroup being abelian in `InducedPcgsByGeneratorsNC` -- this is relevant for an application with multiple 100s of generators.