### PR TITLE
julia-gc: Time collections without going through SyTime

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -23,7 +23,6 @@
 #include "funcs.h"
 #include "gap.h"
 #include "gapstate.h"
-#include "gaptime.h"
 #include "gasman.h"
 #include "objects.h"
 #include "plist.h"
@@ -37,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 #include <unistd.h>
 
 #include <julia.h>
@@ -637,6 +637,20 @@ static void GapTaskScanner(jl_task_t * task, int root_task)
 
 #endif // DISABLE_STACK_SCAN
 
+// Time spent in the process, in milliseconds.
+//
+// SyTime raises a GAP error when the clock cannot be read, which a GC hook
+// must not do: entering the error handler mid-collection runs GAP code. Read
+// the clock directly instead, and report 0 if it is unavailable. The Julia GC
+// is only supported on systems providing getrusage.
+static UInt GCTime(void)
+{
+    struct rusage buf;
+    if (getrusage(RUSAGE_SELF, &buf))
+        return 0;
+    return buf.ru_utime.tv_sec * 1000 + buf.ru_utime.tv_usec / 1000;
+}
+
 // Julia callback
 static void PreGCHook(int full)
 {
@@ -650,7 +664,7 @@ static void PreGCHook(int full)
     if (STATE(CurrLVars))
         CHANGED_BAG(STATE(CurrLVars));
 
-    StartTime = SyTime();
+    StartTime = GCTime();
 
 #ifndef REQUIRE_PRECISE_MARKING
     memset(MarkCache, 0, sizeof(MarkCache));
@@ -666,7 +680,7 @@ static void PostGCHook(int full)
 #ifndef DISABLE_STACK_SCAN
     ScannedRootTask = 0;
 #endif
-    TotalTime += SyTime() - StartTime;
+    TotalTime += GCTime() - StartTime;
 #ifdef COLLECT_MARK_CACHE_STATS
     /* printf("\n>>>Attempts: %ld\nHit rate: %lf\nCollision rate: %lf\n",
       (long) MarkCacheAttempts,


### PR DESCRIPTION
The pre and post GC hooks called SyTime to accumulate GC time. SyTime raises a GAP error when the clock cannot be read, and entering the error handler mid-collection runs GAP code, which the collector must not do.

getrusage cannot realistically fail with these arguments, so this has never fired, but the collector should not depend on that. Read the clock directly and report 0 if it is unavailable. The Julia GC is only built on systems that provide getrusage; a native Windows port would have larger problems than this.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>