### PR TITLE
Re-enable Codecov comments but delay PR notifications

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+  notify:
+    manual_trigger: true  # needed for codecov-notify CI step
+
 coverage:
   precision: 2
   round: down
@@ -13,8 +17,6 @@ coverage:
     changes:
       default:
         informational: true
-
-comment: false
 
 ignore:
  - "extern"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -280,6 +280,18 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  codecov-notify:
+    name: Finalize Codecov notifications
+    runs-on: ubuntu-slim
+    needs: test
+    if: ${{ always() }}
+
+    steps:
+      - name: "Send Codecov notifications"
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: send-notifications
 
   cross_compile:
     # The host should always be linux


### PR DESCRIPTION
Switch Codecov to manual notifications and send them once after the coverage-uploading test matrix finishes. This avoids noisy intermediate PR comments and temporary dropped-coverage reports while uploads are still in flight.

---

Follow-up to PR #6331. To repeat what I wrote there

I disabled Codecov comments 5 years ago in PR #4265, let's try them again. Back then this was done to fix issue #4260, reported by @ThomasBreuer, which was quite annoying.

That issue persists, but I've now added code which hopefully should avoid it. We'll see.