### PR TITLE
kernel: refactor `FuncPRINT_CURRENT_STATEMENT`

### DIFF
--- a/lib/error.g
+++ b/lib/error.g
@@ -135,7 +135,8 @@ BIND_GLOBAL("PRETTY_PRINT_VARS", function(context)
 end);
 
 BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
-    local bottom, lastcontext, f, level, totaldepth, countcontext;
+    local bottom, lastcontext, f, level, totaldepth, countcontext,
+          prefixwidth, location;
     if depth <= 0 then
         return;
     fi;
@@ -151,14 +152,20 @@ BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
         totaldepth := totaldepth + 1;
         countcontext := ParentLVars(countcontext);
     od;
+    prefixwidth := Length(String(totaldepth));
     level := 1;
     while depth > 0  and context <> bottom do
-        PRINT_CURRENT_STATEMENT(
+        location := PRINT_CURRENT_STATEMENT(
             ERROR_OUTPUT,
             context,
             activecontext,
             level,
-            totaldepth);
+            prefixwidth);
+        if location <> fail then
+            PrintTo(ERROR_OUTPUT, "\n",
+                    ListWithIdenticalEntries(prefixwidth+2, ' '),
+                    "@ ", location[1], ":", location[2]);
+        fi;
         if showlocals then
             PRETTY_PRINT_VARS(context);
         else

--- a/src/error.c
+++ b/src/error.c
@@ -184,12 +184,17 @@ static Obj FuncCURRENT_STATEMENT_LOCATION(Obj self, Obj context)
     return retlist;
 }
 
-static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
-                                       Obj activeContext, Obj level,
-                                       Obj totalDepth)
+static Obj FuncPRINT_CURRENT_STATEMENT(Obj self,
+                                       Obj stream,
+                                       Obj context,
+                                       Obj activeContext,
+                                       Obj level,
+                                       Obj prefixWidth)
 {
+    volatile Obj location = Fail;
+
     if (IsBottomLVars(context))
-        return 0;
+        return Fail;
 
     // HACK: we want to redirect output
     // Try to print the output to stream. Use *errout* as a fallback.
@@ -208,35 +213,26 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
     BOOL rethrow = FALSE;
     GAP_TRY
     {
-        UInt levelInt = INT_INTOBJ(level);
-        UInt totalDepthInt = INT_INTOBJ(totalDepth);
-        UInt prefixWidth = 0;
-        UInt levelWidth = 0;
-        UInt i;
-
-        char prefix[32];
         Obj func = FUNC_LVARS(context);
         Obj funcname = NAME_FUNC(func);
         Int line = -1;
-        GAP_ASSERT(func);
+
         Stat call = STAT_LVARS(context);
         Obj  body = BODY_FUNC(func);
         Obj  filename = GET_FILENAME_BODY(body);
 
-        while (totalDepthInt > 0) {
-            prefixWidth++;
-            totalDepthInt /= 10;
-        }
-
         if (activeContext != Fail) {
-            i = levelInt;
+            char prefix[32];
+            UInt levelInt = INT_INTOBJ(level);
+            UInt levelWidth = 0;
+            UInt i = levelInt;
             while (i > 0) {
                 levelWidth++;
                 i /= 10;
             }
             snprintf(prefix, sizeof(prefix), "%c%*s[%lu] ",
                      context == activeContext ? '*' : ' ',
-                     (int)(prefixWidth - levelWidth), "",
+                     (int)(INT_INTOBJ(prefixWidth) - levelWidth), "",
                      (unsigned long)levelInt);
             Pr("%s", (Int)prefix, 0);
         }
@@ -274,11 +270,7 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
             SWITCH_TO_OLD_LVARS(currLVars);
         }
         if (line > 0) {
-            Pr("\n", 0, 0);
-            for (i = 0; i < prefixWidth + 2; i++) {
-                Pr(" ", 0, 0);
-            }
-            Pr("@ %g:%d", (Int)filename, line);
+            location = NewPlistFromArgs(filename, INTOBJ_INT(line));
         }
     }
     GAP_CATCH
@@ -292,7 +284,7 @@ static Obj FuncPRINT_CURRENT_STATEMENT(Obj self, Obj stream, Obj context,
     if (rethrow)
         GAP_THROW();
 
-    return 0;
+    return location;
 }
 
 /****************************************************************************

--- a/tst/testinstall/kernel/gap.tst
+++ b/tst/testinstall/kernel/gap.tst
@@ -112,9 +112,9 @@ fail
 gap> CURRENT_STATEMENT_LOCATION(GetCurrentLVars());
 fail
 gap> PRINT_CURRENT_STATEMENT("*errout*", GetCurrentLVars(), fail, 1, 1);
+fail
 gap> f:=function() local l; l:=GetCurrentLVars(); PRINT_CURRENT_STATEMENT("*errout*", l, fail, 1, 1); Print("\n"); end;; f();
 PRINT_CURRENT_STATEMENT( "*errout*", l, fail, 1, 1 );
-   @ stream:1
 
 #
 gap> CALL_WITH_CATCH(fail,fail);


### PR DESCRIPTION
Move part of the code from the kernel to the library. This will make future improvements easier.

Co-authored-by: Codex <codex@openai.com>

---

(Specifically, I have two follow-up PRs prepared that will further improve the stacktrace printing; it is easier to do that if as much of the code as possible is written in GAP.)