### PR TITLE
kernel: Let a GC hook into the TRY/CATCH machinery

### DIFF
--- a/src/gasman.h
+++ b/src/gasman.h
@@ -488,6 +488,29 @@ EXPORT_INLINE Bag NewWordSizedBag(UInt type, UInt size)
 
 /****************************************************************************
 **
+*F  GAP_GC_SAVE_STACK_STATE() . . . . . . . record the collector's root stack
+*F  GAP_GC_RESTORE_STACK_STATE(<state>) . . . . . . . . . . . . restore it
+**
+**  A GAP error 'longjmp's out of the call chain that raised it. Whatever
+**  that chain registered with the collector - the Julia GC keeps a chain of
+**  root frames on the C stack - is never unregistered, and points into
+**  stack that is gone. So every place that sets up such a jump saves the
+**  state before, and restores it on the error path. Collectors that find
+**  their roots by scanning the C stack have nothing to record.
+*/
+typedef void * GAP_GCStackState;
+
+#if defined(USE_JULIA_GC)
+GAP_GCStackState GAP_GC_SAVE_STACK_STATE(void) JL_NOTSAFEPOINT;
+void GAP_GC_RESTORE_STACK_STATE(GAP_GCStackState state) JL_NOTSAFEPOINT;
+#else
+#define GAP_GC_SAVE_STACK_STATE() ((GAP_GCStackState)0)
+#define GAP_GC_RESTORE_STACK_STATE(state) ((void)(state))
+#endif
+
+
+/****************************************************************************
+**
 *F  RetypeBag(<bag>,<new>) . . . . . . . . . . . . . change the type of a bag
 *F  RetypeBagIntern(<bag>,<new>) . . . . . . . . . . . . . internal interface
 **

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -823,6 +823,16 @@ UInt TotalGCTime(void)
     return TotalTime;
 }
 
+GAP_GCStackState GAP_GC_SAVE_STACK_STATE(void) JL_NOTSAFEPOINT
+{
+    return (GAP_GCStackState)jl_pgcstack;
+}
+
+void GAP_GC_RESTORE_STACK_STATE(GAP_GCStackState state) JL_NOTSAFEPOINT
+{
+    jl_pgcstack = (jl_gcframe_t *)state;
+}
+
 BOOL IsGapObj(void * p)
 {
     return jl_typeis(p, DatatypeGapObj);

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -664,7 +664,7 @@ void GAP_Error_Postjmp_Returning_(void)
     if (EnterStackCount > 0) {
         EnterStackCount = -EnterStackCount;
     }
-    GAP_GC_RESTORE_STACK_STATE((GAP_GCStackState)GCStack);
+    GAP_GC_RESTORE_STACK_STATE(GCStack);
     SetRecursionDepth(RecursionDepth);
 }
 

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -608,6 +608,7 @@ jmp_buf * GAP_GetReadJmpError(void)
 
 static volatile sig_atomic_t EnterStackCount = 0;
 static volatile Int RecursionDepth;
+static volatile GAP_GCStackState GCStack;
 
 
 // These are wrapped by the macros GAP_EnterStack() and GAP_LeaveStack()
@@ -644,6 +645,7 @@ int GAP_Error_Prejmp_(const char * file, int line)
         return 1;
     }
     RecursionDepth = GetRecursionDepth();
+    GCStack = GAP_GC_SAVE_STACK_STATE();
     return 0;
 }
 
@@ -662,6 +664,7 @@ void GAP_Error_Postjmp_Returning_(void)
     if (EnterStackCount > 0) {
         EnterStackCount = -EnterStackCount;
     }
+    GAP_GC_RESTORE_STACK_STATE((GAP_GCStackState)GCStack);
     SetRecursionDepth(RecursionDepth);
 }
 

--- a/src/libgap-api.c
+++ b/src/libgap-api.c
@@ -606,6 +606,12 @@ jmp_buf * GAP_GetReadJmpError(void)
 }
 
 
+// Only the outermost GAP_Enter() installs the jump target: GAP_Error_Setjmp()
+// asks GAP_Error_Prejmp_, which uses EnterStackCount to tell the outermost
+// entry from nested ones and saves the state to return to only for the
+// former. An error longjmps back to that outermost entry, where
+// GAP_Error_Postjmp_Returning_ restores the state. So one global variable
+// per piece of state suffices: right now RecursionDepth and GCStack.
 static volatile sig_atomic_t EnterStackCount = 0;
 static volatile Int RecursionDepth;
 static volatile GAP_GCStackState GCStack;

--- a/src/read.c
+++ b/src/read.c
@@ -77,7 +77,9 @@
 #define TRY_IF_NO_ERROR                                                      \
     if (!rs->s.NrError) {                                                    \
         volatile Int recursionDepth = GetRecursionDepth();                   \
+        volatile GAP_GCStackState gcStack = GAP_GC_SAVE_STACK_STATE();       \
         if (GAP_SETJMP(STATE(ReadJmpError))) {                               \
+            GAP_GC_RESTORE_STACK_STATE(gcStack);                             \
             SetRecursionDepth(recursionDepth);                               \
             rs->s.NrError++;                                                 \
         }                                                                    \

--- a/src/trycatch.h
+++ b/src/trycatch.h
@@ -14,6 +14,7 @@
 #define GAP_TRYCATCH_H
 
 #include "funcs.h"    // for SetRecursionDepth
+#include "gasman.h"   // for GAP_GC_SAVE_STACK_STATE
 #include "gapstate.h"
 #include "system.h"    // for NORETURN
 
@@ -100,6 +101,7 @@ void InvokeTryCatchHandler(TryCatchMode mode);
 typedef struct {
     volatile int tryCatchDepth;
     volatile Int recursionDepth;
+    volatile GAP_GCStackState gcStack;
     jmp_buf      jb;
 } GAP_TryCatchEnv;
 
@@ -108,6 +110,7 @@ static inline int gap_safe_trycatch(GAP_TryCatchEnv * env)
 {
     memcpy(env->jb, STATE(ReadJmpError), sizeof(jmp_buf));
     env->recursionDepth = GetRecursionDepth();
+    env->gcStack = GAP_GC_SAVE_STACK_STATE();
     env->tryCatchDepth = STATE(TryCatchDepth)++;
     return 0;
 }
@@ -115,6 +118,7 @@ static inline int gap_safe_trycatch(GAP_TryCatchEnv * env)
 static inline int gap_restore_trycatch(GAP_TryCatchEnv * env)
 {
     memcpy(STATE(ReadJmpError), env->jb, sizeof(jmp_buf));
+    GAP_GC_RESTORE_STACK_STATE(env->gcStack);
     SetRecursionDepth(env->recursionDepth);
     STATE(TryCatchDepth) = env->tryCatchDepth;
     return 0;


### PR DESCRIPTION
Add two hooks, GAP_GC_SAVE_STACK_STATE and GAP_GC_RESTORE_STACK_STATE, and call them wherever GAP sets up a setjmp for its error handling: the reader's TRY_IF_NO_ERROR, the GAP_TRY/GAP_CATCH helpers, and the libgap entry points. The state is saved before the setjmp and restored on the error path, next to the recursion depth that is already handled there.

The point of this is the Julia GC integration. The Julia GC keeps a chain of root frames on the C stack. A GAP error longjmps out of the call chain that raised it, so the frames that chain registered are never unregistered, and after the jump they point into stack that no longer exists; the next collection then walks garbage. With the hooks, the head of that chain is saved and restored like the rest of the error state, which fixes this for every error GAP catches.

GASMAN and Boehm find their roots by scanning the C stack and have nothing to record; for them the hooks compile to nothing.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

You may be wondering why this isn't using the existing hook system: well, that only works for `GAP_TRY`/`GAP_CATCH`, but not `TRY_IF_NO_ERROR`. One of these days, I'll think again about whether we can unify these systems. But for now, I think this doesn't add too much complexity and is required for the "precise Julia GC" work.