### PR TITLE
Uprank {Copy,Extract}SubMatrix methods for compressed matrices

### DIFF
--- a/hpcgap/lib/vec8bit.gi
+++ b/hpcgap/lib/vec8bit.gi
@@ -1063,7 +1063,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and an 8bit mat",
   end );
 
 InstallMethod( ExtractSubMatrix, "for an 8bit matrix, and two lists",
-  [Is8BitMatrixRep, IsList, IsList],
+  [Is8BitMatrixRep and IsMatrix, IsList, IsList],
   function( m, rows, cols )
     local mm;
     mm := m{rows}{cols};
@@ -1072,14 +1072,8 @@ InstallMethod( ExtractSubMatrix, "for an 8bit matrix, and two lists",
     return mm;
   end );
 
-InstallMethod( CopySubVector, "for two 8bit vectors, and two lists",
-  [Is8BitVectorRep, Is8BitVectorRep and IsMutable, IsList, IsList],
-  function( v, w, f, t )
-    w{t} := v{f};
-  end );
-
 InstallMethod( CopySubMatrix, "for two 8bit matrices, and four lists",
-  [Is8BitMatrixRep, Is8BitMatrixRep, IsList, IsList, IsList, IsList],
+  [Is8BitMatrixRep and IsMatrix, Is8BitMatrixRep and IsMatrix, IsList, IsList, IsList, IsList],
   function( a, b, frows, trows, fcols, tcols )
     b{trows}{tcols} := a{frows}{fcols};
   end );

--- a/hpcgap/lib/vecmat.gi
+++ b/hpcgap/lib/vecmat.gi
@@ -2470,7 +2470,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and a gf2 mat",
   end );
 
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
-  [IsGF2MatrixRep, IsList, IsList],
+  [IsGF2MatrixRep and IsMatrix, IsList, IsList],
   function( m, rows, cols )
     local mm,r;
     mm := [];
@@ -2494,14 +2494,8 @@ InstallMethod( CopySubVector, "for two gf2 vectors, and two ranges",
     fi;
   end );
 
