### PR TITLE
Update julia used in CI

### DIFF
--- a/dev/ci-configure-gap.sh
+++ b/dev/ci-configure-gap.sh
@@ -30,7 +30,7 @@ fi
 if [[ $JULIA = yes ]]
 then
   pushd extern
-  wget https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.6-linux-x86_64.tar.gz
+  wget https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.10-linux-x86_64.tar.gz
   tar xvf julia-*.tar.gz
   rm julia-*.tar.gz
   cd julia-*


### PR DESCRIPTION
This should have been part of https://github.com/gap-system/gap/pull/6040, but I forgot to check this place.

Analogous to https://github.com/gap-system/gap/pull/6040, this does not need release notes, but should be backported to stable-1.14.

cc @fingolfin 