### PR TITLE
Add CHARS_ALPHA and _StripEscapeSequences

### DIFF
--- a/dev/releases/HelpLinks-to-JSON.g
+++ b/dev/releases/HelpLinks-to-JSON.g
@@ -65,7 +65,7 @@ for x in NamesOfComponents(HELP_BOOKS_INFO) do
 
   for i in [1 .. Length(book.entries)] do
     entry := HELP_BOOK_HANDLER.HelpDataRef(book, i);
-    name := StripEscapeSequences(entry[1]);
+    name := _StripEscapeSequences(entry[1]);
     name := ReplacedString(name, match, "");
     NormalizeWhitespace(name);
 

--- a/hpcgap/lib/helpbase.gi
+++ b/hpcgap/lib/helpbase.gi
@@ -55,11 +55,6 @@ end);
 ##  This utility will first be used in some debug tools showing what is newly
 ##  installed by loading a package. Can be documented if desired.
 ##
-# avoid warning for vars from GAPDoc package
-if not IsBound(StripEscapeSequences) then
-  StripEscapeSequences := 0;
-fi;
-
 BindGlobal( "IsDocumentedWord", function( arg )
   local inid, word, case, simple, cword, book, matches, a, match;
 
@@ -76,7 +71,7 @@ BindGlobal( "IsDocumentedWord", function( arg )
   for book in HELP_KNOWN_BOOKS[1] do
     matches:= HELP_GET_MATCHES( [ book ], simple, true );
     for a in Concatenation( matches ) do
-      match:= case( StripEscapeSequences( a[1].entries[ a[2] ][1] ) );
+      match:= case( _StripEscapeSequences( a[1].entries[ a[2] ][1] ) );
       if cword in SplitString( match, "", Difference( match, inid ) ) then
         return true;
       fi;
@@ -285,7 +280,7 @@ for pair in TRANSATL do
   for book in HELP_KNOWN_BOOKS[1] do
     matches:= HELP_GET_MATCHES( [ book ], word, false );
     for a in Concatenation( matches ) do
-      match:= StripEscapeSequences( a[1].entries[ a[2] ][1] );
+      match:= _StripEscapeSequences( a[1].entries[ a[2] ][1] );
       patterns:=[];
       for i in [1..Length(TRANSATL)] do
         patterns[i]:=[];
@@ -314,10 +309,6 @@ od;
 return report;
 od; # end atomic
 end);
-
-if StripEscapeSequences = 0 then
-  Unbind(StripEscapeSequences);
-fi;
 
 
 #############################################################################
@@ -1061,9 +1052,6 @@ end);
 if not IsBound( InitialSubstringUTF8String ) then
   InitialSubstringUTF8String:= "dummy";
 fi;
-if not IsBound( LETTERS ) then
-  LETTERS:= "dummy";
-fi;
 if not IsBound( WidthUTF8String ) then
   WidthUTF8String:= "dummy";
 fi;
@@ -1094,7 +1082,7 @@ BindGlobal( "InitialSubstringUTF8Text", function( str, cols )
       fi;
       # Now pos points at an ESC character; all escape sequences we
       # support are terminated by a letter, so search for one.
-      j:= PositionProperty( str, c -> c in LETTERS, pos );
+      j:= PositionProperty( str, c -> c in CHARS_ALPHA, pos );
       if j = fail then
         Error( "string end inside escape sequence" );
       fi;
@@ -1105,9 +1093,6 @@ end );
 
 if not IsReadOnlyGlobal( "InitialSubstringUTF8String" ) then
   Unbind( InitialSubstringUTF8String );
-fi;
-if not IsReadOnlyGlobal( "LETTERS" ) then
-  Unbind( LETTERS );
 fi;
 if not IsReadOnlyGlobal( "WidthUTF8String" ) then
   Unbind( WidthUTF8String );

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -794,16 +794,6 @@ end );
 ##
 DeclareGlobalFunction( "Edit" );
 
