### PR TITLE
Fix and document argument handling of `Blocks`, `Cycle`, `Permutation` and related functions; `Blocks` and `RepresentativesMinimalBlocks` now reject intransitive actions

### DIFF
--- a/doc/ref/grpoper.xml
+++ b/doc/ref/grpoper.xml
@@ -348,8 +348,9 @@ remains invariant under the action of <M>G</M>.
 For operations concerning block systems, &GAP; assumes that <M>G</M> acts
 transitively on <M>\Omega</M>
 (see <Ref Oper="IsTransitive" Label="for a group, an action domain, etc."/>).
-One may get wrong results or error messages (perhaps at a much later stage)
-if this condition is not satisfied.
+If this condition is not satisfied, an error is signalled for a permutation
+group acting on points; for other actions one may get wrong results or error
+messages, perhaps at a much later stage.
 
 <#Include Label="Blocks">
 <#Include Label="MaximalBlocks">

--- a/lib/ghomperm.gi
+++ b/lib/ghomperm.gi
@@ -1485,15 +1485,23 @@ InstallMethod( ImagesRepresentative,"Constituent homomorphism",
   FamSourceEqFamElm,
         [ IsConstituentHomomorphism, IsMultiplicativeElementWithInverse ], 0,
     function( hom, elm )
-    local   D;
+    local   D,  img;
 
     D := Enumerator( UnderlyingExternalSet( hom ) );
     if Length( D ) = 0  then
         return ();
-    else
-        return PermList( OnTuples( [ 1 .. Length( D ) ],
-                       elm ^ hom!.conperm ) );
     fi;
+    img:= PermList( OnTuples( [ 1 .. Length( D ) ], elm ^ hom!.conperm ) );
+    if img = fail  then
+        # <elm> maps a point of the domain outside of it, so the underlying
+        # group does not act on the domain; report that instead of handing
+        # `fail' on to the caller
+        if ValueOption( "actioncanfail" ) = true  then
+            return fail;
+        fi;
+        Error( "<elm> does not induce a permutation of the action domain" );
+    fi;
+    return img;
 #T problem if the image consists of wrapped permutations!
 end );
 

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -1741,7 +1741,9 @@ OrbitsishOperation( "Transitivity", OrbitsishReq, false, NewAttribute );
 ##  If <A>seed</A> is given, a block system in which <A>seed</A>
 ##  is the subset of one block is computed.
 ##  <P/>
-##  The result is undefined if the action is not transitive.
+##  If the action is not transitive, an error is signalled for a
+##  permutation group acting on points, and the result is undefined
+##  otherwise.
 ##  <Example><![CDATA[
 ##  gap> g:=TransitiveGroup(8,3);
 ##  E(8)=2[x]2[x]2
@@ -1797,7 +1799,9 @@ OrbitishFO( "Blocks",
 ##  If <A>seed</A> is given, a block system is computed in which <A>seed</A>
 ##  is a subset of one block.
 ##  <P/>
-##  The result is undefined if the action is not transitive.
+##  If the action is not transitive, an error is signalled for a
+##  permutation group acting on points, and the result is undefined
+##  otherwise.
 ##  <Example><![CDATA[
 ##  gap> MaximalBlocks(g,[1..8]);
 ##  [ [ 1, 2, 3, 8 ], [ 4 .. 7 ] ]
@@ -1845,7 +1849,9 @@ OrbitishFO( "MaximalBlocks",
 ##  <Ref Oper="IsTransitive" Label="for a group, an action domain, etc."/>)
 ##  action of <A>G</A> on <A>Omega</A>.
 ##  <P/>
-##  The result is undefined if the action is not transitive.
+##  If the action is not transitive, an error is signalled for a
+##  permutation group acting on points, and the result is undefined
+##  otherwise.
 ##  <Example><![CDATA[
 ##  gap> RepresentativesMinimalBlocks(g,[1..8]);
 ##  [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ], [ 1, 6 ], [ 1, 7 ],

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -1744,6 +1744,11 @@ OrbitsishOperation( "Transitivity", OrbitsishReq, false, NewAttribute );
 ##  If the action is not transitive, an error is signalled for a
 ##  permutation group acting on points, and the result is undefined
 ##  otherwise.
+##  For a permutation group and a given <A>seed</A>, verifying transitivity
+##  costs one extra orbit computation;
+##  call <Ref Oper="Blocks" Label="for a group, an action domain, etc."/>
+##  with the option <C>check := false</C> to suppress it if the action is
+##  known to be transitive.
 ##  <Example><![CDATA[
 ##  gap> g:=TransitiveGroup(8,3);
 ##  E(8)=2[x]2[x]2

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -699,11 +699,12 @@ end );
 
 #############################################################################
 ##
-#F  OrbitishFO( <name>, <reqs>, <famrel>, <usetype>, <realenum> )
+#F  OrbitishFO( <name>, <reqs>, <famrel>, <usetype>, <realenum>[, <usage>] )
 ##
 ##  <#GAPDoc Label="OrbitishFO">
 ##  <ManSection>
-##  <Func Name="OrbitishFO" Arg='name, reqs, famrel, usetype, realenum'/>
+##  <Func Name="OrbitishFO"
+##   Arg='name, reqs, famrel, usetype, realenum[, usage]'/>
 ##
 ##  <Description>
 ##  is used to create operations like <Ref Oper="Orbit"/>.
@@ -743,12 +744,29 @@ end );
 ##  should use the enumerator, otherwise it uses the
 ##  <Ref Attr="HomeEnumerator"/> value. This will
 ##  make a difference for external orbits as part of a larger domain.
