### PR TITLE
Fix `CopySubVector` for GF(2) vectors to not produce invalid results for certain inputs

### DIFF
--- a/src/bits_intern.h
+++ b/src/bits_intern.h
@@ -120,7 +120,7 @@ static ALWAYS_INLINE void CopyBits(const UInt * fromblock,
                        (tobit - frombit));
             fromblock++;
             CopyInWord(toblock, 0, tailbits + frombit - 1 - BIPEB,
-                       fromblock[1], tobit + BIPEB - frombit);
+                       *fromblock, tobit + BIPEB - frombit);
             frombit += tailbits - BIPEB;
         }
         toblock++;

--- a/tst/testinstall/MatrixObj/CopySubVector.tst
+++ b/tst/testinstall/MatrixObj/CopySubVector.tst
@@ -1,4 +1,4 @@
-#@local l1, v1, l2, v2, v3, v4
+#@local l1, v1, l2, v2, v3, v4, x, src, dst, expected, from, to, len, one
 gap> START_TEST("CopySubVector.tst");
 
 #
@@ -22,6 +22,40 @@ gap> v4 := Vector(GF(5), l2*One(GF(5)));
 gap> CopySubVector( v3, v4, [1,2,3], [2,4,6] );
 gap> v4;
 [ Z(5)^0, Z(5)^0, Z(5)^0, Z(5), Z(5), Z(5)^3, Z(5)^3, Z(5)^3, Z(5)^3 ]
+
+#
+gap> x := IdentityMat(72, GF(2));;
+gap> src := x[72];;
+gap> dst := ZeroVector(9, x[1]);;
+gap> CopySubVector(src, dst, [64..71], [2..9]);
+gap> List(dst{[2..9]}, IntFFE);
+[ 0, 0, 0, 0, 0, 0, 0, 0 ]
+gap> src := x[64];;
+gap> dst := ZeroVector(9, x[1]);;
+gap> CopySubVector(src, dst, [63..70], [2..9]);
+gap> List(dst{[2..9]}, IntFFE);
+[ 0, 1, 0, 0, 0, 0, 0, 0 ]
+gap> src := x[65];;
+gap> dst := ZeroVector(9, x[1]);;
+gap> CopySubVector(src, dst, [64..71], [2..9]);
+gap> List(dst{[2..9]}, IntFFE);
+[ 0, 1, 0, 0, 0, 0, 0, 0 ]
+gap> one := One(GF(2));;
+gap> src := Vector(GF(2), List([1..80], i -> one));;
+gap> for from in [1,2,63,64,65] do
+> for to in [1,2,3,63,64,65] do
+> for len in [1,2,7,8,9,16] do
+>   dst := ZeroVector(90, src);;
+>   expected := ZeroVector(90, src);;
+>   CopySubVector(src, dst, [from..from+len-1], [to..to+len-1]);
+>   expected{[to..to+len-1]} := List([1..len], i -> one);
+>   if List(dst, IntFFE) <> List(expected, IntFFE) then
+>     Error("unexpected result for from=", from,
+>           ", to=", to, ", len=", len);
+>   fi;
+> od;
+> od;
+> od;
 
 #
 gap> STOP_TEST("CopySubVector.tst");


### PR DESCRIPTION
Fix the unaligned carry path in CopyBits so GF(2) section copies read the adjacent source word instead of skipping ahead at a word boundary.

Discovered while investigating https://github.com/gap-packages/recog/issues/343 -- it is one of the causes of that issue (@ThomasBreuer: who would have thought? puh).