### PR TITLE
kernel: adjust SyGasmanNumbers initialization

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -596,15 +596,6 @@ void InitSystem (
     SyUseModule = 1;
     SyWindow = 0;
 
-#ifdef USE_GASMAN
-    for (i = 0; i < 2; i++) {
-      UInt j;
-      for (j = 0; j < 7; j++) {
-        SyGasmanNumbers[i][j] = 0;
-      }
-    }
-#endif
-
     if (handleSignals) {
         SyInstallAnswerIntr();
     }


### PR DESCRIPTION
Global variables are guaranteed to be zero initialized, so we can just discard this. Note that the existing code actually used the wrong bounds (it looped from 0 to 6 in the second argument, but should have looped to 8).