### PR TITLE
Turn `IsUFDFamily` into a category; set `One` & `Zero` of free magma ring families

### DIFF
--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -131,7 +131,7 @@ function(f,p,check)
   od;
   fam!.mulrange:=MakeImmutable(red);
 
-  SetIsUFDFamily(fam,true);
+  SetFilterObj(fam,IsUFDFamily);
   SetCoefficientsFamily(fam,FamilyObj(One(f)));
 
   # and set one and zero

--- a/lib/arith.gd
+++ b/lib/arith.gd
@@ -2066,7 +2066,7 @@ DeclareProperty( "IsSkewFieldFamily", IsFamily );
 #P  IsUFDFamily( <family> )
 ##
 ##  <ManSection>
-##  <Prop Name="IsUFDFamily" Arg='family'/>
+##  <Filt Name="IsUFDFamily" Arg='family'/>
 ##
 ##  <Description>
 ##  the family <A>family</A> is at least a commutative ring-with-one,
@@ -2075,7 +2075,20 @@ DeclareProperty( "IsSkewFieldFamily", IsFamily );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareProperty( "IsUFDFamily", IsFamily );
+DeclareCategory( "IsUFDFamily", IsFamily );
+
+# IsUFDFamily used to be defined as a property, and some packages are using
+# SetIsUFDFamily. For backwards compatibility, we provide a replacement
+BIND_GLOBAL("SetIsUFDFamily", function(fam, val)
+    if val then
+      SetFilterObj(fam, IsUFDFamily);
+    elif IsUFDFamily(fam) then
+      Error("cannot remove filter IsUFDFamily");
+      # Actually, we could use ResetFilterObj, but dropping a filter later on
+      # can result in all kinds of problematic situations, so it is better to
+      # avoid this.
+    fi;
+end);
 
 
 #############################################################################

--- a/lib/cyclotom.g
+++ b/lib/cyclotom.g
@@ -372,7 +372,7 @@ SetCharacteristic( CyclotomicsFamily, 0 );
 ##
 #v  IsUFDFamily( CyclotomicsFamily )
 ##
-SetIsUFDFamily( CyclotomicsFamily, true );
+SetFilterObj( CyclotomicsFamily, IsUFDFamily );
 
 
 #############################################################################

--- a/lib/ffe.g
+++ b/lib/ffe.g
@@ -37,7 +37,7 @@ BIND_GLOBAL( "TYPE_FFE", MemoizePosIntFunction(
         local fam;
         fam:= NewFamily( "FFEFamily",
         IS_FFE,CanEasilySortElements,CanEasilySortElements );
-        SetIsUFDFamily( fam, true );
+        SetFilterObj( fam, IsUFDFamily );
         SetCharacteristic( fam, p );
         return NewType( fam, IS_FFE and IsInternalRep and HasDegreeFFE);
     end, rec(flush := false) ));

--- a/lib/ffe.gi
+++ b/lib/ffe.gi
@@ -189,7 +189,7 @@ InstallGlobalFunction( FFEFamily, function( p )
         SetZero( F, ZmodnZObj( F, 0 ) );
 
         # The whole family is a unique factorisation domain.
-        SetIsUFDFamily( F, true );
+        SetFilterObj( F, IsUFDFamily );
 
         return F;
 

--- a/lib/ieee754.g
+++ b/lib/ieee754.g
@@ -144,7 +144,7 @@ BindGlobal("IEEE754FLOAT", rec(
     creator := MACFLOAT_STRING,
     eager := 'l'));
 
-SetIsUFDFamily(IEEE754FloatsFamily,true);
+SetFilterObj(IEEE754FloatsFamily, IsUFDFamily);
 SetZero(IEEE754FloatsFamily, NewFloat(IsIEEE754FloatRep,0));
 SetOne(IEEE754FloatsFamily, NewFloat(IsIEEE754FloatRep,0));
 

--- a/lib/mgmring.gi
+++ b/lib/mgmring.gi
@@ -796,6 +796,8 @@ InstallGlobalFunction( FreeMagmaRing, function( R, M )
                 [ ElementOfMagmaRing( F, zero, [ one ], [ One( M ) ] ) ] );
       fi;
 
+      SetOne(F, One(RM));
+
     else
 
       SetGeneratorsOfLeftOperatorRing( RM,
@@ -803,6 +805,7 @@ InstallGlobalFunction( FreeMagmaRing, function( R, M )
                 x -> ElementOfMagmaRing( F, zero, [ one ], [ x ] ) ) );
 
     fi;
+    SetZero(F, Zero(RM));
 
     # Return the ring.
     return RM;

--- a/lib/ringsc.gi
+++ b/lib/ringsc.gi
@@ -403,8 +403,6 @@ InstallGlobalFunction( RingByStructureConstants, function( arg )
         NewType( Fam, IsSCRingObj and IsDenseCoeffVectorRep );
 
     SetCoefficientsFamily( Fam, ElementsFamily( FamilyObj( Integers ) ) );
-    # temporary
-    SetIsUFDFamily(Fam,false);
 
     # Make the generators and the ring.
     SetZero( Fam, ObjByExtRep( Fam, List( [ 1 .. n ], x -> 0 ) ) );

--- a/lib/zmodnz.gi
+++ b/lib/zmodnz.gi
@@ -1106,8 +1106,7 @@ InstallGlobalFunction( ZmodnZ, function( n )
     # Store the objects type.
     F!.typeOfZmodnZObj:= NewType( F, IsZmodnZObjNonprime and IsModulusRep );
 
-    # as n is no prime, the family is no UFD
-    SetIsUFDFamily(F,false);
+    # as n is no prime, the family is no UFD, so we don't add IsUFDFamily as a filter
 
     # Make the domain.
     R:= RingWithOneByGenerators( [ ZmodnZObj( F, 1 ) ] );


### PR DESCRIPTION
Resolves #5998 in so far as that the error there is fixed; and then the next error this reveals. However, the example there still will lead to an error because our polynomial rings expect a one element and a free magma doesn't have one. But it works if we use a free magma with one instead:
```
gap> F := FreeMagmaWithOne(2);
gap> ZF := FreeMagmaRing(Integers, F);
gap> PolynomialRing(ZF, 2);
<magma>[x_1,x_2]
```
I can add this as a test case but I'd like to first get some sanity checks / feedback from @ThomasBreuer and @TWiedemann 