### PR TITLE
Fix 'gap --version' to send its output to stdout and include a trailing newline

### DIFF
--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -405,6 +405,24 @@ GAPInput
   testexpect)
     INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b $(gap_cover_arg 1)" $SRCDIR/dev/gaptest.expect
     INPUTRC=/tmp/inputrc expect -c "spawn $GAP -A -b $(gap_cover_arg 2) -l missing-dir" $SRCDIR/dev/gaptest2.expect
+
+    # not using expect but in a similar vein: check `gap --version output`
+    echo "Testing 'gap --version'"
+    $GAP --version 0>gap_stdin 1>gap_stdout 2>gap_stderr
+    if [ -s gap_stdin ] ; then
+        echo "Error, 'gap --version' prints to stdin but should not"
+        exit 1
+    fi
+    if [ -s gap_stderr ] ; then
+        echo "Error, 'gap --version' prints to stderr but should not"
+        exit 1
+    fi
+    if ! fgrep -q 'GAP 4.' gap_stdout; then
+        # must look like "GAP 4.X.y ..."
+        echo "Error, 'gap --version' does not print expected output to stdout"
+        exit 1
+    fi
+
     ;;
 
   *)

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -134,6 +134,7 @@
 #endif
 
 #ifdef GAP_MEM_CHECK
+#include <stdio.h>
 #include <sys/mman.h>
 #endif
 
@@ -1140,7 +1141,7 @@ Int EnableMemCheck = 0;
 
 Int enableMemCheck(Char ** argv, void * dummy)
 {
-    SyFputs( "# Warning: --enableMemCheck causes SEVERE slowdowns. Starting GAP may take several days!\n", 3 );
+    fputs("# Warning: --enableMemCheck causes SEVERE slowdowns. Starting GAP may take several days!\n", stderr);
     EnableMemCheck = 1;
     return 1;
 }

--- a/src/system.c
+++ b/src/system.c
@@ -465,8 +465,8 @@ static Int setGapRootPath( Char **argv, void *Dummy)
 
 static Int enableMemCheck(Char ** argv, void * dummy)
 {
-    SyFputs( "# Error: --enableMemCheck not supported by this copy of GAP\n", 3);
-    SyFputs( "  pass --enable-memory-checking to ./configure\n", 3 );
+    fputs("# Error: --enableMemCheck not supported by this copy of GAP\n", stderr);
+    fputs("  pass --enable-memory-checking to ./configure\n", stderr);
     SyExit(2);
 }
 #endif
@@ -474,10 +474,11 @@ static Int enableMemCheck(Char ** argv, void * dummy)
 
 static Int printVersion(Char ** argv, void * dummy)
 {
-    SyFputs("GAP ", 1);
-    SyFputs(SyBuildVersion, 1);
-    SyFputs(" built on ", 1);
-    SyFputs(SyBuildDateTime, 1);
+    fputs("GAP ", stdout);
+    fputs(SyBuildVersion, stdout);
+    fputs(" built on ", stdout);
+    fputs(SyBuildDateTime, stdout);
+    fputs("\n", stdout);
     SyExit(0);
 }
 


### PR DESCRIPTION
Also add a trailing newline.

Apparently it was printing to `stdin` before. Even after looking at the code I completely fail to see *why* it did that. But while I'd love to get to the bottom of this, let's first get this trivial fix out of the door.