### PR TITLE
Disabling incompatible pointer types in MinGW

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -231,6 +231,8 @@ SYSINFO_CFLAGS += $(PTHREAD_CFLAGS)
 
 GAP_CFLAGS += $(JULIA_CFLAGS) # not added to SYSINFO_CFLAGS
 
+GAP_CFLAGS += -Wno-incompatible-pointer-types
+
 # Finally add user provided CFLAGS
 GAP_CFLAGS += $(CFLAGS)
 SYSINFO_CFLAGS += $(CFLAGS)


### PR DESCRIPTION
The following `ObjFunc` definition in `common.h`:
```
typedef Obj(* ObjFunc) (/*arguments*/);
```
seems to be interpreted differently between Linux gcc and Windows MinGW. In Linux gcc, it is interpreted as a pointer to a function that can accept any number of arguments. Meanwhile, in MinGW it is interpreted as strictly a pointer to a function with no argument. Unfortunately, I couldn't find an alternative for this that works in both platform so I am disabling this error.

An alternative, that will be more intrusive (but has an advantage that we don't globally turn off incompatible-pointer-types), is to make the kind of changes, for example in `calls.h` from
```
void InitHandlerFunc(ObjFunc hdlr, const Char * cookie);
```
to
```
void InitHandlerFunc_hidden(ObjFunc hdlr, const Char * cookie);
#define InitHandlerFunc(hdlr,cookie) InitHandlerFunc_hidden((ObjFunc)hdlr,cookie)
```

Specifically, without this commit we will have the following error in MinGW:
```
   C       src/bool.c => build/obj/src/bool.c.o
src/bool.c: In function 'InitKernel':
src/bool.c:332:22: error: passing argument 1 of 'InitHandlerFunc' from incompatible pointer type [-Wincompatible-pointer-types]
  332 |     InitHandlerFunc( ReturnTrue1, "src/bool.c:ReturnTrue1" );
      |                      ^~~~~~~~~~~
      |                      |
      |                      struct OpaqueBag * (*)(struct OpaqueBag *, struct OpaqueBag *)
In file included from src/bool.c:20:
src/calls.h:416:30: note: expected 'ObjFunc' {aka 'struct OpaqueBag * (*)(void)'} but argument is of type 'struct OpaqueBag * (*)(struct OpaqueBag *, struct OpaqueBag *)'
  416 | void InitHandlerFunc(ObjFunc hdlr, const Char * cookie);
      |                      ~~~~~~~~^~~~
src/bool.c:172:12: note: 'ReturnTrue1' declared here
  172 | static Obj ReturnTrue1(Obj self, Obj val1)
      |            ^~~~~~~~~~~
In file included from src/gasman.h:39,
                 from src/objects.h:20,
                 from src/bool.h:16,
                 from src/bool.c:17:
src/common.h:168:16: note: 'ObjFunc' declared here
  168 | typedef Obj (* ObjFunc) (/*arguments*/);
      |                ^~~~~~~
```

I like the more intrusive renaming option more than this commit because we can keep this incompatible-pointer-type check for everything else. But before doing that, may I know your thoughts on this? @fingolfin 

This PR will help #4157.