### PR TITLE
NewMatrix(...,ncols,list) changed to NewMatrix(...,list,ncols)

### DIFF
--- a/lib/matobj.gi
+++ b/lib/matobj.gi
@@ -344,7 +344,7 @@ InstallOtherMethod( ZeroVector, "for an integer and a plain list",
 ##
 InstallMethod( Matrix,
   [ IsOperation, IsSemiring, IsList, IsInt ],
-  { filt, R, list, nrCols } -> NewMatrix( filt, R, nrCols, list ) );
+  { filt, R, list, nrCols } -> NewMatrix( filt, R, list, nrCols ) );
 
 InstallMethod( Matrix,
     [ IsOperation, IsSemiring, IsList ],
@@ -353,18 +353,18 @@ InstallMethod( Matrix,
       Error( "<list> must be not empty; ",
              "to create empty matrices, please specify nrCols");
     fi;
-    return NewMatrix( filt, R, Length( list[1] ), list );
+    return NewMatrix( filt, R, list, Length( list[1] ) );
   end );
 
 InstallMethod( Matrix,
     [ IsOperation, IsSemiring, IsMatrixObj ],
-    { filt, R, mat } -> NewMatrix( filt, R, NrCols( mat ), Unpack( mat ) ) );
+    { filt, R, mat } -> NewMatrix( filt, R, Unpack( mat ), NrCols( mat ) ) );
 # TODO: can we do better? encourage MatrixObj implementors to overload this?
 
 InstallMethod( Matrix,
     [ IsSemiring, IsList, IsInt ],
     { R, list, nrCols } -> NewMatrix( DefaultMatrixRepForBaseDomain( R ),
-                                      R, nrCols, list ) );
+                                      R, list, nrCols ) );
 
 InstallMethod( Matrix,
     [ IsSemiring, IsList ],
@@ -381,14 +381,13 @@ local l;
     if ForAny([2..Length(list)],x->Length(list[x])<>l) then
       TryNextMethod();
     fi;
-    return NewMatrix( DefaultMatrixRepForBaseDomain( R ),
-                      R, l, list );
+    return NewMatrix( DefaultMatrixRepForBaseDomain( R ), R, list, l );
 end );
 
 InstallMethod( Matrix,
     [ IsSemiring, IsMatrixObj ],
     { R, M } -> NewMatrix( DefaultMatrixRepForBaseDomain( R ),
-                           R, NrCols( M ), Unpack( M ) ) );
+                           R, Unpack( M ), NrCols( M ) ) );
 # TODO: can we do better? encourage MatrixObj implementors to overload this?
 
 #
