### PR TITLE
Fix SyTime unit under Emscripten

### DIFF
--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -79,7 +79,7 @@ UInt SyTime(void)
     // for some period of time. Use NanosecondsSinceEpoch() as
     // a substitute (it is not perfect, as NanosecondsSinceEpoch()
     // is walltime, while RUSAGE_SELF is CPU time).
-    return SyNanosecondsSinceEpoch()/1000000000;
+    return SyNanosecondsSinceEpoch() / 1000000;
 #else
     struct rusage buf;
 


### PR DESCRIPTION
SyTime is documented in milliseconds; the Emscripten substitute divided nanoseconds by 10^9, so Runtime() reported seconds there.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>