### PR TITLE
document more features of `DeclareGlobalName`

### DIFF
--- a/doc/ref/create.xml
+++ b/doc/ref/create.xml
@@ -999,6 +999,11 @@ eventually be defined, and that thus no syntax warnings pertaining to its use
 should be printed.
 <P/>
 
+It is allowed to call <Ref Func="DeclareGlobalName"/> several times with
+the same variable name, and it is also no problem to call this function
+after a value has been assigned to the variable.
+<P/>
+
 We recommend using <Ref Func="DeclareGlobalName"/> instead of <Ref
 Func="DeclareGlobalVariable"/> or <Ref Func="DeclareGlobalFunction"/>
 whenever possible.

--- a/tst/testinstall/declarename.tst
+++ b/tst/testinstall/declarename.tst
@@ -1,0 +1,16 @@
+#@local x
+
+#
+gap> START_TEST( "declarename.tst" );
+
+#
+gap> DeclareGlobalName( "x" );
+gap> x;
+Error, Variable: 'x' must have an assigned value
+gap> {} -> x;;  # no syntax warning
+gap> DeclareGlobalName( "x" );  # can be called several times
+gap> x:= 0;;
+gap> DeclareGlobalName( "x" );  # can be called also after the assignment
+
+#
+gap> STOP_TEST( "declarename.tst" );


### PR DESCRIPTION
I want to make sure that I can rely on this behaviour, because it is useful in certain situations when one cannot guarantee that files are read in a particular order.

For example, take a function in some package extension that wants to refer to a variable name that gets defined in a package extension of another package.
It is not guaranteed in which order the two package extensions will be read.
In such a situation, the syntax warning about an unbound variable can be avoided by calling `DeclareGlobalName` for the variable name that belongs to the other package and that will be bound after the two package extensions have been loaded.

If we think that declaring variable names from other packages is bad style then we could recommend that the names of all those package variables that belong to package extensions are declared already "unconditionally" when the package gets loaded, no matter whether also the package extensions get loaded.