### PR TITLE
kernel: fix potential bug in 'print path' tracking

### DIFF
--- a/src/objects.c
+++ b/src/objects.c
@@ -986,6 +986,9 @@ void PrintObj(Obj obj)
     // dispatch to the appropriate printing function
     else if (os->PrintObjDepth < MAXPRINTDEPTH) {
 
+        Obj oldThis = os->PrintObjThiss[os->PrintObjDepth];
+        Int oldIndx = os->PrintObjIndices[os->PrintObjDepth];
+
         // push obj on the stack
         os->PrintObjThiss[os->PrintObjDepth] = obj;
         os->PrintObjIndices[os->PrintObjDepth] = 0;
@@ -998,6 +1001,8 @@ void PrintObj(Obj obj)
 
         // pop <obj> from the stack
         os->PrintObjDepth--;
+        os->PrintObjThiss[os->PrintObjDepth] = oldThis;
+        os->PrintObjIndices[os->PrintObjDepth] = oldIndx;
     }
     else {
         Pr("\nprinting stopped, too many recursion levels!\n", 0, 0);
@@ -1097,6 +1102,9 @@ void ViewObj(Obj obj)
     // dispatch to the appropriate viewing function
     else if (os->PrintObjDepth < MAXPRINTDEPTH) {
 
+        Obj oldThis = os->PrintObjThiss[os->PrintObjDepth];
+        Int oldIndx = os->PrintObjIndices[os->PrintObjDepth];
+
         // push obj on the stack
         os->PrintObjThiss[os->PrintObjDepth] = obj;
         os->PrintObjIndices[os->PrintObjDepth] = 0;
@@ -1109,6 +1117,8 @@ void ViewObj(Obj obj)
 
         // pop <obj> from the stack
         os->PrintObjDepth--;
+        os->PrintObjThiss[os->PrintObjDepth] = oldThis;
+        os->PrintObjIndices[os->PrintObjDepth] = oldIndx;
     }
     else {
         Pr("\nviewing stopped, too many recursion levels!\n", 0, 0);


### PR DESCRIPTION
The kernel function `SetPrintObjState` is used to save the current printing state at the start of a new read-eval-loop, and to restore it to the previous value.

The idea here being that if an error triggering a break loop is raised in the middle of printing, the printing state is stored; then the user performs action in the break loop, which of course can trigger printing, and thus modify the kernel printing state. Hence it makes sense to save and restore this state.

Alas, we only stored the current depth of the printing stack, but not its *content*. Any printing in the print loop would overwrite this content.

So in the above scenario, after existing the break loop, we'd be accessing the wrong objects. In fact these objects might not even exist anymore, and a crash could result.

We solve this by adjusting the code modifying these stacks to actually safe and restore the content of the printing stacks, too.

Most likely nobody ever triggered this.