### PR TITLE
Change update-gh-pages workflow to download all packages

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Build GAP
         run: |
           make -j4
-      - name: Download minimal packages
+      - name: Download packages
         run: |
-          make bootstrap-pkg-minimal
+          make bootstrap-pkg-full
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Currently, the "update-gh-pages" workflow calls `make bootstrap-pkg-minimal` when setting up GAP, and then proceeds to create the GAP manual. However, the manual contains references to the manuals of packages not contained in this minimal installation. So even after a second run, GAPDoc will report a plethora of warnings:
```
#W WARNING: non resolved reference: rec(
BookName := "browse",
Func := "BrowseUserPreferences" )
#W WARNING: non resolved reference: rec(
BookName := "browse",
Func := "BrowseProfile" )
#W WARNING: non resolved reference: rec(
BookName := "browse",
Func := "BrowseDirectory" )
#W WARNING: non resolved reference: rec(
BookName := "IO",
Oper := "IO_File" )
[...]
```

This causes the hyperlinks in the HTML version of the manual to not work, see e.g. [here](https://gap-system.github.io/gap/doc/ref/chap3_mj.html#X7B0AD104839B6C3C):

> The **Browse** package provides the function `BrowseUserPreferences` (???) which gives an overview of the known user preferenes and also admits editing the values of the preferences.

This PR configures the action to instead call `make bootstrap-pkg-full`, which ensures that the relevant packages (and their documentation) are present.

## Text for release notes

None, I think, since this is not relevant for the actual GAP program.