### PR TITLE
Faster `IsFinite` for rational matrix groups (and hence for matrix groups over cyclotomics as well)

### DIFF
--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -1587,6 +1587,23 @@
   <other type="fjournal">Archiv der Mathematik</other>
 </article></entry>
 
+<entry id="DFO13"><article>
+  <author>
+    <name><first>A. S.</first><last>Detinko</last></name>
+    <name><first>D. L.</first><last>Flannery</last></name>
+    <name><first>E. A.</first><last>O'Brien</last></name>
+  </author>
+  <title>Recognizing finite matrix groups over infinite fields</title>
+  <journal><value key="jsymc"/></journal>
+  <year>2013</year>
+  <volume>50</volume>
+  <pages>100&ndash;109</pages>
+  <issn>0747-7171</issn>
+  <other type="fjournal">Journal of Symbolic Computation</other>
+  <url>https://doi.org/10.1016/j.jsc.2012.04.002</url>
+  <other type="doi">10.1016/j.jsc.2012.04.002</other>
+</article></entry>
+
 <entry id="Dix67"><article>
   <author>
     <name><first>John D.</first><last>Dixon</last></name>

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -265,7 +265,7 @@ InstallMethod( IsFinite,
     "cyclotomic matrix group",
     [ IsCyclotomicMatrixGroup ],
 function( G )
-
+    # The code below is based on the algorithm described in [DFO13]
     local badPrimes, n, g, FindPrimesInMatDenominators, p, e, H, phi, gens, rels;
 
     # if not rational, use the nice monomorphism into a rational matrix group

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -266,7 +266,7 @@ InstallMethod( IsFinite,
     [ IsCyclotomicMatrixGroup ],
 function( G )
     # The code below is based on the algorithm described in [DFO13]
-    local badPrimes, n, g, FindPrimesInMatDenominators, p, e, H, phi, gens, rels;
+    local badPrimes, n, g, FindPrimesInMatDenominators, p, e, H, phi, gens, rels, nice;
 
     # if not rational, use the nice monomorphism into a rational matrix group
     if not IsRationalMatrixGroup( G ) then
@@ -319,9 +319,12 @@ function( G )
     fi;
 
     # set as a nice monomorphism
-    phi := GroupHomomorphismByFunction(G, H,  x -> x * e);
-    SetNiceMonomorphism(G, phi);
+    gens := GeneratorsOfGroup(Range(phi));
+    nice := GroupHomomorphismByFunction(G, H,  x -> x * e,
+        y -> MappedWord(phi(y), gens, GeneratorsOfGroup(G)));
+    SetNiceMonomorphism(G, nice);
     SetNiceObject(G, H);
+    SetIsHandledByNiceMonomorphism(G, true);
     return true;
 end );
 

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -28,7 +28,7 @@ InstallMethod( IsIntegerMatrixGroup, [ IsCyclotomicMatrixGroup ],
     function( G )
     local gen;
     gen := GeneratorsOfGroup( G );
-    return ForAll( Flat( gen ), IsInt ) and
+    return ForAll( gen, r -> ForAll( r, IsInt ) ) and
            ForAll( gen, g -> AbsInt( DeterminantMat( g ) ) = 1 );
     end
 );
@@ -320,8 +320,19 @@ function( G )
 
     # set as a nice monomorphism
     gens := GeneratorsOfGroup(Range(phi));
-    nice := GroupHomomorphismByFunction(G, H,  x -> x * e,
-        y -> MappedWord(phi(y), gens, GeneratorsOfGroup(G)));
+    nice := GroupHomomorphismByFunction(G, H,
+              function(x)
+                  if ValueOption("actioncanfail")=true then
+                    if not ForAll( x, r -> ForAll( r, IsInt ) ) then
+                      return fail;
+                    fi;
+                  fi;
+                  return x * e;
+              end,
+              function(y)
+                return MappedWord(phi(y), gens, GeneratorsOfGroup(G));
+              end
+            );
     SetNiceMonomorphism(G, nice);
     SetNiceObject(G, H);
     SetIsHandledByNiceMonomorphism(G, true);

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -240,6 +240,23 @@ function( G )
 
 end );
 
+
+BindGlobal("MinkowskiMultiple", function(n)
+    local res;
+    if n <= 0 then
+        Error("<n> must be a positive integer");
+    fi;
+    res := 2;
+    for n in [n,n-1..2] do
+        if IsOddInt(n) then
+            res := res * 2;
+        else
+            res := res * DenominatorRat(Bernoulli(n)/n);
+        fi;
+    od;
+    return res;
+end);
+
 #############################################################################
 ##
 #M  IsFinite( G ) . . . . . . . . . . .  IsFinite for cyclotomic matrix group
@@ -287,8 +304,10 @@ function( G )
     e := One(GF(p));
     H := Group( GeneratorsOfGroup( G ) * e );
 
-    # TODO: could speed up things by checking Minkowski bounds here to
-    # immediately reject some G as infinite -- at least for small enough n
+    # check Minkowski bounds here to immediately reject some G as infinite
+    if MinkowskiMultiple(n) mod Size(H) <> 0 then
+        return false;
+    fi;
 
     # evaluate relators
     phi := IsomorphismFpGroupByGenerators(H, GeneratorsOfGroup( H ));

--- a/lib/morpheus.gd
+++ b/lib/morpheus.gd
@@ -533,7 +533,7 @@ DeclareGlobalFunction("IsomorphismSimpleGroups");
 ##  gap> h:=Group((1,2,3),(1,2));
 ##  Group([ (1,2,3), (1,2) ])
 ##  gap> quo:=GQuotients(g,h);
-##  [ [ (1,2,3,4), (2,4,3) ] -> [ (2,3), (1,2,3) ] ]
+##  [ [ (2,4), (1,4,3) ] -> [ (2,3), (1,2,3) ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -421,8 +421,6 @@ true
 
 # set NiceMonomorphism by hand (as suggested in the Tutorial)
 gap> g:= Group( [ [ [ 0, 1 ], [ 1, 0 ] ] ] );;
-gap> IsHandledByNiceMonomorphism( g );
-true
 gap> vecs:= Orbit( g, [ 1, 0 ], OnRight );;
 gap> hom:= ActionHomomorphism( g, vecs, OnRight );;
 gap> HasNiceMonomorphism( g );


### PR DESCRIPTION
Resolves #6006

Implements the algorithm from Detinko, Flannery, O'Brien "Recognizing finite matrix groups over infinite fields", Section 4.2, which we also have in OSCAR (only in OSCAR we also do this directly for matrix groups over number fields instead of blowing up the matrices).

For me the previous problematic example now only takes 5 seconds.

TODO:
- [x] add code comment pointing out the source for the algorithm
- [x] also add it to the GAP .bib
- [x] ensure the code is tested (let's look at CodeCov output, I assume it already gets tested by existing tests)
- [x] perhaps add in something like the `_minkowski_multiple` test in OSCAR (at least for small dimensions) though this will only matter for infinite inputs
- [ ] maybe also hook this up via the `MayBeHandledByNiceMonomorphism` mechanism so we also use it in other situations?
- [x] enhance the nice monomorphism to be able to compute preimages