### PR TITLE
meataxe: make endomorphism ring computation faster

### DIFF
--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1126,11 +1126,16 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
           cnt:=cnt + 1;
         fi;
 
-        # if the minimal polynomial is not irreducible, pick any non-trivial
-        # proper factor from it and evaluate the result at a; the resulting
-        # matrix will be non-zero and non-regular, giving us a chance to find
-        # a splitting in the next step
-        fac := Factors(MinimalPolynomialMatrixNC( F, a, 1 ));
+        # Compute the order polynomial of `a` with respect to a random vector,
+        # i.e., a (cheap) factor of the minimal polynomial, then pick the any
+        # factor of that (in practice, we pick one with minimal degree for
+        # efficiency) and evaluate it at a. The resulting matrix will be
+        # non-zero and non-regular, giving us a chance to find a splitting in
+        # the next step.
+        coeffs:=List([1..n], x -> Random(F));
+        ConvertToVectorRep(coeffs);
+        f := Matrix_OrderPolynomialSameField( F, a, coeffs, 1 );
+        fac := Factors(f);
         if Length(fac) > 1 then # not irreducible?
           f := Set(fac)[1]; # pick factor with minimal degree
           a := f(a);

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -980,7 +980,7 @@ end);
 BindGlobal("ProperModuleDecomp",function (M)
 local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
       echelon, nildim, p, maxorder, maxa, nilbase, nilech, cnt, remain,
-      coeffs, a, rk, order, fit, pos, newa, lastdim, i;
+      coeffs, a, rk, order, fit, pos, newa, lastdim, i, fac, f;
 
   # Check whether we have found the indecomposability proof. That is,
   # see whether our regular element generates a subalgebra which
@@ -1125,7 +1125,20 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
         else
           cnt:=cnt + 1;
         fi;
-      else
+
+        # if the minimal polynomial is not irreducible, pick any non-trivial
+        # proper factor from it and evaluate the result at a; the resulting
+        # matrix will be non-zero and non-regular, giving us a chance to find
+        # a splitting in the next step
+        fac := Factors(MinimalPolynomialMatrixNC( F, a, 1 ));
+        if Length(fac) > 1 then # not irreducible?
+          f := Set(fac)[1]; # pick factor with minimal degree
+          a := f(a);
+          rk := RankMat(a);
+        fi;
+      fi;
+
+      if rk < n then
         fit:=FittingSplitModule(a,rk,F);
         if fit<>fail then
           return fit;


### PR DESCRIPTION
... at least in some examples. The performance of the previous code also fluctuated extremely based on the RNG seed.

Before:

    gap> G:=SmallGroup(24, 3);;
    gap> p:=NextPrimeInt(100);;
    gap> MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    3998
    gap> zz := MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);;
    Error, Unable to ascertain module decomposition within time limits.
    ...
    gap> zz := MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    1061
    gap> zz := MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    16724

After:

    gap> G:=SmallGroup(24, 3);;
    gap> p:=NextPrimeInt(100);;
    gap> MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    100
    gap> MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    69
    gap> MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    70
    gap> MTX.HomogeneousComponents(RegularModule(G, GF(p))[2]);; time;
    73



What I have *not* done yet is to try systematically with other examples if they got faster or slower (!). I think it would make sense for us to setup some benchmark set -- perhaps similar to what I did in #5958, or perhaps just a bunch of modules we then use for testing.


There is also more work to be done: the original example by @fieker that lead me to look into this was the regular module of `SmallGroup(240, 3)` (not 24!) which is much larger, and which still performs badly. For this much more work is needed; one of the things missing there is applying the same "evaluate at a factor of the minpoly" trick, but there computing the minpoly gets to expensive. So we should probably add a new helper function which takes a matrix and computes a factor of the minpoly by spinning (and then optionally tries to factor it -- in my tests, factoring was basically never the bottleneck).

Even with such an improvement we run in more problems. I am going to try to see how far we can push this code, but in the end we maybe have to look into completely reimplementing this in order to catch up with Magma.