### PR TITLE
Stop spinning in POW_MAT_INT once the basis is complete

### DIFF
--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -4840,18 +4840,22 @@ BindGlobal("POW_MAT_INT", function(mat, n)
   # two matrix multiplications, we assemble mm from what the spinning has
   # produced anyway, using one vector-matrix product per chain.
   trafo := function(m)
-    local id, rows, b, t, r, a, ends, images, ti, mm, j;
-    id := m^0;
-#TODO: 'RowsOfMatrix' is not what we want to call here.
-#      In fact, we should better create standard basis vectors
-#      as we need them, instead of creating 'id' .
-    rows := RowsOfMatrix( id );
+    local d, b, t, r, a, ends, images, i, ti, mm, j;
+    d := NrRows(m);
     b := rec(vectors := [], pivots := [], heads := []);
     t := [];
     ends := [];
     images := [];
+    # Spin up standard basis vectors, created one at a time as they are
+    # needed, until they span the whole space. Stopping as soon as that
+    # happens matters: any further vector would still be reduced against the
+    # complete basis, which for a cyclic matrix amounts to as much work again
+    # as the spinning itself.
     # maybe better start with a random vector?
-    for a in rows do
+    i := 0;
+    while Length(t) < d do
+      i := i + 1;
+      a := StandardBasisVector(d, m, i);
       r := addb(b,a);
       if r = true then
         repeat
@@ -4867,9 +4871,8 @@ BindGlobal("POW_MAT_INT", function(mat, n)
     od;
     t := Matrix(t, m);
     ti := t^-1;
-    # all rows but those ending a chain are standard basis vectors, so start
-    # from the identity matrix shifted up by one row and patch the rest
-    mm := rows{[2..NrRows(m)]};
+    # all rows but those ending a chain are standard basis vectors
+    mm := List([2..d], k -> StandardBasisVector(d, m, k));
     for j in [1..Length(ends)] do
       mm[ends[j]] := images[j] * ti;
     od;


### PR DESCRIPTION
The base change in POW_MAT_INT spins up standard basis vectors until they span the whole space. It took them from the rows of the identity matrix and iterated over all of them, so once the accumulated basis was already complete, every remaining vector was still reduced against all of it, only to be found dependent. Those are the most expensive reductions of all, and for a cyclic matrix there are as many of them as there are useful ones: spinning up a 200 by 200 matrix over GF(5) made 400 calls to the reduction, 199 of them after the basis was complete.

Create the standard basis vectors one at a time instead, using the new StandardBasisVector, and stop as soon as the basis spans everything. This also removes the need to build the identity matrix at all, and thereby resolves a longstanding TODO.

The base change itself becomes 16 to 50 percent faster, the more so the cheaper the field arithmetic is, since then the reductions dominate; for a 1000 by 1000 matrix over GF(2) it drops from 150 to 76 milliseconds. Powering a matrix by a large exponent, which is what the base change is for, becomes 6 to 19 percent faster.

This commit was prepared with assistance from the AI tool Claude Code (benchmarking, analysis and drafting of the implementation).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
