### PR TITLE
Represent extensions on cosets of a module hyperplane

### DIFF
--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -1277,6 +1277,81 @@ local e,one,m,r,a,c,is,i;
   return false;
 end );
 
+#############################################################################
+##
+##  Permutation degree still considered manageable when representing a group
+##  extension on the cosets of a module hyperplane.
+##
+BindGlobal("EXTENSION_COSET_ENUMERATION_MAXDEG",10^5);
+
+#############################################################################
+##
+#F  ModuleCoreOfSubspace( <module>, <bas> )
+##
+##  Basis of the largest submodule of <module> contained in the subspace
+##  spanned by <bas>, that is of the intersection of the images of this
+##  subspace under the group. Intersecting with the images under the module
+##  generators repeatedly reaches this intersection.
+##
+BindGlobal("ModuleCoreOfSubspace",function(module,bas)
+local old,gen;
+  while not IsEmpty(bas) do
+    old:=Length(bas);
+    for gen in module.generators do
+      bas:=SumIntersectionMat(bas,bas*gen)[2];
+      if IsEmpty(bas) then
+        return bas;
+      fi;
+    od;
+    if Length(bas)=old then
+      return bas;
+    fi;
+  od;
+  return bas;
+end);
+
+#############################################################################
+##
+#F  SubmoduleFreeSubspace( <module> )
+##
+##  Basis of a subspace of <module> that contains no nonzero submodule and is
+##  maximal with this property under greedy extension. In an extension of a
+##  group by <module> the corresponding subgroup has trivial core -- a normal
+##  subgroup contained in it lies in the module and thus is a submodule -- so
+##  the extension acts faithfully on its cosets. For an irreducible module
+##  this gives a hyperplane, and thus degree |G| times the field size.
+##
+BindGlobal("SubmoduleFreeSubspace",function(module)
+local bas,extend,v,bad;
+
+  extend:=function(v)
+  local new;
+    new:=Concatenation(bas,[v]);
+    if RankMat(new)>Length(bas)
+       and IsEmpty(ModuleCoreOfSubspace(module,new)) then
+      bas:=new;
+      return true;
+    fi;
+    return false;
+  end;
+
+  bas:=[];
+  for v in IdentityMat(module.dimension,module.field) do
+    extend(v);
+  od;
+
+  # a basis adapted to the module structure can do better than the standard
+  # one; random vectors are a cheap substitute
+  bad:=0;
+  while Length(bas)<module.dimension-1 and bad<module.dimension do
+    if not extend(Random(module.field^module.dimension)) then
+      bad:=bad+1;
+    fi;
+  od;
+
+  return bas;
+end);
+
 BindGlobal("WreathElm",function(b,l,m)
 local n,ran,r,d,p,i,j;
   n:=Length(l);
@@ -1440,7 +1515,7 @@ end);
 InstallGlobalFunction(FpGroupCocycle,function(arg)
 local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
       it,hom,trysy,prime,mindeg,fps,ei,mgens,mwrd,nn,newfree,mfpi,mmats,sub,
-      tab,tab0,evalprod,gensmrep,invsmrep,zerob,simi,simiq,#wasbold,
+      tab,tab0,evalprod,gensmrep,invsmrep,zerob,simi,simiq,bas,deg,#wasbold,
       #step,
       mon,ord,mn,melmvec,killgens,frew,fffam,ofgens,rws,formalinverse;
 
@@ -1680,6 +1755,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
   fi;
 
   if Length(arg)>2 and arg[3]=true then
+    new:=fail;
     if IsZero(z) and MTX.IsIrreducible(r.module) then
       # make SDP directly
       m:=PermrepSemidirectModule(r.group,r.module:cheap);
@@ -1688,6 +1764,44 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
       new:=GroupHomomorphismByImages(fp,p,GeneratorsOfGroup(fp),
         Concatenation(m.ggens,m.basis));
     else
+      # The extension acts faithfully on the cosets of a subspace of the
+      # module that contains no nonzero submodule, and enumerating them
+      # costs far less than the quotient lifting below. Every codimension
+      # of that subspace multiplies the degree by <prime> though, and the
+      # degree reduction afterwards then eats up the gain -- so insist on a
+      # hyperplane, as an irreducible module provides. (A one-dimensional
+      # module has none, its cosets are those of the trivial subgroup.)
+      bas:=SubmoduleFreeSubspace(r.module);
+      deg:=Size(r.group)*prime;
+      if Length(bas)>0 and Length(bas)=dim-1
+        and deg<=EXTENSION_COSET_ENUMERATION_MAXDEG then
+        Info(InfoExtReps,2,"Enumerate ",deg," cosets of module subspace");
+        tab:=CosetTableFromGensAndRels(gens,RelatorsOfFpGroup(fp),
+          List(bas,x->LinearCombinationPcgs(gens{[n+1..n+dim]},x)):
+          silent:=true,max:=Maximum(20*deg,CosetTableDefaultLimit));
+        if tab<>fail then
+          p:=Group(List(tab{[1,3..Length(tab)-1]},PermList));
+          StabChain(p,rec(limit:=Size(fp)));
+        fi;
+
+        if tab<>fail and Size(p)=Size(fp) then
+          new:=GroupHomomorphismByImagesNC(fp,p,GeneratorsOfGroup(fp),
+            GeneratorsOfGroup(p));
+
+          # this degree is far off the optimum, so -- unlike elsewhere -- a
+          # full reduction pays for itself here
+          if ValueOption("cheap")<>true then
+            e:=SmallerDegreePermutationRepresentation(p);
+            if NrMovedPoints(ImagesSource(e))<NrMovedPoints(p) then
+              new:=new*e;
+              p:=ImagesSource(e);
+            fi;
+          fi;
+        fi;
+      fi;
+    fi;
+
+    if new=fail then
 
       #sim:=IsomorphismSimplifiedFpGroup(fp);
       sim:=IdentityMapping(fp);


### PR DESCRIPTION
## The problem

`Extensions(G,M)` for a non-solvable `G` spends nearly all its time in
`FpGroupCocycle`, finding a permutation representation of the extension --
not in `TwoCohomologyGeneric`. Reported by Thomas Breuer for `L3(3)` with
its 7-dimensional `GF(3)` module, where the `cohomolo` package is an order
of magnitude faster overall:

```gap
G:= AtlasGroup( "L3(3)" );;
info:= AllAtlasGeneratingSetInfos( "L3(3)", Ring, GF(3), Dimension, 7 );;
M:= GModuleByMats( AtlasGenerators( info[1] ).generators, GF(3) );;
ext:= Extensions( G, M );;   # 6308 seconds
```

Breakdown on my machine: `TwoCohomologyGeneric` 0.4 s, then 373 s for
*each* of the eight non-split cocycles.

The search lifts the quotient `E -> G` step by step, testing subgroups of
descending index and using `LargerQuotientBySubgroupAbelianization`. For a
candidate of index `i` the preimage's presentation is rewritten on roughly
`i * ngens` generators. `L3(3)` has nothing usable below index 52; the
attempt at index 144 with 16 generators produces a presentation on some
2000 generators, and everything downstream chokes on it.

## The change

If a subspace `U` of the module contains no nonzero submodule, then its
core in the extension is trivial -- a normal subgroup contained in `U`
lies in the module and hence is a submodule. So the extension acts
faithfully on the cosets of `U`, and one coset enumeration produces that
action. For an irreducible module `U` is a hyperplane, of index
`prime * |G|`.

Two new helpers, `ModuleCoreOfSubspace` and `SubmoduleFreeSubspace`, find
such a subspace; `FpGroupCocycle` uses it before falling back to the
existing search.

Guards, each of which measurement showed to be necessary:

* **Only at codimension 1.** Every further codimension multiplies the
  degree by `prime`, and the degree reduction afterwards then costs more
  than the old search. On the reducible 10-dimensional `GF(5)` module from
  `tst/testbugfix/2025-11-06-PermrepExtension.tst`: old 1 s, new 170 s.
* **Only up to degree `10^5`** (`EXTENSION_COSET_ENUMERATION_MAXDEG`).
* **Not for 1-dimensional modules**, where the only such subspace is
  trivial and the enumeration degenerates to the regular representation.
* `:cheap` skips the full `SmallerDegreePermutationRepresentation`
  afterwards. Without the option that reduction is worth its price here,
  because the degree coming out of the module is far off the optimum.

## Numbers

`Extensions` for the example above, and the tests that cover this code:

| | master | this PR |
| --- | ---: | ---: |
| `Extensions(L3(3), M)` | ~3400 s | **~120 s** |
| resulting degrees | 156 ... 1296 | 117 ... 702 |
| `NrConjugacyClasses` of all nine | 1.7 s | 0.9 s |
| `tst/teststandard/twocohom.tst` | 5142 ms | 4720 ms |
| `tst/testbugfix/2025-11-06-PermrepExtension.tst` | 2108 ms | 2102 ms |
| `tst/testextra/grpperm.tst` | 211 s | 240 s (noise) |

For reference, the `cohomolo` route on the same machine costs about 200 s
for the nine extensions, so this also removes the gap that prompted the
report.

## Test

`tst/teststandard/twocohom.tst` gains the reported example, built without
`AtlasRep` from the tensor square of the natural module of `SL(3,3)`. It
constructs one of the nine extensions rather than all nine, which keeps it
at about 15 seconds -- against some 370 seconds on master.

## Verification

* All nine groups have order 12282192, `PCore(.,3)` elementary abelian of
  order `3^7`, quotient of order 5616, and exactly one of them splits.
* The multiset of class numbers matches what `cohomolo` produces
  (3 x 57, 6 x 49).
* `twocohom.tst`, `2025-11-06-PermrepExtension.tst`,
  `2026-08-02-TwoCohomologyGeneric.tst` and `testextra/grpperm.tst` pass.
* Small cases (`C2`, `S3`, `A5` with trivial, regular and reducible
  modules) produce degrees identical to master.

## Not addressed here

* The presentation `TwoCohomologyGeneric` derives from the confluent
  rewriting system has 9 generators for `L3(3)` where 2 suffice.
  `cohomolo`'s extension presentation has 9 generators against our 16, and
  that alone is worth a factor of about 7 when the generic
  `IsomorphismPermGroup` is used on either.
* What remains of the runtime is `SmallerDegreePermutationRepresentation`,
  roughly 8 s per extension; `cohomolo` pays the same.
* `TwoCohomologyGeneric(TrivialGroup(IsPermGroup), <module of dim >= 2>)`
  errors with `MaximumList: <list> must contain at least one element`.
  Pre-existing, unrelated, not touched here.

---

This pull request was prepared with AI assistance (Claude Opus 5); see the
`Co-authored-by` trailer on the commit.