### PR TITLE
Add `IsGenericMatrixRep` matrix object type

### DIFF
--- a/benchmark/matobj/bench-matelm-access.g
+++ b/benchmark/matobj/bench-matelm-access.g
@@ -136,17 +136,23 @@ RunMatTest := function(desc, m)
     TestWritingMatrix(m);
 end;
 
-m:=IdentityMat(10);;
-RunMatTest("integer matrix", m);
+m:=IdentityMat(10,GF(257));;    # plain list of plain lists
+RunMatTest("GF(257) plist-of-plist matrix", m);
 
-m:=IdentityMat(10,GF(2));;
+m:=IdentityMatrix(GF(257), 10); # IsPlistMatrixRep
+RunMatTest("GF(257) IsPlistMatrixRep", m);
+
+m:=IdentityMatrix(GF(257), 10); # IsGenericMatrixRep
+RunMatTest("GF(257) IsGenericMatrixRep", m);
+
+m:=IdentityMat(10,GF(2));;      # plain list of IsGF2VectorRep
 RunMatTest("GF(2) rowlist", m);
 
-m:=IdentityMat(10,GF(2));; ConvertToMatrixRep(m);;
+m:=IdentityMatrix(GF(2), 10);   # IsGF2MatrixRep
 RunMatTest("GF(2) compressed matrix", m);
 
-m:=IdentityMat(10,GF(7));;
+m:=IdentityMat(10,GF(7));;      # plain list of Is8BitVectorRep
 RunMatTest("GF(7) rowlist", m);
 
-m:=IdentityMat(10,GF(7));; ConvertToMatrixRep(m);;
+m:=IdentityMatrix(GF(7), 10);   # Is8BitMatrixRep
 RunMatTest("GF(7) compressed matrix", m);

--- a/benchmark/matobj/bench-matobj-creation.g
+++ b/benchmark/matobj/bench-matobj-creation.g
@@ -91,18 +91,23 @@ RunMatTest := function(desc, ring)
     TestCreatingMatrix(ring);
 end;
 
-RunMatTest("GF(2)", GF(2));
-RunMatTest("Rationals", Rationals);
-
 RunMatObjTest := function(desc, filter, ring)
     Print("\n");
     PrintBoxed(Concatenation("Testing ", desc));
     TestCreatingMatrixObj(filter, ring);
 end;
 
-RunMatObjTest("GF(2) IsPlistMatrixRep", IsPlistMatrixRep, GF(2));
+RunMatTest("GF(257)", GF(257));
+RunMatObjTest("GF(257) IsPlistMatrixRep", IsPlistMatrixRep, GF(257));
+RunMatObjTest("GF(257) IsGenericMatrixRep", IsGenericMatrixRep, GF(257));
+
+RunMatTest("Integers", Integers);
 RunMatObjTest("integer IsPlistMatrixRep", IsPlistMatrixRep, Integers);
+RunMatObjTest("integer IsGenericMatrixRep", IsGenericMatrixRep, Integers);
+
+RunMatTest("Rationals", Rationals);
 RunMatObjTest("rational IsPlistMatrixRep", IsPlistMatrixRep, Rationals);
+RunMatObjTest("rational IsGenericMatrixRep", IsGenericMatrixRep, Rationals);
 
 # TODO: other reps
 # TODO: other compare with creating plist-of-plist

--- a/doc/ref/makedocreldata.g
+++ b/doc/ref/makedocreldata.g
@@ -119,6 +119,7 @@ GAPInfo.ManualDataRef:= rec(
     "../../lib/matobj2.gd",
     "../../lib/matobjnz.gd",
     "../../lib/matobjplist.gd",
+    "../../lib/matobjgeneric.gd",
     "../../lib/matrix.gd",
     "../../lib/meataxe.gi",
     "../../lib/memory.gd",

--- a/doc/ref/matobj.xml
+++ b/doc/ref/matobj.xml
@@ -374,6 +374,7 @@ described in this chapter is supported.
 <#Include Label="IsGF2MatrixRep">
 <#Include Label="Is8BitMatrixRep">
 <#Include Label="IsPlistMatrixRep">
+<#Include Label="IsGenericMatrixRep">
 <#Include Label="IsZmodnZMatrixRep">
 
 </Section>

--- a/lib/matobjgeneric.gd
+++ b/lib/matobjgeneric.gd
@@ -1,0 +1,55 @@
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+
+############################################################################
+#
+# Dense matrix objects backed by plain lists of plain row lists.
+#
+
+#############################################################################
+##
+##  <#GAPDoc Label="IsGenericMatrixRep">
+##  <ManSection>
+##  <Filt Name="IsGenericMatrixRep" Arg='obj' Type="Representation"/>
+##
+##  <Description>
+##  An object <A>obj</A> in <Ref Filt="IsGenericMatrixRep"/> describes
+##  a matrix object (see <Ref Filt="IsMatrixObj"/>) whose entries are stored
+##  as a dense plain list of dense plain row lists.
+##  <P/>
+##  Unlike <Ref Filt="IsPlistMatrixRep"/>, this representation is not a row
+##  list matrix, so direct row access via <M>M[i]</M> is not supported.
+##  Instead, it is intended as the general-purpose representation for
+##  matrix objects.
+##  <P/>
+##  This representation supports the usual matrix operations and is often more
+##  efficient than <Ref Filt="IsPlistMatrixRep"/>. If existing code uses row
+##  access, it is often possible to replace this by the operations from
+##  Section <Ref Sect="Basic operations for row/column reductions"/>.
+##  <P/>
+##  Use <Ref Filt="IsPlistMatrixRep"/> instead if you need the rows to be
+##  available as vector objects in <Ref Filt="IsPlistVectorRep"/>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareRepresentation( "IsGenericMatrixRep",
+        IsMatrixObj and IsPositionalObjectRep
+    and IsCopyable
+    and IsNoImmediateMethodsObject
+    and HasNumberRows and HasNumberColumns
+    and HasBaseDomain and HasOneOfBaseDomain and HasZeroOfBaseDomain,
+    [] );
+
+
+# Internal positions for IsGenericMatrixRep:
+BindConstant( "GEN_MAT_REP_BASEDOMAIN_POS", 1 ); # BaseDomain
+BindConstant( "GEN_MAT_REP_NCOLS_POS", 2 ); # number of columns (needed to represent 0 x m matrices)
+BindConstant( "GEN_MAT_REP_ROWS_POS", 3 ); # "rows" as a plist-of-plists

