### PR TITLE
rewrite dev/releases/update_website.py, cleanup devtools

### DIFF
--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -10,6 +10,8 @@
 ##
 ##  This script makes a github release and uploads all tarballs as assets.
 ##
+import re
+import subprocess
 import sys
 
 import utils
@@ -19,12 +21,51 @@ from utils import error, notice
 if len(sys.argv) != 3:
     error("usage: " + sys.argv[0] + " <tag_name> <path_to_release>")
 
+
+def is_possible_gap_release_tag(tag: str) -> bool:
+    return re.fullmatch(r"v[1-9]+\.[0-9]+\.[0-9]+(-.+)?", tag) is not None
+
+
+def verify_is_possible_gap_release_tag(tag: str) -> None:
+    if not is_possible_gap_release_tag(tag):
+        error(f"{tag} does not look like the tag of a GAP release version")
+
+
+# lightweight vs annotated
+# https://stackoverflow.com/questions/40479712/how-can-i-tell-if-a-given-git-tag-is-annotated-or-lightweight#40499437
+def is_annotated_git_tag(tag: str) -> bool:
+    res = subprocess.run(
+        ["git", "for-each-ref", "refs/tags/" + tag],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return res.returncode == 0 and res.stdout.split()[1] == "tag"
+
+
+def check_git_tag_for_release(tag: str) -> None:
+    if not is_annotated_git_tag(tag):
+        error(f"There is no annotated tag {tag}")
+    # check that tag points to HEAD
+    tag_commit = subprocess.run(
+        ["git", "rev-parse", tag + "^{}"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    if tag_commit != head:
+        error(
+            f"The tag {tag} does not point to the current commit {head} but"
+            + f" instead points to {tag_commit}"
+        )
+
+
 TAG_NAME = sys.argv[1]
 PATH_TO_RELEASE = sys.argv[2]
 VERSION = TAG_NAME[1:]  # strip 'v' prefix
 
 utils.verify_git_clean()
-utils.verify_is_possible_gap_release_tag(TAG_NAME)
+verify_is_possible_gap_release_tag(TAG_NAME)
 repo = utils_github.initialize_github()
 
 # Error if the tag TAG_NAME hasn't been pushed out yet.
@@ -35,7 +76,7 @@ if not any(tag.name == TAG_NAME for tag in repo.get_tags()):
 # - exists
 # - is an annotated tag
 # - points to current HEAD
-utils.check_git_tag_for_release(TAG_NAME)
+check_git_tag_for_release(TAG_NAME)
 
 # Error if this release has been already created on GitHub
 if any(r.tag_name == TAG_NAME for r in repo.get_releases()):

--- a/dev/releases/make_github_release.py
+++ b/dev/releases/make_github_release.py
@@ -8,12 +8,7 @@
 ##
 ##  SPDX-License-Identifier: GPL-2.0-or-later
 ##
-##  This script makes a github release and uploads all tar balls as assets.
-##  The name of the target repository CURRENT_REPO_NAME is defined in
-##  utils.py.
-##
-##  If we do import * from utils, then initialize_github can't overwrite the
-##  global CURRENT_REPO variables.
+##  This script makes a github release and uploads all tarballs as assets.
 ##
 import sys
 
@@ -30,11 +25,11 @@ VERSION = TAG_NAME[1:]  # strip 'v' prefix
 
 utils.verify_git_clean()
 utils.verify_is_possible_gap_release_tag(TAG_NAME)
-utils_github.initialize_github()
+repo = utils_github.initialize_github()
 
-# Error if the tag TAG_NAME hasn't been pushed to CURRENT_REPO yet.
-if not any(tag.name == TAG_NAME for tag in utils_github.CURRENT_REPO.get_tags()):
-    error(f"Repository {utils_github.CURRENT_REPO_NAME} has no tag '{TAG_NAME}'")
+# Error if the tag TAG_NAME hasn't been pushed out yet.
+if not any(tag.name == TAG_NAME for tag in repo.get_tags()):
+    error(f"Repository {repo.full_name} has no tag '{TAG_NAME}'")
 
 # make sure that TAG_NAME
 # - exists
@@ -43,7 +38,7 @@ if not any(tag.name == TAG_NAME for tag in utils_github.CURRENT_REPO.get_tags())
 utils.check_git_tag_for_release(TAG_NAME)
 
 # Error if this release has been already created on GitHub
-if any(r.tag_name == TAG_NAME for r in utils_github.CURRENT_REPO.get_releases()):
+if any(r.tag_name == TAG_NAME for r in repo.get_releases()):
     error(f"Github release with tag '{TAG_NAME}' already exists!")
 
 # Create release
@@ -52,9 +47,7 @@ RELEASE_NOTE = (
     + f"[CHANGES.md](https://github.com/gap-system/gap/blob/{TAG_NAME}/CHANGES.md) file."
 )
 notice(f"Creating release {TAG_NAME}")
-RELEASE = utils_github.CURRENT_REPO.create_git_release(
-    TAG_NAME, TAG_NAME, RELEASE_NOTE, prerelease=True
-)
+RELEASE = repo.create_git_release(TAG_NAME, TAG_NAME, RELEASE_NOTE, prerelease=True)
 
 with utils.working_directory(PATH_TO_RELEASE):
     manifest_filename = "MANIFEST"

--- a/dev/releases/release_notes.py
+++ b/dev/releases/release_notes.py
@@ -29,12 +29,19 @@ from datetime import datetime
 from typing import Any, Dict, List, TextIO
 
 import requests
-from utils import download_with_sha256, error, is_existing_tag, notice, warning
+from utils import download_with_sha256, error, notice, warning
 
 
 def usage(name: str) -> None:
     print(f"Usage: `{name} NEWVERSION`")
     sys.exit(1)
+
+
+def is_existing_tag(tag: str) -> bool:
+    res = subprocess.run(
+        ["git", "show-ref", "--quiet", "--verify", "refs/tags/" + tag], check=False
+    )
+    return res.returncode == 0
 
 
 def find_previous_version(version: str) -> str:

--- a/dev/releases/utils_github.py
+++ b/dev/releases/utils_github.py
@@ -9,11 +9,10 @@
 ##
 import os
 import subprocess
+from typing import Optional
 
 import github
 from utils import error, notice, sha256file
-
-from typing import Optional
 
 
 # If no token is provided, this uses the value of the environment variable

--- a/dev/releases/utils_github.py
+++ b/dev/releases/utils_github.py
@@ -13,23 +13,12 @@ import subprocess
 import github
 from utils import error, notice, sha256file
 
-CURRENT_REPO_NAME = os.environ.get("GITHUB_REPOSITORY", "gap-system/gap")
-
-# Initialized by initialize_github
-GITHUB_INSTANCE = None
-CURRENT_REPO = None
+from typing import Optional
 
 
-# sets the global variables GITHUB_INSTANCE and CURRENT_REPO
 # If no token is provided, this uses the value of the environment variable
 # GITHUB_TOKEN.
-def initialize_github(token=None) -> None:
-    global GITHUB_INSTANCE, CURRENT_REPO
-    if GITHUB_INSTANCE is not None or CURRENT_REPO is not None:
-        error(
-            "Global variables GITHUB_INSTANCE and CURRENT_REPO"
-            + " are already initialized."
-        )
+def initialize_github(token: Optional[str] = None) -> github.Repository.Repository:
     if token is None and "GITHUB_TOKEN" in os.environ:
         token = os.environ["GITHUB_TOKEN"]
     if token is None:
@@ -50,11 +39,11 @@ def initialize_github(token=None) -> None:
             token = token_file.read().strip()
     if token is None:
         error("Error: no access token found or provided")
-    g = github.Github(token)
-    GITHUB_INSTANCE = g
-    notice(f"Accessing repository {CURRENT_REPO_NAME}")
+    g = github.Github(auth=github.Auth.Token(token))
+    repo_name = os.environ.get("GITHUB_REPOSITORY", "gap-system/gap")
+    notice(f"Accessing repository {repo_name}")
     try:
-        CURRENT_REPO = GITHUB_INSTANCE.get_repo(CURRENT_REPO_NAME)
+        return g.get_repo(repo_name)
     except github.GithubException:
         error("Error: the access token may be incorrect")
 
@@ -74,7 +63,9 @@ def verify_via_checksumfile(filename: str) -> None:
 # just to be safe, in the latter case). Then upload the files <filename> and
 # <filename>.sha256 as assets to the GitHub <release>.
 # Files already ending in ".sha256" are ignored.
-def upload_asset_with_checksum(release, filename: str) -> None:
+def upload_asset_with_checksum(
+    release: github.GitRelease.GitRelease, filename: str
+) -> None:
     if not os.path.isfile(filename):
         error(f"{filename} not found")
 


### PR DESCRIPTION
- **devtools: rewrite dev/releases/update_website.py** -- resolves #5781 
- **devtools: remove global variables in utils_github**
- **devtools: move stuff out of utils.py that has only one user**

With this `dev/releases/update_website.py` is mostly decoupled from the rest, which should make it easier to migrate it to the `GapWWW` repository later on.