### PR TITLE
Test the Julia GC integration with VALIDATE_MARKING in CI

### DIFF
--- a/.github/workflows/gapjl.yml
+++ b/.github/workflows/gapjl.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - GAP.jl ${{ matrix.gapjl-version }} - ${{ matrix.os }}
+    name: Julia ${{ matrix.julia-version }} - GAP.jl ${{ matrix.gapjl-version }} - ${{ matrix.os }}${{ matrix.validate-marking && ' - VALIDATE_MARKING' || '' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
@@ -33,6 +33,8 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+        validate-marking:
+          - false
         include:
           # Add a few macOS jobs (the number we can run in parallel is limited)
           - gapjl-version: 'latest-release'
@@ -41,6 +43,13 @@ jobs:
           - gapjl-version: 'master'
             julia-version: '1'
             os: macOS-latest
+          # build the Julia GC integration with VALIDATE_MARKING, to detect
+          # invalid references during GC marking
+          # (see https://github.com/oscar-system/GAP.jl/issues/1364)
+          - gapjl-version: 'master'
+            julia-version: '1'
+            os: ubuntu-latest
+            validate-marking: true
 
     steps:
       - name: Checkout GAP
@@ -97,7 +106,7 @@ jobs:
           make -j`nproc`
       - name: "Override bundled GAP"
         run: |
-          julia --project=$GAPJLPATH $GAPJLPATH/etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override --enable-Werror
+          julia --project=$GAPJLPATH $GAPJLPATH/etc/setup_override_dir.jl /tmp/GAPROOT /tmp/gap_jll_override --enable-Werror ${{ matrix.validate-marking && '--validate-marking' || '' }}
       - name: "Run tests"
         run: |
           julia --project=$GAPJLPATH $GAPJLPATH/etc/run_with_override.jl /tmp/gap_jll_override --depwarn=error -e "using Pkg; Pkg.test(\"GAP\")"


### PR DESCRIPTION
Add a job to the GAP.jl workflow that builds the override GAP with `VALIDATE_MARKING` enabled, so regressions in the GC marking code abort the tests instead of going unnoticed.

Stacked on #6523. Also needs the `--validate-marking` flag of `etc/setup_override_dir.jl` from oscar-system/GAP.jl#1420 in GAP.jl master, hence the job pins `gapjl-version` to master; draft until both are merged.

As the last piece of the work requested there:
Fixes https://github.com/oscar-system/GAP.jl/issues/1364

AI disclosure: prepared with the assistance of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
