### PR TITLE
FIX: solvable steps in FittingFree classes

### DIFF
--- a/lib/clashom.gi
+++ b/lib/clashom.gi
@@ -1152,8 +1152,8 @@ local cs,       # chief series of G
     N:=cs[i];
 
     Info(InfoHomClass,1,i,":",Index(M,N),";  ",Size(N));
-    if HasAbelianFactorGroup(M,N) then
-      Info(InfoHomClass,2,"abelian factor ignored");
+    if HasSolvableFactorGroup(M,N) or IsSubset(N,Socle(G)) then
+      Info(InfoHomClass,2,"solvable/top factor ignored");
     else
       # nonabelian factor. Now it means real work.
 

--- a/tst/testbugfix/2026-07-22-issue-6465.tst
+++ b/tst/testbugfix/2026-07-22-issue-6465.tst
@@ -1,0 +1,12 @@
+# Regression test for issue #6465:
+# https://github.com/gap-system/gap/issues/6465
+#
+# ConjugacyClassesFittingFreeGroup could call `NrMovedPoints' on the image
+# of `NaturalHomomorphismByNormalSubgroupNC', but that image need not be a
+# permutation group (e.g. it can be a pc group), which raised
+# "no 1st choice method found for `NrMovedPoints'".
+gap> gens:= [ (1,2,5,4,3)(6,7)(9,10)(12,13),
+>             (1,5)(2,3)(6,11,7,12,8,13,9,14)(10,15) ];;
+gap> G:= Group( gens );;
+gap> Length( ConjugacyClasses( G ) );
+175


### PR DESCRIPTION
ConjugacyClassesFittingFreeGroup walks a chief series of G layer by layer, skipping layers already accounted for and otherwise doing real work: decomposing the layer via CompositionSeries into its simple direct factors to compute the action for that step. That "real work" path assumes the layer is a non-solvable (semisimple) chief factor.

The skip test was HasAbelianFactorGroup(M,N), but a layer handled here could be more general on the top.
Widen the skip test so all are correctly skipped.

This fixes #6465