### PR TITLE
Optimize `IsZero` and `IsOne` for rational functions and (Laurent) polynomials

### DIFF
--- a/hpcgap/lib/basis.gi
+++ b/hpcgap/lib/basis.gi
@@ -1404,7 +1404,7 @@ InstallMethod( Coefficients,
     IsCollsElms,
     [ IsBasis and IsEmpty, IsVector ], SUM_FLAGS,
     function( B, v )
-    if v = Zero( UnderlyingLeftModule( B ) ) then
+    if IsZero( v ) then
       return [];
     else
       return fail;

--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -1404,7 +1404,7 @@ local n,e,ff,p,ffp,ffd,roots,allroots,nowroots,fm,fft,comb,combi,k,h,i,j,
     Info(InfoPoly,2,"testing combination ",combi,": ");
     fft:=ff{combi};
     ffp:=List(fft,i->AlgebraicPolynomialModP(kfam,i,fm[1],p));
-    roots:=Filtered(fm,i->ForAny(ffp,j->Value(j,i)=Zero(k)));
+    roots:=Filtered(fm,i->ForAny(ffp,j->IsZero(Value(j,i))));
     if Length(roots)<>Sum(ffd{combi}) then
       Error("serious error");
     fi;
@@ -1413,7 +1413,7 @@ local n,e,ff,p,ffp,ffd,roots,allroots,nowroots,fm,fft,comb,combi,k,h,i,j,
     j:=1;
     while j<=Length(roots) and gut do
       ffp:=List(fft,i->AlgebraicPolynomialModP(kfam,i,roots[j],p));
-      nowroots:=Filtered(allroots,i->ForAny(ffp,j->Value(j,i)=Zero(k)));
+      nowroots:=Filtered(allroots,i->ForAny(ffp,j->IsZero(Value(j,i))));
       gut := Length(nowroots)=Sum(ffd{combi});
       j:=j+1;
     od;

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -1489,7 +1489,7 @@ InstallMethod( AdjointAssociativeAlgebra,
             found:= false;
             l1:= 1; l2:= 1;
             while not found do
-              if m[l1][l2] <> Zero( F ) then
+              if not IsZero( m[l1][l2] ) then
                 Add( posits, [l1,l2] );
                 found:= true;
               else
@@ -1992,7 +1992,7 @@ InstallMethod( DirectSumDecomposition,
                 Append( comlist, List( B[i], y -> bb[j]*y ) );
             od;
 
-            if not ForAll( comlist, x -> x = Zero(L) ) then
+            if not ForAll( comlist, IsZero ) then
               Append( bb, B[i] );
               B:= Filtered( B, x -> x <> B[i] );
               i:= 1;

--- a/lib/algliess.gi
+++ b/lib/algliess.gi
@@ -767,7 +767,7 @@ BindGlobal( "SimpleLieAlgebraTypeW", function( n, F )
           for k in [1..Length( n )] do
             cf:= Binomial( ex[k], x1[1][k] ) * cf;
           od;
-          if cf<>Zero(F) then
+          if not IsZero(cf) then
             no:=Position(eltlist,[ex,x2[2]]);
             AddendumSCTable( T, i, j, no, cf );
           fi;
@@ -779,7 +779,7 @@ BindGlobal( "SimpleLieAlgebraTypeW", function( n, F )
           for k in [1..Length( n )] do
             cf:= Binomial( ex[k], x2[1][k] ) * cf;
           od;
-          if cf<>Zero(F) then
+          if not IsZero(cf) then
             no:=Position(eltlist,[ex,x1[2]]);
             AddendumSCTable( T, i, j, no, -cf );
           fi;
@@ -948,7 +948,7 @@ BindGlobal( "SimpleLieAlgebraTypeH", function( n, F )
           cf[pos]:= -One( F );
         fi;
       od;
-      if cf <> Zero( F )*cf then
+      if not IsZero(cf) then
         if IsBound( sp ) then
           if not IsContainedInSpan( sp, cf ) then
             CloseMutableBasis( sp, cf );
@@ -1070,7 +1070,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1:= ShallowCopy(x1); y2:= ShallowCopy(x2);
               y1[k]:=y1[k]-1; y2[k+r]:=y2[k+r]-1;
               v:=coef( y1+y2, y1, F );
-              if v<>Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, y1+y2 );
                 vals[pos]:= vals[pos] + v;
               fi;
@@ -1080,7 +1080,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1:= ShallowCopy(x1); y2:= ShallowCopy(x2);
               y1[k]:=y1[k]-1; y2[ m ]:=y2[ m ]-1;
               v:=coef(x1+y2,y1,F)*(x2[k]+1);
-              if v<>Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, x1+y2 );
                 vals[pos]:= vals[pos]-v;
               fi;
@@ -1094,7 +1094,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1:= ShallowCopy(x1); y2:= ShallowCopy(x2);
               y1[m]:=y1[m]-1; y2[k+r]:=y2[k+r]-1;
               v:=coef( y1+x2, y2, F )*(x1[k+r]+1);
-              if v<>Zero( F ) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, y1+x2 );
                 vals[pos]:= vals[pos] + v;
               fi;
@@ -1105,7 +1105,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1[m]:=y1[m]-1; y2[ m ]:=y2[ m ]-1;
               y1[k+r]:=y1[k+r]+1; y2[k]:=y2[k]+1;
               v:=coef(y1+y2,y1,F)*y1[k+r]*y2[k];
-              if v<>Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, y1+y2 );
                 vals[pos]:= vals[pos]-v;
               fi;
@@ -1114,7 +1114,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1[m]:=y1[m]-1; y2[ m ]:=y2[ m ]-1;
               y1[k]:=y1[k]+1; y2[k+r]:=y2[k+r]+1;
               v:=coef(y1+y2,y1,F)*y1[k]*y2[k+r];
-              if v<>Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, y1+y2 );
                 vals[pos]:= vals[pos]+v;
               fi;
@@ -1124,7 +1124,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1:= ShallowCopy(x1); y2:= ShallowCopy(x2);
               y1[m]:=y1[m]-1; y2[k]:=y2[k]-1;
               v:=coef( y1+x2, y2, F )*(x1[k]+1);
-              if v <> Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, y1+x2 );
                 vals[pos]:= vals[pos] + v;
               fi;
