### PR TITLE
Approximate new logo (A1) in launch banner

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -434,7 +434,7 @@ function( prefix, values, suffix )
 end);
 
 BindGlobal( "ShowKernelInformation", function()
-  local sysdate, btop, vert, bbot, config, str, gap;
+  local sysdate, btop, vert, bbot, title, config, str, gap;
 
   if GAPInfo.Date <> "today" then
     sysdate := " of ";
@@ -448,8 +448,10 @@ BindGlobal( "ShowKernelInformation", function()
 
   if GAPInfo.TermEncoding = "UTF-8" then
     btop := "┌───────┐\c"; vert := "│"; bbot := "└───────┘\c";
+    title := " \033[33m⋊\033[0m \033[36mGΛP\033[0m ";
   else
     btop := "*********"; vert := "*"; bbot := btop;
+    title := "  GAP  ";
   fi;
   if IsHPCGAP then
     gap := "HPC-GAP";
@@ -458,7 +460,7 @@ BindGlobal( "ShowKernelInformation", function()
   fi;
   Print( " ",btop,"   ",gap," ", GAPInfo.BuildVersion,
          sysdate, "\n",
-         " ",vert,"  GAP  ",vert,"   https://www.gap-system.org\n",
+         " ",vert,title,vert,"   https://www.gap-system.org\n",
          " ",bbot,"   Architecture: ", GAPInfo.Architecture, "\n" );
   if IsHPCGAP then
     Print( "             Maximum concurrent threads: ",


### PR DESCRIPTION
This week we will adopt [a new GAP logo](https://www.gap-system.org/logo/finalists/), and it occurred to me that if proposal A1 is adopted:

<image src="https://www.gap-system.org/logo/finalists/logos/A1/light/logo-notext.png" width=200 />

then it would be quite easy to approximate it in the GAP banner:

![image](https://github.com/user-attachments/assets/472faa84-9c40-4cc6-952b-5a75c980a654)
![image](https://github.com/user-attachments/assets/5e74ba6f-0f6e-4c5c-b78b-3aa51f7fadb3)

This PR makes this change to the banner. I've tested it with every colour scheme in my terminal emulator and it's always legible; and I tried it in a no-colour terminal with `xterm -cm`, and the colour is ignored.

It only affects the case when UTF-8 is enabled (the ⋊ and Λ symbols require this anyway) so the fallback is unaffected:

![image](https://github.com/user-attachments/assets/e33d9fb6-ff28-4565-a2a2-9eedeb3a154a)

Naturally this should only be merged if logo A1 is chosen.

## Text for release notes

None