--- a/lib/matobjgeneric.gi
+++ b/lib/matobjgeneric.gi
@@ -1,0 +1,480 @@
+#############################################################################
+##
+##  This file is part of GAP, a system for computational discrete algebra.
+##
+##  SPDX-License-Identifier: GPL-2.0-or-later
+##
+##  Copyright of GAP belongs to its developers, whose names are too numerous
+##  to list here. Please refer to the COPYRIGHT file for details.
+##
+
+############################################################################
+#
+# Dense matrix objects backed by plain lists of plain row lists.
+#
+
+BindGlobal( "MakeIsGenericMatrixRep",
+  function( basedomain, ncols, list, check )
+    local efam, fam, filter, typ, row;
+    efam := ElementsFamily( FamilyObj( basedomain ) );
+    fam := CollectionsFamily( FamilyObj( basedomain ) );
+
+    # Currently there is no special handling depending on 'basedomain',
+    # the types are always cached in 'fam'.
+    if not IsBound( fam!.GenericMatrixRepTypes ) then
+      # initialize type cache
+      # TODO: make this thread safe for HPC-GAP
+      filter := IsGenericMatrixRep;
+      if CanEasilyCompareElementsFamily( efam ) then
+        filter := filter and CanEasilyCompareElements;
+      fi;
+      fam!.GenericMatrixRepTypes := [
+          NewType( fam, filter ),
+          NewType( fam, filter and IsMutable ),
+      ];
+    fi;
+    if IsMutable( list ) then
+      typ := fam!.GenericMatrixRepTypes[2];
+    else
+      typ := fam!.GenericMatrixRepTypes[1];
+    fi;
+
+    if check and ValueOption( "check" ) <> false then
+      Assert( 0, IsPlistRep( list ) );
+      for row in list do
+        if not IsPlistRep( row ) then
+          Error( "the entries of <list> must be plain lists" );
+        elif Length( row ) <> ncols then
+          Error( "the entries of <list> must have length <ncols>" );
+        elif not IsSubset( basedomain, row ) then
+          Error( "the elements in <list> must lie in <basedomain>" );
+        fi;
+      od;
+    fi;
+
+    return Objectify( typ, [ basedomain, ncols, list ] );
+  end );
+
+
+InstallTagBasedMethod( NewMatrix,
+  IsGenericMatrixRep,
+  function( filter, basedomain, ncols, list )
+    local nd, rows, i, row;
+
+    if Length( list ) > 0 and not IsVectorObj( list[1] ) then
+      nd := NestingDepthA( list );
+      if nd < 2 or nd mod 2 = 1 then
+        if Length( list ) mod ncols <> 0 then
+          Error( "NewMatrix: Length of <list> is not a multiple of <ncols>" );
+        fi;
+        list := List( [ 0, ncols .. Length( list ) - ncols ],
+                      i -> list{ [ i + 1 .. i + ncols ] } );
+      fi;
+    fi;
+
+    rows := EmptyPlist( Length( list ) );
+    for i in [ 1 .. Length( list ) ] do
+      row := list[i];
+      if IsVectorObj( row ) then
+        rows[i] := Unpack( row );
+      else
+        rows[i] := PlainListCopy( row );
+      fi;
+    od;
+    return MakeIsGenericMatrixRep( basedomain, ncols, rows, true );
+  end );
+
+
+InstallTagBasedMethod( NewZeroMatrix,
+  IsGenericMatrixRep,
+  function( filter, basedomain, rows, cols )
+    local list, row, i, z;
+    list := EmptyPlist( rows );
+    z := Zero( basedomain );
+    for i in [ 1 .. rows ] do
+      row := ListWithIdenticalEntries( cols, z );
+      list[i] := row;
+    od;
+    return MakeIsGenericMatrixRep( basedomain, cols, list, false );
+  end );
+
+
+InstallMethod( ConstructingFilter,
+  [ "IsGenericMatrixRep" ],
+  M -> IsGenericMatrixRep );
+
+InstallMethod( CompatibleVectorFilter,
+  [ "IsGenericMatrixRep" ],
+  M -> IsPlistVectorRep );
+
+
+InstallMethod( BaseDomain,
+  [ "IsGenericMatrixRep" ],
+  M -> M![GEN_MAT_REP_BASEDOMAIN_POS] );
+
+InstallMethod( NumberRows,
+  [ "IsGenericMatrixRep" ],
+  M -> Length( M![GEN_MAT_REP_ROWS_POS] ) );
+
+InstallMethod( NumberColumns,
+  [ "IsGenericMatrixRep" ],
+  M -> M![GEN_MAT_REP_NCOLS_POS] );
+
+InstallMethod( \[\],
+  [ "IsGenericMatrixRep", "IsPosInt" ],
+  function( M, pos )
+    ErrorNoReturn( "row access unsupported; use M[i,j] or RowsOfMatrix(M)" );
+  end );
+
+InstallMethod( MatElm,
+  [ "IsGenericMatrixRep", "IsPosInt", "IsPosInt" ],
+  { M, row, col } -> M![GEN_MAT_REP_ROWS_POS][row,col] );
+
+InstallMethod( SetMatElm,
+  [ "IsGenericMatrixRep and IsMutable", "IsPosInt", "IsPosInt", "IsObject" ],
+  function( M, row, col, val )
+    if ValueOption( "check" ) <> false then
+      if not val in BaseDomain( M ) then
+        Error( "<val> must lie in the base domain of <M>" );
+      elif not row in [ 1 .. NrRows( M ) ] then
+        Error( "<row> is out of bounds" );
+      elif not col in [ 1 .. NrCols( M ) ] then
+        Error( "<col> is out of bounds" );
+      fi;
+    fi;
+    M![GEN_MAT_REP_ROWS_POS][row,col] := val;
+  end );
+
+
+InstallMethod( Unpack,
+  [ "IsGenericMatrixRep" ],
+  M -> List( M![GEN_MAT_REP_ROWS_POS], ShallowCopy ) );
+
+InstallMethod( ShallowCopy,
+  [ "IsGenericMatrixRep" ],
+  M -> MakeIsGenericMatrixRep( BaseDomain(M), NrCols(M),
+           List( M![GEN_MAT_REP_ROWS_POS], ShallowCopy ), false ) );
+
+InstallMethod( MutableCopyMatrix,
+  [ "IsGenericMatrixRep" ],
+  M -> MakeIsGenericMatrixRep( BaseDomain(M), NrCols(M),
+           List( M![GEN_MAT_REP_ROWS_POS], ShallowCopy ), false ) );
+
+InstallMethod( ExtractSubMatrix,
+  [ "IsGenericMatrixRep", "IsList", "IsList" ],
+  function( M, rowspos, colspos )
+    local list;
+    list := M![GEN_MAT_REP_ROWS_POS]{ rowspos }{ colspos };
+    return MakeIsGenericMatrixRep( BaseDomain(M), Length( colspos ), list, false );
+  end );
+
+InstallMethod( CopySubMatrix,
+  [ "IsGenericMatrixRep", "IsGenericMatrixRep and IsMutable",
+    "IsList", "IsList", "IsList", "IsList" ],
+  function( M, N, srcrows, dstrows, srccols, dstcols )
+    if ValueOption( "check" ) <> false and
+       not IsIdenticalObj( BaseDomain(M), BaseDomain(N) ) then
+      Error( "<M> and <N> are not compatible" );
+    fi;
+    N![GEN_MAT_REP_ROWS_POS]{dstrows}{dstcols} := M![GEN_MAT_REP_ROWS_POS]{srcrows}{srccols};
+  end );
+
+InstallMethod( TransposedMatMutable,
+  [ "IsGenericMatrixRep" ],
+  function( M )
+    local list;
+    list := TransposedMatMutable(M![GEN_MAT_REP_ROWS_POS]);
+    return MakeIsGenericMatrixRep( BaseDomain(M), NrRows(M), list, false );
+  end );
+
+InstallMethod( \+,
+  [ "IsGenericMatrixRep", "IsGenericMatrixRep" ],
+  function( a, b )
+    if ValueOption( "check" ) <> false and
+       ( not IsIdenticalObj( BaseDomain( a ), BaseDomain( b ) ) or
+         NrRows( a ) <> NrRows( b ) or
+         NrCols( a ) <> NrCols( b ) ) then
+      Error( "<a> and <b> are not compatible" );
+    fi;
+    return MakeIsGenericMatrixRep( BaseDomain( a ), NrCols( a ),
+               a![GEN_MAT_REP_ROWS_POS] + b![GEN_MAT_REP_ROWS_POS], false );
+  end );
+
+InstallMethod( \-,
+  [ "IsGenericMatrixRep", "IsGenericMatrixRep" ],
+  function( a, b )
+    if ValueOption( "check" ) <> false and
+       ( not IsIdenticalObj( BaseDomain( a ), BaseDomain( b ) ) or
+         NrRows( a ) <> NrRows( b ) or
+         NrCols( a ) <> NrCols( b ) ) then
+      Error( "<a> and <b> are not compatible" );
+    fi;
+    return MakeIsGenericMatrixRep( BaseDomain( a ), NrCols( a ),
+               a![GEN_MAT_REP_ROWS_POS] - b![GEN_MAT_REP_ROWS_POS], false );
+  end );
+
+InstallMethod( AdditiveInverseMutable,
+  [ "IsGenericMatrixRep" ],
+  M -> MakeIsGenericMatrixRep( BaseDomain( M ), NrCols( M ),
+           AdditiveInverseMutable( M![GEN_MAT_REP_ROWS_POS] ), false ) );
+
+InstallMethod( ZeroMutable,
+  [ "IsGenericMatrixRep" ],
+  function( M )
+    local z;
+    z := MakeIsGenericMatrixRep( BaseDomain( M ), NrCols( M ),
+             ZeroMutable( M![GEN_MAT_REP_ROWS_POS] ), false );
+    return z;
+  end );
+
+InstallMethod( InverseMutable,
+  [ "IsGenericMatrixRep" ],
+  function( M )
+    local bd, rows;
+
+    bd := BaseDomain( M );
+    if NrRows( M ) <> NrCols( M ) then
+      ErrorNoReturn( "InverseMutable: matrix must be square" );
+    elif NrRows( M ) = 0 then
+      rows := [];
+    elif IsFinite( bd ) and IsField( bd ) then
+      rows := INV_MAT_DEFAULT_MUTABLE( M![GEN_MAT_REP_ROWS_POS] );
+    else
+      rows := INV_MATRIX_MUTABLE( M![GEN_MAT_REP_ROWS_POS] );
+    fi;
+    if rows = fail then
+      return fail;
+    fi;
+    return MakeIsGenericMatrixRep( bd, NrCols( M ), rows, false );
+  end );
+
+InstallMethod( \*,
+  [ "IsGenericMatrixRep", "IsGenericMatrixRep" ],
+  function( a, b )
+    local rowsA, colsA, rowsB, colsB, bd, list, i;
+
+    rowsA := NumberRows( a );
+    colsA := NumberColumns( a );
+    rowsB := NumberRows( b );
+    colsB := NumberColumns( b );
+    bd := BaseDomain( a );
+
+    if ValueOption( "check" ) <> false then
+      if colsA <> rowsB then
+        ErrorNoReturn( "\\*: Matrices do not fit together" );
+      elif not IsIdenticalObj( bd, BaseDomain( b ) ) then
+        ErrorNoReturn( "\\*: Matrices not over same base domain" );
+      fi;
+    fi;
+
+    if rowsA = 0 or colsB = 0 then
+      list := [];
+    elif colsA = 0 then  # colsA = rowsB
+      list := EmptyPlist( rowsA );
+      for i in [ 1 .. rowsA ] do
+        list[i] := ListWithIdenticalEntries( colsB, Zero( bd ) );
+      od;
+    else
+      list := a![GEN_MAT_REP_ROWS_POS] * b![GEN_MAT_REP_ROWS_POS];
+    fi;
+    return MakeIsGenericMatrixRep( bd, colsB, list, false );
+  end );
+
+InstallOtherMethod( \*,
+  [ "IsGenericMatrixRep", "IsRowVectorOrVectorObj" ],
+  {} -> RankFilter(IsPlistVectorRep),  # rank above method for [IsScalar, IsPlistVectorRep]
+  function( M, v )
+    local rows, cols, bd, res;
+
+    rows := NumberRows( M );
+    cols := NumberColumns( M );
+    bd := BaseDomain( M );
+
+    if ValueOption( "check" ) <> false then
+      if cols <> Length( v ) then
+        Error( "<M> and <v> are not compatible" );
+      elif not IsIdenticalObj( bd, BaseDomain( v ) ) then
+        Error( "<M> and <v> are not compatible" );
+      fi;
+    fi;
+
+    # special case for empty matrices
+    if rows = 0 or cols = 0 then
+      return ZeroVector( rows, v );
+    fi;
+
+    # "unpack" cheaply and then delegate to kernel implementation
+    if IsPlistVectorRep(v) then
+      res := v![ELSPOS];
+    elif IsList(v) then
+      res := v;
+    else
+      res := Unpack(v);
+    fi;
+    res := M![GEN_MAT_REP_ROWS_POS] * res;
+    return Vector( res, v );
+  end );
+
+InstallOtherMethod( \*,
+  [ "IsRowVectorOrVectorObj", "IsGenericMatrixRep" ],
+  {} -> RankFilter(IsPlistVectorRep),  # rank above method for [IsPlistVectorRep, IsScalar]
+  function( v, M )
+    local rows, cols, bd, res;
+
+    rows := NumberRows( M );
+    cols := NumberColumns( M );
+    bd := BaseDomain( M );
+
+    if ValueOption( "check" ) <> false then
+      if Length( v ) <> rows then
+        Error( "<v> and <M> are not compatible" );
+      elif not IsIdenticalObj( BaseDomain( v ), bd ) then
+        Error( "<v> and <M> are not compatible" );
+      fi;
+    fi;
+
+    # special case for empty matrices
+    if rows = 0 or cols = 0 then
+      return ZeroVector( cols, v );
+    fi;
+
+    # "unpack" cheaply and then delegate to kernel implementation
+    if IsPlistVectorRep(v) then
+      res := v![ELSPOS];
+    elif IsList(v) then
+      res := v;
+    else
+      res := Unpack(v);
+    fi;
+    res := res * M![GEN_MAT_REP_ROWS_POS];
+    return Vector( res, v );
+  end );
+
+InstallMethod( ChangedBaseDomain,
+  [ "IsGenericMatrixRep", "IsRing" ],
+  function( M, r )
+    local A;
+    A := NewMatrix( IsGenericMatrixRep, r, NrCols(M), M![GEN_MAT_REP_ROWS_POS] );
+    if not IsMutable( M ) then
+      MakeImmutable(A);
+    fi;
+    return A;
+  end );
+
+
+InstallMethod( MultMatrixRowLeft,
+  [ "IsGenericMatrixRep and IsMutable", "IsInt", "IsObject" ],
+  function( mat, row, scalar )
+    MultMatrixRowLeft(mat![GEN_MAT_REP_ROWS_POS], row, scalar);
+  end );
+
+InstallMethod( MultMatrixRowRight,
+  [ "IsGenericMatrixRep and IsMutable", "IsInt", "IsObject" ],
+  function( mat, row, scalar )
+    MultMatrixRowRight(mat![GEN_MAT_REP_ROWS_POS], row, scalar);
+  end );
+
+InstallMethod( AddMatrixRowsLeft,
+  [ "IsGenericMatrixRep and IsMutable", "IsInt", "IsInt", "IsObject" ],
+  function( mat, row1, row2, scalar )
+    AddMatrixRowsLeft( mat![GEN_MAT_REP_ROWS_POS], row1, row2, scalar );
+  end );
+
+InstallMethod( AddMatrixRowsRight,
+  [ "IsGenericMatrixRep and IsMutable", "IsInt", "IsInt", "IsObject" ],
+  function( mat, row1, row2, scalar )
+    AddMatrixRowsRight( mat![GEN_MAT_REP_ROWS_POS], row1, row2, scalar );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  [ "IsGenericMatrixRep", "IsPosInt" ],
+  function( mat, row )
+    return PositionNonZero( mat![GEN_MAT_REP_ROWS_POS][row] );
+  end );
+
+InstallMethod( PositionNonZeroInRow,
+  [ "IsGenericMatrixRep", "IsPosInt", "IsInt" ],
+  function( mat, row, from )
+    return PositionNonZero( mat![GEN_MAT_REP_ROWS_POS][row], from );
+  end );
+
+InstallMethod( SwapMatrixRows,
+  [ "IsGenericMatrixRep and IsMutable", "IsInt", "IsInt" ],
+  function( mat, row1, row2 )
+    SwapMatrixRows(mat![GEN_MAT_REP_ROWS_POS], row1, row2);
+  end );
+
+InstallMethod( SwapMatrixColumns,
+  [ "IsGenericMatrixRep and IsMutable", "IsInt", "IsInt" ],
+  function( mat, col1, col2 )
+    SwapMatrixColumns(mat![GEN_MAT_REP_ROWS_POS], col1, col2);
+  end );
+
+
+InstallMethod( PostMakeImmutable,
+  [ "IsGenericMatrixRep" ],
+  function( M )
+    MakeImmutable( M![GEN_MAT_REP_ROWS_POS] );
+  end );
+
+
+InstallMethod( ViewObj, [ "IsGenericMatrixRep" ],
+  function( M )
+    Print( "<" );
+    if not IsMutable( M ) then
+      Print( "immutable " );
+    fi;
+    Print( NrRows(M), "x", NrCols(M),
+           "-matrix over ", BaseDomain(M), ">" );
+  end );
+
+InstallMethod( PrintObj, [ "IsGenericMatrixRep" ],
+  function( M )
+    Print( "NewMatrix(IsGenericMatrixRep" );
+    if IsFinite( BaseDomain(M) ) and IsField( BaseDomain(M) ) then
+      Print( ",GF(", Size( BaseDomain(M) ), ")," );
+    else
+      Print( ",", String( BaseDomain(M) ), "," );
+    fi;
+    Print( NumberColumns( M ), ",", Unpack( M ), ")" );
+  end );
+
+InstallMethod( Display, [ "IsGenericMatrixRep" ],
+  function( M )
+    local i;
+    Print( "<" );
+    if not IsMutable( M ) then
+      Print( "immutable " );
+    fi;
+    Print( NrRows(M), "x", NrCols(M),
+           "-matrix over ", BaseDomain(M), ":\n" );
+    for i in [ 1 .. NrRows(M) ] do
+      if i = 1 then
+        Print( "[" );
+      else
+        Print( " " );
+      fi;
+      Print( M![GEN_MAT_REP_ROWS_POS][i], "\n" );
+    od;
+    Print( "]>\n" );
+  end );
+
+InstallMethod( String, [ "IsGenericMatrixRep" ],
+  function( M )
+    local st;
+    st := "NewMatrix(IsGenericMatrixRep";
+    Add( st, ',' );
+    if IsFinite( BaseDomain(M) ) and IsField( BaseDomain(M) ) then
+      Append( st, "GF(" );
+      Append( st, String( Size( BaseDomain(M) ) ) );
+      Append( st, ")," );
+    else
+      Append( st, String( BaseDomain(M) ) );
+      Append( st, "," );
+    fi;
+    Append( st, String( NumberColumns( M ) ) );
+    Add( st, ',' );
+    Append( st, String( Unpack( M ) ) );
+    Add( st, ')' );
+    return st;
+  end );

