### PR TITLE
Fix PQuotient error for large groups.

### DIFF
--- a/lib/pquot.gd
+++ b/lib/pquot.gd
@@ -26,11 +26,11 @@ DeclareGlobalFunction( "AbelianPQuotient" );
 
 #############################################################################
 ##
-#F  PQuotient(<F>, <p>[, <c>][, <logord>][, <ctype>])  . .  pq of an fp group
+#F  PQuotient(<F>, <p>[, <c>][, <logord>][, <ctype>] : noninteractive)  . .  pq of an fp group
 ##
 ##  <#GAPDoc Label="PQuotient">
 ##  <ManSection>
-##  <Func Name="PQuotient" Arg='F, p[, c][, logord][, ctype]'/>
+##  <Func Name="PQuotient" Arg='F, p[, c][, logord][, ctype] : noninteractive'/>
 ##
 ##  <Description>
 ##  computes a factor <A>p</A>-group of a finitely presented group <A>F</A>
@@ -61,10 +61,11 @@ DeclareGlobalFunction( "AbelianPQuotient" );
 ##  most <M>p^{256}</M>. If the parameter <A>logord</A> is present, it will
 ##  compute with factor groups of order at most <M>p^{<A>logord</A>}</M>.
 ##  If this parameter is specified, then the parameter <A>c</A> must also be
-##  given.  The present
-##  implementation produces an error message if the order of a
-##  <M>p</M>-quotient exceeds <M>p^{256}</M> or <M>p^{<A>logord</A>}</M>,
-##  respectively.
+##  given. If the order of a <M>p</M>-quotient exceeds <M>p^{256}</M>
+##  or <M>p^{<A>logord</A>}</M>,
+##  respectively, the behaviour of the algorithm depends on the option
+##  <A>noninteractive</A>: if it is present, the current implementation
+##  produces an error message; otherwise it returns <C>fail</C>.
 ##  Note that the order of intermediate <M>p</M>-groups may be larger than
 ##  the final order of a <M>p</M>-quotient.
 ##  <P/>

--- a/lib/pquot.gi
+++ b/lib/pquot.gi
@@ -1310,7 +1310,9 @@ end );
 
 #############################################################################
 ##
-#F  AbelianPQuotient  . . . . . . . . . . .  initialize an abelian p-quotient
+#F  AbelianPQuotient  . . . . . . try to initialize an abelian p-quotient
+##                    . . . . . . return true if we are sucessful
+##                    . . . . . . return false otherwise
 ##
 InstallGlobalFunction( AbelianPQuotient,
 function( qs )
@@ -1342,6 +1344,9 @@ function( qs )
     generators := DifferenceLists( [1..n], trailers );
 
     ##  Their images are the first d generators.
+    if Length(gens) < d then
+        return false;
+    fi;
     qs!.images{ generators } := gens{[1..d]};
 
     ##  Fix their definitions.
@@ -1367,6 +1372,8 @@ function( qs )
     qs!.collector![SCP_WEIGHTS]{[1..qs!.numberOfGenerators]} :=
       [1..qs!.numberOfGenerators] * 0 + 1;
 
+    return true;
+
 end );
 
 #############################################################################
@@ -1376,7 +1383,8 @@ end );
 InstallGlobalFunction( PQuotient,
 function( arg )
 
-    local   G,  p,  cl,  ngens,  collector,  qs,  t,noninteractive;
+    local   G,  p,  cl,  ngens,  collector,  qs,  t,noninteractive,
+            isAbelianPQuotientSucessful;
 
 
     ##  First we parse the arguments to this function
@@ -1453,7 +1461,20 @@ function( arg )
           LengthOfDescendingSeries(qs)+1, " quotient" );
 
     t := Runtime();
-    AbelianPQuotient( qs );
+    isAbelianPQuotientSucessful := AbelianPQuotient( qs );
+    if not isAbelianPQuotientSucessful then
+        if noninteractive then
+            return fail;
+        else
+            Error( "Collector not large enough ",
+                    "to define generators for abelian p-quotient.\n",
+                    "To return the current quotient (of class ",
+                    LengthOfDescendingSeries(qs), ") type `return;' ",
+                    "and `quit;' otherwise.\n" );
+
+            return qs;
+        fi;
+    fi;
 
     Info( InfoQuotientSystem, 1, "  rank of this layer: ",
           RanksOfDescendingSeries(qs)[LengthOfDescendingSeries(qs)],

--- a/tst/testbugfix/2024-10-15-PQuotient.tst
+++ b/tst/testbugfix/2024-10-15-PQuotient.tst
@@ -1,0 +1,16 @@
+# see <https://github.com/gap-system/gap/issues/5809>
+gap> F := FreeGroup(["a", "b"]);;
+gap> a := F.1;;
+gap> b := F.1;;
+gap> p := 5;;
+gap> G := F / [a^p, b^p, Comm(a,b)];;
+gap> PQuotient(G, p, 1, 2 : noninteractive) <> fail;
+true
+gap> PQuotient(G, p, 1, 1 : noninteractive) = fail;
+true
+
+#
+gap> PQuotient( FreeGroup(2), 5, 10, 520 : noninteractive ) <> fail;
+true
+gap> gPQuotient( FreeGroup(2), 5, 10, 519 : noninteractive ) = fail;
+true


### PR DESCRIPTION
Closes #5809 

## Text for release notes

Fix PQuotient error for large groups: If `logord` is too small, we return fail or error depending on option `noninteractive`.
