### PR TITLE
Increase GAP kernel version to 10.0 to indicate there were breaking kernel changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,8 +23,8 @@ dnl 2. Otherwise (i.e., if no interfaces have been removed or changed),
 dnl    if any interfaces have been added since the last public release, then
 dnl    increment minor.
 dnl
-m4_define([kernel_major_version], [9])
-m4_define([kernel_minor_version], [1])
+m4_define([kernel_major_version], [10])
+m4_define([kernel_minor_version], [0])
 
 m4_define([GAP_DEFINE], [GAP_DEFINES="$GAP_DEFINES -D$1"])
 


### PR DESCRIPTION
E.g. we had #5849 -- while it likely won't affect 99% of kernel extension and other libgap consumers, it nevertheless is "breaking change"