### PR TITLE
compiler: Emit write barrier after storing a function body

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1130,6 +1130,8 @@ static CVar CompFuncExpr(Expr expr)
     Emit( "SET_ENDLINE_BODY(%c, %d);\n", tmp, GET_ENDLINE_BODY(BODY_FUNC(fexp)));
     Emit( "SET_FILENAME_BODY(%c, FileName);\n",tmp);
     Emit( "SET_BODY_FUNC(%c, %c);\n", func, tmp );
+    // the function may already be old by now, the body is young
+    Emit( "CHANGED_BAG(%c);\n", func );
     FreeTemp( TEMP_CVAR( tmp ) );
 
     // we know that the result is a function

--- a/tst/test-compile/and_filter.g.dynamic.c
+++ b/tst/test-compile/and_filter.g.dynamic.c
@@ -278,6 +278,7 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_4, 5);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
+ CHANGED_BAG(t_3);
  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
   t_2 = CALL_0ARGS( t_3 );
  }
@@ -304,6 +305,7 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_4, 6);
  SET_FILENAME_BODY(t_4, FileName);
  SET_BODY_FUNC(t_3, t_4);
+ CHANGED_BAG(t_3);
  if ( TNUM_OBJ( t_3 ) == T_FUNCTION ) {
   t_2 = CALL_0ARGS( t_3 );
  }
@@ -364,6 +366,7 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_3, 13);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -384,6 +387,7 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_3, 16);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -404,6 +408,7 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_3, 18);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -424,6 +429,7 @@ static Obj  HdlrFunc2 (
  SET_ENDLINE_BODY(t_3, 19);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -481,6 +487,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 21);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/assert.g.dynamic.c
+++ b/tst/test-compile/assert.g.dynamic.c
@@ -225,6 +225,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 20);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/basics.g.dynamic.c
+++ b/tst/test-compile/basics.g.dynamic.c
@@ -370,6 +370,7 @@ static Obj  HdlrFunc3 (
  SET_ENDLINE_BODY(t_2, 60);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  l_vararg__fun = t_1;
  
  /* Print( vararg_fun(  ), "\n" ); */
@@ -607,6 +608,7 @@ static Obj  HdlrFunc3 (
  SET_ENDLINE_BODY(t_2, 91);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  l_vararg__fun = t_1;
  
  /* vararg_fun(  ); */
@@ -2405,6 +2407,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 48);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__int__constants, t_1 );
  
  /* test_func_calls := function (  )
@@ -2447,6 +2450,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 112);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__func__calls, t_1 );
  
  /* test_cmp_ops := function (  )
@@ -2546,6 +2550,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 163);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__cmp__ops, t_1 );
  
  /* test_arith := function (  )
@@ -2563,6 +2568,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 177);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__arith, t_1 );
  
  /* test_tilde := function (  )
@@ -2576,6 +2582,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 199);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__tilde, t_1 );
  
  /* test_list_rec_exprs := function (  )
@@ -2615,6 +2622,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 233);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__list__rec__exprs, t_1 );
  
  /* myglobal := 1; */
@@ -2675,6 +2683,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 299);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__IsBound__Unbind, t_1 );
  
  /* test_loops := function (  )
@@ -2722,6 +2731,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 346);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_test__loops, t_1 );
  
  /* runtest := function (  )
@@ -2743,6 +2753,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 364);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/callfunc.g.dynamic.c
+++ b/tst/test-compile/callfunc.g.dynamic.c
@@ -618,6 +618,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_5, 49);
  SET_FILENAME_BODY(t_5, FileName);
  SET_BODY_FUNC(t_4, t_5);
+ CHANGED_BAG(t_4);
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
   CALL_3ARGS( t_1, t_2, t_3, t_4 );
  }
@@ -753,6 +754,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_3, 64);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -774,6 +776,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_3, 65);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -795,6 +798,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_3, 66);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -816,6 +820,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_3, 68);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -837,6 +842,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_3, 69);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -858,6 +864,7 @@ static Obj  HdlrFunc8 (
  SET_ENDLINE_BODY(t_3, 70);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -895,6 +902,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 5);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_p0, t_1 );
  
  /* p1 := function ( f )
@@ -909,6 +917,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 10);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_p1, t_1 );
  
  /* p7 := function ( f )
@@ -923,6 +932,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 15);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_p7, t_1 );
  
  /* f0 := function ( f )
@@ -937,6 +947,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 21);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f0, t_1 );
  
  /* f1 := function ( f )
@@ -951,6 +962,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 26);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f1, t_1 );
  
  /* f7 := function ( f )
@@ -965,6 +977,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 31);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f7, t_1 );
  
  /* runtest := function (  )
@@ -1024,6 +1037,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 72);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/function_types.g.dynamic.c
+++ b/tst/test-compile/function_types.g.dynamic.c
@@ -386,6 +386,7 @@ static Obj  HdlrFunc7 (
  SET_ENDLINE_BODY(t_3, 35);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -406,6 +407,7 @@ static Obj  HdlrFunc7 (
  SET_ENDLINE_BODY(t_3, 36);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -426,6 +428,7 @@ static Obj  HdlrFunc7 (
  SET_ENDLINE_BODY(t_3, 37);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -446,6 +449,7 @@ static Obj  HdlrFunc7 (
  SET_ENDLINE_BODY(t_3, 38);
  SET_FILENAME_BODY(t_3, FileName);
  SET_BODY_FUNC(t_2, t_3);
+ CHANGED_BAG(t_2);
  t_3 = NEW_PLIST( T_PLIST, 0 );
  SET_LEN_PLIST( t_3, 0 );
  if ( TNUM_OBJ( t_1 ) == T_FUNCTION ) {
@@ -482,6 +486,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 3);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f1, t_1 );
  
  /* f2 := function ( a, b )
@@ -495,6 +500,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 7);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f2, t_1 );
  
  /* f3 := function ( a... )
@@ -508,6 +514,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 11);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f3, t_1 );
  
  /* f4 := function ( a, b... )
@@ -521,6 +528,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 15);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f4, t_1 );
  
  /* f5 := function ( a\,b )
@@ -534,6 +542,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 20);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_f5, t_1 );
  
  /* runtest := function (  )
@@ -568,6 +577,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 40);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/info.g.dynamic.c
+++ b/tst/test-compile/info.g.dynamic.c
@@ -188,6 +188,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 10);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/plus.g.dynamic.c
+++ b/tst/test-compile/plus.g.dynamic.c
@@ -48,6 +48,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 3);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/print_various.g.dynamic.c
+++ b/tst/test-compile/print_various.g.dynamic.c
@@ -160,6 +160,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 7);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */

--- a/tst/test-compile/ranges.g.dynamic.c
+++ b/tst/test-compile/ranges.g.dynamic.c
@@ -301,6 +301,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 1);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_range2, t_1 );
  
  /* range3 := function ( a, b, c )
@@ -313,6 +314,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 2);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_range3, t_1 );
  
  /* runtest := function (  )
@@ -340,6 +342,7 @@ static Obj  HdlrFunc1 (
  SET_ENDLINE_BODY(t_2, 26);
  SET_FILENAME_BODY(t_2, FileName);
  SET_BODY_FUNC(t_1, t_2);
+ CHANGED_BAG(t_1);
  AssGVar( G_runtest, t_1 );
  
  /* return; */


### PR DESCRIPTION
Compiled code creates a function literal, then its body, then stores the body with `SET_BODY_FUNC`. But it was missing a write barrier, i.e., a call to `CHANGED_BAG`.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>