### PR TITLE
Declare NumberRows and NumberColumns as kernel attributes

### DIFF
--- a/lib/matobj1.gd
+++ b/lib/matobj1.gd
@@ -321,11 +321,13 @@ DeclareAttribute( "BaseDomain", IsVecOrMatObj );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareAttribute( "NumberRows", IsMatrixOrMatrixObj );
+DeclareAttributeKernel( "NumberRows", IsMatrixOrMatrixObj, NUMBER_ROWS );
 DeclareSynonymAttr( "NrRows", NumberRows );
+InstallTrueMethod( HasNumberRows, IsMatrixOrMatrixObj and IsPlistRep);
 
-DeclareAttribute( "NumberColumns", IsMatrixOrMatrixObj );
+DeclareAttributeKernel( "NumberColumns", IsMatrixOrMatrixObj, NUMBER_COLUMNS );
 DeclareSynonymAttr( "NrCols", NumberColumns );
+InstallTrueMethod( HasNumberColumns, IsMatrixOrMatrixObj and IsPlistRep );
 
 
 #############################################################################

--- a/src/lists.c
+++ b/src/lists.c
@@ -81,6 +81,8 @@ BOOL (*IsSmallListFuncs[LAST_REAL_TNUM + 1])(Obj obj);
 static Obj IsSmallListFilt;
 static Obj HasIsSmallListFilt;
 static Obj LengthAttr;
+static Obj NumberRowsAttr;
+static Obj NumberColumnsAttr;
 static Obj SetIsSmallList;
 
 static BOOL IsSmallListObject(Obj obj)
@@ -160,6 +162,41 @@ static Obj AttrLENGTH(Obj self, Obj list)
     else {
         return DoAttribute( LengthAttr, list );
     }
+}
+
+
+/****************************************************************************
+**
+*F  AttrNUMBER_ROWS( <self>, <mat> )  . . . . . .  'NumberRows' interface
+*/
+static Obj AttrNUMBER_ROWS(Obj self, Obj mat)
+{
+    if (IS_PLIST(mat)) {
+        return ObjInt_Int(LEN_PLIST(mat));
+    }
+
+    return DoAttribute(NumberRowsAttr, mat);
+}
+
+
+/****************************************************************************
+**
+*F  AttrNUMBER_COLUMNS( <self>, <mat> ) . . . .  'NumberColumns' interface
+*/
+static Obj AttrNUMBER_COLUMNS(Obj self, Obj mat)
+{
+    if (IS_PLIST(mat)) {
+        if (LEN_PLIST(mat) == 0) {
+            return INTOBJ_INT(0);
+        }
+
+        Obj row = ELM_PLIST(mat, 1);
+        if (row != 0) {
+            return AttrLENGTH(LengthAttr, row);
+        }
+    }
+
+    return DoAttribute(NumberColumnsAttr, mat);
 }
 
 
@@ -1874,6 +1911,8 @@ static StructGVarFilt GVarFilts [] = {
 static StructGVarAttr GVarAttrs [] = {
 
     GVAR_ATTR(LENGTH, "list", &LengthAttr),
+    GVAR_ATTR(NUMBER_ROWS, "mat", &NumberRowsAttr),
+    GVAR_ATTR(NUMBER_COLUMNS, "mat", &NumberColumnsAttr),
     { 0, 0, 0, 0, 0 }
 
 };

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -114,6 +114,10 @@ false
 
 #
 gap> m := Z(5)^0 * [[0, 1], [1, 0]];;
+gap> HasNumberRows(m);
+true
+gap> HasNumberColumns(m);
+true
 gap> m := GeneratorsWithMemory([m])[1];;
 gap> BaseDomain(m) = GF(5);
 true


### PR DESCRIPTION
... and provide optimized kernel methods for plist matrices

Before:

    gap> m:=IdentityMat(4500);; List([1..10000], i -> NrRows(m));; time;
    2044
    gap> m:=IdentityMatrix(GF(2), 4500);; List([1..10000], i -> NrRows(m));; time;
    1
    gap> m:=IdentityMatrix(GF(37), 4500);; List([1..10000], i -> NrRows(m));; time;
    1
    gap> m:=IdentityMatrix(Rationals, 4500);; List([1..10000], i -> NrRows(m));; time;
    1

After:

    gap> m:=IdentityMat(4500);; List([1..10000], i -> NrRows(m));; time;
    1
    gap> m:=IdentityMatrix(GF(2), 4500);; List([1..10000], i -> NrRows(m));; time;
    1
    gap> m:=IdentityMatrix(GF(37), 4500);; List([1..10000], i -> NrRows(m));; time;
    1
    gap> m:=IdentityMatrix(Rationals, 4500);; List([1..10000], i -> NrRows(m));; time;
    1

Co-authored-by: Codex <codex@openai.com>
