### PR TITLE
Don't call TzPrintStatus if printLevel = 0

### DIFF
--- a/grp/glzmodmz.gi
+++ b/grp/glzmodmz.gi
@@ -314,7 +314,7 @@ local oper,n,R,o,nrit,
             e:=List(em,r->List(r,Int))-b;
             e:=1/pp*e;
             e:=Concatenation(e)*one;
-        e:=ImmutableVector(p,e);
+            e:=ImmutableVector(p,e);
             if not e in sub then
               Add(bas,e);
               Add(basm,em);

--- a/lib/tietze.gi
+++ b/lib/tietze.gi
@@ -2351,7 +2351,7 @@ local tietze,oll,num,gens,gensn,rev,w,i,r,a;
           TzGo(T); # cleanup
           TzOptions(T).loopLimit:=oll;
           TzOptions(T).protected:=downto;
-          TzPrintStatus(T,true);
+          if TzOptions(T).printLevel >= 1 then  TzPrintStatus( T, true );  fi;
 
         fi;
 
@@ -2393,7 +2393,7 @@ local tietze,oll,num,gens,gensn,rev,w,i,r,a;
       TzGo(T); # cleanup
       TzOptions(T).loopLimit:=oll;
       TzOptions(T).protected:=downto;
-      TzPrintStatus(T,true);
+      if TzOptions(T).printLevel >= 1 then  TzPrintStatus( T, true );  fi;
 
     fi;
   od;


### PR DESCRIPTION
The changes in PR #5770 caused a failure in the HAP test suite, because this input started to print additional messages:
```gap
LoadPackage("hap");
Y:=PoincareDodecahedronCWComplex(
  [[1,2,3,4,5],[6,7,8,9,10]],
  [[1,11,16,12,2],[19,9,8,18,14]],
  [[2,12,17,13,3],[20,10,9,19,15]],
  [[3,13,18,14,4],[16,6,10,20,11]],
  [[4,14,19,15,5],[17,7,6,16,12]],
  [[5,15,20,11,1],[18,8,7,17,13]]);;
IsClosedManifold(Y);
List([0..3],n->Homology(Y,n));
StructureDescription(FundamentalGroup(Y));
```

The last line should output just `"SL(2,5)"`, and with this PR it does so again.

With current master we get instead
```
gap> StructureDescription(FundamentalGroup(Y));
#I  there are 11 generators and 13 relators of total length 72
#I  there are 8 generators and 10 relators of total length 75
#I  there are 6 generators and 8 relators of total length 84
#I  there are 4 generators and 6 relators of total length 82
"SL(2,5)"
```


Also fix a bad indentation elsewhere I noticed by chance while searching for the place that needs to be adjusted.