### PR TITLE
Adjust when 'Stack trace:' message is printed

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -42,7 +42,6 @@ error as in the following example occurs and a break loop is entered:
 gap> IsNormal(2,2);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `IsNormal' on 2 arguments
-Stack trace:
 called from read-eval loop at *stdin*:1
 type 'quit;' to quit to outer loop
 brk>
@@ -918,6 +917,7 @@ gap> dive(100);
 gap> OnBreak:= function() Where(2); end;; # shorter traceback
 gap> dive(6000);
 Error, recursion depth trap (5000)
+Stack trace:
 *[1] dive( depth - 1 );
    @ *stdin*:1
  [2] dive( depth - 1 );
@@ -928,6 +928,7 @@ you can 'return;' to continue
 brk> return;
 gap> dive(11000);
 Error, recursion depth trap (5000)
+Stack trace:
 *[1] dive( depth - 1 );
    @ *stdin*:1
  [2] dive( depth - 1 );
@@ -937,6 +938,7 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> return;
 Error, recursion depth trap (10000)
+Stack trace:
 *[1] dive( depth - 1 );
    @ *stdin*:1
  [2] dive( depth - 1 );
@@ -980,6 +982,7 @@ gap> dive(100);
 Depth 100
 gap> dive(2500);
 Error, recursion depth trap (1000)
+Stack trace:
 *[1] dive( depth - 1 );
    @ *stdin*:4
  [2] dive( depth - 1 );
@@ -989,6 +992,7 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> return;
 Error, recursion depth trap (2000)
+Stack trace:
 *[1] dive( depth - 1 );
    @ *stdin*:4
  [2] dive( depth - 1 );

--- a/doc/ref/language.xml
+++ b/doc/ref/language.xml
@@ -716,7 +716,6 @@ gap> xx := 15;
 gap> MakeReadOnlyGlobal("xx");
 gap> xx := 16;
 Error, Variable: 'xx' is read only
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -751,7 +751,8 @@ Error, user interrupt
    @ GAPROOT/lib/stbc.gi:18
 <function "StabChain">( <arguments> )
  called from read-eval loop at *stdin*:2
-you can 'return;'
+you can 'quit;' to quit to outer loop, or
+you can 'return;' to continue
 brk> Where(2);
 *[1] genlabels := Filtered( genlabels, function ( x )
         return pnt ^ sgs[x] = pnt;

--- a/doc/ref/mloop.xml
+++ b/doc/ref/mloop.xml
@@ -477,7 +477,6 @@ indicate that you are in a break loop.
 <Log><![CDATA[
 gap> 1/0;
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 ]]></Log>
@@ -488,7 +487,6 @@ If errors occur within a break loop &GAP; enters another break loop at a
 <Log><![CDATA[
 brk> 1/0;
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 not in any function at *errin*:1
 type 'quit;' to quit to outer loop
 brk_2>
@@ -634,7 +632,8 @@ Here is a somewhat trivial demonstration of the use of
 <P/>
 <Log><![CDATA[
 gap> ErrorNoTraceBack("Gidday!", " How's", " it", " going?\n");
-Error, Gidday! How's it going?
+Error,
+Gidday! How's it going?
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> quit;
@@ -828,14 +827,15 @@ Error, !
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
+Stack trace:
 *[1] Error( "!\n" );
-   @ *stdin*:4
+   @ *stdin*:3
  [2] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [3] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [4] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> n;
@@ -844,28 +844,30 @@ brk> DownEnv();
 brk> n;
 3
 brk> Where();
+Stack trace:
  [1] Error( "!\n" );
-   @ *stdin*:4
+   @ *stdin*:3
 *[2] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [3] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [4] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> DownEnv( 2 );
 brk> n;
 1
 brk> Where();
+Stack trace:
  [1] Error( "!\n" );
-   @ *stdin*:4
+   @ *stdin*:3
  [2] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [3] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 *[4] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:8
 brk> DownEnv( -2 );

--- a/doc/ref/types.xml
+++ b/doc/ref/types.xml
@@ -602,7 +602,6 @@ for an object.
 <Log><![CDATA[
 gap> Setter( prop )( Rationals, false );
 Error, You cannot set an "and-filter" except to true
-Stack trace:
 not in any function at *stdin*:8
 type 'quit;' to quit to outer loop
 brk>

--- a/doc/tut/group.xml
+++ b/doc/tut/group.xml
@@ -928,6 +928,7 @@ gap> Size( Image( hom, DerivedSubgroup(s4) ) );
 <Log><![CDATA[
 gap> PreImage( hom, (1,2,3) );
 Error, <map> must be an injective and surjective mapping
+Stack trace:
 *[1] ErrorNoReturn( "<map> must be an injective and surjective ", "mapping" );
    @ GAPROOT/lib/mapping.gi:262
 <function "PreImage">( <arguments> )

--- a/doc/tut/lists.xml
+++ b/doc/tut/lists.xml
@@ -342,7 +342,6 @@ gap> list[3][5] := 'w';; list; copy;
 [ 1, 2, "three", [ 4 ] ]
 gap> copy[3][5] := 'w';
 Error, List Assignment: <list> must be a mutable list
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/doc/tut/migrat.xml
+++ b/doc/tut/migrat.xml
@@ -851,24 +851,23 @@ When interrupting, the first line printed by <C>Where</C> actually may be
 one level higher, as shown below.
 <P/>
 <Log><![CDATA[
-gap> OnBreak := function() Where(0); end;; # eliminate back-tracing on
-gap>                                       # entry to break loop
+gap> OnBreak := function() end;; # eliminate back-tracing on entry to break loop
 gap> test:= function( n )
 >    if n > 3 then Error( "!\n" ); fi; test( n+1 ); end;;
 gap> test( 1 );
 Error, !
-at *stdin*:6
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
+Stack trace:
 *[1] Error( "!\n" );
-   @ *stdin*:4
+   @ *stdin*:3
  [2] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [3] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [4] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> n;
@@ -877,28 +876,30 @@ brk> DownEnv();
 brk> n;
 3
 brk> Where();
+Stack trace:
  [1] Error( "!\n" );
-   @ *stdin*:4
+   @ *stdin*:3
 *[2] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [3] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [4] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:5
 brk> DownEnv( 2 );
 brk> n;
 1
 brk> Where();
+Stack trace:
  [1] Error( "!\n" );
-   @ *stdin*:4
+   @ *stdin*:3
  [2] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
  [3] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 *[4] test( n + 1 );
-   @ *stdin*:4
+   @ *stdin*:3
 <function "test">( <arguments> )
  called from read-eval loop at *errin*:8
 brk> DownEnv( -2 );

--- a/lib/error.g
+++ b/lib/error.g
@@ -144,6 +144,7 @@ BIND_GLOBAL("WHERE", function(depth, context, activecontext, showlocals)
         PrintTo(ERROR_OUTPUT, "called from read-eval loop ");
         return;
     fi;
+    PrintTo(ERROR_OUTPUT, "Stack trace:\n");
     lastcontext := context;
     totaldepth := 0;
     countcontext := context;
@@ -301,9 +302,6 @@ BIND_GLOBAL("ErrorInner", function(options, earlyMessage)
 
     printAutomaticTraceback := function()
         if IsBound(OnBreak) and IsFunction(OnBreak) then
-            if OnBreak = Where or OnBreak = WhereWithVars then
-                PrintTo(ERROR_OUTPUT, "Stack trace:\n");
-            fi;
             OnBreak();
         fi;
     end;

--- a/lib/integer.gd
+++ b/lib/integer.gd
@@ -249,6 +249,7 @@ DeclareGlobalFunction( "BestQuoInt" );
 ##  <Log><![CDATA[
 ##  gap> ChineseRem( [ 6, 10, 14 ], [ 1, 2, 3 ] );
 ##  Error, the residues must be equal modulo 2
+##  Stack trace:
 ##  *[1] Error( "the residues must be equal modulo ", g.gcd );
 ##     @ GAPROOT/lib/integer.gi:391
 ##  <function "ChineseRem">( <arguments> )

--- a/lib/oper1.g
+++ b/lib/oper1.g
@@ -929,6 +929,7 @@ end);
 ##  <Log><![CDATA[
 ##  gap> SylowSubgroup( s4, 6 );
 ##  Error, SylowSubgroup: <p> must be a prime
+##  Stack trace:
 ##  *[1] <<compiled GAP function>>
 ##     @ GAPROOT/lib/oper1.g:964
 ##   [2] <<compiled GAP function "SylowSubgroup default method">>

--- a/tst/testspecial/64bit/low-mem-list-types.g.out
+++ b/tst/testspecial/64bit/low-mem-list-types.g.out
@@ -1,18 +1,15 @@
 gap> ListWithIdenticalEntries(2^50, 'a');
 Error, Cannot allocate 1125899906842633 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> ListWithIdenticalEntries(2^50, true);
 Error, Cannot allocate 140737488355336 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> ListWithIdenticalEntries(2^50, 2);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/64bit/low-mem-plist-1.g.out
+++ b/tst/testspecial/64bit/low-mem-plist-1.g.out
@@ -2,13 +2,11 @@ gap> l := [];
 [  ]
 gap> l[2^50] := 1;
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> l[2^50] := 2;
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!!!
-Stack trace:
 not in any function at *stdin*:3
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/64bit/low-mem-plist-2.g.out
+++ b/tst/testspecial/64bit/low-mem-plist-2.g.out
@@ -1,12 +1,10 @@
 gap> EmptyPlist(2^50);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;
 gap> EmptyPlist(2^50);
 Error, Cannot allocate 9007199254741000 bytes: cannot extend the workspace any more!!
-Stack trace:
 not in any function at *stdin*:2
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/backtrace.g.out
+++ b/tst/testspecial/backtrace.g.out
@@ -20,11 +20,13 @@ Stack trace:
  called from read-eval loop at *stdin*:13
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] l[[ 1 .. 3 ]] := 1;
    @ *stdin*:11
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] l[[ 1 .. 3 ]] := 1;
    @ *stdin*:11
   arguments: <none>
@@ -45,11 +47,13 @@ Stack trace:
  called from read-eval loop at *stdin*:16
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] 1 / 0
    @ *stdin*:15
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] 1 / 0
    @ *stdin*:15
   arguments: <none>
@@ -71,6 +75,7 @@ fi;
  called from read-eval loop at *stdin*:19
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] if x then
     return 1;
 fi;
@@ -78,6 +83,7 @@ fi;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] if x then
     return 1;
 fi;
@@ -102,6 +108,7 @@ fi;
  called from read-eval loop at *stdin*:22
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] if 1 then
     return 1;
 fi;
@@ -109,6 +116,7 @@ fi;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] if 1 then
     return 1;
 fi;
@@ -134,6 +142,7 @@ fi;
  called from read-eval loop at *stdin*:25
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] if 1 < 0 then
     return 1;
 elif 1 then
@@ -143,6 +152,7 @@ fi;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] if 1 < 0 then
     return 1;
 elif 1 then
@@ -168,6 +178,7 @@ od;
  called from read-eval loop at *stdin*:28
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] while 1 do
     return 1;
 od;
@@ -175,6 +186,7 @@ od;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] while 1 do
     return 1;
 od;
@@ -201,6 +213,7 @@ od;
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> Where();
+Stack trace:
 *[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" );
    @ GAPROOT/lib/integer.gi:LINE
  [2] for i in 1 do
@@ -210,6 +223,7 @@ od;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] Error( "You cannot loop over the integer ", n, " did you mean the range [1..", n, "]" );
    @ GAPROOT/lib/integer.gi:LINE
   arguments:
@@ -240,6 +254,7 @@ od;
  called from read-eval loop at *stdin*:34
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -247,6 +262,7 @@ od;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -271,6 +287,7 @@ od;
  called from read-eval loop at *stdin*:36
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -278,6 +295,7 @@ od;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -304,6 +322,7 @@ od;
  called from read-eval loop at *stdin*:38
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -311,6 +330,7 @@ od;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -337,6 +357,7 @@ od;
  called from read-eval loop at *stdin*:40
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -344,6 +365,7 @@ od;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] for i in true do
     return 1;
 od;
@@ -369,6 +391,7 @@ until 1;
  called from read-eval loop at *stdin*:42
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] repeat
     x := 1;
 until 1;
@@ -376,6 +399,7 @@ until 1;
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] repeat
     x := 1;
 until 1;
@@ -398,11 +422,13 @@ Stack trace:
  called from read-eval loop at *stdin*:45
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] Assert( 0, 1 );
    @ *stdin*:44
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] Assert( 0, 1 );
    @ *stdin*:44
   arguments: <none>
@@ -423,11 +449,13 @@ Stack trace:
  called from read-eval loop at *stdin*:48
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] Assert( 0, 1, "hello" );
    @ *stdin*:47
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] Assert( 0, 1, "hello" );
    @ *stdin*:47
   arguments: <none>
@@ -457,6 +485,7 @@ Stack trace:
  called from read-eval loop at *stdin*:56
 type 'quit;' to quit to outer loop
 brk> Where();
+Stack trace:
 *[1] return m[i][j];
    @ GAPROOT/lib/matrix.gi:LINE
  [2] ELM_LIST( m, row, col )
@@ -466,6 +495,7 @@ brk> Where();
 <function "f">( <arguments> )
  called from read-eval loop at *errin*:1
 brk> WhereWithVars();
+Stack trace:
 *[1] return m[i][j];
    @ GAPROOT/lib/matrix.gi:LINE
   arguments:

--- a/tst/testspecial/backtrace2.g.out
+++ b/tst/testspecial/backtrace2.g.out
@@ -39,6 +39,7 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> n; Where();
 3
+Stack trace:
 *[1] Error( "!\n" );
    @ *stdin*:24
  [2] test( n + 1 );
@@ -49,6 +50,7 @@ brk> n; Where();
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 2
+Stack trace:
  [1] Error( "!\n" );
    @ *stdin*:24
 *[2] test( n + 1 );
@@ -59,6 +61,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 1
+Stack trace:
  [1] Error( "!\n" );
    @ *stdin*:24
  [2] test( n + 1 );
@@ -69,6 +72,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
+Stack trace:
  [1] Error( "!\n" );
    @ *stdin*:24
  [2] test( n + 1 );
@@ -79,6 +83,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
+Stack trace:
  [1] Error( "!\n" );
    @ *stdin*:24
 *[2] test( n + 1 );
@@ -89,6 +94,7 @@ brk> UpEnv(); n; Where();
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
+Stack trace:
 *[1] Error( "!\n" );
    @ *stdin*:24
  [2] test( n + 1 );
@@ -99,6 +105,7 @@ brk> UpEnv(); n; Where();
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
+Stack trace:
 *[1] Error( "!\n" );
    @ *stdin*:24
  [2] test( n + 1 );
@@ -133,6 +140,7 @@ Stack trace:
 type 'quit;' to quit to outer loop
 brk> n; Where();
 3
+Stack trace:
 *[1] 1 / 0
    @ *stdin*:35
  [2] test( n + 1 );
@@ -143,6 +151,7 @@ brk> n; Where();
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 2
+Stack trace:
  [1] 1 / 0
    @ *stdin*:35
 *[2] test( n + 1 );
@@ -153,6 +162,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 1
+Stack trace:
  [1] 1 / 0
    @ *stdin*:35
  [2] test( n + 1 );
@@ -163,6 +173,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
+Stack trace:
  [1] 1 / 0
    @ *stdin*:35
  [2] test( n + 1 );
@@ -173,6 +184,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
+Stack trace:
  [1] 1 / 0
    @ *stdin*:35
 *[2] test( n + 1 );
@@ -183,6 +195,7 @@ brk> UpEnv(); n; Where();
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
+Stack trace:
 *[1] 1 / 0
    @ *stdin*:35
  [2] test( n + 1 );
@@ -193,6 +206,7 @@ brk> UpEnv(); n; Where();
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
+Stack trace:
 *[1] 1 / 0
    @ *stdin*:35
  [2] test( n + 1 );
@@ -229,6 +243,7 @@ Stack trace:
 type 'quit;' to quit to outer loop
 brk> n; Where();
 3
+Stack trace:
 *[1] IsAbelian( 1 )
    @ *stdin*:47
  [2] test( n + 1 );
@@ -239,6 +254,7 @@ brk> n; Where();
  called from read-eval loop at *errin*:1
 brk> DownEnv(); n; Where();
 3
+Stack trace:
 *[1] IsAbelian( 1 )
    @ *stdin*:47
  [2] test( n + 1 );
@@ -249,6 +265,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:2
 brk> DownEnv(); n; Where();
 2
+Stack trace:
  [1] IsAbelian( 1 )
    @ *stdin*:47
 *[2] test( n + 1 );
@@ -259,6 +276,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:3
 brk> DownEnv(); n; Where();
 1
+Stack trace:
  [1] IsAbelian( 1 )
    @ *stdin*:47
  [2] test( n + 1 );
@@ -269,6 +287,7 @@ brk> DownEnv(); n; Where();
  called from read-eval loop at *errin*:4
 brk> UpEnv(); n; Where();
 2
+Stack trace:
  [1] IsAbelian( 1 )
    @ *stdin*:47
 *[2] test( n + 1 );
@@ -279,6 +298,7 @@ brk> UpEnv(); n; Where();
  called from read-eval loop at *errin*:5
 brk> UpEnv(); n; Where();
 3
+Stack trace:
 *[1] IsAbelian( 1 )
    @ *stdin*:47
  [2] test( n + 1 );
@@ -289,6 +309,7 @@ brk> UpEnv(); n; Where();
  called from read-eval loop at *errin*:6
 brk> UpEnv(); n; Where();
 3
+Stack trace:
 *[1] IsAbelian( 1 )
    @ *stdin*:47
  [2] test( n + 1 );

--- a/tst/testspecial/debug-var.g.out
+++ b/tst/testspecial/debug-var.g.out
@@ -89,7 +89,6 @@ gap> x;
 42
 gap> y;
 Error, Variable: 'y' must have a value
-Stack trace:
 not in any function at *stdin*:16
 gap> 
 gap> h:=function(p)

--- a/tst/testspecial/error-in-InputTextString.g.out
+++ b/tst/testspecial/error-in-InputTextString.g.out
@@ -1,7 +1,6 @@
 gap> Read(InputTextString("Print(1 + [()]);"));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `+' on 2 arguments
