### PR TITLE
Move over changes to the GAP.jl-CI job

### DIFF
--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -93,7 +93,7 @@ jobs:
             done
           fi
           ./autogen.sh
-          ./configure
+          ./configure --enable-Werror
           make -j`nproc`
       - name: "Override bundled GAP"
         run: |

--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -67,11 +67,31 @@ jobs:
       - name: "Install dependencies (for macOS)"
         if: runner.os == 'macOS'
         run: |
-          brew install autoconf zlib # gmp pkg-config
+          # - autoconf, gmp, zlib are needed by GAP's build system
+          # - coreutils provides nproc
+          # - force use of Homebrew gcc to build GAP for proper stacktrace support
+          #   Homebrew installs versioned binaries such as gcc-14 and g++-14,
+          #   while later scripts expect unversioned gcc and g++ in PATH.
+          brew install autoconf gmp zlib gcc@14 coreutils
+
+          # ensure gcc and g++ are available under those names (on macOS,
+          # these names are aliases for clang / clang++ out of the box)
+          shimdir="${HOME}/bin"
+          mkdir -p "${shimdir}"
+          ln -sf "$(brew --prefix)/bin/gcc-14" "${shimdir}/gcc"
+          ln -sf "$(brew --prefix)/bin/g++-14" "${shimdir}/g++"
+          echo "${shimdir}" >> "${GITHUB_PATH}"
       - name: "Build GAP"
         run: |
           mv GAPROOT /tmp/GAPROOT
           cd /tmp/GAPROOT
+          patchdir=.github/workflows/GAP_patches/master
+          if [ -d $patchdir ]; then
+            for f in $patchdir/*.patch; do
+              echo "Applying patch ${f}"
+              patch -p1 -d . < ${f}
+            done
+          fi
           ./autogen.sh
           ./configure --enable-Werror
           make -j`nproc`

--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           mv GAPROOT /tmp/GAPROOT
           cd /tmp/GAPROOT
-          patchdir=.github/workflows/GAP_patches/master
+          patchdir=$GAPJLPATH/.github/workflows/GAP_patches/master
           if [ -d $patchdir ]; then
             for f in $patchdir/*.patch; do
               echo "Applying patch ${f}"

--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -93,7 +93,7 @@ jobs:
             done
           fi
           ./autogen.sh
-          ./configure --enable-Werror
+          ./configure
           make -j`nproc`
       - name: "Override bundled GAP"
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -727,12 +727,12 @@ for READLINE_PREFIX in ${READLINE_SEARCH_PATH} ; do
     [DEFAULTS_EREADLINE],[
       dnl ereadline is the name of GNU readline library on OpenBSD
       READLINE_PREFIX=""
-      READLINE_CPPFLAGS="-I/usr/local/include/ereadline"
+      READLINE_CPPFLAGS="-isystem /usr/local/include/ereadline"
       READLINE_LDFLAGS=""
       READLINE_LIBS="-lereadline"
     ],
     [*],[
-      READLINE_CPPFLAGS="-I${READLINE_PREFIX}/include"
+      READLINE_CPPFLAGS="-isystem ${READLINE_PREFIX}/include"
       READLINE_LDFLAGS="-L${READLINE_PREFIX}/lib"
       READLINE_LIBS="-lreadline"
     ]


### PR DESCRIPTION
In particular, the part about the compiler handling is required to make the two macOS CI-with-GAP.jl jobs pass again (as of https://github.com/oscar-system/GAP.jl/pull/1361). 