### PR TITLE
kernel: include julia_gc.h in gap_all.h

### DIFF
--- a/src/gap_all.h
+++ b/src/gap_all.h
@@ -88,6 +88,10 @@ extern "C" {
 #include "hpc/traverse.h"
 #endif
 
+#ifdef USE_JULIA_GC
+#include "julia_gc.h"
+#endif
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
... at least when using the Julia garbage collector.

This will make it easier for the GAP.jl resp. JuliaInterface packages to interface to the GAP kernel in light of recent changes to our header include path.

See also https://github.com/oscar-system/GAP.jl/pull/1239

CC @lgoettgens 