### PR TITLE
Colour in GAP banner logo

### DIFF
--- a/lib/init.g
+++ b/lib/init.g
@@ -434,7 +434,7 @@ function( prefix, values, suffix )
 end);
 
 BindGlobal( "ShowKernelInformation", function()
-  local sysdate, btop, vert, bbot, config, str, gap;
+  local sysdate, btop, bmid, bbot, config, str, gap;
 
   if GAPInfo.Date <> "today" then
     sysdate := " of ";
@@ -447,19 +447,26 @@ BindGlobal( "ShowKernelInformation", function()
   fi;
 
   if GAPInfo.TermEncoding = "UTF-8" then
-    btop := "┌───────┐\c"; vert := "│"; bbot := "└───────┘\c";
+    # Includes colour, which causes line-wrapping issues at 80 columns
+    btop := "   \033[94m● \033[1;31mG\033[0m";
+    bmid := "\033[92m● \033[91m●  \033[1;31mA\033[0m";
+    bbot := "   \033[93m● \033[1;31mP\033[0m";
   else
-    btop := "*********"; vert := "*"; bbot := btop;
+    btop := "   o G";
+    bmid := "o o  A";
+    bbot := "   o P";
   fi;
   if IsHPCGAP then
     gap := "HPC-GAP";
   else
     gap := "GAP";
   fi;
-  Print( " ",btop,"   ",gap," ", GAPInfo.BuildVersion,
+  Print( "\n",  # Could remove first and last newlines for a more compact look
+         "  ",btop,"  ",gap," ", GAPInfo.BuildVersion,
          sysdate, "\n",
-         " ",vert,"  GAP  ",vert,"   https://www.gap-system.org\n",
-         " ",bbot,"   Architecture: ", GAPInfo.Architecture, "\n" );
+         "  ",bmid,"  https://www.gap-system.org\n",
+         "  ",bbot,"  Architecture: ", GAPInfo.Architecture, "\n",
+         "\n" );
   if IsHPCGAP then
     Print( "             Maximum concurrent threads: ",
        GAPInfo.KernelInfo.NUM_CPUS, "\n");

--- a/lib/init.g
+++ b/lib/init.g
@@ -447,9 +447,9 @@ BindGlobal( "ShowKernelInformation", function()
   fi;
 
   if GAPInfo.TermEncoding = "UTF-8" then
-    btop := "   ● G";
-    bmid := "● ●  A";
-    bbot := "   ● P";
+    btop := "   \033[94m● \033[1;31mG\033[0m";
+    bmid := "\033[92m● \033[91m●  \033[1;31mA\033[0m";
+    bbot := "   \033[93m● \033[1;31mP\033[0m";
   else
     btop := "   o G";
     bmid := "o o  A";

--- a/lib/init.g
+++ b/lib/init.g
@@ -447,9 +447,9 @@ BindGlobal( "ShowKernelInformation", function()
   fi;
 
   if GAPInfo.TermEncoding = "UTF-8" then
-    btop := "   \033[94m● \033[1;31mG\033[0m";
-    bmid := "\033[92m● \033[91m●  \033[1;31mA\033[0m";
-    bbot := "   \033[93m● \033[1;31mP\033[0m";
+    btop := "   \033[32m● \033[0mG";
+    bmid := "\033[94m● \033[91m●  \033[0mA";
+    bbot := "   \033[93m● \033[0mP";
   else
     btop := "   o G";
     bmid := "o o  A";


### PR DESCRIPTION
This PR modifies the GAP banner on startup to show a rendering of the new logo. If the terminal encoding is UTF-8 it does this with nice Unicode dot characters, but falls back to letter `o` symbols otherwise.

As mentioned in Issue #6128, there is a possible concern with text wrapping. In an 80-character terminal some lines will be unnecessarily wrapped early due to the colour escape codes. I tried looking into the line-wrapping logic, but it was beyond me!