### PR TITLE
kernel: add GAP_realpath helper

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -42,6 +42,7 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
@@ -1080,6 +1081,22 @@ static Obj FuncGAP_chdir(Obj self, Obj path)
     return True;
 }
 
+/****************************************************************************
+**
+*F  FuncGAP_realpath( <self>, <path> ) . . . .  TODO
+*/
+static Obj FuncGAP_realpath(Obj self, Obj path)
+{
+    RequireStringRep(SELF_NAME, path);
+    char resolved_path[PATH_MAX];
+
+    if (NULL == realpath(CONST_CSTR_STRING(path), resolved_path)) {
+        SySetErrorNo();
+        return Fail;
+    }
+    return MakeString(resolved_path);
+}
+
 
 /****************************************************************************
 **
@@ -1716,6 +1733,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_1ARGS(IS_DIR, path),
     GVAR_FUNC_0ARGS(GAP_getcwd),
     GVAR_FUNC_1ARGS(GAP_chdir, path),
+    GVAR_FUNC_1ARGS(GAP_realpath, path),
     GVAR_FUNC_0ARGS(LastSystemError),
     GVAR_FUNC_1ARGS(IsExistingFile, filename),
     GVAR_FUNC_1ARGS(IsReadableFile, filename),


### PR DESCRIPTION
Some usage examples:

    gap> GAP_getcwd();
    "/Users/mhorn/Projekte/GAP/gap"
    gap> GAP_realpath(".");
    "/Users/mhorn/Projekte/GAP/gap"
    gap> GAP_realpath("../..");
    "/Users/mhorn/Projekte/"

@lgoettgens @ThomasBreuer as discussed.

Of course this for POSIX only, this may be a nuisance for future ports, but we'll cross that bridge when we get there -- as long as we don't widely use `GAP_realpath` it should be fine.