### PR TITLE
Clean up non-portable long family types

### DIFF
--- a/etc/ffgen.c
+++ b/etc/ffgen.c
@@ -18,7 +18,7 @@ unsigned      max_deg;
 
 void make_primes()
 {
-    unsigned long i, j;
+    unsigned int i, j;
     for (i = 2; i <= MAX_FF; i++)
         is_prime[i] = 1;
     for (i = 2; i * i <= MAX_FF; i++) {
@@ -31,7 +31,7 @@ void make_primes()
 
 void make_ff()
 {
-    unsigned long i, j, d;
+    unsigned int i, j, d;
     for (i = 2; i <= MAX_FF; i++) {
         if (is_prime[i]) {
             for (j = i, d = 1; j <= MAX_FF; j *= i, d++) {

--- a/src/blister.c
+++ b/src/blister.c
@@ -33,7 +33,7 @@
 **
 **  The  first  entry is  the logical  length of the list,  represented as  a
 **  {\GAP} immediate integer.  The other entries are blocks, represented as C
-**  unsigned  long integer.   Each  block corresponds  to  <n>  (usually  32)
+**  uintptr_t integers.   Each  block corresponds  to  <n>  (usually  32)
 **  elements of the list.  The <j>-th bit (the bit corresponding to '2\^<j>')
 **  in  the <i>-th block  is 1 if  the element  '<list>[BIPEB*<i>+<j>+1]'  it
 **  'true'  and '0' if  it  is 'false'.  If the logical length of the boolean
@@ -268,8 +268,8 @@ static Obj ShallowCopyBlist(Obj list)
 */
 static Int EqBlist(Obj listL, Obj listR)
 {
-    long                lenL;           // length of the left operand
-    long                lenR;           // length of the right operand
+    Int                 lenL;           // length of the left operand
+    Int                 lenR;           // length of the right operand
     const UInt *        ptrL;           // pointer to the left operand
     const UInt *        ptrR;           // pointer to the right operand
     UInt                i;              // loop variable

--- a/src/finfield_conway.h
+++ b/src/finfield_conway.h
@@ -22,8 +22,8 @@
 **  entries are the  proper prime powers,  odd entries are the  corresponding
 **  conway polynomials.
 */
-extern const unsigned long PolsFF[]; // FIXME: should be static, but cvec uses it
-const unsigned long PolsFF[] = {
+extern const unsigned int PolsFF[]; // FIXME: should be static, but cvec uses it
+const unsigned int PolsFF[] = {
        4,  1 +2,
        8,  1 +2,
       16,  1 +2,

--- a/src/integer.c
+++ b/src/integer.c
@@ -2614,8 +2614,8 @@ static Obj FuncIS_PROBAB_PRIME_INT(Obj self, Obj n, Obj reps)
 **  InitRandomMT.
 **
 **  Implementation details are a bit tricky to obtain the same random
-**  integers on 32 bit and 64 bit machines (which have different long
-**  integer digit lengths and different ranges of small integers).
+**  integers on 32 bit and 64 bit machines (which have different ranges of
+**  integers).
 **
 */
 static Obj FuncRandomIntegerMT(Obj self, Obj mtstr, Obj nrbits)

--- a/src/macfloat.h
+++ b/src/macfloat.h
@@ -15,19 +15,11 @@
 
 #include "objects.h"
 
-#ifdef VERY_LONG_DOUBLES
-typedef long double /* __float128 */ Double;
-#define PRINTFDIGITS 20
-#define PRINTFFORMAT "Lg"
-#define STRTOD strtold
-#define MATH(name) name##l
-#else
 typedef double Double;
 #define PRINTFDIGITS 16
 #define PRINTFFORMAT "g"
 #define STRTOD strtod
 #define MATH(name) name
-#endif
 
 Double VAL_MACFLOAT(Obj obj);
 void SET_VAL_MACFLOAT(Obj obj, Double val);

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -28,7 +28,7 @@ enum {
 *V  Symbol  . . . . . . . . . . . . . . . . .  current symbol read from input
 **
 **  The  variable 'Symbol' contains the current  symbol read from  the input.
-**  It is represented as an unsigned long integer.
+**  It is represented as an uintptr_t.
 **
 **  The possible values for 'Symbol' are defined in the  definition  file  of
 **  this package as follows:
@@ -146,7 +146,7 @@ enum SCANNER_SYMBOLS {
 **  between members in one class.  And now  every symbol class, many of which
 **  contain   just  one  symbol,  has exactly  one   of  the  remaining most
 **  significant 29  bits  set.   Thus   sets  of symbols  are  represented as
-**  unsigned long integers, which is typedef-ed to 'TypSymbolSet'.
+**  uintptr_t, which is typedef-ed to 'TypSymbolSet'.
 **
 **  The classes are as follows, all other symbols are in a class themself:
 **      identifiers, IsBound, Unbind, Info, Assert


### PR DESCRIPTION
As a followup of PR #6014, we are cleaning up long family types (including long and long double) that has different sizes in MinGW and Linux gcc. This clean up includes all uses outside hpc, extern that are not part of some print statements.

All of these uses of long are benign, except for the blister case and some of the inaccurate comments. The blister changes are manually tested in gap by adding print statement on the list lengths and comparing huge boolean lists of size above 2^33.
