### PR TITLE
GAP banner: split `ShowPackageInformation` into two functions

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -815,11 +815,13 @@ BindGlobal( "ShowPackageInformation", function()
                                  GAPInfo.PackagesLoaded.( name )[2] ) ),
                "\n" );
   fi;
+end );
 
+BindGlobal( "ShowHelpInformation", function()
   Print( " Try '??help' for help. See also '?copyright', '?cite' and '?authors'",
          "\n" );
 end );
-#T show also root paths?
+
 
 CallAndInstallPostRestore( function()
      if not ( GAPInfo.CommandLineOptions.q or
@@ -828,12 +830,14 @@ CallAndInstallPostRestore( function()
          ShowKernelInformation();
        fi;
        ShowPackageInformation();
+       ShowHelpInformation();
      fi;
      end );
 
 BindGlobal ("ShowSystemInformation", function ()
     ShowKernelInformation();
     ShowPackageInformation();
+    ShowHelpInformation();
 end );
 
 


### PR DESCRIPTION
The function `ShowPackageInformation` prints part of the GAP banner. Up to now, it prints an overview of the loaded packages and then a line about GAP's interactive help system.

The proposed change separates the two parts,
the last line is printed by the new function `ShowHelpInformation`.

See oscar-system/GAP.jl/issues/1298 for a situation where one wants only the first part.