### PR TITLE
introduce `MayBeHandledByNiceMonomorphism`, in order to detect early whether a group shall be handled by nice monomorphisms

### DIFF
--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -56,47 +56,22 @@ end);
 ##
 #M  GeneratorsOfMagmaWithInverses( <group> )  .  get generators from nice obj
 ##
-InstallMethod( GeneratorsOfMagmaWithInverses,
-    true,
-    [ IsGroup and IsHandledByNiceMonomorphism ],
-    0,
-
-function( grp )
-    local   nice;
-    nice := NiceMonomorphism(grp);
-    return List( GeneratorsOfGroup(NiceObject(grp)),
-                 x -> PreImagesRepresentative(nice,x) );
-end );
+AttributeMethodByNiceMonomorphismList( GeneratorsOfMagmaWithInverses,
+  [ IsGroup ] );
 
 
 #############################################################################
 ##
 #M  SmallGeneratingSet( <group> )  .  get generators from nice obj
 ##
-InstallMethod( SmallGeneratingSet, true,
-    [ IsGroup and IsHandledByNiceMonomorphism ], 0,
-
-function( grp )
-    local   nice;
-    nice := NiceMonomorphism(grp);
-    return List( SmallGeneratingSet(NiceObject(grp)),
-                 x -> PreImagesRepresentative(nice,x) );
-end );
+AttributeMethodByNiceMonomorphismList( SmallGeneratingSet, [ IsGroup ] );
 
 
 #############################################################################
 ##
 #M  MinimalGeneratingSet( <group> )  .  get generators from nice obj
 ##
-InstallMethod( MinimalGeneratingSet, true,
-    [ IsGroup and IsHandledByNiceMonomorphism ], 0,
-
-function( grp )
-    local   nice;
-    nice := NiceMonomorphism(grp);
-    return List( MinimalGeneratingSet(NiceObject(grp)),
-                 x -> PreImagesRepresentative(nice,x) );
-end );
+AttributeMethodByNiceMonomorphismList( MinimalGeneratingSet, [ IsGroup ] );
 
 
 #############################################################################
