### PR TITLE
Avoid `IdGroup` in `IsSymmetricGroup`

### DIFF
--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -1278,12 +1278,21 @@ InstallMethod( IsSymmetricGroup,
       return true;
     fi;
 
+    # the derived subgroup must be alternating and have index 2
     G1 := DerivedSubgroup(G);
-    if   not (IsAlternatingGroup(G1) and Index(G,G1) = 2)
-      # this requires deg>=4
-      or not IsTrivial(Centralizer(G,G1))
-      or Size(G) = 720 and IdGroup(G) <> [ 720, 763 ]
-    then return false; fi;
+    if not (IsAlternatingGroup(G1) and Index(G,G1) = 2) then
+      return false;
+    fi;
+    # the derived subgroup must have trivial centralizer (since degree >= 4)
+    if not IsTrivial(Centralizer(G,G1)) then
+      return false;
+    fi;
+    # one more special case: there are three groups of order 720 which satisfy
+    # the above, so here we need extra work to pick the correct one: it is
+    # only one in which all elements have order <= 6
+    if Size(G) = 720 and not ForAll(G,x->Order(x)<=6) then
+      return false;
+    fi;
     SetSymmetricDegree(G,AlternatingDegree(G1));
     return true;
   end );

--- a/lib/grpnames.gi
+++ b/lib/grpnames.gi
@@ -1288,9 +1288,11 @@ InstallMethod( IsSymmetricGroup,
       return false;
     fi;
     # one more special case: there are three groups of order 720 which satisfy
-    # the above, so here we need extra work to pick the correct one: it is
-    # only one in which all elements have order <= 6
-    if Size(G) = 720 and not ForAll(G,x->Order(x)<=6) then
+    # the above (those with small group ids 763, 764, 765). So here we need
+    # extra work to pick the correct one: it is only one in which all elements
+    # have order <= 6. Conversely, the other two groups contain elements of
+    # order 8 or 10, but none of order 6
+    if Size(G) = 720 and Order(First(G,x->Order(x)>=6)) > 6 then
       return false;
     fi;
     SetSymmetricDegree(G,AlternatingDegree(G1));


### PR DESCRIPTION
Based on experiments, just testing the order seemed to be fastest. Though of course it also depends on the representation used for the group.

With this many more packages pass test with `gap --bare`.

In my experiments the new code was never slower and sometimes faster than `IdGroup`. For example, in `master` (the three groups used here are the ones of order 720 which contains an A6 of index 2)
```
gap> G:=SmallGroup(720, 763);; for i in [1..1000] do IsSymmetricGroup(Group(GeneratorsOfGroup(G))); od; time;
271
gap> G:=SmallGroup(720, 764);; for i in [1..1000] do IsSymmetricGroup(Group(GeneratorsOfGroup(G))); od; time;
1212
gap> G:=SmallGroup(720, 765);; for i in [1..1000] do IsSymmetricGroup(Group(GeneratorsOfGroup(G))); od; time;
994
```

With this PR:
```
gap> G:=SmallGroup(720, 763);; for i in [1..1000] do IsSymmetricGroup(Group(GeneratorsOfGroup(G))); od; time;
273
gap> G:=SmallGroup(720, 764);; for i in [1..1000] do IsSymmetricGroup(Group(GeneratorsOfGroup(G))); od; time;
943
gap> G:=SmallGroup(720, 765);; for i in [1..1000] do IsSymmetricGroup(Group(GeneratorsOfGroup(G))); od; time;
715
```
