### PR TITLE
kernel: restore (De)ActivateHooks return value

### DIFF
--- a/src/hookintrprtr.c
+++ b/src/hookintrprtr.c
@@ -109,19 +109,19 @@ static Obj ProfileEvalBoolPassthrough(Expr stat)
 **
 */
 
-void ActivateHooks(struct InterpreterHooks * hook)
+BOOL ActivateHooks(struct InterpreterHooks * hook)
 {
     Int i;
 
     if (HookActiveCount == MAX_HOOK_COUNT) {
-        return;
+        return FALSE;
     }
 
     HashLock(&activeHooks);
     for (i = 0; i < MAX_HOOK_COUNT; ++i) {
         if (activeHooks[i] == hook) {
             HashUnlock(&activeHooks);
-            return;
+            return FALSE;
         }
     }
 
@@ -135,13 +135,15 @@ void ActivateHooks(struct InterpreterHooks * hook)
         if (!activeHooks[i]) {
             activeHooks[i] = hook;
             HookActiveCount++;
-            break;
+            HashUnlock(&activeHooks);
+            return TRUE;
         }
     }
     HashUnlock(&activeHooks);
+    return FALSE;
 }
 
-void DeactivateHooks(struct InterpreterHooks * hook)
+BOOL DeactivateHooks(struct InterpreterHooks * hook)
 {
     HashLock(&activeHooks);
     for (int i = 0; i < MAX_HOOK_COUNT; ++i) {
@@ -158,6 +160,7 @@ void DeactivateHooks(struct InterpreterHooks * hook)
     }
 
     HashUnlock(&activeHooks);
+    return TRUE;
 }
 
 /****************************************************************************

--- a/src/hookintrprtr.h
+++ b/src/hookintrprtr.h
@@ -83,8 +83,8 @@ enum { MAX_HOOK_COUNT = 6 };
 
 extern struct InterpreterHooks * activeHooks[MAX_HOOK_COUNT];
 
-void ActivateHooks(struct InterpreterHooks * hook);
-void DeactivateHooks(struct InterpreterHooks * hook);
+BOOL ActivateHooks(struct InterpreterHooks * hook);
+BOOL DeactivateHooks(struct InterpreterHooks * hook);
 
 /****************************************************************************
 **


### PR DESCRIPTION
While it is not used by the kernel, it is used by the (undeposited) debugger package.