### PR TITLE
FIX: Delete wrong index limit

### DIFF
--- a/lib/grpfp.gi
+++ b/lib/grpfp.gi
@@ -3796,7 +3796,7 @@ end );
 ##  enumerations with cumulatively bigger coset tables up to table size
 ##  <maxtable>. It returns `fail' if no table could be found.
 BindGlobal("FinIndexCyclicSubgroupGenerator",function(G,maxtable)
-  local fgens, grels, powers, max, gens, t, Attempt, perms, short;
+  local fgens, grels, max, gens, t, Attempt, perms, short;
 
   fgens:=FreeGeneratorsOfFpGroup(G);
   grels:=RelatorsOfFpGroup(G);
@@ -3806,15 +3806,6 @@ BindGlobal("FinIndexCyclicSubgroupGenerator",function(G,maxtable)
     max:=CosetTableDefaultMaxLimit;
   fi;
   max:=Minimum(max,maxtable);
-
-  powers := List(grels, ExtRepOfObj);
-  powers := Filtered(powers, x -> Length(x) = 2);
-  if not IsEmpty(powers) then
-    SortBy(powers, x -> x[2]);
-    if Last(powers)[2] > 10 then
-      max := Last(powers)[2];
-    fi;
-  fi;
 
   # take the generators, most frequent first
   gens:=GeneratorsOfGroup(G);

--- a/tst/testbugfix/2025-07-10-FpIndex.tst
+++ b/tst/testbugfix/2025-07-10-FpIndex.tst
@@ -1,0 +1,6 @@
+# Index of cyclic subgroup not bounded by powers of generators
+gap> g:=DirectProduct(WeylGroupFp("A",7),CyclicGroup(IsFpGroup,11));;
+gap> Size(g);
+443520
+gap> FinIndexCyclicSubgroupGenerator(g,100000)<>fail;
+true


### PR DESCRIPTION
In #5677 a changed, wrong, index limit of cyclic subgroups was introduced. This patch removes it. This fixes #6031.

