### PR TITLE
Refine `SetSize` and remove some immediate methods

### DIFF
--- a/lib/coll.gi
+++ b/lib/coll.gi
@@ -92,10 +92,6 @@ InstallMethod( PrintObj,
 ##
 #M  IsEmpty(<C>)  . . . . . . . . . . . . . . . test if a collection is empty
 ##
-InstallImmediateMethod( IsEmpty,
-    IsCollection and HasSize, 0,
-    C -> Size( C ) = 0 );
-
 InstallMethod( IsEmpty,
     "for a collection",
     [ IsCollection ],
@@ -111,10 +107,6 @@ InstallMethod( IsEmpty,
 ##
 #M  IsTrivial(<C>)  . . . . . . . . . . . . . test if a collection is trivial
 ##
-InstallImmediateMethod( IsTrivial,
-    IsCollection and HasSize, 0,
-    C -> Size( C ) = 1 );
-
 InstallMethod( IsTrivial,
     "for a collection",
     [ IsCollection ],
@@ -143,10 +135,6 @@ InstallMethod( IsNonTrivial,
 ##
 #M  IsFinite(<C>) . . . . . . . . . . . . . .  test if a collection is finite
 ##
-InstallImmediateMethod( IsFinite,
-    IsCollection and HasSize, 0,
-    C -> not IsIdenticalObj( Size( C ), infinity ) );
-
 InstallMethod( IsFinite,
     "for a collection",
     [ IsCollection ],
@@ -2879,17 +2867,27 @@ local filt;
   fi;
 
   # some sanity checks
-  Assert(0, not HasIsEmpty(obj) or (IsEmpty(obj) = (sz=0)));
-  Assert(0, not HasIsNonTrivial(obj) or (IsNonTrivial(obj) = (sz<>1)));
-  Assert(0, not HasIsTrivial(obj) or (IsTrivial(obj) = (sz=1)));
-  Assert(0, not HasIsFinite(obj) or (IsFinite(obj) = (sz<>infinity)));
+  Assert(1, not HasIsEmpty(obj) or (IsEmpty(obj) = (sz=0)));
+  Assert(1, not HasIsNonTrivial(obj) or (IsNonTrivial(obj) = (sz<>1)));
+  Assert(1, not HasIsTrivial(obj) or (IsTrivial(obj) = (sz=1)));
+  Assert(1, not HasIsFinite(obj) or (IsFinite(obj) = (sz<>infinity)));
 
-  if sz=0 then filt:=IsEmpty;
-  elif sz=1 then filt:=IsTrivial;
-  elif sz=infinity then filt:=IsNonTrivial and HasIsFinite;
-  else filt:=IsNonTrivial and IsFinite;
+  filt:=HasSize;
+  if sz=0 then
+    filt:=filt and IsEmpty;
+  else
+    filt:=filt and HasIsEmpty;
   fi;
-  filt:=filt and HasSize;
+  if sz=1 then
+    filt:=filt and IsTrivial;
+  else
+    filt:=filt and IsNonTrivial;
+  fi;
+  if sz=infinity then
+    filt:=filt and HasIsFinite;
+  else
+    filt:=filt and IsFinite;
+  fi;
   obj!.Size:=sz;
   SetFilterObj(obj,filt);
 end);

--- a/lib/modfree.gi
+++ b/lib/modfree.gi
@@ -104,16 +104,6 @@ InstallMethod( \in,
 ##  ring is needed since all generator dependent questions are handled in the
 ##  `IsTrivial' call.)
 ##
-InstallImmediateMethod( IsFinite,
-    IsFreeLeftModule and HasIsFiniteDimensional, 0,
-    function( V )
-    if not IsFiniteDimensional( V ) then
-      return false;
-    else
-      TryNextMethod();
-    fi;
-    end );
-
 InstallMethod( IsFinite,
     "for a free left module",
     [ IsFreeLeftModule ],
@@ -136,9 +126,6 @@ InstallMethod( IsFinite,
 ##
 #M  IsTrivial( <V> )
 ##
-InstallImmediateMethod( IsTrivial, IsFreeLeftModule and HasDimension, 0,
-    V -> Dimension( V ) = 0 );
-
 InstallMethod( IsTrivial,
     "for a free left module",
     [ IsFreeLeftModule ],

--- a/tst/testinstall/coll.tst
+++ b/tst/testinstall/coll.tst
@@ -46,13 +46,12 @@ gap> List(props, p -> p(M0));
 gap> N1:=Magma([[[1,0],[0,0]]]);;
 gap> ForAll(props, prop -> not Tester(prop)(N1));
 true
-
-#gap> Size(N1);
-#1
-#gap> ForAll(props, prop -> Tester(prop)(N1));
-#true
-#gap> List(props, p -> p(N1));
-#[ false, true, false, true ]
+gap> Size(N1);
+1
+gap> ForAll(props, prop -> Tester(prop)(N1));
+true
+gap> List(props, p -> p(N1));
+[ false, true, false, true ]
 
 # ... immediate methods for a collection which knows its size,
 # applied to collection with size greater than 1


### PR DESCRIPTION
The removed methods mostly were already obsolete due to the custom `SetSize`. Only the "non emptiness" was not recorded right, which the new code in `SetSize` now handles.

Immediate methods are always a bit problematic because they slow down things. We added the custom `SetSize` (and `SetDimension`) precisely to reduce the need for some of these, but it seems we then did not remove all the now obsolete methods.