### PR TITLE
Replace many redundant uses of `IsContainedInSpan`

### DIFF
--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -3517,9 +3517,8 @@ InstallMethod( CentralIdempotentsOfAlgebra,
             sp:= MutableBasis( F, vv );
             x:= ShallowCopy( e );
 
-            while not IsContainedInSpan( sp, x ) do
+            while CloseMutableBasis( sp, x ) do
               Add( vv, x );
-              CloseMutableBasis( sp, x );
               x:= x*e;
             od;
             sp:= UnderlyingLeftModule( ImmutableBasis( sp ) );
@@ -3567,9 +3566,8 @@ InstallMethod( CentralIdempotentsOfAlgebra,
         # We calculate the minimum polynomial of `e'.
 
           x:= ShallowCopy( e );
-          while not IsContainedInSpan( sp, x ) do
+          while CloseMutableBasis( sp, x ) do
             Add( vv, x );
-            CloseMutableBasis( sp, x );
             x:= x*e;
           od;
           sp:= UnderlyingLeftModule( ImmutableBasis( sp ) );
@@ -3775,9 +3773,8 @@ InstallMethod( LeviMalcevDecomposition,
     for k in BasisVectors( Basis( L ) ) do
       if Length( bb ) = s then
         break;
-      elif not IsContainedInSpan( sp, k ) then
+      elif CloseMutableBasis( sp, k ) then
         Add( bb, k );
-        CloseMutableBasis( sp, k );
       fi;
     od;
 
@@ -3814,9 +3811,8 @@ InstallMethod( LeviMalcevDecomposition,
         k:= 1;
       else
         x:= BasisVectors( Basis( ser[i] ) )[k];
-        if not IsContainedInSpan( sp, x ) then
+        if CloseMutableBasis( sp, x ) then
           Add( Rbas, x );
-          CloseMutableBasis( sp, x );
         fi;
         k:= k+1;
       fi;

--- a/lib/alghom.gi
+++ b/lib/alghom.gi
@@ -364,10 +364,9 @@ InstallMethod( AsLeftModuleGeneralMappingByImages,
           gen:= origgenerators[i];
           for j in [ 1 .. Length( generators ) ] do
             prod:= generators[j] * gen;
-            if not IsContainedInSpan( MB, prod ) then
+            if CloseMutableBasis( MB, prod ) then
               Add( generators, prod );
               Add( genimages, genimages[j] * origgenimages[i] );
-              CloseMutableBasis( MB, prod );
             fi;
           od;
         od;
@@ -379,10 +378,9 @@ InstallMethod( AsLeftModuleGeneralMappingByImages,
             gen:= origgenerators[i];
             for j in [ 1 .. Length( generators ) ] do
               prod:= gen * generators[j];
-              if not IsContainedInSpan( MB, prod ) then
+              if CloseMutableBasis( MB, prod ) then
                 Add( generators, prod );
                 Add( genimages, origgenimages[i] * genimages[j] );
-                CloseMutableBasis( MB, prod );
               fi;
             od;
           od;
@@ -874,10 +872,9 @@ InstallMethod( MakePreImagesInfoOperationAlgebraHomomorphism,
         gen:= origgenimages[i];
         for j in [ 1 .. Length( genimages ) ] do
           prod:= genimages[j] * gen;
-          if not IsContainedInSpan( MB, prod ) then
+          if CloseMutableBasis( MB, prod ) then
             Add( genimages, prod );
             Add( preimages, preimages[j] * origgenerators[i] );
-            CloseMutableBasis( MB, prod );
           fi;
         od;
       od;
@@ -1049,10 +1046,9 @@ InstallMethod( MakePreImagesInfoOperationAlgebraHomomorphism,
         gen:= origgenimages[i];
         for j in [ 1 .. Length( genimages ) ] do
           prod:= genimages[j] * gen;
-          if not IsContainedInSpan( MB, prod ) then
+          if CloseMutableBasis( MB, prod ) then
             Add( genimages, prod );
             Add( preimages, preimages[j] * origgenerators[i] );
-            CloseMutableBasis( MB, prod );
           fi;
         od;
       od;
@@ -1425,9 +1421,8 @@ InstallMethod( NaturalHomomorphismByIdeal,
     mb:= MutableBasis( F, Ivectors );
     compl:= [];
     for gen in BasisVectors( Basis( A ) ) do
-      if not IsContainedInSpan( mb, gen ) then
+      if CloseMutableBasis( mb, gen ) then
         Add( compl, gen );
-        CloseMutableBasis( mb, gen );
       fi;
     od;
     B:= BasisNC( A, Concatenation( Ivectors, compl ) );
@@ -1661,10 +1656,9 @@ InstallMethod( IsomorphismFpFLMLOR,
         gen:= Agens[i];
         for j in [ 1 .. Length( generators ) ] do
           prod:= generators[j] * gen;
-          if not IsContainedInSpan( MB, prod ) then
+          if CloseMutableBasis( MB, prod ) then
             Add( generators, prod );
             Add( genimages, genimages[j] * Fgens[i] );
-            CloseMutableBasis( MB, prod );
           fi;
         od;
       od;
@@ -1676,10 +1670,9 @@ InstallMethod( IsomorphismFpFLMLOR,
           gen:= Agens[i];
           for j in [ 1 .. Length( generators ) ] do
             prod:= gen * generators[j];
-            if not IsContainedInSpan( MB, prod ) then
+            if CloseMutableBasis( MB, prod ) then
               Add( generators, prod );
               Add( genimages, Fgens[i] * genimages[j] );
-              CloseMutableBasis( MB, prod );
             fi;
           od;
         od;

--- a/lib/alglie.gi
+++ b/lib/alglie.gi
@@ -922,10 +922,9 @@ InstallMethod( AdjointBasis,
     inds:= [];
     for i in [1..n] do
       adi:= AdjointMatrix( B, bb[i] );
-      if not IsContainedInSpan( adLsp, adi ) then
+      if CloseMutableBasis( adLsp, adi ) then
         Add( adL, adi );
         Add( inds, i );
-        CloseMutableBasis( adLsp, adi );
       fi;
     od;
 
@@ -1859,8 +1858,7 @@ InstallMethod( DirectSumDecomposition,
         while k<=Length(bas) do
           if Length(bas)=Dimension(L)-Dimension(H) then break; fi;
           M:= bas[ k ]*bas[ l ];
-          if not IsContainedInSpan( sp, M ) then
-            CloseMutableBasis( sp, M );
+          if CloseMutableBasis( sp, M ) then
             Add( bas, M );
           fi;
           if l < Length(bas) then l:=l+1;
@@ -1910,11 +1908,7 @@ InstallMethod( DirectSumDecomposition,
                   Add( mat, Coefficients( Basis( B[k], b ), x ) );
                 od;
                 mat:= TransposedMat( mat );
-
-                if not IsContainedInSpan( sp, mat ) then
-                  CloseMutableBasis( sp, mat );
-                fi;
-
+                CloseMutableBasis( sp, mat );
               od;
               res:= BasisVectors( sp );
 
@@ -2047,9 +2041,8 @@ InstallMethod( DirectSumDecomposition,
                    BasisVectors( Basis( CD ) ), Zero( CD ) );
           while Length( B1 ) + Dimension( CD ) <> Dimension( C ) do
             x:= bvc[k];
-            if not IsContainedInSpan( sp, x ) then
+            if CloseMutableBasis( sp, x ) then
               Add( B1, x );
-              CloseMutableBasis( sp, x );
             fi;
             k:=k+1;
           od;
@@ -2064,9 +2057,8 @@ InstallMethod( DirectSumDecomposition,
           sp:= MutableBasis( F, b );
           while Length( B2 )+Length( B1 ) <> n do
             x:= bvl[k];
-            if not IsContainedInSpan( sp, x ) then
+            if CloseMutableBasis( sp, x ) then
               Add( B2, x );
-              CloseMutableBasis( sp, x );
             fi;
             k:= k+1;
           od;
@@ -2392,9 +2384,8 @@ InstallMethod( SemiSimpleType,
     bvl:= BasisVectors( Basis( L ) );
     while Length( bas ) < Dimension( L ) do
       a:= bvl[k];
-      if not IsContainedInSpan( sp, a ) then
+      if CloseMutableBasis( sp, a ) then
         Add( bas, a );
-        CloseMutableBasis( sp, a );
       fi;
       k:= k+1;
     od;
@@ -2585,9 +2576,8 @@ InstallMethod( SemiSimpleType,
             r:= R[i];
             k:= Position( R, -r );
             h:= Rvecs[i] * Rvecs[k];
-            if not IsContainedInSpan( sp, h ) then
+            if CloseMutableBasis( sp, h ) then
               Add( basH, h );
-              CloseMutableBasis( sp, h );
               Add( basR, r );
             fi;
             i:= i+1;
@@ -2975,8 +2965,7 @@ InstallMethod( RootSystem,
       a:= S[i];
       j:= Position( S, -a );
       h:= B[i][1]*B[j][1];
-      if not IsContainedInSpan( sp, h ) then
-        CloseMutableBasis( sp, h );
+      if CloseMutableBasis( sp, h ) then
         Add( basR, a );
         Add( basH, h );
       fi;
@@ -4083,8 +4072,7 @@ InstallMethod( PreImagesRepresentative,
                         if c <> [] then
 
                             imz:= Image( f, z );
-                            if not IsContainedInSpan( sp, imz ) then
-                                CloseMutableBasis( sp, imz );
+                            if CloseMutableBasis( sp, imz ) then
                                 Add( b1, z );
                                 Add( newlev, z );
                                 Add( newbracks, c );

--- a/lib/algliess.gi
+++ b/lib/algliess.gi
@@ -950,9 +950,7 @@ BindGlobal( "SimpleLieAlgebraTypeH", function( n, F )
       od;
       if not IsZero(cf) then
         if IsBound( sp ) then
-          if not IsContainedInSpan( sp, cf ) then
-            CloseMutableBasis( sp, cf );
-          fi;
+          CloseMutableBasis( sp, cf );
         else
           sp:= MutableBasis( F, [ cf ] );
         fi;

--- a/lib/field.gi
+++ b/lib/field.gi
@@ -911,12 +911,11 @@ InstallMethod( MinimalPolynomial,
       coe:= Coefficients( B, pow );
       mat:= [ coe ];
       MB:= MutableBasis( F, [ coe ] );
-      repeat
-        CloseMutableBasis( MB, coe );
+      while CloseMutableBasis( MB, coe ) do
         pow:= pow * z;
         coe:= Coefficients( B, pow );
         Add( mat, coe );
-      until IsContainedInSpan( MB, coe );
+      od;
 
       # The coefficients of the minimal polynomial
       # are given by the linear relation.

--- a/lib/lierep.gi
+++ b/lib/lierep.gi
@@ -3915,7 +3915,7 @@ InstallGlobalFunction( ExtendRepresentation,
                V:= MutableBasis( F, bb );
            fi;
 
-           if IsContainedInSpan( V, vv ) then
+           if not CloseMutableBasis( V, vv ) then
 
     # We take the next element of 'orb'.
 
@@ -3928,7 +3928,6 @@ InstallGlobalFunction( ExtendRepresentation,
 
              c:= c1;
              Add( orb1, c );
-             CloseMutableBasis( V, vv );
 
            fi;
 
@@ -4129,13 +4128,12 @@ InstallGlobalFunction( ExtendRepresentation,
 
         for j in [ Last(w)..Length( mats )] do
             m:= asbas[i]*mats[j];
-            if not IsContainedInSpan( sp, m ) then
+            if CloseMutableBasis( sp, m ) then
                 ready:= false;
                 Add( asbas, m );
                 w1:= ShallowCopy(w);
                 Add( w1, j );
                 Add( wds, w1 );
-                CloseMutableBasis( sp, m );
             fi;
         od;
 
@@ -4151,10 +4149,9 @@ InstallGlobalFunction( ExtendRepresentation,
 
           cf:= List( asbas, m -> m[j][i] );
 
-        if not IsContainedInSpan( sp, cf ) then
+        if CloseMutableBasis( sp, cf ) then
           Add( fcts, cf );
           Add( cc, [i,j] );
-          CloseMutableBasis( sp, cf );
         fi;
       od;
     od;

--- a/lib/vspchom.gi
+++ b/lib/vspchom.gi
@@ -1333,9 +1333,8 @@ InstallGlobalFunction( NaturalHomomorphismBySubspaceOntoFullRowSpace,
     fi;
     compl:= [];
     for gen in BasisVectors( Basis( V ) ) do
-      if not IsContainedInSpan( mb, gen ) then
+      if CloseMutableBasis( mb, gen ) then
         Add( compl, gen );
-        CloseMutableBasis( mb, gen );
       fi;
     od;
     B:= BasisNC( V, Concatenation( Wvectors, compl ) );


### PR DESCRIPTION
Instead use the return value by CloseMutableBasis (which was not always there but was added by @ThomasBreuer in 2019 in PR #3247), which explains why so much code did not make use of it).

This essentially avoids doing the same computation twice, and can have a quite noticeable performance benefit in some cases.