### PR TITLE
Add `IsFittingFree`

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -332,6 +332,7 @@ as they depend on a parameter.
 
 <#Include Label="IsCyclic">
 <#Include Label="IsElementaryAbelian">
+<#Include Label="IsFittingFree">
 <#Include Label="IsFrattiniFree">
 <#Include Label="IsNilpotentGroup">
 <#Include Label="NilpotencyClassOfGroup">

--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -1902,6 +1902,51 @@ InstallTrueMethod( IsCommutative,
 
 #############################################################################
 ##
+#P  IsFittingFree( <G> )
+##
+##  <#GAPDoc Label="IsFittingFree">
+##  <ManSection>
+##  <Prop Name="IsFittingFree" Arg='G'/>
+##
+##  <Description>
+##  A group is called <E>Fitting-free</E> if its Fitting subgroup
+##  (see <Ref Attr="FittingSubgroup"/>) is trivial. For a finite group this
+##  is the case if and only if its solvable radical
+##  (see <Ref Attr="SolvableRadical"/>) is trivial, which is why such groups
+##  are also called groups with trivial Fitting subgroup, or TF-groups.
+##  <P/>
+##  Methods for this property are only installed for finite groups.
+##  A nontrivial finite solvable group is never Fitting-free, while every
+##  finite nonabelian simple group is.
+##  <Example><![CDATA[
+##  gap> IsFittingFree( SymmetricGroup( 5 ) );
+##  true
+##  gap> IsFittingFree( SymmetricGroup( 4 ) );
+##  false
+##  gap> IsFittingFree( SL( 2, 5 ) );
+##  false
+##  gap> IsFittingFree( PSL( 2, 5 ) );
+##  true
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareProperty( "IsFittingFree", IsGroup );
+
+InstallIsomorphismMaintenance( IsFittingFree, IsGroup, IsGroup );
+
+InstallTrueMethod( IsFittingFree, IsGroup and IsTrivial );
+
+# a nonabelian simple group has no nontrivial proper normal subgroup at all
+InstallTrueMethod( IsFittingFree, IsGroup and IsFinite and IsNonabelianSimpleGroup );
+
+# for a finite group G we have Phi(G) <= F(G)
+InstallTrueMethod( IsFrattiniFree, IsGroup and IsFinite and IsFittingFree );
+
+
+#############################################################################
+##
 #A  InvariantForm( <D> )
 ##
 ##  <ManSection>

--- a/lib/grp.gi
+++ b/lib/grp.gi
@@ -1704,6 +1704,40 @@ RedispatchOnCondition( IsFrattiniFree, true, [IsGroup], [IsFinite], 0);
 
 #############################################################################
 ##
+#M  IsFittingFree( <G> )  . . . . . . . .  is the Fitting subgroup trivial ?
+##
+InstallMethod( IsFittingFree, "for groups with known Fitting subgroup",
+            [ IsGroup and HasFittingSubgroup ], SUM_FLAGS,
+            G -> IsTrivial( FittingSubgroup( G ) ) );
+
+InstallMethod( IsFittingFree, "for finite solvable groups",
+            [ IsGroup and IsFinite and IsSolvableGroup ],
+            # a nontrivial solvable group has a nontrivial Fitting subgroup
+            IsTrivial );
+
+InstallMethod( IsFittingFree, "for groups allowing the TF approach",
+            [ IsGroup and CanComputeFittingFree ],
+            # F(G) is trivial if and only if the solvable radical is, and the
+            # latter is directly available from the TF setup
+            G -> IsTrivial( SolvableRadical( G ) ) );
+
+InstallMethod( IsFittingFree, "generic method for finite groups",
+            [ IsGroup and IsFinite ],
+            G -> IsTrivial( FittingSubgroup( G ) ) );
+
+RedispatchOnCondition( IsFittingFree, true, [IsGroup], [IsFinite], 0);
+
+InstallMethod( FittingSubgroup, "for Fitting free groups",
+            [ IsGroup and IsFittingFree ], SUM_FLAGS,
+            TrivialSubgroup );
+
+InstallMethod( SolvableRadical, "for Fitting free groups",
+            [ IsGroup and IsFittingFree ], SUM_FLAGS,
+            TrivialSubgroup );
+
+
+#############################################################################
+##
 #M  JenningsSeries( <G> ) . . . . . . . . . . .  jennings series of a p-group
 ##
 InstallMethod( JenningsSeries,

--- a/tst/testinstall/opers/IsFittingFree.tst
+++ b/tst/testinstall/opers/IsFittingFree.tst
@@ -1,0 +1,76 @@
+gap> START_TEST("IsFittingFree.tst");
+
+#
+gap> IsFittingFree(TrivialGroup());
+true
+gap> IsFittingFree(Group(()));
+true
+
+# a nontrivial solvable group is never Fitting-free
+gap> IsFittingFree(CyclicGroup(6));
+false
+gap> IsFittingFree(DihedralGroup(8));
+false
+gap> List([1..6], n -> IsFittingFree(SymmetricGroup(n)));  # S1 is trivial
+[ true, false, false, false, true, true ]
+
+# nonabelian simple groups are Fitting-free, abelian simple ones are not
+gap> IsFittingFree(AlternatingGroup(5));
+true
+gap> IsFittingFree(PSL(3,2));
+true
+gap> IsFittingFree(CyclicGroup(7));
+false
+
+# a nontrivial solvable normal subgroup destroys the property
+gap> IsFittingFree(SL(2,5));
+false
+gap> IsFittingFree(PSL(2,5));
+true
+gap> IsFittingFree(DirectProduct(AlternatingGroup(5), CyclicGroup(2)));
+false
+gap> IsFittingFree(DirectProduct(AlternatingGroup(5), AlternatingGroup(6)));
+true
+gap> IsFittingFree(SymmetricGroup(5));
+true
+
+# pc groups and matrix groups
+gap> IsFittingFree(SymmetricGroup(IsPcGroup,4));
+false
+gap> IsFittingFree(GL(3,2));  # simple, isomorphic to PSL(3,2) above
+true
+gap> IsFittingFree(GL(2,3));  # solvable
+false
+
+# the property agrees with the definition
+#@if IsPackageMarkedForLoading( "smallgrp", "" )
+gap> ForAll([1..100], n -> ForAll([1..NrSmallGroups(n)],
+>      i -> IsFittingFree(SmallGroup(n,i))
+>           = IsTrivial(FittingSubgroup(SmallGroup(n,i)))));
+true
+#@fi
+
+# knowing the property makes the Fitting subgroup and the solvable radical trivial
+gap> G := SymmetricGroup(5);;
+gap> SetIsFittingFree(G, true);
+gap> FittingSubgroup(G);
+Group(())
+gap> SolvableRadical(G);
+Group(())
+
+# conversely a known Fitting subgroup decides the property, also for groups
+# which are not known to be finite
+gap> G := FreeGroup(2);;
+gap> SetFittingSubgroup(G, TrivialSubgroup(G));
+gap> IsFittingFree(G);
+true
+
+# Fitting-free groups are Frattini-free
+gap> G := AlternatingGroup(6);;
+gap> IsFittingFree(G);
+true
+gap> HasIsFrattiniFree(G) and IsFrattiniFree(G);
+true
+
+#
+gap> STOP_TEST("IsFittingFree.tst");


### PR DESCRIPTION
Follow-up to #6487, where @ThomasBreuer [remarked](https://github.com/gap-system/gap/pull/6487#pullrequestreview-3532893521):

> This reminds me that there is no `IsFittingFree` yet, and that none of the various `FittingFreeSomething` functions is documented.

This adds the property. A group is *Fitting-free* if its Fitting subgroup is trivial, equivalently -- for a finite group -- if its solvable radical is trivial. Such groups play a special role in the TF paradigm used throughout the library, but so far there was no way to ask for the property directly.

The methods take the cheap route wherever one exists:

- if the Fitting subgroup is already known, decide from it (this needs no finiteness assumption);
- a nontrivial finite solvable group is never Fitting-free, so there the test is just `IsTrivial`;
- if `CanComputeFittingFree` holds, use `IsTrivial(SolvableRadical(G))`, since the radical is part of the TF setup, whereas the generic method for `FittingSubgroup` computes a `PCore` for every prime divisor of the group order. For permutation groups this is a noticeable difference, e.g. 2ms instead of 6ms for `PSL(3,5)` and 2ms instead of 14ms for `WreathProduct(AlternatingGroup(5),CyclicGroup(IsPermGroup,2))`;
- otherwise fall back to `IsTrivial(FittingSubgroup(G))`.

Conversely a group known to be Fitting-free gets a trivial `FittingSubgroup` and `SolvableRadical` for free, and since the Frattini subgroup of a finite group is contained in its Fitting subgroup, `IsFittingFree` implies `IsFrattiniFree` (#6487).

Besides the new test file, the property was checked to agree with `IsTrivial(FittingSubgroup(G))` for all groups in the small groups library of order at most 255 and all transitive groups of degree at most 12.

Note that the second half of Thomas' remark is *not* addressed here. The eight `FittingFree...` GAPDoc blocks in `lib/fitfree.gd` are not merely missing from the manual; several of them cannot be included as they stand, because the markup is broken: the block for `AttemptPermRadicalMethod` lacks its closing `</ManSection>` and `<#/GAPDoc>`, several `<Ref Func="..."/>` tags are missing the closing slash, and one place writes `<G>` where `<A>G</A>` is meant. Fixing and including those seems worth a pull request of its own, and per Thomas' suggestion @hulpke may want to review the prose while at it.

AI disclosure: prepared with the help of Claude Code (Opus 5), which wrote the implementation, documentation and tests, ran the checks and test suites described above, and drafted this description.