### PR TITLE
Fix a potential linker issue during `make install` on macOS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -431,7 +431,7 @@ build/obj/%.c.o: %.c cnf/GAP-CFLAGS cnf/GAP-CPPFLAGS $(obj_deps)
 ########################################################################
 
 LINK=$(CC)
-
+GAP_INSTALL_EXTRAFLAGS =
 SHLIB_MAJOR = $(GAP_KERNEL_MAJOR_VERSION)
 ifneq (,$(findstring cygwin,$(host_os)))
   SHLIB_EXT=.dll
@@ -447,7 +447,8 @@ else ifneq (,$(findstring darwin,$(host_os)))
   LINK_SHLIB_FLAGS += -compatibility_version $(LIBGAP_COMPAT_VER)
   LINK_SHLIB_FLAGS += -current_version $(LIBGAP_CURRENT_VER)
   LINK_SHLIB_FLAGS += -Wl,-single_module
-  LINK_SHLIB_FLAGS += -headerpad_max_install_names
+  LINK_SHLIB_FLAGS += -Wl,-headerpad_max_install_names
+  GAP_INSTALL_EXTRAFLAGS = -Wl,-headerpad_max_install_names
 
   GAP_CPPFLAGS += -DPIC
   GAP_CFLAGS += -fno-common
@@ -519,7 +520,7 @@ build/main.c: src/main.c config.status
 
 # build rule for the gap executable used by the `install-bin` target
 build/gap-install: build/obj/build/main.c.o libgap$(SHLIB_EXT) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
-	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
+	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(GAP_INSTALL_EXTRAFLAGS) $< $(GAP_LIBS) -L${abs_builddir} -lgap -o $@
 	$(INSTALL_NAME_TOOL) -change $(LIBGAP_FULL) $(libdir)/$(LIBGAP_FULL) $@
 
 endif


### PR DESCRIPTION
This should fix #5989 - darwin headerpad issues. 

## Text for release notes

None

