### PR TITLE
be more restrictive in the default method of `SmallGeneratingSet`, in order to avoid error messages

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -5359,19 +5359,37 @@ RedispatchOnCondition(MinimalNormalSubgroups, true,
 ##
 #M  SmallGeneratingSet(<G>)
 ##
+##  Restrict the criteria used by the generic method to situations where
+##  "no method found" errors and expensive/impossible membership computations
+##  do not occur.
+##
 BindGlobal("SMALLGENERATINGSETGENERIC",function (G)
-local  i, U, gens,test;
-  gens := Set(GeneratorsOfGroup(G));
+local  gens, x, i, Ugens, U, test;
+
+  gens:= GeneratorsOfGroup(G);
+  if IsEmpty( gens ) then
+    return gens;
+  fi;
+
+  x:= gens[1];
+  if CanEasilySortElements( x ) then
+    gens:= Set( gens );
+  elif CanEasilyCompareElements( x ) then
+    gens:= DuplicateFreeList( gens );
+  fi;
+
   i := 1;
   while i < Length(gens)  do
-    U:= SubgroupNC( G, gens{ Difference( [ 1 .. Length( gens ) ], [ i ] ) } );
+    Ugens:= gens{ Difference( [ 1 .. Length( gens ) ], [ i ] ) };
+    U:= SubgroupNC( G, Ugens );
+    test:= false;
     if HasIsFinite(G) and IsFinite(G) and CanComputeSizeAnySubgroup(G) then
       test:=Size(U)=Size(G);
-    else
-      test:=IsSubset(U,G);
+    elif CanEasilyTestMembership( U ) then
+      test:= gens[i] in U;
     fi;
     if test then
-      gens:=GeneratorsOfGroup(U);
+      gens:= Ugens;
       # this throws out i, so i is the new i+1;
     else
       i:=i+1;


### PR DESCRIPTION
The proposed change resolves #5542/#5790 in the sense that one does no longer get error messages when a call of `SmallGeneratingSet` delegates to its generic method `SMALLGENERATINGSETGENERIC`.

The idea is to try element comparisons (via `\=` or `\<`) and membership tests only if the filters `CanEasilyCompareElements`, `CanEasilySortElements`, `CanEasilyTestMembership` indicate that these operations will be cheap.

This change may yield worse results of `SmallGeneratingSet` in situations where the abovementioned filters are not set but where the old function was successful.
For an example where this happens, see the comment by @Stefan-Kohl in the discussion of #5790.
(But note that for that group, in fact `SmallGeneratingSet` does *not* call the generic method, and the result of `SmallGeneratingSet` is not as good as that of the old generic method.)

If this proposal is acceptable, I will add some tests and improve also the documentation of `SmallGeneratingSet`.