### PR TITLE
RFC: Remove 'Stack trace' from break loop messages (???)

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -42,7 +42,6 @@ error as in the following example occurs and a break loop is entered:
 gap> IsNormal(2,2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `IsNormal' on 2 arguments
-Stack trace:
 called from read-eval loop at *stdin*:1
 type 'quit;' to quit to outer loop
 brk>

--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -716,7 +716,6 @@ gap> xx := 15;
 gap> MakeReadOnlyGlobal("xx");
 gap> xx := 16;
 Error, Variable: 'xx' is read only
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;
@@ -1562,7 +1561,6 @@ gap> f2:= function( x ) return f1( x ); end;;
 gap> f2( 4 );
 value: 4
 Error, Function Calls: <func> must return a value
-Stack trace:
 *[1] f1( x )
    @ *stdin*:2
 <function "f2">( <arguments> )

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -477,7 +477,6 @@ indicate that you are in a break loop.
 <Log><![CDATA[
 gap> 1/0;
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 ]]></Log>
@@ -488,7 +487,6 @@ If errors occur within a break loop &GAP; enters another break loop at a
 <Log><![CDATA[
 brk> 1/0;
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 not in any function at *errin*:1
 type 'quit;' to quit to outer loop
 brk_2>
@@ -898,7 +896,6 @@ gap> fun := function() local x; x := 3; bar(); end;
 function(  ) ... end
 gap> fun();
 Error, !!
-Stack trace:
 *[1] Error( "!!\n" );
    @ *stdin*:4
  [2] bar(  );

--- a/doc/ref/types.xml
+++ b/doc/ref/types.xml
@@ -602,7 +602,6 @@ for an object.
 <Log><![CDATA[
 gap> Setter( prop )( Rationals, false );
 Error, You cannot set an "and-filter" except to true
-Stack trace:
 not in any function at *stdin*:8
 type 'quit;' to quit to outer loop
 brk>

--- a/doc/tut/lists.xml
+++ b/doc/tut/lists.xml
@@ -342,7 +342,6 @@ gap> list[3][5] := 'w';; list; copy;
 [ 1, 2, "three", [ 4 ] ]
 gap> copy[3][5] := 'w';
 Error, List Assignment: <list> must be a mutable list
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/lib/error.g
+++ b/lib/error.g
@@ -301,9 +301,6 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
 
     printAutomaticTraceback := function()
         if IsBound(OnBreak) and IsFunction(OnBreak) then
-            if OnBreak = Where or OnBreak = WhereWithVars then
-                PrintTo(ERROR_OUTPUT, "Stack trace:\n");
-            fi;
             OnBreak();
         fi;
     end;

--- a/lib/grpfp.gd
+++ b/lib/grpfp.gd
@@ -78,7 +78,6 @@ fi;
 ##  Group([ b ])
 ##  gap> Index( f, u );
 ##  Error, the coset enumeration has defined more than 4096000 cosets
-##  Stack trace:
 ##  *[1] Error( "the coset enumeration has defined more ", "than ", limit, " cosets\n" );
 ##     @ GAPROOT/lib/grpfp.gi:1230
 ##   [2] TCENUM.CosetTableFromGensAndRels( fgens, grels, fsgens )

--- a/tst/testspecial/64bit/low-mem-list-types.g.out
+++ b/tst/testspecial/64bit/low-mem-list-types.g.out
@@ -1,18 +1,15 @@
 gap> ListWithIdenticalEntries(2^50, 'a');
 Error, Cannot allocate 1125899906842633 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> ListWithIdenticalEntries(2^50, true);
 Error, Cannot allocate 140737488355336 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> ListWithIdenticalEntries(2^50, 2);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/64bit/low-mem-plist-1.g.out
+++ b/tst/testspecial/64bit/low-mem-plist-1.g.out
@@ -2,13 +2,11 @@ gap> l := [];
 [  ]
 gap> l[2^50] := 1;
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> l[2^50] := 2;
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/64bit/low-mem-plist-2.g.out
+++ b/tst/testspecial/64bit/low-mem-plist-2.g.out
@@ -1,12 +1,10 @@
 gap> EmptyPlist(2^50);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> EmptyPlist(2^50);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -13,7 +13,6 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]:=' on 3 arguments
-Stack trace:
 *[1] l[[ 1 .. 3 ]] := 1;
    @ *stdin*:11
 <function "f">( <arguments> )
@@ -38,7 +37,6 @@ gap> ###########################################################################
 gap> f:=function() if true = 1/0 then return 1; fi; return 2; end;;
 gap> f();
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 *[1] 1 / 0
    @ *stdin*:15
 <function "f">( <arguments> )
@@ -62,7 +60,6 @@ gap> ###########################################################################
 gap> f:=function() local x; if x then return 1; fi; return 2; end;;
 gap> f();
 Error, Variable: 'x' must have an assigned value
-Stack trace:
 *[1] if x then
     return 1;
 fi;
@@ -93,7 +90,6 @@ gap> ###########################################################################
 gap> f:=function() if 1 then return 1; fi; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
-Stack trace:
 *[1] if 1 then
     return 1;
 fi;
@@ -123,7 +119,6 @@ gap> ###########################################################################
 gap> f:=function() if 1 < 0 then return 1; elif 1 then return 2; fi; return 3; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
-Stack trace:
 *[1] if 1 < 0 then
     return 1;
 elif 1 then
@@ -159,7 +154,6 @@ gap> ###########################################################################
 gap> f:=function() while 1 do return 1; od; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
-Stack trace:
 *[1] while 1 do
     return 1;
 od;
@@ -189,7 +183,6 @@ gap> ###########################################################################
 gap> f:=function() local i; for i in 1 do return 1; od; return 2; end;;
 gap> f();
 Error, You cannot loop over the integer 1 did you mean the range [1..1]
-Stack trace:
 *[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" );
    @ GAPROOT/lib/integer.gi:LINE
  [2] for i in 1 do
@@ -231,7 +224,6 @@ gap> f:=function() local i; for i in true do return 1; od; return 2; end;;
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
-Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -262,7 +254,6 @@ gap> f:=function(x) local i,j; for i in true do return 1; od; return 2; end;;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
-Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -295,7 +286,6 @@ gap> f:=function(x) local i,j; Unbind(x); for i in true do return 1; od; return 
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
-Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -328,7 +318,6 @@ gap> f:=function(x) local i,j; Unbind(x); j := 4; for i in true do return 1; od;
 gap> f([1,2,3]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Iterator' on 1 arguments
-Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -360,7 +349,6 @@ gap>
 gap> f:=function() local x; repeat x:=1; until 1; return 2; end;;
 gap> f();
 Error, <expr> must be 'true' or 'false' (not the integer 1)
-Stack trace:
 *[1] repeat
     x := 1;
 until 1;
@@ -391,7 +379,6 @@ gap> ###########################################################################
 gap> f:=function() local x; Assert(0, 1); return 2; end;;
 gap> f();
 Error, Assert: <cond> must be 'true' or 'false' (not the integer 1)
-Stack trace:
 *[1] Assert( 0, 1 );
    @ *stdin*:44
 <function "f">( <arguments> )
@@ -416,7 +403,6 @@ gap> ###########################################################################
 gap> f:=function() local x; Assert(0, 1, "hello"); return 2; end;;
 gap> f();
 Error, Assert: <cond> must be 'true' or 'false' (not the integer 1)
-Stack trace:
 *[1] Assert( 0, 1, "hello" );
    @ *stdin*:47
 <function "f">( <arguments> )
@@ -446,7 +432,6 @@ gap> InstallMethod( \[\,\], [ IsMatrixOrMatrixObj, IsPosInt, IsPosInt ],
 gap> l := [[1]];; f := {} -> l[2,1];;
 gap> f();
 Error, List Element: <list>[2] must have an assigned value
-Stack trace:
 *[1] return m[i][j];
    @ GAPROOT/lib/matrix.gi:LINE
  [2] ELM_LIST( m, row, col )
@@ -494,7 +479,6 @@ gap> ##  Verify issue #1373 is fixed
 gap> ##
 gap> InstallMethod( Matrix, [IsFilter, IsSemiring, IsMatrixObj], {a,b,c} -> fail );
 Error, FLAGS_FILTER: <oper> must be an operation (not a function)
-Stack trace:
 *[1] <<compiled GAP function "INSTALL_METHOD">>
    @ GAPROOT/lib/oper1.g:LINE
  [2] <<compiled GAP function "InstallMethod">>

--- a/tst/testspecial/backtrace2.g.out
+++ b/tst/testspecial/backtrace2.g.out
@@ -26,7 +26,6 @@ gap> test:= function( n )
 > end;;
 gap> test( 1 );
 Error, !
-Stack trace:
 *[1] Error( "!\n" );
    @ *stdin*:24
  [2] test( n + 1 );
@@ -121,7 +120,6 @@ gap> test:= function( n )
 > end;;
 gap> test( 1 );
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 *[1] 1 / 0
    @ *stdin*:35
  [2] test( n + 1 );
@@ -217,7 +215,6 @@ gap> test:= function( n )
 gap> test( 1 );
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `IsCommutative' on 1 arguments
-Stack trace:
 *[1] IsAbelian( 1 )
    @ *stdin*:47
  [2] test( n + 1 );

--- a/tst/testspecial/bad-add.g.out
+++ b/tst/testspecial/bad-add.g.out
@@ -5,7 +5,6 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
-Stack trace:
 *[1] 1 + "abc"
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-array-double-1.g.out
+++ b/tst/testspecial/bad-array-double-1.g.out
@@ -5,7 +5,6 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[,]' on 3 arguments
-Stack trace:
 *[1] return "abc"[1, 1];
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-array-int-0.g.out
+++ b/tst/testspecial/bad-array-int-0.g.out
@@ -7,7 +7,6 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments
-Stack trace:
 *[1] return l[0];
    @ *stdin*:5
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-array-int-1.g.out
+++ b/tst/testspecial/bad-array-int-1.g.out
@@ -4,7 +4,6 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, List Element: <list> must be a list (not the integer 1)
-Stack trace:
 *[1] return 1[1];
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-array-string.g.out
+++ b/tst/testspecial/bad-array-string.g.out
@@ -5,7 +5,6 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments
-Stack trace:
 *[1] return 1["abc"];
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-array-undef-0.g.out
+++ b/tst/testspecial/bad-array-undef-0.g.out
@@ -5,7 +5,6 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, Variable: 'l' must have an assigned value
-Stack trace:
 *[1] return l[1];
    @ *stdin*:4
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-array-undef-1.g.out
+++ b/tst/testspecial/bad-array-undef-1.g.out
@@ -6,7 +6,6 @@ gap> f := function()
 function(  ) ... end
 gap> f();
 Error, Variable: 'm' must have an assigned value
-Stack trace:
 *[1] return l[m];
    @ *stdin*:5
 <function "f">( <arguments> )

--- a/tst/testspecial/bad-minus.g.out
+++ b/tst/testspecial/bad-minus.g.out
@@ -5,7 +5,6 @@ function(  ) ... end
 gap> f();
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `AdditiveInverseMutable' on 1 arguments
-Stack trace:
 *[1] AdditiveInverseMutable( elm )
    @ GAPROOT/lib/arith.gi:LINE
  [2] AdditiveInverseImmutable( elm )

--- a/tst/testspecial/break-loop-loop.g.out
+++ b/tst/testspecial/break-loop-loop.g.out
@@ -4,7 +4,6 @@ gap> i:=0;
 0
 gap> f(1);
 Error, bar
-Stack trace:
 *[1] Error( "bar" );
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/broken-test.g.out
+++ b/tst/testspecial/broken-test.g.out
@@ -1,6 +1,5 @@
 gap> Test("broken-test-2.tst", rec(width := 800));
 Error, Invalid test file: #@ command found in the middle of a single test at broken-test-2.tst:5
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: #@ command found in the middle of a single test" );
@@ -13,7 +12,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-3.tst", rec(width := 800));
 Error, Invalid test file at broken-test-3.tst:5
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file" );
@@ -26,7 +24,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-4.tst", rec(width := 800));
 Error, Invalid test file: Nested #@if at broken-test-4.tst:2
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: Nested #@if" );
@@ -39,7 +36,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-5.tst", rec(width := 800));
 Error, Invalid test file: two #@else at broken-test-5.tst:7
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: two #@else" );
@@ -52,7 +48,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-6.tst", rec(width := 800));
 Error, Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space at broken-test-6.tst:3
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: Continuation prompt '> ' followed by a tab, expected a regular space" );
@@ -65,7 +60,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-7.tst", rec(width := 800));
 Error, Invalid test file: #@elif after #@else at broken-test-7.tst:7
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: #@elif after #@else" );
@@ -78,7 +72,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-8.tst", rec(width := 800));
 Error, Invalid test file: #@elif without #@if at broken-test-8.tst:1
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: #@elif without #@if" );
@@ -91,7 +84,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("broken-test-9.tst", rec(width := 800));
 Error, Invalid test file: Unterminated #@if at broken-test-9.tst:7
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file: Unterminated #@if" );
@@ -104,7 +96,6 @@ type 'quit;' to quit to outer loop
 brk> quit;
 gap> Test("invalidtestfile.tst", rec(width := 800));
 Error, Invalid test file at invalidtestfile.tst:7
-Stack trace:
 *[1] ErrorNoReturn( s, " at ", fnam, ":", i );
    @ GAPROOT/lib/test.gi:LINE
  [2] testError( "Invalid test file" );

--- a/tst/testspecial/current-env.g.out
+++ b/tst/testspecial/current-env.g.out
@@ -7,7 +7,6 @@ gap> f := function()
 > end;;
 gap> f();
 Error, You cannot loop over the integer 1 did you mean the range [1..1]
-Stack trace:
 *[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" );
    @ GAPROOT/lib/integer.gi:LINE
  [2] for i in 1 do

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -12,7 +12,6 @@ gap> f:=function(a)
 > end;;
 gap> f(1);
 Error, breakpoint
-Stack trace:
 *[1] Error( "breakpoint" );
    @ *stdin*:9
  [2] g( 10 )
@@ -37,7 +36,6 @@ Syntax warning: Unbound global variable in *errin*:6
 unbound_global;
 ^^^^^^^^^^^^^^
 Error, Variable: 'unbound_global' must have a value
-Stack trace:
 *[1] Error( "breakpoint" );
    @ *stdin*:9
  [2] g( 10 )
@@ -54,7 +52,6 @@ brk> IsBound(y);
 true
 brk> unbound_higher;
 Error, Variable: 'unbound_higher' must have an assigned value
-Stack trace:
 *[1] Error( "breakpoint" );
    @ *stdin*:9
  [2] g( 10 )
@@ -73,7 +70,6 @@ brk> IsBound(z);
 true
 brk> unbound_local;
 Error, Variable: 'unbound_local' must have an assigned value
-Stack trace:
 *[1] Error( "breakpoint" );
    @ *stdin*:9
  [2] g( 10 )
@@ -89,7 +85,6 @@ gap> x;
 42
 gap> y;
 Error, Variable: 'y' must have a value
-Stack trace:
 not in any function at *stdin*:16
 gap> 
 gap> h:=function(p)
@@ -100,7 +95,6 @@ gap> h:=function(p)
 function( p ) ... end
 gap> f(1);
 Error, breakpoint
-Stack trace:
 *[1] Error( "breakpoint" );
    @ *stdin*:9
  [2] g( 10 )
@@ -111,7 +105,6 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> h(2);
 Error, foobar
-Stack trace:
 *[1] Error( "foobar" );
    @ *stdin*:20
  [2] Error( "breakpoint" );
@@ -132,7 +125,6 @@ brk_2> IsBound(y);
 true
 brk_2> unbound_higher;
 Error, Variable: <debug-variable-1-4> must have a value
-Stack trace:
 *[1] Error( "foobar" );
    @ *stdin*:20
  [2] Error( "breakpoint" );
@@ -145,7 +137,6 @@ brk_2>
 brk_2> # check coding of dvars
 brk_2> function() return unbound_higher; end;
 Error, Variable: <debug-variable-1-4> cannot be used here
-Stack trace:
 *[1] Error( "foobar" );
    @ *stdin*:20
  [2] Error( "breakpoint" );
@@ -156,7 +147,6 @@ Stack trace:
  called from read-eval loop at *errin*:9
 brk_2> function() return IsBound(unbound_higher); end;
 Error, Variable: <debug-variable-1-4> cannot be used here
-Stack trace:
 *[1] Error( "foobar" );
    @ *stdin*:20
  [2] Error( "breakpoint" );
@@ -167,7 +157,6 @@ Stack trace:
  called from read-eval loop at *errin*:10
 brk_2> function() Unbind(unbound_higher); end;
 Error, Variable: <debug-variable-1-4> cannot be used here
-Stack trace:
 *[1] Error( "foobar" );
    @ *stdin*:20
  [2] Error( "breakpoint" );
@@ -178,7 +167,6 @@ Stack trace:
  called from read-eval loop at *errin*:11
 brk_2> function() unbound_higher:=0; end;
 Error, Variable: <debug-variable-1-4> cannot be used here
-Stack trace:
 *[1] Error( "foobar" );
    @ *stdin*:20
  [2] Error( "breakpoint" );

--- a/tst/testspecial/error-in-InputTextString.g.out
+++ b/tst/testspecial/error-in-InputTextString.g.out
@@ -1,7 +1,6 @@
 gap> Read(InputTextString("Print(1 + [()]);"));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
-Stack trace:
 called from read-eval loop at stream:1
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/func-and-proc-call-trace.g.out
+++ b/tst/testspecial/func-and-proc-call-trace.g.out
@@ -5,7 +5,6 @@ gap> informproc0 := function(l)
 gap> informproc0([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l(  );
    @ *stdin*:4
 <function "informproc0">( <arguments> )
@@ -22,7 +21,6 @@ gap> informproc1 := function(l)
 gap> informproc1([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1 );
    @ *stdin*:9
 <function "informproc1">( <arguments> )
@@ -39,7 +37,6 @@ gap> informproc2 := function(l)
 gap> informproc2([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2 );
    @ *stdin*:14
 <function "informproc2">( <arguments> )
@@ -56,7 +53,6 @@ gap> informproc3 := function(l)
 gap> informproc3([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3 );
    @ *stdin*:19
 <function "informproc3">( <arguments> )
@@ -73,7 +69,6 @@ gap> informproc4 := function(l)
 gap> informproc4([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4 );
    @ *stdin*:24
 <function "informproc4">( <arguments> )
@@ -90,7 +85,6 @@ gap> informproc5 := function(l)
 gap> informproc5([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4, 5 );
    @ *stdin*:29
 <function "informproc5">( <arguments> )
@@ -107,7 +101,6 @@ gap> informproc6 := function(l)
 gap> informproc6([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4, 5, 6 );
    @ *stdin*:34
 <function "informproc6">( <arguments> )
@@ -124,7 +117,6 @@ gap> informprocmore := function(l)
 gap> informprocmore([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4, 5, 6, 7 );
    @ *stdin*:39
 <function "informprocmore">( <arguments> )
@@ -141,7 +133,6 @@ gap> informfunc0 := function(l)
 gap> informfunc0([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l(  )
    @ *stdin*:44
 <function "informfunc0">( <arguments> )
@@ -158,7 +149,6 @@ gap> informfunc1 := function(l)
 gap> informfunc1([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1 )
    @ *stdin*:49
 <function "informfunc1">( <arguments> )
@@ -175,7 +165,6 @@ gap> informfunc2 := function(l)
 gap> informfunc2([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2 )
    @ *stdin*:54
 <function "informfunc2">( <arguments> )
@@ -192,7 +181,6 @@ gap> informfunc3 := function(l)
 gap> informfunc3([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3 )
    @ *stdin*:59
 <function "informfunc3">( <arguments> )
@@ -209,7 +197,6 @@ gap> informfunc4 := function(l)
 gap> informfunc4([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4 )
    @ *stdin*:64
 <function "informfunc4">( <arguments> )
@@ -226,7 +213,6 @@ gap> informfunc5 := function(l)
 gap> informfunc5([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4, 5 )
    @ *stdin*:69
 <function "informfunc5">( <arguments> )
@@ -243,7 +229,6 @@ gap> informfunc6 := function(l)
 gap> informfunc6([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4, 5, 6 )
    @ *stdin*:74
 <function "informfunc6">( <arguments> )
@@ -260,7 +245,6 @@ gap> informfuncmore := function(l)
 gap> informfuncmore([]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CallFuncList' on 2 arguments
-Stack trace:
 *[1] l( 1, 2, 3, 4, 5, 6, 7 )
    @ *stdin*:79
 <function "informfuncmore">( <arguments> )

--- a/tst/testspecial/last-access.g.out
+++ b/tst/testspecial/last-access.g.out
@@ -5,7 +5,6 @@ gap> 1;2;3;[last,last2,last3];
 [ 3, 2, 1 ]
 gap> Error("err");
 Error, err
-Stack trace:
 not in any function at *stdin*:3
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/line-continuation.g.out
+++ b/tst/testspecial/line-continuation.g.out
@@ -4,10 +4,8 @@ gap> # counter only once, so that both examples below report the error in line 2
 gap> #
 gap> EvalString("123\\\n45x;");
 Error, Variable: '12345x' must have a value
-Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
-Stack trace:
 *[1] Error( "Could not evaluate string.\n" );
    @ GAPROOT/lib/string.gi:LINE
 <function "EvalString">( <arguments> )
@@ -17,10 +15,8 @@ you can 'return;' to continue
 brk> quit;
 gap> EvalString("123\\\r\n45x;");
 Error, Variable: '12345x' must have a value
-Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
-Stack trace:
 *[1] Error( "Could not evaluate string.\n" );
    @ GAPROOT/lib/string.gi:LINE
 <function "EvalString">( <arguments> )

--- a/tst/testspecial/mem-overflow.g.out
+++ b/tst/testspecial/mem-overflow.g.out
@@ -2,7 +2,6 @@ gap> # double a list until there is a memory overflow
 gap> l:=[1];; while true do Append(l,l); od;
 Error, reached the pre-set memory limit
 (change it with the -o command line option)
-Stack trace:
 *[1] Append( l, l );
    @ *stdin*:3
 <function "unknown">( <arguments> )

--- a/tst/testspecial/method-not-found-where.g.out
+++ b/tst/testspecial/method-not-found-where.g.out
@@ -3,7 +3,6 @@ gap> f := a -> IsDiagonalMat(a);;
 gap> f(());
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `IsDiagonalMatrix' on 1 arguments
-Stack trace:
 *[1] IsDiagonalMat( a )
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/method-not-found.g.out
+++ b/tst/testspecial/method-not-found.g.out
@@ -2,7 +2,6 @@ gap> # test returning from a 'method not found' error
 gap> f:=a->a+a;; f(());
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
-Stack trace:
 *[1] a + a
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -22,7 +22,6 @@ gap>
 gap> # test formatting status for errout
 gap> 1/0; # trigger a break loop
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 not in any function at *stdin*:14
 type 'quit;' to quit to outer loop
 brk> old := PrintFormattingStatus("*errout*");

--- a/tst/testspecial/repl-syntax-err.g.out
+++ b/tst/testspecial/repl-syntax-err.g.out
@@ -7,7 +7,6 @@ gap> # error, which wasn't reported correctly before the above issues was
 gap> # fixed.
 gap> Error(""):
 Error, 
-Stack trace:
 not in any function at *stdin*:9
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/stack-depth-func.g.out
+++ b/tst/testspecial/stack-depth-func.g.out
@@ -2,7 +2,6 @@ gap> f := function() f(); end;
 function(  ) ... end
 gap> f();
 Error, recursion depth trap (5000)
-Stack trace:
 *[1] f(  );
    @ *stdin*:2
  [2] f(  );
@@ -18,7 +17,6 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> return; # try once more
 Error, recursion depth trap (10000)
-Stack trace:
 *[1] f(  );
    @ *stdin*:2
  [2] f(  );

--- a/tst/testspecial/stack-depth-func2.g.out
+++ b/tst/testspecial/stack-depth-func2.g.out
@@ -2,7 +2,6 @@ gap> f := function() local x; x := f(); return x; end;
 function(  ) ... end
 gap> y := f();
 Error, recursion depth trap (5000)
-Stack trace:
 *[1] f(  )
    @ *stdin*:2
  [2] f(  )
@@ -18,7 +17,6 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> return; # try once more
 Error, recursion depth trap (10000)
-Stack trace:
 *[1] f(  )
    @ *stdin*:2
  [2] f(  )

--- a/tst/testspecial/stack-depth-rec.g.out
+++ b/tst/testspecial/stack-depth-rec.g.out
@@ -70,7 +70,6 @@ rec(
                                                                                                                                                                                                                                                                  ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) )
 gap> String(r);
 Error, recursion depth trap (5000)
