### PR TITLE
Fix prompt characters being repainted in the input color

### DIFF
--- a/lib/colorprompt.g
+++ b/lib/colorprompt.g
@@ -30,6 +30,7 @@ fi;
 
 # same behaviour as with unbound functions
 PrintPromptHook := CPROMPT;
+PreInputHook := function() end;
 EndLineHook := function() end;
 
 ############################################################################
@@ -130,7 +131,7 @@ EndLineHook := function() end;
 ##  <#/GAPDoc>
 ##
 BindGlobal( "ColorPrompt", function(arg)
-  local b, r, a;
+  local b, r, a, promptshown;
   b := arg[1];
   r := rec(
          MarkupStdPrompt := "\033[1m\033[34m",
@@ -148,6 +149,7 @@ BindGlobal( "ColorPrompt", function(arg)
 
   if b <> true then
     Unbind(PrintPromptHook);
+    Unbind(PreInputHook);
     Unbind(EndLineHook);
     return;
   fi;
@@ -183,7 +185,17 @@ BindGlobal( "ColorPrompt", function(arg)
     # use this instead of Print such that the column counter for the
     # command line editor is correct
     PRINT_CPROMPT(r.TextPrompt());
-    # another color for input
+    promptshown := true;
+  end;
+  # Another color for input. This is not done in 'PrintPromptHook' because
+  # readline may still redraw parts of the prompt afterwards, which then would
+  # use the input color (see https://github.com/gap-system/gap/issues/5419).
+  promptshown := false;
+  PreInputHook := function()
+    if not promptshown then
+      return;
+    fi;
+    promptshown := false;
     WriteAll(STDOut, "\033[0m");
     if IsString(r.MarkupInput) then
       WriteAll(STDOut, r.MarkupInput);

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -88,6 +88,19 @@
 // If not bound, nothing is done.
 static Obj EndLineHook = 0;
 
+// 'PreInputHook' is a GAP-level variable which can be set to a function to be
+// called once the line editor is ready to accept input. If not bound, nothing
+// is done. 'ColorPrompt' uses it to switch to the color for user input, which
+// must not happen earlier: readline may redraw parts of the prompt when it
+// starts up, and those redraws have to use the prompt color.
+static Obj PreInputHook = 0;
+
+static void CallPreInputHook(void)
+{
+    if (PreInputHook)
+        Call0ArgsInNewReader(PreInputHook);
+}
+
 /****************************************************************************
 **
 *V  syBuf . . . . . . . . . . . . . .  buffer and other info for files, local
@@ -2041,6 +2054,12 @@ static int charreadhook_rl(void)
   return 0;
 }
 
+static int preInputHook_rl(void)
+{
+  CallPreInputHook();
+  return 0;
+}
+
 static void initreadline(void)
 {
 
@@ -2060,6 +2079,8 @@ static void initreadline(void)
   rl_add_defun( "handled-by-GAP", GAP_rl_func, -1 );
 
   rl_bind_keyseq("\\C-x\\C-g", GAP_set_macro);
+
+  rl_pre_input_hook = preInputHook_rl;
 
   // disable bracketed paste mode by default: it interferes with our handling
   // of pastes of data involving REPL prompts "gap>"
@@ -2176,6 +2197,7 @@ static Char * syFgets(Char * line, UInt length, Int fid, UInt block)
     /* no line editing if the user disabled it
        or we can't make it into raw mode */
     if ( SyLineEdit == 0 || ! syBeginEdit(fid) ) {
+        CallPreInputHook();
         p = syFgetsNoEdit(line, length, fid, block );
         return p;
     }
@@ -2195,6 +2217,9 @@ static Char * syFgets(Char * line, UInt length, Int fid, UInt block)
         return line;
     }
 #endif
+
+    // with readline this is done by 'preInputHook_rl'
+    CallPreInputHook();
 
     /* In line editing mode 'length' is not allowed bigger than the
       yank buffer (= length of line buffer for input files).*/
@@ -3285,6 +3310,7 @@ static Int InitKernel(
 #endif
 
     InitCopyGVar("EndLineHook", &EndLineHook);
+    InitCopyGVar("PreInputHook", &PreInputHook);
 
     return 0;
 }


### PR DESCRIPTION
GAP prints the prompt itself and sets `rl_already_prompted`, so readline only records the prompt for redisplay. Its `rl_on_new_line_with_prompt` copies the prompt into `visible_line` and `invisible_line`, but not into the face arrays added in readline 8.1; `update_line` compares faces, too, and thus rewrites the tail of the prompt starting at the first stale face byte. Those characters then appear in the input color, e.g. as a red `>` after a continuation line.

Delay switching to the input color until readline has done its initial redisplay, so that any such rewrite uses the prompt color. This adds a GAP-level hook `PreInputHook`, called once the line editor is ready to accept input, and moves the input color escape sequence there.

Fixes #5419

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>

CC @jengelh 