-Stack trace:
 called from read-eval loop at stream:1
 type 'quit;' to quit to outer loop
 brk> quit;

--- a/tst/testspecial/last-access.g.out
+++ b/tst/testspecial/last-access.g.out
@@ -5,7 +5,6 @@ gap> 1;2;3;[last,last2,last3];
 [ 3, 2, 1 ]
 gap> Error("err");
 Error, err
-Stack trace:
 not in any function at *stdin*:3
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/line-continuation.g.out
+++ b/tst/testspecial/line-continuation.g.out
@@ -4,7 +4,6 @@ gap> # counter only once, so that both examples below report the error in line 2
 gap> #
 gap> EvalString("123\\\n45x;");
 Error, Variable: '12345x' must have a value
-Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
 Stack trace:
@@ -17,7 +16,6 @@ you can 'return;' to continue
 brk> quit;
 gap> EvalString("123\\\r\n45x;");
 Error, Variable: '12345x' must have a value
-Stack trace:
 not in any function at stream:2
 Error, Could not evaluate string.
 Stack trace:

--- a/tst/testspecial/method-not-found-where.g.out
+++ b/tst/testspecial/method-not-found-where.g.out
@@ -13,6 +13,7 @@ brk> ShowMethods(1);
 #I  Searching Method for IsDiagonalMatrix with 1 argument:
 #I  Total: 3 entries
 brk> Where(5);
