### PR TITLE
CI: cache the autoconf tarball used when wrapping releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
     timeout-minutes: 60
     outputs:
       gap-build-version: ${{ steps.get-build.outputs.name }}
+    env:
+      # Ubuntu only ships autoconf 2.71, but we need 2.72 for compatibility
+      # with GCC 14 & recent clang versions, so we build it ourselves.
+      AUTOCONF_VERSION: "2.72"
+      AUTOCONF_SHA256: "ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a"
 
     steps:
       # We need to force fetch tags on the repository in the next step, which
@@ -92,14 +97,46 @@ jobs:
           git fetch https://github.com/gap-system/gap --tags --force
           git fetch --tags --force
 
-      - name: "Install autoconf 2.72"   # for compatibility with GCC 14 & clang versions
+      # Downloading the autoconf tarball from the GNU file servers regularly
+      # fails with 5xx errors. So we keep a copy of it in the GitHub Actions
+      # cache: as long as this workflow keeps running (it does so daily), the
+      # cache never expires, and we hardly ever bother the GNU servers again.
+      - name: "Cache the autoconf ${{ env.AUTOCONF_VERSION }} tarball"
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/gnu
+          key: autoconf-${{ env.AUTOCONF_VERSION }}.tar.xz
+
+      - name: "Install autoconf ${{ env.AUTOCONF_VERSION }}"
         run: |
-          wget https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz
-          tar xvf autoconf-2.72.tar.xz
-          cd autoconf-2.72
+          set -e
+          TARBALL="autoconf-${AUTOCONF_VERSION}.tar.xz"
+          mkdir -p ~/.cache/gnu
+          if [ ! -f ~/.cache/gnu/"${TARBALL}" ] ; then
+            # ftpmirror.gnu.org redirects to a nearby mirror and hence is what
+            # GNU asks us to use; ftp.gnu.org is the master server, so only
+            # resort to it if all else fails.
+            for url in "https://ftpmirror.gnu.org/gnu/autoconf/${TARBALL}" \
+                       "https://mirrors.kernel.org/gnu/autoconf/${TARBALL}" \
+                       "https://ftp.gnu.org/gnu/autoconf/${TARBALL}" ; do
+              echo "Fetching ${url}"
+              wget --tries=3 --timeout=30 --retry-connrefused \
+                   --retry-on-http-error=429,500,502,503,504 \
+                   -O "${TARBALL}" "${url}" && break
+            done
+            # verify before caching, so that a failed or truncated download
+            # cannot poison the cache
+            echo "${AUTOCONF_SHA256}  ${TARBALL}" | sha256sum --check --strict
+            mv "${TARBALL}" ~/.cache/gnu/"${TARBALL}"
+          fi
+          # verify again, as this time the tarball may have come from the cache
+          echo "${AUTOCONF_SHA256}  ${HOME}/.cache/gnu/${TARBALL}" | sha256sum --check --strict
+          tar xf ~/.cache/gnu/"${TARBALL}"
+          cd "autoconf-${AUTOCONF_VERSION}"
           ./configure
-          make
+          make -j$(nproc)
           sudo make install
+          autoconf --version
 
       - name: "Set up Python"
         uses: actions/setup-python@v7


### PR DESCRIPTION
The `Wrap releases` workflow builds autoconf 2.72 from source (Ubuntu only ships 2.71). Lately the download of the tarball keeps failing and kills the whole job, e.g. [this run](https://github.com/gap-system/gap/actions/runs/30964461723/job/92175451245), where `ftpmirror.gnu.org` answered with `502 Bad Gateway` and `wget` exited 8.

Since the workflow runs on every PR plus nightly via cron, we were asking the GNU file servers for the same never-changing file several times a day.

## Changes

- **Keep the tarball in the GitHub Actions cache.** As the workflow runs daily, the cache entry is never evicted, so after the first run we hardly ever contact the GNU servers again. Caching the tarball rather than the built installation keeps this simple: no custom `--prefix` (autoconf hardcodes its prefix at configure time), no `$GITHUB_PATH` juggling, and the cache key needs no OS/arch component. We still pay for the build on every run, but the job did that anyway.
- **Retry and fall back to other mirrors.** `ftpmirror.gnu.org` first, since that is the redirector GNU asks us to use; `ftp.gnu.org` is the master server and is only used as a last resort.
- **Verify the SHA256 checksum**, which was not done at all before. This happens on every run, including those where the tarball came from the cache. It is also verified *before* the tarball is moved into the cache, so that a failed or truncated download cannot poison it — the cache key is stable, so a bad entry would otherwise break every subsequent run.

## Testing

I ran the step's shell body locally against a redirected `$HOME`:

- **Cold cache:** by coincidence `ftpmirror.gnu.org` was failing during the test, so the fallback to `mirrors.kernel.org` got exercised for real against exactly the failure mode from CI. Checksum OK, tarball cached, extraction OK.
- **Warm cache:** no network access at all, checksum still verified.
- **All mirrors unreachable:** the step fails and the cache directory is left empty, i.e. the poison guard works.

Note that when bumping `AUTOCONF_VERSION`, `AUTOCONF_SHA256` has to be updated along with it.

Once `ubuntu-latest` moves to Ubuntu 26.04 (currently available as the preview label `ubuntu-26.04`), all of this can be dropped: that image ships autoconf 2.72 already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
