### PR TITLE
Add `ChiefLength` (length of any chief series)

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -405,6 +405,7 @@ the series without destroying the properties of the series.
 <P/>
 <#Include Label="[1]{grp}">
 <#Include Label="ChiefSeries">
+<#Include Label="ChiefLength">
 <#Include Label="ChiefSeriesThrough">
 <#Include Label="ChiefSeriesUnderAction">
 <#Include Label="SubnormalSeries">

--- a/lib/ctbl.gd
+++ b/lib/ctbl.gd
@@ -1083,6 +1083,7 @@ DeclareAttributeSuppCT( "OrdinaryCharacterTable", IsGroup, [] );
 #############################################################################
 ##
 #A  AbelianInvariants( <tbl> )
+#A  ChiefLength( <tbl> )
 #A  CommutatorLength( <tbl> )
 #A  Exponent( <tbl> )
 #P  IsAbelian( <tbl> )
@@ -1105,6 +1106,7 @@ DeclareAttributeSuppCT( "OrdinaryCharacterTable", IsGroup, [] );
 ##  <ManSection>
 ##  <Heading>Group Operations Applicable to Character Tables</Heading>
 ##  <Attr Name="AbelianInvariants" Arg='tbl' Label="for a character table"/>
+##  <Attr Name="ChiefLength" Arg='tbl' Label="for a character table"/>
 ##  <Attr Name="CommutatorLength" Arg='tbl' Label="for a character table"/>
 ##  <Attr Name="Exponent" Arg='tbl' Label="for a character table"/>
 ##  <Prop Name="IsAbelian" Arg='tbl' Label="for a character table"/>
@@ -1139,6 +1141,8 @@ DeclareAttributeSuppCT( "OrdinaryCharacterTable", IsGroup, [] );
 ##  >               CharacterTable( SL( 2, 5 ) ) ];;
 ##  gap> List( tables, AbelianInvariants );
 ##  [ [ 3 ], [ 2 ], [  ], [  ] ]
+##  gap> List( tables, ChiefLength );
+##  [ 1, 3, 1, 2 ]
 ##  gap> List( tables, CommutatorLength );
 ##  [ 1, 1, 1, 1 ]
 ##  gap> List( tables, Exponent );
@@ -1192,6 +1196,7 @@ DeclareAttributeSuppCT( "OrdinaryCharacterTable", IsGroup, [] );
 ##  <#/GAPDoc>
 ##
 DeclareAttributeSuppCT( "AbelianInvariants", IsNearlyCharacterTable, [] );
+DeclareAttributeSuppCT( "ChiefLength", IsNearlyCharacterTable, [] );
 DeclareAttributeSuppCT( "CommutatorLength", IsNearlyCharacterTable, [] );
 DeclareAttributeSuppCT( "Exponent", IsNearlyCharacterTable, [] );
 DeclarePropertySuppCT( "IsAbelian", IsNearlyCharacterTable );

--- a/lib/ctbl.gi
+++ b/lib/ctbl.gi
@@ -807,6 +807,36 @@ AttributeMethodByNiceMonomorphism( CharacterDegrees, [ IsGroup ] );
 
 #############################################################################
 ##
+#F  ChiefLength( <tbl> )  . . . . . . . . . . . . . . . for a character table
+##
+InstallMethod( ChiefLength,
+    "for a character table",
+    [ IsCharacterTable ],
+    function( tbl )
+    local n, prev, N;
+
+    if Size( tbl ) = 1 then
+      return 0;
+    elif IsPrimePowerInt( Size( tbl ) ) or IsAbelian( tbl ) then
+      # Avoid computing all normal subgroups in obvious cases.
+      return Length( Factors( Size( tbl ) ) );
+    fi;
+
+    n:= -1;
+    prev:= [];
+    for N in ClassPositionsOfNormalSubgroups( tbl ) do
+      # The list is sorted according to increasing number of classes.
+      if IsSubset( N, prev ) then
+        prev:= N;
+        n:= n + 1;
+      fi;
+    od;
+    return n;
+    end );
+
+
+#############################################################################
+##
 #F  CommutatorLength( <tbl> ) . . . . . . . . . . . . . for a character table
 ##
 InstallMethod( CommutatorLength,

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1531,7 +1531,6 @@ DeclareAttribute( "LatticeSubgroups", IsGroup );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "ChiefLength", IsGroup );
-InstallIsomorphismMaintenance( ChiefLength, IsGroup, IsGroup );
 
 
 #############################################################################
@@ -1556,7 +1555,6 @@ InstallIsomorphismMaintenance( ChiefLength, IsGroup, IsGroup );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "DerivedLength", IsGroup );
-InstallIsomorphismMaintenance( DerivedLength, IsGroup, IsGroup );
 
 
 #############################################################################
@@ -1663,7 +1661,6 @@ DeclareAttribute( "MaximalAbelianQuotient",IsGroup);
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "CommutatorLength", IsGroup );
-InstallIsomorphismMaintenance( CommutatorLength, IsGroup, IsGroup );
 
 
 #############################################################################

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1511,6 +1511,31 @@ DeclareAttribute( "LatticeSubgroups", IsGroup );
 
 #############################################################################
 ##
