### PR TITLE
Fix `MaximalAbelianQuotient(G)` to not set `AbelianInvariants(G)` to a list with invalid format (e.g. `[2, 12]` instead of `[2,3,4]`)

### DIFF
--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1084,7 +1084,7 @@ local m,s,g,i,j,gen,img,hom,d,pos;
     d:=DiagonalOfMat(s.normal);
     pos:=Filtered([1..Length(d)],x->d[x]<>1);
     d:=d{pos};
-    SetAbelianInvariants(f,d);
+    SetAbelianInvariants( f, AbelianInvariantsOfList( d ) );
 
     # Make abelian group
     g:=AbelianGroup(d);

--- a/tst/testbugfix/2026-02-23-AbelianInvariants.tst
+++ b/tst/testbugfix/2026-02-23-AbelianInvariants.tst
@@ -1,0 +1,18 @@
+# Fix bug in MaximalAbelianQuotient
+# (format of the AbelianInvariants value)
+#@local G
+gap> START_TEST("AbelianInvariants.tst");
+
+#
+gap> G:= AbelianGroup( IsFpGroup, [ 2, 3, 4 ] );;
+gap> AbelianInvariants( G );
+[ 2, 3, 4 ]
+gap> G:= AbelianGroup( IsFpGroup, [ 2, 3, 4 ] );;
+gap> MaximalAbelianQuotient( G );;  # sets the abelian invariants
+gap> HasAbelianInvariants( G );
+true
+gap> AbelianInvariants( G );
+[ 2, 3, 4 ]
+
+#
+gap> STOP_TEST("AbelianInvariants.tst");


### PR DESCRIPTION
The `MaximalAbelianQuotient` method for f.p. groups sets the `AbelianInvariants` value, but the format of this value was in general not correct.