### PR TITLE
Automorphism cleanup

### DIFF
--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -1116,6 +1116,7 @@ local
           a:=List(b,x->ConjugatorAutomorphism(Source(AQ.1),x));
           b:=Filtered(GeneratorsOfGroup(AQ),x->not HasConjugatorOfConjugatorIsomorphism(x));
           a:=Concatenation(a,b);
+          SetIsAutomorphismGroup(AQ,true);
           b:=InnerAutomorphismsAutomorphismGroup(AQ);
           AQ:=Group(a,One(AQ));
           SetInnerAutomorphismsAutomorphismGroup(AQ,b);

--- a/lib/autsr.gi
+++ b/lib/autsr.gi
@@ -155,6 +155,7 @@ local
 
   epi:=EpimorphismFromFreeGroup(sub);
   free:=Source(epi);
+
   sub:=TrivialSubgroup(M);
   cnt:=0;
   while Size(sub)<Size(M) do
@@ -419,12 +420,6 @@ BindGlobal("AGSRAutomLift",function(ocr,nat,fhom,miso)
     Info(InfoMorph,5,"Search through module automorphisms of size ",
       Size(Image(phom)));
   fi;
-
-  #if trick<>fail then
-  #  t:=ImagesRepresentative(phom,trick);
-  #  # try the trickrels result first
-  #  enum:=Concatenation([t],AsList(enum));
-  #fi;
 
   for ep in enum do
     e:=PreImagesRepresentative(phom,ep);


### PR DESCRIPTION
A number of fixes and code cleanups for computing automorphism groups. 
This includes better comments on variables, and setting a status to avoid a no method found error.