### PR TITLE
Fix IsOne for rational functions

### DIFF
--- a/hpcgap/lib/ratfun.gi
+++ b/hpcgap/lib/ratfun.gi
@@ -972,6 +972,57 @@ function( left, right )
   return ExtRepPolynomialRatFun(left)=ExtRepPolynomialRatFun(right);
 end);
 
+
+#############################################################################
+##
+#M  IsZero( <ratfun> )
+##
+InstallMethod( IsZero,
+    "ratfun",
+    [ IsRationalFunction ],
+    function( f )
+    if HasCoefficientsOfLaurentPolynomial(f) then
+      f := CoefficientsOfLaurentPolynomial(f);
+      return Length(f[1]) = 0;
+    elif HasCoefficientsOfUnivariateRationalFunction(f) then
+      f := CoefficientsOfUnivariateRationalFunction(f);
+      return Length(f[1]) = 0;
+    elif HasExtRepPolynomialRatFun(f) then
+      return Length(ExtRepPolynomialRatFun(f)) = 0;
+    elif HasExtRepNumeratorRatFun(f) then
+      return Length(ExtRepNumeratorRatFun(f)) = 0;
+    fi;
+    TryNextMethod();
+    end );
+
+
+#############################################################################
+##
+#M  IsOne( <ratfun> )
+##
+InstallMethod( IsOne,
+    "ratfun",
+    [ IsRationalFunction ],
+    function( f )
+    if HasCoefficientsOfLaurentPolynomial(f) then
+      f := CoefficientsOfLaurentPolynomial(f);
+      return Length(f) = 2 and Length(f[1]) = 1 and IsOne(f[1][1]) and f[2] = 0;
+    elif HasCoefficientsOfUnivariateRationalFunction(f) then
+      f := CoefficientsOfUnivariateRationalFunction(f);
+      return Length(f) = 3 and f[3] = 0 and f[1] = f[2];
+    elif HasExtRepPolynomialRatFun(f) then
+      f := ExtRepPolynomialRatFun(f);
+      return Length(f) = 2 and Length(f[1]) = 0 and IsOne(f[2]);
+    elif HasExtRepNumeratorRatFun(f) and HasExtRepDenominatorRatFun(f) then
+      return ExtRepDenominatorRatFun(f) = ExtRepNumeratorRatFun(f);
+    elif HasExtRepNumeratorRatFun(f) then
+      f := ExtRepNumeratorRatFun(f);
+      return Length(f) = 2 and Length(f[1]) = 0 and IsOne(f[2]);
+    fi;
+    TryNextMethod();
+    end );
+
+
 #############################################################################
 ##
 #M  <ratfun> < <ratfun>

--- a/lib/ratfun.gi
+++ b/lib/ratfun.gi
@@ -977,10 +977,16 @@ InstallMethod( IsZero,
     function( f )
     if HasCoefficientsOfLaurentPolynomial(f) then
       f := CoefficientsOfLaurentPolynomial(f);
-      return Length(f) = 2 and Length(f[1]) = 0 and f[2] = 0;
-    else
+      return Length(f[1]) = 0;
+    elif HasCoefficientsOfUnivariateRationalFunction(f) then
+      f := CoefficientsOfUnivariateRationalFunction(f);
+      return Length(f[1]) = 0;
+    elif HasExtRepPolynomialRatFun(f) then
+      return Length(ExtRepPolynomialRatFun(f)) = 0;
+    elif HasExtRepNumeratorRatFun(f) then
       return Length(ExtRepNumeratorRatFun(f)) = 0;
     fi;
+    TryNextMethod();
     end );
 
 
