### PR TITLE
Fix typo in `TryGcdCancelExtRepPolynomials`

### DIFF
--- a/lib/ratfun1.gi
+++ b/lib/ratfun1.gi
@@ -1236,7 +1236,7 @@ local q,p,e,i,j,cnt,sel,si;
   q:=QuotientPolynomialsExtRep(fam,den,num);
   if q<>fail then
     # true quotient
-    return [[[],fam!.oneCoefficient],q,num];
+    return [[[],fam!.oneCoefficient],q];
   fi;
 
   q:=HeuristicCancelPolynomialsExtRep(fam,num,den);

--- a/tst/testinstall/ratfun.tst
+++ b/tst/testinstall/ratfun.tst
@@ -1,4 +1,4 @@
-#@local det,mat,p0,p1,p2,q0,q1,q2,t,y1,y2,y3,u,f,g,data
+#@local det,mat,p0,p1,p2,q0,q1,q2,t,y1,y2,y3,u,f,g,data,fam
 gap> START_TEST("ratfun.tst");
 
 #
@@ -204,6 +204,17 @@ gap> Gcd(f,g);
 t^8*u-u
 gap> Gcd(t, u/3);
 1
+
+#
+# TryGcdCancelExtRepPolynomials
+#
+gap> fam := FamilyObj(t);;
+gap> TryGcdCancelExtRepPolynomials(fam, ExtRepPolynomialRatFun(t), ExtRepPolynomialRatFun(u));
+[ [ [ 100, 1 ], 1 ], [ [ 101, 1 ], 1 ] ]
+gap> TryGcdCancelExtRepPolynomials(fam, ExtRepPolynomialRatFun(t*u), ExtRepPolynomialRatFun(u));
+[ [ [ 100, 1 ], 1 ], [ [  ], 1 ] ]
+gap> TryGcdCancelExtRepPolynomials(fam, ExtRepPolynomialRatFun(t), ExtRepPolynomialRatFun(u*t));
+[ [ [  ], 1 ], [ [ 101, 1 ], 1 ] ]
 
 #
 gap> STOP_TEST("ratfun.tst");


### PR DESCRIPTION
The documentation specifies that `TryGcdCancelExtRepPolynomials` should return a list with two elements. In the case that the first input polynomial divides the second input polynomial, however, a list with three elements is returned. This does not seem to cause any problems, but the third list entry is still superfluous.

I noticed this in the context of #5993, but it is independent of that issue.

@hulpke Could you please check that this is ok?

## Text for release notes

none
