### PR TITLE
Avoid using GAPDoc's `FormatParagraph` (improve `--bare`)

### DIFF
--- a/lib/cmdledit.g
+++ b/lib/cmdledit.g
@@ -960,7 +960,7 @@ GAPInfo.CommandLineEditFunctions.Functions.Completion := function(l)
   wordplace := [pos+1, l[4]-1];
   word := l[3]{[wordplace[1]..wordplace[2]]};
   # see if we are in the case of a component name
-  while pos > 0 and l[3][pos] in " \n\t\r" do
+  while pos > 0 and l[3][pos] in CHARS_WHITESPACE do
     pos := pos-1;
   od;
   idbnd := IDENTS_BOUND_GVARS();

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -240,7 +240,7 @@ leave the <C>Editor</C> and <C>EditorOptions</C> preferences empty."
     local str, sp;
     if IsBound(GAPInfo.KernelInfo.ENVIRONMENT.EDITOR) then
       str := GAPInfo.KernelInfo.ENVIRONMENT.EDITOR;
-      sp := SplitStringInternal(str, "", " \n\t\r");
+      sp := SplitStringInternal(str, "", CHARS_WHITESPACE);
       if Length(sp) > 0 then
         return [ sp[1], sp{[2..Length(sp)]} ];
       fi;

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -136,7 +136,7 @@ InstallGlobalFunction( RECORDS_FILE, function( name )
       if pos <> fail then
         r:= r{ [ 1 .. pos-1 ] };
       fi;
-      Append( recs, SplitString( r, "", " \n\t\r" ) );
+      Append( recs, SplitString( r, "", CHARS_WHITESPACE ) );
     od;
     return List( recs, LowercaseString );
     end );
