### PR TITLE
kernel: improve `ErrorReturnVoid` break-loop message

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -923,7 +923,8 @@ Error, recursion depth trap (5000)
  [2] dive( depth - 1 );
    @ *stdin*:1
 ...  at *stdin*:4
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> return;
 gap> dive(11000);
 Error, recursion depth trap (5000)
@@ -932,7 +933,8 @@ Error, recursion depth trap (5000)
  [2] dive( depth - 1 );
    @ *stdin*:1
 ...  at *stdin*:5
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> return;
 Error, recursion depth trap (10000)
 *[1] dive( depth - 1 );
@@ -940,8 +942,10 @@ Error, recursion depth trap (10000)
  [2] dive( depth - 1 );
    @ *stdin*:1
 ...  at *stdin*:5
-you may 'return;'
-brk> return;gap>
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
+brk> return;
+gap>
 ]]></Log>
 <P/>
 
@@ -981,7 +985,8 @@ Error, recursion depth trap (1000)
  [2] dive( depth - 1 );
    @ *stdin*:4
 ...  at *stdin*:12
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> return;
 Error, recursion depth trap (2000)
 *[1] dive( depth - 1 );
@@ -989,7 +994,8 @@ Error, recursion depth trap (2000)
  [2] dive( depth - 1 );
    @ *stdin*:4
 ...  at *stdin*:12
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> GetRecursionDepth();
 0
 brk> return;

--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -715,11 +715,10 @@ gap> xx := 15;
 15
 gap> MakeReadOnlyGlobal("xx");
 gap> xx := 16;
-Variable: 'xx' is read only
-not in any function
-Entering break read-eval-print loop ...
-you can 'quit;' to quit to outer loop, or
-you can 'return;' after making it writable to continue
+Error, Variable: 'xx' is read only
+Stack trace:
+not in any function at *stdin*:3
+type 'quit;' to quit to outer loop
 brk> quit;
 gap> IsReadOnlyGlobal("xx");
 true
@@ -1563,6 +1562,7 @@ gap> f2:= function( x ) return f1( x ); end;;
 gap> f2( 4 );
 value: 4
 Error, Function Calls: <func> must return a value
+Stack trace:
 *[1] f1( x )
    @ *stdin*:2
 <function "f2">( <arguments> )

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -477,6 +477,7 @@ indicate that you are in a break loop.
 <Log><![CDATA[
 gap> 1/0;
 Error, Rational operations: <divisor> must not be zero
+Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 ]]></Log>
@@ -487,7 +488,8 @@ If errors occur within a break loop &GAP; enters another break loop at a
 <Log><![CDATA[
 brk> 1/0;
 Error, Rational operations: <divisor> must not be zero
-not in any function at *stdin*:2
+Stack trace:
+not in any function at *errin*:1
 type 'quit;' to quit to outer loop
 brk_2>
 ]]></Log>
@@ -537,25 +539,11 @@ purpose of this function.
 <Index Key="return"><K>return</K></Index>
 <Index>return from break loop</Index>
 The other way to leave a break loop is to <E>return</E> from a break loop.
-To do this you type <C>return;</C> or <C>return <A>obj</A>;</C>.
 If the break loop was entered because you interrupted &GAP;,
 then you can continue by typing <C>return;</C>.
-If the break loop was entered due to an error,
-you may have to modify the value of a variable before typing <C>return;</C>
-(see the example for&nbsp;<Ref Filt="IsDenseList"/>) or you may have to
-return an object <A>obj</A>
-(by typing: <C>return <A>obj</A>;</C>) to continue the computation;
-in any case, the message printed on entering the break loop will
-tell you which of these alternatives is possible.
-For example, if the break loop was entered because a variable had no
-assigned value, the value to be returned is often a value that this
-variable should have to continue the computation.
-<P/>
-<Log><![CDATA[
-brk> return 9;  # we had tried to enter the divisor 9 but typed 0 ...
-1/9
-gap> 
-]]></Log>
+If the break loop was entered due to an error, this option may or may not
+be available, depending on the kind of error. The message printed on entering
+the break loop will tell you whether this possible.
 
 </Subsection>
 
