### PR TITLE
Fix `TwoCohomologyGeneric` when there are no conditions on the tails, leading to either an unexpected error or even a wrong output

### DIFF
--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -987,7 +987,8 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   #eqs:=Filtered(TriangulizedMat(eqs),x->not IsZero(x));
   eqs:=ShallowCopy(BasisVectors(eqs));
   if Length(eqs)=0 then
-    eqs:=IdentityMat(Length(rules),field);
+    # no conditions, so the whole space of tail vectors consists of cocycles
+    eqs:=IdentityMat(nvars,field);
   else
     eqs:=ImmutableMatrix(field,eqs);
     eqs:=NullspaceMat(TransposedMat(eqs)); # basis of cocycles

--- a/tst/testbugfix/2026-08-02-TwoCohomologyGeneric.tst
+++ b/tst/testbugfix/2026-08-02-TwoCohomologyGeneric.tst
@@ -1,0 +1,17 @@
+# TwoCohomologyGeneric used the wrong dimension for the space of cocycles
+# in case no conditions on the tails were found, which made it error out
+# (or return a wrong answer) for modules of dimension > 1.
+gap> triv:=function(G,d,F)
+>      local mo;
+>      mo:=GModuleByMats(List(GeneratorsOfGroup(G),x->IdentityMat(d,F)),d,F);
+>      return Length(TwoCohomologyGeneric(G,mo).cohomology);
+>    end;;
+gap> List([1..3],d->triv(CyclicGroup(2),d,GF(2)));
+[ 1, 2, 3 ]
+gap> List([1..3],d->triv(ElementaryAbelianGroup(8),d,GF(2)));
+[ 6, 12, 18 ]
+gap> List([1..3],d->triv(DihedralGroup(8),d,GF(2)));
+[ 3, 6, 9 ]
+gap> List([1..3],d->triv(CyclicGroup(3),d,GF(3)));
+[ 1, 2, 3 ]
+gap> Unbind(triv);


### PR DESCRIPTION
If no conditions on the tails were collected, the whole space of tail vectors consists of cocycles, and `TwoCohomologyGeneric` said so by using an identity matrix. But it sized that matrix by the number of rewriting rules instead of by the dimension `nvars` of the space the cocycles actually live in.

For modules of dimension 1 the two often agree, but for higher dimensional modules they do not, and the wrongly sized matrix either triggered the assertion in the coboundary loop

    Error, SolutionMat: matrix and vector incompatible

or, if that assertion was not reached (it sits inside a conditional), silently produced a wrong dimension for `r.cohomology`.

An example which errors before this change:

    TwoCohomologyGeneric(CyclicGroup(2),
      GModuleByMats([IdentityMat(2, GF(2))], 2, GF(2)));
