### PR TITLE
Fix `Irr` for natural symmetric groups when the conjugacy classes are ordered differently in the group and its character table

### DIFF
--- a/lib/ctblsymm.gi
+++ b/lib/ctblsymm.gi
@@ -1232,7 +1232,7 @@ InstallMethod( Irr,
     # Compute the correspondence of classes.
     cp:= gentbl.classparam[1]( deg );
     perm:= [];
-    for i in ConjugacyClasses( G ) do
+    for i in ConjugacyClasses( cG ) do
       i:= List( Orbits( SubgroupNC( G, [ Representative(i) ] ), dom ),
                 Length );
       Sort( i );

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -381,6 +381,15 @@ true
 gap> IsPerfectCharacterTable( t );
 false
 
+# test another bugfix
+gap> G:= SymmetricGroup( 2 );;
+gap> SetConjugacyClasses( G,
+>        List( [ (1,2), () ], x -> ConjugacyClass( G, x ) ) );
+gap> t:= CharacterTable( G );;
+gap> lin:= Irr( t );;
+gap> lin[1][1];
+1
+
 # compute indicators
 gap> t:= CharacterTable( SymmetricGroup( 4 ) );;
 gap> Indicator( t, 2 );
@@ -434,19 +443,19 @@ gap> HasIsIrreducibleCharacter( TrivialCharacter( SymmetricGroup( 4 ) ) );
 true
 
 # concurring 'Irr' methods
-gap> G:= SmallGroup( 24, 5 );;
+gap> G:= PcGroupCode( 221729, 24 );;
 gap> IsSupersolvable( G );
 true
 gap> Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Baum-Clausen Algorithm"
-gap> G:= SmallGroup( 24, 5 );;
+gap> G:= PcGroupCode( 221729, 24 );;
 gap> IsSupersolvable( G );
 true
 gap> IrrConlon( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Conlon's Algorithm"
-gap> G:= SmallGroup( 24, 5 );;
+gap> G:= PcGroupCode( 221729, 24 );;
 gap> IrrDixonSchneider( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Dixon's Algorithm"


### PR DESCRIPTION
When the conjugacy classes of a natural symmetric group and its character table are ordered differently and the `Irr` value of the table is not yet stored then the result of the special `Irr` method for natural symmetric groups was wrong because the columns  erroneously referred to the classes of the group, not to the classes of the table.