### PR TITLE
kernel: move all refs to SyLoadSystemInitFile to gap.c

### DIFF
--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -161,6 +161,10 @@ extern UInt SyInitializing;
 /****************************************************************************
 **
 *V  SyLoadSystemInitFile  . . . . . . should GAP load 'lib/init.g' at startup
+**
+**  TODO: this variable could be made static or even deleted. However for
+**  now the GAP.jl Julia package is accessing it, so we have to keep it.
+**  See also issue #5890 for the reasons behind this.
 */
 extern Int SyLoadSystemInitFile;
 

--- a/src/system.c
+++ b/src/system.c
@@ -209,13 +209,6 @@ UInt SyInitializing;
 
 /****************************************************************************
 **
-*V  SyLoadSystemInitFile  . . . . . . should GAP load 'lib/init.g' at startup
-*/
-Int SyLoadSystemInitFile = 1;
-
-
-/****************************************************************************
-**
 *V  SyUseModule . . . . . . . . . check for static modules in 'READ_GAP_ROOT'
 */
 int SyUseModule;
@@ -662,16 +655,6 @@ void InitSystem (
         SyRedirectStderrToStdOut();
         syWinPut( 0, "@p", "1." );
     }
-
-    // should GAP load 'init/lib.g' on initialization
-    if ( SyCompilePlease ) {
-        SyLoadSystemInitFile = 0;
-    }
-#ifdef GAP_ENABLE_SAVELOAD
-    else if ( SyRestoring ) {
-        SyLoadSystemInitFile = 0;
-    }
-#endif
 
     // the users home directory
     if ( getenv("HOME") != 0 ) {


### PR DESCRIPTION
Ideally it would be eliminated but for now GAP.jl requires it.

See issue #5890 for some background.