### PR TITLE
Fix bug in `SpecialPcgs` that could corrupt group objects and cause nonsense outputs

### DIFF
--- a/lib/pcgsspec.gi
+++ b/lib/pcgsspec.gi
@@ -686,12 +686,7 @@ InstallOtherMethod( SpecialPcgs,
 function( group )
     local   spec;
 
-    if HasPcgs(group)  then
-        spec := SpecialPcgs( Pcgs( group ) );
-    else
-        spec := SpecialPcgs( AttributeValueNotSet( Pcgs, group ) );
-        SetPcgs( group, spec );
-    fi;
+    spec := SpecialPcgs( Pcgs( group ) );
     SetGroupOfPcgs (spec, group);
     return spec;
 end );

--- a/tst/testbugfix/2025-06-04-SpecialPcgs.tst
+++ b/tst/testbugfix/2025-06-04-SpecialPcgs.tst
@@ -1,0 +1,12 @@
+# Verify <https://github.com/gap-system/gap/issues/6000> is fixed
+gap> g1:= ExtraspecialGroup( 2^3, "+" );;
+gap> g2:= CyclicGroup( 4 );;
+gap> dp:= DirectProduct( g1, g2 );;
+gap> Centre( dp );;  # this line makes the difference
+gap> img:= Image( Embedding( dp, 2 ) );;
+gap> IsCyclic( img );
+true
+gap> List( GeneratorsOfGroup( img ), Order );
+[ 4, 2 ]
+gap> List( AllSubgroups( img ), Size );  # this gave wrong output
+[ 1, 2, 4 ]


### PR DESCRIPTION
This fixes the issue reported in #6000 but I am leaving that issue open because it would be good to understand *why* this corrupts things.

This was introduced by my commit 0c67c5af7e75fdbc5cf94628bcdd2d4141538dd5 from PR #3655.
