### PR TITLE
Fix handling of order 2 generators in MTC

### DIFF
--- a/lib/sgpres.gi
+++ b/lib/sgpres.gi
@@ -2978,6 +2978,10 @@ local m,offset,rels,ri,ccr,i,r,ct,A,a,w,n,DATA,p,dr,
   for i in ri do
     r:=i;
     while not r in ccr[offset+r[1]] do
+      # replace order 2 gens
+      for j in [1..Length(r)] do
+        if -r[j] in ordertwo then r[j]:=-r[j];fi;
+      od;
       AddSet(ccr[offset+r[1]],Immutable(r));
       r:=Concatenation(r{[2..Length(r)]},r{[1]});
     od;
@@ -3191,8 +3195,11 @@ local m,offset,rels,ri,ccr,i,r,ct,A,a,w,n,DATA,p,dr,
     i:=i+1;
   od;
 
+
   NEWTC_Compress(DATA,true); # always compress at the end
   DATA.index:=DATA.n;
+
+  Info(InfoFpGroup,3,"found index ",DATA.index);
 
   if Length(collapse)>0 then
     Info(InfoFpGroup,3,DATA.defcount," definitions");
@@ -3242,6 +3249,7 @@ local freegens,freerels,subgens,aug,trace,e,ldc,up,bastime,start,bl,bw,first,tim
     trace:=arg[5];
   fi;
   start:=timerFunc();
+
   if aug and trace=false then
     e:=NEWTC_DoCosetEnum(freegens,freerels,subgens,aug,trace);
     if e=fail then return fail;fi;

--- a/tst/testbugfix/2024-06-17-MTC.tst
+++ b/tst/testbugfix/2024-06-17-MTC.tst
@@ -1,0 +1,5 @@
+# Fix #5744
+gap> f := FreeGroup("a","b");;
+gap> g := f / [ f.1*f.1,f.1*f.2*f.1*f.2*f.1*f.2,f.1*f.2*f.2*f.1*f.2^-1 ];;
+gap> Size(g);
+1


### PR DESCRIPTION
When the MT detects that generators must be of order 2, it avoids the inverse column. This however means that all ocurrences of the inverse generator in the conjugate relators also need to be replaced with the positive powers.

This fixes #5744

## Text for release notes

An error in the MTC for subgroups of finitely presented groups, in which generators of order 2 were not properly handled, was corrected. It could have led to wrong results.