### PR TITLE
kernel: turn global GAP and module states back into static globals

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -44,12 +44,15 @@
 
 GAP_STATIC_ASSERT(sizeof(StatHeader) == 8, "StatHeader has wrong size");
 
+#ifdef HPCGAP
 struct CodeModuleState {
-    Bag StackStat;
-    Int CountStat;
+#endif
+DECL_MODULE_STATE Bag StackStat;
+DECL_MODULE_STATE Int CountStat;
 
-    Bag StackExpr;
-    Int CountExpr;
+DECL_MODULE_STATE Bag StackExpr;
+DECL_MODULE_STATE Int CountExpr;
+#ifdef HPCGAP
 };
 
 static ModuleStateOffset CodeStateOffset = -1;
@@ -60,6 +63,9 @@ extern inline struct CodeModuleState * CShelper(void)
 }
 
 #define CS(x) (CShelper()->x)
+#else
+#define CS(x) (x)
+#endif
 
 
 /****************************************************************************
@@ -3250,8 +3256,10 @@ static StructInitInfo module = {
     .preSave = PreSave,
     .postRestore = PostRestore,
 
+#ifdef HPCGAP
     .moduleStateSize = sizeof(struct CodeModuleState),
     .moduleStateOffsetPtr = &CodeStateOffset,
+#endif
     .initModuleState = InitModuleState,
 };
 

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -1796,9 +1796,6 @@ static StructInitInfo module = {
 #ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(CollectorsState_),
  /* moduleStateOffsetPtr = */ &CollectorsStateOffset,
-#else
- /* moduleStateSize      = */ 0,
- /* moduleStateOffsetPtr = */ 0,
 #endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,

