### PR TITLE
Fix standalone manual builds and update doc READMEs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -13,6 +13,10 @@ documented [here](https://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/doc/chap
 
 There is also a document describing [**Changes from Earlier Versions**](../CHANGES.md).
 
+In addition, the directory `doc/dev` contains the (incomplete) **GAP Development
+Manual**, which is built together with the main manuals but is not included in
+GAP releases; see [its README](dev/README.md).
+
 The official GAP distribution includes all documentation, so there is no need to
 build it after GAP installation. However, if you need to build the development
 version of main GAP manuals from this repository, you need to perform the following

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -7,11 +7,13 @@ with caution. Contributions are welcomed!
 To build this manual, call
 
 ```
-gap makedocrelx.g
-````
+gap makedocrel.g
+```
 
 in this directory. This will build HTML, PDF and text versions.
 
-Please note that this manual is not a part of the GAP distribution,
-so it will not be built by calling `make doc`.
+This manual is also built (together with the other main manuals) by
+calling `make doc` in the top-level directory. Note however that it is not
+part of the GAP distribution: the release scripts remove `doc/dev` from the
+release archives.
 

--- a/doc/hpc/makedocrel.g
+++ b/doc/hpc/makedocrel.g
@@ -2,16 +2,7 @@
 ##  mkindex, dvips
 ##
 
-GAPInfo.ManualDataHPC:= rec(
-  pathtodoc:= ".",
-  main:= "main.xml",
-  bookname:= "hpc",
-  pathtoroot:= "../..",
-
-  files:= [
-  ],
- );;
-
+Read( "makedocreldata.g" );
 
 SetGapDocLaTeXOptions("nocolor", rec(Maintitlesize :=
 "\\fontsize{36}{38}\\selectfont"));

--- a/doc/ref/makedocrel.g
+++ b/doc/ref/makedocrel.g
@@ -4,6 +4,9 @@
 
 Read( "makedocreldata.g" );
 
+# create/update the (gitignored) file user_pref_list.xml
+UpdateXMLForUserPreferences();
+
 SetGapDocLaTeXOptions("nocolor", rec(Maintitlesize :=
 "\\fontsize{36}{38}\\selectfont"));
 


### PR DESCRIPTION
Fixes a few issues with building the manuals via the per-manual `makedocrel.g` scripts (as opposed to `make doc`), and updates the corresponding READMEs. Three commits:

1. **Fix standalone build of the reference manual.** Since #5681, `doc/ref/user_pref_list.xml` is gitignored and generated at build time by `UpdateXMLForUserPreferences()`. That call was added to `doc/make_doc.in` and `tst/extractmanuals.g` but not to `doc/ref/makedocrel.g`, so in a fresh clone it failed with `Error, Cannot include file ./user_pref_list.xml.`
2. **Make `doc/hpc/makedocrel.g` read `makedocreldata.g`** like the other three manuals do, instead of duplicating the record inline.
3. **Update READMEs.** `doc/dev/README.md` still referred to `makedocrelx.g`, which was renamed to `makedocrel.g` in 24780c6bc (2017), and claimed the development manual is not built by `make doc`, which has been wrong since 994885412 (2017). `doc/README.md` now also mentions the development manual.

All four manuals (`ref`, `tut`, `hpc`, `dev`) were built successfully with their `makedocrel.g` scripts after these changes.

## Text for release notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
