### PR TITLE
BUILD: set install_name for libgap on macOS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -447,6 +447,7 @@ else ifneq (,$(findstring darwin,$(host_os)))
   LINK_SHLIB_FLAGS += -compatibility_version $(LIBGAP_COMPAT_VER)
   LINK_SHLIB_FLAGS += -current_version $(LIBGAP_CURRENT_VER)
   LINK_SHLIB_FLAGS += -Wl,-single_module
+  LINK_SHLIB_FLAGS += -headerpad_max_install_names
 
   GAP_CPPFLAGS += -DPIC
   GAP_CFLAGS += -fno-common

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -465,7 +465,7 @@ else
 endif
 
 ifneq (,$(findstring darwin,$(host_os)))
-INSTALL_NAME_TOOL = install_name_tool
+INSTALL_NAME_TOOL = @install_name_tool
 else
 INSTALL_NAME_TOOL = @echo > /dev/null
 endif

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -448,9 +448,6 @@ else ifneq (,$(findstring darwin,$(host_os)))
   LINK_SHLIB_FLAGS += -current_version $(LIBGAP_CURRENT_VER)
   LINK_SHLIB_FLAGS += -Wl,-single_module
 
-  # TODO: set install_name, at least for installed version of the lib?
-  #LINK_SHLIB_FLAGS += -install_name $(libdir)/$(LIBGAP_FULL)
-
   GAP_CPPFLAGS += -DPIC
   GAP_CFLAGS += -fno-common
   GAP_CXXFLAGS += -fno-common
@@ -516,6 +513,7 @@ build/main.c: src/main.c
 # build rule for the gap executable used by the `install-bin` target
 build/gap-install: libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS build/obj/build/main.c.o
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) build/obj/build/main.c.o $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
+	@install_name_tool -change $(LIBGAP_FULL) $(libdir)/$(LIBGAP_FULL) $@
 
 endif
 
@@ -687,6 +685,7 @@ install-libgap: $(LIBGAP_FULL) libgap.pc
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)
 	$(INSTALL) -m 0644 $(LIBGAP_FULL) $(DESTDIR)$(libdir)
 	ln -sf $(LIBGAP_FULL) $(DESTDIR)$(libdir)/libgap$(SHLIB_EXT)
+	install_name_tool -id $(libdir)/$(LIBGAP_FULL) $(DESTDIR)$(libdir)/$(LIBGAP_FULL)
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL) -m 0644 libgap.pc $(DESTDIR)$(libdir)/pkgconfig
 

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -464,6 +464,12 @@ else
   GAP_LDFLAGS += -Wl,--export-dynamic
 endif
 
+ifneq (,$(findstring darwin,$(host_os)))
+INSTALL_NAME_TOOL = install_name_tool
+else
+INSTALL_NAME_TOOL = @echo > /dev/null
+endif
+
 libgap: libgap$(SHLIB_EXT) $(LIBGAP_FULL)
 .PHONY: libgap
 
@@ -513,7 +519,7 @@ build/main.c: src/main.c
 # build rule for the gap executable used by the `install-bin` target
 build/gap-install: libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS build/obj/build/main.c.o
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) build/obj/build/main.c.o $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
-	@install_name_tool -change $(LIBGAP_FULL) $(libdir)/$(LIBGAP_FULL) $@
+	$(INSTALL_NAME_TOOL) -change $(LIBGAP_FULL) $(libdir)/$(LIBGAP_FULL) $@
 
 endif
 
@@ -685,7 +691,7 @@ install-libgap: $(LIBGAP_FULL) libgap.pc
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)
 	$(INSTALL) -m 0644 $(LIBGAP_FULL) $(DESTDIR)$(libdir)
 	ln -sf $(LIBGAP_FULL) $(DESTDIR)$(libdir)/libgap$(SHLIB_EXT)
-	install_name_tool -id $(libdir)/$(LIBGAP_FULL) $(DESTDIR)$(libdir)/$(LIBGAP_FULL)
+	$(INSTALL_NAME_TOOL) -id $(libdir)/$(LIBGAP_FULL) $(DESTDIR)$(libdir)/$(LIBGAP_FULL)
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL) -m 0644 libgap.pc $(DESTDIR)$(libdir)/pkgconfig
 


### PR DESCRIPTION
... but only for the installed version of the library

Alternative to PR #5736
Closes #5736

@mkoeppe I wonder if this also work for you?

Note that I am not yet removing `-single_module`, as I still need to figure out when exactly it became default (if you happen to have any info on this, please let me know). But presumably this is "just" about silencing a warning, so hopefully OK to delay its removal a bit more.