### PR TITLE
Make AvailabilityTest for packages optional

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -273,13 +273,6 @@ The following components of this record are <E>mandatory</E>.
   </Item>
   </List>
 </Item>
-<Mark><C>AvailabilityTest</C></Mark>
-<Item>
-  a function with no arguments that returns <K>true</K> if the package is
-  available, and <K>false</K> otherwise
-  (can be <Ref Func="ReturnTrue"/> if the package consists only of &GAP;
-  code).
-</Item>
 </List>
 
 The following components of the record are <E>optional</E>.
@@ -383,6 +376,13 @@ The following components of the record are <E>optional</E>.
     denoting conditions on external programs,
   </Item>
   </List>
+</Item>
+<Mark><C>AvailabilityTest</C></Mark>
+<Item>
+  a function with no arguments that returns <K>true</K> if the package is
+  available, and <K>false</K> otherwise
+  (can be <Ref Func="ReturnTrue"/> if the package consists only of &GAP;
+  code; this is also the default value),
 </Item>
 <Mark><C>BannerString</C> or <C>BannerFunction</C></Mark>
 <Item>

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -865,7 +865,7 @@ InstallGlobalFunction( PackageAvailabilityInfo,
 
       # Test whether the availability test function fits.
       GAPInfo.PackageCurrent:= inforec;
-      test:= inforec.AvailabilityTest();
+      test:= (not IsBound(inforec.AvailabilityTest)) or (inforec.AvailabilityTest() = true);
       Unbind( GAPInfo.PackageCurrent );
       if test = true then
         LogPackageLoadingMessage( PACKAGE_DEBUG,
@@ -2524,7 +2524,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
                                   ForAll( l, IsString ) ) and
                          IsBound( r.filename ) and IsString( r.filename ) ),
         "a list of records with components `needed' and `filename'" );
