### PR TITLE
Ensure `InterpolatedPolynomial` always returns a polynomial, even for "constant" input

### DIFF
--- a/lib/ring.gi
+++ b/lib/ring.gi
@@ -330,7 +330,7 @@ InstallOtherMethod( InterpolatedPolynomial, true,
         od;
         a[i] := t[1];
     od;
-    p := a[Length(x)];
+    p := a[Length(x)] * Indeterminate(R)^0;
     for i  in [ Length(x)-1, Length(x)-2 .. 1 ]  do
         p := p * (Indeterminate(R)-x[i]) + a[i];
     od;

--- a/tst/testbugfix/2025-08-25-InterpolatedPolynomial.tst
+++ b/tst/testbugfix/2025-08-25-InterpolatedPolynomial.tst
@@ -1,0 +1,17 @@
+# InterpolatedPolynomial should always return a polynomial.
+# Reported by István Szöllősi during GAP Days 2025.
+#
+gap> f:=InterpolatedPolynomial( Integers, [ 1, 2, 3 ], [ 5, 5, 5 ] );
+5
+gap> IsInt(f);
+false
+gap> IsPolynomial(f);
+true
+
+#
+gap> f:=InterpolatedPolynomial( Integers, [ 1 ], [ 5 ] );
+5
+gap> IsInt(f);
+false
+gap> IsPolynomial(f);
+true


### PR DESCRIPTION
Before:

    gap> f:=InterpolatedPolynomial( Integers, [ 1 ], [ 5 ] );
    5
    gap> IsInt(f);
    true
    gap> IsPolynomial(f);
    false

After:

    gap> f:=InterpolatedPolynomial( Integers, [ 1 ], [ 5 ] );
    5
    gap> IsInt(f);
    false
    gap> IsPolynomial(f);
    true

Please provide a short summary of this PR and its purpose here. E.g., does it add a new feature, and which? Does it fix a bug, and which? If there is an associated issue, please list it here.

## Text for release notes

We track noteworthy changes as entries in the `CHANGES.md` file in the root directory of this repository. To help us decide whether and how to describe your PR, please do one of the following:

1. If this PR shall **not** be mentioned in the release notes, write "none" here.
2. If a brief note suffices, edit the title of this PR to be usable as entry in `CHANGES.md`, and write "see title" here (or if you have the required permissions, add the label `release notes: use title` to this PR and remove this section)
3. If a longer note is needed, just write it here, ideally following the general style used in that file

## Further details

If necessary, provide further details down here.
