### PR TITLE
kernel: simplify LtPRec code

### DIFF
--- a/src/precord.c
+++ b/src/precord.c
@@ -682,8 +682,8 @@ static Int LtPRec(Obj left, Obj right)
         // The sense of this comparison is determined by the rule that
         // unbound entries compare less than bound ones
         if ( GET_RNAM_PREC(left,i) != GET_RNAM_PREC(right,i) ) {
-            res = !LT(NAME_RNAM(labs(GET_RNAM_PREC(left, i))),
-                      NAME_RNAM(labs(GET_RNAM_PREC(right, i))));
+            res = !LT(NAME_RNAM(-GET_RNAM_PREC(left, i)),
+                      NAME_RNAM(-GET_RNAM_PREC(right, i)));
             break;
         }
 


### PR DESCRIPTION
Since both records are sorted at the start, we know that all values returned by `GET_RNAM_PREC` are negative. So we can do without `labs`.

In case someone is paranoid, note that `GET_RNAM_PREC` uses `ELM_PLIST` which has an assertion verifying the given index is positive.