### PR TITLE
Document `IsFrattiniFree` and add methods for computing it

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -332,6 +332,7 @@ as they depend on a parameter.
 
 <#Include Label="IsCyclic">
 <#Include Label="IsElementaryAbelian">
+<#Include Label="IsFrattiniFree">
 <#Include Label="IsNilpotentGroup">
 <#Include Label="NilpotencyClassOfGroup">
 <#Include Label="IsPerfectGroup">

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1834,6 +1834,7 @@ DeclareAttribute( "PrefrattiniSubgroup", IsGroup );
 ##  <Description>
 ##  The Frattini subgroup of a group <A>G</A> is the intersection of all
 ##  maximal subgroups of <A>G</A>.
+##  See also <Ref Prop="IsFrattiniFree"/>.
 ##  <Example><![CDATA[
 ##  gap> FrattiniSubgroup(g);
 ##  Group(())
@@ -1843,6 +1844,60 @@ DeclareAttribute( "PrefrattiniSubgroup", IsGroup );
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "FrattiniSubgroup", IsGroup );
+
+
+#############################################################################
+##
+#P  IsFrattiniFree( <G> )
+##
+##  <#GAPDoc Label="IsFrattiniFree">
+##  <ManSection>
+##  <Prop Name="IsFrattiniFree" Arg='G'/>
+##
+##  <Description>
+##  A group is called <E>Frattini-free</E> if its Frattini subgroup
+##  (see <Ref Attr="FrattiniSubgroup"/>) is trivial.
+##  <P/>
+##  Methods for this property are only installed for finite groups.
+##  Note that a finite nilpotent group is Frattini-free if and only if all
+##  of its Sylow subgroups are elementary abelian, and that a finite group
+##  of squarefree order is always Frattini-free.
+##  <Example><![CDATA[
+##  gap> IsFrattiniFree( SymmetricGroup( 4 ) );
+##  true
+##  gap> IsFrattiniFree( CyclicGroup( 6 ) );
+##  true
+##  gap> IsFrattiniFree( CyclicGroup( 4 ) );
+##  false
+##  gap> IsFrattiniFree( QuaternionGroup( 8 ) );
+##  false
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsFrattiniFree", IsGroup );
+
+InstallIsomorphismMaintenance( IsFrattiniFree, IsGroup, IsGroup );
+
+InstallTrueMethod( IsFrattiniFree, IsGroup and IsTrivial );
+
+# In an (infinite dimensional) vector space over a field with p elements the
+# hyperplanes intersect trivially.
+InstallTrueMethod( IsFrattiniFree, IsGroup and IsElementaryAbelian );
+
+# A nontrivial finite group has a maximal subgroup, hence its Frattini
+# subgroup is a proper normal subgroup and thus trivial if the group
+# is simple.
+InstallTrueMethod( IsFrattiniFree, IsGroup and IsFinite and IsSimpleGroup );
+
+# For a finite p-group P we have Phi(P) = P'P^p, hence P is Frattini-free
+# if and only if it is elementary abelian; a finite nilpotent group is the
+# direct product of its Sylow subgroups.
+InstallTrueMethod( IsElementaryAbelian,
+    IsGroup and IsFinite and IsPGroup and IsFrattiniFree );
+InstallTrueMethod( IsCommutative,
+    IsGroup and IsFinite and IsNilpotentGroup and IsFrattiniFree );
 
 
 #############################################################################

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1641,6 +1641,58 @@ local m;
     return m;
 end);
 
