### PR TITLE
CI: increase timeout for GAP.jl jobs

### DIFF
--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - GAP.jl ${{ matrix.gapjl-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Recently GAP.jl switched to downloading each package archive
separately. That takes longer the first time around (subsequent
runs in the CI are faster again thanks to caching).
