### PR TITLE
Validate GitHub usernames in package metadata

### DIFF
--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -315,8 +315,7 @@ The following components of the record are <E>optional</E>.
   </Item>
   <Mark><C>GitHubUsername</C></Mark>
   <Item>
-    a string containing a GitHub username. It may contain letters, digits,
-    and single hyphens, but must not start or end with a hyphen.
+    a string containing a GitHub username.
   </Item>
   </List>
   If the <C>IsMaintainer</C> value is <K>true</K> then also one of the

--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -315,7 +315,8 @@ The following components of the record are <E>optional</E>.
   </Item>
   <Mark><C>GitHubUsername</C></Mark>
   <Item>
-    a string containing a GitHub username, without <C>@</C> or a URL.
+    a string containing a GitHub username. It may contain letters, digits,
+    and single hyphens, but must not start or end with a hyphen.
   </Item>
   </List>
   If the <C>IsMaintainer</C> value is <K>true</K> then also one of the

--- a/doc/ref/gappkg.xml
+++ b/doc/ref/gappkg.xml
@@ -313,6 +313,10 @@ The following components of the record are <E>optional</E>.
   <Item>
     a string,
   </Item>
+  <Mark><C>GitHubUsername</C></Mark>
+  <Item>
+    a string containing a GitHub username, without <C>@</C> or a URL.
+  </Item>
   </List>
   If the <C>IsMaintainer</C> value is <K>true</K> then also one of the
   following components is mandatory, otherwise these components are optional.

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2258,8 +2258,19 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
           ( x[1] <> '/' and IsReadableFile( Concatenation( pkgdir, x ) ) ) );
     IsFilenameList:= x -> IsList( x ) and ForAll( x, IsFilename );
     IsURL := x -> ForAny(["http://","https://","ftp://"], s -> StartsWith(x,s));
-    IsGitHubUsername := x -> IsString( x ) and not IsURL( x )
-        and Length( x ) > 0 and x[1] <> '@';
+    IsGitHubUsername := function( x )
+      local len;
+      if not IsString( x ) then
+        return false;
+      fi;
+      len := Length( x );
+      return 0 < len and len <= 39
+          and x[1] <> '-' and x[len] <> '-'
+          and ForAll( x, c -> IsAlphaChar( c ) or IsDigitChar( c )
+                             or c = '-' )
+          and not ForAny( [ 1 .. len - 1 ],
+                          i -> x[i] = '-' and x[i+1] = '-' );
+    end;
 
     result:= true;
 
@@ -2377,7 +2388,7 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
         TestOption( subrec, "Place", IsString, "a string" );
         TestOption( subrec, "Institution", IsString, "a string" );
         TestOption( subrec, "GitHubUsername", IsGitHubUsername,
-            "a string containing a GitHub username, without `@' or a URL" );
+            "a string containing a valid GitHub username" );
       od;
     fi;
 

