### PR TITLE
Add `IsSymmetricMatrix` (and `IsSymmetricMat` as a synonym)

### DIFF
--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -310,6 +310,7 @@ see&nbsp;<Ref Sect="Mutability and Copyability"/>.
 <#Include Label="IsDiagonalMat">
 <#Include Label="IsUpperTriangularMat">
 <#Include Label="IsLowerTriangularMat">
+<#Include Label="IsSymmetricMat">
 
 </Section>
 

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -154,6 +154,39 @@ DeclareSynonym( "IsLowerTriangularMat", IsLowerTriangularMatrix );
 
 #############################################################################
 ##
+#P  IsSymmetricMatrix( <mat> )
+#P  IsSymmetricMat( <mat> )
+##
+##  <#GAPDoc Label="IsSymmetricMat">
+##  <ManSection>
+##  <Prop Name="IsSymmetricMatrix" Arg='mat'/>
+##  <Prop Name="IsSymmetricMat" Arg='mat'/>
+##
+##  <Description>
+##  return <K>true</K> if the matrix <A>mat</A> is a square matrix and
+##  satisfies <C><A>mat</A>[i,j] = <A>mat</A>[j,i]</C> for all
+##  <M>i, j</M>, and <K>false</K> otherwise.
+##  <Example><![CDATA[
+##  gap> IsSymmetricMatrix( [ [ 1 ] ] );
+##  true
+##  gap> IsSymmetricMatrix( [ [ 1, 2 ], [ 2, 1 ] ] );
+##  true
+##  gap> IsSymmetricMatrix( [ [ 0, 1 ], [ 2, 0 ] ] );
+##  false
+##  gap> IsSymmetricMatrix( [ [ 1, 2, 3 ], [ 2, 4, 5 ] ] );
+##  false
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsSymmetricMatrix", IsMatrixOrMatrixObj );
+
+DeclareSynonym( "IsSymmetricMat", IsSymmetricMatrix );
+
+
+#############################################################################
+##
 #F  DiagonalOfMatrix( <mat> )
 #F  DiagonalOfMat( <mat> )
 ##

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -251,6 +251,31 @@ InstallMethod( IsLowerTriangularMatrix,
 
 #############################################################################
 ##
+#M  IsSymmetricMatrix(<mat>)
+##
+InstallMethod( IsSymmetricMatrix,
+    "for a matrix",
+    [ IsMatrixOrMatrixObj ],
+    function( mat )
+    local i, j;
+    if NrRows( mat ) <> NrCols( mat ) then
+        return false;
+    fi;
+    for i in [ 1 .. NrRows( mat ) ] do
+        for j in [ i+1 .. NrCols( mat ) ] do
+            if mat[i,j] <> mat[j,i] then
+                return false;
+            fi;
+        od;
+    od;
+    return true;
+    end );
+
+InstallTrueMethod( IsSymmetricMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
+
+
+#############################################################################
+##
 #M  DiagonalOfMatrix(<mat>) . . . . . . . . . . . . . . .  diagonal of matrix
 ##
 InstallGlobalFunction( DiagonalOfMatrix, function ( mat )

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -89,6 +89,30 @@ gap> IsLowerTriangularMat([[1,0],[1,1],[1,1]]);
 true
 
 #
+gap> IsSymmetricMat(NullMat(3, 3));
+true
+gap> IsSymmetricMat(IdentityMat(3));
+true
+gap> IsSymmetricMat([[1]]);
+true
+gap> IsSymmetricMat([[1,2],[2,1]]);
+true
+gap> IsSymmetricMat([[1,2,3],[2,4,5],[3,5,6]]);
+true
+gap> IsSymmetricMat([[0,1],[2,0]]);
+false
+gap> IsSymmetricMat([[1,1],[1,1]]);
+true
+gap> IsSymmetricMat(NullMat(2, 3));
+false
+gap> IsSymmetricMat(NullMat(3, 2));
+false
+gap> IsSymmetricMat([[1,2,3],[2,4,5]]);
+false
+gap> IsSymmetricMat([[1,2],[3,4],[5,6]]);
+false
+
+#
 gap> m := Z(5)^0 * [[0, 1], [1, 0]];;
 gap> m := GeneratorsWithMemory([m])[1];;
 gap> BaseDomain(m) = GF(5);


### PR DESCRIPTION
This adds `IsSymmetricMatrix` (and `IsSymmetricMat` as a synonym) as a new property on `IsMatrixOrMatrixObj`. 

Fixes #6258

