### PR TITLE
Speed up `AutomorphismGroup` for solvable Frattini-free groups

### DIFF
--- a/lib/morpheus.gi
+++ b/lib/morpheus.gi
@@ -2491,7 +2491,9 @@ local A;
     #LoadPackage("autpgrp"); # try to load the package if it exists
     A:=AutomorphismGroupNilpotentGroup(G);
   elif IsSolvableGroup(G) then
-    if HasIsFrattiniFree(G) and IsFrattiniFree(G) then
+    # AutomorphismGroupFrattFreeGroup needs a pcgs for subgroups of G, which
+    # is not available for example for finitely presented groups
+    if CanEasilyComputePcgs(G) and IsFrattiniFree(G) then
       A:=AutomorphismGroupFrattFreeGroup(G);
     else
       # currently autactbase does not work well, as the representation might

--- a/tst/testinstall/opers/AutomorphismGroup.tst
+++ b/tst/testinstall/opers/AutomorphismGroup.tst
@@ -24,8 +24,22 @@ true
 # solvable group
 gap> G:=DihedralGroup(100);
 <pc group of size 100 with 4 generators>
+gap> IsFrattiniFree(G);
+false
 gap> AutomorphismGroup(G);
 <group of size 1000 with 4 generators>
+
+# solvable Frattini-free groups, handled by AutomorphismGroupFrattFreeGroup
+gap> G:=SymmetricGroup(4);;
+gap> IsFrattiniFree(G);
+true
+gap> Size(AutomorphismGroup(G));
+24
+gap> Size(AutomorphismGroup(SymmetricGroup(IsPcGroup,4)));
+24
+gap> G:=Group((1,2,3,4,5),(2,3,5,4));;  # Frobenius group of order 20
+gap> Size(AutomorphismGroup(G));
+20
 
 #
 gap> STOP_TEST("AutomorphismGroup.tst");


### PR DESCRIPTION
Follow-up to #6487, implementing what @hulpke [pointed out there](https://github.com/gap-system/gap/pull/6487#issuecomment-3389779340):

> The only reason for the `HasIsFrattiniFree` check in `morpheus` was the lack of a general `IsFrattiniFree` method (on which it would have hung). Once it exists the `Has` bit can be removed.

For a solvable group, `AutomorphismGroup` tested `HasIsFrattiniFree(G) and IsFrattiniFree(G)` before using `AutomorphismGroupFrattFreeGroup`, so that path was only ever taken for groups which had the property set beforehand -- in practice only those produced by the group construction and random isomorphism code. Now that `IsFrattiniFree` can be computed, the property is simply asked for.

Deciding `IsFrattiniFree` is cheap compared to constructing the automorphism group. Timings for the complete `AutomorphismGroup` call, so the cost of the new test is included in the "new" column:

| group | new | old |
| --- | --- | --- |
| `SmallGroup(864,4675)` | 25ms | 122ms |
| `SmallGroup(600,148)` | 10ms | 58ms |
| `WreathProduct(SymmetricGroup(3),SymmetricGroup(3))` | 29ms | 84ms |
| `SmallGroup(1080,497)` | 37ms | 90ms |
| `DihedralGroup(100)` (not Frattini-free) | 48ms | 54ms |

Note that `AutomorphismGroupFrattFreeGroup` was previously not reached by the test suite at all, and that the new route also applies to permutation and matrix groups, which the old one essentially never saw. It therefore seemed prudent to check it more broadly than the test suite does: for every solvable, non-nilpotent, Frattini-free group of order at most 200 the resulting automorphism group order was compared with the one obtained from `AutomorphismGroupSolvableGroup`, and for order at most 100 also with the one from the independent `AutomorphismGroupMorpheus`; the same was done for permutation representations of these groups. This covered 340 pc groups and 124 permutation groups without a single mismatch. The added test in `AutomorphismGroup.tst` makes sure the code path is exercised by CI from now on.

`grppcext.gi` guards a similar use of the property when deciding whether reducing a set of extensions is worthwhile. There the test whether the property is already known looks like a deliberate cost heuristic -- it sits next to a `HasAutomorphismGroup` check -- so it is left alone here; happy to revisit if that is wrong.

AI disclosure: prepared with the help of Claude Code (Opus 5), which made the change, ran the cross-checks and test suites described above, and drafted this description.