### PR TITLE
Disallow duplicate named generators when constructing magmas, semigroups, groups, etc

### DIFF
--- a/doc/ref/grplib.xml
+++ b/doc/ref/grplib.xml
@@ -106,7 +106,7 @@ It is possible to influence this naming with the option <C>generatorNames</C>,
 see Section&nbsp;<Ref Sect="Function Call With Options"/>.
 If this option holds a string, then the generators are named with this
 string and sequential numbers starting with <C>1</C>.
-If this option holds a list of sufficient length consisting of
+If this option holds a list of sufficient length consisting of distinct
 nonempty strings, then the generator names are taken from this list, in order.
 <P/>
 <Example><![CDATA[

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -1491,7 +1491,8 @@ DeclareOperation( "AsLieAlgebra", [ IsDivisionRing, IsCollection ] );
 ##  <Description>
 ##  is a free (nonassociative) algebra of rank <A>rank</A>
 ##  over the division ring <A>R</A>.
-##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional strings
+##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional
+##  distinct nonempty strings
 ##  that can be used to provide names for the generators.
 ##  <Example><![CDATA[
 ##  gap> A:= FreeAlgebra( Rationals, "a", "b" );
@@ -1523,7 +1524,8 @@ DeclareGlobalFunction( "FreeAlgebra" );
 ##  <Description>
 ##  is a free (nonassociative) algebra-with-one of rank <A>rank</A>
 ##  over the division ring <A>R</A>.
-##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional strings
+##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional
+##  distinct nonempty strings
 ##  that can be used to provide names for the generators.
 ##  <Example><![CDATA[
 ##  gap> A:= FreeAlgebraWithOne( Rationals, 4, "q" );
@@ -1555,7 +1557,8 @@ DeclareGlobalFunction( "FreeAlgebraWithOne" );
 ##  <Description>
 ##  is a free associative algebra of rank <A>rank</A> over the
 ##  division ring <A>R</A>.
-##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional strings
+##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional
+##  distinct nonempty strings
 ##  that can be used to provide names for the generators.
 ##  <Example><![CDATA[
 ##  gap> A:= FreeAssociativeAlgebra( GF( 5 ), 4, "a" );
@@ -1583,7 +1586,8 @@ DeclareGlobalFunction( "FreeAssociativeAlgebra" );
 ##  <Description>
 ##  is a free associative algebra-with-one of rank <A>rank</A> over the
 ##  division ring <A>R</A>.
-##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional strings
+##  Here <A>name</A>, and <A>name1</A>, <A>name2</A>, ... are optional
+##  distinct nonempty strings
 ##  that can be used to provide names for the generators.
 ##  <Example><![CDATA[
 ##  gap> A:= FreeAssociativeAlgebraWithOne( Rationals, "a", "b", "c" );

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -3322,6 +3322,10 @@ BindGlobal( "FreeAlgebraConstructor", function( name, magma )
                  "or ", name, "( <R>, <name1>, ... )" );
     fi;
 
+    if not IsDuplicateFreeList(names) then
+      Error( "the given generator names must be distinct" );
+    fi;
+
     M := magma( names );
 
     # Construct the algebra as free magma algebra of a free magma over `R'.

--- a/lib/alglie.gd
+++ b/lib/alglie.gd
@@ -1253,6 +1253,7 @@ DeclareAttribute(
 ##  <C>FreeLieAlgebra( <A>R</A>, <A>name1</A>, <A>name2</A>,...)</C> returns
 ##  a free Lie algebra over <A>R</A> with generators named <A>name1</A>,
 ##  <A>name2</A>, and so on.
+##  Note that any provided generator names must be distinct.
 ##  The elements of a free Lie algebra are written on the Hall-Lyndon
 ##  basis.
 ##  <Example><![CDATA[

--- a/lib/grpfree.gd
+++ b/lib/grpfree.gd
@@ -79,14 +79,14 @@ DeclareSynonym( "IsElementOfFreeGroupFamily",IsAssocWordWithInverseFamily );
 ##    </Item>
 ##    <Mark>2: For given generator names</Mark>
 ##    <Item>
-##      Called with various nonempty strings,
+##      Called with various distinct nonempty strings,
 ##      <Ref Func="FreeGroup" Label="for various names"/> returns
 ##      a free group on as many generators as arguments, which are labelled
 ##      <A>name1</A>, <A>name2</A>, etc.
 ##    </Item>
 ##    <Mark>3: For a given list of generator names</Mark>
 ##    <Item>
-##      Called with a finite list <A>names</A> of
+##      Called with a finite duplicate-free list <A>names</A> of
 ##      nonempty strings,
 ##      <Ref Func="FreeGroup" Label="for a list of names"/> returns
 ##      a free group on <C>Length(<A>names</A>)</C> generators, whose
@@ -104,11 +104,12 @@ DeclareSynonym( "IsElementOfFreeGroupFamily",IsAssocWordWithInverseFamily );
 ##      The optional argument <A>name</A> must be a string; its default value is
 ##      <C>"f"</C>,
 ##      and the optional argument <A>init</A> must be a finite list of
-##      nonempty strings; its default value is an empty list.
+##      distinct nonempty strings; its default value is an empty list.
 ##      The generators are initially labelled according to the list <A>init</A>,
 ##      followed by
 ##      <A>name</A><C>i</C> for each <C>i</C> in the range from
-##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>; such a label is not
+##      allowed to appear in <A>init</A>.
 ##    </Item>
 ##  </List>
 ##  If the optional first argument <A>wfilt</A> is given, then it must be either

--- a/lib/magma.gd
+++ b/lib/magma.gd
@@ -818,7 +818,7 @@ DeclareGlobalFunction("FreeXArgumentProcessor");
 ##    </Item>
 ##    <Mark>2: For given generator names</Mark>
 ##    <Item>
-##      Called with various (at least one) nonempty strings,
+##      Called with various (one or more) distinct nonempty strings,
 ##      <Ref Func="FreeMagma" Label="for various names"/> returns
 ##      a free magma on as many generators as arguments, which are labelled
 ##      <A>name1</A>, <A>name2</A>, etc.
@@ -826,7 +826,7 @@ DeclareGlobalFunction("FreeXArgumentProcessor");
 ##    <Mark>3: For a given list of generator names</Mark>
 ##    <Item>
 ##      Called with a finite nonempty list <A>names</A> of
-##      nonempty strings,
+##      distinct nonempty strings,
 ##      <Ref Func="FreeMagma" Label="for a list of names"/> returns
 ##      a free magma on <C>Length(<A>names</A>)</C> generators, whose
 ##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
@@ -843,11 +843,12 @@ DeclareGlobalFunction("FreeXArgumentProcessor");
 ##      The optional argument <A>name</A> must be a string; its default value is
 ##      <C>"x"</C>,
 ##      and the optional argument <A>init</A> must be a finite list of
-##      nonempty strings; its default value is an empty list.
+##      distinct nonempty strings; its default value is an empty list.
 ##      The generators are initially labelled according to the list <A>init</A>,
 ##      followed by
 ##      <A>name</A><C>i</C> for each <C>i</C> in the range from
-##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>; such a label is not
+##      allowed to appear in <A>init</A>.
 ##    </Item>
 ##  </List>
 ##  <Example><![CDATA[
@@ -931,7 +932,7 @@ DeclareGlobalFunction( "FreeMagma" );
 ##    </Item>
 ##    <Mark>2: For given generator names</Mark>
 ##    <Item>
-##      Called with various nonempty strings,
+##      Called with various (one or more) distinct nonempty strings,
 ##      <Ref Func="FreeMagmaWithOne" Label="for various names"/> returns
 ##      a free magma-with-one on as many generators as arguments, which are
 ##      labelled <A>name1</A>, <A>name2</A>, etc.
@@ -939,7 +940,7 @@ DeclareGlobalFunction( "FreeMagma" );
 ##    <Mark>3: For a given list of generator names</Mark>
 ##    <Item>
 ##      Called with a finite list <A>names</A> of
-##      nonempty strings,
+##      distinct nonempty strings,
 ##      <Ref Func="FreeMagmaWithOne" Label="for a list of names"/> returns
 ##      a free magma-with-one on <C>Length(<A>names</A>)</C> generators, whose
 ##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
@@ -956,11 +957,12 @@ DeclareGlobalFunction( "FreeMagma" );
 ##      The optional argument <A>name</A> must be a string; its default value is
 ##      <C>"x"</C>,
 ##      and the optional argument <A>init</A> must be a finite list of
-##      nonempty strings; its default value is an empty list.
+##      distinct nonempty strings; its default value is an empty list.
 ##      The generators are initially labelled according to the list <A>init</A>,
 ##      followed by
 ##      <A>name</A><C>i</C> for each <C>i</C> in the range from
-##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>; such a label is not
+##      allowed to appear in <A>init</A>.
 ##    </Item>
 ##  </List>
 ##  <Example><![CDATA[

--- a/lib/monoid.gd
+++ b/lib/monoid.gd
@@ -231,7 +231,7 @@ DeclareSynonymAttr( "TrivialSubmonoid", TrivialSubmagmaWithOne );
 ##    </Item>
 ##    <Mark>2: For given generator names</Mark>
 ##    <Item>
-##      Called with various nonempty strings,
+##      Called with various (one or more) distinct nonempty strings,
 ##      <Ref Func="FreeMonoid" Label="for various names"/> returns
 ##      a free monoid on as many generators as arguments, which are labelled
 ##      <A>name1</A>, <A>name2</A>, etc.
@@ -239,7 +239,7 @@ DeclareSynonymAttr( "TrivialSubmonoid", TrivialSubmagmaWithOne );
 ##    <Mark>3: For a given list of generator names</Mark>
 ##    <Item>
 ##      Called with a finite list <A>names</A> of
-##      nonempty strings,
+##      distinct nonempty strings,
 ##      <Ref Func="FreeMonoid" Label="for a list of names"/> returns
 ##      a free monoid on <C>Length(<A>names</A>)</C> generators, whose
 ##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
@@ -256,11 +256,12 @@ DeclareSynonymAttr( "TrivialSubmonoid", TrivialSubmagmaWithOne );
 ##      The optional argument <A>name</A> must be a string; its default value is
 ##      <C>"m"</C>,
 ##      and the optional argument <A>init</A> must be a finite list of
-##      nonempty strings; its default value is an empty list.
+##      distinct nonempty strings; its default value is an empty list.
 ##      The generators are initially labelled according to the list <A>init</A>,
 ##      followed by
 ##      <A>name</A><C>i</C> for each <C>i</C> in the range from
-##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>.
+##      <C>Length(<A>init</A>)+1</C> to <K>infinity</K>; such a label is not
+##      allowed to appear in <A>init</A>.
 ##    </Item>
 ##  </List>
 ##

--- a/lib/semigrp.gd
+++ b/lib/semigrp.gd
@@ -300,7 +300,7 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##  generators, and the labels given to the generators, can be specified in
 ##  several different ways.
 ##  Warning: the labels of generators are only an aid for printing,
-##  and do not necessarily distinguish generators;
+##  and do not necessarily distinguish elements of the semigroup;
 ##  see the examples at the end for more information.
 ##  <List>
 ##    <Mark>
@@ -323,7 +323,7 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##    </Item>
 ##    <Mark>2: For given generator names</Mark>
 ##    <Item>
-##      Called with various (at least one) nonempty strings,
+##      Called with various (one or more) distinct nonempty strings,
 ##      <Ref Func="FreeSemigroup" Label="for various names"/> returns
 ##      a free semigroup on as many generators as arguments, which are labelled
 ##      <A>name1</A>, <A>name2</A>, etc.
@@ -331,7 +331,7 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##    <Mark>3: For a given list of generator names</Mark>
 ##    <Item>
 ##      Called with a nonempty finite list <A>names</A> of
-##      nonempty strings,
+##      distinct nonempty strings,
 ##      <Ref Func="FreeSemigroup" Label="for a list of names"/> returns
 ##      a free semigroup on <C>Length(<A>names</A>)</C> generators, whose
 ##      <C>i</C>-th generator is labelled <A>names</A><C>[i]</C>.
@@ -417,6 +417,8 @@ DeclareAttribute("CayleyGraphDualSemigroup",IsSemigroup);
 ##  distinguish letters.
 ##  It is possible to create arbitrarily weird situations by choosing strange
 ##  names for the letters.
+##  However, as a small step to avoiding confusion, it is disallowed to choose
+##  duplicate generator names.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> f := FreeGroup( "x", "x" );

--- a/tst/testinstall/grpfree.tst
+++ b/tst/testinstall/grpfree.tst
@@ -167,6 +167,10 @@ gap> FreeGroup("bacon", "eggs", "beans");
 <free group on the generators [ bacon, eggs, beans ]>
 gap> FreeGroup("shed");
 <free group on the generators [ shed ]>
+gap> FreeGroup("shed", "shed");
+Error, FreeGroup( <name1>, <name2>, ... ): the names must be distinct
+gap> FreeGroup("a", "b", "c", "d", "b", "e", "f");
+Error, FreeGroup( <name1>, <name2>, ... ): the names must be distinct
 
 # FreeGroup( [ <name1>, <name2>, ... ] )
 gap> FreeGroup(InfiniteListOfNames("a"));

--- a/tst/testinstall/mgmfree.tst
+++ b/tst/testinstall/mgmfree.tst
@@ -113,6 +113,10 @@ gap> FreeMagma("bacon", "eggs", "beans");
 <free magma on the generators [ bacon, eggs, beans ]>
 gap> FreeMagma("shed");
 <free magma on the generators [ shed ]>
+gap> FreeMagma("shed", "shed");
+Error, FreeMagma( <name1>, <name2>, ... ): the names must be distinct
+gap> FreeMagma("a", "b", "c", "d", "b", "e", "f");
+Error, FreeMagma( <name1>, <name2>, ... ): the names must be distinct
 
 # FreeMagma( [ <name1>[, <name2>, ...] ] )
 gap> FreeMagma(InfiniteListOfNames("a"));
@@ -238,6 +242,10 @@ gap> FreeMagmaWithOne("bacon", "eggs", "beans");
 <free magma-with-one on the generators [ bacon, eggs, beans ]>
 gap> FreeMagmaWithOne("shed");
 <free magma-with-one on the generators [ shed ]>
+gap> FreeMagmaWithOne("shed", "shed");
+Error, FreeMagmaWithOne( <name1>, <name2>, ... ): the names must be distinct
+gap> FreeMagmaWithOne("a", "b", "c", "d", "b", "e", "f");
+Error, FreeMagmaWithOne( <name1>, <name2>, ... ): the names must be distinct
 
 # FreeMagmaWithOne( [ <name1>[, <name2>, ...] ] )
 gap> FreeMagmaWithOne(InfiniteListOfNames("a"));

--- a/tst/testinstall/monofree.tst
+++ b/tst/testinstall/monofree.tst
@@ -133,6 +133,10 @@ gap> FreeMonoid("bacon", "eggs", "beans");
 <free monoid on the generators [ bacon, eggs, beans ]>
 gap> FreeMonoid("shed");
 <free monoid on the generators [ shed ]>
+gap> FreeMonoid("shed", "shed");
+Error, FreeMonoid( <name1>, <name2>, ... ): the names must be distinct
+gap> FreeMonoid("a", "b", "c", "d", "b", "e", "f");
+Error, FreeMonoid( <name1>, <name2>, ... ): the names must be distinct
 
 # FreeMonoid( [ <name1>, <name2>, ... ] )
 gap> FreeMonoid(InfiniteListOfNames("a"));

--- a/tst/testinstall/smgrpfre.tst
+++ b/tst/testinstall/smgrpfre.tst
@@ -147,8 +147,8 @@ Error, usage: FreeSemigroup( [<wfilt>, ]<rank>[, <name>] )
 # generatorNames
 gap> FreeSemigroup(5 : generatorNames := false);
 Error, Cannot process the `generatorNames` option: the value must be either a \
-single string, or a list of sufficiently many nonempty strings (at least 5, in\
- this case)
+single string, or a list of sufficiently many distinct nonempty strings (at le\
+ast 5, in this case)
 gap> PushOptions( rec( generatorNames := fail ) );
 gap> FreeSemigroup(3 : generatorNames := "");
 <free semigroup on the generators [ 1, 2, 3 ]>
@@ -156,8 +156,8 @@ gap> FreeSemigroup(2 : generatorNames := "cool");
 <free semigroup on the generators [ cool1, cool2 ]>
 gap> FreeSemigroup(2 : generatorNames := ["red"]);
 Error, Cannot process the `generatorNames` option: the value must be either a \
-single string, or a list of sufficiently many nonempty strings (at least 2, in\
- this case)
+single string, or a list of sufficiently many distinct nonempty strings (at le\
+ast 2, in this case)
 gap> PushOptions( rec( generatorNames := fail ) );
 gap> FreeSemigroup(2 : generatorNames := ["red", "yellow"]);
 <free semigroup on the generators [ red, yellow ]>


### PR DESCRIPTION
To me it seems like doing something like `FreeGroup("x", "x");` can only possibly lead to potential confusion, I can't see a use case for it and I think it should be disallowed. But I'm open to contrary opinions.

To add:
- [x] `generatorNames` option for pc groups
- [x] `FreeMagma`
- [x] `FreeMagmaWithOne`
- [x] `FreeSemigroup`
- [x] `FreeMonoid`
- [x] `FreeGroup`
- [x] `FreeAlgebra`
- [x] `FreeAlgebraWithOne`
- [x] `FreeAssociativeAlgebra`
- [x] `FreeAssociativeAlgebraWithOne`
- [x] `FreeLieAlgebra`
- [x] `FreeBand` and `FreeInverseSemigroup`: https://github.com/semigroups/Semigroups/pull/1118

Plus:
- [ ] Add tests for everything
- [ ] Update manual entries for everything
- [ ] Update manual examples