### PR TITLE
julia-gc: Exit through jl_exit

### DIFF
--- a/src/system.c
+++ b/src/system.c
@@ -255,9 +255,10 @@ UInt SyWindow;
 void SyExit(UInt ret)
 {
 #ifdef USE_JULIA_GC
-    jl_atexit_hook(ret);
-#endif
+    jl_exit((int)ret);
+#else
     exit((int)ret);
+#endif
 }
 
 


### PR DESCRIPTION
SyExit called jl_atexit_hook and then fell through to exit. jl_exit does both, in the order Julia expects.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>