### PR TITLE
transfer changes `lib/vecmat.gi` -> `hpcgap/lib/vecmat.gi`

### DIFF
--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -657,6 +657,24 @@ end);
 
 #############################################################################
 ##
+#M  SwapMatrixRows( <gf2mat>, <row1>, <row2> )  . . . swap rows of GF2 matrix
+##
+InstallMethod( SwapMatrixRows, "for a mutable GF2 matrix, and two row numbers",
+  [ IsList and IsGF2MatrixRep and IsMutable, IsPosInt, IsPosInt ],
+  SWAP_ROWS_GF2MAT );
+
+
+#############################################################################
+##
+#M  SwapMatrixColumns( <gf2mat>, <col1>, <col2> ) . . swap cols of GF2 matrix
+##
+InstallMethod( SwapMatrixColumns, "for a mutable GF2 matrix, and two column numbers",
+  [ IsList and IsGF2MatrixRep and IsMutable, IsPosInt, IsPosInt ],
+  SWAP_COLS_GF2MAT );
+
+
+#############################################################################
+##
 #M  PrintObj( <gf2mat> )  . . . . . . . . . . . . . . . .  print a GF2 matrix
 ##
 InstallMethod( PrintObj,
@@ -2144,7 +2162,8 @@ InstallMethod(DomainForAction,"matrix/matrix",IsElmsCollsX,
 function(pnt,acts,act)
 local l,f;
   if (not ForAll(acts,IsMatrix)) or
-    (act<>OnPoints and act<>OnSubspacesByCanonicalBasis and act<>OnRight) then
+    (act<>OnPoints and act<>OnSubspacesByCanonicalBasis and act<>OnRight and act<>OnSets and
+    act<>OnTuples) then
     TryNextMethod(); # strange operation, might extend the domain
   fi;
   l:=NaturalActedSpace(acts,pnt);


### PR DESCRIPTION
(addresses a comment in #6186)

If the two changes shall *not* be copied to `hpcgap/lib/vecmat.gi` then we must add hints about this to the files.

There is *one more dubious difference* between `lib/vecmat.gi` and `hpcgap/lib/vecmat.gi`, which looks a bit complicated:
The commit d5df043 adds a code line `if not IsMutable(matrix) # matrix was immutable` which is currently contained in `hpcgap/lib/vecmat.gi` but not in `lib/vecmat.gi`, but I cannot find a commit that removes this line from `lib/vecmat.gi`.
Furthermore, the text of the commit is strange:

> Formerly it was possible to change in-place the representation of rows of an immutable matrix 'mat' by calling ImmutableMatrix(mat). Now a copy of a matrix will be created first and then its rows will be compressed, and then the result will be made immutable.

Currently it *does* happen that `ImmutableMatrix` changes the representations of rows of an immutable matrix, as in the following example. (Is this a bug or not?)
```
gap> imm:= Immutable( [[Z(2)],[Z(2)]] );
[ [ Z(2)^0 ], [ Z(2)^0 ] ]
gap> IsPlistRep( imm[1] );
true
gap> new:= ImmutableMatrix( GF(4), imm );
[ [ Z(2)^0 ], [ Z(2)^0 ] ]
gap> IsPlistRep( imm[1] );
false
```
However, this behaviour is independent of the abovementioned code line.
What do I misunderstand?