### PR TITLE
Let PreImagesElm return [] outside the image

### DIFF
--- a/lib/field.gi
+++ b/lib/field.gi
@@ -1340,7 +1340,7 @@ InstallMethod( PreImagesElm,
     if not (elm in Range(hom)) then
       Error( "<elm> is not in the range of <hom>" );
     elif not (elm in Image(hom)) then
-      return fail;
+      return [];
     fi;
     return PreImagesElmNC( hom, elm );
     end );

--- a/lib/fldabnum.gi
+++ b/lib/fldabnum.gi
@@ -1942,7 +1942,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(aut) ) then
         Error( "<elm> is not in the range of mapping <aut>" );
     elif not ( elm in Image(aut) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( aut, elm );
     end );

--- a/lib/liefam.gi
+++ b/lib/liefam.gi
@@ -465,7 +465,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(emb) ) then
         Error( "<elm> is not in the range of mapping <emb>" );
     elif not ( elm in Image(emb) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( emb, elm );
     end );

--- a/lib/mapphomo.gi
+++ b/lib/mapphomo.gi
@@ -358,7 +358,7 @@ function( map, elm )
   if not ( elm in Range( map ) ) then
     Error( "<elm> is not in the range of <map>" );
   elif not ( elm in Image( map ) ) then
-    return fail;
+    return [];
   fi;
   return PreImagesElmNC( map, elm );
 end );
@@ -753,7 +753,7 @@ InstallMethod( PreImagesElm,
       if not ( elm in Range( map ) ) then
         Error( "<elm> is not in the range of <map>" );
       elif not ( elm in Image( map ) ) then
-        return fail;
+        return [];
       fi;
       return PreImagesElmNC( map, elm );
     end );

--- a/lib/mapping.gd
+++ b/lib/mapping.gd
@@ -985,7 +985,7 @@ DeclareGlobalFunction( "Images" );
 ##  <C>PreImagesElm</C> was renamed <C>PreImagesElmNC</C>
 ##  throughout the library, and the new <C>PreImagesElm</C> checks that
 ##  <A>elm</A> is an element of the image before calling <C>PreImagesElmNC</C>.
-##  If <A>elm</A> is in the range but not in the image then <K>fail</K>
+##  If <A>elm</A> is in the range but not in the image then the empty list
 ##  is returned.
 ##  If <A>elm</A> is not even in the range then an error is signalled.
 ##  <P/>

--- a/lib/mapping.gi
+++ b/lib/mapping.gi
@@ -1096,14 +1096,14 @@ InstallMethod( PreImagesElmNC,
     end );
 
 InstallMethod( PreImagesElm,
-    "for general mapping with finite source, and element",
+    "for general mapping, and element",
     FamRangeEqFamElm,
     [ IsGeneralMapping, IsObject ], 0,
     function ( map, elm )
     if not ( elm in Range( map ) ) then
         Error( "<elm> is not in the range of <map>" );
     elif not ( elm in Image( map ) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( map, elm );
     end );
@@ -1137,7 +1137,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range( map ) ) then
         Error( "<elm> is not in the range of <map>" );
     elif not ( elm in Image( map ) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( map, elm );
     end );

--- a/lib/mapprep.gi
+++ b/lib/mapprep.gi
@@ -329,7 +329,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(com) ) then
       Error( "<elm> is not in the range of mapping <com>" );
     elif not ( elm in Image(com) ) then
-      return fail;
+      return [];
     fi;
     return PreImagesElmNC( com, elm );
     end );
@@ -738,7 +738,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(map) ) then
         Error( "<elm> is not in the range of <map>" );
     elif not ( elm in Image(map) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( map, elm );
     end );
@@ -1165,7 +1165,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(inv) ) then
         Error( "<elm> is not in the range of mapping <inv>" );
     elif not ( elm in Image(inv) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( inv, elm );
     end );
@@ -1450,7 +1450,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(id) ) then
         Error( "<elm> is not in the range of mapping <id>" );
     elif not ( elm in Image(id) ) then
-        return fail;
+        return [];
     fi;
     return PreImagesElmNC( id, elm );
   end );
@@ -1782,7 +1782,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(zero) ) then
       Error( "<elm> is not in the range of mapping <zero>" );
     elif not ( elm in Image(zero) ) then
-      return fail;
+      return [];
     fi;
     return PreImagesElmNC( zero, elm );
     end );
@@ -2060,7 +2060,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range(res) ) then
       Error( "<elm> is not in the range of mapping <res>" );
     elif not ( elm in Image(res) ) then
-      return fail;
+      return [];
     fi;
     return PreImagesElmNC( res, elm );
     end );

