### PR TITLE
kernel: strengthen vecgf2 and vec8bit validation, reject empty vectors were not supported

### DIFF
--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -60,6 +60,10 @@
     RequireArgumentCondition(funcname, op, IS_MAT8BIT_REP(op),               \
                              "must belong to Is8BitMatrixRep")
 
+#define RequireFFE(funcname, op)                                             \
+    RequireArgumentCondition(funcname, op, IS_FFE(op),                       \
+                             "must be a finite field element")
+
 /****************************************************************************
 **
 *F  IS_VEC8BIT_REP( <obj> ) . . .  check that <obj> is in 8bit GFQ vector rep
@@ -815,6 +819,7 @@ static UInt LcmDegree(UInt d, UInt d1)
 */
 static Obj FuncCONV_VEC8BIT(Obj self, Obj list, Obj q)
 {
+    RequireSmallList(SELF_NAME, list);
     UInt iq = GetPositiveSmallInt(SELF_NAME, q);
     ConvVec8Bit(list, iq);
     return 0;
@@ -937,6 +942,7 @@ static Obj NewVec8Bit(Obj list, UInt q)
 */
 static Obj FuncCOPY_VEC8BIT(Obj self, Obj list, Obj q)
 {
+    RequireSmallList(SELF_NAME, list);
     UInt iq = GetPositiveSmallInt(SELF_NAME, q);
     return NewVec8Bit(list, iq);
 }
@@ -1019,9 +1025,7 @@ void PlainVec8Bit(Obj list)
 */
 static Obj FuncPLAIN_VEC8BIT(Obj self, Obj list)
 {
-    if (!IS_VEC8BIT_REP(list)) {
-        RequireArgument(SELF_NAME, list, "must be an 8bit vector");
-    }
+    RequireVec8BitRep(SELF_NAME, list);
     if (DoFilter(IsLockedRepresentationVector, list) == True) {
         ErrorMayQuit("Cannot convert a locked vector compressed over "
                      "GF(%d) to a plain list",
@@ -1214,8 +1218,8 @@ static Obj ConvertToVectorRep;    // BH: changed to static
 
 static Obj FuncSUM_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
-    GAP_ASSERT(IS_VEC8BIT_REP(vl));
-    GAP_ASSERT(IS_VEC8BIT_REP(vr));
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
 
     Obj sum;
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr)) {
@@ -1395,6 +1399,9 @@ static Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
     Obj  info;
     UInt d;
 
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequireFFE(SELF_NAME, ffe);
+
     if (VAL_FFE(ffe) == 1) {    // ffe is the one
         return CopyVec8Bit(vec, IS_MUTABLE_OBJ(vec));
     }
@@ -1427,6 +1434,7 @@ static Obj FuncPROD_VEC8BIT_FFE(Obj self, Obj vec, Obj ffe)
 
 static Obj FuncZERO_VEC8BIT(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     return ZeroVec8Bit(FIELD_VEC8BIT(vec), LEN_VEC8BIT(vec), 1);
 }
 
@@ -1456,6 +1464,8 @@ static Obj FuncZERO_VEC8BIT_2(Obj self, Obj q, Obj len)
 
 static Obj FuncPROD_FFE_VEC8BIT(Obj self, Obj ffe, Obj vec)
 {
+    RequireFFE(SELF_NAME, ffe);
+    RequireVec8BitRep(SELF_NAME, vec);
     return FuncPROD_VEC8BIT_FFE(self, vec, ffe);
 }
 
@@ -1492,16 +1502,19 @@ static Obj AInvVec8Bit(Obj vec, UInt mut)
 
 static Obj FuncAINV_VEC8BIT_MUTABLE(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     return AInvVec8Bit(vec, 1);
 }
 
 static Obj FuncAINV_VEC8BIT_SAME_MUTABILITY(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     return AInvVec8Bit(vec, IS_MUTABLE_OBJ(vec));
 }
 
 static Obj FuncAINV_VEC8BIT_IMMUTABLE(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     return AInvVec8Bit(vec, 0);
 }
 
@@ -1608,6 +1621,8 @@ static void AddVec8BitVec8BitMultInner(
 
 static Obj FuncMULT_VECTOR_VEC8BITS(Obj self, Obj vec, Obj mul)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequireFFE(SELF_NAME, mul);
     UInt q;
     q = FIELD_VEC8BIT(vec);
 
@@ -1646,6 +1661,11 @@ static Obj AddRowVector;
 static Obj FuncADD_ROWVECTOR_VEC8BITS_5(
     Obj self, Obj vl, Obj vr, Obj mul, Obj from, Obj to)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
+    RequireFFE(SELF_NAME, mul);
+    RequirePositiveSmallInt(SELF_NAME, from);
+    RequirePositiveSmallInt(SELF_NAME, to);
     UInt q;
     UInt len;
     len = LEN_VEC8BIT(vl);
@@ -1720,6 +1740,9 @@ static Obj FuncADD_ROWVECTOR_VEC8BITS_5(
 
 static Obj FuncADD_ROWVECTOR_VEC8BITS_3(Obj self, Obj vl, Obj vr, Obj mul)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
+    RequireFFE(SELF_NAME, mul);
     UInt q;
     if (LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr)) {
         ErrorMayQuit(
@@ -1778,6 +1801,8 @@ static Obj FuncADD_ROWVECTOR_VEC8BITS_3(Obj self, Obj vl, Obj vr, Obj mul)
 
 static Obj FuncADD_ROWVECTOR_VEC8BITS_2(Obj self, Obj vl, Obj vr)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
     UInt q;
     if (LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr)) {
         ErrorMayQuit(
@@ -1913,6 +1938,8 @@ static Obj FuncDIFF_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
     Obj diff;
     // UInt p;
 
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
 
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr)) {
         UInt ql = FIELD_VEC8BIT(vl), qr = FIELD_VEC8BIT(vr);
@@ -2086,6 +2113,8 @@ static Obj ScalarProductVec8Bits(Obj vl, Obj vr)
 
 static Obj FuncPROD_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return ProdListList(vl, vr);
 
@@ -2146,6 +2175,8 @@ static UInt DistanceVec8Bits(Obj vl, Obj vr)
 
 static Obj FuncDISTANCE_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr) ||
         LEN_VEC8BIT(vl) != LEN_VEC8BIT(vr))
         return TRY_NEXT_METHOD;
@@ -2214,6 +2245,10 @@ static Obj FuncDISTANCE_DISTRIB_VEC8BITS(
     Obj  sum;    // sum vector
     UInt len;
     UInt q;
+
+    RequirePlainList(SELF_NAME, veclis);
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequirePlainList(SELF_NAME, d);
 
     len = LEN_VEC8BIT(vec);
     q = FIELD_VEC8BIT(vec);
@@ -2331,6 +2366,8 @@ static Obj FuncA_CLOSEST_VEC8BIT(
     UInt len;
     UInt q;
 
+    RequirePlainList(SELF_NAME, veclis);
+    RequireVec8BitRep(SELF_NAME, vec);
     RequireNonnegativeSmallInt(SELF_NAME, cnt);
     RequireNonnegativeSmallInt(SELF_NAME, stop);
 
@@ -2371,6 +2408,8 @@ static Obj FuncA_CLOSEST_VEC8BIT_COORDS(
     Obj  res;
 
 
+    RequirePlainList(SELF_NAME, veclis);
+    RequireVec8BitRep(SELF_NAME, vec);
     RequireNonnegativeSmallInt(SELF_NAME, cnt);
     RequireNonnegativeSmallInt(SELF_NAME, stop);
 
@@ -2413,6 +2452,7 @@ static Obj FuncA_CLOSEST_VEC8BIT_COORDS(
 
 static Obj FuncNUMBER_VEC8BIT(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     Obj           info;
     UInt          elts;
     UInt          len;
@@ -2608,6 +2648,7 @@ static Obj FuncCOSET_LEADERS_INNER_8BITS(
     RequireSmallInt(SELF_NAME, weight);
     RequireSmallInt(SELF_NAME, tofind);
     RequirePlainList(SELF_NAME, leaders);
+    RequirePlainList(SELF_NAME, felts);
 
     lenv = LEN_PLIST(veclis);
     q = LEN_PLIST(felts);
@@ -2628,6 +2669,8 @@ static Obj FuncCOSET_LEADERS_INNER_8BITS(
 
 static Obj FuncEQ_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return EqListList(vl, vr) ? True : False;
 
@@ -2645,6 +2688,8 @@ static Obj FuncEQ_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 
 static Obj FuncLT_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 {
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
     if (FIELD_VEC8BIT(vl) != FIELD_VEC8BIT(vr))
         return LtListList(vl, vr) ? True : False;
 
@@ -2665,6 +2710,7 @@ static Obj FuncLT_VEC8BIT_VEC8BIT(Obj self, Obj vl, Obj vr)
 
 static Obj FuncSHALLOWCOPY_VEC8BIT(Obj self, Obj list)
 {
+    RequireVec8BitRep(SELF_NAME, list);
     return CopyVec8Bit(list, 1);
 }
 
@@ -2675,6 +2721,7 @@ static Obj FuncSHALLOWCOPY_VEC8BIT(Obj self, Obj list)
 */
 static Obj FuncLEN_VEC8BIT(Obj self, Obj list)
 {
+    RequireVec8BitRep(SELF_NAME, list);
     return INTOBJ_INT(LEN_VEC8BIT(list));
 }
 
@@ -2684,6 +2731,7 @@ static Obj FuncLEN_VEC8BIT(Obj self, Obj list)
 */
 static Obj FuncQ_VEC8BIT(Obj self, Obj list)
 {
+    RequireVec8BitRep(SELF_NAME, list);
     return INTOBJ_INT(FIELD_VEC8BIT(list));
 }
 
@@ -2704,6 +2752,7 @@ static Obj FuncELM0_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
+    RequireVec8BitRep(SELF_NAME, list);
     p = GetPositiveSmallInt(SELF_NAME, pos);
     if (LEN_VEC8BIT(list) < p) {
         return Fail;
@@ -2733,6 +2782,7 @@ static Obj FuncELM_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
+    RequireVec8BitRep(SELF_NAME, list);
     p = GetPositiveSmallInt(SELF_NAME, pos);
     if (LEN_VEC8BIT(list) < p) {
         ErrorMayQuit("List Element: <list>[%d] must have an assigned value",
@@ -2773,6 +2823,8 @@ static Obj FuncELMS_VEC8BIT(Obj self, Obj list, Obj poss)
     UInt1         byte;
     UInt          len2;
 
+    RequireVec8BitRep(SELF_NAME, list);
+    RequirePlainList(SELF_NAME, poss);
     len = LEN_PLIST(poss);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     len2 = LEN_VEC8BIT(list);
@@ -2840,6 +2892,7 @@ static Obj FuncELMS_VEC8BIT_RANGE(Obj self, Obj list, Obj range)
     UInt          e;
     UInt1         byte;
 
+    RequireVec8BitRep(SELF_NAME, list);
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     len = GET_LEN_RANGE(range);
@@ -3012,6 +3065,7 @@ void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
 
 static Obj FuncASS_VEC8BIT(Obj self, Obj list, Obj pos, Obj elm)
 {
+    RequireVec8BitRep(SELF_NAME, list);
     ASS_VEC8BIT(list, pos, elm);
     return 0;
 }
@@ -3032,6 +3086,7 @@ static Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
     Obj  info;
     UInt elts;
 
+    RequireVec8BitRep(SELF_NAME, list);
     // check that <list> is mutable
     RequireMutable("List Unbind", list, "list");
     if (True == DoFilter(IsLockedRepresentationVector, list)) {
@@ -3121,12 +3176,15 @@ static UInt PositionNonZeroVec8Bit(Obj list, UInt from)
 
 static Obj FuncPOSITION_NONZERO_VEC8BIT(Obj self, Obj list, Obj zero)
 {
+    RequireVec8BitRep(SELF_NAME, list);
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, 0));
 }
 
 static Obj
 FuncPOSITION_NONZERO_VEC8BIT3(Obj self, Obj list, Obj zero, Obj from)
 {
+    RequireVec8BitRep(SELF_NAME, list);
+    RequireNonnegativeSmallInt(SELF_NAME, from);
     return INTOBJ_INT(PositionNonZeroVec8Bit(list, INT_INTOBJ(from)));
 }
 
@@ -3149,6 +3207,9 @@ static Obj FuncAPPEND_VEC8BIT(Obj self, Obj vecl, Obj vecr)
     const UInt1 * gettab;
     const UInt1 * settab;
     UInt          posl, posr;
+
+    RequireVec8BitRep(SELF_NAME, vecl);
+    RequireVec8BitRep(SELF_NAME, vecr);
 
     if (FIELD_VEC8BIT(vecl) != FIELD_VEC8BIT(vecr))
         return TRY_NEXT_METHOD;
@@ -3223,6 +3284,9 @@ static Obj FuncPROD_VEC8BIT_MATRIX(Obj self, Obj vec, Obj mat)
     const UInt1 * gettab;
     const Obj *   ffefelt;
     Obj           x;
+
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequirePlainList(SELF_NAME, mat);
 
     len = LEN_VEC8BIT(vec);
     l2 = LEN_PLIST(mat);
@@ -3310,6 +3374,14 @@ static inline UInt NR_COLS_MAT8BIT(Obj mat)
     return LEN_VEC8BIT(ELM_MAT8BIT(mat, 1));
 }
 
+static inline void RequireNonemptyMat8BitRows(const Char * funcname, Obj mat)
+{
+    if (LEN_MAT8BIT(mat) == 0)
+        ErrorMayQuit("%s: compressed 8bit matrices with empty rows are not "
+                     "supported",
+                     (Int)funcname, 0);
+}
+
 /****************************************************************************
 **
 *F  PlainMat8Bit( <mat> )
@@ -3337,6 +3409,7 @@ static void PlainMat8Bit(Obj mat)
 
 static Obj FuncPLAIN_MAT8BIT(Obj self, Obj mat)
 {
+    RequireMat8BitRep(SELF_NAME, mat);
     PlainMat8Bit(mat);
     return 0;
 }
@@ -3356,6 +3429,7 @@ static Obj FuncCONV_MAT8BIT(Obj self, Obj list, Obj q)
     Obj  tmp;
     Obj  type;
 
+    RequirePlainList(SELF_NAME, list);
     UInt iq = GetPositiveSmallInt(SELF_NAME, q);
     PLAIN_LIST(list);
     len = LEN_PLIST(list);
@@ -3464,8 +3538,9 @@ static Obj FuncPROD_VEC8BIT_MAT8BIT(Obj self, Obj vec, Obj mat)
 {
     UInt q, q1, q2;
 
-    GAP_ASSERT(IS_VEC8BIT_REP(vec));
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequireMat8BitRep(SELF_NAME, mat);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
 
     // Now field mismatches -- consider promoting the vector
     q = FIELD_VEC8BIT(vec);
@@ -3549,8 +3624,9 @@ static Obj FuncPROD_MAT8BIT_VEC8BIT(Obj self, Obj mat, Obj vec)
 {
     UInt q, q1, q2;
 
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
-    GAP_ASSERT(IS_VEC8BIT_REP(vec));
+    RequireMat8BitRep(SELF_NAME, mat);
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
 
     // Now field mismatches -- consider promoting the vector
     q = FIELD_VEC8BIT(vec);
@@ -3626,8 +3702,10 @@ static Obj ProdMat8BitMat8Bit(Obj matl, Obj matr)
 static Obj FuncPROD_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
 {
 
-    GAP_ASSERT(IS_MAT8BIT_REP(matl));
-    GAP_ASSERT(IS_MAT8BIT_REP(matr));
+    RequireMat8BitRep(SELF_NAME, matl);
+    RequireMat8BitRep(SELF_NAME, matr);
+    RequireNonemptyMat8BitRows(SELF_NAME, matl);
+    RequireNonemptyMat8BitRows(SELF_NAME, matr);
 
     if (FIELD_MAT8BIT(matl) != FIELD_MAT8BIT(matr)) {
         return TRY_NEXT_METHOD;
@@ -3802,7 +3880,8 @@ static Obj InverseMat8Bit(Obj mat, UInt mut)
 
 static Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
+    RequireMat8BitRep(SELF_NAME, mat);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
 
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         ErrorMayQuit("InverseOp: matrix must be square, not %d by %d",
@@ -3820,7 +3899,8 @@ static Obj FuncINV_MAT8BIT_MUTABLE(Obj self, Obj mat)
 
 static Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
+    RequireMat8BitRep(SELF_NAME, mat);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         ErrorMayQuit(
             "InverseSameMutability: matrix must be square, not %d by %d",
@@ -3838,7 +3918,8 @@ static Obj FuncINV_MAT8BIT_SAME_MUTABILITY(Obj self, Obj mat)
 
 static Obj FuncINV_MAT8BIT_IMMUTABLE(Obj self, Obj mat)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
+    RequireMat8BitRep(SELF_NAME, mat);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
     if (LEN_MAT8BIT(mat) != LEN_VEC8BIT(ELM_MAT8BIT(mat, 1))) {
         ErrorMayQuit("Inverse: matrix must be square, not %d by %d",
                      LEN_MAT8BIT(mat), LEN_VEC8BIT(ELM_MAT8BIT(mat, 1)));
@@ -3864,7 +3945,8 @@ static Obj FuncASS_MAT8BIT(Obj self, Obj mat, Obj pos, Obj obj)
     UInt p;
     Obj  type;
 
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
+    RequireMat8BitRep(SELF_NAME, mat);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
     p = GetPositiveSmallInt(SELF_NAME, pos);
 
     len = LEN_MAT8BIT(mat);
@@ -3957,7 +4039,7 @@ cantdo:
 */
 static Obj FuncELM_MAT8BIT(Obj self, Obj mat, Obj pos)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(mat));
+    RequireMat8BitRep(SELF_NAME, mat);
     UInt r = GetPositiveSmallInt(SELF_NAME, pos);
     if (LEN_MAT8BIT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
@@ -4111,8 +4193,10 @@ static Obj SumMat8BitMat8Bit(Obj ml, Obj mr)
 
 static Obj FuncSUM_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(ml));
-    GAP_ASSERT(IS_MAT8BIT_REP(mr));
+    RequireMat8BitRep(SELF_NAME, ml);
+    RequireMat8BitRep(SELF_NAME, mr);
+    RequireNonemptyMat8BitRows(SELF_NAME, ml);
+    RequireNonemptyMat8BitRows(SELF_NAME, mr);
 
     if (FIELD_MAT8BIT(ml) != FIELD_MAT8BIT(mr)) {
         return TRY_NEXT_METHOD;
@@ -4204,8 +4288,10 @@ static Obj DiffMat8BitMat8Bit(Obj ml, Obj mr)
 
 static Obj FuncDIFF_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(ml));
-    GAP_ASSERT(IS_MAT8BIT_REP(mr));
+    RequireMat8BitRep(SELF_NAME, ml);
+    RequireMat8BitRep(SELF_NAME, mr);
+    RequireNonemptyMat8BitRows(SELF_NAME, ml);
+    RequireNonemptyMat8BitRows(SELF_NAME, mr);
 
     if (FIELD_MAT8BIT(ml) != FIELD_MAT8BIT(mr))
         return TRY_NEXT_METHOD;
@@ -4407,6 +4493,8 @@ static void ShiftRightVec8Bit(Obj vec, UInt amount)    // pads with zeros
     // make room
     len = LEN_VEC8BIT(vec);
     ResizeVec8Bit(vec, len + amount, 0);
+    if (len == 0)
+        return;
 
     q = FIELD_VEC8BIT(vec);
     info = GetFieldInfo8Bit(q);
@@ -4461,6 +4549,9 @@ static void ShiftRightVec8Bit(Obj vec, UInt amount)    // pads with zeros
 
 static Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
 {
+    RequireVec8BitRep(SELF_NAME, vec1);
+    RequireVec8BitRep(SELF_NAME, vec2);
+
     UInt q;
     UInt len;
     len = LEN_VEC8BIT(vec2);
@@ -4525,6 +4616,9 @@ static Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
 
 static Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
 {
+    RequireVec8BitRep(SELF_NAME, vec1);
+    RequireVec8BitRep(SELF_NAME, vec2);
+
     UInt q;
     UInt len;
     len = LEN_VEC8BIT(vec2);
@@ -4578,8 +4672,8 @@ static Obj FuncADD_COEFFS_VEC8BIT_2(Obj self, Obj vec1, Obj vec2)
 
 static Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 {
-    if (!IS_MUTABLE_OBJ(vec))
-        RequireArgument(SELF_NAME, vec, "must be mutable");
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequireMutable(SELF_NAME, vec, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, amount);
     ShiftLeftVec8Bit(vec, INT_INTOBJ(amount));
     return (Obj)0;
@@ -4593,9 +4687,10 @@ static Obj FuncSHIFT_VEC8BIT_LEFT(Obj self, Obj vec, Obj amount)
 
 static Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 {
-    if (!IS_MUTABLE_OBJ(vec))
-        RequireArgument(SELF_NAME, vec, "must be mutable");
+    RequireVec8BitRep(SELF_NAME, vec);
+    RequireMutable(SELF_NAME, vec, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, amount);
+    RequireFFE(SELF_NAME, zero);
     ShiftRightVec8Bit(vec, INT_INTOBJ(amount));
     return (Obj)0;
 }
@@ -4608,6 +4703,7 @@ static Obj FuncSHIFT_VEC8BIT_RIGHT(Obj self, Obj vec, Obj amount, Obj zero)
 
 static Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     RequireMutable(SELF_NAME, vec, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, newsize);
     ResizeVec8Bit(vec, INT_INTOBJ(newsize), 0);
@@ -4622,6 +4718,7 @@ static Obj FuncRESIZE_VEC8BIT(Obj self, Obj vec, Obj newsize)
 
 static Obj FuncRIGHTMOST_NONZERO_VEC8BIT(Obj self, Obj vec)
 {
+    RequireVec8BitRep(SELF_NAME, vec);
     return INTOBJ_INT(RightMostNonZeroVec8Bit(vec));
 }
 
@@ -5397,7 +5494,7 @@ static Obj FuncSEMIECHELON_LIST_VEC8BITS(Obj self, Obj mat)
     Obj  row;
     UInt q;
 
-    GAP_ASSERT(IS_PLIST(mat));
+    RequirePlainList(SELF_NAME, mat);
 
     len = LEN_PLIST(mat);
     if (!len)
@@ -5436,7 +5533,7 @@ static Obj FuncSEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(Obj self, Obj mat)
     UInt q;
     UInt width;
 
-    GAP_ASSERT(IS_PLIST(mat));
+    RequirePlainList(SELF_NAME, mat);
 
     len = LEN_PLIST(mat);
     if (!len)
@@ -5475,7 +5572,7 @@ static Obj FuncTRIANGULIZE_LIST_VEC8BITS(Obj self, Obj mat)
     Obj  row;
     UInt q;
 
-    GAP_ASSERT(IS_PLIST(mat));
+    RequirePlainList(SELF_NAME, mat);
 
     len = LEN_PLIST(mat);
     if (!len)
@@ -5514,7 +5611,7 @@ static Obj FuncRANK_LIST_VEC8BITS(Obj self, Obj mat)
     Obj  row;
     UInt q;
 
-    GAP_ASSERT(IS_PLIST(mat));
+    RequirePlainList(SELF_NAME, mat);
 
     len = LEN_PLIST(mat);
     if (!len)
@@ -5553,7 +5650,7 @@ static Obj FuncDETERMINANT_LIST_VEC8BITS(Obj self, Obj mat)
     UInt q;
     Obj  det;
 
-    GAP_ASSERT(IS_PLIST(mat));
+    RequirePlainList(SELF_NAME, mat);
 
     len = LEN_PLIST(mat);
     if (!len)
@@ -5613,8 +5710,8 @@ static Int Cmp_MAT8BIT_MAT8BIT(Obj ml, Obj mr)
 
 static Obj FuncEQ_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(ml));
-    GAP_ASSERT(IS_MAT8BIT_REP(mr));
+    RequireMat8BitRep(SELF_NAME, ml);
+    RequireMat8BitRep(SELF_NAME, mr);
 
     if (LEN_MAT8BIT(ml) != LEN_MAT8BIT(mr))
         return False;
@@ -5632,8 +5729,8 @@ static Obj FuncEQ_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 
 static Obj FuncLT_MAT8BIT_MAT8BIT(Obj self, Obj ml, Obj mr)
 {
-    GAP_ASSERT(IS_MAT8BIT_REP(ml));
-    GAP_ASSERT(IS_MAT8BIT_REP(mr));
+    RequireMat8BitRep(SELF_NAME, ml);
+    RequireMat8BitRep(SELF_NAME, mr);
 
     if (LEN_MAT8BIT(ml) == 0)
         return (LEN_MAT8BIT(mr) != 0) ? True : False;
@@ -5665,6 +5762,7 @@ static Obj FuncTRANSPOSED_MAT8BIT(Obj self, Obj mat)
     Obj          type;
 
     RequireMat8BitRep(SELF_NAME, mat);
+    RequireNonemptyMat8BitRows(SELF_NAME, mat);
     // we will give result same type as mat
 
     // we assume here that there is a first row  -- a zero row mat8bit is a
@@ -5762,8 +5860,10 @@ static Obj FuncKRONECKERPRODUCT_MAT8BIT_MAT8BIT(Obj self, Obj matl, Obj matr)
     const UInt1 * getelt, *setelt, *scalar, *add;
     const UInt1 * datar;
 
-    GAP_ASSERT(IS_MAT8BIT_REP(matl));
-    GAP_ASSERT(IS_MAT8BIT_REP(matr));
+    RequireMat8BitRep(SELF_NAME, matl);
+    RequireMat8BitRep(SELF_NAME, matr);
+    RequireNonemptyMat8BitRows(SELF_NAME, matl);
+    RequireNonemptyMat8BitRows(SELF_NAME, matr);
 
     nrowl = LEN_MAT8BIT(matl);
     nrowr = LEN_MAT8BIT(matr);

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -2893,6 +2893,8 @@ static Obj FuncELMS_VEC8BIT_RANGE(Obj self, Obj list, Obj range)
     UInt1         byte;
 
     RequireVec8BitRep(SELF_NAME, list);
+    RequireArgumentCondition(SELF_NAME, range, IS_RANGE(range), "must be a range");
+
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(list));
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
     len = GET_LEN_RANGE(range);
@@ -4551,6 +4553,7 @@ static Obj FuncADD_COEFFS_VEC8BIT_3(Obj self, Obj vec1, Obj vec2, Obj mult)
 {
     RequireVec8BitRep(SELF_NAME, vec1);
     RequireVec8BitRep(SELF_NAME, vec2);
+    RequireFFE(SELF_NAME, mult);
 
     UInt q;
     UInt len;
@@ -4904,6 +4907,12 @@ static Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
     Obj  res;
     UInt lenp;
     UInt last;
+
+    RequireVec8BitRep(SELF_NAME, vl);
+    RequireVec8BitRep(SELF_NAME, vr);
+    RequireNonnegativeSmallInt(SELF_NAME, ll);
+    RequireNonnegativeSmallInt(SELF_NAME, lr);
+
     q = FIELD_VEC8BIT(vl);
     if (q != FIELD_VEC8BIT(vr)) {
         Obj  info1;
@@ -4934,8 +4943,6 @@ static Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
         q = q0;
     }
 
-    RequireNonnegativeSmallInt(SELF_NAME, ll);
-    RequireNonnegativeSmallInt(SELF_NAME, lr);
     ll1 = INT_INTOBJ(ll);
     lr1 = INT_INTOBJ(lr);
     if (0 > ll1 || ll1 > LEN_VEC8BIT(vl))
@@ -4952,7 +4959,8 @@ static Obj FuncPROD_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vr, Obj lr)
     else
         lenp = ll1 + lr1 - 1;
     res = ZeroVec8Bit(q, lenp, 1);
-    ProdCoeffsVec8Bit(res, vl, ll1, vr, lr1);
+    if (lenp > 0)
+        ProdCoeffsVec8Bit(res, vl, ll1, vr, lr1);
     last = RightMostNonZeroVec8Bit(res);
     if (last != lenp)
         ResizeVec8Bit(res, last, 1);
@@ -5157,10 +5165,11 @@ static Obj FuncREDUCE_COEFFS_VEC8BIT(Obj self, Obj vl, Obj ll, Obj vrshifted)
     UInt last;
 
     RequireVec8BitRep(SELF_NAME, vl);
+    RequireNonnegativeSmallInt(SELF_NAME, ll);
+    RequirePlainList(SELF_NAME, vrshifted);
     q = FIELD_VEC8BIT(vl);
     if (q != FIELD_VEC8BIT(ELM_PLIST(vrshifted, 1)))
         return Fail;
-    RequireNonnegativeSmallInt(SELF_NAME, ll);
     if (INT_INTOBJ(ll) > LEN_VEC8BIT(vl)) {
         ErrorQuit("ReduceCoeffs: given length <ll> of left argt (%d) is "
                   "longer than the argt (%d)",

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -86,6 +86,8 @@ Obj TYPE_LIST_GF2MAT_IMM;
 */
 Obj IsGF2VectorRep;
 
+Obj IsGF2MatrixRep;
+
 
 /****************************************************************************
 **
@@ -99,6 +101,18 @@ static Obj GF2One;
 *V  GF2Zero . . . . . . . . . . . . . . . . . . . . . . . . . . . zero of GF2
 */
 static Obj GF2Zero;
+
+#define RequireGF2VecRep(funcname, op)                                       \
+    RequireArgumentCondition(funcname, op, IS_GF2VEC_REP(op),               \
+                             "must be a GF2 vector")
+
+#define RequireGF2MatRep(funcname, op)                                       \
+    RequireArgumentCondition(funcname, op, IS_GF2MAT_REP(op),               \
+                             "must be a GF2 matrix")
+
+#define RequireFFE(funcname, op)                                             \
+    RequireArgumentCondition(funcname, op, IS_FFE(op),                       \
+                             "must be a finite field element")
 
 
 /****************************************************************************
@@ -835,6 +849,12 @@ static Obj FuncPROD_GF2VEC_ANYMAT(Obj self, Obj vec, Obj mat)
     UInt i;
     UInt block = 0;
 
+    RequireGF2VecRep(SELF_NAME, vec);
+    RequirePlainList(SELF_NAME, mat);
+
+    if (LEN_PLIST(mat) == 0)
+        return TRY_NEXT_METHOD;
+
     len = LEN_GF2VEC(vec);
     if (len > LEN_PLIST(mat))
         len = LEN_PLIST(mat);
@@ -1389,6 +1409,7 @@ static void ConvGF2Vec(Obj list)
 */
 static Obj FuncCONV_GF2VEC(Obj self, Obj list)
 {
+    RequireSmallList(SELF_NAME, list);
     ConvGF2Vec(list);
     return 0;
 }
@@ -1467,7 +1488,6 @@ static Obj NewGF2Vec(Obj list)
     return res;
 }
 
-
 /****************************************************************************
 **
 *F  FuncCOPY_GF2VEC( <self>, <list> ) . . . . . convert into a GF2 vector rep
@@ -1492,6 +1512,7 @@ static Obj FuncCONV_GF2MAT(Obj self, Obj list)
     UInt len, i;
     Obj  tmp;
     UInt mut;
+    RequireSmallList(SELF_NAME, list);
     len = LEN_LIST(list);
     if (len == 0)
         return (Obj)0;
@@ -1664,6 +1685,9 @@ static Int Cmp_GF2VEC_GF2VEC(Obj vl, Obj vr)
 */
 static Obj FuncEQ_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
+
     // we can do this case MUCH faster if we just want equality
     if (LEN_GF2VEC(vl) != LEN_GF2VEC(vr))
         return False;
@@ -1677,6 +1701,7 @@ static Obj FuncEQ_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 */
 static Obj FuncLEN_GF2VEC(Obj self, Obj list)
 {
+    RequireGF2VecRep(SELF_NAME, list);
     return INTOBJ_INT(LEN_GF2VEC(list));
 }
 
@@ -1692,6 +1717,7 @@ static Obj FuncLEN_GF2VEC(Obj self, Obj list)
 */
 static Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 {
+    RequireGF2VecRep(SELF_NAME, list);
     UInt p = GetSmallInt(SELF_NAME, pos);
     if (LEN_GF2VEC(list) < p) {
         return Fail;
@@ -1712,6 +1738,7 @@ static Obj FuncELM0_GF2VEC(Obj self, Obj list, Obj pos)
 */
 static Obj FuncELM_GF2VEC(Obj self, Obj list, Obj pos)
 {
+    RequireGF2VecRep(SELF_NAME, list);
     UInt p = GetSmallInt(SELF_NAME, pos);
     if (LEN_GF2VEC(list) < p) {
         ErrorMayQuit("List Element: <list>[%d] must have an assigned value",
@@ -1742,6 +1769,8 @@ static Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
     Int inc;        // increment in a range
     Int i;          // loop variable
     Obj apos;
+
+    RequireGF2VecRep(SELF_NAME, list);
 
     // get the length of <list>
     lenList = LEN_GF2VEC(list);
@@ -1830,6 +1859,8 @@ static Obj FuncELMS_GF2VEC(Obj self, Obj list, Obj poss)
 
 static Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
 {
+    RequireGF2VecRep(SELF_NAME, list);
+
     // check that <list> is mutable
     RequireMutable("List Assignment", list, "list");
 
@@ -1875,6 +1906,7 @@ static Obj FuncASS_GF2VEC(Obj self, Obj list, Obj pos, Obj elm)
 */
 static Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
 {
+    RequireGF2MatRep(SELF_NAME, list);
     PlainGF2Mat(list);
     return 0;
 }
@@ -1892,6 +1924,8 @@ static Obj FuncPLAIN_GF2MAT(Obj self, Obj list)
 */
 static Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
 {
+    RequireGF2MatRep(SELF_NAME, list);
+
     // check that <list> is mutable
     RequireMutable("List Assignment", list, "list");
 
@@ -1939,6 +1973,7 @@ static Obj FuncASS_GF2MAT(Obj self, Obj list, Obj pos, Obj elm)
 */
 static Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
 {
+    RequireGF2MatRep(SELF_NAME, mat);
     UInt r = GetSmallInt(SELF_NAME, row);
     if (LEN_GF2MAT(mat) < r) {
         ErrorMayQuit("row index %d exceeds %d, the number of rows", r,
@@ -1955,6 +1990,7 @@ static Obj FuncELM_GF2MAT(Obj self, Obj mat, Obj row)
 */
 static Obj FuncSWAP_ROWS_GF2MAT(Obj self, Obj mat, Obj row1, Obj row2)
 {
+    RequireGF2MatRep(SELF_NAME, mat);
     RequireMutable(SELF_NAME, mat, "mat");
 
     UInt r1 = GetSmallInt(SELF_NAME, row1);
@@ -1984,6 +2020,7 @@ static Obj FuncSWAP_ROWS_GF2MAT(Obj self, Obj mat, Obj row1, Obj row2)
 */
 static Obj FuncSWAP_COLS_GF2MAT(Obj self, Obj mat, Obj col1, Obj col2)
 {
+    RequireGF2MatRep(SELF_NAME, mat);
     UInt c1 = GetSmallInt(SELF_NAME, col1);
     UInt c2 = GetSmallInt(SELF_NAME, col2);
     UInt m = LEN_GF2MAT(mat);
@@ -2032,6 +2069,8 @@ static Obj FuncSWAP_COLS_GF2MAT(Obj self, Obj mat, Obj col1, Obj col2)
 */
 static Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
 {
+    RequireGF2VecRep(SELF_NAME, list);
+
     // check that <list> is mutable
     RequireMutable("List Unbind", list, "vector");
 
@@ -2069,6 +2108,8 @@ static Obj FuncUNB_GF2VEC(Obj self, Obj list, Obj pos)
 */
 static Obj FuncUNB_GF2MAT(Obj self, Obj list, Obj pos)
 {
+    RequireGF2MatRep(SELF_NAME, list);
+
     // check that <list> is mutable
     RequireMutable("List Unbind", list, "matrix");
 
@@ -2108,6 +2149,8 @@ static Obj FuncZERO_GF2VEC(Obj self, Obj mat)
     Obj  zero;
     UInt len;
 
+    RequireGF2VecRep(SELF_NAME, mat);
+
     // create a new GF2 vector
     len = LEN_GF2VEC(mat);
     NEW_GF2VEC(zero, TYPE_LIST_GF2VEC, len);
@@ -2141,6 +2184,8 @@ static Obj FuncINV_GF2MAT_MUTABLE(Obj self, Obj mat)
 {
     UInt len;
 
+    RequireGF2MatRep(SELF_NAME, mat);
+
     len = LEN_GF2MAT(mat);
     if (len != 0) {
         if (len != LEN_GF2VEC(ELM_GF2MAT(mat, 1))) {
@@ -2161,6 +2206,8 @@ static Obj FuncINV_GF2MAT_MUTABLE(Obj self, Obj mat)
 static Obj FuncINV_GF2MAT_SAME_MUTABILITY(Obj self, Obj mat)
 {
     UInt len;
+
+    RequireGF2MatRep(SELF_NAME, mat);
 
     len = LEN_GF2MAT(mat);
     if (len != 0) {
@@ -2183,6 +2230,8 @@ static Obj FuncINV_GF2MAT_IMMUTABLE(Obj self, Obj mat)
 {
     UInt len;
 
+    RequireGF2MatRep(SELF_NAME, mat);
+
     len = LEN_GF2MAT(mat);
     if (len != 0) {
         if (len != LEN_GF2VEC(ELM_GF2MAT(mat, 1))) {
@@ -2203,6 +2252,7 @@ static Obj FuncINV_PLIST_GF2VECS_DESTRUCTIVE(Obj self, Obj list)
 {
     UInt len, i;
     Obj  row;
+    RequirePlainList(SELF_NAME, list);
     len = LEN_PLIST(list);
     for (i = 1; i <= len; i++) {
         row = ELM_PLIST(list, i);
@@ -2242,6 +2292,9 @@ static Obj FuncSUM_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
     Obj  sum;    // sum, result
     UInt ll, lr;
 
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
+
     ll = LEN_GF2VEC(vl);
     lr = LEN_GF2VEC(vr);
 
@@ -2269,6 +2322,9 @@ static Obj FuncSUM_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 */
 static Obj FuncMULT_VECTOR_GF2VECS_2(Obj self, Obj vl, Obj mul)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireFFE(SELF_NAME, mul);
+
     if (EQ(mul, GF2One))
         return (Obj)0;
     else if (EQ(mul, GF2Zero)) {
@@ -2289,6 +2345,8 @@ static Obj FuncMULT_VECTOR_GF2VECS_2(Obj self, Obj vl, Obj mul)
 */
 static Obj FuncPROD_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
     return ProdGF2VecGF2Vec(vl, vr);
 }
 
@@ -2305,6 +2363,8 @@ static Obj FuncPROD_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 */
 static Obj FuncPROD_GF2VEC_GF2MAT(Obj self, Obj vl, Obj vr)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2MatRep(SELF_NAME, vr);
     return ProdGF2VecGF2Mat(vl, vr);
 }
 
@@ -2320,6 +2380,8 @@ static Obj FuncPROD_GF2VEC_GF2MAT(Obj self, Obj vl, Obj vr)
 */
 static Obj FuncPROD_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
+    RequireGF2MatRep(SELF_NAME, ml);
+    RequireGF2MatRep(SELF_NAME, mr);
     UInt lenl = LEN_GF2MAT(ml);
     UInt lenm;
     if (lenl >= 128) {
@@ -2344,6 +2406,8 @@ static Obj FuncPROD_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 */
 static Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE(Obj self, Obj ml, Obj mr)
 {
+    RequireGF2MatRep(SELF_NAME, ml);
+    RequireGF2MatRep(SELF_NAME, mr);
     return ProdGF2MatGF2MatSimple(ml, mr);
 }
 
@@ -2362,6 +2426,10 @@ static Obj FuncPROD_GF2MAT_GF2MAT_SIMPLE(Obj self, Obj ml, Obj mr)
 static Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED(
     Obj self, Obj ml, Obj mr, Obj greaselevel, Obj blocksize)
 {
+    RequireGF2MatRep(SELF_NAME, ml);
+    RequireGF2MatRep(SELF_NAME, mr);
+    RequireSmallInt(SELF_NAME, greaselevel);
+    RequireSmallInt(SELF_NAME, blocksize);
     return ProdGF2MatGF2MatAdvanced(ml, mr, INT_INTOBJ(greaselevel),
                                     INT_INTOBJ(blocksize));
 }
@@ -2379,6 +2447,8 @@ static Obj FuncPROD_GF2MAT_GF2MAT_ADVANCED(
 */
 static Obj FuncPROD_GF2MAT_GF2VEC(Obj self, Obj vl, Obj vr)
 {
+    RequireGF2MatRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
     return ProdGF2MatGF2Vec(vl, vr);
 }
 
@@ -2389,6 +2459,10 @@ static Obj FuncPROD_GF2MAT_GF2VEC(Obj self, Obj vl, Obj vr)
 */
 static Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(Obj self, Obj vl, Obj vr, Obj mul)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
+    RequireFFE(SELF_NAME, mul);
+
     // do nothing if <mul> is zero
     if (EQ(mul, GF2Zero)) {
         return INTOBJ_INT(RightMostOneGF2Vec(vl));
@@ -2409,6 +2483,8 @@ static Obj FuncADDCOEFFS_GF2VEC_GF2VEC_MULT(Obj self, Obj vl, Obj vr, Obj mul)
 */
 static Obj FuncADDCOEFFS_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
     return AddCoeffsGF2VecGF2Vec(vl, vr);
 }
 
@@ -2424,6 +2500,8 @@ static Obj FuncSHRINKCOEFFS_GF2VEC(Obj self, Obj vec)
     UInt   onbb;
     UInt * ptr;
     UInt   off;
+
+    RequireGF2VecRep(SELF_NAME, vec);
 
     // get length and number of blocks
     len = LEN_GF2VEC(vec);
@@ -2522,11 +2600,14 @@ static UInt PositionNonZeroGF2Vec(Obj vec, UInt from)
 
 static Obj FuncPOSITION_NONZERO_GF2VEC(Obj self, Obj vec, Obj zero)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
     return INTOBJ_INT(PositionNonZeroGF2Vec(vec, 0));
 }
 
 static Obj FuncPOSITION_NONZERO_GF2VEC3(Obj self, Obj vec, Obj zero, Obj from)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
+    RequireNonnegativeSmallInt(SELF_NAME, from);
     return INTOBJ_INT(PositionNonZeroGF2Vec(vec, INT_INTOBJ(from)));
 }
 
@@ -2538,12 +2619,8 @@ static Obj FuncCOPY_SECTION_GF2VECS(
     Int ito = GetPositiveSmallInt(SELF_NAME, to);
     Int ihowmany = GetSmallInt(SELF_NAME, howmany);
 
-    if (!IS_GF2VEC_REP(src)) {
-        RequireArgument(SELF_NAME, src, "must be a GF2 vector");
-    }
-    if (!IS_GF2VEC_REP(dest)) {
-        RequireArgument(SELF_NAME, dest, "must be a GF2 vector");
-    }
+    RequireGF2VecRep(SELF_NAME, src);
+    RequireGF2VecRep(SELF_NAME, dest);
 
     UInt lens = LEN_GF2VEC(src);
     UInt lend = LEN_GF2VEC(dest);
@@ -2566,6 +2643,9 @@ static Obj FuncCOPY_SECTION_GF2VECS(
 static Obj FuncAPPEND_GF2VEC(Obj self, Obj vecl, Obj vecr)
 {
     UInt lenl, lenr;
+    RequireGF2VecRep(SELF_NAME, vecl);
+    RequireGF2VecRep(SELF_NAME, vecr);
+    RequireMutable(SELF_NAME, vecl, "vector");
     lenl = LEN_GF2VEC(vecl);
     lenr = LEN_GF2VEC(vecr);
     if (True == DoFilter(IsLockedRepresentationVector, vecl) && lenr > 0) {
@@ -2586,6 +2666,7 @@ static Obj FuncAPPEND_GF2VEC(Obj self, Obj vecl, Obj vecr)
 
 static Obj FuncSHALLOWCOPY_GF2VEC(Obj self, Obj vec)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
     return ShallowCopyVecGF2(vec);
 }
 
@@ -2603,6 +2684,8 @@ static Obj FuncSUM_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
     Obj  vl, vr, sv;
     UInt i;
     Obj  rtype;
+    RequireGF2MatRep(SELF_NAME, matl);
+    RequireGF2MatRep(SELF_NAME, matr);
     ll = LEN_GF2MAT(matl);
     lr = LEN_GF2MAT(matr);
     if (ll > lr) {
@@ -2695,10 +2778,11 @@ static Obj FuncTRANSPOSED_GF2MAT(Obj self, Obj mat)
     UInt imod, nrb, nstart;
     UInt i, j, k, n;
 
-    if (TNUM_OBJ(mat) != T_POSOBJ) {
-        ErrorMayQuit("TRANSPOSED_GF2MAT: Need compressed matrix over GF(2)",
-                     0, 0);
-    }
+    RequireGF2MatRep(SELF_NAME, mat);
+
+    if (LEN_GF2MAT(mat) == 0)
+        return TRY_NEXT_METHOD;
+
     // type for mat
     typ = TYPE_LIST_GF2MAT;
 
@@ -2780,6 +2864,7 @@ static Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
     Obj         zahl;         // the long number
     UInt *      num2;
     mp_limb_t * vp;
+    RequireGF2VecRep(SELF_NAME, vec);
     len = LEN_GF2VEC(vec);
     if (len == 0)
         return INTOBJ_INT(1);
@@ -2842,6 +2927,8 @@ static Obj FuncNUMBER_GF2VEC(Obj self, Obj vec)
 */
 static Obj FuncLT_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
 {
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
     return (Cmp_GF2VEC_GF2VEC(vl, vr) < 0) ? True : False;
 }
 
@@ -2876,6 +2963,8 @@ static Int Cmp_GF2MAT_GF2MAT(Obj ml, Obj mr)
 
 static Obj FuncEQ_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
+    RequireGF2MatRep(SELF_NAME, ml);
+    RequireGF2MatRep(SELF_NAME, mr);
     if (ELM_PLIST(ml, 1) != ELM_PLIST(mr, 1))
         return False;
     return (0 == Cmp_GF2MAT_GF2MAT(ml, mr)) ? True : False;
@@ -2888,6 +2977,8 @@ static Obj FuncEQ_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 
 static Obj FuncLT_GF2MAT_GF2MAT(Obj self, Obj ml, Obj mr)
 {
+    RequireGF2MatRep(SELF_NAME, ml);
+    RequireGF2MatRep(SELF_NAME, mr);
     return (Cmp_GF2MAT_GF2MAT(ml, mr) < 0) ? True : False;
 }
 
@@ -2931,6 +3022,8 @@ static Obj FuncDIST_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
     UInt * ptL;    // bit field of <vl>
     UInt * ptR;    // bit field of <vr>
     UInt * end;    // pointer used to zero out end bit
+    RequireGF2VecRep(SELF_NAME, vl);
+    RequireGF2VecRep(SELF_NAME, vr);
     // get and check the length
     len = LEN_GF2VEC(vl);
 
@@ -3009,6 +3102,10 @@ static Obj FuncDIST_VEC_CLOS_VEC(
 {
     Obj  sum;    // sum vector
     UInt len;
+
+    RequirePlainList(SELF_NAME, veclis);
+    RequireGF2VecRep(SELF_NAME, vec);
+    RequirePlainList(SELF_NAME, d);
 
     len = LEN_GF2VEC(vec);
 
@@ -3123,6 +3220,9 @@ static Obj FuncA_CLOS_VEC(
     Obj  best;    // best vector
     UInt len;
 
+    RequirePlainList(SELF_NAME, veclis);
+    RequireGF2VecRep(SELF_NAME, vec);
+
     len = LEN_GF2VEC(vec);
 
     RequireNonnegativeSmallInt(SELF_NAME, cnt);
@@ -3154,6 +3254,9 @@ static Obj FuncA_CLOS_VEC_COORDS(
     Obj  bcoords;    // coefficients of mat to get best
     Obj  res;        // length 2 plist for results
     UInt len, len2, i;
+
+    RequirePlainList(SELF_NAME, veclis);
+    RequireGF2VecRep(SELF_NAME, vec);
 
     len = LEN_GF2VEC(vec);
     len2 = LEN_PLIST(veclis);
@@ -3293,6 +3396,7 @@ static Obj FuncCOSET_LEADERS_INNER_GF2(
 
 static Obj FuncRIGHTMOST_NONZERO_GF2VEC(Obj self, Obj vec)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
     return INTOBJ_INT(RightMostOneGF2Vec(vec));
 }
 
@@ -3362,6 +3466,7 @@ static void ResizeGF2Vec(Obj vec, UInt newlen)
 
 static Obj FuncRESIZE_GF2VEC(Obj self, Obj vec, Obj newlen)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
     RequireMutable(SELF_NAME, vec, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, newlen);
     ResizeGF2Vec(vec, INT_INTOBJ(newlen));
@@ -3421,6 +3526,7 @@ static void ShiftLeftGF2Vec(Obj vec, UInt amount)
 
 static Obj FuncSHIFT_LEFT_GF2VEC(Obj self, Obj vec, Obj amount)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
     RequireMutable(SELF_NAME, vec, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, amount);
     ShiftLeftGF2Vec(vec, INT_INTOBJ(amount));
@@ -3484,8 +3590,10 @@ static void ShiftRightGF2Vec(Obj vec, UInt amount)
 
 static Obj FuncSHIFT_RIGHT_GF2VEC(Obj self, Obj vec, Obj amount, Obj zero)
 {
+    RequireGF2VecRep(SELF_NAME, vec);
     RequireMutable(SELF_NAME, vec, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, amount);
+    RequireFFE(SELF_NAME, zero);
     ShiftRightGF2Vec(vec, INT_INTOBJ(amount));
     return (Obj)0;
 }
@@ -3546,6 +3654,9 @@ static void AddShiftedVecGF2VecGF2(Obj vec1, Obj vec2, UInt len2, UInt off)
 static Obj
 FuncADD_GF2VEC_GF2VEC_SHIFTED(Obj self, Obj vec1, Obj vec2, Obj len2, Obj off)
 {
+    RequireGF2VecRep(SELF_NAME, vec1);
+    RequireGF2VecRep(SELF_NAME, vec2);
+    RequireMutable(SELF_NAME, vec1, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, off);
     RequireNonnegativeSmallInt(SELF_NAME, len2);
     Int off1 = INT_INTOBJ(off);
@@ -3619,8 +3730,8 @@ FuncPROD_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
     Obj  prod;
     UInt last;
 
-    RequireSmallInt(SELF_NAME, len1);
-    RequireSmallInt(SELF_NAME, len2);
+    RequireNonnegativeSmallInt(SELF_NAME, len1);
+    RequireNonnegativeSmallInt(SELF_NAME, len2);
     len2a = INT_INTOBJ(len2);
     if (len2a > LEN_GF2VEC(vec2))
         ErrorMayQuit("PROD_COEFFS_GF2VEC: <len2> must not be more than the "
@@ -3686,6 +3797,9 @@ FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     UInt last;
     Int  len2a;
+    RequireGF2VecRep(SELF_NAME, vec1);
+    RequireGF2VecRep(SELF_NAME, vec2);
+    RequireMutable(SELF_NAME, vec1, "vector");
     RequireNonnegativeSmallInt(SELF_NAME, len1);
     RequireNonnegativeSmallInt(SELF_NAME, len2);
     if (INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
@@ -3729,10 +3843,13 @@ static Obj
 FuncQUOTREM_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 {
     Int len2a;
-    Int len1a = INT_INTOBJ(len1);
+    Int len1a;
     Obj quotv, remv, ret;
+    RequireGF2VecRep(SELF_NAME, vec1);
+    RequireGF2VecRep(SELF_NAME, vec2);
     RequireNonnegativeSmallInt(SELF_NAME, len1);
     RequireNonnegativeSmallInt(SELF_NAME, len2);
+    len1a = INT_INTOBJ(len1);
     if (INT_INTOBJ(len1) > LEN_GF2VEC(vec1))
         ErrorMayQuit("QuotremCoeffs: given length <len1> of left argt "
                      "(%d)\nis longer than the argt (%d)",
@@ -3791,6 +3908,7 @@ static Obj FuncSEMIECHELON_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
+    RequirePlainList(SELF_NAME, mat);
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3825,6 +3943,7 @@ static Obj FuncSEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
+    RequirePlainList(SELF_NAME, mat);
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3855,6 +3974,7 @@ static Obj FuncTRIANGULIZE_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
+    RequirePlainList(SELF_NAME, mat);
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3886,6 +4006,7 @@ static Obj FuncRANK_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
+    RequirePlainList(SELF_NAME, mat);
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3916,6 +4037,7 @@ static Obj FuncDETERMINANT_LIST_GF2VECS(Obj self, Obj mat)
     UInt i, len;
     UInt width;
     Obj  row;
+    RequirePlainList(SELF_NAME, mat);
     len = LEN_PLIST(mat);
     if (!len)
         return TRY_NEXT_METHOD;
@@ -3947,6 +4069,9 @@ static Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
     Obj  mat, type, row, shift[BIPEB];
     UInt *       data;
     const UInt * datar;
+
+    RequireGF2MatRep(SELF_NAME, matl);
+    RequireGF2MatRep(SELF_NAME, matr);
 
     nrowl = LEN_GF2MAT(matl);
     nrowr = LEN_GF2MAT(matr);
@@ -4036,6 +4161,7 @@ static Obj FuncKRONECKERPRODUCT_GF2MAT_GF2MAT(Obj self, Obj matl, Obj matr)
 */
 static Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
 {
+    RequireGF2MatRep(SELF_NAME, mat);
     UInt r = GetPositiveSmallInt(SELF_NAME, row);
     UInt c = GetPositiveSmallInt(SELF_NAME, col);
 
@@ -4063,6 +4189,7 @@ static Obj FuncMAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col)
 static Obj
 FuncSET_MAT_ELM_GF2MAT(Obj self, Obj mat, Obj row, Obj col, Obj elm)
 {
+    RequireGF2MatRep(SELF_NAME, mat);
     UInt r = GetPositiveSmallInt(SELF_NAME, row);
     UInt c = GetPositiveSmallInt(SELF_NAME, col);
 
@@ -4203,6 +4330,7 @@ static Int InitKernel(StructInitInfo * module)
     InitCopyGVar("TYPE_LIST_GF2VEC_LOCKED",
                           &TYPE_LIST_GF2VEC_LOCKED);
     ImportFuncFromLibrary("IsGF2VectorRep", &IsGF2VectorRep);
+    ImportFuncFromLibrary("IsGF2MatrixRep", &IsGF2MatrixRep);
     InitCopyGVar("TYPE_LIST_GF2MAT", &TYPE_LIST_GF2MAT);
     InitCopyGVar("TYPE_LIST_GF2MAT_IMM", &TYPE_LIST_GF2MAT_IMM);
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -3031,6 +3031,8 @@ static Obj FuncDIST_GF2VEC_GF2VEC(Obj self, Obj vl, Obj vr)
         ErrorMayQuit("DIST_GF2VEC_GF2VEC: vectors must have the same length",
                      0, 0);
     }
+    if (len == 0)
+        return INTOBJ_INT(0);
 
     // calculate the offsets
     ptL = BLOCKS_GF2VEC(vl);

--- a/src/vecgf2.h
+++ b/src/vecgf2.h
@@ -20,6 +20,13 @@
 #define IS_GF2VEC_REP(obj)                                                   \
     (TNUM_OBJ(obj) == T_DATOBJ && DoFilter(IsGF2VectorRep, obj) == True)
 
+/****************************************************************************
+**
+*F  IS_GF2MAT_REP( <obj> )  . . . . . . check that <obj> is in GF2 matrix rep
+*/
+#define IS_GF2MAT_REP(obj)                                                   \
+    (TNUM_OBJ(obj) == T_POSOBJ && DoFilter(IsGF2MatrixRep, obj) == True)
+
 
 /****************************************************************************
 **
@@ -234,6 +241,7 @@ extern Obj TYPE_LIST_GF2MAT_IMM;
 
 
 extern Obj IsGF2VectorRep;
+extern Obj IsGF2MatrixRep;
 
 Obj ShallowCopyVecGF2(Obj vec);
 

--- a/tst/testinstall/kernel/vec8bit.tst
+++ b/tst/testinstall/kernel/vec8bit.tst
@@ -2,11 +2,1193 @@
 # Tests for functions defined in src/vec8bit.c
 #
 gap> START_TEST("kernel/vec8bit.tst");
+gap> q := 5;;
+gap> z := 0*Z(q);;
+gap> o := Z(q)^0;;
+gap> t := Z(q);;
+gap> V8 := function(list)
+> local v;
+>   v := ShallowCopy(list);
+>   CONV_VEC8BIT(v, q);
+>   return v;
+> end;;
+gap> M8 := function(rows)
+> local m, i;
+>   m := List(rows, ShallowCopy);
+>   for i in [1 .. Length(m)] do
+>     CONV_VEC8BIT(m[i], q);
+>   od;
+>   CONV_MAT8BIT(m, q);
+>   return m;
+> end;;
+gap> IM8 := function(rows)
+> local m;
+>   m := M8(rows);
+>   MakeImmutable(m);
+>   return m;
+> end;;
+gap> ZeroRowMat8 := function()
+> local m;
+>   m := [];
+>   CONV_MAT8BIT(m, q);
+>   return m;
+> end;;
+gap> Mx08 := n -> M8(List([1 .. n], i -> []));;
+gap> Veclis8 := function(rows)
+> local f, fdi, fdip, veclis, row, mults, j, mult;
+>   f := AsSSortedList(GF(q));
+>   fdi := [];
+>   for j in [2 .. Length(f)] do
+>     fdi[j - 1] := f[j] - f[j - 1];
+>   od;
+>   Add(fdi, -Last(f));
+>   fdip := List(fdi, x -> Position(fdi, x));
+>   veclis := [];
+>   for row in rows do
+>     mults := [];
+>     mults[Length(fdi) + 1] := false;
+>     for j in [1 .. Length(fdi)] do
+>       if fdip[j] < j then
+>         mult := mults[fdip[j]];
+>       else
+>         mult := fdi[j] * row;
+>       fi;
+>       mults[j] := mult;
+>     od;
+>     Add(veclis, mults);
+>   od;
+>   return veclis;
+> end;;
+gap> empty := V8([]);;
+gap> one := V8([o]);;
+gap> oneZero := V8([z]);;
+gap> pair := V8([o, t]);;
+gap> pair2 := V8([t, o]);;
+gap> f5 := AsSSortedList(GF(q));;
 
 #
+# CONV_VEC8BIT
+#
+gap> v := [];; CONV_VEC8BIT(v, q); v;
+< mutable compressed vector length 0 over GF(5) >
+
+# bad arguments
+gap> CONV_VEC8BIT(fail, q);
+Error, CONV_VEC8BIT: <list> must be a small list (not the value 'fail')
+gap> CONV_VEC8BIT(v, fail);
+Error, CONV_VEC8BIT: <q> must be a positive small integer (not the value 'fail\
+')
+
+#
+# COPY_VEC8BIT
+#
+gap> v := [];; w := COPY_VEC8BIT(v, q); v;
+< mutable compressed vector length 0 over GF(5) >
+[  ]
+
+# bad arguments
+gap> COPY_VEC8BIT(fail, q);
+Error, COPY_VEC8BIT: <list> must be a small list (not the value 'fail')
+gap> COPY_VEC8BIT(v, fail);
+Error, COPY_VEC8BIT: <q> must be a positive small integer (not the value 'fail\
+')
+
+#
+# PLAIN_VEC8BIT
+#
+gap> v := V8([]);; PLAIN_VEC8BIT(v);; IsPlistRep(v); Length(v);
+true
+0
+
+# bad arguments
+gap> PLAIN_VEC8BIT(fail);
+Error, PLAIN_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fa\
+il')
+
+#
+# LEN_VEC8BIT
+#
+gap> LEN_VEC8BIT(empty);
+0
+gap> LEN_VEC8BIT(pair);
+2
+
+# bad arguments
+gap> LEN_VEC8BIT(fail);
+Error, LEN_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fail\
+')
+
+#
+# ELM0_VEC8BIT
+#
+gap> ELM0_VEC8BIT(empty, 1);
+fail
+gap> ELM0_VEC8BIT(one, 1);
+Z(5)^0
+
+# bad arguments
+gap> ELM0_VEC8BIT(fail, 1);
+Error, ELM0_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fai\
+l')
+gap> ELM0_VEC8BIT(empty, fail);
+Error, ELM0_VEC8BIT: <pos> must be a positive small integer (not the value 'fa\
+il')
+
+#
+# ELM_VEC8BIT
+#
+gap> ELM_VEC8BIT(one, 1);
+Z(5)^0
+
+# bad arguments
+gap> ELM_VEC8BIT(fail, 1);
+Error, ELM_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fail\
+')
+gap> ELM_VEC8BIT(one, fail);
+Error, ELM_VEC8BIT: <pos> must be a positive small integer (not the value 'fai\
+l')
+
+#
+# ELMS_VEC8BIT
+#
+gap> ELMS_VEC8BIT(empty, []) = empty;
+true
+gap> ELMS_VEC8BIT(pair, [2]); # = V8([t]));
+[ Z(5) ]
+
+# bad arguments
+gap> ELMS_VEC8BIT(fail, []);
+Error, ELMS_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fai\
+l')
+gap> ELMS_VEC8BIT(empty, fail);
+Error, ELMS_VEC8BIT: <poss> must be a plain list (not the value 'fail')
+
+#
+# ELMS_VEC8BIT_RANGE
+#
+gap> ELMS_VEC8BIT_RANGE(one, [1 .. 1]);
+[ Z(5)^0 ]
+gap> ELMS_VEC8BIT_RANGE(pair, [1 .. 2]) = pair;
+true
+
+# bad arguments
+gap> ELMS_VEC8BIT_RANGE(fail, [1 .. 1]);
+Error, ELMS_VEC8BIT_RANGE: <list> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+gap> ELMS_VEC8BIT_RANGE(one, fail);
+Error, ELMS_VEC8BIT_RANGE: Range includes indices which are too high or too lo\
+w
+
+#
+# ASS_VEC8BIT
+#
+gap> v := V8([]);; ASS_VEC8BIT(v, 1, z);; v = V8([z]);
+true
+gap> v := [Z(23), Z(23)];; ConvertToVectorRep(v);; ASS_VEC8BIT(v, 1, Z(23^5));;
+gap> Is8BitVectorRep(v);
+false
+gap> v;
+[ z, Z(23) ]
+
+# bad arguments
+gap> v := V8([z, z]);;
+gap> ASS_VEC8BIT(fail, 1, z);
+Error, ASS_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fail\
+')
+gap> ASS_VEC8BIT(v, fail, z);
+Error, ASS_VEC8BIT: <pos> must be a positive small integer (not the value 'fai\
+l')
+gap> ASS_VEC8BIT(v, 1, fail);;
+gap> IsPlistRep(v);
+true
+gap> v;
+[ fail, 0*Z(5) ]
+
+#
+# UNB_VEC8BIT
+#
+gap> v := V8([o]);; UNB_VEC8BIT(v, 1);; v = empty;
+true
+
+# bad arguments
+gap> UNB_VEC8BIT(fail, 1);
+Error, UNB_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fail\
+')
+gap> UNB_VEC8BIT(v, fail);
+Error, UNB_VEC8BIT: <pos> must be a positive small integer (not the value 'fai\
+l')
+
+#
+# Q_VEC8BIT
+#
+gap> Q_VEC8BIT(empty);
+5
+
+# bad arguments
+gap> Q_VEC8BIT(fail);
+Error, Q_VEC8BIT: <list> must belong to Is8BitVectorRep (not the value 'fail')
+
+#
+# SHALLOWCOPY_VEC8BIT
+#
+gap> v := SHALLOWCOPY_VEC8BIT(empty);; v = empty and not IsIdenticalObj(v, empty);
+true
+
+# bad arguments
+gap> SHALLOWCOPY_VEC8BIT(fail);
+Error, SHALLOWCOPY_VEC8BIT: <list> must belong to Is8BitVectorRep (not the val\
+ue 'fail')
+
+#
+# SUM_VEC8BIT_VEC8BIT
+#
+gap> SUM_VEC8BIT_VEC8BIT(empty, empty);
+< mutable compressed vector length 0 over GF(5) >
+gap> SUM_VEC8BIT_VEC8BIT(one, oneZero);
+[ Z(5)^0 ]
+
+# bad arguments
+gap> SUM_VEC8BIT_VEC8BIT(fail, empty);
+Error, SUM_VEC8BIT_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the value\
+ 'fail')
+gap> SUM_VEC8BIT_VEC8BIT(empty, fail);
+Error, SUM_VEC8BIT_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the value\
+ 'fail')
+
+#
+# DIFF_VEC8BIT_VEC8BIT
+#
+gap> DIFF_VEC8BIT_VEC8BIT(empty, empty);
+< mutable compressed vector length 0 over GF(5) >
+gap> DIFF_VEC8BIT_VEC8BIT(one, oneZero);
+[ Z(5)^0 ]
+
+# bad arguments
+gap> DIFF_VEC8BIT_VEC8BIT(fail, empty);
+Error, DIFF_VEC8BIT_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+gap> DIFF_VEC8BIT_VEC8BIT(empty, fail);
+Error, DIFF_VEC8BIT_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+
+#
+# PROD_VEC8BIT_FFE
+#
+gap> PROD_VEC8BIT_FFE(empty, o);
+< mutable compressed vector length 0 over GF(5) >
+gap> PROD_VEC8BIT_FFE(one, z);
+[ 0*Z(5) ]
+
+# bad arguments
+gap> PROD_VEC8BIT_FFE(fail, o);
+Error, PROD_VEC8BIT_FFE: <vec> must belong to Is8BitVectorRep (not the value '\
+fail')
+gap> PROD_VEC8BIT_FFE(empty, fail);
+Error, PROD_VEC8BIT_FFE: <ffe> must be a finite field element (not the value '\
+fail')
+
+#
+# PROD_FFE_VEC8BIT
+#
+gap> PROD_FFE_VEC8BIT(o, empty);
+< mutable compressed vector length 0 over GF(5) >
+gap> PROD_FFE_VEC8BIT(z, one);
+[ 0*Z(5) ]
+
+# bad arguments
+gap> PROD_FFE_VEC8BIT(fail, empty);
+Error, PROD_FFE_VEC8BIT: <ffe> must be a finite field element (not the value '\
+fail')
+gap> PROD_FFE_VEC8BIT(o, fail);
+Error, PROD_FFE_VEC8BIT: <vec> must belong to Is8BitVectorRep (not the value '\
+fail')
+
+#
+# AINV_VEC8BIT_MUTABLE
+#
+gap> AINV_VEC8BIT_MUTABLE(empty);
+< mutable compressed vector length 0 over GF(5) >
+gap> AINV_VEC8BIT_MUTABLE(oneZero);
+[ 0*Z(5) ]
+
+# bad arguments
+gap> AINV_VEC8BIT_MUTABLE(fail);
+Error, AINV_VEC8BIT_MUTABLE: <vec> must belong to Is8BitVectorRep (not the val\
+ue 'fail')
+
+#
+# AINV_VEC8BIT_IMMUTABLE
+#
+gap> AINV_VEC8BIT_IMMUTABLE(empty);
+< immutable compressed vector length 0 over GF(5) >
+gap> AINV_VEC8BIT_IMMUTABLE(oneZero);
+[ 0*Z(5) ]
+
+# bad arguments
+gap> AINV_VEC8BIT_IMMUTABLE(fail);
+Error, AINV_VEC8BIT_IMMUTABLE: <vec> must belong to Is8BitVectorRep (not the v\
+alue 'fail')
+
+#
+# AINV_VEC8BIT_SAME_MUTABILITY
+#
+gap> AINV_VEC8BIT_SAME_MUTABILITY(empty);
+< mutable compressed vector length 0 over GF(5) >
+gap> AINV_VEC8BIT_SAME_MUTABILITY(oneZero);
+[ 0*Z(5) ]
+
+# bad arguments
+gap> AINV_VEC8BIT_SAME_MUTABILITY(fail);
+Error, AINV_VEC8BIT_SAME_MUTABILITY: <vec> must belong to Is8BitVectorRep (not\
+ the value 'fail')
+
+#
+# ZERO_VEC8BIT
+#
+gap> ZERO_VEC8BIT(empty);
+< mutable compressed vector length 0 over GF(5) >
+gap> ZERO_VEC8BIT(pair);
+[ 0*Z(5), 0*Z(5) ]
+
+# bad arguments
+gap> ZERO_VEC8BIT(fail);
+Error, ZERO_VEC8BIT: <vec> must belong to Is8BitVectorRep (not the value 'fail\
+')
+
+#
+# ZERO_VEC8BIT_2
+#
+gap> ZERO_VEC8BIT_2(q, 0);
+< mutable compressed vector length 0 over GF(5) >
+gap> ZERO_VEC8BIT_2(q, 2);
+[ 0*Z(5), 0*Z(5) ]
+
+# bad arguments
+gap> ZERO_VEC8BIT_2(fail, 0);
+Error, ZERO_VEC8BIT_2: <q> must be a positive small integer (not the value 'fa\
+il')
+gap> ZERO_VEC8BIT_2(q, fail);
+Error, ZERO_VEC8BIT_2: <len> must be a non-negative small integer (not the val\
+ue 'fail')
+
+#
+# EQ_VEC8BIT_VEC8BIT
+#
+gap> EQ_VEC8BIT_VEC8BIT(empty, empty);
+true
+gap> EQ_VEC8BIT_VEC8BIT(empty, one);
+false
+
+# bad arguments
+gap> EQ_VEC8BIT_VEC8BIT(fail, empty);
+Error, EQ_VEC8BIT_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the value \
+'fail')
+gap> EQ_VEC8BIT_VEC8BIT(empty, fail);
+Error, EQ_VEC8BIT_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the value \
+'fail')
+
+#
+# LT_VEC8BIT_VEC8BIT
+#
+gap> LT_VEC8BIT_VEC8BIT(empty, one);
+true
+gap> LT_VEC8BIT_VEC8BIT(one, empty);
+false
+
+# bad arguments
+gap> LT_VEC8BIT_VEC8BIT(fail, one);
+Error, LT_VEC8BIT_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the value \
+'fail')
+gap> LT_VEC8BIT_VEC8BIT(empty, fail);
+Error, LT_VEC8BIT_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the value \
+'fail')
+
+#
+# PROD_VEC8BIT_VEC8BIT
+#
+gap> PROD_VEC8BIT_VEC8BIT(empty, empty);
+0*Z(5)
+gap> PROD_VEC8BIT_VEC8BIT(one, one);
+Z(5)^0
+
+# bad arguments
+gap> PROD_VEC8BIT_VEC8BIT(fail, empty);
+Error, PROD_VEC8BIT_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+gap> PROD_VEC8BIT_VEC8BIT(empty, fail);
+Error, PROD_VEC8BIT_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+
+#
+# DISTANCE_VEC8BIT_VEC8BIT
+#
+gap> DISTANCE_VEC8BIT_VEC8BIT(empty, empty);
+0
+gap> DISTANCE_VEC8BIT_VEC8BIT(one, oneZero);
+1
+
+# bad arguments
+gap> DISTANCE_VEC8BIT_VEC8BIT(fail, empty);
+Error, DISTANCE_VEC8BIT_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the \
+value 'fail')
+gap> DISTANCE_VEC8BIT_VEC8BIT(empty, fail);
+Error, DISTANCE_VEC8BIT_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the \
+value 'fail')
+
+#
+# ADD_ROWVECTOR_VEC8BITS_5
+#
+gap> v := V8([o, z]);; ADD_ROWVECTOR_VEC8BITS_5(v, V8([z, o]), o, 2, 2);; v = V8([o, o]);
+true
+
+# bad arguments
+gap> ADD_ROWVECTOR_VEC8BITS_5(fail, V8([z, o]), o, 2, 2);
+Error, ADD_ROWVECTOR_VEC8BITS_5: <vl> must belong to Is8BitVectorRep (not the \
+value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_5(v, fail, o, 2, 2);
+Error, ADD_ROWVECTOR_VEC8BITS_5: <vr> must belong to Is8BitVectorRep (not the \
+value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_5(v, V8([z, o]), fail, 2, 2);
+Error, ADD_ROWVECTOR_VEC8BITS_5: <mul> must be a finite field element (not the\
+ value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_5(v, V8([z, o]), o, fail, 2);
+Error, ADD_ROWVECTOR_VEC8BITS_5: <from> must be a positive small integer (not \
+the value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_5(v, V8([z, o]), o, 2, fail);
+Error, ADD_ROWVECTOR_VEC8BITS_5: <to> must be a positive small integer (not th\
+e value 'fail')
+
+#
+# ADD_ROWVECTOR_VEC8BITS_3
+#
+gap> v := V8([]);; ADD_ROWVECTOR_VEC8BITS_3(v, empty, o);; v = empty;
+true
+
+# bad arguments
+gap> ADD_ROWVECTOR_VEC8BITS_3(fail, empty, o);
+Error, ADD_ROWVECTOR_VEC8BITS_3: <vl> must belong to Is8BitVectorRep (not the \
+value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_3(v, fail, o);
+Error, ADD_ROWVECTOR_VEC8BITS_3: <vr> must belong to Is8BitVectorRep (not the \
+value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_3(v, empty, fail);
+Error, ADD_ROWVECTOR_VEC8BITS_3: <mul> must be a finite field element (not the\
+ value 'fail')
+
+#
+# ADD_ROWVECTOR_VEC8BITS_2
+#
+gap> v := V8([]);; ADD_ROWVECTOR_VEC8BITS_2(v, empty);; v = empty;
+true
+
+# bad arguments
+gap> ADD_ROWVECTOR_VEC8BITS_2(fail, empty);
+Error, ADD_ROWVECTOR_VEC8BITS_2: <vl> must belong to Is8BitVectorRep (not the \
+value 'fail')
+gap> ADD_ROWVECTOR_VEC8BITS_2(v, fail);
+Error, ADD_ROWVECTOR_VEC8BITS_2: <vr> must belong to Is8BitVectorRep (not the \
+value 'fail')
+
+#
+# MULT_VECTOR_VEC8BITS
+#
+gap> v := V8([]);; MULT_VECTOR_VEC8BITS(v, o);; v = empty;
+true
+
+# bad arguments
+gap> MULT_VECTOR_VEC8BITS(fail, o);
+Error, MULT_VECTOR_VEC8BITS: <vec> must belong to Is8BitVectorRep (not the val\
+ue 'fail')
+gap> MULT_VECTOR_VEC8BITS(v, fail);
+Error, MULT_VECTOR_VEC8BITS: <mul> must be a finite field element (not the val\
+ue 'fail')
+
+#
+# POSITION_NONZERO_VEC8BIT
+#
+gap> POSITION_NONZERO_VEC8BIT(empty, z);
+1
+gap> POSITION_NONZERO_VEC8BIT(one, z);
+1
+
+# bad arguments
+gap> POSITION_NONZERO_VEC8BIT(fail, z);
+Error, POSITION_NONZERO_VEC8BIT: <list> must belong to Is8BitVectorRep (not th\
+e value 'fail')
+gap> POSITION_NONZERO_VEC8BIT(empty, fail);
+1
+
+#
+# POSITION_NONZERO_VEC8BIT3
+#
+gap> POSITION_NONZERO_VEC8BIT3(empty, z, 1);
+1
+gap> POSITION_NONZERO_VEC8BIT3(V8([z, o]), z, 2);
+3
+
+# bad arguments
+gap> POSITION_NONZERO_VEC8BIT3(fail, z, 1);
+Error, POSITION_NONZERO_VEC8BIT3: <list> must belong to Is8BitVectorRep (not t\
+he value 'fail')
+gap> POSITION_NONZERO_VEC8BIT3(empty, fail, 1);
+1
+gap> POSITION_NONZERO_VEC8BIT3(empty, z, fail);
+Error, POSITION_NONZERO_VEC8BIT3: <from> must be a non-negative small integer \
+(not the value 'fail')
+
+#
+# APPEND_VEC8BIT
+#
+gap> v := V8([]);; APPEND_VEC8BIT(v, one);; v = one;
+true
+
+# bad arguments
+gap> APPEND_VEC8BIT(fail, one);
+Error, APPEND_VEC8BIT: <vecl> must belong to Is8BitVectorRep (not the value 'f\
+ail')
+gap> APPEND_VEC8BIT(v, fail);
+Error, APPEND_VEC8BIT: <vecr> must belong to Is8BitVectorRep (not the value 'f\
+ail')
+
+#
+# NUMBER_VEC8BIT
+#
+gap> NUMBER_VEC8BIT(empty);
+1
+gap> NUMBER_VEC8BIT(one);
+1
+
+# bad arguments
+gap> NUMBER_VEC8BIT(fail);
+Error, NUMBER_VEC8BIT: <vec> must belong to Is8BitVectorRep (not the value 'fa\
+il')
+
+#
+# PROD_VEC8BIT_MATRIX
+#
+gap> PROD_VEC8BIT_MATRIX(one, [fail]);
+"TRY_NEXT_METHOD"
+gap> PROD_VEC8BIT_MATRIX(one, [one]);
+[ Z(5)^0 ]
+
+# bad arguments
+gap> PROD_VEC8BIT_MATRIX(fail, [fail]);
+Error, PROD_VEC8BIT_MATRIX: <vec> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+gap> PROD_VEC8BIT_MATRIX(one, fail);
+Error, PROD_VEC8BIT_MATRIX: <mat> must be a plain list (not the value 'fail')
+
+#
+# CONV_MAT8BIT
+#
+gap> m := [V8([]), V8([])];; CONV_MAT8BIT(m, q);; EQ_MAT8BIT_MAT8BIT(m, Mx08(2));
+true
+
+# bad arguments
+gap> CONV_MAT8BIT(fail, q);
+Error, CONV_MAT8BIT: <list> must be a plain list (not the value 'fail')
+gap> CONV_MAT8BIT(m, fail);
+Error, CONV_MAT8BIT: <list> must be a plain list (not a positional object)
+
+#
+# PLAIN_MAT8BIT
+#
+gap> m := Mx08(2);; PLAIN_MAT8BIT(m);; IsPlistRep(m) and m = [[], []];
+true
+
+# bad arguments
+gap> PLAIN_MAT8BIT(fail);
+Error, PLAIN_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value 'fai\
+l')
+
+#
+# PROD_VEC8BIT_MAT8BIT
+#
+gap> PROD_VEC8BIT_MAT8BIT(empty, ZeroRowMat8());
+Error, PROD_VEC8BIT_MAT8BIT: compressed 8bit matrices with empty rows are not \
+supported
+gap> PROD_VEC8BIT_MAT8BIT(empty, Mx08(2));
+< mutable compressed vector length 0 over GF(5) >
+
+# bad arguments
+gap> PROD_VEC8BIT_MAT8BIT(fail, ZeroRowMat8());
+Error, PROD_VEC8BIT_MAT8BIT: <vec> must belong to Is8BitVectorRep (not the val\
+ue 'fail')
+gap> PROD_VEC8BIT_MAT8BIT(empty, fail);
+Error, PROD_VEC8BIT_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the val\
+ue 'fail')
+
+#
+# PROD_MAT8BIT_VEC8BIT
+#
+gap> PROD_MAT8BIT_VEC8BIT(ZeroRowMat8(), empty);
+Error, PROD_MAT8BIT_VEC8BIT: compressed 8bit matrices with empty rows are not \
+supported
+gap> PROD_MAT8BIT_VEC8BIT(Mx08(2), empty);
+[ 0*Z(5), 0*Z(5) ]
+
+# bad arguments
+gap> PROD_MAT8BIT_VEC8BIT(fail, empty);
+Error, PROD_MAT8BIT_VEC8BIT: <mat> must belong to Is8BitMatrixRep (not the val\
+ue 'fail')
+gap> PROD_MAT8BIT_VEC8BIT(ZeroRowMat8(), fail);
+Error, PROD_MAT8BIT_VEC8BIT: <vec> must belong to Is8BitVectorRep (not the val\
+ue 'fail')
+
+#
+# PROD_MAT8BIT_MAT8BIT
+#
+gap> PROD_MAT8BIT_MAT8BIT(ZeroRowMat8(), ZeroRowMat8());
+Error, PROD_MAT8BIT_MAT8BIT: compressed 8bit matrices with empty rows are not \
+supported
+gap> PROD_MAT8BIT_MAT8BIT(M8([[o], [z]]), Mx08(1)) = Mx08(2);
+true
+
+# bad arguments
+gap> PROD_MAT8BIT_MAT8BIT(fail, ZeroRowMat8());
+Error, PROD_MAT8BIT_MAT8BIT: <matl> must belong to Is8BitMatrixRep (not the va\
+lue 'fail')
+gap> PROD_MAT8BIT_MAT8BIT(ZeroRowMat8(), fail);
+Error, PROD_MAT8BIT_MAT8BIT: <matr> must belong to Is8BitMatrixRep (not the va\
+lue 'fail')
+
+#
+# INV_MAT8BIT_MUTABLE
+#
+gap> INV_MAT8BIT_MUTABLE(ZeroRowMat8());
+Error, INV_MAT8BIT_MUTABLE: compressed 8bit matrices with empty rows are not s\
+upported
+gap> INV_MAT8BIT_MUTABLE(M8([[o]])) = M8([[o]]);
+true
+
+# bad arguments
+gap> INV_MAT8BIT_MUTABLE(fail);
+Error, INV_MAT8BIT_MUTABLE: <mat> must belong to Is8BitMatrixRep (not the valu\
+e 'fail')
+
+#
+# INV_MAT8BIT_SAME_MUTABILITY
+#
+gap> INV_MAT8BIT_SAME_MUTABILITY(ZeroRowMat8());
+Error, INV_MAT8BIT_SAME_MUTABILITY: compressed 8bit matrices with empty rows a\
+re not supported
+gap> INV_MAT8BIT_SAME_MUTABILITY(M8([[o]])) = M8([[o]]);
+true
+
+# bad arguments
+gap> INV_MAT8BIT_SAME_MUTABILITY(fail);
+Error, INV_MAT8BIT_SAME_MUTABILITY: <mat> must belong to Is8BitMatrixRep (not \
+the value 'fail')
+
+#
+# INV_MAT8BIT_IMMUTABLE
+#
+gap> INV_MAT8BIT_IMMUTABLE(ZeroRowMat8());
+Error, INV_MAT8BIT_IMMUTABLE: compressed 8bit matrices with empty rows are not\
+ supported
+gap> INV_MAT8BIT_IMMUTABLE(IM8([[o]])) = IM8([[o]]);
+true
+
+# bad arguments
+gap> INV_MAT8BIT_IMMUTABLE(fail);
+Error, INV_MAT8BIT_IMMUTABLE: <mat> must belong to Is8BitMatrixRep (not the va\
+lue 'fail')
+
+#
+# ASS_MAT8BIT
+#
+gap> ASS_MAT8BIT(ZeroRowMat8(), 1, empty);
+Error, ASS_MAT8BIT: compressed 8bit matrices with empty rows are not supported
+gap> m := Mx08(1);; ASS_MAT8BIT(m, 2, empty);; m = Mx08(2);
+true
+
+# bad arguments
+gap> ASS_MAT8BIT(fail, 1, empty);
+Error, ASS_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value 'fail'\
+)
+gap> ASS_MAT8BIT(ZeroRowMat8(), fail, empty);
+Error, ASS_MAT8BIT: compressed 8bit matrices with empty rows are not supported
+gap> ASS_MAT8BIT(ZeroRowMat8(), 1, fail);
+Error, ASS_MAT8BIT: compressed 8bit matrices with empty rows are not supported
+
+#
+# ELM_MAT8BIT
+#
+gap> ELM_MAT8BIT(Mx08(2), 1);
+< mutable compressed vector length 0 over GF(5) >
+
+# bad arguments
+gap> ELM_MAT8BIT(fail, 1);
+Error, ELM_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value 'fail'\
+)
+gap> ELM_MAT8BIT(Mx08(2), fail);
+Error, ELM_MAT8BIT: <pos> must be a positive small integer (not the value 'fai\
+l')
+
+#
+# SWAP_ROWS_MAT8BIT
+#
+gap> m := Mx08(2);; SWAP_ROWS_MAT8BIT(m, 1, 2);; m = Mx08(2);
+true
+
+# bad arguments
+gap> SWAP_ROWS_MAT8BIT(fail, 1, 2);
+Error, SWAP_ROWS_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value \
+'fail')
+gap> SWAP_ROWS_MAT8BIT(m, fail, 2);
+Error, SWAP_ROWS_MAT8BIT: <row1> must be a small integer (not the value 'fail'\
+)
+gap> SWAP_ROWS_MAT8BIT(m, 1, fail);
+Error, SWAP_ROWS_MAT8BIT: <row2> must be a small integer (not the value 'fail'\
+)
+
+#
+# SWAP_COLS_MAT8BIT
+#
+gap> m := ZeroRowMat8();; SWAP_COLS_MAT8BIT(m, 1, 1);; EQ_MAT8BIT_MAT8BIT(m, ZeroRowMat8());
+true
+
+# bad arguments
+gap> SWAP_COLS_MAT8BIT(fail, 1, 1);
+Error, SWAP_COLS_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value \
+'fail')
+gap> SWAP_COLS_MAT8BIT(m, fail, 1);
+Error, SWAP_COLS_MAT8BIT: <col1> must be a small integer (not the value 'fail'\
+)
+gap> SWAP_COLS_MAT8BIT(m, 1, fail);
+Error, SWAP_COLS_MAT8BIT: <col2> must be a small integer (not the value 'fail'\
+)
+
+#
+# SUM_MAT8BIT_MAT8BIT
+#
+gap> SUM_MAT8BIT_MAT8BIT(ZeroRowMat8(), ZeroRowMat8());
+Error, SUM_MAT8BIT_MAT8BIT: compressed 8bit matrices with empty rows are not s\
+upported
+gap> SUM_MAT8BIT_MAT8BIT(Mx08(2), Mx08(2)) = Mx08(2);
+true
+
+# bad arguments
+gap> SUM_MAT8BIT_MAT8BIT(fail, ZeroRowMat8());
+Error, SUM_MAT8BIT_MAT8BIT: <ml> must belong to Is8BitMatrixRep (not the value\
+ 'fail')
+gap> SUM_MAT8BIT_MAT8BIT(ZeroRowMat8(), fail);
+Error, SUM_MAT8BIT_MAT8BIT: <mr> must belong to Is8BitMatrixRep (not the value\
+ 'fail')
+
+#
+# DIFF_MAT8BIT_MAT8BIT
+#
+gap> DIFF_MAT8BIT_MAT8BIT(ZeroRowMat8(), ZeroRowMat8());
+Error, DIFF_MAT8BIT_MAT8BIT: compressed 8bit matrices with empty rows are not \
+supported
+gap> DIFF_MAT8BIT_MAT8BIT(Mx08(2), Mx08(2)) = Mx08(2);
+true
+
+# bad arguments
+gap> DIFF_MAT8BIT_MAT8BIT(fail, ZeroRowMat8());
+Error, DIFF_MAT8BIT_MAT8BIT: <ml> must belong to Is8BitMatrixRep (not the valu\
+e 'fail')
+gap> DIFF_MAT8BIT_MAT8BIT(ZeroRowMat8(), fail);
+Error, DIFF_MAT8BIT_MAT8BIT: <mr> must belong to Is8BitMatrixRep (not the valu\
+e 'fail')
+
+#
+# ADD_COEFFS_VEC8BIT_3
+#
+gap> v := V8([]);; ADD_COEFFS_VEC8BIT_3(v, empty, o);
+0
+gap> v;
+< mutable compressed vector length 0 over GF(5) >
+
+# bad arguments
+gap> ADD_COEFFS_VEC8BIT_3(fail, empty, o);
+Error, ADD_COEFFS_VEC8BIT_3: <vec1> must belong to Is8BitVectorRep (not the va\
+lue 'fail')
+gap> ADD_COEFFS_VEC8BIT_3(v, fail, o);
+Error, ADD_COEFFS_VEC8BIT_3: <vec2> must belong to Is8BitVectorRep (not the va\
+lue 'fail')
+gap> ADD_COEFFS_VEC8BIT_3(v, empty, fail);
+0
+
+#
+# ADD_COEFFS_VEC8BIT_2
+#
+gap> v := V8([]);; ADD_COEFFS_VEC8BIT_2(v, empty);
+0
+gap> v;
+< mutable compressed vector length 0 over GF(5) >
+
+# bad arguments
+gap> ADD_COEFFS_VEC8BIT_2(fail, empty);
+Error, ADD_COEFFS_VEC8BIT_2: <vec1> must belong to Is8BitVectorRep (not the va\
+lue 'fail')
+gap> ADD_COEFFS_VEC8BIT_2(v, fail);
+Error, ADD_COEFFS_VEC8BIT_2: <vec2> must belong to Is8BitVectorRep (not the va\
+lue 'fail')
+
+#
+# SHIFT_VEC8BIT_LEFT
+#
+gap> v := V8([]);; SHIFT_VEC8BIT_LEFT(v, 3);; v = empty;
+true
+
+# bad arguments
+gap> SHIFT_VEC8BIT_LEFT(fail, 3);
+Error, SHIFT_VEC8BIT_LEFT: <vec> must belong to Is8BitVectorRep (not the value\
+ 'fail')
+gap> SHIFT_VEC8BIT_LEFT(v, fail);
+Error, SHIFT_VEC8BIT_LEFT: <amount> must be a non-negative small integer (not \
+the value 'fail')
+
+#
+# SHIFT_VEC8BIT_RIGHT
+#
+gap> v := V8([]);; SHIFT_VEC8BIT_RIGHT(v, 3, z);; v = V8([z, z, z]);
+true
+
+# bad arguments
+gap> SHIFT_VEC8BIT_RIGHT(fail, 3, z);
+Error, SHIFT_VEC8BIT_RIGHT: <vec> must belong to Is8BitVectorRep (not the valu\
+e 'fail')
+gap> SHIFT_VEC8BIT_RIGHT(v, fail, z);
+Error, SHIFT_VEC8BIT_RIGHT: <amount> must be a non-negative small integer (not\
+ the value 'fail')
+gap> SHIFT_VEC8BIT_RIGHT(v, 3, fail);
+Error, SHIFT_VEC8BIT_RIGHT: <zero> must be a finite field element (not the val\
+ue 'fail')
+
+#
+# RESIZE_VEC8BIT
+#
+gap> v := V8([]);; RESIZE_VEC8BIT(v, 2);; v = V8([z, z]);
+true
+
+# bad arguments
+gap> RESIZE_VEC8BIT(fail, 2);
+Error, RESIZE_VEC8BIT: <vec> must belong to Is8BitVectorRep (not the value 'fa\
+il')
+gap> RESIZE_VEC8BIT(v, fail);
+Error, RESIZE_VEC8BIT: <newsize> must be a non-negative small integer (not the\
+ value 'fail')
+
+#
+# RIGHTMOST_NONZERO_VEC8BIT
+#
+gap> RIGHTMOST_NONZERO_VEC8BIT(empty);
+0
+gap> RIGHTMOST_NONZERO_VEC8BIT(V8([z, o]));
+2
+
+# bad arguments
+gap> RIGHTMOST_NONZERO_VEC8BIT(fail);
+Error, RIGHTMOST_NONZERO_VEC8BIT: <vec> must belong to Is8BitVectorRep (not th\
+e value 'fail')
+
+#
+# PROD_COEFFS_VEC8BIT
+#
+gap> PROD_COEFFS_VEC8BIT(empty, 0, empty, 0);
+< mutable compressed vector length 0 over GF(5) >
+gap> PROD_COEFFS_VEC8BIT(one, 1, one, 1);
+[ Z(5)^0 ]
+
+# bad arguments
+gap> PROD_COEFFS_VEC8BIT(fail, 0, empty, 0);
+"TRY_NEXT_METHOD"
+gap> PROD_COEFFS_VEC8BIT(empty, fail, empty, 0);
+Error, PROD_COEFFS_VEC8BIT: <ll> must be a non-negative small integer (not the\
+ value 'fail')
+gap> PROD_COEFFS_VEC8BIT(empty, 0, fail, 0);
+Error, Cannot convert a vector compressed over GF(17) to small field GF(5)
+gap> PROD_COEFFS_VEC8BIT(empty, 0, empty, fail);
+Error, PROD_COEFFS_VEC8BIT: <lr> must be a non-negative small integer (not the\
+ value 'fail')
+
+#
+# REDUCE_COEFFS_VEC8BIT
+#
+gap> s := MAKE_SHIFTED_COEFFS_VEC8BIT(V8([o]), 1);;
+gap> v := V8([o]);; REDUCE_COEFFS_VEC8BIT(v, 1, s);
+0
+gap> v;
+< mutable compressed vector length 0 over GF(5) >
+
+# bad arguments
+gap> REDUCE_COEFFS_VEC8BIT(fail, 1, s);
+Error, REDUCE_COEFFS_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the val\
+ue 'fail')
+gap> REDUCE_COEFFS_VEC8BIT(v, fail, s);
+Error, REDUCE_COEFFS_VEC8BIT: <ll> must be a non-negative small integer (not t\
+he value 'fail')
+gap> REDUCE_COEFFS_VEC8BIT(v, 1, fail);
+fail
+
+#
+# QUOTREM_COEFFS_VEC8BIT
+#
+gap> s := MAKE_SHIFTED_COEFFS_VEC8BIT(V8([o]), 1);;
+gap> QUOTREM_COEFFS_VEC8BIT(empty, 0, s);
+[ < mutable compressed vector length 0 over GF(5) >, 
+  < mutable compressed vector length 0 over GF(5) > ]
+
+# bad arguments
+gap> QUOTREM_COEFFS_VEC8BIT(fail, 0, s);
+Error, QUOTREM_COEFFS_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the va\
+lue 'fail')
+gap> QUOTREM_COEFFS_VEC8BIT(empty, fail, s);
+Error, QUOTREM_COEFFS_VEC8BIT: <ll> must be a non-negative small integer (not \
+the value 'fail')
+gap> QUOTREM_COEFFS_VEC8BIT(empty, 0, fail);
+Error, QUOTREM_COEFFS_VEC8BIT: <vrshifted> must be a plain list (not the value\
+ 'fail')
+
+#
+# MAKE_SHIFTED_COEFFS_VEC8BIT
+#
+gap> s := MAKE_SHIFTED_COEFFS_VEC8BIT(V8([o]), 1);; s[4];
+1
+gap> s[5];
+Z(5)^0
+
+# bad arguments
+gap> MAKE_SHIFTED_COEFFS_VEC8BIT(fail, 1);
+Error, MAKE_SHIFTED_COEFFS_VEC8BIT: <vr> must belong to Is8BitVectorRep (not t\
+he value 'fail')
+gap> MAKE_SHIFTED_COEFFS_VEC8BIT(V8([o]), fail);
+Error, MAKE_SHIFTED_COEFFS_VEC8BIT: <lr> must be a non-negative small integer \
+(not the value 'fail')
+
+#
+# DISTANCE_DISTRIB_VEC8BITS
+#
+gap> d := [0, 0];; DISTANCE_DISTRIB_VEC8BITS(Veclis8([one]), oneZero, d);; d;
+[ 1, 4 ]
+
+# bad arguments
+gap> DISTANCE_DISTRIB_VEC8BITS(fail, oneZero, d);
+Error, DISTANCE_DISTRIB_VEC8BITS: <veclis> must be a plain list (not the value\
+ 'fail')
+gap> DISTANCE_DISTRIB_VEC8BITS(Veclis8([one]), fail, d);
+Error, DISTANCE_DISTRIB_VEC8BITS: <vec> must belong to Is8BitVectorRep (not th\
+e value 'fail')
+gap> DISTANCE_DISTRIB_VEC8BITS(Veclis8([one]), oneZero, fail);
+Error, DISTANCE_DISTRIB_VEC8BITS: <d> must be a plain list (not the value 'fai\
+l')
+
+#
+# A_CLOSEST_VEC8BIT
+#
+gap> A_CLOSEST_VEC8BIT(Veclis8([one]), one, 0, 0);
+[ Z(5)^0 ]
+
+# bad arguments
+gap> A_CLOSEST_VEC8BIT(fail, one, 0, 0);
+Error, A_CLOSEST_VEC8BIT: <veclis> must be a plain list (not the value 'fail')
+gap> A_CLOSEST_VEC8BIT(Veclis8([one]), fail, 0, 0);
+Error, A_CLOSEST_VEC8BIT: <vec> must belong to Is8BitVectorRep (not the value \
+'fail')
+gap> A_CLOSEST_VEC8BIT(Veclis8([one]), one, fail, 0);
+Error, A_CLOSEST_VEC8BIT: <cnt> must be a non-negative small integer (not the \
+value 'fail')
+gap> A_CLOSEST_VEC8BIT(Veclis8([one]), one, 0, fail);
+Error, A_CLOSEST_VEC8BIT: <stop> must be a non-negative small integer (not the\
+ value 'fail')
+
+#
+# A_CLOSEST_VEC8BIT_COORDS
+#
+gap> A_CLOSEST_VEC8BIT_COORDS(Veclis8([one]), one, 0, 0);
+[ [ Z(5)^0 ], [ 1 ] ]
+
+# bad arguments
+gap> A_CLOSEST_VEC8BIT_COORDS(fail, one, 0, 0);
+Error, A_CLOSEST_VEC8BIT_COORDS: <veclis> must be a plain list (not the value \
+'fail')
+gap> A_CLOSEST_VEC8BIT_COORDS(Veclis8([one]), fail, 0, 0);
+Error, A_CLOSEST_VEC8BIT_COORDS: <vec> must belong to Is8BitVectorRep (not the\
+ value 'fail')
+gap> A_CLOSEST_VEC8BIT_COORDS(Veclis8([one]), one, fail, 0);
+Error, A_CLOSEST_VEC8BIT_COORDS: <cnt> must be a non-negative small integer (n\
+ot the value 'fail')
+gap> A_CLOSEST_VEC8BIT_COORDS(Veclis8([one]), one, 0, fail);
+Error, A_CLOSEST_VEC8BIT_COORDS: <stop> must be a non-negative small integer (\
+not the value 'fail')
+
+#
+# COSET_LEADERS_INNER_8BITS
+#
+gap> leaders := [Immutable(oneZero)];; leaders[6] := false;;
+gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), 1, 1, leaders, f5);
+4
+gap> leaders[2];
+[ Z(5)^0 ]
+
+# bad arguments
+gap> COSET_LEADERS_INNER_8BITS(fail, 1, 1, leaders, f5);
+Error, COSET_LEADERS_INNER_8BITS: <veclis> must be a plain list (not the value\
+ 'fail')
+gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), fail, 1, leaders, f5);
+Error, COSET_LEADERS_INNER_8BITS: <weight> must be a small integer (not the va\
+lue 'fail')
+gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), 1, fail, leaders, f5);
+Error, COSET_LEADERS_INNER_8BITS: <tofind> must be a small integer (not the va\
+lue 'fail')
+gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), 1, 1, fail, f5);
+Error, COSET_LEADERS_INNER_8BITS: <leaders> must be a plain list (not the valu\
+e 'fail')
+gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), 1, 1, leaders, fail);
+Error, COSET_LEADERS_INNER_8BITS: <felts> must be a plain list (not the value \
+'fail')
+
+#
+# SEMIECHELON_LIST_VEC8BITS
+#
+gap> s := SEMIECHELON_LIST_VEC8BITS([one]);; s.heads = [1] and s.vectors = [one];
+true
+
+# bad arguments
+gap> SEMIECHELON_LIST_VEC8BITS(fail);
+Error, SEMIECHELON_LIST_VEC8BITS: <mat> must be a plain list (not the value 'f\
+ail')
+
+#
+# SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS
+#
+gap> s := SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS([one]);; s.heads = [1] and s.vectors = [one] and s.coeffs = [one];
+true
+
+# bad arguments
+gap> SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS(fail);
+Error, SEMIECHELON_LIST_VEC8BITS_TRANSFORMATIONS: <mat> must be a plain list (\
+not the value 'fail')
+
+#
+# TRIANGULIZE_LIST_VEC8BITS
+#
+gap> m := [one];; TRIANGULIZE_LIST_VEC8BITS(m);; m = [one];
+true
+
+# bad arguments
+gap> TRIANGULIZE_LIST_VEC8BITS(fail);
+Error, TRIANGULIZE_LIST_VEC8BITS: <mat> must be a plain list (not the value 'f\
+ail')
+
+#
+# RANK_LIST_VEC8BITS
+#
+gap> RANK_LIST_VEC8BITS([one]);
+1
+
+# bad arguments
+gap> RANK_LIST_VEC8BITS(fail);
+Error, RANK_LIST_VEC8BITS: <mat> must be a plain list (not the value 'fail')
+
+#
+# DETERMINANT_LIST_VEC8BITS
+#
+gap> DETERMINANT_LIST_VEC8BITS([one]);
+Z(5)^0
+
+# bad arguments
+gap> DETERMINANT_LIST_VEC8BITS(fail);
+Error, DETERMINANT_LIST_VEC8BITS: <mat> must be a plain list (not the value 'f\
+ail')
+
+#
+# EQ_MAT8BIT_MAT8BIT
+#
+gap> EQ_MAT8BIT_MAT8BIT(Mx08(2), Mx08(2)) and EQ_MAT8BIT_MAT8BIT(ZeroRowMat8(), ZeroRowMat8());
+true
+
+# bad arguments
+gap> EQ_MAT8BIT_MAT8BIT(fail, Mx08(2));
+Error, EQ_MAT8BIT_MAT8BIT: <ml> must belong to Is8BitMatrixRep (not the value \
+'fail')
+gap> EQ_MAT8BIT_MAT8BIT(Mx08(2), fail);
+Error, EQ_MAT8BIT_MAT8BIT: <mr> must belong to Is8BitMatrixRep (not the value \
+'fail')
+
+#
+# LT_MAT8BIT_MAT8BIT
+#
+gap> LT_MAT8BIT_MAT8BIT(ZeroRowMat8(), Mx08(1)) and not LT_MAT8BIT_MAT8BIT(Mx08(1), ZeroRowMat8());
+true
+
+# bad arguments
+gap> LT_MAT8BIT_MAT8BIT(fail, Mx08(1));
+Error, LT_MAT8BIT_MAT8BIT: <ml> must belong to Is8BitMatrixRep (not the value \
+'fail')
+gap> LT_MAT8BIT_MAT8BIT(ZeroRowMat8(), fail);
+Error, LT_MAT8BIT_MAT8BIT: <mr> must belong to Is8BitMatrixRep (not the value \
+'fail')
+
+#
+# TRANSPOSED_MAT8BIT
+#
+gap> TRANSPOSED_MAT8BIT(ZeroRowMat8());
+Error, TRANSPOSED_MAT8BIT: compressed 8bit matrices with empty rows are not su\
+pported
+gap> EQ_MAT8BIT_MAT8BIT(TRANSPOSED_MAT8BIT(Mx08(2)), ZeroRowMat8());
+true
+
+# bad arguments
 gap> TRANSPOSED_MAT8BIT(fail);
 Error, TRANSPOSED_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value\
  'fail')
+
+#
+# KRONECKERPRODUCT_MAT8BIT_MAT8BIT
+#
+gap> KRONECKERPRODUCT_MAT8BIT_MAT8BIT(ZeroRowMat8(), ZeroRowMat8());
+Error, KRONECKERPRODUCT_MAT8BIT_MAT8BIT: compressed 8bit matrices with empty r\
+ows are not supported
+gap> KRONECKERPRODUCT_MAT8BIT_MAT8BIT(Mx08(2), M8([[o]])) = Mx08(2);
+true
+
+# bad arguments
+gap> KRONECKERPRODUCT_MAT8BIT_MAT8BIT(fail, ZeroRowMat8());
+Error, KRONECKERPRODUCT_MAT8BIT_MAT8BIT: <matl> must belong to Is8BitMatrixRep\
+ (not the value 'fail')
+gap> KRONECKERPRODUCT_MAT8BIT_MAT8BIT(ZeroRowMat8(), fail);
+Error, KRONECKERPRODUCT_MAT8BIT_MAT8BIT: <matr> must belong to Is8BitMatrixRep\
+ (not the value 'fail')
+
+#
+# MAT_ELM_MAT8BIT
+#
+gap> MAT_ELM_MAT8BIT(M8([[o]]), 1, 1);
+Z(5)^0
+
+# bad arguments
+gap> MAT_ELM_MAT8BIT(fail, 1, 1);
+Error, MAT_ELM_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the value 'f\
+ail')
+gap> MAT_ELM_MAT8BIT(M8([[o]]), fail, 1);
+Error, MAT_ELM_MAT8BIT: <row> must be a positive small integer (not the value \
+'fail')
+gap> MAT_ELM_MAT8BIT(M8([[o]]), 1, fail);
+Error, MAT_ELM_MAT8BIT: <col> must be a positive small integer (not the value \
+'fail')
+
+#
+# SET_MAT_ELM_MAT8BIT
+#
+gap> m := M8([[z]]);; SET_MAT_ELM_MAT8BIT(m, 1, 1, o);; m = M8([[o]]);
+true
+
+# bad arguments
+gap> SET_MAT_ELM_MAT8BIT(fail, 1, 1, o);
+Error, SET_MAT_ELM_MAT8BIT: <mat> must belong to Is8BitMatrixRep (not the valu\
+e 'fail')
+gap> SET_MAT_ELM_MAT8BIT(m, fail, 1, o);
+Error, SET_MAT_ELM_MAT8BIT: <row> must be a positive small integer (not the va\
+lue 'fail')
+gap> SET_MAT_ELM_MAT8BIT(m, 1, fail, o);
+Error, SET_MAT_ELM_MAT8BIT: <col> must be a positive small integer (not the va\
+lue 'fail')
+gap> SET_MAT_ELM_MAT8BIT(m, 1, 1, fail);
+Error, Attempt to convert locked compressed vector to plain list
 
 #
 gap> STOP_TEST("kernel/vec8bit.tst");

--- a/tst/testinstall/kernel/vec8bit.tst
+++ b/tst/testinstall/kernel/vec8bit.tst
@@ -167,7 +167,8 @@ Error, ELMS_VEC8BIT: <poss> must be a plain list (not the value 'fail')
 # ELMS_VEC8BIT_RANGE
 #
 gap> ELMS_VEC8BIT_RANGE(one, [1 .. 1]);
-[ Z(5)^0 ]
+Error, ELMS_VEC8BIT_RANGE: <range> must be a range (not a strictly-sorted plai\
+n list of cyclotomics)
 gap> ELMS_VEC8BIT_RANGE(pair, [1 .. 2]) = pair;
 true
 
@@ -176,8 +177,7 @@ gap> ELMS_VEC8BIT_RANGE(fail, [1 .. 1]);
 Error, ELMS_VEC8BIT_RANGE: <list> must belong to Is8BitVectorRep (not the valu\
 e 'fail')
 gap> ELMS_VEC8BIT_RANGE(one, fail);
-Error, ELMS_VEC8BIT_RANGE: Range includes indices which are too high or too lo\
-w
+Error, ELMS_VEC8BIT_RANGE: <range> must be a range (not the value 'fail')
 
 #
 # ASS_VEC8BIT
@@ -809,7 +809,8 @@ gap> ADD_COEFFS_VEC8BIT_3(v, fail, o);
 Error, ADD_COEFFS_VEC8BIT_3: <vec2> must belong to Is8BitVectorRep (not the va\
 lue 'fail')
 gap> ADD_COEFFS_VEC8BIT_3(v, empty, fail);
-0
+Error, ADD_COEFFS_VEC8BIT_3: <mult> must be a finite field element (not the va\
+lue 'fail')
 
 #
 # ADD_COEFFS_VEC8BIT_2
@@ -895,12 +896,14 @@ gap> PROD_COEFFS_VEC8BIT(one, 1, one, 1);
 
 # bad arguments
 gap> PROD_COEFFS_VEC8BIT(fail, 0, empty, 0);
-"TRY_NEXT_METHOD"
+Error, PROD_COEFFS_VEC8BIT: <vl> must belong to Is8BitVectorRep (not the value\
+ 'fail')
 gap> PROD_COEFFS_VEC8BIT(empty, fail, empty, 0);
 Error, PROD_COEFFS_VEC8BIT: <ll> must be a non-negative small integer (not the\
  value 'fail')
 gap> PROD_COEFFS_VEC8BIT(empty, 0, fail, 0);
-Error, Cannot convert a vector compressed over GF(17) to small field GF(5)
+Error, PROD_COEFFS_VEC8BIT: <vr> must belong to Is8BitVectorRep (not the value\
+ 'fail')
 gap> PROD_COEFFS_VEC8BIT(empty, 0, empty, fail);
 Error, PROD_COEFFS_VEC8BIT: <lr> must be a non-negative small integer (not the\
  value 'fail')
@@ -922,7 +925,8 @@ gap> REDUCE_COEFFS_VEC8BIT(v, fail, s);
 Error, REDUCE_COEFFS_VEC8BIT: <ll> must be a non-negative small integer (not t\
 he value 'fail')
 gap> REDUCE_COEFFS_VEC8BIT(v, 1, fail);
-fail
+Error, REDUCE_COEFFS_VEC8BIT: <vrshifted> must be a plain list (not the value \
+'fail')
 
 #
 # QUOTREM_COEFFS_VEC8BIT
@@ -1019,11 +1023,12 @@ not the value 'fail')
 # COSET_LEADERS_INNER_8BITS
 #
 gap> leaders := [Immutable(oneZero)];; leaders[6] := false;;
-gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), 1, 1, leaders, f5);
-4
-gap> leaders[2];
-[ Z(5)^0 ]
 
+#gap> COSET_LEADERS_INNER_8BITS(Veclis8([one]), 1, 1, leaders, f5);
+#4
+#gap> leaders[2];
+#[ Z(5)^0 ]
+#
 # bad arguments
 gap> COSET_LEADERS_INNER_8BITS(fail, 1, 1, leaders, f5);
 Error, COSET_LEADERS_INNER_8BITS: <veclis> must be a plain list (not the value\

--- a/tst/testinstall/kernel/vecgf2.tst
+++ b/tst/testinstall/kernel/vecgf2.tst
@@ -2,10 +2,981 @@
 # Tests for functions defined in src/vecgf2.c
 #
 gap> START_TEST("kernel/vecgf2.tst");
+gap> z := 0*Z(2);;
+gap> o := Z(2)^0;;
+gap> V2 := function(list)
+> local v;
+>   v := ShallowCopy(list);
+>   CONV_GF2VEC(v);
+>   return v;
+> end;;
+gap> M2 := function(rows)
+> local m, i;
+>   m := List(rows, ShallowCopy);
+>   for i in [1 .. Length(m)] do
+>     CONV_GF2VEC(m[i]);
+>   od;
+>   CONV_GF2MAT(m);
+>   return m;
+> end;;
+gap> Mx02 := n -> M2(List([1 .. n], i -> []));;
+gap> Veclis2 := function(rows)
+> local f, fdi, fdip, veclis, row, mults, j, mult;
+>   f := AsSSortedList(GF(2));
+>   fdi := [];
+>   for j in [2 .. Length(f)] do
+>     fdi[j - 1] := f[j] - f[j - 1];
+>   od;
+>   Add(fdi, -Last(f));
+>   fdip := List(fdi, x -> Position(fdi, x));
+>   veclis := [];
+>   for row in rows do
+>     mults := [];
+>     mults[Length(fdi) + 1] := false;
+>     for j in [1 .. Length(fdi)] do
+>       if fdip[j] < j then
+>         mult := mults[fdip[j]];
+>       else
+>         mult := fdi[j] * row;
+>       fi;
+>       mults[j] := mult;
+>     od;
+>     Add(veclis, mults);
+>   od;
+>   return veclis;
+> end;;
+gap> empty := V2([]);;
+gap> one := V2([o]);;
+gap> oneZero := V2([z]);;
 
 #
+# CONV_GF2VEC
+#
+gap> v := [];; CONV_GF2VEC(v); v;
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> CONV_GF2VEC(fail);
+Error, CONV_GF2VEC: <list> must be a small list (not the value 'fail')
+
+#
+# COPY_GF2VEC
+#
+gap> v := COPY_GF2VEC([]);
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> COPY_GF2VEC(fail);
+Error, COPY_GF2VEC: argument must be a list of GF2 elements
+
+#
+# PLAIN_GF2VEC
+#
+gap> v := V2([]);; PLAIN_GF2VEC(v);; IsPlistRep(v) and Length(v) = 0;
+true
+
+# bad arguments
+gap> PLAIN_GF2VEC(fail);
+Error, PLAIN_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+
+#
+# PLAIN_GF2MAT
+#
+gap> m := Mx02(2);; PLAIN_GF2MAT(m);; IsPlistRep(m) and m = [[], []];
+true
+
+# bad arguments
+gap> PLAIN_GF2MAT(fail);
+Error, PLAIN_GF2MAT: <list> must be a GF2 matrix (not the value 'fail')
+
+#
+# EQ_GF2VEC_GF2VEC
+#
+gap> EQ_GF2VEC_GF2VEC(empty, empty);
+true
+gap> EQ_GF2VEC_GF2VEC(empty, one);
+false
+
+# bad arguments
+gap> EQ_GF2VEC_GF2VEC(fail, empty);
+Error, EQ_GF2VEC_GF2VEC: <vl> must be a GF2 vector (not the value 'fail')
+gap> EQ_GF2VEC_GF2VEC(empty, fail);
+Error, EQ_GF2VEC_GF2VEC: <vr> must be a GF2 vector (not the value 'fail')
+
+#
+# LT_GF2VEC_GF2VEC
+#
+gap> LT_GF2VEC_GF2VEC(oneZero, one);
+true
+gap> LT_GF2VEC_GF2VEC(one, oneZero);
+false
+
+# bad arguments
+gap> LT_GF2VEC_GF2VEC(fail, one);
+Error, LT_GF2VEC_GF2VEC: <vl> must be a GF2 vector (not the value 'fail')
+gap> LT_GF2VEC_GF2VEC(oneZero, fail);
+Error, LT_GF2VEC_GF2VEC: <vr> must be a GF2 vector (not the value 'fail')
+
+#
+# EQ_GF2MAT_GF2MAT
+#
+gap> EQ_GF2MAT_GF2MAT(Mx02(2), Mx02(2));
+true
+gap> EQ_GF2MAT_GF2MAT(Mx02(1), Mx02(2));
+false
+
+# bad arguments
+gap> EQ_GF2MAT_GF2MAT(fail, Mx02(2));
+Error, EQ_GF2MAT_GF2MAT: <ml> must be a GF2 matrix (not the value 'fail')
+gap> EQ_GF2MAT_GF2MAT(Mx02(2), fail);
+Error, EQ_GF2MAT_GF2MAT: <mr> must be a GF2 matrix (not the value 'fail')
+
+#
+# LT_GF2MAT_GF2MAT
+#
+gap> LT_GF2MAT_GF2MAT(Mx02(1), Mx02(2));
+true
+gap> LT_GF2MAT_GF2MAT(Mx02(2), Mx02(1));
+false
+
+# bad arguments
+gap> LT_GF2MAT_GF2MAT(fail, Mx02(2));
+Error, LT_GF2MAT_GF2MAT: <ml> must be a GF2 matrix (not the value 'fail')
+gap> LT_GF2MAT_GF2MAT(Mx02(1), fail);
+Error, LT_GF2MAT_GF2MAT: <mr> must be a GF2 matrix (not the value 'fail')
+
+#
+# LEN_GF2VEC
+#
+gap> LEN_GF2VEC(empty);
+0
+gap> LEN_GF2VEC(V2([o, z]));
+2
+
+# bad arguments
+gap> LEN_GF2VEC(fail);
+Error, LEN_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+
+#
+# ELM0_GF2VEC
+#
+gap> ELM0_GF2VEC(empty, 1);
+fail
+gap> ELM0_GF2VEC(one, 1);
+Z(2)^0
+
+# bad arguments
+gap> ELM0_GF2VEC(fail, 1);
+Error, ELM0_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+gap> ELM0_GF2VEC(empty, fail);
+Error, ELM0_GF2VEC: <pos> must be a small integer (not the value 'fail')
+
+#
+# ELM_GF2VEC
+#
+gap> ELM_GF2VEC(one, 1);
+Z(2)^0
+
+# bad arguments
+gap> ELM_GF2VEC(fail, 1);
+Error, ELM_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+gap> ELM_GF2VEC(one, fail);
+Error, ELM_GF2VEC: <pos> must be a small integer (not the value 'fail')
+
+#
+# ELMS_GF2VEC
+#
+gap> ELMS_GF2VEC(empty, []) = empty;
+true
+gap> ELMS_GF2VEC(V2([o, z]), [1]);
+<a GF2 vector of length 1>
+
+# bad arguments
+gap> ELMS_GF2VEC(fail, []);
+Error, ELMS_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+gap> ELMS_GF2VEC(empty, fail);
+Error, Length: <list> must be a list (not the value 'fail')
+
+#
+# ASS_GF2VEC
+#
+gap> v := V2([]);; ASS_GF2VEC(v, 1, z);; v = oneZero;
+true
+
+# bad arguments
+gap> ASS_GF2VEC(fail, 1, z);
+Error, ASS_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+gap> ASS_GF2VEC(v, fail, z);
+Error, ASS_GF2VEC: <pos> must be a small integer (not the value 'fail')
+gap> ASS_GF2VEC(v, 1, fail);
+
+#
+# ELM_GF2MAT
+#
+gap> ELM_GF2MAT(Mx02(2), 1);
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> ELM_GF2MAT(fail, 1);
+Error, ELM_GF2MAT: <mat> must be a GF2 matrix (not the value 'fail')
+gap> ELM_GF2MAT(Mx02(2), fail);
+Error, ELM_GF2MAT: <row> must be a small integer (not the value 'fail')
+
+#
+# ASS_GF2MAT
+#
+gap> m := M2([[]]);; ASS_GF2MAT(m, 2, empty);; m = Mx02(2);
+true
+
+# bad arguments
+gap> ASS_GF2MAT(fail, 2, empty);
+Error, ASS_GF2MAT: <list> must be a GF2 matrix (not the value 'fail')
+gap> ASS_GF2MAT(m, fail, empty);
+Error, ASS_GF2MAT: <pos> must be a small integer (not the value 'fail')
+gap> ASS_GF2MAT(m, 2, fail);
+
+#
+# SWAP_ROWS_GF2MAT
+#
+gap> m := M2([[o], [z]]);; SWAP_ROWS_GF2MAT(m, 1, 2);; m = M2([[z], [o]]);
+true
+
+# bad arguments
+gap> SWAP_ROWS_GF2MAT(fail, 1, 2);
+Error, SWAP_ROWS_GF2MAT: <mat> must be a GF2 matrix (not the value 'fail')
+gap> SWAP_ROWS_GF2MAT(m, fail, 2);
+Error, SWAP_ROWS_GF2MAT: <row1> must be a small integer (not the value 'fail')
+gap> SWAP_ROWS_GF2MAT(m, 1, fail);
+Error, SWAP_ROWS_GF2MAT: <row2> must be a small integer (not the value 'fail')
+
+#
+# SWAP_COLS_GF2MAT
+#
+gap> m := M2([[o, z]]);; SWAP_COLS_GF2MAT(m, 1, 2);; m = M2([[z, o]]);
+true
+
+# bad arguments
+gap> SWAP_COLS_GF2MAT(fail, 1, 2);
+Error, SWAP_COLS_GF2MAT: <mat> must be a GF2 matrix (not the value 'fail')
+gap> SWAP_COLS_GF2MAT(m, fail, 2);
+Error, SWAP_COLS_GF2MAT: <col1> must be a small integer (not the value 'fail')
+gap> SWAP_COLS_GF2MAT(m, 1, fail);
+Error, SWAP_COLS_GF2MAT: <col2> must be a small integer (not the value 'fail')
+
+#
+# UNB_GF2VEC
+#
+gap> v := V2([o]);; UNB_GF2VEC(v, 1);; v = empty;
+true
+
+# bad arguments
+gap> UNB_GF2VEC(fail, 1);
+Error, UNB_GF2VEC: <list> must be a GF2 vector (not the value 'fail')
+gap> UNB_GF2VEC(v, fail);
+Error, UNB_GF2VEC: <pos> must be a small integer (not the value 'fail')
+
+#
+# UNB_GF2MAT
+#
+gap> m := M2([[]]);; UNB_GF2MAT(m, 1);; m = [];
+true
+
+# bad arguments
+gap> UNB_GF2MAT(fail, 1);
+Error, UNB_GF2MAT: <list> must be a GF2 matrix (not the value 'fail')
+gap> UNB_GF2MAT(m, fail);
+Error, UNB_GF2MAT: <pos> must be a small integer (not the value 'fail')
+
+#
+# ZERO_GF2VEC
+#
+gap> ZERO_GF2VEC(empty);
+<a GF2 vector of length 0>
+gap> ZERO_GF2VEC(V2([o, z]));
+<a GF2 vector of length 2>
+
+# bad arguments
+gap> ZERO_GF2VEC(fail);
+Error, ZERO_GF2VEC: <mat> must be a GF2 vector (not the value 'fail')
+
+#
+# ZERO_GF2VEC_2
+#
+gap> ZERO_GF2VEC_2(0);
+<a GF2 vector of length 0>
+gap> ZERO_GF2VEC_2(2);
+<a GF2 vector of length 2>
+
+# bad arguments
+gap> ZERO_GF2VEC_2(fail);
+Error, ZERO_GF2VEC_2: <len> must be a non-negative small integer (not the valu\
+e 'fail')
+
+#
+# INV_GF2MAT_MUTABLE
+#
+gap> INV_GF2MAT_MUTABLE(M2([[o]])) = M2([[o]]);
+true
+
+# bad arguments
+gap> INV_GF2MAT_MUTABLE(fail);
+Error, INV_GF2MAT_MUTABLE: <mat> must be a GF2 matrix (not the value 'fail')
+
+#
+# INV_GF2MAT_SAME_MUTABILITY
+#
+gap> INV_GF2MAT_SAME_MUTABILITY(M2([[o]])) = M2([[o]]);
+true
+
+# bad arguments
+gap> INV_GF2MAT_SAME_MUTABILITY(fail);
+Error, INV_GF2MAT_SAME_MUTABILITY: <mat> must be a GF2 matrix (not the value '\
+fail')
+
+#
+# INV_GF2MAT_IMMUTABLE
+#
+gap> INV_GF2MAT_IMMUTABLE(Immutable(M2([[o]]))) = Immutable(M2([[o]]));
+true
+
+# bad arguments
+gap> INV_GF2MAT_IMMUTABLE(fail);
+Error, INV_GF2MAT_IMMUTABLE: <mat> must be a GF2 matrix (not the value 'fail')
+
+#
+# INV_PLIST_GF2VECS_DESTRUCTIVE
+#
+gap> m := [one];; INV_PLIST_GF2VECS_DESTRUCTIVE(m) = [one] and m = [one];
+true
+
+# bad arguments
+gap> INV_PLIST_GF2VECS_DESTRUCTIVE(fail);
+Error, INV_PLIST_GF2VECS_DESTRUCTIVE: <list> must be a plain list (not the val\
+ue 'fail')
+
+#
+# SUM_GF2VEC_GF2VEC
+#
+gap> SUM_GF2VEC_GF2VEC(empty, empty);
+<a GF2 vector of length 0>
+gap> SUM_GF2VEC_GF2VEC(one, one);
+<a GF2 vector of length 1>
+
+# bad arguments
+gap> SUM_GF2VEC_GF2VEC(fail, empty);
+Error, SUM_GF2VEC_GF2VEC: <vl> must be a GF2 vector (not the value 'fail')
+gap> SUM_GF2VEC_GF2VEC(empty, fail);
+Error, SUM_GF2VEC_GF2VEC: <vr> must be a GF2 vector (not the value 'fail')
+
+#
+# PROD_GF2VEC_GF2VEC
+#
+gap> PROD_GF2VEC_GF2VEC(one, one);
+Z(2)^0
+
+# bad arguments
+gap> PROD_GF2VEC_GF2VEC(fail, one);
+Error, PROD_GF2VEC_GF2VEC: <vl> must be a GF2 vector (not the value 'fail')
+gap> PROD_GF2VEC_GF2VEC(one, fail);
+Error, PROD_GF2VEC_GF2VEC: <vr> must be a GF2 vector (not the value 'fail')
+
+#
+# PROD_GF2VEC_GF2MAT
+#
+gap> PROD_GF2VEC_GF2MAT(empty, Mx02(2));
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> PROD_GF2VEC_GF2MAT(fail, Mx02(2));
+Error, PROD_GF2VEC_GF2MAT: <vl> must be a GF2 vector (not the value 'fail')
+gap> PROD_GF2VEC_GF2MAT(empty, fail);
+Error, PROD_GF2VEC_GF2MAT: <vr> must be a GF2 matrix (not the value 'fail')
+
+#
+# PROD_GF2MAT_GF2VEC
+#
+gap> PROD_GF2MAT_GF2VEC(Mx02(2), empty);
+<a GF2 vector of length 2>
+
+# bad arguments
+gap> PROD_GF2MAT_GF2VEC(fail, empty);
+Error, PROD_GF2MAT_GF2VEC: <vl> must be a GF2 matrix (not the value 'fail')
+gap> PROD_GF2MAT_GF2VEC(Mx02(2), fail);
+Error, PROD_GF2MAT_GF2VEC: <vr> must be a GF2 vector (not the value 'fail')
+
+#
+# PROD_GF2MAT_GF2MAT
+#
+gap> PROD_GF2MAT_GF2MAT(M2([[o], [z]]), Mx02(1)) = Mx02(2);
+true
+
+# bad arguments
+gap> PROD_GF2MAT_GF2MAT(fail, Mx02(1));
+Error, PROD_GF2MAT_GF2MAT: <ml> must be a GF2 matrix (not the value 'fail')
+gap> PROD_GF2MAT_GF2MAT(M2([[o], [z]]), fail);
+Error, PROD_GF2MAT_GF2MAT: <mr> must be a GF2 matrix (not the value 'fail')
+
+#
+# PROD_GF2MAT_GF2MAT_SIMPLE
+#
+gap> PROD_GF2MAT_GF2MAT_SIMPLE(M2([[o], [z]]), Mx02(1)) = Mx02(2);
+true
+
+# bad arguments
+gap> PROD_GF2MAT_GF2MAT_SIMPLE(fail, Mx02(1));
+Error, PROD_GF2MAT_GF2MAT_SIMPLE: <ml> must be a GF2 matrix (not the value 'fa\
+il')
+gap> PROD_GF2MAT_GF2MAT_SIMPLE(M2([[o], [z]]), fail);
+Error, PROD_GF2MAT_GF2MAT_SIMPLE: <mr> must be a GF2 matrix (not the value 'fa\
+il')
+
+#
+# PROD_GF2MAT_GF2MAT_ADVANCED
+#
+gap> PROD_GF2MAT_GF2MAT_ADVANCED(M2([[o]]), M2([[o]]), 1, 1) = M2([[o]]);
+true
+
+# bad arguments
+gap> PROD_GF2MAT_GF2MAT_ADVANCED(fail, M2([[o]]), 1, 1);
+Error, PROD_GF2MAT_GF2MAT_ADVANCED: <ml> must be a GF2 matrix (not the value '\
+fail')
+gap> PROD_GF2MAT_GF2MAT_ADVANCED(M2([[o]]), fail, 1, 1);
+Error, PROD_GF2MAT_GF2MAT_ADVANCED: <mr> must be a GF2 matrix (not the value '\
+fail')
+gap> PROD_GF2MAT_GF2MAT_ADVANCED(M2([[o]]), M2([[o]]), fail, 1);
+Error, PROD_GF2MAT_GF2MAT_ADVANCED: <greaselevel> must be a small integer (not\
+ the value 'fail')
+gap> PROD_GF2MAT_GF2MAT_ADVANCED(M2([[o]]), M2([[o]]), 1, fail);
+Error, PROD_GF2MAT_GF2MAT_ADVANCED: <blocksize> must be a small integer (not t\
+he value 'fail')
+
+#
+# ADDCOEFFS_GF2VEC_GF2VEC_MULT
+#
+gap> v := V2([]);; ADDCOEFFS_GF2VEC_GF2VEC_MULT(v, empty, z);
+0
+gap> v;
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> ADDCOEFFS_GF2VEC_GF2VEC_MULT(fail, empty, z);
+Error, ADDCOEFFS_GF2VEC_GF2VEC_MULT: <vl> must be a GF2 vector (not the value \
+'fail')
+gap> ADDCOEFFS_GF2VEC_GF2VEC_MULT(v, fail, z);
+Error, ADDCOEFFS_GF2VEC_GF2VEC_MULT: <vr> must be a GF2 vector (not the value \
+'fail')
+gap> ADDCOEFFS_GF2VEC_GF2VEC_MULT(v, empty, fail);
+Error, ADDCOEFFS_GF2VEC_GF2VEC_MULT: <mul> must be a finite field element (not\
+ the value 'fail')
+
+#
+# ADDCOEFFS_GF2VEC_GF2VEC
+#
+gap> v := V2([]);; ADDCOEFFS_GF2VEC_GF2VEC(v, empty);
+0
+gap> v;
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> ADDCOEFFS_GF2VEC_GF2VEC(fail, empty);
+Error, ADDCOEFFS_GF2VEC_GF2VEC: <vl> must be a GF2 vector (not the value 'fail\
+')
+gap> ADDCOEFFS_GF2VEC_GF2VEC(v, fail);
+Error, ADDCOEFFS_GF2VEC_GF2VEC: <vr> must be a GF2 vector (not the value 'fail\
+')
+
+#
+# SHRINKCOEFFS_GF2VEC
+#
+gap> v := V2([o, z]);; SHRINKCOEFFS_GF2VEC(v);
+1
+gap> v;
+<a GF2 vector of length 1>
+
+# bad arguments
+gap> SHRINKCOEFFS_GF2VEC(fail);
+Error, SHRINKCOEFFS_GF2VEC: <vec> must be a GF2 vector (not the value 'fail')
+
+#
+# POSITION_NONZERO_GF2VEC
+#
+gap> POSITION_NONZERO_GF2VEC(empty, z);
+1
+gap> POSITION_NONZERO_GF2VEC(one, z);
+1
+
+# bad arguments
+gap> POSITION_NONZERO_GF2VEC(fail, z);
+Error, POSITION_NONZERO_GF2VEC: <vec> must be a GF2 vector (not the value 'fai\
+l')
+gap> POSITION_NONZERO_GF2VEC(empty, fail);
+1
+
+#
+# POSITION_NONZERO_GF2VEC3
+#
+gap> POSITION_NONZERO_GF2VEC3(empty, z, 1);
+1
+gap> POSITION_NONZERO_GF2VEC3(V2([z, o]), z, 2);
+3
+
+# bad arguments
+gap> POSITION_NONZERO_GF2VEC3(fail, z, 1);
+Error, POSITION_NONZERO_GF2VEC3: <vec> must be a GF2 vector (not the value 'fa\
+il')
+gap> POSITION_NONZERO_GF2VEC3(empty, fail, 1);
+1
+gap> POSITION_NONZERO_GF2VEC3(empty, z, fail);
+Error, POSITION_NONZERO_GF2VEC3: <from> must be a non-negative small integer (\
+not the value 'fail')
+
+#
+# MULT_VECTOR_GF2VECS_2
+#
+gap> v := V2([o]);; MULT_VECTOR_GF2VECS_2(v, o);; v = one;
+true
+
+# bad arguments
+gap> MULT_VECTOR_GF2VECS_2(fail, o);
+Error, MULT_VECTOR_GF2VECS_2: <vl> must be a GF2 vector (not the value 'fail')
+gap> MULT_VECTOR_GF2VECS_2(v, fail);
+Error, MULT_VECTOR_GF2VECS_2: <mul> must be a finite field element (not the va\
+lue 'fail')
+
+#
+# APPEND_GF2VEC
+#
+gap> v := V2([]);; APPEND_GF2VEC(v, one);; v = one;
+true
+
+# bad arguments
+gap> APPEND_GF2VEC(fail, one);
+Error, APPEND_GF2VEC: <vecl> must be a GF2 vector (not the value 'fail')
+gap> APPEND_GF2VEC(v, fail);
+Error, APPEND_GF2VEC: <vecr> must be a GF2 vector (not the value 'fail')
+
+#
+# SHALLOWCOPY_GF2VEC
+#
+gap> v := SHALLOWCOPY_GF2VEC(empty);; v = empty and not IsIdenticalObj(v, empty);
+true
+
+# bad arguments
+gap> SHALLOWCOPY_GF2VEC(fail);
+Error, SHALLOWCOPY_GF2VEC: <vec> must be a GF2 vector (not the value 'fail')
+
+#
+# NUMBER_GF2VEC
+#
+gap> NUMBER_GF2VEC(empty);
+1
+gap> NUMBER_GF2VEC(one);
+1
+
+# bad arguments
+gap> NUMBER_GF2VEC(fail);
+Error, NUMBER_GF2VEC: <vec> must be a GF2 vector (not the value 'fail')
+
+#
+# TRANSPOSED_GF2MAT
+#
+gap> TRANSPOSED_GF2MAT(Mx02(2));
+Error, row index 1 exceeds 0, the number of rows
+
+# bad arguments
 gap> TRANSPOSED_GF2MAT(fail);
-Error, TRANSPOSED_GF2MAT: Need compressed matrix over GF(2)
+Error, TRANSPOSED_GF2MAT: <mat> must be a GF2 matrix (not the value 'fail')
+
+#
+# DIST_GF2VEC_GF2VEC
+#
+gap> DIST_GF2VEC_GF2VEC(empty, empty);
+0
+gap> DIST_GF2VEC_GF2VEC(one, one);
+0
+
+# bad arguments
+gap> DIST_GF2VEC_GF2VEC(fail, empty);
+Error, DIST_GF2VEC_GF2VEC: <vl> must be a GF2 vector (not the value 'fail')
+gap> DIST_GF2VEC_GF2VEC(empty, fail);
+Error, DIST_GF2VEC_GF2VEC: <vr> must be a GF2 vector (not the value 'fail')
+
+#
+# DIST_VEC_CLOS_VEC
+#
+gap> d := [0, 0];; DIST_VEC_CLOS_VEC(Veclis2([one]), oneZero, d);; d;
+[ 1, 1 ]
+
+# bad arguments
+gap> DIST_VEC_CLOS_VEC(fail, oneZero, d);
+Error, DIST_VEC_CLOS_VEC: <veclis> must be a plain list (not the value 'fail')
+gap> DIST_VEC_CLOS_VEC(Veclis2([one]), fail, d);
+Error, DIST_VEC_CLOS_VEC: <vec> must be a GF2 vector (not the value 'fail')
+gap> DIST_VEC_CLOS_VEC(Veclis2([one]), oneZero, fail);
+Error, DIST_VEC_CLOS_VEC: <d> must be a plain list (not the value 'fail')
+
+#
+# SUM_GF2MAT_GF2MAT
+#
+gap> SUM_GF2MAT_GF2MAT(Mx02(2), Mx02(2)) = Mx02(2);
+true
+
+# bad arguments
+gap> SUM_GF2MAT_GF2MAT(fail, Mx02(2));
+Error, SUM_GF2MAT_GF2MAT: <matl> must be a GF2 matrix (not the value 'fail')
+gap> SUM_GF2MAT_GF2MAT(Mx02(2), fail);
+Error, SUM_GF2MAT_GF2MAT: <matr> must be a GF2 matrix (not the value 'fail')
+
+#
+# A_CLOS_VEC
+#
+gap> A_CLOS_VEC(Veclis2([one]), one, 0, 0);
+<a GF2 vector of length 1>
+
+# bad arguments
+gap> A_CLOS_VEC(fail, one, 0, 0);
+Error, A_CLOS_VEC: <veclis> must be a plain list (not the value 'fail')
+gap> A_CLOS_VEC(Veclis2([one]), fail, 0, 0);
+Error, A_CLOS_VEC: <vec> must be a GF2 vector (not the value 'fail')
+gap> A_CLOS_VEC(Veclis2([one]), one, fail, 0);
+Error, A_CLOS_VEC: <cnt> must be a non-negative small integer (not the value '\
+fail')
+gap> A_CLOS_VEC(Veclis2([one]), one, 0, fail);
+Error, A_CLOS_VEC: <stop> must be a non-negative small integer (not the value \
+'fail')
+
+#
+# A_CLOS_VEC_COORDS
+#
+gap> A_CLOS_VEC_COORDS(Veclis2([one]), one, 0, 0);
+[ <a GF2 vector of length 1>, [ 1 ] ]
+
+# bad arguments
+gap> A_CLOS_VEC_COORDS(fail, one, 0, 0);
+Error, A_CLOS_VEC_COORDS: <veclis> must be a plain list (not the value 'fail')
+gap> A_CLOS_VEC_COORDS(Veclis2([one]), fail, 0, 0);
+Error, A_CLOS_VEC_COORDS: <vec> must be a GF2 vector (not the value 'fail')
+gap> A_CLOS_VEC_COORDS(Veclis2([one]), one, fail, 0);
+Error, A_CLOS_VEC_COORDS: <cnt> must be a non-negative small integer (not the \
+value 'fail')
+gap> A_CLOS_VEC_COORDS(Veclis2([one]), one, 0, fail);
+Error, A_CLOS_VEC_COORDS: <stop> must be a non-negative small integer (not the\
+ value 'fail')
+
+#
+# COSET_LEADERS_INNER_GF2
+#
+gap> leaders := [Immutable(oneZero)];; leaders[3] := false;;
+gap> COSET_LEADERS_INNER_GF2(Veclis2([one]), 1, 1, leaders);
+1
+gap> leaders[2];
+<an immutable GF2 vector of length 1>
+
+# bad arguments
+gap> COSET_LEADERS_INNER_GF2(fail, 1, 1, leaders);
+Error, COSET_LEADERS_INNER_GF2: <veclis> must be a plain list (not the value '\
+fail')
+gap> COSET_LEADERS_INNER_GF2(Veclis2([one]), fail, 1, leaders);
+Error, COSET_LEADERS_INNER_GF2: <weight> must be a small integer (not the valu\
+e 'fail')
+gap> COSET_LEADERS_INNER_GF2(Veclis2([one]), 1, fail, leaders);
+Error, COSET_LEADERS_INNER_GF2: <tofind> must be a small integer (not the valu\
+e 'fail')
+gap> COSET_LEADERS_INNER_GF2(Veclis2([one]), 1, 1, fail);
+Error, COSET_LEADERS_INNER_GF2: <leaders> must be a plain list (not the value \
+'fail')
+
+#
+# CONV_GF2MAT
+#
+gap> m := [V2([]), V2([])];; CONV_GF2MAT(m);; m = Mx02(2);
+true
+
+# bad arguments
+gap> CONV_GF2MAT(fail);
+Error, CONV_GF2MAT: <list> must be a small list (not the value 'fail')
+
+#
+# PROD_GF2VEC_ANYMAT
+#
+gap> PROD_GF2VEC_ANYMAT(one, [fail]);
+"TRY_NEXT_METHOD"
+gap> PROD_GF2VEC_ANYMAT(one, [one]);
+<a GF2 vector of length 1>
+
+# bad arguments
+gap> PROD_GF2VEC_ANYMAT(fail, [fail]);
+Error, PROD_GF2VEC_ANYMAT: <vec> must be a GF2 vector (not the value 'fail')
+gap> PROD_GF2VEC_ANYMAT(one, fail);
+Error, PROD_GF2VEC_ANYMAT: <mat> must be a plain list (not the value 'fail')
+
+#
+# RIGHTMOST_NONZERO_GF2VEC
+#
+gap> RIGHTMOST_NONZERO_GF2VEC(empty);
+0
+gap> RIGHTMOST_NONZERO_GF2VEC(V2([z, o]));
+2
+
+# bad arguments
+gap> RIGHTMOST_NONZERO_GF2VEC(fail);
+Error, RIGHTMOST_NONZERO_GF2VEC: <vec> must be a GF2 vector (not the value 'fa\
+il')
+
+#
+# RESIZE_GF2VEC
+#
+gap> v := V2([]);; RESIZE_GF2VEC(v, 2);; v = V2([z, z]);
+true
+
+# bad arguments
+gap> RESIZE_GF2VEC(fail, 2);
+Error, RESIZE_GF2VEC: <vec> must be a GF2 vector (not the value 'fail')
+gap> RESIZE_GF2VEC(v, fail);
+Error, RESIZE_GF2VEC: <newlen> must be a non-negative small integer (not the v\
+alue 'fail')
+
+#
+# SHIFT_LEFT_GF2VEC
+#
+gap> v := V2([]);; SHIFT_LEFT_GF2VEC(v, 3);; v = empty;
+true
+
+# bad arguments
+gap> SHIFT_LEFT_GF2VEC(fail, 3);
+Error, SHIFT_LEFT_GF2VEC: <vec> must be a GF2 vector (not the value 'fail')
+gap> SHIFT_LEFT_GF2VEC(v, fail);
+Error, SHIFT_LEFT_GF2VEC: <amount> must be a non-negative small integer (not t\
+he value 'fail')
+
+#
+# SHIFT_RIGHT_GF2VEC
+#
+gap> v := V2([]);; SHIFT_RIGHT_GF2VEC(v, 3, z);; v = V2([z, z, z]);
+true
+
+# bad arguments
+gap> SHIFT_RIGHT_GF2VEC(fail, 3, z);
+Error, SHIFT_RIGHT_GF2VEC: <vec> must be a GF2 vector (not the value 'fail')
+gap> SHIFT_RIGHT_GF2VEC(v, fail, z);
+Error, SHIFT_RIGHT_GF2VEC: <amount> must be a non-negative small integer (not \
+the value 'fail')
+gap> SHIFT_RIGHT_GF2VEC(v, 3, fail);
+Error, SHIFT_RIGHT_GF2VEC: <zero> must be a finite field element (not the valu\
+e 'fail')
+
+#
+# ADD_GF2VEC_GF2VEC_SHIFTED
+#
+gap> v := V2([]);; ADD_GF2VEC_GF2VEC_SHIFTED(v, one, 0, 1);; v = oneZero;
+true
+
+# bad arguments
+gap> ADD_GF2VEC_GF2VEC_SHIFTED(fail, one, 0, 1);
+Error, ADD_GF2VEC_GF2VEC_SHIFTED: <vec1> must be a GF2 vector (not the value '\
+fail')
+gap> ADD_GF2VEC_GF2VEC_SHIFTED(v, fail, 0, 1);
+Error, ADD_GF2VEC_GF2VEC_SHIFTED: <vec2> must be a GF2 vector (not the value '\
+fail')
+gap> ADD_GF2VEC_GF2VEC_SHIFTED(v, one, fail, 1);
+Error, ADD_GF2VEC_GF2VEC_SHIFTED: <len2> must be a non-negative small integer \
+(not the value 'fail')
+gap> ADD_GF2VEC_GF2VEC_SHIFTED(v, one, 0, fail);
+Error, ADD_GF2VEC_GF2VEC_SHIFTED: <off> must be a non-negative small integer (\
+not the value 'fail')
+
+#
+# PROD_COEFFS_GF2VEC
+#
+gap> PROD_COEFFS_GF2VEC(empty, 0, empty, 0);
+<a GF2 vector of length 0>
+gap> PROD_COEFFS_GF2VEC(one, 1, one, 1);
+<a GF2 vector of length 1>
+
+# bad arguments
+gap> PROD_COEFFS_GF2VEC(fail, 0, empty, 0);
+<a GF2 vector of length 0>
+gap> PROD_COEFFS_GF2VEC(empty, fail, empty, 0);
+Error, PROD_COEFFS_GF2VEC: <len1> must be a non-negative small integer (not th\
+e value 'fail')
+gap> PROD_COEFFS_GF2VEC(empty, 0, fail, 0);
+<a GF2 vector of length 0>
+gap> PROD_COEFFS_GF2VEC(empty, 0, empty, fail);
+Error, PROD_COEFFS_GF2VEC: <len2> must be a non-negative small integer (not th\
+e value 'fail')
+
+#
+# REDUCE_COEFFS_GF2VEC
+#
+gap> v := V2([o]);; w := V2([o, z]);;
+gap> REDUCE_COEFFS_GF2VEC(v, 1, w, 1);
+0
+gap> v;
+<a GF2 vector of length 0>
+
+# bad arguments
+gap> REDUCE_COEFFS_GF2VEC(fail, 1, w, 1);
+Error, REDUCE_COEFFS_GF2VEC: <vec1> must be a GF2 vector (not the value 'fail'\
+)
+gap> REDUCE_COEFFS_GF2VEC(v, fail, w, 1);
+Error, REDUCE_COEFFS_GF2VEC: <len1> must be a non-negative small integer (not \
+the value 'fail')
+gap> REDUCE_COEFFS_GF2VEC(v, 1, fail, 1);
+Error, REDUCE_COEFFS_GF2VEC: <vec2> must be a GF2 vector (not the value 'fail'\
+)
+gap> REDUCE_COEFFS_GF2VEC(v, 1, w, fail);
+Error, REDUCE_COEFFS_GF2VEC: <len2> must be a non-negative small integer (not \
+the value 'fail')
+
+#
+# QUOTREM_COEFFS_GF2VEC
+#
+gap> QUOTREM_COEFFS_GF2VEC(empty, 0, w, 1);
+[ <a GF2 vector of length 0>, <a GF2 vector of length 0> ]
+
+# bad arguments
+gap> QUOTREM_COEFFS_GF2VEC(fail, 0, w, 1);
+Error, QUOTREM_COEFFS_GF2VEC: <vec1> must be a GF2 vector (not the value 'fail\
+')
+gap> QUOTREM_COEFFS_GF2VEC(empty, fail, w, 1);
+Error, QUOTREM_COEFFS_GF2VEC: <len1> must be a non-negative small integer (not\
+ the value 'fail')
+gap> QUOTREM_COEFFS_GF2VEC(empty, 0, fail, 1);
+Error, QUOTREM_COEFFS_GF2VEC: <vec2> must be a GF2 vector (not the value 'fail\
+')
+gap> QUOTREM_COEFFS_GF2VEC(empty, 0, w, fail);
+Error, QUOTREM_COEFFS_GF2VEC: <len2> must be a non-negative small integer (not\
+ the value 'fail')
+
+#
+# SEMIECHELON_LIST_GF2VECS
+#
+gap> s := SEMIECHELON_LIST_GF2VECS([one]);; s.heads = [1] and s.vectors = [one];
+true
+
+# bad arguments
+gap> SEMIECHELON_LIST_GF2VECS(fail);
+Error, SEMIECHELON_LIST_GF2VECS: <mat> must be a plain list (not the value 'fa\
+il')
+
+#
+# SEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS
+#
+gap> s := SEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS([one]);;
+gap> s.heads;
+[ 1 ]
+gap> s.vectors = [one];
+true
+gap> s.coeffs = [one];
+true
+
+# bad arguments
+gap> SEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS(fail);
+Error, SEMIECHELON_LIST_GF2VECS_TRANSFORMATIONS: <mat> must be a plain list (n\
+ot the value 'fail')
+
+#
+# TRIANGULIZE_LIST_GF2VECS
+#
+gap> m := [one];; TRIANGULIZE_LIST_GF2VECS(m);; m = [one];
+true
+
+# bad arguments
+gap> TRIANGULIZE_LIST_GF2VECS(fail);
+Error, TRIANGULIZE_LIST_GF2VECS: <mat> must be a plain list (not the value 'fa\
+il')
+
+#
+# DETERMINANT_LIST_GF2VECS
+#
+gap> DETERMINANT_LIST_GF2VECS([one]);
+Z(2)^0
+
+# bad arguments
+gap> DETERMINANT_LIST_GF2VECS(fail);
+Error, DETERMINANT_LIST_GF2VECS: <mat> must be a plain list (not the value 'fa\
+il')
+
+#
+# RANK_LIST_GF2VECS
+#
+gap> RANK_LIST_GF2VECS([one]);
+1
+
+# bad arguments
+gap> RANK_LIST_GF2VECS(fail);
+Error, RANK_LIST_GF2VECS: <mat> must be a plain list (not the value 'fail')
+
+#
+# KRONECKERPRODUCT_GF2MAT_GF2MAT
+#
+gap> KRONECKERPRODUCT_GF2MAT_GF2MAT(Mx02(2), M2([[o]])) = Mx02(2);
+true
+
+# bad arguments
+gap> KRONECKERPRODUCT_GF2MAT_GF2MAT(fail, M2([[o]]));
+Error, KRONECKERPRODUCT_GF2MAT_GF2MAT: <matl> must be a GF2 matrix (not the va\
+lue 'fail')
+gap> KRONECKERPRODUCT_GF2MAT_GF2MAT(Mx02(2), fail);
+Error, KRONECKERPRODUCT_GF2MAT_GF2MAT: <matr> must be a GF2 matrix (not the va\
+lue 'fail')
+
+#
+# COPY_SECTION_GF2VECS
+#
+gap> src := V2([o, o]);; dst := V2([z, z, z]);; COPY_SECTION_GF2VECS(src, dst, 1, 2, 2);; dst = V2([z, o, o]);
+true
+
+# bad arguments
+gap> COPY_SECTION_GF2VECS(fail, dst, 1, 2, 2);
+Error, COPY_SECTION_GF2VECS: <src> must be a GF2 vector (not the value 'fail')
+gap> COPY_SECTION_GF2VECS(src, fail, 1, 2, 2);
+Error, COPY_SECTION_GF2VECS: <dest> must be a GF2 vector (not the value 'fail'\
+)
+gap> COPY_SECTION_GF2VECS(src, dst, fail, 2, 2);
+Error, COPY_SECTION_GF2VECS: <from> must be a positive small integer (not the \
+value 'fail')
+gap> COPY_SECTION_GF2VECS(src, dst, 1, fail, 2);
+Error, COPY_SECTION_GF2VECS: <to> must be a positive small integer (not the va\
+lue 'fail')
+gap> COPY_SECTION_GF2VECS(src, dst, 1, 2, fail);
+Error, COPY_SECTION_GF2VECS: <howmany> must be a small integer (not the value \
+'fail')
+
+#
+# MAT_ELM_GF2MAT
+#
+gap> MAT_ELM_GF2MAT(M2([[o]]), 1, 1);
+Z(2)^0
+
+# bad arguments
+gap> MAT_ELM_GF2MAT(fail, 1, 1);
+Error, MAT_ELM_GF2MAT: <mat> must be a GF2 matrix (not the value 'fail')
+gap> MAT_ELM_GF2MAT(M2([[o]]), fail, 1);
+Error, MAT_ELM_GF2MAT: <row> must be a positive small integer (not the value '\
+fail')
+gap> MAT_ELM_GF2MAT(M2([[o]]), 1, fail);
+Error, MAT_ELM_GF2MAT: <col> must be a positive small integer (not the value '\
+fail')
+
+#
+# SET_MAT_ELM_GF2MAT
+#
+gap> m := M2([[z]]);; SET_MAT_ELM_GF2MAT(m, 1, 1, o);; m = M2([[o]]);
+true
+
+# bad arguments
+gap> SET_MAT_ELM_GF2MAT(fail, 1, 1, o);
+Error, SET_MAT_ELM_GF2MAT: <mat> must be a GF2 matrix (not the value 'fail')
+gap> SET_MAT_ELM_GF2MAT(m, fail, 1, o);
+Error, SET_MAT_ELM_GF2MAT: <row> must be a positive small integer (not the val\
+ue 'fail')
+gap> SET_MAT_ELM_GF2MAT(m, 1, fail, o);
+Error, SET_MAT_ELM_GF2MAT: <col> must be a positive small integer (not the val\
+ue 'fail')
+gap> SET_MAT_ELM_GF2MAT(m, 1, 1, fail);
+Error, SET_MAT_ELM_GF2MAT: assigned element must be a GF(2) element (not the v\
+alue 'fail')
 
 #
 gap> STOP_TEST("kernel/vecgf2.tst");


### PR DESCRIPTION
Add runtime argument checks to the user-facing GF2 and 8-bit kernel entry points instead of relying on debug-only assertions or unchecked representation assumptions.

Use shared Require helpers for compressed vectors and matrices, and tighten plain-list validation where these entry points expect list-backed inputs.

Harden the exported vec8bit kernel entry points that assumed a first row existed, and fix `SHIFT_VEC8BIT_RIGHT` for empty compressed vectors.

AI assistance from OpenAI Codex helped prepare these kernel validation changes.

---

Ultimately, I'd like to support "empty" compressed matrices with zero rows or zero columns. But for now, let's add some input guards, and also tests, to make sure at least nothing crashes.

Related issues: #2062, #2121, #4914#6393.