### PR TITLE
Various minor meataxe improvements

### DIFF
--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -191,38 +191,16 @@ local n, weights, mat, vec, ReduceRow, t,
   od;
 end);
 
-BindGlobal("SMTX_NewEqns",function (arg)
-local X, n, F, V, eqns;
-
-  if Length(arg) <2 then
-    Error("NewEqns(dim, field) or NewEqns(X, V)");
-  fi;
-
-  if IsInt(arg[1]) then
-    X := false;
-    n := arg[1];
-    F := arg[2];
-  else
-    X := arg[1];
-    V := arg[2];
-    n := Length(X[1]);
-    F := Field(X[1][1]); # Note: prime field only
-  fi;
-
-  eqns := rec();
-  eqns.dim := n;              # number of variables
-  eqns.field := F;            # field over which the equation hold
-  eqns.mat := [];             # left-hand sides of system
-  eqns.weights := [];         # echelon weights for lhs matrix
-  eqns.vec := [];             # right-hand sides of system
-  eqns.failed := false;         # flag to indicate inconsistent system
-  eqns.index := [];           # index for row ordering
-
-  if IsMatrix(X) then
-    SMTX_AddEqns(eqns, X, V);
-  fi;
-
-  return eqns;
+BindGlobal("SMTX_NewEqns",function (dim, field)
+  return rec(
+    dim := dim,         # number of variables
+    field := field,     # field over which the equation hold
+    mat := [],          # left-hand sides of system
+    weights := [],      # echelon weights for lhs matrix
+    vec := [],          # right-hand sides of system
+    failed := false,    # flag to indicate inconsistent system
+    index := [],        # index for row ordering
+  );
 end);
 
 BindGlobal("SMTX_KillAbovePivotsEqns",function (eqns)

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -552,7 +552,7 @@ end);
 # If a linearly dependent set of elements is supplied, this
 # routine will trim it down to a basis.
 BindGlobal("SMTX_EcheloniseMats",function (gens, F)
-local n, m, zero, ech, k, i, j, found, l;
+local n, m, zero, ech, k, i, j, l;
 
   if Length(gens) = 0 then
     return [ [], [] ];
@@ -568,20 +568,14 @@ local n, m, zero, ech, k, i, j, found, l;
   k:=1;
 
   while k <= Length(gens) do
-    i:=1; j:=1;
-    found:=false;
-    while not found and i <= n do
-      if (gens[k][i,j] <> zero) then
-        found:=true;
-      else
-        j:=j + 1;
-        if (j > m) then
-          j:=1; i:=i + 1;
-        fi;
+    for i in [1..n] do
+      j:=PositionNonZero(gens[k][i]);
+      if j <= m then
+        break;
       fi;
     od;
 
-    if found then
+    if j <= m then
 
       # Now basis element k will have echelonisation index [i,j]
       Add(ech, [i,j]);

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1377,31 +1377,28 @@ SMTX.IsomorphismModules:=SMTX_IsomorphismModules;
 # running down diagonals below the main diagonal:
 #   [2,1], [3,2], [4,3], ..., [3,1], [4,2], ..., [n-1,1], [n, 2], [n,1]
 BindGlobal("SMTX_EcheloniseNilpotentMatAlg",function (matalg, F)
-local zero, n, flags, base, ech, k, diff, i, j, found, l;
+local zero, n, base, ech, k, diff, i, j, found, l;
 
   zero:=Zero(F);
   n := NrCols(matalg[1]);
-  flags := NullMat(n,n);
 
-  base := matalg;
+  base := ShallowCopy(matalg);
   ech := [];
   k := 1;
 
   while k <= Length(base) do
     diff := 1;
-    i := 2; j := i - diff;
+    i := 2;
     found := false;
     while not found and diff < n do
-      if (base[k][i,j] <> zero) and
-        (flags[i,j] = 0) then
+      j := i - diff;
+      if base[k][i,j] <> zero then
         found := true;
       else
         i := i + 1;
-        j := i - diff;
-        if (i > n) then
+        if i > n then
           diff := diff + 1;
           i := diff + 1;
-          j := i - diff;
         fi;
       fi;
     od;

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1171,7 +1171,7 @@ end);
 
 
 BindGlobal("SMTX_Indecomposition",function(m)
-local n, F, stack, i, d, d2, md, b, endo, sel, e1, e2;
+local n, F, stack, i, d, d2, md, b, binv, endo, sel, e1, e2;
   if not IsBound(m.indecomposition) then
     n:=m.dimension;
     F:=m.field;
@@ -1189,9 +1189,10 @@ local n, F, stack, i, d, d2, md, b, endo, sel, e1, e2;
         Assert(1,ForAll(md,i->i<>fail));
         # Translate endomorphism rings
         b:=Concatenation(d[1],d[2]); # local new basis
+        binv := b^-1;
         # basechange
         endo:=List(stack[i][2].basisModuleEndomorphisms,
-                   i->b*i/b);
+                   mat->b*mat*binv);
         sel:=[1..Length(d[1])];
         e1:=List(endo,i->i{sel}{sel});
         e1:=SMTX_EcheloniseMats(e1,F)[1];

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -263,7 +263,7 @@ local mat, n, one, zerovec, i, k, nullspace, row;
     for i  in [ NrRows(mat)+1 .. n ]  do
       Add(mat, zerovec);
     od;
-    ConvertToMatrixRep(mat);
+    ConvertToMatrixRep(mat, e.field);
   fi;
 
   # The following comment from NullspaceMat:
@@ -673,7 +673,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
     ans:=SpinHomFindVector(work);
     v0:=ans[1];
     M:=ans[2];
-    ConvertToMatrixRep(M);
+    ConvertToMatrixRep(M, F);
 
     # find residue of <v0> modulo current submodule <U>
     x:=EchResidueCoeffs(U, echu, v0,2);
@@ -750,7 +750,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
           # difference between <v0^m> and <uu> in <U>.
           x:=v[i] * gV[j];
           m:=ag;
-          ConvertToMatrixRep(m);
+          ConvertToMatrixRep(m, F);
           uu:=u[i] * gV[j];
 
           ret:=EchResidueCoeffs(U, echu, x,3);
@@ -798,7 +798,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
             uu:=v[i] * gV[j] - s1;
 
             X:=NullMat(t, nw, F);
-            ConvertToMatrixRep(X);
+            ConvertToMatrixRep(X, F);
             for l in [1..Length(v)] do
               if c[l] <> zero then
                 if Length(X) > 0 then
@@ -850,6 +850,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
       hom:=[];
       if r > 0 then
         Uhom:=NullMat(r, nw, F);
+        ConvertToMatrixRep(Uhom, F);
         for l in [1..s] do
           if ans[i][l] <> zero then
             Uhom:=Uhom + ans[i][l] * homs[l];

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -559,8 +559,8 @@ local n, m, zero, ech, k, i, j, found, l;
   # copy the list to avoid destroying the original list
   gens:=List(gens,i->List(i,ShallowCopy));
 
-  n:=Length(gens[1]);
-  m:=Length(gens[1][1]);
+  n:=NrRows(gens[1]);
+  m:=NrCols(gens[1]);
   zero:=Zero(F);
 
   ech:=[];
@@ -570,7 +570,7 @@ local n, m, zero, ech, k, i, j, found, l;
     i:=1; j:=1;
     found:=false;
     while not found and i <= n do
-      if (gens[k][i][j] <> zero) then
+      if (gens[k][i,j] <> zero) then
         found:=true;
       else
         j:=j + 1;
@@ -586,12 +586,12 @@ local n, m, zero, ech, k, i, j, found, l;
       Add(ech, [i,j]);
 
       # First normalise the [i,j] position to 1
-      gens[k]:=gens[k] / gens[k][i][j];
+      gens[k]:=gens[k] / gens[k][i,j];
 
       # Now zero position [i,j] in all further generators
       for l in [k+1..Length(gens)] do
-        if (gens[l][i][j] <> zero) then
-          gens[l]:=gens[l] - gens[k] * gens[l][i][j];
+        if (gens[l][i,j] <> zero) then
+          gens[l]:=gens[l] - gens[k] * gens[l][i,j];
         fi;
       od;
       k:=k + 1;
@@ -992,8 +992,8 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
 
     for i in [1..nildim] do
       r:=echelon[nilech[i]][1]; c:=echelon[nilech[i]][2];
-      if a[r][c] <> zero then
-        a:=a - a[r][c] * nilbase[i] / nilbase[i][r][c];
+      if a[r,c] <> zero then
+        a:=a - a[r,c] * nilbase[i] / nilbase[i][r,c];
       fi;
     od;
 
@@ -1002,7 +1002,7 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
     while not done and k <= Length(remain) do
       l:=remain[k];
       r:=echelon[l][1]; c:=echelon[l][2];
-      if a[r][c] <> zero then
+      if a[r,c] <> zero then
         done:=true;
       else
         k:=k + 1;
@@ -1381,7 +1381,7 @@ BindGlobal("SMTX_EcheloniseNilpotentMatAlg",function (matalg, F)
 local zero, n, flags, base, ech, k, diff, i, j, found, l;
 
   zero:=Zero(F);
-  n := Length(matalg[1][1]);
+  n := NrCols(matalg[1]);
   flags := NullMat(n,n);
 
   base := matalg;
@@ -1393,8 +1393,8 @@ local zero, n, flags, base, ech, k, diff, i, j, found, l;
     i := 2; j := i - diff;
     found := false;
     while not found and diff < n do
-      if (base[k][i][j] <> zero) and
-        (flags[i][j] = 0) then
+      if (base[k][i,j] <> zero) and
+        (flags[i,j] = 0) then
         found := true;
       else
         i := i + 1;
@@ -1413,12 +1413,12 @@ local zero, n, flags, base, ech, k, diff, i, j, found, l;
       Add(ech, [i,j]);
 
       # First normalise the [i,j] position to 1
-      base[k] := base[k] / base[k][i][j];
+      base[k] := base[k] / base[k][i,j];
 
       # Now zero position [i,j] in all other basis elements
       for l in [1..Length(base)] do
-        if (l <> k) and (base[l][i][j] <> zero) then
-          base[l] := base[l] - base[k] * base[l][i][j];
+        if (l <> k) and (base[l][i,j] <> zero) then
+          base[l] := base[l] - base[k] * base[l][i,j];
         fi;
       od;
       k := k + 1;
@@ -1445,7 +1445,7 @@ local decompose, field, Y, mats, newbase;
       Append(Y, b);
     else
 
-      n := Length(m[1][1]);
+      n := NrCols(m[1]);
 
       # find the intersection of the nullspaces
       subs:=NullspaceMat(m[1]);
@@ -1481,7 +1481,7 @@ local decompose, field, Y, mats, newbase;
 
   Y   := [];
 
-  decompose( matalg, IdentityMat(Length(matalg[1][1]), field));
+  decompose( matalg, IdentityMat(NrCols(matalg[1]), field));
   #
   # Y is the change of basis matrix
 

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1433,8 +1433,8 @@ end);
 
 # compute a change of basis that exhibits the matrix algebra
 # defined by the basis 'matalg' in triangular form.
-BindGlobal("SMTX_NilpotentBasis",function (matalg)
-local decompose, field, Y, mats, newbase;
+BindGlobal("SMTX_NilpotentBasis",function (matalg,field)
+local decompose, Y, mats, newbase;
 
   decompose := function ( m, b )
   local n, subs, vs, vsi,rep, newm,j,ran;
@@ -1476,8 +1476,6 @@ local decompose, field, Y, mats, newbase;
 
   # return empty list if empty matrix list
   if Length(matalg) = 0 then return []; fi;
-
-  field := DefaultField(matalg[1][1]);
 
   Y   := [];
 
@@ -1562,7 +1560,7 @@ BindGlobal("SMTX_ModuleAutomorphisms",function(m)
     # of the endomorphism algebra as a circle group
     nilbase:=SMTX.BasisEndomorphismsRadical(h[i].component[2]);
     if Length(nilbase)>0 then
-      nilbase:=SMTX_NilpotentBasis(nilbase);
+      nilbase:=SMTX_NilpotentBasis(nilbase,f);
       nilbase:=nilbase[2]^-1*nilbase[1]*nilbase[2];
     fi;
     a:=(Size(f)^Length(nilbase))^(r^2);

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -316,6 +316,7 @@ local n, coeffs, x, zero, z, i;
         coeffs[i]:=z;
       fi;
     od;
+    ConvertToVectorRep(coeffs);
   fi;
 
   if mode=1 then
@@ -557,7 +558,7 @@ local n, m, zero, ech, k, i, j, found, l;
     return [ [], [] ];
   fi;
   # copy the list to avoid destroying the original list
-  gens:=List(gens,i->List(i,ShallowCopy));
+  gens:=ShallowCopy(gens);
 
   n:=NrRows(gens[1]);
   m:=NrCols(gens[1]);
@@ -678,6 +679,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
     ans:=SpinHomFindVector(work);
     v0:=ans[1];
     M:=ans[2];
+    ConvertToMatrixRep(M);
 
     # find residue of <v0> modulo current submodule <U>
     x:=EchResidueCoeffs(U, echu, v0,2);
@@ -754,6 +756,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
           # difference between <v0^m> and <uu> in <U>.
           x:=v[i] * gV[j];
           m:=ag;
+          ConvertToMatrixRep(m);
           uu:=u[i] * gV[j];
 
           ret:=EchResidueCoeffs(U, echu, x,3);
@@ -801,6 +804,7 @@ local nv, nw, F, zero, zeroW, gV, gW, k, U, echu, r, homs, s, work, ans, v0,
             uu:=v[i] * gV[j] - s1;
 
             X:=NullMat(t, nw, F);
+            ConvertToMatrixRep(X);
             for l in [1..Length(v)] do
               if c[l] <> zero then
                 if Length(X) > 0 then

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -742,7 +742,7 @@ end;
 ##
 #F  SMTX.InducedActionFactorModuleWithBasis( module, sub )
 ##
-# FIXME: this function is never used and documented. Keep it or remove it?
+# FIXME: this function is never used and undocumented. Keep it or remove it?
 SMTX.InducedActionFactorModuleWithBasis:=function(module,sub)
 local ans, qmodule;
 
@@ -822,7 +822,7 @@ end;
 #F  SMTX.InducedActionSubMatrixNB( mat, sub ) . . . . construct submodule
 ##
 ##  as InducedActionSubmoduleNB but for a matrix.
-# FIXME: this function is never used and documented. Keep it or remove it?
+# FIXME: this function is never used and undocumented. Keep it or remove it?
 SMTX.InducedActionSubMatrixNB:=function( mat, sub )
 local module, ans;
 
@@ -842,7 +842,7 @@ local module, ans;
 end;
 
 # Ditto, but allowing also unnormed modules
-# FIXME: this function is never used and documented. Keep it or remove it?
+# FIXME: this function is never used and undocumented. Keep it or remove it?
 SMTX.InducedActionSubMatrix:=function(mat,sub)
 local nb, module, ans;
 

--- a/tst/testinstall/meatauto.tst
+++ b/tst/testinstall/meatauto.tst
@@ -12,28 +12,4 @@ gap> SMTX_NullspaceEqns(e);
   [ 0*Z(5), 0*Z(5), Z(5)^0 ] ]
 
 #
-gap> F := GF(2);;
-gap> M := IdentityMat(3, F);; M[1,3]:=M[1,1];; M[3,1]:=M[1,1];;
-gap> v := ImmutableVector(F, M[2]);;
-gap> e := SMTX_NewEqns(M, v);
-rec( dim := 3, failed := false, field := GF(2), index := [  ], 
-  mat := [ <a GF2 vector of length 3>, <a GF2 vector of length 3> ], 
-  vec := [ 0*Z(2), Z(2)^0 ], weights := [ 1, 2 ] )
-gap> N := SMTX_NullspaceEqns(e);
-[ <a GF2 vector of length 3> ]
-gap> N = [ [ Z(2)^0, 0*Z(2), Z(2)^0 ] ];
-true
-
-#
-gap> F := GF(5);;
-gap> M := IdentityMat(3, F);; M[1,3]:=M[1,1];; M[3,1]:=M[1,1];;
-gap> v := ImmutableVector(F, M[2]);;
-gap> e := SMTX_NewEqns(M, v);
-rec( dim := 3, failed := false, field := GF(5), index := [  ], 
-  mat := [ [ Z(5)^0, 0*Z(5), Z(5)^0 ], [ 0*Z(5), Z(5)^0, 0*Z(5) ] ], 
-  vec := [ 0*Z(5), Z(5)^0 ], weights := [ 1, 2 ] )
-gap> SMTX_NullspaceEqns(e);
-[ [ Z(5)^2, 0*Z(5), Z(5)^0 ] ]
-
-#
 gap> STOP_TEST("meatauto.tst");

--- a/tst/testinstall/meatauto.tst
+++ b/tst/testinstall/meatauto.tst
@@ -1,4 +1,4 @@
-#@local F, e, M, v, N
+#@local F, e, M, v, N, G, p, hc, A
 gap> START_TEST("meatauto.tst");
 
 #
@@ -10,6 +10,50 @@ rec( dim := 3, failed := false, field := GF(5), index := [  ], mat := [  ],
 gap> SMTX_NullspaceEqns(e);
 [ [ Z(5)^0, 0*Z(5), 0*Z(5) ], [ 0*Z(5), Z(5)^0, 0*Z(5) ], 
   [ 0*Z(5), 0*Z(5), Z(5)^0 ] ]
+
+#
+# MTX.BasisModuleEndomorphisms
+#
+gap> G:=SmallGroup(24, 3);;
+gap> p:=NextPrimeInt(100);;
+gap> M:=RegularModule(G, GF(p))[2];;
+gap> MTX.BasisModuleEndomorphisms(M);
+[ < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) >, 
+  < immutable compressed matrix 24x24 over GF(101) > ]
+
+#
+# MTX.HomogeneousComponents
+#
+gap> G:=SmallGroup(24, 3);;
+gap> p:=NextPrimeInt(100);;
+gap> M:=RegularModule(G, GF(p))[2];;
+gap> hc := MTX.HomogeneousComponents(M);;
+gap> SortedList(List(hc, x -> Length(x.indices)));
+[ 1, 1, 2, 2, 3 ]
+gap> Union(List(hc, x -> x.indices));
+[ 1 .. 9 ]
 
 #
 gap> STOP_TEST("meatauto.tst");


### PR DESCRIPTION
- **meataxe: simplify SMTX_NewEqns**
- **meataxe: use some MatrixObj features**
- **meataxe: avoid a DefaultField call**
- **meataxe: fix comment typos**
- **meataxe: ensure more matrices are/stay compressed**
- **meataxe: avoid repeatedly inverting the same matrix**

Recently @fieker pointed out some small inputs for which the GAP meataxe takes unreasonable amounts of time.

While working on resolving these, I have made numerous small tweaks that also should be added. Since they are mostly local and hopefully uncontroversial I am submitting them hereby in a separate PR.