### PR TITLE
Add an accumulating SHA256 API (`SHA256State`, `UpdateSHA256`, `UpdateSHA256File`)

### DIFF
--- a/doc/ref/string.xml
+++ b/doc/ref/string.xml
@@ -692,6 +692,10 @@ gap> HexStringInt(last);
 <#Include Label="CrcString">
 <#Include Label="HexSHA256">
 <#Include Label="HexSHA256File">
+<#Include Label="IsSHA256State">
+<#Include Label="SHA256State">
+<#Include Label="UpdateSHA256">
+<#Include Label="UpdateSHA256File">
 <#Include Label="Pluralize">
 
 </Section>

--- a/lib/files.gd
+++ b/lib/files.gd
@@ -828,6 +828,7 @@ DeclareGlobalFunction( "Edit" );
 ##  <ManSection>
 ##  <Func Name="HexSHA256" Arg='string'/>
 ##  <Func Name="HexSHA256" Arg='stream' Label="for a stream"/>
+##  <Func Name="HexSHA256" Arg='state' Label="for a SHA256 state"/>
 ##
 ##  <Description>
 ##  <Index>hash function</Index>
@@ -836,6 +837,10 @@ DeclareGlobalFunction( "Edit" );
 ##  resp. of the data in the input stream object <A>stream</A>
 ##  (see Chapter&nbsp;<Ref Chap="Streams"/> to learn about streams)
 ##  when read from the current position until EOF (end-of-file).
+##  <P/>
+##  Given a SHA-256 state (see <Ref Func="SHA256State"/>), return the checksum
+##  of everything accumulated in it so far.  Reading it does not consume the
+##  state: it may be read again, and fed more data afterwards.
 ##  <P/>
 ##  The checksum is returned as string with 64 lowercase hexadecimal digits.
 ##  <Example><![CDATA[
@@ -889,5 +894,91 @@ DeclareGlobalFunction("HexSHA256");
 ##
 DeclareGlobalFunction("HexSHA256File");
 
+##  <#GAPDoc Label="IsSHA256State">
+##  <ManSection>
+##  <Filt Name="IsSHA256State" Arg='obj' Type='Category'/>
+##
+##  <Description>
+##  The category of SHA-256 states, as returned by
+##  <Ref Func="SHA256State"/>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareCategory("IsSHA256State", IsObject);
+
+BIND_GLOBAL("GAP_SHA256_State_Family", NewFamily("GAP_SHA256_State_Family"));
+
 BIND_GLOBAL("GAP_SHA256_State_Type",
-           NewType(NewFamily("GAP_SHA256_State_Family"), IsObject) );
+           NewType(GAP_SHA256_State_Family, IsSHA256State) );
+
+
+##  <#GAPDoc Label="SHA256State">
+##  <ManSection>
+##  <Func Name="SHA256State" Arg=''/>
+##
+##  <Description>
+##  <Index>hash function</Index>
+##  <Index>checksum</Index>
+##  Return a new SHA-256 state, which accumulates data fed to it with
+##  <Ref Func="UpdateSHA256"/> and <Ref Func="UpdateSHA256File"/>.  Its digest
+##  is read with <Ref Func="HexSHA256"/>.
+##  <Log><![CDATA[
+##  gap> s := SHA256State();;
+##  gap> UpdateSHA256(s, "ab");;
+##  gap> UpdateSHA256(s, "cd");;
+##  gap> HexSHA256(s) = HexSHA256("abcd");
+##  true
+##  ]]></Log>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("SHA256State");
+
+
+##  <#GAPDoc Label="UpdateSHA256">
+##  <ManSection>
+##  <Func Name="UpdateSHA256" Arg='state, string'/>
+##
+##  <Description>
+##  Append <A>string</A> to the data accumulated in <A>state</A>.
+##  <A>string</A> is left untouched.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("UpdateSHA256");
+
+
+##  <#GAPDoc Label="UpdateSHA256File">
+##  <ManSection>
+##  <Func Name="UpdateSHA256File" Arg='state, filename, decompress'/>
+##
+##  <Description>
+##  Append the contents of the file <A>filename</A> to the data accumulated in
+##  <A>state</A>. Return <K>true</K> on success, or <K>fail</K> if the file
+##  cannot be read, in which case <A>state</A> is left as it was.
+##  <P/>
+##  The file is read as binary data, so the result always describes the bytes
+##  on disk, also on systems which distinguish text and binary mode and would
+##  otherwise translate line endings.  It is read in chunks, so the size of
+##  the file is not limited by the available memory.
+##  <P/>
+##  <A>decompress</A> means what it does for
+##  <Ref Func="HexSHA256File"/>, and is likewise required.
+##  <Log><![CDATA[
+##  gap> name := Filename(DirectoryTemporary(), "test.txt");;
+##  gap> FileString(name, "cd");;
+##  gap> s := SHA256State();;
+##  gap> UpdateSHA256(s, "ab");
+##  gap> UpdateSHA256File(s, name, false);
+##  true
+##  gap> HexSHA256(s) = HexSHA256("abcd");
+##  true
+##  ]]></Log>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction("UpdateSHA256File");

