### PR TITLE
Fix `RingGeneralMappingByImages` for non-SCRing

### DIFF
--- a/lib/ringhom.gi
+++ b/lib/ringhom.gi
@@ -52,12 +52,7 @@ function( S, R, gens, imgs )
   fi;
 
   # Make the general mapping.
-  map:= Objectify( TypeOfDefaultGeneralMapping( S, R,
-                            IsSPGeneralMapping
-                        and IsRingGeneralMapping
-                        and IsSCRingGeneralMappingByImagesDefaultRep ),
-                    rec(
-                        ) );
+  map:= Objectify( TypeOfDefaultGeneralMapping( S, R, filter ), rec( ) );
 
     SetMappingGeneratorsImages(map,[Immutable(gens),Immutable(imgs)]);
     # return the general mapping

--- a/lib/ringsc.gd
+++ b/lib/ringsc.gd
@@ -47,6 +47,14 @@ DeclareSynonym("IsSubringSCRing",IsRing and IsSCRingObjCollection);
 ##  it can be either a string <A>name</A>
 ##  (then <A>name</A><C>1</C>, <A>name</A><C>2</C> etc. are chosen)
 ##  or a list of strings which are then chosen.
+##  <Example><![CDATA[
+##  gap> T:=EmptySCTable( 1, 0 );;
+##  gap> SetEntrySCTable( T, 1, 1, [ 1, 1 ] );
+##  gap> R:=RingByStructureConstants([9], T);   # Z/9Z
+##  <ring with 1 generator>
+##  gap> Elements(R);
+##  [ 0*r.1, r.1, 2*r.1, 3*r.1, 4*r.1, 5*r.1, 6*r.1, 7*r.1, -r.1 ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
A filter was computed but not used. The filter that was used instead always implied IsSCRingGeneralMappingByImagesDefaultRep which is too broad. As a result, inappropriate methods were applied to some ring homomorphisms.

Also add an example for using RingByStructureConstants.

---

Motivated by a report by Stefan Witzel on the GAP Forum. He wanted to do this:
```
R := ZmodnZ(9);
S := ZmodnZ(3);
RingHomomorphismByImages(R,S,[One(R)],[One(S)]);

# or:
RingHomomorphismByImages(S,S,[One(S)],[One(S)]);

# or:
RingHomomorphismByImages(Integers,Integers,[1],[1]);
```
but in all cases got errors of the form
```
Error, Record Element: '<rec>.moduli' must have an assigned value
```

This PR does not include a test case, because the example still error, but now with a "no method found" error:
```
gap> RingHomomorphismByImages(Integers,Integers,[1],[1]);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `GeneratorsOfNearAdditiveGroup' on 1 arguments
*[1] GeneratorsOfAdditiveGroup( elms )
   @ /Users/mhorn/Projekte/GAP/gap/lib/mapphomo.gi:717
 [2] PreImagesSet( map, Range( map ) )
   @ /Users/mhorn/Projekte/GAP/gap/lib/mapping.gi:1154
 [3] PreImagesRange( map )
   @ /Users/mhorn/Projekte/GAP/gap/lib/mapping.gi:574
 [4] IsMapping( hom )
   @ /Users/mhorn/Projekte/GAP/gap/lib/ringhom.gi:86
<function "RingHomomorphismByImages">( <arguments> )
 called from read-eval loop at *stdin*:3
type 'quit;' to quit to outer loop
brk>
```

While one can solve that one by doing `SetGeneratorsOfAdditiveGroup(Integers, [1]);`, one just runs into the next "method not found". Similar for the finite rings `R`, `S`, where one gets a little bit farther, but not much.

So in the end, this is simply a missing feature, which is not great, but at least explicable.

A workaround can be to use rings created via `RingByStructureConstants`, for those more functionality exists:
```gap-repl
gap> T:= EmptySCTable( 1, 0 );;
gap> SetEntrySCTable( T, 1, 1, [ 1, 1 ] );
gap> R:=RingByStructureConstants([9], T);
<ring with 1 generator>
gap> S:=RingByStructureConstants([3], T);
<ring with 1 generator>
gap> hom := RingHomomorphismByImages(R,S,[One(R)],[One(S)]);
[ r.1 ] -> [ r.1 ]
gap> AsSet(Kernel(hom));
[ 0*r.1, 3*r.1, 6*r.1 ]
```
