### PR TITLE
buildsys: always link gap against libgap

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -448,6 +448,7 @@ ifneq (,$(findstring cygwin,$(host_os)))
   LIBGAP_FULL = libgap$(SHLIB_EXT)
 
   LINK_SHLIB_FLAGS = -shared -Wl,--enable-auto-image-base -Wl,--out-implib,libgap.dll.a
+  GAP_LDFLAGS += -Wl,-rpath,$(libdir)
 else ifneq (,$(findstring darwin,$(host_os)))
   SHLIB_EXT=.dylib
   LIBGAP_FULL = libgap.$(SHLIB_MAJOR)$(SHLIB_EXT)
@@ -463,6 +464,7 @@ else ifneq (,$(findstring darwin,$(host_os)))
   GAP_CPPFLAGS += -DPIC
   GAP_CFLAGS += -fno-common
   GAP_CXXFLAGS += -fno-common
+  GAP_LDFLAGS += -Wl,-rpath,$(libdir)
 else
   # Note: the following was tested on Linux -- patches making this work better
   # on e.g. FreeBSD/OpenBSD/... are highly welcome

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -316,10 +316,12 @@ ifneq (,$(findstring cygwin,$(host_os)))
 else
   ifneq (,$(findstring darwin,$(host_os)))
     GAC_CFLAGS = -fno-common
-    GAC_LDFLAGS = -bundle -undefined dynamic_lookup -Wl,-no_fixup_chains
+    GAC_LDFLAGS = -bundle -L$(abs_builddir) -lgap
+    GAC_LDFLAGS_FOR_INSTALL = -bundle -L$(libdir) -lgap
   else
     GAC_CFLAGS = -fPIC
-    GAC_LDFLAGS = -shared -fPIC
+    GAC_LDFLAGS = -shared -fPIC -L$(abs_builddir) -lgap
+    GAC_LDFLAGS_FOR_INSTALL = -shared -fPIC -L$(libdir) -lgap
   endif
 endif
 
@@ -518,8 +520,8 @@ libgap$(SHLIB_EXT): $(LIBGAP_FULL)
 	ln -sf $< $@
 
 # build rule for the main gap executable
-gap$(EXEEXT): build/obj/src/main.c.o $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(OBJS) $(GAP_LIBS) -o $@
+gap$(EXEEXT): build/obj/src/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
 
 # generate a special main.c which sets SYS_DEFAULT_PATHS and then includes
 # regular main.c; this is used to build the `gap-install` binary
@@ -686,6 +688,7 @@ install-sysinfo: SYSINFO_CPPFLAGS = -I${includedir}/gap/extra $(GAP_DEFINES)
 install-sysinfo: SYSINFO_LDFLAGS = $(ABI_CFLAGS)
 install-sysinfo: SYSINFO_GAP = $(bindir)/gap
 install-sysinfo: SYSINFO_GAC = $(bindir)/gac
+install-sysinfo: GAC_LDFLAGS = $(GAC_LDFLAGS_FOR_INSTALL)
 install-sysinfo: GMP_PREFIX =
 install-sysinfo: install-dirs
 	@echo "$$sysinfo_gap" > $(DESTDIR)$(libdir)/gap/sysinfo.gap

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -448,7 +448,6 @@ ifneq (,$(findstring cygwin,$(host_os)))
   LIBGAP_FULL = libgap$(SHLIB_EXT)
 
   LINK_SHLIB_FLAGS = -shared -Wl,--enable-auto-image-base -Wl,--out-implib,libgap.dll.a
-  GAP_LDFLAGS += -Wl,-rpath,$(libdir)
 else ifneq (,$(findstring darwin,$(host_os)))
   SHLIB_EXT=.dylib
   LIBGAP_FULL = libgap.$(SHLIB_MAJOR)$(SHLIB_EXT)
@@ -459,12 +458,12 @@ else ifneq (,$(findstring darwin,$(host_os)))
   LINK_SHLIB_FLAGS += -current_version $(LIBGAP_CURRENT_VER)
   LINK_SHLIB_FLAGS += -Wl,-single_module
   LINK_SHLIB_FLAGS += -Wl,-headerpad_max_install_names
+  LINK_SHLIB_FLAGS += -Wl,-install_name,$(abs_builddir)/$(LIBGAP_FULL)
   GAP_INSTALL_EXTRAFLAGS = -Wl,-headerpad_max_install_names
 
   GAP_CPPFLAGS += -DPIC
   GAP_CFLAGS += -fno-common
   GAP_CXXFLAGS += -fno-common
-  GAP_LDFLAGS += -Wl,-rpath,$(libdir)
 else
   # Note: the following was tested on Linux -- patches making this work better
   # on e.g. FreeBSD/OpenBSD/... are highly welcome
