### PR TITLE
set the irreducibility flag in group characters

### DIFF
--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -1332,8 +1332,14 @@ end );
 InstallMethod( TrivialCharacter,
     "for a character table",
     [ IsNearlyCharacterTable ],
-    tbl -> Character( tbl,
-               ListWithIdenticalEntries( NrConjugacyClasses( tbl ), 1 ) ) );
+    function( tbl )
+    local chi;
+
+    chi:= Character( tbl,
+              ListWithIdenticalEntries( NrConjugacyClasses( tbl ), 1 ) );
+    SetIsIrreducibleCharacter( chi, true );
+    return chi;
+    end );
 
 
 #############################################################################

--- a/lib/ctblsolv.gi
+++ b/lib/ctblsolv.gi
@@ -15,7 +15,7 @@
 ##  as words in generators.
 InstallMethod(LinearCharacters, ["CanEasilyComputePcgs"], function(G)
   local pcgs, hom, Gab, abinv, exp, e, Ee, genexp,
-        clexps, tab, irgens, a, lin, c, res, j, i, sz;
+        clexps, tab, irgens, a, lin, c, res, j, i, sz, chi;
   if Size(G) = 1 then
     return [TrivialCharacter(G)];
   fi;
@@ -54,7 +54,9 @@ InstallMethod(LinearCharacters, ["CanEasilyComputePcgs"], function(G)
   # coefficients of a linear combination of irgens
   c := 0*[1..Length(abinv)];
   for i in [1..sz] do
-    Add(res, Character(tab, Ee{((clexps * lin) mod exp)+1}));
+    chi:= Character(tab, Ee{((clexps * lin) mod exp)+1});
+    SetIsIrreducibleCharacter( chi, true );
+    Add(res, chi);
     if i < sz then
       c[1] := c[1]+1;
       lin := lin + irgens[1];
@@ -2007,7 +2009,7 @@ BindGlobal( "IrreducibleRepresentationsByBaumClausen", function( G )
       for i in [ 1 .. lg ] do
         mat:= NullMat( dim, dim, Rationals );
         for k in [ 1 .. dim ] do
-          mat[k][ rep[i].perm[k] ]:=
+          mat[ k, rep[i].perm[k] ]:=
               Ee^( rep[i].diag[ rep[i].perm[k] ] / gcd );
         od;
         images[i]:= mat;

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -1,4 +1,4 @@
-#@local g,t
+#@local g,t,lin
 gap> START_TEST("ctbl.tst");
 
 # `ClassPositionsOf...' for the trivial group (which usually causes trouble)
@@ -376,6 +376,47 @@ gap> Indicator( t mod 3, 2 );
 [ 1, 1, 1, 1 ]
 gap> Indicator( t mod 2, 2 );
 [ 1, 1 ]
+
+# linear characters
+gap> lin:= LinearCharacters( SmallGroup( 24, 12 ) );;
+gap> Length( lin );
+2
+gap> ForAll( lin, HasIsIrreducibleCharacter );
+true
+gap> lin:= LinearCharacters( SymmetricGroup( 4 ) );;
+gap> Length( lin );
+2
+gap> ForAll( lin, HasIsIrreducibleCharacter );
+true
+gap> lin:= LinearCharacters( SymmetricGroup( 4 ), 2 );;
+gap> Length( lin );
+1
+gap> ForAll( lin, HasIsIrreducibleCharacter );
+true
+gap> lin:= LinearCharacters( CharacterTable( SymmetricGroup( 4 ) ) );;
+gap> Length( lin );
+2
+gap> ForAll( lin, HasIsIrreducibleCharacter );
+true
+gap> lin:= LinearCharacters( CharacterTable( SymmetricGroup( 4 ), 2 ) );;
+gap> Length( lin );
+1
+gap> ForAll( lin, HasIsIrreducibleCharacter );
+true
+
+# irreducibility flag
+gap> ForAll( Irr( SymmetricGroup( 4 ) ), HasIsIrreducibleCharacter );
+true
+gap> ForAll( Irr( SymmetricGroup( 4 ), 2 ), HasIsIrreducibleCharacter );
+true
+gap> ForAll( Irr( CharacterTable( SymmetricGroup( 4 ) ) ),
+>            HasIsIrreducibleCharacter );
+true
+gap> ForAll( Irr( CharacterTable( SymmetricGroup( 4 ), 2 ) ),
+>            HasIsIrreducibleCharacter );
+true
+gap> HasIsIrreducibleCharacter( TrivialCharacter( SymmetricGroup( 4 ) ) );
+true
 
 ##
 gap> STOP_TEST( "ctbl.tst" );


### PR DESCRIPTION
For characters that are created with `TrivialCharacter`, `Irr`, and `LinearCharacters`, set `HasIsIrreducibleCharacter`.

Note that asking later for the property can be expensive if the flag is not set.