### PR TITLE
let `LoadPackage` collect data

### DIFF
--- a/lib/package.gd
+++ b/lib/package.gd
@@ -303,9 +303,30 @@ DeclareGlobalFunction( "LinearOrderByPartialWeakOrder" );
 ##  <P/>
 ##  The arguments <A>record</A> and <A>suggested</A> are used
 ##  for loading packages, as follows.
+##  <P/>
 ##  The record <A>record</A> collects information about the needed and
 ##  suggested packages of the package <A>name</A>, which allows one to
 ##  compute an appropriate loading order of these packages.
+##  After the call, the value of the component <C>LoadInfo</C> of
+##  <A>record</A> is a record with the components
+##  <List>
+##  <Item>
+##    <C>name</C> (the name of the package),
+##  </Item>
+##  <Item>
+##    <C>comment</C> (a string that is empty or describes why the package
+##    cannot be loaded, independent of the installed version), and
+##  </Item>
+##  <Item>
+##    <C>versions</C> (a list of records, one for each installed version of
+##    the package that has been checked; each such record has the components
+##    <C>version</C>, <C>comment</C>, and <C>dependencies</C>,
+##    where the latter is a list of records for each needed package that was
+##    checked, and each entry has the same format as the <C>LoadInfo</C>
+##    record itself.
+##  </Item>
+##  </List>
+##  <P/>
 ##  Finally, the value of <A>suggested</A> determines whether needed and
 ##  suggested packages are considered (value <K>true</K>) or only needed
 ##  packages (value <K>false</K>);

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -752,8 +752,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
         Append( loadinfo.comment,
                 Concatenation( "package '", name,
                     "' is already loaded, required version ", version,
-                    " is not compatible with the actual version ",
-                    GAPInfo.PackagesLoaded.( name )[2] ) );
+                    " is not compatible with the actual version" ) );
         return false;
       fi;
     fi;

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -712,8 +712,7 @@ fail
 gap> loadinfo;
 rec( 
   comment := "package 'mockpkg' is already loaded, required version =0.0 is no\
-t compatible with the actual version 0.1", name := "mockpkg", 
-  versions := [  ] )
+t compatible with the actual version", name := "mockpkg", versions := [  ] )
 
 # Force "unload" it (see above, we have done this already once).
 gap> Unbind(GAPInfo.PackagesInfo.mockpkg);
@@ -817,9 +816,8 @@ rec( comment := "", name := "mockpkg",
             [ 
               rec( 
                   comment := "package 'gapdoc' is already loaded, required vers\
-ion =0.0 is not compatible with the actual version 1.6.7.dev", 
-                  name := "gapdoc", versions := [  ] ) ], version := "0.1" ) 
-     ] )
+ion =0.0 is not compatible with the actual version", name := "gapdoc", 
+                  versions := [  ] ) ], version := "0.1" ) ] )
 
 # Try to load an unknown package.
 gap> loadinfo:= rec();;

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -729,7 +729,11 @@ gap> SetPackagePath("mockpkg", mockpkgpath);
 
 # Force unavailability of the mock package, for various reasons.
 # Try to load the package into a not admissible GAP version.
-gap> info:= GAPInfo.PackagesInfo.mockpkg[1];;
+gap> GAPInfo.PackagesInfo.mockpkg:= ShallowCopy( GAPInfo.PackagesInfo.mockpkg );;
+gap> info:= GAPInfo.PackagesInfo.mockpkg;;
+gap> info[1]:= ShallowCopy( info[1] );;
+gap> info:= info[1];;
+gap> info.Dependencies:= ShallowCopy( info.Dependencies );;
 gap> info.Dependencies.GAP:= "=0.0";;
 gap> loadinfo:= rec();;
 gap> LoadPackage( "mockpkg" : LoadInfo:= loadinfo );

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -1,4 +1,4 @@
-#@local entry,equ,pair,sml,oldTermEncoding,pkginfo,info,tmp_dir,mockpkgpath,old_warning_level,p,n,filename,IsDateFormatValid
+#@local entry,equ,pair,sml,oldTermEncoding,pkginfo,info,tmp_dir,mockpkgpath,old_warning_level,p,n,filename,IsDateFormatValid,loadinfo
 gap> START_TEST("package.tst");
 
 # CompareVersionNumbers( <supplied>, <required>[, \"equal\"] )
@@ -699,4 +699,136 @@ gap> SetPackagePath( "mockpkg", "/some/other/directory" );
 Error, another version of package mockpkg is already loaded
 
 #
