### PR TITLE
Fix an unexpected error in `IsomorphismGroups`

### DIFF
--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -1561,6 +1561,7 @@ end);
 # find corresponding characteristic subgroups
 BindGlobal("AGSRMatchedCharacteristics",function(g,h)
 local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
+
   props:=function(a)
   local p,b;
 
@@ -1583,8 +1584,11 @@ local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
     return p;
   end;
 
+  # Process that G-subgroup i matches H-subgroup j. Return true if there is
+  # a problem.
   coinc:=function(i,j)
   local a,b,sa,sb,sel,p,q;
+    if pg[i]<>ph[j] then Error("matching bug");fi;
     a:=cg[i];
     b:=ch[j];
     Add(ng,a);
@@ -1595,6 +1599,7 @@ local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
     sel:=Difference([1..Length(ch)],[j]);
     ch:=ch{sel};
     ph:=ph{sel};
+    # find associated modules and further match
     sa:=AGSRModuleLayerSeries(a);
     sb:=AGSRModuleLayerSeries(b);
     if List(sa,Size)<>List(sb,Size) then return true;fi;
@@ -1605,7 +1610,8 @@ local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
         if q<>fail then return true;fi;
       elif q=fail then return true;
       else
-        if coinc(p,q) then return true;fi;
+        if pg[p]<>ph[q] # but not same properties
+         or coinc(p,q) then return true;fi;
       fi;
     od;
     return false;
@@ -1614,20 +1620,24 @@ local a,props,cg,ch,clg,clh,ng,nh,coug,couh,pg,ph,i,j,stop,coinc;
   ng:=[];
   nh:=[];
 
+  # get the characteristic subgroups
   cg:=ShallowCopy(CharacteristicSubgroups(g));
   ch:=ShallowCopy(CharacteristicSubgroups(h));
   SortBy(cg,x->-Size(x));
   SortBy(ch,x->-Size(x));
 
+  # find list of properties, tryign to match them up
   pg:=List(cg,props);
   ph:=List(ch,props);
-  if Collected(pg)<>Collected(ph) then return fail;fi;
 
   stop:=false;
   while Length(cg)>0 and not stop do
+    # test in loop as list changes
+    if Collected(pg)<>Collected(ph) then return fail;fi;
     i:=First([1..Length(pg)],x->Number(pg,y->y=pg[x])=1);
     if i<>fail then
       # found a unique one -- process
+      # because properties agree this must match
       j:=Position(ph,pg[i]);
       if coinc(i,j) then return fail;fi;
     else

--- a/lib/fitfree.gi
+++ b/lib/fitfree.gi
@@ -153,6 +153,7 @@ local ffs,pcisom,rest,kpc,k,x,ker,r,pool,i,xx,pregens,iso;
   r:=rec(parentffs:=ffs,
             rest:=rest,
             radical:=ker,
+            ker:=ker,
             pcgs:=k,
             serdepths:=List(ffs.depths,y->First([1..Length(r)],x->r[x]>=y))
             );
@@ -185,6 +186,7 @@ local ffs,cache,rest,ker,k,r;
     r:=rec(parentffs:=ffs,
               rest:=rest,
               radical:=ker,
+              ker:=ker,
               pcgs:=k,
               serdepths:=List(ffs.depths,y->First([1..Length(r)],x->r[x]>=y))
               );
@@ -298,6 +300,7 @@ local ffs,hom,U,rest,ker,r,p,l,i,depths,pcisom,subsz,pcimgs;
   r:=rec(parentffs:=ffs,
             rest:=rest,
             radical:=ker,
+            ker:=ker,
             pcgs:=ipcgs,
             serdepths:=List(ffs.depths,y->First([1..Length(r)],x->r[x]>=y))
             );

--- a/tst/testbugfix/2025-02-10-Isomorphism.tst
+++ b/tst/testbugfix/2025-02-10-Isomorphism.tst
@@ -1,0 +1,15 @@
+# Fix #5931 Isomorphism test / Characteristic matching
+gap> G:= PcGroupCode( 7081272684613405169270145749707713769178346454326033042960705194376896383, 512 );;
+gap> H:= PcGroupCode( 13830610712135556969734175751921406466451196220671918889959595223883643, 512 );;
+gap> IsomorphismGroups(G,H);
+fail
+gap> IsomorphismGroups(H,G);
+fail
+gap> GG:=PcGroupWithPcgs(SpecialPcgs(G));; # different isomorphic
+gap> IsGeneralMapping(IsomorphismGroups(G,GG)); # so isomorphism works
+true
+gap> HH:=PcGroupWithPcgs(SpecialPcgs(H));;
+gap> IsGeneralMapping(IsomorphismGroups(H,HH));
+true
+gap> IsGeneralMapping(IsomorphismGroups(HH,H));
+true


### PR DESCRIPTION
Fix for #5931.

The matching of characteristic subgroups matched some subgroups without
testing that they indeed can match. This could lead to an error when no
partner is found.
This issue can only come up if the groups are nonisomorphic, so it should
not be able to lead to wrong results.


Also included is to force a `ker` component in `FittingFreeSubgroupSetup`.