### PR TITLE
Add `InverseOp` for `IsNonssocWord`

### DIFF
--- a/lib/mgmfree.gi
+++ b/lib/mgmfree.gi
@@ -229,6 +229,22 @@ InstallMethod( Size,
 
 #############################################################################
 ##
+#M  InverseOp( <x> ) . . . . . . . . . . . . . . . .  for free magma element
+##
+InstallOtherMethod( InverseOp,
+    "for free magma element",
+    [ IsNonassocWord ],
+    function( x )
+    if IsMultiplicativeElementWithOne( x ) and x = One( x ) then
+      return One( x );
+    else
+      return fail;
+    fi;
+    end );
+
+
+#############################################################################
+##
 #M  Random( <S> ) . . . . . . . . . . . . . .  random element of a free magma
 ##
 #T use better method for the whole family

--- a/lib/mgmfree.gi
+++ b/lib/mgmfree.gi
@@ -236,7 +236,7 @@ InstallOtherMethod( InverseOp,
     [ IsNonassocWord ],
     function( x )
     if IsMultiplicativeElementWithOne( x ) and x = One( x ) then
-      return One( x );
+      return x;
     else
       return fail;
     fi;

--- a/tst/testinstall/mgmfree.tst
+++ b/tst/testinstall/mgmfree.tst
@@ -265,6 +265,18 @@ Error, usage: FreeMagmaWithOne( <rank>[, <name>] )
               FreeMagmaWithOne( <names> )
               FreeMagmaWithOne( infinity[, <name>][, <init>] )
 
+# inverse
+gap> M := FreeMagma(1);;
+gap> Inverse(M.1);
+fail
+gap> M := FreeMagmaWithOne(2);;
+gap> Inverse(M.1);
+fail
+gap> Inverse(M.1*M.2*M.1);
+fail
+gap> Inverse(One(M)) = One(M);
+true
+
 # wfilt
 gap> FreeMagma(IsSyllableWordsFamily, 4);
 Error, the first argument must not be a filter

--- a/tst/testinstall/mgmfree.tst
+++ b/tst/testinstall/mgmfree.tst
@@ -276,6 +276,12 @@ gap> Inverse(M.1*M.2*M.1);
 fail
 gap> Inverse(One(M)) = One(M);
 true
+gap> One(M)^-1 = One(M);
+true
+gap> IsMultiplicativeElementWithInverse(M.1);
+true
+gap> IsMultiplicativeElementWithInverse(One(M));
+true
 
 # wfilt
 gap> FreeMagma(IsSyllableWordsFamily, 4);


### PR DESCRIPTION
A nonassociative word (i.e., an element of a free magma or of a free magma-with-one) is invertible if and only if it equals the identity element (if such an element exists).

This is a draft because not all the tests that I added pass:

```
gap> M := FreeMagmaWithOne(2);
<free magma-with-one on the generators [ x1, x2 ]>
gap> IsMultiplicativeElementWithInverse(One(M));
false
```
We should have `IsMultiplicativeElementWithInverse(One(M)) = true`. I think the filter `IsNonassocWordWithOne` should imply `IsMultiplicativeElementWithInverse`, but I do not know how to implement that. (Note that `IsMultiplicativeElementWithInverse(x) = true` only implies that `x` is an admissible argument for `Inverse`, but it is allowed that `Inverse(x) = fail`.) If this is done, the PR should be complete.

@ThomasBreuer is listed as an author in the file.

## Text for release notes

none.