### PR TITLE
Add PackageManager to default PackagesToLoad

### DIFF
--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1948,8 +1948,8 @@ For backwards compatibility, the default lists most of packages \
 that were autoloaded in &GAP; 4.4 (add or remove packages as you like)."
     ],
   default:= [ "autpgrp", "alnuth", "crisp", "ctbllib", "factint", "fga",
-              "irredsol", "laguna", "polenta", "polycyclic", "resclasses",
-              "sophus", "tomlib" ],
+              "irredsol", "laguna", "PackageManager", "polenta", "polycyclic",
+              "resclasses", "sophus", "tomlib" ],
   values:= function() return RecNames( GAPInfo.PackagesInfo ); end,
   multi:= true,
   ) );


### PR DESCRIPTION
This PR adds PackageManager to the list of packages loaded by default at startup.

PackageManager is a helpful tool for beginners, and it's also quite lightweight and distributed with GAP. I've talked a number of beginners through setting up GAP and its packages (people who haven't yet understood gap.ini files and so on) and sometimes I have to tell them to run `LoadPackage("PackageManager");` several times in just a few minutes when they're restarting GAP, running tests and so on. This would reduce that barrier and make it easier to do things with packages quickly.

Having said this, I'm aware `PackagesToLoad` is an exclusive list that shouldn't be edited lightly. If there are reasons to keep the list lean, I won't be offended if someone closes this PR!

## Text for release notes

"The GAP package manager is now loaded automatically at startup by default."