### PR TITLE
Fix infinite recursion in `MaximalSubgroupClassReps` for A_n

### DIFF
--- a/lib/maxsub.gi
+++ b/lib/maxsub.gi
@@ -548,10 +548,16 @@ local m,id,epi,H,ids,ft;
     if ids.series="A" then
       Info(InfoPerformance,1,"Alternating recognition needed!");
       H:=AlternatingGroup(ids.parameter);
-      m:=MaximalSubgroupClassReps(H); # library, natural
-      epi:=IsomorphismGroups(G,H);
-      m:=List(m,x->PreImage(epi,x));
-      return m;
+      # Do not call `MaximalSubgroupClassReps` here: if the calculation for
+      # the natural alternating group is not possible (e.g. because the
+      # primitive groups library is unavailable), it would end up calling
+      # this very method again, resulting in an infinite recursion.
+      m:=MaximalSubgroupsSymmAlt(H,false); # library, natural
+      if m<>fail then
+        epi:=IsomorphismGroups(G,H);
+        m:=List(m,x->PreImage(epi,x));
+        return m;
+      fi;
     elif IsBound(ids.parameter) and IsList(ids.parameter)
       and Length(ids.parameter)=2 and ForAll(ids.parameter,IsInt) then
 

--- a/tst/testinstall/maxsub.tst
+++ b/tst/testinstall/maxsub.tst
@@ -34,5 +34,14 @@ gap> SortedList(List(msc, H -> Index(G, H)));
 [ 5, 6, 10 ]
 #@fi
 
+# used to run into an infinite recursion without the primitive groups library
+gap> oldlevel := InfoLevel(InfoPerformance);;
+gap> SetInfoLevel(InfoPerformance, 0);
+gap> G := AlternatingGroup(6);;
+gap> msc := MaximalSubgroupClassReps(G);;
+gap> SetInfoLevel(InfoPerformance, oldlevel);
+gap> SortedList(List(msc, H -> Index(G, H)));
+[ 6, 6, 10, 15, 15 ]
+
 #
 gap> STOP_TEST("maxsub.tst");


### PR DESCRIPTION
Without the primitive groups library, `MaximalSubgroupClassReps` for an alternating group ran into an infinite recursion:

    gap> MaximalSubgroupClassReps( AlternatingGroup(6) );  # gap --bare
    #I  Alternating recognition needed!
    #I  Alternating recognition needed!
    ...

The `MaxesAlmostSimple` method "table of marks and classical", upon recognizing `G` as `A_n`, constructed the natural `AlternatingGroup(n)` and called `MaximalSubgroupClassReps` on it. But if `MaximalSubgroupsSymmAlt` returns `fail` -- which it does when the primitive groups library is unavailable -- then every method for the natural `A_n` gives up as well and control ends up in this very method again.

Call `MaximalSubgroupsSymmAlt` directly instead, and fall through to `TryNextMethod` (and thus the lattice fallback) if it fails.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Granted, it is not very useful to try to get maximal subgroups of `Alt(n)` when the primitive groups library is not available, but this actually happens in some fairly cheap cases (with small `n`) in the test suite of some GAP packages (e.g. `MajoranaAlgebras`). This fallback is better than a surprising infinite recursion.