### PR TITLE
Fix error in membership test for rational functions

### DIFF
--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -817,7 +817,7 @@ function(f,R)
   
   # For an integral domain S, the function fields over S and over its fraction
   # field coincide. Hence we check whether the coefficients lie in the fraction
-  # field of cring if the fraction fields is implemented in GAP.
+  # field of cring if the fraction field is implemented in GAP.
   if crng = Integers then
     crng := Rationals;
   elif IsPolynomialRing(crng) then

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -814,6 +814,7 @@ function(f,R)
   crng := CoefficientsRing(R);
   inds := Set(IndeterminatesOfFunctionField(R),
                       x -> ExtRepPolynomialRatFun(x)[1][1]);
+
   # For an integral domain S, the function fields over S and over its fraction
   # field coincide. Hence we check whether the coefficients lie in the fraction
   # field of cring if the fraction field is implemented in GAP.

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -825,16 +825,6 @@ function(f,R)
     crng := FunctionField(CoefficientsRing(crng), crnginds);
   fi;
 
-  # For an integral domain S, the function fields over S and over its fraction
-  # field coincide. Hence we check whether the coefficients lie in the fraction
-  # field of cring if the fraction field is implemented in GAP.
-  if IsIntegers(crng) then
-    crng := Rationals;
-  elif IsPolynomialRing(crng) then
-    crnginds := IndeterminatesOfPolynomialRing(crng);
-    crng := FunctionField(CoefficientsRing(crng), crnginds);
-  fi;
-
   for ext in [ExtRepNumeratorRatFun(f),ExtRepDenominatorRatFun(f)] do
     # first check the indeterminates
     for exp  in ext{[1,3 .. Length(ext)-1]}  do

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -818,7 +818,7 @@ function(f,R)
   # For an integral domain S, the function fields over S and over its fraction
   # field coincide. Hence we check whether the coefficients lie in the fraction
   # field of cring if the fraction field is implemented in GAP.
-  if crng = Integers then
+  if IsIntegers(crng) then
     crng := Rationals;
   elif IsPolynomialRing(crng) then
     crnginds := IndeterminatesOfPolynomialRing(crng);

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -814,6 +814,16 @@ function(f,R)
   crng := CoefficientsRing(R);
   inds := Set(IndeterminatesOfFunctionField(R),
                       x -> ExtRepPolynomialRatFun(x)[1][1]);
+  
+  # For an integral domain S, the function fields over S and over its fraction
+  # field coincide. Hence we check whether the coefficients lie in the fraction
+  # field of cring if the fraction fields is implemented in GAP.
+  if crng = Integers then
+    crng := Rationals;
+  elif IsPolynomialRing(crng) then
+    crnginds := IndeterminatesOfPolynomialRing(crng);
+    crng := FunctionField(CoefficientsRing(crng), crnginds);
+  fi;
 
   # For an integral domain S, the function fields over S and over its fraction
   # field coincide. Hence we check whether the coefficients lie in the fraction

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -814,7 +814,6 @@ function(f,R)
   crng := CoefficientsRing(R);
   inds := Set(IndeterminatesOfFunctionField(R),
                       x -> ExtRepPolynomialRatFun(x)[1][1]);
-  
   # For an integral domain S, the function fields over S and over its fraction
   # field coincide. Hence we check whether the coefficients lie in the fraction
   # field of cring if the fraction field is implemented in GAP.