-# the character set definitions might be needed when processing files, thus
-# they must come earlier.
-BIND_GLOBAL("CHARS_DIGITS",Immutable(SSortedList("0123456789")));
-BIND_GLOBAL("CHARS_UALPHA",
-  Immutable(SSortedList("ABCDEFGHIJKLMNOPQRSTUVWXYZ")));
-BIND_GLOBAL("CHARS_LALPHA",
-  Immutable(SSortedList("abcdefghijklmnopqrstuvwxyz")));
-BIND_GLOBAL("CHARS_SYMBOLS",Immutable(SSortedList(
-  " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")));
-
 
 ##  <#GAPDoc Label="HexSHA256">
 ##  <ManSection>

--- a/lib/helpbase.gi
+++ b/lib/helpbase.gi
@@ -55,11 +55,6 @@ end);
 ##  This utility will first be used in some debug tools showing what is newly
 ##  installed by loading a package. Can be documented if desired.
 ##
-# avoid warning for vars from GAPDoc package
-if not IsBound(StripEscapeSequences) then
-  StripEscapeSequences := 0;
-fi;
-
 BindGlobal( "IsDocumentedWord", function( arg )
   local inid, word, case, simple, cword, book, matches, a, match;
 
@@ -75,7 +70,7 @@ BindGlobal( "IsDocumentedWord", function( arg )
   for book in HELP_KNOWN_BOOKS[1] do
     matches:= HELP_GET_MATCHES( [ book ], simple, true );
     for a in Concatenation( matches ) do
-      match:= case( StripEscapeSequences( a[1].entries[ a[2] ][1] ) );
+      match:= case( _StripEscapeSequences( a[1].entries[ a[2] ][1] ) );
       if cword in SplitString( match, "", Difference( match, inid ) ) then
         return true;
       fi;
@@ -279,7 +274,7 @@ for pair in TRANSATL do
   for book in HELP_KNOWN_BOOKS[1] do
     matches:= HELP_GET_MATCHES( [ book ], word, false );
     for a in Concatenation( matches ) do
-      match:= StripEscapeSequences( a[1].entries[ a[2] ][1] );
+      match:= _StripEscapeSequences( a[1].entries[ a[2] ][1] );
       patterns:=[];
       for i in [1..Length(TRANSATL)] do
         patterns[i]:=[];
@@ -307,10 +302,6 @@ for pair in TRANSATL do
 od;
 return report;
 end);
-
-if StripEscapeSequences = 0 then
-  Unbind(StripEscapeSequences);
-fi;
 
 
 #############################################################################
@@ -1037,9 +1028,6 @@ end);
 if not IsBound( InitialSubstringUTF8String ) then
   InitialSubstringUTF8String:= "dummy";
 fi;
-if not IsBound( LETTERS ) then
-  LETTERS:= "dummy";
-fi;
 if not IsBound( WidthUTF8String ) then
   WidthUTF8String:= "dummy";
 fi;
@@ -1070,7 +1058,7 @@ BindGlobal( "InitialSubstringUTF8Text", function( str, cols )
       fi;
       # Now pos points at an ESC character; all escape sequences we
       # support are terminated by a letter, so search for one.
-      j:= PositionProperty( str, c -> c in LETTERS, pos );
+      j:= PositionProperty( str, c -> c in CHARS_ALPHA, pos );
       if j = fail then
         Error( "string end inside escape sequence" );
       fi;
@@ -1081,9 +1069,6 @@ end );
 
 if not IsReadOnlyGlobal( "InitialSubstringUTF8String" ) then
   Unbind( InitialSubstringUTF8String );
