### PR TITLE
fix problems with `IsBlockMatrixRep`

### DIFF
--- a/lib/matblock.gi
+++ b/lib/matblock.gi
@@ -42,6 +42,8 @@
 ##       outside the blocks in `blocks'.
 ##  \enditems
 ##
+##  Currently matrices in `IsBlockMatrixRep' are *not* in `IsMatrixObj'.
+##
 DeclareRepresentation( "IsBlockMatrixRep",
     IsComponentObjectRep,
     [ "blocks", "zero", "nrb", "ncb", "rpb", "cpb" ] );
@@ -157,6 +159,16 @@ InstallMethod( NrCols,
     "for an ordinary block matrix",
     [ IsOrdinaryMatrix and IsBlockMatrixRep ],
     blockmat -> blockmat!.ncb * blockmat!.cpb );
+
+
+#############################################################################
+##
+#M  BaseDomain( <blockmat> )  . . . . . . . . . . . . . .  for a block matrix
+##
+InstallMethod( BaseDomain,
+    "for an ordinary block matrix",
+    [ IsOrdinaryMatrix and IsBlockMatrixRep ],
+    blockmat -> BaseDomain( Concatenation( List( blockmat!.blocks, x -> x[3] ) ) ) );
 
 
 #############################################################################
@@ -639,6 +651,18 @@ InstallOtherMethod( OneOp,
       TryNextMethod();
     fi;
     end );
+
+
+#############################################################################
+##
+#M  ZeroOp( <bm> ) . . . . . . . . . . . . . . . . . . . . for a block matrix
+##
+InstallOtherMethod( ZeroOp,
+    "for an ordinary block matrix",
+    [ IsOrdinaryMatrix and IsBlockMatrixRep ], 3,
+    # being a block matrix is better than being a small list
+    bm -> BlockMatrix( [],
+                       bm!.nrb, bm!.ncb, bm!.rpb, bm!.cpb, bm!.zero ) );
 
 
 #############################################################################

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -250,6 +250,14 @@ InstallOtherMethod( Vector,
     { v, example } -> v );
 
 
+# The following method is used when one deals with matrices that are not in
+# 'IsPlistep' but whose 'CompatibleVectorFilter' is 'IsPlistRep'.
+# Currently 'IsBlockMatrixRep' is an example for that.
+InstallTagBasedMethod( NewVector,
+  IsPlistRep,
+  { filter, basedomain, list } -> Unpack( list ) );
+
+
 #############################################################################
 ##
 #M  ZeroVector( <filt>, <R>, <len> )

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -1,4 +1,4 @@
-#@local dim,m1,m2,m3,mm,o1,o2,p1,p2,p3,p4,tmp,z
+#@local dim,m1,m2,m3,mm,o1,o2,p1,p2,p3,p4,tmp,z,R,G,H,reps,ind,img
 gap> START_TEST("matblock.tst");
 gap> m1 := BlockMatrix( [ [ 1, 1, [[1,1],[0,1]] ],
 >                         [ 1, 3, [[1,0],[0,1]] ],
@@ -60,6 +60,8 @@ gap> p4:= TransposedMat( m1 ) * m2;
 gap> p3 = p4;
 false
 gap> z = AsBlockMatrix( z, 2, 2 );
+true
+gap> Zero( m3 ) = z;
 true
 gap> MatrixByBlockMatrix( m1 );
 [ [ 1, 1, 0, 0, 1, 0, 0, 0 ], [ 0, 1, 0, 0, 0, 1, 0, 0 ], 
@@ -123,6 +125,29 @@ gap> m1[1,2] := 5;
 Error, Matrix Assignment: <mat> must be a mutable matrix (not a component obje\
 ct)
 #@fi
+
+# Matrix operations for block matrices
+gap> R:= BaseDomain( MatrixByBlockMatrix( m2 ) );;
+gap> R = BaseDomain( m2 );
+true
+gap> TraceMatrix( m2 ) = TraceMatrix( MatrixByBlockMatrix( m2 ) );
+true
+gap> Determinant( m2 ) = Determinant( MatrixByBlockMatrix( m2 ) );
+true
+gap> MinimalPolynomial( R, m2 ) = MinimalPolynomial( R, MatrixByBlockMatrix( m2 ) );
+true
+
+# Groups that consist of block matrices
+gap> G:= SmallGroup( 24, 12 );;
+gap> H:= SylowSubgroup( G, 2 );;
+gap> reps:= IrreducibleRepresentations( H );;
+gap> ind:= InducedRepresentation( reps[5], G );;
+gap> img:= Image( ind );
+<matrix group with 4 generators>
+gap> ForAll( GeneratorsOfGroup( img ), IsBlockMatrixRep );
+true
+gap> Size( img );
+24
 
 #
 gap> STOP_TEST("matblock.tst");


### PR DESCRIPTION
- add `BaseDomain` method for `IsBlockMatrixRep`,
- add `ZeroOp` method for `IsBlockMatrixRep`,
- add `NewVector( IsPlistRep, R, list )` method.

Is the new `NewVector` method o.k.?
(Why did we not miss it up to now? It is needed for non-`IsPlistRep` matrices whose `CompatibleVectorFilter` is `IsPlistRep`.)

resolves #5949