### PR TITLE
Improve `CosetLeadersMatFFE` documentation

### DIFF
--- a/lib/listcoef.gd
+++ b/lib/listcoef.gd
@@ -684,13 +684,30 @@ DeclareOperation("AClosestVectorCombinationsMatFFEVecFFECoords",
 ##  <Oper Name="CosetLeadersMatFFE" Arg='mat, f'/>
 ##
 ##  <Description>
-##  returns a list of representatives of minimal weight for the cosets of a
-##  code.
-##  <A>mat</A> must be a <E>check matrix</E> for the code,
-##  the code is defined over the finite field <A>f</A>.
-##  All rows of <A>mat</A> must have the same length, and all elements must
-##  lie in the field <A>f</A>.
-##  The rows of <A>mat</A> must be linearly independent.
+##  Let <M>C</M> be the linear code over <A>f</A> with check matrix
+##  <A>mat</A>, that is, <M>C</M> is the right null space of <A>mat</A>:
+##  <Display>
+##  C = \{ v \mid mat \cdot v = 0 \}.
+##  </Display>
+##  For each syndrome <M>s</M>, the solutions of the non-homogeneous system
+##  <M><A>mat</A> * v = s</M> form one coset of <M>C</M>. Equivalently, two vectors
+##  lie in the same coset if their difference lies in <M>C</M>, just as in
+##  group theory.
+##  <P/>
+##  <Ref Oper="CosetLeadersMatFFE"/> returns, for each coset of <M>C</M>, a
+##  vector of smallest Hamming weight in that coset. Such a vector is called
+##  a <E>coset leader</E>.
+##  <P/>
+##  If <C>L := CosetLeadersMatFFE( <A>mat</A>, <A>f</A> )</C> and
+##  <C>q := Size( <A>f</A> )</C>, then <C>L[i]</C> is the coset leader whose
+##  syndrome is the vector with number <C>i-1</C>; in other words,
+##  <C>NumberFFVector( mat * L[i], q ) = i - 1</C>
+##  for all valid indices <C>i</C>.
+##  <P/>
+##  Thus the list is indexed by syndromes, not by codewords.
+##  <P/>
+##  All rows of <A>mat</A> must have the same length, all entries must lie in
+##  <A>f</A>, and the rows of <A>mat</A> must be linearly independent.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
Codex wrote most of this and I edited it.

Co-authored-by: Codex <codex@openai.com>

@ThomasBreuer I hope that is clear and then helps with the other two PRs related to `CosetLeadersMatFFE` 

@osj1961 if you happen to have time to double check what I wrote, great! If not, don't worry :-)