@@ -995,12 +1001,19 @@ InstallMethod( IsOne,
     if HasCoefficientsOfLaurentPolynomial(f) then
       f := CoefficientsOfLaurentPolynomial(f);
       return Length(f) = 2 and Length(f[1]) = 1 and IsOne(f[1][1]) and f[2] = 0;
-    elif HasExtRepDenominatorRatFun(f) then
+    elif HasCoefficientsOfUnivariateRationalFunction(f) then
+      f := CoefficientsOfUnivariateRationalFunction(f);
+      return Length(f) = 3 and f[3] = 0 and f[1] = f[2];
+    elif HasExtRepPolynomialRatFun(f) then
+      f := ExtRepPolynomialRatFun(f);
+      return Length(f) = 2 and Length(f[1]) = 0 and IsOne(f[2]);
+    elif HasExtRepNumeratorRatFun(f) and HasExtRepDenominatorRatFun(f) then
       return ExtRepDenominatorRatFun(f) = ExtRepNumeratorRatFun(f);
-    else
+    elif HasExtRepNumeratorRatFun(f) then
       f := ExtRepNumeratorRatFun(f);
-      return Length(f) = 2 and Length(f[1]) = 0 and f[2] = 1;
+      return Length(f) = 2 and Length(f[1]) = 0 and IsOne(f[2]);
     fi;
+    TryNextMethod();
     end );
 
 

--- a/tst/testinstall/ratfun.tst
+++ b/tst/testinstall/ratfun.tst
@@ -1,4 +1,4 @@
-#@local det,mat,p0,p1,p2,q0,q1,q2,t,y1,y2,y3,u,f,g,data,fam
+#@local det,mat,p0,p1,p2,q0,q1,q2,t,y1,y2,y3,u,f,g,data,fam,helper,data2
 gap> START_TEST("ratfun.tst");
 
 #
@@ -26,6 +26,52 @@ gap> List(data, IsUnivariateRationalFunction);
 [ true, true, true, true, true, true, false, false, false, false, false ]
 gap> List(data, IsLaurentPolynomial);
 [ true, true, true, true, true, false, false, false, false, false, false ]
+gap> List(data, IsZero);
+[ true, false, false, false, false, false, false, false, false, true, false ]
+gap> List(data, IsOne);
+[ false, true, false, false, false, false, false, false, false, false, false ]
+
+#
+# some more tests in special representations
+#
+gap> helper := [
+>   f -> PolynomialByExtRep(FamilyObj(f), ExtRepPolynomialRatFun(f)),
+>   f -> RationalFunctionByExtRep(FamilyObj(f), ExtRepNumeratorRatFun(f), ExtRepDenominatorRatFun(f)),
+>   f -> UnivariatePolynomial(Rationals,CoefficientsOfUnivariatePolynomial(f),IndeterminateNumberOfUnivariateLaurentPolynomial(f)),
+>   f -> UnivariateRationalFunctionByCoefficients(FamilyObj(f),
+>               CoefficientsOfUnivariateRationalFunction(f)[1],
+>               CoefficientsOfUnivariateRationalFunction(f)[2],
+>               CoefficientsOfUnivariateRationalFunction(f)[3],
+>               IndeterminateNumberOfUnivariateRationalFunction(f)),
+> ];;
+
+#
+gap> data2 := Concatenation(List(helper, f -> [f(t), f(t^0), f(t*0)]));
+[ t, 1, 0, t/1, 1/1, 0/1, t, 1, 0, 1*x_100, 1, 0 ]
+gap> List(data2, IsOne);
+[ false, true, false, false, true, false, false, true, false, false, true, 
+  false ]
+gap> List(data2, IsZero);
+[ false, false, true, false, false, true, false, false, true, false, false, 
+  true ]
+gap> List(data2, NamesOfComponents);
+[ [ "ExtRepPolynomialRatFun" ], [ "ExtRepPolynomialRatFun" ], 
+  [ "ExtRepPolynomialRatFun" ], 
+  [ "ExtRepNumeratorRatFun", "ExtRepDenominatorRatFun" ], 
+  [ "ExtRepNumeratorRatFun", "ExtRepDenominatorRatFun" ], 
+  [ "ExtRepNumeratorRatFun", "ExtRepDenominatorRatFun" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ] ]
 
 #
 # arithmetics

