### PR TITLE
fix `Extensions` for nonsolvable group and trivial cohomology

### DIFF
--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -2026,7 +2026,7 @@ InstallOtherMethod(Extensions,"generic method for finite groups",
 function(G,M)
 local coh;
   coh:=TwoCohomologyGeneric(G,M);
-  return List(Elements(VectorSpace(coh.module.field,coh.cohomology)),
+  return List(Elements(VectorSpace(coh.module.field,coh.cohomology,coh.zero)),
     x->FpGroupCocycle(coh,x,true:normalform));
 end);
 

--- a/tst/teststandard/twocohom.tst
+++ b/tst/teststandard/twocohom.tst
@@ -58,6 +58,9 @@ gap> cp:=CompatiblePairs(g,mo);
 <group of size 240 with 4 generators>
 gap> Length(ExtensionRepresentatives(g,mo,cp));
 2
+gap> mo:= TrivialGModule( g, GF(3) );;
+gap> Length( Extensions( g, mo ) );
+1
 
 # New code for Pc groups
 gap> g:=AbelianGroup([2,2]);;


### PR DESCRIPTION
Note that `Extensions` for nonsolvable groups is in fact not  documented, the documentation claims that the returned groups are pc groups.