### PR TITLE
Fix input for setup-cygwin@v2 in CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: gap-actions/setup-cygwin@v2
         if: ${{ runner.os == 'Windows' }}
         with:
-          extra-pkgs-to-install: 'm4,autoconf2.5,libmpc-devel,libmpfr-devel,pkg-config'
+          extra-pkgs-to-install: 'libmpc-devel,libmpfr-devel,pkg-config'
 
       # There are two cygwin installs on github actions (ours,
       # and a preinstalled one which we can't use as not enough packages are installed.


### PR DESCRIPTION
The `setup-cygwin` action was bumped from `v1` to `v2` in 42eba62666576f743c9ef02178eb0bbb1000335c, but the input was not adjusted accordingly (renamed `PKGS_TO_INSTALL` → `pkgs-to-install`). 

As the list of packages to install in `CI.yml` fully contains the default list of packages that `setup-cygwin@v2` uses, it seems more logical to use the `extra-pkgs-to-install` instead of overriding the default `pkgs-to-install` value.

## Text for release notes

none

## Further details

Since this didn't cause any problems until now, perhaps it's worth checking which of these extra packages even need to be installed? The list may have been copied from the default list of `setup-cygwin@v1`, which included things only needed for certain GAP packages, e.g. `libmpc-devel` and `libmpfr-devel` for `float`.
