### PR TITLE
deal with `FpGroup`s without `IsFinite` flag

### DIFF
--- a/doc/ref/grpfp.xml
+++ b/doc/ref/grpfp.xml
@@ -107,6 +107,21 @@ A consequence of our convention is that elements of finitely presented
 groups are not printed in a unique way.
 See also <Ref Func="SetReducedMultiplication"/>.
 
+For many <Q>higher level</Q> computations for a finite group,
+such as conjugacy classes or character table,
+it is advisable not to use an FpGroup but an isomorphic group in a better
+internal representation,
+such as a pc group (see <Ref Attr="IsomorphismPcGroup"/>)
+or a permutation group (see <Ref Attr="IsomorphismPermGroup"/>).
+
+In fact,
+calling a function such as <Ref Attr="ConjugacyClasses" Label="attribute"/>
+with an FpGroup that does not store that it is finite
+may result in an error message.
+(Once the <Ref Prop="IsFinite"/> value is known, the computation in question
+can be done with the FpGroup, but still it is advisable to use a better
+internal representation.)
+
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="sect:IsSubgroupFpGroup">
@@ -269,6 +284,9 @@ true
 Finitely presented groups are groups and so all operations for groups should
 be applicable to them (though not necessarily efficient methods are
 available).
+However, one may run into errors if the FpGroup does not store that it is
+finite; see the introduction to this chapter.
+
 Most methods for finitely presented groups rely on coset enumeration.
 See&nbsp;<Ref Sect="Coset Tables and Coset Enumeration"/> for details.
 <P/>

--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -5866,3 +5866,47 @@ InstallMethod( IndependentGeneratorsOfAbelianGroup,
   IndependentGeneratorsOfMaximalAbelianQuotientOfFpGroup );
 
 BindGlobal( "TRIVIAL_FP_GROUP", FreeGroup(0) / [] );
+
+
+#############################################################################
+##
+#M  ConjugacyClasses( <G> ) . . . . . . . .  for f.p. groups (error messages)
+##
+##  For an FpGroup that does not have the 'IsFinite' flag,
+##  we do not want that calling 'ConjugacyClasses' triggers a call of
+##  'IsFinite',
+##  see the introduction of the Chapter "Finitely Presented Groups"
+##  in the Reference Manual.
+##
+InstallMethod( ConjugacyClasses,
+  "throw an error for f.p. groups without HasIsFinite",
+  [ IsSubgroupFpGroup ],
+  function( G )
+  if HasIsFinite( G ) then
+    if IsFinite( G ) then
+      # Something went wrong, we should not get here.
+      ErrorNoReturn( "there should be a higher ranked method" );
+    else
+      # We can at least give a better message than "no method found".
+      ErrorNoReturn( "the f.p. group <G> is not finite" );
+    fi;
+  fi;
+
+  while not ( HasIsFinite( G ) and IsFinite( G ) ) do
+    if HasIsFinite( G ) then
+      ErrorNoReturn( "the f.p. group <G> is not finite" );
+    fi;
+    Error( "the f.p. group <G> does not know whether it is finite,\n",
+           "no 'ConjugacyClasses' method is available for such groups,\n",
+           "see the introduction to Chapter \"Finitely Presented Groups\"\n",
+           "in the Reference Manual for the background.\n",
+           "Perhaps you want to replace <G> by a group of another type.\n",
+           "If you want to continue with the given <G> then\n",
+           "you can call 'IsFinite( G );' and then enter 'return;'" );
+  od;
+  if HasIsFinite( G ) and IsFinite( G ) then
+    # The type of 'G' has changed since we entered the method,
+    # it is safe to call the operation again.
+    return ConjugacyClasses( G );
+  fi;
+end );


### PR DESCRIPTION
The discussion of #5944 came to the conclusion that there is a design decision that operations for f.p. groups should not automatically call `IsFinite` --the user should explicitly call (or set) `IsFinite`.

I did not find a statement of such a design decision in the documentation, therefore this pull request proposes adding a paragraph about it to the manual chapter on f.p. groups.

Further, the "no method found error" which one gets is not appropriate; note that the error disappears if  the group knows that it is finite, which is confusing for users.
Therefore this pull request proposes a method that gives a better error message in case of the operation `ConjugacyClasses`.

There are other operations for which the same treatment would be appropriate, otherwise the term "design decision" would not make sense. (`IsDihedralGroup` is one example.)
Similar methods should get installed for them, ideally in a generic way.

Unfortunately, it is not that easy to determine the operations for which the design decision really holds, and for which methods showing a nicer error message should get installed:
In fact, many operations have methods that just take a group without `IsFinite` flag, and call `IsFinite` at some point.
And if the operation is declared for finite groups then there are already fallback methods that check `IsFinite`.

It would be good if the operatons for which the design decision holds could be determined automatically, for example in order to give the Oscar system enough information to catch the errors in advance.