### PR TITLE
kernel: clarify comments when calling InitGlobalBag

### DIFF
--- a/src/bool.c
+++ b/src/bool.c
@@ -347,7 +347,7 @@ static Int InitKernel (
     ImportGVarFromLibrary( "TYPE_BOOL", &TYPE_BOOL );
     TypeObjFuncs[ T_BOOL ] = TypeBool;
 
-    // make the boolean bags
+    // register boolean bags with the garbage collector
     InitGlobalBag( &True,  "src/bool.c:TRUE"  );
     InitGlobalBag( &False, "src/bool.c:FALSE" );
     InitGlobalBag( &Fail,  "src/bool.c:FAIL"  );

--- a/src/code.c
+++ b/src/code.c
@@ -3184,7 +3184,7 @@ static Int InitKernel (
     MakeBagTypePublic(T_BODY);
 #endif
 
-    // allocate the statements and expressions stacks
+    // register global bags with the garbage collector
     InitGlobalBag(&CS(StackStat), "CS(StackStat)");
     InitGlobalBag(&CS(StackExpr), "CS(StackExpr)");
 

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -1738,7 +1738,7 @@ static Int InitLibrary (
 
 static Int InitModuleState(void)
 {
-#ifndef HPCGAP
+    // register global bags with the garbage collector
     InitGlobalBag( &CollectorsState()->SC_NW_STACK, "SC_NW_STACK" );
     InitGlobalBag( &CollectorsState()->SC_LW_STACK, "SC_LW_STACK" );
     InitGlobalBag( &CollectorsState()->SC_PW_STACK, "SC_PW_STACK" );
@@ -1746,7 +1746,6 @@ static Int InitModuleState(void)
     InitGlobalBag( &CollectorsState()->SC_GE_STACK, "SC_GE_STACK" );
     InitGlobalBag( &CollectorsState()->SC_CW_VECTOR, "SC_CW_VECTOR" );
     InitGlobalBag( &CollectorsState()->SC_CW2_VECTOR, "SC_CW2_VECTOR" );
-#endif
 
     const UInt maxStackSize = 256;
     const UInt desiredStackSize = sizeof(Obj) * (maxStackSize + 2);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -5463,7 +5463,7 @@ static Int InitKernel (
     // init filters and functions
     InitHdlrFuncsFromTable( GVarFuncs );
 
-    // announce the global variables
+    // register global bags with the garbage collector
     InitGlobalBag( &CompInfoGVar,  "src/compiler.c:CompInfoGVar"  );
     InitGlobalBag( &CompInfoRNam,  "src/compiler.c:CompInfoRNam"  );
     InitGlobalBag( &CompFunctions, "src/compiler.c:CompFunctions" );

--- a/src/costab.c
+++ b/src/costab.c
@@ -2337,7 +2337,7 @@ static Int InitKernel (
     // import type object
     InitCopyGVar("TYPE_LOWINDEX_DATA", &TYPE_LOWINDEX_DATA);
 
-    // static variables
+    // register global bags with the garbage collector
     InitGlobalBag( &objRel      , "src/costab.c:objRel"       );
     InitGlobalBag( &objNums     , "src/costab.c:objNums"      );
     InitGlobalBag( &objFactor   , "src/costab.c:objFactor"    );

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -2077,10 +2077,8 @@ static Int InitKernel (
     // install the marking function
     InitMarkFuncBags( T_CYC, MarkCycSubBags );
 
-    // create the result buffer
+    // register global bags with the garbage collector
     InitGlobalBag( &ResultCyc , "src/cyclotom.c:ResultCyc" );
-
-    // tell Gasman about the place were we remember the primitive root
     InitGlobalBag( &LastECyc, "src/cyclotom.c:LastECyc" );
 
     // install the type function

--- a/src/finfield.c
+++ b/src/finfield.c
@@ -1528,7 +1528,7 @@ static Int InitKernel (
     InitFopyGVar( "PrimitiveRootMod", &PrimitiveRootMod );
     TypeObjFuncs[ T_FFE ] = TypeFFE;
 
-    // create the fields and integer conversion bags
+    // register global bags with the garbage collector
     InitGlobalBag( &SuccFF, "src/finfield.c:SuccFF" );
     InitGlobalBag( &TypeFF, "src/finfield.c:TypeFF" );
     InitGlobalBag( &TypeFF0, "src/finfield.c:TypeFF0" );

--- a/src/gap.c
+++ b/src/gap.c
@@ -1315,7 +1315,7 @@ static StructGVarFunc GVarFuncs[] = {
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    // list of exit functions
+    // register global bags with the garbage collector
     InitGlobalBag( &WindowCmdString, "src/gap.c:WindowCmdString" );
 
     // init filters and functions

--- a/src/intrprtr.c
+++ b/src/intrprtr.c
@@ -4163,11 +4163,9 @@ void IntrAssertEnd3Args(IntrState * intr)
 static Int InitKernel (
     StructInitInfo *    module )
 {
+    // register global bags with the garbage collector
     InitGlobalBag( &STATE(ErrorLVars), "STATE(ErrorLVars)"         );
-
-    // Ensure that the value in '~' does not get garbage collected
     InitGlobalBag( &STATE(Tilde), "STATE(Tilde)" );
-
     InitGlobalBag( &VoidReturnMarker, "VoidReturnMarker");
 
     // Create a bag which is not used anywhere else

--- a/src/io.c
+++ b/src/io.c
@@ -1981,7 +1981,7 @@ static Int InitKernel (
     DeclareGVar(&DEFAULT_OUTPUT_STREAM, "DEFAULT_OUTPUT_STREAM");
 
 #else
-    // tell GASMAN about the global bags
+    // register global bags with the garbage collector
     InitGlobalBag(&(IO()->InputLogFileOrStream.stream),
                   "src/io.c:InputLogFileOrStream");
     InitGlobalBag(&(IO()->OutputLogFileOrStream.stream),

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -3671,6 +3671,7 @@ static Int InitKernel (
 
     CountFlags = 0;
 
+    // register global bags with the garbage collector
     InitGlobalBag( &StringFilterSetter, "src/opers.c:StringFilterSetter" );
     InitGlobalBag( &ArglistObj,         "src/opers.c:ArglistObj"         );
     InitGlobalBag( &ArglistObjVal,      "src/opers.c:ArglistObjVal"      );
@@ -3750,21 +3751,13 @@ static Int InitKernel (
     ImportGVarFromLibrary( "TYPE_FLAGS", &TYPE_FLAGS );
     TypeObjFuncs[ T_FLAGS ] = TypeFlags;
 
-
-    // set up hidden implications
+    // register global bags with the garbage collector
     InitGlobalBag( &WITH_HIDDEN_IMPS_FLAGS_CACHE, "src/opers.c:WITH_HIDDEN_IMPS_FLAGS_CACHE");
     InitGlobalBag( &HIDDEN_IMPS, "src/opers.c:HIDDEN_IMPS");
-
-    // set up implications
     InitGlobalBag( &WITH_IMPS_FLAGS_CACHE, "src/opers.c:WITH_IMPS_FLAGS_CACHE");
     InitGlobalBag( &IMPLICATIONS_SIMPLE, "src/opers.c:IMPLICATIONS_SIMPLE");
     InitGlobalBag( &IMPLICATIONS_COMPOSED, "src/opers.c:IMPLICATIONS_COMPOSED");
-
-    // make the 'true' operation
     InitGlobalBag( &ReturnTrueFilter, "src/opers.c:ReturnTrueFilter" );
-
-    // install the (function) copies of global variables
-    /*for the inside-out (kernel to library) interface                    */
     InitGlobalBag( &TRY_NEXT_METHOD, "src/opers.c:TRY_NEXT_METHOD" );
 
     ImportFuncFromLibrary("ReturnTrue", &ReturnTrue);

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -2898,12 +2898,8 @@ static Int InitKernel (
     InitHandlerFunc( (ObjFunc)FuncListPerm1, "src/permutat.cc:FuncListPerm1" );
     InitHandlerFunc( (ObjFunc)FuncListPerm2, "src/permutat.cc:FuncListPerm2" );
 
-    // make the buffer bag
-#ifndef HPCGAP
+    // register global bags with the garbage collector
     InitGlobalBag( &TmpPerm, "src/permutat.cc:TmpPerm" );
-#endif
-
-    // make the identity permutation
     InitGlobalBag( &IdentityPerm, "src/permutat.cc:IdentityPerm" );
 
 #ifdef GAP_ENABLE_SAVELOAD

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -3861,11 +3861,8 @@ static Int InitKernel(StructInitInfo * module)
     InitHdlrFiltsFromTable(GVarFilts);
     InitHdlrFuncsFromTable(GVarFuncs);
 
-// make the buffer bag
-#ifndef HPCGAP
+    // register global bags with the garbage collector
     InitGlobalBag(&TmpPPerm, "src/pperm.c:TmpPPerm");
-#endif
-
     InitGlobalBag(&EmptyPartialPerm, "src/pperm.c:EmptyPartialPerm");
 
 #ifdef GAP_ENABLE_SAVELOAD

--- a/src/records.c
+++ b/src/records.c
@@ -453,7 +453,7 @@ static Int InitKernel (
 {
     UInt                type;           // loop variable
 
-    // make the list of names of record names
+    // register global bags with the garbage collector
     InitGlobalBag( &NamesRNam, "src/records.c:NamesRNam" );
 
     // make the hash list of record names

--- a/src/stats.c
+++ b/src/stats.c
@@ -1548,7 +1548,7 @@ static Int InitKernel (
 {
     UInt                i;              // loop variable
 
-    // make the global bags known to Gasman
+    // register global bags with the garbage collector
     InitGlobalBag( &STATE(ReturnObjStat), "src/stats.c:ReturnObjStat" );
 
     // connect to external functions

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -4210,12 +4210,8 @@ static Int InitKernel(StructInitInfo * module)
     InitHdlrFiltsFromTable(GVarFilts);
     InitHdlrFuncsFromTable(GVarFuncs);
 
-// make the buffer bag
-#ifndef HPCGAP
+    // register global bags with the garbage collector
     InitGlobalBag(&MODULE_STATE(Trans).TmpTrans, "src/trans.c:TmpTrans");
-#endif
-
-    // make the identity trans
     InitGlobalBag(&IdentityTrans, "src/trans.c:IdentityTrans");
 
 #ifdef GAP_ENABLE_SAVELOAD


### PR DESCRIPTION
Several of the old comments were phrased in a way that suggested `InitGlobalBag` would "create" something, which is not the case. Also some referred to Gasman, even though `InitGlobalBag` also does something when using the Julia garbage collector.

Also remove some `#ifndef HPCGAP` which were redundant as `InitGlobalBag` already is a no-op in HPC-GAP.