--- a/lib/files.gi
+++ b/lib/files.gi
@@ -407,9 +407,46 @@ function(words)
     return res;
 end);
 
+InstallGlobalFunction( SHA256State, GAP_SHA256_INIT );
+
+InstallMethod( PrintObj, "for a SHA256 state", [ IsSHA256State ],
+function(state)
+    Print("<SHA256 state>");
+end);
+
+InstallGlobalFunction( UpdateSHA256,
+function(state, string)
+    if not IsSHA256State(state) then
+        ErrorNoReturn("<state> must be a SHA256 state");
+    elif not IsString(string) then
+        ErrorNoReturn("<string> must be a string");
+    fi;
+
+    # CopyToStringRep: the kernel converts its argument to a string in place,
+    # which would retype a list of characters belonging to the caller.
+    GAP_SHA256_UPDATE(state, CopyToStringRep(string));
+end);
+
+InstallGlobalFunction( UpdateSHA256File,
+function(state, filename, decompress)
+    if not IsSHA256State(state) then
+        ErrorNoReturn("<state> must be a SHA256 state");
+    elif not IsString(filename) then
+        ErrorNoReturn("<filename> must be a string");
+    elif not decompress in [ true, false ] then
+        ErrorNoReturn("<decompress> must be 'true' or 'false'");
+    fi;
+
+    return GAP_SHA256_UPDATE_FILE(state, UserHomeExpand(filename), decompress);
+end);
+
 InstallGlobalFunction( HexSHA256,
 function(str)
     local s, chunk;
+
+    if IsSHA256State(str) then
+        return GAP_SHA256_HexOfWords(GAP_SHA256_DIGEST(str));
+    fi;
 
     s := GAP_SHA256_INIT();
     if IsString(str) then
@@ -423,25 +460,20 @@ function(str)
             fi;
         until not IsString(chunk) or Length(chunk) = 0;
     else
-        ErrorNoReturn("<str> has to be a string or an input stream");
+        ErrorNoReturn("<str> has to be a string, an input stream, or a ",
+                      "SHA256 state");
     fi;
 
-    return GAP_SHA256_HexOfWords(GAP_SHA256_FINAL(s));
+    return GAP_SHA256_HexOfWords(GAP_SHA256_DIGEST(s));
 end);
 
 InstallGlobalFunction( HexSHA256File,
 function(filename, decompress)
-    local res;
+    local s;
 
-    if not IsString(filename) then
-        ErrorNoReturn("<filename> must be a string");
-    elif not decompress in [ true, false ] then
-        ErrorNoReturn("<decompress> must be 'true' or 'false'");
-    fi;
-
-    res := GAP_SHA256_FILE(UserHomeExpand(filename), decompress);
-    if res = fail then
+    s := SHA256State();
+    if UpdateSHA256File(s, filename, decompress) = fail then
         return fail;
     fi;
-    return GAP_SHA256_HexOfWords(res);
+    return HexSHA256(s);
 end);

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -240,12 +240,63 @@ static int sha256_final(sha256_state_t * state)
     return 0;
 }
 
