### PR TITLE
kernel: Add write barriers after stores of fresh objects

### DIFF
--- a/src/dt.c
+++ b/src/dt.c
@@ -1624,6 +1624,8 @@ static void SetSubs(Obj list, Obj a, Obj tree)
         for  (j=1;  j <= len2;  j++)
             SET_DT_POS(tree, CELM( ELM_PLIST(list, i), j), ELM_PLIST(a, i) );
     }
+    // <tree> may be old and the entries of <a> young
+    CHANGED_BAG(tree);
 }
 
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -425,6 +425,7 @@ static Obj FuncLoadedModules(Obj self)
             CHANGED_BAG(list);
             str = MakeImmString(Modules[i].filename);
             SET_ELM_PLIST(list, 3 * i + 3, str);
+            CHANGED_BAG(list);
         }
         else if (IS_MODULE_STATIC(m->type)) {
             SET_ELM_PLIST(list, 3 * i + 1, ObjsChar[(Int)'s']);
@@ -434,6 +435,7 @@ static Obj FuncLoadedModules(Obj self)
             CHANGED_BAG(list);
             str = MakeImmString(Modules[i].filename);
             SET_ELM_PLIST(list, 3 * i + 3, str);
+            CHANGED_BAG(list);
         }
     }
     return list;

--- a/src/records.c
+++ b/src/records.c
@@ -385,6 +385,7 @@ static Obj FuncALL_RNAMES(Obj self)
         name = NAME_RNAM( i );
         s = CopyToStringRep(name);
         SET_ELM_PLIST( copy, i, s );
+        CHANGED_BAG( copy );
     }
     SET_LEN_PLIST( copy, countRNam );
     return copy;

--- a/src/vars.c
+++ b/src/vars.c
@@ -2365,6 +2365,8 @@ static Int InitLibrary (
     hdr->parent = Fail;
     tmpBody = NewFunctionBody();
     SET_BODY_FUNC( tmpFunc, tmpBody );
+    // tmpFunc predates two allocations, tmpBody is young
+    CHANGED_BAG( tmpFunc );
 
     // init filters and functions
     InitGVarFuncsFromTable( GVarFuncs );


### PR DESCRIPTION
Found by an audit of `SET_ELM_PLIST` and `SET_BODY_FUNC` sites storing a value that is not an immediate without a `CHANGED_BAG` nearby. Each of these stores a freshly allocated object into a container that may already be old: the bottom function's body, strings copied into the result of `ALL_RNAMES` and `LOADED_MODULES`, and positions written into an existing DT tree.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>