-Stack trace:
 *[1] String( record.(nam) )
    @ GAPROOT/lib/record.gi:LINE
  [2] String( record.(nam) )
@@ -86,7 +85,6 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> return; # try once more
 Error, recursion depth trap (5000)
-Stack trace:
 *[1] String( record.(nam) )
    @ GAPROOT/lib/record.gi:LINE
  [2] String( record.(nam) )

--- a/tst/testspecial/stack-trace-depth.g.out
+++ b/tst/testspecial/stack-trace-depth.g.out
@@ -33,7 +33,6 @@ gap> f1 := function()
 > end;;
 gap> f1();
 Error, foo
-Stack trace:
 *[1] Error( "foo" );
    @ *stdin*:3
  [2] f11(  )

--- a/tst/testspecial/stack-trace-label.g.out
+++ b/tst/testspecial/stack-trace-label.g.out
@@ -3,7 +3,6 @@ gap> f := function()
 > end;;
 gap> f();
 Error, foo
-Stack trace:
 *[1] Error( "foo" );
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/syntax-tree-error.g.out
+++ b/tst/testspecial/syntax-tree-error.g.out
@@ -8,7 +8,6 @@ function(  ) ... end
 gap> 
 gap> func( );
 Error, oops
-Stack trace:
 *[1] 
 <function "func">( <arguments> )
  called from read-eval loop at *stdin*:8