+Stack trace:
 *[1] IsDiagonalMat( a )
    @ *stdin*:3
 <function "f">( <arguments> )

--- a/tst/testspecial/print-formatting.g.out
+++ b/tst/testspecial/print-formatting.g.out
@@ -22,7 +22,6 @@ gap>
 gap> # test formatting status for errout
 gap> 1/0; # trigger a break loop
 Error, Rational operations: <divisor> must not be zero
-Stack trace:
 not in any function at *stdin*:14
 type 'quit;' to quit to outer loop
 brk> old := PrintFormattingStatus("*errout*");

--- a/tst/testspecial/repl-syntax-err.g.out
+++ b/tst/testspecial/repl-syntax-err.g.out
@@ -7,7 +7,6 @@ gap> # error, which wasn't reported correctly before the above issues was
 gap> # fixed.
 gap> Error(""):
 Error, 
-Stack trace:
 not in any function at *stdin*:9
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/stack-trace-depth.g.out
+++ b/tst/testspecial/stack-trace-depth.g.out
@@ -49,6 +49,7 @@ you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
 brk> SetUserPreference("WhereDepth", 12);
 brk> Where();
+Stack trace:
 * [1] Error( "foo" );
     @ *stdin*:3
   [2] f11(  )
@@ -75,6 +76,7 @@ brk> Where();
  called from read-eval loop at *errin*:2
 brk> SetUserPreference("WhereDepth", 5);
 brk> Where();
