### PR TITLE
Fix unexpected errors in `recog` and `genss` by improving `GroupWithMemory` when given compressed matrices over small fields

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -24,6 +24,9 @@ BindGlobal( "ObjWithMemory", function( slp, n, el )
     if IsMatrixObj( el ) then
       filt:= filt and IsMatrixObj;
     fi;
+    if HasBaseDomain( el ) then
+      filt:= filt and HasBaseDomain;
+    fi;
   fi;
 
   return Objectify( NewType( FamilyObj( el ), filt ),

--- a/tst/testbugfix/2025-01-17-HasDomain-for-matrix-with-memory.tst
+++ b/tst/testbugfix/2025-01-17-HasDomain-for-matrix-with-memory.tst
@@ -1,5 +1,5 @@
-gap> G := GroupWithMemory([One(GL(3,4))]);
-gap> mat := G.1;
+gap> G := GroupWithMemory([One(GL(3,4))]);;
+gap> mat := G.1;;
 gap> HasBaseDomain(mat);
 true
 gap> BaseDomain(mat);

--- a/tst/testbugfix/2025-01-17-HasDomain-for-matrix-with-memory.tst
+++ b/tst/testbugfix/2025-01-17-HasDomain-for-matrix-with-memory.tst
@@ -1,0 +1,8 @@
+gap> G := GroupWithMemory([One(GL(3,4))]);
+gap> mat := G.1;
+gap> HasBaseDomain(mat);
+true
+gap> BaseDomain(mat);
+GF(2^2)
+gap> DefaultScalarDomainOfMatrixList([mat]);
+GF(2^2)


### PR DESCRIPTION
... at least if the wrapped matrixobj had it set (which really should always be the case).

This fixes a nasty long-standing issue in genss / orb / recog where `DefaultScalarDomainOfMatrixList` returned to small a field when called on a list of matrixobj-with-memory. This then caused `GroupWithGenerators` to rewrite the generators over a smaller field, which then lead `genss` to produce (compressed) vectors for use as base points in the orbit algorithm over the smaller field; and a matching hash function. When later generators got added that really needed the larger field, everything exploded in confusing ways.


This issue has been a thorn in my side for years, but today after several hours of debugging I finally tracked it down.