### PR TITLE
Avoid undefined behavior in be32decode

### DIFF
--- a/src/sha256.c
+++ b/src/sha256.c
@@ -95,8 +95,8 @@ static void be32decode(UInt4 * dst, const UInt1 * src, UInt len)
 {
     UInt i;
     for (i = 0; i < (len >> 2); i++) {
-        dst[i] = (src[i * 4] << 24) | (src[i * 4 + 1] << 16) |
-                 (src[i * 4 + 2] << 8) | (src[i * 4 + 3]);
+        dst[i] = (((UInt4)src[i * 4]) << 24) | (((UInt4)src[i * 4 + 1]) << 16) |
+                 (((UInt4)src[i * 4 + 2]) << 8) | ((UInt4)src[i * 4 + 3]);
     }
 }
 


### PR DESCRIPTION
When GAP is built with UBSAN, the undefined behavior sanitizer, the sanitizer emits this warning:
```
src/sha256.c:98:30: runtime error: left shift of 128 by 24 places cannot be represented in type 'int'
```

The affected code in `be32decode` performs bitwise operations on values of type `UInt1`.  Section 6.3.1.1 of the C standard requires that such 8-bit values be promoted to type `int` prior to performing the operations.  The promotion introduces a sign bit and leads to a left shift that cannot be represented in the `int` type.  This change keeps the values unsigned at all times to avoid undefined left shifts.

## Text for release notes

see title

## Further details

I am not claiming that the current code produces incorrect results.  Most likely it produces correct results on all supported architectures with current compilers.  However, undefined behavior can lead to problems in the future if a new compiler optimization assumes that undefined behavior never occurs.