### PR TITLE
Fix wreath product with trivial group to not contain redundant trivial generators

### DIFF
--- a/lib/gprdmat.gi
+++ b/lib/gprdmat.gi
@@ -256,7 +256,8 @@ InstallGlobalFunction(MatWreathProduct,function(A,B)
 local f,n,m,Agens,Bgens,emb,i,j,a,g,dim,rans,range,orbs;
   f:=DefaultFieldOfMatrixGroup(A);
   n:=DimensionOfMatrixGroup(A);
-  m:=LargestMovedPoint(B);
+  # force trivial top group to act on one point
+  m:=Maximum(1, LargestMovedPoint(B));
   dim:=n*m;
   emb:=[];
   rans:=[];
@@ -272,11 +273,26 @@ local f,n,m,Agens,Bgens,emb,i,j,a,g,dim,rans,range,orbs;
     emb[j]:=Agens;
   od;
   orbs := OrbitsDomain(B);
-  Agens := Concatenation(List(orbs, orb -> emb[orb[1]]));
-
-  Bgens:=List(GeneratorsOfGroup(B),
-          x->KroneckerProduct(PermutationMat(x,m,f),One(A)));
-  g:=Group(Concatenation(Agens,Bgens));
+  # force trivial top group to act on one point
+  if IsEmpty(orbs) then
+    orbs := [[1]];
+  fi;
+  # generators for the cases where one component is trivial
+  if IsTrivial(A) and IsTrivial(B) then
+    g := Group( One(A) );
+  elif IsTrivial(A) then
+    Bgens:=List(GeneratorsOfGroup(B),
+            x->PermutationMat(x,m,f));
+    g := Group(Bgens);
+  elif IsTrivial(B) then
+    Agens := Concatenation(List(orbs, orb -> emb[orb[1]]));
+    g := Group(Agens);
+  else
+    Agens := Concatenation(List(orbs, orb -> emb[orb[1]]));
+    Bgens:=List(GeneratorsOfGroup(B),
+            x->KroneckerProduct(PermutationMat(x,m,f),One(A)));
+    g:=Group(Concatenation(Agens,Bgens));
+  fi;
   if HasSize(A) then
     SetSize(g,Size(A)^m*Size(B));
   fi;

--- a/lib/gprdmat.gi
+++ b/lib/gprdmat.gi
@@ -279,10 +279,9 @@ local f,n,m,Agens,Bgens,emb,i,j,a,g,dim,rans,range,orbs;
   fi;
   # generators for the cases where one component is trivial
   if IsTrivial(A) and IsTrivial(B) then
-    g := Group( One(A) );
+    g := A;
   elif IsTrivial(A) then
-    Bgens:=List(GeneratorsOfGroup(B),
-            x->PermutationMat(x,m,f));
+    Bgens:=List(GeneratorsOfGroup(B), x -> PermutationMat(x,m,f));
     g := Group(Bgens);
   elif IsTrivial(B) then
     Agens := Concatenation(List(orbs, orb -> emb[orb[1]]));

--- a/lib/gprdperm.gi
+++ b/lib/gprdperm.gi
@@ -621,16 +621,21 @@ local   G,H,        # factors
     # force trivial group to act on 1 point
     if degG = 0 then domG := [1]; degG := 1; fi;
 
-    for i  in [1..degI]  do
-        components[i]:=[(i-1)*degG+1..i*degG];
-        shift := MappingPermListList( domG, components[i] );
-        Add(perms,shift);
-        for gen  in Ggens  do
-            Add( gens, gen ^ shift );
-        od;
-        if i=1 then gens1:=ShallowCopy(gens);fi;
-    od;
-    basegens:=ShallowCopy(gens);
+    if IsTrivial(G) then
+      gens1 := [ One(G) ];
+      basegens := ShallowCopy(gens1);
+    else
+      for i  in [1..degI]  do
+          components[i]:=[(i-1)*degG+1..i*degG];
+          shift := MappingPermListList( domG, components[i] );
+          Add(perms,shift);
+          for gen  in Ggens  do
+              Add( gens, gen ^ shift );
+          od;
+          if i=1 then gens1:=ShallowCopy(gens);fi;
+      od;
+      basegens:=ShallowCopy(gens);
+    fi;
 
     # reduce generator number if it becomes too large -- only first base
     # part
@@ -649,7 +654,9 @@ local   G,H,        # factors
             od;
         od;
         shift:=PermList(shift);
-        Add( gens, shift );
+        if not IsOne(shift) then
+            Add( gens, shift );
+        fi;
         Add(hgens, shift );
     od;
 
@@ -1039,7 +1046,9 @@ InstallGlobalFunction( WreathProductProductAction, function( G, H )
                      ( Position( domG, domG[ q ] ^ gen ) - q ) * val );
             od;
             q:=PermList( list + 1 );
-            Add(gens,q);
+            if not IsOne(q) then
+              Add(gens,q);
+            fi;
             Add(basegens[i],q);
             val := Val;
         od;
@@ -1060,7 +1069,9 @@ InstallGlobalFunction( WreathProductProductAction, function( G, H )
             Add( list, q );
         od;
         q:=PermList( list + 1 );
-        Add(gens,q);
+        if not IsOne(q) then
+          Add(gens,q);
+        fi;
         Add(hgens,q);
     od;
     W := GroupByGenerators( gens, () );  # `gens' arose from `PermList'

--- a/tst/testbugfix/2024_10_24_WreathProductWIthTrivialGroups.tst
+++ b/tst/testbugfix/2024_10_24_WreathProductWIthTrivialGroups.tst
@@ -1,0 +1,53 @@
+#
+gap> START_TEST("WreathProductWithTrivialGroups.tst");
+gap> P := SymmetricGroup(3);;
+gap> IP := Group( One(P) );;
+gap> M := GL(6, 5);;
+gap> IM := Group( One(M) );;
+
+# Generators should not contain the identity element,
+# unless the group is trivial.
+gap> checkGens := function(G)
+>      local gens;
+>      gens := GeneratorsOfGroup(G);
+>      return gens = [One(G)] or ForAll(gens, g -> g <> One(G));
+>    end;;
+
+# imprimitive perm, trivial top
+gap> checkGens( WreathProduct(P, IP) );
+true
+
+# imprimitive perm, trivial base
+gap> checkGens( WreathProduct(IP, P) );
+true
+
+# imprimitive perm, trivial base and top
+gap> checkGens( WreathProduct(IP, IP) );
+true
+
+# imprimitive mat, trivial top
+gap> checkGens( WreathProduct(M, IP) );
+true
+
+# imprimitive mat, trivial base
+gap> checkGens( WreathProduct(IM, P) );
+true
+
+# imprimitive mat, trivial base and top
+gap> checkGens( WreathProduct(IM, IP) );
+true
+
+# product action perm, trivial top
+gap> checkGens( WreathProductProductAction(P, IP) );
+true
+
+# product action perm, trivial base
+gap> checkGens( WreathProductProductAction(IP, P) );
+true
+
+# product action perm, trivial base and top
+gap> checkGens( WreathProductProductAction(IP, IP) );
+true
+
+#
+gap> STOP_TEST("WreathProductWithTrivialGroups.tst");


### PR DESCRIPTION
Generators of wreath products should not contain the identity element, unless the group is trivial.

## Text for release notes

see title

## Further details

```
gap> WreathProduct(SymmetricGroup(3), Group( () ));
Group([ (1,2,3), (1,2), () ])
```
