### PR TITLE
Add `Extensions( G, map )` where `map` is a group homomorphism to a matrix group

### DIFF
--- a/doc/ref/groups.xml
+++ b/doc/ref/groups.xml
@@ -598,11 +598,13 @@ see <Cite Key="BJR87"/>.
 <Section Label="2-Cohomology">
 <Heading>2-Cohomology</Heading>
 
+The functions in this section describe generic operations and methods.
+See Section <Ref Sect="2-Cohomology and Extensions"/> for operations and
+methods specific for Pc groups.
+
 <#Include Label="TwoCohomologyGeneric">
 <#Include Label="FpGroupCocycle">
-
-Also see Section <Ref Sect="2-Cohomology and Extensions"/> for operations and
-methods specific for Pc groups.
+<#Include Label="Extensions_from_map">
 
 </Section>
 

--- a/doc/ref/grppc.xml
+++ b/doc/ref/grppc.xml
@@ -429,7 +429,7 @@ arbitrary finite groups.
 
 <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 <Section Label="2-Cohomology and Extensions">
-<Heading><M>2</M>-Cohomology and Extensions</Heading>
+<Heading><M>2</M>-Cohomology and Extensions for Pc Groups</Heading>
 
 One of the most interesting applications of pc groups is the possibility
 to compute with extensions of these groups by elementary abelian groups;

--- a/lib/grppcext.gd
+++ b/lib/grppcext.gd
@@ -174,8 +174,31 @@ DeclareOperation( "ExtensionNC", [ CanEasilyComputePcgs, IsObject, IsVector ] );
 ##  <Oper Name="Extensions" Arg='G, M'/>
 ##
 ##  <Description>
-##  returns all extensions of <A>G</A> by the <A>G</A>-module <A>M</A>
+##  For a group <M>G</M> in the filter <Ref Filt="CanEasilyComputePcgs"/>
+##  and a <A>G</A>-module <A>M</A>,
+##  <Ref Oper="Extensions"/> returns all extensions of <A>G</A> by <A>M</A>
 ##  up to equivalence as pc groups.
+##  <P/>
+##  Mapping <C>Pcgs( <A>G</A> )</C> to the <C>generators</C> list of <A>M</A>
+##  must define a group homomorphism.
+##  If one is not sure about this correspondence,
+##  one can use the variant that takes a homomorphism as the second argument,
+##  see <Ref Oper="Extensions" Label="for group and map"/>.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> G := SmallGroup( 4, 2 );;
+##  gap> mats := List( Pcgs( G ), x -> IdentityMat( 1, GF(2) ) );;
+##  gap> M := GModuleByMats( mats, GF(2) );;
+##  gap> Extensions( G, M );
+##  [ <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators>,
+##    <pc group of size 8 with 3 generators> ]
+##  ]]></Example>
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>

--- a/lib/grppcext.gi
+++ b/lib/grppcext.gi
@@ -322,12 +322,7 @@ end);
 ##
 #M  Extensions( G, M )
 ##
