### PR TITLE
Update etc/emscripten/build.sh and web-template to split gap.data so that it can be hosted on Github pages

### DIFF
--- a/etc/emscripten/README.md
+++ b/etc/emscripten/README.md
@@ -4,9 +4,6 @@ Files:
 
 - `build.sh`: Run as `etc/emscripten/build.sh` from a fresh copy of GAP.
 
-Note that this built copy has one major weakness -- the 'gap.data' (which includes all packages files) is huge.
-
-
 - `web-template`: Uses 'xterm-pty' to create a "nice" interface to the Wasm GAP.
 
 See 'run-web-demo.sh' as an example on how to set up a working website.

--- a/etc/emscripten/build.sh
+++ b/etc/emscripten/build.sh
@@ -91,3 +91,16 @@ cp native-build/build/c_*.c native-build/build/ffdata.* src/
 # The EXEEXT is usually for windows, but here it lets us set GAP's extension,
 # which lets us produce a html page to run GAP in
 emmake make -j8 LDFLAGS="--preload-file pkg --preload-file lib --preload-file grp --preload-file tst -s ASYNCIFY=1 -sTOTAL_STACK=32mb -sASYNCIFY_STACK_SIZE=32000000 -sINITIAL_MEMORY=2048mb -O2" EXEEXT=".html"
+
+# SPLIT THE DATA FILE
+echo "Splitting gap.data..."
+split -b 75m gap.data "gap.data.part"
+
+# Rename to .part1, .part2...
+i=1
+for f in gap.data.part*; do
+    mv "$f" "gap.data.part$i"
+    echo "Created gap.data.part$i"
+    ((i++))
+done
+rm gap.data

--- a/etc/emscripten/run-web-demo.sh
+++ b/etc/emscripten/run-web-demo.sh
@@ -6,6 +6,6 @@ echo This script assumes you have already run 'build.sh'
 
 mkdir -p web-example
 cp etc/emscripten/web-template/* web-example
-cp gap.js gap.wasm gap.data web-example
+cp gap.js gap.wasm gap.data.part* web-example
 cd web-example
 ../etc/emscripten/server.rb

--- a/etc/emscripten/web-template/example.worker.js
+++ b/etc/emscripten/web-template/example.worker.js
@@ -1,7 +1,0 @@
-importScripts("https://cdn.jsdelivr.net/npm/xterm-pty@0.9.4/workerTools.js");
-
-onmessage = (msg) => {
-  importScripts(location.origin + "/gap.js");
-
-  emscriptenHack(new TtyClient(msg.data));
-};

--- a/etc/emscripten/web-template/gap-worker.js
+++ b/etc/emscripten/web-template/gap-worker.js
@@ -1,0 +1,73 @@
+importScripts("https://cdn.jsdelivr.net/npm/xterm-pty@0.9.4/workerTools.js");
+
+onmessage = (msg) => {
+  // We wrap the initialization in an async function to handle the data fetching
+  async function loadAndStart() {
+    const buffers = [];
+    let i = 1;
+
+    // 1. Download all split parts
+    // It will look for gap.data.part1, part2, etc. until it hits a 404.
+    while (true) {
+      const url = location.origin + `/gap.data.part${i}`;
+      try {
+        const response = await fetch(url);
+        if (!response.ok) break; // Stop when we hit 404
+        
+        const buf = await response.arrayBuffer();
+        buffers.push(new Uint8Array(buf));
+        i++;
+      } catch (e) {
+        break;
+      }
+    }
+
+    // 2. Prepare the Module object BEFORE importing gap.js
+    self.Module = self.Module || {};
+
+    // 2a. MERGE DATA (If parts were found)
+    if (buffers.length > 0) {
+      const totalLength = buffers.reduce((acc, b) => acc + b.length, 0);
+      const mergedData = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const buffer of buffers) {
+        mergedData.set(buffer, offset);
+        offset += buffer.length;
+      }
+
+      console.log(`Worker: Loaded ${buffers.length} parts. Total size: ${totalLength} bytes.`);
+
+      // CRITICAL FIX: Override the default downloader.
+      // When gap.js asks for 'gap.data', we give it our merged array immediately.
+      // This stops it from trying to fetch 'gap.data' via XHR (which causes the 404).
+      self.Module.getPreloadedPackage = function(remotePackageName, remotePackageSize) {
+        if (remotePackageName === 'gap.data') {
+          return mergedData.buffer; 
+        }
+        return null; // Let other files download normally if any
+      };
+
+      // Just in case: also write it to FS in preRun (redundancy doesn't hurt)
+      self.Module.preRun = self.Module.preRun || [];
+      self.Module.preRun.push(() => {
+         try {
+             // Create the path just in case
+             FS.writeFile('/gap.data', mergedData); 
+         } catch(e) { /* ignore if already handled by getPreloadedPackage */ }
+      });
+    } else {
+      console.warn("Worker: No gap.data parts found. The standard downloader will likely fail with 404.");
+    }
+
+    // 3. Load GAP
+    // Now that Module.getPreloadedPackage is defined, gap.js will use it.
+    importScripts(location.origin + "/gap.js");
+
+    // 4. Connect xterm-pty
+    // We pass the TtyClient to the Emscripten TTY interface
+    emscriptenHack(new TtyClient(msg.data));
+  }
+
+  // Start the async process
+  loadAndStart();
+};

