### PR TITLE
kernel: close streams after internal exception

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -853,9 +853,10 @@ static Obj FuncREAD(Obj self, Obj inputObj)
 static Obj FuncREAD_STREAM_LOOP(Obj self,
                                 Obj instream,
                                 Obj outstream,
-                                Obj context)
+                                Obj ctx)
 {
     Int res;
+    volatile Obj context = ctx;
 
     RequireInputStream(SELF_NAME, instream);
     RequireOutputStream(SELF_NAME, outstream);

--- a/src/streams.c
+++ b/src/streams.c
@@ -139,7 +139,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
     RequireInputStream("READ_ALL_COMMANDS", instream);
 
     // try to open the streams
-    TypInputFile input;
+    volatile TypInputFile input;
     if (!OpenInputStream(&input, instream, echo == True)) {
         return Fail;
     }
@@ -149,7 +149,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
         outstream = DoOperation2Args(ValGVar(GVarName("OutputTextString")),
                                      outstreamString, True);
     }
-    TypOutputFile output;
+    volatile TypOutputFile output;
     if (outstream && !OpenOutputStream(&output, outstream)) {
         CloseInput(&input);
         return Fail;
@@ -242,7 +242,7 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     AssPlist(result, 1, False);
 
     // open the stream, read a command, and close it again
-    TypInputFile input;
+    volatile TypInputFile input;
     if (!OpenInputStream(&input, stream, echo == True)) {
         return result;
     }
@@ -414,7 +414,7 @@ Int READ_GAP_ROOT ( const Char * filename )
         Pr("#I  READ_GAP_ROOT: loading '%s' as GAP file\n", (Int)filename, 0);
     }
 
-    TypInputFile input;
+    volatile TypInputFile input;
     if (!OpenInput(&input, path))
         return 0;
 
@@ -455,7 +455,7 @@ static Obj FuncCALL_WITH_STREAM(Obj self, Obj stream, Obj func, Obj args)
     RequireOutputStream(SELF_NAME, stream);
     RequireSmallList(SELF_NAME, args);
 
-    TypOutputFile output;
+    volatile TypOutputFile output;
     if (!OpenOutputStream(&output, stream)) {
         ErrorQuit("CALL_WITH_STREAM: cannot open stream for output", 0, 0);
     }
@@ -699,7 +699,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
     // first entry is the file or stream
     destination = ELM_LIST(args, 1);
 
-    TypOutputFile output;
+    volatile TypOutputFile output;
 
     // try to open the output and handle failures
     if (file) {
@@ -820,7 +820,7 @@ static Obj FuncAPPEND_TO_STREAM(Obj self, Obj args)
 */
 static Obj FuncREAD(Obj self, Obj inputObj)
 {
-    TypInputFile input;
+    volatile TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 
@@ -867,12 +867,12 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
                         "must be a local variables bag "
                         "or the value 'false'");
 
-    TypInputFile input;
+    volatile TypInputFile input;
     if (!OpenInputStream(&input, instream, FALSE)) {
         return False;
     }
 
-    TypOutputFile output;
+    volatile TypOutputFile output;
     if (!OpenOutputStream(&output, outstream)) {
         res = CloseInput(&input);
         GAP_ASSERT(res);
@@ -947,7 +947,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
 */
 static Obj FuncREAD_AS_FUNC(Obj self, Obj inputObj)
 {
-    TypInputFile input;
+    volatile TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -139,7 +139,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
     RequireInputStream("READ_ALL_COMMANDS", instream);
 
     // try to open the streams
-    volatile TypInputFile input;
+    TypInputFile input;
     if (!OpenInputStream(&input, instream, echo == True)) {
         return Fail;
     }
@@ -149,7 +149,7 @@ Obj READ_ALL_COMMANDS(Obj instream, Obj echo, Obj capture, Obj resultCallback)
         outstream = DoOperation2Args(ValGVar(GVarName("OutputTextString")),
                                      outstreamString, True);
     }
-    volatile TypOutputFile output;
+    TypOutputFile output;
     if (outstream && !OpenOutputStream(&output, outstream)) {
         CloseInput(&input);
         return Fail;
@@ -242,7 +242,7 @@ static Obj FuncREAD_COMMAND_REAL(Obj self, Obj stream, Obj echo)
     AssPlist(result, 1, False);
 
     // open the stream, read a command, and close it again
-    volatile TypInputFile input;
+    TypInputFile input;
     if (!OpenInputStream(&input, stream, echo == True)) {
         return result;
     }
@@ -414,7 +414,7 @@ Int READ_GAP_ROOT ( const Char * filename )
         Pr("#I  READ_GAP_ROOT: loading '%s' as GAP file\n", (Int)filename, 0);
     }
 
-    volatile TypInputFile input;
+    TypInputFile input;
     if (!OpenInput(&input, path))
         return 0;
 
@@ -455,7 +455,7 @@ static Obj FuncCALL_WITH_STREAM(Obj self, Obj stream, Obj func, Obj args)
     RequireOutputStream(SELF_NAME, stream);
     RequireSmallList(SELF_NAME, args);
 
-    volatile TypOutputFile output;
+    TypOutputFile output;
     if (!OpenOutputStream(&output, stream)) {
         ErrorQuit("CALL_WITH_STREAM: cannot open stream for output", 0, 0);
     }
@@ -699,7 +699,7 @@ static Obj PRINT_OR_APPEND_TO_FILE_OR_STREAM(Obj args, int append, int file)
     // first entry is the file or stream
     destination = ELM_LIST(args, 1);
 
-    volatile TypOutputFile output;
+    TypOutputFile output;
 
     // try to open the output and handle failures
     if (file) {
@@ -820,7 +820,7 @@ static Obj FuncAPPEND_TO_STREAM(Obj self, Obj args)
 */
 static Obj FuncREAD(Obj self, Obj inputObj)
 {
-    volatile TypInputFile input;
+    TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 
@@ -867,12 +867,12 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
                         "must be a local variables bag "
                         "or the value 'false'");
 
-    volatile TypInputFile input;
+    TypInputFile input;
     if (!OpenInputStream(&input, instream, FALSE)) {
         return False;
     }
 
-    volatile TypOutputFile output;
+    TypOutputFile output;
     if (!OpenOutputStream(&output, outstream)) {
         res = CloseInput(&input);
         GAP_ASSERT(res);
@@ -947,7 +947,7 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
 */
 static Obj FuncREAD_AS_FUNC(Obj self, Obj inputObj)
 {
-    volatile TypInputFile input;
+    TypInputFile input;
     if (!OpenInputFileOrStream(SELF_NAME, &input, inputObj))
         return False;
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -881,8 +881,8 @@ static Obj FuncREAD_STREAM_LOOP(Obj self,
 
     LockCurrentOutput(TRUE);
 
-    // get the starting time
-    UInt oldPrintObjState = SetPrintObjState(0);
+    // save the old print state
+    volatile UInt oldPrintObjState = SetPrintObjState(0);
 
     BOOL rethrow = FALSE;
 


### PR DESCRIPTION
... then rethrow.

Otherwise we may end up with references to input/output stream objects on the stack that are invalid.

I am actually not sure why this worked so far w/o causing us crashes in various situations. I think I reasoned this through at some point in the distant past and convinced myself the code is fine as it is, but I don't see it anymore. In any case, even if for some reason it was OK after all, I feel it is better to explicitly deal with this.

Diffs best viewed with "ignore whitespace" turned on.