-InstallMethod( Extensions,
-    "generic method for pc groups",
-    true,
-    [ CanEasilyComputePcgs, IsObject],
-    0,
-function( G, M )
+BindGlobal( "ExtensionsWRTPcgs", function( G, M )
     local C, ext, co, cc, c, i;
 
     C := CollectorSQ( G, M, false );
@@ -345,6 +340,44 @@ function( G, M )
         Add( ext, ExtensionSQ( C, G, M, c ) );
     od;
     return ext;
+end );
+
+InstallMethod( Extensions,
+    "generic method for pc groups",
+    [ CanEasilyComputePcgs, IsObject],
+    ExtensionsWRTPcgs );
+
+#############################################################################
+##
+#M  Extensions( G, map )
+##
+InstallMethod( Extensions,
+  "for a finite group and a mapping",
+  [ IsGroup and IsFinite, IsMapping ],
+function( G, map )
+  local matgrp, F, M;
+
+  matgrp:= Range( map );
+  if not IsMatrixGroup( matgrp ) then
+    Error( "range of <map> must be a matrix group over a finite prime field" );
+  fi;
+  F:= FieldOfMatrixGroup( matgrp );
+  if not ( IsFinite( F ) and IsPrimeField( F ) ) then
+    Error( "range of <map> must be a matrix group over a finite prime field" );
+  fi;
+  if CanEasilyComputePcgs( G ) then
+    # We will call the method from 'grppcext.gi',
+    # the generators of the module correspond to 'Pcgs( G )'.
+    M:= GModuleByMats( List( Pcgs( G ),
+                             x -> ImagesRepresentative( map, x ) ), F );
+    return ExtensionsWRTPcgs( G, M );
+  else
+    # We will call the method from 'twocohom.gi',
+    # the generators of the module correspond to 'GeneratorsOfGroup( G )'.
+    M:= GModuleByMats( List( GeneratorsOfGroup( G ),
+                             x -> ImagesRepresentative( map, x ) ), F );
+    return ExtensionsWRTGenerators( G, M );
+  fi;
 end );
 
 InstallGlobalFunction(EXPermutationActionPairs,function(D)

--- a/lib/twocohom.gd
+++ b/lib/twocohom.gd
@@ -307,6 +307,50 @@ DeclareOperation( "TwoCohomologyGeneric", [ IsGroup, IsObject ] );
 ##
 DeclareGlobalFunction("FpGroupCocycle");
 
+
+#############################################################################
+##
+#O  Extensions( <G>, <map> )
+##
+##  <#GAPDoc Label="Extensions_from_map">
+##  <ManSection>
+##  <Oper Name="Extensions" Arg='G, map' Label="for group and map"/>
+##
+##  <Description>
+##  For a finite group <A>G</A> and a group homomorphism <A>map</A>
+##  whose <Ref Attr="Source"/> is a group containing <A>G</A> and
+##  whose <Ref Attr="Range" Label="of a general mapping"/>
+##  is a matrix group over a finite prime field,
+##  <Ref Oper="Extensions" Label="for group and map"/> returns
+##  all extensions of <A>G</A> by the <A>G</A>-module defined by <A>map</A>,
+##  up to equivalence.
+##  <P/>
+##  The result is a list of pc groups if <A>G</A> is a pc group,
+##  it is a list of finitely presented groups if <A>G</A> is nonsolvable,
+##  and it is one of these two possibilities otherwise.
+##  <P/>
+##  <Example><![CDATA[
+##  gap> G:= ElementaryAbelianGroup( 4 );;
+##  gap> gens:= GeneratorsOfGroup( G );;
+##  gap> gl:= GL(1, 2);;
+##  gap> map:= GroupHomomorphismByImages( G, gl,
+##  >              gens, List( gens, x -> One( gl ) ) );;
+##  gap> Length( Extensions( G, map ) );
+##  8
+##  gap> G:= AlternatingGroup( 5 );;
+##  gap> gens:= GeneratorsOfGroup( G );;
+##  gap> map:= GroupHomomorphismByImages( G, gl,
+##  >              gens, List( gens, x -> One( gl ) ) );;
+##  gap> Length( Extensions( G, map ) );
+##  2
+##  ]]></Example>
+##  </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+DeclareOperation( "Extensions", [ IsGroup, IsMapping ] );
+
+
 #############################################################################
 ##
 #O  CompatiblePairOrbitRepsGeneric( <compair>,<coh> )

--- a/lib/twocohom.gi
+++ b/lib/twocohom.gi
@@ -2048,15 +2048,22 @@ end);
 ##
 #M  Extensions( G, M )
 ##
-InstallOtherMethod(Extensions,"generic method for finite groups",
-    true,[IsGroup and IsFinite,IsObject],
-    -RankFilter(IsGroup and IsFinite),
-function(G,M)
+##  undocumented, not safe because the documented method for pc groups
+##  with the same input assumes that 'M.generators' corresponds to
+##  'Pcgs( G )' not to 'GeneratorsOfGroup( G )'
+##
+BindGlobal( "ExtensionsWRTGenerators", function( G, M )
 local coh;
+
   coh:=TwoCohomologyGeneric(G,M);
   return List(Elements(VectorSpace(coh.module.field,coh.cohomology,coh.zero)),
     x->FpGroupCocycle(coh,x,true:normalform));
 end);
+
+InstallOtherMethod(Extensions,"generic method for finite groups",
+    true,[IsGroup and IsFinite,IsObject],
+    -RankFilter(IsGroup and IsFinite),
+    ExtensionsWRTGenerators );
 
 InstallOtherMethod(ExtensionRepresentatives,"generic method for finite groups",
   true,[IsGroup and IsFinite,IsObject,IsGroup],
@@ -2067,4 +2074,3 @@ local coh;
   return List(CompatiblePairOrbitRepsGeneric(P,coh),
     x->FpGroupCocycle(coh,x,true:normalform));
 end);
-

--- a/tst/teststandard/twocohom.tst
+++ b/tst/teststandard/twocohom.tst
@@ -1,4 +1,7 @@
+#@local g, mo, coh, comp, reps, h, a, pos, gp, p, G, mods, M, mats, map, cp
 gap> START_TEST("twocohom.tst");
+
+#
 gap> g:=PerfectGroup(IsPermGroup,1344,1);;
 gap> mo:=IrreducibleModules(g,GF(2),1);;List(mo[2],x->x.dimension);
 [ 1 ]
@@ -47,17 +50,64 @@ gap> ConfluentMonoidPresentationForGroup(p);;
 gap> Length(ConjugacyClasses(p));
 119
 
+# Extensions for given group homomorphism
+gap> G:= DihedralGroup( 6 );;
+gap> Extensions( G, IdentityMapping( G ) );
+Error, range of <map> must be a matrix group over a finite prime field
+gap> G:= GL(2, 4);;
+gap> Extensions( G, IdentityMapping( G ) );
+Error, range of <map> must be a matrix group over a finite prime field
+gap> G:= GL(2, 2);;
+gap> Length( Extensions( G, IdentityMapping( G ) ) );
+1
+gap> G:= DihedralGroup( 6 );  # pc group
+<pc group of size 6 with 2 generators>
+gap> mods:= IrreducibleModules( G, GF(2) );;
+gap> M:= First( mods[2], x -> x.dimension = 2 );;
+gap> g:= Group( M.generators );;
+gap> map:= GroupHomomorphismByImages( G, g, mods[1], M.generators );;
+gap> Length( Extensions( G, map ) );
+1
+gap> G:= SymmetricGroup( 3 );  # solvable
+Sym( [ 1 .. 3 ] )
+gap> mods:= IrreducibleModules( G, GF(2) );;
+gap> M:= First( mods[2], x -> x.dimension = 2 );;
+gap> g:= Group( M.generators );;
+gap> map:= GroupHomomorphismByImages( G, g, mods[1], M.generators );;
+gap> Length( Extensions( G, map ) );
+1
+gap> G:= AlternatingGroup( 5 );  # nonsolvable
+Alt( [ 1 .. 5 ] )
+gap> mods:= IrreducibleModules( G, GF(2) );;
+gap> M:= First( mods[2], x -> x.dimension = 1 );;
+gap> g:= Group( M.generators );;
+gap> map:= GroupHomomorphismByImages( G, g, mods[1], M.generators );;
+gap> Length( Extensions( G, map ) );
+2
+
+# Extensions for pc groups (documented method)
+gap> G:= DihedralGroup( 6 );
+<pc group of size 6 with 2 generators>
+gap> mods:= IrreducibleModules( G, GF(2) );;
+gap> M:= First( mods[2], x -> x.dimension = 2 );;
+gap> Length( Extensions( G, M ) );
+1
+
 # Extensions nonsolvable
 gap> g:=Group((1,2,3,4,5),(3,4,5));;
 gap> mats:=[[[0,1,0,0],[0,0,1,0],[0,0,0,1],[2,2,2,2]],
-> [[1,0,0,0],[0,1,1,0],[0,0,0,1],[0,0,2,2]]];;
-gap> mo:=GModuleByMats(mats*Z(3)^0,GF(3));;
+> [[1,0,0,0],[0,1,1,0],[0,0,0,1],[0,0,2,2]]] * Z(3)^0;;
+gap> mo:=GModuleByMats(mats,GF(3));;
 gap> Length(Extensions(g,mo));
 3
 gap> cp:=CompatiblePairs(g,mo);
 <group of size 240 with 4 generators>
 gap> Length(ExtensionRepresentatives(g,mo,cp));
 2
+gap> map:= GroupHomomorphismByImages( g, Group( mats ),
+>              GeneratorsOfGroup( g ), mats );;
+gap> Length( Extensions( g, map ) );
+3
 gap> mo:= TrivialGModule( g, GF(3) );;
 gap> Length( Extensions( g, mo ) );
 1


### PR DESCRIPTION
- add new syntax `Extensions( G, map )` where `map` is a group homomorphism to a matrix group, such that the action of `G` on the given module is explicitly given; for that, make the two `Extensions( G, M )` methods accessible as global functions, and call the right function directly
- document that the `Extensions( G, M )` method for pc groups and a module `M` (which is the only documented `Extensions( G, M )` method) expects a correspondence between `Pcgs( G )` and `M.generators`
- in the manual section on 2-cohomology, move the cross-reference to the special methods for pc groups from the end to the beginning
- change the section header "Cohomology and Extensions" to "Cohomology and Extensions for Pc Groups"

resolves #6471