### PR TITLE
Rename `IsPlistMatrixRep` to `IsRowPlistMatrixRep`

### DIFF
--- a/benchmark/matobj/bench-matobj-creation.g
+++ b/benchmark/matobj/bench-matobj-creation.g
@@ -100,9 +100,9 @@ RunMatObjTest := function(desc, filter, ring)
     TestCreatingMatrixObj(filter, ring);
 end;
 
-RunMatObjTest("GF(2) IsPlistMatrixRep", IsPlistMatrixRep, GF(2));
-RunMatObjTest("integer IsPlistMatrixRep", IsPlistMatrixRep, Integers);
-RunMatObjTest("rational IsPlistMatrixRep", IsPlistMatrixRep, Rationals);
+RunMatObjTest("GF(2) IsRowPlistMatrixRep", IsRowPlistMatrixRep, GF(2));
+RunMatObjTest("integer IsRowPlistMatrixRep", IsRowPlistMatrixRep, Integers);
+RunMatObjTest("rational IsRowPlistMatrixRep", IsRowPlistMatrixRep, Rationals);
 
 # TODO: other reps
 # TODO: other compare with creating plist-of-plist

--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -177,7 +177,7 @@ section.
 
 One implementation of such matrices is given by the
 <Ref Attr="ConstructingFilter" Label="for a matrix object"/> value
-<Ref Filt="IsPlistMatrixRep"/>,
+<Ref Filt="IsRowPlistMatrixRep"/>,
 and any row of these matrices is a vector object in
 <Ref Filt="IsPlistVectorRep"/>.
 Note that these objects do <E>not</E> lie in <Ref Filt="IsList"/>
@@ -370,7 +370,7 @@ described in this chapter is supported.
 
 <#Include Label="IsGF2MatrixRep">
 <#Include Label="Is8BitMatrixRep">
-<#Include Label="IsPlistMatrixRep">
+<#Include Label="IsRowPlistMatrixRep">
 <#Include Label="IsZmodnZMatrixRep">
 
 </Section>

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -173,7 +173,7 @@ function( basedomain )
 ##      elif IsFinite(basedomain) and IsZmodnZObj(Zero(basedomain)) then
 ##        return IsZmodnZMatrixRep;
     fi;
