### PR TITLE
Adjust julia gc to `jl_gc_new_weakref` no longer being exported

### DIFF
--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -40,6 +40,13 @@
 #ifdef USE_JULIA_GC
 #include "julia.h"
 #include "julia_gc.h"
+#include <julia_threads.h>    // for jl_get_ptls_states
+
+#if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR == 7
+// workaround issue with Julia 1.7 headers which "forgot" to export this
+// function
+JL_DLLEXPORT void * jl_get_ptls_states(void);
+#endif
 #endif
 
 #define RequireWPObj(funcname, op)                                           \

--- a/src/weakptr.c
+++ b/src/weakptr.c
@@ -151,7 +151,7 @@ static inline void SET_ELM_WPOBJ(Obj list, UInt pos, Obj val)
         return;
     }
     if (!IS_BAG_REF(ptr[pos])) {
-        ptr[pos] = (Bag)jl_gc_new_weakref((jl_value_t *)val);
+        ptr[pos] = (Bag)jl_gc_new_weakref_th(jl_get_ptls_states(), (jl_value_t *)val);
         jl_gc_wb_back(BAG_HEADER(list));
     }
     else {


### PR DESCRIPTION
As discussed in https://github.com/oscar-system/GAP.jl/issues/1032#issuecomment-2435216269. cc @fingolfin 

## Text for release notes

not needed
