### PR TITLE
Add an `Irr` method for natural alternating groups, using the generic character table

### DIFF
--- a/lib/ctblfuns.gd
+++ b/lib/ctblfuns.gd
@@ -1472,7 +1472,7 @@ DeclareAttribute( "DegreeOfCharacter", IsClassFunction );
 ##  gap> der:= DerivedSubgroup( S4 );
 ##  Alt( [ 1 .. 4 ] )
 ##  gap> List( Irr( der ), chi -> InertiaSubgroup( S4, chi ) );
-##  [ S4, Alt( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ), S4 ]
+##  [ S4, S4, Alt( [ 1 .. 4 ] ), Alt( [ 1 .. 4 ] ) ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/ctblmono.gd
+++ b/lib/ctblmono.gd
@@ -405,7 +405,7 @@ DeclareProperty( "IsQuasiPrimitive", IsClassFunction );
 ##  >          TestInducedFromNormalSubgroup );
 ##  [ rec( comment := "linear character", isInduced := false ),
 ##    rec( character := Character( CharacterTable( Alt( [ 1 .. 4 ] ) ),
-##          [ 1, 1, E(3)^2, E(3) ] ),
+##          [ 1, 1, E(3), E(3)^2 ] ),
 ##        comment := "induced from component '.character'",
 ##        isInduced := true ),
 ##    rec( comment := "all maximal normal subgroups checked",

--- a/lib/ctblsymm.gi
+++ b/lib/ctblsymm.gi
@@ -1241,16 +1241,13 @@ InstallMethod( Irr,
 
     # Compute the irreducibles.
     irr:= List( gentbl.matrix( deg ), i -> Character( cG, i{ perm } ) );
-    MakeImmutable( irr );
-    SetIrr( cG, irr );
+    SetIrr( cG, MakeImmutable( irr ) );
 
     # Store the class and character parameters.
     cp:= List( cp, x -> [ 1, x ] );
-    MakeImmutable( cp );
-    SetCharacterParameters( cG, cp );
+    SetCharacterParameters( cG, MakeImmutable( cp ) );
     cp:= cp{ perm };
-    MakeImmutable( cp );
-    SetClassParameters( cG, cp );
+    SetClassParameters( cG, MakeImmutable( cp ) );
 
     # Compute and store the power maps.
     pow:= ComputedPowerMaps( cG );
@@ -1265,13 +1262,13 @@ InstallMethod( Irr,
     # Compute and store centralizer orders and representative orders.
     if not HasSizesCentralizers( cG ) then
       SetSizesCentralizers( cG,
-          List( cp, x -> gentbl.centralizers[1]( deg, x[2] ) ) );
+          MakeImmutable( List( cp, x -> gentbl.centralizers[1]( deg, x[2] ) ) ) );
     fi;
     if not HasOrdersClassRepresentatives( cG ) then
       SetOrdersClassRepresentatives( cG,
-          List( cp, x -> gentbl.orders[1]( deg, x[2] ) ) );
+          MakeImmutable( List( cp, x -> gentbl.orders[1]( deg, x[2] ) ) ) );
     fi;
-    SetInfoText( cG, Concatenation( "computed using ", gentbl.text ) );
+    SetInfoText( cG, MakeImmutable( Concatenation( "computed using ", gentbl.text ) ) );
 
     # Return the irreducibles.
     return irr;
