### PR TITLE
Fix crash in `CosetLeadersMatFFE`

### DIFF
--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -1523,7 +1523,7 @@ InstallMethod(CosetLeadersMatFFE,"generic",IsCollsElms,
     fi;
     tofind := q^m;
     t := TransposedMat(mat);
-    vl := [];
+    vl := EmptyPlist(m);
     felts := AsSSortedList(f);
     Assert(2, felts[1] = Zero(f));
     nzfelts := felts{[2..q]};
@@ -1541,7 +1541,6 @@ InstallMethod(CosetLeadersMatFFE,"generic",IsCollsElms,
                 Add(vl[i], v*fds[j]);
             fi;
         od;
-        Add(vl[i],false);
     od;
     v := ListWithIdenticalEntries(n, felts[1]);
     w := ZeroOp(t[1]);

--- a/lib/listcoef.gi
+++ b/lib/listcoef.gi
@@ -1516,10 +1516,14 @@ InstallMethod(CosetLeadersMatFFE,"generic",IsCollsElms,
     q := Size(f);
     n := Length(mat[1]);
     m := Length(mat);
+    # The search below assumes the rows form a basis for an m-dimensional
+    # syndrome space, so reject dependent input before building the column data.
+    if RankMat(mat) <> m then
+        Error("CosetLeadersMatFFE: <mat> must have linearly independent rows");
+    fi;
     tofind := q^m;
     t := TransposedMat(mat);
     vl := [];
-    vl[m+1] := false;
     felts := AsSSortedList(f);
     Assert(2, felts[1] = Zero(f));
     nzfelts := felts{[2..q]};

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2590,8 +2590,10 @@ static Obj FuncCOSET_LEADERS_INNER_8BITS(
     Obj  v, w;
     UInt lenv, lenw, q;
 
+    RequirePlainList(SELF_NAME, veclis);
     RequireSmallInt(SELF_NAME, weight);
     RequireSmallInt(SELF_NAME, tofind);
+    RequirePlainList(SELF_NAME, leaders);
 
     lenv = LEN_PLIST(veclis);
     q = LEN_PLIST(felts);

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -3262,8 +3262,10 @@ static Obj FuncCOSET_LEADERS_INNER_GF2(
     Obj  v, w;
     UInt lenv, lenw;
 
+    RequirePlainList(SELF_NAME, veclis);
     RequireSmallInt(SELF_NAME, weight);
     RequireSmallInt(SELF_NAME, tofind);
+    RequirePlainList(SELF_NAME, leaders);
 
     lenv = LEN_PLIST(veclis);
     NEW_GF2VEC(v, TYPE_LIST_GF2VEC, lenv);

--- a/tst/testbugfix/2026-04-15-CosetLeadersMatFFE-errors.tst
+++ b/tst/testbugfix/2026-04-15-CosetLeadersMatFFE-errors.tst
@@ -1,0 +1,8 @@
+# Regression test for square matrices and invalid dependent input in
+# CosetLeadersMatFFE.
+gap> M := IdentityMat(2, GF(2));;
+gap> L := CosetLeadersMatFFE(M, GF(2));;
+gap> Length(L);
+4
+gap> CosetLeadersMatFFE(L, GF(2));
+Error, CosetLeadersMatFFE: <mat> must have linearly independent rows


### PR DESCRIPTION
Reject matrices with dependent rows before building the internal search tables for CosetLeadersMatFFE. This avoids a crash in the 8-bit path and restores correct behaviour for square full-rank inputs.

AI assistance: Codex reproduced the crash, traced it to the internal row-independence assumption, added a regression test, and prepared the fix.

Co-authored-by: Codex <codex@openai.com>
