### PR TITLE
fix a bug in `AlgebraHomomorphismByImages`

### DIFF
--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -66,9 +66,9 @@ InstallMethod( AlgebraGeneralMappingByImages,
           filter,
           i,basic;
 
-    # Handle the case that `gens' is a basis or empty.
+    # Handle the case that `gens' is empty.
     # We can form a left module general mapping directly.
-    if IsBasis( gens ) or IsEmpty( gens ) then
+    if IsEmpty( gens ) then
 
       map:= LeftModuleGeneralMappingByImages( S, R, gens, imgs );
       SetIsAlgebraGeneralMapping( map, true );
@@ -327,6 +327,7 @@ InstallMethod( AsLeftModuleGeneralMappingByImages,
     A:=MappingGeneratorsImages(alg_gen_map);
     origgenerators := A[1];
     origgenimages  := A[2];
+    A:= Source( alg_gen_map );
 
     if IsBasis( origgenerators ) then
 
@@ -337,8 +338,6 @@ InstallMethod( AsLeftModuleGeneralMappingByImages,
 
       generators := ShallowCopy( origgenerators );
       genimages  := ShallowCopy( origgenimages );
-
-      A:= Source( alg_gen_map );
 
       left:= not (    ( HasIsAssociative( A ) and IsAssociative( A ) )
                    or ( HasIsLieAlgebra( A ) and IsLieAlgebra( A ) ) );
@@ -402,6 +401,8 @@ InstallMethod( AsLeftModuleGeneralMappingByImages,
       # pairs we obtain below, but rather only those that are not linearly
       # dependent on the already known pairs.
       len := Length( generators );
+      generators:= ShallowCopy( generators );
+      genimages:= ShallowCopy( genimages );
       for i in [ 1 .. len ] do
         for j in [ 1 .. len ] do
           Add( generators, generators[i] * generators[j] );

--- a/tst/testinstall/alghom.tst
+++ b/tst/testinstall/alghom.tst
@@ -110,6 +110,11 @@ gap> AlgebraHomomorphismByImages( A, A, [ 1 ], [ 2 ] );
 fail
 gap> AlgebraHomomorphismByImages( A, A, b, [ 2 ] );
 fail
+gap> map:= AlgebraHomomorphismByImages( A, A, b, [ 1 ] );;
+gap> IsAlgebraGeneralMappingByImagesDefaultRep( map );
+true
+gap> IsLinearGeneralMappingByImagesDefaultRep( map );
+false
 
 #
 gap> STOP_TEST("alghom.tst");

--- a/tst/testinstall/alghom.tst
+++ b/tst/testinstall/alghom.tst
@@ -101,4 +101,15 @@ gap> Q:=R/id;
 <ring with 1 generator>
 gap> Elements(Q);
 [ 0*q1, q1, 2*q1, 3*q1, 4*q1, 5*q1, 6*q1, -q1 ]
+
+# bugfix
+gap> A:= Rationals;;  b:= Basis( A );;
+gap> b = [ 1 ];
+true
+gap> AlgebraHomomorphismByImages( A, A, [ 1 ], [ 2 ] );
+fail
+gap> AlgebraHomomorphismByImages( A, A, b, [ 2 ] );
+fail
+
+#
 gap> STOP_TEST("alghom.tst");


### PR DESCRIPTION
resolves #5915

## Text for release notes
Up to now, `AlgebraHomomorphismByImages` returned a linear mapping if the third argument was a basis object, without checking whether this map is really an algebra homomorphism.