### PR TITLE
add a missing `ComputeAllPowerMaps` call

### DIFF
--- a/lib/ctblgrp.gi
+++ b/lib/ctblgrp.gi
@@ -2313,6 +2313,7 @@ InstallMethod( Irr,
         # The list is complete.
         C:= OrdinaryCharacterTable( G );
         SetIrr( C, irr );
+        ComputeAllPowerMaps( C );
         return irr;
       fi;
       # We feed the partial list into the Dixon-Schneider-algorithm.


### PR DESCRIPTION
This was missing from #6141, and detected in the crystcat tests, see #6143.
