### PR TITLE
Fix year for GAP release in output of `Cite()`

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2785,10 +2785,10 @@ InstallGlobalFunction( BibEntry, function( arg )
       if Length( val ) = 3 then
         if Int( val[2] ) in [ 1 .. 12 ] then
           val:= Concatenation( "  <month>", months[ Int( val[2] ) ],
-                               "</month>\n  <year>", val[3], "</year>\n" );
+                               "</month>\n  <year>", val[1], "</year>\n" );
         else
           val:= Concatenation( "  <month>", val[2],
-                               "</month>\n  <year>", val[3], "</year>\n" );
+                               "</month>\n  <year>", val[1], "</year>\n" );
         fi;
       else
         val:= "";


### PR DESCRIPTION
Resolves https://github.com/gap-system/gap/issues/5755 as suggested by https://github.com/olexandr-konovalov in https://github.com/gap-system/gap/issues/5755#issuecomment-2182718059.

## Text for release notes

see title
