### PR TITLE
PlainListCopy for list not knowing they are small

### DIFF
--- a/src/lists.c
+++ b/src/lists.c
@@ -1649,7 +1649,8 @@ Obj PLAIN_LIST_COPY(Obj list)
 
 Obj FuncPlainListCopy(Obj self, Obj list)
 {
-    RequireSmallList(SELF_NAME, list);
+    if (!IS_LIST(list))
+        RequireArgument(SELF_NAME, list, "must be a list");
     return PLAIN_LIST_COPY(list);
 }
 

--- a/tst/testbugfix/2026-04-19-PlainListCopy.tst
+++ b/tst/testbugfix/2026-04-19-PlainListCopy.tst
@@ -1,0 +1,6 @@
+# Fix PlainListCopy for lists which are small but do not know it yet know they
+# are in filter `IsSmallList`; this is e.g. needed for the semigroups test
+# suite
+gap> l:=RightTransversal(Group([ (1,2) ]),Group([ () ]));;
+gap> PlainListCopy(l);
+[ (), (1,2) ]

--- a/tst/testinstall/list.tst
+++ b/tst/testinstall/list.tst
@@ -336,15 +336,15 @@ true
 gap> checkPlainListCopy(NewZeroVector(Is8BitVectorRep, GF(3), 10));
 true
 gap> PlainListCopy(6);
-Error, PlainListCopy: <list> must be a small list (not the integer 6)
+Error, PlainListCopy: <list> must be a list (not the integer 6)
 gap> PlainListCopy((1,2,3));
-Error, PlainListCopy: <list> must be a small list (not a permutation (small))
+Error, PlainListCopy: <list> must be a list (not a permutation (small))
 #@if IsHPCGAP
 gap> PlainListCopy(Group((1,2)));
-Error, PlainListCopy: <list> must be a small list (not an atomic component object)
+Error, PlainListCopy: <list> must be a list (not an atomic component object)
 #@else
 gap> PlainListCopy(Group((1,2)));
-Error, PlainListCopy: <list> must be a small list (not a component object)
+Error, PlainListCopy: <list> must be a list (not a component object)
 #@fi
 
 # Check TNUM behaviours


### PR DESCRIPTION
Fix `PlainListCopy` for lists which are small but do not know it yet know they are in filter `IsSmallList`; this is e.g. needed for the semigroups test suite.

This is a regression caused by PR #6327