### PR TITLE
ENHANCE: Added User Warnings

### DIFF
--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -2415,25 +2415,29 @@ if rule[1]=rule[2] then return;fi;
         od;
       od;
     od;
-
     # modified coxeter relations with blocking borels in between
     # normalize using bn-pairs
     for pri in coxrels do
       pri:=pri[1];
       a:=List(pri,x->trawou(weylword(wgens[x])));
-      for jj in Cartesian(noncelm{pri{[2..Length(pri)]}}) do
-        if not ForAll(jj,IsOne) then
-          b:=wgens[pri[1]]*Product([1..Length(jj)],x->jj[x]*wgens[pri[x+1]]);
-          j:=decomp(b);
-          j:=[borelword(j[1]),weylword(j[2]),borelword(j[3])];
-          k:=List(jj,x->trawou(borelword(x)));
-          b:=a[1]*Product([1..Length(jj)],x->k[x]*a[x+1]);
-          j:=j[1]*j[2]*j[3];
-          b:=[b,trawou(j)];
-          addrule(b);
-        fi;
-      od;
+      if Product(List(noncelm{pri{[2..Length(pri)]}},Length))>10^7 then
+        Info(InfoWarning,1,"Likely huge RWS");
+      else
+        for jj in Cartesian(noncelm{pri{[2..Length(pri)]}}) do
+          if not ForAll(jj,IsOne) then
+            b:=wgens[pri[1]]*Product([1..Length(jj)],x->jj[x]*wgens[pri[x+1]]);
+            j:=decomp(b);
+            j:=[borelword(j[1]),weylword(j[2]),borelword(j[3])];
+            k:=List(jj,x->trawou(borelword(x)));
+            b:=a[1]*Product([1..Length(jj)],x->k[x]*a[x+1]);
+            j:=j[1]*j[2]*j[3];
+            b:=[b,trawou(j)];
+            addrule(b);
+          fi;
+        od;
+      fi;
     od;
+
   else
 
     # BN-style reductions

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -724,7 +724,7 @@ local m, fact, fg, reps, ma, idx, nm, embs, proj, kproj, k, ag, agl, ug,
 
   #4b: Get minimal blocks on socle components
 
-  bl:=RepresentativesMinimalBlocks(fg,[1..n],1);
+  bl:=RepresentativesMinimalBlocks(fg,[1..n]);
   bl:=Filtered(bl,i->Length(i)<n);
   if Length(bl)>0 then
     Info(InfoLattice,1,Length(bl)," minimal block systems");

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -804,7 +804,10 @@ local str, orbish, func,isnotest;
               act := OnPoints;
           fi;
           if     Length( arg ) > 2
-            and famrel( FamilyObj( arg[ 2 ] ), FamilyObj( arg[ 3 ] ) )
+            and (famrel( FamilyObj( arg[ 2 ] ), FamilyObj( arg[ 3 ] ) ) or
+              # blocks with empty seed
+              (IsListOrCollection(arg[2]) and IsListOrCollection(arg[3])
+                and Length(arg[3])=0) )
             # for blocks on the groups elements
             and not (IsOperation(usetype) and le=4)
             then
@@ -878,7 +881,7 @@ local str, orbish, func,isnotest;
       fi;
 
       if used<>[1..Length(arg)] then
-        Info(InfoWarning,1,name,": Argumemnts #",
+        Info(InfoWarning,1,name,": Arguments #",
           Difference([1..Length(arg)],used)," were ignored");
       fi;
       return result;

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -760,14 +760,18 @@ local str, orbish, func,isnotest;
 
     # Create the wrapper function.
     func := function( arg )
-    local   G,  D,  pnt,  gens,  acts,  act,  xset,  p,  attrG,  result,le;
+    local   G,  D,  pnt,  gens,  acts,  act,  xset,  p,  attrG,
+    result,le,used;
 
+      used:=[];
       # Get the arguments.
       if Length( arg ) <= 2 and IsExternalSet( arg[ 1 ] )  then
           xset := arg[ 1 ];
+          AddSet(used,1);
           if Length(arg)>1 then
             # force immutability
             pnt := Immutable(arg[ 2 ]);
+            AddSet(used,2);
           else
               # `Blocks' like operations
               pnt:=[];
@@ -791,8 +795,10 @@ local str, orbish, func,isnotest;
       elif 2 <= Length( arg ) then
           le:=Length(arg);
           G := arg[ 1 ];
+          AddSet(used,1);
           if IsFunction( arg[ le ] )  then
               act := arg[ le ];
+              AddSet(used,le);
               le:=le-1;
           else
               act := OnPoints;
@@ -803,6 +809,7 @@ local str, orbish, func,isnotest;
             and not (IsOperation(usetype) and le=4)
             then
               D := arg[ 2 ];
+              AddSet(used,2);
               if IsDomain( D )  then
            if IsFinite( D ) then D:= AsSSortedList( D ); else D:= Enumerator( D ); fi;
               fi;
@@ -811,9 +818,12 @@ local str, orbish, func,isnotest;
               p := 2;
           fi;
           pnt := Immutable(arg[ p ]);
+          AddSet(used,p);
           if Length( arg ) > p + 1  then
               gens := arg[ p + 1 ];
               acts := arg[ p + 2 ];
+              AddSet(used,p+1);
+              AddSet(used,p+2);
           fi;
       else
         Error( "usage: ", name, "(<xset>,<pnt>)\n",
@@ -867,6 +877,10 @@ local str, orbish, func,isnotest;
           Setter( usetype )( G, result );
       fi;
 
+      if used<>[1..Length(arg)] then
+        Info(InfoWarning,1,name,": Argumemnts #",
+          Difference([1..Length(arg)],used)," were ignored");
+      fi;
       return result;
   end;
   BIND_GLOBAL( name, func );


### PR DESCRIPTION
Added user warnings in two situations that otherwise might seem strange:

- If a rewriting system is computed for a  group from a generic presentation, such systems tend to be large and take a long time to make confluent.
- When calling a function such as `Orbit` (which can take a large number and variants of arguments) with extra arguments that are not used at all.