-fi;
-if not IsReadOnlyGlobal( "LETTERS" ) then
-  Unbind( LETTERS );
 fi;
 if not IsReadOnlyGlobal( "WidthUTF8String" ) then
   Unbind( WidthUTF8String );

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2086,10 +2086,6 @@ InstallGlobalFunction( AutoloadPackages, function()
 ##
 #F  GAPDocManualLab(<pkgname>) . create manual.lab for package w/ GAPDoc docs
 ##
-# avoid warning (will be def. in GAPDoc)
-if not IsBound(StripEscapeSequences) then
-  StripEscapeSequences := 0;
-fi;
 InstallGlobalFunction( GAPDocManualLabFromSixFile,
     function( bookname, sixfilepath )
     local stream, entries, SecNumber, esctex, file;
@@ -2112,7 +2108,7 @@ InstallGlobalFunction( GAPDocManualLabFromSixFile,
 
     # throw away TeX critical characters here
     esctex:= function( str )
-      return Filtered( StripEscapeSequences( str ), c -> not c in "%#$&^_~" );
+      return Filtered( _StripEscapeSequences( str ), c -> not c in "%#$&^_~" );
     end;
 
     bookname:= LowercaseString( bookname );
@@ -2160,9 +2156,6 @@ InstallGlobalFunction( GAPDocManualLab, function(pkgname)
     GAPDocManualLabFromSixFile( book.BookName, file );
   od;
 end );
-if StripEscapeSequences = 0 then
-  Unbind(StripEscapeSequences);
-fi;
 
 
 #############################################################################

--- a/lib/profile.g
+++ b/lib/profile.g
@@ -778,7 +778,7 @@ BIND_GLOBAL("ProfileOperationsOff",function()
     UnprofileMethods(\+,\-,\*,\/,\^,\mod,\<,\=,\in,
                      \.,\.\:\=,IsBound\.,Unbind\.,
                      \[\],\[\]\:\=,IsBound\[\],Unbind\[\]);
-#T Why?  These operations are listed in PFOFILED_OPERATIONS!
+#T Why?  These operations are listed in PROFILED_OPERATIONS!
 end);
 
 BIND_GLOBAL("ProfileOperations",function( arg )
@@ -836,7 +836,7 @@ BIND_GLOBAL("ProfileOperationsAndMethodsOn",function()
     ProfileMethods(\+,\-,\*,\/,\^,\mod,\<,\=,\in,
                      \.,\.\:\=,IsBound\.,Unbind\.,
                      \[\],\[\]\:\=,IsBound\[\],Unbind\[\]);
-#T Why?  These operations are listed in PFOFILED_OPERATIONS!
+#T Why?  These operations are listed in PROFILED_OPERATIONS!
 end);
 
 ProfileOperationsAndMethodsOff := ProfileOperationsOff;

--- a/lib/string.g
+++ b/lib/string.g
@@ -349,3 +349,70 @@ BIND_GLOBAL("UserHomeExpand", function(str)
     return str;
   fi;
 end);
+
+
+# the character set definitions might be needed when processing files, thus
+# they must come earlier.
+BIND_GLOBAL("CHARS_DIGITS",MakeImmutable(LIST_SORTED_LIST("0123456789")));
+BIND_GLOBAL("CHARS_UALPHA",
+  MakeImmutable(LIST_SORTED_LIST("ABCDEFGHIJKLMNOPQRSTUVWXYZ")));
+BIND_GLOBAL("CHARS_LALPHA",
+  MakeImmutable(LIST_SORTED_LIST("abcdefghijklmnopqrstuvwxyz")));
+BIND_GLOBAL("CHARS_ALPHA",
+  MakeImmutable(LIST_SORTED_LIST("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")));
+BIND_GLOBAL("CHARS_SYMBOLS",
+  MakeImmutable(LIST_SORTED_LIST(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")));
+
+
+#############################################################################
+##
+#F  _StripEscapeSequences( <str> ) . . . . . remove escape sequences from str
+##
+##  <#GAPDoc Label="_StripEscapeSequences">
+##  <ManSection >
+##  <Func Arg="str" Name="_StripEscapeSequences" />
+##  <Returns>string without escape sequences</Returns>
+##  <Description>
+##  This function returns the string one gets from the string <A>str</A> by
+##  removing all escape sequences. If <A>str</A> does not contain such a
+##  sequence then <A>str</A> itself is returned.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+BIND_GLOBAL("_StripEscapeSequences", function(str)
+  local   esc,  res,  i,  ls,  p;
+  esc := CHAR_INT(27);
+  res := "";
+  i := 1;
+  ls := Length(str);
+  while i <= ls do
+    if str[i] = esc then
+      i := i+1;
+      while not str[i] in CHARS_ALPHA do
+        i := i+1;
+      od;
+      # first letter is last character of escape sequence
+      i := i+1;
+      # remove \027 marker of inner escape sequences as well
+      if IsBound(str[i]) and str[i] = '\027' then
+        i := i+1;
+      fi;
+    else
+      p := Position(str, esc, i);
+      if p=fail then
+        if i=1 then
+          # don't copy if no escape there
+          return str;
+        else
+          Append(res, str{[i..ls]});
+          return res;
+        fi;
+      else
+        Append(res, str{[i..p-1]});
+        i := p;
+      fi;
+    fi;
+  od;
+  return res;
+end);

--- a/lib/string.gi
+++ b/lib/string.gi
@@ -40,8 +40,7 @@ InstallGlobalFunction(IsLowerAlphaChar,x->x in CHARS_LALPHA);
 ##
 #F  IsAlphaChar(<c>)
 ##
-InstallGlobalFunction(IsAlphaChar,
-  x->x in CHARS_LALPHA or x in CHARS_UALPHA);
+InstallGlobalFunction(IsAlphaChar,x->x in CHARS_ALPHA);
 
 
 #############################################################################

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -421,7 +421,7 @@ static void FindLiveRangeReverse(PtrArray * arr, void * start, void * end)
 {
     // HACK: the following deals with stacks of 'negative size' exposed by
     // Julia -- however, despite us having this code in here for a few years,
-    // I know think it may actually be due to a bug on the Julia side. See
+    // I now think it may actually be due to a bug on the Julia side. See
     // <https://github.com/JuliaLang/julia/pull/54639> for details.
     if (lt_ptr(end, start)) {
         SWAP(void *, start, end);

--- a/tst/delegation.g
+++ b/tst/delegation.g
@@ -53,9 +53,9 @@ for pos in [1..Length(rules)] do
         while true do
           n := POSITION_SUBSTRING(str, r, n);
           if n = fail then break; fi;
-          if n > 1 and str[n-1] in LETTERS then continue; fi;
+          if n > 1 and str[n-1] in CHARS_ALPHA then continue; fi;
           if Length(str) >= n + Length(r) then
-            if not str[n + Length(r)] in LETTERS then
+            if not str[n + Length(r)] in CHARS_ALPHA then
               Add( illegal_delegations, r );
               break;
             fi;

--- a/tst/teststandard/varnames.tst
+++ b/tst/teststandard/varnames.tst
@@ -7,7 +7,7 @@ gap> Filtered( NamesSystemGVars(), x -> not x in ALL_KEYWORDS() and
 >            ( Length(x)=1 or (IsLowerAlphaChar(x[1]) and Length(x) < 5) ) );
 [ "*", "+", "-", ".", "/", "<", "=", "E", "X", "Z", "^", "fail", "last", 
   "time" ]
-gap> Filtered(NamesSystemGVars(),name->IsSubset(LETTERS,name));;
+gap> Filtered(NamesSystemGVars(),name->IsSubset(CHARS_ALPHA,name));;
 gap> IsSubset(IDENTS_GVAR(), IDENTS_BOUND_GVARS() );
 true
 gap> E;


### PR DESCRIPTION
Removes the need for using LETTERS and StripEscapeSequences from GAPDoc in the library.

The code from `_StripEscapeSequences` is copied from GAPDoc with trivial modifications.

Also fix a few unrelated typos in comments