+#A  ChiefLength( <G> )
+##
+##  <#GAPDoc Label="ChiefLength">
+##  <ManSection>
+##  <Attr Name="ChiefLength" Arg='G'/>
+##
+##  <Description>
+##  The chief length of a group is the number of steps in any of its chief
+##  series, see <Ref Attr="ChiefSeries"/>.
+##  <Example><![CDATA[
+##  gap> List( ChiefSeries( g ), Size );
+##  [ 24, 12, 4, 1 ]
+##  gap> ChiefLength( g );
+##  3
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareAttribute( "ChiefLength", IsGroup );
+InstallIsomorphismMaintenance( ChiefLength, IsGroup, IsGroup );
+
+
+#############################################################################
+##
 #A  DerivedLength( <G> )
 ##
 ##  <#GAPDoc Label="DerivedLength">
@@ -1531,6 +1556,8 @@ DeclareAttribute( "LatticeSubgroups", IsGroup );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "DerivedLength", IsGroup );
+InstallIsomorphismMaintenance( DerivedLength, IsGroup, IsGroup );
+
 
 #############################################################################
 ##
@@ -1636,6 +1663,7 @@ DeclareAttribute( "MaximalAbelianQuotient",IsGroup);
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "CommutatorLength", IsGroup );
+InstallIsomorphismMaintenance( CommutatorLength, IsGroup, IsGroup );
 
 
 #############################################################################

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1247,6 +1247,30 @@ end);
 
 ##############################################################################
 ##
+#M  ChiefLength( <G> ) . . . . . . . . . . . . . . . . chief length of a group
+##
+##  For small groups, computing the 'IsSupersolvableGroup' flag is more
+##  expensive than computing a chief series,
+##  but the flag helps if it is known.
+##
+InstallMethod( ChiefLength,
+    "generic method for groups",
+    [ IsGroup ],
+    G -> Length( ChiefSeries( G ) ) - 1 );
+
+InstallMethod( ChiefLength,
+    "for a supersolvable group",
+    [ IsGroup and IsSupersolvableGroup ],
+    function( G )
+    if Size( G ) = 1 then
+      return 0;
+    fi;
+    return Length( Factors( Size( G ) ) );
+    end );
+
+
+##############################################################################
+##
 #M  DerivedLength( <G> ) . . . . . . . . . . . . . . derived length of a group
 ##
 InstallMethod( DerivedLength,

--- a/lib/grpnice.gi
+++ b/lib/grpnice.gi
@@ -365,6 +365,22 @@ GroupMethodByNiceMonomorphismCollColl( CoreOp,
 
 ##############################################################################
 ##
+#M  ChiefLength( <G> ) . . . . . . . . . . length of a chief series of a group
+##
+AttributeMethodByNiceMonomorphism( ChiefLength,
+    [ IsGroup ] );
+
+
+##############################################################################
+##
+#M  CommutatorLength( <G> )  . . . . . . . . . .  commutator length of a group
+##
+AttributeMethodByNiceMonomorphism( CommutatorLength,
+    [ IsGroup ] );
+
+
+##############################################################################
+##
 #M  DerivedLength( <G> ) . . . . . . . . . . . . . . derived length of a group
 ##
 AttributeMethodByNiceMonomorphism( DerivedLength,

--- a/tst/testinstall/ctbl.tst
+++ b/tst/testinstall/ctbl.tst
@@ -1,5 +1,9 @@
-#@local g,t,lin,G
+#@local g,t,lin,G,attr
 gap> START_TEST("ctbl.tst");
+
+# Reset the counter of automatically assigned identifiers,
+# in order to admit reading this file several times in a GAP session.
+gap> LARGEST_IDENTIFIER_NUMBER[1]:= 0;;
 
 # `ClassPositionsOf...' for the trivial group (which usually causes trouble)
 gap> g:= TrivialGroup( IsPermGroup );;
@@ -459,6 +463,40 @@ gap> G:= PcGroupCode( 221729, 24 );;  # = SmallGroup( 24, 5 )
 gap> IrrDixonSchneider( G );;  Irr( G );;
 gap> InfoText( OrdinaryCharacterTable( G ) );
 "origin: Dixon's Algorithm"
+
+# group attributes for character tables
+gap> for G in [ TrivialGroup(), CyclicGroup( 5 ), DihedralGroup( 12 ),
+>               SymmetricGroup( 4 ), AlternatingGroup( 6 ), SL( 2, 5 ) ] do
+>      t:= CharacterTable( G );
+>      for attr in [
+>                    AbelianInvariants,
+>                    ChiefLength,
+>                    CommutatorLength,
+>                    Exponent,
+>                    IsAbelian,
+>                    IsAlmostSimple,
+>                    IsCyclic,
+>                    IsElementaryAbelian,
+>                    IsFinite,
+>                    IsMonomial,
+>                    IsNilpotent,
+>                    IsPerfect,
+>                    IsQuasisimple,
+>                    IsSimple,
+>                    IsSporadicSimple,
+>                    IsSupersolvable,
+>                    NrConjugacyClasses,
+>                    Size,
+>                  ] do
+>        if attr( G ) <> attr( t ) then
+>          Error( "difference for '", attr, "'" );
+>        fi;
+>      od;
+>      if IsSimple( G ) and IsomorphismTypeInfoFiniteSimpleGroup( G ) <>
+>                           IsomorphismTypeInfoFiniteSimpleGroup( t ) then
+>        Error( "difference for '", IsomorphismTypeInfoFiniteSimpleGroup, "'" );
+>      fi;
+>    od;
 
 ##
 gap> STOP_TEST( "ctbl.tst" );


### PR DESCRIPTION
This is invariant under isomorphisms.
Declare also `CommutatorLength` and `DerivedLength` as isomorphism invariant.
Define `ChiefLength` also for character tables, since it can be computed from the lattice of normal subgroups.