### PR TITLE
minor documentation changes

### DIFF
--- a/lib/grp.gd
+++ b/lib/grp.gd
@@ -4124,7 +4124,7 @@ InParentFOA( "RightTransversal", IsGroup, IsGroup, DeclareAttribute );
 ##  <Oper Name="IntermediateSubgroups" Arg='G, U'/>
 ##
 ##  <Description>
-##  returns a list of all subgroups of <A>G</A> that properly contain
+##  returns a list of all proper subgroups of <A>G</A> that properly contain
 ##  <A>U</A>; that is all subgroups between <A>G</A> and <A>U</A>.
 ##  It returns a record with a component <C>subgroups</C>, which is a list of
 ##  these subgroups, as well as a component <C>inclusions</C>,
@@ -4134,6 +4134,15 @@ InParentFOA( "RightTransversal", IsGroup, IsGroup, DeclareAttribute );
 ##  <M>j</M>,
 ##  the numbers <M>0</M> and <M>1 +</M> <C>Length(subgroups)</C> are used to
 ##  denote <A>U</A> and <A>G</A>, respectively.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> G:= DihedralGroup( IsPermGroup, 8 );;
+##  gap> IntermediateSubgroups( G, Centre( G ) );
+##  rec( inclusions := [ [ 0, 1 ], [ 0, 2 ], [ 0, 3 ], [ 1, 4 ], [ 2, 4 ],
+##        [ 3, 4 ] ],
+##    subgroups := [ Group([ (2,4), (1,3)(2,4) ]), Group([ (1,2,3,4) ]),
+##        Group([ (1,2)(3,4), (1,3)(2,4) ]) ] )
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/mapping.gd
+++ b/lib/mapping.gd
@@ -1183,10 +1183,11 @@ DeclareGlobalFunction( "PreImages" );
 ##  and then maps the images under <A>map2</A>.
 ##  <P/>
 ##  (Note the reverse ordering of arguments in the composition via
-##  the multiplication <Ref Oper="\*"/>.
+##  the multiplication <Ref Oper="\*"/>.)
 ##  <P/>
 ##  <Ref Func="CompositionMapping2General"/> is the method that forms a
-##  composite mapping with two constituent mappings.
+##  composite mapping with two constituent mappings,
+##  see&nbsp;<Ref Filt="IsCompositionMappingRep"/>.
 ##  (This is used in some algorithms.)
 ##  </Description>
 ##  </ManSection>


### PR DESCRIPTION
- `CompositionMapping2`: add a missing bracket and a cross-reference
- `IntermediateSubgroups`: add a missing "proper" and an example