### PR TITLE
Improve break-loop stack traces to be more consistent, provide more information and to indicate the current environment selected via `DownEnv`/`UpEnv`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,19 @@ To run a specific test file, pass it to `./gap`, for example:
 ./gap -q tst/testinstall/magma.tst -c 'QUIT;'
 ```
 
+### REPL / break-loop output tests
+
+Use `tst/testspecial/` for tests that exercise the interactive REPL,
+break loops, or other output that depends on GAP's terminal handling.
+
+- `./tst/testspecial/run_gap.sh ./gap tst/testspecial/<name>.g [outfile]`
+  runs a single special test, captures combined output, prevents GAP from
+  attaching to the terminal, and rewrites local paths in the transcript.
+- From `tst/testspecial/`, `GAPDIR=../.. ./run_all.sh` runs the full special
+  test suite.
+- From `tst/testspecial/`, `./regenerate_tests.sh` regenerates all expected
+  `.out` files.
+
 ## Commit messages and pull requests
 
 When writing commit messages, use the title format `component: Brief summary`.

--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -41,9 +41,9 @@ error as in the following example occurs and a break loop is entered:
 <Log><![CDATA[
 gap> IsNormal(2,2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `IsNormal' on 2 arguments at GAPROOT/lib/methsel2.g:250 called from
