### PR TITLE
Fix `WreathProductElementList` to not modify its list argument

### DIFF
--- a/lib/gprd.gi
+++ b/lib/gprd.gi
@@ -959,7 +959,7 @@ end);
 InstallMethod( WreathProductElementListNC, "generic wreath product", true,
  [ HasWreathProductInfo, IsList ], 0,
 function(G, list)
-  return Objectify(FamilyObj(One(G))!.defaultType, StructuralCopy(list));
+  return Objectify(FamilyObj(One(G))!.defaultType, ShallowCopy(list));
 end);
 
 #############################################################################

--- a/tst/testinstall/opers/ListWreathProductElement.tst
+++ b/tst/testinstall/opers/ListWreathProductElement.tst
@@ -253,7 +253,7 @@ gap> W := WreathProduct(K, H);;
 gap> l := [x*y, x, y, (1,2,3)];;
 gap> MakeImmutable(l);;
 gap> w := WreathProductElementList(W, l);;
-gap> l = [x*y, x, y, (1,2,3)]; # was previously l = w
+gap> l = [x*y, x, y, (1,2,3)];
 true
 
 #

--- a/tst/testinstall/opers/ListWreathProductElement.tst
+++ b/tst/testinstall/opers/ListWreathProductElement.tst
@@ -245,6 +245,7 @@ true
 # Generic Wreath Product : Bugfix for immutable lists
 #
 
+#
 gap> K := FreeGroup("x", "y");;
 gap> x := K.1;;
 gap> y := K.2;;

--- a/tst/testinstall/opers/ListWreathProductElement.tst
+++ b/tst/testinstall/opers/ListWreathProductElement.tst
@@ -246,7 +246,8 @@ true
 #
 
 gap> K := FreeGroup("x", "y");;
-gap> AssignGeneratorVariables(K);;
+gap> x := K.1;;
+gap> y := K.2;;
 gap> H := SymmetricGroup(3);;
 gap> W := WreathProduct(K, H);;
 gap> l := [x*y, x, y, (1,2,3)];;

--- a/tst/testinstall/opers/ListWreathProductElement.tst
+++ b/tst/testinstall/opers/ListWreathProductElement.tst
@@ -242,4 +242,18 @@ gap> x = WreathProductElementList(G, list);
 true
 
 #
+# Generic Wreath Product : Bugfix for immutable lists
+#
+
+gap> K := FreeGroup("x", "y");;
+gap> AssignGeneratorVariables(K);;
+gap> H := SymmetricGroup(3);;
+gap> W := WreathProduct(K, H);;
+gap> l := [x*y, x, y, (1,2,3)];;
+gap> MakeImmutable(l);;
+gap> w := WreathProductElementList(W, l);;
+gap> l = [x*y, x, y, (1,2,3)]; # was previously l = w
+true
+
+#
 gap> STOP_TEST("ListWreathProductElement.tst", 1);


### PR DESCRIPTION
Replace `StructuralCopy` with `ShallowCopy` in `WreathProductElementListNC`.

Otherwise an immutable list representation from the input gets replaced with the wreath product element even outside of the scope of `WreathProductElementList`.

Setup:
```
gap> K := FreeGroup("x", "y");;
gap> AssignGeneratorVariables(K);;
gap> H := SymmetricGroup(3);;
gap> W := WreathProduct(K, H);
<group with 4 generators>
gap> l := [x*y, x, y, (1,2,3)];
[ x*y, x, y, (1,2,3) ]
gap> MakeImmutable(l);;
gap> w := WreathProductElementList(W, l);
WreathProductElement(x*y,x,y,(1,2,3))
```

Current behaviour: list l gets overwritten by output w.
```
gap> l;
WreathProductElement(x*y,x,y,(1,2,3))
```

Expected behaviur: list l should be unchanged
```
gap> l;
[ x*y, x, y, (1,2,3) ]
```

## Text for release notes

Fix a bug in `WreathProductElementList` for generic wreath products, which replaced an immutable list from the input with the constructed wreath product element.
