### PR TITLE
Widen declaration for many matrix related functions

### DIFF
--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -1315,14 +1315,6 @@ InstallMethod( InverseSameMutability, "for a zmodnz matrix",
     return n;
   end );
 
-InstallMethod( RankMat, "for a zmodnz matrix", [ IsZmodnZMatrixRep ],
-function( m )
-  m:=MutableCopyMatrix(m);
-  m:=SemiEchelonMatDestructive(m);
-  if m<>fail then m:=Length(m.vectors);fi;
-  return m;
-end);
-
 
 #InstallMethodWithRandomSource( Randomize,
 #  "for a random source and a mutable zmodnz matrix",
@@ -1450,14 +1442,6 @@ InstallMethod( CompatibleVector, "for a zmodnz matrix",
   function( v )
     return NewZeroVector(IsZmodnZVectorRep,BaseDomain(v),NumberRows(v));
   end );
-
-InstallMethod( DeterminantMat, "for a zmodnz matrix", [ IsZmodnZMatrixRep ],
-function( a )
-local m;
-  m:=Size(BaseDomain(a));
-  a:=List(a![ROWSPOS],x->x![ELSPOS]);
-  return ZmodnZObj(DeterminantMat(a),m);
-end );
 
 
 # Minimal/Characteristic  Polynomial stuff

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -296,7 +296,7 @@ DeclareSynonym( "DiagonalOfMat", DiagonalOfMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "BaseMat", IsMatrix );
+DeclareAttribute( "BaseMat", IsMatrixOrMatrixObj );
 
 #############################################################################
 ##
@@ -323,7 +323,7 @@ DeclareAttribute( "BaseMat", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "BaseMatDestructive", [ IsMatrix ] );
+DeclareOperation( "BaseMatDestructive", [ IsMatrixOrMatrixObj ] );
 
 #############################################################################
 ##