--- a/lib/package.gi
+++ b/lib/package.gi
@@ -2220,8 +2220,8 @@ InstallGlobalFunction( DeclareAutoreadableVariables,
 ##
 InstallGlobalFunction( ValidatePackageInfo, function( info )
     local record, pkgdir, i, IsStringList, IsRecordList, IsProperBool, IsURL,
-          IsFilename, IsFilenameList, result, TestOption, TestMandat, subrec,
-          list, CheckDateValidity;
+          IsGitHubUsername, IsFilename, IsFilenameList, result, TestOption,
+          TestMandat, subrec, list, CheckDateValidity;
 
     if IsString( info ) then
       if IsReadableFile( info ) then
@@ -2258,6 +2258,8 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
           ( x[1] <> '/' and IsReadableFile( Concatenation( pkgdir, x ) ) ) );
     IsFilenameList:= x -> IsList( x ) and ForAll( x, IsFilename );
     IsURL := x -> ForAny(["http://","https://","ftp://"], s -> StartsWith(x,s));
+    IsGitHubUsername := x -> IsString( x ) and not IsURL( x )
+        and Length( x ) > 0 and x[1] <> '@';
 
     result:= true;
 
@@ -2374,6 +2376,8 @@ InstallGlobalFunction( ValidatePackageInfo, function( info )
         TestOption( subrec, "PostalAddress", IsString, "a string" );
         TestOption( subrec, "Place", IsString, "a string" );
         TestOption( subrec, "Institution", IsString, "a string" );
+        TestOption( subrec, "GitHubUsername", IsGitHubUsername,
+            "a string containing a GitHub username, without `@' or a URL" );
       od;
     fi;
 

--- a/tst/mockpkg/PackageInfo.g
+++ b/tst/mockpkg/PackageInfo.g
@@ -22,6 +22,7 @@ Persons := [
     LastName := "Author",
     WWWHome := "https://mockpkg.gap-system.org/~author",
     Email := "a.author@mockpkg.gap-system.org",
+    GitHubUsername := "active-author",
   ),
   rec(
     IsAuthor := true,

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -343,17 +343,42 @@ true
 gap> info.Persons[1].GitHubUsername := 4784;;
 gap> ValidatePackageInfo(info);
 #E  component `GitHubUsername', if present, must be bound to a string containi\
-ng a GitHub username, without `@' or a URL
+ng a valid GitHub username
 false
 gap> info.Persons[1].GitHubUsername := "https://github.com/gap-maintainer";;
 gap> ValidatePackageInfo(info);
 #E  component `GitHubUsername', if present, must be bound to a string containi\
-ng a GitHub username, without `@' or a URL
+ng a valid GitHub username
 false
 gap> info.Persons[1].GitHubUsername := "@gap-maintainer";;
 gap> ValidatePackageInfo(info);
 #E  component `GitHubUsername', if present, must be bound to a string containi\
-ng a GitHub username, without `@' or a URL
+ng a valid GitHub username
+false
+gap> info.Persons[1].GitHubUsername := "gap--maintainer";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a valid GitHub username
+false
+gap> info.Persons[1].GitHubUsername := "-gap-maintainer";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a valid GitHub username
+false
+gap> info.Persons[1].GitHubUsername := "gap-maintainer-";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a valid GitHub username
+false
+gap> info.Persons[1].GitHubUsername := "gap_maintainer";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a valid GitHub username
+false
+gap> info.Persons[1].GitHubUsername := "1234567890123456789012345678901234567890";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a valid GitHub username
 false
 
 #

--- a/tst/testinstall/package.tst
+++ b/tst/testinstall/package.tst
@@ -332,6 +332,29 @@ gap> info.PackageDoc := rec(
 >   );;
 gap> ValidatePackageInfo(info);
 true
+gap> info.Persons := [ rec(
+>     LastName := "Maintainer",
+>     IsMaintainer := true,
+>     Email := "maintainer@gap-system.org",
+>     GitHubUsername := "gap-maintainer",
+>   ) ];;
+gap> ValidatePackageInfo(info);
+true
+gap> info.Persons[1].GitHubUsername := 4784;;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a GitHub username, without `@' or a URL
+false
+gap> info.Persons[1].GitHubUsername := "https://github.com/gap-maintainer";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a GitHub username, without `@' or a URL
+false
+gap> info.Persons[1].GitHubUsername := "@gap-maintainer";;
+gap> ValidatePackageInfo(info);
+#E  component `GitHubUsername', if present, must be bound to a string containi\
+ng a GitHub username, without `@' or a URL
+false
 
 #
 # Deal with mock package


### PR DESCRIPTION
Allow `PackageInfo.g` person records to provide an optional bare GitHub username for automation. The validator rejects values written as profile URLs or `@` mentions, and the package metadata reference documents the accepted form.

Resolves #4784.

AI disclosure: Created using Codex (GPT-5.5), which assisted with code changes, tests, documentation, and PR preparation.