--- a/lib/ringpoly.gi
+++ b/lib/ringpoly.gi
@@ -808,12 +808,22 @@ end);
 InstallMethod(\in,"ratfun in fctfield",IsElmsColls,
     [IsRationalFunction,IsFunctionField],0,
 function(f,R)
-  local crng,inds,ext,exp,i;
+  local crng,inds,crnginds,ext,exp,i;
 
   # and the indeterminates and coefficients ring of <R>
   crng := CoefficientsRing(R);
   inds := Set(IndeterminatesOfFunctionField(R),
                       x -> ExtRepPolynomialRatFun(x)[1][1]);
+  
+  # For an integral domain S, the function fields over S and over its fraction
+  # field coincide. Hence we check whether the coefficients lie in the fraction
+  # field of cring if the fraction fields is implemented in GAP.
+  if crng = Integers then
+    crng := Rationals;
+  elif IsPolynomialRing(crng) then
+    crnginds := IndeterminatesOfPolynomialRing(crng);
+    crng := FunctionField(CoefficientsRing(crng), crnginds);
+  fi;
 
   for ext in [ExtRepNumeratorRatFun(f),ExtRepDenominatorRatFun(f)] do
     # first check the indeterminates

--- a/tst/testinstall/ringpoly.tst
+++ b/tst/testinstall/ringpoly.tst
@@ -1,4 +1,4 @@
-#@local R
+#@local R,P,F,fam,f
 gap> START_TEST("ringpoly.tst");
 
 # Commutativity and associativity
@@ -13,6 +13,20 @@ true
 # Integral ring
 gap> R := PolynomialRing(Integers, 2);;
 gap> HasIsIntegralRing(R) and IsIntegralRing(R);
+true
+
+# Membership
+gap> P := PolynomialRing(Rationals, 2);;
+gap> F := FunctionField(Rationals, 2);;
+gap> fam := FamilyObj(P.1);;
+gap> f := RationalFunctionByExtRep(fam, [ [], 1 ], [ [ 2, 1 ], 1/2 ]);;
+gap> f in F;
+true
+gap> P := PolynomialRing(Integers, 2);;
+gap> F := FunctionField(Integers, 2);;
+gap> fam := FamilyObj(P.1);;
+gap> f := RationalFunctionByExtRep(fam, [ [], 1 ], [ [ 2, 1 ], 1/2 ]);;
+gap> f in F;
 true
 
 #

--- a/tst/testinstall/ringpoly.tst
+++ b/tst/testinstall/ringpoly.tst
@@ -1,4 +1,4 @@
-#@local R,P,F,fam,f
+#@local R,P,F,fam,f,PP,PF
 gap> START_TEST("ringpoly.tst");
 
 # Commutativity and associativity
@@ -15,7 +15,7 @@ gap> R := PolynomialRing(Integers, 2);;
 gap> HasIsIntegralRing(R) and IsIntegralRing(R);
 true
 
-# Membership
+# Membership for function fields over rationals/integers
 gap> P := PolynomialRing(Rationals, 2);;
 gap> F := FunctionField(Rationals, 2);;
 gap> fam := FamilyObj(P.1);;
@@ -27,6 +27,23 @@ gap> F := FunctionField(Integers, 2);;
 gap> fam := FamilyObj(P.1);;
 gap> f := RationalFunctionByExtRep(fam, [ [], 1 ], [ [ 2, 1 ], 1/2 ]);;
 gap> f in F;
+true
+
+# Membership for function fields over polynomial rings
+gap> ITER_POLY_WARN := false;;
+gap> P := PolynomialRing(Rationals, 2);;
+gap> PP := PolynomialRing(P, 2);;
+gap> PF := FunctionField(P, 2);;
+gap> fam := FamilyObj(PP.1);;
+gap> f := RationalFunctionByExtRep(fam, [ [], One(P) ], [ [ 2, 1 ], 1/2*One(P) ]);;
+gap> f in PF;
+true
+gap> P := PolynomialRing(Integers, 2);;
+gap> PP := PolynomialRing(P, 2);;
+gap> PF := FunctionField(P, 2);;
+gap> fam := FamilyObj(PP.1);;
+gap> f := RationalFunctionByExtRep(fam, [ [], One(P) ], [ [ 2, 1 ], 1/2*One(P) ]);;
+gap> f in PF;
 true
 
 #


### PR DESCRIPTION
Fixes the inconsistency in #5993: For a function field `F` over a integral ring `C`, the membership test for `F` should check whether all coefficients lie in the fraction field of `C` (and not just in `C`). The reason is that `F` coincides with the function field over the fraction field of `C`.

Since it is not possible to obtain the fraction field from an integral ring in a direct way (I think), this uses a case distinction on `C`. If there are more integral rings `C` with the properties that
- The fraction field of `C` is implemented in GAP,
- Elements of `C` are also elements of the fraction field of `C`,

then they should be added to this case distinction. The only examples I could think of are `C = Integers` and `C` a polynomial ring. (Probably also ring extensions of `Integers`, but I am not sure how to implement that.)

If there is a better way to implement this than by this case distinction, please let me know.

The case that `C` is a polynomial ring is theoretical: Currently polynomial rings over integral rings do not know that they are integral rings and hence function fields over such polynomial rings cannot be constructed. Once #5996 is merged, I will add tests for this case as well.

## Text for release notes

none.
