### PR TITLE
forbid `Order` for non-endo group homomorphisms

### DIFF
--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -26,6 +26,9 @@ MORPHEUSELMS := 50000;
 InstallMethod(Order,"for automorphisms",true,[IsGroupHomomorphism],0,
 function(hom)
 local map,phi,o,lo,i,j,start,img,d,nat,ser,jord,first;
+  if not IsEndoGeneralMapping( hom ) then
+    Error( "Source and Range of <hom> must be equal" );
+  fi;
   d:=Source(hom);
   if not (HasIsFinite(d) and IsFinite(d)) then
     TryNextMethod();

--- a/tst/testinstall/mapphomo.tst
+++ b/tst/testinstall/mapphomo.tst
@@ -71,6 +71,20 @@ fail
 gap> GroupHomomorphismByImages(G, H, [], []);
 fail
 
+# Order for homomorphisms
+gap> G:= SymmetricGroup( 3 );;
+gap> hom:= IdentityMapping( G );;
+gap> Order( hom );
+1
+gap> One( hom ) = hom;
+true
+gap> H:= Group( (1,2) );;
+gap> hom:= RestrictedMapping( hom, H );;
+gap> Order( hom );
+Error, Source and Range of <hom> must be equal
+gap> One( hom );
+fail
+
 # Check that group homomorphisms created by a function can compute preimages.
 gap> for G in [ SymmetricGroup(5), SmallGroup( 24, 12 ), GL(2,3) ] do
 >      hom:= GroupHomomorphismByFunction( G, G, x -> x );


### PR DESCRIPTION
For a group homomorphism `hom`, `Order( hom )` is defined as the smallest positive exponent `e` such that `hom^e` is equal to `One( hom )`.

Up to now, `Order` returned an integer also in certain cases where `hom` not surjective; if `Source( hom ) = Image( hom )` then the result was the order of the induced endomorphism on `Source( hom )`.
On the other hand, `One( hom )` returned `fail` in these cases.

With the proposed change, the `Order` method in question compares `Source( hom )` and `Range( hom )`, and throws an error if the two are different.

This additional comparison may slow down the computations.
If we do not want this then we could think about introducing an option for skipping the test; or, if we want to keep the old behaviour, we could run the check only if the assertion level is high enough.

resolves #6150 