### PR TITLE
Make MutableCopyMat slightly less 'obsolete'

### DIFF
--- a/lib/matrix.gd
+++ b/lib/matrix.gd
@@ -1565,6 +1565,23 @@ DeclareOperation( "MutableCopyMatrix", [ IsList ] );
 
 #############################################################################
 ##
+#O  MutableCopyMat( <mat> )
+##
+##  Declared obsolete in February 2023.
+##
+##  Still used in corelg, crisp, cryst, cubefree, cvec, fining, forms, genss,
+##  guava, hap, hapcryst, lpres, matricesforhomalg, modisom, polycyclic,
+##  recog, semigroups, smallsemi, sophus (02/2023)
+##
+##  (We cannot use 'DeclareObsoleteSynonym' because the cvec package wants to
+##  install a method for 'MutableCopyMat', thus 'MutableCopyMat' must be an
+##  operation.)
+##
+DeclareSynonym( "MutableCopyMat", MutableCopyMatrix );
+
+
+#############################################################################
+##
 #F  NullMat( <m>, <n> [, <R>] ) . . . . . . . . . null matrix of a given size
 ##
 ##  <#GAPDoc Label="NullMat">

--- a/lib/meatauto.gi
+++ b/lib/meatauto.gi
@@ -638,7 +638,7 @@ local nv, nw, F, zero, minusone, zeroW, gV, gW, k, U, echu, r, homs, s, work, an
           # create new element <x>, with its definition as the
           # difference between <v0^m> and <uu> in <U>.
           x:=v[i] * gV[j];
-          m:=MutableCopyMat(ag);
+          m:=MutableCopyMatrix(ag);
           ConvertToMatrixRep(m, F);
           uu:=u[i] * gV[j];
 

--- a/lib/obsolete.gd
+++ b/lib/obsolete.gd
@@ -251,23 +251,6 @@ DeclareObsoleteSynonym( "RadicalGroup", "SolvableRadical" );
 
 #############################################################################
 ##
-#O  MutableCopyMat( <mat> )
-##
-##  Moved to obsoletes in February 2023.
-##
-##  Still used in corelg, crisp, cryst, cubefree, cvec, fining, forms, genss,
-##  guava, hap, hapcryst, lpres, matricesforhomalg, modisom, polycyclic,
-##  recog, semigroups, smallsemi, sophus (02/2023)
-##
-##  (We cannot use 'DeclareObsoleteSynonym' because the cvec package wants to
-##  install a method for 'MutableCopyMat', thus 'MutableCopyMat' must be an
-##  operation.)
-##
-DeclareSynonym( "MutableCopyMat", MutableCopyMatrix );
-
-
-#############################################################################
-##
 #F  SCRSiftOld( <S>, <g> )
 ##
 ##  Moved to obsoletes in August 2025.


### PR DESCRIPTION
By having the synonym in lib/obsolete.gd, it is not loaded when
the -O option is passed to GAP. But tons of packages still use it
(and frankly I am not sure it is worth the effort to change this,
considering it breaks compatibility with older GAP versions for no
good reason). Anyway: let's move the synonym declaration out there
to make -O less problematic again.

Also change one accidental use of MutableCopyMat in the library
that recently slipped in (my fault). It would not have happened if
we had a test using `-O`; this PR is a step towards that by
reducing the number of errors the option causes.
