### PR TITLE
fix `ConvertToMatrixRep`, fix some `Matrix` calls

### DIFF
--- a/lib/mat8bit.gi
+++ b/lib/mat8bit.gi
@@ -269,7 +269,7 @@ InstallMethod( \-, "for two 8 bit matrices in same characteristic",
 
 InstallGlobalFunction(ConvertToMatrixRep,
         function( arg )
-    local m,qs, v,  q, givenq, q1, LeastCommonPower, lens;
+    local m,qs, v,  q, givenq, q1, LeastCommonPower, lens, d;
 
     LeastCommonPower := function(qs)
         local p, d, x, i;
@@ -389,19 +389,32 @@ InstallGlobalFunction(ConvertToMatrixRep,
         fi;
 
         if givenq and q1 <> q then
-            Error("ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over <q>");
-        fi;
+          # It may be possible to write the matrix over the field
+          # with 'q1' elements.
+          # We are not allowed to call 'ConvertToVectorRep( v, q1 )'
+          # in order to *test* whether the row 'v' lives over the desired
+          # field, but we may call it once we *know* that this is the case.
+          d:= Length( Factors( q1 ) );
+          for v in m do
+            if d mod DegreeFFE( v ) <> 0 then
+              Error("ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over <q>");
+            elif q1 <> ConvertToVectorRep( v, q1 ) then
+              return fail;
+            fi;
+          od;
+          q:= q1;
+        else
+          #
+          # Now try and rewrite all the rows over this field
+          # this may fail if some rows are locked over a smaller field
+          #
 
-        #
-        # Now try and rewrite all the rows over this field
-        # this may fail if some rows are locked over a smaller field
-        #
-
-        for v in m do
+          for v in m do
             if q <> ConvertToVectorRepNC(v,q) then
                 return fail;
             fi;
-        od;
+          od;
+        fi;
     fi;
 
     if q <= 256 then

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -3401,7 +3401,7 @@ function( hom, elm )
   else
     R:= f;
   fi;
-#TODO: Here `BaseDomain( G )` should be used.
+#TODO: Here `BaseDomain( G )` should be used, once it is implemented.
   if not IsBound(hom!.linActBasisPositions) then
     hom!.linActBasisPositions:=List(lab,i->PositionCanonical(V,i));
   fi;

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -3379,7 +3379,7 @@ end );
 InstallMethod( PreImagesRepresentative,"IsLinearActionHomomorphism",
   FamRangeEqFamElm, [ IsLinearActionHomomorphism, IsPerm ], 0,
 function( hom, elm )
-  local   V, G, Grep, xset,lab,f;
+  local   V, G, Grep, filt, R, xset,lab,f;
 
   # is this method applicable? Test whether the domain contains a vector
   # space basis (respectively just get this basis).
@@ -3394,19 +3394,26 @@ function( hom, elm )
   V := HomeEnumerator(xset);
   G:= Source( hom );
   Grep:= Representative( G );
+  filt:= ConstructingFilter( Grep );
   f:=DefaultFieldOfMatrixGroup(G);
-
+  if IsMatrixObj( Grep ) then
+    R:= BaseDomain( Grep );
+  else
+    R:= f;
+  fi;
+#TODO: Here `BaseDomain( G )` should be used.
   if not IsBound(hom!.linActBasisPositions) then
     hom!.linActBasisPositions:=List(lab,i->PositionCanonical(V,i));
   fi;
   if not IsBound(hom!.linActInverse) then
-    lab:=ImmutableMatrix(f, Matrix( lab, Grep ));
+    # Create a matrix whose `BaseDomain` is the same as that of the group.
+    lab:=ImmutableMatrix(f, Matrix( filt, R, lab ));
     hom!.linActInverse:=Inverse(lab);
   fi;
 
   elm:=OnTuples(hom!.linActBasisPositions,elm); # image points
   elm:=V{elm}; # the corresponding vectors
-  elm:=ImmutableMatrix(f, Matrix( elm, Grep ));
+  elm:=ImmutableMatrix(f, Matrix( filt, R, elm ));
 
   return hom!.linActInverse*elm;
 end );
@@ -3437,7 +3444,7 @@ end );
 InstallMethod( PreImagesRepresentative,"IsProjectiveActionHomomorphism",
   FamRangeEqFamElm, [ IsProjectiveActionHomomorphism, IsPerm ], 0,
 function( hom, elm )
-  local   V,  G, Grep, mat, xset,lab,dim,sol,i;
+  local   V,  G, Grep, filt, R, mat, xset,lab,dim,sol,i;
 
   # is this method applicable? Test whether field
   # finite, that the domain contains a vector
@@ -3456,12 +3463,18 @@ function( hom, elm )
   V := HomeEnumerator(xset);
   G:= Source( hom );
   Grep:= Representative( G );
+  filt:= ConstructingFilter( Grep );
+  if IsMatrixObj( Grep ) then
+    R:= BaseDomain( Grep );
+  else
+    R:= DefaultFieldOfMatrixGroup(G);
+  fi;
   dim:=DimensionOfMatrixGroup(G);
 
   elm:=OnTuples(hom!.projActBasisPositions,elm); # image points
   elm:=V{elm}; # the corresponding vectors
 
-  mat:= Matrix( List( elm{ [ 1 .. dim ] }, ShallowCopy ), Grep );
+  mat:= Matrix( filt, R, List( elm{ [ 1 .. dim ] }, ShallowCopy ) );
   sol:=SolutionMat(mat,elm[dim+1]);
   for i in [1..dim] do
     MultMatrixRow( mat, i, sol[i] );
@@ -3487,7 +3500,7 @@ end);
 InstallMethod(LinearActionBasis,"find basis in domain",true,
   [IsLinearActionHomomorphism],0,
 function(hom)
-local xset, base, M, D, b, t, i, r, pos, v;
+local xset, base, M, filt, R, D, b, t, i, r, pos, v;
   xset:=UnderlyingExternalSet(hom);
   if Size(xset)=0 then
     return fail;
@@ -3498,7 +3511,12 @@ local xset, base, M, D, b, t, i, r, pos, v;
     if IsMatrix( base ) then
       M:= base;
     elif ForAll( base, IsVectorObj ) then
-      M:= Matrix( BaseOfGroup( xset ), One( ActingDomain( xset ) ) );
+      # All entries of 'base' have the same 'BaseDomain'.
+      filt:= ConstructingFilter( Representative( ActingDomain( xset ) ) );
+      R:= BaseDomain( base[1] );
+      M:= Matrix( filt, R, base );
+    else
+      Error( "unsupported 'BaseOfGroup' value for <xset>" );
     fi;
     if RankMat( M ) = NrCols( M ) then
       # this implies injectivity
@@ -3561,7 +3579,7 @@ end);
 InstallOtherMethod(LinearActionBasis,"projective with extra vector",true,
   [IsProjectiveActionHomomorphism],0,
 function(hom)
-local xset,G,Grep,D,b,t,i,r,binv,pos,dets,roots,dim,f,v;
+local xset,G,Grep,filt,R,D,b,t,i,r,binv,pos,dets,roots,dim,f,v;
   xset:=UnderlyingExternalSet(hom);
   if Size(xset)=0 then
     return fail;
@@ -3570,9 +3588,14 @@ local xset,G,Grep,D,b,t,i,r,binv,pos,dets,roots,dim,f,v;
   # will the determinants suffice to get suitable scalars?
   G:= Source(hom);
   Grep:= Representative( G );
+  filt:= ConstructingFilter( Grep );
   dim:=DimensionOfMatrixGroup(G);
   f:=DefaultFieldOfMatrixGroup(G);
-
+  if IsMatrixObj( Grep ) then
+    R:= BaseDomain( Grep );
+  else
+    R:= f;
+  fi;
   roots:=Set(RootsOfUPol(f,X(f)^dim-1));
   D:=List(GeneratorsOfGroup(G),DeterminantMat);
 
@@ -3621,7 +3644,7 @@ local xset,G,Grep,D,b,t,i,r,binv,pos,dets,roots,dim,f,v;
   fi;
 
   # try to find a vector that has nonzero coefficients for all b
-  binv:= Inverse( ImmutableMatrix( f, Matrix( b, Grep ) ) );
+  binv:= Inverse( ImmutableMatrix( f, Matrix( filt, R, b ) ) );
   while i<=Length(D) do
     if ForAll( Unpack( D[i] * binv ), x -> not IsZero(x) ) then
 #TODO: get rid of 'Unpack'?

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -3396,7 +3396,7 @@ function( hom, elm )
   Grep:= Representative( G );
   filt:= ConstructingFilter( Grep );
   f:=DefaultFieldOfMatrixGroup(G);
-  if IsMatrixObj( Grep ) then
+  if HasBaseDomain( Grep ) then
     R:= BaseDomain( Grep );
   else
     R:= f;
@@ -3464,7 +3464,7 @@ function( hom, elm )
   G:= Source( hom );
   Grep:= Representative( G );
   filt:= ConstructingFilter( Grep );
-  if IsMatrixObj( Grep ) then
+  if HasBaseDomain( Grep ) then
     R:= BaseDomain( Grep );
   else
     R:= DefaultFieldOfMatrixGroup(G);
@@ -3510,7 +3510,7 @@ local xset, base, M, filt, R, D, b, t, i, r, pos, v;
     base:= BaseOfGroup(xset);
     if IsMatrix( base ) then
       M:= base;
-    elif ForAll( base, IsVectorObj ) then
+    elif ForAll( base, IsVectorObj and HasBaseDomain ) then
       # All entries of 'base' have the same 'BaseDomain'.
       filt:= ConstructingFilter( Representative( ActingDomain( xset ) ) );
       R:= BaseDomain( base[1] );
@@ -3591,7 +3591,7 @@ local xset,G,Grep,filt,R,D,b,t,i,r,binv,pos,dets,roots,dim,f,v;
   filt:= ConstructingFilter( Grep );
   dim:=DimensionOfMatrixGroup(G);
   f:=DefaultFieldOfMatrixGroup(G);
-  if IsMatrixObj( Grep ) then
+  if HasBaseDomain( Grep ) then
     R:= BaseDomain( Grep );
   else
     R:= f;

--- a/tst/testinstall/mat8bit.tst
+++ b/tst/testinstall/mat8bit.tst
@@ -564,9 +564,32 @@ gap> m := [m[1], mm[1], m[2], mm[2],[]];
   <a GF2 vector of length 4>, <a GF2 vector of length 4>, [  ] ]
 gap> ConvertToMatrixRep(m);
 fail
+gap> m:= [ [ Z(3) ] ];;
+gap> ConvertToVectorRep( m[1], 9 ) = 9;
+true
+gap> ConvertToMatrixRep( m, 3 ) = 3;
+true
+gap> m:= [ [ Z(3) ] ];;
+gap> ConvertToVectorRep( m[1], 27 ) = 27;
+true
+gap> ConvertToMatrixRep( m, 9 ) = 9;
+true
+gap> m:= [ [ Z(3) ] ];;
+gap> ConvertToVectorRep( m[1], 9 ) = 9;
+true
+gap> ConvertToMatrixRep( m, 27 ) = 27;
+true
+gap> m:= [ [ Z(9) ] ];;
+gap> ConvertToVectorRep( m[1], 3 ) = 9;
+Error, ConvertToVectorRepNC: Vector cannot be written over GF(3)
+gap> ConvertToVectorRep( m[1], 9 );
+9
+gap> ConvertToMatrixRep( m, 3 );
+Error, ConvertToMatrixRep( <mat>, <q> ): not all entries of <mat> written over\
+ <q>
 
 # ConvertToMatrixRepNC
-gap> ConvertToMatrixRepNC([], 3);
+gap> ConvertToMatrixRepNC([], 3);   # What is this test supposed to show?
 3
 
 # DefaultFieldOfMatrix


### PR DESCRIPTION
Address the problem from #6389, for the moment without introducing `BaseDomain` for matrix groups.
I regard this pull request as an alternative to #6395.

As stated in #6389, calling `Matrix( elm, Grep )` is possible only if `Grep` is a proper matrix object; if `Grep` is a list of lists then it may have a too small `BaseDomain`. Thus the `Matrix` calls introduced in #6232 have to be replaced by calls where the `ConstructingFilter` and the `BaseDomain` are given as arguments.
