### PR TITLE
Add `RunProcess`, a safer alternative to `Exec`

### DIFF
--- a/doc/ref/process.xml
+++ b/doc/ref/process.xml
@@ -23,6 +23,7 @@
 
 <#Include Label="Process">
 <#Include Label="Exec">
+<#Include Label="RunProcess">
 
 </Section>
 </Chapter>

--- a/lib/helpview.gi
+++ b/lib/helpview.gi
@@ -80,7 +80,9 @@ if ARCH_IS_WINDOWS() then
       winfilename:=MakeExternalFilename( SplitString( filename, "#" )[1] );
     fi;
     Print( "Opening help page ", winfilename, " in default windows browser ... \c" );
-    Exec( Concatenation("start ", winfilename ) );
+    # the empty string is the window title argument of `start`, without
+    # which `start` would mistake the filename for a title
+    RunProcess( "cmd.exe", "/c", "start", "", winfilename );
     Print( "done! \n" );
   end
   );
@@ -138,7 +140,7 @@ elif ARCH_IS_MAC_OS_X() then
             fi;
             file := file.file;
           fi;
-          Exec(Concatenation("open -a Preview ", file));
+          RunProcess("open", "-a", "Preview", file);
           Print("#  see page ", page, " in the Preview window.\n");
         end
     );
@@ -155,7 +157,7 @@ elif ARCH_IS_MAC_OS_X() then
             fi;
             file := file.file;
           fi;
-          Exec(Concatenation("open -a \"Adobe Reader\" ", file));
+          RunProcess("open", "-a", "Adobe Reader", file);
           Print("#  see page ", page, " in the Adobe Reader window.\n");
         end
     );
@@ -172,7 +174,7 @@ elif ARCH_IS_MAC_OS_X() then
             fi;
             file := file.file;
           fi;
-          Exec(Concatenation("open ", file));
+          RunProcess("open", file);
           Print("#  see page ", page, " in the pdf viewer window.\n");
         end
     );
@@ -187,16 +189,17 @@ elif ARCH_IS_MAC_OS_X() then
                 fi;
                 file := file.file;
             fi;
-            Exec( Concatenation(
-                "osascript <<ENDSCRIPT\n",
-                    "tell application \"Skim\"\n",
-                    "activate\n",
-                    "open \"", file, "\"\n",
-                    "set theDoc to document of front window\n",
-                    "go theDoc to page ",String(page)," of theDoc\n",
-                    "end tell\n",
-                "ENDSCRIPT\n" ) );
-            return;
+            RunProcess("osascript", "-", file, page,
+                rec(input := InputTextString("""
+                    on run argv
+                      tell application "Skim"
+                        activate
+                        open (item 1 of argv)
+                        set theDoc to document of front window
+                        go theDoc to page ((item 2 of argv) as integer) of theDoc
+                      end tell
+                    end run
+                """)));
         end
     );
 
@@ -210,7 +213,8 @@ else # UNIX but not macOS
       # Ignoring part of the URL after '#' since we are unable
       # to navigate to the precise location on Windows
       url := SplitString( url, "#" )[1];
-      Exec(Concatenation("explorer.exe \"$(wslpath -a -w \"",url, "\")\""));
+      url := Chomp( RunProcess("wslpath", "-a", "-w", url).output );
+      RunProcess("explorer.exe", url);
     end
     );
 
@@ -226,7 +230,8 @@ else # UNIX but not macOS
             fi;
             file := file.file;
           fi;
-          Exec(Concatenation("explorer.exe \"$(wslpath -a -w \"",file, "\")\""));
+          file := Chomp( RunProcess("wslpath", "-a", "-w", file).output );
+          RunProcess("explorer.exe", file);
           Print("#  see page ", page, " in PDF.\n");
     end
     );
@@ -235,7 +240,7 @@ else # UNIX but not macOS
     HELP_VIEWER_INFO.netscape := rec(
     type := "url",
     show := function(url)
-      Exec(Concatenation("netscape -remote \"openURL(file:", url, ")\""));
+      RunProcess("netscape", "-remote", Concatenation("openURL(file:", url, ")"));
     end
     );
 
