### PR TITLE
Manual: remove duplicate PostalAddress field for persons linked to a GAP package

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -314,7 +314,7 @@ The following components of the record are <E>optional</E>.
   </Item>
   </List>
   If the <C>IsMaintainer</C> value is <K>true</K> then also one of the
-  following components is mandatory.
+  following components is mandatory, otherwise these components are optional.
   <List>
   <Mark><C>Email</C></Mark>
   <Item>

--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -304,10 +304,6 @@ The following components of the record are <E>optional</E>.
   <Item>
     a string (was mandatory before &GAP; 4.14),
   </Item>
-  <Mark><C>PostalAddress</C></Mark>
-  <Item>
-    a string,
-  </Item>
   <Mark><C>Place</C></Mark>
   <Item>
     a string,


### PR DESCRIPTION
In [section 76.3-15](https://docs.gap-system.org/doc/ref/chap76.html#X85C8DE357EE424D8) of the manual, `PostalAddress` is listed twice as a possible component for a `Persons` record. First as a purely optional component, then as a potentially mandatory component if the person is a maintainer.

I think the first occurrence can be removed, considering that neither the `Email` nor the `WWWHome` components are listed twice either?

## Text for release notes

none