### PR TITLE
Fix `BaumClausenInfo` when the given pcgs does not describe a normal series of the group

### DIFF
--- a/lib/ctblsolv.gi
+++ b/lib/ctblsolv.gi
@@ -992,6 +992,7 @@ InstallMethod( BaumClausenInfo,
           invX,          # inverse of `X'
           D_gi,          #
           hom,           # homomorphism to adjust the composition series
+          ds,            # series in the image of `hom'
           orb,           #
           Forb,          #
           sigma, pi,     # permutations needed in the fusion case
@@ -1064,15 +1065,14 @@ InstallMethod( BaumClausenInfo,
       # a list of subgroups such that any composition series through
       # `ds' from `G' down to the residuum is a chief series.
       pcgs:= [];
+      ds:= List( ssr.ds, U -> ImagesSet( hom, U ) );
       for i in [ 2 .. Length( ssr.ds ) ] do
-        j:= NaturalHomomorphismByNormalSubgroupNC( ssr.ds[ i-1 ], ssr.ds[i] );
+        j:= NaturalHomomorphismByNormalSubgroupNC( ds[ i-1 ], ds[i] );
         Append( pcgs, List( SpecialPcgs( ImagesSource( j ) ),
                             x -> PreImagesRepresentative( j, x ) ) );
       od;
-      Append( pcgs, SpecialPcgs( Last(ssr.ds) ) );
+      Append( pcgs, SpecialPcgs( Last( ds ) ) );
       G:= ImagesSource( hom );
-      pcgs:= List( pcgs, x -> ImagesRepresentative( hom, x ) );
-      pcgs:= Filtered( pcgs, x -> Order( x ) <> 1 );
       pcgs:= PcgsByPcSequence( ElementsFamily( FamilyObj( G ) ), pcgs );
       cs:= PcSeries( pcgs );
       lg:= Length( pcgs );

--- a/tst/testbugfix/2026-07-13-Irr.tst
+++ b/tst/testbugfix/2026-07-13-Irr.tst
@@ -1,0 +1,8 @@
+# See https://github.com/gap-system/gap/issues/6457
+gap> START_TEST( "2026-07-13-Irr.tst");
+
+# `SmallGroup( 384, 5761 )`
+gap> IrrBaumClausen( PcGroupCode( 3070794187849707469814486105098811742240, 384 ) );;
+
+#
+gap> STOP_TEST( "2026-07-13-Irr.tst");


### PR DESCRIPTION
In the situation of a pcgs that does not describe a normal series, the algorithm switches to a different pcgs that belongs to  normal series. In some cases, this construction did not define a pcgs, which caused an error message.

This problem was present for a long time. The chance to run into the error became bigger since #6134 got merged, because `IrrBaumClausen` is used in more cases due to the changes introduced there.

resolves #6457