### PR TITLE
ReadPackage now prints warning if file is missing / cannot be read

### DIFF
--- a/lib/package.gd
+++ b/lib/package.gd
@@ -688,7 +688,8 @@ DeclareGlobalFunction( "DirectoriesPackageLibrary" );
 ##  package to be loaded.)
 ##  <P/>
 ##  If the file is readable then <K>true</K> is returned,
-##  otherwise <K>false</K>.
+##  otherwise a warning is displayed (for <Ref Func="ReadPackage"/>)
+##  or <K>false</K> is returned (for <Ref Func="RereadPackage"/>).
 ##  <P/>
 ##  Each of <A>name</A> and <A>file</A> should be a string.
 ##  The <A>name</A> argument is case insensitive.


### PR DESCRIPTION
Resolves #5745 but unfortunately can't be merged as-is because it turns out several packages read files that don't exist... But I didn't want to loose these changes, so here they are as a PR anyway. (In fact I modified this PR to only print a warning instead of just erroring out

How to proceed? Some options:
1. we update all affected packages to not do this anymore, then once they are all updated in the package distro, we merge this but with the error turned into a warning
2. same as 1, but we keep the warning as a warning (possibly using `InfoWarning` ?)
3. some clever alternative I can't think of right now...