### PR TITLE
Tweak handling of finite integer matrix groups

### DIFF
--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -303,6 +303,7 @@ function( G )
     # now reduce mod p
     e := One(GF(p));
     H := Group( GeneratorsOfGroup( G ) * e );
+    UseIsomorphismRelation(G, H);
 
     # check Minkowski bounds here to immediately reject some G as infinite
     if MinkowskiMultiple(n) mod Size(H) <> 0 then
@@ -335,6 +336,7 @@ function( G )
             );
     SetNiceMonomorphism(G, nice);
     SetNiceObject(G, H);
+    UseIsomorphismRelation(H, G);
     SetIsHandledByNiceMonomorphism(G, true);
     return true;
 end );


### PR DESCRIPTION
Transfer information between the original and image group via `UseIsomorphismRelation`.

This fixes one small issue in the test suite of the cryst package. Unfortunately there is a bigger one which requires an update to `cryst` (the `hapcryst` test suite also has failures but I think they are consequences of those in `cryst`). See https://github.com/gap-packages/cryst/pull/54