### PR TITLE
Make `ArithmeticElementCreator` understand re-read mode

### DIFF
--- a/lib/proto.gi
+++ b/lib/proto.gi
@@ -29,7 +29,7 @@ function(spec)
     eFam, eType;    # the element family and element type
 
   # first check to see this hasn't already been done
-  if IsBoundGlobal(Concatenation("Is",spec.ElementName)) then
+  if not REREADING and IsBoundGlobal(Concatenation("Is",spec.ElementName)) then
     Error(Concatenation(spec.ElementName," already defined"));
   fi;
 


### PR DESCRIPTION
In GAP one can use `Reread` (and its variants) instead of `Read` (and its variants) while developing code; this suppresses errors caused by re-defining global read-only variables.

But this didn't work when using `ArithmeticElementCreator` because that had its own check for detecting and rejecting such redefinitions.

This patch teaches it to honor the `REREADING` global for a smoother developer experience.


Based on questions by @twiedemann