### PR TITLE
Portability cleanups: no compiler warning if there is no dlopen; no GAP warning if UNIXSelect is missing

### DIFF
--- a/lib/streams.gi
+++ b/lib/streams.gi
@@ -1463,6 +1463,9 @@ end);
 ##
 #M  ReadAllLine( <iostream>[, <nofail>][, <IsAllLine>] ) . .  read whole line
 ##
+# this method serves pty based iostreams, which only exist on systems that
+# also have UNIXSelect
+if IsBound( UNIXSelect ) then
 InstallMethod( ReadAllLine, "iostream,boolean,function",
         [ IsInputOutputStreamByPtyRep and IsInputOutputStream, IsBool, IsFunction ],
     function(iostream, nofail, IsAllLine)
@@ -1484,6 +1487,7 @@ InstallMethod( ReadAllLine, "iostream,boolean,function",
     fi;
     return line;
 end);
+fi;
 
 InstallMethod( ReadAllLine, "iostream,boolean,function",
         [ IsInputOutputStream, IsBool, IsFunction ],

--- a/src/modules.c
+++ b/src/modules.c
@@ -903,9 +903,9 @@ void LoadModules(void)
             }
             else {
                 // and dynamic case
+#ifdef HAVE_DLOPEN
                 InitInfoFunc init;
 
-#ifdef HAVE_DLOPEN
                 const char * res = SyLoadModule(buf, &init);
                 if (init == 0) {
                     Panic("failed to load dynamic module %s, %s\n", buf, res);


### PR DESCRIPTION
Some more portability tweaks that were created as part of the new MingW port (see issue #4157).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>