### PR TITLE
Add benchmarks for `ExtractSubMatrix` + `CopySubMatrix`

### DIFF
--- a/benchmark/matobj/bench-matelm-access.g
+++ b/benchmark/matobj/bench-matelm-access.g
@@ -7,9 +7,9 @@ TestReadingMatrix := function(m)
     PrintHeadline("m[i][j]");
     MyBench(function()
         local u, i, j, rows, cols, x;
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     x:=m[i][j];
@@ -21,9 +21,9 @@ TestReadingMatrix := function(m)
     PrintHeadline("m[i,j]");
     MyBench(function()
         local u, i, j, rows, cols, x;
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     x:=m[i,j];
@@ -35,9 +35,9 @@ TestReadingMatrix := function(m)
     PrintHeadline("MatElm(m,i,j)");
     MyBench(function()
         local u, i, j, rows, cols, x;
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     x:=MatElm(m,i,j);
@@ -50,9 +50,9 @@ TestReadingMatrix := function(m)
     f:=ApplicableMethod(MatElm, [m,1,1]);;
     MyBench(function()
         local u, i, j, rows, cols, x;
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     x:=f(m,i,j);
@@ -70,9 +70,9 @@ TestWritingMatrix := function(m)
     MyBench(function()
         local u, i, j, rows, cols, x;
         x:=m[1][1];
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     m[i][j]:=x;
@@ -85,9 +85,9 @@ TestWritingMatrix := function(m)
     MyBench(function()
         local u, i, j, rows, cols, x;
         x:=m[1][1];
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     m[i,j]:=x;
@@ -100,9 +100,9 @@ TestWritingMatrix := function(m)
     MyBench(function()
         local u, i, j, rows, cols, x;
         x:=m[1][1];
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     SetMatElm(m,i,j,x);
@@ -116,9 +116,9 @@ TestWritingMatrix := function(m)
     MyBench(function()
         local u, i, j, rows, cols, x;
         x:=m[1][1];
-        rows := [1..Length(m)];
-        cols := [1..Length(m[1])];
-        for u in [1..QuoInt(100000,Length(m)*Length(m[1]))] do
+        rows := [1..NrRows(m)];
+        cols := [1..NrCols(m)];
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
             for i in rows do
                 for j in cols do
                     f(m,i,j,x);

--- a/benchmark/matobj/bench-submat.g
+++ b/benchmark/matobj/bench-submat.g
@@ -1,0 +1,80 @@
+ReadGapRoot("benchmark/matobj/bench.g");
+
+
+TestExtractingSubmatrix := function(m)
+    local rows, cols;
+
+    rows := [2..NrRows(m)-2];
+    cols := [3..NrCols(m)-1];
+
+    PrintHeadline("m{}{}");
+    MyBench(function()
+        local u, x;
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
+            x:=m{rows}{cols};
+        od;
+    end);
+
+    PrintHeadline("ExtractSubMatrix");
+    MyBench(function()
+        local u, x;
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
+            x:=ExtractSubMatrix(m, rows, cols);
+        od;
+    end);
+
+end;
+
+TestCopyingSubmatrix := function(m)
+    local x, rows, cols;
+
+    x := MutableCopyMat(m);
+    rows := [2..NrRows(m)-2];
+    cols := [3..NrCols(m)-1];
+
+    PrintHeadline("m{}{}:=n{}{}");
+    MyBench(function()
+        local u;
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
+            x{rows}{cols}:=m{rows}{cols};
+        od;
+    end);
+
+    PrintHeadline("CopySubMatrix");
+    MyBench(function()
+        local u;
+        for u in [1..QuoInt(100000,NrRows(m)*NrCols(m))] do
+            CopySubMatrix(m, x, rows, cols, rows, cols);
+        od;
+    end);
+
+end;
+
+RunMatTest := function(desc, m)
+    Print("\n");
+    PrintBoxed(Concatenation("Testing submatrix extraction for ", desc));
+    TestExtractingSubmatrix(m);
+    Print(TextAttr.2, "...now testing submatrix copying...\n", TextAttr.reset);
+    TestCopyingSubmatrix(m);
+end;
+
+for dim in [10, 100] do
+    PrintBoxed(Concatenation("Now testing in dimension ", String(dim)));
+
+    m:=IdentityMat(dim);;
+    RunMatTest("integer matrix", m);
+
+    m:=IdentityMat(dim,GF(2));;
+    RunMatTest("GF(2) rowlist", m);
+
+    m:=IdentityMat(dim,GF(2));; ConvertToMatrixRep(m);;
+    RunMatTest("GF(2) compressed matrix", m);
+
+    m:=IdentityMat(dim,GF(7));;
+    RunMatTest("GF(7) rowlist", m);
+
+    m:=IdentityMat(dim,GF(7));; ConvertToMatrixRep(m);;
+    RunMatTest("GF(7) compressed matrix", m);
+
+# TODO: also add cvec matrices
+od;


### PR DESCRIPTION
These functions are part of the MatrixObj AP, but currently they are basically always slower than their list arithmetic counter parts involving the `m{}{}` syntax, even in situations where those APIs were supposed to be superior.

I believe this can be reversed by providing tuned methods for these functions (at least for the built-in plain and compressed matrices). In order to tackler this systematically, we need robust benchmarks to measure the effect of any changes.

This patch adds a first version of such benchmarks. Of course what we *really* need are the improvements, but now at least we have a baseline.