### PR TITLE
Fix `FactorCosetAction(G, G)` for perm. groups

### DIFF
--- a/lib/csetperm.gi
+++ b/lib/csetperm.gi
@@ -883,10 +883,12 @@ local G,u,op,h,N,rt,ac,actions,hom,i,q;
     u:=G;
     Error("only trivial operation ?  I Set u:=G;");
   fi;
+  if IsSubset(u, G) then
+    return DoFactorCosetAction(G, u, G);
+  fi;
   if N=false then
     N:=Core(G,u);
   fi;
-
   ac:=ActionRefinedSeries(G,u);
   actions:=ac[2];
   ac:=ac[1];

--- a/lib/factgrp.gd
+++ b/lib/factgrp.gd
@@ -167,6 +167,8 @@ DeclareAttribute("NaturalHomomorphismsPool",IsGroup,
 ##
 DeclareOperation( "FactorCosetAction", [IsGroup,IsGroup] );
 
+DeclareGlobalFunction( "DoFactorCosetAction" );
+
 #############################################################################
 ##
 #F  ImproveActionDegreeByBlocks( <G>, <N> , <hom> [,forceblocks] )

--- a/lib/factgrp.gi
+++ b/lib/factgrp.gi
@@ -475,7 +475,7 @@ end);
 #F  FactorCosetAction( <G>, <U>, [<N>] )  operation on the right cosets Ug
 ##                                        with possibility to indicate kernel
 ##
-BindGlobal("DoFactorCosetAction",function(arg)
+InstallGlobalFunction("DoFactorCosetAction",function(arg)
 local G,u,op,h,N,rt;
   G:=arg[1];
   u:=arg[2];

--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -155,6 +155,8 @@ gap> u:=Normalizer(g,SylowSubgroup(g,3));;
 gap> act:=FactorCosetAction(g,u);;
 gap> NrMovedPoints(Range(act));
 70840
+gap> NrMovedPoints(Range(FactorCosetAction(g,g)));
+0
 
 #
 gap> STOP_TEST("permgrp.tst");


### PR DESCRIPTION
Catch the case of an action with trivial image in `DoFactorCosetActionPerm`, and delegate to `DoFactorCosetAction` in this case.

resolves #5902

(Just for curiosity:
The code for `DoFactorCosetAction` and `DoFactorCosetActionPerm` deals with the case that the second argument is a *list* (not a group), but only in order to call `Error` if this list is empty. The functions called later, such as `Core` and `ActionRefinedSeries`, do not accept a list as the value of this argument.
Is this list situation meaningful at all?)