--- a/lib/matobjplist.gd
+++ b/lib/matobjplist.gd
@@ -71,6 +71,16 @@ DeclareRepresentation( "IsPlistVectorRep",
 ##  a matrix object (see <Ref Filt="IsMatrixObj"/>) that behaves similar to
 ##  a list of its rows, in the sense of <Ref Filt="IsRowListMatrix"/>.
 ##  <P/>
+##  In particular, the rows can be accessed via <M>M[i]</M>,
+##  and they are vector objects in <Ref Filt="IsPlistVectorRep"/>.
+##  This representation is useful if one wants to work explicitly with
+##  such row objects.
+##  <P/>
+##  For most purposes, <Ref Filt="IsGenericMatrixRep"/> is the better choice.
+##  Unlike <Ref Filt="IsPlistMatrixRep"/>, it does not support direct row
+##  access, but it is intended as the general-purpose representation for
+##  matrix objects.
+##  <P/>
 ##  <Ref Filt="IsPlistMatrixRep"/> implies <Ref Filt="IsCopyable"/>,
 ##  thus matrix objects in this representation can be mutable.
 ##  </Description>
@@ -126,4 +136,3 @@ BindConstant( "ELSPOS", 2 );
 # Two filters to speed up some methods:
 DeclareFilter( "IsIntVector" );
 DeclareFilter( "IsFFEVector" );
-

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -34,55 +34,43 @@
 ##
 BindGlobal( "MakeIsPlistVectorRep",
   function( basedomain, list, check )
-    local fam, types, typ;
-    fam := FamilyObj(basedomain);
-    #types := _PlistVectorRepTypeCache(basedomain);
+    local efam, fam, filter, types, typ;
 
-    # special case: integers
-    if IsIntegers(basedomain) then
-        if not IsBound(basedomain!.PlistVectorRepTypes) then
-            # initialize type cache
-            # TODO: make this thread safe for HPC-GAP
-            basedomain!.PlistVectorRepTypes := [
-                NewType(fam, IsPlistVectorRep and IsIntVector and CanEasilyCompareElements),
-                NewType(fam, IsPlistVectorRep and IsIntVector and CanEasilyCompareElements and IsMutable),
-            ];
-        fi;
-        types := basedomain!.PlistVectorRepTypes;
-    elif IsFFECollection(basedomain) then
-        if not IsBound(basedomain!.PlistVectorRepTypes) then
-            # initialize type cache
-            # TODO: make this thread safe for HPC-GAP
-            basedomain!.PlistVectorRepTypes := [
-                NewType(fam, IsPlistVectorRep and IsFFEVector and CanEasilyCompareElements),
-                NewType(fam, IsPlistVectorRep and IsFFEVector and CanEasilyCompareElements and IsMutable),
-            ];
-        fi;
-        types := basedomain!.PlistVectorRepTypes;
+    efam := ElementsFamily( FamilyObj( basedomain ) );
+    fam := FamilyObj( basedomain );
+
+    # we store the types in the base domain if the filter carries
+    # information specific to it
+    if IsBound( basedomain!.PlistVectorRepTypes ) then
+      types := basedomain!.PlistVectorRepTypes;
+    elif IsBound( fam!.PlistVectorRepTypes ) and not IsIntegers(basedomain) then
+      types := fam!.PlistVectorRepTypes;
     else
-        if not IsBound(fam!.PlistVectorRepTypes) then
-            # initialize type cache
-            # TODO: make this thread safe for HPC-GAP
-            fam!.PlistVectorRepTypes := [
-                NewType(fam, IsPlistVectorRep),
-                NewType(fam, IsPlistVectorRep and IsMutable),
-            ];
-            fam!.PlistVectorRepTypesEasyCompare := [
-                NewType(fam, IsPlistVectorRep and CanEasilyCompareElements),
-                NewType(fam, IsPlistVectorRep and CanEasilyCompareElements and IsMutable),
-            ];
-        fi;
-        if HasCanEasilyCompareElements(Representative(basedomain)) and
-           CanEasilyCompareElements(Representative(basedomain)) then
-            types := fam!.PlistVectorRepTypesEasyCompare;
-        else
-            types := fam!.PlistVectorRepTypes;
-        fi;
+      # initialize type cache
+      # TODO: make this thread safe for HPC-GAP
+      filter := IsPlistVectorRep;
+      if CanEasilyCompareElementsFamily( efam ) then
+        filter := filter and CanEasilyCompareElements;
+      fi;
+      if IsIntegers(basedomain) then
+        filter := filter and IsIntVector;
+      elif IsFFECollection(basedomain) then
+        filter := filter and IsFFEVector;
+      fi;
+      types := [
+          NewType( fam, filter ),
+          NewType( fam, filter and IsMutable ),
+      ];
+      if IsIntegers(basedomain) then
+        basedomain!.PlistVectorRepTypes := types;
+      else
+        fam!.PlistVectorRepTypes := types;
+      fi;
     fi;
-    if IsMutable(list) then
-        typ := types[2];
+    if IsMutable( list ) then
+      typ := types[2];
     else
-        typ := types[1];
+      typ := types[1];
     fi;
 
     if check and ValueOption( "check" ) <> false then
@@ -122,33 +110,29 @@ BindGlobal( "MakeIsPlistVectorRep",
 ##
 BindGlobal( "MakeIsPlistMatrixRep",
   function( basedomain, emptyvector, ncols, list, check )
-    local fam, types, typ, row;
-    fam:= CollectionsFamily( FamilyObj( basedomain ) );
+    local efam, fam, filter, typ, row;
+
+    efam := ElementsFamily( FamilyObj( basedomain ) );
+    fam := CollectionsFamily( FamilyObj( basedomain ) );
 
     # Currently there is no special handling depending on 'basedomain',
     # the types are always cached in 'fam'.
     if not IsBound( fam!.PlistMatrixRepTypes ) then
       # initialize type cache
       # TODO: make this thread safe for HPC-GAP
-      fam!.PlistMatrixRepTypes:= [
-          NewType( fam, IsPlistMatrixRep ),
-          NewType( fam, IsPlistMatrixRep and IsMutable ),
+      filter := IsPlistMatrixRep;
+      if CanEasilyCompareElementsFamily( efam ) then
+        filter := filter and CanEasilyCompareElements;
+      fi;
+      fam!.PlistMatrixRepTypes := [
+          NewType( fam, filter ),
+          NewType( fam, filter and IsMutable ),
       ];
-      fam!.PlistMatrixRepTypesEasyCompare:= [
-          NewType( fam, IsPlistMatrixRep and CanEasilyCompareElements ),
-          NewType( fam, IsPlistMatrixRep and CanEasilyCompareElements and IsMutable ),
-      ];
-    fi;
-    if HasCanEasilyCompareElements( Representative( basedomain ) ) and
-       CanEasilyCompareElements( Representative( basedomain ) ) then
-      types:= fam!.PlistMatrixRepTypesEasyCompare;
-    else
-      types:= fam!.PlistMatrixRepTypes;
     fi;
     if IsMutable( list ) then
-      typ:= types[2];
+      typ := fam!.PlistMatrixRepTypes[2];
     else
-      typ:= types[1];
+      typ := fam!.PlistMatrixRepTypes[1];
     fi;
 
     if check and ValueOption( "check" ) <> false then
@@ -160,10 +144,10 @@ BindGlobal( "MakeIsPlistMatrixRep",
       for row in list do
         if not IsPlistVectorRep( row ) then
           Error( "the entries of <list> must be in 'IsPlistVectorRep'" );
-        elif not IsIdenticalObj( basedomain, row![BDPOS] ) then
-          Error( "the entries of <list> must have the given base domain" );
         elif Length( row![ELSPOS] ) <> ncols then
           Error( "the entries of <list> must have length <ncols>" );
+        elif not IsIdenticalObj( basedomain, row![BDPOS] ) then
+          Error( "the entries of <list> must have the given base domain" );
         fi;
       od;
     fi;

--- a/lib/read3.g
+++ b/lib/read3.g
@@ -107,6 +107,7 @@ ReadLib( "wordass.gd"  );
 
 ReadLib( "matobj2.gd"  );
 ReadLib( "matobjplist.gd" );
+ReadLib( "matobjgeneric.gd" );
 ReadLib( "matobjnz.gd" );
 
 # files dealing with rewriting systems

--- a/lib/read5.g
+++ b/lib/read5.g
@@ -114,6 +114,7 @@ ReadLib( "vecmat.gi"   );
 ReadLib( "vec8bit.gi"  );
 ReadLib( "mat8bit.gi"  );
 ReadLib( "matobjplist.gi" );
+ReadLib( "matobjgeneric.gi" );
 ReadLib( "matobjnz.gi" );
 ReadLib( "meataxe.gi"  );
 ReadLib( "meatauto.gi" );

--- a/tst/testinstall/MatrixObj/CompanionMatrix.tst
+++ b/tst/testinstall/MatrixObj/CompanionMatrix.tst
@@ -68,6 +68,22 @@ gap> TestCompanionMatrix(IsPlistMatrixRep, x^2+x+1, F);
 <2x2-matrix over Rationals>
 
 #
+# IsGenericMatrixRep
+#
+gap> F:= GF(251);;  x:= X(F);;
+gap> TestCompanionMatrix(IsGenericMatrixRep, x+1, F);
+<1x1-matrix over GF(251)>
+gap> TestCompanionMatrix(IsGenericMatrixRep, x^2+x+1, F);
+<2x2-matrix over GF(251)>
+
+#
+gap> F:= Integers;;  x:= X(F);;
+gap> TestCompanionMatrix(IsGenericMatrixRep, x+1, F);
+<1x1-matrix over Integers>
+gap> TestCompanionMatrix(IsGenericMatrixRep, x^2+x+1, F);
+<2x2-matrix over Integers>
+
+#
 # IsPlistRep
 #
 gap> F:= GF(251);;  x:= X(F);;

--- a/tst/testinstall/MatrixObj/ElementaryMatrices.tst
+++ b/tst/testinstall/MatrixObj/ElementaryMatrices.tst
@@ -68,6 +68,14 @@ gap> TestElementaryTransforms( mat, -1 );
 gap> TestWholeMatrixTransforms( mat, -1 );
 
 #
+gap> mat := NewMatrix(IsGenericMatrixRep, Integers, 3,
+>                     [ [ 2, 4, 5 ], [ 7, 11, -4 ], [ -3, 20, 0 ] ] );;
+gap> IsGenericMatrixRep(mat);
+true
+gap> TestElementaryTransforms( mat, -1 );
+gap> TestWholeMatrixTransforms( mat, -1 );
+
+#
 gap> TestPositionNonZeroInRow([ [ 1 ] ]);
 gap> TestPositionNonZeroInRow(Matrix([ [ 1 ] ]));
 gap> TestPositionNonZeroInRow(Matrix(GF(2), [ [ 1 ] ] * Z(2)));

--- a/tst/testinstall/MatrixObj/IdentityMatrix.tst
+++ b/tst/testinstall/MatrixObj/IdentityMatrix.tst
@@ -74,6 +74,24 @@ gap> TestIdentityMatrix(IsPlistMatrixRep, Integers mod 4, -1);
 Error, IdentityMatrix: the dimension must be non-negative
 
 #
+# IsGenericMatrixRep
+#
+gap> TestIdentityMatrix(IsGenericMatrixRep, GF(2), 2);
+<2x2-matrix over GF(2)>
+gap> TestIdentityMatrix(IsGenericMatrixRep, GF(2), 0);
+<0x0-matrix over GF(2)>
+gap> TestIdentityMatrix(IsGenericMatrixRep, GF(2), -1);
+Error, IdentityMatrix: the dimension must be non-negative
+
+#
+gap> TestIdentityMatrix(IsGenericMatrixRep, Integers, 2);
+<2x2-matrix over Integers>
+gap> TestIdentityMatrix(IsGenericMatrixRep, Integers, 0);
+<0x0-matrix over Integers>
+gap> TestIdentityMatrix(IsGenericMatrixRep, Integers, -1);
+Error, IdentityMatrix: the dimension must be non-negative
+
+#
 # Test IdentityMatrix variant which "guesses" a suitable representation, i.e.:
 #    IdentityMatrix( <R>, <m>, <n> )
 #

--- a/tst/testinstall/MatrixObj/Matrix.tst
+++ b/tst/testinstall/MatrixObj/Matrix.tst
@@ -46,4 +46,15 @@ gap> m = Matrix( IsPlistMatrixRep, GF(2), [1,2,3,4] * Z(2), 2 );
 true
 
 #
+gap> m := Matrix( IsGenericMatrixRep, GF(2), [[1,2],[3,4]] * Z(2) );
+<2x2-matrix over GF(2)>
+gap> Display(m);
+<2x2-matrix over GF(2):
+[[ Z(2)^0, 0*Z(2) ]
+ [ Z(2)^0, 0*Z(2) ]
+]>
+gap> m = Matrix( IsGenericMatrixRep, GF(2), [1,2,3,4] * Z(2), 2 );
+true
+
+#
 gap> STOP_TEST("Matrix.tst");

--- a/tst/testinstall/MatrixObj/ZeroMatrix.tst
+++ b/tst/testinstall/MatrixObj/ZeroMatrix.tst
@@ -80,6 +80,24 @@ gap> TestZeroMatrix(IsPlistMatrixRep, Integers mod 4, 0, 3);
 <0x3-matrix over (Integers mod 4)>
 
 #
+# IsGenericMatrixRep
+#
+gap> TestZeroMatrix(IsGenericMatrixRep, GF(2), 2, 3);
+<2x3-matrix over GF(2)>
+gap> TestZeroMatrix(IsGenericMatrixRep, GF(2), 2, 0);
+<2x0-matrix over GF(2)>
+gap> TestZeroMatrix(IsGenericMatrixRep, GF(2), 0, 3);
+<0x3-matrix over GF(2)>
+
+#
+gap> TestZeroMatrix(IsGenericMatrixRep, Integers, 2, 3);
+<2x3-matrix over Integers>
+gap> TestZeroMatrix(IsGenericMatrixRep, Integers, 2, 0);
+<2x0-matrix over Integers>
+gap> TestZeroMatrix(IsGenericMatrixRep, Integers, 0, 3);
+<0x3-matrix over Integers>
+
+#
 # Test ZeroMatrix variant which "guesses" a suitable representation, i.e.:
 #    ZeroMatrix( <R>, <m>, <n> )
 #

--- a/tst/testinstall/MatrixObj/matobjgeneric.tst
+++ b/tst/testinstall/MatrixObj/matobjgeneric.tst
@@ -1,0 +1,465 @@
+#@local e, v, v2, w, M, z, rows, a, b, c, d, p, ev, n, ai, inv, zm, zs, N, T, R
+gap> START_TEST( "matobjgeneric.tst" );
+
+#
+# MakeIsPlistVectorRep: test input validation
+#
+gap> e:= MakeIsPlistVectorRep( Integers, [], true );
+<plist vector over Integers of length 0>
+gap> v:= MakeIsPlistVectorRep( Integers, [ 1 ], true );
+<plist vector over Integers of length 1>
+gap> v2:= NewVector( IsPlistVectorRep, Integers, [ 1, 0 ] );
+<plist vector over Integers of length 2>
+gap> w:= MakeIsPlistVectorRep( Rationals, [ 1 ], true );
+<plist vector over Rationals of length 1>
+
+#
+gap> MakeIsGenericMatrixRep( Integers, 2, [ v ], true );
+Error, the entries of <list> must be plain lists
+gap> M:= MakeIsGenericMatrixRep( Integers, 2, [], true );
+<0x2-matrix over Integers>
+gap> MakeIsGenericMatrixRep( Integers, 1, [ [ 1 ] ], true );
+<1x1-matrix over Integers>
+gap> MakeIsGenericMatrixRep( Integers, 2, [ [ 1 ] ], true );
+Error, the entries of <list> must have length <ncols>
+gap> MakeIsGenericMatrixRep( Integers, 1, [ [ 1/2 ] ], true );
+Error, the elements in <list> must lie in <basedomain>
+gap> MakeIsGenericMatrixRep( GF(2), 1, [ [ Z(2) ] ], true );
+<1x1-matrix over GF(2)>
+gap> MakeIsGenericMatrixRep( GF(2), 1, [ [ Z(4) ] ], true );
+Error, the elements in <list> must lie in <basedomain>
+
+#
+gap> NewMatrix( IsGenericMatrixRep, Integers, 2, [] );
+<0x2-matrix over Integers>
+gap> NewMatrix( IsGenericMatrixRep, Integers, 2, [ 1 ] );
+Error, NewMatrix: Length of <list> is not a multiple of <ncols>
+gap> NewMatrix( IsGenericMatrixRep, Integers, 2, [ [ 1 ] ] );
+Error, the entries of <list> must have length <ncols>
+gap> NewMatrix( IsGenericMatrixRep, Integers, 2, [ [ 1, 2 ] ] );
+<1x2-matrix over Integers>
+gap> NewMatrix( IsGenericMatrixRep, Integers, 2, [ v ] );
+Error, the entries of <list> must have length <ncols>
+gap> M:= NewMatrix( IsGenericMatrixRep, Integers, 2, [ [ 1, 2 ], [ 3, 4 ] ] );
+<2x2-matrix over Integers>
+gap> IsMutable( M );
+true
+gap> Unpack( M );
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> M[2,1];
+3
+gap> M[1];
+Error, row access unsupported; use M[i,j] or RowsOfMatrix(M)
+gap> M[2,2] := 5;;
+gap> Unpack( M );
+[ [ 1, 2 ], [ 3, 5 ] ]
+
+#
+gap> rows:= RowsOfMatrix( M );
+[ <immutable plist vector over Integers of length 2>, 
+  <immutable plist vector over Integers of length 2> ]
+gap> Length( rows );
+2
+gap> IsPlistVectorRep( rows[1] );
+true
+gap> Unpack( rows[1] );
+[ 1, 2 ]
+gap> M[1,1] := 77;;
+gap> rows[1][1];
+1
+
+#
+gap> M:= NewMatrix( IsGenericMatrixRep, Integers, 2, [ v2, v2 ] );;
+gap> Unpack( M );
+[ [ 1, 0 ], [ 1, 0 ] ]
+
+#
+# Empty matrices and empty vectors
+#
+#
+gap> a:= ZeroMatrix( IsGenericMatrixRep, Integers, 2, 0 );
+<2x0-matrix over Integers>
+gap> b:= ZeroMatrix( IsGenericMatrixRep, Integers, 0, 3 );
+<0x3-matrix over Integers>
+gap> c:= ZeroMatrix( IsGenericMatrixRep, Integers, 0, 0 );
+<0x0-matrix over Integers>
+gap> d:= ZeroMatrix( IsGenericMatrixRep, Integers, 0, 2 );
+<0x2-matrix over Integers>
+gap> z:= ZeroMatrix( IsGenericMatrixRep, Integers, 2, 3 );
+<2x3-matrix over Integers>
+gap> IsMutable( z );
+true
+gap> Unpack( z );
+[ [ 0, 0, 0 ], [ 0, 0, 0 ] ]
+
+#
+gap> M:= NewIdentityMatrix( IsGenericMatrixRep, Integers, 2 );;
+gap> Unpack( M );
+[ [ 1, 0 ], [ 0, 1 ] ]
+
+#
+gap> a = NewMatrix( IsGenericMatrixRep, Integers, 0, [ [], [] ] );
+true
+gap> b = NewMatrix( IsGenericMatrixRep, Integers, 3, [] );
+true
+gap> c = NewMatrix( IsGenericMatrixRep, Integers, 0, [] );
+true
+gap> d = NewMatrix( IsGenericMatrixRep, Integers, 2, [] );
+true
+
+#
+gap> p:= a * b;
+<2x3-matrix over Integers>
+gap> Unpack( p );
+[ [ 0, 0, 0 ], [ 0, 0, 0 ] ]
+gap> p:= d * a;
+<0x0-matrix over Integers>
+gap> Unpack( p );
+[  ]
+gap> p:= c * b;
+<0x3-matrix over Integers>
+gap> Unpack( p );
+[  ]
+
+# empty vector times (necessarily also empty) matrix
+gap> ev:= NewVector( IsPlistVectorRep, Integers, [] );
+<plist vector over Integers of length 0>
+gap> a * ev;
+<plist vector over Integers of length 2>
+gap> Unpack( last );
+[ 0, 0 ]
+gap> ev * b;
+<plist vector over Integers of length 3>
+gap> Unpack( last );
+[ 0, 0, 0 ]
+
+# non-empty vector times empty matrix
+gap> v2:= NewVector( IsPlistVectorRep, Integers, [ 1, 2 ] );
+<plist vector over Integers of length 2>
+gap> d * v2;
+<plist vector over Integers of length 0>
+gap> Unpack( last );
+[  ]
+gap> Unpack( v2 * a );
+[  ]
+
+#
+gap> b + b;
+<0x3-matrix over Integers>
+gap> b - b;
+<0x3-matrix over Integers>
+gap> -b;
+<0x3-matrix over Integers>
+gap> ZeroMutable( b );
+<0x3-matrix over Integers>
+
+#
+gap> InverseMutable( c );
+<0x0-matrix over Integers>
+gap> InverseSameMutability( c );
+<0x0-matrix over Integers>
+
+#
+gap> M:= Matrix( IsGenericMatrixRep, Integers, [ [ 0, 0, 2 ], [ 0, 0, 0 ] ] );;
+gap> PositionNonZeroInRow( M, 1 );
+3
+gap> PositionNonZeroInRow( M, 1, 2 );
+3
+gap> PositionNonZeroInRow( M, 2 );
+4
+
+#
+gap> M:= Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] );;
+gap> MultMatrixRowLeft( M, 1, -1 );;
+gap> Unpack( M );
+[ [ -1, -2, -3 ], [ 4, 5, 6 ] ]
+gap> MultMatrixRowRight( M, 2, 2 );;
+gap> Unpack( M );
+[ [ -1, -2, -3 ], [ 8, 10, 12 ] ]
+gap> AddMatrixRowsLeft( M, 1, 2, 3 );;
+gap> Unpack( M );
+[ [ 23, 28, 33 ], [ 8, 10, 12 ] ]
+gap> AddMatrixRowsRight( M, 2, 1, 2 );;
+gap> Unpack( M );
+[ [ 23, 28, 33 ], [ 54, 66, 78 ] ]
+gap> SwapMatrixRows( M, 1, 2 );;
+gap> Unpack( M );
+[ [ 54, 66, 78 ], [ 23, 28, 33 ] ]
+
+#
+# Test Inverse / InverseMutable
+#
+gap> M:= Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ] );;
+gap> InverseMutable( M );
+Error, InverseMutable: matrix must be square
+
+#
+gap> M:= ZeroMatrix( IsGenericMatrixRep, Integers, 2, 2 );;
+gap> InverseMutable( M );
+fail
+
+#
+gap> M:= Matrix( IsGenericMatrixRep, GF(2), [ [ Z(2)^0, Z(2)^0 ], [ Z(2)^0, 0*Z(2) ] ] );;
+gap> N:= InverseMutable( M );;
+gap> Display( N );
+<2x2-matrix over GF(2):
+[[ 0*Z(2), Z(2)^0 ]
+ [ Z(2)^0, Z(2)^0 ]
+]>
+gap> IsOne( N * M );
+true
+gap> IsOne( M * N );
+true
+
+#
+gap> M:= Matrix( IsGenericMatrixRep, Rationals, [ [ 1, 2 ], [ 3, 5 ] ] );;
+gap> N:= InverseMutable( M );;
+gap> Display( N );
+<2x2-matrix over Rationals:
+[[ -5, 2 ]
+ [ 3, -1 ]
+]>
+
+#
+# mutability after operations
+#
+gap> M:= Matrix( IsGenericMatrixRep, Rationals, [ [ 1, 2 ], [ 3, 5 ] ] );;
+gap> IsMutable(M);
+true
+gap> N:= InverseSameMutability( M );;
+gap> IsMutable(N);
+true
+gap> IsMutable( M * N );
+true
+gap> IsMutable( M + N );
+true
+gap> IsMutable( M - N );
+true
+gap> IsMutable( -M );
+true
+gap> MakeImmutable(M);;
+gap> IsMutable( M * N );
+true
+gap> IsMutable( M + N );
+true
+gap> IsMutable( M - N );
+true
+gap> N:= InverseSameMutability( M );;
+gap> IsMutable(N);
+false
+gap> IsMutable( M * N );
+false
+gap> IsMutable( M + N );
+false
+gap> IsMutable( M - N );
+false
+gap> IsMutable( -M );
+false
+
+#
+gap> M:= Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2 ], [ 3, 4 ] ] );;
+gap> M[1,1] := 1/2;
+Error, <val> must lie in the base domain of <M>
+gap> M[3,1] := 1;
+Error, <row> is out of bounds
+gap> M[1,3] := 1;
+Error, <col> is out of bounds
+
+#
+gap> a:= Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2 ] ] );;
+gap> b:= Matrix( IsGenericMatrixRep, Rationals, [ [ 1, 2 ] ] );;
+gap> a + b;
+Error, <a> and <b> are not compatible
+gap> a - b;
+Error, <a> and <b> are not compatible
+gap> c:= Matrix( IsGenericMatrixRep, Integers, [ [ 1 ], [ 2 ] ] );;
+gap> c * c;
+Error, \*: Matrices do not fit together
+gap> d:= Matrix( IsGenericMatrixRep, Rationals, [ [ 1 ], [ 2 ] ] );;
+gap> a * d;
+Error, \*: Matrices not over same base domain
+
+#
+# ShallowCopy, MutableCopyMatrix
+#
+gap> M:= Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2 ], [ 3, 4 ] ] );;
+gap> N:= ShallowCopy( M );;
+gap> N[1,1] := 99;;
+gap> Unpack( M );
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> Unpack( N );
+[ [ 99, 2 ], [ 3, 4 ] ]
+gap> N:= MutableCopyMatrix( M );;
+gap> N[1,2] := 77;;
+gap> Unpack( M );
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> Unpack( N );
+[ [ 1, 77 ], [ 3, 4 ] ]
+
+#
+# ExtractSubMatrix, CopySubMatrix
+#
+gap> Unpack( ExtractSubMatrix( M, [ 2, 1 ], [ 2 ] ) );
+[ [ 4 ], [ 2 ] ]
+gap> T:= ZeroMatrix( IsGenericMatrixRep, Integers, 2, 3 );;
+gap> CopySubMatrix( M, T, [ 2, 1 ], [ 1, 2 ], [ 2 ], [ 3 ] );;
+gap> Unpack( T );
+[ [ 0, 0, 4 ], [ 0, 0, 2 ] ]
+gap> CopySubMatrix( Matrix( IsGenericMatrixRep, Rationals, [ [ 1, 2 ] ] ),
+>                   T, [ 1 ], [ 1 ], [ 1 ], [ 1 ] );
+Error, <M> and <N> are not compatible
+
+#
+# TransposedMatMutable
+#
+gap> Unpack( TransposedMatMutable( M ) );
+[ [ 1, 3 ], [ 2, 4 ] ]
+
+#
+# ChangedBaseDomain
+#
+gap> N:= ChangedBaseDomain( M, Rationals );;
+gap> BaseDomain( N );
+Rationals
+gap> Unpack( N );
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> IsMutable( N );
+true
+gap> MakeImmutable( M );;
+gap> N:= ChangedBaseDomain( M, Rationals );;
+gap> IsMutable( N );
+false
+
+#
+# ViewObj, PrintObj, Display, String
+#
+gap> M := Matrix( IsGenericMatrixRep, GF(2), [ [ Z(2)^0, 0*Z(2) ] ] );
+<1x2-matrix over GF(2)>
+gap> Print(M, "\n");
+NewMatrix(IsGenericMatrixRep,GF(2),2,[ [ Z(2)^0, 0*Z(2) ] ])
+gap> Display(M);
+<1x2-matrix over GF(2):
+[[ Z(2)^0, 0*Z(2) ]
+]>
+gap> String(M);
+"NewMatrix(IsGenericMatrixRep,GF(2),2,[ [ Z(2)^0, 0*Z(2) ] ])"
+
+#
+gap> MakeImmutable( M );
+<immutable 1x2-matrix over GF(2)>
+gap> Print(M, "\n");
+NewMatrix(IsGenericMatrixRep,GF(2),2,[ [ Z(2)^0, 0*Z(2) ] ])
+gap> Display(M);
+<immutable 1x2-matrix over GF(2):
+[[ Z(2)^0, 0*Z(2) ]
+]>
+gap> String(M);
+"NewMatrix(IsGenericMatrixRep,GF(2),2,[ [ Z(2)^0, 0*Z(2) ] ])"
+
+#
+gap> M :=Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2 ], [ 3, 4 ] ] );
+<2x2-matrix over Integers>
+gap> Print(M, "\n");
+NewMatrix(IsGenericMatrixRep,Integers,2,[ [ 1, 2 ], [ 3, 4 ] ])
+gap> Display(M);
+<2x2-matrix over Integers:
+[[ 1, 2 ]
+ [ 3, 4 ]
+]>
+gap> String(M);
+"NewMatrix(IsGenericMatrixRep,Integers,2,[ [ 1, 2 ], [ 3, 4 ] ])"
+
+#
+gap> MakeImmutable( M );
+<immutable 2x2-matrix over Integers>
+gap> Print(M, "\n");
+NewMatrix(IsGenericMatrixRep,Integers,2,[ [ 1, 2 ], [ 3, 4 ] ])
+gap> Display(M);
+<immutable 2x2-matrix over Integers:
+[[ 1, 2 ]
+ [ 3, 4 ]
+]>
+gap> String(M);
+"NewMatrix(IsGenericMatrixRep,Integers,2,[ [ 1, 2 ], [ 3, 4 ] ])"
+
+#
+# vec * mat, mat * vec
+#
+gap> M:= Matrix( IsGenericMatrixRep, Integers, [ [ 1, 2 ], [ 3, 4 ] ] );;
+gap> v:= Vector( Integers, [ 1, 2 ] );
+<plist vector over Integers of length 2>
+gap> Display( M * v );
+<a plist vector over Integers:
+[ 5, 11 ]
+>
+gap> Display( v * M );
+<a plist vector over Integers:
+[ 7, 10 ]
+>
+
+#
+gap> M * [ 1, 2 ];
+[ 5, 11 ]
+gap> [ 1, 2 ] * M;
+[ 7, 10 ]
+
+#
+gap> R:= Integers mod 6;;
+gap> M:= Matrix( IsGenericMatrixRep, R, One(R) * [ [ 1, 2 ], [ 3, 4 ] ] );;
+gap> v:= NewVector( IsZmodnZVectorRep, R, One(R) * [ 1, 2 ] );
+<vector mod 6: [ 1, 2 ]>
+gap> Display( M * v );
+<a zmodnz vector over (Integers mod 6):
+[ 5, 5 ]
+>
+gap> Display( v * M );
+<a zmodnz vector over (Integers mod 6):
+[ 1, 4 ]
+>
+
+# error handling
+gap> M * [ 1, 2, 3 ];
+Error, <M> and <v> are not compatible
+gap> [ 1, 2, 3 ] * M;
+Error, <v> and <M> are not compatible
+gap> M * [ Z(2), Z(2) ];
+Error, <M> and <v> are not compatible
+gap> [ Z(2), Z(2) ] * M;
+Error, <v> and <M> are not compatible
+
+# multiplication with empty list is not well-defined: we don't know if
+# is meant to be a vector of length 0, or something else; so rather
+# error out
+gap> a:= ZeroMatrix( IsGenericMatrixRep, Integers, 2, 0 );;
+gap> b:= ZeroMatrix( IsGenericMatrixRep, Integers, 0, 3 );;
+gap> a * [];
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BaseDomain' on 1 arguments
+gap> [] * b;
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `BaseDomain' on 1 arguments
+
+#
+# families
+#
+gap> M:= NewZeroMatrix( IsGenericMatrixRep, Integers, 2, 3 );
+<2x3-matrix over Integers>
+gap> IsMutable( M );
+true
+gap> IsCyclotomicCollColl( M );
+true
+gap> IsFFECollColl( M );
+false
+
+#
+gap> M:= NewZeroMatrix( IsGenericMatrixRep, GF(257), 2, 3 );
+<2x3-matrix over GF(257)>
+gap> IsMutable( M );
+true
+gap> IsCyclotomicCollColl( M );
+false
+gap> IsFFECollColl( M );
+true
+
+#
+gap> STOP_TEST( "matobjgeneric.tst" );

--- a/tst/testinstall/MatrixObj/matobjplist.tst
+++ b/tst/testinstall/MatrixObj/matobjplist.tst
@@ -39,10 +39,8 @@ gap> NewVector( IsPlistVectorRep, Integers, [ 1/2 ] );;
 Error, the elements in <list> must lie in <basedomain>
 
 #
-gap> NewZeroVector( IsPlistVectorRep, Integers, 0 );;
-gap> z:= NewZeroVector( IsPlistVectorRep, Integers, 1 );;
-gap> IsMutable( z );
-true
+gap> NewZeroVector( IsPlistVectorRep, Integers, 0 );
+<plist vector over Integers of length 0>
 
 #
 gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [] );;
@@ -58,17 +56,73 @@ gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
 true
 
 #
-gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 0 );;
-gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 0 );;
-gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 3 );;
-gap> M:= NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 3 );;
+gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 0 );
+<0x0-matrix over Integers>
+gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 0 );
+<2x0-matrix over Integers>
+gap> NewZeroMatrix( IsPlistMatrixRep, Integers, 0, 3 );
+<0x3-matrix over Integers>
+gap> M:= NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 3 );
+<2x3-matrix over Integers>
 gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
 true
 
 #
-gap> NewIdentityMatrix( IsPlistMatrixRep, Integers, 0 );;
-gap> M:= NewIdentityMatrix( IsPlistMatrixRep, Integers, 2 );;
+gap> NewIdentityMatrix( IsPlistMatrixRep, Integers, 0 );
+<0x0-matrix over Integers>
+gap> M:= NewIdentityMatrix( IsPlistMatrixRep, Integers, 2 );
+<2x2-matrix over Integers>
 gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
+true
+
+#
+# special filters and families
+#
+gap> v:= NewVector( IsPlistVectorRep, Integers, [ 1, 2, 0 ] );
+<plist vector over Integers of length 3>
+gap> IsMutable( v );
+true
+gap> IsIntVector( v );
+true
+gap> IsFFEVector( v );
+false
+gap> IsCyclotomicCollection( v );
+true
+gap> IsFFECollection( v );
+false
+
+#
+gap> v:= NewVector( IsPlistVectorRep, GF(257), Z(257)^0 * [ 1, 2, 0 ] );
+<plist vector over GF(257) of length 3>
+gap> IsMutable( v );
+true
+gap> IsIntVector( v );
+false
+gap> IsFFEVector( v );
+true
+gap> IsCyclotomicCollection( v );
+false
+gap> IsFFECollection( v );
+true
+
+#
+gap> M:= NewZeroMatrix( IsPlistMatrixRep, Integers, 2, 3 );
+<2x3-matrix over Integers>
+gap> IsMutable( M );
+true
+gap> IsCyclotomicCollColl( M );
+true
+gap> IsFFECollColl( M );
+false
+
+#
+gap> M:= NewZeroMatrix( IsPlistMatrixRep, GF(257), 2, 3 );
+<2x3-matrix over GF(257)>
+gap> IsMutable( M );
+true
+gap> IsCyclotomicCollColl( M );
+false
+gap> IsFFECollColl( M );
 true
 
 #

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -211,6 +211,8 @@ TestWholeMatrixTransforms := function(mat, scalar)
     basedomain := BaseDomain(mat);
     if IsPlistMatrixRep(mat) then
         src := NewMatrix(IsPlistMatrixRep, basedomain, NrCols(mat), src);
+    elif IsGenericMatrixRep(mat) then
+        src := NewMatrix(IsGenericMatrixRep, basedomain, NrCols(mat), src);
     elif Is8BitMatrixRep(mat) then
         ConvertToMatrixRep(src, basedomain);
     fi;

--- a/tst/testspecial/method-not-found-where.g
+++ b/tst/testspecial/method-not-found-where.g
@@ -1,5 +1,5 @@
 # test method-not-found traceback rendering while preserving helper access
-f := a -> a + a;;
+f := a -> IsDiagonalMat(a);;
 f(());
 ShowMethods(1);
 Where(5);

--- a/tst/testspecial/method-not-found-where.g.out
+++ b/tst/testspecial/method-not-found-where.g.out
@@ -1,19 +1,19 @@
 gap> # test method-not-found traceback rendering while preserving helper access
-gap> f := a -> a + a;;
+gap> f := a -> IsDiagonalMat(a);;
 gap> f(());
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `+' on 2 arguments
+Error, no 1st choice method found for `IsDiagonalMatrix' on 1 arguments
 Stack trace:
-*[1] a + a
+*[1] IsDiagonalMat( a )
    @ *stdin*:3
 <function "f">( <arguments> )
  called from read-eval loop at *stdin*:4
 type 'quit;' to quit to outer loop
 brk> ShowMethods(1);
-#I  Searching Method for + with 2 arguments:
-#I  Total: 138 entries
+#I  Searching Method for IsDiagonalMatrix with 1 argument:
+#I  Total: 3 entries
 brk> Where(5);
-*[1] a + a
+*[1] IsDiagonalMat( a )
    @ *stdin*:3
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:2


### PR DESCRIPTION
Store dense matrices as plain row lists for faster entry access.

Partially addresses issue #2148 (the unresolved part is that of a "vector object that is not in `IsList`)
Closes #2973 (an older attempt of something similar)

This PR was created with help of Codex by OpenAI: I planned the work with it, then it did a full first implementation, which was improved by me at first via some rounds of prompts requesting tweaks, then a bunch of manual work to implement details and speedups the AI was not aware.

Since this is fresh, I am sure there are some bugs, and definitely opportunities for things to be improved. And of course plenty of places in the code where using these MatrixObj will blow up because they are not row lists... but that's for future work.

---

Some microbenchmarks show the benefit, namely that performance for basic arithmetic in many cases matches that of ist-of-list matrices, while IsPlistMatrixRep is basically always slower, sometimes quite substantially so.

I am deliberately doing this over a finite field that is not covered by our compressed matrices, as that is IMHO going to be one of the central use cases in GAP; though for integer/rational matrices, I don't think things will be substantially difference, at least relative to each other. There is no point comparing e.g. over GF(2) to our compressed GF(2) matrices, which of course will be much faster than any of the three implementations being tested here.

Setup:

    R:=GF(257);;n:=20;;
    M1:=IdentityMat(n,R);;
    M2:=IdentityMatrix(IsPlistMatrixRep,R,n);;
    M3:=IdentityMatrix(IsFlatPlistMatrixRep,R,n);;

Addition:

    gap> for i in [1..1000] do x:=M1+M1; od; time;
    4
    gap> for i in [1..1000] do x:=M2+M2; od; time;
    12
    gap> for i in [1..1000] do x:=M3+M3; od; time;
    4

Multiplication:

    gap> for i in [1..1000] do x:=M1*M1; od; time;
    66
    gap> for i in [1..1000] do x:=M2*M2; od; time;
    1448
    gap> for i in [1..1000] do x:=M3*M3; od; time;
    60

Inversion:

    gap> for i in [1..1000] do x:=Inverse(M1); od; time;
    7
    gap> for i in [1..1000] do x:=Inverse(M2); od; time;
    83
    gap> for i in [1..1000] do x:=Inverse(M3); od; time;
    4

Powers:

    gap>
    gap> for i in [1..1000] do x:=M1^5; od; time;
    187
    gap> for i in [1..1000] do x:=M2^5; od; time;
    4350
    gap> for i in [1..1000] do x:=M3^5; od; time;
    182

Element access (plist-of-plist benefits from a direct kernel implementation; we could add that for both IsPlistMatrixRep and IsFlatPlistMatrixRep, if so desired)

    gap> for i in [1..1000000] do x:=M1[1,1]; od; time;
    19
    gap> for i in [1..1000000] do x:=M2[1,1]; od; time;
    78
    gap> for i in [1..1000000] do x:=M3[1,1]; od; time;
    66

Example of a typical matrix property: IsDiagonalMat

    gap> for i in [1..10000] do x:=IsDiagonalMat(M1); od; time;
    132
    gap> for i in [1..10000] do x:=IsDiagonalMat(M2); od; time;
    191
    gap> for i in [1..10000] do x:=IsDiagonalMat(M3); od; time;
    146

IsOne (surprisingly is slower for IsFlatPlistMatrixRep, I do not yet know why)

    gap> for i in [1..10000] do x:=IsOne(M1); od; time;
    144
    gap> for i in [1..10000] do x:=IsOne(M2); od; time;
    145
    gap> for i in [1..10000] do x:=IsOne(M3); od; time;
    172

PositionNonZeroInRow is among the core functionality for row reduction:

    gap> for i in [1..1000000] do x:=PositionNonZeroInRow(M1,1); od; time;
    334
    gap> for i in [1..1000000] do x:=PositionNonZeroInRow(M2,1); od; time;
    486
    gap> for i in [1..1000000] do x:=PositionNonZeroInRow(M3,1); od; time;
    376
