### PR TITLE
Add `PositionNonZeroInRow` for matrices and matrix objects

### DIFF
--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -219,6 +219,7 @@ All rows of a matrix must have the same length and the same base domain.
 <#Include Label="AddMatrixRowsRight">
 <#Include Label="AddMatrixColumns">
 <#Include Label="AddMatrixColumnsLeft">
+<#Include Label="PositionNonZeroInRow">
 <#Include Label="SwapMatrixRows">
 <#Include Label="SwapMatrixColumns">
 <#Include Label="AddMatrix">

--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -1865,6 +1865,46 @@ InstallEarlyMethod( AddMatrixColumnsLeft,
 
 ############################################################################
 
+InstallMethod( PositionNonZeroInRow,
+  "for a row list matrix and a row number",
+  [ IsRowListMatrix, IsPosInt ],
+  function( mat, row )
+    return PositionNonZero( mat[row] );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a row list matrix, a row number, and a start position",
+  [ IsRowListMatrix, IsPosInt, IsInt ],
+  function( mat, row, from )
+    return PositionNonZero( mat[row], from );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a matrix or matrix object and a row number",
+  [ IsMatrixOrMatrixObj, IsPosInt ],
+  function( mat, row )
+    return PositionNonZeroInRow( mat, row, 0 );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  "for a matrix or matrix object, a row number, and a start position",
+  [ IsMatrixOrMatrixObj, IsPosInt, IsInt ],
+  function( mat, row, from )
+    local col, ncols, zero;
+
+    ncols := NrCols( mat );
+    zero := ZeroOfBaseDomain( mat );
+    for col in [ Maximum( 1, from + 1 ) .. ncols ] do
+      if mat[row, col] <> zero then
+        return col;
+      fi;
+    od;
+
+    return ncols + 1;
+  end );
+
+############################################################################
+
 InstallMethod( SwapMatrixRows, "for a mutable matrix object, and two row numbers",
   [ IsMatrixOrMatrixObj and IsMutable, IsInt, IsInt ],
   function( mat, row1, row2 )

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -2021,6 +2021,27 @@ DeclareOperation( "AddMatrixColumnsLeft", [ IsMatrixOrMatrixObj and IsMutable, I
 
 ############################################################################
 ##
+##  <#GAPDoc Label="PositionNonZeroInRow">
+##  <ManSection>
+##  <Oper Name="PositionNonZeroInRow" Arg='M,i[,from]'/>
+##
+##  <Returns>a positive integer</Returns>
+##
+##  <Description>
+##  <P/>
+##  Returns the position of the first nonzero entry in the <A>i</A>-th row of
+##  the matrix <A>M</A>, or <C>NrCols( M ) + 1</C> if the row is zero.
+##  If the optional argument <A>from</A> is given, the search starts after
+##  position <A>from</A>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "PositionNonZeroInRow", [ IsMatrixOrMatrixObj, IsPosInt ] );
+DeclareOperation( "PositionNonZeroInRow", [ IsMatrixOrMatrixObj, IsPosInt, IsInt ] );
+
+############################################################################
+##
 ##  <#GAPDoc Label="SwapMatrixRows">
 ##  <ManSection>
 ##  <Oper Name="SwapMatrixRows" Arg='M,i,j'/>

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -174,14 +174,16 @@ InstallMethod( IsDiagonalMatrix,
     "for a matrix",
     [ IsMatrixOrMatrixObj ],
     function( mat )
-    local  i, j, z;
-    z:=ZeroOfBaseDomain(mat);
+    local i, ncols, p;
+    ncols := NrCols( mat );
     for i  in [ 1 .. NrRows( mat ) ]  do
-        for j  in [ 1 .. NrCols( mat ) ]  do
-            if mat[i,j] <> z and i <> j  then
-                return false;
-            fi;
-        od;
+        p := PositionNonZeroInRow( mat, i );
+        if p <= ncols and p <> i then
+            return false;
+        fi;
+        if PositionNonZeroInRow( mat, i, i ) <= ncols then
+            return false;
+        fi;
     od;
     return true;
     end);
@@ -215,14 +217,13 @@ InstallMethod( IsUpperTriangularMatrix,
     "for a matrix",
     [ IsMatrixOrMatrixObj ],
     function( mat )
-    local  i, j, z;
-    z:=ZeroOfBaseDomain(mat);
-    for j  in [ 1 .. NrCols( mat ) ]  do
-        for i  in [ j+1 .. NrRows( mat ) ]  do
-            if mat[i,j] <> z  then
-                return false;
-            fi;
-        od;
+    local i, ncols, p;
+    ncols := NrCols( mat );
+    for i in [ 1 .. NrRows( mat ) ] do
+        p := PositionNonZeroInRow( mat, i );
+        if p <= ncols and p < i then
+            return false;
+        fi;
     od;
     return true;
     end);
@@ -236,14 +237,12 @@ InstallMethod( IsLowerTriangularMatrix,
     "for a matrix",
     [ IsMatrixOrMatrixObj ],
     function( mat )
-    local  i, j, z;
-    z:=ZeroOfBaseDomain(mat);
+    local i, ncols;
+    ncols := NrCols( mat );
     for i  in [ 1 .. NrRows( mat ) ]  do
-        for j  in [ i+1 .. NrCols( mat ) ]  do
-            if mat[i,j] <> z  then
-                return false;
-            fi;
-        od;
+        if PositionNonZeroInRow( mat, i, i ) <= ncols then
+            return false;
+        fi;
     od;
     return true;
     end);

--- a/tst/testinstall/MatrixObj/ElementaryMatrices.tst
+++ b/tst/testinstall/MatrixObj/ElementaryMatrices.tst
@@ -67,6 +67,39 @@ true
 gap> TestElementaryTransforms( mat, -1 );
 gap> TestWholeMatrixTransforms( mat, -1 );
 
+#
+gap> TestPositionNonZeroInRow([ [ 1 ] ]);
+gap> TestPositionNonZeroInRow(Matrix([ [ 1 ] ]));
+gap> TestPositionNonZeroInRow(Matrix(GF(2), [ [ 1 ] ] * Z(2)));
+gap> TestPositionNonZeroInRow(Matrix(GF(5), [ [ 1 ] ] * Z(5)^0));
+
+#
+gap> mat := Matrix([ [ 1, 0, 0 ], [ 0, 2, 0 ] ]);;
+gap> IsDiagonalMatrix(mat);
+true
+gap> IsUpperTriangularMatrix(mat);
+true
+gap> IsLowerTriangularMatrix(mat);
+true
+
+#
+gap> mat := Matrix([ [ 1, 2, 0 ], [ 0, 3, 0 ] ]);;
+gap> IsDiagonalMatrix(mat);
+false
+gap> IsUpperTriangularMatrix(mat);
+true
+gap> IsLowerTriangularMatrix(mat);
+false
+
+#
+gap> mat := Matrix([ [ 1, 0, 0 ], [ 4, 3, 0 ] ]);;
+gap> IsDiagonalMatrix(mat);
+false
+gap> IsUpperTriangularMatrix(mat);
+false
+gap> IsLowerTriangularMatrix(mat);
+true
+
 ##########
 #
 gap> mat := Matrix( [[2,4,5],[7,11,-4],[-3,20,0]]);;

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -251,3 +251,30 @@ TestWholeMatrixTransforms := function(mat, scalar)
     MultMatrix(copy, scalar);
     if not same_entries(mat, copy) then Error("MultMatrix(", scalar, ") failure"); fi;
 end;
+
+TestPositionNonZeroInRow := function(mat)
+    local ncols;
+
+    # Make a matrix with specific patter of the same kind as mat
+    mat := Matrix([ [ 0, 1, 0, 1 ], [ 0, 0, 0, 0 ], [ 0, 0, 1, 0 ] ], mat);
+
+    ncols := NrCols(mat);
+    if PositionNonZeroInRow(mat, 1) <> 2 then
+        Error("PositionNonZeroInRow(_,1) failure");
+    fi;
+    if PositionNonZeroInRow(mat, 1, 2) <> 4 then
+        Error("PositionNonZeroInRow(_,1,2) failure");
+    fi;
+    if PositionNonZeroInRow(mat, 1, 4) <> ncols + 1 then
+        Error("PositionNonZeroInRow(_,1,4) failure");
+    fi;
+    if PositionNonZeroInRow(mat, 2) <> ncols + 1 then
+        Error("PositionNonZeroInRow(_,2) zero-row failure");
+    fi;
+    if PositionNonZeroInRow(mat, 3) <> 3 then
+        Error("PositionNonZeroInRow(_,3) failure");
+    fi;
+    if PositionNonZeroInRow(mat, 3, 3) <> ncols + 1 then
+        Error("PositionNonZeroInRow(_,3,3) failure");
+    fi;
+end;


### PR DESCRIPTION
Use it in the generic diagonal and triangular predicates.

Resolves #6231

Co-authored-by: Codex <codex@openai.com>
