### PR TITLE
Fix return value of `PartitionsGreatestLE(0, m)` and improve its documentation

### DIFF
--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -970,7 +970,7 @@ DeclareGlobalFunction("NrPartitions");
 
 #############################################################################
 ##
-#F  PartitionsGreatestLE( <n>, <m> ) . . .  set of partitions of n parts <= n
+#F  PartitionsGreatestLE( <n>, <m> ) . . .  partitions of n with parts <= m
 ##
 ##  <#GAPDoc Label="PartitionsGreatestLE">
 ##  <ManSection>
@@ -979,6 +979,16 @@ DeclareGlobalFunction("NrPartitions");
 ##  <Description>
 ##  returns the set of all (unordered) partitions of the integer <A>n</A>
 ##  having parts less or equal to the integer <A>m</A>.
+##  For <M><A>n</A> = 0</M> and <M><A>m</A> \geq 0</M>, this returns the empty partition
+##  <C>[[]]</C>.
+##  Negative arguments yield the empty list.
+##  <Example><![CDATA[
+##  gap> PartitionsGreatestLE( 6, 3 );
+##  [ [ 1, 1, 1, 1, 1, 1 ], [ 2, 1, 1, 1, 1 ], [ 2, 2, 1, 1 ], [ 2, 2, 2 ],
+##    [ 3, 1, 1, 1 ], [ 3, 2, 1 ], [ 3, 3 ] ]
+##  gap> List( [ 0 .. 3 ], m -> PartitionsGreatestLE( 0, m ) );
+##  [ [ [  ] ], [ [  ] ], [ [  ] ], [ [  ] ] ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -988,7 +998,7 @@ DeclareGlobalFunction("PartitionsGreatestLE");
 
 #############################################################################
 ##
-#F  PartitionsGreatestEQ( <n>, <m> ) . . . . set of partitions of n parts = n
+#F  PartitionsGreatestEQ( <n>, <m> ) . . . . partitions of n with max part m
 ##
 ##  <#GAPDoc Label="PartitionsGreatestEQ">
 ##  <ManSection>
@@ -997,6 +1007,14 @@ DeclareGlobalFunction("PartitionsGreatestLE");
 ##  <Description>
 ##  returns the set of all (unordered) partitions of the integer <A>n</A>
 ##  having greatest part equal to the integer <A>m</A>.
+##  Since partitions use positive parts, this returns the empty list if
+##  <M><A>n</A> \leq 0</M> or <M><A>m</A> \leq 0</M>.
+##  <Example><![CDATA[
+##  gap> PartitionsGreatestEQ( 6, 3 );
+##  [ [ 3, 1, 1, 1 ], [ 3, 2, 1 ], [ 3, 3 ] ]
+##  gap> PartitionsGreatestEQ( 0, 1 );
+##  [  ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -1887,7 +1887,7 @@ end);
 
 #############################################################################
 ##
-#F  PartitionsGreatestLE( <n>, <m> ) . . .  set of partitions of n parts <= m
+#F  PartitionsGreatestLE( <n>, <m> ) . . .  partitions of n with parts <= m
 ##
 ##  returns the set of all (unordered) partitions of the integer <n> having
 ##  parts less or equal to the integer <m>.
@@ -1984,11 +1984,8 @@ function(n,m)
         parts := [];
     else
         if n = 0  then
-            if m = 0  then
-                parts := [ [  ] ];
-            else
-                parts := [  ];
-            fi;
+            # The empty partition satisfies every nonnegative upper bound.
+            parts := [ [  ] ];
         else
             if m = 0  then
                 parts := [  ];
@@ -2003,7 +2000,7 @@ end);
 
 #############################################################################
 ##
-#F  PartitionsGreatestEQ( <n>, <m> ) . . . . set of partitions of n parts = n
+#F  PartitionsGreatestEQ( <n>, <m> ) . . . . partitions of n with max part m
 ##
 ##  returns the set of all (unordered) partitions of the integer <n> having
 ##  greatest part equal to the integer <m>.
@@ -2041,7 +2038,6 @@ BindGlobal( "GPartitionsGreatestEQ", function(n,m)
   # This works exactly as `GPartitionsGreatestLE' for n-m and m and
   # adds a part m to all partitions. This is however done effectively
   # during the work.
-  # This is the same as `Partitions(n,m)' in the GAP library.
   # n and m must be a natural numbers >= 1.
   local B,j,k,l,p,res;
   if m > n then return []; fi;     # a special case

--- a/tst/testinstall/combinat.tst
+++ b/tst/testinstall/combinat.tst
@@ -388,6 +388,28 @@ gap> NrPartitions( 100 );
 gap> NrPartitions( 100, 10 );
 2977866
 
+#F  PartitionsGreatestLE( <n>, <m> ) . . . partitions with largest part <= m
+gap> List( [0..3], m -> PartitionsGreatestLE( 0, m ) );
+[ [ [  ] ], [ [  ] ], [ [  ] ], [ [  ] ] ]
+gap> Print(PartitionsGreatestLE( 6, 3 ),"\n");
+[ [ 1, 1, 1, 1, 1, 1 ], [ 2, 1, 1, 1, 1 ], [ 2, 2, 1, 1 ], [ 2, 2, 2 ], 
+  [ 3, 1, 1, 1 ], [ 3, 2, 1 ], [ 3, 3 ] ]
+gap> Partitions( 6 ) = PartitionsGreatestLE( 6, 6 );
+true
+gap> List( [1..4], k ->
+>      Difference( PartitionsGreatestLE( 6, k ),
+>                  PartitionsGreatestLE( 6, k-1 ) )
+>      = PartitionsGreatestEQ( 6, k ) );
+[ true, true, true, true ]
+gap> Difference( PartitionsGreatestLE( 0, 1 ),
+>                PartitionsGreatestLE( 0, 0 ) )
+>      = PartitionsGreatestEQ( 0, 1 );
+true
+gap> Print(PartitionsGreatestEQ( 6, 3 ),"\n");
+[ [ 3, 1, 1, 1 ], [ 3, 2, 1 ], [ 3, 3 ] ]
+gap> PartitionsGreatestEQ( 0, 1 );
+[  ]
+
 #F  OrderedPartitions( <n> ) . . . .  set of ordered partitions of an integer
 gap> OrderedPartitions( 0 );
 [ [  ] ]


### PR DESCRIPTION
Return the empty partition from PartitionsGreatestLE(0, m) for every nonnegative m. Also clarify the documentation.

Co-authored-by: Codex <codex@openai.com>

Fixes #5548