@@ -581,7 +569,6 @@ function(  ) ... end
 gap> Error("!\n");
 Error, !
 Hello
-Entering break read-eval-print loop ...
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> quit;
@@ -606,8 +593,7 @@ emitted at <Ref InfoClass="InfoWarning"/> level 1
 <!-- %may make it obsolete. -->
 <P/>
 Note that for break loops entered by a call to <Ref Func="Error"/>,
-the lines after <Q><C>Entering break read-eval-print loop ...</C></Q>
-and before the <C>brk></C> prompt can also be customised,
+the lines just before the <C>brk></C> prompt can also be customised,
 namely by redefining <Ref Func="OnBreakMessage"/>.
 <P/>
 <Index Key="ErrorNoTraceBack"><C>ErrorNoTraceBack</C></Index>
@@ -649,7 +635,6 @@ Here is a somewhat trivial demonstration of the use of
 <Log><![CDATA[
 gap> ErrorNoTraceBack("Gidday!", " How's", " it", " going?\n");
 Error, Gidday! How's it going?
-Entering break read-eval-print loop ...
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> quit;
@@ -661,7 +646,6 @@ Now we call <Ref Func="Error"/> with the same arguments to show the difference.
 gap> Error("Gidday!", " How's", " it", " going?\n");
 Error, Gidday! How's it going?
 Hello
-Entering break read-eval-print loop ...
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> quit;
@@ -685,9 +669,8 @@ gap> OnBreak := Where;;
 <Description>
 <Index>Break loop message</Index>
 When a break loop is entered by a call to <Ref Func="Error"/>
-the message after the
-<Q><C>Entering break read-eval-print loop ...</C></Q> line is produced
-by the function <C>OnBreakMessage</C>,
+the message at the end starting with <Q><C>you can 'quit;' to ...</C></Q>
+is produced by the function <C>OnBreakMessage</C>,
 which just like <Ref Func="OnBreak"/>
 is a user-configurable global variable
 that is a <E>function</E> with <E>no arguments</E>.
@@ -718,7 +701,6 @@ calling <Ref Func="Error"/> as we did above, now produces:
 gap> Error("!\n");
 Error, !
 Hello
-Entering break read-eval-print loop ...
 brk> quit; # to get back to outer loop
 ]]></Log>
 <P/>

--- a/doc/ref/types.xml
+++ b/doc/ref/types.xml
@@ -601,12 +601,10 @@ for an object.
 <P/>
 <Log><![CDATA[
 gap> Setter( prop )( Rationals, false );
-You cannot set an "and-filter" except to true
-not in any function
-Entering break read-eval-print loop ...
-you can 'quit;' to quit to outer loop, or
-you can type 'return true;' to set all components true
-(but you might really want to reset just one component) to continue
+Error, You cannot set an "and-filter" except to true
+Stack trace:
+not in any function at *stdin*:8
+type 'quit;' to quit to outer loop
 brk>
 ]]></Log>
 </Description>

--- a/doc/tut/lists.xml
+++ b/doc/tut/lists.xml
@@ -341,11 +341,10 @@ gap> list[3][5] := 'w';; list; copy;
 [ 1, 2, "threw", [ 4 ] ]
 [ 1, 2, "three", [ 4 ] ]
 gap> copy[3][5] := 'w';
-List Assignment: <list> must be a mutable list
-not in any function
-Entering break read-eval-print loop ...
-you can 'quit;' to quit to outer loop, or
-you can 'return;' and ignore the assignment to continue
+Error, List Assignment: <list> must be a mutable list
+Stack trace:
+not in any function at *stdin*:3
+type 'quit;' to quit to outer loop
 brk> quit;
 ]]></Log>
 <P/>

--- a/lib/list.gd
+++ b/lib/list.gd
@@ -379,7 +379,7 @@ DeclareSynonym( "AsSSortedListList", AS_LIST_SORTED_LIST );
 ##  Lists with holes are sometimes convenient when the list represents
 ##  a mapping from a finite, but not consecutive,
 ##  subset of the positive integers.