+Stack trace:
 *[1] Error( "foo" );
    @ *stdin*:3
  [2] f11(  )

--- a/tst/testspecial/top-level-error.g.out
+++ b/tst/testspecial/top-level-error.g.out
@@ -1,6 +1,5 @@
 gap> Error("foo");
 Error, foo
-Stack trace:
 not in any function at *stdin*:2
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue

--- a/tst/testspecial/trace.g.out
+++ b/tst/testspecial/trace.g.out
@@ -31,7 +31,6 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument operations
-Stack trace:
 not in any function at *stdin*:25
 gap> 
 gap> # with tracing
@@ -59,7 +58,6 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7);
 Error, sorry: cannot yet have X argument operations
-Stack trace:
 not in any function at *stdin*:36
 gap> UntraceMethods( o ); # not (yet?) supported
 gap> 
@@ -80,7 +78,6 @@ gap> o(1,2,3,4,5,6);
 [ 1, 2, 3, 4, 5, 6 ]
 gap> o(1,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument operations
-Stack trace:
 not in any function at *stdin*:47
 gap> 
 gap> #
@@ -113,7 +110,6 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
-Stack trace:
 not in any function at *stdin*:70
 gap> 
 gap> # with tracing
@@ -138,7 +134,6 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
-Stack trace:
 not in any function at *stdin*:80
 gap> UntraceMethods( o );
 gap> 
@@ -157,6 +152,5 @@ gap> o(IsInt,2,3,4,5,6);
 [ <Category "IsInt">, 2, 3, 4, 5, 6 ]
 gap> o(IsInt,2,3,4,5,6,7); # not (yet?) supported
 Error, sorry: cannot yet have X argument constructors
-Stack trace:
 not in any function at *stdin*:90
 gap> QUIT;

--- a/tst/testspecial/up-down-env.g.out
+++ b/tst/testspecial/up-down-env.g.out
@@ -55,7 +55,6 @@ brk> ##  start a fresh execution context
 brk> ##
 brk> Read("top-level-error.g");
 Error, foo
-Stack trace:
 not in any function at top-level-error.g:1
 you can 'quit;' to quit to outer loop, or
 you can 'return;' to continue
@@ -63,7 +62,6 @@ brk_2> Where(20);
 not in any function at *errin*:1
 brk_2> lvl; # since `Read` started a fresh execution context, we can't access lvl here
 Error, Variable: 'lvl' must have a value
-Stack trace:
 not in any function at *errin*:2
 brk_2> quit;
 brk> lvl;


### PR DESCRIPTION
Alternative to and hence closes #6429.

This retains the `Stack trace:` but now prints it more consistently (e.g. also when the `browse` package is used), and doesn't print it in pointless cases (when there is no stack trace)