### PR TITLE
ExtRepOfObj for IsLetterAssocWordRep: return mutable list

### DIFF
--- a/lib/wordlett.gi
+++ b/lib/wordlett.gi
@@ -171,7 +171,7 @@ local  i,r,elm,len,g,h,e;
 end);
 
 InstallMethod(ExtRepOfObj,"assoc word in letter rep",true,
-  [IsAssocWord and IsLetterAssocWordRep],0,ERepLettWord);
+  [IsAssocWord and IsLetterAssocWordRep],0,x->ShallowCopy(ERepLettWord(x)));
 
 InstallMethod(NumberSyllables,"assoc word in letter rep",true,
   [IsAssocWord and IsLetterAssocWordRep],0,

--- a/tst/testinstall/wordrep.tst
+++ b/tst/testinstall/wordrep.tst
@@ -306,9 +306,9 @@ true
 #
 gap> f:= FreeGroup(IsLetterWordsFamily,4);;
 gap> IsMutable(ExtRepOfObj(f.1));
-false
+true
 gap> IsMutable(ExtRepOfObj(f.1));
-false
+true
 
 #
 gap> STOP_TEST("wordrep.tst");


### PR DESCRIPTION
... as this is how GAP behaved for years, and also many (most?) other `ExtRepOfObj` implementations also return a mutable list. So it seems plausible to mimic that.

At the same time, keep the return value of `ERepLettWord` immutable, to avoid many needless copies of a list in code that does things like `Length(ERepLettWord(w))` or `ERepLettWord(w)[2*n-1]`.


Addresses fallout from #5802 in an arguably better way. So `semigroups` wouldn't have to change (CC @james-d-mitchell) and `groupoids` could roll back its changes (CC @cdwensley), though it would also be safe for it to stay as it is (though potentially a teeny tiny bit less efficient).

Sorry for the back and forth folks. 