### PR TITLE
Make `TwoCohomologyGeneric` work for the trivial group

### DIFF
--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -807,7 +807,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
 
   dag:=EmptyKBDAG(Union(List(GeneratorsOfMonoid(FreeMonoidOfFpMonoid(mon)),
     LetterRepAssocWord)));
-  mal:=Maximum(List(tzrules,x->Length(x[1])));
+  mal:=MaximumList(List(tzrules,x->Length(x[1])),0); # 0 if there are no rules
   for i in [1..Length(tzrules)] do
     AddRuleKBDAG(dag,tzrules[i][1],i);
   od;
@@ -815,9 +815,19 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   gens:=List(GeneratorsOfGroup(FamilyObj(fpg)!.wholeGroup),
     x->PreImagesRepresentativeNC(fp,x));
 
-  hom:=GroupHomomorphismByImagesNC(G,Group(mo.generators),
-    GeneratorsOfGroup(G),mo.generators);
-  mo:=GModuleByMats(List(gens,x->ImagesRepresentative(hom,x)),mo.field); # new gens
+  # a module built without generators carries a single dummy identity
+  # generator instead of one image per generator of G
+  if MTX.IsZeroGens(mo) then
+    new:=ListWithIdenticalEntries(Length(ogens),One(mo.generators[1]));
+  else
+    new:=mo.generators;
+  fi;
+
+  hom:=GroupHomomorphismByImagesNC(G,Group(mo.generators),ogens,new);
+  # new gens; `gens` can be empty, so state the dimension. It is taken from
+  # the matrices, as <mo> need not have a `dimension` component.
+  mo:=GModuleByMats(List(gens,x->ImagesRepresentative(hom,x)),
+    NrRows(mo.generators[1]),mo.field);
 
   l1:=GeneratorsOfGroup(fpg);
   l1:=Concatenation(l1,List(l1,Inverse));
@@ -898,7 +908,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   mats:=List(GeneratorsOfMonoid(mon),
     x->ImagesRepresentative(hom,PreImagesRepresentativeNC(fp,
     PreImagesRepresentativeNC(fm,x)))); # matrices for monoid generators
-  one:=One(mats[1]);
+  one:=onemat; # `mats` can be empty
   nonone:=Filtered([1..Length(mats)],x->not IsOne(mats[x]));
   zero:=zerovec;
   dim:=Length(zero);
@@ -986,7 +996,9 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
 
   #eqs:=Filtered(TriangulizedMat(eqs),x->not IsZero(x));
   eqs:=ShallowCopy(BasisVectors(eqs));
-  if Length(eqs)=0 then
+  if nvars=0 then
+    eqs:=[]; # no tails, so no cocycles; IdentityMat would give NullMapMatrix
+  elif Length(eqs)=0 then
     # no conditions, so the whole space of tail vectors consists of cocycles
     eqs:=IdentityMat(nvars,field);
   else
@@ -1036,7 +1048,7 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   bds:=List(bds,Immutable);
 
   if gens<>GeneratorsOfGroup(G) then
-    G:=GroupWithGenerators(gens);
+    G:=GroupWithGenerators(gens,One(G)); # `gens` can be empty
   fi;
   r:=rec(group:=G,module:=mo,cocycles:=eqs,coboundaries:=bds,zero:=zeroq,
          prime:=Size(field));
