### PR TITLE
kernel: make some in-place conversions safe when using a precise GC.

### DIFF
--- a/src/blister.c
+++ b/src/blister.c
@@ -733,10 +733,12 @@ static void PlainBlist(Obj list)
     Int                 len;            // length of <list>
     UInt                i;              // loop variable
 
-    // resize the list and retype it, in this order
+    // grow first: the grow can collect, and the bit blocks must not yet be
+    // scanned as list entries
     len = LEN_BLIST(list);
+    if (SIZE_OBJ(list) < (len + 1) * sizeof(Obj))
+        ResizeBag(list, (len + 1) * sizeof(Obj));
     RetypeBagSM( list, T_PLIST );
-    GROW_PLIST( list, (UInt)len );
     SET_LEN_PLIST( list, len );
 
     // replace the bits by 'True' or 'False' as the case may be

--- a/src/range.c
+++ b/src/range.c
@@ -606,13 +606,15 @@ static void PlainRange(Obj list)
     inc     = GET_INC_RANGE( list );
 
     // change the type of the list, and allocate enough space
+    // grow first: the grow can collect
+    if (SIZE_OBJ(list) < (lenList + 1) * sizeof(Obj))
+        ResizeBag(list, (lenList + 1) * sizeof(Obj));
     if (lenList == 0)
         RetypeBagSM(list, T_PLIST_EMPTY);
     else if (inc > 0)
         RetypeBagSM(list, T_PLIST_CYC_SSORT);
     else
         RetypeBagSM(list, T_PLIST_CYC_NSORT);
-    GROW_PLIST( list, lenList );
     SET_LEN_PLIST( list, lenList );
 
     // enter the values in <list>

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -980,10 +980,11 @@ void PlainVec8Bit(Obj list)
     q = FIELD_VEC8BIT(list);
     info = GetFieldInfo8Bit(q);
     elts = ELS_BYTE_FIELDINFO_8BIT(info);
-
+    // grow first: the grow can collect, and the packed bytes must not yet
+    // be scanned as list entries
+    if (SIZE_OBJ(list) < (len + 1) * sizeof(Obj))
+        ResizeBag(list, (len + 1) * sizeof(Obj));
     RetypeBagSM(list, (len == 0) ? T_PLIST_EMPTY : T_PLIST_FFE);