+static sha256_state_t * SHA256_STATE(Obj state)
+{
+    return (sha256_state_t *)(&ADDR_OBJ(state)[1]);
+}
+
+#define RequireSHA256State(funcname, op)                                     \
+    RequireArgumentCondition(funcname, op,                                   \
+                             IS_DATOBJ(op) &&                                \
+                                 TYPE_OBJ(op) == GAP_SHA256_State_Type,      \
+                             "must be a SHA256 state")
+
+// Feed the contents of <filename> into <st>.  Mode "rb" rather than "r" so
+// that no line ending translation happens; the digest has to describe the
+// bytes on disk.  With <decompress> set, a file whose name ends in '.gz' is
+// read as its decompressed content instead, matching 'InputTextFile'.
+// Returns 0 on success, -1 if the file could not be read.
+static int sha256_update_file(sha256_state_t * st,
+                              Obj              filename,
+                              Obj              decompress)
+{
+    Int   fid, len;
+    UChar buf[16384];
+
+    fid = SyFopen(CONST_CSTR_STRING(filename), "rb", decompress == True);
+    if (fid == -1)
+        return -1;
+
+    while ((len = SyRead(fid, buf, sizeof(buf))) > 0) {
+        sha256_update(st, buf, len);
+    }
+    SyFclose(fid);
+    return len < 0 ? -1 : 0;
+}
+
+// The eight words of <st> as a plain list, most significant first.  <st> is
+// taken by value on purpose: NEW_PLIST below may trigger a garbage collection,
+// which can move bags, so this must not be handed a pointer into one.
+static Obj sha256_words(sha256_state_t st)
+{
+    Obj result;
+    int i;
+
+    result = NEW_PLIST(T_PLIST, 8);
+    SET_LEN_PLIST(result, 8);
+    for (i = 0; i < 8; i++) {
+        SET_ELM_PLIST(result, i + 1, ObjInt_UInt(st.r[i]));
+        CHANGED_BAG(result);
+    }
+    return result;
+}
+
 Obj FuncGAP_SHA256_INIT(Obj self)
 {
     Obj              result;
     sha256_state_t * sptr;
 
-    result = NewBag(T_DATOBJ, sizeof(UInt4) + sizeof(sha256_state_t));
+    result = NewBag(T_DATOBJ, sizeof(Obj) + sizeof(sha256_state_t));
     SET_TYPE_OBJ(result, GAP_SHA256_State_Type);
 
     sptr = (sha256_state_t *)(&ADDR_OBJ(result)[1]);
@@ -256,82 +307,50 @@ Obj FuncGAP_SHA256_INIT(Obj self)
 
 Obj FuncGAP_SHA256_UPDATE(Obj self, Obj state, Obj bytes)
 {
-    sha256_state_t * sptr;
-
-    RequireArgumentCondition(SELF_NAME, state,
-                             IS_DATOBJ(state) &&
-                                 TYPE_OBJ(state) == GAP_SHA256_State_Type,
-                             "must be a SHA256 state");
+    RequireSHA256State(SELF_NAME, state);
     RequireStringRep(SELF_NAME, bytes);
 
-    sptr = (sha256_state_t *)(&ADDR_OBJ(state)[1]);
-    sha256_update(sptr, CHARS_STRING(bytes), GET_LEN_STRING(bytes));
+    sha256_update(SHA256_STATE(state), CHARS_STRING(bytes),
+                  GET_LEN_STRING(bytes));
     CHANGED_BAG(state);
 
     return 0;
 }
 
-Obj FuncGAP_SHA256_FINAL(Obj self, Obj state)
+// Feed a whole file into <state>.  Returns 'true' on success, or 'fail' if
+// the file could not be read, in which case <state> is left as it was.
+Obj FuncGAP_SHA256_UPDATE_FILE(Obj self, Obj state, Obj filename,
+                               Obj decompress)
 {
-    Obj              result;
-    sha256_state_t * sptr;
-    int              i;
-
-    RequireArgumentCondition(SELF_NAME, state,
-                             IS_DATOBJ(state) &&
-                                 TYPE_OBJ(state) == GAP_SHA256_State_Type,
-                             "must be a SHA256 state");
-
-    result = NEW_PLIST(T_PLIST, 8);
-    SET_LEN_PLIST(result, 8);
-
-    sptr = (sha256_state_t *)(&ADDR_OBJ(state)[1]);
-    sha256_final(sptr);
-    CHANGED_BAG(state);
-
-    for (i = 0; i < 8; i++) {
-        SET_ELM_PLIST(result, i + 1, ObjInt_UInt(sptr->r[i]));
-        CHANGED_BAG(result);
-    }
-    return result;
-}
-
-Obj FuncGAP_SHA256_FILE(Obj self, Obj filename, Obj decompress)
-{
-    Obj            result;
     sha256_state_t st;
-    Int            fid, len;
-    int            i;
-    UChar          buf[16384];
 
+    RequireSHA256State(SELF_NAME, state);
     RequireStringRep(SELF_NAME, filename);
     RequireTrueOrFalse(SELF_NAME, decompress);
 
-    // Mode "rb" rather than "r" so that no line ending translation happens;
-    // the digest has to describe the bytes on disk.  With <decompress> set,
-    // a file whose name ends in '.gz' is hashed as its decompressed content
-    // instead, matching what 'InputTextFile' would read.
-    fid = SyFopen(CONST_CSTR_STRING(filename), "rb", decompress == True);
-    if (fid == -1)
+    // Work on a copy, so that a file which turns out to be unreadable part
+    // way through does not leave half of itself in the caller's state.
+    st = *SHA256_STATE(state);
+    if (sha256_update_file(&st, filename, decompress) < 0)
         return Fail;
 
-    sha256_init(&st);
-    while ((len = SyRead(fid, buf, sizeof(buf))) > 0) {
-        sha256_update(&st, buf, len);
-    }
-    SyFclose(fid);
-    if (len < 0)
-        return Fail;
+    *SHA256_STATE(state) = st;
+    CHANGED_BAG(state);
+    return True;
+}
 
+// The digest of <state> as it stands, leaving <state> usable.  Padding a
+// SHA256 state is destructive, so this finalizes a copy: reading the digest
+// must not be a one-shot operation the caller has to know about.
+Obj FuncGAP_SHA256_DIGEST(Obj self, Obj state)
+{
+    sha256_state_t st;
+
+    RequireSHA256State(SELF_NAME, state);
+
+    st = *SHA256_STATE(state);
     sha256_final(&st);
-
-    result = NEW_PLIST(T_PLIST, 8);
-    SET_LEN_PLIST(result, 8);
-    for (i = 0; i < 8; i++) {
-        SET_ELM_PLIST(result, i + 1, ObjInt_UInt(st.r[i]));
-        CHANGED_BAG(result);
-    }
-    return result;
+    return sha256_words(st);
 }
 
 Obj FuncGAP_SHA256_HMAC(Obj self, Obj key, Obj text)
@@ -393,8 +412,8 @@ Obj FuncGAP_SHA256_HMAC(Obj self, Obj key, Obj text)
 static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_0ARGS(GAP_SHA256_INIT),
     GVAR_FUNC_2ARGS(GAP_SHA256_UPDATE, state, bytes),
-    GVAR_FUNC_1ARGS(GAP_SHA256_FINAL, state),
-    GVAR_FUNC_2ARGS(GAP_SHA256_FILE, filename, decompress),
+    GVAR_FUNC_3ARGS(GAP_SHA256_UPDATE_FILE, state, filename, decompress),
+    GVAR_FUNC_1ARGS(GAP_SHA256_DIGEST, state),
     GVAR_FUNC_2ARGS(GAP_SHA256_HMAC, key, text),
 
     { 0 }    // Finish with an empty entry

--- a/tst/testinstall/sha256.tst
+++ b/tst/testinstall/sha256.tst
@@ -1,12 +1,12 @@
 #
-#@local dir, gzname, name, out, state, str
+#@local c, dir, gzname, l, name, out, s, state, str, t
 gap> START_TEST("sha256.tst");
 
 #
 # test input validation for the kernel functions
 #
 gap> state := GAP_SHA256_INIT();
-<object>
+<SHA256 state>
 
 #
 gap> GAP_SHA256_UPDATE(fail, fail);
@@ -95,6 +95,98 @@ gap> HexSHA256File(42, false);
 Error, <filename> must be a string
 gap> HexSHA256File(name, "yes");
 Error, <decompress> must be 'true' or 'false'
+
+#
+# SHA256State: accumulating input that is not in one place
+#
+gap> s := SHA256State();
+<SHA256 state>
+gap> IsSHA256State(s);
+true
+gap> IsSHA256State(fail);
+false
+
+# How the input is divided up between calls makes no difference.
+gap> UpdateSHA256(s, "ab");
+gap> UpdateSHA256(s, "cd");
+gap> HexSHA256(s) = HexSHA256("abcd");
+true
+gap> t := SHA256State();;
+gap> for c in "abcd" do UpdateSHA256(t, [c]); od;
+gap> HexSHA256(t) = HexSHA256("abcd");
+true
+gap> HexSHA256(SHA256State()) = HexSHA256("");
+true
+
+# Reading the digest does not consume the state.  Finalizing a SHA256 state
+# pads it in place and so destroys it; GAP_SHA256_DIGEST does that to a copy,
+# which is what makes reading a digest an ordinary operation.
+gap> HexSHA256(s) = HexSHA256(s);
+true
+gap> UpdateSHA256(s, "e");
+gap> HexSHA256(s) = HexSHA256("abcde");
+true
+
+# The argument is left alone: the kernel converts a list of characters to a
+# string in place, which must not happen to the caller's list.
+gap> l := List("ab", c -> c);;
+gap> UpdateSHA256(SHA256State(), l);
+gap> IsStringRep(l);
+false
+
+#
+# UpdateSHA256File
+#
+gap> dir := DirectoryTemporary();;
+gap> name := Filename(dir, "half.txt");;
+gap> FileString(name, "cd");;
+gap> s := SHA256State();;
+gap> UpdateSHA256(s, "ab");
+gap> UpdateSHA256File(s, name, false);
+true
+gap> HexSHA256(s) = HexSHA256("abcd");
+true
+
+# A file that cannot be read leaves the state as it was.
+gap> UpdateSHA256File(s, Filename(dir, "no-such-file"), false);
+fail
+gap> HexSHA256(s) = HexSHA256("abcd");
+true
+
+# ... and the two answers a '.gz' file has, as for HexSHA256File.
+gap> gzname := Filename(dir, "c.txt.gz");;
+gap> out := OutputGzipFile(gzname, false);;
+gap> WriteAll(out, "abcd");;
+gap> CloseStream(out);
+gap> s := SHA256State();; UpdateSHA256File(s, gzname, true);;
+gap> HexSHA256(s) = HexSHA256("abcd");
+true
+gap> s := SHA256State();; UpdateSHA256File(s, gzname, false);;
+gap> HexSHA256(s) = HexSHA256File(gzname, false);
+true
+
+# What this is for: a git object is a header followed by a body, and neither
+# has to be brought together in memory to be hashed.
+gap> FileString(name, "hello artifact\n");;
+gap> s := SHA256State();;
+gap> UpdateSHA256(s, "blob 15\000");
+gap> UpdateSHA256File(s, name, false);
+true
+gap> HexSHA256(s);
+"68a5de2c96dafbd696ef65b07482b6acdc0de5b763d5e49006638cab5ae0542f"
+
+# ... which is what 'git hash-object' reports for the same file in a
+# repository created with 'git init --object-format=sha256'.
+
+# argument checking
+gap> UpdateSHA256(fail, "a");
+Error, <state> must be a SHA256 state
+gap> UpdateSHA256(SHA256State(), 42);
+Error, <string> must be a string
+gap> UpdateSHA256File(SHA256State(), name, "yes");
+Error, <decompress> must be 'true' or 'false'
+gap> HexSHA256(42);
+Error, <str> has to be a string, an input stream, or a SHA256 state
 
 #
 gap> STOP_TEST("sha256.tst");


### PR DESCRIPTION
GAP can hash a string, a stream, or a file, but not a *concatenation* of those without building it in memory first. Git object hashes are exactly that shape: `"blob <size>\0"` followed by a file's contents

This PR adds functionality to allow handling that within GAP:
```gap
s := SHA256State();
UpdateSHA256( s, "blob 15\000" );
UpdateSHA256File( s, name, false );
HexSHA256( s );      # = git hash-object, in a --object-format=sha256 repo
```

**Two drive-by fixes**:

- the state bag is allocated `sizeof(UInt4) + sizeof(sha256_state_t)` but addressed from `ADDR_OBJ(result)[1]`, i.e. 4 bytes short. Masked by GASMAN rounding bag sizes up to whole words.
- building the result list allocates, which may move bags, so the state is now taken by value rather than as a pointer into one. On 64-bit a `UInt4` is always an immediate integer, which is why this has never bitten.

*Written with Claude Opus 5 via Claude Code; reviewed by me. The commit lists
the tool as co-author.*
