### PR TITLE
`IsFinite` redispatch for `ConjugacyClasses`

### DIFF
--- a/lib/clas.gi
+++ b/lib/clas.gi
@@ -422,6 +422,7 @@ function(G)
   fi;
 end);
 
+RedispatchOnCondition( ConjugacyClasses, true, [ IsGroup ], [ IsFinite ], 0 );
 
 DEFAULT_CLASS_ORBIT_LIMIT:=500;
 InstallGlobalFunction(ConjugacyClassesForSmallGroup,function(G)

--- a/tst/testinstall/grpfp.tst
+++ b/tst/testinstall/grpfp.tst
@@ -140,4 +140,10 @@ gap> IsomorphismFpGroupByGeneratorsNC( Group( (1,2) ), [], "F" );
 Error, <emptygens> does not generate <G>
 
 #
+gap> F:= FreeGroup( 1 );;
+gap> G:= F / [ F.1^2 ];;
+gap> Length( ConjugacyClasses( G ) );
+2
+
+#
 gap> STOP_TEST( "grpfp.tst" );


### PR DESCRIPTION
In a message to the GAP Forum, Taro Sakurai reported that calling `ConjugacyClasses` with a group that does not know whether it is finite results in a "no method found" error.

```
gap> F:= FreeGroup( 1 );;  G:= F / [ F.1^2 ];;
gap> ConjugacyClasses(G);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 3rd choice method found for `ConjugacyClasses' on 1 arguments at /.../lib/methsel2.g:250 called from
<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
 called from read-eval loop at *stdin*:2
type 'quit;' to quit to outer loop
brk>
```

The problem disappears if we add a finiteness test, via a methods installed with `RedispatchOnCondition`, which is proposed here.

(Alternatively, we could restrict the declaration of `ConjugacyClasses` to groups that store the `IsFinite` flag,
but then all its methods would have to get installed with this requirement, thus this change might break private GAP code.)