### PR TITLE
Fix `SCRSift` for non-internal permutations

### DIFF
--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -268,6 +268,22 @@ DeclareSynonym( "MutableCopyMat", MutableCopyMatrix );
 
 #############################################################################
 ##
+#F  SCRSiftOld( <S>, <g> )
+##
+##  Moved to obsoletes in August 2025.
+##
+##  The function was never documented.
+##  It was a library code version of 'SCRSift', which is a kernel function
+##  (see https://github.com/gap-system/gap/pull/525).
+##  The functions 'SCRSiftOld' and 'SiftedPermutation' do essentially the
+##  same, in particular they return the same results, thus 'SCRSiftOld' is
+##  obsolete.
+##
+DeclareObsoleteSynonym( "SCRSiftOld", "SiftedPermutation" );
+
+
+#############################################################################
+##
 ##  Not used in any redistributed package
 DeclareObsoleteSynonym( "ZeroSM", "ZeroSameMutability" );
 DeclareObsoleteSynonym( "AdditiveInverseSM", "AdditiveInverseSameMutability" );

--- a/lib/stbcrand.gi
+++ b/lib/stbcrand.gi
@@ -658,37 +658,16 @@ end );
 ##
 ##  tries to factor g as product of cosetreps in S; returns remainder
 ##
- SCRSiftOld :=  function ( S, g )
-     local stb,   # the stabilizer of S we currently work with
-           bpt;   # first point of stb.orbit
-
-     stb := S;
-     while IsBound( stb.stabilizer ) do
-         bpt := stb.orbit[1];
-         if IsBound( stb.transversal[bpt^g] ) then
-             while bpt <> bpt^g do
-                 g := g*stb.transversal[bpt^g];
-             od;
-             stb := stb.stabilizer;
-         else
-             #current g witnesses that input was not in S
-             return g;
-         fi;
-     od;
-
-     return g;
- end;
-
-
-
- InstallGlobalFunction( SCRSift, function(S,g)
+InstallGlobalFunction( SCRSift, function(S,g)
      local result;
 
-#     return SCRSiftOld(S, g);
+     if not IsInternalRep( g ) then
+       return SiftedPermutation(S, g);
+     fi;
 
      result :=  SCR_SIFT_HELPER(S, g, Maximum(LargestMovedPoint(g),LargestMovedPoint(S!.generators)));
 
-#     Assert(2,result = SCRSiftOld(S, g));
+#     Assert(2,result = SiftedPermutation(S, g));
      return result;
 end);
 

--- a/tst/teststandard/stabchain.tst
+++ b/tst/teststandard/stabchain.tst
@@ -48,5 +48,17 @@ gap> SCRSift(S,(1,2));
 gap> SCRSift(S,GeneratorsOfGroup(m)[1]);
 ()
 
+# 'SCRSift' works also for non-internal permutations,
+# by delegating to 'SiftedPermutation'.
+gap> G:= GroupWithMemory( MathieuGroup( 11 ) );;
+gap> a:= G.1;;
+gap> IsPerm( a );
+true
+gap> IsInternalRep( a );
+false
+gap> S:= StabChain( G );;
+gap> SCRSift( S, a );
+<() with mem>
+
 #
 gap> STOP_TEST("stabchain.tst");


### PR DESCRIPTION
- Make `SCRSiftOld` an obsolete synonym of `SiftedPermutation`,
- call `SiftedPermutation` in `SCRSift` if the permutation is non-internal.

fixes the bug that motivated #5381