### PR TITLE
Guard some `IdGroup` calls by `ID_AVAILABLE`

### DIFF
--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2762,10 +2762,10 @@ local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,emb,u,pos,
   local idx,hom,l,f;
     idx:=Index(gp,nor);
     hom:=NaturalHomomorphismByNormalSubgroup(gp,nor);
-    if idx>1000 or idx=512 or not uselib then
-      l:=[idx,fail];
-    else
+    if uselib and ID_AVAILABLE(idx) <> fail then
       l:=ShallowCopy(IdGroup(gp/nor));
+    else
+      l:=[idx,fail];
     fi;
     f:=Image(hom,gp);
     Add(l,hom);
@@ -2835,7 +2835,7 @@ local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,emb,u,pos,
         for k in no do
           hom:=NaturalHomomorphismByNormalSubgroup(j[1],k.representative);
           f:=Image(hom);
-          if Size(f)<1000 and Size(f)<>512 and uselib then
+          if uselib and ID_AVAILABLE(Size(f)) <> fail then
             myid:=ShallowCopy(IdGroup(f));
           else
             myid:=[Size(f),fail];

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2762,7 +2762,7 @@ local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,emb,u,pos,
   local hom,l,f;
     hom:=NaturalHomomorphismByNormalSubgroup(gp,nor);
     f:=Image(hom);
-    if uselib and ID_AVAILABLE(Size(f)) <> fail then
+    if uselib and Size(f) < 1000 and ID_AVAILABLE(Size(f)) <> fail then
       l:=ShallowCopy(IdGroup(f));
     else
       l:=[Size(f),fail];
@@ -2834,7 +2834,7 @@ local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,emb,u,pos,
         for k in no do
           hom:=NaturalHomomorphismByNormalSubgroup(j[1],k.representative);
           f:=Image(hom);
-          if uselib and ID_AVAILABLE(Size(f)) <> fail then
+          if uselib and Size(f) < 1000 and ID_AVAILABLE(Size(f)) <> fail then
             myid:=ShallowCopy(IdGroup(f));
           else
             myid:=[Size(f),fail];

--- a/lib/grplatt.gi
+++ b/lib/grplatt.gi
@@ -2759,15 +2759,14 @@ local fgi,inducedfactorautos,projs,psubs,info,n,l,nl,emb,u,pos,
   fi;
 
   fgi:=function(gp,nor)
-  local idx,hom,l,f;
-    idx:=Index(gp,nor);
+  local hom,l,f;
     hom:=NaturalHomomorphismByNormalSubgroup(gp,nor);
-    if uselib and ID_AVAILABLE(idx) <> fail then
-      l:=ShallowCopy(IdGroup(gp/nor));
+    f:=Image(hom);
+    if uselib and ID_AVAILABLE(Size(f)) <> fail then
+      l:=ShallowCopy(IdGroup(f));
     else
-      l:=[idx,fail];
+      l:=[Size(f),fail];
     fi;
-    f:=Image(hom,gp);
     Add(l,hom);
     Add(l,f);
     Add(l,AutomorphismGroup(f));

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -1861,7 +1861,7 @@ BindGlobal( "StructureDescriptionForFiniteGroups", # for finite groups
 
     # fetch name from precomputed list, if available
     if ValueOption("recompute") <> true and Size(G) <= 2000 then
-      if IsBound(NAMES_OF_SMALL_GROUPS[Size(G)]) then
+      if IsBound(NAMES_OF_SMALL_GROUPS[Size(G)]) and ID_AVAILABLE(Size(G)) <> fail then
         i := IdGroup(G)[2];
         if IsBound(NAMES_OF_SMALL_GROUPS[Size(G)][i]) then
           name := ShallowCopy(NAMES_OF_SMALL_GROUPS[Size(G)][i]);


### PR DESCRIPTION
... instead of hardcoding  assumptions about the availability of `IdGroup`.
