### PR TITLE
Fix a bug in the code computing automorphisms of modules, which e.g. affects computing automorphism groups and could lead to outer automorphisms being missed

### DIFF
--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1038,7 +1038,7 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
   if n = 1 then
     # A 1-dimensional module is always indecomposable
     Info(InfoMtxHom,3,"1dimensional");
-    SMTX.SetEndAlgResidue(M, [[[ PrimitiveElement(F) ]], Size(F) - 1]);
+    SMTX.SetEndAlgResidue(M, [[[ PrimitiveRoot(F) ]], Size(F) - 1]);
     SMTX.SetBasisEndomorphismsRadical(M, []);
     return fail;
   fi;
@@ -1047,7 +1047,7 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
   if Length(basis) = 1 then
     # if endomorphism algebra has dimension 1 then indecomposable
     #SMTX.SetEndAlgResidueFlag(M, F.root * GModOps.EndAlgBasisFlag(M)[1], F.size - 1);
-    SMTX.SetEndAlgResidue(M, [PrimitiveElement(F)*One(basis[1]), Size(F) - 1]);
+    SMTX.SetEndAlgResidue(M, [PrimitiveRoot(F)*One(basis[1]), Size(F) - 1]);
     Info(InfoMtxHom,3,"basislength 1");
     SMTX.SetBasisEndomorphismsRadical(M, []);
     return fail;
@@ -1532,7 +1532,7 @@ BindGlobal("SMTX_ModuleAutomorphisms",function(m)
     q:=SMTX.EndAlgResidue(h[i].component[2]);
     w:=q[1];
     q:=q[2]+1;
-    Fqr:=PrimitiveElement(GF(q));
+    Fqr:=Z(q);
     gl:=GL(r,q);
     autorder:=autorder*Size(gl);
     Info(InfoMtxHom,3,"increase by gl",Size(gl)," ",autorder);
@@ -1540,10 +1540,10 @@ BindGlobal("SMTX_ModuleAutomorphisms",function(m)
       a:=IdentityMat(m.dimension,f);
       for j in [1..r] do
         for k in [1..r] do
-          if IsZero(g[j][k]) then
+          if IsZero(g[j,k]) then
             subm:=w*0;
           else
-            subm:=w^LogFFE(g[j][k],Fqr);
+            subm:=w^LogFFE(g[j,k],Fqr);
           fi;
           a{[(j-1)*dim+1..j*dim]}{[(k-1)*dim+1..k*dim]}:=subm;
         od;

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -1047,7 +1047,7 @@ local proveIndecomposability, addnilpotent, n, F, zero, basis, enddim,
   if Length(basis) = 1 then
     # if endomorphism algebra has dimension 1 then indecomposable
     #SMTX.SetEndAlgResidueFlag(M, F.root * GModOps.EndAlgBasisFlag(M)[1], F.size - 1);
-    SMTX.SetEndAlgResidue(M, [PrimitiveElement(F)*basis[1], Size(F) - 1]);
+    SMTX.SetEndAlgResidue(M, [PrimitiveElement(F)*One(basis[1]), Size(F) - 1]);
     Info(InfoMtxHom,3,"basislength 1");
     SMTX.SetBasisEndomorphismsRadical(M, []);
     return fail;

--- a/tst/testbugfix/2025-03-28-ModuleAutomorphisms.tst
+++ b/tst/testbugfix/2025-03-28-ModuleAutomorphisms.tst
@@ -1,0 +1,39 @@
+# bug reported by David Roe on the GAP Forum: the command
+#   AutomorphismGroup(TransitiveGroup(45, 3878));
+# sometimes gives a result that is too small. Traced back to
+# a bug in MTX.ModuleAutomorphisms
+gap> mats:=Z(3)^0*[
+> [ [ 0, 0, 0, 2, 0, 0, 0, 1, 0, 1, 0 ],
+>   [ 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0 ],
+>   [ 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0 ],
+>   [ 0, 0, 0, 1, 0, 2, 0, 1, 0, 0, 0 ],
+>   [ 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0 ],
+>   [ 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0 ],
+>   [ 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0 ],
+>   [ 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 1 ],
+>   [ 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 0 ],
+>   [ 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0 ],
+>   [ 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0 ] ],
+> [ [ 0, 0, 0, 0, 2, 0, 1, 0, 0, 1, 0 ],
+>   [ 0, 0, 1, 0, 2, 0, 1, 2, 0, 2, 0 ],
+>   [ 0, 0, 0, 1, 0, 0, 1, 1, 0, 2, 0 ],
+>   [ 0, 0, 0, 0, 2, 0, 1, 0, 2, 2, 0 ],
+>   [ 0, 0, 0, 0, 2, 0, 2, 2, 0, 2, 0 ],
+>   [ 0, 0, 0, 0, 0, 2, 1, 1, 0, 1, 0 ],
+>   [ 0, 0, 0, 0, 1, 0, 1, 1, 0, 2, 1 ],
+>   [ 1, 0, 0, 0, 1, 0, 2, 1, 0, 2, 0 ],
+>   [ 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0 ],
+>   [ 0, 2, 0, 0, 1, 0, 1, 2, 0, 0, 0 ],
+>   [ 0, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0 ] ]
+> ];;
+gap> m:=GModuleByMats(mats,GF(3));;
+gap> MTX.ModuleAutomorphisms(m);
+<matrix group of size 2 with 2 generators>
+gap> MTX.ModuleAutomorphisms(m);
+<matrix group of size 2 with 2 generators>
+gap> MTX.ModuleAutomorphisms(m);
+<matrix group of size 2 with 2 generators>
+gap> MTX.ModuleAutomorphisms(m);
+<matrix group of size 2 with 2 generators>
+gap> MTX.ModuleAutomorphisms(m);
+<matrix group of size 2 with 2 generators>


### PR DESCRIPTION
In the case of a 1-dimensional endomorphism algebra, the code assumed that the basis of the endomorphisms would consists of an identity matrix. But that is not always the case (we make no attempt to "normalize" the basis elements we compute).

This fixes a bug reported by David Roe on the GAP Forum, where

    AutomorphismGroup(TransitiveGroup(45, 3878));

would sometimes return an incorrect (too small) result.