@@ -1138,7 +1138,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1:= ShallowCopy(x1); y2:= ShallowCopy(x2);
               y1[k+r]:=y1[k+r]-1; y2[k]:=y2[k]-1;
               v:=coef( y1+y2, y1, F );
-              if v<>Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, y1+y2 );
                 vals[pos]:= vals[pos] - v;
               fi;
@@ -1148,7 +1148,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
               y1:= ShallowCopy(x1); y2:= ShallowCopy(x2);
               y1[k+r]:=y1[k+r]-1; y2[ m ]:=y2[ m ]-1;
               v:=coef(x1+y2,y1,F)*(x2[k+r]+1);
-              if v<>Zero(F) then
+              if not IsZero(v) then
                 pos:= Position( eltlist, x1+y2 );
                 vals[pos]:= vals[pos]-v;
               fi;
@@ -1160,7 +1160,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
             y1:= ShallowCopy(x1);
             y1[m]:=y1[m]-1;
             v:=coef(y1+x2,x2,F);
-            if v<>Zero(F) then
+            if not IsZero(v) then
               pos:= Position( eltlist, y1+x2 );
               vals[pos]:= vals[pos]-2*v;
             fi;
@@ -1170,7 +1170,7 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
             y2:= ShallowCopy(x2);
             y2[m]:=y2[m]-1;
             v:= coef(x1+y2,x1,F);
-            if v<>Zero(F) then
+            if not IsZero(v) then
               pos:= Position( eltlist, x1+y2 );
               vals[pos]:= vals[pos]+2*v;
             fi;