@@ -489,7 +488,7 @@ libgap: libgap$(SHLIB_EXT) $(LIBGAP_FULL)
 
 # Linking rule and dependencies for libgap
 $(LIBGAP_FULL): $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) -o $@ $(LINK_SHLIB_FLAGS) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS)
+	$(QUIET_LINK)$(LINK) -o $@ $(LINK_SHLIB_FLAGS) $(GAP_LDFLAGS) -Wl,-rpath,$(abs_builddir) $(OBJS) $(GAP_LIBS)
 
 ifneq (,$(findstring cygwin,$(host_os)))
 
@@ -523,7 +522,7 @@ libgap$(SHLIB_EXT): $(LIBGAP_FULL)
 
 # build rule for the main gap executable
 gap$(EXEEXT): build/obj/src/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) -Wl,-rpath,$(abs_builddir) -L${abs_builddir} -lgap -o $@
 
 # generate a special main.c which sets SYS_DEFAULT_PATHS and then includes
 # regular main.c; this is used to build the `gap-install` binary
@@ -533,7 +532,7 @@ build/main.c: sysinfo.gap
 
 # build rule for the gap executable used by the `install-bin` target
 build/gap-install: build/obj/build/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(GAP_INSTALL_EXTRAFLAGS) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(GAP_INSTALL_EXTRAFLAGS) -Wl,-rpath,$(libdir) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
 	$(INSTALL_NAME_TOOL) -change $(LIBGAP_FULL) $(libdir)/$(LIBGAP_FULL) $@
 
 endif

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -212,13 +212,6 @@ SYSINFO_CPPFLAGS += -I$(abs_srcdir)/src/extra
 GAP_CPPFLAGS += $(GAP_DEFINES)
 SYSINFO_CPPFLAGS += $(GAP_DEFINES)
 
-# Normalize __FILE__ expansions so installed binaries do not embed absolute
-# source or build paths from out-of-tree builds.
-GAP_CPPFLAGS += -fmacro-prefix-map=$(abs_srcdir)/=
-GAP_CPPFLAGS += -fmacro-prefix-map=$(abs_builddir)/=
-GAP_CPPFLAGS += -ffile-prefix-map=$(abs_srcdir)/=
-GAP_CPPFLAGS += -ffile-prefix-map=$(abs_builddir)/=
-
 # Add flags for dependencies
 GAP_CPPFLAGS += $(GMP_CPPFLAGS)
 GAP_CPPFLAGS += $(ZLIB_CPPFLAGS)

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -212,6 +212,13 @@ SYSINFO_CPPFLAGS += -I$(abs_srcdir)/src/extra
 GAP_CPPFLAGS += $(GAP_DEFINES)
 SYSINFO_CPPFLAGS += $(GAP_DEFINES)
 
+# Normalize __FILE__ expansions so installed binaries do not embed absolute
+# source or build paths from out-of-tree builds.
+GAP_CPPFLAGS += -fmacro-prefix-map=$(abs_srcdir)/=
+GAP_CPPFLAGS += -fmacro-prefix-map=$(abs_builddir)/=
+GAP_CPPFLAGS += -ffile-prefix-map=$(abs_srcdir)/=
+GAP_CPPFLAGS += -ffile-prefix-map=$(abs_builddir)/=
+
 # Add flags for dependencies
 GAP_CPPFLAGS += $(GMP_CPPFLAGS)
 GAP_CPPFLAGS += $(ZLIB_CPPFLAGS)
@@ -309,6 +316,7 @@ GAP_LIBS += $(LIBS)
 ifneq (,$(findstring cygwin,$(host_os)))
   GAC_CFLAGS =
   GAC_LDFLAGS = -shared -Wl,$(abs_builddir)/bin/$(GAPARCH)/gap.dll -Wl,--enable-auto-image-base
+  GAC_LDFLAGS_FOR_INSTALL = $(GAC_LDFLAGS)
   # Note: the above won't be correct after "make install"; but then I am not
   # sure we care about "make install" on Cygwin, so I am not going to work on
   # this until someone specifically asks for it (and even then I'll require
@@ -316,12 +324,12 @@ ifneq (,$(findstring cygwin,$(host_os)))
 else
   ifneq (,$(findstring darwin,$(host_os)))
     GAC_CFLAGS = -fno-common
-    GAC_LDFLAGS = -bundle -L$(abs_builddir) -lgap
-    GAC_LDFLAGS_FOR_INSTALL = -bundle -L$(libdir) -lgap
+    GAC_LDFLAGS = -bundle $(LIBGAP_BUILD_LDFLAGS)
+    GAC_LDFLAGS_FOR_INSTALL = -bundle $(LIBGAP_INSTALL_LDFLAGS)
   else
     GAC_CFLAGS = -fPIC
