### PR TITLE
Add parse-only REPL input completeness check

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -2477,21 +2477,23 @@ static void RecreateStackNams(ReaderState * rs, Obj context)
 
 /****************************************************************************
 **
-*F  ReadEvalCommand() . . . . . . . . . . . . . . . . . . .  read one command
+*F  ReadEvalCommandInternal() . . . . . . read one command, evaluate or check
 **
-**  'ReadEvalCommand' reads one command and interprets it immediately.
+**  Shared implementation of 'ReadEvalCommand' and 'ReadCheckCommand'.
 **
-**  It does not expect the first symbol of its input already read and won't
-**  read the first symbol of the next input.
-**
-**  If 'dualSemicolon' is a non-zero pointer, then the integer it points to
-**  will be set to 1 if the command was followed by a double semicolon, else
-**  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
+**  If 'checkOnly' is set, the command is parsed but not executed: the
+**  interpreter is switched into ignoring mode for the duration, so no
+**  statement has any effect, and 'IntrEnd' is skipped. If 'syntaxErrors' is
+**  non-zero, it must be a plist; diagnostics are then appended to it as
+**  records instead of being printed (see 'ScannerState.errors').
 */
-ExecStatus ReadEvalCommand(Obj            context,
-                           TypInputFile * input,
-                           Obj *          evalResult,
-                           BOOL *         dualSemicolon)
+static ExecStatus ReadEvalCommandInternal(Obj            context,
+                                          TypInputFile * input,
+                                          BOOL           checkOnly,
+                                          Obj            syntaxErrors,
+                                          Obj *          evalResult,
+                                          BOOL *         dualSemicolon,
+                                          BOOL *         errorAtEOF)
 {
     volatile ExecStatus status;
     volatile Obj        tilde;
@@ -2507,6 +2509,7 @@ ExecStatus ReadEvalCommand(Obj            context,
 
     GAP_ASSERT(input);
     rs->s.input = input;
+    rs->s.errors = syntaxErrors;
 
     ClearError();
 
@@ -2516,6 +2519,8 @@ ExecStatus ReadEvalCommand(Obj            context,
     // if scanning the first symbol produced a syntax error, abort
     if (rs->s.NrError) {
         FlushRestOfInputLine(input);
+        if (errorAtEOF)
+            *errorAtEOF = rs->s.firstErrorAtEOF;
         return STATUS_ERROR;
     }
 
@@ -2539,8 +2544,9 @@ ExecStatus ReadEvalCommand(Obj            context,
     lockSP = RegionLockSP();
 #endif
 
-    AssGVar(GVarName("READEVALCOMMAND_LINENUMBER"),
-            INTOBJ_INT(GetInputLineNumber(input)));
+    if (!checkOnly)
+        AssGVar(GVarName("READEVALCOMMAND_LINENUMBER"),
+                INTOBJ_INT(GetInputLineNumber(input)));
 
     // remember the old execution state and start an execution environment
     Bag oldLVars =
@@ -2553,6 +2559,12 @@ ExecStatus ReadEvalCommand(Obj            context,
 
     IntrBegin(&rs->intr);
     rs->intr.gapnameid = GetInputFilenameID(input);
+
+    // in check mode, parse with the interpreter ignoring everything; every
+    // interpreter action keeps 'ignoring' balanced when it is already
+    // positive, so nothing is executed and nothing is left on the stack
+    if (checkOnly)
+        rs->intr.ignoring = 1;
 
     switch (rs->s.Symbol) {
     // read an expression or an assignment or a procedure call
@@ -2588,8 +2600,13 @@ ExecStatus ReadEvalCommand(Obj            context,
     if (dualSemicolon)
         *dualSemicolon = (rs->s.Symbol == S_DUALSEMICOLON);
 
-    // end the interpreter
-    status = IntrEnd(&rs->intr, rs->s.NrError > 0, evalResult);
+    // end the interpreter; in check mode 'IntrEnd' must be skipped (nothing
+    // was interpreted, so there is no result on the stack), the status is
+    // derived from the error count alone
+    if (checkOnly)
+        status = rs->s.NrError > 0 ? STATUS_ERROR : STATUS_END;
+    else
+        status = IntrEnd(&rs->intr, rs->s.NrError > 0, evalResult);
 
     // restore the execution environment
     SWITCH_TO_OLD_LVARS(oldLVars);
@@ -2611,8 +2628,57 @@ ExecStatus ReadEvalCommand(Obj            context,
 
     ClearError();
 
+    if (errorAtEOF)
+        *errorAtEOF = rs->s.firstErrorAtEOF;
+
     // return whether a return-statement or a quit-statement were executed
     return status;
+}
+
+
+/****************************************************************************
+**
+*F  ReadEvalCommand() . . . . . . . . . . . . . . . . . . .  read one command
+**
+**  'ReadEvalCommand' reads one command and interprets it immediately.
+**
+**  It does not expect the first symbol of its input already read and won't
+**  read the first symbol of the next input.
+**
+**  If 'dualSemicolon' is a non-zero pointer, then the integer it points to
+**  will be set to 1 if the command was followed by a double semicolon, else
+**  it is set to 0. If 'dualSemicolon' is zero then it is ignored.
+*/
+ExecStatus ReadEvalCommand(Obj            context,
+                           TypInputFile * input,
+                           Obj *          evalResult,
+                           BOOL *         dualSemicolon)
+{
+    return ReadEvalCommandInternal(context, input, FALSE, 0, evalResult,
+                                   dualSemicolon, 0);
+}
+
+
+/****************************************************************************
+**
+*F  ReadCheckCommand()  . . . . . . . parse one command, but do not execute it
+**
+**  'ReadCheckCommand' parses one command from <input> without executing any
+**  of it and without printing anything. It returns 'STATUS_END' if a
+**  complete command was parsed, 'STATUS_EOF' if the input was exhausted
+**  before the first symbol of a command, and 'STATUS_ERROR' on a syntax
+**  error.
+**
+**  Diagnostics are appended to <syntaxErrors> (a plist) if it is non-zero.
+**  On 'STATUS_ERROR', if <errorAtEOF> is non-zero, the value it points to is
+**  set to TRUE iff the first syntax error was caused by the input ending,
+**  i.e., the input is a truncated prefix of potentially valid input.
+*/
+ExecStatus
+ReadCheckCommand(TypInputFile * input, Obj syntaxErrors, BOOL * errorAtEOF)
+{
+    return ReadEvalCommandInternal(0, input, TRUE, syntaxErrors, 0, 0,
+                                   errorAtEOF);
 }
 
 /****************************************************************************

--- a/src/read.h
+++ b/src/read.h
@@ -42,6 +42,25 @@ ExecStatus ReadEvalCommand(Obj            context,
 
 /****************************************************************************
 **
+*F  ReadCheckCommand()  . . . . . . . parse one command, but do not execute it
+**
+**  'ReadCheckCommand' parses one command from <input> without executing any
+**  of it and without printing anything. It returns 'STATUS_END' if a
+**  complete command was parsed, 'STATUS_EOF' if the input was exhausted
+**  before the first symbol of a command, and 'STATUS_ERROR' on a syntax
+**  error.
+**
+**  Diagnostics are appended to <syntaxErrors> (a plist) if it is non-zero.
+**  On 'STATUS_ERROR', if <errorAtEOF> is non-zero, the value it points to is
+**  set to TRUE iff the first syntax error was caused by the input ending,
+**  i.e., the input is a truncated prefix of potentially valid input.
+*/
+ExecStatus
+ReadCheckCommand(TypInputFile * input, Obj syntaxErrors, BOOL * errorAtEOF);
+
+
+/****************************************************************************
+**
 *F  ReadEvalFile()  . . . . . . . . . . . . . . . . . . . . . . . read a file
 **
 **  'ReadEvalFile' reads an entire file and returns (in 'evalResult') the

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -16,12 +16,15 @@
 
 #include "scanner.h"
 
+#include "bool.h"
 #include "error.h"
 #include "gapstate.h"
 #include "gaputils.h"
 #include "io.h"
 #include "lists.h"
 #include "plist.h"
+#include "precord.h"
+#include "records.h"
 #include "stringobj.h"
 #include "sysstr.h"
 
@@ -29,6 +32,35 @@
 static UInt NextSymbol(ScannerState * s);
 
 #define GET_NEXT_CHAR() GetNextChar(s->input)
+
+/****************************************************************************
+**
+*F  NewSyntaxErrorRecord( <msg> ) . . . build a record describing a diagnostic
+**
+**  Build a record describing a syntax error or warning, for collection into
+**  'ScannerState.errors'. The positions are those the caret printer in
+**  'SyntaxErrorOrWarning' uses.
+*/
+static Obj NewSyntaxErrorRecord(ScannerState * s,
+                                const Char *   msg,
+                                UInt           error,
+                                Int            tokenoffset)
+{
+    Int pos = (tokenoffset == 0) ? GetInputLinePosition(s->input)
+                                 : s->SymbolStartPos[tokenoffset - 1];
+
+    Obj record = NEW_PREC(6);
+    AssPRec(record, RNamName("message"), MakeImmString(msg));
+    AssPRec(record, RNamName("isError"), error ? True : False);
+    AssPRec(record, RNamName("line"),
+            INTOBJ_INT(s->SymbolStartLine[tokenoffset]));
+    AssPRec(record, RNamName("pos"), INTOBJ_INT(s->SymbolStartPos[tokenoffset]));
+    AssPRec(record, RNamName("endLine"),
+            INTOBJ_INT(GetInputLineNumber(s->input)));
+    AssPRec(record, RNamName("endPos"), INTOBJ_INT(pos));
+    return record;
+}
+
 
 /****************************************************************************
 **
@@ -43,8 +75,22 @@ static void SyntaxErrorOrWarning(ScannerState * s,
                                  Int            tokenoffset)
 {
     GAP_ASSERT(tokenoffset >= 0 && tokenoffset <= 2);
+
+    // classify the first error: is the input merely truncated, i.e., could
+    // appending more text still produce valid input?
+    if (error && s->NrError == 0)
+        s->firstErrorAtEOF = (s->Symbol == S_EOF) || s->pendingEOFError;
+    s->pendingEOFError = FALSE;
+
+    // if diagnostics are being collected, record instead of printing; honour
+    // the same one-message-per-line gate as the printing branch below
+    if (s->errors) {
+        if (s->input->lastErrorLine != s->input->number)
+            PushPlist(s->errors,
+                      NewSyntaxErrorRecord(s, msg, error, tokenoffset));
+    }
     // do not print a message if we found one already on the current line
-    if (s->input->lastErrorLine != s->input->number) {
+    else if (s->input->lastErrorLine != s->input->number) {
 
         // open error output
         TypOutputFile output = { 0 };
@@ -475,10 +521,13 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
         seenADigit = TRUE;
         c = GET_NEXT_CHAR();
     }
-    if (!seenADigit)
+    if (!seenADigit) {
+        if (c == '\377')
+            s->pendingEOFError = TRUE;
         SyntaxError(s,
                     "Badly formed number: need a digit before or after the "
                     "decimal point");
+    }
     if (c == '\\')
         SyntaxError(s, "Badly formed number");
 
@@ -495,9 +544,12 @@ static UInt GetNumber(ScannerState * s, Int readDecimalPoint, Char c)
 
         // Here we are into the unsigned exponent of a number in scientific
         // notation, so we just read digits
-        if (!IsDigit(c))
+        if (!IsDigit(c)) {
+            if (c == '\377')
+                s->pendingEOFError = TRUE;
             SyntaxError(s, "Badly formed number: need at least one digit in "
                            "the exponent");
+        }
         while (IsDigit(c)) {
             i = AddCharToValue(s, i, c);
             c = GET_NEXT_CHAR();
@@ -561,8 +613,11 @@ static inline Char GetOctalDigits(ScannerState * s, Char c)
     Char result;
     result = 8 * (c - '0');
     c = GET_NEXT_CHAR();
-    if ( c < '0' || c > '7' )
+    if ( c < '0' || c > '7' ) {
+        if (c == '\377')
+            s->pendingEOFError = TRUE;
         SyntaxError(s, "Expecting octal digit");
+    }
     result = result + (c - '0');
 
     return result;
@@ -578,6 +633,8 @@ static inline Char CharHexDigit(ScannerState * s)
 {
     Char c = GET_NEXT_CHAR();
     if (!isxdigit((unsigned int)c)) {
+        if (c == '\377')
+            s->pendingEOFError = TRUE;
         SyntaxError(s, "Expecting hexadecimal digit");
     }
     if (c >= 'a') {
@@ -622,6 +679,8 @@ static Char GetEscapedChar(ScannerState * s)
     } else if (c >= '0' && c <= '7') {
         result += GetOctalDigits(s, c);
     } else {
+        if (c == '\377')
+            s->pendingEOFError = TRUE;
         SyntaxError(s, "Expecting hexadecimal escape, or two more octal digits");
     }
   } else if ( c >= '1' && c <= '7' ) {
@@ -683,6 +742,7 @@ static Char GetStr(ScannerState * s, Char c)
 
     if (c == '\377') {
         FlushRestOfInputLine(s->input);
+        s->pendingEOFError = TRUE;
         SyntaxError(s, "String must end with \" before end of file");
     }
 
@@ -759,6 +819,7 @@ static Char GetTripStr(ScannerState * s, Char c)
 
     if (c == '\377') {
         FlushRestOfInputLine(s->input);
+        s->pendingEOFError = TRUE;
         SyntaxError(s, "String must end with \"\"\" before end of file");
     }
 
@@ -835,6 +896,8 @@ static void GetChar(ScannerState * s)
     if ( c == '\'' ) {
       c = GET_NEXT_CHAR();
     } else {
+      if (c == '\377')
+        s->pendingEOFError = TRUE;
       SyntaxError(s, "Missing single quote in character constant");
     }
   }

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -234,6 +234,20 @@ typedef struct {
     // error occurred.
     UInt NrError;
 
+    // If non-zero, this is a plist: syntax errors and warnings are appended
+    // to it as records instead of being printed to ERROR_OUTPUT.
+    Obj errors;
+
+    // One-shot flag set by token getters immediately before raising a
+    // SyntaxError caused by hitting end of input inside a token (e.g. an
+    // unterminated string). Consumed and reset by 'SyntaxErrorOrWarning'.
+    BOOL pendingEOFError;
+
+    // Set when the first syntax error is raised: TRUE iff that error was
+    // caused by end of input, i.e., the input is a truncated prefix of
+    // potentially valid input. Never reset afterwards.
+    BOOL firstErrorAtEOF;
+
 } ScannerState;
 
 

--- a/src/streams.c
+++ b/src/streams.c
@@ -224,6 +224,80 @@ static Obj FuncREAD_ALL_COMMANDS(
 }
 
 
+/****************************************************************************
+**
+*F  FuncCHECK_ALL_COMMANDS( <self>, <instream> )  . . . . classify some input
+**
+**  FuncCHECK_ALL_COMMANDS parses all statements from the stream <instream>
+**  without executing anything and without printing anything, and classifies
+**  the input. It returns a record with these components:
+**
+**  - 'status' is one of "complete" (the input consists of zero or more
+**    complete statements), "incomplete" (the input ends in the middle of a
+**    statement, i.e., it is a truncated prefix of potentially valid input,
+**    and a frontend should request more input), or "error" (the input
+**    contains a syntax error before its end).
+**
+**  - 'statements' is the number of complete statements parsed before the
+**    end of the input or the first erroneous statement.
+**
+**  - 'errors' is a list of records describing the diagnostics raised for
+**    the first erroneous statement, each with components 'message',
+**    'isError', 'line', 'pos', 'endLine' and 'endPos'.
+**
+**  This is the primitive alternative frontends (Jupyter kernels, REPLs with
+**  multi-line editing) need to decide whether input is ready for evaluation.
+**
+**  The classification is best-effort: a genuine syntax error whose first
+**  diagnostic coincides with the end of the input is reported as
+**  "incomplete"; it surfaces as an error once the completed input is
+**  evaluated.
+*/
+static Obj FuncCHECK_ALL_COMMANDS(Obj self, Obj instream)
+{
+    RequireInputStream(SELF_NAME, instream);
+
+    TypInputFile input;
+    if (!OpenInputStream(&input, instream, FALSE)) {
+        return Fail;
+    }
+
+    Obj                    errors = NEW_PLIST(T_PLIST, 0);
+    volatile UInt          nrStatements = 0;
+    const Char * volatile  status = "complete";
+    BOOL                   rethrow = FALSE;
+
+    GAP_TRY
+    {
+        while (1) {
+            BOOL       errorAtEOF = FALSE;
+            ExecStatus st = ReadCheckCommand(&input, errors, &errorAtEOF);
+            if (st == STATUS_EOF)
+                break;
+            if (st == STATUS_ERROR) {
+                status = errorAtEOF ? "incomplete" : "error";
+                break;
+            }
+            nrStatements++;
+        }
+    }
+    GAP_CATCH
+    {
+        rethrow = TRUE;
+    }
+
+    CloseInput(&input);
+    if (rethrow)
+        GAP_THROW();
+
+    Obj result = NEW_PREC(3);
+    AssPRec(result, RNamName("status"), MakeImmString(status));
+    AssPRec(result, RNamName("statements"), INTOBJ_INT(nrStatements));
+    AssPRec(result, RNamName("errors"), errors);
+    return result;
+}
+
+
 /*
  Returns a list with one or two entries. The first
  entry is set to "false" if there was any error
@@ -1747,6 +1821,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC_1ARGS(READ, input),
     GVAR_FUNC_4ARGS(
         READ_ALL_COMMANDS, instream, echo, capture, resultCallback),
+    GVAR_FUNC_1ARGS(CHECK_ALL_COMMANDS, instream),
     GVAR_FUNC_2ARGS(READ_COMMAND_REAL, stream, echo),
     GVAR_FUNC_3ARGS(READ_STREAM_LOOP, stream, catchstderrout, context),
     GVAR_FUNC_1ARGS(READ_AS_FUNC, input),

--- a/tst/testinstall/checkinput.tst
+++ b/tst/testinstall/checkinput.tst
@@ -1,0 +1,147 @@
+#@local check, count, e, sideEffect
+#
+# Test CHECK_ALL_COMMANDS, the parse-only input completeness check: it
+# classifies input as "complete", "incomplete" (truncated prefix of
+# potentially valid input; a frontend should request more input) or "error",
+# without executing or printing anything.
+#
+gap> START_TEST("checkinput.tst");
+gap> check := s -> CHECK_ALL_COMMANDS(InputTextString(s)).status;;
+gap> count := s -> CHECK_ALL_COMMANDS(InputTextString(s)).statements;;
+
+# complete inputs
+gap> check("1+1;");
+"complete"
+gap> check("1+1;;");
+"complete"
+gap> check("1+1; 2+2;");
+"complete"
+gap> check("");
+"complete"
+gap> check("# comment only\n");
+"complete"
+gap> check("# comment only");
+"complete"
+gap> check("1+1; # trailing comment");
+"complete"
+gap> check("f := function(x) return x; end;;");
+"complete"
+gap> check("if true then fi;");
+"complete"
+gap> check("x := 'a';");
+"complete"
+gap> check("s := \"\"\"a\"\"\";");
+"complete"
+gap> count("1+1; 2+2;");
+2
+gap> count("# comment only");
+0
+
+# quit, QUIT, help and pragmas parse as complete statements, and like
+# everything else they are not executed by the check
+gap> check("quit;");
+"complete"
+gap> check("QUIT;");
+"complete"
+gap> check("?some help topic");
+"complete"
+gap> check("#%some pragma\n");
+"complete"
+gap> check("while true do od;");
+"complete"
+
+# nothing is executed and nothing is printed
+gap> sideEffect := 0;;
+gap> check("sideEffect := 1;");
+"complete"
+gap> sideEffect;
+0
+gap> check("Print(999);");
+"complete"
+
+# incomplete inputs: open constructs
+gap> check("1+");
+"incomplete"
+gap> check("1+1");
+"incomplete"
+gap> check("quit");
+"incomplete"
+gap> check("if 2 >");
+"incomplete"
+gap> check("if 2 > 1 then");
+"incomplete"
+gap> check("while true do");
+"incomplete"
+gap> check("for i in [1..3] do");
+"incomplete"
+gap> check("repeat");
+"incomplete"
+gap> check("f := function(x)");
+"incomplete"
+gap> check("f := x ->");
+"incomplete"
+gap> check("x := [1, 2");
+"incomplete"
+gap> check("r := rec(a := 1,");
+"incomplete"
+
+# incomplete inputs: end of input hit inside a token
+gap> check("s := \"abc");
+"incomplete"
+gap> check("s := \"\"\"abc\nline2");
+"incomplete"
+gap> check("x := 'a");
+"incomplete"
+gap> check("1.5e");
+"incomplete"
+gap> check("1+1;\\");
+"incomplete"
+
+# a complete statement followed by an open construct is incomplete; the
+# statement count reports how many statements already parsed completely
+gap> check("1+1; if 2 >");
+"incomplete"
+gap> count("1+1; if 2 >");
+1
+
+# genuine syntax errors, including ones followed by valid statements
+gap> check("1+;");
+"error"
+gap> check("1+; 2+2;");
+"error"
+gap> check("if then fi;");
+"error"
+gap> check("fi;");
+"error"
+gap> check("od;");
+"error"
+gap> check("f(;");
+"error"
+gap> check("x := \"abc\ndef\";");
+"error"
+gap> check("1+1;\n1+;");
+"error"
+gap> count("1+1;\n1+;");
+1
+
+# diagnostics are returned as records instead of being printed
+gap> e := CHECK_ALL_COMMANDS(InputTextString("1+;")).errors[1];;
+gap> [ e.message, e.isError, e.line, e.pos ];
+[ "expression expected", true, 1, 2 ]
+gap> e := CHECK_ALL_COMMANDS(InputTextString("1+1;\n1+;")).errors[1];;
+gap> [ e.message, e.line ];
+[ "expression expected", 2 ]
+gap> CHECK_ALL_COMMANDS(InputTextString("if 2 >")).errors[1].message;
+"expression expected"
+gap> CHECK_ALL_COMMANDS(InputTextString("s := \"abc")).errors[1].message;
+"String must end with \" before end of file"
+gap> CHECK_ALL_COMMANDS(InputTextString("1+1;")).errors;
+[  ]
+
+# the argument must be an input stream
+gap> CHECK_ALL_COMMANDS(fail);
+Error, CHECK_ALL_COMMANDS: <instream> must be an input stream (not the value '\
+fail')
+
+#
+gap> STOP_TEST("checkinput.tst");


### PR DESCRIPTION
Adds `CHECK_ALL_COMMANDS(instream)`: parse input without executing or printing anything, and classify it as `"complete"`, `"incomplete"` (truncated prefix of valid input) or `"error"`. Diagnostics are returned as records with message and caret positions instead of being printed.

This is the primitive alternative frontends need for multi-line editing: a Julia REPL "GAP mode" via GAP.jl, or a Jupyter kernel's `is_complete_request`, can ask on every Enter whether the buffer is ready to evaluate, instead of submitting half-typed input.

Implementation: the reader runs with the interpreter in ignoring mode (cf. the experiment in #4130, but no asserts are relaxed; `IntrEnd` is skipped in check mode, so nothing runs, not even `quit;` or `?help`). The scanner records whether the first syntax error was caused by the input ending; only then is input "incomplete", so a typo inside an open construct still reports "error" and cannot trap the user in an editor that never submits.

Planned follow-ups: a structured chunk evaluator (per-statement results, captured output and error text, no break loop) and libgap wrappers `GAP_CheckInput` / `GAP_EvalStringEx`.

Written with Claude Code (Claude Fable 5).