### PR TITLE
Add `EnumeratorOfPartitionsSet` enumerator

### DIFF
--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -1199,17 +1199,19 @@ DeclareGlobalFunction( "IteratorOfPartitions" );
 ##  also different from the list returned by <Ref Func="PartitionsSet"/>.
 ##  <P/>
 ##  <Example>
-##  gap> m:=[1..15];; Add(m, 15);
-##  gap> NrCombinations(m);
-##  49152
-##  gap> i := 0;; for c in Combinations(m) do i := i+1; od;
+##  gap> m:=[1..9];;
+##  gap> Bell(9);
+##  21147
+##  gap> i := 0;; for c in PartitionsSet(m) do i := i+1; od;
 ##  gap> i;
-##  49152
-##  gap> cm := EnumeratorOfCombinations(m);;
+##  21147
+##  gap> cm := EnumeratorOfPartitionsSet(m);;
 ##  gap> cm[1000];
-##  [ 1, 2, 3, 6, 7, 8, 9, 10 ]
-##  gap> Position(cm, [1,13,15,15]);
-##  36866
+##  [ [ 1, 2, 4, 9 ], [ 3, 6, 8 ], [ 5, 7 ] ]
+##  gap> Position(cm, [[1, 3], [2, 5], [4], [6, 7, 8, 9]]);
+##  11001
+##  gap> cm[11001];
+##  [ [ 1, 3 ], [ 2, 5 ], [ 4 ], [ 6, 7, 8, 9 ] ]
 ##  </Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -1202,16 +1202,13 @@ DeclareGlobalFunction( "IteratorOfPartitions" );
 ##  gap> m:=[1..9];;
 ##  gap> Bell(9);
 ##  21147
-##  gap> i := 0;; for c in PartitionsSet(m) do i := i+1; od;
-##  gap> i;
+##  gap> Length(PartitionsSet(m));
 ##  21147
 ##  gap> cm := EnumeratorOfPartitionsSet(m);;
 ##  gap> cm[1000];
 ##  [ [ 1, 2, 4, 9 ], [ 3, 6, 8 ], [ 5, 7 ] ]
-##  gap> Position(cm, [[1, 3], [2, 5], [4], [6, 7, 8, 9]]);
-##  11001
-##  gap> cm[11001];
-##  [ [ 1, 3 ], [ 2, 5 ], [ 4 ], [ 6, 7, 8, 9 ] ]
+##  gap> Position(cm, last);
+##  1000
 ##  </Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/combinat.gd
+++ b/lib/combinat.gd
@@ -1169,14 +1169,16 @@ DeclareGlobalFunction("NrRestrictedPartitions");
 ##
 DeclareGlobalFunction( "IteratorOfPartitions" );
 
-
 #############################################################################
 ##
-#F  IteratorOfPartitionsSet( <set> [, <k> [ <flag> ] ] )
+#F  IteratorOfPartitionsSet( <set> [, <k> [, <flag> ] ] )
+#F  EnumeratorOfPartitionsSet( <set> [, <k> [, <flag> ] ] )
 ##
 ##  <#GAPDoc Label="IteratorOfPartitionsSet">
 ##  <ManSection>
-##  <Func Name="IteratorOfPartitionsSet" Arg='set [, k [ flag ] ]'/>
+##  <Heading>Iterator and enumerator of unordered set partitions</Heading>
+##  <Func Name="IteratorOfPartitionsSet" Arg='set [, k [, flag ] ]'/>
+##  <Func Name="EnumeratorOfPartitionsSet" Arg='set [, k [, flag ] ]'/>
 ##
 ##  <Description>
 ##  <Ref Func="IteratorOfPartitionsSet" /> returns an iterator
@@ -1187,12 +1189,34 @@ DeclareGlobalFunction( "IteratorOfPartitions" );
 ##  then only partitions of size <A>k</A> are computed.
 ##  If <A>k</A> is given and <A>flag</A> is equal to <K>true</K>,
 ##  then only partitions of size at most <A>k</A> are computed.
