### PR TITLE
Fix `SimpleGroupsIterator` for start values just below 10^18

### DIFF
--- a/grp/simple.gd
+++ b/grp/simple.gd
@@ -77,9 +77,8 @@ DeclareGlobalFunction("EpimorphismFromClassical");
 ##  <Description>
 ##  This function returns an iterator that will run over all nonabelian simple groups, starting
 ##  at order <A>start</A> if specified, and stopping at order <A>end</A> if specified.
-##  Only orders up to <M>10^{27}</M> are available, and asking for more is an error,
-##  whether through <A>start</A> or by iterating that far.
-##  If the option <A>NOPSL2</A> is given, groups of type
+##  Only orders up to <M>10^{27}</M> are available. Attempting to iterate beyond that
+##  results in an error. If the option <A>NOPSL2</A> is given, groups of type
 ##  <M>PSL_2(q)</M> are omitted.
 ##  <Example><![CDATA[
 ##  gap> it:=SimpleGroupsIterator(20000);

--- a/grp/simple.gd
+++ b/grp/simple.gd
@@ -76,8 +76,10 @@ DeclareGlobalFunction("EpimorphismFromClassical");
 ##
 ##  <Description>
 ##  This function returns an iterator that will run over all nonabelian simple groups, starting
-##  at order <A>start</A> if specified, up to order <M>10^{27}</M> (or -- if specified
-##  -- order <A>end</A>). If the option <A>NOPSL2</A> is given, groups of type
+##  at order <A>start</A> if specified, and stopping at order <A>end</A> if specified.
+##  Only orders up to <M>10^{27}</M> are available, and asking for more is an error,
+##  whether through <A>start</A> or by iterating that far.
+##  If the option <A>NOPSL2</A> is given, groups of type
 ##  <M>PSL_2(q)</M> are omitted.
 ##  <Example><![CDATA[
 ##  gap> it:=SimpleGroupsIterator(20000);

--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -787,6 +787,19 @@ InstallGlobalFunction(SimpleGroupsIterator,function(arg)
   fi;
   nopsl2:=ValueOption("NOPSL2")=true or ValueOption("nopsl2")=true;
 
+  # The non-L2 orders come in two lists, the second loaded on demand.
+  # We do so early, so that a `start' beyond the data is rejected at
+  # once rather than after searching for it.
+  pos:=PositionProperty(SIMPLEGPSNONL2,x->x[1]>=start);
+  if pos=fail then
+    LOADSIMPLE2();
+    pos:=PositionProperty(SIMPLEGPSNONL2,x->x[1]>=start);
+    if pos=fail then
+      Error("simple groups of order > ",SIMPLE_GROUPS_ITERATOR_RANGE,
+        " are not available");
+    fi;
+  fi;
+
   # find relevant L2 order
   a:=RootInt(start,3)-1;
   stack:=fail;
@@ -796,19 +809,6 @@ InstallGlobalFunction(SimpleGroupsIterator,function(arg)
     stack:=a[3];
     a:=a[2];
   until SizeL2Q(b)>=start;
-  # Running off the end of the first list is what says the second one is
-  # needed. Testing `start' against a fixed bound instead left a window between
-  # the largest order in the first list and 10^18 in which nothing was loaded
-  # and `pos' stayed `fail'.
-  pos:=PositionProperty(SIMPLEGPSNONL2,x->x[1]>=start);
-  if pos=fail then
-    LOADSIMPLE2();
-    pos:=PositionProperty(SIMPLEGPSNONL2,x->x[1]>=start);
-    if pos=fail then
-      Error("List of simple groups only available up to order ",
-        SIMPLE_GROUPS_ITERATOR_RANGE);
-    fi;
-  fi;
   return IteratorByFunctions(rec(
     IsDoneIterator:=IsDoneIterator_SimGp,
     NextIterator:=NextIterator_SimGp,

--- a/grp/simple.gi
+++ b/grp/simple.gi
@@ -796,8 +796,19 @@ InstallGlobalFunction(SimpleGroupsIterator,function(arg)
     stack:=a[3];
     a:=a[2];
   until SizeL2Q(b)>=start;
-  if start>=10^18 then LOADSIMPLE2(); fi;
-  pos:=First([1..Length(SIMPLEGPSNONL2)],x->SIMPLEGPSNONL2[x][1]>=start);
+  # Running off the end of the first list is what says the second one is
+  # needed. Testing `start' against a fixed bound instead left a window between
+  # the largest order in the first list and 10^18 in which nothing was loaded
+  # and `pos' stayed `fail'.
+  pos:=PositionProperty(SIMPLEGPSNONL2,x->x[1]>=start);
+  if pos=fail then
+    LOADSIMPLE2();
+    pos:=PositionProperty(SIMPLEGPSNONL2,x->x[1]>=start);
+    if pos=fail then
+      Error("List of simple groups only available up to order ",
+        SIMPLE_GROUPS_ITERATOR_RANGE);
+    fi;
+  fi;
   return IteratorByFunctions(rec(
     IsDoneIterator:=IsDoneIterator_SimGp,
     NextIterator:=NextIterator_SimGp,

--- a/tst/testbugfix/2026-08-15-SimpleGroupsIterator.tst
+++ b/tst/testbugfix/2026-08-15-SimpleGroupsIterator.tst
@@ -1,0 +1,12 @@
+# The orders of the non-PSL(2,q) simple groups come in two lists, the second
+# loaded on demand. `SimpleGroupsIterator' asked for it when `start' reached
+# 10^18, but the first list ends at 911215823217986880; in between nothing was
+# loaded, `pos' stayed `fail', and building the iterator broke on indexing the
+# list with it.
+gap> it := SimpleGroupsIterator(10^18-1, 10^18-1);;
+gap> IsDoneIterator(it);
+true
+gap> it := SimpleGroupsIterator(10^18-1, 11*10^17 : NOPSL2);;
+gap> l := [];; for g in it do Add(l, g); od;
+gap> List(l, Size);
+[ 1053927211015007280 ]

--- a/tst/testbugfix/2026-08-15-SimpleGroupsIterator.tst
+++ b/tst/testbugfix/2026-08-15-SimpleGroupsIterator.tst
@@ -10,3 +10,8 @@ gap> it := SimpleGroupsIterator(10^18-1, 11*10^17 : NOPSL2);;
 gap> l := [];; for g in it do Add(l, g); od;
 gap> List(l, Size);
 [ 1053927211015007280 ]
+
+# An order beyond the data is rejected when the iterator is built, before the
+# search for the PSL(2,q) order to start from.
+gap> SimpleGroupsIterator(10^28, 10^28);
+Error, simple groups of order > 1000000000000000000000000000 are not available


### PR DESCRIPTION
The orders of the non-PSL(2,q) simple groups come in two lists, the second loaded on demand. The iterator asked for it once `start` reached 10^18, but the first list ends already at 911215823217986880, so for a start value between the two nothing was loaded, the search for the first relevant entry returned `fail`, and building the iterator broke on indexing the list with it.

Load the second list when the search comes up empty instead, which is what `NextIterator_SimGp` already does, and report an order beyond the documented range rather than indexing with `fail` -- that case failed the same way above the second list.

Assistance from Claude Code (Claude Opus 5): diagnosis from a stack trace, the fix, and the regression test.