@@ -1295,10 +1292,8 @@ InstallMethod( Irr,
     "ordinary characters for natural alternating group",
     [ IsNaturalAlternatingGroup, IsZeroCyc ],
     function( G, zero )
-    local gentbl, dom, deg, cG, whole, cp, perm, i, pos, charparas, irr, pow,
-          known, inv;
+    local dom, deg, cG, gentbl, whole, cp, perm, i, pos, irr, pow, known, inv;
 
-    gentbl:= CharTableAlternating;
     dom:= MovedPoints( G );
     deg:= Length( dom );
     if deg = 0 then
@@ -1308,12 +1303,13 @@ InstallMethod( Irr,
     cG:= CharacterTable( G );
 
     # Compute the character table information.
+    gentbl:= CharTableAlternating;
     whole:= gentbl.wholetable( gentbl, deg );
 
     # Compute the correspondence of classes.
     cp:= List( whole.ClassParameters, x -> x[2] );
     perm:= [];
-    for i in ConjugacyClasses( G ) do
+    for i in ConjugacyClasses( cG ) do
       i:= List( Orbits( SubgroupNC( G, [ Representative(i) ] ), dom ),
                 Length );
       Sort( i );
@@ -1330,16 +1326,12 @@ InstallMethod( Irr,
     od;
 
     # Adjust the irreducibles.
-    cp:= cp{ perm };
-    charparas:= gentbl.charparam[1]( deg );
     irr:= List( whole.Irr, x -> Character( cG, x{ perm } ) );
-    MakeImmutable( irr );
-    SetIrr( cG, irr );
+    SetIrr( cG, MakeImmutable( irr ) );
 
     # Adjust and store the class and character parameters.
-    cp:= whole.ClassParameters{ perm };
-    SetClassParameters( cG, MakeImmutable( cp ) );
-    SetCharacterParameters( cG, MakeImmutable( whole.ClassParameters ) );
+    SetClassParameters( cG, MakeImmutable( whole.ClassParameters{ perm } ) );
+    SetCharacterParameters( cG, MakeImmutable( whole.CharacterParameters ) );
 
     # Adjust and store the power maps.
     pow:= ComputedPowerMaps( cG );

--- a/lib/ctblsymm.gi
+++ b/lib/ctblsymm.gi
@@ -1285,7 +1285,7 @@ end );
 ##  (Note that the pairs of classes obtained by splitting classes of the
 ##  symmetric group can be chosen independently.)
 ##
-##  Note that we do *not* call `CharacterTable( "Symmetric", <n> )' directly
+##  Note that we do *not* call `CharacterTable( "Alternating", <n> )' directly
 ##  because the character table library may be not installed.
 ##
 InstallMethod( Irr,

--- a/lib/gpprmsya.gi
+++ b/lib/gpprmsya.gi
@@ -216,8 +216,7 @@ end);
 
 InstallMethod( ConjugacyClasses,
     "alternating",
-    true,
-    [ IsNaturalAlternatingGroup ], 0,
+    [ IsNaturalAlternatingGroup ], OVERRIDENICE,
 function ( G )
     local   classes,    # conjugacy classes of <G>, result
             prt,        # partition of <G>
@@ -1720,8 +1719,7 @@ end);
 
 InstallMethod( ConjugacyClasses,
     "symmetric",
-    true,
-    [ IsNaturalSymmetricGroup ], 0,
+    [ IsNaturalSymmetricGroup ], OVERRIDENICE,
 function ( G )
     local   classes,    # conjugacy classes of <G>, result
             prt,        # partition of <G>

--- a/tst/testinstall/ctblmono.tst
+++ b/tst/testinstall/ctblmono.tst
@@ -61,7 +61,7 @@ gap> List( Irr( S4 ){ [ 1, 3, 4 ] },
 >          TestInducedFromNormalSubgroup );
 [ rec( comment := "linear character", isInduced := false ), 
   rec( character := Character( CharacterTable( Alt( [ 1 .. 4 ] ) ),
-      [ 1, 1, E(3)^2, E(3) ] ), 
+      [ 1, 1, E(3), E(3)^2 ] ), 
       comment := "induced from component '.character'", isInduced := true ), 
   rec( comment := "all maximal normal subgroups checked", isInduced := false 
      ) ]

--- a/tst/teststandard/ctblsymm.tst
+++ b/tst/teststandard/ctblsymm.tst
@@ -1,3 +1,5 @@
+#@local c3, n, wr, irr, betas, i, G, reps, t, G1, t1, charparam1, classparam1
+#@local pi, G2, t2, tr
 gap> START_TEST( "ctblsymm.tst" );
 
 #
@@ -16,6 +18,38 @@ gap> for i in [ 1 .. Length( irr ) ] do
 >    od;
 gap> Length(Irr(CharacterTable("symmetric",12)));
 77
+
+#
+gap> G:= SymmetricGroup( 5 );;
+gap> reps:= [(),(1,2),(1,2)(3,4),(1,2,3),(1,2,3)(4,5),(1,2,3,4),(1,2,3,4,5)];;
+gap> SetConjugacyClasses( G,
+>        List( Permuted( reps, (4,5)(6,7) ), x -> ConjugacyClass( G, x ) ) );
+gap> t:= CharacterTable( G );;  Irr( t );;
+gap> Irr(t)[7] = TrivialCharacter( t );
+true
+gap> CharacterParameters( t )[7] = [ 1, [ 5 ] ];
+true
+
+# use the generic character table for natural alternating groups
+gap> G1:= AlternatingGroup(7);;
+gap> t1:= CharacterTable( G1 );;  Irr( t1 );;
+gap> charparam1:= CharacterParameters( t1 );;
+gap> classparam1:= ClassParameters( t1 );;
+gap> reps:= List( ConjugacyClasses( t1 ), Representative );;
+gap> pi:= (5,6,7);;
+gap> G2:= AlternatingGroup(7);;
+gap> SetConjugacyClasses( G2,
+>        List( Permuted( reps, pi ), x -> ConjugacyClass( G1, x ) ) );
+gap> t2:= CharacterTable( G2 );;  Irr( t2 );;
+gap> CharacterParameters( t2 ) = charparam1;
+true
+gap> ClassParameters( t2 ) = Permuted( classparam1, pi );
+true
+gap> tr:= TransformingPermutationsCharacterTables( t1, t2 );;
+gap> tr.columns = pi;
+true
+gap> tr.rows = ();
+true
 
 #
 gap> STOP_TEST( "ctblsymm.tst" );


### PR DESCRIPTION
- add an `Irr` method that uses the `wholetable` function of the generic character table of alternating groups
(thus this method is quite different from the one for symmetric groups),
- fix a bug in the `Irr` method for natural symmetric groups
(this bug was relevant only if one forced a non-natural ordering of the conjugacy classes before calling this `Irr` method; in this sense, it was a rather hypothetical bug),
- rank up the special `ConjugacyClasses` methods for alternating and symmetric groups, such that these methods have a chance to get called.

resolves #5725