### PR TITLE
Add an argument check to `CodePcgs`

### DIFF
--- a/lib/randiso.gi
+++ b/lib/randiso.gi
@@ -240,6 +240,11 @@ end );
 InstallGlobalFunction( CodePcgs, function( pcgs )
     local code, indices, l, mi, i, base, nt, r, j, size;
 
+    # Check the argument.
+    if not ( IsPcgs( pcgs ) and IsPrimeOrdersPcgs( pcgs ) ) then
+      Error( "<pcgs> must be a pcgs in 'IsPrimeOrdersPcgs'" );
+    fi;
+
     # basic structures
     l := Length( pcgs );
     if l = 0 then


### PR DESCRIPTION
The argument of `CodePcgs` must be in `IsPrimeOrdersPcgs` (see #6441 for details).

(Yes, adding a test with a non-prime order pcgs would be natural, but looking at such examples uncovers more problems, see #6452.)