### PR TITLE
Correct typo in COPYRIGHT

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -100,7 +100,7 @@ Copyright (C) 1988-2024 by its authors, which include:
 * Maximilian Downey Twiss
 * Michael Orlitzky
 * Michael Smith
-* Michael Young (née Torpey)
+* Michael Young (né Torpey)
 * Mohamed Barakat
 * Nikita Hismatov
 * Olexandr Konovalov


### PR DESCRIPTION
This PR corrects a typo in the COPYRIGHT file.

## Text for release notes

None

