### PR TITLE
Add `ConformalSymplecticGroup`

### DIFF
--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -4901,6 +4901,15 @@
   <url>https://arxiv.org/abs/2201.09155</url>
 </article></entry>
 
+<entry id="Tay21"><misc>
+  <author>
+    <name><first>D. E.</first><last>Taylor</last></name>
+  </author>
+  <title>Conjugacy Classes in Finite Conformal Symplectic Groups</title>
+  <year>2021</year>
+  <howpublished>https://www.maths.usyd.edu.au/u/don/code/Magma/CSpConjugacy.pdf</howpublished>
+</misc></entry>
+
 <entry id="Theissen93"><mastersthesis>
   <author>
     <name><first>Heiko</first><last>Theißen</last></name>

--- a/doc/ref/grpmat.xml
+++ b/doc/ref/grpmat.xml
@@ -91,6 +91,8 @@ that represent a faithful action on vectors.
 
 <#Include Label="InvariantBilinearForm">
 <#Include Label="IsFullSubgroupGLorSLRespectingBilinearForm">
+<#Include Label="InvariantBilinearFormUpToScalars">
+<#Include Label="IsFullSubgroupGLRespectingBilinearFormUpToScalars">
 <#Include Label="InvariantSesquilinearForm">
 <#Include Label="IsFullSubgroupGLorSLRespectingSesquilinearForm">
 <#Include Label="InvariantQuadraticForm">

