### PR TITLE
Ensure ˋDoubleCosets( G, U, V )ˋ checks that both ˋUˋand ˋVˋ are contained in ˋGˋ, and immediately throws an error if this is not the case

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -833,7 +833,7 @@ end);
 #end);
 
 InstallGlobalFunction( DoubleCosets, function(G,U,V)
-  if not IsSubset(G,U) and IsSubset(G,V) then
+  if not (IsSubset(G,U) and IsSubset(G,V)) then
     Error("not contained");
   fi;
   return DoubleCosetsNC(G,U,V);

--- a/tst/testbugfix/2025-06-11-DoubleCosets-Error.tst
+++ b/tst/testbugfix/2025-06-11-DoubleCosets-Error.tst
@@ -1,0 +1,7 @@
+gap> S := SymmetricGroup( 4 );; A := AlternatingGroup( 4 );;
+gap> DoubleCosets( A, S, A );
+Error, not contained
+gap> DoubleCosets( A, A, S );
+Error, not contained
+gap> DoubleCosets( A, S, S );
+Error, not contained


### PR DESCRIPTION
## Text for release notes
see title

## Further details
Currently, `DoubleCosets( G, U, V )` only throws an error when `U` is not a subset of `G` but `V` is.
```
gap> S := SymmetricGroup( 4 );; A := AlternatingGroup( 4 );;
gap> DoubleCosets( A, S, A );
Error, not contained at /opt/gap/4.14.0/lib/csetgrp.gi:837 called from
<function "DoubleCosets">( <arguments> )
[...]
gap> DoubleCosets( A, A, S );
Error, <H> must be contained in <G> at /opt/gap/4.14.0/lib/grp.gi:2872 called from
oper( super, sub ) at /opt/gap/4.14.0/lib/domain.gd:452 called from
Index( G, a ) at /opt/gap/4.14.0/lib/csetgrp.gi:1017 called from
DoubleCosetRepsAndSizes( G, U, V ) at /opt/gap/4.14.0/lib/csetgrp.gi:1713 called from
DoubleCosetsNC( G, U, V ) at /opt/gap/4.14.0/lib/csetgrp.gi:839 called from
<function "DoubleCosets">( <arguments> )
[...]
gap> DoubleCosets( A, S, S );
Error, <H> must be contained in <G> at /opt/gap/4.14.0/lib/grp.gi:2872 called from
oper( super, sub ) at /opt/gap/4.14.0/lib/domain.gd:452 called from
Index( G, a ) at /opt/gap/4.14.0/lib/csetgrp.gi:1017 called from
DoubleCosetRepsAndSizes( G, U, V ) at /opt/gap/4.14.0/lib/csetgrp.gi:1713 called from
DoubleCosetsNC( G, U, V ) at /opt/gap/4.14.0/lib/csetgrp.gi:839 called from
<function "DoubleCosets">( <arguments> )
[...]
```
After this PR, `DoubleCosets( G, U, V )` should throw an error when either `U` or `V` is not a subset of `G`.
```
gap> S := SymmetricGroup( 4 );; A := AlternatingGroup( 4 );;
gap> DoubleCosets( A, S, A );
Error, not contained at /opt/gap/4.14.0/lib/csetgrp.gi:837 called from
<function "DoubleCosets">( <arguments> )
[...]
gap> DoubleCosets( A, A, S );
Error, not contained at /opt/gap/4.14.0/lib/csetgrp.gi:837 called from
<function "DoubleCosets">( <arguments> )
[...]
gap> DoubleCosets( A, S, S );
Error, not contained at /opt/gap/4.14.0/lib/csetgrp.gi:837 called from
<function "DoubleCosets">( <arguments> )
[...]
```