-
-    GROW_PLIST(list, (UInt)len);
     SET_LEN_PLIST(list, len);
 
     if (len != 0) {

--- a/src/vec8bit.c
+++ b/src/vec8bit.c
@@ -738,9 +738,11 @@ static void ConvVec8Bit(Obj list, UInt q)
     if (nsize > SIZE_OBJ(list))
         ResizeWordSizedBag(list, nsize);
 
+    // Everything that may allocate happens before the first byte is
+    // written below: from then on the body no longer matches the list
+    // tnum, and a precise collector would scan the bytes as references.
+    type = TypeVec8Bit(q, IS_MUTABLE_OBJ(list));
 
-    // writing the first byte may clobber the third list entry
-    // before we have read it, so we take a copy
     firstthree[0] = ELM0_LIST(list, 1);
     firstthree[1] = ELM0_LIST(list, 2);
     firstthree[2] = ELM0_LIST(list, 3);
@@ -779,14 +781,13 @@ static void ConvVec8Bit(Obj list, UInt q)
     while ((ptr - BYTES_VEC8BIT(list)) % sizeof(UInt))
         *ptr++ = 0;
 
-    // retype and resize bag
-    if (nsize != SIZE_OBJ(list))
-        ResizeWordSizedBag(list, nsize);
-    SET_LEN_VEC8BIT(list, len);
-    SET_FIELD_VEC8BIT(list, q);
-    type = TypeVec8Bit(q, IS_MUTABLE_OBJ(list));
+    // retype first: the shrink is a safepoint and must see a data object
     SetTypeDatObj(list, type);
     RetypeBag(list, T_DATOBJ);
+    SET_LEN_VEC8BIT(list, len);
+    SET_FIELD_VEC8BIT(list, q);
+    if (nsize != SIZE_OBJ(list))
+        ResizeWordSizedBag(list, nsize);
 }
 
 /****************************************************************************

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1360,28 +1360,31 @@ static void ConvGF2Vec(Obj list)
     // change its representation
     len = LEN_PLIST(list);
 
-    // We may have to resize the bag now because a length 1
-    // plain list is shorter than a length 1 GF2VEC
+    // Bring every element to GF2One or GF2Zero first: EQ may run GAP code
+    // and collect, and the packing below overwrites the list body, which
+    // must still be a list of references whenever a collection can happen.
+    for (i = 1; i <= len; i++) {
+        x = ELM_PLIST(list, i);
+        if (x == GF2One || x == GF2Zero)
+            continue;
+        if (EQ(x, GF2One))
+            SET_ELM_PLIST(list, i, GF2One);
+        else if (EQ(x, GF2Zero))
+            SET_ELM_PLIST(list, i, GF2Zero);
+        else
+            ErrorMayQuit(
+                "COPY_GF2VEC: argument must be a list of GF2 elements", 0,
+                0);
+    }
     if (SIZE_PLEN_GF2VEC(len) > SIZE_OBJ(list))
         ResizeBag(list, SIZE_PLEN_GF2VEC(len));
+    BOOL mutable = IS_PLIST_MUTABLE(list);
 
-    // now do the work
     block = 0;
     bit = 1;
     for (i = 1; i <= len; i++) {
-        x = ELM_PLIST(list, i);
-        if (x == GF2One)
+        if (ELM_PLIST(list, i) == GF2One)
             block |= bit;
-        else if (x != GF2Zero) {
-            // might be GF(2) elt written over bigger field
-            if (EQ(x, GF2One))
-                block |= bit;
-            else if (!EQ(x, GF2Zero))
-                ErrorMayQuit(
-                    "COPY_GF2VEC: argument must be a list of GF2 elements",
-                    0, 0);
-        }
-
         bit = bit << 1;
         if (bit == 0 || i == len) {
             BLOCK_ELM_GF2VEC(list, i) = block;
@@ -1390,16 +1393,11 @@ static void ConvGF2Vec(Obj list)
         }
     }
 
-    // retype and resize bag
-    ResizeWordSizedBag(list, SIZE_PLEN_GF2VEC(len));
-    SET_LEN_GF2VEC(list, len);
-    if (IS_PLIST_MUTABLE(list)) {
-        SetTypeDatObj(list, TYPE_LIST_GF2VEC);
-    }
-    else {
-        SetTypeDatObj(list, TYPE_LIST_GF2VEC_IMM);
-    }
+    // retype first: the shrink is a safepoint and must see a data object
+    SetTypeDatObj(list, mutable ? TYPE_LIST_GF2VEC : TYPE_LIST_GF2VEC_IMM);
     RetypeBag(list, T_DATOBJ);
+    SET_LEN_GF2VEC(list, len);
+    ResizeWordSizedBag(list, SIZE_PLEN_GF2VEC(len));
 }
 
 

--- a/src/vecgf2.c
+++ b/src/vecgf2.c
@@ -1276,12 +1276,12 @@ static void PlainGF2Vec(Obj list)
         ErrorMayQuit("Cannot convert a locked GF2 vector into a plain list",
                      0, 0);
 
-    // resize the list and retype it, in this order
+    // grow first: the grow can collect, and the bit blocks must not yet be
+    // scanned as list entries
     len = LEN_GF2VEC(list);
-
+    if (SIZE_OBJ(list) < (len + 1) * sizeof(Obj))
+        ResizeBag(list, (len + 1) * sizeof(Obj));
     RetypeBagSM(list, (len == 0) ? T_PLIST_EMPTY : T_PLIST_FFE);
-
-    GROW_PLIST(list, (UInt)len);
     SET_LEN_PLIST(list, len);
 
     // keep the first entry because setting the second destroys the first


### PR DESCRIPTION
The two commits in this PR fix issues that should not matter when using GASMAN, but they do when using a precise GC like Julia's; or also potentially when using a concurrent kernel, like HPC-GAP.

Specifically, while performing in-place conversion on certain kinds of objects, we would change the objects temporarily in a way that means they are internally broken. That is, the object have started out as a plist, and still had a plist TNUM, but instead of pointers might e.g. contain raw binary data.

If any other code, such as the garbage collector, were to access the objects during that time, Bad Things (TM)  could happen.

To address this, some code was changed to be very careful about the order in which we retype, modify content, resize or otherwise execute code that may trigger a garbage collection.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

I *think* we don't need this when using GASMAN; but it also shouldn't hurt.