### PR TITLE
Remove the `HACKUSERPREF` code from files in `lib`

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -639,7 +639,7 @@ end );
 ##
 #X  files installing compatibility with deprecated, obsolescent or
 ##  obsolete GAP4 behaviour;
-##  *not* to be read if `GAPInfo.UserPreferences.ReadObsolete' has the value
+##  *not* to be read if `UserPreference( "ReadObsolete" )' has the value
 ##  `false'
 ##  (this value can be set in the `gap.ini' file)
 ##
@@ -654,8 +654,6 @@ which may vanish in a future version of &GAP;"
   values:= [ true, false ],
   multi:= false,
   ) );
-# HACKUSERPREF temporary hack for AtlasRep and CTblLib:
-GAPInfo.UserPreferences.ReadObsolete := UserPreference("ReadObsolete");
 
 ReadLib("obsolete.g"); # the helpers in there are always read
 CallAndInstallPostRestore( function()

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -76,9 +76,9 @@
 ##  for example in order to make sure that one's own &GAP; code does not rely
 ##  on the obsolete variables.
 ##  For that, one can use the <C>-O</C> command line option
-##  (see <Ref Label="Command Line Options"/>) or set the component
+##  (see <Ref Label="Command Line Options"/>) or set the user preference
 ##  <C>ReadObsolete</C> in the file <F>gap.ini</F> to <K>false</K>
-##  (see <Ref Sect="sect:gap.ini"/>). Note that <C>-O</C> command
+##  (see <Ref Sect="sect:gap.ini"/>). Note that the <C>-O</C> command
 ##  line option overrides <C>ReadObsolete</C>.
 ##  <P/>
 ##  (Note that the condition whether the library files with the obsolete

--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -96,8 +96,6 @@ leave the <C>Pager</C> and <C>PagerOptions</C> preferences empty."
     fi;
   end,
   ) );
-## HACKUSERPREF  temporary until all packages are adjusted
-GAPInfo.UserPreferences.Pager := UserPreference("Pager");
 
 #############################################################################
 ##

--- a/lib/permdeco.gi
+++ b/lib/permdeco.gi
@@ -41,7 +41,7 @@ local   pcgs,r,hom,A,iso,p,i,depths,ords,b,mo,pc,limit,good,new,start,np;
       A:=First(G!.cachedFFS,x->IsSubset(r,x[1]!.radical));
       if A<>fail then
         b:=Image(A[2].rest);
-        b:=NaturalHomomorphismByNormalSubgroupNC(b,RadicalGroup(b));
+        b:=NaturalHomomorphismByNormalSubgroupNC(b,SolvableRadical(b));
         hom:=A[2]!.rest*b;
         SetKernelOfMultiplicativeGeneralMapping(hom,r);
         AddNaturalHomomorphismsPool(G,r,hom);

--- a/lib/userpref.g
+++ b/lib/userpref.g
@@ -620,8 +620,6 @@ BindGlobal( "StringUserPreferences", function( arg )
     # Run over the preferences, first the ones that belong to GAP,
     # then the ones that belong to packages
     pkglist := Concatenation(["gap"], Difference(RecNames( pref ), ["gap"] ));
-## HACKUSERPREF  temporary until all packages are adjusted
-    pkglist := Filtered(pkglist, a-> not a in ["Pager","ReadObsolete"]);
     for pkgname in pkglist do
       Append( str, ListWithIdenticalEntries( 77, '#' ) );
       Append( str, "\n\n" );
@@ -662,9 +660,6 @@ BindGlobal( "ShowUserPreferences", function(arg)
       pkglist := Concatenation(  [ "gap" ],
                        Difference( RecNames( pref ), [ "gap" ] ) );
     fi;
-
-## HACKUSERPREF  temporary until all packages are adjusted
-    pkglist := Filtered(pkglist, a-> not a in ["Pager","ReadObsolete"]);
 
     str:= "";
     for pkgname in pkglist do


### PR DESCRIPTION
At least since GAP 4.12.2, no distributed package uses
`GAPInfo.UserPreferences.Pager` or `GAPInfo.UserPreferences.ReadObsolete`.
`UserPreference( "Pager" )` and `UserPreference( "ReadObsolete" )` are used
instead.
Thus the code that provides these variables can be removed.

(And use `SolvableRadical` not `RadicalGroup`: There was still one place where the obsolete variable was used. The CI tests show just a warning in such cases.)