### PR TITLE
Let `ObjWithMemory` transfer `IsRowListMatrix` filter

### DIFF
--- a/lib/memory.gi
+++ b/lib/memory.gi
@@ -30,6 +30,9 @@ BindGlobal( "ObjWithMemory", function( slp, n, el )
     if IsMatrixObj( el ) then
       filt:= filt and IsMatrixObj;
     fi;
+    if IsRowListMatrix( el ) then
+      filt:= filt and IsRowListMatrix;
+    fi;
     if HasBaseDomain( el ) then
       filt:= filt and HasBaseDomain;
     fi;

--- a/tst/testinstall/memory.tst
+++ b/tst/testinstall/memory.tst
@@ -6,6 +6,12 @@ gap> START_TEST( "memory.tst" );
 gap> G := GroupWithMemory([ (1,2,3,4,5), (1,2) ]);;
 gap> H := GroupWithMemory(GL(IsMatrixGroup, 3, 3));;
 gap> g := H.1 ^ 2;; h := H.2 ^ 2;;
+gap> IsMatrix(g);
+true
+gap> IsMatrixObj(g);
+true
+gap> IsRowListMatrix(g);
+true
 gap> StripMemory(g);
 [ [ Z(3)^0, 0*Z(3), 0*Z(3) ], [ 0*Z(3), Z(3)^0, 0*Z(3) ], 
   [ 0*Z(3), 0*Z(3), Z(3)^0 ] ]


### PR DESCRIPTION
Some code has optimizations for IsRowListMatrix matrices. It is desirable to benefit from them even for matrices-with-memory if possible, which this patch ensures.