### PR TITLE
Adding yacc and texlive-full

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ slowing down the compilation process, or omit certain features):
 
 On Ubuntu or Debian, you can install these with the following command:
 
-    sudo apt-get install build-essential autoconf libgmp-dev libreadline-dev zlib1g-dev
+    sudo apt-get install build-essential autoconf libgmp-dev libreadline-dev zlib1g-dev yacc texlive-full
 
 On Fedora:
 


### PR DESCRIPTION
Why `yacc` - See the error:

![image](https://github.com/user-attachments/assets/e682c132-bb69-4891-bbd8-868c1fcdd025)

Why `texlive-full` - See the error:

![image](https://github.com/user-attachments/assets/c791d3b6-61da-4513-9bd5-f06d7b9431e1)

![image](https://github.com/user-attachments/assets/f4052f76-7ae5-49af-94c7-b448b0777b82)

cc @mtorpey

cc https://github.com/gap-packages/packagemanager README.md file