### PR TITLE
`ValidatePackageInfo`: suppress `Print` output if requested

### DIFF
--- a/lib/package.gd
+++ b/lib/package.gd
@@ -1066,7 +1066,7 @@ DeclareGlobalFunction( "DeclareAutoreadableVariables" );
 ##  respectively, has correct format, and <K>false</K> otherwise;
 ##  in the latter case information about the incorrect components is printed.
 ##  These diagnostic messages can be suppressed by setting the global option
-##  <C>verbose</C> to <K>false</K>.
+##  <C>quiet</C> to <K>true</K>.
 ##  <P/>
 ##  Note that the components used for package loading are checked as well as
 ##  the components that are needed for composing the package overview web

--- a/lib/package.gd
+++ b/lib/package.gd
@@ -1065,6 +1065,8 @@ DeclareGlobalFunction( "DeclareAutoreadableVariables" );
 ##  The result is <K>true</K> if the record or the contents of the file,
 ##  respectively, has correct format, and <K>false</K> otherwise;
 ##  in the latter case information about the incorrect components is printed.
+##  These diagnostic messages can be suppressed by setting the global option
+##  <C>verbose</C> to <K>false</K>.
 ##  <P/>
 ##  Note that the components used for package loading are checked as well as
 ##  the components that are needed for composing the package overview web

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2234,7 +2234,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
 
     TestOption:= function( record, name, type, typename )
     if IsBound( record.( name ) ) and not type( record.( name ) ) then
-      if ValueOption( "verbose" ) <> false then
+      if ValueOption( "quiet" ) <> true then
         Print( "#E  component `", name, "', if present, must be bound to ",
                typename, "\n" );
       fi;
@@ -2246,7 +2246,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
 
     TestMandat:= function( record, name, type, typename )
     if not IsBound( record.( name ) ) or not type( record.( name ) ) then
-      if ValueOption( "verbose" ) <> false then
+      if ValueOption( "quiet" ) <> true then
         Print( "#E  component `", name, "' must be bound to ",
                typename, "\n" );
       fi;
@@ -2307,7 +2307,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                  IsBound(record.BinaryFiles),
                  IsBound(record.TextBinaryFilesPatterns) ],
                a -> a=true ) > 1 then
-      if ValueOption( "verbose" ) <> false then
+      if ValueOption( "quiet" ) <> true then
         Print("#W  only one of TextFiles, BinaryFiles or TextBinaryFilesPatterns\n");
         Print("#W  components must be bound\n");
       fi;
@@ -2319,7 +2319,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
         TestMandat( subrec, "FirstNames", IsString, "a string" );
         if not (    IsBound( subrec.IsAuthor )
                  or IsBound( subrec.IsMaintainer ) ) then
-          if ValueOption( "verbose" ) <> false then
+          if ValueOption( "quiet" ) <> true then
             Print( "#E  one of the components `IsAuthor', `IsMaintainer' ",
                    "must be bound\n" );
           fi;
@@ -2333,7 +2333,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                not ( IsBound( subrec.Email ) or
                      IsBound( subrec.WWWHome ) or
                      IsBound( subrec.PostalAddress ) ) then
-            if ValueOption( "verbose" ) <> false then
+            if ValueOption( "quiet" ) <> true then
               Print( "#E  one of the components `Email', `WWWHome', `PostalAddress'\n",
                      "#E  must be bound for each package maintainer\n" );
             fi;
@@ -2371,7 +2371,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
       fi;
       for subrec in list do
         TestMandat( subrec, "BookName", IsString, "a string" );
-        if IsBound(subrec.Archive) and ValueOption( "verbose" ) <> false then
+        if IsBound(subrec.Archive) and ValueOption( "quiet" ) <> true then
           Print("#W  PackageDoc.Archive is withdrawn, use PackageDoc.ArchiveURLSubset instead\n");
         fi;
         TestMandat( subrec, "ArchiveURLSubset", IsFilenameList,
@@ -2418,7 +2418,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                               and IsString( x[1] )
                               and not LowercaseString( x[1] ) in list );
         if not IsEmpty( list ) then
-          if ValueOption( "verbose" ) <> false then
+          if ValueOption( "quiet" ) <> true then
             Print( "#E  the needed packages in '",
                    List( list, x -> x[1] ), "'\n",
                    "#E  are currently not needed packages of GAP\n" );

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2234,8 +2234,10 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
 
     TestOption:= function( record, name, type, typename )
     if IsBound( record.( name ) ) and not type( record.( name ) ) then
