### PR TITLE
Fix regression introduced in GAP 4.13.1 that could cause coset enumeration to fail in cases were it used to work fine in GAP 4.13.0 

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -3796,7 +3796,7 @@ end );
 ##  enumerations with cumulatively bigger coset tables up to table size
 ##  <maxtable>. It returns `fail' if no table could be found.
 BindGlobal("FinIndexCyclicSubgroupGenerator",function(G,maxtable)
-  local fgens, grels, powers, max, gens, t, Attempt, perms, short;
+  local fgens, grels, max, gens, t, Attempt, perms, short;
 
   fgens:=FreeGeneratorsOfFpGroup(G);
   grels:=RelatorsOfFpGroup(G);
@@ -3806,15 +3806,6 @@ BindGlobal("FinIndexCyclicSubgroupGenerator",function(G,maxtable)
     max:=CosetTableDefaultMaxLimit;
   fi;
   max:=Minimum(max,maxtable);
-
-  powers := List(grels, ExtRepOfObj);
-  powers := Filtered(powers, x -> Length(x) = 2);
-  if not IsEmpty(powers) then
-    SortBy(powers, x -> x[2]);
-    if Last(powers)[2] > 10 then
-      max := Last(powers)[2];
-    fi;
-  fi;
 
   # take the generators, most frequent first
   gens:=GeneratorsOfGroup(G);

--- a/tst/testbugfix/2024-03-16-FpGroups.tst
+++ b/tst/testbugfix/2024-03-16-FpGroups.tst
@@ -51,3 +51,11 @@ gap> AsList(G);
   f2^-42*f1, f2^43*f1, f2^-43*f1, f2^44*f1, f2^-44*f1, f2^45*f1, f2^-45*f1, 
   f2^46*f1, f2^-46*f1, f2^47*f1, f2^-47*f1, f2^48*f1, f2^-48*f1, f2^49*f1, 
   f2^-49*f1, f2^50*f1 ]
+
+# Issue #6031 - too small max. cosets
+gap> F := FreeGroup("x", "y", "z");;
+gap> R := ParseRelators(GeneratorsOfGroup(F), 
+> "x^25=y^25=z^125=1, [x,y]=1, z^y=z^6, z^x=y^5*z, x^5=z^50");;
+gap> H_F := F/R;;
+gap> H := Image(IsomorphismPcGroup(H_F));
+<pc group of size 15625 with 6 generators>


### PR DESCRIPTION
This PR fixes #6031 by increasing the maximum number of cosets used by `FinIndexCyclicSubgroupGenerator` when one of the relators is a power. Previously this limit was set to be the power itself but the example in #6031 indicates that this isn't enough (i.e. although the final coset table requires only at most `Last(powers)[2]` rows, the enumeration may require more). The choice of 128 times the power is entirely arbitrary, it works in this example, (as do some lower values). 

I'm not sure how to fix this "properly" or if such a fix is even possible. 