+##  <P/>
+##  The optional 6th argument <A>usage</A> is the error message that is shown
+##  if the wrapper function is called with arguments it cannot make sense of.
+##  It defaults to a message describing the calling conventions of
+##  <Ref Oper="Orbit"/>, and must be given for operations that deviate from
+##  them, such as <Ref Oper="Blocks"
+##  Label="for a group, an action domain, etc."/>,
+##  whose third argument is an optional list.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-BindGlobal( "OrbitishFO", function( name, reqs, famrel, usetype,realenum )
-local str, orbish, func,isnotest;
+BindGlobal( "OrbitishFO",
+    function( name, reqs, famrel, usetype, realenum, usage... )
+local str, orbish, func, isnotest, usagestr;
+
+    # <pnt> is a single mandatory point unless the caller says otherwise
+    if Length( usage ) = 1 then
+      usagestr:= usage[1];
+    else
+      usagestr:= Concatenation( "usage: ", name, "(<xset>,<pnt>)\n",
+              "or ", name, "(<G>[,<Omega>],<pnt>[,<gens>,<acts>][,<act>])" );
+    fi;
 
     # Create the operation.
     str:= SHALLOW_COPY_OBJ( name );
@@ -760,15 +778,13 @@ local str, orbish, func,isnotest;
 
     # Create the wrapper function.
     func := function( arg )
-    local le, usage, xset, pnt, G, D, gens, acts, act, attrG, result;
+    local le, xset, pnt, G, D, gens, acts, act, attrG, result;
 
       le:= Length( arg );
-      usage:= Concatenation( "usage: ", name, "(<xset>,<pnt>)\n",
-              "or ", name, "(<G>[,<Omega>],<pnt>[,<gens>,<acts>][,<act>])" );
 
       # Get the arguments.
       if le = 0 then
-        Error( usage );
+        Error( usagestr );
       elif le <= 2 and IsExternalSet( arg[ 1 ] )  then
           xset := arg[ 1 ];
           if Length(arg)>1 then
@@ -830,7 +846,13 @@ local str, orbish, func,isnotest;
           acts:= arg[ le ];
         fi;
       else
-        Error( usage );
+        Error( usagestr );
+      fi;
+
+      # <pnt> must be acceptable for the operation, otherwise the call would
+      # end in a `no method found' error further down.
+      if not ( reqs[2]( pnt ) or reqs[3]( pnt ) ) then
+        Error( usagestr );
       fi;
 
       if not IsBound( gens )  then
@@ -1295,7 +1317,9 @@ OrbitishFO( "ExternalSubset",
     [ IsGroup, IsList, IsList,
       IsList,
       IsList,
-      IsFunction ], IsIdenticalObj, true, false );
+      IsFunction ], IsIdenticalObj, true, false,
+    Concatenation( "usage: ExternalSubset(<xset>,<start>)\n",
+      "or ExternalSubset(<G>,<Omega>,<start>[,<gens>,<acts>][,<act>])" ) );
 
 
 #############################################################################
@@ -1741,7 +1765,9 @@ OrbitishFO( "Blocks",
     [ IsGroup, IsList, IsList,
       IsList,
       IsList,
-      IsFunction ], IsIdenticalObj, BlocksAttr, true );
+      IsFunction ], IsIdenticalObj, BlocksAttr, true,
+    Concatenation( "usage: Blocks(<xset>[,<seed>])\n",
+      "or Blocks(<G>,<Omega>[,<seed>][,<gens>,<acts>][,<act>])" ) );
 
 
 #############################################################################
@@ -1790,7 +1816,9 @@ OrbitishFO( "MaximalBlocks",
     [ IsGroup, IsList, IsList,
       IsList,
       IsList,
-      IsFunction ], IsIdenticalObj, MaximalBlocksAttr,true );
+      IsFunction ], IsIdenticalObj, MaximalBlocksAttr, true,
+    Concatenation( "usage: MaximalBlocks(<xset>[,<seed>])\n",
+      "or MaximalBlocks(<G>,<Omega>[,<seed>][,<gens>,<acts>][,<act>])" ) );
 
 #T  the following syntax would be nice for consistency as well:
 ##  RepresentativesMinimalBlocks(<G>,<Omega>[,<seed>][,<gens>,<acts>][,<act>])
@@ -1833,7 +1861,9 @@ OrbitishFO( "RepresentativesMinimalBlocks",
     [ IsGroup, IsList, IsList,
       IsList,
       IsList,
-      IsFunction ], IsIdenticalObj, RepresentativesMinimalBlocksAttr,true );
+      IsFunction ], IsIdenticalObj, RepresentativesMinimalBlocksAttr, true,
+    Concatenation( "usage: RepresentativesMinimalBlocks(<xset>)\n",
+      "or RepresentativesMinimalBlocks(<G>,<Omega>[,<gens>,<acts>][,<act>])" ) );
 
 
 #############################################################################

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -1709,7 +1709,11 @@ OrbitsishOperation( "Transitivity", OrbitsishReq, false, NewAttribute );
 ##  <Ref Oper="IsTransitive" Label="for a group, an action domain, etc."/>)
 ##  action of <A>G</A> on <A>Omega</A>.
 ##  If <A>seed</A> is not given and the action is imprimitive,
