### PR TITLE
Make `RestrictedMapping` of a group homomorphism use the same `Range` as the original morphism

### DIFF
--- a/lib/ghom.gi
+++ b/lib/ghom.gi
@@ -95,22 +95,14 @@ end);
 InstallMethod(RestrictedMapping,"create new GHBI",
   CollFamSourceEqFamElms,[IsGroupHomomorphism,IsGroup],0,
 function(hom,U)
-local rest,gens,imgs,imgp;
+local rest,gens,imgs;
 
   gens:=GeneratorsOfGroup(U);
   imgs:=List(gens,i->ImageElm(hom,i));
 
-  if HasImagesSource(hom) then
-    imgp:=ImagesSource(hom);
-  else
-    imgp:=Subgroup(Range(hom),imgs);
-  fi;
-  rest:=GroupHomomorphismByImagesNC(U,imgp,gens,imgs);
+  rest:=GroupHomomorphismByImagesNC(U,Range(hom),gens,imgs);
   if HasIsInjective(hom) and IsInjective(hom) then
     SetIsInjective(rest,true);
-  fi;
-  if HasIsTotal(hom) and IsTotal(hom) then
-    SetIsTotal(rest,true);
   fi;
 
   return rest;


### PR DESCRIPTION
Closes #6225

## Text for release notes

see title

## Further details

Shouldn't have much impact, unless some other code actually relied on `RestrictedMapping` returning a surjective map.
