### PR TITLE
Change deprecated RUN_IN_GGMBI to `fail`

### DIFF
--- a/lib/grpnice.gd
+++ b/lib/grpnice.gd
@@ -192,7 +192,7 @@ InstallSubsetMaintenance( IsHandledByNiceMonomorphism,
 # We recommend the (documented) global option `Run_In_GGMBI`
 # instead of the global variable `RUN_IN_GGMBI`,
 # but `RUN_IN_GGMBI` is still supported because GAP packages might use it.
-RUN_IN_GGMBI:=false; # If somebody would call `GHBI' to make a
+RUN_IN_GGMBI:=fail;  # If somebody would call `GHBI' to make a
                      # NiceMonomorphism, we would get an infinite recursion.
                      # This flag can be set to avoid GHBIs to be translated
                      # via the niceo. If it is set, the method which does

--- a/tst/testinstall/ggmbi.tst
+++ b/tst/testinstall/ggmbi.tst
@@ -17,7 +17,7 @@ gap> IsHandledByNiceMonomorphism( G );
 true
 gap> GroupGeneralMappingByImagesNC( G, G, gens, gens );;
 #I  use the global option 'Run_In_GGMBI' not the global variable 'RUN_IN_GGMBI', see '?Run_In_GGMBI'
-gap> RUN_IN_GGMBI:= false;;
+gap> RUN_IN_GGMBI:= fail;;
 
 # - Run some examples where the option gets set,
 #   and where no other tests were available.


### PR DESCRIPTION
This variable is still set by old versions of the `matgrp` package.

By setting the default to `fail`, though, newer `matgrp` versions can detect that it runs in a GAP version where `RUN_IN_GGMBI` is deprecated, and can then instead use the `Run_In_GGMBI` global option.

Follow up to PR #6442.