### PR TITLE
Change `IsomorphismPermGroupForMatrixGroup` to always use `NiceMonomorphism` if available

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -536,14 +536,23 @@ end );
 BindGlobal( "IsomorphismPermGroupForMatrixGroup",
 function(G)
 local map;
-  if not HasNiceMonomorphism(G) or not IsPermGroup(Range(NiceMonomorphism(G))) then
-    if not HasIsFinite(G) then
-      Info(InfoWarning,1,
-           "IsomorphismPermGroup: The group is not known to be finite");
+
+  if HasNiceMonomorphism( G ) then
+    map:= NiceMonomorphism( G );
+    if not IsPermGroup( Range( map ) ) then
+      # Trust GAP that this map is still useful.
+      map:= CompositionMapping( IsomorphismPermGroup( Image( map ) ), map );
+    fi;
+  else
+    # We cannot be sure about `IsHandledByNiceMonomorphism` for `G`.
+    if not HasIsFinite( G ) then
+      Info( InfoWarning,1,
+            "IsomorphismPermGroup: The group is not known to be finite" );
     fi;
     map:=NicomorphismOfGeneralMatrixGroup(G,false,false);
     SetNiceMonomorphism(G,map);
   fi;
+  # Now `G` stores a `NiceMonomorphism`.
   if IsPermGroup(Range(NiceMonomorphism(G))) then
     map:=RestrictedNiceMonomorphism(G);
   fi;


### PR DESCRIPTION
Use a known `NiceMonomorphism` also in the case that its image is *not* a permutation group.

The idea is:
We trust GAP that the image is nicer than the given group, in the sense that computing an `IsomorphismPermGroup` for the image is easier.
An example is that the given group is a matrix group in characteristic zero and its `NiceMonomorphism` is a reduction to a matrix group over a finite field.

(This strategy works only because `NiceMonomorphism` guarantees an image that is really nicer.
Note that other functions do not have this property, for example `SmallerDegreePermutationRepresentation` is allowed to return an identity mapping.)

(The same change has been  implemented in oscar-system/Oscar.jl/pull/5791.)