### PR TITLE
Allow loading of extraperfect files from all root dirs

### DIFF
--- a/grp/perf.grp
+++ b/grp/perf.grp
@@ -16,7 +16,7 @@
 #F  PerfGrpLoad(<size>)  force loading of secondary files, return index
 ##
 InstallGlobalFunction( PerfGrpLoad, function(sz)
-local p,pos,name,libname;
+local p,pos,name,file;
   if PERFRec=fail then
     ReadGrp("perf0.grp");
   fi;
@@ -36,22 +36,20 @@ local p,pos,name,libname;
     p:=12+p;
   fi;
   name:=Concatenation("perf",String(p),".grp");
-  libname := SHALLOW_COPY_OBJ( "grp" );
-  APPEND_LIST_INTR( libname, "/" );
-  APPEND_LIST_INTR( libname, name );
-  while not READ_GAP_ROOT( libname ) do
+  file:=Filename( DirectoriesLibrary( "grp" ), name );
+  while file = fail do
     Error("\n\n",
     "For reasons of size, the perfect groups library for orders >10^6 is\n",
     "not distributed fully by default. To access the group requested, get\n",
     "the file ",name," from\n",
     "https://github.com/hulpke/extraperfect\n",
-    "and put it in the `grp` subdirectory of your GAP installation. Then",
+    "and put it in the `grp` subdirectory of a GAP root path. Then",
     " type \n\nreturn;\n\n",
     "to continue in this GAP session ",
     "(which will read in the file).\n\n\n");
+    file:=Filename( DirectoriesLibrary( "grp" ), name );
   od;
-
-  ReadGrp(name);
+  Read(file);
   return pos;
 end );
 


### PR DESCRIPTION
The former code for loading perf27.grp and perf33.grp tried to load them using `READ_GAP_ROOT` which only checks the root directories in `SyGapRootPaths` aka the root paths that are known at GAP's startup e.g. via the `-l` flag.
However, this won't check any root directories that were added later using `ExtendRootDirectories`.

This PR changes this to check all root directories in `GAPInfo.RootPaths`. The motivation for this is in OSCAR, where we want the julia lazy artifact handler to do the downloading of these files on first access, but due to how julia loads OSCAR and GAP.jl, this seems to be only possible using `ExtendRootDirectories`. (x-ref https://github.com/oscar-system/Oscar.jl/pull/4592)

cc @fingolfin @ThomasBreuer 