### PR TITLE
kernel: refactor `InitSystem`

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1047,7 +1047,7 @@ UInt SyIsIntr ( void )
 
 /****************************************************************************
 **
-*F  getwindowsize() . . . . . . . get screen size from termcap or TIOCGWINSZ
+*F  InitWindowSize() . . . . . . . get screen size from termcap or TIOCGWINSZ
 **
 **  For UNIX  we  install 'syWindowChangeIntr' to answer 'SIGWINCH'.
 */
@@ -1069,7 +1069,7 @@ void syWindowChangeIntr ( int signr )
 
 #endif // TIOCGWINSZ
 
-void getwindowsize( void )
+void InitWindowSize(void)
 {
 // it might be that SyNrRows, SyNrCols have been set by the user with -x, -y
 // otherwise they are zero

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -3232,7 +3232,10 @@ void InitSysFiles(void)
     setbuf(stdin, (char *)0);
     setbuf(stdout, (char *)0);
     setbuf(stderr, (char *)0);
+}
 
+void InitReadline(void)
+{
 #ifdef HAVE_LIBREADLINE
     // don't use readline if in Window mode (e.g. for XGAP)
     if (SyWindow)

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -434,11 +434,11 @@ char SyFileType(const Char * path);
 
 /****************************************************************************
 **
-*F  void getwindowsize( void )  . probe the OS for the window size and
+*F  void InitWindowSize( void )  . probe the OS for the window size and
 **                               set SyNrRows and SyNrCols accordingly
 */
 
-void getwindowsize(void);
+void InitWindowSize(void);
 
 /****************************************************************************
 **

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -484,6 +484,9 @@ void * SyMemmove(void * dst, const void * src, size_t size);
 // initialization.
 void InitSysFiles(void);
 
+//
+void InitReadline(void);
+
 /****************************************************************************
 **
 *F  InitInfoSysFiles()  . . . . . . . . . . . . . . . table of init functions

--- a/src/sysopt.h
+++ b/src/sysopt.h
@@ -49,11 +49,13 @@ extern const char * SyCompileMagic1;
 */
 extern Int SyDebugLoading;
 
+
 /****************************************************************************
 **
 *F  SyDotGapPath()
 */
 const Char * SyDotGapPath(void);
+
 
 /****************************************************************************
 **
@@ -65,6 +67,7 @@ const Char * SyDotGapPath(void);
 */
 extern UInt SyLineEdit;
 
+
 /****************************************************************************
 **
 *V  SyUseReadline   . . . . . . . . . . . . . . . . . .  support line editing
@@ -72,6 +75,7 @@ extern UInt SyLineEdit;
 **  Switch for not using readline although GAP is compiled with libreadline
 */
 extern UInt SyUseReadline;
+
 
 /****************************************************************************
 **
@@ -85,10 +89,11 @@ extern UInt SyUseReadline;
 **  'Pr' uses this to decide where to insert a <newline> on the output lines.
 **  'SyRead' uses it to decide when to start scrolling the echoed input line.
 **
-**  Put in this package because the command line processing takes place here.
+**  See also InitWindowSize().
 */
 extern UInt SyNrCols;
 extern UInt SyNrColsLocked;
+
 
 /****************************************************************************
 **
@@ -99,7 +104,7 @@ extern UInt SyNrColsLocked;
 **  Per default this is 24, which is the  usual  size  of  terminal  screens.
 **  It can be changed with the '-y' option for larger terminals or  printers.
 **
-**  'SyHelp' uses this to decide where to stop with '-- <space> for more --'.
+**  See also InitWindowSize().
 */
 extern UInt SyNrRows;
 extern UInt SyNrRowsLocked;
@@ -109,7 +114,7 @@ extern UInt SyNrRowsLocked;
 **
 *V  SyQuiet . . . . . . . . . . . . . . . . . . . . . . . . . suppress prompt
 **
-**  'SyQuit' determines whether GAP should print the prompt and  the  banner.
+**  'SyQuiet' determines whether GAP should print the prompt and the  banner.
 **
 **  Per default its false, i.e. GAP prints the prompt and  the  nice  banner.
 **  It can be changed by the '-q' option to have GAP operate in silent  mode.
@@ -119,6 +124,7 @@ extern UInt SyNrRowsLocked;
 **  Put in this package because the command line processing takes place here.
 */
 extern UInt SyQuiet;
+
 
 /****************************************************************************
 **
@@ -133,6 +139,7 @@ extern UInt SyQuiet;
 */
 extern UInt SyQuitOnBreak;
 
+
 /****************************************************************************
 **
 *V  SyRestoring . . . . . . . . . . . . . . . . . . . . restoring a workspace
@@ -145,6 +152,7 @@ extern UInt SyQuitOnBreak;
 #ifdef GAP_ENABLE_SAVELOAD
 extern Char * SyRestoring;
 #endif
+
 
 /****************************************************************************
 **

--- a/src/system.c
+++ b/src/system.c
@@ -107,6 +107,7 @@ static Char DotGapPath[GAP_PATH_MAX];
 */
 static Int IgnoreGapRC;
 
+
 /****************************************************************************
 **
 *V  SyLineEdit  . . . . . . . . . . . . . . . . . . . .  support line editing
@@ -117,6 +118,7 @@ static Int IgnoreGapRC;
 */
 UInt SyLineEdit;
 
+
 /****************************************************************************
 **
 *V  SyUseReadline   . . . . . . . . . . . . . . . . . .  support line editing
@@ -124,6 +126,7 @@ UInt SyLineEdit;
 **  Switch for not using readline although GAP is compiled with libreadline
 */
 UInt SyUseReadline;
+
 
 /****************************************************************************
 **
@@ -138,11 +141,10 @@ UInt SyUseReadline;
 **  'SyRead' uses it to decide when to start scrolling the echoed input line.
 **
 **  See also InitWindowSize().
-**
-**  Put in this package because the command line processing takes place here.
 */
 UInt SyNrCols;
 UInt SyNrColsLocked;
+
 
 /****************************************************************************
 **
@@ -153,12 +155,11 @@ UInt SyNrColsLocked;
 **  Per default this is 24, which is the  usual  size  of  terminal  screens.
 **  It can be changed with the '-y' option for larger terminals or  printers.
 **
-**  'SyHelp' uses this to decide where to stop with '-- <space> for more --'.
-**
 **  See also InitWindowSize().
 */
 UInt SyNrRows;
 UInt SyNrRowsLocked;
+
 
 /****************************************************************************
 **
@@ -175,17 +176,26 @@ UInt SyNrRowsLocked;
 */
 UInt SyQuiet;
 
+
 /****************************************************************************
 **
 *V  SyQuitOnBreak . . . . . . . . . . exit GAP instead of entering break loop
+**
+**  'SyQuitOnBreak' determines whether GAP should quit (with non-zero return
+**  value) instead of entering the break loop.
+**
+**  False by default, can be changed with the '--quitonbreak' option.
+**
+**  Put in this package because the command line processing takes place here.
 */
 UInt SyQuitOnBreak;
+
 
 /****************************************************************************
 **
 *V  SyRestoring . . . . . . . . . . . . . . . . . . . . restoring a workspace
 **
-**  `SyRestoring' determines whether GAP is restoring a workspace or not.  If
+**  'SyRestoring' determines whether GAP is restoring a workspace or not.  If
 **  it is zero no restoring should take place otherwise it holds the filename
 **  of a workspace to restore.
 **
@@ -199,7 +209,7 @@ Char * SyRestoring;
 **
 *V  SyInitializing                               set to 1 during library init
 **
-**  `SyInitializing' is set to 1 during the library initialization phase of
+**  'SyInitializing' is set to 1 during the library initialization phase of
 **  startup. It suppresses some behaviours that may not be possible so early
 **  such as homogeneity tests in the plist code.
 */

--- a/src/system.c
+++ b/src/system.c
@@ -571,61 +571,59 @@ static void InitSysOpts(void)
 
 static void ParseCommandLineOptions(int argc, const char * argv[])
 {
-    UInt                i;             // loop variable
-    Int res;                       // return from option processing function
+    UInt i;      // loop variable
+    Int  res;    // return from option processing function
 
     // scan the command line for options that we have to process in the kernel
-    // we just scan the whole command line looking for the keys for the options we recognise
-    // anything else will presumably be dealt with in the library
-    while ( argc > 1 )
-      {
-        if (argv[1][0] == '-' ) {
+    // we just scan the whole command line looking for the keys for the
+    // options we recognise anything else will presumably be dealt with in the
+    // library
+    while (argc > 1) {
+        if (argv[1][0] == '-') {
 
-          if ( strlen(argv[1]) != 2 && argv[1][1] != '-') {
-            fputs("gap: sorry, options must not be grouped '", stderr);
-            fputs(argv[1], stderr);
-            fputs("'.\n", stderr);
-            usage();
-          }
-
-
-          for (i = 0;  options[i].shortkey != argv[1][1] &&
-                       (argv[1][1] != '-' || argv[1][2] == 0 || strcmp(options[i].longkey, argv[1] + 2)) &&
-                       (options[i].shortkey != 0 || options[i].longkey[0] != 0); i++)
-            ;
-
-
-
-
-          if (argc < 2 + options[i].minargs)
-            {
-              Char buf[2];
-              fputs("gap: option ", stderr);
-              fputs(argv[1], stderr);
-              fputs(" requires at least ", stderr);
-              buf[0] = options[i].minargs + '0';
-              buf[1] = '\0';
-              fputs(buf, stderr);
-              fputs(" arguments\n", stderr);
-              usage();
+            if (strlen(argv[1]) != 2 && argv[1][1] != '-') {
+                fputs("gap: sorry, options must not be grouped '", stderr);
+                fputs(argv[1], stderr);
+                fputs("'.\n", stderr);
+                usage();
             }
-          if (options[i].handler) {
-            res = (*options[i].handler)(argv+2, options[i].otherArg);
-            GAP_ASSERT(res == options[i].minargs);
-          }
-          else
-            res = options[i].minargs;
-          // recordOption(argv[1][1], res,  argv+2);
-          argv += 1 + res;
-          argc -= 1 + res;
 
+
+            for (i = 0;
+                 options[i].shortkey != argv[1][1] &&
+                 (argv[1][1] != '-' || argv[1][2] == 0 ||
+                  strcmp(options[i].longkey, argv[1] + 2)) &&
+                 (options[i].shortkey != 0 || options[i].longkey[0] != 0);
+                 i++)
+                ;
+
+
+            if (argc < 2 + options[i].minargs) {
+                Char buf[2];
+                fputs("gap: option ", stderr);
+                fputs(argv[1], stderr);
+                fputs(" requires at least ", stderr);
+                buf[0] = options[i].minargs + '0';
+                buf[1] = '\0';
+                fputs(buf, stderr);
+                fputs(" arguments\n", stderr);
+                usage();
+            }
+            if (options[i].handler) {
+                res = (*options[i].handler)(argv + 2, options[i].otherArg);
+                GAP_ASSERT(res == options[i].minargs);
+            }
+            else
+                res = options[i].minargs;
+            // recordOption(argv[1][1], res,  argv+2);
+            argv += 1 + res;
+            argc -= 1 + res;
         }
         else {
-          argv++;
-          argc--;
+            argv++;
+            argc--;
         }
-
-      }
+    }
 }
 
 static void InitDotGapPath(void)

--- a/src/system.c
+++ b/src/system.c
@@ -630,30 +630,34 @@ static void ParseCommandLineOptions(int argc, const char * argv[])
 
 static void InitDotGapPath(void)
 {
-    // the users home directory
-    if ( getenv("HOME") != 0 ) {
-        strxcpy(DotGapPath, getenv("HOME"), sizeof(DotGapPath));
-# if defined(__APPLE__)
-        // On Mac OS, add .gap to the sys roots, but leave
-        // DotGapPath at $HOME/Library/Preferences/GAP
-        strxcat(DotGapPath, "/.gap;", sizeof(DotGapPath));
-        if (!IgnoreGapRC) {
-          SySetGapRootPath(DotGapPath);
-        }
+    const char * home = getenv("HOME");
+    if (home == 0)
+        return;
 
-        strxcpy(DotGapPath, getenv("HOME"), sizeof(DotGapPath));
-        strxcat(DotGapPath, "/Library/Preferences/GAP;", sizeof(DotGapPath));
-# elif defined(__CYGWIN__)
-        strxcat(DotGapPath, "/_gap;", sizeof(DotGapPath));
-# else
-        strxcat(DotGapPath, "/.gap;", sizeof(DotGapPath));
-# endif
+#if defined(__CYGWIN__)
+    strxcpy(DotGapPath, home, sizeof(DotGapPath));
+    strxcat(DotGapPath, "/_gap;", sizeof(DotGapPath));
+#else
+    strxcpy(DotGapPath, home, sizeof(DotGapPath));
+    strxcat(DotGapPath, "/.gap;", sizeof(DotGapPath));
+#endif
 
-        if (!IgnoreGapRC) {
-          SySetGapRootPath(DotGapPath);
-        }
-        DotGapPath[strlen(DotGapPath)-1] = '\0';
+    if (!IgnoreGapRC) {
+        SySetGapRootPath(DotGapPath);
     }
+
+#if defined(__APPLE__)
+    strxcpy(DotGapPath, home, sizeof(DotGapPath));
+    strxcat(DotGapPath, "/Library/Preferences/GAP;", sizeof(DotGapPath));
+
+    if (!IgnoreGapRC) {
+        SySetGapRootPath(DotGapPath);
+    }
+#endif
+
+    // get rid of trailing semicolon (which was added to ensure
+    // SySetGapRootPath prepends the path to the list of root paths)
+    DotGapPath[strlen(DotGapPath) - 1] = '\0';
 }
 
 

--- a/src/system.c
+++ b/src/system.c
@@ -137,7 +137,7 @@ UInt SyUseReadline;
 **  'Pr' uses this to decide where to insert a <newline> on the output lines.
 **  'SyRead' uses it to decide when to start scrolling the echoed input line.
 **
-**  See also getwindowsize() below.
+**  See also InitWindowSize().
 **
 **  Put in this package because the command line processing takes place here.
 */
@@ -155,7 +155,7 @@ UInt SyNrColsLocked;
 **
 **  'SyHelp' uses this to decide where to stop with '-- <space> for more --'.
 **
-**  See also getwindowsize() below.
+**  See also InitWindowSize().
 */
 UInt SyNrRows;
 UInt SyNrRowsLocked;
@@ -675,7 +675,7 @@ void InitSystem(int argc, const char * argv[], BOOL handleSignals)
 
     // now that the user has had a chance to give -x and -y,
     // we determine the size of the screen ourselves
-    getwindowsize();
+    InitWindowSize();
 
     // when running in package mode set ctrl-d and line editing
     if (SyWindow) {


### PR DESCRIPTION
- split `InitSystem` into multiple parts
- rename `getwindowsize` -> `InitWindowSize`
- refactor code computing `DotGapPath`
- format `ParseCommandLineOptions`
- update some comments
- refactor `ParseCommandLineOptions`

Reaping the fruits of previous labor... 

Best to view this commit-by-commit, and possibly with "ignore whitespace" turned on.