### PR TITLE
Add a missing local declaration in a tst file

### DIFF
--- a/tst/teststandard/permgrp.tst
+++ b/tst/teststandard/permgrp.tst
@@ -2,7 +2,7 @@
 ##
 ##  Some tests for permutation groups and friends(takes a few seconds to run)
 ##
-#@local g, dc, ac, p, s, dc1, u, part, iso,l,it,i,w,d,a,hom
+#@local g, dc, ac, p, s, dc1, u, part, iso,l,it,i,w,d,a,hom,act
 gap> START_TEST("permgrp.tst");
 gap> Size(Normalizer(SymmetricGroup(100),PrimitiveGroup(100,1)));
 1209600


### PR DESCRIPTION
This caused the test to fail when run in isolation. I guess it was OK in CI because some other test file run before it and defined `act` globally.

