### PR TITLE
Clarify that perfect groups data is licensed under GPL 2.0 or later

### DIFF
--- a/grp/perf13.grp
+++ b/grp/perf13.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[96]:=[# 61440.1
 [[1,"abcde",

--- a/grp/perf14.grp
+++ b/grp/perf14.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[111]:=[# 86016.1
 [[1,"abcd",

--- a/grp/perf15.grp
+++ b/grp/perf15.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[131]:=[# 122880.1
 [[1,"abcdef",

--- a/grp/perf16.grp
+++ b/grp/perf16.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[150]:=[# 172032.1
 [[1,"abc",

--- a/grp/perf17.grp
+++ b/grp/perf17.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[179]:=[# 245760.1
 [[1,"abcde",

--- a/grp/perf18.grp
+++ b/grp/perf18.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[200]:=[# 344064.1
 [[1,"abcd",

--- a/grp/perf19.grp
+++ b/grp/perf19.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[210]:=[# 368640.1
 [[1,"abcdef",

--- a/grp/perf21.grp
+++ b/grp/perf21.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[276]:=[# 688128.1
 [[1,"abcde",

--- a/grp/perf22.grp
+++ b/grp/perf22.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 number:=[ 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 2, 7, 1, 1, 1, 1, 3, 1, 1,
   1, 7, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 5, 1, 1, 3, 1, 1, 9, 4, 1, 1,

--- a/grp/perf24.grp
+++ b/grp/perf24.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[332]:=[# 1008000.1
 [[1,"abcdef",

--- a/grp/perf25.grp
+++ b/grp/perf25.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[355]:=[# 1180980.1
 [[1,"abcde",

--- a/grp/perf26.grp
+++ b/grp/perf26.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[371]:=[# 1290240.1
 [[1,"abcdefg",

--- a/grp/perf28.grp
+++ b/grp/perf28.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[382]:=[# 1382400.1
 [[1,"abcdefg",

--- a/grp/perf29.grp
+++ b/grp/perf29.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[396]:=[# 1474560.1
 [[1,"abcdefg",

--- a/grp/perf30.grp
+++ b/grp/perf30.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[421]:=[# 1749600.1
 [[1,"abcdefgh",

--- a/grp/perf31.grp
+++ b/grp/perf31.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[435]:=[# 1843200.1
 [[1,"abcdef",

--- a/grp/perf32.grp
+++ b/grp/perf32.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[436]:=[# 1843968.1
 [[1,"abcdef",

--- a/grp/perf34.grp
+++ b/grp/perf34.grp
@@ -5,7 +5,7 @@
 ##  This data was computed by Alexander Hulpke
 ##  It is distributed under the artistic license 2.0
 ##  https://opensource.org/licenses/Artistic-2.0
-##  as well as (dual licensing) under GPL 2
+##  as well as (dual licensing) under GPL-2.0-or-later
 
 PERFGRP[452]:=[# 1975680.1
 [[1,"abcd",


### PR DESCRIPTION
Wrote more general licensing text to appease GPL sherrifs.