### PR TITLE
kernel: simplify 'print path' handling

### DIFF
--- a/src/lists.c
+++ b/src/lists.c
@@ -1646,7 +1646,6 @@ Obj             TYPES_LIST_FAM (
 /****************************************************************************
 **
 *F  PrintListDefault(<list>)  . . . . . . . . . . . . . . . . .  print a list
-*F  PrintPathList(<list>,<indx>)  . . . . . . . . . . . . . print a list path
 **
 **  'PrintListDefault' simply prints the elements in the given list.
 **  The line break hints are consistent with those
@@ -1676,11 +1675,6 @@ static void PrintListDefault(Obj list)
         }
     }
     Pr(" %4<]", 0, 0);
-}
-
-static void PrintPathList(Obj list, Int indx)
-{
-    Pr("[%d]", indx, 0);
 }
 
 
@@ -2215,7 +2209,6 @@ static Int InitKernel (
     // install the default printers
     for ( type = FIRST_LIST_TNUM; type <= LAST_LIST_TNUM; type++ ) {
         PrintObjFuncs [ type ] = PrintListDefault;
-        PrintPathFuncs[ type ] = PrintPathList;
     }
 
 

--- a/src/objects.h
+++ b/src/objects.h
@@ -782,26 +782,6 @@ void ViewObj(Obj obj);
 
 /****************************************************************************
 **
-*V  PrintPathFuncs[<type>]  . . . . . . printer for subobjects of type <type>
-**
-**  'PrintPathFuncs'  is   the   dispatch table  that     contains for  every
-**  appropriate type of objects a pointer to  the path printer for objects of
-**  that type.  The path  printer is the function '<func>(<obj>,<idx>)' that
-**  should be  called  to print  the  selector   that selects  the  <idx>-th
-**  subobject of the object <obj> of this type.
-**
-**  These are also used for viewing
-*/
-extern void (*PrintPathFuncs[LAST_REAL_TNUM + 1])(Obj obj, Int idx);
-EXPORT_INLINE void PRINT_PATH(Obj obj, Int idx)
-{
-    UInt tnum = TNUM_OBJ(obj);
-    (PrintPathFuncs[tnum])(obj, idx);
-}
-
-
-/****************************************************************************
-**
 *F  IS_COMOBJ( <obj> )  . . . . . . . . . . . is an object a component object
 */
 EXPORT_INLINE BOOL IS_COMOBJ(Obj obj)

--- a/src/precord.c
+++ b/src/precord.c
@@ -521,11 +521,6 @@ void SortPRecRNam (
 */
 
 
-static void PrintPathPRec(Obj rec, Int indx)
-{
-    Pr(".%I", (Int)NAME_RNAM(labs(GET_RNAM_PREC(rec, indx))), 0);
-}
-
 /****************************************************************************
 **
 *F  FuncREC_NAMES( <self>, <rec> )  . . . . . . . .  record names of a record
@@ -850,8 +845,6 @@ static Int InitKernel (
     // install printer
     PrintObjFuncs[  T_PREC            ] = PrintPRec;
     PrintObjFuncs[  T_PREC +IMMUTABLE ] = PrintPRec;
-    PrintPathFuncs[ T_PREC            ] = PrintPathPRec;
-    PrintPathFuncs[ T_PREC +IMMUTABLE ] = PrintPathPRec;
 
     // install the comparison methods
     for (UInt t1 = T_PREC; t1 <= T_PREC + IMMUTABLE; t1++) {


### PR DESCRIPTION
No need for a complex dispatch setup when there really are only two cases to be handled.

Also remove some HPC-GAP specific code -- since the ObjectsModuleState is stored in thread local storage anyway, there is no need to dynamically allocate part of it.