### PR TITLE
Fix an inconsistency problem in `IsFinite` for matrix groups over cycl. fields.

### DIFF
--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -105,12 +105,7 @@ end );
 ##
 #M  NiceObject( <group> ) . . . . . . . . . . . . .  get nice object of group
 ##
-InstallMethod( NiceObject,
-    true,
-    [ IsGroup and IsHandledByNiceMonomorphism ],
-    0,
-
-function( G )
+_NiceObject_method:= function( G )
     local   nice,  img,  D;
 
     nice := NiceMonomorphism( G );
@@ -132,7 +127,17 @@ function( G )
         SetBaseOfGroup( img, UnderlyingExternalSet( nice )!.basePermImage );
     fi;
     return img;
-end );
+end;
+
+InstallMethod( NiceObject,
+    [ IsGroup and IsHandledByNiceMonomorphism ],
+    _NiceObject_method );
+
+InstallMethod( NiceObject,
+    [ IsGroup and HasNiceMonomorphism ],
+    _NiceObject_method );
+
+Unbind( _NiceObject_method );
 
 
 #############################################################################

--- a/lib/grpramat.gi
+++ b/lib/grpramat.gi
@@ -268,12 +268,13 @@ function( G )
     # The code below is based on the algorithm described in [DFO13]
     local badPrimes, n, g, FindPrimesInMatDenominators, p, e, H, phi, gens, rels, nice, inv, Hnice;
 
-    # if not rational, use the nice monomorphism into a rational matrix group
-    if not IsRationalMatrixGroup( G ) then
-        # the following does not use NiceObject(G) as the only method for
-        # that currently requires IsHandledByNiceMonomorphism
-        SetNiceObject( G, Image( NiceMonomorphism( G ), G ) );
-        return IsFinite( NiceObject( G ) );
+    if HasNiceMonomorphism( G ) then
+      # Assume that the computation is easier in the image.
+      return IsFinite( NiceObject( G ) );
+    elif not IsRationalMatrixGroup( G ) then
+      # Use the nice monomorphism into a rational matrix group.
+      NiceMonomorphism( G );
+      return IsFinite( NiceObject( G ) );
     fi;
 
     # if not integer, choose basis in which it is integer
@@ -319,8 +320,12 @@ function( G )
     rels := RelatorsOfFpGroup(Range(phi));
     if not ForAll(rels, r -> IsOne(MappedWord(r, gens, GeneratorsOfGroup(G)))) then
         return false;
+    elif HasNiceMonomorphism( G ) or HasNiceObject( G ) then
+        # The two values must be consistent, we cannot set them here.
+        return true;
     fi;
 
+    # Set a nice monomorphism in 'G'.
     # bypass the finite field matrix group in the middle so that we can
     # compute preimages more easily
     inv := GroupHomomorphismByImagesNC(H, G : noassert);

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -1,4 +1,4 @@
-#@local cl,g,gd,gens,hom,i,img,iso,pcgs,u,G,F,o,a
+#@local cl,g,gd,gens,hom,i,img,iso,pcgs,u,G,F,o,a,m,nice,H
 gap> START_TEST("grpmat.tst");
 gap> i := E(4);; G := Group([[i,0],[0,-i]],[[0,1],[-1,0]]);;
 gap> gens := GeneratorsOfGroup( G );; IsSSortedList( gens );
@@ -66,6 +66,20 @@ gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;
 gap> NiceMonomorphism( G );;
 gap> G:= Group( [ [ 0, 1 ], [ 1, 0 ] ] );;
 gap> IsomorphismFpGroup( G );;
+
+# 'NiceMonomorphism' and 'NiceObject' are consistent.
+gap> m:= [ [ E(4) ] ];;
+gap> G:= Group( m );;                # not rational matrix group
+gap> nice:= NiceMonomorphism( G );;
+gap> H:= SubgroupNC( G, [ m^2 ] );;  # rational matrix group
+gap> HasNiceMonomorphism( H );
+true
+gap> IsIdenticalObj( NiceMonomorphism( H ), nice );
+true
+gap> IsFinite( H );
+true
+gap> NiceObject( H ) = Image( nice, H );
+true
 
 #
 gap> TrivialSubgroup( GL(2, 2) );


### PR DESCRIPTION
resolves #6195

Up to now, the method in question wanted to set the attributes `NiceMonomorphism` and `NiceObject` for the given group, provided this group was finite.
This can lead to an inconsistent group object if the group had already a stored `NiceMonomorphism` but no stored `NiceObject`.

The newly added test shows an example how such a situation can arise.

Additionally, a convenience method for `NiceObject` was added. This attribute makes sense whenever a `NiceMonomorphism` is stored, not only in the case that the group has the flag `IsHandledByNiceMonomorphism`.