--- a/doc/ref/makedocreldata.g
+++ b/doc/ref/makedocreldata.g
@@ -13,6 +13,7 @@ GAPInfo.ManualDataRef:= rec(
     "../../src/sysfiles.c",
     "../../grp/basic.gd",
     "../../grp/classic.gd",
+    "../../grp/conformal.gd",
     "../../grp/perf.gd",
     "../../grp/ree.gd",
     "../../grp/suzuki.gd",

--- a/grp/basicmat.gi
+++ b/grp/basicmat.gi
@@ -139,23 +139,29 @@ InstallMethod( GeneralLinearGroupCons,
       IsInt and IsPosRat,
       IsField and IsFinite ],
 function( filter, n, f )
-    local   q,  z,  o,  mat1,  mat2,  i,  g;
+    local   q,  filt,  z,  o,  mat1,  mat2,  i,  g;
 
     q:= Size( f );
+
+    # Decide about the internal representation of group generators.
+    filt:= ValueOption( "ConstructingFilter" );
+    if filt = fail then
+      filt:= IsPlistRep;
+    fi;
 
     # small cases
     if q = 2 and 1 < n  then
 #T why 1 < n?
-        return SL( n, 2 );
+        return SL( n, f );
     fi;
 
     # construct the generators
     z := PrimitiveRoot( f );
     o := One( f );
 
-    mat1 := IdentityMat( n, f );
+    mat1 := IdentityMatrix( filt, f, n );
     mat1[1,1] := z;
-    mat2 := List( Zero(o) * mat1, ShallowCopy );
+    mat2 := ZeroMatrix( filt, f, n, n );
     mat2[1,1] := -o;
     mat2[1,n] := o;
     for i  in [ 2 .. n ]  do mat2[i,i-1]:= -o;  od;
@@ -189,13 +195,19 @@ InstallMethod( SpecialLinearGroupCons,
       IsField and IsFinite ],
 
 function( filter, n, f )
-    local   q,  g,  o,  z,  mat1,  mat2,  i,  size,  qi;
+    local   q,  filt,  g,  o,  z,  mat1,  mat2,  i,  size,  qi;
 
     q:= Size( f );
 
+    # Decide about the internal representation of group generators.
+    filt:= ValueOption( "ConstructingFilter" );
+    if filt = fail then
+      filt:= IsPlistRep;
+    fi;
+
     # handle the trivial case first
     if n = 1 then
-        g := GroupByGenerators( [ ImmutableMatrix( f, [[One(f)]],true ) ] );
+        g := GroupByGenerators( [ ImmutableMatrix( f, IdentityMatrix( filt, f, 1 ), true ) ] );
 
     # now the general case
     else
@@ -203,8 +215,8 @@ function( filter, n, f )
         # construct the generators
         o := One(f);
         z := PrimitiveRoot(f);
-        mat1 := IdentityMat( n, f );
-        mat2 := List( Zero(o) * mat1, ShallowCopy );
+        mat1 := IdentityMatrix( filt, f, n );
+        mat2 := ZeroMatrix( filt, f, n, n );
         mat2[1,n] := o;
         for i  in [ 2 .. n ]  do mat2[i,i-1]:= -o;  od;
 

--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -18,20 +18,28 @@
 ##  <#GAPDoc Label="[1]{classic}">
 ##  The following functions return classical groups.
 ##  <P/>
+##  <E>Generators</E>
+##  <P/>
+##  <List>
+##  <Item>
 ##  For the linear, symplectic, and unitary groups (the latter in dimension
 ##  at least <M>3</M>),
 ##  the generators are taken from&nbsp;<Cite Key="Tay87"/>.
+##  </Item>
+##  <Item>
 ##  For the unitary groups in dimension <M>2</M>, the isomorphism of
 ##  SU<M>(2,q)</M> and SL<M>(2,q)</M> is used,
 ##  see for example&nbsp;<Cite Key="Hup67"/>.
-##  <P/>
+##  </Item>
+##  <Item>
 ##  The generators of the general and special orthogonal groups are taken
 ##  from&nbsp;<Cite Key="IshibashiEarnest94"/> and
 ##  <Cite Key="KleidmanLiebeck90"/>,
 ##  except that the generators of the groups in odd dimension in even
 ##  characteristic are constructed via the isomorphism to a symplectic group,
 ##  see for example&nbsp;<Cite Key="Car72a"/>.
-##  <P/>
+##  </Item>
+##  <Item>
 ##  The generators of the groups <M>\Omega^\epsilon(d, q)</M> are taken
 ##  from&nbsp;<Cite Key="RylandsTalor98"/>,
 ##  except that in odd dimension and even characteristic,
@@ -45,7 +53,8 @@
 ##  except in the case <M>(d,q) = (5,2)</M>,
 ##  where the matrices from&nbsp;<Cite Key="RylandsTalor98"/> generate
 ##  the simple group <M>S_4(2)'</M> and not the group <M>S_4(2)</M>.
-##  <P/>
+##  </Item>
+##  <Item>
 ##  The generators for the semilinear groups are constructed from the
 ##  generators of the corresponding linear groups plus one additional
 ##  generator that describes the action of the group of field automorphisms;
@@ -53,15 +62,36 @@
 ##  this yields the matrix groups <M>Gamma</M>L<M>(d, p^f)</M> and
 ##  <M>Sigma</M>L<M>(d, p^f)</M> as groups of <M>d f \times df</M> matrices
 ##  over the field with <M>p</M> elements.
+##  </Item>
+##  <Item>
+##  The generators for the conformal symplectic groups are taken
+##  from&nbsp;<Cite Key="Tay21"/>.
+##  </Item>
+##  </List>
 ##  <P/>
+##  <E>Invariant forms</E>
+##  <P/>
+##  <List>
+##  <Item>
 ##  For symplectic and orthogonal matrix groups returned by the functions
 ##  described below, the invariant bilinear form is stored as the value of
 ##  the attribute <Ref Attr="InvariantBilinearForm"/>.
-##  Analogously, the invariant sesquilinear form defining the unitary groups
+##  </Item>
+##  <Item>
+##  The invariant sesquilinear form defining the unitary groups
 ##  is stored as the value of the attribute
 ##  <Ref Attr="InvariantSesquilinearForm"/>).
+##  </Item>
+##  <Item>
 ##  The defining quadratic form of orthogonal groups is stored as the value
 ##  of the attribute <Ref Attr="InvariantQuadraticForm"/>.
+##  </Item>
+##  <Item>
+##  The bilinear form that is invariant up to scalars under the
+##  conformal symplectic group is stored as the value of the attribute
+##  <Ref Attr="InvariantBilinearFormUpToScalars"/>.
+##  </Item>
+##  </List>
 ##  <P/>
 ##  Note that due to the different sources for the generators,
 ##  the invariant forms for the groups <M>\Omega(e,d,q)</M> are in general
@@ -707,45 +737,51 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 
 #############################################################################
 ##
+#F  SymplecticGroup( [<filt>, ]<d>, <R>[, <form>] ) . . . .  symplectic group
 #F  SymplecticGroup( [<filt>, ]<d>, <q>[, <form>] ) . . . .  symplectic group
 #F  SymplecticGroup( [<filt>, ]<form> ) . . . . . . . . . .  symplectic group
+#F  Sp( [<filt>, ]<d>, <R>[, <form>] )
 #F  Sp( [<filt>, ]<d>, <q>[, <form>] )
 #F  Sp( [<filt>, ]<form> )
+#F  SP( [<filt>, ]<d>, <R>[, <form>] )
 #F  SP( [<filt>, ]<d>, <q>[, <form>] )
 #F  SP( [<filt>, ]<form> )
 ##
 ##  <#GAPDoc Label="SymplecticGroup">
 ##  <ManSection>
 ##  <Heading>SymplecticGroup</Heading>
+##  <Func Name="SymplecticGroup" Arg='[filt, ]d, R[, form]'
+##   Label="for dimension and a ring"/>
 ##  <Func Name="SymplecticGroup" Arg='[filt, ]d, q[, form]'
 ##   Label="for dimension and field size"/>
-##  <Func Name="SymplecticGroup" Arg='[filt, ]d, ring[, form]'
-##   Label="for dimension and a ring"/>
 ##  <Func Name="SymplecticGroup" Arg='[filt, ]form'
 ##   Label="for form"/>
+##  <Func Name="Sp" Arg='[filt, ]d, R[, form]'
+##   Label="for dimension and a ring"/>
 ##  <Func Name="Sp" Arg='[filt, ]d, q[, form]'
 ##   Label="for dimension and field size"/>
-##  <Func Name="Sp" Arg='[filt, ]d, ring[, form]'
-##   Label="for dimension and a ring"/>
 ##  <Func Name="Sp" Arg='[filt, ]form'
 ##   Label="for form"/>
+##  <Func Name="SP" Arg='[filt, ]d, R[, form]'
+##   Label="for dimension and a ring"/>
 ##  <Func Name="SP" Arg='[filt, ]d, q[, form]'
 ##   Label="for dimension and field size"/>
-##  <Func Name="SP" Arg='[filt, ]d, ring[, form]'
-##   Label="for dimension and a ring"/>
 ##  <Func Name="SP" Arg='[filt, ]form'
 ##   Label="for form"/>
 ##
 ##  <Description>
 ##  constructs a group isomorphic to the symplectic group
-##  Sp( <A>d</A>, <A>q</A> ) of those <M><A>d</A> \times <A>d</A></M>
-##  matrices over the field with <A>q</A> elements (respectively the ring
-##  <A>ring</A>)
+##  Sp( <A>d</A>, <A>R</A> ) of those <M><A>d</A> \times <A>d</A></M>
+##  matrices over the ring <A>R</A> or the field with <A>q</A> elements,
+##  respectively,
 ##  that respect a fixed nondegenerate symplectic form,
 ##  in the category given by the filter <A>filt</A>.
 ##  <P/>
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the symplectic group itself.
+##  Another supported value for <A>filt</A> is
+##  <Ref Filt="IsPermGroup"/>;
+##  in this case, the argument <A>form</A> is not supported.
 ##  <P/>
 ##  At the moment finite fields or residue class rings
 ##  <C>Integers mod <A>q</A></C>, with <A>q</A> an odd prime power, are
@@ -759,7 +795,7 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  or a group with stored <Ref Attr="InvariantBilinearForm"/> value
 ##  (and then this form is taken).
 ##  <P/>
-##  A given <A>form</A> determines and <A>d</A>, and also <A>q</A>
+##  A given <A>form</A> determines <A>d</A>, and also <A>R</A>
 ##  except if <A>form</A> is a matrix that does not store its
 ##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
 ##  These parameters can be entered, and an error is signalled if they do

--- a/grp/conformal.gd
+++ b/grp/conformal.gd
@@ -1,0 +1,140 @@
+#############################################################################
+##
+##  conformal.gd
+##
+##  Provide 'ConformalSymplecticGroup' and related functions.
+##
+
+
+#############################################################################
+##
+#A  InvariantBilinearFormUpToScalars( <matgrp> )
+##
+##  <#GAPDoc Label="InvariantBilinearFormUpToScalars">
+##  <ManSection>
+##  <Attr Name="InvariantBilinearFormUpToScalars" Arg='matgrp'/>
+##
+##  <Description>
+##  This attribute describes a bilinear form that is invariant up to scalars
+##  under the matrix group <A>matgrp</A>.
+##  The form is given by a record with the component <C>matrix</C>
+##  which is a matrix <M>J</M> such that for every generator <M>g</M> of
+##  <A>matgrp</A> the equation <M>g \cdot J \cdot g^{tr} = \lambda(g) J</M>
+##  holds, for <M>\lambda(g)</M> in the
+##  <Ref Attr="FieldOfMatrixGroup"/> value of <A>matgrp</A>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareAttribute( "InvariantBilinearFormUpToScalars", IsMatrixGroup );
+
+
+#############################################################################
+##
+#P  IsFullSubgroupGLRespectingBilinearFormUpToScalars( <matgrp> )
+##
+##  <#GAPDoc Label="IsFullSubgroupGLRespectingBilinearFormUpToScalars">
+##  <ManSection>
+##  <Prop Name="IsFullSubgroupGLRespectingBilinearFormUpToScalars"
+##  Arg='matgrp'/>
+##
+##  <Description>
+##  This property tests whether the matrix group <A>matgrp</A> is the full
+##  subgroup of GL respecting, up to scalars, the form stored as the value of
+##  <Ref Attr="InvariantBilinearFormUpToScalars"/> for <A>matgrp</A>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsFullSubgroupGLRespectingBilinearFormUpToScalars",
+    IsMatrixGroup );
+
+InstallTrueMethod( IsGroup,
+    IsFullSubgroupGLRespectingBilinearFormUpToScalars );
+
+
+#############################################################################
+##
+#O  ConformalSymplecticGroupCons( <filter>, <d>, <R> )
+#O  ConformalSymplecticGroupCons( <filter>, <d>, <q> )
+##
+DeclareConstructor( "ConformalSymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
+DeclareConstructor( "ConformalSymplecticGroupCons", [ IsGroup, IsPosInt, IsPosInt ] );
+
+
+#############################################################################
+##
+#F  ConformalSymplecticGroup( [<filt>, ]<d>, <R>[, <form>] ) conf. sympl. gp.
+#F  ConformalSymplecticGroup( [<filt>, ]<d>, <q>[, <form>] ) conf. sympl. gp.
+#F  ConformalSymplecticGroup( [<filt>, ]<form> )   conformal symplectic group
+#F  CSp( [<filt>, ]<d>, <R>[, <form>] ) . . . . .  conformal symplectic group
+#F  CSp( [<filt>, ]<d>, <q>[, <form>] ) . . . . .  conformal symplectic group
+#F  CSp( [<filt>, ]<form> ) . . . . . . . . . . .  conformal symplectic group
+##
+##  <#GAPDoc Label="ConformalSymplecticGroup">
+##  <ManSection>
+##  <Heading>ConformalSymplecticGroup</Heading>
+##  <Func Name="ConformalSymplecticGroup" Arg='[filt, ]d, R[, form]'
+##   Label="for dimension and a ring"/>
+##  <Func Name="ConformalSymplecticGroup" Arg='[filt, ]d, q[, form]'
+##   Label="for dimension and field size"/>
+##  <Func Name="ConformalSymplecticGroup" Arg='[filt, ]form'
+##   Label="for form"/>
+##  <Func Name="CSp" Arg='[filt, ]d, R[, form]'
+##   Label="for dimension and a ring"/>
+##  <Func Name="CSp" Arg='[filt, ]d, q[, form]'
+##   Label="for dimension and field size"/>
+##  <Func Name="CSp" Arg='[filt, ]form'
+##   Label="for form"/>
+##
+##  <Description>
+##  constructs a group isomorphic to the conformal symplectic group
+##  CSp( <A>d</A>, <A>R</A> ) of those <M><A>d</A> \times <A>d</A></M>
+##  matrices over the ring <A>R</A> or the field with <A>q</A> elements,
+##  respectively,
+##  that respect a fixed nondegenerate symplectic form up to scalars,
+##  in the category given by the filter <A>filt</A>.
+##  <P/>
+##  Currently only finite fields <A>R</A> are supported.
+##  <P/>
+##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
+##  and the returned group is the conformal symplectic group itself.
+##  Another supported value for <A>filt</A> is
+##  <Ref Filt="IsPermGroup"/>;
+##  in this case, the argument <A>form</A> is not supported.
+##  <P/>
+##  If version at least 1.2.15 of the <Package>Forms</Package> package is
+##  loaded and the arguments describe a matrix group over a finite field then
+##  the desired bilinear form can be specified via <A>form</A>,
+##  which can be either a matrix
+##  or a form object in <Ref Filt="IsBilinearForm" BookName="Forms"/>
+##  or a group with stored <Ref Attr="InvariantBilinearForm"/> or
+##  <Ref Attr="InvariantBilinearFormUpToScalars"/> value
+##  (and then this form is taken).
+##  <P/>
+##  A given <A>form</A> determines <A>d</A>, and also <A>R</A>
+##  except if <A>form</A> is a matrix that does not store its
+##  <Ref Attr="BaseDomain" Label="for a matrix object"/> value.
+##  These parameters can be entered, and an error is signalled if they do
+##  not fit to the given <A>form</A>.
+##  <P/>
+##  If <A>form</A> is not given then a default is chosen as described in the
+##  introduction to Section <Ref Sect="Classical Groups"/>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> g:= ConformalSymplecticGroup( 4, 2 );
+##  CSp(4,2)
+##  gap> Size( g );
+##  720
+##  gap> StructureDescription( g );
+##  "S6"
+##  gap> ConformalSymplecticGroup( IsPermGroup, 4, 2 );
+##  Perm_CSp(4,2)
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "ConformalSymplecticGroup" );
+
+DeclareSynonym( "CSp", ConformalSymplecticGroup );

