### PR TITLE
Fix `IsomorphismFpGroup` for perm groups to avoid unexpected errors when e.g. computing preimages

### DIFF
--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -392,7 +392,7 @@ function(g,str,N)
       fi;
 
       # the range is elementary. Use this for the fp group isomorphism
-      f:=Range(hom);
+      f:=Image(hom);
       # calculate automorphisms of f induced by G
       fgens:=GeneratorsOfGroup(f);
       auts:=List(GeneratorsOfGroup(g),i->

--- a/tst/testbugfix/2024-Halloween-IsomorphismFp.tst
+++ b/tst/testbugfix/2024-Halloween-IsomorphismFp.tst
@@ -1,0 +1,8 @@
+# Fix for bug in IsomorphismFp
+# reported by Andries Brouwer, 10/31/24
+
+gap> G:=PSL(3,7);;
+gap> maxes := MaximalSubgroupClassReps(G);;
+gap> maxes1 := MaximalSubgroupClassReps(maxes[1]);;
+gap> maxes12:= maxes1[2];;
+gap> StructureDescription(maxes12:short);;

--- a/tst/testbugfix/2024-Halloween-IsomorphismFp.tst
+++ b/tst/testbugfix/2024-Halloween-IsomorphismFp.tst
@@ -5,4 +5,4 @@ gap> G:=PSL(3,7);;
 gap> maxes := MaximalSubgroupClassReps(G);;
 gap> maxes1 := MaximalSubgroupClassReps(maxes[1]);;
 gap> maxes12:= maxes1[2];;
-gap> StructureDescription(maxes12:short);;
+gap> StructureDescription(maxes12:short);;  # used to trigger an error


### PR DESCRIPTION
This fixes a bug reported to me by Andries Brouwer on 10/31/24
A homomorphism is created in a way that does not enforce it to be onto.