### PR TITLE
CI: better support for PRs made from main GAP repository

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,14 +10,18 @@ on:
         type: boolean
   pull_request:
   push:
+    branches:
+      - 'master'
+      - 'stable-*'
+    tags: '*'
   schedule:
     # Every day at 2:30 AM UTC
     - cron: '30 2 * * *'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # requests, we limit to 1 concurrent job, but for the default repository branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_name != github.event.repository.default_branch || github.run_number }}
   # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
@@ -30,8 +34,6 @@ env:
 jobs:
   test:
     name: ${{ matrix.test-suites }} - ${{ matrix.extra }} - ${{ matrix.os }}
-    # Don't run this twice on PRs for branches pushed to the same repository
-    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
-      - "stable-*.*"
+      - 'master'
+      - 'stable-*'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
-      - "stable-*.*"
+      - 'master'
+      - 'stable-*'
   schedule:
     # Every day at 3:10 AM UTC
     - cron: '10 3 * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,16 @@ on:
       - v[1-9]+.[0-9]+.[0-9]    # allow v1.2.3
       - v[1-9]+.[0-9]+.[0-9]-*  # allow v1.2.3-beta3 etc.
     branches:
-      - master
-      - stable-*
+      - 'master'
+      - 'stable-*'
   schedule:
     # Every day at 3:33 AM UTC
     - cron: '33 3 * * *'
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # requests, we limit to 1 concurrent job, but for the default repository branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref_name != github.event.repository.default_branch || github.run_number }}
   # Cancel intermediate builds, but only if it is a pull request build.
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
@@ -62,8 +62,6 @@ jobs:
   unix:
     name: "Create Unix archives and data"
     needs: tools
-    # Don't run this twice on PRs for branches pushed to the same repository
-    if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:


### PR DESCRIPTION
It can be convenient for people with direct write access to the main GAP repository to put branches there (instead of their personal fork). For example, GitHub can automatically delete such branches once they are merged into master.

But so far this was problematic because not all CI tests were run on PRs created from such a branch.

This PR is changing that. The critical part is adding `branches` restrictions to all relevant workflows, and then remove the `Don't run this twice on PRs for branches` logic.

The rest is unifying some stuff