### PR TITLE
Improve printing of nested expressions

### DIFF
--- a/tst/testinstall/kernel/exprs.tst
+++ b/tst/testinstall/kernel/exprs.tst
@@ -59,7 +59,25 @@ function ( x )
 end
 gap> Display( x -> 2 * f( 3 + 4 ));
 function ( x )
-    return 2 * f( (3 + 4) );
+    return 2 * f( 3 + 4 );
+end
+gap> Display({}->1^(1,2,2*(4-1)));
+function (  )
+    return 1 ^ (1,2,2 * (4 - 1));
+end
+gap> Display({}->1-[1-1]);
+function (  )
+    return 1 - [ 1 - 1 ];
+end
+gap> Display(function (  )
+>     return 1 - function (  )
+>             return 1 - 1;
+>         end(  );
+> end);
+function (  )
+    return 1 - function (  )
+              return 1 - 1;
+          end(  );
 end
 
 # PrintTildeExpr, EvalTildeExpr


### PR DESCRIPTION
Specifically, make it better at eliding redundant parenthesis. We do so by changing the code so that the PrintPrecedence is reset to 0 whenever a expression is print that is not a unary or binary op, and then restored afterwards. For "leave" expressions such as integer literals this has no effect. But for expression that can have further subexpressions, such as function expressions, list expression, permutation expressions etc., this allows us to avoid redundant parenthesis.

Resolves #4523 by @zickgraf 