### PR TITLE
Fix re-reading a file using `InstallTagBasedMethod`

### DIFF
--- a/lib/methsel.g
+++ b/lib/methsel.g
@@ -293,7 +293,7 @@ BIND_GLOBAL( "InstallTagBasedMethod", function( oper, meth... )
       Error( "usage: InstallTagBasedMethod( oper[, tag], meth )" );
     fi;
 
-    if FIND_OBJ_MAP( dict, tag, fail ) <> fail then
+    if not REREADING and FIND_OBJ_MAP( dict, tag, fail ) <> fail then
       Error( "<tag> has already been set in <dict>" );
     elif not IS_FUNCTION( meth ) then
       Error( "<meth> must be a function" );


### PR DESCRIPTION
For example `RereadLib("matobj.gi");` now works again.

Before we got this:
```
gap> RereadLib("matobj.gi");
Error, <tag> has already been set in <dict> at /Users/mhorn/Projekte/GAP/gap/lib/methsel.g:297 called from
<function "InstallTagBasedMethod">( <arguments> )
 called from read-eval loop at /Users/mhorn/Projekte/GAP/gap/lib/matobj.gi:258
you can 'quit;' to quit to outer loop, or
you can 'return;' to continue
brk>
```