### PR TITLE
Reset the options stack after an error also when the break loop is disabled (`-T` command line option)

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -371,7 +371,25 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         ErrorTracebackLVars := errorTracebackLVars;
         SET_ERROR_LVARS(kernelErrorLVars);
         if IsBound(OnQuit) and IsFunction(OnQuit) then
-            OnQuit();
+            # OnQuit();
+            # We would like to call 'OnQuit()' but the
+            # 'ResetMethodReordering()' call inside 'OnQuit'
+            # affects the output of some tests involving 'TraceMethods'.
+            # Thus we copy the relevant lines from 'OnQuit' here.
+            if not IsEmpty(OptionsStack) then
+              repeat
+                PopOptions();
+              until IsEmpty(OptionsStack);
+              # We would like to print an info message
+              # but this affects the output of some tests.
+              # Note that 'Test' sets 'BreakOnError' to 'false'.
+              # Info(InfoWarning,1,"Options stack has been reset");
+            fi;
+            if REREADING = true then
+              MakeReadWriteGlobal("REREADING");
+              REREADING := false;
+              MakeReadOnlyGlobal("REREADING");
+            fi;
         fi;
         if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;
         JUMP_TO_CATCH(0);

--- a/lib/error.g
+++ b/lib/error.g
@@ -32,13 +32,14 @@ ERROR_OUTPUT := MakeImmutable("*errout*");
 Unbind(OnQuit);
 BIND_GLOBAL( "OnQuit", function()
     if not IsEmpty(OptionsStack) then
+      if IsBound(ResetMethodReordering) and IsFunction(ResetMethodReordering)
+         and ValueOption( "ReadingPackageFiles" ) = true then
+        ResetMethodReordering();
+      fi;
       repeat
         PopOptions();
       until IsEmpty(OptionsStack);
-      Info(InfoWarning,1,"Options stack has been reset");
-    fi;
-    if IsBound(ResetMethodReordering) and IsFunction(ResetMethodReordering) then
-        ResetMethodReordering();
+      Info(InfoWarning,2,"Options stack has been reset");
     fi;
     if REREADING = true then
         MakeReadWriteGlobal("REREADING");
@@ -371,25 +372,7 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         ErrorTracebackLVars := errorTracebackLVars;
         SET_ERROR_LVARS(kernelErrorLVars);
         if IsBound(OnQuit) and IsFunction(OnQuit) then
-            # OnQuit();
-            # We would like to call 'OnQuit()' but the
-            # 'ResetMethodReordering()' call inside 'OnQuit'
-            # affects the output of some tests involving 'TraceMethods'.
-            # Thus we copy the relevant lines from 'OnQuit' here.
-            if not IsEmpty(OptionsStack) then
-              repeat
-                PopOptions();
-              until IsEmpty(OptionsStack);
-              # We would like to print an info message
-              # but this affects the output of some tests.
-              # Note that 'Test' sets 'BreakOnError' to 'false'.
-              # Info(InfoWarning,1,"Options stack has been reset");
-            fi;
-            if REREADING = true then
-              MakeReadWriteGlobal("REREADING");
-              REREADING := false;
-              MakeReadOnlyGlobal("REREADING");
-            fi;
+            OnQuit();
         fi;
         if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;
         JUMP_TO_CATCH(0);

--- a/lib/error.g
+++ b/lib/error.g
@@ -370,6 +370,9 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         ErrorLVars := errorLVars;
         ErrorTracebackLVars := errorTracebackLVars;
         SET_ERROR_LVARS(kernelErrorLVars);
+        if IsBound(OnQuit) and IsFunction(OnQuit) then
+            OnQuit();
+        fi;
         if ErrorLevel = 0 then LEAVE_ALL_NAMESPACES(); fi;
         JUMP_TO_CATCH(0);
     fi;

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -1750,7 +1750,7 @@ InstallGlobalFunction( LoadPackage, function( arg )
             "start reading file 'init.g'",
             info.PackageName );
         GAPInfo.PackageCurrent:= info;
-        ReadPackage( pkgname, "init.g" );
+        ReadPackage( pkgname, "init.g" : ReadingPackageFiles:= true );
         Unbind( GAPInfo.PackageCurrent );
         LogPackageLoadingMessage( PACKAGE_DEBUG,
             "finish reading file 'init.g'",
@@ -1766,7 +1766,8 @@ InstallGlobalFunction( LoadPackage, function( arg )
       # (We have delayed this until now because it uses functionality
       # from the package GAPDoc.)
       # Note that no banners are printed during autoloading.
-      LoadPackage_ReadImplementationParts( secondrun, banner );
+      LoadPackage_ReadImplementationParts( secondrun, banner
+        : ReadingPackageFiles:= true );
       secondrun:= [];
 
     od;

--- a/tst/testinstall/error.tst
+++ b/tst/testinstall/error.tst
@@ -34,3 +34,13 @@ gap> if false then Stabilizer; fi;
 Syntax error: found an expression when a statement was expected in stream:1
 if false then Stabilizer; fi;
                         ^
+
+#
+gap> oldBreakOnError:= BreakOnError;;
+gap> BreakOnError:= false;;
+gap> PushOptions( rec( test:= true ) );
+gap> Error( "!" );
+Error, !
+gap> Length( OptionsStack ) = 0;
+true
+gap> BreakOnError:= oldBreakOnError;;


### PR DESCRIPTION
This situation occurs for example when the GAP is started by GAP.jl in a Julia session.
Not resetting the options stack has strange effects.

resolves #6350