### PR TITLE
Update the tested julia versions in `gapjl.yml`

### DIFF
--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -28,7 +28,7 @@ jobs:
           - 'latest-release'
           - 'master'
         julia-version:
-          - '1.6'
+          - '1.10'
           - '1'         # latest stable release
           - 'nightly'
         os:
@@ -80,4 +80,4 @@ jobs:
           julia --proj=override $GAPJLPATH/etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override --enable-Werror
       - name: "Run tests"
         run: |
-           julia --proj=override $GAPJLPATH/etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"
+          julia --proj=override $GAPJLPATH/etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"


### PR DESCRIPTION
GAP.jl will drop support for julia versions 1.6 to 1.9 with https://github.com/oscar-system/GAP.jl/pull/1209, so the CI job here should only run with julia versions 1.10 and later.

Release notes: none

I think this should be backported to 4.14 as well, to have a working testsuite there after https://github.com/oscar-system/GAP.jl/pull/1209 is merged.

cc @fingolfin 