### PR TITLE
lib: restrict the ZmodnZ polynomial methods to ZmodnZ matrices

### DIFF
--- a/lib/matobjnz.gi
+++ b/lib/matobjnz.gi
@@ -1519,7 +1519,7 @@ end );
 
 InstallOtherMethod( MinimalPolynomial, "ZModnZ, spinning over field",
     IsElmsCollsX,
-    [ IsField and IsFinite, IsMatrixObj, IsPosInt ],
+    [ IsField and IsFinite, IsZmodnZMatrixRep, IsPosInt ],
 function( fld, mat, ind )
     local i, n, base, vec, one, fam,
           mp, dim, span,op,w, piv,j;
@@ -1583,7 +1583,7 @@ end);
 
 InstallOtherMethod( CharacteristicPolynomialMatrixNC, "zmodnz spinning over field",
     IsElmsCollsX,
-    [ IsField, IsMatrixObj, IsPosInt ], function( fld, mat, ind)
+    [ IsField, IsZmodnZMatrixRep, IsPosInt ], function( fld, mat, ind)
 local i, n, base, imat, vec, one,cp,op,zero,fam;
     Info(InfoMatrix,1,"Characteristic Polynomial called on ",
     NrRows(mat)," x ",NrCols(mat)," matrix over ",fld);

--- a/tst/testinstall/MatrixObj/CharacteristicPolynomial.tst
+++ b/tst/testinstall/MatrixObj/CharacteristicPolynomial.tst
@@ -1,38 +1,50 @@
 #@local F, l, u, M, rep
 gap> START_TEST( "CharacteristicPolynomial.tst" );
 
+#
 # Characteristic and minimal polynomials must be computable for every kind of
 # matrix object, and must not depend on the representation used. Matrices in
 # IsGenericMatrixRep are the interesting case here, as they do not offer
 # access to their rows, which the methods spinning up vectors rely on.
+#
 gap> F := GF(257);;
 gap> l := [[1,2,3,4],[0,1,2,3],[5,0,1,2],[1,0,0,1]] * One(F);;
 gap> u := List(l, ShallowCopy);;
-gap> for rep in [ IsPlistMatrixRep, IsGenericMatrixRep ] do
->      M := Matrix(rep, F, l);
->      if CharacteristicPolynomial(F, F, M, 1)
->         <> CharacteristicPolynomial(F, F, u, 1) then
->        Print("wrong characteristic polynomial for ", rep, "\n");
->      fi;
->      if MinimalPolynomial(F, M, 1) <> MinimalPolynomial(F, u, 1) then
->        Print("wrong minimal polynomial for ", rep, "\n");
->      fi;
->    od;
 
+#
+gap> M := Matrix(IsPlistMatrixRep, F, l);;
+gap> CharacteristicPolynomial(F, F, M, 1) = CharacteristicPolynomial(F, F, u, 1);
+true
+gap> MinimalPolynomial(F, M, 1) = MinimalPolynomial(F, u, 1);
+true
+
+#
+gap> M := Matrix(IsGenericMatrixRep, F, l);;
+gap> CharacteristicPolynomial(F, F, M, 1) = CharacteristicPolynomial(F, F, u, 1);
+true
+gap> MinimalPolynomial(F, M, 1) = MinimalPolynomial(F, u, 1);
+true
+
+#
 # the same over a small field, where the matrices are compressed
+#
 gap> F := GF(5);;
 gap> l := [[1,2,3,4],[0,1,2,3],[3,0,1,2],[1,0,0,1]] * One(F);;
 gap> u := List(l, ShallowCopy);;
-gap> for rep in [ IsPlistMatrixRep, IsGenericMatrixRep ] do
->      M := Matrix(rep, F, l);
->      if CharacteristicPolynomial(F, F, M, 1)
->         <> CharacteristicPolynomial(F, F, u, 1) then
->        Print("wrong characteristic polynomial for ", rep, "\n");
->      fi;
->      if MinimalPolynomial(F, M, 1) <> MinimalPolynomial(F, u, 1) then
->        Print("wrong minimal polynomial for ", rep, "\n");
->      fi;
->    od;
+
+#
+gap> M := Matrix(IsPlistMatrixRep, F, l);;
+gap> CharacteristicPolynomial(F, F, M, 1) = CharacteristicPolynomial(F, F, u, 1);
+true
+gap> MinimalPolynomial(F, M, 1) = MinimalPolynomial(F, u, 1);
+true
+
+#
+gap> M := Matrix(IsGenericMatrixRep, F, l);;
+gap> CharacteristicPolynomial(F, F, M, 1) = CharacteristicPolynomial(F, F, u, 1);
+true
+gap> MinimalPolynomial(F, M, 1) = MinimalPolynomial(F, u, 1);
+true
 
 #
 gap> STOP_TEST( "CharacteristicPolynomial.tst" );

--- a/tst/testinstall/MatrixObj/CharacteristicPolynomial.tst
+++ b/tst/testinstall/MatrixObj/CharacteristicPolynomial.tst
@@ -1,0 +1,38 @@
+#@local F, l, u, M, rep
+gap> START_TEST( "CharacteristicPolynomial.tst" );
+
+# Characteristic and minimal polynomials must be computable for every kind of
+# matrix object, and must not depend on the representation used. Matrices in
+# IsGenericMatrixRep are the interesting case here, as they do not offer
+# access to their rows, which the methods spinning up vectors rely on.
+gap> F := GF(257);;
+gap> l := [[1,2,3,4],[0,1,2,3],[5,0,1,2],[1,0,0,1]] * One(F);;
+gap> u := List(l, ShallowCopy);;
+gap> for rep in [ IsPlistMatrixRep, IsGenericMatrixRep ] do
+>      M := Matrix(rep, F, l);
+>      if CharacteristicPolynomial(F, F, M, 1)
+>         <> CharacteristicPolynomial(F, F, u, 1) then
+>        Print("wrong characteristic polynomial for ", rep, "\n");
+>      fi;
+>      if MinimalPolynomial(F, M, 1) <> MinimalPolynomial(F, u, 1) then
+>        Print("wrong minimal polynomial for ", rep, "\n");
+>      fi;
+>    od;
+
+# the same over a small field, where the matrices are compressed
+gap> F := GF(5);;
+gap> l := [[1,2,3,4],[0,1,2,3],[3,0,1,2],[1,0,0,1]] * One(F);;
+gap> u := List(l, ShallowCopy);;
+gap> for rep in [ IsPlistMatrixRep, IsGenericMatrixRep ] do
+>      M := Matrix(rep, F, l);
+>      if CharacteristicPolynomial(F, F, M, 1)
+>         <> CharacteristicPolynomial(F, F, u, 1) then
+>        Print("wrong characteristic polynomial for ", rep, "\n");
+>      fi;
+>      if MinimalPolynomial(F, M, 1) <> MinimalPolynomial(F, u, 1) then
+>        Print("wrong minimal polynomial for ", rep, "\n");
+>      fi;
+>    od;
+
+#
+gap> STOP_TEST( "CharacteristicPolynomial.tst" );


### PR DESCRIPTION
The methods computing characteristic and minimal polynomials in `matobjnz.gi` hardcode `ZModnZMOPI` and access the rows of the matrix as mat[1], so they only work for matrices in `IsZmodnZMatrixRep`. They were however installed for `IsMatrixObj`, and thus were selected for arbitrary matrix objects, outranking the generic methods which unpack the matrix first. For matrix objects in `IsGenericMatrixRep`, which deliberately do not support access to their rows, this made `CharacteristicPolynomial` and` MinimalPolynomial` fail:

    gap> m := Matrix(IsGenericMatrixRep, GF(257),
    >                List([1..6], i -> List([1..6], j -> Random(GF(257)))));;
    gap> CharacteristicPolynomial(m);
    Error, row access unsupported; use M[i,j] or RowsOfMatrix(M)

Restrict both methods to `IsZmodnZMatrixRep`, so that other matrix objects reach the generic methods again.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>