### PR TITLE
Add GModuleByGroup helper

### DIFF
--- a/doc/ref/meataxe.xml
+++ b/doc/ref/meataxe.xml
@@ -70,6 +70,15 @@ bases used are needed as well.
 </Description>
 </ManSection>
 
+
+<ManSection>
+<Heading>GModuleByGroup</Heading>
+<Func Name="GModuleByMats" Arg='group[, field]' Label="for matrix group and a field"/>
+<Description>
+TODO
+</Description>
+</ManSection>
+
 </Section>
 
 

--- a/lib/meataxe.gd
+++ b/lib/meataxe.gd
@@ -21,6 +21,12 @@ DeclareGlobalFunction("GModuleByMats");
 
 #############################################################################
 ##
+#F  GModuleByGroup(<group>,[<f>])
+##
+DeclareGlobalFunction("GModuleByGroup");
+
+#############################################################################
+##
 #F  TrivialGModule ( g, F ) . . . trivial G-module
 ##
 ##  g is a finite group, F a field, trivial smash G-module computed.

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -16,7 +16,7 @@ InstallGlobalFunction(GModuleByMats,function(arg)
 local l,f,dim,m;
   l:=arg[1];
   if Length(arg)=1 then
-    Error("Usage: GModuleByMats(<mats>,[<id>,]<field>)");
+    Error("Usage: GModuleByMats(<mats>,[<dim>,]<field>)");
   fi;
   f:=arg[Length(arg)];
   if Length(l)>0 and Characteristic(l[1])<>Characteristic(f) then
@@ -43,6 +43,22 @@ local l,f,dim,m;
   m.generators:=MakeImmutable(l);
   m.IsOverFiniteField:= Size(f)<>infinity and IsFFECollCollColl(l);
   return m;
+end);
+
+InstallGlobalFunction(GModuleByGroup,function(group, field...)
+# TODO: also accept permutation groups and then hand off to PermutationGModule
+
+  if not IsFFEMatrixGroup(group) then
+    Error("<group> must be a matrix group over a finite field");
+  fi;
+  if Length(field) = 0 then
+    field := DefaultFieldOfMatrixGroup(group);
+  elif Length(field) = 1 then
+    field := field[1];
+  else
+    Error("too many argyments");
+  fi;
+  return GModuleByMats(GeneratorsOfGroup(group), DimensionOfMatrixGroup(group), field);
 end);
 
 # variant of Value: if we evaluate the polynomial `f` at a matrix `x`, then it
@@ -3413,18 +3429,18 @@ end;
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> g:= SO(-1, 4, 2);;
-##  gap> m:= GModuleByMats( GeneratorsOfGroup( g ), GF(2) );;
+##  gap> m:= GModuleByGroup( g );;
 ##  gap> Display( MTX.InvariantQuadraticForm( m ) );
 ##   . . . .
 ##   1 . . .
 ##   . . 1 .
 ##   . . 1 1
-##  gap> g:= SP(4, 2);;
-##  gap> m:= GModuleByMats( GeneratorsOfGroup( g ), GF(2) );;
+##  gap> g:= Sp(4, 2);;
+##  gap> m:= GModuleByGroup( g );;
 ##  gap> MTX.InvariantQuadraticForm( m );
 ##  fail
-##  gap> g:= SP(4, 3);;
-##  gap> m:= GModuleByMats( GeneratorsOfGroup( g ), GF(3) );;
+##  gap> g:= Sp(4, 3);;
+##  gap> m:= GModuleByGroup( g );;
 ##  gap> q:= MTX.InvariantQuadraticForm( m );;
 ##  gap> q = - TransposedMat( q );  # antisymmetric inv. bilinear form
 ##  true


### PR DESCRIPTION
Also fix usage error message for GModuleByMats.

The main gist is: instead of this
```
g:= SP(4, 2);;
m:= GModuleByMats( GeneratorsOfGroup( g ), GF(2) );;
```
you can now write this
```
g:= Sp(4, 2);;
m:= GModuleByGroup( g );;
```
which just is quite convenient when dealing with matrix groups over finite fields.

A field can be specified as an optional second argument in case the matrix groups is defined over one field, but we want the module over another. But perhaps I should just drop it?


This is a draft, as there is no documentation yet for the new function (just a placeholder), and also a TODO comment here or there in the code.

Before I fine tune it I wanted to check if this seems sensible. Also I wonder whether the function's name should be changed to e.g. just `GModule`, or perhaps `NaturalGModule`, or something else.