### PR TITLE
Fix ExtRepOfPolynomial_String for zero polynomial

### DIFF
--- a/hpcgap/lib/ratfun.gi
+++ b/hpcgap/lib/ratfun.gi
@@ -510,7 +510,7 @@ local fam,ext,zero,one,mone,i,j,ind,bra,str,s,b,c, mbra,le;
   le:=Length(ext);
 
   if le=0 then
-    return String(zero);
+    return ShallowCopy(String(zero));
   fi;
   for i  in [ le-1,le-3..1] do
     if i<le-1 then

--- a/lib/ratfun.gi
+++ b/lib/ratfun.gi
@@ -504,7 +504,7 @@ local fam,ext,zero,one,mone,i,j,ind,bra,str,s,b,c, mbra,le;
   le:=Length(ext);
 
   if le=0 then
-    return String(zero);
+    return ShallowCopy(String(zero));
   fi;
   for i  in [ le-1,le-3..1] do
     if i<le-1 then

--- a/tst/testbugfix/2025-05-09-ratfun-zero-string.tst
+++ b/tst/testbugfix/2025-05-09-ratfun-zero-string.tst
@@ -1,0 +1,6 @@
+# Fix #5987 ExtRepOfPolynomial_String for zero polynomial
+gap> x1 := Indeterminate(Rationals, 1);; x2 := Indeterminate(Rationals, 2);; x3 := Indeterminate(Rationals, 3);;
+gap> a := (x1*x2)/(x1*x3) - x2/x3;
+0/x_1
+gap> String(a);
+"0/x_1"

--- a/tst/testbugfix/2025-05-09-ratfun-zero-string.tst
+++ b/tst/testbugfix/2025-05-09-ratfun-zero-string.tst
@@ -1,6 +1,6 @@
 # Fix #5987 ExtRepOfPolynomial_String for zero polynomial
 gap> x1 := Indeterminate(Rationals, "x1");; x2 := Indeterminate(Rationals, "x2");; x3 := Indeterminate(Rationals, "x3");;
 gap> a := (x1*x2)/(x1*x3) - x2/x3;
-0/x_1
+0/x1
 gap> String(a);
-"0/x_1"
+"0/x1"

--- a/tst/testbugfix/2025-05-09-ratfun-zero-string.tst
+++ b/tst/testbugfix/2025-05-09-ratfun-zero-string.tst
@@ -1,5 +1,5 @@
 # Fix #5987 ExtRepOfPolynomial_String for zero polynomial
-gap> x1 := Indeterminate(Rationals, 1);; x2 := Indeterminate(Rationals, 2);; x3 := Indeterminate(Rationals, 3);;
+gap> x1 := Indeterminate(Rationals, "x1");; x2 := Indeterminate(Rationals, "x2");; x3 := Indeterminate(Rationals, "x3");;
 gap> a := (x1*x2)/(x1*x3) - x2/x3;
 0/x_1
 gap> String(a);


### PR DESCRIPTION
Fixes #5986: `String(a)` for a rational function `a` with zero numerator throws an error. The problem was that `ExtRepOfPolynomial_String` normally returns a mutable string, but for a zero polynomial it used to return `String(zero)` which is immutable. Hence I changed this to `ShallowCopy(String(zero))`.

With this change, the example from #5986 works:
```
gap> x1 := Indeterminate(Rationals, 1);; x2 := Indeterminate(Rationals, 2);; x3 := Indeterminate(Rationals, 3);;
gap> a := (x1*x2)/(x1*x3) - x2/x3;
0/x_1
gap> String(a);
"0/x_1"
```
The issue that `a` is represented as `0/x_1` and not as `0` persists.

## Text for release notes
none