@@ -1299,9 +1311,18 @@ end);
 
 BindGlobal("PermrepSemidirectModule",function(G,module)
 local hom,mats,m,i,j,mo,bas,a,l,ugens,gi,r,cy,act,k,it,p;
-  if not MTX.IsIrreducible(module) then Error("reducible");fi;
   p:=Size(module.field);
   if not IsPrime(p) then Error("must be over prime field");fi;
+
+  if IsTrivial(G) then
+    # nothing acts, so the semidirect product is just the module
+    mo:=AbelianGroup(IsPermGroup,ListWithIdenticalEntries(module.dimension,p));
+    return rec(group:=mo,
+               ggens:=List(GeneratorsOfGroup(G),x->One(mo)),
+               basis:=AsList(Pcgs(mo)));
+  fi;
+
+  if not MTX.IsIrreducible(module) then Error("reducible");fi;
   k:=Length(module.generators);
   hom:=GroupHomomorphismByImagesNC(G,Group(module.generators),
     GeneratorsOfGroup(G),module.generators);
@@ -1680,7 +1701,7 @@ local r,z,ogens,n,gens,str,dim,i,j,f,rels,new,quot,g,p,collect,m,e,fp,sim,
   fi;
 
   if Length(arg)>2 and arg[3]=true then
-    if IsZero(z) and MTX.IsIrreducible(r.module) then
+    if IsZero(z) and (IsTrivial(r.group) or MTX.IsIrreducible(r.module)) then
       # make SDP directly
       m:=PermrepSemidirectModule(r.group,r.module:cheap);
       p:=m.group;

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -815,9 +815,10 @@ local field,fp,fpg,gens,hom,mats,fm,mon,tzrules,dim,rules,eqs,i,j,k,l,o,l1,
   gens:=List(GeneratorsOfGroup(FamilyObj(fpg)!.wholeGroup),
     x->PreImagesRepresentativeNC(fp,x));
 
-  # a module built without generators carries a single dummy identity
-  # generator instead of one image per generator of G
-  if MTX.IsZeroGens(mo) then
+  # A module built without generators carries a single dummy identity
+  # generator, so for the trivial group it cannot match the generators of G.
+  # Everywhere else the generators have to correspond one to one.
+  if MTX.IsZeroGens(mo) and IsTrivial(G) then
     new:=ListWithIdenticalEntries(Length(ogens),One(mo.generators[1]));
   else
     new:=mo.generators;

--- a/tst/testbugfix/2026-08-31-TwoCohomologyGeneric-trivial.tst
+++ b/tst/testbugfix/2026-08-31-TwoCohomologyGeneric-trivial.tst
@@ -1,11 +1,13 @@
 # For the trivial group the confluent monoid presentation has neither
 # generators nor rules, which broke TwoCohomologyGeneric and FpGroupCocycle.
-# H^2 is zero and the extension is just the module.
+# H^2 is zero and the extension is just the module. Go through the permutation
+# representation, as FpGroupCocycle only asserts the size of the fp group.
 gap> triv:=function(G,d,F)
->      local coh,ext;
+>      local coh,ext,p;
 >      coh:=TwoCohomologyGeneric(G,GModuleByMats([],d,F));
 >      ext:=FpGroupCocycle(coh,coh.zero,true);
->      return [Length(coh.cohomology),Size(ext),AbelianInvariants(ext)];
+>      p:=Image(IsomorphismPermGroup(ext));
+>      return [Length(coh.cohomology),Size(p),AbelianInvariants(p)];
 >    end;;
 gap> triv(TrivialGroup(IsPermGroup),1,GF(2));
 [ 0, 2, [ 2 ] ]
@@ -21,10 +23,24 @@ gap> triv(TrivialGroup(IsFpGroup),2,GF(2));
 [ 0, 4, [ 2, 2 ] ]
 gap> Unbind(triv);
 
-# a module given without generators acts trivially, also on a bigger group
-gap> coh:=TwoCohomologyGeneric(SymmetricGroup(3),GModuleByMats([],2,GF(2)));;
+# a module given without generators is acted on trivially, also by a bigger
+# group: it must agree with the same module given by identity matrices
+gap> G:=SymmetricGroup(3);;
+gap> mats:=ListWithIdenticalEntries(Length(GeneratorsOfGroup(G)),
+>            IdentityMat(2,GF(2)));;
+gap> coh:=TwoCohomologyGeneric(G,GModuleByMats([],2,GF(2)));;
+gap> coh.cohomology=TwoCohomologyGeneric(G,
+>      GModuleByMats(mats,GF(2))).cohomology;
+true
+
+# H^2(S3,GF(2)) is one-dimensional for the trivial action, so twice that here.
+# The nonzero classes give the central extension Dic3 x C2, the zero class the
+# split one.
 gap> Length(coh.cohomology);
 2
-gap> Size(FpGroupCocycle(coh,coh.cohomology[1],true));
-24
-gap> Unbind(coh);
+gap> Set(coh.cohomology,c->IdGroup(Image(IsomorphismPermGroup(
+>      FpGroupCocycle(coh,c,true)))));
+[ [ 24, 7 ] ]
+gap> IdGroup(Image(IsomorphismPermGroup(FpGroupCocycle(coh,coh.zero,true))));
+[ 24, 14 ]
+gap> Unbind(coh); Unbind(mats); Unbind(G);

--- a/tst/testbugfix/2026-08-31-TwoCohomologyGeneric-trivial.tst
+++ b/tst/testbugfix/2026-08-31-TwoCohomologyGeneric-trivial.tst
@@ -1,0 +1,30 @@
+# For the trivial group the confluent monoid presentation has neither
+# generators nor rules, which broke TwoCohomologyGeneric and FpGroupCocycle.
+# H^2 is zero and the extension is just the module.
+gap> triv:=function(G,d,F)
+>      local coh,ext;
+>      coh:=TwoCohomologyGeneric(G,GModuleByMats([],d,F));
+>      ext:=FpGroupCocycle(coh,coh.zero,true);
+>      return [Length(coh.cohomology),Size(ext),AbelianInvariants(ext)];
+>    end;;
+gap> triv(TrivialGroup(IsPermGroup),1,GF(2));
+[ 0, 2, [ 2 ] ]
+gap> triv(TrivialGroup(IsPermGroup),2,GF(2));
+[ 0, 4, [ 2, 2 ] ]
+gap> triv(TrivialGroup(IsPermGroup),3,GF(3));
+[ 0, 27, [ 3, 3, 3 ] ]
+
+# a trivial group that does have (redundant) generators
+gap> triv(Group(()),2,GF(2));
+[ 0, 4, [ 2, 2 ] ]
+gap> triv(TrivialGroup(IsFpGroup),2,GF(2));
+[ 0, 4, [ 2, 2 ] ]
+gap> Unbind(triv);
+
+# a module given without generators acts trivially, also on a bigger group
+gap> coh:=TwoCohomologyGeneric(SymmetricGroup(3),GModuleByMats([],2,GF(2)));;
+gap> Length(coh.cohomology);
+2
+gap> Size(FpGroupCocycle(coh,coh.cohomology[1],true));
+24
+gap> Unbind(coh);

--- a/tst/testbugfix/2026-08-31-TwoCohomologyGeneric-trivial.tst
+++ b/tst/testbugfix/2026-08-31-TwoCohomologyGeneric-trivial.tst
@@ -16,31 +16,12 @@ gap> triv(TrivialGroup(IsPermGroup),2,GF(2));
 gap> triv(TrivialGroup(IsPermGroup),3,GF(3));
 [ 0, 27, [ 3, 3, 3 ] ]
 
-# a trivial group that does have (redundant) generators
+# a trivial group that does have (redundant) generators, so that the single
+# dummy generator of the module matches neither too few nor too many of them
 gap> triv(Group(()),2,GF(2));
+[ 0, 4, [ 2, 2 ] ]
+gap> triv(Group((),()),2,GF(2));
 [ 0, 4, [ 2, 2 ] ]
 gap> triv(TrivialGroup(IsFpGroup),2,GF(2));
 [ 0, 4, [ 2, 2 ] ]
 gap> Unbind(triv);
-
-# a module given without generators is acted on trivially, also by a bigger
-# group: it must agree with the same module given by identity matrices
-gap> G:=SymmetricGroup(3);;
-gap> mats:=ListWithIdenticalEntries(Length(GeneratorsOfGroup(G)),
->            IdentityMat(2,GF(2)));;
-gap> coh:=TwoCohomologyGeneric(G,GModuleByMats([],2,GF(2)));;
-gap> coh.cohomology=TwoCohomologyGeneric(G,
->      GModuleByMats(mats,GF(2))).cohomology;
-true
-
-# H^2(S3,GF(2)) is one-dimensional for the trivial action, so twice that here.
-# The nonzero classes give the central extension Dic3 x C2, the zero class the
-# split one.
-gap> Length(coh.cohomology);
-2
-gap> Set(coh.cohomology,c->IdGroup(Image(IsomorphismPermGroup(
->      FpGroupCocycle(coh,c,true)))));
-[ [ 24, 7 ] ]
-gap> IdGroup(Image(IsomorphismPermGroup(FpGroupCocycle(coh,coh.zero,true))));
-[ 24, 14 ]
-gap> Unbind(coh); Unbind(mats); Unbind(G);


### PR DESCRIPTION
While working on other stuff, we stumbled over an issue with `TwoCohomologyGeneric` on the trivial group.

This PR is a draft, and pushed here in lieu of a bug report (we already had made the fix, so I figure we might as well submit it).

@hulpke feel free to completely ignore the code in here and roll your own, or to take any parts that seem useful; or request changes; or whatever else. No pressure intended. 