### PR TITLE
Ensure more tests pass with `gap --bare`

### DIFF
--- a/tst/testbugfix/00008.tst
+++ b/tst/testbugfix/00008.tst
@@ -5,7 +5,7 @@ gap> EulerianFunction( CyclicGroup(6), 1 );
 2
 gap> EulerianFunction( CyclicGroup(5), 1 );
 4
-gap> g:=SmallGroup(1,1);;
+gap> g:=TrivialGroup(IsPcGroup);;
 gap> ConjugacyClassesSubgroups(g);;
 gap> g:=Group([ (3,5), (1,3,5) ]);;
 gap> MaximalSubgroups(g);;

--- a/tst/testbugfix/2005-05-03-t00070.tst
+++ b/tst/testbugfix/2005-05-03-t00070.tst
@@ -1,5 +1,0 @@
-# 2005/05/03 (BE)
-gap> NumberSmallGroups(5^6);
-684
-gap> NumberSmallGroups(5*7*9*11*13);
-22

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -443,19 +443,19 @@ gap> HasIsIrreducibleCharacter( TrivialCharacter( SymmetricGroup( 4 ) ) );
 true
 
 # concurring 'Irr' methods
-gap> G:= PcGroupCode( 221729, 24 );;
+gap> G:= DirectProduct(CyclicGroup(4), DihedralGroup(6));;
 gap> IsSupersolvable( G );
 true
 gap> Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Baum-Clausen Algorithm"
