### PR TITLE
added a sentence to the ref manual subsection on direct sums of algebras

### DIFF
--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -581,6 +581,10 @@ DeclareOperation( "ProductSpace", [ IsFreeLeftModule, IsFreeLeftModule ] );
 ##  If all involved algebras are matrix algebras, and either both are Lie
 ##  algebras or both are associative then the result is again a
 ##  matrix algebra of the appropriate type.
+##  <P/>
+##  Experimental methods for <C>Embedding</C> and <C>Projection</C>
+##  for direct sums of algebras are included in version 1.26 of package
+##  <Package>XModAlg</Package>.
 ##  <Example><![CDATA[
 ##  gap> A:= QuaternionAlgebra( Rationals );;
 ##  gap> DirectSumOfAlgebras( [A, A, A] );


### PR DESCRIPTION
This PR just adds the following sentence to section 62.9.14 of the reference manual:  "Experimental methods for Embedding and Projection for direct sums of algebras are included in version 1.26 of package XModAlg."
The purpose of this PR is really to get some feedback.  
The XModAlg package may well not be the best place for these methods, and the 3 obvious options are:
(1)  to leave these developments in the XModAlg package;
(2)  to move them to the Utils package;
(3)  to move them into the main library, where other adjustments could then be made.
They have been added to XModAlg to be used when constructing actions on direct sums of algebras and direct sums of crossed modules of algebras.  The full set of declarations/methods not specific to XModAlg is [ DirectSumOfAlgebrasInfo, Embedding, Projection, DirectSumOfAlgebraHomomorphisms ].
Advice, suggestions, etc. most welcome!