### PR TITLE
minor improvements of the Reference Manual

### DIFF
--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -121,7 +121,7 @@ DeclareConstructor( "GeneralLinearGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  <Ref Prop="IsNaturalGLnZ"/>).
 ##  <P/>
 ##  Currently supported rings <A>R</A> are finite fields,
-##  the ring <Ref Var="Integers"/>,
+##  the ring <Ref Var="Integers" Label="global variable"/>,
 ##  and residue class rings <C>Integers mod <A>m</A></C>,
 ##  see <Ref Sect="Residue Class Rings"/>.
 ##  <P/>

--- a/lib/cache.gd
+++ b/lib/cache.gd
@@ -71,7 +71,7 @@ InstallMethod( FlushCaches, "return method", [], function() end );
 ##  <Mark><C>defaults</C> (default an empty list)</Mark>
 ##  <Item>
 ##    Used to initialise the cache, both initially and after each flush.
-##    If <C>defaults[i]</C> is bound, then this is used as default vale
+##    If <C>defaults[i]</C> is bound, then this is used as default value
 ##    for the input <C>i</C>.
 ##  </Item>
 ##  <Mark><C>flush</C> (default <K>true</K>)</Mark>

--- a/lib/ctbllatt.gd
+++ b/lib/ctbllatt.gd
@@ -237,13 +237,6 @@ DeclareGlobalFunction( "Extract" );
 ##        [ 0, 0, 1, 0, 0, 0, 0, 0 ], [ 0, 0, 0, -1, 1, 0, 0, 0 ],
 ##        [ 0, 0, 0, 0, 0, 1, 0, 0 ], [ 0, 0, 0, 0, 0, 0, 1, 1 ],
 ##        [ 0, 0, 0, 0, 0, 0, 1, 0 ], [ 0, 0, 0, 0, 0, 0, 0, 1 ] ] )
-##  ]]></Example>
-##  <P/>
-##  In the following example we temporarily decrease the line length limit
-##  from its default value <M>80</M> to <M>62</M>
-##  in order to get a nicer output format.
-##  <P/>
-##  <Example><![CDATA[
 ##  gap> emb2:= OrthogonalEmbeddingsSpecialDimension( s6, rem, gram, 8 );
 ##  rec(
 ##    irreducibles :=
@@ -317,10 +310,6 @@ DeclareGlobalFunction( "OrthogonalEmbeddingsSpecialDimension" );
 ##      component.
 ##  </Item>
 ##  </List>
-##  <P/>
-##  In the following example we temporarily decrease the line length limit
-##  from its default value <M>80</M> to <M>62</M>
-##  in order to get a nicer output format.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> s4:= CharacterTable( "Symmetric", 4 );;
@@ -402,10 +391,6 @@ DeclareGlobalFunction( "Decreased" );
 ##  So <Ref Func="DnLattice"/> might be useful even if it fails to find
 ##  irreducible characters.
 ##  <P/>
-##  In the following example we temporarily decrease the line length limit
-##  from its default value <M>80</M> to <M>62</M>
-##  in order to get a nicer output format.
-##  <P/>
 ##  <Example><![CDATA[
 ##  gap> s4:= CharacterTable( "Symmetric", 4 );;
 ##  gap> red:= [ [ 2, 0, 2, 2, 0 ], [ 4, 0, 0, 1, 2 ],
@@ -452,10 +437,6 @@ DeclareGlobalFunction( "DnLattice" );
 ##  <P/>
 ##  <Ref Func="DnLatticeIterative"/> returns a record with the same
 ##  components and meaning of components as <Ref Func="LLL"/>.
-##  <P/>
-##  In the following example we temporarily decrease the line length limit
-##  from its default value <M>80</M> to <M>62</M>
-##  in order to get a nicer output format.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> s4:= CharacterTable( "Symmetric", 4 );;

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4739,8 +4739,8 @@ DeclareGlobalFunction("GroupEnumeratorByClosure");
 ##
 ##  <Description>
 ##  The operation <Ref Oper="LowIndexSubgroups"/> computes representatives of
-##  the conjugacy classes of subgroups of the group <A>G</A> that index less
-##  than or equal to <A>index</A>.
+##  the conjugacy classes of subgroups of the group <A>G</A> that have index
+##  less than or equal to <A>index</A>.
 ##  <P/>
 ##  For finitely presented groups this operation simply defaults to
 ##  <Ref Oper="LowIndexSubgroupsFpGroup"/>. In other cases, it uses repeated

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1347,7 +1347,7 @@ DeclareGlobalFunction( "BaseFixedSpace" );
 ##  <List>
 ##  <Mark><C>subspace</C></Mark>
 ##  <Item>
-##  s a basis of the space spanned by <A>mat</A> in upper triangular
+##  is a basis of the space spanned by <A>mat</A> in upper triangular
 ##  form with leading ones at all echelon steps and zeroes above these ones.
 ##  </Item>
 ##  <Mark><C>factorspace</C></Mark>
@@ -1754,16 +1754,14 @@ DeclareGlobalFunction( "DiagonalMat" );
 ##  <P/>
 ##  The matrix of the reflection in <M>v</M> is defined as
 ##  <Display Mode="M">
-##  M = I_n +
-##    \overline{{v^{tr}}} \cdot (w-1) / ( v \overline{{v^{tr}}} ) \cdot v
+##  M = I_n + <A>conj</A>(v^{tr}) \cdot (<A>root</A>-1) /
+##  (v \cdot <A>conj</A>(v^{tr})) \cdot v
 ##  </Display>
-##  where <M>w</M> equals <A>root</A>,
-##  <M>n</M> is the length of the coefficient list,
-##  and <M>\overline{{\vphantom{x}}}</M> denotes the conjugation.
+##  where <M>n</M> is the length of the coefficient list.
 ##  <P/>
-##  So <M>v</M> is mapped to <M>w v</M>, with default <M>-v</M>,
-##  and any vector <M>x</M> with the property
-##  <M>x \overline{{v^{tr}}} = 0</M> is fixed by the reflection.
+##  So <M>v</M> is mapped to <A>root</A><M> \cdot v</M>,
+##  with default <M>-v</M>, and any vector <M>x</M> with the property
+##  <M>x \cdot </M><A>conj</A><M>(v^{tr}) = 0</M> is fixed by the reflection.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/permutat.g
+++ b/lib/permutat.g
@@ -602,11 +602,11 @@ end);
 ##  Let <A>src</A> and <A>dst</A> be lists of positive integers of the same
 ##  length, such that there is a permutation <M>\pi</M> such that
 ##  <C>OnTuples(<A>src</A>,</C> <M>\pi</M><C>) = <A>dst</A></C>.
