### PR TITLE
Re-enable codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,8 +14,6 @@ coverage:
       default:
         informational: true
 
-comment: false
-
 ignore:
  - "extern"
  - "hpcgap/extern"


### PR DESCRIPTION
I disabled them 5 years ago in PR #4265, let's try them again. Back then this was done to fix issue #4260, reported by @ThomasBreuer, which was quite annoying.

If that issue still affects us, there are some ways to deal with it apparently. I'll investigate that if and when it is necessary.