### PR TITLE
Fix hangs and errors when constructing group extensions

### DIFF
--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1118,32 +1118,25 @@ local m,s,g,i,j,gen,img,hom,d,pos;
 end);
 
 InstallMethod(MaximalAbelianQuotient,
-        "for subgroups of finitely presented groups, through new fp",
-        true, [IsSubgroupFpGroup], -1,
-function(U)
-local phi, m;
-  # do cheaper Tietze (and thus do not store)
-  phi:=AttributeValueNotSet(IsomorphismFpGroup,U:
-    eliminationsLimit:=50,
-    generatorsLimit:=Length(GeneratorsOfGroup(Parent(U)))*LogInt(IndexInWholeGroup(U),2),
-    cheap);
-  m:=MaximalAbelianQuotient(Image(phi));
-  SetAbelianInvariants(U,AbelianInvariants(Image(phi)));
-  return phi*m;
-end);
-
-InstallMethod(MaximalAbelianQuotient,
-        "subgroups of fp., rewrite", true, [IsSubgroupFpGroup], 2,
+        "subgroups of fp., rewrite", true, [IsSubgroupFpGroup], 0,
 function(u)
-local iso;
+local iso, m;
   if (HasIsWholeFamily(u) and IsWholeFamily(u))
   # catch trivial case of rank 0 group
    or Length(GeneratorsOfGroup(FamilyObj(u)!.wholeGroup))=0 then
-    TryNextMethod();
+    # do cheaper Tietze (and thus do not store)
+    iso:=AttributeValueNotSet(IsomorphismFpGroup,u:
+      eliminationsLimit:=50,
+      generatorsLimit:=Length(GeneratorsOfGroup(Parent(u)))
+                       *LogInt(IndexInWholeGroup(u),2),
+      cheap);
+  else
+    iso:=IsomorphismFpGroup(u);
   fi;
 
-  iso:=IsomorphismFpGroup(u);
-  return iso*MaximalAbelianQuotient(Range(iso));
+  m:=MaximalAbelianQuotient(Range(iso));
+  SetAbelianInvariants(u,AbelianInvariants(Range(iso)));
+  return iso*m;
 end);
 
 

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1273,7 +1273,7 @@ local v,aiu,aiv,G,primes,irrel,ma,mao,mau,a,k,gens,imgs,q,dec,deco,piv,co;
 
   Info(InfoFpGroup,1,"Larger by factor ",Product(aiv)/Product(aiu));
   ma:=MaximalAbelianQuotient(v);
-  mao:=ma; # keep ortignioal one, as pre image of subgroup will be easier.
+  mao:=ma; # keep original one, as preimage of subgroup will be easier.
   a:=Image(ma);
   k:=List(GeneratorsOfGroup(v),x->ImagesRepresentative(ma,x));
 

