### PR TITLE
Change GAP kernel version to 9.1 (also changes the shared library version)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ dnl    if any interfaces have been added since the last public release, then
 dnl    increment minor.
 dnl
 m4_define([kernel_major_version], [9])
-m4_define([kernel_minor_version], [0])
+m4_define([kernel_minor_version], [1])
 
 m4_define([GAP_DEFINE], [GAP_DEFINES="$GAP_DEFINES -D$1"])
 


### PR DESCRIPTION
This indicates that new interfaces were added to the kernel but no existing ones were removed or changed. This change also adjusts the shared library version.


Should PRs #5849 or #5850 get into the release we'd need to change the kernel version to 10.0, so perhaps we wait a bit with merging those (CC @ChrisJefferson)