### PR TITLE
Fix permission problem in streams.txt

### DIFF
--- a/tst/testinstall/streams.tst
+++ b/tst/testinstall/streams.tst
@@ -212,6 +212,7 @@ Error, Print formatting status must be true or false
 
 # too many open files
 gap> streams := [ ];;
+gap> fname := Filename(tmpdir, "testdata");;
 gap> for i in [ 1 .. 300 ] do
 >    stream := OutputTextFile( fname, false );
 >    Assert(0, stream <> fail);


### PR DESCRIPTION
The current test yields an error if called by a user that has no write permissions in the GAP installation directory.

With this change the files in the test are created in a temporary directory instead.

## Text for release notes
none
