### PR TITLE
Improve documentation of `InverseGeneralMapping`

### DIFF
--- a/doc/ref/mapping.xml
+++ b/doc/ref/mapping.xml
@@ -30,7 +30,7 @@ called differently,
 see Section&nbsp;<Ref Sect="Mappings which are Compatible with Algebraic Structures"/>.
 <P/>
 Some technical details of general mappings are described in
-section&nbsp;<Ref Sect="General Mappings"/>.
+section&nbsp;<Ref Sect="Technical Matters Concerning General Mappings"/>.
 
 <!-- %%  The general support for mappings is due to Thomas Breuer. -->
 

--- a/lib/mapping.gd
+++ b/lib/mapping.gd
@@ -682,15 +682,12 @@ DeclareAttribute( "IdentityMapping", IsCollection );
 ##  if and only if the underlying relation of <A>map</A> contains the pair
 ##  <M>(s,r)</M>.
 ##  <P/>
-##  See the introduction to Chapter&nbsp;<Ref Chap="Mappings"/>
-##  for the subtleties concerning the difference between
-##  <Ref Attr="InverseGeneralMapping"/> and <Ref Attr="Inverse"/>.
-##  <P/>
 ##  Note that the inverse general mapping of a mapping <A>map</A> is
 ##  in general only a general mapping.
-##  If <A>map</A> knows to be bijective its inverse general mapping will know
+##  If <A>map</A> knows to be bijective, then its inverse general mapping will know
 ##  to be a mapping.
-##  In this case also <C>Inverse( <A>map</A> )</C> works.
+##  However, <Ref Attr="Inverse"/> works for a bijective general mapping <A>map</A>
+##  only if the source and range of <A>map</A> coincide.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/mapping.gd
+++ b/lib/mapping.gd
@@ -688,6 +688,7 @@ DeclareAttribute( "IdentityMapping", IsCollection );
 ##  to be a mapping.
 ##  However, <Ref Attr="Inverse"/> works for a bijective general mapping <A>map</A>
 ##  only if the source and range of <A>map</A> coincide.
+##  This behaviour agrees with the definition of <A>Inverse</A>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
The documentation of `InverseGeneralMapping` claims that `Inverse` also works for bijective general mappings; however, this is only true for bijective general mappings where `source = range`. This is correctly explained in the documentation of `Inverse`, which I have referenced.

I also removed the paragraph "See the introduction..." because it seems to be outdated. There is no such explanation in the introduction of the chapter.

Further, there was an incorrect section reference in the introduction of the chapter.

## Text for release notes

none
