### PR TITLE
Fix errors for algebra homomorphisms (infinite recursions and "no method found" errors), in particular concerning homomorphisms that are constructed as inverse mappings

### DIFF
--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -590,16 +590,6 @@ InstallMethod( PreImagesRepresentative,
                                     elm );
     end );
 
-InstallMethod( PreImagesRepresentative,
-    "for algebra g.m.b.i. knowing inverse, and element",
-    FamRangeEqFamElm,
-    [ IsGeneralMapping and IsAlgebraGeneralMappingByImagesDefaultRep
-      and HasInverseGeneralMapping,
-      IsObject ],
-    function( map, elm )
-    return ImagesRepresentative( InverseGeneralMapping(map), elm );
-    end );
-
 
 #############################################################################
 ##
@@ -652,7 +642,7 @@ InstallMethod( CompositionMapping2,
 #M  CompositionMapping2( <map2>, map1> )  for algebra hom. & algebra g.m.b.i.
 ##
 InstallMethod( CompositionMapping2,
-    "for left module hom. and algebra g.m.b.i.",
+    "for algebra hom. and algebra g.m.b.i.",
     FamSource1EqFamRange2,
     [ IsAlgebraHomomorphism,
           IsAlgebraGeneralMapping
@@ -664,20 +654,19 @@ InstallMethod( CompositionMapping2,
           mapi1,mapi2;
 
     mapi1:=MappingGeneratorsImages(map1);
-    mapi2:=MappingGeneratorsImages(map2);
     # Compute images for the generators of `map1'.
-    if     IsAlgebraGeneralMappingByImagesDefaultRep( map2 )
-       and mapi1[2]=mapi2[1] then
-
-      gens      := mapi1[1];
-      genimages := mapi2[2];
-
+    gens:= mapi1[1];
+    if IsAlgebraGeneralMappingByImagesDefaultRep( map2 ) then
+      mapi2:= MappingGeneratorsImages( map2 );
+      if mapi1[2] = mapi2[1] then
+        genimages:= mapi2[2];
+      else
+        genimages:= List( mapi1[2],
+                          v -> ImagesRepresentative( map2, v ) );
+      fi;
     else
-
-      gens:= mapi1[1];
       genimages:= List( mapi1[2],
                         v -> ImagesRepresentative( map2, v ) );
-
     fi;
 
     # Construct the linear general mapping.

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -900,10 +900,8 @@ InstallMethod( InverseGeneralMapping,
 ##
 InstallMethod( IsSingleValued,
     "for an inverse mapping",
-    true,
     [ IsGeneralMapping and IsInverseGeneralMappingRep ],
-    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
-          - RankFilter( IsInverseGeneralMappingRep ) + 1,
+    SUM_FLAGS,
     inv -> IsInjective( InverseGeneralMapping( inv ) ) );
 
 
@@ -913,10 +911,8 @@ InstallMethod( IsSingleValued,
 ##
 InstallMethod( IsInjective,
     "for an inverse mapping",
-    true,
     [ IsGeneralMapping and IsInverseGeneralMappingRep ],
-    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
-          - RankFilter( IsInverseGeneralMappingRep ) + 1,
+    SUM_FLAGS,
     inv -> IsSingleValued( InverseGeneralMapping( inv ) ) );
 
 
@@ -926,10 +922,8 @@ InstallMethod( IsInjective,
 ##
 InstallMethod( IsSurjective,
     "for an inverse mapping",
-    true,
     [ IsGeneralMapping and IsInverseGeneralMappingRep ],
-    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
-          - RankFilter( IsInverseGeneralMappingRep ) + 1,
+    SUM_FLAGS,
     inv -> IsTotal( InverseGeneralMapping( inv ) ) );
 
 
@@ -939,10 +933,8 @@ InstallMethod( IsSurjective,
 ##
 InstallMethod( IsTotal,
     "for an inverse mapping",
-    true,
     [ IsGeneralMapping and IsInverseGeneralMappingRep ],
-    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
-          - RankFilter( IsInverseGeneralMappingRep ) + 1,
+    SUM_FLAGS,
     inv -> IsSurjective( InverseGeneralMapping( inv ) ) );
 
 

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -901,7 +901,9 @@ InstallMethod( InverseGeneralMapping,
 InstallMethod( IsSingleValued,
     "for an inverse mapping",
     true,
-    [ IsGeneralMapping and IsInverseGeneralMappingRep ], 0,
+    [ IsGeneralMapping and IsInverseGeneralMappingRep ],
+    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
+          - RankFilter( IsInverseGeneralMappingRep ) + 1,
     inv -> IsInjective( InverseGeneralMapping( inv ) ) );
 
 
@@ -912,7 +914,9 @@ InstallMethod( IsSingleValued,
 InstallMethod( IsInjective,
     "for an inverse mapping",
     true,
-    [ IsGeneralMapping and IsInverseGeneralMappingRep ], 0,
+    [ IsGeneralMapping and IsInverseGeneralMappingRep ],
+    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
+          - RankFilter( IsInverseGeneralMappingRep ) + 1,
     inv -> IsSingleValued( InverseGeneralMapping( inv ) ) );
 
 
@@ -923,7 +927,9 @@ InstallMethod( IsInjective,
 InstallMethod( IsSurjective,
     "for an inverse mapping",
     true,
-    [ IsGeneralMapping and IsInverseGeneralMappingRep ], 0,
+    [ IsGeneralMapping and IsInverseGeneralMappingRep ],
+    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
+          - RankFilter( IsInverseGeneralMappingRep ) + 1,
     inv -> IsTotal( InverseGeneralMapping( inv ) ) );
 
 
@@ -934,7 +940,9 @@ InstallMethod( IsSurjective,
 InstallMethod( IsTotal,
     "for an inverse mapping",
     true,
-    [ IsGeneralMapping and IsInverseGeneralMappingRep ], 0,
+    [ IsGeneralMapping and IsInverseGeneralMappingRep ],
+    {} -> RankFilter( RespectsAddition and RespectsAdditiveInverses )
+          - RankFilter( IsInverseGeneralMappingRep ) + 1,
     inv -> IsSurjective( InverseGeneralMapping( inv ) ) );
 
 
@@ -1027,7 +1035,7 @@ InstallMethod( ImagesSet,
 
 #############################################################################
 ##
-#M  ImagesSet( <invmap>, <coll> ) . . . .  for inverse mapping and collection
+#M  ImagesRepresentative( <invmap>, <coll> )  . .  for inv. mapping and coll.
 ##
 InstallMethod( ImagesRepresentative,
     "for an inverse mapping and an element",

--- a/tst/testinstall/alghom.tst
+++ b/tst/testinstall/alghom.tst
@@ -1,5 +1,5 @@
 #@local A,B,C,ExampleRing,I,O,P,Q,R,T,b,coker,f,gensq,id,ker,m1,m2,map,pols
-#@local pr,q,x,y,z
+#@local pr,q,x,y,z,inv,gens,map1,map2
 gap> START_TEST("alghom.tst");
 
 # An example of a non-homomorphism which is total but not single-valued.
@@ -102,7 +102,7 @@ gap> Q:=R/id;
 gap> Elements(Q);
 [ 0*q1, q1, 2*q1, 3*q1, 4*q1, 5*q1, 6*q1, -q1 ]
 
-# bugfix
+# bugfixes
 gap> A:= Rationals;;  b:= Basis( A );;
 gap> b = [ 1 ];
 true
@@ -115,6 +115,16 @@ gap> IsAlgebraGeneralMappingByImagesDefaultRep( map );
 true
 gap> IsLinearGeneralMappingByImagesDefaultRep( map );
 false
+gap> inv:= InverseGeneralMapping( map );;
+gap> PreImagesRepresentative( map, 1 );
+1
+gap> T:= EmptySCTable( 2, 0 );;
+gap> SetEntrySCTable( T, 1, 1, [ 1/2, 1, 2/3, 2 ] );
+gap> A:= AlgebraByStructureConstants( Rationals, T );;
+gap> gens:= GeneratorsOfAlgebra( A );;
+gap> map1:= AlgebraHomomorphismByImages( A, A, gens, gens );;
+gap> map2:= AlgebraHomomorphismByFunction( A, A, x -> 2*x );;
+gap> CompositionMapping2( map2, map1 );;  # no error
 
 #
 gap> STOP_TEST("alghom.tst");


### PR DESCRIPTION
1. remove a `PreImagesRepresentative` method that is applicable if the given map knows its inverse, and then delegates to `ImagesRepresentative` for that inverse (This conflicts with a delegation in the other direction for maps in `IsInverseGeneralMappingRep`, which causes an infinite recursion.)

2. fix `CompositionMapping2` for algebra homom. and algebra g.m.b.i., `MappingGeneratorsImages` is apparently supported only for mappings "by image"

3. rank up the `IsSingleValued`, `IsInjective`, `IsSurjective`, `IsTotal` methods for `IsGeneralMapping and IsInverseGeneralMappingRep`, in order to make the initial example from issue #5953 work

- An alternative to 1. would be to keep the method in question, but to exit with `TryNextMethod()` if the stored inverse map is in `IsInverseGeneralMappingRep`.
- Eventually the documentation for `MappingGeneratorsImages` should explain for which types of general mappings one may call it. Currently the documentation appears in the section "Representations for Group Homomorphisms", which is too restrictive.
- Conceptually, the rank change in 3. should probably prescribe the rank `SUM_FLAGS`. Once we have decided about the solution, the changes may have to be mentioned in the release notes.

resolves #5953