### PR TITLE
Improve linker flags for kernel extensions on macOS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -308,7 +308,7 @@ ifneq (,$(findstring cygwin,$(host_os)))
 else
   ifneq (,$(findstring darwin,$(host_os)))
     GAC_CFLAGS = -fno-common
-    GAC_LDFLAGS = -bundle -flat_namespace -bundle_loader $(SYSINFO_GAP)
+    GAC_LDFLAGS = -bundle -undefined dynamic_lookup -Wl,-no_fixup_chains
   else
     GAC_CFLAGS = -fPIC
     GAC_LDFLAGS = -shared -fPIC


### PR DESCRIPTION
- don't use a bundle loader (esp. for installed GAP)
- don't use flat namespace, instead use dynamic lookup
- use `-Wl,-no_fixup_chains` to avoid warnings (and resolve
  potential issues) with certain Xcode versions, see
  <https://github.com/python/cpython/issues/97524>

This resolves some issues for me with using GAP-in-Julia.