-<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
- called from read-eval loop at *stdin*:1
+Error, no 1st choice method found for `IsNormal' on 2 arguments
+Stack trace:
+called from read-eval loop at *stdin*:1
 type 'quit;' to quit to outer loop
 brk>
 ]]></Log>

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -836,10 +836,10 @@ Error, !
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
-* Error( "!\n" ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
+*[1] Error( "!\n" ); at *stdin*:3 called from
+ [2] test( n + 1 ); at *stdin*:3 called from
+ [3] test( n + 1 ); at *stdin*:3 called from
+ [4] test( n + 1 ); at *stdin*:3 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> n;
@@ -848,20 +848,20 @@ brk> DownEnv();
 brk> n;
 3
 brk> Where();
-  Error( "!\n" ); at *stdin*:3 called from
-* test( n + 1 ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
+ [1] Error( "!\n" ); at *stdin*:3 called from
+*[2] test( n + 1 ); at *stdin*:3 called from
+ [3] test( n + 1 ); at *stdin*:3 called from
+ [4] test( n + 1 ); at *stdin*:3 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> DownEnv( 2 );
 brk> n;
 1
 brk> Where();
-  Error( "!\n" ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
-  test( n + 1 ); at *stdin*:3 called from
-* test( n + 1 ); at *stdin*:3 called from
+ [1] Error( "!\n" ); at *stdin*:3 called from
+ [2] test( n + 1 ); at *stdin*:3 called from
+ [3] test( n + 1 ); at *stdin*:3 called from
+*[4] test( n + 1 ); at *stdin*:3 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:8
 brk> DownEnv( -2 );

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -827,7 +827,7 @@ on the execution stack are displayed by <Ref Func="Where"/>).
 present this is the local variables bag used by the break loop for local
 variable lookup; outside such a context it returns <K>fail</K>.
 <P/>
-<Example><![CDATA[
+<Log><![CDATA[
 gap> OnBreak := function() end;; # eliminate back-tracing on entry to break loop
 gap> test:= function( n )
 >    if n > 3 then Error( "!\n" ); fi; test( n+1 ); end;;
@@ -869,7 +869,7 @@ brk> n;
 3
 brk> quit;
 gap> OnBreak := Where;; # restore OnBreak to its default value
-]]></Example>
+]]></Log>
 <P/>
 Note that the change of the environment caused by <Ref Func="DownEnv"/>
 only affects variable access in the break loop.

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -811,6 +811,7 @@ variable at the lowest level can be accessed.
 <Heading>DownEnv and UpEnv</Heading>
 <Func Name="DownEnv" Arg='nr'/>
 <Func Name="UpEnv" Arg='nr'/>
+<Func Name="CurrentEnv" Arg=''/>
 
 <Description>
 <Ref Func="DownEnv"/> moves down <A>nr</A> steps in the environment and
@@ -822,45 +823,53 @@ but in the reverse direction
 (the mnemonic rule to remember the difference between
 <Ref Func="DownEnv"/> and <Ref Func="UpEnv"/> is the order in which commands
 on the execution stack are displayed by <Ref Func="Where"/>).
+<Ref Func="CurrentEnv"/> returns the currently selected environment. At
+present this is the local variables bag used by the break loop for local
+variable lookup; outside such a context it returns <K>fail</K>.
 <P/>
-<Log><![CDATA[
-gap> OnBreak := function() Where(0); end;; # eliminate back-tracing on
-gap>                                       # entry to break loop
+<Example><![CDATA[
+gap> OnBreak := function() end;; # eliminate back-tracing on entry to break loop
 gap> test:= function( n )
 >    if n > 3 then Error( "!\n" ); fi; test( n+1 ); end;;
 gap> test( 1 );
 Error, !
-Entering break read-eval-print loop ...
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
- called from
-test( n + 1 ); called from
-test( n + 1 ); called from
-test( n + 1 ); called from
-<function>( <arguments> ) called from read-eval-loop
+* Error( "!\n" ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+<function "test">( <arguments> )
+ called from read-eval loop at *errin*:1
 brk> n;
 4
 brk> DownEnv();
 brk> n;
 3
 brk> Where();
- called from
-test( n + 1 ); called from
-test( n + 1 ); called from
-<function>( <arguments> ) called from read-eval-loop
+  Error( "!\n" ); at *stdin*:3 called from
+* test( n + 1 ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+<function "test">( <arguments> )
+ called from read-eval loop at *errin*:5
 brk> DownEnv( 2 );
 brk> n;
 1
 brk> Where();
- called from
-<function>( <arguments> ) called from read-eval-loop
+  Error( "!\n" ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+  test( n + 1 ); at *stdin*:3 called from
+* test( n + 1 ); at *stdin*:3 called from
+<function "test">( <arguments> )
+ called from read-eval loop at *errin*:8
 brk> DownEnv( -2 );
 brk> n;
 3
 brk> quit;
 gap> OnBreak := Where;; # restore OnBreak to its default value
-]]></Log>
+]]></Example>
 <P/>
 Note that the change of the environment caused by <Ref Func="DownEnv"/>
 only affects variable access in the break loop.

--- a/lib/error.g
+++ b/lib/error.g
@@ -424,7 +424,6 @@ BIND_GLOBAL("Error", function(arg)
     ErrorInner(
         rec(
             context := ParentLVars(GetCurrentLVars()),
-            tracebackContext := ~.context,
             mayReturnVoid := true,
             lateMessage := true,
         ),
@@ -437,7 +436,6 @@ BIND_GLOBAL("ErrorNoReturn", function(arg)
     ErrorInner(
         rec(
             context := ParentLVars(GetCurrentLVars()),
-            tracebackContext := ~.context,
             mayReturnVoid := false,
             mayReturnObj := false,
             lateMessage := "type 'quit;' to quit to outer loop",

--- a/lib/error.g
+++ b/lib/error.g
@@ -134,7 +134,7 @@ BIND_GLOBAL("PRETTY_PRINT_VARS", function(context)
 end);
 
 BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
-    local bottom, lastcontext, f;
+    local bottom, lastcontext, f, level;
     if depth <= 0 then
         return;
     fi;
@@ -144,8 +144,9 @@ BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
         return;
     fi;
     lastcontext := context;
+    level := 1;
     while depth > 0  and context <> bottom do
-        PRINT_CURRENT_STATEMENT(ERROR_OUTPUT, context, activecontext);
+        PRINT_CURRENT_STATEMENT(ERROR_OUTPUT, context, activecontext, level);
         if showlocals then
             PRETTY_PRINT_VARS(context);
         fi;
@@ -154,6 +155,7 @@ BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
         lastcontext := context;
         context := ParentLVars(context);
         depth := depth-1;
+        level := level + 1;
     od;
     if depth = 0 then
         PrintTo(ERROR_OUTPUT, "...  ");

--- a/lib/error.g
+++ b/lib/error.g
@@ -57,6 +57,40 @@ BIND_GLOBAL("AncestorLVars", function(lv, depth)
 end);
 
 ErrorLVars := fail;
+ErrorTracebackLVars := fail;
+
+BIND_GLOBAL("GET_VISIBLE_ERROR_LVARS", function()
+    local active, context, bottom;
+
+    if ErrorTracebackLVars = fail then
+        return fail;
+    fi;
+
+    active := CurrentEnv();
+    if active = fail then
+        return ErrorTracebackLVars;
+    fi;
+    bottom := GetBottomLVars();
+    context := ErrorTracebackLVars;
+    while context <> bottom do
+        if context = active then
+            return active;
+        fi;
+        context := ParentLVars(context);
+    od;
+    return ErrorTracebackLVars;
+end);
+
+BIND_GLOBAL("ERROR_MESSAGE_ENDS_WITH_NEWLINE", function(message)
+    local last;
+
+    if Length(message) = 0 then
+        return false;
+    fi;
+
+    last := Last(message);
+    return IsString(last) and Length(last) > 0 and Last(last) = '\n';
+end);
 
 # In this method the line hint changes in every PrintTo are balanced, because at the moment
 # PrintTo(ERROR_OUTPUT,...) resets the indentation level every time it is called.
@@ -99,16 +133,19 @@ BIND_GLOBAL("PRETTY_PRINT_VARS", function(context)
     PrintTo(ERROR_OUTPUT,"\n");
 end);
 
-BIND_GLOBAL("WHERE", function(depth, context, showlocals)
+BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
     local bottom, lastcontext, f;
     if depth <= 0 then
         return;
     fi;
     bottom := GetBottomLVars();
+    if context = bottom then
+        PrintTo(ERROR_OUTPUT, "called from read-eval loop ");
+        return;
+    fi;
     lastcontext := context;
-    context := ParentLVars(context);
     while depth > 0  and context <> bottom do
-        PRINT_CURRENT_STATEMENT(ERROR_OUTPUT, context);
+        PRINT_CURRENT_STATEMENT(ERROR_OUTPUT, context, activecontext);
         if showlocals then
             PRETTY_PRINT_VARS(context);
         fi;
@@ -129,10 +166,12 @@ end);
 
 
 BIND_GLOBAL("WHERE_INTERNAL", function(depth, showlocals)
+    local activecontext;
     if ErrorLVars = fail or ErrorLVars = GetBottomLVars() then
         PrintTo(ERROR_OUTPUT, "not in any function ");
     else
-        WHERE(depth, ErrorLVars, showlocals);
+        activecontext := GET_VISIBLE_ERROR_LVARS();
+        WHERE(depth, ErrorTracebackLVars, activecontext, showlocals);
     fi;
     PrintTo(ERROR_OUTPUT, "at ", INPUT_FILENAME(), ":", INPUT_LINENUMBER(), "\n");
 end);
@@ -172,9 +211,10 @@ end);
 #
 Unbind(ErrorInner);
 BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
-    local   context, mayReturnVoid,  mayReturnObj,  lateMessage,
-            x,  prompt,  res, errorLVars, justQuit, printThisStatement,
-            printEarlyMessage, printEarlyTraceback, lastErrorStream;
+    local   context, tracebackContext, mayReturnVoid, mayReturnObj,
+            lateMessage, x, prompt, res, errorLVars, errorTracebackLVars,
+            kernelErrorLVars, justQuit, printEarlyMessage,
+            printEarlyTraceback, printAutomaticTraceback, lastErrorStream;
 
     context := options.context;
     if not IsLVarsBag(context) then
@@ -216,15 +256,15 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         mayReturnObj := false;
     fi;
 
-    if IsBound(options.printThisStatement) then
-        printThisStatement := options.printThisStatement;
-        if not printThisStatement in [false, true] then
-            PrintTo(ERROR_OUTPUT, "ErrorInner: option printThisStatement must be true or false\n");
+    if IsBound(options.tracebackContext) then
+        tracebackContext := options.tracebackContext;
+        if not IsLVarsBag(tracebackContext) then
+            PrintTo(ERROR_OUTPUT, "ErrorInner: option tracebackContext must be a local variables bag\n");
             LEAVE_ALL_NAMESPACES();
             JUMP_TO_CATCH(1);
         fi;
     else
-        printThisStatement := true;
+        tracebackContext := context;
     fi;
 
     if IsBound(options.lateMessage) then
@@ -248,27 +288,31 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
     end;
 
     printEarlyTraceback := function(stream)
-        local location;
-        if printThisStatement then
-            if context <> GetBottomLVars() then
-                PrintTo(stream, " in\n  ");
-                PRINT_CURRENT_STATEMENT(stream, context);
-                PrintTo(stream, " called from ");
-            fi;
-        else
-            location := CURRENT_STATEMENT_LOCATION(context);
-            if location <> fail then
-              PrintTo(stream, " at ", location[1], ":", location[2]);
-            fi;
-            PrintTo(stream, " called from");
+        if not ERROR_MESSAGE_ENDS_WITH_NEWLINE(earlyMessage) then
+            PrintTo(stream, "\n");
         fi;
-        PrintTo(ERROR_OUTPUT, "\n");
+    end;
+
+    printAutomaticTraceback := function()
+        if IsBound(OnBreak) and IsFunction(OnBreak) then
+            if OnBreak = Where or OnBreak = WhereWithVars then
+                PrintTo(ERROR_OUTPUT, "Stack trace:\n");
+            fi;
+            OnBreak();
+        fi;
     end;
 
     ErrorLevel := ErrorLevel+1;
     ERROR_COUNT := ERROR_COUNT+1;
     errorLVars := ErrorLVars;
+    errorTracebackLVars := ErrorTracebackLVars;
+    kernelErrorLVars := CurrentEnv();
+    if kernelErrorLVars = fail then
+        kernelErrorLVars := GetBottomLVars();
+    fi;
     ErrorLVars := context;
+    ErrorTracebackLVars := tracebackContext;
+    SET_ERROR_LVARS(context);
     # Do we want to skip the break loop?
     # BreakOnError is initialized by the `-T` command line flag in init.g
     if QUITTING or not BreakOnError then
@@ -283,9 +327,7 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
             printEarlyMessage(ERROR_OUTPUT);
             if AlwaysPrintTracebackOnError then
                 printEarlyTraceback(ERROR_OUTPUT);
-                if IsBound(OnBreak) and IsFunction(OnBreak) then
-                    OnBreak();
-                fi;
+                printAutomaticTraceback();
             else
                 PrintTo(ERROR_OUTPUT, "\n");
             fi;
@@ -313,6 +355,8 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         fi;
         ErrorLevel := ErrorLevel-1;
         ErrorLVars := errorLVars;
+        ErrorTracebackLVars := errorTracebackLVars;
+        SET_ERROR_LVARS(kernelErrorLVars);
         if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;
         JUMP_TO_CATCH(0);
     fi;
@@ -323,17 +367,14 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
     if SHOULD_QUIT_ON_BREAK() then
         # Again, the default is to not print the rest of the traceback.
         # If AlwaysPrintTracebackOnError is true we do so anyways.
-        if AlwaysPrintTracebackOnError
-            and IsBound(OnBreak) and IsFunction(OnBreak) then
-            OnBreak();
+        if AlwaysPrintTracebackOnError then
+            printAutomaticTraceback();
         fi;
         ForceQuitGap(1);
     fi;
 
     # OnBreak() is set to Where() by default, which prints the traceback.
-    if IsBound(OnBreak) and IsFunction(OnBreak) then
-        OnBreak();
-    fi;
+    printAutomaticTraceback();
 
     # Now print lateMessage and OnBreakMessage a la "press return; to .."
     if IsString(lateMessage) then
@@ -355,6 +396,8 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
     fi;
     ErrorLevel := ErrorLevel-1;
     ErrorLVars := errorLVars;
+    ErrorTracebackLVars := errorTracebackLVars;
+    SET_ERROR_LVARS(kernelErrorLVars);
     if res = fail then
         if IsBound(OnQuit) and IsFunction(OnQuit) then
             OnQuit();
@@ -379,9 +422,9 @@ BIND_GLOBAL("Error", function(arg)
     ErrorInner(
         rec(
             context := ParentLVars(GetCurrentLVars()),
+            tracebackContext := ~.context,
             mayReturnVoid := true,
             lateMessage := true,
-            printThisStatement := false,
         ),
         arg);
 end);
@@ -392,10 +435,10 @@ BIND_GLOBAL("ErrorNoReturn", function(arg)
     ErrorInner(
         rec(
             context := ParentLVars(GetCurrentLVars()),
+            tracebackContext := ~.context,
             mayReturnVoid := false,
             mayReturnObj := false,
             lateMessage := "type 'quit;' to quit to outer loop",
-            printThisStatement := false,
         ),
         arg);
 end);

--- a/lib/methsel2.g
+++ b/lib/methsel2.g
@@ -247,7 +247,15 @@ end;
       APPEND_LIST(no_method_found, " argument is 'fail' which might point to an earlier problem\n" );
     fi;
   od;
-  ErrorNoReturn(no_method_found);
+  ErrorInner(
+      rec(
+          context := GetCurrentLVars(),
+          tracebackContext := ParentLVars(GetCurrentLVars()),
+          mayReturnVoid := false,
+          mayReturnObj := false,
+          lateMessage := "type 'quit;' to quit to outer loop"
+      ),
+      [ no_method_found ]);
 end;
 
 ## This is the other part of the above mentioned dirty trick:

--- a/src/error.c
+++ b/src/error.c
@@ -384,8 +384,7 @@ static Obj CallErrorInner(const Char * msg,
                           UInt         justQuit,
                           UInt         mayReturnVoid,
                           UInt         mayReturnObj,
-                          Obj          lateMessage,
-                          UInt         printThisStatement)
+                          Obj          lateMessage)
 {
     // Must do this before creating any other GAP objects,
     // as one of the args could be a pointer into a Bag.
@@ -411,8 +410,6 @@ static Obj CallErrorInner(const Char * msg,
     AssPRec(r, RNamName("justQuit"), justQuit ? True : False);
     AssPRec(r, RNamName("mayReturnObj"), mayReturnObj ? True : False);
     AssPRec(r, RNamName("mayReturnVoid"), mayReturnVoid ? True : False);
-    AssPRec(r, RNamName("printThisStatement"),
-            printThisStatement ? True : False);
     AssPRec(r, RNamName("lateMessage"), lateMessage);
     l = NewPlistFromArgs(EarlyMsg);
     MakeImmutableNoRecurse(l);
@@ -433,7 +430,7 @@ static Obj CallErrorInner(const Char * msg,
 
 void ErrorQuit(const Char * msg, Int arg1, Int arg2)
 {
-    CallErrorInner(msg, arg1, arg2, 1, 0, 0, False, 1);
+    CallErrorInner(msg, arg1, arg2, 1, 0, 0, False);
     Panic("ErrorQuit must not return");
 }
 
@@ -468,7 +465,7 @@ Obj ErrorReturnObj(const Char * msg, Int arg1, Int arg2, const Char * msg2)
 {
     Obj LateMsg;
     LateMsg = MakeString(msg2);
-    return CallErrorInner(msg, arg1, arg2, 0, 0, 1, LateMsg, 1);
+    return CallErrorInner(msg, arg1, arg2, 0, 0, 1, LateMsg);
 }
 
 
@@ -480,7 +477,7 @@ void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2)
 {
     Obj LateMsg;
     LateMsg = MakeString(msg2);
-    CallErrorInner(msg, arg1, arg2, 0, 1, 0, LateMsg, 1);
+    CallErrorInner(msg, arg1, arg2, 0, 1, 0, LateMsg);
     // ErrorMode( msg, arg1, arg2, (Obj)0, msg2, 'x' );
 }
 
@@ -491,7 +488,7 @@ void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2)
 void ErrorMayQuit(const Char * msg, Int arg1, Int arg2)
 {
     Obj LateMsg = MakeString("type 'quit;' to quit to outer loop");
-    CallErrorInner(msg, arg1, arg2, 0, 0, 0, LateMsg, 1);
+    CallErrorInner(msg, arg1, arg2, 0, 0, 0, LateMsg);
     Panic("ErrorMayQuit must not return");
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -185,7 +185,7 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
 }
 
 static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
-                                       Obj activeContext)
+                                       Obj activeContext, Obj level)
 {
     if (IsBottomLVars(context))
         return 0;
@@ -213,7 +213,8 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
         Obj  body = BODY_FUNC(func);
         Obj  filename = GET_FILENAME_BODY(body);
         if (activeContext != Fail) {
-            Pr(context == activeContext ? "* " : "  ", 0, 0);
+            Pr(context == activeContext ? "*[%d] " : " [%d] ",
+               INT_INTOBJ(level), 0);
         }
         if (IsKernelFunction(func)) {
             PrintKernelFunction(func);
@@ -646,7 +647,8 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_2ARGS(CALL_WITH_CATCH, func, args),
     GVAR_FUNC_1ARGS(JUMP_TO_CATCH, payload),
 
-    GVAR_FUNC_3ARGS(PRINT_CURRENT_STATEMENT, stream, context, activeContext),
+    GVAR_FUNC_4ARGS(PRINT_CURRENT_STATEMENT, stream, context, activeContext,
+                    level),
     GVAR_FUNC_1ARGS(CURRENT_STATEMENT_LOCATION, context),
 
     GVAR_FUNC_1ARGS(SetUserHasQuit, value),

--- a/src/error.c
+++ b/src/error.c
@@ -135,6 +135,20 @@ static Obj FuncUpEnv(Obj self, Obj args)
     return (Obj)0;
 }
 
+static Obj FuncCurrentEnv(Obj self)
+{
+    if (!STATE(ErrorLVars) || IsBottomLVars(STATE(ErrorLVars)))
+        return Fail;
+    MakeHighVars(STATE(ErrorLVars));
+    return STATE(ErrorLVars);
+}
+
+static Obj FuncSET_ERROR_LVARS(Obj self, Obj lvars)
+{
+    STATE(ErrorLVars) = lvars;
+    return (Obj)0;
+}
+
 static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
 {
     if (IsBottomLVars(context))
@@ -170,7 +184,8 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
     return retlist;
 }
 
-static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
+static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
+                                       Obj activeContext)
 {
     if (IsBottomLVars(context))
         return 0;
@@ -197,6 +212,9 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context)
         Stat call = STAT_LVARS(context);
         Obj  body = BODY_FUNC(func);
         Obj  filename = GET_FILENAME_BODY(body);
+        if (activeContext != Fail) {
+            Pr(context == activeContext ? "* " : "  ", 0, 0);
+        }
         if (IsKernelFunction(func)) {
             PrintKernelFunction(func);
             Obj funcname = NAME_FUNC(func);
@@ -622,11 +640,13 @@ static StructGVarFunc GVarFuncs[] = {
 
     GVAR_FUNC_XARGS(DownEnv, -1, "args"),
     GVAR_FUNC_XARGS(UpEnv, -1, "args"),
+    GVAR_FUNC_0ARGS(CurrentEnv),
+    GVAR_FUNC_1ARGS(SET_ERROR_LVARS, lvars),
 
     GVAR_FUNC_2ARGS(CALL_WITH_CATCH, func, args),
     GVAR_FUNC_1ARGS(JUMP_TO_CATCH, payload),
 
-    GVAR_FUNC_2ARGS(PRINT_CURRENT_STATEMENT, stream, context),
+    GVAR_FUNC_3ARGS(PRINT_CURRENT_STATEMENT, stream, context, activeContext),
     GVAR_FUNC_1ARGS(CURRENT_STATEMENT_LOCATION, context),
 
     GVAR_FUNC_1ARGS(SetUserHasQuit, value),

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -111,9 +111,9 @@ fail
 #
 gap> CURRENT_STATEMENT_LOCATION(GetCurrentLVars());
 fail
-gap> PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars(), fail);
-gap> f:=function() PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars(), fail); Print("\n"); end;; f();
-PRINT_CURRENT_STATEMENT( "*errout*", GetCurrentLVars(  ), fail ); at stream:1
+gap> PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars(), fail, 1);
+gap> f:=function() local l; l:=GetCurrentLVars(); PRINT_CURRENT_STATEMENT("*errout*", l, fail, 1); Print("\n"); end;; f();
+PRINT_CURRENT_STATEMENT( "*errout*", l, fail, 1 ); at stream:1
 
 #
 gap> CALL_WITH_CATCH(fail,fail);

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -105,13 +105,15 @@ gap> UpEnv(1,2);
 Error, usage: UpEnv( [ <depth> ] )
 gap> UpEnv(fail);
 Error, usage: UpEnv( [ <depth> ] )
+gap> CurrentEnv();
+fail
 
 #
 gap> CURRENT_STATEMENT_LOCATION(GetCurrentLVars());
 fail
-gap> PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars());
-gap> f:=function() PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars()); Print("\n"); end;; f();
-PRINT_CURRENT_STATEMENT( "*errout*", GetCurrentLVars(  ) ); at stream:1
+gap> PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars(), fail);
+gap> f:=function() PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars(), fail); Print("\n"); end;; f();
+PRINT_CURRENT_STATEMENT( "*errout*", GetCurrentLVars(  ), fail ); at stream:1
 
 #
 gap> CALL_WITH_CATCH(fail,fail);

--- a/tst/testspecial/64bit/low-mem-list-types.g.out
+++ b/tst/testspecial/64bit/low-mem-list-types.g.out
@@ -1,15 +1,18 @@
 gap> ListWithIdenticalEntries(2^50, 'a');
 Error, Cannot allocate 1125899906842633 bytes: cannot extend the workspace any more!!
+Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> ListWithIdenticalEntries(2^50, true);
 Error, Cannot allocate 140737488355336 bytes: cannot extend the workspace any more!!
+Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> ListWithIdenticalEntries(2^50, 2);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
+Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/64bit/low-mem-plist-1.g.out
+++ b/tst/testspecial/64bit/low-mem-plist-1.g.out
@@ -2,11 +2,13 @@ gap> l := [];
 [  ]
 gap> l[2^50] := 1;
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
+Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> l[2^50] := 2;
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
+Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/64bit/low-mem-plist-2.g.out
+++ b/tst/testspecial/64bit/low-mem-plist-2.g.out
@@ -1,10 +1,12 @@
 gap> EmptyPlist(2^50);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
+Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> EmptyPlist(2^50);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
+Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -12,17 +12,18 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]:=' on 3 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
+Error, no 1st choice method found for `[]:=' on 3 arguments
+Stack trace:
+* l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:13
 type 'quit;' to quit to outer loop
 brk> Where();
-l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
+* l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-l[[ 1 .. 3 ]] := 1; at *stdin*:11
+* l[[ 1 .. 3 ]] := 1; at *stdin*:11
   arguments: <none>
   local variables:
     l := [ 0, 0, 0, 0, 0, 0 ]
@@ -34,15 +35,21 @@ gap>
 gap> #############################################################################
 gap> f:=function() if true = 1/0 then return 1; fi; return 2; end;;
 gap> f();