--- a/tst/testinstall/ratfun_gf5.tst
+++ b/tst/testinstall/ratfun_gf5.tst
@@ -24,6 +24,53 @@ gap> List(data, IsUnivariateRationalFunction);
 [ true, true, true, true, true, true, false, false, false, false, false ]
 gap> List(data, IsLaurentPolynomial);
 [ true, true, true, true, true, false, false, false, false, false, false ]
+gap> List(data, IsZero);
+[ true, false, false, false, false, false, false, false, false, true, false ]
+gap> List(data, IsOne);
+[ false, true, false, false, false, false, false, false, false, false, false ]
+
+#
+# some more tests in special representations
+#
+gap> helper := [
+>   f -> PolynomialByExtRep(FamilyObj(f), ExtRepPolynomialRatFun(f)),
+>   f -> RationalFunctionByExtRep(FamilyObj(f), ExtRepNumeratorRatFun(f), ExtRepDenominatorRatFun(f)),
+>   f -> UnivariatePolynomial(GF(5),CoefficientsOfUnivariatePolynomial(f),IndeterminateNumberOfUnivariateLaurentPolynomial(f)),
+>   f -> UnivariateRationalFunctionByCoefficients(FamilyObj(f),
+>               CoefficientsOfUnivariateRationalFunction(f)[1],
+>               CoefficientsOfUnivariateRationalFunction(f)[2],
+>               CoefficientsOfUnivariateRationalFunction(f)[3],
+>               IndeterminateNumberOfUnivariateRationalFunction(f)),
+> ];;
+
+#
+gap> data2 := Concatenation(List(helper, f -> [f(t), f(t^0), f(t*0)]));
+[ t, Z(5)^0, 0*Z(5), t/Z(5)^0, Z(5)^0/Z(5)^0, 0*Z(5)/Z(5)^0, t, Z(5)^0, 
+  0*Z(5), Z(5)^0*x_100, Z(5)^0, 0*Z(5) ]
+gap> List(data2, IsOne);
+[ false, true, false, false, true, false, false, true, false, false, true, 
+  false ]
+gap> List(data2, IsZero);
+[ false, false, true, false, false, true, false, false, true, false, false, 
+  true ]
+gap> List(data2, NamesOfComponents);
+[ [ "ExtRepPolynomialRatFun" ], [ "ExtRepPolynomialRatFun" ], 
+  [ "ExtRepPolynomialRatFun" ], 
+  [ "ExtRepNumeratorRatFun", "ExtRepDenominatorRatFun" ], 
+  [ "ExtRepNumeratorRatFun", "ExtRepDenominatorRatFun" ], 
+  [ "ExtRepNumeratorRatFun", "ExtRepDenominatorRatFun" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ], 
+  [ "CoefficientsOfLaurentPolynomial", 
+      "IndeterminateNumberOfUnivariateRationalFunction" ] ]
 
 #
 # arithmetics

--- a/tst/testinstall/ringpoly.tst
+++ b/tst/testinstall/ringpoly.tst
@@ -1,4 +1,4 @@
-#@local R,P,F,fam,f,PP,PF
+#@local R,P,F,fam,f,PP,PF,old_ITER_POLY_WARN
 gap> START_TEST("ringpoly.tst");
 
 # Commutativity and associativity
@@ -30,6 +30,7 @@ gap> f in F;
 true
 
 # Membership for function fields over polynomial rings
+gap> old_ITER_POLY_WARN := ITER_POLY_WARN;;
 gap> ITER_POLY_WARN := false;;
 gap> P := PolynomialRing(Rationals, 2);;
 gap> PP := PolynomialRing(P, 2);;
@@ -45,6 +46,7 @@ gap> fam := FamilyObj(PP.1);;
 gap> f := RationalFunctionByExtRep(fam, [ [], One(P) ], [ [ 2, 1 ], 1/2*One(P) ]);;
 gap> f in PF;
 true
+gap> ITER_POLY_WARN := old_ITER_POLY_WARN;;
 
 #
 gap> STOP_TEST("ringpoly.tst");


### PR DESCRIPTION
Also improve the `IsZero` method, add a bunch of tests covering different representations for univariate polynomials, and sync the code with its HPC-GAP version.

Resolves #6065 (at least for GBNP)