-gap> G:= PcGroupCode( 221729, 24 );;
+gap> G:= DirectProduct(CyclicGroup(4), DihedralGroup(6));;
 gap> IsSupersolvable( G );
 true
 gap> IrrConlon( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Conlon's Algorithm"
-gap> G:= PcGroupCode( 221729, 24 );;
+gap> G:= DirectProduct(CyclicGroup(4), DihedralGroup(6));;
 gap> IrrDixonSchneider( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Dixon's Algorithm"

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -443,19 +443,19 @@ gap> HasIsIrreducibleCharacter( TrivialCharacter( SymmetricGroup( 4 ) ) );
 true
 
 # concurring 'Irr' methods
-gap> G:= DirectProduct(CyclicGroup(4), DihedralGroup(6));;
+gap> G:= PcGroupCode( 221729, 24 );;  # = SmallGroup( 24, 5 )
 gap> IsSupersolvable( G );
 true
 gap> Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Baum-Clausen Algorithm"
-gap> G:= DirectProduct(CyclicGroup(4), DihedralGroup(6));;
+gap> G:= PcGroupCode( 221729, 24 );;  # = SmallGroup( 24, 5 )
 gap> IsSupersolvable( G );
 true
 gap> IrrConlon( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Conlon's Algorithm"
-gap> G:= DirectProduct(CyclicGroup(4), DihedralGroup(6));;
+gap> G:= PcGroupCode( 221729, 24 );;  # = SmallGroup( 24, 5 )
 gap> IrrDixonSchneider( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Dixon's Algorithm"

--- a/tst/testinstall/ctblmaps.tst
+++ b/tst/testinstall/ctblmaps.tst
@@ -3,8 +3,7 @@ gap> START_TEST( "ctblmaps.tst" );
 
 # `ConsiderStructureConstants` can unexpectedly exclude all candidates.
 # (Benjamin Sambale found examples for that.)
-gap> if TestPackageAvailability("ctbllib") <> fail and
->       LoadPackage("ctbllib", false) <> fail then
+gap> if IsPackageMarkedForLoading( "ctbllib", "" ) then
 >      s:= CharacterTable( "2.A6" );;
 >      t:= CharacterTable( "Co3" );;
 >      maps:= [ [ 1, 2, 8, 4, 11, 4, 13, 18, 18, 9, 22, 9, 22 ],

--- a/tst/testinstall/ctblmono.tst
+++ b/tst/testinstall/ctblmono.tst
@@ -96,6 +96,8 @@ gap> TestMonomial( irr[2] );
 rec( comment := "whole group is monomial", isMonomial := true )
 gap> IsMonomial( irr[2] );
 true
+
+#
 gap> irr:= Irr( SL(2,3) );;
 gap> chi:= First( irr, x -> x[1] = 3 );;
 gap> TestMonomialQuick( chi );
@@ -104,6 +106,8 @@ gap> TestMonomial( chi );
 rec( comment := "codegree is prime power", isMonomial := true )
 gap> IsMonomial( chi );
 true
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> irr:= Irr( SmallGroup( 120, 15 ) );;
 gap> chi:= First( irr, x -> x[1] = 3 and
 >                           Length( ClassPositionsOfKernel( x ) ) = 2 );;
@@ -121,6 +125,9 @@ gap> TestMonomial( chi );
 rec( comment := "induced from monomial Hall subgroup", isMonomial := true )
 gap> IsMonomial( chi );
 true
+#@fi
+
+#
 gap> g:= DirectProduct( AlternatingGroup(5), SymmetricGroup(3),
 >                       SymmetricGroup(3) );;
 gap> chi:= First( Irr( g ), x -> x[1] = 2 and
@@ -131,6 +138,8 @@ gap> TestMonomial( chi );
 rec( comment := "kernel factor group is supersolvable", isMonomial := true )
 gap> IsMonomial( chi );
 true
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> irr:= Irr( SmallGroup( 144, 31 ) );;
 gap> chi:= First( irr, x -> x[1] = 6 );;
 gap> TestMonomialQuick( chi );
@@ -139,6 +148,9 @@ gap> TestMonomial( chi );
 rec( comment := "kernel factor group is monomial", isMonomial := true )
 gap> IsMonomial( chi );
 true
+#@fi
+
+#
 gap> irr:= Irr( SL(2,3) );;
 gap> chi:= First( irr, x -> x[1] = 2 );;
 gap> TestMonomialQuick( chi );
@@ -147,6 +159,8 @@ gap> TestMonomial( chi );
 rec( comment := "quasiprimitive character", isMonomial := false )
 gap> IsMonomial( chi );
 false
+
+#
 gap> irr:= Irr( AlternatingGroup( 5 ) );;
 gap> chi:= First( irr, x -> x[1] = 5 );;
 gap> TestMonomialQuick( chi );
@@ -166,6 +180,8 @@ gap> TestMonomial( chi, true ).comment;
 "lattice checked"
 gap> IsMonomial( chi );
 false
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> irr:= Irr( SmallGroup( 96, 204 ) );;
 gap> chi:= First( irr, x -> x[1] = 4 );;
 gap> TestMonomialQuick( chi );
@@ -174,6 +190,9 @@ gap> TestMonomial( chi ).comment;
 "induced from 'character'"
 gap> IsMonomial( chi );
 true
+#@fi
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> chi:= First( Irr( SmallGroup( 144, 31 ) ), x -> x[1] = 4 );;
 gap> TestMonomialQuick( chi );
 rec( comment := "no decision by cheap tests", isMonomial := "?" )
@@ -183,6 +202,9 @@ gap> TestMonomial( chi, true ).comment;
 "induced from 'character'"
 gap> IsMonomial( chi );
 true
+#@fi
+
+#
 gap> chi:= 0 * [ 1 .. NrConjugacyClasses( S4 ) ];;
 gap> chi[1]:= Size( S4 );;
 gap> chi:= ClassFunction( S4, chi );;
@@ -193,6 +215,8 @@ gap> TestMonomial( chi, true ).comment;
 gap> IsMonomial( chi );
 true
 gap> TestMonomialUseLattice:= TestMonomialUseLattice_Orig;;
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> chi:= First( Irr( SmallGroup( 48, 28 ) ), x -> x[1] = 4 );;
 gap> TestMonomialQuick( chi );
 rec( comment := "no decision by cheap tests", isMonomial := "?" )
@@ -200,6 +224,7 @@ gap> TestMonomial( chi ).comment;
 "induced from 'character'"
 gap> IsMonomial( chi );
 true
+#@fi
 
 ##
 gap> TestMonomialQuick( S4 );
@@ -214,6 +239,8 @@ gap> TestMonomial( Sl23 );
 rec( comment := "list Delta( G ) contains entry > 1", isMonomial := false )
 gap> IsMonomial( Sl23 );
 false
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> g:= SmallGroup( 96, 204 );;
 gap> TestMonomialQuick( g );
 rec( comment := "no decision by cheap tests", isMonomial := "?" )
@@ -239,6 +266,9 @@ gap> TestMonomial( g );
 rec( comment := "was already stored", isMonomial := true )
 gap> IsMonomial( g );
 true
+#@fi
+
+#
 gap> g:= AlternatingGroup( 5 );;
 gap> TestMonomialQuick( g );
 rec( comment := "non-solvable group", isMonomial := false )
@@ -246,6 +276,8 @@ gap> TestMonomial( g );
 rec( comment := "non-solvable group", isMonomial := false )
 gap> IsMonomial( g );
 false
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> g:= SmallGroup( 56, 10 );;
 gap> TestMonomialQuick( g );
 rec( comment := "group order is monomial", isMonomial := true )
@@ -274,6 +306,7 @@ gap> TestMonomial( g );
 rec( comment := "Sylow abelian by supersolvable group", isMonomial := true )
 gap> IsMonomial( g );
 true
+#@fi
 
 ##
 gap> TestSubnormallyMonomial( S4 );

--- a/tst/testinstall/ctblsolv.tst
+++ b/tst/testinstall/ctblsolv.tst
@@ -1,7 +1,7 @@
 #@local G, pair, mth, all, rks, tbl
 gap> START_TEST("ctblsolv.tst");
 
-##
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> CharacterDegrees( SmallGroup( 256, 529 ) );
 [ [ 1, 8 ], [ 2, 30 ], [ 4, 8 ] ]
 gap> for pair in [ [ 18, 3 ], [ 27, 3 ], [ 36, 7 ], [ 50, 3 ], [ 54, 4 ] ] do
@@ -11,6 +11,7 @@ gap> for pair in [ [ 18, 3 ], [ 27, 3 ], [ 36, 7 ], [ 50, 3 ], [ 54, 4 ] ] do
 >        Error( IdGroup( G ) );
 >      fi;
 >    od;
+#@fi
 
 ##
 gap> mth:= [];;
@@ -18,11 +19,11 @@ gap> G:= AbelianGroup( [ 2, 3, 5 ] );;
 gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
 gap> CharacterDegrees( G ) = [ [ 1, 30 ] ];
 true
-gap> G:= SmallGroup( 24, 12 );;  Irr( G );;
+gap> G:= SymmetricGroup(IsPcGroup, 4);;  Irr( G );;
 gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
 gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
 true
-gap> G:= SmallGroup( 24, 12 );;  CharacterTable( G );;
+gap> G:= SymmetricGroup(IsPcGroup, 4);;  CharacterTable( G );;
 gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
 gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
 true
@@ -34,7 +35,7 @@ gap> G:= Group( [ [ E(3) ] ], [ [ E(4) ] ] );;
 gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
 gap> CharacterDegrees( G ) = [ [ 1, 12 ] ];
 true
-gap> G:= SmallGroup( 24, 12 );;  # hier: auch überaufl.!!!
+gap> G:= SymmetricGroup(IsPcGroup, 4);;  # hier: auch überaufl.!!!
 gap> Add( mth, ApplicableMethod( CharacterDegrees, [ G ] ) );
 gap> CharacterDegrees( G ) = [ [ 1, 2 ], [ 2, 1 ], [ 3, 2 ] ];
 true

--- a/tst/testinstall/grp/basic.tst
+++ b/tst/testinstall/grp/basic.tst
@@ -271,10 +271,10 @@ true
 #
 # dicyclic groups
 #
-gap> IdGroup(DicyclicGroup(4));
-[ 4, 1 ]
-gap> IdGroup(DicyclicGroup(IsFpGroup,4));
-[ 4, 1 ]
+gap> StructureDescription(DicyclicGroup(4));
+"C4"
+gap> StructureDescription(DicyclicGroup(IsFpGroup,4));
+"C4"
 gap> DicyclicGroup(8);
 <pc group of size 8 with 3 generators>
 gap> DicyclicGroup(IsPcGroup,8);
@@ -340,10 +340,12 @@ gap> for n in [ 4, 12, 20, 24 ] do
 >        Error( "gen. quat. group?" );
 >      fi;
 >    od;
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> Number( AllSmallGroups( [  1 .. 32 ], IsDicyclicGroup ) );
 8
 gap> Number( AllSmallGroups( [  1 .. 32 ], IsGeneralisedQuaternionGroup ) );
 3
+#@fi
 
 #
 gap> Q:= DicyclicGroup( 20 );;

--- a/tst/testinstall/grpfp.tst
+++ b/tst/testinstall/grpfp.tst
@@ -162,6 +162,7 @@ false
 Error, the f.p. group <G> is not finite
 
 # RWS for G2(3) and S_6(2)
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> g:=SimpleGroup("G2(3)");;
 gap> hom:=IsomorphismFpGroupForRewriting(g);;
 gap> m:=Image(IsomorphismFpMonoid(Image(hom)));;
@@ -169,6 +170,9 @@ gap> F:=m!.rewritingSystem;;;
 gap> ReducedForm(F,UnderlyingElement(
 > Product(GeneratorsOfMonoid(m){[1,3..19]})));
 w1*B5*b6*b7*B8*w2*b1*B3*B4*b5*b6*b7
+#@fi
+
+#
 gap> g:=SimpleGroup("S6(2)");;
 gap> hom:=IsomorphismFpGroupForRewriting(g);;
 gap> m:=Image(IsomorphismFpMonoid(Image(hom)));;

--- a/tst/testinstall/grpmat.tst
+++ b/tst/testinstall/grpmat.tst
@@ -86,8 +86,10 @@ gap> TrivialSubgroup( GL(2, 2) );
 <matrix group of size 1>
 
 # The following should take less than a second.
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> Length( LowIndexSubgroups( GL(2,5), 50 ) ) = 31;
 true
+#@fi
 
 # 'NiceMonomorphism' behaves well w.r.t. 'ConstructingFilter'
 gap> G:= SP( 4, 2 );;

--- a/tst/testinstall/grppc.tst
+++ b/tst/testinstall/grppc.tst
@@ -137,7 +137,7 @@ gap> List( sys, Size );
 [ 4, 7 ]
 gap> List(sys,i->Length(AsList(i)));
 [ 4, 7 ]
-gap> G := SmallGroup( 144, 183 );;
+gap> G := DirectProduct(SymmetricGroup(IsPcGroup, 3), SymmetricGroup(IsPcGroup, 4));;
 gap> F := FittingSubgroup( G );;
 gap> S := SylowSubgroup( F, 2 );;
 gap> Display(Image(IsomorphismPcGroup(S)));
@@ -166,7 +166,7 @@ gap> RepresentativeAction(G,x,x^2)<>fail;
 true
 gap> RepresentativeAction(G,x,x^2);
 f1*f2
-gap> g := SmallGroup(243,27);;
+gap> g := PcGroupCode(14055476799225975, 243);; # = SmallGroup(243,27)
 gap> AsSet(Omega(g,3,1)) = Set(Filtered(g, g -> IsOne(g^3)));
 true
 gap> AsSet(Omega(g,3,2)) = Set(Filtered(g, g -> IsOne(g^9)));

--- a/tst/testinstall/interpreter.tst
+++ b/tst/testinstall/interpreter.tst
@@ -39,8 +39,10 @@ gap> QUIT;
 #
 # help system
 #
+#@if IsPackageMarkedForLoading( "gapdoc", "" )
 gap> ?qwert_asdf
 Help: no matching entry found
+#@fi
 
 #
 # function call with options

--- a/tst/testinstall/mapphomo.tst
+++ b/tst/testinstall/mapphomo.tst
@@ -86,7 +86,7 @@ gap> One( hom );
 fail
 
 # Check that group homomorphisms created by a function can compute preimages.
-gap> for G in [ SymmetricGroup(5), SmallGroup( 24, 12 ), GL(2,3) ] do
+gap> for G in [ SymmetricGroup(5), DihedralGroup(8), GL(2,3) ] do
 >      hom:= GroupHomomorphismByFunction( G, G, x -> x );
 >      PreImagesRepresentative( hom, G.1 );
 >    od;

--- a/tst/testinstall/matblock.tst
+++ b/tst/testinstall/matblock.tst
@@ -138,7 +138,7 @@ gap> MinimalPolynomial( R, m2 ) = MinimalPolynomial( R, MatrixByBlockMatrix( m2 
 true
 
 # Groups that consist of block matrices
-gap> G:= SmallGroup( 24, 12 );;
+gap> G:= SymmetricGroup(IsPcGroup, 4);;
 gap> H:= SylowSubgroup( G, 2 );;
 gap> reps:= IrreducibleRepresentations( H );;
 gap> ind:= InducedRepresentation( reps[5], G );;

--- a/tst/testinstall/meatauto.tst
+++ b/tst/testinstall/meatauto.tst
@@ -12,7 +12,7 @@ gap> SMTX_NullspaceEqns(e);
 #
 # MTX.BasisModuleEndomorphisms
 #
-gap> G:=SmallGroup(24, 3);;
+gap> G:=SL(2, 3);;
 gap> p:=NextPrimeInt(100);;
 gap> M:=RegularModule(G, GF(p))[2];;
 gap> MTX.BasisModuleEndomorphisms(M);
@@ -44,7 +44,7 @@ gap> MTX.BasisModuleEndomorphisms(M);
 #
 # MTX.HomogeneousComponents
 #
-gap> G:=SmallGroup(24, 3);;
+gap> G:=SL(2, 3);;
 gap> p:=NextPrimeInt(100);;
 gap> M:=RegularModule(G, GF(p))[2];;
 gap> hc := MTX.HomogeneousComponents(M);;

--- a/tst/testinstall/meataxe.tst
+++ b/tst/testinstall/meataxe.tst
@@ -77,8 +77,10 @@ gap> M2:=TensorProductGModule(M,M);
 rec( IsOverFiniteField := true, dimension := 9, field := GF(2), 
   generators := [ <an immutable 9x9 matrix over GF2>, 
       <an immutable 9x9 matrix over GF2> ], isMTXModule := true )
-gap> IdGroup(MTX.ModuleAutomorphisms(M2));
-[ 1344, 11301 ]
+gap> G:=MTX.ModuleAutomorphisms(M2);
+<matrix group of size 1344 with 9 generators>
+gap> StructureDescription(G);
+"PSL(3,2) x D8"
 gap> cf:=MTX.CompositionFactors(M2);;
 gap> ForAll(cf, MTX.IsAbsolutelyIrreducible);
 true
@@ -138,8 +140,8 @@ false
 
 #
 gap> M2:=First(MTX.CompositionFactors(M), m -> m.dimension = 4);;
-gap> IdGroup(MTX.ModuleAutomorphisms(M2));
-[ 48, 2 ]
+gap> StructureDescription(MTX.ModuleAutomorphisms(M2));
+"C48"
 gap> MTX.IsIndecomposable(M2);
 true
 gap> MTX.IsAbsolutelyIrreducible(M2);

--- a/tst/testinstall/opers/FittingSubgroup.tst
+++ b/tst/testinstall/opers/FittingSubgroup.tst
@@ -15,11 +15,12 @@ gap> G := CyclicGroup(IsPcGroup, 12);;
 gap> IsIdenticalObj(G, FittingSubgroup(G));
 true
 
-#
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> List(AllSmallGroups(60), g -> Size(FittingSubgroup(g)));
 [ 30, 30, 30, 60, 1, 15, 15, 15, 20, 30, 30, 30, 60 ]
 gap> ForAll(AllSmallGroups(60), g -> IsNormal(g, FittingSubgroup(g)));
 true
+#@fi
 
 #
 gap> g := SL(2,5);;

--- a/tst/testinstall/opers/FrattiniSubgroup.tst
+++ b/tst/testinstall/opers/FrattiniSubgroup.tst
@@ -16,12 +16,12 @@ gap> HasIsAbelian(FrattiniSubgroup(G));
 true
 gap> GeneratorsOfGroup(FrattiniSubgroup(G));
 [ (x^-195*y^196)^6, (x^-1*y)^630, (x^-1*y)^840 ]
-gap> G := DirectProduct(DihedralGroup(IsPcGroup,8), SmallGroup(27,4));;
+gap> G := DirectProduct(DihedralGroup(8), ExtraspecialGroup(27,9));;
 gap> IsNilpotentGroup(G);
 true
 gap> F := FrattiniSubgroup(G);;
-gap> IdGroup(F);
-[ 6, 2 ]
+gap> StructureDescription(F);
+"C6"
 gap> HasIsNilpotentGroup(F);
 true
 
@@ -43,11 +43,12 @@ Group([  ])
 gap> AsSet( FrattiniSubgroup(CyclicGroup(IsPcGroup, 9)) );
 [ <identity> of ..., f2, f2^2 ]
 
-#
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> List(AllSmallGroups(60), g -> Size(FrattiniSubgroup(g)));
 [ 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
 gap> ForAll(AllSmallGroups(60), g -> IsNormal(g, FrattiniSubgroup(g)));
 true
+#@fi
 
 #
 gap> g := SL(2,5);;

--- a/tst/testinstall/opers/HallSubgroup.tst
+++ b/tst/testinstall/opers/HallSubgroup.tst
@@ -2,20 +2,25 @@ gap> START_TEST("HallSubgroup.tst");
 gap> G := GL(3,4);;
 gap> HallSubgroup(G, [2,3]);
 fail
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> G := PSL(4,2);;
 gap> IdGroup(HallSubgroup(G, [2,3]));
 [ 576, 8654 ]
 gap> G := PSp(4,5);;
 gap> IdGroup(HallSubgroup(G,[2,3]));
 [ 576, 8277 ]
+#@fi
+
+#
 gap> G := Group([ [ [ Z(2)^0, 0*Z(2), 0*Z(2) ],
 > [ 0*Z(2), Z(2)^0, 0*Z(2) ],
 > [ 0*Z(2), Z(2)^0, Z(2)^0 ] ], 
 > [ [ 0*Z(2), Z(2)^0, 0*Z(2) ],
 > [ 0*Z(2), 0*Z(2), Z(2)^0 ],
 > [ Z(2)^0, 0*Z(2), 0*Z(2) ] ] ]);;
-gap> List(HallSubgroup(G, [2,3]), IdGroup);
-[ [ 24, 12 ], [ 24, 12 ] ]
+gap> List(HallSubgroup(G, [2,3]), StructureDescription);
+[ "S4", "S4" ]
 
 #
 gap> G:=PerfectGroup(IsFpGroup,60,1);

--- a/tst/testinstall/opers/IsSolvableGroup.tst
+++ b/tst/testinstall/opers/IsSolvableGroup.tst
@@ -1,9 +1,11 @@
 gap> START_TEST("IsSolvableGroup.tst");
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> List(AllSmallGroups(120), IsSolvableGroup);
 [ true, true, true, true, false, true, true, true, true, true, true, true, 
   true, true, true, true, true, true, true, true, true, true, true, true, 
   true, true, true, true, true, true, true, true, true, false, false, true, 
   true, true, true, true, true, true, true, true, true, true, true ]
+#@fi
 gap> grps := [
 >  [ (1,2,3,4,5,6,7,8) ], [ (1,2,3,8)(4,5,6,7), (1,5)(2,6)(3,7)(4,8) ],
 >  [ (1,8)(2,3)(4,5)(6,7), (1,3)(2,8)(4,6)(5,7), (1,5)(2,6)(3,7)(4,8) ],

--- a/tst/testinstall/opers/LatticeByCyclicExtension.tst
+++ b/tst/testinstall/opers/LatticeByCyclicExtension.tst
@@ -1,8 +1,13 @@
 gap> START_TEST("LatticeByCyclicExtension.tst");
 
+# construct SmallGroup(500,1)
+gap> H:=CyclicGroup(4);;
+gap> N:=CyclicGroup(125);;
+gap> A:=AutomorphismGroup(N);;
+gap> alpha:=GroupHomomorphismByImages(H,A,[H.1],[A.1^50]);;
+gap> G:=SemidirectProduct(H, alpha, N);;
+
 #
-gap> G:=SmallGroup(500,1);
-<pc group of size 500 with 5 generators>
 gap> fun:=g->IsInt(4/Size(g));;
 gap> LatticeByCyclicExtension(G);
 <subgroup lattice of <pc group of size 500 with 5 generators>, 12 classes, 

--- a/tst/testinstall/opers/MinimalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MinimalNormalSubgroups.tst
@@ -7,42 +7,49 @@ gap> G := Group(());; NormalSubgroups(G);; MinimalNormalSubgroups(G);
 gap> D := DihedralGroup(8);;
 gap> MinimalNormalSubgroups(D) = [ Center(D) ];
 true
-gap> List(MinimalNormalSubgroups(D), IdGroup);
-[ [ 2, 1 ] ]
+gap> List(MinimalNormalSubgroups(D), Size);
+[ 2 ]
 gap> D := DihedralGroup(IsFpGroup, 8);;
 gap> MinimalNormalSubgroups(D) = [ Center(D) ];
 true
-gap> List(MinimalNormalSubgroups(D), IdGroup);
-[ [ 2, 1 ] ]
+gap> List(MinimalNormalSubgroups(D), Size);
+[ 2 ]
 gap> D := Group((1,3),(1,2,3,4));;
 gap> MinimalNormalSubgroups(D) = [ Center(D) ];
 true
-gap> List(MinimalNormalSubgroups(D), IdGroup);
-[ [ 2, 1 ] ]
+gap> List(MinimalNormalSubgroups(D), Size);
+[ 2 ]
 gap> DDD := DirectProduct(D, D, D);;
-gap> List(MinimalNormalSubgroups(DDD), IdGroup);
-[ [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ] ]
+gap> List(MinimalNormalSubgroups(DDD), Size);
+[ 2, 2, 2, 2, 2, 2, 2 ]
 gap> Q := QuaternionGroup(8);;
 gap> MinimalNormalSubgroups(Q) = [ Center(Q) ];
 true
-gap> List(MinimalNormalSubgroups(Q), IdGroup);
-[ [ 2, 1 ] ]
+gap> List(MinimalNormalSubgroups(Q), Size);
+[ 2 ]
 gap> MinimalNormalSubgroups(SymmetricGroup(4)) = [ Group((1,2)(3,4),(1,3)(2,4)) ];
 true
-gap> List(MinimalNormalSubgroups(SymmetricGroup(5)), IdGroup);
-[ [ 60, 5 ] ]
-gap> List(MinimalNormalSubgroups(AlternatingGroup(5)), IdGroup);
-[ [ 60, 5 ] ]
+gap> MinimalNormalSubgroups(SymmetricGroup(5)) = [ AlternatingGroup(5) ];
+true
+gap> MinimalNormalSubgroups(AlternatingGroup(5)) = [ AlternatingGroup(5) ];
+true
+
+#
 gap> G := Group((1,2),(3,4),(5,6),(7,8));;
 gap> IsElementaryAbelian(G);
 true
 gap> Size(MinimalNormalSubgroups(G));
 15
-gap> MinimalNormalSubgroups(PrimitiveGroup(8,3)) = [ Group([ (1,7)(2,8)(3,5)(4,6), (1,3)(2,4)(5,7)(6,8), (1,2)(3,4)(5,6)(7,8) ]) ];
+
+#
+gap> G := Group((2,7,4,8,6,5,3), (2,3)(6,7), (1,2)(3,4)(5,6)(7,8));; # = PrimitiveGroup(8,3)
+gap> MinimalNormalSubgroups(G) = [ Group([ (1,7)(2,8)(3,5)(4,6), (1,3)(2,4)(5,7)(6,8), (1,2)(3,4)(5,6)(7,8) ]) ];
 true
 gap> k := 5;; P := SylowSubgroup(SymmetricGroup(4*k), 2);; A := Group((4*k+1, 4*k+2, 4*k+3));; G := ClosureGroup(P, A);; IsNilpotentGroup(G);;
 gap> Set(MinimalNormalSubgroups(G)) = Set([ Group([ (1,2)(3,4)(5,6)(7,8)(9,10)(11,12)(13,14)(15,16) ]), Group([ (17,18)(19,20) ]), Group([ (1,2)(3,4)(5,6)(7,8)(9,10)(11,12)(13,14)(15,16)(17,18)(19,20) ]), Group([ (21,22,23) ]) ]);
 true
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> G := SmallGroup(24,12);;
 gap> SortedList(List(MinimalNormalSubgroups(G), IdGroup));
 [ [ 4, 2 ] ]
@@ -50,13 +57,16 @@ gap> A := DihedralGroup(16);;
 gap> B := SmallGroup(27, 3);;
 gap> C := SmallGroup(125, 4);;
 gap> D := DirectProduct(A, B, C, SmallGroup(1536, 2));;
-gap> SortedList(List(MinimalNormalSubgroups(D), IdGroup));
-[ [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], 
-  [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], 
-  [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], 
-  [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], 
-  [ 2, 1 ], [ 2, 1 ], [ 2, 1 ], [ 3, 1 ], [ 3, 1 ], [ 3, 1 ], [ 3, 1 ], 
-  [ 5, 1 ] ]
+gap> SortedList(List(MinimalNormalSubgroups(D), Size));
+[ 2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 3, 3, 3, 3, 
+  5 ]
+#@fi
+
+#
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
 gap> Set(MinimalNormalSubgroups(G)) = Set([ Group([ (6,12)(8,10), (2,10)(4,12), (2,12)(6,10) ]), Group([ (5,11)(7,9), (3,9)(7,11), (1,9,5,11,7) ]) ]);
 true
@@ -69,6 +79,8 @@ gap> G := F/[x^2, y^2, x^(-1)*y^(-1)*x*y, z];;
 gap> IsFinite(G);;
 gap> Size(MinimalNormalSubgroups(G));
 3
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> for G in AllSmallGroups(60) do NormalSubgroups(G);; Print(Collected(List(Set(MinimalNormalSubgroups(G)), IdGroup)), "\n"); od;
 [ [ [ 2, 1 ], 1 ], [ [ 3, 1 ], 1 ], [ [ 5, 1 ], 1 ] ]
 [ [ [ 2, 1 ], 1 ], [ [ 3, 1 ], 1 ], [ [ 5, 1 ], 1 ] ]
@@ -105,6 +117,9 @@ gap> for G in AllSmallGroups(360) do if not IsSolvable(G) then NormalSubgroups(G
 [ [ 3, 1 ], [ 60, 5 ] ]
 [ [ 3, 1 ], [ 60, 5 ] ]
 [ [ 2, 1 ], [ 3, 1 ], [ 60, 5 ] ]
+#@fi
+
+#
 gap> G := AbelianGroup([2, 3, 4, 5, 6, 7, 8, 9, 10]);;
 gap> Collected(List(Set(MinimalNormalSubgroups(G)), Size));
 [ [ 2, 31 ], [ 3, 13 ], [ 5, 6 ], [ 7, 1 ] ]
@@ -114,4 +129,6 @@ gap> Collected(List(Set(MinimalNormalSubgroups(G)), Size));
 gap> G := ElementaryAbelianGroup(7^4);;
 gap> Collected(List(Set(MinimalNormalSubgroups(G)), Size));
 [ [ 7, 400 ] ]
+
+#
 gap> STOP_TEST("Socle.tst");

--- a/tst/testinstall/opers/MinimalNormalSubgroups.tst
+++ b/tst/testinstall/opers/MinimalNormalSubgroups.tst
@@ -58,12 +58,8 @@ gap> B := SmallGroup(27, 3);;
 gap> C := SmallGroup(125, 4);;
 gap> D := DirectProduct(A, B, C, SmallGroup(1536, 2));;
 gap> SortedList(List(MinimalNormalSubgroups(D), Size));
-[ 2, 2, 2, 2, 2, 2, 2, 
-  2, 2, 2, 2, 2, 2, 2, 
-  2, 2, 2, 2, 2, 2, 2, 
-  2, 2, 2, 2, 2, 2, 2, 
-  2, 2, 2, 3, 3, 3, 3, 
-  5 ]
+[ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 
+  2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 5 ]
 #@fi
 
 #

--- a/tst/testinstall/opers/NormalHallSubgroups.tst
+++ b/tst/testinstall/opers/NormalHallSubgroups.tst
@@ -1,4 +1,5 @@
 gap> START_TEST("NormalHallSubgroups.tst");
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> for G in AllSmallGroups(60) do Print(List(NormalHallSubgroups(G), IdGroup), "\n"); od;
 [ [ 1, 1 ], [ 5, 1 ], [ 3, 1 ], [ 15, 1 ], [ 12, 1 ], [ 60, 1 ] ]
 [ [ 1, 1 ], [ 3, 1 ], [ 5, 1 ], [ 15, 1 ], [ 20, 1 ], [ 60, 2 ] ]
@@ -40,11 +41,18 @@ gap> List(AllSmallGroups(168), G -> List(NormalHallSubgroups(G), Size));
   [ 1, 8, 7, 56, 168 ], [ 1, 3, 7, 56, 21, 168 ], [ 1, 7, 3, 24, 21, 168 ], 
   [ 1, 3, 7, 21, 168 ], [ 1, 8, 3, 24, 7, 56, 21, 168 ] ]
 gap> for G in AllSmallGroups(168) do primes := PrimeDivisors(Size(G)); l := []; for pi in IteratorOfCombinations(primes) do N := HallSubgroup(G, pi); if N<>fail and IsGroup(N) and IsNormal(G, N) then AddSet(l, N); fi; od; if l <> NormalHallSubgroups(G) then Print(IdGroup(G), "\n"); fi; od;
+#@fi
+
+#
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> List(AllPrimitiveGroups(DegreeAction, 8), G -> List(NormalHallSubgroups(G), Size));
 [ [ 1, 56, 8 ], [ 1, 168, 56, 8 ], [ 1, 1344 ], [ 1, 168 ], [ 1, 336 ], 
   [ 1, 20160 ], [ 1, 40320 ] ]
 gap> List(NormalHallSubgroups(PrimitiveGroup(8,2)), Size);
 [ 1, 168, 56, 8 ]
+#@fi
+
+#
 gap> grps := [ [ (1,2,3,4,5,6) ], [ (1,3,5)(2,4,6), (1,4)(2,3)(5,6) ],
 >  [ (1,2,3,4,5,6), (1,4)(2,3)(5,6) ], [ (1,4)(2,5), (1,3,5)(2,4,6) ],
 >  [ (2,4,6), (1,4)(2,5)(3,6) ], [ (3,6), (1,3,5)(2,4,6) ],

--- a/tst/testinstall/opers/SimpleGroup.tst
+++ b/tst/testinstall/opers/SimpleGroup.tst
@@ -31,6 +31,7 @@ M11
 rec( name := "M(11)", series := "Spor", shortname := "M11" )
 
 #
+#@if IsPackageMarkedForLoading( "primggrp", "" )
 gap> SimpleGroup("J1"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 J_1
 175560
@@ -39,10 +40,12 @@ gap> SimpleGroup("J_2"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2)
 J_2
 604800
 rec( name := "HJ = J(2) = F(5-)", series := "Spor", shortname := "J2" )
+#@fi
 gap> SimpleGroup("J5");
 Error, illegal parameter for Janko groups
 
 #
+#@if IsPackageMarkedForLoading( "primggrp", "" )
 gap> SimpleGroup("CO3"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 Co_3
 495766656000
@@ -51,6 +54,7 @@ gap> SimpleGroup("CO(2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last
 Co(2)
 42305421312000
 rec( name := "Co(2)", series := "Spor", shortname := "Co2" )
+#@fi
 gap> SimpleGroup("CO4");
 Error, illegal parameter for Conway groups
 
@@ -59,6 +63,7 @@ gap> SimpleGroup("Fi20");
 Error, illegal parameter for Fischer groups
 
 #
+#@if IsPackageMarkedForLoading( "primggrp", "" )
 gap> SimpleGroup("SuZ"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 Suz
 448345497600
@@ -78,6 +83,7 @@ Sz(8)
 29120
 rec( name := "2B(2,8) = 2C(2,8) = Sz(8)", parameter := 8, series := "2B", 
   shortname := "Sz(8)" )
+#@fi
 gap> SimpleGroup("Sz(9)");
 Error, illegal parameter for Suzuki groups
 gap> SimpleGroup("Suz(16)");
@@ -105,6 +111,7 @@ gap> SimpleGroup("Ree(16)");
 Error, illegal parameter for Ree groups
 
 #
+#@if IsPackageMarkedForLoading( "primggrp", "" )
 gap> SimpleGroup("HE"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 He
 4030387200
@@ -122,6 +129,7 @@ gap> SimpleGroup("T"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 17971200
 rec( name := "2F(4,2)' = Ree(2)' = Tits", parameter := 2, series := "2F", 
   shortname := "2F4(2)'" )
+#@fi
 
 #
 # linear groups
@@ -263,6 +271,7 @@ Error, Can't do yet
 #
 gap> SimpleGroup("G3(3)");
 Error, G(n,q) needs n=2
+#@if IsPackageMarkedForLoading( "primggrp", "" )
 gap> SimpleGroup("G2(2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 PSU(3,3)
 6048
@@ -280,15 +289,18 @@ gap> SimpleGroup("G2(5)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last
 G_2(5)
 5859000000
 rec( name := "G(2,5)", parameter := 5, series := "G", shortname := "G2(5)" )
+#@fi
 
 #
 gap> SimpleGroup("3D(3,4)");
 Error, 3D(n,q) needs n=4
+#@if IsPackageMarkedForLoading( "primggrp", "" )
 gap> SimpleGroup("3D(4,2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 3D(4, 2)
 211341312
 rec( name := "3D(4,2)", parameter := 2, series := "3D", shortname := "3D4(2)" 
  )
+#@fi
 gap> g:=SimpleGroup("3D(4,169)");
 3D4(169)
 gap> Size(g);

--- a/tst/testinstall/opers/SimpleGroup.tst
+++ b/tst/testinstall/opers/SimpleGroup.tst
@@ -31,7 +31,7 @@ M11
 rec( name := "M(11)", series := "Spor", shortname := "M11" )
 
 #
-#@if IsPackageMarkedForLoading( "primggrp", "" )
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> SimpleGroup("J1"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 J_1
 175560
@@ -45,7 +45,7 @@ gap> SimpleGroup("J5");
 Error, illegal parameter for Janko groups
 
 #
-#@if IsPackageMarkedForLoading( "primggrp", "" )
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> SimpleGroup("CO3"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 Co_3
 495766656000
@@ -63,7 +63,7 @@ gap> SimpleGroup("Fi20");
 Error, illegal parameter for Fischer groups
 
 #
-#@if IsPackageMarkedForLoading( "primggrp", "" )
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> SimpleGroup("SuZ"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 Suz
 448345497600
@@ -111,7 +111,7 @@ gap> SimpleGroup("Ree(16)");
 Error, illegal parameter for Ree groups
 
 #
-#@if IsPackageMarkedForLoading( "primggrp", "" )
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> SimpleGroup("HE"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 He
 4030387200
@@ -271,7 +271,7 @@ Error, Can't do yet
 #
 gap> SimpleGroup("G3(3)");
 Error, G(n,q) needs n=2
-#@if IsPackageMarkedForLoading( "primggrp", "" )
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> SimpleGroup("G2(2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 PSU(3,3)
 6048
@@ -294,7 +294,7 @@ rec( name := "G(2,5)", parameter := 5, series := "G", shortname := "G2(5)" )
 #
 gap> SimpleGroup("3D(3,4)");
 Error, 3D(n,q) needs n=4
-#@if IsPackageMarkedForLoading( "primggrp", "" )
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> SimpleGroup("3D(4,2)"); Size(last); IsomorphismTypeInfoFiniteSimpleGroup(last2);
 3D(4, 2)
 211341312

--- a/tst/testinstall/opers/Socle.tst
+++ b/tst/testinstall/opers/Socle.tst
@@ -4,34 +4,34 @@ Group(())
 gap> D := DihedralGroup(8);;
 gap> Socle(D) = ClosureSubgroup(TrivialSubgroup(D), Union(Set(MinimalNormalSubgroups(D), GeneratorsOfGroup)));
 true
-gap> IdGroup(Socle(D));
-[ 2, 1 ]
+gap> Size(Socle(D));
+2
 gap> Socle(D) = Center(D);
 true
 gap> D := DihedralGroup(IsFpGroup, 8);;
 gap> Socle(D) = ClosureSubgroup(TrivialSubgroup(D), Union(Set(MinimalNormalSubgroups(D), GeneratorsOfGroup)));
 true
-gap> IdGroup(Socle(D));
-[ 2, 1 ]
+gap> Size(Socle(D));
+2
 gap> Socle(D) = Center(D);
 true
 gap> D := DihedralGroup(IsPermGroup, 8);;
 gap> Socle(D) = ClosureSubgroup(TrivialSubgroup(D), Union(Set(MinimalNormalSubgroups(D), GeneratorsOfGroup)));
 true
-gap> IdGroup(Socle(D));
-[ 2, 1 ]
+gap> Size(Socle(D));
+2
 gap> Socle(D) = Center(D);
 true
 gap> D := Group((1,3),(1,2,3,4));;
 gap> Socle(D) = ClosureSubgroup(TrivialSubgroup(D), Union(Set(MinimalNormalSubgroups(D), GeneratorsOfGroup)));
 true
-gap> IdGroup(Socle(D));
-[ 2, 1 ]
+gap> Size(Socle(D));
+2
 gap> Socle(D) = Center(D);
 true
 gap> DDD := DirectProduct(D, D, D);;
-gap> IdGroup(Socle(DDD));
-[ 8, 5 ]
+gap> StructureDescription(Socle(DDD));
+"C2 x C2 x C2"
 gap> Socle(DDD) = ClosureSubgroup(TrivialSubgroup(DDD), Union(Set(MinimalNormalSubgroups(DDD), GeneratorsOfGroup)));
 true
 gap> Socle(DDD) = Center(DDD);
@@ -39,22 +39,23 @@ true
 gap> Q := QuaternionGroup(8);;
 gap> Socle(Q) = ClosureSubgroup(TrivialSubgroup(Q), Union(Set(MinimalNormalSubgroups(Q), GeneratorsOfGroup)));
 true
-gap> IdGroup(Socle(Q));
-[ 2, 1 ]
+gap> Size(Socle(Q));
+2
 gap> Socle(Q) = Center(Q);
 true
 gap> Socle(SymmetricGroup(4)) = Group((1,2)(3,4),(1,3)(2,4));
 true
-gap> IdGroup(Socle(SymmetricGroup(5)));
-[ 60, 5 ]
-gap> IdGroup(Socle(AlternatingGroup(5)));
-[ 60, 5 ]
+gap> AlternatingGroup(5) = Socle(SymmetricGroup(5));
+true
+gap> AlternatingGroup(5) = Socle(AlternatingGroup(5));
+true
 gap> G := Group((1,2),(3,4),(5,6),(7,8));;
 gap> IsElementaryAbelian(G);
 true
 gap> Socle(G)=G;
 true
-gap> Socle(PrimitiveGroup(8,3)) = Group([ (1,7)(2,8)(3,5)(4,6), (1,3)(2,4)(5,7)(6,8), (1,2)(3,4)(5,6)(7,8) ]);
+gap> G:=Group([ (2,7,4,8,6,5,3), (2,3)(6,7), (1,2)(3,4)(5,6)(7,8) ]);; # = PrimitiveGroup(8,3)
+gap> Socle(G) = Group([ (1,7)(2,8)(3,5)(4,6), (1,3)(2,4)(5,7)(6,8), (1,2)(3,4)(5,6)(7,8) ]);
 true
 gap> k := 5;; P := SylowSubgroup(SymmetricGroup(4*k), 2);; A := Group((4*k+1, 4*k+2, 4*k+3));; G := ClosureGroup(P, A);;
 gap> Socle(G) = Group([ (21,22,23), (1,2)(3,4)(5,6)(7,8)(9,10)(11,12)(13,14)(15,16), (17,18)(19,20) ]);
@@ -62,17 +63,19 @@ true
 gap> G := Group([ (1,2,3,5,4), (1,3)(2,4)(6,7) ]);;
 gap> Socle(G) = Group((1,2,3),(3,4,5),(6,7));
 true
-gap> G := SmallGroup(24,12);;
-gap> IdGroup(Socle(G));
-[ 4, 2 ]
+gap> G := SymmetricGroup(IsPcGroup, 4);;
+gap> StructureDescription(Socle(G));
+"C2 x C2"
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> A := DihedralGroup(16);;
-gap> B := SmallGroup(27, 3);;
-gap> C := SmallGroup(125, 4);;
+gap> B := ExtraspecialGroup( 27, 3 );;
+gap> C := ExtraspecialGroup( 125, 25 );;
 gap> D := DirectProduct(A, B, C, SmallGroup(1536, 2));;
-gap> IdGroup(Socle(D));
-[ 1440, 5958 ]
+gap> StructureDescription(Socle(D));
+"C30 x C6 x C2 x C2 x C2"
 gap> Socle(D) = Center(D);
 true
+#@fi
 gap> Socle(FittingSubgroup(SymmetricGroup(4))) = Group([ (1,4)(2,3), (1,3)(2,4) ]);
 true
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)

--- a/tst/testinstall/opers/StructureDescription.tst
+++ b/tst/testinstall/opers/StructureDescription.tst
@@ -1,6 +1,7 @@
 gap> START_TEST("StructureDescription.tst");
 
 ## Examples from manual
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> l := AllSmallGroups(12);;
 gap> List(l, StructureDescription);; l;
 [ C3 : C4, C12, A4, D12, C6 x C2 ]
@@ -42,9 +43,15 @@ gap> List(AllSmallGroups(60), G -> StructureDescription(G:recompute));
 [ "C5 x (C3 : C4)", "C3 x (C5 : C4)", "C3 : (C5 : C4)", "C60", "A5", 
   "C3 x (C5 : C4)", "C3 : (C5 : C4)", "S3 x D10", "C5 x A4", "C6 x D10", 
   "C10 x S3", "D60", "C30 x C2" ]
+#@fi
+
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> List(AllPrimitiveGroups(DegreeAction, 8), StructureDescription);
 [ "(C2 x C2 x C2) : C7", "(C2 x C2 x C2) : (C7 : C3)", 
   "(C2 x C2 x C2) : PSL(3,2)", "PSL(3,2)", "PSL(3,2) : C2", "A8", "S8" ]
+#@fi
+
+#
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,6]):short);
 "Z^3x6^2"
 gap> G := Group([ (4,8)(6,10), (4,6,10,8,12), (2,4,12)(6,10,8), (3,9)(4,6,10,8,12)(7,11), (3,5)(4,6,10,8,12)(9,11), (1,3,11,9,5)(4,6,10,8,12) ]);;
@@ -71,6 +78,7 @@ gap> G := PerfectGroup(IsPermGroup,1344,1);; StructureDescription(G);
 "(C2 x C2 x C2) : PSL(3,2)"
 gap> G := PerfectGroup(IsPermGroup,1344,2);; StructureDescription(G);
 "(C2 x C2 x C2) . PSL(3,2)"
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> StructureDescription(SmallGroup(32,15):recompute);
 "C4 . D8 = C4 . (C4 x C2)"
 gap> List(AllSmallNonabelianSimpleGroups([1..1000000]), StructureDescription);
@@ -84,6 +92,9 @@ gap> List(AllSmallNonabelianSimpleGroups([1..1000000]), StructureDescription);
   "PSL(2,89)", "PSL(3,5)", "M22", "PSL(2,97)", "PSL(2,101)", "PSL(2,103)", 
   "HJ", "PSL(2,107)", "PSL(2,109)", "PSL(2,113)", "PSL(2,121)", "PSL(2,125)", 
   "O(5,4)" ]
+#@fi
+
+#
 gap> G := FactorGroup(Sp(6,3), Center(Sp(6,3)));;
 gap> StructureDescription(G);
 "PSp(6,3)"
@@ -91,8 +102,13 @@ gap> StructureDescription(Omega(1,8,2));
 "O+(8,2)"
 gap> StructureDescription(Omega(-1,8,2));
 "O-(8,2)"
+
+#@if IsPackageMarkedForLoading( "primgrp", "" )
 gap> List(AllPrimitiveGroups(DegreeAction, 819, Size, 211341312, IsSimple, true), StructureDescription);
 [ "3D(4,2)" ]
+#@fi
+
+#
 gap> G := Ree(27);;
 gap> HasIsFinite(G) and IsFinite(G) and HasIsSimpleGroup(G) and IsSimple(G);
 true
@@ -102,6 +118,8 @@ gap> StructureDescription(AbelianGroup([0,0,0,2,3,4,5,6,7,8,9,10]));
 "Z x Z x Z x C2520 x C60 x C6 x C2 x C2"
 gap> StructureDescription(AbelianGroup([0,0,0,2,3,4,5,6,7,8,9,10]):short);
 "Z^3x2520x60x6x2^2"
+
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
 gap> infolevel:=InfoLevel(InfoWarning);; SetInfoLevel(InfoWarning,2);
 gap> StructureDescription(SmallGroup(48,16):recompute,nice);
 #I  Warning! Non-unique semidirect product:
@@ -112,6 +130,9 @@ gap> StructureDescription(SmallGroup(64,17):recompute,nice);
 #I  [ [ "C4 x C2", "C8" ], [ "C8 x C2", "C4" ] ]
 "(C4 x C2) : C8"
 gap> SetInfoLevel(InfoWarning,infolevel);
+#@fi
+
+#
 gap> F := FreeGroup("r", "s");; r := F.1;; s := F.2;;
 gap> G := F/[s^2, r^3, s*r*s*r];;
 gap> StructureDescription(G);

--- a/tst/testinstall/opers/SubdirectProducts.tst
+++ b/tst/testinstall/opers/SubdirectProducts.tst
@@ -4,30 +4,30 @@ gap> H := SymmetricGroup(4);;
 gap> A := CyclicGroup(6);;
 
 #
-gap> Set(SubdirectProducts(G, G), IdGroup);
-[ [ 6, 1 ], [ 18, 4 ], [ 36, 10 ] ]
-gap> Set(SubdirectProducts(H, H), IdGroup);
-[ [ 24, 12 ], [ 96, 227 ], [ 288, 1026 ], [ 576, 8653 ] ]
-gap> Set(SubdirectProducts(A, A), IdGroup);
-[ [ 6, 2 ], [ 12, 5 ], [ 18, 5 ], [ 36, 14 ] ]
+gap> Set(SubdirectProducts(G, G), StructureDescription);
+[ "(C3 x C3) : C2", "S3", "S3 x S3" ]
+gap> Set(SubdirectProducts(H, H), StructureDescription);
+[ "((C2 x C2 x C2 x C2) : C3) : C2", "(A4 x A4) : C2", "S4", "S4 x S4" ]
+gap> Set(SubdirectProducts(A, A), StructureDescription);
+[ "C6", "C6 x C2", "C6 x C3", "C6 x C6" ]
 
 #
-gap> Set(SubdirectProducts(G, H), IdGroup);
-[ [ 24, 12 ], [ 72, 43 ], [ 144, 183 ] ]
-gap> Set(SubdirectProducts(H, G), IdGroup);
-[ [ 24, 12 ], [ 72, 43 ], [ 144, 183 ] ]
+gap> Set(SubdirectProducts(G, H), StructureDescription);
+[ "(C3 x A4) : C2", "S4", "S4 x S3" ]
+gap> Set(SubdirectProducts(H, G), StructureDescription);
+[ "(C3 x A4) : C2", "S3 x S4", "S4" ]
 
 #
-gap> Set(SubdirectProducts(G, A), IdGroup);
-[ [ 18, 3 ], [ 36, 12 ] ]
-gap> Set(SubdirectProducts(A, G), IdGroup);
-[ [ 18, 3 ], [ 36, 12 ] ]
+gap> Set(SubdirectProducts(G, A), StructureDescription);
+[ "C3 x S3", "C6 x S3" ]
+gap> Set(SubdirectProducts(A, G), StructureDescription);
+[ "C3 x S3", "C6 x S3" ]
 
 #
-gap> Set(SubdirectProducts(H, A), IdGroup);
-[ [ 72, 42 ], [ 144, 188 ] ]
-gap> Set(SubdirectProducts(A, H), IdGroup);
-[ [ 72, 42 ], [ 144, 188 ] ]
+gap> Set(SubdirectProducts(H, A), StructureDescription);
+[ "C3 x S4", "C6 x S4" ]
+gap> Set(SubdirectProducts(A, H), StructureDescription);
+[ "C3 x S4", "C6 x S4" ]
 
 #
 gap> STOP_TEST("SubdirectProducts.tst");

--- a/tst/testinstall/opers/SubdirectProducts.tst
+++ b/tst/testinstall/opers/SubdirectProducts.tst
@@ -4,29 +4,29 @@ gap> H := SymmetricGroup(4);;
 gap> A := CyclicGroup(6);;
 
 #
-gap> Set(SubdirectProducts(G, G), StructureDescription);
+gap> SortedList(List(SubdirectProducts(G, G), StructureDescription));
 [ "(C3 x C3) : C2", "S3", "S3 x S3" ]
-gap> Set(SubdirectProducts(H, H), StructureDescription);
-[ "((C2 x C2 x C2 x C2) : C3) : C2", "(A4 x A4) : C2", "S4", "S4 x S4" ]
-gap> Set(SubdirectProducts(A, A), StructureDescription);
-[ "C6", "C6 x C2", "C6 x C3", "C6 x C6" ]
+gap> SortedList(List(SubdirectProducts(H, H), Size));
+[ 24, 96, 288, 576 ]
+gap> SortedList(List(SubdirectProducts(A, A), StructureDescription));
+[ "C6", "C6", "C6 x C2", "C6 x C2", "C6 x C3", "C6 x C6" ]
 
 #
-gap> Set(SubdirectProducts(G, H), StructureDescription);
+gap> SortedList(List(SubdirectProducts(G, H), StructureDescription));
 [ "(C3 x A4) : C2", "S4", "S4 x S3" ]
-gap> Set(SubdirectProducts(H, G), StructureDescription);
+gap> SortedList(List(SubdirectProducts(H, G), StructureDescription));
 [ "(C3 x A4) : C2", "S3 x S4", "S4" ]
 
 #
-gap> Set(SubdirectProducts(G, A), StructureDescription);
+gap> SortedList(List(SubdirectProducts(G, A), StructureDescription));
 [ "C3 x S3", "C6 x S3" ]
-gap> Set(SubdirectProducts(A, G), StructureDescription);
+gap> SortedList(List(SubdirectProducts(A, G), StructureDescription));
 [ "C3 x S3", "C6 x S3" ]
 
 #
-gap> Set(SubdirectProducts(H, A), StructureDescription);
+gap> SortedList(List(SubdirectProducts(H, A), StructureDescription));
 [ "C3 x S4", "C6 x S4" ]
-gap> Set(SubdirectProducts(A, H), StructureDescription);
+gap> SortedList(List(SubdirectProducts(A, H), StructureDescription));
 [ "C3 x S4", "C6 x S4" ]
 
 #

--- a/tst/testinstall/opers/SubdirectProducts.tst
+++ b/tst/testinstall/opers/SubdirectProducts.tst
@@ -6,16 +6,29 @@ gap> A := CyclicGroup(6);;
 #
 gap> SortedList(List(SubdirectProducts(G, G), StructureDescription));
 [ "(C3 x C3) : C2", "S3", "S3 x S3" ]
-gap> SortedList(List(SubdirectProducts(H, H), Size));
-[ 24, 96, 288, 576 ]
 gap> SortedList(List(SubdirectProducts(A, A), StructureDescription));
 [ "C6", "C6", "C6 x C2", "C6 x C2", "C6 x C3", "C6 x C6" ]
 
-#
-gap> SortedList(List(SubdirectProducts(G, H), StructureDescription));
-[ "(C3 x A4) : C2", "S4", "S4 x S3" ]
-gap> SortedList(List(SubdirectProducts(H, G), StructureDescription));
-[ "(C3 x A4) : C2", "S3 x S4", "S4" ]
+# for the next couple tests, StructureDescription gives different outputs
+# depending on which packages are loaded; e.g. for SubdirectProducts(H, H):
+# [ "((C2 x C2 x C2 x C2) : C3) : C2", "(A4 x A4) : C2", "S4", "S4 x S4" ]
+# [ "(C2 x C2) : ((C3 x A4) : C2)", "(C2 x C2) : S4", "S4", "S4 x S4" ]
+# thus we use IdGroup if available, and else fall back to a weaker size test.
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
+gap> SortedList(List(SubdirectProducts(H, H), IdGroup));
+[ [ 24, 12 ], [ 96, 227 ], [ 288, 1026 ], [ 576, 8653 ] ]
+gap> SortedList(List(SubdirectProducts(G, H), IdGroup));
+[ [ 24, 12 ], [ 72, 43 ], [ 144, 183 ] ]
+gap> SortedList(List(SubdirectProducts(H, G), IdGroup));
+[ [ 24, 12 ], [ 72, 43 ], [ 144, 183 ] ]
+#@else
+gap> SortedList(List(SubdirectProducts(H, H), Size));
+[ 24, 96, 288, 576 ]
+gap> SortedList(List(SubdirectProducts(G, H), Size));
+[ 24, 72, 144 ]
+gap> SortedList(List(SubdirectProducts(H, G), Size));
+[ 24, 72, 144 ]
+#@fi
 
 #
 gap> SortedList(List(SubdirectProducts(G, A), StructureDescription));


### PR DESCRIPTION
- remove a bunch of SmallGroup and IdGroup uses
- remove tst/testbugfix/2005-05-03-t00070.tst (an equivalent test was added to the smallgrp package recently)
- modify some .tst file to run parts only if certain packages are available, via `#@if IsPackageMarkedForLoading(...)`
- don't load `ctbllib` (and all its dependencies) in `ctblmaps.tst`

Extracted from PR #6346