-  InstallMethod( CopySubVector, "for two gf2 vectors, and two lists",
-  [IsGF2VectorRep, IsGF2VectorRep and IsMutable, IsList, IsList],
-        function( v, w, f, t )
-    w{t} := v{f};
-  end );
-
 InstallMethod( CopySubMatrix, "for two gf2 matrices, and four lists",
-  [IsGF2MatrixRep, IsGF2MatrixRep, IsList, IsList, IsList, IsList],
+  [IsGF2MatrixRep and IsMatrix, IsGF2MatrixRep and IsMatrix, IsList, IsList, IsList, IsList],
         function( a, b, frows, trows, fcols, tcols )
     local   i;
     for i in [1..Length(frows)] do
@@ -2510,7 +2504,7 @@ InstallMethod( CopySubMatrix, "for two gf2 matrices, and four lists",
 end );
 
 InstallMethod( CopySubMatrix, "for two gf2 matrices, two lists and two ranges",
-  [IsGF2MatrixRep, IsGF2MatrixRep, IsList, IsList, IsRange, IsRange],
+  [IsGF2MatrixRep and IsMatrix, IsGF2MatrixRep and IsMatrix, IsList, IsList, IsRange, IsRange],
         function( a, b, frows, trows, fcols, tcols )
     local   l,  i;
     l := Length(fcols);

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1018,7 +1018,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and an 8bit mat",
   end );
 
 InstallMethod( ExtractSubMatrix, "for an 8bit matrix, and two lists",
-  [Is8BitMatrixRep, IsList, IsList],
+  [Is8BitMatrixRep and IsMatrix, IsList, IsList],
   function( m, rows, cols )
     local mm;
     mm := m{rows}{cols};
@@ -1027,14 +1027,8 @@ InstallMethod( ExtractSubMatrix, "for an 8bit matrix, and two lists",
     return mm;
   end );
 
-InstallMethod( CopySubVector, "for two 8bit vectors, and two lists",
-  [Is8BitVectorRep, Is8BitVectorRep and IsMutable, IsList, IsList],
-  function( v, w, f, t )
-    w{t} := v{f};
-  end );
-
 InstallMethod( CopySubMatrix, "for two 8bit matrices, and four lists",
-  [Is8BitMatrixRep, Is8BitMatrixRep, IsList, IsList, IsList, IsList],
+  [Is8BitMatrixRep and IsMatrix, Is8BitMatrixRep and IsMatrix, IsList, IsList, IsList, IsList],
   function( a, b, frows, trows, fcols, tcols )
     b{trows}{tcols} := a{frows}{fcols};
   end );

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2468,7 +2468,7 @@ InstallMethod( Matrix, "for a list of vecs, an integer, and a gf2 mat",
   end );
 
 InstallMethod( ExtractSubMatrix, "for a gf2 matrix, and two lists",
-  [IsGF2MatrixRep, IsList, IsList],
+  [IsGF2MatrixRep and IsMatrix, IsList, IsList],
   function( m, rows, cols )
     local mm,r;
     mm := [];
@@ -2492,14 +2492,8 @@ InstallMethod( CopySubVector, "for two gf2 vectors, and two ranges",
     fi;
   end );
 
-  InstallMethod( CopySubVector, "for two gf2 vectors, and two lists",
-  [IsGF2VectorRep, IsGF2VectorRep and IsMutable, IsList, IsList],
-        function( v, w, f, t )
-    w{t} := v{f};
-  end );
-
 InstallMethod( CopySubMatrix, "for two gf2 matrices, and four lists",
-  [IsGF2MatrixRep, IsGF2MatrixRep, IsList, IsList, IsList, IsList],
+  [IsGF2MatrixRep and IsMatrix, IsGF2MatrixRep and IsMatrix, IsList, IsList, IsList, IsList],
         function( a, b, frows, trows, fcols, tcols )
     local   i;
     for i in [1..Length(frows)] do
@@ -2508,7 +2502,7 @@ InstallMethod( CopySubMatrix, "for two gf2 matrices, and four lists",
 end );
 
 InstallMethod( CopySubMatrix, "for two gf2 matrices, two lists and two ranges",
-  [IsGF2MatrixRep, IsGF2MatrixRep, IsList, IsList, IsRange, IsRange],
+  [IsGF2MatrixRep and IsMatrix, IsGF2MatrixRep and IsMatrix, IsList, IsList, IsRange, IsRange],
         function( a, b, frows, trows, fcols, tcols )
     local   l,  i;
     l := Length(fcols);

--- a/tst/testinstall/MatrixObj/CopySubMatrix.tst
+++ b/tst/testinstall/MatrixObj/CopySubMatrix.tst
@@ -80,5 +80,55 @@ Error, source and destination row lists must be of equal length
 gap> CopySubMatrix( m5, m4, [ 1 ], [ 1 ], [ 1, 2 ], [ 1 ] );
 Error, source and destination column lists must be of equal length
 
+# IsGF2MatrixRep
+gap> m1 := IdentityMatrix( IsPlistMatrixRep, Rationals, 10 );
+<10x10-matrix over Rationals>
+gap> m2 := ZeroMatrix( 6, 6, m1 );
+<6x6-matrix over Rationals>
+gap> CopySubMatrix( m1, m2, [ 1..3 ], [ 3..5 ], [ 2..4 ], [ 4..6 ] );
+gap> IsOne(m1);
+true
+gap> Display(m2);
+<6x6-matrix over Rationals:
+[[ 0, 0, 0, 0, 0, 0 ]
+ [ 0, 0, 0, 0, 0, 0 ]
+ [ 0, 0, 0, 0, 0, 0 ]
+ [ 0, 0, 0, 1, 0, 0 ]
+ [ 0, 0, 0, 0, 1, 0 ]
+ [ 0, 0, 0, 0, 0, 0 ]
+]>
+
+# IsGF2MatrixRep
+gap> m1 := IdentityMatrix( GF(2), 10 );
+<a 10x10 matrix over GF2>
+gap> m2 := ZeroMatrix( 6, 6, m1 );
+<a 6x6 matrix over GF2>
+gap> CopySubMatrix( m1, m2, [ 1..3 ], [ 3..5 ], [ 2..4 ], [ 4..6 ] );
+gap> IsOne(m1);
+true
+gap> Display(m2);
+ . . . . . .
+ . . . . . .
+ . . . . . .
+ . . . 1 . .
+ . . . . 1 .
+ . . . . . .
+
+# Is8BitMatrixRep
+gap> m1 := IdentityMatrix( GF(3), 10 );
+< mutable compressed matrix 10x10 over GF(3) >
+gap> m2 := ZeroMatrix( 6, 6, m1 );
+< mutable compressed matrix 6x6 over GF(3) >
+gap> CopySubMatrix( m1, m2, [ 1..3 ], [ 3..5 ], [ 2..4 ], [ 4..6 ] );
+gap> IsOne(m1);
+true
+gap> Display(m2);
+ . . . . . .
+ . . . . . .
+ . . . . . .
+ . . . 1 . .
+ . . . . 1 .
+ . . . . . .
+
 #
 gap> STOP_TEST("CopySubMatrix.tst");

--- a/tst/testinstall/MatrixObj/ExtractSubMatrix.tst
+++ b/tst/testinstall/MatrixObj/ExtractSubMatrix.tst
@@ -1,13 +1,32 @@
 gap> START_TEST("ExtractSubMatrix.tst");
-gap> IsBoundGlobal("EXTRACT_SUB_MATRIX");
-true
-gap> EXTRACT_SUB_MATRIX = ExtractSubMatrix;
-true
+
+#
 gap> m1 := [ [ 1, 2, 3 ], [ 4, 5, 6 ] ];
 [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
 gap> ExtractSubMatrix( m1, [ 2, 1 ], [ 3, 1 ] );
 [ [ 6, 4 ], [ 3, 1 ] ]
-gap> m2 := IdentityMatrix( Integers, 4 );;
-gap> Unpack( ExtractSubMatrix( m2, [ 2, 4 ], [ 4, 2 ] ) );
+gap> m2 := IdentityMatrix( Integers, 4 );
+<4x4-matrix over Integers>
+gap> m3 := ExtractSubMatrix( m2, [ 2, 4 ], [ 4, 2 ] );
+<2x2-matrix over Integers>
+gap> Unpack( m3 );
 [ [ 0, 1 ], [ 1, 0 ] ]
+
+# IsGF2MatrixRep
+gap> m1 := IdentityMatrix( GF(2), 100 );
+<a 100x100 matrix over GF2>
+gap> m2 := ExtractSubMatrix( m1, [ 11..30 ], [ 11..30 ] );
+<a 20x20 matrix over GF2>
+gap> IsOne(m2);
+true
+
+# Is8BitMatrixRep
+gap> m1 := IdentityMatrix( GF(3), 100 );
+< mutable compressed matrix 100x100 over GF(3) >
+gap> m2 := ExtractSubMatrix( m1, [ 11..30 ], [ 11..30 ] );
+< mutable compressed matrix 20x20 over GF(3) >
+gap> IsOne(m2);
+true
+
+#
 gap> STOP_TEST("ExtractSubMatrix.tst");


### PR DESCRIPTION
... so that they are actually used.

Also remove redundant `CopySubVector` methods.