### PR TITLE
scanner: don't print EOF sentinel as line context on syntax error

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -62,13 +62,23 @@ static void SyntaxErrorOrWarning(ScannerState * s,
             Pr(" in %g:%d", (Int)name, GetInputLineNumber(s->input));
         Pr("\n", 0, 0);
 
-        // print the current line
+        // print the current line — but skip the line print, and the
+        // caret below, if the buffer has been replaced by the scanner's
+        // end-of-input sentinel (0xFF). That happens when the syntax
+        // error fires after parsing has advanced past the offending
+        // line (e.g. `h := ;` parsed from a string with no trailing
+        // newline): the line buffer is refilled at EOF before the
+        // error is reported, so the pretty-printed context would leak
+        // a literal 0xFF byte to *errout* with no caret to anchor it.
         const char * line = GetInputLineBuffer(s->input);
         const UInt len = strlen(line);
-        if (len > 0 && line[len-1] != '\n')
-            Pr("%s\n", (Int)line, 0);
-        else
-            Pr("%s", (Int)line, 0);
+        const int line_is_sentinel = (len == 0 || line[0] == '\377');
+        if (!line_is_sentinel) {
+            if (line[len-1] != '\n')
+                Pr("%s\n", (Int)line, 0);
+            else
+                Pr("%s", (Int)line, 0);
+        }
 
         // print a '^' pointing to the current position
         Int startPos = s->SymbolStartPos[tokenoffset];
@@ -83,7 +93,7 @@ static void SyntaxErrorOrWarning(ScannerState * s,
             pos = GetInputLinePosition(s->input);
         }
 
-        if (0 < pos && startPos <= pos) {
+        if (!line_is_sentinel && 0 < pos && startPos <= pos) {
             Int i;
             for (i = 0; i < startPos; i++) {
                 if (line[i] == '\t')

--- a/tst/testspecial/syntax-err-eof-sentinel.g
+++ b/tst/testspecial/syntax-err-eof-sentinel.g
@@ -1,0 +1,33 @@
+# Regression test for a 0xFF byte leak in syntax-error context lines.
+#
+# When a syntax error fires after the scanner has advanced past EOF
+# (e.g. parsing "h := ;" via READ_ALL_COMMANDS from a string with no
+# trailing newline), the input-line buffer is replaced with the
+# scanner's end-of-input sentinel (0xFF). Before the fix in
+# src/scanner.c the SyntaxErrorOrWarning() pretty-printer would dump
+# that sentinel verbatim alongside the error message — visible as a
+# stray `ÿ` glyph in any UTF-8 / log-file consumer of *errout*
+# (e.g. the JupyterKernel package).
+errFile := Filename(DirectoryTemporary(), "syntax.log");;
+errStream := OutputTextFile(errFile, false);;
+SetPrintFormattingStatus(errStream, false);;
+
+MakeReadWriteGlobal("ERROR_OUTPUT");;
+saved := ERROR_OUTPUT;;
+ERROR_OUTPUT := errStream;;
+MakeReadOnlyGlobal("ERROR_OUTPUT");;
+
+READ_ALL_COMMANDS(InputTextString("h := ;"), false, false, IdFunc);;
+
+MakeReadWriteGlobal("ERROR_OUTPUT");;
+ERROR_OUTPUT := saved;;
+MakeReadOnlyGlobal("ERROR_OUTPUT");;
+CloseStream(errStream);;
+
+inStream := InputTextFile(errFile);;
+captured := ReadAll(inStream);;
+CloseStream(inStream);;
+
+Print("contains-eof-sentinel: ", '\377' in captured, "\n");
+Print("contains-error-message: ",
+      PositionSublist(captured, "expression expected") <> fail, "\n");

--- a/tst/testspecial/syntax-err-eof-sentinel.g.out
+++ b/tst/testspecial/syntax-err-eof-sentinel.g.out
@@ -1,0 +1,36 @@
+gap> # Regression test for a 0xFF byte leak in syntax-error context lines.
+gap> #
+gap> # When a syntax error fires after the scanner has advanced past EOF
+gap> # (e.g. parsing "h := ;" via READ_ALL_COMMANDS from a string with no
+gap> # trailing newline), the input-line buffer is replaced with the
+gap> # scanner's end-of-input sentinel (0xFF). Before the fix in
+gap> # src/scanner.c the SyntaxErrorOrWarning() pretty-printer would dump
+gap> # that sentinel verbatim alongside the error message — visible as a
+gap> # stray `ÿ` glyph in any UTF-8 / log-file consumer of *errout*
+gap> # (e.g. the JupyterKernel package).
+gap> errFile := Filename(DirectoryTemporary(), "syntax.log");;
+gap> errStream := OutputTextFile(errFile, false);;
+gap> SetPrintFormattingStatus(errStream, false);;
+gap> 
+gap> MakeReadWriteGlobal("ERROR_OUTPUT");;
+gap> saved := ERROR_OUTPUT;;
+gap> ERROR_OUTPUT := errStream;;
+gap> MakeReadOnlyGlobal("ERROR_OUTPUT");;
+gap> 
+gap> READ_ALL_COMMANDS(InputTextString("h := ;"), false, false, IdFunc);;
+gap> 
+gap> MakeReadWriteGlobal("ERROR_OUTPUT");;
+gap> ERROR_OUTPUT := saved;;
+gap> MakeReadOnlyGlobal("ERROR_OUTPUT");;
+gap> CloseStream(errStream);;
+gap> 
+gap> inStream := InputTextFile(errFile);;
+gap> captured := ReadAll(inStream);;
+gap> CloseStream(inStream);;
+gap> 
+gap> Print("contains-eof-sentinel: ", '\377' in captured, "\n");
+contains-eof-sentinel: false
+gap> Print("contains-error-message: ",
+>       PositionSublist(captured, "expression expected") <> fail, "\n");
+contains-error-message: true
+gap> QUIT;


### PR DESCRIPTION
When a syntax error fires after the scanner has advanced past EOF — e.g. parsing `h := ;` via READ_ALL_COMMANDS from a string with no trailing newline — the input-line buffer is refilled with GAP's end-of-input sentinel (\377) before SyntaxErrorOrWarning() runs. SyntaxErrorOrWarning() then printed the buffer verbatim as the line context, leaking a literal 0xFF byte to *errout*.

On a tty this is harmless: the byte either gets eaten by the terminal or shown as some replacement glyph. But anything that captures *errout* programmatically — log files, the JupyterKernel package, an OutputTextFile redirect — sees the stray byte. JSON/UTF-8 has no encoding for it, so a Jupyter front-end renders it as a literal `ÿ` just below the error message.

Skip the line print (and the corresponding caret) when the line buffer is the bare sentinel. The fix is local to SyntaxErrorOrWarning and doesn't change tty behaviour: the line-context print was already useless in this case, since the scanner had moved past the offending line.

Add a testspecial regression that reproduces the leak via READ_ALL_COMMANDS + an ERROR_OUTPUT redirect to a temp file, then checks that the captured bytes contain the error message but not \377.
