### PR TITLE
julia-gc: Repair the `DISABLE_STACK_SCAN` build

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -491,10 +491,14 @@ static NOINLINE void TryMarkRange(jl_ptls_t ptls, void * start, void * end)
     }
 }
 
+#endif // DISABLE_STACK_SCAN
+
 // Julia callback
 static void GapRootScanner(int full)
 {
-    jl_ptls_t   ptls = jl_get_ptls_states();
+    jl_ptls_t ptls = jl_get_ptls_states();
+
+#ifndef DISABLE_STACK_SCAN
     jl_task_t * task = (jl_task_t *)jl_get_current_task();
 
     ScannedRootTask = task;
@@ -522,13 +526,6 @@ static void GapRootScanner(int full)
     }
 #endif
 
-    // Allow installing a custom marking function. This is used for
-    // integrating GAP (possibly linked as a shared library) with other code
-    // bases which use their own form of garbage collection. For example,
-    // with Python (for SageMath).
-    if (ExtraMarkFuncBags)
-        (*ExtraMarkFuncBags)();
-
     // We scan the stack of the current task from the stack pointer
     // towards the stack bottom, ensuring that we also scan any
     // references stored in registers.
@@ -536,6 +533,14 @@ static void GapRootScanner(int full)
     GAP_SETJMP(registers);
     TryMarkRange(ptls, registers, (char *)registers + sizeof(jmp_buf));
     TryMarkRange(ptls, (char *)registers + sizeof(jmp_buf), stackend);
+#endif // DISABLE_STACK_SCAN
+
+    // Allow installing a custom marking function. This is used for
+    // integrating GAP (possibly linked as a shared library) with other code
+    // bases which use their own form of garbage collection. For example,
+    // with Python (for SageMath).
+    if (ExtraMarkFuncBags)
+        (*ExtraMarkFuncBags)();
 
     // mark all global objects
     for (Int i = 0; i < GlobalCount; i++) {
@@ -545,6 +550,8 @@ static void GapRootScanner(int full)
         }
     }
 }
+
+#ifndef DISABLE_STACK_SCAN
 
 // Julia callback
 static void GapTaskScanner(jl_task_t * task, int root_task)
@@ -719,10 +726,12 @@ void GAP_InitJuliaMemoryInterface(jl_module_t *   module,
     jl_init();
 #endif
 
-#ifndef DISABLE_STACK_SCAN
-    // These callbacks potentially require access to the Julia
-    // TLS and thus need to be installed after initialization.
+    // The root scanner also marks GAP's global bags, so it is required
+    // whether or not stacks are scanned conservatively. These callbacks
+    // potentially require access to the Julia TLS and thus need to be
+    // installed after initialization.
     jl_gc_set_cb_root_scanner(GapRootScanner, 1);
+#ifndef DISABLE_STACK_SCAN
     jl_gc_set_cb_task_scanner(GapTaskScanner, 1);
 #endif
     jl_gc_set_cb_pre_gc(PreGCHook, 1);
@@ -775,13 +784,15 @@ void InitBags(UInt initial_size, Bag * stack_bottom)
 {
     TotalTime = 0;
 
-#if !defined(USE_GAP_INSIDE_JULIA) && !defined(DISABLE_STACK_SCAN)
+#if !defined(USE_GAP_INSIDE_JULIA)
     // initialize Julia memory interface. Note that this is only necessary
     // when we run standalone. In contrast, when GAP is loaded from GAP.jl
     // then GAP.jl invokes `GAP_InitJuliaMemoryInterface` at an appropriate
-    // point in time.
+    // point in time. This is needed whether or not we scan stacks
+    // conservatively: it is what starts Julia.
     GAP_InitJuliaMemoryInterface(0, 0);
 
+#ifndef DISABLE_STACK_SCAN
     GapStackBottom = stack_bottom;
 
     // If we are embedding Julia in GAP, remember the root task
@@ -789,6 +800,7 @@ void InitBags(UInt initial_size, Bag * stack_bottom)
     // task is calculated a bit differently than for other tasks.
     if (!IsUsingLibGap())
         RootTaskOfMainThread = (jl_task_t *)jl_get_current_task();
+#endif
 #endif
 }
 

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -491,6 +491,32 @@ static NOINLINE void TryMarkRange(jl_ptls_t ptls, void * start, void * end)
     }
 }
 
+// Julia callback
+static void GapTaskScanner(jl_task_t * task, int root_task)
+{
+    // If this task has been scanned by GapRootScanner() already, skip it
+    if (task == ScannedRootTask)
+        return;
+
+    char *active_start, *active_end, *total_start, *total_end;
+    jl_active_task_stack(task, &active_start, &active_end, &total_start,
+                         &total_end);
+
+    if (active_start) {
+#if !defined(USE_GAP_INSIDE_JULIA)
+        if (task == RootTaskOfMainThread) {
+            active_end = (char *)GapStackBottom;
+        }
+#endif
+        // Unlike the stack of the current task that we scan in
+        // GapRootScanner, we do not know the stack pointer. We
+        // therefore use a separate routine that scans from the
+        // stack bottom until we reach the other end of the stack
+        // or a guard page.
+        ScanTaskStack(task, active_start, active_end);
+    }
+}
+
 #endif // DISABLE_STACK_SCAN
 
 // Julia callback
@@ -550,36 +576,6 @@ static void GapRootScanner(int full)
         }
     }
 }
-
-#ifndef DISABLE_STACK_SCAN
-
-// Julia callback
-static void GapTaskScanner(jl_task_t * task, int root_task)
-{
-    // If this task has been scanned by GapRootScanner() already, skip it
-    if (task == ScannedRootTask)
-        return;
-
-    char *active_start, *active_end, *total_start, *total_end;
-    jl_active_task_stack(task, &active_start, &active_end, &total_start,
-                         &total_end);
-
-    if (active_start) {
-#if !defined(USE_GAP_INSIDE_JULIA)
-        if (task == RootTaskOfMainThread) {
-            active_end = (char *)GapStackBottom;
-        }
-#endif
-        // Unlike the stack of the current task that we scan in
-        // GapRootScanner, we do not know the stack pointer. We
-        // therefore use a separate routine that scans from the
-        // stack bottom until we reach the other end of the stack
-        // or a guard page.
-        ScanTaskStack(task, active_start, active_end);
-    }
-}
-
-#endif // DISABLE_STACK_SCAN
 
 // Time spent in the process, in milliseconds.
 //


### PR DESCRIPTION
That option is meant to turn off conservative stack scanning, but it had come to gate two unrelated things as well, so a build with it defined did not even start.

Starting Julia was conditional on it. `InitBags` calls `GAP_InitJuliaMemoryInterface`, which is what invokes `jl_init`, from a block guarded on stack scanning being enabled. With it disabled the first `NewBag` dereferenced a null current task. Whether GAP starts Julia depends only on whether GAP is the main program, not on how stacks are scanned.

Marking GAP's global bags was conditional on it too. That loop lives in `GapRootScanner`, and the callback was only installed when stack scanning was enabled, so every global root (the symbol table among them) was collected on the first GC. Install the root scanner either way and guard only the stack walk inside it; scanning other tasks' stacks stays conditional, being purely conservative.

With both separated, a `DISABLE_STACK_SCAN` build starts and runs into genuine rooting gaps rather than into this.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>