### PR TITLE
Add `CurrentSecondsSinceEpoch` for obtaining the current date and time

### DIFF
--- a/doc/ref/debug.xml
+++ b/doc/ref/debug.xml
@@ -444,6 +444,10 @@ hour/minute format.
 that has passed since some fixed, but unspecified time in the past.
 
 This function is appropriate for doing wallclock time measurements.
+Only differences between two of its values are meaningful: despite the
+name, the values are not counted from 1-Jan-1970, and on most systems not
+from any particular date at all.  To find out what the current date and
+time are, use <Ref Func="CurrentSecondsSinceEpoch"/> instead.
 
 The actual resolution depends on the system that &GAP; is run on.
 Information about the used timers can be obtained by calling

--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -713,6 +713,37 @@ gap> HexStringInt(last);
 <#Include Label="SecondsDMYhms">
 <#Include Label="DMYhmsSeconds">
 
+<ManSection>
+<Func Name="CurrentSecondsSinceEpoch" Arg=''/>
+<Description>
+returns the number of seconds that have passed since
+1-Jan-1970, 00:00:00 UTC, ignoring leap seconds,
+or <K>fail</K> if the system clock cannot be read.
+<P/>
+That epoch is guaranteed, and does not depend on the epoch the underlying
+operating system happens to count from.  Note that the value says nothing
+about the local time zone; it is a point in time, not a local clock
+reading.
+<P/>
+This is the same time scale that the other functions in this section use,
+so the result can be passed to <Ref Func="DMYhmsSeconds"/> to obtain the
+current date and time.
+<P/>
+<Log><![CDATA[
+gap> secs:= CurrentSecondsSinceEpoch();;
+gap> DMYhmsSeconds( secs );
+[ 11, 8, 2026, 23, 14, 29 ]
+gap> StringDate( DMYDay( QuoInt( secs, 86400 ) ) );
+"11-Aug-2026"
+]]></Log>
+<P/>
+Note that <Ref Func="NanosecondsSinceEpoch"/> does <E>not</E> count from
+1-Jan-1970, despite its name: it counts from an unspecified point in the
+past, and is meant for measuring durations rather than for recording when
+something happened.
+</Description>
+</ManSection>
+
 </Section>
 
 

--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -43,6 +43,24 @@
 #include <sys/time.h>
 #endif
 
