### PR TITLE
Modify the GAP banner to show a rendition of the logo

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -434,7 +434,7 @@ function( prefix, values, suffix )
 end);
 
 BindGlobal( "ShowKernelInformation", function()
-  local sysdate, btop, vert, bbot, config, str, gap;
+  local sysdate, config, str, gap;
 
   if GAPInfo.Date <> "today" then
     sysdate := " of ";
@@ -446,20 +446,19 @@ BindGlobal( "ShowKernelInformation", function()
     Append(sysdate, GAPInfo.BuildDateTime);
   fi;
 
-  if GAPInfo.TermEncoding = "UTF-8" then
-    btop := "┌───────┐\c"; vert := "│"; bbot := "└───────┘\c";
-  else
-    btop := "*********"; vert := "*"; bbot := btop;
-  fi;
   if IsHPCGAP then
     gap := "HPC-GAP";
   else
     gap := "GAP";
   fi;
-  Print( " ",btop,"   ",gap," ", GAPInfo.BuildVersion,
-         sysdate, "\n",
-         " ",vert,"  GAP  ",vert,"   https://www.gap-system.org\n",
-         " ",bbot,"   Architecture: ", GAPInfo.Architecture, "\n" );
+
+  Print( """   . - O      """, "\n" );
+  Print( """  /   /  \    """, gap, " ", GAPInfo.BuildVersion, sysdate, "\n" );
+  Print( """ O---O    |   """, "Architecture: ", GAPInfo.Architecture, "\n" );
+  Print( """  \   \  /    """, "Web: https://www.gap-system.org", "\n" );
+  Print( """   ` - O      """, "\n" );
+
+
   if IsHPCGAP then
     Print( "             Maximum concurrent threads: ",
        GAPInfo.KernelInfo.NUM_CPUS, "\n");


### PR DESCRIPTION
First iteration -- based on the sketches in https://github.com/gap-system/gap-logo/blob/main/gap-logo-ascii.txt but using a "rotated" / "flipped" version of the logo in anticipation of us changing the logo orientation (clearly we could also flip it back).

I am sure this could be improved. Perhaps e.g. @mtorpey would be interested in that ;-).

Here is a "preview" of the current state:
```
$ ./gap
   . - O
  /   /  \    GAP 4.16dev-15-g0b145d9-dirty built on 2025-09-23 13:50:33+0200
 O---O    |   Architecture: aarch64-apple-darwin24-default64-kv10
  \   \  /    Web: https://www.gap-system.org
   ` - O
 Configuration:  gmp 6.3.0, GASMAN, readline
 Loading the library and packages ...
 Packages:   AClib 1.3.3, Alnuth 3.2.1, AtlasRep 2.1.9, AutoDoc 2025.05.09,
             AutPGrp 1.11.1, Browse 1.8.21, CaratInterface 2.3.7, CRISP 1.4.8,
             Cryst 4.1.29, CrystCat 1.1.10, CTblLib 1.3.11,
             curlInterface 2.4.2, FactInt 1.6.3, FGA 1.5.0, Forms 1.2.13,
             GAPDoc 1.6.7, genss 1.6.9, IO 4.9.3, IRREDSOL 1.4.4,
             LAGUNA 3.9.7, orb 5.0.1, PackageManager 1.6.3, Polenta 1.3.11,
             Polycyclic 2.17, PrimGrp 4.0.0, RadiRoot 2.9, recog 1.4.4,
             ResClasses 4.7.3, SmallGrp 1.5.4, Sophus 1.27, SpinSym 1.5.2,
             StandardFF 1.0, TomLib 1.2.11, TransGrp 3.6.5, utils 0.91
 Try '??help' for help. See also '?copyright', '?cite' and '?authors'
gap>
```