### PR TITLE
Fix `ElementaryAbelianSeries` returning an invalid series after `AutomorphismGroup`

### DIFF
--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1487,18 +1487,26 @@ InstallMethod( ElementaryAbelianSeries,
 #M  ElementaryAbelianSeries( <G> )  . .  elementary abelian series of a group
 ##
 BindGlobal( "DoEASLS", function( S )
-local   N,I,i,L;
+local   N,I,i,last,L;
 
   N:=ElementaryAbelianSeries(S);
   # remove spurious factors
   L:=[N[1]];
   I:=N[1];
   i:=2;
+  last:=1;
   repeat
     while i<Length(N) and HasElementaryAbelianFactorGroup(I,N[i+1])
       and (IsIdenticalObj(I,N[i]) or not N[i] in S) do
       i:=i+1;
     od;
+    if i=last then
+      # we did not advance, that is the factor N[i]/N[i+1] is not elementary
+      # abelian. Bail out instead of looping forever.
+      ErrorNoReturn("ElementaryAbelianSeries did not return an elementary ",
+                    "abelian series");
+    fi;
+    last:=i;
     I:=N[i];
     Add(L,I);
   until Size(I)=1;

--- a/lib/pcgsspec.gi
+++ b/lib/pcgsspec.gi
@@ -599,8 +599,15 @@ function( pcgs )
         # change to complement base
         Info(InfoSpecPcgs, 1, "exhibit complement system");
         pcgssys := PcgsSystemWithComplementSystem( pcgssys );
-        if IsBound(pcgssys.pcgs!.LGWeights) then
-          # pcgs is reused -- force new one
+        if IsBound(pcgssys.pcgs!.LGWeights)
+           or HasIndicesEANormalSteps(pcgssys.pcgs)
+           or HasIndicesChiefNormalSteps(pcgssys.pcgs)
+           or HasIndicesCentralNormalSteps(pcgssys.pcgs)
+           or HasIndicesPCentralNormalStepsPGroup(pcgssys.pcgs) then
+          # pcgs is reused and already carries series indices which might be
+          # incompatible with the LG series -- force new one. (Setting an
+          # attribute that is already set is silently ignored, so reusing such
+          # a pcgs would leave it in an inconsistent state.)
           pcgssys.pcgs:=PcgsByPcSequence(FamilyObj(OneOfPcgs(pcgs)),
             pcgssys.pcgs!.pcSequence);
         fi;

--- a/tst/testbugfix/2026-07-31-issue-6407.tst
+++ b/tst/testbugfix/2026-07-31-issue-6407.tst
@@ -1,0 +1,18 @@
+# Regression test for https://github.com/gap-system/gap/issues/6407
+# `FittingSubgroup' leaves a central series pcgs on `H' which is not an
+# elementary abelian series; `AutomorphismGroup' used to turn that pcgs into
+# the special pcgs, without being able to correct its stale series indices.
+# `ElementaryAbelianSeries' then returned a series with a non-elementary
+# abelian factor, and `ElementaryAbelianSeriesLargeSteps' looped forever.
+gap> H := Group([(1,2)(3,4)(5,8,7,6)(9,12)(10,11),
+>                (1,4,3,2)(5,7),
+>                (2,4)(5,6,7,8)(9,10,11,12)]);;
+gap> StabChain(H, [1, 5, 9]);;
+gap> FittingSubgroup(H);;
+gap> AutomorphismGroup(H);;
+gap> e := ElementaryAbelianSeries(H);;
+gap> ForAll([1..Length(e)-1],
+>           i -> HasElementaryAbelianFactorGroup(e[i], e[i+1]));
+true
+gap> List(ElementaryAbelianSeriesLargeSteps(H), Size);
+[ 64, 16, 2, 1 ]


### PR DESCRIPTION
`ElementaryAbelianSeries` could return a series with a factor that is not elementary abelian, and `ElementaryAbelianSeriesLargeSteps` then looped forever on it:

```gap
H := Group([(1,2)(3,4)(5,8,7,6)(9,12)(10,11),
            (1,4,3,2)(5,7),
            (2,4)(5,6,7,8)(9,10,11,12)]);;
StabChain(H, [1,5,9]);;
FittingSubgroup(H);;
AutomorphismGroup(H);;
List(ElementaryAbelianSeries(H), Size);   # [ 64, 32, 16, 4, 2, 1 ] -- 16/4 is C4
ElementaryAbelianSeriesLargeSteps(H);     # hangs
```

All three preparatory calls are needed. `FittingSubgroup` leaves a *central* series pcgs on `H` which carries `IndicesEANormalSteps`, although its factors need not have exponent p — here one of them is a cyclic group of order 4. `AutomorphismGroup` then computes `SpecialPcgs(H)`, and the generic method turns out to be handed that very pcgs. It has a guard for that case, which forces a fresh object so that the attributes it sets afterwards actually take effect, but the guard only tested `LGWeights`. So the pcgs was reused, the subsequent `SetIndicesEANormalSteps` was silently ignored, and the result was a pcgs marked `IsSpecialPcgs` whose `IndicesEANormalSteps` disagrees with its `LGFirst`. Through the implication `IsSpecialPcgs => IsPcgsElementaryAbelianSeries` the stale indices are then trusted without validation.

This PR widens that guard to cover all series indices the method sets, and makes `ElementaryAbelianSeriesLargeSteps` raise an error instead of spinning when it is handed a series that is not elementary abelian.

It deliberately does not touch the deeper cause, namely that `TryPcgsPermGroup` sets `IndicesEANormalSteps` on central pcgs at all (`lib/pcgsperm.gi:423`). That attribute is used as a generic "indices of the steps of this pcgs's series" in several places — conjugacy classes of p-groups read it off a central pcgs — so changing it needs a decision about the intended meaning of the attribute; that question is posted on the issue and still open. With this PR the containment that used to keep the situation harmless (`IsPcgsElementaryAbelianSeries` validating the stored indices before anyone trusts them) is restored.

Originally reported against CRISP (bh11/crisp#11), which only appeared in the traceback because `CompositionSeriesUnderAction` calls `InvariantElementaryAbelianSeries` right after `AutomorphismGroup`; it reproduces with `gap -A` and no packages.

Fixes #6407

*AI disclosure: this change was prepared with the help of Claude Code (Claude Opus 5), which reduced the reproducer, diagnosed the cause and drafted the patch and the test; reviewed by me.*
