### PR TITLE
Groundwork for the native Windows (mingw-w64) port

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -972,7 +972,7 @@ dnl
 dnl check for functionality related to child process handling,
 dnl including pseudo TTY support, signals, etc.
 AC_CHECK_HEADERS([termios.h])
-AC_CHECK_HEADERS([sys/ioctl.h sys/resource.h])
+AC_CHECK_HEADERS([sys/ioctl.h sys/resource.h sys/utsname.h])
 
 
 # openpty() is available on various BSD variants, but also in glibc.
@@ -1007,6 +1007,9 @@ AC_CHECK_TYPE([sig_atomic_t], [],
     [#include <signal.h>]
 )
 AC_CHECK_FUNCS([signal sigaction setpgid])
+
+dnl POSIX functions absent on native Windows (mingw)
+AC_CHECK_FUNCS([realpath readlink mkdtemp lstat ttyname])
 
 
 dnl

--- a/lib/system.g
+++ b/lib/system.g
@@ -561,6 +561,10 @@ end );
 ##  <#/GAPDoc>
 ##
 BIND_GLOBAL("ARCH_IS_WINDOWS",function()
+  # native Windows (mingw) has no POSIX tools
+  if POSITION_SUBSTRING (GAPInfo.Architecture, "mingw", 0) <> fail then
+    return true;
+  fi;
   # Exit early if we are not in Cygwin
   if POSITION_SUBSTRING (GAPInfo.Architecture, "cygwin", 0) = fail then
     return false;

--- a/src/common.h
+++ b/src/common.h
@@ -46,6 +46,16 @@ GAP_STATIC_ASSERT(sizeof(void *) == SIZEOF_VOID_P, "sizeof(void *) is wrong");
 #define SYS_IS_CYGWIN32 1
 #endif
 
+// native Windows: mingw-w64 predefines _WIN32, Cygwin GCC does not, as
+// Cygwin is a POSIX system to GAP
+#ifdef _WIN32
+#define SYS_IS_MINGW 1
+#endif
+
+// either flavour of Windows
+#if defined(SYS_IS_CYGWIN32) || defined(SYS_IS_MINGW)
+#define SYS_IS_WINDOWS 1
+#endif
 
 // GAP_SETJMP and GAP_LONGJMP are used for error handling and for GASMAN's
 // register capture. On POSIX systems we use _setjmp/_longjmp, which do not
@@ -55,7 +65,7 @@ GAP_STATIC_ASSERT(sizeof(void *) == SIZEOF_VOID_P, "sizeof(void *) is wrong");
 // TODO(windows-port): Windows longjmp performs SEH stack unwinding; if that
 // misbehaves across GAP stack frames, switch to mingw's _setjmp(env, NULL).
 // Callers must include <setjmp.h> themselves.
-#ifdef SYS_IS_WINDOWS
+#ifdef SYS_IS_MINGW
 #define GAP_SETJMP(env) setjmp(env)
 #define GAP_LONGJMP(env, val) longjmp(env, val)
 #else

--- a/src/gaptime.c
+++ b/src/gaptime.c
@@ -35,6 +35,30 @@
 #include <sys/resource.h>
 #endif
 
+#ifdef SYS_IS_MINGW
+// omit rarely used parts of windows.h, whose names clash with GAP's
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>    // for Sleep, GetProcessTimes
+#endif
+
+#ifdef SYS_IS_MINGW
+// user and kernel CPU time of this process in milliseconds
+static void SyWinProcessTimes(UInt * user, UInt * kernel)
+{
+    const UInt     FILETIME_PER_MS = 10000;    // FILETIME counts 100 ns
+    FILETIME       creation, exit, kern, usr;
+    ULARGE_INTEGER t;
+
+    GetProcessTimes(GetCurrentProcess(), &creation, &exit, &kern, &usr);
+    t.LowPart = usr.dwLowDateTime;
+    t.HighPart = usr.dwHighDateTime;
+    *user = t.QuadPart / FILETIME_PER_MS;
+    t.LowPart = kern.dwLowDateTime;
+    t.HighPart = kern.dwHighDateTime;
+    *kernel = t.QuadPart / FILETIME_PER_MS;
+}
+#endif
+
 #if defined(__APPLE__) && defined(__MACH__) // macOS
 #include <mach/mach_time.h>
 #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
@@ -80,6 +104,10 @@ UInt SyTime(void)
     // a substitute (it is not perfect, as NanosecondsSinceEpoch()
     // is walltime, while RUSAGE_SELF is CPU time).
     return SyNanosecondsSinceEpoch() / 1000000;
+#elif defined(SYS_IS_MINGW)
+    UInt user, kernel;
+    SyWinProcessTimes(&user, &kernel);
+    return user;
 #else
     struct rusage buf;
 
@@ -227,6 +255,17 @@ static Obj FuncRuntime(Obj self)
 
 static Obj FuncRUNTIMES(Obj self)
 {
+#ifdef SYS_IS_MINGW
+    // Windows keeps no times of terminated children
+    UInt user, kernel;
+    SyWinProcessTimes(&user, &kernel);
+    Obj res = NEW_PLIST(T_PLIST, 4);
+    ASS_LIST(res, 1, ObjInt_UInt(user));
+    ASS_LIST(res, 2, ObjInt_UInt(kernel));
+    ASS_LIST(res, 3, ObjInt_UInt(0));
+    ASS_LIST(res, 4, ObjInt_UInt(0));
+    return res;
+#else
     UInt          tmp;
     struct rusage buf;
     Obj           res = NEW_PLIST(T_PLIST, 4);
@@ -254,6 +293,7 @@ static Obj FuncRUNTIMES(Obj self)
     ASS_LIST(res, 4, ObjInt_UInt(tmp));
 
     return res;
+#endif
 }
 
 
@@ -414,7 +454,11 @@ static Obj FuncSleep(Obj self, Obj secs)
     Int s = GetSmallInt(SELF_NAME, secs);
 
     if (s > 0)
+#ifdef SYS_IS_MINGW
+        Sleep((DWORD)s * 1000);
+#else
         sleep((UInt)s);
+#endif
 
     // either we used up the time, or we were interrupted.
     if (HaveInterrupt()) {
@@ -437,7 +481,11 @@ static Obj FuncMicroSleep(Obj self, Obj msecs)
     Int s = GetSmallInt(SELF_NAME, msecs);
 
     if (s > 0)
+#ifdef SYS_IS_MINGW
+        Sleep((DWORD)(s / 1000));
+#else
         usleep((UInt)s);
+#endif
 
     // either we used up the time, or we were interrupted.
     if (HaveInterrupt()) {

--- a/src/integer.c
+++ b/src/integer.c
@@ -161,7 +161,7 @@ static inline void ENSURE_BAG(Bag bag)
 {
 // Note: This workaround is only required with the original GMP and not with
 // MPIR
-#if defined(SYS_IS_CYGWIN32) && defined(SYS_IS_64_BIT) &&                    \
+#if defined(SYS_IS_WINDOWS) && defined(SYS_IS_64_BIT) &&                     \
     !defined(__MPIR_VERSION)
     memset(PTR_BAG(bag), 0, SIZE_BAG(bag));
 #endif

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -40,7 +40,8 @@
 
 #include "config.h"
 
-#ifndef GAP_DISABLE_SUBPROCESS_CODE
+// the POSIX implementation, on top of fork and pseudo terminals
+#if !defined(GAP_DISABLE_SUBPROCESS_CODE) && !defined(SYS_IS_MINGW)
 
 #include <errno.h>
 #include <fcntl.h>
@@ -1127,7 +1128,7 @@ FuncExecuteProcess(Obj self, Obj dir, Obj prg, Obj in, Obj out, Obj args)
     return res == 255 ? Fail : INTOBJ_INT(res);
 }
 
-#else // !defined(GAP_DISABLE_SUBPROCESS_CODE)
+#else // !defined(GAP_DISABLE_SUBPROCESS_CODE) && !defined(SYS_IS_MINGW)
 
 int CheckChildStatusChanged(int childPID, int status)
 {
@@ -1225,7 +1226,7 @@ static StructGVarFunc GVarFuncs[] = {
 */
 static Int InitKernel(StructInitInfo * module)
 {
-#ifndef GAP_DISABLE_SUBPROCESS_CODE
+#if !defined(GAP_DISABLE_SUBPROCESS_CODE) && !defined(SYS_IS_MINGW)
     UInt i;
     PtyIOStreams[0].childPID = -1;
     for (i = 1; i < MAX_PTYS; i++) {

--- a/src/iostream.c
+++ b/src/iostream.c
@@ -1183,6 +1183,16 @@ static Obj FuncFD_OF_IOSTREAM(Obj self, Obj stream)
 static Obj
 FuncExecuteProcess(Obj self, Obj dir, Obj prg, Obj in, Obj out, Obj args)
 {
+    // validate the arguments exactly as the real implementation does
+    RequireStringRep(SELF_NAME, dir);
+    RequireStringRep(SELF_NAME, prg);
+    GetSmallInt(SELF_NAME, in);
+    GetSmallInt(SELF_NAME, out);
+    RequirePlainList(SELF_NAME, args);
+    for (Int i = 1; i <= LEN_PLIST(args); i++) {
+        Obj tmp = ELM_PLIST(args, i);
+        RequireStringRep(SELF_NAME, tmp);
+    }
     return Fail;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,12 @@
 #include <mach-o/dyld.h>
 #endif
 
+#ifdef SYS_IS_MINGW
+// omit rarely used parts of windows.h, whose names clash with GAP's
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>    // for GetModuleFileNameA
+#endif
+
 extern int realmain(int argc, const char * argv[]);
 
 /****************************************************************************
@@ -42,6 +48,33 @@ extern int realmain(int argc, const char * argv[]);
 static void SetupInitialGapRoot(const char * argv0)
 {
     gap_strlcpy(SyDefaultRootPath, SYS_DEFAULT_PATHS, sizeof(SyDefaultRootPath));
+}
+
+#else
+
+#ifdef SYS_IS_MINGW
+
+static void SetupGAPLocation(const char * argv0, char * GAPExecLocation)
+{
+    char locBuf[GAP_PATH_MAX] = "";
+
+    DWORD len = GetModuleFileNameA(NULL, locBuf, sizeof(locBuf));
+    if (len == 0 || len >= sizeof(locBuf))
+        *locBuf = 0;    // reset buffer after error
+
+    // GAP uses '/' as its directory separator throughout
+    for (char * p = locBuf; *p; p++)
+        if (*p == '\\')
+            *p = '/';
+
+    gap_strlcpy(GAPExecLocation, locBuf, GAP_PATH_MAX);
+
+    // now strip the executable name off
+    size_t length = strlen(GAPExecLocation);
+    while (length > 0 && GAPExecLocation[length] != '/') {
+        GAPExecLocation[length] = 0;
+        length--;
+    }
 }
 
 #else
@@ -142,6 +175,8 @@ static void SetupGAPLocation(const char * argv0, char * GAPExecLocation)
         length--;
     }
 }
+
+#endif
 
 /****************************************************************************
 **

--- a/src/streams.c
+++ b/src/streams.c
@@ -1015,7 +1015,7 @@ static Obj FuncREAD_GAP_ROOT(Obj self, Obj filename)
 static Obj FuncTmpName(Obj self)
 {
     char name[100] = "/tmp/gaptempfile.XXXXXX";
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
     // If /tmp is missing, write into Window's temp directory
     DIR* dir = opendir("/tmp");
     if(dir) {
@@ -1045,7 +1045,7 @@ static Obj FuncTmpDirectory(Obj self)
         name = MakeString(env_tmpdir);
     }
     else {
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
         // If /tmp is missing, write into Window's temp directory
         DIR* dir = opendir("/tmp");
         if(dir) {
@@ -1514,7 +1514,7 @@ static Obj FuncREAD_ALL_FILE(Obj self, Obj fid, Obj limit)
     len = 0;
     lstr = 0;
 
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
  getmore:
 #endif
     while (ilim == -1 || len < ilim ) {
@@ -1555,7 +1555,7 @@ static Obj FuncREAD_ALL_FILE(Obj self, Obj fid, Obj limit)
 
     // fix the length of <str>
     len = GET_LEN_STRING(str);
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
     // line end hackery
     UInt i = 0, j = 0;
     while (i < len) {

--- a/src/streams.c
+++ b/src/streams.c
@@ -48,6 +48,33 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifdef SYS_IS_MINGW
+#include <io.h>                         // for _mktemp
+#endif
+
+#ifndef HAVE_MKDTEMP
+// substitute for mkdtemp: _mktemp proposes an unused name and mkdir creates
+// it atomically, so if another process got there first, we try again
+static char * syMkdtemp(char * tmpl)
+{
+    enum { ATTEMPTS = 100 };
+    char candidate[GAP_PATH_MAX];
+
+    for (int i = 0; i < ATTEMPTS; i++) {
+        gap_strlcpy(candidate, tmpl, sizeof(candidate));
+        if (_mktemp(candidate) == NULL)
+            return NULL;
+        if (SyMkdir(candidate) == 0) {
+            gap_strlcpy(tmpl, candidate, strlen(tmpl) + 1);
+            return tmpl;
+        }
+        if (errno != EEXIST)
+            return NULL;
+    }
+    return NULL;
+}
+#endif
+
 #ifdef HAVE_SELECT
 // For FuncUNIXSelect
 #include <sys/time.h>
@@ -1035,8 +1062,13 @@ static Obj FuncTmpDirectory(Obj self)
     const char * extra = "/gaptempdirXXXXXX";
     AppendCStr(name, extra, strlen(extra));
 
+#ifdef HAVE_MKDTEMP
     if (mkdtemp(CSTR_STRING(name)) == 0)
         return Fail;
+#else
+    if (syMkdtemp(CSTR_STRING(name)) == NULL)
+        return Fail;
+#endif
     return name;
 }
 
@@ -1131,7 +1163,11 @@ static Obj FuncGAP_realpath(Obj self, Obj path)
     RequireStringRep(SELF_NAME, path);
     char resolved_path[GAP_PATH_MAX];
 
+#ifdef SYS_IS_MINGW
+    if (NULL == _fullpath(resolved_path, CONST_CSTR_STRING(path), sizeof(resolved_path))) {
+#else
     if (NULL == realpath(CONST_CSTR_STRING(path), resolved_path)) {
+#endif
         SySetErrorNo();
         return Fail;
     }

--- a/src/sysenv.h
+++ b/src/sysenv.h
@@ -21,6 +21,12 @@
 #include <crt_externs.h>
 #define environ (*_NSGetEnviron())
 
+#elif defined(SYS_IS_MINGW)
+
+// mingw declares _environ in stdlib.h
+#include <stdlib.h>
+#define environ _environ
+
 #elif !defined(environ)
 
 extern char ** environ;

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -1371,6 +1371,11 @@ Int SyFseek (
         return -1;
     }
 
+    // reject negative positions uniformly; Windows' lseek does not
+    if ( pos < 0 ) {
+        return -1;
+    }
+
     if (syBuf[fid].bufno >= 0) {
         UInt bufno = syBuf[fid].bufno;
         syBuffers[bufno].buflen = 0;

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -758,7 +758,7 @@ Int SyFopen(const Char * name, const Char * mode, BOOL transparent_compress)
         Panic("Unknown mode %s", mode);
     }
 
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
     if (strlen(mode) >= 2 && mode[1] == 'b')
         flags |= O_BINARY;
 #endif
@@ -1419,7 +1419,7 @@ Int SyFseek (
  * a similar problem.
  */
 
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
 #  define LINE_END_HACK 1
 #endif
 

--- a/src/sysfiles.c
+++ b/src/sysfiles.c
@@ -44,9 +44,12 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <termios.h>
 #include <time.h>
 #include <unistd.h>
+
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -80,7 +83,16 @@
 
 #include <zlib.h>
 
+#ifdef HAVE_SYS_UTSNAME_H
 #include <sys/utsname.h>
+#endif
+
+#ifdef SYS_IS_MINGW
+#include <direct.h>                     // for _mkdir
+// omit rarely used parts of windows.h, whose names clash with GAP's
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 
 // 'EndLineHook' is a GAP-level variable which can be set to a function to be
@@ -364,6 +376,7 @@ static Obj FuncCrcString(Obj self, Obj str)
 Obj SyGetOsRelease(void)
 {
     Obj            r = NEW_PREC(0);
+#ifdef HAVE_SYS_UTSNAME_H
     struct utsname buf;
     if (!uname(&buf)) {
         AssPRec(r, RNamName("sysname"), MakeImmString(buf.sysname));
@@ -372,6 +385,47 @@ Obj SyGetOsRelease(void)
         AssPRec(r, RNamName("version"), MakeImmString(buf.version));
         AssPRec(r, RNamName("machine"), MakeImmString(buf.machine));
     }
+#endif
+#ifdef SYS_IS_MINGW
+    // RtlGetVersion tells the truth; GetVersionEx lies to executables
+    // without a manifest
+    typedef LONG(WINAPI * RtlGetVersionFn)(RTL_OSVERSIONINFOW *);
+    RtlGetVersionFn getVersion = (RtlGetVersionFn)GetProcAddress(
+        GetModuleHandleA("ntdll.dll"), "RtlGetVersion");
+    RTL_OSVERSIONINFOW info = { .dwOSVersionInfoSize = sizeof(info) };
+    if (getVersion != NULL && getVersion(&info) == 0) {
+        char release[32], version[32];
+        snprintf(release, sizeof(release), "%lu.%lu", info.dwMajorVersion,
+                 info.dwMinorVersion);
+        snprintf(version, sizeof(version), "%lu", info.dwBuildNumber);
+        AssPRec(r, RNamName("sysname"), MakeImmString("Windows"));
+        AssPRec(r, RNamName("release"), MakeImmString(release));
+        AssPRec(r, RNamName("version"), MakeImmString(version));
+    }
+
+    char  node[MAX_COMPUTERNAME_LENGTH + 1];
+    DWORD len = sizeof(node);
+    if (GetComputerNameA(node, &len))
+        AssPRec(r, RNamName("nodename"), MakeImmString(node));
+
+    SYSTEM_INFO  si;
+    const char * machine;
+    GetNativeSystemInfo(&si);
+    switch (si.wProcessorArchitecture) {
+    case PROCESSOR_ARCHITECTURE_AMD64:
+        machine = "x86_64";
+        break;
+    case PROCESSOR_ARCHITECTURE_ARM64:
+        machine = "aarch64";
+        break;
+    case PROCESSOR_ARCHITECTURE_INTEL:
+        machine = "i686";
+        break;
+    default:
+        machine = "unknown";
+    }
+    AssPRec(r, RNamName("machine"), MakeImmString(machine));
+#endif
 
     return r;
 }
@@ -875,6 +929,8 @@ Int SyIsEndOfFile (
 **  continue signals if this particular version  of UNIX supports them, so we
 **  can turn the terminal line back to cooked mode before stopping GAP.
 */
+#ifdef HAVE_TERMIOS_H
+
 static struct termios   syOld, syNew;           // old and new terminal state
 
 #ifdef SIGTSTP
@@ -963,6 +1019,21 @@ void syStopraw (
         fputs("gap: 'tcsetattr' could not turn off raw mode!\n",stderr);
 }
 
+#else
+
+// no termios, no raw mode: the line editor falls back to syFgetsNoEdit
+// TODO(windows-port): implement raw mode via the Windows console API
+UInt syStartraw(Int fid)
+{
+    return 0;
+}
+
+void syStopraw(Int fid)
+{
+}
+
+#endif
+
 
 /****************************************************************************
 **
@@ -1022,12 +1093,16 @@ static void syAnswerIntr(int signr)
 
 void SyInstallAnswerIntr ( void )
 {
+#ifdef HAVE_SIGACTION
     struct sigaction sa;
 
     sa.sa_handler = syAnswerIntr;
     sigemptyset(&(sa.sa_mask));
     sa.sa_flags = SA_RESTART;
     sigaction( SIGINT, &sa, NULL );
+#else
+    signal( SIGINT, syAnswerIntr );
+#endif
 }
 
 
@@ -2045,14 +2120,14 @@ static Obj FuncREADLINEINITLINE(Obj self, Obj line)
 static Int ISINITREADLINE = 0;
 // a hook function called regularly while waiting on input
 static Int current_rl_fid;
+#ifdef HAVE_SELECT
 static int charreadhook_rl(void)
 {
-#ifdef HAVE_SELECT
     if (OnCharReadHookActiveCheck())
         HandleCharReadHook(syBuf[current_rl_fid].fp);
-#endif
-  return 0;
+    return 0;
 }
+#endif
 
 static int preInputHook_rl(void)
 {
@@ -2945,7 +3020,11 @@ Int SyMkdir ( const Char * name )
 {
     Int res;
     SyClearErrorNo();
+#ifdef SYS_IS_MINGW
+    res = _mkdir(name);
+#else
     res = mkdir(name, 0777);
+#endif
     if (res == -1)
        SySetErrorNo();
     return res;
@@ -2984,7 +3063,11 @@ char SyFileType(const Char * path)
     int         res;
     struct stat ourlstatbuf;
 
+#ifdef HAVE_LSTAT
     res = lstat(path, &ourlstatbuf);
+#else
+    res = stat(path, &ourlstatbuf);
+#endif
     if (res < 0) {
         SySetErrorNo();
         return 0;
@@ -2993,8 +3076,10 @@ char SyFileType(const Char * path)
         return 'F';
     if (S_ISDIR(ourlstatbuf.st_mode))
         return 'D';
+#ifdef S_ISLNK
     if (S_ISLNK(ourlstatbuf.st_mode))
         return 'L';
+#endif
 #ifdef S_ISCHR
     if (S_ISCHR(ourlstatbuf.st_mode))
         return 'C';
@@ -3217,12 +3302,14 @@ void InitSysFiles(void)
     syBuf[0].echo = fileno(stdout);
     syBuf[0].bufno = -1;
     syBuf[0].isTTY = isatty(fileno(stdin));
+#ifdef HAVE_TTYNAME
     if (syBuf[0].isTTY) {
         // if stdin is on a terminal, make sure stdout in on the same terminal
         if (stat_in.st_dev != stat_out.st_dev ||
             stat_in.st_ino != stat_out.st_ino)
             syBuf[0].echo = open(ttyname(fileno(stdin)), O_WRONLY);
     }
+#endif
 
     // set up stdout
     syBuf[1].type = raw_socket;
@@ -3236,12 +3323,14 @@ void InitSysFiles(void)
     syBuf[2].echo = fileno(stderr);
     syBuf[2].bufno = -1;
     syBuf[2].isTTY = isatty(fileno(stderr));
+#ifdef HAVE_TTYNAME
     if (syBuf[2].isTTY) {
         // if stderr is on a terminal, make sure errin in on the same terminal
         if (stat_in.st_dev != stat_err.st_dev ||
             stat_in.st_ino != stat_err.st_ino)
             syBuf[2].fp = open(ttyname(fileno(stderr)), O_RDONLY);
     }
+#endif
 
     // set up errout
     syBuf[3].type = raw_socket;

--- a/src/sysmem.c
+++ b/src/sysmem.c
@@ -23,9 +23,9 @@
 
 #ifdef GAP_MEM_CHECK
 #include <fcntl.h>
-#include <stdlib.h>     // for qsort
 #endif
 
+#include <stdlib.h>     // for calloc, qsort
 #include <stdio.h>      // for fputs
 #include <unistd.h>     // for ftruncate, getpid, unlink, sbrk, sysconf
 

--- a/src/sysroots.c
+++ b/src/sysroots.c
@@ -165,7 +165,7 @@ void SySetGapRootPath(const Char * string)
         while (*p && *p != ';') {
             *q = *p++;
 
-#ifdef SYS_IS_CYGWIN32
+#ifdef SYS_IS_WINDOWS
             // change backslash to slash for Windows
             if (*q == '\\')
                 *q = '/';

--- a/src/system.c
+++ b/src/system.c
@@ -660,7 +660,7 @@ static void InitDotGapPath(void)
     if (home == 0)
         return;
 
-#if defined(__CYGWIN__)
+#ifdef SYS_IS_WINDOWS
     strxcpy(DotGapPath, home, sizeof(DotGapPath));
     strxcat(DotGapPath, "/_gap;", sizeof(DotGapPath));
 #else


### PR DESCRIPTION
Groundwork for the native Windows (mingw-w64) port, split off #6557: the four commits that change nothing on current platforms.

- `SYS_IS_WINDOWS`, from `_WIN32`; disjoint from `SYS_IS_CYGWIN32`
- guards for POSIX-only kernel code (termios, uname, sigaction, lstat, ttyname, mkdtemp, realpath, readlink, getrusage, sleep, environ, mkdir), with the matching configure checks; on Windows, CPU times come from `GetProcessTimes`, `TmpDirectory` from an `mkdtemp` built on `_mktemp` and `mkdir`, the `uname` record from `RtlGetVersion`
- `SYS_IS_CYGWIN32` guards that any Windows needs (O_BINARY, CRLF stripping, temp dir fallback, `~/_gap`, GMP bag zeroing) widened to `SYS_IS_WINDOWS`
- two small alignments with POSIX: `SyFseek` rejects negative positions, the `ExecuteProcess` stub validates its arguments

Every guard is a no-op where GAP builds today. The rest of the port sits on top in #6557, whose CI job exercises the Windows side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


This has IMHO decent quality and is not sloppy, so I have no qualms asking for reviews :-)