+// Pick the source for the wall clock, see FuncCurrentSecondsSinceEpoch.
+// POSIX fixes the epoch of the first two to 1970-01-01 00:00:00 UTC; the
+// fallback needs converting, so it is named separately.
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_REALTIME)
+#define GAP_WALLCLOCK_CLOCK_GETTIME
+#elif defined(HAVE_GETTIMEOFDAY)
+#define GAP_WALLCLOCK_GETTIMEOFDAY
+#else
+#define GAP_WALLCLOCK_TIME
+#endif
+
+// 'time' is in C89 and thus always available, unlike the monotonic timer,
+// which needs whatever the platform happens to offer.
+#include <time.h>
+#ifdef GAP_WALLCLOCK_GETTIMEOFDAY
+#include <sys/time.h>
+#endif
+
 
 /****************************************************************************
 **
@@ -254,6 +272,93 @@ static Obj FuncNanosecondsSinceEpoch(Obj self)
 }
 
 
+#ifdef GAP_WALLCLOCK_TIME
+
+/****************************************************************************
+**
+*F  SyUnixEpochSecondsFromTimeT( <t> )
+**
+**  Convert a 'time_t' to the number of seconds since 1970-01-01 00:00:00 UTC.
+**
+**  ISO C leaves the epoch of 'time_t' implementation defined, so a value from
+**  'time' cannot simply be returned as is.  Breaking it down with 'gmtime'
+**  and counting from the fields is independent of whatever epoch the system
+**  uses.  Returns -1 if the conversion fails.
+**
+**  Only correct for dates from 1970 onwards, which is all we need: the input
+**  is the current time.
+*/
+static Int8 SyUnixEpochSecondsFromTimeT(time_t t)
+{
+    struct tm * bd;
+    Int8        year, days, leaps;
+
+    bd = gmtime(&t);
+    if (bd == NULL)
+        return -1;
+
+    year = (Int8)bd->tm_year + 1900;
+    if (year < 1970)
+        return -1;
+
+    // leap days completed between 1970-01-01 and 1 January of <year>
+    leaps = (year - 1) / 4 - (year - 1) / 100 + (year - 1) / 400 -
+            (1969 / 4 - 1969 / 100 + 1969 / 400);
+    days = (year - 1970) * 365 + leaps + bd->tm_yday;
+
+    return ((days * 24 + bd->tm_hour) * 60 + bd->tm_min) * 60 + bd->tm_sec;
+}
+
+#endif    // GAP_WALLCLOCK_TIME
+
+
+/****************************************************************************
+**
+*F  FuncCurrentSecondsSinceEpoch( <self> )
+**
+**  'FuncCurrentSecondsSinceEpoch' returns the number of seconds that have
+**  passed since 1970-01-01 00:00:00 UTC, ignoring leap seconds, or 'fail' if
+**  the system clock cannot be read.  That epoch is guaranteed, whatever the
+**  system happens to count from.
+**
+**  Note that this is a different quantity from the one returned by
+**  'SyNanosecondsSinceEpoch', which counts from an unspecified point and is
+**  monotonic where possible.  That makes it right for measuring durations
+**  and useless for recording when something happened, which is what this is
+**  for.
+*/
+static Obj FuncCurrentSecondsSinceEpoch(Obj self)
+{
+    Int8 secs;
+
+    // POSIX pins both of these to 1970-01-01 00:00:00 UTC, so their seconds
+    // field is already the value we promise.
+#if defined(GAP_WALLCLOCK_CLOCK_GETTIME)
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+        return Fail;
+    secs = (Int8)ts.tv_sec;
+#elif defined(GAP_WALLCLOCK_GETTIMEOFDAY)
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) != 0)
+        return Fail;
+    secs = (Int8)tv.tv_sec;
+#else
+    time_t t = time(NULL);
+
+    if (t == (time_t)-1)
+        return Fail;
+    secs = SyUnixEpochSecondsFromTimeT(t);
+    if (secs < 0)
+        return Fail;
+#endif
+
+    return ObjInt_Int8(secs);
+}
+
+
 /****************************************************************************
 **
 *F  FuncNanosecondsSinceEpochInfo( <self> )
@@ -356,6 +461,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_0ARGS(RUNTIMES),
     GVAR_FUNC_0ARGS(NanosecondsSinceEpoch),
     GVAR_FUNC_0ARGS(NanosecondsSinceEpochInfo),
+    GVAR_FUNC_0ARGS(CurrentSecondsSinceEpoch),
 
     GVAR_FUNC_1ARGS(Sleep, secs),
     GVAR_FUNC_1ARGS(MicroSleep, msecs),

--- a/tst/testinstall/strings.tst
+++ b/tst/testinstall/strings.tst
@@ -2,7 +2,7 @@
 ##
 ##  This file tests output methods (mainly for strings)
 ##
-#@local hadHome, len, savedHome, str, x
+#@local hadHome, len, savedHome, str, x, secs
 gap> START_TEST("strings.tst");
 
 # FFE
@@ -278,6 +278,25 @@ gap> Print(_FormatParagraph(
 ##  the lazy dog
 gap> Print(_FormatParagraph("a b", 20, "<", ">"));
 <a b>
+
+# CurrentSecondsSinceEpoch
+gap> secs := CurrentSecondsSinceEpoch();;
+gap> IsInt(secs);
+true
+
+# Any roughly correct clock lands in this window, while a monotonic timer
+# counting from boot -- which is what NanosecondsSinceEpoch returns -- does
+# not.  1600000000 is Sep 2020, 4000000000 is Oct 2096.
+gap> 1600000000 < secs and secs < 4000000000;
+true
+
+# It uses the same time scale as the other calendar functions.
+gap> SecondsDMYhms(DMYhmsSeconds(secs)) = secs;
+true
+gap> DMYhmsSeconds(secs)[3] >= 2020;
+true
+gap> CurrentSecondsSinceEpoch() >= secs;
+true
 
 #
 gap> STOP_TEST("strings.tst");


### PR DESCRIPTION
GAP cannot tell the time. `NanosecondsSinceEpoch` looks like the answer but
counts from an unspecified point — `CLOCK_MONOTONIC`, or `mach_absolute_time`
on macOS. Here `NanosecondsSinceEpoch()/10^9` is 73750, the uptime.

23 packages in the distribution handle dates; `yags`, `QGNAG` and the
`libsemigroups` benchmarks shell out to `date`.

`CurrentSecondsSinceEpoch()` returns seconds since 1970-01-01 00:00:00 UTC, so
it feeds the calendar functions that already exist:

```gap
gap> DMYhmsSeconds( CurrentSecondsSinceEpoch() );
[ 11, 8, 2026, 23, 14, 29 ]
```

The epoch is guaranteed rather than assumed: POSIX pins `CLOCK_REALTIME` and
`gettimeofday` to 1970, and the `time()` fallback converts via `gmtime`,
checked against a C reference for every 86399-second step from 1970 to 2030.

The manual entry for `NanosecondsSinceEpoch` now says it does not count from
1970 and points here.

**Naming.** `CurrentSecondsSinceEpoch` now sits beside `NanosecondsSinceEpoch`,
which is *not* since the epoch. `CurrentUnixTime` and `CurrentTime` were the
alternatives; renaming is four lines.

`make check`: 0 failures in 314 files.

*Written with Claude Opus 5 via Claude Code; reviewed by me. The commit lists
the tool as co-author.*
