### PR TITLE
Fix `VALIDATE_MARKING` in the Julia GC integration

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -279,16 +279,28 @@ static inline int JMarkTyped(jl_ptls_t ptls, void * obj, jl_datatype_t * ty)
     return jl_gc_mark_queue_obj(ptls, (jl_value_t *)obj);
 }
 
+// Check that `obj` is still allocated and not on a free list already,
+// by verifying that its type is a valid datatype object. A datatype is
+// either a pool object, or lives in a system or package image (e.g. the
+// types of GAP.jl bags after loading it from a precompiled image), as
+// indicated by the `in_image` bit in its header.
+static inline int ValidTypeOfMarkedObj(void * obj)
+{
+    jl_value_t * ty = jl_typeof(obj);
+    // for a freed pool object, `ty` is the freelist link: NULL or a
+    // pointer into a pool page; check before dereferencing it
+    if (ty == NULL)
+        return 0;
+    if (jl_gc_internal_obj_base_ptr(ty) != ty &&
+        !jl_astaggedvalue(ty)->bits.in_image)
+        return 0;
+    return jl_typeis(ty, jl_datatype_type);
+}
+
 static inline int JMark(jl_ptls_t ptls, void * obj)
 {
 #ifdef VALIDATE_MARKING
-    // Validate that `obj` is still allocated and not on a
-    // free list already. We verify this by checking that the
-    // type is a pool object of type `jl_datatype_type`.
-    jl_value_t * ty = jl_typeof(obj);
-    if (jl_gc_internal_obj_base_ptr(ty) != ty)
-        abort();
-    if (!jl_typeis(ty, jl_datatype_type))
+    if (!ValidTypeOfMarkedObj(obj))
         abort();
 #endif
     return jl_gc_mark_queue_obj(ptls, (jl_value_t *)obj);
@@ -299,13 +311,7 @@ void MarkJuliaObjSafe(void * obj, void * ref)
 {
     if (!obj)
         return;
-    // Validate that `obj` is still allocated and not on a
-    // free list already. We verify this by checking that the
-    // type is a pool object of type `jl_datatype_type`.
-    jl_value_t * ty = jl_typeof(obj);
-    if (jl_gc_internal_obj_base_ptr(ty) != ty)
-        return;
-    if (!jl_typeis(ty, jl_datatype_type))
+    if (!ValidTypeOfMarkedObj(obj))
         return;
     if (jl_gc_mark_queue_obj(((MarkData *)ref)->ptls, (jl_value_t *)obj))
         ((MarkData *)ref)->youngRef++;


### PR DESCRIPTION
The `VALIDATE_MARKING` check in `JMark` required the type of a marked object to be a live pool allocation, tested via `jl_gc_internal_obj_base_ptr`. Since GAP.jl became precompilable, its foreign types are restored from a package image and live in image memory, so the first collection aborted (the same held for types of wrapped Julia objects, which mostly live in the system image, and for the corresponding check in `MarkJuliaObjSafe`, which silently skipped marking). Now type objects carrying Julia's `in_image` header bit are accepted as valid.

The second commit adds a CI job to the GAP.jl workflow that builds with `VALIDATE_MARKING`; it depends on the `--validate-marking` flag added to `etc/setup_override_dir.jl` in the companion GAP.jl PR, so this PR should stay in draft until that one is merged.

AI disclosure: diagnosis, patch and testing by Claude Code, reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
