### PR TITLE
Avoid undefined behavior in integer.c

### DIFF
--- a/src/integer.c
+++ b/src/integer.c
@@ -505,7 +505,7 @@ Obj ObjInt_Int( Int i )
   }
   else if (i < 0 ) {
     gmp = NewBag( T_INTNEG, sizeof(mp_limb_t) );
-    i = -i;
+    i = (Int)(0U - (UInt)i);
   }
   else {
     gmp = NewBag( T_INTPOS, sizeof(mp_limb_t) );
@@ -620,7 +620,7 @@ Int Int_ObjInt(Obj i)
     if ((!sign && (val > INT32_MAX)) || (sign && (val > (UInt)INT32_MIN)))
 #endif
         ErrorMayQuit("Conversion error: integer too large", 0, 0);
-    return sign ? -(Int)val : (Int)val;
+    return (Int)(sign ? (0U - val) : val);
 }
 
 UInt UInt_ObjInt(Obj i)


### PR DESCRIPTION
When GAP is built with UBSAN, the undefined behavior sanitizer, the sanitizer emits these warnings while running the tests:
```
src/integer.c:623:29: runtime error: negation of -9223372036854775808 cannot be represented in type '<unknown>'; cast to an unsigned type to negate this value to itself
src/integer.c:508:7: runtime error: negation of -9223372036854775808 cannot be represented in type 'long int'; cast to an unsigned type to negate this value to itself
```

Taking the negative of `INTPTR_MIN` is undefined behavior, because the result depends on whether the CPU uses two's complement or not.  This PR instead uses unsigned arithmetic to compute the negative, which is well-defined behavior.  The optimizing compiler I tested (gcc 16.0.1 on `x86_64`) produced the same CPU instructions with this PR applied as it did with the current code.

## Text for release notes

see title

## Further details

As with the previous undefined behavior patch, I am not saying that anything wrong is happening at the CPU instruction level currently.  The point of this patch is purely to avoid undefined behavior.