@@ -243,7 +248,7 @@ else # UNIX but not macOS
     HELP_VIEWER_INFO.mozilla := rec(
     type := "url",
     show := function(url)
-      Exec(Concatenation("mozilla -remote \"openURL(file:", url, ")\""));
+      RunProcess("mozilla", "-remote", Concatenation("openURL(file:", url, ")"));
     end
     );
 
@@ -272,11 +277,14 @@ else # UNIX but not macOS
     );
   fi;
 
+  # The following viewers are interactive, so they are given GAP's terminal,
+  # which they used to inherit implicitly via `Exec`.
+
   # html version with lynx
   HELP_VIEWER_INFO.lynx := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("lynx \"", url, "\""));
+    RunProcess("lynx", url, rec(input := InputTextUser(), output := OutputTextUser()));
   end
   );
 
@@ -284,28 +292,28 @@ else # UNIX but not macOS
   HELP_VIEWER_INFO.w3m := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("w3m \"", url, "\""));
+    RunProcess("w3m", url, rec(input := InputTextUser(), output := OutputTextUser()));
   end
   );
 
   HELP_VIEWER_INFO.elinks := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("elinks \"", url, "\""));
+    RunProcess("elinks", url, rec(input := InputTextUser(), output := OutputTextUser()));
   end
   );
 
   HELP_VIEWER_INFO.links2ng := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("links2 \"", url, "\""));
+    RunProcess("links2", url, rec(input := InputTextUser(), output := OutputTextUser()));
   end
   );
 
   HELP_VIEWER_INFO.links2 := rec(
   type := "url",
   show := function(url)
-    Exec(Concatenation("links2 -g \"", url, "\""));
+    RunProcess("links2", "-g", url, rec(input := InputTextUser(), output := OutputTextUser()));
   end
   );
 fi;

