### PR TITLE
Extend `Permuted` to also support non-dense lists

### DIFF
--- a/lib/list.gd
+++ b/lib/list.gd
@@ -2010,7 +2010,8 @@ DeclareGlobalFunction( "Cartesian" );
 ##  <Description>
 ##  returns a new list <A>new</A> that contains the elements of the
 ##  list <A>list</A> permuted according to the permutation <A>perm</A>.
-##  That is <C><A>new</A>[<A>i</A>^<A>perm</A>] = <A>list</A>[<A>i</A>]</C>.
+##  That is <C><A>new</A>[<A>i</A>^<A>perm</A>] = <A>list</A>[<A>i</A>]</C>
+##  whenever <C><A>list</A>[<A>i</A>]</C> is bound.
 ##  <P/>
 ##  <Ref Oper="Sortex"/> allows you to compute a permutation that must
 ##  be applied to a list in order to get the sorted list.
@@ -2018,6 +2019,8 @@ DeclareGlobalFunction( "Cartesian" );
 ##  <Example><![CDATA[
 ##  gap> Permuted( [ 5, 4, 6, 1, 7, 5 ], (1,3,5,6,4) );
 ##  [ 1, 4, 5, 5, 6, 7 ]
+##  gap> Permuted( [ 5, 4, 6,, 7, 5 ], (1,3,5,6,4) );
+##  [ , 4, 5, 5, 6, 7 ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/list.gi
+++ b/lib/list.gi
@@ -2836,11 +2836,26 @@ end );
 #M  Permuted( <list>, <perm> )  . . . apply permutation <perm> to list <list>
 ##
 InstallMethod( Permuted,
-    "for a list and a permutation",
-    [ IsList, IS_PERM ],
+    "for a dense list and a permutation",
+    [ IsDenseList, IS_PERM ],
     function( list, perm )
     # this was proposed by Jean Michel
     return list{ OnTuples( [ 1 .. Length( list ) ], perm^-1 ) };
+    end );
+
+InstallMethod( Permuted,
+    "for a (non-dense) list and a permutation",
+    [ IsList, IS_PERM ],
+    function( list, perm )
+    local result, i;
+
+    result := [];
+    for i in [1 .. Length(list)] do
+      if IsBound(list[i]) then
+        result[i ^ perm] := list[i];
+      fi;
+    od;
+    return result;
     end );
 
 


### PR DESCRIPTION
I noticed while doing something else that the method for `Permuted` implicitly assumed that the list was dense. In this PR I'm making that assumption explicit, I've added a method for `Permuted` for non-dense lists, and updated the documentation for `Permuted` so that it correctly reflects the functionality.