### PR TITLE
Admit the syntax `SymplecticGroup( IsPlistMatrixRep, 4, GF(4) )`

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -377,4 +377,28 @@ described in this chapter is supported.
 
 </Section>
 
+<!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
+<Section Label="Groups Consisting of Matrix Objects">
+<Heading>Groups Consisting of Matrix Objects</Heading>
+
+One application of matrix objects is to construct groups whose elements
+are matrix objects.
+The following conventions hold for such a group <C>G</C>.
+
+<List>
+<Item>
+  All elements of <C>G</C> have the same
+  <Ref Attr="ConstructingFilter" Label="for a matrix object"/>
+  and the same <Ref Attr="BaseDomain" Label="for a matrix object"/>.
+  For a given matrix or matrix object <C>M</C>,
+  a matrix object that can be multiplied with elements of <C>G</C>
+  can be constructed as <C>Matrix( M, Representative( G ) )</C>,
+  and the result can be tested for membership in <C>G</C>.
+</Item>
+</List>
+
+<#Include Label="ConstructingFiltersForMatrixGroupElements">
+
+</Section>
+
 </Chapter>

--- a/grp/basic.gd
+++ b/grp/basic.gd
@@ -34,6 +34,12 @@
 ##  constructed over a specified field, which can be given as second argument
 ##  of the function that constructs the group;
 ##  The default field is <Ref Var="Rationals"/>.
+##  <P/>
+##  In the case of matrix groups, also the internal representation of the
+##  group elements can be prescribed.
+##  For convenience, one can enter one of the filters in the list
+##  <Ref Var="ConstructingFiltersForMatrixGroupElements"/>,
+##  which then implies <Ref Filt="IsMatrixGroup"/>.
 ##  <#/GAPDoc>
 
 

--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -779,9 +779,9 @@ DeclareConstructor( "SymplecticGroupCons", [ IsGroup, IsPosInt, IsRing ] );
 ##  <P/>
 ##  If <A>filt</A> is not given it defaults to <Ref Filt="IsMatrixGroup"/>,
 ##  and the returned group is the symplectic group itself.
-##  Another supported value for <A>filt</A> is
-##  <Ref Filt="IsPermGroup"/>;
-##  in this case, the argument <A>form</A> is not supported.
+##  Other supported values for <A>filt</A> are <Ref Filt="IsPermGroup"/>
+##  (in this case, the argument <A>form</A> is not supported)
+##  and the entries of <Ref Var="ConstructingFiltersForMatrixGroupElements"/>.
 ##  <P/>
 ##  At the moment finite fields or residue class rings
 ##  <C>Integers mod <A>q</A></C>, with <A>q</A> an odd prime power, are