-    TestMandat( record, "AvailabilityTest", IsFunction, "a function" );
+    TestOption( record, "AvailabilityTest", IsFunction, "a function" );
     TestOption( record, "BannerFunction", IsFunction, "a function" );
     TestOption( record, "BannerString", IsString, "a string" );
     TestOption( record, "TestFile", IsFilename,

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -231,7 +231,6 @@ gap> info := rec(
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
 >     PackageWWWHome := "https://",
->     PackageDoc := rec(),
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);
@@ -239,16 +238,7 @@ gap> ValidatePackageInfo(info);
 /yyyy that represents a date since 1999
 #E  component `License' must be bound to a nonempty string containing an SPDX \
 ID
-#E  component `BookName' must be bound to a string
-#E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
-elative paths to readable files or directories
-#E  component `HTMLStart' must be bound to a string denoting a relative path t\
-o a readable file
-#E  component `PDFFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `SixFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `LongTitle' must be bound to a string
+#E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
 >     PackageName := "pkg",
@@ -261,22 +251,12 @@ gap> info := rec(
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
 >     PackageWWWHome := "https://",
->     PackageDoc := rec(),
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);
 #E  component `License' must be bound to a nonempty string containing an SPDX \
 ID
-#E  component `BookName' must be bound to a string
-#E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
-elative paths to readable files or directories
-#E  component `HTMLStart' must be bound to a string denoting a relative path t\
-o a readable file
-#E  component `PDFFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `SixFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `LongTitle' must be bound to a string
+#E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
 >     PackageName := "pkg",
@@ -289,7 +269,6 @@ gap> info := rec(
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
 >     PackageWWWHome := "https://",
->     PackageDoc := rec(),
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);
@@ -297,16 +276,7 @@ gap> ValidatePackageInfo(info);
 /yyyy that represents a date since 1999
 #E  component `License' must be bound to a nonempty string containing an SPDX \
 ID
-#E  component `BookName' must be bound to a string
-#E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
-elative paths to readable files or directories
-#E  component `HTMLStart' must be bound to a string denoting a relative path t\
-o a readable file
-#E  component `PDFFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `SixFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `LongTitle' must be bound to a string
+#E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
 >     PackageName := "pkg",
@@ -319,7 +289,6 @@ gap> info := rec(
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
 >     PackageWWWHome := "https://",
->     PackageDoc := rec(),
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);
@@ -327,16 +296,7 @@ gap> ValidatePackageInfo(info);
 /yyyy that represents a date since 1999
 #E  component `License' must be bound to a nonempty string containing an SPDX \
 ID
-#E  component `BookName' must be bound to a string
-#E  component `ArchiveURLSubset' must be bound to a list of strings denoting r\
-elative paths to readable files or directories
-#E  component `HTMLStart' must be bound to a string denoting a relative path t\
-o a readable file
-#E  component `PDFFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `SixFile' must be bound to a string denoting a relative path to \
-a readable file
-#E  component `LongTitle' must be bound to a string
+#E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
 >     PackageName := "pkg",

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -217,7 +217,6 @@ ps:// or ftp://
 #E  component `PackageWWWHome' must be bound to a string started with http://,\
  https:// or ftp://
 #E  component `PackageDoc' must be bound to a record or a list of records
-#E  component `AvailabilityTest' must be bound to a function
 false
 gap> ValidatePackageInfo(rec() : quiet);
 false

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -231,7 +231,7 @@ gap> info := rec(
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
 >     PackageWWWHome := "https://",
->     AvailabilityTest := ReturnTrue,
+>     AvailabilityTest := "invalid",  # ought to be a function
 >   );;
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
@@ -239,6 +239,7 @@ gap> ValidatePackageInfo(info);
 #E  component `License' must be bound to a nonempty string containing an SPDX \
 ID
 #E  component `PackageDoc' must be bound to a record or a list of records
+#E  component `AvailabilityTest', if present, must be bound to a function
 false
 gap> info := rec(
 >     PackageName := "pkg",

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -224,7 +224,8 @@ gap> info := rec(
 >     PackageName := "pkg",
 >     Subtitle := "desc",
 >     Version := "0",
->     Date := "01/20/2015",
+>     Date := "01/20/2015",      # invalid date, validator should flag it
+>     License := "GPL-2.0-or-later",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
 >     README_URL := "https://",
@@ -236,8 +237,6 @@ gap> info := rec(
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
-#E  component `License' must be bound to a nonempty string containing an SPDX \
-ID
 #E  component `PackageDoc' must be bound to a record or a list of records
 #E  component `AvailabilityTest', if present, must be bound to a function
 false
@@ -245,7 +244,8 @@ gap> info := rec(
 >     PackageName := "pkg",
 >     Subtitle := "desc",
 >     Version := "0",
->     Date := "2013-05-22",
+>     Date := "2013-05-22",     # valid ISO 8601 date
+>     License := "GPL-2.0-or-later",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
 >     README_URL := "https://",
@@ -255,15 +255,14 @@ gap> info := rec(
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);
-#E  component `License' must be bound to a nonempty string containing an SPDX \
-ID
 #E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
 >     PackageName := "pkg",
 >     Subtitle := "desc",
 >     Version := "0",
->     Date := "2013-22-05",
+>     Date := "2013-22-05",      # invalid date, validator should flag it
+>     License := "GPL-2.0-or-later",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
 >     README_URL := "https://",
@@ -275,15 +274,14 @@ gap> info := rec(
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
-#E  component `License' must be bound to a nonempty string containing an SPDX \
-ID
 #E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
 >     PackageName := "pkg",
 >     Subtitle := "desc",
 >     Version := "0",
->     Date := "2013-05-22-",
+>     Date := "2013-05-22-",   # invalid date, validator should flag it
+>     License := "GPL-2.0-or-later",
 >     ArchiveURL := "https://",
 >     ArchiveFormats := "",
 >     README_URL := "https://",
@@ -295,8 +293,6 @@ gap> info := rec(
 gap> ValidatePackageInfo(info);
 #E  component `Date' must be bound to a string of the form yyyy-mm-dd or dd/mm\
 /yyyy that represents a date since 1999
-#E  component `License' must be bound to a nonempty string containing an SPDX \
-ID
 #E  component `PackageDoc' must be bound to a record or a list of records
 false
 gap> info := rec(
@@ -311,7 +307,7 @@ gap> info := rec(
 >     PackageInfoURL := "https://",
 >     AbstractHTML := "",
 >     PackageWWWHome := "https://",
->     PackageDoc := rec(),
+>     PackageDoc := rec(),    # incomplete PackageDoc record
 >     AvailabilityTest := ReturnTrue,
 >   );;
 gap> ValidatePackageInfo(info);


### PR DESCRIPTION
If missing we assume it is ReturnTrue which is what >= 100 of our packages use.
