### PR TITLE
provide `DefaultRingByGenerators` for alg. extensions

### DIFF
--- a/lib/algfld.gi
+++ b/lib/algfld.gi
@@ -1040,6 +1040,14 @@ end);
 
 #############################################################################
 ##
+#M  DefaultRingByGenerators( <elms> )
+##
+InstallMethod( DefaultRingByGenerators,
+  [ "IsList and IsAlgebraicElementCollection" ],
+  DefaultFieldByGenerators );
+
+#############################################################################
+##
 #M  DefaultFieldOfMatrixGroup( <elms> )
 ##
 InstallMethod(DefaultFieldOfMatrixGroup,"alg elms",

--- a/tst/testinstall/vecmat.tst
+++ b/tst/testinstall/vecmat.tst
@@ -73,6 +73,8 @@ false
 # zero vector over GF(9) but not in internal format
 gap> F := F9;; v := ListWithIdenticalEntries( 3, Zero(F) );
 [ !0*Z(3), !0*Z(3), !0*Z(3) ]
+gap> IsIdenticalObj( BaseDomain( v ), F );
+true
 gap> w := ImmutableVector( 9, v );
 [ !0*Z(3), !0*Z(3), !0*Z(3) ]
 gap> v = w;
@@ -199,6 +201,8 @@ false
 gap> F := F9;; m := IdentityMat( 3, F );
 [ [ !Z(3)^0, !0*Z(3), !0*Z(3) ], [ !0*Z(3), !Z(3)^0, !0*Z(3) ], 
   [ !0*Z(3), !0*Z(3), !Z(3)^0 ] ]
+gap> IsIdenticalObj( BaseDomain( m ), F );
+true
 gap> w := ImmutableMatrix( 9, m );
 [ [ !Z(3)^0, !0*Z(3), !0*Z(3) ], [ !0*Z(3), !Z(3)^0, !0*Z(3) ], 
   [ !0*Z(3), !0*Z(3), !Z(3)^0 ] ]


### PR DESCRIPTION
In fact I want to get a meaningful `BaseDomain` for vectors and matrices over alg. extensions.

And I want this first of all for vectors and matrices over the fields provided by the StandardFF package,
because this is useful for matrix groups over these fields.