### PR TITLE
Adjust conway polynomial error message

### DIFF
--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -80,7 +80,7 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
 
     if not IsCheapConwayPolynomial(p,d) then
         Error("Conway Polynomial ",p,"^",d,
-              " will need to computed and might be slow");
+              " will need to be computed and might be slow");
     fi;
     cp := CoefficientsOfUnivariatePolynomial(ConwayPolynomial(p,d));
 

--- a/hpcgap/lib/ffeconway.gi
+++ b/hpcgap/lib/ffeconway.gi
@@ -80,7 +80,7 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
 
     if not IsCheapConwayPolynomial(p,d) then
         Error("Conway Polynomial ",p,"^",d,
-              " will need to computed and might be slow\n", "return to continue");
+              " will need to computed and might be slow");
     fi;
     cp := CoefficientsOfUnivariatePolynomial(ConwayPolynomial(p,d));
 

--- a/lib/ffe.gd
+++ b/lib/ffe.gd
@@ -119,8 +119,8 @@
 ##  <Log><![CDATA[
 ##  gap> Z(11,40);
 ##  Error, Conway Polynomial 11^40 will need to computed and might be slow
-##  return to continue
-##  *[1] Error( "Conway Polynomial ", p, "^", d, " will need to computed and might be slow\n", "return to continue" );
+##  Stack trace:
+##  *[1] Error( "Conway Polynomial ", p, "^", d, " will need to computed and might be slow" );
 ##     @ GAPROOT/lib/ffeconway.gi:81
 ##   [2] FFECONWAY.SetUpConwayStuff( p, d );
 ##     @ GAPROOT/lib/ffeconway.gi:140

--- a/lib/ffe.gd
+++ b/lib/ffe.gd
@@ -118,9 +118,9 @@
 ##  ]]></Example>
 ##  <Log><![CDATA[
 ##  gap> Z(11,40);
-##  Error, Conway Polynomial 11^40 will need to computed and might be slow
+##  Error, Conway Polynomial 11^40 will need to be computed and might be slow
 ##  Stack trace:
-##  *[1] Error( "Conway Polynomial ", p, "^", d, " will need to computed and might be slow" );
+##  *[1] Error( "Conway Polynomial ", p, "^", d, " will need to be computed and might be slow" );
 ##     @ GAPROOT/lib/ffeconway.gi:81
 ##   [2] FFECONWAY.SetUpConwayStuff( p, d );
 ##     @ GAPROOT/lib/ffeconway.gi:140

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -78,7 +78,7 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
 
     if not IsCheapConwayPolynomial(p,d) then
         Error("Conway Polynomial ",p,"^",d,
-              " will need to computed and might be slow\n", "return to continue");
+              " will need to computed and might be slow");
     fi;
     cp := CoefficientsOfUnivariatePolynomial(ConwayPolynomial(p,d));
 

--- a/lib/ffeconway.gi
+++ b/lib/ffeconway.gi
@@ -78,7 +78,7 @@ FFECONWAY.SetUpConwayStuff := function(p,d)
 
     if not IsCheapConwayPolynomial(p,d) then
         Error("Conway Polynomial ",p,"^",d,
-              " will need to computed and might be slow");
+              " will need to be computed and might be slow");
     fi;
     cp := CoefficientsOfUnivariatePolynomial(ConwayPolynomial(p,d));
 


### PR DESCRIPTION
The 'return to continue' is redundant and potentially confusing.

Notice how a few lines later we already print `you can 'return;' to continue`