### PR TITLE
Fix a bug in `RepresentativesPerfectSubgroups` that could lead to the omission of subgroups

### DIFF
--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -992,6 +992,7 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
     if Length(mpcgs)>0 then
       gf:=GF(RelativeOrders(mpcgs)[1]);
       if select=IsPerfectGroup then
+
         # the only normal subgroups are those that are normal under any
         # subgroup so far.
 
@@ -1008,7 +1009,14 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
         od;
         SortBy(nts,Size); # increasing order
         # by setting up `act' as fail, we force a different selection later
-        act:=[nts,fail];
+        #act:=[nts,fail];
+
+        # there is an issue in selecting representatives. Form G-orbits to
+        # remain in usual case.
+        nts:=Union(Orbits(G,nts));
+        act:=ActionHomomorphism(G,nts,"surjective");
+        act:=[nts,act];
+          
 
       elif select=IsNonabelianSimpleGroup then
         # simple -> no extensions, only the trivial subgroup is valid.

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -1016,7 +1016,6 @@ InstallGlobalFunction(LatticeViaRadical,function(arg)
         nts:=Union(Orbits(G,nts));
         act:=ActionHomomorphism(G,nts,"surjective");
         act:=[nts,act];
-          
 
       elif select=IsNonabelianSimpleGroup then
         # simple -> no extensions, only the trivial subgroup is valid.

--- a/tst/testbugfix/2025-11-06-perfectsubs.tst
+++ b/tst/testbugfix/2025-11-06-perfectsubs.tst
@@ -1,4 +1,5 @@
-# 6157, missing subgroups when finding perfect subgroups
+# missing subgroups when finding perfect subgroups
+# See <https://github.com/gap-system/gap/issues/6157>.
 gap> G:=WreathProduct(Group((1,2)), SymmetricGroup(6));;
 gap> Size(ConjugacyClassesPerfectSubgroups(G));
 8

--- a/tst/testbugfix/2025-11-06-perfectsubs.tst
+++ b/tst/testbugfix/2025-11-06-perfectsubs.tst
@@ -1,0 +1,4 @@
+# 6157, missing subgroups when finding perfect subgroups
+gap> G:=WreathProduct(Group((1,2)), SymmetricGroup(6));;
+gap> Size(ConjugacyClassesPerfectSubgroups(G));
+8


### PR DESCRIPTION
The subgroup lattice routine for `RepresentativesPerfectSubgroups` was too aggressive in eliminating possible norml subgroups

## Text for release notes

A bug in `RepresentativesPerfectSubgroups` that led to the ommission of subgroups was fixed.