### PR TITLE
Fix two bugs in `IsomorphismPermGroupForMatrixGroup`

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -556,7 +556,7 @@ end );
 ##
 BindGlobal( "IsomorphismPermGroupForMatrixGroup",
 function(G)
-local map;
+local map,H;
   if HasNiceMonomorphism(G) and IsPermGroup(Range(NiceMonomorphism(G))) then
     map:=NiceMonomorphism(G);
   else
@@ -571,10 +571,13 @@ local map;
     return map;
   fi;
   if IsIdenticalObj(map, NiceMonomorphism(G)) then
-    return GeneralRestrictedMapping(map,G,NiceObject(G));
+    H:=NiceObject(G);
   else
-    return GeneralRestrictedMapping(map,G,ImagesSet(map,G));
+    H:=ImagesSet(map,G);
   fi;
+  map:=GeneralRestrictedMapping(map, G, H);
+  SetIsBijective(map, true);
+  return map;
 end);
 
 InstallMethod( IsomorphismPermGroup,

--- a/tst/testbugfix/2026-01-26-IsomorphismPermGroupForMatrixGroup.tst
+++ b/tst/testbugfix/2026-01-26-IsomorphismPermGroupForMatrixGroup.tst
@@ -91,4 +91,18 @@ gap> IsBijective(IsomorphismPermGroupForMatrixGroup(G));
 true
 
 #
+# Verify that things that were computed as being isomorphisms
+# also *know* they are isomorphisms
+#
+gap> G:=Group(Z(3)^0*[[2,0],[0,1]]);;
+gap> iso:= IsomorphismPermGroupForMatrixGroup( G );;
+gap> HasIsBijective( iso );
+true
+gap> G:=Group(Z(3)^0*[[2,0],[0,1]]);;
+gap> NiceMonomorphism( G );;
+gap> iso:= IsomorphismPermGroupForMatrixGroup( G );;
+gap> HasIsBijective( iso );
+true
+
+#
 gap> STOP_TEST("IsomorphismPermGroupForMatrixGroup.tst");


### PR DESCRIPTION
First bug: if the input group `G` has a nice monomorphism which has `G` as source, it is always returned, even if it is not surjective.

Secondly, if `G` has a nice monomorphism  whose range is not a perm group, then `NicomorphismOfGeneralMatrixGroup` is called to compute a new morphism into a permutation group. This is then also set as nice monomorphism -- but of course that only has an effect if no nice monomorphism had been set before.

But if it was set before, then we might end up restricting the range of the new map produced by `NicomorphismOfGeneralMatrixGroup` to the wrong group (namely `NiceObject(G)`).

Fixes #6205 (at least the "superficial" part of it, not yet clear why it produces a worse nice mono).