### PR TITLE
Introduce square brackets as an alternative syntax for sublist access

### DIFF
--- a/lib/list.gd
+++ b/lib/list.gd
@@ -254,6 +254,10 @@ DeclareOperationKernel( "{}",
     [ IsList, IsList ],
     ELMS_LIST );
 
+InstallOtherMethod( \[\],
+    [ IsList, IsList ],
+    ELMS_LIST );
+
 
 #############################################################################
 ##


### PR DESCRIPTION
This makes it easier to share code between GAP and Julia, for example:
```
gap> ["a", "b", "c"][[3, 1]];
[ "c", "a" ]
```

```
julia> ["a", "b", "c"][[3, 1]]
2-element Vector{String}:
 "c"
 "a"
```

I post this as a draft because I expect this to be controversial. If the change is welcome, I will of course add documentation and tests :-)

## Text for release notes

see title