### PR TITLE
fix delegations among `IrreducibleModules` methods

### DIFF
--- a/lib/grpreps.gi
+++ b/lib/grpreps.gi
@@ -55,8 +55,8 @@ local modu, modus,gens,v,subs,sub,ser,i,j,a,si,dims,cf,mats,clos,bas,rad;
     a:=DerivedSubgroup(G);
     if Size(a)=Size(G) then
       return [gens,[TrivialModule(Length(gens),F)]];
-    elif IsPrimeField(F) then
-      if IsAbelian(G) then
+    elif IsAbelian(G) then
+      if IsPrimeField(F) then
         if CanEasilyComputePcgs(G) then
           # call `IrreducibleMethods` again;
           # we assume that now another method is applicable
@@ -67,23 +67,27 @@ local modu, modus,gens,v,subs,sub,ser,i,j,a,si,dims,cf,mats,clos,bas,rad;
           a:= IsomorphismPcGroup(G);
         fi;
       else
-        # delegate to a proper factor group
-        a:= MaximalAbelianQuotient(G);
+        a:= IsomorphismPermGroup(G);
       fi;
-      si:=List(gens,x->ImagesRepresentative(a,x));
-      sub:= Group(si);
-      SetIsAbelian(sub, true);
-      sub:=IrreducibleModules(sub,F,1);
-      if sub[1]=si then
-        return [gens,sub[2]];
-      else
-        modu:=[];
-        for i in sub[2] do
+    else
+      # delegate to a proper factor group
+      a:= MaximalAbelianQuotient(G);
+    fi;
+    si:=List(gens,x->ImagesRepresentative(a,x));
+    sub:= Group(si);
+    SetIsAbelian(sub, true);
+    sub:= IrreducibleModules(sub,F,0);
+    if sub[1]=si then
+      return [gens, Filtered( sub[2], x -> x.dimension = 1 )];
+    else
+      modu:=[];
+      for i in sub[2] do
+        if i.dimension = 1 then
           v:=GroupHomomorphismByImages(Image(a),Group(i.generators),sub[1],i.generators);
           Add(modu,GModuleByMats(List(si,x->ImagesRepresentative(v,x)),F));
-        od;
-        return [gens,modu];
-      fi;
+        fi;
+      od;
+      return [gens,modu];
     fi;
 
   fi;

--- a/lib/grpreps.gi
+++ b/lib/grpreps.gi
@@ -55,10 +55,25 @@ local modu, modus,gens,v,subs,sub,ser,i,j,a,si,dims,cf,mats,clos,bas,rad;
     a:=DerivedSubgroup(G);
     if Size(a)=Size(G) then
       return [gens,[TrivialModule(Length(gens),F)]];
-    else
-      a:=MaximalAbelianQuotient(G);
+    elif IsPrimeField(F) then
+      if IsAbelian(G) then
+        if CanEasilyComputePcgs(G) then
+          # call `IrreducibleMethods` again;
+          # we assume that now another method is applicable
+          return IrreducibleModules(G, F, 1);
+        else
+          # delegate to a pc group,
+          # for which another method is available
+          a:= IsomorphismPcGroup(G);
+        fi;
+      else
+        # delegate to a proper factor group
+        a:= MaximalAbelianQuotient(G);
+      fi;
       si:=List(gens,x->ImagesRepresentative(a,x));
-      sub:=IrreducibleModules(Group(si),F,1);
+      sub:= Group(si);
+      SetIsAbelian(sub, true);
+      sub:=IrreducibleModules(sub,F,1);
       if sub[1]=si then
         return [gens,sub[2]];
       else

--- a/tst/testinstall/grpreps.tst
+++ b/tst/testinstall/grpreps.tst
@@ -21,11 +21,13 @@ gap> Length( IrreducibleModules( AlternatingGroup(5), GF(3), 1 )[2] ) = 1;
 true
 gap> Length( IrreducibleModules( Group( (1,2), (1,2) ), GF(3), 1 )[2] ) = 2;
 true
-gap> true; # Length( IrreducibleModules( Group( (1,2), (1,2) ), GF(4), 1 )[2] ) = 1;
+gap> Length( IrreducibleModules( Group( (1,2), (1,2) ), GF(4), 1 )[2] ) = 1;
+true
+gap> Length( IrreducibleModules( Group( (1,2,3,4,5) ), GF(4), 1 )[2] ) = 1;
 true
 gap> Length( IrreducibleModules( CyclicGroup( IsFpGroup, 2 ), GF(3), 1 )[2] ) = 2;
 true
-gap> true; # Length( IrreducibleModules( CyclicGroup( IsFpGroup, 2 ), GF(4), 1 )[2] ) = 1;
+gap> Length( IrreducibleModules( CyclicGroup( IsFpGroup, 2 ), GF(4), 1 )[2] ) = 1;
 true
 gap> Length( IrreducibleModules( SymmetricGroup(5), GF(3), 1 )[2] ) = 2;
 true

--- a/tst/testinstall/grpreps.tst
+++ b/tst/testinstall/grpreps.tst
@@ -16,5 +16,19 @@ gap> res2:= AbsolutelyIrreducibleModules( G2, F, 10 );;
 gap> List( res2[2], r -> [ r.field, r.dimension ] );
 [ [ GF(2), 1 ] ]
 
+# Test that the delegation between methods for 'IrreducibleModules' works.
+gap> Length( IrreducibleModules( AlternatingGroup(5), GF(3), 1 )[2] ) = 1;
+true
+gap> Length( IrreducibleModules( Group( (1,2), (1,2) ), GF(3), 1 )[2] ) = 2;
+true
+gap> true; # Length( IrreducibleModules( Group( (1,2), (1,2) ), GF(4), 1 )[2] ) = 1;
+true
+gap> Length( IrreducibleModules( CyclicGroup( IsFpGroup, 2 ), GF(3), 1 )[2] ) = 2;
+true
+gap> true; # Length( IrreducibleModules( CyclicGroup( IsFpGroup, 2 ), GF(4), 1 )[2] ) = 1;
+true
+gap> Length( IrreducibleModules( SymmetricGroup(5), GF(3), 1 )[2] ) = 2;
+true
+
 #
 gap> STOP_TEST( "grpreps.tst" );


### PR DESCRIPTION
There were infinite recursions in the case of abelian groups.

Apparently there is code for computing the irreducible representations of abelian groups over finite fields only for the case of prime fields.

The infinite recursions do not catch the case of non-prime fields anymore after the current changes; the generic code now runs into errors.

addresses #5924