### PR TITLE
Fix `HexSHA256` to always return 64 hex digits and not drop leading zero digits

### DIFF
--- a/lib/files.gi
+++ b/lib/files.gi
@@ -412,5 +412,11 @@ function(str)
     GAP_SHA256_UPDATE(s, str);
     res := GAP_SHA256_FINAL(s);
     res := Sum([0..7], i -> res[8-i]*2^(32*i));;
-    return LowercaseString(HexStringInt(res));
+    res := LowercaseString(HexStringInt(res));
+    # HexStringInt drops leading zero digits, but a SHA256 digest is always
+    # 256 bits = 64 hex digits, so left-pad with '0' if the top byte(s) were 0.
+    if Length(res) < 64 then
+        res := Concatenation(ListWithIdenticalEntries(64 - Length(res), '0'), res);
+    fi;
+    return res;
 end);

--- a/tst/testinstall/sha256.tst
+++ b/tst/testinstall/sha256.tst
@@ -32,6 +32,17 @@ gap> HexSHA256("abcd\r\n");
 gap> HexSHA256("");
 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
+# Inputs whose SHA256 starts with one or more zero hex digits: the result
+# must still be 64 hex characters (the digest is always 256 bits).
+gap> HexSHA256("39");
+"0b918943df0962bc7a1824c0555a389347b4febdc7cf9d1254406d80ce44e3f9"
+gap> HexSHA256("286");
+"00328ce57bbc14b33bd6695bc8eb32cdf2fb5f3a7d89ec14a42825e15d39df60"
+gap> HexSHA256("886");
+"000f21ac06aceb9cdd0575e82d0d85fc39bed0a7a1d71970ba1641666a44f530"
+gap> ForAll(["", "abcd", "39", "286", "886"], s -> Length(HexSHA256(s)) = 64);
+true
+
 #
 gap> HexSHA256(InputTextString("abcd"));
 "88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589"


### PR DESCRIPTION
When the SHA256 digest's leading byte(s) were zero, HexStringInt dropped those leading zero hex digits, so HexSHA256 returned a string shorter than 64 characters. Left-pad the result to 64 hex digits, since a SHA256 digest is always 256 bits.

I don't *love* this, because it is going to change the result of the function if people have been using it, but on the other hand it will make it agree with the function is people use it in other places, and this is more standard.