+##  <P/>
+##  <Ref Func="EnumeratorOfPartitionsSet"/> returns an enumerator
+##  (see&nbsp;<Ref Attr="Enumerator" />) for all unordered partitions of the
+##  set <A>set</A>. The arguments <A>k</A> and <A>flag</A> function in the
+##  same manner as for the iterator.
+##  <P/>
+##  The ordering of the partitions from these functions can be different and
+##  also different from the list returned by <Ref Func="PartitionsSet"/>.
+##  <P/>
+##  <Example>
+##  gap> m:=[1..15];; Add(m, 15);
+##  gap> NrCombinations(m);
+##  49152
+##  gap> i := 0;; for c in Combinations(m) do i := i+1; od;
+##  gap> i;
+##  49152
+##  gap> cm := EnumeratorOfCombinations(m);;
+##  gap> cm[1000];
+##  [ 1, 2, 3, 6, 7, 8, 9, 10 ]
+##  gap> Position(cm, [1,13,15,15]);
+##  36866
+##  </Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "IteratorOfPartitionsSet" );
-
+DeclareGlobalFunction( "EnumeratorOfPartitionsSet" );
 
 #############################################################################
 ##

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -2488,13 +2488,13 @@ InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
         np := ((np - 1) mod t) + 1;
       fi;
     od;
-    return res;
+    return List(res, Reversed);
   end;
 
   NumberElement := function(enu, p, k)
     local res, kp, ks, sp, perm, i, j, jp;
 
-    if not IsList(p) or Length(p) <> k then
+    if not IsSet(p) or Length(p) <> k then
       return fail;
     fi;
 
@@ -2509,8 +2509,9 @@ InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
     # end of the i-th part of p in the flattened
     # version of p (stored as sp)
     ks := [];
+    sp := [];
     for kp in [1 .. k] do
-      if not IsList(p[kp]) then
+      if not IsSet(p[kp]) then
         return fail;
       fi;
       if kp = 1 then
@@ -2518,8 +2519,8 @@ InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
       else
         Add(ks, ks[Length(ks)] + Length(p[kp]));
       fi;
+      Append(sp, p[kp]);
     od;
-    sp := Flat(p);
 
     # Every partition of s must store all of the same elements as s.
     perm := PermListList(sp, s);
@@ -2534,15 +2535,15 @@ InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
       # i is the part of p that s[j] is in
       i := PositionSorted(ks, jp);
 
-      # jp = ks[i] if and only if s[j] is the last element of the i-th
+      # Check passes if and only if s[j] is the first element of the i-th
       # part of p. According to our encoding convention in ElementNumber,
       # this means that the remaining partition is a (kp-1)-partition.
-      if (jp = ks[i]) then
+      if jp = 1 or (i > 1 and ks[i - 1] + 1 = jp) then
         kp := kp - 1;
       else
         # Otherwise, we perform the reverse manipulation to the one
         # modifying np in ElementNumber
-        res := res + i * Stirling2(j-1, kp) + Stirling2(j-1, kp-1);
+        res := res + (i-1) * Stirling2(j-1, kp) + Stirling2(j-1, kp-1);
       fi;
     od;
 
@@ -2585,7 +2586,7 @@ InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
       if Length(p) > k then
         return fail;
       fi;
-      return NumberElement(enu, p, Length(p));
+      return cumulative_stirling[Length(p)] + NumberElement(enu, p, Length(p));
     end;
     r.Length := x -> cumulative_stirling[k + 1];
   elif (Length(arg) = 2 and arg[2] = false) or (Length(arg) = 1) then

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -2429,6 +2429,185 @@ InstallGlobalFunction( "IteratorOfPartitions", function( n )
              next           := 0 * [ 1 .. n ] + 1 ) );
     end );
 
