### PR TITLE
Change `CoverageLineByLine` to produce output compatible with that produced by the `--coverage` command line option

### DIFF
--- a/lib/newprofile.g
+++ b/lib/newprofile.g
@@ -115,7 +115,7 @@ end);
 ##  <#/GAPDoc>
 
 BIND_GLOBAL("CoverageLineByLine", function(name)
-  return ProfileLineByLine(name, rec(coverage := true));
+  return ProfileLineByLine(name, rec(coverage := true, recordMem := true));
 end);
 
 #############################################################################


### PR DESCRIPTION
That is, when asking the `profiling` package to process multiple files produced by each of the two options, this should just work, while currently it leads to this error:
> Error, Some profiles use wall time, some use CPU time