--- a/grp/classic.gd
+++ b/grp/classic.gd
@@ -825,27 +825,35 @@ BindGlobal( "DescribesInvariantBilinearForm",
            ( IsGroup( obj ) and HasInvariantBilinearForm( obj ) ) );
 
 BindGlobal( "SymplecticGroup", function ( arg )
-  local filt, form;
+  local filt, rep, form;
 
   if IsFilter( First( arg ) ) then
     filt:= Remove( arg, 1 );
   else
     filt:= IsMatrixGroup;
   fi;
+  if filt in ConstructingFiltersForMatrixGroupElements then
+    rep:= filt;
+    filt:= IsMatrixGroup;
+  else
+    rep:= fail;
+  fi;
   if DescribesInvariantBilinearForm( Last( arg ) ) then
     form:= Remove( arg );
     if Length( arg ) = 0 then
       # ( [<filt>, ]<form> )
-      return SymplecticGroupCons( filt, form );
+      return SymplecticGroupCons( filt, form : ConstructingFilter:= rep );
     elif Length( arg ) = 2 and IsPosInt( arg[1] )
                            and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
       # ( [<filt>, ]<d>, <q>, <form> ) or ( [<filt>, ]<d>, <R>, <form> )
-      return SymplecticGroupCons( filt, arg[1], arg[2], form );
+      return SymplecticGroupCons( filt, arg[1], arg[2], form
+                                  : ConstructingFilter:= rep );
     fi;
   elif Length( arg ) = 2 and IsPosInt( arg[1] )
                          and ( IsPosInt( arg[2] ) or IsRing( arg[2] ) ) then
     # ( [<filt>, ]<d>, <q> ) or ( [<filt>, ]<d>, <R> )
-    return SymplecticGroupCons( filt, arg[1], arg[2] );
+    return SymplecticGroupCons( filt, arg[1], arg[2]
+                                : ConstructingFilter:= rep );
   fi;
   Error( "usage: SymplecticGroup( [<filt>, ]<d>, <q>[, <form>] )\n",
          "or SymplecticGroup( [<filt>, ]<d>, <R>[, <form>] )\n",

--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1161,11 +1161,21 @@ InstallTagBasedMethod( NewZeroVector,
 InstallTagBasedMethod( NewMatrix,
   Is8BitMatrixRep,
   function( filter, f, rl, l )
-    local m;
+    local len, m;
     if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");
     fi;
-    m := List(l,ShallowCopy);
+    # If applicable then replace a flat list 'l' by a nested list
+    # of lists of length 'rl'.
+    len:= Length( l );
+    if len > 0 and not IsList( l[1] ) then
+      if len mod rl <> 0 then
+        Error( "NewMatrix: Length of <l> is not a multiple of <rl>" );
+      fi;
+      m := List([0, rl .. len-rl], i -> l{[i+1..i+rl]});
+    else
+      m := List(l,ShallowCopy);
+    fi;
     ConvertToMatrixRep(m,Size(f));
     return m;
   end );

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2559,9 +2559,20 @@ InstallTagBasedMethod( NewZeroVector,
 InstallTagBasedMethod( NewMatrix,
   IsGF2MatrixRep,
   function( filter, f, rl, l )
-    local m;
+    local len, m;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
-    m := List(l,ShallowCopy);
+
+    # If applicable then replace a flat list 'l' by a nested list
+    # of lists of length 'rl'.
+    len:= Length( l );
+    if len > 0 and not IsList( l[1] ) then
+      if len mod rl <> 0 then
+        Error( "NewMatrix: Length of <l> is not a multiple of <rl>" );
+      fi;
+      m := List([0, rl .. len-rl], i -> l{[i+1..i+rl]});
+    else
+      m := List(l,ShallowCopy);
+    fi;
     ConvertToMatrixRep(m,2);
     return m;
   end );

--- a/lib/mat8bit.gd
+++ b/lib/mat8bit.gd
@@ -51,6 +51,8 @@ DeclareRepresentation( "Is8BitMatrixRep",
     and HasNumberRows and HasNumberColumns
     and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain);
 
+Add( ConstructingFiltersForMatrixGroupElements, Is8BitMatrixRep );
+
 
 #############################################################################
 ##

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -370,3 +370,14 @@ DeclareAttribute( "OneOfBaseDomain", IsVecOrMatObj );
 DeclareAttribute( "ZeroOfBaseDomain", IsVecOrMatObj );
 #DeclareAttribute( "ZeroOfBaseDomain", IsVectorObj );
 #DeclareAttribute( "ZeroOfBaseDomain", IsMatrixOrMatrixObj );
+
+
+#############################################################################
+##
+#V  ConstructingFiltersForMatrixGroupElements
+##
+##  This is a list of filters 'f' that are supported as the first argument
+##  of group constructors such as 'SymplecticGroup',
+##  meaning that one asks for a matrix group whose elements are in 'f'.
+##
+BIND_GLOBAL( "ConstructingFiltersForMatrixGroupElements", [] );

--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -376,8 +376,21 @@ DeclareAttribute( "ZeroOfBaseDomain", IsVecOrMatObj );
 ##
 #V  ConstructingFiltersForMatrixGroupElements
 ##
-##  This is a list of filters 'f' that are supported as the first argument
-##  of group constructors such as 'SymplecticGroup',
-##  meaning that one asks for a matrix group whose elements are in 'f'.
+##  <#GAPDoc Label="ConstructingFiltersForMatrixGroupElements">
+##  <ManSection>
+##  <Var Name="ConstructingFiltersForMatrixGroupElements"/>
+##
+##  <Description>
+##  This is a list of filters <C>f</C> that are supported as
+##  the first argument of group constructors such as
+##  <Ref Func="SymplecticGroup" Label="for dimension and a ring"/>,
+##  meaning that one asks for a matrix group whose elements are in <C>f</C>.
+##  <P/>
+##  If one creates a new representation of matrix objects such that it makes
+##  sense to create matrix groups from them then the underlying filter
+##  should be added to <Ref Var="ConstructingFiltersForMatrixGroupElements"/>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
 ##
 BIND_GLOBAL( "ConstructingFiltersForMatrixGroupElements", [] );

--- a/lib/matobjnz.gd
+++ b/lib/matobjnz.gd
@@ -98,3 +98,5 @@ DeclareRepresentation( "IsZmodnZMatrixRep",
     and HasNumberRows and HasNumberColumns
     and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
     [] );
+
+Add( ConstructingFiltersForMatrixGroupElements, IsZmodnZMatrixRep );

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -111,6 +111,7 @@ DeclareRepresentation( "IsPlistMatrixRep",
     and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
     [] );
 
+Add( ConstructingFiltersForMatrixGroupElements, IsPlistMatrixRep );
 
 # Some constants for matrix access:
 BindGlobal( "BDPOS", 1 );

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1116,11 +1116,21 @@ InstallTagBasedMethod( NewZeroVector,
 InstallTagBasedMethod( NewMatrix,
   Is8BitMatrixRep,
   function( filter, f, rl, l )
-    local m;
+    local len, m;
     if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");
     fi;
-    m := List(l,ShallowCopy);
+    # If applicable then replace a flat list 'l' by a nested list
+    # of lists of length 'rl'.
+    len:= Length( l );
+    if len > 0 and not IsList( l[1] ) then
+      if len mod rl <> 0 then
+        Error( "NewMatrix: Length of <l> is not a multiple of <rl>" );
+      fi;
+      m := List([0, rl .. len-rl], i -> l{[i+1..i+rl]});
+    else
+      m := List(l,ShallowCopy);
+    fi;
     ConvertToMatrixRep(m,Size(f));
     return m;
   end );

--- a/lib/vecmat.gd
+++ b/lib/vecmat.gd
@@ -260,6 +260,8 @@ DeclareRepresentation( "IsGF2MatrixRep",
     and HasNumberRows and HasNumberColumns
     and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain);
 
+Add( ConstructingFiltersForMatrixGroupElements, IsGF2MatrixRep );
+
 
 #############################################################################
 ##

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2557,9 +2557,20 @@ InstallTagBasedMethod( NewZeroVector,
 InstallTagBasedMethod( NewMatrix,
   IsGF2MatrixRep,
   function( filter, f, rl, l )
-    local m;
+    local len, m;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
-    m := List(l,ShallowCopy);
+
+    # If applicable then replace a flat list 'l' by a nested list
+    # of lists of length 'rl'.
+    len:= Length( l );
+    if len > 0 and not IsList( l[1] ) then
+      if len mod rl <> 0 then
+        Error( "NewMatrix: Length of <l> is not a multiple of <rl>" );
+      fi;
+      m := List([0, rl .. len-rl], i -> l{[i+1..i+rl]});
+    else
+      m := List(l,ShallowCopy);
+    fi;
     ConvertToMatrixRep(m,2);
     return m;
   end );

--- a/tst/testinstall/MatrixObj/Matrix.tst
+++ b/tst/testinstall/MatrixObj/Matrix.tst
@@ -22,6 +22,8 @@ gap> m := Matrix( IsGF2MatrixRep, GF(2), [[1,2],[3,4]] * Z(2) );
 gap> Display(m);
  1 .
  1 .
+gap> m = Matrix( IsGF2MatrixRep, GF(2), [1,2,3,4] * Z(2), 2 );
+true
 
 #
 gap> m := Matrix( Is8BitMatrixRep, GF(4), [[1,2],[3,4]] * Z(2) );
@@ -29,6 +31,8 @@ gap> m := Matrix( Is8BitMatrixRep, GF(4), [[1,2],[3,4]] * Z(2) );
 gap> Display(m);
  1 .
  1 .
+gap> m = Matrix( Is8BitMatrixRep, GF(4), [1,2,3,4] * Z(2), 2 );
+true
 
 #
 gap> m := Matrix( IsPlistMatrixRep, GF(2), [[1,2],[3,4]] * Z(2) );
@@ -38,6 +42,8 @@ gap> Display(m);
 [[ Z(2)^0, 0*Z(2) ]
  [ Z(2)^0, 0*Z(2) ]
 ]>
+gap> m = Matrix( IsPlistMatrixRep, GF(2), [1,2,3,4] * Z(2), 2 );
+true
 
 #
 gap> STOP_TEST("Matrix.tst");

--- a/tst/testinstall/grp/classic-S.tst
+++ b/tst/testinstall/grp/classic-S.tst
@@ -125,6 +125,18 @@ or SymplecticGroup( [<filt>, ]<d>, <R>[, <form>] )
 or SymplecticGroup( [<filt>, ]<form> )
 gap> Sp(4,6);
 Error, <subfield> must be a prime or a finite field
+gap> for para in [ [ IsGF2MatrixRep, GF(2) ],
+>                  [ Is8BitMatrixRep, GF(3) ],
+>      #           [ IsZmodnZMatrixRep, Integers mod 25 ], # not yet converted
+>                  [ IsPlistMatrixRep, GF(4) ] ] do
+>      f:= para[1];
+>      F:= para[2];
+>      G:= Sp( f, 4, F );
+>      if not f( G.1 ) or not f( InvariantBilinearForm( G ).matrix ) then
+>        Error( "wrong internal representation of matrices in Sp( ",
+>               f, ", 4, ", F, " )" );
+>      fi;
+>    od;
 
 #
 gap> SigmaL(3,5);


### PR DESCRIPTION
Up to now, we had to say
`SymplecticGroup( IsMatrixGroup, 4, GF(4) : ConstructingFilter:= IsPlistMatrixRep )`.

For the new syntax, introduce the global list `ConstructingFiltersForMatrixGroupElements`
and add the current MatrixObj filters to it.
That is, we derive from the fact that `IsPlistMatrixRep` is contained in `ConstructingFiltersForMatrixGroupElements` that `SymplecticGroup( IsPlistMatrixRep, 4, GF(4) )` asks for a matrix group.

If this approach is o.k. then I can document it, and change the code for more group constructions to use it.

(Three separate commits fix two `NewMatrix` methods, the situation that the matrix is given by a flat list was not handled before.)