### PR TITLE
kernel: cleanup CRC code

### DIFF
--- a/src/gap.c
+++ b/src/gap.c
@@ -409,7 +409,6 @@ int realmain(int argc, const char * argv[])
 {
   UInt                type;                   // result of compile
   Obj                 func;                   // function (compiler)
-  Int4                crc;                    // crc of file to compile
 
   // initialize everything and read init.g which runs the GAP session
   InitializeGap(&argc, argc, argv, 1);
@@ -425,12 +424,11 @@ int realmain(int argc, const char * argv[])
       if (!CloseInput(&input)) {
           return 2;
       }
-      crc  = SyGAPCRC(SyCompileInput);
       type = CompileFunc(
                          MakeImmString(SyCompileOutput),
                          func,
                          MakeImmString(SyCompileName),
-                         crc,
+                         SyGAPCRC(SyCompileInput),
                          MakeImmString(SyCompileMagic1) );
       return ( type == 0 ) ? 1 : 0;
     }

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -191,10 +191,7 @@ static ssize_t echoandcheck(int fid, const char *buf, size_t count)
 **
 *F  SyGAPCRC( <name> )  . . . . . . . . . . . . . . . . . . crc of a GAP file
 **
-**  This function should  be clever and handle  white spaces and comments but
-**  one has to make certain that such characters are not ignored in strings.
-**
-**  This function *never* returns a 0 unless an error occurred.
+**  This function returns 0 for missing or unreadable files.
 */
 static const UInt4 syCcitt32[ 256 ] =
 {
@@ -248,7 +245,7 @@ Int4 SyGAPCRC( const Char * name )
     UInt4       crc;
     UInt4       old;
     UInt4       new;
-    Int4        ch;
+    Int         ch;
     Int         fid;
     BOOL        seen_nl;
 
@@ -273,21 +270,18 @@ Int4 SyGAPCRC( const Char * name )
         }
         else
             seen_nl = FALSE;
-        old = (crc >> 8) & 0x00FFFFFFL;
-        new = syCcitt32[ ( (UInt4)( crc ^ ch ) ) & 0xff ];
+        old = crc >> 8;
+        new = syCcitt32[(crc ^ ch) & 0xff];
         crc = old ^ new;
-    }
-    if ( crc == 0 ) {
-        crc = 1;
     }
 
     // and close it again
     SyFclose( fid );
-    // Emulate a signed shift:
-    if (crc & 0x80000000L)
-        return (Int4) ((crc >> 4) | 0xF0000000L);
-    else
-        return (Int4) (crc >> 4);
+
+    // Emulate a signed shift (the C compiler does not specify whether right
+    // shifts preserve signs or not; it seems more or less all compilers in
+    // active use these days do, but better safe than sorry)
+    return ((Int)((crc >> 4) ^ 0x08000000U)) - 0x08000000;
 }
 
 
@@ -320,7 +314,7 @@ static Obj FuncCrcString(Obj self, Obj str)
     UInt4       new;
     UInt4       i, len;
     const Char  *ptr;
-    Int4        ch;
+    Int         ch;
     BOOL        seen_nl;
 
     RequireStringRep(SELF_NAME, str);
@@ -330,7 +324,7 @@ static Obj FuncCrcString(Obj self, Obj str)
     crc = 0x12345678L;
     seen_nl = FALSE;
     for (i = 0; i < len; i++) {
-        ch = (Int4)(ptr[i]);
+        ch = (Int)(ptr[i]);
         if ( ch == '\377' || ch == '\n' || ch == '\r' )
             ch = '\n';
         if ( ch == '\n' ) {
@@ -341,14 +335,15 @@ static Obj FuncCrcString(Obj self, Obj str)
         }
         else
             seen_nl = FALSE;
-        old = (crc >> 8) & 0x00FFFFFFL;
-        new = syCcitt32[ ( (UInt4)( crc ^ ch ) ) & 0xff ];
+        old = crc >> 8;
+        new = syCcitt32[(crc ^ ch) & 0xff];
         crc = old ^ new;
     }
-    if ( crc == 0 ) {
-        crc = 1;
-    }
-    return INTOBJ_INT(((Int4) crc) >> 4);
+
+    // Emulate a signed shift (the C compiler does not specify whether right
+    // shifts preserve signs or not; it seems more or less all compilers in
+    // active use these days do, but better safe than sorry)
+    return INTOBJ_INT(((Int)((crc >> 4) ^ 0x08000000U)) - 0x08000000);
 }
 
 // Get OS Kernel version. Used to discover if GAP is running inside

--- a/src/sysfiles.h
+++ b/src/sysfiles.h
@@ -23,8 +23,7 @@
 **
 *F  SyGAPCRC( <name> )  . . . . . . . . . . . . . . . . . . crc of a GAP file
 **
-**  This function should  be clever and handle  white spaces and comments but
-**  one has to certain that such characters are not ignored in strings.
+**  This function returns 0 for missing or unreadable files.
 */
 Int4 SyGAPCRC(const Char * name);
 


### PR DESCRIPTION
There was an incorrect comment claiming that SyGAPCRC only ever returns 0 in case of an error. There was also code that looked as if it ensured that (by checking if `crc` is 0 and if so replacing it by 1). But this code in fact was a no-op, and has been one since 1997, when the code was changed to return `crc >> 4` instead of `crc` -- yet both `0 >> 4` and `1 >> 4` are equal to 0.

Regarding the other changes:
- `(crc >> 8) & 0x00FFFFFFL` is the same as `crc >> 8` since `crc` is an unsigned 32 bit value
- removed a comment from the 1990ies suggesting that `SyGAPCRC` should ignore whitespace and comment changes; but we will never do that (as it would be very difficult, break backwards compatibility, and have little practical use)
- align right shift in SyGAPCRC and FuncCrcString: one was "emulating" a signed shift, the other didn't. This didn't cause a problem in practice because essentially every compiler in active uses nowadays implements signed right shifts; but the C standard does not require this. Now both use the same branchless emulation code which e.g. clang compiles down into a single instruction (GCC, MSVC, ICC do not, but that's fine, this code is not a bottleneck for anything)