@@ -223,13 +198,8 @@ PropertyMethodByNiceMonomorphismCollColl( \=,
 ##
 #M  \in( <elm>, <G> ) . . . . . . . . . . . . . . . . .  test if <elm> in <G>
 ##
-InstallMethod( \in,
-    "by nice monomorphism",
-    IsElmsColls,
-    [ IsMultiplicativeElementWithInverse,
-      IsGroup and IsHandledByNiceMonomorphism ],
-    0,
-
+AttributeMethodByNiceMonomorphismElmColl( \in,
+    [ IsMultiplicativeElementWithInverse, IsGroup ],
 function( elm, G )
     local   nice,  img;
 
@@ -301,13 +271,10 @@ GroupMethodByNiceMonomorphismCollColl( ClosureGroup,
 ##
 #M  ClosureGroup( <G>, <elm> )  . . . . . . . . closure of group with element
 ##
-# don't use `GroupMethodByNiceMonomorphismCollElm' to treat case of element
-# contained in.
-#GroupMethodByNiceMonomorphismCollElm( ClosureGroup,
-#    [ IsGroup, IsMultiplicativeElementWithInverse ] );
-InstallMethod(ClosureGroup,"by niceo",
-  IsCollsElms,[IsGroup and IsHandledByNiceMonomorphism,
-               IsMultiplicativeElementWithInverse],0,
+##  Don't use the generic code of `GroupMethodByNiceMonomorphismCollElm'
+##  to treat case of element membership.
+GroupMethodByNiceMonomorphismCollElm( ClosureGroup,
+  [ IsGroup, IsMultiplicativeElementWithInverse ],
 function( obj1, obj2 )
     local   nice,no,  img,  img1;
     nice := NiceMonomorphism(obj1);
@@ -360,10 +327,10 @@ GroupSeriesMethodByNiceMonomorphism( CompositionSeries,
 
 #############################################################################
 ##
-#M  ConjugacyClasses
+#M  ConjugacyClasses( <G> )  . . . . . . . . . . conjugacy classes of a group
 ##
-InstallMethod(ConjugacyClasses,"via niceomorphism",true,
-  [IsGroup and IsHandledByNiceMonomorphism],0,
+AttributeMethodByNiceMonomorphism( ConjugacyClasses,
+    [ IsGroup ],
 function(g)
 local mon,cl,clg,c,i;
   cl:=ConjugacyClassesForSmallGroup(g);
@@ -462,8 +429,8 @@ SubgroupMethodByNiceMonomorphism( FrattiniSubgroup,
 ##
 #M  HallSubgroup
 ##
-InstallMethod(HallSubgroupOp,"via niceomorphism",true,
-  [IsGroup and IsHandledByNiceMonomorphism,IsList],0,
+GroupMethodByNiceMonomorphismCollOther( HallSubgroup,
+    [ IsGroup, IsList ],
 function(g,l)
 local mon,h;
    mon:=NiceMonomorphism(g);
@@ -698,9 +665,8 @@ GroupSeriesMethodByNiceMonomorphism( LowerCentralSeriesOfGroup,
 ##
 #M  MaximalSubgroupClassReps( <G> )
 ##
-InstallOtherMethod( CalcMaximalSubgroupClassReps,
-  "handled by nice monomorphism, transfer tainter",
-  [IsGroup and IsHandledByNiceMonomorphism],
+AttributeMethodByNiceMonomorphism( CalcMaximalSubgroupClassReps,
+  [ IsGroup ],
 function( G )
 local   nice,  img,  sub,i;
   nice := NiceMonomorphism(G);
@@ -823,8 +789,8 @@ InstallMethodWithRandomSource( Random,
 ##
 #M  RationalClasses
 ##
-InstallMethod(RationalClasses,"via niceomorphism",true,
-  [IsGroup and IsHandledByNiceMonomorphism],0,
+AttributeMethodByNiceMonomorphism( RationalClasses,
+    [ IsGroup ],
 function(g)
 local mon,cl,clg,c,i;
    mon:=NiceMonomorphism(g);
@@ -848,8 +814,8 @@ end);
 ##
 #M  RightCosets
 ##
-InstallMethod(RightCosetsNC,"via niceomorphism",true,
-  [IsGroup and IsHandledByNiceMonomorphism,IsGroup],0,
+GroupMethodByNiceMonomorphismCollOther( RightCosetsNC,
+    [ IsGroup, IsGroup ],
 function(g,u)
 local mon,rt;
    mon:=NiceMonomorphism(g);
@@ -1080,9 +1046,9 @@ DeclareRepresentation( "IsEnumeratorByNiceomorphismRep",
 ##
 #M  Enumerator( <G> ) . . . . . . . . . . . . . . . . .  enumerator by niceo
 ##
-InstallMethod( Enumerator,"use nice monomorphism",true,
-        [ IsGroup and IsHandledByNiceMonomorphism and IsFinite ], 0,
-function( G )
+AttributeMethodByNiceMonomorphism( Enumerator,
+  [ IsGroup and IsAttributeStoringRep ],
+  function( G )
     return Objectify(
         NewType( FamilyObj(G), IsList and IsEnumeratorByNiceomorphismRep ),
         rec( group:=G,

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -429,7 +429,7 @@ SubgroupMethodByNiceMonomorphism( FrattiniSubgroup,
 ##
 #M  HallSubgroup
 ##
-GroupMethodByNiceMonomorphismCollOther( HallSubgroup,
+GroupMethodByNiceMonomorphismCollOther( HallSubgroupOp,
     [ IsGroup, IsList ],
 function(g,l)
 local mon,h;

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -405,12 +405,24 @@ InstallMethod( NiceMonomorphism,
 ##  we can decide finiteness.
 ##
 ##  (Note that nice monomorphisms may be used also for infinite groups,
-##  for example for non-rational matrix groups over the cyclotomics.)
+##  for example for non-rational matrix groups over the cyclotomics,
+##  where the image of the monomorphism is a rational matrix group.)
 ##
 InstallMethod( IsHandledByNiceMonomorphism,
     "for a cyclotomic matrix group",
     [ IsCyclotomicMatrixGroup ],
     IsFinite );
+
+
+#############################################################################
+##
+#F  MayBeHandledByNiceMonomorphism( <G> ) . . . for a cyclotomic matrix group
+##
+##  Since we can decide finiteness for a cyclotomic matrix group,
+##  it makes sense to set 'MayBeHandledByNiceMonomorphism' for it,
+##  see the documentation of this filter.
+##
+InstallTrueMethod( MayBeHandledByNiceMonomorphism, IsCyclotomicMatrixGroup );
 
 
 #############################################################################

--- a/lib/morpheus.gd
+++ b/lib/morpheus.gd
@@ -533,7 +533,7 @@ DeclareGlobalFunction("IsomorphismSimpleGroups");
 ##  gap> h:=Group((1,2,3),(1,2));
 ##  Group([ (1,2,3), (1,2) ])
 ##  gap> quo:=GQuotients(g,h);
-##  [ [ (1,2,3,4), (1,4,3) ] -> [ (2,3), (1,2,3) ] ]
+##  [ [ (1,2,3,4), (2,4,3) ] -> [ (2,3), (1,2,3) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/pcgsnice.gi
+++ b/lib/pcgsnice.gi
@@ -13,8 +13,8 @@
 ##
 #M  Pcgs( <G> ) . . . . . . . . . . . . . . . . . . . . via nice monomorphism
 ##
-InstallMethod( Pcgs, "via niceomorphism", true,
-  [ IsGroup and IsHandledByNiceMonomorphism ], 0,
+AttributeMethodByNiceMonomorphism( Pcgs,
+  [ IsGroup ],
     function( G )
     local   nice,  npcgs,  pcgs;
 
@@ -43,15 +43,8 @@ end );
 AttributeMethodByNiceMonomorphismCollElm( DepthOfPcElement,
         [ IsPcgs, IsMultiplicativeElementWithInverse ] );
 
-InstallOtherMethod( DepthOfPcElement, true,
-        [ IsPcgs and IsHandledByNiceMonomorphism,
-          IsMultiplicativeElementWithInverse,
-          IsPosInt ], 0,
-    function( pcgs, g, depth )
-    return DepthOfPcElement( NiceObject( pcgs ),
-                   ImagesRepresentative( NiceMonomorphism( pcgs ), g ),
-                   depth );
-end );
+AttributeMethodByNiceMonomorphismCollElmOther( DepthOfPcElement,
+        [ IsPcgs, IsMultiplicativeElementWithInverse, IsPosInt ] );
 
 #############################################################################
 ##
@@ -62,39 +55,23 @@ AttributeMethodByNiceMonomorphismCollElm( LeadingExponentOfPcElement,
 
 #############################################################################
 ##
-#M  ExponentsOfPcElement( <pcgs>, <g> [ , <poss> ] )  . via nice monomorphism
+#M  ExponentsOfPcElement( <pcgs>, <g>[, <poss>] ) . . . via nice monomorphism
 ##
 AttributeMethodByNiceMonomorphismCollElm( ExponentsOfPcElement,
         [ IsPcgs, IsMultiplicativeElementWithInverse ] );
 
-InstallOtherMethod( ExponentsOfPcElement, true,
-        [ IsPcgs and IsHandledByNiceMonomorphism,
-          IsMultiplicativeElementWithInverse,
-          IsList and IsCyclotomicCollection ], 0,
-    function( pcgs, g, poss )
-    return ExponentsOfPcElement( NiceObject( pcgs ),
-                   ImagesRepresentative( NiceMonomorphism( pcgs ), g ),
-                   poss );
-end );
+AttributeMethodByNiceMonomorphismCollElmOther( ExponentsOfPcElement,
+        [ IsPcgs, IsMultiplicativeElementWithInverse,
+          IsList and IsCyclotomicCollection ] );
 
-InstallOtherMethod( ExponentsOfPcElement, "perm group with 0 positions", true,
-        [ IsPcgs and IsHandledByNiceMonomorphism,
-          IsMultiplicativeElementWithInverse,
-          IsList and IsEmpty ], 0,
-    function( pcgs, g, poss )
-    return [  ];
-end );
+AttributeMethodByNiceMonomorphismCollElmOther( ExponentsOfPcElement,
+        [ IsPcgs, IsMultiplicativeElementWithInverse,
+          IsList and IsEmpty ],
+        { pcgs, g, poss } -> [] );
 
 #############################################################################
 ##
 #M  ExponentOfPcElement( <pcgs>, <g>, <pos> ) . . . . . via nice monomorphism
 ##
-InstallMethod( ExponentOfPcElement, "via nicoemorphism", true,
-        [ IsPcgs and IsHandledByNiceMonomorphism,
-          IsMultiplicativeElementWithInverse,
-          IsPosInt ], 0,
-    function( pcgs, g, pos )
-    return ExponentOfPcElement( NiceObject( pcgs ),
-                   ImagesRepresentative( NiceMonomorphism( pcgs ), g ),
-                   pos );
-end );
+AttributeMethodByNiceMonomorphismCollElmOther( ExponentOfPcElement,
+        [ IsPcgs, IsMultiplicativeElementWithInverse, IsPosInt ] );

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -436,6 +436,137 @@ gap> SetNiceMonomorphism( g, hom );
 gap> HasNiceMonomorphism( g );
 true
 
+# MayBeHandledByNiceMonomorphism and IsHandledByNiceMonomorphism
+# - check a method installed by AttributeMethodByNiceMonomorphism
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> HasIsHandledByNiceMonomorphism( g ); MayBeHandledByNiceMonomorphism( g );
+false
+true
+gap> AbelianInvariants( g );
+[ 2 ]
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> SmallGeneratingSet( g );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by AttributeMethodByNiceMonomorphismElmColl
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> A * B in g;
+true
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by AttributeMethodByNiceMonomorphismCollColl
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= GroupWithGenerators( [ A, B ] );;
+gap> SetParent( g2, g );
+gap> Index( g, g2 );
+4
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by AttributeMethodByNiceMonomorphismCollElm
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> res:= Pcgs( g );;
+gap> HasIsHandledByNiceMonomorphism( res );
+true
+gap> DepthOfPcElement( res, One( g ) );
+7
+gap> DepthOfPcElement( res, One( g ), 5 );
+7
+
+# - GroupMethodByNiceMonomorphism seems to be not used
+# - GroupMethodByNiceMonomorphismCollOther seems to be not used
+# - check a method installed by GroupMethodByNiceMonomorphismCollColl
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= CommutatorSubgroup( g, g );;
+gap> Size( g2 );
+48
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by GroupMethodByNiceMonomorphismCollElm
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= SubgroupNC( g, [ A, B ] );;  # need a parent
+gap> HasIsHandledByNiceMonomorphism( g2 ); MayBeHandledByNiceMonomorphism( g2 );
+false
+true
+gap> g2:= ConjugateGroup( g2, C );;
+gap> HasIsHandledByNiceMonomorphism( g2 ); IsHandledByNiceMonomorphism( g2 );
+true
+true
+
+# - check a method installed by SubgroupMethodByNiceMonomorphism
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> DerivedSubgroup( g );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by SubgroupsMethodByNiceMonomorphism
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= NormalSubgroups( g );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+gap> ForAll( g2, HasNiceMonomorphism );
+true
+
+# - check a method installed by SubgroupMethodByNiceMonomorphismCollOther
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= SylowSubgroup( g, 2 );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by SubgroupMethodByNiceMonomorphismCollColl
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= Centralizer( g, Group( [ A ] ) );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by SubgroupMethodByNiceMonomorphismCollElm
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= Centralizer( g, A );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by GroupSeriesMethodByNiceMonomorphism
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= DerivedSeriesOfGroup( g );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by GroupSeriesMethodByNiceMonomorphismCollOther
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= PCentralSeriesOp( g, 2 );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - check a method installed by GroupSeriesMethodByNiceMonomorphismCollColl
+gap> g:= GroupWithGenerators( [ A, B, C ] );;
+gap> g2:= SubgroupNC( g, [ A ] );;
+gap> HasIsHandledByNiceMonomorphism( g ); MayBeHandledByNiceMonomorphism( g );
+false
+true
+gap> g2:= SubnormalSeries( g, g2 );;
+gap> HasIsHandledByNiceMonomorphism( g ); IsHandledByNiceMonomorphism( g );
+true
+true
+
+# - GroupSeriesMethodByNiceMonomorphismCollElm seems to be not used
+
 # printing of identity mapping string in direct product element (PR #3753) 
 gap> String(IdentityMapping(SymmetricGroup(3)));
 "IdentityMapping( SymmetricGroup( [ 1 .. 3 ] ) )"

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -142,8 +142,7 @@ gap> G:= SmallGroup( 24, 12 );;
 gap> H:= SylowSubgroup( G, 2 );;
 gap> reps:= IrreducibleRepresentations( H );;
 gap> ind:= InducedRepresentation( reps[5], G );;
-gap> img:= Image( ind );
-<matrix group with 4 generators>
+gap> img:= Image( ind );;
 gap> ForAll( GeneratorsOfGroup( img ), IsBlockMatrixRep );
 true
 gap> Size( img );


### PR DESCRIPTION
The idea is as follows (citing from `lib/grpnice.gd`).

The filter `MayBeHandledByNiceMonomorphism` is intended to deal with the following situation.
We have a group `G` that can be handled via a nice monomorphism if it satisfies certain conditions, but we do not want to check these conditions until we can take advantage of the nice monomorphism, i.e., until the call of an operation for which a method is installed that has `IsHandledByNiceMonomorphism` as a requirement for one of its arguments.

The `MayBeHandledByNiceMonomorphism` mechanism can be used for example if `G` is a matrix group for which finiteness can be decided but is not a priori known, such as groups of matrices with entries in some cyclotomic field.
These groups can be handled by a nice monomorphism if they are finite, hence an `IsHandledByNiceMonomorphism` method can be installed that checks finiteness.
The mechanism is *not* intended for situations where `IsHandledByNiceMonomorphism` cannot be decided. For example, it is not suitable for arbitrary finitely presented groups.

The motivation for these changes comes from the Oscar system: We have a method (independent of GAP) for computing a nice monomorphism for matrix groups over number fields, and we want to trigger this computation as soon as an operation is called that takes advantage of this monomorphism.

Implementation details:
- Use the special code for method installations in `lib/grpnice.gd` to install also methods that require `MayBeHandledByNiceMonomorphism`; these methods call `IsHandledByNiceMonomorphism`, and if the result is `true` then the method with requirement `IsHandledByNiceMonomorphism` gets called,
- enable the mechanism for groups in `IsCyclotomicMatrixGroup`.

Note that computations may get *slower* if nice monomorphisms are used.
On the other hand, some methods that use nice monomorphisms may be cheaper but create objects that store less information than objects created by other methods.
Thus it is not obvious whether using nice monomorphisms improves the performance.

The changes proposed here will have the effect that nice monomorphisms will get computed earlier than before.