-    return IsPlistMatrixRep;
+    return IsRowPlistMatrixRep;
 end);
 
 

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -115,7 +115,7 @@ DeclareCategory( "IsVectorObj", IsVector and IsVecOrMatObj and IsRowVectorOrVect
 ##  true
 ##  false
 ##  true
-##  gap> m:= NewIdentityMatrix( IsPlistMatrixRep, GF(2), 2 );;
+##  gap> m:= NewIdentityMatrix( IsRowPlistMatrixRep, GF(2), 2 );;
 ##  gap> IsMatrix( m );  IsMatrixObj( m ); IsMatrixOrMatrixObj( m );
 ##  false
 ##  true

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -1220,7 +1220,7 @@ DeclareOperation( "IdentityMatrix", [ IsOperation, IsSemiring, IsInt ] );
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> x:= X( GF(5) );;  pol:= x^3 + x^2 + 2*x + 3;;
-##  gap> M:= CompanionMatrix( IsPlistMatrixRep, pol, GF(25) );;
+##  gap> M:= CompanionMatrix( IsRowPlistMatrixRep, pol, GF(25) );;
 ##  gap> Display( M );
 ##  <3x3-matrix over GF(5^2):
 ##  [[ 0*Z(5), 0*Z(5), Z(5) ]

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -62,16 +62,16 @@ DeclareRepresentation( "IsPlistVectorRep",
 
 #############################################################################
 ##
-##  <#GAPDoc Label="IsPlistMatrixRep">
+##  <#GAPDoc Label="IsRowPlistMatrixRep">
 ##  <ManSection>
-##  <Filt Name="IsPlistMatrixRep" Arg='obj' Type="Representation"/>
+##  <Filt Name="IsRowPlistMatrixRep" Arg='obj' Type="Representation"/>
 ##
 ##  <Description>
-##  An object <A>obj</A> in <Ref Filt="IsPlistMatrixRep"/> describes
+##  An object <A>obj</A> in <Ref Filt="IsRowPlistMatrixRep"/> describes
 ##  a matrix object (see <Ref Filt="IsMatrixObj"/>) that behaves similar to
 ##  a list of its rows, in the sense of <Ref Filt="IsRowListMatrix"/>.
 ##  <P/>
-##  <Ref Filt="IsPlistMatrixRep"/> implies <Ref Filt="IsCopyable"/>,
+##  <Ref Filt="IsRowPlistMatrixRep"/> implies <Ref Filt="IsCopyable"/>,
 ##  thus matrix objects in this representation can be mutable.
 ##  </Description>
 ##  </ManSection>
@@ -97,13 +97,13 @@ DeclareRepresentation( "IsPlistVectorRep",
 ##  </Item>
 ##  </Enum>
 ##  <P/>
-##  Any <A>obj</A> in <Ref Filt="IsPlistMatrixRep"/> satisfies that
+##  Any <A>obj</A> in <Ref Filt="IsRowPlistMatrixRep"/> satisfies that
 ##  each entry in the stored plain list is a vector in
 ##  <Ref Filt="IsPlistVectorRep"/>, whose base domain is identical with the
 ##  stored base domain of <A>obj</A> and whose length is the stored number
 ##  of columns.
 ##
-DeclareRepresentation( "IsPlistMatrixRep",
+DeclareRepresentation( "IsRowPlistMatrixRep",
         IsRowListMatrix and IsPositionalObjectRep
     and IsCopyable
     and IsNoImmediateMethodsObject

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -97,10 +97,10 @@ BindGlobal( "MakeIsPlistVectorRep",
 
 ############################################################################
 ##
-#F  MakeIsPlistMatrixRep( <basedomain>, <emptyvector>, <ncols>, <list>,
+#F  MakeIsRowPlistMatrixRep( <basedomain>, <emptyvector>, <ncols>, <list>,
 #F                        <check> )
 ##
-##  Construct a new matrix in the filter 'IsPlistMatrixRep' with base domain
+##  Construct a new matrix in the filter 'IsRowPlistMatrixRep' with base domain
 ##  <basedomain> and rows given by the list <list>, whose entries must be
 ##  'IsPlistVectorObj' vectors with base domain <basedomain> and length <ncols>.
 ##  <emptyvector> must be an 'IsPlistVectorObj' vector of length zero and with
@@ -118,7 +118,7 @@ BindGlobal( "MakeIsPlistVectorRep",
 ##  the entries lie in <basedomain>; this check is assumed to belong to the
 ##  creation of the vectors.)
 ##
-BindGlobal( "MakeIsPlistMatrixRep",
+BindGlobal( "MakeIsRowPlistMatrixRep",
   function( basedomain, emptyvector, ncols, list, check )
     local fam, types, typ, row;
     fam:= CollectionsFamily( FamilyObj( basedomain ) );
@@ -129,12 +129,12 @@ BindGlobal( "MakeIsPlistMatrixRep",
       # initialize type cache
       # TODO: make this thread safe for HPC-GAP
       fam!.PlistMatrixRepTypes:= [
-          NewType( fam, IsPlistMatrixRep ),
-          NewType( fam, IsPlistMatrixRep and IsMutable ),
+          NewType( fam, IsRowPlistMatrixRep ),
+          NewType( fam, IsRowPlistMatrixRep and IsMutable ),
       ];
       fam!.PlistMatrixRepTypesEasyCompare:= [
-          NewType( fam, IsPlistMatrixRep and CanEasilyCompareElements ),
-          NewType( fam, IsPlistMatrixRep and CanEasilyCompareElements and IsMutable ),
+          NewType( fam, IsRowPlistMatrixRep and CanEasilyCompareElements ),
+          NewType( fam, IsRowPlistMatrixRep and CanEasilyCompareElements and IsMutable ),
       ];
     fi;
     if HasCanEasilyCompareElements( Representative( basedomain ) ) and
@@ -189,7 +189,7 @@ InstallTagBasedMethod( NewZeroVector,
   end );
 
 InstallTagBasedMethod( NewMatrix,
-  IsPlistMatrixRep,
+  IsRowPlistMatrixRep,
   function( filter, basedomain, ncols, list )
     local nd, filterVectors, m, e, i;
 
@@ -216,12 +216,12 @@ InstallTagBasedMethod( NewMatrix,
         fi;
     od;
     e := NewVector(filterVectors, basedomain, []);
-    return MakeIsPlistMatrixRep( basedomain, e, ncols, m, true );
+    return MakeIsRowPlistMatrixRep( basedomain, e, ncols, m, true );
   end );
 
 # This is faster than the default method.
 InstallTagBasedMethod( NewZeroMatrix,
-  IsPlistMatrixRep,
+  IsRowPlistMatrixRep,
   function( filter, basedomain, rows, cols )
     local m,i,e,filter2;
     filter2 := IsPlistVectorRep;
@@ -230,7 +230,7 @@ InstallTagBasedMethod( NewZeroMatrix,
     for i in [1..rows] do
         m[i] := ZeroVector( cols, e );
     od;
-    return MakeIsPlistMatrixRep( basedomain, e, cols, m, false );
+    return MakeIsRowPlistMatrixRep( basedomain, e, cols, m, false );
   end );
 
 
@@ -279,7 +279,7 @@ InstallMethod( Display, [ "IsPlistVectorRep" ],
     Print(v![ELSPOS],"\n>\n");
   end );
 
-InstallMethod( CompatibleVectorFilter, ["IsPlistMatrixRep"],
+InstallMethod( CompatibleVectorFilter, ["IsRowPlistMatrixRep"],
   M -> IsPlistVectorRep );
 
 ############################################################################
@@ -309,7 +309,7 @@ InstallMethod( ZeroVector,
   { len, v } -> NewZeroVector( IsPlistVectorRep, v![BDPOS], len ) );
 
 InstallMethod( ZeroVector,
-  [ "IsInt", "IsPlistMatrixRep" ],
+  [ "IsInt", "IsRowPlistMatrixRep" ],
   { len, M } -> NewZeroVector( IsPlistVectorRep, M![BDPOS], len ) );
 
 InstallMethod( Vector,
@@ -624,19 +624,19 @@ InstallMethod( CopySubVector,
 ############################################################################
 
 InstallMethod( BaseDomain,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> M![BDPOS] );
 
 InstallMethod( NumberRows,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> Length( M![ROWSPOS] ) );
 
 InstallMethod( NumberColumns,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> M![RLPOS] );
 
 InstallMethod( DimensionsMat,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> [ Length( M![ROWSPOS]), M![RLPOS] ] );
 
 
@@ -645,16 +645,16 @@ InstallMethod( DimensionsMat,
 ############################################################################
 
 InstallMethod( ZeroMatrix,
-  [ "IsInt", "IsInt", "IsPlistMatrixRep" ],
+  [ "IsInt", "IsInt", "IsRowPlistMatrixRep" ],
   function( nrows, ncols, M )
     local t, list;
     t := M![EMPOS];
     list := List([1..nrows],i->ZeroVector(ncols,t));
-    return MakeIsPlistMatrixRep( M![BDPOS], t, ncols, list, false );
+    return MakeIsRowPlistMatrixRep( M![BDPOS], t, ncols, list, false );
   end );
 
 InstallMethod( IdentityMatrix,
-  [ "IsInt", "IsPlistMatrixRep" ],
+  [ "IsInt", "IsRowPlistMatrixRep" ],
   function( nrows, M )
     local t, list, o, i;
     t := M![EMPOS];
@@ -663,11 +663,11 @@ InstallMethod( IdentityMatrix,
     for i in [1..nrows] do
         list[i][i] := o;
     od;
-    return MakeIsPlistMatrixRep( M![BDPOS], t, nrows, list, false );
+    return MakeIsRowPlistMatrixRep( M![BDPOS], t, nrows, list, false );
   end );
 
 InstallMethod( Matrix,
-  [ "IsList", "IsInt", "IsPlistMatrixRep" ],
+  [ "IsList", "IsInt", "IsRowPlistMatrixRep" ],
   function( list, ncols, M )
     local basedomain, check, i,l,nrrows,t;
     t := M![EMPOS];
@@ -707,7 +707,7 @@ InstallMethod( Matrix,
     if not IsMutable( list ) then
       MakeImmutable( l );
     fi;
-    return MakeIsPlistMatrixRep( basedomain, t, ncols, l, false );
+    return MakeIsRowPlistMatrixRep( basedomain, t, ncols, l, false );
   end );
 
 
@@ -718,11 +718,11 @@ InstallMethod( Matrix,
 InstallOtherMethod( \[\],
 #T Once the declaration of '\[\]' for 'IsMatrixObj' disappears,
 #T we can use 'InstallMethod'.
-  [ "IsPlistMatrixRep", "IsPosInt" ],
+  [ "IsRowPlistMatrixRep", "IsPosInt" ],
   { M, p } -> M![ROWSPOS][p] );
 
 InstallMethod( \[\]\:\=,
-  [ "IsPlistMatrixRep and IsMutable", "IsPosInt", "IsPlistVectorRep" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsPosInt", "IsPlistVectorRep" ],
   function( M, p, v )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( M![BDPOS], v![BDPOS] ) or
@@ -733,12 +733,12 @@ InstallMethod( \[\]\:\=,
   end );
 
 InstallMethod( \{\},
-  [ "IsPlistMatrixRep", "IsList" ],
-  { M, list } -> MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+  [ "IsRowPlistMatrixRep", "IsList" ],
+  { M, list } -> MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
                      M![ROWSPOS]{ list }, false ) );
 
 InstallMethod( Add,
-  [ "IsPlistMatrixRep and IsMutable", "IsPlistVectorRep" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsPlistVectorRep" ],
   function( M, v )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( M![BDPOS], v![BDPOS] ) or
@@ -749,7 +749,7 @@ InstallMethod( Add,
   end );
 
 InstallMethod( Add,
-  [ "IsPlistMatrixRep and IsMutable", "IsPlistVectorRep", "IsPosInt" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsPlistVectorRep", "IsPosInt" ],
   function( M, v, p )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( M![BDPOS], v![BDPOS] ) or
@@ -760,11 +760,11 @@ InstallMethod( Add,
   end );
 
 InstallMethod( Remove,
-  [ "IsPlistMatrixRep and IsMutable" ],
+  [ "IsRowPlistMatrixRep and IsMutable" ],
   M -> Remove( M![ROWSPOS] ) );
 
 InstallMethod( Remove,
-  [ "IsPlistMatrixRep and IsMutable", "IsPosInt" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsPosInt" ],
   function( M, p )
     if p <= Length( M![ROWSPOS] ) then
       return Remove( M![ROWSPOS], p );
@@ -772,11 +772,11 @@ InstallMethod( Remove,
   end );
 
 InstallMethod( IsBound\[\],
-  [ "IsPlistMatrixRep", "IsPosInt" ],
+  [ "IsRowPlistMatrixRep", "IsPosInt" ],
   { M, p } -> p <= Length( M![ROWSPOS] ) );
 
 InstallMethod( Unbind\[\],
-  [ "IsPlistMatrixRep and IsMutable", "IsPosInt" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsPosInt" ],
   function( M, p )
     if p <> Length( M![ROWSPOS] ) then
         ErrorNoReturn("Unbind\\[\\]: Matrices must stay dense, you cannot Unbind here");
@@ -785,8 +785,8 @@ InstallMethod( Unbind\[\],
   end );
 
 InstallMethod( \{\}\:\=,
-  [ "IsPlistMatrixRep and IsMutable", "IsList",
-    "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsList",
+    "IsRowPlistMatrixRep" ],
   function( M, pp, N )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( M![BDPOS], N![BDPOS] ) or
@@ -797,7 +797,7 @@ InstallMethod( \{\}\:\=,
   end );
 
 InstallMethod( Append,
-  [ "IsPlistMatrixRep and IsMutable", "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsRowPlistMatrixRep" ],
   function( M, N )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( M![BDPOS], N![BDPOS] ) or
@@ -808,35 +808,35 @@ InstallMethod( Append,
   end );
 
 InstallMethod( ShallowCopy,
-  [ "IsPlistMatrixRep" ],
-  M -> MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+  [ "IsRowPlistMatrixRep" ],
+  M -> MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
            ShallowCopy( M![ROWSPOS] ), false ) );
 
 InstallMethod( PostMakeImmutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     MakeImmutable( M![ROWSPOS] );
   end );
 
 InstallMethod( ListOp,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> List( M![ROWSPOS] ) );
 
 InstallMethod( ListOp,
-  [ "IsPlistMatrixRep", "IsFunction" ],
+  [ "IsRowPlistMatrixRep", "IsFunction" ],
   { M, f } -> List( M![ROWSPOS], f ) );
 
 InstallMethod( Unpack,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> List( M![ROWSPOS], v -> ShallowCopy( v![ELSPOS] ) ) );
 
 InstallMethod( MutableCopyMatrix,
-  [ "IsPlistMatrixRep" ],
-  M -> MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+  [ "IsRowPlistMatrixRep" ],
+  M -> MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
            List( M![ROWSPOS], ShallowCopy ), false ) );
 
 InstallMethod( ExtractSubMatrix,
-  [ "IsPlistMatrixRep", "IsList", "IsList" ],
+  [ "IsRowPlistMatrixRep", "IsList", "IsList" ],
   function( M, rowspos, colspos )
     local i, list;
     list := M![ROWSPOS]{ rowspos };
@@ -844,12 +844,12 @@ InstallMethod( ExtractSubMatrix,
       list[i]:= MakeIsPlistVectorRep( list[i]![BDPOS],
                     list[i]![ELSPOS]{ colspos }, false );
     od;
-    return MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], Length( colspos ),
+    return MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], Length( colspos ),
                list, false );
   end );
 
 InstallMethod( CopySubMatrix,
-  [ "IsPlistMatrixRep", "IsPlistMatrixRep and IsMutable",
+  [ "IsRowPlistMatrixRep", "IsRowPlistMatrixRep and IsMutable",
     "IsList", "IsList", "IsList", "IsList" ],
   function( M, N, srcrows, dstrows, srccols, dstcols )
     local i;
@@ -881,11 +881,11 @@ InstallOtherMethod( CopySubMatrix,
 #T move to another file?
 
 InstallMethod( MatElm,
-  [ "IsPlistMatrixRep", "IsPosInt", "IsPosInt" ],
+  [ "IsRowPlistMatrixRep", "IsPosInt", "IsPosInt" ],
   { M, row, col } -> M![ROWSPOS][row]![ELSPOS][col] );
 
 InstallMethod( SetMatElm,
-  [ "IsPlistMatrixRep and IsMutable", "IsPosInt", "IsPosInt", "IsObject" ],
+  [ "IsRowPlistMatrixRep and IsMutable", "IsPosInt", "IsPosInt", "IsObject" ],
   function( M, row, col, ob )
     if ValueOption( "check" ) <> false then
       if not ob in BaseDomain( M ) then
@@ -902,16 +902,16 @@ InstallMethod( SetMatElm,
 # Printing and viewing methods:
 ############################################################################
 
-InstallMethod( ViewObj, [ "IsPlistMatrixRep" ],
+InstallMethod( ViewObj, [ "IsRowPlistMatrixRep" ],
   function( M )
     Print("<");
     if not IsMutable(M) then Print("immutable "); fi;
     Print(Length(M![ROWSPOS]),"x",M![RLPOS],"-matrix over ",M![BDPOS],">");
   end );
 
-InstallMethod( PrintObj, [ "IsPlistMatrixRep" ],
+InstallMethod( PrintObj, [ "IsRowPlistMatrixRep" ],
   function( M )
-    Print("NewMatrix(IsPlistMatrixRep");
+    Print("NewMatrix(IsRowPlistMatrixRep");
     if IsFinite(M![BDPOS]) and IsField(M![BDPOS]) then
         Print(",GF(",Size(M![BDPOS]),"),");
     else
@@ -920,7 +920,7 @@ InstallMethod( PrintObj, [ "IsPlistMatrixRep" ],
     Print(NumberColumns(M),",",Unpack(M),")");
   end );
 
-InstallMethod( Display, [ "IsPlistMatrixRep" ],
+InstallMethod( Display, [ "IsRowPlistMatrixRep" ],
   function( M )
     local i;
     Print("<");
@@ -937,10 +937,10 @@ InstallMethod( Display, [ "IsPlistMatrixRep" ],
     Print("]>\n");
   end );
 
-InstallMethod( String, [ "IsPlistMatrixRep" ],
+InstallMethod( String, [ "IsRowPlistMatrixRep" ],
   function( M )
     local st;
-    st := "NewMatrix(IsPlistMatrixRep";
+    st := "NewMatrix(IsRowPlistMatrixRep";
     Add(st,',');
     if IsFinite(M![BDPOS]) and IsField(M![BDPOS]) then
         Append(st,"GF(");
@@ -962,31 +962,31 @@ InstallMethod( String, [ "IsPlistMatrixRep" ],
 ############################################################################
 
 InstallMethod( \+,
-  [ "IsPlistMatrixRep", "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep", "IsRowPlistMatrixRep" ],
   function( a, b )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( a![BDPOS], b![BDPOS] ) or
          a![RLPOS] <> b![RLPOS] ) then
       Error( "<a> and <b> are not compatible" );
     fi;
-    return MakeIsPlistMatrixRep( a![BDPOS], a![EMPOS], a![RLPOS],
+    return MakeIsRowPlistMatrixRep( a![BDPOS], a![EMPOS], a![RLPOS],
                SUM_LIST_LIST_DEFAULT( a![ROWSPOS], b![ROWSPOS] ), false );
   end );
 
 InstallMethod( \-,
-  [ "IsPlistMatrixRep", "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep", "IsRowPlistMatrixRep" ],
   function( a, b )
     if ValueOption( "check" ) <> false and
        ( not IsIdenticalObj( a![BDPOS], b![BDPOS] ) or
          a![RLPOS] <> b![RLPOS] ) then
       Error( "<a> and <b> are not compatible" );
     fi;
-    return MakeIsPlistMatrixRep( a![BDPOS], a![EMPOS], a![RLPOS],
+    return MakeIsRowPlistMatrixRep( a![BDPOS], a![EMPOS], a![RLPOS],
                DIFF_LIST_LIST_DEFAULT( a![ROWSPOS], b![ROWSPOS] ), false );
   end );
 
 InstallMethod( \*,
-  [ "IsPlistMatrixRep", "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep", "IsRowPlistMatrixRep" ],
   function( a, b )
     local i,j,l,v,w;
     if ValueOption( "check" ) <> false then
@@ -1012,15 +1012,15 @@ InstallMethod( \*,
     if not IsMutable(a) and not IsMutable(b) then
         MakeImmutable(l);
     fi;
-    return MakeIsPlistMatrixRep( a![BDPOS], a![EMPOS], b![RLPOS], l, false );
+    return MakeIsRowPlistMatrixRep( a![BDPOS], a![EMPOS], b![RLPOS], l, false );
   end );
 
 InstallMethod( \=,
-  [ "IsPlistMatrixRep", "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep", "IsRowPlistMatrixRep" ],
   { a, b } -> EQ_LIST_LIST_DEFAULT( a![ROWSPOS], b![ROWSPOS] ) );
 
 InstallMethod( \<,
-  [ "IsPlistMatrixRep", "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep", "IsRowPlistMatrixRep" ],
   { a, b } -> LT_LIST_LIST_DEFAULT( a![ROWSPOS], b![ROWSPOS] ) );
 
 # According to "Mutability Status and List Arithmetic":
@@ -1028,7 +1028,7 @@ InstallMethod( \<,
 # all its rows are mutable if the first row of 'M' is mutable,
 # and all its rows are immutable otherwise.
 InstallMethod( AdditiveInverseSameMutability,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local l;
 
@@ -1039,23 +1039,23 @@ InstallMethod( AdditiveInverseSameMutability,
     else
       l:= List( M![ROWSPOS], AdditiveInverseImmutable );
     fi;
-    return MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS], l, false );
+    return MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS], l, false );
   end );
 
 InstallMethod( AdditiveInverseImmutable,
-  [ "IsPlistMatrixRep" ],
-  M -> MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+  [ "IsRowPlistMatrixRep" ],
+  M -> MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
            MakeImmutable( List( M![ROWSPOS], AdditiveInverseImmutable ) ),
            false ) );
 
 # all rows mutable
 InstallMethod( AdditiveInverseMutable,
-  [ "IsPlistMatrixRep" ],
-  M -> MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+  [ "IsRowPlistMatrixRep" ],
+  M -> MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
            List( M![ROWSPOS], AdditiveInverseMutable ), false ) );
 
 InstallMethod( ZeroSameMutability,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local l;
 
@@ -1066,25 +1066,25 @@ InstallMethod( ZeroSameMutability,
     else
       l:= List( M![ROWSPOS], ZeroImmutable );
     fi;
-    return MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS], l, false );
+    return MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS], l, false );
   end );
 
 InstallMethod( ZeroImmutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
-    M:= MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+    M:= MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
             MakeImmutable( List( M![ROWSPOS], ZeroImmutable ) ), false );
     SetIsZero( M, true );
     return M;
   end );
 
 InstallMethod( ZeroMutable,
-  [ "IsPlistMatrixRep" ],
-  M -> MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
+  [ "IsRowPlistMatrixRep" ],
+  M -> MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], M![RLPOS],
            List( M![ROWSPOS], ZeroMutable ), false ) );
 
 InstallMethod( IsZero,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local i;
     for i in [1..Length(M![ROWSPOS])] do
@@ -1096,7 +1096,7 @@ InstallMethod( IsZero,
   end );
 
 InstallMethod( IsOne,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local n, i, row;
     if Length(M![ROWSPOS]) <> M![RLPOS] then
@@ -1116,7 +1116,7 @@ InstallMethod( IsOne,
   end );
 
 InstallMethod( OneSameMutability,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local o, i;
     if M![RLPOS] <> Length(M![ROWSPOS]) then
@@ -1142,7 +1142,7 @@ InstallMethod( OneSameMutability,
   end );
 
 InstallMethod( OneMutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     if M![RLPOS] <> Length(M![ROWSPOS]) then
         #Error("OneMutable: Matrix is not square");
@@ -1153,7 +1153,7 @@ InstallMethod( OneMutable,
   end );
 
 InstallMethod( OneImmutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     if M![RLPOS] <> Length(M![ROWSPOS]) then
         #Error("OneImmutable: Matrix is not square");
@@ -1169,7 +1169,7 @@ InstallMethod( OneImmutable,
 # lists of plain lists:
 
 InstallMethod( InverseMutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local n;
     if M![RLPOS] <> Length(M![ROWSPOS]) then
@@ -1185,7 +1185,7 @@ InstallMethod( InverseMutable,
   end );
 
 InstallMethod( InverseImmutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local n;
     if M![RLPOS] <> Length(M![ROWSPOS]) then
@@ -1201,7 +1201,7 @@ InstallMethod( InverseImmutable,
   end );
 
 InstallMethod( InverseSameMutability,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local n;
     if M![RLPOS] <> Length(M![ROWSPOS]) then
@@ -1221,12 +1221,12 @@ InstallMethod( InverseSameMutability,
   end );
 
 InstallMethod( RankMat,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> RankMat( List( M![ROWSPOS], x -> x![ELSPOS] ) ) );
 
 InstallMethodWithRandomSource( Randomize,
   "for a random source and a mutable plist matrix",
-  [ IsRandomSource, IsPlistMatrixRep and IsMutable ],
+  [ IsRandomSource, IsRowPlistMatrixRep and IsMutable ],
   function( rs, M )
     local v;
     for v in M![ROWSPOS] do
@@ -1236,18 +1236,18 @@ InstallMethodWithRandomSource( Randomize,
   end );
 
 InstallMethod( TransposedMatMutable,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   function( M )
     local i,n;
     n := ListWithIdenticalEntries(M![RLPOS],0);
     for i in [1..M![RLPOS]] do
         n[i]:= Vector(List(M![ROWSPOS],v->v![ELSPOS][i]),M![EMPOS]);
     od;
-    return MakeIsPlistMatrixRep( M![BDPOS], M![EMPOS], Length(M![ROWSPOS]), n, false );
+    return MakeIsRowPlistMatrixRep( M![BDPOS], M![EMPOS], Length(M![ROWSPOS]), n, false );
   end );
 
 InstallMethod( \*,
-  [ "IsPlistVectorRep", "IsPlistMatrixRep" ],
+  [ "IsPlistVectorRep", "IsRowPlistMatrixRep" ],
   function( v, M )
     local i,res,s;
     if ValueOption( "check" ) <> false and
@@ -1269,7 +1269,7 @@ InstallMethod( \*,
   end );
 
 #InstallMethod( \^,
-#  [ "IsPlistMatrixRep", "IsInt" ],
+#  [ "IsRowPlistMatrixRep", "IsInt" ],
 #  function( M, i )
 #    local mi;
 #    if M![RLPOS] <> Length(M![ROWSPOS]) then
@@ -1291,8 +1291,8 @@ InstallMethod( ConstructingFilter,
   v -> IsPlistVectorRep );
 
 InstallMethod( ConstructingFilter,
-  [ "IsPlistMatrixRep" ],
-  M -> IsPlistMatrixRep );
+  [ "IsRowPlistMatrixRep" ],
+  M -> IsRowPlistMatrixRep );
 
 InstallMethod( ChangedBaseDomain,
   [ "IsPlistVectorRep", "IsRing" ],
@@ -1305,9 +1305,9 @@ InstallMethod( ChangedBaseDomain,
   end );
 
 InstallMethod( ChangedBaseDomain,
-  [ "IsPlistMatrixRep", "IsRing" ],
+  [ "IsRowPlistMatrixRep", "IsRing" ],
   function( M, r )
-    r:= NewMatrix( IsPlistMatrixRep, r, M![RLPOS],
+    r:= NewMatrix( IsRowPlistMatrixRep, r, M![RLPOS],
                    List( M![ROWSPOS], x-> x![ELSPOS] ) );
     if not IsMutable( M ) then
       MakeImmutable( r );
@@ -1317,6 +1317,6 @@ InstallMethod( ChangedBaseDomain,
 
 # We know that 'CompatibleVectorFilter( M )' is 'IsPlistVectorRep'.
 InstallMethod( CompatibleVector,
-  [ "IsPlistMatrixRep" ],
+  [ "IsRowPlistMatrixRep" ],
   M -> NewZeroVector( IsPlistVectorRep, BaseDomain( M ), NumberRows( M ) ) );
 

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1679,9 +1679,9 @@ DeclareGlobalFunction( "PermutationMat" );
 ##  [ [ Z(3)^0, 0*Z(3) ], [ 0*Z(3), Z(3) ] ]
 ##  gap> Is8BitMatrixRep( d1 );
 ##  true
-##  gap> d2:= DiagonalMatrix( IsPlistMatrixRep, GF(9), [ 1, 2 ] * Z(3)^0 );
+##  gap> d2:= DiagonalMatrix( IsRowPlistMatrixRep, GF(9), [ 1, 2 ] * Z(3)^0 );
 ##  <2x2-matrix over GF(3^2)>
-##  gap> IsPlistMatrixRep( d2 );
+##  gap> IsRowPlistMatrixRep( d2 );
 ##  true
 ##  gap> DiagonalMatrix( [ 1, 2 ] );
 ##  <2x2-matrix over Rationals>

--- a/tst/testinstall/MatrixObj/CompanionMatrix.tst
+++ b/tst/testinstall/MatrixObj/CompanionMatrix.tst
@@ -45,26 +45,26 @@ gap> TestCompanionMatrix(Is8BitMatrixRep, One(x), F);
 Error, NewCompanionMatrix: degree of <pol> must be at least 1
 
 #
-# IsPlistMatrixRep
+# IsRowPlistMatrixRep
 #
 gap> F:= GF(251);;  x:= X(F);;
-gap> TestCompanionMatrix(IsPlistMatrixRep, x+1, F);
+gap> TestCompanionMatrix(IsRowPlistMatrixRep, x+1, F);
 <1x1-matrix over GF(251)>
-gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
+gap> TestCompanionMatrix(IsRowPlistMatrixRep, x^2+x+1, F);
 <2x2-matrix over GF(251)>
 
 #
 gap> F:= Integers;;  x:= X(F);;
-gap> TestCompanionMatrix(IsPlistMatrixRep, x+1, F);
+gap> TestCompanionMatrix(IsRowPlistMatrixRep, x+1, F);
 <1x1-matrix over Integers>
-gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
+gap> TestCompanionMatrix(IsRowPlistMatrixRep, x^2+x+1, F);
 <2x2-matrix over Integers>
 
 #
 gap> F:= Rationals;;  x:= X(F);;
-gap> TestCompanionMatrix(IsPlistMatrixRep, x+1, F);
+gap> TestCompanionMatrix(IsRowPlistMatrixRep, x+1, F);
 <1x1-matrix over Rationals>
-gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
+gap> TestCompanionMatrix(IsRowPlistMatrixRep, x^2+x+1, F);
 <2x2-matrix over Rationals>
 
 #

--- a/tst/testinstall/MatrixObj/DiagonalMatrix.tst
+++ b/tst/testinstall/MatrixObj/DiagonalMatrix.tst
@@ -6,21 +6,21 @@ gap> Is8BitMatrixRep( DiagonalMatrix( GF(9), [ 1, 2 ] * Z(3)^0 ) );
 true
 gap> DiagonalMatrix( GF(9), [] );
 Error, Is8BitMatrixRep with zero rows not yet supported
-gap> IsPlistMatrixRep( DiagonalMatrix( Integers, [ 1, 2 ] ) );
+gap> IsRowPlistMatrixRep( DiagonalMatrix( Integers, [ 1, 2 ] ) );
 true
-gap> IsPlistMatrixRep( DiagonalMatrix( Integers, [] ) );
+gap> IsRowPlistMatrixRep( DiagonalMatrix( Integers, [] ) );
 true
 
 # with constructing filter, base domain, and vector of diagonal entries
 gap> Is8BitMatrixRep( DiagonalMatrix( Is8BitMatrixRep, GF(9), [ 1, 2 ] * Z(3)^0 ) );
 true
-gap> IsPlistMatrixRep( DiagonalMatrix( IsPlistMatrixRep, GF(9), [] ) );
+gap> IsRowPlistMatrixRep( DiagonalMatrix( IsRowPlistMatrixRep, GF(9), [] ) );
 true
 gap> IsPlistRep( DiagonalMatrix( IsPlistRep, Integers, [ 1, 2 ] ) );
 true
 
 # with vector of diagonal entries and example matrix
-gap> M:= Matrix( IsPlistMatrixRep, Integers, [ 1 ], 1 );;
+gap> M:= Matrix( IsRowPlistMatrixRep, Integers, [ 1 ], 1 );;
 gap> DiagonalMatrix( [ 1, 2 ], M );
 <2x2-matrix over Integers>
 gap> DiagonalMatrix( [], M );
@@ -30,7 +30,7 @@ gap> DiagonalMatrix( [ 1, 2 ], M );
 [ [ 1, 0 ], [ 0, 2 ] ]
 gap> DiagonalMatrix( [], M );
 [  ]
-gap> M:= Matrix( IsPlistMatrixRep, GF(3), [ Z(3) ], 1 );;
+gap> M:= Matrix( IsRowPlistMatrixRep, GF(3), [ Z(3) ], 1 );;
 gap> DiagonalMatrix( [ 1, 2 ] * Z(3), M );
 <2x2-matrix over GF(3)>
 gap> DiagonalMatrix( [ 1, 2 ], M );
@@ -39,7 +39,7 @@ Error, <ob> must lie in the base domain of <M>
 # with vector of diagonal entries only (choose a default representation)
 gap> Is8BitMatrixRep( DiagonalMatrix( [ 1, 2 ] * Z(3) ) );
 true
-gap> IsPlistMatrixRep( DiagonalMatrix( [ 1, 2 ] ) );
+gap> IsRowPlistMatrixRep( DiagonalMatrix( [ 1, 2 ] ) );
 true
 gap> DiagonalMatrix( [] );
 Error, do not know over which ring the matrix shall be defined

--- a/tst/testinstall/MatrixObj/DirectSumMat.tst
+++ b/tst/testinstall/MatrixObj/DirectSumMat.tst
@@ -28,7 +28,7 @@ gap> DirectSumMat( N, N );
   [ 0, 0, x_3, x_4 ] ]
 
 # matrix objects
-gap> M:= Matrix( IsPlistMatrixRep, Rationals, [ 1, 2, 3, 4 ], 2 );
+gap> M:= Matrix( IsRowPlistMatrixRep, Rationals, [ 1, 2, 3, 4 ], 2 );
 <2x2-matrix over Rationals>
 gap> DirectSumMat( M ) = M;
 true

--- a/tst/testinstall/MatrixObj/Eigenvalues.tst
+++ b/tst/testinstall/MatrixObj/Eigenvalues.tst
@@ -2,7 +2,7 @@ gap> mat := [[1,2,1],[1,0,1],[0,0,1]];
 [ [ 1, 2, 1 ], [ 1, 0, 1 ], [ 0, 0, 1 ] ]
 gap> Eigenvalues(Rationals,mat);
 [ 2, 1, -1 ]
-gap> matObj1 := NewMatrix(IsPlistMatrixRep,GF(5),3,mat*Z(5)^0);
+gap> matObj1 := NewMatrix(IsRowPlistMatrixRep,GF(5),3,mat*Z(5)^0);
 <3x3-matrix over GF(5)>
 gap> Eigenvalues(GF(5),matObj1);
 [ Z(5)^2, Z(5)^0, Z(5) ]

--- a/tst/testinstall/MatrixObj/IdentityMatrix.tst
+++ b/tst/testinstall/MatrixObj/IdentityMatrix.tst
@@ -40,37 +40,37 @@ gap> TestIdentityMatrix(Is8BitMatrixRep, GF(257), 2);
 Error, Is8BitMatrixRep only supports base fields with 3 to 256 elements
 
 #
-# IsPlistMatrixRep
+# IsRowPlistMatrixRep
 #
-gap> TestIdentityMatrix(IsPlistMatrixRep, GF(2), 2);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, GF(2), 2);
 <2x2-matrix over GF(2)>
-gap> TestIdentityMatrix(IsPlistMatrixRep, GF(2), 0);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, GF(2), 0);
 <0x0-matrix over GF(2)>
-gap> TestIdentityMatrix(IsPlistMatrixRep, GF(2), -1);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, GF(2), -1);
 Error, IdentityMatrix: the dimension must be non-negative
 
 #
-gap> TestIdentityMatrix(IsPlistMatrixRep, Integers, 2);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Integers, 2);
 <2x2-matrix over Integers>
-gap> TestIdentityMatrix(IsPlistMatrixRep, Integers, 0);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Integers, 0);
 <0x0-matrix over Integers>
-gap> TestIdentityMatrix(IsPlistMatrixRep, Integers, -1);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Integers, -1);
 Error, IdentityMatrix: the dimension must be non-negative
 
 #
-gap> TestIdentityMatrix(IsPlistMatrixRep, Rationals, 2);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Rationals, 2);
 <2x2-matrix over Rationals>
-gap> TestIdentityMatrix(IsPlistMatrixRep, Rationals, 0);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Rationals, 0);
 <0x0-matrix over Rationals>
-gap> TestIdentityMatrix(IsPlistMatrixRep, Rationals, -1);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Rationals, -1);
 Error, IdentityMatrix: the dimension must be non-negative
 
 #
-gap> TestIdentityMatrix(IsPlistMatrixRep, Integers mod 4, 2);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Integers mod 4, 2);
 <2x2-matrix over (Integers mod 4)>
-gap> TestIdentityMatrix(IsPlistMatrixRep, Integers mod 4, 0);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Integers mod 4, 0);
 <0x0-matrix over (Integers mod 4)>
-gap> TestIdentityMatrix(IsPlistMatrixRep, Integers mod 4, -1);
+gap> TestIdentityMatrix(IsRowPlistMatrixRep, Integers mod 4, -1);
 Error, IdentityMatrix: the dimension must be non-negative
 
 #

--- a/tst/testinstall/MatrixObj/Matrix.tst
+++ b/tst/testinstall/MatrixObj/Matrix.tst
@@ -31,7 +31,7 @@ gap> Display(m);
  1 .
 
 #
-gap> m := Matrix( IsPlistMatrixRep, GF(2), [[1,2],[3,4]] * Z(2) );
+gap> m := Matrix( IsRowPlistMatrixRep, GF(2), [[1,2],[3,4]] * Z(2) );
 <2x2-matrix over GF(2)>
 gap> Display(m);
 <2x2-matrix over GF(2):

--- a/tst/testinstall/MatrixObj/ZeroMatrix.tst
+++ b/tst/testinstall/MatrixObj/ZeroMatrix.tst
@@ -46,37 +46,37 @@ gap> TestZeroMatrix(Is8BitMatrixRep, GF(257), 2, 3);
 Error, Is8BitMatrixRep only supports base fields with 3 to 256 elements
 
 #
-# IsPlistMatrixRep
+# IsRowPlistMatrixRep
 #
-gap> TestZeroMatrix(IsPlistMatrixRep, GF(2), 2, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, GF(2), 2, 3);
 <2x3-matrix over GF(2)>
-gap> TestZeroMatrix(IsPlistMatrixRep, GF(2), 2, 0);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, GF(2), 2, 0);
 <2x0-matrix over GF(2)>
-gap> TestZeroMatrix(IsPlistMatrixRep, GF(2), 0, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, GF(2), 0, 3);
 <0x3-matrix over GF(2)>
 
 #
-gap> TestZeroMatrix(IsPlistMatrixRep, Integers, 2, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Integers, 2, 3);
 <2x3-matrix over Integers>
-gap> TestZeroMatrix(IsPlistMatrixRep, Integers, 2, 0);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Integers, 2, 0);
 <2x0-matrix over Integers>
-gap> TestZeroMatrix(IsPlistMatrixRep, Integers, 0, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Integers, 0, 3);
 <0x3-matrix over Integers>
 
 #
-gap> TestZeroMatrix(IsPlistMatrixRep, Rationals, 2, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Rationals, 2, 3);
 <2x3-matrix over Rationals>
-gap> TestZeroMatrix(IsPlistMatrixRep, Rationals, 2, 0);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Rationals, 2, 0);
 <2x0-matrix over Rationals>
-gap> TestZeroMatrix(IsPlistMatrixRep, Rationals, 0, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Rationals, 0, 3);
 <0x3-matrix over Rationals>
 
 #
-gap> TestZeroMatrix(IsPlistMatrixRep, Integers mod 4, 2, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Integers mod 4, 2, 3);
 <2x3-matrix over (Integers mod 4)>
-gap> TestZeroMatrix(IsPlistMatrixRep, Integers mod 4, 2, 0);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Integers mod 4, 2, 0);
 <2x0-matrix over (Integers mod 4)>
-gap> TestZeroMatrix(IsPlistMatrixRep, Integers mod 4, 0, 3);
+gap> TestZeroMatrix(IsRowPlistMatrixRep, Integers mod 4, 0, 3);
 <0x3-matrix over (Integers mod 4)>
 
 #

--- a/tst/testinstall/MatrixObj/matobjplist.tst
+++ b/tst/testinstall/MatrixObj/matobjplist.tst
@@ -15,17 +15,17 @@ Error, the elements in <list> must lie in <basedomain>
 gap> MakeIsPlistVectorRep( GF(4), [ Z(2) ], true );;
 
 #
-gap> MakeIsPlistMatrixRep( Integers, [], 2, [], true );;
+gap> MakeIsRowPlistMatrixRep( Integers, [], 2, [], true );;
 Error, <emptyvector> must be in 'IsPlistVectorRep'
-gap> M:= MakeIsPlistMatrixRep( Integers, e, 2, [], true );;
-gap> MakeIsPlistMatrixRep( Rationals, e, 2, [], true );;
+gap> M:= MakeIsRowPlistMatrixRep( Integers, e, 2, [], true );;
+gap> MakeIsRowPlistMatrixRep( Rationals, e, 2, [], true );;
 Error, <emptyvector> must have the given base domain
-gap> MakeIsPlistMatrixRep( Integers, e, 1, [ v ], true );;
-gap> MakeIsPlistMatrixRep( Integers, e, 2, [ v ], true );;
+gap> MakeIsRowPlistMatrixRep( Integers, e, 1, [ v ], true );;
+gap> MakeIsRowPlistMatrixRep( Integers, e, 2, [ v ], true );;
 Error, the entries of <list> must have length <ncols>
-gap> MakeIsPlistMatrixRep( Integers, e, 2, [ [ 1, 2 ] ], true );;
+gap> MakeIsRowPlistMatrixRep( Integers, e, 2, [ [ 1, 2 ] ], true );;
 Error, the entries of <list> must be in 'IsPlistVectorRep'
-gap> MakeIsPlistMatrixRep( Integers, e, 1, [ w ], true );;
+gap> MakeIsRowPlistMatrixRep( Integers, e, 1, [ w ], true );;
 Error, the entries of <list> must have the given base domain
 
 #
@@ -43,29 +43,29 @@ gap> IsMutable( z );
 true
 
 #
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [] );;
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ 1 ] );;
+gap> NewMatrix( IsRowPlistMatrixRep, Integers, 2, [] );;
+gap> NewMatrix( IsRowPlistMatrixRep, Integers, 2, [ 1 ] );;
 Error, NewMatrix: Length of <list> is not a multiple of <ncols>
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ [ 1 ] ] );;
+gap> NewMatrix( IsRowPlistMatrixRep, Integers, 2, [ [ 1 ] ] );;
 Error, the entries of <list> must have length <ncols>
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ [ 1, 2 ] ] );;
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ v ] );;
+gap> NewMatrix( IsRowPlistMatrixRep, Integers, 2, [ [ 1, 2 ] ] );;
+gap> NewMatrix( IsRowPlistMatrixRep, Integers, 2, [ v ] );;
 Error, the entries of <list> must have length <ncols>
-gap> M:= NewMatrix( IsPlistMatrixRep, Integers, 2, [ v2, v2 ] );;
+gap> M:= NewMatrix( IsRowPlistMatrixRep, Integers, 2, [ v2, v2 ] );;
 gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
 true
 
 #
-gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 0 );;
-gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 0 );;
-gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 3 );;
-gap> M:= NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 3 );;
+gap> NewZeroMatrix( IsRowPlistMatrixRep, Integers, 0, 0 );;
+gap> NewZeroMatrix( IsRowPlistMatrixRep, Integers, 2, 0 );;
+gap> NewZeroMatrix( IsRowPlistMatrixRep, Integers, 0, 3 );;
+gap> M:= NewZeroMatrix( IsRowPlistMatrixRep, Integers, 2, 3 );;
 gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
 true
 
 #
-gap> NewIdentityMatrix( IsPlistMatrixRep, Integers, 0 );;
-gap> M:= NewIdentityMatrix( IsPlistMatrixRep, Integers, 2 );;
+gap> NewIdentityMatrix( IsRowPlistMatrixRep, Integers, 0 );;
+gap> M:= NewIdentityMatrix( IsRowPlistMatrixRep, Integers, 2 );;
 gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
 true
 

--- a/tst/testinstall/vecmat.tst
+++ b/tst/testinstall/vecmat.tst
@@ -250,7 +250,7 @@ gap> IsMutable(w);
 false
 
 # matrix object
-gap> m:= Matrix( IsPlistMatrixRep, GF(2), [ [ Z(2) ] ] );
+gap> m:= Matrix( IsRowPlistMatrixRep, GF(2), [ [ Z(2) ] ] );
 <1x1-matrix over GF(2)>
 gap> w:= ImmutableMatrix( GF(4), m );
 <immutable 1x1-matrix over GF(2^2)>


### PR DESCRIPTION
Not sure if we should do this or not... but I would like to revive PR #2973, or rather: make a new PR which instead of modifying `IsPlistMatrixRep` creates a new type which is not in the `IsRowListMatrix` filter, and hence does not suffer from the performance penalty.

The question is what to name the new type. One option would be to actually name the new type `IsPlistMatrixRep` and rename the old type to e.g. `IsRowPlistMatrixRep`. There should be little existing code using `IsPlistMatrixRep`. Certainly no packages use it; and I really wonder whether and why anyone should be using it in private code.

So we could merge this PR; or we could wait for a future PR that adds a new "generic" matrixobj type and *then* rename the old type. Or the new type gets a new name. 