### PR TITLE
Fix an unexpected error when calling `ConjugateGroup` on matrix groups not defined over a field

### DIFF
--- a/lib/grpmat.gi
+++ b/lib/grpmat.gi
@@ -1341,7 +1341,12 @@ InstallMethod( ConjugateGroup, "<G>, <g>", IsCollsElms,
     if HasIsSubgroupSL( G ) then
       SetIsSubgroupSL( H, IsSubgroupSL( G ) );
     fi;
-    F:= FieldOfMatrixList( [ g ] );
+
+    F:= DefaultScalarDomainOfMatrixList( [ g ] );
+    if not IsField( F ) then
+      return H;
+    fi;
+
     if HasInvariantBilinearForm( G ) then
       if not IsBound( ginv ) then
         ginv := g^-1;

--- a/tst/testbugfix/2026-06-05-ConjugateGroup.tst
+++ b/tst/testbugfix/2026-06-05-ConjugateGroup.tst
@@ -1,0 +1,13 @@
+# Fix an unexpected error in ConjugateGroup when applied to
+# a matrix group not over a field
+# See https://github.com/gap-system/gap/issues/6423
+gap> G:=SL(2,Integers mod 4);;
+gap> H:=ConjugateGroup(G,G.1);;
+gap> G = H;
+true
+
+# original test case
+gap> S := SylowSubgroup(SL(2,Integers mod 4),2);;
+gap> M := MaximalSubgroups(S);;
+gap> Length(M);
+3


### PR DESCRIPTION
Fixes #6423