-      Print( "#E  component `", name, "', if present, must be bound to ",
-             typename, "\n" );
+      if ValueOption( "verbose" ) <> false then
+        Print( "#E  component `", name, "', if present, must be bound to ",
+               typename, "\n" );
+      fi;
       result:= false;
       return false;
     fi;
@@ -2244,8 +2246,10 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
 
     TestMandat:= function( record, name, type, typename )
     if not IsBound( record.( name ) ) or not type( record.( name ) ) then
-      Print( "#E  component `", name, "' must be bound to ",
-             typename, "\n" );
+      if ValueOption( "verbose" ) <> false then
+        Print( "#E  component `", name, "' must be bound to ",
+               typename, "\n" );
+      fi;
       result:= false;
       return false;
     fi;
@@ -2303,8 +2307,10 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                  IsBound(record.BinaryFiles),
                  IsBound(record.TextBinaryFilesPatterns) ],
                a -> a=true ) > 1 then
-      Print("#W  only one of TextFiles, BinaryFiles or TextBinaryFilesPatterns\n");
-      Print("#W  components must be bound\n");
+      if ValueOption( "verbose" ) <> false then
+        Print("#W  only one of TextFiles, BinaryFiles or TextBinaryFilesPatterns\n");
+        Print("#W  components must be bound\n");
+      fi;
     fi;
     if     TestOption( record, "Persons", IsRecordList, "a list of records" )
        and IsBound( record.Persons ) then
@@ -2313,8 +2319,10 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
         TestMandat( subrec, "FirstNames", IsString, "a string" );
         if not (    IsBound( subrec.IsAuthor )
                  or IsBound( subrec.IsMaintainer ) ) then
-          Print( "#E  one of the components `IsAuthor', `IsMaintainer' ",
-                 "must be bound\n" );
+          if ValueOption( "verbose" ) <> false then
+            Print( "#E  one of the components `IsAuthor', `IsMaintainer' ",
+                   "must be bound\n" );
+          fi;
           result:= false;
         fi;
         TestOption( subrec, "IsAuthor", IsProperBool, "`true' or `false'" );
@@ -2325,8 +2333,10 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                not ( IsBound( subrec.Email ) or
                      IsBound( subrec.WWWHome ) or
                      IsBound( subrec.PostalAddress ) ) then
-            Print( "#E  one of the components `Email', `WWWHome', `PostalAddress'\n",
-                   "#E  must be bound for each package maintainer \n" );
+            if ValueOption( "verbose" ) <> false then
+              Print( "#E  one of the components `Email', `WWWHome', `PostalAddress'\n",
+                     "#E  must be bound for each package maintainer\n" );
+            fi;
             result:= false;
           fi;
         fi;
@@ -2361,7 +2371,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
       fi;
       for subrec in list do
         TestMandat( subrec, "BookName", IsString, "a string" );
-        if IsBound(subrec.Archive) then
+        if IsBound(subrec.Archive) and ValueOption( "verbose" ) <> false then
           Print("#W  PackageDoc.Archive is withdrawn, use PackageDoc.ArchiveURLSubset instead\n");
         fi;
         TestMandat( subrec, "ArchiveURLSubset", IsFilenameList,
@@ -2408,9 +2418,11 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                               and IsString( x[1] )
                               and not LowercaseString( x[1] ) in list );
         if not IsEmpty( list ) then
-          Print( "#E  the needed packages in '",
-                 List( list, x -> x[1] ), "'\n",
-                 "#E  are currently not needed packages of GAP\n" );
+          if ValueOption( "verbose" ) <> false then
+            Print( "#E  the needed packages in '",
+                   List( list, x -> x[1] ), "'\n",
+                   "#E  are currently not needed packages of GAP\n" );
+          fi;
           result:= false;
         fi;
       fi;

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -219,7 +219,7 @@ ps:// or ftp://
 #E  component `PackageDoc' must be bound to a record or a list of records
 #E  component `AvailabilityTest' must be bound to a function
 false
-gap> ValidatePackageInfo(rec() : verbose:= false);
+gap> ValidatePackageInfo(rec() : quiet);
 false
 gap> info := rec(
 >     PackageName := "pkg",

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -219,6 +219,8 @@ ps:// or ftp://
 #E  component `PackageDoc' must be bound to a record or a list of records
 #E  component `AvailabilityTest' must be bound to a function
 false
+gap> ValidatePackageInfo(rec() : verbose:= false);
+false
 gap> info := rec(
 >     PackageName := "pkg",
 >     Subtitle := "desc",


### PR DESCRIPTION
`ValidatePackageInfo` is called programmatically by the PackageManager package.
In this situation, we do not want to show the diagnostic output.