### PR TITLE
Speed up `RandomInvertibleMat` and `Random(GL(n,q))`

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -3848,16 +3848,16 @@ InstallGlobalFunction( RandomInvertibleMat, function ( arg )
 
     # now construct the random matrix
     mat := [];
-    for i  in [1..m]  do
-        repeat
+    repeat
+        for i  in [1..m]  do
             row := [];
             for k  in [1..m]  do
                 row[k] := Random( rs, R );
             od;
             ConvertToVectorRepNC( row, R );
             mat[i] := row;
-        until NullspaceMat( mat ) = [];
-    od;
+        od;
+    until RankMat( mat ) = m;
 
     # We do *not* call ConvertToMatrixRep here, as that can cause
     # unexpected problems for the user (e.g. if a matrix over GF(2) is


### PR DESCRIPTION
Calling NullspaceMat invokes Gaussian elimination, which for an m x n matrix with m < n has complexity in O(nm^2). Calling this repeatedly for m = 1, ..., n essentially turns this into an O(n^4) algorithm. Creating a random n x n matrix is in O(n^2). So it is much faster to simply create the entire matrix and then perform a single rank check at the end. Also, use RankMat instead of NullSpaceMat.

Another approach would be to compute an RREF of the matrix iteratively: each time we compute a new row, reduce it with the RREF rows we already have; if it reduces to zero we need to start over, otherwise we add the reduced vector to the RREF, and proceed to the next row. That would be a bit faster as it could exist earlier.

But then again, "most" matrices have non-zero determinant, so the extra complication of this "more advanced" algorithm are usually not worth it.

Some timings with the helper

    testit:=function(reps,n,R)
      local i;
      Reset(GlobalMersenneTwister,1);
      for i in [1..reps] do
        RandomInvertibleMat(n,R);
      od;
    end;

Before:

    gap> CollectGarbage(true); testit(1000, 10, GF(2)); time;
    117
    gap>
    gap>
    gap> CollectGarbage(true); testit(100, 50, GF(2)); time;
    199
    gap> CollectGarbage(true); testit(100, 50, GF(3)); time;
    292
    gap> CollectGarbage(true); testit(100, 50, GF(4)); time;
    334
    gap> CollectGarbage(true); testit(100, 50, GF(256)); time;
    397
    gap> CollectGarbage(true); testit(100, 50, GF(289)); time;
    1458
    gap> CollectGarbage(true); testit(10, 50, Rationals); time;
    7522
    gap>
    gap>
    gap> CollectGarbage(true); testit(10, 256, GF(2)); time;
    656
    gap> CollectGarbage(true); testit(10, 256, GF(3)); time;
    2415
    gap> CollectGarbage(true); testit(10, 256, GF(4)); time;
    2205
    gap> CollectGarbage(true); testit(10, 256, GF(256)); time;
    8055
    gap> CollectGarbage(true); testit(10, 256, GF(289)); time;
    37020

After:

    gap> CollectGarbage(true); testit(1000, 10, GF(2)); time;
    122
    gap>
    gap>
    gap> CollectGarbage(true); testit(100, 50, GF(2)); time;
    245
    gap> CollectGarbage(true); testit(100, 50, GF(3)); time;
    115
    gap> CollectGarbage(true); testit(100, 50, GF(4)); time;
    161
    gap> CollectGarbage(true); testit(100, 50, GF(256)); time;
    84
    gap> CollectGarbage(true); testit(100, 50, GF(289)); time;
    91
    gap> CollectGarbage(true); testit(10, 50, Rationals); time;
    321
    gap>
    gap>
    gap> CollectGarbage(true); testit(10, 256, GF(2)); time;
    558
    gap> CollectGarbage(true); testit(10, 256, GF(3)); time;
    302
    gap> CollectGarbage(true); testit(10, 256, GF(4)); time;
    433
    gap> CollectGarbage(true); testit(10, 256, GF(256)); time;
    262
    gap> CollectGarbage(true); testit(10, 256, GF(289)); time;
    343

So everything gets faster, in some cases by a lot, except for the 50x50 matrices over GF(2). I believe this is because the code for creating a random row vector is rather inefficient. This could be addressed by adding a `RandomVec` helper operation in the future.


Resolves #6086.