### PR TITLE
Fix `--quiet` in the command line interface to be identical to `-q`

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -512,7 +512,7 @@ static const struct optInfo options[] = {
   { 'o', "", storeMemory2, &SyStorMax, 1 }, // library with new interface
 #endif
   { 'p', "", toggle, &SyWindow, 0 }, // ??
-  { 'q', "", toggle, &SyQuiet, 0 }, // ??
+  { 'q', "quiet", toggle, &SyQuiet, 0 }, // ??
 #ifdef HPCGAP
   { 'S', "", toggle, &ThreadUI, 0 }, // Thread UI
   { 'Z', "", toggle, &DeadlockCheck, 0 }, // Deadlock prevention


### PR DESCRIPTION
Resolves https://github.com/gap-system/gap/issues/5934.

## Text for release notes

see title

## Further details

Somehow, the long form was only present in the cli argument parsing in the lib, but missing from the kernel part.