### PR TITLE
CI: don't rely on primary GNU file server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: "Install autoconf 2.72"   # for compatibility with GCC 14 & clang versions
         run: |
-          wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz
+          wget https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz
           tar xvf autoconf-2.72.tar.xz
           cd autoconf-2.72
           ./configure


### PR DESCRIPTION
Use a mirror is more resilient and often faster, as one close to you is selected.