-Error, Rational operations: <divisor> must not be zero in
-  1 / 0 at *stdin*:15 called from 
+Error, Rational operations: <divisor> must not be zero
+Stack trace:
+* 1 / 0 at *stdin*:15 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:16
 type 'quit;' to quit to outer loop
 brk> Where();
+* 1 / 0 at *stdin*:15 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* 1 / 0 at *stdin*:15
+  arguments: <none>
+  local variables: <none>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -50,17 +57,28 @@ gap>
 gap> #############################################################################
 gap> f:=function() local x; if x then return 1; fi; return 2; end;;
 gap> f();
-Error, Variable: 'x' must have an assigned value in
-  if x then
+Error, Variable: 'x' must have an assigned value
+Stack trace:
+* if x then
     return 1;
-fi; at *stdin*:18 called from 
+fi; at *stdin*:18 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:19
 type 'quit;' to quit to outer loop
 brk> Where();
+* if x then
+    return 1;
+fi; at *stdin*:18 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* if x then
+    return 1;
+fi; at *stdin*:18
+  arguments: <none>
+  local variables:
+    x := <unassigned>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -68,17 +86,27 @@ gap>
 gap> #############################################################################
 gap> f:=function() if 1 then return 1; fi; return 2; end;;
 gap> f();
-Error, <expr> must be 'true' or 'false' (not the integer 1) in
-  if 1 then
+Error, <expr> must be 'true' or 'false' (not the integer 1)
+Stack trace:
+* if 1 then
     return 1;
-fi; at *stdin*:21 called from 
+fi; at *stdin*:21 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:22
 type 'quit;' to quit to outer loop
 brk> Where();
+* if 1 then
+    return 1;
+fi; at *stdin*:21 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* if 1 then
+    return 1;
+fi; at *stdin*:21
+  arguments: <none>
+  local variables: <none>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -86,19 +114,33 @@ gap>
 gap> #############################################################################
 gap> f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; end;;
 gap> f();
-Error, <expr> must be 'true' or 'false' (not the integer 1) in
-  if 1 < 0 then
+Error, <expr> must be 'true' or 'false' (not the integer 1)
+Stack trace:
+* if 1 < 0 then
     return 1;
 elif 1 then
     return 2;
-fi; at *stdin*:24 called from 
+fi; at *stdin*:24 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:25
 type 'quit;' to quit to outer loop
 brk> Where();
+* if 1 < 0 then
+    return 1;
+elif 1 then
+    return 2;
+fi; at *stdin*:24 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* if 1 < 0 then
+    return 1;
+elif 1 then
+    return 2;
+fi; at *stdin*:24
+  arguments: <none>
+  local variables: <none>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -106,17 +148,27 @@ gap>
 gap> #############################################################################
 gap> f:=function() while 1 do return 1; od; return 2; end;;
 gap> f();
-Error, <expr> must be 'true' or 'false' (not the integer 1) in
-  while 1 do
+Error, <expr> must be 'true' or 'false' (not the integer 1)
+Stack trace:
+* while 1 do
     return 1;
-od; at *stdin*:27 called from 
+od; at *stdin*:27 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:28
 type 'quit;' to quit to outer loop
 brk> Where();
+* while 1 do
+    return 1;
+od; at *stdin*:27 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* while 1 do
+    return 1;
+od; at *stdin*:27
+  arguments: <none>
+  local variables: <none>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -124,8 +176,10 @@ gap>
 gap> #############################################################################
 gap> f:=function() local i; for i in 1 do return 1; od; return 2; end;;
 gap> f();
-Error, You cannot loop over the integer 1 did you mean the range [1..1] at GAPROOT/lib/integer.gi:LINE called from
-for i in 1 do
+Error, You cannot loop over the integer 1 did you mean the range [1..1]
+Stack trace:
+* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
+  for i in 1 do
     return 1;
 od; at *stdin*:30 called from
 <function "f">( <arguments> )
@@ -133,13 +187,19 @@ od; at *stdin*:30 called from
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
-for i in 1 do
+* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
+  for i in 1 do
     return 1;
 od; at *stdin*:30 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-for i in 1 do
+* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE
+  arguments:
+    n := 1
+  local variables: <none>
+ called from
+  for i in 1 do
     return 1;
 od; at *stdin*:30
   arguments: <none>
@@ -154,21 +214,22 @@ gap> ###########################################################################
 gap> f:=function() local i; for i in true do return 1; od; return 2; end;;
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-for i in true do
+Error, no 1st choice method found for `Iterator' on 1 arguments
+Stack trace:
+* for i in true do
     return 1;
 od; at *stdin*:33 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:34
 type 'quit;' to quit to outer loop
 brk> Where();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:33 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:33
   arguments: <none>
@@ -182,21 +243,22 @@ gap>
 gap> f:=function(x) local i,j; for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-for i in true do
+Error, no 1st choice method found for `Iterator' on 1 arguments
+Stack trace:
+* for i in true do
     return 1;
 od; at *stdin*:35 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:36
 type 'quit;' to quit to outer loop
 brk> Where();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:35 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:35
   arguments:
@@ -212,21 +274,22 @@ gap>
 gap> f:=function(x) local i,j; Unbind(x); for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-for i in true do
+Error, no 1st choice method found for `Iterator' on 1 arguments
+Stack trace:
+* for i in true do
     return 1;
 od; at *stdin*:37 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:38
 type 'quit;' to quit to outer loop
 brk> Where();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:37 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:37
   arguments:
@@ -242,21 +305,22 @@ gap>
 gap> f:=function(x) local i,j; Unbind(x); j := 4; for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `Iterator' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-for i in true do