--- a/lib/mgmring.gi
+++ b/lib/mgmring.gi
@@ -1244,7 +1244,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range( emb ) ) then
       Error( "<elm> is not in the range of mapping <emb>" );
     elif not ( elm in Image( emb ) ) then
-      return fail;
+      return [];
     fi;
     return PreImagesElmNC( emb, elm );
     end );
@@ -1374,7 +1374,7 @@ InstallMethod( PreImagesElm,
     if not ( elm in Range( emb ) ) then
       Error( "<elm> is not in the range of mapping <emb>" );
     elif not ( elm in Image( emb ) ) then
-      return fail;
+      return [];
     fi;
     return PreImagesElmNC( emb, elm );
     end );

--- a/lib/relation.gi
+++ b/lib/relation.gi
@@ -1003,7 +1003,7 @@ InstallMethod( PreImagesElm,
         if not ( n in Range(rel) ) then
             Error( "<n> is not in the range of <rel>" );
         elif not ( n in Image(rel) ) then
-            return fail;
+            return [];
         fi;
         return PreImagesElmNC( rel, n );
     end );
@@ -1861,7 +1861,7 @@ InstallMethod( PreImagesElm,
         if not ( elm in Range( rel ) ) then ## ?? is there a Range(rel)?
             Error( "<elm> not in the range of <rel>" );
         elif not ( elm in Image( rel ) ) then ## ?? is there an Image(rel)?
-            return fail;
+            return [];
         fi;
         return PreImagesElmNC( rel, elm );
     end);

--- a/tst/testinstall/mapphomo.tst
+++ b/tst/testinstall/mapphomo.tst
@@ -110,7 +110,7 @@ RightCoset(Group([ (1,4)(2,3), (1,2)(3,4) ]),(1,2,4,3))
 gap> PreImagesRepresentative( hom, (4,6)(7,9) );
 (1,2,4,3)
 gap> PreImagesElm( hom, (4,5,6,7,8,9) );
-fail
+[  ]
 gap> PreImagesRepresentative( hom, (4,5,6,7,8,9) );
 fail
 gap> PreImagesElm( hom, (7,8,9) );

--- a/tst/testinstall/preimages.tst
+++ b/tst/testinstall/preimages.tst
@@ -14,7 +14,7 @@ Error, <elm> is not in the range of mapping <hom>
 gap> PreImagesElm(f, (1,2));
 RightCoset(Group(()),(1,2))
 gap> PreImagesElm(f, (1,2,3));
-fail
+[  ]
 gap> PreImagesElm(f, (1,4));
 Error, <elm> is not in the range of <map>
 gap> PreImagesSet(f, Group((1,2)));
@@ -37,7 +37,7 @@ Error, <elm> is not in the range of <map>
 gap> PreImagesElm(map, (1,2));
 [ (1,2) ]
 gap> PreImagesElm(map, (1,2,3));
-fail
+[  ]
 gap> PreImagesElm(map, (1,4));
 Error, <elm> is not in the range of <map>
 gap> PreImagesSet(map, [(), (1,2,3)]);
@@ -59,7 +59,7 @@ Error, <elm> is not in the range of mapping <com>
 gap> PreImagesElm(comp, (1,2));
 [ (1,2) ]
 gap> PreImagesElm(comp, (1,2,3));
-fail
+[  ]
 gap> PreImagesElm(comp, (1,5));
 Error, <elm> is not in the range of mapping <com>
 gap> PreImagesSet(comp, [(), (1,2,3)]);
@@ -104,7 +104,7 @@ fail
 gap> PreImagesRepresentative(z, Z(9));
 Error, <elm> is not in the range of mapping <zero>
 gap> PreImagesElm(z, Z(3));
-fail
+[  ]
 gap> PreImagesElm(z, Z(9));
 Error, <elm> is not in the range of mapping <zero>
 gap> PreImagesSet(z, [0*Z(3), Z(3)]);
@@ -122,7 +122,7 @@ fail
 gap> PreImagesElm(mf, 4);
 [ 3, 4 ]
 gap> PreImagesElm(mf, 1);
-fail
+[  ]
 gap> PreImagesElm(mf, 7);
 Error, <elm> is not in the range of <map>
 


### PR DESCRIPTION
Before #6409, PreImagesElm returned the empty list for an element of the range without preimages; the wrappers added there return fail instead. A set-valued operation returning fail is inconsistent with PreImagesSet, which returns the preimage of the intersection with the image, and it breaks packages (fr, rcwa) that iterate over the result.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

See also https://github.com/gap-system/PackageDistro/issues/1550