### PR TITLE
set an exit code in `make_doc`

### DIFF
--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -78,5 +78,10 @@ Print(outputstring);
 outputstring:= ReplacedString(outputstring, "\c", "");;
 errors:= Filtered(SplitString(outputstring, "\n"),
            x -> StartsWith(x, "#W ") and x <> "#W There are overfull boxes:");;
-QuitGap(Length(errors) = 0);
+if Length(errors) = 0 then
+  QuitGap(true);
+else
+  Print(errors, "\n");
+  QuitGap(false);
+fi;
 EOF

--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 GAP=@abs_top_builddir@/gap
-GAPARGS="-b -m 1g -x 80 -q --quitonbreak"
+GAPARGS="-b -m 1g -x 80 -q --quitonbreak -r"
 if [ "$1" == "nopdf" ]; then
   NOPDF=", \"nopdf\""
 else

--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -19,6 +19,11 @@ base:="@abs_top_srcdir@";;
 books:=["ref", "tut", "hpc", "dev"];;
 latexOpts := rec(Maintitlesize := "\\\\fontsize{36}{38}\\\\selectfont");;
 UpdateXMLForUserPreferences();
+outputstring:= "";;
+outputstream:= OutputTextString(outputstring, true);;
+SetPrintFormattingStatus(outputstream, false);
+SetInfoOutput(InfoGAPDoc, outputstream);
+SetInfoOutput(InfoWarning, outputstream);
 for run in [1,2] do
   for book in books do
     path := Concatenation(base, "/doc/", book);
@@ -29,10 +34,10 @@ for run in [1,2] do
         continue;
     fi;
 
-    Print("----------------------------\n");
-    Print("Building GAP manual '",book,"' at ",path,"\n");
-    Print("Run ",run," of 2\n");
-    Print("----------------------------\n");
+    AppendTo(outputstream, "----------------------------\n");
+    AppendTo(outputstream, "Building GAP manual '",book,"' at ",path,"\n");
+    AppendTo(outputstream, "Run ",run," of 2\n");
+    AppendTo(outputstream, "----------------------------\n");
 
     # for the reference manual, extra list of source files to scan
     if book = "ref" then
@@ -66,4 +71,12 @@ for run in [1,2] do
     MakeGAPDocDoc( path, "main.xml", files, book, "../..", "MathJax" $NOPDF);;
   od;
 od;
+CloseStream(outputstream);
+UnbindInfoOutput(InfoGAPDoc);
+UnbindInfoOutput(InfoWarning);
+Print(outputstring);
+outputstring:= ReplacedString(outputstring, "\c", "");;
+errors:= Filtered(SplitString(outputstring, "\n"),
+           x -> StartsWith(x, "#W ") and x <> "#W There are overfull boxes:");;
+QuitGap(Length(errors) = 0);
 EOF

--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -19,12 +19,14 @@ base:="@abs_top_srcdir@";;
 books:=["ref", "tut", "hpc", "dev"];;
 latexOpts := rec(Maintitlesize := "\\\\fontsize{36}{38}\\\\selectfont");;
 UpdateXMLForUserPreferences();
-outputstring:= "";;
-outputstream:= OutputTextString(outputstring, true);;
-SetPrintFormattingStatus(outputstream, false);
-SetInfoOutput(InfoGAPDoc, outputstream);
-SetInfoOutput(InfoWarning, outputstream);
 for run in [1,2] do
+  # collect output messages separately in both runs
+  outputstring:= "";;
+  outputstream:= OutputTextString(outputstring, true);;
+  SetPrintFormattingStatus(outputstream, false);
+  SetInfoOutput(InfoGAPDoc, outputstream);
+  SetInfoOutput(InfoWarning, outputstream);
+
   for book in books do
     path := Concatenation(base, "/doc/", book);
     dir := Directory(path);
@@ -70,11 +72,14 @@ for run in [1,2] do
     SetGapDocLaTeXOptions("color", latexOpts);
     MakeGAPDocDoc( path, "main.xml", files, book, "../..", "MathJax" $NOPDF);;
   od;
+
+  CloseStream(outputstream);
+  UnbindInfoOutput(InfoGAPDoc);
+  UnbindInfoOutput(InfoWarning);
+  Print(outputstring);
 od;
-CloseStream(outputstream);
-UnbindInfoOutput(InfoGAPDoc);
-UnbindInfoOutput(InfoWarning);
-Print(outputstring);
+
+# evaluate the outputs for the second run
 outputstring:= ReplacedString(outputstring, "\c", "");;
 errors:= Filtered(SplitString(outputstring, "\n"),
            x -> StartsWith(x, "#W ") and x <> "#W There are overfull boxes:");;


### PR DESCRIPTION
With this change, the CI tests detect whether errors like broken references occur when the manuals get built.

For that,
- redirect the `Info` output generated by GAPDoc functions to a string,
- extract the messages that describe warnings; according to https://github.com/frankluebeck/GAPDoc/commit/826c091491438c1f6ba1f330d17914f45b4bd3af, these are the lines starting with `"#W "`,
- omit the LaTeX warnings about overfull boxes (I think we do not want to force ourselves to create manuals without these warning),
- report failure if the set of remaining warnings is nonempty.