### PR TITLE
Backports to stable-4.16

### DIFF
--- a/lib/ghompcgs.gi
+++ b/lib/ghompcgs.gi
@@ -193,21 +193,21 @@ local pcgs,pcgsimg,r,i,j,k,o,elm,img,exp,sp,mapi;
     od;
   od;
 
-  # we still need to test any additional generators. (This could happen
-  # easily, if the mapping is a general inverse.)
+  # The images of the pcgs need not agree with the images prescribed for the
+  # generators, so test these as well. (Testing only generators with a new
+  # image is not enough: an inconsistent image may coincide with the image of
+  # some other generator.)
   mapi:=MappingGeneratorsImages(map);
   for i in [1..Length(mapi[1])] do
-    if not mapi[2][i] in pcgsimg then
-      exp:=ExponentsOfPcElement(pcgs,mapi[1][i]);
-      img  := o;
-      for k in [1..Length(pcgsimg)] do
-        if exp[k]>0 then
-          img := img * sp[k][exp[k]];
-        fi;
-      od;
-      if img<>mapi[2][i] then
-        return false; # the extra generator would be mapped inconsistently.
+    exp:=ExponentsOfPcElement(pcgs,mapi[1][i]);
+    img  := o;
+    for k in [1..Length(pcgsimg)] do
+      if exp[k]>0 then
+        img := img * sp[k][exp[k]];
       fi;
+    od;
+    if img<>mapi[2][i] then
+      return false; # the generator would be mapped inconsistently.
     fi;
   od;
 
@@ -255,21 +255,21 @@ local pcgs,pcgsimg,r,i,j,k,o,elm,img,exp,sp,C,mapi;
     od;
   od;
 
-  # we still need to test any additional generators. (This could happen
-  # easily, if the mapping is a general inverse.)
+  # The images of the pcgs need not agree with the images prescribed for the
+  # generators, so take these into account as well. (Restricting to
+  # generators with a new image is not enough: a deviating image may coincide
+  # with the image of some other generator.)
   mapi:=MappingGeneratorsImages(map);
   for i in [1..Length(mapi[1])] do
-    if not mapi[2][i] in pcgsimg then
-      exp:=ExponentsOfPcElement(pcgs,mapi[1][i]);
-      img  := o;
-      for k in [1..Length(pcgsimg)] do
-        if exp[k]>0 then
-          img := img * sp[k][exp[k]];
-        fi;
-      od;
-      #NC is safe (init with Triv(range))
-      C:=ClosureSubgroupNC(C,img/mapi[2][i]);
-    fi;
+    exp:=ExponentsOfPcElement(pcgs,mapi[1][i]);
+    img  := o;
+    for k in [1..Length(pcgsimg)] do
+      if exp[k]>0 then
+        img := img * sp[k][exp[k]];
+      fi;
+    od;
+    #NC is safe (init with Triv(range))
+    C:=ClosureSubgroupNC(C,img/mapi[2][i]);
   od;
 
   C:=NormalClosure(ImagesSource(map),C);

--- a/lib/matrix.gi
+++ b/lib/matrix.gi
@@ -254,7 +254,14 @@ InstallMethod( IsLowerTriangularMatrix,
 ##
 InstallMethod( IsSquareMatrix,
     "for a matrix",
-    [ IsMatrixOrMatrixObj ],
+    [ IsMatrix ],
+    function( mat )
+    return IsRectangularTable( mat ) and NrRows( mat ) = NrCols( mat );
+    end );
+
+InstallMethod( IsSquareMatrix,
+    "for a matrix object",
+    [ IsMatrixObj ],
     function( mat )
     return NrRows( mat ) = NrCols( mat );
     end );

--- a/tst/testbugfix/2026-08-18-issue-6514.tst
+++ b/tst/testbugfix/2026-08-18-issue-6514.tst
@@ -1,0 +1,39 @@
+# `IsSingleValued' and `CoKernelOfMultiplicativeGeneralMapping' for a mapping
+# of pc groups skipped any generator whose prescribed image occurred among the
+# images of the pcgs. Inconsistent images were thus accepted, and the
+# resulting mapping silently used the images of the pcgs instead.
+# See https://github.com/gap-system/gap/issues/6514
+gap> G := SmallGroup(4, 2);; p := Pcgs(G);;
+gap> gens := [ p[1], p[2], p[1]*p[2] ];;
+gap> IsSingleValued(GroupGeneralMappingByImagesNC(G, G, gens,
+>      [ p[1], p[1], p[1] ]));
+false
+gap> GroupHomomorphismByImages(G, G, gens, [ p[1], p[1], p[1] ]);
+fail
+gap> Size(CoKernelOfMultiplicativeGeneralMapping(
+>      GroupGeneralMappingByImagesNC(G, G, gens, [ p[1], p[1], p[1] ])));
+2
+
+# a consistent assignment on the same generators is still accepted
+gap> h := GroupHomomorphismByImages(G, G, gens, [ p[1], p[1], One(G) ]);;
+gap> List(gens, x -> Image(h, x)) = [ p[1], p[1], One(G) ];
+true
+gap> Size(CoKernelOfMultiplicativeGeneralMapping(
+>      GroupGeneralMappingByImagesNC(G, G, gens, [ p[1], p[1], One(G) ])));
+1
+
+# the same for a non-abelian source and a proper image
+gap> D := SmallGroup(8, 3);; q := Pcgs(D);;
+gap> C := SmallGroup(4, 2);; c := Pcgs(C);;
+gap> GroupHomomorphismByImages(D, C, [ q[1], q[2], q[1]*q[2] ],
+>      [ One(C), c[1], One(C) ]);
+fail
+
+# `MorClassLoop' filters its candidates with `IsSingleValued', so
+# `AllHomomorphismClasses' returned spurious duplicates. Its generating
+# system is random, hence the repetition.
+gap> H := SmallGroup(144, 88);; Q := SmallGroup(24, 12);;
+gap> Set([1..20], i -> Length(AllHomomorphismClasses(H, Q)));
+[ 17 ]
+gap> Set([1..5], i -> Length(AllHomomorphisms(H, Q)));
+[ 172 ]

--- a/tst/testinstall/matrix.tst
+++ b/tst/testinstall/matrix.tst
@@ -141,6 +141,8 @@ gap> IsSquareMat(NullMat(3, 2));
 false
 gap> IsSquareMat([[1,2,3],[4,5,6]]);
 false
+gap> IsSquareMat([[1,2],[4,5,6]]);
+false
 
 #
 gap> IsSymmetricMat(empty_0x2);


### PR DESCRIPTION
Cherry-picks of PRs labelled `backport-to-4.16`, in merge order:

- #6513 Fix `IsSquareMatrix` to not return `true` for lists-of-lists that are not rectangular (so with rows of different length)
- #6515 Fix `IsSingleValued` and cokernel for mappings of pc groups

Both applied without conflicts; `make check` passes locally.