+InstallMethod( FrattiniSubgroup, "for Frattini-free groups",
+            [ IsGroup and IsFrattiniFree ], SUM_FLAGS,
+            TrivialSubgroup );
+
+
+#############################################################################
+##
+#M  IsFrattiniFree( <G> ) . . . . . . .  is the Frattini subgroup trivial ?
+##
+InstallMethod( IsFrattiniFree, "for groups with known Frattini subgroup",
+            [ IsGroup and HasFrattiniSubgroup ], SUM_FLAGS,
+            G -> IsTrivial( FrattiniSubgroup( G ) ) );
+
+InstallMethod( IsFrattiniFree, "for finite nilpotent groups",
+            [ IsGroup and IsFinite and IsNilpotentGroup ],
+function(G)
+    # A finite nilpotent group is the direct product of its Sylow subgroups,
+    # and for a finite p-group P we have Phi(P) = P'P^p. Hence Phi(G) is
+    # trivial if and only if all Sylow subgroups of G are elementary abelian,
+    # i.e., if and only if G is abelian of squarefree exponent.
+    return IsAbelian(G) and IsDuplicateFree(FactorsInt(Exponent(G)));
+end);
+
+InstallMethod( IsFrattiniFree, "generic method for finite groups",
+            [ IsGroup and IsFinite ],
+function(G)
+local n, F;
+    # A group of squarefree order is Frattini-free.
+    n := Size(G);
+    if IsDuplicateFree(FactorsInt(n)) then
+      return true;
+    fi;
+
+    # If N is normal in G then Phi(N) <= Phi(G). Applied to the nilpotent
+    # normal subgroup F = F(G) this shows that G can only be Frattini-free if
+    # F is abelian of squarefree exponent. Deciding this usually is much
+    # cheaper than computing Phi(G).
+    F := FittingSubgroup(G);
+    if not (IsAbelian(F) and IsDuplicateFree(FactorsInt(Exponent(F)))) then
+      return false;
+    fi;
+
+    # if G = F(G), i.e., if G is nilpotent, this criterion is also sufficient
+    if Size(F) = n then
+      return true;
+    fi;
+
+    return IsTrivial(FrattiniSubgroup(G));
+end);
+
+RedispatchOnCondition( IsFrattiniFree, true, [IsGroup], [IsFinite], 0);
+
 
 #############################################################################
 ##

--- a/lib/grppcaut.gd
+++ b/lib/grppcaut.gd
@@ -11,12 +11,7 @@
 
 DeclareGlobalFunction("SpaceAndOrbitStabilizer");
 
-#############################################################################
-##
-#P IsFrattiniFree
-##
-DeclareProperty( "IsFrattiniFree", IsGroup );
-
+# for IsFrattiniFree see grp.gd
 
 DeclareGlobalFunction("AutomorphismGroupNilpotentGroup");
 DeclareGlobalFunction("AutomorphismGroupSolvableGroup");

--- a/lib/methwhy.g
+++ b/lib/methwhy.g
@@ -318,6 +318,14 @@ end);
 ##  +IsFinitelyGeneratedGroup
 ##     IsPolycyclicGroup
 ##
+##  +IsFinite
+##  +IsMagmaWithInverses
+##  +IsAssociative
+##  +IsFrattiniFree
+##     IsCommutative
+##     IsMonomialGroup
+##     IsPolycyclicGroup
+##
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/tst/testinstall/opers/IsFrattiniFree.tst
+++ b/tst/testinstall/opers/IsFrattiniFree.tst
@@ -1,0 +1,108 @@
+gap> START_TEST("IsFrattiniFree.tst");
+
+#
+gap> IsFrattiniFree(TrivialGroup());
+true
+gap> IsFrattiniFree(Group(()));
+true
+
+# abelian groups: Frattini-free iff the exponent is squarefree
+gap> List([1..12], n -> IsFrattiniFree(CyclicGroup(n)));
+[ true, true, true, false, true, true, true, false, false, true, true, false ]
+gap> IsFrattiniFree(AbelianGroup([2,2,3,5]));
+true
+gap> IsFrattiniFree(AbelianGroup([2,2,3,9]));
+false
+
+# p-groups: Frattini-free iff elementary abelian
+gap> IsFrattiniFree(ElementaryAbelianGroup(27));
+true
+gap> IsFrattiniFree(DihedralGroup(8));
+false
+gap> IsFrattiniFree(QuaternionGroup(8));
+false
+gap> IsFrattiniFree(ExtraspecialGroup(27,3));
+false
+
+# nilpotent groups: Frattini-free iff all Sylow subgroups are elementary abelian
+gap> G := DirectProduct(ElementaryAbelianGroup(4), ElementaryAbelianGroup(9));;
+gap> IsNilpotentGroup(G);
+true
+gap> IsFrattiniFree(G);
+true
+gap> G := DirectProduct(ElementaryAbelianGroup(4), CyclicGroup(9));;
+gap> IsNilpotentGroup(G);
+true
+gap> IsFrattiniFree(G);
+false
+
+# groups of squarefree order are Frattini-free
+gap> IsFrattiniFree(SymmetricGroup(3));
+true
+gap> IsFrattiniFree(DihedralGroup(IsPermGroup, 110));
+true
+
+# solvable groups whose order is not squarefree
+gap> IsFrattiniFree(AlternatingGroup(4));
+true
+gap> IsFrattiniFree(Group((1,2,3,4,5),(2,3,5,4)));  # Frobenius group of order 20
+true
+
+# simple groups are Frattini-free, quasisimple ones need not be
+gap> IsFrattiniFree(AlternatingGroup(5));
+true
+gap> IsFrattiniFree(PSL(3,2));
+true
+gap> IsFrattiniFree(SL(2,5));
+false
+
+#
+gap> IsFrattiniFree(SymmetricGroup(4));
+true
+gap> IsFrattiniFree(SymmetricGroup(IsPcGroup, 4));
+true
+gap> IsFrattiniFree(GL(2,3));
+false
+gap> IsFrattiniFree(DirectProduct(AlternatingGroup(5), CyclicGroup(4)));
+false
+
+# the property agrees with the definition
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
+gap> ForAll([1..100], n -> ForAll([1..NrSmallGroups(n)],
+>      i -> IsFrattiniFree(SmallGroup(n,i))
+>           = IsTrivial(FrattiniSubgroup(SmallGroup(n,i)))));
+true
+#@fi
+
+# knowing the property makes computing the Frattini subgroup trivial
+gap> G := SymmetricGroup(5);;
+gap> SetIsFrattiniFree(G, true);
+gap> FrattiniSubgroup(G);
+Group(())
+
+# conversely, a known Frattini subgroup decides the property, also for
+# groups which are not known to be finite
+gap> G := FreeGroup(2);;
+gap> SetFrattiniSubgroup(G, TrivialSubgroup(G));
+gap> IsFrattiniFree(G);
+true
+
+# implied properties
+gap> G := Group((1,2,3,4,5,6,7),(2,3,5)(4,7,6));;
+gap> IsFrattiniFree(G);
+true
+gap> HasIsElementaryAbelian(G);
+false
+gap> G := AbelianGroup(IsPermGroup, [7,7]);;
+gap> IsPGroup(G) and IsFrattiniFree(G);
+true
+gap> HasIsElementaryAbelian(G) and IsElementaryAbelian(G);
+true
+gap> G := AbelianGroup(IsPermGroup, [6,6]);;
+gap> IsNilpotentGroup(G) and IsFrattiniFree(G);
+true
+gap> HasIsCommutative(G) and IsCommutative(G);
+true
+
+#
+gap> STOP_TEST("IsFrattiniFree.tst");


