### PR TITLE
Fix `AntiSymmetricParts`

### DIFF
--- a/lib/ctblfuns.gi
+++ b/lib/ctblfuns.gi
@@ -3924,10 +3924,12 @@ InstallGlobalFunction( AntiSymmetricParts, function( tbl, characters, n )
         od;
 
       od;
-      if IsClassFunction( chi ) and sym[1] > 0 then
-        sym:= ClassFunctionSameType( tbl, chi, sym );
-      elif HasIsVirtualCharacter( chi ) and IsVirtualCharacter( chi ) then
-        sym:= VirtualCharacter( tbl, sym );
+      if IsClassFunction( chi ) then
+        if IsZero( sym ) then
+          sym:= VirtualCharacter( tbl, sym );
+        else
+          sym:= ClassFunctionSameType( tbl, chi, sym );
+        fi;
       fi;
       Add( antisymmetricparts, sym );
 

--- a/tst/testinstall/ctblfuns.tst
+++ b/tst/testinstall/ctblfuns.tst
@@ -91,4 +91,11 @@ gap> chi = chi^0;
 true
 
 #
+gap> tbl:= CharacterTable( SymmetricGroup( 4 ) );;
+gap> chi:= ClassFunction( tbl, 0 * Irr( tbl )[1] );
+ClassFunction( CharacterTable( Sym( [ 1 .. 4 ] ) ), [ 0, 0, 0, 0, 0 ] )
+gap> AntiSymmetricParts( tbl, [ chi ], 2 );
+[ VirtualCharacter( CharacterTable( Sym( [ 1 .. 4 ] ) ), [ 0, 0, 0, 0, 0 ] ) ]
+
+#
 gap> STOP_TEST("ctblfuns.tst");


### PR DESCRIPTION
When calling `AntiSymmetricParts` with a class function object that does not store whether it is a virtual character then a zero result was erroneously not wrapped into a class function object.