-##  <Log><![CDATA[
+##  <Example><![CDATA[
 ##  gap> IsDenseList( [ 1, 2, 3 ] );
 ##  true
 ##  gap> l := [ , 4, 9,, 25,, 49,,,, 121 ];;  IsDenseList( l );
@@ -387,22 +387,12 @@ DeclareSynonym( "AsSSortedListList", AS_LIST_SORTED_LIST );
 ##  gap> l[3];
 ##  9
 ##  gap> l[4];
-##  List Element: <list>[4] must have an assigned value
-##  not in any function
-##  Entering break read-eval-print loop ...
-##  you can 'quit;' to quit to outer loop, or
-##  you can 'return;' after assigning a value to continue
-##  brk> l[4] := 16;;  # assigning a value
-##  brk> return;       # to escape the break-loop
-##  16
-##  gap>
-##  ]]></Log>
+##  Error, List Element: <list>[4] must have an assigned value
+##  ]]></Example>
 ##  <P/>
 ##  Observe that requesting the value of <C>l[4]</C>, which was not
 ##  assigned, caused the entry of a <K>break</K>-loop
 ##  (see Section&nbsp;<Ref Sect="Break Loops"/>).
-##  After assigning a value and typing <C>return;</C>, &GAP; is finally
-##  able to comply with our request (by responding with <C>16</C>).
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/src/cyclotom.c
+++ b/src/cyclotom.c
@@ -836,7 +836,7 @@ static UInt FindCommonField(UInt nl, UInt nr, UInt *ml, UInt *mr)
           "This computation requires a cyclotomic field of degree %d, larger "
           "than the current limit of %d",
           n, (Int)CyclotomicsLimit,
-          "You may return after raising the limit with SetCyclotomicsLimit");
+          "you can 'return;' after raising the limit with SetCyclotomicsLimit");
   }
 
   // Finish up

