### PR TITLE
Fix `ImmutableMatrix` to not strip memory from matrices in the `IsObjWithMemory` filter

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -448,6 +448,21 @@ InstallOtherMethod(ProjectiveOrder,"object with memory",
     return ProjectiveOrder(a!.el);
   end);
 
+InstallOtherMethod( ImmutableMatrix,"object with memory",[IsField,IsMatrixOrMatrixObj and IsObjWithMemory],
+function(f,a)
+    local r;
+    r := rec(slp := a!.slp, n := a!.n, el := ImmutableMatrix(f, a!.el));
+    Objectify(TypeOfObjWithMemory(FamilyObj(a)),r);
+    SetFilterObj(r,IsMatrixOrMatrixObj);
+    if IsMatrix(a) then
+      SetFilterObj(r,IsMatrix);
+    fi;
+    if IsMatrixObj(a) then
+      SetFilterObj(r,IsMatrixObj);
+    fi;
+    return r;
+end);
+
 # Free group methods:
 
 InstallOtherMethod( Length, "for a word with memory",

--- a/tst/testinstall/memory.tst
+++ b/tst/testinstall/memory.tst
@@ -35,3 +35,11 @@ gap> g * h;
   [ Z(3)^0, 0*Z(3), 0*Z(3) ] ] with mem>
 gap> g * G.1;
 Error, \* for objects with memory: a!.slp and b!.slp must be identical
+
+# ImmutableMatrix on a matrix with memory
+# see https://github.com/gap-system/gap/issues/5872
+gap> G:=GroupWithMemory(SL(4,16));;
+gap> g:=ImmutableMatrix(GF(4), G.1^5);
+<[ [ Z(2^2), 0*Z(2), 0*Z(2), 0*Z(2) ], [ 0*Z(2), Z(2^2)^2, 0*Z(2), 0*Z(2) ], 
+  [ 0*Z(2), 0*Z(2), Z(2)^0, 0*Z(2) ], [ 0*Z(2), 0*Z(2), 0*Z(2), Z(2)^0 ] 
+ ] with mem>


### PR DESCRIPTION
Fixes #5872

I'd like to backport this for GAP 4.14.1