### PR TITLE
Fix `Testing` section in dev guidelines

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -156,14 +156,12 @@ multiple parts.
 - `testinstall`: quick test suite that one can test frequently.
    Run via  `./gap tst/testinstall.g`
 - `teststandard`: slower but more comprehensive test suite.
-   Run via  `./gap tst/testinstall.g`
+   Run via  `./gap tst/teststandard.g`
 - `testextra`: very slow test suite that tests even more
    Run via  `./gap tst/testextra.g`
 - `testbugfix`: additional small test files that are created to verify
    specific bugfixes work as intended
    Run via  `./gap tst/testbugfix.g`
-- `testinstall`: quick test suite that one can test frequently.
-   Run via  `./gap tst/testinstall.g`
 
 
 ## Tracking down regressions


### PR DESCRIPTION
When looking up how to run tests locally, I noticed some duplication in the developer guidelines concerning testing. This gets fixed by this PR.

## Text for release notes

none