-    GAC_LDFLAGS = -shared -fPIC -L$(abs_builddir) -lgap
-    GAC_LDFLAGS_FOR_INSTALL = -shared -fPIC -L$(libdir) -lgap
+    GAC_LDFLAGS = -shared -fPIC $(LIBGAP_BUILD_LDFLAGS)
+    GAC_LDFLAGS_FOR_INSTALL = -shared -fPIC $(LIBGAP_INSTALL_LDFLAGS)
   endif
 endif
 
@@ -441,7 +449,6 @@ build/obj/%.c.o: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS $(obj_deps)
 ########################################################################
 
 LINK=$(CC)
-GAP_INSTALL_EXTRAFLAGS =
 SHLIB_MAJOR = $(GAP_KERNEL_MAJOR_VERSION)
 ifneq (,$(findstring cygwin,$(host_os)))
   SHLIB_EXT=.dll
@@ -457,9 +464,7 @@ else ifneq (,$(findstring darwin,$(host_os)))
   LINK_SHLIB_FLAGS += -compatibility_version $(LIBGAP_COMPAT_VER)
   LINK_SHLIB_FLAGS += -current_version $(LIBGAP_CURRENT_VER)
   LINK_SHLIB_FLAGS += -Wl,-single_module
-  LINK_SHLIB_FLAGS += -Wl,-headerpad_max_install_names
-  LINK_SHLIB_FLAGS += -Wl,-install_name,$(abs_builddir)/$(LIBGAP_FULL)
-  GAP_INSTALL_EXTRAFLAGS = -Wl,-headerpad_max_install_names
+  LINK_SHLIB_FLAGS += -Wl,-install_name,@rpath/$(LIBGAP_FULL)
 
   GAP_CPPFLAGS += -DPIC
   GAP_CFLAGS += -fno-common
@@ -477,10 +482,18 @@ else
   GAP_LDFLAGS += -Wl,--export-dynamic
 endif
 
-ifneq (,$(findstring darwin,$(host_os)))
-INSTALL_NAME_TOOL = @install_name_tool
+# Build-tree and installed targets intentionally use different runtime search
+# paths, but both link against libgap through these centralized variables.
+LIBGAP_BUILD_LDFLAGS = $(abs_builddir)/libgap$(SHLIB_EXT)
+LIBGAP_INSTALL_LDFLAGS = -L$(libdir) -lgap
+LIBGAP_BUILD_RPATH =
+LIBGAP_INSTALL_RPATH =
+
+ifneq (,$(findstring cygwin,$(host_os)))
+  LIBGAP_BUILD_LDFLAGS = -L$(abs_builddir) -lgap
 else
-INSTALL_NAME_TOOL = @echo > /dev/null
+  LIBGAP_BUILD_RPATH = -Wl,-rpath,$(abs_builddir)
+  LIBGAP_INSTALL_RPATH = -Wl,-rpath,$(libdir)
 endif
 
 libgap: libgap$(SHLIB_EXT) $(LIBGAP_FULL)
@@ -488,7 +501,7 @@ libgap: libgap$(SHLIB_EXT) $(LIBGAP_FULL)
 
 # Linking rule and dependencies for libgap
 $(LIBGAP_FULL): $(OBJS) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) -o $@ $(LINK_SHLIB_FLAGS) $(GAP_LDFLAGS) -Wl,-rpath,$(abs_builddir) $(OBJS) $(GAP_LIBS)
+	$(QUIET_LINK)$(LINK) -o $@ $(LINK_SHLIB_FLAGS) $(GAP_LDFLAGS) $(OBJS) $(GAP_LIBS)
 
 ifneq (,$(findstring cygwin,$(host_os)))
 
@@ -510,7 +523,7 @@ bin/$(GAPARCH)/gap.dll: libgap$(SHLIB_EXT)
 
 # build rule for the main gap executable
 gap$(EXEEXT): build/obj/src/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -Wl,--export-all-symbols $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -Wl,--export-all-symbols $< $(GAP_LIBS) $(LIBGAP_BUILD_RPATH) $(LIBGAP_BUILD_LDFLAGS) -o $@
 	@( if which peflags > /dev/null ; then peflags --cygwin-heap=2048 gap$(EXEEXT) ; fi )
 
 else
@@ -522,7 +535,7 @@ libgap$(SHLIB_EXT): $(LIBGAP_FULL)
 
 # build rule for the main gap executable
 gap$(EXEEXT): build/obj/src/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) -Wl,-rpath,$(abs_builddir) -L${abs_builddir} -lgap -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) $(LIBGAP_BUILD_RPATH) $(LIBGAP_BUILD_LDFLAGS) -o $@
 
 # generate a special main.c which sets SYS_DEFAULT_PATHS and then includes
 # regular main.c; this is used to build the `gap-install` binary