--- a/grp/conformal.gi
+++ b/grp/conformal.gi
@@ -1,0 +1,143 @@
+
+# auxiliary function analogous to `DescribesInvariantBilinearForm`
+BindGlobal( "DescribesInvariantBilinearFormUpToScalars",
+    obj -> IsMatrixOrMatrixObj( obj ) or
+           ( IsBoundGlobal( "IsBilinearForm" ) and
+             ValueGlobal( "IsBilinearForm" )( obj ) ) or
+           ( IsGroup( obj ) and HasInvariantBilinearForm( obj ) ) or
+           ( IsGroup( obj ) and HasInvariantBilinearFormUpToScalars( obj ) ) );
+
+
+#############################################################################
+##
+#F  ConformalSymplecticGroup( [<filt>, ]<d>, <q>[, <form>] ) conf. sympl. gp.
+#F  ConformalSymplecticGroup( [<filt>, ]<d>, <R>[, <form>] ) conf. sympl. gp.
+#F  ConformalSymplecticGroup( [<filt>, ]<form> )   conformal symplectic group
+#F  CSp( [<filt>, ]<d>, <q>[, <form>] )            conformal symplectic group
+#F  CSp( [<filt>, ]<d>, <R>[, <form>] )            conformal symplectic group
+#F  CSp( [<filt>, ]<form> )                        conformal symplectic group
+##
+InstallGlobalFunction( ConformalSymplecticGroup, function ( arg )
+  local filt, form;
+
+  if IsFilter( First( arg ) ) then
+    filt:= Remove( arg, 1 );
+  else
+    filt:= IsMatrixGroup;
+  fi;
+  if DescribesInvariantBilinearFormUpToScalars( Last( arg ) ) then
+    # interpret this argument (matrix or form or group with stored form)
+    # as "up to scalars"
+    form:= Remove( arg );
+    if Length( arg ) = 0 then
+      # ( [<filt>, ]<form> )
+      return ConformalSymplecticGroupCons( filt, form );
+    elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                           and ( IsRing( arg[2] ) or IsPosInt( arg[2] ) ) then
+      # ( [<filt>, ]<d>, <R>, <form> ) or ( [<filt>, ]<d>, <q>, <form> )
+      return ConformalSymplecticGroupCons( filt, arg[1], arg[2], form );
+    fi;
+  elif Length( arg ) = 2 and IsPosInt( arg[1] )
+                         and ( IsRing( arg[2] ) or IsPosInt( arg[2] ) ) then
+    # ( [<filt>, ]<d>, <R> ) or ( [<filt>, ]<d>, <q> )
+    return ConformalSymplecticGroupCons( filt, arg[1], arg[2] );
+  fi;
+  Error( "usage: ConformalSymplecticGroup( [<filt>, ]<d>, <R>[, <form>] )\n",
+         "or ConformalSymplecticGroup( [<filt>, ]<d>, <q>[, <form>] )\n",
+         "or ConformalSymplecticGroup( [<filt>, ]<form> )" );
+end );
+
+
+#############################################################################
+##
+#M  ConformalSymplecticGroupCons( <IsMatrixGroup>, <d>, <F> )
+##
+InstallMethod( ConformalSymplecticGroupCons,
+  "matrix group for dimension and finite field",
+  [ IsMatrixGroup and IsFinite,
+    IsPosInt,
+    IsField and IsFinite ],
+  function( filter, d, F )
+  local q, o, filt, g, c, data, mat1, mat2, mat3, z, i, size, qi;
+
+  # the dimension must be even
+  if d mod 2 = 1 then
+    Error( "the dimension <d> must be even" );
+  fi;
+  q:= Size( F );
+  o:= One( F );
+
+  # Decide about the internal representation of group generators.
+  filt:= ValueOption( "ConstructingFilter" );
+  if filt = fail then
+    filt:= IsPlistRep;
+  fi;
+
+  if d = 2 then
+    # the group is a general linear group
+    g:= GL( 2, F );
+
+    c:= ZeroMatrix( filt, F, 2, 2 );
+    c[1,2]:= o;
+    c[2,1]:= -o;
+  else
+    data:= GeneratorsAndFormOfSymplecticGroupOverFiniteField( filt,
+               F, d, q );
+    c:= data[2];
+    mat1:= data[1][1];
+    mat2:= data[1][2];
+
+    mat3:= IdentityMatrix( filt, F, d );
+    z:= PrimitiveRoot( F );
+    for i in [ 1 .. d/2 ] do
+      mat3[i, i]:= z;
+    od;
+    mat3:= ImmutableMatrix( F, mat3, true );
+
+    # avoid to call 'Group' because this would check invertibility ...
+    g:= GroupWithGenerators( [ mat1, mat2, mat3 ] );
+    SetName( g, Concatenation( "CSp(", String(d), ",", String(q), ")" ) );
+    SetDimensionOfMatrixGroup( g, d );
+
+    # 'mat1' contains a primitive root of 'F'.
+    SetFieldOfMatrixGroup( g, F );
+
+    # add the size
+    size := 1;
+    qi   := 1;
+    for i in [ 1 .. d/2 ] do
+      qi   := qi * q^2;
+      size := size * (qi-1);
+    od;
+    SetSize( g, q^((d/2)^2) * size * (q-1) );
+  fi;
+
+  # set the form
+  SetInvariantBilinearFormUpToScalars( g,
+      rec( matrix:= ImmutableMatrix( F, c, true ), baseDomain:= F ) );
+  SetIsFullSubgroupGLRespectingBilinearFormUpToScalars( g, true );
+
+  # and return
+  return g;
+end );
+
+
+#############################################################################
+##
+#M  ConformalSymplecticGroupCons( <IsMatrixGroup>, <d>, <q> )
+##
+InstallMethod( ConformalSymplecticGroupCons,
+  "matrix group for dimension and finite field size",
+  [ IsMatrixGroup and IsFinite,
+    IsPosInt,
+    IsPosInt ],
+  { filt, n, q } -> ConformalSymplecticGroupCons( filt, n, GF(q) ) );
+
+
+#############################################################################
+##
+##  Support `IsPermGroup` as first argument in `ConformalSymplecticGroup`.
+##
+PermConstructor( ConformalSymplecticGroupCons,
+  [ IsPermGroup, IsInt, IsObject ],
+  IsMatrixGroup and IsFinite );

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -839,7 +839,8 @@ BindGlobal( "RespectsQuadraticForm", function( Q, M )
 #M  <mat> in <G>  . . . . . . . . . . . . . . . . . . . .  is form invariant?
 ##
 InstallMethod( \in, "respecting quadratic form", IsElmsColls,
-    [ IsMatrix, IsFullSubgroupGLorSLRespectingQuadraticForm ],
+    [ IsMatrixOrMatrixObj,
+      IsFullSubgroupGLorSLRespectingQuadraticForm ],
     {} -> RankFilter( IsHandledByNiceMonomorphism ), # override nice mon. method
                  # this method is better than the one using a nice monom.;
                  # it has the same rank as the method based on the inv.
@@ -859,7 +860,8 @@ InstallMethod( \in, "respecting quadratic form", IsElmsColls,
     end );
 
 InstallMethod( \in, "respecting bilinear form", IsElmsColls,
-    [ IsMatrix, IsFullSubgroupGLorSLRespectingBilinearForm ],
+    [ IsMatrixOrMatrixObj,
+      IsFullSubgroupGLorSLRespectingBilinearForm ],
     {} -> RankFilter( IsHandledByNiceMonomorphism ), # override nice mon. method
 function( mat, G )
     local inv;
@@ -874,7 +876,8 @@ function( mat, G )
 end );
 
 InstallMethod( \in, "respecting sesquilinear form", IsElmsColls,
-    [ IsMatrix, IsFullSubgroupGLorSLRespectingSesquilinearForm ],
+    [ IsMatrixOrMatrixObj,
+      IsFullSubgroupGLorSLRespectingSesquilinearForm ],
     {} -> RankFilter( IsHandledByNiceMonomorphism ), # override nice mon. method
 function( mat, G )
     local form, pow, inv;

--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -892,6 +892,54 @@ function( mat, G )
            = inv;
 end );
 
+# The forms package contains this function with the name '_IsEqualModScalars',
+# note that the function 'IsEqualProjective' from the recog package
+# cannot be used because the matrices that describe forms can have zero rows.
+BindGlobal( "_IsEqualModScalars_GAP",
+    function( mat1, mat2 )
+    local m, n, i, j, s;
+
+    m:= NrRows( mat1 );
+    if m <> NrRows( mat2 ) then
+      return false;
+    fi;
+    n:= NrCols( mat1 );
+    if n <> NrCols( mat2 ) then
+      return false;
+    fi;
+    for i in [ 1 .. m ] do
+      for j in [ 1 .. n ] do
+        if not IsZero( mat1[ i, j ] ) then
+          s:= mat2[ i, j ] / mat1[ i, j ];
+          if IsZero( s ) then
+            return false;
+          elif IsRowListMatrix( mat1 ) and IsRowListMatrix( mat2 ) then
+            # separate case for performance reasons
+            return ForAll( [ 1 .. m ], i -> s * mat1[i] = mat2[i] );
+          fi;
+          return s * mat1 = mat2;
+        fi;
+      od;
+    od;
+    return IsZero( mat2 );
+end );
+
+InstallMethod( \in, "respecting bilinear form up to scalars", IsElmsColls,
+  [ IsMatrixOrMatrixObj,
+    IsFullSubgroupGLRespectingBilinearFormUpToScalars ],
+  {} -> RankFilter( IsHandledByNiceMonomorphism ), # override nice mon. method
+function( mat, G )
+    local inv;
+    # We may use `FieldOfMatrixGroup( G )` instead of `baseDomain` of the form,
+    # see the comment for the '\in' method above.
+    if not IsSubset( FieldOfMatrixGroup( G ),
+                     FieldOfMatrixList( [ mat ] ) ) then
+      return false;
+    fi;
+    inv:= InvariantBilinearFormUpToScalars( G ).matrix;
+    return _IsEqualModScalars_GAP( inv, mat * inv * TransposedMat( mat ) );
+end );
+
 
 #############################################################################
 ##

--- a/lib/read3.g
+++ b/lib/read3.g
@@ -208,6 +208,7 @@ ReadLib( "grpramat.gd" );
 # group library
 ReadGrp( "basic.gd"    );
 ReadGrp( "classic.gd"  );
+ReadGrp( "conformal.gd" );
 ReadGrp( "perf.gd"     );
 ReadGrp( "suzuki.gd"   );
 ReadGrp( "ree.gd"   );

--- a/lib/read6.g
+++ b/lib/read6.g
@@ -18,6 +18,7 @@ ReadGrp( "basicmat.gi" );
 ReadGrp( "basicfp.gi"  );
 ReadGrp( "perf.grp"    );
 ReadGrp( "classic.gi"  );
+ReadGrp( "conformal.gi" );
 ReadGrp( "suzuki.gi"   );
 ReadGrp( "ree.gi"      );
 ReadGrp( "simple.gi"      );

--- a/tst/testinstall/grp/classic-forms.tst
+++ b/tst/testinstall/grp/classic-forms.tst
@@ -1,7 +1,10 @@
 #@local CheckGeneratorsInvertible, CheckGeneratorsSpecial, CheckField
-#@local CheckBilinearForm, CheckQuadraticForm, frob, CheckSesquilinearForm
+#@local CheckBilinearForm, CheckBilinearFormUpToScalars
+#@local CheckQuadraticForm, frob, CheckSesquilinearForm
 #@local CheckSize, CheckClasses, CheckMembershipFromForm
 #@local CheckMembershipBilinear, CheckMembershipBilinear2
+#@local CheckMembershipBilinearUpToScalars
+#@local CheckMembershipBilinearUpToScalars2
 #@local CheckMembershipSesquilinear
 #@local CheckMembershipQuadratic, CheckMembershipQuadratic2
 #@local grps1, grps2, grps, d, q, G, m
@@ -32,6 +35,12 @@ gap> CheckBilinearForm := function(G)
 >   M := InvariantBilinearForm(G).matrix;
 >   return ForAll(GeneratorsOfGroup(G),
 >               g -> g*M*TransposedMat(g) = M);
+> end;;
+gap> CheckBilinearFormUpToScalars := function(G)
+>   local M;
+>   M := InvariantBilinearFormUpToScalars(G).matrix;
+>   return ForAll(GeneratorsOfGroup(G),
+>               g -> _IsEqualModScalars_GAP(g*M*TransposedMat(g), M));
 > end;;
 gap> CheckQuadraticForm := function(G)
 >   local M, Q;
@@ -77,7 +86,8 @@ gap> CheckMembershipFromForm:= function( G, form )
 >    full:= GL( DimensionOfMatrixGroup( G ), form.baseDomain );
 >    return ForAll( [ 1 .. 10 ], i -> PseudoRandom( G ) in G ) and
 >           ( ForAny( GeneratorsOfGroup( full ), g -> not ( g in G ) ) or
->             Size( G ) = Size( full ) );
+>             Size( G ) = Size( full ) ) and
+>           not HasNiceMonomorphism( G );
 > end;;
 gap> CheckMembershipBilinear:= function( G )
 >    return HasIsFullSubgroupGLorSLRespectingBilinearForm( G )
@@ -88,6 +98,20 @@ gap> CheckMembershipBilinear2:= function( G )
 >    if HasIsFullSubgroupGLorSLRespectingBilinearForm( G )
 >       and IsFullSubgroupGLorSLRespectingBilinearForm( G ) then
 >      return CheckMembershipFromForm( G, InvariantBilinearForm( G ) );
+>    fi;
+>    return true;
+> end;;
+gap> CheckMembershipBilinearUpToScalars:= function( G )
+>    return HasIsFullSubgroupGLRespectingBilinearFormUpToScalars( G )
+>           and IsFullSubgroupGLRespectingBilinearFormUpToScalars( G )
+>           and CheckMembershipFromForm( G,
+>                 InvariantBilinearFormUpToScalars( G ) );
+> end;;
+gap> CheckMembershipBilinearUpToScalars2:= function( G )
+>    if HasIsFullSubgroupGLRespectingBilinearFormUpToScalars( G )
+>       and IsFullSubgroupGLRespectingBilinearFormUpToScalars( G ) then
+>      return CheckMembershipFromForm( G,
+>               InvariantBilinearFormUpToScalars( G ) );
 >    fi;
 >    return true;
 > end;;
@@ -336,6 +360,32 @@ true
 gap> ForAll(grps1, CheckMembershipBilinear);
 true
 gap> ForAll(grps2, CheckMembershipBilinear2);
+true
+
+#
+# conformal symplectic groups
+#
+gap> grps1:=[];;
+gap> grps2:=[];;
+gap> for d in [2,4,6,8] do
+>   for q in [2,3,4,5,7,8,9,16,17,25,27] do
+>     Add(grps1, CSp(d,q));
+>     Add(grps2, CSp(d,q) ^ RandomInvertibleMat(d,GF(q)));
+>     Add(grps2, CSp(d,q) ^ RandomInvertibleMat(d,GF(q^2)));
+>   od;
+> od;
+gap> grps:= Concatenation( grps1, grps2 );;
+gap> ForAll(grps, CheckGeneratorsInvertible);
+true
+gap> ForAll(grps, CheckField);
+true
+gap> ForAll(grps1, CheckBilinearFormUpToScalars);
+true
+gap> ForAll(grps, CheckSize);
+true
+gap> ForAll(grps1, CheckMembershipBilinearUpToScalars);
+true
+gap> ForAll(grps2, CheckMembershipBilinearUpToScalars2);
 true
 
 # an undocumented helper function


### PR DESCRIPTION
... and add some generalizations.

- Add `ConformalSymplecticGroup`, essentially analogous to the implementation of `SymplecticGroup`, that is,
  - introduce a plain function `ConformalSymplecticGroup` and a constructor `ConformalSymplecticGroupCons`,
  - install various methods for `ConformalSymplecticGroupCons`,
  - introduce a property `IsFullSubgroupGLRespectingBilinearFormUpToScalars` that is set in the groups returned by `ConformalSymplecticGroup`,
  - install a `\in` method for a matrix and a group in `IsFullSubgroupGLRespectingBilinearFormUpToScalars`,
  - add tests for the new code.

- In `ConformalSymplecticGroup`, `GeneralLinearGroup`, `SpecialLinearGroup`, and `SymplecticGroup`, support a filter that determines the representation of the matrices constructed as generators of the groups and as matrices of the invariant forms. (Note that `ConformalSymplecticGroup` and `SymplecticGroup` call `GeneralLinearGroup` and `SpecialLinearGroup`, respectively, for `n = 2`.) For that, an "experimental" global option `ConstructingFilter` is used. Currently `IsPlistRep` is the default value, `IsPlistRepMatrix` is another possible value. (Eventually we want to support such a filter also for the other classical groups.)

- Change the delegation between methods of `SymplecticGroup`: Do not delegate from the variant where a finite field is given to the variant with given size of the field, but the other way round. This way, it will be possible to use elements from `StandardFiniteField( p, n )` instead of `GF( p, n )` in the matrices. (Eventually we want to change this also for the other classical groups.)

Once we decide about the setup that we want for `ConformalSymplecticGroup`, implementations for other conformal classical group can be added, and the relevant methods in the Forms package can be adjusted and extended accordingly.