### PR TITLE
CI: more timeouts, run testworkspace on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -287,6 +287,7 @@ jobs:
   cross_compile:
     # The host should always be linux
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     name: Cross compiler for s390x
 
     steps:
@@ -362,6 +363,7 @@ jobs:
 
   openbsd:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     name: Test in OpenBSD
     env:
       AUTOCONF_VERSION: 2.71

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,7 +89,7 @@ jobs:
           # this job also tests GAP without readline and gmp
           - os: macos-latest
             shell: bash
-            test-suites: "testmockpkg testinstall"
+            test-suites: "testmockpkg testinstall testworkspace"
             extra: "BOOTSTRAP_MINIMAL=yes"
 
           # run bugfix regression tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       gap-build-version: ${{ steps.get-build.outputs.name }}
 
@@ -171,6 +172,7 @@ jobs:
     name: "Create Windows x86_64 installer"
     needs: unix
     runs-on: windows-2019
+    timeout-minutes: 120
     env:
       CHERE_INVOKING: 1
       GAP_VERSION: ${{ needs.unix.outputs.gap-build-version }}


### PR DESCRIPTION
- **CI: add more timeouts**
- **CI: run testworkspace also on macOS**

Turns out testworkspace on macOS resp. BSD may behave differently
from Linux, so better run it there, too. It is a quick test anyway.