### PR TITLE
Fix `IsIntegerMatrixGroup` regression

### DIFF
--- a/lib/grpramat.gd
+++ b/lib/grpramat.gd
@@ -54,6 +54,15 @@ InstallTrueMethod( IsCyclotomicMatrixGroup, IsRationalMatrixGroup );
 ##
 ##  <Description>
 ##  tests whether all matrices in <A>G</A> have integer entries.
+##  <Example><![CDATA[
+##  gap> A:=[[0,1,0],[0,0,1],[1,0,0]];;
+##  gap> B:=[[0,0,1],[0,1,0],[-1,0,0]];;
+##  gap> C:=[[E(4),0,0],[0,E(4)^(-1),0],[0,0,1]];;
+##  gap> IsIntegerMatrixGroup(Group(A, B));
+##  true
+##  gap> IsIntegerMatrixGroup(Group(A, C));
+##  false
+##  ]]></Example>
 ##  <!--  Not <C>IsIntegralMatrixGroup</C> to avoid confusion with matrix groups of-->
 ##  <!--  integral cyclotomic numbers. -->
 ##  </Description>

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -28,7 +28,7 @@ InstallMethod( IsIntegerMatrixGroup, [ IsCyclotomicMatrixGroup ],
     function( G )
     local gen;
     gen := GeneratorsOfGroup( G );
-    return ForAll( gen, r -> ForAll( r, IsInt ) ) and
+    return ForAll( gen, mat -> ForAll( mat, row -> ForAll( row, IsInt ) ) ) and
            ForAll( gen, g -> AbsInt( DeterminantMat( g ) ) = 1 );
     end
 );


### PR DESCRIPTION
In PR #6008 I stupidly broke `IsIntegerMatrixGroup` -- to my surprise there was no test for it. Now there is one.