### PR TITLE
buildsys: improve cross-compiling experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@
 /src/config.h.in
 /src/config.h.in~
 
+# generated files seeded from a native build when cross-compiling
+/src/ffdata.c
+/src/ffdata.h
+/src/c_oper1.c
+/src/c_type1.c
+
 **/__pycache__/
 
 /build/

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -49,6 +49,9 @@ build_cpu = @build_cpu@
 build_os = @build_os@
 build_vendor = @build_vendor@
 
+# whether host and build differ
+cross_compiling = @cross_compiling@
+
 # compile and linker flags
 CFLAGS = @CFLAGS@
 CXXFLAGS = @CXXFLAGS@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -559,9 +559,20 @@ endif
 build/gap-nocomp$(EXEEXT): $(OBJS_NOCOMP) cnf/GAP-LDFLAGS cnf/GAP-LIBS cnf/GAP-OBJS
 	$(QUIET_LINK)$(LINK) $(GAP_LDFLAGS) $(OBJS_NOCOMP) $(GAP_LIBS) -o $@
 
+ifeq ($(cross_compiling),yes)
+# these need just-built programs (gap-nocomp, ffgen), impossible when
+# cross-compiling: seed them from a native build into src/
+cross_seed_error = cannot generate $@ when cross-compiling; build GAP \
+  natively first and copy build/c_oper1.c, build/c_type1.c, \
+  build/ffdata.c and build/ffdata.h from there into this checkout's \
+  src/ directory
+build/c_%.c: $(srcdir)/lib/%.g
+	$(error $(cross_seed_error))
+else
 build/c_%.c: $(srcdir)/lib/%.g build/gap-nocomp$(EXEEXT)
 	@$(MKDIR_P) $(@D)
 	@"$(abs_srcdir)"/cnf/gap-c-gen.sh $< $@ $(basename $(notdir $<)) build/gap-nocomp$(EXEEXT)
+endif
 .PRECIOUS: build/c_%.c
 
 
@@ -572,8 +583,13 @@ build/c_%.c: $(srcdir)/lib/%.g build/gap-nocomp$(EXEEXT)
 ffgen: $(srcdir)/etc/ffgen.c build/config.h
 	$(QUIET_CC)$(CC) -Wall -Wextra $(GAP_CPPFLAGS) $< -o $@
 
+ifeq ($(cross_compiling),yes)
+build/ffdata.h build/ffdata.c:
+	$(error $(cross_seed_error))
+else
 build/ffdata.h build/ffdata.c: ffgen
 	./ffgen -b build/ffdata
+endif
 
 ########################################################################
 # The "tags" target regenerates the tags file using Exuberant Ctags

--- a/cnf/build-extern.sh
+++ b/cnf/build-extern.sh
@@ -11,6 +11,20 @@ echo "=== START building $pkg ==="
 pkg=$1; shift
 src=$1; shift # directory with package sources -- must be an absolute path
 
+# the test programs cannot run when cross-compiling (--build differs from --host)
+build_triple=
+host_triple=
+for arg in "$@"; do
+  case "$arg" in
+    --build=*) build_triple=${arg#--build=} ;;
+    --host=*)  host_triple=${arg#--host=} ;;
+  esac
+done
+skip_check=no
+if [[ -n "$host_triple" && "$host_triple" != "$build_triple" ]]; then
+  skip_check=yes
+fi
+
 builddir=extern/build/$pkg
 prefix="$PWD/extern/install/$pkg"
 
@@ -26,7 +40,9 @@ if [[ ( ! "$builddir/config.status" -nt "$src/configure" )
 fi
 
 $MAKE -C "$builddir"
-if ! $MAKE -C "$builddir" check; then
+if [[ "$skip_check" = yes ]]; then
+  echo "=== SKIPPING check for $pkg (cross-compiling) ==="
+elif ! $MAKE -C "$builddir" check; then
   echo "=== FAILED checking $pkg ==="
   echo "The copy of $pkg distributed with GAP has failed to pass its internal checks"
   echo "You can either install the library from a different source, or use"

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,9 @@ dnl Get canonical host information
 dnl
 AC_CANONICAL_HOST
 
+dnl for Makefile.rules: generated files cannot be built when cross-compiling
+AC_SUBST([cross_compiling])
+
 
 dnl
 dnl Check for working C and C++ compiler; insist on C99 and C++11 support


### PR DESCRIPTION
`ffgen` and `gap-nocomp` (generating `c_oper1.c`/`c_type1.c`) cannot run when cross-compiling. Fail with an explanation: seed the generated files from a native build into src/, as the s390x CI job does. Skip 'make check' for the bundled GMP and zlib, whose test programs cannot run either.

So this does not actually make it much easier to cross compiler, but it does help porters to discover the mechanism (which is also documented in `README.buildsys.md`), which I think is a win nevertheless.

Extracted from PR #6557.

This pull request was written with the assistance of generative AI (Claude Code).