+Error, no 1st choice method found for `Iterator' on 1 arguments
+Stack trace:
+* for i in true do
     return 1;
 od; at *stdin*:39 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:40
 type 'quit;' to quit to outer loop
 brk> Where();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:39 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-for i in true do
+* for i in true do
     return 1;
 od; at *stdin*:39
   arguments:
@@ -271,17 +335,28 @@ brk> quit;
 gap> 
 gap> f:=function() local x; repeat x:=1; until 1; return 2; end;;
 gap> f();
-Error, <expr> must be 'true' or 'false' (not the integer 1) in
-  repeat
+Error, <expr> must be 'true' or 'false' (not the integer 1)
+Stack trace:
+* repeat
     x := 1;
-until 1; at *stdin*:41 called from 
+until 1; at *stdin*:41 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:42
 type 'quit;' to quit to outer loop
 brk> Where();
+* repeat
+    x := 1;
+until 1; at *stdin*:41 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* repeat
+    x := 1;
+until 1; at *stdin*:41
+  arguments: <none>
+  local variables:
+    x := 1
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -289,15 +364,22 @@ gap>
 gap> #############################################################################
 gap> f:=function() local x; Assert(0, 1); return 2; end;;
 gap> f();
-Error, Assert: <cond> must be 'true' or 'false' (not the integer 1) in
-  Assert( 0, 1 ); at *stdin*:44 called from 
+Error, Assert: <cond> must be 'true' or 'false' (not the integer 1)
+Stack trace:
+* Assert( 0, 1 ); at *stdin*:44 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:45
 type 'quit;' to quit to outer loop
 brk> Where();
+* Assert( 0, 1 ); at *stdin*:44 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* Assert( 0, 1 ); at *stdin*:44
+  arguments: <none>
+  local variables:
+    x := <unassigned>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -305,15 +387,22 @@ gap>
 gap> #############################################################################
 gap> f:=function() local x; Assert(0, 1, "hello"); return 2; end;;
 gap> f();
-Error, Assert: <cond> must be 'true' or 'false' (not the integer 1) in
-  Assert( 0, 1, "hello" ); at *stdin*:47 called from 
+Error, Assert: <cond> must be 'true' or 'false' (not the integer 1)
+Stack trace:
+* Assert( 0, 1, "hello" ); at *stdin*:47 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:48
 type 'quit;' to quit to outer loop
 brk> Where();
+* Assert( 0, 1, "hello" ); at *stdin*:47 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+* Assert( 0, 1, "hello" ); at *stdin*:47
+  arguments: <none>
+  local variables:
+    x := <unassigned>
+ called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;
@@ -326,27 +415,36 @@ gap> InstallMethod( \[\,\], [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt ],
 >     { m, row, col } -> ELM_LIST( m, row, col ) );
 gap> l := [[1]];; f := {} -> l[2,1];;
 gap> f();
-Error, List Element: <list>[2] must have an assigned value in
-  return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from 
-ELM_LIST( m, row, col ) at *stdin*:54 called from
-return l[2, 1]; at *stdin*:55 called from
+Error, List Element: <list>[2] must have an assigned value
+Stack trace:
+* return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from
+  ELM_LIST( m, row, col ) at *stdin*:54 called from
+  return l[2, 1]; at *stdin*:55 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:56
 type 'quit;' to quit to outer loop
 brk> Where();
-ELM_LIST( m, row, col ) at *stdin*:54 called from
-return l[2, 1]; at *stdin*:55 called from
+* return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from
+  ELM_LIST( m, row, col ) at *stdin*:54 called from
+  return l[2, 1]; at *stdin*:55 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-ELM_LIST( m, row, col ) at *stdin*:54
+* return m[i][j]; at GAPROOT/lib/matrix.gi:LINE
+  arguments:
+    m := [ [ 1 ] ]
+    i := 2
+    j := 1
+  local variables: <none>
+ called from
+  ELM_LIST( m, row, col ) at *stdin*:54
   arguments:
     m := [ [ 1 ] ]
     row := 2
     col := 1
   local variables: <none>
  called from
-return l[2, 1]; at *stdin*:55
+  return l[2, 1]; at *stdin*:55
   arguments: <none>
   local variables: <none>
  called from
@@ -359,9 +457,10 @@ gap> ##
 gap> ##  Verify issue #1373 is fixed
 gap> ##
 gap> InstallMethod( Matrix, [IsFilter, IsSemiring, IsMatrixObj], {a,b,c} -> fail );
-Error, FLAGS_FILTER: <oper> must be an operation (not a function) in
-  <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function INSTALL_METHOD called from 
-<<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function InstallMethod called from
+Error, FLAGS_FILTER: <oper> must be an operation (not a function)
+Stack trace:
+* <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function INSTALL_METHOD called from
+  <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function InstallMethod called from
 <function "InstallMethod">( <arguments> )
  called from read-eval loop at *stdin*:61
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -14,16 +14,16 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]:=' on 3 arguments
 Stack trace:
-* l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
+*[1] l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:13
 type 'quit;' to quit to outer loop
 brk> Where();
-* l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
+*[1] l[[ 1 .. 3 ]] := 1; at *stdin*:11 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* l[[ 1 .. 3 ]] := 1; at *stdin*:11
+*[1] l[[ 1 .. 3 ]] := 1; at *stdin*:11
   arguments: <none>
   local variables:
     l := [ 0, 0, 0, 0, 0, 0 ]
@@ -37,16 +37,16 @@ gap> f:=function() if true = 1/0 then return 1; fi; return 2; end;;
 gap> f();
 Error, Rational operations: <divisor> must not be zero
 Stack trace:
-* 1 / 0 at *stdin*:15 called from
+*[1] 1 / 0 at *stdin*:15 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:16
 type 'quit;' to quit to outer loop
 brk> Where();
-* 1 / 0 at *stdin*:15 called from
+*[1] 1 / 0 at *stdin*:15 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* 1 / 0 at *stdin*:15
+*[1] 1 / 0 at *stdin*:15
   arguments: <none>
   local variables: <none>
  called from
@@ -59,20 +59,20 @@ gap> f:=function() local x; if x then return 1; fi; return 2; end;;
 gap> f();
 Error, Variable: 'x' must have an assigned value
 Stack trace:
-* if x then
+*[1] if x then
     return 1;
 fi; at *stdin*:18 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:19
 type 'quit;' to quit to outer loop
 brk> Where();
-* if x then
+*[1] if x then
     return 1;
 fi; at *stdin*:18 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* if x then
+*[1] if x then
     return 1;
 fi; at *stdin*:18
   arguments: <none>
@@ -88,20 +88,20 @@ gap> f:=function() if 1 then return 1; fi; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
 Stack trace:
-* if 1 then
+*[1] if 1 then
     return 1;
 fi; at *stdin*:21 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:22
 type 'quit;' to quit to outer loop
 brk> Where();
-* if 1 then
+*[1] if 1 then
     return 1;
 fi; at *stdin*:21 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* if 1 then
+*[1] if 1 then
     return 1;
 fi; at *stdin*:21
   arguments: <none>
@@ -116,7 +116,7 @@ gap> f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; e
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
 Stack trace:
-* if 1 < 0 then
+*[1] if 1 < 0 then
     return 1;
 elif 1 then
     return 2;
@@ -125,7 +125,7 @@ fi; at *stdin*:24 called from
  called from read-eval loop at *stdin*:25
 type 'quit;' to quit to outer loop
 brk> Where();
-* if 1 < 0 then
+*[1] if 1 < 0 then
     return 1;
 elif 1 then
     return 2;
@@ -133,7 +133,7 @@ fi; at *stdin*:24 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* if 1 < 0 then
+*[1] if 1 < 0 then
     return 1;
 elif 1 then
     return 2;
@@ -150,20 +150,20 @@ gap> f:=function() while 1 do return 1; od; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
 Stack trace:
-* while 1 do
+*[1] while 1 do
     return 1;
 od; at *stdin*:27 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:28
 type 'quit;' to quit to outer loop
 brk> Where();
-* while 1 do
+*[1] while 1 do
     return 1;
 od; at *stdin*:27 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* while 1 do
+*[1] while 1 do
     return 1;
 od; at *stdin*:27
   arguments: <none>
@@ -178,8 +178,8 @@ gap> f:=function() local i; for i in 1 do return 1; od; return 2; end;;
 gap> f();
 Error, You cannot loop over the integer 1 did you mean the range [1..1]
 Stack trace:
-* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
-  for i in 1 do
+*[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
+ [2] for i in 1 do
     return 1;
 od; at *stdin*:30 called from
 <function "f">( <arguments> )
@@ -187,19 +187,19 @@ od; at *stdin*:30 called from
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
-* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
-  for i in 1 do
+*[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
+ [2] for i in 1 do
     return 1;
 od; at *stdin*:30 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE
+*[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE
   arguments:
     n := 1
   local variables: <none>
  called from
-  for i in 1 do
+ [2] for i in 1 do
     return 1;
 od; at *stdin*:30
   arguments: <none>
@@ -216,20 +216,20 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
 Stack trace:
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:33 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:34
 type 'quit;' to quit to outer loop
 brk> Where();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:33 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:33
   arguments: <none>
@@ -245,20 +245,20 @@ gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
 Stack trace:
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:35 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:36
 type 'quit;' to quit to outer loop
 brk> Where();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:35 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:35
   arguments:
@@ -276,20 +276,20 @@ gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
 Stack trace:
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:37 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:38
 type 'quit;' to quit to outer loop
 brk> Where();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:37 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:37
   arguments:
@@ -307,20 +307,20 @@ gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
 Stack trace:
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:39 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:40
 type 'quit;' to quit to outer loop
 brk> Where();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:39 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* for i in true do
+*[1] for i in true do
     return 1;
 od; at *stdin*:39
   arguments:
@@ -337,20 +337,20 @@ gap> f:=function() local x; repeat x:=1; until 1; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
 Stack trace:
-* repeat
+*[1] repeat
     x := 1;
 until 1; at *stdin*:41 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:42
 type 'quit;' to quit to outer loop
 brk> Where();
-* repeat
+*[1] repeat
     x := 1;
 until 1; at *stdin*:41 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* repeat
+*[1] repeat
     x := 1;
 until 1; at *stdin*:41
   arguments: <none>
@@ -366,16 +366,16 @@ gap> f:=function() local x; Assert(0, 1); return 2; end;;
 gap> f();
 Error, Assert: <cond> must be 'true' or 'false' (not the integer 1)
 Stack trace:
-* Assert( 0, 1 ); at *stdin*:44 called from
+*[1] Assert( 0, 1 ); at *stdin*:44 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:45
 type 'quit;' to quit to outer loop
 brk> Where();
-* Assert( 0, 1 ); at *stdin*:44 called from
+*[1] Assert( 0, 1 ); at *stdin*:44 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* Assert( 0, 1 ); at *stdin*:44
+*[1] Assert( 0, 1 ); at *stdin*:44
   arguments: <none>
   local variables:
     x := <unassigned>
@@ -389,16 +389,16 @@ gap> f:=function() local x; Assert(0, 1, "hello"); return 2; end;;
 gap> f();
 Error, Assert: <cond> must be 'true' or 'false' (not the integer 1)
 Stack trace:
-* Assert( 0, 1, "hello" ); at *stdin*:47 called from
+*[1] Assert( 0, 1, "hello" ); at *stdin*:47 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:48
 type 'quit;' to quit to outer loop
 brk> Where();
-* Assert( 0, 1, "hello" ); at *stdin*:47 called from
+*[1] Assert( 0, 1, "hello" ); at *stdin*:47 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* Assert( 0, 1, "hello" ); at *stdin*:47
+*[1] Assert( 0, 1, "hello" ); at *stdin*:47
   arguments: <none>
   local variables:
     x := <unassigned>
@@ -417,34 +417,34 @@ gap> l := [[1]];; f := {} -> l[2,1];;
 gap> f();
 Error, List Element: <list>[2] must have an assigned value
 Stack trace:
-* return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from
-  ELM_LIST( m, row, col ) at *stdin*:54 called from
-  return l[2, 1]; at *stdin*:55 called from
+*[1] return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from
+ [2] ELM_LIST( m, row, col ) at *stdin*:54 called from
+ [3] return l[2, 1]; at *stdin*:55 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:56
 type 'quit;' to quit to outer loop
 brk> Where();
-* return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from
-  ELM_LIST( m, row, col ) at *stdin*:54 called from
-  return l[2, 1]; at *stdin*:55 called from
+*[1] return m[i][j]; at GAPROOT/lib/matrix.gi:LINE called from
+ [2] ELM_LIST( m, row, col ) at *stdin*:54 called from
+ [3] return l[2, 1]; at *stdin*:55 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
-* return m[i][j]; at GAPROOT/lib/matrix.gi:LINE
+*[1] return m[i][j]; at GAPROOT/lib/matrix.gi:LINE
   arguments:
     m := [ [ 1 ] ]
     i := 2
     j := 1
   local variables: <none>
  called from
-  ELM_LIST( m, row, col ) at *stdin*:54
+ [2] ELM_LIST( m, row, col ) at *stdin*:54
   arguments:
     m := [ [ 1 ] ]
     row := 2
     col := 1
   local variables: <none>
  called from
-  return l[2, 1]; at *stdin*:55
+ [3] return l[2, 1]; at *stdin*:55
   arguments: <none>
   local variables: <none>
  called from
@@ -459,8 +459,8 @@ gap> ##
 gap> InstallMethod( Matrix, [IsFilter, IsSemiring, IsMatrixObj], {a,b,c} -> fail );
 Error, FLAGS_FILTER: <oper> must be an operation (not a function)
 Stack trace:
-* <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function INSTALL_METHOD called from
-  <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function InstallMethod called from
+*[1] <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function INSTALL_METHOD called from
+ [2] <<compiled GAP code>> from GAPROOT/lib/oper1.g:LINE in function InstallMethod called from
 <function "InstallMethod">( <arguments> )
  called from read-eval loop at *stdin*:61
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/backtrace2.g.out
+++ b/tst/testspecial/backtrace2.g.out
@@ -26,53 +26,61 @@ gap> test:= function( n )
 > end;;
 gap> test( 1 );
 Error, !
- at *stdin*:24 called from
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+Stack trace:
+* Error( "!\n" ); at *stdin*:24 called from
+  test( n + 1 ); at *stdin*:26 called from
+  test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *stdin*:28
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> n; Where();
 3
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+* Error( "!\n" ); at *stdin*:24 called from
+  test( n + 1 ); at *stdin*:26 called from
+  test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 2
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+  Error( "!\n" ); at *stdin*:24 called from
+* test( n + 1 ); at *stdin*:26 called from
+  test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 1
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+  Error( "!\n" ); at *stdin*:24 called from
+  test( n + 1 ); at *stdin*:26 called from
+* test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+  Error( "!\n" ); at *stdin*:24 called from
+  test( n + 1 ); at *stdin*:26 called from
+* test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+  Error( "!\n" ); at *stdin*:24 called from
+* test( n + 1 ); at *stdin*:26 called from
+  test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+* Error( "!\n" ); at *stdin*:24 called from
+  test( n + 1 ); at *stdin*:26 called from
+  test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
-test( n + 1 ); at *stdin*:26 called from
-test( n + 1 ); at *stdin*:26 called from
+* Error( "!\n" ); at *stdin*:24 called from
+  test( n + 1 ); at *stdin*:26 called from
+  test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:7
 brk> quit;
@@ -88,53 +96,61 @@ gap> test:= function( n )
 >   test( n+1 );
 > end;;
 gap> test( 1 );
-Error, Rational operations: <divisor> must not be zero in
-  1 / 0 at *stdin*:35 called from 
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+Error, Rational operations: <divisor> must not be zero
+Stack trace:
+* 1 / 0 at *stdin*:35 called from
+  test( n + 1 ); at *stdin*:37 called from
+  test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *stdin*:39
 type 'quit;' to quit to outer loop
 brk> n; Where();
 3
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+* 1 / 0 at *stdin*:35 called from
+  test( n + 1 ); at *stdin*:37 called from
+  test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 2
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+  1 / 0 at *stdin*:35 called from
+* test( n + 1 ); at *stdin*:37 called from
+  test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 1
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+  1 / 0 at *stdin*:35 called from
+  test( n + 1 ); at *stdin*:37 called from
+* test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+  1 / 0 at *stdin*:35 called from
+  test( n + 1 ); at *stdin*:37 called from
+* test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+  1 / 0 at *stdin*:35 called from
+* test( n + 1 ); at *stdin*:37 called from
+  test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+* 1 / 0 at *stdin*:35 called from
+  test( n + 1 ); at *stdin*:37 called from
+  test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
-test( n + 1 ); at *stdin*:37 called from
-test( n + 1 ); at *stdin*:37 called from
+* 1 / 0 at *stdin*:35 called from
+  test( n + 1 ); at *stdin*:37 called from
+  test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:7
 brk> quit;
@@ -152,60 +168,61 @@ gap> test:= function( n )
 > end;;
 gap> test( 1 );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `IsCommutative' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+Error, no 1st choice method found for `IsCommutative' on 1 arguments
+Stack trace:
+* IsAbelian( 1 ) at *stdin*:47 called from
+  test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *stdin*:51
 type 'quit;' to quit to outer loop
 brk> n; Where();
 3
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+* IsAbelian( 1 ) at *stdin*:47 called from
+  test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 3
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+* IsAbelian( 1 ) at *stdin*:47 called from
+  test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 2
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+  IsAbelian( 1 ) at *stdin*:47 called from
+* test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+  IsAbelian( 1 ) at *stdin*:47 called from
+  test( n + 1 ); at *stdin*:49 called from
+* test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+  IsAbelian( 1 ) at *stdin*:47 called from
+* test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+* IsAbelian( 1 ) at *stdin*:47 called from
+  test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
-IsAbelian( 1 ) at *stdin*:47 called from
-test( n + 1 ); at *stdin*:49 called from
-test( n + 1 ); at *stdin*:49 called from
+* IsAbelian( 1 ) at *stdin*:47 called from
+  test( n + 1 ); at *stdin*:49 called from
+  test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:7
 brk> quit;

--- a/tst/testspecial/backtrace2.g.out
+++ b/tst/testspecial/backtrace2.g.out
@@ -27,60 +27,60 @@ gap> test:= function( n )
 gap> test( 1 );
 Error, !
 Stack trace:
