### PR TITLE
Fix `--with-zlib=PREFIX` being ignored by the `configure` script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -631,7 +631,7 @@ AS_CASE([$with_zlib],
   ],
   [yes],[],
   [*],[
-    ZLIB_SEARCH_PATH="$with_gmp"
+    ZLIB_SEARCH_PATH="$with_zlib"
   ]
 )
 


### PR DESCRIPTION
A copy-paste error from the GMP block made the wildcard branch of `AS_CASE([$with_zlib], ...)` assign `ZLIB_SEARCH_PATH="$with_gmp"`, so a prefix given via `--with-zlib` was silently ignored: configure searched the GMP prefix instead (or the literal string `yes` when `--with-gmp` was not given).

Verified on macOS: `./configure --with-zlib=/opt/homebrew/opt/zlib` previously reported `checking for zlib... yes, at prefix yes` with bogus `-Iyes/include` flags; with the fix it reports `yes, at prefix /opt/homebrew/opt/zlib` and sets the matching `-I`/`-L` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)