--- a/tst/testspecial/top-level-error.g.out
+++ b/tst/testspecial/top-level-error.g.out
@@ -1,6 +1,5 @@
 gap> Error("foo");
 Error, foo
-Stack trace:
 not in any function at *stdin*:2
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/trace.g.out
+++ b/tst/testspecial/trace.g.out
@@ -31,7 +31,6 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument operations
-Stack trace:
 not in any function at *stdin*:25
 gap> 
 gap> # with tracing
@@ -59,7 +58,6 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7);
 Error, sorry: cannot yet have X argument operations
-Stack trace:
 not in any function at *stdin*:36
 gap> UntraceMethods( o ); # not (yet?) supported
 gap> 
@@ -80,7 +78,6 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument operations
-Stack trace:
 not in any function at *stdin*:47
 gap> 
 gap> #
@@ -113,7 +110,6 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
-Stack trace:
 not in any function at *stdin*:70
 gap> 
 gap> # with tracing
@@ -138,7 +134,6 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
-Stack trace:
 not in any function at *stdin*:80
 gap> UntraceMethods( o );
 gap> 
@@ -157,6 +152,5 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
-Stack trace:
 not in any function at *stdin*:90
 gap> QUIT;

--- a/tst/testspecial/up-down-env.g.out
+++ b/tst/testspecial/up-down-env.g.out
@@ -7,7 +7,6 @@ gap> f:=lvl -> 1/lvl + f(lvl-1);
 function( lvl ) ... end
 gap> f(7);
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 *[1] 1 / lvl
    @ *stdin*:7
  [2] f( lvl - 1 )
@@ -55,7 +54,6 @@ brk> ##  start a fresh execution context
 brk> ##
 brk> Read("top-level-error.g");
 Error, foo
-Stack trace:
 not in any function at top-level-error.g:1
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
@@ -63,7 +61,6 @@ brk_2> Where(20);
 not in any function at *errin*:1
 brk_2> lvl; # since `Read` started a fresh execution context, we can't access lvl here
 Error, Variable: 'lvl' must have a value
-Stack trace:
 not in any function at *errin*:2
 brk_2> quit;
 brk> lvl;


### PR DESCRIPTION
I've added this in PR #6257 but now am not so sure anymore I like it, and the way it is inserted. See [this comment](https://github.com/gap-system/gap/pull/6416/changes#r3368251629) on PR #6416.

