### PR TITLE
Add a discarded const qualifier in SyFopen

### DIFF
--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -647,8 +647,8 @@ Int SyFopen(const Char * name, const Char * mode, BOOL transparent_compress)
     Char                namegz [1024];
     int                 flags = 0;
 
-    Char * terminator = strrchr(name, '.');
-    BOOL   endsgz = terminator && (streq(terminator, ".gz"));
+    const Char * terminator = strrchr(name, '.');
+    BOOL         endsgz = terminator && (streq(terminator, ".gz"));
 
     // handle standard files
     if (streq(name, "*stdin*")) {


### PR DESCRIPTION
Fixes this warning:
```
src/sysfiles.c: In function ‘SyFopen’:
src/sysfiles.c:656:25: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  656 |     Char * terminator = strrchr(name, '.');
      |                         ^~~~~~~
```

## Text for release notes

none

## Further details