+#############################################################################
+##
+#F  EnumeratorOfPartitionsSet( <set> [, <k> [, <flag> ] ]  )
+##
+
+
+InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
+  local k, r, l, j, cumulative_stirling, ElementNumber, NumberElement;
+
+  if not IsSet(s) then
+    Error( "EnumeratorOfPartitionsSet: <s> must be a set" );
+  fi;
+
+  l := Length(s);
+
+  # Method for finding n-th k-partition of s, does not
+  # do argument checking, this is done further down when
+  # instantiating the enumerators.
+  ElementNumber := function(enu, n, k)
+    local res, j, kp, np, t, i;
+    if l = 0 and n = 0 and k = 0 then
+      return [];
+    fi;
+
+    res := List([1 .. k], x -> []);
+    # kp is the largest index of still active parts.
+    # Every time kp is decremented, we guarantee that
+    # res[kp + 1] will not be changed anymore.
+    kp := k;
+    # np keeps track of the part of n that we still need
+    # to process. Use it to avoid recursive calls.
+    np := n;
+    for j in [l, l - 1 .. 1] do
+      # Intuitively, we use identity
+      #   Stirling2(j, k') = Stirling2(j-1, k'-1) + k' * Stirling2(j-1, k')
+      # to recursively encode partitions in the following manner:
+      # If n < Stirling2(j-1, k'-1), then we recursively construct
+      # the (k'-1)-partition corresponding to n and add a new singleton part
+      # consisting solely of s[j] to it.
+      # Otherwise, we can write n = Stirling2(j-1, k'-1) + i * Stirling(j-1, k') + n'
+      # for some numbers i and n' such that
+      #   i < k' and n' < Stirling2(j-1, k').
+      # We then recursively construct the k'-partition corresponding to n' and
+      # add s[j] to the i-th part.
+      t := Stirling2(j - 1, kp - 1);
+      if np <= t then
+        # Add last element to part kp, and
+        # decrement kp to mark res[kp] as complete.
+        Add(res[kp], s[j]);
+        kp := kp - 1;
+      else
+        # np and i are the numbers n' and i described above.
+        np := np - t;
+        t := Stirling2(j - 1, kp);
+        i := QuoInt(np - 1, t) + 1;
+        Add(res[i], s[j]);
+        np := ((np - 1) mod t) + 1;
+      fi;
+    od;
+    return res;
+  end;
+
+  NumberElement := function(enu, p, k)
+    local res, kp, ks, sp, perm, i, j, jp;
+
+    if not IsList(p) or Length(p) <> k then
+      return fail;
+    fi;
+
+    if Length(p) = 0 then
+      if l = 0 and k = 0 then
+        return 1;
+      fi;
+      return fail;
+    fi;
+
+    # ks[i] is the index corresponding to the
+    # end of the i-th part of p in the flattened
+    # version of p (stored as sp)
+    ks := [];
+    for kp in [1 .. k] do
+      if not IsList(p[kp]) then
+        return fail;
+      fi;
+      if kp = 1 then
+        Add(ks, Length(p[kp]));
+      else
+        Add(ks, ks[Length(ks)] + Length(p[kp]));
+      fi;
+    od;
+    sp := Flat(p);
+
+    # Every partition of s must store all of the same elements as s.
+    perm := PermListList(sp, s);
+    if perm = fail then
+      return fail;
+    fi;
+
+    res := 1;
+    kp := k;
+    for j in [l, l - 1 .. 1] do
+      jp := j^perm;
+      # i is the part of p that s[j] is in
+      i := PositionSorted(ks, jp);
+
+      # jp = ks[i] if and only if s[j] is the last element of the i-th
+      # part of p. According to our encoding convention in ElementNumber,
+      # this means that the remaining partition is a (kp-1)-partition.
+      if (jp = ks[i]) then
+        kp := kp - 1;
+      else
+        # Otherwise, we perform the reverse manipulation to the one
+        # modifying np in ElementNumber
+        res := res + i * Stirling2(j-1, kp) + Stirling2(j-1, kp-1);
+      fi;
+    od;
+
+    return res;
+  end;
+
+  r := rec(s := s, l := l);
+  if Length(arg) = 1 or Length(arg) = 2 then
+    k := arg[1];
+    if not IsInt(k) then
+      Error("EnumeratorOfPartitionsSet: <k> must be an integer");
+    fi;
+  fi;
+
+  if (Length(arg) = 2 and arg[2] = true) or (Length(arg) = 0) then
+    # k parts or less, also handles all partition case.
+    if Length(arg) = 0 then
+      k := l;
+    else
+      k := Minimum(k, l);
+    fi;
+
+    cumulative_stirling := [Stirling2(l, 0)];
+    for j in [1 .. k] do
+      Add(cumulative_stirling, cumulative_stirling[j] + Stirling2(l, j));
+    od;
+    r.cumulative_stirling := cumulative_stirling;
+    r.ElementNumber := function(enu, n)
+      local kp;
+      if n > cumulative_stirling[k + 1] then
+        Error("Index ", n, " not bound.");
+      fi;
+      kp := PositionSorted(cumulative_stirling, n) - 1;
+      if kp = 0 then
+        return ElementNumber(enu, n, kp);
+      fi;
+      return ElementNumber(enu, n - cumulative_stirling[kp], kp);
+    end;
+    r.NumberElement := function(enu, p)
+      if Length(p) > k then
+        return fail;
+      fi;
+      return NumberElement(enu, p, Length(p));
+    end;
+    r.Length := x -> cumulative_stirling[k + 1];
+  elif (Length(arg) = 2 and arg[2] = false) or (Length(arg) = 1) then
+    r.ElementNumber := function(enu, n)
+      if n > Stirling2(l, k) then
+        Error("Index ", n, " not bound.");
+      fi;
+      return ElementNumber(enu, n, k);
+    end;
+    r.NumberElement := function(enu, p)
+      return NumberElement(enu, p, k);
+    end;
+    r.Length := x -> Stirling2(l, k);
+  elif Length(arg) = 2 then
+    Error("EnumeratorOfPartitionsSet: <flag> must be true or false");
+  else
+    Error( "usage: EnumeratorOfPartitionsSet( <set> [, <k> [, <flag> ] ] )" );
+  fi;
+
+  r.k := k;
+  return EnumeratorByFunctions(ListsFamily, r);
+end);
 
 #############################################################################
 ##

