### PR TITLE
fix indentation when printing double cosets

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -536,7 +536,7 @@ function(d)
   return(STRINGIFY("DoubleCoset(\<",
                    ViewString(LeftActingGroup(d)),",\>",
                    ViewString(Representative(d)),",\>",
-                   ViewString(RightActingGroup(d)),")"));
+                   ViewString(RightActingGroup(d)),"\<)"));
 end);
 
 InstallMethodWithRandomSource(Random,


### PR DESCRIPTION
The distribution of `\<` and `\>` hints was obviously wrong.

I still do not understand why the hints were chosen this way. Usually the idea is to mark positions in the string where line breaks are more suitable than in other places, for example at the commas that separate objects; but here it is the other way round?

resolves #5840