### PR TITLE
Transfer more properties (such as `IsNaturalSL`, `InvariantQuadraticForm` etc.) when conjugating matrix groups

### DIFF
--- a/lib/grpmat.gd
+++ b/lib/grpmat.gd
@@ -345,7 +345,8 @@ DeclareAttribute( "InvariantBilinearForm", IsMatrixGroup );
 ##  <Description>
 ##  This property tests, whether a matrix group <A>matgrp</A> is the full
 ##  subgroup of GL or SL (the property <Ref Prop="IsSubgroupSL"/> determines
-##  which it is) respecting the form stored as the value of
+##  which it is) in the right dimension over the (smallest) ring which
+##  contains all entries of its elements, respecting the form stored as the value of
 ##  <Ref Attr="InvariantBilinearForm"/> for <A>matgrp</A>.
 ##  </Description>
 ##  </ManSection>
@@ -462,7 +463,9 @@ DeclareAttribute( "InvariantQuadraticForm", IsMatrixGroup );
 ##  <Description>
 ##  This property tests, whether the matrix group <A>matgrp</A> is the full
 ##  subgroup of GL or SL (the property <Ref Prop="IsSubgroupSL"/> determines
-##  which it is) respecting the <Ref Attr="InvariantQuadraticForm"/> value
+##  which it is) in the right dimension over the (smallest) ring which
+##  contains all entries of its elements,
+##  respecting the <Ref Attr="InvariantQuadraticForm"/> value
 ##  of <A>matgrp</A>.
 ##  <Example><![CDATA[
 ##  gap> g:= Sp( 2, 3 );;

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -1266,3 +1266,53 @@ InstallMethod( InvariantBilinearForm,
     Q:= InvariantQuadraticForm( matgrp ).matrix;
     return rec( matrix:= ( Q + TransposedMat( Q ) ) );
     end );
