### PR TITLE
Add <unistd.h> so we can get the pagesize

### DIFF
--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -24,10 +24,10 @@
 #ifdef GAP_MEM_CHECK
 #include <fcntl.h>
 #include <stdlib.h>     // for qsort
-#include <unistd.h>     // for ftruncate, getpid, unlink
 #endif
 
 #include <stdio.h>      // for fputs
+#include <unistd.h>     // for ftruncate, getpid, unlink, sysconf (for _SC_PAGESIZE)
 
 #ifdef HAVE_MADVISE
 #include <sys/mman.h>

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -27,7 +27,7 @@
 #endif
 
 #include <stdio.h>      // for fputs
-#include <unistd.h>     // for ftruncate, getpid, unlink, sbrk, sysconf (and _SC_PAGESIZE)
+#include <unistd.h>     // for ftruncate, getpid, unlink, sbrk, sysconf
 
 #ifdef HAVE_MADVISE
 #include <sys/mman.h>
@@ -419,9 +419,7 @@ static int SyTryToIncreasePool(void)
 static void SyInitialAllocPool(void)
 {
 #ifdef HAVE_SYSCONF
-#ifdef _SC_PAGESIZE
    pagesize = sysconf(_SC_PAGESIZE);
-#endif
 #endif
    // Otherwise we take the default of 4k as pagesize.
 

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -27,7 +27,7 @@
 #endif
 
 #include <stdio.h>      // for fputs
-#include <unistd.h>     // for ftruncate, getpid, unlink, sysconf (for _SC_PAGESIZE)
+#include <unistd.h>     // for ftruncate, getpid, unlink, sbrk, sysconf (and _SC_PAGESIZE)
 
 #ifdef HAVE_MADVISE
 #include <sys/mman.h>
@@ -37,7 +37,6 @@
 #include <mach/mach.h>
 #elif defined(HAVE_SBRK)
 #include <string.h>     // for memset
-#include <unistd.h>     // for sbrk
 #endif
 
 

--- a/src/system.c
+++ b/src/system.c
@@ -47,7 +47,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <unistd.h>
+#include <unistd.h>     // for sysconf (and _SC_PAGESIZE)
 
 #include <sys/stat.h>
 

--- a/src/system.c
+++ b/src/system.c
@@ -47,7 +47,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <unistd.h>     // for sysconf (and _SC_PAGESIZE)
+#include <unistd.h>     // for sysconf
 
 #include <sys/stat.h>
 
@@ -560,7 +560,11 @@ static void InitSysOpts(void)
     SyStorMin = 16 * sizeof(Obj) * 1024;    // in kB
     SyStorMax = 256 * sizeof(Obj) * 1024;   // in kB
 #ifdef SYS_IS_64_BIT
-  #if defined(HAVE_SYSCONF) && defined(_SC_PAGESIZE) && defined(_SC_PHYS_PAGES)
+  // According to POSIX (at least since POSIX.1-2008) unistd.h always
+  // provides _SC_PAGESIZE. However, _SC_PHYS_PAGES is not defined in POSIX
+  // (up to at least POSIX.1-2024). But it is there (and has been for a long
+  // time) in Linux, macOS, FreeBSD, OpenBSD, so we just use it.
+  #if defined(HAVE_SYSCONF)
     // Set to 3/4 of memory size (in kB), if this is larger
     Int SyStorMaxFromMem =
         (sysconf(_SC_PAGESIZE) * sysconf(_SC_PHYS_PAGES) * 3) / 4 / 1024;


### PR DESCRIPTION
On Macs, the pagesize is now 16384. We need to include unistd.h, so we can get this pagesize (we check for _SC_PAGESIZE). Without this, some allocations fail as they are not the a multiple of page size.