--- a/etc/emscripten/web-template/gap-worker.js
+++ b/etc/emscripten/web-template/gap-worker.js
@@ -6,7 +6,7 @@ onmessage = (msg) => {
     const buffers = [];
     let i = 1;
 
-    // 1. Download all split parts
+    // Download all split parts
     // It will look for gap.data.part1, part2, etc. until it hits a 404.
     while (true) {
       const url = location.origin + `/gap.data.part${i}`;
@@ -22,10 +22,10 @@ onmessage = (msg) => {
       }
     }
 
-    // 2. Prepare the Module object BEFORE importing gap.js
+    // Prepare the Module object BEFORE importing gap.js
     self.Module = self.Module || {};
 
-    // 2a. MERGE DATA (If parts were found)
+    // Merge data.
     if (buffers.length > 0) {
       const totalLength = buffers.reduce((acc, b) => acc + b.length, 0);
       const mergedData = new Uint8Array(totalLength);
@@ -37,9 +37,9 @@ onmessage = (msg) => {
 
       console.log(`Worker: Loaded ${buffers.length} parts. Total size: ${totalLength} bytes.`);
 
-      // CRITICAL FIX: Override the default downloader.
+      // Override the default downloader.
       // When gap.js asks for 'gap.data', we give it our merged array immediately.
-      // This stops it from trying to fetch 'gap.data' via XHR (which causes the 404).
+      // This stops it from trying to fetch 'gap.data' via XHR.
       self.Module.getPreloadedPackage = function(remotePackageName, remotePackageSize) {
         if (remotePackageName === 'gap.data') {
           return mergedData.buffer; 
@@ -47,11 +47,11 @@ onmessage = (msg) => {
         return null; // Let other files download normally if any
       };
 
-      // Just in case: also write it to FS in preRun (redundancy doesn't hurt)
+      // Just in case: also write it to FS in preRun.
       self.Module.preRun = self.Module.preRun || [];
       self.Module.preRun.push(() => {
          try {
-             // Create the path just in case
+
              FS.writeFile('/gap.data', mergedData); 
          } catch(e) { /* ignore if already handled by getPreloadedPackage */ }
       });
@@ -59,15 +59,11 @@ onmessage = (msg) => {
       console.warn("Worker: No gap.data parts found. The standard downloader will likely fail with 404.");
     }
 
-    // 3. Load GAP
-    // Now that Module.getPreloadedPackage is defined, gap.js will use it.
+    // Load GAP.
     importScripts(location.origin + "/gap.js");
 
-    // 4. Connect xterm-pty
-    // We pass the TtyClient to the Emscripten TTY interface
     emscriptenHack(new TtyClient(msg.data));
   }
 
-  // Start the async process
   loadAndStart();
 };

--- a/etc/emscripten/web-template/gap-worker.js
+++ b/etc/emscripten/web-template/gap-worker.js
@@ -9,7 +9,7 @@ onmessage = (msg) => {
     // Download all split parts
     // It will look for gap.data.part1, part2, etc. until it hits a 404.
     while (true) {
-      const url = location.origin + `/gap.data.part${i}`;
+      const url = `gap.data.part${i}`;
       try {
         const response = await fetch(url);
         if (!response.ok) break; // Stop when we hit 404
@@ -60,7 +60,7 @@ onmessage = (msg) => {
     }
 
     // Load GAP.
-    importScripts(location.origin + "/gap.js");
+    importScripts("gap.js");
 
     emscriptenHack(new TtyClient(msg.data));
   }

--- a/etc/emscripten/web-template/index.html
+++ b/etc/emscripten/web-template/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>demo</title>
+    <title>gap-wasm</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.17.0/css/xterm.css">
   </head>
   <body>
@@ -14,7 +14,7 @@
       const { master, slave } = openpty();
       xterm.loadAddon(master);
 
-      const worker = new Worker("./example.worker.js");
+      const worker = new Worker("/gap-worker.js");
       new TtyServer(slave).start(worker);
     </script>
 

--- a/etc/emscripten/web-template/index.html
+++ b/etc/emscripten/web-template/index.html
@@ -14,7 +14,7 @@
       const { master, slave } = openpty();
       xterm.loadAddon(master);
 
-      const worker = new Worker("/gap-worker.js");
+      const worker = new Worker("gap-worker.js");
       new TtyServer(slave).start(worker);
     </script>
 


### PR DESCRIPTION
## Changes
Update the following files:
etc/emscripten/build.sh
etc/emscripten/web-template/index.html
etc/emscripten/README.md

Modify and rename etc/emscripten/web-template/example.worker.js
to etc/emscripten/web-template/gap-worker.js

## Features
The gap.data built by emscripten is split into gap.data.part* whose size is up to 75MB (can be adjusted in etc/emscripten/build.sh). Thus, the emscripten built gap-system can be hosted on github pages. 
See this for a bootstrap-pkg-full demo:
https://wangyenshu.github.io/gap-wasm/
https://github.com/wangyenshu/gap-wasm/tree/gh-pages
The overall downloaded file is about 1GB, so it takes a while.

## Text for release notes

none

## Further details

Both the original and the modified build.sh works with emscripten version 3.1.23 but not the latest version.

Sreenshot on Chrome
<img width="1916" height="720" alt="gap-wasm_screenshot" src="https://github.com/user-attachments/assets/52723a6f-f8b4-480c-b464-a73c7650b826" />