--- a/src/collectors.cc
+++ b/src/collectors.cc
@@ -46,15 +46,19 @@ extern "C" {
 *F * * * * * * * * * * * * * module specific state  * * * * * * * * * * * * *
 */
 
+#ifdef HPCGAP
 struct CollectorsState_ {
-    Obj  SC_NW_STACK;
-    Obj  SC_LW_STACK;
-    Obj  SC_PW_STACK;
-    Obj  SC_EW_STACK;
-    Obj  SC_GE_STACK;
-    Obj  SC_CW_VECTOR;
-    Obj  SC_CW2_VECTOR;
-    UInt SC_MAX_STACK_SIZE;
+#endif
+
+DECL_MODULE_STATE Obj  SC_NW_STACK;
+DECL_MODULE_STATE Obj  SC_LW_STACK;
+DECL_MODULE_STATE Obj  SC_PW_STACK;
+DECL_MODULE_STATE Obj  SC_EW_STACK;
+DECL_MODULE_STATE Obj  SC_GE_STACK;
+DECL_MODULE_STATE Obj  SC_CW_VECTOR;
+DECL_MODULE_STATE Obj  SC_CW2_VECTOR;
+DECL_MODULE_STATE UInt SC_MAX_STACK_SIZE;
+#ifdef HPCGAP
 };
 
 static ModuleStateOffset CollectorsStateOffset = -1;
@@ -63,6 +67,17 @@ extern inline struct CollectorsState_ * CollectorsState(void)
 {
     return (struct CollectorsState_ *)StateSlotsAtOffset(CollectorsStateOffset);
 }
+
+#define SC_NW_STACK (CollectorsState()->SC_NW_STACK)
+#define SC_LW_STACK (CollectorsState()->SC_LW_STACK)
+#define SC_PW_STACK (CollectorsState()->SC_PW_STACK)
+#define SC_EW_STACK (CollectorsState()->SC_EW_STACK)
+#define SC_GE_STACK (CollectorsState()->SC_GE_STACK)
+#define SC_CW_VECTOR (CollectorsState()->SC_CW_VECTOR)
+#define SC_CW2_VECTOR (CollectorsState()->SC_CW2_VECTOR)
+#define SC_MAX_STACK_SIZE (CollectorsState()->SC_MAX_STACK_SIZE)
+
+#endif
 
 
 /****************************************************************************
@@ -84,7 +99,7 @@ extern inline struct CollectorsState_ * CollectorsState(void)
 */
 #define SC_PUSH_WORD( word, exp ) \
     if ( ++sp == max ) { \
-        CollectorsState()->SC_MAX_STACK_SIZE *= 2; \
+        SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = DATA_WORD(word); \
@@ -95,7 +110,7 @@ extern inline struct CollectorsState_ * CollectorsState(void)
 
 #define SC_PUSH_GEN( gen, exp ) \
     if ( ++sp == max ) { \
-        CollectorsState()->SC_MAX_STACK_SIZE *= 2; \
+        SC_MAX_STACK_SIZE *= 2; \
         return -1; \
     } \
     *++nw = DATA_WORD(gen); \
@@ -385,22 +400,22 @@ static Int SingleCollectWord(Obj sc, Obj vv, Obj w)
     exps = (UInt)1 << (ebits-1);
 
     // <nw> contains the stack of words to insert
-    vnw = CollectorsState()->SC_NW_STACK;
+    vnw = SC_NW_STACK;
 
     // <lw> contains the word end of the word in <nw>
-    vlw = CollectorsState()->SC_LW_STACK;
+    vlw = SC_LW_STACK;
 
     // <pw> contains the position of the word in <nw> to look at
-    vpw = CollectorsState()->SC_PW_STACK;
+    vpw = SC_PW_STACK;
 
     // <ew> contains the unprocessed exponents at position <pw>
-    vew = CollectorsState()->SC_EW_STACK;
+    vew = SC_EW_STACK;
 
     // <ge> contains the global exponent of the word
-    vge = CollectorsState()->SC_GE_STACK;
+    vge = SC_GE_STACK;
 
     // get the maximal stack size
-    max = CollectorsState()->SC_MAX_STACK_SIZE;
+    max = SC_MAX_STACK_SIZE;
 
     // ensure that the stacks are large enough
     const UInt desiredStackSize = sizeof(Obj) * (max + 2);
@@ -893,22 +908,22 @@ static Int CombiCollectWord(Obj sc, Obj vv, Obj w)
     exps = (UInt)1 << (ebits-1);
 
     // <nw> contains the stack of words to insert
-    vnw = CollectorsState()->SC_NW_STACK;
+    vnw = SC_NW_STACK;
 
     // <lw> contains the word end of the word in <nw>
-    vlw = CollectorsState()->SC_LW_STACK;
+    vlw = SC_LW_STACK;
 
     // <pw> contains the position of the word in <nw> to look at
-    vpw = CollectorsState()->SC_PW_STACK;
+    vpw = SC_PW_STACK;
 
     // <ew> contains the unprocessed exponents at position <pw>
-    vew = CollectorsState()->SC_EW_STACK;
+    vew = SC_EW_STACK;
 
     // <ge> contains the global exponent of the word
-    vge = CollectorsState()->SC_GE_STACK;
+    vge = SC_GE_STACK;
 
     // get the maximal stack size
-    max = CollectorsState()->SC_MAX_STACK_SIZE;
+    max = SC_MAX_STACK_SIZE;
 
     // ensure that the stacks are large enough
     const UInt desiredStackSize = sizeof(Obj) * (max + 2);
@@ -1267,7 +1282,7 @@ static Obj ReducedComm(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
     Obj                 vc2;        // collect vector
 
     // use 'cwVector' to collect word <u>*<w> to
-    vcw = CollectorsState()->SC_CW_VECTOR;
+    vcw = SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     // check that it has the correct length, unpack <u> into it
@@ -1283,7 +1298,7 @@ static Obj ReducedComm(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
     }
 
     // use 'cw2Vector' to collect word <w>*<u> to
-    vc2 = CollectorsState()->SC_CW2_VECTOR;
+    vc2 = SC_CW2_VECTOR;
 
     // check that it has the correct length, unpack <w> into it
     if ( fc->vectorWord( vc2, w, num ) == -1 ) {
@@ -1325,7 +1340,7 @@ static Obj ReducedForm(FinPowConjCol * fc, Obj sc, Obj w)
     Obj                 type;   // type of the return objue
 
     // use 'cwVector' to collect word <w> to
-    vcw = CollectorsState()->SC_CW_VECTOR;
+    vcw = SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     // check that it has the correct length
@@ -1358,7 +1373,7 @@ static Obj ReducedLeftQuotient(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
     Obj                 vc2;        // collect vector
 
     // use 'cwVector' to collect word <w> to
-    vcw = CollectorsState()->SC_CW_VECTOR;
+    vcw = SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     // check that it has the correct length, unpack <w> into it
@@ -1368,7 +1383,7 @@ static Obj ReducedLeftQuotient(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
     }
 
     // use 'cw2Vector' to collect word <u> to
-    vc2 = CollectorsState()->SC_CW2_VECTOR;
+    vc2 = SC_CW2_VECTOR;
 
     // check that it has the correct length, unpack <u> into it
     if ( fc->vectorWord( vc2, u, num ) == -1 ) {
@@ -1402,7 +1417,7 @@ static Obj ReducedProduct(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
     Obj                 vcw;        // collect vector
 
     // use 'cwVector' to collect word <w> to
-    vcw = CollectorsState()->SC_CW_VECTOR;
+    vcw = SC_CW_VECTOR;
     num = SC_NUMBER_RWS_GENERATORS(sc);
 
     // check that it has the correct length, unpack <w> into it
@@ -1441,8 +1456,8 @@ static Obj ReducedPowerSmallInt(FinPowConjCol * fc, Obj sc, Obj w, Obj vpow)
     pow = INT_INTOBJ(vpow);
 
     // use 'cwVector' and 'cw2Vector to collect words to
-    vcw  = CollectorsState()->SC_CW_VECTOR;
-    vc2  = CollectorsState()->SC_CW2_VECTOR;
+    vcw  = SC_CW_VECTOR;
+    vc2  = SC_CW2_VECTOR;
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -1528,8 +1543,8 @@ static Obj ReducedQuotient(FinPowConjCol * fc, Obj sc, Obj w, Obj u)
     Obj                 vc2;        // collect vector
 
     // use 'cwVector' to collect word <w> to
-    vcw  = CollectorsState()->SC_CW_VECTOR;
-    vc2  = CollectorsState()->SC_CW2_VECTOR;
+    vcw  = SC_CW_VECTOR;
+    vc2  = SC_CW2_VECTOR;
     num  = SC_NUMBER_RWS_GENERATORS(sc);
     type = SC_DEFAULT_TYPE(sc);
 
@@ -1647,8 +1662,7 @@ static Obj FuncFinPowConjCol_ReducedQuotient ( Obj self, Obj sc, Obj w, Obj u )
 */
 static Obj FuncSET_SCOBJ_MAX_STACK_SIZE(Obj self, Obj size)
 {
-    CollectorsState()->SC_MAX_STACK_SIZE =
-        GetPositiveSmallInt(SELF_NAME, size);
+    SC_MAX_STACK_SIZE = GetPositiveSmallInt(SELF_NAME, size);
     return 0;
 }
 
@@ -1739,25 +1753,25 @@ static Int InitLibrary (
 static Int InitModuleState(void)
 {
     // register global bags with the garbage collector
-    InitGlobalBag( &CollectorsState()->SC_NW_STACK, "SC_NW_STACK" );
-    InitGlobalBag( &CollectorsState()->SC_LW_STACK, "SC_LW_STACK" );
-    InitGlobalBag( &CollectorsState()->SC_PW_STACK, "SC_PW_STACK" );
-    InitGlobalBag( &CollectorsState()->SC_EW_STACK, "SC_EW_STACK" );
-    InitGlobalBag( &CollectorsState()->SC_GE_STACK, "SC_GE_STACK" );
-    InitGlobalBag( &CollectorsState()->SC_CW_VECTOR, "SC_CW_VECTOR" );
-    InitGlobalBag( &CollectorsState()->SC_CW2_VECTOR, "SC_CW2_VECTOR" );
+    InitGlobalBag(&SC_NW_STACK, "SC_NW_STACK");
+    InitGlobalBag(&SC_LW_STACK, "SC_LW_STACK");
+    InitGlobalBag(&SC_PW_STACK, "SC_PW_STACK");
+    InitGlobalBag(&SC_EW_STACK, "SC_EW_STACK");
+    InitGlobalBag(&SC_GE_STACK, "SC_GE_STACK");
+    InitGlobalBag(&SC_CW_VECTOR, "SC_CW_VECTOR");
+    InitGlobalBag(&SC_CW2_VECTOR, "SC_CW2_VECTOR");
 
     const UInt maxStackSize = 256;
     const UInt desiredStackSize = sizeof(Obj) * (maxStackSize + 2);
-    CollectorsState()->SC_NW_STACK = NewKernelBuffer(desiredStackSize);
-    CollectorsState()->SC_LW_STACK = NewKernelBuffer(desiredStackSize);
-    CollectorsState()->SC_PW_STACK = NewKernelBuffer(desiredStackSize);
-    CollectorsState()->SC_EW_STACK = NewKernelBuffer(desiredStackSize);
-    CollectorsState()->SC_GE_STACK = NewKernelBuffer(desiredStackSize);
+    SC_NW_STACK = NewKernelBuffer(desiredStackSize);
+    SC_LW_STACK = NewKernelBuffer(desiredStackSize);
+    SC_PW_STACK = NewKernelBuffer(desiredStackSize);
+    SC_EW_STACK = NewKernelBuffer(desiredStackSize);
+    SC_GE_STACK = NewKernelBuffer(desiredStackSize);
 
-    CollectorsState()->SC_CW_VECTOR = NEW_STRING(0);
-    CollectorsState()->SC_CW2_VECTOR = NEW_STRING(0);
-    CollectorsState()->SC_MAX_STACK_SIZE = maxStackSize;
+    SC_CW_VECTOR = NEW_STRING(0);
+    SC_CW2_VECTOR = NEW_STRING(0);
+    SC_MAX_STACK_SIZE = maxStackSize;
 
     return 0;
 }
@@ -1779,8 +1793,13 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ 0,
+#ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(CollectorsState_),
  /* moduleStateOffsetPtr = */ &CollectorsStateOffset,
+#else
+ /* moduleStateSize      = */ 0,
+ /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,
 };

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -142,10 +142,11 @@ static inline void SET_NOF_CYC(Obj cyc, Obj val)
 
 // #define XXX_CYC(cyc,len)        (EXPOS_CYC(cyc,len)[0])
 
-
+#ifdef HPCGAP
 static ModuleStateOffset CycStateOffset = -1;
 
 struct CycModuleState {
+#endif
 
 /****************************************************************************
 **
@@ -158,7 +159,7 @@ struct CycModuleState {
 **  It is created in 'InitCyc' with room for up to 1000 coefficients  and  is
 **  resized when need arises.
 */
-Obj ResultCyc;
+DECL_MODULE_STATE Obj ResultCyc;
 
 /****************************************************************************
 **
@@ -178,9 +179,10 @@ Obj ResultCyc;
 **  is called to compute $e_n^i$ and can then do this easier by just  putting
 **  1 at the <i>th place in 'ResultCyc' and then calling 'Cyclotomic'.
 */
-Obj  LastECyc;
-UInt LastNCyc;
+DECL_MODULE_STATE Obj  LastECyc;
+DECL_MODULE_STATE UInt LastNCyc;
 
+#ifdef HPCGAP
 }; // end of struct CycModuleState
 
 extern inline struct CycModuleState *CycState(void)
@@ -189,10 +191,10 @@ extern inline struct CycModuleState *CycState(void)
 }
 
 // For convenience and readability
-#define ResultCyc   CycState()->ResultCyc
-#define LastECyc    CycState()->LastECyc
-#define LastNCyc    CycState()->LastNCyc
-
+#define ResultCyc   (CycState()->ResultCyc)
+#define LastECyc    (CycState()->LastECyc)
+#define LastNCyc    (CycState()->LastNCyc)
+#endif
 
 static void GrowResultCyc(UInt size)
 {
@@ -2201,8 +2203,10 @@ static StructInitInfo module = {
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
 
+#ifdef HPCGAP
     .moduleStateSize = sizeof(struct CycModuleState),
     .moduleStateOffsetPtr = &CycStateOffset,
+#endif
     .initModuleState = InitModuleState,
 };
 

--- a/src/exprs.c
+++ b/src/exprs.c
@@ -40,7 +40,9 @@
 #include "hpc/aobjects.h"
 #endif
 
+#ifdef HPCGAP
 struct ExprsState {
+#endif
 
 /****************************************************************************
 **
@@ -55,10 +57,11 @@ struct ExprsState {
 **  This sometimes puts in superfluous parenthesis: 2 * f( (3 + 4) ), since it
 **  doesn't know that a function call adds automatically parenthesis.
 */
-UInt PrintPrecedence;
+DECL_MODULE_STATE UInt PrintPrecedence;
 
-UInt OldPrintPrecedence;
+DECL_MODULE_STATE UInt OldPrintPrecedence;
 
+#ifdef HPCGAP
 };
 
 static ModuleStateOffset ExprsStateOffset = -1;
@@ -70,6 +73,7 @@ extern inline struct ExprsState * ExprsState(void)
 
 #define PrintPrecedence ExprsState()->PrintPrecedence
 #define OldPrintPrecedence ExprsState()->OldPrintPrecedence
+#endif
 
 /****************************************************************************
 **
@@ -1814,9 +1818,10 @@ static StructInitInfo module = {
     .name = "exprs",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-
+#ifdef HPCGAP
     .moduleStateSize = sizeof(struct ExprsState),
     .moduleStateOffsetPtr = &ExprsStateOffset,
+#endif
 };
 
 StructInitInfo * InitInfoExprs ( void )

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -41,10 +41,13 @@
 #endif
 
 
+#ifdef HPCGAP
 static ModuleStateOffset FuncsStateOffset = -1;
 
 struct FuncsModuleState {
-    Int RecursionDepth;
+#endif
+    DECL_MODULE_STATE Int RecursionDepth;
+#ifdef HPCGAP
 };
 
 extern inline struct FuncsModuleState *FuncsState(void)
@@ -52,32 +55,35 @@ extern inline struct FuncsModuleState *FuncsState(void)
     return (struct FuncsModuleState *)StateSlotsAtOffset(FuncsStateOffset);
 }
 
+#define RecursionDepth (FuncsState()->RecursionDepth)
+#endif
+
 Int IncRecursionDepth(void)
 {
-    int depth = ++(FuncsState()->RecursionDepth);
+    int depth = ++RecursionDepth;
     return depth;
 }
 
 void DecRecursionDepth(void)
 {
-    FuncsState()->RecursionDepth--;
+    RecursionDepth--;
     /* FIXME: According to a comment in the function
               RecursionDepthTrap below, RecursionDepth
               can become "slightly" negative. This
               needs some investigation.
-    GAP_ASSERT(FuncsState()->RecursionDepth >= 0);
+    GAP_ASSERT(RecursionDepth >= 0);
     */
 }
 
 Int GetRecursionDepth(void)
 {
-    return FuncsState()->RecursionDepth;
+    return RecursionDepth;
 }
 
 void SetRecursionDepth(Int depth)
 {
     GAP_ASSERT(depth >= 0);
-    FuncsState()->RecursionDepth = depth;
+    RecursionDepth = depth;
 }
 
 /****************************************************************************
@@ -879,7 +885,7 @@ static Int InitKernel (
 
 static Int InitModuleState(void)
 {
-    FuncsState()->RecursionDepth = 0;
+    RecursionDepth = 0;
 
     return 0;
 }
@@ -895,9 +901,10 @@ static StructInitInfo module = {
     .name = "funcs",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-
+#ifdef HPCGAP
     .moduleStateSize = sizeof(struct FuncsModuleState),
     .moduleStateOffsetPtr = &FuncsStateOffset,
+#endif
     .initModuleState = InitModuleState,
 };
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -18,10 +18,10 @@
 #include "compiler.h"
 #include "error.h"
 #include "funcs.h"
-#include "gapstate.h"
 #ifdef USE_GASMAN
 #include "gasman_intern.h"
 #endif
+#include "gapstate.h"
 #include "gaptime.h"
 #include "gvars.h"
 #include "integer.h"
@@ -123,11 +123,18 @@ static UInt Time;
 */
 static UInt MemoryAllocated;
 
-
 #ifndef HPCGAP
-GAPState MainGAPState;
-#endif
 
+// HACK: include gapstate a second time, but with DECL_GAP_STATE
+// defined to be empty, to root the global variables here; i.e.,
+// `DECL_GAP_STATE Obj Tilde;` is turned into just `Obj Tilde;`
+// and so on.
+#undef GAP_GAPSTATE_H
+#undef DECL_GAP_STATE
+#define DECL_GAP_STATE
+#include "gapstate.h"
+
+#endif
 
 /****************************************************************************
 **

--- a/src/gapstate.h
+++ b/src/gapstate.h
@@ -23,31 +23,35 @@
 
 #include <setjmp.h>
 
+#ifdef HPCGAP
 enum {
     STATE_SLOTS_SIZE = 32768 - 1024,
 };
 
+#define DECL_GAP_STATE
+
 typedef struct GAPState {
-#ifdef HPCGAP
     // TLS data -- this *must* come first, so that we can safely
     // cast a GAPState pointer into a ThreadLocalStorage pointer
     ThreadLocalStorage tls;
+#elif !defined(DECL_GAP_STATE)
+#define DECL_GAP_STATE extern
 #endif
 
     // for Boehm GC
 #if defined(USE_BOEHM_GC)
     #define MAX_GC_PREFIX_DESC 4
-    void ** FreeList[MAX_GC_PREFIX_DESC + 2];
+    DECL_GAP_STATE void ** FreeList[MAX_GC_PREFIX_DESC + 2];
 #endif
 
     // From intrprtr.c
-    Obj  Tilde;
+    DECL_GAP_STATE Obj Tilde;
 
     // The current assertion level for use in Assert
-    Int CurrentAssertionLevel;
+    DECL_GAP_STATE Int CurrentAssertionLevel;
 
     // From gvar.c
-    Obj CurrNamespace;
+    DECL_GAP_STATE Obj CurrNamespace;
 
     // From vars.c
 
@@ -57,19 +61,19 @@ typedef struct GAPState {
     // Assignments to the local variables change this bag. We do not call
     // 'CHANGED_BAG' for each of such change. Instead we wait until a garbage
     // collection begins and then call 'CHANGED_BAG' in 'BeginCollectBags'.
-    Bag   CurrLVars;
+    DECL_GAP_STATE Bag CurrLVars;
 
     // 'PtrLVars' is a pointer to the 'STATE(CurrLVars)' bag. This makes it
     // faster to access local variables.
     //
     // Since a garbage collection may move this bag around, the pointer
     // 'PtrLVars' must be recalculated afterwards in 'VarsAfterCollectBags'.
-    Obj * PtrLVars;
+    DECL_GAP_STATE Obj * PtrLVars;
 
-    Bag   LVarsPool[16];
+    DECL_GAP_STATE Bag LVarsPool[16];
 
     // From read.c
-    jmp_buf ReadJmpError;
+    DECL_GAP_STATE jmp_buf ReadJmpError;
 
     // 'Prompt' holds the string that is to be printed if a new line is read
     // from the interactive files '*stdin*' or '*errin*'.
@@ -77,19 +81,19 @@ typedef struct GAPState {
     // It is set to 'gap> ' or 'brk> ' in the read-eval-print loops and
     // changed to the partial prompt '> ' in 'Read' after the first symbol is
     // read.
-    char Prompt[80];
+    DECL_GAP_STATE char Prompt[80];
 
     // From stats.c
 
     // `ReturnObjStat` is the result of the return-statement that was last
     // executed. It is set in `ExecReturnObj` and used in the handlers that
     // interpret functions.
-    Obj  ReturnObjStat;
+    DECL_GAP_STATE Obj ReturnObjStat;
 
-    ExecStatFunc * CurrExecStatFuncs;
+    DECL_GAP_STATE ExecStatFunc * CurrExecStatFuncs;
 
     // From code.c
-    void * PtrBody;
+    DECL_GAP_STATE void * PtrBody;
 
     // From opers.c
 #ifdef HPCGAP
@@ -99,36 +103,37 @@ typedef struct GAPState {
 #endif
 
     // for use by GAP_TRY / GAP_CATCH and related code
-    int TryCatchDepth;
+    DECL_GAP_STATE int TryCatchDepth;
 
     // Set by `FuncJUMP_TO_CATCH` to the value of its second argument, and
     // and then later extracted by `CALL_WITH_CATCH`. Not currently used by
     // the GAP kernel itself, as far as I can tell.
-    Obj ThrownObject;
+    DECL_GAP_STATE Obj ThrownObject;
 
     // Set to TRUE when a read-eval-loop encounters a `quit` statement.
-    BOOL UserHasQuit;
+    DECL_GAP_STATE BOOL UserHasQuit;
 
     // Set to TRUE when a read-eval-loop encounters a `QUIT` statement.
-    BOOL UserHasQUIT;
+    DECL_GAP_STATE BOOL UserHasQUIT;
 
     // Set by the primary read-eval loop in `FuncSHELL`, based on the value of
     // `ErrorLLevel`. Also, `ReadEvalCommand` saves and restores this value
     // before executing code.
-    Obj ErrorLVars;
+    DECL_GAP_STATE Obj ErrorLVars;
 
     // Records where on the stack `ErrorLVars` is relative to the top; this is
     // modified by `FuncDownEnv` / `FuncUpEnv`, and ultimately used and
     // controlled by the primary read-eval loop in `FuncSHELL`.
-    Int ErrorLLevel;
+    DECL_GAP_STATE Int ErrorLLevel;
 
     // This callback is called in FuncJUMP_TO_CATCH, this is not used by GAP
     // itself but by programs that use GAP as a library to handle errors
-    void (*JumpToCatchCallback)(void);
+    DECL_GAP_STATE void (*JumpToCatchCallback)(void);
 
     // From info.c
-    Int ShowUsedInfoClassesActive;
+    DECL_GAP_STATE Int ShowUsedInfoClassesActive;
 
+#ifdef HPCGAP
     UInt1 StateSlots[STATE_SLOTS_SIZE];
 } GAPState;
 
@@ -136,26 +141,25 @@ typedef struct GAPState {
 // so that all its members can be access with a 16 bit signed offset
 GAP_STATIC_ASSERT(sizeof(GAPState) < 32768, "GAPState is too big");
 
-#ifdef HPCGAP
+#define DECL_MODULE_STATE
 
 EXPORT_INLINE GAPState * ActiveGAPState(void)
 {
     return (GAPState *)GetTLS();
 }
 
+#define STATE(x) (ActiveGAPState()->x)
+
 #else
 
-extern GAPState MainGAPState;
+#define DECL_MODULE_STATE static
 
-EXPORT_INLINE GAPState * ActiveGAPState(void)
-{
-    return &MainGAPState;
-}
+#define STATE(x) (x)
 
 #endif
 
-#define STATE(x) (ActiveGAPState()->x)
 
+#ifdef HPCGAP
 
 // Offset into StateSlots
 typedef Int ModuleStateOffset;
@@ -167,7 +171,9 @@ EXPORT_INLINE void * StateSlotsAtOffset(ModuleStateOffset offset)
 }
 
 // Access a module's registered state
-#define MODULE_STATE(module) \
-    (*(module ## ModuleState *)StateSlotsAtOffset(module ## StateOffset))
+#define MODULE_STATE(module, ident) \
+    (((module ## ModuleState *)StateSlotsAtOffset(module ## StateOffset))->ident)
+
+#endif
 
 #endif    // GAP_GAPSTATE_H

--- a/src/io.c
+++ b/src/io.c
@@ -74,65 +74,73 @@ static Obj SetPrintFormattingStatus;
 static Obj FilenameCache;
 static SymbolTable FilenameSymbolTable;
 
-static ModuleStateOffset IOStateOffset = -1;
-
 enum {
     MAX_OPEN_FILES = 16,
 };
 
+#ifdef HPCGAP
+static ModuleStateOffset IOStateOffset = -1;
+
 struct IOModuleState {
+#endif
 
     // A pointer to the current input file
-    TypInputFile * Input;
+    DECL_MODULE_STATE TypInputFile * Input;
 
     // A pointer to the current output file. It points to the top of the
     // stack 'OutputFiles'.
-    TypOutputFile * Output;
+    DECL_MODULE_STATE TypOutputFile * Output;
 
     //
-    TypOutputFile * IgnoreStdoutErrout;
+    DECL_MODULE_STATE TypOutputFile * IgnoreStdoutErrout;
 
 
     // The file identifier of the current input logfile. If it is not 0 the
     // scanner echoes all input from the files '*stdin*' and '*errin*' to
     // this file.
-    TypOutputFile * InputLog;
+    DECL_MODULE_STATE TypOutputFile * InputLog;
 
     // The file identifier of the current output logfile. If it is not 0 the
     // scanner echoes all output to the files '*stdout*' and '*errout*' to
     // this file.
-    TypOutputFile * OutputLog;
+    DECL_MODULE_STATE TypOutputFile * OutputLog;
 
-    TypOutputFile InputLogFileOrStream;
-    TypOutputFile OutputLogFileOrStream;
+    DECL_MODULE_STATE TypOutputFile InputLogFileOrStream;
+    DECL_MODULE_STATE TypOutputFile OutputLogFileOrStream;
 
-    TypOutputFile DefaultOutput;
+    DECL_MODULE_STATE TypOutputFile DefaultOutput;
 
 #ifdef HPCGAP
-    Obj DefaultOutputStream;
-    Obj DefaultInputStream;
+    DECL_MODULE_STATE Obj DefaultOutputStream;
+    DECL_MODULE_STATE Obj DefaultInputStream;
 #endif
 
-    Int NoSplitLine;
+    DECL_MODULE_STATE Int NoSplitLine;
 
-    BOOL PrintFormattingForStdout;
-    BOOL PrintFormattingForErrout;
+    DECL_MODULE_STATE BOOL PrintFormattingForStdout;
+    DECL_MODULE_STATE BOOL PrintFormattingForErrout;
+#ifdef HPCGAP
 };
 
 // for debugging from GDB / lldb, we mark this as extern inline
-extern inline struct IOModuleState * IO(void)
+extern inline struct IOModuleState * IOHelper(void)
 {
     return (struct IOModuleState *)StateSlotsAtOffset(IOStateOffset);
 }
 
+#define IO(x) (IOHelper()->x)
+#else
+#define IO(x) (x)
+#endif
+
 void LockCurrentOutput(BOOL lock)
 {
-    IO()->IgnoreStdoutErrout = lock ? IO()->Output : NULL;
+    IO(IgnoreStdoutErrout) = lock ? IO(Output) : NULL;
 }
 
 TypInputFile * GetCurrentInput(void)
 {
-    return IO()->Input;
+    return IO(Input);
 }
 
 /****************************************************************************
@@ -279,7 +287,7 @@ static GVarDescriptor DEFAULT_OUTPUT_STREAM;
 static UInt OpenDefaultInput(TypInputFile * input)
 {
   Obj func, stream;
-  stream = IO()->DefaultInputStream;
+  stream = IO(DefaultInputStream);
   if (stream)
       return OpenInputStream(input, stream, FALSE);
   func = GVarOptFunction(&DEFAULT_INPUT_STREAM);
@@ -290,14 +298,14 @@ static UInt OpenDefaultInput(TypInputFile * input)
     ErrorQuit("DEFAULT_INPUT_STREAM() did not return a stream", 0, 0);
   if (IsStringConv(stream))
     return OpenInput(input, CONST_CSTR_STRING(stream));
-  IO()->DefaultInputStream = stream;
+  IO(DefaultInputStream) = stream;
   return OpenInputStream(input, stream, FALSE);
 }
 
 static UInt OpenDefaultOutput(TypOutputFile * output)
 {
   Obj func, stream;
-  stream = IO()->DefaultOutputStream;
+  stream = IO(DefaultOutputStream);
   if (stream)
     return OpenOutputStream(output, stream);
   func = GVarOptFunction(&DEFAULT_OUTPUT_STREAM);
@@ -308,7 +316,7 @@ static UInt OpenDefaultOutput(TypOutputFile * output)
     ErrorQuit("DEFAULT_OUTPUT_STREAM() did not return a stream", 0, 0);
   if (IsStringConv(stream))
     return OpenOutput(output, CONST_CSTR_STRING(stream), FALSE);
-  IO()->DefaultOutputStream = stream;
+  IO(DefaultOutputStream) = stream;
   return OpenOutputStream(output, stream);
 }
 #endif
@@ -353,7 +361,7 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
     /* Handle *defin*; redirect *errin* to *defin* if the default
      * channel is already open. */
     if (streq(filename, "*defin*") ||
-        (streq(filename, "*errin*") && IO()->DefaultInputStream))
+        (streq(filename, "*errin*") && IO(DefaultInputStream)))
         return OpenDefaultInput(input);
 #endif
 
@@ -367,7 +375,7 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
     // paranoia: fill with garbage, to verify we initialize everything
     memset(input, 0x47, sizeof(TypInputFile));
 #endif
-    input->prev = IO()->Input;
+    input->prev = IO(Input);
     input->stream = 0;
     input->file = file;
 
@@ -386,7 +394,7 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
     input->number = 1;
     input->lastErrorLine = 0;
 
-    IO()->Input = input;
+    IO(Input) = input;
 
     // indicate success
     return 1;
@@ -408,7 +416,7 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
     // paranoia: fill with garbage, to verify we initialize everything
     memset(input, 0x47, sizeof(TypInputFile));
 #endif
-    input->prev = IO()->Input;
+    input->prev = IO(Input);
     input->stream = stream;
     input->file = -1;
     input->isstringstream = (CALL_1ARGS(IsInputStringStream, stream) == True);
@@ -429,7 +437,7 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
     input->number = 1;
     input->lastErrorLine = 0;
 
-    IO()->Input = input;
+    IO(Input) = input;
 
     // indicate success
     return 1;
@@ -454,10 +462,10 @@ UInt OpenInputStream(TypInputFile * input, Obj stream, BOOL echo)
 UInt CloseInput(TypInputFile * input)
 {
     GAP_ASSERT(input);
-    GAP_ASSERT(input == IO()->Input);
+    GAP_ASSERT(input == IO(Input));
 
     // revert to previous input
-    IO()->Input = input->prev;
+    IO(Input) = input->prev;
 
     if (input->stream) {
         // if the input stream supports seeking, update its position to
@@ -515,17 +523,17 @@ UInt OpenLog (
 {
 
     // refuse to open a logfile if we already log to one
-    if (IO()->InputLog != 0 || IO()->OutputLog != 0)
+    if (IO(InputLog) != 0 || IO(OutputLog) != 0)
         return 0;
 
     // try to open the file
-    IO()->OutputLogFileOrStream.file = SyFopen(filename, "w", FALSE);
-    IO()->OutputLogFileOrStream.stream = 0;
-    if (IO()->OutputLogFileOrStream.file == -1)
+    IO(OutputLogFileOrStream).file = SyFopen(filename, "w", FALSE);
+    IO(OutputLogFileOrStream).stream = 0;
+    if (IO(OutputLogFileOrStream).file == -1)
         return 0;
 
-    IO()->InputLog = &IO()->OutputLogFileOrStream;
-    IO()->OutputLog = &IO()->OutputLogFileOrStream;
+    IO(InputLog) = &IO(OutputLogFileOrStream);
+    IO(OutputLog) = &IO(OutputLogFileOrStream);
 
     // otherwise indicate success
     return 1;
@@ -543,15 +551,15 @@ UInt OpenLogStream (
 {
 
     // refuse to open a logfile if we already log to one
-    if (IO()->InputLog != 0 || IO()->OutputLog != 0)
+    if (IO(InputLog) != 0 || IO(OutputLog) != 0)
         return 0;
 
     // try to open the file
-    IO()->OutputLogFileOrStream.stream = stream;
-    IO()->OutputLogFileOrStream.file = -1;
+    IO(OutputLogFileOrStream).stream = stream;
+    IO(OutputLogFileOrStream).file = -1;
 
-    IO()->InputLog = &IO()->OutputLogFileOrStream;
-    IO()->OutputLog = &IO()->OutputLogFileOrStream;
+    IO(InputLog) = &IO(OutputLogFileOrStream);
+    IO(OutputLog) = &IO(OutputLogFileOrStream);
 
     // otherwise indicate success
     return 1;
@@ -572,16 +580,16 @@ UInt OpenLogStream (
 UInt CloseLog ( void )
 {
     // refuse to close a non existent logfile
-    if (IO()->InputLog == 0 || IO()->OutputLog == 0 ||
-        IO()->InputLog != IO()->OutputLog)
+    if (IO(InputLog) == 0 || IO(OutputLog) == 0 ||
+        IO(InputLog) != IO(OutputLog))
         return 0;
 
     // close the logfile
-    if (!IO()->InputLog->stream) {
-        SyFclose(IO()->InputLog->file);
+    if (!IO(InputLog)->stream) {
+        SyFclose(IO(InputLog)->file);
     }
-    IO()->InputLog = 0;
-    IO()->OutputLog = 0;
+    IO(InputLog) = 0;
+    IO(OutputLog) = 0;
 
     // indicate success
     return 1;
@@ -608,16 +616,16 @@ UInt OpenInputLog (
 {
 
     // refuse to open a logfile if we already log to one
-    if (IO()->InputLog != 0)
+    if (IO(InputLog) != 0)
         return 0;
 
     // try to open the file
-    IO()->InputLogFileOrStream.file = SyFopen(filename, "w", FALSE);
-    IO()->InputLogFileOrStream.stream = 0;
-    if (IO()->InputLogFileOrStream.file == -1)
+    IO(InputLogFileOrStream).file = SyFopen(filename, "w", FALSE);
+    IO(InputLogFileOrStream).stream = 0;
+    if (IO(InputLogFileOrStream).file == -1)
         return 0;
 
-    IO()->InputLog = &IO()->InputLogFileOrStream;
+    IO(InputLog) = &IO(InputLogFileOrStream);
 
     // otherwise indicate success
     return 1;
@@ -635,14 +643,14 @@ UInt OpenInputLogStream (
 {
 
     // refuse to open a logfile if we already log to one
-    if (IO()->InputLog != 0)
+    if (IO(InputLog) != 0)
         return 0;
 
     // try to open the file
-    IO()->InputLogFileOrStream.stream = stream;
-    IO()->InputLogFileOrStream.file = -1;
+    IO(InputLogFileOrStream).stream = stream;
+    IO(InputLogFileOrStream).file = -1;
 
-    IO()->InputLog = &IO()->InputLogFileOrStream;
+    IO(InputLog) = &IO(InputLogFileOrStream);
 
     // otherwise indicate success
     return 1;
@@ -663,19 +671,19 @@ UInt OpenInputLogStream (
 UInt CloseInputLog ( void )
 {
     // refuse to close a non existent logfile
-    if (IO()->InputLog == 0)
+    if (IO(InputLog) == 0)
         return 0;
 
     // refuse to close a log opened with LogTo
-    if (IO()->InputLog == IO()->OutputLog)
+    if (IO(InputLog) == IO(OutputLog))
         return 0;
 
     // close the logfile
-    if (!IO()->InputLog->stream) {
-        SyFclose(IO()->InputLog->file);
+    if (!IO(InputLog)->stream) {
+        SyFclose(IO(InputLog)->file);
     }
 
-    IO()->InputLog = 0;
+    IO(InputLog) = 0;
 
     // indicate success
     return 1;
@@ -702,17 +710,17 @@ UInt OpenOutputLog (
 {
 
     // refuse to open a logfile if we already log to one
-    if (IO()->OutputLog != 0)
+    if (IO(OutputLog) != 0)
         return 0;
 
     // try to open the file
-    memset(&IO()->OutputLogFileOrStream, 0, sizeof(TypOutputFile));
-    IO()->OutputLogFileOrStream.stream = 0;
-    IO()->OutputLogFileOrStream.file = SyFopen(filename, "w", FALSE);
-    if (IO()->OutputLogFileOrStream.file == -1)
+    memset(&IO(OutputLogFileOrStream), 0, sizeof(TypOutputFile));
+    IO(OutputLogFileOrStream).stream = 0;
+    IO(OutputLogFileOrStream).file = SyFopen(filename, "w", FALSE);
+    if (IO(OutputLogFileOrStream).file == -1)
         return 0;
 
-    IO()->OutputLog = &IO()->OutputLogFileOrStream;
+    IO(OutputLog) = &IO(OutputLogFileOrStream);
 
     // otherwise indicate success
     return 1;
@@ -730,15 +738,15 @@ UInt OpenOutputLogStream (
 {
 
     // refuse to open a logfile if we already log to one
-    if (IO()->OutputLog != 0)
+    if (IO(OutputLog) != 0)
         return 0;
 
     // try to open the file
-    memset(&IO()->OutputLogFileOrStream, 0, sizeof(TypOutputFile));
-    IO()->OutputLogFileOrStream.stream = stream;
-    IO()->OutputLogFileOrStream.file = -1;
+    memset(&IO(OutputLogFileOrStream), 0, sizeof(TypOutputFile));
+    IO(OutputLogFileOrStream).stream = stream;
+    IO(OutputLogFileOrStream).file = -1;
 
-    IO()->OutputLog = &IO()->OutputLogFileOrStream;
+    IO(OutputLog) = &IO(OutputLogFileOrStream);
 
     // otherwise indicate success
     return 1;
@@ -759,19 +767,19 @@ UInt OpenOutputLogStream (
 UInt CloseOutputLog ( void )
 {
     // refuse to close a non existent logfile
-    if (IO()->OutputLog == 0)
+    if (IO(OutputLog) == 0)
         return 0;
 
     // refuse to close a log opened with LogTo
-    if (IO()->OutputLog == IO()->InputLog)
+    if (IO(OutputLog) == IO(InputLog))
         return 0;
 
     // close the logfile
-    if (!IO()->OutputLog->stream) {
-        SyFclose(IO()->OutputLog->file);
+    if (!IO(OutputLog)->stream) {
+        SyFclose(IO(OutputLog)->file);
     }
 
-    IO()->OutputLog = 0;
+    IO(OutputLog) = 0;
 
     // indicate success
     return 1;
@@ -816,7 +824,7 @@ UInt OpenOutput(TypOutputFile * output, const Char * filename, BOOL append)
     GAP_ASSERT(output);
 
     // do nothing for stdout and errout if caught
-    if (IO()->Output != NULL && IO()->IgnoreStdoutErrout == IO()->Output &&
+    if (IO(Output) != NULL && IO(IgnoreStdoutErrout) == IO(Output) &&
         (streq(filename, "*errout*") || streq(filename, "*stdout*"))) {
         return 1;
     }
@@ -839,17 +847,17 @@ UInt OpenOutput(TypOutputFile * output, const Char * filename, BOOL append)
     // paranoia: fill with garbage, to verify we initialize everything
     memset(output, 0x47, sizeof(TypOutputFile));
 #endif
-    output->prev = IO()->Output;
-    IO()->Output = output;
+    output->prev = IO(Output);
+    IO(Output) = output;
     output->isstringstream = FALSE;
     output->stream = 0;
     output->file = file;
     output->line[0] = '\0';
     output->pos = 0;
     if (streq(filename, "*stdout*"))
-        output->format = IO()->PrintFormattingForStdout;
+        output->format = IO(PrintFormattingForStdout);
     else if (streq(filename, "*errout*"))
-        output->format = IO()->PrintFormattingForErrout;
+        output->format = IO(PrintFormattingForErrout);
     else
         output->format = TRUE;
     output->indent = 0;
@@ -879,8 +887,8 @@ UInt OpenOutputStream(TypOutputFile * output, Obj stream)
     // paranoia: fill with garbage, to verify we initialize everything
     memset(output, 0x47, sizeof(TypOutputFile));
 #endif
-    output->prev = IO()->Output;
-    IO()->Output = output;
+    output->prev = IO(Output);
+    IO(Output) = output;
     output->isstringstream = (CALL_1ARGS(IsOutputStringStream, stream) == True);
     output->stream = stream;
     output->file = -1;
@@ -921,15 +929,15 @@ UInt CloseOutput(TypOutputFile * output)
     // silently refuse to close the test output file; this is probably an
     // attempt to close *errout* which is silently not opened, so let's
     // silently not close it
-    if (IO()->IgnoreStdoutErrout == IO()->Output)
+    if (IO(IgnoreStdoutErrout) == IO(Output))
         return 1;
 
-    GAP_ASSERT(output == IO()->Output);
+    GAP_ASSERT(output == IO(Output));
 
     // refuse to close the initial output file '*stdout*'
 #ifdef HPCGAP
     if (output->prev == 0 && output->stream &&
-        IO()->DefaultOutputStream == output->stream)
+        IO(DefaultOutputStream) == output->stream)
         return 0;
 #else
     if (output->prev == 0)
@@ -943,7 +951,7 @@ UInt CloseOutput(TypOutputFile * output)
     }
 
     // revert to previous output file and indicate success
-    IO()->Output = output->prev;
+    IO(Output) = output->prev;
 
     // don't keep GAP objects alive unnecessarily
     output->stream = 0;
@@ -1068,7 +1076,7 @@ static Char GetLine(TypInputFile * input)
             Pr("%c", (Int)'\03', 0);
         }
         else if (input->file == 0 || input->file == 2) {
-            if (IO()->Output->pos > 0)
+            if (IO(Output)->pos > 0)
                 Pr("\n", 0, 0);
             if ( PrintPromptHook )
                  Call0ArgsInNewReader( PrintPromptHook );
@@ -1095,9 +1103,9 @@ static Char GetLine(TypInputFile * input)
     }
 
     // if necessary echo the line to the logfile
-    if (IO()->InputLog != 0 && input->echo == 1)
+    if (IO(InputLog) != 0 && input->echo == 1)
         if (!(input->ptr[0] == '\377' && input->ptr[1] == '\0'))
-            PutLine2(IO()->InputLog, input->ptr, strlen(input->ptr));
+            PutLine2(IO(InputLog), input->ptr, strlen(input->ptr));
 
     // return the current character
     return *input->ptr;
@@ -1156,9 +1164,9 @@ static void PutLineTo(TypOutputFile * stream, UInt len)
   PutLine2( stream, stream->line, len );
 
   // if necessary echo it to the logfile
-  if (IO()->OutputLog != 0 && !stream->stream) {
+  if (IO(OutputLog) != 0 && !stream->stream) {
       if (stream->file == 1 || stream->file == 3) {
-          PutLine2(IO()->OutputLog, stream->line, len);
+          PutLine2(IO(OutputLog), stream->line, len);
       }
   }
 }
@@ -1298,9 +1306,9 @@ static void PutChrTo(TypOutputFile * stream, Char ch)
   /* TODO: For threads other than the main thread, reserve some extra
      space for the thread id indicator. See issue #136. */
   else if (stream->pos <
-           SyNrCols - 2 - 6 * (TLS(threadID) != 0) - IO()->NoSplitLine) {
+           SyNrCols - 2 - 6 * (TLS(threadID) != 0) - IO(NoSplitLine)) {
 #else
-  else if (stream->pos < SyNrCols - 2 - IO()->NoSplitLine) {
+  else if (stream->pos < SyNrCols - 2 - IO(NoSplitLine)) {
 #endif
 
     // put the character on this line
@@ -1390,7 +1398,7 @@ static void PutChrTo(TypOutputFile * stream, Char ch)
 */
 static Obj FuncToggleEcho(Obj self)
 {
-    IO()->Input->echo = !IO()->Input->echo;
+    IO(Input)->echo = !IO(Input)->echo;
     return (Obj)0;
 }
 
@@ -1428,8 +1436,8 @@ static Obj FuncPRINT_CPROMPT(Obj self, Obj prompt)
 
 void ResetOutputIndent(void)
 {
-    GAP_ASSERT(IO()->Output);
-    IO()->Output->indent = 0;
+    GAP_ASSERT(IO(Output));
+    IO(Output)->indent = 0;
 }
 
 
@@ -1625,14 +1633,14 @@ static inline void FormatOutput(
         // with null bytes, behavior of 'prec' is undefined.
         if (*q == '\0')
           continue;
-        if (*q == '\\' && IO()->NoSplitLine == 0) {
+        if (*q == '\\' && IO(NoSplitLine) == 0) {
           if (*(q + 1) < '8' && *(q + 1) >= '0')
-            IO()->NoSplitLine = 3;
+            IO(NoSplitLine) = 3;
           else
-            IO()->NoSplitLine = 1;
+            IO(NoSplitLine) = 1;
         }
-        else if (IO()->NoSplitLine > 0)
-          IO()->NoSplitLine--;
+        else if (IO(NoSplitLine) > 0)
+          IO(NoSplitLine)--;
         put_a_char(state, *q);
 
         if (arg1obj) {
@@ -1788,11 +1796,11 @@ void Pr (
          Int                 arg2 )
 {
 #ifdef HPCGAP
-    if (!IO()->Output) {
-        OpenDefaultOutput(&IO()->DefaultOutput);
+    if (!IO(Output)) {
+        OpenDefaultOutput(&IO(DefaultOutput));
     }
 #endif
-    PrTo(IO()->Output, format, arg1, arg2);
+    PrTo(IO(Output), format, arg1, arg2);
 }
 
 typedef struct {
@@ -1818,52 +1826,52 @@ void SPrTo(Char *buffer, UInt maxlen, const Char *format, Int arg1, Int arg2)
 
 static Obj FuncINPUT_FILENAME(Obj self)
 {
-    if (IO()->Input == 0)
+    if (IO(Input) == 0)
         return MakeImmString("*defin*");
 
-    UInt gapnameid = GetInputFilenameID(IO()->Input);
+    UInt gapnameid = GetInputFilenameID(IO(Input));
     return GetCachedFilename(gapnameid);
 }
 
 static Obj FuncINPUT_LINENUMBER(Obj self)
 {
-    return INTOBJ_INT(IO()->Input ? IO()->Input->number : 0);
+    return INTOBJ_INT(IO(Input) ? IO(Input)->number : 0);
 }
 
 static Obj FuncSET_PRINT_FORMATTING_STDOUT(Obj self, Obj val)
 {
     BOOL format = (val != False);
-    TypOutputFile * output = IO()->Output;
+    TypOutputFile * output = IO(Output);
     while (output) {
         if (!output->stream && output->file == 1)
             output->format = format;
         output = output->prev;
     }
-    IO()->PrintFormattingForStdout = format;
+    IO(PrintFormattingForStdout) = format;
     return 0;
 }
 
 static Obj FuncPRINT_FORMATTING_STDOUT(Obj self)
 {
-    return IO()->PrintFormattingForStdout ? True : False;
+    return IO(PrintFormattingForStdout) ? True : False;
 }
 
 static Obj FuncSET_PRINT_FORMATTING_ERROUT(Obj self, Obj val)
 {
     BOOL format = (val != False);
-    TypOutputFile * output = IO()->Output;
+    TypOutputFile * output = IO(Output);
     while (output) {
         if (!output->stream && output->file == 3)
             output->format = format;
         output = output->prev;
     }
-    IO()->PrintFormattingForErrout = format;
+    IO(PrintFormattingForErrout) = format;
     return 0;
 }
 
 static Obj FuncPRINT_FORMATTING_ERROUT(Obj self)
 {
-    return IO()->PrintFormattingForErrout ? True : False;
+    return IO(PrintFormattingForErrout) ? True : False;
 }
 
 /****************************************************************************
@@ -1878,7 +1886,7 @@ static Obj FuncCALL_WITH_FORMATTING_STATUS(Obj self, Obj status, Obj func, Obj a
     RequireTrueOrFalse(SELF_NAME, status);
     RequireSmallList(SELF_NAME, args);
 
-    TypOutputFile * output = IO()->Output;
+    TypOutputFile * output = IO(Output);
     if (!output)
         ErrorMayQuit("CALL_WITH_FORMATTING_STATUS called while no output is open", 0, 0);
 
@@ -1902,18 +1910,18 @@ static Obj FuncCALL_WITH_FORMATTING_STATUS(Obj self, Obj status, Obj func, Obj a
 
 static Obj FuncIS_INPUT_TTY(Obj self)
 {
-    GAP_ASSERT(IO()->Input);
-    if (IO()->Input->stream)
+    GAP_ASSERT(IO(Input));
+    if (IO(Input)->stream)
         return False;
-    return SyBufIsTTY(IO()->Input->file) ? True : False;
+    return SyBufIsTTY(IO(Input)->file) ? True : False;
 }
 
 static Obj FuncIS_OUTPUT_TTY(Obj self)
 {
-    GAP_ASSERT(IO()->Output);
-    if (IO()->Output->stream)
+    GAP_ASSERT(IO(Output));
+    if (IO(Output)->stream)
         return False;
-    return SyBufIsTTY(IO()->Output->file) ? True : False;
+    return SyBufIsTTY(IO(Output)->file) ? True : False;
 }
 
 static Obj FuncGET_FILENAME_CACHE(Obj self)
@@ -1960,14 +1968,14 @@ static Int InitLibrary (
 static Int InitKernel (
     StructInitInfo *    module )
 {
-    IO()->Input = 0;
-    IO()->Output = 0;
-    IO()->InputLog = 0;
-    IO()->OutputLog = 0;
-    IO()->PrintFormattingForStdout = TRUE;
-    IO()->PrintFormattingForErrout = TRUE;
+    IO(Input) = 0;
+    IO(Output) = 0;
+    IO(InputLog) = 0;
+    IO(OutputLog) = 0;
+    IO(PrintFormattingForStdout) = TRUE;
+    IO(PrintFormattingForErrout) = TRUE;
 
-    OpenOutput(&IO()->DefaultOutput, "*stdout*", FALSE);
+    OpenOutput(&IO(DefaultOutput), "*stdout*", FALSE);
 
     InitSymbolTableKernel(&FilenameSymbolTable, "FilenameSymbolCount",
                           "FilenameSymbolTable", GetCachedFilename,
@@ -1982,9 +1990,9 @@ static Int InitKernel (
 
 #else
     // register global bags with the garbage collector
-    InitGlobalBag(&(IO()->InputLogFileOrStream.stream),
+    InitGlobalBag(&(IO(InputLogFileOrStream).stream),
                   "src/io.c:InputLogFileOrStream");
-    InitGlobalBag(&(IO()->OutputLogFileOrStream.stream),
+    InitGlobalBag(&(IO(OutputLogFileOrStream).stream),
                   "src/io.c:OutputLogFileOrStream");
 #endif
 
@@ -2014,9 +2022,10 @@ static StructInitInfo module = {
     .name = "io",
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
-
+#ifdef HPCGAP
     .moduleStateSize = sizeof(struct IOModuleState),
     .moduleStateOffsetPtr = &IOStateOffset,
+#endif
 };
 
 StructInitInfo * InitInfoIO ( void )

--- a/src/modules.c
+++ b/src/modules.c
@@ -97,6 +97,8 @@ static Int                 NrImportedGVars;
 static StructImportedGVars ImportedFuncs[MAX_IMPORTED_GVARS];
 static Int                 NrImportedFuncs;
 
+#ifdef HPCGAP
+
 static Int StateNextFreeOffset = 0; // Start of next free memory area (as offset into GAPState.StateSlots)
 
 static void RegisterModuleState(StructInitInfo * info)
@@ -123,6 +125,7 @@ static void RegisterModuleState(StructInitInfo * info)
     StateNextFreeOffset = (StateNextFreeOffset + sizeof(Obj)-1) & ~(sizeof(Obj)-1);
 }
 
+#endif
 
 /*************************************************************************
 **
@@ -149,7 +152,9 @@ Int ActivateModule(StructInitInfo * info)
 {
     Int res = 0;
 
+#ifdef HPCGAP
     RegisterModuleState(info);
+#endif
 
     if (info->initKernel) {
         res = info->initKernel(info);
@@ -941,7 +946,9 @@ void ModulesSetup(void)
             fputs(")\n", stderr);
         }
 
+#ifdef HPCGAP
         RegisterModuleState(info);
+#endif
     }
     NrBuiltinModules = NrModules;
 }

--- a/src/modules.h
+++ b/src/modules.h
@@ -90,6 +90,7 @@ struct init_info {
     // function to call after restoring workspace
     Int (*postRestore)(StructInitInfo *);
 
+#ifdef HPCGAP
     // number of bytes this module needs for its per-thread module state
     // Only used in HPC-GAP, but not behind an #ifdef guard to avoid API
     // breakage for C++ kernel extensions
@@ -100,6 +101,7 @@ struct init_info {
     // Only used in HPC-GAP, but not behind an #ifdef guard to avoid API
     // breakage for C++ kernel extensions
     Int * moduleStateOffsetPtr;
+#endif
 
     // initialize thread local module state
     Int (*initModuleState)(void);

--- a/src/modules.h
+++ b/src/modules.h
@@ -91,10 +91,14 @@ struct init_info {
     Int (*postRestore)(StructInitInfo *);
 
     // number of bytes this module needs for its per-thread module state
+    // Only used in HPC-GAP, but not behind an #ifdef guard to avoid API
+    // breakage for C++ kernel extensions
     UInt moduleStateSize;
 
     // if this is not zero, then the module state offset is stored into
     // the address this points at
+    // Only used in HPC-GAP, but not behind an #ifdef guard to avoid API
+    // breakage for C++ kernel extensions
     Int * moduleStateOffsetPtr;
 
     // initialize thread local module state

--- a/src/objcftl.c
+++ b/src/objcftl.c
@@ -32,19 +32,28 @@
 #include "plist.h"
 
 
+#ifdef HPCGAP
 static ModuleStateOffset CFTLStateOffset = -1;
 
 struct CFTLModuleState {
-    Obj WORD_STACK;
-    Obj WORD_EXPONENT_STACK;
-    Obj SYLLABLE_STACK;
-    Obj EXPONENT_STACK;
+#endif
+    DECL_MODULE_STATE Obj WORD_STACK;
+    DECL_MODULE_STATE Obj WORD_EXPONENT_STACK;
+    DECL_MODULE_STATE Obj SYLLABLE_STACK;
+    DECL_MODULE_STATE Obj EXPONENT_STACK;
+#ifdef HPCGAP
 };
 
 extern inline struct CFTLModuleState *CFTLState(void)
 {
     return (struct CFTLModuleState *)StateSlotsAtOffset(CFTLStateOffset);
 }
+
+#define WORD_STACK  (CFTLState()->WORD_STACK)
+#define WORD_EXPONENT_STACK  (CFTLState()->WORD_EXPONENT_STACK)
+#define SYLLABLE_STACK  (CFTLState()->SYLLABLE_STACK)
+#define EXPONENT_STACK  (CFTLState()->EXPONENT_STACK)
+#endif
 
 static inline Obj IncInt(Obj x)
 {
@@ -133,10 +142,10 @@ static Obj CollectPolycyc(Obj pcp, Obj list, Obj word)
     Obj    ipow    = CONST_ADDR_OBJ(pcp)[ PC_INVERSEPOWERS ];
     Obj    exp     = CONST_ADDR_OBJ(pcp)[ PC_EXPONENTS ];
 
-    Obj    wst  = CFTLState()->WORD_STACK;
-    Obj    west = CFTLState()->WORD_EXPONENT_STACK;
-    Obj    sst  = CFTLState()->SYLLABLE_STACK;
-    Obj    est  = CFTLState()->EXPONENT_STACK;
+    Obj    wst  = WORD_STACK;
+    Obj    west = WORD_EXPONENT_STACK;
+    Obj    sst  = SYLLABLE_STACK;
+    Obj    est  = EXPONENT_STACK;
 
     Obj    conj=0, iconj=0;   /*QQ initialize to please compiler */
 
@@ -411,15 +420,15 @@ static Int InitLibrary (
 
 static Int InitModuleState(void)
 {
-    InitGlobalBag( &CFTLState()->WORD_STACK, "WORD_STACK" );
-    InitGlobalBag( &CFTLState()->WORD_EXPONENT_STACK, "WORD_EXPONENT_STACK" );
-    InitGlobalBag( &CFTLState()->SYLLABLE_STACK, "SYLLABLE_STACK" );
-    InitGlobalBag( &CFTLState()->EXPONENT_STACK, "EXPONENT_STACK" );
+    InitGlobalBag( &WORD_STACK, "WORD_STACK" );
+    InitGlobalBag( &WORD_EXPONENT_STACK, "WORD_EXPONENT_STACK" );
+    InitGlobalBag( &SYLLABLE_STACK, "SYLLABLE_STACK" );
+    InitGlobalBag( &EXPONENT_STACK, "EXPONENT_STACK" );
 
-    CFTLState()->WORD_STACK = NEW_PLIST( T_PLIST, 4096 );
-    CFTLState()->WORD_EXPONENT_STACK = NEW_PLIST( T_PLIST, 4096 );
-    CFTLState()->SYLLABLE_STACK = NEW_PLIST( T_PLIST, 4096 );
-    CFTLState()->EXPONENT_STACK = NEW_PLIST( T_PLIST, 4096 );
+    WORD_STACK = NEW_PLIST( T_PLIST, 4096 );
+    WORD_EXPONENT_STACK = NEW_PLIST( T_PLIST, 4096 );
+    SYLLABLE_STACK = NEW_PLIST( T_PLIST, 4096 );
+    EXPONENT_STACK = NEW_PLIST( T_PLIST, 4096 );
 
     return 0;
 }
@@ -436,8 +445,10 @@ static StructInitInfo module = {
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
 
+#ifdef HPCGAP
     .moduleStateSize = sizeof(struct CFTLModuleState),
     .moduleStateOffsetPtr = &CFTLStateOffset,
+#endif
     .initModuleState = InitModuleState,
 };
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -44,12 +44,14 @@ enum {
     MAXPRINTDEPTH = 64,
 };
 
+#ifdef HPCGAP
 static ModuleStateOffset ObjectsStateOffset = -1;
 
 typedef struct {
-    UInt  PrintObjDepth;
-    Obj   PrintObjThiss[MAXPRINTDEPTH];
-    Int   PrintObjIndices[MAXPRINTDEPTH];
+#endif
+    DECL_MODULE_STATE UInt PrintObjDepth;
+    DECL_MODULE_STATE Obj  PrintObjThiss[MAXPRINTDEPTH];
+    DECL_MODULE_STATE Int  PrintObjIndices[MAXPRINTDEPTH];
 
     // This variable is used to allow a ViewObj method to call PrintObj on the
     // same object without triggering use of '~'. It contains one of the
@@ -57,10 +59,16 @@ typedef struct {
     // 0: there is no enclosing call to PrintObj or ViewObj still open, or
     // 1: the innermost such is PrintObj, or
     // 2: the innermost such is ViewObj.
-    UInt LastPV;
+    DECL_MODULE_STATE UInt LastPV;
 
+#ifdef HPCGAP
 } ObjectsModuleState;
 
+#define PrintObjDepth MODULE_STATE(Objects, PrintObjDepth)
+#define PrintObjThiss MODULE_STATE(Objects, PrintObjThiss)
+#define PrintObjIndices MODULE_STATE(Objects, PrintObjIndices)
+#define LastPV MODULE_STATE(Objects, LastPV)
+#endif
 
 static Int lastFreePackageTNUM = FIRST_PACKAGE_TNUM;
 
@@ -895,13 +903,13 @@ static Obj FuncGET_TNAM_FROM_TNUM(Obj self, Obj obj)
 
 // This function is used to keep track of which objects are already
 // being printed or viewed to trigger the use of ~ when needed.
-static inline BOOL IS_ON_PRINT_STACK(const ObjectsModuleState * os, Obj obj)
+static inline BOOL IS_ON_PRINT_STACK(Obj obj)
 {
     if (!(FIRST_RECORD_TNUM <= TNUM_OBJ(obj) &&
           TNUM_OBJ(obj) <= LAST_LIST_TNUM))
         return FALSE;
-    for (UInt i = 0; i < os->PrintObjDepth; i++)
-        if (os->PrintObjThiss[i] == obj)
+    for (UInt i = 0; i < PrintObjDepth; i++)
+        if (PrintObjThiss[i] == obj)
             return TRUE;
     return FALSE;
 }
@@ -961,46 +969,44 @@ void PrintObj(Obj obj)
     }
 #endif
 
-    ObjectsModuleState * os = &MODULE_STATE(Objects);
-
     // First check if <obj> is actually the current object being viewed, since
     // ViewObj(<obj>) may result in a call to PrintObj(<obj>); in that case,
     // we should not put <obj> on the print stack
-    if ((os->PrintObjDepth > 0) && (os->LastPV == 2) &&
-        (obj == os->PrintObjThiss[os->PrintObjDepth - 1])) {
-        os->LastPV = 1;
+    if ((PrintObjDepth > 0) && (LastPV == 2) &&
+        (obj == PrintObjThiss[PrintObjDepth - 1])) {
+        LastPV = 1;
         PRINT_OBJ(obj);
-        os->LastPV = 2;
+        LastPV = 2;
     }
 
     // print the path if <obj> is on the stack
-    else if (IS_ON_PRINT_STACK(os, obj)) {
+    else if (IS_ON_PRINT_STACK(obj)) {
         Pr("~", 0, 0);
-        for (int i = 0; obj != os->PrintObjThiss[i]; i++) {
-            PRINT_PATH(os->PrintObjThiss[i], os->PrintObjIndices[i]);
+        for (int i = 0; obj != PrintObjThiss[i]; i++) {
+            PRINT_PATH(PrintObjThiss[i], PrintObjIndices[i]);
         }
     }
 
     // dispatch to the appropriate printing function
-    else if (os->PrintObjDepth < MAXPRINTDEPTH) {
+    else if (PrintObjDepth < MAXPRINTDEPTH) {
 
-        Obj oldThis = os->PrintObjThiss[os->PrintObjDepth];
-        Int oldIndx = os->PrintObjIndices[os->PrintObjDepth];
+        Obj oldThis = PrintObjThiss[PrintObjDepth];
+        Int oldIndx = PrintObjIndices[PrintObjDepth];
 
         // push obj on the stack
-        os->PrintObjThiss[os->PrintObjDepth] = obj;
-        os->PrintObjIndices[os->PrintObjDepth] = 0;
-        os->PrintObjDepth++;
+        PrintObjThiss[PrintObjDepth] = obj;
+        PrintObjIndices[PrintObjDepth] = 0;
+        PrintObjDepth++;
 
-        UInt lastPV = os->LastPV;
-        os->LastPV = 1;
+        UInt lastPV = LastPV;
+        LastPV = 1;
         PRINT_OBJ(obj);
-        os->LastPV = lastPV;
+        LastPV = lastPV;
 
         // pop <obj> from the stack
-        os->PrintObjDepth--;
-        os->PrintObjThiss[os->PrintObjDepth] = oldThis;
-        os->PrintObjIndices[os->PrintObjDepth] = oldIndx;
+        PrintObjDepth--;
+        PrintObjThiss[PrintObjDepth] = oldThis;
+        PrintObjIndices[PrintObjDepth] = oldIndx;
     }
     else {
         Pr("\nprinting stopped, too many recursion levels!\n", 0, 0);
@@ -1044,19 +1050,19 @@ static Obj FuncPRINT_OBJ(Obj self, Obj obj)
 
 UInt SetPrintObjState(UInt state)
 {
-    UInt oldDepth = MODULE_STATE(Objects).PrintObjDepth;
-    UInt oldLastPV = MODULE_STATE(Objects).LastPV;
-    MODULE_STATE(Objects).PrintObjDepth = state >> 2;
-    MODULE_STATE(Objects).LastPV = state & 3;
+    UInt oldDepth = PrintObjDepth;
+    UInt oldLastPV = LastPV;
+    PrintObjDepth = state >> 2;
+    LastPV = state & 3;
     return (oldDepth << 2) | oldLastPV;
 }
 
 void SetPrintObjIndex(Int index)
 {
-    UInt depth = MODULE_STATE(Objects).PrintObjDepth;
+    UInt depth = PrintObjDepth;
     if (depth == 0)
         ErrorQuit("SetPrintObjIndex: bad state, PrintObjDepth is 0", 0, 0);
-    MODULE_STATE(Objects).PrintObjIndices[depth - 1] = index;
+    PrintObjIndices[depth - 1] = index;
 }
 
 static Obj FuncSET_PRINT_OBJ_INDEX(Obj self, Obj index)
@@ -1087,36 +1093,34 @@ void ViewObj(Obj obj)
     }
 #endif
 
-    ObjectsModuleState * os = &MODULE_STATE(Objects);
-
     // print the path if <obj> is on the stack
-    if (IS_ON_PRINT_STACK(os, obj)) {
+    if (IS_ON_PRINT_STACK(obj)) {
         Pr("~", 0, 0);
-        for (int i = 0; obj != os->PrintObjThiss[i]; i++) {
-            PRINT_PATH(os->PrintObjThiss[i], os->PrintObjIndices[i]);
+        for (int i = 0; obj != PrintObjThiss[i]; i++) {
+            PRINT_PATH(PrintObjThiss[i], PrintObjIndices[i]);
         }
     }
 
     // dispatch to the appropriate viewing function
-    else if (os->PrintObjDepth < MAXPRINTDEPTH) {
+    else if (PrintObjDepth < MAXPRINTDEPTH) {
 
-        Obj oldThis = os->PrintObjThiss[os->PrintObjDepth];
-        Int oldIndx = os->PrintObjIndices[os->PrintObjDepth];
+        Obj oldThis = PrintObjThiss[PrintObjDepth];
+        Int oldIndx = PrintObjIndices[PrintObjDepth];
 
         // push obj on the stack
-        os->PrintObjThiss[os->PrintObjDepth] = obj;
-        os->PrintObjIndices[os->PrintObjDepth] = 0;
-        os->PrintObjDepth++;
+        PrintObjThiss[PrintObjDepth] = obj;
+        PrintObjIndices[PrintObjDepth] = 0;
+        PrintObjDepth++;
 
-        UInt lastPV = os->LastPV;
-        os->LastPV = 2;
+        UInt lastPV = LastPV;
+        LastPV = 2;
         DoOperation1Args(ViewObjOper, obj);
-        os->LastPV = lastPV;
+        LastPV = lastPV;
 
         // pop <obj> from the stack
-        os->PrintObjDepth--;
-        os->PrintObjThiss[os->PrintObjDepth] = oldThis;
-        os->PrintObjIndices[os->PrintObjDepth] = oldIndx;
+        PrintObjDepth--;
+        PrintObjThiss[PrintObjDepth] = oldThis;
+        PrintObjIndices[PrintObjDepth] = oldIndx;
     }
     else {
         Pr("\nviewing stopped, too many recursion levels!\n", 0, 0);
@@ -2341,8 +2345,10 @@ static StructInitInfo module = {
     .initKernel = InitKernel,
     .initLibrary = InitLibrary,
 
+#ifdef HPCGAP
     .moduleStateSize = sizeof(ObjectsModuleState),
     .moduleStateOffsetPtr = &ObjectsStateOffset,
+#endif
 };
 
 StructInitInfo * InitInfoObjects ( void )

--- a/src/objfgelm.cc
+++ b/src/objfgelm.cc
@@ -1596,8 +1596,10 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ 0,
+#ifdef HPCGAP
  /* moduleStateSize      = */ 0,
  /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ 0,
  /* destroyModuleState   = */ 0,
 };

--- a/src/objpcgel.cc
+++ b/src/objpcgel.cc
@@ -381,8 +381,10 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ 0,
+#ifdef HPCGAP
  /* moduleStateSize      = */ 0,
  /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ 0,
  /* destroyModuleState   = */ 0,
 };

--- a/src/opers.cc
+++ b/src/opers.cc
@@ -3903,8 +3903,10 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ PostRestore,
+#ifdef HPCGAP
  /* moduleStateSize      = */ 0,
  /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,
 };

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -3046,9 +3046,6 @@ static StructInitInfo module = {
 #ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(PermutatModuleState),
  /* moduleStateOffsetPtr = */ &PermutatStateOffset,
-#else
- /* moduleStateSize      = */ 0,
- /* moduleStateOffsetPtr = */ 0,
 #endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,

--- a/src/permutat.cc
+++ b/src/permutat.cc
@@ -84,9 +84,11 @@ Obj             IdentityPerm;
 
 static const UInt MAX_DEG_PERM4 = ((Int)1 << (sizeof(UInt) == 8 ? 32 : 28)) - 1;
 
+#ifdef HPCGAP
 static ModuleStateOffset PermutatStateOffset = -1;
 
 typedef struct {
+#endif
 
 /****************************************************************************
 **
@@ -102,11 +104,13 @@ typedef struct {
 **  costs (particularly when starting new threads).
 **  Use the UseTmpPerm(<size>) utility function to ensure it is constructed!
 */
-Obj TmpPerm;
+DECL_MODULE_STATE Obj TmpPerm;
 
+#ifdef HPCGAP
 } PermutatModuleState;
 
-#define  TmpPerm MODULE_STATE(Permutat).TmpPerm
+#define TmpPerm MODULE_STATE(Permutat, TmpPerm)
+#endif
 
 
 static UInt1 * UseTmpPerm(UInt size)
@@ -3039,8 +3043,13 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ PostRestore,
+#ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(PermutatModuleState),
  /* moduleStateOffsetPtr = */ &PermutatStateOffset,
+#else
+ /* moduleStateSize      = */ 0,
+ /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,
 };

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -4001,9 +4001,6 @@ static StructInitInfo module = {
 #ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(PPermModuleState),
  /* moduleStateOffsetPtr = */ &PPermStateOffset,
-#else
- /* moduleStateSize      = */ 0,
- /* moduleStateOffsetPtr = */ 0,
 #endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,

--- a/src/pperm.cc
+++ b/src/pperm.cc
@@ -120,9 +120,11 @@ static Obj EmptyPartialPerm;
                              "must be a partial permutation")
 
 
+#ifdef HPCGAP
 static ModuleStateOffset PPermStateOffset = -1;
 
 typedef struct {
+#endif
 
     /**************************************************************************
      *
@@ -136,12 +138,13 @@ typedef struct {
      * The buffer is *not* guaranteed to have any particular value, routines
      * that require a zero-initialization need to do this at the start.
      */
-    Obj TmpPPerm;
+    DECL_MODULE_STATE Obj TmpPPerm;
 
+#ifdef HPCGAP
 } PPermModuleState;
 
-
-#define TmpPPerm MODULE_STATE(PPerm).TmpPPerm
+#define TmpPPerm MODULE_STATE(PPerm, TmpPPerm)
+#endif
 
 static inline void ResizeTmpPPerm(UInt len)
 {
@@ -3995,8 +3998,13 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ 0,
+#ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(PPermModuleState),
  /* moduleStateOffsetPtr = */ &PPermStateOffset,
+#else
+ /* moduleStateSize      = */ 0,
+ /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,
 };

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -175,21 +175,22 @@ static Int GetPositiveListEntryEx(const char * funcname,
     GetPositiveListEntryEx(funcname, list, idx, NICE_ARGNAME(list))
 
 
+#ifdef HPCGAP
 static ModuleStateOffset TransStateOffset = -1;
 
 typedef struct {
+#endif
     // TmpTrans is essentially the same as TmpPerm
-    Obj TmpTrans;
+    DECL_MODULE_STATE Obj TmpTrans;
+#ifdef HPCGAP
 } TransModuleState;
 
-static inline Obj GetTmpTrans(void)
-{
-    return MODULE_STATE(Trans).TmpTrans;
-}
+#define TmpTrans MODULE_STATE(Trans, TmpTrans)
+#endif
 
 static inline UInt4 * AddrTmpTrans(void)
 {
-    return ADDR_TRANS4(GetTmpTrans());
+    return ADDR_TRANS4(TmpTrans);
 }
 
 
@@ -255,9 +256,9 @@ static inline void SET_EXT_TRANS(Obj f, Obj deg)
 
 static inline void ResizeTmpTrans(UInt len)
 {
-    Obj tmpTrans = GetTmpTrans();
+    Obj tmpTrans = TmpTrans;
     if (tmpTrans == (Obj)0) {
-        MODULE_STATE(Trans).TmpTrans = NewBag(T_TRANS4, len * sizeof(UInt4) + 3 * sizeof(Obj));
+        TmpTrans = NewBag(T_TRANS4, len * sizeof(UInt4) + 3 * sizeof(Obj));
     }
     else if (SIZE_OBJ(tmpTrans) < len * sizeof(UInt4) + 3 * sizeof(Obj)) {
         ResizeBag(tmpTrans, len * sizeof(UInt4) + 3 * sizeof(Obj));
@@ -4211,7 +4212,7 @@ static Int InitKernel(StructInitInfo * module)
     InitHdlrFuncsFromTable(GVarFuncs);
 
     // register global bags with the garbage collector
-    InitGlobalBag(&MODULE_STATE(Trans).TmpTrans, "src/trans.c:TmpTrans");
+    InitGlobalBag(&TmpTrans, "src/trans.c:TmpTrans");
     InitGlobalBag(&IdentityTrans, "src/trans.c:IdentityTrans");
 
 #ifdef GAP_ENABLE_SAVELOAD
@@ -4295,7 +4296,7 @@ static Int InitLibrary(StructInitInfo * module)
 
 static Int InitModuleState(void)
 {
-    MODULE_STATE(Trans).TmpTrans = 0;
+    TmpTrans = 0;
 
     return 0;
 }
@@ -4317,8 +4318,13 @@ static StructInitInfo module = {
  /* preSave     = */ 0,
  /* postSave    = */ 0,
  /* postRestore = */ 0,
+#ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(TransModuleState),
  /* moduleStateOffsetPtr = */ &TransStateOffset,
+#else
+ /* moduleStateSize      = */ 0,
+ /* moduleStateOffsetPtr = */ 0,
+#endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,
 };

--- a/src/trans.cc
+++ b/src/trans.cc
@@ -4321,9 +4321,6 @@ static StructInitInfo module = {
 #ifdef HPCGAP
  /* moduleStateSize      = */ sizeof(TransModuleState),
  /* moduleStateOffsetPtr = */ &TransStateOffset,
-#else
- /* moduleStateSize      = */ 0,
- /* moduleStateOffsetPtr = */ 0,
 #endif
  /* initModuleState      = */ InitModuleState,
  /* destroyModuleState   = */ 0,


### PR DESCRIPTION
... at least in plain GAP; keep them as before in HPC-GAP.

The whole concept was invented to allow HPC-GAP to have thread local GAP and module state. In plain GAP, though, it introduced some minor overhead.

Changing this here allows us to avoid the overhead, and it also prevents GAPState from becoming larger than 32kb. This can happen on platforms with a large jmp_buf (e.g., powerpc64).

Alternative to and hence closes #6373