--- a/src/error.c
+++ b/src/error.c
@@ -500,10 +500,13 @@ void ErrorMayQuitNrAtLeastArgs(Int narg, Int actual)
 */
 void ErrorReturnVoid(const Char * msg, Int arg1, Int arg2, const Char * msg2)
 {
-    Obj LateMsg;
-    LateMsg = MakeString(msg2);
-    CallErrorInner(msg, arg1, arg2, 0, 1, LateMsg);
-    // ErrorMode( msg, arg1, arg2, (Obj)0, msg2, 'x' );
+    if (msg2 == 0) {
+        msg2 = "you can 'return;' to continue";
+    }
+
+    Obj lateMsg = MakeString("you can 'quit;' to quit to outer loop, or\n");
+    AppendString(lateMsg, MakeString(msg2));
+    CallErrorInner(msg, arg1, arg2, 0, 1, lateMsg);
 }
 
 /****************************************************************************
@@ -634,7 +637,7 @@ void ErrorBoundedInt(
 
 void AssertionFailure(void)
 {
-    ErrorReturnVoid("Assertion failure", 0, 0, "you may 'return;'");
+    ErrorReturnVoid("Assertion failure", 0, 0, 0);
 }
 
 void AssertionFailureWithMessage(Obj message)
@@ -645,7 +648,7 @@ void AssertionFailureWithMessage(Obj message)
         AssertionFailure();
     }
     else if (IS_STRING_REP(message)) {
-        ErrorReturnVoid("Assertion failure: %g", (Int)message, 0, "you may 'return;'");
+        ErrorReturnVoid("Assertion failure: %g", (Int)message, 0, 0);
     }
     else {
         PrintObj(message);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -387,8 +387,7 @@ void RecursionDepthTrap( void )
     if (GetRecursionDepth() > 0) {
         recursionDepth = GetRecursionDepth();
         SetRecursionDepth(0);
-        ErrorReturnVoid("recursion depth trap (%d)", (Int)recursionDepth, 0,
-                        "you may 'return;'");
+        ErrorReturnVoid("recursion depth trap (%d)", (Int)recursionDepth, 0, 0);
         SetRecursionDepth(recursionDepth);
     }
 }

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -975,7 +975,7 @@ static void InterruptCurrentThread(int locked, Stat stat)
     if (handler)
         CALL_WITH_CATCH(handler, NEW_PLIST(T_PLIST, 0));
     else
-        ErrorReturnVoid("system interrupt", 0, 0, "you can 'return;'");
+        ErrorReturnVoid("system interrupt", 0, 0, 0);
     if (!locked)
         pthread_mutex_unlock(thread->lock);
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -392,7 +392,7 @@ static ALWAYS_INLINE ExecStatus ExecForHelper(Stat stat, UInt nr)
 #if !defined(HAVE_SIGNAL)
             // test for an interrupt
             if ( HaveInterrupt() ) {
-                ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+                ErrorReturnVoid("user interrupt", 0, 0, 0);
             }
 #endif
 
@@ -435,7 +435,7 @@ static ALWAYS_INLINE ExecStatus ExecForHelper(Stat stat, UInt nr)
 #if !defined(HAVE_SIGNAL)
             // test for an interrupt
             if ( HaveInterrupt() ) {
-                ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+                ErrorReturnVoid("user interrupt", 0, 0, 0);
             }
 #endif
 
@@ -530,7 +530,7 @@ static ALWAYS_INLINE ExecStatus ExecForRangeHelper(Stat stat, UInt nr)
 #if !defined(HAVE_SIGNAL)
         // test for an interrupt
         if ( HaveInterrupt() ) {
-            ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+            ErrorReturnVoid("user interrupt", 0, 0, 0);
         }
 #endif
 
@@ -666,7 +666,7 @@ static ALWAYS_INLINE ExecStatus ExecWhileHelper(Stat stat, UInt nr)
 #if !defined(HAVE_SIGNAL)
         // test for an interrupt
         if ( HaveInterrupt() ) {
-            ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+            ErrorReturnVoid("user interrupt", 0, 0, 0);
         }
 #endif
 
@@ -737,7 +737,7 @@ static ALWAYS_INLINE ExecStatus ExecRepeatHelper(Stat stat, UInt nr)
 #if !defined(HAVE_SIGNAL)
         // test for an interrupt
         if ( HaveInterrupt() ) {
-            ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+            ErrorReturnVoid("user interrupt", 0, 0, 0);
         }
 #endif
 
@@ -952,7 +952,7 @@ static ExecStatus ExecReturnObj(Stat stat)
 #if !defined(HAVE_SIGNAL)
     // test for an interrupt
     if ( HaveInterrupt() ) {
-        ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+        ErrorReturnVoid("user interrupt", 0, 0, 0);
     }
 #endif
 
@@ -980,7 +980,7 @@ static ExecStatus ExecReturnVoid(Stat stat)
 #if !defined(HAVE_SIGNAL)
     // test for an interrupt
     if ( HaveInterrupt() ) {
-        ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+        ErrorReturnVoid("user interrupt", 0, 0, 0);
     }
 #endif
 
@@ -1027,7 +1027,7 @@ UInt TakeInterrupt( void )
 {
   if (HaveInterrupt()) {
       UnInterruptExecStat();
-      ErrorReturnVoid("user interrupt", 0, 0, "you can 'return;'");
+      ErrorReturnVoid("user interrupt", 0, 0, 0);
       return 1;
   }
   return 0;
@@ -1067,12 +1067,12 @@ static ExecStatus ExecIntrStat(Stat stat)
         if (printError) {
             ErrorReturnVoid("reached the pre-set memory limit\n"
                             "(change it with the -o command line option)",
-                            0, 0, "you can 'return;'");
+                            0, 0, 0);
         }
     }
     else
 #endif
-      ErrorReturnVoid( "user interrupt", 0, 0, "you can 'return;'" );
+        ErrorReturnVoid("user interrupt", 0, 0, 0);
 #endif
 
     // continue at the interrupted statement

--- a/src/streams.c
+++ b/src/streams.c
@@ -517,8 +517,7 @@ static Obj FuncLOG_TO(Obj self, Obj filename)
 {
     RequireStringRep(SELF_NAME, filename);
     if ( ! OpenLog( CONST_CSTR_STRING(filename) ) ) {
-        ErrorReturnVoid("LogTo: cannot log to %g", (Int)filename, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("LogTo: cannot log to %g", (Int)filename, 0, 0);
         return False;
     }
     return True;
@@ -533,8 +532,7 @@ static Obj FuncLOG_TO_STREAM(Obj self, Obj stream)
 {
     RequireOutputStream(SELF_NAME, stream);
     if ( ! OpenLogStream(stream) ) {
-        ErrorReturnVoid("LogTo: cannot log to stream", 0, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("LogTo: cannot log to stream", 0, 0, 0);
         return False;
     }
     return True;
@@ -578,8 +576,7 @@ static Obj FuncINPUT_LOG_TO(Obj self, Obj filename)
 {
     RequireStringRep(SELF_NAME, filename);
     if ( ! OpenInputLog( CONST_CSTR_STRING(filename) ) ) {
-        ErrorReturnVoid("InputLogTo: cannot log to %g", (Int)filename, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("InputLogTo: cannot log to %g", (Int)filename, 0, 0);
         return False;
     }
     return True;
@@ -594,8 +591,7 @@ static Obj FuncINPUT_LOG_TO_STREAM(Obj self, Obj stream)
 {
     RequireOutputStream(SELF_NAME, stream);
     if ( ! OpenInputLogStream(stream) ) {
-        ErrorReturnVoid("InputLogTo: cannot log to stream", 0, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("InputLogTo: cannot log to stream", 0, 0, 0);
         return False;
     }
     return True;
@@ -639,8 +635,7 @@ static Obj FuncOUTPUT_LOG_TO(Obj self, Obj filename)
 {
     RequireStringRep(SELF_NAME, filename);
     if ( ! OpenOutputLog( CONST_CSTR_STRING(filename) ) ) {
-        ErrorReturnVoid("OutputLogTo: cannot log to %g", (Int)filename, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("OutputLogTo: cannot log to %g", (Int)filename, 0, 0);
         return False;
     }
     return True;
@@ -655,8 +650,7 @@ static Obj FuncOUTPUT_LOG_TO_STREAM(Obj self, Obj stream)
 {
     RequireOutputStream(SELF_NAME, stream);
     if ( ! OpenOutputLogStream(stream) ) {
-        ErrorReturnVoid("OutputLogTo: cannot log to stream", 0, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("OutputLogTo: cannot log to stream", 0, 0, 0);
         return False;
     }
     return True;

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -3002,7 +3002,7 @@ void ASS_VEC8BIT(Obj list, Obj pos, Obj elm)
                 ErrorReturnVoid("List assignment would increase length of "
                                 "locked compressed vector",
                                 0, 0,
-                                "You can `return;' to ignore the assignment");
+                                "you can 'return;' to ignore the assignment");
                 return;
             }
             ResizeWordSizedBag(list, SIZE_VEC8BIT(p, elts));
@@ -3094,7 +3094,7 @@ static Obj FuncUNB_VEC8BIT(Obj self, Obj list, Obj pos)
     if (True == DoFilter(IsLockedRepresentationVector, list)) {
         ErrorReturnVoid(
             "Unbind of entry of locked compressed vector is forbidden", 0, 0,
-            "You can `return;' to ignore the assignment");
+            "you can 'return;' to ignore the assignment");
         return 0;
     }
 
@@ -3220,7 +3220,7 @@ static Obj FuncAPPEND_VEC8BIT(Obj self, Obj vecl, Obj vecr)
     lenr = LEN_VEC8BIT(vecr);
     if (True == DoFilter(IsLockedRepresentationVector, vecl) && lenr > 0) {
         ErrorReturnVoid("Append to locked compressed vector is forbidden", 0,
-                        0, "You can `return;' to ignore the operation");
+                        0, "you can 'return;' to ignore the operation");
         return 0;
     }
     info = GetFieldInfo8Bit(FIELD_VEC8BIT(vecl));
@@ -4369,7 +4369,7 @@ static void ResizeVec8Bit(Obj vec, UInt newlen, UInt knownclean)
 
     if (True == DoFilter(IsLockedRepresentationVector, vec)) {
         ErrorReturnVoid("Resize of locked compressed vector is forbidden", 0,
-                        0, "You can `return;' to ignore the operation");
+                        0, "you can 'return;' to ignore the operation");
         return;
     }
 
@@ -5002,8 +5002,7 @@ static Obj MakeShiftedVecs(Obj v, UInt len)
     ResizeVec8Bit(vn, len, 0);
     len1 = (len == 0) ? 0 : RightMostNonZeroVec8Bit(vn);
     if (len1 == 0)
-        ErrorReturnVoid("Zero coefficient vector for reduction", 0, 0,
-                        "you can 'return;'");
+        ErrorReturnVoid("Zero coefficient vector for reduction", 0, 0, 0);
     if (len1 != len) {
         ResizeVec8Bit(vn, len1, 1);
         len = len1;

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -3826,7 +3826,7 @@ FuncREDUCE_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
 
     if (len2a == 0) {
         ErrorReturnVoid("ReduceCoeffs: second argument must not be zero", 0,
-                        0, "you may 'return;' to skip the reduction");
+                        0, "you can 'return;' to skip the reduction");
         return 0;
     }
 
@@ -3872,7 +3872,7 @@ FuncQUOTREM_COEFFS_GF2VEC(Obj self, Obj vec1, Obj len1, Obj vec2, Obj len2)
     }
     if (len2a == 0) {
         ErrorReturnVoid("QuotremCoeffs: second argument must not be zero", 0,
-                        0, "you may 'return;' to skip the reduction");
+                        0, "you can 'return;' to skip the reduction");
         return 0;
     }
 

--- a/tst/testspecial/mem-overflow.g.out
+++ b/tst/testspecial/mem-overflow.g.out
@@ -7,7 +7,8 @@ Stack trace:
    @ *stdin*:3
 <function "unknown">( <arguments> )
  called from read-eval loop at *stdin*:3
-you can 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> # ... then we should be in a break loop. Exit that, perform some other computations.
 brk> quit;
 gap> Factorial(42);

--- a/tst/testspecial/stack-depth-func.g.out
+++ b/tst/testspecial/stack-depth-func.g.out
@@ -14,7 +14,8 @@ Stack trace:
  [5] f(  );
    @ *stdin*:2
 ...  at *stdin*:3
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> return; # try once more
 Error, recursion depth trap (10000)
 Stack trace:
@@ -29,5 +30,6 @@ Stack trace:
  [5] f(  );
    @ *stdin*:2
 ...  at *stdin*:3
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> QUIT;

--- a/tst/testspecial/stack-depth-func2.g.out
+++ b/tst/testspecial/stack-depth-func2.g.out
@@ -14,7 +14,8 @@ Stack trace:
  [5] f(  )
    @ *stdin*:2
 ...  at *stdin*:3
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> return; # try once more
 Error, recursion depth trap (10000)
 Stack trace:
@@ -29,5 +30,6 @@ Stack trace:
  [5] f(  )
    @ *stdin*:2
 ...  at *stdin*:3
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> QUIT;

--- a/tst/testspecial/stack-depth-rec.g.out
+++ b/tst/testspecial/stack-depth-rec.g.out
@@ -82,7 +82,8 @@ Stack trace:
  [5] String( record.(nam) )
    @ GAPROOT/lib/record.gi:LINE
 ...  at *stdin*:4
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> return; # try once more
 Error, recursion depth trap (5000)
 Stack trace:
@@ -97,5 +98,6 @@ Stack trace:
  [5] String( record.(nam) )
    @ GAPROOT/lib/record.gi:LINE
 ...  at *stdin*:4
-you may 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> QUIT;


### PR DESCRIPTION
... and in general make its phrasing more consistent.

AI-assisted: OpenAI Codex prepared this code change.

Resolves #6272