### PR TITLE
Speed up orbit computations on integer sets and tuples by providing a better hash function for lists of small integers

### DIFF
--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -152,16 +152,11 @@ end);
 ##
 InstallMethod(SparseIntKey,"for bounded tuples",true,
     [ IsList,IsList and IsCyclotomicCollection ], 0,
-function(m,v)
-local c;
-  if Length(m)<>3 or m[1]<>"BoundedTuples" then
+function(m, v)
+  if Length(m) <> 3 or m[1] <> "BoundedTuples" then
     TryNextMethod();
   fi;
-  c:=[1,Maximum(m[2])+1];
-  return function(a)
-    return a*c;
-  end;
-
+  return x -> HashKeyWholeBag(x, Length(x));
 end);
 
 BindGlobal( "SparseIntKeyVecListAndMatrix", function(d,m)

--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -157,7 +157,7 @@ function(m, v)
     TryNextMethod();
   fi;
   # Due to the way BoundedTuples are presently implemented we expect the input
-  # to the hash function to always be a list of positive integers. This means
+  # to the hash function to always be a list of positive immediate integers. This means
   # that using HashKeyWholeBag should be safe.
   return function(x)
     Assert(1, IsPositionsList(x));

--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -157,8 +157,8 @@ function(m, v)
     TryNextMethod();
   fi;
   # Due to the way BoundedTuples are presently implemented we expect the input
-  # to the hash function to always be a list of integers. This means that using
-  # HashKeyWholeBag should be safe.
+  # to the hash function to always be a list of positive integers. This means
+  # that using HashKeyWholeBag should be safe.
   return function(x)
     Assert(1, IsPositionsList(x));
     if not IsPlistRep(x) then

--- a/lib/dicthf.gi
+++ b/lib/dicthf.gi
@@ -156,7 +156,16 @@ function(m, v)
   if Length(m) <> 3 or m[1] <> "BoundedTuples" then
     TryNextMethod();
   fi;
-  return x -> HashKeyWholeBag(x, Length(x));
+  # Due to the way BoundedTuples are presently implemented we expect the input
+  # to the hash function to always be a list of integers. This means that using
+  # HashKeyWholeBag should be safe.
+  return function(x)
+    Assert(1, IsPositionsList(x));
+    if not IsPlistRep(x) then
+      x := AsPlist(x);
+    fi;
+    return HashKeyWholeBag(x, 1);
+  end;
 end);
 
 BindGlobal( "SparseIntKeyVecListAndMatrix", function(d,m)

--- a/tst/teststandard/hash2.tst
+++ b/tst/teststandard/hash2.tst
@@ -32,4 +32,8 @@ gap> Length(Orbit(h,h.1[1],OnRight));
 2079
 gap> Length(Orbit(h,h.2^5,OnPoints));
 693
+gap> Length(Orbit(SymmetricGroup(14), [1 .. 7], OnSets));
+3432
+gap> Length(Orbit(SymmetricGroup(16), [1 .. 8], OnSets));
+12870
 gap> STOP_TEST( "hash2.tst", 1);


### PR DESCRIPTION
This PR improves the hash function used for lists.

## Text for release notes

see title

## Further details

The existing function essentially determined the hash by onlyconsidering the first two entries of the list. This causes significant lots of hash collision and slowdown when computing the orbit on sets, e.g. before the changes in this PR we get:
```
gap> Orbit(SymmetricGroup(14), [1..7], OnSets);; time;
1341
```
After changes:
```
gap> Orbit(SymmetricGroup(14), [1..7], OnSets);; time;
7
```
