### PR TITLE
There's no need to use `fetch-depth: 0` in the "Wrap releases" CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       # When an annotated tag is pushed, then for some reason we don't see it
       # in this action; instead an unannotated tag with the same name is


### PR DESCRIPTION
From the [`actions/checkout`](https://github.com/actions/checkout) documentation [relevant section](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4):

> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set `fetch-depth: 0` to fetch all history for all branches and tags.

We make the release with only relevant commit, right? And in the next steps of this CI job, we explicitly (force) fetch tags for the GAP repository. I'm not sure what extra information we need from the GAP repository beyond the tags and the state of the repo at the latest commit. If I'm missing something, then I'm keen to hear about it, and I think the reason for including `fetch-depth: 0` at this point should be documented in the YAML file (since its non-obvious, at least to me).

Of course, the benefit of removing this is pretty small, it'll just save a little bit of time because cloning GAP will presumably be slightly quicker. And it also reduces the code by two lines 🙂 