-##  <Ref Func="MappingPermListList"/> returns the permutation <C>p</C> from the
-##  previous sentence, i.e.  <A>src</A><C>[</C><M>i</M><C>]^</C><M>p =</M>
-##  <A>dst</A><C>[</C><M>i</M><C>]</C>.
-##  The permutation <M>\pi</M> fixes any point which is not in <A>src</A> or
-##  <A>dst</A>.
+##  <Ref Func="MappingPermListList"/> returns such a permutation
+##  (i. e., <A>src</A><C>[</C><M>i</M><C>]^</C><M>\pi =</M>
+##  <A>dst</A><C>[</C><M>i</M><C>]</C> holds),
+##  with the property that <M>\pi</M> fixes any point which is not in
+##  <A>src</A> or <A>dst</A>.
 ##  If there are several such permutations, it is not specified which of them
 ##  <Ref Func="MappingPermListList"/> returns. If there is no such
 ##  permutation, then <Ref Func="MappingPermListList"/> returns <K>fail</K>.

--- a/lib/streams.gd
+++ b/lib/streams.gd
@@ -323,7 +323,7 @@ DeclareOperation( "PositionStream", [ IsInputStream ] );
 ##  A default method is supplied for <Ref Oper="ReadAll"/> which simply calls
 ##  <Ref Oper="ReadLine"/> repeatedly.
 ##  This is only really safe for streams which cannot block.
-##  Other streams should install a method for <Ref Oper="ReadAll"/>
+##  Other streams should install a method for <Ref Oper="ReadAll"/>.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> i := InputTextString( "1Hallo\nYou\n1" );;
@@ -401,7 +401,7 @@ DeclareOperation( "ReadByte", [ IsInputStream ] );
 ##  may also return <K>fail</K> or return an incomplete line if the other
 ##  process has not yet written any more. It will always wait (block) for at
 ##  least one byte to be available, but will then return as much input
-##  as is available, up to a limit of one  line
+##  as is available, up to a limit of one line.
 ##  <P/>
 ##  A default method is supplied for <Ref Oper="ReadLine"/> which simply calls <Ref Oper="ReadByte"/>
 ##  repeatedly. This is only safe for streams that cannot block. The kernel


### PR DESCRIPTION
- fix typos
- remove statements about line lengths of some examples (either not true or not relevant)
- improve a <Display> formula
- fix a cross-reference (points to a variable not to a chapter)