@@ -3492,7 +3492,7 @@ Unbind( NamesUserGVars );
 ##
 InstallGlobalFunction( ShowPackageVariables, function( arg )
     local version, arec, pkgname, info, show, documented, undocumented,
-          private, result, len, format, entry, first, subentry, str;
+          private, result, len, entry, first, subentry, str;
 
     # Get and check the arguments.
     version:= "";
@@ -3534,11 +3534,6 @@ InstallGlobalFunction( ShowPackageVariables, function( arg )
     # Render the relevant data.
     result:= "";
     len:= SizeScreen()[1] - 2;
-    if IsBoundGlobal( "FormatParagraph" ) then
-      format:= ValueGlobal( "FormatParagraph" );
-    else
-      format:= function( arg ) return Concatenation( arg[1], "\n" ); end;
-    fi;
     for entry in info do
       if entry[1] in show then
         first:= true;
@@ -3558,7 +3553,7 @@ InstallGlobalFunction( ShowPackageVariables, function( arg )
             Append( result, "\n" );
             if Length( subentry[1] ) = 4 and not IsEmpty( subentry[1][4] ) then
               Append( result,
-                      format( subentry[1][4], len, "left", [ "    ", "" ] ) );
+                      _FormatParagraph( subentry[1][4], len, "    ", "" ) );
             fi;
           fi;
         od;

--- a/lib/pager.gi
+++ b/lib/pager.gi
@@ -62,7 +62,7 @@ leave the <C>Pager</C> and <C>PagerOptions</C> preferences empty."
     local str, sp, pager, options;
     if IsBound(GAPInfo.KernelInfo.ENVIRONMENT.PAGER) then
       str := GAPInfo.KernelInfo.ENVIRONMENT.PAGER;
-      sp := SplitStringInternal(str, "", " \n\t\r");
+      sp := SplitStringInternal(str, "", CHARS_WHITESPACE);
       if Length(sp) > 0 then
         pager:= sp[1];
         options:= sp{ [ 2 .. Length( sp ) ] };
@@ -70,7 +70,7 @@ leave the <C>Pager</C> and <C>PagerOptions</C> preferences empty."
         if "less" in SplitStringInternal(sp[1], "", "/\\") then
           if IsBound(GAPInfo.KernelInfo.ENVIRONMENT.LESS) then
             str := GAPInfo.KernelInfo.ENVIRONMENT.LESS;
-            sp := SplitStringInternal(str, "", " \n\t\r");
+            sp := SplitStringInternal(str, "", CHARS_WHITESPACE);
             Append( options, sp );
           fi;
           # make sure -r is used
@@ -79,7 +79,7 @@ leave the <C>Pager</C> and <C>PagerOptions</C> preferences empty."
           if IsBound(GAPInfo.KernelInfo.ENVIRONMENT.MORE) then
             # similarly for 'more'
             str := GAPInfo.KernelInfo.ENVIRONMENT.MORE;
-            sp := SplitStringInternal(str, "", " \n\t\r");
+            sp := SplitStringInternal(str, "", CHARS_WHITESPACE);
             Append( options, sp );
           fi;
           # make sure -f is used

--- a/lib/string.g
+++ b/lib/string.g
@@ -402,6 +402,7 @@ BIND_GLOBAL("CHARS_ALPHA",
   MakeImmutable(LIST_SORTED_LIST("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")));
 BIND_GLOBAL("CHARS_SYMBOLS",
   MakeImmutable(LIST_SORTED_LIST(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")));
+BIND_GLOBAL("CHARS_WHITESPACE", MakeImmutable(LIST_SORTED_LIST(" \n\t\r")));
 
 
 #############################################################################
@@ -453,6 +454,74 @@ BIND_GLOBAL("_StripEscapeSequences", function(str)
         i := p;
       fi;
     fi;
+  od;
+  return res;
+end);
+
+
+#############################################################################
+##
+#F  _FormatParagraph( <str>, <len>, <prefix>, <suffix> )  reformat a paragraph
+##
+##  This is a heavily simplified variant of GAPDoc's `FormatParagraph`,
+##  adapted from there, so that the GAP library can format text without
+##  loading GAPDoc.
+##
+##  The words in <str> are redistributed into lines of at most <len>
+##  characters, flush left. Each line starts with <prefix> and ends with
+##  <suffix>, both of which count towards <len>. Note that GAPDoc's version
+##  instead treats them as escape sequences of width zero.
+##
+##  The alternative alignments "both", "right" and "center" offered by
+##  GAPDoc's version are not supported, and neither are escape sequences
+##  (which GAPDoc's version copies verbatim and treats as having length
+##  zero). Line lengths are counted in bytes, that is, a multibyte character
+##  counts more than once; GAPDoc's version can be handed `WidthUTF8String`
+##  to avoid this.
+##
+BIND_GLOBAL("_FormatParagraph", function(str, len, prefix, suffix)
+  local words, l, i, j, lw, s, res;
+
+  # <prefix> and <suffix> are part of each line, hence count towards <len>
+  len := len - Length(prefix) - Length(suffix);
+
+  # scan the string for words, stored as ranges of positions in <str>
+  words := [];
+  i := 1;
+  l := Length(str);
+  while i <= l do
+    if str[i] in CHARS_WHITESPACE then
+      i := i+1;
+    else
+      j := i+1;
+      while j <= l and not str[j] in CHARS_WHITESPACE do
+        j := j+1;
+      od;
+      Add(words, [i..j-1]);
+      i := j;
+    fi;
+  od;
+
+  # distribute the words onto lines
+  res := "";
+  lw := Length(words);
+  i := 1;
+  while i <= lw do
+    # the first word of a line is always added, even if it is too long
+    Append(res, prefix);
+    Append(res, str{words[i]});
+    s := Length(words[i]);
+    i := i+1;
+    # further words are added as long as they fit, line breaks only
+    # happen at whitespace
+    while i <= lw and s + 1 + Length(words[i]) <= len do
+      Add(res, ' ');
+      Append(res, str{words[i]});
+      s := s + 1 + Length(words[i]);
+      i := i+1;
+    od;
+    Append(res, suffix);
+    Add(res, '\n');
   od;
   return res;
 end);

--- a/lib/test.gi
+++ b/lib/test.gi
@@ -325,7 +325,7 @@ TEST.transformFunctions.removenl := function(a)
 end;
 TEST.transformFunctions.removewhitespace := function(a)
   a := ReplacedString(ShallowCopy(a), "\\\n", "");
-  RemoveCharacters(a, " \n\t\r");
+  RemoveCharacters(a, CHARS_WHITESPACE);
   return a;
 end;
 

--- a/lib/userpref.g
+++ b/lib/userpref.g
@@ -14,6 +14,7 @@
 ##  or in package files.
 ##
 
+
 #############################################################################
 ##
 #F  DeclareUserPreference( <record> )
@@ -449,20 +450,16 @@ BindGlobal( "DataOfUserPreference", function( pkgname, name )
 #F  StringUserPreference( <data>, <ignorecurrent> )
 ##
 BindGlobal( "StringUserPreference", function( data, ignorecurrent )
-    local string, width, format, paragraph, line;
+    local string, paragraph, line;
 
     if data = fail then
       return "";
     fi;
 
     string:= [];
-    width:= SizeScreen()[1] - 6;
-    format:= ValueGlobal( "FormatParagraph" );
     for paragraph in data.description do
-      Append( string, format( paragraph, width, "left", [ "##  ", "" ] ) );
-    # Append( string, "##  " );
-    # Append( string, line );
-    # Append( string, "\n" );
+      # the file is written with a fixed width of 78 characters
+      Append( string, _FormatParagraph( paragraph, 78, "##  ", "" ) );
     od;
     for line in data.values do
       if ignorecurrent then
@@ -527,15 +524,16 @@ BindGlobal( "StripMarkupFromUserPreferenceDescription", function( str )
 #F  ShowStringUserPreference( <data> )
 ##
 BindGlobal( "ShowStringUserPreference", function( data )
-    local string, width, format, line, paragraph, suff;
+    local string, width, line, paragraph, suff;
 
     if data = fail then
       return "";
     fi;
 
+    width:= SizeScreen()[1] - 2;
+
     # Show the name(s), with indent 2.
     string:= [];
-    width:= SizeScreen()[1] - 6;
     Append( string, "  " );
     for line in data.values do
       Append( string, line[2] );
@@ -545,10 +543,9 @@ BindGlobal( "ShowStringUserPreference", function( data )
     string[ Length( string ) ]:= '\n';
 
     # Show the formatted description, with indent 4.
-    format:= ValueGlobal( "FormatParagraph" );
     for paragraph in List( data.description,
                            StripMarkupFromUserPreferenceDescription ) do
-      Append( string, format( paragraph, width, "left", [ "    ", "" ] ) );
+      Append( string, _FormatParagraph( paragraph, width, "    ", "" ) );
     od;
 
     # Show the default value(s), with indent 6.
@@ -720,7 +717,7 @@ BindGlobal( "ShowUserPreferences", function(arg)
 ##  GAP Reference Manual.
 ##
 BindGlobal( "XMLForUserPreferences", function( pkgname )
-    local stringOfValue, pref, str, done, format, width, name, data, names,
+    local stringOfValue, pref, str, done, name, data, names,
           default;
 
     stringOfValue:= function( val )
@@ -738,8 +735,6 @@ BindGlobal( "XMLForUserPreferences", function( pkgname )
     str:= "";
     done:= [];
     if IsRecord( pref.( pkgname ) ) then
-      format:= ValueGlobal( "FormatParagraph" );
-      width:= ValueGlobal( "WidthUTF8String" );
       for name in Set( RecNames( pref.( pkgname ) ) ) do
         if not name in done then
           data:= First( GAPInfo.DeclarationsOfUserPreferences,
@@ -772,7 +767,7 @@ BindGlobal( "XMLForUserPreferences", function( pkgname )
             # Show the description, which may contain GAPDoc markup.
             Append( str, JoinStringsWithSeparator(
                            List( data.description,
-                                 para -> format( para, "left", width ) ),
+                                 para -> _FormatParagraph( para, 78, "", "" ) ),
                            "<P/>\n" ) );
 
             # Show admissible values if applicable.

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -245,5 +245,39 @@ gap> UserHomeShorten(1234);
 1234
 gap> if hadHome then GAPInfo.UserHome := savedHome; else Unbind(GAPInfo.UserHome); fi;;
 
+# _FormatParagraph
+gap> Print(_FormatParagraph(
+>         "the quick brown fox jumps over the lazy dog", 20, "", ""));
+the quick brown fox
+jumps over the lazy
+dog
+
+# whitespace is normalized
+gap> Print(_FormatParagraph(
+>         "  the quick   brown\nfox\tjumps over the lazy dog  ", 20, "", ""));
+the quick brown fox
+jumps over the lazy
+dog
+gap> _FormatParagraph("", 20, "", "");
+""
+gap> _FormatParagraph("  \n\t ", 20, "", "");
+""
+
+# a word which does not fit into a line is not broken
+gap> Print(_FormatParagraph(
+>         "supercalifragilisticexpialidocious and more", 20, "", ""));
+supercalifragilisticexpialidocious
+and more
+
+# <prefix> and <suffix> are put around each line and count towards the
+# line length
+gap> Print(_FormatParagraph(
+>         "the quick brown fox jumps over the lazy dog", 20, "##  ", ""));
+##  the quick brown
+##  fox jumps over
+##  the lazy dog
+gap> Print(_FormatParagraph("a b", 20, "<", ">"));
+<a b>
+
 #
 gap> STOP_TEST("strings.tst");

--- a/tst/testinstall/userpref.tst
+++ b/tst/testinstall/userpref.tst
@@ -1,0 +1,30 @@
+#############################################################################
+##
+##  This file tests the handling of user preferences
+##
+#@local data, oldsize
+gap> START_TEST("userpref.tst");
+
+# the descriptions shown by ShowUserPreferences are wrapped such that they
+# fit onto the screen
+gap> data := DataOfUserPreference("gap", "UseColorPrompt");;
+gap> data <> fail;
+true
+gap> oldsize := SizeScreen();;
+gap> SizeScreen([80,24]);;
+gap> ForAll(SplitString(ShowStringUserPreference(data), "\n"),
+>           l -> Length(l) <= 78);
+true
+gap> SizeScreen([50,24]);;
+gap> ForAll(SplitString(ShowStringUserPreference(data), "\n"),
+>           l -> Length(l) <= 48);
+true
+
+# the gap.ini file is written with a fixed width of 78 characters
+gap> ForAll(SplitString(StringUserPreference(data, true), "\n"),
+>           l -> Length(l) <= 78);
+true
+gap> SizeScreen(oldsize);;
+
+#
+gap> STOP_TEST("userpref.tst");


### PR DESCRIPTION
Add `_FormatParagraph` to `lib/string.g`, a simplified variant of GAPDoc's `FormatParagraph` adapted from there, and use it in `lib/package.gi` and `lib/userpref.g` instead of GAPDoc's version. This also removes a hidden dependency on GAPDoc: `StringUserPreference` ran into an error if GAPDoc was not loaded.

Our replacement is a lot less capable: it only supports flush left (the "both", "right" and "center" alignments are not implemented), it does not treat escape sequences as having length zero, and it always counts line lengths in bytes, instead of accepting a width function such as `WidthUTF8String`. None of the four call sites needs any of this: the descriptions of user preferences and the comments for method installations in practice are plain ASCII English text without escape sequences.

Unlike GAPDoc's version, which takes the strings put around each line as escape sequences of width zero, we take the width of `<prefix>` and `<suffix>` into account. This incidentally fixes `ShowPackageVariables`, which passed the screen width minus 2 while also indenting each line by 4 blanks, and hence produced lines two characters wider than the screen.

While at it, change the `gap.ini` writing code to use a constant file width of 78 columns, instead of using the user's current terminal width.

Also add `CHARS_WHITESPACE` and use it in place of the `" \n\t\r"` literals scattered over the library.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>