--- a/lib/ghomfp.gi
+++ b/lib/ghomfp.gi
@@ -1118,7 +1118,7 @@ local m,s,g,i,j,gen,img,hom,d,pos;
 end);
 
 InstallMethod(MaximalAbelianQuotient,
-        "for subgroups of finitely presented groups, fallback",
+        "for subgroups of finitely presented groups, through new fp",
         true, [IsSubgroupFpGroup], -1,
 function(U)
 local phi, m;
@@ -1133,7 +1133,7 @@ local phi, m;
 end);
 
 InstallMethod(MaximalAbelianQuotient,
-        "subgroups of fp., rewrite", true, [IsSubgroupFpGroup], 0,
+        "subgroups of fp., rewrite", true, [IsSubgroupFpGroup], 2,
 function(u)
 local iso;
   if (HasIsWholeFamily(u) and IsWholeFamily(u))
@@ -1245,12 +1245,20 @@ end);
 # u must be a subgroup of the image of home
 InstallGlobalFunction(
 LargerQuotientBySubgroupAbelianization,function(hom,u)
-local v,aiu,aiv,G,primes,irrel,ma,mau,a,k,gens,imgs,q,dec,deco,piv,co;
+local v,aiu,aiv,G,primes,irrel,ma,mao,mau,a,k,gens,imgs,q,dec,deco,piv,co;
   v:=PreImage(hom,u);
   aiu:=AbelianInvariants(u);
 
-  G:= FamilyObj(v)!.wholeGroup;
-  aiv:=AbelianInvariantsSubgroupFpGroup( G, v:cheap:=false );
+  if IsBound(FamilyObj(v)!.wholeGroup) then
+    G:= FamilyObj(v)!.wholeGroup;
+  else
+    G:=Source(hom);
+  fi;
+  if IsFpGroup(v) then
+    aiv:=AbelianInvariantsSubgroupFpGroup( G, v:cheap:=false );
+  else
+    aiv:=AbelianInvariants(v);
+  fi;
   if aiv=fail then
     ma:=MaximalAbelianQuotient(v);
     aiv:=AbelianInvariants(Image(ma,v));
@@ -1265,14 +1273,22 @@ local v,aiu,aiv,G,primes,irrel,ma,mau,a,k,gens,imgs,q,dec,deco,piv,co;
 
   Info(InfoFpGroup,1,"Larger by factor ",Product(aiv)/Product(aiu));
   ma:=MaximalAbelianQuotient(v);
-  mau:=MaximalAbelianQuotient(u);
+  mao:=ma; # keep ortignioal one, as pre image of subgroup will be easier.
   a:=Image(ma);
+  k:=List(GeneratorsOfGroup(v),x->ImagesRepresentative(ma,x));
+
+  # rebuild on standard generators, to avoid word length explosion
+  ma:=GroupHomomorphismByImagesNC(v,a,GeneratorsOfGroup(v),k);
+
+  mau:=MaximalAbelianQuotient(u);
   k:=TrivialSubgroup(a);
   for primes in irrel do
     k:=ClosureGroup(k,GeneratorsOfGroup(SylowSubgroup(a,primes)));
   od;
   if Size(k)>1 then
-    ma:=ma*NaturalHomomorphismByNormalSubgroup(a,k);
+    k:=NaturalHomomorphismByNormalSubgroup(a,k);
+    ma:=ma*k;
+    mao:=mao*k;
     a:=Image(ma);
     k:=TrivialSubgroup(Image(mau));
     for primes in irrel do
@@ -1314,7 +1330,7 @@ local v,aiu,aiv,G,primes,irrel,ma,mau,a,k,gens,imgs,q,dec,deco,piv,co;
     co:=ClosureSubgroup(co,gens{piv{[1..Length(piv)-1]}});
   fi;
   Info(InfoFpGroup,2,"Degree larger ",Index(a,co));
-  return PreImage(ma,co);
+  return PreImage(mao,co);
 end);
 
 DeclareRepresentation("IsModuloPcgsFpGroupRep",

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -277,11 +277,9 @@ function(g,str,N)
       f:=Image(hom);
       ser:=ShallowCopy(DirectFactorsFittingFreeSocle(f));
 
-      if not ForAll(ser,x->IsNormal(f,x)) then
-        ser1:=Filtered(ser,x->not IsNormal(f,x));
+      ser1:=Filtered(ser,x->not IsNormal(f,x));
+      if Length(ser1) > 0 then
         ser:=Filtered(ser,x->IsNormal(f,x));
-      else
-        ser1:=[];
       fi;
 
       gens:=Concatenation(List(ser,SmallGeneratingSet));

--- a/lib/gpfpiso.gi
+++ b/lib/gpfpiso.gi
@@ -249,7 +249,7 @@ InstallGlobalFunction(IsomorphismFpGroupByChiefSeriesFactor,
 function(g,str,N)
   local ser, ab, homs, gens, idx, start, pcgs, hom, f, fgens, auts, sf, orb,
   tra, j, a, ad, lad, n, fg, free, rels, fp, vals, dec, still, lgens, ngens,
-  nrels, nvals, p, dodecomp, decomp, hogens, di, i, k, l,
+  nrels, nvals, p, dodecomp, decomp, hogens, di, i, k, l,ser1,
   m,abelianlimit,locallim,abpow,needgens,fampcgs,rad;
 
   abelianlimit:=ValueOption("abelianlimit");
@@ -276,6 +276,14 @@ function(g,str,N)
       hom:=NaturalHomomorphismByNormalSubgroupNC(g,rad);
       f:=Image(hom);
       ser:=ShallowCopy(DirectFactorsFittingFreeSocle(f));
+
+      if not ForAll(ser,x->IsNormal(f,x)) then
+        ser1:=Filtered(ser,x->not IsNormal(f,x));
+        ser:=Filtered(ser,x->IsNormal(f,x));
+      else
+        ser1:=[];
+      fi;
+
       gens:=Concatenation(List(ser,SmallGeneratingSet));
       j:=SubgroupNC(f,gens);
       for i in GeneratorsOfGroup(f) do
@@ -288,7 +296,8 @@ function(g,str,N)
       for i in [Length(ser)-1,Length(ser)-2..1] do
         ser[i]:=ClosureGroup(ser[i+1],ser[i]);
       od;
-      if Size(ser[1])<Size(f) then
+
+      if Length(ser1)>0 or Size(ser[1])<Size(f) then
         ser:=ChiefSeriesThrough(f,ser);
         gens:=Union(gens,Union(List(ser,SmallGeneratingSet)));
       fi;
@@ -298,6 +307,7 @@ function(g,str,N)
       fi;
       # change generators to make split
       ser:=List(ser,x->ClosureGroup(rad,Filtered(gens,y->y in x)));
+
     else
       rad:=g;
     fi;

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1990,7 +1990,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
     fi;
     # if we used factor perm rep, be bolder
     if IsPermGroup(p) then
-      new:=new*SmallerDegreePermutationRepresentation(p:cheap);
+      new:=new*SmallerDegreePermutationRepresentation(p:cheap:=(wasbold=wasbold)); # always true, just so gaplint won't whine
       SetIsomorphismPermGroup(fp,new);
     elif IsPcGroup(p) then
       SetIsomorphismPcGroup(fp,new);

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1439,7 +1439,7 @@ end);
 InstallGlobalFunction(FpGroupCocycle,function(arg)
 local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
       it,hom,trysy,prime,mindeg,fps,ei,mgens,mwrd,nn,newfree,mfpi,mmats,sub,
-      tab,tab0,evalprod,gensmrep,invsmrep,zerob,simi,simiq,wasbold,
+      tab,tab0,evalprod,gensmrep,invsmrep,zerob,simi,simiq,#wasbold,
       #step,
       mon,ord,mn,melmvec,killgens,frew,fffam,ofgens,rws,formalinverse;
 
@@ -1671,7 +1671,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
   fp:=f/rels;
   SetSize(fp,Size(r.group)*prime^r.module.dimension);
   simi:=fail;
-  wasbold:=false;
+  #wasbold:=false;
 
   if mon<>fail then
     rels:=MakeFpGroupToMonoidHomType1(fp,mon);
@@ -1728,7 +1728,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
             it:=DescSubgroupIterator(m:skip:=LogInt(Size(p),2));
           fi;
 
-          wasbold:=false;
+          #wasbold:=false;
           m:=NextIterator(it);
           # catch case of large permdegree, try naive first
           if Index(p,m)=1 and IsPermGroup(p)
@@ -1741,9 +1741,9 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
             fi;
             if IndexNC(p,m)>10*NrMovedPoints(p) then
               m:=p; # after all..
-              wasbold:=false;
+              #wasbold:=false;
             else
-              wasbold:=true;
+              #wasbold:=true;
             fi;
           fi;
           Info(InfoExtReps,3,"Found index ",Index(p,m));
@@ -1990,7 +1990,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
     fi;
     # if we used factor perm rep, be bolder
     if IsPermGroup(p) then
-      new:=new*SmallerDegreePermutationRepresentation(p:cheap:=(wasbold=wasbold)); # always true, just so gaplint won't whine
+      new:=new*SmallerDegreePermutationRepresentation(p:cheap);
       SetIsomorphismPermGroup(fp,new);
     elif IsPcGroup(p) then
       SetIsomorphismPcGroup(fp,new);

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1990,7 +1990,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
     fi;
     # if we used factor perm rep, be bolder
     if IsPermGroup(p) then
-      new:=new*SmallerDegreePermutationRepresentation(p:cheap:=wasbold<>true);
+      new:=new*SmallerDegreePermutationRepresentation(p:cheap);
       SetIsomorphismPermGroup(fp,new);
     elif IsPcGroup(p) then
       SetIsomorphismPcGroup(fp,new);

--- a/tst/testbugfix/2026-07-14-LargerQuotientBySubgroupAbelianization.tst
+++ b/tst/testbugfix/2026-07-14-LargerQuotientBySubgroupAbelianization.tst
@@ -1,6 +1,6 @@
 # Larger quotient finder hangs
 gap> f:=FreeGroup("F1","F2","F3","F5");;
-gap> F1:=f.1;;F2:=f.2;;F3:=F.3;;F5:=F.4;;
+gap> F1:=f.1;;F2:=f.2;;F3:=f.3;;F5:=f.4;;
 gap> rels:=[ F2^4, F3^-2*F2^2, F1^-1*F5*F1*F5^-1, F3^-1*F5^-1*F3*F5, F5^4,
 >   F2^-1*F5^-1*F2*F5, F3^-1*F5*F1^-1*F3*F5*F1^-1, F2^2*F1*F3^2*F1^-1,
 >   F2*F3^-1*(F2*F3)^2, (F1*F2)^2*F1*F2^-1, F5^2*F1^-6,

--- a/tst/testbugfix/2026-07-14-LargerQuotientBySubgroupAbelianization.tst
+++ b/tst/testbugfix/2026-07-14-LargerQuotientBySubgroupAbelianization.tst
@@ -1,0 +1,20 @@
+# Larger quotient finder hangs
+gap> f:=FreeGroup("F1","F2","F3","F5");;
+gap> F1:=f.1;;F2:=f.2;;F3:=F.3;;F5:=F.4;;
+gap> rels:=[ F2^4, F3^-2*F2^2, F1^-1*F5*F1*F5^-1, F3^-1*F5^-1*F3*F5, F5^4,
+>   F2^-1*F5^-1*F2*F5, F3^-1*F5*F1^-1*F3*F5*F1^-1, F2^2*F1*F3^2*F1^-1,
+>   F2*F3^-1*(F2*F3)^2, (F1*F2)^2*F1*F2^-1, F5^2*F1^-6,
+>   F3*F2^-1*F1^3*F2*F3^-1*F1^-3 ];;
+gap> G:=f/rels;;
+gap> perms2:=[(1,2)(3,6,5,4)(7,8,9),(1,2)(3,6,5,4)(7,8)(9,10),
+>   (1,2)(3,6,5,4)(7,8)(10,11), (3,4,5,6) ];;
+gap> hom:=GroupHomomorphismByImages(G,Group(perms2),
+> GeneratorsOfGroup(G),perms2);;
+gap> u:=Group([ (8,10)(9,11), (8,10)(9,11), (1,2)(3,4,5,6)(7,8,9,11,10),
+>   (1,2), (3,6,5,4) ]);;
+gap> v:=LargerQuotientBySubgroupAbelianization(hom,u);
+Group(<fp, no generators known>)
+gap> w:=Intersection(Kernel(hom),v);
+Group(<fp, no generators known>)
+gap> Size(Image(DefiningQuotientHomomorphism(w)));
+960

--- a/tst/testbugfix/2026-07-14-LargerQuotientBySubgroupAbelianization.tst
+++ b/tst/testbugfix/2026-07-14-LargerQuotientBySubgroupAbelianization.tst
@@ -1,4 +1,4 @@
-# Larger quotient finder hangs
+# Larger quotient finder used to hang, check that it works now
 gap> f:=FreeGroup("F1","F2","F3","F5");;
 gap> F1:=f.1;;F2:=f.2;;F3:=f.3;;F5:=f.4;;
 gap> rels:=[ F2^4, F3^-2*F2^2, F1^-1*F5*F1*F5^-1, F3^-1*F5^-1*F3*F5, F5^4,

--- a/tst/testbugfix/2026-07-20-IsomorphismFpGroupByChiefSeriesFactor.tst
+++ b/tst/testbugfix/2026-07-20-IsomorphismFpGroupByChiefSeriesFactor.tst
@@ -1,0 +1,17 @@
+# The simple direct factors of a fitting-free socle need not be normal in the
+# whole group.  In this wreath product, the top group interchanges the two
+# factors.  Check that the rewriting path constructs a valid presentation.
+
+gap> START_TEST("2026-07-20-IsomorphismFpGroupByChiefSeriesFactor.tst");
+gap> G := WreathProduct(AlternatingGroup(5), Group((1,2)));;
+gap> factors := DirectFactorsFittingFreeSocle(G);;
+gap> List(factors, factor -> IsNormal(G, factor));
+[ false, false ]
+gap> oldlevel := InfoLevel(InfoPerformance);;
+gap> SetInfoLevel(InfoPerformance, 0);
+gap> iso := IsomorphismFpGroupByChiefSeriesFactor(
+> G, "x", TrivialSubgroup(G) : rewrite := true);;
+gap> SetInfoLevel(InfoPerformance, oldlevel);
+gap> IsBijective(iso) and Size(Image(iso)) = Size(G);
+true
+gap> STOP_TEST("2026-07-20-IsomorphismFpGroupByChiefSeriesFactor.tst");


### PR DESCRIPTION
A number of smaller fixes that arise in the context of constrcuting extension groups. Some involving code becoming too slow, one causes an error message.