### PR TITLE
kernel: remove `SyOriginalArgv` & `SyOriginalArgc`

### DIFF
--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -157,8 +157,6 @@ extern Char * SyRestoring;
 
 extern UInt SyInitializing;
 
-extern Char ** SyOriginalArgv;
-extern UInt    SyOriginalArgc;
 
 /****************************************************************************
 **

--- a/src/system.c
+++ b/src/system.c
@@ -541,11 +541,6 @@ static const struct optInfo options[] = {
   { 0, "", 0, 0, 0}};
 
 
-Char ** SyOriginalArgv;
-UInt SyOriginalArgc;
-
-
-
 void InitSystem (
     Int                 argc,
     Char *              argv [],
@@ -599,10 +594,6 @@ void InitSystem (
     if (handleSignals) {
         SyInstallAnswerIntr();
     }
-
-    // save the original command line for export to GAP
-    SyOriginalArgc = argc;
-    SyOriginalArgv = argv;
 
     // scan the command line for options that we have to process in the kernel
     // we just scan the whole command line looking for the keys for the options we recognise


### PR DESCRIPTION
These kept references to the `argv` array around. This is potentially problematic for consumers of libgap API, specifically when calling `GAP_Initialize` it is not obvious that one has to keep the `argv` passed to it alive until after GAP completed its startup.

While we could amend the documentation for `GAP_Initialize` (which unfortunately currently does exist at all) to mention this, it seems better to obviate the need for it.

This patch is a first step towards this. However, several pointers to `argv` members remain, at least these:
- `SyCompileOutput`
- `SyCompileInput`
- `SyCompileName`
- `SyCompileMagic1`
- `SyRestoring`