### PR DESCRIPTION
The property `IsFrattiniFree` was declared in `lib/grppcaut.gd`, but it was undocumented and had no methods at all, so `IsFrattiniFree(G)` raised a "no method found" error unless something had set the property explicitly beforehand (as `randiso.gi` does). This documents it and makes it computable for finite groups.

The declaration moves next to `FrattiniSubgroup` in `lib/grp.gd`, together with implications in both directions: trivial, elementary abelian and finite simple groups are Frattini-free, while a finite Frattini-free *p*-group is elementary abelian and a finite Frattini-free nilpotent group is abelian.

The methods try to avoid computing the Frattini subgroup:

- For a finite nilpotent group the property holds if and only if all Sylow subgroups are elementary abelian, i.e. if and only if the group is abelian of squarefree exponent. This needs no subgroup computations at all.
- The generic method for finite groups first checks whether the group order is squarefree. Otherwise it uses that `Phi(N) <= Phi(G)` for `N` normal in `G`: applied to the Fitting subgroup, this decides many groups negatively without ever looking at maximal subgroups, and if `G = F(G)` it decides the question outright. Only then is `Phi(G)` computed.
- Conversely a known Frattini subgroup decides the property (also for groups not known to be finite), and a group known to be Frattini-free has a trivial Frattini subgroup.

The Fitting subgroup criterion is where most of the speedup comes from, e.g. `GL(3,5)` 13ms instead of 476ms, `WreathProduct(DihedralGroup(IsPermGroup,8), AlternatingGroup(5))` 13ms instead of 70ms. When the answer is `true` it costs one extra Fitting subgroup computation, which is usually work the Frattini subgroup computation performs anyway.

Note that `morpheus.gi` and `grppcext.gi` still guard their use of the property with `HasIsFrattiniFree`. Now that it is computable, dropping that guard in `morpheus.gi` would let solvable groups use the much faster `AutomorphismGroupFrattFreeGroup` path, but that affects every solvable automorphism group computation, so it is left for a separate change.

Besides the new test file, the property was checked to agree with `IsTrivial(FrattiniSubgroup(G))` for all groups in the small groups library of order at most 300, all transitive groups of degree at most 12, and all perfect groups of order at most 10^5.

AI disclosure: prepared with the help of Claude Code (Opus 5), which wrote the implementation, documentation and tests, ran the test suites and drafted this description.