### PR TITLE
Fixes for LLP64 systems (i.e. Windows 64bit)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,9 @@ CHECK_COMPILER_BUILTIN([__builtin_mul_overflow],[0,0,&x]);
 CHECK_COMPILER_BUILTIN([__builtin_clz],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzl],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_clzll],[0]);
+CHECK_COMPILER_BUILTIN([__builtin_popcount],[0]);
 CHECK_COMPILER_BUILTIN([__builtin_popcountl],[0]);
+CHECK_COMPILER_BUILTIN([__builtin_popcountll],[0]);
 
 dnl determine sizeof of some standard types, so that the GAP headers
 dnl can pick the correct builtins among those we just tested

--- a/src/blister.c
+++ b/src/blister.c
@@ -840,8 +840,14 @@ void ConvBlist (
 */
 UInt COUNT_TRUES_BLOCK(UInt block)
 {
-#if USE_POPCNT && defined(HAVE___BUILTIN_POPCOUNTL)
+// pick the __builtin_popcount* variant matching UInt in size; in
+// particular 'unsigned long' is only 32 bit on LLP64 systems (Windows)
+#if USE_POPCNT && SIZEOF_VOID_P == SIZEOF_INT && defined(HAVE___BUILTIN_POPCOUNT)
+    return __builtin_popcount(block);
+#elif USE_POPCNT && SIZEOF_VOID_P == SIZEOF_LONG && defined(HAVE___BUILTIN_POPCOUNTL)
     return __builtin_popcountl(block);
+#elif USE_POPCNT && SIZEOF_VOID_P == SIZEOF_LONG_LONG && defined(HAVE___BUILTIN_POPCOUNTLL)
+    return __builtin_popcountll(block);
 #else
 #ifdef SYS_IS_64_BIT
     block =

--- a/src/integer.c
+++ b/src/integer.c
@@ -86,6 +86,7 @@
 #ifndef WARD_ENABLED
 
 #include <gmp.h>
+#include <limits.h>
 
 #if GMP_NAIL_BITS != 0
 #error Aborting compile: GAP does not support non-zero GMP nail size
@@ -2119,10 +2120,17 @@ Obj GcdInt ( Obj opL, Obj opR )
     if (sizeR != 1) {
       SWAP(Obj, opL, opR);
     }
+    // Use mpn_gcd_1, which takes the small operand as an mp_limb_t; the
+    // seemingly more natural mpz_gcd_ui takes an 'unsigned long', which
+    // cannot hold a full limb on LLP64 systems (native Windows)
     UInt r = AbsOfSmallInt(opR);
-    FAKEMPZ_GMPorINTOBJ(mpzL, opL);
-    r = mpz_gcd_ui(0, MPZ_FAKEMPZ(mpzL), r);
-    CHECK_FAKEMPZ(mpzL);
+    if (IS_INTOBJ(opL)) {
+        UInt l = AbsOfSmallInt(opL);
+        r = mpn_gcd_1((mp_srcptr)&l, 1, r);
+    }
+    else {
+        r = mpn_gcd_1((mp_srcptr)CONST_ADDR_INT(opL), SIZE_INT(opL), r);
+    }
     return ObjInt_UInt(r);
   }
 
@@ -2223,6 +2231,11 @@ static Obj FuncFACTORIAL_INT(Obj self, Obj n)
 {
     RequireNonnegativeSmallInt(SELF_NAME, n);
 
+    // mpz_fac_ui takes an 'unsigned long', which is smaller than a small
+    // integer on LLP64 systems (native Windows)
+    if ((UInt)INT_INTOBJ(n) > ULONG_MAX)
+        ErrorMayQuit("Factorial: <n> is too large", 0, 0);
+
     mpz_t mpzResult;
     mpz_init(mpzResult);
     mpz_fac_ui(mpzResult, INT_INTOBJ(n));
@@ -2296,10 +2309,17 @@ Obj BinomialInt(Obj n, Obj k)
         return Fail;
 
     UInt K = IS_INTOBJ(k) ? INT_INTOBJ(k) : VAL_LIMB0(k);
+
+    // mpz_bin_ui and mpz_bin_uiui take K and N as 'unsigned long', which
+    // cannot hold a full limb on LLP64 systems (native Windows)
+    if (K > ULONG_MAX)
+        return Fail;
+
     mpz_t mpzResult;
     mpz_init( mpzResult );
 
-    if (SIZE_INT_OR_INTOBJ(n) == 1) {
+    if (SIZE_INT_OR_INTOBJ(n) == 1 &&
+        (IS_INTOBJ(n) ? (UInt)INT_INTOBJ(n) : VAL_LIMB0(n)) <= ULONG_MAX) {
         UInt N = IS_INTOBJ(n) ? INT_INTOBJ(n) : VAL_LIMB0(n);
         mpz_bin_uiui(mpzResult, N, K);
     } else {

--- a/src/system.c
+++ b/src/system.c
@@ -573,9 +573,9 @@ static void InitSysOpts(void)
 #endif // defined(SYS_IS_64_BIT)
 
 #ifdef SYS_IS_64_BIT
-    SyAllocPool = 4096L*1024*1024;   // Note this is in bytes!
+    SyAllocPool = (UInt)4096*1024*1024;   // Note this is in bytes!
 #else
-    SyAllocPool = 1536L*1024*1024;   // Note this is in bytes!
+    SyAllocPool = (UInt)1536*1024*1024;   // Note this is in bytes!
 #endif // defined(SYS_IS_64_BIT)
     SyStorOverrun = SY_STOR_OVERRUN_CLEAR;
     SyStorKill = 0;


### PR DESCRIPTION
This contains three commits which fix various issues on LLP64 systems (where `sizeof(long)==4` yet `sizeof(void*)==8`).

- **blist**: `COUNT_TRUES_BLOCK` used `__builtin_popcountl`, ignoring bits >= 32 of every block. Every filter with flag number above 32 looked empty, derailing the type system during library bootstrap -- the unexplained breakage in #6077. Now selects the popcount builtin matching `UInt`, like `CLog2UInt` does for clz.
- **integer**: GMP's `mpz_*_ui` take `unsigned long`. `GcdInt(<large>, 2^50)` computed `Gcd(x, 0) = 0`, sending rational arithmetic into an infinite loop (a hang in `ctblmoli.tst`). `GcdInt` now uses `mpn_gcd_1`; `FACTORIAL_INT` errors and `BINOMIAL_INT` returns `fail` above `ULONG_MAX`.
- **system**: `4096L*1024*1024` overflows a 32-bit `long`; compute the default pool sizes in `UInt`.

These are part of a port of GAP to MingW Claude Fable 5 wrote for me (see also issue #4157), but they are clearly of independent use, and therefore in a PR of their own.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>