### PR TITLE
kernel: consistent types for argc, argv

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -387,14 +387,14 @@ static Obj FuncSHELL(Obj self,
     return (Obj)0;
 }
 
-int realmain( int argc, char * argv[] )
+int realmain(int argc, const char * argv[])
 {
   UInt                type;                   // result of compile
   Obj                 func;                   // function (compiler)
   Int4                crc;                    // crc of file to compile
 
   // initialize everything and read init.g which runs the GAP session
-  InitializeGap( &argc, argv, 1 );
+  InitializeGap(&argc, argv, 1);
   if (!STATE(UserHasQUIT)) {         /* maybe the user QUIT from the initial
                                    read of init.g  somehow*/
     // maybe compile in which case init.g got skipped
@@ -1054,7 +1054,7 @@ static Obj FuncSHOULD_QUIT_ON_BREAK(Obj self)
 */
 static Obj KernelArgs;
 
-static void InitKernelArgs(int argc, char * argv[])
+static void InitKernelArgs(int argc, const char * argv[])
 {
     // make command line available to GAP level
     KernelArgs = NEW_PLIST_IMM(T_PLIST, argc);
@@ -1434,11 +1434,14 @@ StructInitInfo * InitInfoGap ( void )
 **  `PostRestore': Everything in  `InitLibrary' execpt  creating objects.  In
 **  general    `InitLibrary'  will  create    all objects    and  then  calls
 **  `PostRestore'.  This function is only used when restoring.
+**
+**  Note that this function does not take the usual argc, argv pair for a
+**  list of arguments, but instead a pointer to argc is passed. This is a
+**  trick to get a pointer to the execution stack on the level of the calling
+**  function. We use the resulting pointer as a hint to the garbage collector
+**  as to where the execution stack (might) start.
 */
-void InitializeGap (
-    int *               pargc,
-    char *              argv [],
-    UInt                handleSignals )
+void InitializeGap(int * pargc, const char * argv[], BOOL handleSignals)
 {
     const int argc = *pargc;
 

--- a/src/gap.h
+++ b/src/gap.h
@@ -85,7 +85,7 @@ BOOL IsUsingLibGap(void);
 **
 *F  InitializeGap( <argc>, <argv>, <handleSignals> )  . . . . . . .  init GAP
 */
-void InitializeGap(int * pargc, char * argv[], UInt handleSignals);
+void InitializeGap(int * pargc, const char * argv[], BOOL handleSignals);
 
 
 /****************************************************************************

--- a/src/gasman.c
+++ b/src/gasman.c
@@ -1139,7 +1139,7 @@ int RegisterAfterCollectFuncBags(TNumCollectFuncBags func)
 
 Int EnableMemCheck = 0;
 
-Int enableMemCheck(Char ** argv, void * dummy)
+int enableMemCheck(const char * argv[], void * dummy)
 {
     fputs("# Warning: --enableMemCheck causes SEVERE slowdowns. Starting GAP may take several days!\n", stderr);
     EnableMemCheck = 1;

--- a/src/gasman_intern.h
+++ b/src/gasman_intern.h
@@ -167,7 +167,7 @@ void CallbackForAllBags(void (*func)(Bag));
 **
 */
 #ifdef GAP_MEM_CHECK
-Int enableMemCheck(Char ** argv, void * dummy);
+int enableMemCheck(const char * argv[], void * dummy);
 extern Int EnableMemCheck;
 #endif
 

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -299,13 +299,13 @@ void InitMainThread(void)
     TLS(CountActive) = 1;
 }
 
-static NOINLINE void RunThreadedMain2(int (*mainFunction)(int, char **),
+static NOINLINE void RunThreadedMain2(int (*mainFunction)(int, const char **),
                              int     argc,
-                             char ** argv);
+                             const char ** argv);
 
-void RunThreadedMain(int (*mainFunction)(int, char **),
+void RunThreadedMain(int (*mainFunction)(int, const char **),
                      int     argc,
-                     char ** argv)
+                     const char ** argv)
 {
 #ifndef USE_NATIVE_TLS
 #ifdef STACK_GROWS_UP
@@ -335,9 +335,9 @@ void RunThreadedMain(int (*mainFunction)(int, char **),
     RunThreadedMain2(mainFunction, argc, argv);
 }
 
-static void RunThreadedMain2(int (*mainFunction)(int, char **),
+static void RunThreadedMain2(int (*mainFunction)(int, const char **),
                              int     argc,
-                             char ** argv)
+                             const char ** argv)
 {
     int                    i;
     static pthread_mutex_t main_thread_mutex;

--- a/src/hpc/thread.h
+++ b/src/hpc/thread.h
@@ -44,9 +44,9 @@ void AddGCRoots(void);
 void RemoveGCroots(void);
 
 void RunThreadedMain(
-        int (*mainFunction)(int, char **),
+        int (*mainFunction)(int, const char **),
         int argc,
-        char **argv );
+        const char **argv );
 
 void CreateMainRegion(void);
 Obj RunThread(void (*start)(void *), void *arg);

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -59,7 +59,7 @@ void GAP_Initialize(int              argc,
 {
     UsingLibGap = TRUE;
 
-    InitializeGap(&argc, argv, handleSignals);
+    InitializeGap(&argc, (const char **)argv, handleSignals);
     SetExtraMarkFuncBags(markBagsCallback);
     STATE(JumpToCatchCallback) = errorCallback;
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
 #include <mach-o/dyld.h>
 #endif
 
-extern int realmain(int argc, char * argv[]);
+extern int realmain(int argc, const char * argv[]);
 
 /****************************************************************************
 **
@@ -188,7 +188,7 @@ static void SetupInitialGapRoot(const char * argv0)
 }
 #endif
 
-int main(int argc, char * argv[])
+int main(int argc, const char * argv[])
 {
     InstallBacktraceHandlers();
     SetupInitialGapRoot(argv[0]);

--- a/src/profile.c
+++ b/src/profile.c
@@ -652,7 +652,7 @@ static struct InterpreterHooks profileHooks = { visitStat,
 
 
 static void
-enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
+enableAtStartup(const char * filename, Int repeats, TickMethod tickMethod)
 {
     if (profileState.status == Profile_Active) {
         Panic("-P or -C can only be passed once\n");
@@ -685,7 +685,7 @@ enableAtStartup(char * filename, Int repeats, TickMethod tickMethod)
 // This function is for when GAP is started with -c, and
 // enables profiling at startup. If anything goes wrong,
 // we quit straight away.
-Int enableCodeCoverageAtStartup( Char **argv, void * dummy)
+int enableCodeCoverageAtStartup(const char * argv[], void * dummy)
 {
     enableAtStartup(argv[0], 0, Tick_Mem);
     return 1;
@@ -694,7 +694,7 @@ Int enableCodeCoverageAtStartup( Char **argv, void * dummy)
 // This function is for when GAP is started with -P, and
 // enables profiling at startup. If anything goes wrong,
 // we quit straight away.
-Int enableProfilingAtStartup( Char **argv, void * dummy)
+int enableProfilingAtStartup(const char * argv[], void * dummy)
 {
     TickMethod tickMethod = Tick_WallTime;
 #ifdef HAVE_GETTIMEOFDAY
@@ -708,7 +708,7 @@ Int enableProfilingAtStartup( Char **argv, void * dummy)
     return 1;
 }
 
-Int enableMemoryProfilingAtStartup(Char ** argv, void * dummy)
+int enableMemoryProfilingAtStartup(const char * argv[], void * dummy)
 {
     enableAtStartup(argv[0], 1, Tick_Mem);
     return 1;

--- a/src/profile.h
+++ b/src/profile.h
@@ -16,9 +16,9 @@
 
 #include "common.h"
 
-Int enableProfilingAtStartup(Char ** argv, void * dummy);
-Int enableMemoryProfilingAtStartup(Char ** argv, void * dummy);
-Int enableCodeCoverageAtStartup(Char ** argv, void * dummy);
+int  enableProfilingAtStartup(const char * argv[], void * dummy);
+int  enableMemoryProfilingAtStartup(const char * argv[], void * dummy);
+int  enableCodeCoverageAtStartup(const char * argv[], void * dummy);
 void pauseProfiling(void);
 void unpauseProfiling(void);
 

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -36,11 +36,11 @@ extern UInt SyCTRD;
 *V  SyCompileName . . . . . . . . . . . . . . . . . . . . . .  with this name
 *V  SyCompileMagic1 . . . . . . . . . . . . . . . . . . and this magic string
 */
-extern Int SyCompilePlease;
-extern Char * SyCompileOutput;
-extern Char * SyCompileInput;
-extern Char * SyCompileName;
-extern Char * SyCompileMagic1;
+extern BOOL SyCompilePlease;
+extern const char * SyCompileOutput;
+extern const char * SyCompileInput;
+extern const char * SyCompileName;
+extern const char * SyCompileMagic1;
 
 
 /****************************************************************************

--- a/src/system.c
+++ b/src/system.c
@@ -77,11 +77,11 @@ UInt SyCTRD;
 *V  SyCompileName . . . . . . . . . . . . . . . . . . . . . .  with this name
 *V  SyCompileMagic1 . . . . . . . . . . . . . . . . . . and this magic string
 */
-Int SyCompilePlease;
-Char * SyCompileOutput;
-Char * SyCompileInput;
-Char * SyCompileName;
-Char * SyCompileMagic1;
+BOOL SyCompilePlease;
+const char * SyCompileOutput;
+const char * SyCompileInput;
+const char * SyCompileName;
+const char * SyCompileMagic1;
 
 
 /****************************************************************************
@@ -322,7 +322,7 @@ static const UInt maxmem = 15000000000000000000UL;
 static const UInt maxmem = 4000000000UL;
 #endif
 
-static BOOL ParseMemory(Char * s, UInt *result)
+static BOOL ParseMemory(const char * s, UInt * result)
 {
     char * end;
     const double size = strtod(s, &end);
@@ -372,13 +372,13 @@ static void usage(void)
 struct optInfo {
   Char shortkey;
   Char longkey[50];
-  Int (*handler)(Char **, void *);
+  int (*handler)(const char * argv[], void *);
   void *otherArg;
   UInt minargs;
 };
 
 
-static Int toggle( Char ** argv, void *Variable )
+static int toggle(const char * argv[], void * Variable)
 {
   UInt * variable = (UInt *) Variable;
   *variable = !*variable;
@@ -386,11 +386,11 @@ static Int toggle( Char ** argv, void *Variable )
 }
 
 #ifdef HPCGAP
-static Int storePosInteger( Char **argv, void *Where )
+static int storePosInteger(const char * argv[], void * Where)
 {
   UInt *where = (UInt *)Where;
   UInt n;
-  Char *p = argv[0];
+  const char *p = argv[0];
   n = 0;
   while (IsDigit(*p)) {
     n = n * 10 + (*p-'0');
@@ -406,16 +406,16 @@ static Int storePosInteger( Char **argv, void *Where )
 #endif
 
 #ifdef GAP_ENABLE_SAVELOAD
-static Int storeString( Char **argv, void *Where )
+static int storeString(const char * argv[], void * Where)
 {
-  Char **where = (Char **)Where;
-  *where = argv[0];
-  return 1;
+    const char ** where = (const char **)Where;
+    *where = argv[0];
+    return 1;
 }
 #endif
 
 #ifdef USE_GASMAN
-static Int storeMemory( Char **argv, void *Where )
+static int storeMemory(const char * argv[], void * Where)
 {
     UInt * where = (UInt *)Where;
     if (!ParseMemory(argv[0], where))
@@ -425,7 +425,7 @@ static Int storeMemory( Char **argv, void *Where )
 #endif
 
 #if defined(USE_GASMAN) || defined(USE_BOEHM_GC)
-static Int storeMemory2( Char **argv, void *Where )
+static int storeMemory2(const char * argv[], void * Where)
 {
     UInt * where = (UInt *)Where;
     if (!ParseMemory(argv[0], where))
@@ -435,9 +435,9 @@ static Int storeMemory2( Char **argv, void *Where )
 }
 #endif
 
-static Int processCompilerArgs( Char **argv, void * dummy)
+static int processCompilerArgs(const char * argv[], void * dummy)
 {
-    SyCompilePlease = 1;
+    SyCompilePlease = TRUE;
     SyCompileOutput = argv[0];
     SyCompileInput = argv[1];
     SyCompileName = argv[2];
@@ -446,21 +446,21 @@ static Int processCompilerArgs( Char **argv, void * dummy)
 }
 
 #ifdef GAP_ENABLE_SAVELOAD
-static Int unsetString( Char **argv, void *Where)
+static int unsetString(const char * argv[], void * Where)
 {
   *(Char **)Where = (Char *)0;
   return 0;
 }
 #endif
 
-static Int forceLineEditing( Char **argv,void *Level)
+static int forceLineEditing(const char * argv[], void * Level)
 {
   UInt level = (UInt)Level;
   SyLineEdit = level;
   return 0;
 }
 
-static Int setGapRootPath( Char **argv, void *Dummy)
+static int setGapRootPath(const char * argv[], void * Dummy)
 {
   SySetGapRootPath( argv[0] );
   return 1;
@@ -470,7 +470,7 @@ static Int setGapRootPath( Char **argv, void *Dummy)
 #ifndef GAP_MEM_CHECK
 // Provide stub with helpful error message
 
-static Int enableMemCheck(Char ** argv, void * dummy)
+static int enableMemCheck(const char * argv[], void * dummy)
 {
     fputs("# Error: --enableMemCheck not supported by this copy of GAP\n", stderr);
     fputs("  pass --enable-memory-checking to ./configure\n", stderr);
@@ -479,7 +479,7 @@ static Int enableMemCheck(Char ** argv, void * dummy)
 #endif
 
 
-static Int printVersion(Char ** argv, void * dummy)
+static int printVersion(const char * argv[], void * dummy)
 {
     fputs("GAP ", stdout);
     fputs(SyBuildVersion, stdout);
@@ -540,17 +540,14 @@ static const struct optInfo options[] = {
   { 0, "", 0, 0, 0}};
 
 
-void InitSystem (
-    Int                 argc,
-    Char *              argv [],
-    UInt                handleSignals )
+void InitSystem(int argc, const char * argv[], BOOL handleSignals)
 {
     UInt                i;             // loop variable
     Int res;                       // return from option processing function
 
     // Initialize global and static variables
     SyCTRD = 1;
-    SyCompilePlease = 0;
+    SyCompilePlease = FALSE;
     SyDebugLoading = 0;
     SyLineEdit = 1;
 #ifdef HAVE_LIBREADLINE

--- a/src/system.h
+++ b/src/system.h
@@ -134,6 +134,6 @@ void Panic_(const char * file, int line, const char * fmt, ...) NORETURN
 **  answer the user interrupts '<ctr>-C', scans the command line for options,
 **  sets up the GAP root paths, locates the '.gaprc' file (if any), and more.
 */
-void InitSystem(Int argc, Char * argv[], UInt handleSignals);
+void InitSystem(int argc, const char * argv[], BOOL handleSignals);
 
 #endif // GAP_SYSTEM_H


### PR DESCRIPTION
Also add a comment explaining why `InitializeGap` takes a *pointer* to `argc` instead of `argc` directly.

(This is another semi-trivial PR in my series working towards refactoring `InitSystem`)