@@ -532,8 +545,7 @@ build/main.c: sysinfo.gap
 
 # build rule for the gap executable used by the `install-bin` target
 build/gap-install: build/obj/build/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(GAP_INSTALL_EXTRAFLAGS) -Wl,-rpath,$(libdir) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
-	$(INSTALL_NAME_TOOL) -change $(LIBGAP_FULL) $(libdir)/$(LIBGAP_FULL) $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) $(LIBGAP_INSTALL_RPATH) $(LIBGAP_BUILD_LDFLAGS) -o $@
 
 endif
 
@@ -1019,7 +1031,7 @@ build-testlibgap: ${LIBGAPTESTS}
 
 # run a test in tst/testlibgap
 tst/testlibgap/%: build/obj/tst/testlibgap/%.c.o build/obj/tst/testlibgap/common.c.o libgap$(SHLIB_EXT)
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -Wl,-rpath,$(abs_builddir) $^ $(GAP_LIBS) -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(LIBGAP_BUILD_RPATH) $^ $(GAP_LIBS) -o $@
 
 clean: clean-testlibgap
 clean-testlibgap:
@@ -1050,7 +1062,7 @@ testpkgconfigbuild: install-libgap install-headers
 	$(eval com := "tst/testlibgap/common")
 	$(CC) -c $(v).c -o $(v).o $(PKG_REPORTED_CFLAGS)
 	$(CC) -c $(com).c -o $(com).o $(PKG_REPORTED_CFLAGS)
-	$(QUIET_LINK)$(LINK) $(v).o -o $(v) $(com).o $(PKG_REPORTED_LDFLAGS) -Wl,-rpath,$(abs_builddir)
+	$(QUIET_LINK)$(LINK) $(v).o -o $(v) $(com).o $(PKG_REPORTED_LDFLAGS) $(LIBGAP_INSTALL_RPATH)
 	$(v) -A -l $(top_srcdir) -q -T --nointeract >$(v).out && \
         diff $(top_srcdir)/$(v).expect $(v).out
 
@@ -1061,7 +1073,7 @@ build-testkernel: ${KERNELTESTS}
 
 # run a test in tst/testkernel
 tst/testkernel/%: build/obj/tst/testkernel/%.c.o libgap$(SHLIB_EXT)
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) -Wl,-rpath,$(abs_builddir) $^ $(GAP_LIBS) -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(LIBGAP_BUILD_RPATH) $^ $(GAP_LIBS) -o $@
 
 clean: clean-testkernel
 clean-testkernel:

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -309,8 +309,11 @@ GAPInput
     strip $GAPPREFIX/bin/gap > /dev/null
     strip $GAPPREFIX/lib/libgap.so > /dev/null 2>&1 || :      # for Linux
     strip -S $GAPPREFIX/lib/libgap.dylib > /dev/null 2>&1 || :   # for macOS
+    echo "Check if BUILDDIR=$BUILDDIR occurs in $GAPPREFIX"
     fgrep -r $BUILDDIR $GAPPREFIX && exit 1
+    echo "Check if SRCDIR=$SRCDIR occurs in $GAPPREFIX"
     fgrep -r $SRCDIR $GAPPREFIX && exit 1
+    echo "Check if HOME=$HOME occurs in $GAPPREFIX"
     fgrep -r $HOME $GAPPREFIX && exit 1
 
     # HACK: symlink packages so we can start GAP

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -319,10 +319,6 @@ GAPInput
     # HACK: symlink packages so we can start GAP
     ln -s $SRCDIR/pkg $GAPPREFIX/share/gap/pkg
 
-    # ensure the dynamic linker finds the install libgap in our custom prefix
-    export LD_LIBRARY_PATH="$GAPPREFIX/lib"
-    export DYLD_LIBRARY_PATH="$GAPPREFIX/lib"
-
     # test building and loading package kernel extension
     testmockpkg "$GAPPREFIX/bin/gap" "$GAPPREFIX/lib/gap" "$SRCDIR/tst/mockpkg"
 


### PR DESCRIPTION
... even the copy we don't install system wide.

On macOS this allows us an annoying issue with the linker flags used by e.g.
gac for building kernel extensions: by always linking them against libgap we
don't need to use a flat namespace, nor rely on a bundle loader (which breaks
if you try to load the kernel extension in another binary using libgap).


However, this is not yet working on Linux at all, as there it won't find the not-yet-installed libgap:
```
$ ./gap
./gap: error while loading shared libraries: libgap.so.9: cannot open shared object file: No such file or directory
```
In principle this can be dealt with but I don't have time to do that right now, but I also didn't want to let this fragment get lost, so this PR will remind me to finish this one day (if someone would like to help out, that'd be welcome, too).

Alternatively one could restrict this change to macOS.

