### PR TITLE
Add `IsSquareMat` and `IsAntisymmetricMat`

### DIFF
--- a/doc/ref/matrix.xml
+++ b/doc/ref/matrix.xml
@@ -310,7 +310,9 @@ see&nbsp;<Ref Sect="Mutability and Copyability"/>.
 <#Include Label="IsDiagonalMat">
 <#Include Label="IsUpperTriangularMat">
 <#Include Label="IsLowerTriangularMat">
+<#Include Label="IsSquareMat">
 <#Include Label="IsSymmetricMat">
+<#Include Label="IsAntisymmetricMat">
 
 </Section>
 

--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -154,6 +154,36 @@ DeclareSynonym( "IsLowerTriangularMat", IsLowerTriangularMatrix );
 
 #############################################################################
 ##
+#P  IsSquareMatrix( <mat> )
+#P  IsSquareMat( <mat> )
+##
+##  <#GAPDoc Label="IsSquareMat">
+##  <ManSection>
+##  <Prop Name="IsSquareMatrix" Arg='mat'/>
+##  <Prop Name="IsSquareMat" Arg='mat'/>
+##
+##  <Description>
+##  return <K>true</K> if the matrix <A>mat</A> has the same number of rows
+##  and columns, and <K>false</K> otherwise.
+##  <Example><![CDATA[
+##  gap> IsSquareMatrix( [ [ 1 ] ] );
+##  true
+##  gap> IsSquareMatrix( [ [ 1, 2 ], [ 3, 4 ] ] );
+##  true
+##  gap> IsSquareMatrix( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
+##  false
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsSquareMatrix", IsMatrixOrMatrixObj );
+
+DeclareSynonym( "IsSquareMat", IsSquareMatrix );
+
+
+#############################################################################
+##
 #P  IsSymmetricMatrix( <mat> )
 #P  IsSymmetricMat( <mat> )
 ##
@@ -183,6 +213,44 @@ DeclareSynonym( "IsLowerTriangularMat", IsLowerTriangularMatrix );
 DeclareProperty( "IsSymmetricMatrix", IsMatrixOrMatrixObj );
 
 DeclareSynonym( "IsSymmetricMat", IsSymmetricMatrix );
