### PR TITLE
Remove some use of `SmallGroup` and `PrimitiveGroup` from GAP tests

### DIFF
--- a/tst/testinstall/ConjNatSym.tst
+++ b/tst/testinstall/ConjNatSym.tst
@@ -6,7 +6,7 @@ gap> IsConjugate( SymmetricGroup(5), Group((1,2)), Group((3,4,5)));
 false
 
 # This runs into the TryNextMethod case
-gap> IsConjugate( SymmetricGroup(200),PrimitiveGroup(200,4), PrimitiveGroup(200,3));
+gap> IsConjugate( SymmetricGroup(200),SymmetricGroup(200), AlternatingGroup(200));
 false
 
 # Here, using SubgpConjSymmgp yields a significant speedup

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -355,15 +355,20 @@ gap> IsCharacterTable( t mod 5 );
 true
 
 # test a bugfix
-gap> g:= SmallGroup( 96, 3 );;
+#gap> g:= SmallGroup( 96, 3 );;
+gap> g:= PcGroupCode( 55306968584587147680, 96 );;
 gap> t:= CharacterTable( g );;
 gap> ClassPositionsOfLowerCentralSeries( t );
 [ [ 1 .. 12 ], [ 1, 3, 4, 5, 6, 9, 10, 11 ] ]
-gap> g:= SmallGroup( 3^5, 22 );;
+
+#gap> g:= SmallGroup( 3^5, 22 );;
+gap> g:= PcGroupCode( 27823197465625143, 3^5 );;
 gap> t:= CharacterTable( g );;
 gap> ClassPositionsOfLowerCentralSeries( t );
 [ [ 1 .. 35 ], [ 1, 4, 6, 12, 15 ], [ 1, 6, 15 ], [ 1 ] ]
-gap> g:= SmallGroup( 96, 66 );;
+
+#gap> g:= SmallGroup( 96, 66 );;
+gap> g:= PcGroupCode( 509649248191328977712712, 96 );;
 gap> t:= CharacterTable( g );;
 gap> ClassPositionsOfSupersolvableResiduum( t );
 [ 1, 5, 6 ]
@@ -385,7 +390,9 @@ gap> Indicator( t mod 2, 2 );
 [ 1, 1 ]
 
 # linear characters
-gap> lin:= LinearCharacters( SmallGroup( 24, 12 ) );;
+#gap> g := SmallGroup( 24, 12 );;
+gap> g := PcGroupCode( 5790338948, 24 );;
+gap> lin:= LinearCharacters( g );;
 gap> Length( lin );
 2
 gap> ForAll( lin, HasIsIrreducibleCharacter );

--- a/tst/testinstall/ctblfuns.tst
+++ b/tst/testinstall/ctblfuns.tst
@@ -16,16 +16,21 @@ gap> List( irr, x -> InertiaSubgroup( S4, x ) );
   Group([ (3,4), (1,4)(2,3) ]), Sym( [ 1 .. 4 ] ) ]
 gap> List( last, Size );
 [ 8, 8, 8, 24 ]
-gap> l:=List( AllSmallGroups(12), CharacterTable );;
+
+#gap> l:=List( AllSmallGroups(12), CharacterTable );;
+gap> l:=List([ 3913, 266, 7012, 321, 1 ],
+>            i -> CharacterTable(PcGroupCode(i, 12)));;
 gap> List( l, ConjugacyClasses );;
 gap> List( l, SizesConjugacyClasses );;
 gap> List( l, OrdersClassRepresentatives );;
 gap> List( l, Irr );;
 gap> ForAll( l, IsInternallyConsistent);
 true
-gap> ForAll(AllSmallGroups(12),g -> IsInternallyConsistent(CharacterTable(g) mod 2));
+gap> l:=List([3913, 266, 7012, 321, 1], i -> PcGroupCode(i, 12));;
+gap> ForAll(l,g -> IsInternallyConsistent(CharacterTable(g) mod 2));
 true
-gap> ForAll(AllSmallGroups(12),g -> IsInternallyConsistent(TableOfMarks(g)));
+gap> l:=List([3913, 266, 7012, 321, 1], i -> PcGroupCode(i, 12));;
+gap> ForAll(l,g -> IsInternallyConsistent(TableOfMarks(g)));
 true
 
 # Up to GAP 4.11.1, the following returned 'fail' results.


### PR DESCRIPTION
This is just a small bit of work in that direction, a quick grep shows that there are well over 100 additional uses of `SmallGroup` alone in the GAP test files. But that's okay, we don't need to do it all at once.