@@ -402,7 +401,7 @@ InstallMethod( Matrix,
     if Length(list[1]) = 0 then Error("list[1] must be not empty, please specify base domain explicitly"); fi;
     basedomain := DefaultScalarDomainOfMatrixList([list]);
     rep := DefaultMatrixRepForBaseDomain(basedomain);
-    return NewMatrix( rep, basedomain, nrCols, list );
+    return NewMatrix( rep, basedomain, list, nrCols );
   end );
 
 InstallMethod( Matrix,
@@ -417,7 +416,7 @@ InstallMethod( Matrix,
     fi;
     R:= DefaultScalarDomainOfMatrixList( [ list ] );
     rep := DefaultMatrixRepForBaseDomain( R );
-    return NewMatrix( rep, R , Length( list[1] ), list );
+    return NewMatrix( rep, R , list, Length( list[1] ) );
   end );
 
 #
@@ -426,7 +425,7 @@ InstallMethod( Matrix,
 InstallMethod( Matrix,
   [IsList, IsInt, IsMatrixOrMatrixObj],
   function( list, nrCols, example )
-    return NewMatrix( ConstructingFilter(example), BaseDomain(example), nrCols, list );
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), list, nrCols );
   end );
 
 InstallMethod( Matrix, "generic convenience method with 2 args",
@@ -438,7 +437,7 @@ InstallMethod( Matrix, "generic convenience method with 2 args",
     if not (IsList(list[1]) or IsVectorObj(list[1])) then
         ErrorNoReturn("Matrix: flat data not supported in two-argument version");
     fi;
-    return NewMatrix( ConstructingFilter(example), BaseDomain(example), Length(list[1]), list );
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), list, Length(list[1]) );
   end );
 
 InstallMethod( Matrix,
@@ -446,7 +445,7 @@ InstallMethod( Matrix,
     function( mat, example )
     # TODO: can we avoid using Unpack? resp. make this more efficient
     # perhaps adjust NewMatrix to take an IsMatrixOrMatrixObj?
-    return NewMatrix( ConstructingFilter(example), BaseDomain(example), NrCols(mat), Unpack(mat) );
+    return NewMatrix( ConstructingFilter(example), BaseDomain(example), Unpack(mat), NrCols(mat) );
   end );
 
 
@@ -466,7 +465,7 @@ InstallTagBasedMethod( NewZeroMatrix,
     z:= Zero( basedomain );
     v:= ListWithIdenticalEntries( cols, z );
     m:= List( [ 1 .. rows ], i -> ShallowCopy( v ) );
-    return NewMatrix( filter, basedomain, cols, m );
+    return NewMatrix( filter, basedomain, m, cols );
   end );
 
 #
@@ -1569,8 +1568,8 @@ InstallMethod( String,
     M -> Concatenation( "NewMatrix( ",
                NameFunction( ConstructingFilter( M ) ), ", ",
                String( BaseDomain( M ) ), ", ",
-               String( NumberColumns( M ) ), ", ",
-               String( Unpack( M ) ), " )" ) );
+               String( Unpack( M ) ), ", ",
+               String( NumberColumns( M ) ), " )" ) );
 
 
 ############################################################################

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -736,14 +736,14 @@ DeclareTagBasedOperation( "NewZeroVector",
 
 #############################################################################
 ##
-#O  NewMatrix( <filt>, <R>, <ncols>, <list> )
+#O  NewMatrix( <filt>, <R>, <list>, <ncols> )
 #O  NewZeroMatrix( <filt>, <R>, <m>, <n> )
 #O  NewIdentityMatrix( <filt>, <R>, <n> )
 ##
 ##  <#GAPDoc Label="NewMatrix">
 ##  <ManSection>
 ##  <Heading>NewMatrix, NewZeroMatrix, NewIdentityMatrix</Heading>
-##  <Oper Name="NewMatrix" Arg='filt,R,ncols,list'/>
+##  <Oper Name="NewMatrix" Arg='filt,R,list,ncols'/>
 ##  <Oper Name="NewZeroMatrix" Arg='filt,R,m,n'/>
 ##  <Oper Name="NewIdentityMatrix" Arg='filt,R,n'/>
 ##
@@ -754,10 +754,10 @@ DeclareTagBasedOperation( "NewZeroVector",
 ##  the <Ref Attr="ConstructingFilter" Label="for a vector object"/>
 ##  <A>filt</A>,
 ##  the <Ref Attr="BaseDomain" Label="for a matrix object"/> <A>R</A>,
-##  <A>n</A> columns
-##  (see <Ref Attr="NumberColumns" Label="for a matrix object"/>),
-##  and the entries described by <A>list</A>,
-##  which can be either a plain list of vector objects of length <A>ncols</A>
+##  the entries described by <A>list</A> and <A>ncols</A> columns
+##  (see <Ref Attr="NumberColumns" Label="for a matrix object"/>).
+##  The <A<list</A> can be either a plain list of vector objects,
+##  each of length <A>ncols</A>,
 ##  or a plain list of plain lists of length <A>ncols</A>
 ##  or a plain list of length a multiple of <A>ncols</A> containing the
 ##  entries in row major order.
@@ -790,7 +790,7 @@ DeclareTagBasedOperation( "NewZeroVector",
 ##  <#/GAPDoc>
 ##
 DeclareTagBasedOperation( "NewMatrix",
-    [ IsOperation, IsSemiring, IsInt, IsList] );
+    [ IsOperation, IsSemiring, IsList, IsInt ] );
 
 DeclareTagBasedOperation( "NewZeroMatrix",
     [ IsOperation, IsSemiring, IsInt, IsInt ] );

--- a/lib/matobj2.gd
+++ b/lib/matobj2.gd
@@ -756,7 +756,7 @@ DeclareTagBasedOperation( "NewZeroVector",
 ##  the <Ref Attr="BaseDomain" Label="for a matrix object"/> <A>R</A>,
 ##  the entries described by <A>list</A> and <A>ncols</A> columns
 ##  (see <Ref Attr="NumberColumns" Label="for a matrix object"/>).
-##  The <A<list</A> can be either a plain list of vector objects,
+##  The <A>list</A> can be either a plain list of vector objects,
 ##  each of length <A>ncols</A>,
 ##  or a plain list of plain lists of length <A>ncols</A>
 ##  or a plain list of length a multiple of <A>ncols</A> containing the

--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -608,7 +608,7 @@ end);
 
 InstallTagBasedMethod( NewMatrix,
   IsZmodnZMatrixRep,
-  function( filter, basedomain, rl, l )
+  function( filter, basedomain, l, rl )
     local check, nd, filterVectors, m, e, filter2, i;
 
     check:= ValueOption( "check" ) <> false;
@@ -793,7 +793,7 @@ InstallMethod( PrintObj, "for a zmodnz matrix", [ IsZmodnZMatrixRep ],
     else
         Print(",",String(m![BDPOS]),",");
     fi;
-    Print(NumberColumns(m),",",Unpack(m),")");
+    Print(Unpack(m),",",NumberColumns(m),")");
   end );
 
 InstallMethod( Display, "for a zmodnz matrix", [ IsZmodnZMatrixRep ],
@@ -826,10 +826,10 @@ InstallMethod( String, "for zmodnz matrix", [ IsZmodnZMatrixRep ],
         Append(st,String(m![BDPOS]));
         Append(st,",");
     fi;
-    Append(st,String(NumberColumns(m)));
-    Add(st,',');
     Append(st,String(Unpack(m)));
     Add(st,')');
+    Append(st,String(NumberColumns(m)));
+    Add(st,',');
     return st;
   end );
 

--- a/lib/matobjplist.gi
+++ b/lib/matobjplist.gi
@@ -190,7 +190,7 @@ InstallTagBasedMethod( NewZeroVector,
 
 InstallTagBasedMethod( NewMatrix,
   IsPlistMatrixRep,
-  function( filter, basedomain, ncols, list )
+  function( filter, basedomain, list, ncols )
     local nd, filterVectors, m, e, i;
 
     # If applicable then replace a flat list 'list' by a nested list
@@ -913,7 +913,7 @@ InstallMethod( PrintObj, [ "IsPlistMatrixRep" ],
     else
         Print(",",String(M![BDPOS]),",");
     fi;
-    Print(NumberColumns(M),",",Unpack(M),")");
+    Print(Unpack(M),",",NumberColumns(M),")");
   end );
 
 InstallMethod( Display, [ "IsPlistMatrixRep" ],
@@ -946,10 +946,10 @@ InstallMethod( String, [ "IsPlistMatrixRep" ],
         Append(st,String(M![BDPOS]));
         Append(st,",");
     fi;
-    Append(st,String(NumberColumns(M)));
-    Add(st,',');
     Append(st,String(Unpack(M)));
     Add(st,')');
+    Append(st,String(NumberColumns(M)));
+    Add(st,',');
     return st;
   end );
 
@@ -1303,8 +1303,8 @@ InstallMethod( ChangedBaseDomain,
 InstallMethod( ChangedBaseDomain,
   [ "IsPlistMatrixRep", "IsRing" ],
   function( M, r )
-    r:= NewMatrix( IsPlistMatrixRep, r, M![RLPOS],
-                   List( M![ROWSPOS], x-> x![ELSPOS] ) );
+    r:= NewMatrix( IsPlistMatrixRep, r,
+                   List( M![ROWSPOS], x-> x![ELSPOS] ), M![RLPOS] );
     if not IsMutable( M ) then
       MakeImmutable( r );
     fi;

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1488,7 +1488,7 @@ InstallOtherMethod( ConstructingFilter,
 ##
 InstallTagBasedMethod( NewMatrix,
   IsPlistRep,
-  function( filter, basedomain, ncols, list )
+  function( filter, basedomain, list, ncols )
     local copied, nd;
 
     # If applicable then replace a flat list 'list' by a nested list

--- a/lib/vec8bit.gi
+++ b/lib/vec8bit.gi
@@ -1109,7 +1109,7 @@ InstallTagBasedMethod( NewZeroVector,
 
 InstallTagBasedMethod( NewMatrix,
   Is8BitMatrixRep,
-  function( filter, f, rl, l )
+  function( filter, f, l, rl )
     local len, m;
     if ValueOption( "check" ) <> false and not Size(f) in [3..256] then
         Error("Is8BitMatrixRep only supports base fields with 3 to 256 elements");

--- a/lib/vecmat.gi
+++ b/lib/vecmat.gi
@@ -2566,7 +2566,7 @@ InstallTagBasedMethod( NewZeroVector,
 
 InstallTagBasedMethod( NewMatrix,
   IsGF2MatrixRep,
-  function( filter, f, rl, l )
+  function( filter, f, l, rl )
     local len, m;
     if Size(f) <> 2 then Error("IsGF2MatrixRep only supported over GF(2)"); fi;
 

--- a/tst/testbugfix/2026-03-23-issue-6270.tst
+++ b/tst/testbugfix/2026-03-23-issue-6270.tst
@@ -1,5 +1,5 @@
-gap> m := NewMatrix( IsPlistMatrixRep, GF(3), 2,
->                    [ [ 0*Z(3), Z(3) ], [ Z(3)^0, 0*Z(3) ] ] );;
+gap> m := NewMatrix( IsPlistMatrixRep, GF(3),
+>                    [ [ 0*Z(3), Z(3) ], [ Z(3)^0, 0*Z(3) ] ], 2 );;
 gap> l := Unpack( m );;
 gap> IsMatrix( m );
 false

--- a/tst/testinstall/MatrixObj/Eigenvalues.tst
+++ b/tst/testinstall/MatrixObj/Eigenvalues.tst
@@ -2,7 +2,7 @@ gap> mat := [[1,2,1],[1,0,1],[0,0,1]];
 [ [ 1, 2, 1 ], [ 1, 0, 1 ], [ 0, 0, 1 ] ]
 gap> Eigenvalues(Rationals,mat);
 [ 2, 1, -1 ]
-gap> matObj1 := NewMatrix(IsPlistMatrixRep,GF(5),3,mat*Z(5)^0);
+gap> matObj1 := NewMatrix(IsPlistMatrixRep,GF(5),mat*Z(5)^0,3);
 <3x3-matrix over GF(5)>
 gap> Eigenvalues(GF(5),matObj1);
 [ Z(5)^2, Z(5)^0, Z(5) ]

--- a/tst/testinstall/MatrixObj/ElementaryMatrices.tst
+++ b/tst/testinstall/MatrixObj/ElementaryMatrices.tst
@@ -60,8 +60,8 @@ true
 gap> TestWholeMatrixTransforms( mat, PrimitiveRoot(F) );
 
 #
-gap> mat := NewMatrix(IsPlistMatrixRep, Integers, 3,
->                     [ [ 2, 4, 5 ], [ 7, 11, -4 ], [ -3, 20, 0 ] ] );;
+gap> mat := NewMatrix(IsPlistMatrixRep, Integers,
+>                     [ [ 2, 4, 5 ], [ 7, 11, -4 ], [ -3, 20, 0 ] ], 3 );;
 gap> IsPlistMatrixRep(mat);
 true
 gap> TestElementaryTransforms( mat, -1 );

--- a/tst/testinstall/MatrixObj/matobjplist.tst
+++ b/tst/testinstall/MatrixObj/matobjplist.tst
@@ -43,15 +43,15 @@ gap> IsMutable( z );
 true
 
 #
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [] );;
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ 1 ] );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, [], 2 );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, [ 1 ], 2 );;
 Error, NewMatrix: Length of <list> is not a multiple of <ncols>
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ [ 1 ] ] );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, [ [ 1 ] ], 2 );;
 Error, the entries of <list> must have length <ncols>
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ [ 1, 2 ] ] );;
-gap> NewMatrix( IsPlistMatrixRep, Integers, 2, [ v ] );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, [ [ 1, 2 ] ], 2 );;
+gap> NewMatrix( IsPlistMatrixRep, Integers, [ v ], 2 );;
 Error, the entries of <list> must have length <ncols>
-gap> M:= NewMatrix( IsPlistMatrixRep, Integers, 2, [ v2, v2 ] );;
+gap> M:= NewMatrix( IsPlistMatrixRep, Integers, [ v2, v2 ], 2 );;
 gap> IsMutable( M ) and ForAll( [ 1 .. Length( M ) ], i -> IsMutable( M[i] ) );
 true
 

--- a/tst/testinstall/MatrixObj/testmatobj.g
+++ b/tst/testinstall/MatrixObj/testmatobj.g
@@ -210,7 +210,7 @@ TestWholeMatrixTransforms := function(mat, scalar)
     od;
     basedomain := BaseDomain(mat);
     if IsPlistMatrixRep(mat) then
-        src := NewMatrix(IsPlistMatrixRep, basedomain, NrCols(mat), src);
+        src := NewMatrix(IsPlistMatrixRep, basedomain, src, NrCols(mat));
     elif Is8BitMatrixRep(mat) then
         ConvertToMatrixRep(src, basedomain);
     fi;


### PR DESCRIPTION
There are four declared versions of Matrix( ..., list, ncols ) but there is NewMatrix( filt, R, ncols, list ).
This discrepancy is undesirable and should be changed before it gets too established.
Perhaps the experts will think it is already too tricky to change? 
As to packages which might be affected:
 -  the intention was to provide a similar PR for cvec, but that proved too tricky - there are just two test cases and a few occurrence in cmat.gi;
 -  semigroups seems to just use Matrix;
 -  are there any others?