### PR TITLE
RFC: GAP logo policy

### DIFF
--- a/LOGO.md
+++ b/LOGO.md
@@ -1,0 +1,59 @@
+# GAP Logo Usage Policy
+
+The GAP logo is a visual symbol of the GAP computer algebra system. While GAP
+itself is free software, the logo is **not licensed under the GNU General
+Public License**. Instead, its use is governed by this policy.
+
+The logo was created by Max Horn and is © 2024, Max Horn. The GAP logo is a
+trademark of the GAP project.
+
+---
+
+## Allowed Uses
+
+You are welcome to use the GAP logo to refer to the GAP project in contexts
+such as:
+
+- Academic papers, talks, slides, and posters.
+- Blog posts, articles, documentation, or tutorials about GAP.
+- Websites that describe or distribute GAP in its unmodified form.
+- Packaging GAP in Unix distributions (e.g. Debian, Fedora, Ubuntu),
+  Homebrew, Conda, or similar systems, even if minor adjustments are applied
+  for compatibility.
+- Educational or non-commercial use where GAP is being presented accurately.
+
+You may resize the logo proportionally, or use a black-and-white/monochrome
+version if needed for printing. We provide several alternative
+versions at <https://www.gap-system.org/logo/>.
+
+---
+
+## Restricted Uses
+
+To protect the integrity of the GAP project, the following uses are
+**not permitted** without explicit permission:
+
+- Modifying the logo (e.g., changing colors, distorting shapes, adding text).
+- Using the logo in a way that suggests endorsement or official affiliation
+  with the GAP project.
+- Using the logo for commercial purposes (e.g., merchandise, advertising)
+  without approval.
+- Using the logo for forks or derivative projects that are not distributed
+  under the name GAP. Such projects should create their own logo and identity.
+
+---
+
+## Legal Notice
+
+The GAP software is licensed under the GNU General Public License (GPL) v2 or
+later. The GAP logo is not covered by this license. Its use is subject to this
+Logo Usage Policy.
+
+Unauthorized or misleading use of the GAP logo may violate trademark law.
+
+---
+
+## Contact
+
+If you are unsure whether your intended use of the GAP logo is permitted,
+please contact the GAP maintainers at <support@gap-system.org>.

--- a/README.md
+++ b/README.md
@@ -156,3 +156,11 @@ Foundation; either version 2 of the License, or (at your option) any later
 version. For details, please refer to the GAP reference manual, as well as the
 file `LICENSE` in the root directory of the GAP distribution or see
 <https://www.gnu.org/licenses/gpl.html>.
+
+**Logo Notice:** The GAP logo is © 2024, Max Horn and is a trademark of the
+GAP project. The logo is not covered by the GPL and may only be used as
+described in the [GAP Logo Usage Policy](LOGO.md).
+
+**Distributor Note:** Linux distributions, Homebrew, and similar packaging
+systems may use the GAP logo when distributing GAP, even if minor adjustments
+are applied for compatibility, provided the software is still clearly GAP.


### PR DESCRIPTION
This is an initial *draft* of a GAP logo policy, to serve as basis for further discussion.

Disclaimer: I created this with help by ChatGPT. My goal was to have something that allows us to retain some control over how the logo is used while not hindering "normal" usage, including by downstream packagers, and academics.

There is no "GAP Foundation" or similar legal entity to which the copyright could be transferred; and under German law I can't easily relinquish it anyway. I realize this might make some people uncomfortable, as in "what if Max has a falling out with the GAP project and wants to screw us". If anyone is seriously concerned about this, they should add to their list of worries that I control our domains, and all GitHub orgs, and the webserver. So, yeah... (If anyone is seriously concerned about this: here is not the place to debate it! You could raise it with the GAP council, by emailing <council@gap-system.org>. Be advised that I am also a member of the GAP council and get those emails as well; so you could e.g. email the chair directly if you don't want me to know who wrote it).


But once again: this is a *draft*. If you are unhappy with anything in it, please don't hesitate to voice it. Ideally as inline-comments on specific points in the text, so that we can dicuss there, but in the end: in whatever form you feel that works.

If you are *content* with parts or all of it, that would also be good to know.

Once we have a rough consensus here, I propose to invite the wider GAP community (via our mailing lists) to comment on it.

I am also explicitly interested in what packagers think about it.