+
+#############################################################################
+##
+#M  ConjugateGroup( <G>, <g> ) of a matrix group
+##
+InstallMethod( ConjugateGroup, "<G>, <g>", IsCollsElms,
+    [ IsMatrixGroup, IsMultiplicativeElementWithInverse ],
+    function( G, g )
+    local   H, m, ginv;
+
+    H := GroupByGenerators( OnTuples( GeneratorsOfGroup( G ), g ), One(G) );
+    UseIsomorphismRelation( G, H );
+    if HasIsGeneralLinearGroup( G ) then
+      SetIsGeneralLinearGroup( H, IsGeneralLinearGroup( G ) );
+    fi;
+    if HasIsSpecialLinearGroup( G ) then
+      SetIsSpecialLinearGroup( H, IsSpecialLinearGroup( G ) );
+    fi;
+    if HasIsSubgroupSL( G ) then
+      SetIsSubgroupSL( H, IsSubgroupSL( G ) );
+    fi;
+    if HasInvariantBilinearForm( G ) or HasInvariantQuadraticForm( G ) then
+      ginv := g^-1;
+    fi;
+    if HasInvariantBilinearForm( G ) then
+      m := ginv * InvariantBilinearForm(G).matrix * TransposedMat(ginv);
+      SetInvariantBilinearForm( H, rec( matrix := m ) );
+    fi;
+    if HasInvariantQuadraticForm( G ) then
+      m := ginv * InvariantQuadraticForm(G).matrix * TransposedMat(ginv);
+      SetInvariantQuadraticForm( H, rec( matrix := m ) );
+    fi;
+    if IsSubset( FieldOfMatrixGroup( G ), FieldOfMatrixList( [ g ] ) ) then
+      if HasIsNaturalGL( G ) then
+        SetIsNaturalGL( H, IsNaturalGL( G ) );
+      fi;
+      if HasIsNaturalSL( G ) then
+        SetIsNaturalSL( H, IsNaturalSL( G ) );
+      fi;
+      if HasIsFullSubgroupGLorSLRespectingBilinearForm( G )
+          and IsFullSubgroupGLorSLRespectingBilinearForm( G ) then
+        SetIsFullSubgroupGLorSLRespectingBilinearForm( H, true );
+      fi;
+      if HasIsFullSubgroupGLorSLRespectingQuadraticForm( G )
+          and IsFullSubgroupGLorSLRespectingQuadraticForm( G ) then
+        SetIsFullSubgroupGLorSLRespectingQuadraticForm( H, true );
+      fi;
+    fi;
+    return H;
+end );

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -1274,9 +1274,9 @@ InstallMethod( InvariantBilinearForm,
 InstallMethod( ConjugateGroup, "<G>, <g>", IsCollsElms,
     [ IsMatrixGroup, IsMultiplicativeElementWithInverse ],
     function( G, g )
-    local   H, m, ginv;
+    local   H, m, ginv, nice, conj;
 
-    H := GroupByGenerators( OnTuples( GeneratorsOfGroup( G ), g ), One(G) );
+    H := GroupByGenerators( OnTuples( GeneratorsOfGroup( G ), g ), One( G ) );
     UseIsomorphismRelation( G, H );
     if HasIsGeneralLinearGroup( G ) then
       SetIsGeneralLinearGroup( H, IsGeneralLinearGroup( G ) );
@@ -1287,15 +1287,18 @@ InstallMethod( ConjugateGroup, "<G>, <g>", IsCollsElms,
     if HasIsSubgroupSL( G ) then
       SetIsSubgroupSL( H, IsSubgroupSL( G ) );
     fi;
-    if HasInvariantBilinearForm( G ) or HasInvariantQuadraticForm( G ) then
-      ginv := g^-1;
-    fi;
     if HasInvariantBilinearForm( G ) then
-      m := ginv * InvariantBilinearForm(G).matrix * TransposedMat(ginv);
+      if not IsBound( ginv ) then
+        ginv := g^-1;
+      fi;
+      m := ginv * InvariantBilinearForm( G ).matrix * TransposedMat( ginv );
       SetInvariantBilinearForm( H, rec( matrix := m ) );
     fi;
     if HasInvariantQuadraticForm( G ) then
-      m := ginv * InvariantQuadraticForm(G).matrix * TransposedMat(ginv);
+      if not IsBound( ginv ) then
+        ginv := g^-1;
+      fi;
+      m := ginv * InvariantQuadraticForm( G ).matrix * TransposedMat( ginv );
       SetInvariantQuadraticForm( H, rec( matrix := m ) );
     fi;
     if IsSubset( FieldOfMatrixGroup( G ), FieldOfMatrixList( [ g ] ) ) then
@@ -1314,5 +1317,16 @@ InstallMethod( ConjugateGroup, "<G>, <g>", IsCollsElms,
         SetIsFullSubgroupGLorSLRespectingQuadraticForm( H, true );
       fi;
     fi;
+    if HasNiceMonomorphism( G ) then
+      nice := NiceMonomorphism( G );
+      if not IsBound( ginv ) then
+        ginv := g^-1;
+      fi;
+      conj := GroupHomomorphismByFunction( H, G, y -> g*y*ginv, x -> ginv*x*g );
+      SetNiceMonomorphism( H, conj * nice );
+      if HasNiceObject( G ) then
+        SetNiceObject( H, NiceObject( G ) );
+      fi;
+     fi;
     return H;
 end );

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -54,6 +54,8 @@ gap> grps:=[];;
 gap> for d in [3,5,7] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, GO(d,q));
+>     Add(grps, GO(d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, GO(d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsInvertible);
@@ -71,6 +73,10 @@ gap> for d in [2,4,6,8] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, GO(+1,d,q));
 >     Add(grps, GO(-1,d,q));
+>     Add(grps, GO(+1,d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, GO(-1,d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, GO(+1,d,q) ^ RandomInvertibleMat(d,GF(q^2)));
+>     Add(grps, GO(-1,d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsInvertible);
@@ -87,6 +93,8 @@ gap> grps:=[];;
 gap> for d in [3,5,7] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, SO(d,q));
+>     Add(grps, SO(d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, SO(d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);
@@ -104,6 +112,10 @@ gap> for d in [2,4,6,8] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, SO(+1,d,q));
 >     Add(grps, SO(-1,d,q));
+>     Add(grps, SO(+1,d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, SO(-1,d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, SO(+1,d,q) ^ RandomInvertibleMat(d,GF(q^2)));
+>     Add(grps, SO(-1,d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);
@@ -124,6 +136,8 @@ gap> grps:=[];;
 gap> for d in [3,5,7] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Omega(d,q));
+>     Add(grps, Omega(d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, Omega(d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);
@@ -141,6 +155,10 @@ gap> for d in [2,4,6,8] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Omega(+1,d,q));
 >     Add(grps, Omega(-1,d,q));
+>     Add(grps, Omega(+1,d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, Omega(-1,d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, Omega(+1,d,q) ^ RandomInvertibleMat(d,GF(q^2)));
+>     Add(grps, Omega(-1,d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);
@@ -191,6 +209,8 @@ gap> grps:=[];;
 gap> for d in [2,4,6,8] do
 >   for q in [2,3,4,5,7,8,9,16,17,25,27] do
 >     Add(grps, Sp(d,q));
+>     Add(grps, Sp(d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps, Sp(d,q) ^ RandomInvertibleMat(d,GF(q^2)));
 >   od;
 > od;
 gap> ForAll(grps, CheckGeneratorsSpecial);

--- a/tst/testinstall/mapping.tst
+++ b/tst/testinstall/mapping.tst
@@ -496,7 +496,7 @@ gap> g2:= SubgroupNC( g, [ A, B ] );;  # need a parent
 gap> HasIsHandledByNiceMonomorphism( g2 ); MayBeHandledByNiceMonomorphism( g2 );
 false
 true
-gap> g2:= ConjugateGroup( g2, C );;
+gap> g2:= ClosureGroup( g2, B );;
 gap> HasIsHandledByNiceMonomorphism( g2 ); IsHandledByNiceMonomorphism( g2 );
 true
 true


### PR DESCRIPTION
Resolves https://github.com/gap-system/gap/issues/5635.

If I am not mistaken the formula for adapting the forms from https://github.com/gap-system/gap/issues/5635#issuecomment-1937347218 does not work. The one present in this PR might work, but I would prefer if this would be double-checked.