-##  a minimal nontrivial block system will be found.
+##  a minimal nontrivial block system will be found,
+##  that is, the blocks are minimal among the blocks with more than one
+##  element.
+##  If the action is primitive, the block system <C>[ <A>Omega</A> ]</C>
+##  consisting of the single block <A>Omega</A> is returned.
 ##  If <A>seed</A> is given, a block system in which <A>seed</A>
 ##  is the subset of one block is computed.
 ##  <P/>
@@ -1721,6 +1725,8 @@ OrbitsishOperation( "Transitivity", OrbitsishReq, false, NewAttribute );
 ##  [ [ 1, 8 ], [ 2, 3 ], [ 4, 5 ], [ 6, 7 ] ]
 ##  gap> Blocks(g,[1..8],[1,4]);
 ##  [ [ 1, 4 ], [ 2, 7 ], [ 3, 6 ], [ 5, 8 ] ]
+##  gap> Blocks(MathieuGroup(11),[1..11]);   # this action is primitive
+##  [ [ 1 .. 11 ] ]
 ##  ]]></Example>
 ##  <P/>
 ##  (See Section&nbsp;<Ref Sect="Basic Actions"/>
@@ -1752,10 +1758,16 @@ OrbitishFO( "Blocks",
 ##   Label="for an external set"/>
 ##
 ##  <Description>
-##  returns a block system that is maximal (i.e., blocks are maximal with
-##  respect to inclusion) for the transitive (see
+##  returns a maximal block system for the transitive (see
 ##  <Ref Oper="IsTransitive" Label="for a group, an action domain, etc."/>)
-##  action of <A>G</A> on <A>Omega</A>.
+##  action of <A>G</A> on <A>Omega</A>,
+##  that is, the blocks are maximal among the blocks that are proper subsets
+##  of <A>Omega</A>.
+##  Equivalently, the action induced by <A>G</A> on the returned block system
+##  is primitive.
+##  If the action of <A>G</A> on <A>Omega</A> is already primitive, then the
+##  block system <C>[ <A>Omega</A> ]</C> consisting of the single block
+##  <A>Omega</A> is returned.
 ##  If <A>seed</A> is given, a block system is computed in which <A>seed</A>
 ##  is a subset of one block.
 ##  <P/>
@@ -1763,6 +1775,10 @@ OrbitishFO( "Blocks",
 ##  <Example><![CDATA[
 ##  gap> MaximalBlocks(g,[1..8]);
 ##  [ [ 1, 2, 3, 8 ], [ 4 .. 7 ] ]
+##  gap> Blocks(g,[1..8]);   # the minimal block system is finer
+##  [ [ 1, 8 ], [ 2, 3 ], [ 4, 5 ], [ 6, 7 ] ]
+##  gap> MaximalBlocks(MathieuGroup(11),[1..11]);   # primitive action
+##  [ [ 1 .. 11 ] ]
 ##  ]]></Example>
 ##  </Description>
 ##  </ManSection>

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -906,9 +906,16 @@ end );
 ##  <Description>
 ##  computes a homomorphism from <A>G</A> into the symmetric group on
 ##  <M>|<A>Omega</A>|</M> points that gives the permutation action of
-##  <A>G</A> on <A>Omega</A>. (In particular, this homomorphism is a
-##  permutation equivalence, that is the permutation image of a group element
-##  is given by the positions of points in <A>Omega</A>.)
+##  <A>G</A> on <A>Omega</A>.
+##  The permutations in the image act on <M>[ 1 .. |<A>Omega</A>| ]</M>,
+##  where the number <M>i</M> stands for the <M>i</M>-th point of
+##  <A>Omega</A>; in other words, the images are taken with respect to the
+##  permutation equivalence between the action of <A>G</A> on <A>Omega</A>
+##  and its image, which is given by numbering the points of <A>Omega</A>
+##  (see the remark on <Ref Oper="PositionCanonical"/> below).
+##  Note that the homomorphism itself need not be injective,
+##  it is injective if and only if <A>G</A> acts faithfully on
+##  <A>Omega</A>.
 ##  <P/>
 ##  The result is undefined if <A>G</A> does not act on <A>Omega</A>.
 ##  <P/>

--- a/lib/oprt.gd
+++ b/lib/oprt.gd
@@ -2140,15 +2140,20 @@ DeclareOperation( "PermutationOp", [ IsObject, IsList, IsFunction ] );
 
 #############################################################################
 ##
-#O  PermutationCycle( <g>, <Omega>, <pnt>[, <act>] )
+#O  PermutationCycle( <g>, <Omega>, <pnt>[, <gens>, <acts>][, <act>] )
 ##
 ##  <#GAPDoc Label="PermutationCycle">
 ##  <ManSection>
-##  <Func Name="PermutationCycle" Arg='g, Omega, pnt[, act]'/>
+##  <Func Name="PermutationCycle" Arg='g, Omega, pnt[, gens, acts][, act]'/>
 ##
 ##  <Description>
 ##  computes the permutation that represents the cycle of <A>pnt</A> under
 ##  the action of the element <A>g</A>.
+##  <P/>
+##  Instead of the domain <A>Omega</A>, an external set <A>xset</A>
+##  may be given; then the action domain is the
+##  <Ref Attr="HomeEnumerator"/> value of <A>xset</A>
+##  (see Section&nbsp;<Ref Sect="External Sets"/>).
 ##  <Example><![CDATA[
 ##  gap> Permutation([[Z(3),-Z(3)],[Z(3),0*Z(3)]],AsList(GF(3)^2));
 ##  (2,7,6)(3,4,8)
@@ -2169,15 +2174,20 @@ DeclareOperation( "PermutationCycleOp",
 
 #############################################################################
 ##
-#O  Cycle( <g>, <Omega>, <pnt> [,<act>] )
+#O  Cycle( <g>, <Omega>, <pnt>[, <gens>, <acts>][, <act>] )
 ##
 ##  <#GAPDoc Label="Cycle">
 ##  <ManSection>
-##  <Func Name="Cycle" Arg='g, Omega, pnt[, act]'/>
+##  <Func Name="Cycle" Arg='g, Omega, pnt[, gens, acts][, act]'/>
 ##
 ##  <Description>
 ##  returns a list of the points in the cycle of <A>pnt</A> under the action
 ##  of the element <A>g</A>.
+##  <P/>
+##  Instead of the domain <A>Omega</A>, an external set <A>xset</A>
+##  may be given; then the action domain is the
+##  <Ref Attr="HomeEnumerator"/> value of <A>xset</A>
+##  (see Section&nbsp;<Ref Sect="External Sets"/>).
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -2189,15 +2199,20 @@ DeclareOperation( "CycleOp", [ IsObject, IsList, IsObject, IsFunction ] );
 
 #############################################################################
 ##
-#O  Cycles( <g>, <Omega> [,<act>] )
+#O  Cycles( <g>, <Omega>[, <gens>, <acts>][, <act>] )
 ##
 ##  <#GAPDoc Label="Cycles">
 ##  <ManSection>
-##  <Func Name="Cycles" Arg='g, Omega[, act]'/>
+##  <Func Name="Cycles" Arg='g, Omega[, gens, acts][, act]'/>
 ##
 ##  <Description>
 ##  returns a list of the cycles (as lists of points) of the action of the
-##  element <A>g</A>.
+##  element <A>g</A> on <A>Omega</A>.
+##  <P/>
+##  Instead of the domain <A>Omega</A>, an external set <A>xset</A>
+##  may be given; then the action domain is the
+##  <Ref Attr="HomeEnumerator"/> value of <A>xset</A>
+##  (see Section&nbsp;<Ref Sect="External Sets"/>).
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -2209,15 +2224,20 @@ DeclareOperation( "CyclesOp", [ IsObject, IsList, IsFunction ] );
 
 #############################################################################
 ##
-#O  CycleLength( <g>, <Omega>, <pnt> [,<act>] )
+#O  CycleLength( <g>, <Omega>, <pnt>[, <gens>, <acts>][, <act>] )
 ##
 ##  <#GAPDoc Label="CycleLength">
 ##  <ManSection>
-##  <Func Name="CycleLength" Arg='g, Omega, pnt[, act]'/>
+##  <Func Name="CycleLength" Arg='g, Omega, pnt[, gens, acts][, act]'/>
 ##
 ##  <Description>
-##  returns the length of the cycle of <A>pnt</A> under the action of the element
-##  <A>g</A>.
+##  returns the length of the cycle of <A>pnt</A> under the action of the
+##  element <A>g</A>.
+##  <P/>
+##  Instead of the domain <A>Omega</A>, an external set <A>xset</A>
+##  may be given; then the action domain is the
+##  <Ref Attr="HomeEnumerator"/> value of <A>xset</A>
+##  (see Section&nbsp;<Ref Sect="External Sets"/>).
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
@@ -2230,15 +2250,20 @@ DeclareOperation( "CycleLengthOp",
 
 #############################################################################
 ##
-#O  CycleLengths( <g>, <Omega>[, <act>] )
+#O  CycleLengths( <g>, <Omega>[, <gens>, <acts>][, <act>] )
 ##
 ##  <#GAPDoc Label="CycleLengths">
 ##  <ManSection>
-##  <Oper Name="CycleLengths" Arg='g, Omega[, act]'/>
+##  <Func Name="CycleLengths" Arg='g, Omega[, gens, acts][, act]'/>
 ##
 ##  <Description>
 ##  returns the lengths of all the cycles under the action of the element
 ##  <A>g</A> on <A>Omega</A>.
+##  <P/>
+##  Instead of the domain <A>Omega</A>, an external set <A>xset</A>
+##  may be given; then the action domain is the
+##  <Ref Attr="HomeEnumerator"/> value of <A>xset</A>
+##  (see Section&nbsp;<Ref Sect="External Sets"/>).
 ##  <Example><![CDATA[
 ##  gap> Cycle((1,2,3)(4,5)(6,7),[4..7],4);
 ##  [ 4, 5 ]
@@ -2261,15 +2286,15 @@ DeclareOperation( "CycleLengthsOp",
 
 #############################################################################
 ##
-#F  CycleIndex( <g>, <Omega>[, <act>] )
-#F  CycleIndex( <G>, <Omega>[, <act>] )
+#F  CycleIndex( <g>[, <Omega>][, <act>] )
+#F  CycleIndex( <G>[, <Omega>][, <act>] )
 ##
 ##  <#GAPDoc Label="CycleIndex">
 ##  <ManSection>
 ##  <Heading>CycleIndex</Heading>
-##  <Func Name="CycleIndex" Arg='g, Omega[, act]'
+##  <Func Name="CycleIndex" Arg='g[, Omega][, act]'
 ##   Label="for a permutation and an action domain"/>
-##  <Func Name="CycleIndex" Arg='G, Omega[, act]'
+##  <Func Name="CycleIndex" Arg='G[, Omega][, act]'
 ##   Label="for a permutation group and an action domain"/>
 ##
 ##  <Description>
@@ -2290,6 +2315,10 @@ DeclareOperation( "CycleLengthsOp",
 ##  <Ref Func="CycleIndex" Label="for a permutation and an action domain"/>
 ##  are the indeterminates <M>1</M> to <M>n</M> over the rationals
 ##  (see&nbsp;<Ref Oper="Indeterminate" Label="for a ring (and a number)"/>).
+##  <P/>
+##  If <A>Omega</A> is omitted then <A>g</A> must be a permutation or a
+##  permutation group, and its <Ref Attr="MovedPoints"
+##  Label="for a permutation"/> value is used as action domain.
 ##  <P/>
 ##  <Example><![CDATA[
 ##  gap> g:=TransitiveGroup(6,8);

--- a/lib/oprt.gi
+++ b/lib/oprt.gi
@@ -2069,6 +2069,11 @@ end );
 InstallGlobalFunction( Permutation, function( arg )
     local   g,  D,  gens,  acts,  act,  xset,  hom;
 
+    # test arguments
+    if Length( arg ) < 2 or Length( arg ) > 5 then
+      Error("usage: Permutation(<g>,<Omega>[,<gens>,<acts>][,<act>])");
+    fi;
+
     # Get the arguments.
     g := arg[ 1 ];
     if Length( arg ) = 2  and  IsExternalSet( arg[ 2 ] )  then
@@ -2165,6 +2170,11 @@ end );
 InstallGlobalFunction( PermutationCycle, function( arg )
     local   g,  D,  pnt,  gens,  acts,  act,  xset,  hom;
 
+    # test arguments
+    if Length( arg ) < 3 or Length( arg ) > 6 then
+      Error("usage: PermutationCycle(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])");
+    fi;
+
     # Get the arguments.
     g := arg[ 1 ];
     if Length( arg ) = 3  and  IsExternalSet( arg[ 2 ] )  then
@@ -2237,6 +2247,11 @@ end );
 InstallGlobalFunction( Cycle, function( arg )
     local   g,  D,  pnt,  gens,  acts,  act,  xset,  hom,  p;
 
+    # test arguments
+    if Length( arg ) < 2 or Length( arg ) > 6 then
+      Error("usage: Cycle(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])");
+    fi;
+
     # Get the arguments.
     g := arg[ 1 ];
     if Length( arg ) = 3  and  IsExternalSet( arg[ 2 ] )  then
@@ -2275,8 +2290,9 @@ InstallGlobalFunction( Cycle, function( arg )
     fi;
 
     if IsBound( gens )  and  not IsIdenticalObj( gens, acts )  then
-        hom := ActionHomomorphismAttr( ExternalOrbitOp
-               ( GroupByGenerators( gens ), D, pnt, gens, acts, act ) );
+        hom := ActionHomomorphismAttr( ExternalSetByFilterConstructor
+                       ( IsExternalSet,
+                         GroupByGenerators( gens ), D, gens, acts, act ) );
         return D{ CycleOp( ImagesRepresentative( hom, g ),
                        PositionCanonical( D, pnt ), OnPoints ) };
     elif IsBound( D )  then
@@ -2325,6 +2341,11 @@ end );
 ##
 InstallGlobalFunction( Cycles, function( arg )
     local   g,  D,  gens,  acts,  act,  xset,  hom;
+
+    # test arguments
+    if Length( arg ) < 2 or Length( arg ) > 5 then
+      Error("usage: Cycles(<g>,<Omega>[,<gens>,<acts>][,<act>])");
+    fi;
 
     # Get the arguments.
     g := arg[ 1 ];
@@ -2533,8 +2554,9 @@ InstallGlobalFunction( CycleLength, function( arg )
     local   g,  D,  pnt,  gens,  acts,  act,  xset,  hom,  p;
 
     # test arguments
-    if Length(arg)<2 or not IsMultiplicativeElementWithInverse(arg[1]) then
-      Error("usage: CycleLength(<g>,<D>,<pnt>[,<act>])");
+    if Length(arg)<2 or Length(arg)>6
+       or not IsMultiplicativeElementWithInverse(arg[1]) then
+      Error("usage: CycleLength(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])");
     fi;
 
     # Get the arguments.
@@ -2568,7 +2590,8 @@ InstallGlobalFunction( CycleLength, function( arg )
         gens := arg[ p + 1 ];
         acts := arg[ p + 2 ];
         if not IsIdenticalObj( gens, acts )  then
-          xset:=ExternalOrbitOp(GroupByGenerators(gens),D,pnt,gens,acts,act);
+          xset:= ExternalSetByFilterConstructor( IsExternalSet,
+                     GroupByGenerators( gens ), D, gens, acts, act );
         fi;
       fi;
     fi;
@@ -2605,8 +2628,9 @@ InstallGlobalFunction( CycleLengths, function( arg )
     local   g,  D,  gens,  acts,  act,  xset,  hom;
 
     # test arguments
-    if Length(arg)<2 or not IsMultiplicativeElementWithInverse(arg[1]) then
-      Error("usage: CycleLengths(<g>,<D>[,<act>])");
+    if Length(arg)<2 or Length(arg)>5
+       or not IsMultiplicativeElementWithInverse(arg[1]) then
+      Error("usage: CycleLengths(<g>,<Omega>[,<gens>,<acts>][,<act>])");
     fi;
 
     # Get the arguments.

--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -151,13 +151,8 @@ InstallMethod( BlocksOp, "permgroup on integers",
         TryNextMethod();
     fi;
 
-    # handle trivial group
-    if Length( acts ) = 0 and Length(D)>1  then
-        Error("<G> must operate transitively on <D>");
-    fi;
-
     # handle trivial domain
-    if Length( D ) = 1  or IsPrimeInt( Length( D ) )  then
+    if Length( D ) <= 1  then
         return Immutable( [ D ] );
     fi;
 
@@ -175,11 +170,19 @@ InstallMethod( BlocksOp, "permgroup on integers",
         od;
     od;
 
-    # check that the group is transitive
+    # check that the group is transitive;
+    # this happens before the shortcut for prime degree below, so that the
+    # answer does not depend on the degree for an intransitive action
     if Length( orbit ) <> Length( D )  then
-        Error("<G> must operate transitively on <D>");
+        Error("<G> must act transitively on <D>");
     fi;
     Info( InfoAction, 4, "BlocksNoSeed transversal computed" );
+
+    # a transitive action of prime degree is primitive
+    if IsPrimeInt( Length( D ) )  then
+        return Immutable( [ D ] );
+    fi;
+
     nrorbs := Length( orbit );
 
     # since $i \in k^{G_1}$ implies $\beta(i)=\beta(k)$,  we initialize <eql>
@@ -437,6 +440,12 @@ InstallMethod( BlocksOp, "integers, with seed", true,
         TryNextMethod();
     fi;
 
+    # check that the group is transitive
+    if Length( D ) > 1
+       and Length( Orbit( G, D, D[1], gens, acts, act ) ) <> Length( D )  then
+        Error("<G> must act transitively on <D>");
+    fi;
+
     nrb := Length(D) - Length(seed) + 1;
 
     # in the beginning each point <d> is in a block by itself
@@ -573,7 +582,7 @@ local   blocks,   # block system of <G>, result
   fi;
 
   # handle trivial domain
-  if Length( D ) = 1  or IsPrime( Length( D ) )  then
+  if Length( D ) <= 1  then
     return Immutable([ D ]);
   fi;
 
@@ -595,11 +604,19 @@ local   blocks,   # block system of <G>, result
     od;
   od;
 
-  # check that the group is transitive
+  # check that the group is transitive;
+  # this happens before the shortcut for prime degree below, so that the
+  # answer does not depend on the degree for an intransitive action
   if Length( orbit ) <> Length( D )  then
     Error( "<G> must act transitively on <D>" );
   fi;
   Info(InfoAction,4,"RepresentativesMinimalBlocks transversal computed");
+
+  # a transitive action of prime degree is primitive
+  if IsPrime( Length( D ) )  then
+    return Immutable([ D ]);
+  fi;
+
   nrorbs := Length( orbit );
 
   # since $i \in k^{G_1}$ implies $\beta(i)=\beta(k)$,  we initialize <eql>

--- a/lib/oprtperm.gi
+++ b/lib/oprtperm.gi
@@ -440,9 +440,13 @@ InstallMethod( BlocksOp, "integers, with seed", true,
         TryNextMethod();
     fi;
 
-    # check that the group is transitive
-    if Length( D ) > 1
-       and Length( Orbit( G, D, D[1], gens, acts, act ) ) <> Length( D )  then
+    # Check that the group is transitive.  Unlike the method without seed,
+    # this method computes no orbit anyway, so the check is not for free;
+    # use the cheapest orbit algorithm available for permutations, and let
+    # `check := false' turn it off.
+    if ValueOption( "check" ) <> false and Length( D ) > 1
+       and ( Length( acts ) = 0
+             or Length( OrbitPerms( acts, D[1] ) ) <> Length( D ) )  then
         Error("<G> must act transitively on <D>");
     fi;
 

--- a/tst/testinstall/action.tst
+++ b/tst/testinstall/action.tst
@@ -22,33 +22,33 @@ Error, RankAction: action must be transitive
 
 #
 gap> Blocks( G, [ 2 .. 5 ] ); # error, good
-Error, <G> must operate transitively on <D>
+Error, <G> must act transitively on <D>
 gap> Blocks( G, [ 1 .. 6 ] ); # error, good
-Error, <G> must operate transitively on <D>
-gap> Blocks( G, [ 1 .. 5 ] );; # works although not transitive
-gap> bl:= Blocks( G, [ 2 .. 6 ] );; # works although no action
-gap> Action( G, bl, OnSets ); # error, good (but late)
-Error, List Element: <list>[1] must have an assigned value
+Error, <G> must act transitively on <D>
+gap> Blocks( G, [ 1 .. 5 ] ); # error, good
+Error, <G> must act transitively on <D>
+gap> Blocks( G, [ 2 .. 6 ] ); # error, good
+Error, <G> must act transitively on <D>
 
 #
 gap> MaximalBlocks( G, [ 2 .. 5 ] ); # error, good
-Error, <G> must operate transitively on <D>
+Error, <G> must act transitively on <D>
 gap> MaximalBlocks( G, [ 1 .. 6 ] ); # error, good
-Error, <G> must operate transitively on <D>
-gap> MaximalBlocks( G, [ 1 .. 5 ] );; # works although not transitive
-gap> bl:= MaximalBlocks( G, [ 2 .. 6 ] );; # works although no action
-gap> Action( G, bl, OnSets ); # error, good (but late)
-Error, List Element: <list>[1] must have an assigned value
+Error, <G> must act transitively on <D>
+gap> MaximalBlocks( G, [ 1 .. 5 ] ); # error, good
+Error, <G> must act transitively on <D>
+gap> MaximalBlocks( G, [ 2 .. 6 ] ); # error, good
+Error, <G> must act transitively on <D>
 
 #
-gap> bl:= RepresentativesMinimalBlocks( G, [ 2 .. 5 ] ); # error, good
+gap> RepresentativesMinimalBlocks( G, [ 2 .. 5 ] ); # error, good
 Error, <G> must act transitively on <D>
-gap> bl:= RepresentativesMinimalBlocks( G, [ 1 .. 6 ] ); # error, good
+gap> RepresentativesMinimalBlocks( G, [ 1 .. 6 ] ); # error, good
 Error, <G> must act transitively on <D>
-gap> RepresentativesMinimalBlocks( G, [ 1 .. 5 ] );; # works although not transitive
-gap> bl:= RepresentativesMinimalBlocks( G, [ 2 .. 6 ] );; # works although no action
-gap> Action( G, bl, OnSets );
-Error, List Element: <list>[1] must have an assigned value
+gap> RepresentativesMinimalBlocks( G, [ 1 .. 5 ] ); # error, good
+Error, <G> must act transitively on <D>
+gap> RepresentativesMinimalBlocks( G, [ 2 .. 6 ] ); # error, good
+Error, <G> must act transitively on <D>
 
 #
 gap> xset:= ExternalSet( G, [ 2 .. 5 ] );; # works although no action

--- a/tst/testinstall/action.tst
+++ b/tst/testinstall/action.tst
@@ -53,9 +53,8 @@ Error, <G> must act transitively on <D>
 #
 gap> xset:= ExternalSet( G, [ 2 .. 5 ] );; # works although no action
 gap> Elements( xset );; # works
-gap> Action( xset );; # error, good (but late)
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `GroupByGenerators' on 2 arguments
+gap> Action( xset ); # error, good
+Error, <elm> does not induce a permutation of the action domain
 
 #
 gap> xset:= ExternalOrbit( G, [ 2 .. 5 ], 2 );; # works although no action
@@ -75,9 +74,10 @@ The 2nd argument is 'fail' which might point to an earlier problem
 
 #
 gap> hom:= ActionHomomorphism( G, [ 2 .. 5 ] );; # works (although no action)
-gap> Image( hom ); # error, good (but late)
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `GroupByGenerators' on 2 arguments
+gap> MappingGeneratorsImages( hom ); # error, good
+Error, <elm> does not induce a permutation of the action domain
+gap> Image( hom ); # error, good
+Error, <elm> does not induce a permutation of the action domain
 
 #
 gap> STOP_TEST( "action.tst" );

--- a/tst/testinstall/opers/cycles.tst
+++ b/tst/testinstall/opers/cycles.tst
@@ -1,0 +1,74 @@
+#@local g, gens, acts, xset
+gap> START_TEST( "cycles.tst" );
+
+# wrong number of arguments must give a usage message, not a kernel error
+gap> Permutation( (1,2,3)(4,5) );
+Error, usage: Permutation(<g>,<Omega>[,<gens>,<acts>][,<act>])
+gap> Permutation( (1,2,3)(4,5), [1..5], [], [], OnPoints, OnPoints );
+Error, usage: Permutation(<g>,<Omega>[,<gens>,<acts>][,<act>])
+gap> PermutationCycle( (1,2,3)(4,5) );
+Error, usage: PermutationCycle(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])
+gap> PermutationCycle( (1,2,3)(4,5), [1..5] );
+Error, usage: PermutationCycle(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])
+gap> Cycle( (1,2,3)(4,5) );
+Error, usage: Cycle(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])
+gap> Cycles( (1,2,3)(4,5) );
+Error, usage: Cycles(<g>,<Omega>[,<gens>,<acts>][,<act>])
+gap> CycleLength( (1,2,3)(4,5) );
+Error, usage: CycleLength(<g>,<Omega>,<pnt>[,<gens>,<acts>][,<act>])
+gap> CycleLengths( (1,2,3)(4,5) );
+Error, usage: CycleLengths(<g>,<Omega>[,<gens>,<acts>][,<act>])
+gap> CycleIndex( [1..5] );
+Error, usage: CycleIndex(<g>,<Omega>[,<act>])
+
+# the documented argument forms still work
+gap> g:= (1,2,3)(4,5)(6,7);;
+gap> Permutation( g, [4..7] );
+(1,2)(3,4)
+gap> PermutationCycle( g, [4..7], 4 );
+(1,2)
+gap> Cycle( g, [4..7], 4 );
+[ 4, 5 ]
+gap> Cycles( g, [4..7] );
+[ [ 4, 5 ], [ 6, 7 ] ]
+gap> CycleLength( g, [4..7], 4 );
+2
+gap> CycleLengths( g, [4..7] );
+[ 2, 2 ]
+gap> CycleIndex( g, [4..7] );
+x_2^2
+gap> CycleIndex( g );
+x_2^2*x_3
+
+# the <gens>, <acts> form
+gap> gens:= [ (1,2,3) ];; acts:= [ (4,5,6) ];;
+gap> Permutation( (1,2,3), [4..6], gens, acts, OnPoints );
+(1,2,3)
+gap> Cycle( (1,2,3), [4..6], 4, gens, acts, OnPoints );
+[ 4, 5, 6 ]
+gap> Cycles( (1,2,3), [4..6], gens, acts, OnPoints );
+[ [ 4, 5, 6 ] ]
+gap> CycleLength( (1,2,3), [4..6], 4, gens, acts, OnPoints );
+3
+gap> CycleLengths( (1,2,3), [4..6], gens, acts, OnPoints );
+[ 3 ]
+gap> PermutationCycle( (1,2,3), [4..6], 4, gens, acts, OnPoints );
+(1,2,3)
+
+# the external set form
+gap> xset:= ExternalSet( Group( (1,2,3)(4,5)(6,7) ), [4..7] );;
+gap> Permutation( g, xset );
+(1,2)(3,4)
+gap> Cycles( g, xset );
+[ [ 4, 5 ], [ 6, 7 ] ]
+gap> Cycle( g, xset, 4 );
+[ 4, 5 ]
+gap> CycleLength( g, xset, 4 );
+2
+gap> CycleLengths( g, xset );
+[ 2, 2 ]
+gap> PermutationCycle( g, xset, 4 );
+(1,2)
+
+#
+gap> STOP_TEST( "cycles.tst" );

--- a/tst/testinstall/oprt.tst
+++ b/tst/testinstall/oprt.tst
@@ -91,5 +91,11 @@ gap> Blocks( V, [1..4] );
 gap> Blocks( V, [1..4], [1,2] );
 [ [ 1, 2 ], [ 3, 4 ] ]
 
+# the transitivity check for a seed can be switched off
+gap> Blocks( Group( (1,2), (3,4,5) ), [1..5], [1,2] );
+Error, <G> must act transitively on <D>
+gap> Blocks( Group( (1,2), (3,4,5) ), [1..5], [1,2] : check := false );
+[ [ 1, 2 ], [ 3 ], [ 4 ], [ 5 ] ]
+
 ##
 gap> STOP_TEST( "oprt.tst" );

--- a/tst/testinstall/oprt.tst
+++ b/tst/testinstall/oprt.tst
@@ -1,4 +1,4 @@
-#@local G,c5,d,eo,es,ess,gens,res
+#@local G,V,c5,d,eo,es,ess,gens,res
 gap> START_TEST("oprt.tst");
 gap> c5:=CyclicGroup(IsPermGroup,5);;
 gap> d:=Combinations([1..5],2);;
@@ -68,6 +68,28 @@ gap> Orbit( G, GF(7), 1 );
 Error, wrong relation between <D> and <pnt>
 gap> Orbit( G, GF(7), 1, OnPoints );
 Error, wrong relation between <D> and <pnt>
+
+# the usage message must describe the operation it belongs to
+gap> V:= Group( (1,2)(3,4), (1,3)(2,4) );;
+gap> Blocks( V );
+Error, usage: Blocks(<xset>[,<seed>])
+or Blocks(<G>,<Omega>[,<seed>][,<gens>,<acts>][,<act>])
+gap> Blocks( V, 1 );
+Error, usage: Blocks(<xset>[,<seed>])
+or Blocks(<G>,<Omega>[,<seed>][,<gens>,<acts>][,<act>])
+gap> MaximalBlocks( V );
+Error, usage: MaximalBlocks(<xset>[,<seed>])
+or MaximalBlocks(<G>,<Omega>[,<seed>][,<gens>,<acts>][,<act>])
+gap> RepresentativesMinimalBlocks( V );
+Error, usage: RepresentativesMinimalBlocks(<xset>)
+or RepresentativesMinimalBlocks(<G>,<Omega>[,<gens>,<acts>][,<act>])
+gap> Orbit( V );
+Error, usage: Orbit(<xset>,<pnt>)
+or Orbit(<G>[,<Omega>],<pnt>[,<gens>,<acts>][,<act>])
+gap> Blocks( V, [1..4] );
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> Blocks( V, [1..4], [1,2] );
+[ [ 1, 2 ], [ 3, 4 ] ]
 
 ##
 gap> STOP_TEST( "oprt.tst" );


### PR DESCRIPTION
- Fixes #3484: `ActionHomomorphism`: "this homomorphism is a permutation equivalence" reads as a claim about the returned map, which is false for unfaithful actions. Name the actual identification of `Omega` with `[1..|Omega|]` instead.
- Fixes #4700: `MaximalBlocks`: "blocks are maximal with respect to inclusion" also describes `[ Omega ]`. Say maximal among the *proper* subsets of `Omega`, i.e. the induced action is primitive, and what happens for a primitive action.
- Fixes #3720: `Permutation`, `PermutationCycle`, `Cycle`, `Cycles` indexed `arg` unguarded, so `Cycles(g)` died with `List Element: <list>[2] must have an assigned value`. Adds usage guards, and documents the `gens, acts` forms, the external set forms, and one argument `CycleIndex`, all previously implemented but undocumented. Also fixes a recursion trap in the `gens, acts` form of `Cycle` and `CycleLength`, which built the action homomorphism from an external orbit rather than an external set.
- Fixes #3541: `OrbitishFO` used one hard coded usage message for every operation it creates; the Blocks family may now pass its own. Also `Blocks(<G>,1)` reports the usage instead of "no method found for `BlocksOp` on 5 arguments".
- Fixes #3364: `BlocksOp` returned `[ Omega ]` for a domain of prime size before checking transitivity, so an intransitive group either errored or returned nonsense depending on the degree. Check first, take the shortcut second; same in `RepresentativesMinimalBlocksOp`; add the check to the seeded `BlocksOp` method, which had none.

Behaviour change: `Blocks` and friends now raise an error in cases where they used to return a meaningless result. The two spellings of that error message now agree ("must act transitively").

Prepared with AI assistance (Claude).