### PR TITLE
Fix the powering of matrix objects by integers

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -1456,6 +1456,15 @@ InstallMethod( RowsOfMatrix,
     [ IsMatrix and IsPlistRep ],
     Immutable );
 
+# The following should be better than the generic method for
+# matrix objects for 'IsMatrixOrMatrixObj',
+# which first 'Unpack's the matrix and then
+# creates new vector objects from the rows of the result.
+InstallMethod( RowsOfMatrix,
+    "generic method for a matrix that is a list",
+    [ IsMatrix ],
+    PlainListCopy );
+
 InstallMethod( NumberRows,
     "generic method for a (perhaps empty) matrix",
     [ IsMatrix ],

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -4797,7 +4797,7 @@ BindGlobal("POW_MAT_INT", function(mat, n)
     b := rec(vectors := [], pivots := [], heads := []);
     t := [];
     # maybe better start with a random vector?
-    for a in id do
+    for a in RowsOfMatrix( id ) do
       r := addb(b,a);
       if r = true then
         repeat

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -4807,6 +4807,9 @@ BindGlobal("POW_MAT_INT", function(mat, n)
     t := [];
     # maybe better start with a random vector?
     for a in RowsOfMatrix( id ) do
+#TODO: 'RowsOfMatrix' is not what we want to call here.
+#      In fact, we should better create standard basis vectors
+#      as we need them, instead of creating 'id' .
       r := addb(b,a);
       if r = true then
         repeat

--- a/tst/testinstall/MatrixObj/arith.tst
+++ b/tst/testinstall/MatrixObj/arith.tst
@@ -16,5 +16,13 @@ Error, <matobj> * <mat> is not defined
 gap> mat * matobj;
 Error, <mat> * <matobj> is not defined
 
+# Powering matrices works.
+gap> mat:= Matrix( Integers, [ [ 1, 1 ], [ 0, 1 ] ] );;
+gap> Unpack( mat^2 ) = Unpack( mat )^2;
+true
+gap> mat:= Matrix( Rationals, [ [ 1, 1 ], [ 0, 1 ] ] );;
+gap> Unpack( mat^2 ) = Unpack( mat )^2;
+true
+
 #
 gap> STOP_TEST( "arith.tst" );


### PR DESCRIPTION
The change affects those matrix objects for which `POW_MAT_INT` does the work. The function `POW_OBJ_INT` (which is used for matrices over rings that aren't fields) did not have this problem.

resolves #6372