### PR TITLE
Fix a bug that could lead to `ContainedConjugates` returning too many results (i.e., with some entries representing the same conjugacy classes)

### DIFF
--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -191,7 +191,7 @@ local cla,clb,i,j,k,bd,r,rep,b2,dc,idx,clu,
           fi;
         od;
         if onlyone then return fail; #otherwise would have found and stopped
-        else 
+        else
           if ForAny(clu,x->Length(x)>1) then
             # there are potential conjugates left
             r:=rep;

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -84,7 +84,7 @@ end );
 # Find element in G to conjugate B into A
 # call with G,A,B;
 InstallGlobalFunction(DoConjugateInto,function(g,a,b,onlyone)
-local cla,clb,i,j,k,bd,r,rep,b2,dc,
+local cla,clb,i,j,k,bd,r,rep,b2,dc,idx,clu,
   gens,conjugate;
 
   Info(InfoCoset,2,"call DoConjugateInto ",Size(g)," ",Size(a)," ",Size(b));
@@ -160,27 +160,64 @@ local cla,clb,i,j,k,bd,r,rep,b2,dc,
       if r=fail then
         Info(InfoCoset,1,"Too many subset combinations");
       else
+        clu:=[]; # potential conjugate ones
         Info(InfoCoset,1,"Testing ",Length(r)," combinations");
         dc:=[];
         for i in r do
           k:=List(i,x->Union(clb{x}));
           k:=RepresentativeAction(g,k,cla,OnTuplesSets);
           if k<>fail then
-            Add(dc,[i,k]);
+            # find the conjugate orbit constellation
+            b2:=OnSetsSets(Set(clb),k);
+            Add(dc,[i,k,b2]);
+            j:=First([1..Length(clu)],x->RepresentativeAction(a,dc[clu[x][1]][3],b2,OnSetsSets)<>fail);
+            if j= fail then Add(clu,[Length(dc)]);j:=Length(clu);
+            else Add(clu[j],Length(dc));fi;
+            Add(dc[Length(dc)],j); # cluster position
           fi;
         od;
         if Length(dc)>0 then g:=Stabilizer(g,cla,OnTuplesSets);fi;
         rep:=[];
-        for i in dc do
-          r:=DoConjugateInto(g,a,b^i[2],onlyone);
+        idx:=[];
+        for i in [1..Length(dc)] do
+          r:=DoConjugateInto(g,a,b^dc[i][2],onlyone);
           if onlyone then
-            if r<>fail then return i[2]*r;fi;
+            if r<>fail then return dc[i][2]*r;fi;
           else
-            if r<>fail then Append(rep,List(r,x->i[2]*x));fi;
+            if r<>fail then
+              Append(rep,List(r,x->dc[i][2]*x));
+              Append(idx,ListWithIdenticalEntries(Length(r),dc[i][4]));
+            fi;
           fi;
         od;
         if onlyone then return fail; #otherwise would have found and stopped
-        else return rep;fi;
+        else 
+          if ForAny(clu,x->Length(x)>1) then
+            # there are potential conjugates left
+            r:=rep;
+            k:=Union(Filtered(clu,x->Length(x)=1));
+            j:=Filtered([1..Length(idx)],y->idx[y] in k);
+            rep:=rep{j}; # those that do not need to be tested
+            clu:=Difference([1..Length(clu)],k);
+            for j in clu do
+              b2:=Filtered([1..Length(idx)],x->idx[x]=j);
+              Info(InfoCoset,2,"Testing ",b2," for conjugacy");
+              b2:=r{b2}; # the reps that need testing for duplicates
+              bd:=[];
+              for j in b2 do
+                k:=b^j;
+                if not ForAny(bd,x->RepresentativeAction(a,x,k)<>fail) then
+                  Add(rep,j);
+                  Add(bd,k);
+                else
+                  Info(InfoCoset,2,"Eliminated conjugate");
+                fi;
+              od;
+            od;
+
+          fi;
+          return rep;
+        fi;
       fi;
     else
       # orbits are fixed. Make sure b is so

--- a/lib/csetgrp.gi
+++ b/lib/csetgrp.gi
@@ -84,7 +84,9 @@ end );
 # Find element in G to conjugate B into A
 # call with G,A,B;
 InstallGlobalFunction(DoConjugateInto,function(g,a,b,onlyone)
-local cla,clb,i,j,k,bd,r,rep,b2,dc,idx,clu,
+# For the orbit matching below, dc stores candidate data, while clu groups
+# completed results whose final B-orbit partitions are A-conjugate.
+local cla,clb,i,j,k,bd,r,rep,b2,dc,clu,
   gens,conjugate;
 
   Info(InfoCoset,2,"call DoConjugateInto ",Size(g)," ",Size(a)," ",Size(b));
@@ -160,25 +162,17 @@ local cla,clb,i,j,k,bd,r,rep,b2,dc,idx,clu,
       if r=fail then
         Info(InfoCoset,1,"Too many subset combinations");
       else
-        clu:=[]; # potential conjugate ones
         Info(InfoCoset,1,"Testing ",Length(r)," combinations");
         dc:=[];
         for i in r do
           k:=List(i,x->Union(clb{x}));
           k:=RepresentativeAction(g,k,cla,OnTuplesSets);
           if k<>fail then
-            # find the conjugate orbit constellation
-            b2:=OnSetsSets(Set(clb),k);
-            Add(dc,[i,k,b2]);
-            j:=First([1..Length(clu)],x->RepresentativeAction(a,dc[clu[x][1]][3],b2,OnSetsSets)<>fail);
-            if j= fail then Add(clu,[Length(dc)]);j:=Length(clu);
-            else Add(clu[j],Length(dc));fi;
-            Add(dc[Length(dc)],j); # cluster position
+            Add(dc,[i,k]);
           fi;
         od;
         if Length(dc)>0 then g:=Stabilizer(g,cla,OnTuplesSets);fi;
         rep:=[];
-        idx:=[];
         for i in [1..Length(dc)] do
           r:=DoConjugateInto(g,a,b^dc[i][2],onlyone);
           if onlyone then
@@ -186,36 +180,44 @@ local cla,clb,i,j,k,bd,r,rep,b2,dc,idx,clu,
           else
             if r<>fail then
               Append(rep,List(r,x->dc[i][2]*x));
-              Append(idx,ListWithIdenticalEntries(Length(r),dc[i][4]));
             fi;
           fi;
         od;
         if onlyone then return fail; #otherwise would have found and stopped
         else
-          if ForAny(clu,x->Length(x)>1) then
-            # there are potential conjugates left
-            r:=rep;
-            k:=Union(Filtered(clu,x->Length(x)=1));
-            j:=Filtered([1..Length(idx)],y->idx[y] in k);
-            rep:=rep{j}; # those that do not need to be tested
-            clu:=Difference([1..Length(clu)],k);
-            for j in clu do
-              b2:=Filtered([1..Length(idx)],x->idx[x]=j);
-              Info(InfoCoset,2,"Testing ",b2," for conjugacy");
-              b2:=r{b2}; # the reps that need testing for duplicates
+          # Recursive conjugation can change a candidate's orbit partition,
+          # so cluster the completed results by their final partitions.
+          clu:=[];
+          for i in [1..Length(rep)] do
+            b2:=OnSetsSets(Set(clb),rep[i]);
+            j:=First([1..Length(clu)],x->RepresentativeAction(a,
+              OnSetsSets(Set(clb),rep[clu[x][1]]),b2,OnSetsSets)<>fail);
+            if j=fail then
+              Add(clu,[i]);
+            else
+              Add(clu[j],i);
+            fi;
+          od;
+
+          r:=rep;
+          rep:=[];
+          for i in clu do
+            if Length(i)=1 then
+              Add(rep,r[i[1]]);
+            else
+              Info(InfoCoset,2,"Testing ",i," for conjugacy");
               bd:=[];
-              for j in b2 do
-                k:=b^j;
+              for j in i do
+                k:=b^r[j];
                 if not ForAny(bd,x->RepresentativeAction(a,x,k)<>fail) then
-                  Add(rep,j);
+                  Add(rep,r[j]);
                   Add(bd,k);
                 else
                   Info(InfoCoset,2,"Eliminated conjugate");
                 fi;
               od;
-            od;
-
-          fi;
+            fi;
+          od;
           return rep;
         fi;
       fi;

--- a/tst/testbugfix/2026-02-28-ContainedConjugates.tst
+++ b/tst/testbugfix/2026-02-28-ContainedConjugates.tst
@@ -2,5 +2,24 @@
 gap> S := SymmetricGroup(10);;
 gap> H := Group([ (3,4), (3,4,5,6,7,8,9,10), (1,2) ]);;
 gap> F := Group([ (1,7)(2,8)(5,6), (1,8)(2,7)(3,9)(5,6) ]);;
-gap> Length(ContainedConjugates(S, H, F));
+gap> cc := ContainedConjugates(S, H, F);;
+gap> Length(cc);
 2
+gap> ForAll(Combinations(cc, 2),
+>            x -> RepresentativeAction(H, x[1][1], x[2][1]) = fail);
+true
+
+# Regression test for confusing candidate indices with cluster numbers.
+gap> S := SymmetricGroup(12);;
+gap> H := ClosureGroup(
+>      Group([ (1,3), (2,6)(5,7), (2,5)(6,7) ]),
+>      SymmetricGroup([8..12]));;
+gap> F := ClosureGroup(
+>      Group([ (1,6)(2,7) ]),
+>      SymmetricGroup([8..12]));;
+gap> cc := ContainedConjugates(S, H, F);;
+gap> Length(cc);
+3
+gap> ForAll(Combinations(cc, 2),
+>            x -> RepresentativeAction(H, x[1][1], x[2][1]) = fail);
+true

--- a/tst/testbugfix/2026-02-28-ContainedConjugates.tst
+++ b/tst/testbugfix/2026-02-28-ContainedConjugates.tst
@@ -1,12 +1,6 @@
 # Bug reported by Martin Rubey in forum, Feb 17, 2026
-#@local S,H,F;
-gap> START_TEST("ContainedConjugates.tst");
-
 gap> S := SymmetricGroup(10);;
 gap> H := Group([ (3,4), (3,4,5,6,7,8,9,10), (1,2) ]);;
 gap> F := Group([ (1,7)(2,8)(5,6), (1,8)(2,7)(3,9)(5,6) ]);;
 gap> Length(ContainedConjugates(S, H, F));
 2
-
-# 
-gap> STOP_TEST("ContainedConjugates.tst");

--- a/tst/testbugfix/2026-02-28-ContainedConjugates.tst
+++ b/tst/testbugfix/2026-02-28-ContainedConjugates.tst
@@ -1,0 +1,12 @@
+# Bug reported by Martin Rubey in forum, Feb 17, 2026
+#@local S,H,F;
+gap> START_TEST("ContainedConjugates.tst");
+
+gap> S := SymmetricGroup(10);;
+gap> H := Group([ (3,4), (3,4,5,6,7,8,9,10), (1,2) ]);;
+gap> F := Group([ (1,7)(2,8)(5,6), (1,8)(2,7)(3,9)(5,6) ]);;
+gap> Length(ContainedConjugates(S, H, F));
+2
+
+# 
+gap> STOP_TEST("ContainedConjugates.tst");

--- a/tst/testinstall/grpperm.tst
+++ b/tst/testinstall/grpperm.tst
@@ -109,7 +109,7 @@ gap> b:=Stabilizer(sym,[[5,6,7],[8,9,10],[11,12],[13]],OnTuplesSets);;
 gap> Index(sym,b);
 3603600
 gap> Length(ContainedConjugates(sym,a,b));
-5
+3
 gap> TwoClosure(SymmetricGroup([3..6]));
 Sym( [ 3 .. 6 ] )
 gap> TwoClosure(AlternatingGroup(6));


### PR DESCRIPTION
When mapping perm orbits first in DoConjugateInto, avoid duplication if orbit images are equivalent.

