### PR TITLE
Allow user packages in 'make doc'

### DIFF
--- a/doc/make_doc.in
+++ b/doc/make_doc.in
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 GAP=@abs_top_builddir@/gap
-GAPARGS="-b -m 1g -x 80 -q --quitonbreak -r"
+GAPARGS="-b -m 1g -x 80 -q --quitonbreak"
 if [ "$1" == "nopdf" ]; then
   NOPDF=", \"nopdf\""
 else


### PR DESCRIPTION
`make doc` fails if there is no installation of GAPDoc in `gap/pkg/` because it runs with the `-r` flag that disables user package directories.

This PR removes the `-r` flag so that user-installed GAPDoc and other packages can be used in compiling the doc.

This is the last link required for users to be able to do a complete install using only PackageManager and no other packages.

(I have some déjà vu with this – apologies if we've talked about this before and I've forgotten.)