### PR TITLE
Normalize release archive permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       #  run: python -m mypy --disallow-untyped-calls --disallow-untyped-defs dev/releases/*.py
 
       - name: "Run tests"
-        run: cd dev/releases && python -m pytest test_release_notes.py
+        run: cd dev/releases && python -m pytest
 
   unix:
     name: "Create Unix archives and data"

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -24,8 +24,11 @@ default: all
 ########################################################################
 # Developer helper targets
 ########################################################################
-test_release_notes:
-	cd dev/releases && python3 -m pytest test_release_notes.py
+test_release_scripts:
+	cd dev/releases && python3 -m pytest
+.PHONY: test_release_scripts
+
+test_release_notes: test_release_scripts
 .PHONY: test_release_notes
 
 

--- a/dev/releases/make_archives.py
+++ b/dev/releases/make_archives.py
@@ -29,6 +29,7 @@ from typing import List, Optional
 from utils import (
     download_with_sha256,
     error,
+    normalize_archive_permissions,
     notice,
     patchfile,
     verify_command_available,
@@ -211,14 +212,11 @@ with working_directory(tmpdir + "/" + basename):
     notice("Extracting package tarballs")
     with tarfile.open(tmpdir + "/" + all_packages_tarball) as tar:
         tar.extractall(path="pkg")
-    # for some reason pkg sometimes ends up with permission 0700 so
-    # we make sure to fix that here
-    subprocess.run(["chmod", "0755", "pkg"], check=True)
-    # ensure all files are at readable by everyone
-    subprocess.run(["chmod", "-R", "a+r", "."], check=True)
 
     with tarfile.open(tmpdir + "/" + req_packages_tarball) as tar:
         tar.extractall(path=tmpdir + "/" + req_packages)
+    notice("Normalizing permissions in required packages")
+    normalize_archive_permissions(tmpdir + "/" + req_packages)
 
     notice("Building GAP's manuals")
     run_with_log(["make", "doc"], "gapdoc", "building the manuals")
@@ -277,6 +275,9 @@ with working_directory(tmpdir + "/" + basename):
 
     notice("Removing generated files we don't want to distribute")
     run_with_log(["make", "distclean"], "make-distclean", "make distclean")
+
+    notice("Normalizing permissions in GAP archive tree")
+    normalize_archive_permissions(".")
 
 
 # Create an archive in the current directory with shutil.make_archive, and

--- a/dev/releases/test_archive_utils.py
+++ b/dev/releases/test_archive_utils.py
@@ -1,0 +1,39 @@
+import os
+import stat
+
+from utils import normalize_archive_permissions
+
+
+def mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_normalize_archive_permissions_removes_group_and_other_write_bits(tmp_path):
+    package_dir = tmp_path / "pkg"
+    package_dir.mkdir()
+    private_dir = package_dir / "private"
+    private_dir.mkdir()
+    unreadable_dir = package_dir / "unreadable"
+    unreadable_dir.mkdir()
+    world_writable_file = package_dir / "data.g"
+    world_writable_file.write_text("data", encoding="utf-8")
+    executable_file = package_dir / "script.sh"
+    executable_file.write_text("#!/bin/sh\n", encoding="utf-8")
+    oddly_executable_file = package_dir / "odd.g"
+    oddly_executable_file.write_text("data", encoding="utf-8")
+
+    os.chmod(package_dir, 0o777)
+    os.chmod(private_dir, 0o700)
+    os.chmod(unreadable_dir, 0o600)
+    os.chmod(world_writable_file, 0o666)
+    os.chmod(executable_file, 0o777)
+    os.chmod(oddly_executable_file, 0o654)
+
+    normalize_archive_permissions(tmp_path)
+
+    assert mode(package_dir) == 0o755
+    assert mode(private_dir) == 0o755
+    assert mode(unreadable_dir) == 0o755
+    assert mode(world_writable_file) == 0o644
+    assert mode(executable_file) == 0o755
+    assert mode(oddly_executable_file) == 0o644

--- a/dev/releases/utils.py
+++ b/dev/releases/utils.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 from typing import Iterator, NoReturn
@@ -72,6 +73,29 @@ def working_directory(path: str) -> Iterator[None]:
     os.chdir(path)
     yield
     os.chdir(prev_cwd)
+
+
+def normalize_archive_permissions(root: str) -> None:
+    """Apply the archive permission policy recursively below ``root``.
+
+    This mirrors ``chmod -R g-w,o-w,g+r,o+r`` for regular files and also makes
+    directories searchable by group and others. File executable bits are
+    normalized from the owner's executable bit, so scripts remain executable
+    without making ordinary data files executable. Symlinks are left untouched.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in [dirpath, *dirnames, *filenames]:
+            path = os.path.join(dirpath, name) if name != dirpath else dirpath
+            if os.path.islink(path):
+                continue
+            mode = stat.S_IMODE(os.stat(path).st_mode)
+            mode |= stat.S_IRGRP | stat.S_IROTH
+            mode &= ~(stat.S_IWGRP | stat.S_IWOTH)
+            if os.path.isdir(path) or mode & stat.S_IXUSR:
+                mode |= stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            else:
+                mode &= ~(stat.S_IXGRP | stat.S_IXOTH)
+            os.chmod(path, mode)
 
 
 # compute the sha256 checksum of a file


### PR DESCRIPTION
Remove group and other write bits before creating release archives. Keep package contents readable while preserving and normalizing executable bits.

Co-authored-by: Codex <codex@openai.com>

---

This is meant to address [the problem observed](https://github.com/gap-system/gap/discussions/6352#discussioncomment-17077588) by @frankluebeck (CC @orlitzky)

I'd like to get this merged quickly so I can make the release (this is the only thing missing on my list)