### PR TITLE
add `IsDicyclicGroup` and `DicyclicGenerators`

### DIFF
--- a/lib/grpnames.gd
+++ b/lib/grpnames.gd
@@ -455,36 +455,53 @@ InstallTrueMethod( IsDihedralGroup, HasDihedralGenerators );
 
 #############################################################################
 ##
-#P  IsQuaternionGroup( <G> )
-#A  QuaternionGenerators( <G> )
+#P  IsDicyclicGroup( <G> )
+#P  IsGeneralizedQuaternionGroup( <G> )
+#A  DicyclicGenerators( <G> )
+#A  GeneralizedQuaternionGenerators( <G> )
 ##
 ##  <#GAPDoc Label="IsQuaternionGroup">
 ##  <ManSection>
+##  <Prop Name="IsDicyclicGroup" Arg="G"/>
+##  <Attr Name="DicyclicGenerators" Arg="G"/>
 ##  <Prop Name="IsGeneralisedQuaternionGroup" Arg="G"/>
-##  <Prop Name="IsQuaternionGroup" Arg="G"/>
 ##  <Attr Name="GeneralisedQuaternionGenerators" Arg="G"/>
+##  <Prop Name="IsQuaternionGroup" Arg="G"/>
 ##  <Attr Name="QuaternionGenerators" Arg="G"/>
 ##
 ##  <Description>
-##    <Ref Prop="IsGeneralisedQuaternionGroup"/> indicates whether the group
-##    <A>G</A> is a generalized quaternion group of size <M>N = 2^(k+1)</M>,
-##    <M>k >= 2</M>.
-##    If it is, methods may set the attribute <Ref Attr="GeneralisedQuaternionGenerators" />
-##    to [<A>t</A>,<A>s</A>], where <A>t</A> and <A>s</A> are two elements such that <A>G</A> =
-##    <M>\langle t, s | s^{(2^k)} = 1, t^2 = s^{(2^k-1)}, s^t = s^{-1} \rangle</M>.
-##    <Ref Prop="IsQuaternionGroup"/> and <Ref Attr="QuaternionGenerators" /> are
-##    provided for backwards compatibility with existing code.
+##  <Ref Prop="IsDicyclicGroup"/> indicates whether the group
+##  <A>G</A> is a dicyclic group of order <M>N = 4n</M>.
+##  If it is, methods may set the attribute <Ref Attr="DicyclicGenerators"/>
+##  to <M>[ t, s ]</M>, where <M>t</M> and <M>s</M> are two elements
+##  such that <A>G</A> =
+##  <M>\langle t, s | s^{2n} = 1, t^2 = s^n, s^t = s^{-1} \rangle</M> holds.
+##  <P/>
+##  <Ref Prop="IsGeneralisedQuaternionGroup"/> indicates whether <A>G</A> is
+##  a generalized quaternion group, i. e.,
+##  a dicyclic group of <M>2</M>-power order.
+##  If it is, methods may set the attribute
+##  <Ref Attr="GeneralisedQuaternionGenerators"/> to the value of
+##  <Ref Attr="DicyclicGenerators"/> for <A>G</A>.
+##  <P/>
+##  <Ref Prop="IsQuaternionGroup"/> and <Ref Attr="QuaternionGenerators"/>
+##  are provided for backwards compatibility with existing code.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+DeclareProperty( "IsDicyclicGroup", IsGroup );
 DeclareProperty( "IsGeneralisedQuaternionGroup", IsGroup );
+DeclareAttribute( "DicyclicGenerators", IsGroup );
 DeclareAttribute( "GeneralisedQuaternionGenerators", IsGroup );
+
 # Backwards compatibility
 DeclareSynonymAttr( "IsQuaternionGroup", IsGeneralisedQuaternionGroup );
 DeclareSynonymAttr( "QuaternionGenerators", GeneralisedQuaternionGenerators );
 
-InstallTrueMethod( IsGroup, IsQuaternionGroup );
+InstallTrueMethod( IsGroup, IsDicyclicGroup );
+InstallTrueMethod( IsDicyclicGroup, HasDicyclicGenerators );
+InstallTrueMethod( IsGroup, IsGeneralisedQuaternionGroup );
 InstallTrueMethod( IsGeneralisedQuaternionGroup, HasGeneralisedQuaternionGenerators );
 
 

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -1,3 +1,5 @@
+#@local A,inputs,ints,filt,G,Q,F,gens,n,i
+
 #
 # tests for grp/basic*.*
 #
@@ -265,7 +267,6 @@ gap> IsDihedralGroup(Q);
 true
 gap> HasDihedralGenerators(Q);
 true
-gap> Unbind(F);; Unbind(Q);;
 
 #
 # dicyclic groups
@@ -319,6 +320,55 @@ gap> DicyclicGroup(IsMatrixGroup, fail, 256);
 Error, usage: <field> must be a field
 gap> DicyclicGroup(IsMatrixGroup, GF(2), 256, "extra");
 Error, usage: DicyclicGroup( [<filter>, [<field>, ] ] <size> )
+
+#
+gap> for n in [ 8, 16, 32, 64 ] do
+>      G:= DicyclicGroup( n );
+>      if not IsDicyclicGroup( G ) then
+>        Error( "not a dicyclic group?" );
+>      elif not IsGeneralisedQuaternionGroup( G ) then
+>        Error( "not a gen. quat. group?" );
+>      elif GeneralisedQuaternionGenerators( G ) <> DicyclicGenerators( G ) then
+>        Error( "strange canon. generators?" );
+>      fi;
+>    od;
+gap> for n in [ 4, 12, 20, 24 ] do
+>      G:= DicyclicGroup( n );
+>      if not IsDicyclicGroup( G ) then
+>        Error( "not a dicyclic group?" );
+>      elif IsGeneralisedQuaternionGroup( G ) then
+>        Error( "gen. quat. group?" );
+>      fi;
+>    od;
+gap> Number( AllSmallGroups( [  1 .. 32 ], IsDicyclicGroup ) );
+8
+gap> Number( AllSmallGroups( [  1 .. 32 ], IsGeneralisedQuaternionGroup ) );
+3
+
+#
+gap> Q:= DicyclicGroup( 20 );;
+gap> gens:= DicyclicGenerators( Q );;
+gap> Group( gens ) = Q;
+true
+gap> Q:= Group( GeneratorsOfGroup( DicyclicGroup( IsPermGroup, 20 ) ) );;
+gap> HasIsDicyclicGroup( Q );
+false
+gap> HasDicyclicGenerators( Q );
+false
+gap> gens:= DicyclicGenerators( Q );;
+gap> Group( gens ) = Q;
+true
+gap> IsDicyclicGroup( Q );
+true
+gap> Q:= Group( GeneratorsOfGroup( DicyclicGroup( IsPermGroup, 20 ) ) );;
+gap> HasIsDicyclicGroup( Q );
+false
+gap> HasDicyclicGenerators( Q );
+false
+gap> IsDicyclicGroup( Q );
+true
+gap> HasDicyclicGenerators( Q );
+true
 
 #
 # (generalised) quaternion groups
@@ -382,7 +432,6 @@ gap> IsGeneralisedQuaternionGroup(Q);
 true
 gap> HasGeneralisedQuaternionGenerators(Q);
 true
-gap> Unbind(F);; Unbind(Q);;
 
 #
 # elementary abelian groups


### PR DESCRIPTION
The code of `DoComputeGeneralisedQuaternionGenerators` was already almost good enough for the more general `DoComputeDicyclicGenerators`.
(Irony: For the special case, the code could have been simpler.)

This change was motivated by oscar-system/Oscar.jl/pull/4661.