@@ -345,7 +345,7 @@ DeclareOperation( "BaseMatDestructive", [ IsMatrix ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "BaseOrthogonalSpaceMat", IsMatrix );
+DeclareAttribute( "BaseOrthogonalSpaceMat", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -372,7 +372,7 @@ DeclareAttribute( "BaseOrthogonalSpaceMat", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "DefaultFieldOfMatrix", IsMatrix );
+DeclareAttribute( "DefaultFieldOfMatrix", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -396,7 +396,7 @@ DeclareAttribute( "DefaultFieldOfMatrix", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "DepthOfUpperTriangularMatrix", IsMatrix );
+DeclareAttribute( "DepthOfUpperTriangularMatrix", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -503,7 +503,7 @@ DeclareSynonym( "DeterminantMatDivFree", DeterminantMatrixDivFree );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "DimensionsMat", IsMatrix );
+DeclareAttribute( "DimensionsMat", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -550,7 +550,7 @@ DeclareAttribute( "DimensionsMat", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "ElementaryDivisorsMat", [IsRing,IsMatrix] );
+DeclareOperation( "ElementaryDivisorsMat", [IsRing, IsMatrixOrMatrixObj] );
 DeclareGlobalFunction( "ElementaryDivisorsMatDestructive" );
 
 #############################################################################
@@ -623,7 +623,7 @@ DeclareGlobalFunction( "ElementaryDivisorsMatDestructive" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "ElementaryDivisorsTransformationsMat", [IsRing,IsMatrix] );
+DeclareOperation( "ElementaryDivisorsTransformationsMat", [IsRing, IsMatrixOrMatrixObj] );
 DeclareGlobalFunction( "ElementaryDivisorsTransformationsMatDestructive" );
 
 #############################################################################
@@ -640,7 +640,7 @@ DeclareGlobalFunction( "ElementaryDivisorsTransformationsMatDestructive" );
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareOperation( "TriangulizedNullspaceMatNT", [ IsMatrix ] );
+DeclareOperation( "TriangulizedNullspaceMatNT", [ IsMatrixOrMatrixObj ] );
 
 
 #############################################################################
@@ -666,8 +666,8 @@ DeclareOperation( "TriangulizedNullspaceMatNT", [ IsMatrix ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "NullspaceMat", IsMatrix );
-DeclareAttribute( "TriangulizedNullspaceMat", IsMatrix );
+DeclareAttribute( "NullspaceMat", IsMatrixOrMatrixObj );
+DeclareAttribute( "TriangulizedNullspaceMat", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -706,8 +706,8 @@ DeclareAttribute( "TriangulizedNullspaceMat", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "NullspaceMatDestructive", [ IsMatrix and IsMutable] );
-DeclareOperation( "TriangulizedNullspaceMatDestructive", [ IsMatrix and IsMutable] );
+DeclareOperation( "NullspaceMatDestructive", [ IsMatrixOrMatrixObj and IsMutable] );
+DeclareOperation( "TriangulizedNullspaceMatDestructive", [ IsMatrixOrMatrixObj and IsMutable] );
 
 
 #############################################################################
@@ -779,7 +779,7 @@ DeclareOperation( "Eigenvalues", [ IsRing, IsMatrixOrMatrixObj ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "Eigenspaces", [ IsRing, IsMatrix ] );
+DeclareOperation( "Eigenspaces", [ IsRing, IsMatrixOrMatrixObj ] );
 
 #############################################################################
 ##
@@ -795,7 +795,7 @@ DeclareOperation( "Eigenspaces", [ IsRing, IsMatrix ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "Eigenvectors", [ IsRing, IsMatrix ] );
+DeclareOperation( "Eigenvectors", [ IsRing, IsMatrixOrMatrixObj ] );
 
 
 #############################################################################
@@ -926,7 +926,7 @@ DeclareSynonymAttr( "RankMatDestructive", RankMatrixDestructive );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "SemiEchelonMat", IsMatrix );
+DeclareAttribute( "SemiEchelonMat", IsMatrixOrMatrixObj );
 
 #############################################################################
 ##
@@ -950,7 +950,7 @@ DeclareAttribute( "SemiEchelonMat", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SemiEchelonMatDestructive", [ IsMatrix and IsMutable] );
+DeclareOperation( "SemiEchelonMatDestructive", [ IsMatrixOrMatrixObj and IsMutable] );
 
 
 #############################################################################
@@ -987,7 +987,7 @@ DeclareOperation( "SemiEchelonMatDestructive", [ IsMatrix and IsMutable] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "SemiEchelonMatTransformation", IsMatrix );
+DeclareAttribute( "SemiEchelonMatTransformation", IsMatrixOrMatrixObj );
 
 #############################################################################
 ##
@@ -1003,7 +1003,7 @@ DeclareAttribute( "SemiEchelonMatTransformation", IsMatrix );
 ##  </ManSection>
 ##
 DeclareOperation( "SemiEchelonMatTransformationDestructive", [
-        IsMatrix and IsMutable ] );
+        IsMatrixOrMatrixObj and IsMutable ] );
 
 
 #############################################################################
@@ -1135,7 +1135,7 @@ DeclareSynonym( "MutableTransposedMat", TransposedMatMutable ); # needed?
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareOperation( "MutableTransposedMatDestructive", [IsMatrix and IsMutable] );
+DeclareOperation( "MutableTransposedMatDestructive", [IsMatrixOrMatrixObj and IsMutable] );
 
 
 #############################################################################
@@ -1163,7 +1163,7 @@ DeclareOperation( "MutableTransposedMatDestructive", [IsMatrix and IsMutable] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "TransposedMatDestructive", [ IsMatrix ] );
+DeclareOperation( "TransposedMatDestructive", [ IsMatrixOrMatrixObj ] );
 
 
 
@@ -1186,7 +1186,7 @@ DeclareOperation( "TransposedMatDestructive", [ IsMatrix ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsMonomialMatrix", IsMatrix );
+DeclareProperty( "IsMonomialMatrix", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -1211,7 +1211,7 @@ DeclareProperty( "IsMonomialMatrix", IsMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "InverseMatMod", [ IsMatrix, IsObject ] );
+DeclareOperation( "InverseMatMod", [ IsMatrixOrMatrixObj, IsObject ] );
 
 
 #############################################################################
@@ -1246,11 +1246,11 @@ DeclareOperation( "KroneckerProduct", [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj
 ##  <Oper Name="SolutionMatNoCo" Arg='mat, vec'/>
 ##
 ##  <Description>
-##  Does thework for <C>SolutionMat</C> and <C>SolutionMatDestructive</C>.
+##  Does the work for <C>SolutionMat</C> and <C>SolutionMatDestructive</C>.
 ##  </Description>
 ##  </ManSection>
 ##
-DeclareOperation( "SolutionMatNoCo", [ IsMatrix, IsRowVector ] );
+DeclareOperation( "SolutionMatNoCo", [ IsMatrixOrMatrixObj, IsRowVectorOrVectorObj ] );
 
 
 #############################################################################
@@ -1268,7 +1268,7 @@ DeclareOperation( "SolutionMatNoCo", [ IsMatrix, IsRowVector ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SolutionMat", [ IsMatrix, IsRowVector ] );
+DeclareOperation( "SolutionMat", [ IsMatrixOrMatrixObj, IsRowVectorOrVectorObj ] );
 
 #############################################################################
 ##
@@ -1300,7 +1300,7 @@ DeclareOperation( "SolutionMat", [ IsMatrix, IsRowVector ] );
 ##  <#/GAPDoc>
 ##
 DeclareOperation( "SolutionMatDestructive",
-    [ IsMatrix and IsMutable, IsRowVector ] );
+    [ IsMatrixOrMatrixObj and IsMutable, IsRowVectorOrVectorObj ] );
 
 
 ############################################################################
@@ -1326,7 +1326,7 @@ DeclareOperation( "SolutionMatDestructive",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "SumIntersectionMat", [ IsMatrix, IsMatrix ] );
+DeclareOperation( "SumIntersectionMat", [ IsMatrixOrMatrixObj, IsMatrixOrMatrixObj ] );
 
 
 
@@ -1349,7 +1349,7 @@ DeclareOperation( "SumIntersectionMat", [ IsMatrix, IsMatrix ] );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "TriangulizedMat", [ IsMatrix ] );
+DeclareOperation( "TriangulizedMat", [ IsMatrixOrMatrixObj ] );
 DeclareSynonym( "RREF", TriangulizedMat);
 
 #############################################################################
@@ -1380,7 +1380,7 @@ DeclareSynonym( "RREF", TriangulizedMat);
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "TriangulizeMat", [ IsMatrix and IsMutable ] );
+DeclareOperation( "TriangulizeMat", [ IsMatrixOrMatrixObj and IsMutable ] );
 
 
 #############################################################################
@@ -1574,7 +1574,7 @@ DeclareGlobalFunction( "BlownUpVector" );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareOperation( "DiagonalizeMat", [IsRing,IsMatrix and IsMutable] );
+DeclareOperation( "DiagonalizeMat", [IsRing, IsMatrixOrMatrixObj and IsMutable] );
 
 
 #############################################################################
@@ -2199,7 +2199,7 @@ DeclareSynonymAttr( "TraceMat", TraceMatrix );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "JordanDecomposition", IsMatrix );
+DeclareAttribute( "JordanDecomposition", IsMatrixOrMatrixObj );
 
 
 #############################################################################
@@ -2382,7 +2382,7 @@ DeclareOperation( "CharacteristicPolynomial",
 ##
 DeclareOperation("CharacteristicPolynomialMatrixNC",
   #IsField is not yet known
-  [IsRing,IsOrdinaryMatrix,IsPosInt]);
+  [IsRing,IsMatrixOrMatrixObj,IsPosInt]);
 
 
 #############################################################################
@@ -2400,7 +2400,7 @@ DeclareOperation("CharacteristicPolynomialMatrixNC",
 ##
 DeclareOperation("MinimalPolynomialMatrixNC",
   #IsField is not yet known
-  [IsRing,IsOrdinaryMatrix,IsPosInt]);
+  [IsRing,IsMatrixOrMatrixObj,IsPosInt]);
 
 #############################################################################
 ##

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -805,7 +805,7 @@ InstallMethod( CharacteristicPolynomial, "spinning over field",
         fi;
         return false;
     end,
-    [ IsField, IsField, IsOrdinaryMatrix, IsPosInt ],
+    [ IsField, IsField, IsMatrixOrMatrixObj, IsPosInt ],
     function( F, E, mat, inum )
         local B;
 
@@ -824,7 +824,7 @@ InstallMethod( CharacteristicPolynomial, "spinning over field",
 
 InstallMethod( CharacteristicPolynomialMatrixNC, "spinning over field",
     IsElmsCollsX,
-    [ IsField, IsOrdinaryMatrix, IsPosInt ],
+    [ IsField, IsMatrixOrMatrixObj, IsPosInt ],
   Matrix_CharacteristicPolynomialSameField);
 
 InstallOtherMethod( CharacteristicPolynomial,
@@ -868,7 +868,7 @@ InstallOtherMethod( CharacteristicPolynomialMatrixNC,
 InstallMethod( MinimalPolynomial,
     "spinning over field",
     IsElmsCollsX,
-    [ IsField, IsOrdinaryMatrix, IsPosInt ],
+    [ IsField, IsMatrixOrMatrixObj, IsPosInt ],
 function( F, mat,inum )
     local fld, B;
 
@@ -905,7 +905,7 @@ end);
 
 InstallMethod( MinimalPolynomialMatrixNC, "spinning over field",
     IsElmsCollsX,
-    [ IsField, IsOrdinaryMatrix, IsPosInt ],
+    [ IsField, IsMatrixOrMatrixObj, IsPosInt ],
   Matrix_MinimalPolynomialSameField);
 
 InstallOtherMethod( MinimalPolynomial,
@@ -1597,7 +1597,7 @@ end);
 ##
 InstallMethod( DeterminantMatDestructive,
     "fraction-free method",
-    [ IsOrdinaryMatrix and IsMutable],
+    [ IsMatrixOrMatrixObj and IsMutable],
     function ( mat )
     local   det, sgn, row, zero, m, i, j, k, mult, row2, piv;
 
@@ -1668,7 +1668,7 @@ end);
 ##  through here also.
 ##
 InstallMethod( DeterminantMatDestructive,"non fraction free",
-    [ IsOrdinaryMatrix and IsFFECollColl and IsMutable],
+    [ IsMatrixOrMatrixObj and IsFFECollColl and IsMutable],
 function( mat )
     local   m,  zero,  det,  sgn,  k,  j,  row,  l, row2, x;
 
@@ -1743,7 +1743,7 @@ InstallMethod( DeterminantMat,
     end );
 
 InstallMethod( DeterminantMatDestructive,"nonprime residue rings",
-    [ IsOrdinaryMatrix and
+    [ IsMatrixOrMatrixObj and
     CategoryCollections(CategoryCollections(IsZmodnZObjNonprime)) and IsMutable],
   DeterminantMatDivFree);
 
@@ -1779,7 +1779,7 @@ InstallMethod( DeterminantMatDestructive,"nonprime residue rings",
 ##
 InstallMethod( DeterminantMatDivFree,
     "Division-free method",
-    [ IsMatrix ],
+    [ IsMatrixOrMatrixObj ],
     function ( M )
         local u,v,w,i,   ## indices
               a,b,c,x,y, ## temp indices
@@ -2335,7 +2335,7 @@ end );
 ##
 InstallMethod( NullspaceMat,
     "generic method for ordinary matrices",
-    [ IsOrdinaryMatrix ],
+    [ IsMatrixOrMatrixObj ],
     mat -> SemiEchelonMatTransformation(mat).relations );
 
 InstallOtherMethod(NullspaceMat,"matrix objects",[IsMatrixObj],
@@ -2356,7 +2356,7 @@ end);
 
 InstallMethod( NullspaceMatDestructive,
     "generic method for ordinary matrices",
-    [ IsOrdinaryMatrix  and IsMutable],
+    [ IsMatrixOrMatrixObj  and IsMutable],
     mat -> SemiEchelonMatTransformationDestructive(mat).relations );
 
 InstallOtherMethod( TriangulizedNullspaceMat,
@@ -2381,7 +2381,7 @@ end );
 
 InstallMethod( TriangulizedNullspaceMatNT,
     "generic method",
-    [ IsOrdinaryMatrix ],
+    [ IsMatrixOrMatrixObj ],
     function( mat )
     local   nullspace, n, empty, i, k, row, zero, one;#
 
@@ -2425,7 +2425,7 @@ InstallMethod( TriangulizedNullspaceMatNT,
 end );
 
 #InstallMethod(TriangulizedNullspaceMat,"generic method",
-#    [IsOrdinaryMatrix],
+#    [IsMatrixOrMatrixObj],
 #    function ( mat )
 #    # triangulize the transposed of the matrix
 #    return TriangulizedNullspaceMatNT(
@@ -2433,7 +2433,7 @@ end );
 #end );
 
 #InstallMethod(TriangulizedNullspaceMatDestructive,"generic method",
-#    [IsOrdinaryMatrix],
+#    [IsMatrixOrMatrixObj],
 #    function ( mat )
 #    # triangulize the transposed of the matrix
 #    return TriangulizedNullspaceMatNT(
@@ -2545,7 +2545,7 @@ InstallOtherMethod( ProjectiveOrder,
 ##
 InstallOtherMethod( RankMatDestructive,
     "generic method for mutable matrices",
-    [ IsMatrix and IsMutable ],
+    [ IsMatrixOrMatrixObj and IsMutable ],
     function( mat )
     mat:= SemiEchelonMatDestructive( mat );
     if mat <> fail then
@@ -2556,7 +2556,7 @@ InstallOtherMethod( RankMatDestructive,
 
 InstallOtherMethod( RankMat,
     "generic method for matrices",
-    [ IsMatrix ],
+    [ IsMatrixOrMatrixObj ],
     mat -> RankMatDestructive( MutableCopyMatrix( mat ) ) );
 
 


### PR DESCRIPTION
The main motivation of course is to be able to use more MatrixObj stuff.

Also remove some now redundant methods.

Before:

    gap> m:=RandomMat(256, 256, GF(1000000007));;
    gap> mat:=Matrix(IsZmodnZMatrixRep, GF(1000000007), m);;
    gap> RankMat(mat)=256; time;
    true
    170
    gap> DeterminantMat(mat); time;
    ZmodpZObj( 873487643, 1000000007 )
    23982

After:

    gap> m:=RandomMat(256, 256, GF(1000000007));;
    gap> mat:=Matrix(IsZmodnZMatrixRep, GF(1000000007), m);;
    gap> RankMat(mat)=256; time;
    true
    161
    gap> DeterminantMat(mat); time;
    ZmodpZObj( 873487643, 1000000007 )
    1949


As discussed on #6088