### PR TITLE
Fix `CompositionSeriesThrough` so that it doesn't add duplicate subgroups

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1227,8 +1227,10 @@ local cs,i,j,pre,post,c,new,rev;
         fi;
         i:=i+1;
       until Size(c)=Size(cs[post]);
+
+      # change cs only if pre<post
+      cs:=Concatenation(new,cs{[post+1..Length(cs)]});
     fi;
-    cs:=Concatenation(new,cs{[post+1..Length(cs)]});
   od;
   return cs;
 end);

--- a/tst/testbugfix/2026-07-23-CompositionSeriesThrough.tst
+++ b/tst/testbugfix/2026-07-23-CompositionSeriesThrough.tst
@@ -1,0 +1,11 @@
+# Regression test for https://github.com/gap-system/gap/pull/6464
+gap> G := SmallGroup(8, 5);;
+gap> gens := GeneratorsOfGroup(G);;
+gap> larger := Subgroup(G, [gens[1], gens[2] * gens[3]]);;
+gap> smaller := Subgroup(G, [gens[2] * gens[3]]);;
+gap> series := CompositionSeriesThrough(G, [larger, smaller]);;
+gap> ForAll([1 .. Length(series) - 1],
+>           i -> Size(series[i]) > Size(series[i + 1]));
+true
+gap> ForAll([larger, smaller], x -> x in series);
+true


### PR DESCRIPTION
In the current form, the function `CompositionSeriesThrough` seems to add further subgroups to the composition series when unnecessary, thus making it an invalid composition series.

In particular, during the iteration for each given subgroup in `normals`, when `pre > post` (i.e. when the series does not need to be changed with respect to the particular subgroup), the composition series was still adding the subgroups in `new` (possibly with subgroups from an earlier iteration). This added subgroups to the composition series that should not be present.

I have only tested this on some p-groups. Here is an example demonstrating the bug.

``` gap
gap> G := SimpleGroup("O(7,3)");
O(7,3)
gap> S := SylowSubgroup(G,3);
<permutation group of size 19683 with 8 generators>
gap> f := IsomorphismPcGroup(S);;
gap> S := Image(f);
Group([ f1, f2, f3, f4, f5, f6, f7, f8, f9 ])
gap> L := LowerCentralSeries(S);
[ Group([ f1, f2, f3, f4, f5, f6, f7, f8, f9 ]), Group([ f3*f4, f5, f6, f7, f8, f9 ]),
  Group([ f5*f9^2, f6, f7, f8*f9^2 ]), Group([ f7, f8*f9^2 ]), Group([ f8*f9^2 ]), Group([ <identity> of ... ]) ]
gap> D := CompositionSeriesThrough(S, L);
[ Group([ f1, f2, f3, f4, f5, f6, f7, f8, f9 ]), Group([ f2, f3, f4, f5, f6, f7, f8, f9 ]),
  Group([ f3, f4, f5, f6, f7, f8, f9 ]), Group([ f3*f4, f5, f6, f7, f8, f9 ]),
  Group([ f9^2, f5^2*f9, f6^2, f7^2, f8^2*f9 ]), Group([ f5*f9^2, f6, f7, f8*f9^2 ]), Group([ f6^2, f7^2, f8^2*f9 ]),
  Group([ f7^2, f8^2*f9 ]), Group([ f8^2*f9, f8*f9^2 ]), Group([  ]), Group([  ]), Group([ f8^2*f9, f8*f9^2 ]),
  Group([  ]) ]
gap> List(D, Size);
[ 19683, 6561, 2187, 729, 243, 81, 27, 9, 3, 1, 1, 3, 1 ]
gap>
```

## Text for release notes

None


