### PR TITLE
Deprecate `InstallValue` for anything but plain objects (i.e., plain GAP lists, records or strings) and warn if it is done anyway

### DIFF
--- a/lib/variable.g
+++ b/lib/variable.g
@@ -126,6 +126,8 @@ end );
 ##  <Ref Func="InstallValue"/> does <E>not</E> work if <A>value</A> is an
 ##  <Q>immediate object</Q>, i.e., an internally represented small integer or
 ##  finite field element. It also fails for booleans.
+##  In addition, the use of any other type of <A>value</A> except for a list
+##  or record is deprecated.
 ##  Furthermore, <Ref Func="InstallFlushableValue"/> works only if
 ##  <A>value</A> is a list or a record.
 ##  (Note that <Ref Func="InstallFlushableValue"/> makes sense only for
@@ -158,7 +160,11 @@ BIND_GLOBAL( "InstallValue", function ( gvar, value )
         Error("InstallValue: a value has been installed already");
     fi;
     if TNUM_OBJ(value) in UNCLONEABLE_TNUMS then
-       Error("InstallValue: <value> cannot be immediate, boolean or character");
+       Error("InstallValue: <value> cannot be immediate, boolean or character, ",
+             "and it should rather be a record or a list");
+    fi;
+    if not IS_REC(value) and not IS_PLIST_REP(value) and not IS_STRING_REP(value) then
+      Print("WARNING, InstallValue: <value> should be a record or list while reading ", INPUT_FILENAME(), ":", INPUT_LINENUMBER(), "\n");
     fi;
     if IsFamily( value ) then
       INFO_DEBUG( 1,

--- a/lib/variable.g
+++ b/lib/variable.g
@@ -157,13 +157,13 @@ BIND_GLOBAL( "InstallValue", function ( gvar, value )
        IsToBeDefinedObj( gvar ) then
         Error("InstallValue: a value has been installed already");
     fi;
+    if TNUM_OBJ(value) in UNCLONEABLE_TNUMS then
+       Error("InstallValue: <value> cannot be immediate, boolean or character");
+    fi;
     if IsFamily( value ) then
       INFO_DEBUG( 1,
           "please use `BindGlobal' for the family object ",
           value!.NAME, ", not `InstallValue'" );
-    fi;
-    if TNUM_OBJ(value) in UNCLONEABLE_TNUMS then
-       Error("InstallValue: <value> cannot be immediate, boolean or character");
     fi;
     CLONE_OBJ (gvar, value);
 end);

--- a/tst/testbugfix/00000.tst
+++ b/tst/testbugfix/00000.tst
@@ -1,3 +1,4 @@
 gap> DeclareGlobalVariable("foo73");
 gap> InstallValue(foo73,true);
-Error, InstallValue: <value> cannot be immediate, boolean or character
+Error, InstallValue: <value> cannot be immediate, boolean or character, and it\
+ should rather be a record or a list


### PR DESCRIPTION
The GAP library hasn't been doing this for quite some time, and with the recent `crisp` 1.4.9 release I believe the last distributed GAP package now stopped using `InstallValue` on non-plain objects.

We can't just remove this capability as users may have code relying on it, but we can at least introduce a warning.

And with a hypothetical strict mode (see #1191) it could be turned into an error. Then CI should run with this error enabled.

Resolves #1637