### PR TITLE
Fix a wrong `false` result of `IsSolvable` for certain trivial permutation groups

### DIFF
--- a/lib/grpperm.gi
+++ b/lib/grpperm.gi
@@ -1288,11 +1288,12 @@ end );
 # if this goes on too long the group may not be solvable. This can be much faster
 # for large degree groups than to use the full pcgs machinery (which uses the same
 # idea but builds a pcgs on the way).
+# The function returns `true` if the group has been proved to be *non*solvable.
 BindGlobal("QuickUnsolvabilityTestPerm",function(G)
 local som,elvth,fct,gens,new,l,i,j,a,b,bound;
   # a few moved points
   som:=MovedPoints(G);
-  if Length(som) = 0 then SetIsTrivial(G,true); return true; fi;
+  if Length(som) = 0 then SetIsTrivial(G,true); return fail; fi;
   bound:=Int(LogInt(Length(som)^5,3)/2); #Dixon Bound
   if Length(som)>100 then
     som:=som{List([1..100],x->Random(1, Length(som)))};

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -145,4 +145,12 @@ gap> List(Iterator(SymmetricGroup(3)));
 [ (), (2,3), (1,3), (1,3,2), (1,2,3), (1,2) ]
 gap> AsList(SymmetricGroup(6)) = List(Iterator(SymmetricGroup(6)));
 true
+
+#
+gap> g:= SymmetricGroup( 4 );;
+gap> h:= Subgroup( g, [ () ] );;
+gap> IsSolvable( h );
+true
+
+#
 gap> STOP_TEST("grpperm.tst");


### PR DESCRIPTION
See the new test for an example where this was not the case before.