+
+InstallTrueMethod( IsSquareMatrix, IsSymmetricMatrix );
+
+
+#############################################################################
+##
+#P  IsAntisymmetricMatrix( <mat> )
+#P  IsAntisymmetricMat( <mat> )
+##
+##  <#GAPDoc Label="IsAntisymmetricMat">
+##  <ManSection>
+##  <Prop Name="IsAntisymmetricMatrix" Arg='mat'/>
+##  <Prop Name="IsAntisymmetricMat" Arg='mat'/>
+##
+##  <Description>
+##  return <K>true</K> if the matrix <A>mat</A> is a square matrix and
+##  satisfies <C><A>mat</A>[i,j] = -<A>mat</A>[j,i]</C> for all
+##  <M>i, j</M>, and <K>false</K> otherwise.
+##  (In particular, the diagonal entries must be zero.)
+##  <Example><![CDATA[
+##  gap> IsAntisymmetricMatrix( [ [ 0 ] ] );
+##  true
+##  gap> IsAntisymmetricMatrix( [ [ 0, 1 ], [ -1, 0 ] ] );
+##  true
+##  gap> IsAntisymmetricMatrix( [ [ 0, 1 ], [ 1, 0 ] ] );
+##  false
+##  gap> IsAntisymmetricMatrix( [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );
+##  false
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsAntisymmetricMatrix", IsMatrixOrMatrixObj );
+
+DeclareSynonym( "IsAntisymmetricMat", IsAntisymmetricMatrix );
+
+InstallTrueMethod( IsSquareMatrix, IsAntisymmetricMatrix );
 
 
 #############################################################################

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -293,11 +293,10 @@ InstallMethod( IsAntisymmetricMatrix,
     "for a matrix",
     [ IsMatrixOrMatrixObj ],
     function( mat )
-    local i, j, zero;
+    local i, j;
     if not IsSquareMatrix( mat ) then
         return false;
     fi;
-    zero := ZeroOfBaseDomain( mat );
     for i in [ 1 .. NrRows( mat ) ] do
         for j in [ 1 .. i ] do
             if mat[i,j] <> -mat[j,i] then

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -251,6 +251,20 @@ InstallMethod( IsLowerTriangularMatrix,
 
 #############################################################################
 ##
+#M  IsSquareMatrix(<mat>)
+##
+InstallMethod( IsSquareMatrix,
+    "for a matrix",
+    [ IsMatrixOrMatrixObj ],
+    function( mat )
+    return NrRows( mat ) = NrCols( mat );
+    end );
+
+InstallTrueMethod( IsSquareMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
+
+
+#############################################################################
+##
 #M  IsSymmetricMatrix(<mat>)
 ##
 InstallMethod( IsSymmetricMatrix,
@@ -258,7 +272,7 @@ InstallMethod( IsSymmetricMatrix,
     [ IsMatrixOrMatrixObj ],
     function( mat )
     local i, j;
-    if NrRows( mat ) <> NrCols( mat ) then
+    if not IsSquareMatrix( mat ) then
         return false;
     fi;
     for i in [ 1 .. NrRows( mat ) ] do
@@ -272,6 +286,35 @@ InstallMethod( IsSymmetricMatrix,
     end );
 
 InstallTrueMethod( IsSymmetricMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
+
+
+#############################################################################
+##
+#M  IsAntisymmetricMatrix(<mat>)
+##
+InstallMethod( IsAntisymmetricMatrix,
+    "for a matrix",
+    [ IsMatrixOrMatrixObj ],
+    function( mat )
+    local i, j, zero;
+    if not IsSquareMatrix( mat ) then
+        return false;
+    fi;
+    zero := ZeroOfBaseDomain( mat );
+    for i in [ 1 .. NrRows( mat ) ] do
+        if mat[i,i] <> zero then
+            return false;
+        fi;
+        for j in [ i+1 .. NrCols( mat ) ] do
+            if mat[i,j] <> -mat[j,i] then
+                return false;
+            fi;
+        od;
+    od;
+    return true;
+    end );
+
+InstallTrueMethod( IsAntisymmetricMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
 
 
 #############################################################################

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -260,8 +260,6 @@ InstallMethod( IsSquareMatrix,
     return NrRows( mat ) = NrCols( mat );
     end );
 
-InstallTrueMethod( IsSquareMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
-
 
 #############################################################################
 ##
@@ -285,7 +283,6 @@ InstallMethod( IsSymmetricMatrix,
     return true;
     end );
 
-InstallTrueMethod( IsSymmetricMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
 
 
 #############################################################################
@@ -302,10 +299,7 @@ InstallMethod( IsAntisymmetricMatrix,
     fi;
     zero := ZeroOfBaseDomain( mat );
     for i in [ 1 .. NrRows( mat ) ] do
-        if mat[i,i] <> zero then
-            return false;
-        fi;
-        for j in [ i+1 .. NrCols( mat ) ] do
+        for j in [ 1 .. i ] do
             if mat[i,j] <> -mat[j,i] then
                 return false;
             fi;

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -308,8 +308,6 @@ InstallMethod( IsAntisymmetricMatrix,
     return true;
     end );
 
-InstallTrueMethod( IsAntisymmetricMatrix, IsMatrixOrMatrixObj and IsEmptyMatrix );
-
 
 #############################################################################
 ##

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -89,6 +89,22 @@ gap> IsLowerTriangularMat([[1,0],[1,1],[1,1]]);
 true
 
 #
+gap> IsSquareMat(NullMat(3, 3));
+true
+gap> IsSquareMat(IdentityMat(3));
+true
+gap> IsSquareMat([[1]]);
+true
+gap> IsSquareMat([[1,2],[3,4]]);
+true
+gap> IsSquareMat(NullMat(2, 3));
+false
+gap> IsSquareMat(NullMat(3, 2));
+false
+gap> IsSquareMat([[1,2,3],[4,5,6]]);
+false
+
+#
 gap> IsSymmetricMat(NullMat(3, 3));
 true
 gap> IsSymmetricMat(IdentityMat(3));
@@ -110,6 +126,26 @@ false
 gap> IsSymmetricMat([[1,2,3],[2,4,5]]);
 false
 gap> IsSymmetricMat([[1,2],[3,4],[5,6]]);
+false
+
+#
+gap> IsAntisymmetricMat(NullMat(3, 3));
+true
+gap> IsAntisymmetricMat([[0]]);
+true
+gap> IsAntisymmetricMat([[0,1],[-1,0]]);
+true
+gap> IsAntisymmetricMat([[0,2,3],[-2,0,5],[-3,-5,0]]);
+true
+gap> IsAntisymmetricMat([[0,1],[1,0]]);
+false
+gap> IsAntisymmetricMat([[1,0],[0,1]]);
+false
+gap> IsAntisymmetricMat(NullMat(2, 3));
+false
+gap> IsAntisymmetricMat(NullMat(3, 2));
+false
+gap> IsAntisymmetricMat([[1,2,3],[4,5,6]]);
 false
 
 #

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -1,4 +1,18 @@
 #
+gap> empty_0x2 := NewZeroMatrix(IsPlistMatrixRep, Integers, 0, 2);
+<0x2-matrix over Integers>
+gap> empty_2x0 := NewZeroMatrix(IsPlistMatrixRep, Integers, 2, 0);
+<2x0-matrix over Integers>
+gap> empty_0x0 := NewZeroMatrix(IsPlistMatrixRep, Integers, 0, 0);
+<0x0-matrix over Integers>
+gap> IsEmptyMatrix(empty_0x2);
+true
+gap> IsEmptyMatrix(empty_2x0);
+true
+gap> IsEmptyMatrix(empty_0x0);
+true
+
+#
 gap> IsGeneralizedCartanMatrix(NullMat(3, 3));
 false
 gap> IsGeneralizedCartanMatrix(NullMat(1, 3));
@@ -21,6 +35,12 @@ gap> IsGeneralizedCartanMatrix([[2,-2],[-2,2]]);
 true
 
 #
+gap> IsDiagonalMat(empty_0x2);
+true
+gap> IsDiagonalMat(empty_2x0);
+true
+gap> IsDiagonalMat(empty_0x0);
+true
 gap> IsDiagonalMat(NullMat(3, 3));
 true
 gap> IsDiagonalMat(NullMat(1, 3));
@@ -45,6 +65,12 @@ gap> IsDiagonalMat([[1,0,0],[0,1,0]]);
 true
 
 #
+gap> IsUpperTriangularMat(empty_0x2);
+true
+gap> IsUpperTriangularMat(empty_2x0);
+true
+gap> IsUpperTriangularMat(empty_0x0);
+true
 gap> IsUpperTriangularMat(NullMat(3, 3));
 true
 gap> IsUpperTriangularMat(NullMat(1, 3));
@@ -67,6 +93,12 @@ gap> IsUpperTriangularMat([[1,1,1],[0,1,1]]);
 true
 
 #
+gap> IsLowerTriangularMat(empty_0x2);
+true
+gap> IsLowerTriangularMat(empty_2x0);
+true
+gap> IsLowerTriangularMat(empty_0x0);
+true
 gap> IsLowerTriangularMat(NullMat(3, 3));
 true
 gap> IsLowerTriangularMat(NullMat(1, 3));
@@ -89,6 +121,12 @@ gap> IsLowerTriangularMat([[1,0],[1,1],[1,1]]);
 true
 
 #
+gap> IsSquareMat(empty_0x2);
+false
+gap> IsSquareMat(empty_2x0);
+false
+gap> IsSquareMat(empty_0x0);
+true
 gap> IsSquareMat(NullMat(3, 3));
 true
 gap> IsSquareMat(IdentityMat(3));
@@ -105,6 +143,12 @@ gap> IsSquareMat([[1,2,3],[4,5,6]]);
 false
 
 #
+gap> IsSymmetricMat(empty_0x2);
+false
+gap> IsSymmetricMat(empty_2x0);
+false
+gap> IsSymmetricMat(empty_0x0);
+true
 gap> IsSymmetricMat(NullMat(3, 3));
 true
 gap> IsSymmetricMat(IdentityMat(3));
@@ -129,6 +173,12 @@ gap> IsSymmetricMat([[1,2],[3,4],[5,6]]);
 false
 
 #
+gap> IsAntisymmetricMat(empty_0x2);
+false
+gap> IsAntisymmetricMat(empty_2x0);
+false
+gap> IsAntisymmetricMat(empty_0x0);
+true
 gap> IsAntisymmetricMat(NullMat(3, 3));
 true
 gap> IsAntisymmetricMat([[0]]);


### PR DESCRIPTION
Add `IsSquareMatrix/IsSquareMat` to check whether a matrix is square.
Add `IsAntisymmetricMatrix/IsAntisymmetricMat` to check whether `mat[i,j] = -mat[j,i]` for all entries. 

Both symmetric and antisymmetric matrices imply `IsSquareMatrix` via `InstallTrueMethod`. `IsSymmetricMatrix` is simplified to use `IsSquareMatrix` instead of an inline dimension check.

Fixes #6264.