### PR TITLE
Add `AddMatrix`, `MultMatrix` (plus explicit left/right side variants) for in-place modification of matrices

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -221,6 +221,8 @@ All rows of a matrix must have the same length and the same base domain.
 <#Include Label="AddMatrixColumnsLeft">
 <#Include Label="SwapMatrixRows">
 <#Include Label="SwapMatrixColumns">
+<#Include Label="AddMatrix">
+<#Include Label="MultMatrix">
 
 </Section>
 
@@ -376,4 +378,3 @@ described in this chapter is supported.
 </Section>
 
 </Chapter>
-

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -463,7 +463,7 @@ end );
 #M  <vec1> = <vec2>
 ##
 
-InstallMethod( \=, "for 2 8 bit vectors",
+InstallMethod( \=, "for two 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -476,7 +476,7 @@ InstallMethod( \=, "for 2 8 bit vectors",
 ##  Usual lexicographic ordering
 ##
 
-InstallMethod( \<, "for 2 8 bit vectors",
+InstallMethod( \<, "for two 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -488,7 +488,7 @@ InstallMethod( \<, "for 2 8 bit vectors",
 ##
 ##  scalar product
 #'
-InstallMethod( \*, "for 2 8 bit vectors",
+InstallMethod( \*, "for two 8 bit vectors",
         IsIdenticalObj, [IsRingElementList and Is8BitVectorRep,
                 IsRingElementList and Is8BitVectorRep],
         0,
@@ -525,7 +525,7 @@ end);
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element and from and to",
+InstallOtherMethod( AddRowVector, "for two 8 bit vectors and a field element and from and to",
         IsCollsCollsElmsXX, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep, IsPosInt, IsPosInt ], 0,
@@ -538,7 +538,7 @@ InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element and f
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element",
+InstallOtherMethod( AddRowVector, "for two 8 bit vectors and a field element",
         IsCollsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep ], 0,
@@ -551,7 +551,7 @@ InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element",
 ##  add <vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "for 2 8 bit vectors",
+InstallOtherMethod( AddRowVector, "for two 8 bit vectors",
         IsIdenticalObj, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         ADD_ROWVECTOR_VEC8BITS_2);

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1906,8 +1906,9 @@ InstallMethod( AddMatrix, "for a mutable matrix object and a matrix object",
   [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj ],
   function( dstmat, srcmat )
     local i, j;
-    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
-    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    if DimensionsMat(dstmat) <> DimensionsMat(srcmat) then
+      Error("AddMatrix: matrices must have the same dimensions");
+    fi;
     for i in [1..NrRows(dstmat)] do
       for j in [1..NrCols(dstmat)] do
         dstmat[i,j] := dstmat[i,j] + srcmat[i,j];
@@ -1919,8 +1920,9 @@ InstallEarlyMethod( AddMatrix,
   function( dstmat, srcmat )
     local i;
     if IsPlistRep(dstmat) and IsPlistRep(srcmat) then
-      # Assert(0, NrRows(dstmat) = NrRows(srcmat));
-      # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+      if DimensionsMat(dstmat) <> DimensionsMat(srcmat) then
+        Error("AddMatrix: matrices must have the same dimensions");
+      fi;
       for i in [1..NrRows(dstmat)] do
         AddRowVector(dstmat[i], srcmat[i]);
       od;
@@ -1932,11 +1934,12 @@ InstallEarlyMethod( AddMatrix,
 InstallMethod( AddMatrix, "for a mutable 8bit matrix and an 8bit matrix",
   [ Is8BitMatrixRep and IsMutable, Is8BitMatrixRep ],
   function( dstmat, srcmat )
-    local i, j;
-    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
-    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    local i;
+    if DimensionsMat(dstmat) <> DimensionsMat(srcmat) then
+      Error("AddMatrix: matrices must have the same dimensions");
+    fi;
     for i in [1..NrRows(dstmat)] do
-      ADD_COEFFS_VEC8BIT_3(dstmat[i], srcmat[i]);
+      ADD_COEFFS_VEC8BIT_2(dstmat[i], srcmat[i]);
     od;
   end );
 
@@ -1949,8 +1952,9 @@ InstallMethod( AddMatrix, "for a mutable matrix object, a matrix object, and a s
   [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj, IsScalar ],
   function( dstmat, srcmat, scalar )
     local i, j;
-    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
-    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    if DimensionsMat(dstmat) <> DimensionsMat(srcmat) then
+      Error("AddMatrix: matrices must have the same dimensions");
+    fi;
     for i in [1..NrRows(dstmat)] do
       for j in [1..NrCols(dstmat)] do
         dstmat[i,j] := dstmat[i,j] + srcmat[i,j] * scalar;
@@ -1962,8 +1966,9 @@ InstallEarlyMethod( AddMatrix,
   function( dstmat, srcmat, scalar )
     local i;
     if IsPlistRep(dstmat) and IsPlistRep(srcmat) then
-      # Assert(0, NrRows(dstmat) = NrRows(srcmat));
-      # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+      if DimensionsMat(dstmat) <> DimensionsMat(srcmat) then
+        Error("AddMatrix: matrices must have the same dimensions");
+      fi;
       for i in [1..NrRows(dstmat)] do
         AddRowVector(dstmat[i], srcmat[i], scalar);
       od;
@@ -1975,9 +1980,10 @@ InstallEarlyMethod( AddMatrix,
 InstallMethod( AddMatrix, "for a mutable 8bit matrix, an 8bit matrix, and a scalar",
   [ Is8BitMatrixRep and IsMutable, Is8BitMatrixRep, IsFFE ],
   function( dstmat, srcmat, scalar )
-    local i, j;
-    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
-    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    local i;
+    if DimensionsMat(dstmat) <> DimensionsMat(srcmat) then
+      Error("AddMatrix: matrices must have the same dimensions");
+    fi;
     for i in [1..NrRows(dstmat)] do
       ADD_COEFFS_VEC8BIT_3(dstmat[i], srcmat[i], scalar);
     od;
@@ -2046,4 +2052,3 @@ InstallMethod(DeterminantMatrix, ["IsMatrixObj"],
 function( mat )
   return DeterminantMat( Unpack( mat ) );
 end);
-

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1897,9 +1897,151 @@ InstallMethod( SwapMatrixColumns, "for a mutable matrix object, and two column n
 
   end );
 
+#############################################################################
+##
+#M  AddMatrix( <mat1>, <mat2> )
+##
+
+InstallMethod( AddMatrix, "for a mutable matrix object and a matrix object",
+  [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj ],
+  function( dstmat, srcmat )
+    local i, j;
+    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
+    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    for i in [1..NrRows(dstmat)] do
+      for j in [1..NrCols(dstmat)] do
+        dstmat[i,j] := dstmat[i,j] + srcmat[i,j];
+      od;
+    od;
+  end );
+
+InstallEarlyMethod( AddMatrix,
+  function( dstmat, srcmat )
+    local i;
+    if IsPlistRep(dstmat) and IsPlistRep(srcmat) then
+      # Assert(0, NrRows(dstmat) = NrRows(srcmat));
+      # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+      for i in [1..NrRows(dstmat)] do
+        AddRowVector(dstmat[i], srcmat[i]);
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
+InstallMethod( AddMatrix, "for a mutable 8bit matrix and an 8bit matrix",
+  [ Is8BitMatrixRep and IsMutable, Is8BitMatrixRep ],
+  function( dstmat, srcmat )
+    local i, j;
+    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
+    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    for i in [1..NrRows(dstmat)] do
+      ADD_COEFFS_VEC8BIT_3(dstmat[i], srcmat[i]);
+    od;
+  end );
+
+#############################################################################
+##
+#M  AddMatrix( <mat1>, <mat2>, <mult> )
+##
+
+InstallMethod( AddMatrix, "for a mutable matrix object, a matrix object, and a scalar",
+  [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj, IsScalar ],
+  function( dstmat, srcmat, scalar )
+    local i, j;
+    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
+    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    for i in [1..NrRows(dstmat)] do
+      for j in [1..NrCols(dstmat)] do
+        dstmat[i,j] := dstmat[i,j] + srcmat[i,j] * scalar;
+      od;
+    od;
+  end );
+
+InstallEarlyMethod( AddMatrix,
+  function( dstmat, srcmat, scalar )
+    local i;
+    if IsPlistRep(dstmat) and IsPlistRep(srcmat) then
+      # Assert(0, NrRows(dstmat) = NrRows(srcmat));
+      # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+      for i in [1..NrRows(dstmat)] do
+        AddRowVector(dstmat[i], srcmat[i], scalar);
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
+InstallMethod( AddMatrix, "for a mutable 8bit matrix, an 8bit matrix, and a scalar",
+  [ Is8BitMatrixRep and IsMutable, Is8BitMatrixRep, IsFFE ],
+  function( dstmat, srcmat, scalar )
+    local i, j;
+    # Assert(0, NrRows(dstmat) = NrRows(srcmat));
+    # Assert(0, NrCols(dstmat) = NrCols(srcmat));
+    for i in [1..NrRows(dstmat)] do
+      ADD_COEFFS_VEC8BIT_3(dstmat[i], srcmat[i], scalar);
+    od;
+  end );
+
+#############################################################################
+##
+#M  MultMatrixRight( <mat>, <mult> )
+##
+
+InstallMethod( MultMatrixRight, "for a mutable matrix object and a scalar",
+  [ IsMatrixOrMatrixObj and IsMutable, IsScalar ],
+  function( mat, scalar )
+    local i, j;
+    for i in [1..NrRows(mat)] do
+      for j in [1..NrCols(mat)] do
+        mat[i,j] := mat[i,j] * scalar;
+      od;
+    od;
+  end );
+
+InstallEarlyMethod( MultMatrixRight,
+  function( mat, scalar )
+    local i;
+    if IsPlistRep(mat) and IsScalar(scalar) then
+      for i in [1..NrRows(mat)] do
+        MultVectorRight(mat[i], scalar);
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
+
+#############################################################################
+##
+#M  MultMatrixLeft( <mat>, <mult> )
+##
+
+InstallMethod( MultMatrixLeft, "for a mutable matrix object and a scalar",
+  [ IsMatrixOrMatrixObj and IsMutable, IsScalar ],
+  function( mat, scalar )
+    local i, j;
+    for i in [1..NrRows(mat)] do
+      for j in [1..NrCols(mat)] do
+        mat[i,j] := scalar * mat[i,j];
+      od;
+    od;
+  end );
+
+InstallEarlyMethod( MultMatrixLeft,
+  function( mat, scalar )
+    local i;
+    if IsPlistRep(mat) and IsScalar(scalar) then
+      for i in [1..NrRows(mat)] do
+        MultVectorLeft(mat[i], scalar);
+      od;
+    else
+      TryNextMethod();
+    fi;
+  end );
 
 ############################################################################
 ##  Fallback method for DeterminantMatrix
+
 InstallMethod(DeterminantMatrix, ["IsMatrixObj"],
 function( mat )
   return DeterminantMat( Unpack( mat ) );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -2052,3 +2052,86 @@ DeclareOperationKernel( "SwapMatrixRows", [ IsMatrixOrMatrixObj and IsMutable, I
 ##  <#/GAPDoc>
 ##
 DeclareOperationKernel( "SwapMatrixColumns", [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ], SWAP_MAT_COLS );
+
+############################################################################
+##
+##  <#GAPDoc Label="AddMatrixRight">
+##  <ManSection>
+##  <Oper Name="AddMatrixRight" Arg='M, N[, c]'/>
+##
+##  <Returns>nothing</Returns>
+##
+##  <Description>
+##  <P/>
+##  Computes the calculation <M>M + c \cdot N</M> in-place, storing the result in <A>M</A>.
+##  If both of the matrices are lists-of-lists, then the program utilises <Ref Oper="AddRowVector"/>
+##  to perform the operation even faster.
+##  <Example><![CDATA[
+##  gap> mat1 := [ [ 1, 2 ], [ 3, 4 ] ];
+##  [ [ 1, 2 ], [ 3, 4 ] ]
+##  gap> mat2 := [ [ 1, 0 ], [ 3, -1 ] ];
+##  [ [ 1, 0 ], [ 3, -1 ] ]
+##  gap> AddMatrix( mat1, mat2, 2 );
+##  gap> mat1;
+##  [ [ 3, 2 ], [ 9, 2 ] ]
+##  gap> mat2;
+##  [ [ 1, 0 ], [ 3, -1 ] ]
+##  gap> AddMatrix( mat1, [ [ 1, 0], [ 3, -1] ] );
+##  gap> mat1;
+##  [ [ 4, 2 ], [ 12, 1 ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "AddMatrix", [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj ] );
+DeclareOperation( "AddMatrix", [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMatrixObj, IsScalar ] );
+
+############################################################################
+##
+##  <#GAPDoc Label="MultMatrix">
+##  <ManSection>
+##  <Oper Name="MultMatrix" Arg='mat, c'/>
+##  <Oper Name="MultMatrixLeft" Arg='mat, c'/>
+##  <Oper Name="MultMatrixRight" Arg='mat, c'/>
+##
+##  <Returns>nothing</Returns>
+##
+##  <Description>
+##  <P/>
+##  These functions multiply the entries of <A>mat</A> by <A>c</A> in-place.
+##  <Ref Oper="MultMatrixRight"/> performs the operation <M>mat \cdot c</M>,
+##  whereas <Ref Oper="MultMatrixLeft"/> performs the operation <M>c \cdot mat</M>
+##  and <Ref Oper="MultMatrix"/> is an alias for <Ref Oper="MultMatrixLeft"/>.
+##  In all of these, if the matrix <A>mat</A> is a lists-of-lists, then the program
+##  utilises the fast in-place operations <Ref Oper="MultVectorRight"/> and <Ref Oper="MultVectorLeft"/>.
+##  to perform the operation even faster.
+##  <Example><![CDATA[
+##  gap> mat1 := [ [ 1, 2 ], [ 3, 4 ] ];
+##  [ [ 1, 2 ], [ 3, 4 ] ]
+##  gap> MultMatrixRight(mat1, -2);
+##  gap> mat1;
+##  [ [ -2, -4 ], [ -6, -8 ] ]
+##  gap> MultMatrix(mat1, -2); # Note that this is the same as calling MultMatrixLeft(mat1, -2)
+##  gap> mat1;
+##  [ [ 4, 8 ], [ 12, 16 ] ]
+##  gap> A := FreeAssociativeAlgebra(Rationals, 2);
+##  <algebra over Rationals, with 2 generators>
+##  gap> mat2 := [ [ A.1, A.2 ], [ A.1 * 2, A.2 * 3 ] ];
+##  [ [ (1)*x.1, (1)*x.2 ], [ (2)*x.1, (3)*x.2 ] ]
+##  gap> MultMatrixLeft(mat2, A.1);
+##  gap> mat2;
+##  [ [ (1)*x.1^2, (1)*x.1*x.2 ], [ (2)*x.1^2, (3)*x.1*x.2 ] ]
+##  gap> mat2 := [ [ A.1, A.2 ], [ A.1 * 2, A.2 * 3 ] ];
+##  [ [ (1)*x.1, (1)*x.2 ], [ (2)*x.1, (3)*x.2 ] ]
+##  gap> MultMatrixRight(mat2, A.1);
+##  gap> mat2;
+##  [ [ (1)*x.1^2, (1)*x.2*x.1 ], [ (2)*x.1^2, (3)*x.2*x.1 ] ]
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "MultMatrixRight", [ IsMatrixOrMatrixObj and IsMutable, IsScalar ] );
+DeclareOperation( "MultMatrixLeft", [ IsMatrixOrMatrixObj and IsMutable, IsScalar ] );
+DeclareSynonym( "MultMatrix", MultMatrixLeft);

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -2064,8 +2064,8 @@ DeclareOperationKernel( "SwapMatrixColumns", [ IsMatrixOrMatrixObj and IsMutable
 ##  <Description>
 ##  Computes the calculation <M>M + c \cdot N</M> in-place, storing the result in <A>M</A>.
 ##  If the optional argument <A>c</A> is omitted, then <A>N</A> is added directly.
-##  If both of the matrices are lists-of-lists, then the program utilises <Ref Oper="AddRowVector"/>
-##  to perform the operation even faster.
+##  If both of the matrices are lists-of-lists, then the operation is delegated
+##  row by row to <Ref Oper="AddRowVector"/>.
 ##  <Example><![CDATA[
 ##  gap> mat1 := [ [ 1, 2 ], [ 3, 4 ] ];
 ##  [ [ 1, 2 ], [ 3, 4 ] ]
@@ -2099,12 +2099,12 @@ DeclareOperation( "AddMatrix", [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMa
 ##
 ##  <Description>
 ##  These functions multiply the entries of <A>mat</A> by <A>c</A> in-place.
-##  <Ref Oper="MultMatrixRight"/> performs the operation <M>mat \cdot c</M>,
-##  whereas <Ref Oper="MultMatrixLeft"/> performs the operation <M>c \cdot mat</M>
+##  <Ref Oper="MultMatrixRight"/> performs the operation <A>mat</A><C>*</C><A>c</A>,
+##  whereas <Ref Oper="MultMatrixLeft"/> performs the operation <A>c</A><C>*</C><A>mat</A>
 ##  and <Ref Oper="MultMatrix"/> is an alias for <Ref Oper="MultMatrixLeft"/>.
-##  In all of these, if the matrix <A>mat</A> is a lists-of-lists, then the program
-##  utilises the fast in-place operations <Ref Oper="MultVectorRight"/> and
-##  <Ref Oper="MultVectorLeft"/> to perform the operation even faster.
+##  In all of these, if the matrix <A>mat</A> is a lists-of-lists, then the
+##  operation is delegated row by row to <Ref Oper="MultVectorRight"/> and
+##  <Ref Oper="MultVectorLeft"/>.
 ##  <Example><![CDATA[
 ##  gap> mat1 := [ [ 1, 2 ], [ 3, 4 ] ];
 ##  [ [ 1, 2 ], [ 3, 4 ] ]

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -2055,15 +2055,15 @@ DeclareOperationKernel( "SwapMatrixColumns", [ IsMatrixOrMatrixObj and IsMutable
 
 ############################################################################
 ##
-##  <#GAPDoc Label="AddMatrixRight">
+##  <#GAPDoc Label="AddMatrix">
 ##  <ManSection>
-##  <Oper Name="AddMatrixRight" Arg='M, N[, c]'/>
+##  <Oper Name="AddMatrix" Arg='M, N[, c]'/>
 ##
 ##  <Returns>nothing</Returns>
 ##
 ##  <Description>
-##  <P/>
 ##  Computes the calculation <M>M + c \cdot N</M> in-place, storing the result in <A>M</A>.
+##  If the optional argument <A>c</A> is omitted, then <A>N</A> is added directly.
 ##  If both of the matrices are lists-of-lists, then the program utilises <Ref Oper="AddRowVector"/>
 ##  to perform the operation even faster.
 ##  <Example><![CDATA[
@@ -2098,14 +2098,13 @@ DeclareOperation( "AddMatrix", [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMa
 ##  <Returns>nothing</Returns>
 ##
 ##  <Description>
-##  <P/>
 ##  These functions multiply the entries of <A>mat</A> by <A>c</A> in-place.
 ##  <Ref Oper="MultMatrixRight"/> performs the operation <M>mat \cdot c</M>,
 ##  whereas <Ref Oper="MultMatrixLeft"/> performs the operation <M>c \cdot mat</M>
 ##  and <Ref Oper="MultMatrix"/> is an alias for <Ref Oper="MultMatrixLeft"/>.
 ##  In all of these, if the matrix <A>mat</A> is a lists-of-lists, then the program
-##  utilises the fast in-place operations <Ref Oper="MultVectorRight"/> and <Ref Oper="MultVectorLeft"/>.
-##  to perform the operation even faster.
+##  utilises the fast in-place operations <Ref Oper="MultVectorRight"/> and
+##  <Ref Oper="MultVectorLeft"/> to perform the operation even faster.
 ##  <Example><![CDATA[
 ##  gap> mat1 := [ [ 1, 2 ], [ 3, 4 ] ];
 ##  [ [ 1, 2 ], [ 3, 4 ] ]
@@ -2134,4 +2133,4 @@ DeclareOperation( "AddMatrix", [ IsMatrixOrMatrixObj and IsMutable, IsMatrixOrMa
 ##
 DeclareOperation( "MultMatrixRight", [ IsMatrixOrMatrixObj and IsMutable, IsScalar ] );
 DeclareOperation( "MultMatrixLeft", [ IsMatrixOrMatrixObj and IsMutable, IsScalar ] );
-DeclareSynonym( "MultMatrix", MultMatrixLeft);
+DeclareSynonym( "MultMatrix", MultMatrixLeft );

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -452,7 +452,7 @@ end );
 #M  <vec1> = <vec2>
 ##
 
-InstallMethod( \=, "for 2 8 bit vectors",
+InstallMethod( \=, "for two 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -465,7 +465,7 @@ InstallMethod( \=, "for 2 8 bit vectors",
 ##  Usual lexicographic ordering
 ##
 
-InstallMethod( \<, "for 2 8 bit vectors",
+InstallMethod( \<, "for two 8 bit vectors",
         IsIdenticalObj, [IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep],
         0,
@@ -477,7 +477,7 @@ InstallMethod( \<, "for 2 8 bit vectors",
 ##
 ##  scalar product
 #'
-InstallMethod( \*, "for 2 8 bit vectors",
+InstallMethod( \*, "for two 8 bit vectors",
         IsIdenticalObj, [IsRingElementList and Is8BitVectorRep,
                 IsRingElementList and Is8BitVectorRep],
         0,
@@ -514,7 +514,7 @@ end);
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element and from and to",
+InstallOtherMethod( AddRowVector, "for two 8 bit vectors and a field element and from and to",
         IsCollsCollsElmsXX, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep, IsPosInt, IsPosInt ], 0,
@@ -527,7 +527,7 @@ InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element and f
 ##  add <mult>*<vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element",
+InstallOtherMethod( AddRowVector, "for two 8 bit vectors and a field element",
         IsCollsCollsElms, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep,
                 IsFFE and IsInternalRep ], 0,
@@ -540,7 +540,7 @@ InstallOtherMethod( AddRowVector, "for 2 8 bit vectors and a field element",
 ##  add <vec2> to <vec1> in place
 ##
 
-InstallOtherMethod( AddRowVector, "for 2 8 bit vectors",
+InstallOtherMethod( AddRowVector, "for two 8 bit vectors",
         IsIdenticalObj, [ IsRowVector and Is8BitVectorRep,
                 IsRowVector and Is8BitVectorRep], 0,
         ADD_ROWVECTOR_VEC8BITS_2);

--- a/tst/testinstall/MatrixObj/ElementaryMatrices.tst
+++ b/tst/testinstall/MatrixObj/ElementaryMatrices.tst
@@ -6,34 +6,66 @@ gap> ReadGapRoot("tst/testinstall/MatrixObj/testmatobj.g");
 #
 gap> TestElementaryTransforms( [[2,4,5],[7,11,-4],[-3,20,0]], -1 );
 gap> TestElementaryTransforms( Matrix( [[2,4,5],[7,11,-4],[-3,20,0]]), -1 );
+gap> TestWholeMatrixTransforms( [[2,4,5],[7,11,-4],[-3,20,0]], -1 );
+gap> TestWholeMatrixTransforms( Matrix( [[2,4,5],[7,11,-4],[-3,20,0]]), -1 );
 
 #
 gap> F := GF(2);;
 gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 gap> ConvertToMatrixRep(mat);;  # proper matrix obj
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 
 #
 gap> F := GF(3);;
 gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 gap> ConvertToMatrixRep(mat);;  # proper matrix obj
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 
 #
 gap> F := GF(4);;
 gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 gap> ConvertToMatrixRep(mat);;  # proper matrix obj
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 
 #
 gap> F := GF(5);;
 gap> mat := RandomInvertibleMat(4, F);; # list of compressed vectors
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 gap> ConvertToMatrixRep(mat);;  # proper matrix obj
 gap> TestElementaryTransforms( mat, PrimitiveRoot(F) );
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
+
+#
+gap> F := GF(3);;
+gap> mat := [ [ Z(3)^0, 0*Z(3), Z(3) ],
+>            [ Z(3), Z(3)^0, 0*Z(3) ],
+>            [ 0*Z(3), Z(3), Z(3)^0 ] ];;
+gap> ConvertToMatrixRep(mat, F);;
+gap> Is8BitMatrixRep(mat);
+true
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
+gap> ConvertToMatrixRep(mat);;
+gap> Is8BitMatrixRep(mat);
+true
+gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
+
+#
+gap> mat := NewMatrix(IsPlistMatrixRep, Integers, 3,
+>                     [ [ 2, 4, 5 ], [ 7, 11, -4 ], [ -3, 20, 0 ] ] );;
+gap> IsPlistMatrixRep(mat);
+true
+gap> TestElementaryTransforms( mat, -1 );
+gap> TestWholeMatrixTransforms( mat, -1 );
 
 ##########
 #
@@ -119,4 +151,28 @@ gap> mat := Matrix( [[2,4,5],[7,11,-4],[-3,20,0]]);;
 gap> AddMatrixColumnsLeft(mat,1,3,-3);
 gap> mat= Matrix( [ [-13,4,5], [19,11,-4], [-3,20,0]]);
 true
+
+#
+gap> mat := Matrix( [ [ 1, 2 ], [ 3, 4 ] ] );;
+gap> AddMatrix( mat, [ [ 1, 0 ], [ 3, -1 ] ], 2 );
+gap> mat = Matrix( [ [ 3, 2 ], [ 9, 2 ] ] );
+true
+gap> AddMatrix( mat, [ [ 1, 0 ], [ 3, -1 ] ] );
+gap> mat = Matrix( [ [ 4, 2 ], [ 12, 1 ] ] );
+true
+
+#
+gap> A := FreeAssociativeAlgebraWithOne(Rationals, 2);;
+gap> mat := [ [ A.1, A.2 ], [ A.1 * 2, A.2 * 3 ] ];;
+gap> MultMatrixLeft(mat, A.1);
+gap> mat;
+[ [ (1)*x.1^2, (1)*x.1*x.2 ], [ (2)*x.1^2, (3)*x.1*x.2 ] ]
+gap> mat := [ [ A.1, A.2 ], [ A.1 * 2, A.2 * 3 ] ];;
+gap> MultMatrixRight(mat, A.1);
+gap> mat;
+[ [ (1)*x.1^2, (1)*x.2*x.1 ], [ (2)*x.1^2, (3)*x.2*x.1 ] ]
+gap> mat := [ [ 1, 2 ], [ 3, 4 ] ];;
+gap> MultMatrix(mat, -2);
+gap> mat;
+[ [ -2, -4 ], [ -6, -8 ] ]
 gap> STOP_TEST("ElementaryMatrices.tst");

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -231,8 +231,8 @@ TestWholeMatrixTransforms := function(mat, scalar)
 
     AddMatrix(mat, src);
     AddMatrix(copy, srccopy);
-    if not same_entries(mat, copy) then Error("AddMatrix(", scalar, ") failure"); fi;
-    if not same_entries(src, srcbefore) then Error("AddMatrix source modified"); fi;
+    if not same_entries(mat, copy) then Error("AddMatrix(_,_) failure"); fi;
+    if not same_entries(src, srcbefore) then Error("AddMatrix(_,_) source modified"); fi;
 
     AddMatrix(mat, src, scalar);
     AddMatrix(copy, srccopy, scalar);

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -190,3 +190,63 @@ TestElementaryTransforms := function(mat, scalar)
         od;
     od;
 end;
+
+TestWholeMatrixTransforms := function(mat, scalar)
+    local i, j, src, copy, srccopy, basedomain, same_entries;
+    Assert(0, NrRows(mat) >= 1);
+    Assert(0, NrCols(mat) >= 1);
+
+    copy := [];
+    src := [];
+    for i in [1..NrRows(mat)] do
+        copy[i] := [];
+        src[i] := [];
+        for j in [1..NrCols(mat)] do
+            copy[i,j] := mat[i,j];
+            src[i,j] := mat[(i mod NrRows(mat)) + 1, (j mod NrCols(mat)) + 1];
+        od;
+    od;
+    basedomain := BaseDomain(mat);
+    if IsPlistMatrixRep(mat) then
+        src := NewMatrix(IsPlistMatrixRep, basedomain, NrCols(mat), src);
+    elif Is8BitMatrixRep(mat) then
+        ConvertToMatrixRep(src, basedomain);
+    fi;
+    srccopy := StructuralCopy(src);
+
+    # Compare entrywise because these tests mix plain list snapshots with
+    # matrix objects in specialized representations.
+    same_entries := function(a, b)
+        local i, j;
+        for i in [1..NrRows(a)] do
+            for j in [1..NrCols(a)] do
+                if a[i,j] <> b[i,j] then
+                    return false;
+                fi;
+            od;
+        od;
+        return true;
+    end;
+
+    AddMatrix(mat, src);
+    AddMatrix(copy, srccopy);
+    if not same_entries(mat, copy) then Error("AddMatrix(", scalar, ") failure"); fi;
+    if not same_entries(src, srccopy) then Error("AddMatrix source modified"); fi;
+
+    AddMatrix(mat, src, scalar);
+    AddMatrix(copy, srccopy, scalar);
+    if not same_entries(mat, copy) then Error("AddMatrix(_,_,", scalar, ") failure"); fi;
+    if not same_entries(src, srccopy) then Error("AddMatrix(_,_,scalar) source modified"); fi;
+
+    MultMatrixLeft(mat, scalar);
+    MultMatrixLeft(copy, scalar);
+    if not same_entries(mat, copy) then Error("MultMatrixLeft(", scalar, ") failure"); fi;
+
+    MultMatrixRight(mat, scalar);
+    MultMatrixRight(copy, scalar);
+    if not same_entries(mat, copy) then Error("MultMatrixRight(", scalar, ") failure"); fi;
+
+    MultMatrix(mat, scalar);
+    MultMatrix(copy, scalar);
+    if not same_entries(mat, copy) then Error("MultMatrix(", scalar, ") failure"); fi;
+end;

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -192,7 +192,7 @@ TestElementaryTransforms := function(mat, scalar)
 end;
 
 TestWholeMatrixTransforms := function(mat, scalar)
-    local i, j, src, copy, srccopy, basedomain, same_entries;
+    local i, j, src, srcbefore, copy, srccopy, basedomain, same_entries;
     Assert(0, NrRows(mat) >= 1);
     Assert(0, NrCols(mat) >= 1);
 
@@ -212,6 +212,7 @@ TestWholeMatrixTransforms := function(mat, scalar)
     elif Is8BitMatrixRep(mat) then
         ConvertToMatrixRep(src, basedomain);
     fi;
+    srcbefore := StructuralCopy(src);
     srccopy := StructuralCopy(src);
 
     # Compare entrywise because these tests mix plain list snapshots with
@@ -231,12 +232,12 @@ TestWholeMatrixTransforms := function(mat, scalar)
     AddMatrix(mat, src);
     AddMatrix(copy, srccopy);
     if not same_entries(mat, copy) then Error("AddMatrix(", scalar, ") failure"); fi;
-    if not same_entries(src, srccopy) then Error("AddMatrix source modified"); fi;
+    if not same_entries(src, srcbefore) then Error("AddMatrix source modified"); fi;
 
     AddMatrix(mat, src, scalar);
     AddMatrix(copy, srccopy, scalar);
     if not same_entries(mat, copy) then Error("AddMatrix(_,_,", scalar, ") failure"); fi;
-    if not same_entries(src, srccopy) then Error("AddMatrix(_,_,scalar) source modified"); fi;
+    if not same_entries(src, srcbefore) then Error("AddMatrix(_,_,scalar) source modified"); fi;
 
     MultMatrixLeft(mat, scalar);
     MultMatrixLeft(copy, scalar);


### PR DESCRIPTION
- **Implemented the AddMatrixLeft/Right and MultMatrixLeft/Right methods.**
- **Implemented the method MultVectorRight for lists to support MultMatrixRight method.**

To make progress on issue #5952 I implemented the operations of summing and multiplying matrices in-place.

## Further work

These functions should now be ready to be used in `meatauto.gi` to speed up those computations (as well as in other other place that might benefit from in-place matrix operations).

The functions also do **NOT** have coverage tests, that should be added sometime later too. 