### PR TITLE
Fix bug in double cosets computation that could lead to wrong results (the error is detectable by the sizes of the double cosets not summing up to the group order)

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -996,7 +996,7 @@ local c, flip, maxidx, cano, tryfct, p, r, t,
   avoidlimit:=200000; # beyond this index we want to get smaller
   badlimit:=5000000; # beyond this index things might break down
 
-  mayflip:=true; # are we allowed to flip?
+  mayflip:=true; # are we allowed to flip for better chain as well?
 
   # Do we *want* stabilizers
   includestab:=ValueOption("includestab")=true;
@@ -1094,6 +1094,7 @@ local c, flip, maxidx, cano, tryfct, p, r, t,
       a:=c;
       flip:=not flip;
       c:=c1;
+      stabs:=[b]; # make sure stabs also flips over
 
     elif IsPermGroup(G) then
 

--- a/tst/testbugfix/2025-04-07-DoubleCosets.tst
+++ b/tst/testbugfix/2025-04-07-DoubleCosets.tst
@@ -1,0 +1,7 @@
+# Fix #5969 Double Cosets
+gap> G := SymmetricGroup(16);;
+gap> H := DirectProduct(SymmetricGroup(4),WreathProduct(SymmetricGroup(3),
+>   SymmetricGroup(3)),SymmetricGroup(3));;
+gap> K := WreathProduct(SymmetricGroup(2),SymmetricGroup(8));;
+gap> Length(DoubleCosetRepsAndSizes(G, H, K));
+121


### PR DESCRIPTION
When computing double cosets, the subgroups might be flipped if this gives a better chain. If so, the correct acting group needs to be initialized in `stab` as well.
This fixes #5969

This is a fix by @hulpke I merely "packaged it up" into a PR