--- a/lib/combinat.gi
+++ b/lib/combinat.gi
@@ -2583,10 +2583,15 @@ InstallGlobalFunction(EnumeratorOfPartitionsSet , function(s, arg...)
       return ElementNumber(enu, n - cumulative_stirling[kp], kp);
     end;
     r.NumberElement := function(enu, p)
-      if Length(p) > k then
+      local t;
+      if not IsSet(p) or Length(p) > k then
         return fail;
       fi;
-      return cumulative_stirling[Length(p)] + NumberElement(enu, p, Length(p));
+      t := NumberElement(enu, p, Length(p));
+      if t = fail then
+        return fail;
+      fi;
+      return cumulative_stirling[Length(p)] + t;
     end;
     r.Length := x -> cumulative_stirling[k + 1];
   elif (Length(arg) = 2 and arg[2] = false) or (Length(arg) = 1) then

--- a/tst/testinstall/combinat.tst
+++ b/tst/testinstall/combinat.tst
@@ -2,7 +2,7 @@
 ##
 ##  This  file  tests  the functions that  mainly  deal  with  combinatorics.
 ##
-#@local n,mset,comb1,comb2,comb3,it,pn1,pn2,s,k,x
+#@local n,mset,comb1,comb2,comb3,it,pn1,pn2,s,k,x,y
 
 gap> START_TEST("combinat.tst");
 
@@ -548,6 +548,143 @@ gap> for s in [[], [5], [1,2,3,4], [2,5,7], ["a","b","c","d","e"], [3..9]] do
 >        fi;
 >      od;
 >    od;
+
+#F  EnumeratorOfPartitionsSet( <set> [, <k> [, <flag> ] ] )
+gap> EnumeratorOfPartitionsSet();
+Error, Function: number of arguments must be at least 1 (not 0)
+gap> EnumeratorOfPartitionsSet(fail);
+Error, EnumeratorOfPartitionsSet: <s> must be a set
+gap> EnumeratorOfPartitionsSet([],fail);
+Error, EnumeratorOfPartitionsSet: <k> must be an integer
+gap> EnumeratorOfPartitionsSet([1],1,fail);
+Error, EnumeratorOfPartitionsSet: <flag> must be true or false
+gap> EnumeratorOfPartitionsSet([1],1,true,"too many");
+Error, usage: EnumeratorOfPartitionsSet( <set> [, <k> [, <flag> ] ] )
+gap> for s in [
+>        [], [5], [1, 2, 3, 4], [2, 5, 7], ["a", "b", "c", "d", "e"], [3 .. 9],
+>        [[1], [1, 2], [2, 3], [4]], ["a", "ab", "c"], "abcd"
+>      ] do
+>      pn1 := PartitionsSet(s);
+>      pn2 := List(EnumeratorOfPartitionsSet(s));
+>      if Length(pn1) <> Length(pn2) then
+>        Error("wrong number of elements for s = ", s);
+>      elif Set(pn1) <> Set(pn2) then
+>        Error("different elements for s = ", s);
+>      fi;
+>      for y in pn1 do
+>        if Position(pn2, y) = fail then
+>          Error("did not find position of element y = ", y, " when s = ", s);
+>        fi;
+>        if pn2[Position(pn2, y)] <> y then
+>          Error("position does not cancel for y = ", y, " when s = ", s);
+>        fi;
+>      od;
+>      for k in [0 .. Size(s) + 1] do
+>        pn1 := PartitionsSet(s, k);
+>        pn2 := List(EnumeratorOfPartitionsSet(s, k));
+>        if Length(pn1) <> Length(pn2) then
+>          Error("wrong number of elements for s = ", s, ", k = ", k);
+>        elif Set(pn1) <> Set(pn2) then
+>          Error("different elements for s = ", s, ", k = ", k);
+>        fi;
+>        for y in pn1 do
+>          if Position(pn2, y) = fail then
+>            Error("did not find position of element y = ", y, " when s = ", s);
+>          fi;
+>          if pn2[Position(pn2, y)] <> y then
+>            Error("position does not cancel for y = ", y, " when s = ", s);
+>          fi;
+>        od;
+>      od; 
+>      for k in [0 .. Size(s) + 1] do
+>        pn1:= [];
+>        for x in [0 .. k] do
+>          Append(pn1, PartitionsSet(s, x));
+>        od;
+>        pn2:= List(IteratorOfPartitionsSet(s, k, true));
+>        if Length(pn1) <> Length(pn2) then
+>          Error("wrong number of elements for s = ", s, ", k <= ", k);
+>        elif Set(pn1) <> Set(pn2) then
+>          Error("different elements for s = ", s, ", k <= ", k);
+>        fi;
+>        for y in pn1 do
+>          if Position(pn2, y) = fail then
+>            Error("did not find position of element y = ", y, " when s = ", s);
+>          fi;
+>          if pn2[Position(pn2, y)] <> y then
+>            Error("position does not cancel for y = ", y, " when s = ", s);
+>          fi;
+>        od;
+>      od;
+>    od;
+gap> pn2 := EnumeratorOfPartitionsSet(["a", "ab", "c", "cd"]);;
+gap> Position(pn2, [["a", "ab", "c"], ["cd"]]);
+2
+gap> Position(pn2, [["a", "ab"], ["c"], ["cd"]]);
+9
+gap> Position(pn2, [["cd"], ["a", "ab", "c"]]);
+fail
+gap> Position(pn2, [["a", "c", "ab"], ["cd"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], ["d"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], "cd"]);
+fail
+gap> Position(pn2, [1, 2]);
+fail
+gap> Position(pn2, 1);
+fail
+gap> pn2 := EnumeratorOfPartitionsSet(["a", "ab", "c", "cd"], 2);;
+gap> Position(pn2, [["a", "ab", "c"], ["cd"]]);
+1
+gap> Position(pn2, [["a", "ab"], ["c"], ["cd"]]);
+fail
+gap> Position(pn2, [["cd"], ["a", "ab", "c"]]);
+fail
+gap> Position(pn2, [["a", "c", "ab"], ["cd"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], ["d"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], "cd"]);
+fail
+gap> Position(pn2, [1, 2]);
+fail
+gap> Position(pn2, 1);
+fail
+gap> pn2 := EnumeratorOfPartitionsSet(["a", "ab", "c", "cd"], 2, false);;
+gap> Position(pn2, [["a", "ab", "c"], ["cd"]]);
+1
+gap> Position(pn2, [["a", "ab"], ["c"], ["cd"]]);
+fail
+gap> Position(pn2, [["cd"], ["a", "ab", "c"]]);
+fail
+gap> Position(pn2, [["a", "c", "ab"], ["cd"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], ["d"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], "cd"]);
+fail
+gap> Position(pn2, [1, 2]);
+fail
+gap> Position(pn2, 1);
+fail
+gap> pn2 := EnumeratorOfPartitionsSet(["a", "ab", "c", "cd"], 2, true);;
+gap> Position(pn2, [["a", "ab", "c"], ["cd"]]);
+2
+gap> Position(pn2, [["a", "ab"], ["c"], ["cd"]]);
+fail
+gap> Position(pn2, [["cd"], ["a", "ab", "c"]]);
+fail
+gap> Position(pn2, [["a", "c", "ab"], ["cd"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], ["d"]]);
+fail
+gap> Position(pn2, [["a", "ab", "c"], "cd"]);
+fail
+gap> Position(pn2, [1, 2]);
+fail
+gap> Position(pn2, 1);
+fail
 
 #F  Lucas(<P>,<Q>,<k>)  . . . . . . . . . . . . . . value of a lucas sequence
 gap> Print(List( [0..10], i->Lucas(1,-2,i)[1] ),"\n");


### PR DESCRIPTION
This PR adds an enumerator for the `PartitionsSet` object, which returns all set partitions of a finite set, with the possibility of restricting the number of parts too. This PR resolves https://github.com/gap-system/gap/issues/6362.

Interestingly, the enumerator is faster than the iterator for a fixed `k` (when `k` is not fixed, they seem to run comparably fast):

```gap
gap> A := EnumeratorOfPartitionsSet([1..20], 10);;
gap> A[1000]; time;
[ [ 1, 2, 5, 6, 12 ], [ 3, 4, 7, 8, 9, 10, 11 ], [ 13 ], [ 14 ], [ 15 ], [ 16 ], [ 17 ], [ 18 ], [ 19 ], [ 20 ] ]
1
gap> B := IteratorOfPartitionsSet([1..20], 10);;
gap> NextIterator(B); time;
[ [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ], [ 12 ], [ 13 ], [ 14 ], [ 15 ], [ 16 ], [ 17 ], [ 18 ], [ 19 ], [ 20 ] ]
584
```

I also used the [Rocq](https://rocq-prover.org/) theorem prover at the initial stages of writing this function to help get the encoding/decoding logic correct (see Further details section for more details).

## Text for release notes

see title

## Further details

The enumerator is implemented using `EnumeratorByFunctions`. To do this we needed to implement two functions: an encoder, which takes a partition and returns its number with respect to some fixed order (`NumberElement`), and a decoder which does the opposite (`ElementNumber`). It was not initially clear to me how to do this, I knew I would make use of the identity `Stirling2(n, k) = Stirling2(n-1, k-1) + k * Stirling2(n-1, k)`, but how exactly to do this would take a lot of iteration on my part if I were to do it directly in GAP. Another option would be to sketch it out on paper, but I decided to instead model it in Rocq.  I am including below an annotated proof script I came up with as a result of this, for those interested. It should work with Rocq 9 and mathcomp >= 2.5:

```rocq
Require Import ssreflect ssrbool ssrfun ssrbool.
From mathcomp Require Import ssrnat div seq zify.

Section PartitionSet.

(* A function for recursively computing Stirling numbers
   of the second kind. *)
Fixpoint Stirling2 (n k: nat): nat :=
  match n, k with
  | 0, 0 => 1
  | n'.+1, k'.+1 => Stirling2 n' k' + k * Stirling2 n' k
  | _, _ => 0
  end.

(* We model partitions as an inductively defined type.
   Instead of using lists of lists of elements as is used
   in GAP I decided to model them as a sequence of operations
   for that incrementally build up the partition starting with
   the empty partition as follows. *)
(* partition n k is the type of partitions of a set of n elements
   into k parts. *)
Inductive partition: nat -> nat -> Type :=
  (* The empty partition serves as our base case - it is a partition
     with 0 elements and 0 parts. *)
| EmptyPartition: partition 0 0
  (* We can construct a partition with n+1 elements and k+1 parts by
     taking an existing partition p with n elements and k parts
     and adding a new singleton part to p using the NewPart constructor. *)
| NewPart (n k: nat) (p: partition n k):
    partition (n.+1) (k.+1)
  (* We can construct a partition with n+1 elements and k parts by
     taking an existing partition p with n elements and k parts
     and adding a new element to the i-th part with the AddToPart
     constructor. *)
| AddToPart (n k i: nat) (p: partition n k):
    partition (n.+1) k.

(* The following function checks if a partition is well defined, namely
   we check that we only ever add an integer to an existing part. *)
Fixpoint partition_well_defined {n k: nat} (p: partition n k): bool :=
  match p with
  | EmptyPartition => true
  | NewPart _ _ p => partition_well_defined p
  | AddToPart _ k' i p => (i < k') && partition_well_defined p
  end.

(* The pickle function encodes a partition as an integer. *)
Fixpoint partition_pickle (n k: nat) (p: partition n k): nat :=
  match p with
  | EmptyPartition => 0
  | NewPart n' k' p' => partition_pickle n' k' p'
  | AddToPart n' k' i p' =>
    partition_pickle n' k' p' + i * Stirling2 n' k' + Stirling2 n' k'.-1 
  end.

(* We can formulate certain properties we want to hold for the encoder
   function and stipulate them as lemmas. For example, the lemma
   partition_pickle_ltn stipulates that when encoding a partition
   with n elements and k parts does not exceed Stirling2 n k.
   
   My initial implementation of the function was wrong, and I was
   unable to prove this lemma, which prompted me to tweak the definition,
   until eventually it was right. *)
Lemma partition_pickle_ltn: forall n k (p: partition n k),
  partition_well_defined p -> partition_pickle n k p < Stirling2 n k.
Proof.
  move => n k.
  elim => [//|n' k' p IH /=|n' [//|k'] i p IH /=].
  - by lia.
  - by nia.
Qed.

(* The unpickle function does the decoding. We allow it to fail on invalid
   inputs by returning None. *)
Let helper_i (n k m: nat): nat := (m - Stirling2 n k) %/ (Stirling2 n k.+1).
Let helper_m (n k m: nat): nat := (m - Stirling2 n k) %% (Stirling2 n k.+1).
Fixpoint partition_unpickle (n k m: nat): option (partition n k) :=
  if m < Stirling2 n k then
    match n, k, m with
    | 0, 0, 0 => Some EmptyPartition
    | n'.+1, k'.+1, m => 
      if m < Stirling2 n' k' then
        if partition_unpickle n' k' m is Some p then
          Some (NewPart n' k' p)
        else
          None
      else
        if partition_unpickle n' k'.+1 (helper_m n' k' m) is Some p then
          Some (AddToPart n' k'.+1 (helper_i n' k' m) p)
        else
          None
    | _, _, _ => None
    end
  else
    None.

(* Here we require that the decoding function is defined if and only if
   the input number is less than Stirling2 n k. *)
Lemma partition_unpickleP: forall n k m,
  reflect (exists p, partition_unpickle n k m = Some p) (m < Stirling2 n k).
Proof.
  move => n k m; apply (iffP idP).
  elim: n k m => [|n IH] [|k m /= H] //;
    first by case => [_|//] /=; by exists EmptyPartition.
  - rewrite H /=; case: ifP => Hm.
  -- move: (IH _ _ Hm) => [p' ->]. by exists (NewPart n k p'). 
  -- have: (helper_m n k m < Stirling2 n k.+1) =>
       [|/IH [p' ->]]; first by rewrite /helper_m; lia.
     by exists (AddToPart n k.+1 (helper_i n k m) p').
  - case: n => [|n]; case: k => [|k] [p] //=;
      first by case: m.
    by case: ifP.
Qed.

(* We also prove that the result of the decoding function is a well defined
   partition. *)
Lemma partition_unpickle_well_defined: forall n k m p,
  partition_unpickle n k m = Some p -> partition_well_defined p.
Proof.
  elim => [|n IH]; case => [|k] //;
    first by case => [p /= [] <-|].
  move => m p /=.
  case: ifP => [Hm |//]; case: ifP => Hm';
  case H: (partition_unpickle _ _ _) => [p'|//]; case => <- /=.
  - by apply IH with m.
  - apply/andP; split;
      last by apply (IH _ _ _ H).
    by rewrite /helper_i; nia.
Qed.

(* Finally, we prove that the pickle and unpickle functions are mutually
   inverse when the partition is well defined. *)
Lemma partition_pickleK: forall n k p,
  partition_well_defined p ->
  partition_unpickle n k (partition_pickle n k p) = Some p.
Proof. 
  move => n k; elim => [//|n' k' p' /= H Hp|n' k' i p' /= H /andP [Hi Hp]];
  move: (H Hp) => {}H.
  - rewrite H;
    have: (partition_pickle n' k' p' < Stirling2 n' k') => [|H'];
      first by apply/partition_unpickleP; exists p'.
    rewrite H'; case: ifP => [//|]; by lia.
  - case: k' p' H Hp Hi => [//|k' p' H Hp Hi].
    have: (partition_pickle n' k'.+1 p' < Stirling2 n' k'.+1) => [|H'];
    first by apply/partition_unpickleP; exists p'.
    case: ifP => [_|] /=; last by nia.
    case: ifP => [|_]; first by lia.
    set m' := helper_m n' k' _.
    set i' := helper_i n' k' _.
    have: (m' = partition_pickle n' k'.+1 p') => [|->];
      first by rewrite /m' /helper_m -addnBA // subnn addn0 addnC modnMDl modn_small.
    have: (i' = i) => [|->];
      first by rewrite /i' /helper_i; nia.
    by rewrite H.
Qed.

End PartitionSet.
```

It was useful since I could detect when the encode/decode functions are wrong: if a function was wrong, I would get stuck when proving a lemma. But the way I got stuck in the proof informed me on what I needed to change in the function to make it more correct. It took about 2-3 iterations until I got the functions right and got all of the proofs correct.

This gave me a good idea for what the GAP functions should look like. I could not translate the functions 1-1 to GAP, since the Rocq script uses a functional style. If I had more Rocq-fu I could probably write it closer to an imperative style. So the main complexity was unrolling the recursion when implementing these functions in GAP and translating the inductive partition definition to the list definition. But this was not too bad, and the big advantage was that I did not have to second guess the mathematical foundations of my encode/decode function.