### PR TITLE
Fix build issues when compiling GAP with GCC 15

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -161,12 +161,7 @@ typedef Bag Obj;
 **
 **  'ObjFunc' is the type of a function returning an object.
 */
-#pragma GCC diagnostic push
-#ifndef __cplusplus
-#pragma GCC diagnostic ignored "-Wstrict-prototypes"
-#endif
-typedef Obj (* ObjFunc) (/*arguments*/);
-#pragma GCC diagnostic pop
+typedef void * ObjFunc;
 
 typedef Obj (* ObjFunc_0ARGS) (Obj self);
 typedef Obj (* ObjFunc_1ARGS) (Obj self, Obj a1);


### PR DESCRIPTION
GCC 15/-std=c23:

```
src/bool.c:332:22: error: passing argument 1 of 'InitHandlerFunc' from incompatible pointer type [-Wincompatible-pointer-types]
  332 |     InitHandlerFunc( ReturnTrue1, "src/bool.c:ReturnTrue1" );
[   19s] src/calls.h:416:30: note: expected ‘ObjFunc’ {aka ‘struct OpaqueBag * (*)(void)’} but argument is of type ‘struct OpaqueBag * (*)(struct OpaqueBag *, struct OpaqueBag *)’
```

Declarators with unspecified arguments `int f();` got socially deprecated with C89; since then, one can write `f(void)` for actual zero-argument functions, and `f(T, ...)` for varargs functions.

C23 finally yanked declarators with unspecified arguments.

Different pointer types may have different size. So you can't have one pointer type for "all kinds of functions" in plain C. Nor C++ for that matter; some use of templates/RTTI would be necessary (possibly hidden in something like std::any, but still).

Or rely on platform-specific extensions, e.g. POSIX>=2001 guarantees that sizeof(void*) >= sizeof(any function pointer). This is what this patch does.

Fixes: #5857 #6009

## Text for release notes

`GCC 15 support`