### PR TITLE
Fix preimage computation for field homomorphisms

### DIFF
--- a/lib/field.gi
+++ b/lib/field.gi
@@ -1322,7 +1322,7 @@ InstallMethod( PreImagesElm,
     FamRangeEqFamElm,
     [ IsFieldHomomorphism, IsObject ],
     function ( hom, elm )
-    if IsInjective( hom ) = 1 then
+    if IsInjective( hom ) then
       return [ PreImagesRepresentative( hom, elm ) ];
     elif IsZero( elm ) then
       return Source( hom );

--- a/lib/fieldfin.gi
+++ b/lib/fieldfin.gi
@@ -759,6 +759,15 @@ InstallMethod( ImagesRepresentative,
     return elm ^ aut!.power;
     end );
 
+InstallMethod( PreImagesRepresentative,
+    "for Frobenius automorphism and range element",
+    FamRangeEqFamElm,
+    [ IsFrobeniusAutomorphism, IsObject ],
+    function( aut, elm )
+    # the inverse is again a Frobenius automorphism (or the identity)
+    return ImagesRepresentative( InverseGeneralMapping( aut ), elm );
+    end );
+
 InstallMethod( CompositionMapping2,
     "for two Frobenius automorphisms",
     IsIdenticalObj,

--- a/tst/testbugfix/2026-08-28-PreImagesFrobenius.tst
+++ b/tst/testbugfix/2026-08-28-PreImagesFrobenius.tst
@@ -1,0 +1,23 @@
+# `PreImagesElm' for field homomorphisms compared `IsInjective' with 1
+# (a GAP3 leftover), so the injective branch was dead and every nonzero
+# element got the empty preimage. Fixing that exposed that Frobenius
+# automorphisms had no `PreImagesRepresentative' method at all.
+gap> frob := FrobeniusAutomorphism(GF(4));;
+gap> PreImagesRepresentative(frob, Z(4));
+Z(2^2)^2
+gap> ImageElm(frob, PreImagesRepresentative(frob, Z(4))) = Z(4);
+true
+gap> PreImagesElm(frob, Z(4));
+[ Z(2^2)^2 ]
+gap> PreImagesElm(frob, 0*Z(4));
+[ 0*Z(2) ]
+gap> PreImagesSet(frob, GF(4)) = GF(4);
+true
+
+# a proper power of the Frobenius automorphism over a larger field
+gap> aut := FrobeniusAutomorphism(GF(8))^2;;
+gap> x := PreImagesRepresentative(aut, Z(8));;
+gap> ImageElm(aut, x) = Z(8);
+true
+gap> PreImagesElm(aut, Z(8)) = [ x ];
+true


### PR DESCRIPTION
PreImagesElm for field homomorphisms compared IsInjective with 1, a GAP3 leftover: the injective branch was dead, so every nonzero element got the empty preimage, even under bijective maps such as Frobenius automorphisms.

With that branch reachable, PreImagesElm needs PreImagesRepresentative, which had no applicable method for Frobenius automorphisms.  Add one that delegates to ImagesRepresentative of the inverse; the inverse of a Frobenius automorphism is again one (or the identity), so this cannot recurse.

Note for #6409 (renames these operations to NC variants): the fixed comparison then belongs in PreImagesElmNC, and the new method in fieldfin.gi should be installed on PreImagesRepresentativeNC.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

Found while having Claude Fable 5 look into improving PR #6409 (CC @cdwensley); those updates will be pushed soon.