### PR TITLE
kernel: remove `ErrorReturnObj`, `C_NEW_STRING`

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -228,7 +228,7 @@ end);
 #
 Unbind(ErrorInner);
 BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
-    local   context, tracebackContext, mayReturnVoid, mayReturnObj,
+    local   context, tracebackContext, mayReturnVoid,
             lateMessage, x, prompt, res, errorLVars, errorTracebackLVars,
             kernelErrorLVars, justQuit, printEarlyMessage,
             printEarlyTraceback, printAutomaticTraceback, lastErrorStream;
@@ -260,17 +260,6 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         fi;
     else
         mayReturnVoid := false;
-    fi;
-
-    if IsBound(options.mayReturnObj) then
-        mayReturnObj := options.mayReturnObj;
-        if not mayReturnObj in [false, true] then
-            PrintTo(ERROR_OUTPUT, "ErrorInner: option mayReturnObj must be true or false\n");
-            LEAVE_ALL_NAMESPACES();
-            JUMP_TO_CATCH(1);
-        fi;
-    else
-        mayReturnObj := false;
     fi;
 
     if IsBound(options.tracebackContext) then
@@ -410,7 +399,7 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
         prompt := "brk> ";
     fi;
     if not justQuit then
-        res := SHELL(context,mayReturnVoid,mayReturnObj,true,prompt,false);
+        res := SHELL(context,mayReturnVoid,false,true,prompt,false);
     else
         res := fail;
     fi;
@@ -455,7 +444,6 @@ BIND_GLOBAL("ErrorNoReturn", function(arg)
         rec(
             context := ParentLVars(GetCurrentLVars()),
             mayReturnVoid := false,
-            mayReturnObj := false,
             lateMessage := "type 'quit;' to quit to outer loop",
         ),
         arg);

--- a/lib/methsel2.g
+++ b/lib/methsel2.g
@@ -252,7 +252,6 @@ end;
           context := GetCurrentLVars(),
           tracebackContext := ParentLVars(GetCurrentLVars()),
           mayReturnVoid := false,
-          mayReturnObj := false,
           lateMessage := "type 'quit;' to quit to outer loop"
       ),
       [ no_method_found ]);

--- a/src/error.c
+++ b/src/error.c
@@ -422,7 +422,6 @@ static Obj CallErrorInner(const Char * msg,
                           Int          arg2,
                           UInt         justQuit,
                           UInt         mayReturnVoid,
-                          UInt         mayReturnObj,
                           Obj          lateMessage)
 {
     // Must do this before creating any other GAP objects,
@@ -447,7 +446,6 @@ static Obj CallErrorInner(const Char * msg,
 #endif
     AssPRec(r, RNamName("context"), STATE(CurrLVars));
     AssPRec(r, RNamName("justQuit"), justQuit ? True : False);
-    AssPRec(r, RNamName("mayReturnObj"), mayReturnObj ? True : False);
     AssPRec(r, RNamName("mayReturnVoid"), mayReturnVoid ? True : False);
     AssPRec(r, RNamName("lateMessage"), lateMessage);
     l = NewPlistFromArgs(EarlyMsg);
@@ -469,7 +467,7 @@ static Obj CallErrorInner(const Char * msg,
 
 void ErrorQuit(const Char * msg, Int arg1, Int arg2)
 {
-    CallErrorInner(msg, arg1, arg2, 1, 0, 0, False);
+    CallErrorInner(msg, arg1, arg2, 1, 0, False);
     Panic("ErrorQuit must not return");
 }
 
@@ -504,7 +502,7 @@ void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2)
 {
     Obj LateMsg;
     LateMsg = MakeString(msg2);
-    CallErrorInner(msg, arg1, arg2, 0, 1, 0, LateMsg);
+    CallErrorInner(msg, arg1, arg2, 0, 1, LateMsg);
     // ErrorMode( msg, arg1, arg2, (Obj)0, msg2, 'x' );
 }
 
@@ -515,7 +513,7 @@ void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2)
 void ErrorMayQuit(const Char * msg, Int arg1, Int arg2)
 {
     Obj LateMsg = MakeString("type 'quit;' to quit to outer loop");
-    CallErrorInner(msg, arg1, arg2, 0, 0, 0, LateMsg);
+    CallErrorInner(msg, arg1, arg2, 0, 0, LateMsg);
     Panic("ErrorMayQuit must not return");
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -498,18 +498,6 @@ void ErrorMayQuitNrAtLeastArgs(Int narg, Int actual)
 
 /****************************************************************************
 **
-*F  ErrorReturnObj( <msg>, <arg1>, <arg2>, <msg2> ) . .  print and return obj
-*/
-Obj ErrorReturnObj(const Char * msg, Int arg1, Int arg2, const Char * msg2)
-{
-    Obj LateMsg;
-    LateMsg = MakeString(msg2);
-    return CallErrorInner(msg, arg1, arg2, 0, 0, 1, LateMsg);
-}
-
-
-/****************************************************************************
-**
 *F  ErrorReturnVoid( <msg>, <arg1>, <arg2>, <msg2> )  . . .  print and return
 */
 void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2)

--- a/src/error.h
+++ b/src/error.h
@@ -71,13 +71,6 @@ void ErrorMayQuitNrAtLeastArgs(Int narg, Int actual) NORETURN;
 
 /****************************************************************************
 **
-*F  ErrorReturnObj( <msg>, <arg1>, <arg2>, <msg2> ) . .  print and return obj
-*/
-Obj ErrorReturnObj(const Char * msg, Int arg1, Int arg2, const Char * msg2);
-
-
-/****************************************************************************
-**
 *F  ErrorReturnVoid( <msg>, <arg1>, <arg2>, <msg2> )  . . .  print and return
 */
 void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2);

--- a/src/stringobj.h
+++ b/src/stringobj.h
@@ -360,18 +360,6 @@ EXPORT_INLINE Obj MakeImmStringWithLen(const char * buf, size_t len)
 
 /****************************************************************************
 **
-*F  C_NEW_STRING( <string>, <len>, <cstring> )  . . . . . . create GAP string
-**
-**  This macro is deprecated and only provided for backwards compatibility
-**  with some package kernel extensions. Use 'MakeStringWithLen' and
-**  'MakeImmStringWithLen' instead.
-*/
-#define C_NEW_STRING(string,len,cstr) \
-    string = MakeStringWithLen( (cstr), (len) )
-
-
-/****************************************************************************
-**
 *F  AppendCStr( <str>, <buf>, <len> ) . . append data in a buffer to a string
 **
 **  'AppendCStr' appends <len> bytes of data taken from <buf> to <str>, where


### PR DESCRIPTION
We don't use them nor does any distributed package.

---

To be merged only *after* `stable-4.16` has been created.