--- a/lib/process.gd
+++ b/lib/process.gd
@@ -176,6 +176,12 @@ DeclareOperation( "Process",
 ##  gap> Exec( "rm foo" );
 ##  ]]></Log>
 ##  <P/>
+##  Because <A>cmd</A> is interpreted by a shell, it is difficult to pass
+##  arguments containing spaces or quotes reliably, and the exit code of the
+##  command is not available.
+##  For new code <Ref Func="RunProcess"/> is therefore usually the better
+##  choice.
+##  <P/>
 ##  <Ref Func="Exec"/> calls the more general operation <Ref Oper="Process"/>.
 ##  The function <Ref Func="Edit"/> should be used to call an editor from
 ##  within &GAP;.
@@ -184,3 +190,93 @@ DeclareOperation( "Process",
 ##  <#/GAPDoc>
 ##
 DeclareGlobalFunction( "Exec" );
+
+
+
+#############################################################################
+##
+#F  RunProcess( <cmd>[, <arg1>, ...][, <options>] ) . . . . . run a program
+##
+##  <#GAPDoc Label="RunProcess">
+##  <ManSection>
+##  <Func Name="RunProcess" Arg='cmd[, arg1, ..., argN][, options]'/>
+##
+##  <Description>
+##  <Ref Func="RunProcess"/> runs the program <A>cmd</A> with the arguments
+##  <A>arg1</A>, ..., <A>argN</A>, waits for it to terminate, and returns a
+##  record describing the outcome.
+##  <P/>
+##  If <A>cmd</A> contains no path separator, it is looked up with
+##  <Ref Func="PathSystemProgram"/>, that is, the first executable file of
+##  that name in one of the directories returned by
+##  <Ref Func="DirectoriesSystemPrograms"/> is used;
+##  otherwise <A>cmd</A> is used as a path as-is, resolved relative to &GAP;'s
+##  current directory rather than to the <C>directory</C> option below.
+##  Each argument must be a string or an integer, the latter being converted
+##  via <Ref Attr="String"/>.
+##  <P/>
+##  No shell is involved: the arguments are handed to the program verbatim.
+##  There is thus no need to quote or escape arguments containing spaces or
+##  other special characters, and the behaviour does not depend on which
+##  shell happens to be installed.
+##  The flip side is that shell features are not available, so unlike
+##  <Ref Func="Exec"/> one cannot use redirections such as
+##  <C>&gt;/dev/null</C>, pipes, or wildcard expansion.
+##  <P/>
+##  The returned record always has the component <C>status</C>: the exit code
+##  of the program, or <K>fail</K> if it could not be executed at all.
+##  A nonzero exit code is not treated as an error by
+##  <Ref Func="RunProcess"/>; it is up to the caller to check it.
+##  Note that <Ref Oper="Process"/>, and hence <Ref Func="RunProcess"/>, reports
+##  <K>fail</K> also for a program that exits with the code 255, and thus
+##  cannot tell the two apart.
+##  <P/>
+##  <Log><![CDATA[
+##  gap> res := RunProcess("echo", "GAP is great!");
+##  rec( output := "GAP is great!\n", status := 0 )
+##  gap> RunProcess("false").status;
+##  1
+##  ]]></Log>
+##  <P/>
+##  The optional final argument <A>options</A> is a record which may have the
+##  following components.
+##  <List>
+##  <Mark><C>directory</C></Mark>
+##  <Item>
+##    the directory in which the program is run, as a directory object
+##    (see&nbsp;<Ref Sect="Directories"/>);
+##    it defaults to <Ref Func="DirectoryCurrent"/>.
+##  </Item>
+##  <Mark><C>input</C></Mark>
+##  <Item>
+##    an input stream serving as the standard input of the program.
+##    By default the program receives no input at all; note that this differs
+##    from <Ref Func="Exec"/>, which passes on whatever the user types.
+##  </Item>
+##  <Mark><C>output</C></Mark>
+##  <Item>
+##    an output stream receiving the standard output of the program.
+##    By default the output is captured and returned in the <C>output</C>
+##    component of the result record; if this option is given, the result
+##    record has no <C>output</C> component.
+##  </Item>
+##  </List>
+##  <P/>
+##  <Log><![CDATA[
+##  gap> input := InputTextString("hello\n");;
+##  gap> RunProcess("sort", rec(input := input, output := OutputTextUser()));
+##  hello
+##  rec( status := 0 )
+##  ]]></Log>
+##  <P/>
+##  The standard error stream of the program is currently inherited from
+##  &GAP; and cannot be redirected or captured, since &GAP; has no support
+##  for this yet.
+##  <P/>
+##  <Ref Func="RunProcess"/> calls the more general operation
+##  <Ref Oper="Process"/>.
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareGlobalFunction( "RunProcess" );

--- a/lib/process.gi
+++ b/lib/process.gi
@@ -261,3 +261,106 @@ InstallGlobalFunction( Exec, function( arg )
     Process( dir, shell, InputTextUser(), OutputTextUser(), [ cs, cmd ] );
 
 end );
+
+
+#############################################################################
+##
+#F  RunProcess( <cmd>[, <arg1>, ...][, <options>] ) . . . . . run a program
+##
+# The keys accepted in the options record of RunProcess. Rejecting anything
+# else keeps the door open for adding e.g. `error` once GAP can capture the
+# standard error stream of a child process (see issue #4657).
+BindGlobal( "RUN_PROCESS_OPTIONS", MakeImmutable( [ "directory", "input", "output" ] ) );
+
+InstallGlobalFunction( RunProcess, function( arg )
+    local opts, key, cmd, args, a, dir, input, output, result;
+
+    # an options record, if given at all, must be the final argument
+    if not IsEmpty(arg) and IsRecord(Last(arg)) then
+        opts := Remove(arg);
+    else
+        opts := rec();
+    fi;
+
+    for key in RecNames(opts) do
+        if not key in RUN_PROCESS_OPTIONS then
+            Error("unsupported option '", key, "'");
+        fi;
+    od;
+
+    if IsEmpty(arg) then
+        Error("must specify a command to execute");
+    fi;
+
+    cmd := arg[1];
+    if not IsString(cmd) then
+        Error("<cmd> must be a string");
+    fi;
+    # guard against the empty name, for which PathSystemProgram would happily
+    # return a directory
+    if IsEmpty(cmd) then
+        Error("<cmd> must not be empty");
+    fi;
+
+    # arguments are passed to the command verbatim; no shell ever sees them,
+    # so there is nothing to quote or escape here
+    args := [];
+    for a in arg{[ 2 .. Length(arg) ]} do
+        if IsInt(a) then
+            a := String(a);
+        elif IsString(a) then
+            a := ShallowCopy(a);
+            ConvertToStringRep(a);
+        else
+            Error("arguments must be strings or integers");
+        fi;
+        Add(args, a);
+    od;
+
+    # resolve the command name via the system PATH, unless it already is a path
+    if not '/' in cmd and not (ARCH_IS_WINDOWS() and '\\' in cmd) then
+        a := PathSystemProgram( cmd );
+        if a = fail and ARCH_IS_WINDOWS() then
+            a := PathSystemProgram( Concatenation( cmd, ".exe" ) );
+        fi;
+        if a = fail then
+            Error("could not locate executable for '", cmd, "'");
+        fi;
+        cmd := a;
+    fi;
+
+    dir := DirectoryCurrent();
+    if IsBound(opts.directory) then
+        dir := opts.directory;
+        if not IsDirectory(dir) then
+            Error("<options>.directory must be a directory object");
+        fi;
+    fi;
+
+    # unlike Exec, pass no input at all unless the caller asks for it
+    input := InputTextNone();
+    if IsBound(opts.input) then
+        input := opts.input;
+        if not IsInputStream(input) then
+            Error("<options>.input must be an input stream");
+        fi;
+    fi;
+
+    result := rec();
+
+    # unlike Exec, capture the output instead of printing it, unless the
+    # caller provides a stream of their own
+    if IsBound(opts.output) then
+        output := opts.output;
+        if not IsOutputStream(output) then
+            Error("<options>.output must be an output stream");
+        fi;
+    else
+        result.output := "";
+        output := OutputTextString(result.output, false);
+    fi;
+
+    result.status := Process( dir, cmd, input, output, args );
+
+    return result;
+end );

--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1308,19 +1308,21 @@ InstallGlobalFunction( InputFromUser,
 InstallGlobalFunction( OpenExternal, function(filename)
     local file;
     if ARCH_IS_MAC_OS_X() then
-      Exec(Concatenation("open \"",filename,"\""));
+      RunProcess("open", filename);
     elif ARCH_IS_WINDOWS() then
-      Exec(Concatenation("cmd /c start \"",filename,"\""));
+      # the empty string is the window title argument of `start`, without
+      # which `start` would mistake the filename for a title
+      RunProcess("cmd.exe", "/c", "start", "", filename);
     elif ARCH_IS_WSL() then
       # If users pass a URL, make sure if does not get mangled.
       if ForAny(["https://", "http://"], {pre} -> StartsWith(filename, pre)) then
         file := filename;
       else
-        file := Concatenation("$(wslpath -a -w \"",filename,"\")");
+        file := Chomp( RunProcess("wslpath", "-a", "-w", filename).output );
       fi;
-      Exec(Concatenation("explorer.exe \"", file, "\""));
+      RunProcess("explorer.exe", file);
     else
-      Exec(Concatenation("xdg-open \"",filename,"\""));
+      RunProcess("xdg-open", filename);
     fi;
 end );
 

--- a/tst/testinstall/process.tst
+++ b/tst/testinstall/process.tst
@@ -1,0 +1,76 @@
+#############################################################################
+##
+##  Tests for RunProcess
+##
+gap> START_TEST("process.tst");
+
+#@if ARCH_IS_UNIX()
+
+# the exit code is reported rather than raised as an error
+gap> RunProcess("true").status;
+0
+gap> RunProcess("false").status = 0;
+false
+
+# output is captured by default
+gap> RunProcess("echo", "GAP is great!");
+rec( output := "GAP is great!\n", status := 0 )
+
+# arguments are passed verbatim; no shell sees them, so spaces and quotes
+# need no escaping
+gap> RunProcess("printf", "[%s]", "a b", "c'd", "e*f").output;
+"[a b][c'd][e*f]"
+
+# integers are accepted and converted
+gap> RunProcess("printf", "[%s]", 42, -7).output;
+"[42][-7]"
+
+# an absolute path is used as-is
+gap> RunProcess("/bin/echo", "hi").output;
+"hi\n"
+
+# input defaults to nothing at all
+gap> RunProcess("cat").output;
+""
+gap> RunProcess("cat", rec(input := InputTextString("meow\n"))).output;
+"meow\n"
+
+# with an explicit output stream, the result has no output component
+gap> out := "";; RunProcess("echo", "hi", rec(output := OutputTextString(out, false)));
+rec( status := 0 )
+gap> out;
+"hi\n"
+
+# the working directory can be chosen
+gap> dir := DirectoryTemporary();;
+gap> PrintTo(Filename(dir, "marker"), "");
+gap> RunProcess("ls", rec(directory := dir)).output;
+"marker\n"
+
+# error cases
+gap> RunProcess();
+Error, must specify a command to execute
+gap> RunProcess(rec(directory := DirectoryCurrent()));
+Error, must specify a command to execute
+gap> RunProcess("echo", rec(colour := "blue"));
+Error, unsupported option 'colour'
+gap> RunProcess("this-program-does-not-exist");
+Error, could not locate executable for 'this-program-does-not-exist'
+gap> RunProcess("echo", [1, 2]);
+Error, arguments must be strings or integers
+gap> RunProcess("echo", rec(input := 1));
+Error, <options>.input must be an input stream
+gap> RunProcess("echo", rec(output := 1));
+Error, <options>.output must be an output stream
+gap> RunProcess("echo", rec(directory := "/tmp"));
+Error, <options>.directory must be a directory object
+gap> RunProcess("");
+Error, <cmd> must not be empty
+
+# a record in a non-final position is treated as an argument, and rejected
+gap> RunProcess("echo", rec(), "x");
+Error, arguments must be strings or integers
+#@fi
+
+#
+gap> STOP_TEST("process.tst");


### PR DESCRIPTION
Grew out of #5103, and hence closes #5103.

`Exec` hands its concatenated arguments to a shell. That makes it hard to pass arguments containing spaces or quotes, ties the behaviour to whichever shell happens to be installed, discards the exit code, and wires the child process to the user's terminal.

`RunProcess` takes the program and its arguments as separate strings and runs it directly:

```gap
RunProcess( cmd[, arg1, ..., argN][, options] )  ->  rec( status[, output] )
```
For example:
```gap-repl
gap> RunProcess("echo", "GAP is great!");
rec( output := "GAP is great!\n", status := 0 )
gap> RunProcess("false").status;
1
```

- Nothing needs quoting or escaping, and no shell is involved.
- The exit code is returned rather than thrown away; a nonzero code is not an error, it is up to the caller to check.
- Output is captured by default instead of being printed.
- Input defaults to nothing at all, rather than to whatever the user types.

The price is that shell features such as redirections and wildcard expansion are gone, so `Exec` stays; its documentation now points here for new code.

### What changed since #5103

The draft let the working directory and the streams appear as positional arguments in any order. Following the discussion there (@ChrisJefferson, @wilfwilson), everything beyond the command line now goes into an optional **trailing options record** with the keys `directory`, `input` and `output`:

```gap
RunProcess("sort", rec(input := someStream, output := OutputTextUser()));
```

Unknown keys are rejected rather than ignored. That is the point of the record: GAP currently cannot capture a child process's standard error at all (#4657), and this leaves room to add an `error` key later without breaking any caller — and without older GAP versions silently dropping it.

The name is the other thing #5103 stalled on. `RunProcess` sits next to the existing `Process` operation, reads as a verb, and matches Mathematica's `RunProcess` and Python's `subprocess.run`.

Arguments must be strings or integers; anything else is an error. Deliberately not `String`-ing arbitrary objects, as that would close off future extensions.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>