-gap> STOP_TEST( "package.tst", 1);
+# Test collecting information when calling LoadPackage, using the mock package
+#
+gap> SetPackagePath("mockpkg", mockpkgpath);
+gap> old_warning_level := InfoLevel( InfoWarning );;
+gap> SetInfoLevel( InfoWarning, 0 );
+
+# Try to load a different version of the package.
+gap> loadinfo:= rec();;
+gap> LoadPackage( "mockpkg", "=0.0" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( 
+  comment := "package 'mockpkg' is already loaded, required version =0.0 is no\
+t compatible with the actual version 0.1", name := "mockpkg", 
+  versions := [  ] )
+
+# Force "unload" it (see above, we have done this already once).
+gap> Unbind(GAPInfo.PackagesInfo.mockpkg);
+gap> Unbind(GAPInfo.PackagesLoaded.mockpkg);
+gap> for n in [ "mockpkg_GlobalFunction", "mockpkg_Operation", "mockpkg_Attribute", "Setmockpkg_Attribute", "Hasmockpkg_Attribute", "mockpkg_Property", "Setmockpkg_Property", "Hasmockpkg_Property", "mockpkg_ExtensionData" ] do
+>   if IsBoundGlobal(n) then
+>     MakeReadWriteGlobal(n);
+>     UnbindGlobal(n);
+>   fi;
+> od;
+
+# Notify the package again
+gap> SetPackagePath("mockpkg", mockpkgpath);
+
+# Force unavailability of the mock package, for various reasons.
+# Try to load the package into a not admissible GAP version.
+gap> info:= GAPInfo.PackagesInfo.mockpkg[1];;
+gap> info.Dependencies.GAP:= "=0.0";;
+gap> loadinfo:= rec();;
+gap> LoadPackage( "mockpkg" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( comment := "", name := "mockpkg", 
+  versions := 
+    [ rec( comment := "GAP version =0.0 is required, ", dependencies := [  ], 
+          version := "0.1" ) ] )
+gap> Unbind( info.Dependencies.GAP );
+
+# Try again to load the package into a not admissible GAP version.
+gap> info.Dependencies.NeededOtherPackages:= [ [ "GAP", "=0.0" ] ];;
+gap> info.AvailabilityTest:= ReturnTrue;;
+gap> loadinfo:= rec();;
+gap> LoadPackage( "mockpkg" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( comment := "", name := "mockpkg", 
+  versions := 
+    [ 
+      rec( comment := "", 
+          dependencies := 
+            [ 
+              rec( 
+                  comment := "required GAP version =0.0 is not compatible with \
+the actual version", name := "gap", versions := [  ] ) ], version := "0.1" ) 
+     ] )
+gap> info.Dependencies.NeededOtherPackages:= [];;
+
+# Try to load the package with a too restrictive availability test.
+gap> info:= GAPInfo.PackagesInfo.mockpkg[1];;
+gap> info.AvailabilityTest:= ReturnFalse;;
+gap> loadinfo:= rec();;
+gap> LoadPackage( "mockpkg" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( comment := "", name := "mockpkg", 
+  versions := 
+    [ rec( comment := "the AvailabilityTest function returned false, ", 
+          dependencies := [  ], version := "0.1" ) ] )
+gap> info.AvailabilityTest:= ReturnTrue;;
+
+# Try to load the package with not satisfied dependencies.
+gap> GAPInfo.PackagesInfo.mockpkg2:= [
+>      rec( PackageName := "mockpkg2", Version:= "0.0",
+>           AvailabilityTest:= ReturnTrue,
+>           InstallationPath:= GAPInfo.PackagesInfo.gapdoc[1].InstallationPath,
+>           Dependencies:= rec( OtherPackagesLoadedInAdvance:= [ [ "mockpkg", "" ] ] ) ) ];;
+gap> info.Dependencies.OtherPackagesLoadedInAdvance:= [ [ "mockpkg2", "" ] ];;
+gap> loadinfo:= rec();;
+gap> LoadPackage( "mockpkg" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( comment := "", name := "mockpkg", 
+  versions := 
+    [ 
+      rec( 
+          comment := "package 'mockpkg2' shall be loaded before package 'mockpk\
+g' but must be in the same load cycle, due to other dependencies, ", 
+          dependencies := 
+            [ 
+              rec( comment := "", name := "mockpkg2", 
+                  versions := 
+                    [ 
+                      rec( comment := "", 
+                          dependencies := 
+                            [ 
+                              rec( comment := "", name := "mockpkg", 
+                                  versions := [  ] ) ], version := "0.0" ) ] 
+                 ) ], version := "0.1" ) ] )
+gap> Unbind( info.Dependencies.OtherPackagesLoadedInAdvance );
+gap> Unbind( GAPInfo.PackagesInfo.mockpkg2 );
+gap> info.Dependencies.NeededOtherPackages:= [ [ "gapdoc", "=0.0" ] ];;
+gap> loadinfo:= rec();;
+gap> LoadPackage( "mockpkg" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( comment := "", name := "mockpkg", 
+  versions := 
+    [ 
+      rec( comment := "", 
+          dependencies := 
+            [ 
+              rec( 
+                  comment := "package 'gapdoc' is already loaded, required vers\
+ion =0.0 is not compatible with the actual version 1.6.7.dev", 
+                  name := "gapdoc", versions := [  ] ) ], version := "0.1" ) 
+     ] )
+
+# Try to load an unknown package.
+gap> loadinfo:= rec();;
+gap> LoadPackage( "unavailable_package" : LoadInfo:= loadinfo );
+fail
+gap> loadinfo;
+rec( comment := "package is not listed in GAPInfo.PackagesInfo", 
+  name := "unavailable_package" )
+gap> SetInfoLevel( InfoWarning, old_warning_level );
+
+#
+gap> STOP_TEST( "package.tst" );


### PR DESCRIPTION
- add a new component `LoadInfo` to the `record` argument of `PackageAvailabilityInfo`, with value a record that essentially collects the information that is up to now printed via `InfoPackageLoading` messages

- describe the format of the data in the description of `PackageAvailabilityInfo`

- support a global option `LoadInfo` in `LoadPackage`, which sets the given value as the `LoadInfo` component of the `record` argument of `PackageAvailabilityInfo`; this way, one can analyse programmatically why a `LoadPackage` was not sucessful

- add tests

- fix a check whether the prescribed GAP version fits: Up to now, the `"equal"` variant of `CompareVersionNumbers` was not called in one situation; this is interesting mainly for tests, thus it was not really a problem

This feature is currently experimental.
Once it gets documented, the right way to do this will be to document `PackageAvailabilityInfo` in the Reference Manual,
and the next release notes should mention it.