### PR TITLE
Fix wrong group orders caused by leaked randomized stabilizer chain options in `CompatiblePairs`

### DIFF
--- a/lib/grppcext.gi
+++ b/lib/grppcext.gi
@@ -406,6 +406,11 @@ local ag, p1iso, agp, p2iso, DP, p1, p2, gens, genimgs, triso,s,i,u,opt,
           fi;
           #Print("rep ",Size(u)," ",s,"\n");
         until Size(u)=s;
+        # the stabilizer chain of <u> reached the known order <s>, hence it is
+        # correct despite being computed randomly. Record that: otherwise the
+        # `random' value is inherited by every stabilizer chain computed later
+        # on inside <u>, where no such limit is known to validate the result.
+        StabChainOptions(u).random:=DefaultStabChainOptions.random;
         agp:=u;
       else
         gens:=GeneratorsOfGroup(agp);

--- a/tst/testbugfix/2026-08-05-EXPermutationActionPairs.tst
+++ b/tst/testbugfix/2026-08-05-EXPermutationActionPairs.tst
@@ -1,0 +1,15 @@
+# `EXPermutationActionPairs' rebuilds the first direct factor with
+# `random := 1'. That is sound there, as the closure is validated against the
+# known group order, but the value used to stay on the resulting group, so
+# every stabilizer chain computed inside it later on was built randomly and
+# without any limit to validate it against -- yielding wrong group orders.
+gap> G := PcGroupCode(379875911272818017220001991, 4356);;
+gap> D := DirectProduct(AutomorphismGroup(G), GL(1,11));;
+gap> Reset(GlobalMersenneTwister, 4);; Reset(GlobalRandomSource, 4);;
+gap> P := DirectProductInfo(EXPermutationActionPairs(D).permgroup).groups[1];;
+gap> StabChainOptions(P).random = DefaultStabChainOptions.random;
+true
+gap> Size(P) = 172497600;
+true
+gap> AbelianInvariants(P) = AbelianInvariants(Group(GeneratorsOfGroup(P)));
+true


### PR DESCRIPTION
Group orders computed inside the group returned by `CompatiblePairs` could come out wrong, which made computations either return wrong results or die with a confusing `no method found` error.

`EXPermutationActionPairs` rebuilds the first factor of the direct product it is handed from a subset of its generators, using `random := 1` together with the known group order as a limit:

```gap
opt := rec(limit := s, random := 1);
...
u := DoClosurePrmGp(u, [i], opt);
...
until Size(u) = s;
agp := u;
```

That is sound in itself: `ClosureRandomPermGroup` accepts a chain without verification only while its size has not reached `options.limit` (`lib/stbcrand.gi:1631`), and the loop stops only once the known order `s` is reached, so the final chain is correct.

But `DoClosurePrmGp` records the requested randomness on the result (`SetStabChainOptions(C, rec(random := options.random))`, `lib/grpperm.gi:805`), and `u` is then handed on as a factor of the direct product used by `CompatiblePairs`. From there `CopyOptionsDefaults` (`lib/grpperm.gi:744`) passes `random := 1` to every stabilizer chain computed inside that group later on — where no limit is known, so nothing validates the result.

Reproducer (plain GAP, no packages):

```gap
G := PcGroupCode(379875911272818017220001991, 4356);;
D := DirectProduct(AutomorphismGroup(G), GL(1,11));;

Reset(GlobalMersenneTwister, 4);; Reset(GlobalRandomSource, 4);;
P := DirectProductInfo(EXPermutationActionPairs(D).permgroup).groups[1];;

StabChainOptions(P);                             # rec( random := 1 )
AbelianInvariants(P);                            # [ 2, 2, 4, 5 ]     <- wrong
AbelianInvariants(Group(GeneratorsOfGroup(P)));  # [ 2, 2, 2, 3, 5 ]  <- correct
```

Depending on the state of the random source the same computation instead runs into

```
Error, no 1st choice method found for `Factors' on 2 arguments
 [1] Factors( Integers, r ) @ lib/grp.gi:949
```

which is the generic `AbelianInvariants` method computing `r := Size(G)/Size(H)` for a subgroup `H` obtained by `ClosureSubgroupNC` and getting a non-integer because the closure reports an order that is too small.

The fix clears the marker once the chain has reached the known order. That is what the library already does elsewhere after a deliberately randomized computation, see `lib/grpperm.gi:1035`, `lib/grpperm.gi:1059` and `lib/factgrp.gi:1184`.

The issue was introduced in 2eadf1a4ce and is present in all releases since GAP 4.9.0. It surfaced through `ConstructAllSolvableNonNilpotentGroups(47916)` in GrpConst, which reaches `CompatiblePairs` via `NonSplitExtensions`; with the fix that computation runs to completion.

*AI disclosure: this change was prepared with the help of Claude Code (Claude Opus 5), which reduced the reproducer, diagnosed the cause and drafted the patch and the test; reviewed by me.*
