### PR TITLE
Add missing local variable declaration

### DIFF
--- a/hpcgap/lib/hpc/tasks.g
+++ b/hpcgap/lib/hpc/tasks.g
@@ -366,7 +366,7 @@ end;
 WaitTasks := WaitTask;
 
 WaitAnyTask := function(arg)
-  local len, task;
+  local i, len, task;
 
   atomic arg[1] do
     if Length(arg) = 1 and IsList(arg[1]) then


### PR DESCRIPTION
It was removed in 1f04ceb0a3b04d849233dee7cfce8d1ecd0cc6ab via PR #5275 by @james-d-mitchell -- I am wondering if this hints at a bug in gaplint?

But weirdly enough, also GAP itself did not complain for me about this... yet a user observed it... I am somewhat confused as to what's going on there... Huh.

Fixes #6161