### PR TITLE
Add test for `GAPInfo.Date` format

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2785,10 +2785,10 @@ InstallGlobalFunction( BibEntry, function( arg )
       if Length( val ) = 3 then
         if Int( val[2] ) in [ 1 .. 12 ] then
           val:= Concatenation( "  <month>", months[ Int( val[2] ) ],
-                               "</month>\n  <year>", val[3], "</year>\n" );
+                               "</month>\n  <year>", val[1], "</year>\n" );
         else
           val:= Concatenation( "  <month>", val[2],
-                               "</month>\n  <year>", val[3], "</year>\n" );
+                               "</month>\n  <year>", val[1], "</year>\n" );
         fi;
       else
         val:= "";

--- a/src/version.c.in
+++ b/src/version.c.in
@@ -26,7 +26,7 @@ const char * SyKernelVersion = "@GAP_VERSION@";
 **
 *V  SyReleaseDay . . . . . . . . . . . . . . release date of this GAP version
 **
-**  'SyReleaseDay' is the date of the release, e.g. "19-Jun-2019"; for
+**  'SyReleaseDay' is the date of the release, e.g. "2019-Jun-19"; for
 **  development versions, this is set to "today".
 */
 const char * SyReleaseDay = "@GAP_RELEASEDAY@";

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -77,7 +77,7 @@ extern const char * SyKernelVersion;
 **
 *V  SyReleaseDay . . . . . . . . . . . . . . release date of this GAP version
 **
-**  'SyReleaseDay' is the date of the release, e.g. "19-Jun-2019"; for
+**  'SyReleaseDay' is the date of the release, e.g. "2019-Jun-19"; for
 **  development versions, this is set to "today".
 */
 extern const char * SyReleaseDay;

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -1,4 +1,4 @@
-#@local entry,equ,pair,sml,oldTermEncoding,pkginfo,info,tmp_dir,mockpkgpath,old_warning_level,p,n,filename
+#@local entry,equ,pair,sml,oldTermEncoding,pkginfo,info,tmp_dir,mockpkgpath,old_warning_level,p,n,filename,IsDateFormatValid
 gap> START_TEST("package.tst");
 
 # CompareVersionNumbers( <supplied>, <required>[, \"equal\"] )
@@ -515,6 +515,23 @@ new methods:
   mockpkg_Operation( G, n )*
   mockpkg_Property( ... )*
 
+
+# Cite() expects GAPInfo.Date to be of the form "YYYY-MM-DD" or "YYYY-Mon-DD" (or "today")
+gap> IsDateFormatValid := function( datestring )
+>      local months, val;
+>      if datestring = "today" then
+>        return true;
+>      fi;
+>      val:= SplitString( datestring, "-" );
+>      if Length( val ) <> 3 then
+>        return false;
+>      fi;
+>      months:= [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+>                       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ];
+>      return Int( val[1] ) in [ 1900 .. 2100 ] and ( val[2] in months or Int( val[2] ) in [ 1 .. 12 ] ) and Int( val[3] ) in [ 1 .. 31 ];
+>    end;;
+gap> IsDateFormatValid( GAPInfo.Date );
+true
 
 # Test the Cite() command (output changed with GAPDoc 1.6.6 and again with 1.6.7)
 #@if CompareVersionNumbers(InstalledPackageVersion("gapdoc"), "1.6.7")


### PR DESCRIPTION
Follow-up to https://github.com/gap-system/gap/pull/5756 as suggested by @ThomasBreuer.

The test accepts the following variants for today's day: "today", "2024-06-25", "2024-Jun-25", as these are the formats that `Cite()` can work with.

## Text for release notes

none
