### PR TITLE
Load the whole GAP library before loading packages

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -669,6 +669,13 @@ end );
 
 #############################################################################
 ##
+##  Load the implementation part of the GAP library.
+##
+ReadGapRoot( "lib/read.g" );
+
+
+#############################################################################
+##
 ##  Autoload packages (suppressing banners).
 ##  (If GAP was started with a workspace then the user may have given
 ##  additional directories, so more suggested packages may become available.
@@ -677,8 +684,6 @@ end );
 ##  `InstallAndCallPostRestore' because some packages may install their own
 ##  post-restore functions, and when a workspaces gets restored then these
 ##  functions must be called *before* loading new packages.)
-##
-##  Load the implementation part of the GAP library.
 ##
 ##  Load additional packages, such that their names appear in the banner.
 ##


### PR DESCRIPTION
Up to now, the "implementation part" of the GAP library was delayed until a package got loaded that claimed to need the whole library.

The idea was to have calls to functions from some packages inside the GAP library, without syntax warnings, and to use some gapdoc functions already during startup.

This was used for some time for the packages gapdoc, primgrp, and transgrp, but meanwhile the GAP library can apparently be loaded without problems before the declaration part of these packages has been loaded.