### PR TITLE
Clarify `IrreducibleModules` description to say 'at most' dim

### DIFF
--- a/lib/grpreps.gd
+++ b/lib/grpreps.gd
@@ -49,8 +49,10 @@ DeclareSynonym(   "AbsolutelyIrreducibleModules", AbsolutIrreducibleModules  );
 ##  <Description>
 ##  returns a list of length 2. The first entry is a generating system of
 ##  <A>G</A>. The second entry is a list of all irreducible modules of
-##  <A>G</A> over the field <A>F</A> in dimension <A>dim</A>, given as MeatAxe modules
+##  <A>G</A> over the field <A>F</A> of dimension at most <A>dim</A>,
+##  given as MeatAxe modules
 ##  (see&nbsp;<Ref Func="GModuleByMats" Label="for generators and a field"/>).
+##  Pass <C>0</C> for <A>dim</A> to impose no dimension bound.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
Closes #6004.

## Problem

The GAPDoc description for `IrreducibleModules` at `lib/grpreps.gd:49-53` claimed the second return entry was:

> a list of all irreducible modules of G over the field F **in** dimension dim

The actual behaviour is to return all irreducible constituents whose dimension is *at most* `dim`, same as the sibling operation `AbsolutelyIrreducibleModules`.

## Evidence

Two independent confirmations in the same file / codebase:

1. **Sibling operation documents it correctly.** `AbsolutelyIrreducibleModules` at `lib/grpreps.gd:18-23` already says *"can be realized over the finite field F and have dimension at most dim"*. Both operations share the same `(G, F, dim)` signature and are implemented side by side; the description should match.

2. **`InstallOtherMethod` comment confirms 0 means "no bound".** `lib/grpreps.gi:314` says:
   ```
   InstallOtherMethod(IrreducibleModules,"Supply no dimension limit",
     [IsGroup, IsField, ...], 0,
   function( G, F ) return IrreducibleModules(G,F,0); end);
   ```
   Only makes sense if `dim=0` lifts the upper bound, not if it selects modules of dimension exactly zero.

## Change

Two-line diff to `lib/grpreps.gd`:

```diff
-##  <A>G</A> over the field <A>F</A> in dimension <A>dim</A>, given as MeatAxe modules
+##  <A>G</A> over the field <A>F</A> of dimension at most <A>dim</A>,
+##  given as MeatAxe modules
 ##  (see&nbsp;<Ref Func="GModuleByMats" Label="for generators and a field"/>).
+##  Pass <C>0</C> for <A>dim</A> to impose no dimension bound.
```

The `Pass 0 to impose no dimension bound` sentence is a small addition that surfaces existing behaviour — previously only discoverable from the `InstallOtherMethod` comment — directly in the reference manual.

Docs only. No behaviour change.