@@ -1182,8 +1182,9 @@ BindGlobal( "SimpleLieAlgebraTypeK", function( n, F )
 
         ii:=[]; cc:=[];
         for k in [1..Length(vals)] do
-          if vals[k] <> Zero( F ) then
-            Add(ii,k); Add(cc,vals[k]);
+          if not IsZero(vals[k]) then
+            Add(ii,k);
+            Add(cc,vals[k]);
           fi;
         od;
 

--- a/lib/basis.gi
+++ b/lib/basis.gi
@@ -1400,7 +1400,7 @@ InstallMethod( Coefficients,
     IsCollsElms,
     [ IsBasis and IsEmpty, IsVector ], SUM_FLAGS,
     function( B, v )
-    if v = Zero( UnderlyingLeftModule( B ) ) then
+    if IsZero( v ) then
       return [];
     else
       return fail;

--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -1835,7 +1835,7 @@ local  classes,            # classes to be constructed, the result
   List(comms,x->ConvertToVectorRep(x,field));
   space:=List(comms,ShallowCopy);
   TriangulizeMat(space);
-  space:=Filtered(space,i->i<>Zero(i)); # remove spurious columns
+  space:=Filtered(space,i->not IsZero(i)); # remove spurious columns
 
   com:=BaseSteinitzVectors(IdentityMat(n,field),space);
 

--- a/lib/claspcgs.gi
+++ b/lib/claspcgs.gi
@@ -2017,8 +2017,8 @@ InstallGlobalFunction( CentralStepRatClPGroup,
                 oprs:=preimage!.operators;
                 type:=preimage!.type;
             else
-                if Q[ 1 ] = Zero( Q[ 1 ] )  then  i:=1;
-                                            else  i:=2;  fi;
+                if IsZero( Q[ 1 ] )  then  i:=1;
+                                     else  i:=2;  fi;
                 if Length( GeneratorsOfGroup( preimage ) ) = 1  then
                     gens:=[ GeneratorsOfGroup( preimage )[ 1 ] ^ i ];
                     oprs:=[ preimage!.operators          [ 1 ] ^ i ];
@@ -2026,8 +2026,8 @@ InstallGlobalFunction( CentralStepRatClPGroup,
                     elif preimage!.type = 2  then  type:=i + 1;
                                              else  type:=3;          fi;
                 else
-                    if Q[ 2 ] = Zero( Q[ 2 ] )  then  j:=1;
-                                                else  j:=2;  fi;
+                    if IsZero( Q[ 2 ] )  then  j:=1;
+                                         else  j:=2;  fi;
                     if i = 1  then
                         gens:=[ GeneratorsOfGroup( preimage )[ 1 ],
                                   GeneratorsOfGroup( preimage )[ 2 ] ^ j ];

--- a/lib/field.gi
+++ b/lib/field.gi
@@ -1140,7 +1140,7 @@ InstallMethod( IsAssociated,
     IsCollsElmsElms,
     [ IsDivisionRing, IsRingElement, IsRingElement ],
     function ( F, r, s )
-    return (r = Zero( F ) ) = (s = Zero( F ) );
+    return IsZero( r ) = IsZero( s );
     end );
 
 
@@ -1153,7 +1153,7 @@ InstallMethod( StandardAssociate,
     IsCollsElms,
     [ IsDivisionRing, IsScalar ],
     function ( R, r )
-    if r = Zero( R ) then
+    if IsZero( r ) then
         return Zero( R );
     else
         return One( R );
@@ -1170,7 +1170,7 @@ InstallMethod( StandardAssociateUnit,
     IsCollsElms,
     [ IsDivisionRing, IsScalar ],
     function ( R, r )
-    if r = Zero( R ) then
+    if IsZero( r ) then
         return One( R );
     else
         return r^-1;

--- a/lib/grpffmat.gi
+++ b/lib/grpffmat.gi
@@ -434,7 +434,7 @@ function( G, flag )
 
     # in the sl-case we have to split this class
     if flag then
-      if DeterminantMat(mat)=Z(q)^0 then
+      if IsOne(DeterminantMat(mat)) then
         gcd := Gcd(Concatenation(List(a, b-> b[4])));
         gcd := Gcd(gcd, q-1);
         mat := [mat];

--- a/lib/grppcatr.gi
+++ b/lib/grppcatr.gi
@@ -839,7 +839,7 @@ InstallGlobalFunction (CentrePcGroup, function( G )
                     conj := List( pcgsF,
                             x -> ExponentsOfPcElement( pcgsF, x^g ) )
                             * One( field );
-                    if conj = conj^0  then
+                    if IsOne( conj )  then
                         AddSet( newgens, g );
                     else
                         Add( matlist, conj );

--- a/lib/grppcrep.gi
+++ b/lib/grppcrep.gi
@@ -355,7 +355,7 @@ InstallGlobalFunction( ExtensionsOfModule, function( pcgsS, modu, conj, dim )
             L := GF(p^b);
             for j in [1..Length(f)] do
               w := PrimitiveRoot( L ) ^ ((p^b - 1)/r);
-              while Value( f[j], w ) <> Zero( E ) do
+              while not IsZero( Value( f[j], w ) ) do
                 w := w * PrimitiveRoot( L )^ ((p^b - 1)/r);
               od;
               mats:=List(Concatenation([w*c*iso],modu.generators),
@@ -432,7 +432,7 @@ InstallGlobalFunction( InitAbsAndIrredModules, function( r, F, dim )
                 E := GF( p^b );
                 for j in [ 1..Length( f ) ] do
                     w := PrimitiveRoot(E)^QuoInt( p^b-1, r );
-                    while Value( f[j], w ) <> Zero( F ) do
+                    while not IsZero( Value( f[j], w ) ) do
                         w := w * PrimitiveRoot(E)^QuoInt( p^b-1, r );
                     od;
                     modu := GModuleByMats( [ImmutableMatrix(E,[[w]])], E );

--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -106,7 +106,7 @@ InstallGlobalFunction( IndependentGeneratorsAbelianPPermGroup,
             h := g ^ (p^(i-1));
 
             # reduce <g> and <h>
-            while h <> h^0
+            while not IsOne(h)
               and IsBound(trns[SmallestMovedPoint(h)^h])
             do
                 g := g / pows[ trns[SmallestMovedPoint(h)^h] ];
@@ -114,7 +114,7 @@ InstallGlobalFunction( IndependentGeneratorsAbelianPPermGroup,
             od;
 
             # if this is linear independent, add it to the generators
-            if h <> h^0  then
+            if not IsOne(h) then
                 Add( inds, g );
                 Add( pows, g );
                 Add( base, h );
@@ -141,7 +141,7 @@ InstallGlobalFunction( IndependentGeneratorsAbelianPPermGroup,
 
         # prepare for the next round
         gens := gens2;
-        pows := List( pows,i->i^ p );
+        pows := List( pows, i->i^p );
 
     od;
 
@@ -175,7 +175,8 @@ InstallMethod( IndependentGeneratorsOfAbelianGroup, "for perm group",
         for g  in GeneratorsOfGroup( G )  do
             o := Order(g);
             while o mod p = 0  do o := o / p; od;
-            if g^o <> g^0  then Add( gens, g^o );  fi;
+            g := g^o;
+            if not IsOne(g)  then Add( gens, g );  fi;
         od;
 
         # append the independent generators for the Sylow <p> subgroup

--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -1404,7 +1404,7 @@ InstallMethod( PrintObj,
             if lst[k+1] > 0 and k>1 then
                 Print("+" );
             fi;
-            if lst[k+1] <> lst[k+1]^0 then
+            if not IsOne(lst[k+1]) then
                 Print( lst[k+1],"*");
             fi;
             if lst[k] = [] then

--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -3866,7 +3866,7 @@ InstallGlobalFunction( ExtendRepresentation,
        F:= LeftActingDomain( L );
 
        A:=EvalMat( w, mats );
-       if A <> Zero(F)*A then return false; fi;
+       if not IsZero(A) then return false; fi;
 
        mons:= [ ExtRepOfObj( w )[2][1] ];
        orb:=[ w ];
@@ -3892,7 +3892,7 @@ InstallGlobalFunction( ExtendRepresentation,
            c1:= elts[i]*c-c*elts[i];
            val:= EvalMat( c1, mats );
 
-           if val <> Zero( F ) * val then return false; fi;
+           if not IsZero( val ) then return false; fi;
            vv:= ListWithIdenticalEntries( Length(mons), Zero( F ) );
            r:= ExtRepOfObj( c1 )[2];
            mons1:= [ ];

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -1102,7 +1102,7 @@ InstallMethod(DistancesDistributionMatFFEVecFFE,"generic",IsCollsElmsElms,
     ConvertToVectorRepNC(vec,f);
     # build the data structures
     f:=AsSSortedList(f);
-    Assert(1,f[1]=Zero(f[1]));
+    Assert(1,IsZero(f[1]));
 
     # get differences between field entries (so we can get the next vector
     # with one addition)
@@ -1265,7 +1265,7 @@ BindGlobal( "AClosestVectorDriver", function(mat,f,vec,cnt,stop,coords)
     # build the data structures
     f:=AsSSortedList(f);
     q := Length(f);
-    Assert(1,f[1]=Zero(f[1]));
+    Assert(1,IsZero(f[1]));
 
     # get differences between field entries (so we can get the next vector
     # with one addition)

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -1588,7 +1588,7 @@ InstallMethod( PreImagesElm,
     FamRangeEqFamElm,
     [ IsGeneralMapping and IsZero, IsObject ], SUM_FLAGS,
     function( zero, elm )
-    if elm = Zero( Range( zero ) ) then
+    if IsZero( elm ) then
       return Source( zero );
     else
       return [];
@@ -1622,7 +1622,7 @@ InstallMethod( PreImagesRepresentative,
     FamRangeEqFamElm,
     [ IsGeneralMapping and IsZero, IsObject ], SUM_FLAGS,
     function( zero, elm )
-    if elm = Zero( Range( zero ) ) then
+    if IsZero( elm ) then
       return Zero( Source( zero ) );
     else
       return fail;

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1037,7 +1037,7 @@ InstallMethod( Order,
   function ( mat )
 
     local dim, F, tracemat, lat, red, det, trace, order, orddet, powdet,
-          ordpowdet, I;
+          ordpowdet;
 
     # Check that the argument is an invertible square matrix.
     dim:= NrRows( mat );
@@ -1106,12 +1106,10 @@ InstallMethod( Order,
     # Now use the theorem (see Morris Newman, Integral Matrices)
     # that `mat' has infinite order if the `2 * order'-th
     # power is not equal to the identity matrix.
-    I:= IdentityMat( dim );
-#T supply better `IsOne' method for matrices, without constructing an object!
     mat:= mat ^ order;
-    if mat = I then
+    if IsOne(mat) then
       return order;
-    elif mat ^ 2 = I then
+    elif IsOne(mat ^ 2) then
       return 2 * order;
     else
       return infinity;

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -2387,7 +2387,7 @@ function( mat )
 
     # check if <A> is invertible
     c := CoefficientsOfUnivariatePolynomial(p);
-    if c[1] = Zero(c[1])  then
+    if IsZero(c[1])  then
         Error( "matrix <mat> must be invertible" );
     fi;
 

--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -52,7 +52,7 @@ BindGlobal("IsCentralModule",function( G, modu )
     local mats;
     if Length( modu ) > 1 then return false; fi;
     mats := LinearOperationLayer( G, modu );
-    return ForAll( mats, x -> x = x^0 );
+    return ForAll( mats, IsOne );
 end);
 
 #############################################################################

--- a/lib/meataxe.gi
+++ b/lib/meataxe.gi
@@ -578,7 +578,7 @@ local module, sub, typ, matrices, dim, subdim, F,
 
         # Check that the vector is now zero - if not, then sub was
         # not the basis of a submodule
-        if im <> Zero(im) then return fail; fi;
+        if not IsZero(im) then return fail; fi;
         Add(newg, newim);
       od;
       Add(smatrices,ImmutableMatrix(F,newg));
@@ -1161,7 +1161,7 @@ SMTX.IrreducibilityTest:=function( module )
                      pfac2:=orig_pol;
                      while true do
                        quotRem := QuotRemLaurpols(pfac2, sfac[facno], 3);
-                       if quotRem[2] <> Zero(R) then
+                       if not IsZero(quotRem[2]) then
                          break;
                        fi;
                        pfac2 := quotRem[1];
@@ -3045,7 +3045,7 @@ local a,u,i,nb;
   u:=[];
   for i in nb do
     TriangulizeMat(i);
-    Add(u,Filtered(i,j->j<>Zero(j)));
+    Add(u,Filtered(i,j->not IsZero(j)));
   od;
   return u;
 end;

--- a/lib/polyfinf.gi
+++ b/lib/polyfinf.gi
@@ -248,7 +248,7 @@ local   cr,  opt,  irf,  i,  ind,  v,  l,  g,  k,  d,
   d := Derivative(k);
 
   # if the derivative is nonzero then $k / Gcd(k,d)$ is squarefree
-  if d <> Zero(R)  then
+  if not IsZero(d)  then
 
     # compute the gcd of <k> and the derivative <d>
     g := GcdOp( k, d );

--- a/lib/polyfinf.gi
+++ b/lib/polyfinf.gi
@@ -362,7 +362,7 @@ local   cr,  opt,  irf,  i,  ind,  v,  l,  g,  k,  d,
   fi;
 
   # return the factorization and store it
-  if l<>l^0 then
+  if not IsOne(l) then
     facs[1] := facs[1]*l;
   fi;
   if not (IsBound(opt.onlydegs) or IsBound(opt.stopdegs))  then

--- a/lib/polyrat.gi
+++ b/lib/polyrat.gi
@@ -1354,7 +1354,7 @@ local  p2, res, j, i,ii,o,d,b,lco,degs, step, cnew, sel, deli,
   until 0 = Length(sel) or Length(sel)<step;
 
   # if <split> is true we *must* find a complete factorization.
-  if split and 0 < Length(res.remaining) and f<>f^0 then
+  if split and 0 < Length(res.remaining) and not IsOne(f) then
 #and not(IsBound(opt.onlydegs) or IsBound(opt.stopdegs)) then
 
     # the remaining f must be an irreducible factor,larger than deg/2

--- a/lib/ratfun.gi
+++ b/lib/ratfun.gi
@@ -966,6 +966,44 @@ function( left, right )
   return ExtRepPolynomialRatFun(left)=ExtRepPolynomialRatFun(right);
 end);
 
+
+#############################################################################
+##
+#M  IsZero( <ratfun> )
+##
+InstallMethod( IsZero,
+    "ratfun",
+    [ IsRationalFunction ],
+    function( f )
+    if HasCoefficientsOfLaurentPolynomial(f) then
+      f := CoefficientsOfLaurentPolynomial(f);
+      return Length(f) = 2 and Length(f[1]) = 0 and f[2] = 0;
+    else
+      return Length(ExtRepNumeratorRatFun(f)) = 0;
+    fi;
+    end );
+
+
+#############################################################################
+##
+#M  IsOne( <ratfun> )
+##
+InstallMethod( IsOne,
+    "ratfun",
+    [ IsRationalFunction ],
+    function( f )
+    if HasCoefficientsOfLaurentPolynomial(f) then
+      f := CoefficientsOfLaurentPolynomial(f);
+      return Length(f) = 2 and Length(f[1]) = 1 and IsOne(f[1][1]) and f[2] = 0;
+    elif HasExtRepDenominatorRatFun(f) then
+      return ExtRepDenominatorRatFun(f) = ExtRepNumeratorRatFun(f);
+    else
+      f := ExtRepNumeratorRatFun(f);
+      return Length(f) = 2 and Length(f[1]) = 0 and f[2] = 1;
+    fi;
+    end );
+
+
 #############################################################################
 ##
 #M  <ratfun> < <ratfun>

--- a/lib/ratfunul.gi
+++ b/lib/ratfunul.gi
@@ -681,7 +681,7 @@ BIND_GLOBAL("QUOMOD_UPOLY",function (r,s,m)
 local f,g,h,fs,gs,hs,q,t;
     f := s;  fs := 1;
     g := m;  gs := 0;
-    while g <> Zero(g) do
+    while not IsZero(g) do
         t := QuotientRemainder(f,g);
         h := g;          hs := gs;
         g := t[2];       gs := fs - t[1]*gs;
@@ -883,7 +883,7 @@ local dom,deg,inum,i,c;
   for i in [0..deg] do
     Add(c,Random(dom));
   od;
-  while c[deg+1]=Zero(dom) do
+  while IsZero(c[deg+1]) do
     c[deg+1]:=Random(dom);
   od;
   return LaurentPolynomialByCoefficients(FamilyObj(c[1]),c,0,inum);

--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -547,8 +547,8 @@ InstallMethod( IsAssociated,
     if HasUnits( R ) then
       return ForAny( Units( R ), u -> r = u * s );
 
-    elif s = Zero( R ) then
-      return r = Zero( R );
+    elif IsZero( s ) then
+      return IsZero( r );
 
     # or check if the quotient is a unit
     else
@@ -879,7 +879,7 @@ InstallMethod( IsUnit,
     else
 
       # simply try to compute the inverse
-      return r <> Zero( R ) and Quotient( R, one, r ) <> fail;
+      return not IsZero( r ) and Quotient( R, one, r ) <> fail;
 #T allowed?
     fi;
     end );
@@ -1153,7 +1153,7 @@ InstallMethod( QuotientMod,
 
     f := s;  fs := 1;
     g := m;  gs := 0;
-    while g <> Zero( R ) do
+    while not IsZero( g ) do
         t := QuotientRemainder( R, f, g );
         h := g;          hs := gs;
         g := t[2];       gs := fs - t[1] * gs;
@@ -1309,7 +1309,7 @@ InstallMethod( GcdOp,
     # perform a Euclidean algorithm
     u := r;
     v := s;
-    while v <> Zero( R ) do
+    while not IsZero( v ) do
         w := v;
         v := EuclideanRemainder( R, u, v );
         u := w;
@@ -1398,14 +1398,14 @@ InstallMethod( GcdRepresentationOp,
     local   f, g, h, fx, gx, hx, q, t;
     f := x;  fx := One( R );
     g := y;  gx := Zero( R );
-    while g <> Zero( R ) do
+    while not IsZero( g ) do
         t := QuotientRemainder( R, f, g );
         h := g;          hx := gx;
         g := t[2];       gx := fx - t[1] * gx;
         f := h;          fx := hx;
     od;
     q := StandardAssociateUnit(R, f);
-    if y = Zero( R ) then
+    if IsZero( y ) then
         return [ q * fx, Zero( R ) ];
     else
         return [ q * fx, Quotient( R, q * (f - fx * x), y ) ];
@@ -1488,7 +1488,7 @@ InstallMethod( LcmOp,
     function( R, r, s )
 
     # compute the least common multiple
-    if r = Zero( R ) and s = Zero( R ) then
+    if IsZero( r ) and IsZero( s ) then
       return r;
     elif r in R and s in R then
       return StandardAssociate( R, Quotient( R, r, GcdOp( R, r, s ) ) * s );

--- a/lib/teaching.g
+++ b/lib/teaching.g
@@ -565,7 +565,7 @@ InstallGlobalFunction(RootsOfPolynomial,function(arg)
     if Size(R)>10^7 then
       Error("R is not an UFD and too large to test for roots");
     fi;
-    return Filtered(Enumerator(R),x->Value(p,x)=Zero(R));
+    return Filtered(Enumerator(R),x->IsZero(Value(p,x)));
   fi;
 end);
 


### PR DESCRIPTION
- **Optimize IsZero and IsOne for rational functions**
- **Use IsOne in more places**
- **Use IsZero in more places**

The optimization is fairly minor and mostly about avoiding allocations.

Before:

    gap> for i in [1..1000000] do
    >     IsOne(X(Rationals));
    >    od; [memory_allocated, time];
    [ 698011107, 1466 ]

After:

    gap> for i in [1..1000000] do
    >     IsOne(X(Rationals));
    >    od; [memory_allocated, time];
    [ 400011920, 1107 ]