### PR TITLE
Support compressed files in `PageSource`

### DIFF
--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -534,10 +534,15 @@ BIND_GLOBAL("PageSource", function ( fun, nr... )
         else
           Print( "Source not available.\n" );
         fi;
-    elif not (IsExistingFile(f) and IsReadableFile(f)) then
-        Print( "Cannot access code from file \"",f,"\".\n");
     else
+      if not IsExistingFile(f) and IsExistingFile(Concatenation(f, ".gz")) then
+        f:= Concatenation(f, ".gz");
+      fi;
+      if not (IsExistingFile(f) and IsReadableFile(f)) then
+        Print( "Cannot access code from file \"",f,"\".\n");
+      else
         Print( "Showing source in ", f, " (from line ", l, ")\n" );
         Pager(rec(lines := StringFile(f), formatted := true, start := l));
+      fi;
     fi;
 end);


### PR DESCRIPTION
Without this change, we get
```
gap>  PageSource(IdStandardPresented512Group);
Cannot access code from file "/.../pkg/smallgrp/small7/smlgp7.g".
```
because the file in question is compressed and thus `IsExistingFile` returns `false` for `smlgp7.g`.
With this change, the code of the function is shown.

Are there perhaps other functions which should be improved in the same way?