-* Error( "!\n" ); at *stdin*:24 called from
-  test( n + 1 ); at *stdin*:26 called from
-  test( n + 1 ); at *stdin*:26 called from
+*[1] Error( "!\n" ); at *stdin*:24 called from
+ [2] test( n + 1 ); at *stdin*:26 called from
+ [3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *stdin*:28
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> n; Where();
 3
-* Error( "!\n" ); at *stdin*:24 called from
-  test( n + 1 ); at *stdin*:26 called from
-  test( n + 1 ); at *stdin*:26 called from
+*[1] Error( "!\n" ); at *stdin*:24 called from
+ [2] test( n + 1 ); at *stdin*:26 called from
+ [3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 2
-  Error( "!\n" ); at *stdin*:24 called from
-* test( n + 1 ); at *stdin*:26 called from
-  test( n + 1 ); at *stdin*:26 called from
+ [1] Error( "!\n" ); at *stdin*:24 called from
+*[2] test( n + 1 ); at *stdin*:26 called from
+ [3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 1
-  Error( "!\n" ); at *stdin*:24 called from
-  test( n + 1 ); at *stdin*:26 called from
-* test( n + 1 ); at *stdin*:26 called from
+ [1] Error( "!\n" ); at *stdin*:24 called from
+ [2] test( n + 1 ); at *stdin*:26 called from
+*[3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
-  Error( "!\n" ); at *stdin*:24 called from
-  test( n + 1 ); at *stdin*:26 called from
-* test( n + 1 ); at *stdin*:26 called from
+ [1] Error( "!\n" ); at *stdin*:24 called from
+ [2] test( n + 1 ); at *stdin*:26 called from
+*[3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
-  Error( "!\n" ); at *stdin*:24 called from
-* test( n + 1 ); at *stdin*:26 called from
-  test( n + 1 ); at *stdin*:26 called from
+ [1] Error( "!\n" ); at *stdin*:24 called from
+*[2] test( n + 1 ); at *stdin*:26 called from
+ [3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
-* Error( "!\n" ); at *stdin*:24 called from
-  test( n + 1 ); at *stdin*:26 called from
-  test( n + 1 ); at *stdin*:26 called from
+*[1] Error( "!\n" ); at *stdin*:24 called from
+ [2] test( n + 1 ); at *stdin*:26 called from
+ [3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
-* Error( "!\n" ); at *stdin*:24 called from
-  test( n + 1 ); at *stdin*:26 called from
-  test( n + 1 ); at *stdin*:26 called from
+*[1] Error( "!\n" ); at *stdin*:24 called from
+ [2] test( n + 1 ); at *stdin*:26 called from
+ [3] test( n + 1 ); at *stdin*:26 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:7
 brk> quit;
@@ -98,59 +98,59 @@ gap> test:= function( n )
 gap> test( 1 );
 Error, Rational operations: <divisor> must not be zero
 Stack trace:
-* 1 / 0 at *stdin*:35 called from
-  test( n + 1 ); at *stdin*:37 called from
-  test( n + 1 ); at *stdin*:37 called from
+*[1] 1 / 0 at *stdin*:35 called from
+ [2] test( n + 1 ); at *stdin*:37 called from
+ [3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *stdin*:39
 type 'quit;' to quit to outer loop
 brk> n; Where();
 3
-* 1 / 0 at *stdin*:35 called from
-  test( n + 1 ); at *stdin*:37 called from
-  test( n + 1 ); at *stdin*:37 called from
+*[1] 1 / 0 at *stdin*:35 called from
+ [2] test( n + 1 ); at *stdin*:37 called from
+ [3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 2
-  1 / 0 at *stdin*:35 called from
-* test( n + 1 ); at *stdin*:37 called from
-  test( n + 1 ); at *stdin*:37 called from
+ [1] 1 / 0 at *stdin*:35 called from
+*[2] test( n + 1 ); at *stdin*:37 called from
+ [3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 1
-  1 / 0 at *stdin*:35 called from
-  test( n + 1 ); at *stdin*:37 called from
-* test( n + 1 ); at *stdin*:37 called from
+ [1] 1 / 0 at *stdin*:35 called from
+ [2] test( n + 1 ); at *stdin*:37 called from
+*[3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
-  1 / 0 at *stdin*:35 called from
-  test( n + 1 ); at *stdin*:37 called from
-* test( n + 1 ); at *stdin*:37 called from
+ [1] 1 / 0 at *stdin*:35 called from
+ [2] test( n + 1 ); at *stdin*:37 called from
+*[3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
-  1 / 0 at *stdin*:35 called from
-* test( n + 1 ); at *stdin*:37 called from
-  test( n + 1 ); at *stdin*:37 called from
+ [1] 1 / 0 at *stdin*:35 called from
+*[2] test( n + 1 ); at *stdin*:37 called from
+ [3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
-* 1 / 0 at *stdin*:35 called from
-  test( n + 1 ); at *stdin*:37 called from
-  test( n + 1 ); at *stdin*:37 called from
+*[1] 1 / 0 at *stdin*:35 called from
+ [2] test( n + 1 ); at *stdin*:37 called from
+ [3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
-* 1 / 0 at *stdin*:35 called from
-  test( n + 1 ); at *stdin*:37 called from
-  test( n + 1 ); at *stdin*:37 called from
+*[1] 1 / 0 at *stdin*:35 called from
+ [2] test( n + 1 ); at *stdin*:37 called from
+ [3] test( n + 1 ); at *stdin*:37 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:7
 brk> quit;
@@ -170,59 +170,59 @@ gap> test( 1 );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `IsCommutative' on 1 arguments
 Stack trace:
-* IsAbelian( 1 ) at *stdin*:47 called from
-  test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+*[1] IsAbelian( 1 ) at *stdin*:47 called from
+ [2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *stdin*:51
 type 'quit;' to quit to outer loop
 brk> n; Where();
 3
-* IsAbelian( 1 ) at *stdin*:47 called from
-  test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+*[1] IsAbelian( 1 ) at *stdin*:47 called from
+ [2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 3
-* IsAbelian( 1 ) at *stdin*:47 called from
-  test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+*[1] IsAbelian( 1 ) at *stdin*:47 called from
+ [2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 2
-  IsAbelian( 1 ) at *stdin*:47 called from
-* test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+ [1] IsAbelian( 1 ) at *stdin*:47 called from
+*[2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
-  IsAbelian( 1 ) at *stdin*:47 called from
-  test( n + 1 ); at *stdin*:49 called from
-* test( n + 1 ); at *stdin*:49 called from
+ [1] IsAbelian( 1 ) at *stdin*:47 called from
+ [2] test( n + 1 ); at *stdin*:49 called from
+*[3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
-  IsAbelian( 1 ) at *stdin*:47 called from
-* test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+ [1] IsAbelian( 1 ) at *stdin*:47 called from
+*[2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
-* IsAbelian( 1 ) at *stdin*:47 called from
-  test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+*[1] IsAbelian( 1 ) at *stdin*:47 called from
+ [2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
-* IsAbelian( 1 ) at *stdin*:47 called from
-  test( n + 1 ); at *stdin*:49 called from
-  test( n + 1 ); at *stdin*:49 called from
+*[1] IsAbelian( 1 ) at *stdin*:47 called from
+ [2] test( n + 1 ); at *stdin*:49 called from
+ [3] test( n + 1 ); at *stdin*:49 called from
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:7
 brk> quit;

--- a/tst/testspecial/bad-add.g.out
+++ b/tst/testspecial/bad-add.g.out
@@ -4,8 +4,9 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-1 + "abc" at *stdin*:3 called from
+Error, no 1st choice method found for `+' on 2 arguments
+Stack trace:
+* 1 + "abc" at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-add.g.out
+++ b/tst/testspecial/bad-add.g.out
@@ -6,7 +6,7 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
 Stack trace:
-* 1 + "abc" at *stdin*:3 called from
+*[1] 1 + "abc" at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-double-1.g.out
+++ b/tst/testspecial/bad-array-double-1.g.out
@@ -4,8 +4,9 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[,]' on 3 arguments at GAPROOT/lib/methsel2.g:LINE called from
-return "abc"[1, 1]; at *stdin*:3 called from
+Error, no 1st choice method found for `[,]' on 3 arguments
+Stack trace:
+* return "abc"[1, 1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-double-1.g.out
+++ b/tst/testspecial/bad-array-double-1.g.out
@@ -6,7 +6,7 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[,]' on 3 arguments
 Stack trace:
-* return "abc"[1, 1]; at *stdin*:3 called from
+*[1] return "abc"[1, 1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-int-0.g.out
+++ b/tst/testspecial/bad-array-int-0.g.out
@@ -8,7 +8,7 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments
 Stack trace:
-* return l[0]; at *stdin*:5 called from
+*[1] return l[0]; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-int-0.g.out
+++ b/tst/testspecial/bad-array-int-0.g.out
@@ -6,8 +6,9 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-return l[0]; at *stdin*:5 called from
+Error, no 1st choice method found for `[]' on 2 arguments
+Stack trace:
+* return l[0]; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-int-1.g.out
+++ b/tst/testspecial/bad-array-int-1.g.out
@@ -3,8 +3,9 @@ gap> f := function()
 > end;
 function(  ) ... end
 gap> f();
-Error, List Element: <list> must be a list (not the integer 1) in
-  return 1[1]; at *stdin*:3 called from 
+Error, List Element: <list> must be a list (not the integer 1)
+Stack trace:
+* return 1[1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-int-1.g.out
+++ b/tst/testspecial/bad-array-int-1.g.out
@@ -5,7 +5,7 @@ function(  ) ... end
 gap> f();
 Error, List Element: <list> must be a list (not the integer 1)
 Stack trace:
-* return 1[1]; at *stdin*:3 called from
+*[1] return 1[1]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-string.g.out
+++ b/tst/testspecial/bad-array-string.g.out
@@ -4,8 +4,9 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `[]' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-return 1["abc"]; at *stdin*:3 called from
+Error, no 1st choice method found for `[]' on 2 arguments
+Stack trace:
+* return 1["abc"]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-string.g.out
+++ b/tst/testspecial/bad-array-string.g.out
@@ -6,7 +6,7 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments
 Stack trace:
-* return 1["abc"]; at *stdin*:3 called from
+*[1] return 1["abc"]; at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-undef-0.g.out
+++ b/tst/testspecial/bad-array-undef-0.g.out
@@ -4,8 +4,9 @@ gap> f := function()
 > end;
 function(  ) ... end
 gap> f();
-Error, Variable: 'l' must have an assigned value in
-  return l[1]; at *stdin*:4 called from 
+Error, Variable: 'l' must have an assigned value
+Stack trace:
+* return l[1]; at *stdin*:4 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:6
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-undef-0.g.out
+++ b/tst/testspecial/bad-array-undef-0.g.out
@@ -6,7 +6,7 @@ function(  ) ... end
 gap> f();
 Error, Variable: 'l' must have an assigned value
 Stack trace:
-* return l[1]; at *stdin*:4 called from
+*[1] return l[1]; at *stdin*:4 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:6
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-undef-1.g.out
+++ b/tst/testspecial/bad-array-undef-1.g.out
@@ -5,8 +5,9 @@ gap> f := function()
 > end;
 function(  ) ... end
 gap> f();
-Error, Variable: 'm' must have an assigned value in
-  return l[m]; at *stdin*:5 called from 
+Error, Variable: 'm' must have an assigned value
+Stack trace:
+* return l[m]; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-array-undef-1.g.out
+++ b/tst/testspecial/bad-array-undef-1.g.out
@@ -7,7 +7,7 @@ function(  ) ... end
 gap> f();
 Error, Variable: 'm' must have an assigned value
 Stack trace:
-* return l[m]; at *stdin*:5 called from
+*[1] return l[m]; at *stdin*:5 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:7
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-minus.g.out
+++ b/tst/testspecial/bad-minus.g.out
@@ -4,10 +4,11 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments at GAPROOT/lib/methsel2.g:LINE called from
-AdditiveInverseMutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
-AdditiveInverseImmutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
-1 - "abc" at *stdin*:3 called from
+Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments
+Stack trace:
+* AdditiveInverseMutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
+  AdditiveInverseImmutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
+  1 - "abc" at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bad-minus.g.out
+++ b/tst/testspecial/bad-minus.g.out
@@ -6,9 +6,9 @@ gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments
 Stack trace:
-* AdditiveInverseMutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
-  AdditiveInverseImmutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
-  1 - "abc" at *stdin*:3 called from
+*[1] AdditiveInverseMutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
+ [2] AdditiveInverseImmutable( elm ) at GAPROOT/lib/arith.gi:LINE called from
+ [3] 1 - "abc" at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/break-loop-loop.g.out
+++ b/tst/testspecial/break-loop-loop.g.out
@@ -5,7 +5,7 @@ gap> i:=0;
 gap> f(1);
 Error, bar
 Stack trace:
-* Error( "bar" ); at *stdin*:3 called from
+*[1] Error( "bar" ); at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/break-loop-loop.g.out
+++ b/tst/testspecial/break-loop-loop.g.out
@@ -3,7 +3,9 @@ gap> f:=function(x) local y; y:=42; Error("bar"); end;;
 gap> i:=0;
 0
 gap> f(1);
-Error, bar at *stdin*:3 called from
+Error, bar
+Stack trace:
+* Error( "bar" ); at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/broken-test.g.out
+++ b/tst/testspecial/broken-test.g.out
@@ -1,9 +1,9 @@
 gap> Test("broken-test-2.tst", rec(width := 800));
 Error, Invalid test file: #@ command found in the middle of a single test at broken-test-2.tst:5
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: #@ command found in the middle of a single test" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: #@ command found in the middle of a single test" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -11,9 +11,9 @@ brk> quit;
 gap> Test("broken-test-3.tst", rec(width := 800));
 Error, Invalid test file at broken-test-3.tst:5
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -21,9 +21,9 @@ brk> quit;
 gap> Test("broken-test-4.tst", rec(width := 800));
 Error, Invalid test file: Nested #@if at broken-test-4.tst:2
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: Nested #@if" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: Nested #@if" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -31,9 +31,9 @@ brk> quit;
 gap> Test("broken-test-5.tst", rec(width := 800));
 Error, Invalid test file: two #@else at broken-test-5.tst:7
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: two #@else" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: two #@else" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -41,9 +41,9 @@ brk> quit;
 gap> Test("broken-test-6.tst", rec(width := 800));
 Error, Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space at broken-test-6.tst:3
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -51,9 +51,9 @@ brk> quit;
 gap> Test("broken-test-7.tst", rec(width := 800));
 Error, Invalid test file: #@elif after #@else at broken-test-7.tst:7
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: #@elif after #@else" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: #@elif after #@else" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -61,9 +61,9 @@ brk> quit;
 gap> Test("broken-test-8.tst", rec(width := 800));
 Error, Invalid test file: #@elif without #@if at broken-test-8.tst:1
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: #@elif without #@if" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: #@elif without #@if" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -71,9 +71,9 @@ brk> quit;
 gap> Test("broken-test-9.tst", rec(width := 800));
 Error, Invalid test file: Unterminated #@if at broken-test-9.tst:7
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file: Unterminated #@if" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file: Unterminated #@if" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
@@ -81,9 +81,9 @@ brk> quit;
 gap> Test("invalidtestfile.tst", rec(width := 800));
 Error, Invalid test file at invalidtestfile.tst:7
 Stack trace:
-* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
-  testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
-  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+*[1] ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+ [2] testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
+ [3] ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/broken-test.g.out
+++ b/tst/testspecial/broken-test.g.out
@@ -1,71 +1,89 @@
 gap> Test("broken-test-2.tst", rec(width := 800));
-Error, Invalid test file: #@ command found in the middle of a single test at broken-test-2.tst:5 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: #@ command found in the middle of a single test" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: #@ command found in the middle of a single test at broken-test-2.tst:5
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: #@ command found in the middle of a single test" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-3.tst", rec(width := 800));
-Error, Invalid test file at broken-test-3.tst:5 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file at broken-test-3.tst:5
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-4.tst", rec(width := 800));
-Error, Invalid test file: Nested #@if at broken-test-4.tst:2 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: Nested #@if" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: Nested #@if at broken-test-4.tst:2
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: Nested #@if" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-5.tst", rec(width := 800));
-Error, Invalid test file: two #@else at broken-test-5.tst:7 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: two #@else" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: two #@else at broken-test-5.tst:7
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: two #@else" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-6.tst", rec(width := 800));
-Error, Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space at broken-test-6.tst:3 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space at broken-test-6.tst:3
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-7.tst", rec(width := 800));
-Error, Invalid test file: #@elif after #@else at broken-test-7.tst:7 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: #@elif after #@else" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: #@elif after #@else at broken-test-7.tst:7
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: #@elif after #@else" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-8.tst", rec(width := 800));
-Error, Invalid test file: #@elif without #@if at broken-test-8.tst:1 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: #@elif without #@if" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: #@elif without #@if at broken-test-8.tst:1
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: #@elif without #@if" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-9.tst", rec(width := 800));
-Error, Invalid test file: Unterminated #@if at broken-test-9.tst:7 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file: Unterminated #@if" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file: Unterminated #@if at broken-test-9.tst:7
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file: Unterminated #@if" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("invalidtestfile.tst", rec(width := 800));
-Error, Invalid test file at invalidtestfile.tst:7 at GAPROOT/lib/test.gi:LINE called from
-testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
-ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
+Error, Invalid test file at invalidtestfile.tst:7
+Stack trace:
+* ErrorNoReturn( s, " at ", fnam, ":", i ); at GAPROOT/lib/test.gi:LINE called from
+  testError( "Invalid test file" ); at GAPROOT/lib/test.gi:LINE called from
+  ParseTestInput( full, opts.ignoreComments, fnam ) at GAPROOT/lib/test.gi:LINE called from
 <function "Test">( <arguments> )
  called from read-eval loop at *stdin*:2
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/bugfix-2019-09-27-LastPV.g.out
+++ b/tst/testspecial/bugfix-2019-09-27-LastPV.g.out
@@ -6,8 +6,7 @@ gap> SetFilterObj(badgroup, filt);
 gap> old_OnBreak:=OnBreak;;
 gap> OnBreak:=fail;; # prevent backtrace with line numbers that keep chaning
 gap> View([[badgroup]]); # <- trigger break loop
-Error, Rational operations: <divisor> must not be zero in
-  0 / 0 at *stdin*:3 called from 
+Error, Rational operations: <divisor> must not be zero
 type 'quit;' to quit to outer loop
 brk> quit;
 [ [ 

--- a/tst/testspecial/current-env.g
+++ b/tst/testspecial/current-env.g
@@ -1,0 +1,12 @@
+f := function()
+    local i;
+    for i in 1 do
+        return 1;
+    od;
+    return 2;
+end;;
+f();
+ContentsLVars(CurrentEnv());
+DownEnv(); ContentsLVars(CurrentEnv());
+DownEnv(); ContentsLVars(CurrentEnv());
+quit;

--- a/tst/testspecial/current-env.g.out
+++ b/tst/testspecial/current-env.g.out
@@ -1,0 +1,26 @@
+gap> f := function()
+>     local i;
+>     for i in 1 do
+>         return 1;
+>     od;
+>     return 2;
+> end;;
+gap> f();
+Error, You cannot loop over the integer 1 did you mean the range [1..1]
+Stack trace:
+* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
+  for i in 1 do
+    return 1;
+od; at *stdin*:6 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:9
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> ContentsLVars(CurrentEnv());
+rec( func := function( n ) ... end, names := [ "n" ], values := [ 1 ] )
+brk> DownEnv(); ContentsLVars(CurrentEnv());
+rec( func := function(  ) ... end, names := [ "i" ], values := [  ] )
+brk> DownEnv(); ContentsLVars(CurrentEnv());
+rec( func := function(  ) ... end, names := [ "i" ], values := [  ] )
+brk> quit;
+gap> QUIT;

--- a/tst/testspecial/current-env.g.out
+++ b/tst/testspecial/current-env.g.out
@@ -8,8 +8,8 @@ gap> f := function()
 gap> f();
 Error, You cannot loop over the integer 1 did you mean the range [1..1]
 Stack trace:
-* Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
-  for i in 1 do
+*[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" ); at GAPROOT/lib/integer.gi:LINE called from
+ [2] for i in 1 do
     return 1;
 od; at *stdin*:6 called from
 <function "f">( <arguments> )

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -11,8 +11,10 @@ gap> f:=function(a)
 >   return g(10) + y;
 > end;;
 gap> f(1);
-Error, breakpoint at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, breakpoint
+Stack trace:
+* Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:14
 you can 'quit;' to quit to outer loop, or
@@ -32,9 +34,10 @@ brk> unbound_global;
 Syntax warning: Unbound global variable in *errin*:6
 unbound_global;
 ^^^^^^^^^^^^^^
-Error, Variable: 'unbound_global' must have a value in
-  Error( "breakpoint" ); at *stdin*:9 called from 
-g( 10 ) at *stdin*:12 called from
+Error, Variable: 'unbound_global' must have a value
+Stack trace:
+* Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> 
@@ -46,9 +49,10 @@ brk> y:=100;
 brk> IsBound(y);
 true
 brk> unbound_higher;
-Error, Variable: 'unbound_higher' must have an assigned value in
-  Error( "breakpoint" ); at *stdin*:9 called from 
-g( 10 ) at *stdin*:12 called from
+Error, Variable: 'unbound_higher' must have an assigned value
+Stack trace:
+* Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:12
 type 'quit;' to quit to outer loop
@@ -62,9 +66,10 @@ brk> z:=1000;
 brk> IsBound(z);
 true
 brk> unbound_local;
-Error, Variable: 'unbound_local' must have an assigned value in
-  Error( "breakpoint" ); at *stdin*:9 called from 
-g( 10 ) at *stdin*:12 called from
+Error, Variable: 'unbound_local' must have an assigned value
+Stack trace:
+* Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:17
 type 'quit;' to quit to outer loop
@@ -76,6 +81,7 @@ gap> x;
 42
 gap> y;
 Error, Variable: 'y' must have a value
+Stack trace:
 not in any function at *stdin*:16
 gap> 
 gap> h:=function(p)
@@ -85,16 +91,20 @@ gap> h:=function(p)
 > end;
 function( p ) ... end
 gap> f(1);
-Error, breakpoint at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, breakpoint
+Stack trace:
+* Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:23
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> h(2);
-Error, foobar at *stdin*:20 called from
-Error( "breakpoint" ); at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, foobar
+Stack trace:
+* Error( "foobar" ); at *stdin*:20 called from
+  Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 you can 'quit;' to quit to outer loop, or
@@ -108,40 +118,45 @@ brk_2> y:=100;
 brk_2> IsBound(y);
 true
 brk_2> unbound_higher;
-Error, Variable: <debug-variable-1-4> must have a value in
-  Error( "foobar" ); at *stdin*:20 called from 
-Error( "breakpoint" ); at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, Variable: <debug-variable-1-4> must have a value
+Stack trace:
+* Error( "foobar" ); at *stdin*:20 called from
+  Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:6
 brk_2> 
 brk_2> # check coding of dvars
 brk_2> function() return unbound_higher; end;
-Error, Variable: <debug-variable-1-4> cannot be used here in
-  Error( "foobar" ); at *stdin*:20 called from 
-Error( "breakpoint" ); at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, Variable: <debug-variable-1-4> cannot be used here
+Stack trace:
+* Error( "foobar" ); at *stdin*:20 called from
+  Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:9
 brk_2> function() return IsBound(unbound_higher); end;
-Error, Variable: <debug-variable-1-4> cannot be used here in
-  Error( "foobar" ); at *stdin*:20 called from 
-Error( "breakpoint" ); at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, Variable: <debug-variable-1-4> cannot be used here
+Stack trace:
+* Error( "foobar" ); at *stdin*:20 called from
+  Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:10
 brk_2> function() Unbind(unbound_higher); end;
-Error, Variable: <debug-variable-1-4> cannot be used here in
-  Error( "foobar" ); at *stdin*:20 called from 
-Error( "breakpoint" ); at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, Variable: <debug-variable-1-4> cannot be used here
+Stack trace:
+* Error( "foobar" ); at *stdin*:20 called from
+  Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:11
 brk_2> function() unbound_higher:=0; end;
-Error, Variable: <debug-variable-1-4> cannot be used here in
-  Error( "foobar" ); at *stdin*:20 called from 
-Error( "breakpoint" ); at *stdin*:9 called from
-g( 10 ) at *stdin*:12 called from
+Error, Variable: <debug-variable-1-4> cannot be used here
+Stack trace:
+* Error( "foobar" ); at *stdin*:20 called from
+  Error( "breakpoint" ); at *stdin*:9 called from
+  g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:12
 brk_2> QUIT;

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -13,8 +13,8 @@ gap> f:=function(a)
 gap> f(1);
 Error, breakpoint
 Stack trace:
-* Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "breakpoint" ); at *stdin*:9 called from
+ [2] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:14
 you can 'quit;' to quit to outer loop, or
@@ -36,8 +36,8 @@ unbound_global;
 ^^^^^^^^^^^^^^
 Error, Variable: 'unbound_global' must have a value
 Stack trace:
-* Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "breakpoint" ); at *stdin*:9 called from
+ [2] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:6
 brk> 
@@ -51,8 +51,8 @@ true
 brk> unbound_higher;
 Error, Variable: 'unbound_higher' must have an assigned value
 Stack trace:
-* Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "breakpoint" ); at *stdin*:9 called from
+ [2] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:12
 type 'quit;' to quit to outer loop
@@ -68,8 +68,8 @@ true
 brk> unbound_local;
 Error, Variable: 'unbound_local' must have an assigned value
 Stack trace:
-* Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "breakpoint" ); at *stdin*:9 called from
+ [2] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:17
 type 'quit;' to quit to outer loop
@@ -93,8 +93,8 @@ function( p ) ... end
 gap> f(1);
 Error, breakpoint
 Stack trace:
-* Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "breakpoint" ); at *stdin*:9 called from
+ [2] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:23
 you can 'quit;' to quit to outer loop, or
@@ -102,9 +102,9 @@ you can 'return;' to continue
 brk> h(2);
 Error, foobar
 Stack trace:
-* Error( "foobar" ); at *stdin*:20 called from
-  Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "foobar" ); at *stdin*:20 called from
+ [2] Error( "breakpoint" ); at *stdin*:9 called from
+ [3] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 you can 'quit;' to quit to outer loop, or
@@ -120,9 +120,9 @@ true
 brk_2> unbound_higher;
 Error, Variable: <debug-variable-1-4> must have a value
 Stack trace:
-* Error( "foobar" ); at *stdin*:20 called from
-  Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "foobar" ); at *stdin*:20 called from
+ [2] Error( "breakpoint" ); at *stdin*:9 called from
+ [3] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:6
 brk_2> 
@@ -130,33 +130,33 @@ brk_2> # check coding of dvars
 brk_2> function() return unbound_higher; end;
 Error, Variable: <debug-variable-1-4> cannot be used here
 Stack trace:
-* Error( "foobar" ); at *stdin*:20 called from
-  Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "foobar" ); at *stdin*:20 called from
+ [2] Error( "breakpoint" ); at *stdin*:9 called from
+ [3] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:9
 brk_2> function() return IsBound(unbound_higher); end;
 Error, Variable: <debug-variable-1-4> cannot be used here
 Stack trace:
-* Error( "foobar" ); at *stdin*:20 called from
-  Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "foobar" ); at *stdin*:20 called from
+ [2] Error( "breakpoint" ); at *stdin*:9 called from
+ [3] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:10
 brk_2> function() Unbind(unbound_higher); end;
 Error, Variable: <debug-variable-1-4> cannot be used here
 Stack trace:
-* Error( "foobar" ); at *stdin*:20 called from
-  Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "foobar" ); at *stdin*:20 called from
+ [2] Error( "breakpoint" ); at *stdin*:9 called from
+ [3] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:11
 brk_2> function() unbound_higher:=0; end;
 Error, Variable: <debug-variable-1-4> cannot be used here
 Stack trace:
-* Error( "foobar" ); at *stdin*:20 called from
-  Error( "breakpoint" ); at *stdin*:9 called from
-  g( 10 ) at *stdin*:12 called from
+*[1] Error( "foobar" ); at *stdin*:20 called from
+ [2] Error( "breakpoint" ); at *stdin*:9 called from
+ [3] g( 10 ) at *stdin*:12 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:12
 brk_2> QUIT;

--- a/tst/testspecial/error-in-InputTextString.g.out
+++ b/tst/testspecial/error-in-InputTextString.g.out
@@ -1,8 +1,8 @@
 gap> Read(InputTextString("Print(1 + [()]);"));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-<function "HANDLE_METHOD_NOT_FOUND">( <arguments> )
- called from read-eval loop at stream:1
+Error, no 1st choice method found for `+' on 2 arguments
+Stack trace:
+called from read-eval loop at stream:1
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> QUIT;

--- a/tst/testspecial/func-and-proc-call-trace.g.out
+++ b/tst/testspecial/func-and-proc-call-trace.g.out
@@ -4,8 +4,9 @@ gap> informproc0 := function(l)
 > end;;
 gap> informproc0([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l(  ); at *stdin*:4 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l(  ); at *stdin*:4 called from
 <function "informproc0">( <arguments> )
  called from read-eval loop at *stdin*:6
 type 'quit;' to quit to outer loop
@@ -19,8 +20,9 @@ gap> informproc1 := function(l)
 > end;;
 gap> informproc1([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1 ); at *stdin*:9 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1 ); at *stdin*:9 called from
 <function "informproc1">( <arguments> )
  called from read-eval loop at *stdin*:11
 type 'quit;' to quit to outer loop
@@ -34,8 +36,9 @@ gap> informproc2 := function(l)
 > end;;
 gap> informproc2([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2 ); at *stdin*:14 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2 ); at *stdin*:14 called from
 <function "informproc2">( <arguments> )
  called from read-eval loop at *stdin*:16
 type 'quit;' to quit to outer loop
@@ -49,8 +52,9 @@ gap> informproc3 := function(l)
 > end;;
 gap> informproc3([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3 ); at *stdin*:19 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3 ); at *stdin*:19 called from
 <function "informproc3">( <arguments> )
  called from read-eval loop at *stdin*:21
 type 'quit;' to quit to outer loop
@@ -64,8 +68,9 @@ gap> informproc4 := function(l)
 > end;;
 gap> informproc4([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4 ); at *stdin*:24 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4 ); at *stdin*:24 called from
 <function "informproc4">( <arguments> )
  called from read-eval loop at *stdin*:26
 type 'quit;' to quit to outer loop
@@ -79,8 +84,9 @@ gap> informproc5 := function(l)
 > end;;
 gap> informproc5([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4, 5 ); at *stdin*:29 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4, 5 ); at *stdin*:29 called from
 <function "informproc5">( <arguments> )
  called from read-eval loop at *stdin*:31
 type 'quit;' to quit to outer loop
@@ -94,8 +100,9 @@ gap> informproc6 := function(l)
 > end;;
 gap> informproc6([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4, 5, 6 ); at *stdin*:34 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4, 5, 6 ); at *stdin*:34 called from
 <function "informproc6">( <arguments> )
  called from read-eval loop at *stdin*:36
 type 'quit;' to quit to outer loop
@@ -109,8 +116,9 @@ gap> informprocmore := function(l)
 > end;;
 gap> informprocmore([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4, 5, 6, 7 ); at *stdin*:39 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4, 5, 6, 7 ); at *stdin*:39 called from
 <function "informprocmore">( <arguments> )
  called from read-eval loop at *stdin*:41
 type 'quit;' to quit to outer loop
@@ -124,8 +132,9 @@ gap> informfunc0 := function(l)
 > end;;
 gap> informfunc0([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l(  ) at *stdin*:44 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l(  ) at *stdin*:44 called from
 <function "informfunc0">( <arguments> )
  called from read-eval loop at *stdin*:46
 type 'quit;' to quit to outer loop
@@ -139,8 +148,9 @@ gap> informfunc1 := function(l)
 > end;;
 gap> informfunc1([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1 ) at *stdin*:49 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1 ) at *stdin*:49 called from
 <function "informfunc1">( <arguments> )
  called from read-eval loop at *stdin*:51
 type 'quit;' to quit to outer loop
@@ -154,8 +164,9 @@ gap> informfunc2 := function(l)
 > end;;
 gap> informfunc2([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2 ) at *stdin*:54 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2 ) at *stdin*:54 called from
 <function "informfunc2">( <arguments> )
  called from read-eval loop at *stdin*:56
 type 'quit;' to quit to outer loop
@@ -169,8 +180,9 @@ gap> informfunc3 := function(l)
 > end;;
 gap> informfunc3([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3 ) at *stdin*:59 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3 ) at *stdin*:59 called from
 <function "informfunc3">( <arguments> )
  called from read-eval loop at *stdin*:61
 type 'quit;' to quit to outer loop
@@ -184,8 +196,9 @@ gap> informfunc4 := function(l)
 > end;;
 gap> informfunc4([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4 ) at *stdin*:64 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4 ) at *stdin*:64 called from
 <function "informfunc4">( <arguments> )
  called from read-eval loop at *stdin*:66
 type 'quit;' to quit to outer loop
@@ -199,8 +212,9 @@ gap> informfunc5 := function(l)
 > end;;
 gap> informfunc5([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4, 5 ) at *stdin*:69 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4, 5 ) at *stdin*:69 called from
 <function "informfunc5">( <arguments> )
  called from read-eval loop at *stdin*:71
 type 'quit;' to quit to outer loop
@@ -214,8 +228,9 @@ gap> informfunc6 := function(l)
 > end;;
 gap> informfunc6([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4, 5, 6 ) at *stdin*:74 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4, 5, 6 ) at *stdin*:74 called from
 <function "informfunc6">( <arguments> )
  called from read-eval loop at *stdin*:76
 type 'quit;' to quit to outer loop
@@ -229,8 +244,9 @@ gap> informfuncmore := function(l)
 > end;;
 gap> informfuncmore([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `CallFuncList' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-l( 1, 2, 3, 4, 5, 6, 7 ) at *stdin*:79 called from
+Error, no 1st choice method found for `CallFuncList' on 2 arguments
+Stack trace:
+* l( 1, 2, 3, 4, 5, 6, 7 ) at *stdin*:79 called from
 <function "informfuncmore">( <arguments> )
  called from read-eval loop at *stdin*:81
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/func-and-proc-call-trace.g.out
+++ b/tst/testspecial/func-and-proc-call-trace.g.out
@@ -6,7 +6,7 @@ gap> informproc0([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l(  ); at *stdin*:4 called from
+*[1] l(  ); at *stdin*:4 called from
 <function "informproc0">( <arguments> )
  called from read-eval loop at *stdin*:6
 type 'quit;' to quit to outer loop
@@ -22,7 +22,7 @@ gap> informproc1([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1 ); at *stdin*:9 called from
+*[1] l( 1 ); at *stdin*:9 called from
 <function "informproc1">( <arguments> )
  called from read-eval loop at *stdin*:11
 type 'quit;' to quit to outer loop
@@ -38,7 +38,7 @@ gap> informproc2([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2 ); at *stdin*:14 called from
+*[1] l( 1, 2 ); at *stdin*:14 called from
 <function "informproc2">( <arguments> )
  called from read-eval loop at *stdin*:16
 type 'quit;' to quit to outer loop
@@ -54,7 +54,7 @@ gap> informproc3([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3 ); at *stdin*:19 called from
+*[1] l( 1, 2, 3 ); at *stdin*:19 called from
 <function "informproc3">( <arguments> )
  called from read-eval loop at *stdin*:21
 type 'quit;' to quit to outer loop
@@ -70,7 +70,7 @@ gap> informproc4([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4 ); at *stdin*:24 called from
+*[1] l( 1, 2, 3, 4 ); at *stdin*:24 called from
 <function "informproc4">( <arguments> )
  called from read-eval loop at *stdin*:26
 type 'quit;' to quit to outer loop
@@ -86,7 +86,7 @@ gap> informproc5([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4, 5 ); at *stdin*:29 called from
+*[1] l( 1, 2, 3, 4, 5 ); at *stdin*:29 called from
 <function "informproc5">( <arguments> )
  called from read-eval loop at *stdin*:31
 type 'quit;' to quit to outer loop
@@ -102,7 +102,7 @@ gap> informproc6([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4, 5, 6 ); at *stdin*:34 called from
+*[1] l( 1, 2, 3, 4, 5, 6 ); at *stdin*:34 called from
 <function "informproc6">( <arguments> )
  called from read-eval loop at *stdin*:36
 type 'quit;' to quit to outer loop
@@ -118,7 +118,7 @@ gap> informprocmore([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4, 5, 6, 7 ); at *stdin*:39 called from
+*[1] l( 1, 2, 3, 4, 5, 6, 7 ); at *stdin*:39 called from
 <function "informprocmore">( <arguments> )
  called from read-eval loop at *stdin*:41
 type 'quit;' to quit to outer loop
@@ -134,7 +134,7 @@ gap> informfunc0([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l(  ) at *stdin*:44 called from
+*[1] l(  ) at *stdin*:44 called from
 <function "informfunc0">( <arguments> )
  called from read-eval loop at *stdin*:46
 type 'quit;' to quit to outer loop
@@ -150,7 +150,7 @@ gap> informfunc1([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1 ) at *stdin*:49 called from
+*[1] l( 1 ) at *stdin*:49 called from
 <function "informfunc1">( <arguments> )
  called from read-eval loop at *stdin*:51
 type 'quit;' to quit to outer loop
@@ -166,7 +166,7 @@ gap> informfunc2([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2 ) at *stdin*:54 called from
+*[1] l( 1, 2 ) at *stdin*:54 called from
 <function "informfunc2">( <arguments> )
  called from read-eval loop at *stdin*:56
 type 'quit;' to quit to outer loop
@@ -182,7 +182,7 @@ gap> informfunc3([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3 ) at *stdin*:59 called from
+*[1] l( 1, 2, 3 ) at *stdin*:59 called from
 <function "informfunc3">( <arguments> )
  called from read-eval loop at *stdin*:61
 type 'quit;' to quit to outer loop
@@ -198,7 +198,7 @@ gap> informfunc4([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4 ) at *stdin*:64 called from
+*[1] l( 1, 2, 3, 4 ) at *stdin*:64 called from
 <function "informfunc4">( <arguments> )
  called from read-eval loop at *stdin*:66
 type 'quit;' to quit to outer loop
@@ -214,7 +214,7 @@ gap> informfunc5([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4, 5 ) at *stdin*:69 called from
+*[1] l( 1, 2, 3, 4, 5 ) at *stdin*:69 called from
 <function "informfunc5">( <arguments> )
  called from read-eval loop at *stdin*:71
 type 'quit;' to quit to outer loop
@@ -230,7 +230,7 @@ gap> informfunc6([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4, 5, 6 ) at *stdin*:74 called from
+*[1] l( 1, 2, 3, 4, 5, 6 ) at *stdin*:74 called from
 <function "informfunc6">( <arguments> )
  called from read-eval loop at *stdin*:76
 type 'quit;' to quit to outer loop
@@ -246,7 +246,7 @@ gap> informfuncmore([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
 Stack trace:
-* l( 1, 2, 3, 4, 5, 6, 7 ) at *stdin*:79 called from
+*[1] l( 1, 2, 3, 4, 5, 6, 7 ) at *stdin*:79 called from
 <function "informfuncmore">( <arguments> )
  called from read-eval loop at *stdin*:81
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/last-access.g.out
+++ b/tst/testspecial/last-access.g.out
@@ -4,7 +4,8 @@ gap> 1;2;3;[last,last2,last3];
 3
 [ 3, 2, 1 ]
 gap> Error("err");
-Error, err called from
+Error, err
+Stack trace:
 not in any function at *stdin*:3
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/line-continuation.g.out
+++ b/tst/testspecial/line-continuation.g.out
@@ -8,7 +8,7 @@ Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
 Stack trace:
-* Error( "Could not evaluate string.\n" ); at GAPROOT/lib/string.gi:LINE called from
+*[1] Error( "Could not evaluate string.\n" ); at GAPROOT/lib/string.gi:LINE called from
 <function "EvalString">( <arguments> )
  called from read-eval loop at *stdin*:6
 you can 'quit;' to quit to outer loop, or
@@ -20,7 +20,7 @@ Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
 Stack trace:
-* Error( "Could not evaluate string.\n" ); at GAPROOT/lib/string.gi:LINE called from
+*[1] Error( "Could not evaluate string.\n" ); at GAPROOT/lib/string.gi:LINE called from
 <function "EvalString">( <arguments> )
  called from read-eval loop at *stdin*:6
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/line-continuation.g.out
+++ b/tst/testspecial/line-continuation.g.out
@@ -4,9 +4,11 @@ gap> # counter only once, so that both examples below report the error in line 2
 gap> #
 gap> EvalString("123\\\n45x;");
 Error, Variable: '12345x' must have a value
+Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
- at GAPROOT/lib/string.gi:LINE called from
+Stack trace:
+* Error( "Could not evaluate string.\n" ); at GAPROOT/lib/string.gi:LINE called from
 <function "EvalString">( <arguments> )
  called from read-eval loop at *stdin*:6
 you can 'quit;' to quit to outer loop, or
@@ -14,9 +16,11 @@ you can 'return;' to continue
 brk> quit;
 gap> EvalString("123\\\r\n45x;");
 Error, Variable: '12345x' must have a value
+Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
- at GAPROOT/lib/string.gi:LINE called from
+Stack trace:
+* Error( "Could not evaluate string.\n" ); at GAPROOT/lib/string.gi:LINE called from
 <function "EvalString">( <arguments> )
  called from read-eval loop at *stdin*:6
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/mem-overflow.g.out
+++ b/tst/testspecial/mem-overflow.g.out
@@ -3,7 +3,7 @@ gap> l:=[1];; while true do Append(l,l); od;
 Error, reached the pre-set memory limit
 (change it with the -o command line option)
 Stack trace:
-* Append( l, l ); at *stdin*:3 called from
+*[1] Append( l, l ); at *stdin*:3 called from
 <function "unknown">( <arguments> )
  called from read-eval loop at *stdin*:3
 you can 'return;'

--- a/tst/testspecial/mem-overflow.g.out
+++ b/tst/testspecial/mem-overflow.g.out
@@ -1,8 +1,9 @@
 gap> # double a list until there is a memory overflow
 gap> l:=[1];; while true do Append(l,l); od;
 Error, reached the pre-set memory limit
-(change it with the -o command line option) in
-  Append( l, l ); at *stdin*:3 called from 
+(change it with the -o command line option)
+Stack trace:
+* Append( l, l ); at *stdin*:3 called from
 <function "unknown">( <arguments> )
  called from read-eval loop at *stdin*:3
 you can 'return;'

--- a/tst/testspecial/method-not-found-where.g
+++ b/tst/testspecial/method-not-found-where.g
@@ -1,0 +1,6 @@
+# test method-not-found traceback rendering while preserving helper access
+f := a -> a + a;;
+f(());
+ShowMethods(1);
+Where(5);
+quit;

--- a/tst/testspecial/method-not-found-where.g.out
+++ b/tst/testspecial/method-not-found-where.g.out
@@ -4,7 +4,7 @@ gap> f(());
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
 Stack trace:
-* a + a at *stdin*:3 called from
+*[1] a + a at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:4
 type 'quit;' to quit to outer loop
@@ -12,7 +12,7 @@ brk> ShowMethods(1);
 #I  Searching Method for + with 2 arguments:
 #I  Total: 138 entries
 brk> Where(5);
-* a + a at *stdin*:3 called from
+*[1] a + a at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2
 brk> quit;

--- a/tst/testspecial/method-not-found-where.g.out
+++ b/tst/testspecial/method-not-found-where.g.out
@@ -1,0 +1,19 @@
+gap> # test method-not-found traceback rendering while preserving helper access
+gap> f := a -> a + a;;
+gap> f(());
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `+' on 2 arguments
+Stack trace:
+* a + a at *stdin*:3 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:4
+type 'quit;' to quit to outer loop
+brk> ShowMethods(1);
+#I  Searching Method for + with 2 arguments:
+#I  Total: 138 entries
+brk> Where(5);
+* a + a at *stdin*:3 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *errin*:2
+brk> quit;
+gap> QUIT;

--- a/tst/testspecial/method-not-found.g.out
+++ b/tst/testspecial/method-not-found.g.out
@@ -1,8 +1,9 @@
 gap> # test returning from a 'method not found' error
 gap> f:=a->a+a;; f(());
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `+' on 2 arguments at GAPROOT/lib/methsel2.g:LINE called from
-a + a at *stdin*:3 called from
+Error, no 1st choice method found for `+' on 2 arguments
+Stack trace:
+* a + a at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:3
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/method-not-found.g.out
+++ b/tst/testspecial/method-not-found.g.out
@@ -3,7 +3,7 @@ gap> f:=a->a+a;; f(());
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
 Stack trace:
-* a + a at *stdin*:3 called from
+*[1] a + a at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:3
 type 'quit;' to quit to outer loop

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -22,6 +22,7 @@ gap>
 gap> # test formatting status for errout
 gap> 1/0; # trigger a break loop
 Error, Rational operations: <divisor> must not be zero
+Stack trace:
 not in any function at *stdin*:14
 type 'quit;' to quit to outer loop
 brk> old := PrintFormattingStatus("*errout*");

--- a/tst/testspecial/repl-syntax-err.g.out
+++ b/tst/testspecial/repl-syntax-err.g.out
@@ -6,7 +6,8 @@ gap> # error then is displayed. The next line then contains another syntax
 gap> # error, which wasn't reported correctly before the above issues was
 gap> # fixed.
 gap> Error(""):
-Error,  called from
+Error,
+Stack trace:
 not in any function at *stdin*:9
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/stack-depth-func.g.out
+++ b/tst/testspecial/stack-depth-func.g.out
@@ -1,23 +1,23 @@
 gap> f := function() f(); end;
 function(  ) ... end
 gap> f();
-Error, recursion depth trap (5000) in
-  f(  ); at *stdin*:2 called from 
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
+Error, recursion depth trap (5000)
+Stack trace:
+* f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> return; # try once more
-Error, recursion depth trap (10000) in
-  f(  ); at *stdin*:2 called from 
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
-f(  ); at *stdin*:2 called from
+Error, recursion depth trap (10000)
+Stack trace:
+* f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
+  f(  ); at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> QUIT;

--- a/tst/testspecial/stack-depth-func.g.out
+++ b/tst/testspecial/stack-depth-func.g.out
@@ -3,21 +3,21 @@ function(  ) ... end
 gap> f();
 Error, recursion depth trap (5000)
 Stack trace:
-* f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
+*[1] f(  ); at *stdin*:2 called from
+ [2] f(  ); at *stdin*:2 called from
+ [3] f(  ); at *stdin*:2 called from
+ [4] f(  ); at *stdin*:2 called from
+ [5] f(  ); at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> return; # try once more
 Error, recursion depth trap (10000)
 Stack trace:
-* f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
-  f(  ); at *stdin*:2 called from
+*[1] f(  ); at *stdin*:2 called from
+ [2] f(  ); at *stdin*:2 called from
+ [3] f(  ); at *stdin*:2 called from
+ [4] f(  ); at *stdin*:2 called from
+ [5] f(  ); at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> QUIT;

--- a/tst/testspecial/stack-depth-func2.g.out
+++ b/tst/testspecial/stack-depth-func2.g.out
@@ -1,23 +1,23 @@
 gap> f := function() local x; x := f(); return x; end;
 function(  ) ... end
 gap> y := f();
-Error, recursion depth trap (5000) in
-  f(  ) at *stdin*:2 called from 
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
+Error, recursion depth trap (5000)
+Stack trace:
+* f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> return; # try once more
-Error, recursion depth trap (10000) in
-  f(  ) at *stdin*:2 called from 
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
-f(  ) at *stdin*:2 called from
+Error, recursion depth trap (10000)
+Stack trace:
+* f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
+  f(  ) at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> QUIT;

--- a/tst/testspecial/stack-depth-func2.g.out
+++ b/tst/testspecial/stack-depth-func2.g.out
@@ -3,21 +3,21 @@ function(  ) ... end
 gap> y := f();
 Error, recursion depth trap (5000)
 Stack trace:
-* f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
+*[1] f(  ) at *stdin*:2 called from
+ [2] f(  ) at *stdin*:2 called from
+ [3] f(  ) at *stdin*:2 called from
+ [4] f(  ) at *stdin*:2 called from
+ [5] f(  ) at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> return; # try once more
 Error, recursion depth trap (10000)
 Stack trace:
-* f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
-  f(  ) at *stdin*:2 called from
+*[1] f(  ) at *stdin*:2 called from
+ [2] f(  ) at *stdin*:2 called from
+ [3] f(  ) at *stdin*:2 called from
+ [4] f(  ) at *stdin*:2 called from
+ [5] f(  ) at *stdin*:2 called from
 ...  at *stdin*:3
 you may 'return;'
 brk> QUIT;

--- a/tst/testspecial/stack-depth-rec.g.out
+++ b/tst/testspecial/stack-depth-rec.g.out
@@ -69,23 +69,23 @@ rec(
                                                                                                                                                                                                                                                                 printing stopped, too many recursion levels!
                                                                                                                                                                                                                                                                  ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) )
 gap> String(r);
-Error, recursion depth trap (5000) in
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from 
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+Error, recursion depth trap (5000)
+Stack trace:
+* String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
 ...  at *stdin*:4
 you may 'return;'
 brk> return; # try once more
-Error, recursion depth trap (5000) in
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from 
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+Error, recursion depth trap (5000)
+Stack trace:
+* String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
 ...  at *stdin*:4
 you may 'return;'
 brk> QUIT;

--- a/tst/testspecial/stack-depth-rec.g.out
+++ b/tst/testspecial/stack-depth-rec.g.out
@@ -71,21 +71,21 @@ rec(
 gap> String(r);
 Error, recursion depth trap (5000)
 Stack trace:
-* String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+*[1] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [2] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [3] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [4] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [5] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
 ...  at *stdin*:4
 you may 'return;'
 brk> return; # try once more
 Error, recursion depth trap (5000)
 Stack trace:
-* String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
-  String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+*[1] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [2] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [3] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [4] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
+ [5] String( record.(nam) ) at GAPROOT/lib/record.gi:LINE called from
 ...  at *stdin*:4
 you may 'return;'
 brk> QUIT;

--- a/tst/testspecial/stack-trace-label.g
+++ b/tst/testspecial/stack-trace-label.g
@@ -1,0 +1,5 @@
+f := function()
+    Error("foo");
+end;;
+f();
+quit;

--- a/tst/testspecial/stack-trace-label.g.out
+++ b/tst/testspecial/stack-trace-label.g.out
@@ -4,7 +4,7 @@ gap> f := function()
 gap> f();
 Error, foo
 Stack trace:
-* Error( "foo" ); at *stdin*:3 called from
+*[1] Error( "foo" ); at *stdin*:3 called from
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:5
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/stack-trace-label.g.out
+++ b/tst/testspecial/stack-trace-label.g.out
@@ -1,0 +1,13 @@
+gap> f := function()
+>     Error("foo");
+> end;;
+gap> f();
+Error, foo
+Stack trace:
+* Error( "foo" ); at *stdin*:3 called from
+<function "f">( <arguments> )
+ called from read-eval loop at *stdin*:5
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> quit;
+gap> QUIT;

--- a/tst/testspecial/syntax-tree-error.g.out
+++ b/tst/testspecial/syntax-tree-error.g.out
@@ -7,7 +7,9 @@ gap> func := SYNTAX_TREE_CODE( SYNTAX_TREE( func ) );
 function(  ) ... end
 gap> 
 gap> func( );
-Error,  called from
+Error,
+Stack trace:
+*  called from
 <function "func">( <arguments> )
  called from read-eval loop at *stdin*:8
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/syntax-tree-error.g.out
+++ b/tst/testspecial/syntax-tree-error.g.out
@@ -9,7 +9,7 @@ gap>
 gap> func( );
 Error,
 Stack trace:
-*  called from
+*[1]  called from
 <function "func">( <arguments> )
  called from read-eval loop at *stdin*:8
 you can 'quit;' to quit to outer loop, or

--- a/tst/testspecial/top-level-error.g.out
+++ b/tst/testspecial/top-level-error.g.out
@@ -1,5 +1,6 @@
 gap> Error("foo");
-Error, foo called from
+Error, foo
+Stack trace:
 not in any function at *stdin*:2
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/trace.g.out
+++ b/tst/testspecial/trace.g.out
@@ -31,6 +31,7 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument operations
+Stack trace:
 not in any function at *stdin*:25
 gap> 
 gap> # with tracing
@@ -58,6 +59,7 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7);
 Error, sorry: cannot yet have X argument operations
+Stack trace:
 not in any function at *stdin*:36
 gap> UntraceMethods( o ); # not (yet?) supported
 gap> 
@@ -78,6 +80,7 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument operations
+Stack trace:
 not in any function at *stdin*:47
 gap> 
 gap> #
@@ -110,6 +113,7 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
+Stack trace:
 not in any function at *stdin*:70
 gap> 
 gap> # with tracing
@@ -134,6 +138,7 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
+Stack trace:
 not in any function at *stdin*:80
 gap> UntraceMethods( o );
 gap> 
@@ -152,5 +157,6 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
+Stack trace:
 not in any function at *stdin*:90
 gap> QUIT;

--- a/tst/testspecial/up-down-env.g.out
+++ b/tst/testspecial/up-down-env.g.out
@@ -8,11 +8,11 @@ function( lvl ) ... end
 gap> f(7);
 Error, Rational operations: <divisor> must not be zero
 Stack trace:
-* 1 / lvl at *stdin*:7 called from
-  f( lvl - 1 ) at *stdin*:7 called from
-  f( lvl - 1 ) at *stdin*:7 called from
-  f( lvl - 1 ) at *stdin*:7 called from
-  f( lvl - 1 ) at *stdin*:7 called from
+*[1] 1 / lvl at *stdin*:7 called from
+ [2] f( lvl - 1 ) at *stdin*:7 called from
+ [3] f( lvl - 1 ) at *stdin*:7 called from
+ [4] f( lvl - 1 ) at *stdin*:7 called from
+ [5] f( lvl - 1 ) at *stdin*:7 called from
 ...  at *stdin*:8
 type 'quit;' to quit to outer loop
 brk> UpEnv(1); lvl;

--- a/tst/testspecial/up-down-env.g.out
+++ b/tst/testspecial/up-down-env.g.out
@@ -6,13 +6,13 @@ gap> ##
 gap> f:=lvl -> 1/lvl + f(lvl-1);
 function( lvl ) ... end
 gap> f(7);
-Error, Rational operations: <divisor> must not be zero in
-  1 / lvl at *stdin*:7 called from 
-f( lvl - 1 ) at *stdin*:7 called from
-f( lvl - 1 ) at *stdin*:7 called from
-f( lvl - 1 ) at *stdin*:7 called from
-f( lvl - 1 ) at *stdin*:7 called from
-f( lvl - 1 ) at *stdin*:7 called from
+Error, Rational operations: <divisor> must not be zero
+Stack trace:
+* 1 / lvl at *stdin*:7 called from
+  f( lvl - 1 ) at *stdin*:7 called from
+  f( lvl - 1 ) at *stdin*:7 called from
+  f( lvl - 1 ) at *stdin*:7 called from
+  f( lvl - 1 ) at *stdin*:7 called from
 ...  at *stdin*:8
 type 'quit;' to quit to outer loop
 brk> UpEnv(1); lvl;
@@ -49,7 +49,8 @@ brk> ##
 brk> ##  start a fresh execution context
 brk> ##
 brk> Read("top-level-error.g");
-Error, foo called from
+Error, foo
+Stack trace:
 not in any function at top-level-error.g:1
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
@@ -57,6 +58,7 @@ brk_2> Where(20);
 not in any function at *errin*:1
 brk_2> lvl; # since `Read` started a fresh execution context, we can't access lvl here
 Error, Variable: 'lvl' must have a value
+Stack trace:
 not in any function at *errin*:2
 brk_2> quit;
 brk> lvl;


### PR DESCRIPTION
This reworks break-loop stack traces so the initial traceback and later `Where()` output are driven by the same visible traceback state.

The break loop now tracks both the real environment used for local variable lookup and the first visible traceback frame. That makes ordinary errors, kernel-thrown errors, and no-method-found errors behave more consistently: `Where()` now shows the same top visible frame that was shown on entry, while method-not-found still keeps its helper environment available for `ShowArguments`, `ShowDetails`, and `ShowMethods`.

This also adds `CurrentEnv()` for inspecting the currently selected break-loop environment and updates the break-loop docs and tests accordingly.

On top of that, visible stack frames are now rendered with numbered prefixes in the style `*[1]`, ` [2]`, ` [3]`, where the `*` denotes the active frame. For me, that makes it *much* easier to use `DownEnv`/`UpEnv` correctly, and also increases readability of in longer traces. The manual examples and special REPL transcripts were refreshed to match the new output.

AI disclosure: prepared with help from Codex for implementation, tests, and documentation.

Resolves #4577
---

The diff contains many concrete examples where you can see how the stack traces changed in concrete examples. I'd be happy to add additional scenarios if I missed any!