### PR TITLE
Correctly pluralise "argument" in some more warning/error messages from the kernel

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -448,7 +448,7 @@ static Obj FuncID_FUNC(Obj self, Obj val1)
 static Obj FuncRETURN_FIRST(Obj self, Obj args)
 {
     if (!IS_PLIST(args) || LEN_PLIST(args) < 1)
-        ErrorMayQuit("RETURN_FIRST requires one or more arguments",0,0);
+        ErrorMayQuit("RETURN_FIRST requires at least one argument",0,0);
 
     return ELM_PLIST(args, 1);
 }

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -484,8 +484,13 @@ static Obj FuncCreateThread(Obj self, Obj funcargs)
         return ArgumentError(
             "CreateThread: Needs at least one function argument");
     Obj func = ELM_PLIST(funcargs, 1);
-    if (NARG_FUNC(func) != n - 1)
-        ErrorMayQuit("CreateThread: <func> expects %d arguments, but got %d", NARG_FUNC(func), n-1);
+    if (NARG_FUNC(func) != n - 1) {
+        if (NARG_FUNC(func) == 1) {
+            ErrorMayQuit("CreateThread: <func> expects 1 argument, but got %d", n - 1, 0);
+        } else {
+            ErrorMayQuit("CreateThread: <func> expects %d arguments, but got %d", NARG_FUNC(func), n - 1);
+        }
+    }
     templist = NEW_PLIST(T_PLIST, n);
     SET_LEN_PLIST(templist, n);
     SET_REGION(templist, NULL); // make it public

--- a/src/modules.c
+++ b/src/modules.c
@@ -520,11 +520,19 @@ static Obj ValidatedArgList(const char * name, int nargs, const char * argStr)
 {
     Obj args = ArgStringToList(argStr);
     int len = LEN_PLIST(args);
-    if (nargs >= 0 && len != nargs)
-        fprintf(stderr,
-                "#W %s takes %d arguments, but argument string is '%s'"
-                " which implies %d arguments\n",
-                name, nargs, argStr, len);
+    if (nargs >= 0 && len != nargs) {
+        if (nargs == 1) {
+            fprintf(stderr,
+                    "#W %s takes 1 argument, but argument string is '%s' "
+                    "which implies %d arguments\n",
+                    name, argStr, len);
+        } else if (len == 1) {
+            fprintf(stderr,
+                    "#W %s takes %d arguments, but argument string is '%s' "
+                    "which implies 1 argument\n",
+                    name, nargs, argStr);
+        }
+    }
     return args;
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -638,7 +638,10 @@ static void ParseCommandLineOptions(int argc, const char * argv[], int phase)
             buf[0] = options[i].minargs + '0';
             buf[1] = '\0';
             fputs(buf, stderr);
-            fputs(" arguments\n", stderr);
+            if (options[i].minargs == 1)
+                fputs("argument\n", stderr);
+            else
+                fputs("arguments\n", stderr);
             usage();
         }
 

--- a/tst/testinstall/kernel/hpc/threadapi.tst
+++ b/tst/testinstall/kernel/hpc/threadapi.tst
@@ -14,7 +14,7 @@ Error, CreateThread: Needs at least one function argument
 gap> CreateThread(1);
 Error, CreateThread: Needs at least one function argument
 gap> CreateThread(x->x);
-Error, CreateThread: <func> expects 1 arguments, but got 0
+Error, CreateThread: <func> expects 1 argument, but got 0
 gap> WaitThread(fail);
 Error, WaitThread: <thread> must be a thread object (not the value 'fail')
 gap> KillThread(fail);


### PR DESCRIPTION
I made this branch four years ago and I just rediscovered it, so I thought I may as well open a pull request. It correctly pluralises the word "argument" in more cases. See also #4343.

Some results of the changes:
```
$ bin/gap.sh -C
gap: option -C requires at least 4 arguments
$ bin/gap.sh -l
gap: option -l requires at least 1 argument
```
and
```
 #W UNB_LIST takes 2 arguments, but argument string is 'listpos' which implies 1 argument
 #W IS_CYC_INT takes 1 argument, but argument string is 'obj,obj' which implies 2 arguments
```
(I don't remember how I created these last two warnings).