### PR TITLE
Speed up `CharacterDegrees`

### DIFF
--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -4394,7 +4394,7 @@ DeclareOperation( "CharacterTableWithSortedClasses",
 ##  of a class of <M>F</M> are consecutive,
 ##  and that the succession of preimages is that of <A>facttbl</A>.
 ##  The <Ref Attr="Irr" Label="for a character table"/> value of <A>tbl</A>
-##  is sorted as with <C>SortCharTable( <A>tbl</A>, <A>kernel</A> )</C>.
+##  is sorted as with <C>SortedCharacterTable( <A>tbl</A>, <A>kernel</A> )</C>.
 ##  <P/>
 ##  (<E>Note</E> that the transformation is only unique up to table
 ##  automorphisms of <M>F</M>, and this need not be unique up to table

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -1629,8 +1629,8 @@ DeclareAttributeSuppCT( "CharacterParameters", IsNearlyCharacterTable,
 ##  "A5"
 ##  gap> tbl:= CharacterTable( Group( () ) );;
 ##  gap> Identifier( tbl );  Identifier( tbl mod 2 );
-##  "CT9"
-##  "CT9mod2"
+##  "CT8"
+##  "CT8mod2"
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -658,38 +658,120 @@ InstallOtherMethod( \/,
 #M  CharacterDegrees( <G> ) . . . . . . . . . . . . . . . . . . . for a group
 #M  CharacterDegrees( <G>, <zero> ) . . . . . . . . . .  for a group and zero
 ##
-##  The attribute delegates to the two-argument version.
-##  The two-argument version delegates to `Irr'.
+##  - The two-argument version with second argument zero
+##    delegates to the one-argument version.
+##
+##  - The two-argument version with second argument a positive integer <p>
+##    has one method that
+##    - calls the one-argument version if <p> does not divide the group order,
+##    - calls 'CharacterDegreesAbelian' if the group is abelian,
+##    - uses stored irreducibles of the Brauer character table in question,
+##    - calls 'CharacterDegreesConlon' if the group is solvable,
+##    - and delegates to the Brauer character table in question otherwise
+##      (which may result in an error if the degrees  cannot be computed).
+##
+##  - The one-argument version has at least the following methods,
+##    listed according to decreasing rank:
+##    - system getter,
+##    - applicable to 'IsGroup and IsAbelian',
+##    - applicable to 'IsGroup and HasIrr',
+##    - applicable to 'IsGroup and HasOrdinaryCharacterTable'
+##      (call 'TryNextMethod()' if the table does not store irreducibles),
+##    - applicable to 'IsGroup and IsHandledByNiceMonomorphism'
+##      (gets installed via 'AttributeMethodByNiceMonomorphism'),
+##    - applicable to 'IsGroup and MayBeHandledByNiceMonomorphism'
+##      (gets installed via 'AttributeMethodByNiceMonomorphism'),
+##    - applicable to 'IsGroup'
+##      (this method decides about the algorithm to be used).
 ##
 InstallMethod( CharacterDegrees,
-    "for a group (call the two-argument version)",
-    [ IsGroup ],
-    G -> CharacterDegrees( G, 0 ) );
+    "for a group, and zero (call the one-argument version)",
+    [ IsGroup, IsZeroCyc ],
+    { G, zero } -> CharacterDegrees( G ) );
+
+BindGlobal( "CharacterDegreesAbelian", function( G, p )
+    G:= Size( G );
+    if p <> 0 then
+      while G mod p = 0 do
+        G:= G / p;
+      od;
+    fi;
+    return [ [ 1, G ] ];
+    end );
 
 InstallMethod( CharacterDegrees,
-    "for a group, and zero",
-    [ IsGroup, IsZeroCyc ],
-    function( G, zero )
+    "for an abelian group",
+    [ IsGroup and IsAbelian ],
+    {} -> RankFilter( IsHandledByNiceMonomorphism ), # override nice mon. method
+    G -> CharacterDegreesAbelian( G, 0 ) );
 
-    # Force a check whether the group is solvable.
-    if not HasIsSolvableGroup( G ) and IsSolvableGroup( G ) then
+InstallMethod( CharacterDegrees,
+    "for a group with known Irr value",
+    [ IsGroup and HasIrr ],
+    {} -> RankFilter( IsHandledByNiceMonomorphism ) + 1, # override nice mon. method
+    G -> Collected( List( Irr( G ), DegreeOfCharacter ) ) );
 
-      # There is a better method which is now applicable.
-      return CharacterDegrees( G, 0 );
+InstallMethod( CharacterDegrees,
+    "for a group with known OrdinaryCharacterTable value",
+    [ IsGroup and HasOrdinaryCharacterTable ],
+    {} -> RankFilter( IsHandledByNiceMonomorphism ), # override nice mon. method
+    function( G )
+    G:= OrdinaryCharacterTable( G );
+    if not HasIrr( G ) then
+      TryNextMethod();
     fi;
-
-    # For nonsolvable groups, there is just the brute force method.
     return Collected( List( Irr( G ), DegreeOfCharacter ) );
     end );
 
 InstallMethod( CharacterDegrees,
+    "for a group",
+    [ IsGroup ],
+    function( G )
+    # We assume that the 'Irr' value is not known,
+    # otherwise a method with higher rank would have been successful.
+    if IsAbelian( G ) then
+      return CharacterDegreesAbelian( G, 0 );
+    elif IsSupersolvableGroup( G ) then
+      return CharacterDegreesBaumClausen( G );
+    elif IsSolvableGroup( G ) then
+      return CharacterDegreesConlon( G, 0 );
+    else
+      # We have no better methods.
+      return Collected( List( Irr( G ), DegreeOfCharacter ) );
+    fi;
+    end );
+
+
+#############################################################################
+##
+#M  CharacterDegrees( <G>, <p> )  . . . . . . . . . . . . . . . for prime <p>
+##
+InstallMethod( CharacterDegrees,
     "for a group, and positive integer",
     [ IsGroup, IsPosInt ],
     function( G, p )
-    if Size( G ) mod p = 0 then
-      return CharacterDegrees( CharacterTable( G, p ) );
+    local tbl, modtbl;
+
+    Assert( 1, IsPrimeInt( p ) );
+    if Size( G ) mod p <> 0 then
+      return CharacterDegrees( G );
+    elif IsAbelian( G ) then
+      return CharacterDegreesAbelian( G, p );
+    elif HasOrdinaryCharacterTable( G ) then
+      # Perhaps the 'p'-modular irreducibles are stored.
+      tbl:= CharacterTable( G );
+      if IsBound( ComputedBrauerTables( tbl )[p] ) then
+        modtbl:= ComputedBrauerTables( tbl )[p];
+        if HasIrr( modtbl ) then
+          return CharacterDegrees( modtbl );
+        fi;
+      fi;
+    fi;
+    if IsSolvableGroup( G ) then
+      return CharacterDegreesConlon( G, p );
     else
-      return CharacterDegrees( G, 0 );
+      # Perhaps we cannot compute the result.
+      return CharacterDegrees( CharacterTable( G, p ) );
     fi;
     end );
 
@@ -708,7 +790,8 @@ InstallMethod( CharacterDegrees,
     [ IsCharacterTable ],
     function( tbl )
     if HasUnderlyingGroup( tbl ) and not HasIrr( tbl ) then
-      return CharacterDegrees( UnderlyingGroup( tbl ) );
+      return CharacterDegrees( UnderlyingGroup( tbl ),
+                               UnderlyingCharacteristic( tbl ) );
     else
       return Collected( List( Irr( tbl ), DegreeOfCharacter ) );
     fi;

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -687,7 +687,7 @@ InstallOtherMethod( \/,
 InstallMethod( CharacterDegrees,
     "for a group, and zero (call the one-argument version)",
     [ IsGroup, IsZeroCyc ],
-    { G, zero } -> CharacterDegrees( G ) );
+    { G, zero } -> List( CharacterDegrees( G ), ShallowCopy ) );
 
 BindGlobal( "CharacterDegreesAbelian", function( G, p )
     G:= Size( G );
@@ -754,7 +754,7 @@ InstallMethod( CharacterDegrees,
 
     Assert( 1, IsPrimeInt( p ) );
     if Size( G ) mod p <> 0 then
-      return CharacterDegrees( G );
+      return List( CharacterDegrees( G ), ShallowCopy );
     elif IsAbelian( G ) then
       return CharacterDegreesAbelian( G, p );
     elif HasOrdinaryCharacterTable( G ) then
@@ -763,7 +763,7 @@ InstallMethod( CharacterDegrees,
       if IsBound( ComputedBrauerTables( tbl )[p] ) then
         modtbl:= ComputedBrauerTables( tbl )[p];
         if HasIrr( modtbl ) then
-          return CharacterDegrees( modtbl );
+          return List( CharacterDegrees( modtbl ), ShallowCopy );
         fi;
       fi;
     fi;
@@ -771,7 +771,7 @@ InstallMethod( CharacterDegrees,
       return CharacterDegreesConlon( G, p );
     else
       # Perhaps we cannot compute the result.
-      return CharacterDegrees( CharacterTable( G, p ) );
+      return List( CharacterDegrees( CharacterTable( G, p ) ), ShallowCopy );
     fi;
     end );
 

--- a/lib/ctblsolv.gd
+++ b/lib/ctblsolv.gd
@@ -376,3 +376,6 @@ DeclareGlobalFunction( "CoveringTriplesCharacters" );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "IrrConlon", IsGroup );
+
+DeclareGlobalName( "CharacterDegreesBaumClausen" );
+DeclareGlobalName( "CharacterDegreesConlon" );

--- a/lib/ctblsolv.gi
+++ b/lib/ctblsolv.gi
@@ -73,25 +73,6 @@ InstallMethod(LinearCharacters, ["CanEasilyComputePcgs"], function(G)
   return res;
 end);
 
-#############################################################################
-##
-#M  CharacterDegrees( <G>, <p> )  . . . . . . . . . . .  for an abelian group
-##
-InstallMethod( CharacterDegrees,
-    "for an abelian group, and an integer p (just strip off the p-part)",
-    [ IsGroup and IsAbelian, IsInt ],
-    {} -> RankFilter(IsZeroCyc), # There is a method for groups for
-                           # the integer zero which is worse
-    function( G, p )
-    G:= Size( G );
-    if p <> 0 then
-      while G mod p = 0 do
-        G:= G / p;
-      od;
-    fi;
-    return [ [ 1, G ] ];
-    end );
-
 
 #############################################################################
 ##
@@ -200,8 +181,6 @@ InstallGlobalFunction( ProjectiveCharDeg, function( G, z, q )
     p:= Factors( i )[1];
 
     if not IsAbelian( N ) then
-
-      h:= NaturalHomomorphismByNormalSubgroupNC( G, SubgroupNC( G, [ z ] ) );
 
       # `c' is a list of complement classes of `N' modulo `z'
       c:= List( ComplementClassesRepresentatives( ImagesSource( h ), ImagesSet( h, N ) ),
@@ -332,7 +311,7 @@ InstallGlobalFunction( ProjectiveCharDeg, function( G, z, q )
     orbs:= Filtered( orbs,
               o -> not IsZero( CanonicalRepresentativeOfExternalSet( o ) ) );
 
-    # In this case the stabilzers of the kernels are already the
+    # In this case the stabilizers of the kernels are already the
     # stabilizers of the characters.
     for orb in orbs do
       k:= KernelUnderDualAction( O, Opcgs,
@@ -464,19 +443,19 @@ BindGlobal( "CharacterDegreesConlon", function( G, q )
     # (Note that we must not call `TryNextMethod' because the method
     # for abelian groups has higher rank.)
     if IsAbelian( G ) then
-      r:= CharacterDegrees( G, q );
+      r:= CharacterDegreesAbelian( G, q );
       Info( InfoCharacterTable, 1,
             "CharacterDegrees: returns ", r );
       return r;
     elif not ( q = 0 or IsPrimeInt( q ) ) then
-      Error( "<q> mut be zero or a prime" );
+      Error( "<q> must be zero or a prime" );
     fi;
 
     # Choose a normal elementary abelian `p'-subgroup `N',
     # not necessarily minimal.
     N:= ElementaryAbelianSeriesLargeSteps( G );
     N:= N[ Length( N ) - 1 ];
-    r:= CharacterDegrees( G / N, q );
+    r:= CharacterDegreesConlon( G / N, q );
     p:= Factors( Size( N ) )[1];
 
     if p = q then
@@ -538,20 +517,6 @@ BindGlobal( "CharacterDegreesConlon", function( G, q )
     Info( InfoCharacterTable, 1,
           "CharacterDegrees: returns ", r );
     return r;
-    end );
-
-InstallMethod( CharacterDegrees,
-    "for a solvable group and an integer (Conlon's algorithm)",
-    [ IsGroup and IsSolvableGroup, IsInt ],
-    {} -> RankFilter(IsZeroCyc), # There is a method for groups for
-                           # the integer zero which is worse
-    function( G, q )
-    if HasIrr( G ) then
-      # Use the known irreducibles.
-      TryNextMethod();
-    else
-      return CharacterDegreesConlon( G, q );
-    fi;
     end );
 
 
@@ -2199,6 +2164,25 @@ InstallMethod( IrrBaumClausen,
 
     # Return the result.
     return irreducibles;
+    end );
+
+
+#############################################################################
+##
+#F  CharacterDegreesBaumClausen( <G> )  . . . . . . . .  for a solvable group
+##
+##  For a solvable group <G>, return the character degrees of the factor
+##  group '<G> / DerivedSubgroup( <R> )',
+##  where <R> is the supersolvable residuum of <G>.
+##  The value is a sorted list of pairs '[ <d>, <n> ]'
+##  where <d> is an irreducible degree and <n> is its multiplicity.
+##
+BindGlobal( "CharacterDegreesBaumClausen", function( G )
+    local info;
+
+    info:= BaumClausenInfo( G );
+    return Concatenation( [ [ 1, Length( info.lin ) ] ],
+               Collected( List( info.nonlin, l -> Length( l[1].diag ) ) ) );
     end );
 
 

--- a/tst/testbugfix/2005-08-23-t00094.tst
+++ b/tst/testbugfix/2005-08-23-t00094.tst
@@ -1,5 +1,14 @@
 # 2005/08/23 (TB)
+# At that time, the fix meant to exit from a method that computes
+# the degrees, in order to get into a method that uses the stored
+# irreducibles.
+# With the changes from 'https://github.com/gap-system/gap/pull/6075',
+# the method that uses the stored irreducibles has higher rank,
+# thus a delegation via 'TryNextMethod' is not necessary anymore.
+
 gap> g:= SymmetricGroup( 4 );; IsSolvable( g );; Irr( g );;
-gap> meth:= ApplicableMethod( CharacterDegrees, [ g, 0 ] );;
-gap> meth( g, 0 );
-"TRY_NEXT_METHOD"
+gap> meth:= ApplicableMethod( CharacterDegrees, [ g ] );;
+gap> info:= First( MethodsOperation( CharacterDegrees, 1 ),
+>                  r -> r.func = meth );;
+gap> info.info = "CharacterDegrees: for a group with known Irr value";
+true

--- a/tst/testinstall/ctblsolv.tst
+++ b/tst/testinstall/ctblsolv.tst
@@ -1,5 +1,7 @@
-#@local G,pair
+#@local G, pair, mth, all, rks, tbl
 gap> START_TEST("ctblsolv.tst");
+
+##
 gap> CharacterDegrees( SmallGroup( 256, 529 ) );
 [ [ 1, 8 ], [ 2, 30 ], [ 4, 8 ] ]
 gap> for pair in [ [ 18, 3 ], [ 27, 3 ], [ 36, 7 ], [ 50, 3 ], [ 54, 4 ] ] do
@@ -9,4 +11,90 @@ gap> for pair in [ [ 18, 3 ], [ 27, 3 ], [ 36, 7 ], [ 50, 3 ], [ 54, 4 ] ] do
 >        Error( IdGroup( G ) );
 >      fi;
 >    od;
+
+##
+gap> mth:= [];;
+gap> G:= AbelianGroup( [ 2, 3, 5 ] );;
+gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
+gap> CharacterDegrees( G ) = [ [ 1, 30 ] ];
+true
+gap> G:= SmallGroup( 24, 12 );;  Irr( G );;
+gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
+true
+gap> G:= SmallGroup( 24, 12 );;  CharacterTable( G );;
+gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
+true
+gap> G:= GL( 2, 3 );;
+gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 3 ], [ 3, 2 ], [ 4, 1 ] ];
+true
+gap> G:= Group( [ [ E(3) ] ], [ [ E(4) ] ] );;
+gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
+gap> CharacterDegrees( G ) = [ [ 1, 12 ] ];
+true
+gap> G:= SmallGroup( 24, 12 );;  # hier: auch überaufl.!!!
+gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
+true
+gap> all:= MethodsOperation( CharacterDegrees, 1 );;
+gap> rks:= Reversed( List( mth, f -> First( all, r -> r.func = f ).rank ) );;
+gap> IsSSortedList( rks );
+true
+gap> G:= Group( (1,2), (3,4) );;
+gap> ApplicableMethod( CharacterDegrees, [ G ] ) = Last( mth );
+true
+gap> CharacterDegrees( G ) = [ [ 1, 4 ] ];
+true
+gap> G:= Group( (1,2,3), (1,2) );;
+gap> ApplicableMethod( CharacterDegrees, [ G ] ) = Last( mth );
+true
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ] ];
+true
+gap> G:= Group( (1,2,3,4), (1,2) );;
+gap> ApplicableMethod( CharacterDegrees, [ G ] ) = Last( mth );
+true
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
+true
+gap> G:= Group( (1,2,3,4,5), (1,2) );;
+gap> ApplicableMethod( CharacterDegrees, [ G ] ) = Last( mth );
+true
+gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 4, 2 ], [ 5, 2 ], [ 6, 1 ] ];
+true
+
+##
+gap> G:= Group( (1,2,3,4,5), (1,2) );;
+gap> CharacterDegrees( G, 0 ) = [ [ 1, 2 ], [ 4, 2 ], [ 5, 2 ], [ 6, 1 ] ];
+true
+gap> HasCharacterDegrees( G );
+true
+gap> G:= Group( (1,2,3,4,5), (1,2) );;
+gap> CharacterDegrees( G, 7 ) = [ [ 1, 2 ], [ 4, 2 ], [ 5, 2 ], [ 6, 1 ] ];
+true
+gap> HasCharacterDegrees( G );
+true
+gap> CharacterDegrees( G, 4 );
+Error, Assertion failure
+gap> G:= Group( (1,2,3), (4,5) );;
+gap> CharacterDegrees( G, 3 ) = [ [ 1, 2 ] ];
+true
+gap> G:= SymmetricGroup( 5 );;  CharacterTable( G ) mod 3;;
+gap> CharacterDegrees( G, 3 ) = [ [ 1, 2 ], [ 4, 2 ], [ 6, 1 ] ];
+true
+gap> G:= SymmetricGroup( 4 );;
+gap> CharacterDegrees( G, 3 ) = [ [ 1, 2 ], [ 3, 2 ] ];
+true
+gap> G:= SymmetricGroup( 5 );;
+gap> CharacterDegrees( G, 3 ) = [ [ 1, 2 ], [ 4, 2 ], [ 6, 1 ] ];
+true
+
+##
+gap> tbl:= CharacterTable( SymmetricGroup( 5 ) );;
+gap> CharacterDegrees( tbl ) = [ [ 1, 2 ], [ 4, 2 ], [ 5, 2 ], [ 6, 1 ] ];
+true
+gap> CharacterDegrees( tbl mod 3 ) = [ [ 1, 2 ], [ 4, 2 ], [ 6, 1 ] ];
+true
+
+##
 gap> STOP_TEST("ctblsolv.tst");


### PR DESCRIPTION
- Use `BaumClausenInfo` if the group in question is supersolvable.
- Redistribute the available code to methods.
- Fix a few typos.
- Change the delegation: Up to now, the one-argument version delegated to the two-argument version, now it is the other way round whenever possible. The idea is to use a stored attribute value whenever possible. ~(This changes the behaviour in the sense that now the two-argument version returns more often an immutable result. We could regard this as a breaking change, which should be avoided.)~

Computing the ordinary character degrees for the groups of order up to 100 needs more than 19 seconds with the old `CharacterDegrees`, the proposed variant needs about 4,6 seconds.
(The speedup is bigger for samples of larger groups, provided that sufficiently many supersolvable groups are contained.)