### PR TITLE
io: Initialise sline when opening a file for input

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -377,6 +377,7 @@ UInt OpenInput(TypInputFile * input, const Char * filename)
 #endif
     input->prev = IO(Input);
     input->stream = 0;
+    input->sline = 0;
     input->file = file;
 
     // enable echo for stdin and errin


### PR DESCRIPTION
OpenInput set every field of the TypInputFile it publishes except sline. While using GASMAN's conservative stack scanning, this was fine. But for a precise GC implementation, it is important that we don't store random values in an object points.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>